### PR TITLE
qa-tests: reschedule constrained-tip-tracking

### DIFF
--- a/.github/workflows/qa-constrained-tip-tracking.yml
+++ b/.github/workflows/qa-constrained-tip-tracking.yml
@@ -2,7 +2,7 @@ name: QA - Constrained Tip tracking
 
 on:
   schedule:
-    - cron: '0 0 * * 1-6'  # Run every night at 00:00 AM UTC except Sunday
+    - cron: '0 0 * * 0'  # Run on Sunday at 00:00 AM UTC
   workflow_dispatch:     # Run manually
   pull_request:
     branches:


### PR DESCRIPTION
Performing this test every day is too expensive, other more important tests are blocked, it is rescheduled so that it is performed only on Sunday.