### PR TITLE
Update release workflow for release/2.60

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,9 @@ on:
 jobs:
 
   build-release:
-    runs-on: ubuntu-22.04
-    ## runs-on: ubuntu-latest-devops-xxlarge
-    timeout-minutes: 120
+    ## runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest-devops-xxlarge
+    timeout-minutes: 60
     name: Build Artifacts and multi-platform Docker image, publish draft of the Release Notes
 
     steps:
@@ -104,7 +104,7 @@ jobs:
             -e APPLICATION=${{ env.APPLICATION }} \
             -v $(pwd):/${{ env.APPLICATION}} \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            ${{ env.BUILDER_IMAGE }} release --clean --skip=validate,announce,publish
+            ${{ env.BUILDER_IMAGE }} release --timeout 60m0s --clean --skip=validate,announce,publish
           echo "DEBUG: ls -lao in the working directory"
           ls -lao
           echo "DEBUG: content of the dist/ directory"
@@ -119,10 +119,11 @@ jobs:
         run: |
           docker buildx build \
           --file ${{ env.DOCKERFILE_PATH }} \
-          --build-arg DOCKER_BASE_IMAGE=${{ env.DOCKER_BASE_IMAGE }} \
+          --build-arg RELEASE_DOCKER_BASE_IMAGE=${{ env.DOCKER_BASE_IMAGE }} \
           --build-arg VERSION=${{ env.BUILD_VERSION }} \
           --build-arg APPLICATION=${{ env.APPLICATION }} \
           --tag ${{ env.DOCKER_URL }}:${{ env.BUILD_VERSION }} \
+          --target release \
           ${{ env.DOCKER_PUBLISH_LATEST_CONDITION }} \
           --label org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
           --label org.opencontainers.image.authors="https://github.com/erigontech/erigon/graphs/contributors" \
@@ -136,7 +137,7 @@ jobs:
           --label org.opencontainers.image.description="${{ env.LABEL_DESCRIPTION }}" \
           --label org.opencontainers.image.base.name="${{ env.DOCKER_BASE_IMAGE }}" \
           --push \
