### PR TITLE
guide: fix conception and link

### DIFF
--- a/docs/programmers_guide/guide.md
+++ b/docs/programmers_guide/guide.md
@@ -429,7 +429,7 @@ efficiently, the set of keys being resolved will be converted into a sorted list
 processes a key, it maintains references to two consecutive keys from that sorted list - one "LTE" (Less Than or Equal
 to the currently processed key), and another "GT" (Greater Than the currently processed key). If max common prefix is
 also prefix of either LTE or GT, then `BRANCH` opcode is emitted, otherwise, `BRANCHHASH` opcode is emitted. This is
-implemented by the type `ResolveSet` in [turbo/trie/resolve_set.go](../../turbo/trie/resolve_set.go)
+implemented by the type `RetainList` in [turbo/trie/resolve_set.go](../../turbo/trie/retain_list.go)
 
 ### Extension of the structure to support contracts with contract storage
 


### PR DESCRIPTION
The conception of the different between` Erigo`n and` Geth` in this guide is outdated. I found the part may be the correct part. But Im not 100% sure.