### PR TITLE
polygon: astrid sync stage fix deadlock on cancelled context

### DIFF
--- a/eth/stagedsync/stage_polygon_sync.go
+++ b/eth/stagedsync/stage_polygon_sync.go
@@ -1430,7 +1430,7 @@ func (e *polygonSyncStageExecutionEngine) currentHeader(ctx context.Context, tx 
 func awaitTxAction[T any](
 	ctx context.Context,
 	txActionStream chan<- polygonSyncStageTxAction,
-	cb func(tx kv.RwTx, respond func(T) error) error,
+	cb func(tx kv.RwTx, respond func(response T) error) error,
 ) (T, error) {
 	responseStream := make(chan T)
 	respondFunc := func(response T) error {

--- a/eth/stagedsync/stage_polygon_sync.go
+++ b/eth/stagedsync/stage_polygon_sync.go
@@ -466,8 +466,9 @@ func (s *polygonSyncStageService) Run(ctx context.Context, tx kv.RwTx, stageStat
 				return nil
 			}
 			if errors.Is(err, context.Canceled) {
-				s.logger.Warn(s.appendLogPrefix("tx action was cancelled by creator"))
-				continue
+				// we return a different err and not context.Canceled because that will cancel the stage loop
+				// instead we want the stage loop to return to this stage and re-processes
+				return errors.New("txAction cancelled by requester")
 			}
 			if err != nil {
 				return err

--- a/eth/stagedsync/stage_polygon_sync.go
+++ b/eth/stagedsync/stage_polygon_sync.go
@@ -465,6 +465,10 @@ func (s *polygonSyncStageService) Run(ctx context.Context, tx kv.RwTx, stageStat
 			if errors.Is(err, updateForkChoiceSuccessErr) {
 				return nil
 			}
+			if errors.Is(err, context.Canceled) {
+				s.logger.Warn(s.appendLogPrefix("tx action was cancelled by creator"))
+				continue
+			}
 			if err != nil {
 				return err
 			}
@@ -563,10 +567,9 @@ func (s polygonSyncStageCheckpointStore) LastEntityId(ctx context.Context) (uint
 		err error
 	}
 
-	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, responseStream chan<- response) error {
+	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, respond func(r response) error) error {
 		id, ok, err := s.checkpointReader.LastCheckpointId(ctx, tx)
-		responseStream <- response{id: id, ok: ok, err: err}
-		return nil
+		return respond(response{id: id, ok: ok, err: err})
 	})
 	if err != nil {
 		return 0, false, err
@@ -593,10 +596,9 @@ func (s polygonSyncStageCheckpointStore) Entity(ctx context.Context, id uint64) 
 		err error
 	}
 
-	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, responseStream chan<- response) error {
+	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, respond func(r response) error) error {
 		v, err := s.checkpointReader.Checkpoint(ctx, tx, id)
-		responseStream <- response{v: v, err: err}
-		return nil
+		return respond(response{v: v, err: err})
 	})
 	if err != nil {
 		return nil, false, err
@@ -629,9 +631,8 @@ func (s polygonSyncStageCheckpointStore) PutEntity(ctx context.Context, id uint6
 		err error
 	}
 
-	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, responseStream chan<- response) error {
-		responseStream <- response{err: tx.Put(kv.BorCheckpoints, k[:], v)}
-		return nil
+	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, respond func(r response) error) error {
+		return respond(response{err: tx.Put(kv.BorCheckpoints, k[:], v)})
 	})
 	if err != nil {
 		return err
@@ -646,11 +647,10 @@ func (s polygonSyncStageCheckpointStore) RangeFromBlockNum(ctx context.Context, 
 		err    error
 	}
 
-	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, responseStream chan<- response) error {
+	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, respond func(r response) error) error {
 		makeEntity := func() *heimdall.Checkpoint { return &heimdall.Checkpoint{} }
 		r, err := blockRangeEntitiesFromBlockNum(tx, kv.BorCheckpoints, makeEntity, blockNum)
-		responseStream <- response{result: r, err: err}
-		return nil
+		return respond(response{result: r, err: err})
 	})
 	if err != nil {
 		return nil, err
@@ -679,10 +679,9 @@ func (s polygonSyncStageMilestoneStore) LastEntityId(ctx context.Context) (uint6
 		err error
 	}
 
-	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, responseStream chan<- response) error {
+	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, respond func(r response) error) error {
 		id, ok, err := s.milestoneReader.LastMilestoneId(ctx, tx)
-		responseStream <- response{id: id, ok: ok, err: err}
-		return nil
+		return respond(response{id: id, ok: ok, err: err})
 	})
 	if err != nil {
 		return 0, false, err
@@ -709,10 +708,9 @@ func (s polygonSyncStageMilestoneStore) Entity(ctx context.Context, id uint64) (
 		err error
 	}
 
-	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, responseStream chan<- response) error {
+	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, respond func(r response) error) error {
 		v, err := s.milestoneReader.Milestone(ctx, tx, id)
-		responseStream <- response{v: v, err: err}
-		return nil
+		return respond(response{v: v, err: err})
 	})
 	if err != nil {
 		return nil, false, err
@@ -743,9 +741,8 @@ func (s polygonSyncStageMilestoneStore) PutEntity(ctx context.Context, id uint64
 		err error
 	}
 
-	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, responseStream chan<- response) error {
-		responseStream <- response{err: tx.Put(kv.BorMilestones, k[:], v)}
-		return nil
+	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, respond func(r response) error) error {
+		return respond(response{err: tx.Put(kv.BorMilestones, k[:], v)})
 	})
 	if err != nil {
 		return err
@@ -760,11 +757,10 @@ func (s polygonSyncStageMilestoneStore) RangeFromBlockNum(ctx context.Context, b
 		err    error
 	}
 
-	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, responseStream chan<- response) error {
+	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, respond func(r response) error) error {
 		makeEntity := func() *heimdall.Milestone { return &heimdall.Milestone{} }
 		r, err := blockRangeEntitiesFromBlockNum(tx, kv.BorMilestones, makeEntity, blockNum)
-		responseStream <- response{result: r, err: err}
-		return nil
+		return respond(response{result: r, err: err})
 	})
 	if err != nil {
 		return nil, err
@@ -793,10 +789,9 @@ func (s polygonSyncStageSpanStore) LastEntityId(ctx context.Context) (id uint64,
 		err error
 	}
 
-	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, responseStream chan<- response) error {
+	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, respond func(r response) error) error {
 		id, ok, err := s.spanReader.LastSpanId(ctx, tx)
-		responseStream <- response{id: id, ok: ok, err: err}
-		return nil
+		return respond(response{id: id, ok: ok, err: err})
 	})
 	if err != nil {
 		return 0, false, err
@@ -823,10 +818,9 @@ func (s polygonSyncStageSpanStore) Entity(ctx context.Context, id uint64) (*heim
 		err error
 	}
 
-	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, responseStream chan<- response) error {
+	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, respond func(r response) error) error {
 		v, err := s.spanReader.Span(ctx, tx, id)
-		responseStream <- response{v: v, err: err}
-		return nil
+		return respond(response{v: v, err: err})
 	})
 	if err != nil {
 		return nil, false, err
@@ -857,9 +851,8 @@ func (s polygonSyncStageSpanStore) PutEntity(ctx context.Context, id uint64, ent
 		err error
 	}
 
-	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, responseStream chan<- response) error {
-		responseStream <- response{err: tx.Put(kv.BorSpans, k[:], v)}
-		return nil
+	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, respond func(r response) error) error {
+		return respond(response{err: tx.Put(kv.BorSpans, k[:], v)})
 	})
 	if err != nil {
 		return err
@@ -874,11 +867,10 @@ func (s polygonSyncStageSpanStore) RangeFromBlockNum(ctx context.Context, blockN
 		err    error
 	}
 
-	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, responseStream chan<- response) error {
+	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, respond func(r response) error) error {
 		makeEntity := func() *heimdall.Span { return &heimdall.Span{} }
 		r, err := blockRangeEntitiesFromBlockNum(tx, kv.BorSpans, makeEntity, blockNum)
-		responseStream <- response{result: r, err: err}
-		return nil
+		return respond(response{result: r, err: err})
 	})
 	if err != nil {
 		return nil, err
@@ -916,27 +908,23 @@ func (s polygonSyncStageSbpsStore) LastEntity(ctx context.Context) (*heimdall.Sp
 		err error
 	}
 
-	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, responseStream chan<- response) error {
+	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, respond func(r response) error) error {
 		cursor, err := tx.Cursor(kv.BorProducerSelections)
 		if err != nil {
-			responseStream <- response{err: err}
-			return nil
+			return respond(response{err: err})
 		}
 
 		defer cursor.Close()
 		k, v, err := cursor.Last()
 		if err != nil {
-			responseStream <- response{v: nil, ok: false, err: err}
-			return nil
+			return respond(response{v: nil, ok: false, err: err})
 		}
 		if k == nil {
 			// not found
-			responseStream <- response{v: nil, ok: false, err: nil}
-			return nil
+			return respond(response{v: nil, ok: false, err: nil})
 		}
 
-		responseStream <- response{v: v, ok: true, err: err}
-		return nil
+		return respond(response{v: v, ok: true, err: err})
 	})
 	if err != nil {
 		return nil, false, err
@@ -957,23 +945,20 @@ func (s polygonSyncStageSbpsStore) Entity(ctx context.Context, id uint64) (*heim
 		err error
 	}
 
-	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, responseStream chan<- response) error {
+	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, respond func(r response) error) error {
 		k := make([]byte, dbutils.NumberLength)
 		binary.BigEndian.PutUint64(k, id)
 
 		v, err := tx.GetOne(kv.BorProducerSelections, k)
 		if err != nil {
-			responseStream <- response{v: nil, ok: false, err: err}
-			return nil
+			return respond(response{v: nil, ok: false, err: err})
 		}
 		if v == nil {
 			// not found
-			responseStream <- response{v: nil, ok: false, err: nil}
-			return nil
+			return respond(response{v: nil, ok: false, err: nil})
 		}
 
-		responseStream <- response{v: v, ok: true, err: err}
-		return nil
+		return respond(response{v: v, ok: true, err: err})
 	})
 	if err != nil {
 		return nil, false, err
@@ -992,18 +977,16 @@ func (s polygonSyncStageSbpsStore) PutEntity(ctx context.Context, id uint64, ent
 		err error
 	}
 
-	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, responseStream chan<- response) error {
+	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, respond func(r response) error) error {
 		k := make([]byte, dbutils.NumberLength)
 		binary.BigEndian.PutUint64(k, id)
 
 		v, err := json.Marshal(entity)
 		if err != nil {
-			responseStream <- response{err: err}
-			return nil
+			return respond(response{err: err})
 		}
 
-		responseStream <- response{err: tx.Put(kv.BorProducerSelections, k, v)}
-		return nil
+		return respond(response{err: tx.Put(kv.BorProducerSelections, k, v)})
 	})
 	if err != nil {
 		return err
@@ -1018,11 +1001,10 @@ func (s polygonSyncStageSbpsStore) RangeFromBlockNum(ctx context.Context, blockN
 		err    error
 	}
 
-	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, responseStream chan<- response) error {
+	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, respond func(r response) error) error {
 		makeEntity := func() *heimdall.SpanBlockProducerSelection { return &heimdall.SpanBlockProducerSelection{} }
 		r, err := blockRangeEntitiesFromBlockNum(tx, kv.BorProducerSelections, makeEntity, blockNum)
-		responseStream <- response{result: r, err: err}
-		return nil
+		return respond(response{result: r, err: err})
 	})
 	if err != nil {
 		return nil, err
@@ -1082,10 +1064,9 @@ func (s polygonSyncStageBridgeStore) LatestEventID(ctx context.Context) (uint64,
 		err error
 	}
 
-	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, responseStream chan<- response) error {
+	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, respond func(r response) error) error {
 		id, _, err := s.eventReader.LastEventId(ctx, tx)
-		responseStream <- response{id: id, err: err}
-		return nil
+		return respond(response{id: id, err: err})
 	})
 	if err != nil {
 		return 0, err
@@ -1099,9 +1080,8 @@ func (s polygonSyncStageBridgeStore) PutEvents(ctx context.Context, events []*he
 		err error
 	}
 
-	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, responseStream chan<- response) error {
-		responseStream <- response{err: bridge.PutEvents(tx, events)}
-		return nil
+	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, respond func(r response) error) error {
+		return respond(response{err: bridge.PutEvents(tx, events)})
 	})
 	if err != nil {
 		return err
@@ -1116,10 +1096,9 @@ func (s polygonSyncStageBridgeStore) LastProcessedEventID(ctx context.Context) (
 		err error
 	}
 
-	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, responseStream chan<- response) error {
+	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, respond func(r response) error) error {
 		id, err := bridge.LastProcessedEventID(tx)
-		responseStream <- response{id: id, err: err}
-		return nil
+		return respond(response{id: id, err: err})
 	})
 	if err != nil {
 		return 0, err
@@ -1141,10 +1120,9 @@ func (s polygonSyncStageBridgeStore) LastProcessedBlockInfo(ctx context.Context)
 		err  error
 	}
 
