### PR TITLE
polygon/sync: block downloader to not re-insert blocks behind start

### DIFF
--- a/polygon/sync/block_downloader_test.go
+++ b/polygon/sync/block_downloader_test.go
@@ -29,9 +29,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
-	"github.com/erigontech/erigon-lib/log/v3"
-
 	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/core/types"
 	"github.com/erigontech/erigon/polygon/heimdall"
 	"github.com/erigontech/erigon/polygon/p2p"
@@ -306,6 +305,41 @@ func TestBlockDownloaderDownloadBlocksUsingCheckpoints(t *testing.T) {
 	require.Equal(t, uint64(7), blocks[6].Header().Number.Uint64())
 	require.Equal(t, uint64(8), blocks[7].Header().Number.Uint64())
 	require.Equal(t, uint64(8192), blocks[8191].Header().Number.Uint64())
+	require.Equal(t, blocks[len(blocks)-1].Header(), tip)
+}
+
+func TestBlockDownloaderDownloadBlocksUsingCheckpointsWhenStartIsInMiddleOfCheckpointRange(t *testing.T) {
+	test := newBlockDownloaderTest(t)
+	test.waypointReader.EXPECT().
+		CheckpointsFromBlock(gomock.Any(), gomock.Any()).
+		Return(test.fakeCheckpoints(2), nil).
+		Times(1)
+	test.p2pService.EXPECT().
+		ListPeersMayHaveBlockNum(gomock.Any()).
+		Return(test.fakePeers(2)).
+		Times(1)
+	test.p2pService.EXPECT().
+		FetchHeaders(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(test.defaultFetchHeadersMock()).
+		Times(2)
+	test.p2pService.EXPECT().
+		FetchBodies(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(test.defaultFetchBodiesMock()).
+		Times(2)
+	var blocks []*types.Block
+	test.store.EXPECT().
+		InsertBlocks(gomock.Any(), gomock.Any()).
+		DoAndReturn(test.defaultInsertBlocksMock(&blocks)).
+		Times(1)
+
+	tip, err := test.blockDownloader.DownloadBlocksUsingCheckpoints(context.Background(), 513)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1536) // [513,1024] = 512 blocks + 1024 blocks from 2nd checkpoint
+	// check blocks are written in order
+	require.Equal(t, uint64(513), blocks[0].Header().Number.Uint64())
+	require.Equal(t, uint64(1024), blocks[511].Header().Number.Uint64())
+	require.Equal(t, uint64(1025), blocks[512].Header().Number.Uint64())
+	require.Equal(t, uint64(2048), blocks[1535].Header().Number.Uint64())
 	require.Equal(t, blocks[len(blocks)-1].Header(), tip)
 }
 


### PR DESCRIPTION
Run into an issue since we started pruning total difficulty.
```
EROR[09-09|10:58:03.057] [2/6 PolygonSync] stopping node          err="parent's total difficulty not found with hash 9334099de5d77c0d56afefde9985d44f8b4416db99dfe926908d5501fa8dbd9e and height 11736178: <nil>
```

It happened for checkpoint [9703](https://heimdall-api-amoy.polygon.technology/checkpoints/9703). Our start block was in the middle of the checkpoint range which meant we have to fetch all the 8k blocks in this checkpoint to verify the checkpoint root hash when receiving blocks from the peer. 

The current logic will attempt to insert all these 8k blocks and it will fail with a missing parent td error because we only keep the last  1000 parent td records.

This PR fixes this by enhancing the block downloader to not re-insert blocks behind the `start` block. This solves the parent td error and also is saving some unnecessary inserts on the first waypoint processing on startup.