### PR TITLE
Pre-Shapella blocks must have nil withdrawals

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -964,6 +964,11 @@ func NewBlock(header *Header, txs []Transaction, uncles []*Header, receipts []*R
 // in this case no reason to copy parts, or re-calculate headers fields - they are all stored in DB
 func NewBlockFromStorage(hash libcommon.Hash, header *Header, txs []Transaction, uncles []*Header, withdrawals []*Withdrawal) *Block {
 	b := &Block{header: header, transactions: txs, uncles: uncles, withdrawals: withdrawals}
+	if header.WithdrawalsHash == nil && len(withdrawals) == 0 {
+		// Hack for Issue 12297
+		// Apparently some snapshots have pre-Shappella blocks with empty rather than nil withdrawals
+		b.withdrawals = nil
+	}
 	b.hash.Store(hash)
 	return b
 }

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -964,11 +964,6 @@ func NewBlock(header *Header, txs []Transaction, uncles []*Header, receipts []*R
 // in this case no reason to copy parts, or re-calculate headers fields - they are all stored in DB
 func NewBlockFromStorage(hash libcommon.Hash, header *Header, txs []Transaction, uncles []*Header, withdrawals []*Withdrawal) *Block {
 	b := &Block{header: header, transactions: txs, uncles: uncles, withdrawals: withdrawals}
-	if header.WithdrawalsHash == nil && len(withdrawals) == 0 {
-		// Hack for Issue 12297
-		// Apparently some snapshots have pre-Shappella blocks with empty rather than nil withdrawals
-		b.withdrawals = nil
-	}
 	b.hash.Store(hash)
 	return b
 }

--- a/turbo/snapshotsync/freezeblocks/block_reader.go
+++ b/turbo/snapshotsync/freezeblocks/block_reader.go
@@ -712,32 +712,23 @@ func (r *BlockReader) blockWithSenders(ctx context.Context, tx kv.Getter, hash c
 		}
 		return
 	}
-	if txsAmount == 0 {
-		block = types.NewBlockFromStorage(hash, h, nil, b.Uncles, b.Withdrawals)
-		if len(senders) != block.Transactions().Len() {
-			if dbgLogs {
-				log.Info(dbgPrefix + fmt.Sprintf("found block with %d transactions, but %d senders", block.Transactions().Len(), len(senders)))
-			}
-			return block, senders, nil // no senders is fine - will recover them on the fly
-		}
-		block.SendersToTxs(senders)
-		return block, senders, nil
-	}
 
-	txnSeg, ok, release := r.sn.ViewSingleFile(coresnaptype.Transactions, blockHeight)
-	if !ok {
-		if dbgLogs {
-			log.Info(dbgPrefix+"no transactions file for this block num", "r.sn.BlocksAvailable()", r.sn.BlocksAvailable(), "r.sn.indicesReady", r.sn.indicesReady.Load())
-		}
-		return
-	}
-	defer release()
 	var txs []types.Transaction
-	txs, senders, err = r.txsFromSnapshot(baseTxnId, txsAmount, txnSeg, buf)
-	if err != nil {
-		return nil, nil, err
+	if txsAmount != 0 {
+		txnSeg, ok, release := r.sn.ViewSingleFile(coresnaptype.Transactions, blockHeight)
+		if !ok {
+			if dbgLogs {
+				log.Info(dbgPrefix+"no transactions file for this block num", "r.sn.BlocksAvailable()", r.sn.BlocksAvailable(), "r.sn.indicesReady", r.sn.indicesReady.Load())
+			}
+			return
+		}
+		defer release()
+		txs, senders, err = r.txsFromSnapshot(baseTxnId, txsAmount, txnSeg, buf)
+		if err != nil {
+			return nil, nil, err
+		}
+		release()
 	}
-	release()
 
 	block = types.NewBlockFromStorage(hash, h, txs, b.Uncles, b.Withdrawals)
 	if len(senders) != block.Transactions().Len() {

--- a/turbo/snapshotsync/freezeblocks/block_reader.go
+++ b/turbo/snapshotsync/freezeblocks/block_reader.go
@@ -730,6 +730,11 @@ func (r *BlockReader) blockWithSenders(ctx context.Context, tx kv.Getter, hash c
 		release()
 	}
 
+	if h.WithdrawalsHash == nil && len(b.Withdrawals) == 0 {
+		// Hack for Issue 12297
+		// Apparently some snapshots have pre-Shapella blocks with empty rather than nil withdrawals
+		b.Withdrawals = nil
+	}
 	block = types.NewBlockFromStorage(hash, h, txs, b.Uncles, b.Withdrawals)
 	if len(senders) != block.Transactions().Len() {
 		if dbgLogs {


### PR DESCRIPTION
Apparently we saved some pre-Shappella blocks into snapshots with empty rather than nil withdrawals. This is a work-around for issues like #12297 to avoid regenerating block snapshots. You can see the problem by running
```
curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x103716A",false],"id":1}' http://localhost:8545
```

