### PR TITLE
integrity: fix no gaps in bor events integrity check

### DIFF
--- a/eth/integrity/no_gaps_bor_events.go
+++ b/eth/integrity/no_gaps_bor_events.go
@@ -57,7 +57,7 @@ func NoGapsInBorEvents(ctx context.Context, db kv.RoDB, blockReader services.Ful
 
 	snapshots := blockReader.BorSnapshots().(*heimdall.RoSnapshots)
 
-	var prevEventId uint64 = 1
+	var prevEventId uint64
 	var maxBlockNum uint64
 
 	if to > 0 {


### PR DESCRIPTION
logic is incorrect, prevEventId should be 0 not 1 since events start at 1 so when we check the first event the prevEventId should be 0