### PR TITLE
Fix typo Update README.md

### DIFF
--- a/turbo/app/README.md
+++ b/turbo/app/README.md
@@ -46,7 +46,7 @@ in the rclone config file.
 The **uploader** is configured to minimize disk usage by doing the following:
 
 * It removes snapshots once they are loaded
-* It agressively prunes the database once entities are transferred to snapshots
+* It aggressively prunes the database once entities are transferred to snapshots
 
 in addition to this it has the following performance related features:
 


### PR DESCRIPTION
Original: "It agressively prunes the database once entities are transferred to snapshots."
Corrected: "It aggressively prunes the database once entities are transferred to snapshots."
This change corrects the spelling, improving the accuracy and professionalism of the document.