### PR TITLE
fix: improve net_listening implementation

### DIFF
--- a/turbo/jsonrpc/net_api.go
+++ b/turbo/jsonrpc/net_api.go
@@ -46,8 +46,17 @@ func NewNetAPIImpl(eth rpchelper.ApiBackend) *NetAPIImpl {
 }
 
 // Listening implements net_listening. Returns true if client is actively listening for network connections.
-// TODO: Remove hard coded value
-func (api *NetAPIImpl) Listening(_ context.Context) (bool, error) {
+func (api *NetAPIImpl) Listening(ctx context.Context) (bool, error) {
+	if api.ethBackend == nil {
+		// We're running in --datadir mode or otherwise cannot get the backend
+		return false, fmt.Errorf(NotAvailableChainData, "net_listening")
+	}
+
+	// If we can get peer count, it means the network is listening
+	_, err := api.ethBackend.NetPeerCount(ctx)
+	if err != nil {
+		return false, nil
+	}
 	return true, nil
 }
 

--- a/turbo/jsonrpc/net_api.go
+++ b/turbo/jsonrpc/net_api.go
@@ -52,8 +52,8 @@ func (api *NetAPIImpl) Listening(ctx context.Context) (bool, error) {
 		return false, fmt.Errorf(NotAvailableChainData, "net_listening")
 	}
 
-	// If we can get peer count, it means the network is listening
-	_, err := api.ethBackend.NetPeerCount(ctx)
+	// If we can get peers info, it means the network interface is up and listening
+	_, err := api.ethBackend.Peers(ctx)
 	if err != nil {
 		return false, nil
 	}


### PR DESCRIPTION
Replace hardcoded value with actual network state check.
 **The method now properly reflects network connectivity status by checking if the node can communicate with the network.**