### PR TITLE
fix incorrect return type for `eth_getProof`

### DIFF
--- a/turbo/trie/retain_list.go
+++ b/turbo/trie/retain_list.go
@@ -31,6 +31,7 @@ import (
 
 	libcommon "github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/hexutil"
+	"github.com/erigontech/erigon-lib/common/hexutility"
 	"github.com/erigontech/erigon-lib/common/length"
 
 	"github.com/erigontech/erigon/core/types/accounts"
@@ -169,6 +170,7 @@ func (pr *ProofRetainer) ProofResult() (*accounts.AccProofResult, error) {
 			// provers will treat the EmptyRoot as a special case and ignore the proof
 			// bytes.
 			result.StorageProof[i].Value = (*hexutil.Big)(new(big.Int))
+			result.StorageProof[i].Proof = make([]hexutility.Bytes, 0)
 			continue
 		}
 


### PR DESCRIPTION
This PR fixes the incorrect return type of `proof` field of `storageProof`. The return type from erigon is `null` whereas the correct return type should be `[]`.
Geth also returns `[]` in this special case which makes the PR compatible across different clients. Parsing `null` as return type breaks a few client like alloy.