### PR TITLE
get back fallback to remote borevents if env `BOREVENTS_REMOTE_FALLBACK` provided

### DIFF
--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -79,6 +79,8 @@ const (
 	inmemorySignatures      = 4096 // Number of recent block signatures to keep in memory
 )
 
+var enableBoreventsRemoteFallback = dbg.EnvBool("BOREVENTS_REMOTE_FALLBACK", false)
+
 // Bor protocol constants.
 var (
 	defaultSprintLength = map[string]uint64{
@@ -1539,6 +1541,48 @@ func (c *Bor) CommitStates(
 	}
 
 	events := chain.Chain.BorEventsByBlock(header.Hash(), blockNum)
+	if enableBoreventsRemoteFallback && blockNum <= chain.Chain.FrozenBorBlocks() && (len(events) == 0 || len(events) == 50) {
+		// we still sometime could get 0 events from borevent file
+		var to time.Time
+		if c.config.IsIndore(blockNum) {
+			stateSyncDelay := c.config.CalculateStateSyncDelay(blockNum)
+			to = time.Unix(int64(header.Time-stateSyncDelay), 0)
+		} else {
+			pHeader := chain.Chain.GetHeaderByNumber(blockNum - c.config.CalculateSprintLength(blockNum))
+			to = time.Unix(int64(pHeader.Time), 0)
+		}
+
+		startEventID := chain.Chain.BorStartEventID(header.Hash(), blockNum)
+		log.Warn("[dbg] fallback to remote bor events", "blockNum", blockNum, "startEventID", startEventID, "events_from_db_or_snaps", len(events))
+		remote, err := c.HeimdallClient.FetchStateSyncEvents(context.Background(), startEventID, to, 0)
+		if err != nil {
+			return err
+		}
+		if len(remote) > 0 {
+			chainID := c.chainConfig.ChainID.String()
+
+			var merged []*heimdall.EventRecordWithTime
+			events = events[:0]
+			for _, event := range remote {
+				if event.ChainID != chainID {
+					continue
+				}
+				if event.Time.After(to) {
+					continue
+				}
+				merged = append(merged, event)
+			}
+
+			for _, ev := range merged {
+				data, err := ev.MarshallBytes()
+				if err != nil {
+					panic(err)
+				}
+
+				events = append(events, data)
+			}
+		}
+	}
 
 	for _, event := range events {
 		if err := c.stateReceiver.CommitState(event, syscall); err != nil {

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -1541,7 +1541,7 @@ func (c *Bor) CommitStates(
 	}
 
 	events := chain.Chain.BorEventsByBlock(header.Hash(), blockNum)
-	if enableBoreventsRemoteFallback && blockNum <= chain.Chain.FrozenBorBlocks() && (len(events) == 0 || len(events) == 50) {
+	if enableBoreventsRemoteFallback && blockNum <= chain.Chain.FrozenBorBlocks() && len(events) == 50 {
 		// we still sometime could get 0 events from borevent file
 		var to time.Time
 		if c.config.IsIndore(blockNum) {


### PR DESCRIPTION
So if `BOREVENTS_REMOTE_FALLBACK=true` then in case of empty borevents from files will check bor events with remote Heimdall.
We still sometimes get 0 events from files (so they are incorrect). 