### PR TITLE
polygon/sync: avoid dropping milestone events

### DIFF
--- a/polygon/sync/event_channel.go
+++ b/polygon/sync/event_channel.go
@@ -19,27 +19,37 @@ package sync
 import (
 	"container/list"
 	"context"
+	"fmt"
 	"sync"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/erigontech/erigon-lib/log/v3"
 )
 
 // EventChannel is a buffered channel that drops oldest events when full.
 type EventChannel[TEvent any] struct {
-	events chan TEvent
-
+	opts       EventChannelOptions
+	events     chan TEvent
 	queue      *list.List
 	queueCap   uint
 	queueMutex sync.Mutex
 	queueCond  *sync.Cond
 }
 
-func NewEventChannel[TEvent any](capacity uint) *EventChannel[TEvent] {
+func NewEventChannel[TEvent any](capacity uint, opts ...EventChannelOption) *EventChannel[TEvent] {
 	if capacity == 0 {
 		panic("NewEventChannel: capacity must be > 0")
 	}
 
-	ec := &EventChannel[TEvent]{
-		events: make(chan TEvent),
+	defaultOpts := EventChannelOptions{}
+	for _, opt := range opts {
+		opt(&defaultOpts)
+	}
 
+	ec := &EventChannel[TEvent]{
+		opts:     defaultOpts,
+		events:   make(chan TEvent),
 		queue:    list.New(),
 		queueCap: capacity,
 	}
@@ -59,8 +69,13 @@ func (ec *EventChannel[TEvent]) PushEvent(e TEvent) {
 	ec.queueMutex.Lock()
 	defer ec.queueMutex.Unlock()
 
+	var dropped bool
 	if uint(ec.queue.Len()) == ec.queueCap {
 		ec.queue.Remove(ec.queue.Front())
+		dropped = true
+	}
+	if ec.opts.logger != nil && dropped {
+		ec.opts.logger.Log(ec.opts.loggerLvl, fmt.Sprintf("[event-channel-%s] dropping event", ec.opts.loggerId))
 	}
 
 	ec.queue.PushBack(e)
@@ -126,4 +141,62 @@ func (ec *EventChannel[TEvent]) Run(ctx context.Context) error {
 			return ctx.Err()
 		}
 	}
+}
+
+type EventChannelOptions struct {
+	logger    log.Logger
+	loggerLvl log.Lvl
+	loggerId  string
+}
+
+type EventChannelOption func(opts *EventChannelOptions)
+
+func WithEventChannelLogging(logger log.Logger, lvl log.Lvl, id string) EventChannelOption {
+	return func(opts *EventChannelOptions) {
+		opts.logger = logger
+		opts.loggerLvl = lvl
+		opts.loggerId = id
+	}
+}
+
+type Topical interface {
+	Topic() string
+}
+
+type CompositeEventChannel[TEvent Topical] struct {
+	topics map[string]*EventChannel[TEvent]
+	events chan TEvent
+}
+
+func (cec CompositeEventChannel[TEvent]) Events() <-chan TEvent {
+	return cec.events
+}
+
+func (cec CompositeEventChannel[TEvent]) PushEvent(e TEvent) {
+	cec.topics[e.Topic()].PushEvent(e)
+}
+
+func (cec CompositeEventChannel[TEvent]) Run(ctx context.Context) error {
+	eg, ctx := errgroup.WithContext(ctx)
+	for _, eventChannel := range cec.topics {
+		eg.Go(func() error {
+			ch := eventChannel.events
+			for {
+				var e TEvent
+				select {
+				case e = <-ch: // receive
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+
+				select {
+				case cec.events <- e: // send
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+		})
+	}
+
+	return eg.Wait()
 }

--- a/polygon/sync/event_channel_test.go
+++ b/polygon/sync/event_channel_test.go
@@ -19,8 +19,10 @@ package sync
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 )
 
 func TestEventChannel(t *testing.T) {
@@ -77,4 +79,70 @@ func TestEventChannel(t *testing.T) {
 		require.Equal(t, "event3", <-events)
 		require.Equal(t, 0, len(events))
 	})
+}
+
+func TestCompositeEventChannel(t *testing.T) {
+	t.Parallel()
+
+	ch := NewCompositeEventChannel[topicEvent](map[string]*EventChannel[topicEvent]{
+		"topic1": NewEventChannel[topicEvent](2),
+		"topic2": NewEventChannel[topicEvent](3),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	t.Cleanup(cancel)
+
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		err := ch.Run(ctx)
+		println(err)
+		return err
+	})
+
+	ch.PushEvent(topicEvent{
+		event: "event1", // should get dropped due to event2 and event3 overflowing the channel for topic1
+		topic: "topic1",
+	})
+	ch.PushEvent(topicEvent{
+		event: "event2",
+		topic: "topic1",
+	})
+	ch.PushEvent(topicEvent{
+		event: "event3",
+		topic: "topic1",
+	})
+	ch.PushEvent(topicEvent{
+		event: "event4",
+		topic: "topic2",
+	})
+
+	events := make([]string, 3)
+	events[0] = read(ctx, t, ch.Events()).event
+	events[1] = read(ctx, t, ch.Events()).event
+	events[2] = read(ctx, t, ch.Events()).event
+	require.ElementsMatch(t, events, []string{"event2", "event3", "event4"})
+	require.Len(t, ch.topics["topic1"].events, 0)
+	require.Len(t, ch.topics["topic2"].events, 0)
+	cancel()
+	err := eg.Wait()
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+type topicEvent struct {
+	event string
+	topic string
+}
+
+func (te topicEvent) Topic() string {
+	return te.topic
+}
+
+func read(ctx context.Context, t *testing.T, ch <-chan topicEvent) topicEvent {
+	select {
+	case e := <-ch:
+		return e
+	case <-ctx.Done():
+		require.FailNow(t, "timed out waiting for event")
+		return topicEvent{}
+	}
 }

--- a/polygon/sync/sync.go
+++ b/polygon/sync/sync.go
@@ -213,6 +213,11 @@ func (s *Sync) applyNewBlockOnTip(
 			"amount", amount,
 		)
 
+		if amount > 1024 {
+			// if we ever get here it means we've missed processing a milestone
+			return errors.New("canonical chain builder root is too far back")
+		}
+
 		opts := []p2p.FetcherOption{p2p.WithMaxRetries(0), p2p.WithResponseTimeout(time.Second)}
 		blocks, err := s.p2pService.FetchBlocksBackwardsByHash(ctx, newBlockHeaderHash, amount, event.PeerId, opts...)
 		if err != nil {

--- a/polygon/sync/sync.go
+++ b/polygon/sync/sync.go
@@ -166,10 +166,10 @@ func (s *Sync) applyNewMilestoneOnTip(
 
 	s.logger.Debug(
 		syncLogPrefix("applying new milestone event"),
-		"id", milestone.RawId(),
-		"start", milestone.StartBlock().Uint64(),
-		"end", milestone.EndBlock().Uint64(),
-		"root", milestone.RootHash(),
+		"milestoneId", milestone.RawId(),
+		"milestoneStart", milestone.StartBlock().Uint64(),
+		"milestoneEnd", milestone.EndBlock().Uint64(),
+		"milestoneRootHash", milestone.RootHash(),
 	)
 
 	milestoneHeaders := ccBuilder.HeadersInRange(milestone.StartBlock().Uint64(), milestone.Length())
@@ -221,6 +221,7 @@ func (s *Sync) applyNewBlockOnTip(
 			// since we do not expect to see such large re-organisations
 			// - if we ever do get a block from a peer for which 1024 blocks back is not enough to connect it
 			// then we shall drop it as the canonical chain builder will fail to connect it and move on
+			// useful read: https://forum.polygon.technology/t/proposal-improved-ux-with-milestones-for-polygon-pos/11534
 			s.logger.Warn(syncLogPrefix("canonical chain builder root is too far"), "amount", amount)
 			amount = 1024
 		}

--- a/polygon/sync/sync.go
+++ b/polygon/sync/sync.go
@@ -312,7 +312,7 @@ func (s *Sync) applyNewBlockHashesOnTip(
 		}
 
 		s.logger.Debug(
-			syncLogPrefix("applying new block hash"),
+			syncLogPrefix("applying new block hash event"),
 			"blockNum", hashOrNum.Number,
 			"blockHash", hashOrNum.Hash,
 		)

--- a/polygon/sync/sync.go
+++ b/polygon/sync/sync.go
@@ -166,9 +166,10 @@ func (s *Sync) applyNewMilestoneOnTip(
 
 	s.logger.Debug(
 		syncLogPrefix("applying new milestone event"),
-		"milestoneStartBlockNum", milestone.StartBlock().Uint64(),
-		"milestoneEndBlockNum", milestone.EndBlock().Uint64(),
-		"milestoneRootHash", milestone.RootHash(),
+		"id", milestone.RawId(),
+		"start", milestone.StartBlock().Uint64(),
+		"end", milestone.EndBlock().Uint64(),
+		"root", milestone.RootHash(),
 	)
 
 	milestoneHeaders := ccBuilder.HeadersInRange(milestone.StartBlock().Uint64(), milestone.Length())
@@ -214,8 +215,14 @@ func (s *Sync) applyNewBlockOnTip(
 		)
 
 		if amount > 1024 {
-			// if we ever get here it means we've missed processing a milestone
-			return errors.New("canonical chain builder root is too far back")
+			// should not ever need to request more than 1024 blocks here in order to backward connect
+			// - if we do then we are missing milestones and need to investigate why
+			// - additionally 1024 blocks should be enough to connect a new block at tip even without milestones
+			// since we do not expect to see such large re-organisations
+			// - if we ever do get a block from a peer for which 1024 blocks back is not enough to connect it
+			// then we shall drop it as the canonical chain builder will fail to connect it and move on
+			s.logger.Warn(syncLogPrefix("canonical chain builder root is too far"), "amount", amount)
+			amount = 1024
 		}
 
 		opts := []p2p.FetcherOption{p2p.WithMaxRetries(0), p2p.WithResponseTimeout(time.Second)}

--- a/polygon/sync/tip_events.go
+++ b/polygon/sync/tip_events.go
@@ -230,7 +230,8 @@ type blockEventKey struct {
 
 func newBlockEventsSpamGuard(logger log.Logger) blockEventsSpamGuard {
 	// 1 key is 104 bytes, 10 keys is ~1KB, 10_000 keys is ~1MB
-	// assume 200 peers, that should be enough to keep last 50 messages from peer - plenty!
+	// assume 200 peers, that should be enough to keep roughly on average
+	// the last 50 messages from each peer - that should be plenty!
 	seenPeerBlockHashes, err := lru.New[blockEventKey, struct{}](10_000)
 	if err != nil {
 		panic(err)

--- a/polygon/sync/tip_events.go
+++ b/polygon/sync/tip_events.go
@@ -215,6 +215,11 @@ func (te *TipEvents) Run(ctx context.Context) error {
 
 // blockEventKey is a comparable struct used for spam detection, to protect ourselves from noisy and/or
 // malicious peers overflowing our event channels. Note that all the struct fields must be comparable.
+// One example of why we need something like this is, Erigon 2 (pre-Astrid) nodes do not keep track of
+// whether they have already notified a peer or whether a peer has notified them about a given block hash,
+// and instead they always announce new block hashes to all of their peers whenever they receive a new
+// block event. In this case, if we are connected to lots of Erigon 2 (pre-Astrid) peers we will get
+// a lot of spam that can overflow our events channel.
 type blockEventKey struct {
 	peerId    p2p.PeerId
 	blockHash common.Hash

--- a/polygon/sync/tip_events.go
+++ b/polygon/sync/tip_events.go
@@ -215,10 +215,10 @@ func (te *TipEvents) Run(ctx context.Context) error {
 
 // blockEventKey is a comparable struct used for spam detection, to protect ourselves from noisy and/or
 // malicious peers overflowing our event channels. Note that all the struct fields must be comparable.
-// One example of why we need something like this is, Erigon 2 (pre-Astrid) nodes do not keep track of
+// One example of why we need something like this is, Erigon (non-Astrid) nodes do not keep track of
 // whether they have already notified a peer or whether a peer has notified them about a given block hash,
 // and instead they always announce new block hashes to all of their peers whenever they receive a new
-// block event. In this case, if we are connected to lots of Erigon 2 (pre-Astrid) peers we will get
+// block event. In this case, if we are connected to lots of Erigon (non-Astrid) peers we will get
 // a lot of spam that can overflow our events channel. In the future, we may find more situations
 // where we need to filter spam from say malicious peers that try to trick us or DDoS us, so this may
 // also serve as a base to build on top of.

--- a/polygon/sync/tip_events.go
+++ b/polygon/sync/tip_events.go
@@ -213,8 +213,8 @@ func (te *TipEvents) Run(ctx context.Context) error {
 	return te.events.Run(ctx)
 }
 
-// blockEventKey is a comparable struct used for spam detection, to protect ourselves from noisy/malicious peers
-// overflowing our event channels. Note that all the struct fields must be comparable.
+// blockEventKey is a comparable struct used for spam detection, to protect ourselves from noisy and/or
+// malicious peers overflowing our event channels. Note that all the struct fields must be comparable.
 type blockEventKey struct {
 	peerId    p2p.PeerId
 	blockHash common.Hash

--- a/polygon/sync/tip_events.go
+++ b/polygon/sync/tip_events.go
@@ -129,11 +129,11 @@ func NewTipEvents(
 	eventChannel := NewCompositeEventChannel[Event](map[string]*EventChannel[Event]{
 		EventTopicHeimdall.String(): NewEventChannel[Event](
 			10,
-			WithEventChannelLogging(logger, log.LvlWarn, EventTopicHeimdall.String()),
+			WithEventChannelLogging(logger, log.LvlTrace, EventTopicHeimdall.String()),
 		),
 		EventTopicP2P.String(): NewEventChannel[Event](
 			1000,
-			WithEventChannelLogging(logger, log.LvlWarn, EventTopicP2P.String()),
+			WithEventChannelLogging(logger, log.LvlTrace, EventTopicP2P.String()),
 		),
 	})
 	return &TipEvents{

--- a/polygon/sync/tip_events.go
+++ b/polygon/sync/tip_events.go
@@ -219,7 +219,9 @@ func (te *TipEvents) Run(ctx context.Context) error {
 // whether they have already notified a peer or whether a peer has notified them about a given block hash,
 // and instead they always announce new block hashes to all of their peers whenever they receive a new
 // block event. In this case, if we are connected to lots of Erigon 2 (pre-Astrid) peers we will get
-// a lot of spam that can overflow our events channel.
+// a lot of spam that can overflow our events channel. In the future, we may find more situations
+// where we need to filter spam from say malicious peers that try to trick us or DDoS us, so this may
+// also serve as a base to build on top of.
 type blockEventKey struct {
 	peerId    p2p.PeerId
 	blockHash common.Hash

--- a/polygon/sync/tip_events_test.go
+++ b/polygon/sync/tip_events_test.go
@@ -1,0 +1,28 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/log/v3"
+	"github.com/erigontech/erigon/polygon/p2p"
+	"github.com/erigontech/erigon/turbo/testlog"
+)
+
+func TestBlockEventsSpamGuard(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlCrit)
+	sg := newBlockEventsSpamGuard(logger)
+	peerId1 := p2p.PeerIdFromUint64(1)
+	peerId2 := p2p.PeerIdFromUint64(2)
+	require.False(t, sg.Spam(peerId1, common.HexToHash("0x0"), 1))
+	require.True(t, sg.Spam(peerId1, common.HexToHash("0x0"), 1))
+	require.True(t, sg.Spam(peerId1, common.HexToHash("0x0"), 1))
+	require.False(t, sg.Spam(peerId2, common.HexToHash("0x0"), 1))
+	require.True(t, sg.Spam(peerId2, common.HexToHash("0x0"), 1))
+	require.False(t, sg.Spam(peerId2, common.HexToHash("0x1"), 1))
+	require.False(t, sg.Spam(peerId2, common.HexToHash("0x0"), 2))
+	require.False(t, sg.Spam(peerId2, common.HexToHash("0x2"), 2))
+	require.False(t, sg.Spam(peerId2, common.HexToHash("0x3"), 3))
+}


### PR DESCRIPTION
Fixes an issue with Astrid at tip where the root of our canonical chain builder got too far away from the tip (> 1024 blocks) which is not to be expected. It should never happen at tip. Milestones are usually ~30 blocks on Mainnet. I've seen worst cases around ~200 blocks on Amoy. So if our processing is accurate our root should never be more than 1024 aways from the tip. The explanation for this is that every time we process a milestone we move our root forward, so it should always be 1 milestone worth of blocks behind tip.

The underlying root cause of this caused 2 problems:
1. an error that crashed the node 
```
[EROR] [10-09|16:54:25.194] [2/6 PolygonSync] stopping node          err="invalid fetch blocks amount: amount=1030"
```

<br/>

2. degrading performance of the node for some time before the error

![Screenshot 2024-10-10 at 16 44 37](https://github.com/user-attachments/assets/f51afc7e-ba32-4619-a56f-b2cb3b59a1a4)


The underlying issue causing the above is that we've dropped milestone events from our `EventsChannel` (it has a capacity of 1000 events and drops oldest events when pushing an event at capacity). We can confirm this via the logs. Notice the gap between the end block of the first and the start block of the second - these are 2 consecutive events that we have processed so there should be no gaps and the time between them should not be ~4mins (should be ~1 min).
```
[DBUG] [10-09|16:14:43.079] [sync] applying new milestone event      milestoneStartBlockNum=62831140 milestoneEndBlockNum=62831154 milestoneRootHash=0xebccef3890f3ba64d1bec949c5ce298acc88bca5e333520546b7dabc473b9043
...
[DBUG] [10-09|16:19:01.605] [sync] applying new milestone event      milestoneStartBlockNum=62831259 milestoneEndBlockNum=62831274 milestoneRootHash=0xac2f53dc691a63e2672ee85572f29670c6217df8cfd68796c680189b08156652
```

<br/>

Additionally, the heimdall process logs confirm we have scrapped the milestones. Milestone 494026 corresponds to the last milestone event we have processed above (ending at block 62831274) before the error. Milestone 494027 is next and we've scrapped it ~36 seconds later. However we've never processed it in Astrid leading to our root falling behind too much.
```
INFO [2024-10-09|16:17:41.841] Served RPC HTTP response                     module=rest-server method=GET url=/milestone/494026 status=200 duration=0 remoteAddr=127.0.0.1:46790
...
INFO [2024-10-09|16:18:17.452] Served RPC HTTP response                     module=rest-server method=GET url=/milestone/494027 status=200 duration=1 remoteAddr=127.0.0.1:49038
```

<br/>

From all of this is clear that we're dropping milestone events in our EventsChannel. I spent time investigating why. When we connect to many peers on mainnet (think >50 peers) we start receiving a lot of NewBlock and NewBlockHashes events from devp2p. If the amount of devp2p events coming in is higher than the rate at which we consume/process the events then we will start dropping stuff from the events channel. 

This is fine in normal circumstances however Erigon (non-astrid) peers seem to over-propagate NewBlockHashes. This is due to the logic in the sentry multi client - when a NewBlock event is received, Erigon responds with NewBlockHashes announcements to all of its peers - without keeping track if that peer already knows about this hash (either because Erigon has already announced that block hash or Erigon has received that block hash announcement from the peer). The end result of this is that the more Erigon peers we connect to the more we will get flooded. This causes a lot of unnecessary processing for us in Astrid and also in us dropping milestone events. Additionally, it is also not following the devp2p specs https://github.com/ethereum/devp2p/blob/master/caps/eth.md#newblockhashes-0x01. *NOTE block propagation via sentry multi client is disabled in Astrid, so it does not suffer from this problem. Block propagation for Astrid will be implemented in a follow up PR as part of the driver and it would not suffer from this problem.*

The above is confirmed by the following logs: 
[period-of-event-spam-log.txt](https://github.com/user-attachments/files/17331131/period-of-event-spam-log.txt). 

In the logs, notice how many duplicate events for the same block we have received from peer `b612fe4679bc08112367904fbb00b26ba9ff1557f7c9c597fc0387a417637a36e6a5f897d2c6bf76a3843e16da286ae949ed11f456228460fff26189bc13fceb` and peer `096ba1be0fbc2996d966a1fce41e309d887ccf322e9a9ffc252b722dc0c65ed0ff4998d2b99671cfdba1311e607860d414e49aa05176dc9bca49d67596498480`. These are both Erigon (non-Astrid) peers. Confirmed via the diagnostics tool.

The solution to all of this in this PR is:
1. Introduce a new `CompositeEventsChannel` which allows us to split our `EventsChannel` into 2 - one for heimdall milestone events so they do not get dropped by the devp2p messages and one for the devp2p messages. The `CompositeEventsChannel`  unifies them so we have to deal with only 1 channel.
2. Introduce a `blockEventsSpamGuard` to protect us from filling our `EventsChannel` with loads and loads of duplicate devp2p messages from the same peer
