### PR TITLE
qa-tests: add rpc integration tests (Erigon v3)

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:     # Run manually
   push:
     branches:
-      - qa_tests_rpc_integration  # only to debug the workflow
+      - qa_tests_rpc_integration_v3  # only to debug the workflow
 
 jobs:
   integration-test-suite:
@@ -16,6 +16,7 @@ jobs:
       ERIGON_TESTBED_DATA_DIR: /opt/erigon-testbed/datadir
       ERIGON_QA_PATH: /home/qarunner/erigon-qa
       RPC_PAST_TEST_DIR: /opt/rpc-past-tests
+      CHAIN: mainnet
 
     steps:
       - name: Check out repository
@@ -24,7 +25,7 @@ jobs:
       - name: Checkout RPC Tests Repository & Install Requirements
         run: |
           rm -rf ${{ runner.workspace }}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch v0.26.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
+          git -c advice.detachedHead=false clone --depth 1 --branch v0.42.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
           cd ${{ runner.workspace }}/rpc-tests
           pip3 install -r requirements.txt
 
@@ -57,6 +58,21 @@ jobs:
           
           echo "Erigon (RpcDaemon) started"
 
+      - name: Wait for port 8545 to be opened
+        run: |
+          for i in {1..30}; do
+            if nc -z localhost 8545; then
+              echo "Port 8545 is open"
+              break
+            fi
+            echo "Waiting for port 8545 to open..."
+            sleep 10
+          done
+          if ! nc -z localhost 8545; then
+            echo "Port 8545 did not open in time"
+            exit 1
+          fi
+
       - name: Run RPC Integration Tests
         id: test_step
         run: |
@@ -67,9 +83,87 @@ jobs:
           rm -rf ./mainnet/results/
           
           # Run RPC integration test runner via http
