### PR TITLE
Fix sync_committee rewards to return no data on non-participation

### DIFF
--- a/cl/beacon/handler/rewards.go
+++ b/cl/beacon/handler/rewards.go
@@ -206,9 +206,6 @@ func (a *ApiHandler) PostEthV1BeaconRewardsSyncCommittees(w http.ResponseWriter,
 	}
 	// validator index -> accumulated rewards
 	accumulatedRewards := map[uint64]int64{}
-	for _, idx := range filterIndicies {
-		accumulatedRewards[idx] = 0
-	}
 	participantReward := int64(a.syncParticipantReward(totalActiveBalance))
 
 	for committeeIdx, v := range committee {


### PR DESCRIPTION
The Beacon API specs say (rather not clearly, but still), that on non-participation of a validator in an epoch, no data should be returned.

See https://github.com/ethereum/beacon-APIs/issues/480