### PR TITLE
qa-tests: update test scheduling and timeouts

### DIFF
--- a/.github/workflows/qa-snap-download.yml
+++ b/.github/workflows/qa-snap-download.yml
@@ -2,17 +2,17 @@ name: QA - Snapshot Download
 
 on:
   schedule:
-    - cron: '0 5 * * 1-6'  # Run every day at 05:00 AM UTC except Sunday
+    - cron: '0 0 * * 1-6'  # Run every night at 00:00 AM UTC except Sunday
   workflow_dispatch:     # Run manually
 
 jobs:
   snap-download-test:
     runs-on: self-hosted
-    timeout-minutes: 800
+    timeout-minutes: 500
     env:
       ERIGON_DATA_DIR: ${{ github.workspace }}/erigon_data
       ERIGON_QA_PATH: /home/qarunner/erigon-qa
-      TOTAL_TIME_SECONDS: 43200 # 12 hours
+      TOTAL_TIME_SECONDS: 28800 # 8 hours
       CHAIN: mainnet
 
     steps:

--- a/.github/workflows/qa-sync-from-scratch-minimal-node.yml
+++ b/.github/workflows/qa-sync-from-scratch-minimal-node.yml
@@ -2,18 +2,18 @@ name: QA - Sync from scratch (minimal node)
 
 on:
   schedule:
-    - cron: '0 0 * * 6'  # Run on Saturday at 00:00 AM UTC
+    - cron: '0 0 * * *'  # Run every night at 00:00 AM UTC
   workflow_dispatch:     # Run manually
 
 jobs:
   minimal-node-sync-from-scratch-test:
     runs-on: self-hosted
-    timeout-minutes: 1500 # 25 hours
+    timeout-minutes: 360 # 6 hours
     env:
       ERIGON_DATA_DIR: ${{ github.workspace }}/erigon_data
       ERIGON_QA_PATH: /home/qarunner/erigon-qa
       TRACKING_TIME_SECONDS: 7200 # 2 hours
-      TOTAL_TIME_SECONDS: 86400 # 24 hours
+      TOTAL_TIME_SECONDS: 18000 # 5 hours
       CHAIN: mainnet
 
     steps:

--- a/.github/workflows/qa-sync-from-scratch.yml
+++ b/.github/workflows/qa-sync-from-scratch.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   sync-from-scratch-test:
     runs-on: self-hosted
-    timeout-minutes: 1100  # 18 hours plus 20 minutes
+    timeout-minutes: 740  # 12 hours plus 20 minutes
     strategy:
       fail-fast: false
       matrix:
@@ -17,7 +17,7 @@ jobs:
       ERIGON_DATA_DIR: ${{ github.workspace }}/erigon_data
       ERIGON_QA_PATH: /home/qarunner/erigon-qa
       TRACKING_TIME_SECONDS: 7200 # 2 hours
-      TOTAL_TIME_SECONDS: 57600 # 16 hours
+      TOTAL_TIME_SECONDS: 43200 # 12 hours
       CHAIN: ${{ matrix.chain }}
 
     steps:

--- a/.github/workflows/qa-tip-tracking.yml
+++ b/.github/workflows/qa-tip-tracking.yml
@@ -2,7 +2,7 @@ name: QA - Tip tracking
 
 on:
   schedule:
-    - cron: '0 0 * * 1-6'  # Run every day at 00:00 AM UTC except Sunday
+    - cron: '0 0 * * 1-6'  # Run every night at 00:00 AM UTC except Sunday
   workflow_dispatch:     # Run manually
 
 jobs:


### PR DESCRIPTION
Change test scheduling and timeouts after Ottersync introduction.
Now we can execute tests more frequently due to the significant reduction in test time.

Scheduled to run every night:
- tip-tracking
- snap-download
- sync-from-scratch for mainnet, minimal node

Scheduled to run on Sunday:
- sync-from-scratch for testnets, archive node