### PR TITLE
Adding debian packaging

### DIFF
--- a/.github/workflows/deb_packager.yml
+++ b/.github/workflows/deb_packager.yml
@@ -1,0 +1,138 @@
+name: packager_deb
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - '**'
+    tags:
+      - 'v*.*.*'
+      - 'v*.*.*-*'
+
+jobs:
+  build:
+    permissions:
+      id-token: write
+      contents: write
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@master
+        with:
+          go-version: 1.22.x
+      # Variables
+      - name: Adding TAG to ENV
+        run: echo "GIT_TAG=`echo $(git describe --tags --abbrev=0)`" >> $GITHUB_ENV
+      - name: adding version
+        run: |
+          NUMERIC_VERSION=$( echo ${{ env.GIT_TAG }} | sed 's/[^0-9.]//g' ) 
+          echo "VERSION=$NUMERIC_VERSION" >> $GITHUB_ENV
+
+      # Update the VM
+      - name: update and install required packages
+        run: sudo apt-get update && sudo apt-get upgrade -y && sudo apt-get install -y dpkg-dev debhelper
+
+      # Repo setup and build
+      - name: Cleaning repo
+        run: make clean
+      - name: Building for amd64
+        run: make erigon
+      - name: clearing dpkg
+        run: sudo dpkg --clear-avail
+
+      # Creating directory structure
+      - name: making directory structure
+        run: mkdir -p packaging/deb/erigon/usr/bin
+      - name: making directory structure for toml
+        run: mkdir -p packaging/deb/erigon/opt/erigon
+      - name: copy the binary for amd64 over
+        run: cp -rp build/bin/erigon packaging/deb/erigon/usr/bin/
+      - name: create systemd directory for service file
+        run: mkdir -p packaging/deb/erigon/lib/systemd/system
+      - name: copy the erigon service file for systemd
+        run: cp -rp packaging/package_scripts/erigon.service packaging/deb/erigon/lib/systemd/system/
+
+      # Create control file and packaging
+      - name: create control file
+        run: |
+          touch packaging/deb/erigon/DEBIAN/control
+          echo "Package: erigon" >> packaging/deb/erigon/DEBIAN/control
+          echo "Version: ${{ env.VERSION }}" >> packaging/deb/erigon/DEBIAN/control
+          echo "Section: base" >> packaging/deb/erigon/DEBIAN/control
+          echo "Priority: optional" >> packaging/deb/erigon/DEBIAN/control
+          echo "Architecture: amd64" >> packaging/deb/erigon/DEBIAN/control
+          echo "Maintainer: devops@polygon.technology" >> packaging/deb/erigon/DEBIAN/control
+          echo "Description: erigon package" >> packaging/deb/erigon/DEBIAN/control
+
+      - name: Creating package directory for binary for erigon ${{ env.ARCH }}
+        run: cp -rp packaging/deb/erigon packaging/deb/erigon-${{ env.GIT_TAG }}-${{ env.ARCH }}
+        env:
+          ARCH: amd64
+      - name: Running package build  for ${{ env.ARCH }}
+        run: dpkg-deb --build --root-owner-group packaging/deb/erigon-${{ env.GIT_TAG }}-${{ env.ARCH }}
+        env:
+          ARCH: amd64
+
+      # arm64 setup
+      - name: prepping environment for arm64 build
+        run: make clean
+
+      - name: removing amd64 control file
+        run: rm -rf packaging/deb/erigon/DEBIAN/control
+
+      - name: Adding requirements for cross compile
+        run: sudo apt-get install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu
+
+      - name: build for arm64
+        run: GOARCH=arm64 GOOS=linux CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ CGO_ENABLED=1 go build -o build/bin/erigon ./cmd/erigon/main.go
+
+      - name: Copying necessary files
+        run: cp -rp build/bin/erigon packaging/deb/erigon/usr/bin/
+      - name: create control file
+        run: |
+          touch packaging/deb/erigon/DEBIAN/control
+          echo "Package: erigon" >> packaging/deb/erigon/DEBIAN/control
+          echo "Version: ${{ env.VERSION }}" >> packaging/deb/erigon/DEBIAN/control
+          echo "Section: base" >> packaging/deb/erigon/DEBIAN/control
+          echo "Priority: optional" >> packaging/deb/erigon/DEBIAN/control
+          echo "Architecture: arm64" >> packaging/deb/erigon/DEBIAN/control
+          echo "Maintainer: devops@polygon.technology" >> packaging/deb/erigon/DEBIAN/control
+          echo "Description: erigon package" >> packaging/deb/erigon/DEBIAN/control
+
+      - name: Creating package directory for binary for erigon ${{ env.ARCH }}
+        run: cp -rp packaging/deb/erigon packaging/deb/erigon-${{ env.GIT_TAG }}-${{ env.ARCH }}
+        env:
+          ARCH: arm64
+
+      - name: Running package build for ${{ env.ARCH }}
+        run: dpkg-deb --build --root-owner-group packaging/deb/erigon-${{ env.GIT_TAG }}-${{ env.ARCH }}
+        env:
+          ARCH: arm64
+
+      - name: shasum the ${{ env.ARCH }} debian package
+        run: cd packaging/deb/ && sha256sum erigon-${{ env.GIT_TAG }}-${{ env.ARCH }}.deb > erigon-${{ env.GIT_TAG }}-${{ env.ARCH }}.deb.checksum
+        env:
+          ARCH: amd64
+
+      - name: shasum the ${{ env.ARCH }} debian package
+        run: cd packaging/deb/ && sha256sum erigon-${{ env.GIT_TAG }}-${{ env.ARCH }}.deb > erigon-${{ env.GIT_TAG }}-${{ env.ARCH }}.deb.checksum
+        env:
+          ARCH: arm64
+
+      # Confirm packages built and upload
+      - name: Confirming package built
+        run: ls -ltr packaging/deb/ | grep erigon
+
+      - name: Release erigon Packages
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ env.GIT_TAG }}
+          prerelease: true
+          files: |
+            packaging/deb/erigon**.deb
+            packaging/deb/erigon**.deb.checksum

