### PR TITLE
Fix ots_searchTransactions* rpc-tests

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -191,24 +191,6 @@ jobs:
           trace_replayTransaction/test_23.tar,\
           trace_replayTransaction/test_24.json,\
           trace_replayTransaction/test_29.tar,\
-          ots_searchTransactionsAfter/test_01.json,\
-          ots_searchTransactionsAfter/test_03.json,\
-          ots_searchTransactionsAfter/test_04.json,\
-          ots_searchTransactionsAfter/test_06.json,\
-          ots_searchTransactionsAfter/test_08.json,\
-          ots_searchTransactionsAfter/test_09.json,\
-          ots_searchTransactionsAfter/test_10.json,\
-          ots_searchTransactionsAfter/test_11.json,\
-          ots_searchTransactionsAfter/test_12.json,\
-          ots_searchTransactionsAfter/test_13.json,\
-          ots_searchTransactionsBefore/test_01.json,\
-          ots_searchTransactionsBefore/test_03.json,\
-          ots_searchTransactionsBefore/test_04.json,\
-          ots_searchTransactionsBefore/test_06.json,\
-          ots_searchTransactionsBefore/test_09.json,\
-          ots_searchTransactionsBefore/test_10.json,\
-          ots_searchTransactionsBefore/test_11.json,\
-          ots_searchTransactionsBefore/test_12.json,\
           admin_nodeInfo/test_01.json,\
           admin_peers/test_01.json,\
           erigon_nodeInfo/test_1.json,\
@@ -260,9 +242,7 @@ jobs:
           ots_getBlockTransactions/test_03.json,\
           ots_getBlockTransactions/test_04.json,\
           ots_getBlockTransactions/test_05.json,\
-          ots_searchTransactionsAfter/test_14.json,\
           ots_searchTransactionsBefore/test_13.json,\
-          ots_searchTransactionsBefore/test_14.json,\
           trace_call/test_05.json,\
           trace_call/test_07.json,\
           trace_call/test_12.json,\


### PR DESCRIPTION
fixes https://github.com/erigontech/erigon/issues/12248

This PR retrofits the receipts generator and remove lots of custom code in order to fix the tests.

However it should be noticed that the receipts generator currently replays the entire block and doesn't consume the receipts domain, i.e., eth_getTransactionReceipt still suffers from the same issue.

From our conversation on Discord, Illya is working on it, so let's wait for his work be finished and we can retrofit his optimizations if needed.

Also, I'm reenabling all `ots_searchTransactions*` rpc-tests, leaving only `ots_searchTransactionsBefore/test_13.json` out. From my analysis so far, that one is breaking because of another unrelated exception, so I need more time to debug separately.