### PR TITLE
Optimise aggregate and proof signature verification

### DIFF
--- a/cl/beacon/handler/utils_test.go
+++ b/cl/beacon/handler/utils_test.go
@@ -120,8 +120,8 @@ func setupTestingHandler(t *testing.T, v clparams.StateVersion, logger log.Logge
 	syncContributionService.EXPECT().ProcessMessage(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, subnetID *uint64, msg *cltypes.SignedContributionAndProof) error {
 		return h.syncMessagePool.AddSyncContribution(postState, msg.Message.Contribution)
 	}).AnyTimes()
-	aggregateAndProofsService.EXPECT().ProcessMessage(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, subnetID *uint64, msg *cltypes.SignedAggregateAndProof) error {
-		opPool.AttestationsPool.Insert(msg.Message.Aggregate.Signature(), msg.Message.Aggregate)
+	aggregateAndProofsService.EXPECT().ProcessMessage(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, subnetID *uint64, msg *cltypes.SignedAggregateAndProofData) error {
+		opPool.AttestationsPool.Insert(msg.SignedAggregateAndProof.Message.Aggregate.Signature(), msg.SignedAggregateAndProof.Message.Aggregate)
 		return nil
 	}).AnyTimes()
 	voluntaryExitService.EXPECT().ProcessMessage(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, subnetID *uint64, msg *cltypes.SignedVoluntaryExit) error {

--- a/cl/cltypes/aggregate.go
+++ b/cl/cltypes/aggregate.go
@@ -18,6 +18,7 @@ package cltypes
 
 import (
 	libcommon "github.com/erigontech/erigon-lib/common"
+	sentinel "github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
 	"github.com/erigontech/erigon/cl/merkle_tree"
 	ssz2 "github.com/erigontech/erigon/cl/ssz"
@@ -52,6 +53,16 @@ func (a *AggregateAndProof) EncodingSizeSSZ() int {
 
 func (a *AggregateAndProof) HashSSZ() ([32]byte, error) {
 	return merkle_tree.HashTreeRoot(a.AggregatorIndex, a.Aggregate, a.SelectionProof[:])
+}
+
+// SignedAggregateAndProofData is passed to SignedAggregateAndProof service. The service does the signature verification
+// asynchronously. That's why we cannot wait for its ProcessMessage call to finish to check error. The service
+// will do re-publishing of the gossip or banning the peer in case of invalid signature by itself.
+// that's why we are passing sentinel.SentinelClient and *sentinel.GossipData to enable the service
+// to do all of that by itself.
+type SignedAggregateAndProofData struct {
+	SignedAggregateAndProof *SignedAggregateAndProof
+	GossipData              *sentinel.GossipData
 }
 
 type SignedAggregateAndProof struct {

--- a/cl/phase1/forkchoice/on_attestation.go
+++ b/cl/phase1/forkchoice/on_attestation.go
@@ -61,6 +61,12 @@ func (f *ForkChoiceStore) OnAttestation(
 	var err error
 	target := data.Target()
 
+	// fmt.Println("Attestation slot: ", attestation.AttestantionData().Slot())
+	// fmt.Println("Attestation beacon block root: ", attestation.AttestantionData().BeaconBlockRoot().String())
+	// a, _ := attestation.AttestantionData().Source().MarshalJSON()
+	// b, _ := attestation.AttestantionData().Target().MarshalJSON()
+	// fmt.Println("Attestation source: ", string(a))
+	// fmt.Println("Attestation target: ", string(b))
 	if headState == nil {
 		attestationIndicies, err = f.verifyAttestationWithCheckpointState(
 			target,
@@ -108,6 +114,11 @@ func (f *ForkChoiceStore) verifyAttestationWithCheckpointState(
 		&data,
 		attestation.AggregationBits(),
 	)
+	// fmt.Println("attesting indexes: ", len(attestationIndicies))
+	// for _, v := range attestationIndicies {
+	// 	fmt.Printf(" %d", v)
+	// }
+	// fmt.Println()
 	if err != nil {
 		return nil, err
 	}
@@ -137,8 +148,12 @@ func (f *ForkChoiceStore) verifyAttestationWithState(
 	if err != nil {
 		return nil, err
 	}
-
 	attestationIndicies, err = s.GetAttestingIndicies(data, attestation.AggregationBits(), true)
+	// fmt.Println("attesting indexes:")
+	// for _, v := range attestationIndicies {
+	// 	fmt.Printf(" %d", v)
+	// }
+	// fmt.Println()
 	if err != nil {
 		return nil, err
 	}

--- a/cl/phase1/forkchoice/on_attestation.go
+++ b/cl/phase1/forkchoice/on_attestation.go
@@ -61,12 +61,6 @@ func (f *ForkChoiceStore) OnAttestation(
 	var err error
 	target := data.Target()
 
-	// fmt.Println("Attestation slot: ", attestation.AttestantionData().Slot())
-	// fmt.Println("Attestation beacon block root: ", attestation.AttestantionData().BeaconBlockRoot().String())
-	// a, _ := attestation.AttestantionData().Source().MarshalJSON()
-	// b, _ := attestation.AttestantionData().Target().MarshalJSON()
-	// fmt.Println("Attestation source: ", string(a))
-	// fmt.Println("Attestation target: ", string(b))
 	if headState == nil {
 		attestationIndicies, err = f.verifyAttestationWithCheckpointState(
 			target,
@@ -114,11 +108,6 @@ func (f *ForkChoiceStore) verifyAttestationWithCheckpointState(
 		&data,
 		attestation.AggregationBits(),
 	)
-	// fmt.Println("attesting indexes: ", len(attestationIndicies))
-	// for _, v := range attestationIndicies {
-	// 	fmt.Printf(" %d", v)
-	// }
-	// fmt.Println()
 	if err != nil {
 		return nil, err
 	}
@@ -148,12 +137,8 @@ func (f *ForkChoiceStore) verifyAttestationWithState(
 	if err != nil {
 		return nil, err
 	}
+
 	attestationIndicies, err = s.GetAttestingIndicies(data, attestation.AggregationBits(), true)
-	// fmt.Println("attesting indexes:")
-	// for _, v := range attestationIndicies {
-	// 	fmt.Printf(" %d", v)
-	// }
-	// fmt.Println()
 	if err != nil {
 		return nil, err
 	}

--- a/cl/phase1/network/gossip_manager.go
+++ b/cl/phase1/network/gossip_manager.go
@@ -201,8 +201,12 @@ func (g *GossipManager) routeAndProcess(ctx context.Context, data *sentinel.Goss
 		}
 		return g.blsToExecutionChangeService.ProcessMessage(ctx, data.SubnetId, obj)
 	case gossip.TopicNameBeaconAggregateAndProof:
-		obj := &cltypes.SignedAggregateAndProof{}
-		if err := obj.DecodeSSZ(data.Data, int(version)); err != nil {
+		obj := &cltypes.SignedAggregateAndProofData{
+			GossipData:              data,
+			SignedAggregateAndProof: &cltypes.SignedAggregateAndProof{},
+		}
+
+		if err := obj.SignedAggregateAndProof.DecodeSSZ(data.Data, int(version)); err != nil {
 			return err
 		}
 		return g.aggregateAndProofService.ProcessMessage(ctx, data.SubnetId, obj)

--- a/cl/phase1/network/services/aggregate_and_proof_service_test.go
+++ b/cl/phase1/network/services/aggregate_and_proof_service_test.go
@@ -35,24 +35,28 @@ import (
 	"github.com/erigontech/erigon/cl/pool"
 )
 
-func getAggregateAndProofAndState(t *testing.T) (*cltypes.SignedAggregateAndProof, *state.CachingBeaconState) {
+func getAggregateAndProofAndState(t *testing.T) (*cltypes.SignedAggregateAndProofData, *state.CachingBeaconState) {
 	_, _, s := tests.GetBellatrixRandom()
 	br, _ := s.BlockRoot()
 	checkpoint := s.CurrentJustifiedCheckpoint()
-	a := &cltypes.SignedAggregateAndProof{
-		Message: &cltypes.AggregateAndProof{
-			AggregatorIndex: 141,
-			Aggregate: solid.NewAttestionFromParameters([]byte{1, 2}, solid.NewAttestionDataFromParameters(
-				s.Slot(),
-				0,
-				br,
-				checkpoint,
-				checkpoint,
-			), common.Bytes96{}),
-			SelectionProof: common.Bytes96{},
+	a := &cltypes.SignedAggregateAndProofData{
+		SignedAggregateAndProof: &cltypes.SignedAggregateAndProof{
+			Message: &cltypes.AggregateAndProof{
+				AggregatorIndex: 141,
+				Aggregate: solid.NewAttestionFromParameters([]byte{1, 2}, solid.NewAttestionDataFromParameters(
+					s.Slot(),
+					0,
+					br,
+					checkpoint,
+					checkpoint,
+				), common.Bytes96{}),
+				SelectionProof: common.Bytes96{},
+			},
 		},
+		GossipData: nil,
 	}
-	a.Message.Aggregate.AttestantionData().Target().SetEpoch(s.Slot() / 32)
+
+	a.SignedAggregateAndProof.Message.Aggregate.AttestantionData().Target().SetEpoch(s.Slot() / 32)
 	return a, s
 
 }
@@ -65,7 +69,7 @@ func setupAggregateAndProofTest(t *testing.T) (AggregateAndProofService, *synced
 	forkchoiceMock := mock_services.NewForkChoiceStorageMock(t)
 	p := pool.OperationsPool{}
 	p.AttestationsPool = pool.NewOperationPool[libcommon.Bytes96, *solid.Attestation](100, "test")
-	blockService := NewAggregateAndProofService(ctx, syncedDataManager, forkchoiceMock, cfg, p, true)
+	blockService := NewAggregateAndProofService(ctx, syncedDataManager, forkchoiceMock, cfg, p, nil, true)
 	return blockService, syncedDataManager, forkchoiceMock
 }
 
@@ -84,7 +88,7 @@ func TestAggregateAndProofServiceHighSlot(t *testing.T) {
 	defer ctrl.Finish()
 
 	agg, s := getAggregateAndProofAndState(t)
-	agg.Message.Aggregate.AttestantionData().SetSlot(9998898)
+	agg.SignedAggregateAndProof.Message.Aggregate.AttestantionData().SetSlot(9998898)
 
 	aggService, sd, _ := setupAggregateAndProofTest(t)
 	sd.OnHeadState(s)
@@ -96,7 +100,7 @@ func TestAggregateAndProofServiceBadEpoch(t *testing.T) {
 	defer ctrl.Finish()
 
 	agg, s := getAggregateAndProofAndState(t)
-	agg.Message.Aggregate.AttestantionData().SetSlot(0)
+	agg.SignedAggregateAndProof.Message.Aggregate.AttestantionData().SetSlot(0)
 
 	aggService, sd, _ := setupAggregateAndProofTest(t)
 	sd.OnHeadState(s)
@@ -138,8 +142,8 @@ func TestAggregateAndProofInvalidEpoch(t *testing.T) {
 	sd.OnHeadState(s)
 	fcu.FinalizedCheckpointVal = s.FinalizedCheckpoint()
 	fcu.Ancestors[s.FinalizedCheckpoint().Epoch()*32] = s.FinalizedCheckpoint().BlockRoot()
-	fcu.Headers[agg.Message.Aggregate.AttestantionData().BeaconBlockRoot()] = &cltypes.BeaconBlockHeader{}
-	agg.Message.Aggregate.AttestantionData().Target().SetEpoch(999999)
+	fcu.Headers[agg.SignedAggregateAndProof.Message.Aggregate.AttestantionData().BeaconBlockRoot()] = &cltypes.BeaconBlockHeader{}
+	agg.SignedAggregateAndProof.Message.Aggregate.AttestantionData().Target().SetEpoch(999999)
 	require.Error(t, aggService.ProcessMessage(context.Background(), nil, agg))
 }
 
@@ -153,8 +157,8 @@ func TestAggregateAndProofInvalidCommittee(t *testing.T) {
 	sd.OnHeadState(s)
 	fcu.FinalizedCheckpointVal = s.FinalizedCheckpoint()
 	fcu.Ancestors[s.FinalizedCheckpoint().Epoch()*32] = s.FinalizedCheckpoint().BlockRoot()
-	fcu.Headers[agg.Message.Aggregate.AttestantionData().BeaconBlockRoot()] = &cltypes.BeaconBlockHeader{}
-	agg.Message.AggregatorIndex = 12453224
+	fcu.Headers[agg.SignedAggregateAndProof.Message.Aggregate.AttestantionData().BeaconBlockRoot()] = &cltypes.BeaconBlockHeader{}
+	agg.SignedAggregateAndProof.Message.AggregatorIndex = 12453224
 	require.Error(t, aggService.ProcessMessage(context.Background(), nil, agg))
 }
 
@@ -168,7 +172,7 @@ func TestAggregateAndProofAncestorMissing(t *testing.T) {
 	sd.OnHeadState(s)
 	fcu.FinalizedCheckpointVal = s.FinalizedCheckpoint()
 	fcu.Ancestors[s.FinalizedCheckpoint().Epoch()*32] = s.FinalizedCheckpoint().BlockRoot()
-	fcu.Headers[agg.Message.Aggregate.AttestantionData().BeaconBlockRoot()] = &cltypes.BeaconBlockHeader{}
+	fcu.Headers[agg.SignedAggregateAndProof.Message.Aggregate.AttestantionData().BeaconBlockRoot()] = &cltypes.BeaconBlockHeader{}
 	require.Error(t, aggService.ProcessMessage(context.Background(), nil, agg))
 }
 
@@ -182,7 +186,7 @@ func TestAggregateAndProofSuccess(t *testing.T) {
 	sd.OnHeadState(s)
 	fcu.FinalizedCheckpointVal = s.FinalizedCheckpoint()
 	fcu.Ancestors[s.FinalizedCheckpoint().Epoch()*32] = s.FinalizedCheckpoint().BlockRoot()
-	fcu.Ancestors[agg.Message.Aggregate.AttestantionData().Slot()] = agg.Message.Aggregate.AttestantionData().Target().BlockRoot()
-	fcu.Headers[agg.Message.Aggregate.AttestantionData().BeaconBlockRoot()] = &cltypes.BeaconBlockHeader{}
+	fcu.Ancestors[agg.SignedAggregateAndProof.Message.Aggregate.AttestantionData().Slot()] = agg.SignedAggregateAndProof.Message.Aggregate.AttestantionData().Target().BlockRoot()
+	fcu.Headers[agg.SignedAggregateAndProof.Message.Aggregate.AttestantionData().BeaconBlockRoot()] = &cltypes.BeaconBlockHeader{}
 	require.NoError(t, aggService.ProcessMessage(context.Background(), nil, agg))
 }

--- a/cl/phase1/network/services/interface.go
+++ b/cl/phase1/network/services/interface.go
@@ -42,7 +42,7 @@ type SyncCommitteeMessagesService Service[*cltypes.SyncCommitteeMessage]
 type SyncContributionService Service[*cltypes.SignedContributionAndProof]
 
 //go:generate mockgen -typed=true -destination=./mock_services/aggregate_and_proof_service_mock.go -package=mock_services . AggregateAndProofService
-type AggregateAndProofService Service[*cltypes.SignedAggregateAndProof]
+type AggregateAndProofService Service[*cltypes.SignedAggregateAndProofData]
 
 //go:generate mockgen -typed=true -destination=./mock_services/attestation_service_mock.go -package=mock_services . AttestationService
 type AttestationService Service[*solid.Attestation]

--- a/cl/phase1/network/services/mock_services/aggregate_and_proof_service_mock.go
+++ b/cl/phase1/network/services/mock_services/aggregate_and_proof_service_mock.go
@@ -41,7 +41,7 @@ func (m *MockAggregateAndProofService) EXPECT() *MockAggregateAndProofServiceMoc
 }
 
 // ProcessMessage mocks base method.
-func (m *MockAggregateAndProofService) ProcessMessage(arg0 context.Context, arg1 *uint64, arg2 *cltypes.SignedAggregateAndProof) error {
+func (m *MockAggregateAndProofService) ProcessMessage(arg0 context.Context, arg1 *uint64, arg2 *cltypes.SignedAggregateAndProofData) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProcessMessage", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -67,13 +67,13 @@ func (c *MockAggregateAndProofServiceProcessMessageCall) Return(arg0 error) *Moc
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAggregateAndProofServiceProcessMessageCall) Do(f func(context.Context, *uint64, *cltypes.SignedAggregateAndProof) error) *MockAggregateAndProofServiceProcessMessageCall {
+func (c *MockAggregateAndProofServiceProcessMessageCall) Do(f func(context.Context, *uint64, *cltypes.SignedAggregateAndProofData) error) *MockAggregateAndProofServiceProcessMessageCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAggregateAndProofServiceProcessMessageCall) DoAndReturn(f func(context.Context, *uint64, *cltypes.SignedAggregateAndProof) error) *MockAggregateAndProofServiceProcessMessageCall {
+func (c *MockAggregateAndProofServiceProcessMessageCall) DoAndReturn(f func(context.Context, *uint64, *cltypes.SignedAggregateAndProofData) error) *MockAggregateAndProofServiceProcessMessageCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/cmd/caplin/caplin1/run.go
+++ b/cmd/caplin/caplin1/run.go
@@ -314,7 +314,7 @@ func RunCaplinService(ctx context.Context, engine execution_client.ExecutionEngi
 	syncCommitteeMessagesService := services.NewSyncCommitteeMessagesService(beaconConfig, ethClock, syncedDataManager, syncContributionPool, false)
 	attestationService := services.NewAttestationService(ctx, forkChoice, committeeSub, ethClock, syncedDataManager, beaconConfig, networkConfig, emitters)
 	syncContributionService := services.NewSyncContributionService(syncedDataManager, beaconConfig, syncContributionPool, ethClock, emitters, false)
-	aggregateAndProofService := services.NewAggregateAndProofService(ctx, syncedDataManager, forkChoice, beaconConfig, pool, false)
+	aggregateAndProofService := services.NewAggregateAndProofService(ctx, syncedDataManager, forkChoice, beaconConfig, pool, sentinel, false)
 	voluntaryExitService := services.NewVoluntaryExitService(pool, emitters, syncedDataManager, beaconConfig, ethClock)
 	blsToExecutionChangeService := services.NewBLSToExecutionChangeService(pool, emitters, syncedDataManager, beaconConfig)
 	proposerSlashingService := services.NewProposerSlashingService(pool, syncedDataManager, beaconConfig, ethClock, emitters)


### PR DESCRIPTION
We are trying to optimise `AggregateAndProofService`. After profiling the service, I see that most of the CPU time is spent on signature verifications. From the graph, overall, the function took 6.6% (74 seconds) of all the time (not just execution time. Percentage would be much higher if we took just cpu time) see the screenshot:

<img width="1470" alt="Screenshot 2024-09-01 at 10 28 38" src="https://github.com/user-attachments/assets/929ce103-2bf3-43d9-a0fa-ca504e4b58bb">


Now we are trying to aggregate all the signatures and verify them altogether with `bls.VerifyMultipleSignatures` function in an async way and run the final functions if verifications succeed. I basically removed all the code where we verified those three signatures and instead gathered them for verifying later. After profiling that I see the following output:

<img width="1468" alt="Screenshot 2024-09-01 at 10 44 31" src="https://github.com/user-attachments/assets/abb842a3-0b4f-4640-8a88-791a2d0af62b">

Now most of the time, as I see, is spent on public key aggregation when we are verifying validator aggregated signatures. But I guess there is no way to optimise that one. As we are spending most of the time on `NewPublicKeyFromBytes` maybe we could cache constructed keys but I think bls already does that. So, that's as good as it gets.

 