### PR TITLE
Caplin: Fixed `History Download` CPU usage

### DIFF
--- a/cl/phase1/network/backward_beacon_downloader.go
+++ b/cl/phase1/network/backward_beacon_downloader.go
@@ -243,6 +243,7 @@ Loop:
 			break
 		}
 
+		fmt.Println("checking3", *slot, clFrozenBlocks, elFrozenBlocks)
 		if b.engine != nil && b.engine.SupportInsertion() {
 			blockHash, err := beacon_indicies.ReadExecutionBlockHash(tx, b.expectedRoot)
 			if err != nil {
@@ -269,6 +270,7 @@ Loop:
 			}
 		}
 		if *slot <= clFrozenBlocks {
+			fmt.Println("checking4", clFrozenBlocks, elFrozenBlocks)
 			break
 		}
 		b.slotToDownload.Store(*slot - 1)

--- a/cl/phase1/network/backward_beacon_downloader.go
+++ b/cl/phase1/network/backward_beacon_downloader.go
@@ -219,7 +219,8 @@ Loop:
 			if err != nil {
 				return err
 			}
-			if blockHash != (libcommon.Hash{}) {
+			frozenBlocks := b.engine.FrozenBlocks(ctx)
+			if blockHash != (libcommon.Hash{}) && *slot >= frozenBlocks {
 				has, err := b.engine.HasBlock(ctx, blockHash)
 				if err != nil {
 					return err

--- a/cl/phase1/network/backward_beacon_downloader.go
+++ b/cl/phase1/network/backward_beacon_downloader.go
@@ -17,6 +17,7 @@
 package network
 
 import (
+	"math"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -33,6 +34,7 @@ import (
 	"github.com/erigontech/erigon/cl/persistence/beacon_indicies"
 	"github.com/erigontech/erigon/cl/phase1/execution_client"
 	"github.com/erigontech/erigon/cl/rpc"
+	"github.com/erigontech/erigon/turbo/snapshotsync/freezeblocks"
 )
 
 // Whether the reverse downloader arrived at expected height or condition.
@@ -48,12 +50,13 @@ type BackwardBeaconDownloader struct {
 	finished       atomic.Bool
 	reqInterval    *time.Ticker
 	db             kv.RwDB
+	sn             *freezeblocks.CaplinSnapshots
 	neverSkip      bool
 
 	mu sync.Mutex
 }
 
-func NewBackwardBeaconDownloader(ctx context.Context, rpc *rpc.BeaconRpcP2P, engine execution_client.ExecutionEngine, db kv.RwDB) *BackwardBeaconDownloader {
+func NewBackwardBeaconDownloader(ctx context.Context, rpc *rpc.BeaconRpcP2P, sn *freezeblocks.CaplinSnapshots, engine execution_client.ExecutionEngine, db kv.RwDB) *BackwardBeaconDownloader {
 	return &BackwardBeaconDownloader{
 		ctx:         ctx,
 		rpc:         rpc,
@@ -61,6 +64,7 @@ func NewBackwardBeaconDownloader(ctx context.Context, rpc *rpc.BeaconRpcP2P, eng
 		reqInterval: time.NewTicker(300 * time.Millisecond),
 		neverSkip:   true,
 		engine:      engine,
+		sn:          sn,
 	}
 }
 
@@ -202,16 +206,32 @@ Loop:
 		return err
 	}
 	defer tx.Rollback()
-	frozenBlocks := b.engine.FrozenBlocks(ctx)
+
+	elFrozenBlocks := uint64(math.MaxUint64)
+	if b.engine != nil && b.engine.SupportInsertion() {
+		elFrozenBlocks = b.engine.FrozenBlocks(ctx)
+	}
+	clFrozenBlocks := uint64(0)
+	if b.sn != nil {
+		clFrozenBlocks = b.sn.SegmentsMax()
+	}
 
 	updateFrozenBlocksTicker := time.NewTicker(5 * time.Second)
+	defer updateFrozenBlocksTicker.Stop()
 	// it will stop if we end finding a gap or if we reach the maxIterations
 	for {
+
 		select {
 		case <-updateFrozenBlocksTicker.C:
-			frozenBlocks = b.engine.FrozenBlocks(ctx)
+			if b.sn != nil {
+				clFrozenBlocks = b.sn.SegmentsMax()
+			}
+			if b.engine != nil && b.engine.SupportInsertion() {
+				elFrozenBlocks = b.engine.FrozenBlocks(ctx)
+			}
 		default:
 		}
+
 		// check if the expected root is in db
 		slot, err := beacon_indicies.ReadBlockSlotByBlockRoot(tx, b.expectedRoot)
 		if err != nil {
@@ -227,7 +247,7 @@ Loop:
 			if err != nil {
 				return err
 			}
-			if blockHash != (libcommon.Hash{}) && *slot >= frozenBlocks {
+			if blockHash != (libcommon.Hash{}) && *slot >= elFrozenBlocks {
 				has, err := b.engine.HasBlock(ctx, blockHash)
 				if err != nil {
 					return err
@@ -236,6 +256,9 @@ Loop:
 					break
 				}
 			}
+		}
+		if *slot < clFrozenBlocks {
+			break
 		}
 		b.slotToDownload.Store(*slot - 1)
 		if err := beacon_indicies.MarkRootCanonical(b.ctx, tx, *slot, b.expectedRoot); err != nil {

--- a/cl/phase1/network/backward_beacon_downloader.go
+++ b/cl/phase1/network/backward_beacon_downloader.go
@@ -17,7 +17,6 @@
 package network
 
 import (
-	"fmt"
 	"math"
 	"sync"
 	"sync/atomic"
@@ -243,7 +242,6 @@ Loop:
 			break
 		}
 
-		fmt.Println("checking3", *slot, clFrozenBlocks, elFrozenBlocks)
 		if b.engine != nil && b.engine.SupportInsertion() {
 			blockHash, err := beacon_indicies.ReadExecutionBlockHash(tx, b.expectedRoot)
 			if err != nil {
@@ -254,23 +252,19 @@ Loop:
 				return err
 			}
 			if blockHash == (libcommon.Hash{}) || blockNumber == nil {
-				fmt.Println("need brak")
 				break
 			}
-			fmt.Println("checking1", *blockNumber, elFrozenBlocks, blockHash)
 			if *blockNumber >= elFrozenBlocks {
 				has, err := b.engine.HasBlock(ctx, blockHash)
 				if err != nil {
 					return err
 				}
-				fmt.Println("chekcing2", *blockNumber, elFrozenBlocks, blockHash, has)
 				if !has {
 					break
 				}
 			}
 		}
 		if *slot <= clFrozenBlocks {
-			fmt.Println("checking4", clFrozenBlocks, elFrozenBlocks)
 			break
 		}
 		b.slotToDownload.Store(*slot - 1)

--- a/cl/phase1/network/backward_beacon_downloader.go
+++ b/cl/phase1/network/backward_beacon_downloader.go
@@ -251,7 +251,10 @@ Loop:
 			if err != nil {
 				return err
 			}
-			if blockHash != (libcommon.Hash{}) && blockNumber != nil && *blockNumber >= elFrozenBlocks {
+			if blockHash == (libcommon.Hash{}) || blockNumber == nil {
+				break
+			}
+			if *blockNumber >= elFrozenBlocks {
 				has, err := b.engine.HasBlock(ctx, blockHash)
 				if err != nil {
 					return err

--- a/cl/phase1/network/backward_beacon_downloader.go
+++ b/cl/phase1/network/backward_beacon_downloader.go
@@ -17,6 +17,7 @@
 package network
 
 import (
+	"fmt"
 	"math"
 	"sync"
 	"sync/atomic"
@@ -252,6 +253,7 @@ Loop:
 				return err
 			}
 			if blockHash == (libcommon.Hash{}) || blockNumber == nil {
+				fmt.Println("need brak")
 				break
 			}
 			if *blockNumber >= elFrozenBlocks {
@@ -259,6 +261,7 @@ Loop:
 				if err != nil {
 					return err
 				}
+				fmt.Println("chekcing", *blockNumber, elFrozenBlocks, blockHash, has)
 				if !has {
 					break
 				}

--- a/cl/phase1/network/backward_beacon_downloader.go
+++ b/cl/phase1/network/backward_beacon_downloader.go
@@ -256,12 +256,13 @@ Loop:
 				fmt.Println("need brak")
 				break
 			}
+			fmt.Println("checking1", *blockNumber, elFrozenBlocks, blockHash)
 			if *blockNumber >= elFrozenBlocks {
 				has, err := b.engine.HasBlock(ctx, blockHash)
 				if err != nil {
 					return err
 				}
-				fmt.Println("chekcing", *blockNumber, elFrozenBlocks, blockHash, has)
+				fmt.Println("chekcing2", *blockNumber, elFrozenBlocks, blockHash, has)
 				if !has {
 					break
 				}

--- a/cl/phase1/network/backward_beacon_downloader.go
+++ b/cl/phase1/network/backward_beacon_downloader.go
@@ -247,7 +247,11 @@ Loop:
 			if err != nil {
 				return err
 			}
-			if blockHash != (libcommon.Hash{}) && *slot >= elFrozenBlocks {
+			blockNumber, err := beacon_indicies.ReadExecutionBlockNumber(tx, b.expectedRoot)
+			if err != nil {
+				return err
+			}
+			if blockHash != (libcommon.Hash{}) && blockNumber != nil && *blockNumber >= elFrozenBlocks {
 				has, err := b.engine.HasBlock(ctx, blockHash)
 				if err != nil {
 					return err
@@ -257,7 +261,7 @@ Loop:
 				}
 			}
 		}
-		if *slot < clFrozenBlocks {
+		if *slot <= clFrozenBlocks {
 			break
 		}
 		b.slotToDownload.Store(*slot - 1)

--- a/cl/phase1/stages/clstages.go
+++ b/cl/phase1/stages/clstages.go
@@ -252,7 +252,7 @@ func ConsensusClStages(ctx context.Context,
 					}
 
 					startingSlot := cfg.state.LatestBlockHeader().Slot
-					downloader := network2.NewBackwardBeaconDownloader(ctx, cfg.rpc, cfg.executionClient, cfg.indiciesDB)
+					downloader := network2.NewBackwardBeaconDownloader(ctx, cfg.rpc, cfg.sn, cfg.executionClient, cfg.indiciesDB)
 
 					if err := SpawnStageHistoryDownload(StageHistoryReconstruction(downloader, cfg.antiquary, cfg.sn, cfg.indiciesDB, cfg.executionClient, cfg.beaconCfg, cfg.backfilling, cfg.blobBackfilling, false, startingRoot, startingSlot, cfg.dirs.Tmp, 600*time.Millisecond, cfg.blockCollector, cfg.blockReader, cfg.blobStore, logger), context.Background(), logger); err != nil {
 						cfg.hasDownloaded = false

--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -157,7 +157,7 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 			}
 		}
 
-		if slot == 0 || isInCLSnapshots && isInElSnapshots {
+		if slot == 0 || (isInCLSnapshots && isInElSnapshots) {
 			return true, tx.Commit()
 		}
 		return (!cfg.backfilling || slot <= cfg.sn.SegmentsMax()) && (slot <= destinationSlotForEL || isInElSnapshots), tx.Commit()

--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -159,6 +159,7 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 		}
 
 		if slot == 0 || (isInCLSnapshots && isInElSnapshots) {
+			fmt.Println("slot", slot, "isInCLSnapshots", isInCLSnapshots, "isInElSnapshots", isInElSnapshots, "isInCLSnapshotsk", cfg.sn.SegmentsMax(), "isInElSnapshots", cfg.engine.FrozenBlocks(ctx))
 			return true, tx.Commit()
 		}
 		return (!cfg.backfilling || slot <= cfg.sn.SegmentsMax()) && (slot <= destinationSlotForEL || isInElSnapshots), tx.Commit()

--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -120,7 +120,8 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 		destinationSlotForCL := cfg.sn.SegmentsMax()
 
 		slot := blk.Block.Slot
-		if destinationSlotForCL <= blk.Block.Slot {
+		isInCLSnapshots := destinationSlotForCL > blk.Block.Slot
+		if !isInCLSnapshots {
 			if err := beacon_indicies.WriteBeaconBlockAndIndicies(ctx, tx, blk, true); err != nil {
 				return false, err
 			}
@@ -157,7 +158,8 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 				destinationSlotForEL = frozenBlocksInEL - 1
 			}
 		}
-		if slot == 0 {
+
+		if slot == 0 || isInCLSnapshots && isInElSnapshots {
 			return true, tx.Commit()
 		}
 		return (!cfg.backfilling || slot <= destinationSlotForCL) && (slot <= destinationSlotForEL || isInElSnapshots), tx.Commit()

--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -126,10 +126,15 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 			}
 		}
 		if cfg.engine != nil && cfg.engine.SupportInsertion() && blk.Version() >= clparams.BellatrixVersion {
+			frozenBlocksInEL := cfg.engine.FrozenBlocks(ctx)
+
 			payload := blk.Block.Body.ExecutionPayload
-			hasELBlock, err := cfg.engine.HasBlock(ctx, payload.BlockHash)
-			if err != nil {
-				return false, fmt.Errorf("error retrieving whether execution payload is present: %s", err)
+			hasELBlock := frozenBlocksInEL > blk.Block.Body.ExecutionPayload.BlockNumber
+			if !hasELBlock {
+				hasELBlock, err = cfg.engine.HasBlock(ctx, payload.BlockHash)
+				if err != nil {
+					return false, fmt.Errorf("error retrieving whether execution payload is present: %s", err)
+				}
 			}
 
 			if !hasELBlock {

--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -134,7 +134,6 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 				if err != nil {
 					return false, fmt.Errorf("error retrieving whether execution payload is present: %s", err)
 				}
-				fmt.Println("hasELBlock", payload.BlockNumber)
 			}
 
 			if !hasELBlock {
@@ -159,7 +158,6 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 		}
 
 		if slot == 0 || (isInCLSnapshots && isInElSnapshots) {
-			fmt.Println("slot", slot, "isInCLSnapshots", isInCLSnapshots, "isInElSnapshots", isInElSnapshots, "isInCLSnapshotsk", cfg.sn.SegmentsMax(), "isInElSnapshots", cfg.engine.FrozenBlocks(ctx))
 			return true, tx.Commit()
 		}
 		return (!cfg.backfilling || slot <= cfg.sn.SegmentsMax()) && (slot <= destinationSlotForEL || isInElSnapshots), tx.Commit()

--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -134,6 +134,7 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 				if err != nil {
 					return false, fmt.Errorf("error retrieving whether execution payload is present: %s", err)
 				}
+				fmt.Println("hasELBlock", payload.BlockNumber)
 			}
 
 			if !hasELBlock {

--- a/cmd/capcli/cli.go
+++ b/cmd/capcli/cli.go
@@ -175,7 +175,7 @@ func (c *Chain) Run(ctx *Context) error {
 		return err
 	}
 
-	downloader := network.NewBackwardBeaconDownloader(ctx, beacon, nil, db)
+	downloader := network.NewBackwardBeaconDownloader(ctx, beacon, nil, nil, db)
 	cfg := stages.StageHistoryReconstruction(downloader, antiquary.NewAntiquary(ctx, nil, nil, nil, nil, dirs, nil, nil, nil, nil, nil, false, false, false, nil), csn, db, nil, beaconConfig, true, false, true, bRoot, bs.Slot(), "/tmp", 300*time.Millisecond, nil, nil, blobStorage, log.Root())
 	return stages.SpawnStageHistoryDownload(cfg, ctx, log.Root())
 }


### PR DESCRIPTION
fixes: https://github.com/erigontech/erigon/issues/11704

Implemented early-stopping at snapshots and reduced CPU usage to 0 by reducing calls to `HasBlock` and `FrozenBlocks`.