### PR TITLE
Rework goreleaser configuration, release workflow and Dockerfile for release images.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,65 +1,216 @@
 name: Release
+run-name: "Build artifacts with goreleaser, build and publish multi-platform docker image, publish initial draft of the Release Notes"
 
-# Uncomment the following to let goreleaser automatically
-# create a GitHub release when a tag is pushed.
-# permissions:
-#   contents: write
+env:
+  APPLICATION: "erigon"
+  BUILDER_IMAGE: "ghcr.io/goreleaser/goreleaser-cross:v1.21.13"
+  DOCKER_BASE_IMAGE: "alpine:3.20.2"
+  APP_REPO: "erigontech/erigon"
+  PACKAGE: "github.com/erigontech/erigon"
+  DOCKERHUB_REPOSITORY: "erigontech/erigon"
+  DOCKERFILE_PATH: "./Dockerfile.release"
+  GITHUB_AUTOMATION_EMAIL: "github-automation@erigon.tech"
+  GITHUB_AUTOMATION_NAME: "Erigon Github Automation"
+  LABEL_DESCRIPTION: "Erigon is an implementation of Ethereum (execution layer with embeddable consensus layer), on the efficiency frontier. Archive Node by default."
 
 on:
   push:
     branches-ignore:
       - '**'
-    tags:
-      - 'v*.*.*'
-      # to be used by fork patch-releases ^^
-      - 'v*.*.*-*'
+    #branches:
+    #  - 'master'
+    #tags:
+      ## only trigger on release tags:
+      #- 'v*.*.*'
+      #- 'v*.*.*-*'
   workflow_dispatch:
+    inputs:
+      checkout_ref:
+        required: true
+        type: string
+        default: 'main'
+        description: 'The branch to checkout and build artifacts from. By default "main".'
+      release_version:
+        required: true
+        type: string
+        description: 'Release version number (Pattern - #.#.# , f.e. 2.41.3 or 3.0.0 or 3.0.0-alpha1 for pre-releases. Do not prefix it with "v".)'
+      perform_release:
+        required: false
+        type: boolean
+        default: false
+        description: 'perform_release: when set then all artifacts will be published and the DRAFT of the release 
+          notes will be created.'
 
 jobs:
-  goreleaser:
-    runs-on: ubuntu-latest
+
+  build-release:
+    ## runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest-devops-xxlarge
+    timeout-minutes: 30
+    name: Build Artifacts and multi-platform Docker image, publish draft of the Release Notes
+
     steps:
-      - name: Maximize build space
-        uses: AdityaGarg8/remove-unwanted-software@v4
+      - name: Checkout git repository ${{ env.APP_REPO }}
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 ## 4.1.7 release
         with:
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
+          repository: ${{ env.APP_REPO }}
           fetch-depth: 0
+          ref: ${{ inputs.checkout_ref }}
 
-      - name: dockerhub-login
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB }}
-          password: ${{ secrets.DOCKERHUB_KEY }}
-      - name: ghcr-login
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Prepare
-        id: prepare
+      - name: Check if tag ${{ inputs.release_version }} already exists in case perform_release is set.
+        if: ${{ (inputs.perform_release) && (inputs.release_version != '') }}
         run: |
-          TAG=${GITHUB_REF#refs/tags/}
-          echo "tag_name=${TAG}" >> $GITHUB_OUTPUT
+          if git ls-remote --exit-code --quiet --tags origin '${{ inputs.release_version }}'; then
+            echo "ERROR: tag ${{ inputs.release_version }} exists and workflow is performing release. Exit."
+            exit 1
+          else
+            echo "OK: tag ${{ inputs.release_version }} does not exists. Proceeding."
+          fi
+
+      - name: Get commit id
+        id: getCommitId
+        run: |
+          echo "id_old=$(git log -1 --format='%H')" >> $GITHUB_OUTPUT
+          echo "short_commit_id_old=$(git log -1 --format='%h')" >> $GITHUB_OUTPUT
+
+          echo "id=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "short_commit_id=$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  ## v3.3.0
+        with:
+          username: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME }}
+          password: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf ## v3.2.0
 
