### PR TITLE
bor: don't produce bor files 

### DIFF
--- a/turbo/snapshotsync/freezeblocks/bor_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/bor_snapshots.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"reflect"
 
+	"github.com/erigontech/erigon-lib/common/dbg"
 	"github.com/erigontech/erigon-lib/downloader/snaptype"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cmd/hack/tool/fromdb"
@@ -31,14 +32,14 @@ import (
 	"github.com/erigontech/erigon/turbo/services"
 )
 
-const DisableBorBlocksProduction = true
+var BorProduceFiles = dbg.EnvBool("BOR_PRODUCE_FILES", false)
 
 func (br *BlockRetire) dbHasEnoughDataForBorRetire(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
 func (br *BlockRetire) retireBorBlocks(ctx context.Context, minBlockNum uint64, maxBlockNum uint64, lvl log.Lvl, seedNewSnapshots func(downloadRequest []services.DownloadRequest) error, onDelete func(l []string) error) (bool, error) {
-	if DisableBorBlocksProduction {
+	if !BorProduceFiles {
 		return false, nil
 	}
 

--- a/turbo/snapshotsync/freezeblocks/bor_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/bor_snapshots.go
@@ -31,11 +31,17 @@ import (
 	"github.com/erigontech/erigon/turbo/services"
 )
 
+const DisableBorBlocksProduction = true
+
 func (br *BlockRetire) dbHasEnoughDataForBorRetire(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
 func (br *BlockRetire) retireBorBlocks(ctx context.Context, minBlockNum uint64, maxBlockNum uint64, lvl log.Lvl, seedNewSnapshots func(downloadRequest []services.DownloadRequest) error, onDelete func(l []string) error) (bool, error) {
+	if DisableBorBlocksProduction {
+		return false, nil
+	}
+
 	select {
 	case <-ctx.Done():
 		return false, ctx.Err()


### PR DESCRIPTION
- disabling bor files production - because it breaking execution 
- by some reason bor files are created ahead of execution stage - and also bor files are bad - and it breaking execution of bor-mainnet/amoy nodes