### PR TITLE
align  getModifiedAccountsByHash to getModifiedAccountsByNumber and f…

### DIFF
--- a/.github/workflows/scripts/run_rpc_tests.sh
+++ b/.github/workflows/scripts/run_rpc_tests.sh
@@ -35,6 +35,8 @@ disabled_tests=(
     debug_traceBlockByNumber/test_10.tar
     debug_traceBlockByNumber/test_11.tar
     debug_traceBlockByNumber/test_12.tar
+    # modified expected in case of empty rsp
+    debug_storageRangeAt/test_11.json
     # remove this line after https://github.com/erigontech/rpc-tests/pull/281
     parity_getBlockReceipts
     parity_listStorageKeys/test_12.json

--- a/turbo/jsonrpc/debug_api.go
+++ b/turbo/jsonrpc/debug_api.go
@@ -214,7 +214,7 @@ func (api *PrivateDebugAPIImpl) GetModifiedAccountsByNumber(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	return getModifiedAccounts(tx.(kv.TemporalTx), startTxNum, endTxNum)
+	return getModifiedAccounts(tx.(kv.TemporalTx), startTxNum, endTxNum-1)
 }
 
 // getModifiedAccounts returns a list of addresses that were modified in the block range
@@ -282,11 +282,11 @@ func (api *PrivateDebugAPIImpl) GetModifiedAccountsByHash(ctx context.Context, s
 	if err != nil {
 		return nil, err
 	}
-	endTxNum, err := txNumsReader.Max(tx, endNum-1)
+	endTxNum, err := txNumsReader.Min(tx, endNum)
 	if err != nil {
 		return nil, err
 	}
-	return getModifiedAccounts(tx.(kv.TemporalTx), startTxNum, endTxNum)
+	return getModifiedAccounts(tx.(kv.TemporalTx), startTxNum, endTxNum-1)
 }
 
 func (api *PrivateDebugAPIImpl) AccountAt(ctx context.Context, blockHash common.Hash, txIndex uint64, address common.Address) (*AccountResult, error) {


### PR DESCRIPTION
This PR contains two changes:
- align getModifiedAccountByHash() to getModifiedAccountsByNumber() on txn calculations
- I assume the txn range is:  fromTxn <= values <= toTxn 
  Therefore the endTxn should be min(next block) - 1
  In  the sw  nextBlock is equal to endBlock (endBlock is increased before)