### PR TITLE
fix: debug_accountRange(): increase block_number on storage walk (e3)

### DIFF
--- a/core/state/dump.go
+++ b/core/state/dump.go
@@ -152,7 +152,7 @@ func (d *Dumper) DumpToCollector(c DumpCollector, excludeCode, excludeStorage bo
 	if err != nil {
 		return nil, err
 	}
-	txNumForStorage, err := rawdbv3.TxNums.Min(ttx, d.blockNumber)
+	txNumForStorage, err := rawdbv3.TxNums.Min(ttx, d.blockNumber+1)
 	if err != nil {
 		return nil, err
 	}

--- a/turbo/jsonrpc/debug_api_test.go
+++ b/turbo/jsonrpc/debug_api_test.go
@@ -343,7 +343,7 @@ func TestAccountRange(t *testing.T) {
 		n = rpc.BlockNumber(7)
 		result, err = api.AccountRange(m.Ctx, rpc.BlockNumberOrHash{BlockNumber: &n}, addr[:], 1, false, false)
 		require.NoError(t, err)
-		require.Equal(t, 0, len(result.Accounts[addr].Storage))
+		require.Equal(t, 35, len(result.Accounts[addr].Storage))
 
 		n = rpc.BlockNumber(10)
 		result, err = api.AccountRange(m.Ctx, rpc.BlockNumberOrHash{BlockNumber: &n}, addr[:], 1, false, false)


### PR DESCRIPTION
PR contains the FIX done on e2 see (PR #11669 )