### PR TITLE
snapcfg:  should not panic on empty network name

### DIFF
--- a/erigon-lib/chain/snapcfg/util.go
+++ b/erigon-lib/chain/snapcfg/util.go
@@ -373,7 +373,7 @@ var knownTypes = map[string][]snaptype.Type{}
 
 func Seedable(networkName string, info snaptype.FileInfo) bool {
 	if networkName == "" {
-		panic("empty network name")
+		return false
 	}
 	return KnownCfg(networkName).Seedable(info)
 }


### PR DESCRIPTION
Fixes the following issue:
This function is invoked regardless of the chain being known. For custom chains with `init` command, the network name is blank and this panic is triggered on restarting the node