### PR TITLE
 typo fix Update wmake.ps1

### DIFF
--- a/wmake.ps1
+++ b/wmake.ps1
@@ -160,7 +160,7 @@ function Get-Uninstall-Item {
     param ([string]$pattern = $(throw "A search pattern must be provided"))    
     
     # Trying to get the enumerable of all installed programs using Get-ItemProperty may cause 
-    # exceptions due to possible garbage values insterted into the registry by installers.
+    # exceptions due to possible garbage values inserted into the registry by installers.
     # Specifically an invalid cast exception throws when registry keys contain invalid DWORD data. 
     # See https://github.com/PowerShell/PowerShell/issues/9552
     # Due to this all items must be parsed one by one


### PR DESCRIPTION
# Typo Fix in `wmake.ps1`

## Description
This pull request addresses a typo in the `wmake.ps1` file:
- Corrected "insterted" to "inserted" in a comment.

## Changes
- Improved the accuracy of comments by fixing a minor spelling error.

## Testing
This change only updates a comment in the script and does not affect the script's functionality. No additional testing is required.

## Notes for Reviewers
Please review the corrected comment to ensure compliance with the project's documentation standards. Let me know if further updates are necessary. Thank you!
