### PR TITLE
feat(jsonrpc/trace): add creationMethod for parity traces

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout RPC Tests Repository & Install Requirements
         run: |
           rm -rf ${{ runner.workspace }}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch v1.22.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
+          git -c advice.detachedHead=false clone --depth 1 --branch feature/add_creationMethod_for_parity_traces https://github.com/jsvisa/erigon-rpc-tests ${{runner.workspace}}/rpc-tests
           cd ${{ runner.workspace }}/rpc-tests
           pip3 install -r requirements.txt
 

--- a/turbo/jsonrpc/gen_traces_test.go
+++ b/turbo/jsonrpc/gen_traces_test.go
@@ -327,6 +327,7 @@ func TestGeneratedTraceApiCollision(t *testing.T) {
     {
         "action": {
             "from": "0x000000000000000000000000000000000000bbbb",
+            "createType": "create2",
             "gas": "0xb49d",
             "init": "0x600360035560046004556158ff6000526002601ef3",
             "value": "0x0"

--- a/turbo/jsonrpc/gen_traces_test.go
+++ b/turbo/jsonrpc/gen_traces_test.go
@@ -327,7 +327,7 @@ func TestGeneratedTraceApiCollision(t *testing.T) {
     {
         "action": {
             "from": "0x000000000000000000000000000000000000bbbb",
-            "createType": "create2",
+            "creationMethod": "create2",
             "gas": "0xb49d",
             "init": "0x600360035560046004556158ff6000526002601ef3",
             "value": "0x0"

--- a/turbo/jsonrpc/trace_adhoc.go
+++ b/turbo/jsonrpc/trace_adhoc.go
@@ -355,6 +355,7 @@ func (ot *OeTracer) captureStartOrEnter(deep bool, typ vm.OpCode, from libcommon
 	if create {
 		action := CreateTraceAction{}
 		action.From = from
+		action.CreateType = strings.ToLower(typ.String())
 		action.Gas.ToInt().SetUint64(gas)
 		action.Init = libcommon.CopyBytes(input)
 		action.Value.ToInt().Set(value.ToBig())

--- a/turbo/jsonrpc/trace_adhoc.go
+++ b/turbo/jsonrpc/trace_adhoc.go
@@ -355,7 +355,7 @@ func (ot *OeTracer) captureStartOrEnter(deep bool, typ vm.OpCode, from libcommon
 	if create {
 		action := CreateTraceAction{}
 		action.From = from
-		action.CreateType = strings.ToLower(typ.String())
+		action.CreationMethod = strings.ToLower(typ.String())
 		action.Gas.ToInt().SetUint64(gas)
 		action.Init = libcommon.CopyBytes(input)
 		action.Value.ToInt().Set(value.ToBig())

--- a/turbo/jsonrpc/trace_types.go
+++ b/turbo/jsonrpc/trace_types.go
@@ -98,10 +98,11 @@ type CallTraceAction struct {
 }
 
 type CreateTraceAction struct {
-	From  common.Address   `json:"from"`
-	Gas   hexutil.Big      `json:"gas"`
-	Init  hexutility.Bytes `json:"init"`
-	Value hexutil.Big      `json:"value"`
+	From       common.Address   `json:"from"`
+	CreateType string           `json:"createType"`
+	Gas        hexutil.Big      `json:"gas"`
+	Init       hexutility.Bytes `json:"init"`
+	Value      hexutil.Big      `json:"value"`
 }
 
 type SuicideTraceAction struct {

--- a/turbo/jsonrpc/trace_types.go
+++ b/turbo/jsonrpc/trace_types.go
@@ -98,11 +98,11 @@ type CallTraceAction struct {
 }
 
 type CreateTraceAction struct {
-	From       common.Address   `json:"from"`
-	CreateType string           `json:"createType"`
-	Gas        hexutil.Big      `json:"gas"`
-	Init       hexutility.Bytes `json:"init"`
-	Value      hexutil.Big      `json:"value"`
+	From           common.Address   `json:"from"`
+	CreationMethod string           `json:"creationMethod"`
+	Gas            hexutil.Big      `json:"gas"`
+	Init           hexutility.Bytes `json:"init"`
+	Value          hexutil.Big      `json:"value"`
 }
 
 type SuicideTraceAction struct {


### PR DESCRIPTION
similiar to https://github.com/ethereum/go-ethereum/pull/30539 add `creationMethod` for the create traces.