### PR TITLE
astrid: fix for polygon sync stage bor events nil ptr

### DIFF
--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -373,14 +373,15 @@ type chainNode struct {
 	number uint64
 }
 
-func fixCanonicalChain(logPrefix string, logEvery *time.Ticker, height uint64, hash libcommon.Hash, tx kv.StatelessRwTx, headerReader services.FullBlockReader, logger log.Logger) ([]chainNode, []chainNode, error) {
+func fixCanonicalChain(logPrefix string, logEvery *time.Ticker, height uint64, hash libcommon.Hash, tx kv.StatelessRwTx, headerReader services.FullBlockReader, logger log.Logger) ([]*types.Header, []chainNode, error) {
 	if height == 0 {
 		return nil, nil, nil
 	}
 	ancestorHash := hash
 	ancestorHeight := height
 
-	var newNodes, badNodes []chainNode
+	var newNodes []*types.Header
+	var badNodes []chainNode
 	var emptyHash libcommon.Hash
 	var ch libcommon.Hash
 	var err error
@@ -411,11 +412,7 @@ func fixCanonicalChain(logPrefix string, logEvery *time.Ticker, height uint64, h
 			})
 		}
 
-		newNodes = append(newNodes, chainNode{
-			hash:   ancestorHash,
-			number: ancestorHeight,
-		})
-
+		newNodes = append(newNodes, ancestor)
 		ancestorHash = ancestor.ParentHash
 		ancestorHeight--
 	}

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -373,15 +373,14 @@ type chainNode struct {
 	number uint64
 }
 
-func fixCanonicalChain(logPrefix string, logEvery *time.Ticker, height uint64, hash libcommon.Hash, tx kv.StatelessRwTx, headerReader services.FullBlockReader, logger log.Logger) ([]*types.Header, []chainNode, error) {
+func fixCanonicalChain(logPrefix string, logEvery *time.Ticker, height uint64, hash libcommon.Hash, tx kv.StatelessRwTx, headerReader services.FullBlockReader, logger log.Logger) ([]chainNode, []chainNode, error) {
 	if height == 0 {
 		return nil, nil, nil
 	}
 	ancestorHash := hash
 	ancestorHeight := height
 
-	var newNodes []*types.Header
-	var badNodes []chainNode
+	var newNodes, badNodes []chainNode
 	var emptyHash libcommon.Hash
 	var ch libcommon.Hash
 	var err error
@@ -412,7 +411,11 @@ func fixCanonicalChain(logPrefix string, logEvery *time.Ticker, height uint64, h
 			})
 		}
 
-		newNodes = append(newNodes, ancestor)
+		newNodes = append(newNodes, chainNode{
+			hash:   ancestorHash,
+			number: ancestorHeight,
+		})
+
 		ancestorHash = ancestor.ParentHash
 		ancestorHeight--
 	}

