### PR TITLE
Reset inner cell arrays in cell.reset()

### DIFF
--- a/erigon-lib/commitment/hex_patricia_hashed.go
+++ b/erigon-lib/commitment/hex_patricia_hashed.go
@@ -121,6 +121,21 @@ func (cell *cell) reset() {
 	cell.hashedExtLen = 0
 	cell.extLen = 0
 	cell.hashLen = 0
+	for i := range cell.hashedExtension {
+		cell.hashedExtension[i] = 0
+	}
+	for i := range cell.extension {
+		cell.extension[i] = 0
+	}
+	for i := range cell.accountAddr {
+		cell.accountAddr[i] = 0
+	}
+	for i := range cell.storageAddr {
+		cell.storageAddr[i] = 0
+	}
+	for i := range cell.hash {
+		cell.hash[i] = 0
+	}
 	cell.Update.Reset()
 }
 


### PR DESCRIPTION
During unfold the cells of a row in the grid can get reset, and although setting the lengths of the fields to 0 is sufficient, the inner arrays appearing non-empty can give a false indication that those cells have not been reset, especially during debugging. So it is best to reset these arrays as well during cell reset.