### PR TITLE
Release workflow: new binary testing job for amd64 and arm64 architectures.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,15 +259,15 @@ jobs:
           ls -l
           echo "DEBUG -- content of directory $(pwd)/qa-tests/tip-tracking/"
           ls -l $(pwd)/qa-tests/tip-tracking/
-          echo "DEBUG -- content of directory GITHUB_WORKSPACE ${GITHUB_WORKSPACE} :"
-          ls -l ${GITHUB_WORKSPACE}
+          echo "DEBUG -- content of directory current dir:"
+          ls -l .
           echo "DEBUG -- end."
-          rm -rf ${RUNNER_WORKSPACE}/erigon-data || true
-          mkdir ${RUNNER_WORKSPACE}/erigon-data
+          rm -rf ./erigon-data || true
+          mkdir ./erigon-data
           # Run Erigon, wait sync and check ability to maintain sync
           python3 qa-tests/tip-tracking/run_and_check_tip_tracking.py \
-            ${GITHUB_WORKSPACE}/${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }} \
-              ${RUNNER_WORKSPACE}/erigon-data ${{ env.TEST_TRACKING_TIME_SECONDS }} ${{ env.TEST_TOTAL_TIME_SECONDS }} ${{ env.APPLICATION_VERSION }} ${{ env.TEST_CHAIN }}
+            ./${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }} \
+              ./erigon-data ${{ env.TEST_TRACKING_TIME_SECONDS }} ${{ env.TEST_TOTAL_TIME_SECONDS }} ${{ env.APPLICATION_VERSION }} ${{ env.TEST_CHAIN }}
           # Capture monitoring script exit status
           test_exit_status=$?
           # Save the subsection reached status

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,10 +226,12 @@ jobs:
       - name: Download artifact ${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }}.tar.gz
         uses: actions/download-artifact@v4
         with:
+          working-directory: "workflow-${{ github.workflow }}-run-${{ github.run_number }}"
           name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }}.tar.gz
           path: .
 
       - name: Extract artifact ${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }}.tar.gz
+        working-directory: "workflow-${{ github.workflow }}-run-${{ github.run_number }}"
         run: |
           pwd
           ls -l ${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }}.tar.gz
@@ -239,6 +241,7 @@ jobs:
       - name: Fast checkout git repository erigontech/erigon-qa
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 ## 4.1.7 release
         with:
+          working-directory: "workflow-${{ github.workflow }}-run-${{ github.run_number }}"
           token: ${{ secrets.ORG_GITHUB_ERIGONTECH_ERIGON_QA_READ }}
           repository: erigontech/erigon-qa
           fetch-depth: 1
@@ -246,6 +249,7 @@ jobs:
           path: erigon-qa
 
       - name: Checkout QA Tests Repository & Install Requirements
+        working-directory: "workflow-${{ github.workflow }}-run-${{ github.run_number }}"
         run: |
           cd ./erigon-qa/test_system
           pwd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,10 +213,10 @@ jobs:
       - name: Setup working directory
         run: |
           echo "DEBUG: Create working directory for workflow:"
-          mkdir "${GITHUB_WORKFLOW}-${GITHUB_RUN_ID}"
+          mkdir "workflow-${GITHUB_WORKFLOW}-run-${GITHUB_RUN_NUMBER}"
           echo "DEBUG: Content of current directory $(pwd) :"
           ls -lao
-          cd "${GITHUB_WORKFLOW}-${GITHUB_RUN_ID}"
+          cd "workflow-${GITHUB_WORKFLOW}-run-${GITHUB_RUN_NUMBER}"
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,8 +262,8 @@ jobs:
           echo "DEBUG -- content of directory current dir:"
           ls -l .
           echo "DEBUG -- end."
-          rm -rf ./erigon-data || true
-          mkdir ./erigon-data
+          rm -rf ../../erigon-data || true
+          mkdir ../../erigon-data
           # Run Erigon, wait sync and check ability to maintain sync
           python3 qa-tests/tip-tracking/run_and_check_tip_tracking.py \
             ./${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }} \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ run-name: Build release ${{ inputs.release_version}} from branch ${{ inputs.chec
 env:
   APPLICATION: "erigon"
   APPLICATION_VERSION: "Erigon3"
+  TEST_TRACKING_TIME_SECONDS: 7200 # 2 hours
+  TEST_TOTAL_TIME_SECONDS: 432000   # 5 days
+  TEST_CHAIN: "mainnet"
   BUILDER_IMAGE: "golang:1.22-bookworm"
   DOCKER_BASE_IMAGE: "debian:12.8-slim"
   APP_REPO: "erigontech/erigon"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,9 +226,8 @@ jobs:
       - name: Download artifact ${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }}.tar.gz
         uses: actions/download-artifact@v4
         with:
-          working-directory: "workflow-${{ github.workflow }}-run-${{ github.run_number }}"
           name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }}.tar.gz
