### PR TITLE
polygon/heimdall: Split read functions into reader

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -550,8 +550,9 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		}
 
 		if config.PolygonSync {
-			polygonBridge = bridge.Assemble(config.Dirs.DataDir, logger, consensusConfig.(*borcfg.BorConfig), heimdallClient)
-			heimdallService = heimdall.AssembleService(consensusConfig.(*borcfg.BorConfig), config.HeimdallURL, dirs.DataDir, tmpdir, logger)
+			borConfig := consensusConfig.(*borcfg.BorConfig)
+			polygonBridge = bridge.Assemble(config.Dirs.DataDir, logger, borConfig, heimdallClient)
+			heimdallService = heimdall.AssembleService(borConfig.CalculateSprintNumber, config.HeimdallURL, dirs.DataDir, tmpdir, logger)
 
 			backend.polygonBridge = polygonBridge
 		}

--- a/eth/stagedsync/stage_polygon_sync.go
+++ b/eth/stagedsync/stage_polygon_sync.go
@@ -97,7 +97,8 @@ func NewPolygonSyncStageCfg(
 		txActionStream: txActionStream,
 	}
 	borConfig := chainConfig.Bor.(*borcfg.BorConfig)
-	heimdallService := heimdall.NewService(borConfig, heimdallClient, heimdallStore, logger)
+	heimdallReader := heimdall.NewReader(borConfig.CalculateSprintNumber, heimdallStore, logger)
+	heimdallService := heimdall.NewService(borConfig.CalculateSprintNumber, heimdallClient, heimdallStore, logger, heimdallReader)
 	bridgeService := bridge.NewBridge(bridgeStore, logger, borConfig, heimdallClient, nil)
 	p2pService := p2p.NewService(maxPeers, logger, sentry, statusDataProvider.GetStatusData)
 	checkpointVerifier := polygonsync.VerifyCheckpointHeaders

--- a/polygon/heimdall/reader.go
+++ b/polygon/heimdall/reader.go
@@ -15,7 +15,7 @@ type Reader struct {
 }
 
 // AssembleReader creates and opens the MDBX store. For use cases where the store is only being read from. Must call Close.
