### PR TITLE
Make sync rewards accessible also in non-epoch boundary slots

### DIFF
--- a/cl/beacon/handler/rewards.go
+++ b/cl/beacon/handler/rewards.go
@@ -169,7 +169,7 @@ func (a *ApiHandler) PostEthV1BeaconRewardsSyncCommittees(w http.ResponseWriter,
 		if !isCanonical {
 			return nil, beaconhttp.NewEndpointError(http.StatusNotFound, errors.New("non-canonical finalized block not found"))
 		}
-		epochData, err := state_accessors.ReadEpochData(tx, blk.Block.Slot)
+		epochData, err := state_accessors.ReadEpochData(tx, a.beaconChainCfg.RoundSlotToEpoch(blk.Block.Slot))
 		if err != nil {
 			return nil, err
 		}

--- a/cl/beacon/handler/rewards.go
+++ b/cl/beacon/handler/rewards.go
@@ -165,7 +165,7 @@ func (a *ApiHandler) PostEthV1BeaconRewardsSyncCommittees(w http.ResponseWriter,
 		syncCommittee      *solid.SyncCommittee
 		totalActiveBalance uint64
 	)
-	if isFinalized {
+	if slot < a.forkchoiceStore.LowestAvailableSlot() {
 		if !isCanonical {
 			return nil, beaconhttp.NewEndpointError(http.StatusNotFound, errors.New("non-canonical finalized block not found"))
 		}


### PR DESCRIPTION
Sync rewards are earned every slot, not just on epoch boundary.

The rewards don't change throughout an epoch, so it's correct, that for the calculation we need the epoch head, but rewards can still be individually lost/earned in a slot: e.g. the whole network can miss slots (proposer misses), or individual sync committee members can get negative rewards for being offline.