### PR TITLE
revert SafeNoSync

### DIFF
--- a/p2p/enode/nodedb.go
+++ b/p2p/enode/nodedb.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/c2h5oh/datasize"
 	"github.com/erigontech/erigon-lib/log/v3"
+	mdbx1 "github.com/erigontech/mdbx-go/mdbx"
 
 	"github.com/erigontech/erigon-lib/kv"
 	"github.com/erigontech/erigon-lib/kv/mdbx"
@@ -122,6 +123,8 @@ func newPersistentDB(ctx context.Context, logger log.Logger, path string) (*DB, 
 		WithTableCfg(bucketsConfig).
 		MapSize(8 * datasize.GB).
 		GrowthStep(16 * datasize.MB).
+		Flags(func(f uint) uint { return f ^ mdbx1.Durable | mdbx1.SafeNoSync }).
+		SyncPeriod(2 * time.Second).
 		DirtySpace(uint64(64 * datasize.MB)).
 		Open(ctx)
 	if err != nil {


### PR DESCRIPTION

Discussion in:
https://github.com/erigontech/erigon/issues/13457

This PR brings back SafeNoSync from v2.60.10 to prevent DB from being congested and slowdown.