### PR TITLE
Caplin: Fixed nil panic in antiquary initizialization and indexing

### DIFF
--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -255,6 +255,7 @@ func (a *Antiquary) Loop() error {
 			if from >= to {
 				continue
 			}
+			from = (from / snaptype.Erigon2MergeLimit) * snaptype.Erigon2MergeLimit
 			to = min(to, to-safetyMargin) // We don't want to retire snapshots that are too close to the finalized head
 			to = (to / snaptype.Erigon2MergeLimit) * snaptype.Erigon2MergeLimit
 			if to-from < snaptype.Erigon2MergeLimit {

--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -153,7 +153,7 @@ func (a *Antiquary) Loop() error {
 		return err
 	}
 	defer logInterval.Stop()
-	if from != a.sn.BlocksAvailable() {
+	if from != a.sn.BlocksAvailable() && a.sn.BlocksAvailable() != 0 {
 		log.Info("[Antiquary] Stopping Caplin to process historical indicies", "from", from, "to", a.sn.BlocksAvailable())
 	}
 

--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -18,6 +18,7 @@ package antiquary
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"math"
 	"strings"
@@ -242,14 +243,17 @@ func (a *Antiquary) Loop() error {
 			}
 			// Sanity checks just to be safe.
 			if from >= to {
+				fmt.Println("from >= to", from, to)
 				continue
 			}
 			from = (from / snaptype.Erigon2MergeLimit) * snaptype.Erigon2MergeLimit
 			to = min(to, to-safetyMargin) // We don't want to retire snapshots that are too close to the finalized head
 			to = (to / snaptype.Erigon2MergeLimit) * snaptype.Erigon2MergeLimit
 			if to-from < snaptype.Erigon2MergeLimit {
+				fmt.Println("to-from < snaptype.Erigon2MergeLimit", from, to, to-from)
 				continue
 			}
+
 			if err := a.antiquate(from, to); err != nil {
 				return err
 			}

--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -222,6 +222,7 @@ func (a *Antiquary) Loop() error {
 		select {
 		case <-retirementTicker.C:
 			if !a.backfilled.Load() {
+				fmt.Println("not backfilled")
 				continue
 			}
 

--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -216,7 +216,7 @@ func (a *Antiquary) Loop() error {
 		return err
 	}
 	// Check for snapshots retirement every 3 minutes
-	retirementTicker := time.NewTicker(3 * time.Minute)
+	retirementTicker := time.NewTicker(10 * time.Second)
 	defer retirementTicker.Stop()
 	for {
 		select {

--- a/cl/persistence/beacon_indicies/indicies.go
+++ b/cl/persistence/beacon_indicies/indicies.go
@@ -132,21 +132,6 @@ func ReadCanonicalBlockRoot(tx kv.Tx, slot uint64) (libcommon.Hash, error) {
 	return blockRoot, nil
 }
 
-func WriteLastBeaconSnapshot(tx kv.RwTx, slot uint64) error {
-	return tx.Put(kv.LastBeaconSnapshot, []byte(kv.LastBeaconSnapshotKey), base_encoding.Encode64ToBytes4(slot))
-}
-
-func ReadLastBeaconSnapshot(tx kv.Tx) (uint64, error) {
-	val, err := tx.GetOne(kv.LastBeaconSnapshot, []byte(kv.LastBeaconSnapshotKey))
-	if err != nil {
-		return 0, err
-	}
-	if len(val) == 0 {
-		return 0, nil
-	}
-	return base_encoding.Decode64FromBytes4(val), nil
-}
-
 func MarkRootCanonical(ctx context.Context, tx kv.RwTx, slot uint64, blockRoot libcommon.Hash) error {
 	return tx.Put(kv.CanonicalBlockRoots, base_encoding.Encode64ToBytes4(slot), blockRoot[:])
 }

--- a/cl/persistence/beacon_indicies/indicies.go
+++ b/cl/persistence/beacon_indicies/indicies.go
@@ -132,6 +132,21 @@ func ReadCanonicalBlockRoot(tx kv.Tx, slot uint64) (libcommon.Hash, error) {
 	return blockRoot, nil
 }
 
+func WriteLastBeaconSnapshot(tx kv.RwTx, slot uint64) error {
+	return tx.Put(kv.LastBeaconSnapshot, []byte(kv.LastBeaconSnapshotKey), base_encoding.Encode64ToBytes4(slot))
+}
+
+func ReadLastBeaconSnapshot(tx kv.Tx) (uint64, error) {
+	val, err := tx.GetOne(kv.LastBeaconSnapshot, []byte(kv.LastBeaconSnapshotKey))
+	if err != nil {
+		return 0, err
+	}
+	if len(val) == 0 {
+		return 0, nil
+	}
+	return base_encoding.Decode64FromBytes4(val), nil
+}
+
 func MarkRootCanonical(ctx context.Context, tx kv.RwTx, slot uint64, blockRoot libcommon.Hash) error {
 	return tx.Put(kv.CanonicalBlockRoots, base_encoding.Encode64ToBytes4(slot), blockRoot[:])
 }

--- a/cl/phase1/forkchoice/utils.go
+++ b/cl/phase1/forkchoice/utils.go
@@ -76,7 +76,7 @@ func (f *ForkChoiceStore) onNewFinalized(newFinalized solid.Checkpoint) {
 		}
 		return true
 	})
-	slotToPrune := ((newFinalized.Epoch() - 1) * f.beaconCfg.SlotsPerEpoch) - 1
+	slotToPrune := ((newFinalized.Epoch() - 2) * f.beaconCfg.SlotsPerEpoch) - 1
 	f.forkGraph.Prune(slotToPrune)
 }
 

--- a/cmd/caplin/caplin1/run.go
+++ b/cmd/caplin/caplin1/run.go
@@ -177,6 +177,7 @@ func RunCaplinService(ctx context.Context, engine execution_client.ExecutionEngi
 				return err
 			}
 		}
+
 	}
 
 	if config.NetworkId == clparams.CustomNetwork {
@@ -190,8 +191,14 @@ func RunCaplinService(ctx context.Context, engine execution_client.ExecutionEngi
 	if len(config.StaticPeers) > 0 {
 		networkConfig.StaticPeers = config.StaticPeers
 	}
-
-	genesisDb.Initialize(genesisState)
+	if genesisState != nil {
+		genesisDb.Initialize(genesisState)
+	} else {
+		genesisState, err = genesisDb.ReadGenesisState()
+		if err != nil {
+			return err
+		}
+	}
 
 	state, err := checkpoint_sync.ReadOrFetchLatestBeaconState(ctx, dirs, beaconConfig, config, genesisDb)
 	if err != nil {

--- a/turbo/snapshotsync/freezeblocks/caplin_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/caplin_snapshots.go
@@ -454,6 +454,9 @@ func dumpBeaconBlocksRange(ctx context.Context, db kv.RoDB, fromSlot uint64, toS
 		}
 
 	}
+	if sn.Count() != snaptype.Erigon2MergeLimit {
+		return fmt.Errorf("expected %d blocks, got %d", snaptype.Erigon2MergeLimit, sn.Count())
+	}
 	if err := sn.Compress(); err != nil {
 		return fmt.Errorf("compress: %w", err)
 	}

--- a/turbo/snapshotsync/freezeblocks/caplin_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/caplin_snapshots.go
@@ -161,6 +161,10 @@ func (s *CaplinSnapshots) BlocksAvailable() uint64 {
 	return min(s.segmentsMax.Load(), s.idxMax.Load())
 }
 
+func (s *CaplinSnapshots) BlocksSegsAvailable() uint64 {
+	return min(s.segmentsMax.Load(), s.idxMax.Load())
+}
+
 func (s *CaplinSnapshots) Close() {
 	if s == nil {
 		return

--- a/turbo/snapshotsync/freezeblocks/caplin_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/caplin_snapshots.go
@@ -161,10 +161,6 @@ func (s *CaplinSnapshots) BlocksAvailable() uint64 {
 	return min(s.segmentsMax.Load(), s.idxMax.Load())
 }
 
-func (s *CaplinSnapshots) BlocksSegsAvailable() uint64 {
-	return min(s.segmentsMax.Load(), s.idxMax.Load())
-}
-
 func (s *CaplinSnapshots) Close() {
 	if s == nil {
 		return


### PR DESCRIPTION
2 bugs were fixed:

* Sometimes `Antiquary` was initizialized with nil genesis
* When building block snapshots from 0, block 0 was skipped