### PR TITLE
Don't break bor_heimdall stage if behind bodies

### DIFF
--- a/eth/stagedsync/stage_bor_heimdall.go
+++ b/eth/stagedsync/stage_bor_heimdall.go
@@ -427,7 +427,18 @@ func BorHeimdallForward(
 		fetchTime += callTime
 		syncEventTime = syncEventTime + time.Since(syncEventStart)
 
-		if cfg.loopBreakCheck != nil && cfg.loopBreakCheck(int(blockNum-lastBlockNum)) {
+		bodyProgress, err := stages.GetStageProgress(tx, stages.Bodies)
+
+		if err != nil {
+			return err
+		}
+
+		// don't break if progress is less than the bodies stage otherwisa
+		// we can potentially process invalid blocks as we won't have fetched
+		// all sync events.  (This can happen if more bodies than bor events
+		// are downloaded from the torrent)
+		if cfg.loopBreakCheck != nil &&
+			blockNum > bodyProgress && cfg.loopBreakCheck(int(blockNum-lastBlockNum)) {
 			headNumber = blockNum
 			break
 		}


### PR DESCRIPTION
This adds a check to make sure that if the bor heimdall stage is behind bodies it catches up in one pass.

This is necessary to avoid missing sync events in execution and erroneously storing no sync events on retire