### PR TITLE
polygon: add unwind prune to sync stage

### DIFF
--- a/eth/stagedsync/default_stages.go
+++ b/eth/stagedsync/default_stages.go
@@ -476,7 +476,7 @@ func PolygonSyncStages(
 			ID:          stages.PolygonSync,
 			Description: "Use polygon sync component to sync headers, bodies and heimdall data",
 			Forward: func(badBlockUnwind bool, s *StageState, u Unwinder, txc wrap.TxContainer, logger log.Logger) error {
-				return SpawnPolygonSyncStage(ctx, txc.Tx, s, u, polygonSyncStageCfg)
+				return ForwardPolygonSyncStage(ctx, txc.Tx, s, u, polygonSyncStageCfg)
 			},
 			Unwind: func(u *UnwindState, s *StageState, txc wrap.TxContainer, logger log.Logger) error {
 				return UnwindPolygonSyncStage(ctx, txc.Tx, u, polygonSyncStageCfg)

--- a/eth/stagedsync/default_stages.go
+++ b/eth/stagedsync/default_stages.go
@@ -479,7 +479,7 @@ func PolygonSyncStages(
 				return SpawnPolygonSyncStage(ctx, txc.Tx, s, u, polygonSyncStageCfg)
 			},
 			Unwind: func(u *UnwindState, s *StageState, txc wrap.TxContainer, logger log.Logger) error {
-				return UnwindPolygonSyncStage()
+				return UnwindPolygonSyncStage(ctx, txc.Tx, u, polygonSyncStageCfg)
 			},
 			Prune: func(p *PruneState, tx kv.RwTx, logger log.Logger) error {
 				return PrunePolygonSyncStage()

--- a/eth/stagedsync/default_stages.go
+++ b/eth/stagedsync/default_stages.go
@@ -84,7 +84,7 @@ func DefaultStages(ctx context.Context,
 				return BorHeimdallUnwind(u, ctx, s, txc.Tx, borHeimdallCfg)
 			},
 			Prune: func(p *PruneState, tx kv.RwTx, logger log.Logger) error {
-				return BorHeimdallPrune(p, ctx, tx, borHeimdallCfg)
+				return nil
 			},
 		},
 		{
@@ -482,7 +482,7 @@ func PolygonSyncStages(
 				return UnwindPolygonSyncStage(ctx, txc.Tx, u, polygonSyncStageCfg)
 			},
 			Prune: func(p *PruneState, tx kv.RwTx, logger log.Logger) error {
-				return PrunePolygonSyncStage()
+				return nil
 			},
 		},
 		{

--- a/eth/stagedsync/stage_bor_heimdall.go
+++ b/eth/stagedsync/stage_bor_heimdall.go
@@ -844,11 +844,3 @@ func BorHeimdallUnwind(u *UnwindState, ctx context.Context, _ *StageState, tx kv
 
 	return
 }
-
-func BorHeimdallPrune(_ *PruneState, _ context.Context, _ kv.RwTx, cfg BorHeimdallCfg) (err error) {
-	if cfg.borConfig == nil {
-		return
-	}
-
-	return
-}

--- a/eth/stagedsync/stage_polygon_sync.go
+++ b/eth/stagedsync/stage_polygon_sync.go
@@ -381,11 +381,6 @@ func UnwindMilestones(tx kv.RwTx, u *UnwindState, unwindTypes []string) error {
 	return err
 }
 
-func PrunePolygonSyncStage() error {
-	// TODO - headers, bodies (including txnums index), checkpoints, milestones, spans, state sync events
-	return nil
-}
-
 type polygonSyncStageTxAction struct {
 	apply func(tx kv.RwTx) error
 }

--- a/eth/stagedsync/stage_polygon_sync.go
+++ b/eth/stagedsync/stage_polygon_sync.go
@@ -150,7 +150,7 @@ type PolygonSyncStageCfg struct {
 	blockWriter *blockio.BlockWriter
 }
 
-func SpawnPolygonSyncStage(
+func ForwardPolygonSyncStage(
 	ctx context.Context,
 	tx kv.RwTx,
 	stageState *StageState,
@@ -405,7 +405,7 @@ func (s *polygonSyncStageService) Run(ctx context.Context, tx kv.RwTx, stageStat
 	s.executionEngine.appendLogPrefix = s.appendLogPrefix
 	s.executionEngine.stageState = stageState
 	s.executionEngine.unwinder = unwinder
-	s.logger.Info(s.appendLogPrefix("begin..."), "progress", stageState.BlockNumber)
+	s.logger.Info(s.appendLogPrefix("forward"), "progress", stageState.BlockNumber)
 
 	s.runBgComponentsOnce(ctx)
 

--- a/eth/stagedsync/stagebuilder.go
+++ b/eth/stagedsync/stagebuilder.go
@@ -69,7 +69,7 @@ func MiningStages(
 				return BorHeimdallUnwind(u, ctx, s, txc.Tx, borHeimdallCfg)
 			},
 			Prune: func(p *PruneState, tx kv.RwTx, logger log.Logger) error {
-				return BorHeimdallPrune(p, ctx, tx, borHeimdallCfg)
+				return nil
 			},
 		},
 		{


### PR DESCRIPTION
closes https://github.com/erigontech/erigon/issues/11177
- adds unwind logic to the new polygon sync stage which uses astrid
- seems like we've never done running for bor heimdall so removing empty funcs