### PR TITLE
Use the same data type as go-ethereum in the stateDiff override for eth_call

### DIFF
--- a/turbo/adapter/ethapi/api.go
+++ b/turbo/adapter/ethapi/api.go
@@ -170,11 +170,11 @@ func (args *CallArgs) ToMessage(globalGasCap uint64, baseFee *uint256.Int) (type
 // if statDiff is set, all diff will be applied first and then execute the call
 // message.
 type Account struct {
-	Nonce     *hexutil.Uint64                 `json:"nonce"`
-	Code      *hexutility.Bytes               `json:"code"`
-	Balance   **hexutil.Big                   `json:"balance"`
-	State     *map[libcommon.Hash]uint256.Int `json:"state"`
-	StateDiff *map[libcommon.Hash]uint256.Int `json:"stateDiff"`
+	Nonce     *hexutil.Uint64                    `json:"nonce"`
+	Code      *hexutility.Bytes                  `json:"code"`
+	Balance   **hexutil.Big                      `json:"balance"`
+	State     *map[libcommon.Hash]uint256.Int    `json:"state"`
+	StateDiff *map[libcommon.Hash]libcommon.Hash `json:"stateDiff"`
 }
 
 func NewRevertError(result *core.ExecutionResult) *RevertError {

--- a/turbo/adapter/ethapi/api.go
+++ b/turbo/adapter/ethapi/api.go
@@ -173,7 +173,7 @@ type Account struct {
 	Nonce     *hexutil.Uint64                    `json:"nonce"`
 	Code      *hexutility.Bytes                  `json:"code"`
 	Balance   **hexutil.Big                      `json:"balance"`
-	State     *map[libcommon.Hash]uint256.Int    `json:"state"`
+	State     *map[libcommon.Hash]libcommon.Hash `json:"state"`
 	StateDiff *map[libcommon.Hash]libcommon.Hash `json:"stateDiff"`
 }
 

--- a/turbo/adapter/ethapi/state_overrides.go
+++ b/turbo/adapter/ethapi/state_overrides.go
@@ -42,7 +42,8 @@ func (overrides *StateOverrides) Override(state *state.IntraBlockState) error {
 		if account.StateDiff != nil {
 			for key, value := range *account.StateDiff {
 				key := key
-				state.SetState(addr, &key, value)
+				intValue := new(uint256.Int).SetBytes32(value.Bytes())
+				state.SetState(addr, &key, *intValue)
 			}
 		}
 	}

--- a/turbo/adapter/ethapi/state_overrides.go
+++ b/turbo/adapter/ethapi/state_overrides.go
@@ -36,7 +36,12 @@ func (overrides *StateOverrides) Override(state *state.IntraBlockState) error {
 		}
 		// Replace entire state if caller requires.
 		if account.State != nil {
-			state.SetStorage(addr, *account.State)
+			intState := map[libcommon.Hash]uint256.Int{}
+			for key, value := range *account.State {
+				intValue := new(uint256.Int).SetBytes32(value.Bytes())
+				intState[key] = *intValue
+			}
+			state.SetStorage(addr, intState)
 		}
 		// Apply state diff into specified accounts.
 		if account.StateDiff != nil {


### PR DESCRIPTION
Change the datatype used for the "stateDiff" override to eth_call to a hash instead of a uint256.
https://github.com/ethereum/go-ethereum/blob/171430c3f5d474327bc1721c7c36ad83ad21b4b2/internal/ethapi/api.go#L975-L976