### PR TITLE
polygon/sync: fix parent td missing when forking at the tip

### DIFF
--- a/polygon/sync/sync.go
+++ b/polygon/sync/sync.go
@@ -232,8 +232,8 @@ func (s *Sync) applyNewBlockOnTip(
 	}
 
 	// len(blockChain) is always <= len(blockChain)
-	lastN := blockChain[len(blockChain)-len(newConnectedHeaders):]
-	if err := s.store.InsertBlocks(ctx, lastN); err != nil {
+	newConnectedBlocks := blockChain[len(blockChain)-len(newConnectedHeaders):]
+	if err := s.store.InsertBlocks(ctx, newConnectedBlocks); err != nil {
 		return err
 	}
 

--- a/polygon/sync/sync.go
+++ b/polygon/sync/sync.go
@@ -213,7 +213,6 @@ func (s *Sync) applyNewBlockOnTip(
 
 	headerChain := make([]*types.Header, len(blockChain))
 	for i, block := range blockChain {
-		block.Hash()
 		headerChain[i] = block.HeaderNoCopy()
 	}
 
@@ -231,7 +230,7 @@ func (s *Sync) applyNewBlockOnTip(
 		return nil
 	}
 
-	// len(blockChain) is always <= len(newConnectedHeaders)
+	// len(newConnectedHeaders) is always <= len(blockChain)
 	newConnectedBlocks := blockChain[len(blockChain)-len(newConnectedHeaders):]
 	if err := s.store.InsertBlocks(ctx, newConnectedBlocks); err != nil {
 		return err

--- a/polygon/sync/sync.go
+++ b/polygon/sync/sync.go
@@ -231,7 +231,7 @@ func (s *Sync) applyNewBlockOnTip(
 		return nil
 	}
 
-	// len(blockChain) is always <= len(blockChain)
+	// len(blockChain) is always <= len(newConnectedHeaders)
 	newConnectedBlocks := blockChain[len(blockChain)-len(newConnectedHeaders):]
 	if err := s.store.InsertBlocks(ctx, newConnectedBlocks); err != nil {
 		return err


### PR DESCRIPTION
fixes https://github.com/erigontech/erigon/issues/11818

issue was:
- when at tip we receive new block hashes and new block events
- we had an if statement which checked if the canonical chain builder tip changed after connecting new headers to the tree
- that if statement was used to determine whether we should call `InsertBlocks` for the blocks we've just connected and also to `commitExecution` (call `UpdateForkChoice`)
- this meant that when at the tip, we would not insert new blocks which would not change the tip of the canonical chain builder
- this is wrong because we should be inserting these blocks as they may end up being on the canonical path several blocks later in case the forks change in their favour based on the connected ancestors

fix is:
- augment `canonicalChainBuilder.Connect` to return the newly connected headers to the tree
- always insert newly connected headers (upon successful connection to the root)