### PR TITLE
Caplin: Fixed caplin parent root indexing

### DIFF
--- a/erigon-lib/kv/tables.go
+++ b/erigon-lib/kv/tables.go
@@ -424,7 +424,8 @@ const (
 	BlockRootToKzgCommitments = "BlockRootToKzgCommitments"
 
 	// [Block Root] => [Parent Root]
-	BlockRootToParentRoot = "BlockRootToParentRoot"
+	BlockRootToParentRoot  = "BlockRootToParentRoot"
+	ParentRootToBlockRoots = "ParentRootToBlockRoots"
 
 	HighestFinalized = "HighestFinalized" // hash -> transaction/receipt lookup metadata
 
@@ -598,6 +599,7 @@ var ChaindataTables = []string{
 	BlockRootToBlockHash,
 	BlockRootToBlockNumber,
 	LastBeaconSnapshot,
+	ParentRootToBlockRoots,
 	// Blob Storage
 	BlockRootToKzgCommitments,
 	// State Reconstitution


### PR DESCRIPTION
So we need to get block roots that have a specific parent roots: there needs to be many

So added new table to indexing DB: parentRoot => list of block roots
Then I fixed the REST API with this new index