### PR TITLE
caplin: Use `HandleEndpointFunc` for `node` endpoints

### DIFF
--- a/cl/beacon/handler/handler.go
+++ b/cl/beacon/handler/handler.go
@@ -228,12 +228,12 @@ func (a *ApiHandler) init() {
 			if a.routerCfg.Node {
 				r.Route("/node", func(r chi.Router) {
 					r.Get("/health", a.GetEthV1NodeHealth)
-					r.Get("/version", a.GetEthV1NodeVersion)
-					r.Get("/peer_count", a.GetEthV1NodePeerCount)
-					r.Get("/peers", a.GetEthV1NodePeersInfos)
-					r.Get("/peers/{peer_id}", a.GetEthV1NodePeerInfos)
-					r.Get("/identity", a.GetEthV1NodeIdentity)
-					r.Get("/syncing", a.GetEthV1NodeSyncing)
+					r.Get("/version", beaconhttp.HandleEndpointFunc(a.GetEthV1NodeVersion))
+					r.Get("/peer_count", beaconhttp.HandleEndpointFunc(a.GetEthV1NodePeerCount))
+					r.Get("/peers", beaconhttp.HandleEndpointFunc(a.GetEthV1NodePeersInfos))
+					r.Get("/peers/{peer_id}", beaconhttp.HandleEndpointFunc(a.GetEthV1NodePeerInfos))
+					r.Get("/identity", beaconhttp.HandleEndpointFunc(a.GetEthV1NodeIdentity))
+					r.Get("/syncing", beaconhttp.HandleEndpointFunc(a.GetEthV1NodeSyncing))
 				})
 			}
 

--- a/cl/beacon/handler/node.go
+++ b/cl/beacon/handler/node.go
@@ -62,6 +62,7 @@ func (a *ApiHandler) GetEthV1NodeHealth(w http.ResponseWriter, r *http.Request) 
 
 func (a *ApiHandler) GetEthV1NodeVersion(w http.ResponseWriter, r *http.Request) {
 	// Get OS and Arch
+	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(map[string]interface{}{
 		"data": map[string]interface{}{
 			"version": fmt.Sprintf("Caplin/%s %s/%s", a.version, runtime.GOOS, runtime.GOARCH),
@@ -78,6 +79,7 @@ func (a *ApiHandler) GetEthV1NodePeerCount(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	// all fields should be converted to string
+	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(map[string]interface{}{
 		"data": map[string]interface{}{
 			"connected":     strconv.FormatUint(ret.Connected, 10),
@@ -121,6 +123,8 @@ func (a *ApiHandler) GetEthV1NodePeersInfos(w http.ResponseWriter, r *http.Reque
 			AgentVersion:       ret.Peers[i].AgentVersion,
 		})
 	}
+
+	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(map[string]interface{}{
 		"data": peers,
 	}); err != nil {
@@ -142,6 +146,7 @@ func (a *ApiHandler) GetEthV1NodePeerInfos(w http.ResponseWriter, r *http.Reques
 	// find the peer with matching enr
 	for _, p := range ret.Peers {
 		if p.Pid == pid {
+			w.Header().Set("Content-Type", "application/json")
 			if err := json.NewEncoder(w).Encode(map[string]interface{}{
 				"data": peer{
 					PeerID:             p.Pid,
@@ -166,6 +171,8 @@ func (a *ApiHandler) GetEthV1NodeIdentity(w http.ResponseWriter, r *http.Request
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(map[string]interface{}{
 		"data": map[string]interface{}{
 			"peer_id":             id.Pid,
@@ -186,6 +193,7 @@ func (a *ApiHandler) GetEthV1NodeIdentity(w http.ResponseWriter, r *http.Request
 func (a *ApiHandler) GetEthV1NodeSyncing(w http.ResponseWriter, r *http.Request) {
 	currentSlot := a.ethClock.GetCurrentSlot()
 
+	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(map[string]interface{}{
 		"data": map[string]interface{}{
 			"head_slot":     strconv.FormatUint(a.syncedData.HeadSlot(), 10),

--- a/cl/beacon/handler/node.go
+++ b/cl/beacon/handler/node.go
@@ -17,7 +17,7 @@
 package handler
 
 import (
-	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"runtime"
@@ -60,39 +60,29 @@ func (a *ApiHandler) GetEthV1NodeHealth(w http.ResponseWriter, r *http.Request) 
 	w.WriteHeader(http.StatusOK)
 }
 
-func (a *ApiHandler) GetEthV1NodeVersion(w http.ResponseWriter, r *http.Request) {
+func (a *ApiHandler) GetEthV1NodeVersion(w http.ResponseWriter, r *http.Request) (*beaconhttp.BeaconResponse, error) {
 	// Get OS and Arch
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(map[string]interface{}{
-		"data": map[string]interface{}{
-			"version": fmt.Sprintf("Caplin/%s %s/%s", a.version, runtime.GOOS, runtime.GOARCH),
-		},
-	}); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	}
+	return newBeaconResponse(map[string]interface{}{
+		"version": fmt.Sprintf("Caplin/%s %s/%s", a.version, runtime.GOOS, runtime.GOARCH),
+	}), nil
 }
 
-func (a *ApiHandler) GetEthV1NodePeerCount(w http.ResponseWriter, r *http.Request) {
+func (a *ApiHandler) GetEthV1NodePeerCount(w http.ResponseWriter, r *http.Request) (*beaconhttp.BeaconResponse, error) {
 	ret, err := a.sentinel.GetPeers(r.Context(), &sentinel.EmptyMessage{})
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+		return nil, beaconhttp.NewEndpointError(http.StatusInternalServerError, err)
 	}
+
 	// all fields should be converted to string
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(map[string]interface{}{
-		"data": map[string]interface{}{
-			"connected":     strconv.FormatUint(ret.Connected, 10),
-			"disconnected":  strconv.FormatUint(ret.Disconnected, 10),
-			"connecting":    strconv.FormatUint(ret.Connecting, 10),
-			"disconnecting": strconv.FormatUint(ret.Disconnecting, 10),
-		},
-	}); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	}
+	return newBeaconResponse(map[string]interface{}{
+		"connected":     strconv.FormatUint(ret.Connected, 10),
+		"disconnected":  strconv.FormatUint(ret.Disconnected, 10),
+		"connecting":    strconv.FormatUint(ret.Connecting, 10),
+		"disconnecting": strconv.FormatUint(ret.Disconnecting, 10),
+	}), nil
 }
 
-func (a *ApiHandler) GetEthV1NodePeersInfos(w http.ResponseWriter, r *http.Request) {
+func (a *ApiHandler) GetEthV1NodePeersInfos(w http.ResponseWriter, r *http.Request) (*beaconhttp.BeaconResponse, error) {
 	state := r.URL.Query().Get("state")
 	direction := r.URL.Query().Get("direction")
 
@@ -109,8 +99,7 @@ func (a *ApiHandler) GetEthV1NodePeersInfos(w http.ResponseWriter, r *http.Reque
 		State:     stateIn,
 	})
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+		return nil, beaconhttp.NewEndpointError(http.StatusInternalServerError, err)
 	}
 	peers := make([]peer, 0, len(ret.Peers))
 	for i := range ret.Peers {
@@ -124,85 +113,63 @@ func (a *ApiHandler) GetEthV1NodePeersInfos(w http.ResponseWriter, r *http.Reque
 		})
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(map[string]interface{}{
-		"data": peers,
-	}); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	}
+	return newBeaconResponse(peers), nil
 }
 
-func (a *ApiHandler) GetEthV1NodePeerInfos(w http.ResponseWriter, r *http.Request) {
+func (a *ApiHandler) GetEthV1NodePeerInfos(w http.ResponseWriter, r *http.Request) (*beaconhttp.BeaconResponse, error) {
 	pid, err := beaconhttp.StringFromRequest(r, "peer_id")
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
+		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
 	}
 	ret, err := a.sentinel.PeersInfo(r.Context(), &sentinel.PeersInfoRequest{})
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+		return nil, beaconhttp.NewEndpointError(http.StatusInternalServerError, err)
 	}
 	// find the peer with matching enr
 	for _, p := range ret.Peers {
 		if p.Pid == pid {
-			w.Header().Set("Content-Type", "application/json")
-			if err := json.NewEncoder(w).Encode(map[string]interface{}{
-				"data": peer{
-					PeerID:             p.Pid,
-					State:              p.State,
-					Enr:                p.Enr,
-					LastSeenP2PAddress: p.Address,
-					Direction:          p.Direction,
-					AgentVersion:       p.AgentVersion,
-				},
-			}); err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-			}
-			return
+			return newBeaconResponse(peer{
+				PeerID:             p.Pid,
+				State:              p.State,
+				Enr:                p.Enr,
+				LastSeenP2PAddress: p.Address,
+				Direction:          p.Direction,
+				AgentVersion:       p.AgentVersion,
+			}), nil
 		}
 	}
-	http.Error(w, "peer not found", http.StatusNotFound)
+
+	return nil, beaconhttp.NewEndpointError(http.StatusNotFound, errors.New("peer not found"))
 }
 
-func (a *ApiHandler) GetEthV1NodeIdentity(w http.ResponseWriter, r *http.Request) {
+func (a *ApiHandler) GetEthV1NodeIdentity(w http.ResponseWriter, r *http.Request) (*beaconhttp.BeaconResponse, error) {
 	id, err := a.sentinel.Identity(r.Context(), &sentinel.EmptyMessage{})
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+		return nil, beaconhttp.NewEndpointError(http.StatusInternalServerError, err)
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(map[string]interface{}{
-		"data": map[string]interface{}{
-			"peer_id":             id.Pid,
-			"enr":                 id.Enr,
-			"p2p_addresses":       id.P2PAddresses,
-			"discovery_addresses": id.DiscoveryAddresses,
-			"metadata": map[string]interface{}{
-				"seq":      strconv.FormatUint(id.Metadata.Seq, 10),
-				"attnets":  id.Metadata.Attnets,
-				"syncnets": id.Metadata.Syncnets,
-			},
+	return newBeaconResponse(map[string]interface{}{
+		"peer_id":             id.Pid,
+		"enr":                 id.Enr,
+		"p2p_addresses":       id.P2PAddresses,
+		"discovery_addresses": id.DiscoveryAddresses,
+		"metadata": map[string]interface{}{
+			"seq":      strconv.FormatUint(id.Metadata.Seq, 10),
+			"attnets":  id.Metadata.Attnets,
+			"syncnets": id.Metadata.Syncnets,
 		},
-	}); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	}
+	}), nil
 }
 
-func (a *ApiHandler) GetEthV1NodeSyncing(w http.ResponseWriter, r *http.Request) {
+func (a *ApiHandler) GetEthV1NodeSyncing(w http.ResponseWriter, r *http.Request) (*beaconhttp.BeaconResponse, error) {
 	currentSlot := a.ethClock.GetCurrentSlot()
 
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(map[string]interface{}{
-		"data": map[string]interface{}{
+	return newBeaconResponse(
+		map[string]interface{}{
 			"head_slot":     strconv.FormatUint(a.syncedData.HeadSlot(), 10),
 			"sync_distance": strconv.FormatUint(currentSlot-a.syncedData.HeadSlot(), 10),
 			"is_syncing":    a.syncedData.Syncing(),
 			"is_optimistic": false, // needs to change
 			"el_offline":    false,
-		},
-	}); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	}
+		}), nil
 }


### PR DESCRIPTION
This fixes an issue where correct response headers were not set for these endpoints. Specifically, `Content-Type` was being set to `text/plain` instead of `application/json`.