### PR TITLE
tip-tracking: use full node and increase test time on polygon

### DIFF
--- a/.github/workflows/qa-tip-tracking-polygon.yml
+++ b/.github/workflows/qa-tip-tracking-polygon.yml
@@ -47,7 +47,7 @@ jobs:
         # 2. Allow time for the Erigon to achieve synchronization
         # 3. Begin timing the duration that Erigon maintains synchronization
         python3 $ERIGON_QA_PATH/test_system/qa-tests/tip-tracking/run_and_check_tip_tracking.py \
-          ${{ github.workspace }}/build/bin $ERIGON_TESTBED_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN
+          ${{ github.workspace }}/build/bin $ERIGON_TESTBED_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN full_node
   
         # Capture monitoring script exit status
         test_exit_status=$?

--- a/.github/workflows/qa-tip-tracking-polygon.yml
+++ b/.github/workflows/qa-tip-tracking-polygon.yml
@@ -13,8 +13,8 @@ jobs:
       ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version/datadir
       ERIGON_TESTBED_DATA_DIR: /opt/erigon-testbed/datadir
       ERIGON_QA_PATH: /home/qarunner/erigon-qa
-      TRACKING_TIME_SECONDS: 14400 # 4 hours
-      TOTAL_TIME_SECONDS: 28800 # 8 hours
+      TRACKING_TIME_SECONDS: 21600 # 6 hours
+      TOTAL_TIME_SECONDS: 43200 # 12 hours
       CHAIN: bor-mainnet
 
     steps:


### PR DESCRIPTION
To speed up erigon on polygon and avoid it not reaching the tip in the expected test times when the pre build db is old, we opt to run in full node instead of archive node.

We also extend the test times as required to be able to see spikes on the block_consumer_delay metric