### PR TITLE
Use the actual datadir when using init for custom network

### DIFF
--- a/turbo/app/init_cmd.go
+++ b/turbo/app/init_cmd.go
@@ -18,8 +18,9 @@ package app
 
 import (
 	"encoding/json"
-	"github.com/erigontech/erigon-lib/common/datadir"
 	"os"
+
+	"github.com/erigontech/erigon-lib/common/datadir"
 
 	"github.com/urfave/cli/v2"
 
@@ -83,7 +84,7 @@ func initGenesis(cliCtx *cli.Context) error {
 	if err != nil {
 		utils.Fatalf("Failed to open database: %v", err)
 	}
-	_, hash, err := core.CommitGenesisBlock(chaindb, genesis, datadir.New(""), logger)
+	_, hash, err := core.CommitGenesisBlock(chaindb, genesis, datadir.New(cliCtx.String(utils.DataDirFlag.Name)), logger)
 	if err != nil {
 		utils.Fatalf("Failed to write genesis block: %v", err)
 	}


### PR DESCRIPTION
I was getting the following logs when running this:

```sh
docker run --rm -it  --user=1003:1003 --volume=/data/erigon:/data:rw --volume=/data/ethereum-network-config/metadata/genesis.json:/genesis.json:ro --network=shared ethpandaops/erigon:main-5e4478f --datadir=/data init /genesis.json
```

```
INFO[07-30|16:44:34.910] logging to file system                   log dir=/data/logs file prefix=erigon log level=info json=false
INFO[07-30|16:44:34.912] Starting Erigon on Ethereum mainnet...
INFO[07-30|16:44:34.914] Maximum peer count                       ETH=100 total=100
INFO[07-30|16:44:34.914] starting HTTP APIs                       port=8545 APIs=eth,erigon,engine
INFO[07-30|16:44:34.915] Opening Database                         label=chaindata path=/data/chaindata
INFO[07-30|16:44:34.922] [db] open                                label=chaindata sizeLimit=12TB pageSize=8192
INFO[07-30|16:44:34.925] Re-Opening DB in exclusive mode to apply migrations
INFO[07-30|16:44:34.934] [db] open                                label=chaindata sizeLimit=12TB pageSize=8192
INFO[07-30|16:44:34.935] Apply migration                          name=db_schema_version5
INFO[07-30|16:44:34.937] Applied migration                        name=db_schema_version5
INFO[07-30|16:44:34.937] Apply migration                          name=prohibit_new_downloads_lock
INFO[07-30|16:44:34.939] Applied migration                        name=prohibit_new_downloads_lock
INFO[07-30|16:44:34.939] Apply migration                          name=squeeze_commit_files
INFO[07-30|16:44:34.940] Applied migration                        name=squeeze_commit_files
INFO[07-30|16:44:34.940] Apply migration                          name=prohibit_new_downloads_lock2
INFO[07-30|16:44:34.941] Applied migration                        name=prohibit_new_downloads_lock2
INFO[07-30|16:44:34.941] Updated DB schema to                     version=7.0.0
INFO[07-30|16:44:34.947] [db] open                                label=chaindata sizeLimit=12TB pageSize=8192
EROR[07-30|16:44:34.950] catch panic                              err="mkdir chaindata: permission denied" stack="[main.go:46 panic.go:770 rw_dir.go:38 dirs.go:80 init_cmd.go:86 make_app.go:130 command.go:276 command.go:269 app.go:333 app.go:307 main.go:51 proc.go:271 asm_amd64.s:1695]"
```

I checked the code and it seemed that the init subcommand was using the relative path of the process `""` . 

So to prove this, I ran the erigon process from `/data` like this:

```sh 
docker run --rm -it  --user=1003:1003 --volume=/data/erigon:/data:rw --volume=/data/ethereum-network-config/metadata/genesis.json:/genesis.json:ro --network=shared --entrypoint sh ethpandaops/erigon:main-5e4478f -ac "cd /data && erigon --datadir=/data init /genesis.json"
 ```
 
 Which solved the permissions problems, since it was now indeed writing into the `/data` directory:
 
 ```
 INFO[07-30|16:53:36.825] logging to file system                   log dir=/data/logs file prefix=erigon log level=info json=false
INFO[07-30|16:53:36.827] Starting Erigon on Ethereum mainnet...
INFO[07-30|16:53:36.829] Maximum peer count                       ETH=100 total=100
INFO[07-30|16:53:36.829] starting HTTP APIs                       port=8545 APIs=eth,erigon,engine
INFO[07-30|16:53:36.830] Opening Database                         label=chaindata path=/data/chaindata
INFO[07-30|16:53:36.838] [db] open                                label=chaindata sizeLimit=12TB pageSize=8192
INFO[07-30|16:53:36.858] Writing custom genesis block             hash=0x28c4dc2a218d50a185e69c0645188210aa3efe511d52e8a1785d27d9015b3aae
INFO[07-30|16:53:36.862] Successfully wrote genesis state         hash=0x28c4dc2a218d50a185e69c0645188210aa3efe511d52e8a1785d27d9015b3aae
```
 
 This code change should fix the problem so that it uses the right directory that was given via the CLI flag. 