### PR TITLE
prep work: getting kurtosis assertoor ci to depend on every docker image push workflow

### DIFF
--- a/.github/workflows/ci-cd-main-branch-docker-images.yml
+++ b/.github/workflows/ci-cd-main-branch-docker-images.yml
@@ -11,17 +11,11 @@ env:
   LABEL_DESCRIPTION: "[docker image built on a last commit id from the main branch] Erigon is an implementation of Ethereum (execution layer with embeddable consensus layer), on the efficiency frontier. Archive Node by default."
 
 on:
-  pull_request:
-    branches:
-      - main
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
   push:
     branches:
       - 'main'
+    paths-ignore:
+      - '.github/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci-cd-main-branch-docker-images2.yml
+++ b/.github/workflows/ci-cd-main-branch-docker-images2.yml
@@ -13,9 +13,7 @@ env:
 on:
   push:
     branches:
-      - 'main'
-    paths-ignore:
-      - '.github/**'
+      - 'kurtosis_fix4'
   workflow_dispatch:
 
 jobs:

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -178,8 +178,6 @@ func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
 	}
 }
 
-func (in *EVMInterpreter) decrementDepth() { in.depth-- }
-
 // Run loops and evaluates the contract's code with the given input data and returns
 // the return byte-slice and an error if one occurred.
 //


### PR DESCRIPTION
- revert changes to ci-cd-main-branch-docker-images.yml
- do those changes instead in ci-cd-main-branch-docker-images2.yml (temp copy) for quicker testing off PRs.