### PR TITLE
core: fix header copy race

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -1095,24 +1095,37 @@ func NewBlockFromNetwork(header *Header, body *Body) *Block {
 // CopyHeader creates a deep copy of a block header to prevent side effects from
 // modifying a header variable.
 func CopyHeader(h *Header) *Header {
-	cpy := *h //nolint
+	cpy := Header{} // note: do not copy hash atomic.Pointer
+	cpy.ParentHash = h.ParentHash
+	cpy.UncleHash = h.UncleHash
+	cpy.Coinbase = h.Coinbase
+	cpy.Root = h.Root
+	cpy.TxHash = h.TxHash
+	cpy.ReceiptHash = h.ReceiptHash
+	cpy.Bloom = h.Bloom
 	if cpy.Difficulty = new(big.Int); h.Difficulty != nil {
 		cpy.Difficulty.Set(h.Difficulty)
 	}
 	if cpy.Number = new(big.Int); h.Number != nil {
 		cpy.Number.Set(h.Number)
 	}
-	if h.BaseFee != nil {
-		cpy.BaseFee = new(big.Int)
-		cpy.BaseFee.Set(h.BaseFee)
-	}
+	cpy.GasLimit = h.GasLimit
+	cpy.GasUsed = h.GasUsed
+	cpy.Time = h.Time
 	if len(h.Extra) > 0 {
 		cpy.Extra = make([]byte, len(h.Extra))
 		copy(cpy.Extra, h.Extra)
 	}
+	cpy.MixDigest = h.MixDigest
+	cpy.Nonce = h.Nonce
+	cpy.AuRaStep = h.AuRaStep
 	if len(h.AuRaSeal) > 0 {
 		cpy.AuRaSeal = make([]byte, len(h.AuRaSeal))
 		copy(cpy.AuRaSeal, h.AuRaSeal)
+	}
+	if h.BaseFee != nil {
+		cpy.BaseFee = new(big.Int)
+		cpy.BaseFee.Set(h.BaseFee)
 	}
 	if h.WithdrawalsHash != nil {
 		cpy.WithdrawalsHash = new(libcommon.Hash)
@@ -1133,6 +1146,15 @@ func CopyHeader(h *Header) *Header {
 	if h.RequestsHash != nil {
 		cpy.RequestsHash = new(libcommon.Hash)
 		cpy.RequestsHash.SetBytes(h.RequestsHash.Bytes())
+	}
+	cpy.Verkle = h.Verkle
+	if len(h.VerkleProof) > 0 {
+		cpy.VerkleProof = make([]byte, len(h.VerkleProof))
+		copy(cpy.VerkleProof, h.VerkleProof)
+	}
+	if len(h.VerkleKeyVals) > 0 {
+		cpy.VerkleKeyVals = make([]verkle.KeyValuePair, len(h.VerkleKeyVals))
+		copy(cpy.VerkleKeyVals, h.VerkleKeyVals)
 	}
 	cpy.mutable = h.mutable
 	if hash := h.hash.Load(); hash != nil {

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -1112,14 +1112,14 @@ func CopyHeader(h *Header) *Header {
 	cpy.GasLimit = h.GasLimit
 	cpy.GasUsed = h.GasUsed
 	cpy.Time = h.Time
-	if len(h.Extra) > 0 {
+	if h.Extra != nil {
 		cpy.Extra = make([]byte, len(h.Extra))
 		copy(cpy.Extra, h.Extra)
 	}
 	cpy.MixDigest = h.MixDigest
 	cpy.Nonce = h.Nonce
 	cpy.AuRaStep = h.AuRaStep
-	if len(h.AuRaSeal) > 0 {
+	if h.AuRaSeal != nil {
 		cpy.AuRaSeal = make([]byte, len(h.AuRaSeal))
 		copy(cpy.AuRaSeal, h.AuRaSeal)
 	}
@@ -1148,11 +1148,11 @@ func CopyHeader(h *Header) *Header {
 		cpy.RequestsHash.SetBytes(h.RequestsHash.Bytes())
 	}
 	cpy.Verkle = h.Verkle
-	if len(h.VerkleProof) > 0 {
+	if h.VerkleProof != nil {
 		cpy.VerkleProof = make([]byte, len(h.VerkleProof))
 		copy(cpy.VerkleProof, h.VerkleProof)
 	}
-	if len(h.VerkleKeyVals) > 0 {
+	if h.VerkleKeyVals != nil {
 		cpy.VerkleKeyVals = make([]verkle.KeyValuePair, len(h.VerkleKeyVals))
 		copy(cpy.VerkleKeyVals, h.VerkleKeyVals)
 	}

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -613,7 +613,7 @@ func TestCopyHeader(t *testing.T) {
 	const runCount = 1000
 	tr := NewTRand()
 	for range make([]byte, runCount) {
-		h1 := tr.RandHeader()
+		h1 := tr.RandHeaderReflectAllFields()
 		h2 := CopyHeader(h1)
 		require.Equal(t, h1, h2)
 	}

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -608,8 +608,8 @@ func TestCopyTxs(t *testing.T) {
 }
 
 func TestCopyHeader(t *testing.T) {
-	// please update copy function to include new attribute
 	// if this test fails when adding a new attribute to the Header struct
+	// please update the copy function to include logic for the new attribute
 	const runCount = 1000
 	tr := NewTRand()
 	for range make([]byte, runCount) {

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -606,3 +606,15 @@ func TestCopyTxs(t *testing.T) {
 	copies := CopyTxs(txs)
 	assert.Equal(t, txs, copies)
 }
+
+func TestCopyHeader(t *testing.T) {
+	// please update copy function to include new attribute
+	// if this test fails when adding a new attribute to the Header struct
+	const runCount = 1000
+	tr := NewTRand()
+	for range make([]byte, runCount) {
+		h1 := tr.RandHeader()
+		h2 := CopyHeader(h1)
+		require.Equal(t, h1, h2)
+	}
+}

--- a/core/types/encdec_test.go
+++ b/core/types/encdec_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gballet/go-verkle"
 	"github.com/holiman/uint256"
 
 	libcommon "github.com/erigontech/erigon-lib/common"
@@ -77,8 +78,27 @@ func (tr *TRand) RandHash() libcommon.Hash {
 	return libcommon.Hash(tr.RandBytes(32))
 }
 
+func (tr *TRand) RandBoolean() bool {
+	return tr.rnd.Intn(2) == 0
+}
+
 func (tr *TRand) RandBloom() Bloom {
 	return Bloom(tr.RandBytes(BloomByteLength))
+}
+
+func (tr *TRand) RandVerkleKeyValuePairs(count int) []verkle.KeyValuePair {
+	res := make([]verkle.KeyValuePair, count)
+	for i := 0; i < count; i++ {
+		res[i] = tr.RandVerkleKeyValuePair()
+	}
+	return res
+}
+
+func (tr *TRand) RandVerkleKeyValuePair() verkle.KeyValuePair {
+	return verkle.KeyValuePair{
+		Key:   tr.RandBytes(tr.RandIntInRange(1, 32)),
+		Value: tr.RandBytes(tr.RandIntInRange(1, 32)),
+	}
 }
 
 func (tr *TRand) RandWithdrawal() *Withdrawal {
@@ -115,6 +135,60 @@ func (tr *TRand) RandHeader() *Header {
 		ExcessBlobGas:         tr.RandUint64(),                            // *uint64
 		ParentBeaconBlockRoot: &pHash,                                     //*libcommon.Hash
 	}
+}
+
+func (tr *TRand) RandHeaderReflectAllFields(skipFields ...string) *Header {
+	skipSet := make(map[string]struct{}, len(skipFields))
+	for _, field := range skipFields {
+		skipSet[field] = struct{}{}
+	}
+
+	emptyUint64 := uint64(0)
+	h := &Header{}
+	// note unexported fields are skipped in reflection auto-assign as they are not assignable
+	h.mutable = tr.RandBoolean()
+	headerValue := reflect.ValueOf(h)
+	headerElem := headerValue.Elem()
+	numField := headerElem.Type().NumField()
+	for i := 0; i < numField; i++ {
+		field := headerElem.Field(i)
+		if !field.CanSet() {
+			continue
+		}
+
+		if _, skip := skipSet[headerElem.Type().Field(i).Name]; skip {
+			continue
+		}
+
+		switch field.Type() {
+		case reflect.TypeOf(libcommon.Hash{}):
+			field.Set(reflect.ValueOf(tr.RandHash()))
+		case reflect.TypeOf(&libcommon.Hash{}):
+			randHash := tr.RandHash()
+			field.Set(reflect.ValueOf(&randHash))
+		case reflect.TypeOf(libcommon.Address{}):
+			field.Set(reflect.ValueOf(tr.RandAddress()))
+		case reflect.TypeOf(Bloom{}):
+			field.Set(reflect.ValueOf(tr.RandBloom()))
+		case reflect.TypeOf(BlockNonce{}):
+			field.Set(reflect.ValueOf(BlockNonce(tr.RandBytes(8))))
+		case reflect.TypeOf(&big.Int{}):
+			field.Set(reflect.ValueOf(tr.RandBig()))
+		case reflect.TypeOf(uint64(0)):
+			field.Set(reflect.ValueOf(*tr.RandUint64()))
+		case reflect.TypeOf(&emptyUint64):
+			field.Set(reflect.ValueOf(tr.RandUint64()))
+		case reflect.TypeOf([]byte{}):
+			field.Set(reflect.ValueOf(tr.RandBytes(tr.RandIntInRange(128, 1024))))
+		case reflect.TypeOf(false):
+			field.Set(reflect.ValueOf(tr.RandBoolean()))
+		case reflect.TypeOf([]verkle.KeyValuePair{}):
+			field.Set(reflect.ValueOf(tr.RandVerkleKeyValuePairs(tr.RandIntInRange(1, 3))))
+		default:
+			panic(fmt.Sprintf("don't know how to generate rand value for Header field type %v - please add handler", field.Type()))
+		}
+	}
+	return h
 }
 
 func (tr *TRand) RandAccessTuple() AccessTuple {


### PR DESCRIPTION
relates to https://github.com/erigontech/erigon/pull/13480
fully fixes https://github.com/erigontech/erigon/issues/13474

Seems like `Header.hash` memoization changes from a few months ago have made `Block.Header()` (which makes a copy by calling `CopyHeader`) show race warnings. This is because we are copying over `atomic.Pointer` in `CopyHeader`.  

This PR fixes this by manually copy-ing all fields and skipping copy of the `hash atomic.Pointer` attribute (instead it will get set using its zero value - correct behaviour) and then the hash will be memoized using it as part of the copy later on.

This is a bit clumsier as we can miss updating the `CopyHeader` function when adding new attributes to the `Header` struct - to address that I've added a reflection based test which will generate random values for all struct fields and as a result capture this pitfall and remind developers to update.

Example race detected:
```
==================
WARNING: DATA RACE
Read at 0x00c03acc0838 by goroutine 26498:
  github.com/erigontech/erigon/core/types.CopyHeader()
      /home/ubuntu/erigon/core/types/block.go:1098 +0x5c
  github.com/erigontech/erigon/core/types.(*Block).Header()
      /home/ubuntu/erigon/core/types/block.go:1278 +0x54
  github.com/erigontech/erigon/turbo/execution/eth1/eth1_utils.ConvertBlockToRPC()
      /home/ubuntu/erigon/turbo/execution/eth1/eth1_utils/grpc.go:108 +0x55
  github.com/erigontech/erigon/turbo/execution/eth1/eth1_utils.ConvertBlocksToRPC()
      /home/ubuntu/erigon/turbo/execution/eth1/eth1_utils/grpc.go:102 +0xc4
  github.com/erigontech/erigon/polygon/sync.(*executionClient).InsertBlocks()
      /home/ubuntu/erigon/polygon/sync/execution_client.go:71 +0x4f
  github.com/erigontech/erigon/polygon/sync.(*ExecutionClientStore).insertBlocks()
      /home/ubuntu/erigon/polygon/sync/store.go:162 +0x14f
  github.com/erigontech/erigon/polygon/sync.(*ExecutionClientStore).Run()
      /home/ubuntu/erigon/polygon/sync/store.go:143 +0x1ab
  github.com/erigontech/erigon/polygon/sync.(*Service).Run.func2()
      /home/ubuntu/erigon/polygon/sync/service.go:125 +0x69
  golang.org/x/sync/errgroup.(*Group).Go.func1()
==================
```