### PR TITLE
diagnostics: export system info

### DIFF
--- a/cmd/diag/downloader/diag_downloader.go
+++ b/cmd/diag/downloader/diag_downloader.go
@@ -74,10 +74,11 @@ func printDownloadStatus(cliCtx *cli.Context) error {
 		util.RenderJson(snapshotDownloadStatus)
 
 	case "text":
-		util.RenderTableWithHeader(
+		util.PrintTable(
 			"Snapshot download info:",
 			table.Row{"Status", "Progress", "Downloaded", "Total", "Time Left", "Total Time", "Download Rate", "Upload Rate", "Peers", "Files", "Connections", "Alloc", "Sys"},
 			[]table.Row{snapshotDownloadStatus},
+			nil,
 		)
 	}
 
@@ -115,17 +116,19 @@ func printFiles(cliCtx *cli.Context) error {
 		util.RenderJson(filteredRows)
 	case "text":
 		//Print overall status
-		util.RenderTableWithHeader(
+		util.PrintTable(
 			"Snapshot download info:",
 			table.Row{"Status", "Progress", "Downloaded", "Total", "Time Left", "Total Time", "Download Rate", "Upload Rate", "Peers", "Files", "Connections", "Alloc", "Sys"},
 			[]table.Row{snapshotDownloadStatus},
+			nil,
 		)
 
 		//Print files status
-		util.RenderTableWithHeader(
+		util.PrintTable(
 			"Files download info:",
 			table.Row{"File", "Progress", "Total", "Downloaded", "Peers", "Peers Download Rate", "Webseeds", "Webseeds Download Rate", "Time Left", "Active"},
 			filteredRows,
+			nil,
 		)
 	}
 
@@ -150,10 +153,11 @@ func printFile(cliCtx *cli.Context) error {
 				util.RenderJson(fileRow)
 			case "text":
 				//Print file status
-				util.RenderTableWithHeader(
+				util.PrintTable(
 					"File download info:",
 					table.Row{"File", "Size", "Average Download Rate", "Time Took"},
 					[]table.Row{fileRow},
+					nil,
 				)
 			}
 		} else {
@@ -168,23 +172,26 @@ func printFile(cliCtx *cli.Context) error {
 				util.RenderJson(fileWebseeds)
 			case "text":
 				//Print file status
-				util.RenderTableWithHeader(
+				util.PrintTable(
 					"file download info:",
 					table.Row{"File", "Progress", "Total", "Downloaded", "Peers", "Peers Download Rate", "Webseeds", "Webseeds Download Rate", "Time Left", "Active"},
 					[]table.Row{fileRow},
+					nil,
 				)
 
 				//Print peers and webseeds status
-				util.RenderTableWithHeader(
+				util.PrintTable(
 					"",
 					table.Row{"Peer", "Download Rate"},
 					filePeers,
+					nil,
 				)
 
-				util.RenderTableWithHeader(
+				util.PrintTable(
 					"",
 					table.Row{"Webseed", "Download Rate"},
 					fileWebseeds,
+					nil,
 				)
 			}
 		}

--- a/cmd/diag/stages/stages.go
+++ b/cmd/diag/stages/stages.go
@@ -133,10 +133,11 @@ func printData(cliCtx *cli.Context, data []table.Row) {
 		util.RenderJson(data)
 
 	case "text":
-		util.RenderTableWithHeader(
+		util.PrintTable(
 			"",
 			table.Row{"Stage", "SubStage", "Status", "Time Elapsed", "Progress"},
 			data,
+			nil,
 		)
 	}
 }

--- a/cmd/diag/sysinfo/sysinfo.go
+++ b/cmd/diag/sysinfo/sysinfo.go
@@ -19,7 +19,6 @@ package sysinfo
 import (
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/jedib0t/go-pretty/v6/table"
@@ -76,20 +75,16 @@ func collectInfo(cliCtx *cli.Context) error {
 		util.RenderError(err)
 	}
 
-	var builder strings.Builder
-	builder.WriteString("Disk info:\n")
-	builder.WriteString(data.Disk.Details)
-	builder.WriteString("\n\n")
-	builder.WriteString("CPU info:\n")
-	writeCPUToStringBuilder(data.CPU, &builder)
-
-	processes := sysutils.GetProcessesInfo()
 	cpuusage := sysutils.CPUUsage()
+	processes := sysutils.GetProcessesInfo()
 	totalMemory := sysutils.TotalMemoryUsage()
-	builder.WriteString("\n\nProcesses info:\n")
+
+	var builder strings.Builder
+
+	writeDiskInfoToStringBuilder(data.Disk, &builder)
+	writeCPUInfoToStringBuilder(data.CPU, cpuusage, &builder)
+
 	writeProcessesToStringBuilder(processes, cpuusage.Total, totalMemory, &builder)
-	builder.WriteString("\n\nCPU usage details:\n")
-	writeCPUUsageToStringBuilder(cpuusage.Cores, &builder)
 
 	// Save data to file
 	err = util.SaveDataToFile(cliCtx.String(ExportPathFlag.Name), cliCtx.String(ExportFileNameFlag.Name), builder.String())
@@ -100,27 +95,45 @@ func collectInfo(cliCtx *cli.Context) error {
 	return nil
 }
 
-func writeCPUToStringBuilder(cpuInfo []diagnostics.CPUInfo, builder *strings.Builder) {
-	spacing := calculateSpacing([]string{"CPU", "VendorID", "Family", "Model", "Stepping", "PhysicalID", "CoreID", "Cores", "ModelName", "Mhz", "CacheSize", "Flags", "Microcode"})
+func writeDiskInfoToStringBuilder(diskInfo diagnostics.DiskInfo, builder *strings.Builder) {
+	builder.WriteString("Disk info:\n")
+	builder.WriteString(diskInfo.Details)
+	builder.WriteString("\n\n")
+}
 
+func writeCPUInfoToStringBuilder(cpuInfo []diagnostics.CPUInfo, cpuusage sysutils.CPUUsageInfo, builder *strings.Builder) {
+	writeOweralCPUInfoToStringBuilder(cpuInfo, builder)
+	writeCPUUsageToStringBuilder(cpuusage.Cores, builder)
+}
+
+func writeOweralCPUInfoToStringBuilder(cpuInfo []diagnostics.CPUInfo, builder *strings.Builder) {
+	builder.WriteString("CPU info:\n")
+	header := table.Row{"CPU", "VendorID", "Family", "Model", "Stepping", "PhysicalID", "CoreID", "Cores", "ModelName", "Mhz", "CacheSize", "Flags", "Microcode"}
+	rows := make([]table.Row, 0, len(cpuInfo))
 	for _, cpu := range cpuInfo {
-		writeStringToBuilder(builder, "CPU", strconv.Itoa(int(cpu.CPU)), spacing)
-		writeStringToBuilder(builder, "VendorID", cpu.VendorID, spacing)
-		writeStringToBuilder(builder, "Family", cpu.Family, spacing)
-		writeStringToBuilder(builder, "Model", cpu.Model, spacing)
-		writeStringToBuilder(builder, "Stepping", strconv.Itoa(int(cpu.Stepping)), spacing)
-		writeStringToBuilder(builder, "PhysicalID", cpu.PhysicalID, spacing)
-		writeStringToBuilder(builder, "CoreID", cpu.CoreID, spacing)
-		writeStringToBuilder(builder, "Cores", strconv.Itoa(int(cpu.Cores)), spacing)
-		writeStringToBuilder(builder, "ModelName", cpu.ModelName, spacing)
-		writeStringToBuilder(builder, "Mhz", fmt.Sprintf("%g", cpu.Mhz), spacing)
-		writeStringToBuilder(builder, "CacheSize", strconv.Itoa(int(cpu.CacheSize)), spacing)
-		writeStringToBuilder(builder, "Flags", strings.Join(cpu.Flags, ", "), spacing)
-		writeStringToBuilder(builder, "Microcode", cpu.Microcode, spacing)
+		rows = append(rows, table.Row{cpu.CPU, cpu.VendorID, cpu.Family, cpu.Model, cpu.Stepping, cpu.PhysicalID, cpu.CoreID, cpu.Cores, cpu.ModelName, cpu.Mhz, cpu.CacheSize, strings.Join(cpu.Flags, ", "), cpu.Microcode})
 	}
+
+	cpuDataTable := util.ExportTable(header, rows, nil)
+	builder.WriteString(cpuDataTable)
+	builder.WriteString("\n\n")
+}
+
+func writeCPUUsageToStringBuilder(cpuUsage []float64, builder *strings.Builder) {
+	builder.WriteString("CPU usage:\n")
+	header := table.Row{"Core #", "% CPU"}
+	rows := make([]table.Row, 0, len(cpuUsage))
+	for idx, core := range cpuUsage {
+		rows = append(rows, table.Row{idx + 1, fmt.Sprintf("%.2f", core)})
+	}
+
+	cpuUsageDataTable := util.ExportTable(header, rows, nil)
+	builder.WriteString(cpuUsageDataTable)
 }
 
 func writeProcessesToStringBuilder(prcInfo []*sysutils.ProcessInfo, cpuUsage float64, totalMemory float64, builder *strings.Builder) {
+	builder.WriteString("\n\nProcesses info:\n")
+
 	prcInfo = sortProcessesByCPU(prcInfo)
 	rows := make([]table.Row, 0)
 	header := table.Row{"PID", "Name", "% CPU", "% Memory"}
@@ -131,38 +144,10 @@ func writeProcessesToStringBuilder(prcInfo []*sysutils.ProcessInfo, cpuUsage flo
 		rows = append(rows, table.Row{process.Pid, process.Name, cpu, memory})
 	}
 
-	t := table.NewWriter()
+	footer := table.Row{"Totals", "", fmt.Sprintf("%.2f", cpuUsage), fmt.Sprintf("%.2f", totalMemory)}
 
-	t.AppendHeader(header)
-	if len(rows) > 0 {
-		t.AppendRows(rows)
-	}
-	t.AppendSeparator()
-	t.AppendRow(table.Row{"Totals", "", fmt.Sprintf("%.2f", cpuUsage), fmt.Sprintf("%.2f", totalMemory)})
-	t.AppendSeparator()
-
-	result := t.Render()
-	builder.WriteString(result)
-}
-
-func writeCPUUsageToStringBuilder(cpuUsage []float64, builder *strings.Builder) {
-	rows := make([]table.Row, 0)
-	header := table.Row{"Core #", "% CPU"}
-
-	for idx, core := range cpuUsage {
-		rows = append(rows, table.Row{idx + 1, fmt.Sprintf("%.2f", core)})
-	}
-
-	t := table.NewWriter()
-
-	t.AppendHeader(header)
-	if len(rows) > 0 {
-		t.AppendRows(rows)
-	}
-
-	t.AppendSeparator()
-	result := t.Render()
-	builder.WriteString(result)
+	processesTable := util.ExportTable(header, rows, footer)
+	builder.WriteString(processesTable)
 }
 
 func sortProcesses(prcInfo []*sysutils.ProcessInfo, sorting SortType) []*sysutils.ProcessInfo {
@@ -191,35 +176,6 @@ func sortProcessesByMemory(prcInfo []*sysutils.ProcessInfo) []*sysutils.ProcessI
 
 func sortProcessesByPID(prcInfo []*sysutils.ProcessInfo) []*sysutils.ProcessInfo {
 	return sortProcesses(prcInfo, SortByPID)
-}
-
-func calculateSpacing(keysArray []string) int {
-	max := 0
-	for _, key := range keysArray {
-		if len(key) > max {
-			max = len(key)
-		}
-	}
-
-	return max + 3
-}
-
-func writeStringToBuilder(result *strings.Builder, name string, value string, spacing int) {
-	marging := 3
-	if value == "" {
-		value = "N/A"
-	}
-
-	writeSpacesToBuilder(result, marging)
-	result.WriteString(name)
-	result.WriteString(":")
-	writeSpacesToBuilder(result, spacing-len(name)-1)
-	result.WriteString(value)
-	result.WriteString("\n")
-}
-
-func writeSpacesToBuilder(result *strings.Builder, spaces int) {
-	result.WriteString(strings.Repeat(" ", spaces))
 }
 
 func getData(cliCtx *cli.Context) (diagnostics.HardwareInfo, error) {

--- a/cmd/diag/sysinfo/sysinfo.go
+++ b/cmd/diag/sysinfo/sysinfo.go
@@ -18,12 +18,15 @@ package sysinfo
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
+	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/urfave/cli/v2"
 
 	"github.com/ledgerwatch/erigon-lib/diagnostics"
+	"github.com/ledgerwatch/erigon-lib/sysutils"
 	"github.com/ledgerwatch/erigon/cmd/diag/flags"
 	"github.com/ledgerwatch/erigon/cmd/diag/util"
 )
@@ -59,6 +62,14 @@ var Command = cli.Command{
 	Description: "Collect information about system and save it to file in order to provide to support person",
 }
 
+type SortType int
+
+const (
+	SortByCPU SortType = iota
+	SortByMemory
+	SortByPID
+)
+
 func collectInfo(cliCtx *cli.Context) error {
 	data, err := getData(cliCtx)
 	if err != nil {
@@ -71,6 +82,10 @@ func collectInfo(cliCtx *cli.Context) error {
 	builder.WriteString("\n\n")
 	builder.WriteString("CPU info:\n")
 	writeCPUToStringBuilder(data.CPU, &builder)
+
+	processes := sysutils.GetProcessesInfo()
+	builder.WriteString("\n\nProcesses info:\n")
+	writeProcessesToStringBuilder(processes, &builder)
 
 	// Save data to file
 	err = util.SaveDataToFile(cliCtx.String(ExportPathFlag.Name), cliCtx.String(ExportFileNameFlag.Name), builder.String())
@@ -99,6 +114,56 @@ func writeCPUToStringBuilder(cpuInfo []diagnostics.CPUInfo, builder *strings.Bui
 		writeStringToBuilder(builder, "Flags", strings.Join(cpu.Flags, ", "), spacing)
 		writeStringToBuilder(builder, "Microcode", cpu.Microcode, spacing)
 	}
+}
+
+func writeProcessesToStringBuilder(prcInfo []*sysutils.ProcessInfo, builder *strings.Builder) {
+	prcInfo = sortProcessesByCPU(prcInfo)
+	rows := make([]table.Row, 0)
+	header := table.Row{"PID", "Name", "% CPU", "% Memory"}
+	for _, process := range prcInfo {
+		cpu := fmt.Sprintf("%.2f", process.CPUUsage)
+		memory := fmt.Sprintf("%.2f", process.Memory)
+		rows = append(rows, table.Row{process.Pid, process.Name, cpu, memory})
+	}
+
+	t := table.NewWriter()
+
+	t.AppendHeader(header)
+	if len(rows) > 0 {
+		t.AppendRows(rows)
+	}
+
+	t.AppendSeparator()
+	result := t.Render()
+	builder.WriteString(result)
+}
+
+func sortProcesses(prcInfo []*sysutils.ProcessInfo, sorting SortType) []*sysutils.ProcessInfo {
+	sort.Slice(prcInfo, func(i, j int) bool {
+		switch sorting {
+		case SortByCPU:
+			return prcInfo[i].CPUUsage > prcInfo[j].CPUUsage
+		case SortByMemory:
+			return prcInfo[i].Memory > prcInfo[j].Memory
+		default:
+			return prcInfo[i].Pid < prcInfo[j].Pid
+		}
+
+	})
+
+	return prcInfo
+}
+
+func sortProcessesByCPU(prcInfo []*sysutils.ProcessInfo) []*sysutils.ProcessInfo {
+	return sortProcesses(prcInfo, SortByCPU)
+}
+
+func sortProcessesByMemory(prcInfo []*sysutils.ProcessInfo) []*sysutils.ProcessInfo {
+	return sortProcesses(prcInfo, SortByMemory)
+}
+
+func sortProcessesByPID(prcInfo []*sysutils.ProcessInfo) []*sysutils.ProcessInfo {
+	return sortProcesses(prcInfo, SortByPID)
 }
 
 func calculateSpacing(keysArray []string) int {

--- a/cmd/diag/sysinfo/sysinfo.go
+++ b/cmd/diag/sysinfo/sysinfo.go
@@ -84,8 +84,12 @@ func collectInfo(cliCtx *cli.Context) error {
 	writeCPUToStringBuilder(data.CPU, &builder)
 
 	processes := sysutils.GetProcessesInfo()
+	cpuusage := sysutils.CPUUsage()
+	totalMemory := sysutils.TotalMemoryUsage()
 	builder.WriteString("\n\nProcesses info:\n")
-	writeProcessesToStringBuilder(processes, &builder)
+	writeProcessesToStringBuilder(processes, cpuusage.Total, totalMemory, &builder)
+	builder.WriteString("\n\nCPU usage details:\n")
+	writeCPUUsageToStringBuilder(cpuusage.Cores, &builder)
 
 	// Save data to file
 	err = util.SaveDataToFile(cliCtx.String(ExportPathFlag.Name), cliCtx.String(ExportFileNameFlag.Name), builder.String())
@@ -116,14 +120,37 @@ func writeCPUToStringBuilder(cpuInfo []diagnostics.CPUInfo, builder *strings.Bui
 	}
 }
 
-func writeProcessesToStringBuilder(prcInfo []*sysutils.ProcessInfo, builder *strings.Builder) {
+func writeProcessesToStringBuilder(prcInfo []*sysutils.ProcessInfo, cpuUsage float64, totalMemory float64, builder *strings.Builder) {
 	prcInfo = sortProcessesByCPU(prcInfo)
 	rows := make([]table.Row, 0)
 	header := table.Row{"PID", "Name", "% CPU", "% Memory"}
+
 	for _, process := range prcInfo {
 		cpu := fmt.Sprintf("%.2f", process.CPUUsage)
 		memory := fmt.Sprintf("%.2f", process.Memory)
 		rows = append(rows, table.Row{process.Pid, process.Name, cpu, memory})
+	}
+
+	t := table.NewWriter()
+
+	t.AppendHeader(header)
+	if len(rows) > 0 {
+		t.AppendRows(rows)
+	}
+	t.AppendSeparator()
+	t.AppendRow(table.Row{"Totals", "", fmt.Sprintf("%.2f", cpuUsage), fmt.Sprintf("%.2f", totalMemory)})
+	t.AppendSeparator()
+
+	result := t.Render()
+	builder.WriteString(result)
+}
+
+func writeCPUUsageToStringBuilder(cpuUsage []float64, builder *strings.Builder) {
+	rows := make([]table.Row, 0)
+	header := table.Row{"Core #", "% CPU"}
+
+	for idx, core := range cpuUsage {
+		rows = append(rows, table.Row{idx + 1, fmt.Sprintf("%.2f", core)})
 	}
 
 	t := table.NewWriter()

--- a/cmd/diag/util/util.go
+++ b/cmd/diag/util/util.go
@@ -59,7 +59,7 @@ func RenderJson(data interface{}) {
 	}
 }
 
-func ExportTable(title string, header table.Row, rows []table.Row, footer table.Row) string {
+func ExportTable(header table.Row, rows []table.Row, footer table.Row) string {
 	if len(rows) > 0 {
 		t := CreateTable(header, rows, footer)
 		return t.Render()

--- a/cmd/diag/util/util.go
+++ b/cmd/diag/util/util.go
@@ -59,7 +59,16 @@ func RenderJson(data interface{}) {
 	}
 }
 
-func RenderTableWithHeader(title string, header table.Row, rows []table.Row) {
+func ExportTable(title string, header table.Row, rows []table.Row, footer table.Row) string {
+	if len(rows) > 0 {
+		t := CreateTable(header, rows, footer)
+		return t.Render()
+	}
+
+	return ""
+}
+
+func PrintTable(title string, header table.Row, rows []table.Row, footer table.Row) {
 	if title != "" {
 		txt := text.Colors{text.FgBlue, text.Bold}
 		fmt.Println(txt.Sprint(title))
@@ -71,19 +80,30 @@ func RenderTableWithHeader(title string, header table.Row, rows []table.Row) {
 	}
 
 	if len(rows) > 0 {
-		t := table.NewWriter()
+		t := CreateTable(header, rows, footer)
 		t.SetOutputMirror(os.Stdout)
-
-		t.AppendHeader(header)
-		if len(rows) > 0 {
-			t.AppendRows(rows)
-		}
-
-		t.AppendSeparator()
 		t.Render()
 	}
 
 	fmt.Print("\n")
+}
+
+func CreateTable(header table.Row, rows []table.Row, footer table.Row) table.Writer {
+	t := table.NewWriter()
+
+	if header != nil {
+		t.AppendHeader(header)
+	}
+
+	if len(rows) > 0 {
+		t.AppendRows(rows)
+	}
+
+	if footer != nil {
+		t.AppendFooter(footer)
+	}
+
+	return t
 }
 
 func RenderUseDiagUI() {

--- a/erigon-lib/sysutils/sysutils.go
+++ b/erigon-lib/sysutils/sysutils.go
@@ -1,0 +1,171 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package sysutils
+
+import (
+	"time"
+
+	"github.com/ledgerwatch/log/v3"
+	"github.com/shirou/gopsutil/v4/process"
+)
+
+type ProcessInfo struct {
+	Pid      int32
+	Name     string
+	CPUUsage float64
+	Memory   float32
+}
+
+type ProcessMerge struct {
+	CPUUsage float64
+	Memory   float32
+	Times    int
+	Name     string
+}
+
+const (
+	iterations     = 5
+	sleepSeconds   = 2
+	usageThreshold = 0.05
+)
+
+func GetProcessesInfo() []*ProcessInfo {
+	procs, err := process.Processes()
+	if err != nil {
+		log.Debug("[Sysutil] Error retrieving processes: %v", err)
+	}
+
+	return averageProceses(procs)
+}
+
+func AverageProceses(procs []*process.Process) []*ProcessInfo {
+	return averageProceses(procs)
+}
+
+func averageProceses(procs []*process.Process) []*ProcessInfo {
+	// Collect processes and calculate average stats.
+	allProcsRepeats := make([][]*ProcessInfo, 0, iterations)
+
+	// Collect all processes N times with a delay of N seconds to calculate average stats.
+	for i := 0; i < iterations; i++ {
+		processes := allProcesses(procs)
+		allProcsRepeats = append(allProcsRepeats, processes)
+		time.Sleep(sleepSeconds * time.Second)
+	}
+
+	// Calculate average stats.
+	averageProcs := mergeProcesses(allProcsRepeats)
+	averageProcs = removeProcessesBelowThreshold(averageProcs, usageThreshold)
+
+	return averageProcs
+}
+
+func RemoveProcessesBelowThreshold(processes []*ProcessInfo, treshold float64) []*ProcessInfo {
+	return removeProcessesBelowThreshold(processes, treshold)
+}
+
+func removeProcessesBelowThreshold(processes []*ProcessInfo, treshold float64) []*ProcessInfo {
+	// remove processes with CPU or Memory usage less than threshold
+	filtered := make([]*ProcessInfo, 0, len(processes))
+	for _, p := range processes {
+		if p.CPUUsage >= treshold || p.Memory >= float32(treshold) {
+			filtered = append(filtered, p)
+		}
+	}
+
+	return filtered
+}
+
+func MergeProcesses(allProcsRepeats [][]*ProcessInfo) []*ProcessInfo {
+	return mergeProcesses(allProcsRepeats)
+}
+
+func mergeProcesses(allProcsRepeats [][]*ProcessInfo) []*ProcessInfo {
+	if len(allProcsRepeats) == 0 || len(allProcsRepeats[0]) == 0 {
+		return nil
+	}
+
+	repeats := len(allProcsRepeats)
+	if repeats == 1 {
+		return allProcsRepeats[0]
+	}
+
+	prcmap := make(map[int32]*ProcessMerge)
+
+	for _, procList := range allProcsRepeats {
+		for _, proc := range procList {
+			if prc, exists := prcmap[proc.Pid]; exists {
+				prc.CPUUsage += proc.CPUUsage
+				prc.Memory += proc.Memory
+				prc.Times++
+			} else {
+				prcmap[proc.Pid] = &ProcessMerge{
+					CPUUsage: proc.CPUUsage,
+					Memory:   proc.Memory,
+					Times:    1,
+					Name:     proc.Name,
+				}
+			}
+		}
+	}
+
+	resultArray := make([]*ProcessInfo, 0, len(prcmap))
+
+	for pid, prc := range prcmap {
+		resultArray = append(resultArray, &ProcessInfo{
+			Pid:      pid,
+			Name:     prc.Name,
+			CPUUsage: prc.CPUUsage / float64(prc.Times),
+			Memory:   prc.Memory / float32(prc.Times),
+		})
+	}
+
+	return resultArray
+}
+
+func allProcesses(procs []*process.Process) []*ProcessInfo {
+	processes := make([]*ProcessInfo, 0)
+
+	for _, proc := range procs {
+		pid := proc.Pid
+		name, err := proc.Name()
+		if err != nil {
+			name = "Unknown"
+		}
+
+		//remove gopls process as it is what we use to get info
+		if name == "gopls" {
+			continue
+		}
+
+		cpuPercent, err := proc.CPUPercent()
+		if err != nil {
+			log.Trace("[Sysutil] Error retrieving CPU percent for PID %d: %v Name: %s", pid, err, name)
+			continue
+		}
+
+		memPercent, err := proc.MemoryPercent()
+		if err != nil {
+			log.Trace("[Sysutil] Error retrieving memory percent for PID %d: %v Name: %s", pid, err, name)
+			continue
+		}
+
+		processes = append(processes, &ProcessInfo{Pid: pid, Name: name, CPUUsage: cpuPercent, Memory: memPercent})
+	}
+
+	return processes
+}

--- a/erigon-lib/sysutils/sysutils_test.go
+++ b/erigon-lib/sysutils/sysutils_test.go
@@ -1,0 +1,68 @@
+package sysutils_test
+
+import (
+	"testing"
+
+	"github.com/ledgerwatch/erigon-lib/sysutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeProcesses(t *testing.T) {
+	initaldata := [][]*sysutils.ProcessInfo{
+		{
+			{Pid: 1, Name: "test1", CPUUsage: 1.0, Memory: 1.0},
+			{Pid: 2, Name: "test2", CPUUsage: 2.0, Memory: 2.0},
+			{Pid: 3, Name: "test3", CPUUsage: 3.0, Memory: 3.0},
+			{Pid: 31, Name: "test31", CPUUsage: 3.0, Memory: 3.0},
+		},
+		{
+			{Pid: 1, Name: "test1", CPUUsage: 1.0, Memory: 1.0},
+			{Pid: 2, Name: "test2", CPUUsage: 1.0, Memory: 1.0},
+			{Pid: 22, Name: "test4", CPUUsage: 1.0, Memory: 1.0},
+		},
+	}
+
+	expected := []*sysutils.ProcessInfo{
+		{Pid: 1, Name: "test1", CPUUsage: 1.0, Memory: 1.0},
+		{Pid: 2, Name: "test2", CPUUsage: 1.5, Memory: 1.5},
+		{Pid: 3, Name: "test3", CPUUsage: 3.0, Memory: 3.0},
+		{Pid: 31, Name: "test31", CPUUsage: 3.0, Memory: 3.0},
+		{Pid: 22, Name: "test4", CPUUsage: 1.0, Memory: 1.0},
+	}
+
+	result := sysutils.MergeProcesses(initaldata)
+	for _, proc := range result {
+		require.Contains(t, expected, proc)
+	}
+}
+
+func TestRemoveProcessesBelowThreshold(t *testing.T) {
+	initaldata := [][]*sysutils.ProcessInfo{
+		{
+			{Pid: 1, Name: "test1", CPUUsage: 1.0, Memory: 1.0},
+			{Pid: 2, Name: "test2", CPUUsage: 2.0, Memory: 2.0},
+			{Pid: 3, Name: "test3", CPUUsage: 3.0, Memory: 3.0},
+			{Pid: 12, Name: "test5", CPUUsage: 0.001, Memory: 1.0},
+			{Pid: 45, Name: "test8", CPUUsage: 0.001, Memory: 0.0},
+		},
+		{
+			{Pid: 1, Name: "test1", CPUUsage: 1.0, Memory: 1.0},
+			{Pid: 2, Name: "test2", CPUUsage: 1.0, Memory: 1.0},
+			{Pid: 22, Name: "test4", CPUUsage: 1.0, Memory: 0.001},
+		},
+	}
+
+	expected := []*sysutils.ProcessInfo{
+		{Pid: 1, Name: "test1", CPUUsage: 1.0, Memory: 1.0},
+		{Pid: 2, Name: "test2", CPUUsage: 1.5, Memory: 1.5},
+		{Pid: 3, Name: "test3", CPUUsage: 3.0, Memory: 3.0},
+		{Pid: 22, Name: "test4", CPUUsage: 1.0, Memory: 0.001},
+		{Pid: 12, Name: "test5", CPUUsage: 0.001, Memory: 1.0},
+	}
+
+	result := sysutils.MergeProcesses(initaldata)
+	result = sysutils.RemoveProcessesBelowThreshold(result, 0.01)
+	for _, proc := range result {
+		require.Contains(t, expected, proc)
+	}
+}


### PR DESCRIPTION
Changes:
- Collecting CPU and Memory usage info about all processes running on the machine
- Running loop 5 times with 2 seconds delay and to calculate average
- Sort by CPU usage
- Write result to report file
- Display totals for CPU and Memory usage to processes table
- Display CPU usage by cores
- Print CPU details to table

Cherry pick from:
- #11516
- #11526
- #11537
- #11544