### PR TITLE
polygon/heimdall: add ErrServiceUnavailable transient err

### DIFF
--- a/polygon/bridge/bridge.go
+++ b/polygon/bridge/bridge.go
@@ -57,6 +57,12 @@ func Assemble(config Config) *Bridge {
 }
 
 func NewBridge(store Store, logger log.Logger, borConfig *borcfg.BorConfig, eventFetcher eventFetcher, reader *Reader) *Bridge {
+	transientErrors := []error{
+		heimdall.ErrBadGateway,
+		heimdall.ErrServiceUnavailable,
+		context.DeadlineExceeded,
+	}
+
 	return &Bridge{
 		store:                        store,
 		logger:                       logger,
@@ -64,7 +70,7 @@ func NewBridge(store Store, logger log.Logger, borConfig *borcfg.BorConfig, even
 		eventFetcher:                 eventFetcher,
 		stateReceiverContractAddress: libcommon.HexToAddress(borConfig.StateReceiverContract),
 		reader:                       reader,
-		transientErrors:              []error{context.DeadlineExceeded, heimdall.ErrBadGateway},
+		transientErrors:              transientErrors,
 		fetchedEventsSignal:          make(chan struct{}),
 		processedBlocksSignal:        make(chan struct{}),
 	}

--- a/polygon/heimdall/service.go
+++ b/polygon/heimdall/service.go
@@ -78,6 +78,7 @@ func newService(calculateSprintNumberFn CalculateSprintNumberFunc, client Heimda
 	spanFetcher := newSpanFetcher(client, logger)
 	commonTransientErrors := []error{
 		ErrBadGateway,
+		ErrServiceUnavailable,
 		context.DeadlineExceeded,
 	}
 


### PR DESCRIPTION
fixes a crash when running astrid
```
[DBUG] [10-02|04:14:04.330] Error while executing stage              err="[2/6 PolygonSync] stopped: service unavailable: url='https://heimdall-api-amoy.polygon.technology/milestone/count', status=503"
[EROR] [10-02|04:14:04.330] [2/6 PolygonSync] stopping node          err="service unavailable: url='https://heimdall-api-amoy.polygon.technology/milestone/count', status=503"
```