### PR TITLE
Fix extra quotation marks in the command section

### DIFF
--- a/docs/examples/single-process.md
+++ b/docs/examples/single-process.md
@@ -8,8 +8,8 @@ How to run Erigon in a single process (all parts of the system run as one).
 2. Run erigon:
     ``` 
     ./build/bin/erigon --datadir=/desired/path/to/datadir \
-     --chain=sepolia" \
-     --port=30304" \
+     --chain=sepolia \
+     --port=30304 \
      --http.port=8546 \
      --authrpc.port=8552 \
      --torrent.port=42068 \


### PR DESCRIPTION
I noticed that there were extra quotation marks in the commands section, specifically after the `--chain=sepolia` and `--port=30304` options

<img width="486" alt="Снимок экрана 2024-12-08 в 15 16 50" src="https://github.com/user-attachments/assets/c789e769-f371-4ec8-a015-c24dc119ba66">

This caused a syntax issue when trying to execute the commands. The unnecessary quotation marks have been removed to ensure the commands work properly without errors.

Here is the corrected version:

```bash
--chain=sepolia \
--port=30304 \
```

This change is important because it prevents syntax errors that could confuse users or lead to failed command executions.