### PR TITLE
qa-tests: temporary solution for runner n.1 out of space 

### DIFF
--- a/.github/workflows/qa-clean-exit-block-downloading.yml
+++ b/.github/workflows/qa-clean-exit-block-downloading.yml
@@ -38,9 +38,9 @@ jobs:
       run: |
         python3 $ERIGON_QA_PATH/test_system/db-producer/pause_production.py || true
 
-    - name: Restore Erigon Testbed Data Directory
-      run: |
-        rsync -a --delete $ERIGON_REFERENCE_DATA_DIR/ $ERIGON_TESTBED_DATA_DIR/
+    #- name: Restore Erigon Testbed Data Directory
+    #  run: |
+    #    rsync -a --delete $ERIGON_REFERENCE_DATA_DIR/ $ERIGON_TESTBED_DATA_DIR/
 
     - name: Run Erigon, send ctrl-c and check for clean exiting
       id: test_step
@@ -48,7 +48,7 @@ jobs:
         set +e # Disable exit on error
         
         # Run Erigon, send ctrl-c and check logs
-        python3 $ERIGON_QA_PATH/test_system/qa-tests/clean-exit/run_and_check_clean_exit.py ${{ github.workspace }}/build/bin $ERIGON_TESTBED_DATA_DIR $WORKING_TIME_SECONDS Erigon2
+        python3 $ERIGON_QA_PATH/test_system/qa-tests/clean-exit/run_and_check_clean_exit.py ${{ github.workspace }}/build/bin $ERIGON_REFERENCE_DATA_DIR $WORKING_TIME_SECONDS Erigon2
   
         # Capture monitoring script exit status
         test_exit_status=$?
@@ -72,10 +72,10 @@ jobs:
           echo "TEST_RESULT=failure" >> "$GITHUB_OUTPUT"
         fi
 
-    - name: Delete Erigon Testbed Data Directory
-      if: always()
-      run: |
-        rm -rf $ERIGON_TESTBED_DATA_DIR
+    #- name: Delete Erigon Testbed Data Directory
+    #  if: always()
+    #  run: |
+    #    rm -rf $ERIGON_TESTBED_DATA_DIR
 
     - name: Resume the Erigon instance dedicated to db maintenance
       run: |

--- a/.github/workflows/qa-tip-tracking.yml
+++ b/.github/workflows/qa-tip-tracking.yml
@@ -40,9 +40,9 @@ jobs:
       run: |
         python3 $ERIGON_QA_PATH/test_system/db-producer/pause_production.py || true
 
-    - name: Restore Erigon Testbed Data Directory
-      run: |
-        rsync -a --delete $ERIGON_REFERENCE_DATA_DIR/ $ERIGON_TESTBED_DATA_DIR/
+    #- name: Restore Erigon Testbed Data Directory
+    #  run: |
+    #    rsync -a --delete $ERIGON_REFERENCE_DATA_DIR/ $ERIGON_TESTBED_DATA_DIR/
 
     - name: Run Erigon, wait sync and check ability to maintain sync
       id: test_step
@@ -52,7 +52,7 @@ jobs:
         # 1. Launch the testbed Erigon instance
         # 2. Allow time for the Erigon to achieve synchronization
         # 3. Begin timing the duration that Erigon maintains synchronization
-        python3 $ERIGON_QA_PATH/test_system/qa-tests/tip-tracking/run_and_check_tip_tracking.py ${{ github.workspace }}/build/bin $ERIGON_TESTBED_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon2 $CHAIN
+        python3 $ERIGON_QA_PATH/test_system/qa-tests/tip-tracking/run_and_check_tip_tracking.py ${{ github.workspace }}/build/bin $ERIGON_REFERENCE_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon2 $CHAIN
   
         # Capture monitoring script exit status
         test_exit_status=$?
@@ -76,10 +76,10 @@ jobs:
           echo "TEST_RESULT=failure" >> "$GITHUB_OUTPUT"
         fi
 
-    - name: Delete Erigon Testbed Data Directory
-      if: always()
-      run: |
-        rm -rf $ERIGON_TESTBED_DATA_DIR
+    #- name: Delete Erigon Testbed Data Directory
+    #  if: always()
+    #  run: |
+    #    rm -rf $ERIGON_TESTBED_DATA_DIR
 
     - name: Resume the Erigon instance dedicated to db maintenance
       run: |


### PR DESCRIPTION
tip-tracking and clean-exit (block downloading) require the prebuilt db to be copied before execution, so as not to corrupt it. But the prebuilt db has grown in size and there is no room to keep 2 copies of it on the runner.

So, as a temporary solution, we will run tests on release/2.6x on the pre-built db itself, and not on its copy.