-          path: .
+          path: ./workflow-${{ github.workflow }}-run-${{ github.run_number }}/
 
       - name: Extract artifact ${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }}.tar.gz
         working-directory: "workflow-${{ github.workflow }}-run-${{ github.run_number }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,7 +245,7 @@ jobs:
           repository: erigontech/erigon-qa
           fetch-depth: 1
           ref: main
-          path: erigon-qa
+          path: workflow-${{ github.workflow }}-run-${{ github.run_number }}/erigon-qa
 
       - name: Checkout QA Tests Repository & Install Requirements
         working-directory: "workflow-${{ github.workflow }}-run-${{ github.run_number }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,7 +289,7 @@ jobs:
 
 
   publish-docker-image:
-    needs: [ build-release ]
+    needs: [ build-release, test-release ]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     name: Docker image        

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,9 +265,10 @@ jobs:
           rm -rf ../../erigon-data || true
           mkdir ../../erigon-data
           # Run Erigon, wait sync and check ability to maintain sync
+          find ../.. -ls
           python3 qa-tests/tip-tracking/run_and_check_tip_tracking.py \
-            ./${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }} \
-              ./erigon-data ${{ env.TEST_TRACKING_TIME_SECONDS }} ${{ env.TEST_TOTAL_TIME_SECONDS }} ${{ env.APPLICATION_VERSION }} ${{ env.TEST_CHAIN }}
+            ../../${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }} \
+              ../../erigon-data ${{ env.TEST_TRACKING_TIME_SECONDS }} ${{ env.TEST_TOTAL_TIME_SECONDS }} ${{ env.APPLICATION_VERSION }} ${{ env.TEST_CHAIN }}
           # Capture monitoring script exit status
           test_exit_status=$?
           # Save the subsection reached status

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,9 +193,95 @@ jobs:
           if-no-files-found: error
 
 
+  test-release:
+    name: test on ${{ matrix.id }}
+    runs-on: [ self-hosted, Release, "${{ matrix.runner-arch }}" ]
+    timeout-minutes: 7200  # 5 days
+    needs: [ build-release ]
+    strategy:
+      matrix:
+        include:
+          - id: linux/amd64
+            runner-arch: X64
+            artifact: linux_amd64
+          - id: linux/arm64
+            runner-arch: ARM64
+            artifact: linux_arm64
+
+    steps:
+
+      - name: Setup working directory
+        run: |
+          echo "DEBUG: Create working directory for workflow:"
+          mkdir "${GITHUB_WORKFLOW}-${GITHUB_RUN_ID}"
+          echo "DEBUG: Content of current directory $(pwd) :"
+          ls -lao
+          cd "${GITHUB_WORKFLOW}-${GITHUB_RUN_ID}"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Download artifact ${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }}.tar.gz
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }}.tar.gz
+          path: .
+
+      - name: Extract artifact ${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }}.tar.gz
+        run: |
+          pwd
+          ls -l ${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }}.tar.gz
+          tar xzvf ${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }}.tar.gz
+          ls -lR
+
+      - name: Fast checkout git repository erigontech/erigon-qa
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 ## 4.1.7 release
+        with:
+          token: ${{ secrets.ORG_GITHUB_ERIGONTECH_ERIGON_QA_READ }}
+          repository: erigontech/erigon-qa
+          fetch-depth: 1
+          ref: main
+          path: erigon-qa
+
+      - name: Checkout QA Tests Repository & Install Requirements
+        run: |
+          cd ./erigon-qa/test_system
+          pwd
+          ls -lao
+          pip3 install -r requirements.txt   
+          ln -s $(pwd)/base_library $(pwd)/qa-tests/tip-tracking/base_library
+          echo "DEBUG -- content of directory $(pwd) :"
+          ls -l
+          echo "DEBUG -- content of directory $(pwd)/qa-tests/tip-tracking/"
+          ls -l $(pwd)/qa-tests/tip-tracking/
+          echo "DEBUG -- content of directory GITHUB_WORKSPACE ${GITHUB_WORKSPACE} :"
+          ls -l ${GITHUB_WORKSPACE}
+          echo "DEBUG -- end."
+          rm -rf ${RUNNER_WORKSPACE}/erigon-data || true
+          mkdir ${RUNNER_WORKSPACE}/erigon-data
+          # Run Erigon, wait sync and check ability to maintain sync
+          python3 qa-tests/tip-tracking/run_and_check_tip_tracking.py \
+            ${GITHUB_WORKSPACE}/${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }} \
+              ${RUNNER_WORKSPACE}/erigon-data ${{ env.TEST_TRACKING_TIME_SECONDS }} ${{ env.TEST_TOTAL_TIME_SECONDS }} ${{ env.APPLICATION_VERSION }} ${{ env.TEST_CHAIN }}
+          # Capture monitoring script exit status
+          test_exit_status=$?
+          # Save the subsection reached status
+          echo "::set-output name=test_executed::true"
+          # Check test runner script exit status
+          if [ $test_exit_status -eq 0 ]; then
+            echo "Tests completed successfully"
+            echo "TEST_RESULT=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "Error detected during tests"
+            echo "TEST_RESULT=failure" >> "$GITHUB_OUTPUT"
+          fi
+
+
   build-debian-pkg:
     name: Debian packages
