### PR TITLE
astrid: stage integration fix for connectTip error

### DIFF
--- a/eth/stagedsync/stage_polygon_sync.go
+++ b/eth/stagedsync/stage_polygon_sync.go
@@ -1567,13 +1567,9 @@ func (e *polygonSyncStageExecutionEngine) connectTip(
 	var emptyHash common.Hash
 	var ch common.Hash
 	for {
-		var ok bool
-		ch, ok, err = e.blockReader.CanonicalHash(ctx, tx, blockNum)
+		ch, _, err = e.blockReader.CanonicalHash(ctx, tx, blockNum)
 		if err != nil {
 			return nil, nil, fmt.Errorf("connectTip reading canonical hash for %d: %w", blockNum, err)
-		}
-		if !ok {
-			return nil, nil, fmt.Errorf("connectTip canonical hash not found. blockNum %d", blockNum)
 		}
 		if ch == blockHash {
 			break


### PR DESCRIPTION
fixes a mistake ive made in a previous PR that causes the below error on initial sync

```
INFO[09-23|18:10:08.623] [1/6 OtterSync] DONE                     in=3h7m31.843364875s block=12074999
... ^^ snapshots downloaded up to block 12074999 ...
DBUG[09-23|18:10:42.927] [sync] inserted blocks                   len=6267 duration=119.914625ms
... ^^ sync to tip started and downloaded first batch of 6267 blocks ...
INFO[09-23|18:10:42.928] [2/6 PolygonSync] update fork choice     block=12081266 age=6d4h58m hash=0x9d03bac27519eb1c655a9d354eeac6d0352ff69a09d421755a55813dd318ef2a
... ^^ update fork choice called for 12074999+1+6267 ...
DBUG[09-23|18:10:42.928] [2/6 PolygonSync] connecting tip         blockNum=12081266 blockHash=0x9d03bac27519eb1c655a9d354eeac6d0352ff69a09d421755a55813dd318ef2a
EROR[09-23|18:10:45.930] [2/6 PolygonSync] stopping node          err="connectTip canonical hash not found. blockNum 12081266"
```