### PR TITLE
bt: use madv_normal instead madv_readahead for index opening

### DIFF
--- a/erigon-lib/state/aggregator_test.go
+++ b/erigon-lib/state/aggregator_test.go
@@ -412,6 +412,7 @@ func aggregatorV3_RestartOnDatadir(t *testing.T, rc runCfg) {
 }
 
 func TestAggregatorV3_PruneSmallBatches(t *testing.T) {
+
 	aggStep := uint64(10)
 	db, agg := testDbAndAggregatorv3(t, aggStep)
 

--- a/erigon-lib/state/aggregator_test.go
+++ b/erigon-lib/state/aggregator_test.go
@@ -412,7 +412,6 @@ func aggregatorV3_RestartOnDatadir(t *testing.T, rc runCfg) {
 }
 
 func TestAggregatorV3_PruneSmallBatches(t *testing.T) {
-
 	aggStep := uint64(10)
 	db, agg := testDbAndAggregatorv3(t, aggStep)
 

--- a/erigon-lib/state/btree_index.go
+++ b/erigon-lib/state/btree_index.go
@@ -843,7 +843,7 @@ func OpenBtreeIndexWithDecompressor(indexPath string, M uint64, kv *seg.Decompre
 
 	idx.ef, _ = eliasfano32.ReadEliasFano(idx.data[pos:])
 
-	defer kv.EnableReadAhead().DisableReadAhead()
+	defer kv.EnableMadvNormal().DisableReadAhead()
 	kvGetter := NewArchiveGetter(kv.MakeGetter(), compress)
 
 	//fmt.Printf("open btree index %s with %d keys b+=%t data compressed %t\n", indexPath, idx.ef.Count(), UseBpsTree, idx.compressed)

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -1247,7 +1247,7 @@ func buildAccessor(ctx context.Context, d *seg.Decompressor, compressed FileComp
 	p := ps.AddNew(fileName, uint64(count))
 	defer ps.Delete(p)
 
-	defer d.EnableReadAhead().DisableReadAhead()
+	defer d.EnableMadvNormal().DisableReadAhead()
 
 	g := NewArchiveGetter(d.MakeGetter(), compressed)
 	var rs *recsplit.RecSplit


### PR DESCRIPTION
To reduce disk IO
To protect PageCache from restart
