### PR TITLE
In-memory hashsort for commitment keys

### DIFF
--- a/erigon-lib/commitment/commitment.go
+++ b/erigon-lib/commitment/commitment.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"math/bits"
+	"runtime"
 	"slices"
 	"sort"
 	"strings"
@@ -1139,7 +1140,7 @@ type keyWithHash struct {
 
 func hashKeysConcurrently(keys []string, hasher keyHasher) []*keyWithHash {
 	keysWithHash := make([]*keyWithHash, len(keys))
-	numWorkers := 8 // hardcoded for now
+	numWorkers := runtime.NumCPU()
 	// Split the keys slice into chunks and process in parallel.
 	chunkSize := (len(keys) + numWorkers - 1) / numWorkers
 	var wg sync.WaitGroup

--- a/erigon-lib/commitment/commitment.go
+++ b/erigon-lib/commitment/commitment.go
@@ -1142,7 +1142,7 @@ func hashKeysConcurrently(keys []string, hasher keyHasher) []*keyWithHash {
 	keysWithHash := make([]*keyWithHash, len(keys))
 	numWorkers := runtime.NumCPU()
 	// Split the keys slice into chunks and process in parallel.
-	chunkSize := (len(keys) + numWorkers - 1) / numWorkers
+	chunkSize := (len(keys) + numWorkers) / numWorkers
 	var wg sync.WaitGroup
 	for w := 0; w < numWorkers; w++ {
 		start := w * chunkSize

--- a/erigon-lib/commitment/hex_patricia_hashed_bench_test.go
+++ b/erigon-lib/commitment/hex_patricia_hashed_bench_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func buildUpdates(b *testing.B, mode Mode) (*MockState, *Updates, [][]byte, []Update) {
+	b.Helper()
 	keysCount := 4_000_000
 	// generate updates
 	b.Logf("keys count: %d", keysCount)


### PR DESCRIPTION
Currently both modes ModeDirect and ModeUpdate use ETL for sorting plainkeys by hash as a preprocessing step before processing commitment updates. This PR introduces a new mode : ModeInMemory which sorts plainkeys by their hash in-memory using  `slices.SortFunc` . 

Prior to sorting, the keys are hashed concurrently by a number of worker goroutines. With the concurrent hashing the benchmark tests yield  neck-to-neck performance results compared to ModeDirect, with ModeInMemory sometimes faster.
