### PR TITLE
backend: fix interface conversion: chain.BorConfig is nil panic

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -979,7 +979,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		}()
 	}
 
-	if config.PolygonSync {
+	if chainConfig.Bor != nil && config.PolygonSync {
 		backend.polygonSyncService = polygonsync.NewService(
 			logger,
 			chainConfig,


### PR DESCRIPTION
QA test failed after https://github.com/erigontech/erigon/pull/13376 with 
```
!!->[EROR] [01-15|15:37:50.790] catch panic                              err="interface conversion: chain.BorConfig is nil, not *borcfg.BorConfig" stack="[main.go:46 panic.go:770 iface.go:262 iface.go:272 service.go:52 backend.go:983 node.go:143 main.go:98 make_app.go:71 command.go:276 app.go:333 app.go:307 main.go:51 proc.go:271 asm_amd64.s:1695]"
*** - 2025-01-15 15:38:48 - Check failed: panic
```

https://github.com/erigontech/erigon/actions/runs/12791773578/job/35660649947