### PR TITLE
Changes in the release workflow: get rid of goreleaser, debian base image, etc.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,7 @@ jobs:
           make GOARCH=arm64 GOBIN=/erigon-build BUILD_TAGS=nosqlite,noboltdb,nosilkworm 
           erigon downloader devnet evm caplin diag integration rpcdaemon sentry txpool"
 
+        ## temporary disable silkworm in 3.x.x
       - name: Build for linux/amd64 (with nosilkworm tag)
         run: >
           docker run --platform linux/amd64
@@ -128,8 +129,9 @@ jobs:
           -c "git config --global --add safe.directory /erigon;
           make GOARCH=amd64 GOAMD64=v1 GOBIN=/erigon-build BUILD_TAGS=nosqlite,noboltdb,nosilkworm 
           erigon downloader devnet evm caplin diag integration rpcdaemon sentry txpool;
-          find / -name libsilkworm_capi.so -exec install {} /erigon-build \; "
+          if [ ${WITH_SILKWORM} ]; then find / -name libsilkworm_capi.so -exec install {} /erigon-build \; ; fi;"
 
+        ## temporary disable silkworm in 3.x.x
       - name: Build for linux/amd64/v2 (with nosilkworm tag)
         run: >
           docker run --platform linux/amd64/v2
@@ -143,7 +145,7 @@ jobs:
           -c "git config --global --add safe.directory /erigon;
           make GOARCH=amd64 GOAMD64=v2 GOBIN=/erigon-build BUILD_TAGS=nosqlite,noboltdb,nosilkworm 
           erigon downloader devnet evm caplin diag integration rpcdaemon sentry txpool;
-          find / -name libsilkworm_capi.so -exec install {} /erigon-build \; "
+          if [ ${WITH_SILKWORM} ]; then find / -name libsilkworm_capi.so -exec install {} /erigon-build \; ; fi;"
 
       - name: Create archives and checksums
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,19 +221,16 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_arm64.tar.gz
-        path: dist/
 
     - name: Download amd64 artifact
       uses: actions/download-artifact@v4
       with:
         name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_amd64.tar.gz
-        path: dist/
 
     - name: Download amd64v2 artifact
       uses: actions/download-artifact@v4
       with:
         name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_amd64v2.tar.gz
-        path: dist/
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf ## v3.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,8 @@ on:
 jobs:
 
   build-release:
-    ## runs-on: ubuntu-22.04
-    runs-on: ubuntu-latest-devops-xxlarge
+    runs-on: ubuntu-latest
+    #runs-on: ubuntu-latest-devops-xxlarge
     timeout-minutes: 75
     name: Create git tag, build and publish Release Artifacts
     outputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,22 +1,17 @@
 name: Release
-run-name: "Build release ${{ inputs.release_version}} from branch ${{ inputs.checkout_ref }} by @${{ github.actor}}"
+run-name: Build release ${{ inputs.release_version}} from branch ${{ inputs.checkout_ref }} by @${{ github.actor }}
 
 env:
   APPLICATION: "erigon"
-  BUILDER_IMAGE: "ghcr.io/goreleaser/goreleaser-cross:v1.22.7"
-  DOCKER_BASE_IMAGE: "alpine:3.20.3"
+  BUILDER_IMAGE: "golang:1.22-bookworm"
+  DOCKER_BASE_IMAGE: "debian:12.8-slim"
   APP_REPO: "erigontech/erigon"
   PACKAGE: "github.com/erigontech/erigon"
   DOCKERHUB_REPOSITORY: "erigontech/erigon"
   DOCKERFILE_PATH: "Dockerfile.release"
-  GITHUB_AUTOMATION_EMAIL: "github-automation@erigon.tech"
-  GITHUB_AUTOMATION_NAME: "Erigon Github Automation"
   LABEL_DESCRIPTION: "Erigon is an implementation of Ethereum (execution layer with embeddable consensus layer), on the efficiency frontier. Archive Node by default."
 
 on:
