### PR TITLE
e2: fix regression in json encoding of stack values in traces due to chan…

### DIFF
--- a/eth/tracers/logger/json_stream.go
+++ b/eth/tracers/logger/json_stream.go
@@ -139,7 +139,7 @@ func (l *JsonStreamLogger) CaptureState(pc uint64, op vm.OpCode, gas, cost uint6
 			if i > 0 {
 				l.stream.WriteMore()
 			}
-			l.stream.WriteString(stackValue.String())
+			l.stream.WriteString(stackValue.Hex())
 		}
 		l.stream.WriteArrayEnd()
 	}

--- a/turbo/jsonrpc/trace_adhoc.go
+++ b/turbo/jsonrpc/trace_adhoc.go
@@ -492,7 +492,7 @@ func (ot *OeTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scop
 			}
 			for i := showStack - 1; i >= 0; i-- {
 				if st.Len() > i {
-					ot.lastVmOp.Ex.Push = append(ot.lastVmOp.Ex.Push, st.Back(i).String())
+					ot.lastVmOp.Ex.Push = append(ot.lastVmOp.Ex.Push, st.Back(i).Hex())
 				}
 			}
 			// Set the "mem" of the last operation
@@ -512,7 +512,7 @@ func (ot *OeTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scop
 		if ot.lastOffStack != nil {
 			ot.lastOffStack.Ex.Used = int(gas)
 			if st.Len() > 0 {
-				ot.lastOffStack.Ex.Push = []string{st.Back(0).String()}
+				ot.lastOffStack.Ex.Push = []string{st.Back(0).Hex()}
 			} else {
 				ot.lastOffStack.Ex.Push = []string{}
 			}
@@ -584,7 +584,7 @@ func (ot *OeTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scop
 			ot.memLenStack = append(ot.memLenStack, 0)
 		case vm.SSTORE:
 			if st.Len() > 1 {
-				ot.lastVmOp.Ex.Store = &VmTraceStore{Key: st.Back(0).String(), Val: st.Back(1).String()}
+				ot.lastVmOp.Ex.Store = &VmTraceStore{Key: st.Back(0).Hex(), Val: st.Back(1).Hex()}
 			}
 		}
 		if ot.lastVmOp.Ex.Used < 0 {


### PR DESCRIPTION
cherry-pick from PR #11061 from main (the regression is present also in release 2.60)

Regression caused by this change in uint256 library:

https://github.com/holiman/uint256/commit/f24ed59bea89c23941cf073aeb3f702514f3b371

It was causing trace json to encode stack values as quoted (string) decimal values rather than a hex encoded value.