### PR TITLE
polygon: astrid fix --no-downloader issue due to bridge snapshot store bug

### DIFF
--- a/polygon/bridge/snapshot_store.go
+++ b/polygon/bridge/snapshot_store.go
@@ -267,7 +267,7 @@ func (s *SnapshotStore) BlockEventIdsRange(ctx context.Context, blockNum uint64)
 
 func (s *SnapshotStore) Events(ctx context.Context, start, end uint64) ([][]byte, error) {
 	lastFrozenEventId := s.LastFrozenEventId()
-	if start > lastFrozenEventId || lastFrozenEventId == 0 /* because start may be 0 */ {
+	if start > lastFrozenEventId || lastFrozenEventId == 0 {
 		return s.Store.Events(ctx, start, end)
 	}
 

--- a/polygon/bridge/snapshot_store.go
+++ b/polygon/bridge/snapshot_store.go
@@ -266,7 +266,8 @@ func (s *SnapshotStore) BlockEventIdsRange(ctx context.Context, blockNum uint64)
 }
 
 func (s *SnapshotStore) Events(ctx context.Context, start, end uint64) ([][]byte, error) {
-	if start > s.LastFrozenEventId() {
+	lastFrozenEventId := s.LastFrozenEventId()
+	if start > lastFrozenEventId || lastFrozenEventId == 0 /* because start may be 0 */ {
 		return s.Store.Events(ctx, start, end)
 	}
 


### PR DESCRIPTION
Running Amoy with --no-downloader failed with trie root mismatch because the bridge didn't return correct events mapping for the first block with events which is 35072. This was because the snapshot store incorrectly checked in snapshots instead of in the DB store when Events was called with start=0