### PR TITLE
Create git tag before release build, small cosmetic changes.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
     name: Build Artifacts and multi-platform Docker image, publish draft of the Release Notes
 
     steps:
-      - name: Checkout git repository ${{ env.APP_REPO }}
+      - name: Checkout git repository ${{ env.APP_REPO }} reference ${{ inputs.checkout_ref }}
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 ## 4.1.7 release
         with:
           repository: ${{ env.APP_REPO }}
@@ -65,9 +65,6 @@ jobs:
             git push origin ${{ inputs.release_version }}
             echo; echo "Git TAG ${{ inputs.release_version }} created and pushed."
           fi
-
-      - name: testing failure
-        run: exit 1
 
       - name: Run some commands, get commit id
         id: getCommitId
@@ -246,7 +243,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - name: Checkout git repository ${{ env.APP_REPO }}
+      - name: Checkout git repository ${{ env.APP_REPO }} reference ${{ inputs.checkout_ref }}
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 ## 4.1.7 release
         with:
           repository: ${{ env.APP_REPO }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release
+run-name: Build release ${{ inputs.release_version }} from branch ${{ inputs.checkout_ref }} by @${{ github.actor }}
 
 env:
   APPLICATION: "erigon"
@@ -241,7 +242,7 @@ jobs:
   In-case-of-failure:
     name: "In case of failure: remove remote git tag pointing to the new version."
     needs: [ build-release ]
-    if: always() && !contains(needs.build-release.result, 'success') && ${{ inputs.perform_release }} && ${{ (inputs.release_version != '') }}
+    if: always() && !contains(needs.build-release.result, 'success')
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,9 +66,6 @@ jobs:
             echo; echo "Git TAG ${{ inputs.release_version }} created and pushed."
           fi
 
-      - name: simulate failure
-        run: exit 1
-
       - name: Run some commands, get commit id
         id: getCommitId
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           ref: ${{ inputs.checkout_ref }}
           path: 'erigon'
 
-      - name: Check if tag ${{ inputs.release_version }} already exists in case perform_release is set.
+      - name: Check if tag ${{ inputs.release_version }} already exists and create it in case perform_release is set.
         if: ${{ (inputs.perform_release) && (inputs.release_version != '') }}
         run: |
           if git ls-remote --exit-code --quiet --tags origin '${{ inputs.release_version }}'; then
@@ -59,7 +59,13 @@ jobs:
             exit 1
           else
             echo "OK: tag ${{ inputs.release_version }} does not exists. Proceeding."
+            git tag ${{ inputs.release_version }}
+            git push origin ${{ inputs.release_version }}
+            echo; echo "Git TAG ${{ inputs.release_version }} created and pushed."
           fi
+
+      - name: testing failure
+        run: exit 1
 
       - name: Run some commands, get commit id
         id: getCommitId
@@ -230,3 +236,16 @@ jobs:
             --notes "**Improvements:**<br>- ...coming soon <br><br>**Bugfixes:**<br><br>- ...coming soon<br><br>**Docker images:**<br><br>Docker image released:<br> ${{ env.DOCKER_TAGS }}<br><br>... coming soon<br>" \
              ${{ inputs.release_version }} \
              *.tar.gz ${{ env.APPLICATION }}_${{ inputs.release_version }}_checksums.txt
+
+  in-case-failure:
+    needs: [ build-release ]
+    if:  always() && !contains(needs.build-release.result, 'success') && ${{ (inputs.perform_release) && (inputs.release_version != '') }}
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Remove git tag 
+        run: |
+          cd erigon
+          git push -d origin ${{ inputs.release_version }}
+
+                  

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Check if tag ${{ inputs.release_version }} already exists and create it in case perform_release is set.
         if: ${{ (inputs.perform_release) && (inputs.release_version != '') }}
         run: |
+          cd erigon
           if git ls-remote --exit-code --quiet --tags origin '${{ inputs.release_version }}'; then
             echo "ERROR: tag ${{ inputs.release_version }} exists and workflow is performing release. Exit."
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,10 +240,22 @@ jobs:
 
   in-case-failure:
     needs: [ build-release ]
-    if:  always() && !contains(needs.build-release.result, 'success') && ${{ (inputs.perform_release) && (inputs.release_version != '') }}
+    if: |
+        always() &&
+        !contains(needs.build-release.result, 'success') && 
+        ${{ inputs.perform_release }} && 
+        ${{ (inputs.release_version != '') }}
     runs-on: ubuntu-22.04
 
     steps:
+      - name: Checkout git repository ${{ env.APP_REPO }}
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 ## 4.1.7 release
+        with:
+          repository: ${{ env.APP_REPO }}
+          fetch-depth: 0
+          ref: ${{ inputs.checkout_ref }}
+          path: 'erigon'
+
       - name: Remove git tag 
         run: |
           cd erigon

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,13 +238,10 @@ jobs:
              ${{ inputs.release_version }} \
              *.tar.gz ${{ env.APPLICATION }}_${{ inputs.release_version }}_checksums.txt
 
-  in-case-failure:
+  In-case-of-failure:
+    name: "In case of failure: remove remote git tag pointing to the new version."
     needs: [ build-release ]
-    if: |
-        always() &&
-        !contains(needs.build-release.result, 'success') && 
-        ${{ inputs.perform_release }} && 
-        ${{ (inputs.release_version != '') }}
+    if: always() && !contains(needs.build-release.result, 'success') && ${{ inputs.perform_release }} && ${{ (inputs.release_version != '') }}
     runs-on: ubuntu-22.04
 
     steps:
@@ -256,7 +253,7 @@ jobs:
           ref: ${{ inputs.checkout_ref }}
           path: 'erigon'
 
-      - name: Remove git tag 
+      - name: Rollback - remove git tag 
         run: |
           cd erigon
           git push -d origin ${{ inputs.release_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ run-name: Build release ${{ inputs.release_version }} from branch ${{ inputs.che
 env:
   APPLICATION: "erigon"
   BUILDER_IMAGE: "golang:1.22-bookworm"
-  DOCKER_BASE_IMAGE: "debian:12.7-slim"
+  DOCKER_BASE_IMAGE: "debian:12.8-slim"
   APP_REPO: "erigontech/erigon"
   PACKAGE: "github.com/erigontech/erigon"
   DOCKERHUB_REPOSITORY: "erigontech/erigon"
@@ -251,7 +251,8 @@ jobs:
           ref: ${{ inputs.checkout_ref }}
           path: 'erigon'
 
-      - name: Rollback - remove git tag 
+      - name: Rollback - remove git tag ${{ inputs.release_version }}
+        if: ${{ (inputs.perform_release) && (inputs.release_version != '') }}
         run: |
           cd erigon
           git push -d origin ${{ inputs.release_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,9 @@ jobs:
             echo; echo "Git TAG ${{ inputs.release_version }} created and pushed."
           fi
 
+      - name: simulate failure
+        run: exit 1
+
       - name: Run some commands, get commit id
         id: getCommitId
         run: |


### PR DESCRIPTION
See https://github.com/erigontech/erigon/issues/12661 for more details.
Changes:
- workflow will create git tag referencing to the last commit id in "checkout_ref" (branch name as for now)
- in case of not successful build -- second job will start and will remove git tag.
- workflow will now contain useful name which reflects released version, branch used to build artifacts and person who run workflow.
- latest docker base images debian:12.8-slim