### PR TITLE
Fix article usage in code comments and documentation

### DIFF
--- a/accounts/abi/event.go
+++ b/accounts/abi/event.go
@@ -32,7 +32,7 @@ import (
 // don't get the signature canonical representation as the first LOG topic.
 type Event struct {
 	// Name is the event name used for internal representation. It's derived from
-	// the raw name and a suffix will be added in the case of a event overload.
+	// the raw name and a suffix will be added in the case of an event overload.
 	//
 	// e.g.
 	// These are two events that have the same name:

--- a/accounts/abi/reflect.go
+++ b/accounts/abi/reflect.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 )
 
-// ConvertType converts an interface of a runtime type into a interface of the
+// ConvertType converts an interface of a runtime type into an interface of the
 // given type
 // e.g. turn
 // var fields []reflect.StructField

--- a/accounts/abi/type_test.go
+++ b/accounts/abi/type_test.go
@@ -28,7 +28,7 @@ import (
 	libcommon "github.com/erigontech/erigon-lib/common"
 )
 
-// typeWithoutStringer is a alias for the Type type which simply doesn't implement
+// typeWithoutStringer is an alias for the Type type which simply doesn't implement
 // the stringer interface to allow printing type details in the tests below.
 type typeWithoutStringer Type
 

--- a/cl/cltypes/block_production.go
+++ b/cl/cltypes/block_production.go
@@ -25,7 +25,7 @@ import (
 )
 
 // BlindOrExecutionBeaconBlock is a union type that can be either a BlindedBeaconBlock or a BeaconBlock, depending on the context.
-// It's a intermediate type used in the block production process.
+// It's an intermediate type used in the block production process.
 type BlindOrExecutionBeaconBlock struct {
 	Slot          uint64         `json:"-"`
 	ProposerIndex uint64         `json:"-"`

--- a/cmd/erigoncustom/main.go
+++ b/cmd/erigoncustom/main.go
@@ -61,7 +61,7 @@ func runErigon(ctx *cli.Context) error {
 	//err := eri.Serve()
 
 	//if err != nil {
-	//	log.Error("error while serving a Erigon node", "err", err)
+	//	log.Error("error while serving an Erigon node", "err", err)
 	//  return err
 	//}
 	return nil

--- a/consensus/aura/config.go
+++ b/consensus/aura/config.go
@@ -30,7 +30,7 @@ import (
 	"github.com/erigontech/erigon/consensus"
 )
 
-// Draws an validator nonce modulo number of validators.
+// Draws a validator nonce modulo number of validators.
 func GetFromValidatorSet(set ValidatorSet, parent libcommon.Hash, nonce uint, call consensus.Call) (libcommon.Address, error) {
 	//d, err := set.defaultCaller(parent)
 	//if err != nil {

--- a/consensus/merge/merge.go
+++ b/consensus/merge/merge.go
@@ -52,7 +52,7 @@ var (
 	// errInvalidNonce is returned if the nonce is non-zero.
 	errInvalidNonce = errors.New("invalid nonce")
 
-	// errInvalidUncleHash is returned if a block contains an non-empty uncle list.
+	// errInvalidUncleHash is returned if a block contains a non-empty uncle list.
 	errInvalidUncleHash = errors.New("non empty uncle hash")
 
 	errOlderBlockTime = errors.New("timestamp older than parent")

--- a/turbo/node/node.go
+++ b/turbo/node/node.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Erigon. If not, see <http://www.gnu.org/licenses/>.
 
-// Package node contains classes for running a Erigon node.
+// Package node contains classes for running an Erigon node.
 package node
 
 import (


### PR DESCRIPTION
This pull request corrects the use of articles in multiple code files, specifically replacing the incorrect "a" with "an" and vice versa in places where the next word starts with a vowel sound or a consonant sound. 

These changes improve the clarity and grammatical accuracy of comments and documentation.
