### PR TITLE
[UX] Print only recent forks in chain config

### DIFF
--- a/erigon-lib/chain/chain_config.go
+++ b/erigon-lib/chain/chain_config.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math/big"
 	"strconv"
+	"time"
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/fixedgas"
@@ -106,35 +107,36 @@ type BorConfig interface {
 	IsNapoli(num uint64) bool
 	GetNapoliBlock() *big.Int
 	IsAhmedabad(number uint64) bool
+	GeAhmedabadBlock() *big.Int
 	StateReceiverContractAddress() common.Address
 	CalculateSprintNumber(number uint64) uint64
 	CalculateSprintLength(number uint64) uint64
 }
 
+func timestampToTime(unixTime *big.Int) *time.Time {
+	if unixTime == nil {
+		return nil
+	}
+	t := time.Unix(unixTime.Int64(), 0).UTC()
+	return &t
+}
+
 func (c *Config) String() string {
 	engine := c.getEngine()
 
-	return fmt.Sprintf("{ChainID: %v, Homestead: %v, DAO: %v, Tangerine Whistle: %v, Spurious Dragon: %v, Byzantium: %v, Constantinople: %v, Petersburg: %v, Istanbul: %v, Muir Glacier: %v, Berlin: %v, London: %v, Arrow Glacier: %v, Gray Glacier: %v, Terminal Total Difficulty: %v, Merge Netsplit: %v, Shanghai: %v, Cancun: %v, Prague: %v, Osaka: %v, Engine: %v}",
+	if c.Bor != nil {
+		return fmt.Sprintf("{ChainID: %v, Napoli: %v, Ahmedabad: %v, Engine: %v}",
+			c.ChainID,
+			c.Bor.GetNapoliBlock(),
+			c.Bor.GeAhmedabadBlock(),
+			engine,
+		)
+	}
+
+	return fmt.Sprintf("{ChainID: %v, Cancun: %v, Prague: %v, Engine: %v}",
 		c.ChainID,
-		c.HomesteadBlock,
-		c.DAOForkBlock,
-		c.TangerineWhistleBlock,
-		c.SpuriousDragonBlock,
-		c.ByzantiumBlock,
-		c.ConstantinopleBlock,
-		c.PetersburgBlock,
-		c.IstanbulBlock,
-		c.MuirGlacierBlock,
-		c.BerlinBlock,
-		c.LondonBlock,
-		c.ArrowGlacierBlock,
-		c.GrayGlacierBlock,
-		c.TerminalTotalDifficulty,
-		c.MergeNetsplitBlock,
-		c.ShanghaiTime,
-		c.CancunTime,
-		c.PragueTime,
-		c.OsakaTime,
+		timestampToTime(c.CancunTime),
+		timestampToTime(c.PragueTime),
 		engine,
 	)
 }

--- a/erigon-lib/chain/chain_config.go
+++ b/erigon-lib/chain/chain_config.go
@@ -133,7 +133,7 @@ func (c *Config) String() string {
 		)
 	}
 
-	return fmt.Sprintf("{ChainID: %v, Cancun: %v, Prague: %v, Engine: %v}",
+	return fmt.Sprintf("{ChainID: %v, Dencun: %v, Pectra: %v, Engine: %v}",
 		c.ChainID,
 		timestampToTime(c.CancunTime),
 		timestampToTime(c.PragueTime),

--- a/erigon-lib/chain/chain_config.go
+++ b/erigon-lib/chain/chain_config.go
@@ -125,18 +125,22 @@ func (c *Config) String() string {
 	engine := c.getEngine()
 
 	if c.Bor != nil {
-		return fmt.Sprintf("{ChainID: %v, Napoli: %v, Ahmedabad: %v, Engine: %v}",
+		return fmt.Sprintf("{ChainID: %v, Agra: %v, Napoli: %v, Ahmedabad: %v, Engine: %v}",
 			c.ChainID,
+			c.Bor.GetAgraBlock(),
 			c.Bor.GetNapoliBlock(),
 			c.Bor.GeAhmedabadBlock(),
 			engine,
 		)
 	}
 
-	return fmt.Sprintf("{ChainID: %v, Dencun: %v, Pectra: %v, Engine: %v}",
+	return fmt.Sprintf("{ChainID: %v, Terminal Total Difficulty: %v, Shapella: %v, Dencun: %v, Pectra: %v, Fusaka: %v, Engine: %v}",
 		c.ChainID,
+		c.TerminalTotalDifficulty,
+		timestampToTime(c.ShanghaiTime),
 		timestampToTime(c.CancunTime),
 		timestampToTime(c.PragueTime),
+		timestampToTime(c.OsakaTime),
 		engine,
 	)
 }

--- a/polygon/bor/borcfg/bor_config.go
+++ b/polygon/bor/borcfg/bor_config.go
@@ -156,12 +156,16 @@ func (c *BorConfig) IsNapoli(num uint64) bool {
 	return isForked(c.NapoliBlock, num)
 }
 
+func (c *BorConfig) GetNapoliBlock() *big.Int {
+	return c.NapoliBlock
+}
+
 func (c *BorConfig) IsAhmedabad(number uint64) bool {
 	return isForked(c.AhmedabadBlock, number)
 }
 
-func (c *BorConfig) GetNapoliBlock() *big.Int {
-	return c.NapoliBlock
+func (c *BorConfig) GeAhmedabadBlock() *big.Int {
+	return c.AhmedabadBlock
 }
 
 func (c *BorConfig) CalculateStateSyncDelay(number uint64) uint64 {


### PR DESCRIPTION
Print
`"{ChainID: 1, Terminal Total Difficulty: 58750000000000000000000, Shapella: 2023-04-12 22:27:35 +0000 UTC, Dencun: 2024-03-13 13:55:35 +0000 UTC, Pectra: <nil>, Fusaka: <nil>, Engine: ethash}"`
instead of 
`"{ChainID: 1, Homestead: 1150000, DAO:
 1920000, Tangerine Whistle: 2463000, Spurious Dragon: 2675000, Byzantium: 4370000, Constantinople: 7280000, Petersburg: 7280000, Istanbul: 9069000, Muir Glacier: 9200000, Berlin: 12244000, London: 12965000, Arrow Glacier: 13773
000, Gray Glacier: 15050000, Terminal Total Difficulty: 58750000000000000000000, Merge Netsplit: <nil>, Shanghai: 
1681338455, Cancun: 1710338135, Prague: <nil>, Osaka: <nil>, Engine: ethash}"`

Also print the last three forks for Polygon.