### PR TITLE
commitment: avoid binary.Wirte 

### DIFF
--- a/erigon-lib/commitment/commitment.go
+++ b/erigon-lib/commitment/commitment.go
@@ -258,34 +258,37 @@ func (be *BranchEncoder) CollectUpdate(
 	return lastNibble, nil
 }
 
+func (be *BranchEncoder) putUvarAndVal(size uint64, val []byte) error {
+	n := binary.PutUvarint(be.bitmapBuf[:], size)
+	wn, err := be.buf.Write(be.bitmapBuf[:n])
+	if err != nil {
+		return err
+	}
+	if n != wn {
+		return errors.New("n != wn size")
+	}
+	wn, err = be.buf.Write(val)
+	if err != nil {
+		return err
+	}
+	if len(val) != wn {
+		return errors.New("wn != value size")
+	}
+	return nil
+}
+
 // Encoded result should be copied before next call to EncodeBranch, underlying slice is reused
 func (be *BranchEncoder) EncodeBranch(bitmap, touchMap, afterMap uint16, readCell func(nibble int, skip bool) (*cell, error)) (BranchData, int, error) {
 	be.buf.Reset()
 
-	if err := binary.Write(be.buf, binary.BigEndian, touchMap); err != nil {
+	var encoded [2]byte
+	binary.BigEndian.PutUint16(encoded[:], touchMap)
+	if _, err := be.buf.Write(encoded[:]); err != nil {
 		return nil, 0, err
 	}
-	if err := binary.Write(be.buf, binary.BigEndian, afterMap); err != nil {
+	binary.BigEndian.PutUint16(encoded[:], afterMap)
+	if _, err := be.buf.Write(encoded[:]); err != nil {
 		return nil, 0, err
-	}
-
-	putUvarAndVal := func(size uint64, val []byte) error {
-		n := binary.PutUvarint(be.bitmapBuf[:], size)
-		wn, err := be.buf.Write(be.bitmapBuf[:n])
-		if err != nil {
-			return err
-		}
-		if n != wn {
-			return errors.New("n != wn size")
-		}
-		wn, err = be.buf.Write(val)
-		if err != nil {
-			return err
-		}
-		if len(val) != wn {
-			return errors.New("wn != value size")
-		}
-		return nil
 	}
 
 	var lastNibble int
@@ -325,27 +328,27 @@ func (be *BranchEncoder) EncodeBranch(bitmap, touchMap, afterMap uint16, readCel
 				return nil, 0, err
 			}
 			if fields&fieldExtension != 0 {
-				if err := putUvarAndVal(uint64(cell.extLen), cell.extension[:cell.extLen]); err != nil {
+				if err := be.putUvarAndVal(uint64(cell.extLen), cell.extension[:cell.extLen]); err != nil {
 					return nil, 0, err
 				}
 			}
 			if fields&fieldAccountAddr != 0 {
-				if err := putUvarAndVal(uint64(cell.accountAddrLen), cell.accountAddr[:cell.accountAddrLen]); err != nil {
+				if err := be.putUvarAndVal(uint64(cell.accountAddrLen), cell.accountAddr[:cell.accountAddrLen]); err != nil {
 					return nil, 0, err
 				}
 			}
 			if fields&fieldStorageAddr != 0 {
-				if err := putUvarAndVal(uint64(cell.storageAddrLen), cell.storageAddr[:cell.storageAddrLen]); err != nil {
+				if err := be.putUvarAndVal(uint64(cell.storageAddrLen), cell.storageAddr[:cell.storageAddrLen]); err != nil {
 					return nil, 0, err
 				}
 			}
 			if fields&fieldHash != 0 {
-				if err := putUvarAndVal(uint64(cell.hashLen), cell.hash[:cell.hashLen]); err != nil {
+				if err := be.putUvarAndVal(uint64(cell.hashLen), cell.hash[:cell.hashLen]); err != nil {
 					return nil, 0, err
 				}
 			}
 			if fields&fieldStateHash != 0 {
-				if err := putUvarAndVal(uint64(cell.stateHashLen), cell.stateHash[:cell.stateHashLen]); err != nil {
+				if err := be.putUvarAndVal(uint64(cell.stateHashLen), cell.stateHash[:cell.stateHashLen]); err != nil {
 					return nil, 0, err
 				}
 			}

--- a/erigon-lib/commitment/commitment.go
+++ b/erigon-lib/commitment/commitment.go
@@ -260,19 +260,11 @@ func (be *BranchEncoder) CollectUpdate(
 
 func (be *BranchEncoder) putUvarAndVal(size uint64, val []byte) error {
 	n := binary.PutUvarint(be.bitmapBuf[:], size)
-	wn, err := be.buf.Write(be.bitmapBuf[:n])
-	if err != nil {
+	if _, err := be.buf.Write(be.bitmapBuf[:n]); err != nil {
 		return err
 	}
-	if n != wn {
-		return errors.New("n != wn size")
-	}
-	wn, err = be.buf.Write(val)
-	if err != nil {
+	if _, err := be.buf.Write(val); err != nil {
 		return err
-	}
-	if len(val) != wn {
-		return errors.New("wn != value size")
 	}
 	return nil
 }

--- a/erigon-lib/commitment/commitment_bench_test.go
+++ b/erigon-lib/commitment/commitment_bench_test.go
@@ -17,30 +17,12 @@
 package commitment
 
 import (
-	"bytes"
 	"encoding/binary"
 	"testing"
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/stretchr/testify/require"
 )
-
-func BenchmarkName(b *testing.B) {
-	b.Run("commitment1", func(b *testing.B) {
-		buf := bytes.NewBuffer(make([]byte, 1024))
-		v := uint16(1)
-		for i := 0; i < b.N; i++ {
-			buf.Reset()
-			_ = binary.Write(buf, binary.BigEndian, v)
-		}
-	})
-	b.Run("commitment2", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			var buf [2]byte
-			binary.BigEndian.PutUint16(buf[:], uint16(i))
-		}
-	})
-}
 
 func BenchmarkBranchMerger_Merge(b *testing.B) {
 	b.StopTimer()

--- a/erigon-lib/commitment/commitment_bench_test.go
+++ b/erigon-lib/commitment/commitment_bench_test.go
@@ -17,12 +17,30 @@
 package commitment
 
 import (
+	"bytes"
 	"encoding/binary"
 	"testing"
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/stretchr/testify/require"
 )
+
+func BenchmarkName(b *testing.B) {
+	b.Run("commitment1", func(b *testing.B) {
+		buf := bytes.NewBuffer(make([]byte, 1024))
+		v := uint16(1)
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			_ = binary.Write(buf, binary.BigEndian, v)
+		}
+	})
+	b.Run("commitment2", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			var buf [2]byte
+			binary.BigEndian.PutUint16(buf[:], uint16(i))
+		}
+	})
+}
 
 func BenchmarkBranchMerger_Merge(b *testing.B) {
 	b.StopTimer()


### PR DESCRIPTION
`binary.Write` is slow: 
- does dynamic interface method call 
- does alloc
- bench of `binary.Write` vs `binary.BigEndian.PutUint32` shows 100ns vs 1ns 

Also i turned `putUvarAndVal` into method (otherwise it allocates closure - and it's context).

