### PR TITLE
filter logs from rawdb

### DIFF
--- a/turbo/jsonrpc/eth_receipts.go
+++ b/turbo/jsonrpc/eth_receipts.go
@@ -335,7 +335,7 @@ func (api *BaseAPI) getLogsV3(ctx context.Context, tx kv.TemporalTx, begin, end 
 				log.TxHash = txn.Hash()
 			}
 		} else {
-			filtered = r.Logs
+			filtered = r.Logs.Filter(addrMap, crit.Topics, 0)
 		}
 
 		for _, filteredLog := range filtered {


### PR DESCRIPTION
Fix `eth_getLog` call log filtering in case when receipts are read from rawdb.