### PR TITLE
Add support for building Debian packages (arm/amd) in the release workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     name: Build debian packages for both arch
-    uses: erigontech/erigon/.github/workflows/reusable-release-build-debian-pkg.yml@main
+    uses: erigontech/erigon/.github/workflows/reusable-release-build-debian-pkg.yml@feature/issue-12891 #### !!!! FIX-IT-BEFORE-MERGE !!!!
     with:
       application: ${{ env.APPLICATION }}
       version: ${{ inputs.release_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,16 +183,19 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_arm64.tar.gz
+        path: dist/
 
     - name: Download amd64 artifact
       uses: actions/download-artifact@v4
       with:
         name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_amd64.tar.gz
+        path: dist/
 
-    - name: Download arm64 artifact
+    - name: Download amd64v2 artifact
       uses: actions/download-artifact@v4
       with:
         name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_amd64v2.tar.gz
+        path: dist/
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf ## v3.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 name: Release
-run-name: "Release version ${{ inputs.release_version}} from branch ${{ inputs.checkout_ref }} started by @${{ github.actor}}"
+run-name: "Build release ${{ inputs.release_version}} from branch ${{ inputs.checkout_ref }} by @${{ github.actor}}"
 
 env:
   APPLICATION: "erigon"
@@ -46,7 +46,10 @@ jobs:
     ## runs-on: ubuntu-22.04
     runs-on: ubuntu-latest-devops-xxlarge
     timeout-minutes: 75
-    name: Build Artifacts and multi-platform Docker image, publish draft of the Release Notes
+    name: Create git tag, build and publish Artifacts
+    outputs:
+      commit-id: ${{ steps.getCommitId.outputs.id }}
+      short-commit-id: ${{ steps.getCommitId.outputs.short_commit_id }}
 
     steps:
       - name: Checkout git repository ${{ env.APP_REPO }}
@@ -75,12 +78,6 @@ jobs:
           echo "id=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
           echo "short_commit_id=$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  ## v3.3.0
-        with:
-          username: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME }}
-          password: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_TOKEN }}
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf ## v3.2.0
 
@@ -107,37 +104,6 @@ jobs:
           ls -lao
           echo "DEBUG: content of the dist/ directory"
           find dist/ -ls
-
-      - name: Build and push multi-platform docker images (${{ env.BUILD_VERSION }} and latest) in case perform_release is true
-        if: ${{ inputs.perform_release }}
-        env:
-          BUILD_VERSION: ${{ inputs.release_version }}
-          DOCKER_URL: ${{ env.DOCKERHUB_REPOSITORY }}
-          DOCKER_PUBLISH_LATEST_CONDITION: ${{ inputs.publish_latest_tag && format('--tag {0}:latest ',env.DOCKERHUB_REPOSITORY) || '' }}
-        run: |
-          docker buildx build \
-          --file ${{ env.DOCKERFILE_PATH }} \
-          --build-arg RELEASE_DOCKER_BASE_IMAGE=${{ env.DOCKER_BASE_IMAGE }} \
-          --build-arg VERSION=${{ env.BUILD_VERSION }} \
-          --build-arg APPLICATION=${{ env.APPLICATION }} \
-          --tag ${{ env.DOCKER_URL }}:${{ env.BUILD_VERSION }} \
-          --target release \
-          --attest type=provenance,mode=max \
-          --sbom=true \
-          ${{ env.DOCKER_PUBLISH_LATEST_CONDITION }} \
-          --label org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
-          --label org.opencontainers.image.authors="https://github.com/erigontech/erigon/graphs/contributors" \
-          --label org.opencontainers.image.url="https://github.com/erigontech/erigon/blob/main/Dockerfile" \
-          --label org.opencontainers.image.documentation="https://github.com/erigontech/erigon/blob/main/Dockerfile" \
-          --label org.opencontainers.image.source="https://github.com/erigontech/erigon/blob/main/Dockerfile" \
-          --label org.opencontainers.image.version=${{ inputs.release_version }} \
-          --label org.opencontainers.image.revision=${{ steps.getCommitId.outputs.id }} \
-          --label org.opencontainers.image.vcs-ref-short=${{ steps.getCommitId.outputs.short_commit_id }} \
-          --label org.opencontainers.image.vendor="${{ github.repository_owner }}" \
-          --label org.opencontainers.image.description="${{ env.LABEL_DESCRIPTION }}" \
-          --label org.opencontainers.image.base.name="${{ env.DOCKER_BASE_IMAGE }}" \
-          --push \
-          --platform linux/amd64,linux/amd64/v2,linux/arm64 .
 
       - name: Upload artifact -- linux/arm64
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  ## v4.3.6
@@ -184,6 +150,111 @@ jobs:
           compression-level: 0
           if-no-files-found: error
 
