### PR TITLE
handle error from `semaphore.Aquire` 

### DIFF
--- a/erigon-lib/commitment/hex_patricia_hashed_fuzz_test.go
+++ b/erigon-lib/commitment/hex_patricia_hashed_fuzz_test.go
@@ -92,7 +92,7 @@ func Fuzz_ProcessUpdates_ArbitraryUpdateCount(f *testing.F) {
 			t.Skip()
 		}
 		i := 0
-		keysCount := binary.BigEndian.Uint32(build[i : i+4])
+		keysCount := uint16(binary.BigEndian.Uint32(build[i : i+4]))
 		i += 4
 		ks := binary.BigEndian.Uint32(build[i : i+4])
 		keysSeed := rand.New(rand.NewSource(int64(ks)))
@@ -105,7 +105,7 @@ func Fuzz_ProcessUpdates_ArbitraryUpdateCount(f *testing.F) {
 		plainKeys := make([][]byte, keysCount)
 		updates := make([]Update, keysCount)
 
-		for k := uint32(0); k < keysCount; k++ {
+		for k := uint16(0); k < keysCount; k++ {
 
 			aux := make([]byte, 32)
 

--- a/turbo/execution/eth1/inserters.go
+++ b/turbo/execution/eth1/inserters.go
@@ -31,7 +31,7 @@ import (
 	"github.com/erigontech/erigon/turbo/execution/eth1/eth1_utils"
 )
 
-func (s *EthereumExecutionModule) validatePayloadBlobs(expectedBlobHashes []libcommon.Hash, transactions []types.Transaction, blobGasUsed uint64) error {
+func (e *EthereumExecutionModule) validatePayloadBlobs(expectedBlobHashes []libcommon.Hash, transactions []types.Transaction, blobGasUsed uint64) error {
 	if expectedBlobHashes == nil {
 		return &rpc.InvalidParamsError{Message: "nil blob hashes array"}
 	}
@@ -39,11 +39,11 @@ func (s *EthereumExecutionModule) validatePayloadBlobs(expectedBlobHashes []libc
 	for _, txn := range transactions {
 		actualBlobHashes = append(actualBlobHashes, txn.GetBlobHashes()...)
 	}
-	if len(actualBlobHashes) > int(s.config.GetMaxBlobsPerBlock()) || blobGasUsed > s.config.GetMaxBlobGasPerBlock() {
+	if len(actualBlobHashes) > int(e.config.GetMaxBlobsPerBlock()) || blobGasUsed > e.config.GetMaxBlobGasPerBlock() {
 		return nil
 	}
 	if !reflect.DeepEqual(actualBlobHashes, expectedBlobHashes) {
-		s.logger.Warn("[NewPayload] mismatch in blob hashes",
+		e.logger.Warn("[NewPayload] mismatch in blob hashes",
 			"expectedBlobHashes", expectedBlobHashes, "actualBlobHashes", actualBlobHashes)
 		return nil
 	}


### PR DESCRIPTION
```
panic: semaphore: released more than held

goroutine 10342 [running]:
golang.org/x/sync/semaphore.(*Weighted).Release(0xc002e8cdc0, 0x1114288c0?)
	golang.org/x/sync@v0.8.0/semaphore/semaphore.go:127 +0xb8
github.com/erigontech/erigon/turbo/execution/eth1.(*EthereumExecutionModule).Start(0xc003766780, {0x10fef16f8, 0xc001901d60})
	github.com/erigontech/erigon/turbo/execution/eth1/ethereum_execution.go:349 +0x167
created by github.com/erigontech/erigon/eth.(*Ethereum).Start in goroutine 1
	github.com/erigontech/erigon/eth/backend.go:1516 +0xddf
exit status 2
```