### PR TITLE
`Comitment`: Updates refactor

### DIFF
--- a/erigon-lib/commitment/bin_patricia_hashed.go
+++ b/erigon-lib/commitment/bin_patricia_hashed.go
@@ -1524,7 +1524,7 @@ func (bph *BinPatriciaHashed) SetState(buf []byte) error {
 	return nil
 }
 
-func (bph *BinPatriciaHashed) ProcessTree(ctx context.Context, t *UpdateTree, lp string) (rootHash []byte, err error) {
+func (bph *BinPatriciaHashed) ProcessTree(ctx context.Context, t *Updates, lp string) (rootHash []byte, err error) {
 	panic("not implemented")
 }
 

--- a/erigon-lib/commitment/commitment.go
+++ b/erigon-lib/commitment/commitment.go
@@ -91,7 +91,7 @@ const (
 	VariantBinPatriciaTrie TrieVariant = "bin-patricia-hashed"
 )
 
-func InitializeTrieAndUpdateTree(tv TrieVariant, mode Mode, tmpdir string) (Trie, *Updates) {
+func InitializeTrieAndUpdates(tv TrieVariant, mode Mode, tmpdir string) (Trie, *Updates) {
 	switch tv {
 	case VariantBinPatriciaTrie:
 		trie := NewBinPatriciaHashed(length.Addr, nil, tmpdir)

--- a/erigon-lib/commitment/commitment_test.go
+++ b/erigon-lib/commitment/commitment_test.go
@@ -305,7 +305,7 @@ func TestBranchData_ReplacePlainKeys_WithEmpty(t *testing.T) {
 	})
 }
 
-func TestNewUpdateTree(t *testing.T) {
+func TestNewUpdates(t *testing.T) {
 	t.Run("ModeUpdate", func(t *testing.T) {
 		ut := NewUpdates(ModeUpdate, t.TempDir(), keyHasherNoop)
 
@@ -325,7 +325,7 @@ func TestNewUpdateTree(t *testing.T) {
 
 }
 
-func TestUpdateTree_TouchPlainKey(t *testing.T) {
+func TestUpdates_TouchPlainKey(t *testing.T) {
 	utUpdate := NewUpdates(ModeUpdate, t.TempDir(), keyHasherNoop)
 	utDirect := NewUpdates(ModeDirect, t.TempDir(), keyHasherNoop)
 	utUpdate1 := NewUpdates(ModeUpdate, t.TempDir(), keyHasherNoop)

--- a/erigon-lib/commitment/commitment_test.go
+++ b/erigon-lib/commitment/commitment_test.go
@@ -307,7 +307,7 @@ func TestBranchData_ReplacePlainKeys_WithEmpty(t *testing.T) {
 
 func TestNewUpdateTree(t *testing.T) {
 	t.Run("ModeUpdate", func(t *testing.T) {
-		ut := NewUpdateTree(ModeUpdate, t.TempDir(), keyHasherNoop)
+		ut := NewUpdates(ModeUpdate, t.TempDir(), keyHasherNoop)
 
 		require.NotNil(t, ut.tree)
 		require.NotNil(t, ut.keccak)
@@ -316,7 +316,7 @@ func TestNewUpdateTree(t *testing.T) {
 	})
 
 	t.Run("ModeDirect", func(t *testing.T) {
-		ut := NewUpdateTree(ModeDirect, t.TempDir(), keyHasherNoop)
+		ut := NewUpdates(ModeDirect, t.TempDir(), keyHasherNoop)
 
 		require.NotNil(t, ut.keccak)
 		require.NotNil(t, ut.keys)
@@ -326,10 +326,10 @@ func TestNewUpdateTree(t *testing.T) {
 }
 
 func TestUpdateTree_TouchPlainKey(t *testing.T) {
-	utUpdate := NewUpdateTree(ModeUpdate, t.TempDir(), keyHasherNoop)
-	utDirect := NewUpdateTree(ModeDirect, t.TempDir(), keyHasherNoop)
-	utUpdate1 := NewUpdateTree(ModeUpdate, t.TempDir(), keyHasherNoop)
-	utDirect1 := NewUpdateTree(ModeDirect, t.TempDir(), keyHasherNoop)
+	utUpdate := NewUpdates(ModeUpdate, t.TempDir(), keyHasherNoop)
+	utDirect := NewUpdates(ModeDirect, t.TempDir(), keyHasherNoop)
+	utUpdate1 := NewUpdates(ModeUpdate, t.TempDir(), keyHasherNoop)
+	utDirect1 := NewUpdates(ModeDirect, t.TempDir(), keyHasherNoop)
 
 	type tc struct {
 		key []byte

--- a/erigon-lib/commitment/hex_patricia_hashed.go
+++ b/erigon-lib/commitment/hex_patricia_hashed.go
@@ -1273,7 +1273,7 @@ func (hph *HexPatriciaHashed) RootHash() ([]byte, error) {
 	return rootHash[1:], nil // first byte is 128+hash_len
 }
 
-func (hph *HexPatriciaHashed) ProcessTree(ctx context.Context, tree *UpdateTree, logPrefix string) (rootHash []byte, err error) {
+func (hph *HexPatriciaHashed) ProcessTree(ctx context.Context, tree *Updates, logPrefix string) (rootHash []byte, err error) {
 	var (
 		stagedCell = new(Cell)
 		logEvery   = time.NewTicker(20 * time.Second)

--- a/erigon-lib/state/domain_shared.go
+++ b/erigon-lib/state/domain_shared.go
@@ -1021,7 +1021,7 @@ type SharedDomainsCommitmentContext struct {
 	mode          commitment.Mode
 	branches      map[string]cachedBranch
 	keccak        cryptozerocopy.KeccakState
-	updates       *commitment.UpdateTree
+	updates       *commitment.Updates
 	patriciaTrie  commitment.Trie
 	justRestored  atomic.Bool
 }

--- a/erigon-lib/state/domain_shared.go
+++ b/erigon-lib/state/domain_shared.go
@@ -1035,7 +1035,7 @@ func NewSharedDomainsCommitmentContext(sd *SharedDomains, mode commitment.Mode, 
 		keccak:        sha3.NewLegacyKeccak256().(cryptozerocopy.KeccakState),
 	}
 
-	ctx.patriciaTrie, ctx.updates = commitment.InitializeTrieAndUpdateTree(trieVariant, mode, sd.aggTx.a.tmpdir)
+	ctx.patriciaTrie, ctx.updates = commitment.InitializeTrieAndUpdates(trieVariant, mode, sd.aggTx.a.tmpdir)
 	ctx.patriciaTrie.ResetContext(ctx)
 	return ctx
 }


### PR DESCRIPTION
Tree is redundant since we don't really use ModeUpdates using btree. Mostly we collect updated keys in map so let's just refer as Updates. 