### PR TITLE
 Fix typos in documentation and comments

### DIFF
--- a/erigon-lib/downloader/README.md
+++ b/erigon-lib/downloader/README.md
@@ -8,7 +8,7 @@ The diagram below shows the components used to manage downloads between torrents
 
 By default the downloader will try to use the underlying bittorrent library to download files from peers and web peers.  
 
-However this can result in slow or stalled downloads.  When this happens [rclone](https://rclone.org/) can be used as an auxiliary process to aid the download process.  When it is availible the download library will pass downloads to rclone under the following circumstances:
+However this can result in slow or stalled downloads.  When this happens [rclone](https://rclone.org/) can be used as an auxiliary process to aid the download process.  When it is available the download library will pass downloads to rclone under the following circumstances:
 
 * There are no torrent peers available for a file
 * There is not torrent info available for a file, but a torrent file with a matching info hash can be found on the webseeds
@@ -43,13 +43,13 @@ the `well know` hash for a particular segment file in the following format.
 
 Where multiple version of files exists there may be several likes per segment and the code in the released Erigon version will select the version that it is interesting.
 
-As this file is versioned as part of the Erigon release process the file to hash mapping can potentially change between releases.  This can potentially cause an issue for running Erigon node which expect the downloads in the snapshots directory to remain constant, which is why a seperate file is used to record the hases used by the process when it originally downloaded its files.
+As this file is versioned as part of the Erigon release process the file to hash mapping can potentially change between releases.  This can potentially cause an issue for running Erigon node which expect the downloads in the snapshots directory to remain constant, which is why a separate file is used to record the hases used by the process when it originally downloaded its files.
 
 ## snapshot-lock.json
 
 This is a file which resides in the <data-dir>/snapshots directory for an Erigon node.  It is created when the node performs its initial download.  It contains the list of downloaded files and their respective hashes.
 
-When a `snapshot-lock` file exists it is used reather than the chain.toml file to determine which files should be downloaded.  This means that the directory contents can be maintained even if Erigon is re-versioned and the chain.toml contents change.
+When a `snapshot-lock` file exists it is used rather than the chain.toml file to determine which files should be downloaded.  This means that the directory contents can be maintained even if Erigon is re-versioned and the chain.toml contents change.
 
 ### Deleting snapshot-lock.json
 

--- a/erigon-lib/downloader/mdbx_piece_completion.go
+++ b/erigon-lib/downloader/mdbx_piece_completion.go
@@ -129,7 +129,7 @@ func (m *mdbxPieceCompletion) Set(pk metainfo.PieceKey, b bool, awaitFlush bool)
 	}
 
 	// if we're awaiting flush update the DB immediately so it does not
-	// intefere with the timing of the background commit - may not be
+	// interfere with the timing of the background commit - may not be
 	// necessary - in which case the batch can be used
 	if awaitFlush {
 		return m.db.Update(context.Background(), func(tx kv.RwTx) error {


### PR DESCRIPTION

## Changes

### erigon-lib/downloader/README.md
- `availible` -> `available`
  - Correct spelling of "available" in documentation
- `seperate` -> `separate` 
  - Correct spelling of "separate" in documentation
- `reather` -> `rather`
  - Correct spelling of "rather" in documentation

### erigon-lib/downloader/mdbx_piece_completion.go
- `intefere` -> `interfere`
  - Correct spelling of "interfere" in code comment


The changes fix typos and grammatical errors to improve code documentation quality and readability. Having correct spelling and grammar in documentation and comments helps other developers better understand the codebase.

All changes are simple text corrections with no functional code changes.