### PR TITLE
[wip] L0 LRU experiment

### DIFF
--- a/cl/phase1/forkchoice/utils.go
+++ b/cl/phase1/forkchoice/utils.go
@@ -62,8 +62,8 @@ func (f *ForkChoiceStore) onNewFinalized(newFinalized solid.Checkpoint) {
 		}
 		return true
 	})
-
-	f.forkGraph.Prune(newFinalized.Epoch() * f.beaconCfg.SlotsPerEpoch)
+	slotToPrune := ((newFinalized.Epoch() - 1) * f.beaconCfg.SlotsPerEpoch) - 1
+	f.forkGraph.Prune(slotToPrune)
 }
 
 // updateCheckpoints updates the justified and finalized checkpoints if new checkpoints have higher epochs.

--- a/erigon-lib/kv/tables.go
+++ b/erigon-lib/kv/tables.go
@@ -1017,7 +1017,8 @@ func String2Domain(in string) (Domain, error) {
 	case "commitment":
 		return CommitmentDomain, nil
 	default:
-		return 0, fmt.Errorf("unknown history name: %s", in)
+		const MaxUint16 uint16 = 1<<16 - 1
+		return Domain(MaxUint16), fmt.Errorf("unknown history name: %s", in)
 	}
 }
 

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -1423,13 +1423,8 @@ func (dt *DomainRoTx) getFromFiles(filekey []byte) (v []byte, found bool, fileSt
 			var ok bool
 			v, ok = dt.l0Cache.Get(hi)
 			if ok {
-				dt.l0CacheHit++
-				if dt.l0CacheMiss%100_000 == 0 {
-					log.Warn("[dbg] l0Cache", "a", dt.d.filenameBase, "hit", dt.l0CacheHit, "miss", dt.l0CacheMiss, "ratio", fmt.Sprintf("%.2f", float64(dt.l0CacheHit)/float64(dt.l0CacheHit+dt.l0CacheMiss)))
-				}
 				return v, true, dt.files[i].startTxNum, dt.files[i].endTxNum, nil
 			}
-			dt.l0CacheMiss++
 		}
 
 		v, found, err = dt.getFromFile(i, filekey)

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -1423,13 +1423,8 @@ func (dt *DomainRoTx) getFromFiles(filekey []byte) (v []byte, found bool, fileSt
 			var ok bool
 			v, ok = dt.l0Cache.Get(hi)
 			if ok {
-				dt.l0CacheHit++
-				if dt.l0CacheHit%100 == 0 {
-					log.Warn("[dbg] l0Cache", "a", dt.d.filenameBase, "hit", dt.l0CacheHit, "miss", dt.l0CacheMiss, "ratio", fmt.Sprintf("%.2f", float64(dt.l0CacheHit)/float64(dt.l0CacheHit+dt.l0CacheMiss)))
-				}
 				return v, true, dt.files[i].startTxNum, dt.files[i].endTxNum, nil
 			}
-			dt.l0CacheMiss++
 		}
 
 		v, found, err = dt.getFromFile(i, filekey)

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -1423,8 +1423,10 @@ func (dt *DomainRoTx) getFromFiles(filekey []byte) (v []byte, found bool, fileSt
 			var ok bool
 			v, ok = dt.l0Cache.Get(hi)
 			if ok {
+				dt.l0CacheHit++
 				return v, true, dt.files[i].startTxNum, dt.files[i].endTxNum, nil
 			}
+			dt.l0CacheMiss++
 		}
 
 		v, found, err = dt.getFromFile(i, filekey)

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -714,7 +714,7 @@ type DomainRoTx struct {
 	lEachCacheHit, lEachCacheTotal [LevelsWithLRU]int
 }
 
