### PR TITLE
polygon: fix astrid stage integration deadlock on tip unwind

### DIFF
--- a/eth/stagedsync/stage_polygon_sync.go
+++ b/eth/stagedsync/stage_polygon_sync.go
@@ -434,7 +434,8 @@ func (s *polygonSyncStageService) Run(ctx context.Context, tx kv.RwTx, stageStat
 	s.runBgComponentsOnce(ctx)
 
 	if s.executionEngine.cachedForkChoice != nil {
-		err := s.executionEngine.UpdateForkChoice(ctx, s.executionEngine.cachedForkChoice, nil)
+		s.logger.Info(s.appendLogPrefix("new fork - processing cached fork choice after unwind"))
+		err := s.executionEngine.updateForkChoice(tx, s.executionEngine.cachedForkChoice)
 		if err != nil {
 			return err
 		}
@@ -1377,6 +1378,7 @@ func (e *polygonSyncStageExecutionEngine) updateForkChoice(tx kv.RwTx, tip *type
 	}
 
 	if len(badNodes) > 0 {
+		e.logger.Info(e.appendLogPrefix("new fork - unwinding and caching fork choice"))
 		badNode := badNodes[len(badNodes)-1]
 		e.cachedForkChoice = tip
 		return e.unwinder.UnwindTo(badNode.number, ForkReset(badNode.hash), tx)


### PR DESCRIPTION
Astrid sync stage deadlocked on chain tip when a new fork choice update resulted in a change of fork. Logs:

```
INFO[08-23|23:24:36.845] [2/6 PolygonSync] forward                progress=11087680
DBUG[08-23|23:24:36.847] [bridge] processing new blocks           from=11087052 to=11087682 lastProcessedBlockNum=11087680 lastProcessedBlockTime=1724451852 lastProcessedEventID=2312
DBUG[08-23|23:24:36.848] [sync] inserted blocks                   len=631 duration=2.2985ms
DBUG[08-23|23:24:36.848] [bor.heimdall] synchronizing spans...    blockNum=11087682
DBUG[08-23|23:24:36.848] [bridge] synchronizing events...         blockNum=11087682 lastProcessedBlockNum=11087680
INFO[08-23|23:24:36.848] [2/6 PolygonSync] update fork choice     block=11087682 hash=0x6d788e5262313d75fa5877e23654570b06755078d55dbf07dfa6d1ac22458e1b
DBUG[08-23|23:24:36.848] UnwindTo                                 block=11087680 block_hash=0x27a2c3eccda5d3f69c4012beb0ce516216458a26dc4ec680dc00c21ea443fbb6 err=nil stack="[sync.go:171 stage_polygon_sync.go:1382 stage_polygon_sync.go:1350 stage_polygon_sync.go:1462 stage_polygon_sync.go:463 stage_polygon_s
ync.go:175 default_stages.go:479 sync.go:531 sync.go:410 stageloop.go:259 stageloop.go:103 asm_arm64.s:1222]"
DBUG[08-23|23:24:37.226] [2/6 PolygonSync] DONE                   in=381.261458ms
DBUG[08-23|23:24:37.226] [1/6 OtterSync] DONE                     in=13.5µs
INFO[08-23|23:24:37.226] [2/6 PolygonSync] forward                progress=11087680

.... nothing happened after this for the whole weekend ....
```

Looking at http://localhost:6060/debug/pprof/goroutine?debug=2 (check goroutine trace below) I noticed that the astrid stage is stuck on waiting for the txActionStream channel at `stage_polygon_sync.go:437` after calling `err := s.executionEngine.UpdateForkChoice(ctx, s.executionEngine.cachedForkChoice, nil)`.

The reason for this is because the for loop consuming and processing this channel happens after this call is being made. The fix is to use `s.executionEngine.updateForkChoice` which relies on a tx and not on the txActionStream instead of `s.executionEngine.UpdateForkChoice` which relies on the txActionStream.

```
goroutine 131 [select, 3686 minutes, locked to thread]:
github.com/erigontech/erigon/eth/stagedsync.awaitTxAction[...]({0x102e47600, 0x14001012960}, 0x14001791320, 0x1400a0f6fa8)
	/Users/taratorio/erigon3-run/eth/stagedsync/stage_polygon_sync.go:1473 +0x144
github.com/erigontech/erigon/eth/stagedsync.(*polygonSyncStageExecutionEngine).UpdateForkChoice(0x14000fec000, {0x102e47600, 0x14001012960}, 0x140342b0848, 0x140015d61c0?)
	/Users/taratorio/erigon3-run/eth/stagedsync/stage_polygon_sync.go:1349 +0x90
github.com/erigontech/erigon/eth/stagedsync.(*polygonSyncStageService).Run(0x14000c5ab40, {0x102e47600, 0x14001012960}, {0x102e79dd0, 0x1402b19fd40}, 0x1401f63de60, {0x102e418e0, 0x1400189c000})
	/Users/taratorio/erigon3-run/eth/stagedsync/stage_polygon_sync.go:437 +0x264
github.com/erigontech/erigon/eth/stagedsync.ForwardPolygonSyncStage({0x102e47600?, 0x14001012960?}, {0x0, 0x0?}, 0x1401f63de60?, {0x102e418e0?, 0x1400189c000?}, {{0x102e5e050, 0x14001480048}, 0x14000c5ab40, ...})
	/Users/taratorio/erigon3-run/eth/stagedsync/stage_polygon_sync.go:175 +0x118
github.com/erigontech/erigon/eth/stagedsync.PolygonSyncStages.func4(0x0?, 0x101f189cf?, {0x102e418e0?, 0x1400189c000?}, {{0x0, 0x0}, {0x0, 0x0}, 0x0}, {0x102e5cd68?, ...})
	/Users/taratorio/erigon3-run/eth/stagedsync/default_stages.go:479 +0x78
github.com/erigontech/erigon/eth/stagedsync.(*Sync).runStage(0x1400189c000, 0x14000ff15e0, {0x102e5e050, 0x14001480048}, {{0x0, 0x0}, {0x0, 0x0}, 0x0}, 0x0, ...)
	/Users/taratorio/erigon3-run/eth/stagedsync/sync.go:531 +0x118
github.com/erigontech/erigon/eth/stagedsync.(*Sync).Run(0x1400189c000, {0x102e5e050, 0x14001480048}, {{0x0, 0x0}, {0x0, 0x0}, 0x0}, 0xe8?, 0x0)
	/Users/taratorio/erigon3-run/eth/stagedsync/sync.go:410 +0x224
github.com/erigontech/erigon/turbo/stages.StageLoopIteration({0x102e47600, 0x14001012960}, {0x102e5e050, 0x14001480048}, {{0x0, 0x0}, {0x0, 0x0}, 0x0}, 0x1400189c000, ...)
	/Users/taratorio/erigon3-run/turbo/stages/stageloop.go:259 +0x394
github.com/erigontech/erigon/turbo/stages.StageLoop({0x102e47600, 0x14001012960}, {0x102e5e050, 0x14001480048}, 0x1400189c000, 0x14000dc4400, 0x0?, 0x0, {0x102e5cd68, 0x14000d50b00}, ...)
	/Users/taratorio/erigon3-run/turbo/stages/stageloop.go:103 +0x230
created by github.com/erigontech/erigon/eth.(*Ethereum).Start in goroutine 1
	/Users/taratorio/erigon3-run/eth/backend.go:1542 +0x53c

```