### PR TITLE
e2: Fix state root calculation for EIP-7702 accounts with storage

### DIFF
--- a/turbo/trie/trie_root.go
+++ b/turbo/trie/trie_root.go
@@ -247,9 +247,6 @@ func (l *FlatDBTrieLoader) CalcTrieRoot(tx kv.Tx, quit <-chan struct{}) (libcomm
 			if err = l.receiver.Receive(AccountStreamItem, kHex, nil, &l.accountValue, nil, nil, false, 0); err != nil {
 				return EmptyRoot, err
 			}
-			if l.accountValue.Incarnation == 0 {
-				continue
-			}
 			copy(l.accAddrHashWithInc[:], k)
 			binary.BigEndian.PutUint64(l.accAddrHashWithInc[32:], l.accountValue.Incarnation)
 			accWithInc := l.accAddrHashWithInc[:]


### PR DESCRIPTION
With EIP-7702 even EOAs might have some storage set, and we use zero incarnation for EOAs. 