### PR TITLE
adds kurtosis-assertoor to ci

### DIFF
--- a/.github/workflows/kurtosis/config.yaml
+++ b/.github/workflows/kurtosis/config.yaml
@@ -1,0 +1,91 @@
+participants_matrix:
+  el:
+    #    - el_type: nethermind
+    #      el_image: nethermindeth/nethermind:pectra
+    - el_type: erigon
+      el_image: moskud/erigon_images:7702txpool_test3
+  #    - el_type: ethereumjs
+  #      el_image: ethpandaops/ethereumjs:master
+  cl:
+    - cl_type: lighthouse
+      cl_image: ethpandaops/lighthouse:electra-devnet-1
+    - cl_type: teku
+      cl_image: ethpandaops/teku:master
+#    - cl_type: nimbus
+#      cl_image: ethpandaops/nimbus-eth2:unstable
+network_params:
+  electra_fork_epoch: 1
+  min_validator_withdrawability_delay: 1
+  shard_committee_period: 1
+additional_services:
+  - dora
+  - apache
+  - assertoor
+snooper_enabled: true
+assertoor_params:
+  run_stability_check: false
+  run_block_proposal_check: false
+  tests:
+    - {
+        file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
+        id: "wait1",
+        config: { slot: 34 },
+      }
+    - {
+        file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/bls-changes.yaml",
+        config: { validatorCount: 300 },
+      }
+
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/eip7702-test.yaml
+
+    # EIP-6110
+    - {
+        file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
+        id: "wait2",
+        config: { slot: 38 },
+      }
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/massive-deposit-0x02.yaml
+
+    # EIP-2935
+    - {
+        file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
+        id: "wait3",
+        config: { slot: 42 },
+      }
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/blockhash-test.yaml
+
+    # EIP-7002
+    - {
+        file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
+        id: "wait4",
+        config: { slot: 46 },
+      }
+    - {
+        file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/voluntary-exits.yaml",
+        config: { validatorCount: 10 },
+      }
+    - {
+        file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
+        id: "wait5",
+        config: { slot: 50 },
+      }
+    - {
+        file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/el-triggered-exit.yaml",
+        config: { validatorIndex: 20 },
+      }
+
+    # EIP-7251
+    - {
+        file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
+        id: "wait6",
+        config: { slot: 54 },
+      }
+    - {
+        file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/el-triggered-consolidation.yaml",
+        config: { sourceValidatorIndex: 21, targetValidatorIndex: 25 },
+      }
+
+    # Final check
+    - {
+        file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/block-proposal-check.yaml",
+      }

--- a/.github/workflows/kurtosis/config.yaml
+++ b/.github/workflows/kurtosis/config.yaml
@@ -25,10 +25,11 @@ assertoor_params:
     - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/eoa-transactions-test.yaml
     - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/stability-check.yaml
     - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/synchronized-check.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-exit-test.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-lifecycle-test-v2.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-lifecycle-test.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-proposer-slashing-test.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-withdrawal-test.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-withdrawal-test-v2.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/validator-exit-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/validator-lifecycle-test-v2.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/validator-lifecycle-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/validator-proposer-slashing-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/validator-withdrawal-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/validator-withdrawal-test-v2.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/validator-slashing-test.yaml
     - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/block-proposal-check.yaml

--- a/.github/workflows/kurtosis/config.yaml
+++ b/.github/workflows/kurtosis/config.yaml
@@ -26,23 +26,37 @@ assertoor_params:
   run_stability_check: false
   run_block_proposal_check: false
   tests:
-    - {
-        file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
-        id: "wait1",
-        config: { slot: 14 },
-      }
-    - {
-        file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/bls-changes.yaml",
-        config: { validatorCount: 300 },
-      }
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/all-opcodes-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/blob-transactions-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/dencun-opcodes-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/eoa-transactions-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/stability-check.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/synchronized-check.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-exit-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-lifecycle-test-v2.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-lifecycle-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-proposer-slashing-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-withdrawal-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-withdrawal-test-v2.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/block-proposal-check.yaml
 
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/eip7702-test.yaml
+    # - {
+    #     file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
+    #     id: "wait1",
+    #     config: { slot: 14 },
+    #   }
+    # - {
+    #     file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/bls-changes.yaml",
+    #     config: { validatorCount: 300 },
+    #   }
 
