### PR TITLE
block files: idxAvailability must rely on visibleFiles instead of atomics

### DIFF
--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -663,7 +663,9 @@ func (s *RoSnapshots) idxAvailability() uint64 {
 		if !s.HasType(segtype.Type()) {
 			return true
 		}
-		maxIdx = value.maxVisibleBlock.Load()
+		if len(value.VisibleSegments) > 0 {
+			maxIdx = value.VisibleSegments[len(value.VisibleSegments)-1].to - 1
+		}
 		return false // all types of segments have the same height. stop here
 	})
 

--- a/turbo/snapshotsync/freezeblocks/caplin_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/caplin_snapshots.go
@@ -358,9 +358,11 @@ func (s *CaplinSnapshots) recalcVisibleFiles() {
 	s.BeaconBlocks.VisibleSegments = getNewVisibleSegments(s.BeaconBlocks.DirtySegments)
 	s.BlobSidecars.VisibleSegments = getNewVisibleSegments(s.BlobSidecars.DirtySegments)
 
+	var maxIdx uint64
 	if len(s.BeaconBlocks.VisibleSegments) > 0 {
-		s.BeaconBlocks.maxVisibleBlock.Store(s.BeaconBlocks.VisibleSegments[len(s.BeaconBlocks.VisibleSegments)-1].to - 1)
+		maxIdx = s.BeaconBlocks.VisibleSegments[len(s.BeaconBlocks.VisibleSegments)-1].to - 1
 	}
+	s.BeaconBlocks.maxVisibleBlock.Store(maxIdx)
 }
 
 func (s *CaplinSnapshots) idxAvailability() uint64 {


### PR DESCRIPTION
reason: visible files guarantee consistency - between file types (because hide under same mutex). `maxVisibleBlock` atomic - doesn't give such guaranty (mutex doesn't guard them).

for: https://github.com/erigontech/erigon/issues/12069