### PR TITLE
stagedsync: Fix nil panic on custom chains

### DIFF
--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -744,8 +744,11 @@ Loop:
 				HistoryExecution: offsetFromBlockBeginning > 0 && txIndex < int(offsetFromBlockBeginning),
 
 				BlockReceipts: receipts,
-				Config:        cfg.genesis.Config,
 			}
+			if cfg.genesis != nil {
+				txTask.Config = cfg.genesis.Config
+			}
+
 			if txTask.TxNum <= txNumInDB && txTask.TxNum > 0 {
 				inputTxNum++
 				skipPostEvaluation = true


### PR DESCRIPTION
Custom chains started using `init` may put nil genesis here. I am working on a design fix for this, but this PR will prevent a panic