### PR TITLE
Correct Caplin description and documentation link update

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ Engine API.
 
 #### Caplin's Usage
 
-Caplin is be enabled by default. to disable it and enable the Engine API, use the `--externalcl` flag. from that point
+Caplin is enabled by default. to disable it and enable the Engine API, use the `--externalcl` flag. from that point
 on, an external Consensus Layer will not be need
 anymore.
 
@@ -368,7 +368,7 @@ Quote your path if it has spaces.
 
 ### Dev Chain
 
-<code> 🔬 Detailed explanation is [DEV_CHAIN](/DEV_CHAIN.md).</code>
+<code> 🔬 Detailed explanation is [DEV_CHAIN](/docs/DEV_CHAIN.md).</code>
 
 Key features
 ============


### PR DESCRIPTION
### 1. Change in Caplin description:

- Before:
 
 Caplin is be enabled by default. to disable it and enable the Engine API, use the `--externalcl` flag. from that point

- After:

 Caplin is enabled by default. to disable it and enable the Engine API, use the `--externalcl` flag. from that point

> Explanation:
The original sentence "Caplin is be enabled by default" contains a grammatical error. The phrase "is be" is incorrect because "is" and "be" cannot appear together in this context. The correct form is "is enabled".

### 2. Change in documentation path:
- Before:
<code> (/DEV_CHAIN.md).</code>

- After:
+<code> (/docs/DEV_CHAIN.md).</code>

> Explanation:
Corrected the path to the documentation file to accurately reflect its location.

Before:
![image](https://github.com/user-attachments/assets/d9c00500-d2d8-4a1f-b45d-76c89dd8dbf8)
After:
![image](https://github.com/user-attachments/assets/212be4b5-d633-4444-a724-91540cbd7abb)

