### PR TITLE
Improve release workflow in main branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
   build-release:
     ## runs-on: ubuntu-22.04
     runs-on: ubuntu-latest-devops-xxlarge
-    timeout-minutes: 30
+    timeout-minutes: 60
     name: Build Artifacts and multi-platform Docker image, publish draft of the Release Notes
 
     steps:
@@ -124,6 +124,8 @@ jobs:
           --build-arg APPLICATION=${{ env.APPLICATION }} \
           --tag ${{ env.DOCKER_URL }}:${{ env.BUILD_VERSION }} \
           --target release \
+          --attest type=provenance,mode=max \
+          --sbom=true \
           ${{ env.DOCKER_PUBLISH_LATEST_CONDITION }} \
           --label org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
           --label org.opencontainers.image.authors="https://github.com/erigontech/erigon/graphs/contributors" \
@@ -193,15 +195,6 @@ jobs:
           compression-level: 0
           if-no-files-found: error
 
-      - name: Upload artifact -- checksum
-        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  ## v4.3.6
-        with:
-          name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_checksums.txt
-          path: ./dist/${{ env.APPLICATION }}_${{ inputs.release_version }}_checksums.txt
-          retention-days: 1
-          compression-level: 0
-          if-no-files-found: error
-
 ## not required for now -- commented:
 #      - name: Create and push a git tag for the released version in case perform_release is set
 #        if: ${{ inputs.perform_release }}
@@ -220,10 +213,10 @@ jobs:
           GITHUB_RELEASE_TARGET: ${{ inputs.checkout_ref }}
         run: |
           cd dist
-          gh release create ${{ inputs.release_version }} *.tar.gz *_checksums.txt \
+          sha256sum *.tar.gz > ${HOME}/${{ env.APPLICATION }}_${{ inputs.release_version }}_checksums.txt
+          gh release create ${{ inputs.release_version }} *.tar.gz ${HOME}/${{ env.APPLICATION }}_${{ inputs.release_version }}_checksums.txt \
             --generate-notes \
             --target ${GITHUB_RELEASE_TARGET} \
             --draft=true \
             --title "${{ inputs.release_version }}" \
             --notes "**Improvements:**<br>- ...coming soon <br><br>**Bugfixes:**<br><br>- ...coming soon<br><br>**Docker images:**<br><br>Docker image released:<br> ${{ env.DOCKER_TAGS }}<br><br>... coming soon<br>"
-

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1024,18 +1024,6 @@ builds:
 ## Windows AMD64
 
 
-## Checksums
-checksum:
-  name_template: "{{ .Env.APPLICATION }}_{{ .Env.BUILD_VERSION }}_checksums.txt"
-  algorithm: sha256
-  ids:
-    - linux-arm64
-    - linux-amd64
-    - darwin-amd64
-    - darwin-arm64
-    # - windows-amd64
-
-
 archives:
   - id: linux-arm64
     builds:
@@ -1066,22 +1054,6 @@ archives:
       - linux-amd64-sentry
       - linux-amd64-txpool
     name_template: '{{ .Env.APPLICATION }}_{{ .Env.BUILD_VERSION }}_{{ .Os }}_{{ .Arch }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
-    wrap_in_directory: true
-    format: tar.gz
-
-  - id: linux-amd64-v2
-    builds:
-      - linux-amd64-v2-erigon
-      - linux-amd64-v2-downloader
-      - linux-amd64-v2-devnet
-      - linux-amd64-v2-evm
-      - linux-amd64-v2-caplin
-      - linux-amd64-v2-diag
-      - linux-amd64-v2-integration
-      - linux-amd64-v2-rpcdaemon
-      - linux-amd64-v2-sentry
-      - linux-amd64-v2-txpool
-    name_template: "{{ .Env.APPLICATION }}_{{ .Env.BUILD_VERSION }}_{{ .Os }}_{{ .Arch }}v2"
     wrap_in_directory: true
     format: tar.gz
 


### PR DESCRIPTION
Move checksum step to github workflow due to
the issue with automatic processing in goreleaser
for both amd64 artifacts