-func AssembleReader(ctx context.Context, calculateSprintNumber CalculateSprintNumberType, dataDir string, tmpDir string, logger log.Logger) (*Reader, error) {
+func AssembleReader(ctx context.Context, calculateSprintNumber CalculateSprintNumberFunc, dataDir string, tmpDir string, logger log.Logger) (*Reader, error) {
 	store := NewMdbxServiceStore(logger, dataDir, tmpDir)
 
 	err := store.Prepare(ctx)
@@ -26,7 +26,7 @@ func AssembleReader(ctx context.Context, calculateSprintNumber CalculateSprintNu
 	return NewReader(calculateSprintNumber, store, logger), nil
 }
 
-func NewReader(calculateSprintNumber CalculateSprintNumberType, store ServiceStore, logger log.Logger) *Reader {
+func NewReader(calculateSprintNumber CalculateSprintNumberFunc, store ServiceStore, logger log.Logger) *Reader {
 	return &Reader{
 		logger:                    logger,
 		store:                     store,

--- a/polygon/heimdall/reader.go
+++ b/polygon/heimdall/reader.go
@@ -8,18 +8,6 @@ import (
 	"github.com/erigontech/erigon/polygon/bor/valset"
 )
 
-type HeimdallReader interface {
-	Span(ctx context.Context, id uint64) (*Span, bool, error)
-	CheckpointsFromBlock(ctx context.Context, startBlock uint64) (Waypoints, error)
-	MilestonesFromBlock(ctx context.Context, startBlock uint64) (Waypoints, error)
-	Producers(ctx context.Context, blockNum uint64) (*valset.ValidatorSet, error)
-}
-
-type ReaderService interface {
-	Reader
-	Close()
-}
-
 type Reader struct {
 	logger                    log.Logger
 	store                     ServiceStore

--- a/polygon/heimdall/service.go
+++ b/polygon/heimdall/service.go
@@ -52,18 +52,18 @@ type service struct {
 	spanBlockProducersTracker *spanBlockProducersTracker
 }
 
-func AssembleService(calculateSprintNumberFn CalculateSprintNumberType, heimdallUrl string, dataDir string, tmpDir string, logger log.Logger) Service {
+func AssembleService(calculateSprintNumberFn CalculateSprintNumberFunc, heimdallUrl string, dataDir string, tmpDir string, logger log.Logger) Service {
 	store := NewMdbxServiceStore(logger, dataDir, tmpDir)
 	client := NewHeimdallClient(heimdallUrl, logger)
 	reader := NewReader(calculateSprintNumberFn, store, logger)
 	return NewService(calculateSprintNumberFn, client, store, logger, reader)
 }
 
-func NewService(calculateSprintNumberFn CalculateSprintNumberType, client HeimdallClient, store ServiceStore, logger log.Logger, reader *Reader) Service {
+func NewService(calculateSprintNumberFn CalculateSprintNumberFunc, client HeimdallClient, store ServiceStore, logger log.Logger, reader *Reader) Service {
 	return newService(calculateSprintNumberFn, client, store, logger, reader)
 }
 
-func newService(calculateSprintNumberFn CalculateSprintNumberType, client HeimdallClient, store ServiceStore, logger log.Logger, reader *Reader) *service {
+func newService(calculateSprintNumberFn CalculateSprintNumberFunc, client HeimdallClient, store ServiceStore, logger log.Logger, reader *Reader) *service {
 	checkpointFetcher := newCheckpointFetcher(client, logger)
 	milestoneFetcher := newMilestoneFetcher(client, logger)
 	spanFetcher := newSpanFetcher(client, logger)

--- a/polygon/heimdall/service.go
+++ b/polygon/heimdall/service.go
@@ -31,7 +31,7 @@ import (
 )
 
 type Service interface {
-	Reader
+	HeimdallReader
 	RegisterMilestoneObserver(callback func(*Milestone), opts ...ObserverOption) polygoncommon.UnregisterFunc
 	Run(ctx context.Context) error
 	SynchronizeCheckpoints(ctx context.Context) error
@@ -42,7 +42,7 @@ type Service interface {
 type service struct {
 	logger                    log.Logger
 	store                     ServiceStore
-	reader                    Reader
+	reader                    HeimdallReader
 	checkpointScraper         *scraper[*Checkpoint]
 	milestoneScraper          *scraper[*Milestone]
 	spanScraper               *scraper[*Span]
@@ -56,11 +56,11 @@ func AssembleService(calculateSprintNumberFn CalculateSprintNumberType, heimdall
 	return NewService(calculateSprintNumberFn, client, store, logger, reader)
 }
 
-func NewService(calculateSprintNumberFn CalculateSprintNumberType, client HeimdallClient, store ServiceStore, logger log.Logger, reader Reader) Service {
+func NewService(calculateSprintNumberFn CalculateSprintNumberType, client HeimdallClient, store ServiceStore, logger log.Logger, reader HeimdallReader) Service {
 	return newService(calculateSprintNumberFn, client, store, logger, reader)
 }
 
-func newService(calculateSprintNumberFn CalculateSprintNumberType, client HeimdallClient, store ServiceStore, logger log.Logger, reader Reader) *service {
+func newService(calculateSprintNumberFn CalculateSprintNumberType, client HeimdallClient, store ServiceStore, logger log.Logger, reader HeimdallReader) *service {
 	checkpointFetcher := newCheckpointFetcher(client, logger)
 	milestoneFetcher := newMilestoneFetcher(client, logger)
 	spanFetcher := newSpanFetcher(client, logger)

--- a/polygon/heimdall/service_test.go
+++ b/polygon/heimdall/service_test.go
@@ -77,7 +77,8 @@ func (suite *ServiceTestSuite) SetupSuite() {
 	suite.setupSpans()
 	suite.setupCheckpoints()
 	suite.setupMilestones()
-	suite.service = newService(borConfig, suite.client, store, logger)
+	reader := NewReader(borConfig.CalculateSprintNumber, store, logger)
+	suite.service = newService(borConfig.CalculateSprintNumber, suite.client, store, logger, reader)
 
 	err := suite.service.store.Prepare(suite.ctx)
 	require.NoError(suite.T(), err)

--- a/polygon/heimdall/span_block_producers_tracker.go
+++ b/polygon/heimdall/span_block_producers_tracker.go
@@ -26,11 +26,11 @@ import (
 	"github.com/erigontech/erigon/polygon/bor/valset"
 )
 
-type CalculateSprintNumberType func(uint64) uint64
+type CalculateSprintNumberFunc func(uint64) uint64
 
 func newSpanBlockProducersTracker(
 	logger log.Logger,
-	calculateSprintNumber CalculateSprintNumberType,
+	calculateSprintNumber CalculateSprintNumberFunc,
 	store EntityStore[*SpanBlockProducerSelection],
 ) *spanBlockProducersTracker {
 	return &spanBlockProducersTracker{
@@ -44,7 +44,7 @@ func newSpanBlockProducersTracker(
 
 type spanBlockProducersTracker struct {
 	logger                log.Logger
-	calculateSprintNumber CalculateSprintNumberType
+	calculateSprintNumber CalculateSprintNumberFunc
 	store                 EntityStore[*SpanBlockProducerSelection]
 	newSpans              chan *Span
 	queued                atomic.Int32


### PR DESCRIPTION
- Create `heimdall.Reader` for future use in `bor_*` API
- Make `AssembleReader` and `NewReader` leaner by not requiring full `BorConfig`