### PR TITLE
downloader: show correct rates after restart

### DIFF
--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -1974,7 +1974,7 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 	stats.BytesCompleted = uint64(connStats.BytesCompleted.Int64())
 
 	if prevStats.BytesDownload == 0 {
-		prevStats.BytesDownload = stats.BytesDownload
+		prevStats.BytesDownload = stats.BytesCompleted
 	}
 
 	if prevStats.BytesCompleted == 0 {

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -1973,6 +1973,7 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 	stats.BytesDownload = uint64(connStats.BytesReadData.Int64())
 	stats.BytesCompleted = uint64(connStats.BytesCompleted.Int64())
 
+	// if we have no previous stats, it means that node was restarted and need to set initial values
 	if prevStats.BytesDownload == 0 {
 		prevStats.BytesDownload = stats.BytesCompleted
 	}

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -1973,6 +1973,14 @@ func (d *Downloader) ReCalcStats(interval time.Duration) {
 	stats.BytesDownload = uint64(connStats.BytesReadData.Int64())
 	stats.BytesCompleted = uint64(connStats.BytesCompleted.Int64())
 
+	if prevStats.BytesDownload == 0 {
+		prevStats.BytesDownload = stats.BytesDownload
+	}
+
+	if prevStats.BytesCompleted == 0 {
+		prevStats.BytesCompleted = stats.BytesCompleted
+	}
+
 	lastMetadataReady := stats.MetadataReady
 
 	stats.BytesTotal, stats.ConnectionsTotal, stats.MetadataReady = 0, 0, 0


### PR DESCRIPTION
Set initial values `prevStats.BytesDownload` and `prevStats.BytesCompleted` if they are zero, which can occur if the node was restarted or launched for first time.
Fix for https://github.com/erigontech/erigon/issues/13250 and https://github.com/erigontech/erigon/issues/13044