### PR TITLE
Typo fix in `README.md

### DIFF
--- a/turbo/app/README.md
+++ b/turbo/app/README.md
@@ -46,7 +46,7 @@ in the rclone config file.
 The **uploader** is configured to minimize disk usage by doing the following:
 
 * It removes snapshots once they are loaded
-* It agressively prunes the database once entities are transferred to snapshots
+* It aggressively prunes the database once entities are transferred to snapshots
 
 in addition to this it has the following performance related features:
 


### PR DESCRIPTION
### Title
Typo fix in `README.md`

### Description
Corrected a typo in the `README.md` file. The word "agressively" was corrected to "aggressively".

### Changes
- Fixed the typo in the sentence: "It agressively prunes the database once entities are transferred to snapshots" to "It aggressively prunes the database once entities are transferred to snapshots."

### Impact
This fix only affects the documentation and does not change the functionality of the code.
