### PR TITLE
Use cache only for main and latest two release branches.

### DIFF
--- a/.github/workflows/test-integration-caplin.yml
+++ b/.github/workflows/test-integration-caplin.yml
@@ -27,6 +27,12 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.22'
+          cache: ${{ contains(fromJSON('[
+      "refs/heads/release/2.60",
+      "refs/heads/release/2.61",
+      "refs/heads/main"
+    ]'), github.ref) }}
+
       - name: Install dependencies on Linux
         if: runner.os == 'Linux'
         run: sudo apt update && sudo apt install build-essential
@@ -45,6 +51,11 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.22'
+          cache: ${{ contains(fromJSON('[
+              "refs/heads/release/2.60",
+              "refs/heads/release/2.61",
+              "refs/heads/main"
+            ]'), github.ref) }}          
 
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/test-integration-caplin.yml
+++ b/.github/workflows/test-integration-caplin.yml
@@ -28,10 +28,10 @@ jobs:
         with:
           go-version: '1.22'
           cache: ${{ contains(fromJSON('[
-      "refs/heads/release/2.60",
-      "refs/heads/release/2.61",
-      "refs/heads/main"
-    ]'), github.ref) }}
+            "refs/heads/release/2.60",
+            "refs/heads/release/2.61",
+            "refs/heads/main"
+            ]'), github.ref) }}
 
       - name: Install dependencies on Linux
         if: runner.os == 'Linux'
@@ -52,9 +52,9 @@ jobs:
         with:
           go-version: '1.22'
           cache: ${{ contains(fromJSON('[
-              "refs/heads/release/2.60",
-              "refs/heads/release/2.61",
-              "refs/heads/main"
+            "refs/heads/release/2.60",
+            "refs/heads/release/2.61",
+            "refs/heads/main"
             ]'), github.ref) }}          
 
       - uses: actions/cache@v4


### PR DESCRIPTION
Cache is branch-specific.

For pull-requests based on some feature-branch we can skip cache and save available space on our workflow cache as well as time required to run workflow.