### PR TITLE
Make CommonTx have TransactionMisc as pointer

### DIFF
--- a/core/types/blob_tx.go
+++ b/core/types/blob_tx.go
@@ -81,19 +81,19 @@ func (stx *BlobTx) AsMessage(s Signer, baseFee *big.Int, rules *chain.Rules) (Me
 }
 
 func (stx *BlobTx) Sender(signer Signer) (libcommon.Address, error) {
-	if sc := stx.from.Load(); sc != nil {
+	if sc := stx.LoadFrom(); sc != nil {
 		return sc.(libcommon.Address), nil
 	}
 	addr, err := signer.Sender(stx)
 	if err != nil {
 		return libcommon.Address{}, err
 	}
-	stx.from.Store(addr)
+	stx.StoreFrom(addr)
 	return addr, nil
 }
 
 func (stx *BlobTx) Hash() libcommon.Hash {
-	if hash := stx.hash.Load(); hash != nil {
+	if hash := stx.LoadHash(); hash != nil {
 		return *hash.(*libcommon.Hash)
 	}
 	hash := prefixedRlpHash(BlobTxType, []interface{}{
@@ -110,7 +110,7 @@ func (stx *BlobTx) Hash() libcommon.Hash {
 		stx.BlobVersionedHashes,
 		stx.V, stx.R, stx.S,
 	})
-	stx.hash.Store(&hash)
+	stx.StoreHash(&hash)
 	return hash
 }
 


### PR DESCRIPTION
This is a follow-up of the previous PR: https://github.com/ledgerwatch/erigon/pull/9667

As described in the previous PR, we must not copy `atomic.Value`, but `TransactionMisc` has `atomic.Value`, and it is implicitly copied in such codes (like https://github.com/ledgerwatch/erigon/pull/9667#issuecomment-2003040875).

So I made `CommonTx` have `TransactionMisc` as a pointer to prevent implicit copy. 
And added store/load methods for `atomic.Value` to prevent nil pointer error at the initial time.

The concern about this change is there could be two TX objects which are sharing a same `TransactionMisc` pointer. This could make performance improvement(because cache is preserved), but may make bugs. I wanna ask your opinion. Thanks!