### PR TITLE
Add early return in `ComputeTxEnv` for state sync transactions

### DIFF
--- a/turbo/transactions/tracing.go
+++ b/turbo/transactions/tracing.go
@@ -45,9 +45,6 @@ func ComputeTxEnv(ctx context.Context, engine consensus.EngineReader, block *typ
 	// Create the parent state database
 	statedb := state.New(reader)
 
-	if txIndex == 0 && len(block.Transactions()) == 0 {
-		return nil, evmtypes.BlockContext{}, evmtypes.TxContext{}, statedb, reader, nil
-	}
 	getHeader := func(hash libcommon.Hash, n uint64) *types.Header {
 		h, _ := headerReader.HeaderByNumber(ctx, dbtx, n)
 		return h
@@ -55,6 +52,11 @@ func ComputeTxEnv(ctx context.Context, engine consensus.EngineReader, block *typ
 	header := block.HeaderNoCopy()
 
 	blockContext := core.NewEVMBlockContext(header, core.GetHashFn(header, getHeader), engine, nil)
+
+	if txIndex == len(block.Transactions()) {
+		// tx is a state sync transaction
+		return nil, blockContext, evmtypes.TxContext{}, statedb, nil, nil
+	}
 
 	// Recompute transactions up to the target index.
 	signer := types.MakeSigner(cfg, block.NumberU64(), block.Time())


### PR DESCRIPTION
`ComputeTxEnv` relied on `txIndex < len(block.Transactions())` which is violated by Polygon's state sync event transaction. We handle this case by adding an early return for this case, returning only ibs and blockContext which is used during state sync event tracing.

Fixes #11701, #12007