### PR TITLE
polygon/bridge: fix process new blocks gaps

### DIFF
--- a/cmd/devnet/services/polygon/heimdallsim/heimdall_simulator.go
+++ b/cmd/devnet/services/polygon/heimdallsim/heimdall_simulator.go
@@ -95,7 +95,7 @@ func (noopBridgeStore) PutEvents(ctx context.Context, events []*heimdall.EventRe
 func (noopBridgeStore) PutBlockNumToEventId(ctx context.Context, blockNumToEventId map[uint64]uint64) error {
 	return nil
 }
-func (noopBridgeStore) PutProcessedBlockInfo(ctx context.Context, info bridge.ProcessedBlockInfo) error {
+func (noopBridgeStore) PutProcessedBlockInfo(ctx context.Context, info []bridge.ProcessedBlockInfo) error {
 	return nil
 }
 func (noopBridgeStore) Unwind(ctx context.Context, blockNum uint64) error {

--- a/eth/stagedsync/stage_polygon_sync.go
+++ b/eth/stagedsync/stage_polygon_sync.go
@@ -1001,7 +1001,7 @@ func (s polygonSyncStageBridgeStore) LastProcessedBlockInfo(ctx context.Context)
 	return r.info, r.ok, r.err
 }
 
-func (s polygonSyncStageBridgeStore) PutProcessedBlockInfo(ctx context.Context, info bridge.ProcessedBlockInfo) error {
+func (s polygonSyncStageBridgeStore) PutProcessedBlockInfo(ctx context.Context, info []bridge.ProcessedBlockInfo) error {
 	type response struct {
 		err error
 	}

--- a/polygon/bridge/mdbx_store.go
+++ b/polygon/bridge/mdbx_store.go
@@ -127,7 +127,7 @@ func (s *MdbxStore) LastProcessedBlockInfo(ctx context.Context) (ProcessedBlockI
 	return txStore{tx}.LastProcessedBlockInfo(ctx)
 }
 
-func (s *MdbxStore) PutProcessedBlockInfo(ctx context.Context, info ProcessedBlockInfo) error {
+func (s *MdbxStore) PutProcessedBlockInfo(ctx context.Context, info []ProcessedBlockInfo) error {
 	tx, err := s.db.BeginRw(ctx)
 	if err != nil {
 		return err
@@ -418,14 +418,19 @@ func (s txStore) LastProcessedBlockInfo(ctx context.Context) (ProcessedBlockInfo
 	return info, true, nil
 }
 
-func (s txStore) PutProcessedBlockInfo(ctx context.Context, info ProcessedBlockInfo) error {
+func (s txStore) PutProcessedBlockInfo(ctx context.Context, info []ProcessedBlockInfo) error {
 	tx, ok := s.tx.(kv.RwTx)
-
 	if !ok {
 		return errors.New("expected RW tx")
 	}
 
-	return putProcessedBlockInfo(tx, info)
+	for _, i := range info {
+		if err := putProcessedBlockInfo(tx, i); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (s txStore) LastFrozenEventBlockNum() uint64 {

--- a/polygon/bridge/service.go
+++ b/polygon/bridge/service.go
@@ -418,7 +418,7 @@ func (s *Service) Synchronize(ctx context.Context, blockNum uint64) error {
 // Unwind delete unwindable bridge data.
 // The blockNum parameter is exclusive, i.e. only data in the range (blockNum, last] is deleted.
 func (s *Service) Unwind(ctx context.Context, blockNum uint64) error {
-	s.logger.Debug(bridgeLogPrefix("unwinding"), "blockNum", blockNum)
+	s.logger.Info(bridgeLogPrefix("unwinding"), "blockNum", blockNum)
 
 	s.unwindMu.Lock()
 	defer s.unwindMu.Unlock()

--- a/polygon/bridge/service.go
+++ b/polygon/bridge/service.go
@@ -438,7 +438,12 @@ func (s *Service) Unwind(ctx context.Context, blockNum uint64) error {
 		return errors.New("no last processed block info after unwind")
 	}
 
-	s.logger.Debug(bridgeLogPrefix("last processed block after unwind"), "info", lastProcessedBlockInfo)
+	s.logger.Debug(
+		bridgeLogPrefix("last processed block after unwind"),
+		"blockNum", lastProcessedBlockInfo.BlockNum,
+		"blockTime", lastProcessedBlockInfo.BlockTime,
+	)
+
 	s.lastProcessedBlockInfo.Store(&lastProcessedBlockInfo)
 	return nil
 }

--- a/polygon/bridge/service.go
+++ b/polygon/bridge/service.go
@@ -280,7 +280,7 @@ func (s *Service) ReplayInitialBlock(ctx context.Context, block *types.Block) er
 	}
 
 	s.lastProcessedBlockInfo.Store(&lastProcessedBlockInfo)
-	return s.store.PutProcessedBlockInfo(ctx, lastProcessedBlockInfo)
+	return s.store.PutProcessedBlockInfo(ctx, []ProcessedBlockInfo{lastProcessedBlockInfo})
 }
 
 // ProcessNewBlocks iterates through all blocks and constructs a map from block number to sync events
@@ -304,6 +304,7 @@ func (s *Service) ProcessNewBlocks(ctx context.Context, blocks []*types.Block) e
 		return errors.New("lastProcessedBlockInfo must be set before bridge processing")
 	}
 
+	from := blocks[0].NumberU64()
 	s.logger.Debug(
 		bridgeLogPrefix("processing new blocks"),
 		"from", blocks[0].NumberU64(),
@@ -313,9 +314,9 @@ func (s *Service) ProcessNewBlocks(ctx context.Context, blocks []*types.Block) e
 		"lastProcessedEventId", lastProcessedEventId,
 	)
 
-	var processedBlock bool
 	blockNumToEventId := make(map[uint64]uint64)
 	eventTxnToBlockNum := make(map[libcommon.Hash]uint64)
+	processedBlocks := make([]ProcessedBlockInfo, 0, 1+len(blocks)/int(s.borConfig.CalculateSprintLength(from)))
 	for _, block := range blocks {
 		// check if block is start of span and > 0
 		blockNum := block.NumberU64()
@@ -371,14 +372,16 @@ func (s *Service) ProcessNewBlocks(ctx context.Context, blocks []*types.Block) e
 			blockNumToEventId[blockNum] = endId
 		}
 
-		processedBlock = true
 		lastProcessedBlockInfo = ProcessedBlockInfo{
 			BlockNum:  blockNum,
 			BlockTime: blockTime,
 		}
+
+		// keep track for updating at the end as a last step (once all other updates have successfully been applied)
+		processedBlocks = append(processedBlocks, lastProcessedBlockInfo)
 	}
 
-	if !processedBlock {
+	if len(processedBlocks) == 0 {
 		return nil
 	}
 
@@ -390,7 +393,7 @@ func (s *Service) ProcessNewBlocks(ctx context.Context, blocks []*types.Block) e
 		return err
 	}
 
-	if err := s.store.PutProcessedBlockInfo(ctx, lastProcessedBlockInfo); err != nil {
+	if err := s.store.PutProcessedBlockInfo(ctx, processedBlocks); err != nil {
 		return err
 	}
 
@@ -435,6 +438,7 @@ func (s *Service) Unwind(ctx context.Context, blockNum uint64) error {
 		return errors.New("no last processed block info after unwind")
 	}
 
+	s.logger.Debug(bridgeLogPrefix("last processed block after unwind"), "info", lastProcessedBlockInfo)
 	s.lastProcessedBlockInfo.Store(&lastProcessedBlockInfo)
 	return nil
 }

--- a/polygon/bridge/service.go
+++ b/polygon/bridge/service.go
@@ -307,7 +307,7 @@ func (s *Service) ProcessNewBlocks(ctx context.Context, blocks []*types.Block) e
 	from := blocks[0].NumberU64()
 	s.logger.Debug(
 		bridgeLogPrefix("processing new blocks"),
-		"from", blocks[0].NumberU64(),
+		"from", from,
 		"to", blocks[len(blocks)-1].NumberU64(),
 		"lastProcessedBlockNum", lastProcessedBlockInfo.BlockNum,
 		"lastProcessedBlockTime", lastProcessedBlockInfo.BlockTime,

--- a/polygon/bridge/store.go
+++ b/polygon/bridge/store.go
@@ -43,7 +43,7 @@ type Store interface {
 	PutEventTxnToBlockNum(ctx context.Context, eventTxnToBlockNum map[libcommon.Hash]uint64) error
 	PutEvents(ctx context.Context, events []*heimdall.EventRecordWithTime) error
 	PutBlockNumToEventId(ctx context.Context, blockNumToEventId map[uint64]uint64) error
-	PutProcessedBlockInfo(ctx context.Context, info ProcessedBlockInfo) error
+	PutProcessedBlockInfo(ctx context.Context, info []ProcessedBlockInfo) error
 
 	Unwind(ctx context.Context, blockNum uint64) error
 


### PR DESCRIPTION
fixes https://github.com/erigontech/erigon/issues/13493

Error:
`pos sync store failed: nonsequential block in bridge processing: 66842880 != 66842848"`

Happened because we were inserting `ProcessedBlockInfo` with gaps when processing a batch of blocks in `ProcessNewBlocks` that contain more than 1 sprint start block. We should always be inserting 1 `ProcessedBlockInfo` per sprint start block. In this particular case however, we were only inserting the last 1 - causing a gap in the table. This manifested itself as an error in rare situations when bridge unwinds happened due to change of forks.

This PR also adds some store flush and bridge synchronisation points that we've missed to avoid race conditions.
