### PR TITLE
partial hash check for mock_sentry.go

### DIFF
--- a/p2p/sentry/sentry_multi_client/sentry_multi_client.go
+++ b/p2p/sentry/sentry_multi_client/sentry_multi_client.go
@@ -408,7 +408,7 @@ func (cs *MultiClient) newBlock66(ctx context.Context, inreq *proto_sentry.Inbou
 	if err := request.SanityCheck(); err != nil {
 		return fmt.Errorf("newBlock66: %w", err)
 	}
-	if err := request.Block.HashCheck(); err != nil {
+	if err := request.Block.HashCheck(true); err != nil {
 		return fmt.Errorf("newBlock66: %w", err)
 	}
 

--- a/polygon/sync/blocks_verifier.go
+++ b/polygon/sync/blocks_verifier.go
@@ -29,7 +29,7 @@ func VerifyBlocks(blocks []*types.Block) error {
 			return err
 		}
 
-		if err := block.HashCheck(); err != nil {
+		if err := block.HashCheck(true); err != nil {
 			return err
 		}
 

--- a/turbo/app/import_cmd.go
+++ b/turbo/app/import_cmd.go
@@ -264,7 +264,7 @@ func insertPosChain(ethereum *eth.Ethereum, chain *core.ChainPack, logger log.Lo
 	}
 
 	for i := posBlockStart; i < chain.Length(); i++ {
-		if err := chain.Blocks[i].HashCheck(); err != nil {
+		if err := chain.Blocks[i].HashCheck(true); err != nil {
 			return err
 		}
 	}

--- a/turbo/stages/mock/mock_sentry.go
+++ b/turbo/stages/mock/mock_sentry.go
@@ -687,7 +687,7 @@ func (ms *MockSentry) insertPoWBlocks(chain *core.ChainPack) error {
 		return nil
 	}
 	for i := 0; i < chain.Length(); i++ {
-		if err := chain.Blocks[i].HashCheck(); err != nil {
+		if err := chain.Blocks[i].HashCheck(false); err != nil {
 			return err
 		}
 	}
@@ -767,7 +767,7 @@ func (ms *MockSentry) insertPoSBlocks(chain *core.ChainPack) error {
 
 	ctx := context.Background()
 	for i := n; i < chain.Length(); i++ {
-		if err := chain.Blocks[i].HashCheck(); err != nil {
+		if err := chain.Blocks[i].HashCheck(false); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
> I encountered a problem in the way we run execution-spec-tests, and need more eyes on it:
some execution spec tests have a failure associated with a block. An example is: a 7702 tx with empty auth list should cause block rejection because such a tx is invalid.
now when the BlockTest#Run executes, it tries to "insertChain", after which mock_sentry does block.HashCheck() before calling the el to insert block.
one of the check in HashCheck() is that if receiptRoot is emptyRootHash and block has any tx, it rejects the block right there, even before sending it to el (lots if not all execution-spec-tests wherein block should be rejected have receiptRoot=emptyRootHash)
The execution-spec-test in the above scenario passes, since the block was "rejected". But this can (and does) lead to false positive test-success, as the block is never executed, so we don't actually check if the block is rejected "for correct reasons". So for example, recently Mario added a test to check "tx should not be nil in 7702 tx" in latest spec tests. This is not done by our code, but the test still passes because the rejection happens at block.HashCheck()


to counter these false positives, I add a `fullCheck` flag for `HashCheck` which bypasses the empty receipt check for mock_sentry. 
