### PR TITLE
qa-tests: increase test time of sync-from-scratch for minimal node

### DIFF
--- a/.github/workflows/qa-sync-from-scratch-minimal-node.yml
+++ b/.github/workflows/qa-sync-from-scratch-minimal-node.yml
@@ -8,12 +8,12 @@ on:
 jobs:
   minimal-node-sync-from-scratch-test:
     runs-on: self-hosted
-    timeout-minutes: 800
+    timeout-minutes: 1500 # 25 hours
     env:
       ERIGON_DATA_DIR: ${{ github.workspace }}/erigon_data
       ERIGON_QA_PATH: /home/qarunner/erigon-qa
       TRACKING_TIME_SECONDS: 7200 # 2 hours
-      TOTAL_TIME_SECONDS: 43200 # 12 hours
+      TOTAL_TIME_SECONDS: 86400 # 24 hours
       CHAIN: mainnet
 
     steps:


### PR DESCRIPTION
the last few runs of the test did not complete on time