### PR TITLE
Fix --torrent.staticpeers param

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -716,7 +716,7 @@ var (
 	}
 	TorrentStaticPeersFlag = cli.StringFlag{
 		Name:  "torrent.staticpeers",
-		Usage: "Comma separated enode URLs to connect to",
+		Usage: "Comma separated host:port to connect to",
 		Value: "",
 	}
 	NoDownloaderFlag = cli.BoolFlag{

--- a/erigon-lib/downloader/downloadercfg/downloadercfg.go
+++ b/erigon-lib/downloader/downloadercfg/downloadercfg.go
@@ -149,7 +149,7 @@ func New(dirs datadir.Dirs, version string, verbosity lg.Level, downloadRate, up
 				for _, seed := range staticPeers {
 					if network == "udp" {
 						var addr *net.UDPAddr
-						addr, err := net.ResolveUDPAddr(network, seed+":80")
+						addr, err := net.ResolveUDPAddr(network, seed)
 						if err != nil {
 							log.Warn("[downloader] Cannot UDP resolve address", "network", network, "addr", seed)
 							continue
@@ -158,7 +158,7 @@ func New(dirs datadir.Dirs, version string, verbosity lg.Level, downloadRate, up
 					}
 					if network == "tcp" {
 						var addr *net.TCPAddr
-						addr, err := net.ResolveTCPAddr(network, seed+":80")
+						addr, err := net.ResolveTCPAddr(network, seed)
 						if err != nil {
 							log.Warn("[downloader] Cannot TCP resolve address", "network", network, "addr", seed)
 							continue


### PR DESCRIPTION
The `--torrent.staticpeers` param always append a hardcoded :80 port regardless of what is passed on CLI, it is already broken.

Removes the hardcoded part requiring the user to pass a complete host:port string.

Also fixes the help msg which seems copy/pasted from the p2p help.