### PR TITLE
turbo/node: log gnosis chain init not as a devnet

### DIFF
--- a/turbo/node/node.go
+++ b/turbo/node/node.go
@@ -97,6 +97,10 @@ func NewNodConfigUrfave(ctx *cli.Context, logger log.Logger) (*nodecfg.Config, e
 		logger.Info("Starting Erigon on Bor Mainnet...")
 	case networkname.BorDevnet:
 		logger.Info("Starting Erigon on Bor Devnet...")
+	case networkname.Gnosis:
+		logger.Info("Starting Erigon on Gnosis Mainnet...")
+	case networkname.Chiado:
+		logger.Info("Starting Erigon on Chiado testnet...")
 	case "", networkname.Mainnet:
 		if !ctx.IsSet(utils.NetworkIdFlag.Name) {
 			logger.Info("Starting Erigon on Ethereum mainnet...")


### PR DESCRIPTION
minor one, log used to be showing up as devnet
```
Starting Erigon on "devnet"=chiado
```