### PR TITLE
Caplin: reduced in `MerkleTree`'s `CopyInto`

### DIFF
--- a/cl/cltypes/solid/uint64slice_byte.go
+++ b/cl/cltypes/solid/uint64slice_byte.go
@@ -71,17 +71,12 @@ func (arr *byteBasedUint64Slice) Clear() {
 
 // CopyTo copies the slice to a target slice.
 func (arr *byteBasedUint64Slice) CopyTo(target *byteBasedUint64Slice) {
-	target.Clear()
-	// TODO: implement CopyTo for MPT
 	target.c = arr.c
 	target.l = arr.l
 	if len(target.u) < len(arr.u) {
 		target.u = make([]byte, len(arr.u))
 	}
 	if arr.MerkleTree != nil {
-		if target.MerkleTree == nil {
-			target.MerkleTree = &merkle_tree.MerkleTree{}
-		}
 		arr.MerkleTree.CopyInto(target.MerkleTree)
 	}
 

--- a/cl/cltypes/solid/uint64slice_byte.go
+++ b/cl/cltypes/solid/uint64slice_byte.go
@@ -77,6 +77,9 @@ func (arr *byteBasedUint64Slice) CopyTo(target *byteBasedUint64Slice) {
 		target.u = make([]byte, len(arr.u))
 	}
 	if arr.MerkleTree != nil {
+		if target.MerkleTree == nil {
+			target.MerkleTree = &merkle_tree.MerkleTree{}
+		}
 		arr.MerkleTree.CopyInto(target.MerkleTree)
 	}
 

--- a/cl/merkle_tree/merkle_tree.go
+++ b/cl/merkle_tree/merkle_tree.go
@@ -226,9 +226,7 @@ func (m *MerkleTree) CopyInto(other *MerkleTree) {
 	for i := 0; i < len(m.layers); i++ {
 		// If the destination buffer is too short, extend it
 		if len(m.layers[i]) > cap(other.layers[i]) {
-			tmp := other.layers[i]
 			other.layers[i] = make([]byte, len(m.layers[i]), (len(m.layers[i])*3)/2)
-			copy(other.layers[i], tmp)
 		}
 		// Normalizr the destination length
 		other.layers[i] = other.layers[i][:len(m.layers[i])]

--- a/cl/merkle_tree/merkle_tree.go
+++ b/cl/merkle_tree/merkle_tree.go
@@ -208,16 +208,42 @@ func (m *MerkleTree) CopyInto(other *MerkleTree) {
 	defer m.mu.RUnlock()
 	defer other.mu.Unlock()
 	other.computeLeaf = m.computeLeaf
-	other.layers = make([][]byte, len(m.layers))
+	if len(other.layers) > len(m.layers) {
+		for i := len(m.layers); i < len(other.layers); i++ {
+			other.layers[i] = other.layers[i][:0]
+		}
+		other.layers = m.layers[:0]
+	}
+
+	if len(m.layers) > len(other.layers) {
+		for len(other.layers) != len(m.layers) {
+			idx := len(other.layers)
+			other.layers = append(other.layers, make([]byte, len(m.layers[idx]), (len(m.layers[idx])*3)/2))
+		}
+	}
+
 	for i := 0; i < len(m.layers); i++ {
-		other.layers[i] = make([]byte, len(m.layers[i]))
+		// If the destination buffer is too short, extend it
+		if len(m.layers[i]) > cap(other.layers[i]) {
+			tmp := other.layers[i]
+			other.layers[i] = make([]byte, len(m.layers[i]), (len(m.layers[i])*3)/2)
+			copy(other.layers[i], tmp)
+		}
+		// Normalizr the destination length
+		other.layers[i] = other.layers[i][:len(m.layers[i])]
+
+		// Now that the 2 slices are of equal length we can do a simple memcopy
 		copy(other.layers[i], m.layers[i])
 	}
+
 	other.leavesCount = m.leavesCount
 	other.limit = m.limit
-	other.dirtyLeaves = make([]atomic.Bool, len(m.dirtyLeaves))
+	//other.dirtyLeaves = make([]atomic.Bool, len(m.dirtyLeaves))
 
 	for i := 0; i < len(m.dirtyLeaves); i++ {
+		if i >= len(other.dirtyLeaves) {
+			other.dirtyLeaves = append(other.dirtyLeaves, atomic.Bool{})
+		}
 		other.dirtyLeaves[i].Store(m.dirtyLeaves[i].Load())
 	}
 }

--- a/cl/merkle_tree/merkle_tree.go
+++ b/cl/merkle_tree/merkle_tree.go
@@ -209,10 +209,11 @@ func (m *MerkleTree) CopyInto(other *MerkleTree) {
 	defer other.mu.Unlock()
 	other.computeLeaf = m.computeLeaf
 	if len(other.layers) > len(m.layers) {
+		// reset the internal layers
 		for i := len(m.layers); i < len(other.layers); i++ {
 			other.layers[i] = other.layers[i][:0]
 		}
-		other.layers = m.layers[:0]
+		other.layers = other.layers[:len(m.layers)]
 	}
 
 	if len(m.layers) > len(other.layers) {

--- a/cl/phase1/core/state/copy.go
+++ b/cl/phase1/core/state/copy.go
@@ -43,7 +43,13 @@ func (b *CachingBeaconState) copyCachesInto(bs *CachingBeaconState) error {
 	if bs.publicKeyIndicies == nil {
 		bs.publicKeyIndicies = make(map[[48]byte]uint64)
 	}
-	for k := range bs.publicKeyIndicies {
+	for k, idx := range bs.publicKeyIndicies {
+		if otherIdx, ok := b.publicKeyIndicies[k]; ok {
+			if idx != otherIdx {
+				delete(bs.publicKeyIndicies, k)
+			}
+			continue
+		}
 		delete(bs.publicKeyIndicies, k)
 	}
 	for pk, index := range b.publicKeyIndicies {

--- a/cl/phase1/network/services/aggregate_and_proof_service.go
+++ b/cl/phase1/network/services/aggregate_and_proof_service.go
@@ -398,7 +398,6 @@ func (a *aggregateAndProofServiceImpl) loop(ctx context.Context) {
 				return true
 			}
 			if err := a.ProcessMessage(ctx, nil, job.aggregate); err != nil {
-				log.Trace("blob sidecar verification failed", "err", err)
 				return true
 			}
 


### PR DESCRIPTION
Reduced allocs by 58% overall