### PR TITLE
diagnostics: collect diskinfo for macos

### DIFF
--- a/cmd/diag/main.go
+++ b/cmd/diag/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/erigontech/erigon/cmd/diag/db"
 	"github.com/erigontech/erigon/cmd/diag/downloader"
 	"github.com/erigontech/erigon/cmd/diag/stages"
+	sinfo "github.com/erigontech/erigon/cmd/diag/sysinfo"
 	"github.com/erigontech/erigon/cmd/diag/ui"
 	"github.com/erigontech/erigon/cmd/snapshots/sync"
 	"github.com/erigontech/erigon/cmd/utils"
@@ -52,6 +53,7 @@ func main() {
 		&stages.Command,
 		&db.Command,
 		&ui.Command,
+		&sinfo.Command,
 	}
 
 	app.Flags = []cli.Flag{}

--- a/cmd/diag/sysinfo/sysinfo.go
+++ b/cmd/diag/sysinfo/sysinfo.go
@@ -1,0 +1,84 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package sysinfo
+
+import (
+	"github.com/urfave/cli/v2"
+
+	"github.com/erigontech/erigon-lib/diagnostics"
+	"github.com/erigontech/erigon/cmd/diag/flags"
+	"github.com/erigontech/erigon/cmd/diag/util"
+)
+
+var (
+	ExportPathFlag = cli.StringFlag{
+		Name:     "export.path",
+		Aliases:  []string{"ep"},
+		Usage:    "Path to folder for export result",
+		Required: true,
+		Value:    "",
+	}
+
+	ExportFileNameFlag = cli.StringFlag{
+		Name:     "export.file",
+		Aliases:  []string{"ef"},
+		Usage:    "File name to export result default is sysinfo.txt",
+		Required: false,
+		Value:    "sysinfo.txt",
+	}
+)
+
+var Command = cli.Command{
+	Name:      "sysinfo",
+	Aliases:   []string{"sinfo"},
+	ArgsUsage: "",
+	Action:    collectInfo,
+	Flags: []cli.Flag{
+		&flags.DebugURLFlag,
+		&ExportPathFlag,
+		&ExportFileNameFlag,
+	},
+	Description: "Collect information about system and save it to file in order to provide to support person",
+}
+
+func collectInfo(cliCtx *cli.Context) error {
+	data, err := getData(cliCtx)
+	if err != nil {
+		util.RenderError(err)
+	}
+
+	// Save data to file
+	err = util.SaveDataToFile(cliCtx.String(ExportPathFlag.Name), cliCtx.String(ExportFileNameFlag.Name), data.Disk.Details)
+	if err != nil {
+		util.RenderError(err)
+	}
+
+	return nil
+}
+
+func getData(cliCtx *cli.Context) (diagnostics.HardwareInfo, error) {
+	var data diagnostics.HardwareInfo
+	url := "http://" + cliCtx.String(flags.DebugURLFlag.Name) + flags.ApiPath + "/hardware-info"
+
+	err := util.MakeHttpGetCall(cliCtx.Context, url, &data)
+
+	if err != nil {
+		return data, err
+	}
+
+	return data, nil
+}

--- a/cmd/diag/util/util.go
+++ b/cmd/diag/util/util.go
@@ -112,3 +112,36 @@ func RenderError(err error) {
 	txt := text.Colors{text.FgWhite, text.BgRed}
 	fmt.Printf("%s %s\n", txt.Sprint("[ERROR]"), err)
 }
+
+func SaveDataToFile(filePath string, fileName string, data string) error {
+	//check is folder exists
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		err := os.MkdirAll(filePath, 0755)
+		if err != nil {
+			return err
+		}
+	}
+
+	fullPath := MakePath(filePath, fileName)
+
+	file, err := os.Create(fullPath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = file.WriteString(fmt.Sprintf("%v\n", data))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func MakePath(filePath string, fileName string) string {
+	if filePath[len(filePath)-1] == '/' {
+		filePath = filePath[:len(filePath)-1]
+	}
+
+	return fmt.Sprintf("%s/%s", filePath, fileName)
+}

--- a/diagnostics/setup.go
+++ b/diagnostics/setup.go
@@ -133,4 +133,5 @@ func SetupEndpoints(ctx *cli.Context, node *node.ErigonNode, diagMux *http.Serve
 	SetupMemAccess(diagMux)
 	SetupHeadersAccess(diagMux, diagnostic)
 	SetupBodiesAccess(diagMux, diagnostic)
+	SetupSysInfoAccess(diagMux, diagnostic)
 }

--- a/diagnostics/snapshot_sync.go
+++ b/diagnostics/snapshot_sync.go
@@ -39,12 +39,6 @@ func SetupStagesAccess(metricsMux *http.ServeMux, diag *diaglib.DiagnosticClient
 		writeFilesList(w, diag)
 	})
 
