### PR TITLE
qa-tests: Gnosis Tip-Tracking Test - use v2 pre-built database on release/2.60

### DIFF
--- a/.github/workflows/qa-tip-tracking-gnosis.yml
+++ b/.github/workflows/qa-tip-tracking-gnosis.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: [self-hosted, Gnosis]
     timeout-minutes: 600
     env:
-      ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version/datadir
+      ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version-2/datadir
       ERIGON_TESTBED_DATA_DIR: /opt/erigon-testbed/datadir
       ERIGON_QA_PATH: /home/qarunner/erigon-qa
       TRACKING_TIME_SECONDS: 14400 # 4 hours


### PR DESCRIPTION
Having started testing Erigon v.3 on Gnosis, it is necessary to distinguish between the pre-build database of v.2 and v.3 on the test runner.