-const LevelsWithLRU = 1
+const LevelsWithLRU = 2
 
 func domainReadMetric(name kv.Domain, level int) metrics.Summary {
 	if level > 4 {

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -1424,6 +1424,9 @@ func (dt *DomainRoTx) getFromFiles(filekey []byte) (v []byte, found bool, fileSt
 			v, ok = dt.l0Cache.Get(hi)
 			if ok {
 				dt.l0CacheHit++
+				if dt.l0CacheMiss%100_000 == 0 {
+					log.Warn("[dbg] l0Cache", "a", dt.d.filenameBase, "hit", dt.l0CacheHit, "miss", dt.l0CacheMiss, "ratio", fmt.Sprintf("%.2f", float64(dt.l0CacheHit)/float64(dt.l0CacheHit+dt.l0CacheMiss)))
+				}
 				return v, true, dt.files[i].startTxNum, dt.files[i].endTxNum, nil
 			}
 			dt.l0CacheMiss++

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -1425,7 +1425,7 @@ func (dt *DomainRoTx) getFromFiles(filekey []byte) (v []byte, found bool, fileSt
 			if ok {
 				if dbg.KVReadLevelledMetrics {
 					dt.lEachCacheHit[i]++
-					if dt.lEachCacheHit[i]%100_000 == 0 {
+					if dt.lEachCacheTotal[i]%1_000_000 == 0 {
 						log.Warn("[dbg] lEachCache", "a", dt.d.filenameBase, "hit", dt.lEachCacheHit[i], "total", dt.lEachCacheTotal[i], "ratio", fmt.Sprintf("%.2f", float64(dt.lEachCacheHit[i])/float64(dt.lEachCacheTotal[i])))
 					}
 				}

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -1419,12 +1419,16 @@ func (dt *DomainRoTx) getFromFiles(filekey []byte) (v []byte, found bool, fileSt
 			}
 			var ok bool
 			v, ok = dt.lEachCache[i].Get(hi)
-			//dt.lEachCacheTotal[i]++
+			if dbg.KVReadLevelledMetrics {
+				dt.lEachCacheTotal[i]++
+			}
 			if ok {
-				//dt.lEachCacheHit[i]++
-				//if dt.lEachCacheHit[i]%100_000 == 0 {
-				//	log.Warn("[dbg] lEachCache", "a", dt.d.filenameBase, "hit", dt.lEachCacheHit[i], "total", dt.lEachCacheTotal[i], "ratio", fmt.Sprintf("%.2f", float64(dt.lEachCacheHit[i])/float64(dt.lEachCacheTotal[i])))
-				//}
+				if dbg.KVReadLevelledMetrics {
+					dt.lEachCacheHit[i]++
+					if dt.lEachCacheHit[i]%100_000 == 0 {
+						log.Warn("[dbg] lEachCache", "a", dt.d.filenameBase, "hit", dt.lEachCacheHit[i], "total", dt.lEachCacheTotal[i], "ratio", fmt.Sprintf("%.2f", float64(dt.lEachCacheHit[i])/float64(dt.lEachCacheTotal[i])))
+					}
+				}
 				return v, true, dt.files[i].startTxNum, dt.files[i].endTxNum, nil
 			}
 		}

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -710,9 +710,11 @@ type DomainRoTx struct {
 
 	valsC kv.Cursor
 
-	lEachCache                     [2]*simplelru.LRU[uint64, []byte]
-	lEachCacheHit, lEachCacheTotal [2]int
+	lEachCache                     [LevelsWithLRU]*simplelru.LRU[uint64, []byte]
+	lEachCacheHit, lEachCacheTotal [LevelsWithLRU]int
 }
+
+const LevelsWithLRU = 1
 
 func domainReadMetric(name kv.Domain, level int) metrics.Summary {
 	if level > 4 {

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -1413,7 +1413,7 @@ func (dt *DomainRoTx) getFromFiles(filekey []byte) (v []byte, found bool, fileSt
 			}
 		}
 
-		if i == 0 {
+		if dt.d.name != kv.CommitmentDomain && i == 0 {
 			if dt.l0Cache == nil {
 				dt.l0Cache, err = simplelru.NewLRU[uint64, []byte](32, nil)
 				if err != nil {

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -1441,7 +1441,7 @@ func (dt *DomainRoTx) getFromFiles(filekey []byte) (v []byte, found bool, fileSt
 			fmt.Printf("GetLatest(%s, %x) -> found in file %s\n", dt.d.filenameBase, filekey, dt.files[i].src.decompressor.FileName())
 		}
 
-		if i == 0 {
+		if dt.d.name != kv.CommitmentDomain && i == 0 {
 			dt.l0Cache.Add(hi, v)
 		}
 		return v, true, dt.files[i].startTxNum, dt.files[i].endTxNum, nil

--- a/erigon-lib/state/domain_shared.go
+++ b/erigon-lib/state/domain_shared.go
@@ -29,7 +29,6 @@ import (
 	"time"
 	"unsafe"
 
-	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/sha3"
 
@@ -102,8 +101,6 @@ type SharedDomains struct {
 
 	currentChangesAccumulator *StateChangeSet
 	pastChangesAccumulator    map[string]*StateChangeSet
-
-	codeSizeCache *lru.Cache[common.Hash, []byte]
 }
 
 type HasAggTx interface {
@@ -114,17 +111,10 @@ type HasAgg interface {
 }
 
 func NewSharedDomains(tx kv.Tx, logger log.Logger) (*SharedDomains, error) {
-	codeCache, err := lru.New[common.Hash, []byte](100)
-	if err != nil {
-		panic(err)
-	}
-
 	sd := &SharedDomains{
 		logger:  logger,
 		storage: btree2.NewMap[string, dataWithPrevStep](128),
 		//trace:   true,
-
-		codeSizeCache: codeCache,
 	}
 	sd.SetTx(tx)
 

--- a/erigon-lib/state/domain_shared.go
+++ b/erigon-lib/state/domain_shared.go
@@ -29,6 +29,7 @@ import (
 	"time"
 	"unsafe"
 
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/sha3"
 
@@ -101,6 +102,8 @@ type SharedDomains struct {
 
 	currentChangesAccumulator *StateChangeSet
 	pastChangesAccumulator    map[string]*StateChangeSet
+
+	codeSizeCache *lru.Cache[common.Hash, []byte]
 }
 
 type HasAggTx interface {
@@ -111,11 +114,17 @@ type HasAgg interface {
 }
 
 func NewSharedDomains(tx kv.Tx, logger log.Logger) (*SharedDomains, error) {
+	codeCache, err := lru.New[common.Hash, []byte](100)
+	if err != nil {
+		panic(err)
+	}
 
 	sd := &SharedDomains{
 		logger:  logger,
 		storage: btree2.NewMap[string, dataWithPrevStep](128),
 		//trace:   true,
+
+		codeSizeCache: codeCache,
 	}
 	sd.SetTx(tx)
 

--- a/erigon-lib/state/domain_test.go
+++ b/erigon-lib/state/domain_test.go
@@ -83,7 +83,7 @@ func testDbAndDomainOfStep(t *testing.T, aggStep uint64, logger log.Logger) (kv.
 			iiCfg:             iiCfg{salt: &salt, dirs: dirs, db: db},
 			withLocalityIndex: false, withExistenceIndex: false, compression: CompressNone, historyLargeValues: true,
 		}}
-	d, err := NewDomain(cfg, aggStep, kv.AccountsDomain.String(), valsTable, historyKeysTable, historyValsTable, indexTable, nil, logger)
+	d, err := NewDomain(cfg, aggStep, kv.AccountsDomain, valsTable, historyKeysTable, historyValsTable, indexTable, nil, logger)
 	require.NoError(t, err)
 	d.DisableFsync()
 	d.compressWorkers = 1

--- a/erigon-lib/state/metrics.go
+++ b/erigon-lib/state/metrics.go
@@ -61,7 +61,7 @@ var (
 
 var (
 	mxsKVGet = map[string][]metrics.Summary{
-		"account": {
+		"accounts": {
 			metrics.GetOrCreateSummary(`kv_get{level="L0",domain="account"}`),
 			metrics.GetOrCreateSummary(`kv_get{level="L1",domain="account"}`),
 			metrics.GetOrCreateSummary(`kv_get{level="L2",domain="account"}`),


### PR DESCRIPTION
32-items cache. Only L0: 
```
eth-mainnet:
a=accounts hit=13700 miss=9803 ratio=0.58
a=storage hit=12500 miss=22865 ratio=0.35
a=code hit=17500 miss=12962 ratio=0.57
```
```
bor-mainnet
a=code hit=420500 miss=96412 ratio=0.81
a=storage hit=26000 miss=103800 ratio=0.20
a=accounts hit=10100 miss=9450 ratio=0.52
```


------
128 items cache. all levels: 
```
bor-mainnet
a=accounts hit=1606275 total=2000000 ratio=0.80
a=code hit=5201420 total=7000000 ratio=0.74
a=storage hit=1793932 total=5000000 ratio=0.36
```
