### PR TITLE
Know cfg new more optimized strings.split

### DIFF
--- a/erigon-lib/chain/snapcfg/util.go
+++ b/erigon-lib/chain/snapcfg/util.go
@@ -228,15 +228,14 @@ func (p Preverified) Versioned(preferredVersion snaptype.Version, minVersion sna
 
 func (p Preverified) MaxBlock(version snaptype.Version) (uint64, error) {
 	max := uint64(0)
-	var ext, fileName string
 	for _, p := range p {
-		_, fileName = filepath.Split(p.Name)
-		ext = filepath.Ext(fileName)
+		_, fileName := filepath.Split(p.Name)
+		ext := filepath.Ext(fileName)
 		if ext != ".seg" {
 			continue
 		}
 
-		to, err := NameToParts(fileName[:len(fileName)-len(ext)], version)
+		to, err := ExtractBlockFromName(fileName[:len(fileName)-len(ext)], version)
 		if err != nil {
 			if errors.Is(err, errWrongVersion) {
 				continue
@@ -258,7 +257,7 @@ func (p Preverified) MaxBlock(version snaptype.Version) (uint64, error) {
 
 var errWrongVersion = errors.New("wrong version")
 
-func NameToParts(name string, v snaptype.Version) (block uint64, err error) {
+func ExtractBlockFromName(name string, v snaptype.Version) (block uint64, err error) {
 	i := 0
 	for i < len(name) && name[i] != '-' {
 		i++

--- a/erigon-lib/chain/snapcfg/util.go
+++ b/erigon-lib/chain/snapcfg/util.go
@@ -433,10 +433,6 @@ func Seedable(networkName string, info snaptype.FileInfo) bool {
 	return KnownCfg(networkName).Seedable(info)
 }
 
-func MergeLimit(networkName string, snapType snaptype.Enum, fromBlock uint64) uint64 {
-	return KnownCfg(networkName).MergeLimit(snapType, fromBlock)
-}
-
 func MergeLimitFromCfg(cfg *Cfg, snapType snaptype.Enum, fromBlock uint64) uint64 {
 	return cfg.MergeLimit(snapType, fromBlock)
 }

--- a/erigon-lib/chain/snapcfg/util.go
+++ b/erigon-lib/chain/snapcfg/util.go
@@ -94,15 +94,28 @@ func (p Preverified) Typed(types []snaptype.Type) Preverified {
 
 		var preferredVersion, minVersion snaptype.Version
 
-		parts := strings.Split(name, "-")
-		if len(parts) < 3 {
+		countSep := 0
+		var lastSep, dot int
+		for i := range name {
+			if name[i] == '-' {
+				countSep++
+				lastSep = i
+			}
+			if name[i] == '.' {
+				dot = i
+			}
+		}
+
+		if countSep < 2 {
 			if strings.HasPrefix(p.Name, "domain") || strings.HasPrefix(p.Name, "history") || strings.HasPrefix(p.Name, "idx") || strings.HasPrefix(p.Name, "accessor") {
 				bestVersions.Set(p.Name, p)
 				continue
 			}
 			continue
 		}
-		typeName, _ := strings.CutSuffix(parts[2], filepath.Ext(parts[2]))
+
+		//typeName, _ := strings.CutSuffix(parts[2], filepath.Ext(parts[2]))
+		typeName := name[lastSep+1 : dot]
 		include := false
 
 		for _, typ := range types {

--- a/erigon-lib/chain/snapcfg/util.go
+++ b/erigon-lib/chain/snapcfg/util.go
@@ -437,6 +437,10 @@ func MergeLimit(networkName string, snapType snaptype.Enum, fromBlock uint64) ui
 	return KnownCfg(networkName).MergeLimit(snapType, fromBlock)
 }
 
+func MergeLimitFromCfg(cfg *Cfg, snapType snaptype.Enum, fromBlock uint64) uint64 {
+	return cfg.MergeLimit(snapType, fromBlock)
+}
+
 func MaxSeedableSegment(chain string, dir string) uint64 {
 	var max uint64
 
@@ -453,8 +457,8 @@ func MaxSeedableSegment(chain string, dir string) uint64 {
 
 var oldMergeSteps = append([]uint64{snaptype.Erigon2OldMergeLimit}, snaptype.MergeSteps...)
 
-func MergeSteps(networkName string, snapType snaptype.Enum, fromBlock uint64) []uint64 {
-	mergeLimit := MergeLimit(networkName, snapType, fromBlock)
+func MergeStepsFromCfg(cfg *Cfg, snapType snaptype.Enum, fromBlock uint64) []uint64 {
+	mergeLimit := MergeLimitFromCfg(cfg, snapType, fromBlock)
 
 	if mergeLimit == snaptype.Erigon2OldMergeLimit {
 		return oldMergeSteps

--- a/erigon-lib/chain/snapcfg/util.go
+++ b/erigon-lib/chain/snapcfg/util.go
@@ -235,19 +235,6 @@ func (p Preverified) MaxBlock(version snaptype.Version) (uint64, error) {
 		if ext != ".seg" {
 			continue
 		}
-		//onlyName := fileName[:len(fileName)-len(ext)]
-		//parts := strings.Split(onlyName, "-")
-		//
-		//to, err := strconv.ParseUint(parts[2], 10, 64)
-		//if err != nil {
-		//	return 0, err
-		//}
-		//
-		//if version != 0 {
-		//	if v, err := snaptype.ParseVersion(parts[0]); err != nil || v != version {
-		//		continue
-		//	}
-		//}
 
 		to, err := NameToParts(fileName[:len(fileName)-len(ext)], version)
 		if err != nil {

--- a/erigon-lib/chain/snapcfg/util_test.go
+++ b/erigon-lib/chain/snapcfg/util_test.go
@@ -1,0 +1,86 @@
+package snapcfg
+
+import (
+	"github.com/erigontech/erigon-lib/downloader/snaptype"
+	"testing"
+)
+
+func TestNameToParts(t *testing.T) {
+	type args struct {
+		name string
+		v    snaptype.Version
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantBlock uint64
+		wantErr   bool
+	}{
+		{
+			"happy pass",
+			args{
+				name: "v1-asd-12-d",
+				v:    0,
+			},
+			12,
+			false,
+		},
+		{
+			"happy pass with version",
+			args{
+				name: "v2-asd-12-d",
+				v:    2,
+			},
+			12,
+			false,
+		},
+		{
+			"happy pass && block in the end",
+			args{
+				name: "v1-asd-12",
+				v:    0,
+			},
+			12,
+			false,
+		},
+		{
+			"version mismatch",
+			args{
+				name: "v1-asd-12",
+				v:    2,
+			},
+			0,
+			true,
+		},
+		{
+			"block parse error",
+			args{
+				name: "v1-asd-dd12",
+				v:    0,
+			},
+			0,
+			true,
+		},
+		{
+			"bad name",
+			args{
+				name: "v1-dd12",
+				v:    0,
+			},
+			0,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotBlock, err := NameToParts(tt.args.name, tt.args.v)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NameToParts() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotBlock != tt.wantBlock {
+				t.Errorf("NameToParts() gotBlock = %v, want %v", gotBlock, tt.wantBlock)
+			}
+		})
+	}
+}

--- a/erigon-lib/chain/snapcfg/util_test.go
+++ b/erigon-lib/chain/snapcfg/util_test.go
@@ -73,13 +73,13 @@ func TestNameToParts(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotBlock, err := NameToParts(tt.args.name, tt.args.v)
+			gotBlock, err := ExtractBlockFromName(tt.args.name, tt.args.v)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("NameToParts() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("ExtractBlockFromName() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if gotBlock != tt.wantBlock {
-				t.Errorf("NameToParts() gotBlock = %v, want %v", gotBlock, tt.wantBlock)
+				t.Errorf("ExtractBlockFromName() gotBlock = %v, want %v", gotBlock, tt.wantBlock)
 			}
 		})
 	}

--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -1223,7 +1223,7 @@ func chooseSegmentEnd(from, to uint64, snapType snaptype.Enum, chainConfig *chai
 	if chainConfig != nil {
 		chainName = chainConfig.ChainName
 	}
-	blocksPerFile := snapcfg.MergeLimit(chainName, snapType, from)
+	blocksPerFile := snapcfg.MergeLimitFromCfg(snapcfg.KnownCfg(chainName), snapType, from)
 
 	next := (from/blocksPerFile + 1) * blocksPerFile
 	to = min(next, to)
@@ -1322,7 +1322,7 @@ func canRetire(from, to uint64, snapType snaptype.Enum, chainConfig *chain.Confi
 		chainName = chainConfig.ChainName
 	}
 
-	mergeLimit := snapcfg.MergeLimit(chainName, snapType, blockFrom)
+	mergeLimit := snapcfg.MergeLimitFromCfg(snapcfg.KnownCfg(chainName), snapType, blockFrom)
 
 	if blockFrom%mergeLimit == 0 {
 		maxJump = mergeLimit

--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -2040,13 +2040,14 @@ func NewMerger(tmpDir string, compressWorkers int, lvl log.Lvl, chainDB kv.RoDB,
 func (m *Merger) DisableFsync() { m.noFsync = true }
 
 func (m *Merger) FindMergeRanges(currentRanges []Range, maxBlockNum uint64) (toMerge []Range) {
+	cfg := snapcfg.KnownCfg(m.chainConfig.ChainName)
 	for i := len(currentRanges) - 1; i > 0; i-- {
 		r := currentRanges[i]
-		mergeLimit := snapcfg.MergeLimit(m.chainConfig.ChainName, snaptype.Unknown, r.from)
+		mergeLimit := snapcfg.MergeLimitFromCfg(cfg, snaptype.Unknown, r.from)
 		if r.to-r.from >= mergeLimit {
 			continue
 		}
-		for _, span := range snapcfg.MergeSteps(m.chainConfig.ChainName, snaptype.Unknown, r.from) {
+		for _, span := range snapcfg.MergeStepsFromCfg(cfg, snaptype.Unknown, r.from) {
 			if r.to%span != 0 {
 				continue
 			}

--- a/turbo/snapshotsync/freezeblocks/block_snapshots_test.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots_test.go
@@ -81,6 +81,67 @@ func createTestSegmentFile(t *testing.T, from, to uint64, name snaptype.Enum, di
 	}
 }
 
+func BenchmarkFindMergeRange(t *testing.B) {
+	merger := NewMerger("x", 1, log.LvlInfo, nil, params.MainnetChainConfig, nil)
+	merger.DisableFsync()
+	t.Run("big", func(t *testing.B) {
+		for j := 0; j < t.N; j++ {
+			var rangesOld []Range
+			for i := 0; i < 24; i++ {
+				rangesOld = append(rangesOld, Range{from: uint64(i * 100_000), to: uint64((i + 1) * 100_000)})
+			}
+			found := merger.FindMergeRanges(rangesOld, uint64(24*100_000))
+
+			expect := Ranges{{0, 500000}, {500000, 1000000}, {1000000, 1500000}, {1500000, 2000000}}
+			require.Equal(t, expect.String(), Ranges(found).String())
+
+			var rangesNew []Range
+			start := uint64(19_000_000)
+			for i := uint64(0); i < 24; i++ {
+				rangesNew = append(rangesNew, Range{from: start + (i * 100_000), to: start + ((i + 1) * 100_000)})
+			}
+			found = merger.FindMergeRanges(rangesNew, uint64(24*100_000))
+
+			expect = Ranges{}
+			require.Equal(t, expect.String(), Ranges(found).String())
+		}
+	})
+
+	t.Run("small", func(t *testing.B) {
+		for j := 0; j < t.N; j++ {
+			var rangesOld Ranges
+			for i := uint64(0); i < 240; i++ {
+				rangesOld = append(rangesOld, Range{from: i * 10_000, to: (i + 1) * 10_000})
+			}
+			found := merger.FindMergeRanges(rangesOld, uint64(240*10_000))
+			var expect Ranges
+			for i := uint64(0); i < 4; i++ {
+				expect = append(expect, Range{from: i * snaptype.Erigon2OldMergeLimit, to: (i + 1) * snaptype.Erigon2OldMergeLimit})
+			}
+			for i := uint64(0); i < 4; i++ {
+				expect = append(expect, Range{from: 2_000_000 + i*snaptype.Erigon2MergeLimit, to: 2_000_000 + (i+1)*snaptype.Erigon2MergeLimit})
+			}
+
+			require.Equal(t, expect.String(), Ranges(found).String())
+
+			var rangesNew Ranges
+			start := uint64(19_000_000)
+			for i := uint64(0); i < 240; i++ {
+				rangesNew = append(rangesNew, Range{from: start + i*10_000, to: start + (i+1)*10_000})
+			}
+			found = merger.FindMergeRanges(rangesNew, uint64(240*10_000))
+			expect = nil
+			for i := uint64(0); i < 24; i++ {
+				expect = append(expect, Range{from: start + i*snaptype.Erigon2MergeLimit, to: start + (i+1)*snaptype.Erigon2MergeLimit})
+			}
+
+			require.Equal(t, expect.String(), Ranges(found).String())
+		}
+
+	})
+
+}
+
 func TestFindMergeRange(t *testing.T) {
 	merger := NewMerger("x", 1, log.LvlInfo, nil, params.MainnetChainConfig, nil)
 	merger.DisableFsync()

--- a/turbo/snapshotsync/freezeblocks/caplin_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/caplin_snapshots.go
@@ -538,9 +538,9 @@ func dumpBlobSidecarsRange(ctx context.Context, db kv.RoDB, storage blob_storage
 }
 
 func DumpBeaconBlocks(ctx context.Context, db kv.RoDB, fromSlot, toSlot uint64, salt uint32, dirs datadir.Dirs, workers int, lvl log.Lvl, logger log.Logger) error {
-
+	cfg := snapcfg.KnownCfg("")
 	for i := fromSlot; i < toSlot; i = chooseSegmentEnd(i, toSlot, snaptype.CaplinEnums.BeaconBlocks, nil) {
-		blocksPerFile := snapcfg.MergeLimit("", snaptype.CaplinEnums.BeaconBlocks, i)
+		blocksPerFile := snapcfg.MergeLimitFromCfg(cfg, snaptype.CaplinEnums.BeaconBlocks, i)
 
 		if toSlot-i < blocksPerFile {
 			break
@@ -555,8 +555,9 @@ func DumpBeaconBlocks(ctx context.Context, db kv.RoDB, fromSlot, toSlot uint64, 
 }
 
 func DumpBlobsSidecar(ctx context.Context, blobStorage blob_storage.BlobStorage, db kv.RoDB, fromSlot, toSlot uint64, salt uint32, dirs datadir.Dirs, compressWorkers int, lvl log.Lvl, logger log.Logger) error {
+	cfg := snapcfg.KnownCfg("")
 	for i := fromSlot; i < toSlot; i = chooseSegmentEnd(i, toSlot, snaptype.CaplinEnums.BlobSidecars, nil) {
-		blocksPerFile := snapcfg.MergeLimit("", snaptype.CaplinEnums.BlobSidecars, i)
+		blocksPerFile := snapcfg.MergeLimitFromCfg(cfg, snaptype.CaplinEnums.BlobSidecars, i)
 
 		if toSlot-i < blocksPerFile {
 			break


### PR DESCRIPTION
closes #11653
```
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/turbo/snapshotsync/freezeblocks
cpu: Apple M3 Max
                        │   old.txt    │               new.txt               │
                        │    sec/op    │   sec/op     vs base                │
FindMergeRange/big        10.846m ± 1%   3.373m ± 4%  -68.90% (p=0.000 n=10)
FindMergeRange/big-16      7.673m ± 0%   2.879m ± 1%  -62.48% (p=0.000 n=10)
FindMergeRange/small      19.516m ± 1%   6.684m ± 1%  -65.75% (p=0.000 n=10)
FindMergeRange/small-16   14.212m ± 0%   5.985m ± 1%  -57.89% (p=0.000 n=10)
geomean                    12.33m        4.439m       -63.98%

                        │    old.txt    │               new.txt                │
                        │     B/op      │     B/op      vs base                │
FindMergeRange/big         7.819Mi ± 0%   1.712Mi ± 0%  -78.11% (p=0.000 n=10)
FindMergeRange/big-16      7.833Mi ± 0%   1.717Mi ± 0%  -78.08% (p=0.000 n=10)
FindMergeRange/small      13.837Mi ± 0%   3.379Mi ± 0%  -75.58% (p=0.000 n=10)
FindMergeRange/small-16   13.855Mi ± 0%   3.391Mi ± 0%  -75.52% (p=0.000 n=10)
geomean                    10.41Mi        2.409Mi       -76.86%

                        │   old.txt    │               new.txt               │
                        │  allocs/op   │  allocs/op   vs base                │
FindMergeRange/big         59.38k ± 0%   22.72k ± 0%  -61.73% (p=0.000 n=10)
FindMergeRange/big-16      59.38k ± 0%   22.72k ± 0%  -61.73% (p=0.000 n=10)
FindMergeRange/small      110.32k ± 0%   48.49k ± 0%  -56.04% (p=0.000 n=10)
FindMergeRange/small-16   110.33k ± 0%   48.50k ± 0%  -56.04% (p=0.000 n=10)
geomean                    80.94k        33.20k       -58.99%
```