### PR TITLE
core: fix genesis to block to use empty requests hash to fix Hive tests (#13436)

### DIFF
--- a/core/genesis_write.go
+++ b/core/genesis_write.go
@@ -550,11 +550,10 @@ func GenesisToBlock(g *types.Genesis, tmpDir string, logger log.Logger) (*types.
 	}
 
 	if g.Config != nil && g.Config.IsPrague(g.Timestamp) {
-		// TODO @somnathb1 - if later iterations and/or tests don't need this from genesis.json, remove the following
 		if g.RequestsHash != nil {
 			head.RequestsHash = g.RequestsHash
 		} else {
-			head.RequestsHash = &types.EmptyRootHash
+			head.RequestsHash = &types.EmptyRequestsHash
 		}
 	}
 


### PR DESCRIPTION
e2 port of https://github.com/erigontech/erigon/pull/13436

`erigon init genesis.json` was causing a genesis block to be created with the wrong hash due to using inccorrect RequestsHash for blocks before Prague

this caused the Hive tests to fail with:
```
parent's total difficulty not found with hash 6549118a1de2c28b204c671688e0aa4f6b522e72bf3a4a3f76cc8def0a7ecc8f and height 0: <nil>
```

when trying to insert blocks, causing a considerable amount of tests in rpc-compat to fail, hence making the CI red