-    needs: [ build-release ]
+    needs: [ build-release, test-release ]
     uses: erigontech/erigon/.github/workflows/reusable-release-build-debian-pkg.yml@main
     with:
       application: ${{ needs.build-release.outputs.application }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ run-name: Build release ${{ inputs.release_version}} from branch ${{ inputs.chec
 
 env:
   APPLICATION: "erigon"
+  APPLICATION_VERSION: "Erigon3"
   BUILDER_IMAGE: "golang:1.22-bookworm"
   DOCKER_BASE_IMAGE: "debian:12.8-slim"
   APP_REPO: "erigontech/erigon"
@@ -210,13 +211,8 @@ jobs:
 
     steps:
 
-      - name: Setup working directory
-        run: |
-          echo "DEBUG: Create working directory for workflow:"
-          mkdir "workflow-${GITHUB_WORKFLOW}-run-${GITHUB_RUN_NUMBER}"
-          echo "DEBUG: Content of current directory $(pwd) :"
-          ls -lao
-          cd "workflow-${GITHUB_WORKFLOW}-run-${GITHUB_RUN_NUMBER}"
+      - name: Cleanup working directory
+        run: rm -drfv *
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -227,28 +223,24 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }}.tar.gz
-          path: ./workflow-${{ github.workflow }}-run-${{ github.run_number }}/
+          path: .
 
       - name: Extract artifact ${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }}.tar.gz
-        working-directory: "workflow-${{ github.workflow }}-run-${{ github.run_number }}"
         run: |
           pwd
           ls -l ${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }}.tar.gz
           tar xzvf ${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }}.tar.gz
           ls -lR
-
       - name: Fast checkout git repository erigontech/erigon-qa
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 ## 4.1.7 release
         with:
-          working-directory: "workflow-${{ github.workflow }}-run-${{ github.run_number }}"
           token: ${{ secrets.ORG_GITHUB_ERIGONTECH_ERIGON_QA_READ }}
           repository: erigontech/erigon-qa
           fetch-depth: 1
           ref: main
-          path: workflow-${{ github.workflow }}-run-${{ github.run_number }}/erigon-qa
+          path: erigon-qa
 
       - name: Checkout QA Tests Repository & Install Requirements
-        working-directory: "workflow-${{ github.workflow }}-run-${{ github.run_number }}"
         run: |
           cd ./erigon-qa/test_system
           pwd
@@ -259,16 +251,15 @@ jobs:
           ls -l
           echo "DEBUG -- content of directory $(pwd)/qa-tests/tip-tracking/"
           ls -l $(pwd)/qa-tests/tip-tracking/
-          echo "DEBUG -- content of directory current dir:"
-          ls -l .
+          echo "DEBUG -- content of directory GITHUB_WORKSPACE ${GITHUB_WORKSPACE} :"
+          ls -l ${GITHUB_WORKSPACE}
           echo "DEBUG -- end."
-          rm -rf ../../erigon-data || true
-          mkdir ../../erigon-data
+          rm -rf ${RUNNER_WORKSPACE}/erigon-data || true
+          mkdir ${RUNNER_WORKSPACE}/erigon-data
           # Run Erigon, wait sync and check ability to maintain sync
-          find ../.. -ls
           python3 qa-tests/tip-tracking/run_and_check_tip_tracking.py \
-            ../../${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }} \
-              ../../erigon-data ${{ env.TEST_TRACKING_TIME_SECONDS }} ${{ env.TEST_TOTAL_TIME_SECONDS }} ${{ env.APPLICATION_VERSION }} ${{ env.TEST_CHAIN }}
+            ${GITHUB_WORKSPACE}/${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }} \
+              ${RUNNER_WORKSPACE}/erigon-data ${{ env.TEST_TRACKING_TIME_SECONDS }} ${{ env.TEST_TOTAL_TIME_SECONDS }} ${{ env.APPLICATION_VERSION }} ${{ env.TEST_CHAIN }}
           # Capture monitoring script exit status
           test_exit_status=$?
           # Save the subsection reached status
@@ -282,6 +273,8 @@ jobs:
             echo "TEST_RESULT=failure" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Cleanup working directory
+        run: rm -drfv *
 
   build-debian-pkg:
     name: Debian packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -428,7 +428,7 @@ jobs:
 
   In-case-of-failure:
     name: "In case of failure: remove remote git tag pointing to the new version."
-    needs: [ publish-release, build-release ]
+    needs: [ publish-release, build-release, test-release ]
     if: always() && !contains(needs.build-release.result, 'success')
     runs-on: ubuntu-22.04
 


### PR DESCRIPTION
This change add extra job which may take ~8-10h for each release process.
The extra job performs tests for freshly built binaries for amd64 and arm64.
Note, binary for amd64v2 does not configured for such tests due to lack of runners/time.

Thanks @mriccobene for support 👍 

Requested in https://github.com/erigontech/devops-metarepo-for-issues/issues/15