### PR TITLE
chain_config: Fix json name for deposit contract address

### DIFF
--- a/erigon-lib/chain/chain_config.go
+++ b/erigon-lib/chain/chain_config.go
@@ -80,7 +80,7 @@ type Config struct {
 
 	// (Optional) deposit contract of PoS chains
 	// See also EIP-6110: Supply validator deposits on chain
-	DepositContract common.Address `json:"depositContract,omitempty"`
+	DepositContract common.Address `json:"depositContractAddress,omitempty"`
 
 	// Various consensus engines
 	Ethash *EthashConfig `json:"ethash,omitempty"`


### PR DESCRIPTION
The community seems to be using `depositContractAddress` in the standard format for importing genesis.json, as seen in pectra-devnet-2
(This was mandated in EIP-6110)