### PR TITLE
exec: do not `Add` into `RecentLogs` if got nil receipt

### DIFF
--- a/turbo/shards/events.go
+++ b/turbo/shards/events.go
@@ -17,6 +17,7 @@
 package shards
 
 import (
+	"github.com/erigontech/erigon-lib/log/v3"
 	"sync"
 
 	"github.com/erigontech/erigon-lib/common"
@@ -239,6 +240,10 @@ func (r *RecentLogs) Notify(n *Events, from, to uint64, isUnwind bool) {
 
 func (r *RecentLogs) Add(receipts types.Receipts) {
 	if len(receipts) == 0 {
+		return
+	}
+	if receipts[0] == nil {
+		log.Debug("RecentLogs.Add: first receipt is nil, .Add is skipped")
 		return
 	}
 	r.mu.Lock()

--- a/turbo/shards/events.go
+++ b/turbo/shards/events.go
@@ -17,7 +17,7 @@
 package shards
 
 import (
-	"github.com/erigontech/erigon-lib/log/v3"
+	"fmt"
 	"sync"
 
 	"github.com/erigontech/erigon-lib/common"
@@ -243,7 +243,7 @@ func (r *RecentLogs) Add(receipts types.Receipts) {
 		return
 	}
 	if receipts[0] == nil {
-		log.Debug("RecentLogs.Add: first receipt is nil, .Add is skipped")
+		fmt.Printf("RecentLogs.Add: first receipt is nil, .Add is skipped")
 		return
 	}
 	r.mu.Lock()


### PR DESCRIPTION
touches https://github.com/erigontech/erigon/issues/12255
If `receipts[0]` is nil, have to investigate why nil value is added into receipt list.