-          python3 ./run_tests.py --continue --blockchain mainnet --display-only-fail --port 8545 -x debug_,trace_ --transport_type http,websocket
-          #python3 ./run_tests.py --continue --blockchain mainnet --display-only-fail --port 8545 -x debug_,trace_,admin_,eth_mining,eth_getWork,eth_coinbase,eth_createAccessList/test_16.json,engine_,net_,web3_,txpool_,eth_submitWork,eth_submitHashrate,eth_protocolVersion,erigon_nodeInfo --transport_type http,websocket
-
+          python3 ./run_tests.py -p 8545 --continue -f -x debug_,\
+          engine_exchangeCapabilities/test_1.json,\
+          engine_exchangeTransitionConfigurationV1/test_01.json,\
+          engine_getClientVersionV1/test_1.json,\
+          erigon_getLogsByHash/test_04.json,\
+          erigon_getBalanceChangesInBlock/,\
+          eth_callBundle/test_09.json,\
+          eth_callBundle/test_12.json,\
+          eth_createAccessList/test_06.json,\
+          eth_createAccessList/test_07.json,\
+          eth_createAccessList/test_15.json,\
+          eth_createAccessList/test_16.json,\
+          eth_getBlockTransactionCountByHash/test_02.json,\
+          eth_getBlockTransactionCountByNumber/test_08.json,\
+          eth_getUncleCountByBlockHash/test_03.json,\
+          parity_getBlockReceipts/test_01.json,\
+          parity_getBlockReceipts/test_02.json,\
+          parity_getBlockReceipts/test_03.json,\
+          parity_getBlockReceipts/test_04.json,\
+          parity_getBlockReceipts/test_05.json,\
+          parity_getBlockReceipts/test_06.json,\
+          parity_getBlockReceipts/test_07.json,\
+          parity_getBlockReceipts/test_08.json,\
+          parity_getBlockReceipts/test_09.json,\
+          parity_getBlockReceipts/test_10.json,\
+          trace_call/test_02.json,\
+          trace_call/test_04.tar,\
+          trace_call/test_08.tar,\
+          trace_call/test_11.tar,\
+          trace_call/test_13.json,\
+          trace_call/test_17.tar,\
+          trace_call/test_19.tar,\
+          trace_call/test_20.json,\
+          trace_callMany/test_01.json,\
+          trace_callMany/test_02.json,\
+          trace_callMany/test_03.json,\
+          trace_callMany/test_04.json,\
+          trace_callMany/test_05.json,\
+          trace_callMany/test_06.json,\
+          trace_callMany/test_08.json,\
+          trace_callMany/test_09.json,\
+          trace_callMany/test_10.json,\
+          trace_callMany/test_11.json,\
+          trace_rawTransaction/test_01.json,\
+          trace_rawTransaction/test_03.json,\
+          trace_replayBlockTransactions/test_01.tar,\
+          trace_replayBlockTransactions/test_02.tar,\
+          trace_replayBlockTransactions/test_03.tar,\
+          trace_replayBlockTransactions/test_04.tar,\
+          trace_replayBlockTransactions/test_05.tar,\
+          trace_replayBlockTransactions/test_08.tar,\
+          trace_replayBlockTransactions/test_10.json,\
+          trace_replayBlockTransactions/test_11.json,\
+          trace_replayBlockTransactions/test_13.tar,\
+          trace_replayBlockTransactions/test_14.tar,\
+          trace_replayBlockTransactions/test_15.tar,\
+          trace_replayBlockTransactions/test_16.tar,\
+          trace_replayBlockTransactions/test_17.tar,\
+          trace_replayBlockTransactions/test_18.tar,\
+          trace_replayBlockTransactions/test_19.tar,\
+          trace_replayBlockTransactions/test_20.tar,\
+          trace_replayBlockTransactions/test_21.tar,\
+          trace_replayBlockTransactions/test_22.tar,\
+          trace_replayBlockTransactions/test_23.tar,\
+          trace_replayBlockTransactions/test_24.tar,\
+          trace_replayBlockTransactions/test_25.tar,\
+          trace_replayTransaction/test_02.tar,\
+          trace_replayTransaction/test_03.tar,\
+          trace_replayTransaction/test_04.tar,\
+          trace_replayTransaction/test_05.tar,\
+          trace_replayTransaction/test_06.tar,\
+          trace_replayTransaction/test_07.tar,\
+          trace_replayTransaction/test_10.tar,\
+          trace_replayTransaction/test_11.tar,\
+          trace_replayTransaction/test_14.tar,\
+          trace_replayTransaction/test_16.tar,\
+          trace_replayTransaction/test_18.tar,\
+          trace_replayTransaction/test_23.tar,\
+          trace_replayTransaction/test_24.json,\
+          trace_replayTransaction/test_29.tar
+          
           # Capture test runner script exit status
           test_exit_status=$?
           
@@ -122,7 +216,13 @@ jobs:
         working-directory: ${{ github.workspace }}
         env:
           TEST_RESULT: ${{ steps.test_step.outputs.TEST_RESULT }}
-        run: python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py --repo erigon --commit $(git rev-parse HEAD) --test_name rpc-integration-tests --outcome $TEST_RESULT #--result_file ${{runner.workspace}}/rpc-tests/integration/mainnet/result.json
+        run: |
+          db_version=$(python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/prod_info.py $ERIGON_REFERENCE_DATA_DIR/../production.ini production erigon_repo_commit)
+          if [ -z "$db_version" ]; then
+            db_version="no-version"
+          fi
+          
+          python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py --repo erigon --commit $(git rev-parse HEAD) --branch ${{ github.ref_name }} --test_name rpc-integration-tests --chain $CHAIN --runner ${{ runner.name }} --db_version $db_version --outcome $TEST_RESULT #--result_file ${{ github.workspace }}/result-$CHAIN.json
 
       - name: Action for Success
         if: steps.test_step.outputs.TEST_RESULT == 'success'

--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -88,6 +88,29 @@ jobs:
           engine_exchangeTransitionConfigurationV1/test_01.json,\
           engine_getClientVersionV1/test_1.json,\
           erigon_getLogsByHash/test_04.json,\
