### PR TITLE
qa-tests: avoid deleting snapshots from testbed data dir

### DIFF
--- a/.github/workflows/qa-clean-exit-block-downloading.yml
+++ b/.github/workflows/qa-clean-exit-block-downloading.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Delete Erigon Testbed Data Directory
       if: always()
       run: |
-        rm -rf $ERIGON_TESTBED_DATA_DIR
+        find $ERIGON_TESTBED_DATA_DIR -mindepth 1 -maxdepth 1 ! -name 'snapshots' -exec rm -rf {} +
 
     - name: Resume the Erigon instance dedicated to db maintenance
       run: |

--- a/.github/workflows/qa-constrained-tip-tracking.yml
+++ b/.github/workflows/qa-constrained-tip-tracking.yml
@@ -109,7 +109,7 @@ jobs:
     - name: Delete Erigon Testbed Data Directory
       if: always()
       run: |
-        rm -rf $ERIGON_TESTBED_DATA_DIR
+        find $ERIGON_TESTBED_DATA_DIR -mindepth 1 -maxdepth 1 ! -name 'snapshots' -exec rm -rf {} +
 
     - name: Resume the Erigon instance dedicated to db maintenance
       run: |

--- a/.github/workflows/qa-tip-tracking.yml
+++ b/.github/workflows/qa-tip-tracking.yml
@@ -101,10 +101,10 @@ jobs:
           ${{ github.workspace }}/result-${{ env.CHAIN }}.json
           ${{ env.ERIGON_TESTBED_DATA_DIR }}/logs/erigon.log
 
-    - name: Delete Erigon Testbed Data Directory
+    - name: Delete Erigon Testbed Data Directory (except snapshots)
       if: always()
       run: |
-        rm -rf $ERIGON_TESTBED_DATA_DIR
+        find $ERIGON_TESTBED_DATA_DIR -mindepth 1 -maxdepth 1 ! -name 'snapshots' -exec rm -rf {} +
 
     - name: Resume the Erigon instance dedicated to db maintenance
       run: |


### PR DESCRIPTION
For tests that require a pre-built db, which is usually copied to the testbed data dir, we can improve the setup time if we avoid deleting snapshots from that dir.