-  push:
-    branches-ignore:
-      - '**'
   workflow_dispatch:
     inputs:
       checkout_ref:
@@ -27,7 +22,7 @@ on:
       release_version:
         required: true
         type: string
-        description: 'Release version number (Pattern - v#.#.# , f.e. v2.60.8 or v3.0.0 or v3.0.0-alpha1 for pre-releases. Prefix it with "v".)'
+        description: 'Release version number (Pattern - v#.#.# , f.e. v2.60.1 or v3.0.0 or v3.0.0-alpha1 for pre-releases. Use prefix "v".)'
       perform_release:
         required: false
         type: boolean
@@ -46,7 +41,7 @@ jobs:
     ## runs-on: ubuntu-22.04
     runs-on: ubuntu-latest-devops-xxlarge
     timeout-minutes: 75
-    name: Create git tag, build and publish Artifacts
+    name: Create git tag, build and publish Release Artifacts
     outputs:
       commit-id: ${{ steps.getCommitId.outputs.id }}
       short-commit-id: ${{ steps.getCommitId.outputs.short_commit_id }}
@@ -54,16 +49,18 @@ jobs:
       parsed-version: ${{ steps.getCommitId.outputs.parsed_version}}
 
     steps:
-      - name: Checkout git repository ${{ env.APP_REPO }}
+      - name: Checkout git repository ${{ env.APP_REPO }} reference ${{ inputs.checkout_ref }}
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 ## 4.1.7 release
         with:
           repository: ${{ env.APP_REPO }}
           fetch-depth: 0
           ref: ${{ inputs.checkout_ref }}
+          path: 'erigon'
 
-      - name: Check if tag ${{ inputs.release_version }} already exists in case perform_release is set.
+      - name: Check if tag ${{ inputs.release_version }} already exists and create it in case perform_release is set.
         if: ${{ (inputs.perform_release) && (inputs.release_version != '') }}
         run: |
+          cd erigon
           if git ls-remote --exit-code --quiet --tags origin '${{ inputs.release_version }}'; then
             echo "ERROR: tag ${{ inputs.release_version }} exists and workflow is performing release. Exit."
             exit 1
@@ -74,12 +71,20 @@ jobs:
             echo; echo "Git TAG ${{ inputs.release_version }} created and pushed."
           fi
 
-      - name: Get commit id
+      - name: Run some commands, get commit id
         id: getCommitId
         run: |
+          mkdir $GITHUB_WORKSPACE/build-arm64 $GITHUB_WORKSPACE/build-amd64 $GITHUB_WORKSPACE/build-amd64v2
           echo "id=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
           echo "short_commit_id=$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
           echo "parsed_version=$(echo ${{ inputs.release_version }} | sed -e 's/^v//g')" >> $GITHUB_OUTPUT
+          echo "week_of_the_year=$(/bin/date -u "+%Y-%W")" >> $GITHUB_OUTPUT
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  ## v3.3.0
+        with:
+          username: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME }}
+          password: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf ## v3.2.0
@@ -87,33 +92,84 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db ## v3.6.1
 
