### PR TITLE
d_lru: to store decompressed values

### DIFF
--- a/erigon-lib/state/cache.go
+++ b/erigon-lib/state/cache.go
@@ -27,6 +27,7 @@ type domainGetFromFileCacheItem struct {
 	lvl    uint8
 	exists bool
 	offset uint64
+	v      []byte
 }
 
 var (

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -1589,7 +1589,7 @@ func (dt *DomainRoTx) getFromFiles(filekey []byte, maxTxNum uint64) (v []byte, f
 		}
 
 		if dt.getFromFileCache != nil {
-			dt.getFromFileCache.Add(hi, domainGetFromFileCacheItem{lvl: uint8(i), offset: offset, exists: true, v: nil})
+			dt.getFromFileCache.Add(hi, domainGetFromFileCacheItem{lvl: uint8(i), offset: offset, exists: true, v: v})
 		}
 		return v, true, dt.files[i].startTxNum, dt.files[i].endTxNum, nil
 	}

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -1541,11 +1541,11 @@ func (dt *DomainRoTx) getFromFiles(filekey []byte, maxTxNum uint64) (v []byte, f
 			if !cv.exists {
 				return nil, true, dt.files[cv.lvl].startTxNum, dt.files[cv.lvl].endTxNum, nil
 			}
-			g := dt.statelessGetter(int(cv.lvl))
-			g.Reset(cv.offset)
-			g.Skip()
-			v, _ = g.Next(nil) // can be compressed
-			return v, true, dt.files[cv.lvl].startTxNum, dt.files[cv.lvl].endTxNum, nil
+			//g := dt.statelessGetter(int(cv.lvl))
+			//g.Reset(cv.offset)
+			//g.Skip()
+			//v, _ = g.Next(nil) // can be compressed
+			return cv.v, true, dt.files[cv.lvl].startTxNum, dt.files[cv.lvl].endTxNum, nil
 		}
 	}
 
@@ -1589,7 +1589,7 @@ func (dt *DomainRoTx) getFromFiles(filekey []byte, maxTxNum uint64) (v []byte, f
 		}
 
 		if dt.getFromFileCache != nil {
-			dt.getFromFileCache.Add(hi, domainGetFromFileCacheItem{lvl: uint8(i), offset: offset, exists: true})
+			dt.getFromFileCache.Add(hi, domainGetFromFileCacheItem{lvl: uint8(i), offset: offset, exists: true, v: nil})
 		}
 		return v, true, dt.files[i].startTxNum, dt.files[i].endTxNum, nil
 	}
@@ -1598,7 +1598,7 @@ func (dt *DomainRoTx) getFromFiles(filekey []byte, maxTxNum uint64) (v []byte, f
 	}
 
 	if dt.getFromFileCache != nil {
-		dt.getFromFileCache.Add(hi, domainGetFromFileCacheItem{lvl: 0, offset: 0, exists: false})
+		dt.getFromFileCache.Add(hi, domainGetFromFileCacheItem{lvl: 0, offset: 0, exists: false, v: nil})
 	}
 	return nil, false, 0, 0, nil
 }


### PR DESCRIPTION
- decompressing CodeDomain values: taking ~7% of execution speed
