### PR TITLE
Don't mark unwound non-bad blocks as bad

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -758,7 +758,7 @@ func stageHeaders(db kv.RwDB, ctx context.Context, logger log.Logger) error {
 			}
 		}
 		// remove all canonical markers from this point
-		if err = rawdb.TruncateCanonicalHash(tx, progress+1, false); err != nil {
+		if err = rawdb.TruncateCanonicalHash(tx, progress+1, false /* markChainAsBad */); err != nil {
 			return err
 		}
 		if err = rawdb.TruncateTd(tx, progress+1); err != nil {

--- a/core/rawdb/rawdbreset/reset_stages.go
+++ b/core/rawdb/rawdbreset/reset_stages.go
@@ -67,7 +67,7 @@ func ResetBlocks(tx kv.RwTx, db kv.RoDB, agg *state.Aggregator, br services.Full
 	}
 
 	// remove all canonical markers from this point
-	if err := rawdb.TruncateCanonicalHash(tx, 1, false); err != nil {
+	if err := rawdb.TruncateCanonicalHash(tx, 1, false /* markChainAsBad */); err != nil {
 		return err
 	}
 	if err := rawdb.TruncateTd(tx, 1); err != nil {

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -421,8 +421,10 @@ func HeadersUnwind(ctx context.Context, u *UnwindState, s *StageState, tx kv.RwT
 	}
 	// Delete canonical hashes that are being unwound
 	unwindBlock := (u.Reason.Block != nil)
+	badBlock := false
 	if unwindBlock {
-		if u.Reason.IsBadBlock() {
+		badBlock = u.Reason.IsBadBlock()
+		if badBlock {
 			cfg.hd.ReportBadHeader(*u.Reason.Block)
 		}
 
@@ -448,7 +450,7 @@ func HeadersUnwind(ctx context.Context, u *UnwindState, s *StageState, tx kv.RwT
 			return fmt.Errorf("iterate over headers to mark bad headers: %w", err)
 		}
 	}
-	if err := rawdb.TruncateCanonicalHash(tx, u.UnwindPoint+1, unwindBlock); err != nil {
+	if err := rawdb.TruncateCanonicalHash(tx, u.UnwindPoint+1, badBlock); err != nil {
 		return err
 	}
 	if unwindBlock {

--- a/eth/stagedsync/stage_polygon_sync.go
+++ b/eth/stagedsync/stage_polygon_sync.go
@@ -240,8 +240,8 @@ func UnwindPolygonSyncStage(ctx context.Context, tx kv.RwTx, u *UnwindState, cfg
 	}
 
 	// headers
-	unwindBlock := u.Reason.Block != nil
-	if err := rawdb.TruncateCanonicalHash(tx, u.UnwindPoint+1, unwindBlock); err != nil {
+	badBlock := u.Reason.IsBadBlock()
+	if err := rawdb.TruncateCanonicalHash(tx, u.UnwindPoint+1, badBlock); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
An `UnwindReason` created w/o an error (by `ForkReset`) means that a block has to be unwound, but it's not bad, so it shouldn't be inserted into `BadHeaderNumber` by `TruncateCanonicalHash`. `ForkReset` is used in Bor milestone rewind.