### PR TITLE
set specific stream bound limits

### DIFF
--- a/cl/sentinel/sentinel.go
+++ b/cl/sentinel/sentinel.go
@@ -246,7 +246,7 @@ func New(
 	newLimit := rcmgr.PartialLimitConfig{
 		System: rcmgr.ResourceLimits{
 			StreamsOutbound: defaultLimits.ToPartialLimitConfig().System.StreamsOutbound/16,
-			StreamsInbound: defaultLimits.ToPartialLimitConfig().System.StreamsOutbound/16,
+			StreamsInbound:  defaultLimits.ToPartialLimitConfig().System.StreamsOutbound/16,
 		},
 	}.Build(defaultLimits)
 

--- a/cl/sentinel/sentinel.go
+++ b/cl/sentinel/sentinel.go
@@ -245,9 +245,7 @@ func New(
 	defaultLimits := rcmgr.DefaultLimits.AutoScale()
 	newLimit := rcmgr.PartialLimitConfig{
 		System: rcmgr.ResourceLimits{
-			// Default:  64 * 16, now it's 64 * 4
 			StreamsOutbound: rcmgr.LimitVal(defaultLimits.ToPartialLimitConfig().System.StreamsOutbound/4),
-			// Default: 128 * 16, now it's 128 * 4
 			StreamsInbound: rcmgr.LimitVal(defaultLimits.ToPartialLimitConfig().System.StreamsOutbound/4),
 		},
 	}.Build(defaultLimits)

--- a/cl/sentinel/sentinel.go
+++ b/cl/sentinel/sentinel.go
@@ -245,8 +245,8 @@ func New(
 	defaultLimits := rcmgr.DefaultLimits.AutoScale()
 	newLimit := rcmgr.PartialLimitConfig{
 		System: rcmgr.ResourceLimits{
-			StreamsOutbound: rcmgr.LimitVal(defaultLimits.ToPartialLimitConfig().System.StreamsOutbound/4),
-			StreamsInbound: rcmgr.LimitVal(defaultLimits.ToPartialLimitConfig().System.StreamsOutbound/4),
+			StreamsOutbound: defaultLimits.ToPartialLimitConfig().System.StreamsOutbound/16,
+			StreamsInbound: defaultLimits.ToPartialLimitConfig().System.StreamsOutbound/16,
 		},
 	}.Build(defaultLimits)
 

--- a/cl/sentinel/sentinel.go
+++ b/cl/sentinel/sentinel.go
@@ -244,8 +244,10 @@ func New(
 
 	newLimit := rcmgr.PartialLimitConfig{
 		System: rcmgr.ResourceLimits{
-			StreamsOutbound: rcmgr.LimitVal(rcmgr.DefaultLimits.SystemBaseLimit.StreamsOutbound/2),
-			StreamsInbound: rcmgr.LimitVal(rcmgr.DefaultLimits.SystemBaseLimit.StreamsOutbound/2),
+			// Default:  64 * 16, now it's 64 * 4
+			StreamsOutbound: rcmgr.LimitVal(rcmgr.DefaultLimits.SystemBaseLimit.StreamsOutbound/4),
+			// Default: 128 * 16, now it's 128 * 4
+			StreamsInbound: rcmgr.LimitVal(rcmgr.DefaultLimits.SystemBaseLimit.StreamsOutbound/4),
 		},
 	}.Build(rcmgr.DefaultLimits.AutoScale())
 

--- a/cl/sentinel/sentinel.go
+++ b/cl/sentinel/sentinel.go
@@ -245,8 +245,8 @@ func New(
 	defaultLimits := rcmgr.DefaultLimits.AutoScale()
 	newLimit := rcmgr.PartialLimitConfig{
 		System: rcmgr.ResourceLimits{
-			StreamsOutbound: defaultLimits.ToPartialLimitConfig().System.StreamsOutbound/16,
-			StreamsInbound:  defaultLimits.ToPartialLimitConfig().System.StreamsOutbound/16,
+			StreamsOutbound: defaultLimits.ToPartialLimitConfig().System.StreamsOutbound / 16,
+			StreamsInbound:  defaultLimits.ToPartialLimitConfig().System.StreamsOutbound / 16,
 		},
 	}.Build(defaultLimits)
 

--- a/cl/sentinel/sentinel.go
+++ b/cl/sentinel/sentinel.go
@@ -245,8 +245,8 @@ func New(
 	defaultLimits := rcmgr.DefaultLimits.AutoScale()
 	newLimit := rcmgr.PartialLimitConfig{
 		System: rcmgr.ResourceLimits{
-			StreamsOutbound: defaultLimits.ToPartialLimitConfig().System.StreamsOutbound / 16,
-			StreamsInbound:  defaultLimits.ToPartialLimitConfig().System.StreamsOutbound / 16,
+			StreamsOutbound: 16,
+			StreamsInbound:  16,
 		},
 	}.Build(defaultLimits)
 

--- a/cl/sentinel/sentinel.go
+++ b/cl/sentinel/sentinel.go
@@ -242,7 +242,14 @@ func New(
 		return nil, err
 	}
 
-	rmgr, err := rcmgr.NewResourceManager(rcmgr.NewFixedLimiter(rcmgr.DefaultLimits.AutoScale()), rcmgr.WithTraceReporter(str))
+	newLimit := rcmgr.PartialLimitConfig{
+		System: rcmgr.ResourceLimits{
+			StreamsOutbound: rcmgr.LimitVal(rcmgr.DefaultLimits.SystemBaseLimit.StreamsOutbound/2),
+			StreamsInbound: rcmgr.LimitVal(rcmgr.DefaultLimits.SystemBaseLimit.StreamsOutbound/2),
+		},
+	}.Build(rcmgr.DefaultLimits.AutoScale())
+
+	rmgr, err := rcmgr.NewResourceManager(rcmgr.NewFixedLimiter(newLimit), rcmgr.WithTraceReporter(str))
 	if err != nil {
 		return nil, err
 	}

--- a/cl/sentinel/sentinel.go
+++ b/cl/sentinel/sentinel.go
@@ -242,14 +242,15 @@ func New(
 		return nil, err
 	}
 
+	defaultLimits := rcmgr.DefaultLimits.AutoScale()
 	newLimit := rcmgr.PartialLimitConfig{
 		System: rcmgr.ResourceLimits{
 			// Default:  64 * 16, now it's 64 * 4
-			StreamsOutbound: rcmgr.LimitVal(rcmgr.DefaultLimits.SystemBaseLimit.StreamsOutbound/4),
+			StreamsOutbound: rcmgr.LimitVal(defaultLimits.ToPartialLimitConfig().System.StreamsOutbound/4),
 			// Default: 128 * 16, now it's 128 * 4
-			StreamsInbound: rcmgr.LimitVal(rcmgr.DefaultLimits.SystemBaseLimit.StreamsOutbound/4),
+			StreamsInbound: rcmgr.LimitVal(defaultLimits.ToPartialLimitConfig().System.StreamsOutbound/4),
 		},
-	}.Build(rcmgr.DefaultLimits.AutoScale())
+	}.Build(defaultLimits)
 
 	rmgr, err := rcmgr.NewResourceManager(rcmgr.NewFixedLimiter(newLimit), rcmgr.WithTraceReporter(str))
 	if err != nil {


### PR DESCRIPTION
Limiting default `StreamsOutbound` and `StreamsInbound` for p2p resource manager.