### PR TITLE
comment docker-build-check job as mentioned in the issue 11872.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,6 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.59.1
-          skip-build-cache: true
           args: --help
 
       - name: Lint
@@ -114,23 +113,23 @@ jobs:
       - name: Test erigon-lib
         run: cd erigon-lib && make test-no-fuzz
 
-  docker-build-check:
-    # don't run this on main - the PR must have run it to be merged and it misleads that this pushes the docker image
-    if: (${{ github.event_name == 'push' || !github.event.pull_request.draft }}) && ${{ github.ref != 'refs/heads/main' }}
-    runs-on: ubuntu-22.04
+#  docker-build-check:
+#    # don't run this on main - the PR must have run it to be merged and it misleads that this pushes the docker image
+#    if: (${{ github.event_name == 'push' || !github.event.pull_request.draft }}) && ${{ github.ref != 'refs/heads/main' }}
+#    runs-on: ubuntu-22.04
+#
+#    steps:
+#      - uses: AutoModality/action-clean@v1
+#      - uses: actions/checkout@v4
+#        with:
+#          fetch-depth: 0 # fetch git tags for "git describe"
 
-    steps:
-      - uses: AutoModality/action-clean@v1
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # fetch git tags for "git describe"
-
-      - name: make docker (see dockerhub for image builds)
-        run: DOCKER_TAG=thorax/erigon:ci-$GITHUB_SHA DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) make docker
+#      - name: make docker (see dockerhub for image builds)
+#        run: DOCKER_TAG=thorax/erigon:ci-$GITHUB_SHA DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) make docker
 
       # check with root permissions, should be cached from previous build
-      - name: sudo make docker
-        run: sudo DOCKER_TAG=thorax/erigon:ci-$GITHUB_SHA DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) make docker
+#      - name: sudo make docker
+#        run: sudo DOCKER_TAG=thorax/erigon:ci-$GITHUB_SHA DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) make docker
 
 #  automated-tests:
 #    runs-on:


### PR DESCRIPTION
comment docker-build-check job as mentioned in the issue [11872](https://github.com/erigontech/erigon/issues/11872) -- it will save us 5-6 mins time of waiting for the routine check for each workflow run (faster PR check, etc).

get rid of "skip-build-cache" which is removed since v5