### PR TITLE
Caplin: better fix for orphaned blocks

### DIFF
--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -1194,13 +1194,15 @@ func (a *ApiHandler) storeBlockAndBlobs(
 	if headState == nil {
 		return errors.New("failed to get head state")
 	}
-	a.syncedData.OnHeadState(headState)
 
 	if err := a.indiciesDB.View(ctx, func(tx kv.Tx) error {
 		_, err := a.attestationProducer.ProduceAndCacheAttestationData(tx, headState, blockRoot, block.Block.Slot, 0)
 		return err
 	}); err != nil {
 		return err
+	}
+	if err := a.syncedData.OnHeadState(headState); err != nil {
+		return fmt.Errorf("failed to update synced data: %w", err)
 	}
 
 	return nil

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -301,16 +301,10 @@ func (a *ApiHandler) GetEthV3ValidatorBlock(
 	}
 
 	// make a simple copy to the current head state
-	var baseState *state.CachingBeaconState
-	if err := a.syncedData.ViewHeadState(func(headState *state.CachingBeaconState) error {
-		baseState, err = headState.Copy()
-		if err != nil {
-			return err
-		}
-		return nil
-	}); err != nil {
-		return nil, err
-	}
+	baseState, err := a.forkchoiceStore.GetStateAtBlockRoot(
+		baseBlockRoot,
+		true,
+	) // we start the block production from this state
 
 	if err != nil {
 		return nil, err

--- a/cl/phase1/forkchoice/fork_graph/fork_graph_disk_fs.go
+++ b/cl/phase1/forkchoice/fork_graph/fork_graph_disk_fs.go
@@ -100,7 +100,7 @@ func (f *forkGraphDisk) readBeaconStateFromDisk(blockRoot libcommon.Hash, out *s
 		return nil, err
 	}
 
-	if err := bs.DecodeCaches(cacheFile); err != nil {
+	if err := bs.DecodeCaches(b); err != nil {
 		return nil, err
 	}
 

--- a/cl/phase1/forkchoice/fork_graph/fork_graph_disk_fs.go
+++ b/cl/phase1/forkchoice/fork_graph/fork_graph_disk_fs.go
@@ -86,12 +86,19 @@ func (f *forkGraphDisk) readBeaconStateFromDisk(blockRoot libcommon.Hash, out *s
 	if err = bs.DecodeSSZ(f.sszBuffer, int(v[0])); err != nil {
 		return nil, fmt.Errorf("failed to decode beacon state: %w, root: %x, len: %d, decLen: %d, bs: %+v", err, blockRoot, n, len(f.sszBuffer), bs)
 	}
+
 	// decode the cache file
 	cacheFile, err := f.fs.Open(getBeaconStateCacheFilename(blockRoot))
 	if err != nil {
 		return
 	}
 	defer cacheFile.Close()
+
+	f.sszBuffer = f.sszBuffer[:0]
+	b := bytes.NewBuffer(f.sszBuffer)
+	if _, err := io.Copy(b, cacheFile); err != nil {
+		return nil, err
+	}
 
 	if err := bs.DecodeCaches(cacheFile); err != nil {
 		return nil, err


### PR DESCRIPTION
so the issues is that decoding caches from disk was too IO intensive. this does one batch read and calls it a day.