### PR TITLE
speedup Fuzz_ProcessUpdates_ArbitraryUpdateCount

### DIFF
--- a/erigon-lib/commitment/hex_patricia_hashed_fuzz_test.go
+++ b/erigon-lib/commitment/hex_patricia_hashed_fuzz_test.go
@@ -92,7 +92,7 @@ func Fuzz_ProcessUpdates_ArbitraryUpdateCount(f *testing.F) {
 			t.Skip()
 		}
 		i := 0
-		keysCount := binary.BigEndian.Uint32(build[i : i+4])
+		keysCount := uint16(binary.BigEndian.Uint32(build[i : i+4]))
 		i += 4
 		ks := binary.BigEndian.Uint32(build[i : i+4])
 		keysSeed := rand.New(rand.NewSource(int64(ks)))
@@ -105,7 +105,7 @@ func Fuzz_ProcessUpdates_ArbitraryUpdateCount(f *testing.F) {
 		plainKeys := make([][]byte, keysCount)
 		updates := make([]Update, keysCount)
 
-		for k := uint32(0); k < keysCount; k++ {
+		for k := uint16(0); k < keysCount; k++ {
 
 			aux := make([]byte, 32)
 


### PR DESCRIPTION
problem: test can go to `2^32` random keys - and timeouting on CI

with `2^16` limit it takes ~20sec

probably we need re-work this fuzz test - to make it faster
