### PR TITLE
Generate Bor receipts

### DIFF
--- a/core/gen_bor.go
+++ b/core/gen_bor.go
@@ -1,0 +1,78 @@
+package core
+
+import (
+	"context"
+
+	"github.com/erigontech/erigon-lib/chain"
+	libcommon "github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/kv"
+	"github.com/erigontech/erigon-lib/kv/rawdbv3"
+	"github.com/erigontech/erigon/consensus"
+	"github.com/erigontech/erigon/core/state"
+	"github.com/erigontech/erigon/core/types"
+	"github.com/erigontech/erigon/core/vm"
+	"github.com/erigontech/erigon/core/vm/evmtypes"
+	bortypes "github.com/erigontech/erigon/polygon/bor/types"
+	"github.com/erigontech/erigon/turbo/services"
+	"github.com/erigontech/erigon/turbo/shards"
+)
+
+func GenerateBorReceipt(ctx context.Context, tx kv.Tx, block *types.Block, msgs []*types.Message, engine consensus.EngineReader, chainConfig *chain.Config, txNumsReader rawdbv3.TxNumsReader, headerReader services.HeaderReader, blockReceipts []*types.Receipt) (*types.Receipt, error) {
+	stateReader := state.NewHistoryReaderV3()
+	stateReader.SetTx(tx)
+	minTxNum, err := txNumsReader.Min(tx, block.NumberU64())
+	if err != nil {
+		return nil, err
+	}
+	stateReader.SetTxNum(uint64(int(minTxNum) + /* 1 system txNum in beginning of block */ 1))
+	stateCache := shards.NewStateCache(
+		32, 0 /* no limit */) // this cache living only during current RPC call, but required to store state writes
+	cachedReader := state.NewCachedReader(stateReader, stateCache)
+	ibs := state.New(cachedReader)
+
+	getHeader := func(hash libcommon.Hash, n uint64) *types.Header {
+		h, _ := headerReader.HeaderByNumber(ctx, tx, n)
+		return h
+	}
+
+	gp := new(GasPool).AddGas(msgs[0].Gas() * uint64(len(msgs))).AddBlobGas(msgs[0].BlobGas() * uint64(len(msgs)))
+	blockContext := NewEVMBlockContext(block.Header(), GetHashFn(block.Header(), getHeader), engine, nil, chainConfig)
+	evm := vm.NewEVM(blockContext, evmtypes.TxContext{}, ibs, chainConfig, vm.Config{})
+	return applyBorTransaction(msgs, evm, gp, ibs, block, blockReceipts)
+}
+
+func applyBorTransaction(msgs []*types.Message, evm *vm.EVM, gp *GasPool, ibs *state.IntraBlockState, block *types.Block, blockReceipts []*types.Receipt) (*types.Receipt, error) {
+	for _, msg := range msgs {
+		txContext := NewEVMTxContext(msg)
+		evm.Reset(txContext, ibs)
+
+		_, err := ApplyMessage(evm, msg, gp, true /* refunds */, false /* gasBailout */)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	numReceipts := len(blockReceipts)
+	lastReceipt := &types.Receipt{
+		CumulativeGasUsed: 0,
+		GasUsed:           0,
+	}
+	if numReceipts > 0 {
+		lastReceipt = blockReceipts[numReceipts-1]
+	}
+
+	receiptLogs := ibs.Logs()
+	receipt := types.Receipt{
+		Type:              0,
+		CumulativeGasUsed: lastReceipt.CumulativeGasUsed,
+		TxHash:            bortypes.ComputeBorTxHash(block.NumberU64(), block.Hash()),
+		ContractAddress:   *msgs[0].To(),
+		GasUsed:           lastReceipt.GasUsed,
+		BlockHash:         block.Hash(),
+		BlockNumber:       block.Number(),
+		TransactionIndex:  uint(numReceipts),
+		Logs:              receiptLogs,
+	}
+
+	return &receipt, nil
+}

--- a/core/rawdb/bor_receipts.go
+++ b/core/rawdb/bor_receipts.go
@@ -17,110 +17,23 @@
 package rawdb
 
 import (
-	"bytes"
-	"fmt"
+	"encoding/binary"
 	"math/big"
 
 	libcommon "github.com/erigontech/erigon-lib/common"
-	"github.com/erigontech/erigon-lib/common/hexutility"
 	"github.com/erigontech/erigon-lib/kv"
-	"github.com/erigontech/erigon-lib/kv/dbutils"
-	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/core/types"
-	"github.com/erigontech/erigon/ethdb/cbor"
 	bortypes "github.com/erigontech/erigon/polygon/bor/types"
-	"github.com/erigontech/erigon/rlp"
-)
-
-var (
-	// bor receipt key
-	borReceiptKey = bortypes.BorReceiptKey
 )
 
 // HasBorReceipts verifies the existence of all block receipt belonging to a block.
 func HasBorReceipts(db kv.Has, number uint64) bool {
-	if has, err := db.Has(kv.BorReceipts, borReceiptKey(number)); !has || err != nil {
+	k := make([]byte, 8)
+	binary.BigEndian.PutUint64(k, number)
+	if has, err := db.Has(kv.BorEventNums, k); !has || err != nil {
 		return false
 	}
 	return true
-}
-
-func ReadRawBorReceipt(db kv.Tx, number uint64) (*types.Receipt, bool, error) {
-	data, err := db.GetOne(kv.BorReceipts, borReceiptKey(number))
-	if err != nil {
-		return nil, false, fmt.Errorf("ReadBorReceipt failed getting bor receipt with blockNumber=%d, err=%s", number, err)
-	}
-	if len(data) == 0 {
-		return nil, false, nil
-	}
-
-	var borReceipt *types.Receipt
-	err = cbor.Unmarshal(&borReceipt, bytes.NewReader(data))
-	if err == nil {
-		return borReceipt, false, nil
-	}
-
-	// Convert the receipts from their storage form to their internal representation
-	var borStorageReceipt types.ReceiptForStorage
-	if err := rlp.DecodeBytes(data, &borStorageReceipt); err != nil {
-		log.Error("Invalid receipt array RLP", "err", err)
-		return nil, true, err
-	}
-
-	return (*types.Receipt)(&borStorageReceipt), true, nil
-}
-
-func ReadBorReceipt(db kv.Tx, blockHash libcommon.Hash, blockNumber uint64, receipts types.Receipts) (*types.Receipt, error) {
-	borReceipt, hasEmbeddedLogs, err := ReadRawBorReceipt(db, blockNumber)
-	if err != nil {
-		return nil, err
-	}
-
-	if borReceipt == nil {
-		return nil, nil
-	}
-
-	if !hasEmbeddedLogs {
-		logsData, err := db.GetOne(kv.Log, dbutils.LogKey(blockNumber, uint32(len(receipts))))
-		if err != nil {
-			return nil, fmt.Errorf("ReadBorReceipt failed getting bor logs with blockNumber=%d, err=%s", blockNumber, err)
-		}
-		if logsData != nil {
-			var logs types.Logs
-			if err = cbor.Unmarshal(&logs, bytes.NewReader(logsData)); err != nil {
-				return nil, fmt.Errorf("logs unmarshal failed:  %w", err)
-			}
-			borReceipt.Logs = logs
-		}
-	}
-
-	bortypes.DeriveFieldsForBorReceipt(borReceipt, blockHash, blockNumber, receipts)
-
-	return borReceipt, nil
-}
-
-// WriteBorReceipt stores all the bor receipt belonging to a block (storing the state sync receipt and log).
-func WriteBorReceipt(tx kv.RwTx, number uint64, borReceipt *types.Receipt) error {
-	// Convert the bor receipt into their storage form and serialize them
-	buf := bytes.NewBuffer(make([]byte, 0, 1024))
-	if err := cbor.Marshal(buf, borReceipt.Logs); err != nil {
-		return err
-	}
-	if err := tx.Append(kv.Log, dbutils.LogKey(number, uint32(borReceipt.TransactionIndex)), buf.Bytes()); err != nil {
-		return err
-	}
-
-	buf.Reset()
-	err := cbor.Marshal(buf, borReceipt)
-	if err != nil {
-		return err
-	}
-	// Store the flattened receipt slice
-	if err := tx.Append(kv.BorReceipts, borReceiptKey(number), buf.Bytes()); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func ReadBorTxLookupEntry(db kv.Getter, borTxHash libcommon.Hash) (*uint64, error) {
@@ -143,14 +56,4 @@ func ReadBorTransactionForBlock(db kv.Tx, blockNum uint64) types.Transaction {
 		return nil
 	}
 	return bortypes.NewBorTransaction()
-}
-
-// TruncateBorReceipts removes all bor receipt for given block number or newer
-func TruncateBorReceipts(db kv.RwTx, number uint64) error {
-	if err := db.ForEach(kv.BorReceipts, hexutility.EncodeTs(number), func(k, _ []byte) error {
-		return db.Delete(kv.BorReceipts, k)
-	}); err != nil {
-		return err
-	}
-	return nil
 }

--- a/core/rawdb/bor_receipts.go
+++ b/core/rawdb/bor_receipts.go
@@ -21,12 +21,11 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/erigontech/erigon-lib/log/v3"
-
 	libcommon "github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/hexutility"
 	"github.com/erigontech/erigon-lib/kv"
 	"github.com/erigontech/erigon-lib/kv/dbutils"
+	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/core/types"
 	"github.com/erigontech/erigon/ethdb/cbor"
 	bortypes "github.com/erigontech/erigon/polygon/bor/types"

--- a/core/rawdb/rawdbreset/reset_stages.go
+++ b/core/rawdb/rawdbreset/reset_stages.go
@@ -193,8 +193,8 @@ var Tables = map[stages.SyncStage][]string{
 	stages.Finish: {},
 }
 var stateBuckets = []string{
-	kv.Epoch, kv.PendingEpoch, kv.BorReceipts,
-	kv.Code, kv.PlainContractCode, kv.ContractCode, kv.IncarnationMap,
+	kv.Epoch, kv.PendingEpoch, kv.Code,
+	kv.PlainContractCode, kv.ContractCode, kv.IncarnationMap,
 }
 var stateHistoryBuckets = []string{
 	kv.Receipts,

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -21,6 +21,7 @@ package types
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -484,6 +485,9 @@ func (r *Receipt) DeriveFieldsV3ForSingleReceipt(txnIdx int, blockHash libcommon
 
 // TODO: maybe make it more prettier (only for debug purposes)
 func (r *Receipt) String() string {
-	str := fmt.Sprintf("Receipt of tx %+v", *r)
-	return str
+	j, err := json.Marshal(r)
+	if err != nil {
+		return fmt.Sprintf("Error during JSON marshalling, receipt: %v", *r)
+	}
+	return string(j)
 }

--- a/erigon-lib/kv/tables.go
+++ b/erigon-lib/kv/tables.go
@@ -331,7 +331,6 @@ const (
 	PendingEpoch = "DevPendingEpoch" // block_num_u64+block_hash->transition_proof
 
 	// BOR
-	BorReceipts             = "BorReceipt"
 	BorFinality             = "BorFinality"
 	BorTxLookup             = "BlockBorTransactionLookup" // transaction_hash -> block_num_u64
 	BorSeparate             = "BorSeparate"               // persisted snapshots of the Validator Sets, with their proposer priorities
@@ -537,7 +536,6 @@ var ChaindataTables = []string{
 	HeaderTD,
 	Epoch,
 	PendingEpoch,
-	BorReceipts,
 	BorFinality,
 	BorTxLookup,
 	BorSeparate,
@@ -749,7 +747,6 @@ var ChaindataTablesCfg = TableCfg{
 }
 
 var BorTablesCfg = TableCfg{
-	BorReceipts:             {Flags: DupSort},
 	BorFinality:             {Flags: DupSort},
 	BorTxLookup:             {Flags: DupSort},
 	BorEvents:               {Flags: DupSort},

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -23,8 +23,9 @@ import (
 	"time"
 
 	"github.com/c2h5oh/datasize"
-	"github.com/erigontech/erigon/cmd/state/exec3"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/erigontech/erigon/cmd/state/exec3"
 
 	"github.com/erigontech/erigon-lib/chain"
 	"github.com/erigontech/erigon-lib/common"
@@ -216,9 +217,6 @@ func unwindExec3(u *UnwindState, s *StageState, txc wrap.TxContainer, ctx contex
 	}
 	if err := rs.Unwind(ctx, txc.Tx, u.UnwindPoint, txNum, accumulator, changeset); err != nil {
 		return fmt.Errorf("StateV3.Unwind(%d->%d): %w, took %s", s.BlockNumber, u.UnwindPoint, err, time.Since(t))
-	}
-	if err := rawdb.TruncateBorReceipts(txc.Tx, u.UnwindPoint+1); err != nil {
-		return fmt.Errorf("truncate bor receipts: %w", err)
 	}
 	if err := rawdb.DeleteNewerEpochs(txc.Tx, u.UnwindPoint+1); err != nil {
 		return fmt.Errorf("delete newer epochs: %w", err)

--- a/polygon/tracer/trace_bor_state_sync_txn.go
+++ b/polygon/tracer/trace_bor_state_sync_txn.go
@@ -93,7 +93,7 @@ func TraceBorStateSyncTxnTraceAPI(
 	blockNum uint64,
 	blockTime uint64,
 ) (*evmtypes.ExecutionResult, error) {
-	stateSyncEvents, err := blockReader.EventsByBlock(ctx, dbTx, blockHash, blockNum)
+	stateSyncEvents, err := blockReader.EventsByBlock(ctx, dbTx, blockHash, blockNum) // TODO: use bridge reader here
 	if err != nil {
 		return nil, err
 	}

--- a/turbo/jsonrpc/eth_receipts.go
+++ b/turbo/jsonrpc/eth_receipts.go
@@ -21,8 +21,12 @@ import (
 	"fmt"
 
 	"github.com/RoaringBitmap/roaring"
+
 	"github.com/erigontech/erigon-lib/log/v3"
+	"github.com/erigontech/erigon/common/u256"
+	"github.com/erigontech/erigon/core"
 	"github.com/erigontech/erigon/core/rawdb/rawtemporaldb"
+	"github.com/erigontech/erigon/core/state"
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/kv"
@@ -32,7 +36,6 @@ import (
 	"github.com/erigontech/erigon-lib/kv/stream"
 
 	"github.com/erigontech/erigon/cmd/state/exec3"
-	"github.com/erigontech/erigon/core/rawdb"
 	"github.com/erigontech/erigon/core/types"
 	"github.com/erigontech/erigon/eth/ethutils"
 	"github.com/erigontech/erigon/eth/filters"
@@ -416,12 +419,12 @@ func (api *APIImpl) GetTransactionReceipt(ctx context.Context, txnHash common.Ha
 		return nil, err
 	}
 
-	cc, err := api.chainConfig(ctx, tx)
+	chainConfig, err := api.chainConfig(ctx, tx)
 	if err != nil {
 		return nil, err
 	}
 	// Private API returns 0 if transaction is not found.
-	if blockNum == 0 && cc.Bor != nil {
+	if blockNum == 0 && chainConfig.Bor != nil {
 		if api.bridgeReader != nil {
 			blockNum, ok, err = api.bridgeReader.EventTxnLookup(ctx, txnHash)
 		} else {
@@ -454,34 +457,62 @@ func (api *APIImpl) GetTransactionReceipt(ctx context.Context, txnHash common.Ha
 		}
 	}
 
-	var borTx types.Transaction
-	if txn == nil && cc.Bor != nil {
-		borTx = rawdb.ReadBorTransactionForBlock(tx, blockNum)
-		if borTx == nil {
-			borTx = bortypes.NewBorTransaction()
-		}
-	}
 	receipts, err := api.getReceipts(ctx, tx, block)
 	if err != nil {
 		return nil, fmt.Errorf("getReceipts error: %w", err)
 	}
 
-	if txn == nil && cc.Bor != nil {
-		borReceipt, err := rawdb.ReadBorReceipt(tx, block.Hash(), blockNum, receipts)
+	if txn == nil && chainConfig.Bor != nil {
+		var events []*types.Message
+		if api.bridgeReader != nil {
+			events, err = api.bridgeReader.Events(ctx, blockNum)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			rawEvents, err := api._blockReader.EventsByBlock(ctx, tx, block.Hash(), blockNum)
+			if err != nil {
+				return nil, err
+			}
+
+			msgs := make([]*types.Message, 0, len(rawEvents))
+			to := common.HexToAddress(chainConfig.Bor.GetStateReceiverContract())
+			for i, event := range rawEvents {
+				msg := types.NewMessage(
+					state.SystemAddress,
+					&to,
+					0, u256.Num0,
+					core.SysCallGasLimit,
+					u256.Num0,
+					nil, nil,
+					event, nil, false,
+					true, // isFree
+					nil,  // maxFeePerBlobGas
+				)
+				msgs[i] = &msg
+			}
+
+			events = msgs
+		}
+
+		if len(events) == 0 {
+			return nil, fmt.Errorf("tx not found")
+		}
+
+		txNumsReader := rawdbv3.TxNums.WithCustomReadTxNumFunc(freezeblocks.ReadTxNumFuncFromBlockReader(ctx, api._blockReader))
+		borReceipt, err := core.GenerateBorReceipt(ctx, tx, block, events, api.engine(), chainConfig, txNumsReader, api._blockReader, receipts)
 		if err != nil {
 			return nil, err
 		}
-		if borReceipt == nil {
-			return nil, nil
-		}
-		return ethutils.MarshalReceipt(borReceipt, borTx, cc, block.HeaderNoCopy(), txnHash, false), nil
+
+		return ethutils.MarshalReceipt(borReceipt, bortypes.NewBorTransaction(), chainConfig, block.HeaderNoCopy(), txnHash, false), nil
 	}
 
 	if len(receipts) <= int(txnIndex) {
 		return nil, fmt.Errorf("block has less receipts than expected: %d <= %d, block: %d", len(receipts), int(txnIndex), blockNum)
 	}
 
-	return ethutils.MarshalReceipt(receipts[txnIndex], block.Transactions()[txnIndex], cc, block.HeaderNoCopy(), txnHash, true), nil
+	return ethutils.MarshalReceipt(receipts[txnIndex], block.Transactions()[txnIndex], chainConfig, block.HeaderNoCopy(), txnHash, true), nil
 }
 
 // GetBlockReceipts - receipts for individual block
@@ -518,15 +549,46 @@ func (api *APIImpl) GetBlockReceipts(ctx context.Context, numberOrHash rpc.Block
 	}
 
 	if chainConfig.Bor != nil {
-		borTx := rawdb.ReadBorTransactionForBlock(tx, blockNum)
-		if borTx != nil {
-			borReceipt, err := rawdb.ReadBorReceipt(tx, block.Hash(), blockNum, receipts)
+		var events []*types.Message
+		if api.bridgeReader != nil {
+			events, err = api.bridgeReader.Events(ctx, blockNum)
 			if err != nil {
 				return nil, err
 			}
-			if borReceipt != nil {
-				result = append(result, ethutils.MarshalReceipt(borReceipt, borTx, chainConfig, block.HeaderNoCopy(), borReceipt.TxHash, false))
+		} else {
+			rawEvents, err := api._blockReader.EventsByBlock(ctx, tx, block.Hash(), blockNum)
+			if err != nil {
+				return nil, err
 			}
+
+			msgs := make([]*types.Message, 0, len(rawEvents))
+			to := common.HexToAddress(chainConfig.Bor.GetStateReceiverContract())
+			for i, event := range rawEvents {
+				msg := types.NewMessage(
+					state.SystemAddress,
+					&to,
+					0, u256.Num0,
+					core.SysCallGasLimit,
+					u256.Num0,
+					nil, nil,
+					event, nil, false,
+					true, // isFree
+					nil,  // maxFeePerBlobGas
+				)
+				msgs[i] = &msg
+			}
+
+			events = msgs
+		}
+
+		if len(events) != 0 {
+			txNumsReader := rawdbv3.TxNums.WithCustomReadTxNumFunc(freezeblocks.ReadTxNumFuncFromBlockReader(ctx, api._blockReader))
+			borReceipt, err := core.GenerateBorReceipt(ctx, tx, block, events, api.engine(), chainConfig, txNumsReader, api._blockReader, receipts)
+			if err != nil {
+				return nil, err
+			}
+
+			result = append(result, ethutils.MarshalReceipt(borReceipt, bortypes.NewBorTransaction(), chainConfig, block.HeaderNoCopy(), borReceipt.TxHash, false))
 		}
 	}
 

--- a/turbo/jsonrpc/receipts/receipts_generator.go
+++ b/turbo/jsonrpc/receipts/receipts_generator.go
@@ -20,6 +20,10 @@ import (
 	"github.com/erigontech/erigon/turbo/transactions"
 )
 
+type bridgeReader interface {
+	Events(ctx context.Context, blockNum uint64) ([]*types.Message, error)
+}
+
 type Generator struct {
 	receiptsCache *lru.Cache[common.Hash, []*types.Receipt]
 	blockReader   services.FullBlockReader

--- a/turbo/jsonrpc/receipts/receipts_generator.go
+++ b/turbo/jsonrpc/receipts/receipts_generator.go
@@ -20,10 +20,6 @@ import (
 	"github.com/erigontech/erigon/turbo/transactions"
 )
 
-type bridgeReader interface {
-	Events(ctx context.Context, blockNum uint64) ([]*types.Message, error)
-}
-
 type Generator struct {
 	receiptsCache *lru.Cache[common.Hash, []*types.Receipt]
 	blockReader   services.FullBlockReader


### PR DESCRIPTION
1. kv.BorReceipts was unpopulated, but was still being relied on at various parts of the codebase. This caused discrepancies in various RPCs such as `eth_getBlockByNumber` that would not show the synthetic Bor transaction

2. Since we do not store receipts in E3, new code is added to generate the Bor receipts during RPC requests.