### PR TITLE
New workflow ci-cd-main-branch-docker-images.yml and changes in release workflow

### DIFF
--- a/.github/workflows/ci-cd-main-branch-docker-images.yml
+++ b/.github/workflows/ci-cd-main-branch-docker-images.yml
@@ -1,0 +1,93 @@
+name: Publishing snapshot images
+run-name: "Publishing snapshot images "
+
+env:
+  APPLICATION: "erigon"
+  BUILDER_IMAGE: "golang:1.22.6-alpine3.20"
+  TARGET_BASE_IMAGE: "alpine:3.20.2"
+  APP_REPO: "erigontech/erigon"
+  CHECKOUT_REF: "main"
+  DOCKERHUB_REPOSITORY: "erigontech/erigon"
+  LABEL_DESCRIPTION: "[docker image built on a last commit id from the main branch] Erigon is an implementation of Ethereum (execution layer with embeddable consensus layer), on the efficiency frontier. Archive Node by default."
+
+on:
+  push:
+    branches:
+      - 'master'
+    paths-ignore:
+      - '.github/**'
+    #tags:
+      ## only trigger on release tags:
+      #- 'v*.*.*'
+      #- 'v*.*.*-*'
+  workflow_dispatch:
+
+jobs:
+
+  Build:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Fast checkout git repository in order to get commit id for further checkouts by this workflow
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 ## 4.1.7 release
+        with:
+          repository: ${{ env.APP_REPO }}
+          fetch-depth: 1
+          ref: ${{ env.CHECKOUT_REF }}
+          path: 'erigon'
+
+      - name: Get commit id
+        id: getCommitId
+        run: |
+          cd erigon
+          echo "id=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "short_commit_id=$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
+          cd ..
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  ## v3.3.0
+        with:
+          username: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME }}
+          password: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf ## v3.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db ## v3.6.1
+
+      - name: Build and push multi-platform docker image based on the last commit in main branch
+        env:
+          BUILD_VERSION: "main-${{ steps.getCommitId.outputs.id }}"
+          DOCKER_URL: ${{ env.DOCKERHUB_REPOSITORY }}
+          DOCKERFILE_PATH: Dockerfile.release
+        run: |
+          cd erigon
+          docker buildx build \
+          --file ${{ env.DOCKERFILE_PATH }} \
+          --target ci-cd-main-branch \
+          --build-arg CI_CD_MAIN_TARGET_BASE_IMAGE=${{ env.TARGET_BASE_IMAGE }} \
+          --build-arg CI_CD_MAIN_BUILDER_IMAGE=${{ env.BUILDER_IMAGE }} \
+          --tag ${{ env.DOCKER_URL }}:${{ env.BUILD_VERSION }} \
+          --tag ${{ env.DOCKER_URL }}:main-latest \
+          --label org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
+          --label org.opencontainers.image.authors="https://github.com/erigontech/erigon/graphs/contributors" \
+          --label org.opencontainers.image.url="https://github.com/erigontech/erigon/blob/main/Dockerfile" \
+          --label org.opencontainers.image.documentation="https://github.com/erigontech/erigon/blob/main/Dockerfile" \
+          --label org.opencontainers.image.source="https://github.com/erigontech/erigon/blob/main/Dockerfile" \
+          --label org.opencontainers.image.version=${{ steps.getCommitId.outputs.id }} \
+          --label org.opencontainers.image.revision=${{ steps.getCommitId.outputs.id }} \
+          --label org.opencontainers.image.vcs-ref-short=${{ steps.getCommitId.outputs.short_commit_id }} \
+          --label org.opencontainers.image.vendor="${{ github.repository_owner }}" \
+          --label org.opencontainers.image.description="${{ env.LABEL_DESCRIPTION }}" \
+          --label org.opencontainers.image.base.name="${{ env.TARGET_BASE_IMAGE }}" \
+          --push \
+          --platform linux/amd64,linux/arm64 .
+
+      - name: Print docker images published
+        run: |
+          echo Following docker images published:
+          echo "${{ env.DOCKERHUB_REPOSITORY }}:main-${{ steps.getCommitId.outputs.id }}"
+          echo "${{ env.DOCKERHUB_REPOSITORY }}:main-latest"
+        

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,7 @@ jobs:
           --build-arg VERSION=${{ env.BUILD_VERSION }} \
           --build-arg APPLICATION=${{ env.APPLICATION }} \
           --tag ${{ env.DOCKER_URL }}:${{ env.BUILD_VERSION }} \
+          --target release \
           ${{ env.DOCKER_PUBLISH_LATEST_CONDITION }} \
           --label org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
           --label org.opencontainers.image.authors="https://github.com/erigontech/erigon/graphs/contributors" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
         run: |
           docker buildx build \
           --file ${{ env.DOCKERFILE_PATH }} \
