### PR TITLE
Enable param on erigon binary

### DIFF
--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -107,6 +107,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.SnapKeepBlocksFlag,
 	&utils.SnapStopFlag,
 	&utils.SnapStateStopFlag,
+	&utils.SnapSkipStateSnapshotDownloadFlag,
 	&utils.DbPageSizeFlag,
 	&utils.DbSizeLimitFlag,
 	&utils.DbWriteMapFlag,


### PR DESCRIPTION
the following line was missing from https://github.com/erigontech/erigon/pull/13107