### PR TITLE
Bypass broken GetClientVersionV1 problem

### DIFF
--- a/turbo/engineapi/engine_api_methods.go
+++ b/turbo/engineapi/engine_api_methods.go
@@ -140,17 +140,20 @@ func (e *EngineServer) GetClientVersionV1(ctx context.Context, callerVersion *en
 	if callerVersion != nil {
 		e.logger.Info("[GetClientVersionV1] Received request from" + callerVersion.String())
 	}
+	/**
 	commitBytes := [4]byte{}
 	c := []byte(params.GitCommit)
 	if len(c) >= 4 {
 		copy(commitBytes[:], c[0:4])
 	}
+        **/
 	result := make([]engine_types.ClientVersionV1, 1)
 	result[0] = engine_types.ClientVersionV1{
 		Code:    params.ClientCode,
 		Name:    params.ClientName,
 		Version: params.Version,
-		Commit:  commitBytes,
+		//Commit:  commitBytes,
+		Commit:  params.Version,
 	}
 	return result, nil
 }

--- a/turbo/engineapi/engine_types/jsonrpc.go
+++ b/turbo/engineapi/engine_types/jsonrpc.go
@@ -112,7 +112,8 @@ type ClientVersionV1 struct {
 	Code    string  `json:"code" gencodec:"required"`
 	Name    string  `json:"name" gencodec:"required"`
 	Version string  `json:"version" gencodec:"required"`
-	Commit  [4]byte `json:"commit" gencodec:"required"`
+	//Commit  [4]byte `json:"commit" gencodec:"required"`
+	Commit  string  `json:"commit" gencodec:"required"`
 }
 
 func (c ClientVersionV1) String() string {


### PR DESCRIPTION
Bypass https://github.com/erigontech/erigon/issues/13320 issue

This allows to bypass the broken GetClientVersionV1 method and allows CL to connect with Erigon3

To sync

1. Build erigon3 with this PR

2. Sync to tip with internal caplin CL ( no flags required )

3. Connect CL with `--externalcl --authrpc.addr="0.0.0.0" --authrpc.vhosts=*` and now CL will connect with Erigon and serve latest blocks