### PR TITLE
qa-tests: change snap-download scheduling

### DIFF
--- a/.github/workflows/qa-snap-download.yml
+++ b/.github/workflows/qa-snap-download.yml
@@ -2,7 +2,7 @@ name: QA - Snapshot Download
 
 on:
   schedule:
-    - cron: '0 20 * * 1-6'  # Run every night at 20:00 (8:00 PM) UTC except Sunday
+    - cron: '0 22 * * 1-6'  # Run every night at 22:00 (10:00 PM) UTC except Sunday
   workflow_dispatch:     # Run manually
 
 jobs:

--- a/.github/workflows/qa-snap-download.yml
+++ b/.github/workflows/qa-snap-download.yml
@@ -2,7 +2,7 @@ name: QA - Snapshot Download
 
 on:
   schedule:
-    - cron: '0 0 * * 1-6'  # Run every night at 00:00 AM UTC except Sunday
+    - cron: '0 20 * * 1-6'  # Run every night at 20:00 (8:00 PM) UTC except Sunday
   workflow_dispatch:     # Run manually
 
 jobs:


### PR DESCRIPTION
Change snap-download test scheduling so as not to clash with the tip-tracking schedule