### PR TITLE
polygon: fix bor_heimdall stage unwinding due to event processed blocks table

### DIFF
--- a/eth/stagedsync/stage_polygon_sync.go
+++ b/eth/stagedsync/stage_polygon_sync.go
@@ -347,8 +347,7 @@ func UnwindHeimdall(tx kv.RwTx, u *UnwindState, unwindCfg HeimdallUnwindCfg) err
 		}
 	}
 
-	if unwindCfg.Astrid && !unwindCfg.KeepEventProcessedBlocks {
-		// this table is only used in the Astrid bridge
+	if !unwindCfg.KeepEventProcessedBlocks && unwindCfg.Astrid {
 		if err := bridge.UnwindEventProcessedBlocks(tx, u.UnwindPoint); err != nil {
 			return err
 		}
@@ -360,7 +359,7 @@ func UnwindHeimdall(tx kv.RwTx, u *UnwindState, unwindCfg HeimdallUnwindCfg) err
 		}
 	}
 
-	if !unwindCfg.KeepSpanBlockProducerSelections {
+	if !unwindCfg.KeepSpanBlockProducerSelections && unwindCfg.Astrid {
 		if err := UnwindSpanBlockProducerSelections(tx, u.UnwindPoint); err != nil {
 			return err
 		}


### PR DESCRIPTION
fixes 
```
INFO] [09-30|16:59:20.466] aggregator unwind                        step=2940 txUnwindTo=4595202440 stepsRangeInDB="accounts:0.9, storage:0.9, code:0.9, commitment:0.0, receipt:0.9, logaddrs: 0.9, logtopics: 0.9, tracesfrom: 0.9, tracesto: 0.9"
[EROR] [09-30|16:59:20.671] Staged Sync                              err="[3/9 BorHeimdall] unexpected missing first processed block info entry when unwinding"
```

that table (BorEventProcessedBlocks) is only populated as part of astrid, so bor heimdall stage should not attempt to unwind it (same for BorProducerSelections table)