### PR TITLE
Implement DomainRange in KvServer

### DIFF
--- a/erigon-lib/kv/remotedbserver/remotedbserver.go
+++ b/erigon-lib/kv/remotedbserver/remotedbserver.go
@@ -676,7 +676,7 @@ func (s *KvServer) DomainRange(_ context.Context, req *remote.DomainRangeReq) (*
 		if !ok {
 			return errors.New("server DB doesn't implement kv.Temporal interface")
 		}
-		it, err := ttx.DomainRange(kv.Domain(domainName), fromKey, toKey, req.Ts, order.By(req.OrderAscend), limit)
+		it, err := ttx.DomainRange(domainName, fromKey, toKey, req.Ts, order.By(req.OrderAscend), limit)
 		if err != nil {
 			return err
 		}

--- a/erigon-lib/kv/remotedbserver/remotedbserver.go
+++ b/erigon-lib/kv/remotedbserver/remotedbserver.go
@@ -606,7 +606,7 @@ func (s *KvServer) IndexRange(_ context.Context, req *remote.IndexRangeReq) (*re
 			reply.Timestamps = append(reply.Timestamps, v)
 			limit--
 		}
-		if len(reply.Timestamps) == PageSizeLimit && it.HasNext() {
+		if len(reply.Timestamps) == int(req.PageSize) && it.HasNext() {
 			next, err := it.Next()
 			if err != nil {
 				return err
@@ -645,7 +645,62 @@ func (s *KvServer) HistoryRange(_ context.Context, req *remote.HistoryRangeReq) 
 			value := bytesCopy(v)
 			reply.Keys = append(reply.Keys, key)
 			reply.Values = append(reply.Values, value)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return reply, nil
+}
+
+func (s *KvServer) DomainRange(_ context.Context, req *remote.DomainRangeReq) (*remote.Pairs, error) {
+	domainName, err := kv.String2Domain(req.Table)
+	if err != nil {
+		return nil, err
+	}
+	reply := &remote.Pairs{}
+	fromKey, toKey, limit := req.FromKey, req.ToKey, int(req.Limit)
+	if req.PageToken != "" {
+		var pagination remote.ParisPagination
+		if err := unmarshalPagination(req.PageToken, &pagination); err != nil {
+			return nil, err
+		}
+		fromKey, limit = pagination.NextKey, int(pagination.Limit)
+	}
+	if req.PageSize <= 0 || req.PageSize > PageSizeLimit {
+		req.PageSize = PageSizeLimit
+	}
+
+	if err := s.with(req.TxId, func(tx kv.Tx) error {
+		ttx, ok := tx.(kv.TemporalTx)
+		if !ok {
+			return errors.New("server DB doesn't implement kv.Temporal interface")
+		}
+		it, err := ttx.DomainRange(kv.Domain(domainName), fromKey, toKey, req.Ts, order.By(req.OrderAscend), limit)
+		if err != nil {
+			return err
+		}
+		defer it.Close()
+		for it.HasNext() {
+			k, v, err := it.Next()
+			if err != nil {
+				return err
+			}
+			key := bytesCopy(k)
+			value := bytesCopy(v)
+			reply.Keys = append(reply.Keys, key)
+			reply.Values = append(reply.Values, value)
 			limit--
+		}
+		if len(reply.Keys) == int(req.PageSize) && it.HasNext() {
+			nextK, _, err := it.Next()
+			if err != nil {
+				return err
+			}
+			reply.NextPageToken, err = marshalPagination(&remote.ParisPagination{NextKey: nextK, Limit: int64(limit)})
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	}); err != nil {


### PR DESCRIPTION
It is necessary when using temporal KV remotely.

Additional changes:
- remove what I think is an oversight in `IndexRange`, where `req.PageSize` was checked and cut to `PageSizeLimit`, but then not used (`PageSizeLimit` itself was used instead)
- remove useless `limit--` in `HistoryRange`
