### PR TITLE
engineapi: fix req root mismatch upon `newPayload`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ define run_suite
     echo -e "\n\n============================================================"; \
     echo "Running test: $1-$2"; \
     echo -e "\n"; \
-    ./hive --sim ethereum/$1 --sim.limit=$2 --client erigon $3 2>&1 | tee output.log; \
+    ./hive --sim ethereum/$1 --sim.limit=$2 --sim.parallelism=8 --client erigon $3 2>&1 | tee output.log; \
     if [ $$? -gt 0 ]; then \
         echo "Exitcode gt 0"; \
     fi; \

--- a/turbo/engineapi/engine_server.go
+++ b/turbo/engineapi/engine_server.go
@@ -213,7 +213,7 @@ func (s *EngineServer) newPayload(ctx context.Context, req *engine_types.Executi
 			if len(r) <= 1 {
 				return nil, &rpc.InvalidParamsError{Message: fmt.Sprintf("Invalid Request at index %d", i)}
 			}
-			requests = append(requests, types.FlatRequest{Type: r[0], RequestData: r})
+			requests = append(requests, types.FlatRequest{Type: r[0], RequestData: r[1:]})
 		}
 		rh := requests.Hash()
 		header.RequestsHash = rh


### PR DESCRIPTION
Fix issues like header hash mismatch in hive tests for pectra-devnet-5
`RequestData` refers to the raw output from the various different requests contract, in the rest of the code