### PR TITLE
Update Empty requests list behaviour for Pectra-5

### DIFF
--- a/consensus/merge/merge.go
+++ b/consensus/merge/merge.go
@@ -196,11 +196,17 @@ func (s *Merge) Finalize(config *chain.Config, header *types.Header, state *stat
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("error: could not parse requests logs: %v", err)
 		}
-		rs = append(rs, *depositReqs)
+		if depositReqs != nil {
+			rs = append(rs, *depositReqs)
+		}
 		withdrawalReq := misc.DequeueWithdrawalRequests7002(syscall)
-		rs = append(rs, *withdrawalReq)
+		if withdrawalReq != nil {
+			rs = append(rs, *withdrawalReq)
+		}
 		consolidations := misc.DequeueConsolidationRequests7251(syscall)
-		rs = append(rs, *consolidations)
+		if consolidations != nil {
+			rs = append(rs, *consolidations)
+		}
 		if header.RequestsHash != nil {
 			rh := rs.Hash()
 			if *header.RequestsHash != *rh {

--- a/consensus/misc/eip6110.go
+++ b/consensus/misc/eip6110.go
@@ -85,5 +85,8 @@ func ParseDepositLogs(logs []*types.Log, depositContractAddress libcommon.Addres
 			reqData = append(reqData, d...)
 		}
 	}
-	return &types.FlatRequest{Type: types.DepositRequestType, RequestData: reqData}, nil
+	if len(reqData) > 0 {
+		return &types.FlatRequest{Type: types.DepositRequestType, RequestData: reqData}, nil
+	}
+	return nil, nil
 }

--- a/consensus/misc/eip7002.go
+++ b/consensus/misc/eip7002.go
@@ -29,9 +29,9 @@ func DequeueWithdrawalRequests7002(syscall consensus.SystemCall) *types.FlatRequ
 		log.Warn("Err with syscall to WithdrawalRequestAddress", "err", err)
 		return nil
 	}
-	if res == nil {
-		res = make([]byte, 0)
+	if res != nil {
+		return &types.FlatRequest{Type: types.WithdrawalRequestType, RequestData: res}
 	}
+	return nil
 	// Just append the contract outputs
-	return &types.FlatRequest{Type: types.WithdrawalRequestType, RequestData: res}
 }

--- a/consensus/misc/eip7002.go
+++ b/consensus/misc/eip7002.go
@@ -30,8 +30,8 @@ func DequeueWithdrawalRequests7002(syscall consensus.SystemCall) *types.FlatRequ
 		return nil
 	}
 	if res != nil {
+		// Just append the contract output
 		return &types.FlatRequest{Type: types.WithdrawalRequestType, RequestData: res}
 	}
 	return nil
-	// Just append the contract outputs
 }

--- a/consensus/misc/eip7251.go
+++ b/consensus/misc/eip7251.go
@@ -29,9 +29,9 @@ func DequeueConsolidationRequests7251(syscall consensus.SystemCall) *types.FlatR
 		log.Warn("Err with syscall to ConsolidationRequestAddress", "err", err)
 		return nil
 	}
-	if res == nil {
-		res = make([]byte, 0)
+	if res != nil {
+		return &types.FlatRequest{Type: types.ConsolidationRequestType, RequestData: res}
 	}
+	return nil
 	// Just append the contract outputs as the encoded request data
-	return &types.FlatRequest{Type: types.ConsolidationRequestType, RequestData: res}
 }

--- a/consensus/misc/eip7251.go
+++ b/consensus/misc/eip7251.go
@@ -30,8 +30,8 @@ func DequeueConsolidationRequests7251(syscall consensus.SystemCall) *types.FlatR
 		return nil
 	}
 	if res != nil {
+		// Just append the contract output as the request data
 		return &types.FlatRequest{Type: types.ConsolidationRequestType, RequestData: res}
 	}
 	return nil
