### PR TITLE
integration tests: added parallel execution

### DIFF
--- a/tests/init_test.go
+++ b/tests/init_test.go
@@ -281,6 +281,7 @@ func sortedMapKeys(m reflect.Value) []string {
 }
 
 func runTestFunc(runTest interface{}, t *testing.T, name string, m reflect.Value, key string) {
+	t.Parallel()
 	reflect.ValueOf(runTest).Call([]reflect.Value{
 		reflect.ValueOf(t),
 		reflect.ValueOf(name),


### PR DESCRIPTION
Added parallel execution for integration tests which is speedup them by 25% in average