-    - {
-        file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
-        id: "wait1",
-        config: { slot: 24 },
-    }
+    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/eip7702-test.yaml
+
+    # - {
+    #     file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
+    #     id: "wait1",
+    #     config: { slot: 24 },
+    # }
 
     # # EIP-6110
     # - {
@@ -92,6 +106,6 @@ assertoor_params:
     #   }
 
     # Final check
-    - {
-        file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/block-proposal-check.yaml",
-      }
+    # - {
+    #     file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/block-proposal-check.yaml",
+    #   }

--- a/.github/workflows/kurtosis/config.yaml
+++ b/.github/workflows/kurtosis/config.yaml
@@ -1,14 +1,11 @@
 participants_matrix:
   el:
     - el_type: geth
-#      el_image: ethpandaops/geth:master
     - el_type: erigon
       el_image: <<ERIGON_IMAGE_PLACEHOLDER>>
   cl:
     - cl_type: lighthouse
-      #cl_image: ethpandaops/lighthouse:stable
     - cl_type: teku
-      #cl_image: ethpandaops/teku:master
 network_params:
   electra_fork_epoch: 1
   min_validator_withdrawability_delay: 1
@@ -22,16 +19,16 @@ assertoor_params:
   run_stability_check: false
   run_block_proposal_check: false
   tests:
-    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/all-opcodes-test.yaml
-    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/blob-transactions-test.yaml
-    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/dencun-opcodes-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/all-opcodes-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/blob-transactions-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/dencun-opcodes-test.yaml
     - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/eoa-transactions-test.yaml
-    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/stability-check.yaml
-    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/synchronized-check.yaml
-    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-exit-test.yaml
-    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-lifecycle-test-v2.yaml
-    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-lifecycle-test.yaml
-    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-proposer-slashing-test.yaml
-    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-withdrawal-test.yaml
-    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-withdrawal-test-v2.yaml
-    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/block-proposal-check.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/stability-check.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/synchronized-check.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-exit-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-lifecycle-test-v2.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-lifecycle-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-proposer-slashing-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-withdrawal-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-withdrawal-test-v2.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/block-proposal-check.yaml

--- a/.github/workflows/kurtosis/config.yaml
+++ b/.github/workflows/kurtosis/config.yaml
@@ -36,54 +36,60 @@ assertoor_params:
         config: { validatorCount: 300 },
       }
 
-    #- https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/eip7702-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/eip7702-test.yaml
 
-    # EIP-6110
     - {
         file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
-        id: "wait2",
-        config: { slot: 38 },
-      }
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/massive-deposit-0x02.yaml
+        id: "wait1",
+        config: { slot: 24 },
+    }
 
-    # EIP-2935
-    - {
-        file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
-        id: "wait3",
-        config: { slot: 42 },
-      }
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/blockhash-test.yaml
+    # # EIP-6110
+    # - {
+    #     file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
+    #     id: "wait2",
+    #     config: { slot: 38 },
+    #   }
+    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/massive-deposit-0x02.yaml
 
-    # EIP-7002
-    - {
-        file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
-        id: "wait4",
-        config: { slot: 46 },
-      }
-    - {
-        file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/voluntary-exits.yaml",
-        config: { validatorCount: 10 },
-      }
-    - {
-        file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
-        id: "wait5",
-        config: { slot: 50 },
-      }
-    - {
-        file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/el-triggered-exit.yaml",
-        config: { validatorIndex: 20 },
-      }
+    # # EIP-2935
+    # - {
+    #     file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
+    #     id: "wait3",
+    #     config: { slot: 42 },
+    #   }
+    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/blockhash-test.yaml
 
