### PR TITLE
polygon/heimdall: add observer options

### DIFF
--- a/polygon/heimdall/service.go
+++ b/polygon/heimdall/service.go
@@ -33,8 +33,8 @@ type Service interface {
 	FetchLatestSpans(ctx context.Context, count uint) ([]*Span, error)
 	FetchCheckpointsFromBlock(ctx context.Context, startBlock uint64) (Waypoints, error)
 	FetchMilestonesFromBlock(ctx context.Context, startBlock uint64) (Waypoints, error)
-	RegisterMilestoneObserver(callback func(*Milestone)) polygoncommon.UnregisterFunc
-	RegisterSpanObserver(callback func(*Span)) polygoncommon.UnregisterFunc
+	RegisterMilestoneObserver(cb func(*Milestone), opts ...ObserverOption) polygoncommon.UnregisterFunc
+	RegisterSpanObserver(cb func(*Span), opts ...ObserverOption) polygoncommon.UnregisterFunc
 	Run(ctx context.Context) error
 }
 
@@ -193,22 +193,20 @@ func (s *service) FetchMilestonesFromBlock(ctx context.Context, startBlock uint6
 	return libcommon.SliceMap(entities, castEntityToWaypoint[*Milestone]), err
 }
 
-// TODO: this limit is a temporary solution to avoid piping thousands of events
-// during the first sync. Let's discuss alternatives. Hopefully we can remove this limit.
-const maxEntityEvents = 5
-
-func (s *service) RegisterMilestoneObserver(callback func(*Milestone)) polygoncommon.UnregisterFunc {
+func (s *service) RegisterMilestoneObserver(cb func(*Milestone), opts ...ObserverOption) polygoncommon.UnregisterFunc {
+	options := NewObserverOptions(opts...)
 	return s.milestoneScraper.RegisterObserver(func(entities []*Milestone) {
-		for _, entity := range libcommon.SliceTakeLast(entities, maxEntityEvents) {
-			callback(entity)
+		for _, entity := range libcommon.SliceTakeLast(entities, options.eventsLimit) {
+			cb(entity)
 		}
 	})
 }
 
-func (s *service) RegisterSpanObserver(callback func(*Span)) polygoncommon.UnregisterFunc {
+func (s *service) RegisterSpanObserver(cb func(*Span), opts ...ObserverOption) polygoncommon.UnregisterFunc {
+	options := NewObserverOptions(opts...)
 	return s.spanScraper.RegisterObserver(func(entities []*Span) {
-		for _, entity := range libcommon.SliceTakeLast(entities, maxEntityEvents) {
-			callback(entity)
+		for _, entity := range libcommon.SliceTakeLast(entities, options.eventsLimit) {
+			cb(entity)
 		}
 	})
 }

--- a/polygon/heimdall/service.go
+++ b/polygon/heimdall/service.go
@@ -33,8 +33,8 @@ type Service interface {
 	FetchLatestSpans(ctx context.Context, count uint) ([]*Span, error)
 	FetchCheckpointsFromBlock(ctx context.Context, startBlock uint64) (Waypoints, error)
 	FetchMilestonesFromBlock(ctx context.Context, startBlock uint64) (Waypoints, error)
-	RegisterMilestoneObserver(cb func(*Milestone), opts ...ObserverOption) polygoncommon.UnregisterFunc
-	RegisterSpanObserver(cb func(*Span), opts ...ObserverOption) polygoncommon.UnregisterFunc
+	RegisterMilestoneObserver(callback func(*Milestone), opts ...ObserverOption) polygoncommon.UnregisterFunc
+	RegisterSpanObserver(callback func(*Span), opts ...ObserverOption) polygoncommon.UnregisterFunc
 	Run(ctx context.Context) error
 }
 
@@ -193,20 +193,20 @@ func (s *service) FetchMilestonesFromBlock(ctx context.Context, startBlock uint6
 	return libcommon.SliceMap(entities, castEntityToWaypoint[*Milestone]), err
 }
 
-func (s *service) RegisterMilestoneObserver(cb func(*Milestone), opts ...ObserverOption) polygoncommon.UnregisterFunc {
+func (s *service) RegisterMilestoneObserver(callback func(*Milestone), opts ...ObserverOption) polygoncommon.UnregisterFunc {
 	options := NewObserverOptions(opts...)
 	return s.milestoneScraper.RegisterObserver(func(entities []*Milestone) {
 		for _, entity := range libcommon.SliceTakeLast(entities, options.eventsLimit) {
-			cb(entity)
+			callback(entity)
 		}
 	})
 }
 
-func (s *service) RegisterSpanObserver(cb func(*Span), opts ...ObserverOption) polygoncommon.UnregisterFunc {
+func (s *service) RegisterSpanObserver(callback func(*Span), opts ...ObserverOption) polygoncommon.UnregisterFunc {
 	options := NewObserverOptions(opts...)
 	return s.spanScraper.RegisterObserver(func(entities []*Span) {
 		for _, entity := range libcommon.SliceTakeLast(entities, options.eventsLimit) {
-			cb(entity)
+			callback(entity)
 		}
 	})
 }

--- a/polygon/heimdall/service_observer_options.go
+++ b/polygon/heimdall/service_observer_options.go
@@ -20,7 +20,7 @@ type ObserverOptions struct {
 
 type ObserverOption func(opts *ObserverOptions)
 
-func ObserverWithEventsLimit(eventsLimit int) ObserverOption {
+func WithEventsLimit(eventsLimit int) ObserverOption {
 	return func(config *ObserverOptions) {
 		config.eventsLimit = eventsLimit
 	}

--- a/polygon/heimdall/service_observer_options.go
+++ b/polygon/heimdall/service_observer_options.go
@@ -1,0 +1,27 @@
+package heimdall
+
+import "math"
+
+func NewObserverOptions(opts ...ObserverOption) ObserverOptions {
+	defaultOptions := ObserverOptions{
+		eventsLimit: math.MaxInt,
+	}
+
+	for _, o := range opts {
+		o(&defaultOptions)
+	}
+
+	return defaultOptions
+}
+
+type ObserverOptions struct {
+	eventsLimit int
+}
+
+type ObserverOption func(opts *ObserverOptions)
+
+func ObserverWithEventsLimit(eventsLimit int) ObserverOption {
+	return func(config *ObserverOptions) {
+		config.eventsLimit = eventsLimit
+	}
+}

--- a/polygon/sync/tip_events.go
+++ b/polygon/sync/tip_events.go
@@ -89,8 +89,8 @@ type p2pObserverRegistrar interface {
 }
 
 type heimdallObserverRegistrar interface {
-	RegisterMilestoneObserver(func(*heimdall.Milestone)) polygoncommon.UnregisterFunc
-	RegisterSpanObserver(func(*heimdall.Span)) polygoncommon.UnregisterFunc
+	RegisterMilestoneObserver(cb func(*heimdall.Milestone), opts ...heimdall.ObserverOption) polygoncommon.UnregisterFunc
+	RegisterSpanObserver(cb func(*heimdall.Span), opts ...heimdall.ObserverOption) polygoncommon.UnregisterFunc
 }
 
 type TipEvents struct {
@@ -149,7 +149,7 @@ func (te *TipEvents) Run(ctx context.Context) error {
 			Type:         EventTypeNewMilestone,
 			newMilestone: milestone,
 		})
-	})
+	}, heimdall.ObserverWithEventsLimit(5))
 	defer milestoneObserverCancel()
 
 	spanObserverCancel := te.heimdallObserverRegistrar.RegisterSpanObserver(func(span *heimdall.Span) {
@@ -157,7 +157,7 @@ func (te *TipEvents) Run(ctx context.Context) error {
 			Type:    EventTypeNewSpan,
 			newSpan: span,
 		})
-	})
+	}, heimdall.ObserverWithEventsLimit(2))
 	defer spanObserverCancel()
 
 	return te.events.Run(ctx)

--- a/polygon/sync/tip_events.go
+++ b/polygon/sync/tip_events.go
@@ -149,7 +149,7 @@ func (te *TipEvents) Run(ctx context.Context) error {
 			Type:         EventTypeNewMilestone,
 			newMilestone: milestone,
 		})
-	}, heimdall.ObserverWithEventsLimit(5))
+	}, heimdall.WithEventsLimit(5))
 	defer milestoneObserverCancel()
 
 	spanObserverCancel := te.heimdallObserverRegistrar.RegisterSpanObserver(func(span *heimdall.Span) {
@@ -157,7 +157,7 @@ func (te *TipEvents) Run(ctx context.Context) error {
 			Type:    EventTypeNewSpan,
 			newSpan: span,
 		})
-	}, heimdall.ObserverWithEventsLimit(2))
+	}, heimdall.WithEventsLimit(2))
 	defer spanObserverCancel()
 
 	return te.events.Run(ctx)

--- a/polygon/sync/tip_events.go
+++ b/polygon/sync/tip_events.go
@@ -89,8 +89,8 @@ type p2pObserverRegistrar interface {
 }
 
 type heimdallObserverRegistrar interface {
-	RegisterMilestoneObserver(cb func(*heimdall.Milestone), opts ...heimdall.ObserverOption) polygoncommon.UnregisterFunc
-	RegisterSpanObserver(cb func(*heimdall.Span), opts ...heimdall.ObserverOption) polygoncommon.UnregisterFunc
+	RegisterMilestoneObserver(callback func(*heimdall.Milestone), opts ...heimdall.ObserverOption) polygoncommon.UnregisterFunc
+	RegisterSpanObserver(callback func(*heimdall.Span), opts ...heimdall.ObserverOption) polygoncommon.UnregisterFunc
 }
 
 type TipEvents struct {


### PR DESCRIPTION
part 2 of https://github.com/erigontech/erigon/pull/11339 to make the PR smaller and easier to review
Adds an "observer options" optional param to "RegisterSpanObserver" and "RegisterMilestoneObserver" functions, as we have 3 different requirements for event limit: last 2 for span observer, last 5 for milestone observer and in the above linked PR we want all span events (ie no events limit)