### PR TITLE
Prune still affecting chain-tip "fsync"

### DIFF
--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -397,7 +397,12 @@ func PruneExecutionStage(s *PruneState, tx kv.RwTx, cfg ExecuteBlockCfg, ctx con
 	// on chain-tip:
 	//  - can prune only between blocks (without blocking blocks processing)
 	//  - need also leave some time to prune blocks
-	pruneTimeout := 500 * time.Millisecond
+	//  - need keep "fsync" time of db fast
+	// Means - the best is:
+	//  - stop prune when `tx.SpaceDirty()` is big
+	//  - and set ~500ms timeout
+	// because on slow disks - prune is slower. but for now - let's tune for nvme first, and add `tx.SpaceDirty()` check later https://github.com/erigontech/erigon/issues/11635
+	pruneTimeout := 250 * time.Millisecond
 	if s.CurrentSyncCycle.IsInitialCycle {
 		pruneTimeout = 12 * time.Hour
 	}


### PR DESCRIPTION
And write mb/s is also big at prune time - nvme handles it - but on a bit slower disks will affect chain-tip perf. 

BorMainnet: 
<img width="1054" alt="Screenshot 2024-08-16 at 08 26 22" src="https://github.com/user-attachments/assets/87e8d227-ac33-4800-a53a-594d872b074f">

Gnosis:
<img width="1026" alt="Screenshot 2024-08-16 at 08 36 23" src="https://github.com/user-attachments/assets/1290e57c-3325-4e89-95cd-83baf8fa93c7">


