### PR TITLE
consensuschain: fix getHeaderByHash return nil

### DIFF
--- a/eth/consensuschain/consensus_chain_reader.go
+++ b/eth/consensuschain/consensus_chain_reader.go
@@ -74,11 +74,8 @@ func (cr Reader) GetHeaderByNumber(number uint64) *types.Header {
 }
 func (cr Reader) GetHeaderByHash(hash common.Hash) *types.Header {
 	if cr.blockReader != nil {
-		number := rawdb.ReadHeaderNumber(cr.tx, hash)
-		if number == nil {
-			return nil
-		}
-		return cr.GetHeader(hash, *number)
+		h, _ := cr.blockReader.HeaderByHash(context.Background(), cr.tx, hash)
+		return h
 	}
 	h, _ := rawdb.ReadHeaderByHash(cr.tx, hash)
 	return h


### PR DESCRIPTION
Once remove chaindata, it will always return nil when get block number by hash. Because the kv.HeaderNumber won't filled when FillDBFromsanpshot. 