### PR TITLE
Optionally disable fcu timer

### DIFF
--- a/polygon/sync/execution_client.go
+++ b/polygon/sync/execution_client.go
@@ -84,13 +84,12 @@ func (e *executionClient) InsertBlocks(ctx context.Context, blocks []*types.Bloc
 
 func (e *executionClient) UpdateForkChoice(ctx context.Context, tip *types.Header, finalizedHeader *types.Header) (common.Hash, error) {
 	tipHash := tip.Hash()
-	const timeout = 5 * time.Second
 
 	request := executionproto.ForkChoice{
 		HeadBlockHash:      gointerfaces.ConvertHashToH256(tipHash),
 		SafeBlockHash:      gointerfaces.ConvertHashToH256(tipHash),
 		FinalizedBlockHash: gointerfaces.ConvertHashToH256(finalizedHeader.Hash()),
-		Timeout:            uint64(timeout.Milliseconds()),
+		Timeout:            0,
 	}
 
 	response, err := e.client.UpdateForkChoice(ctx, &request)

--- a/turbo/execution/eth1/forkchoice.go
+++ b/turbo/execution/eth1/forkchoice.go
@@ -127,19 +127,24 @@ func (e *EthereumExecutionModule) UpdateForkChoice(ctx context.Context, req *exe
 
 	// So we wait at most the amount specified by req.Timeout before just sending out
 	go e.updateForkChoice(e.bacgroundCtx, blockHash, safeHash, finalizedHash, outcomeCh)
-	fcuTimer := time.NewTimer(time.Duration(req.Timeout) * time.Millisecond)
 
-	select {
-	case <-fcuTimer.C:
-		e.logger.Debug("treating forkChoiceUpdated as asynchronous as it is taking too long")
-		return &execution.ForkChoiceReceipt{
-			LatestValidHash: gointerfaces.ConvertHashToH256(common.Hash{}),
-			Status:          execution.ExecutionStatus_Busy,
-		}, nil
-	case outcome := <-outcomeCh:
-		return outcome.receipt, outcome.err
+	if req.Timeout > 0 {
+		fcuTimer := time.NewTimer(time.Duration(req.Timeout) * time.Millisecond)
+
+		select {
+		case <-fcuTimer.C:
+			e.logger.Debug("treating forkChoiceUpdated as asynchronous as it is taking too long")
+			return &execution.ForkChoiceReceipt{
+				LatestValidHash: gointerfaces.ConvertHashToH256(common.Hash{}),
+				Status:          execution.ExecutionStatus_Busy,
+			}, nil
+		case outcome := <-outcomeCh:
+			return outcome.receipt, outcome.err
+		}
 	}
 
+	outcome := <-outcomeCh
+	return outcome.receipt, outcome.err
 }
 
 func writeForkChoiceHashes(tx kv.RwTx, blockHash, safeHash, finalizedHash common.Hash) {


### PR DESCRIPTION
For internal users of the execution api allow the option of not timing out so they can wait indefinitely.

To avoid api changes this is signaled by passing a 0 timeout which is interpreted as wait forever rather than return immediately.

