### PR TITLE
Caplin: Shuffle validator set in idle time during previous epoch

### DIFF
--- a/cl/phase1/core/caches/shuffled_indicies_cache.go
+++ b/cl/phase1/core/caches/shuffled_indicies_cache.go
@@ -1,0 +1,74 @@
+package caches
+
+import (
+	"math"
+	"sync"
+
+	"github.com/erigontech/erigon-lib/common"
+)
+
+var ShuffledIndiciesCacheGlobal = NewShuffledIndiciesCache(MaxShuffledIndiciesCacheSize)
+
+const MaxShuffledIndiciesCacheSize = 8
+
+type shuffledIndiciesCacheVal struct {
+	epoch       uint64
+	root        common.Hash
+	shuffledSet []uint64
+}
+
+type ShuffledIndiciesCache struct {
+	list []*shuffledIndiciesCacheVal
+
+	cap int
+	mu  sync.Mutex
+}
+
+func NewShuffledIndiciesCache(cap int) *ShuffledIndiciesCache {
+	return &ShuffledIndiciesCache{
+		list: make([]*shuffledIndiciesCacheVal, MaxShuffledIndiciesCacheSize),
+		cap:  cap,
+	}
+}
+
+func (c *ShuffledIndiciesCache) Get(epoch uint64, root common.Hash) ([]uint64, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for i := 0; i < len(c.list); i++ {
+		if c.list[i] != nil && c.list[i].epoch == epoch && c.list[i].root == root {
+			return c.list[i].shuffledSet, true
+		}
+	}
+	return nil, false
+}
+
+func (c *ShuffledIndiciesCache) Put(epoch uint64, root common.Hash, shuffledSet []uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.list) == 0 {
+		return
+	}
+	minEpochIdx := 0
+	minEpoch := uint64(math.MaxUint64)
+
+	for i := 0; i < len(c.list); i++ {
+		if c.list[i] == nil {
+			c.list[i] = &shuffledIndiciesCacheVal{
+				epoch:       epoch,
+				root:        root,
+				shuffledSet: shuffledSet,
+			}
+			return
+		}
+		if minEpoch > c.list[i].epoch {
+			minEpoch = c.list[i].epoch
+			minEpochIdx = i
+		}
+	}
+	c.list[minEpochIdx] = &shuffledIndiciesCacheVal{
+		epoch:       epoch,
+		root:        root,
+		shuffledSet: shuffledSet,
+	}
+
+}

--- a/cl/phase1/core/state/cache_accessors.go
+++ b/cl/phase1/core/state/cache_accessors.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"runtime/debug"
 	"time"
 
 	"github.com/erigontech/erigon/cl/cltypes/solid"
@@ -95,7 +94,6 @@ func (b *CachingBeaconState) ComputeCommittee(
 			shuffledIndicies = cachedIndicies
 		} else {
 			// print stack trace
-			debug.PrintStack()
 			shuffledIndicies = make([]uint64, lenIndicies)
 			start := time.Now()
 			shuffledIndicies = shuffling.ComputeShuffledIndicies(b.BeaconConfig(), mix, shuffledIndicies, indicies, slot)

--- a/cl/phase1/core/state/cache_accessors.go
+++ b/cl/phase1/core/state/cache_accessors.go
@@ -22,10 +22,12 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"runtime/debug"
 	"time"
 
 	"github.com/erigontech/erigon/cl/cltypes/solid"
 	"github.com/erigontech/erigon/cl/monitor/shuffling_metrics"
+	"github.com/erigontech/erigon/cl/phase1/core/caches"
 	"github.com/erigontech/erigon/cl/phase1/core/state/shuffling"
 	shuffling2 "github.com/erigontech/erigon/cl/phase1/core/state/shuffling"
 
@@ -88,10 +90,18 @@ func (b *CachingBeaconState) ComputeCommittee(
 	if shuffledIndicesInterface, ok := b.shuffledSetsCache.Get(seed); ok {
 		shuffledIndicies = shuffledIndicesInterface
 	} else {
-		shuffledIndicies = make([]uint64, lenIndicies)
-		start := time.Now()
-		shuffledIndicies = shuffling.ComputeShuffledIndicies(b.BeaconConfig(), mix, shuffledIndicies, indicies, slot)
-		shuffling_metrics.ObserveComputeShuffledIndiciesTime(start)
+		blockRootAtBegginingPrevEpoch, err := b.GetBlockRootAtSlot(((epoch - 1) * b.BeaconConfig().SlotsPerEpoch) - 1)
+		if cachedIndicies, ok := caches.ShuffledIndiciesCacheGlobal.Get(epoch, blockRootAtBegginingPrevEpoch); ok && err == nil {
+			shuffledIndicies = cachedIndicies
+		} else {
+			// print stack trace
+			debug.PrintStack()
+			shuffledIndicies = make([]uint64, lenIndicies)
+			start := time.Now()
+			shuffledIndicies = shuffling.ComputeShuffledIndicies(b.BeaconConfig(), mix, shuffledIndicies, indicies, slot)
+			shuffling_metrics.ObserveComputeShuffledIndiciesTime(start)
+		}
+
 		b.shuffledSetsCache.Add(seed, shuffledIndicies)
 	}
 

--- a/cl/sentinel/gossip.go
+++ b/cl/sentinel/gossip.go
@@ -518,7 +518,7 @@ func (g *GossipManager) Start(ctx context.Context) {
 					}
 					return true
 				})
-				log.Debug("[Gossip] Subscriptions", "subscriptions", logArgs)
+				log.Trace("[Gossip] Subscriptions", "subscriptions", logArgs)
 			}
 		}
 	}()


### PR DESCRIPTION
Moves the latency of shuffled sets in the `idle period` of the slot.