### PR TITLE
 Type of error field in structlog logger differs from geth, alloy  (#12089)

### DIFF
--- a/eth/tracers/logger/json_stream.go
+++ b/eth/tracers/logger/json_stream.go
@@ -127,9 +127,7 @@ func (l *JsonStreamLogger) CaptureState(pc uint64, op vm.OpCode, gas, cost uint6
 	if err != nil {
 		l.stream.WriteMore()
 		l.stream.WriteObjectField("error")
-		l.stream.WriteObjectStart()
-		l.stream.WriteObjectEnd()
-		//l.stream.WriteString(err.Error())
+		l.stream.WriteString(err.Error())
 	}
 	if !l.cfg.DisableStack {
 		l.stream.WriteMore()


### PR DESCRIPTION

cherry-pick https://github.com/erigontech/erigon/pull/12089 into E2

https://github.com/erigontech/erigon/issues/12085