### PR TITLE
Merge MiningResultPOSCh with MiningResultCh

### DIFF
--- a/cmd/integration/commands/state_stages.go
+++ b/cmd/integration/commands/state_stages.go
@@ -332,7 +332,7 @@ func syncBySmallSteps(db kv.RwDB, miningConfig params.MiningConfig, ctx context.
 			}
 			defer tx.Rollback()
 			minedBlock := <-miner.MiningResultCh
-			checkMinedBlock(nextBlock, minedBlock, chainConfig)
+			checkMinedBlock(nextBlock, minedBlock.Block, chainConfig)
 		}
 
 		// Unwind all stages to `execStage - unwind` block

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -1043,8 +1043,8 @@ func (e *remoteConsensusEngine) CalcDifficulty(_ consensus.ChainHeaderReader, _ 
 	panic("remoteConsensusEngine.CalcDifficulty not supported")
 }
 
-func (e *remoteConsensusEngine) GenerateAuRaSeal(_ consensus.ChainHeaderReader, _ *types.Header, _ *types.Header, _ consensus.Call) []byte {
-	panic("remoteConsensusEngine.GenerateAuRaSeal not supported")
+func (e *remoteConsensusEngine) GenerateSeal(_ consensus.ChainHeaderReader, _ *types.Header, _ *types.Header, _ consensus.Call) []byte {
+	panic("remoteConsensusEngine.GenerateSeal not supported")
 }
 
 func (e *remoteConsensusEngine) APIs(_ consensus.ChainHeaderReader) []rpc.API {

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -1031,7 +1031,7 @@ func (e *remoteConsensusEngine) FinalizeAndAssemble(_ *chain.Config, _ *types.He
 	panic("remoteConsensusEngine.FinalizeAndAssemble not supported")
 }
 
-func (e *remoteConsensusEngine) Seal(_ consensus.ChainHeaderReader, _ *types.Block, _ chan<- *types.Block, _ <-chan struct{}) error {
+func (e *remoteConsensusEngine) Seal(_ consensus.ChainHeaderReader, _ *types.BlockWithReceipts, _ chan<- *types.BlockWithReceipts, _ <-chan struct{}) error {
 	panic("remoteConsensusEngine.Seal not supported")
 }
 

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -1043,8 +1043,8 @@ func (e *remoteConsensusEngine) CalcDifficulty(_ consensus.ChainHeaderReader, _ 
 	panic("remoteConsensusEngine.CalcDifficulty not supported")
 }
 
-func (e *remoteConsensusEngine) GenerateSeal(_ consensus.ChainHeaderReader, _ *types.Header, _ *types.Header, _ consensus.Call) []byte {
-	panic("remoteConsensusEngine.GenerateSeal not supported")
+func (e *remoteConsensusEngine) GenerateAuRaSeal(_ consensus.ChainHeaderReader, _ *types.Header, _ *types.Header, _ consensus.Call) []byte {
+	panic("remoteConsensusEngine.GenerateAuRaSeal not supported")
 }
 
 func (e *remoteConsensusEngine) APIs(_ consensus.ChainHeaderReader) []rpc.API {

--- a/consensus/aura/aura.go
+++ b/consensus/aura/aura.go
@@ -881,7 +881,7 @@ func (c *AuRa) GenesisEpochData(header *types.Header, caller consensus.SystemCal
 }
 
 func (c *AuRa) Seal(chain consensus.ChainHeaderReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
-	panic("AuRa block production is not implemented")
+	return nil
 	//header := block.Header()
 	//
 	/// Sealing the genesis block is not supported
@@ -959,11 +959,11 @@ func stepProposer(validators ValidatorSet, blockHash libcommon.Hash, step uint64
 	return validators.getWithCaller(blockHash, uint(step), call)
 }
 
-// GenerateAuRaSeal - Attempt to seal the block internally.
+// GenerateSeal - Attempt to seal the block internally.
 //
 // This operation is synchronous and may (quite reasonably) not be available, in which case
 // `Seal::None` will be returned.
-func (c *AuRa) GenerateAuRaSeal(chain consensus.ChainHeaderReader, current, parent *types.Header, call consensus.Call) []byte {
+func (c *AuRa) GenerateSeal(chain consensus.ChainHeaderReader, current, parent *types.Header, call consensus.Call) []byte {
 	// first check to avoid generating signature most of the time
 	// (but there's still a race to the `compare_exchange`)
 	if !c.step.canPropose.Load() {

--- a/consensus/aura/aura.go
+++ b/consensus/aura/aura.go
@@ -881,7 +881,7 @@ func (c *AuRa) GenesisEpochData(header *types.Header, caller consensus.SystemCal
 }
 
 func (c *AuRa) Seal(chain consensus.ChainHeaderReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
-	return nil
+	panic("AuRa block production is not implemented")
 	//header := block.Header()
 	//
 	/// Sealing the genesis block is not supported

--- a/consensus/aura/aura.go
+++ b/consensus/aura/aura.go
@@ -880,7 +880,7 @@ func (c *AuRa) GenesisEpochData(header *types.Header, caller consensus.SystemCal
 	return res, nil
 }
 
-func (c *AuRa) Seal(chain consensus.ChainHeaderReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
+func (c *AuRa) Seal(chain consensus.ChainHeaderReader, block *types.BlockWithReceipts, results chan<- *types.BlockWithReceipts, stop <-chan struct{}) error {
 	panic("AuRa block production is not implemented")
 	//header := block.Header()
 	//

--- a/consensus/aura/aura.go
+++ b/consensus/aura/aura.go
@@ -881,7 +881,7 @@ func (c *AuRa) GenesisEpochData(header *types.Header, caller consensus.SystemCal
 }
 
 func (c *AuRa) Seal(chain consensus.ChainHeaderReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
-	return nil
+	panic("AuRa block production is not implemented")
 	//header := block.Header()
 	//
 	/// Sealing the genesis block is not supported
@@ -959,11 +959,11 @@ func stepProposer(validators ValidatorSet, blockHash libcommon.Hash, step uint64
 	return validators.getWithCaller(blockHash, uint(step), call)
 }
 
-// GenerateSeal - Attempt to seal the block internally.
+// GenerateAuRaSeal - Attempt to seal the block internally.
 //
 // This operation is synchronous and may (quite reasonably) not be available, in which case
 // `Seal::None` will be returned.
-func (c *AuRa) GenerateSeal(chain consensus.ChainHeaderReader, current, parent *types.Header, call consensus.Call) []byte {
+func (c *AuRa) GenerateAuRaSeal(chain consensus.ChainHeaderReader, current, parent *types.Header, call consensus.Call) []byte {
 	// first check to avoid generating signature most of the time
 	// (but there's still a race to the `compare_exchange`)
 	if !c.step.canPropose.Load() {

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -480,7 +480,7 @@ func (c *Clique) Seal(chain consensus.ChainHeaderReader, block *types.Block, res
 	return nil
 }
 
-func (c *Clique) GenerateSeal(chain consensus.ChainHeaderReader, currnt, parent *types.Header, call consensus.Call) []byte {
+func (c *Clique) GenerateAuRaSeal(chain consensus.ChainHeaderReader, currnt, parent *types.Header, call consensus.Call) []byte {
 	return nil
 }
 

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -408,8 +408,9 @@ func (c *Clique) Authorize(signer libcommon.Address, signFn SignerFn) {
 
 // Seal implements consensus.Engine, attempting to create a sealed block using
 // the local signing credentials.
-func (c *Clique) Seal(chain consensus.ChainHeaderReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
-
+func (c *Clique) Seal(chain consensus.ChainHeaderReader, blockWithReceipts *types.BlockWithReceipts, results chan<- *types.BlockWithReceipts, stop <-chan struct{}) error {
+	block := blockWithReceipts.Block
+	receipts := blockWithReceipts.Receipts
 	header := block.Header()
 
 	// Sealing the genesis block is not supported
@@ -471,7 +472,7 @@ func (c *Clique) Seal(chain consensus.ChainHeaderReader, block *types.Block, res
 		}
 
 		select {
-		case results <- block.WithSeal(header):
+		case results <- &types.BlockWithReceipts{Block: block.WithSeal(header), Receipts: receipts}:
 		default:
 			c.logger.Warn("Sealing result is not read by miner", "sealhash", SealHash(header))
 		}

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -480,7 +480,7 @@ func (c *Clique) Seal(chain consensus.ChainHeaderReader, block *types.Block, res
 	return nil
 }
 
-func (c *Clique) GenerateAuRaSeal(chain consensus.ChainHeaderReader, currnt, parent *types.Header, call consensus.Call) []byte {
+func (c *Clique) GenerateSeal(chain consensus.ChainHeaderReader, currnt, parent *types.Header, call consensus.Call) []byte {
 	return nil
 }
 

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -72,8 +72,6 @@ var (
 	NonceAuthVote = hexutil.MustDecode("0xffffffffffffffff") // Magic nonce number to vote on adding a new signer
 	nonceDropVote = hexutil.MustDecode("0x0000000000000000") // Magic nonce number to vote on removing a signer.
 
-	emptyUncleHash = types.CalcUncleHash(nil) // Always Keccak256(RLP([])) as uncles are meaningless outside of PoW.
-
 	DiffInTurn = big.NewInt(2) // Block difficulty for in-turn signatures
 	diffNoTurn = big.NewInt(1) // Block difficulty for out-of-turn signatures
 )

--- a/consensus/clique/verifier.go
+++ b/consensus/clique/verifier.go
@@ -83,7 +83,7 @@ func (c *Clique) verifyHeader(chain consensus.ChainHeaderReader, header *types.H
 		return errInvalidMixDigest
 	}
 	// Ensure that the block doesn't contain any uncles which are meaningless in PoA
-	if header.UncleHash != emptyUncleHash {
+	if header.UncleHash != types.EmptyUncleHash {
 		return errInvalidUncleHash
 	}
 	// Ensure that the block's difficulty is meaningful (may not be correct at this point)

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -195,7 +195,7 @@ type EngineWriter interface {
 	CalcDifficulty(chain ChainHeaderReader, time, parentTime uint64, parentDifficulty *big.Int, parentNumber uint64,
 		parentHash, parentUncleHash libcommon.Hash, parentAuRaStep uint64) *big.Int
 
-	GenerateSeal(chain ChainHeaderReader, currnt, parent *types.Header, call Call) []byte
+	GenerateAuRaSeal(chain ChainHeaderReader, currnt, parent *types.Header, call Call) []byte
 
 	// APIs returns the RPC APIs this consensus engine provides.
 	APIs(chain ChainHeaderReader) []rpc.API

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -185,7 +185,7 @@ type EngineWriter interface {
 	//
 	// Note, the method returns immediately and will send the result async. More
 	// than one result may also be returned depending on the consensus algorithm.
-	Seal(chain ChainHeaderReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error
+	Seal(chain ChainHeaderReader, block *types.BlockWithReceipts, results chan<- *types.BlockWithReceipts, stop <-chan struct{}) error
 
 	// SealHash returns the hash of a block prior to it being sealed.
 	SealHash(header *types.Header) libcommon.Hash

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -195,7 +195,7 @@ type EngineWriter interface {
 	CalcDifficulty(chain ChainHeaderReader, time, parentTime uint64, parentDifficulty *big.Int, parentNumber uint64,
 		parentHash, parentUncleHash libcommon.Hash, parentAuRaStep uint64) *big.Int
 
-	GenerateAuRaSeal(chain ChainHeaderReader, currnt, parent *types.Header, call Call) []byte
+	GenerateSeal(chain ChainHeaderReader, currnt, parent *types.Header, call Call) []byte
 
 	// APIs returns the RPC APIs this consensus engine provides.
 	APIs(chain ChainHeaderReader) []rpc.API

--- a/consensus/mainnet/mainnet.go
+++ b/consensus/mainnet/mainnet.go
@@ -180,7 +180,7 @@ func (b baseMainnet) verifyHeader(chain consensus.ChainHeaderReader, header, par
 	return nil
 }
 
-func (b baseMainnet) GenerateSeal(chain consensus.ChainHeaderReader, currnt, parent *types.Header, call consensus.Call) []byte {
+func (b baseMainnet) GenerateAuRaSeal(chain consensus.ChainHeaderReader, currnt, parent *types.Header, call consensus.Call) []byte {
 	return nil
 }
 

--- a/consensus/mainnet/mainnet.go
+++ b/consensus/mainnet/mainnet.go
@@ -298,7 +298,7 @@ type MainnetConfig struct {
 
 // Seal implements consensus.Engine, attempting to find a nonce that satisfies
 // the block's difficulty requirements.
-func (baseMainnet) Seal(chain consensus.ChainHeaderReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
+func (baseMainnet) Seal(chain consensus.ChainHeaderReader, block *types.BlockWithReceipts, results chan<- *types.BlockWithReceipts, stop <-chan struct{}) error {
 	return nil
 }
 
@@ -408,12 +408,14 @@ func (f *MainnetConsensus) VerifySeal(_ consensus.ChainHeaderReader, header *typ
 }
 
 // If we're running a fake PoW, simply return a 0 nonce immediately
-func (f *MainnetConsensus) Seal(_ consensus.ChainHeaderReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
+func (f *MainnetConsensus) Seal(_ consensus.ChainHeaderReader, blockWithReceipts *types.BlockWithReceipts, results chan<- *types.BlockWithReceipts, stop <-chan struct{}) error {
+	block := blockWithReceipts.Block
+	receipts := blockWithReceipts.Receipts
 	header := block.Header()
 	header.Nonce, header.MixDigest = types.BlockNonce{}, libcommon.Hash{}
 
 	select {
-	case results <- block.WithSeal(header):
+	case results <- &types.BlockWithReceipts{Block: block.WithSeal(header), Receipts: receipts}:
 	default:
 		log.Warn("Sealing result is not read by miner", "mode", "fake", "sealhash", block.Hash())
 	}

--- a/consensus/mainnet/mainnet.go
+++ b/consensus/mainnet/mainnet.go
@@ -180,7 +180,7 @@ func (b baseMainnet) verifyHeader(chain consensus.ChainHeaderReader, header, par
 	return nil
 }
 
-func (b baseMainnet) GenerateAuRaSeal(chain consensus.ChainHeaderReader, currnt, parent *types.Header, call consensus.Call) []byte {
+func (b baseMainnet) GenerateSeal(chain consensus.ChainHeaderReader, currnt, parent *types.Header, call consensus.Call) []byte {
 	return nil
 }
 

--- a/consensus/merge/merge.go
+++ b/consensus/merge/merge.go
@@ -334,6 +334,16 @@ func (s *Merge) Seal(chain consensus.ChainHeaderReader, block *types.Block, resu
 	if !misc.IsPoSHeader(block.HeaderNoCopy()) {
 		return s.eth1Engine.Seal(chain, block, results, stop)
 	}
+
+	header := block.Header()
+	header.Nonce = ProofOfStakeNonce
+
+	select {
+	case results <- block.WithSeal(header):
+	default:
+		log.Warn("Sealing result is not read", "sealhash", block.Hash())
+	}
+
 	return nil
 }
 

--- a/consensus/merge/merge.go
+++ b/consensus/merge/merge.go
@@ -330,16 +330,18 @@ func (s *Merge) verifyHeader(chain consensus.ChainHeaderReader, header, parent *
 	return nil
 }
 
-func (s *Merge) Seal(chain consensus.ChainHeaderReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
+func (s *Merge) Seal(chain consensus.ChainHeaderReader, blockWithReceipts *types.BlockWithReceipts, results chan<- *types.BlockWithReceipts, stop <-chan struct{}) error {
+	block := blockWithReceipts.Block
+	receipts := blockWithReceipts.Receipts
 	if !misc.IsPoSHeader(block.HeaderNoCopy()) {
-		return s.eth1Engine.Seal(chain, block, results, stop)
+		return s.eth1Engine.Seal(chain, blockWithReceipts, results, stop)
 	}
 
 	header := block.Header()
 	header.Nonce = ProofOfStakeNonce
 
 	select {
-	case results <- block.WithSeal(header):
+	case results <- &types.BlockWithReceipts{Block: block.WithSeal(header), Receipts: receipts}:
 	default:
 		log.Warn("Sealing result is not read", "sealhash", block.Hash())
 	}

--- a/consensus/merge/merge.go
+++ b/consensus/merge/merge.go
@@ -337,7 +337,7 @@ func (s *Merge) Seal(chain consensus.ChainHeaderReader, block *types.Block, resu
 	return nil
 }
 
-func (s *Merge) GenerateSeal(chain consensus.ChainHeaderReader, currnt, parent *types.Header, call consensus.Call) []byte {
+func (s *Merge) GenerateAuRaSeal(chain consensus.ChainHeaderReader, currnt, parent *types.Header, call consensus.Call) []byte {
 	return nil
 }
 

--- a/consensus/merge/merge.go
+++ b/consensus/merge/merge.go
@@ -347,7 +347,7 @@ func (s *Merge) Seal(chain consensus.ChainHeaderReader, block *types.Block, resu
 	return nil
 }
 
-func (s *Merge) GenerateAuRaSeal(chain consensus.ChainHeaderReader, currnt, parent *types.Header, call consensus.Call) []byte {
+func (s *Merge) GenerateSeal(chain consensus.ChainHeaderReader, currnt, parent *types.Header, call consensus.Call) []byte {
 	return nil
 }
 

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -612,7 +612,7 @@ func makeHeader(chain consensus.ChainReader, parent *types.Block, state *state.I
 		parent.UncleHash(),
 		parent.Header().AuRaStep,
 	)
-	header.AuRaSeal = engine.GenerateAuRaSeal(chain, header, parent.Header(), nil)
+	header.AuRaSeal = engine.GenerateSeal(chain, header, parent.Header(), nil)
 
 	return header
 }

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -612,7 +612,7 @@ func makeHeader(chain consensus.ChainReader, parent *types.Block, state *state.I
 		parent.UncleHash(),
 		parent.Header().AuRaStep,
 	)
-	header.AuRaSeal = engine.GenerateSeal(chain, header, parent.Header(), nil)
+	header.AuRaSeal = engine.GenerateAuRaSeal(chain, header, parent.Header(), nil)
 
 	return header
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -703,7 +703,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 
 	// proof-of-stake mining
 	assembleBlockPOS := func(param *core.BlockBuilderParameters, interrupt *int32) (*types.BlockWithReceipts, error) {
-		miningStatePos := stagedsync.NewProposingState(&config.Miner)
+		miningStatePos := stagedsync.NewMiningState(&config.Miner)
 		miningStatePos.MiningConfig.Etherbase = param.SuggestedFeeRecipient
 		proposingSync := stagedsync.New(
 			config.Sync,
@@ -734,7 +734,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		if err := stages2.MiningStep(ctx, backend.chainDB, proposingSync, tmpdir, logger); err != nil {
 			return nil, err
 		}
-		block := <-miningStatePos.MiningResultPOSCh
+		block := <-miningStatePos.MiningResultCh
 		return block, nil
 	}
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1315,8 +1315,8 @@ func (s *Ethereum) StartMining(ctx context.Context, db kv.RwDB, stateDiffClient 
 						select {
 						case block := <-miner.MiningResultCh:
 							if block != nil {
-								s.logger.Debug("Mined block", "block", block.Number())
-								s.minedBlocks <- block
+								s.logger.Debug("Mined block", "block", block.Block.Number())
+								s.minedBlocks <- block.Block
 							}
 							return
 						case <-workCtx.Done():

--- a/eth/stagedsync/stage_mining_create_block.go
+++ b/eth/stagedsync/stage_mining_create_block.go
@@ -53,11 +53,10 @@ type MiningBlock struct {
 }
 
 type MiningState struct {
-	MiningConfig      *params.MiningConfig
-	PendingResultCh   chan *types.Block
-	MiningResultCh    chan *types.BlockWithReceipts
-	MiningResultPOSCh chan *types.BlockWithReceipts
-	MiningBlock       *MiningBlock
+	MiningConfig    *params.MiningConfig
+	PendingResultCh chan *types.Block
+	MiningResultCh  chan *types.BlockWithReceipts
+	MiningBlock     *MiningBlock
 }
 
 func NewMiningState(cfg *params.MiningConfig) MiningState {
@@ -66,16 +65,6 @@ func NewMiningState(cfg *params.MiningConfig) MiningState {
 		PendingResultCh: make(chan *types.Block, 1),
 		MiningResultCh:  make(chan *types.BlockWithReceipts, 1),
 		MiningBlock:     &MiningBlock{},
-	}
-}
-
-func NewProposingState(cfg *params.MiningConfig) MiningState {
-	return MiningState{
-		MiningConfig:      cfg,
-		PendingResultCh:   make(chan *types.Block, 1),
-		MiningResultCh:    make(chan *types.BlockWithReceipts, 1),
-		MiningResultPOSCh: make(chan *types.BlockWithReceipts, 1),
-		MiningBlock:       &MiningBlock{},
 	}
 }
 

--- a/eth/stagedsync/stage_mining_create_block.go
+++ b/eth/stagedsync/stage_mining_create_block.go
@@ -55,7 +55,7 @@ type MiningBlock struct {
 type MiningState struct {
 	MiningConfig      *params.MiningConfig
 	PendingResultCh   chan *types.Block
-	MiningResultCh    chan *types.Block
+	MiningResultCh    chan *types.BlockWithReceipts
 	MiningResultPOSCh chan *types.BlockWithReceipts
 	MiningBlock       *MiningBlock
 }
@@ -64,7 +64,7 @@ func NewMiningState(cfg *params.MiningConfig) MiningState {
 	return MiningState{
 		MiningConfig:    cfg,
 		PendingResultCh: make(chan *types.Block, 1),
-		MiningResultCh:  make(chan *types.Block, 1),
+		MiningResultCh:  make(chan *types.BlockWithReceipts, 1),
 		MiningBlock:     &MiningBlock{},
 	}
 }
@@ -73,7 +73,7 @@ func NewProposingState(cfg *params.MiningConfig) MiningState {
 	return MiningState{
 		MiningConfig:      cfg,
 		PendingResultCh:   make(chan *types.Block, 1),
-		MiningResultCh:    make(chan *types.Block, 1),
+		MiningResultCh:    make(chan *types.BlockWithReceipts, 1),
 		MiningResultPOSCh: make(chan *types.BlockWithReceipts, 1),
 		MiningBlock:       &MiningBlock{},
 	}

--- a/eth/stagedsync/stage_mining_finish.go
+++ b/eth/stagedsync/stage_mining_finish.go
@@ -80,10 +80,6 @@ func SpawnMiningFinishStage(s *StageState, tx kv.RwTx, cfg MiningFinishCfg, quit
 	//}
 	//prev = sealHash
 	cfg.latestBlockBuiltStore.AddBlockBuilt(block)
-	if cfg.miningState.MiningResultPOSCh != nil {
-		cfg.miningState.MiningResultPOSCh <- blockWithReceipts
-		return nil
-	}
 
 	// Tests may set pre-calculated nonce
 	if block.NonceU64() != 0 {

--- a/eth/stagedsync/stage_mining_finish.go
+++ b/eth/stagedsync/stage_mining_finish.go
@@ -89,7 +89,7 @@ func SpawnMiningFinishStage(s *StageState, tx kv.RwTx, cfg MiningFinishCfg, quit
 	if block.NonceU64() != 0 {
 		// Note: To propose a new signer for Clique consensus, the block nonce should be set to 0xFFFFFFFFFFFFFFFF.
 		if cfg.engine.Type() != chain.CliqueConsensus {
-			cfg.miningState.MiningResultCh <- block
+			cfg.miningState.MiningResultCh <- blockWithReceipts
 			return nil
 		}
 	}
@@ -112,7 +112,7 @@ func SpawnMiningFinishStage(s *StageState, tx kv.RwTx, cfg MiningFinishCfg, quit
 		logger.Trace("No in-flight sealing task.")
 	}
 	chain := ChainReader{Cfg: cfg.chainConfig, Db: tx, BlockReader: cfg.blockReader, Logger: logger}
-	if err := cfg.engine.Seal(chain, block, cfg.miningState.MiningResultCh, cfg.sealCancel); err != nil {
+	if err := cfg.engine.Seal(chain, blockWithReceipts, cfg.miningState.MiningResultCh, cfg.sealCancel); err != nil {
 		logger.Warn("Block sealing failed", "err", err)
 	}
 

--- a/eth/stagedsync/stagedsynctest/harness.go
+++ b/eth/stagedsync/stagedsynctest/harness.go
@@ -480,13 +480,13 @@ func (h *Harness) generateChain(ctx context.Context, t *testing.T, ctrl *gomock.
 
 func (h *Harness) seal(t *testing.T, chr consensus.ChainHeaderReader, eng consensus.Engine, block *types.Block) {
 	h.logger.Info("Sealing mock block", "blockNum", block.Number())
-	sealRes, sealStop := make(chan *types.Block, 1), make(chan struct{}, 1)
-	if err := eng.Seal(chr, block, sealRes, sealStop); err != nil {
+	sealRes, sealStop := make(chan *types.BlockWithReceipts, 1), make(chan struct{}, 1)
+	if err := eng.Seal(chr, &types.BlockWithReceipts{Block: block}, sealRes, sealStop); err != nil {
 		t.Fatal(err)
 	}
 
 	sealedParentBlock := <-sealRes
-	h.sealedHeaders[sealedParentBlock.Number().Uint64()] = sealedParentBlock.Header()
+	h.sealedHeaders[sealedParentBlock.Block.Number().Uint64()] = sealedParentBlock.Block.Header()
 }
 
 func (h *Harness) consensusEngine(t *testing.T, cfg HarnessCfg) consensus.Engine {

--- a/eth/stagedsync/stagedsynctest/harness.go
+++ b/eth/stagedsync/stagedsynctest/harness.go
@@ -64,7 +64,7 @@ func InitHarness(ctx context.Context, t *testing.T, cfg HarnessCfg) Harness {
 	borConsensusDB := memdb.NewTestDB(t)
 	ctrl := gomock.NewController(t)
 	heimdallClient := heimdall.NewMockHeimdallClient(ctrl)
-	miningState := stagedsync.NewProposingState(&ethconfig.Defaults.Miner)
+	miningState := stagedsync.NewMiningState(&ethconfig.Defaults.Miner)
 	bhCfg := stagedsync.StageBorHeimdallCfg(
 		chainDataDB,
 		borConsensusDB,

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -1142,7 +1142,9 @@ func (c *Bor) Authorize(currentSigner libcommon.Address, signFn SignerFn) {
 
 // Seal implements consensus.Engine, attempting to create a sealed block using
 // the local signing credentials.
-func (c *Bor) Seal(chain consensus.ChainHeaderReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
+func (c *Bor) Seal(chain consensus.ChainHeaderReader, blockWithReceipts *types.BlockWithReceipts, results chan<- *types.BlockWithReceipts, stop <-chan struct{}) error {
+	block := blockWithReceipts.Block
+	receipts := blockWithReceipts.Receipts
 	header := block.HeaderNoCopy()
 	// Sealing the genesis block is not supported
 	number := header.Number.Uint64()
@@ -1220,7 +1222,7 @@ func (c *Bor) Seal(chain consensus.ChainHeaderReader, block *types.Block, result
 			}
 		}
 		select {
-		case results <- block.WithSeal(header):
+		case results <- &types.BlockWithReceipts{Block: block.WithSeal(header), Receipts: receipts}:
 		default:
 			c.logger.Warn("Sealing result was not read by miner", "number", number, "sealhash", SealHash(header, c.config))
 		}

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -1123,7 +1123,7 @@ func (c *Bor) FinalizeAndAssemble(chainConfig *chain.Config, header *types.Heade
 	return block, txs, receipts, nil
 }
 
-func (c *Bor) GenerateSeal(chain consensus.ChainHeaderReader, currnt, parent *types.Header, call consensus.Call) []byte {
+func (c *Bor) GenerateAuRaSeal(chain consensus.ChainHeaderReader, currnt, parent *types.Header, call consensus.Call) []byte {
 	return nil
 }
 

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -86,8 +86,6 @@ var (
 		"0": 64,
 	} // Default number of blocks after which to checkpoint and reset the pending votes
 
-	emptyUncleHash = types.CalcUncleHash(nil) // Always Keccak256(RLP([])) as uncles are meaningless outside of PoW.
-
 	// diffInTurn = big.NewInt(2) // Block difficulty for in-turn signatures
 	// diffNoTurn = big.NewInt(1) // Block difficulty for out-of-turn signatures
 
@@ -578,7 +576,7 @@ func ValidateHeaderUnusedFields(header *types.Header) error {
 	}
 
 	// Ensure that the block doesn't contain any uncles which are meaningless in PoA
-	if header.UncleHash != emptyUncleHash {
+	if header.UncleHash != types.EmptyUncleHash {
 		return errInvalidUncleHash
 	}
 

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -1123,7 +1123,7 @@ func (c *Bor) FinalizeAndAssemble(chainConfig *chain.Config, header *types.Heade
 	return block, txs, receipts, nil
 }
 
-func (c *Bor) GenerateAuRaSeal(chain consensus.ChainHeaderReader, currnt, parent *types.Header, call consensus.Call) []byte {
+func (c *Bor) GenerateSeal(chain consensus.ChainHeaderReader, currnt, parent *types.Header, call consensus.Call) []byte {
 	return nil
 }
 

--- a/polygon/bor/bor_test.go
+++ b/polygon/bor/bor_test.go
@@ -266,12 +266,12 @@ func (v validator) IsProposer(block *types.Block) (bool, error) {
 	return v.Engine.(*bor.Bor).IsProposer(block.Header())
 }
 
-func (v validator) sealBlocks(blocks []*types.Block) ([]*types.Block, error) {
+func (v validator) sealBlocks(blocks []*types.Block, receipts []types.Receipts) ([]*types.Block, error) {
 	sealedBlocks := make([]*types.Block, 0, len(blocks))
 
 	hr := headerReader{v}
 
-	for _, block := range blocks {
+	for i, block := range blocks {
 		header := block.HeaderNoCopy()
 
 		if err := v.Engine.Prepare(hr, header, nil); err != nil {
@@ -282,15 +282,16 @@ func (v validator) sealBlocks(blocks []*types.Block) ([]*types.Block, error) {
 			header.ParentHash = parent.Hash()
 		}
 
-		sealResults := make(chan *types.Block, 1)
+		sealResults := make(chan *types.BlockWithReceipts, 1)
 
-		if err := v.Engine.Seal(hr, block, sealResults, nil); err != nil {
+		blockWithReceipts := &types.BlockWithReceipts{Block: block, Receipts: receipts[i]}
+		if err := v.Engine.Seal(hr, blockWithReceipts, sealResults, nil); err != nil {
 			return nil, err
 		}
 
 		sealedBlock := <-sealResults
-		v.blocks[sealedBlock.NumberU64()] = sealedBlock
-		sealedBlocks = append(sealedBlocks, sealedBlock)
+		v.blocks[sealedBlock.Block.NumberU64()] = sealedBlock.Block
+		sealedBlocks = append(sealedBlocks, sealedBlock.Block)
 	}
 
 	return sealedBlocks, nil
@@ -378,7 +379,7 @@ func TestVerifyHeader(t *testing.T) {
 		t.Fatalf("generate blocks failed: %v", err)
 	}
 
-	sealedBlocks, err := v.sealBlocks(chain.Blocks)
+	sealedBlocks, err := v.sealBlocks(chain.Blocks, chain.Receipts)
 
 	if err != nil {
 		t.Fatalf("seal block failed: %v", err)
@@ -432,6 +433,7 @@ func testVerify(t *testing.T, noValidators int, chainLength int) {
 	for bi := 0; bi < chainLength; bi++ {
 		for vi, v := range validators {
 			block := chains[vi].Blocks[bi]
+			receipts := chains[vi].Receipts[bi]
 
 			isProposer, err := v.IsProposer(block)
 
@@ -449,7 +451,7 @@ func testVerify(t *testing.T, noValidators int, chainLength int) {
 					lastProposerIndex = vi
 				}
 
-				sealedBlocks, err := v.sealBlocks([]*types.Block{block})
+				sealedBlocks, err := v.sealBlocks([]*types.Block{block}, []types.Receipts{receipts})
 
 				if err != nil {
 					t.Fatalf("seal block failed: %v", err)
@@ -478,7 +480,7 @@ func TestSendBlock(t *testing.T) {
 		t.Fatalf("generate blocks failed: %v", err)
 	}
 
-	sealedBlocks, err := s.sealBlocks(chain.Blocks)
+	sealedBlocks, err := s.sealBlocks(chain.Blocks, chain.Receipts)
 
 	if err != nil {
 		t.Fatalf("seal block failed: %v", err)

--- a/turbo/stages/mock/mock_sentry.go
+++ b/turbo/stages/mock/mock_sentry.go
@@ -109,7 +109,7 @@ type MockSentry struct {
 	Sync                 *stagedsync.Sync
 	MiningSync           *stagedsync.Sync
 	PendingBlocks        chan *types.Block
-	MinedBlocks          chan *types.Block
+	MinedBlocks          chan *types.BlockWithReceipts
 	sentriesClient       *sentry_multi_client.MultiClient
 	Key                  *ecdsa.PrivateKey
 	Genesis              *types.Block

--- a/turbo/stages/mock/mock_sentry.go
+++ b/turbo/stages/mock/mock_sentry.go
@@ -474,7 +474,7 @@ func MockWithEverything(tb testing.TB, gspec *types.Genesis, key *ecdsa.PrivateK
 	mock.MinedBlocks = miner.MiningResultCh
 	// proof-of-stake mining
 	assembleBlockPOS := func(param *core.BlockBuilderParameters, interrupt *int32) (*types.BlockWithReceipts, error) {
-		miningStatePos := stagedsync.NewProposingState(&cfg.Miner)
+		miningStatePos := stagedsync.NewMiningState(&cfg.Miner)
 		miningStatePos.MiningConfig.Etherbase = param.SuggestedFeeRecipient
 		proposingSync := stagedsync.New(
 			cfg.Sync,
@@ -507,7 +507,7 @@ func MockWithEverything(tb testing.TB, gspec *types.Genesis, key *ecdsa.PrivateK
 		if err := stages2.MiningStep(ctx, mock.DB, proposingSync, tmpdir, logger); err != nil {
 			return nil, err
 		}
-		block := <-miningStatePos.MiningResultPOSCh
+		block := <-miningStatePos.MiningResultCh
 		return block, nil
 	}
 

--- a/turbo/stages/mock/sentry_mock_test.go
+++ b/turbo/stages/mock/sentry_mock_test.go
@@ -144,7 +144,7 @@ func TestMineBlockWith1Tx(t *testing.T) {
 	got := <-m.PendingBlocks
 	require.Equal(chain.TopBlock.Transactions().Len(), got.Transactions().Len())
 	got2 := <-m.MinedBlocks
-	require.Equal(chain.TopBlock.Transactions().Len(), got2.Transactions().Len())
+	require.Equal(chain.TopBlock.Transactions().Len(), got2.Block.Transactions().Len())
 }
 
 func TestReorg(t *testing.T) {


### PR DESCRIPTION
Rationale: one small step to converge Polygon and Ethereum block production.

Also, now `(s *Merge) Seal` calls `block.WithSeal`, which is important after PR #11513.