### PR TITLE
Reducing unnecessary attestation processing from gossip

### DIFF
--- a/cl/phase1/network/gossip_manager.go
+++ b/cl/phase1/network/gossip_manager.go
@@ -228,7 +228,10 @@ func (g *GossipManager) routeAndProcess(ctx context.Context, data *sentinel.Goss
 			if err := att.DecodeSSZ(data.Data, int(version)); err != nil {
 				return err
 			}
-			return g.attestationService.ProcessMessage(ctx, data.SubnetId, att)
+			if g.committeeSub.NeedToAggregate(att.AttestantionData().CommitteeIndex()) {
+				return g.attestationService.ProcessMessage(ctx, data.SubnetId, att)
+			}
+			return nil
 		default:
 			return fmt.Errorf("unknown topic %s", data.Name)
 		}

--- a/cl/phase1/network/services/attestation_service.go
+++ b/cl/phase1/network/services/attestation_service.go
@@ -99,6 +99,10 @@ func (s *attestationService) ProcessMessage(ctx context.Context, subnet *uint64,
 		return ErrIgnore
 	}
 
+	if !s.committeeSubscribe.NeedToAggregate(committeeIndex) {
+		return ErrIgnore
+	}
+
 	key, err := att.HashSSZ()
 	if err != nil {
 		return err

--- a/cl/phase1/network/services/attestation_service.go
+++ b/cl/phase1/network/services/attestation_service.go
@@ -99,10 +99,6 @@ func (s *attestationService) ProcessMessage(ctx context.Context, subnet *uint64,
 		return ErrIgnore
 	}
 
-	if !s.committeeSubscribe.NeedToAggregate(committeeIndex) {
-		return ErrIgnore
-	}
-
 	key, err := att.HashSSZ()
 	if err != nil {
 		return err

--- a/cl/validator/committee_subscription/interface.go
+++ b/cl/validator/committee_subscription/interface.go
@@ -27,4 +27,5 @@ import (
 type CommitteeSubscribe interface {
 	AddAttestationSubscription(ctx context.Context, p *cltypes.BeaconCommitteeSubscription) error
 	CheckAggregateAttestation(att *solid.Attestation) error
+	NeedToAggregate(committeeIndex uint64) bool
 }

--- a/cl/validator/committee_subscription/mock_services/committee_subscribe_mock.go
+++ b/cl/validator/committee_subscription/mock_services/committee_subscribe_mock.go
@@ -116,3 +116,41 @@ func (c *MockCommitteeSubscribeCheckAggregateAttestationCall) DoAndReturn(f func
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
+
+// NeedToAggregate mocks base method.
+func (m *MockCommitteeSubscribe) NeedToAggregate(arg0 uint64) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NeedToAggregate", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// NeedToAggregate indicates an expected call of NeedToAggregate.
+func (mr *MockCommitteeSubscribeMockRecorder) NeedToAggregate(arg0 any) *MockCommitteeSubscribeNeedToAggregateCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NeedToAggregate", reflect.TypeOf((*MockCommitteeSubscribe)(nil).NeedToAggregate), arg0)
+	return &MockCommitteeSubscribeNeedToAggregateCall{Call: call}
+}
+
+// MockCommitteeSubscribeNeedToAggregateCall wrap *gomock.Call
+type MockCommitteeSubscribeNeedToAggregateCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockCommitteeSubscribeNeedToAggregateCall) Return(arg0 bool) *MockCommitteeSubscribeNeedToAggregateCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockCommitteeSubscribeNeedToAggregateCall) Do(f func(uint64) bool) *MockCommitteeSubscribeNeedToAggregateCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockCommitteeSubscribeNeedToAggregateCall) DoAndReturn(f func(uint64) bool) *MockCommitteeSubscribeNeedToAggregateCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}


### PR DESCRIPTION
Don't need to process attestations from gossip if the committee index associated with the attestation is not subscribed or doesn't require aggregation.
