### PR TITLE
Drop go 1.21 in release/2.60 - cherry pick PR 11966, 11897

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
       - name: Install dependencies on Linux
         if: runner.os == 'Linux'
         run: sudo apt update && sudo apt install build-essential
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,30 +119,4 @@ jobs:
       - name: Test erigon-lib
         run: cd erigon-lib && make test-no-fuzz
 
-  docker-build-check:
-    # don't run this on devel - the PR must have run it to be merged and it misleads that this pushes the docker image
-    if: (${{ github.event_name == 'push' || !github.event.pull_request.draft }}) && ${{ github.ref != 'refs/heads/devel' }}
-    runs-on: ubuntu-22.04
 
-    steps:
-      - uses: AutoModality/action-clean@v1
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0 # fetch git tags for "git describe"
-
-      - name: make docker (see dockerhub for image builds)
-        run: DOCKER_TAG=thorax/erigon:ci-$GITHUB_SHA DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) make docker
-
-      # check with root permissions, should be cached from previous build
-      - name: sudo make docker
-        run: sudo DOCKER_TAG=thorax/erigon:ci-$GITHUB_SHA DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) make docker
-
-#  automated-tests:
-#    runs-on:
-#      ubuntu-22.04
-#    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
-#    steps:
-#      - uses: actions/checkout@v3
-#
-#      - name: run automated testing
-#        run: BUILD_ERIGON=1 ./tests/automated-testing/run.sh

--- a/.github/workflows/test-integration-caplin.yml
+++ b/.github/workflows/test-integration-caplin.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
       - name: Install dependencies on Linux
         if: runner.os == 'Linux'
         run: sudo apt update && sudo apt install build-essential
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -24,7 +24,7 @@ jobs:
       - run: git submodule update --init --recursive --force
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
       - name: Install dependencies on Linux
         if: runner.os == 'Linux'
         run: sudo apt update && sudo apt install build-essential
@@ -51,7 +51,7 @@ jobs:
       - run: git submodule update --init --recursive --force
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
 
       - uses: actions/cache@v3
         with:

--- a/erigon-lib/go.mod
+++ b/erigon-lib/go.mod
@@ -1,6 +1,6 @@
 module github.com/ledgerwatch/erigon-lib
 
-go 1.21
+go 1.22.0
 
 require (
 	github.com/erigontech/mdbx-go v0.27.24

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ledgerwatch/erigon
 
-go 1.21
+go 1.22.0
 
 require (
 	github.com/erigontech/mdbx-go v0.27.24


### PR DESCRIPTION
I am not sure about https://github.com/erigontech/erigon/pull/11897/files#diff-032140708bca135b7bd11337e3debb2651170c556efaa3c931896debca32eaf9L171

Please, check it and let me know if this commit should be also back-ported to release/2.60.
