### PR TITLE
Fix typos in comments and constant names

### DIFF
--- a/eth/stagedsync/stage_postexec.go
+++ b/eth/stagedsync/stage_postexec.go
@@ -23,7 +23,7 @@ import (
 	"github.com/erigontech/erigon-lib/kv"
 )
 
-// PostExec stage is run after execution stage to peform extra verifications that are only possible when state is available.
+// PostExec stage is run after execution stage to perform extra verifications that are only possible when state is available.
 // It is used for consensus engines which keep validators inside smart contracts (Bor, AuRa)
 
 type PostExecCfg struct {

--- a/eth/stagedsync/testutil.go
+++ b/eth/stagedsync/testutil.go
@@ -31,7 +31,7 @@ import (
 const (
 	staticCodeStaticIncarnations         = iota // no incarnation changes, no code changes
 	changeCodeWithIncarnations                  // code changes with incarnation
-	changeCodeIndepenentlyOfIncarnations        // code changes with and without incarnation
+	changeCodeIndependentlyOfIncarnations        // code changes with and without incarnation
 )
 
 type testGenHook func(n, from, numberOfBlocks uint64)
@@ -72,7 +72,7 @@ func generateBlocks2(t *testing.T, from uint64, numberOfBlocks uint64, blockWrit
 					}
 				}
 			}
-			if blockNumber == 1 || updateIncarnation || difficulty == changeCodeIndepenentlyOfIncarnations {
+			if blockNumber == 1 || updateIncarnation || difficulty == changeCodeIndependentlyOfIncarnations {
 				if newAcc.Incarnation > 0 {
 					code := []byte(fmt.Sprintf("acc-code-%v", blockNumber))
 					codeHash, _ := libcommon.HashData(code)


### PR DESCRIPTION


Fixed misspellings in comments and constant names to improve code readability:

1. eth/stagedsync/stage_postexec.go:
- peform -> perform
Reason: Correct spelling in documentation comment

2. eth/stagedsync/testutil.go:
- changeCodeIndepenentlyOfIncarnations -> changeCodeIndependentlyOfIncarnations  
Reason: Fix typo in constant name

These changes improve code readability and documentation quality without affecting functionality. No tests required as changes are cosmetic only.