### PR TITLE
Dont reopen idx with refs

### DIFF
--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -354,6 +354,10 @@ func (s *DirtySegment) reopenIdxIfNeed(dir string, optimistic bool) (err error) 
 }
 
 func (s *DirtySegment) reopenIdx(dir string) (err error) {
+	if s.refcount.Load() == 0 {
+		return nil
+	}
+
 	s.closeIdx()
 	if s.Decompressor == nil {
 		return nil

--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -354,7 +354,7 @@ func (s *DirtySegment) reopenIdxIfNeed(dir string, optimistic bool) (err error) 
 }
 
 func (s *DirtySegment) reopenIdx(dir string) (err error) {
-	if s.refcount.Load() == 0 {
+	if s.refcount.Load() > 0 {
 		return nil
 	}
 


### PR DESCRIPTION
It looks like the closeIdx function here will close indexes while they are referenced by transactions.

This adds a check to stop that.