### PR TITLE
polygon/bridge: fix BorTxLookup encoding discrepancy

### DIFF
--- a/polygon/bridge/db.go
+++ b/polygon/bridge/db.go
@@ -22,6 +22,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math/big"
 	"time"
 
 	libcommon "github.com/erigontech/erigon-lib/common"
@@ -217,12 +218,9 @@ func (s *MdbxStore) PutEventTxnToBlockNum(ctx context.Context, eventTxnToBlockNu
 	}
 	defer tx.Rollback()
 
-	vByte := make([]byte, 8)
-
+	vBigNum := new(big.Int)
 	for k, v := range eventTxnToBlockNum {
-		binary.BigEndian.PutUint64(vByte, v)
-
-		err = tx.Put(kv.BorTxLookup, k.Bytes(), vByte)
+		err = tx.Put(kv.BorTxLookup, k.Bytes(), vBigNum.SetUint64(v).Bytes())
 		if err != nil {
 			return err
 		}
@@ -248,7 +246,7 @@ func (s *MdbxStore) EventTxnToBlockNum(ctx context.Context, borTxHash libcommon.
 		return blockNum, false, nil
 	}
 
-	blockNum = binary.BigEndian.Uint64(v)
+	blockNum = new(big.Int).SetBytes(v).Uint64()
 	return blockNum, true, nil
 }
 
@@ -474,7 +472,7 @@ func Unwind(tx kv.RwTx, blockNum uint64) error {
 	return UnwindEventTxnToBlockNum(tx, blockNum)
 }
 
-// UnwindEventProcessedBlocks deletes data in kv.BorEventProcessedBlocks.
+// UnwindBlockNumToEventID deletes data in kv.BorEventProcessedBlocks.
 // The blockNum parameter is exclusive, i.e. only data in the range (blockNum, last] is deleted.
 func UnwindBlockNumToEventID(tx kv.RwTx, blockNum uint64) error {
 	c, err := tx.RwCursor(kv.BorEventNums)
@@ -532,7 +530,7 @@ func UnwindEventProcessedBlocks(tx kv.RwTx, blockNum uint64) error {
 	return err
 }
 
-// UnwindEventProcessedBlocks deletes data in kv.BorTxLookup.
+// UnwindEventTxnToBlockNum deletes data in kv.BorTxLookup.
 // The blockNum parameter is exclusive, i.e. only data in the range (blockNum, last] is deleted.
 func UnwindEventTxnToBlockNum(tx kv.RwTx, blockNum uint64) error {
 	c, err := tx.RwCursor(kv.BorTxLookup)
@@ -541,11 +539,10 @@ func UnwindEventTxnToBlockNum(tx kv.RwTx, blockNum uint64) error {
 	}
 
 	defer c.Close()
-	blockNumBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(blockNumBytes, blockNum)
+	blockNumBig := new(big.Int)
 	var k, v []byte
 	for k, v, err = c.Last(); err == nil && k != nil; k, v, err = c.Prev() {
-		if currentBlockNum := binary.BigEndian.Uint64(v); currentBlockNum <= blockNum {
+		if currentBlockNum := blockNumBig.SetBytes(v).Uint64(); currentBlockNum <= blockNum {
 			break
 		}
 


### PR DESCRIPTION
```
EROR[10-16|01:26:00.055] Staged Sync                              err="runtime error: index out of range [7] with length 3, trace: [stageloop.go:202 panic.go:770 panic.go:114 binary.go:183 db.go:548 db.go:474 stage_polygon_sync.go:1306 stage_polygon_sync.go:1816 stage_polygon_sync.go:578 stage_polygon_sync.g
o:196 default_stages.go:479 sync.go:531 sync.go:410 stageloop.go:249 stageloop.go:101 asm_arm64.s:1222]"
```

Fixes an index out of range found while running Astrid stage integration. The problem was due to encoding mismatch in the BorTxLookup table. The current code uses big.Int byte encoding for storing the block number, while the Astrid Bridge assumed binary.BigEndian.Uint64 encoding.

This PR fixes the runtime error and brings the 2 implementations in sync by keeping the new one backward compatible.