-      - name: Build binaries with goreleaser
+      - name: Setup GO build and pkg cache for one week only
+        id: cache
+        uses: actions/cache@v4
+        with:
+          key: cache-year-week-${{ steps.getCommitId.outputs.week_of_the_year }}-go.mod-hash:${{ hashFiles('erigon/go.mod') }}
+          path: |
+            ~/go/pkg
+            ~/.cache
+
+      - name: Build for linux/arm64
+        run: >
+          docker run --platform linux/arm64
+          --rm
+          -v $(pwd)/erigon:/erigon:ro
+          -v ${GITHUB_WORKSPACE}/build-arm64:/erigon-build
+          -v ${HOME}/.cache:/root/.cache
+          -v ${HOME}/go/pkg/mod:/go/pkg/mod
+          -w /erigon --entrypoint /bin/bash
+          ${{ env.BUILDER_IMAGE }}
+          -c "git config --global --add safe.directory /erigon;
+          make GOARCH=arm64 GOBIN=/erigon-build BUILD_TAGS=nosqlite,noboltdb,nosilkworm 
+          erigon downloader devnet evm caplin diag integration rpcdaemon sentry txpool"
+
+      - name: Build for linux/amd64 (with nosilkworm tag)
+        run: >
+          docker run --platform linux/amd64
+          --rm
+          -v $(pwd)/erigon:/erigon:ro
+          -v ${GITHUB_WORKSPACE}/build-amd64:/erigon-build
+          -v ${HOME}/.cache:/root/.cache
+          -v ${HOME}/go/pkg/mod:/go/pkg/mod
+          -w /erigon --entrypoint /bin/bash
+          ${{ env.BUILDER_IMAGE }}
+          -c "git config --global --add safe.directory /erigon;
+          make GOARCH=amd64 GOAMD64=v1 GOBIN=/erigon-build BUILD_TAGS=nosqlite,noboltdb,nosilkworm 
+          erigon downloader devnet evm caplin diag integration rpcdaemon sentry txpool;
+          find / -name libsilkworm_capi.so -exec install {} /erigon-build \; "
+
+      - name: Build for linux/amd64/v2 (with nosilkworm tag)
+        run: >
+          docker run --platform linux/amd64/v2
+          --rm
+          -v $(pwd)/erigon:/erigon:ro
+          -v ${GITHUB_WORKSPACE}/build-amd64v2:/erigon-build
+          -v ${HOME}/.cache:/root/.cache
+          -v ${HOME}/go/pkg/mod:/go/pkg/mod
+          -w /erigon --entrypoint /bin/bash
+          ${{ env.BUILDER_IMAGE }}
+          -c "git config --global --add safe.directory /erigon;
+          make GOARCH=amd64 GOAMD64=v2 GOBIN=/erigon-build BUILD_TAGS=nosqlite,noboltdb,nosilkworm 
+          erigon downloader devnet evm caplin diag integration rpcdaemon sentry txpool;
+          find / -name libsilkworm_capi.so -exec install {} /erigon-build \; "
+
+      - name: Create archives and checksums
         env:
-          BUILD_VERSION: ${{ inputs.release_version }}
-          DOCKER_URL: ${{ env.DOCKERHUB_REPOSITORY }}
+          RELEASE_VERSION: ${{ inputs.release_version }}
         run: |
-          docker run --rm \
-            -w /${{ env.APPLICATION }}/ \
-            -e BUILD_VERSION=${{ env.BUILD_VERSION }} \
-            -e GIT_COMMIT=${{ steps.getCommitId.outputs.id }} \
-            -e GIT_BRANCH=${{ inputs.checkout_ref }} \
-            -e GIT_TAG=${{ inputs.release_version }} \
-            -e PACKAGE=${{ env.PACKAGE }} \
-            -e APPLICATION=${{ env.APPLICATION }} \
-            -v $(pwd):/${{ env.APPLICATION}} \
-            -v /var/run/docker.sock:/var/run/docker.sock \
-            ${{ env.BUILDER_IMAGE }} release --timeout 60m0s --clean --skip=validate,announce,publish
-          echo "DEBUG: ls -lao in the working directory"
-          ls -lao
-          echo "DEBUG: content of the dist/ directory"
-          find dist/ -ls
+          cd ${GITHUB_WORKSPACE}
+          mkdir $GITHUB_WORKSPACE/release
+          for dir in build-*; do
+            cd $dir
+            echo Current directory is $(pwd) . Checksum file and archive will be created for this directory
+            sha256sum * > checksums.txt
+            tar czvf $GITHUB_WORKSPACE/release/${APPLICATION}_${RELEASE_VERSION}_linux_$(echo $dir | sed 's,build-,,').tar.gz \
+              --transform "s,^./,${APPLICATION}_${RELEASE_VERSION}_linux_$(echo $dir | sed 's,build-,,')/," .
+            cd -
+          done
+          cd $GITHUB_WORKSPACE/release
+          sha256sum * > ${APPLICATION}_${RELEASE_VERSION}_checksums.txt
+          echo Content of release directory:
+          find . -type f -ls
 
       - name: Upload artifact -- linux/arm64
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  ## v4.3.6
         with:
           name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_arm64.tar.gz
