### PR TITLE
qa-tests: fix sync-from-scratch test result uploading

### DIFF
--- a/.github/workflows/qa-sync-from-scratch.yml
+++ b/.github/workflows/qa-sync-from-scratch.yml
@@ -97,7 +97,7 @@ jobs:
       if: steps.test_step.outputs.test_executed == 'true'
       uses: actions/upload-artifact@v4
       with:
-        name: test-results
+        name: test-results-${{ env.CHAIN }}
         path: ${{ github.workspace }}/result-${{ env.CHAIN }}.json
 
     - name: Action for Success


### PR DESCRIPTION
The test results are uploaded to the github actions test run page at the end of the test. As this test has 2 jobs, we need to give the uploaded test results different names to avoid clashes.
