### PR TITLE
Caplin: Reduced snapshot semaphore to 1

### DIFF
--- a/erigon-lib/common/dbg/experiments.go
+++ b/erigon-lib/common/dbg/experiments.go
@@ -62,7 +62,7 @@ var (
 
 	// allow simultaneous build of multiple snapshot types.
 	// Values from 1 to 4 makes sense since we have only 3 types of snapshots.
-	BuildSnapshotAllowance = EnvInt("SNAPSHOT_BUILD_SEMA_SIZE", 1) // allows 1 kind of snapshots to be built simultaneously (e.g Caplin+Domains)
+	BuildSnapshotAllowance = EnvInt("SNAPSHOT_BUILD_SEMA_SIZE", 1) // allows 1 kind of snapshots to be built simultaneously
 
 	SnapshotMadvRnd       = EnvBool("SNAPSHOT_MADV_RND", true)
 	KvMadvNormalNoLastLvl = EnvString("KV_MADV_NORMAL_NO_LAST_LVL", "") //TODO: move this logic - from hacks to app-level

--- a/erigon-lib/common/dbg/experiments.go
+++ b/erigon-lib/common/dbg/experiments.go
@@ -62,7 +62,7 @@ var (
 
 	// allow simultaneous build of multiple snapshot types.
 	// Values from 1 to 4 makes sense since we have only 3 types of snapshots.
-	BuildSnapshotAllowance = EnvInt("SNAPSHOT_BUILD_SEMA_SIZE", 2) // allows 2 kind of snapshots to be built simultaneously (e.g Caplin+Domains)
+	BuildSnapshotAllowance = EnvInt("SNAPSHOT_BUILD_SEMA_SIZE", 1) // allows 1 kind of snapshots to be built simultaneously (e.g Caplin+Domains)
 
 	SnapshotMadvRnd       = EnvBool("SNAPSHOT_MADV_RND", true)
 	KvMadvNormalNoLastLvl = EnvString("KV_MADV_NORMAL_NO_LAST_LVL", "") //TODO: move this logic - from hacks to app-level


### PR DESCRIPTION
I fixed the long caplin's snapshot wait time