### PR TITLE
Fix Typo in README

### DIFF
--- a/cmd/snapshots/README.md
+++ b/cmd/snapshots/README.md
@@ -1,4 +1,4 @@
-# Snapshots - tool for managing remote stanshots
+# Snapshots - tool for managing remote snapshots
 
 In the root of `Erigon` project, use this command to build the commands:
 


### PR DESCRIPTION
### Description
This commit corrects a typographical error in the `cmd/snapshots/README.md` file. The word "stanshots" has been replaced with the correct term "snapshots" in the heading, improving documentation clarity and accuracy.