### PR TITLE
Fix bor-heimdall stall after chaindb removal

### DIFF
--- a/eth/stagedsync/bor_heimdall_shared.go
+++ b/eth/stagedsync/bor_heimdall_shared.go
@@ -525,7 +525,7 @@ func fetchAndWriteHeimdallStateSyncEvents(
 	}
 
 	if lastEventRecord != nil {
-		logger.Info("putting state sync events", "blockNum", blockNum, "lastID", lastEventRecord.ID)
+		logger.Debug("putting state sync events", "blockNum", blockNum, "lastID", lastEventRecord.ID)
 
 		var blockNumBuf [8]byte
 		binary.BigEndian.PutUint64(blockNumBuf[:], blockNum)

--- a/eth/stagedsync/stage_bor_heimdall.go
+++ b/eth/stagedsync/stage_bor_heimdall.go
@@ -296,6 +296,11 @@ func BorHeimdallForward(
 				return err
 			}
 
+			// this will happen if for example chaindb is removed
+			if lastPersistedBlockNum > blockNum {
+				lastPersistedBlockNum = blockNum
+			}
+
 			// if the last time we persisted snapshots is too far away re-run the forward
 			// initialization process - this is to avoid memory growth due to recusrion
 			// in persistValidatorSets


### PR DESCRIPTION
This adds an overflow check to stop bor-heimdall failing to initialize after chain db has been removed