### PR TITLE
fix(turbo/execution): skip if header number is nil

### DIFF
--- a/turbo/execution/eth1/getters.go
+++ b/turbo/execution/eth1/getters.go
@@ -151,6 +151,10 @@ func (e *EthereumExecutionModule) GetBodiesByHashes(ctx context.Context, req *ex
 		if err != nil {
 			return nil, fmt.Errorf("ethereumExecutionModule.GetBodiesByHashes: HeaderNumber error %w", err)
 		}
+		if number == nil {
+			bodies = append(bodies, nil)
+			continue
+		}
 		body, err := e.getBody(ctx, tx, h, *number)
 		if err != nil {
 			return nil, fmt.Errorf("ethereumExecutionModule.GetBodiesByHashes: getBody error %w", err)


### PR DESCRIPTION
I'm running with erigon e3 in holesky chain, and found somd panic message in erigon's log:


```bash
[EROR] [09-18|23:57:23.899] RPC method engine_getPayloadBodiesByHashV1 crashed: runtime error: invalid memory address or nil pointer dereference
[service.go:223 panic.go:770 panic.go:261 signal_unix.go:881 getters.go:154 execution_client.go:41 chain_reader.go:220 engine_server.go:599 engine_server.go:766 value.go:596 value.go:380 service.go:228 handler.go:534 handler.go:484 handler.go:425 handler.go:245 handler.go:338 asm_amd64.s:1695]
```

The panic was raised in this line https://github.com/erigontech/erigon/blob/1dd4a55ddf08f02d6484e66a767ce5ecddfb3a5e/turbo/execution/eth1/getters.go#L150-L154


After some digging, found `HeaderByNumber` maybe return `nil, nil`, so I think we need to handle the `nil` number case

https://github.com/erigontech/erigon/blob/f0acc51c44bcbcc6849026b049214cc389361b85/turbo/snapshotsync/freezeblocks/block_reader.go#L265-L274

https://github.com/erigontech/erigon/blob/f0acc51c44bcbcc6849026b049214cc389361b85/turbo/snapshotsync/freezeblocks/block_reader.go#L478-L490

