### PR TITLE
downloader: race at startup 

### DIFF
--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -278,12 +278,12 @@ func Downloader(ctx context.Context, logger log.Logger) error {
 		}
 	}
 
-	d.MainLoopInBackground(false)
-
 	bittorrentServer, err := downloader.NewGrpcServer(d)
 	if err != nil {
 		return fmt.Errorf("new server: %w", err)
 	}
+
+	d.MainLoopInBackground(false)
 	if seedbox {
 		var downloadItems []*proto_downloader.AddItem
 		for _, it := range snapcfg.KnownCfg(chain).Preverified {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1394,11 +1394,11 @@ func (s *Ethereum) setUpSnapDownloader(ctx context.Context, downloaderCfg *downl
 		if err != nil {
 			return err
 		}
-		s.downloader.MainLoopInBackground(true)
 		bittorrentServer, err := downloader.NewGrpcServer(s.downloader)
 		if err != nil {
 			return fmt.Errorf("new server: %w", err)
 		}
+		s.downloader.MainLoopInBackground(true)
 
 		s.downloaderClient = direct.NewDownloaderClient(bittorrentServer)
 	}


### PR DESCRIPTION
```
==================
WARNING: DATA RACE
Read at 0x00c0266a01e0 by goroutine 24836:
  github.com/erigontech/erigon-lib/downloader.(*Downloader).notifyCompleted()
      github.com/erigontech/erigon-lib@v0.0.0-00010101000000-000000000000/downloader/downloader.go:2957 +0x665
  github.com/erigontech/erigon-lib/downloader.(*Downloader).torrentCompleted()
      github.com/erigontech/erigon-lib@v0.0.0-00010101000000-000000000000/downloader/downloader.go:2946 +0x65d
  github.com/erigontech/erigon-lib/downloader.(*Downloader).mainLoop.func2()
      github.com/erigontech/erigon-lib@v0.0.0-00010101000000-000000000000/downloader/downloader.go:956 +0x1f84

Previous write at 0x00c0266a01e0 by main goroutine:
  github.com/erigontech/erigon-lib/downloader.NewGrpcServer()
      github.com/erigontech/erigon-lib@v0.0.0-00010101000000-000000000000/downloader/downloader_grpc_server.go:47 +0x44d
  github.com/erigontech/erigon/eth.(*Ethereum).setUpSnapDownloader()
      github.com/erigontech/erigon/eth/backend.go:1398 +0x325
  github.com/erigontech/erigon/eth.New()
      github.com/erigontech/erigon/eth/backend.go:351 +0x1b45
  github.com/erigontech/erigon/turbo/node.New()
      github.com/erigontech/erigon/turbo/node/node.go:139 +0x124
  main.runErigon()
      github.com/erigontech/erigon/cmd/erigon/main.go:98 +0x53b
  github.com/erigontech/erigon/turbo/app.MakeApp.func1()
```

