### PR TITLE
Improve ci-cd-main-branch-docker-images workflow

### DIFF
--- a/.github/workflows/ci-cd-main-branch-docker-images.yml
+++ b/.github/workflows/ci-cd-main-branch-docker-images.yml
@@ -33,6 +33,12 @@ jobs:
           ref: ${{ env.CHECKOUT_REF }}
           path: 'erigon'
 
+      - name: Setup go env and cache
+        uses: actions/setup-go@v5
+        with:
+          cache-dependency-path: |
+            erigon/go.sum
+
       - name: Get commit id
         id: getCommitId
         run: |
@@ -53,12 +59,37 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db ## v3.6.1
 
+      - name: Build arm64
+        run: |
+          docker run --platform linux/arm64 \
+          --rm -v $(pwd)/erigon:/erigon:ro \
+          -v $(pwd)/build-arm64:/erigon-build \
+          -v ${HOME}/.cache/go-build/arm64:/root/.cache/go-build \
+          -v ${HOME}/go/pkg/mod:/go/pkg/mod \
+          -w /erigon --entrypoint /bin/sh \
+          ${{ env.BUILDER_IMAGE }} \
+          -c "apk update; apk add make git gcc libstdc++ build-base linux-headers bash ca-certificates; make -d GOARCH=arm64 GOBIN=/erigon-build BUILD_TAGS=nosqlite,noboltdb,nosilkworm erigon integration rpcdaemon"
+
+      - name: Build amd64
+        run: |
+          docker run --platform linux/amd64 \
+          --rm -v $(pwd)/erigon:/erigon:ro \
+          -v $(pwd)/build-amd64:/erigon-build \
+          -v ${HOME}/.cache/go-build/amd64:/root/.cache/go-build \
+          -v ${HOME}/go/pkg/mod:/go/pkg/mod \
+          -w /erigon --entrypoint /bin/sh \
+          ${{ env.BUILDER_IMAGE }} \
+          -c "apk update; apk add make git gcc libstdc++ build-base linux-headers bash ca-certificates; make -d GOARCH=amd64 GOAMD64=v2 GOBIN=/erigon-build BUILD_TAGS=nosqlite,noboltdb,nosilkworm erigon integration rpcdaemon"
+
+
       - name: Build and push multi-platform docker image based on the commit id ${{ steps.getCommitId.outputs.short_commit_id }} in the main branch
         env:
           BUILD_VERSION: "main-${{ steps.getCommitId.outputs.short_commit_id }}"
           DOCKER_URL: ${{ env.DOCKERHUB_REPOSITORY }}
           DOCKERFILE_PATH: Dockerfile.release
         run: |
+          mv -v build-amd64 erigon/
+          mv -v build-arm64 erigon/
           cd erigon
           docker buildx build \
           --file ${{ env.DOCKERFILE_PATH }} \

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -60,35 +60,26 @@ ENTRYPOINT [ "/usr/local/bin/erigon" ]
 ### CI-CD : main branch docker image publishing for each new commit id
 FROM ${CI_CD_MAIN_BUILDER_IMAGE} AS ci-cd-main-branch-builder
 
-ARG TARGETOS \
-    TARGETARCH
+COPY /build-amd64 /build-amd64/
+COPY /build-arm64 /build-arm64/
 
-ENV GOOS=$TARGETOS \
-    GOARCH=$TARGETARCH
+RUN echo "DEBUG: content of build-amd64" && ls -l /build-amd64 && \
+    echo && \
+    echo "DEBUG: content of build-arm64" && ls -l /build-arm64
 
-COPY . /home/erigon
 
-WORKDIR /home/erigon
-
-RUN --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg \
-    apk update && \
-    apk add make git gcc libstdc++ build-base linux-headers bash ca-certificates && \
-    make BUILD_TAGS=nosqlite,noboltdb,nosilkworm erigon integration rpcdaemon && \
-    echo "DEBUG: list of binaries:" && \
-    ls -l build/bin/
-    
 FROM ${CI_CD_MAIN_TARGET_BASE_IMAGE} AS ci-cd-main-branch
 ARG USER=erigon \
     GROUP=erigon \
+    GOARCH \
     EXPOSED_PORTS
 
-RUN --mount=type=bind,from=ci-cd-main-branch-builder,source=/home/erigon,target=/tmp/erigon \
+RUN --mount=type=bind,from=ci-cd-main-branch-builder,source=/build-${GOARCH},target=/tmp/erigon \
     apk add --no-cache ca-certificates tzdata libstdc++ && \
     addgroup ${GROUP} && \
     adduser -D -h /home/${USER} -G ${GROUP} ${USER} && \
     install -d -o ${USER} -g ${GROUP} /home/${USER}/.local /home/${USER}/.local/share /home/${USER}/.local/share/erigon && \
-    install -o ${USER} -g ${GROUP} /tmp/erigon/build/bin/* /usr/local/bin/
+    install -o ${USER} -g ${GROUP} /tmp/erigon/* /usr/local/bin/
 
 VOLUME [ "/home/${USER}" ]
 WORKDIR /home/${USER}


### PR DESCRIPTION
- Add actions/setup-go and use its cache (faster repeated builds)
- Build "snapshot" images one-by-one and pass GOAMD64=v2 flag for AMD64 architecture
- Simplify final docker image build process (just install binaries).