### PR TITLE
qa-tests: add timeout to rpc test suite

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   integration-test-suite:
     runs-on: [ self-hosted, Erigon3 ]
+    timeout-minutes: 15
     env:
       ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version/datadir
       ERIGON_TESTBED_DATA_DIR: /opt/erigon-testbed/datadir


### PR DESCRIPTION
Sometimes the changes made in the code cause the test to hang for a long time. 
To avoid delaying the other executions a timeout of 15 min is added (currently the executions take less than 5 minutes).