### PR TITLE
Caplin: Remove cache files completely

### DIFF
--- a/cl/cltypes/solid/hash_list.go
+++ b/cl/cltypes/solid/hash_list.go
@@ -106,11 +106,12 @@ func (h *hashList) CopyTo(t IterableSSZ[libcommon.Hash]) {
 	if h.MerkleTree != nil {
 		if tu.MerkleTree == nil {
 			tu.MerkleTree = &merkle_tree.MerkleTree{}
-			tu.MerkleTree.Initialize(h.l, merkle_tree.OptimalMaxTreeCacheDepth, func(idx int, out []byte) {
-				copy(out, tu.u[idx*length.Hash:(idx+1)*length.Hash])
-			}, /*limit=*/ nil)
 		}
 		h.MerkleTree.CopyInto(tu.MerkleTree)
+		// make the leaf function on the new buffer
+		tu.MerkleTree.SetComputeLeafFn(func(idx int, out []byte) {
+			copy(out, tu.u[idx*length.Hash:])
+		})
 	}
 	copy(tu.u, h.u)
 }

--- a/cl/cltypes/solid/hash_list.go
+++ b/cl/cltypes/solid/hash_list.go
@@ -18,6 +18,7 @@ package solid
 
 import (
 	"encoding/json"
+	"io"
 
 	libcommon "github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/length"
@@ -190,23 +191,23 @@ func (h *hashList) Pop() libcommon.Hash {
 	panic("didnt ask, dont need it, go fuck yourself")
 }
 
-// func (h *hashList) ReadMerkleTree(r io.Reader) error {
-// 	if h.MerkleTree == nil {
-// 		h.MerkleTree = &merkle_tree.MerkleTree{}
-// 		h.MerkleTree.Initialize(h.l, merkle_tree.OptimalMaxTreeCacheDepth, func(idx int, out []byte) {
-// 			copy(out, h.u[idx*length.Hash:(idx+1)*length.Hash])
-// 		}, /*limit=*/ nil)
-// 	}
-// 	return h.MerkleTree.ReadMerkleTree(r)
-// }
+func (h *hashList) ReadMerkleTree(r io.Reader) error {
+	if h.MerkleTree == nil {
+		h.MerkleTree = &merkle_tree.MerkleTree{}
+		h.MerkleTree.Initialize(h.l, merkle_tree.OptimalMaxTreeCacheDepth, func(idx int, out []byte) {
+			copy(out, h.u[idx*length.Hash:(idx+1)*length.Hash])
+		}, /*limit=*/ nil)
+	}
+	return h.MerkleTree.ReadMerkleTree(r)
+}
 
-// func (h *hashList) WriteMerkleTree(w io.Writer) error {
-// 	if h.MerkleTree == nil {
-// 		cap := uint64(h.c)
-// 		h.MerkleTree = &merkle_tree.MerkleTree{}
-// 		h.MerkleTree.Initialize(h.l, merkle_tree.OptimalMaxTreeCacheDepth, func(idx int, out []byte) {
-// 			copy(out, h.u[idx*length.Hash:(idx+1)*length.Hash])
-// 		}, /*limit=*/ &cap)
-// 	}
-// 	return h.MerkleTree.WriteMerkleTree(w)
-// }
+func (h *hashList) WriteMerkleTree(w io.Writer) error {
+	if h.MerkleTree == nil {
+		cap := uint64(h.c)
+		h.MerkleTree = &merkle_tree.MerkleTree{}
+		h.MerkleTree.Initialize(h.l, merkle_tree.OptimalMaxTreeCacheDepth, func(idx int, out []byte) {
+			copy(out, h.u[idx*length.Hash:(idx+1)*length.Hash])
+		}, /*limit=*/ &cap)
+	}
+	return h.MerkleTree.WriteMerkleTree(w)
+}

--- a/cl/cltypes/solid/hash_list.go
+++ b/cl/cltypes/solid/hash_list.go
@@ -109,6 +109,8 @@ func (h *hashList) CopyTo(t IterableSSZ[libcommon.Hash]) {
 			tu.MerkleTree = &merkle_tree.MerkleTree{}
 		}
 		h.MerkleTree.CopyInto(tu.MerkleTree)
+	} else {
+		tu.MerkleTree = nil
 	}
 	copy(tu.u, h.u)
 }