-      - run: echo ${{ steps.prepare.outputs.tag_name }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db ## v3.6.1
 
-      - name: Release
-        run: |
-          make release
-          docker images
+      - name: Build binaries with goreleaser
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ steps.prepare.outputs.tag_name }}
-          DOCKER_USERNAME: ${{ secrets.DOCKERHUB }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_KEY }}
+          BUILD_VERSION: ${{ inputs.release_version }}
+          DOCKER_URL: ${{ env.DOCKERHUB_REPOSITORY }}
+        run: |
+          docker run --rm \
+            -w /${{ env.APPLICATION }}/ \
+            -e BUILD_VERSION=${{ env.BUILD_VERSION }} \
+            -e GIT_COMMIT=${{ steps.getCommitId.outputs.id }} \
+            -e GIT_BRANCH=${{ inputs.checkout_ref }} \
+            -e GIT_TAG=${{ inputs.release_version }} \
+            -e PACKAGE=${{ env.PACKAGE }} \
+            -e APPLICATION=${{ env.APPLICATION }} \
+            -v $(pwd):/${{ env.APPLICATION}} \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            ${{ env.BUILDER_IMAGE }} release --clean --skip=validate,announce,publish
+          echo "DEBUG: ls -lao in the working directory"
+          ls -lao
+          echo "DEBUG: content of the dist/ directory"
+          find dist/ -ls
+
+      - name: Build and push multi-platform docker images (${{ env.BUILD_VERSION }} and latest) in case perform_release is true
+        if: ${{ inputs.perform_release }}
+        env:
+          BUILD_VERSION: ${{ inputs.release_version }}
+          DOCKER_URL: ${{ env.DOCKERHUB_REPOSITORY }}
+        run: |
+          docker buildx build \
+          --file ${{ env.DOCKERFILE_PATH }} \
+          --build-arg DOCKER_BASE_IMAGE=${{ env.DOCKER_BASE_IMAGE }} \
+          --build-arg VERSION=${{ env.BUILD_VERSION }} \
+          --build-arg APPLICATION=${{ env.APPLICATION }} \
+          --tag ${{ env.DOCKER_URL }}:${{ env.BUILD_VERSION }} \
+          --tag ${{ env.DOCKER_URL }}:latest \
+          --label org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
+          --label org.opencontainers.image.authors="https://github.com/erigontech/erigon/graphs/contributors" \
+          --label org.opencontainers.image.url="https://github.com/erigontech/erigon/blob/main/Dockerfile" \
+          --label org.opencontainers.image.documentation="https://github.com/erigontech/erigon/blob/main/Dockerfile" \
+          --label org.opencontainers.image.source="https://github.com/erigontech/erigon/blob/main/Dockerfile" \
+          --label org.opencontainers.image.version=${{ inputs.release_version }} \
+          --label org.opencontainers.image.revision=${{ steps.getCommitId.outputs.id }} \
+          --label org.opencontainers.image.vcs-ref-short=${{ steps.getCommitId.outputs.short_commit_id }} \
+          --label org.opencontainers.image.vendor="${{ github.repository_owner }}" \
+          --label org.opencontainers.image.description="${{ env.LABEL_DESCRIPTION }}" \
+          --label org.opencontainers.image.base.name="${{ env.DOCKER_BASE_IMAGE }}" \
+          --push \
+          --platform linux/amd64/v2,linux/arm64 .
+
+      - name: Upload artifact -- linux/arm64
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  ## v4.3.6
+        with:
+          name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_arm64.tar.gz
+          path: ./dist/${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_arm64.tar.gz
+          retention-days: 1
+          compression-level: 0
+          if-no-files-found: error
+
+      - name: Upload artifact -- linux/amd64
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  ## v4.3.6
+        with:
+          name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_amd64.tar.gz
+          path: ./dist/${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_amd64.tar.gz
+          retention-days: 1
+          compression-level: 0
+          if-no-files-found: error
+
+      - name: Upload artifact -- darwin/arm64
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  ## v4.3.6
+        with:
+          name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_darwin_arm64.tar.gz
+          path: ./dist/${{ env.APPLICATION }}_${{ inputs.release_version }}_darwin_arm64.tar.gz
+          retention-days: 1
+          compression-level: 0
+          if-no-files-found: error
+
+      - name: Upload artifact -- darwin/amd64
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  ## v4.3.6
+        with:
+          name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_darwin_amd64.tar.gz
+          path: ./dist/${{ env.APPLICATION }}_${{ inputs.release_version }}_darwin_amd64.tar.gz
+          retention-days: 1
+          compression-level: 0
+          if-no-files-found: error
+
+      - name: Upload artifact -- windows/amd64
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  ## v4.3.6
+        with:
+          name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_windows_amd64.zip
+          path: ./dist/${{ env.APPLICATION }}_${{ inputs.release_version }}_windows_amd64.zip
+          retention-days: 1
+          compression-level: 0
+          if-no-files-found: error
+
+      - name: Upload artifact -- checksum
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  ## v4.3.6
+        with:
+          name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_checksums.txt
+          path: ./dist/${{ env.APPLICATION }}_${{ inputs.release_version }}_checksums.txt
+          retention-days: 1
+          compression-level: 0
+          if-no-files-found: error
+
+      - name: Create and push a git tag for the released version in case perform_release is set
+        if: ${{ inputs.perform_release }}
+        run: |
+          git config --global user.email ${{ env.GITHUB_AUTOMATION_EMAIL }}
+          git config --global user.name "${{ env.GITHUB_AUTOMATION_NAME }}"
+          git tag -a ${{ inputs.release_version }} -m "Release ${{ inputs.release_version }}"
+          git push origin ${{ inputs.release_version }}
+
+      - name: Publish draft of the Release notes with assets (without windows .zip) in case perform_release is set
+        if: ${{ inputs.perform_release }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          DOCKER_TAGS: ${{ env.DOCKERHUB_REPOSITORY }}:${{ inputs.release_version }}
+          GITHUB_RELEASE_TARGET: ${{ inputs.checkout_ref }}
+        run: |
+          cd dist
+          gh release create ${{ inputs.release_version }} *.tar.gz *_checksums.txt \
+            --generate-notes \
+            --target ${GITHUB_RELEASE_TARGET} \
+            --draft=true \
+            --title "${{ inputs.release_version }}" \
+            --notes "**Improvements:**<br>- ...coming soon <br><br>**Bugfixes:**<br><br>- ...coming soon<br><br>**Docker images:**<br><br>Docker image released:<br> ${{ env.DOCKER_TAGS }}<br><br>... coming soon<br>"
+

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,23 +1,228 @@
+#version: 2
+
 project_name: erigon
 
 release:
-  disable: false
+  disable: true
   draft: true
   prerelease: auto
 
+env:
+  - CGO_ENABLED=1
+  - GOPRIVATE=github.com/erigontech/silkworm-go
+  - BUILD_VERSION={{ .Env.BUILD_VERSION }}
+  - CGO_CFLAGS_DEFAULT=-DMDBX_ENV_CHECKPID=0 -DMDBX_DISABLE_VALIDATION=0 -DMDBX_FORCE_ASSERTIONS=0 -Wno-unknown-warning-option -Wno-enum-int-mismatch -Wno-strict-prototypes -Wno-unused-but-set-variable -O3
+  - CGO_CFLAGS_WINDOWS=-Wno-unknown-warning-option -Wno-enum-int-mismatch -Wno-strict-prototypes -Wno-unused-but-set-variable -g -O2 -D__BLST_PORTABLE__
+  - CGO_LDFLAGS_DEFAULT=-O3 -g
+  - CGO_LDFLAGS_DEFAULT_DARWIN=-O3 -g
+
 builds:
-  - id: darwin-amd64
+
+## Darwin AMD64:
+  - id: darwin-amd64-erigon
     main: ./cmd/erigon
     binary: erigon
     goos: [ darwin ]
     goarch: [ amd64 ]
+    goamd64:
+      - v2
     env:
       - CC=o64-clang
       - CXX=o64-clang++
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
     tags: [ nosqlite, noboltdb, nosilkworm ]
-    ldflags: -s -w
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
 
-  - id: darwin-arm64
+  - id: darwin-amd64-downloader
+    main: ./cmd/downloader
+    binary: downloader
+    goos: [ darwin ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2
+    env:
+      - CC=o64-clang
+      - CXX=o64-clang++
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: darwin-amd64-devnet
+    main: ./cmd/devnet
+    binary: devnet
+    goos: [ darwin ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2
+    env:
+      - CC=o64-clang
+      - CXX=o64-clang++
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: darwin-amd64-evm
+    main: ./cmd/evm
+    binary: evm
+    goos: [ darwin ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2
+    env:
+      - CC=o64-clang
+      - CXX=o64-clang++
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: darwin-amd64-caplin
+    main: ./cmd/caplin
+    binary: caplin
+    goos: [ darwin ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2
+    env:
+      - CC=o64-clang
+      - CXX=o64-clang++
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: darwin-amd64-diag
+    main: ./cmd/diag
+    binary: diag
+    goos: [ darwin ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2
+    env:
+      - CC=o64-clang
+      - CXX=o64-clang++
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: darwin-amd64-integration
+    main: ./cmd/integration
+    binary: integration
+    goos: [ darwin ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2    
+    env:
+      - CC=o64-clang
+      - CXX=o64-clang++
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: darwin-amd64-rpcdaemon
+    main: ./cmd/rpcdaemon
+    binary: rpcdaemon
+    goos: [ darwin ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2    
+    env:
+      - CC=o64-clang
+      - CXX=o64-clang++
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: darwin-amd64-sentry
+    main: ./cmd/sentry
+    binary: sentry
+    goos: [ darwin ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2    
+    env:
+      - CC=o64-clang
+      - CXX=o64-clang++
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: darwin-amd64-txpool
+    main: ./cmd/txpool
+    binary: txpool
+    goos: [ darwin ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2    
+    env:
+      - CC=o64-clang
+      - CXX=o64-clang++
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+## End Darwin AMD64
+
+
+## Darwin ARM64:
+  - id: darwin-arm64-erigon
     main: ./cmd/erigon
     binary: erigon
     goos: [ darwin ]
@@ -25,21 +230,385 @@ builds:
     env:
       - CC=oa64-clang
       - CXX=oa64-clang++
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
     tags: [ nosqlite, noboltdb, nosilkworm ]
-    ldflags: -s -w
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
 
-  - id: linux-amd64
+  - id: darwin-arm64-downloader
+    main: ./cmd/downloader
+    binary: downloader
+    goos: [ darwin ]
+    goarch: [ arm64 ]
+    env:
+      - CC=oa64-clang
+      - CXX=oa64-clang++
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: darwin-arm64-devnet
+    main: ./cmd/devnet
+    binary: devnet
+    goos: [ darwin ]
+    goarch: [ arm64 ]
+    env:
+      - CC=oa64-clang
+      - CXX=oa64-clang++
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: darwin-arm64-evm
+    main: ./cmd/evm
+    binary: evm
+    goos: [ darwin ]
+    goarch: [ arm64 ]
+    env:
+      - CC=oa64-clang
+      - CXX=oa64-clang++
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: darwin-arm64-caplin
+    main: ./cmd/caplin
+    binary: caplin
+    goos: [ darwin ]
+    goarch: [ arm64 ]
+    env:
+      - CC=oa64-clang
+      - CXX=oa64-clang++
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: darwin-arm64-diag
+    main: ./cmd/diag
+    binary: diag
+    goos: [ darwin ]
+    goarch: [ arm64 ]
+    env:
+      - CC=oa64-clang
+      - CXX=oa64-clang++
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: darwin-arm64-integration
+    main: ./cmd/integration
+    binary: integration
+    goos: [ darwin ]
+    goarch: [ arm64 ]
+    env:
+      - CC=oa64-clang
+      - CXX=oa64-clang++
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: darwin-arm64-rpcdaemon
+    main: ./cmd/rpcdaemon
+    binary: rpcdaemon
+    goos: [ darwin ]
+    goarch: [ arm64 ]
+    env:
+      - CC=oa64-clang
+      - CXX=oa64-clang++
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: darwin-arm64-sentry
+    main: ./cmd/sentry
+    binary: sentry
+    goos: [ darwin ]
+    goarch: [ arm64 ]
+    env:
+      - CC=oa64-clang
+      - CXX=oa64-clang++
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: darwin-arm64-txpool
+    main: ./cmd/txpool
+    binary: txpool
+    goos: [ darwin ]
+    goarch: [ arm64 ]
+    env:
+      - CC=oa64-clang
+      - CXX=oa64-clang++
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+## End Darwin ARM64
+
+
+## Linux AMD64:
+  - id: linux-amd64-erigon
     main: ./cmd/erigon
     binary: erigon
     goos: [ linux ]
     goarch: [ amd64 ]
+    goamd64:
+      - v2
     env:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
     tags: [ nosqlite, noboltdb, nosilkworm ]
-    ldflags: -s -w -extldflags "-static" # We need to build a static binary because we are building in a glibc based system and running in a musl container
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
 
-  - id: linux-arm64
+  - id: linux-amd64-downloader
+    main: ./cmd/downloader
+    binary: downloader
+    goos: [ linux ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2
+    env:
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: linux-amd64-devnet
+    main: ./cmd/devnet
+    binary: devnet
+    goos: [ linux ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2
+    env:
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: linux-amd64-evm
+    main: ./cmd/evm
+    binary: evm
+    goos: [ linux ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2
+    env:
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: linux-amd64-caplin
+    main: ./cmd/caplin
+    binary: caplin
+    goos: [ linux ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2
+    env:
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: linux-amd64-diag
+    main: ./cmd/diag
+    binary: diag
+    goos: [ linux ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2
+    env:
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: linux-amd64-integration
+    main: ./cmd/integration
+    binary: integration
+    goos: [ linux ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2
+    env:
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: linux-amd64-rpcdaemon
+    main: ./cmd/rpcdaemon
+    binary: rpcdaemon
+    goos: [ linux ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2
+    env:
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: linux-amd64-sentry
+    main: ./cmd/sentry
+    binary: sentry
+    goos: [ linux ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2
+    env:
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: linux-amd64-txpool
+    main: ./cmd/txpool
+    binary: txpool
+    goos: [ linux ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2
+    env:
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+## End of Linux AMD64
+
+
+## Linux ARM64
+  - id: linux-arm64-erigon
     main: ./cmd/erigon
     binary: erigon
     goos: [ linux ]
@@ -47,10 +616,182 @@ builds:
     env:
       - CC=aarch64-linux-gnu-gcc
       - CXX=aarch64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
     tags: [ nosqlite, noboltdb, nosilkworm ]
-    ldflags: -s -w -extldflags "-static" # We need to build a static binary because we are building in a glibc based system and running in a musl container
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
 
-  - id: windows-amd64
+  - id: linux-arm64-downloader
+    main: ./cmd/downloader
+    binary: downloader
+    goos: [ linux ]
+    goarch: [ arm64 ]
+    env:
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: linux-arm64-devnet
+    main: ./cmd/devnet
+    binary: devnet
+    goos: [ linux ]
+    goarch: [ arm64 ]
+    env:
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: linux-arm64-evm
+    main: ./cmd/evm
+    binary: evm
+    goos: [ linux ]
+    goarch: [ arm64 ]
+    env:
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: linux-arm64-caplin
+    main: ./cmd/caplin
+    binary: caplin
+    goos: [ linux ]
+    goarch: [ arm64 ]
+    env:
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: linux-arm64-diag
+    main: ./cmd/diag
+    binary: diag
+    goos: [ linux ]
+    goarch: [ arm64 ]
+    env:
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: linux-arm64-integration
+    main: ./cmd/integration
+    binary: integration
+    goos: [ linux ]
+    goarch: [ arm64 ]
+    env:
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: linux-arm64-rpcdaemon
+    main: ./cmd/rpcdaemon
+    binary: rpcdaemon
+    goos: [ linux ]
+    goarch: [ arm64 ]
+    env:
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: linux-arm64-sentry
+    main: ./cmd/sentry
+    binary: sentry
+    goos: [ linux ]
+    goarch: [ arm64 ]
+    env:
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: linux-arm64-txpool
+    main: ./cmd/txpool
+    binary: txpool
+    goos: [ linux ]
+    goarch: [ arm64 ]
+    env:
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+## End of Linux ARM64
+
+
+## Windows AMD64:
+  - id: windows-amd64-erigon
     main: ./cmd/erigon
     binary: erigon
     goos: [ windows ]
@@ -58,65 +799,310 @@ builds:
     env:
       - CC=x86_64-w64-mingw32-gcc
       - CXX=x86_64-w64-mingw32-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_WINDOWS }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+      - CMAKE_MDBX_BUILD_SHARED_LIBRARY:BOOL=OFF
+      - CMAKE_MDBX_WITHOUT_MSVC_CRT:BOOOL=OFF
+      - CMAKE_MDBX_BUILD_TIMESTAMP=unknown
+      - CMAKE_MDBX_FORCE_ASSERTIONS:INT=0
     tags: [ nosqlite, noboltdb, nosilkworm ]
-    ldflags: -s -w
+    flags:
+      - -v
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: windows-amd64-downloader
+    main: ./cmd/downloader
+    binary: downloader
+    goos: [ windows ]
+    goarch: [ amd64 ]
+    env:
+      - CC=x86_64-w64-mingw32-gcc
+      - CXX=x86_64-w64-mingw32-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_WINDOWS }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+      - CMAKE_MDBX_BUILD_SHARED_LIBRARY:BOOL=OFF
+      - CMAKE_MDBX_WITHOUT_MSVC_CRT:BOOOL=OFF
+      - CMAKE_MDBX_BUILD_TIMESTAMP=unknown
+      - CMAKE_MDBX_FORCE_ASSERTIONS:INT=0
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: windows-amd64-devnet
+    main: ./cmd/devnet
+    binary: devnet
+    goos: [ windows ]
+    goarch: [ amd64 ]
+    env:
+      - CC=x86_64-w64-mingw32-gcc
+      - CXX=x86_64-w64-mingw32-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_WINDOWS }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+      - CMAKE_MDBX_BUILD_SHARED_LIBRARY:BOOL=OFF
+      - CMAKE_MDBX_WITHOUT_MSVC_CRT:BOOOL=OFF
+      - CMAKE_MDBX_BUILD_TIMESTAMP=unknown
+      - CMAKE_MDBX_FORCE_ASSERTIONS:INT=0
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: windows-amd64-evm
+    main: ./cmd/evm
+    binary: evm
+    goos: [ windows ]
+    goarch: [ amd64 ]
+    env:
+      - CC=x86_64-w64-mingw32-gcc
+      - CXX=x86_64-w64-mingw32-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_WINDOWS }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+      - CMAKE_MDBX_BUILD_SHARED_LIBRARY:BOOL=OFF
+      - CMAKE_MDBX_WITHOUT_MSVC_CRT:BOOOL=OFF
+      - CMAKE_MDBX_BUILD_TIMESTAMP=unknown
+      - CMAKE_MDBX_FORCE_ASSERTIONS:INT=0
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: windows-amd64-caplin
+    main: ./cmd/caplin
+    binary: caplin
+    goos: [ windows ]
+    goarch: [ amd64 ]
+    env:
+      - CC=x86_64-w64-mingw32-gcc
+      - CXX=x86_64-w64-mingw32-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_WINDOWS }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+      - CMAKE_MDBX_BUILD_SHARED_LIBRARY:BOOL=OFF
+      - CMAKE_MDBX_WITHOUT_MSVC_CRT:BOOOL=OFF
+      - CMAKE_MDBX_BUILD_TIMESTAMP=unknown
+      - CMAKE_MDBX_FORCE_ASSERTIONS:INT=0
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: windows-amd64-diag
+    main: ./cmd/diag
+    binary: diag
+    goos: [ windows ]
+    goarch: [ amd64 ]
+    env:
+      - CC=x86_64-w64-mingw32-gcc
+      - CXX=x86_64-w64-mingw32-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_WINDOWS }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+      - CMAKE_MDBX_BUILD_SHARED_LIBRARY:BOOL=OFF
+      - CMAKE_MDBX_WITHOUT_MSVC_CRT:BOOOL=OFF
+      - CMAKE_MDBX_BUILD_TIMESTAMP=unknown
+      - CMAKE_MDBX_FORCE_ASSERTIONS:INT=0
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: windows-amd64-integration
+    main: ./cmd/integration
+    binary: integration
+    goos: [ windows ]
+    goarch: [ amd64 ]
+    env:
+      - CC=x86_64-w64-mingw32-gcc
+      - CXX=x86_64-w64-mingw32-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_WINDOWS }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+      - CMAKE_MDBX_BUILD_SHARED_LIBRARY:BOOL=OFF
+      - CMAKE_MDBX_WITHOUT_MSVC_CRT:BOOOL=OFF
+      - CMAKE_MDBX_BUILD_TIMESTAMP=unknown
+      - CMAKE_MDBX_FORCE_ASSERTIONS:INT=0
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: windows-amd64-rpcdaemon
+    main: ./cmd/rpcdaemon
+    binary: rpcdaemon
+    goos: [ windows ]
+    goarch: [ amd64 ]
+    env:
+      - CC=x86_64-w64-mingw32-gcc
+      - CXX=x86_64-w64-mingw32-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_WINDOWS }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+      - CMAKE_MDBX_BUILD_SHARED_LIBRARY:BOOL=OFF
+      - CMAKE_MDBX_WITHOUT_MSVC_CRT:BOOOL=OFF
+      - CMAKE_MDBX_BUILD_TIMESTAMP=unknown
+      - CMAKE_MDBX_FORCE_ASSERTIONS:INT=0
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: windows-amd64-sentry
+    main: ./cmd/sentry
+    binary: sentry
+    goos: [ windows ]
+    goarch: [ amd64 ]
+    env:
+      - CC=x86_64-w64-mingw32-gcc
+      - CXX=x86_64-w64-mingw32-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_WINDOWS }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+      - CMAKE_MDBX_BUILD_SHARED_LIBRARY:BOOL=OFF
+      - CMAKE_MDBX_WITHOUT_MSVC_CRT:BOOOL=OFF
+      - CMAKE_MDBX_BUILD_TIMESTAMP=unknown
+      - CMAKE_MDBX_FORCE_ASSERTIONS:INT=0
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: windows-amd64-txpool
+    main: ./cmd/txpool
+    binary: txpool
+    goos: [ windows ]
+    goarch: [ amd64 ]
+    env:
+      - CC=x86_64-w64-mingw32-gcc
+      - CXX=x86_64-w64-mingw32-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_WINDOWS }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+      - CMAKE_MDBX_BUILD_SHARED_LIBRARY:BOOL=OFF
+      - CMAKE_MDBX_WITHOUT_MSVC_CRT:BOOOL=OFF
+      - CMAKE_MDBX_BUILD_TIMESTAMP=unknown
+      - CMAKE_MDBX_FORCE_ASSERTIONS:INT=0
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+## Windows AMD64
 
 
-snapshot:
-  name_template: "{{ .Tag }}.next"
+## Checksums
+checksum:
+  name_template: "{{ .Env.APPLICATION }}_{{ .Env.BUILD_VERSION }}_checksums.txt"
+  algorithm: sha256
+  ids:
+    - linux-arm64
+    - linux-amd64
+    - darwin-amd64
+    - darwin-arm64
+    # - windows-amd64
 
-dockers:
-  - image_templates:
-      - thorax/{{ .ProjectName }}:{{ .Version }}-amd64
-      - ghcr.io/erigontech/{{ .ProjectName }}:{{ .Version }}-amd64
-    dockerfile: Dockerfile.release
-    use: buildx
-    skip_push: true
-    goarch: amd64
-    ids:
-      - linux-amd64
-    build_flag_templates:
-      - --platform=linux/amd64
 
-  - image_templates:
-      - thorax/{{ .ProjectName }}:{{ .Version }}-arm64
-      - ghcr.io/erigontech/{{ .ProjectName }}:{{ .Version }}-arm64
-    dockerfile: Dockerfile.release
-    skip_push: true
-    use: buildx
-    goarch: arm64
-    ids:
-      - linux-arm64
-    build_flag_templates:
-      - --platform=linux/arm64/v8
+archives:
+  - id: linux-arm64
+    builds:
+      - linux-arm64-erigon
+      - linux-arm64-downloader
+      - linux-arm64-devnet
+      - linux-arm64-evm
+      - linux-arm64-caplin
+      - linux-arm64-diag
+      - linux-arm64-integration
+      - linux-arm64-rpcdaemon
+      - linux-arm64-sentry
+      - linux-arm64-txpool
+    name_template: "{{ .Env.APPLICATION }}_{{ .Env.BUILD_VERSION }}_{{ .Os }}_{{ .Arch }}"
+    wrap_in_directory: true
+    format: tar.gz
 
-docker_manifests:
-  - name_template: thorax/{{ .ProjectName }}:{{ .Version }}
-    skip_push: true
-    image_templates:
-      - thorax/{{ .ProjectName }}:{{ .Version }}-amd64
-      - thorax/{{ .ProjectName }}:{{ .Version }}-arm64
+  - id: linux-amd64
+    builds:
+      - linux-amd64-erigon
+      - linux-amd64-downloader
+      - linux-amd64-devnet
+      - linux-amd64-evm
+      - linux-amd64-caplin
+      - linux-amd64-diag
+      - linux-amd64-integration
+      - linux-amd64-rpcdaemon
+      - linux-amd64-sentry
+      - linux-amd64-txpool
+    name_template: "{{ .Env.APPLICATION }}_{{ .Env.BUILD_VERSION }}_{{ .Os }}_{{ .Arch }}"
+    wrap_in_directory: true
+    format: tar.gz
 
-  - name_template: ghcr.io/erigontech/{{ .ProjectName }}:{{ .Version }}
-    skip_push: true
-    image_templates:
-      - ghcr.io/erigontech/{{ .ProjectName }}:{{ .Version }}-amd64
-      - ghcr.io/erigontech/{{ .ProjectName }}:{{ .Version }}-arm64
+  - id: darwin-amd64
+    builds:
+      - darwin-amd64-erigon
+      - darwin-amd64-downloader
+      - darwin-amd64-devnet
+      - darwin-amd64-evm
+      - darwin-amd64-caplin
+      - darwin-amd64-diag
+      - darwin-amd64-integration
+      - darwin-amd64-rpcdaemon
+      - darwin-amd64-sentry
+      - darwin-amd64-txpool
+    name_template: "{{ .Env.APPLICATION }}_{{ .Env.BUILD_VERSION }}_{{ .Os }}_{{ .Arch }}"
+    wrap_in_directory: true
+    format: tar.gz
 
-  - name_template: thorax/{{ .ProjectName }}:latest
-    skip_push: true
-    image_templates:
-      - thorax/{{ .ProjectName }}:{{ .Version }}-amd64
-      - thorax/{{ .ProjectName }}:{{ .Version }}-arm64
+  - id: darwin-arm64
+    builds:
+      - darwin-arm64-erigon
+      - darwin-arm64-downloader
+      - darwin-arm64-devnet
+      - darwin-arm64-evm
+      - darwin-arm64-caplin
+      - darwin-arm64-diag
+      - darwin-arm64-integration
+      - darwin-arm64-rpcdaemon
+      - darwin-arm64-sentry
+      - darwin-arm64-txpool
+    name_template: "{{ .Env.APPLICATION }}_{{ .Env.BUILD_VERSION }}_{{ .Os }}_{{ .Arch }}"
+    wrap_in_directory: true
+    format: tar.gz
 
-  - name_template: ghcr.io/erigontech/{{ .ProjectName }}:latest
-    skip_push: true
-    image_templates:
-      - ghcr.io/erigontech/{{ .ProjectName }}:{{ .Version }}-amd64
-      - ghcr.io/erigontech/{{ .ProjectName }}:{{ .Version }}-arm64
-
-announce:
-  slack:
-    enabled: false
-    # The name of the channel that the user selected as a destination for webhook messages.
-    channel: '#code-releases'
+  - id: windows-amd64
+    builds:
+      - windows-amd64-erigon
+      - windows-amd64-downloader
+      - windows-amd64-devnet
+      - windows-amd64-evm
+      - windows-amd64-caplin
+      - windows-amd64-diag
+      - windows-amd64-integration
+      - windows-amd64-rpcdaemon
+      - windows-amd64-sentry
+      - windows-amd64-txpool
+    name_template: "{{ .Env.APPLICATION }}_{{ .Env.BUILD_VERSION }}_{{ .Os }}_{{ .Arch }}"
+    wrap_in_directory: true
+    format: zip

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,8 +1,50 @@
-FROM alpine:3.14
+ARG DOCKER_BASE_IMAGE="alpine:3.20.1"
 
-RUN apk add --no-cache ca-certificates && \
-    mkdir -p /etc/erigon
-COPY erigon /usr/local/bin/
+## Note TARGETARCH is a crucial variable:
+##   see https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope
 
-EXPOSE 8545 8551 8546 30303 30303/udp 42069 42069/udp 8080 9090 6060
-ENTRYPOINT ["erigon"]
+FROM ${DOCKER_BASE_IMAGE} AS temporary
+ARG TARGETARCH \
+    VERSION=${VERSION} \
+    APPLICATION
+
+COPY ./dist/${APPLICATION}_${VERSION}_linux_${TARGETARCH}.tar.gz /tmp/${APPLICATION}.tar.gz
+RUN tar xzvf /tmp/${APPLICATION}.tar.gz -C /tmp && \
+    mv /tmp/${APPLICATION}_${VERSION}_linux_${TARGETARCH} /tmp/${APPLICATION}
+
+FROM ${DOCKER_BASE_IMAGE}
+
+ARG USER=erigon \
+    GROUP=erigon \
+    APPLICATION
+
+RUN --mount=type=bind,from=temporary,source=/tmp/${APPLICATION},target=/tmp/${APPLICATION} \
+    apk add --no-cache ca-certificates tzdata && \
+    addgroup ${GROUP} && \
+    adduser -D -h /home/${USER} -G ${GROUP} ${USER} && \
+    install -d -o ${USER} -g ${GROUP} /home/${USER}/.local /home/${USER}/.local/share /home/${USER}/.local/share/erigon && \
+    install -o ${USER} -g ${GROUP} /tmp/${APPLICATION}/erigon /usr/local/bin/ && \
+    install -o ${USER} -g ${GROUP} /tmp/${APPLICATION}/integration /usr/local/bin/ && \
+    install -o ${USER} -g ${GROUP} /tmp/${APPLICATION}/diag /usr/local/bin/ && \
+    install -o ${USER} -g ${GROUP} /tmp/${APPLICATION}/sentry /usr/local/bin/ && \
+    install -o ${USER} -g ${GROUP} /tmp/${APPLICATION}/txpool /usr/local/bin/ && \
+    install -o ${USER} -g ${GROUP} /tmp/${APPLICATION}/downloader /usr/local/bin/ && \
+    install -o ${USER} -g ${GROUP} /tmp/${APPLICATION}/rpcdaemon /usr/local/bin/
+
+VOLUME [ "/home/${USER}" ]
+WORKDIR /home/${USER}
+
+USER ${USER}
+
+EXPOSE 8545 \
+       8551 \
+       8546 \
+       30303 \
+       30303/udp \
+       42069 \
+       42069/udp \
+       8080 \
+       9090 \
+       6060
+
+ENTRYPOINT [ "/usr/local/bin/erigon" ]


### PR DESCRIPTION
It is a work on https://github.com/erigontech/erigon/issues/10251 .

Main changes:
- goreleaser reconfigured (more binaries added, most of the build flags passed to goreleaser)
- released erigon binary now has "Build info" dynamic values such as a branch, tag, commit id.
- amd64 binaries will be build using GOAMD64=v2 support for better support of modern CPUs.
- as agreed -- now it will generate release without prefix "v", i.e. "2.60.7", but not "v2.60.7".
- docker image will have following binaries: erigon, integration, diag, sentry, txpool, downloader and rpcdaemon. (Exactly the same binaries as published in artifacts in the release notes).
- multi-platform docker tag created with support of two OS/Arch -- linux/amd64/v2 and linux/arm64 which should cover almost all use cases when docker container used.
- docker images will have labels which refer to full commit id and short commit id, build timestamp, and others. It may help to identify which commit is a part of the image.
- this workflow could be executed in a "dry_run" mode, i.e. to build artifacts and keep it for a 1d in a workflow artifact store (in this case we can download artifacts and test before actual release).

Windows artifacts will be not released for now (require fix).