### PR TITLE
cl/params: enable chiado embedded support

### DIFF
--- a/cl/clparams/config.go
+++ b/cl/clparams/config.go
@@ -1134,8 +1134,8 @@ func EmbeddedSupported(id uint64) bool {
 	return id == 1 ||
 		id == 17000 ||
 		id == 11155111 ||
-		id == 100 // ||
-	//id == 10200
+		id == 100 ||
+		id == 10200
 }
 
 // Subset of supported networks where embedded CL is stable enough


### PR DESCRIPTION
trying to get Caplin to run on Chiado, need to update `EmbeddedSupported` for it otherwise E3 waits endlessly (no CL active to control it)

follow up from https://github.com/erigontech/erigon/pull/12699