### PR TITLE
[DO NOT MERGE] make IndexRange agnostic of business logic

### DIFF
--- a/erigon-lib/state/aggregator2.go
+++ b/erigon-lib/state/aggregator2.go
@@ -22,19 +22,19 @@ func NewAggregator2(ctx context.Context, dirs datadir.Dirs, aggregationStep uint
 	if err != nil {
 		return nil, err
 	}
-	if err := a.registerDomain(kv.AccountsDomain, salt, dirs, aggregationStep, logger); err != nil {
+	if err := a.registerDomain(kv.AccountsDomain, kv.AccountsHistoryIdx, salt, dirs, aggregationStep, logger); err != nil {
 		return nil, err
 	}
-	if err := a.registerDomain(kv.StorageDomain, salt, dirs, aggregationStep, logger); err != nil {
+	if err := a.registerDomain(kv.StorageDomain, kv.StorageHistoryIdx, salt, dirs, aggregationStep, logger); err != nil {
 		return nil, err
 	}
-	if err := a.registerDomain(kv.CodeDomain, salt, dirs, aggregationStep, logger); err != nil {
+	if err := a.registerDomain(kv.CodeDomain, kv.CodeHistoryIdx, salt, dirs, aggregationStep, logger); err != nil {
 		return nil, err
 	}
-	if err := a.registerDomain(kv.CommitmentDomain, salt, dirs, aggregationStep, logger); err != nil {
+	if err := a.registerDomain(kv.CommitmentDomain, kv.CommitmentHistoryIdx, salt, dirs, aggregationStep, logger); err != nil {
 		return nil, err
 	}
-	if err := a.registerDomain(kv.ReceiptDomain, salt, dirs, aggregationStep, logger); err != nil {
+	if err := a.registerDomain(kv.ReceiptDomain, kv.ReceiptHistoryIdx, salt, dirs, aggregationStep, logger); err != nil {
 		return nil, err
 	}
 	if err := a.registerII(kv.LogAddrIdx, salt, dirs, aggregationStep, kv.FileLogAddressIdx, kv.TblLogAddressKeys, kv.TblLogAddressIdx, logger); err != nil {


### PR DESCRIPTION
- if we're going towards "register domains/ii from anywhere", should kv.Domain also be string? -- I guess it's not needed now though. We can achieve the target of "make agg free of business logic" with kv.Domain as int as well.
- map feels ugly. can also just store the historyIdx (kv.InvertedIndex) in domain/history struct and iterate over to find the queried kv.InvertedIndex. But that seems inconsistent with what we did with aggregator.iis.