### PR TITLE
e3 use same goreleaser-cross version as in e2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ on:
       - 'v*.*.*-*'
   workflow_dispatch:
     inputs:
-      dry_run:
-        description: 'Dry run'
+      publish_artifacts:
+        description: 'Publish Artifacts (not dry-run)'
         required: true
         type: boolean
 
@@ -59,12 +59,12 @@ jobs:
 
       - run: echo ${{ steps.prepare.outputs.tag_name }}
 
-      - name: Release dry_run=${{ inputs.dry_run }}
+      - name: Release publish_artifacts=${{ inputs.publish_artifacts }}
         run: |
-          if ${{ inputs.dry_run }}; then
-            make release-dry-run
-          else
+          if ${{ inputs.publish_artifacts }}; then
             make release
+          else
+            make release-dry-run
           fi
           docker images
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,20 +59,13 @@ jobs:
 
       - run: echo ${{ steps.prepare.outputs.tag_name }}
 
-
-      - if:  ${{ !inputs.dry_run }}
+      - name: Release dry_run=${{ inputs.dry_run }}
         run: |
-          make release
-          docker images
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ steps.prepare.outputs.tag_name }}
-          DOCKER_USERNAME: ${{ secrets.DOCKERHUB }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_KEY }}
-
-      - if: ${{ inputs.dry_run }}
-        run: |
-          make release-dry-run
+          if ${{ inputs.dry_run }}; then
+            make release-dry-run
+          else
+            make release
+          fi
           docker images
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Maximize build space
-        uses: AdityaGarg8/remove-unwanted-software@v1
+        uses: AdityaGarg8/remove-unwanted-software@v4
         with:
           remove-dotnet: 'true'
           remove-android: 'true'
@@ -37,12 +37,12 @@ jobs:
           fetch-depth: 0
 
       - name: dockerhub-login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB }}
           password: ${{ secrets.DOCKERHUB_KEY }}
       - name: ghcr-login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -55,7 +55,7 @@ jobs:
           echo "tag_name=${TAG}" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - run: echo ${{ steps.prepare.outputs.tag_name }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,9 +59,20 @@ jobs:
 
       - run: echo ${{ steps.prepare.outputs.tag_name }}
 
-      - name: Run GoReleaser
+
+      - if:  ${{ !inputs.dry_run }}
         run: |
           make release
+          docker images
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.prepare.outputs.tag_name }}
+          DOCKER_USERNAME: ${{ secrets.DOCKERHUB }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_KEY }}
+
+      - if: ${{ inputs.dry_run }}
+        run: |
+          make release-dry-run
           docker images
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,11 @@ on:
       # to be used by fork patch-releases ^^
       - 'v*.*.*-*'
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run'
+        required: true
+        type: boolean
 
 jobs:
   goreleaser:

--- a/Makefile
+++ b/Makefile
@@ -277,7 +277,8 @@ install:
 	@ls -al "$(DIST)"
 
 PACKAGE_NAME          := github.com/erigontech/erigon
-GOLANG_CROSS_VERSION  ?= v1.22.4
+GOLANG_CROSS_VERSION  ?= v1.21.5
+
 
 .PHONY: release-dry-run
 release-dry-run: git-submodules


### PR DESCRIPTION
- switched to `v1.21.5` 
- added to UI checkbox "Publish Artifacts" - which is disabled by default. if not set: `make release-dry-run`
