### PR TITLE
Caplin: fix occasional missed attestations

### DIFF
--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -183,6 +183,7 @@ func (a *ApiHandler) GetEthV1ValidatorAttestationData(
 		fmt.Println("cache-hit")
 		return newBeaconResponse(attestationData), nil
 	}
+	fmt.Println("cache-miss")
 
 	clversion := a.beaconChainCfg.GetCurrentStateVersion(*slot / a.beaconChainCfg.SlotsPerEpoch)
 	if clversion.BeforeOrEqual(clparams.DenebVersion) && committeeIndex == nil {

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -144,6 +144,7 @@ func (a *ApiHandler) GetEthV1ValidatorAttestationData(
 	w http.ResponseWriter,
 	r *http.Request,
 ) (*beaconhttp.BeaconResponse, error) {
+	start := time.Now()
 	slot, err := beaconhttp.Uint64FromQueryParams(r, "slot")
 	if err != nil {
 		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
@@ -180,10 +181,12 @@ func (a *ApiHandler) GetEthV1ValidatorAttestationData(
 		log.Warn("Failed to get attestation data", "err", err)
 	}
 	if ok {
-		fmt.Println("cache-hit")
+		fmt.Println("cache-hit", time.Since(start))
 		return newBeaconResponse(attestationData), nil
 	}
-	fmt.Println("cache-miss")
+	defer func() {
+		fmt.Println("cache-miss", time.Since(start))
+	}()
 
 	clversion := a.beaconChainCfg.GetCurrentStateVersion(*slot / a.beaconChainCfg.SlotsPerEpoch)
 	if clversion.BeforeOrEqual(clparams.DenebVersion) && committeeIndex == nil {

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -181,12 +181,8 @@ func (a *ApiHandler) GetEthV1ValidatorAttestationData(
 		log.Warn("Failed to get attestation data", "err", err)
 	}
 	if ok {
-		fmt.Println("cache-hit", time.Since(start))
 		return newBeaconResponse(attestationData), nil
 	}
-	defer func() {
-		fmt.Println("cache-miss", time.Since(start))
-	}()
 
 	clversion := a.beaconChainCfg.GetCurrentStateVersion(*slot / a.beaconChainCfg.SlotsPerEpoch)
 	if clversion.BeforeOrEqual(clparams.DenebVersion) && committeeIndex == nil {

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -144,7 +144,6 @@ func (a *ApiHandler) GetEthV1ValidatorAttestationData(
 	w http.ResponseWriter,
 	r *http.Request,
 ) (*beaconhttp.BeaconResponse, error) {
-	start := time.Now()
 	slot, err := beaconhttp.Uint64FromQueryParams(r, "slot")
 	if err != nil {
 		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)

--- a/cl/phase1/stages/forkchoice.go
+++ b/cl/phase1/stages/forkchoice.go
@@ -321,12 +321,12 @@ func postForkchoiceOperations(ctx context.Context, tx kv.RwTx, logger log.Logger
 	if _, err = cfg.attestationDataProducer.ProduceAndCacheAttestationData(tx, headState, headRoot, headState.Slot(), 0); err != nil {
 		logger.Warn("failed to produce and cache attestation data", "err", err)
 	}
+	start := time.Now()
 	cfg.forkChoice.SetSynced(true) // Now we are synced
 	// Update the head state with the new head state
 	if err := cfg.syncedData.OnHeadState(headState); err != nil {
 		return fmt.Errorf("failed to set head state: %w", err)
 	}
-	start := time.Now()
 	defer func() {
 		logger.Debug("Post forkchoice operations", "duration", time.Since(start))
 	}()

--- a/cl/phase1/stages/forkchoice.go
+++ b/cl/phase1/stages/forkchoice.go
@@ -319,6 +319,9 @@ func postForkchoiceOperations(ctx context.Context, tx kv.RwTx, logger log.Logger
 	if err != nil {
 		return fmt.Errorf("failed to get state at block root: %w", err)
 	}
+	if _, err = cfg.attestationDataProducer.ProduceAndCacheAttestationData(tx, headState, headRoot, headState.Slot(), 0); err != nil {
+		logger.Warn("failed to produce and cache attestation data", "err", err)
+	}
 	cfg.forkChoice.SetSynced(true) // Now we are synced
 	// Update the head state with the new head state
 	if err := cfg.syncedData.OnHeadState(headState); err != nil {
@@ -331,9 +334,6 @@ func postForkchoiceOperations(ctx context.Context, tx kv.RwTx, logger log.Logger
 
 	return cfg.syncedData.ViewHeadState(func(headState *state.CachingBeaconState) error {
 		// Produce and cache attestation data for validator node (this is not an expensive operation so we can do it for all nodes)
-		// if _, err = cfg.attestationDataProducer.ProduceAndCacheAttestationData(tx, headState, headRoot, headState.Slot(), 0); err != nil {
-		// 	logger.Warn("failed to produce and cache attestation data", "err", err)
-		// }
 
 		// Run indexing routines for the database
 		if err := runIndexingRoutines(ctx, tx, cfg, headState); err != nil {

--- a/cl/phase1/stages/forkchoice.go
+++ b/cl/phase1/stages/forkchoice.go
@@ -313,7 +313,6 @@ func saveHeadStateOnDiskIfNeeded(cfg *Cfg, headState *state.CachingBeaconState) 
 // postForkchoiceOperations performs the post fork choice operations such as updating the head state, producing and caching attestation data,
 // these sets of operations can take as long as they need to run, as by-now we are already synced.
 func postForkchoiceOperations(ctx context.Context, tx kv.RwTx, logger log.Logger, cfg *Cfg, headSlot uint64, headRoot common.Hash) error {
-
 	// Retrieve the head state
 	headState, err := cfg.forkChoice.GetStateAtBlockRoot(headRoot, false)
 	if err != nil {

--- a/cl/validator/attestation_producer/attestation_producer.go
+++ b/cl/validator/attestation_producer/attestation_producer.go
@@ -124,10 +124,14 @@ func (ap *attestationProducer) CachedAttestationData(slot uint64, committeeIndex
 	ap.attCacheMutex.RLock()
 	defer ap.attCacheMutex.RUnlock()
 	if baseAttestationData, ok := ap.attestationsCache.Get(epoch); ok {
+		beaconBlockRoot, ok := ap.blockRootsUsedForSlotCache.Get(slot)
+		if !ok {
+			return solid.AttestationData{}, false, nil
+		}
 		return solid.AttestationData{
 			Slot:            slot,
 			CommitteeIndex:  committeeIndex,
-			BeaconBlockRoot: baseAttestationData.BeaconBlockRoot,
+			BeaconBlockRoot: beaconBlockRoot,
 			Source:          baseAttestationData.Source,
 			Target:          baseAttestationData.Target,
 		}, true, nil

--- a/cl/validator/attestation_producer/attestation_producer.go
+++ b/cl/validator/attestation_producer/attestation_producer.go
@@ -51,7 +51,7 @@ type attestationProducer struct {
 }
 
 func New(ctx context.Context, beaconCfg *clparams.BeaconChainConfig) AttestationDataProducer {
-	ttl := time.Duration(beaconCfg.SecondsPerSlot) * time.Second
+	ttl := time.Duration(beaconCfg.SecondsPerSlot) * time.Second / 2
 	attestationsCache := lru.NewWithTTL[uint64, solid.AttestationData]("attestations", attestationsCacheSize, ttl)
 	blockRootsUsedForSlotCache, err := lru.New[uint64, libcommon.Hash]("blockRootsUsedForSlot", attestationsCacheSize)
 	if err != nil {
@@ -200,6 +200,7 @@ func (ap *attestationProducer) ProduceAndCacheAttestationData(tx kv.Tx, baseStat
 		Source:          baseState.CurrentJustifiedCheckpoint(),
 		Target:          targetCheckpoint,
 	}
+	fmt.Println("baseAttestationData", baseAttestationData, "epoch", epoch, "baseStateBlockRoot", baseStateBlockRoot)
 	ap.attestationsCache.Add(epoch, baseAttestationData)
 	ap.blockRootsUsedForSlotCache.Add(slot, baseStateBlockRoot)
 

--- a/cl/validator/attestation_producer/interface.go
+++ b/cl/validator/attestation_producer/interface.go
@@ -25,4 +25,5 @@ import (
 
 type AttestationDataProducer interface {
 	ProduceAndCacheAttestationData(tx kv.Tx, baseState *state.CachingBeaconState, baseStateBlockRoot libcommon.Hash, slot uint64, committeeIndex uint64) (solid.AttestationData, error)
+	CachedAttestationData(slot uint64, committeeIndex uint64) (solid.AttestationData, bool, error)
 }

--- a/cl/validator/attestation_producer/interface.go
+++ b/cl/validator/attestation_producer/interface.go
@@ -21,9 +21,10 @@ import (
 	"github.com/erigontech/erigon-lib/kv"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
 	"github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 type AttestationDataProducer interface {
 	ProduceAndCacheAttestationData(tx kv.Tx, baseState *state.CachingBeaconState, baseStateBlockRoot libcommon.Hash, slot uint64, committeeIndex uint64) (solid.AttestationData, error)
-	CachedAttestationData(slot uint64, committeeIndex uint64) (solid.AttestationData, bool, error)
+	CachedAttestationData(slot uint64, committeeIndex uint64, beaconBlockRoot common.Hash) (solid.AttestationData, bool, error)
 }

--- a/cl/validator/attestation_producer/interface.go
+++ b/cl/validator/attestation_producer/interface.go
@@ -21,10 +21,9 @@ import (
 	"github.com/erigontech/erigon-lib/kv"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
 	"github.com/erigontech/erigon/cl/phase1/core/state"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 type AttestationDataProducer interface {
 	ProduceAndCacheAttestationData(tx kv.Tx, baseState *state.CachingBeaconState, baseStateBlockRoot libcommon.Hash, slot uint64, committeeIndex uint64) (solid.AttestationData, error)
-	CachedAttestationData(slot uint64, committeeIndex uint64, beaconBlockRoot common.Hash) (solid.AttestationData, bool, error)
+	CachedAttestationData(slot uint64, committeeIndex uint64) (solid.AttestationData, bool, error)
 }


### PR DESCRIPTION
Cache attestation before calling `OnHeadState`, the reason why it was a probably is that it takes up to a second to update the head state but if we wait too much other nodes might stop accepting attestations and we may lose the block vote