-	metricsMux.HandleFunc("/hardware-info", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Content-Type", "application/json")
-		writeHardwareInfo(w, diag)
-	})
-
 	metricsMux.HandleFunc("/resources-usage", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Content-Type", "application/json")
@@ -78,10 +72,6 @@ func writeStages(w http.ResponseWriter, diag *diaglib.DiagnosticClient) {
 
 func writeFilesList(w http.ResponseWriter, diag *diaglib.DiagnosticClient) {
 	diag.SnapshotFilesListJson(w)
-}
-
-func writeHardwareInfo(w http.ResponseWriter, diag *diaglib.DiagnosticClient) {
-	diag.HardwareInfoJson(w)
 }
 
 func writeSyncStages(w http.ResponseWriter, diag *diaglib.DiagnosticClient) {

--- a/diagnostics/sysinfo.go
+++ b/diagnostics/sysinfo.go
@@ -14,18 +14,26 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Erigon. If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !darwin
+package diagnostics
 
-package diskutils
+import (
+	"net/http"
 
-import "github.com/erigontech/erigon-lib/log/v3"
+	diaglib "github.com/erigontech/erigon-lib/diagnostics"
+)
 
-func MountPointForDirPath(dirPath string) string {
-	log.Debug("[diskutils] Implemented only for darwin")
-	return "/"
+func SetupSysInfoAccess(metricsMux *http.ServeMux, diag *diaglib.DiagnosticClient) {
+	if metricsMux == nil {
+		return
+	}
+
+	metricsMux.HandleFunc("/disk-info", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Content-Type", "application/json")
+		writeHardwareInfo(w, diag)
+	})
 }
 
-func DiskInfo(disk string) (string, error) {
-	log.Debug("[diskutils] Implemented only for darwin")
-	return "", nil
+func writeDiskInfo(w http.ResponseWriter, diag *diaglib.DiagnosticClient) {
+	diag.HardwareInfoJson(w)
 }

--- a/diagnostics/sysinfo.go
+++ b/diagnostics/sysinfo.go
@@ -27,13 +27,13 @@ func SetupSysInfoAccess(metricsMux *http.ServeMux, diag *diaglib.DiagnosticClien
 		return
 	}
 
-	metricsMux.HandleFunc("/disk-info", func(w http.ResponseWriter, r *http.Request) {
+	metricsMux.HandleFunc("/hardware-info", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Content-Type", "application/json")
 		writeHardwareInfo(w, diag)
 	})
 }
 
-func writeDiskInfo(w http.ResponseWriter, diag *diaglib.DiagnosticClient) {
+func writeHardwareInfo(w http.ResponseWriter, diag *diaglib.DiagnosticClient) {
 	diag.HardwareInfoJson(w)
 }

--- a/erigon-lib/diagnostics/entities.go
+++ b/erigon-lib/diagnostics/entities.go
@@ -164,9 +164,12 @@ type RAMInfo struct {
 }
 
 type DiskInfo struct {
-	FsType string `json:"fsType"`
-	Total  uint64 `json:"total"`
-	Free   uint64 `json:"free"`
+	FsType     string `json:"fsType"`
+	Total      uint64 `json:"total"`
+	Free       uint64 `json:"free"`
+	MountPoint string `json:"mountPoint"`
+	Device     string `json:"device"`
+	Details    string `json:"details"`
 }
 
 type CPUInfo struct {

--- a/erigon-lib/diagnostics/sys_info.go
+++ b/erigon-lib/diagnostics/sys_info.go
@@ -112,6 +112,8 @@ func GetDiskInfo(nodeDisk string) DiskInfo {
 	fsType := ""
 	total := uint64(0)
 	free := uint64(0)
+	mountPoint := "/"
+	device := "/"
 
 	partitions, err := disk.Partitions(false)
 
@@ -123,6 +125,8 @@ func GetDiskInfo(nodeDisk string) DiskInfo {
 					fsType = partition.Fstype
 					total = iocounters.Total
 					free = iocounters.Free
+					mountPoint = partition.Mountpoint
+					device = partition.Device
 
 					break
 				}
@@ -130,10 +134,18 @@ func GetDiskInfo(nodeDisk string) DiskInfo {
 		}
 	}
 
+	diskDetails, err := diskutils.DiskInfo(device)
+	if err != nil {
+		log.Debug("[diagnostics] Failed to get disk info", "err", err)
+	}
+
 	return DiskInfo{
-		FsType: fsType,
-		Total:  total,
-		Free:   free,
+		FsType:     fsType,
+		Total:      total,
+		Free:       free,
+		MountPoint: mountPoint,
+		Device:     device,
+		Details:    diskDetails,
 	}
 }
 

--- a/erigon-lib/diskutils/diskutils_darwin.go
+++ b/erigon-lib/diskutils/diskutils_darwin.go
@@ -19,7 +19,9 @@
 package diskutils
 
 import (
+	"bytes"
 	"os"
+	"os/exec"
 	"syscall"
 
 	"github.com/erigontech/erigon-lib/log/v3"
@@ -64,4 +66,17 @@ func SmlinkForDirPath(dirPath string) string {
 	} else {
 		return dirPath
 	}
+}
+
+func DiskInfo(disk string) (string, error) {
+	cmd := exec.Command("diskutil", "info", disk)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", err
+	}
+
+	output := out.String()
+	return output, nil
 }


### PR DESCRIPTION
- Added collections info about disk, as we are interested in disk type. For now it's only for macOS