-	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, responseStream chan<- response) error {
+	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, respond func(r response) error) error {
 		info, ok, err := bridge.LastProcessedBlockInfo(tx)
-		responseStream <- response{info: info, ok: ok, err: err}
-		return nil
+		return respond(response{info: info, ok: ok, err: err})
 	})
 	if err != nil {
 		return bridge.ProcessedBlockInfo{}, false, err
@@ -1158,9 +1136,8 @@ func (s polygonSyncStageBridgeStore) PutProcessedBlockInfo(ctx context.Context, 
 		err error
 	}
 
-	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, responseStream chan<- response) error {
-		responseStream <- response{err: bridge.PutProcessedBlockInfo(tx, info)}
-		return nil
+	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, respond func(r response) error) error {
+		return respond(response{err: bridge.PutProcessedBlockInfo(tx, info)})
 	})
 	if err != nil {
 		return err
@@ -1179,10 +1156,9 @@ func (s polygonSyncStageBridgeStore) LastEventIDWithinWindow(ctx context.Context
 		err error
 	}
 
-	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, responseStream chan<- response) error {
+	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, respond func(r response) error) error {
 		id, err := bridge.LastEventIDWithinWindow(tx, fromID, toTime)
-		responseStream <- response{id: id, err: err}
-		return nil
+		return respond(response{id: id, err: err})
 	})
 	if err != nil {
 		return 0, err
@@ -1199,9 +1175,8 @@ func (s polygonSyncStageBridgeStore) PutBlockNumToEventID(ctx context.Context, b
 		err error
 	}
 
-	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, responseStream chan<- response) error {
-		responseStream <- response{err: bridge.PutBlockNumToEventID(tx, blockNumToEventId)}
-		return nil
+	r, err := awaitTxAction(ctx, s.txActionStream, func(tx kv.RwTx, respond func(r response) error) error {
+		return respond(response{err: bridge.PutBlockNumToEventID(tx, blockNumToEventId)})
 	})
 	if err != nil {
 		return err
@@ -1271,10 +1246,9 @@ func (e *polygonSyncStageExecutionEngine) GetHeader(ctx context.Context, blockNu
 		err    error
 	}
 
-	r, err := awaitTxAction(ctx, e.txActionStream, func(tx kv.RwTx, responseStream chan<- response) error {
+	r, err := awaitTxAction(ctx, e.txActionStream, func(tx kv.RwTx, respond func(r response) error) error {
 		header, err := e.blockReader.HeaderByNumber(ctx, tx, blockNum)
-		responseStream <- response{header: header, err: err}
-		return nil
+		return respond(response{header: header, err: err})
 	})
 	if err != nil {
 		return nil, err
@@ -1288,9 +1262,8 @@ func (e *polygonSyncStageExecutionEngine) InsertBlocks(ctx context.Context, bloc
 		err error
 	}
 
-	r, err := awaitTxAction(ctx, e.txActionStream, func(tx kv.RwTx, responseStream chan<- response) error {
-		responseStream <- response{err: e.insertBlocks(blocks, tx)}
-		return nil
+	r, err := awaitTxAction(ctx, e.txActionStream, func(tx kv.RwTx, respond func(r response) error) error {
+		return respond(response{err: e.insertBlocks(blocks, tx)})
 	})
 	if err != nil {
 		return err
@@ -1347,9 +1320,11 @@ func (e *polygonSyncStageExecutionEngine) UpdateForkChoice(ctx context.Context, 
 		err error
 	}
 
-	r, err := awaitTxAction(ctx, e.txActionStream, func(tx kv.RwTx, responseStream chan<- response) error {
+	r, err := awaitTxAction(ctx, e.txActionStream, func(tx kv.RwTx, respond func(r response) error) error {
 		err := e.updateForkChoice(tx, tip)
-		responseStream <- response{err: err}
+		if responseErr := respond(response{err: err}); responseErr != nil {
+			return responseErr
+		}
 		if err == nil {
 			return updateForkChoiceSuccessErr
 		}
@@ -1421,10 +1396,9 @@ func (e *polygonSyncStageExecutionEngine) CurrentHeader(ctx context.Context) (*t
 		err    error
 	}
 
-	r, err := awaitTxAction(ctx, e.txActionStream, func(tx kv.RwTx, responseStream chan<- response) error {
+	r, err := awaitTxAction(ctx, e.txActionStream, func(tx kv.RwTx, respond func(r response) error) error {
 		r, err := e.currentHeader(ctx, tx)
-		responseStream <- response{result: r, err: err}
-		return nil
+		return respond(response{result: r, err: err})
 	})
 	if err != nil {
 		return nil, err
@@ -1456,12 +1430,20 @@ func (e *polygonSyncStageExecutionEngine) currentHeader(ctx context.Context, tx 
 func awaitTxAction[T any](
 	ctx context.Context,
 	txActionStream chan<- polygonSyncStageTxAction,
-	cb func(tx kv.RwTx, responseStream chan<- T) error,
+	cb func(tx kv.RwTx, respond func(T) error) error,
 ) (T, error) {
 	responseStream := make(chan T)
+	respondFunc := func(response T) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case responseStream <- response:
+			return nil
+		}
+	}
 	txAction := polygonSyncStageTxAction{
 		apply: func(tx kv.RwTx) error {
-			return cb(tx, responseStream)
+			return cb(tx, respondFunc)
 		},
 	}
 


### PR DESCRIPTION
Run into a deadlock in my long running process of Astrid stage mode. It happened in the following scenario:
- there was an error returned from one of the background components running in the background (the process should have terminated with the error but instead it deadlocked)
- the errorgroup running all the background components ([here](https://github.com/erigontech/erigon/blob/main/eth/stagedsync/stage_polygon_sync.go#L485-L519)) cancelled the context
- `polygonSyncStageSbpsStore.Entity` func queued a tx action in the stream, the action got executed and was just about to pass back the response via the response channel however at the same time the `Entity` func exited due to the context cancelation and there was no one to consume the response from the response stream, so the writer (the polygon sync stage) got stuck and was not able to process the err from the background components
- the solution is to introduce a `respond` function in the `awaitTxAction` mechanism which is context aware and returns when the creator of the action decides to terminate the context

Output from pprof/goroutines:
```
1 @ 0x100a44d08 0x100a0ce00 0x100a0ca38 0x1022ec08c 0x100a7f4b4
#	0x1022ec08b	github.com/erigontech/erigon/eth/stagedsync.(*polygonSyncStageService).runBgComponentsOnce.func1+0x29b	/Users/taratorio/erigon3-run/eth/stagedsync/stage_polygon_sync.go:518

1 @ 0x100a44d08 0x100a0ce00 0x100a0ca38 0x1022ee9c8 0x102307710 0x1022eb858 0x1022e9a68 0x1022c4718 0x102305248 0x1023043f4 0x10250d774 0x10250c900 0x100a7f4b4
#	0x1022ee9c7	github.com/erigontech/erigon/eth/stagedsync.polygonSyncStageSbpsStore.Entity.func1+0xd7	/Users/taratorio/erigon3-run/eth/stagedsync/stage_polygon_sync.go:975
#	0x10230770f	github.com/erigontech/erigon/eth/stagedsync.awaitTxAction[...].func1+0x2f		/Users/taratorio/erigon3-run/eth/stagedsync/stage_polygon_sync.go:1464
#	0x1022eb857	github.com/erigontech/erigon/eth/stagedsync.(*polygonSyncStageService).Run+0x387	/Users/taratorio/erigon3-run/eth/stagedsync/stage_polygon_sync.go:464
#	0x1022e9a67	github.com/erigontech/erigon/eth/stagedsync.ForwardPolygonSyncStage+0x117		/Users/taratorio/erigon3-run/eth/stagedsync/stage_polygon_sync.go:175
#	0x1022c4717	github.com/erigontech/erigon/eth/stagedsync.PolygonSyncStages.func4+0x77		/Users/taratorio/erigon3-run/eth/stagedsync/default_stages.go:479
#	0x102305247	github.com/erigontech/erigon/eth/stagedsync.(*Sync).runStage+0x117			/Users/taratorio/erigon3-run/eth/stagedsync/sync.go:531
#	0x1023043f3	github.com/erigontech/erigon/eth/stagedsync.(*Sync).Run+0x223				/Users/taratorio/erigon3-run/eth/stagedsync/sync.go:410
#	0x10250d773	github.com/erigontech/erigon/turbo/stages.StageLoopIteration+0x393			/Users/taratorio/erigon3-run/turbo/stages/stageloop.go:259
#	0x10250c8ff	github.com/erigontech/erigon/turbo/stages.StageLoop+0x22f				/Users/taratorio/erigon3-run/turbo/stages/stageloop.go:103
```

<br>
Logs

```
INFO[08-27|19:42:25.553] [2/6 PolygonSync] update fork choice     block=11243027 hash=0xfb9d01451bd586667af5a898357029a772e451f945d517ba3abd2774d9e14036
DBUG[08-27|19:42:25.753] [sync] applyNewBlockOnTip: couldn't connect a header to the local chain tip, ignoring err="canonicalChainBuilder.Connect: invalid header error context canceled"
DBUG[08-27|19:42:25.934] [2/6 PolygonSync] DONE                   in=382.240917ms
DBUG[08-27|19:42:26.267] [3/6 Senders] DONE                       in=333.140375ms
INFO[08-27|19:42:26.662] [4/6 Execution] Done Commit every block  blk=11243027 blks=2 blk/s=5.1 txs=9 tx/s=22 gas/s=1.96M buf=191.0KB/2.0GB stepsInDB=0.00 step=23.7 alloc=559.4MB sys=4.9GB
DBUG[08-27|19:42:26.662] [4/6 Execution] DONE                     in=394.539ms
DBUG[08-27|19:42:26.995] [5/6 TxLookup] DONE                      in=333.325084ms
DBUG[08-27|19:42:27.327] [6/6 Finish] DONE                        in=331.952625ms
DBUG[08-27|19:42:27.327] RPC Daemon notified of new headers       from=11243025 to=11243027 amount=2 hash=0xfb9d01451bd586667af5a898357029a772e451f945d517ba3abd2774d9e14036 header sending=15.208µs log sending=166ns
INFO[08-27|19:42:27.327] Timings (slower than 50ms)               OtterSync=356ms PolygonSync=382ms Senders=333ms Execution=394ms TxLookup=333ms Finish=331ms alloc=559.7MB sys=4.9GB
DBUG[08-27|19:42:27.327] [6/6 Finish] Prune done                  in=3.791µs
DBUG[08-27|19:42:27.327] [5/6 TxLookup] Prune done                in=44.833µs
DBUG[08-27|19:42:27.701] [4/6 Execution] Prune done               in=373.344292ms
DBUG[08-27|19:42:27.701] [3/6 Senders] Prune done                 in=3.584µs
DBUG[08-27|19:42:27.701] [2/6 PolygonSync] Prune done             in=1.083µs
DBUG[08-27|19:42:27.701] [snapshots] Prune Blocks                 to=11241976 limit=10
DBUG[08-27|19:42:27.701] [snapshots] Prune Bor Blocks             to=11241976 limit=10
DBUG[08-27|19:42:27.702] [1/6 OtterSync] Prune done               in=793.625µs
DBUG[08-27|19:42:28.548] [1/6 OtterSync] DONE                     in=352.445625ms
INFO[08-27|19:42:28.548] [2/6 PolygonSync] forward                progress=11243027

... process deadlocked here and no progress was made nor error message/shutdown ...
... notice the log line applyNewBlockOnTip: couldn't connect a header to the local chain tip, ignoring err="canonicalChainBuilder.Connect: invalid header error context canceled" ...
```