### PR TITLE
Sync GIT_TAG with main branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DOCKER := $(shell command -v docker 2> /dev/null)
 
 GIT_COMMIT ?= $(shell git rev-list -1 HEAD)
 GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
-GIT_TAG    ?= $(shell git describe --tags '--match=v*' --dirty)
+GIT_TAG    ?= $(shell git describe --tags '--match=*.*.*' --abbrev=7 --dirty)
 ERIGON_USER ?= erigon
 # if using volume-mounting data dir, then must exist on host OS
 DOCKER_UID ?= $(shell id -u)


### PR DESCRIPTION
changes:
-  7 chars for commit id
- match pattern *.*.* (for example -- it will match v2.60.9 or 2.60.9)