### PR TITLE
qa-tests: add holesky to sync-from-scratch test

### DIFF
--- a/.github/workflows/qa-sync-from-scratch.yml
+++ b/.github/workflows/qa-sync-from-scratch.yml
@@ -8,16 +8,16 @@ on:
 jobs:
   sync-from-scratch-test:
     runs-on: self-hosted
-    timeout-minutes: 800
+    timeout-minutes: 1100  # 18 hours plus 20 minutes
     strategy:
       fail-fast: false
       matrix:
-        chain: [ sepolia, amoy ]  # Chain name as specified on the erigon command line
+        chain: [ sepolia, holesky, amoy ]  # Chain name as specified on the erigon command line
     env:
       ERIGON_DATA_DIR: ${{ github.workspace }}/erigon_data
       ERIGON_QA_PATH: /home/qarunner/erigon-qa
       TRACKING_TIME_SECONDS: 7200 # 2 hours
-      TOTAL_TIME_SECONDS: 43200 # 12 hours
+      TOTAL_TIME_SECONDS: 57600 # 16 hours
       CHAIN: ${{ matrix.chain }}
 
     steps:


### PR DESCRIPTION
This PR 
- adds Holesky net "sync-from-scratch" test
- increases test time due to Amoy's slowness