### PR TITLE
workflows: use fixed CL images for kurtosis-assertoor tests

### DIFF
--- a/.github/workflows/kurtosis/regular-assertoor.io
+++ b/.github/workflows/kurtosis/regular-assertoor.io
@@ -4,7 +4,9 @@ participants_matrix:
       el_image: test/erigon:current
   cl:
     - cl_type: lighthouse
+      cl_image: sigp/lighthouse:v6.0.0
     - cl_type: nimbus
+      cl_image: statusim/nimbus-eth2:multiarch-v24.11.0
 network_params:
   #electra_fork_epoch: 1
   min_validator_withdrawability_delay: 1


### PR DESCRIPTION
Should fix the recent broken kurtosis tests due to some Lighthouse or Nimbus release