### PR TITLE
seg: speed up rebuildSegments (Alternative)

### DIFF
--- a/erigon-lib/common/datadir/dirs.go
+++ b/erigon-lib/common/datadir/dirs.go
@@ -38,6 +38,7 @@ type Dirs struct {
 	Chaindata       string
 	Tmp             string
 	Snap            string
+	SnapCommitment  string
 	SnapIdx         string
 	SnapHistory     string
 	SnapDomain      string
@@ -68,6 +69,7 @@ func New(datadir string) Dirs {
 		Chaindata:       filepath.Join(datadir, "chaindata"),
 		Tmp:             filepath.Join(datadir, "temp"),
 		Snap:            filepath.Join(datadir, "snapshots"),
+		SnapCommitment:  filepath.Join(datadir, "snapshots", "commitment"),
 		SnapIdx:         filepath.Join(datadir, "snapshots", "idx"),
 		SnapHistory:     filepath.Join(datadir, "snapshots", "history"),
 		SnapDomain:      filepath.Join(datadir, "snapshots", "domain"),
@@ -82,7 +84,7 @@ func New(datadir string) Dirs {
 	}
 
 	dir.MustExist(dirs.Chaindata, dirs.Tmp,
-		dirs.SnapIdx, dirs.SnapHistory, dirs.SnapDomain, dirs.SnapAccessors,
+		dirs.SnapCommitment, dirs.SnapIdx, dirs.SnapHistory, dirs.SnapDomain, dirs.SnapAccessors,
 		dirs.Downloader, dirs.TxPool, dirs.Nodes, dirs.CaplinBlobs, dirs.CaplinIndexing, dirs.CaplinLatest, dirs.CaplinGenesis)
 	return dirs
 }

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -2976,11 +2976,10 @@ func (d *Downloader) torrentCompleted(tName string, tHash metainfo.Hash) {
 	}
 
 	// create commitment file for .seg/.idx files
-	if !strings.HasSuffix(tName, ".seg") || !strings.HasSuffix(tName, ".idx") {
+	if !strings.HasSuffix(tName, ".seg") && !strings.HasSuffix(tName, ".idx") {
 		return
 	}
-	tName = strings.ReplaceAll(tName, ".seg", ".txt")
-	tName = strings.ReplaceAll(tName, ".idx", ".txt")
+	// add suffix to the name?
 	commitmentFile := filepath.Join(d.cfg.Dirs.SnapCommitment, tName)
 	cf, err := os.Create(commitmentFile)
 	if err != nil {

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -2974,6 +2974,25 @@ func (d *Downloader) torrentCompleted(tName string, tHash metainfo.Hash) {
 		path: tName,
 		hash: hash,
 	}
+
+	// create commitment file for .seg/.idx files
+	if !strings.HasSuffix(tName, ".seg") || !strings.HasSuffix(tName, ".idx") {
+		return
+	}
+	tName = strings.ReplaceAll(tName, ".seg", ".txt")
+	tName = strings.ReplaceAll(tName, ".idx", ".txt")
+	commitmentFile := filepath.Join(d.cfg.Dirs.SnapCommitment, tName)
+	cf, err := os.Create(commitmentFile)
+	if err != nil {
+		d.logger.Error("[snapshots] failed to create commitment file", "file", tName)
+	} else {
+		defer cf.Close()
+	}
+	_, err = cf.WriteAt(tHash[:], 0)
+	if err != nil {
+		d.logger.Error("[snapshots] failed to write to commitment file", "file", tName)
+	}
+
 }
 
 // Notify GrpcServer subscribers about completed torrent

--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -68,7 +68,7 @@ type MdbxOpts struct {
 	shrinkThreshold int
 	flags           uint
 	pageSize        uint64
-	dirtySpace      uint64 // if exeed this space, modified pages will `spill` to disk
+	dirtySpace      uint64 // if exceed this space, modified pages will `spill` to disk
 	mergeThreshold  uint64
 	verbosity       kv.DBVerbosityLvl
 	label           kv.Label // marker to distinct db instances - one process may open many databases. for example to collect metrics of only 1 database

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -442,13 +442,16 @@ func (d *Domain) openDirtyFiles() (err error) {
 }
 
 func (d *Domain) closeWhatNotInList(fNames []string) {
+	files := make(map[string]struct{}, len(fNames))
+	for _, f := range fNames {
+		files[f] = struct{}{}
+	}
 	var toClose []*filesItem
 	d.dirtyFiles.Walk(func(items []*filesItem) bool {
-	Loop1:
 		for _, item := range items {
-			for _, protectName := range fNames {
-				if item.decompressor != nil && item.decompressor.FileName() == protectName {
-					continue Loop1
+			if item.decompressor != nil {
+				if _, ok := files[item.decompressor.FileName()]; ok {
+					continue
 				}
 			}
 			toClose = append(toClose, item)

--- a/erigon-lib/state/history.go
+++ b/erigon-lib/state/history.go
@@ -76,7 +76,7 @@ type History struct {
 	compressCfg seg.Cfg
 	compression seg.FileCompression
 
-	//TODO: re-visit this check - maybe we don't need it. It's abot kill in the middle of merge
+	//TODO: re-visit this check - maybe we don't need it. It's about kill in the middle of merge
 	integrityCheck func(fromStep, toStep uint64) bool
 
 	// not large:
@@ -292,13 +292,16 @@ func (h *History) openDirtyFiles() error {
 }
 
 func (h *History) closeWhatNotInList(fNames []string) {
+	files := make(map[string]struct{}, len(fNames))
+	for _, f := range fNames {
+		files[f] = struct{}{}
+	}
 	var toClose []*filesItem
 	h.dirtyFiles.Walk(func(items []*filesItem) bool {
-	Loop1:
 		for _, item := range items {
-			for _, protectName := range fNames {
-				if item.decompressor != nil && item.decompressor.FileName() == protectName {
-					continue Loop1
+			if item.decompressor != nil {
+				if _, ok := files[item.decompressor.FileName()]; ok {
+					continue
 				}
 			}
 			toClose = append(toClose, item)

--- a/erigon-lib/state/inverted_index.go
+++ b/erigon-lib/state/inverted_index.go
@@ -348,15 +348,19 @@ func (ii *InvertedIndex) openDirtyFiles() error {
 }
 
 func (ii *InvertedIndex) closeWhatNotInList(fNames []string) {
+	files := make(map[string]struct{}, len(fNames))
+	for _, f := range fNames {
+		files[f] = struct{}{}
+	}
 	var toClose []*filesItem
 	ii.dirtyFiles.Walk(func(items []*filesItem) bool {
-	Loop1:
 		for _, item := range items {
-			for _, protectName := range fNames {
-				if item.decompressor != nil && item.decompressor.FileName() == protectName {
-					continue Loop1
+			if item.decompressor != nil {
+				if _, ok := files[item.decompressor.FileName()]; ok {
+					continue
 				}
 			}
+
 			toClose = append(toClose, item)
 		}
 		return true

--- a/eth/stagedsync/stage.go
+++ b/eth/stagedsync/stage.go
@@ -87,7 +87,7 @@ func (s *StageState) ExecutionAt(db kv.Getter) (uint64, error) {
 }
 
 type UnwindReason struct {
-	// If we;re unwinding due to a fork - we want to unlink blocks but not mark
+	// If we're unwinding due to a fork - we want to unlink blocks but not mark
 	// them as bad - as they may get replayed then deselected
 	Block *libcommon.Hash
 	// If unwind is caused by a bad block, this error is not empty

--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -757,19 +757,25 @@ func (s *RoSnapshots) integrityCheck(fName string) bool {
 func integrityCheck(dir, fName string) bool {
 	file := filepath.Join(dir, fName)
 	f, err := os.Stat(file)
-	if os.IsNotExist(err) {
+	if err != nil {
+		log.Warn("[snapshots] integrityCheck", "err", err)
 		return false
 	}
 	torrentFile := filepath.Join(dir, fName) + ".torrent"
-	if _, err := os.Stat(torrentFile); os.IsNotExist(err) {
+	_, err = os.Stat(torrentFile)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Warn("[snapshots] integrityCheck", "err", err)
+		}
 		// torrent file not exists means that file is created locally, in this case file must be complete
 		return true
 	}
-	fName = strings.ReplaceAll(fName, ".seg", ".txt")
-	fName = strings.ReplaceAll(fName, ".idx", ".txt")
 	commitmentFile := filepath.Join(dir, "commitment", fName)
 	cf, err := os.Stat(commitmentFile)
-	if os.IsNotExist(err) {
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Warn("[snapshots] integrityCheck", "err", err)
+		}
 		return false
 	}
 	if cf.ModTime().After(f.ModTime()) {

--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -791,7 +791,7 @@ func (s *RoSnapshots) rebuildSegments(fileNames []string, open bool, optimistic 
 			sn = &DirtySegment{segType: f.Type, version: f.Version, Range: Range{f.From, f.To}, frozen: snapcfg.Seedable(s.cfg.ChainName, f)}
 		}
 
-		if open {
+		if open && sn.Decompressor == nil {
 			if err := sn.reopenSeg(s.dir); err != nil {
 				if errors.Is(err, os.ErrNotExist) {
 					if optimistic {
@@ -814,7 +814,7 @@ func (s *RoSnapshots) rebuildSegments(fileNames []string, open bool, optimistic 
 			segtype.DirtySegments.Set(sn)
 		}
 
-		if open {
+		if open && sn.indexes == nil {
 			if err := sn.reopenIdxIfNeed(s.dir, optimistic); err != nil {
 				return err
 			}
@@ -899,23 +899,22 @@ func (s *RoSnapshots) Close() {
 }
 
 func (s *RoSnapshots) closeWhatNotInList(l []string) {
+	files := make(map[string]struct{}, len(l))
+	for _, f := range l {
+		files[f] = struct{}{}
+	}
 	toClose := make(map[snaptype.Enum][]*DirtySegment, 0)
 	s.segments.Scan(func(segtype snaptype.Enum, value *segments) bool {
 		value.DirtySegments.Walk(func(segs []*DirtySegment) bool {
-
-		Loop1:
 			for _, seg := range segs {
-				for _, fName := range l {
-					if fName == seg.FileName() {
-						continue Loop1
-					}
+				if _, ok := files[seg.FileName()]; ok {
+					continue
 				}
 				if _, ok := toClose[seg.segType.Enum()]; !ok {
 					toClose[segtype] = make([]*DirtySegment, 0)
 				}
 				toClose[segtype] = append(toClose[segtype], seg)
 			}
-
 			return true
 		})
 		return true


### PR DESCRIPTION
This is alternative to #12114 

Add a subdir "/snapshots/commitment" to store commitment files for .seg/.idx files that are fully downloaded. 
In this way we know if downloading is finished and if it's ok to open downloaded files.

- do not reopen .seg/.idx files if already opened during rebuildSegments
- accelerate scanning files by avoiding doubly nested loop