### PR TITLE
astrid: fix ReportBadHeaderPoS nil ptr in standalone

### DIFF
--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -30,9 +30,10 @@ import (
 	"time"
 
 	"github.com/c2h5oh/datasize"
-	"github.com/erigontech/erigon/core/rawdb/rawtemporaldb"
 	"github.com/erigontech/mdbx-go/mdbx"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/erigontech/erigon/core/rawdb/rawtemporaldb"
 
 	"github.com/erigontech/erigon-lib/chain"
 	"github.com/erigontech/erigon-lib/common"
@@ -912,7 +913,7 @@ Loop:
 					return err
 				}
 				logger.Warn(fmt.Sprintf("[%s] Execution failed", execStage.LogPrefix()), "block", blockNum, "txNum", txTask.TxNum, "hash", header.Hash().String(), "err", err)
-				if cfg.hd != nil && errors.Is(err, consensus.ErrInvalidBlock) {
+				if cfg.hd != nil && cfg.hd.POSSync() && errors.Is(err, consensus.ErrInvalidBlock) {
 					cfg.hd.ReportBadHeaderPoS(header.Hash(), header.ParentHash)
 				}
 				if cfg.badBlockHalt {
@@ -1226,7 +1227,7 @@ func flushAndCheckCommitmentV3(ctx context.Context, header *types.Header, applyT
 	if cfg.badBlockHalt {
 		return false, errors.New("wrong trie root")
 	}
-	if cfg.hd != nil {
+	if cfg.hd != nil && cfg.hd.POSSync() {
 		cfg.hd.ReportBadHeaderPoS(header.Hash(), header.ParentHash)
 	}
 	minBlockNum := e.BlockNumber

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -63,6 +63,7 @@ const (
 
 type headerDownloader interface {
 	ReportBadHeaderPoS(badHeader, lastValidAncestor common.Hash)
+	POSSync() bool
 }
 
 type ExecuteBlockCfg struct {

--- a/eth/stagedsync/stage_senders.go
+++ b/eth/stagedsync/stage_senders.go
@@ -282,7 +282,7 @@ Loop:
 			return minBlockErr
 		}
 		minHeader := rawdb.ReadHeader(tx, minBlockHash, minBlockNum)
-		if cfg.hd != nil && errors.Is(minBlockErr, consensus.ErrInvalidBlock) {
+		if cfg.hd != nil && cfg.hd.POSSync() && errors.Is(minBlockErr, consensus.ErrInvalidBlock) {
 			cfg.hd.ReportBadHeaderPoS(minBlockHash, minHeader.ParentHash)
 		}
 


### PR DESCRIPTION
Run into below error when running Astrid standalone. Handling blocks in Astrid is done by the driver, so we should not be calling ReportBadHeaderPoS in execution when run outside of Astrid. Additionally, ReportBadHeaderPoS should currently only be called for Ethereum-based PoS chains.

```
[INFO] [10-16|14:34:46.953] [4/6 Execution] Done                     blk=4540047 blks=4895 blk/s=1091.2 txs=10820 tx/s=2.41k gas/s=47.01M buf=566.5KB/512.0MB stepsInDB=0.00 step=5.9 alloc=307.2MB sys=920.5MB
panic: assignment to entry in nil map

goroutine 862285 [running]:
github.com/erigontech/erigon/turbo/stages/headerdownload.(*HeaderDownload).ReportBadHeaderPoS(0xc000b46a00, {0x9d, 0x6f, 0x66, 0x23, 0x29, 0x7d, 0x90, 0x89, 0x20, ...}, ...)
github.com/erigontech/erigon/turbo/stages/headerdownload/header_algos.go:167 +0x87
github.com/erigontech/erigon/eth/stagedsync.ExecV3({_, _}, _, {_, _}, _, {{0x32f5f90, 0xc001a840a8}, 0x20000000, {0x1, ...}, ...}, ...)
github.com/erigontech/erigon/eth/stagedsync/exec3.go:916 +0x4e39
github.com/erigontech/erigon/eth/stagedsync.ExecBlockV3(_, {_, _}, {{_, _}, {_, _}, _}, _, {0x32de288, ...}, ...)
github.com/erigontech/erigon/eth/stagedsync/stage_execute.go:163 +0x20f
github.com/erigontech/erigon/eth/stagedsync.SpawnExecuteBlocksStage(_, {_, _}, {{_, _}, {_, _}, _}, _, {0x32de288, ...}, ...)
github.com/erigontech/erigon/eth/stagedsync/stage_execute.go:253 +0x10e
github.com/erigontech/erigon/eth/stagedsync.PipelineStages.func10(0x9?, 0x7fb39933fe18?, {0x32d7fe0?, 0xc000a08640?}, {{0x3316c90, 0xc00cbc6700}, {0x0, 0x0}, 0x0}, {0x32f4a08, ...})
github.com/erigontech/erigon/eth/stagedsync/default_stages.go:238 +0xee
github.com/erigontech/erigon/eth/stagedsync.(*Sync).runStage(0xc000a08640, 0xc001d53810, {0x32f5f90, 0xc001a840a8}, {{0x3316c90, 0xc00cbc6700}, {0x0, 0x0}, 0x0}, 0x1, ...)
github.com/erigontech/erigon/eth/stagedsync/sync.go:531 +0x190
github.com/erigontech/erigon/eth/stagedsync.(*Sync).Run(0xc000a08640, {0x32f5f90, 0xc001a840a8}, {{0x3316c90, 0xc00cbc6700}, {0x0, 0x0}, 0x0}, 0x73?, 0x0)
github.com/erigontech/erigon/eth/stagedsync/sync.go:410 +0x2ad
github.com/erigontech/erigon/turbo/execution/eth1.(*EthereumExecutionModule).updateForkChoice(0xc000a08780, {0x32de288, 0xc001d52190}, {0xb5, 0x5d, 0xb5, 0x42, 0x65, 0x2a, 0x58, ...}, ...)
github.com/erigontech/erigon/turbo/execution/eth1/forkchoice.go:439 +0x13e5
created by github.com/erigontech/erigon/turbo/execution/eth1.(*EthereumExecutionModule).UpdateForkChoice in goroutine 206
github.com/erigontech/erigon/turbo/execution/eth1/forkchoice.go:129 +0x316
```