### PR TITLE
qa-tests: enable ots_getTransactionBySenderAndNonce tests

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -191,8 +191,6 @@ jobs:
           trace_replayTransaction/test_23.tar,\
           trace_replayTransaction/test_24.json,\
           trace_replayTransaction/test_29.tar,\
-          ots_getTransactionBySenderAndNonce/test_05.json,\
-          ots_getTransactionBySenderAndNonce/test_11.json,\
           ots_searchTransactionsAfter/test_01.json,\
           ots_searchTransactionsAfter/test_03.json,\
           ots_searchTransactionsAfter/test_04.json,\


### PR DESCRIPTION
The PR https://github.com/erigontech/erigon/pull/12322 fixed the behavior of erigon relative to these tests so we re-enable them
