### PR TITLE
Specify minor go version in go.mod

### DIFF
--- a/erigon-lib/go.mod
+++ b/erigon-lib/go.mod
@@ -1,6 +1,6 @@
 module github.com/erigontech/erigon-lib
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/erigontech/erigon-snapshot v1.3.1-0.20240814160410-2ce37904b978

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/erigontech/erigon
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/erigontech/erigonwatch v0.0.0-20240718131902-b6576bde1116


### PR DESCRIPTION
Otherwise I'm getting
```
go: download go1.22 for darwin/arm64: toolchain not available
```
on my mac.

See https://github.com/golang/go/issues/65568 & https://github.com/golang/go/issues/62278#issuecomment-1693538776