### PR TITLE
chore: fix some comments

### DIFF
--- a/cl/beacon/beacontest/linux_basepathfs.go
+++ b/cl/beacon/beacontest/linux_basepathfs.go
@@ -233,7 +233,7 @@ func (b *BasePathFs) ReadlinkIfPossible(name string) (string, error) {
 	return "", &os.PathError{Op: "readlink", Path: name, Err: afero.ErrNoReadlink}
 }
 
-// the readDirFile helper is requried
+// the readDirFile helper is required
 
 // readDirFile provides adapter from afero.File to fs.ReadDirFile needed for correct Open
 type readDirFile struct {

--- a/cl/cltypes/solid/bitlist.go
+++ b/cl/cltypes/solid/bitlist.go
@@ -26,7 +26,7 @@ import (
 	"github.com/erigontech/erigon/cl/merkle_tree"
 )
 
-// Bitlist is like a dynamic binary string. It's like a flipbook of 1s and 0s!
+// BitList is like a dynamic binary string. It's like a flipbook of 1s and 0s!
 // And just like a flipbook, we can add (Append), remove (Pop), or look at any bit (Get) we want.
 type BitList struct {
 	// the underlying bytes that store the data

--- a/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
+++ b/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
@@ -332,7 +332,7 @@ func (f *forkGraphDisk) GetState(blockRoot libcommon.Hash, alwaysCopy bool) (*st
 		}
 	}
 
-	// collect all blocks beetwen greatest extending node path and block.
+	// collect all blocks between greatest extending node path and block.
 	blocksInTheWay := []*cltypes.SignedBeaconBlock{}
 	// Use the parent root as a reverse iterator.
 	currentIteratorRoot := blockRoot

--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -375,7 +375,7 @@ func downloadBlobHistoryWorker(cfg StageHistoryReconstructionCfg, ctx context.Co
 					continue
 				}
 				if block.Signature != header.Signature {
-					return errors.New("signature mismatch beetwen blob and stored block")
+					return errors.New("signature mismatch between blob and stored block")
 				}
 				return nil
 			}

--- a/consensus/merge/merge_test.go
+++ b/consensus/merge/merge_test.go
@@ -70,7 +70,7 @@ func (r readerMock) BorSpan(spanId uint64) []byte {
 	return nil
 }
 
-// The thing only that changes beetwen normal ethash checks other than POW, is difficulty
+// The thing only that changes between normal ethash checks other than POW, is difficulty
 // and nonce so we are gonna test those
 func TestVerifyHeaderDifficulty(t *testing.T) {
 	header := &types.Header{


### PR DESCRIPTION
Fix some comments, including the name of the struct, the typos  in the comment.