+
+
+  build-debian-pkg:
+    needs: [ build-release ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    name: Build debian packages for both arch
+
+    steps:
+
+    - name: Build debian packages
+      uses: erigontech/erigon/.github/workflows/reusable-release-build-debian-pkg.yml@main
+      with:
+        application: ${{ env.APPLICATION }}
+        version: ${{ inputs.release_version }}
+
+
+
+  publish-docker-image:
+    needs: [ build-release ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    name: Publish release notes          
+
+    steps:
+
+    - name: Fast checkout just ${{ env.DOCKERFILE_PATH }} from git repository ${{ env.APP_REPO }}
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 ## 4.1.7 release
+      with:
+        repository: ${{ env.APP_REPO }}
+        sparse-checkout: |
+          ${{ env.DOCKERFILE_PATH }}
+        sparse-checkout-cone-mode: false
+        ref: ${{ needs.build-release.outputs.commit-id }}
+
+    - name: Download arm64 artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_arm64.tar.gz
+
+    - name: Download amd64 artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_amd64.tar.gz
+
+    - name: Download arm64 artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_amd64v2.tar.gz
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf ## v3.2.0
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db ## v3.6.1
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  ## v3.3.0
+      with:
+        username: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME }}
+        password: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_TOKEN }}
+
+    - name: Build and push multi-platform docker images (${{ env.BUILD_VERSION }} and maybe latest) in case perform_release is true
+      if: ${{ inputs.perform_release }}
+      env:
+        BUILD_VERSION: ${{ inputs.release_version }}
+        DOCKER_URL: ${{ env.DOCKERHUB_REPOSITORY }}
+        DOCKER_PUBLISH_LATEST_CONDITION: ${{ inputs.publish_latest_tag && format('--tag {0}:latest ',env.DOCKERHUB_REPOSITORY) || '' }}
+      run: |
+        pwd
+        find . -ls
+        docker buildx build \
+        --file ${{ env.DOCKERFILE_PATH }} \
+        --build-arg RELEASE_DOCKER_BASE_IMAGE=${{ env.DOCKER_BASE_IMAGE }} \
+        --build-arg VERSION=${{ env.BUILD_VERSION }} \
+        --build-arg APPLICATION=${{ env.APPLICATION }} \
+        --tag ${{ env.DOCKER_URL }}:${{ env.BUILD_VERSION }} \
+        --target release \
+        --attest type=provenance,mode=max \
+        --sbom=true \
+        ${{ env.DOCKER_PUBLISH_LATEST_CONDITION }} \
+        --label org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
+        --label org.opencontainers.image.authors="https://github.com/erigontech/erigon/graphs/contributors" \
+        --label org.opencontainers.image.url="https://github.com/erigontech/erigon/blob/${{ inputs.checkout_ref }}/${{ env.DOCKERFILE_PATH }}" \
+        --label org.opencontainers.image.documentation="https://github.com/erigontech/erigon/blob/${{ inputs.checkout_ref }}/${{ env.DOCKERFILE_PATH }}" \
+        --label org.opencontainers.image.source="https://github.com/erigontech/erigon/blob/${{ inputs.checkout_ref }}/${{ env.DOCKERFILE_PATH }}" \
+        --label org.opencontainers.image.version=${{ inputs.release_version }} \
+        --label org.opencontainers.image.revision=${{ needs.build-release.outputs.commit-id }} \
+        --label org.opencontainers.image.vcs-ref-short=${{ needs.build-release.outputs.short-commit-id }} \
+        --label org.opencontainers.image.vendor="${{ github.repository_owner }}" \
+        --label org.opencontainers.image.description="${{ env.LABEL_DESCRIPTION }}" \
+        --label org.opencontainers.image.base.name="${{ env.DOCKER_BASE_IMAGE }}" \
+        --push \
+        --platform linux/amd64,linux/amd64/v2,linux/arm64 .
+
+
+
+  publish-release:
+    needs: [ build-debian-pkg, publish-docker-image ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    name: Publish release notes
+
+    steps:
+
       - name: Publish draft of the Release notes with assets in case perform_release is set
         if: ${{ inputs.perform_release }}
         env:
@@ -202,3 +273,25 @@ jobs:
             --notes "**Improvements:**<br>- ...coming soon <br><br>**Bugfixes:**<br><br>- ...coming soon<br><br>**Docker images:**<br><br>Docker image released:<br> ${{ env.DOCKER_TAGS }}<br><br>... coming soon<br>" \
             "${{ inputs.release_version }}" \
             *.tar.gz ${HOME}/${{ env.APPLICATION }}_${{ inputs.release_version }}_checksums.txt
+
+
+  In-case-of-failure:
+    name: "In case of failure: remove remote git tag pointing to the new version."
+    needs: [ publish-release, build-release ]
+    if: always() && !contains(needs.build-release.result, 'success')
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout git repository ${{ env.APP_REPO }} reference ${{ inputs.checkout_ref }}
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 ## 4.1.7 release
+        with:
+          repository: ${{ env.APP_REPO }}
+          fetch-depth: 0
+          ref: ${{ inputs.checkout_ref }}
+          path: 'erigon'
+
+      - name: Rollback - remove git tag ${{ inputs.release_version }}
+        if: ${{ (inputs.perform_release) && (inputs.release_version != '') }}
+        run: |
+          cd erigon
+          git push -d origin ${{ inputs.release_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ env:
   APP_REPO: "erigontech/erigon"
   PACKAGE: "github.com/erigontech/erigon"
   DOCKERHUB_REPOSITORY: "erigontech/erigon"
-  DOCKERFILE_PATH: "./Dockerfile.release"
+  DOCKERFILE_PATH: "Dockerfile.release"
   GITHUB_AUTOMATION_EMAIL: "github-automation@erigon.tech"
   GITHUB_AUTOMATION_NAME: "Erigon Github Automation"
   LABEL_DESCRIPTION: "Erigon is an implementation of Ethereum (execution layer with embeddable consensus layer), on the efficiency frontier. Archive Node by default."
@@ -154,7 +154,7 @@ jobs:
 
 
   build-debian-pkg:
-    name: Build debian packages for both arch
+    name: Debian packages
     needs: [ build-release ]
     uses: erigontech/erigon/.github/workflows/reusable-release-build-debian-pkg.yml@feature/issue-12891 #### !!!! FIX-IT-BEFORE-MERGE !!!!
     with:
@@ -167,7 +167,7 @@ jobs:
     needs: [ build-release ]
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    name: Publish release notes          
+    name: Docker image        
 
     steps:
 
@@ -175,8 +175,7 @@ jobs:
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 ## 4.1.7 release
       with:
         repository: ${{ env.APP_REPO }}
-        sparse-checkout: |
-          ${{ env.DOCKERFILE_PATH }}
+        sparse-checkout: ${{ env.DOCKERFILE_PATH }}
         sparse-checkout-cone-mode: false
         ref: ${{ needs.build-release.outputs.commit-id }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
       commit-id: ${{ steps.getCommitId.outputs.id }}
       short-commit-id: ${{ steps.getCommitId.outputs.short_commit_id }}
       application: ${{ env.APPLICATION }}
+      parsed-version: ${{ steps.getCommitId.outputs.parsed_version}}
 
     steps:
       - name: Checkout git repository ${{ env.APP_REPO }}
@@ -78,6 +79,7 @@ jobs:
         run: |
           echo "id=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
           echo "short_commit_id=$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
+          echo "parsed_version=$(echo ${{ inputs.version }} | sed -e 's/^v//g')" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf ## v3.2.0
@@ -159,7 +161,7 @@ jobs:
     uses: erigontech/erigon/.github/workflows/reusable-release-build-debian-pkg.yml@feature/issue-12891 #### !!!! FIX-IT-BEFORE-MERGE !!!!
     with:
       application: ${{ needs.build-release.outputs.application }}
-      version: ${{ inputs.release_version }}
+      version: ${{ needs.build-release.outputs.parsed-version }}
 
 
 
@@ -245,7 +247,7 @@ jobs:
 
 
   publish-release:
-    needs: [ build-debian-pkg, publish-docker-image ]
+    needs: [ build-debian-pkg, publish-docker-image, build-release ]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     name: Publish release notes
@@ -284,13 +286,13 @@ jobs:
     - name: Download arm64 debian package
       uses: actions/download-artifact@v4
       with:
-        name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_arm64.deb
+        name: ${{ env.APPLICATION }}_${{ needs.build-release.outputs.parsed-version }}_arm64.deb
         path: dist/
 
     - name: Download amd64 debian package
       uses: actions/download-artifact@v4
       with:
-        name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_amd64.deb
+        name: ${{ env.APPLICATION }}_${{ needs.build-release.outputs.parsed-version }}_amd64.deb
         path: dist/
 
     - name: Publish draft of the Release notes with assets in case perform_release is set

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
   build-debian-pkg:
     name: Debian packages
     needs: [ build-release ]
-    uses: erigontech/erigon/.github/workflows/reusable-release-build-debian-pkg.yml@feature/issue-12891 #### !!!! FIX-IT-BEFORE-MERGE !!!!
+    uses: erigontech/erigon/.github/workflows/reusable-release-build-debian-pkg.yml@main
     with:
       application: ${{ needs.build-release.outputs.application }}
       version: ${{ needs.build-release.outputs.parsed-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 name: Release
-run-name: "Release ${{ inputs.release_version}} from branch ${{ github.ref_name }} started by ${{ github.actor}}"
+run-name: "Release version ${{ inputs.release_version}} from branch ${{ inputs.checkout_ref }} started by @${{ github.actor}}"
 
 env:
   APPLICATION: "erigon"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,10 +153,8 @@ jobs:
 
 
   build-debian-pkg:
-    needs: [ build-release ]
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
     name: Build debian packages for both arch
+    needs: [ build-release ]
     uses: erigontech/erigon/.github/workflows/reusable-release-build-debian-pkg.yml@feature/issue-12891 #### !!!! FIX-IT-BEFORE-MERGE !!!!
     with:
       application: ${{ env.APPLICATION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           echo "id=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
           echo "short_commit_id=$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
-          echo "parsed_version=$(echo ${{ inputs.version }} | sed -e 's/^v//g')" >> $GITHUB_OUTPUT
+          echo "parsed_version=$(echo ${{ inputs.release_version }} | sed -e 's/^v//g')" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf ## v3.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release
+run-name: "Release ${{ inputs.release_version}} from branch ${{ github.ref_name }} started by ${{ github.actor}}"
 
 env:
   APPLICATION: "erigon"
@@ -16,12 +17,6 @@ on:
   push:
     branches-ignore:
       - '**'
-    #branches:
-    #  - 'master'
-    #tags:
-      ## only trigger on release tags:
-      #- 'v*.*.*'
-      #- 'v*.*.*-*'
   workflow_dispatch:
     inputs:
       checkout_ref:
@@ -50,7 +45,7 @@ jobs:
   build-release:
     ## runs-on: ubuntu-22.04
     runs-on: ubuntu-latest-devops-xxlarge
-    timeout-minutes: 60
+    timeout-minutes: 75
     name: Build Artifacts and multi-platform Docker image, publish draft of the Release Notes
 
     steps:
@@ -69,6 +64,9 @@ jobs:
             exit 1
           else
             echo "OK: tag ${{ inputs.release_version }} does not exists. Proceeding."
+            git tag ${{ inputs.release_version }}
+            git push origin ${{ inputs.release_version }}
+            echo; echo "Git TAG ${{ inputs.release_version }} created and pushed."
           fi
 
       - name: Get commit id
@@ -185,15 +183,6 @@ jobs:
           retention-days: 1
           compression-level: 0
           if-no-files-found: error
-
-## not required for now -- commented:
-#      - name: Create and push a git tag for the released version in case perform_release is set
-#        if: ${{ inputs.perform_release }}
-#        run: |
-#          git config --global user.email ${{ env.GITHUB_AUTOMATION_EMAIL }}
-#          git config --global user.name "${{ env.GITHUB_AUTOMATION_NAME }}"
-#          git tag -a ${{ inputs.release_version }} -m "Release ${{ inputs.release_version }}"
-#          git push origin ${{ inputs.release_version }}
 
       - name: Publish draft of the Release notes with assets in case perform_release is set
         if: ${{ inputs.perform_release }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
     outputs:
       commit-id: ${{ steps.getCommitId.outputs.id }}
       short-commit-id: ${{ steps.getCommitId.outputs.short_commit_id }}
+      application: ${{ env.APPLICATION }}
 
     steps:
       - name: Checkout git repository ${{ env.APP_REPO }}
@@ -157,7 +158,7 @@ jobs:
     needs: [ build-release ]
     uses: erigontech/erigon/.github/workflows/reusable-release-build-debian-pkg.yml@feature/issue-12891 #### !!!! FIX-IT-BEFORE-MERGE !!!!
     with:
-      application: ${{ env.APPLICATION }}
+      application: ${{ needs.build-release.outputs.application }}
       version: ${{ inputs.release_version }}
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,14 +157,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     name: Build debian packages for both arch
-
-    steps:
-
-    - name: Build debian packages
-      uses: erigontech/erigon/.github/workflows/reusable-release-build-debian-pkg.yml@main
-      with:
-        application: ${{ env.APPLICATION }}
-        version: ${{ inputs.release_version }}
+    uses: erigontech/erigon/.github/workflows/reusable-release-build-debian-pkg.yml@main
+    with:
+      application: ${{ env.APPLICATION }}
+      version: ${{ inputs.release_version }}
 
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,25 +251,66 @@ jobs:
     name: Publish release notes
 
     steps:
+    - name: Download linux/arm64 artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_arm64.tar.gz
+        path: dist/
 
-      - name: Publish draft of the Release notes with assets in case perform_release is set
-        if: ${{ inputs.perform_release }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          DOCKER_TAGS: ${{ env.DOCKERHUB_REPOSITORY }}:${{ inputs.release_version }}
-          GITHUB_RELEASE_TARGET: ${{ inputs.checkout_ref }}
-        run: |
-          cd dist
-          sha256sum *.tar.gz > ${HOME}/${{ env.APPLICATION }}_${{ inputs.release_version }}_checksums.txt
-          gh release create \
-            --generate-notes \
-            --target ${GITHUB_RELEASE_TARGET} \
-            --draft=true \
-            --title "${{ inputs.release_version }}" \
-            --notes "**Improvements:**<br>- ...coming soon <br><br>**Bugfixes:**<br><br>- ...coming soon<br><br>**Docker images:**<br><br>Docker image released:<br> ${{ env.DOCKER_TAGS }}<br><br>... coming soon<br>" \
-            "${{ inputs.release_version }}" \
-            *.tar.gz ${HOME}/${{ env.APPLICATION }}_${{ inputs.release_version }}_checksums.txt
+    - name: Download linux/amd64 artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_amd64.tar.gz
+        path: dist/
+
+    - name: Download linux/amd64v2 artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_amd64v2.tar.gz
+        path: dist/
+
+    - name: Download darwin/amd64 artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_darwin_amd64.tar.gz
+        path: dist/
+
+    - name: Download darwin/arm64 artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_darwin_arm64.tar.gz
+        path: dist/
+
+    - name: Download arm64 debian package
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_arm64.deb
+        path: dist/
+
+    - name: Download amd64 debian package
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_amd64.deb
+        path: dist/
+
+    - name: Publish draft of the Release notes with assets in case perform_release is set
+      if: ${{ inputs.perform_release }}
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+        DOCKER_TAGS: ${{ env.DOCKERHUB_REPOSITORY }}:${{ inputs.release_version }}
+        GITHUB_RELEASE_TARGET: ${{ inputs.checkout_ref }}
+      run: |
+        cd dist
+        sha256sum *.tar.gz *.deb > ${HOME}/${{ env.APPLICATION }}_${{ inputs.release_version }}_checksums.txt
+        gh release create \
+          --generate-notes \
+          --target ${GITHUB_RELEASE_TARGET} \
+          --draft=true \
+          --title "${{ inputs.release_version }}" \
+          --notes "**Improvements:**<br>- ...coming soon <br><br>**Bugfixes:**<br><br>- ...coming soon<br><br>**Docker images:**<br><br>Docker image released:<br> ${{ env.DOCKER_TAGS }}<br><br>... coming soon<br>" \
+          "${{ inputs.release_version }}" \
+          *.tar.gz *.deb ${HOME}/${{ env.APPLICATION }}_${{ inputs.release_version }}_checksums.txt
 
 
   In-case-of-failure:

--- a/.github/workflows/reusable-release-build-debian-pkg.yml
+++ b/.github/workflows/reusable-release-build-debian-pkg.yml
@@ -19,12 +19,12 @@ jobs:
       - name: Download arm64 artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.application }}_${{ inputs.version }}_linux_arm64.tar.gz
+          name: ${{ inputs.application }}_v${{ inputs.version }}_linux_arm64.tar.gz
 
       - name: Download amd64v2 artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.application }}_${{ inputs.version }}_linux_amd64v2.tar.gz
+          name: ${{ inputs.application }}_v${{ inputs.version }}_linux_amd64v2.tar.gz
 
       - name: Update and install required packages, run dpkg
         run: |

--- a/.github/workflows/reusable-release-build-debian-pkg.yml
+++ b/.github/workflows/reusable-release-build-debian-pkg.yml
@@ -9,13 +9,11 @@ on:
       version:
         required: true
         type: string
-      arch:
-        required: false
-        type: string
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Download arm64 artifact

--- a/.github/workflows/reusable-release-build-debian-pkg.yml
+++ b/.github/workflows/reusable-release-build-debian-pkg.yml
@@ -52,13 +52,11 @@ jobs:
           acl = private
           END
 
-      - name: Extract archives
+      - name: Extract archives and rename amd64v2 to amd64
         run: |
           tar xzvf ${{ inputs.application }}_${{ inputs.version }}_linux_amd64v2.tar.gz
-          #### mv -v ${{ inputs.application }}_${{ inputs.version }}_linux_amd64v2 ${{ inputs.application }}_${{ inputs.version }}_linux_amd64
-          mv erigon_v3.0.0-alpha5_linux_amd64v2 ${{ inputs.application }}_${{ inputs.version }}_linux_amd64
+          mv -v ${{ inputs.application }}_${{ inputs.version }}_linux_amd64v2 ${{ inputs.application }}_${{ inputs.version }}_linux_amd64
           tar xzvf ${{ inputs.application }}_${{ inputs.version }}_linux_arm64.tar.gz
-          mv erigon_v3.0.0-alpha5_linux_arm64 ${{ inputs.application }}_${{ inputs.version }}_linux_arm64
 
       # Creating directory structure
       # see https://www.debian.org/doc/debian-policy/ch-controlfields.html#version

--- a/.github/workflows/reusable-release-build-debian-pkg.yml
+++ b/.github/workflows/reusable-release-build-debian-pkg.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           tar xzvf ${{ inputs.application }}_v${{ inputs.version }}_linux_amd64v2.tar.gz
           mv -v ${{ inputs.application }}_v${{ inputs.version }}_linux_amd64v2 ${{ inputs.application }}_${{ inputs.version }}_linux_amd64
-          tar xzvf ${{ inputs.application }}_${{ inputs.version }}_linux_arm64.tar.gz
+          tar xzvf ${{ inputs.application }}_v${{ inputs.version }}_linux_arm64.tar.gz
 
       # Creating directory structure
       # see https://www.debian.org/doc/debian-policy/ch-controlfields.html#version

--- a/.github/workflows/reusable-release-build-debian-pkg.yml
+++ b/.github/workflows/reusable-release-build-debian-pkg.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Extract archives and rename amd64v2 to amd64
         run: |
           tar xzvf ${{ inputs.application }}_v${{ inputs.version }}_linux_amd64v2.tar.gz
-          mv -v ${{ inputs.application }}_v${{ inputs.version }}_linux_amd64v2 ${{ inputs.application }}_${{ inputs.version }}_linux_amd64
+          mv -v ${{ inputs.application }}_v${{ inputs.version }}_linux_amd64v2 ${{ inputs.application }}_v${{ inputs.version }}_linux_amd64
           tar xzvf ${{ inputs.application }}_v${{ inputs.version }}_linux_arm64.tar.gz
 
       # Creating directory structure

--- a/.github/workflows/reusable-release-build-debian-pkg.yml
+++ b/.github/workflows/reusable-release-build-debian-pkg.yml
@@ -19,12 +19,12 @@ jobs:
       - name: Download arm64 artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.application }}_v${{ inputs.version }}_linux_arm64.tar.gz
+          name: ${{ inputs.application }}_${{ 'v' }}${{ inputs.version }}_linux_arm64.tar.gz
 
       - name: Download amd64v2 artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.application }}_v${{ inputs.version }}_linux_amd64v2.tar.gz
+          name: ${{ inputs.application }}_${{ 'v' }}${{ inputs.version }}_linux_amd64v2.tar.gz
 
       - name: Update and install required packages, run dpkg
         run: |

--- a/.github/workflows/reusable-release-build-debian-pkg.yml
+++ b/.github/workflows/reusable-release-build-debian-pkg.yml
@@ -30,27 +30,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get upgrade -y
-          sudo apt-get install -y dpkg-dev debhelper rclone reprepro
+          sudo apt-get install -y dpkg-dev debhelper
           sudo dpkg --clear-avail
-
-      - name: Setup parsed version
-        id: variables
-        run: |
-          echo "PARSED_VERSION=$(echo ${{ inputs.version }} | sed -e 's/^v//g')" >> $GITHUB_OUTPUT
-
-      - name: Configure rclone [skip for now]
-        if: 1>2
-        run: |
-          mkdir -p ~/.config/rclone
-          cat <<-END > ~/.config/rclone/rclone.conf
-          [r2]
-          type = s3
-          provider = Cloudflare
-          access_key_id = ${R2_ACCESS_KEY_ID}
-          secret_access_key = ${R2_SECRET_ACCESS_KEY}
-          endpoint = ${R2_ENDPOINT}
-          acl = private
-          END
 
       - name: Extract archives and rename amd64v2 to amd64
         run: |
@@ -64,13 +45,12 @@ jobs:
       - name: Build debian package for amd64
         env:
           ARCH: "amd64"
-          PARSED_VERSION: ${{ steps.variables.outputs.PARSED_VERSION }}
         run: |
-          mkdir -p deb-pkg/${{ inputs.application }}_${PARSED_VERSION}_${ARCH}/usr/bin \
-                   deb-pkg/${{ inputs.application }}_${PARSED_VERSION}_${ARCH}/DEBIAN
-          cat <<-END  > deb-pkg/${{ inputs.application }}_${PARSED_VERSION}_${ARCH}/DEBIAN/control
+          mkdir -p deb-pkg/${{ inputs.application }}_${{ inputs.version }}_${ARCH}/usr/bin \
+                   deb-pkg/${{ inputs.application }}_${{ inputs.version }}_${ARCH}/DEBIAN
+          cat <<-END  > deb-pkg/${{ inputs.application }}_${{ inputs.version }}_${ARCH}/DEBIAN/control
           Package: ${{ inputs.application }}
-          Version: ${PARSED_VERSION}
+          Version: ${{ inputs.version }}
           Section: misc
           Priority: optional
           Architecture: ${ARCH}
@@ -80,19 +60,18 @@ jobs:
           Vcs-Browser: https://github.com/erigontech/erigon 
           END
           install -v -p ${{ inputs.application }}_${{ inputs.version }}_linux_${ARCH}/* \
-                      deb-pkg/${{ inputs.application }}_${PARSED_VERSION}_${ARCH}/usr/bin
-          dpkg-deb --build --root-owner-group deb-pkg/${{ inputs.application }}_${PARSED_VERSION}_${ARCH}
+                      deb-pkg/${{ inputs.application }}_${{ inputs.version }}_${ARCH}/usr/bin
+          dpkg-deb --build --root-owner-group deb-pkg/${{ inputs.application }}_${{ inputs.version }}_${ARCH}
 
       - name: Build debian package for arm64
         env:
           ARCH: "arm64"
-          PARSED_VERSION: ${{ steps.variables.outputs.PARSED_VERSION }}
         run: |
-          mkdir -p deb-pkg/${{ inputs.application }}_${PARSED_VERSION}_${ARCH}/usr/bin \
-                    deb-pkg/${{ inputs.application }}_${PARSED_VERSION}_${ARCH}/DEBIAN
-          cat <<-END  > deb-pkg/${{ inputs.application }}_${PARSED_VERSION}_${ARCH}/DEBIAN/control
+          mkdir -p deb-pkg/${{ inputs.application }}_${{ inputs.version }}_${ARCH}/usr/bin \
+                    deb-pkg/${{ inputs.application }}_${{ inputs.version }}_${ARCH}/DEBIAN
+          cat <<-END  > deb-pkg/${{ inputs.application }}_${{ inputs.version }}_${ARCH}/DEBIAN/control
           Package: ${{ inputs.application }}
-          Version: ${PARSED_VERSION}
+          Version: ${{ inputs.version }}
           Section: misc
           Priority: optional
           Architecture: ${ARCH}
@@ -102,26 +81,24 @@ jobs:
           Vcs-Browser: https://github.com/erigontech/erigon 
           END
           echo "debug start"
-          cat deb-pkg/${{ inputs.application }}_${PARSED_VERSION}_${ARCH}/DEBIAN/control
+          cat deb-pkg/${{ inputs.application }}_${{ inputs.version }}_${ARCH}/DEBIAN/control
           echo "debug end"
           install -v -p ${{ inputs.application }}_${{ inputs.version }}_linux_${ARCH}/* \
-                      deb-pkg/${{ inputs.application }}_${PARSED_VERSION}_${ARCH}/usr/bin
-          dpkg-deb --build --root-owner-group deb-pkg/${{ inputs.application }}_${PARSED_VERSION}_${ARCH}
+                      deb-pkg/${{ inputs.application }}_${{ inputs.version }}_${ARCH}/usr/bin
+          dpkg-deb --build --root-owner-group deb-pkg/${{ inputs.application }}_${{ inputs.version }}_${ARCH}
 
       - name: Debug output
-        env:
-          PARSED_VERSION: ${{ steps.variables.outputs.PARSED_VERSION }}
         run: |
           cd ./deb-pkg
-          sha256sum ${{ inputs.application }}_${PARSED_VERSION}_amd64.deb > ${{ inputs.application }}_${PARSED_VERSION}_amd64.deb.checksum
-          sha256sum ${{ inputs.application }}_${PARSED_VERSION}_arm64.deb > ${{ inputs.application }}_${PARSED_VERSION}_arm64.deb.checksum
+          sha256sum ${{ inputs.application }}_${{ inputs.version }}_amd64.deb > ${{ inputs.application }}_${{ inputs.version }}_amd64.deb.checksum
+          sha256sum ${{ inputs.application }}_${{ inputs.version }}_arm64.deb > ${{ inputs.application }}_${{ inputs.version }}_arm64.deb.checksum
           ls -l *deb *.checksum
 
       - name: Apload artifact amd64.deb
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  ## v4.3.6
         with:
-          name: ${{ inputs.application }}_${{ steps.variables.outputs.PARSED_VERSION }}_amd64.deb
-          path: ./deb-pkg/${{ inputs.application }}_${{ steps.variables.outputs.PARSED_VERSION }}_amd64.deb
+          name: ${{ inputs.application }}_${{ inputs.version }}_amd64.deb
+          path: ./deb-pkg/${{ inputs.application }}_${{ inputs.version }}_amd64.deb
           retention-days: 5
           compression-level: 0
           if-no-files-found: error
@@ -129,8 +106,8 @@ jobs:
       - name: Apload artifact amd64.deb.checksum
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  ## v4.3.6
         with:
-          name: ${{ inputs.application }}_${{ steps.variables.outputs.PARSED_VERSION }}_amd64.deb.checksum
-          path: ./deb-pkg/${{ inputs.application }}_${{ steps.variables.outputs.PARSED_VERSION }}_amd64.deb.checksum
+          name: ${{ inputs.application }}_${{ inputs.version }}_amd64.deb.checksum
+          path: ./deb-pkg/${{ inputs.application }}_${{ inputs.version }}_amd64.deb.checksum
           retention-days: 5
           compression-level: 0
           if-no-files-found: error
@@ -138,8 +115,8 @@ jobs:
       - name: Apload artifact arm64.deb
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  ## v4.3.6
         with:
-          name: ${{ inputs.application }}_${{ steps.variables.outputs.PARSED_VERSION }}_arm64.deb
-          path: ./deb-pkg/${{ inputs.application }}_${{ steps.variables.outputs.PARSED_VERSION }}_arm64.deb
+          name: ${{ inputs.application }}_${{ inputs.version }}_arm64.deb
+          path: ./deb-pkg/${{ inputs.application }}_${{ inputs.version }}_arm64.deb
           retention-days: 5
           compression-level: 0
           if-no-files-found: error
@@ -147,8 +124,8 @@ jobs:
       - name: Apload artifact arm64.deb.checksum
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  ## v4.3.6
         with:
-          name: ${{ inputs.application }}_${{ steps.variables.outputs.PARSED_VERSION }}_arm64.deb.checksum
-          path: ./deb-pkg/${{ inputs.application }}_${{ steps.variables.outputs.PARSED_VERSION }}_arm64.deb.checksum
+          name: ${{ inputs.application }}_${{ inputs.version }}_arm64.deb.checksum
+          path: ./deb-pkg/${{ inputs.application }}_${{ inputs.version }}_arm64.deb.checksum
           retention-days: 5
           compression-level: 0
           if-no-files-found: error

--- a/.github/workflows/reusable-release-build-debian-pkg.yml
+++ b/.github/workflows/reusable-release-build-debian-pkg.yml
@@ -19,12 +19,11 @@ jobs:
       - name: Download arm64 artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.application }}_${{ 'v' }}${{ inputs.version }}_linux_arm64.tar.gz
-
+          name: ${{ inputs.application }}_${{ format('v{0}', inputs.version ) }}_linux_arm64.tar.gz
       - name: Download amd64v2 artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.application }}_${{ 'v' }}${{ inputs.version }}_linux_amd64v2.tar.gz
+          name: ${{ inputs.application }}_${{ format('v{0}', inputs.version )  }}_linux_amd64v2.tar.gz
 
       - name: Update and install required packages, run dpkg
         run: |

--- a/.github/workflows/reusable-release-build-debian-pkg.yml
+++ b/.github/workflows/reusable-release-build-debian-pkg.yml
@@ -38,6 +38,12 @@ jobs:
           tar xzvf ${{ inputs.application }}_v${{ inputs.version }}_linux_amd64v2.tar.gz
           mv -v ${{ inputs.application }}_v${{ inputs.version }}_linux_amd64v2 ${{ inputs.application }}_v${{ inputs.version }}_linux_amd64
           tar xzvf ${{ inputs.application }}_v${{ inputs.version }}_linux_arm64.tar.gz
+          cat <<-END > postinst.template
+          #!/bin/bash
+          echo "WARNING: erigon package does not install any configurations nor services."
+          echo "Use your specific way to configure and run erigon according to your needs."
+          echo "More details how to run erigon could be found at https://erigon.gitbook.io/erigon ."
+          END
 
       # Creating directory structure
       # see https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
@@ -48,6 +54,7 @@ jobs:
         run: |
           mkdir -p deb-pkg/${{ inputs.application }}_${{ inputs.version }}_${ARCH}/usr/bin \
                    deb-pkg/${{ inputs.application }}_${{ inputs.version }}_${ARCH}/DEBIAN
+          install postinst.template deb-pkg/${{ inputs.application }}_${{ inputs.version }}_${ARCH}/DEBIAN/postinst
           cat <<-END  > deb-pkg/${{ inputs.application }}_${{ inputs.version }}_${ARCH}/DEBIAN/control
           Package: ${{ inputs.application }}
           Version: ${{ inputs.version }}
@@ -69,6 +76,7 @@ jobs:
         run: |
           mkdir -p deb-pkg/${{ inputs.application }}_${{ inputs.version }}_${ARCH}/usr/bin \
                     deb-pkg/${{ inputs.application }}_${{ inputs.version }}_${ARCH}/DEBIAN
+          install postinst.template deb-pkg/${{ inputs.application }}_${{ inputs.version }}_${ARCH}/DEBIAN/postinst
           cat <<-END  > deb-pkg/${{ inputs.application }}_${{ inputs.version }}_${ARCH}/DEBIAN/control
           Package: ${{ inputs.application }}
           Version: ${{ inputs.version }}

--- a/.github/workflows/reusable-release-build-debian-pkg.yml
+++ b/.github/workflows/reusable-release-build-debian-pkg.yml
@@ -42,7 +42,7 @@ jobs:
           #!/bin/bash
           echo "WARNING: erigon package does not install any configurations nor services."
           echo "Use your specific way to configure and run erigon according to your needs."
-          echo "More details how to run erigon could be found at https://erigon.gitbook.io/erigon ."
+          echo "More details on how to run erigon could be found at https://erigon.gitbook.io/erigon ."
           END
 
       # Creating directory structure

--- a/.github/workflows/reusable-release-build-debian-pkg.yml
+++ b/.github/workflows/reusable-release-build-debian-pkg.yml
@@ -1,0 +1,158 @@
+name: Build debian package (part of release process)
+
+on:
+  workflow_call:
+    inputs:
+      application:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+      arch:
+        required: false
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download arm64 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.application }}_${{ inputs.version }}_linux_arm64.tar.gz
+
+      - name: Download amd64v2 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.application }}_${{ inputs.version }}_linux_amd64v2.tar.gz
+
+      - name: Update and install required packages, run dpkg
+        run: |
+          sudo apt-get update
+          sudo apt-get upgrade -y
+          sudo apt-get install -y dpkg-dev debhelper rclone reprepro
+          sudo dpkg --clear-avail
+
+      - name: Setup parsed version
+        id: variables
+        run: |
+          echo "PARSED_VERSION=$(echo ${{ inputs.version }} | sed -e 's/^v//g')" >> $GITHUB_OUTPUT
+
+      - name: Configure rclone [skip for now]
+        if: 1>2
+        run: |
+          mkdir -p ~/.config/rclone
+          cat <<-END > ~/.config/rclone/rclone.conf
+          [r2]
+          type = s3
+          provider = Cloudflare
+          access_key_id = ${R2_ACCESS_KEY_ID}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
+          endpoint = ${R2_ENDPOINT}
+          acl = private
+          END
+
+      - name: Extract archives
+        run: |
+          tar xzvf ${{ inputs.application }}_${{ inputs.version }}_linux_amd64v2.tar.gz
+          #### mv -v ${{ inputs.application }}_${{ inputs.version }}_linux_amd64v2 ${{ inputs.application }}_${{ inputs.version }}_linux_amd64
+          mv erigon_v3.0.0-alpha5_linux_amd64v2 ${{ inputs.application }}_${{ inputs.version }}_linux_amd64
+          tar xzvf ${{ inputs.application }}_${{ inputs.version }}_linux_arm64.tar.gz
+          mv erigon_v3.0.0-alpha5_linux_arm64 ${{ inputs.application }}_${{ inputs.version }}_linux_arm64
+
+      # Creating directory structure
+      # see https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
+      #     https://www.debian.org/doc/manuals/developers-reference/best-pkging-practices.html
+      - name: Build debian package for amd64
+        env:
+          ARCH: "amd64"
+          PARSED_VERSION: ${{ steps.variables.outputs.PARSED_VERSION }}
+        run: |
+          mkdir -p deb-pkg/${{ inputs.application }}_${PARSED_VERSION}_${ARCH}/usr/bin \
+                   deb-pkg/${{ inputs.application }}_${PARSED_VERSION}_${ARCH}/DEBIAN
+          cat <<-END  > deb-pkg/${{ inputs.application }}_${PARSED_VERSION}_${ARCH}/DEBIAN/control
+          Package: ${{ inputs.application }}
+          Version: ${PARSED_VERSION}
+          Section: misc
+          Priority: optional
+          Architecture: ${ARCH}
+          Maintainer: Erigon DevOps [https://github.com/erigontech/erigon/issues]
+          Description: Erigon - Ethereum implementation on the efficiency frontier
+          Vcs-Git: https://github.com/erigontech/erigon.git
+          Vcs-Browser: https://github.com/erigontech/erigon 
+          END
+          install -v -p ${{ inputs.application }}_${{ inputs.version }}_linux_${ARCH}/* \
+                      deb-pkg/${{ inputs.application }}_${PARSED_VERSION}_${ARCH}/usr/bin
+          dpkg-deb --build --root-owner-group deb-pkg/${{ inputs.application }}_${PARSED_VERSION}_${ARCH}
+
+      - name: Build debian package for arm64
+        env:
+          ARCH: "arm64"
+          PARSED_VERSION: ${{ steps.variables.outputs.PARSED_VERSION }}
+        run: |
+          mkdir -p deb-pkg/${{ inputs.application }}_${PARSED_VERSION}_${ARCH}/usr/bin \
+                    deb-pkg/${{ inputs.application }}_${PARSED_VERSION}_${ARCH}/DEBIAN
+          cat <<-END  > deb-pkg/${{ inputs.application }}_${PARSED_VERSION}_${ARCH}/DEBIAN/control
+          Package: ${{ inputs.application }}
+          Version: ${PARSED_VERSION}
+          Section: misc
+          Priority: optional
+          Architecture: ${ARCH}
+          Maintainer: Erigon DevOps [https://github.com/erigontech/erigon/issues]
+          Description: Erigon - Ethereum implementation on the efficiency frontier
+          Vcs-Git: https://github.com/erigontech/erigon.git
+          Vcs-Browser: https://github.com/erigontech/erigon 
+          END
+          echo "debug start"
+          cat deb-pkg/${{ inputs.application }}_${PARSED_VERSION}_${ARCH}/DEBIAN/control
+          echo "debug end"
+          install -v -p ${{ inputs.application }}_${{ inputs.version }}_linux_${ARCH}/* \
+                      deb-pkg/${{ inputs.application }}_${PARSED_VERSION}_${ARCH}/usr/bin
+          dpkg-deb --build --root-owner-group deb-pkg/${{ inputs.application }}_${PARSED_VERSION}_${ARCH}
+
+      - name: Debug output
+        env:
+          PARSED_VERSION: ${{ steps.variables.outputs.PARSED_VERSION }}
+        run: |
+          cd ./deb-pkg
+          sha256sum ${{ inputs.application }}_${PARSED_VERSION}_amd64.deb > ${{ inputs.application }}_${PARSED_VERSION}_amd64.deb.checksum
+          sha256sum ${{ inputs.application }}_${PARSED_VERSION}_arm64.deb > ${{ inputs.application }}_${PARSED_VERSION}_arm64.deb.checksum
+          ls -l *deb *.checksum
+
+      - name: Apload artifact amd64.deb
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  ## v4.3.6
+        with:
+          name: ${{ inputs.application }}_${{ steps.variables.outputs.PARSED_VERSION }}_amd64.deb
+          path: ./deb-pkg/${{ inputs.application }}_${{ steps.variables.outputs.PARSED_VERSION }}_amd64.deb
+          retention-days: 5
+          compression-level: 0
+          if-no-files-found: error
+
+      - name: Apload artifact amd64.deb.checksum
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  ## v4.3.6
+        with:
+          name: ${{ inputs.application }}_${{ steps.variables.outputs.PARSED_VERSION }}_amd64.deb.checksum
+          path: ./deb-pkg/${{ inputs.application }}_${{ steps.variables.outputs.PARSED_VERSION }}_amd64.deb.checksum
+          retention-days: 5
+          compression-level: 0
+          if-no-files-found: error
+
+      - name: Apload artifact arm64.deb
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  ## v4.3.6
+        with:
+          name: ${{ inputs.application }}_${{ steps.variables.outputs.PARSED_VERSION }}_arm64.deb
+          path: ./deb-pkg/${{ inputs.application }}_${{ steps.variables.outputs.PARSED_VERSION }}_arm64.deb
+          retention-days: 5
+          compression-level: 0
+          if-no-files-found: error
+  
+      - name: Apload artifact arm64.deb.checksum
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  ## v4.3.6
+        with:
+          name: ${{ inputs.application }}_${{ steps.variables.outputs.PARSED_VERSION }}_arm64.deb.checksum
+          path: ./deb-pkg/${{ inputs.application }}_${{ steps.variables.outputs.PARSED_VERSION }}_arm64.deb.checksum
+          retention-days: 5
+          compression-level: 0
+          if-no-files-found: error

--- a/.github/workflows/reusable-release-build-debian-pkg.yml
+++ b/.github/workflows/reusable-release-build-debian-pkg.yml
@@ -19,11 +19,12 @@ jobs:
       - name: Download arm64 artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.application }}_${{ format('v{0}', inputs.version ) }}_linux_arm64.tar.gz
+          name: ${{ inputs.application }}_v${{ inputs.version }}_linux_arm64.tar.gz
+
       - name: Download amd64v2 artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.application }}_${{ format('v{0}', inputs.version )  }}_linux_amd64v2.tar.gz
+          name: ${{ inputs.application }}_v${{ inputs.version }}_linux_amd64v2.tar.gz
 
       - name: Update and install required packages, run dpkg
         run: |

--- a/.github/workflows/reusable-release-build-debian-pkg.yml
+++ b/.github/workflows/reusable-release-build-debian-pkg.yml
@@ -35,8 +35,8 @@ jobs:
 
       - name: Extract archives and rename amd64v2 to amd64
         run: |
-          tar xzvf ${{ inputs.application }}_${{ inputs.version }}_linux_amd64v2.tar.gz
-          mv -v ${{ inputs.application }}_${{ inputs.version }}_linux_amd64v2 ${{ inputs.application }}_${{ inputs.version }}_linux_amd64
+          tar xzvf ${{ inputs.application }}_v${{ inputs.version }}_linux_amd64v2.tar.gz
+          mv -v ${{ inputs.application }}_v${{ inputs.version }}_linux_amd64v2 ${{ inputs.application }}_${{ inputs.version }}_linux_amd64
           tar xzvf ${{ inputs.application }}_${{ inputs.version }}_linux_arm64.tar.gz
 
       # Creating directory structure
@@ -59,7 +59,7 @@ jobs:
           Vcs-Git: https://github.com/erigontech/erigon.git
           Vcs-Browser: https://github.com/erigontech/erigon 
           END
-          install -v -p ${{ inputs.application }}_${{ inputs.version }}_linux_${ARCH}/* \
+          install -v -p ${{ inputs.application }}_v${{ inputs.version }}_linux_${ARCH}/* \
                       deb-pkg/${{ inputs.application }}_${{ inputs.version }}_${ARCH}/usr/bin
           dpkg-deb --build --root-owner-group deb-pkg/${{ inputs.application }}_${{ inputs.version }}_${ARCH}
 
@@ -83,7 +83,7 @@ jobs:
           echo "debug start"
           cat deb-pkg/${{ inputs.application }}_${{ inputs.version }}_${ARCH}/DEBIAN/control
           echo "debug end"
-          install -v -p ${{ inputs.application }}_${{ inputs.version }}_linux_${ARCH}/* \
+          install -v -p ${{ inputs.application }}_v${{ inputs.version }}_linux_${ARCH}/* \
                       deb-pkg/${{ inputs.application }}_${{ inputs.version }}_${ARCH}/usr/bin
           dpkg-deb --build --root-owner-group deb-pkg/${{ inputs.application }}_${{ inputs.version }}_${ARCH}
 


### PR DESCRIPTION
See https://github.com/erigontech/erigon/issues/12891 for more details.
Changes:
- new reusable workflow for building debian packages
- this reusable workflow is a part of release workflow. Binaries which is built during build stage used to build docker image, debian package and to publish as release artifacts.