### PR TITLE
dbg: add save heap options for logger and memstats inputs

### DIFF
--- a/erigon-lib/common/dbg/experiments.go
+++ b/erigon-lib/common/dbg/experiments.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"time"
 
+	libcommon "github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon-lib/mmap"
 )
@@ -289,7 +290,11 @@ func SaveHeapProfileNearOOM(opts ...SaveHeapOption) {
 
 	totalMemory := mmap.TotalMemory()
 	if logger != nil {
-		logger.Info("[Experiment] heap profile threshold check", "alloc", memStats.Alloc, "total", totalMemory)
+		logger.Info(
+			"[Experiment] heap profile threshold check",
+			"alloc", libcommon.ByteCount(memStats.Alloc),
+			"total", libcommon.ByteCount(totalMemory),
+		)
 	}
 	if memStats.Alloc < (totalMemory/100)*45 {
 		return
@@ -298,11 +303,7 @@ func SaveHeapProfileNearOOM(opts ...SaveHeapOption) {
 	// above 45%
 	filePath := filepath.Join(os.TempDir(), "erigon-mem.prof")
 	if logger != nil {
-		logger.Info(
-			"[Experiment] saving heap profile as near OOM",
-			"alloc", memStats.Alloc,
-			"filePath", filePath,
-		)
+		logger.Info("[Experiment] saving heap profile as near OOM", "filePath", filePath)
 	}
 
 	f, err := os.Create(filePath)

--- a/erigon-lib/common/dbg/experiments.go
+++ b/erigon-lib/common/dbg/experiments.go
@@ -291,7 +291,7 @@ func SaveHeapProfileNearOOM(opts ...SaveHeapOption) {
 	if logger != nil {
 		logger.Info("[Experiment] heap profile threshold check", "alloc", memStats.Alloc, "total", totalMemory)
 	}
-	if options.memStats.Alloc < (totalMemory/100)*45 {
+	if memStats.Alloc < (totalMemory/100)*45 {
 		return
 	}
 
@@ -300,7 +300,7 @@ func SaveHeapProfileNearOOM(opts ...SaveHeapOption) {
 	if logger != nil {
 		logger.Info(
 			"[Experiment] saving heap profile as near OOM",
-			"alloc", options.memStats.Alloc,
+			"alloc", memStats.Alloc,
 			"filePath", filePath,
 		)
 	}

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -296,7 +296,7 @@ Loop:
 				logger.Info("Req/resp stats", "req", stats.Requests, "reqMin", stats.ReqMinBlock, "reqMax", stats.ReqMaxBlock,
 					"skel", stats.SkeletonRequests, "skelMin", stats.SkeletonReqMinBlock, "skelMax", stats.SkeletonReqMaxBlock,
 					"resp", stats.Responses, "respMin", stats.RespMinBlock, "respMax", stats.RespMaxBlock, "dups", stats.Duplicates, "alloc", libcommon.ByteCount(m.Alloc), "sys", libcommon.ByteCount(m.Sys))
-				dbg.SaveHeapProfileNearOOM()
+				dbg.SaveHeapProfileNearOOM(dbg.SaveHeapWithLogger(&logger), dbg.SaveHeapWithMemStats(&m))
 				cfg.hd.LogAnchorState()
 				if wasProgress {
 					logger.Warn("Looks like chain is not progressing, moving to the next stage")

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -122,7 +122,7 @@ func (hd *HeaderDownload) SingleHeaderAsSegment(headerRaw []byte, header *types.
 	headerHash := types.RawRlpHash(headerRaw)
 	if _, bad := hd.badHeaders[headerHash]; bad {
 		hd.stats.RejectedBadHeaders++
-		dbg.SaveHeapProfileNearOOM()
+		dbg.SaveHeapProfileNearOOM(dbg.SaveHeapWithLogger(&hd.logger))
 		hd.logger.Warn("[downloader] SingleHeaderAsSegment: Rejected header marked as bad", "hash", headerHash, "height", header.Number.Uint64())
 		return nil, BadBlockPenalty, nil
 	}
@@ -539,7 +539,7 @@ func (hd *HeaderDownload) InsertHeader(hf FeedHeaderFunc, terminalTotalDifficult
 			hd.removeUpwards(link)
 			dataflow.HeaderDownloadStates.AddChange(link.blockHeight, dataflow.HeaderBad)
 			hd.stats.RejectedBadHeaders++
-			dbg.SaveHeapProfileNearOOM()
+			dbg.SaveHeapProfileNearOOM(dbg.SaveHeapWithLogger(&hd.logger))
 			hd.logger.Warn("[downloader] InsertHeader: Rejected header marked as bad", "hash", link.hash, "height", link.blockHeight)
 			return true, false, 0, lastTime, nil
 		}


### PR DESCRIPTION
`log.Info` does not get piped to our log files, making it hard to figure out what is going on
need to pass in the correct `logger`
this PR adds optional args to `SaveHeapProfileNearOOM` to allow passing in loggers and memStats when needed