### PR TITLE
use DomainRangeLatest for parity_api.go#ListStorageKeys

### DIFF
--- a/erigon-lib/kv/kv_interface.go
+++ b/erigon-lib/kv/kv_interface.go
@@ -572,6 +572,7 @@ type TemporalTx interface {
 	// Example: IndexRange("IndexName", -1, -1, order.Asc, 10)
 	IndexRange(name InvertedIdx, k []byte, fromTs, toTs int, asc order.By, limit int) (timestamps stream.U64, err error)
 	DomainRange(name Domain, fromKey, toKey []byte, ts uint64, asc order.By, limit int) (it stream.KV, err error)
+	DomainRangeLatest(name Domain, fromKey, toKey []byte, limit int) (it stream.KV, err error)
 
 	// HistoryRange - producing "state patch" - sorted list of keys updated at [fromTs,toTs) with their most-recent value.
 	//   no duplicates

--- a/erigon-lib/kv/temporal/kv_temporal.go
+++ b/erigon-lib/kv/temporal/kv_temporal.go
@@ -204,6 +204,15 @@ func (tx *Tx) DomainRange(name kv.Domain, fromKey, toKey []byte, asOfTs uint64, 
 	return it, nil
 }
 
+func (tx *Tx) DomainRangeLatest(name kv.Domain, fromKey, toKey []byte, limit int) (stream.KV, error) {
+	it, err := tx.filesTx.DomainRangeLatest(tx.MdbxTx, name, fromKey, toKey, limit)
+	if err != nil {
+		return nil, err
+	}
+	tx.resourcesToClose = append(tx.resourcesToClose, it)
+	return it, nil
+}
+
 func (tx *Tx) DomainGet(name kv.Domain, k, k2 []byte) (v []byte, step uint64, err error) {
 	v, step, ok, err := tx.filesTx.GetLatest(name, k, k2, tx.MdbxTx)
 	if err != nil {

--- a/turbo/jsonrpc/parity_api.go
+++ b/turbo/jsonrpc/parity_api.go
@@ -24,9 +24,6 @@ import (
 	libcommon "github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/hexutility"
 	"github.com/erigontech/erigon-lib/kv"
-	"github.com/erigontech/erigon-lib/kv/order"
-	"github.com/erigontech/erigon-lib/kv/rawdbv3"
-	"github.com/erigontech/erigon/core/rawdb"
 	"github.com/erigontech/erigon/turbo/rpchelper"
 
 	"github.com/erigontech/erigon/rpc"
@@ -74,18 +71,12 @@ func (api *ParityAPIImpl) ListStorageKeys(ctx context.Context, account libcommon
 		return nil, errors.New("acc not found")
 	}
 
-	bn := rawdb.ReadCurrentBlockNumber(tx)
-	minTxNum, err := rawdbv3.TxNums.Min(tx, *bn)
-	if err != nil {
-		return nil, err
-	}
-
 	from := account[:]
 	if offset != nil {
 		from = append(from, *offset...)
 	}
 	to, _ := kv.NextSubtree(account[:])
-	r, err := tx.(kv.TemporalTx).DomainRange(kv.StorageDomain, from, to, minTxNum, order.Asc, quantity)
+	r, err := tx.(kv.TemporalTx).DomainRangeLatest(kv.StorageDomain, from, to, quantity)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
use DomainRangeLatest as blockNum=-1 (latest block) always for ListStorageKeys, so no need to look in history.