### PR TITLE
heimdall/client: revert retryBackoff hack left behind

### DIFF
--- a/polygon/heimdall/client.go
+++ b/polygon/heimdall/client.go
@@ -486,9 +486,6 @@ func FetchWithRetryEx[T any](
 ) (result *T, err error) {
 	attempt := 0
 	// create a new ticker for retrying the request
-	if client.retryBackOff < apiHeimdallTimeout {
-		client.retryBackOff = apiHeimdallTimeout + time.Second*2
-	}
 	ticker := time.NewTicker(client.retryBackOff)
 	defer ticker.Stop()
 


### PR DESCRIPTION
reverts a change from https://github.com/erigontech/erigon/commit/73476abdb0de07654c3a1f9ca6567951e12c2900#diff-ace6e4f24916671d83adb720ebd0fff8e611f09ed451f334e92e10aeb8591525R489-R491

not sure why this has been done - seems like a weird hack that has been left behind maybe unintentionally - it is definitely unnecessary

main reason for removing is:
- it entirely circumvents the retryBackoff config of the client and always overrides the value which is wrong
- it slows down tests a lot - this test should take milliseconds, but after this change it takes a minute
![Screenshot 2024-11-05 at 15 57 08](https://github.com/user-attachments/assets/c8419264-5e73-4e0b-a600-93169b1d12bd)
