### PR TITLE
Switch to dynamically linked binaries in goreleaser

### DIFF
--- a/.github/workflows/ci-cd-main-branch-docker-images.yml
+++ b/.github/workflows/ci-cd-main-branch-docker-images.yml
@@ -83,7 +83,7 @@ jobs:
           -v ${HOME}/go/pkg/mod:/go/pkg/mod \
           -w /erigon --entrypoint /bin/sh \
           ${{ env.BUILDER_IMAGE }} \
-          -c "apk update; apk add make git gcc libstdc++ build-base linux-headers bash ca-certificates; git config --global --add safe.directory /erigon; make GOARCH=arm64 GOBIN=/erigon-build BUILD_TAGS=nosqlite,noboltdb,nosilkworm,netgo erigon integration rpcdaemon"
+          -c "apk update; apk add make git gcc libstdc++ build-base linux-headers bash ca-certificates; git config --global --add safe.directory /erigon; make GOARCH=arm64 GOBIN=/erigon-build BUILD_TAGS=nosqlite,noboltdb,nosilkworm erigon integration rpcdaemon"
 
       - name: Build amd64
         run: |
@@ -94,7 +94,7 @@ jobs:
           -v ${HOME}/go/pkg/mod:/go/pkg/mod \
           -w /erigon --entrypoint /bin/sh \
           ${{ env.BUILDER_IMAGE }} \
-          -c "apk update; apk add make git gcc libstdc++ build-base linux-headers bash ca-certificates; git config --global --add safe.directory /erigon; make GOARCH=amd64 GOAMD64=v2 GOBIN=/erigon-build BUILD_TAGS=nosqlite,noboltdb,nosilkworm,netgo erigon integration rpcdaemon"
+          -c "apk update; apk add make git gcc libstdc++ build-base linux-headers bash ca-certificates; git config --global --add safe.directory /erigon; make GOARCH=amd64 GOAMD64=v2 GOBIN=/erigon-build BUILD_TAGS=nosqlite,noboltdb,nosilkworm erigon integration rpcdaemon"
 
       - name: Build and push multi-platform docker image based on the commit id ${{ steps.getCommitId.outputs.short_commit_id }} in the main branch
         env:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -423,7 +423,7 @@ builds:
       - -trimpath
       - -buildvcs=false
     ldflags:
-      - -s -w -extldflags "-static"
+      - -s -w
       - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
 
   - id: linux-amd64-downloader
@@ -444,7 +444,7 @@ builds:
       - -trimpath
       - -buildvcs=false
     ldflags:
-      - -s -w -extldflags "-static"
+      - -s -w
       - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
 
   - id: linux-amd64-devnet
@@ -465,7 +465,7 @@ builds:
       - -trimpath
       - -buildvcs=false
     ldflags:
-      - -s -w -extldflags "-static"
+      - -s -w
       - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
 
   - id: linux-amd64-evm
@@ -486,7 +486,7 @@ builds:
       - -trimpath
       - -buildvcs=false
     ldflags:
-      - -s -w -extldflags "-static"
+      - -s -w
       - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
 
   - id: linux-amd64-caplin
@@ -507,7 +507,7 @@ builds:
       - -trimpath
       - -buildvcs=false
     ldflags:
-      - -s -w -extldflags "-static"
+      - -s -w
       - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
 
   - id: linux-amd64-diag
@@ -528,7 +528,7 @@ builds:
       - -trimpath
       - -buildvcs=false
     ldflags:
-      - -s -w -extldflags "-static"
+      - -s -w
       - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
 
   - id: linux-amd64-integration
@@ -549,7 +549,7 @@ builds:
       - -trimpath
       - -buildvcs=false
     ldflags:
-      - -s -w -extldflags "-static"
+      - -s -w
       - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
 
   - id: linux-amd64-rpcdaemon
@@ -570,7 +570,7 @@ builds:
       - -trimpath
       - -buildvcs=false
     ldflags:
-      - -s -w -extldflags "-static"
+      - -s -w
       - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
 
   - id: linux-amd64-sentry
