### PR TITLE
erigon-lib: move event notifier and observers to erigon-lib

### DIFF
--- a/erigon-lib/event/observers.go
+++ b/erigon-lib/event/observers.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Erigon. If not, see <http://www.gnu.org/licenses/>.
 
-package polygoncommon
+package event
 
 import (
 	"sync"

--- a/polygon/heimdall/scraper.go
+++ b/polygon/heimdall/scraper.go
@@ -22,12 +22,11 @@ import (
 	"fmt"
 	"time"
 
+	libcommon "github.com/erigontech/erigon-lib/common"
 	commonerrors "github.com/erigontech/erigon-lib/common/errors"
 	"github.com/erigontech/erigon-lib/common/generics"
+	"github.com/erigontech/erigon-lib/event"
 	"github.com/erigontech/erigon-lib/log/v3"
-
-	libcommon "github.com/erigontech/erigon-lib/common"
-	"github.com/erigontech/erigon/polygon/polygoncommon"
 )
 
 type Scraper[TEntity Entity] struct {
@@ -35,8 +34,8 @@ type Scraper[TEntity Entity] struct {
 	store           EntityStore[TEntity]
 	fetcher         entityFetcher[TEntity]
 	pollDelay       time.Duration
-	observers       *polygoncommon.Observers[[]TEntity]
-	syncEvent       *polygoncommon.EventNotifier
+	observers       *event.Observers[[]TEntity]
+	syncEvent       *event.Notifier
 	transientErrors []error
 	logger          log.Logger
 }
@@ -54,8 +53,8 @@ func NewScraper[TEntity Entity](
 		store:           store,
 		fetcher:         fetcher,
 		pollDelay:       pollDelay,
-		observers:       polygoncommon.NewObservers[[]TEntity](),
-		syncEvent:       polygoncommon.NewEventNotifier(),
+		observers:       event.NewObservers[[]TEntity](),
+		syncEvent:       event.NewNotifier(),
 		transientErrors: transientErrors,
 		logger:          logger,
 	}
@@ -146,7 +145,7 @@ func (s *Scraper[TEntity]) Run(ctx context.Context) error {
 	return ctx.Err()
 }
 
-func (s *Scraper[TEntity]) RegisterObserver(observer func([]TEntity)) polygoncommon.UnregisterFunc {
+func (s *Scraper[TEntity]) RegisterObserver(observer func([]TEntity)) event.UnregisterFunc {
 	return s.observers.Register(observer)
 }
 

--- a/polygon/heimdall/service.go
+++ b/polygon/heimdall/service.go
@@ -26,10 +26,10 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	libcommon "github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/event"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/polygon/bor/borcfg"
 	"github.com/erigontech/erigon/polygon/bor/valset"
-	"github.com/erigontech/erigon/polygon/polygoncommon"
 )
 
 type ServiceConfig struct {
@@ -222,7 +222,7 @@ func (s *Service) Producers(ctx context.Context, blockNum uint64) (*valset.Valid
 	return s.reader.Producers(ctx, blockNum)
 }
 
-func (s *Service) RegisterMilestoneObserver(callback func(*Milestone), opts ...ObserverOption) polygoncommon.UnregisterFunc {
+func (s *Service) RegisterMilestoneObserver(callback func(*Milestone), opts ...ObserverOption) event.UnregisterFunc {
 	options := NewObserverOptions(opts...)
 	return s.milestoneScraper.RegisterObserver(func(entities []*Milestone) {
 		for _, entity := range libcommon.SliceTakeLast(entities, options.eventsLimit) {
@@ -231,7 +231,7 @@ func (s *Service) RegisterMilestoneObserver(callback func(*Milestone), opts ...O
 	})
 }
 
-func (s *Service) RegisterCheckpointObserver(callback func(*Checkpoint), opts ...ObserverOption) polygoncommon.UnregisterFunc {
+func (s *Service) RegisterCheckpointObserver(callback func(*Checkpoint), opts ...ObserverOption) event.UnregisterFunc {
 	options := NewObserverOptions(opts...)
 	return s.checkpointScraper.RegisterObserver(func(entities []*Checkpoint) {
 		for _, entity := range libcommon.SliceTakeLast(entities, options.eventsLimit) {
@@ -240,7 +240,7 @@ func (s *Service) RegisterCheckpointObserver(callback func(*Checkpoint), opts ..
 	})
 }
 
-func (s *Service) RegisterSpanObserver(callback func(*Span), opts ...ObserverOption) polygoncommon.UnregisterFunc {
+func (s *Service) RegisterSpanObserver(callback func(*Span), opts ...ObserverOption) event.UnregisterFunc {
 	options := NewObserverOptions(opts...)
 	return s.spanScraper.RegisterObserver(func(entities []*Span) {
 		for _, entity := range libcommon.SliceTakeLast(entities, options.eventsLimit) {

--- a/polygon/p2p/message_listener.go
+++ b/polygon/p2p/message_listener.go
@@ -23,13 +23,12 @@ import (
 
 	"google.golang.org/grpc"
 
-	"github.com/erigontech/erigon-lib/log/v3"
-
+	"github.com/erigontech/erigon-lib/event"
 	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon-lib/p2p/sentry"
 	"github.com/erigontech/erigon-lib/rlp"
 	"github.com/erigontech/erigon/eth/protocols/eth"
-	"github.com/erigontech/erigon/polygon/polygoncommon"
 )
 
 type DecodedInboundMessage[TPacket any] struct {
@@ -38,7 +37,7 @@ type DecodedInboundMessage[TPacket any] struct {
 	PeerId  *PeerId
 }
 
-type UnregisterFunc = polygoncommon.UnregisterFunc
+type UnregisterFunc = event.UnregisterFunc
 
 func NewMessageListener(
 	logger log.Logger,
@@ -51,11 +50,11 @@ func NewMessageListener(
 		sentryClient:            sentryClient,
 		statusDataFactory:       statusDataFactory,
 		peerPenalizer:           peerPenalizer,
-		newBlockObservers:       polygoncommon.NewObservers[*DecodedInboundMessage[*eth.NewBlockPacket]](),
-		newBlockHashesObservers: polygoncommon.NewObservers[*DecodedInboundMessage[*eth.NewBlockHashesPacket]](),
-		blockHeadersObservers:   polygoncommon.NewObservers[*DecodedInboundMessage[*eth.BlockHeadersPacket66]](),
-		blockBodiesObservers:    polygoncommon.NewObservers[*DecodedInboundMessage[*eth.BlockBodiesPacket66]](),
-		peerEventObservers:      polygoncommon.NewObservers[*sentryproto.PeerEvent](),
+		newBlockObservers:       event.NewObservers[*DecodedInboundMessage[*eth.NewBlockPacket]](),
+		newBlockHashesObservers: event.NewObservers[*DecodedInboundMessage[*eth.NewBlockHashesPacket]](),
+		blockHeadersObservers:   event.NewObservers[*DecodedInboundMessage[*eth.BlockHeadersPacket66]](),
+		blockBodiesObservers:    event.NewObservers[*DecodedInboundMessage[*eth.BlockBodiesPacket66]](),
+		peerEventObservers:      event.NewObservers[*sentryproto.PeerEvent](),
 	}
 }
 
@@ -64,11 +63,11 @@ type MessageListener struct {
 	sentryClient            sentryproto.SentryClient
 	statusDataFactory       sentry.StatusDataFactory
 	peerPenalizer           *PeerPenalizer
-	newBlockObservers       *polygoncommon.Observers[*DecodedInboundMessage[*eth.NewBlockPacket]]
-	newBlockHashesObservers *polygoncommon.Observers[*DecodedInboundMessage[*eth.NewBlockHashesPacket]]
-	blockHeadersObservers   *polygoncommon.Observers[*DecodedInboundMessage[*eth.BlockHeadersPacket66]]
-	blockBodiesObservers    *polygoncommon.Observers[*DecodedInboundMessage[*eth.BlockBodiesPacket66]]
-	peerEventObservers      *polygoncommon.Observers[*sentryproto.PeerEvent]
+	newBlockObservers       *event.Observers[*DecodedInboundMessage[*eth.NewBlockPacket]]
+	newBlockHashesObservers *event.Observers[*DecodedInboundMessage[*eth.NewBlockHashesPacket]]
+	blockHeadersObservers   *event.Observers[*DecodedInboundMessage[*eth.BlockHeadersPacket66]]
+	blockBodiesObservers    *event.Observers[*DecodedInboundMessage[*eth.BlockBodiesPacket66]]
+	peerEventObservers      *event.Observers[*sentryproto.PeerEvent]
 	stopWg                  sync.WaitGroup
 }
 
@@ -98,23 +97,23 @@ func (ml *MessageListener) Run(ctx context.Context) error {
 	return ctx.Err()
 }
 
-func (ml *MessageListener) RegisterNewBlockObserver(observer polygoncommon.Observer[*DecodedInboundMessage[*eth.NewBlockPacket]]) UnregisterFunc {
+func (ml *MessageListener) RegisterNewBlockObserver(observer event.Observer[*DecodedInboundMessage[*eth.NewBlockPacket]]) UnregisterFunc {
 	return ml.newBlockObservers.Register(observer)
 }
 
-func (ml *MessageListener) RegisterNewBlockHashesObserver(observer polygoncommon.Observer[*DecodedInboundMessage[*eth.NewBlockHashesPacket]]) UnregisterFunc {
+func (ml *MessageListener) RegisterNewBlockHashesObserver(observer event.Observer[*DecodedInboundMessage[*eth.NewBlockHashesPacket]]) UnregisterFunc {
 	return ml.newBlockHashesObservers.Register(observer)
 }
 
-func (ml *MessageListener) RegisterBlockHeadersObserver(observer polygoncommon.Observer[*DecodedInboundMessage[*eth.BlockHeadersPacket66]]) UnregisterFunc {
+func (ml *MessageListener) RegisterBlockHeadersObserver(observer event.Observer[*DecodedInboundMessage[*eth.BlockHeadersPacket66]]) UnregisterFunc {
 	return ml.blockHeadersObservers.Register(observer)
 }
 
-func (ml *MessageListener) RegisterBlockBodiesObserver(observer polygoncommon.Observer[*DecodedInboundMessage[*eth.BlockBodiesPacket66]]) UnregisterFunc {
+func (ml *MessageListener) RegisterBlockBodiesObserver(observer event.Observer[*DecodedInboundMessage[*eth.BlockBodiesPacket66]]) UnregisterFunc {
 	return ml.blockBodiesObservers.Register(observer)
 }
 
-func (ml *MessageListener) RegisterPeerEventObserver(observer polygoncommon.Observer[*sentryproto.PeerEvent]) UnregisterFunc {
+func (ml *MessageListener) RegisterPeerEventObserver(observer event.Observer[*sentryproto.PeerEvent]) UnregisterFunc {
 	return ml.peerEventObservers.Register(observer)
 }
 
@@ -193,7 +192,7 @@ func notifyInboundMessageObservers[TPacket any](
 	ctx context.Context,
 	logger log.Logger,
 	peerPenalizer *PeerPenalizer,
-	observers *polygoncommon.Observers[*DecodedInboundMessage[TPacket]],
+	observers *event.Observers[*DecodedInboundMessage[TPacket]],
 	message *sentryproto.InboundMessage,
 ) error {
 	peerId := PeerIdFromH512(message.PeerId)

--- a/polygon/p2p/peer_event_registrar.go
+++ b/polygon/p2p/peer_event_registrar.go
@@ -17,14 +17,14 @@
 package p2p
 
 import (
+	"github.com/erigontech/erigon-lib/event"
 	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon/eth/protocols/eth"
-	"github.com/erigontech/erigon/polygon/polygoncommon"
 )
 
 //go:generate mockgen -typed=true -source=./peer_event_registrar.go -destination=./peer_event_registrar_mock.go -package=p2p
 type peerEventRegistrar interface {
-	RegisterPeerEventObserver(observer polygoncommon.Observer[*sentryproto.PeerEvent]) UnregisterFunc
-	RegisterNewBlockObserver(observer polygoncommon.Observer[*DecodedInboundMessage[*eth.NewBlockPacket]]) UnregisterFunc
-	RegisterNewBlockHashesObserver(observer polygoncommon.Observer[*DecodedInboundMessage[*eth.NewBlockHashesPacket]]) UnregisterFunc
+	RegisterPeerEventObserver(observer event.Observer[*sentryproto.PeerEvent]) UnregisterFunc
+	RegisterNewBlockObserver(observer event.Observer[*DecodedInboundMessage[*eth.NewBlockPacket]]) UnregisterFunc
+	RegisterNewBlockHashesObserver(observer event.Observer[*DecodedInboundMessage[*eth.NewBlockHashesPacket]]) UnregisterFunc
 }

--- a/polygon/p2p/peer_event_registrar_mock.go
+++ b/polygon/p2p/peer_event_registrar_mock.go
@@ -12,9 +12,9 @@ package p2p
 import (
 	reflect "reflect"
 
+	event "github.com/erigontech/erigon-lib/event"
 	sentryproto "github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	eth "github.com/erigontech/erigon/eth/protocols/eth"
-	polygoncommon "github.com/erigontech/erigon/polygon/polygoncommon"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -22,7 +22,6 @@ import (
 type MockpeerEventRegistrar struct {
 	ctrl     *gomock.Controller
 	recorder *MockpeerEventRegistrarMockRecorder
-	isgomock struct{}
 }
 
 // MockpeerEventRegistrarMockRecorder is the mock recorder for MockpeerEventRegistrar.
@@ -43,7 +42,7 @@ func (m *MockpeerEventRegistrar) EXPECT() *MockpeerEventRegistrarMockRecorder {
 }
 
 // RegisterNewBlockHashesObserver mocks base method.
-func (m *MockpeerEventRegistrar) RegisterNewBlockHashesObserver(observer polygoncommon.Observer[*DecodedInboundMessage[*eth.NewBlockHashesPacket]]) UnregisterFunc {
+func (m *MockpeerEventRegistrar) RegisterNewBlockHashesObserver(observer event.Observer[*DecodedInboundMessage[*eth.NewBlockHashesPacket]]) UnregisterFunc {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterNewBlockHashesObserver", observer)
 	ret0, _ := ret[0].(UnregisterFunc)
@@ -69,19 +68,19 @@ func (c *MockpeerEventRegistrarRegisterNewBlockHashesObserverCall) Return(arg0 U
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockpeerEventRegistrarRegisterNewBlockHashesObserverCall) Do(f func(polygoncommon.Observer[*DecodedInboundMessage[*eth.NewBlockHashesPacket]]) UnregisterFunc) *MockpeerEventRegistrarRegisterNewBlockHashesObserverCall {
+func (c *MockpeerEventRegistrarRegisterNewBlockHashesObserverCall) Do(f func(event.Observer[*DecodedInboundMessage[*eth.NewBlockHashesPacket]]) UnregisterFunc) *MockpeerEventRegistrarRegisterNewBlockHashesObserverCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockpeerEventRegistrarRegisterNewBlockHashesObserverCall) DoAndReturn(f func(polygoncommon.Observer[*DecodedInboundMessage[*eth.NewBlockHashesPacket]]) UnregisterFunc) *MockpeerEventRegistrarRegisterNewBlockHashesObserverCall {
+func (c *MockpeerEventRegistrarRegisterNewBlockHashesObserverCall) DoAndReturn(f func(event.Observer[*DecodedInboundMessage[*eth.NewBlockHashesPacket]]) UnregisterFunc) *MockpeerEventRegistrarRegisterNewBlockHashesObserverCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // RegisterNewBlockObserver mocks base method.
-func (m *MockpeerEventRegistrar) RegisterNewBlockObserver(observer polygoncommon.Observer[*DecodedInboundMessage[*eth.NewBlockPacket]]) UnregisterFunc {
+func (m *MockpeerEventRegistrar) RegisterNewBlockObserver(observer event.Observer[*DecodedInboundMessage[*eth.NewBlockPacket]]) UnregisterFunc {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterNewBlockObserver", observer)
 	ret0, _ := ret[0].(UnregisterFunc)
@@ -107,19 +106,19 @@ func (c *MockpeerEventRegistrarRegisterNewBlockObserverCall) Return(arg0 Unregis
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockpeerEventRegistrarRegisterNewBlockObserverCall) Do(f func(polygoncommon.Observer[*DecodedInboundMessage[*eth.NewBlockPacket]]) UnregisterFunc) *MockpeerEventRegistrarRegisterNewBlockObserverCall {
+func (c *MockpeerEventRegistrarRegisterNewBlockObserverCall) Do(f func(event.Observer[*DecodedInboundMessage[*eth.NewBlockPacket]]) UnregisterFunc) *MockpeerEventRegistrarRegisterNewBlockObserverCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockpeerEventRegistrarRegisterNewBlockObserverCall) DoAndReturn(f func(polygoncommon.Observer[*DecodedInboundMessage[*eth.NewBlockPacket]]) UnregisterFunc) *MockpeerEventRegistrarRegisterNewBlockObserverCall {
+func (c *MockpeerEventRegistrarRegisterNewBlockObserverCall) DoAndReturn(f func(event.Observer[*DecodedInboundMessage[*eth.NewBlockPacket]]) UnregisterFunc) *MockpeerEventRegistrarRegisterNewBlockObserverCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // RegisterPeerEventObserver mocks base method.
-func (m *MockpeerEventRegistrar) RegisterPeerEventObserver(observer polygoncommon.Observer[*sentryproto.PeerEvent]) UnregisterFunc {
+func (m *MockpeerEventRegistrar) RegisterPeerEventObserver(observer event.Observer[*sentryproto.PeerEvent]) UnregisterFunc {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterPeerEventObserver", observer)
 	ret0, _ := ret[0].(UnregisterFunc)
@@ -145,13 +144,13 @@ func (c *MockpeerEventRegistrarRegisterPeerEventObserverCall) Return(arg0 Unregi
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockpeerEventRegistrarRegisterPeerEventObserverCall) Do(f func(polygoncommon.Observer[*sentryproto.PeerEvent]) UnregisterFunc) *MockpeerEventRegistrarRegisterPeerEventObserverCall {
+func (c *MockpeerEventRegistrarRegisterPeerEventObserverCall) Do(f func(event.Observer[*sentryproto.PeerEvent]) UnregisterFunc) *MockpeerEventRegistrarRegisterPeerEventObserverCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockpeerEventRegistrarRegisterPeerEventObserverCall) DoAndReturn(f func(polygoncommon.Observer[*sentryproto.PeerEvent]) UnregisterFunc) *MockpeerEventRegistrarRegisterPeerEventObserverCall {
+func (c *MockpeerEventRegistrarRegisterPeerEventObserverCall) DoAndReturn(f func(event.Observer[*sentryproto.PeerEvent]) UnregisterFunc) *MockpeerEventRegistrarRegisterPeerEventObserverCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/polygon/p2p/peer_tracker.go
+++ b/polygon/p2p/peer_tracker.go
@@ -24,10 +24,10 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/event"
 	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/eth/protocols/eth"
-	"github.com/erigontech/erigon/polygon/polygoncommon"
 )
 
 func NewPeerTracker(
@@ -65,7 +65,7 @@ type PeerTracker struct {
 func (pt *PeerTracker) Run(ctx context.Context) error {
 	pt.logger.Info(peerTrackerLogPrefix("running peer tracker component"))
 
-	var peerEventUnreg polygoncommon.UnregisterFunc
+	var peerEventUnreg event.UnregisterFunc
 	defer func() { peerEventUnreg() }()
 
 	err := func() error {
@@ -214,7 +214,7 @@ func (pt *PeerTracker) updatePeerSyncProgress(peerId *PeerId, update func(psp *p
 	update(peerSyncProgress)
 }
 
-func newPeerEventObserver(pt *PeerTracker) polygoncommon.Observer[*sentryproto.PeerEvent] {
+func newPeerEventObserver(pt *PeerTracker) event.Observer[*sentryproto.PeerEvent] {
 	return func(message *sentryproto.PeerEvent) {
 		peerId := PeerIdFromH512(message.PeerId)
 		switch message.EventId {
@@ -226,7 +226,7 @@ func newPeerEventObserver(pt *PeerTracker) polygoncommon.Observer[*sentryproto.P
 	}
 }
 
-func newBlockHashAnnouncesObserver(pt *PeerTracker) polygoncommon.Observer[*DecodedInboundMessage[*eth.NewBlockHashesPacket]] {
+func newBlockHashAnnouncesObserver(pt *PeerTracker) event.Observer[*DecodedInboundMessage[*eth.NewBlockHashesPacket]] {
 	return func(message *DecodedInboundMessage[*eth.NewBlockHashesPacket]) {
 		for _, hashOrNum := range *message.Decoded {
 			pt.BlockHashPresent(message.PeerId, hashOrNum.Hash)
@@ -234,7 +234,7 @@ func newBlockHashAnnouncesObserver(pt *PeerTracker) polygoncommon.Observer[*Deco
 	}
 }
 
-func newBlockAnnouncesObserver(pt *PeerTracker) polygoncommon.Observer[*DecodedInboundMessage[*eth.NewBlockPacket]] {
+func newBlockAnnouncesObserver(pt *PeerTracker) event.Observer[*DecodedInboundMessage[*eth.NewBlockPacket]] {
 	return func(message *DecodedInboundMessage[*eth.NewBlockPacket]) {
 		pt.BlockHashPresent(message.PeerId, message.Decoded.Block.Hash())
 	}

--- a/polygon/p2p/peer_tracker_test.go
+++ b/polygon/p2p/peer_tracker_test.go
@@ -29,12 +29,12 @@ import (
 	"go.uber.org/mock/gomock"
 
 	libcommon "github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/event"
 	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/core/types"
 	"github.com/erigontech/erigon/eth/protocols/eth"
-	"github.com/erigontech/erigon/polygon/polygoncommon"
 	"github.com/erigontech/erigon/turbo/testlog"
 )
 
@@ -286,7 +286,7 @@ func (ptt *peerTrackerTest) mockPeerProvider(peerReply *sentryproto.PeersReply) 
 func (ptt *peerTrackerTest) mockPeerEvents(events <-chan *sentryproto.PeerEvent) {
 	ptt.peerEventRegistrar.EXPECT().
 		RegisterPeerEventObserver(gomock.Any()).
-		DoAndReturn(func(observer polygoncommon.Observer[*sentryproto.PeerEvent]) UnregisterFunc {
+		DoAndReturn(func(observer event.Observer[*sentryproto.PeerEvent]) UnregisterFunc {
 			ctx, cancel := context.WithCancel(context.Background())
 			go func() {
 				for {
@@ -308,7 +308,7 @@ func (ptt *peerTrackerTest) mockNewBlockHashesEvents(events <-chan *DecodedInbou
 	ptt.peerEventRegistrar.EXPECT().
 		RegisterNewBlockHashesObserver(gomock.Any()).
 		DoAndReturn(
-			func(observer polygoncommon.Observer[*DecodedInboundMessage[*eth.NewBlockHashesPacket]]) UnregisterFunc {
+			func(observer event.Observer[*DecodedInboundMessage[*eth.NewBlockHashesPacket]]) UnregisterFunc {
 				ctx, cancel := context.WithCancel(context.Background())
 				go func() {
 					for {
@@ -331,7 +331,7 @@ func (ptt *peerTrackerTest) mockNewBlockEvents(events <-chan *DecodedInboundMess
 	ptt.peerEventRegistrar.EXPECT().
 		RegisterNewBlockObserver(gomock.Any()).
 		DoAndReturn(
-			func(observer polygoncommon.Observer[*DecodedInboundMessage[*eth.NewBlockPacket]]) UnregisterFunc {
+			func(observer event.Observer[*DecodedInboundMessage[*eth.NewBlockPacket]]) UnregisterFunc {
 				ctx, cancel := context.WithCancel(context.Background())
 				go func() {
 					for {

--- a/polygon/p2p/publisher_test.go
+++ b/polygon/p2p/publisher_test.go
@@ -31,12 +31,12 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/erigontech/erigon-lib/direct"
+	"github.com/erigontech/erigon-lib/event"
 	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/core/types"
 	"github.com/erigontech/erigon/eth/protocols/eth"
-	"github.com/erigontech/erigon/polygon/polygoncommon"
 	"github.com/erigontech/erigon/turbo/testlog"
 )
 
@@ -234,7 +234,7 @@ func (pt publisherTest) mockPeerProvider(peerReply *sentryproto.PeersReply) {
 func (pt publisherTest) mockPeerEvents(events <-chan *sentryproto.PeerEvent) {
 	pt.peerEventRegistrar.EXPECT().
 		RegisterPeerEventObserver(gomock.Any()).
-		DoAndReturn(func(observer polygoncommon.Observer[*sentryproto.PeerEvent]) UnregisterFunc {
+		DoAndReturn(func(observer event.Observer[*sentryproto.PeerEvent]) UnregisterFunc {
 			ctx, cancel := context.WithCancel(context.Background())
 			go func() {
 				for {
@@ -260,7 +260,7 @@ func (pt publisherTest) mockNewBlockHashesEvents(events <-chan *DecodedInboundMe
 	pt.peerEventRegistrar.EXPECT().
 		RegisterNewBlockHashesObserver(gomock.Any()).
 		DoAndReturn(
-			func(observer polygoncommon.Observer[*DecodedInboundMessage[*eth.NewBlockHashesPacket]]) UnregisterFunc {
+			func(observer event.Observer[*DecodedInboundMessage[*eth.NewBlockHashesPacket]]) UnregisterFunc {
 				ctx, cancel := context.WithCancel(context.Background())
 				go func() {
 					for {
@@ -287,7 +287,7 @@ func (pt publisherTest) mockNewBlockEvents(events <-chan *DecodedInboundMessage[
 	pt.peerEventRegistrar.EXPECT().
 		RegisterNewBlockObserver(gomock.Any()).
 		DoAndReturn(
-			func(observer polygoncommon.Observer[*DecodedInboundMessage[*eth.NewBlockPacket]]) UnregisterFunc {
+			func(observer event.Observer[*DecodedInboundMessage[*eth.NewBlockPacket]]) UnregisterFunc {
 				ctx, cancel := context.WithCancel(context.Background())
 				go func() {
 					for {

--- a/polygon/p2p/service.go
+++ b/polygon/p2p/service.go
@@ -24,12 +24,12 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	libcommon "github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/event"
 	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon-lib/p2p/sentry"
 	"github.com/erigontech/erigon/core/types"
 	"github.com/erigontech/erigon/eth/protocols/eth"
-	"github.com/erigontech/erigon/polygon/polygoncommon"
 )
 
 func NewService(logger log.Logger, maxPeers int, sc sentryproto.SentryClient, sdf sentry.StatusDataFactory) *Service {
@@ -124,10 +124,10 @@ func (s *Service) Penalize(ctx context.Context, peerId *PeerId) error {
 	return s.peerPenalizer.Penalize(ctx, peerId)
 }
 
-func (s *Service) RegisterNewBlockObserver(o polygoncommon.Observer[*DecodedInboundMessage[*eth.NewBlockPacket]]) polygoncommon.UnregisterFunc {
+func (s *Service) RegisterNewBlockObserver(o event.Observer[*DecodedInboundMessage[*eth.NewBlockPacket]]) event.UnregisterFunc {
 	return s.messageListener.RegisterNewBlockObserver(o)
 }
 
-func (s *Service) RegisterNewBlockHashesObserver(o polygoncommon.Observer[*DecodedInboundMessage[*eth.NewBlockHashesPacket]]) polygoncommon.UnregisterFunc {
+func (s *Service) RegisterNewBlockHashesObserver(o event.Observer[*DecodedInboundMessage[*eth.NewBlockHashesPacket]]) event.UnregisterFunc {
 	return s.messageListener.RegisterNewBlockHashesObserver(o)
 }

--- a/polygon/sync/tip_events.go
+++ b/polygon/sync/tip_events.go
@@ -20,17 +20,16 @@ import (
 	"context"
 	"fmt"
 
+	lru "github.com/hashicorp/golang-lru/v2"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/event"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/core/types"
 	"github.com/erigontech/erigon/eth/protocols/eth"
 	"github.com/erigontech/erigon/polygon/heimdall"
 	"github.com/erigontech/erigon/polygon/p2p"
-	"github.com/erigontech/erigon/polygon/polygoncommon"
-
-	lru "github.com/hashicorp/golang-lru/v2"
 )
 
 type EventType string
@@ -107,12 +106,12 @@ func (e Event) AsNewMilestone() EventNewMilestone {
 }
 
 type p2pObserverRegistrar interface {
-	RegisterNewBlockObserver(polygoncommon.Observer[*p2p.DecodedInboundMessage[*eth.NewBlockPacket]]) polygoncommon.UnregisterFunc
-	RegisterNewBlockHashesObserver(polygoncommon.Observer[*p2p.DecodedInboundMessage[*eth.NewBlockHashesPacket]]) polygoncommon.UnregisterFunc
+	RegisterNewBlockObserver(event.Observer[*p2p.DecodedInboundMessage[*eth.NewBlockPacket]]) event.UnregisterFunc
+	RegisterNewBlockHashesObserver(event.Observer[*p2p.DecodedInboundMessage[*eth.NewBlockHashesPacket]]) event.UnregisterFunc
 }
 
 type heimdallObserverRegistrar interface {
-	RegisterMilestoneObserver(callback func(*heimdall.Milestone), opts ...heimdall.ObserverOption) polygoncommon.UnregisterFunc
+	RegisterMilestoneObserver(callback func(*heimdall.Milestone), opts ...heimdall.ObserverOption) event.UnregisterFunc
 }
 
 func NewTipEvents(logger log.Logger, p2pReg p2pObserverRegistrar, heimdallReg heimdallObserverRegistrar) *TipEvents {


### PR DESCRIPTION
moving `EventNotifier` and `Observers` structs from `polygon/polygoncommon` pkg to `erigon-lib/event` pkg since those will be used in other packages outside of polygon (e.g. using in `shutter` pkg as part of https://github.com/erigontech/erigon/pull/13306)