### PR TITLE
Throw error if txNum is less than smallest txNum in files

### DIFF
--- a/erigon-lib/state/inverted_index.go
+++ b/erigon-lib/state/inverted_index.go
@@ -555,6 +555,10 @@ func (iit *InvertedIndexRoTx) seekInFiles(key []byte, txNum uint64) (found bool,
 	if len(iit.files) == 0 {
 		return false, 0, nil
 	}
+
+	if txNum < iit.files[0].startTxNum {
+		return false, 0, fmt.Errorf("seek with txNum=%d but data before txNum=%d is not available", txNum, iit.files[0].startTxNum)
+	}
 	if iit.files[len(iit.files)-1].endTxNum <= txNum {
 		return false, 0, nil
 	}


### PR DESCRIPTION
Throw error in `seekInFiles`  if txNum is less than smallest txNum in files.

Eventually this error needs to be handled by IntrablockState, and ideally the RPC call layer should check if the data is available to serve the request, but that will be a feature for later.

Issue: https://github.com/erigontech/erigon/issues/12977