### PR TITLE
trace_filter: return error at empty request

### DIFF
--- a/erigon-lib/kv/rawdbv3/txnum.go
+++ b/erigon-lib/kv/rawdbv3/txnum.go
@@ -237,14 +237,14 @@ func (TxNumsReader) Last(tx kv.Tx) (blockNum, txNum uint64, err error) {
 	}
 	defer c.Close()
 
-	lastK, lastV, err := c.Last()
+	k, v, err := c.Last()
 	if err != nil {
 		return 0, 0, err
 	}
-	if lastK == nil || lastV == nil {
+	if k == nil || v == nil {
 		return 0, 0, nil
 	}
-	return binary.BigEndian.Uint64(lastK), binary.BigEndian.Uint64(lastV), nil
+	return binary.BigEndian.Uint64(k), binary.BigEndian.Uint64(v), nil
 }
 func (TxNumsReader) First(tx kv.Tx) (blockNum, txNum uint64, err error) {
 	c, err := tx.Cursor(kv.MaxTxNum)
@@ -253,14 +253,14 @@ func (TxNumsReader) First(tx kv.Tx) (blockNum, txNum uint64, err error) {
 	}
 	defer c.Close()
 
-	lastK, lastV, err := c.First()
+	k, v, err := c.First()
 	if err != nil {
 		return 0, 0, err
 	}
-	if lastK == nil || lastV == nil {
+	if k == nil || v == nil {
 		return 0, 0, nil
 	}
-	return binary.BigEndian.Uint64(lastK), binary.BigEndian.Uint64(lastV), nil
+	return binary.BigEndian.Uint64(k), binary.BigEndian.Uint64(v), nil
 }
 
 // LastKey
@@ -355,7 +355,9 @@ func (i *MapTxNum2BlockNumIter) Next() (txNum, blockNum uint64, txIndex int, isF
 			return
 		}
 		if !ok {
-			return txNum, i.blockNum, txIndex, isFinalTxn, blockNumChanged, fmt.Errorf("can't find blockNumber by txnID=%d", txNum)
+			_lb, _lt, _ := i.txNumsReader.Last(i.tx)
+			_fb, _ft, _ := i.txNumsReader.First(i.tx)
+			return txNum, i.blockNum, txIndex, isFinalTxn, blockNumChanged, fmt.Errorf("can't find blockNumber by txnID=%d; last in db: (%d-%d, %d-%d)", txNum, _fb, _lb, _ft, _lt)
 		}
 	}
 	blockNum = i.blockNum

--- a/erigon-lib/kv/stream/stream.go
+++ b/erigon-lib/kv/stream/stream.go
@@ -66,9 +66,6 @@ func (it *ArrStream[V]) NextBatch() ([]V, error) {
 }
 
 func Range[T constraints.Integer](from, to T) *RangeIter[T] {
-	if from == to {
-		to++
-	}
 	return &RangeIter[T]{i: from, to: to}
 }
 

--- a/erigon-lib/kv/stream/stream_test.go
+++ b/erigon-lib/kv/stream/stream_test.go
@@ -213,7 +213,7 @@ func TestRange(t *testing.T) {
 		s1 := stream.Range[uint64](1, 1)
 		res, err := stream.ToArray[uint64](s1)
 		require.NoError(t, err)
-		require.Equal(t, []uint64{1}, res)
+		require.Empty(t, res)
 	})
 }
 


### PR DESCRIPTION
on empty request see error `can't find blockNumber by txnID=1235`