### PR TITLE
eth_call: global RPC gas limit

### DIFF
--- a/turbo/transactions/call.go
+++ b/turbo/transactions/call.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/holiman/uint256"
@@ -109,7 +110,12 @@ func DoCall(
 		evm.Cancel()
 	}()
 
-	gp := new(core.GasPool).AddGas(msg.Gas()).AddBlobGas(msg.BlobGas())
+	gp := new(core.GasPool)
+	if gasCap == 0 {
+		gp.AddGas(math.MaxUint64)
+	} else {
+		gp.AddGas(gasCap)
+	}
 	result, err := core.ApplyMessage(evm, msg, gp, true /* refunds */, false /* gasBailout */)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
compatibility with  https://github.com/ethereum/go-ethereum/blob/bc1ec69008174aa2f5fd3642adeafb0459d2464b/internal/ethapi/api.go#L677 
related to https://github.com/erigontech/erigon/issues/11312