### PR TITLE
downloader: updated progress logging

### DIFF
--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -1395,8 +1395,8 @@ func (d *Downloader) mainLoop(silent bool) error {
 		case <-logEvery.C:
 			if !prevStats.Completed {
 				d.logProgress()
-				prevStats = d.Stats()
 			}
+			prevStats = d.Stats()
 
 			if silent {
 				continue

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -2195,12 +2195,16 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 	rate := stats.DownloadRate
 	remainingBytes := stats.BytesTotal - stats.BytesDownload
 
-	if stats.BytesDownload >= stats.BytesTotal && stats.MetadataReady == stats.FilesTotal {
+	if stats.BytesDownload >= stats.BytesTotal && stats.MetadataReady == stats.FilesTotal && stats.BytesTotal > 0 {
 		status = "Verifying"
 		percentDone = float32(100) * (float32(stats.BytesCompleted) / float32(stats.BytesTotal))
 		bytesDone = common.ByteCount(stats.BytesCompleted)
 		rate = stats.CompletionRate
 		remainingBytes = stats.BytesTotal - stats.BytesCompleted
+	}
+
+	if stats.BytesTotal == 0 {
+		percentDone = 0
 	}
 
 	timeLeft := calculateTime(remainingBytes, rate)

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -2873,7 +2873,7 @@ func (d *Downloader) logProgress() {
 	prefix := d.logPrefix
 
 	if d.logPrefix == "" {
-		prefix = "[snapshots]"
+		prefix = "snapshots"
 	}
 
 	if d.stats.Completed {

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -1384,7 +1384,7 @@ func (d *Downloader) mainLoop(silent bool) error {
 	defer statEvery.Stop()
 
 	var m runtime.MemStats
-	prevStats := d.Stats()
+
 	for {
 		select {
 		case <-d.ctx.Done():
@@ -1393,10 +1393,9 @@ func (d *Downloader) mainLoop(silent bool) error {
 			d.ReCalcStats(statInterval)
 
 		case <-logEvery.C:
-			if !prevStats.Completed {
+			if !d.stats.Completed {
 				d.logProgress()
 			}
-			prevStats = d.Stats()
 
 			if silent {
 				continue
@@ -2384,7 +2383,6 @@ func (d *Downloader) logProgress() {
 			"alloc", common.ByteCount(m.Alloc),
 			"sys", common.ByteCount(m.Sys))
 	}
-
 }
 
 type filterWriter struct {

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -2176,6 +2176,26 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 		stats.Completed = false
 	}
 
+	logger.Debug("[snapshots] downloading",
+		"len", len(torrents),
+		"webTransfers", webTransfers,
+		"torrent", torrentInfo,
+		"db", dbInfo,
+		"t-complete", tComplete,
+		"hashed", common.ByteCount(stats.BytesHashed),
+		"hash-rate", fmt.Sprintf("%s/s", common.ByteCount(stats.HashRate)),
+		"completed", common.ByteCount(stats.BytesCompleted),
+		"completion-rate", fmt.Sprintf("%s/s", common.ByteCount(stats.CompletionRate)),
+		"flushed", common.ByteCount(stats.BytesFlushed),
+		"flush-rate", fmt.Sprintf("%s/s", common.ByteCount(stats.FlushRate)),
+		"webseed-trips", stats.WebseedTripCount.Load(),
+		"webseed-active", stats.WebseedActiveTrips.Load(),
+		"webseed-max-active", stats.WebseedMaxActiveTrips.Load(),
+		"webseed-discards", stats.WebseedDiscardCount.Load(),
+		"webseed-fails", stats.WebseedServerFails.Load(),
+		"webseed-bytes", common.ByteCount(uint64(stats.WebseedBytesDownload.Load())),
+		"localHashes", stats.LocalFileHashes, "localHashTime", stats.LocalFileHashTime)
+
 	if lastMetadataReady != stats.MetadataReady {
 		now := time.Now()
 		stats.LastMetadataUpdate = &now
@@ -2295,26 +2315,6 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 
 	stats.PeersUnique = int32(len(peers))
 	stats.FilesTotal = int32(len(torrents)) + webTransfers
-
-	logger.Debug("[snapshots] downloading",
-		"len", len(torrents),
-		"webTransfers", webTransfers,
-		"torrent", torrentInfo,
-		"db", dbInfo,
-		"t-complete", tComplete,
-		"hashed", common.ByteCount(stats.BytesHashed),
-		"hash-rate", fmt.Sprintf("%s/s", common.ByteCount(stats.HashRate)),
-		"completed", common.ByteCount(stats.BytesCompleted),
-		"completion-rate", fmt.Sprintf("%s/s", common.ByteCount(stats.CompletionRate)),
-		"flushed", common.ByteCount(stats.BytesFlushed),
-		"flush-rate", fmt.Sprintf("%s/s", common.ByteCount(stats.FlushRate)),
-		"webseed-trips", stats.WebseedTripCount.Load(),
-		"webseed-active", stats.WebseedActiveTrips.Load(),
-		"webseed-max-active", stats.WebseedMaxActiveTrips.Load(),
-		"webseed-discards", stats.WebseedDiscardCount.Load(),
-		"webseed-fails", stats.WebseedServerFails.Load(),
-		"webseed-bytes", common.ByteCount(uint64(stats.WebseedBytesDownload.Load())),
-		"localHashes", stats.LocalFileHashes, "localHashTime", stats.LocalFileHashTime)
 
 	d.lock.Lock()
 	d.stats = stats

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -2366,20 +2366,17 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 
 		timeLeft := calculateTime(remainingBytes, rate)
 
-		var logStr strings.Builder
-		if stats.MetadataReady < stats.FilesTotal {
-			logStr.WriteString(fmt.Sprintf("(%d/%d files) ", stats.MetadataReady, stats.FilesTotal))
-		}
-		logStr.WriteString(fmt.Sprintf("%.2f%% - %s/%s", percentDone, bytesDone, common.ByteCount(stats.BytesTotal)))
-		logStr.WriteString(" rate=" + common.ByteCount(rate) + "/s")
-		logStr.WriteString(" time-left=" + timeLeft)
-		logStr.WriteString(" total-time=" + time.Since(d.startTime).Round(time.Second).String())
-		if stats.MetadataReady < stats.FilesTotal {
-			logStr.WriteString(" no-metadata=" + strconv.Itoa(int(stats.FilesTotal-stats.MetadataReady)))
-		}
-
 		if !stats.Completed {
-			log.Info(fmt.Sprintf("[%s] %s", prefix, status), "progress", logStr.String(), "alloc", common.ByteCount(m.Alloc), "sys", common.ByteCount(m.Sys))
+			log.Info(
+				fmt.Sprintf("[%s] %s", prefix, status),
+				"progress", fmt.Sprintf("(%d/%d files) %.2f%% - %s/%s", stats.MetadataReady, stats.FilesTotal, percentDone, bytesDone, common.ByteCount(stats.BytesTotal)),
+				"rate", fmt.Sprintf("%s/s", common.ByteCount(rate)),
+				"time-left", timeLeft,
+				"total-time", time.Since(d.startTime).Round(time.Second).String(),
+				"flush-rate", fmt.Sprintf("%s/s", common.ByteCount(stats.FlushRate)),
+				"hash-rate", fmt.Sprintf("%s/s", common.ByteCount(stats.HashRate)),
+				"alloc", common.ByteCount(m.Alloc),
+				"sys", common.ByteCount(m.Sys))
 		}
 	}
 }

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -1990,6 +1990,7 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 	stats.BytesHashed = uint64(connStats.BytesHashed.Int64())
 	stats.BytesFlushed = uint64(connStats.BytesFlushed.Int64())
 	stats.BytesDownload = uint64(connStats.BytesReadData.Int64())
+	stats.BytesCompleted = uint64(connStats.BytesCompleted.Int64())
 
 	lastMetadataReady := stats.MetadataReady
 
@@ -2205,14 +2206,14 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 	timeLeft := calculateTime(remainingBytes, rate)
 
 	var logStr strings.Builder
-	if stats.MetadataReady != stats.FilesTotal {
+	if stats.MetadataReady < stats.FilesTotal {
 		logStr.WriteString(fmt.Sprintf("(%d/%d files) ", stats.MetadataReady, stats.FilesTotal))
 	}
 	logStr.WriteString(fmt.Sprintf("%.2f%% - %s/%s", percentDone, bytesDone, common.ByteCount(stats.BytesTotal)))
 	logStr.WriteString(" rate=" + common.ByteCount(rate) + "/s")
 	logStr.WriteString(" time-left=" + timeLeft)
 	logStr.WriteString(" total-time=" + time.Since(d.startTime).Round(time.Second).String())
-	if stats.MetadataReady != stats.FilesTotal {
+	if stats.MetadataReady < stats.FilesTotal {
 		logStr.WriteString(" no-metadata=" + strconv.Itoa(int(stats.FilesTotal-stats.MetadataReady)))
 	}
 

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -2176,26 +2176,6 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 		stats.Completed = false
 	}
 
-	logger.Debug("[snapshots] downloading",
-		"len", len(torrents),
-		"webTransfers", webTransfers,
-		"torrent", torrentInfo,
-		"db", dbInfo,
-		"t-complete", tComplete,
-		"hashed", common.ByteCount(stats.BytesHashed),
-		"hash-rate", fmt.Sprintf("%s/s", common.ByteCount(stats.HashRate)),
-		"completed", common.ByteCount(stats.BytesCompleted),
-		"completion-rate", fmt.Sprintf("%s/s", common.ByteCount(stats.CompletionRate)),
-		"flushed", common.ByteCount(stats.BytesFlushed),
-		"flush-rate", fmt.Sprintf("%s/s", common.ByteCount(stats.FlushRate)),
-		"webseed-trips", stats.WebseedTripCount.Load(),
-		"webseed-active", stats.WebseedActiveTrips.Load(),
-		"webseed-max-active", stats.WebseedMaxActiveTrips.Load(),
-		"webseed-discards", stats.WebseedDiscardCount.Load(),
-		"webseed-fails", stats.WebseedServerFails.Load(),
-		"webseed-bytes", common.ByteCount(uint64(stats.WebseedBytesDownload.Load())),
-		"localHashes", stats.LocalFileHashes, "localHashTime", stats.LocalFileHashTime)
-
 	if lastMetadataReady != stats.MetadataReady {
 		now := time.Now()
 		stats.LastMetadataUpdate = &now
@@ -2327,6 +2307,28 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 	}
 
 	d.lock.Unlock()
+
+	if !stats.Completed {
+		logger.Debug("[snapshots] downloading",
+			"len", len(torrents),
+			"webTransfers", webTransfers,
+			"torrent", torrentInfo,
+			"db", dbInfo,
+			"t-complete", tComplete,
+			"hashed", common.ByteCount(stats.BytesHashed),
+			"hash-rate", fmt.Sprintf("%s/s", common.ByteCount(stats.HashRate)),
+			"completed", common.ByteCount(stats.BytesCompleted),
+			"completion-rate", fmt.Sprintf("%s/s", common.ByteCount(stats.CompletionRate)),
+			"flushed", common.ByteCount(stats.BytesFlushed),
+			"flush-rate", fmt.Sprintf("%s/s", common.ByteCount(stats.FlushRate)),
+			"webseed-trips", stats.WebseedTripCount.Load(),
+			"webseed-active", stats.WebseedActiveTrips.Load(),
+			"webseed-max-active", stats.WebseedMaxActiveTrips.Load(),
+			"webseed-discards", stats.WebseedDiscardCount.Load(),
+			"webseed-fails", stats.WebseedServerFails.Load(),
+			"webseed-bytes", common.ByteCount(uint64(stats.WebseedBytesDownload.Load())),
+			"localHashes", stats.LocalFileHashes, "localHashTime", stats.LocalFileHashTime)
+	}
 }
 
 func (d *Downloader) logProgress() {

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -2222,7 +2222,7 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 		}
 		sort.Strings(files)
 
-		logger.Log(verbosity, "[snapshots] downloading", "files", amount, "list", strings.Join(files, ", "))
+		logger.Log(verbosity, "[snapshots] files progress", "files", amount, "list", strings.Join(files, ", "))
 	}
 
 	if d.stuckFileDetailedLogs && time.Since(stats.lastTorrentStatus) > 5*time.Minute {

--- a/erigon-lib/downloader/downloader_grpc_server.go
+++ b/erigon-lib/downloader/downloader_grpc_server.go
@@ -56,6 +56,10 @@ func (s *GrpcServer) ProhibitNewDownloads(ctx context.Context, req *proto_downlo
 func (s *GrpcServer) Add(ctx context.Context, request *proto_downloader.AddRequest) (*emptypb.Empty, error) {
 	defer s.d.ReCalcStats(10 * time.Second) // immediately call ReCalc to set stat.Complete flag
 
+	if len(s.d.torrentClient.Torrents()) == 0 {
+		s.d.startTime = time.Now()
+	}
+
 	logEvery := time.NewTicker(20 * time.Second)
 	defer logEvery.Stop()
 

--- a/turbo/snapshotsync/snapshotsync.go
+++ b/turbo/snapshotsync/snapshotsync.go
@@ -21,18 +21,14 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/erigontech/erigon-lib/chain"
 	"github.com/erigontech/erigon-lib/chain/snapcfg"
-	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/datadir"
-	"github.com/erigontech/erigon-lib/common/dbg"
 	"github.com/erigontech/erigon-lib/config3"
-	"github.com/erigontech/erigon-lib/diagnostics"
 	"github.com/erigontech/erigon-lib/downloader/downloadergrpc"
 	"github.com/erigontech/erigon-lib/downloader/snaptype"
 	proto_downloader "github.com/erigontech/erigon-lib/gointerfaces/downloaderproto"
@@ -379,9 +375,7 @@ func WaitForDownloader(ctx context.Context, logPrefix string, dirs datadir.Dirs,
 			}
 			if stats, err = snapshotDownloader.Stats(ctx, &proto_downloader.StatsRequest{}); err != nil {
 				log.Warn("Error while waiting for snapshots progress", "err", err)
-			} //} else {
-			//logStats(ctx, stats, downloadStartTime, stagesIdsList, logPrefix, headerchain)
-			//}
+			}
 		}
 	}
 
@@ -402,9 +396,7 @@ func WaitForDownloader(ctx context.Context, logPrefix string, dirs datadir.Dirs,
 		case <-logEvery.C:
 			if stats, err = snapshotDownloader.Stats(ctx, &proto_downloader.StatsRequest{}); err != nil {
 				log.Warn("Error while waiting for snapshots progress", "err", err)
-			} //} else {
-			//logStats(ctx, stats, downloadStartTime, stagesIdsList, logPrefix, headerchain)
-			//}
+			}
 		}
 	}
 
@@ -492,80 +484,4 @@ func WaitForDownloader(ctx context.Context, logPrefix string, dirs datadir.Dirs,
 		}
 	}
 	return nil
-}
-
-func logStats(ctx context.Context, stats *proto_downloader.StatsReply, startTime time.Time, stagesIdsList []string, logPrefix string, headerchain bool) {
-	var m runtime.MemStats
-
-	logReason := "download"
-	if headerchain {
-		logReason = "downloading header-chain"
-	}
-	logEnd := "download finished"
-	if headerchain {
-		logEnd = "header-chain download finished"
-	}
-
-	diagnostics.Send(diagnostics.SnapshotDownloadStatistics{
-		Downloaded:           stats.BytesCompleted,
-		Total:                stats.BytesTotal,
-		TotalTime:            time.Since(startTime).Round(time.Second).Seconds(),
-		DownloadRate:         stats.DownloadRate,
-		UploadRate:           stats.UploadRate,
-		Peers:                stats.PeersUnique,
-		Files:                stats.FilesTotal,
-		Connections:          stats.ConnectionsTotal,
-		Alloc:                m.Alloc,
-		Sys:                  m.Sys,
-		DownloadFinished:     stats.Completed,
-		TorrentMetadataReady: stats.MetadataReady,
-	})
-
-	if stats.Completed {
-		log.Info(fmt.Sprintf("[%s] %s", logPrefix, logEnd), "time", time.Since(startTime).String())
-	} else {
-
-		if stats.MetadataReady < stats.FilesTotal && stats.BytesTotal == 0 {
-			log.Info(fmt.Sprintf("[%s] Waiting for torrents metadata: %d/%d", logPrefix, stats.MetadataReady, stats.FilesTotal))
-		}
-
-		dbg.ReadMemStats(&m)
-
-		var remainingBytes uint64
-
-		if stats.BytesTotal > stats.BytesCompleted {
-			remainingBytes = stats.BytesTotal - stats.BytesCompleted
-		}
-
-		downloadTimeLeft := calculateTime(remainingBytes, stats.CompletionRate)
-
-		log.Info(fmt.Sprintf("[%s] %s", logPrefix, logReason),
-			"progress", fmt.Sprintf("(%d/%d files) %.2f%% %s/%s", stats.MetadataReady, stats.FilesTotal, stats.Progress, common.ByteCount(stats.BytesCompleted), common.ByteCount(stats.BytesTotal)),
-			// TODO: "downloading", stats.Downloading,
-			"download-rate", common.ByteCount(stats.DownloadRate)+"/s",
-			"time-left", downloadTimeLeft,
-			"total-time", time.Since(startTime).Round(time.Second).String(),
-			"flush", common.ByteCount(stats.FlushRate)+"/s",
-			"hash", common.ByteCount(stats.HashRate)+"/s",
-			"complete", common.ByteCount(stats.CompletionRate)+"/s",
-			"upload", common.ByteCount(stats.UploadRate)+"/s",
-			"peers", stats.PeersUnique,
-			"files", stats.FilesTotal,
-			"no-metadata", strconv.Itoa(int(stats.FilesTotal-stats.MetadataReady)),
-			"connections", stats.ConnectionsTotal,
-			"alloc", common.ByteCount(m.Alloc), "sys", common.ByteCount(m.Sys),
-		)
-	}
-}
-
-func calculateTime(amountLeft, rate uint64) string {
-	if rate == 0 {
-		return "999hrs:99m"
-	}
-	timeLeftInSeconds := amountLeft / rate
-
-	hours := timeLeftInSeconds / 3600
-	minutes := (timeLeftInSeconds / 60) % 60
-
-	return fmt.Sprintf("%dhrs:%dm", hours, minutes)
 }

--- a/turbo/snapshotsync/snapshotsync.go
+++ b/turbo/snapshotsync/snapshotsync.go
@@ -353,7 +353,7 @@ func WaitForDownloader(ctx context.Context, logPrefix string, dirs datadir.Dirs,
 
 	}
 
-	downloadStartTime := time.Now()
+	//downloadStartTime := time.Now()
 	const logInterval = 20 * time.Second
 	logEvery := time.NewTicker(logInterval)
 	defer logEvery.Stop()
@@ -379,9 +379,9 @@ func WaitForDownloader(ctx context.Context, logPrefix string, dirs datadir.Dirs,
 			}
 			if stats, err = snapshotDownloader.Stats(ctx, &proto_downloader.StatsRequest{}); err != nil {
 				log.Warn("Error while waiting for snapshots progress", "err", err)
-			} else {
-				logStats(ctx, stats, downloadStartTime, stagesIdsList, logPrefix, headerchain)
-			}
+			} //} else {
+			//logStats(ctx, stats, downloadStartTime, stagesIdsList, logPrefix, headerchain)
+			//}
 		}
 	}
 
