### PR TITLE
Preserve requests nil-ness in (un)marshalling

### DIFF
--- a/core/types/request.go
+++ b/core/types/request.go
@@ -143,6 +143,9 @@ func (r *Requests) Withdrawals() WithdrawalRequests {
 }
 
 func MarshalRequestsBinary(requests Requests) ([][]byte, error) {
+	if requests == nil {
+		return nil, nil
+	}
 	ret := make([][]byte, 0)
 	for _, req := range requests {
 		buf := new(bytes.Buffer)
@@ -155,6 +158,10 @@ func MarshalRequestsBinary(requests Requests) ([][]byte, error) {
 }
 
 func UnmarshalRequestsFromBinary(requests [][]byte) (reqs Requests, err error) {
+	if requests == nil {
+		return nil, nil
+	}
+	reqs = make(Requests, 0)
 	for _, b := range requests {
 		switch b[0] {
 		case DepositRequestType:


### PR DESCRIPTION
This change was necessary for `TestExecutionSpec` to pass in e2.

Without this change the following check 		
```
if !reflect.DeepEqual(rss, requests) {
  return nil, nil, nil, fmt.Errorf("invalid requests for block %d", header.Number.Uint64())
}
```
from `FinalizeBlockExecution` fails in e2. Apparently this check in not called in e3.