### PR TITLE
Check refcount in reopen dirty seg

### DIFF
--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -276,10 +276,12 @@ func (s *DirtySegment) isSubSetOf(j *DirtySegment) bool {
 }
 
 func (s *DirtySegment) reopenSeg(dir string) (err error) {
-	s.closeSeg()
-	s.Decompressor, err = seg.NewDecompressor(filepath.Join(dir, s.FileName()))
-	if err != nil {
-		return fmt.Errorf("%w, fileName: %s", err, s.FileName())
+	if s.refcount.Load() == 0 {
+		s.closeSeg()
+		s.Decompressor, err = seg.NewDecompressor(filepath.Join(dir, s.FileName()))
+		if err != nil {
+			return fmt.Errorf("%w, fileName: %s", err, s.FileName())
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This fixes a race condition when merging dirty segs.

If the refcount is > 0 we should not remove the seg immediately because there is a visible segment holding a reference.

This will get tidied-up when the last visible segment closes and the file is removed.

 This condition happens in a destructive way after a merge.  In this case any new visible segments will be given the newly merged file so will not hold references to this file.

I've tested this by running amoy to the chain tip and leaving it running and previous crashes seem to have been tidied up.