### PR TITLE
Fix grammar and typos in documentation

### DIFF
--- a/cl/beacon/beaconhttp/args.go
+++ b/cl/beacon/beaconhttp/args.go
@@ -152,7 +152,7 @@ func HashFromQueryParams(r *http.Request, name string) (*common.Hash, error) {
 	if hashStr == "" {
 		return nil, nil
 	}
-	// check if hashstr is an hex string
+	// check if hashstr is a hex string
 	if len(hashStr) != 2+2*32 {
 		return nil, errors.New("invalid hash length")
 	}

--- a/cmd/devnet/README.md
+++ b/cmd/devnet/README.md
@@ -74,7 +74,7 @@ Scenarios are similarly specified in code in `main.go` in the `action` function.
     })
 ```
 
-Scenarios are created a groups of steps which are created by registering a `step` handler too see an example of this take a look at the `commands\ping.go` file which adds a ping rpc method (see `PingErigonRpc` above).
+Scenarios are created as groups of steps which are created by registering a `step` handler too see an example of this take a look at the `commands\ping.go` file which adds a ping rpc method (see `PingErigonRpc` above).
 
 This illustrates the registration process.  The `init` function in the file registers the method with the `scenarios` package - which uses the function name as the default step name.  Others can be added with additional string arguments fo the `StepHandler` call where they will treated as regular expressions to be matched when processing scenario steps.
 

--- a/docs/DEV_CHAIN.md
+++ b/docs/DEV_CHAIN.md
@@ -142,7 +142,7 @@ From the RPC daemon terminal, you will see something like this
  
 <img width="1633" alt="Transaction example" src="https://user-images.githubusercontent.com/24697803/140479146-94b6e66c-22b7-4d8a-a160-b3643d27b612.png">
 
- Finally you will see the ethers in the Dev 2 account balance.
+ Finally, you will see the ethers in the Dev 2 account balance.
     
 
 

--- a/docs/evm_semantics.md
+++ b/docs/evm_semantics.md
@@ -22,7 +22,7 @@ the initial state, environment, and the transaction object. So they look more li
 
 `EXPRESSION(STATE_init, env, tx, STATE_end) == true?`
 
-Moreover, this representation allows for some non determinism, which means that there could be some extra "oracle" input that helps the
+Moreover, this representation allows for some non-determinism, which means that there could be some extra "oracle" input that helps the
 evaluation:
 
 `EXPRESSION(STATE_init, env, tx, STATE_end, ORACLE_input) == true?`
@@ -50,7 +50,7 @@ Obviously, oracle input of the `EXPRESSION` could simply be a collection of all 
 Next observation we make is that the intermediate transitions are usually quite "local", which means that if we compare
 the initial state and the end state of each of those transitions, the difference between can be described succinctly. This
 can be understood as the length of the description having a pre-determined upper bound. Since there is no upper bound on
-the size of the state, we need a way of specifying part of the state the state transition modifies. At this point, we
+the size of the state, we need a way of specifying part of the state transition modifies. At this point, we
 choose to represent the state as an array of accounts. Here, we use "array" in the context of theory of arrays. In this
 theory, there are two main functions defined for an array: `select` and `store`. Expression `select(a, i)` evaluates to the
 `i`-th element of the array `a`. Expression `store(a, i, v)` evaluates to a new array which is equal to the array `a`


### PR DESCRIPTION
This pull request addresses minor grammar and typographical issues in both documentation and code comments. 
The changes improve readability, accuracy, and professionalism across the project. 
Below are the details of the updates:

#### **Summary of Changes**:
1. **`cl/beacon/beaconhttp/args.go`**:
   - Corrected grammar in a code comment: Replaced "an hex string" with "a hex string".

2. **`cmd/devnet/README.md`**:
   - Fixed article usage: Replaced "a groups" with "as groups".
   - Improved grammatical accuracy in explanations.

3. **`docs/DEV_CHAIN.md`**:
   - Added a missing comma after "Finally" to follow proper punctuation rules.

4. **`docs/evm_semantics.md`**:
   - Fixed a typographical error: Added a hyphen in "non determinism" to correctly render it as "non-determinism".
   - Removed redundant word repetition: Simplified "the state the state transition" to "the state transition".
