### PR TITLE
Parallel receipts root to `ComputeCommitment`

### DIFF
--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -811,7 +811,6 @@ Loop:
 				GetHashFn:          getHashFn,
 				EvmBlockContext:    blockContext,
 				Withdrawals:        b.Withdrawals(),
-				Requests:           b.Requests(),
 				PruneNonEssentials: pruneNonEssentials,
 
 				// use history reader instead of state reader to catch up to the tx where we left off
@@ -1637,7 +1636,6 @@ func reconstituteStep(last bool,
 						GetHashFn:       getHashFn,
 						EvmBlockContext: blockContext,
 						Withdrawals:     b.Withdrawals(),
-						Requests:        b.Requests(),
 					}
 					if txIndex >= 0 && txIndex < len(txs) {
 						txTask.Tx = txs[txIndex]


### PR DESCRIPTION
Improve chain tip block times by around 3%