-	// Just append the contract outputs as the encoded request data
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -337,7 +337,6 @@ func FinalizeBlockExecution(
 	if isMining {
 		newBlock, newTxs, newReceipt, retRequests, err = engine.FinalizeAndAssemble(cc, header, ibs, txs, uncles, receipts, withdrawals, chainReader, syscall, nil, logger)
 	} else {
-		// var rss types.Requests
 		newTxs, newReceipt, retRequests, err = engine.Finalize(cc, header, ibs, txs, uncles, receipts, withdrawals, chainReader, syscall, logger)
 	}
 	if err != nil {

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -40,7 +40,7 @@ import (
 
 var (
 	EmptyRootHash     = libcommon.HexToHash("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
-	EmptyRequestsHash = libcommon.HexToHash("6036c41849da9c076ed79654d434017387a88fb833c2856b32e18218b3341c5f")
+	EmptyRequestsHash = libcommon.HexToHash("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
 	EmptyUncleHash    = rlpHash([]*Header(nil))
 
 	ExtraVanityLength = 32 // Fixed number of extra-data prefix bytes reserved for signer vanity

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -40,7 +40,7 @@ import (
 
 var (
 	EmptyRootHash     = libcommon.HexToHash("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
-	EmptyRequestsHash = libcommon.HexToHash("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+	EmptyRequestsHash = libcommon.HexToHash("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855") // sha256.Sum256([]byte(""))
 	EmptyUncleHash    = rlpHash([]*Header(nil))
 
 	ExtraVanityLength = 32 // Fixed number of extra-data prefix bytes reserved for signer vanity

--- a/core/types/eip7685_requests.go
+++ b/core/types/eip7685_requests.go
@@ -52,12 +52,12 @@ func (f *FlatRequest) copy() *FlatRequest {
 type FlatRequests []FlatRequest
 
 func (r FlatRequests) Hash() *libcommon.Hash {
-	if r == nil || len(r) < len(KnownRequestTypes) {
+	if r == nil {
 		return nil
 	}
 	sha := sha256.New()
-	for i, t := range KnownRequestTypes {
-		hi := sha256.Sum256(append([]byte{t}, r[i].RequestData...))
+	for i, t := range r {
+		hi := sha256.Sum256(append([]byte{t.Type}, r[i].RequestData...))
 		sha.Write(hi[:])
 	}
 	h := libcommon.BytesToHash(sha.Sum(nil))

--- a/core/types/reqeusts_test.go
+++ b/core/types/reqeusts_test.go
@@ -1,0 +1,37 @@
+// Copyright 2014 The go-ethereum Authors
+// (original work)
+// Copyright 2024 The Erigon Authors
+// (modifications)
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	libcommon "github.com/erigontech/erigon-lib/common"
+)
+
+func TestEmptyRequestsHashCalculation(t *testing.T) {
+	reqs := make(FlatRequests, 0)
+	h := reqs.Hash()
+	testHArr := sha256.Sum256([]byte(""))
+	testH := libcommon.BytesToHash(testHArr[:])
+	if *h != testH {
+		t.Errorf("Requests Hash calculation error for empty hash, expected: %v, got: %v", testH, h)
+	}
+}

--- a/core/types/requests_test.go
+++ b/core/types/requests_test.go
@@ -1,7 +1,4 @@
-// Copyright 2014 The go-ethereum Authors
-// (original work)
-// Copyright 2024 The Erigon Authors
-// (modifications)
+// Copyright 2025 The Erigon Authors
 // This file is part of Erigon.
 //
 // Erigon is free software: you can redistribute it and/or modify
@@ -20,17 +17,13 @@
 package types
 
 import (
-	"crypto/sha256"
 	"testing"
-
-	libcommon "github.com/erigontech/erigon-lib/common"
 )
 
 func TestEmptyRequestsHashCalculation(t *testing.T) {
 	reqs := make(FlatRequests, 0)
 	h := reqs.Hash()
-	testHArr := sha256.Sum256([]byte(""))
-	testH := libcommon.BytesToHash(testHArr[:])
+	testH := EmptyRequestsHash
 	if *h != testH {
 		t.Errorf("Requests Hash calculation error for empty hash, expected: %v, got: %v", testH, h)
 	}

--- a/turbo/builder/block_builder.go
+++ b/turbo/builder/block_builder.go
@@ -17,7 +17,6 @@
 package builder
 
 import (
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -50,11 +49,7 @@ func NewBlockBuilder(build BlockBuilderFunc, param *core.BlockBuilderParameters)
 			log.Warn("Failed to build a block", "err", err)
 		} else {
 			block := result.Block
-			reqLenStr := "nil"
-			if len(result.Requests) == 3 {
-				reqLenStr = fmt.Sprint("Deposit Requests", len(result.Requests[0].RequestData), "Withdrawal Requests", len(result.Requests[1].RequestData), "Consolidation Requests", len(result.Requests[2].RequestData))
-			}
-			log.Info("Built block", "hash", block.Hash(), "height", block.NumberU64(), "txs", len(block.Transactions()), "executionRequests", len(result.Requests), "Requests", reqLenStr, "gas used %", 100*float64(block.GasUsed())/float64(block.GasLimit()), "time", time.Since(t))
+			log.Info("Built block", "hash", block.Hash(), "height", block.NumberU64(), "txs", len(block.Transactions()), "executionRequests", len(result.Requests), "gas used %", 100*float64(block.GasUsed())/float64(block.GasLimit()), "time", time.Since(t))
 		}
 
 		builder.syncCond.L.Lock()

--- a/turbo/engineapi/engine_server.go
+++ b/turbo/engineapi/engine_server.go
@@ -209,9 +209,9 @@ func (s *EngineServer) newPayload(ctx context.Context, req *engine_types.Executi
 	}
 	if version >= clparams.ElectraVersion {
 		requests = make(types.FlatRequests, 0)
-		for _, r := range executionRequests {
-			if len(r) == 0 {
-				continue
+		for i, r := range executionRequests {
+			if len(r) <= 1 {
+				return nil, &rpc.InvalidParamsError{Message: fmt.Sprintf("Invalid Request at index %d", i)}
 			}
 			requests = append(requests, types.FlatRequest{Type: r[0], RequestData: r})
 		}

--- a/turbo/engineapi/engine_server.go
+++ b/turbo/engineapi/engine_server.go
@@ -215,12 +215,9 @@ func (s *EngineServer) newPayload(ctx context.Context, req *engine_types.Executi
 		return nil, err
 	}
 	if version >= clparams.ElectraVersion {
-		requests = make(types.FlatRequests, len(types.KnownRequestTypes))
-		for i, r := range types.KnownRequestTypes {
-			if len(executionRequests) == i {
-				executionRequests = append(executionRequests, []byte{})
-			}
-			requests[i] = types.FlatRequest{Type: r, RequestData: executionRequests[i]}
+		requests = make(types.FlatRequests, 0)
+		for _, r := range executionRequests {
+			requests = append(requests, types.FlatRequest{Type: r[0], RequestData: r})
 		}
 		rh := requests.Hash()
 		header.RequestsHash = rh
@@ -499,16 +496,9 @@ func (s *EngineServer) getPayload(ctx context.Context, payloadId uint64, version
 	data := resp.Data
 	var executionRequests []hexutility.Bytes
 	if version >= clparams.ElectraVersion {
-		executionRequests = make([]hexutility.Bytes, len(types.KnownRequestTypes))
-		if len(data.Requests.Requests) != 3 {
-			s.logger.Warn("Error in getPayload - data.Requests.Requests len not 3")
-		}
-		for i := 0; i < len(types.KnownRequestTypes); i++ {
-			if len(data.Requests.Requests) < i+1 || data.Requests.Requests[i] == nil {
-				executionRequests[i] = make(hexutility.Bytes, 0)
-			} else {
-				executionRequests[i] = data.Requests.Requests[i]
-			}
+		executionRequests = make([]hexutility.Bytes, 0)
+		for _, r := range data.Requests.Requests {
+			executionRequests = append(executionRequests, r)
 		}
 	}
 

--- a/turbo/engineapi/engine_server.go
+++ b/turbo/engineapi/engine_server.go
@@ -147,13 +147,6 @@ func (s *EngineServer) checkRequestsPresence(version clparams.StateVersion, exec
 		if executionRequests != nil {
 			return &rpc.InvalidParamsError{Message: "requests in EngineAPI not supported before Prague"}
 		}
-	} else {
-		if executionRequests == nil {
-			return &rpc.InvalidParamsError{Message: "missing requests list"}
-		}
-		if len(executionRequests) != len(types.KnownRequestTypes) {
-			return &rpc.InvalidParamsError{Message: "invalid requests lists"}
-		}
 	}
 	return nil
 }

--- a/turbo/engineapi/engine_server.go
+++ b/turbo/engineapi/engine_server.go
@@ -210,6 +210,9 @@ func (s *EngineServer) newPayload(ctx context.Context, req *engine_types.Executi
 	if version >= clparams.ElectraVersion {
 		requests = make(types.FlatRequests, 0)
 		for _, r := range executionRequests {
+			if len(r) == 0 {
+				continue
+			}
 			requests = append(requests, types.FlatRequest{Type: r[0], RequestData: r})
 		}
 		rh := requests.Hash()

--- a/turbo/execution/eth1/block_building.go
+++ b/turbo/execution/eth1/block_building.go
@@ -215,21 +215,15 @@ func (e *EthereumExecutionModule) GetAssembledBlock(ctx context.Context, req *ex
 		}
 	}
 
-	var requestsBundle types2.RequestsBundle
+	var requestsBundle *types2.RequestsBundle
 	if blockWithReceipts.Requests != nil {
-		requests := make([][]byte, len(types.KnownRequestTypes))
-		if len(blockWithReceipts.Requests) == len(types.KnownRequestTypes) {
-			for i, r := range blockWithReceipts.Requests {
-				requests[i] = make([]byte, 0)
-				requests[i] = append(requests[i], r.RequestData...)
-			}
-		} else {
-			e.logger.Error("Requests len SHOULD BE", "equal to", len(types.KnownRequestTypes), "got", len(blockWithReceipts.Requests))
-			for i := 0; i < len(types.KnownRequestTypes); i++ {
-				requests[i] = make([]byte, 0)
-			}
+		requestsBundle = &types2.RequestsBundle{}
+		requests := make([][]byte, 0)
+		for i, r := range blockWithReceipts.Requests {
+			requests[i] = make([]byte, 0)
+			requests[i] = append(requests[i], r.RequestData...)
 		}
-		requestsBundle = types2.RequestsBundle{Requests: requests}
+		requestsBundle.Requests = requests
 	}
 
 	return &execution.GetAssembledBlockResponse{
@@ -237,7 +231,7 @@ func (e *EthereumExecutionModule) GetAssembledBlock(ctx context.Context, req *ex
 			ExecutionPayload: payload,
 			BlockValue:       gointerfaces.ConvertUint256IntToH256(blockValue),
 			BlobsBundle:      blobsBundle,
-			Requests:         &requestsBundle,
+			Requests:         requestsBundle,
 		},
 		Busy: false,
 	}, nil


### PR DESCRIPTION
The updated EIP-7685 says requests with empty `request_data` should be dropped from `executionRequests` field in the API and ignored for hash calculation.
See https://github.com/ethereum/EIPs/pull/8989, https://github.com/ethereum/execution-apis/pull/599

Issue board: https://github.com/erigontech/erigon/issues/12401
