### PR TITLE
Fix EmptyRequestHash value to match empty set

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -40,7 +40,8 @@ import (
 
 var (
 	EmptyRootHash     = libcommon.HexToHash("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
-	EmptyRequestsHash = libcommon.HexToHash("6036c41849da9c076ed79654d434017387a88fb833c2856b32e18218b3341c5f")
+	// EmptyRequestsHash is the known hash of an empty request set, sha256("").
+	EmptyRequestsHash = libcommon.HexToHash("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
 	EmptyUncleHash    = rlpHash([]*Header(nil))
 
 	ExtraVanityLength = 32 // Fixed number of extra-data prefix bytes reserved for signer vanity


### PR DESCRIPTION
**Description:**

This PR corrects the computation of the `requests_hash` field for block headers. According to [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685), the `requests_hash` should match the value of an empty `sha256()` digest if there are no valid requests. Currently, the computed hash does not align with the expected result, and also differs from the implementation in [go-ethereum](https://github.com/ethereum/go-ethereum/blob/341647f1865dab437a690dc1424ba71495de2dd8/core/types/hashes.go#L45).

**Changes:**

```python
def compute_requests_hash(block_requests: Sequence[bytes]):
    m = sha256()
    for r in block_requests:
        if len(r) > 1:
            m.update(sha256(r).digest())
    return m.digest()

block.header.requests_hash = compute_requests_hash(requests)
```
