### PR TITLE
debug_traceBlockByNumber with refund=false

### DIFF
--- a/turbo/jsonrpc/tracing.go
+++ b/turbo/jsonrpc/tracing.go
@@ -224,7 +224,12 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 	}
 
 	if dbg.AssertEnabled {
-		if block.GasUsed() != usedGas {
+		var refunds = true
+		if config.NoRefunds != nil && *config.NoRefunds {
+			refunds = false
+		}
+
+		if refunds == true && block.GasUsed() != usedGas {
 			panic(fmt.Errorf("assert: block.GasUsed() %d != usedGas %d. blockNum=%d", block.GasUsed(), usedGas, blockNumber))
 		}
 	}


### PR DESCRIPTION
The check on gasUsed should be done only if refund is true (default case)