### PR TITLE
Update ethereum/tests to v14.1

### DIFF
--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -59,22 +59,3 @@ func TestBlockchain(t *testing.T) {
 		}
 	})
 }
-
-func TestBlockchainEIP(t *testing.T) {
-	defer log.Root().SetHandler(log.Root().GetHandler())
-	log.Root().SetHandler(log.LvlFilterHandler(log.LvlError, log.StderrHandler))
-
-	bt := new(testMatcher)
-
-	// EOF is not supported yet
-	bt.skipLoad(`^StateTests/stEOF/`)
-	bt.skipLoad(`^StateTests/stEIP2537/`)
-
-	checkStateRoot := true
-
-	bt.walk(t, blockEipTestDir, func(t *testing.T, name string, test *BlockTest) {
-		if err := bt.checkFailure(t, test.Run(t, checkStateRoot)); err != nil {
-			t.Error(err)
-		}
-	})
-}

--- a/tests/init_test.go
+++ b/tests/init_test.go
@@ -39,7 +39,6 @@ import (
 var (
 	baseDir            = filepath.Join(".", "testdata")
 	blockTestDir       = filepath.Join(baseDir, "BlockchainTests")
-	blockEipTestDir    = filepath.Join(baseDir, "EIPTests", "BlockchainTests")
 	stateTestDir       = filepath.Join(baseDir, "GeneralStateTests")
 	transactionTestDir = filepath.Join(baseDir, "TransactionTests")
 	rlpTestDir         = filepath.Join(baseDir, "RLPTests")

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -52,14 +52,6 @@ func TestState(t *testing.T) {
 	st.skipLoad(`^stTimeConsuming/`)
 	st.skipLoad(`.*vmPerformance/loop.*`)
 
-	//st.slow(`^/modexp`)
-	//st.slow(`^stQuadraticComplexityTest/`)
-
-	// Very time consuming
-	st.skipLoad(`^stTimeConsuming/`)
-	st.skipLoad(`.*vmPerformance/loop.*`)
-	//if ethconfig.EnableHistoryV3InTest {
-	//}
 	// these need to implement eip-7610
 	st.skipLoad(`InitCollisionParis.json`)
 	st.skipLoad(`RevertInCreateInInit_Paris.json`)


### PR DESCRIPTION
[v14.1](https://github.com/ethereum/tests/releases/tag/v14.1) is the last version to add new test vectors; going forward all new tests will be added to [execution-spec-tests](https://github.com/ethereum/execution-spec-tests).