### PR TITLE
Don't validate skipped events

### DIFF
--- a/eth/stagedsync/bor_heimdall_shared.go
+++ b/eth/stagedsync/bor_heimdall_shared.go
@@ -469,8 +469,8 @@ func fetchAndWriteHeimdallStateSyncEvents(
 
 	if config.OverrideStateSyncRecords != nil {
 		if val, ok := config.OverrideStateSyncRecords[strconv.FormatUint(blockNum, 10)]; ok {
-			eventRecords = eventRecords[0:val]
 			overrideCount = len(eventRecords) - val
+			eventRecords = eventRecords[0:val]
 			fmt.Println("OVR", overrideCount, "LEN", len(eventRecords))
 		}
 	}

--- a/eth/stagedsync/bor_heimdall_shared.go
+++ b/eth/stagedsync/bor_heimdall_shared.go
@@ -465,13 +465,10 @@ func fetchAndWriteHeimdallStateSyncEvents(
 
 	var overrideCount int
 
-	fmt.Println("BLK", blockNum, "FROM ID", fromId, "FROM", from, "TO", to, "LEN", len(eventRecords), "SC", skipCount)
-
 	if config.OverrideStateSyncRecords != nil {
 		if val, ok := config.OverrideStateSyncRecords[strconv.FormatUint(blockNum, 10)]; ok {
 			overrideCount = len(eventRecords) - val
 			eventRecords = eventRecords[0:val]
-			fmt.Println("OVR", overrideCount, "LEN", len(eventRecords))
 		}
 	}
 
@@ -497,8 +494,6 @@ func fetchAndWriteHeimdallStateSyncEvents(
 
 			return initialTime.After(from)
 		}
-
-		fmt.Println("EV", i, eventRecord.ID, eventRecord.Time, "SC", skipCount)
 
 		// don't apply this for devnets we may have looser state event constraints
 		// (TODO these probably needs fixing)

--- a/eth/stagedsync/bor_heimdall_shared.go
+++ b/eth/stagedsync/bor_heimdall_shared.go
@@ -465,7 +465,7 @@ func fetchAndWriteHeimdallStateSyncEvents(
 
 	var overrideCount int
 
-	fmt.Println("BLK", blockNum, "FROM ID", fromId, "FROM", from, "TO", to, "LEN", len(eventRecords))
+	fmt.Println("BLK", blockNum, "FROM ID", fromId, "FROM", from, "TO", to, "LEN", len(eventRecords), "SC", skipCount)
 
 	if config.OverrideStateSyncRecords != nil {
 		if val, ok := config.OverrideStateSyncRecords[strconv.FormatUint(blockNum, 10)]; ok {
@@ -517,17 +517,15 @@ func fetchAndWriteHeimdallStateSyncEvents(
 			}
 		}
 
-		skipCount += overrideCount
-
 		data, err := eventRecord.MarshallBytes()
 		if err != nil {
 			logger.Error(fmt.Sprintf("[%s] Unable to pack txn for commitState", logPrefix), "err", err)
-			return lastStateSyncEventID, i, skipCount, time.Since(fetchStart), err
+			return lastStateSyncEventID, i, skipCount + overrideCount, time.Since(fetchStart), err
 		}
 
 		eventIdBytes := eventRecord.MarshallIdBytes()
 		if err = tx.Put(kv.BorEvents, eventIdBytes, data); err != nil {
-			return lastStateSyncEventID, i, skipCount, time.Since(fetchStart), err
+			return lastStateSyncEventID, i, skipCount + overrideCount, time.Since(fetchStart), err
 		}
 
 		if initialRecordTime == nil {
@@ -538,6 +536,8 @@ func fetchAndWriteHeimdallStateSyncEvents(
 		lastStateSyncEventID++
 		lastEventRecord = eventRecord
 	}
+
+	skipCount += overrideCount
 
 	if lastEventRecord != nil {
 		logger.Info("putting state sync events", "blockNum", blockNum, "lastID", lastEventRecord.ID)

--- a/eth/stagedsync/stage_bor_heimdall.go
+++ b/eth/stagedsync/stage_bor_heimdall.go
@@ -233,9 +233,9 @@ func BorHeimdallForward(
 
 	// sometimes via config eveents are skipped from particular blocks and
 	// pushed into the next one, when this happens we need to skip validation
-	// as the times won't match the expected window. In practice it only affects 
+	// as the times won't match the expected window. In practice it only affects
 	// these blocks: 14949120,14949184, 14953472, 14953536, 14953600, 14953664,
-	// 14953728, 14953792, 14953856 so it seems keeping a local skip marker is good 
+	// 14953728, 14953792, 14953856 so it seems keeping a local skip marker is good
 	// enough - it will only impact sync from origin operations.  If
 	// this becomes more prevalent this will need to be re-thought
 	var skipCount int
@@ -295,6 +295,7 @@ func BorHeimdallForward(
 
 		if cfg.blockReader.BorSnapshots().SegmentsMin() == 0 {
 			snapTime = snapTime + time.Since(snapStart)
+			// SegmentsMin is only set if running as an uploader process (check SnapshotsCfg.snapshotUploader and
 			// SegmentsMin is only set if running as an uploader process (check SnapshotsCfg.snapshotUploader and
 			// UploadLocationFlag) when we remove snapshots based on FrozenBlockLimit and number of uploaded snapshots
 			// avoid calling this if block for blockNums <= SegmentsMin to avoid reinsertion of snapshots

--- a/eth/stagedsync/stage_bor_heimdall.go
+++ b/eth/stagedsync/stage_bor_heimdall.go
@@ -231,6 +231,11 @@ func BorHeimdallForward(
 
 	var nextEventRecord *heimdall.EventRecordWithTime
 
+	// sometimes via config eveents are skipped from particular blocks and
+	// pushed into the next one, when this happens we need to skip validation
+	// as the times won't match the expected window
+	var skipCount int
+
 	for blockNum = lastBlockNum + 1; blockNum <= headNumber; blockNum++ {
 		select {
 		default:
@@ -357,7 +362,7 @@ func BorHeimdallForward(
 			var records int
 
 			if lastStateSyncEventID == 0 || lastStateSyncEventID != endStateSyncEventId {
-				lastStateSyncEventID, records, callTime, err = fetchRequiredHeimdallStateSyncEventsIfNeeded(
+				lastStateSyncEventID, records, skipCount, callTime, err = fetchRequiredHeimdallStateSyncEventsIfNeeded(
 					ctx,
 					header,
 					tx,
@@ -368,6 +373,7 @@ func BorHeimdallForward(
 					s.LogPrefix(),
 					logger,
 					lastStateSyncEventID,
+					skipCount,
 				)
 
 				if err != nil {

--- a/eth/stagedsync/stage_bor_heimdall.go
+++ b/eth/stagedsync/stage_bor_heimdall.go
@@ -233,7 +233,11 @@ func BorHeimdallForward(
 
 	// sometimes via config eveents are skipped from particular blocks and
 	// pushed into the next one, when this happens we need to skip validation
-	// as the times won't match the expected window
+	// as the times won't match the expected window. In practice it only affects 
+	// these blocks: 14949120,14949184, 14953472, 14953536, 14953600, 14953664,
+	// 14953728, 14953792, 14953856 so it seems keeping a local skip marker is good 
+	// enough - it will only impact sync from origin operations.  If
+	// this becomes more prevalent this will need to be re-thought
 	var skipCount int
 
 	for blockNum = lastBlockNum + 1; blockNum <= headNumber; blockNum++ {

--- a/eth/stagedsync/stage_mining_bor_heimdall.go
+++ b/eth/stagedsync/stage_mining_bor_heimdall.go
@@ -81,7 +81,7 @@ func MiningBorHeimdallForward(
 		return err
 	}
 
-	lastStateSyncEventID, records, fetchTime, err := fetchRequiredHeimdallStateSyncEventsIfNeeded(
+	lastStateSyncEventID, records, _, fetchTime, err := fetchRequiredHeimdallStateSyncEventsIfNeeded(
 		ctx,
 		header,
 		tx,
@@ -92,6 +92,7 @@ func MiningBorHeimdallForward(
 		logPrefix,
 		logger,
 		lastStateSyncEventID,
+		0,
 	)
 
 	if err != nil {


### PR DESCRIPTION
Sometimes via config events are skipped from particular blocks and
pushed into the next one, when this happens we need to skip validation
as the times won't match the expected window. 

In practice it only affects these blocks: 
  14949120,14949184, 14953472, 14953536, 14953600, 14953664,
  14953728, 14953792, 14953856 

So it seems keeping a local skip marker is good enough - it will only impact sync from origin operations.  If
this becomes more prevalent this will need to be re-thought