### PR TITLE
Fix typos in README files across multiple directories

### DIFF
--- a/cmd/devnet/README.md
+++ b/cmd/devnet/README.md
@@ -104,19 +104,19 @@ Fetch the devnet logger - which can be used for logging step processing.
 func SelectNode(ctx context.Context, selector ...interface{}) 
 ```
 
-This method selects a node on the network the selector argument can be either an `int` index or an implementation of the `network.NodeSelector` interface.  If no selector is specified a either the `current node` will be returned or a node will be selected at random from the network.
+This method selects a node on the network the selector argument can be either an `int` index or an implementation of the `network.NodeSelector` interface.  If no selector is specified an either the `current node` will be returned or a node will be selected at random from the network.
 
 ```go
 func SelectMiner(ctx context.Context, selector ...interface{})
 ```
 
-This method selects a mining node on the network the selector argument can be either an `int` index or an implementation of the `network.NodeSelector` interface.  If no selector is specified a either the `current node` will be returned or a miner will be selected at random from the network.
+This method selects a mining node on the network the selector argument can be either an `int` index or an implementation of the `network.NodeSelector` interface.  If no selector is specified an either the `current node` will be returned or a miner will be selected at random from the network.
 
 ```go
 func SelectNonMiner(ctx context.Context, selector ...interface{})
 ```
 
-This method selects a non mining node on the network the selector argument can be either an `int` index or an implementation of the `network.NodeSelector` interface.  If no selector is specified a either the `current node` will be returned or a non-miner will be selected at random from the network.
+This method selects a non mining node on the network the selector argument can be either an `int` index or an implementation of the `network.NodeSelector` interface.  If no selector is specified an either the `current node` will be returned or a non-miner will be selected at random from the network.
 
 ```go
 func WithCurrentNode(ctx context.Context, selector interface{}) Context

--- a/cmd/evm/testdata/9/readme.md
+++ b/cmd/evm/testdata/9/readme.md
@@ -1,6 +1,6 @@
 ## EIP-1559 testing
 
-This test contains testcases for EIP-1559, which uses an new transaction type and has a new block parameter. 
+This test contains testcases for EIP-1559, which uses a new transaction type and has a new block parameter. 
 
 ### Prestate
 

--- a/erigon-lib/downloader/README.md
+++ b/erigon-lib/downloader/README.md
@@ -75,6 +75,6 @@ It contains the following entries
 | Name | The unqualified name of the file being downloaded.  e.g. `v1-000000-000500-transactions.seg`.  This field is treated as the primary key for the table, there can only be one download per file. |
 | Hash | The hash of the file being downloaded.  This value can change if the external hash received either from `chain.toml` or `snapshot-lock.json` changes.  If the hash changes the entry is treated as a new download and the `Length` and `Completed` fields are reset. 
 | Length | The length of the file downloaded.  This may be available from the torrent info - but in general is only completed once the file has been downloaded. |
-| Created | The date and time that this record was created, or that the `Hash` field changed, effectively making this an new download. |
+| Created | The date and time that this record was created, or that the `Hash` field changed, effectively making this a new download. |
 | Completed | This is the date and time that the download was completed.  The presence of a completion date is also used as an indication of completion.  If the field is nil then the download is treated as incomplete |
 

--- a/p2p/simulations/README.md
+++ b/p2p/simulations/README.md
@@ -116,7 +116,7 @@ the expectation and what network events were emitted during the step run.
 
 ## HTTP API
 
-The simulation framework includes a HTTP API which can be used to control the
+The simulation framework includes an HTTP API which can be used to control the
 simulation.
 
 The API is initialised with a particular node adapter and has the following


### PR DESCRIPTION
This pull request addresses multiple typos found in various `README.md` files.  

**Summary of Changes:**  
1. Corrected the use of "a" to "an" where appropriate (e.g., before words starting with a vowel sound).  
2. Adjusted grammatical errors and refined phrasing for clarity.  
3. Ensured consistent usage of terms across files (e.g., "an HTTP API" instead of "a HTTP API").  

**Files Modified:**  
- `cmd/devnet/README.md`  
- `cmd/evm/testdata/9/readme.md`  
- `erigon-lib/downloader/README.md`  
- `p2p/simulations/README.md`  

These updates enhance the readability and grammatical accuracy of the documentation.  