### PR TITLE
fix goreleaser after update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,7 +292,7 @@ release-dry-run: git-submodules
 		-v `pwd`:/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \
 		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
-		--clean --skip-validate --skip-publish
+		--clean --skip=validate --skip=publish
 
 .PHONY: release
 release: git-submodules
@@ -307,7 +307,7 @@ release: git-submodules
 		-v `pwd`:/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \
 		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
-		--clean --skip-validate
+		--clean --skip=validate
 
 	@docker image push --all-tags thorax/erigon
 	@docker image push --all-tags ghcr.io/erigontech/erigon


### PR DESCRIPTION
Fixes https://github.com/erigontech/erigon/actions/runs/10041015251/job/27748204997#step:9:72 (caused by PR #10726 apparently). See also https://github.com/goreleaser/goreleaser-cross-example/pull/10