### PR TITLE
polygon: astrid service to run inside bg components errgroup for shutdown wait

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1576,9 +1576,10 @@ func (s *Ethereum) Start() error {
 			stopErr := s.stopNode()
 			if stopErr != nil {
 				s.logger.Error("could not stop node", "err", stopErr)
+				err = fmt.Errorf("%w: %w", stopErr, err)
 			}
 
-			return fmt.Errorf("%w: %w", stopErr, err)
+			return err
 		})
 	} else {
 		diagnostics.Send(diagnostics.SyncStageList{StagesList: diagnostics.InitStagesFromList(s.stagedSync.StagesIdsList())})

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1549,7 +1549,7 @@ func (s *Ethereum) Start() error {
 	} else if s.config.PolygonSync {
 		diagnostics.Send(diagnostics.SyncStageList{StagesList: diagnostics.InitStagesFromList(s.stagedSync.StagesIdsList())})
 		s.waitForStageLoopStop = nil // Shutdown is handled by context
-		go func() {
+		s.bgComponentsEg.Go(func() error {
 			// when we're running in stand alone mode we need to run the downloader before we start the
 			// polygon services becuase they will wait for it to complete before opening thier stores
 			// which make use of snapshots and expect them to be initialize
@@ -1569,15 +1569,17 @@ func (s *Ethereum) Start() error {
 			ctx := s.sentryCtx
 			err := s.polygonSyncService.Run(ctx)
 			if err == nil || errors.Is(err, context.Canceled) {
-				return
+				return err
 			}
 
 			s.logger.Error("polygon sync crashed - stopping node", "err", err)
-			err = s.stopNode()
-			if err != nil {
-				s.logger.Error("could not stop node", "err", err)
+			stopErr := s.stopNode()
+			if stopErr != nil {
+				s.logger.Error("could not stop node", "err", stopErr)
 			}
-		}()
+
+			return fmt.Errorf("%w: %w", stopErr, err)
+		})
 	} else {
 		diagnostics.Send(diagnostics.SyncStageList{StagesList: diagnostics.InitStagesFromList(s.stagedSync.StagesIdsList())})
 		go stages2.StageLoop(s.sentryCtx, s.chainDB, s.stagedSync, s.sentriesClient.Hd, s.waitForStageLoopStop, s.config.Sync.LoopThrottle, s.logger, s.blockReader, hook)
@@ -1663,7 +1665,11 @@ func (s *Ethereum) Stop() error {
 		}
 	}
 
-	return s.bgComponentsEg.Wait()
+	if err := s.bgComponentsEg.Wait(); err != nil && !errors.Is(err, context.Canceled) {
+		s.logger.Error("bgComponentsEg.Wait error", "err", err)
+	}
+
+	return nil
 }
 
 func (s *Ethereum) ChainDB() kv.RwDB {


### PR DESCRIPTION
While working on Shutter, I decided to follow the same `Run(ctx)` pattern that we use in Astrid to initiate long running background goroutines which are ctx aware and do their own shutdown/cleanup logic as part of defers inside `Run(ctx)` so that when the parent ctx is cancelled each component with a Run manages its own shutdown logic.

However, I noticed that when the `Ethereum.Close` function is called we do not wait for these `Run` functions of  bg goroutines to finish before exiting the `Close` function. So I added a `bgComponentsEg` errgroup to the `Ethereum` object which is used in `Start` and `Close` to wait properly in the following Shutter PR https://github.com/erigontech/erigon/pull/13081/files#diff-9cc7046826ce92d9cc5432cf41ed4fc14bb6907da44f771e3932302c40e8dbc2R1640-R1643. 

This PR is to make a small change to `Ethereum.Start` to run the Astrid service `Run` bg goroutine as part of the same `bgComponentsEg` errgroup as well so that `Ethereum.Close` waits for it to finish its shutdown logic. This will also serve as a template for future bg components that use the `Run(ctx)` pattern.