### PR TITLE
qa-tests: handle Erigon2 json rpc api improvements regarding the error reason

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout RPC Tests Repository & Install Requirements
         run: |
           rm -rf ${{ runner.workspace }}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch v0.52.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
+          git -c advice.detachedHead=false clone --depth 1 --branch erigon_v2.6x https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
           cd ${{ runner.workspace }}/rpc-tests
           pip3 install -r requirements.txt
 


### PR DESCRIPTION
Erigon2 v2.6x add correct **error reason** to some json rpc api responses.
Previously, the expected reason for the error was "{}".

Affected apis are `debug_traceCall`, `debug_traceCallMany`, `debug_traceTransaction`.

This PR uses a new branch of the rpc-tests repo that has been updated with these changes.