### PR TITLE
fix: err msg for eth_callMany

### DIFF
--- a/turbo/jsonrpc/eth_callMany.go
+++ b/turbo/jsonrpc/eth_callMany.go
@@ -292,7 +292,11 @@ func (api *APIImpl) CallMany(ctx context.Context, bundles []Bundle, simulateCont
 			jsonResult := make(map[string]interface{})
 			if result.Err != nil {
 				if len(result.Revert()) > 0 {
-					jsonResult["error"] = ethapi.NewRevertError(result)
+					revertErr := ethapi.NewRevertError(result)
+					jsonResult["error"] = map[string]interface{}{
+						"message": revertErr.Error(),
+						"data":    revertErr.ErrorData(),
+					}
 				} else {
 					jsonResult["error"] = result.Err.Error()
 				}


### PR DESCRIPTION
if revert happend in eth_callMany, the error will be included in the normal result rather than error result, and the revert info will be ignored when response marshaling.

current response: 
`{
   ......
    "error": {}
   ......
}`

expected response:
`{
   ......
    "error": {
        "message": "execution reverted: ......",
        "data": "0x......"
    }
   ......
}`