### PR TITLE
Add support for build for linux/amd64 (v1) [binaries/docker]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
           --label org.opencontainers.image.description="${{ env.LABEL_DESCRIPTION }}" \
           --label org.opencontainers.image.base.name="${{ env.DOCKER_BASE_IMAGE }}" \
           --push \
-          --platform linux/amd64/v2,linux/arm64 .
+          --platform linux/amd64,linux/amd64/v2,linux/arm64 .
 
       - name: Upload artifact -- linux/arm64
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  ## v4.3.6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
             -e APPLICATION=${{ env.APPLICATION }} \
             -v $(pwd):/${{ env.APPLICATION}} \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            ${{ env.BUILDER_IMAGE }} release --clean --skip=validate,announce,publish
+            ${{ env.BUILDER_IMAGE }} release --timeout 60m0s --clean --skip=validate,announce,publish
           echo "DEBUG: ls -lao in the working directory"
           ls -lao
           echo "DEBUG: content of the dist/ directory"
@@ -153,6 +153,15 @@ jobs:
         with:
           name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_amd64.tar.gz
           path: ./dist/${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_amd64.tar.gz
+          retention-days: 1
+          compression-level: 0
+          if-no-files-found: error
+
+      - name: Upload artifact -- linux/amd64/v2
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  ## v4.3.6
+        with:
+          name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_amd64v2.tar.gz
+          path: ./dist/${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_amd64v2.tar.gz
           retention-days: 1
           compression-level: 0
           if-no-files-found: error

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -404,7 +404,7 @@ builds:
 ## End Darwin ARM64
 
 
-## Linux AMD64 (v1):
+## Linux AMD64 (v1, v2):
   - id: linux-amd64-erigon
     main: ./cmd/erigon
     binary: erigon
@@ -412,6 +412,7 @@ builds:
     goarch: [ amd64 ]
     goamd64:
       - v1
+      - v2
     env:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
@@ -432,6 +433,7 @@ builds:
     goarch: [ amd64 ]
     goamd64:
       - v1
+      - v2
     env:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
@@ -452,6 +454,7 @@ builds:
     goarch: [ amd64 ]
     goamd64:
       - v1
+      - v2
     env:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
@@ -472,6 +475,7 @@ builds:
     goarch: [ amd64 ]
     goamd64:
       - v1
+      - v2
     env:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
@@ -492,6 +496,7 @@ builds:
     goarch: [ amd64 ]
     goamd64:
       - v1
+      - v2
     env:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
@@ -512,6 +517,7 @@ builds:
     goarch: [ amd64 ]
     goamd64:
       - v1
+      - v2
     env:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
@@ -532,6 +538,7 @@ builds:
     goarch: [ amd64 ]
     goamd64:
       - v1
+      - v2
     env:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
@@ -552,6 +559,7 @@ builds:
     goarch: [ amd64 ]
     goamd64:
       - v1
+      - v2
     env:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
@@ -572,6 +580,7 @@ builds:
     goarch: [ amd64 ]
     goamd64:
       - v1
+      - v2
     env:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
@@ -592,28 +601,6 @@ builds:
     goarch: [ amd64 ]
     goamd64:
       - v1
-    env:
-      - CC=x86_64-linux-gnu-gcc
-      - CXX=x86_64-linux-gnu-g++
-      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
-      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm ]
-    flags:
-      - -trimpath
-      - -buildvcs=false
-    ldflags:
-      - -s -w -extldflags "-static"
-      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
-## End of Linux AMD64
-
-
-## Linux AMD64-v2:
-  - id: linux-amd64-v2-erigon
-    main: ./cmd/erigon
-    binary: erigon
-    goos: [ linux ]
-    goarch: [ amd64 ]
-    goamd64:
       - v2
     env:
       - CC=x86_64-linux-gnu-gcc
@@ -627,189 +614,7 @@ builds:
     ldflags:
       - -s -w -extldflags "-static"
       - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
-
-  - id: linux-amd64-v2-downloader
-    main: ./cmd/downloader
-    binary: downloader
-    goos: [ linux ]
-    goarch: [ amd64 ]
-    goamd64:
-      - v2
-    env:
-      - CC=x86_64-linux-gnu-gcc
-      - CXX=x86_64-linux-gnu-g++
-      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
-      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm ]
-    flags:
-      - -trimpath
-      - -buildvcs=false
-    ldflags:
-      - -s -w -extldflags "-static"
-      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
-
-  - id: linux-amd64-v2-devnet
-    main: ./cmd/devnet
-    binary: devnet
-    goos: [ linux ]
-    goarch: [ amd64 ]
-    goamd64:
-      - v2
-    env:
-      - CC=x86_64-linux-gnu-gcc
-      - CXX=x86_64-linux-gnu-g++
-      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
-      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm ]
-    flags:
-      - -trimpath
-      - -buildvcs=false
-    ldflags:
-      - -s -w -extldflags "-static"
-      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
-
-  - id: linux-amd64-v2-evm
-    main: ./cmd/evm
-    binary: evm
-    goos: [ linux ]
-    goarch: [ amd64 ]
-    goamd64:
-      - v2
-    env:
-      - CC=x86_64-linux-gnu-gcc
-      - CXX=x86_64-linux-gnu-g++
-      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
-      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm ]
-    flags:
-      - -trimpath
-      - -buildvcs=false
-    ldflags:
-      - -s -w -extldflags "-static"
-      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
-
-  - id: linux-amd64-v2-caplin
-    main: ./cmd/caplin
-    binary: caplin
-    goos: [ linux ]
-    goarch: [ amd64 ]
-    goamd64:
-      - v2
-    env:
-      - CC=x86_64-linux-gnu-gcc
-      - CXX=x86_64-linux-gnu-g++
-      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
-      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm ]
-    flags:
-      - -trimpath
-      - -buildvcs=false
-    ldflags:
-      - -s -w -extldflags "-static"
-      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
-
-  - id: linux-amd64-v2-diag
-    main: ./cmd/diag
-    binary: diag
-    goos: [ linux ]
-    goarch: [ amd64 ]
-    goamd64:
-      - v2
-    env:
-      - CC=x86_64-linux-gnu-gcc
-      - CXX=x86_64-linux-gnu-g++
-      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
-      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm ]
-    flags:
-      - -trimpath
-      - -buildvcs=false
-    ldflags:
-      - -s -w -extldflags "-static"
-      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
-
-  - id: linux-amd64-v2-integration
-    main: ./cmd/integration
-    binary: integration
-    goos: [ linux ]
-    goarch: [ amd64 ]
-    goamd64:
-      - v2
-    env:
-      - CC=x86_64-linux-gnu-gcc
-      - CXX=x86_64-linux-gnu-g++
-      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
-      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm ]
-    flags:
-      - -trimpath
-      - -buildvcs=false
-    ldflags:
-      - -s -w -extldflags "-static"
-      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
-
-  - id: linux-amd64-v2-rpcdaemon
-    main: ./cmd/rpcdaemon
-    binary: rpcdaemon
-    goos: [ linux ]
-    goarch: [ amd64 ]
-    goamd64:
-      - v2
-    env:
-      - CC=x86_64-linux-gnu-gcc
-      - CXX=x86_64-linux-gnu-g++
-      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
-      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm ]
-    flags:
-      - -trimpath
-      - -buildvcs=false
-    ldflags:
-      - -s -w -extldflags "-static"
-      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
-
-  - id: linux-amd64-v2-sentry
-    main: ./cmd/sentry
-    binary: sentry
-    goos: [ linux ]
-    goarch: [ amd64 ]
-    goamd64:
-      - v2
-    env:
-      - CC=x86_64-linux-gnu-gcc
-      - CXX=x86_64-linux-gnu-g++
-      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
-      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm ]
-    flags:
-      - -trimpath
-      - -buildvcs=false
-    ldflags:
-      - -s -w -extldflags "-static"
-      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
-
-  - id: linux-amd64-v2-txpool
-    main: ./cmd/txpool
-    binary: txpool
-    goos: [ linux ]
-    goarch: [ amd64 ]
-    goamd64:
-      - v2
-    env:
-      - CC=x86_64-linux-gnu-gcc
-      - CXX=x86_64-linux-gnu-g++
-      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
-      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm ]
-    flags:
-      - -trimpath
-      - -buildvcs=false
-    ldflags:
-      - -s -w -extldflags "-static"
-      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
-## End of Linux AMD64v2
-
-
+## End of Linux AMD64 (v1, v2)
 
 
 ## Linux ARM64
