### PR TITLE
`.bt` indices with list of keys to cache

### DIFF
--- a/erigon-lib/state/aggregator_test.go
+++ b/erigon-lib/state/aggregator_test.go
@@ -22,10 +22,12 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"github.com/erigontech/erigon-lib/common/background"
 	"math"
 	"math/rand"
 	"os"
 	"path"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -409,6 +411,27 @@ func aggregatorV3_RestartOnDatadir(t *testing.T, rc runCfg) {
 	dc.Close()
 
 	require.EqualValues(t, maxWrite, binary.BigEndian.Uint64(v[:]))
+}
+
+func TestNewBtIndex(t *testing.T) {
+	keyCount := 1000
+	kvPath := generateKV(t, t.TempDir(), 20, 10, keyCount, log.New(), CompressNone)
+
+	indexPath := strings.TrimSuffix(kvPath, ".kv") + ".bt"
+
+	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, kvPath, uint64(DefaultBtreeM), CompressNone, false)
+	require.NoError(t, err)
+	defer bt.Close()
+	defer kv.Close()
+	require.NotNil(t, kv)
+	require.NotNil(t, bt)
+	require.Len(t, bt.bplus.mx, keyCount/int(DefaultBtreeM))
+
+	for i := 1; i < len(bt.bplus.mx); i++ {
+		require.NotZero(t, bt.bplus.mx[i].di)
+		require.NotZero(t, bt.bplus.mx[i].off)
+		require.NotEmpty(t, bt.bplus.mx[i].key)
+	}
 }
 
 func TestAggregatorV3_PruneSmallBatches(t *testing.T) {
@@ -1014,16 +1037,6 @@ func pivotKeysFromKV(dataPath string) ([][]byte, error) {
 func generateKV(tb testing.TB, tmp string, keySize, valueSize, keyCount int, logger log.Logger, compressFlags FileCompression) string {
 	tb.Helper()
 
-	args := BtIndexWriterArgs{
-		IndexFile: path.Join(tmp, fmt.Sprintf("%dk.bt", keyCount/1000)),
-		TmpDir:    tmp,
-		KeyCount:  12,
-	}
-
-	iw, err := NewBtIndexWriter(args, logger)
-	require.NoError(tb, err)
-
-	defer iw.Close()
 	rnd := rand.New(rand.NewSource(0))
 	values := make([]byte, valueSize)
 
@@ -1072,29 +1085,15 @@ func generateKV(tb testing.TB, tmp string, keySize, valueSize, keyCount int, log
 
 	decomp, err := seg.NewDecompressor(dataPath)
 	require.NoError(tb, err)
+	defer decomp.Close()
+	compPath := decomp.FilePath()
+	ps := background.NewProgressSet()
 
-	getter := NewArchiveGetter(decomp.MakeGetter(), compressFlags)
-	getter.Reset(0)
+	IndexFile := path.Join(tmp, fmt.Sprintf("%dk.bt", keyCount/1000))
+	err = BuildBtreeIndexWithDecompressor(IndexFile, decomp, compressFlags, ps, tb.TempDir(), 777, logger, true)
+	require.NoError(tb, err)
 
-	var pos uint64
-	key := make([]byte, keySize)
-	for i := 0; i < keyCount; i++ {
-		if !getter.HasNext() {
-			tb.Fatalf("not enough values at %d", i)
-		}
-
-		keys, _ := getter.Next(key[:0])
-		err = iw.AddKey(keys[:], pos)
-
-		pos, _ = getter.Skip()
-		require.NoError(tb, err)
-	}
-	decomp.Close()
-
-	require.NoError(tb, iw.Build())
-	iw.Close()
-
-	return decomp.FilePath()
+	return compPath
 }
 
 func testDbAndAggregatorv3(t *testing.T, aggStep uint64) (kv.RwDB, *Aggregator) {

--- a/erigon-lib/state/aggregator_test.go
+++ b/erigon-lib/state/aggregator_test.go
@@ -414,7 +414,7 @@ func aggregatorV3_RestartOnDatadir(t *testing.T, rc runCfg) {
 }
 
 func TestNewBtIndex(t *testing.T) {
-	keyCount := 1000
+	keyCount := 10000
 	kvPath := generateKV(t, t.TempDir(), 20, 10, keyCount, log.New(), CompressNone)
 
 	indexPath := strings.TrimSuffix(kvPath, ".kv") + ".bt"

--- a/erigon-lib/state/aggregator_test.go
+++ b/erigon-lib/state/aggregator_test.go
@@ -419,7 +419,7 @@ func TestNewBtIndex(t *testing.T) {
 
 	indexPath := strings.TrimSuffix(kvPath, ".kv") + ".bt"
 
-	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, kvPath, uint64(DefaultBtreeM), CompressNone, false)
+	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, kvPath, DefaultBtreeM, CompressNone, false)
 	require.NoError(t, err)
 	defer bt.Close()
 	defer kv.Close()

--- a/erigon-lib/state/bps_tree.go
+++ b/erigon-lib/state/bps_tree.go
@@ -170,7 +170,7 @@ type Node struct {
 
 func encodeListNodes(nodes []Node, w io.Writer) error {
 	numBuf := make([]byte, 8)
-	binary.BigEndian.PutUint64(numBuf[:], uint64(len(nodes)))
+	binary.BigEndian.PutUint64(numBuf, uint64(len(nodes)))
 	if _, err := w.Write(numBuf); err != nil {
 		return err
 	}

--- a/erigon-lib/state/bps_tree.go
+++ b/erigon-lib/state/bps_tree.go
@@ -18,8 +18,11 @@ package state
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"github.com/erigontech/erigon-lib/common/dbg"
+	"io"
 	"time"
 	"unsafe"
 
@@ -54,6 +57,37 @@ func NewBpsTree(kv ArchiveGetter, offt *eliasfano32.EliasFano, M uint64, dataLoo
 	if err := bt.WarmUp(kv); err != nil {
 		panic(err)
 	}
+	return bt
+}
+
+// "assert key behind offset == to stored key in bt"
+var envAssertBTKeys = dbg.EnvBool("BT_ASSERT_OFFSETS", false)
+
+func NewBpsTreeWithNodes(kv ArchiveGetter, offt *eliasfano32.EliasFano, M uint64, dataLookup dataLookupFunc, keyCmp keyCmpFunc, nodes []Node) *BpsTree {
+	bt := &BpsTree{M: M, offt: offt, dataLookupFunc: dataLookup, keyCmpFunc: keyCmp, mx: nodes}
+
+	t := time.Now()
+	nsz := uint64(unsafe.Sizeof(Node{}))
+	var cachedBytes uint64
+	for i := 0; i < len(nodes); i++ {
+		if envAssertBTKeys {
+			eq, r, err := keyCmp(nodes[i].key, nodes[i].di, kv)
+			if err != nil {
+				panic(err)
+			}
+			if eq != 0 {
+				panic(fmt.Errorf("key mismatch %x %x %d %d", nodes[i].key, r, nodes[i].di, i))
+			}
+		}
+		cachedBytes += nsz + uint64(len(nodes[i].key))
+		nodes[i].off = offt.Get(nodes[i].di)
+	}
+
+	N := offt.Count()
+	log.Root().Debug("BtIndex opened", "file", kv.FileName(), "M", bt.M, "N", common.PrettyCounter(N),
+		"cached", fmt.Sprintf("%s %.2f%%", common.PrettyCounter(len(bt.mx)), 100*(float64(len(bt.mx))/float64(N))),
+		"cacheSize", datasize.ByteSize(cachedBytes).HR(), "fileSize", datasize.ByteSize(kv.Size()).HR(),
+		"took", time.Since(t))
 	return bt
 }
 
@@ -134,6 +168,57 @@ type Node struct {
 	di  uint64 // key ordinal number in kv
 }
 
+func encodeListNodes(nodes []Node, w io.Writer) error {
+	numBuf := make([]byte, 8)
+	binary.BigEndian.PutUint64(numBuf[:], uint64(len(nodes)))
+	if _, err := w.Write(numBuf); err != nil {
+		return err
+	}
+
+	for ni := 0; ni < len(nodes); ni++ {
+		if _, err := w.Write(nodes[ni].Encode()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func decodeListNodes(data []byte) ([]Node, error) {
+	count := binary.BigEndian.Uint64(data[:8])
+	nodes := make([]Node, count)
+	pos := 8
+	for ni := 0; ni < int(count); ni++ {
+		dp, err := (&nodes[ni]).Decode(data[pos:])
+		if err != nil {
+			return nil, fmt.Errorf("decode node %d: %w", ni, err)
+		}
+		pos += int(dp)
+	}
+	return nodes, nil
+}
+
+func (n Node) Encode() []byte {
+	buf := make([]byte, 8+2+len(n.key))
+	binary.BigEndian.PutUint64(buf[:8], n.di)
+	binary.BigEndian.PutUint16(buf[8:10], uint16(len(n.key)))
+	copy(buf[10:], n.key)
+	return buf
+}
+
+func (n *Node) Decode(buf []byte) (uint64, error) {
+	if len(buf) < 10 {
+		return 0, errors.New("short buffer (less than 10b)")
+	}
+	n.di = binary.BigEndian.Uint64(buf[:8])
+	l := int(binary.BigEndian.Uint16(buf[8:10]))
+	if len(buf) < 10+l {
+		return 0, errors.New("short buffer")
+	}
+	n.key = buf[10 : 10+l]
+	//madvise(k, len(k), MADV_WILL_NEED)
+	return uint64(10 + l), nil
+}
+
 func (b *BpsTree) WarmUp(kv ArchiveGetter) error {
 	t := time.Now()
 	N := b.offt.Count()
@@ -163,8 +248,8 @@ func (b *BpsTree) WarmUp(kv ArchiveGetter) error {
 		cachedBytes += nsz + uint64(len(key))
 	}
 
-	log.Root().Debug("WarmUp finished", "file", kv.FileName(), "M", b.M, "N", N,
-		"cached", fmt.Sprintf("%d %%%.5f", len(b.mx), float64(len(b.mx))/float64(N)*100),
+	log.Root().Debug("WarmUp finished", "file", kv.FileName(), "M", b.M, "N", common.PrettyCounter(N),
+		"cached", fmt.Sprintf("%d %.2f%%", len(b.mx), 100*(float64(len(b.mx))/float64(N)*100)),
 		"cacheSize", datasize.ByteSize(cachedBytes).HR(), "fileSize", datasize.ByteSize(kv.Size()).HR(),
 		"took", time.Since(t))
 	return nil

--- a/erigon-lib/state/btree_index.go
+++ b/erigon-lib/state/btree_index.go
@@ -876,12 +876,16 @@ func OpenBtreeIndexWithDecompressor(indexPath string, M uint64, kv *seg.Decompre
 	//fmt.Printf("open btree index %s with %d keys b+=%t data compressed %t\n", indexPath, idx.ef.Count(), UseBpsTree, idx.compressed)
 	switch UseBpsTree {
 	case true:
-		nodes, err := decodeListNodes(idx.data[pos:])
-		if err != nil {
-			return nil, err
+		if len(idx.data[pos:]) == 0 {
+			idx.bplus = NewBpsTree(kvGetter, idx.ef, M, idx.dataLookup, idx.keyCmp)
+			// fallback for files without nodes encoded
+		} else {
+			nodes, err := decodeListNodes(idx.data[pos:])
+			if err != nil {
+				return nil, err
+			}
+			idx.bplus = NewBpsTreeWithNodes(kvGetter, idx.ef, M, idx.dataLookup, idx.keyCmp, nodes)
 		}
-		//idx.bplus = NewBpsTree(kvGetter, idx.ef, M, idx.dataLookup, idx.keyCmp)
-		idx.bplus = NewBpsTreeWithNodes(kvGetter, idx.ef, M, idx.dataLookup, idx.keyCmp, nodes)
 	default:
 		idx.alloc = newBtAlloc(idx.ef.Count(), M, false, idx.dataLookup, idx.keyCmp)
 		if idx.alloc != nil {


### PR DESCRIPTION
+ reduces amount of memory required to built .bt index - previously we put key into collector, now we put key into collector only if it's meant to be cached. 
+ In file, list of nodes is presented as `uint64 (len Nodes) + [uint64(di), uint16(lenKey), key], [...]`. All numbers are encoded in big-endian notion. So 11 bytes min for each node (8 di + 2 length + at least 1 byte key)

During .bt file opening, nodes are decoded and enriched with correct offset from `elias-fano.Get(di)`. No reads from kv file made on start.

Now M is also a parameter of `BtIndexWriter`