### PR TITLE
log: demote a very verbose log level

### DIFF
--- a/erigon-lib/state/domain_committed.go
+++ b/erigon-lib/state/domain_committed.go
@@ -239,7 +239,7 @@ func (dt *DomainRoTx) commitmentValTransformDomain(rng MergeRange, accounts, sto
 				visibleFiles += fmt.Sprintf("%d-%d;", f.startTxNum/dt.d.aggregationStep, f.endTxNum/dt.d.aggregationStep)
 			}
 
-			dt.d.logger.Warn("[agg] lookupVisibleFileByItsRange: file not found",
+			dt.d.logger.Debug("[agg] lookupVisibleFileByItsRange: file not found",
 				"stepFrom", rng.from/dt.d.aggregationStep, "stepTo", rng.to/dt.d.aggregationStep,
 				"_visible", visibleFiles, "visibleFilesCount", len(dt.files))
 
@@ -256,7 +256,7 @@ func (dt *DomainRoTx) commitmentValTransformDomain(rng MergeRange, accounts, sto
 				visibleFiles += fmt.Sprintf("%d-%d;", f.startTxNum/dt.d.aggregationStep, f.endTxNum/dt.d.aggregationStep)
 			}
 
-			dt.d.logger.Warn("[agg] lookupVisibleFileByItsRange: file not found",
+			dt.d.logger.Debug("[agg] lookupVisibleFileByItsRange: file not found",
 				"stepFrom", rng.from/dt.d.aggregationStep, "stepTo", rng.to/dt.d.aggregationStep,
 				"_visible", visibleFiles, "visibleFilesCount", len(dt.files))
 			return nil, fmt.Errorf("merged v1-account.%d-%d.kv file not found", rng.from/dt.d.aggregationStep, rng.to/dt.d.aggregationStep)

--- a/erigon-lib/state/domain_shared.go
+++ b/erigon-lib/state/domain_shared.go
@@ -492,7 +492,7 @@ func (sd *SharedDomains) replaceShortenedKeysInBranch(prefix []byte, branch comm
 	}
 	accountItem := acc.lookupVisibleFileByItsRange(fStartTxNum, fEndTxNum)
 	if accountItem == nil {
-		sd.logger.Warn(fmt.Sprintf("visible account file of steps %d-%d not found", fStartTxNum/sd.aggTx.a.aggregationStep, fEndTxNum/sd.aggTx.a.aggregationStep))
+		sd.logger.Debug(fmt.Sprintf("visible account file of steps %d-%d not found", fStartTxNum/sd.aggTx.a.aggregationStep, fEndTxNum/sd.aggTx.a.aggregationStep))
 		accountItem = acc.lookupDirtyFileByItsRange(fStartTxNum, fEndTxNum)
 		if accountItem == nil {
 			sd.logger.Crit(fmt.Sprintf("dirty account file of steps %d-%d not found", fStartTxNum/sd.aggTx.a.aggregationStep, fEndTxNum/sd.aggTx.a.aggregationStep))


### PR DESCRIPTION
The log file on a test system is infested with millions of lines like this, which, apparently, is not that important:

`[WARN] [11-08|01:44:03.174] visible account file of steps 1660-1662 not found 
[WARN] [11-08|01:44:03.175] [agg] lookupVisibleFileByItsRange: file not found stepFrom=1660 stepTo=1662 _visible=0-1024;1024-1536;1536-1664; visibleFilesCount=3`

The log is almost impossible to analyse. This PR lowers the log level of these lines to debug level