+          erigon_getHeaderByHash/test_02.json,\
+          erigon_getHeaderByHash/test_03.json,\
+          erigon_getHeaderByHash/test_04.json,\
+          erigon_getHeaderByHash/test_06.json,\
+          erigon_getHeaderByNumber/test_01.json,\
+          erigon_getHeaderByNumber/test_02.json,\
+          erigon_getHeaderByNumber/test_03.json,\
+          erigon_getHeaderByNumber/test_04.json,\
+          erigon_getHeaderByNumber/test_05.json,\
+          erigon_getHeaderByNumber/test_06.json,\
+          erigon_getHeaderByNumber/test_07.json,\
+          erigon_getHeaderByNumber/test_08.json,\
+          erigon_getLatestLogs/test_01.json,\
+          erigon_getLatestLogs/test_02.json,\
+          erigon_getLatestLogs/test_03.json,\
+          erigon_getLatestLogs/test_04.json,\
+          erigon_getLatestLogs/test_05.json,\
+          erigon_getLatestLogs/test_06.json,\
+          erigon_getLatestLogs/test_08.json,\
+          erigon_getLatestLogs/test_09.json,\
+          erigon_getLatestLogs/test_10.json,\
+          erigon_getLatestLogs/test_11.json,\
+          erigon_getLatestLogs/test_12.json,\
           erigon_getBalanceChangesInBlock/,\
           eth_callBundle/test_09.json,\
           eth_callBundle/test_12.json,\
@@ -122,10 +145,13 @@ jobs:
           trace_callMany/test_04.json,\
           trace_callMany/test_05.json,\
           trace_callMany/test_06.json,\
+          trace_callMany/test_07.json,\
           trace_callMany/test_08.json,\
           trace_callMany/test_09.json,\
           trace_callMany/test_10.json,\
           trace_callMany/test_11.json,\
+          trace_callMany/test_12.json,\
+          trace_filter/test_16.json,\
           trace_rawTransaction/test_01.json,\
           trace_rawTransaction/test_03.json,\
           trace_replayBlockTransactions/test_01.tar,\
@@ -162,7 +188,28 @@ jobs:
           trace_replayTransaction/test_18.tar,\
           trace_replayTransaction/test_23.tar,\
           trace_replayTransaction/test_24.json,\
-          trace_replayTransaction/test_29.tar
+          trace_replayTransaction/test_29.tar,\
+          ots_getTransactionBySenderAndNonce/test_05.json,\
+          ots_getTransactionBySenderAndNonce/test_11.json,\
+          ots_searchTransactionsAfter/test_01.json,\
+          ots_searchTransactionsAfter/test_03.json,\
+          ots_searchTransactionsAfter/test_04.json,\
+          ots_searchTransactionsAfter/test_06.json,\
+          ots_searchTransactionsAfter/test_08.json,\
+          ots_searchTransactionsAfter/test_09.json,\
+          ots_searchTransactionsAfter/test_10.json,\
+          ots_searchTransactionsAfter/test_11.json,\
+          ots_searchTransactionsAfter/test_12.json,\
+          ots_searchTransactionsAfter/test_13.json,\
+          ots_searchTransactionsBefore/test_01.json,\
+          ots_searchTransactionsBefore/test_03.json,\
+          ots_searchTransactionsBefore/test_04.json,\
+          ots_searchTransactionsBefore/test_06.json,\
+          ots_searchTransactionsBefore/test_09.json,\
+          ots_searchTransactionsBefore/test_10.json,\
+          ots_searchTransactionsBefore/test_11.json,\
+          ots_searchTransactionsBefore/test_12.json,\
+          ots_searchTransactionsBefore/test_13.json
           
           # Capture test runner script exit status
           test_exit_status=$?


### PR DESCRIPTION
Import Silkworm RPC Integration tests.

Out of 800 tests about 268 are disabled and need investigation.
On Erigon v2 only 164 tests are disabled.

We can trace regressions from this point on.

The Silkworm team is investigating the failing tests: later we will update the list of these tests to include the bad ones that have been fixed or the correct ones that fail due to some erigon bug.
