### PR TITLE
Caplin: use sentinel default UDP address 0.0.0.0

### DIFF
--- a/cl/sentinel/sentinel.go
+++ b/cl/sentinel/sentinel.go
@@ -152,7 +152,8 @@ func (s *Sentinel) createListener() (*discover.UDPv5, error) {
 		return nil, fmt.Errorf("bad ip address provided, %s was provided", ipAddr)
 	}
 
-	bindIP, networkVersion := net.IPv4(127, 0, 0, 1), "udp4"
+	var bindIP net.IP
+	var networkVersion string
 	// If the IP is an IPv4 address, bind to the correct zero address.
 	if ip.To4() != nil {
 		bindIP, networkVersion = ip.To4(), "udp4"

--- a/cl/sentinel/sentinel.go
+++ b/cl/sentinel/sentinel.go
@@ -172,11 +172,13 @@ func (s *Sentinel) createListener() (*discover.UDPv5, error) {
 	if err != nil {
 		return nil, err
 	}
+	s.logger.Info("[Sentinel] Listening for UDP packets", "at", udpAddr.String())
 
 	localNode, err := s.createLocalNode(discCfg.PrivateKey, ip, port, int(s.cfg.TCPPort), s.cfg.TmpDir)
 	if err != nil {
 		return nil, err
 	}
+	s.logger.Info("[Sentinel] Listening for TCP packets", "addr", ip, "port", s.cfg.TCPPort)
 
 	// Start stream handlers
 

--- a/cl/sentinel/sentinel.go
+++ b/cl/sentinel/sentinel.go
@@ -157,10 +157,12 @@ func (s *Sentinel) createListener() (*discover.UDPv5, error) {
 
 	// If the IP is an IPv4 address, bind to the correct zero address.
 	if ip.To4() != nil {
-		bindIP = net.IPv4zero
+		// bindIP = net.IPv4zero
+		bindIP = ip.To4()
 		networkVersion = "udp4"
 	} else {
-		bindIP = net.IPv6zero
+		// bindIP = net.IPv6zero
+		bindIP = ip.To16()
 		networkVersion = "udp6"
 	}
 
@@ -178,7 +180,6 @@ func (s *Sentinel) createListener() (*discover.UDPv5, error) {
 	if err != nil {
 		return nil, err
 	}
-	s.logger.Info("[Sentinel] Listening for TCP packets", "addr", ip, "port", s.cfg.TCPPort)
 
 	// Start stream handlers
 
@@ -186,6 +187,8 @@ func (s *Sentinel) createListener() (*discover.UDPv5, error) {
 	if err != nil {
 		return nil, err
 	}
+	s.logger.Info("[Sentinel] Listening for TCP packets", "addr", net.Self().String())
+
 	handlers.NewConsensusHandlers(s.ctx, s.blockReader, s.indiciesDB, s.host, s.peers, s.cfg.NetworkConfig, localNode, s.cfg.BeaconConfig, s.ethClock, s.handshaker, s.forkChoiceReader, s.blobStorage, s.cfg.EnableBlocks).Start()
 
 	return net, err

--- a/cl/sentinel/sentinel.go
+++ b/cl/sentinel/sentinel.go
@@ -185,6 +185,7 @@ func (s *Sentinel) createListener() (*discover.UDPv5, error) {
 
 	net, err := discover.ListenV5(s.ctx, "any", conn, localNode, discCfg)
 	if err != nil {
+		s.logger.Error("[Sentinel] failed Listening for TCP packets", "err", err)
 		return nil, err
 	}
 	s.logger.Info("[Sentinel] Listening for TCP packets", "addr", net.Self().String())

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -819,7 +819,7 @@ var (
 	CaplinDiscoveryAddrFlag = cli.StringFlag{
 		Name:  "caplin.discovery.addr",
 		Usage: "Address for Caplin DISCV5 protocol",
-		Value: "127.0.0.1",
+		Value: "0.0.0.0",
 	}
 	CaplinDiscoveryPortFlag = cli.Uint64Flag{
 		Name:  "caplin.discovery.port",


### PR DESCRIPTION
Caplin's sentinel opens UDP port controlled by flag `--caplin.discovery.port` we open it at `0.0.0.0` ignoring another flag `--caplin.discovery.addr` which is `127.0.0.1`. TCP port opened correctly with respect of `.addr`.

PR fixes default behavior.