### PR TITLE
borcfg: GetStateReceiverContract returns common.Address

### DIFF
--- a/erigon-lib/chain/chain_config.go
+++ b/erigon-lib/chain/chain_config.go
@@ -98,7 +98,7 @@ type BorConfig interface {
 	IsNapoli(num uint64) bool
 	GetNapoliBlock() *big.Int
 	IsAhmedabad(number uint64) bool
-	GetStateReceiverContract() string
+	GetStateReceiverContract() common.Address
 	CalculateSprintNumber(number uint64) uint64
 }
 

--- a/eth/ethconsensusconfig/config.go
+++ b/eth/ethconsensusconfig/config.go
@@ -118,7 +118,7 @@ func CreateConsensusEngine(ctx context.Context, nodeConfig *nodecfg.Config, chai
 		// In order to pass the ethereum transaction tests, we need to set the burn contract which is in the bor config
 		// Then, bor != nil will also be enabled for ethash and clique. Only enable Bor for real if there is a validator contract present.
 		if chainConfig.Bor != nil && consensusCfg.ValidatorContract != "" {
-			stateReceiver := bor.NewStateReceiver(consensusCfg.StateReceiverContract)
+			stateReceiver := bor.NewStateReceiver(consensusCfg.GetStateReceiverContract())
 			spanner := bor.NewChainSpanner(borabi.ValidatorSetContractABI(), chainConfig, withoutHeimdall, logger)
 
 			var err error

--- a/eth/stagedsync/stagedsynctest/harness.go
+++ b/eth/stagedsync/stagedsynctest/harness.go
@@ -491,7 +491,7 @@ func (h *Harness) seal(t *testing.T, chr consensus.ChainHeaderReader, eng consen
 
 func (h *Harness) consensusEngine(t *testing.T, cfg HarnessCfg) consensus.Engine {
 	if h.chainConfig.Bor != nil {
-		stateReceiver := bor.NewStateReceiver(h.borConfig.StateReceiverContract)
+		stateReceiver := bor.NewStateReceiver(h.borConfig.GetStateReceiverContract())
 		borConsensusEng := bor.New(
 			h.chainConfig,
 			h.borConsensusDB,

--- a/polygon/bor/borcfg/bor_config.go
+++ b/polygon/bor/borcfg/bor_config.go
@@ -167,8 +167,8 @@ func (c *BorConfig) CalculateStateSyncDelay(number uint64) uint64 {
 	return borKeyValueConfigHelper(c.StateSyncConfirmationDelay, number)
 }
 
-func (c *BorConfig) GetStateReceiverContract() string {
-	return c.StateReceiverContract
+func (c *BorConfig) GetStateReceiverContract() common.Address {
+	return common.HexToAddress(c.StateReceiverContract)
 }
 
 func borKeyValueConfigHelper[T uint64 | common.Address](field map[string]T, number uint64) T {

--- a/polygon/bor/state_receiver.go
+++ b/polygon/bor/state_receiver.go
@@ -31,9 +31,9 @@ type ChainStateReceiver struct {
 	contractAddress libcommon.Address
 }
 
-func NewStateReceiver(contractAddress string) *ChainStateReceiver {
+func NewStateReceiver(contractAddress libcommon.Address) *ChainStateReceiver {
 	return &ChainStateReceiver{
-		contractAddress: libcommon.HexToAddress(contractAddress),
+		contractAddress: contractAddress,
 	}
 }
 

--- a/polygon/bridge/bridge.go
+++ b/polygon/bridge/bridge.go
@@ -52,7 +52,7 @@ type Config struct {
 func Assemble(config Config) *Bridge {
 	bridgeDB := polygoncommon.NewDatabase(config.DataDir, kv.PolygonBridgeDB, databaseTablesCfg, config.Logger, false /* accede */, config.RoTxLimit)
 	bridgeStore := NewStore(bridgeDB)
-	reader := NewReader(bridgeStore, config.Logger, config.BorConfig.StateReceiverContract)
+	reader := NewReader(bridgeStore, config.Logger, config.BorConfig.GetStateReceiverContract())
 	return NewBridge(bridgeStore, config.Logger, config.BorConfig, config.EventFetcher, reader)
 }
 
@@ -68,7 +68,7 @@ func NewBridge(store Store, logger log.Logger, borConfig *borcfg.BorConfig, even
 		logger:                       logger,
 		borConfig:                    borConfig,
 		eventFetcher:                 eventFetcher,
-		stateReceiverContractAddress: libcommon.HexToAddress(borConfig.StateReceiverContract),
+		stateReceiverContractAddress: borConfig.GetStateReceiverContract(),
 		reader:                       reader,
 		transientErrors:              transientErrors,
 		fetchedEventsSignal:          make(chan struct{}),

--- a/polygon/bridge/reader.go
+++ b/polygon/bridge/reader.go
@@ -30,7 +30,7 @@ type ReaderConfig struct {
 	Ctx                          context.Context
 	DataDir                      string
 	Logger                       log.Logger
-	StateReceiverContractAddress string
+	StateReceiverContractAddress libcommon.Address
 	RoTxLimit                    int64
 }
 
@@ -46,11 +46,11 @@ func AssembleReader(config ReaderConfig) (*Reader, error) {
 	return NewReader(bridgeStore, config.Logger, config.StateReceiverContractAddress), nil
 }
 
-func NewReader(store Store, logger log.Logger, stateReceiverContractAddress string) *Reader {
+func NewReader(store Store, logger log.Logger, stateReceiverContractAddress libcommon.Address) *Reader {
 	return &Reader{
 		store:              store,
 		logger:             logger,
-		stateClientAddress: libcommon.HexToAddress(stateReceiverContractAddress),
+		stateClientAddress: stateReceiverContractAddress,
 	}
 }
 

--- a/polygon/tracer/trace_bor_state_sync_txn.go
+++ b/polygon/tracer/trace_bor_state_sync_txn.go
@@ -69,7 +69,7 @@ func TraceBorStateSyncTxnDebugAPI(
 	}
 
 	defer cancel()
-	stateReceiverContract := libcommon.HexToAddress(chainConfig.Bor.(*borcfg.BorConfig).StateReceiverContract)
+	stateReceiverContract := chainConfig.Bor.(*borcfg.BorConfig).GetStateReceiverContract()
 	tracer = NewBorStateSyncTxnTracer(tracer, len(stateSyncEvents), stateReceiverContract)
 	rules := chainConfig.Rules(blockNum, blockTime)
 	stateWriter := state.NewNoopWriter()
@@ -98,7 +98,7 @@ func TraceBorStateSyncTxnTraceAPI(
 		return nil, err
 	}
 
-	stateReceiverContract := libcommon.HexToAddress(chainConfig.Bor.(*borcfg.BorConfig).StateReceiverContract)
+	stateReceiverContract := chainConfig.Bor.(*borcfg.BorConfig).GetStateReceiverContract()
 	if vmConfig.Tracer != nil {
 		vmConfig.Tracer = NewBorStateSyncTxnTracer(vmConfig.Tracer, len(stateSyncEvents), stateReceiverContract)
 	}


### PR DESCRIPTION
All usages so far were converting the string to an address. The string is still directly accessible via the variable. 