### PR TITLE
qa-tests: handle Erigon2 json rpc api improvements regarding the error reason (v2.61)

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'release/2.*'
-      - qa_tests_rpc_with_rpcdaemon  # only to debug the workflow
   pull_request:
     branches:
       - 'release/2.*'
@@ -29,7 +28,7 @@ jobs:
       - name: Checkout RPC Tests Repository & Install Requirements
         run: |
           rm -rf ${{ runner.workspace }}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch v0.52.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
+          git -c advice.detachedHead=false clone --depth 1 --branch erigon_v2.6x https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
           cd ${{ runner.workspace }}/rpc-tests
           pip3 install -r requirements.txt
 


### PR DESCRIPTION
Same as https://github.com/erigontech/erigon/pull/12547 but for branch release/2.61