### PR TITLE
qa-tests: add constrained-tip-tracking test

### DIFF
--- a/.github/workflows/qa-constrained-tip-tracking.yml
+++ b/.github/workflows/qa-constrained-tip-tracking.yml
@@ -7,7 +7,11 @@ on:
   pull_request:
     branches:
       - qa_tests_contrained_tip_tracking
-
+    types:
+      - opened
+      - synchronize
+      - ready_for_review
+      
 jobs:
   tip-tracking-test:
     runs-on: [self-hosted, Erigon3]

--- a/.github/workflows/qa-constrained-tip-tracking.yml
+++ b/.github/workflows/qa-constrained-tip-tracking.yml
@@ -11,9 +11,9 @@ on:
       - opened
       - synchronize
       - ready_for_review
-      
+
 jobs:
-  tip-tracking-test:
+  constrained-tip-tracking-test:
     runs-on: [self-hosted, Erigon3]
     timeout-minutes: 600
     env:

--- a/.github/workflows/qa-constrained-tip-tracking.yml
+++ b/.github/workflows/qa-constrained-tip-tracking.yml
@@ -1,0 +1,124 @@
+name: QA - Constrained Tip tracking
+
+on:
+  schedule:
+    - cron: '0 0 * * 1-6'  # Run every night at 00:00 AM UTC except Sunday
+  workflow_dispatch:     # Run manually
+  pull_request:
+    branches:
+      - qa_tests_contrained_tip_tracking
+
+jobs:
+  tip-tracking-test:
+    runs-on: [self-hosted, Erigon3]
+    timeout-minutes: 600
+    env:
+      ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version/datadir
+      ERIGON_TESTBED_DATA_DIR: /opt/erigon-testbed/datadir
+      ERIGON_QA_PATH: /home/qarunner/erigon-qa
+      TRACKING_TIME_SECONDS: 14400 # 4 hours
+      TOTAL_TIME_SECONDS: 28800 # 8 hours
+      CHAIN: mainnet
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+
+    - name: Clean Erigon Build Directory
+      run: |
+        make clean
+
+    - name: Build Erigon
+      run: |
+        make erigon
+      working-directory: ${{ github.workspace }}
+
+    - name: Pause the Erigon instance dedicated to db maintenance
+      run: |
+        python3 $ERIGON_QA_PATH/test_system/db-producer/pause_production.py || true
+
+    - name: Restore Erigon Testbed Data Directory
+      run: |
+        rsync -a --delete $ERIGON_REFERENCE_DATA_DIR/ $ERIGON_TESTBED_DATA_DIR/
+
+    - name: Run Erigon, wait sync and check ability to maintain sync
+      id: test_step
+      run: |
+        set +e # Disable exit on error
+        
+        # 1. Launch the testbed Erigon instance
+        # 2. Allow time for the Erigon to achieve synchronization
+        # 3. Begin timing the duration that Erigon maintains synchronization
+        prlimit --as=17179869184: python3 $ERIGON_QA_PATH/test_system/qa-tests/tip-tracking/run_and_check_tip_tracking.py \
+          ${{ github.workspace }}/build/bin $ERIGON_TESTBED_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN
+  
+        # Capture monitoring script exit status
+        test_exit_status=$?
+        
+        # Save the subsection reached status
+        echo "::set-output name=test_executed::true"
+    
+        # Clean up Erigon process if it's still running
+        if kill -0 $ERIGON_PID 2> /dev/null; then
+          echo "Terminating Erigon"
+          kill $ERIGON_PID
+          wait $ERIGON_PID
+        fi
+
+        # Check test runner script exit status
+        if [ $test_exit_status -eq 0 ]; then
+          echo "Tests completed successfully"
+          echo "TEST_RESULT=success" >> "$GITHUB_OUTPUT"
+        else
+          echo "Error detected during tests"
+          echo "TEST_RESULT=failure" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Save test results
+      if: steps.test_step.outputs.test_executed == 'true'
+      env:
+        TEST_RESULT: ${{ steps.test_step.outputs.TEST_RESULT }}
+      run: |
+        db_version=$(python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/prod_info.py $ERIGON_REFERENCE_DATA_DIR/../production.ini production erigon_repo_commit)
+        if [ -z "$db_version" ]; then
+          db_version="no-version"
+        fi
+        
+        python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py \
+          --repo erigon \
+          --commit $(git rev-parse HEAD) \
+          --branch ${{ github.ref_name }} \
+          --test_name constrained-tip-tracking \
+          --chain $CHAIN \
+          --runner ${{ runner.name }} \
+          --db_version $db_version \
+          --outcome $TEST_RESULT \
+          --result_file ${{ github.workspace }}/result-$CHAIN.json
+
+    - name: Upload test results
+      if: steps.test_step.outputs.test_executed == 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-results
+        path: |
+          ${{ github.workspace }}/result-${{ env.CHAIN }}.json
+          ${{ env.ERIGON_TESTBED_DATA_DIR }}/logs/erigon.log
+
+    - name: Delete Erigon Testbed Data Directory
+      if: always()
+      run: |
+        rm -rf $ERIGON_TESTBED_DATA_DIR
+
+    - name: Resume the Erigon instance dedicated to db maintenance
+      run: |
+        python3 $ERIGON_QA_PATH/test_system/db-producer/resume_production.py || true
+
+    - name: Action for Success
+      if: steps.test_step.outputs.TEST_RESULT == 'success'
+      run: echo "::notice::Tests completed successfully"
+
+    - name: Action for Not Success
+      if: steps.test_step.outputs.TEST_RESULT != 'success'
+      run: |
+        echo "::error::Error detected during tests"
+        exit 1


### PR DESCRIPTION
This PR introduces a version of the tip-tracking test that runs with limited resources. 
Currently only a RAM limit is set as per Erigon's readme.