--- a/cl/cltypes/solid/hash_list.go
+++ b/cl/cltypes/solid/hash_list.go
@@ -156,13 +156,13 @@ func (h *hashList) Set(index int, newValue libcommon.Hash) {
 }
 
 func (h *hashList) hashVectorSSZ() ([32]byte, error) {
-	//if h.MerkleTree == nil {
-	cap := uint64(h.c)
-	h.MerkleTree = &merkle_tree.MerkleTree{}
-	h.MerkleTree.Initialize(h.l, merkle_tree.OptimalMaxTreeCacheDepth, func(idx int, out []byte) {
-		copy(out, h.u[idx*length.Hash:(idx+1)*length.Hash])
-	}, /*limit=*/ &cap)
-	//}
+	if h.MerkleTree == nil {
+		cap := uint64(h.c)
+		h.MerkleTree = &merkle_tree.MerkleTree{}
+		h.MerkleTree.Initialize(h.l, merkle_tree.OptimalMaxTreeCacheDepth, func(idx int, out []byte) {
+			copy(out, h.u[idx*length.Hash:(idx+1)*length.Hash])
+		}, /*limit=*/ &cap)
+	}
 	return h.MerkleTree.ComputeRoot(), nil
 }
 

--- a/cl/cltypes/solid/hash_list.go
+++ b/cl/cltypes/solid/hash_list.go
@@ -105,9 +105,9 @@ func (h *hashList) CopyTo(t IterableSSZ[libcommon.Hash]) {
 		tu.u = make([]byte, len(h.u))
 	}
 	if h.MerkleTree != nil {
-		if tu.MerkleTree == nil {
-			tu.MerkleTree = &merkle_tree.MerkleTree{}
-		}
+		//if tu.MerkleTree == nil {
+		tu.MerkleTree = &merkle_tree.MerkleTree{}
+		//}
 		h.MerkleTree.CopyInto(tu.MerkleTree)
 	} else {
 		tu.MerkleTree = nil

--- a/cl/cltypes/solid/hash_list.go
+++ b/cl/cltypes/solid/hash_list.go
@@ -112,6 +112,8 @@ func (h *hashList) CopyTo(t IterableSSZ[libcommon.Hash]) {
 		tu.MerkleTree.SetComputeLeafFn(func(idx int, out []byte) {
 			copy(out, tu.u[idx*length.Hash:])
 		})
+	} else {
+		tu.MerkleTree = nil
 	}
 	copy(tu.u, h.u)
 }

--- a/cl/cltypes/solid/hash_list.go
+++ b/cl/cltypes/solid/hash_list.go
@@ -104,14 +104,14 @@ func (h *hashList) CopyTo(t IterableSSZ[libcommon.Hash]) {
 	if len(h.u) > len(tu.u) {
 		tu.u = make([]byte, len(h.u))
 	}
-	if h.MerkleTree != nil {
-		//if tu.MerkleTree == nil {
-		tu.MerkleTree = &merkle_tree.MerkleTree{}
-		//}
-		h.MerkleTree.CopyInto(tu.MerkleTree)
-	} else {
-		tu.MerkleTree = nil
-	}
+	// if h.MerkleTree != nil {
+	// 	if tu.MerkleTree == nil {
+	// 		tu.MerkleTree = &merkle_tree.MerkleTree{}
+	// 	}
+	// 	h.MerkleTree.CopyInto(tu.MerkleTree)
+	// } else {
+	tu.MerkleTree = nil
+	//}
 	copy(tu.u, h.u)
 }
 

