### PR TITLE
engineapi: Fix `engine_getClientVersionV1`

### DIFF
--- a/turbo/engineapi/engine_api_methods.go
+++ b/turbo/engineapi/engine_api_methods.go
@@ -151,7 +151,7 @@ func (e *EngineServer) GetClientVersionV1(ctx context.Context, callerVersion *en
 		Code:    params.ClientCode,
 		Name:    params.ClientName,
 		Version: params.VersionWithCommit(params.GitCommit),
-		Commit:  commitString,
+		Commit:  "0x" + commitString,
 	}
 	return result, nil
 }

--- a/turbo/engineapi/engine_api_methods.go
+++ b/turbo/engineapi/engine_api_methods.go
@@ -140,18 +140,17 @@ func (e *EngineServer) GetClientVersionV1(ctx context.Context, callerVersion *en
 	if callerVersion != nil {
 		e.logger.Info("[GetClientVersionV1] Received request from" + callerVersion.String())
 	}
-	c := []byte(params.GitCommit)
-	if len(c) >= 4 {
-		c = c[0:4]
-	} else {
-		c = []byte{0, 0, 0, 0}
+	commitString := params.GitCommit
+	if len(commitString) >= 8 {
+		commitString = commitString[:8]
+	} else if len(commitString) == 0{
+		commitString = "00000000"	// shouldn't be triggered
 	}
-	commitString := hexutility.Encode(c)[2:]
 	result := make([]engine_types.ClientVersionV1, 1)
 	result[0] = engine_types.ClientVersionV1{
 		Code:    params.ClientCode,
 		Name:    params.ClientName,
-		Version: params.Version,
+		Version: params.VersionWithCommit(params.GitCommit),
 		Commit:  commitString,
 	}
 	return result, nil

--- a/turbo/engineapi/engine_api_methods.go
+++ b/turbo/engineapi/engine_api_methods.go
@@ -140,17 +140,19 @@ func (e *EngineServer) GetClientVersionV1(ctx context.Context, callerVersion *en
 	if callerVersion != nil {
 		e.logger.Info("[GetClientVersionV1] Received request from" + callerVersion.String())
 	}
-	commitBytes := [4]byte{}
 	c := []byte(params.GitCommit)
 	if len(c) >= 4 {
-		copy(commitBytes[:], c[0:4])
+		c = c[0:4]
+	} else {
+		c = []byte{0, 0, 0, 0}
 	}
+	commitString := hexutility.Encode(c)[2:]
 	result := make([]engine_types.ClientVersionV1, 1)
 	result[0] = engine_types.ClientVersionV1{
 		Code:    params.ClientCode,
 		Name:    params.ClientName,
 		Version: params.Version,
-		Commit:  commitBytes,
+		Commit:  commitString,
 	}
 	return result, nil
 }

--- a/turbo/engineapi/engine_api_methods.go
+++ b/turbo/engineapi/engine_api_methods.go
@@ -143,7 +143,7 @@ func (e *EngineServer) GetClientVersionV1(ctx context.Context, callerVersion *en
 	commitString := params.GitCommit
 	if len(commitString) >= 8 {
 		commitString = commitString[:8]
-	} else if len(commitString) == 0 {
+	} else {
 		commitString = "00000000" // shouldn't be triggered
 	}
 	result := make([]engine_types.ClientVersionV1, 1)

--- a/turbo/engineapi/engine_api_methods.go
+++ b/turbo/engineapi/engine_api_methods.go
@@ -143,8 +143,8 @@ func (e *EngineServer) GetClientVersionV1(ctx context.Context, callerVersion *en
 	commitString := params.GitCommit
 	if len(commitString) >= 8 {
 		commitString = commitString[:8]
-	} else if len(commitString) == 0{
-		commitString = "00000000"	// shouldn't be triggered
+	} else if len(commitString) == 0 {
+		commitString = "00000000" // shouldn't be triggered
 	}
 	result := make([]engine_types.ClientVersionV1, 1)
 	result[0] = engine_types.ClientVersionV1{

--- a/turbo/engineapi/engine_types/jsonrpc.go
+++ b/turbo/engineapi/engine_types/jsonrpc.go
@@ -109,10 +109,10 @@ type GetPayloadResponse struct {
 }
 
 type ClientVersionV1 struct {
-	Code    string  `json:"code" gencodec:"required"`
-	Name    string  `json:"name" gencodec:"required"`
-	Version string  `json:"version" gencodec:"required"`
-	Commit  [4]byte `json:"commit" gencodec:"required"`
+	Code    string `json:"code" gencodec:"required"`
+	Name    string `json:"name" gencodec:"required"`
+	Version string `json:"version" gencodec:"required"`
+	Commit  string `json:"commit" gencodec:"required"`
 }
 
 func (c ClientVersionV1) String() string {


### PR DESCRIPTION
For specs: https://github.com/ethereum/execution-apis/blob/main/src/engine/identification.md#engine_getclientversionv1

The issue earlier was in json marshalling of strings returned by CL clients. Since Git commits are already hex, no need to further hexlify the string.
Commit string with "0x" prefix - that's contentious
The version string doesn't have size limits, hence extending it to what we would be using otherwise.