### PR TITLE
Fix bor-heimdall stall after chaindb removal

### DIFF
--- a/eth/stagedsync/stage_bor_heimdall.go
+++ b/eth/stagedsync/stage_bor_heimdall.go
@@ -288,10 +288,15 @@ func BorHeimdallForward(
 				return err
 			}
 
+			// this will happen if for example chaindb is removed
+			if lastPersistedBlockNum > blockNum {
+				lastPersistedBlockNum = blockNum
+			}
+
 			// if the last time we persisted snapshots is too far away re-run the forward
 			// initialization process - this is to avoid memory growth due to recusrion
 			// in persistValidatorSets
-			if snap == nil && blockNum-lastPersistedBlockNum > (snapshotPersistInterval*5) {
+			if snap == nil && (blockNum == 1 || blockNum-lastPersistedBlockNum > (snapshotPersistInterval*5)) {
 				snap, err = initValidatorSets(
 					ctx,
 					tx,


### PR DESCRIPTION
In the first run, init validators was skipped due to the check. Updated it by checking the erigon3 code to init snapshot for 1st block (this logic is borrowed from main branch).

cherry-pick adaptation of https://github.com/erigontech/erigon/pull/11725