### PR TITLE
Add dirty lock to recalc visible segments

### DIFF
--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -597,6 +597,9 @@ func (s *RoSnapshots) recalcVisibleFiles() {
 	s.visibleSegmentsLock.Lock()
 	defer s.visibleSegmentsLock.Unlock()
 
+	s.dirtySegmentsLock.RLock()
+	defer s.dirtySegmentsLock.RUnlock()
+
 	var maxVisibleBlocks []uint64
 	s.segments.Scan(func(segtype snaptype.Enum, value *segments) bool {
 		dirtySegments := value.DirtySegments


### PR DESCRIPTION
This change adds a dirty segments read lock to 

```
(s *RoSnapshots) recalcVisibleFiles
```

To make sure that visible segments contains an atomic set of dirty segment references not interleaved with the file recalculation process.