### PR TITLE
downloader: Fixed downloaded value

### DIFF
--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -121,9 +121,8 @@ type AggStats struct {
 	Completed bool
 	Progress  float32
 
-	BytesCompleted, BytesTotal     uint64
-	CompletionRate                 uint64
-	DroppedCompleted, DroppedTotal uint64
+	BytesCompleted, BytesTotal uint64
+	CompletionRate             uint64
 
 	BytesDownload, BytesUpload uint64
 	UploadRate, DownloadRate   uint64
@@ -1989,8 +1988,7 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 
 	lastMetadataReady := stats.MetadataReady
 
-	stats.BytesTotal, stats.ConnectionsTotal, stats.MetadataReady =
-		atomic.LoadUint64(&stats.DroppedTotal), 0, 0
+	stats.BytesTotal, stats.ConnectionsTotal, stats.MetadataReady = 0, 0, 0
 
 	var zeroProgress []string
 	var noMetadata []string

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -2027,11 +2027,14 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 		weebseedPeersOfThisFile := t.WebseedPeerConns()
 
 		tLen := t.Length()
-		bytesCompleted := t.BytesCompleted()
+		var bytesCompleted int64
 
 		if torrentComplete {
 			tComplete++
+			bytesCompleted = tLen
 			delete(downloading, torrentName)
+		} else {
+			bytesCompleted = t.BytesCompleted()
 		}
 
 		progress := float32(float64(100) * (float64(bytesCompleted) / float64(tLen)))

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -2007,7 +2007,6 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 	var torrentInfo int
 
 	downloadedBytes := int64(0)
-	totalBytes := int64(0)
 
 	for _, t := range torrents {
 		select {
@@ -2045,7 +2044,7 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 		}
 
 		downloadedBytes += bytesCompleted
-		totalBytes += tLen
+		stats.BytesTotal += uint64(tLen)
 
 		for _, peer := range peersOfThisFile {
 			stats.ConnectionsTotal++
@@ -2099,7 +2098,6 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 	}
 
 	stats.BytesCompleted = uint64(downloadedBytes)
-	stats.BytesTotal = uint64(totalBytes)
 
 	var webTransfers int32
 

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -2127,7 +2127,6 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 				}
 
 				stats.BytesCompleted += bytesCompleted
-				fmt.Println("BytesCompleted 3", stats.BytesCompleted)
 				stats.BytesTotal += tLen
 
 				stats.BytesDownload += bytesCompleted


### PR DESCRIPTION
Corrected the calculation of downloaded bytes, which was previously overestimating by at least 30%. This was one of the main reasons the logs would often appear stuck at 99.90% for long time. 
List of changes :
- Removed `DroppedCompleted, DroppedTotal` it wasn't used anywhere
- Use `connStats.BytesReadData` to calculate download rate as torrent library says `// Sample Torrent.Stats.DataBytesRead for actual file data download rate.`