### PR TITLE
polygon/heimdall: entity stores to do 1 write at a time

### DIFF
--- a/polygon/heimdall/service_store.go
+++ b/polygon/heimdall/service_store.go
@@ -18,6 +18,7 @@ package heimdall
 
 import (
 	"context"
+	"sync"
 
 	"golang.org/x/sync/errgroup"
 
@@ -41,11 +42,12 @@ func NewMdbxServiceStore(logger log.Logger, dataDir string, tmpDir string) *Mdbx
 		return NewRangeIndex(ctx, tmpDir, logger)
 	}
 
+	var writeMu sync.Mutex
 	return &MdbxServiceStore{
 		db:          db,
-		checkpoints: newMdbxEntityStore(db, kv.BorCheckpoints, generics.New[Checkpoint], blockNumToIdIndexFactory),
-		milestones:  newMdbxEntityStore(db, kv.BorMilestones, generics.New[Milestone], blockNumToIdIndexFactory),
-		spans:       newMdbxEntityStore(db, kv.BorSpans, generics.New[Span], blockNumToIdIndexFactory),
+		checkpoints: newMdbxEntityStore(db, kv.BorCheckpoints, generics.New[Checkpoint], blockNumToIdIndexFactory, &writeMu),
+		milestones:  newMdbxEntityStore(db, kv.BorMilestones, generics.New[Milestone], blockNumToIdIndexFactory, &writeMu),
+		spans:       newMdbxEntityStore(db, kv.BorSpans, generics.New[Span], blockNumToIdIndexFactory, &writeMu),
 	}
 }
 


### PR DESCRIPTION
part 3 of https://github.com/erigontech/erigon/pull/11339 to make the PR smaller and easier to review

MDBX allows only 1 rw tx at a time. If more than 1 is used an error is thrown (check test below).
This PR fixes that for the heimdall entity stores.

```
func TestConfirmCantHave2RwTxAtSameTime(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)

 	logger := testlog.Logger(t, log.LvlDebug)
 	dataDir := t.TempDir()
 	db := polygoncommon.NewDatabase(dataDir, logger)
 	err := db.OpenOnce(ctx, kv.HeimdallDB, databaseTablesCfg)
 	require.NoError(t, err)

 	tx1, err := db.BeginRw(ctx)
 	require.NoError(t, err)
 	t.Cleanup(tx1.Rollback)

 	tx2, err := db.BeginRw(ctx)
 	require.NoError(t, err)
 	t.Cleanup(tx2.Rollback)
 }
```