### PR TITLE
Add a small test utility to get rewards data from beaconcha.in

### DIFF
--- a/tests/caplinrpc/beaconcha.in-query.py
+++ b/tests/caplinrpc/beaconcha.in-query.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python3
+
+# This is a small utility, to get centralized, but trusted historical rewards data for the beaconchain mainnet.
+#
+# Used when debugging corner-cases of Caplin's reward RPCs and the correctness of the returned data from Caplin.
+
+import requests
+import json
+import sys
+import pprint
+
+def main(validator_index, epoch):
+    resp = requests.request('GET', f'https://beaconcha.in/api/v1/validator/{validator_index}/incomedetailhistory?latest_epoch={epoch}&limit=1',
+                            headers = {
+                                'accept': 'application/json',
+                                'content-type': 'application/json',
+                            })
+    resp = json.loads(resp.content)
+    pprint.pprint(resp)
+    if 'proposer_attestation_inclusion_reward' in resp['data'][0]['income']:
+        print(f"Proposal    sum: {resp['data'][0]['income']['proposer_attestation_inclusion_reward'] + resp['data'][0]['income']['proposer_sync_inclusion_reward']}")
+    print(f"Attestation sum: {resp['data'][0]['income']['attestation_head_reward'] + resp['data'][0]['income']['attestation_source_reward'] + resp['data'][0]['income']['attestation_target_reward']}")
+
+if len(sys.argv) != 3:
+    print(f'Usage: {sys.argv[0]} <validator_index> <epoch>')
+else:
+    main(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
I'm still debugging some corner-cases in caplin rpcs, and found this API, where the rate limits are enough for solo developer just comparing caplin to some upstream, well-tested source.

Might be useful later if bugs come up.

I understand this is not strictly related to erigon in any sense, happy to move it into a different directory inside the project (maybe we should have something like "misc" or "contrib") or just host it on my own github, if erigon doesn't want to include this.