### PR TITLE
Fix eth/67 vs eth/68 peers for NewPooledTransactionHashes

### DIFF
--- a/txnprovider/txpool/send.go
+++ b/txnprovider/txpool/send.go
@@ -157,7 +157,7 @@ func (f *Send) AnnouncePooledTxns(types []byte, sizes []uint32, hashes Hashes, m
 			}
 
 			switch protocols[protocolIndex] {
-			case 66, 67:
+			case 67:
 				if i > prevI {
 					req := &sentryproto.SendMessageToRandomPeersRequest{
 						Data: &sentryproto.OutboundMessageData{


### PR DESCRIPTION
[eth/68](https://eips.ethereum.org/EIPS/eip-5793) and eth/67 are only different w.r.t. to `NewPooledTransactionHashes`. Previously the determination of `msgcode` was sometimes failing because it relied only on one protocol version,  namely `ss.Protocols[0].Version`.