### PR TITLE
polygon/sync: block downloader to handle possible gaps between last checkpoint and first milestone

### DIFF
--- a/polygon/heimdall/checkpoint.go
+++ b/polygon/heimdall/checkpoint.go
@@ -141,6 +141,14 @@ func (cs Checkpoints) Swap(i, j int) {
 	cs[i], cs[j] = cs[j], cs[i]
 }
 
+func (cs Checkpoints) Waypoints() Waypoints {
+	waypoints := make(Waypoints, len(cs))
+	for i, c := range cs {
+		waypoints[i] = c
+	}
+	return waypoints
+}
+
 type CheckpointResponse struct {
 	Height string     `json:"height"`
 	Result Checkpoint `json:"result"`

--- a/polygon/heimdall/milestone.go
+++ b/polygon/heimdall/milestone.go
@@ -173,6 +173,16 @@ type MilestoneIDResponse struct {
 	Result MilestoneID `json:"result"`
 }
 
+type Milestones []*Milestone
+
+func (ms Milestones) Waypoints() Waypoints {
+	waypoints := make(Waypoints, len(ms))
+	for i, m := range ms {
+		waypoints[i] = m
+	}
+	return waypoints
+}
+
 var ErrMilestoneNotFound = errors.New("milestone not found")
 
 func MilestoneIdAt(tx kv.Tx, block uint64) (MilestoneId, error) {

--- a/polygon/heimdall/reader.go
+++ b/polygon/heimdall/reader.go
@@ -7,7 +7,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 
-	libcommon "github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/gointerfaces"
 	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
 	"github.com/erigontech/erigon-lib/log/v3"
@@ -53,14 +52,12 @@ func (r *Reader) Span(ctx context.Context, id uint64) (*Span, bool, error) {
 	return r.store.Spans().Entity(ctx, id)
 }
 
-func (r *Reader) CheckpointsFromBlock(ctx context.Context, startBlock uint64) (Waypoints, error) {
-	entities, err := r.store.Checkpoints().RangeFromBlockNum(ctx, startBlock)
-	return libcommon.SliceMap(entities, castEntityToWaypoint[*Checkpoint]), err
+func (r *Reader) CheckpointsFromBlock(ctx context.Context, startBlock uint64) (Checkpoints, error) {
+	return r.store.Checkpoints().RangeFromBlockNum(ctx, startBlock)
 }
 
-func (r *Reader) MilestonesFromBlock(ctx context.Context, startBlock uint64) (Waypoints, error) {
-	entities, err := r.store.Milestones().RangeFromBlockNum(ctx, startBlock)
-	return libcommon.SliceMap(entities, castEntityToWaypoint[*Milestone]), err
+func (r *Reader) MilestonesFromBlock(ctx context.Context, startBlock uint64) (Milestones, error) {
+	return r.store.Milestones().RangeFromBlockNum(ctx, startBlock)
 }
 
 func (r *Reader) Producers(ctx context.Context, blockNum uint64) (*valset.ValidatorSet, error) {

--- a/polygon/heimdall/service.go
+++ b/polygon/heimdall/service.go
@@ -41,8 +41,8 @@ type ServiceConfig struct {
 
 type Service interface {
 	Span(ctx context.Context, id uint64) (*Span, bool, error)
-	CheckpointsFromBlock(ctx context.Context, startBlock uint64) (Waypoints, error)
-	MilestonesFromBlock(ctx context.Context, startBlock uint64) (Waypoints, error)
+	CheckpointsFromBlock(ctx context.Context, startBlock uint64) (Checkpoints, error)
+	MilestonesFromBlock(ctx context.Context, startBlock uint64) (Milestones, error)
 	Producers(ctx context.Context, blockNum uint64) (*valset.ValidatorSet, error)
 	RegisterMilestoneObserver(callback func(*Milestone), opts ...ObserverOption) polygoncommon.UnregisterFunc
 	Run(ctx context.Context) error
@@ -182,10 +182,6 @@ func (s *service) Span(ctx context.Context, id uint64) (*Span, bool, error) {
 	return s.reader.Span(ctx, id)
 }
 
-func castEntityToWaypoint[TEntity Waypoint](entity TEntity) Waypoint {
-	return entity
-}
-
 func (s *service) SynchronizeCheckpoints(ctx context.Context) error {
 	s.logger.Debug(heimdallLogPrefix("synchronizing checkpoints..."))
 	return s.checkpointScraper.Synchronize(ctx)
@@ -234,11 +230,11 @@ func (s *service) synchronizeSpans(ctx context.Context) error {
 	return nil
 }
 
-func (s *service) CheckpointsFromBlock(ctx context.Context, startBlock uint64) (Waypoints, error) {
+func (s *service) CheckpointsFromBlock(ctx context.Context, startBlock uint64) (Checkpoints, error) {
 	return s.reader.CheckpointsFromBlock(ctx, startBlock)
 }
 
-func (s *service) MilestonesFromBlock(ctx context.Context, startBlock uint64) (Waypoints, error) {
+func (s *service) MilestonesFromBlock(ctx context.Context, startBlock uint64) (Milestones, error) {
 	return s.reader.MilestonesFromBlock(ctx, startBlock)
 }
 

--- a/polygon/sync/block_downloader.go
+++ b/polygon/sync/block_downloader.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 	"reflect"
 	"sync"
 	"sync/atomic"
@@ -112,21 +113,41 @@ type blockDownloader struct {
 }
 
 func (d *blockDownloader) DownloadBlocksUsingCheckpoints(ctx context.Context, start uint64) (*types.Header, error) {
-	waypoints, err := d.waypointReader.CheckpointsFromBlock(ctx, start)
+	checkpoints, err := d.waypointReader.CheckpointsFromBlock(ctx, start)
 	if err != nil {
 		return nil, err
 	}
 
-	return d.downloadBlocksUsingWaypoints(ctx, waypoints, d.checkpointVerifier, start)
+	return d.downloadBlocksUsingWaypoints(ctx, checkpoints.Waypoints(), d.checkpointVerifier, start)
 }
 
 func (d *blockDownloader) DownloadBlocksUsingMilestones(ctx context.Context, start uint64) (*types.Header, error) {
-	waypoints, err := d.waypointReader.MilestonesFromBlock(ctx, start)
+	milestones, err := d.waypointReader.MilestonesFromBlock(ctx, start)
 	if err != nil {
 		return nil, err
 	}
 
-	return d.downloadBlocksUsingWaypoints(ctx, waypoints, d.milestoneVerifier, start)
+	if len(milestones) == 0 {
+		return nil, nil
+	}
+
+	if firstMilestoneStart := milestones[0].StartBlock().Uint64(); start < firstMilestoneStart {
+		// Note this can happen (rarely, but it has happened) on initial sync if there is
+		// a gap between the last downloaded checkpoint EndBlock and the StartBlock of the oldest
+		// milestone that we have scrapped. We fill the gap by overriding the StartBlock of the milestone.
+		// We are safe to do so because the RootHash of the milestone is in fact the last block of the milestone
+		// range meaning that we can fetch an extended block range without failing the root hash check.
+		d.logger.Warn(
+			syncLogPrefix("gap between start and first milestone, overriding milestone start"),
+			"start", start,
+			"firstMilestoneStart", firstMilestoneStart,
+			"gap", firstMilestoneStart-start,
+		)
+
+		milestones[0].Fields.StartBlock = new(big.Int).SetUint64(start)
+	}
+
+	return d.downloadBlocksUsingWaypoints(ctx, milestones.Waypoints(), d.milestoneVerifier, start)
 }
 
 func (d *blockDownloader) downloadBlocksUsingWaypoints(

--- a/polygon/sync/waypoint_reader.go
+++ b/polygon/sync/waypoint_reader.go
@@ -24,6 +24,6 @@ import (
 
 //go:generate mockgen -typed=true -source=./waypoint_reader.go -destination=./waypoint_reader_mock.go -package=sync
 type waypointReader interface {
-	CheckpointsFromBlock(ctx context.Context, startBlock uint64) (heimdall.Waypoints, error)
-	MilestonesFromBlock(ctx context.Context, startBlock uint64) (heimdall.Waypoints, error)
+	CheckpointsFromBlock(ctx context.Context, startBlock uint64) (heimdall.Checkpoints, error)
+	MilestonesFromBlock(ctx context.Context, startBlock uint64) (heimdall.Milestones, error)
 }

--- a/polygon/sync/waypoint_reader_mock.go
+++ b/polygon/sync/waypoint_reader_mock.go
@@ -41,10 +41,10 @@ func (m *MockwaypointReader) EXPECT() *MockwaypointReaderMockRecorder {
 }
 
 // CheckpointsFromBlock mocks base method.
-func (m *MockwaypointReader) CheckpointsFromBlock(ctx context.Context, startBlock uint64) (heimdall.Waypoints, error) {
+func (m *MockwaypointReader) CheckpointsFromBlock(ctx context.Context, startBlock uint64) (heimdall.Checkpoints, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckpointsFromBlock", ctx, startBlock)
-	ret0, _ := ret[0].(heimdall.Waypoints)
+	ret0, _ := ret[0].(heimdall.Checkpoints)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -62,28 +62,28 @@ type MockwaypointReaderCheckpointsFromBlockCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockwaypointReaderCheckpointsFromBlockCall) Return(arg0 heimdall.Waypoints, arg1 error) *MockwaypointReaderCheckpointsFromBlockCall {
+func (c *MockwaypointReaderCheckpointsFromBlockCall) Return(arg0 heimdall.Checkpoints, arg1 error) *MockwaypointReaderCheckpointsFromBlockCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockwaypointReaderCheckpointsFromBlockCall) Do(f func(context.Context, uint64) (heimdall.Waypoints, error)) *MockwaypointReaderCheckpointsFromBlockCall {
+func (c *MockwaypointReaderCheckpointsFromBlockCall) Do(f func(context.Context, uint64) (heimdall.Checkpoints, error)) *MockwaypointReaderCheckpointsFromBlockCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockwaypointReaderCheckpointsFromBlockCall) DoAndReturn(f func(context.Context, uint64) (heimdall.Waypoints, error)) *MockwaypointReaderCheckpointsFromBlockCall {
+func (c *MockwaypointReaderCheckpointsFromBlockCall) DoAndReturn(f func(context.Context, uint64) (heimdall.Checkpoints, error)) *MockwaypointReaderCheckpointsFromBlockCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // MilestonesFromBlock mocks base method.
-func (m *MockwaypointReader) MilestonesFromBlock(ctx context.Context, startBlock uint64) (heimdall.Waypoints, error) {
+func (m *MockwaypointReader) MilestonesFromBlock(ctx context.Context, startBlock uint64) (heimdall.Milestones, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MilestonesFromBlock", ctx, startBlock)
-	ret0, _ := ret[0].(heimdall.Waypoints)
+	ret0, _ := ret[0].(heimdall.Milestones)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -101,19 +101,19 @@ type MockwaypointReaderMilestonesFromBlockCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockwaypointReaderMilestonesFromBlockCall) Return(arg0 heimdall.Waypoints, arg1 error) *MockwaypointReaderMilestonesFromBlockCall {
+func (c *MockwaypointReaderMilestonesFromBlockCall) Return(arg0 heimdall.Milestones, arg1 error) *MockwaypointReaderMilestonesFromBlockCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockwaypointReaderMilestonesFromBlockCall) Do(f func(context.Context, uint64) (heimdall.Waypoints, error)) *MockwaypointReaderMilestonesFromBlockCall {
+func (c *MockwaypointReaderMilestonesFromBlockCall) Do(f func(context.Context, uint64) (heimdall.Milestones, error)) *MockwaypointReaderMilestonesFromBlockCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockwaypointReaderMilestonesFromBlockCall) DoAndReturn(f func(context.Context, uint64) (heimdall.Waypoints, error)) *MockwaypointReaderMilestonesFromBlockCall {
+func (c *MockwaypointReaderMilestonesFromBlockCall) DoAndReturn(f func(context.Context, uint64) (heimdall.Milestones, error)) *MockwaypointReaderMilestonesFromBlockCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }


### PR DESCRIPTION
Fixes a rare error that occurred while testing Astrid on initial sync:
```
[DBUG] [10-03|13:41:32.989] [sync] downloading blocks using waypoints waypointsLen=1 start=12718963 end=12722546 kind=*heimdall.Checkpoint blockLimit=5000
...
[DBUG] [10-03|13:41:59.690] [sync] downloading blocks using waypoints waypointsLen=118 start=12724223 end=12729230 kind=*heimdall.Milestone blockLimit=5000
```

<br/>

Notice how the last block of the last checkpoint is `12722546` and then we start downloading using milestones however the start block of the first milestone is `12724223`.

This then causes an error because we end up inserting blocks with a gap:
```
[EROR] [10-03|13:42:04.075] [2/6 PolygonSync] stopping node          err="parent's total difficulty not found with hash fde25b040035255afcf92804f4a6abe0a4b9e3b632c547ba39aa44e9785a491c and height 12724222: <nil>"
```

At time of checking after noticing the error:
- latest checkpoint (10144) still hadnt moved - https://heimdall-api-amoy.polygon.technology/checkpoints/10144 with "start_block":12718963,"end_block":12722546
- oldest query-able (non pruned) milestone was - https://heimdall-api-amoy.polygon.technology/milestone/313310 with "start_block":12726704,"end_block":12726717

Eventually the latest checkpoint moved to - https://heimdall-api-amoy.polygon.technology/checkpoints/10145 - with "start_block":12722547,"end_block":12730482. 

Notice this checkpoint is quite bulky (~8000 blocks) which shows there was a delay of some sort on the heimdall side in the process responsible for checkpoint generation.