--- a/cl/cltypes/solid/hash_list.go
+++ b/cl/cltypes/solid/hash_list.go
@@ -154,13 +154,13 @@ func (h *hashList) Set(index int, newValue libcommon.Hash) {
 }
 
 func (h *hashList) hashVectorSSZ() ([32]byte, error) {
-	if h.MerkleTree == nil {
-		cap := uint64(h.c)
-		h.MerkleTree = &merkle_tree.MerkleTree{}
-		h.MerkleTree.Initialize(h.l, merkle_tree.OptimalMaxTreeCacheDepth, func(idx int, out []byte) {
-			copy(out, h.u[idx*length.Hash:(idx+1)*length.Hash])
-		}, /*limit=*/ &cap)
-	}
+	//if h.MerkleTree == nil {
+	cap := uint64(h.c)
+	h.MerkleTree = &merkle_tree.MerkleTree{}
+	h.MerkleTree.Initialize(h.l, merkle_tree.OptimalMaxTreeCacheDepth, func(idx int, out []byte) {
+		copy(out, h.u[idx*length.Hash:(idx+1)*length.Hash])
+	}, /*limit=*/ &cap)
+	//}
 	return h.MerkleTree.ComputeRoot(), nil
 }
 

--- a/cl/cltypes/solid/uint64slice_byte.go
+++ b/cl/cltypes/solid/uint64slice_byte.go
@@ -176,14 +176,14 @@ func (arr *byteBasedUint64Slice) Cap() int {
 
 // HashListSSZ computes the SSZ hash of the slice as a list. It returns the hash and any error encountered.
 func (arr *byteBasedUint64Slice) HashListSSZ() ([32]byte, error) {
-	if arr.MerkleTree == nil {
-		arr.MerkleTree = &merkle_tree.MerkleTree{}
-		cap := uint64((arr.c*8 + length.Hash - 1) / length.Hash)
+	//if arr.MerkleTree == nil {
+	arr.MerkleTree = &merkle_tree.MerkleTree{}
+	cap := uint64((arr.c*8 + length.Hash - 1) / length.Hash)
 
-		arr.MerkleTree.Initialize((arr.l+3)/4, merkle_tree.OptimalMaxTreeCacheDepth, func(idx int, out []byte) {
-			copy(out, arr.u[idx*length.Hash:])
-		}, &cap)
-	}
+	arr.MerkleTree.Initialize((arr.l+3)/4, merkle_tree.OptimalMaxTreeCacheDepth, func(idx int, out []byte) {
+		copy(out, arr.u[idx*length.Hash:])
+	}, &cap)
+	//}
 
 	coreRoot := arr.ComputeRoot()
 	lengthRoot := merkle_tree.Uint64Root(uint64(arr.l))
@@ -192,12 +192,12 @@ func (arr *byteBasedUint64Slice) HashListSSZ() ([32]byte, error) {
 
 // HashVectorSSZ computes the SSZ hash of the slice as a vector. It returns the hash and any error encountered.
 func (arr *byteBasedUint64Slice) HashVectorSSZ() ([32]byte, error) {
-	if arr.MerkleTree == nil {
-		arr.MerkleTree = &merkle_tree.MerkleTree{}
-		arr.MerkleTree.Initialize((arr.l+3)/4, merkle_tree.OptimalMaxTreeCacheDepth, func(idx int, out []byte) {
-			copy(out, arr.u[idx*length.Hash:])
-		}, nil)
-	}
+	//if arr.MerkleTree == nil {
+	arr.MerkleTree = &merkle_tree.MerkleTree{}
+	arr.MerkleTree.Initialize((arr.l+3)/4, merkle_tree.OptimalMaxTreeCacheDepth, func(idx int, out []byte) {
+		copy(out, arr.u[idx*length.Hash:])
+	}, nil)
+	//}
 
 	return arr.ComputeRoot(), nil
 }

--- a/cl/cltypes/solid/uint64slice_byte.go
+++ b/cl/cltypes/solid/uint64slice_byte.go
@@ -82,7 +82,7 @@ func (arr *byteBasedUint64Slice) CopyTo(target *byteBasedUint64Slice) {
 		}
 		arr.MerkleTree.CopyInto(target.MerkleTree)
 		target.SetComputeLeafFn(func(idx int, out []byte) {
-			copy(out, arr.u[idx*length.Hash:])
+			copy(out, target.u[idx*length.Hash:])
 		})
 	} else {
 		target.MerkleTree = nil

--- a/cl/cltypes/solid/uint64slice_byte.go
+++ b/cl/cltypes/solid/uint64slice_byte.go
@@ -76,14 +76,14 @@ func (arr *byteBasedUint64Slice) CopyTo(target *byteBasedUint64Slice) {
 	if len(target.u) < len(arr.u) {
 		target.u = make([]byte, len(arr.u))
 	}
-	if arr.MerkleTree != nil {
-		//if target.MerkleTree == nil {
-		target.MerkleTree = &merkle_tree.MerkleTree{}
-		//}
-		arr.MerkleTree.CopyInto(target.MerkleTree)
-	} else {
-		target.MerkleTree = nil
-	}
+	// if arr.MerkleTree != nil {
+	// 	if target.MerkleTree == nil {
+	// 		target.MerkleTree = &merkle_tree.MerkleTree{}
+	// 	}
+	// 	arr.MerkleTree.CopyInto(target.MerkleTree)
+	// } else {
+	target.MerkleTree = nil
+	//}
 
 	target.u = target.u[:len(arr.u)]
 	copy(target.u, arr.u)

--- a/cl/cltypes/solid/uint64slice_byte.go
+++ b/cl/cltypes/solid/uint64slice_byte.go
@@ -178,14 +178,14 @@ func (arr *byteBasedUint64Slice) Cap() int {
 
 // HashListSSZ computes the SSZ hash of the slice as a list. It returns the hash and any error encountered.
 func (arr *byteBasedUint64Slice) HashListSSZ() ([32]byte, error) {
-	//if arr.MerkleTree == nil {
-	arr.MerkleTree = &merkle_tree.MerkleTree{}
-	cap := uint64((arr.c*8 + length.Hash - 1) / length.Hash)
+	if arr.MerkleTree == nil {
+		arr.MerkleTree = &merkle_tree.MerkleTree{}
+		cap := uint64((arr.c*8 + length.Hash - 1) / length.Hash)
 
-	arr.MerkleTree.Initialize((arr.l+3)/4, merkle_tree.OptimalMaxTreeCacheDepth, func(idx int, out []byte) {
-		copy(out, arr.u[idx*length.Hash:])
-	}, &cap)
-	//}
+		arr.MerkleTree.Initialize((arr.l+3)/4, merkle_tree.OptimalMaxTreeCacheDepth, func(idx int, out []byte) {
+			copy(out, arr.u[idx*length.Hash:])
+		}, &cap)
+	}
 
 	coreRoot := arr.ComputeRoot()
 	lengthRoot := merkle_tree.Uint64Root(uint64(arr.l))
@@ -194,12 +194,12 @@ func (arr *byteBasedUint64Slice) HashListSSZ() ([32]byte, error) {
 
 // HashVectorSSZ computes the SSZ hash of the slice as a vector. It returns the hash and any error encountered.
 func (arr *byteBasedUint64Slice) HashVectorSSZ() ([32]byte, error) {
-	//if arr.MerkleTree == nil {
-	arr.MerkleTree = &merkle_tree.MerkleTree{}
-	arr.MerkleTree.Initialize((arr.l+3)/4, merkle_tree.OptimalMaxTreeCacheDepth, func(idx int, out []byte) {
-		copy(out, arr.u[idx*length.Hash:])
-	}, nil)
-	//}
+	if arr.MerkleTree == nil {
+		arr.MerkleTree = &merkle_tree.MerkleTree{}
+		arr.MerkleTree.Initialize((arr.l+3)/4, merkle_tree.OptimalMaxTreeCacheDepth, func(idx int, out []byte) {
+			copy(out, arr.u[idx*length.Hash:])
+		}, nil)
+	}
 
 	return arr.ComputeRoot(), nil
 }

--- a/cl/cltypes/solid/uint64slice_byte.go
+++ b/cl/cltypes/solid/uint64slice_byte.go
@@ -81,6 +81,8 @@ func (arr *byteBasedUint64Slice) CopyTo(target *byteBasedUint64Slice) {
 			target.MerkleTree = &merkle_tree.MerkleTree{}
 		}
 		arr.MerkleTree.CopyInto(target.MerkleTree)
+	} else {
+		target.MerkleTree = nil
 	}
 
 	target.u = target.u[:len(arr.u)]

--- a/cl/cltypes/solid/uint64slice_byte.go
+++ b/cl/cltypes/solid/uint64slice_byte.go
@@ -77,9 +77,9 @@ func (arr *byteBasedUint64Slice) CopyTo(target *byteBasedUint64Slice) {
 		target.u = make([]byte, len(arr.u))
 	}
 	if arr.MerkleTree != nil {
-		if target.MerkleTree == nil {
-			target.MerkleTree = &merkle_tree.MerkleTree{}
-		}
+		//if target.MerkleTree == nil {
+		target.MerkleTree = &merkle_tree.MerkleTree{}
+		//}
 		arr.MerkleTree.CopyInto(target.MerkleTree)
 	} else {
 		target.MerkleTree = nil

--- a/cl/cltypes/solid/uint64slice_byte.go
+++ b/cl/cltypes/solid/uint64slice_byte.go
@@ -76,14 +76,17 @@ func (arr *byteBasedUint64Slice) CopyTo(target *byteBasedUint64Slice) {
 	if len(target.u) < len(arr.u) {
 		target.u = make([]byte, len(arr.u))
 	}
-	// if arr.MerkleTree != nil {
-	// 	if target.MerkleTree == nil {
-	// 		target.MerkleTree = &merkle_tree.MerkleTree{}
-	// 	}
-	// 	arr.MerkleTree.CopyInto(target.MerkleTree)
-	// } else {
-	target.MerkleTree = nil
-	//}
+	if arr.MerkleTree != nil {
+		if target.MerkleTree == nil {
+			target.MerkleTree = &merkle_tree.MerkleTree{}
+		}
+		arr.MerkleTree.CopyInto(target.MerkleTree)
+		target.SetComputeLeafFn(func(idx int, out []byte) {
+			copy(out, arr.u[idx*length.Hash:])
+		})
+	} else {
+		target.MerkleTree = nil
+	}
 
 	target.u = target.u[:len(arr.u)]
 	copy(target.u, arr.u)

--- a/cl/cltypes/solid/validator_set.go
+++ b/cl/cltypes/solid/validator_set.go
@@ -137,9 +137,9 @@ func (v *ValidatorSet) CopyTo(t *ValidatorSet) {
 		t.attesterBits = make([]byte, len(v.attesterBits))
 	}
 	if v.MerkleTree != nil {
-		if t.MerkleTree == nil {
-			t.MerkleTree = &merkle_tree.MerkleTree{}
-		}
+		//if t.MerkleTree == nil {
+		t.MerkleTree = &merkle_tree.MerkleTree{}
+		//}
 		v.MerkleTree.CopyInto(t.MerkleTree)
 	} else {
 		t.MerkleTree = nil

--- a/cl/cltypes/solid/validator_set.go
+++ b/cl/cltypes/solid/validator_set.go
@@ -187,21 +187,21 @@ func (v *ValidatorSet) Get(idx int) Validator {
 
 func (v *ValidatorSet) HashSSZ() ([32]byte, error) {
 	// generate root list
-	if v.MerkleTree == nil {
-		v.MerkleTree = &merkle_tree.MerkleTree{}
-		cap := uint64(v.c)
-		hashBuffer := make([]byte, 8*32)
-		v.MerkleTree.Initialize(v.l, merkle_tree.OptimalMaxTreeCacheDepth, func(idx int, out []byte) {
-			validator := v.Get(idx)
-			if err := validator.CopyHashBufferTo(hashBuffer); err != nil {
-				panic(err)
-			}
-			hashBuffer = hashBuffer[:(8 * 32)]
-			if err := merkle_tree.MerkleRootFromFlatLeaves(hashBuffer, out); err != nil {
-				panic(err)
-			}
-		}, &cap)
-	}
+	//if v.MerkleTree == nil {
+	v.MerkleTree = &merkle_tree.MerkleTree{}
+	cap := uint64(v.c)
+	hashBuffer := make([]byte, 8*32)
+	v.MerkleTree.Initialize(v.l, merkle_tree.OptimalMaxTreeCacheDepth, func(idx int, out []byte) {
+		validator := v.Get(idx)
+		if err := validator.CopyHashBufferTo(hashBuffer); err != nil {
+			panic(err)
+		}
+		hashBuffer = hashBuffer[:(8 * 32)]
+		if err := merkle_tree.MerkleRootFromFlatLeaves(hashBuffer, out); err != nil {
+			panic(err)
+		}
+	}, &cap)
+	//}
 	lengthRoot := merkle_tree.Uint64Root(uint64(v.l))
 	coreRoot := v.MerkleTree.ComputeRoot()
 	return utils.Sha256(coreRoot[:], lengthRoot[:]), nil

--- a/cl/cltypes/solid/validator_set.go
+++ b/cl/cltypes/solid/validator_set.go
@@ -136,14 +136,17 @@ func (v *ValidatorSet) CopyTo(t *ValidatorSet) {
 		t.expandBuffer(v.l)
 		t.attesterBits = make([]byte, len(v.attesterBits))
 	}
-	// if v.MerkleTree != nil {
-	// 	if t.MerkleTree == nil {
-	// 		t.MerkleTree = &merkle_tree.MerkleTree{}
-	// 	}
-	// 	v.MerkleTree.CopyInto(t.MerkleTree)
-	// } else {
-	t.MerkleTree = nil
-	//}
+	if v.MerkleTree != nil {
+		if t.MerkleTree == nil {
+			t.MerkleTree = &merkle_tree.MerkleTree{}
+		}
+		v.MerkleTree.CopyInto(t.MerkleTree)
+		t.MerkleTree.SetComputeLeafFn(func(idx int, out []byte) {
+			copy(out, t.buffer[idx*validatorSize:])
+		})
+	} else {
+		t.MerkleTree = nil
+	}
 	// skip copying (unsupported for phase0)
 	t.phase0Data = make([]Phase0Data, t.l)
 	copy(t.buffer, v.buffer)

--- a/cl/cltypes/solid/validator_set.go
+++ b/cl/cltypes/solid/validator_set.go
@@ -136,14 +136,14 @@ func (v *ValidatorSet) CopyTo(t *ValidatorSet) {
 		t.expandBuffer(v.l)
 		t.attesterBits = make([]byte, len(v.attesterBits))
 	}
-	if v.MerkleTree != nil {
-		//if t.MerkleTree == nil {
-		t.MerkleTree = &merkle_tree.MerkleTree{}
-		//}
-		v.MerkleTree.CopyInto(t.MerkleTree)
-	} else {
-		t.MerkleTree = nil
-	}
+	// if v.MerkleTree != nil {
+	// 	if t.MerkleTree == nil {
+	// 		t.MerkleTree = &merkle_tree.MerkleTree{}
+	// 	}
+	// 	v.MerkleTree.CopyInto(t.MerkleTree)
+	// } else {
+	t.MerkleTree = nil
+	//}
 	// skip copying (unsupported for phase0)
 	t.phase0Data = make([]Phase0Data, t.l)
 	copy(t.buffer, v.buffer)

--- a/cl/cltypes/solid/validator_set.go
+++ b/cl/cltypes/solid/validator_set.go
@@ -141,6 +141,8 @@ func (v *ValidatorSet) CopyTo(t *ValidatorSet) {
 			t.MerkleTree = &merkle_tree.MerkleTree{}
 		}
 		v.MerkleTree.CopyInto(t.MerkleTree)
+	} else {
+		t.MerkleTree = nil
 	}
 	// skip copying (unsupported for phase0)
 	t.phase0Data = make([]Phase0Data, t.l)

--- a/cl/cltypes/solid/validator_set.go
+++ b/cl/cltypes/solid/validator_set.go
@@ -189,21 +189,21 @@ func (v *ValidatorSet) Get(idx int) Validator {
 
 func (v *ValidatorSet) HashSSZ() ([32]byte, error) {
 	// generate root list
-	//if v.MerkleTree == nil {
-	v.MerkleTree = &merkle_tree.MerkleTree{}
-	cap := uint64(v.c)
-	hashBuffer := make([]byte, 8*32)
-	v.MerkleTree.Initialize(v.l, merkle_tree.OptimalMaxTreeCacheDepth, func(idx int, out []byte) {
-		validator := v.Get(idx)
-		if err := validator.CopyHashBufferTo(hashBuffer); err != nil {
-			panic(err)
-		}
-		hashBuffer = hashBuffer[:(8 * 32)]
-		if err := merkle_tree.MerkleRootFromFlatLeaves(hashBuffer, out); err != nil {
-			panic(err)
-		}
-	}, &cap)
-	//}
+	if v.MerkleTree == nil {
+		v.MerkleTree = &merkle_tree.MerkleTree{}
+		cap := uint64(v.c)
+		hashBuffer := make([]byte, 8*32)
+		v.MerkleTree.Initialize(v.l, merkle_tree.OptimalMaxTreeCacheDepth, func(idx int, out []byte) {
+			validator := v.Get(idx)
+			if err := validator.CopyHashBufferTo(hashBuffer); err != nil {
+				panic(err)
+			}
+			hashBuffer = hashBuffer[:(8 * 32)]
+			if err := merkle_tree.MerkleRootFromFlatLeaves(hashBuffer, out); err != nil {
+				panic(err)
+			}
+		}, &cap)
+	}
 	lengthRoot := merkle_tree.Uint64Root(uint64(v.l))
 	coreRoot := v.MerkleTree.ComputeRoot()
 	return utils.Sha256(coreRoot[:], lengthRoot[:]), nil

--- a/cl/merkle_tree/merkle_tree.go
+++ b/cl/merkle_tree/merkle_tree.go
@@ -207,7 +207,7 @@ func (m *MerkleTree) CopyInto(other *MerkleTree) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	defer other.mu.Unlock()
-	other.computeLeaf = m.computeLeaf
+	//other.computeLeaf = m.computeLeaf
 	if len(other.layers) > len(m.layers) {
 		// reset the internal layers
 		for i := len(m.layers); i < len(other.layers); i++ {

--- a/cl/merkle_tree/merkle_tree.go
+++ b/cl/merkle_tree/merkle_tree.go
@@ -208,18 +208,43 @@ func (m *MerkleTree) CopyInto(other *MerkleTree) {
 	defer m.mu.RUnlock()
 	defer other.mu.Unlock()
 	other.computeLeaf = m.computeLeaf
-	other.layers = make([][]byte, len(m.layers))
-	for i := range m.layers {
-		if m.layers[i] == nil {
-			continue
+	if len(other.layers) > len(m.layers) {
+		// reset the internal layers
+		for i := len(m.layers); i < len(other.layers); i++ {
+			other.layers[i] = other.layers[i][:0]
 		}
-		other.layers[i] = make([]byte, len(m.layers[i]))
+		other.layers = other.layers[:len(m.layers)]
+	}
+
+	if len(m.layers) > len(other.layers) {
+		for len(other.layers) != len(m.layers) {
+			idx := len(other.layers)
+			other.layers = append(other.layers, make([]byte, len(m.layers[idx]), (len(m.layers[idx])*3)/2))
+		}
+	}
+
+	for i := 0; i < len(m.layers); i++ {
+		// If the destination buffer is too short, extend it
+		if len(m.layers[i]) > cap(other.layers[i]) {
+			other.layers[i] = make([]byte, len(m.layers[i]), (len(m.layers[i])*3)/2)
+		}
+		// Normalizr the destination length
+		other.layers[i] = other.layers[i][:len(m.layers[i])]
+
+		// Now that the 2 slices are of equal length we can do a simple memcopy
 		copy(other.layers[i], m.layers[i])
 	}
+
 	other.leavesCount = m.leavesCount
 	other.limit = m.limit
-	other.dirtyLeaves = make([]atomic.Bool, len(m.dirtyLeaves))
-	copy(other.dirtyLeaves, m.dirtyLeaves)
+	//other.dirtyLeaves = make([]atomic.Bool, len(m.dirtyLeaves))
+
+	for i := 0; i < len(m.dirtyLeaves); i++ {
+		if i >= len(other.dirtyLeaves) {
+			other.dirtyLeaves = append(other.dirtyLeaves, atomic.Bool{})
+		}
+		other.dirtyLeaves[i].Store(m.dirtyLeaves[i].Load())
+	}
 }
 
 func (m *MerkleTree) finishHashing(lastLayerIdx int, root []byte) {

--- a/cl/merkle_tree/merkle_tree.go
+++ b/cl/merkle_tree/merkle_tree.go
@@ -208,43 +208,18 @@ func (m *MerkleTree) CopyInto(other *MerkleTree) {
 	defer m.mu.RUnlock()
 	defer other.mu.Unlock()
 	other.computeLeaf = m.computeLeaf
-	if len(other.layers) > len(m.layers) {
-		// reset the internal layers
-		for i := len(m.layers); i < len(other.layers); i++ {
-			other.layers[i] = other.layers[i][:0]
+	other.layers = make([][]byte, len(m.layers))
+	for i := range m.layers {
+		if m.layers[i] == nil {
+			continue
 		}
-		other.layers = other.layers[:len(m.layers)]
-	}
-
-	if len(m.layers) > len(other.layers) {
-		for len(other.layers) != len(m.layers) {
-			idx := len(other.layers)
-			other.layers = append(other.layers, make([]byte, len(m.layers[idx]), (len(m.layers[idx])*3)/2))
-		}
-	}
-
-	for i := 0; i < len(m.layers); i++ {
-		// If the destination buffer is too short, extend it
-		if len(m.layers[i]) > cap(other.layers[i]) {
-			other.layers[i] = make([]byte, len(m.layers[i]), (len(m.layers[i])*3)/2)
-		}
-		// Normalizr the destination length
-		other.layers[i] = other.layers[i][:len(m.layers[i])]
-
-		// Now that the 2 slices are of equal length we can do a simple memcopy
+		other.layers[i] = make([]byte, len(m.layers[i]))
 		copy(other.layers[i], m.layers[i])
 	}
-
 	other.leavesCount = m.leavesCount
 	other.limit = m.limit
-	//other.dirtyLeaves = make([]atomic.Bool, len(m.dirtyLeaves))
-
-	for i := 0; i < len(m.dirtyLeaves); i++ {
-		if i >= len(other.dirtyLeaves) {
-			other.dirtyLeaves = append(other.dirtyLeaves, atomic.Bool{})
-		}
-		other.dirtyLeaves[i].Store(m.dirtyLeaves[i].Load())
-	}
+	other.dirtyLeaves = make([]atomic.Bool, len(m.dirtyLeaves))
+	copy(other.dirtyLeaves, m.dirtyLeaves)
 }
 
 func (m *MerkleTree) finishHashing(lastLayerIdx int, root []byte) {

--- a/cl/merkle_tree/merkle_tree.go
+++ b/cl/merkle_tree/merkle_tree.go
@@ -58,6 +58,10 @@ func (m *MerkleTree) Initialize(leavesCount, maxTreeCacheDepth int, computeLeaf 
 	m.dirtyLeaves = make([]atomic.Bool, leavesCount)
 }
 
+func (m *MerkleTree) SetComputeLeafFn(computeLeaf func(idx int, out []byte)) {
+	m.computeLeaf = computeLeaf
+}
+
 func (m *MerkleTree) MarkLeafAsDirty(idx int) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/cl/phase1/core/state/cache.go
+++ b/cl/phase1/core/state/cache.go
@@ -267,7 +267,7 @@ func (b *CachingBeaconState) initCaches() error {
 func (b *CachingBeaconState) InitBeaconState() error {
 	b.totalActiveBalanceCache = nil
 	b._refreshActiveBalancesIfNeeded()
-
+	b.previousStateRoot = common.Hash{}
 	b.publicKeyIndicies = make(map[[48]byte]uint64)
 	b.ForEachValidator(func(validator solid.Validator, i, total int) bool {
 		b.publicKeyIndicies[validator.PublicKey()] = uint64(i)


### PR DESCRIPTION
* It was a pre-optimization and it is now not needed
* simpler code
* less headaches for concurrency