### PR TITLE
txpool: addRemoteTxs broadcast - missed some txs

### DIFF
--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -508,13 +508,24 @@ func (p *TxPool) processRemoteTxns(ctx context.Context) (err error) {
 		return err
 	}
 
-	announcements, _, err := p.addTxns(p.lastSeenBlock.Load(), cacheView, p.senders, newTxns,
+	announcements, reasons, err := p.addTxns(p.lastSeenBlock.Load(), cacheView, p.senders, newTxns,
 		p.pendingBaseFee.Load(), p.pendingBlobFee.Load(), p.blockGasLimit.Load(), true, p.logger)
 	if err != nil {
 		return err
 	}
 	p.promoted.Reset()
 	p.promoted.AppendOther(announcements)
+
+	reasons = fillDiscardReasons(reasons, newTxns, p.discardReasonsLRU)
+	for i, reason := range reasons {
+		if reason == txpoolcfg.Success {
+			txn := newTxns.Txns[i]
+			if txn.Traced {
+				p.logger.Info(fmt.Sprintf("TX TRACING: processRemoteTxns promotes idHash=%x, senderId=%d", txn.IDHash, txn.SenderID))
+			}
+			p.promoted.Append(txn.Type, txn.Size, txn.IDHash[:])
+		}
+	}
 
 	if p.promoted.Len() > 0 {
 		select {


### PR DESCRIPTION
The txpool does not broadcast remote transactions or send them to their peers. Steps to reproduce the bug:

1) The devnet contains 3 nodes: node1 is connected to node2 via P2P, and node2 is connected to node3 via P2P. 
2) Send a transaction to node3, 
3) It is added to node3 as a local transaction and broadcasted to node2. 
4) Node2 receives it as a remote transaction, adds it to its pool, but never broadcasts it to its peers.

Is this the expected behavior, or is it a bug?

If it is a bug, it seems we may have forgotten to promote transactions added to the pool (similar to how local transactions are handled in the AddLocalTxns function).