### PR TITLE
fix: check `r.err != nil` but return a nil value error `err`

### DIFF
--- a/eth/stagedsync/stage_polygon_sync.go
+++ b/eth/stagedsync/stage_polygon_sync.go
@@ -1039,7 +1039,7 @@ func (s polygonSyncStageBridgeStore) LastEventIdWithinWindow(ctx context.Context
 		return 0, err
 	}
 	if r.err != nil {
-		return 0, err
+		return 0, r.err
 	}
 
 	return r.id, nil


### PR DESCRIPTION
the `err` has been checked. so it's value must be nil, so should return `r.err`

I have an idea to detect code that returns a non-relevant nilness error bug. I checked the top 1000 GitHub Go repositories and found this, all result listed in https://github.com/alingse/sundrylint/issues/4