### PR TITLE
Add "ERIGON_" prefix to env variables

### DIFF
--- a/erigon-lib/common/dbg/dbg_env.go
+++ b/erigon-lib/common/dbg/dbg_env.go
@@ -49,6 +49,7 @@ func EnvBool(envVarName string, defaultVal bool) bool {
 		return true
 	}
 	if v == "false" {
+		log.Warn("[env] please use ERIGON_ prefix for env variables of erigon", "var", envVarName)
 		log.Info("[dbg] env", envVarName, false)
 		return false
 	}

--- a/erigon-lib/common/dbg/dbg_env.go
+++ b/erigon-lib/common/dbg/dbg_env.go
@@ -29,6 +29,7 @@ import (
 func EnvString(envVarName string, defaultVal string) string {
 	v, _ := os.LookupEnv(envVarName)
 	if v != "" {
+		log.Warn("[env] please use ERIGON_ prefix for env variables of erigon", "var", envVarName)
 		log.Info("[dbg] env", envVarName, v)
 		return v
 	}
@@ -43,6 +44,7 @@ func EnvString(envVarName string, defaultVal string) string {
 func EnvBool(envVarName string, defaultVal bool) bool {
 	v, _ := os.LookupEnv(envVarName)
 	if v == "true" {
+		log.Warn("[env] please use ERIGON_ prefix for env variables of erigon", "var", envVarName)
 		log.Info("[dbg] env", envVarName, true)
 		return true
 	}
@@ -65,6 +67,7 @@ func EnvBool(envVarName string, defaultVal bool) bool {
 func EnvInt(envVarName string, defaultVal int) int {
 	v, _ := os.LookupEnv(envVarName)
 	if v != "" {
+		log.Warn("[env] please use ERIGON_ prefix for env variables of erigon", "var", envVarName)
 		i, err := strconv.Atoi(v)
 		if err != nil {
 			panic(err)
@@ -87,6 +90,7 @@ func EnvInt(envVarName string, defaultVal int) int {
 func EnvDataSize(envVarName string, defaultVal datasize.ByteSize) datasize.ByteSize {
 	v, _ := os.LookupEnv(envVarName)
 	if v != "" {
+		log.Warn("[env] please use ERIGON_ prefix for env variables of erigon", "var", envVarName)
 		val, err := datasize.ParseString(v)
 		if err != nil {
 			panic(err)
@@ -110,6 +114,7 @@ func EnvDataSize(envVarName string, defaultVal datasize.ByteSize) datasize.ByteS
 func EnvDuration(envVarName string, defaultVal time.Duration) time.Duration {
 	v, _ := os.LookupEnv(envVarName)
 	if v != "" {
+		log.Warn("[env] please use ERIGON_ prefix for env variables of erigon", "var", envVarName)
 		log.Info("[dbg] env", envVarName, v)
 		val, err := time.ParseDuration(v)
 		if err != nil {

--- a/erigon-lib/common/dbg/dbg_env.go
+++ b/erigon-lib/common/dbg/dbg_env.go
@@ -32,10 +32,26 @@ func EnvString(envVarName string, defaultVal string) string {
 		log.Info("[dbg] env", envVarName, v)
 		return v
 	}
+
+	v, _ = os.LookupEnv("ERIGON_" + envVarName)
+	if v != "" {
+		log.Info("[dbg] env", envVarName, v)
+		return v
+	}
 	return defaultVal
 }
 func EnvBool(envVarName string, defaultVal bool) bool {
 	v, _ := os.LookupEnv(envVarName)
+	if v == "true" {
+		log.Info("[dbg] env", envVarName, true)
+		return true
+	}
+	if v == "false" {
+		log.Info("[dbg] env", envVarName, false)
+		return false
+	}
+
+	v, _ = os.LookupEnv("ERIGON_" + envVarName)
 	if v == "true" {
 		log.Info("[dbg] env", envVarName, true)
 		return true
@@ -56,10 +72,30 @@ func EnvInt(envVarName string, defaultVal int) int {
 		log.Info("[dbg] env", envVarName, i)
 		return i
 	}
+
+	v, _ = os.LookupEnv("ERIGON_" + envVarName)
+	if v != "" {
+		i, err := strconv.Atoi(v)
+		if err != nil {
+			panic(err)
+		}
+		log.Info("[dbg] env", envVarName, i)
+		return i
+	}
 	return defaultVal
 }
 func EnvDataSize(envVarName string, defaultVal datasize.ByteSize) datasize.ByteSize {
 	v, _ := os.LookupEnv(envVarName)
+	if v != "" {
+		val, err := datasize.ParseString(v)
+		if err != nil {
+			panic(err)
+		}
+		log.Info("[dbg] env", envVarName, val)
+		return val
+	}
+
+	v, _ = os.LookupEnv("ERIGON_" + envVarName)
 	if v != "" {
 		val, err := datasize.ParseString(v)
 		if err != nil {
@@ -73,6 +109,15 @@ func EnvDataSize(envVarName string, defaultVal datasize.ByteSize) datasize.ByteS
 
 func EnvDuration(envVarName string, defaultVal time.Duration) time.Duration {
 	v, _ := os.LookupEnv(envVarName)
+	if v != "" {
+		log.Info("[dbg] env", envVarName, v)
+		val, err := time.ParseDuration(v)
+		if err != nil {
+			panic(err)
+		}
+		return val
+	}
+	v, _ = os.LookupEnv("ERIGON_" + envVarName)
 	if v != "" {
 		log.Info("[dbg] env", envVarName, v)
 		val, err := time.ParseDuration(v)


### PR DESCRIPTION
step1: allow both, and log.Warn
step2 (in some future): something more radical
