### PR TITLE
el-consensus: Add 2935 condition to fail silently if no code in HistoryStorageAddress

### DIFF
--- a/consensus/misc/eip2935.go
+++ b/consensus/misc/eip2935.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/erigontech/erigon-lib/chain"
 	libcommon "github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/log/v3"
 
 	"github.com/erigontech/erigon/consensus"
 	"github.com/erigontech/erigon/core/state"
@@ -29,6 +30,10 @@ import (
 )
 
 func StoreBlockHashesEip2935(header *types.Header, state *state.IntraBlockState, config *chain.Config, headerReader consensus.ChainHeaderReader) {
+	if state.GetCodeSize(params.HistoryStorageAddress) == 0 {
+		log.Debug("[EIP-2935] No code deployed to HistoryStorageAddress before call to store EIP-2935 history")
+		return
+	}
 	headerNum := header.Number.Uint64()
 	if headerNum == 0 { // Activation of fork at Genesis
 		return


### PR DESCRIPTION
Few points:
- Of the two options for inserting the parent block hash , we go for option 2, that is `Avoid EVM processing and directly write to the state trie.` . 
- Although option 1 is preferred "till verkle", there is no benefit in adding the EVM overhead. Furthermore, verkle-related changes will be there afterwards.
- Now this necessitates additional checking - `if no code exists at HISTORY_STORAGE_ADDRESS, the call must fail silently`.
- We include this check and add a debug log for the fail

Ref: https://github.com/ethereum/EIPs/blob/117933b21665ca7c0d040835a9d19b4a02392f47/EIPS/eip-2935.md