@@ -591,7 +591,7 @@ builds:
       - -trimpath
       - -buildvcs=false
     ldflags:
-      - -s -w -extldflags "-static"
+      - -s -w
       - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
 
   - id: linux-amd64-txpool
@@ -612,7 +612,7 @@ builds:
       - -trimpath
       - -buildvcs=false
     ldflags:
-      - -s -w -extldflags "-static"
+      - -s -w
       - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
 ## End of Linux AMD64 (v1, v2)
 
@@ -633,7 +633,7 @@ builds:
       - -trimpath
       - -buildvcs=false
     ldflags:
-      - -s -w -extldflags "-static"
+      - -s -w
       - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
 
   - id: linux-arm64-downloader
@@ -651,7 +651,7 @@ builds:
       - -trimpath
       - -buildvcs=false
     ldflags:
-      - -s -w -extldflags "-static"
+      - -s -w
       - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
 
   - id: linux-arm64-devnet
@@ -669,7 +669,7 @@ builds:
       - -trimpath
       - -buildvcs=false
     ldflags:
-      - -s -w -extldflags "-static"
+      - -s -w
       - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
 
   - id: linux-arm64-evm
@@ -687,7 +687,7 @@ builds:
       - -trimpath
       - -buildvcs=false
     ldflags:
-      - -s -w -extldflags "-static"
+      - -s -w
       - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
 
   - id: linux-arm64-caplin
@@ -705,7 +705,7 @@ builds:
       - -trimpath
       - -buildvcs=false
     ldflags:
-      - -s -w -extldflags "-static"
+      - -s -w
       - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
 
   - id: linux-arm64-diag
@@ -723,7 +723,7 @@ builds:
       - -trimpath
       - -buildvcs=false
     ldflags:
-      - -s -w -extldflags "-static"
+      - -s -w
       - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
 
   - id: linux-arm64-integration
@@ -741,7 +741,7 @@ builds:
       - -trimpath
       - -buildvcs=false
     ldflags:
-      - -s -w -extldflags "-static"
+      - -s -w
       - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
 
   - id: linux-arm64-rpcdaemon
@@ -759,7 +759,7 @@ builds:
       - -trimpath
       - -buildvcs=false
     ldflags:
-      - -s -w -extldflags "-static"
+      - -s -w
       - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
 
   - id: linux-arm64-sentry
@@ -777,7 +777,7 @@ builds:
       - -trimpath
       - -buildvcs=false
     ldflags:
-      - -s -w -extldflags "-static"
+      - -s -w
       - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
 
   - id: linux-arm64-txpool
@@ -795,7 +795,7 @@ builds:
       - -trimpath
       - -buildvcs=false
     ldflags:
-      - -s -w -extldflags "-static"
+      - -s -w
       - -X {{ .Env.PACKAGE }}/params.GitCommit={{ .Env.GIT_COMMIT }} -X {{ .Env.PACKAGE }}/params.GitBranch={{ .Env.GIT_BRANCH }} -X {{ .Env.PACKAGE }}/params.GitTag={{ .Env.GIT_TAG }}
 ## End of Linux ARM64
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,7 +31,7 @@ builds:
       - CXX=o64-clang++
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -51,7 +51,7 @@ builds:
       - CXX=o64-clang++
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -71,7 +71,7 @@ builds:
       - CXX=o64-clang++
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -91,7 +91,7 @@ builds:
       - CXX=o64-clang++
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -111,7 +111,7 @@ builds:
       - CXX=o64-clang++
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -131,7 +131,7 @@ builds:
       - CXX=o64-clang++
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -151,7 +151,7 @@ builds:
       - CXX=o64-clang++
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -171,7 +171,7 @@ builds:
       - CXX=o64-clang++
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -191,7 +191,7 @@ builds:
       - CXX=o64-clang++
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -211,7 +211,7 @@ builds:
       - CXX=o64-clang++
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -232,7 +232,7 @@ builds:
       - CXX=oa64-clang++
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -250,7 +250,7 @@ builds:
       - CXX=oa64-clang++
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -268,7 +268,7 @@ builds:
       - CXX=oa64-clang++
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -286,7 +286,7 @@ builds:
       - CXX=oa64-clang++
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -304,7 +304,7 @@ builds:
       - CXX=oa64-clang++
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -322,7 +322,7 @@ builds:
       - CXX=oa64-clang++
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -340,7 +340,7 @@ builds:
       - CXX=oa64-clang++
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -358,7 +358,7 @@ builds:
       - CXX=oa64-clang++
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -376,7 +376,7 @@ builds:
       - CXX=oa64-clang++
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -394,7 +394,7 @@ builds:
       - CXX=oa64-clang++
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT_DARWIN }}
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -418,7 +418,7 @@ builds:
       - CXX=x86_64-linux-gnu-g++
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -439,7 +439,7 @@ builds:
       - CXX=x86_64-linux-gnu-g++
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -460,7 +460,7 @@ builds:
       - CXX=x86_64-linux-gnu-g++
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -481,7 +481,7 @@ builds:
       - CXX=x86_64-linux-gnu-g++
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -502,7 +502,7 @@ builds:
       - CXX=x86_64-linux-gnu-g++
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -523,7 +523,7 @@ builds:
       - CXX=x86_64-linux-gnu-g++
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -544,7 +544,7 @@ builds:
       - CXX=x86_64-linux-gnu-g++
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -565,7 +565,7 @@ builds:
       - CXX=x86_64-linux-gnu-g++
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -586,7 +586,7 @@ builds:
       - CXX=x86_64-linux-gnu-g++
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -607,7 +607,7 @@ builds:
       - CXX=x86_64-linux-gnu-g++
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }}
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -628,7 +628,7 @@ builds:
       - CXX=aarch64-linux-gnu-g++
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -646,7 +646,7 @@ builds:
       - CXX=aarch64-linux-gnu-g++
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -664,7 +664,7 @@ builds:
       - CXX=aarch64-linux-gnu-g++
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -682,7 +682,7 @@ builds:
       - CXX=aarch64-linux-gnu-g++
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -700,7 +700,7 @@ builds:
       - CXX=aarch64-linux-gnu-g++
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -718,7 +718,7 @@ builds:
       - CXX=aarch64-linux-gnu-g++
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -736,7 +736,7 @@ builds:
       - CXX=aarch64-linux-gnu-g++
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -754,7 +754,7 @@ builds:
       - CXX=aarch64-linux-gnu-g++
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -772,7 +772,7 @@ builds:
       - CXX=aarch64-linux-gnu-g++
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false
@@ -790,7 +790,7 @@ builds:
       - CXX=aarch64-linux-gnu-g++
       - CGO_CFLAGS={{ .Env.CGO_CFLAGS_DEFAULT }} -D__BLST_PORTABLE__
       - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS_DEFAULT }}
-    tags: [ nosqlite, noboltdb, nosilkworm, netgo ]
+    tags: [ nosqlite, noboltdb, nosilkworm ]
     flags:
       - -trimpath
       - -buildvcs=false

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ ifeq ($(shell uname -s), Darwin)
 endif
 
 # about netgo see: https://github.com/golang/go/issues/30310#issuecomment-471669125 and https://github.com/golang/go/issues/57757
-BUILD_TAGS = nosqlite,noboltdb,netgo
+BUILD_TAGS = nosqlite,noboltdb
 
 ifneq ($(shell "$(CURDIR)/turbo/silkworm/silkworm_compat_check.sh"),)
 	BUILD_TAGS := $(BUILD_TAGS),nosilkworm


### PR DESCRIPTION
The released binaries of erigon3-alpha5 have cross-compatibility issues as demonstrated here:

https://github.com/erigontech/erigon/issues/12556
https://github.com/erigontech/erigon/issues/12570

The reason for this was the static linking of system libraries which may not work correctly  in other operating systems (e.g. Arch Linux).

This problem can be averted by producing a dynamically linked binary instead, and assume that the user has correctly working system library dependencies.