--- a/eth/stagedsync/stage_polygon_sync.go
+++ b/eth/stagedsync/stage_polygon_sync.go
@@ -914,6 +914,8 @@ func (e *polygonSyncStageExecutionEngine) downloadStateSyncEvents(
 	header *types.Header,
 	logTicker *time.Ticker,
 ) error {
+	e.logger.Trace(e.appendLogPrefix("download state sync event"), "block", header.Number.Uint64())
+
 	var err error
 	if !e.lastStateSyncEventIdInit {
 		e.lastStateSyncEventId, _, err = e.blockReader.LastEventId(ctx, tx)


### PR DESCRIPTION
Fix for below nil ptr in the new polygon sync stage using Astrid.

Gist of fix: move call of `downloadStateSyncEvents(header)` to the stage's `updateForkChoice` handler instead of the `insertBlocks` handler. The reason for this is because `downloadStateSyncEvents` uses `blockReader.HeaderByNumber` before `Indore` fork and that requires the canonical hash at each block height to be set before calling it. This is done by `fixCanonicalChain` and we only call that in the `updateForkChoice` handler so `downloadStateSyncEvents` needs to be called after it.

Note: `downloadStateSyncEvents` will be removed and replaced by integrating the bridge in the new polygon sync stage as part of https://github.com/erigontech/erigon/issues/11195 but for now would prefer to do this fix to unblock myself.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x1d8 pc=0x106a01e9c]

goroutine 116 [running]:
github.com/erigontech/erigon/eth/stagedsync.fetchAndWriteHeimdallStateSyncEvents({_, _}, _, _, {_, _}, _, {_, _}, {_, ...}, ...)
        /Users/taratorio/erigon3-run/eth/stagedsync/bor_heimdall_shared.go:435 +0x15c
github.com/erigontech/erigon/eth/stagedsync.fetchRequiredHeimdallStateSyncEventsIfNeeded({_, _}, _, {_, _}, _, {_, _}, {_, _}, ...)
        /Users/taratorio/erigon3-run/eth/stagedsync/bor_heimdall_shared.go:390 +0x130
github.com/erigontech/erigon/eth/stagedsync.(*polygonSyncStageExecutionEngine).downloadStateSyncEvents(0x14001a32b08, {0x107b60a00, 0x14001747db0}, {0x107b92b30, 0x140017b0600}, 0x140010982c8, 0x14001757900)
        /Users/taratorio/erigon3-run/eth/stagedsync/stage_polygon_sync.go:904 +0x1cc
github.com/erigontech/erigon/eth/stagedsync.(*polygonSyncStageExecutionEngine).insertBlocks(0x14001a32b08, {0x107b60a00, 0x14001747db0}, {0x140013d0000, 0x1072, 0x140021e1a38?}, {0x107b92b30, 0x140017b0600})
        /Users/taratorio/erigon3-run/eth/stagedsync/stage_polygon_sync.go:771 +0x344
github.com/erigontech/erigon/eth/stagedsync.(*polygonSyncStageExecutionEngine).InsertBlocks.func1({0x107b92b30?, 0x140017b0600?}, 0x14001b8c420)
        /Users/taratorio/erigon3-run/eth/stagedsync/stage_polygon_sync.go:719 +0x54
github.com/erigontech/erigon/eth/stagedsync.awaitTxAction[...].func1()
        /Users/taratorio/erigon3-run/eth/stagedsync/stage_polygon_sync.go:949 +0x30
github.com/erigontech/erigon/eth/stagedsync.(*polygonSyncStageService).Run(0x14000bfecb0, {0x107b60a00, 0x14001747450}, {0x107b92b30, 0x140017b0600}, 0x14000faaa20, {0x107b5b010, 0x14001a6e580})
        /Users/taratorio/erigon3-run/eth/stagedsync/stage_polygon_sync.go:240 +0x330
github.com/erigontech/erigon/eth/stagedsync.SpawnPolygonSyncStage({0x107b60a00?, 0x14001747450?}, {0x0, 0x0?}, 0x14000faaa20?, {0x107b5b010?, 0x14001a6e580?}, {{0x107b77250?, 0x14001a92048?}, 0x14000bfecb0?})
        /Users/taratorio/erigon3-run/eth/stagedsync/stage_polygon_sync.go:160 +0x108
github.com/erigontech/erigon/eth/stagedsync.PolygonSyncStages.func4(0x80?, 0x106c50a6f?, {0x107b5b010?, 0x14001a6e580?}, {{0x0, 0x0}, {0x0, 0x0}, 0x0}, {0x107b75f48?, ...})
        /Users/taratorio/erigon3-run/eth/stagedsync/default_stages.go:479 +0x6c
github.com/erigontech/erigon/eth/stagedsync.(*Sync).runStage(0x14001a6e580, 0x14001a24a50, {0x107b77250, 0x14001a92048}, {{0x0, 0x0}, {0x0, 0x0}, 0x0}, 0x1, ...)
        /Users/taratorio/erigon3-run/eth/stagedsync/sync.go:529 +0x118
github.com/erigontech/erigon/eth/stagedsync.(*Sync).Run(0x14001a6e580, {0x107b77250, 0x14001a92048}, {{0x0, 0x0}, {0x0, 0x0}, 0x0}, 0x0?, 0x1)
        /Users/taratorio/erigon3-run/eth/stagedsync/sync.go:413 +0x21c
github.com/erigontech/erigon/turbo/stages.ProcessFrozenBlocks({0x107b60a00, 0x14001747450}, {0x107b77250, 0x14001a92048}, {0x107b96960, 0x14001a9a020}, 0x14001a6e580)
        /Users/taratorio/erigon3-run/turbo/stages/stageloop.go:141 +0x84
github.com/erigontech/erigon/turbo/stages.StageLoop({0x107b60a00, 0x14001747450}, {0x107b77250, 0x14001a92048}, 0x14001a6e580, 0x14000dc2200, 0x0?, 0x0, {0x107b75f48, 0x14000d7ab00}, ...)
        /Users/taratorio/erigon3-run/turbo/stages/stageloop.go:76 +0x8c
created by github.com/erigontech/erigon/eth.(*Ethereum).Start in goroutine 1
        /Users/taratorio/erigon3-run/eth/backend.go:1556 +0x53c

Process finished with the exit code 2
```