### PR TITLE
Revert "rpchelper: limits for filters by default (#11911)"

### DIFF
--- a/turbo/rpchelper/config.go
+++ b/turbo/rpchelper/config.go
@@ -30,9 +30,9 @@ type FiltersConfig struct {
 // These default values set no limits on the number of logs, block headers, transactions,
 // addresses, or topics that can be stored per subscription.
 var DefaultFiltersConfig = FiltersConfig{
-	RpcSubscriptionFiltersMaxLogs:      60,     // Limit on the number of logs per subscription, 0 for no limit
-	RpcSubscriptionFiltersMaxHeaders:   60,     // Limit on the number of block headers per subscription, 0 for no limit
-	RpcSubscriptionFiltersMaxTxs:       10_000, // Limit on the number of transactions per subscription, 0 for no limit
-	RpcSubscriptionFiltersMaxAddresses: 1_000,  // Limit on the number of addresses per subscription to filter logs by, 0 for no limit
-	RpcSubscriptionFiltersMaxTopics:    1_000,  // Limit on the number of topics per subscription to filter logs by, 0 for no limit
+	RpcSubscriptionFiltersMaxLogs:      0, // No limit on the number of logs per subscription
+	RpcSubscriptionFiltersMaxHeaders:   0, // No limit on the number of block headers per subscription
+	RpcSubscriptionFiltersMaxTxs:       0, // No limit on the number of transactions per subscription
+	RpcSubscriptionFiltersMaxAddresses: 0, // No limit on the number of addresses per subscription to filter logs by
+	RpcSubscriptionFiltersMaxTopics:    0, // No limit on the number of topics per subscription to filter logs by
 }


### PR DESCRIPTION
This reverts commit d7d9ded0ea3f5f887206f6c7f5e976eb58405154.

based on advice from @bretep
https://discord.com/channels/687972960811745322/983710221308416010/1281647424569344141

relates to https://github.com/erigontech/erigon/issues/11890