@@ -1226,7 +1031,6 @@ checksum:
   ids:
     - linux-arm64
     - linux-amd64
-    - linux-amd64-v2
     - darwin-amd64
     - darwin-arm64
     # - windows-amd64
@@ -1261,7 +1065,7 @@ archives:
       - linux-amd64-rpcdaemon
       - linux-amd64-sentry
       - linux-amd64-txpool
-    name_template: "{{ .Env.APPLICATION }}_{{ .Env.BUILD_VERSION }}_{{ .Os }}_{{ .Arch }}"
+    name_template: `{{ .Env.APPLICATION }}_{{ .Env.BUILD_VERSION }}_{{ .Os }}_{{ .Arch }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}`
     wrap_in_directory: true
     format: tar.gz
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1065,7 +1065,7 @@ archives:
       - linux-amd64-rpcdaemon
       - linux-amd64-sentry
       - linux-amd64-txpool
-    name_template: {{ .Env.APPLICATION }}_{{ .Env.BUILD_VERSION }}_{{ .Os }}_{{ .Arch }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
+    name_template: '{{ .Env.APPLICATION }}_{{ .Env.BUILD_VERSION }}_{{ .Os }}_{{ .Arch }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
     wrap_in_directory: true
     format: tar.gz
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1065,7 +1065,7 @@ archives:
       - linux-amd64-rpcdaemon
       - linux-amd64-sentry
       - linux-amd64-txpool
-    name_template: `{{ .Env.APPLICATION }}_{{ .Env.BUILD_VERSION }}_{{ .Os }}_{{ .Arch }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}`
+    name_template: {{ .Env.APPLICATION }}_{{ .Env.BUILD_VERSION }}_{{ .Os }}_{{ .Arch }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
     wrap_in_directory: true
     format: tar.gz
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -404,14 +404,14 @@ builds:
 ## End Darwin ARM64
 
 
-## Linux AMD64:
+## Linux AMD64 (v1):
   - id: linux-amd64-erigon
     main: ./cmd/erigon
     binary: erigon
     goos: [ linux ]
     goarch: [ amd64 ]
     goamd64:
-      - v2
+      - v1
     env:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
@@ -431,7 +431,7 @@ builds:
     goos: [ linux ]
     goarch: [ amd64 ]
     goamd64:
-      - v2
+      - v1
     env:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
@@ -451,7 +451,7 @@ builds:
     goos: [ linux ]
     goarch: [ amd64 ]
     goamd64:
-      - v2
+      - v1
     env:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
@@ -471,7 +471,7 @@ builds:
     goos: [ linux ]
     goarch: [ amd64 ]
     goamd64:
-      - v2
+      - v1
     env:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
@@ -491,7 +491,7 @@ builds:
     goos: [ linux ]
     goarch: [ amd64 ]
     goamd64:
-      - v2
+      - v1
     env:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
@@ -511,7 +511,7 @@ builds:
     goos: [ linux ]
     goarch: [ amd64 ]
     goamd64:
-      - v2
+      - v1
     env:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
@@ -531,7 +531,7 @@ builds:
     goos: [ linux ]
     goarch: [ amd64 ]
     goamd64:
-      - v2
+      - v1
     env:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
@@ -551,7 +551,7 @@ builds:
     goos: [ linux ]
     goarch: [ amd64 ]
     goamd64:
-      - v2
+      - v1
     env:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
@@ -571,7 +571,7 @@ builds:
     goos: [ linux ]
     goarch: [ amd64 ]
     goamd64:
-      - v2
+      - v1
     env:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
@@ -591,7 +591,7 @@ builds:
     goos: [ linux ]
     goarch: [ amd64 ]
     goamd64:
-      - v2
+      - v1
     env:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
@@ -605,6 +605,211 @@ builds:
       - -s -w -extldflags "-static"
       - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
 ## End of Linux AMD64
+
+
+## Linux AMD64-v2:
+  - id: linux-amd64-v2-erigon
+    main: ./cmd/erigon
+    binary: erigon
+    goos: [ linux ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2
+    env:
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: linux-amd64-v2-downloader
+    main: ./cmd/downloader
+    binary: downloader
+    goos: [ linux ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2
+    env:
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: linux-amd64-v2-devnet
+    main: ./cmd/devnet
+    binary: devnet
+    goos: [ linux ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2
+    env:
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: linux-amd64-v2-evm
+    main: ./cmd/evm
+    binary: evm
+    goos: [ linux ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2
+    env:
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: linux-amd64-v2-caplin
+    main: ./cmd/caplin
+    binary: caplin
+    goos: [ linux ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2
+    env:
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: linux-amd64-v2-diag
+    main: ./cmd/diag
+    binary: diag
+    goos: [ linux ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2
+    env:
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: linux-amd64-v2-integration
+    main: ./cmd/integration
+    binary: integration
+    goos: [ linux ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2
+    env:
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: linux-amd64-v2-rpcdaemon
+    main: ./cmd/rpcdaemon
+    binary: rpcdaemon
+    goos: [ linux ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2
+    env:
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: linux-amd64-v2-sentry
+    main: ./cmd/sentry
+    binary: sentry
+    goos: [ linux ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2
+    env:
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+
+  - id: linux-amd64-v2-txpool
+    main: ./cmd/txpool
+    binary: txpool
+    goos: [ linux ]
+    goarch: [ amd64 ]
+    goamd64:
+      - v2
+    env:
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
+      - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
+    tags: [ nosqlite, noboltdb, nosilkworm ]
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -extldflags "-static"
+      - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
+## End of Linux AMD64v2
+
+
 
 
 ## Linux ARM64
@@ -1021,6 +1226,7 @@ checksum:
   ids:
     - linux-arm64
     - linux-amd64
+    - linux-amd64-v2
     - darwin-amd64
     - darwin-arm64
     # - windows-amd64
@@ -1056,6 +1262,22 @@ archives:
       - linux-amd64-sentry
       - linux-amd64-txpool
     name_template: "{{ .Env.APPLICATION }}_{{ .Env.BUILD_VERSION }}_{{ .Os }}_{{ .Arch }}"
+    wrap_in_directory: true
+    format: tar.gz
+
+  - id: linux-amd64-v2
+    builds:
+      - linux-amd64-v2-erigon
+      - linux-amd64-v2-downloader
+      - linux-amd64-v2-devnet
+      - linux-amd64-v2-evm
+      - linux-amd64-v2-caplin
+      - linux-amd64-v2-diag
+      - linux-amd64-v2-integration
+      - linux-amd64-v2-rpcdaemon
+      - linux-amd64-v2-sentry
+      - linux-amd64-v2-txpool
+    name_template: "{{ .Env.APPLICATION }}_{{ .Env.BUILD_VERSION }}_{{ .Os }}_{{ .Arch }}v2"
     wrap_in_directory: true
     format: tar.gz
 

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -18,10 +18,11 @@ ARG RELEASE_DOCKER_BASE_IMAGE="alpine:3.20.1" \
 ### Release Dockerfile
 FROM ${RELEASE_DOCKER_BASE_IMAGE} AS temporary
 ARG TARGETARCH \
+    TARGETVARIANT="" \
     VERSION=${VERSION} \
     APPLICATION
 
-COPY ./dist/${APPLICATION}_${VERSION}_linux_${TARGETARCH}.tar.gz /tmp/${APPLICATION}.tar.gz
+COPY ./dist/${APPLICATION}_${VERSION}_linux_${TARGETARCH}${TARGETVARIANT}.tar.gz /tmp/${APPLICATION}.tar.gz
 RUN tar xzvf /tmp/${APPLICATION}.tar.gz -C /tmp && \
     mv /tmp/${APPLICATION}_${VERSION}_linux_${TARGETARCH} /tmp/${APPLICATION}
 


### PR DESCRIPTION
Changes:
- compile new binaries for AMD64 microarchitecture level 1 (linux/amd64)
- explicitly use v2 suffix in binaries and docker images build for AMD64 microarchitecture level 2

After that change there will be multi-platform docker image with 3 OS/Arch:
- linux/arm64
- linux/amd64
- linux/amd64/v2

as well as a new release artifact.