### PR TITLE
reset sigint default handler after libp2p.New call

### DIFF
--- a/cl/sentinel/sentinel.go
+++ b/cl/sentinel/sentinel.go
@@ -256,7 +256,7 @@ func New(
 	opts = append(opts, libp2p.ConnectionGater(gater))
 
 	host, err := libp2p.New(opts...)
-	signal.Reset(syscall.SIGINT, syscall.SIGTERM)
+	signal.Reset(syscall.SIGINT)
 	if err != nil {
 		return nil, err
 	}

--- a/cl/sentinel/sentinel.go
+++ b/cl/sentinel/sentinel.go
@@ -22,9 +22,11 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os/signal"
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -254,6 +256,7 @@ func New(
 	opts = append(opts, libp2p.ConnectionGater(gater))
 
 	host, err := libp2p.New(opts...)
+	signal.Reset(syscall.SIGINT, syscall.SIGTERM)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
After investigation I see that SIGINT default handler is modified AFTER the line `host, err := libp2p.New(opts...)`

I looked into the library but couldn't find where the handlers are modified. From experimentations it's clear that this is the line after which the SIGINT behaviour changes (does nothing). 

I'm resetting the default behavior after the call. 

I tested it simply running the caplin for a few seconds and shutting it down with ctl+c which didn't work before the change. 