### PR TITLE
Add state consistency check during witness generation

### DIFF
--- a/erigon-lib/commitment/hex_patricia_hashed.go
+++ b/erigon-lib/commitment/hex_patricia_hashed.go
@@ -1131,6 +1131,10 @@ func (c *cell) String() string {
 	return s
 }
 
+func (hph *HexPatriciaHashed) GetPatriciaContext() PatriciaContext {
+	return hph.ctx
+}
+
 func (hph *HexPatriciaHashed) PrintGrid() {
 	fmt.Printf("GRID:\n")
 	for row := 0; row < hph.activeRows; row++ {


### PR DESCRIPTION
This is to prevent the witness algorithm from running  if the account and storage data that will be read by `hph.ctx.Account` and `hph.ctx.Storage` is inconsistent with the data from the StateReader for that block, as that would result in a root hash mismatch.

In general there are 2 cases where we can get a root hash mismatch:

1. The witness trie structure was created improperly
2. The witness trie structure is correct but the state data (i.e. account nodes and storage values) is incorrect. This could happen if `hph.ctx.Account` and `hph.ctx.Storage` return the wrong value. 


Case 2 could happen because of for example stale data being read by `hph.ctx` after the unwind, or if the unwind was not applied properly, or a variety of other reasons.  It's not clear what the underlying cause is and needs further investigation.