### PR TITLE
qa-tests: enable more erigon_getBlockByTimestamp tests

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -211,11 +211,6 @@ jobs:
           ots_searchTransactionsBefore/test_12.json,\
           admin_nodeInfo/test_01.json,\
           admin_peers/test_01.json,\
-          erigon_getBlockByTimestamp/test_03.json,\
-          erigon_getBlockByTimestamp/test_04.json,\
-          erigon_getBlockByTimestamp/test_05.json,\
-          erigon_getBlockByTimestamp/test_06.json,\
-          erigon_getBlockByTimestamp/test_07.json,\
           erigon_nodeInfo/test_1.json,\
           eth_coinbase/test_01.json,\
           eth_feeHistory/test_01.json,\


### PR DESCRIPTION
Enable more erigon_getBlockByTimestamp tests after a bug is fixed with this commit
https://github.com/erigontech/erigon/commit/b266c6562f18c0f28164387260e7497df089779f
