### PR TITLE
Exclude workflows from some checks out of scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+    paths:
+      - '!.github/workflows/**'
+      
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-integration-caplin.yml
+++ b/.github/workflows/test-integration-caplin.yml
@@ -13,6 +13,8 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+    paths:
+      - '!.github/workflows/**'
 
 jobs:
   tests:

--- a/.github/workflows/test-integration-erigon.yml
+++ b/.github/workflows/test-integration-erigon.yml
@@ -12,6 +12,8 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+    paths:
+      - '!.github/workflows/**'
   schedule:
     - cron: '20 16 * * *' # daily at 16:20 UTC
   workflow_dispatch:


### PR DESCRIPTION
There are some mandatory checks which make no sense for changes within workflows files. This excludes such checks.