### PR TITLE
StateReader: remove CodeHash parameter

### DIFF
--- a/cmd/integration/commands/state_domains.go
+++ b/cmd/integration/commands/state_domains.go
@@ -171,7 +171,7 @@ func requestDomains(chainDb, stateDb kv.RwDB, ctx context.Context, readDomain st
 		}
 	case "code":
 		for _, addr := range addrs {
-			code, err := r.ReadAccountCode(libcommon.BytesToAddress(addr), 0, libcommon.Hash{})
+			code, err := r.ReadAccountCode(libcommon.BytesToAddress(addr), 0)
 			if err != nil {
 				logger.Error("failed to read code", "addr", addr, "err", err)
 				continue

--- a/core/state/cached_reader.go
+++ b/core/state/cached_reader.go
@@ -78,11 +78,11 @@ func (cr *CachedReader) ReadAccountStorage(address common.Address, incarnation u
 
 // ReadAccountCode is called when code of an account needs to be fetched from the state
 // Usually, one of (address;incarnation) or codeHash is enough to uniquely identify the code
-func (cr *CachedReader) ReadAccountCode(address common.Address, incarnation uint64, codeHash common.Hash) ([]byte, error) {
+func (cr *CachedReader) ReadAccountCode(address common.Address, incarnation uint64) ([]byte, error) {
 	if c, ok := cr.cache.GetCode(address.Bytes(), incarnation); ok {
 		return c, nil
 	}
-	c, err := cr.r.ReadAccountCode(address, incarnation, codeHash)
+	c, err := cr.r.ReadAccountCode(address, incarnation)
 	if err != nil {
 		return nil, err
 	}
@@ -92,8 +92,8 @@ func (cr *CachedReader) ReadAccountCode(address common.Address, incarnation uint
 	return c, nil
 }
 
-func (cr *CachedReader) ReadAccountCodeSize(address common.Address, incarnation uint64, codeHash common.Hash) (int, error) {
-	c, err := cr.ReadAccountCode(address, incarnation, codeHash)
+func (cr *CachedReader) ReadAccountCodeSize(address common.Address, incarnation uint64) (int, error) {
+	c, err := cr.ReadAccountCode(address, incarnation)
 	return len(c), err
 }
 

--- a/core/state/cached_reader.go
+++ b/core/state/cached_reader.go
@@ -79,9 +79,6 @@ func (cr *CachedReader) ReadAccountStorage(address common.Address, incarnation u
 // ReadAccountCode is called when code of an account needs to be fetched from the state
 // Usually, one of (address;incarnation) or codeHash is enough to uniquely identify the code
 func (cr *CachedReader) ReadAccountCode(address common.Address, incarnation uint64, codeHash common.Hash) ([]byte, error) {
-	if codeHash == emptyCodeHashH {
-		return nil, nil
-	}
 	if c, ok := cr.cache.GetCode(address.Bytes(), incarnation); ok {
 		return c, nil
 	}

--- a/core/state/cached_reader3.go
+++ b/core/state/cached_reader3.go
@@ -17,8 +17,6 @@
 package state
 
 import (
-	"bytes"
-
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/kv"
 	"github.com/erigontech/erigon-lib/kv/kvcache"
@@ -84,9 +82,6 @@ func (r *CachedReader3) ReadAccountStorage(address common.Address, incarnation u
 }
 
 func (r *CachedReader3) ReadAccountCode(address common.Address, incarnation uint64, codeHash common.Hash) ([]byte, error) {
-	if bytes.Equal(codeHash.Bytes(), emptyCodeHash) {
-		return nil, nil
-	}
 	code, err := r.cache.GetCode(address[:])
 	if len(code) == 0 {
 		return nil, nil

--- a/core/state/cached_reader3.go
+++ b/core/state/cached_reader3.go
@@ -81,7 +81,7 @@ func (r *CachedReader3) ReadAccountStorage(address common.Address, incarnation u
 	return enc, nil
 }
 
-func (r *CachedReader3) ReadAccountCode(address common.Address, incarnation uint64, codeHash common.Hash) ([]byte, error) {
+func (r *CachedReader3) ReadAccountCode(address common.Address, incarnation uint64) ([]byte, error) {
 	code, err := r.cache.GetCode(address[:])
 	if len(code) == 0 {
 		return nil, nil
@@ -89,8 +89,8 @@ func (r *CachedReader3) ReadAccountCode(address common.Address, incarnation uint
 	return code, err
 }
 
-func (r *CachedReader3) ReadAccountCodeSize(address common.Address, incarnation uint64, codeHash common.Hash) (int, error) {
-	code, err := r.ReadAccountCode(address, incarnation, codeHash)
+func (r *CachedReader3) ReadAccountCodeSize(address common.Address, incarnation uint64) (int, error) {
+	code, err := r.ReadAccountCode(address, incarnation)
 	return len(code), err
 }
 

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -39,8 +39,8 @@ type StateReader interface {
 	ReadAccountData(address common.Address) (*accounts.Account, error)
 	ReadAccountDataForDebug(address common.Address) (*accounts.Account, error)
 	ReadAccountStorage(address common.Address, incarnation uint64, key *common.Hash) ([]byte, error)
-	ReadAccountCode(address common.Address, incarnation uint64, codeHash common.Hash) ([]byte, error)
-	ReadAccountCodeSize(address common.Address, incarnation uint64, codeHash common.Hash) (int, error)
+	ReadAccountCode(address common.Address, incarnation uint64) ([]byte, error)
+	ReadAccountCodeSize(address common.Address, incarnation uint64) (int, error)
 	ReadAccountIncarnation(address common.Address) (uint64, error)
 }
 

--- a/core/state/database_test.go
+++ b/core/state/database_test.go
@@ -1274,7 +1274,6 @@ func TestChangeAccountCodeBetweenBlocks(t *testing.T) {
 	sd.SetTxNum(2)
 	sd.SetBlockNum(1)
 
-	oldCodeHash := libcommon.BytesToHash(crypto.Keccak256(oldCode))
 	trieCode, tcErr := r.ReadAccountCode(contract, 1)
 	assert.NoError(t, tcErr, "you can receive the new code")
 	assert.Equal(t, oldCode, trieCode, "new code should be received")
@@ -1286,7 +1285,6 @@ func TestChangeAccountCodeBetweenBlocks(t *testing.T) {
 		t.Errorf("error finalising 1st tx: %v", err)
 	}
 
-	newCodeHash := libcommon.BytesToHash(crypto.Keccak256(newCode))
 	trieCode, tcErr = r.ReadAccountCode(contract, 1)
 	assert.NoError(t, tcErr, "you can receive the new code")
 	assert.Equal(t, newCode, trieCode, "new code should be received")

--- a/core/state/database_test.go
+++ b/core/state/database_test.go
@@ -1275,7 +1275,7 @@ func TestChangeAccountCodeBetweenBlocks(t *testing.T) {
 	sd.SetBlockNum(1)
 
 	oldCodeHash := libcommon.BytesToHash(crypto.Keccak256(oldCode))
-	trieCode, tcErr := r.ReadAccountCode(contract, 1, oldCodeHash)
+	trieCode, tcErr := r.ReadAccountCode(contract, 1)
 	assert.NoError(t, tcErr, "you can receive the new code")
 	assert.Equal(t, oldCode, trieCode, "new code should be received")
 
@@ -1287,7 +1287,7 @@ func TestChangeAccountCodeBetweenBlocks(t *testing.T) {
 	}
 
 	newCodeHash := libcommon.BytesToHash(crypto.Keccak256(newCode))
-	trieCode, tcErr = r.ReadAccountCode(contract, 1, newCodeHash)
+	trieCode, tcErr = r.ReadAccountCode(contract, 1)
 	assert.NoError(t, tcErr, "you can receive the new code")
 	assert.Equal(t, newCode, trieCode, "new code should be received")
 
@@ -1325,11 +1325,11 @@ func TestCacheCodeSizeSeparately(t *testing.T) {
 	}
 
 	codeHash := libcommon.BytesToHash(crypto.Keccak256(code))
-	codeSize, err := r.ReadAccountCodeSize(contract, 1, codeHash)
+	codeSize, err := r.ReadAccountCodeSize(contract, 1)
 	assert.NoError(t, err, "you can receive the new code")
 	assert.Equal(t, len(code), codeSize, "new code should be received")
 
-	code2, err := r.ReadAccountCode(contract, 1, codeHash)
+	code2, err := r.ReadAccountCode(contract, 1)
 	assert.NoError(t, err, "you can receive the new code")
 	assert.Equal(t, code, code2, "new code should be received")
 }
@@ -1368,13 +1368,13 @@ func TestCacheCodeSizeInTrie(t *testing.T) {
 	require.EqualValues(t, root, libcommon.CastToHash(r2))
 
 	codeHash := libcommon.BytesToHash(crypto.Keccak256(code))
-	codeSize, err := r.ReadAccountCodeSize(contract, 1, codeHash)
+	codeSize, err := r.ReadAccountCodeSize(contract, 1)
 	assert.NoError(t, err, "you can receive the code size ")
 	assert.Equal(t, len(code), codeSize, "you can receive the code size")
 
 	assert.NoError(t, tx.Delete(kv.Code, codeHash[:]), nil)
 
-	codeSize2, err := r.ReadAccountCodeSize(contract, 1, codeHash)
+	codeSize2, err := r.ReadAccountCodeSize(contract, 1)
 	assert.NoError(t, err, "you can still receive code size even with empty DB")
 	assert.Equal(t, len(code), codeSize2, "code size should be received even with empty DB")
 

--- a/core/state/database_test.go
+++ b/core/state/database_test.go
@@ -1322,7 +1322,6 @@ func TestCacheCodeSizeSeparately(t *testing.T) {
 		t.Errorf("error committing block: %v", err)
 	}
 
-	codeHash := libcommon.BytesToHash(crypto.Keccak256(code))
 	codeSize, err := r.ReadAccountCodeSize(contract, 1)
 	assert.NoError(t, err, "you can receive the new code")
 	assert.Equal(t, len(code), codeSize, "new code should be received")

--- a/core/state/history_reader_v3.go
+++ b/core/state/history_reader_v3.go
@@ -89,6 +89,7 @@ func (hr *HistoryReaderV3) ReadAccountStorage(address common.Address, incarnatio
 
 func (hr *HistoryReaderV3) ReadAccountCode(address common.Address, incarnation uint64, codeHash common.Hash) ([]byte, error) {
 	if codeHash == emptyCodeHashH {
+		panic(1)
 		return nil, nil
 	}
 	//  must pass key2=Nil here: because Erigon4 does concatinate key1+key2 under the hood

--- a/core/state/history_reader_v3.go
+++ b/core/state/history_reader_v3.go
@@ -88,10 +88,6 @@ func (hr *HistoryReaderV3) ReadAccountStorage(address common.Address, incarnatio
 }
 
 func (hr *HistoryReaderV3) ReadAccountCode(address common.Address, incarnation uint64, codeHash common.Hash) ([]byte, error) {
-	if codeHash == emptyCodeHashH {
-		panic(1)
-		return nil, nil
-	}
 	//  must pass key2=Nil here: because Erigon4 does concatinate key1+key2 under the hood
 	//code, _, err := hr.ttx.GetAsOf(kv.CodeDomain, address.Bytes(), codeHash.Bytes(), hr.txNum)
 	code, _, err := hr.ttx.GetAsOf(kv.CodeDomain, address[:], nil, hr.txNum)

--- a/core/state/history_reader_v3.go
+++ b/core/state/history_reader_v3.go
@@ -87,17 +87,17 @@ func (hr *HistoryReaderV3) ReadAccountStorage(address common.Address, incarnatio
 	return enc, err
 }
 
-func (hr *HistoryReaderV3) ReadAccountCode(address common.Address, incarnation uint64, codeHash common.Hash) ([]byte, error) {
+func (hr *HistoryReaderV3) ReadAccountCode(address common.Address, incarnation uint64) ([]byte, error) {
 	//  must pass key2=Nil here: because Erigon4 does concatinate key1+key2 under the hood
 	//code, _, err := hr.ttx.GetAsOf(kv.CodeDomain, address.Bytes(), codeHash.Bytes(), hr.txNum)
 	code, _, err := hr.ttx.GetAsOf(kv.CodeDomain, address[:], nil, hr.txNum)
 	if hr.trace {
-		fmt.Printf("ReadAccountCode [%x %x] => [%x]\n", address, codeHash, code)
+		fmt.Printf("ReadAccountCode [%x] => [%x]\n", address, code)
 	}
 	return code, err
 }
 
-func (hr *HistoryReaderV3) ReadAccountCodeSize(address common.Address, incarnation uint64, codeHash common.Hash) (int, error) {
+func (hr *HistoryReaderV3) ReadAccountCodeSize(address common.Address, incarnation uint64) (int, error) {
 	enc, _, err := hr.ttx.GetAsOf(kv.CodeDomain, address[:], nil, hr.txNum)
 	return len(enc), err
 }

--- a/core/state/intra_block_state.go
+++ b/core/state/intra_block_state.go
@@ -311,7 +311,7 @@ func (sdb *IntraBlockState) GetCodeSize(addr libcommon.Address) (int, error) {
 		return len(stateObject.code), nil
 	}
 	if stateObject.data.CodeHash == emptyCodeHashH {
-		return 0
+		return 0, nil
 	}
 	l, err := sdb.stateReader.ReadAccountCodeSize(addr, stateObject.data.Incarnation)
 	if err != nil {

--- a/core/state/intra_block_state.go
+++ b/core/state/intra_block_state.go
@@ -291,6 +291,9 @@ func (sdb *IntraBlockState) GetCodeSize(addr libcommon.Address) int {
 	if stateObject.code != nil {
 		return len(stateObject.code)
 	}
+	if stateObject.data.CodeHash == emptyCodeHashH {
+		return 0
+	}
 	l, err := sdb.stateReader.ReadAccountCodeSize(addr, stateObject.data.Incarnation, stateObject.data.CodeHash)
 	if err != nil {
 		sdb.setErrorUnsafe(err)

--- a/core/state/intra_block_state.go
+++ b/core/state/intra_block_state.go
@@ -294,7 +294,7 @@ func (sdb *IntraBlockState) GetCodeSize(addr libcommon.Address) int {
 	if stateObject.data.CodeHash == emptyCodeHashH {
 		return 0
 	}
-	l, err := sdb.stateReader.ReadAccountCodeSize(addr, stateObject.data.Incarnation, stateObject.data.CodeHash)
+	l, err := sdb.stateReader.ReadAccountCodeSize(addr, stateObject.data.Incarnation)
 	if err != nil {
 		sdb.setErrorUnsafe(err)
 	}

--- a/core/state/rw_v3.go
+++ b/core/state/rw_v3.go
@@ -628,7 +628,7 @@ func (r *ReaderV3) ReadAccountStorage(address common.Address, incarnation uint64
 	return enc, nil
 }
 
-func (r *ReaderV3) ReadAccountCode(address common.Address, incarnation uint64, codeHash common.Hash) ([]byte, error) {
+func (r *ReaderV3) ReadAccountCode(address common.Address, incarnation uint64) ([]byte, error) {
 	enc, _, err := r.tx.GetLatest(kv.CodeDomain, address[:], nil)
 	if err != nil {
 		return nil, err
@@ -639,7 +639,7 @@ func (r *ReaderV3) ReadAccountCode(address common.Address, incarnation uint64, c
 	return enc, nil
 }
 
-func (r *ReaderV3) ReadAccountCodeSize(address common.Address, incarnation uint64, codeHash common.Hash) (int, error) {
+func (r *ReaderV3) ReadAccountCodeSize(address common.Address, incarnation uint64) (int, error) {
 	enc, _, err := r.tx.GetLatest(kv.CodeDomain, address[:], nil)
 	if err != nil {
 		return 0, err
@@ -750,7 +750,7 @@ func (r *ReaderParallelV3) ReadAccountStorage(address common.Address, incarnatio
 	return enc, nil
 }
 
-func (r *ReaderParallelV3) ReadAccountCode(address common.Address, incarnation uint64, codeHash common.Hash) ([]byte, error) {
+func (r *ReaderParallelV3) ReadAccountCode(address common.Address, incarnation uint64) ([]byte, error) {
 	enc, _, err := r.sd.GetLatest(kv.CodeDomain, address[:], nil)
 	if err != nil {
 		return nil, err
@@ -765,7 +765,7 @@ func (r *ReaderParallelV3) ReadAccountCode(address common.Address, incarnation u
 	return enc, nil
 }
 
-func (r *ReaderParallelV3) ReadAccountCodeSize(address common.Address, incarnation uint64, codeHash common.Hash) (int, error) {
+func (r *ReaderParallelV3) ReadAccountCodeSize(address common.Address, incarnation uint64) (int, error) {
 	enc, _, err := r.sd.GetLatest(kv.CodeDomain, address[:], nil)
 	if err != nil {
 		return 0, err

--- a/core/state/rw_v3.go
+++ b/core/state/rw_v3.go
@@ -629,10 +629,6 @@ func (r *ReaderV3) ReadAccountStorage(address common.Address, incarnation uint64
 }
 
 func (r *ReaderV3) ReadAccountCode(address common.Address, incarnation uint64, codeHash common.Hash) ([]byte, error) {
-	if codeHash == emptyCodeHashH {
-		panic(1)
-		//return nil, nil
-	}
 	enc, _, err := r.tx.GetLatest(kv.CodeDomain, address[:], nil)
 	if err != nil {
 		return nil, err
@@ -644,10 +640,6 @@ func (r *ReaderV3) ReadAccountCode(address common.Address, incarnation uint64, c
 }
 
 func (r *ReaderV3) ReadAccountCodeSize(address common.Address, incarnation uint64, codeHash common.Hash) (int, error) {
-	if codeHash == emptyCodeHashH {
-		panic(1)
-		//return nil, nil
-	}
 	enc, _, err := r.tx.GetLatest(kv.CodeDomain, address[:], nil)
 	if err != nil {
 		return 0, err

--- a/core/state/rw_v3.go
+++ b/core/state/rw_v3.go
@@ -629,9 +629,10 @@ func (r *ReaderV3) ReadAccountStorage(address common.Address, incarnation uint64
 }
 
 func (r *ReaderV3) ReadAccountCode(address common.Address, incarnation uint64, codeHash common.Hash) ([]byte, error) {
-	//if codeHash == emptyCodeHashH { // TODO: how often do we have this case on mainnet/bor-mainnet?
-	//	return nil, nil
-	//}
+	if codeHash == emptyCodeHashH {
+		panic(1)
+		//return nil, nil
+	}
 	enc, _, err := r.tx.GetLatest(kv.CodeDomain, address[:], nil)
 	if err != nil {
 		return nil, err
@@ -643,6 +644,10 @@ func (r *ReaderV3) ReadAccountCode(address common.Address, incarnation uint64, c
 }
 
 func (r *ReaderV3) ReadAccountCodeSize(address common.Address, incarnation uint64, codeHash common.Hash) (int, error) {
+	if codeHash == emptyCodeHashH {
+		panic(1)
+		//return nil, nil
+	}
 	enc, _, err := r.tx.GetLatest(kv.CodeDomain, address[:], nil)
 	if err != nil {
 		return 0, err

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -333,7 +333,7 @@ func (so *stateObject) Code() []byte {
 	if so.data.CodeHash == emptyCodeHashH {
 		return nil
 	}
-	code, err := so.db.stateReader.ReadAccountCode(so.Address(), so.data.Incarnation, so.data.CodeHash)
+	code, err := so.db.stateReader.ReadAccountCode(so.Address(), so.data.Incarnation)
 	if err != nil {
 		so.setError(fmt.Errorf("can't load code hash %x: %w", so.data.CodeHash, err))
 	}

--- a/eth/stagedsync/stage_mining_exec.go
+++ b/eth/stagedsync/stage_mining_exec.go
@@ -345,7 +345,7 @@ func filterBadTransactions(transactions []types.Transaction, chainID *uint256.In
 		if !account.IsEmptyCodeHash() {
 			isEoaCodeAllowed := false
 			if config.IsPrague(header.Time) {
-				code, err := simStateReader.ReadAccountCode(sender, account.Incarnation, account.CodeHash)
+				code, err := simStateReader.ReadAccountCode(sender, account.Incarnation)
 				if err != nil {
 					return nil, err
 				}

--- a/turbo/jsonrpc/eth_accounts.go
+++ b/turbo/jsonrpc/eth_accounts.go
@@ -111,7 +111,7 @@ func (api *APIImpl) GetCode(ctx context.Context, address libcommon.Address, bloc
 	if acc == nil || err != nil {
 		return hexutility.Bytes(""), nil
 	}
-	res, _ := reader.ReadAccountCode(address, acc.Incarnation, acc.CodeHash)
+	res, _ := reader.ReadAccountCode(address, acc.Incarnation)
 	if res == nil {
 		return hexutility.Bytes(""), nil
 	}


### PR DESCRIPTION
- moved empty-code-hash check to callers: `ibs` and `stateObject`
- removed CodeHash param from state reader interface (E3 does store code by acc address. E2 did by code hash)