### PR TITLE
BeginTemporalRo/Rw defer rules

### DIFF
--- a/erigon-lib/rules.go
+++ b/erigon-lib/rules.go
@@ -52,6 +52,10 @@ func txDeferRollback(m dsl.Matcher) {
 		`$tx, $err = $db.Begin($ctx); $chk; $rollback`,
 		`$tx, $err := $db.BeginRo($ctx); $chk; $rollback`,
 		`$tx, $err = $db.BeginRo($ctx); $chk; $rollback`,
+		`$tx, $err = $db.BeginTemporalRw($ctx); $chk; $rollback`,
+		`$tx, $err := $db.BeginTemporalRw($ctx); $chk; $rollback`,
+		`$tx, $err = $db.BeginTemporalRo($ctx); $chk; $rollback`,
+		`$tx, $err := $db.BeginTemporalRo($ctx); $chk; $rollback`,
 	).
 		Where(!m["rollback"].Text.Matches(`defer .*\.Rollback()`)).
 		//At(m["rollback"]).

--- a/erigon-lib/rules.go
+++ b/erigon-lib/rules.go
@@ -56,6 +56,8 @@ func txDeferRollback(m dsl.Matcher) {
 		`$tx, $err := $db.BeginTemporalRw($ctx); $chk; $rollback`,
 		`$tx, $err = $db.BeginTemporalRo($ctx); $chk; $rollback`,
 		`$tx, $err := $db.BeginTemporalRo($ctx); $chk; $rollback`,
+		`$tx, $err := $db.BeginRwNosync($ctx); $chk; $rollback`,
+		`$tx, $err = $db.BeginRwNosync($ctx); $chk; $rollback`,
 	).
 		Where(!m["rollback"].Text.Matches(`defer .*\.Rollback()`)).
 		//At(m["rollback"]).

--- a/rules.go
+++ b/rules.go
@@ -51,6 +51,10 @@ func txDeferRollback(m dsl.Matcher) {
 		`$tx, $err = $db.Begin($ctx); $chk; $rollback`,
 		`$tx, $err := $db.BeginRo($ctx); $chk; $rollback`,
 		`$tx, $err = $db.BeginRo($ctx); $chk; $rollback`,
+		`$tx, $err = $db.BeginTemporalRw($ctx); $chk; $rollback`,
+		`$tx, $err := $db.BeginTemporalRw($ctx); $chk; $rollback`,
+		`$tx, $err = $db.BeginTemporalRo($ctx); $chk; $rollback`,
+		`$tx, $err := $db.BeginTemporalRo($ctx); $chk; $rollback`,
 	).
 		Where(!m["rollback"].Text.Matches(`defer .*\.Rollback()`)).
 		//At(m["rollback"]).

--- a/rules.go
+++ b/rules.go
@@ -55,6 +55,8 @@ func txDeferRollback(m dsl.Matcher) {
 		`$tx, $err := $db.BeginTemporalRw($ctx); $chk; $rollback`,
 		`$tx, $err = $db.BeginTemporalRo($ctx); $chk; $rollback`,
 		`$tx, $err := $db.BeginTemporalRo($ctx); $chk; $rollback`,
+		`$tx, $err := $db.BeginRwNosync($ctx); $chk; $rollback`,
+		`$tx, $err = $db.BeginRwNosync($ctx); $chk; $rollback`,
 	).
 		Where(!m["rollback"].Text.Matches(`defer .*\.Rollback()`)).
 		//At(m["rollback"]).


### PR DESCRIPTION

example run:
```
// BalanceAt returns the wei balance of a certain account in the blockchain.
func (b *SimulatedBackend) BalanceAt(ctx context.Context, contract libcommon.Address, blockNumber *big.Int) (*uint256.Int, error) {
	b.mu.Lock()
	defer b.mu.Unlock()
	// tx, err := b.m.DB.BeginTemporalRo(context.Background())
	// if err != nil {
	// 	return nil, err
	// }
	// defer tx.Rollback()
	// stateDB := b.stateByBlockNumber(tx, blockNumber)

	tx2, err := b.m.DB.BeginTemporalRo(context.Background())
	if err != nil {
		return nil, err
	}

	stateDb := b.stateByBlockNumber(tx2, blockNumber)

	return stateDb.GetBalance(contract)
}
```

linter run:
```
>> make lint
	            ^
accounts/abi/bind/backends/simulated.go:224:2: ruleguard: Add "defer tx2.Rollback()" right after transaction creation error check.
			If you are in the loop - consider use "b.m.DB.View" or "b.m.DB.Update" or extract whole transaction to function.
```