### PR TITLE
refactor: using slices.Contains to simplify the code

### DIFF
--- a/erigon-lib/chain/networkname/network_name.go
+++ b/erigon-lib/chain/networkname/network_name.go
@@ -41,12 +41,3 @@ var All = []string{
 	Chiado,
 	Test,
 }
-
-func IsKnownNetwork(s string) bool {
-	for _, n := range All {
-		if n == s {
-			return true
-		}
-	}
-	return false
-}

--- a/erigon-lib/downloader/downloadercfg/downloadercfg.go
+++ b/erigon-lib/downloader/downloadercfg/downloadercfg.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
@@ -240,7 +241,7 @@ func New(ctx context.Context, dirs datadir.Dirs, version string, verbosity lg.Le
 // LoadSnapshotsHashes checks local preverified.toml. If file exists, used local hashes.
 // If there are no such file, try to fetch hashes from the web and create local file.
 func LoadSnapshotsHashes(ctx context.Context, dirs datadir.Dirs, chainName string) (*snapcfg.Cfg, error) {
-	if !networkname.IsKnownNetwork(chainName) {
+	if !slices.Contains(networkname.All, chainName) {
 		log.Root().Warn("No snapshot hashes for chain", "chain", chainName)
 		return snapcfg.NewNonSeededCfg(chainName), nil
 	}


### PR DESCRIPTION
This is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.