### PR TITLE
rpcdaemon: Set miner on `eth_getBlockByNumber` on Polygon

### DIFF
--- a/turbo/jsonrpc/eth_block.go
+++ b/turbo/jsonrpc/eth_block.go
@@ -261,6 +261,12 @@ func (api *APIImpl) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber
 			response[field] = nil
 		}
 	}
+
+	if chainConfig.Bor != nil {
+		borConfig := chainConfig.Bor.(*borcfg.BorConfig)
+		response["miner"], _ = ecrecover(b.Header(), borConfig)
+	}
+
 	return response, err
 }
 
@@ -319,18 +325,18 @@ func (api *APIImpl) GetBlockByHash(ctx context.Context, numberOrHash rpc.BlockNu
 	}
 
 	response, err := ethapi.RPCMarshalBlockEx(block, true, fullTx, borTx, borTxHash, additionalFields)
-
-	if chainConfig.Bor != nil {
-		borConfig := chainConfig.Bor.(*borcfg.BorConfig)
-		response["miner"], _ = ecrecover(block.Header(), borConfig)
-	}
-
 	if err == nil && int64(number) == rpc.PendingBlockNumber.Int64() {
 		// Pending blocks need to nil out a few fields
 		for _, field := range []string{"hash", "nonce", "miner"} {
 			response[field] = nil
 		}
 	}
+
+	if chainConfig.Bor != nil {
+		borConfig := chainConfig.Bor.(*borcfg.BorConfig)
+		response["miner"], _ = ecrecover(block.Header(), borConfig)
+	}
+
 	return response, err
 }
 


### PR DESCRIPTION
Fixes #12690

```bash
➜  ~ curl --request POST \
  -s --url http://127.0.0.1:8545/ \
  --header 'Content-Type: application/json' \
  --data '{
        "method": "eth_getBlockByNumber",
        "params": [
                "0x3F515FC",
                false
        ],
        "id": 1,
        "jsonrpc": "2.0"
}' | jq '.result.miner'
"0x83d69448f88bf9c701c1b93f43e1f753d39b2632"
➜  ~ curl --request POST \
  -s --url http://127.0.0.1:8545/ \
  --header 'Content-Type: application/json' \
  --data '{
        "method": "eth_getBlockByHash",
        "params": [
                "0xd925f567ee22d63a003f890af94c1e77e6d4d55a3bcef2b35b7b2317948d7f28",
                false
        ],
        "id": 1,
        "jsonrpc": "2.0"
}' | jq '.result.miner'
"0x83d69448f88bf9c701c1b93f43e1f753d39b2632"
```