-          --build-arg DOCKER_BASE_IMAGE=${{ env.DOCKER_BASE_IMAGE }} \
+          --build-arg RELEASE_DOCKER_BASE_IMAGE=${{ env.DOCKER_BASE_IMAGE }} \
           --build-arg VERSION=${{ env.BUILD_VERSION }} \
           --build-arg APPLICATION=${{ env.APPLICATION }} \
           --tag ${{ env.DOCKER_URL }}:${{ env.BUILD_VERSION }} \

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -12,7 +12,7 @@ COPY ./dist/${APPLICATION}_${VERSION}_linux_${TARGETARCH}.tar.gz /tmp/${APPLICAT
 RUN tar xzvf /tmp/${APPLICATION}.tar.gz -C /tmp && \
     mv /tmp/${APPLICATION}_${VERSION}_linux_${TARGETARCH} /tmp/${APPLICATION}
 
-FROM ${DOCKER_BASE_IMAGE}
+FROM ${DOCKER_BASE_IMAGE} AS release
 
 ARG USER=erigon \
     GROUP=erigon \

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,9 +1,10 @@
-ARG DOCKER_BASE_IMAGE="alpine:3.20.1"
+ARG RELEASE_DOCKER_BASE_IMAGE="alpine:3.20.1"
 
 ## Note TARGETARCH is a crucial variable:
 ##   see https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope
 
-FROM ${DOCKER_BASE_IMAGE} AS temporary
+### Release Dockerfile
+FROM ${RELEASE_DOCKER_BASE_IMAGE} AS temporary
 ARG TARGETARCH \
     VERSION=${VERSION} \
     APPLICATION
@@ -12,7 +13,7 @@ COPY ./dist/${APPLICATION}_${VERSION}_linux_${TARGETARCH}.tar.gz /tmp/${APPLICAT
 RUN tar xzvf /tmp/${APPLICATION}.tar.gz -C /tmp && \
     mv /tmp/${APPLICATION}_${VERSION}_linux_${TARGETARCH} /tmp/${APPLICATION}
 
-FROM ${DOCKER_BASE_IMAGE} AS release
+FROM ${RELEASE_DOCKER_BASE_IMAGE} AS release
 
 ARG USER=erigon \
     GROUP=erigon \
@@ -48,3 +49,57 @@ EXPOSE 8545 \
        6060
 
 ENTRYPOINT [ "/usr/local/bin/erigon" ]
+
+### End of Release Dockerfile
+
+
+ARG CI_CD_MAIN_BUILDER_IMAGE="golang:1.22-bookworm" \
+    CI_CD_MAIN_TARGET_BASE_IMAGE="alpine:3.20.1"
+
+### CI-CD : main branch docker image publishing for each new commit id
+FROM ${CI_CD_MAIN_BUILDER_IMAGE} AS builder
+
+ARG TARGETOS TARGETARCH
+
+ENV GOOS=$TARGETOS \
+    GOARCH=$TARGETARCH
+
+COPY . /home/erigon
+
+WORKDIR /home/erigon
+
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    apk update && \
+    apk add make git gcc libstdc++ build-base linux-headers bash ca-certificates && \
+    make BUILD_TAGS=nosqlite,noboltdb,nosilkworm erigon integration rpcdaemon
+    
+FROM ${CI_CD_MAIN_TARGET_BASE_IMAGE} AS ci-cd-main-branch
+ARG USER=erigon \
+    GROUP=erigon
+
+RUN --mount=type=bind,from=builder,source=/home/erigon,target=/tmp/erigon \
+    apk add --no-cache ca-certificates tzdata libstdc++ && \
+    addgroup ${GROUP} && \
+    adduser -D -h /home/${USER} -G ${GROUP} ${USER} && \
+    install -d -o ${USER} -g ${GROUP} /home/${USER}/.local /home/${USER}/.local/share /home/${USER}/.local/share/erigon && \
+    install -o ${USER} -g ${GROUP} /tmp/erigon/build/bin/* /usr/local/bin/
+
+VOLUME [ "/home/${USER}" ]
+WORKDIR /home/${USER}
+
+USER ${USER}
+EXPOSE 8545 \
+       8551 \
+       8546 \
+       30303 \
+       30303/udp \
+       42069 \
+       42069/udp \
+       8080 \
+       9090 \
+       6060
+
+ENTRYPOINT [ "/usr/local/bin/erigon" ]
+
+### End of CI-CD : main branch docker image publishing for each new commit id


### PR DESCRIPTION
New workflow ci-cd-main-branch-docker-images.yml
New Dockerfile targets for the new workflow in Dockerfile.release
Changes in release workflow: rename arg.

See issue https://github.com/erigontech/erigon/issues/10251 for more info.