--- a/packaging/deb/erigon/DEBIAN/postinst
+++ b/packaging/deb/erigon/DEBIAN/postinst
@@ -1,12 +1,12 @@
 #!/bin/bash
 # This is a postinstallation script so the service can be configured and started when requested
 #
-sudo adduser --disabled-password --disabled-login --shell /usr/sbin/nologin --quiet --system --no-create-home --home /nonexistent erigon
+adduser --disabled-password --disabled-login --shell /usr/sbin/nologin --quiet --system --no-create-home --home /nonexistent erigon
 if [ -d "/opt/erigon" ]
 then
     echo "Directory /opt/erigon exists."
 else
     mkdir -p /opt/erigon
-    sudo chown -R erigon /opt/erigon
+    chown -R erigon /opt/erigon
 fi
-sudo systemctl daemon-reload
+systemctl daemon-reload

--- a/packaging/deb/erigon/DEBIAN/postinst
+++ b/packaging/deb/erigon/DEBIAN/postinst
@@ -1,0 +1,12 @@
+#!/bin/bash
+# This is a postinstallation script so the service can be configured and started when requested
+#
+sudo adduser --disabled-password --disabled-login --shell /usr/sbin/nologin --quiet --system --no-create-home --home /nonexistent erigon
+if [ -d "/opt/erigon" ]
+then
+    echo "Directory /opt/erigon exists."
+else
+    mkdir -p /opt/erigon
+    sudo chown -R erigon /opt/erigon
+fi
+sudo systemctl daemon-reload

--- a/packaging/deb/erigon/DEBIAN/postrm
+++ b/packaging/deb/erigon/DEBIAN/postrm
@@ -3,6 +3,6 @@
 ###############
 # Remove erigon installs
 ##############
-sudo rm -rf /lib/systemd/system/erigon.service
-sudo deluser erigon
-sudo systemctl daemon-reload
+rm -rf /lib/systemd/system/erigon.service
+deluser erigon
+systemctl daemon-reload

--- a/packaging/deb/erigon/DEBIAN/postrm
+++ b/packaging/deb/erigon/DEBIAN/postrm
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+###############
+# Remove erigon installs
+##############
+sudo rm -rf /lib/systemd/system/erigon.service
+sudo deluser erigon
+sudo systemctl daemon-reload

--- a/packaging/package_scripts/erigon.service
+++ b/packaging/package_scripts/erigon.service
@@ -1,0 +1,16 @@
+[Unit]
+  Description=erigon
+  StartLimitIntervalSec=500
+  StartLimitBurst=5
+
+[Service]
+  Restart=on-failure
+  RestartSec=5s
+  ExecStart=/usr/bin/erigon server -config "/opt/erigon/config.toml"
+  Type=simple
+  KillSignal=SIGINT
+  User=erigon
+  TimeoutStopSec=120
+
+[Install]
+  WantedBy=multi-user.target


### PR DESCRIPTION
The PR does the following:

- Introduces a simple debian packager for x86/amd64 and arm64
- Creates the required service file for systemd control with the packages
- postrm and postinst for proper install and removal of the package.

Uses the /opt/erigon location for data, this can be changed, using this approach is more in line with *nix standards for optional software packages location. 

