### PR TITLE
fix generating genesis config for chiado

### DIFF
--- a/cl/clparams/initial_state/initial_state.go
+++ b/cl/clparams/initial_state/initial_state.go
@@ -68,6 +68,10 @@ func GetGenesisState(network clparams.NetworkType) (*state.CachingBeaconState, e
 		if err := returnState.DecodeSSZ(gnosisStateSSZ, int(clparams.Phase0Version)); err != nil {
 			return nil, err
 		}
+	case clparams.ChiadoNetwork:
+		if err := returnState.DecodeSSZ(gnosisStateSSZ, int(clparams.Phase0Version)); err != nil {
+			return nil, err
+		}
 	case clparams.HoleskyNetwork:
 		// Download genesis state by wget the url
 		encodedState, err := downloadGenesisState("https://github.com/eth-clients/holesky/raw/main/metadata/genesis.ssz")
@@ -84,5 +88,5 @@ func GetGenesisState(network clparams.NetworkType) (*state.CachingBeaconState, e
 }
 
 func IsGenesisStateSupported(network clparams.NetworkType) bool {
-	return network == clparams.MainnetNetwork || network == clparams.SepoliaNetwork || network == clparams.GnosisNetwork || network == clparams.HoleskyNetwork
+	return network == clparams.MainnetNetwork || network == clparams.SepoliaNetwork || network == clparams.GnosisNetwork || network == clparams.ChiadoNetwork || network == clparams.HoleskyNetwork
 }


### PR DESCRIPTION
We couldn't start chiado without passing genesis state file and custom config. 

```
open /Users/shota/Desktop/work.nosync/datadir/caplin-chiado3/caplin/genesis/genesis_state.ssz_snappy: no such file or directory
```

Now

```
./build/bin/caplin --datadir ../datadir/caplin-chiado --chain=chiado
```

works. 