### PR TITLE
tracer: in case stack error(overflow/underflow) return to tracer costs 0

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -264,13 +264,13 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		// enough stack items available to perform the operation.
 		op = contract.GetOp(_pc)
 		operation := in.jt[op]
-		cost = operation.constantGas // For tracing
 		// Validate stack
 		if sLen := locStack.Len(); sLen < operation.numPop {
 			return nil, &ErrStackUnderflow{stackLen: sLen, required: operation.numPop}
 		} else if sLen > operation.maxStack {
 			return nil, &ErrStackOverflow{stackLen: sLen, limit: operation.maxStack}
 		}
+		cost = operation.constantGas // For tracing
 		if !contract.UseGas(cost, tracing.GasChangeIgnored) {
 			return nil, ErrOutOfGas
 		}


### PR DESCRIPTION
To be more consistent in case check stack fails (the first checks during fetch opcode, before the opcode is processed)  the op code cost should be zero not the constantGas value as now happens.
Now the cost is loaded from constantGas into cost variable, then in case check on stack fails, the method return and so the defer function is called that calls CaptureState() using as cost the constantGas value (not zero)
When approved I will create PR on rel 2.60.x