### PR TITLE
chore: update profile's Content-Type

### DIFF
--- a/diagnostics/profile.go
+++ b/diagnostics/profile.go
@@ -44,7 +44,7 @@ func writePprofProfile(w http.ResponseWriter, profile string) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "aplication/profile")
+	w.Header().Set("Content-Type", "application/profile")
 	err := p.WriteTo(w, 0)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to write profile: %v", err), http.StatusInternalServerError)

--- a/turbo/app/support_cmd.go
+++ b/turbo/app/support_cmd.go
@@ -410,7 +410,7 @@ func tunnel(ctx context.Context, cancel context.CancelFunc, sigs chan os.Signal,
 						})
 					}
 
-				case "aplication/profile":
+				case "application/profile":
 					if _, err := io.Copy(buffer, debugResponse.Body); err != nil {
 						return codec.WriteJSON(ctx1, &nodeResponse{
 							Id: requestId,


### PR DESCRIPTION
Keep consistent with previous case naming, like:
```
case "application/json"
case "application/octet-stream"
```