### PR TITLE
qa-tests: change test scheduling

### DIFF
--- a/.github/workflows/qa-constrained-tip-tracking.yml
+++ b/.github/workflows/qa-constrained-tip-tracking.yml
@@ -2,15 +2,8 @@ name: QA - Constrained Tip tracking
 
 on:
   schedule:
-    - cron: '0 0 * * 0'  # Run on Sunday at 00:00 AM UTC
+    - cron: '0 20 * * 0'  # Run on Sunday at 08:00 PM UTC
   workflow_dispatch:     # Run manually
-  pull_request:
-    branches:
-      - qa_tests_constrained_tip_tracking
-    types:
-      - opened
-      - synchronize
-      - ready_for_review
 
 jobs:
   constrained-tip-tracking-test:

--- a/.github/workflows/qa-snap-download.yml
+++ b/.github/workflows/qa-snap-download.yml
@@ -2,7 +2,7 @@ name: QA - Snapshot Download
 
 on:
   schedule:
-    - cron: '0 22 * * 1-6'  # Run every night at 22:00 (10:00 PM) UTC except Sunday
+    - cron: '0 20 * * 1-6'  # Run every night at 20:00 (08:00 PM) UTC except Sunday
   workflow_dispatch:     # Run manually
 
 jobs:

--- a/.github/workflows/qa-tip-tracking.yml
+++ b/.github/workflows/qa-tip-tracking.yml
@@ -2,7 +2,7 @@ name: QA - Tip tracking
 
 on:
   schedule:
-    - cron: '0 0 * * 1-6'  # Run every night at 00:00 AM UTC except Sunday
+    - cron: '0 20 * * 1-6'  # Run every night at 08:00 PM UTC except Sunday
   workflow_dispatch:     # Run manually
 
 jobs:


### PR DESCRIPTION
This PR re-schedule some tests to run at 08:00 PM UTC - It is a try to help team members working at non-EU timezones