### PR TITLE
downloader: `.Completed()` method race fix

### DIFF
--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -2957,7 +2957,7 @@ func (d *Downloader) notifyCompleted(tName string, tHash *prototypes.H160) {
 	d.onTorrentComplete(tName, tHash)
 }
 
-func (d *Downloader) getCompletedTorrents() map[string]completedTorrentInfo {
+func (d *Downloader) CompletedTorrents() map[string]completedTorrentInfo {
 	d.lock.RLock()
 	defer d.lock.RUnlock()
 

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -2930,6 +2930,8 @@ func calculateTime(amountLeft, rate uint64) string {
 }
 
 func (d *Downloader) Completed() bool {
+	d.lock.RLock()
+	d.lock.RUnlock()
 	return d.stats.Completed
 }
 

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -2931,7 +2931,7 @@ func calculateTime(amountLeft, rate uint64) string {
 
 func (d *Downloader) Completed() bool {
 	d.lock.RLock()
-	d.lock.RUnlock()
+	defer d.lock.RUnlock()
 	return d.stats.Completed
 }
 

--- a/erigon-lib/downloader/downloader_grpc_server.go
+++ b/erigon-lib/downloader/downloader_grpc_server.go
@@ -160,8 +160,7 @@ func (s *GrpcServer) TorrentCompleted(req *proto_downloader.TorrentCompletedRequ
 	s.mu.Unlock()
 
 	//Notifying about all completed torrents to the new subscriber
-	cmp := s.d.getCompletedTorrents()
-	for _, cmpInfo := range cmp {
+	for _, cmpInfo := range s.d.CompletedTorrents() {
 		s.onTorrentComplete(cmpInfo.path, cmpInfo.hash)
 	}
 

--- a/erigon-lib/go.mod
+++ b/erigon-lib/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/stretchr/testify v1.9.0
 	github.com/tidwall/btree v1.6.0
-		go.uber.org/mock v0.5.0
+	go.uber.org/mock v0.5.0
 	golang.org/x/crypto v0.28.0
 	golang.org/x/exp v0.0.0-20231226003508-02704c960a9b
 	golang.org/x/sync v0.8.0


### PR DESCRIPTION
```
WARNING: DATA RACE
Read at 0x00c001bee46c by goroutine 599:
  github.com/erigontech/erigon-lib/downloader.(*Downloader).Completed()
      github.com/erigontech/erigon-lib@v0.0.0-00010101000000-000000000000/downloader/downloader.go:2933 +0x4b
  github.com/erigontech/erigon-lib/downloader.(*GrpcServer).Completed()
      github.com/erigontech/erigon-lib@v0.0.0-00010101000000-000000000000/downloader/downloader_grpc_server.go:153 +0x12
  github.com/erigontech/erigon-lib/direct.(*DownloaderClient).Completed()
      github.com/erigontech/erigon-lib@v0.0.0-00010101000000-000000000000/direct/downloader_client.go:53 +0x5b
  github.com/erigontech/erigon/turbo/snapshotsync.WaitForDownloader()
      github.com/erigontech/erigon/turbo/snapshotsync/snapshotsync.go:372 +0x133a
  github.com/erigontech/erigon/eth/stagedsync.DownloadAndIndexSnapshotsIfNeed()
      github.com/erigontech/erigon/eth/stagedsync/stage_snapshots.go:274 +0xead
  github.com/erigontech/erigon/eth/stagedsync.SpawnStageSnapshots()
      github.com/erigontech/erigon/eth/stagedsync/stage_snapshots.go:186 +0x1e5
  github.com/erigontech/erigon/eth/stagedsync.PipelineStages.func1()
      github.com/erigontech/erigon/eth/stagedsync/default_stages.go:199 +0x18f
  github.com/erigontech/erigon/eth/stagedsync.(*Sync).runStage()
      github.com/erigontech/erigon/eth/stagedsync/sync.go:531 +0x285
  github.com/erigontech/erigon/eth/stagedsync.(*Sync).Run()
      github.com/erigontech/erigon/eth/stagedsync/sync.go:410 +0x593
  github.com/erigontech/erigon/turbo/stages.ProcessFrozenBlocks()
      github.com/erigontech/erigon/turbo/stages/stageloop.go:149 +0x19a
  github.com/erigontech/erigon/turbo/execution/eth1.(*EthereumExecutionModule).Start()
      github.com/erigontech/erigon/turbo/execution/eth1/ethereum_execution.go:344 +0x1ab
  github.com/erigontech/erigon/eth.(*Ethereum).Start.gowrap1()
      github.com/erigontech/erigon/eth/backend.go:1516 +0x4f

Previous write at 0x00c001bee468 by goroutine 436:
  github.com/erigontech/erigon-lib/downloader.(*Downloader).ReCalcStats()
      github.com/erigontech/erigon-lib@v0.0.0-00010101000000-000000000000/downloader/downloader.go:2285 +0x315a
  github.com/erigontech/erigon-lib/downloader.(*Downloader).mainLoop()
      github.com/erigontech/erigon-lib@v0.0.0-00010101000000-000000000000/downloader/downloader.go:1394 +0xeb6
  github.com/erigontech/erigon-lib/downloader.(*Downloader).MainLoopInBackground.func1()
      github.com/erigontech/erigon-lib@v0.0.0-00010101000000-000000000000/downloader/downloader.go:796 +0xb6
```