### PR TITLE
qa-tests: test Erigon on a 32GB memory machine

### DIFF
--- a/.github/workflows/qa-constrained-tip-tracking.yml
+++ b/.github/workflows/qa-constrained-tip-tracking.yml
@@ -44,7 +44,7 @@ jobs:
         set +e # Disable exit on error
         
         # Run Erigon under memory constraints, wait sync and check ability to maintain sync
-        cgexec -g memory:constrained_res_64G python3 $ERIGON_QA_PATH/test_system/qa-tests/tip-tracking/run_and_check_tip_tracking.py \
+        cgexec -g memory:constrained_res_32G python3 $ERIGON_QA_PATH/test_system/qa-tests/tip-tracking/run_and_check_tip_tracking.py \
           ${{ github.workspace }}/build/bin $ERIGON_TESTBED_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN standard_node statistics
   
         # Capture monitoring script exit status

--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -32,9 +32,7 @@ jobs:
       - name: Checkout RPC Tests Repository & Install Requirements
         run: |
           rm -rf ${{ runner.workspace }}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch main https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
-          cd ${{ runner.workspace }}/rpc-tests
-          git checkout 0edbdc1681b2a7080212364dbd0a22f06a163614
+          git -c advice.detachedHead=false clone --depth 1 --branch v1.14.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
           pip3 install -r requirements.txt
 
       - name: Clean Erigon Build Directory

--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -33,6 +33,7 @@ jobs:
         run: |
           rm -rf ${{ runner.workspace }}/rpc-tests
           git -c advice.detachedHead=false clone --depth 1 --branch v1.14.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
+          cd ${{ runner.workspace }}/rpc-tests
           pip3 install -r requirements.txt
 
       - name: Clean Erigon Build Directory


### PR DESCRIPTION
This PR modifies the tip-tracking test to test Erigon on the chain tip by limiting the ram usage to 32gb (previously 64gb).

The ram limitation was obtained via cgroups:
```
cgcreate -a runner_user:runner_user -g memory:constrained_res_32G -t runner_user:runner_user
cgset -r memory.max=32G constrained_res_32G
cgset -r memory.swap.max=max constrained_res_32G
```
One [run](https://github.com/erigontech/erigon/actions/runs/11939412573/job/33279879839) showed some difficulty holding the tip. It is not clear if this was a coincidence.
