### PR TITLE
stagedsync: revert Sync.Run return error on bad block

### DIFF
--- a/eth/stagedsync/sync.go
+++ b/eth/stagedsync/sync.go
@@ -365,8 +365,8 @@ func (s *Sync) Run(db kv.RwDB, txc wrap.TxContainer, initialCycle, firstCycle bo
 	s.timings = s.timings[:0]
 
 	hasMore := false
-	var badBlockUnwind bool
 	for !s.IsDone() {
+		var badBlockUnwind bool
 		if s.unwindPoint != nil {
 			for j := 0; j < len(s.unwindOrder); j++ {
 				if s.unwindOrder[j] == nil || s.unwindOrder[j].Disabled || s.unwindOrder[j].Unwind == nil {
@@ -447,11 +447,6 @@ func (s *Sync) Run(db kv.RwDB, txc wrap.TxContainer, initialCycle, firstCycle bo
 	}
 
 	s.currentStage = 0
-
-	if badBlockUnwind {
-		return false, errors.New("bad block unwinding")
-	}
-
 	return hasMore, nil
 }
 


### PR DESCRIPTION
Reverting [this](https://github.com/erigontech/erigon/pull/11385/files#diff-1a50e885d0d9cf95e595879af5fe15ea7a65b9b8a7f7f637913f11a83b157989R451-R453) change because it broke the contract of `ExecutionEngine.UpdateForkChoice`. Previously calling `executionPipeline.Run` would not return error upon bad block and would eventually reach this [point](https://github.com/erigontech/erigon/blob/main/turbo/execution/eth1/forkchoice.go#L477) where we set the `ForkChoiceReceipt.Status` to `ExecutionStatus_BadBlock`. Now, however, because of this newly returned error we never reach there and the response doesn't have the correct status. Checked with @JkLondon and looks like returning this error may not be necessary.

This appeared during an Astrid run on mainnet as per the logs below. Astrid relies on a response with correctly set `ExecutionStatus_BadBlock` status so that it marks the block as bad and continues the chain tip sync. If the error from execution engine is anything else it is treated as an operational node error (meaning some logical/unexpected error happened)  which is non-recoverable and terminates the process.

```
[EROR] [10-30|13:33:47.363] [4/6 Execution] Wrong trie root of block 63674880: 975d274ce135313a4a716fa3f885b5e9ba1a81fb4aee919425d95725775bc233, expected (from header): 3db744974deac3ee9963fc0c80523d0125b42705640efa6f878cc2ed7fc31c46. Block hash: c6db82a7a298a4067597f8841d354f0a0461c3c662a33dee49b3fbd2142e0844 
[WARN] [10-30|13:33:47.363] Unwinding due to incorrect root hash     to=63674879
[DBUG] [10-30|13:33:47.363] UnwindTo                                 block=63674879 block_hash=0xc6db82a7a298a4067597f8841d354f0a0461c3c662a33dee49b3fbd2142e0844 err="invalid state root hash" stack="[sync.go:171 exec3.go:1250 exec3.go:1100 stage_execute.go:164 stage_execute.go:254 default_stages.go:238 sync.go:531 sync.go:410 forkchoice.go:453 asm_amd64.s:1695]"
[INFO] [10-30|13:33:47.364] [4/6 Execution] Done Commit every block  blk=63674880 blks=1 blk/s=102.0 txs=2 tx/s=204 gas/s=0 buf=229.5KB/512.0MB stepsInDB=0.00 step=2998.5 alloc=19.2GB sys=38.7GB
[DBUG] [10-30|13:33:47.364] [4/6 Execution] DONE                     in=10.221333ms
[INFO] [10-30|13:33:47.364] [4/6 Execution] Unwind Execution         from=63674880 to=63674879
[INFO] [10-30|13:33:47.364] aggregator unwind                        step=2998 txUnwindTo=4685159753 stepsRangeInDB="accounts:0.5, storage:0.5, code:0.5, commitment:0.0, receipt:0.5, logaddrs: 0.5, logtopics: 0.5, tracesfrom: 0.5, tracesto: 0.5"
[WARN] [10-30|13:33:47.365] Cannot update chain head                 hash=0xc6db82a7a298a4067597f8841d354f0a0461c3c662a33dee49b3fbd2142e0844 err="updateForkChoice: bad block unwinding"
[EROR] [10-30|13:33:47.365] failed to update fork choice             latestValidHash=0x0000000000000000000000000000000000000000000000000000000000000000 err="updateForkChoice: bad block unwinding"
[EROR] [10-30|13:33:50.365] polygon sync crashed - stopping node     err="pos sync failed: updateForkChoice: bad block unwinding"
[INFO] [10-30|13:33:50.365] Exiting... 
```