### PR TITLE
Use cache only on main and release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - uses: actions/setup-go@v5
         with:
           go-version: '1.22'
+          cache: ${{ contains(fromJSON('[
+            "refs/heads/release/2.60",
+            "refs/heads/release/2.61",
+            "refs/heads/main"
+            ]'), github.ref) }}
+
       - name: Install dependencies on Linux
         if: runner.os == 'Linux'
         run: sudo apt update && sudo apt install build-essential
@@ -84,6 +91,11 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.22'
+          cache: ${{ contains(fromJSON('[
+            "refs/heads/release/2.60",
+            "refs/heads/release/2.61",
+            "refs/heads/main"
+            ]'), github.ref) }}
 
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
Using cache by default for each run is useless waste of cache.

Some runs for some branches executed only once, but their caches replace action cache which instead could be used by frequently running jobs on main/release branches.