### PR TITLE
Fix duplicate borevent snapshot entries

### DIFF
--- a/polygon/bor/snaptype/types.go
+++ b/polygon/bor/snaptype/types.go
@@ -109,15 +109,15 @@ var (
 						return false, e
 					}
 
-					logger.Info("extractingRange", "blockNum", blockNum, "start", startEventId, "end", endEventId)
+					if blockNum >= blockTo {
+						return false, nil
+					}
+
 					if e := extractEventRange(startEventId, endEventId, tx, blockNum, blockHash, collect); e != nil {
 						return false, e
 					}
 					startEventId = endEventId
 
-					if blockNum >= blockTo {
-						return false, nil
-					}
 					lastEventId = binary.BigEndian.Uint64(eventIdBytes)
 					select {
 					case <-ctx.Done():


### PR DESCRIPTION
`extractRange` was being called for the same block number multiple times with different event ID ranges which broke the block reader. 