### PR TITLE
fix: update mpt document logic

### DIFF
--- a/docs/programmers_guide/guide.md
+++ b/docs/programmers_guide/guide.md
@@ -359,7 +359,7 @@ neighbours are 1 and 3. Therefore, this key will emit the opcode
 prefix group).
 
 The following, optional, part of the step only happens if the common prefix of the current key and the preceding key is
-longer or equal than the common prefix of the current key and the succeeding key, in other words, if at least one prefix
+longer than the common prefix of the current key and the succeeding key, in other words, if at least one prefix
 group needs to be "closed". Closing a prefix group means first emitting opcode `BRANCH` or `BRANCHHASH`. The value for
 the operand is taken from the item in the `groups` slice, which corresponds to the length of the prefix for this group.
 Once value is taken, `groups` slice is trimmed to remove the used item. Secondly, closing a prefix groups means invoking


### PR DESCRIPTION
Hi, I'm diving into the merkle tree calculation step and thanks for such a detailed doc in `guide.md`, it is very helpful for understanding the entire process.

I found a logical error in the article that could mislead others' understanding, so I hope to help Erigon fix it.
I found the [corresponding position](https://github.com/erigontech/erigon/blob/main/turbo/trie/gen_struct_step.go#L270) in the code and proved that only the case of 'less' will cause a prefix group closing, while the original' equal 'will not cause it.