### PR TITLE
Fixed `ClientVersionV1`

### DIFF
--- a/turbo/engineapi/engine_api_methods.go
+++ b/turbo/engineapi/engine_api_methods.go
@@ -151,7 +151,7 @@ func (e *EngineServer) GetClientVersionV1(ctx context.Context, callerVersion *en
 		Code:    params.ClientCode,
 		Name:    params.ClientName,
 		Version: params.Version,
-		Commit:  commit[:8],
+		Commit:  "0x" + commit[:8],
 	}
 	return result, nil
 }

--- a/turbo/engineapi/engine_api_methods.go
+++ b/turbo/engineapi/engine_api_methods.go
@@ -140,17 +140,18 @@ func (e *EngineServer) GetClientVersionV1(ctx context.Context, callerVersion *en
 	if callerVersion != nil {
 		e.logger.Info("[GetClientVersionV1] Received request from" + callerVersion.String())
 	}
-	commitBytes := [4]byte{}
-	c := []byte(params.GitCommit)
-	if len(c) >= 4 {
-		copy(commitBytes[:], c[0:4])
+	commit := params.GitCommit
+	// Pad with 0s to 8 characters (string)
+	if len(commit) < 8 {
+		commit = commit + "00000000"
 	}
+
 	result := make([]engine_types.ClientVersionV1, 1)
 	result[0] = engine_types.ClientVersionV1{
 		Code:    params.ClientCode,
 		Name:    params.ClientName,
 		Version: params.Version,
-		Commit:  commitBytes,
+		Commit:  commit[:8],
 	}
 	return result, nil
 }

--- a/turbo/engineapi/engine_types/jsonrpc.go
+++ b/turbo/engineapi/engine_types/jsonrpc.go
@@ -109,10 +109,10 @@ type GetPayloadResponse struct {
 }
 
 type ClientVersionV1 struct {
-	Code    string  `json:"code" gencodec:"required"`
-	Name    string  `json:"name" gencodec:"required"`
-	Version string  `json:"version" gencodec:"required"`
-	Commit  [4]byte `json:"commit" gencodec:"required"`
+	Code    string        `json:"code" gencodec:"required"`
+	Name    string        `json:"name" gencodec:"required"`
+	Version string        `json:"version" gencodec:"required"`
+	Commit  common.Bytes4 `json:"commit" gencodec:"required"`
 }
 
 func (c ClientVersionV1) String() string {

--- a/turbo/engineapi/engine_types/jsonrpc.go
+++ b/turbo/engineapi/engine_types/jsonrpc.go
@@ -109,10 +109,10 @@ type GetPayloadResponse struct {
 }
 
 type ClientVersionV1 struct {
-	Code    string        `json:"code" gencodec:"required"`
-	Name    string        `json:"name" gencodec:"required"`
-	Version string        `json:"version" gencodec:"required"`
-	Commit  common.Bytes4 `json:"commit" gencodec:"required"`
+	Code    string `json:"code" gencodec:"required"`
+	Name    string `json:"name" gencodec:"required"`
+	Version string `json:"version" gencodec:"required"`
+	Commit  string `json:"commit" gencodec:"required"`
 }
 
 func (c ClientVersionV1) String() string {


### PR DESCRIPTION
.GitCommit is already the hex commit hash btw so you just the `0x` prefix.