### PR TITLE
Erigon 3: Fix occassional need for reorgs (during first sync in polygon) through a "safety" threshold

### DIFF
--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -683,7 +683,7 @@ Loop:
 			aggTx := applyTx.(state2.HasAggTx).AggTx().(*state2.AggregatorRoTx)
 			aggTx.RestrictSubsetFileDeletions(true)
 			start := time.Now()
-			doms.SetChangesetAccumulator(nil) // Make sure we don't generate changesets during the execution
+			doms.SetChangesetAccumulator(nil) // Make sure we don't have an active changeset accumulator
 			// First compute and commit the progress done so far
 			if _, err := doms.ComputeCommitment(ctx, true, blockNum, execStage.LogPrefix()); err != nil {
 				return err

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -683,6 +683,7 @@ Loop:
 			aggTx := applyTx.(state2.HasAggTx).AggTx().(*state2.AggregatorRoTx)
 			aggTx.RestrictSubsetFileDeletions(true)
 			start := time.Now()
+			doms.SetChangesetAccumulator(nil) // Make sure we don't generate changesets during the execution
 			// First compute and commit the progress done so far
 			if _, err := doms.ComputeCommitment(ctx, true, blockNum, execStage.LogPrefix()); err != nil {
 				return err

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -931,7 +931,7 @@ Loop:
 					return err
 				}
 			}
-
+			fmt.Println(blockNum)
 			doms.SetChangesetAccumulator(nil)
 		}
 

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -78,7 +78,7 @@ var (
 
 const (
 	changesetBlockRange = 1_000 // Generate changeset only if execution of blocks <= changesetBlockRange
-	changesetSafeRange  = 8     // Safety net for long-sync, keep last 8 changesets
+	changesetSafeRange  = 32    // Safety net for long-sync, keep last 32 changesets
 )
 
 func NewProgress(prevOutputBlockNum, commitThreshold uint64, workersCount int, updateMetrics bool, logPrefix string, logger log.Logger) *Progress {


### PR DESCRIPTION
Always save last 8 blocks of a "block batch"