### PR TITLE
optimize FindMergeRange

### DIFF
--- a/turbo/snapshotsync/merger.go
+++ b/turbo/snapshotsync/merger.go
@@ -39,7 +39,7 @@ func (m *Merger) FindMergeRanges(currentRanges []Range, maxBlockNum uint64) (toM
 	cfg := snapcfg.KnownCfg(m.chainConfig.ChainName)
 	for i := len(currentRanges) - 1; i > 0; i-- {
 		r := currentRanges[i]
-		mergeLimit := snapcfg.MergeLimitFromCfg(cfg, snaptype.Unknown, r.From())
+		mergeLimit := cfg.MergeLimit(snaptype.Unknown, r.From())
 		if r.To()-r.From() >= mergeLimit {
 			continue
 		}


### PR DESCRIPTION
Now it does too much allocs because often parsing file names of `.Preverified` immutable list: 
<img width="892" alt="Screenshot 2025-01-18 at 12 15 55" src="https://github.com/user-attachments/assets/a01f8891-7ef6-4c97-9ed6-f037b8db9cf0" />

I don't want to make more complex changes before `beta1` release - so small memoization is enough. 