### PR TITLE
new dirWalk for test purposes

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1688,7 +1688,7 @@ func RemoveContents(dirname string) error {
 		FollowSymbolicLinks: true,
 		Unsorted:            true,
 		Callback: func(osPathname string, d *godirwalk.Dirent) error {
-			if d.Name() == dirname {
+			if osPathname == dirname {
 				return nil
 			}
 			err := os.RemoveAll(filepath.Join(dirname, d.Name()))

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/karrick/godirwalk"
 	"math"
 	"math/big"
 	"net"
@@ -36,6 +35,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/karrick/godirwalk"
 
 	"github.com/erigontech/mdbx-go/mdbx"
 	lru "github.com/hashicorp/golang-lru/arc/v2"
@@ -1689,6 +1690,9 @@ func RemoveContents(dirname string) error {
 		Unsorted:            true,
 		Callback: func(osPathname string, d *godirwalk.Dirent) error {
 			if osPathname == dirname {
+				return nil
+			}
+			if d.IsSymlink() {
 				return nil
 			}
 			err := os.RemoveAll(filepath.Join(dirname, d.Name()))

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1695,11 +1695,7 @@ func RemoveContents(dirname string) error {
 			if d.IsSymlink() {
 				return nil
 			}
-			err := os.RemoveAll(filepath.Join(dirname, d.Name()))
-			if err != nil {
-				return err
-			}
-			return nil
+			return os.RemoveAll(filepath.Join(dirname, d.Name()))
 		},
 		PostChildrenCallback: nil,
 		ScratchBuffer:        nil,

--- a/go.mod
+++ b/go.mod
@@ -114,6 +114,7 @@ require (
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
+	github.com/karrick/godirwalk v1.17.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.14 // indirect
 	github.com/tklauser/numcpus v0.8.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.5.9
 	github.com/json-iterator/go v1.1.12
 	github.com/julienschmidt/httprouter v1.3.0
+	github.com/karrick/godirwalk v1.17.0
 	github.com/klauspost/compress v1.17.8
 	github.com/libp2p/go-libp2p v0.34.0
 	github.com/libp2p/go-libp2p-mplex v0.9.0
@@ -114,7 +115,6 @@ require (
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
-	github.com/karrick/godirwalk v1.17.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.14 // indirect
 	github.com/tklauser/numcpus v0.8.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -516,6 +516,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/karrick/godirwalk v1.17.0 h1:b4kY7nqDdioR/6qnbHQyDvmA17u5G1cZ6J+CZXwSWoI=
+github.com/karrick/godirwalk v1.17.0/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=


### PR DESCRIPTION
closes #10086 but it uses old lib (https://github.com/karrick/godirwalk). This branch could be used for tests for someone who experiences troubles with RAM with RemoveContents func. (For example for this guy https://discord.com/channels/687972960811745322/1233600171821240380)


Maybe we should fork this lib :) thing for future milestone