### PR TITLE
txn overlap

### DIFF
--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -1634,12 +1634,6 @@ func (a *Aggregator) BuildFilesInBackground(txNum uint64) chan struct{} {
 
 	a.wg.Add(1)
 	go func() {
-		lastInDB := max(
-			lastIdInDB(a.db, a.d[kv.AccountsDomain]),
-			lastIdInDB(a.db, a.d[kv.CodeDomain]),
-			lastIdInDB(a.db, a.d[kv.StorageDomain]),
-			lastIdInDBNoHistory(a.db, a.d[kv.CommitmentDomain]))
-		log.Info("BuildFilesInBackground", "step", step, "lastInDB", lastInDB)
 		defer a.wg.Done()
 		defer a.buildingFiles.Store(false)
 
@@ -1652,11 +1646,12 @@ func (a *Aggregator) BuildFilesInBackground(txNum uint64) chan struct{} {
 			defer a.snapshotBuildSema.Release(1)
 		}
 
-		lastInDB = max(
+		lastInDB := max(
 			lastIdInDB(a.db, a.d[kv.AccountsDomain]),
 			lastIdInDB(a.db, a.d[kv.CodeDomain]),
 			lastIdInDB(a.db, a.d[kv.StorageDomain]),
 			lastIdInDBNoHistory(a.db, a.d[kv.CommitmentDomain]))
+		log.Info("BuildFilesInBackground", "step", step, "lastInDB", lastInDB)
 
 		// check if db has enough data (maybe we didn't commit them yet or all keys are unique so history is empty)
 		//lastInDB := lastIdInDB(a.db, a.d[kv.AccountsDomain])

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -1631,14 +1631,15 @@ func (a *Aggregator) BuildFilesInBackground(txNum uint64) chan struct{} {
 	}
 
 	step := a.visibleFilesMinimaxTxNum.Load() / a.StepSize()
-	lastInDB := max(
-		lastIdInDB(a.db, a.d[kv.AccountsDomain]),
-		lastIdInDB(a.db, a.d[kv.CodeDomain]),
-		lastIdInDB(a.db, a.d[kv.StorageDomain]),
-		lastIdInDBNoHistory(a.db, a.d[kv.CommitmentDomain]))
-	log.Info("BuildFilesInBackground", "step", step, "lastInDB", lastInDB)
+
 	a.wg.Add(1)
 	go func() {
+		lastInDB := max(
+			lastIdInDB(a.db, a.d[kv.AccountsDomain]),
+			lastIdInDB(a.db, a.d[kv.CodeDomain]),
+			lastIdInDB(a.db, a.d[kv.StorageDomain]),
+			lastIdInDBNoHistory(a.db, a.d[kv.CommitmentDomain]))
+		log.Info("BuildFilesInBackground", "step", step, "lastInDB", lastInDB)
 		defer a.wg.Done()
 		defer a.buildingFiles.Store(false)
 
@@ -1651,7 +1652,7 @@ func (a *Aggregator) BuildFilesInBackground(txNum uint64) chan struct{} {
 			defer a.snapshotBuildSema.Release(1)
 		}
 
-		lastInDB := max(
+		lastInDB = max(
 			lastIdInDB(a.db, a.d[kv.AccountsDomain]),
 			lastIdInDB(a.db, a.d[kv.CodeDomain]),
 			lastIdInDB(a.db, a.d[kv.StorageDomain]),


### PR DESCRIPTION
Fixed ```MDBX_TXN_OVERLAPPING: Overlapping read and write transactions for the current thread, label: chaindata, trace: [kv_mdbx.go:782 kv_mdbx.go:935 aggregator.go:1959 aggregator.go:1635 exec3.go:369 stage_execute.go:164 stage_execute.go:254 default_stages.go:238 sync.go:531 sync.go:410 forkchoice.go:453 asm_amd64.s:1695]"```