### PR TITLE
Generalize iterator exhausted error

### DIFF
--- a/erigon-lib/common/errors/errors.go
+++ b/erigon-lib/common/errors/errors.go
@@ -18,6 +18,8 @@ package errors
 
 import "errors"
 
+var ErrIteratorExhausted = errors.New("iterator exhausted")
+
 func IsOneOf(err error, targets []error) bool {
 	if err == nil {
 		return false

--- a/erigon-lib/common/errors/errors.go
+++ b/erigon-lib/common/errors/errors.go
@@ -18,8 +18,6 @@ package errors
 
 import "errors"
 
-var ErrIteratorExhausted = errors.New("iterator exhausted")
-
 func IsOneOf(err error, targets []error) bool {
 	if err == nil {
 		return false

--- a/erigon-lib/kv/stream/stream_interface.go
+++ b/erigon-lib/kv/stream/stream_interface.go
@@ -16,6 +16,8 @@
 
 package stream
 
+import "errors"
+
 // Streams - it's iterator-like composable high-level abstraction - which designed for inter-process communication and between processes:
 //  - cancelable
 //  - return errors
@@ -37,6 +39,10 @@ package stream
 //   4. automatically checks cancelation of `ctx` passed to `db.Begin(ctx)`, can skip this
 //     check in loops on stream. Duo has very limited API - user has no way to
 //     terminate it - but user can specify more strict conditions when creating stream (then server knows better when to stop)
+
+// Indicates the iterator has no more elements. Meant to be returned by implementations of Next()
+// when there are no more elements.
+var ErrIteratorExhausted = errors.New("iterator exhausted")
 
 // Uno - return 1 item. Example:
 //

--- a/erigon-lib/recsplit/eliasfano32/elias_fano.go
+++ b/erigon-lib/recsplit/eliasfano32/elias_fano.go
@@ -26,7 +26,7 @@ import (
 	"unsafe"
 
 	"github.com/erigontech/erigon-lib/common/bitutil"
-	"github.com/erigontech/erigon-lib/common/errors"
+	"github.com/erigontech/erigon-lib/kv/stream"
 )
 
 // EliasFano algo overview https://www.antoniomallia.it/sorted-integers-compression-with-elias-fano-encoding.html
@@ -484,7 +484,7 @@ func (efi *EliasFanoIter) decrement() {
 
 func (efi *EliasFanoIter) Next() (uint64, error) {
 	if !efi.HasNext() {
-		return 0, errors.ErrIteratorExhausted
+		return 0, stream.ErrIteratorExhausted
 	}
 	idx64, shift := efi.lowerIdx/64, efi.lowerIdx%64
 	lower := efi.lowerBits[idx64] >> shift

--- a/erigon-lib/recsplit/eliasfano32/elias_fano.go
+++ b/erigon-lib/recsplit/eliasfano32/elias_fano.go
@@ -18,7 +18,6 @@ package eliasfano32
 
 import (
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -27,6 +26,7 @@ import (
 	"unsafe"
 
 	"github.com/erigontech/erigon-lib/common/bitutil"
+	"github.com/erigontech/erigon-lib/common/errors"
 )
 
 // EliasFano algo overview https://www.antoniomallia.it/sorted-integers-compression-with-elias-fano-encoding.html
@@ -43,8 +43,6 @@ const (
 	qPerSuperQ uint64 = superQ / q       // 64
 	superQSize uint64 = 1 + qPerSuperQ/2 // 1 + 64/2 = 33
 )
-
-var ErrEliasFanoIterExhausted = errors.New("elias fano iterator exhausted")
 
 // EliasFano can be used to encode one monotone sequence
 type EliasFano struct {
@@ -486,7 +484,7 @@ func (efi *EliasFanoIter) decrement() {
 
 func (efi *EliasFanoIter) Next() (uint64, error) {
 	if !efi.HasNext() {
-		return 0, ErrEliasFanoIterExhausted
+		return 0, errors.ErrIteratorExhausted
 	}
 	idx64, shift := efi.lowerIdx/64, efi.lowerIdx%64
 	lower := efi.lowerBits[idx64] >> shift

--- a/erigon-lib/recsplit/eliasfano32/elias_fano_test.go
+++ b/erigon-lib/recsplit/eliasfano32/elias_fano_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/erigontech/erigon-lib/common/errors"
 	"github.com/erigontech/erigon-lib/common/hexutility"
 	"github.com/erigontech/erigon-lib/kv/stream"
 )
@@ -356,7 +355,7 @@ func TestIterator(t *testing.T) {
 			require.NoError(t, err)
 		}
 		_, err := it.Next()
-		require.ErrorIs(t, err, errors.ErrIteratorExhausted)
+		require.ErrorIs(t, err, stream.ErrIteratorExhausted)
 
 		it = ef.ReverseIterator()
 		for range offsets {
@@ -364,7 +363,7 @@ func TestIterator(t *testing.T) {
 			require.NoError(t, err)
 		}
 		_, err = it.Next()
-		require.ErrorIs(t, err, errors.ErrIteratorExhausted)
+		require.ErrorIs(t, err, stream.ErrIteratorExhausted)
 	})
 
 	t.Run("article-example1", func(t *testing.T) {

--- a/erigon-lib/recsplit/eliasfano32/elias_fano_test.go
+++ b/erigon-lib/recsplit/eliasfano32/elias_fano_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon-lib/common/errors"
 	"github.com/erigontech/erigon-lib/common/hexutility"
 	"github.com/erigontech/erigon-lib/kv/stream"
 )
@@ -355,7 +356,7 @@ func TestIterator(t *testing.T) {
 			require.NoError(t, err)
 		}
 		_, err := it.Next()
-		require.ErrorIs(t, err, ErrEliasFanoIterExhausted)
+		require.ErrorIs(t, err, errors.ErrIteratorExhausted)
 
 		it = ef.ReverseIterator()
 		for range offsets {
@@ -363,7 +364,7 @@ func TestIterator(t *testing.T) {
 			require.NoError(t, err)
 		}
 		_, err = it.Next()
-		require.ErrorIs(t, err, ErrEliasFanoIterExhausted)
+		require.ErrorIs(t, err, errors.ErrIteratorExhausted)
 	})
 
 	t.Run("article-example1", func(t *testing.T) {


### PR DESCRIPTION
As part of https://github.com/erigontech/erigon/pull/12907 I'll have other iterator-like sequence implementations.

It makes sense to generalize the ErrEliasFanoIterExhausted and move it to a common package and reuse it, rather than making a bunch of IteratorExhausted-like for each implementation.