-          path: ./dist/${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_arm64.tar.gz
-          retention-days: 1
+          path: ${{ github.workspace }}/release/${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_arm64.tar.gz
+          retention-days: 3
           compression-level: 0
           if-no-files-found: error
 
@@ -121,8 +177,8 @@ jobs:
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  ## v4.3.6
         with:
           name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_amd64.tar.gz
-          path: ./dist/${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_amd64.tar.gz
-          retention-days: 1
+          path: ${{ github.workspace }}/release/${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_amd64.tar.gz
+          retention-days: 3
           compression-level: 0
           if-no-files-found: error
 
@@ -130,29 +186,10 @@ jobs:
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  ## v4.3.6
         with:
           name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_amd64v2.tar.gz
-          path: ./dist/${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_amd64v2.tar.gz
-          retention-days: 1
+          path: ${{ github.workspace }}/release/${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_amd64v2.tar.gz
+          retention-days: 3
           compression-level: 0
           if-no-files-found: error
-
-      - name: Upload artifact -- darwin/arm64
-        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  ## v4.3.6
-        with:
-          name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_darwin_arm64.tar.gz
-          path: ./dist/${{ env.APPLICATION }}_${{ inputs.release_version }}_darwin_arm64.tar.gz
-          retention-days: 1
-          compression-level: 0
-          if-no-files-found: error
-
-      - name: Upload artifact -- darwin/amd64
-        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  ## v4.3.6
-        with:
-          name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_darwin_amd64.tar.gz
-          path: ./dist/${{ env.APPLICATION }}_${{ inputs.release_version }}_darwin_amd64.tar.gz
-          retention-days: 1
-          compression-level: 0
-          if-no-files-found: error
-
 
 
   build-debian-pkg:
@@ -162,7 +199,6 @@ jobs:
     with:
       application: ${{ needs.build-release.outputs.application }}
       version: ${{ needs.build-release.outputs.parsed-version }}
-
 
 
   publish-docker-image:
@@ -269,18 +305,6 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_linux_amd64v2.tar.gz
-        path: dist/
-
-    - name: Download darwin/amd64 artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_darwin_amd64.tar.gz
-        path: dist/
-
-    - name: Download darwin/arm64 artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_darwin_arm64.tar.gz
         path: dist/
 
     - name: Download arm64 debian package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,7 @@ on:
         required: false
         type: boolean
         default: false
-        description: 'perform_release: when set then all artifacts will be published and the DRAFT of the release 
-          notes will be created.'
+        description: 'perform_release: when set then all artifacts will be published and the DRAFT of the release notes will be created.'
       publish_latest_tag:
         required: false
         type: boolean
@@ -38,8 +37,8 @@ on:
 jobs:
 
   build-release:
-    runs-on: ubuntu-latest
-    #runs-on: ubuntu-latest-devops-xxlarge
+    #runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-devops-xxlarge
     timeout-minutes: 75
     name: Create git tag, build and publish Release Artifacts
     outputs:

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -45,7 +45,7 @@ SHELL ["/bin/bash", "-c"]
 
 RUN --mount=type=bind,from=temporary,source=/tmp/${APPLICATION},target=/tmp/${APPLICATION} \
     echo Installing on ${TARGETOS} with variant ${TARGETVARIANT} && \
-    addgroup --gid {GID_ERIGON} ${GROUP} && \
+    addgroup --gid ${GID_ERIGON} ${GROUP} && \
     adduser --system --uid ${UID_ERIGON} --ingroup ${GROUP} --home /home/${USER} --shell /bin/bash ${USER} && \
     apt update -y && \
     apt install -y --no-install-recommends ca-certificates && \

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,6 +1,6 @@
-ARG RELEASE_DOCKER_BASE_IMAGE="alpine:3.20.1" \
+ARG RELEASE_DOCKER_BASE_IMAGE="debian:12.8-slim" \
     CI_CD_MAIN_BUILDER_IMAGE="golang:1.22-bookworm" \
-    CI_CD_MAIN_TARGET_BASE_IMAGE="alpine:3.20.1" \
+    CI_CD_MAIN_TARGET_BASE_IMAGE="alpine:3" \
     UID_ERIGON=1000 \
     GID_ERIGON=1000 \
     EXPOSED_PORTS="8545 \
@@ -24,7 +24,8 @@ ARG TARGETARCH \
     VERSION=${VERSION} \
     APPLICATION
 
-COPY ./dist/${APPLICATION}_${VERSION}_linux_${TARGETARCH}${TARGETVARIANT}.tar.gz /tmp/${APPLICATION}.tar.gz
+COPY ${APPLICATION}_${VERSION}_linux_${TARGETARCH}${TARGETVARIANT}.tar.gz /tmp/${APPLICATION}.tar.gz
+
 RUN tar xzvf /tmp/${APPLICATION}.tar.gz -C /tmp && \
     mv /tmp/${APPLICATION}_${VERSION}_linux_${TARGETARCH}${TARGETVARIANT} /tmp/${APPLICATION}
 
@@ -34,15 +35,27 @@ ARG USER=erigon \
     GROUP=erigon \
     UID_ERIGON \
     GID_ERIGON \
+    TARGETARCH \
     APPLICATION \
     EXPOSED_PORTS
 
 STOPSIGNAL 2
 
+SHELL ["/bin/bash", "-c"]
+
 RUN --mount=type=bind,from=temporary,source=/tmp/${APPLICATION},target=/tmp/${APPLICATION} \
-    apk add --no-cache ca-certificates tzdata && \
-    addgroup -g ${GID_ERIGON} ${GROUP} && \
-    adduser -D -u ${UID_ERIGON} -h /home/${USER} -G ${GROUP} ${USER} && \
+    echo Installing on ${TARGETOS} with variant ${TARGETVARIANT} && \
+    addgroup --gid {GID_ERIGON} ${GROUP} && \
+    adduser --system --uid ${UID_ERIGON} --ingroup ${GROUP} --home /home/${USER} --shell /bin/bash ${USER} && \
+    apt update -y && \
+    apt install -y --no-install-recommends ca-certificates && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    if [ "x${TARGETARCH}" == "xamd64" ]; then \
+        echo "Installing libsilkworm_capi.so library to /lib/x86_64-linux-gnu/ in case amd64 architecture:"; \
+        find /tmp/${APPLICATION} -name libsilkworm_capi.so -type f | xargs -I % install -m a=r -v % /lib/x86_64-linux-gnu/; \
+        echo "Done." ; \
+    fi && \
     install -d -o ${USER} -g ${GROUP} /home/${USER}/.local /home/${USER}/.local/share /home/${USER}/.local/share/erigon && \
     install -o root -g root /tmp/${APPLICATION}/erigon /usr/local/bin/ && \
     install -o root -g root /tmp/${APPLICATION}/integration /usr/local/bin/ && \


### PR DESCRIPTION
Fix for the https://github.com/erigontech/erigon/issues/13092 
Main changes:
- get rid of goreleaser, build binaries on Debian based golang docker containers;
- **get rid of Darwin artifacts: only linux artifacts will be published;**
- switch from Alpine base image to Debian one;
- sync with release workflow in release/2.6x
- preparation for Silkworm (which is not yet ready for 3.x) support;
