### PR TITLE
cl: fix caplin interop with lighthouse vc on gnosis

### DIFF
--- a/cl/clparams/config.go
+++ b/cl/clparams/config.go
@@ -885,6 +885,7 @@ func holeskyConfig() BeaconChainConfig {
 
 func gnosisConfig() BeaconChainConfig {
 	cfg := MainnetBeaconConfig
+	cfg.PresetBase = "gnosis"
 	cfg.MinGenesisTime = 1638968400
 	cfg.MinGenesisActiveValidatorCount = 4096
 	cfg.GenesisDelay = 6000
@@ -922,6 +923,7 @@ func gnosisConfig() BeaconChainConfig {
 
 func chiadoConfig() BeaconChainConfig {
 	cfg := MainnetBeaconConfig
+	cfg.PresetBase = "gnosis"
 	cfg.MinGenesisTime = 1665396000
 	cfg.MinGenesisActiveValidatorCount = 6000
 	cfg.GenesisDelay = 300

--- a/eth/stagedsync/stages/sync_mode.go
+++ b/eth/stagedsync/stages/sync_mode.go
@@ -1,9 +1,5 @@
 package stages
 
-import (
-	"fmt"
-)
-
 type Mode int8 // in which staged sync can run
 
 const (
@@ -37,6 +33,6 @@ func ModeFromString(s string) Mode { //nolint
 	case "UnknownMode":
 		return ModeUnknown
 	default:
-		panic(fmt.Sprintf("unexpected mode string: %s", s))
+		panic("unexpected mode string: " + s)
 	}
 }


### PR DESCRIPTION
Lighthouse VC was throwing the below error when running a validator with Caplin on Chiado:
```
The minimal/mainnet spec type of the beacon node does not match the validator
```

After a bit of debugging I found that it was because Lighthouse expects the preset base to be set to "gnosis"