### PR TITLE
polygon: fix linter

### DIFF
--- a/eth/stagedsync/stage_polygon_sync.go
+++ b/eth/stagedsync/stage_polygon_sync.go
@@ -1541,9 +1541,7 @@ func (e *polygonSyncStageExecutionEngine) processCachedForkChoiceIfNeeded(ctx co
 	}
 
 	if e.cachedForkChoice.state == forkChoiceConnected {
-		if err := e.executeForkChoice(tx); err != nil {
-			return err
-		}
+		return e.executeForkChoice(tx)
 	}
 
 	if e.cachedForkChoice.state == forkChoiceExecuted {


### PR DESCRIPTION
e.executeForkChoice(tx) always returns err which is expected but the linter complains that there is an unnecessary if err != nil check in the caller of executeForkChoice which is a fair suggestion to remove