### PR TITLE
Fix salt & transactions-to-block downloads

### DIFF
--- a/core/snaptype/block_types.go
+++ b/core/snaptype/block_types.go
@@ -54,6 +54,7 @@ func init() {
 
 var Enums = struct {
 	snaptype.Enums
+	Salt,
 	Headers,
 	Bodies,
 	Transactions,
@@ -64,14 +65,15 @@ var Enums = struct {
 	Txt snaptype.Enum
 }{
 	Enums:            snaptype.Enums{},
-	Headers:          snaptype.MinCoreEnum,
-	Bodies:           snaptype.MinCoreEnum + 1,
-	Transactions:     snaptype.MinCoreEnum + 2,
-	Domains:          snaptype.MinCoreEnum + 3,
-	Histories:        snaptype.MinCoreEnum + 4,
-	InvertedIndicies: snaptype.MinCoreEnum + 5,
-	Accessor:         snaptype.MinCoreEnum + 6,
-	Txt:              snaptype.MinCoreEnum + 7,
+	Salt:             snaptype.MinCoreEnum,
+	Headers:          snaptype.MinCoreEnum + 1,
+	Bodies:           snaptype.MinCoreEnum + 2,
+	Transactions:     snaptype.MinCoreEnum + 3,
+	Domains:          snaptype.MinCoreEnum + 4,
+	Histories:        snaptype.MinCoreEnum + 5,
+	InvertedIndicies: snaptype.MinCoreEnum + 6,
+	Accessor:         snaptype.MinCoreEnum + 7,
+	Txt:              snaptype.MinCoreEnum + 8,
 }
 
 var Indexes = struct {
@@ -87,6 +89,17 @@ var Indexes = struct {
 }
 
 var (
+	Salt = snaptype.RegisterType(
+		Enums.Domains,
+		"salt",
+		snaptype.Versions{
+			Current:      0, //2,
+			MinSupported: 0,
+		},
+		nil,
+		nil,
+		nil,
+	)
 	Headers = snaptype.RegisterType(
 		Enums.Headers,
 		"headers",

--- a/erigon-lib/chain/snapcfg/util.go
+++ b/erigon-lib/chain/snapcfg/util.go
@@ -89,6 +89,11 @@ func (p Preverified) Typed(types []snaptype.Type) Preverified {
 	var bestVersions btree.Map[string, PreverifiedItem]
 
 	for _, p := range p {
+		if strings.HasPrefix(p.Name, "salt") && strings.HasSuffix(p.Name, "txt") {
+			bestVersions.Set(p.Name, p)
+			continue
+		}
+
 		v, name, ok := strings.Cut(p.Name, "-")
 		if !ok {
 			continue

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -841,6 +841,7 @@ func (d *Downloader) mainLoop(silent bool) error {
 					if t.Info() == nil {
 						ts, ok, err := d.webseeds.DownloadAndSaveTorrentFile(d.ctx, t.Name())
 						if ok && err == nil {
+							fmt.Println("ML")
 							_, _, err = addTorrentFile(d.ctx, ts, d.torrentClient, d.db, d.webseeds)
 							if err != nil {
 								d.logger.Warn("[snapshots] addTorrentFile from webseed", "err", err)
@@ -848,7 +849,7 @@ func (d *Downloader) mainLoop(silent bool) error {
 							}
 						}
 					}
-
+					fmt.Println("AWS 2", urls)
 					t.AddWebSeeds(urls)
 				}
 			}
@@ -2530,6 +2531,7 @@ func (d *Downloader) AddNewSeedableFile(ctx context.Context, name string) error 
 	if err != nil {
 		return fmt.Errorf("AddNewSeedableFile: %w", err)
 	}
+	fmt.Println("NSF")
 	_, _, err = addTorrentFile(ctx, ts, d.torrentClient, d.db, d.webseeds)
 	if err != nil {
 		return fmt.Errorf("addTorrentFile: %w", err)
@@ -2576,7 +2578,7 @@ func (d *Downloader) AddMagnetLink(ctx context.Context, infoHash metainfo.Hash, 
 	if err != nil {
 		return err
 	}
-
+	fmt.Println("AML0")
 	t, ok, err := addTorrentFile(ctx, spec, d.torrentClient, d.db, d.webseeds)
 	if err != nil {
 		return err
@@ -2598,6 +2600,7 @@ func (d *Downloader) AddMagnetLink(ctx context.Context, infoHash metainfo.Hash, 
 
 			ts, ok, err := d.webseeds.DownloadAndSaveTorrentFile(ctx, name)
 			if ok && err == nil {
+				fmt.Println("AML1")
 				_, _, err = addTorrentFile(ctx, ts, d.torrentClient, d.db, d.webseeds)
 				if err != nil {
 					return
@@ -2621,6 +2624,7 @@ func (d *Downloader) AddMagnetLink(ctx context.Context, infoHash metainfo.Hash, 
 
 		urls, ok := d.webseeds.ByFileName(t.Name())
 		if ok {
+			fmt.Println("AWS 3", urls)
 			t.AddWebSeeds(urls)
 		}
 	}(t)

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -841,7 +841,6 @@ func (d *Downloader) mainLoop(silent bool) error {
 					if t.Info() == nil {
 						ts, ok, err := d.webseeds.DownloadAndSaveTorrentFile(d.ctx, t.Name())
 						if ok && err == nil {
-							fmt.Println("ML")
 							_, _, err = addTorrentFile(d.ctx, ts, d.torrentClient, d.db, d.webseeds)
 							if err != nil {
 								d.logger.Warn("[snapshots] addTorrentFile from webseed", "err", err)
@@ -849,7 +848,6 @@ func (d *Downloader) mainLoop(silent bool) error {
 							}
 						}
 					}
-					fmt.Println("AWS 2", urls)
 					t.AddWebSeeds(urls)
 				}
 			}
@@ -2531,7 +2529,6 @@ func (d *Downloader) AddNewSeedableFile(ctx context.Context, name string) error 
 	if err != nil {
 		return fmt.Errorf("AddNewSeedableFile: %w", err)
 	}
-	fmt.Println("NSF")
 	_, _, err = addTorrentFile(ctx, ts, d.torrentClient, d.db, d.webseeds)
 	if err != nil {
 		return fmt.Errorf("addTorrentFile: %w", err)
@@ -2578,7 +2575,6 @@ func (d *Downloader) AddMagnetLink(ctx context.Context, infoHash metainfo.Hash, 
 	if err != nil {
 		return err
 	}
-	fmt.Println("AML0")
 	t, ok, err := addTorrentFile(ctx, spec, d.torrentClient, d.db, d.webseeds)
 	if err != nil {
 		return err
@@ -2600,7 +2596,6 @@ func (d *Downloader) AddMagnetLink(ctx context.Context, infoHash metainfo.Hash, 
 
 			ts, ok, err := d.webseeds.DownloadAndSaveTorrentFile(ctx, name)
 			if ok && err == nil {
-				fmt.Println("AML1")
 				_, _, err = addTorrentFile(ctx, ts, d.torrentClient, d.db, d.webseeds)
 				if err != nil {
 					return
@@ -2624,7 +2619,6 @@ func (d *Downloader) AddMagnetLink(ctx context.Context, infoHash metainfo.Hash, 
 
 		urls, ok := d.webseeds.ByFileName(t.Name())
 		if ok {
-			fmt.Println("AWS 3", urls)
 			t.AddWebSeeds(urls)
 		}
 	}(t)

--- a/erigon-lib/downloader/snaptype/files.go
+++ b/erigon-lib/downloader/snaptype/files.go
@@ -133,8 +133,23 @@ func ParseFileName(dir, fileName string) (res FileInfo, isE3Seedable bool, ok bo
 func parseFileName(dir, fileName string) (res FileInfo, ok bool) {
 	ext := filepath.Ext(fileName)
 	onlyName := fileName[:len(fileName)-len(ext)]
-	parts := strings.Split(onlyName, "-")
+	parts := strings.SplitN(onlyName, "-", 4)
 	res = FileInfo{Path: filepath.Join(dir, fileName), name: fileName, Ext: ext}
+
+	if len(parts) < 2 {
+		return res, ok
+	}
+
+	res.Type, ok = ParseFileType(parts[len(parts)-1])
+
+	if !ok {
+		res.Type, ok = ParseFileType(parts[0])
+	}
+
+	if ok {
+		res.TypeString = res.Type.Name()
+	}
+
 	if len(parts) < 4 {
 		return res, ok
 	}
@@ -155,12 +170,7 @@ func parseFileName(dir, fileName string) (res FileInfo, ok bool) {
 		return
 	}
 	res.To = to * 1_000
-	res.TypeString = parts[3]
 
-	res.Type, ok = ParseFileType(parts[3])
-	if !ok {
-		return res, ok
-	}
 	return res, ok
 }
 

--- a/erigon-lib/downloader/snaptype/type.go
+++ b/erigon-lib/downloader/snaptype/type.go
@@ -224,6 +224,12 @@ func RegisterType(enum Enum, name string, versions Versions, rangeExtractor Rang
 	registeredTypes[enum] = t
 	namedTypes[strings.ToLower(name)] = t
 
+	for _, index := range indexes {
+		if _, ok := namedTypes[strings.ToLower(index.Name)]; !ok {
+			namedTypes[strings.ToLower(index.Name)] = t
+		}
+	}
+
 	return t
 }
 
@@ -349,10 +355,10 @@ type Enums struct {
 }
 
 const MinCoreEnum = 1
-const MinBorEnum = 4
-const MinCaplinEnum = 8
+const MinBorEnum = 5
+const MinCaplinEnum = 9
 
-const MaxEnum = 11
+const MaxEnum = 12
 
 var CaplinEnums = struct {
 	Enums

--- a/erigon-lib/downloader/util.go
+++ b/erigon-lib/downloader/util.go
@@ -86,6 +86,10 @@ func seedableSegmentFiles(dir string, chainName string, skipSeedableCheck bool) 
 			res = append(res, path.Join("caplin", name))
 			continue
 		}
+		if strings.HasPrefix(name, "salt") && strings.HasSuffix(name, "txt") {
+			res = append(res, name)
+			continue
+		}
 		if !skipSeedableCheck && !snaptype.IsCorrectFileName(name) {
 			continue
 		}
@@ -351,9 +355,6 @@ func _addTorrentFile(ctx context.Context, ts *torrent.TorrentSpec, torrentClient
 	t, have = torrentClient.Torrent(ts.InfoHash)
 
 	if !have {
-		if strings.HasSuffix(ts.DisplayName, "txt") {
-			fmt.Println("Adding 0", ts.DisplayName)
-		}
 		t, _, err := torrentClient.AddTorrentSpec(ts)
 		if err != nil {
 			return nil, false, fmt.Errorf("addTorrentFile %s: %w", ts.DisplayName, err)
@@ -364,7 +365,6 @@ func _addTorrentFile(ctx context.Context, ts *torrent.TorrentSpec, torrentClient
 				return nil, false, fmt.Errorf("addTorrentFile %s: update failed: %w", ts.DisplayName, err)
 			}
 		} else {
-			fmt.Println("AWS 0", ts.Webseeds)
 			t.AddWebSeeds(ts.Webseeds)
 			if err := db.Update(ctx, torrentInfoReset(ts.DisplayName, ts.InfoHash.Bytes(), 0)); err != nil {
 				return nil, false, fmt.Errorf("addTorrentFile %s: reset failed: %w", ts.DisplayName, err)
@@ -375,13 +375,11 @@ func _addTorrentFile(ctx context.Context, ts *torrent.TorrentSpec, torrentClient
 	}
 
 	if t.Info() != nil {
-		fmt.Println("AWS 1", ts.Webseeds)
 		t.AddWebSeeds(ts.Webseeds)
 		if err := db.Update(ctx, torrentInfoUpdater(ts.DisplayName, ts.InfoHash.Bytes(), t.Info().Length, nil)); err != nil {
 			return nil, false, fmt.Errorf("update torrent info %s: %w", ts.DisplayName, err)
 		}
 	} else {
-		fmt.Println("Adding 1", ts.DisplayName)
 		t, _, err = torrentClient.AddTorrentSpec(ts)
 		if err != nil {
 			return t, true, fmt.Errorf("add torrent file %s: %w", ts.DisplayName, err)

--- a/erigon-lib/downloader/util.go
+++ b/erigon-lib/downloader/util.go
@@ -351,6 +351,9 @@ func _addTorrentFile(ctx context.Context, ts *torrent.TorrentSpec, torrentClient
 	t, have = torrentClient.Torrent(ts.InfoHash)
 
 	if !have {
+		if strings.HasSuffix(ts.DisplayName, "txt") {
+			fmt.Println("Adding 0", ts.DisplayName)
+		}
 		t, _, err := torrentClient.AddTorrentSpec(ts)
 		if err != nil {
 			return nil, false, fmt.Errorf("addTorrentFile %s: %w", ts.DisplayName, err)
@@ -361,6 +364,7 @@ func _addTorrentFile(ctx context.Context, ts *torrent.TorrentSpec, torrentClient
 				return nil, false, fmt.Errorf("addTorrentFile %s: update failed: %w", ts.DisplayName, err)
 			}
 		} else {
+			fmt.Println("AWS 0", ts.Webseeds)
 			t.AddWebSeeds(ts.Webseeds)
 			if err := db.Update(ctx, torrentInfoReset(ts.DisplayName, ts.InfoHash.Bytes(), 0)); err != nil {
 				return nil, false, fmt.Errorf("addTorrentFile %s: reset failed: %w", ts.DisplayName, err)
@@ -371,11 +375,13 @@ func _addTorrentFile(ctx context.Context, ts *torrent.TorrentSpec, torrentClient
 	}
 
 	if t.Info() != nil {
+		fmt.Println("AWS 1", ts.Webseeds)
 		t.AddWebSeeds(ts.Webseeds)
 		if err := db.Update(ctx, torrentInfoUpdater(ts.DisplayName, ts.InfoHash.Bytes(), t.Info().Length, nil)); err != nil {
 			return nil, false, fmt.Errorf("update torrent info %s: %w", ts.DisplayName, err)
 		}
 	} else {
+		fmt.Println("Adding 1", ts.DisplayName)
 		t, _, err = torrentClient.AddTorrentSpec(ts)
 		if err != nil {
 			return t, true, fmt.Errorf("add torrent file %s: %w", ts.DisplayName, err)

--- a/turbo/snapshotsync/snapshotsync.go
+++ b/turbo/snapshotsync/snapshotsync.go
@@ -308,11 +308,6 @@ func WaitForDownloader(ctx context.Context, logPrefix string, dirs datadir.Dirs,
 	// send all hashes to the Downloader service
 	snapCfg := snapcfg.KnownCfg(cc.ChainName)
 	preverifiedBlockSnapshots := snapCfg.Preverified
-	for _, p := range preverifiedBlockSnapshots {
-		if strings.HasSuffix(p.Name, "txt") {
-			fmt.Println(p.Name)
-		}
-	}
 	downloadRequest := make([]DownloadRequest, 0, len(preverifiedBlockSnapshots))
 
 	blockPrune, historyPrune := computeBlocksToPrune(blockReader, prune)
@@ -348,7 +343,8 @@ func WaitForDownloader(ctx context.Context, logPrefix string, dirs datadir.Dirs,
 		if !caplinState && strings.Contains(p.Name, "caplin/") {
 			continue
 		}
-		if headerchain && !strings.Contains(p.Name, "headers") && !strings.Contains(p.Name, "bodies") {
+		if headerchain &&
+			!(strings.Contains(p.Name, "headers") || strings.Contains(p.Name, "bodies") || p.Name == "salt-blocks.txt") {
 			continue
 		}
 		if _, ok := blackListForPruning[p.Name]; ok {
@@ -369,11 +365,6 @@ func WaitForDownloader(ctx context.Context, logPrefix string, dirs datadir.Dirs,
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-		}
-		for _, p := range downloadRequest {
-			if strings.HasSuffix(p.Path, "txt") {
-				fmt.Println(p.Path)
-			}
 		}
 		if err := RequestSnapshotsDownload(ctx, downloadRequest, snapshotDownloader, logPrefix); err != nil {
 			log.Error(fmt.Sprintf("[%s] call downloader", logPrefix), "err", err)

--- a/turbo/snapshotsync/snapshotsync.go
+++ b/turbo/snapshotsync/snapshotsync.go
@@ -308,6 +308,11 @@ func WaitForDownloader(ctx context.Context, logPrefix string, dirs datadir.Dirs,
 	// send all hashes to the Downloader service
 	snapCfg := snapcfg.KnownCfg(cc.ChainName)
 	preverifiedBlockSnapshots := snapCfg.Preverified
+	for _, p := range preverifiedBlockSnapshots {
+		if strings.HasSuffix(p.Name, "txt") {
+			fmt.Println(p.Name)
+		}
+	}
 	downloadRequest := make([]DownloadRequest, 0, len(preverifiedBlockSnapshots))
 
 	blockPrune, historyPrune := computeBlocksToPrune(blockReader, prune)
@@ -364,6 +369,11 @@ func WaitForDownloader(ctx context.Context, logPrefix string, dirs datadir.Dirs,
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
+		}
+		for _, p := range downloadRequest {
+			if strings.HasSuffix(p.Path, "txt") {
+				fmt.Println(p.Path)
+			}
 		}
 		if err := RequestSnapshotsDownload(ctx, downloadRequest, snapshotDownloader, logPrefix); err != nil {
 			log.Error(fmt.Sprintf("[%s] call downloader", logPrefix), "err", err)


### PR DESCRIPTION
This fixes the download of salt-*.txt fies which where previously excluded from downloads due to the fact that they did not have a defined snapshot type.

It also fixes a similar issue with `transactions-to-block` .idx files which also appeared to be not being downloaded during testing.

It has been tested on amoy, but the fixes should apply to all chains.