### PR TITLE
rpcdaemon: Add missing flag

### DIFF
--- a/turbo/jsonrpc/tracing.go
+++ b/turbo/jsonrpc/tracing.go
@@ -149,12 +149,6 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 		}
 
 		if isBorStateSyncTxn {
-			// recompute blockCtx
-			_, borBlockCtx, _, _, _, err := transactions.ComputeTxEnv(ctx, engine, block, chainConfig, api._blockReader, tx, idx, api.historyV3(tx), true)
-			if err != nil {
-				return err
-			}
-
 			err = polygontracer.TraceBorStateSyncTxnDebugAPI(
 				ctx,
 				tx,
@@ -165,7 +159,7 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 				block.Hash(),
 				block.NumberU64(),
 				block.Time(),
-				borBlockCtx,
+				blockCtx,
 				stream,
 				api.evmCallTimeout,
 			)

--- a/turbo/jsonrpc/tracing.go
+++ b/turbo/jsonrpc/tracing.go
@@ -84,16 +84,6 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 	}
 	engine := api.engine()
 
-	_, blockCtx, _, ibs, _, err := transactions.ComputeTxEnv(ctx, engine, block, chainConfig, api._blockReader, tx, 0, api.historyV3(tx), false)
-	if err != nil {
-		stream.WriteNil()
-		return err
-	}
-
-	signer := types.MakeSigner(chainConfig, block.NumberU64(), block.Time())
-	rules := chainConfig.Rules(block.NumberU64(), block.Time())
-	stream.WriteArrayStart()
-
 	txns := block.Transactions()
 	var borStateSyncTxn types.Transaction
 	if *config.BorTraceEnabled {
@@ -108,6 +98,16 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 			txns = append(txns, borStateSyncTxn)
 		}
 	}
+
+	_, blockCtx, _, ibs, _, err := transactions.ComputeTxEnv(ctx, engine, block, chainConfig, api._blockReader, tx, 0, api.historyV3(tx), borStateSyncTxn != nil)
+	if err != nil {
+		stream.WriteNil()
+		return err
+	}
+
+	signer := types.MakeSigner(chainConfig, block.NumberU64(), block.Time())
+	rules := chainConfig.Rules(block.NumberU64(), block.Time())
+	stream.WriteArrayStart()
 
 	for idx, txn := range txns {
 		isBorStateSyncTxn := borStateSyncTxn == txn
@@ -149,6 +149,12 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 		}
 
 		if isBorStateSyncTxn {
+			// recompute blockCtx
+			_, borBlockCtx, _, _, _, err := transactions.ComputeTxEnv(ctx, engine, block, chainConfig, api._blockReader, tx, idx, api.historyV3(tx), true)
+			if err != nil {
+				return err
+			}
+
 			err = polygontracer.TraceBorStateSyncTxnDebugAPI(
 				ctx,
 				tx,
@@ -159,7 +165,7 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 				block.Hash(),
 				block.NumberU64(),
 				block.Time(),
-				blockCtx,
+				borBlockCtx,
 				stream,
 				api.evmCallTimeout,
 			)

--- a/turbo/transactions/tracing.go
+++ b/turbo/transactions/tracing.go
@@ -127,7 +127,7 @@ func ComputeTxEnv(ctx context.Context, engine consensus.EngineReader, block *typ
 	}
 
 	if isBorStateSyncTxn && txIndex == len(block.Transactions()) {
-		// tx is a state sync transaction
+		// we can reach here if the block has 0 normal transactions but has state sync transactions
 		return nil, blockContext, evmtypes.TxContext{}, statedb, reader, nil
 	}
 


### PR DESCRIPTION
Following #12342, we were missing a check on `debug_traceBlockByNumber` for state sync events during `ComputeTxEnv`.