### PR TITLE
qa-tests: add chiado to sync from scratch test

### DIFF
--- a/.github/workflows/qa-sync-from-scratch.yml
+++ b/.github/workflows/qa-sync-from-scratch.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        chain: [ sepolia, holesky, amoy ]  # Chain name as specified on the erigon command line
+        chain: [ sepolia, holesky, amoy, chiado ]  # Chain name as specified on the erigon command line
     env:
       ERIGON_DATA_DIR: ${{ github.workspace }}/erigon_data
       ERIGON_QA_PATH: /home/qarunner/erigon-qa


### PR DESCRIPTION
This add chiado chain to sync-from-scratch test.
Erigon will be runned with:
```
--chain=chiado
--batchSize=1g
```