### PR TITLE
chore: fix 404 status URL in cmd/devnet/README.md

### DIFF
--- a/cmd/devnet/README.md
+++ b/cmd/devnet/README.md
@@ -1,7 +1,7 @@
 # Devnet
 
 This is an automated tool run on the devnet that simulates p2p connection between nodes and ultimately tests operations on them.
-See [DEV_CHAIN](https://github.com/erigontech/erigon/blob/main/DEV_CHAIN.md) for a manual version.
+See [DEV_CHAIN](https://github.com/erigontech/erigon/blob/main/docs/DEV_CHAIN.md) for a manual version.
 
 The devnet code performs 3 main functions:
 


### PR DESCRIPTION
The previous link has expired and has been replaced with the latest address.