### PR TITLE
e3 visibleFiles: if domain `A` has `n+1` steps and domain `B` has `n` steps - then user will see only files up to step `n` 

### DIFF
--- a/erigon-lib/config3/config3.go
+++ b/erigon-lib/config3/config3.go
@@ -17,8 +17,8 @@
 package config3
 
 // AggregationStep number of transactions in smallest static file
-// const HistoryV3AggregationStep = 1_562_500 // = 100M / 64. Dividers: 2, 5, 10, 20, 50, 100, 500
-const HistoryV3AggregationStep = 1_562_500 / 10
+const HistoryV3AggregationStep = 1_562_500 // = 100M / 64. Dividers: 2, 5, 10, 20, 50, 100, 500
+//const HistoryV3AggregationStep = 1_562_500 / 10
 
 const EnableHistoryV4InTest = true
 

--- a/erigon-lib/config3/config3.go
+++ b/erigon-lib/config3/config3.go
@@ -17,8 +17,8 @@
 package config3
 
 // AggregationStep number of transactions in smallest static file
-const HistoryV3AggregationStep = 1_562_500 // = 100M / 64. Dividers: 2, 5, 10, 20, 50, 100, 500
-//const HistoryV3AggregationStep = 1_562_500 / 10
+// const HistoryV3AggregationStep = 1_562_500 // = 100M / 64. Dividers: 2, 5, 10, 20, 50, 100, 500
+const HistoryV3AggregationStep = 1_562_500 / 10
 
 const EnableHistoryV4InTest = true
 

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -1381,12 +1381,6 @@ func (a *Aggregator) recalcVisibleFilesMinimaxTxNum() {
 	aggTx := a.BeginFilesRo()
 	defer aggTx.Close()
 	a.visibleFilesMinimaxTxNum.Store(aggTx.minimaxTxNumInDomainFiles())
-
-	fmt.Printf("[dbg] a1: EndTxNumMinimax=%d, minimaxTxNumInDomainFiles=%d\n", a.EndTxNumMinimax()/a.StepSize(), aggTx.minimaxTxNumInDomainFiles()/a.StepSize())
-	for _, d := range a.d {
-		fmt.Printf("[dbg] a2[%s]: dirtyFilesEndTxNumMinimax=%d\n", d.name.String(), d.dirtyFilesEndTxNumMinimax()/a.StepSize())
-	}
-
 }
 
 type RangesV3 struct {

--- a/erigon-lib/state/appendable.go
+++ b/erigon-lib/state/appendable.go
@@ -192,8 +192,8 @@ func (ap *Appendable) scanDirtyFiles(fileNames []string) (garbageFiles []*filesI
 	return garbageFiles
 }
 
-func (ap *Appendable) reCalcVisibleFiles() {
-	ap._visibleFiles = calcVisibleFiles(ap.dirtyFiles, ap.indexList, false)
+func (ap *Appendable) reCalcVisibleFiles(toTxNum uint64) {
+	ap._visibleFiles = calcVisibleFiles(ap.dirtyFiles, ap.indexList, false, toTxNum)
 }
 
 func (ap *Appendable) missedAccessors() (l []*filesItem) {

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -452,9 +452,9 @@ func (d *Domain) closeWhatNotInList(fNames []string) {
 	}
 }
 
-func (d *Domain) reCalcVisibleFiles() {
-	d._visible = newDomainVisible(d.name, calcVisibleFiles(d.dirtyFiles, d.indexList, false))
-	d.History.reCalcVisibleFiles()
+func (d *Domain) reCalcVisibleFiles(toTxNum uint64) {
+	d._visible = newDomainVisible(d.name, calcVisibleFiles(d.dirtyFiles, d.indexList, false, toTxNum))
+	d.History.reCalcVisibleFiles(toTxNum)
 }
 
 func (d *Domain) Close() {

--- a/erigon-lib/state/files_item.go
+++ b/erigon-lib/state/files_item.go
@@ -201,16 +201,22 @@ func (i *visibleFile) hasTS(ts uint64) bool           { return i.startTxNum <= t
 func (i *visibleFile) isSubSetOf(j *visibleFile) bool { return i.src.isSubsetOf(j.src) } //nolint
 func (i *visibleFile) isSubsetOf(j *visibleFile) bool { return i.src.isSubsetOf(j.src) } //nolint
 
-func calcVisibleFiles(files *btree2.BTreeG[*filesItem], l idxList, trace bool) (roItems []visibleFile) {
+func calcVisibleFiles(files *btree2.BTreeG[*filesItem], l idxList, trace bool, toTxNum uint64) (roItems []visibleFile) {
 	newVisibleFiles := make([]visibleFile, 0, files.Len())
 	if trace {
 		log.Warn("[dbg] calcVisibleFiles", "amount", files.Len())
 	}
 	files.Walk(func(items []*filesItem) bool {
 		for _, item := range items {
+			if item.endTxNum > toTxNum {
+				if trace {
+					log.Warn("[dbg] calcVisibleFiles: more than", "f", item.decompressor.FileName())
+				}
+				continue
+			}
 			if item.canDelete.Load() {
 				if trace {
-					log.Warn("[dbg] calcVisibleFiles0", "f", item.decompressor.FileName())
+					log.Warn("[dbg] calcVisibleFiles: canDelete=true", "f", item.decompressor.FileName())
 				}
 				continue
 			}

--- a/erigon-lib/state/gc_test.go
+++ b/erigon-lib/state/gc_test.go
@@ -55,7 +55,7 @@ func TestGCReadAfterRemoveFile(t *testing.T) {
 			require.False(lastOnFs.frozen) // prepared dataset must have some non-frozen files. or it's bad dataset.
 			h.integrateMergedDirtyFiles(nil, []*filesItem{lastOnFs}, nil, nil)
 			require.NotNil(lastOnFs.decompressor)
-			h.reCalcVisibleFiles()
+			h.reCalcVisibleFiles(h.dirtyFilesEndTxNumMinimax())
 
 			lastInView := hc.files[len(hc.files)-1]
 			g := lastInView.src.decompressor.MakeGetter()
@@ -139,7 +139,7 @@ func TestDomainGCReadAfterRemoveFile(t *testing.T) {
 			require.False(lastOnFs.frozen) // prepared dataset must have some non-frozen files. or it's bad dataset.
 			h.integrateMergedDirtyFiles([]*filesItem{lastOnFs}, nil, nil, nil, nil, nil)
 			require.NotNil(lastOnFs.decompressor)
-			h.reCalcVisibleFiles()
+			h.reCalcVisibleFiles(h.dirtyFilesEndTxNumMinimax())
 
 			lastInView := hc.files[len(hc.files)-1]
 			g := lastInView.src.decompressor.MakeGetter()
@@ -179,7 +179,7 @@ func TestDomainGCReadAfterRemoveFile(t *testing.T) {
 			lastOnFs, _ := h.dirtyFiles.Max()
 			require.False(lastOnFs.frozen) // prepared dataset must have some non-frozen files. or it's bad dataset.
 			h.integrateMergedDirtyFiles([]*filesItem{lastOnFs}, nil, nil, nil, nil, nil)
-			h.reCalcVisibleFiles()
+			h.reCalcVisibleFiles(h.dirtyFilesEndTxNumMinimax())
 
 			require.NotNil(lastOnFs.decompressor)
 			hc.Close()

--- a/erigon-lib/state/history.go
+++ b/erigon-lib/state/history.go
@@ -809,9 +809,9 @@ func (sf HistoryFiles) CleanupOnError() {
 		sf.efExistence.Close()
 	}
 }
-func (h *History) reCalcVisibleFiles() {
-	h._visibleFiles = calcVisibleFiles(h.dirtyFiles, h.indexList, false)
-	h.InvertedIndex.reCalcVisibleFiles()
+func (h *History) reCalcVisibleFiles(toTxNum uint64) {
+	h._visibleFiles = calcVisibleFiles(h.dirtyFiles, h.indexList, false, toTxNum)
+	h.InvertedIndex.reCalcVisibleFiles(toTxNum)
 }
 
 // buildFiles performs potentially resource intensive operations of creating

--- a/erigon-lib/state/history_test.go
+++ b/erigon-lib/state/history_test.go
@@ -159,7 +159,7 @@ func TestHistoryCollationsAndBuilds(t *testing.T) {
 				require.True(t, sort.StringsAreSorted(seenKeys))
 			}
 			h.integrateDirtyFiles(sf, i, i+h.aggregationStep)
-			h.reCalcVisibleFiles()
+			h.reCalcVisibleFiles(h.dirtyFilesEndTxNumMinimax())
 			lastAggergatedTx = i + h.aggregationStep
 		}
 
@@ -342,7 +342,7 @@ func TestHistoryAfterPrune(t *testing.T) {
 		require.NoError(err)
 
 		h.integrateDirtyFiles(sf, 0, 16)
-		h.reCalcVisibleFiles()
+		h.reCalcVisibleFiles(h.dirtyFilesEndTxNumMinimax())
 		hc.Close()
 
 		hc = h.BeginFilesRo()
@@ -860,7 +860,7 @@ func TestHistoryHistory(t *testing.T) {
 				sf, err := h.buildFiles(ctx, step, c, background.NewProgressSet())
 				require.NoError(err)
 				h.integrateDirtyFiles(sf, step*h.aggregationStep, (step+1)*h.aggregationStep)
-				h.reCalcVisibleFiles()
+				h.reCalcVisibleFiles(h.dirtyFilesEndTxNumMinimax())
 
 				hc := h.BeginFilesRo()
 				_, err = hc.Prune(ctx, tx, step*h.aggregationStep, (step+1)*h.aggregationStep, math.MaxUint64, false, logEvery)
@@ -899,7 +899,7 @@ func collateAndMergeHistory(tb testing.TB, db kv.RwDB, h *History, txs uint64, d
 		sf, err := h.buildFiles(ctx, step, c, background.NewProgressSet())
 		require.NoError(err)
 		h.integrateDirtyFiles(sf, step*h.aggregationStep, (step+1)*h.aggregationStep)
-		h.reCalcVisibleFiles()
+		h.reCalcVisibleFiles(h.dirtyFilesEndTxNumMinimax())
 
 		if doPrune {
 			hc := h.BeginFilesRo()
@@ -925,7 +925,7 @@ func collateAndMergeHistory(tb testing.TB, db kv.RwDB, h *History, txs uint64, d
 			indexIn, historyIn, err := hc.mergeFiles(ctx, indexOuts, historyOuts, r, background.NewProgressSet())
 			require.NoError(err)
 			h.integrateMergedDirtyFiles(indexOuts, historyOuts, indexIn, historyIn)
-			h.reCalcVisibleFiles()
+			h.reCalcVisibleFiles(h.dirtyFilesEndTxNumMinimax())
 			return false
 		}(); stop {
 			break

--- a/erigon-lib/state/inverted_index.go
+++ b/erigon-lib/state/inverted_index.go
@@ -232,8 +232,8 @@ var (
 	withExistence idxList = 0b100
 )
 
-func (ii *InvertedIndex) reCalcVisibleFiles() {
-	ii._visible = newIIVisible(ii.filenameBase, calcVisibleFiles(ii.dirtyFiles, ii.indexList, false))
+func (ii *InvertedIndex) reCalcVisibleFiles(toTxNum uint64) {
+	ii._visible = newIIVisible(ii.filenameBase, calcVisibleFiles(ii.dirtyFiles, ii.indexList, false, toTxNum))
 }
 
 func (ii *InvertedIndex) missedAccessors() (l []*filesItem) {

--- a/erigon-lib/state/merge.go
+++ b/erigon-lib/state/merge.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/erigontech/erigon-lib/common/dbg"
 	"github.com/tidwall/btree"
 
 	"github.com/erigontech/erigon-lib/common"
@@ -62,6 +63,7 @@ func (ii *InvertedIndex) dirtyFilesEndTxNumMinimax() uint64 {
 }
 func (h *History) dirtyFilesEndTxNumMinimax() uint64 {
 	if h.snapshotsDisabled {
+		fmt.Printf("[dbg] maxu64 %s\n", dbg.Stack())
 		return math.MaxUint64
 	}
 	minimax := h.InvertedIndex.dirtyFilesEndTxNumMinimax()

--- a/erigon-lib/state/merge.go
+++ b/erigon-lib/state/merge.go
@@ -73,6 +73,16 @@ func (h *History) dirtyFilesEndTxNumMinimax() uint64 {
 	}
 	return minimax
 }
+func (a *Appendable) dirtyFilesEndTxNumMinimax() uint64 {
+	var minimax uint64
+	if _max, ok := a.dirtyFiles.Max(); ok {
+		endTxNum := _max.endTxNum
+		if minimax == 0 || endTxNum < minimax {
+			minimax = endTxNum
+		}
+	}
+	return minimax
+}
 
 type DomainRanges struct {
 	name    kv.Domain

--- a/erigon-lib/state/merge.go
+++ b/erigon-lib/state/merge.go
@@ -27,7 +27,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/erigontech/erigon-lib/common/dbg"
 	"github.com/tidwall/btree"
 
 	"github.com/erigontech/erigon-lib/common"
@@ -63,7 +62,6 @@ func (ii *InvertedIndex) dirtyFilesEndTxNumMinimax() uint64 {
 }
 func (h *History) dirtyFilesEndTxNumMinimax() uint64 {
 	if h.snapshotsDisabled {
-		fmt.Printf("[dbg] maxu64 %s\n", dbg.Stack())
 		return math.MaxUint64
 	}
 	minimax := h.InvertedIndex.dirtyFilesEndTxNumMinimax()

--- a/erigon-lib/state/merge_test.go
+++ b/erigon-lib/state/merge_test.go
@@ -39,7 +39,7 @@ func emptyTestInvertedIndex(aggStep uint64) *InvertedIndex {
 		filenameBase: "test", aggregationStep: aggStep, dirtyFiles: btree2.NewBTreeG[*filesItem](filesItemLess)}
 }
 func TestFindMergeRangeCornerCases(t *testing.T) {
-	t.Run("> 2 unmerged files", func(t *testing.T) {
+	t.Run("ii: > 2 unmerged files", func(t *testing.T) {
 		ii := emptyTestInvertedIndex(1)
 		ii.scanDirtyFiles([]string{
 			"v1-test.0-2.ef",
@@ -63,8 +63,9 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 
 		idxF := ic.staticFilesInRange(mr.from, mr.to)
 		assert.Equal(t, 3, len(idxF))
-
-		ii = emptyTestInvertedIndex(1)
+	})
+	t.Run("hist: > 2 unmerged files", func(t *testing.T) {
+		ii := emptyTestInvertedIndex(1)
 		ii.scanDirtyFiles([]string{
 			"v1-test.0-1.ef",
 			"v1-test.1-2.ef",
@@ -77,13 +78,6 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 			return true
 		})
 		ii.reCalcVisibleFiles(ii.dirtyFilesEndTxNumMinimax())
-		ic = ii.BeginFilesRo()
-		defer ic.Close()
-
-		mr = ic.findMergeRange(4, 32)
-		assert.True(t, mr.needMerge)
-		assert.Equal(t, 0, int(mr.from))
-		assert.Equal(t, 2, int(mr.to))
 
 		h := &History{InvertedIndex: ii, dirtyFiles: btree2.NewBTreeG[*filesItem](filesItemLess)}
 		h.scanDirtyFiles([]string{
@@ -97,8 +91,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 			item.decompressor = &seg.Decompressor{FileName1: fName}
 			return true
 		})
-		ii.reCalcVisibleFiles(ii.dirtyFilesEndTxNumMinimax())
-		ic.Close()
+		h.reCalcVisibleFiles(h.dirtyFilesEndTxNumMinimax())
 
 		hc := h.BeginFilesRo()
 		defer hc.Close()

--- a/erigon-lib/state/merge_test.go
+++ b/erigon-lib/state/merge_test.go
@@ -51,7 +51,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 			item.decompressor = &seg.Decompressor{FileName1: fName}
 			return true
 		})
-		ii.reCalcVisibleFiles()
+		ii.reCalcVisibleFiles(ii.dirtyFilesEndTxNumMinimax())
 
 		ic := ii.BeginFilesRo()
 		defer ic.Close()
@@ -76,7 +76,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 			item.decompressor = &seg.Decompressor{FileName1: fName}
 			return true
 		})
-		ii.reCalcVisibleFiles()
+		ii.reCalcVisibleFiles(ii.dirtyFilesEndTxNumMinimax())
 		ic = ii.BeginFilesRo()
 		defer ic.Close()
 
@@ -97,7 +97,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 			item.decompressor = &seg.Decompressor{FileName1: fName}
 			return true
 		})
-		h.reCalcVisibleFiles()
+		ii.reCalcVisibleFiles(ii.dirtyFilesEndTxNumMinimax())
 		ic.Close()
 
 		hc := h.BeginFilesRo()
@@ -120,7 +120,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 			item.decompressor = &seg.Decompressor{FileName1: fName}
 			return true
 		})
-		ii.reCalcVisibleFiles()
+		ii.reCalcVisibleFiles(ii.dirtyFilesEndTxNumMinimax())
 
 		h := &History{InvertedIndex: ii, dirtyFiles: btree2.NewBTreeG[*filesItem](filesItemLess)}
 		h.scanDirtyFiles([]string{
@@ -132,7 +132,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 			item.decompressor = &seg.Decompressor{FileName1: fName}
 			return true
 		})
-		h.reCalcVisibleFiles()
+		h.reCalcVisibleFiles(h.dirtyFilesEndTxNumMinimax())
 
 		hc := h.BeginFilesRo()
 		defer hc.Close()
@@ -156,7 +156,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 			item.decompressor = &seg.Decompressor{FileName1: fName}
 			return true
 		})
-		ii.reCalcVisibleFiles()
+		ii.reCalcVisibleFiles(ii.dirtyFilesEndTxNumMinimax())
 
 		h := &History{InvertedIndex: ii, dirtyFiles: btree2.NewBTreeG[*filesItem](filesItemLess)}
 		h.scanDirtyFiles([]string{
@@ -168,7 +168,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 			item.decompressor = &seg.Decompressor{FileName1: fName}
 			return true
 		})
-		h.reCalcVisibleFiles()
+		h.reCalcVisibleFiles(h.dirtyFilesEndTxNumMinimax())
 
 		hc := h.BeginFilesRo()
 		defer hc.Close()
@@ -193,7 +193,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 			item.decompressor = &seg.Decompressor{FileName1: fName}
 			return true
 		})
-		ii.reCalcVisibleFiles()
+		ii.reCalcVisibleFiles(ii.dirtyFilesEndTxNumMinimax())
 
 		h := &History{InvertedIndex: ii, dirtyFiles: btree2.NewBTreeG[*filesItem](filesItemLess)}
 		h.scanDirtyFiles([]string{
@@ -207,7 +207,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 			item.decompressor = &seg.Decompressor{FileName1: fName}
 			return true
 		})
-		h.reCalcVisibleFiles()
+		h.reCalcVisibleFiles(h.dirtyFilesEndTxNumMinimax())
 
 		hc := h.BeginFilesRo()
 		defer hc.Close()
@@ -231,7 +231,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 			item.decompressor = &seg.Decompressor{FileName1: fName}
 			return true
 		})
-		ii.reCalcVisibleFiles()
+		ii.reCalcVisibleFiles(ii.dirtyFilesEndTxNumMinimax())
 
 		h := &History{InvertedIndex: ii, dirtyFiles: btree2.NewBTreeG[*filesItem](filesItemLess)}
 		h.scanDirtyFiles([]string{
@@ -245,7 +245,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 			item.decompressor = &seg.Decompressor{FileName1: fName}
 			return true
 		})
-		h.reCalcVisibleFiles()
+		h.reCalcVisibleFiles(h.dirtyFilesEndTxNumMinimax())
 
 		hc := h.BeginFilesRo()
 		defer hc.Close()
@@ -269,7 +269,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 			item.decompressor = &seg.Decompressor{FileName1: fName}
 			return true
 		})
-		ii.reCalcVisibleFiles()
+		ii.reCalcVisibleFiles(ii.dirtyFilesEndTxNumMinimax())
 
 		// `kill -9` may leave small garbage files, but if big one already exists we assume it's good(fsynced) and no reason to merge again
 		h := &History{InvertedIndex: ii, dirtyFiles: btree2.NewBTreeG[*filesItem](filesItemLess)}
@@ -283,7 +283,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 			item.decompressor = &seg.Decompressor{FileName1: fName}
 			return true
 		})
-		h.reCalcVisibleFiles()
+		h.reCalcVisibleFiles(h.dirtyFilesEndTxNumMinimax())
 
 		hc := h.BeginFilesRo()
 		defer hc.Close()
@@ -311,7 +311,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 			item.decompressor = &seg.Decompressor{FileName1: fName}
 			return true
 		})
-		ii.reCalcVisibleFiles()
+		ii.reCalcVisibleFiles(ii.dirtyFilesEndTxNumMinimax())
 
 		h := &History{InvertedIndex: ii, dirtyFiles: btree2.NewBTreeG[*filesItem](filesItemLess)}
 		h.scanDirtyFiles([]string{
@@ -326,7 +326,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 			item.decompressor = &seg.Decompressor{FileName1: fName}
 			return true
 		})
-		h.reCalcVisibleFiles()
+		h.reCalcVisibleFiles(h.dirtyFilesEndTxNumMinimax())
 
 		hc := h.BeginFilesRo()
 		defer hc.Close()
@@ -353,7 +353,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 			item.decompressor = &seg.Decompressor{FileName1: fName}
 			return true
 		})
-		ii.reCalcVisibleFiles()
+		ii.reCalcVisibleFiles(ii.dirtyFilesEndTxNumMinimax())
 
 		h := &History{InvertedIndex: ii, dirtyFiles: btree2.NewBTreeG[*filesItem](filesItemLess)}
 		h.scanDirtyFiles([]string{
@@ -366,7 +366,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 			item.decompressor = &seg.Decompressor{FileName1: fName}
 			return true
 		})
-		h.reCalcVisibleFiles()
+		h.reCalcVisibleFiles(h.dirtyFilesEndTxNumMinimax())
 
 		hc := h.BeginFilesRo()
 		defer hc.Close()
@@ -392,7 +392,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 			item.decompressor = &seg.Decompressor{FileName1: fName}
 			return true
 		})
-		ii.reCalcVisibleFiles()
+		ii.reCalcVisibleFiles(ii.dirtyFilesEndTxNumMinimax())
 
 		h := &History{InvertedIndex: ii, dirtyFiles: btree2.NewBTreeG[*filesItem](filesItemLess)}
 		h.scanDirtyFiles([]string{
@@ -406,7 +406,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 			item.decompressor = &seg.Decompressor{FileName1: fName}
 			return true
 		})
-		h.reCalcVisibleFiles()
+		h.reCalcVisibleFiles(h.dirtyFilesEndTxNumMinimax())
 
 		hc := h.BeginFilesRo()
 		defer hc.Close()
@@ -428,7 +428,7 @@ func TestFindMergeRangeCornerCases(t *testing.T) {
 			item.decompressor = &seg.Decompressor{FileName1: fName}
 			return true
 		})
-		ii.reCalcVisibleFiles()
+		ii.reCalcVisibleFiles(ii.dirtyFilesEndTxNumMinimax())
 		ic := ii.BeginFilesRo()
 		defer ic.Close()
 		mr := ic.findMergeRange(4, 32)

--- a/erigon-lib/state/reconst.go
+++ b/erigon-lib/state/reconst.go
@@ -19,7 +19,7 @@ type AggregatorStep struct {
 
 func (a *Aggregator) StepSize() uint64 { return a.aggregationStep }
 func (a *Aggregator) MakeSteps() ([]*AggregatorStep, error) {
-	frozenAndIndexed := a.EndTxNumDomainsFrozen()
+	frozenAndIndexed := a.DirtyFilesEndTxNumMinimax()
 	accountSteps := a.d[kv.AccountsDomain].MakeSteps(frozenAndIndexed)
 	codeSteps := a.d[kv.CodeDomain].MakeSteps(frozenAndIndexed)
 	storageSteps := a.d[kv.StorageDomain].MakeSteps(frozenAndIndexed)


### PR DESCRIPTION
Preventing pruning of domain A before all Domains produce `n+1` steps of files
fixing https://github.com/erigontech/erigon/issues/10724