### PR TITLE
Make structlog's error field a string instead of an object

### DIFF
--- a/eth/tracers/logger/json_stream.go
+++ b/eth/tracers/logger/json_stream.go
@@ -144,9 +144,7 @@ func (l *JsonStreamLogger) CaptureState(pc uint64, op vm.OpCode, gas, cost uint6
 	if err != nil {
 		l.stream.WriteMore()
 		l.stream.WriteObjectField("error")
-		l.stream.WriteObjectStart()
-		l.stream.WriteObjectEnd()
-		//l.stream.WriteString(err.Error())
+		l.stream.WriteString(err.Error())
 	}
 	if !l.cfg.DisableStack {
 		l.stream.WriteMore()


### PR DESCRIPTION
Resolves #12085