### PR TITLE
dl: remove webdownload logic

### DIFF
--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -883,7 +883,6 @@ func (d *Downloader) mainLoop(silent bool) error {
 		waiting := map[string]struct{}{}
 
 		downloadComplete := make(chan downloadStatus, 100)
-		seedHashMismatches := map[infohash.T][]*seedHash{}
 
 		// set limit here to make load predictable, not to control Disk/CPU consumption
 		// will impact start times depending on the amount of non complete files - should


### PR DESCRIPTION
no i see tons of requests: all webseeds * all files (even if webseed doesn't have this file. even if webseed doesn't exists - example: caplin bucket on amoy). 
it happening because of `.getWebpeerTorrentInfo` call in mainLoop. 
webdownload logic is not complete and probably don't need anymore