### PR TITLE
polygon: move valset logic inside valset package

### DIFF
--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -1608,45 +1608,6 @@ func (c *Bor) getNextHeimdallSpanForTest(
 	return &heimdallSpan, nil
 }
 
-func validatorContains(a []*valset.Validator, x *valset.Validator) (*valset.Validator, bool) {
-	for _, n := range a {
-		if bytes.Equal(n.Address.Bytes(), x.Address.Bytes()) {
-			return n, true
-		}
-	}
-
-	return nil, false
-}
-
-func getUpdatedValidatorSet(oldValidatorSet *valset.ValidatorSet, newVals []*valset.Validator, logger log.Logger) *valset.ValidatorSet {
-	v := oldValidatorSet
-	oldVals := v.Validators
-
-	changes := make([]*valset.Validator, 0, len(oldVals))
-
-	for _, ov := range oldVals {
-		if f, ok := validatorContains(newVals, ov); ok {
-			ov.VotingPower = f.VotingPower
-		} else {
-			ov.VotingPower = 0
-		}
-
-		changes = append(changes, ov)
-	}
-
-	for _, nv := range newVals {
-		if _, ok := validatorContains(changes, nv); !ok {
-			changes = append(changes, nv)
-		}
-	}
-
-	if err := v.UpdateWithChangeSet(changes); err != nil {
-		logger.Error("[bor] Error while updating change set", "error", err)
-	}
-
-	return v
-}
-
 func isSprintStart(number, sprint uint64) bool {
 	return number%sprint == 0
 }

--- a/polygon/bor/snapshot.go
+++ b/polygon/bor/snapshot.go
@@ -199,7 +199,7 @@ func (s *Snapshot) Apply(parent *types.Header, headers []*types.Header, logger l
 
 			// get validators from headers and use that for new validator set
 			newVals, _ := valset.ParseValidators(validatorBytes)
-			v := getUpdatedValidatorSet(snap.ValidatorSet.Copy(), newVals, logger)
+			v := valset.GetUpdatedValidatorSet(snap.ValidatorSet.Copy(), newVals, logger)
 			v.IncrementProposerPriority(1)
 			snap.ValidatorSet = v
 		}

--- a/polygon/bor/valset/validator_set.go
+++ b/polygon/bor/valset/validator_set.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	libcommon "github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/log/v3"
 )
 
 // MaxTotalVotingPower - the maximum allowed total voting power.
@@ -816,4 +817,43 @@ func safeSubClip(a, b int64) int64 {
 	}
 
 	return c
+}
+
+func GetUpdatedValidatorSet(oldValidatorSet *ValidatorSet, newVals []*Validator, logger log.Logger) *ValidatorSet {
+	v := oldValidatorSet
+	oldVals := v.Validators
+
+	changes := make([]*Validator, 0, len(oldVals))
+
+	for _, ov := range oldVals {
+		if f, ok := validatorContains(newVals, ov); ok {
+			ov.VotingPower = f.VotingPower
+		} else {
+			ov.VotingPower = 0
+		}
+
+		changes = append(changes, ov)
+	}
+
+	for _, nv := range newVals {
+		if _, ok := validatorContains(changes, nv); !ok {
+			changes = append(changes, nv)
+		}
+	}
+
+	if err := v.UpdateWithChangeSet(changes); err != nil {
+		logger.Error("error while updating change set", "err", err)
+	}
+
+	return v
+}
+
+func validatorContains(a []*Validator, x *Validator) (*Validator, bool) {
+	for _, n := range a {
+		if bytes.Equal(n.Address.Bytes(), x.Address.Bytes()) {
+			return n, true
+		}
+	}
+
+	return nil, false
 }


### PR DESCRIPTION
part 1 of https://github.com/erigontech/erigon/pull/11339 to make the PR smaller and easier to review
moves `getUpdatedValidatorSet` to `valset` package to solve a circular dependency and also for better code grouping since that code is related to validator sets