### PR TITLE
Caplin: Add more sanity checks to blob antiquation

### DIFF
--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -240,7 +240,10 @@ func (a *Antiquary) Loop() error {
 			)
 			if err := a.mainDB.View(a.ctx, func(roTx kv.Tx) error {
 				// read the last beacon snapshots
-				from = a.sn.BlocksAvailable()
+				from, err = beacon_indicies.ReadLastBeaconSnapshot(roTx)
+				if err != nil {
+					return err
+				}
 				// read the finalized head
 				to, err = beacon_indicies.ReadHighestFinalized(roTx)
 				if err != nil {
@@ -272,7 +275,7 @@ func (a *Antiquary) Loop() error {
 
 // weight for the semaphore to build only one type of snapshots at a time
 // for now all of them have the same weight
-const caplinSnapshotBuildSemaWeight int64 = 1
+//const caplinSnapshotBuildSemaWeight int64 = 1
 
 // Antiquate will antiquate a specific block range (aka. retire snapshots), this should be ran in the background.
 func (a *Antiquary) antiquate(from, to uint64) error {

--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -240,11 +240,7 @@ func (a *Antiquary) Loop() error {
 			)
 			if err := a.mainDB.View(a.ctx, func(roTx kv.Tx) error {
 				// read the last beacon snapshots
-				from, err = beacon_indicies.ReadLastBeaconSnapshot(roTx)
-				if err != nil {
-					return err
-				}
-				from += 1
+				from = a.sn.BlocksAvailable()
 				// read the finalized head
 				to, err = beacon_indicies.ReadHighestFinalized(roTx)
 				if err != nil {
@@ -254,7 +250,6 @@ func (a *Antiquary) Loop() error {
 			}); err != nil {
 				return err
 			}
-			fmt.Println("from", from, "to", to)
 			// Sanity checks just to be safe.
 			if from >= to {
 				continue
@@ -262,6 +257,8 @@ func (a *Antiquary) Loop() error {
 			from = (from / snaptype.CaplinMergeLimit) * snaptype.CaplinMergeLimit
 			to = min(to, to-safetyMargin) // We don't want to retire snapshots that are too close to the finalized head
 			to = (to / snaptype.CaplinMergeLimit) * snaptype.CaplinMergeLimit
+			fmt.Println(to - from)
+
 			if to-from < snaptype.CaplinMergeLimit {
 				continue
 			}

--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -276,6 +276,7 @@ const caplinSnapshotBuildSemaWeight int64 = 1
 
 // Antiquate will antiquate a specific block range (aka. retire snapshots), this should be ran in the background.
 func (a *Antiquary) antiquate(from, to uint64) error {
+	fmt.Println(a.snapgen)
 	if !a.snapgen {
 		return nil
 	}

--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -286,9 +286,6 @@ func (a *Antiquary) antiquate(from, to uint64) error {
 	// 	}
 	// 	defer a.snBuildSema.TryAcquire(caplinSnapshotBuildSemaWeight)
 	// }
-	if from-1 != a.sn.BlocksAvailable() {
-		return nil
-	}
 
 	a.logger.Info("[Antiquary] Antiquating", "from", from, "to", to)
 	if err := freezeblocks.DumpBeaconBlocks(a.ctx, a.mainDB, from, to, a.sn.Salt, a.dirs, 1, log.LvlDebug, a.logger); err != nil {

--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -390,6 +390,9 @@ func (a *Antiquary) antiquateBlobs() error {
 		if err != nil {
 			return 0, err
 		}
+		if blindedBlock == nil {
+			return 0, nil
+		}
 		return uint64(blindedBlock.Block.Body.BlobKzgCommitments.Len()), nil
 	}
 

--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -264,7 +264,7 @@ func (a *Antiquary) Loop() error {
 				continue
 			}
 			if err := a.antiquate(from, to); err != nil {
-				return err
+				log.Warn("[Antiquary] Failed to antiquate", "err", err)
 			}
 		case <-a.ctx.Done():
 		}

--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -280,12 +280,12 @@ func (a *Antiquary) antiquate(from, to uint64) error {
 	if !a.snapgen {
 		return nil
 	}
-	if a.snBuildSema != nil {
-		if !a.snBuildSema.TryAcquire(caplinSnapshotBuildSemaWeight) {
-			return nil
-		}
-		defer a.snBuildSema.TryAcquire(caplinSnapshotBuildSemaWeight)
-	}
+	// if a.snBuildSema != nil {
+	// 	if !a.snBuildSema.TryAcquire(caplinSnapshotBuildSemaWeight) {
+	// 		return nil
+	// 	}
+	// 	defer a.snBuildSema.TryAcquire(caplinSnapshotBuildSemaWeight)
+	// }
 
 	a.logger.Info("[Antiquary] Antiquating", "from", from, "to", to)
 	if err := freezeblocks.DumpBeaconBlocks(a.ctx, a.mainDB, from, to, a.sn.Salt, a.dirs, 1, log.LvlDebug, a.logger); err != nil {
@@ -355,12 +355,12 @@ func (a *Antiquary) antiquateBlobs() error {
 	if !a.snapgen {
 		return nil
 	}
-	if a.snBuildSema != nil {
-		if !a.snBuildSema.TryAcquire(caplinSnapshotBuildSemaWeight) {
-			return nil
-		}
-		defer a.snBuildSema.TryAcquire(caplinSnapshotBuildSemaWeight)
-	}
+	// if a.snBuildSema != nil {
+	// 	if !a.snBuildSema.TryAcquire(caplinSnapshotBuildSemaWeight) {
+	// 		return nil
+	// 	}
+	// 	defer a.snBuildSema.TryAcquire(caplinSnapshotBuildSemaWeight)
+	// }
 	roTx, err := a.mainDB.BeginRo(a.ctx)
 	if err != nil {
 		return err

--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -40,7 +40,7 @@ import (
 	"github.com/erigontech/erigon/turbo/snapshotsync/freezeblocks"
 )
 
-const safetyMargin = 10_000 // We retire snapshots 10k blocks after the finalized head
+const safetyMargin = 20_000 // We retire snapshots 10k blocks after the finalized head
 
 // Antiquary is where the snapshots go, aka old history, it is what keep track of the oldest records.
 type Antiquary struct {

--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -239,10 +239,7 @@ func (a *Antiquary) Loop() error {
 			)
 			if err := a.mainDB.View(a.ctx, func(roTx kv.Tx) error {
 				// read the last beacon snapshots
-				from, err = beacon_indicies.ReadLastBeaconSnapshot(roTx)
-				if err != nil {
-					return err
-				}
+				from = a.sn.BlocksAvailable()
 				// read the finalized head
 				to, err = beacon_indicies.ReadHighestFinalized(roTx)
 				if err != nil {

--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -283,7 +283,7 @@ func (a *Antiquary) antiquate() error {
 	to = min(to, to-safetyMargin) // We don't want to retire snapshots that are too close to the finalized head
 	to = (to / snaptype.CaplinMergeLimit) * snaptype.CaplinMergeLimit
 
-	if to-from < snaptype.CaplinMergeLimit {
+	if from >= to || to-from < snaptype.CaplinMergeLimit {
 		return nil
 	}
 	// if a.snBuildSema != nil {

--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -260,7 +260,6 @@ func (a *Antiquary) Loop() error {
 			from = (from / snaptype.CaplinMergeLimit) * snaptype.CaplinMergeLimit
 			to = min(to, to-safetyMargin) // We don't want to retire snapshots that are too close to the finalized head
 			to = (to / snaptype.CaplinMergeLimit) * snaptype.CaplinMergeLimit
-			fmt.Println(to - from)
 
 			if to-from < snaptype.CaplinMergeLimit {
 				continue

--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -275,10 +275,7 @@ func (a *Antiquary) antiquate() error {
 	}); err != nil {
 		return err
 	}
-	// Sanity checks just to be safe.
-	if from >= to {
-		return nil
-	}
+
 	from = (from / snaptype.CaplinMergeLimit) * snaptype.CaplinMergeLimit
 	to = min(to, to-safetyMargin) // We don't want to retire snapshots that are too close to the finalized head
 	to = (to / snaptype.CaplinMergeLimit) * snaptype.CaplinMergeLimit

--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -265,7 +265,7 @@ func (a *Antiquary) antiquate() error {
 
 	if err := a.mainDB.View(a.ctx, func(roTx kv.Tx) error {
 		// read the last beacon snapshots
-		from = a.sn.BlocksAvailable()
+		from = a.sn.BlocksAvailable() + 1
 		// read the finalized head
 		to, err = beacon_indicies.ReadHighestFinalized(roTx)
 		if err != nil {

--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -18,6 +18,7 @@ package antiquary
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"math"
 	"strings"
@@ -253,6 +254,7 @@ func (a *Antiquary) Loop() error {
 			}); err != nil {
 				return err
 			}
+			fmt.Println("from", from, "to", to)
 			// Sanity checks just to be safe.
 			if from >= to {
 				continue

--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -373,10 +373,7 @@ func (a *Antiquary) antiquateBlobs() error {
 	minimunBlobsProgress := ((a.cfg.DenebForkEpoch * a.cfg.SlotsPerEpoch) / snaptype.CaplinMergeLimit) * snaptype.CaplinMergeLimit
 	currentBlobsProgress = max(currentBlobsProgress, minimunBlobsProgress)
 	// read the finalized head
-	to, err := beacon_indicies.ReadHighestFinalized(roTx)
-	if err != nil {
-		return err
-	}
+	to := a.sn.BlocksAvailable()
 	if to <= currentBlobsProgress || to-currentBlobsProgress < snaptype.CaplinMergeLimit {
 		return nil
 	}

--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -18,7 +18,6 @@ package antiquary
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"math"
 	"strings"
@@ -278,7 +277,6 @@ func (a *Antiquary) Loop() error {
 
 // Antiquate will antiquate a specific block range (aka. retire snapshots), this should be ran in the background.
 func (a *Antiquary) antiquate(from, to uint64) error {
-	fmt.Println(a.snapgen)
 	if !a.snapgen {
 		return nil
 	}

--- a/cmd/capcli/cli.go
+++ b/cmd/capcli/cli.go
@@ -1093,7 +1093,7 @@ func (c *CheckBlobsSnapshotsCount) Run(ctx *Context) error {
 		}
 		if bBlock == nil {
 			if len(sds) != 0 {
-				return fmt.Errorf("missed block and missed blob", i)
+				return fmt.Errorf("missed block and missed blob")
 			}
 			continue
 		}

--- a/cmd/capcli/cli.go
+++ b/cmd/capcli/cli.go
@@ -1051,6 +1051,7 @@ type CheckBlobsSnapshotsCount struct {
 	chainCfg
 	outputFolder
 	withPPROF
+	From uint64 `name:"from" help:"from slot" default:"0"`
 }
 
 func (c *CheckBlobsSnapshotsCount) Run(ctx *Context) error {
@@ -1080,8 +1081,9 @@ func (c *CheckBlobsSnapshotsCount) Run(ctx *Context) error {
 	}
 	to := csn.FrozenBlobs()
 	snr := freezeblocks.NewBeaconSnapshotReader(csn, nil, beaconConfig)
+	start := max(beaconConfig.SlotsPerEpoch*beaconConfig.DenebForkEpoch+1, c.From)
 
-	for i := beaconConfig.SlotsPerEpoch*beaconConfig.DenebForkEpoch + 1; i < to; i++ {
+	for i := start; i < to; i++ {
 		sds, err := csn.ReadBlobSidecars(i)
 		if err != nil {
 			return err

--- a/cmd/capcli/cli.go
+++ b/cmd/capcli/cli.go
@@ -984,7 +984,7 @@ func (c *DumpBlobsSnapshots) Run(ctx *Context) error {
 		return err
 	}
 
-	return freezeblocks.DumpBlobsSidecar(ctx, blobStorage, db, from, to, salt, dirs, estimate.CompressSnapshot.Workers(), log.LvlInfo, log.Root())
+	return freezeblocks.DumpBlobsSidecar(ctx, blobStorage, db, from, to, salt, dirs, estimate.CompressSnapshot.Workers(), nil, log.LvlInfo, log.Root())
 }
 
 type CheckBlobsSnapshots struct {

--- a/cmd/capcli/cli.go
+++ b/cmd/capcli/cli.go
@@ -67,18 +67,19 @@ import (
 )
 
 var CLI struct {
-	Chain                    Chain                    `cmd:"" help:"download the entire chain from reqresp network"`
-	DumpSnapshots            DumpSnapshots            `cmd:"" help:"generate caplin snapshots"`
-	CheckSnapshots           CheckSnapshots           `cmd:"" help:"check snapshot folder against content of chain data"`
-	LoopSnapshots            LoopSnapshots            `cmd:"" help:"loop over snapshots"`
-	RetrieveHistoricalState  RetrieveHistoricalState  `cmd:"" help:"retrieve historical state from db"`
-	ChainEndpoint            ChainEndpoint            `cmd:"" help:"chain endpoint"`
-	ArchiveSanitizer         ArchiveSanitizer         `cmd:"" help:"archive sanitizer"`
-	BenchmarkNode            BenchmarkNode            `cmd:"" help:"benchmark node"`
-	BlobArchiveStoreCheck    BlobArchiveStoreCheck    `cmd:"" help:"blob archive store check"`
-	DumpBlobsSnapshots       DumpBlobsSnapshots       `cmd:"" help:"dump blobs snapshots"`
-	CheckBlobsSnapshots      CheckBlobsSnapshots      `cmd:"" help:"check blobs snapshots"`
-	CheckBlobsSnapshotsCount CheckBlobsSnapshotsCount `cmd:"" help:"check blobs snapshots count"`
+	Chain                     Chain                     `cmd:"" help:"download the entire chain from reqresp network"`
+	DumpSnapshots             DumpSnapshots             `cmd:"" help:"generate caplin snapshots"`
+	CheckSnapshots            CheckSnapshots            `cmd:"" help:"check snapshot folder against content of chain data"`
+	LoopSnapshots             LoopSnapshots             `cmd:"" help:"loop over snapshots"`
+	RetrieveHistoricalState   RetrieveHistoricalState   `cmd:"" help:"retrieve historical state from db"`
+	ChainEndpoint             ChainEndpoint             `cmd:"" help:"chain endpoint"`
+	ArchiveSanitizer          ArchiveSanitizer          `cmd:"" help:"archive sanitizer"`
+	BenchmarkNode             BenchmarkNode             `cmd:"" help:"benchmark node"`
+	BlobArchiveStoreCheck     BlobArchiveStoreCheck     `cmd:"" help:"blob archive store check"`
+	DumpBlobsSnapshots        DumpBlobsSnapshots        `cmd:"" help:"dump blobs snapshots"`
+	CheckBlobsSnapshots       CheckBlobsSnapshots       `cmd:"" help:"check blobs snapshots"`
+	CheckBlobsSnapshotsCount  CheckBlobsSnapshotsCount  `cmd:"" help:"check blobs snapshots count"`
+	DumpBlobsSnapshotsToStore DumpBlobsSnapshotsToStore `cmd:"" help:"dump blobs snapshots to store"`
 }
 
 type chainCfg struct {

--- a/cmd/capcli/cli.go
+++ b/cmd/capcli/cli.go
@@ -1091,6 +1091,12 @@ func (c *CheckBlobsSnapshotsCount) Run(ctx *Context) error {
 		if err != nil {
 			return err
 		}
+		if bBlock == nil {
+			if len(sds) != 0 {
+				return fmt.Errorf("missed block and missed blob", i)
+			}
+			continue
+		}
 		if len(sds) != int(bBlock.Block.Body.BlobKzgCommitments.Len()) {
 			return fmt.Errorf("slot %d: blob count mismatch", i)
 		}

--- a/cmd/capcli/cli.go
+++ b/cmd/capcli/cli.go
@@ -1097,12 +1097,12 @@ func (c *CheckBlobsSnapshotsCount) Run(ctx *Context) error {
 		if bBlock == nil {
 			continue
 		}
-		if len(sds) != int(bBlock.Block.Body.BlobKzgCommitments.Len()) {
+		if len(sds) != bBlock.Block.Body.BlobKzgCommitments.Len() {
 			if !c.CheckNeedRegen {
 				return fmt.Errorf("slot %d: blob count mismatch, have %d, want %d", i, len(sds), bBlock.Block.Body.BlobKzgCommitments.Len())
 			}
 			log.Warn("Slot", "slot", i, "have", len(sds), "want", bBlock.Block.Body.BlobKzgCommitments.Len())
-			slotsToRegen[i/snaptype.CaplinMergeLimit] = struct{}{}
+			slotsToRegen[i] = struct{}{}
 		}
 		if i%2000 == 0 {
 			log.Info("Successfully checked", "slot", i)
@@ -1110,7 +1110,7 @@ func (c *CheckBlobsSnapshotsCount) Run(ctx *Context) error {
 	}
 	if c.CheckNeedRegen {
 		for slot := range slotsToRegen {
-			log.Info("Range needs regen", "slot", slot)
+			log.Info("The following slot need to be regenerated", "slot", slot)
 		}
 	}
 	return nil

--- a/cmd/capcli/cli.go
+++ b/cmd/capcli/cli.go
@@ -1098,7 +1098,7 @@ func (c *CheckBlobsSnapshotsCount) Run(ctx *Context) error {
 			continue
 		}
 		if len(sds) != int(bBlock.Block.Body.BlobKzgCommitments.Len()) {
-			return fmt.Errorf("slot %d: blob count mismatch", i)
+			return fmt.Errorf("slot %d: blob count mismatch, have %d, want %d", i, len(sds), bBlock.Block.Body.BlobKzgCommitments.Len())
 		}
 		if i%2000 == 0 {
 			log.Info("Successfully checked", "slot", i)

--- a/cmd/capcli/cli.go
+++ b/cmd/capcli/cli.go
@@ -1130,7 +1130,7 @@ func (c *DumpBlobsSnapshotsToStore) Run(ctx *Context) error {
 	}
 	c.withProfile()
 	log.Root().SetHandler(log.LvlFilterHandler(log.LvlDebug, log.StderrHandler))
-	log.Info("Started the checking process", "chain", c.Chain)
+	log.Info("Started the dumping process", "chain", c.Chain)
 	dirs := datadir.New(c.Datadir)
 	log.Root().SetHandler(log.LvlFilterHandler(log.LvlInfo, log.StderrHandler))
 
@@ -1164,6 +1164,9 @@ func (c *DumpBlobsSnapshotsToStore) Run(ctx *Context) error {
 		}
 		if err := blobStore.WriteBlobSidecars(ctx, blockRoot, sds); err != nil {
 			return err
+		}
+		if i%2000 == 0 {
+			log.Info("Successfully dumped", "slot", i)
 		}
 	}
 

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -895,7 +895,7 @@ Loop:
 				txTask.CreateReceipt(applyTx)
 
 				if txTask.Final {
-					if !isMining && !inMemExec && !execStage.CurrentSyncCycle.IsInitialCycle {
+					if !isMining && !inMemExec && !skipPostEvaluation && !execStage.CurrentSyncCycle.IsInitialCycle {
 						cfg.notifications.RecentLogs.Add(blockReceipts)
 					}
 					checkReceipts := !cfg.vmConfig.StatelessExec && chainConfig.IsByzantium(txTask.BlockNum) && !cfg.vmConfig.NoReceipts && !isMining

--- a/turbo/snapshotsync/freezeblocks/beacon_block_reader.go
+++ b/turbo/snapshotsync/freezeblocks/beacon_block_reader.go
@@ -142,6 +142,9 @@ func (r *beaconSnapshotReader) ReadBlindedBlockBySlot(ctx context.Context, tx kv
 
 	var buf []byte
 	if slot > r.sn.BlocksAvailable() {
+		if tx == nil {
+			return nil, fmt.Errorf("no mdbx transaction provided for slot %d", slot)
+		}
 		blockRoot, err := beacon_indicies.ReadCanonicalBlockRoot(tx, slot)
 		if err != nil {
 			return nil, err

--- a/turbo/snapshotsync/freezeblocks/caplin_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/caplin_snapshots.go
@@ -556,7 +556,7 @@ func dumpBeaconBlocksRange(ctx context.Context, db kv.RoDB, fromSlot uint64, toS
 	return BeaconSimpleIdx(ctx, f, salt, tmpDir, p, lvl, logger)
 }
 
-func dumpBlobSidecarsRange(ctx context.Context, db kv.RoDB, storage blob_storage.BlobStorage, fromSlot uint64, toSlot uint64, salt uint32, dirs datadir.Dirs, workers int, blobCountFn BlobCountBySlotFn, lvl log.Lvl, logger log.Logger) error {
+func DumpBlobSidecarsRange(ctx context.Context, db kv.RoDB, storage blob_storage.BlobStorage, fromSlot uint64, toSlot uint64, salt uint32, dirs datadir.Dirs, workers int, blobCountFn BlobCountBySlotFn, lvl log.Lvl, logger log.Logger) error {
 	tmpDir, snapDir := dirs.Tmp, dirs.Snap
 
 	segName := snaptype.BlobSidecars.FileName(0, fromSlot, toSlot)
@@ -671,7 +671,7 @@ func DumpBlobsSidecar(ctx context.Context, blobStorage blob_storage.BlobStorage,
 		}
 		to := chooseSegmentEnd(i, toSlot, snaptype.CaplinEnums.BlobSidecars, nil)
 		logger.Log(lvl, "Dumping blobs sidecars", "from", i, "to", to)
-		if err := dumpBlobSidecarsRange(ctx, db, blobStorage, i, to, salt, dirs, compressWorkers, blobCountFn, lvl, logger); err != nil {
+		if err := DumpBlobSidecarsRange(ctx, db, blobStorage, i, to, salt, dirs, compressWorkers, blobCountFn, lvl, logger); err != nil {
 			return err
 		}
 	}

--- a/turbo/snapshotsync/freezeblocks/caplin_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/caplin_snapshots.go
@@ -556,7 +556,7 @@ func dumpBeaconBlocksRange(ctx context.Context, db kv.RoDB, fromSlot uint64, toS
 	return BeaconSimpleIdx(ctx, f, salt, tmpDir, p, lvl, logger)
 }
 
-func dumpBlobSidecarsRange(ctx context.Context, db kv.RoDB, storage blob_storage.BlobStorage, fromSlot uint64, toSlot uint64, salt uint32, dirs datadir.Dirs, workers int, lvl log.Lvl, logger log.Logger) error {
+func dumpBlobSidecarsRange(ctx context.Context, db kv.RoDB, storage blob_storage.BlobStorage, fromSlot uint64, toSlot uint64, salt uint32, dirs datadir.Dirs, workers int, blobCountFn BlobCountBySlotFn, lvl log.Lvl, logger log.Logger) error {
 	tmpDir, snapDir := dirs.Tmp, dirs.Snap
 
 	segName := snaptype.BlobSidecars.FileName(0, fromSlot, toSlot)
@@ -578,6 +578,8 @@ func dumpBlobSidecarsRange(ctx context.Context, db kv.RoDB, storage blob_storage
 
 	reusableBuf := []byte{}
 
+	sanityCheckBlobCount := blobCountFn != nil
+
 	// Generate .seg file, which is just the list of beacon blocks.
 	for i := fromSlot; i < toSlot; i++ {
 		// read root.
@@ -590,6 +592,16 @@ func dumpBlobSidecarsRange(ctx context.Context, db kv.RoDB, storage blob_storage
 		if err != nil {
 			return err
 		}
+		var blobCount uint64
+		if sanityCheckBlobCount {
+			blobCount, err = blobCountFn(i)
+			if err != nil {
+				return err
+			}
+			if blobCount != uint64(commitmentsCount) {
+				return fmt.Errorf("blob storage count mismatch at slot %d: %d != %d", i, blobCount, commitmentsCount)
+			}
+		}
 		if commitmentsCount == 0 {
 			sn.AddWord(nil)
 			continue
@@ -597,6 +609,9 @@ func dumpBlobSidecarsRange(ctx context.Context, db kv.RoDB, storage blob_storage
 		sidecars, found, err := storage.ReadBlobSidecars(ctx, i, blockRoot)
 		if err != nil {
 			return err
+		}
+		if sanityCheckBlobCount && uint64(len(sidecars)) != blobCount {
+			return fmt.Errorf("blob sidecars count mismatch at slot %d: %d != %d", i, len(sidecars), blobCount)
 		}
 		if !found {
 			return fmt.Errorf("blob sidecars not found for block %d", i)
@@ -644,7 +659,9 @@ func DumpBeaconBlocks(ctx context.Context, db kv.RoDB, fromSlot, toSlot uint64, 
 	return nil
 }
 
-func DumpBlobsSidecar(ctx context.Context, blobStorage blob_storage.BlobStorage, db kv.RoDB, fromSlot, toSlot uint64, salt uint32, dirs datadir.Dirs, compressWorkers int, lvl log.Lvl, logger log.Logger) error {
+type BlobCountBySlotFn func(slot uint64) (uint64, error)
+
+func DumpBlobsSidecar(ctx context.Context, blobStorage blob_storage.BlobStorage, db kv.RoDB, fromSlot, toSlot uint64, salt uint32, dirs datadir.Dirs, compressWorkers int, blobCountFn BlobCountBySlotFn, lvl log.Lvl, logger log.Logger) error {
 	cfg := snapcfg.KnownCfg("")
 	for i := fromSlot; i < toSlot; i = chooseSegmentEnd(i, toSlot, snaptype.CaplinEnums.BlobSidecars, nil) {
 		blocksPerFile := snapcfg.MergeLimitFromCfg(cfg, snaptype.CaplinEnums.BlobSidecars, i)
@@ -654,7 +671,7 @@ func DumpBlobsSidecar(ctx context.Context, blobStorage blob_storage.BlobStorage,
 		}
 		to := chooseSegmentEnd(i, toSlot, snaptype.CaplinEnums.BlobSidecars, nil)
 		logger.Log(lvl, "Dumping blobs sidecars", "from", i, "to", to)
-		if err := dumpBlobSidecarsRange(ctx, db, blobStorage, i, to, salt, dirs, compressWorkers, lvl, logger); err != nil {
+		if err := dumpBlobSidecarsRange(ctx, db, blobStorage, i, to, salt, dirs, compressWorkers, blobCountFn, lvl, logger); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Now that `--caplin.snapgen` is false by default we can:
* Avoid the semaphore for antiquation speed
* Sanity check blob seg files