### PR TITLE
rpcdaemon: fix on FeeHistory check on GetMaxBlobGasPerBlock() method of chainConfig

### DIFF
--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -116,7 +116,7 @@ func (oracle *Oracle) processBlock(bf *blockFees, percentiles []float64) {
 	}
 	bf.gasUsedRatio = float64(bf.header.GasUsed) / float64(bf.header.GasLimit)
 
-	if blobGasUsed := bf.header.BlobGasUsed; blobGasUsed != nil {
+	if blobGasUsed := bf.header.BlobGasUsed; blobGasUsed != nil && chainconfig.GetMaxBlobGasPerBlock() != 0 {
 		bf.blobGasUsedRatio = float64(*blobGasUsed) / float64(chainconfig.GetMaxBlobGasPerBlock())
 	}
 

--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -115,14 +115,16 @@ func (oracle *Oracle) processBlock(bf *blockFees, percentiles []float64) {
 		bf.nextBlobBaseFee = new(big.Int)
 	}
 	bf.gasUsedRatio = float64(bf.header.GasUsed) / float64(bf.header.GasLimit)
+
+	if blobGasUsed := bf.header.BlobGasUsed; blobGasUsed != nil {
+		bf.blobGasUsedRatio = float64(*blobGasUsed) / float64(chainconfig.GetMaxBlobGasPerBlock())
+	}
+
 	if len(percentiles) == 0 {
 		// rewards were not requested, return null
 		return
 	}
 
-	if blobGasUsed := bf.header.BlobGasUsed; blobGasUsed != nil && chainconfig.MaxBlobGasPerBlock != nil {
-		bf.blobGasUsedRatio = float64(*blobGasUsed) / float64(*chainconfig.MaxBlobGasPerBlock)
-	}
 	if bf.block == nil || (bf.receipts == nil && len(bf.block.Transactions()) != 0) {
 		oracle.log.Error("Block or receipts are missing while reward percentiles are requested")
 		return


### PR DESCRIPTION
To read MaxBlobGasPerBlock it is necessary use the method GetMaxBlobGasPerBlock() that returns MAX_BLOB_GAS_PER_BLOCK (EIP-4844) if not override in config with custom value MaxBlobGasPerBlock 