-          --platform linux/amd64/v2,linux/arm64 .
+          --platform linux/amd64,linux/amd64/v2,linux/arm64 .
 
       - name: Upload artifact -- linux/arm64
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  ## v4.3.6
@@ -152,6 +153,15 @@ jobs:
         with:
           name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_amd64.tar.gz
           path: ./dist/${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_amd64.tar.gz
+          retention-days: 1
+          compression-level: 0
+          if-no-files-found: error
+
+      - name: Upload artifact -- linux/amd64/v2
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  ## v4.3.6
+        with:
+          name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_amd64v2.tar.gz
+          path: ./dist/${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_amd64v2.tar.gz
           retention-days: 1
           compression-level: 0
           if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,8 @@ jobs:
           --build-arg APPLICATION=${{ env.APPLICATION }} \
           --tag ${{ env.DOCKER_URL }}:${{ env.BUILD_VERSION }} \
           --target release \
+          --attest type=provenance,mode=max \
+          --sbom=true \
           ${{ env.DOCKER_PUBLISH_LATEST_CONDITION }} \
           --label org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
           --label org.opencontainers.image.authors="https://github.com/erigontech/erigon/graphs/contributors" \
@@ -193,15 +195,6 @@ jobs:
           compression-level: 0
           if-no-files-found: error
 
-      - name: Upload artifact -- checksum
-        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  ## v4.3.6
-        with:
-          name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_checksums.txt
-          path: ./dist/${{ env.APPLICATION }}_${{ inputs.release_version }}_checksums.txt
-          retention-days: 1
-          compression-level: 0
-          if-no-files-found: error
-
 ## not required for now -- commented:
 #      - name: Create and push a git tag for the released version in case perform_release is set
 #        if: ${{ inputs.perform_release }}
@@ -220,7 +213,8 @@ jobs:
           GITHUB_RELEASE_TARGET: ${{ inputs.checkout_ref }}
         run: |
           cd dist
-          gh release create ${{ inputs.release_version }} *.tar.gz *_checksums.txt \
+          sha256sum *.tar.gz > ${HOME}/${{ env.APPLICATION }}_${{ inputs.release_version }}_checksums.txt
+          gh release create ${{ inputs.release_version }} *.tar.gz ${HOME}/${{ env.APPLICATION }}_${{ inputs.release_version }}_checksums.txt \
             --generate-notes \
             --target ${GITHUB_RELEASE_TARGET} \
             --draft=true \

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1034,7 +1034,9 @@ checksum:
     - darwin-amd64
     - darwin-arm64
     # - windows-amd64
-
+  ## dynamic archive for amd64/v2 case:
+  extra_files:
+    - glob: {{ .Env.APPLICATION }}_{{ .Env.BUILD_VERSION }}**v2.tar.gz
 
 archives:
   - id: linux-arm64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1069,22 +1069,6 @@ archives:
     wrap_in_directory: true
     format: tar.gz
 
-  - id: linux-amd64-v2
-    builds:
-      - linux-amd64-v2-erigon
-      - linux-amd64-v2-downloader
-      - linux-amd64-v2-devnet
-      - linux-amd64-v2-evm
-      - linux-amd64-v2-caplin
-      - linux-amd64-v2-diag
-      - linux-amd64-v2-integration
-      - linux-amd64-v2-rpcdaemon
-      - linux-amd64-v2-sentry
-      - linux-amd64-v2-txpool
-    name_template: "{{ .Env.APPLICATION }}_{{ .Env.BUILD_VERSION }}_{{ .Os }}_{{ .Arch }}v2"
-    wrap_in_directory: true
-    format: tar.gz
-
   - id: darwin-amd64
     builds:
       - darwin-amd64-erigon

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1024,20 +1024,6 @@ builds:
 ## Windows AMD64
 
 
-## Checksums
-checksum:
-  name_template: "{{ .Env.APPLICATION }}_{{ .Env.BUILD_VERSION }}_checksums.txt"
-  algorithm: sha256
-  ids:
-    - linux-arm64
-    - linux-amd64
-    - darwin-amd64
-    - darwin-arm64
-    # - windows-amd64
-  ## dynamic archive for amd64/v2 case:
-  extra_files:
-    - glob: {{ .Env.APPLICATION }}_{{ .Env.BUILD_VERSION }}**v2.tar.gz
-
 archives:
   - id: linux-arm64
     builds:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,3 @@
-
 #version: 2
 
 project_name: erigon
@@ -405,13 +404,14 @@ builds:
 ## End Darwin ARM64
 
 
-## Linux AMD64:
+## Linux AMD64 (v1, v2):
   - id: linux-amd64-erigon
     main: ./cmd/erigon
     binary: erigon
     goos: [ linux ]
     goarch: [ amd64 ]
     goamd64:
+      - v1
       - v2
     env:
       - CC=x86_64-linux-gnu-gcc
@@ -432,6 +432,7 @@ builds:
     goos: [ linux ]
     goarch: [ amd64 ]
     goamd64:
+      - v1
       - v2
     env:
       - CC=x86_64-linux-gnu-gcc
@@ -452,6 +453,7 @@ builds:
     goos: [ linux ]
     goarch: [ amd64 ]
     goamd64:
+      - v1
       - v2
     env:
       - CC=x86_64-linux-gnu-gcc
@@ -472,6 +474,7 @@ builds:
     goos: [ linux ]
     goarch: [ amd64 ]
     goamd64:
+      - v1
       - v2
     env:
       - CC=x86_64-linux-gnu-gcc
@@ -492,6 +495,7 @@ builds:
     goos: [ linux ]
     goarch: [ amd64 ]
     goamd64:
+      - v1
       - v2
     env:
       - CC=x86_64-linux-gnu-gcc
@@ -512,6 +516,7 @@ builds:
     goos: [ linux ]
     goarch: [ amd64 ]
     goamd64:
+      - v1
       - v2
     env:
       - CC=x86_64-linux-gnu-gcc
@@ -532,6 +537,7 @@ builds:
     goos: [ linux ]
     goarch: [ amd64 ]
     goamd64:
+      - v1
       - v2
     env:
       - CC=x86_64-linux-gnu-gcc
@@ -552,6 +558,7 @@ builds:
     goos: [ linux ]
     goarch: [ amd64 ]
     goamd64:
+      - v1
       - v2
     env:
       - CC=x86_64-linux-gnu-gcc
@@ -572,6 +579,7 @@ builds:
     goos: [ linux ]
     goarch: [ amd64 ]
     goamd64:
+      - v1
       - v2
     env:
       - CC=x86_64-linux-gnu-gcc
@@ -592,6 +600,7 @@ builds:
     goos: [ linux ]
     goarch: [ amd64 ]
     goamd64:
+      - v1
       - v2
     env:
       - CC=x86_64-linux-gnu-gcc
@@ -605,7 +614,7 @@ builds:
     ldflags:
       - -s -w -extldflags "-static"
       - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
-## End of Linux AMD64
+## End of Linux AMD64 (v1, v2)
 
 
 ## Linux ARM64
@@ -1056,7 +1065,23 @@ archives:
       - linux-amd64-rpcdaemon
       - linux-amd64-sentry
       - linux-amd64-txpool
-    name_template: "{{ .Env.APPLICATION }}_{{ .Env.BUILD_VERSION }}_{{ .Os }}_{{ .Arch }}"
+    name_template: '{{ .Env.APPLICATION }}_{{ .Env.BUILD_VERSION }}_{{ .Os }}_{{ .Arch }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
+    wrap_in_directory: true
+    format: tar.gz
+
+  - id: linux-amd64-v2
+    builds:
+      - linux-amd64-v2-erigon
+      - linux-amd64-v2-downloader
+      - linux-amd64-v2-devnet
+      - linux-amd64-v2-evm
+      - linux-amd64-v2-caplin
+      - linux-amd64-v2-diag
+      - linux-amd64-v2-integration
+      - linux-amd64-v2-rpcdaemon
+      - linux-amd64-v2-sentry
+      - linux-amd64-v2-txpool
+    name_template: "{{ .Env.APPLICATION }}_{{ .Env.BUILD_VERSION }}_{{ .Os }}_{{ .Arch }}v2"
     wrap_in_directory: true
     format: tar.gz
 

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,22 +1,37 @@
-ARG DOCKER_BASE_IMAGE="alpine:3.20.1"
+ARG RELEASE_DOCKER_BASE_IMAGE="alpine:3.20.1" \
+    CI_CD_MAIN_BUILDER_IMAGE="golang:1.22-bookworm" \
+    CI_CD_MAIN_TARGET_BASE_IMAGE="alpine:3.20.1" \
+    EXPOSED_PORTS="8545 \
+       8551 \
+       8546 \
+       30303 \
+       30303/udp \
+       42069 \
+       42069/udp \
+       8080 \
+       9090 \
+       6060"
 
 ## Note TARGETARCH is a crucial variable:
 ##   see https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope
 
-FROM ${DOCKER_BASE_IMAGE} AS temporary
+### Release Dockerfile
+FROM ${RELEASE_DOCKER_BASE_IMAGE} AS temporary
 ARG TARGETARCH \
+    TARGETVARIANT \
     VERSION=${VERSION} \
     APPLICATION
 
-COPY ./dist/${APPLICATION}_${VERSION}_linux_${TARGETARCH}.tar.gz /tmp/${APPLICATION}.tar.gz
+COPY ./dist/${APPLICATION}_${VERSION}_linux_${TARGETARCH}${TARGETVARIANT}.tar.gz /tmp/${APPLICATION}.tar.gz
 RUN tar xzvf /tmp/${APPLICATION}.tar.gz -C /tmp && \
-    mv /tmp/${APPLICATION}_${VERSION}_linux_${TARGETARCH} /tmp/${APPLICATION}
+    mv /tmp/${APPLICATION}_${VERSION}_linux_${TARGETARCH}${TARGETVARIANT} /tmp/${APPLICATION}
 
-FROM ${DOCKER_BASE_IMAGE}
+FROM ${RELEASE_DOCKER_BASE_IMAGE} AS release
 
 ARG USER=erigon \
     GROUP=erigon \
-    APPLICATION
+    APPLICATION \
+    EXPOSED_PORTS
 
 RUN --mount=type=bind,from=temporary,source=/tmp/${APPLICATION},target=/tmp/${APPLICATION} \
     apk add --no-cache ca-certificates tzdata && \
@@ -36,15 +51,43 @@ WORKDIR /home/${USER}
 
 USER ${USER}
 
-EXPOSE 8545 \
-       8551 \
-       8546 \
-       30303 \
-       30303/udp \
-       42069 \
-       42069/udp \
-       8080 \
-       9090 \
-       6060
+EXPOSE ${EXPOSED_PORTS}
 
 ENTRYPOINT [ "/usr/local/bin/erigon" ]
+
+### End of Release Dockerfile
+
+
+### CI-CD : main branch docker image publishing for each new commit id
+FROM ${CI_CD_MAIN_BUILDER_IMAGE} AS ci-cd-main-branch-builder
+
+COPY /build-amd64 /build-amd64/
+COPY /build-arm64 /build-arm64/
+
+RUN echo "DEBUG: content of build-amd64" && ls -l /build-amd64 && \
+    echo && \
+    echo "DEBUG: content of build-arm64" && ls -l /build-arm64
+
+
+FROM ${CI_CD_MAIN_TARGET_BASE_IMAGE} AS ci-cd-main-branch
+ARG USER=erigon \
+    GROUP=erigon \
+    TARGETARCH \
+    EXPOSED_PORTS
+
+RUN --mount=type=bind,from=ci-cd-main-branch-builder,source=/build-${TARGETARCH},target=/tmp/erigon \
+    apk add --no-cache ca-certificates tzdata libstdc++ && \
+    addgroup ${GROUP} && \
+    adduser -D -h /home/${USER} -G ${GROUP} ${USER} && \
+    install -d -o ${USER} -g ${GROUP} /home/${USER}/.local /home/${USER}/.local/share /home/${USER}/.local/share/erigon && \
+    install -o ${USER} -g ${GROUP} /tmp/erigon/* /usr/local/bin/
+
+VOLUME [ "/home/${USER}" ]
+WORKDIR /home/${USER}
+
+USER ${USER}
+EXPOSE ${EXPOSED_PORTS}
+
+ENTRYPOINT [ "/usr/local/bin/erigon" ]
+
+### End of CI-CD : main branch docker image publishing for each new commit id


### PR DESCRIPTION
Changes:
- new binaries for linux/amd64 (v1)
- new docker image for linux/amd64 (v1)
- improve dockerhub health score
- remove checksum step from goreleaser and move it to workflow (due to dynamic archive for two amd64 cases)
- use bigger runner
- add Dockerfile stages for ci-cd routine builds (not required atm for release/2.60).