### PR TITLE
workflows: add Pectra kurtosis assertoor tests (#12889)

### DIFF
--- a/.github/workflows/kurtosis/pectra.io
+++ b/.github/workflows/kurtosis/pectra.io
@@ -1,0 +1,23 @@
+participants_matrix:
+  el:
+    - el_type: erigon
+      el_image: test/erigon:current
+  cl:
+    - cl_type: lighthouse
+      cl_image: ethpandaops/lighthouse:pawan-electra-alpha7-0dd215c
+    - cl_type: teku
+      cl_image: ethpandaops/teku:mekong
+network_params:
+  electra_fork_epoch: 1
+  min_validator_withdrawability_delay: 1
+  shard_committee_period: 1
+  churn_limit_quotient: 16
+additional_services:
+  - assertoor
+snooper_enabled: true
+assertoor_params:
+  run_stability_check: false
+  run_block_proposal_check: true
+  tests:
+    - { file: "https://raw.githubusercontent.com/ethpandaops/assertoor/refs/heads/electra-support/playbooks/pectra-dev/kurtosis/all.yaml"}
+

--- a/.github/workflows/kurtosis/regular-assertoor.io
+++ b/.github/workflows/kurtosis/regular-assertoor.io
@@ -1,0 +1,25 @@
+participants_matrix:
+  el:
+    - el_type: erigon
+      el_image: test/erigon:current
+  cl:
+    - cl_type: lighthouse
+    - cl_type: nimbus
+network_params:
+  #electra_fork_epoch: 1
+  min_validator_withdrawability_delay: 1
+  shard_committee_period: 1
+additional_services:
+  - assertoor
+assertoor_params:
+  run_stability_check: false
+  run_block_proposal_check: true
+  tests:
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/all-opcodes-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/blob-transactions-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/dencun-opcodes-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/eoa-transactions-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/synchronized-check.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/validator-exit-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/block-proposal-check.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/master/assertoor-tests/stability-check.yaml

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -1,0 +1,42 @@
+name: Kurtosis Assertoor GitHub Action
+
+env:
+  DOCKERHUB_REPOSITORY: "erigontech/erigon"
+  APP_REPO: "erigontech/erigon"
+
+on:
+  push:
+    branches:
+        - main
+        - release/*
+        - docker_pectra
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  assertoor_test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fast checkout git repository
+        uses: actions/checkout@v4
+
+      - name: Docker build current branch
+        run: |
+          docker build -t test/erigon:current .
+
+      - name: Run regular Kurtosis + assertoor tests
+        uses: ethpandaops/kurtosis-assertoor-github-action@v1
+        with:
+            enclave_name: "kurtosis-run1-${{ github.run_id }}"
+            ethereum_package_args: ".github/workflows/kurtosis/regular-assertoor.io"
+            kurtosis_extra_args: --verbosity detailed --cli-log-level trace
+            persistent_logs: "true"
+
+      - name: Run Pectra Kurtosis + assertoor tests
+        uses: ethpandaops/kurtosis-assertoor-github-action@v1
+        with:
+            enclave_name: "kurtosis-run2-${{ github.run_id }}"
+            ethereum_package_args: ".github/workflows/kurtosis/pectra.io"
+            kurtosis_extra_args: --verbosity detailed --cli-log-level trace
+            persistent_logs: "true"

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -7,9 +7,8 @@ env:
 on:
   push:
     branches:
-        - main
         - release/*
-        - docker_pectra
+        - pectra_e2
   workflow_call:
   workflow_dispatch:
 


### PR DESCRIPTION
Cherry pick https://github.com/erigontech/erigon/pull/12889
- Adding Pectra kurtosis/assertoor tests from Ethpandaops in the workflows
- Renaming file for regular kurtosis from `config.properties` to `regular-kurtosis.io` as it supports syntax highlighting on vscode(possibly others) for yaml-like file