-    # EIP-7251
-    - {
-        file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
-        id: "wait6",
-        config: { slot: 54 },
-      }
-    - {
-        file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/el-triggered-consolidation.yaml",
-        config: { sourceValidatorIndex: 21, targetValidatorIndex: 25 },
-      }
+    # # EIP-7002
+    # - {
+    #     file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
+    #     id: "wait4",
+    #     config: { slot: 46 },
+    #   }
+    # - {
+    #     file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/voluntary-exits.yaml",
+    #     config: { validatorCount: 10 },
+    #   }
+    # - {
+    #     file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
+    #     id: "wait5",
+    #     config: { slot: 50 },
+    #   }
+    # - {
+    #     file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/el-triggered-exit.yaml",
+    #     config: { validatorIndex: 20 },
+    #   }
+
+    # # EIP-7251
+    # - {
+    #     file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
+    #     id: "wait6",
+    #     config: { slot: 54 },
+    #   }
+    # - {
+    #     file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/el-triggered-consolidation.yaml",
+    #     config: { sourceValidatorIndex: 21, targetValidatorIndex: 25 },
+    #   }
 
     # Final check
     - {

--- a/.github/workflows/kurtosis/config.yaml
+++ b/.github/workflows/kurtosis/config.yaml
@@ -16,8 +16,8 @@ additional_services:
   - assertoor
 snooper_enabled: true
 assertoor_params:
-  run_stability_check: false
-  run_block_proposal_check: false
+  run_stability_check: true
+  run_block_proposal_check: true
   tests:
     - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/all-opcodes-test.yaml
     - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/blob-transactions-test.yaml

--- a/.github/workflows/kurtosis/config.yaml
+++ b/.github/workflows/kurtosis/config.yaml
@@ -29,14 +29,14 @@ assertoor_params:
     - {
         file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
         id: "wait1",
-        config: { slot: 34 },
+        config: { slot: 14 },
       }
     - {
         file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/bls-changes.yaml",
         config: { validatorCount: 300 },
       }
 
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/eip7702-test.yaml
+    #- https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/eip7702-test.yaml
 
     # EIP-6110
     - {

--- a/.github/workflows/kurtosis/config.yaml
+++ b/.github/workflows/kurtosis/config.yaml
@@ -32,4 +32,4 @@ assertoor_params:
     # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/validator-withdrawal-test.yaml
     # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/validator-withdrawal-test-v2.yaml
     # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/validator-slashing-test.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/block-proposal-check.yaml
+    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/block-proposal-check.yaml

--- a/.github/workflows/kurtosis/config.yaml
+++ b/.github/workflows/kurtosis/config.yaml
@@ -1,18 +1,14 @@
 participants_matrix:
   el:
-    #    - el_type: nethermind
-    #      el_image: nethermindeth/nethermind:pectra
+    - el_type: geth
+#      el_image: ethpandaops/geth:master
     - el_type: erigon
-      el_image: moskud/erigon_images:7702txpool_test3
-  #    - el_type: ethereumjs
-  #      el_image: ethpandaops/ethereumjs:master
+      el_image: thorax/erigon:latest
   cl:
     - cl_type: lighthouse
-      cl_image: ethpandaops/lighthouse:electra-devnet-1
+      #cl_image: ethpandaops/lighthouse:stable
     - cl_type: teku
-      cl_image: ethpandaops/teku:master
-#    - cl_type: nimbus
-#      cl_image: ethpandaops/nimbus-eth2:unstable
+      #cl_image: ethpandaops/teku:master
 network_params:
   electra_fork_epoch: 1
   min_validator_withdrawability_delay: 1
@@ -26,86 +22,16 @@ assertoor_params:
   run_stability_check: false
   run_block_proposal_check: false
   tests:
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/all-opcodes-test.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/blob-transactions-test.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/dencun-opcodes-test.yaml
+    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/all-opcodes-test.yaml
+    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/blob-transactions-test.yaml
+    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/dencun-opcodes-test.yaml
     - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/eoa-transactions-test.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/stability-check.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/synchronized-check.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-exit-test.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-lifecycle-test-v2.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-lifecycle-test.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-proposer-slashing-test.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-withdrawal-test.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-withdrawal-test-v2.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/block-proposal-check.yaml
-
-    # - {
-    #     file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
-    #     id: "wait1",
-    #     config: { slot: 14 },
-    #   }
-    # - {
-    #     file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/bls-changes.yaml",
-    #     config: { validatorCount: 300 },
-    #   }
-
-    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/eip7702-test.yaml
-
-    # - {
-    #     file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
-    #     id: "wait1",
-    #     config: { slot: 24 },
-    # }
-
-    # # EIP-6110
-    # - {
-    #     file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
-    #     id: "wait2",
-    #     config: { slot: 38 },
-    #   }
-    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/massive-deposit-0x02.yaml
-
-    # # EIP-2935
-    # - {
-    #     file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
-    #     id: "wait3",
-    #     config: { slot: 42 },
-    #   }
-    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/blockhash-test.yaml
-
-    # # EIP-7002
-    # - {
-    #     file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
-    #     id: "wait4",
-    #     config: { slot: 46 },
-    #   }
-    # - {
-    #     file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/voluntary-exits.yaml",
-    #     config: { validatorCount: 10 },
-    #   }
-    # - {
-    #     file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
-    #     id: "wait5",
-    #     config: { slot: 50 },
-    #   }
-    # - {
-    #     file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/el-triggered-exit.yaml",
-    #     config: { validatorIndex: 20 },
-    #   }
-
-    # # EIP-7251
-    # - {
-    #     file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/wait-for-slot.yaml",
-    #     id: "wait6",
-    #     config: { slot: 54 },
-    #   }
-    # - {
-    #     file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/pectra-dev/el-triggered-consolidation.yaml",
-    #     config: { sourceValidatorIndex: 21, targetValidatorIndex: 25 },
-    #   }
-
-    # Final check
-    # - {
-    #     file: "https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/block-proposal-check.yaml",
-    #   }
+    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/stability-check.yaml
+    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/synchronized-check.yaml
+    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-exit-test.yaml
+    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-lifecycle-test-v2.yaml
+    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-lifecycle-test.yaml
+    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-proposer-slashing-test.yaml
+    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-withdrawal-test.yaml
+    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/vaidator-withdrawal-test-v2.yaml
+    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/block-proposal-check.yaml

--- a/.github/workflows/kurtosis/config.yaml
+++ b/.github/workflows/kurtosis/config.yaml
@@ -16,20 +16,20 @@ additional_services:
   - assertoor
 snooper_enabled: true
 assertoor_params:
-  run_stability_check: true
-  run_block_proposal_check: true
+  run_stability_check: false
+  run_block_proposal_check: false
   tests:
     - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/all-opcodes-test.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/blob-transactions-test.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/dencun-opcodes-test.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/eoa-transactions-test.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/stability-check.yaml
+    #- https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/blob-transactions-test.yaml
+    #- https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/dencun-opcodes-test.yaml
+    #- https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/eoa-transactions-test.yaml
+    #- https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/stability-check.yaml
     - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/synchronized-check.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/validator-exit-test.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/validator-lifecycle-test-v2.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/validator-lifecycle-test.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/validator-proposer-slashing-test.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/validator-withdrawal-test.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/validator-withdrawal-test-v2.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/validator-slashing-test.yaml
+    #- https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/validator-exit-test.yaml
+    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/validator-lifecycle-test-v2.yaml
+    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/validator-lifecycle-test.yaml
+    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/validator-proposer-slashing-test.yaml
+    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/validator-withdrawal-test.yaml
+    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/validator-withdrawal-test-v2.yaml
+    # - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/validator-slashing-test.yaml
     - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/block-proposal-check.yaml

--- a/.github/workflows/kurtosis/config.yaml
+++ b/.github/workflows/kurtosis/config.yaml
@@ -3,7 +3,7 @@ participants_matrix:
     - el_type: geth
 #      el_image: ethpandaops/geth:master
     - el_type: erigon
-      el_image: thorax/erigon:latest
+      el_image: <<ERIGON_IMAGE_PLACEHOLDER>>
   cl:
     - cl_type: lighthouse
       #cl_image: ethpandaops/lighthouse:stable

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -1,9 +1,20 @@
 name: Kurtosis Assertoor GitHub Action
 
 on:
-  schedule:
-    - cron: "0 2,14 * * *" # runs at 2am and 2pm UTC
-  workflow_dispatch:
+  pull_request:
+    branches:
+      - kurtosis_assertoor
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  push:
+    branches:
+      - kurtosis_assertoor
+  # schedule:
+  #   - cron: "0 2,14 * * *" # runs at 2am and 2pm UTC
+  # workflow_dispatch:
 
 
 jobs:

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -1,0 +1,25 @@
+name: Kurtosis Assertoor GitHub Action
+
+on:
+    pull_request:
+       branches:
+          - main
+       types:
+           - opened
+           - reopened
+           - synchronize
+           - ready_for_review
+
+jobs:
+    assertoor_test:
+        strategy:
+            matrix:
+                # list of os: https://github.com/actions/virtual-environments
+                os:
+                    #- ubuntu-22.04
+                    - macos-14
+        runs-on: ${{ matrix.os }}
+
+        steps:
+            - uses: ethpandaops/kurtosis-assertoor-github-action@v1
+

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -25,7 +25,10 @@ jobs:
     runs-on: ${{ matrix.os.id }}
 
     steps:
-#      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - name: make docker (see dockerhub for image builds)
+        run: DOCKER_TAG=thorax/erigon:ci-$GITHUB_SHA DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) make docker
+
 
       - name: Install dependencies on Linux
         if: runner.os == 'Linux'
@@ -33,7 +36,8 @@ jobs:
 
       - name: download kurtosis config
         run: |
-          wget -O kurtosis_config.yaml https://raw.githubusercontent.com/erigontech/erigon/kurtosis_assertoor/.github/workflows/kurtosis/config.yaml
+          wget -O kurtosis_config_with_p.yaml https://raw.githubusercontent.com/erigontech/erigon/kurtosis_assertoor/.github/workflows/kurtosis/config.yaml
+          sed 's/<<ERIGON_IMAGE_PLACEHOLDER>>/thorax\/erigon:ci-'$GITHUB_SHA'/' kurtosis_config_with_p.yaml > kurtosis_config.yaml
 
       - name: Run Kurtosis + assertoor tests
         uses: ethpandaops/kurtosis-assertoor-github-action@v1

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -13,6 +13,7 @@ on:
     branches:
       - kurtosis_assertoor
 
+
 jobs:
   assertoor_test:
     strategy:
@@ -32,7 +33,14 @@ jobs:
       - name: Install dependencies on Linux
         if: runner.os == 'Linux'
         run: sudo apt update && sudo apt install build-essential
+
+      - name: download kurtosis config
+        run: |
+          wget -O kurtosis_config.yaml https://raw.githubusercontent.com/erigontech/erigon/kurtosis_assertoor/.github/workflows/kurtosis/config.yaml
+
       - name: Run Kurtosis + assertoor tests
         uses: ethpandaops/kurtosis-assertoor-github-action@v1
         with:
             enclave_name: "kurtosis-run-${{ matrix.os.name }}-${{ github.run_id }}"
+            ethereum_package_args: "./kurtosis_config.yaml"
+            kurtosis_extra_args: --verbosity detailed --cli-log-level trace

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -3,7 +3,7 @@ name: Kurtosis Assertoor GitHub Action
 on:
     pull_request:
        branches:
-          - main
+          - kurtosis_assertoor
        types:
            - opened
            - reopened
@@ -21,5 +21,10 @@ jobs:
         runs-on: ${{ matrix.os }}
 
         steps:
-            - uses: ethpandaops/kurtosis-assertoor-github-action@v1
+            - uses: actions/checkout@v4
+            - name: Install dependencies on Linux
+              if: runner.os == 'Linux'
+              run: sudo apt update && sudo apt install build-essential
+            - name: Run Kurtosis + assertoor tests
+              uses: ethpandaops/kurtosis-assertoor-github-action@v1
 

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -43,4 +43,5 @@ jobs:
         with:
             enclave_name: "kurtosis-run-${{ matrix.os.name }}-${{ github.run_id }}"
             ethereum_package_args: "./kurtosis_config.yaml"
-            kurtosis_extra_args: --verbosity detailed --cli-log-level trace
+            #kurtosis_extra_args: --verbosity detailed --cli-log-level trace
+            enclave_dump: false

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -25,10 +25,7 @@ jobs:
     runs-on: ${{ matrix.os.id }}
 
     steps:
-      - uses: actions/checkout@v4
-      - name: Create a temporary file
-        run: |
-          echo "This is a temporary file" > ${{ runner.temp }}/tempfile.txt
+#      - uses: actions/checkout@v4
 
       - name: Install dependencies on Linux
         if: runner.os == 'Linux'

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -1,17 +1,9 @@
 name: Kurtosis Assertoor GitHub Action
 
 on:
-  pull_request:
-    branches:
-      - kurtosis_assertoor
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
-  push:
-    branches:
-      - kurtosis_assertoor
+  schedule:
+    - cron: "0 2,14 * * *" # runs at 2am and 2pm UTC
+  workflow_dispatch:
 
 
 jobs:
@@ -21,7 +13,6 @@ jobs:
         # list of os: https://github.com/actions/virtual-environments
         os:
           - { id: ubuntu-22.04, name: ubuntu } 
-          #- macos-14
     runs-on: ${{ matrix.os.id }}
 
     steps:

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -1,30 +1,32 @@
 name: Kurtosis Assertoor GitHub Action
 
 on:
-    pull_request:
-       branches:
-          - kurtosis_assertoor
-       types:
-           - opened
-           - reopened
-           - synchronize
-           - ready_for_review
+  pull_request:
+    branches:
+      - kurtosis_assertoor
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  push:
+    branches:
+      - kurtosis_assertoor
 
 jobs:
-    assertoor_test:
-        strategy:
-            matrix:
-                # list of os: https://github.com/actions/virtual-environments
-                os:
-                    #- ubuntu-22.04
-                    - macos-14
-        runs-on: ${{ matrix.os }}
+  assertoor_test:
+    strategy:
+      matrix:
+        # list of os: https://github.com/actions/virtual-environments
+        os:
+          # - ubuntu-22.04
+          - macos-14
+    runs-on: ${{ matrix.os }}
 
-        steps:
-            - uses: actions/checkout@v4
-            - name: Install dependencies on Linux
-              if: runner.os == 'Linux'
-              run: sudo apt update && sudo apt install build-essential
-            - name: Run Kurtosis + assertoor tests
-              uses: ethpandaops/kurtosis-assertoor-github-action@v1
-
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies on Linux
+        if: runner.os == 'Linux'
+        run: sudo apt update && sudo apt install build-essential
+      - name: Run Kurtosis + assertoor tests
+        uses: ethpandaops/kurtosis-assertoor-github-action@v1

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -25,8 +25,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Create a temporary file
+        run: |
+          echo "This is a temporary file" > ${{ runner.temp }}/tempfile.txt
+
       - name: Install dependencies on Linux
         if: runner.os == 'Linux'
         run: sudo apt update && sudo apt install build-essential
       - name: Run Kurtosis + assertoor tests
         uses: ethpandaops/kurtosis-assertoor-github-action@v1
+        with:
+            enclave_name: "kurtosis-run-${{ matrix.os }}-${{ github.run_id }}"

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -1,20 +1,21 @@
 name: Kurtosis Assertoor GitHub Action
 
 on:
-  pull_request:
-    branches:
-      - kurtosis_assertoor
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
-  push:
-    branches:
-      - kurtosis_assertoor
-  # schedule:
-  #   - cron: "0 2,14 * * *" # runs at 2am and 2pm UTC
-  # workflow_dispatch:
+  schedule:
+    - cron: "0 2,14 * * *" # runs at 2am and 2pm UTC
+  workflow_dispatch:
+  # pull_request:
+  #   branches:
+  #     - kurtosis_assertoor
+  #   types:
+  #     - opened
+  #     - reopened
+  #     - synchronize
+  #     - ready_for_review
+  # push:
+  #   branches:
+  #     - kurtosis_assertoor
+
 
 
 jobs:

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -19,9 +19,9 @@ jobs:
       matrix:
         # list of os: https://github.com/actions/virtual-environments
         os:
-          # - ubuntu-22.04
-          - macos-14
-    runs-on: ${{ matrix.os }}
+          - { id: ubuntu-22.04, name: ubuntu } 
+          #- macos-14
+    runs-on: ${{ matrix.os.id }}
 
     steps:
       - uses: actions/checkout@v4
@@ -35,4 +35,4 @@ jobs:
       - name: Run Kurtosis + assertoor tests
         uses: ethpandaops/kurtosis-assertoor-github-action@v1
         with:
-            enclave_name: "kurtosis-run-${{ matrix.os }}-${{ github.run_id }}"
+            enclave_name: "kurtosis-run-${{ matrix.os.name }}-${{ github.run_id }}"


### PR DESCRIPTION
kurtosis assertoor tests in ci

decision points:

- since the job takes about 45 minutes to run, I decided not to run it on every PR, but rather we run it every 12 hours at 2AM/PM UTC.
- all tests are present in https://github.com/ethpandaops/assertoor-test/tree/master/assertoor-tests. This ci runs [these](https://github.com/erigontech/erigon/pull/11464/files#diff-b45e49409c33f39133315225d30c02d8cfacfd9a53d1157bca61284683a4c498R22) tests.
- test is for ubuntu only; not for mac or windows.

Many tests are failing; specially the validator related ones. Tracked separately - https://github.com/erigontech/erigon/issues/11590