### PR TITLE
Fix typos in metric names

### DIFF
--- a/erigon-lib/kv/Readme.md
+++ b/erigon-lib/kv/Readme.md
@@ -1,4 +1,4 @@
-# `Ethdb` package hold's bouquet of objects to access DB
+# `Ethdb` package holds bouquet of objects to access DB
 
 Words "KV" and "DB" have special meaning here:
 

--- a/erigon-lib/kv/kv_interface.go
+++ b/erigon-lib/kv/kv_interface.go
@@ -133,9 +133,9 @@ var (
 	//DbGcWorkPnlMergeTime   = metrics.GetOrCreateSummary(`db_gc_pnl_seconds{phase="work_merge_time"}`) //nolint
 	//DbGcWorkPnlMergeVolume = metrics.NewCounter(`db_gc_pnl{phase="work_merge_volume"}`)               //nolint
 	//DbGcWorkPnlMergeCalls  = metrics.NewCounter(`db_gc{phase="work_merge_calls"}`)                    //nolint
-	//DbGcSelfPnlMergeTime   = metrics.GetOrCreateSummary(`db_gc_pnl_seconds{phase="slef_merge_time"}`) //nolint
+	//DbGcSelfPnlMergeTime   = metrics.GetOrCreateSummary(`db_gc_pnl_seconds{phase="self_merge_time"}`) //nolint
 	//DbGcSelfPnlMergeVolume = metrics.NewCounter(`db_gc_pnl{phase="self_merge_volume"}`)               //nolint
-	//DbGcSelfPnlMergeCalls  = metrics.NewCounter(`db_gc_pnl{phase="slef_merge_calls"}`)                //nolint
+	//DbGcSelfPnlMergeCalls  = metrics.NewCounter(`db_gc_pnl{phase="self_merge_calls"}`)                //nolint
 
 	GcLeafMetric     = metrics.GetOrCreateGauge(`db_gc_leaf`)     //nolint
 	GcOverflowMetric = metrics.GetOrCreateGauge(`db_gc_overflow`) //nolint


### PR DESCRIPTION


## Changes Made
In `erigon-lib/kv/kv_interface.go`:
- Changed `"slef_merge_calls"` -> `"self_merge_calls"`
- Changed `"slef_merge_time"` -> `"self_merge_time"`

## Why
Fixed typos in commented metrics to maintain code clarity and avoid confusion if metrics are enabled in future. Changed "slef" to correct spelling "self" to properly reflect metric's purpose.

## Files Changed
- erigon-lib/kv/kv_interface.go