### PR TITLE
memory exhaustion due to connections with numerous validators & unwind issue

### DIFF
--- a/cl/beacon/handler/pool.go
+++ b/cl/beacon/handler/pool.go
@@ -97,7 +97,7 @@ func (a *ApiHandler) PostEthV1BeaconPoolAttestations(w http.ResponseWriter, r *h
 		)
 		_ = i
 		if err := a.attestationService.ProcessMessage(r.Context(), &subnet, attestation); err != nil {
-			log.Warn("[Beacon REST] failed to process attestation", "err", err)
+			log.Warn("[Beacon REST] failed to process attestation in attestation service", "err", err)
 			failures = append(failures, poolingFailure{
 				Index:   i,
 				Message: err.Error(),
@@ -330,7 +330,7 @@ func (a *ApiHandler) PostEthV1BeaconPoolSyncCommittees(w http.ResponseWriter, r 
 		}
 		for _, subnet := range publishingSubnets {
 			if err = a.syncCommitteeMessagesService.ProcessMessage(r.Context(), &subnet, v); err != nil && !errors.Is(err, services.ErrIgnore) {
-				log.Warn("[Beacon REST] failed to process attestation", "err", err)
+				log.Warn("[Beacon REST] failed to process attestation in syncCommittee service", "err", err)
 				failures = append(failures, poolingFailure{Index: idx, Message: err.Error()})
 				break
 			}

--- a/cl/phase1/network/services/aggregate_and_proof_service.go
+++ b/cl/phase1/network/services/aggregate_and_proof_service.go
@@ -133,7 +133,7 @@ func (a *aggregateAndProofServiceImpl) ProcessMessage(
 	// [REJECT] The aggregate attestation's target block is an ancestor of the block named in the LMD vote -- i.e. get_checkpoint_block(store, aggregate.data.beacon_block_root, aggregate.data.target.epoch) == aggregate.data.target.root
 	if a.forkchoiceStore.Ancestor(
 		aggregateData.BeaconBlockRoot(),
-		epoch*a.beaconCfg.SlotsPerEpoch,
+		target.Epoch()*a.beaconCfg.SlotsPerEpoch,
 	) != target.BlockRoot() {
 		return errors.New("invalid target block")
 	}

--- a/cl/phase1/network/services/attestation_service.go
+++ b/cl/phase1/network/services/attestation_service.go
@@ -182,7 +182,7 @@ func (s *attestationService) ProcessMessage(ctx context.Context, subnet *uint64,
 	if valid, err := blsVerify(signature[:], signingRoot[:], pubKey[:]); err != nil {
 		return err
 	} else if !valid {
-		log.Warn("lodestar: invalid signature", "signature", common.Bytes2Hex(signature[:]), "signningRoot", common.Bytes2Hex(signingRoot[:]), "pubKey", common.Bytes2Hex(pubKey[:]))
+		log.Warn("invalid signature", "signature", common.Bytes2Hex(signature[:]), "signningRoot", common.Bytes2Hex(signingRoot[:]), "pubKey", common.Bytes2Hex(pubKey[:]))
 		return errors.New("invalid signature")
 	}
 

--- a/cl/phase1/network/services/attestation_service.go
+++ b/cl/phase1/network/services/attestation_service.go
@@ -197,7 +197,7 @@ func (s *attestationService) ProcessMessage(ctx context.Context, subnet *uint64,
 	// get_checkpoint_block(store, attestation.data.beacon_block_root, attestation.data.target.epoch) == attestation.data.target.root
 	startSlotAtEpoch := targetEpoch * s.beaconCfg.SlotsPerEpoch
 	if s.forkchoiceStore.Ancestor(root, startSlotAtEpoch) != att.AttestantionData().Target().BlockRoot() {
-		return errors.New("invalid target block")
+		return fmt.Errorf("invalid target block. root %v targetEpoch %v targetBlockRoot %v", root.Hex(), targetEpoch, att.AttestantionData().Target().BlockRoot().Hex())
 	}
 	// [IGNORE] The current finalized_checkpoint is an ancestor of the block defined by attestation.data.beacon_block_root --
 	// i.e. get_checkpoint_block(store, attestation.data.beacon_block_root, store.finalized_checkpoint.epoch) == store.finalized_checkpoint.root

--- a/cl/phase1/network/services/block_service.go
+++ b/cl/phase1/network/services/block_service.go
@@ -186,7 +186,15 @@ func (b *blockService) processAndStoreBlock(ctx context.Context, block *cltypes.
 	}); err != nil {
 		return err
 	}
-	if err := b.forkchoiceStore.OnBlock(ctx, block, true, true, true); err != nil {
+	isNewPayload := true
+	blockRoot, err := block.Block.HashSSZ()
+	if err != nil {
+		return err
+	}
+	if _, exist := b.forkchoiceStore.GetHeader(blockRoot); exist {
+		isNewPayload = false
+	}
+	if err := b.forkchoiceStore.OnBlock(ctx, block, isNewPayload, true, true); err != nil {
 		return err
 	}
 	go b.importBlockOperations(block)

--- a/cl/validator/attestation_producer/attestation_producer.go
+++ b/cl/validator/attestation_producer/attestation_producer.go
@@ -130,6 +130,7 @@ func (ap *attestationProducer) listenOnCopyStateAtSlot(ctx context.Context) {
 	}
 }
 
+// acquireBeaconStateAtSlot returns a copy of the beacon state at the given slot. Note the returned state should NOT be modified.
 func (ap *attestationProducer) acquireBeaconStateAtSlot(baseState *state.CachingBeaconState, slot uint64) (*state.CachingBeaconState, error) {
 	respCh := make(chan stateAcquireResp, 1)
 	ap.reqStateAtSlotCh <- struct {

--- a/cl/validator/attestation_producer/attestation_producer.go
+++ b/cl/validator/attestation_producer/attestation_producer.go
@@ -142,7 +142,7 @@ func (ap *attestationProducer) acquireBeaconStateAtSlot(baseState *state.Caching
 	case resp := <-respCh:
 		return resp.state, resp.err
 	case <-time.After(5 * time.Second):
-		return nil, ErrHeadStateNotAvailable
+		return nil, errors.New("timeout waiting for state generation")
 	}
 }
 

--- a/cl/validator/attestation_producer/attestation_producer.go
+++ b/cl/validator/attestation_producer/attestation_producer.go
@@ -147,8 +147,6 @@ func (ap *attestationProducer) acquireBeaconStateAtSlot(baseState *state.Caching
 }
 
 func (ap *attestationProducer) ProduceAndCacheAttestationData(baseState *state.CachingBeaconState, slot uint64, committeeIndex uint64) (solid.AttestationData, error) {
-	begin := time.Now()
-	defer log.Info("[AttestationProducer] ProduceAndCacheAttestationData", "slot", slot, "committeeIndex", committeeIndex, "duration", time.Since(begin))
 	epoch := slot / ap.beaconCfg.SlotsPerEpoch
 	baseStateBlockRoot, err := baseState.BlockRoot()
 	if err != nil {

--- a/cl/validator/attestation_producer/attestation_producer.go
+++ b/cl/validator/attestation_producer/attestation_producer.go
@@ -72,7 +72,7 @@ func New(ctx context.Context, beaconCfg *clparams.BeaconChainConfig) Attestation
 // which might lead to 10k copies of the same state in memory)
 func (ap *attestationProducer) listenOnCopyStateAtSlot(ctx context.Context) {
 	// beaconStateCache *lru.CacheWithTTL[uint64, *state.CachingBeaconState] // Slot => BeaconState
-	beaconStateCache := lru.NewWithTTL[uint64, *state.CachingBeaconState]("attestaion_producer_beacon_state_cpy", 128, time.Minute)
+	beaconStateCache := lru.NewWithTTL[uint64, *state.CachingBeaconState]("attestaion_producer_beacon_state_cpy", 32, time.Minute)
 	generatingWaitList := map[uint64][]chan<- stateAcquireResp{}
 	slotGenerateDone := make(chan uint64, 32)
 	for {

--- a/cl/validator/attestation_producer/attestation_producer.go
+++ b/cl/validator/attestation_producer/attestation_producer.go
@@ -65,7 +65,7 @@ func (ap *attestationProducer) ProduceAndCacheAttestationData(baseState *state.C
 	}
 
 	ap.attCacheMutex.RLock()
-	if baseAttestationData, ok := ap.attestationsCache.Get(epoch); ok {
+	if baseAttestationData, ok := ap.attestationsCache.Get(slot); ok {
 		ap.attCacheMutex.RUnlock()
 		beaconBlockRoot := baseStateBlockRoot
 		if baseState.Slot() > slot {
@@ -89,7 +89,7 @@ func (ap *attestationProducer) ProduceAndCacheAttestationData(baseState *state.C
 	ap.attCacheMutex.Lock()
 	defer ap.attCacheMutex.Unlock()
 	// check again if the target epoch is already generated
-	if baseAttestationData, ok := ap.attestationsCache.Get(epoch); ok {
+	if baseAttestationData, ok := ap.attestationsCache.Get(slot); ok {
 		beaconBlockRoot := baseStateBlockRoot
 		if baseState.Slot() > slot {
 			beaconBlockRoot, err = baseState.GetBlockRootAtSlot(slot)
@@ -116,7 +116,7 @@ func (ap *attestationProducer) ProduceAndCacheAttestationData(baseState *state.C
 			log.Warn("Failed to copy base state", "slot", slot, "err", err)
 			return solid.AttestationData{}, err
 		}
-		if err := transition.DefaultMachine.ProcessSlots(baseState, epoch*ap.beaconCfg.SlotsPerEpoch); err != nil {
+		if err := transition.DefaultMachine.ProcessSlots(baseState, slot); err != nil {
 			log.Warn("Failed to process slots", "slot", slot, "err", err)
 			return solid.AttestationData{}, err
 		}
@@ -150,7 +150,7 @@ func (ap *attestationProducer) ProduceAndCacheAttestationData(baseState *state.C
 			targetEpoch,
 		),
 	)
-	ap.attestationsCache.Add(epoch, baseAttestationData)
+	ap.attestationsCache.Add(slot, baseAttestationData)
 	return solid.NewAttestionDataFromParameters(
 		slot,
 		committeeIndex,

--- a/cl/validator/attestation_producer/attestation_producer.go
+++ b/cl/validator/attestation_producer/attestation_producer.go
@@ -17,7 +17,9 @@
 package attestation_producer
 
 import (
+	"context"
 	"errors"
+	"time"
 
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
@@ -26,6 +28,7 @@ import (
 	"github.com/erigontech/erigon/cl/transition"
 
 	libcommon "github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/log/v3"
 )
 
 var (
@@ -38,17 +41,108 @@ type attestationProducer struct {
 	beaconCfg *clparams.BeaconChainConfig
 
 	attestationsCache *lru.Cache[uint64, solid.AttestationData] // Epoch => Base AttestationData
+	reqStateAtSlotCh  chan struct {
+		slot      uint64
+		baseState *state.CachingBeaconState
+		resp      chan<- stateAcquireResp
+	}
 }
 
-func New(beaconCfg *clparams.BeaconChainConfig) AttestationDataProducer {
+type stateAcquireResp struct {
+	state *state.CachingBeaconState
+	err   error
+}
+
+func New(ctx context.Context, beaconCfg *clparams.BeaconChainConfig) AttestationDataProducer {
 	attestationsCache, err := lru.New[uint64, solid.AttestationData]("attestations", attestationsCacheSize)
 	if err != nil {
 		panic(err)
 	}
 
-	return &attestationProducer{
+	p := &attestationProducer{
 		beaconCfg:         beaconCfg,
 		attestationsCache: attestationsCache,
+	}
+	go p.genStateAtSlotManager(ctx)
+	return p
+}
+
+// genStateAtSlotManager generates beacon state at slot in background and also notify all ch in waiting list. This is used to avoid over-copying of
+// beacon state in case of multiple requests for the same slot. (e.g. 10k validators requesting attestation data for the same slot almost at the same time,
+// which might lead to 10k copies of the same state in memory)
+func (ap *attestationProducer) genStateAtSlotManager(ctx context.Context) {
+	// beaconStateCache *lru.CacheWithTTL[uint64, *state.CachingBeaconState] // Slot => BeaconState
+	beaconStateCache := lru.NewWithTTL[uint64, *state.CachingBeaconState]("attestaion_producer_beacon_state_cpy", 128, time.Minute)
+	generatingWaitList := map[uint64][]chan<- stateAcquireResp{}
+	slotGenerateDone := make(chan uint64, 32)
+	for {
+		select {
+		case req := <-ap.reqStateAtSlotCh:
+			slot := req.slot
+			baseState := req.baseState
+			if state, ok := beaconStateCache.Get(slot); ok {
+				// if state is already generated, return it
+				req.resp <- stateAcquireResp{state: state, err: nil}
+				continue
+			}
+			if _, ok := generatingWaitList[slot]; ok {
+				// append to wait list
+				generatingWaitList[slot] = append(generatingWaitList[slot], req.resp)
+				continue
+			}
+			generatingWaitList[slot] = []chan<- stateAcquireResp{req.resp}
+
+			// generate state in background
+			go func() {
+				defer func() {
+					// notify all waiting requests
+					slotGenerateDone <- slot
+				}()
+				cpyBaseState, err := baseState.Copy()
+				if err != nil {
+					log.Warn("Failed to copy base state", "slot", slot, "err", err)
+					return
+				}
+				if err := transition.DefaultMachine.ProcessSlots(cpyBaseState, slot); err != nil {
+					log.Warn("Failed to process slots", "slot", slot, "err", err)
+					return
+				}
+				beaconStateCache.Add(slot, cpyBaseState)
+			}()
+		case slot := <-slotGenerateDone:
+			if reqChs, ok := generatingWaitList[slot]; ok {
+				delete(generatingWaitList, slot)
+				state, ok := beaconStateCache.Get(slot)
+				if !ok {
+					log.Warn("Failed to get generated state", "slot", slot)
+					for _, ch := range reqChs {
+						ch <- stateAcquireResp{state: nil, err: errors.New("failed to get generated state")}
+					}
+					continue
+				}
+				for _, ch := range reqChs {
+					ch <- stateAcquireResp{state: state, err: nil}
+				}
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (ap *attestationProducer) acquireBeaconStateAtSlot(baseState *state.CachingBeaconState, slot uint64) (*state.CachingBeaconState, error) {
+	respCh := make(chan stateAcquireResp, 1)
+	ap.reqStateAtSlotCh <- struct {
+		slot      uint64
+		baseState *state.CachingBeaconState
+		resp      chan<- stateAcquireResp
+	}{slot: slot, baseState: baseState, resp: respCh}
+
+	select {
+	case resp := <-respCh:
+		return resp.state, resp.err
+	case <-time.After(5 * time.Second):
+		return nil, ErrHeadStateNotAvailable
 	}
 }
 
@@ -77,15 +171,12 @@ func (ap *attestationProducer) ProduceAndCacheAttestationData(baseState *state.C
 	stateEpoch := state.Epoch(baseState)
 
 	if baseState.Slot() > slot {
-		return solid.AttestationData{}, errors.New("head state slot is bigger than requested slot, the attestation should have been cached, try again later.")
+		return solid.AttestationData{}, errors.New("head state slot is bigger than requested slot, the attestation should have been cached, try again later")
 	}
 
 	if stateEpoch < epoch {
-		baseState, err = baseState.Copy()
+		baseState, err = ap.acquireBeaconStateAtSlot(baseState, epoch*ap.beaconCfg.SlotsPerEpoch)
 		if err != nil {
-			return solid.AttestationData{}, err
-		}
-		if err := transition.DefaultMachine.ProcessSlots(baseState, slot); err != nil {
 			return solid.AttestationData{}, err
 		}
 	}

--- a/cl/validator/attestation_producer/attestation_producer.go
+++ b/cl/validator/attestation_producer/attestation_producer.go
@@ -65,7 +65,7 @@ func (ap *attestationProducer) ProduceAndCacheAttestationData(baseState *state.C
 	}
 
 	ap.attCacheMutex.RLock()
-	if baseAttestationData, ok := ap.attestationsCache.Get(slot); ok {
+	if baseAttestationData, ok := ap.attestationsCache.Get(epoch); ok {
 		ap.attCacheMutex.RUnlock()
 		beaconBlockRoot := baseStateBlockRoot
 		if baseState.Slot() > slot {
@@ -89,7 +89,7 @@ func (ap *attestationProducer) ProduceAndCacheAttestationData(baseState *state.C
 	ap.attCacheMutex.Lock()
 	defer ap.attCacheMutex.Unlock()
 	// check again if the target epoch is already generated
-	if baseAttestationData, ok := ap.attestationsCache.Get(slot); ok {
+	if baseAttestationData, ok := ap.attestationsCache.Get(epoch); ok {
 		beaconBlockRoot := baseStateBlockRoot
 		if baseState.Slot() > slot {
 			beaconBlockRoot, err = baseState.GetBlockRootAtSlot(slot)
@@ -150,7 +150,7 @@ func (ap *attestationProducer) ProduceAndCacheAttestationData(baseState *state.C
 			targetEpoch,
 		),
 	)
-	ap.attestationsCache.Add(slot, baseAttestationData)
+	ap.attestationsCache.Add(epoch, baseAttestationData)
 	return solid.NewAttestionDataFromParameters(
 		slot,
 		committeeIndex,

--- a/cl/validator/attestation_producer/attestation_producer_test.go
+++ b/cl/validator/attestation_producer/attestation_producer_test.go
@@ -17,6 +17,7 @@
 package attestation_producer_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/erigontech/erigon/cl/antiquary/tests"
@@ -26,7 +27,7 @@ import (
 )
 
 func TestAttestationProducer(t *testing.T) {
-	attProducer := attestation_producer.New(&clparams.MainnetBeaconConfig)
+	attProducer := attestation_producer.New(context.Background(), &clparams.MainnetBeaconConfig)
 
 	_, _, headState := tests.GetPhase0Random()
 

--- a/cmd/caplin/caplin1/run.go
+++ b/cmd/caplin/caplin1/run.go
@@ -245,7 +245,7 @@ func RunCaplinService(ctx context.Context, engine execution_client.ExecutionEngi
 	rcsn := freezeblocks.NewBeaconSnapshotReader(csn, eth1Getter, beaconConfig)
 
 	pool := pool.NewOperationsPool(beaconConfig)
-	attestationProducer := attestation_producer.New(beaconConfig)
+	attestationProducer := attestation_producer.New(ctx, beaconConfig)
 
 	caplinFcuPath := path.Join(dirs.Tmp, "caplin-forkchoice")
 	os.RemoveAll(caplinFcuPath)


### PR DESCRIPTION
- Memory issue
Memory usage spirals out of control when a large number of validators simultaneously request attestation data via `validator/attestation_data`. The root cause is that each request attempts to create a copy of the beacon state, which includes a memory-intensive validator set data structure. 
To mitigate this, here try to reduce the frequency of identical beacon state copies.

- Unwind issue
Reproduce step:
1. add or say register validator
2. caplin then subscribes some gossip channels to receive new blocks
3. receive an old block from gossip and process it.
4. leads to unwind to the old block
