### PR TITLE
Run release workflow on default runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,8 @@ on:
 jobs:
 
   build-release:
-    #runs-on: ubuntu-latest
-    runs-on: ubuntu-latest-devops-xxlarge
+    runs-on: ubuntu-latest
+    #runs-on: ubuntu-latest-devops-xxlarge
     timeout-minutes: 75
     name: Create git tag, build and publish Release Artifacts
     outputs:


### PR DESCRIPTION
job is frozen on xxlarge runner for some reasons.