### PR TITLE
turbo/jsonrpc: correction in fetching validatorByte in bor_snapshot.go

### DIFF
--- a/turbo/jsonrpc/bor_snapshot.go
+++ b/turbo/jsonrpc/bor_snapshot.go
@@ -526,7 +526,7 @@ func (s *Snapshot) apply(headers []*types.Header) (*Snapshot, error) {
 			if err := bor.ValidateHeaderExtraLength(header.Extra); err != nil {
 				return nil, err
 			}
-			validatorBytes := header.Extra[extraVanity : len(header.Extra)-extraSeal]
+			validatorBytes := bor.GetValidatorBytes(header, s.config)
 
 			// get validators from headers and use that for new validator set
 			newVals, _ := valset.ParseValidators(validatorBytes)


### PR DESCRIPTION
**Fix: Outdated validatorByte Method in apply Function**

The outdated validatorByte method in apply() (found in turbo/jsonrpc/bor_snapshot.go) caused the newVals array to remain empty. As a result, the validator's power was always set to 0, leading to incorrect RPC information.

This bug affected the following RPC calls:

- getSnapshot
- bor_getSnapshotProposerSequence

**Changes:**

- Fixed the logic within the apply() function to ensure newVals is populated correctly.
- Validators now retain their proper power, resulting in accurate responses for the affected RPC calls.

This fix ensures that the snapshot and proposer sequence information are reflected correctly in RPC outputs.