@@ -402,9 +402,9 @@ func WaitForDownloader(ctx context.Context, logPrefix string, dirs datadir.Dirs,
 		case <-logEvery.C:
 			if stats, err = snapshotDownloader.Stats(ctx, &proto_downloader.StatsRequest{}); err != nil {
 				log.Warn("Error while waiting for snapshots progress", "err", err)
-			} else {
-				logStats(ctx, stats, downloadStartTime, stagesIdsList, logPrefix, headerchain)
-			}
+			} //} else {
+			//logStats(ctx, stats, downloadStartTime, stagesIdsList, logPrefix, headerchain)
+			//}
 		}
 	}
 

--- a/turbo/snapshotsync/snapshotsync.go
+++ b/turbo/snapshotsync/snapshotsync.go
@@ -349,7 +349,6 @@ func WaitForDownloader(ctx context.Context, logPrefix string, dirs datadir.Dirs,
 
 	}
 
-	//downloadStartTime := time.Now()
 	const logInterval = 20 * time.Second
 	logEvery := time.NewTicker(logInterval)
 	defer logEvery.Stop()


### PR DESCRIPTION
- Moved logging for downloader progress to downloader
- Updated log progress message structure
- Display correct state of file downloading which is solve user complaints that downloader stuck at 99%

Example of the log output which include downloading and verifying states:
`INFO[08-26|16:58:47.045] [1/6 OtterSync] Downloading              progress="(358/358 files) 97.21% - 216.0GB/222.2GB" rate=5.9MB/s time-left=0hrs:17m total-time=23m0s download-rate=5.9MB/s completion-rate=2.0GB/s alloc=10.9GB sys=13.7GB`
`INFO[08-26|16:59:07.019] [1/6 OtterSync] Downloading              progress="(358/358 files) 99.57% - 221.2GB/222.2GB" rate=268.3MB/s time-left=0hrs:0m total-time=23m20s download-rate=268.3MB/s completion-rate=839.4MB/s alloc=11.7GB sys=13.7GB`
`INFO[08-26|16:59:27.037] [1/6 OtterSync] Verifying                progress="(358/358 files) 53.22% - 118.3GB/222.2GB" rate=42.3MB/s time-left=0hrs:41m total-time=23m40s download-rate=48.6MB/s completion-rate=42.3MB/s alloc=6.8GB sys=13.7GB`
`INFO[08-26|16:59:47.019] [1/6 OtterSync] Verifying                progress="(358/358 files) 73.96% - 164.3GB/222.2GB" rate=2.3GB/s time-left=0hrs:0m total-time=24m0s download-rate=24.3MB/s completion-rate=2.3GB/s alloc=8.4GB sys=13.7GB`
`INFO[08-26|17:00:07.020] [1/6 OtterSync] Verifying                progress="(358/358 files) 97.82% - 217.3GB/222.2GB" rate=2.7GB/s time-left=0hrs:0m total-time=24m20s download-rate=12.1MB/s completion-rate=2.7GB/s alloc=9.3GB sys=13.9GB`
`INFO[08-26|17:00:27.019] [1/6 OtterSync] Downloading complete     time=24m39.974669982s`