### PR TITLE
fix concurrent rw on touchedLeaves map

### DIFF
--- a/cl/phase1/core/state/raw/copy.go
+++ b/cl/phase1/core/state/raw/copy.go
@@ -81,7 +81,7 @@ func (b *BeaconState) CopyInto(dst *BeaconState) error {
 	dst.version = b.version
 	// Now sync internals
 	copy(dst.leaves, b.leaves)
-	dst.touchedLeaves = make([]atomic.Bool, len(b.touchedLeaves))
+	dst.touchedLeaves = make([]atomic.Uint32, len(b.touchedLeaves))
 	for leafIndex := range b.touchedLeaves {
 		// Copy the value
 		dst.touchedLeaves[leafIndex].Store(b.touchedLeaves[leafIndex].Load())

--- a/cl/phase1/core/state/raw/copy.go
+++ b/cl/phase1/core/state/raw/copy.go
@@ -81,7 +81,7 @@ func (b *BeaconState) CopyInto(dst *BeaconState) error {
 	dst.version = b.version
 	// Now sync internals
 	copy(dst.leaves, b.leaves)
-	dst.touchedLeaves = make([]atomic.Uint32, len(b.touchedLeaves))
+	dst.touchedLeaves = make([]atomic.Uint32, StateLeafSize)
 	for leafIndex := range b.touchedLeaves {
 		// Copy the value
 		dst.touchedLeaves[leafIndex].Store(b.touchedLeaves[leafIndex].Load())

--- a/cl/phase1/core/state/raw/copy.go
+++ b/cl/phase1/core/state/raw/copy.go
@@ -17,6 +17,8 @@
 package raw
 
 import (
+	"sync/atomic"
+
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
@@ -79,9 +81,10 @@ func (b *BeaconState) CopyInto(dst *BeaconState) error {
 	dst.version = b.version
 	// Now sync internals
 	copy(dst.leaves, b.leaves)
-	dst.touchedLeaves = make(map[StateLeafIndex]bool)
-	for leafIndex, touchedVal := range b.touchedLeaves {
-		dst.touchedLeaves[leafIndex] = touchedVal
+	dst.touchedLeaves = make([]atomic.Bool, len(b.touchedLeaves))
+	for leafIndex := range b.touchedLeaves {
+		// Copy the value
+		dst.touchedLeaves[leafIndex].Store(b.touchedLeaves[leafIndex].Load())
 	}
 	return nil
 }

--- a/cl/phase1/core/state/raw/hashing.go
+++ b/cl/phase1/core/state/raw/hashing.go
@@ -204,16 +204,17 @@ func (b *BeaconState) updateLeaf(idx StateLeafIndex, leaf libcommon.Hash) {
 	// Update leaf with new value.
 	copy(b.leaves[idx*32:], leaf[:])
 	// Now leaf is clean :).
-	b.touchedLeaves[idx].Store(false)
+	b.touchedLeaves[idx].Store(LeafCleanValue)
 }
 
 func (b *BeaconState) isLeafDirty(idx StateLeafIndex) bool {
 	// If leaf is non-initialized or if it was touched then we change it.
-	return b.touchedLeaves[idx].Load()
+	v := b.touchedLeaves[idx].Load()
+	return v == LeafInitValue || v == LeafDirtyValue
 }
 
 func (b *BeaconState) markLeaf(idxs ...StateLeafIndex) {
 	for _, idx := range idxs {
-		b.touchedLeaves[idx].Store(true)
+		b.touchedLeaves[idx].Store(LeafDirtyValue)
 	}
 }

--- a/cl/phase1/core/state/raw/hashing.go
+++ b/cl/phase1/core/state/raw/hashing.go
@@ -204,17 +204,16 @@ func (b *BeaconState) updateLeaf(idx StateLeafIndex, leaf libcommon.Hash) {
 	// Update leaf with new value.
 	copy(b.leaves[idx*32:], leaf[:])
 	// Now leaf is clean :).
-	b.touchedLeaves[idx] = false
+	b.touchedLeaves[idx].Store(false)
 }
 
 func (b *BeaconState) isLeafDirty(idx StateLeafIndex) bool {
 	// If leaf is non-initialized or if it was touched then we change it.
-	touched, isInitialized := b.touchedLeaves[idx]
-	return !isInitialized || touched // change only if the leaf was touched or root is non-initialized.
+	return b.touchedLeaves[idx].Load()
 }
 
 func (b *BeaconState) markLeaf(idxs ...StateLeafIndex) {
 	for _, idx := range idxs {
-		b.touchedLeaves[idx] = true
+		b.touchedLeaves[idx].Store(true)
 	}
 }

--- a/cl/phase1/core/state/raw/params.go
+++ b/cl/phase1/core/state/raw/params.go
@@ -55,4 +55,8 @@ const (
 
 const (
 	StateLeafSize = 28
+
+	LeafInitValue  = 0
+	LeafCleanValue = 1
+	LeafDirtyValue = 2
 )

--- a/cl/phase1/core/state/raw/params.go
+++ b/cl/phase1/core/state/raw/params.go
@@ -52,3 +52,7 @@ const (
 	NextWithdrawalValidatorIndexLeafIndex StateLeafIndex = 26
 	HistoricalSummariesLeafIndex          StateLeafIndex = 27
 )
+
+const (
+	StateLeafSize = 28
+)

--- a/cl/phase1/core/state/raw/state.go
+++ b/cl/phase1/core/state/raw/state.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"strconv"
 	"sync"
+	"sync/atomic"
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon/cl/clparams"
@@ -72,8 +73,8 @@ type BeaconState struct {
 	currentEpochAttestations  *solid.ListSSZ[*solid.PendingAttestation]
 
 	//  leaves for computing hashes
-	leaves        []byte                  // Pre-computed leaves.
-	touchedLeaves map[StateLeafIndex]bool // Maps each leaf to whether they were touched or not.
+	leaves        []byte        // Pre-computed leaves.
+	touchedLeaves []atomic.Bool // Maps each leaf to whether they were touched or not.
 
 	// cl version
 	version      clparams.StateVersion // State version
@@ -118,7 +119,7 @@ func New(cfg *clparams.BeaconChainConfig) *BeaconState {
 
 func (b *BeaconState) init() error {
 	if b.touchedLeaves == nil {
-		b.touchedLeaves = make(map[StateLeafIndex]bool)
+		b.touchedLeaves = make([]atomic.Bool, StateLeafSize)
 	}
 	return nil
 }

--- a/cl/phase1/core/state/raw/state.go
+++ b/cl/phase1/core/state/raw/state.go
@@ -73,8 +73,8 @@ type BeaconState struct {
 	currentEpochAttestations  *solid.ListSSZ[*solid.PendingAttestation]
 
 	//  leaves for computing hashes
-	leaves        []byte        // Pre-computed leaves.
-	touchedLeaves []atomic.Bool // Maps each leaf to whether they were touched or not.
+	leaves        []byte          // Pre-computed leaves.
+	touchedLeaves []atomic.Uint32 // Maps each leaf to whether they were touched or not.
 
 	// cl version
 	version      clparams.StateVersion // State version
@@ -119,7 +119,7 @@ func New(cfg *clparams.BeaconChainConfig) *BeaconState {
 
 func (b *BeaconState) init() error {
 	if b.touchedLeaves == nil {
-		b.touchedLeaves = make([]atomic.Bool, StateLeafSize)
+		b.touchedLeaves = make([]atomic.Uint32, StateLeafSize)
 	}
 	return nil
 }


### PR DESCRIPTION
got crash on sepolia due to concurrent rw panic:

```
fatal error: concurrent map iteration and map write

goroutine 125102027 [running, locked to thread]:
github.com/erigontech/erigon/cl/phase1/core/state/raw.(*BeaconState).CopyInto(0xc04b46c908, 0xc04b46cb48)
        github.com/erigontech/erigon/cl/phase1/core/state/raw/copy.go:83 +0xd93
github.com/erigontech/erigon/cl/phase1/core/state.(*CachingBeaconState).CopyInto(0xc08b77cea0, 0xc08b77d2c0)
        github.com/erigontech/erigon/cl/phase1/core/state/copy.go:28 +0x74
github.com/erigontech/erigon/cl/phase1/core/state.(*CachingBeaconState).Copy(0xc08b77cea0)
        github.com/erigontech/erigon/cl/phase1/core/state/copy.go:66 +0x37
github.com/erigontech/erigon/cl/phase1/stages.emitNextPaylodAttributesEvent(0xc05c490c40, 0x56133a, {0x64, 0xac, 0xff, 0x77, 0xa0, 0x8e, 0xc2, 0x14, ...}, ...)
        github.com/erigontech/erigon/cl/phase1/stages/forkchoice.go:220 +0x20b
github.com/erigontech/erigon/cl/phase1/stages.postForkchoiceOperations({0x3215620, 0xc05bc64820}, {0x324d000, 0xc08a900280}, {0x322b8c8, 0xc09a1ae4c0}, 0xc05c490c40, 0x56133a, {0x64, 0xac, ...})
        github.com/erigontech/erigon/cl/phase1/stages/forkchoice.go:332 +0x3cb
github.com/erigontech/erigon/cl/phase1/stages.doForkchoiceRoutine({0x3215620, 0xc05bc64820}, {0x322b8c8, 0xc09a1ae4c0}, 0xc05c490c40, {0x40, 0x2b098, 0x2b099, 0x56133a, 0x56133a, ...})
        github.com/erigontech/erigon/cl/phase1/stages/forkchoice.go:357 +0x30e
github.com/erigontech/erigon/cl/clstages.(*StageGraph[...]).StartWithStage.func1()
        github.com/erigontech/erigon/cl/clstages/clstages.go:54 +0x6e
created by github.com/erigontech/erigon/cl/clstages.(*StageGraph[...]).StartWithStage in goroutine 3439
        github.com/erigontech/erigon/cl/clstages/clstages.go:50 +0x3a5
```