### PR TITLE
contracts: add direct contract backend

### DIFF
--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -310,7 +310,7 @@ func EmbeddedServices(ctx context.Context,
 	blockReader services.FullBlockReader, ethBackendServer remote.ETHBACKENDServer, txPoolServer txpool.TxpoolServer,
 	miningServer txpool.MiningServer, stateDiffClient StateChangesClient,
 	logger log.Logger,
-) (eth rpchelper.ApiBackend, txPool txpool.TxpoolClient, mining txpool.MiningClient, stateCache kvcache.Cache, ff *rpchelper.Filters, err error) {
+) (eth rpchelper.ApiBackend, txPool txpool.TxpoolClient, mining txpool.MiningClient, stateCache kvcache.Cache, ff *rpchelper.Filters) {
 	if stateCacheCfg.CacheSize > 0 {
 		// notification about new blocks (state stream) doesn't work now inside erigon - because
 		// erigon does send this stream to privateAPI (erigon with enabled rpc, still have enabled privateAPI).

--- a/contracts/backend.go
+++ b/contracts/backend.go
@@ -1,0 +1,196 @@
+package contracts
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/big"
+
+	ethereum "github.com/erigontech/erigon"
+	libcommon "github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/common/hexutil"
+	"github.com/erigontech/erigon-lib/common/hexutility"
+	"github.com/erigontech/erigon/accounts/abi/bind"
+	"github.com/erigontech/erigon/core/types"
+	"github.com/erigontech/erigon/eth/filters"
+	"github.com/erigontech/erigon/event"
+	"github.com/erigontech/erigon/rpc"
+	"github.com/erigontech/erigon/turbo/adapter/ethapi"
+	"github.com/erigontech/erigon/turbo/jsonrpc"
+)
+
+var _ bind.ContractBackend = Backend{}
+
+type Backend struct {
+	api jsonrpc.EthAPI
+}
+
+func NewDirectBackend(api jsonrpc.EthAPI) Backend {
+	return Backend{
+		api: api,
+	}
+}
+
+func (b Backend) CodeAt(ctx context.Context, contract libcommon.Address, blockNum *big.Int) ([]byte, error) {
+	return b.api.GetCode(ctx, contract, BlockNumArg(blockNum))
+}
+
+func (b Backend) CallContract(ctx context.Context, callMsg ethereum.CallMsg, blockNum *big.Int) ([]byte, error) {
+	return b.api.Call(ctx, CallArgsFromCallMsg(callMsg), BlockNumArg(blockNum), nil)
+}
+
+func (b Backend) PendingCodeAt(ctx context.Context, account libcommon.Address) ([]byte, error) {
+	return b.api.GetCode(ctx, account, PendingBlockNumArg())
+}
+
+func (b Backend) PendingNonceAt(ctx context.Context, account libcommon.Address) (uint64, error) {
+	count, err := b.api.GetTransactionCount(ctx, account, PendingBlockNumArg())
+	if err != nil {
+		return 0, err
+	}
+
+	return uint64(*count), nil
+}
+
+func (b Backend) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
+	price, err := b.api.GasPrice(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return price.ToInt(), nil
+}
+
+func (b Backend) EstimateGas(ctx context.Context, call ethereum.CallMsg) (uint64, error) {
+	callArgs := CallArgsFromCallMsg(call)
+	gas, err := b.api.EstimateGas(ctx, &callArgs, nil, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	return gas.Uint64(), nil
+}
+
+func (b Backend) SendTransaction(ctx context.Context, txn types.Transaction) error {
+	var buf bytes.Buffer
+	err := txn.MarshalBinary(&buf)
+	if err != nil {
+		return err
+	}
+
+	_, err = b.api.SendRawTransaction(ctx, buf.Bytes())
+	return err
+}
+
+func (b Backend) FilterLogs(ctx context.Context, query ethereum.FilterQuery) ([]types.Log, error) {
+	logs, err := b.api.GetLogs(ctx, filters.FilterCriteria(query))
+	if err != nil {
+		return nil, err
+	}
+
+	res := make([]types.Log, len(logs))
+	for i, log := range logs {
+		res[i] = *log
+	}
+
+	return res, nil
+}
+
+func (b Backend) SubscribeFilterLogs(ctx context.Context, query ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
+	resc, closec := make(chan any), make(chan any)
+	ctx = rpc.ContextWithNotifier(ctx, rpc.NewLocalNotifier("eth", resc, closec))
+	_, err := b.api.Logs(ctx, filters.FilterCriteria(query))
+	if err != nil {
+		return nil, err
+	}
+
+	sub := event.NewSubscription(func(quit <-chan struct{}) error {
+		for {
+			select {
+			case <-quit:
+				close(closec)
+				return nil
+			case res := <-resc:
+				log, ok := res.(*types.Log)
+				if !ok {
+					return fmt.Errorf("unexpected type %T in SubscribeFilterLogs", res)
+				}
+
+				ch <- *log
+			}
+		}
+	})
+
+	return sub, nil
+}
+
+func BlockNumArg(blockNum *big.Int) rpc.BlockNumberOrHash {
+	var blockRef rpc.BlockReference
+	if blockNum == nil {
+		blockRef = rpc.LatestBlock
+	} else {
+		blockRef = rpc.AsBlockReference(blockNum)
+	}
+
+	return rpc.BlockNumberOrHash(blockRef)
+}
+
+func PendingBlockNumArg() rpc.BlockNumberOrHash {
+	return rpc.BlockNumberOrHash(rpc.PendingBlock)
+}
+
+func CallArgsFromCallMsg(callMsg ethereum.CallMsg) ethapi.CallArgs {
+	var emptyAddress libcommon.Address
+	var from *libcommon.Address
+	if callMsg.From != emptyAddress {
+		from = &callMsg.From
+	}
+
+	var gas *hexutil.Uint64
+	if callMsg.Gas != 0 {
+		gas = (*hexutil.Uint64)(&callMsg.Gas)
+	}
+
+	var gasPrice *hexutil.Big
+	if callMsg.GasPrice != nil {
+		gasPrice = (*hexutil.Big)(callMsg.GasPrice.ToBig())
+	}
+
+	var feeCap *hexutil.Big
+	if callMsg.FeeCap != nil {
+		feeCap = (*hexutil.Big)(callMsg.FeeCap.ToBig())
+	}
+
+	var maxFeePerBlobGas *hexutil.Big
+	if callMsg.MaxFeePerBlobGas != nil {
+		maxFeePerBlobGas = (*hexutil.Big)(callMsg.MaxFeePerBlobGas.ToBig())
+	}
+
+	var value *hexutil.Big
+	if callMsg.Value != nil {
+		value = (*hexutil.Big)(callMsg.Value.ToBig())
+	}
+
+	var data *hexutility.Bytes
+	if callMsg.Data != nil {
+		b := hexutility.Bytes(callMsg.Data)
+		data = &b
+	}
+
+	var accessList *types.AccessList
+	if callMsg.AccessList != nil {
+		accessList = &callMsg.AccessList
+	}
+
+	return ethapi.CallArgs{
+		From:             from,
+		To:               callMsg.To,
+		Gas:              gas,
+		GasPrice:         gasPrice,
+		MaxFeePerGas:     feeCap,
+		MaxFeePerBlobGas: maxFeePerBlobGas,
+		Value:            value,
+		Data:             data,
+		AccessList:       accessList,
+	}
+}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -743,9 +743,8 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 			logger,
 		)
 		contractBackend := contracts.NewDirectBackend(ethApi)
-		chainEvents := backend.notifications.Events
 		secondaryTxnProvider := backend.txPool
-		backend.shutterPool = shutter.NewPool(logger, config.Shutter, secondaryTxnProvider, chainEvents, contractBackend)
+		backend.shutterPool = shutter.NewPool(logger, config.Shutter, secondaryTxnProvider, contractBackend)
 		txnProvider = backend.shutterPool
 	}
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -82,11 +82,12 @@ import (
 	"github.com/erigontech/erigon/cl/persistence/format/snapshot_format/getters"
 	executionclient "github.com/erigontech/erigon/cl/phase1/execution_client"
 	"github.com/erigontech/erigon/cmd/caplin/caplin1"
-	"github.com/erigontech/erigon/cmd/rpcdaemon/cli"
+	rpcdaemoncli "github.com/erigontech/erigon/cmd/rpcdaemon/cli"
 	"github.com/erigontech/erigon/consensus"
 	"github.com/erigontech/erigon/consensus/clique"
 	"github.com/erigontech/erigon/consensus/ethash"
 	"github.com/erigontech/erigon/consensus/merge"
+	"github.com/erigontech/erigon/contracts"
 	"github.com/erigontech/erigon/core"
 	"github.com/erigontech/erigon/core/rawdb"
 	"github.com/erigontech/erigon/core/rawdb/blockio"
@@ -124,6 +125,7 @@ import (
 	"github.com/erigontech/erigon/turbo/execution/eth1"
 	"github.com/erigontech/erigon/turbo/execution/eth1/eth1_chain_reader"
 	"github.com/erigontech/erigon/turbo/jsonrpc"
+	"github.com/erigontech/erigon/turbo/rpchelper"
 	"github.com/erigontech/erigon/turbo/services"
 	"github.com/erigontech/erigon/turbo/shards"
 	"github.com/erigontech/erigon/turbo/silkworm"
@@ -163,10 +165,14 @@ type Ethereum struct {
 
 	eth1ExecutionServer *eth1.EthereumExecutionModule
 
-	ethBackendRPC      *privateapi.EthBackendServer
-	engineBackendRPC   *engineapi.EngineServer
-	miningRPC          txpoolproto.MiningServer
-	stateChangesClient txpool.StateChangesClient
+	ethBackendRPC       *privateapi.EthBackendServer
+	ethRpcClient        rpchelper.ApiBackend
+	engineBackendRPC    *engineapi.EngineServer
+	miningRPC           *privateapi.MiningServer
+	miningRpcClient     txpoolproto.MiningClient
+	stateDiffClient     *direct.StateDiffClientDirect
+	rpcFilters          *rpchelper.Filters
+	rpcDaemonStateCache kvcache.Cache
 
 	miningSealingQuit chan struct{}
 	pendingBlocks     chan *types.Block
@@ -194,6 +200,7 @@ type Ethereum struct {
 
 	txPool                    *txpool.TxPool
 	txPoolGrpcServer          txpoolproto.TxpoolServer
+	txPoolRpcClient           txpoolproto.TxpoolClient
 	shutterPool               *shutter.Pool
 	blockBuilderNotifyNewTxns chan struct{}
 	forkValidator             *engine_helpers.ForkValidator
@@ -643,7 +650,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		return nil, err
 	}
 
-	stateDiffClient := direct.NewStateDiffClientDirect(kvRPC)
+	backend.stateDiffClient = direct.NewStateDiffClientDirect(kvRPC)
 	var txnProvider txnprovider.TxnProvider
 	if config.TxPool.Disable {
 		backend.txPoolGrpcServer = &txpool.GrpcDisabled{}
@@ -661,7 +668,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 			backend.chainDB,
 			kvcache.NewDummy(),
 			sentries,
-			stateDiffClient,
+			backend.stateDiffClient,
 			blockBuilderNotifyNewTxns,
 			logger,
 		)
@@ -671,12 +678,74 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 
 		txnProvider = backend.txPool
 	}
+
+	var ethashApi *ethash.API
+	if casted, ok := backend.engine.(*ethash.Ethash); ok {
+		ethashApi = casted.APIs(nil)[1].Service.(*ethash.API)
+	}
+
+	backend.miningRPC = privateapi.NewMiningServer(ctx, backend, ethashApi, logger)
+	backend.ethBackendRPC = privateapi.NewEthBackendServer(
+		ctx,
+		backend,
+		backend.chainDB,
+		backend.notifications,
+		blockReader,
+		logger,
+		latestBlockBuiltStore,
+	)
+	httpRpcCfg := stack.Config().Http
+	ethRpcClient, txPoolRpcClient, miningRpcClient, rpcDaemonStateCache, rpcFilters := rpcdaemoncli.EmbeddedServices(
+		ctx,
+		backend.chainDB,
+		httpRpcCfg.StateCache,
+		httpRpcCfg.RpcFiltersConfig,
+		blockReader,
+		backend.ethBackendRPC,
+		backend.txPoolGrpcServer,
+		backend.miningRPC,
+		backend.stateDiffClient,
+		logger,
+	)
+	backend.ethRpcClient = ethRpcClient
+	backend.txPoolRpcClient = txPoolRpcClient
+	backend.miningRpcClient = miningRpcClient
+	backend.rpcDaemonStateCache = rpcDaemonStateCache
+	backend.rpcFilters = rpcFilters
+
 	if config.Shutter.Enabled {
 		if config.TxPool.Disable {
 			panic("can't enable shutter pool when devp2p txpool is disabled")
 		}
 
-		backend.shutterPool = shutter.NewPool(logger, config.Shutter, backend.txPool)
+		baseApi := jsonrpc.NewBaseApi(
+			backend.rpcFilters,
+			backend.rpcDaemonStateCache,
+			blockReader,
+			httpRpcCfg.WithDatadir,
+			httpRpcCfg.EvmCallTimeout,
+			backend.engine,
+			httpRpcCfg.Dirs,
+			backend.polygonBridge,
+		)
+		ethApi := jsonrpc.NewEthAPI(
+			baseApi,
+			backend.chainDB,
+			backend.ethRpcClient,
+			backend.txPoolRpcClient,
+			backend.miningRpcClient,
+			httpRpcCfg.Gascap,
+			httpRpcCfg.Feecap,
+			httpRpcCfg.ReturnDataLimit,
+			httpRpcCfg.AllowUnprotectedTxs,
+			httpRpcCfg.MaxGetProofRewindBlockCount,
+			httpRpcCfg.WebsocketSubscribeLogsChannelSize,
+			logger,
+		)
+		contractBackend := contracts.NewDirectBackend(ethApi)
+		chainEvents := backend.notifications.Events
+		secondaryTxnProvider := backend.txPool
+		backend.shutterPool = shutter.NewPool(logger, config.Shutter, secondaryTxnProvider, chainEvents, contractBackend)
 		txnProvider = backend.shutterPool
 	}
 
@@ -736,11 +805,6 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		), stagedsync.MiningUnwindOrder, stagedsync.MiningPruneOrder,
 		logger, stages.ModeBlockProduction)
 
-	var ethashApi *ethash.API
-	if casted, ok := backend.engine.(*ethash.Ethash); ok {
-		ethashApi = casted.APIs(nil)[1].Service.(*ethash.API)
-	}
-
 	// proof-of-stake mining
 	assembleBlockPOS := func(param *core.BlockBuilderParameters, interrupt *int32) (*types.BlockWithReceipts, error) {
 		miningStatePos := stagedsync.NewMiningState(&config.Miner)
@@ -792,14 +856,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		return block, nil
 	}
 
-	// Initialize ethbackend
-	ethBackendRPC := privateapi.NewEthBackendServer(ctx, backend, backend.chainDB, backend.notifications, blockReader, logger, latestBlockBuiltStore)
-	// initialize engine backend
-
 	blockRetire := freezeblocks.NewBlockRetire(1, dirs, blockReader, blockWriter, backend.chainDB, heimdallStore, bridgeStore, backend.chainConfig, config, backend.notifications.Events, segmentsBuildLimiter, logger)
-
-	var miningRPC txpoolproto.MiningServer = privateapi.NewMiningServer(ctx, backend, ethashApi, logger)
-
 	var creds credentials.TransportCredentials
 	if stack.Config().PrivateApiAddr != "" {
 		if stack.Config().TLSConnection {
@@ -810,9 +867,9 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		}
 		backend.privateAPI, err = privateapi.StartGrpc(
 			kvRPC,
-			ethBackendRPC,
+			backend.ethBackendRPC,
 			backend.txPoolGrpcServer,
-			miningRPC,
+			backend.miningRPC,
 			bridgeRPC,
 			heimdallRPC,
 			stack.Config().PrivateApiAddr,
@@ -846,7 +903,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 				//p2p
 				//backend.sentriesClient.BroadcastNewBlock(context.Background(), b, b.Difficulty())
 				//rpcdaemon
-				if err := miningRPC.(*privateapi.MiningServer).BroadcastMinedBlock(b); err != nil {
+				if err := backend.miningRPC.BroadcastMinedBlock(b); err != nil {
 					logger.Error("txpool rpc mined block broadcast", "err", err)
 				}
 				logger.Trace("BroadcastMinedBlock successful", "number", b.Number(), "GasUsed", b.GasUsed(), "txn count", b.Transactions().Len())
@@ -858,7 +915,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 				})
 
 			case b := <-backend.pendingBlocks:
-				if err := miningRPC.(*privateapi.MiningServer).BroadcastPendingBlock(b); err != nil {
+				if err := backend.miningRPC.BroadcastPendingBlock(b); err != nil {
 					logger.Error("txpool rpc pending block broadcast", "err", err)
 				}
 			case <-backend.sentriesClient.Hd.QuitPoWMining:
@@ -870,7 +927,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 	if err := backend.StartMining(
 		context.Background(),
 		backend.chainDB,
-		stateDiffClient,
+		backend.stateDiffClient,
 		mining,
 		miner,
 		backend.gasPrice,
@@ -880,8 +937,6 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		logger); err != nil {
 		return nil, err
 	}
-
-	backend.ethBackendRPC, backend.miningRPC, backend.stateChangesClient = ethBackendRPC, miningRPC, stateDiffClient
 
 	if config.PolygonSyncStage {
 		backend.syncStages = stages2.NewPolygonSyncStages(
@@ -1031,7 +1086,6 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 }
 
 func (s *Ethereum) Init(stack *node.Node, config *ethconfig.Config, chainConfig *chain.Config) error {
-	ethBackendRPC, miningRPC, stateDiffClient := s.ethBackendRPC, s.miningRPC, s.stateChangesClient
 	blockReader := s.blockReader
 	ctx := s.sentryCtx
 	chainKv := s.chainDB
@@ -1064,22 +1118,16 @@ func (s *Ethereum) Init(stack *node.Node, config *ethconfig.Config, chainConfig 
 	}
 	// start HTTP API
 	httpRpcCfg := stack.Config().Http
-	ethRpcClient, txPoolRpcClient, miningRpcClient, stateCache, ff, err := cli.EmbeddedServices(ctx, chainKv, httpRpcCfg.StateCache, httpRpcCfg.RpcFiltersConfig, blockReader, ethBackendRPC,
-		s.txPoolGrpcServer, miningRPC, stateDiffClient, s.logger)
-	if err != nil {
-		return err
-	}
-
 	//eth.APIBackend.gpo = gasprice.NewOracle(eth.APIBackend, gpoParams)
 	if config.Ethstats != "" {
 		var headCh chan [][]byte
 		headCh, s.unsubscribeEthstat = s.notifications.Events.AddHeaderSubscription()
-		if err := ethstats.New(stack, s.sentryServers, chainKv, s.blockReader, s.engine, config.Ethstats, s.networkID, ctx.Done(), headCh, txPoolRpcClient); err != nil {
+		if err := ethstats.New(stack, s.sentryServers, chainKv, s.blockReader, s.engine, config.Ethstats, s.networkID, ctx.Done(), headCh, s.txPoolRpcClient); err != nil {
 			return err
 		}
 	}
 
-	s.apiList = jsonrpc.APIList(chainKv, ethRpcClient, txPoolRpcClient, miningRpcClient, ff, stateCache, blockReader, &httpRpcCfg, s.engine, s.logger, s.polygonBridge, s.heimdallService)
+	s.apiList = jsonrpc.APIList(chainKv, s.ethRpcClient, s.txPoolRpcClient, s.miningRpcClient, s.rpcFilters, s.rpcDaemonStateCache, blockReader, &httpRpcCfg, s.engine, s.logger, s.polygonBridge, s.heimdallService)
 
 	if config.SilkwormRpcDaemon && httpRpcCfg.Enabled {
 		interface_log_settings := silkworm.RpcInterfaceLogSettings{
@@ -1106,14 +1154,14 @@ func (s *Ethereum) Init(stack *node.Node, config *ethconfig.Config, chainConfig 
 		s.silkwormRPCDaemonService = &silkwormRPCDaemonService
 	} else {
 		go func() {
-			if err := cli.StartRpcServer(ctx, &httpRpcCfg, s.apiList, s.logger); err != nil {
+			if err := rpcdaemoncli.StartRpcServer(ctx, &httpRpcCfg, s.apiList, s.logger); err != nil {
 				s.logger.Error("cli.StartRpcServer error", "err", err)
 			}
 		}()
 	}
 
 	if chainConfig.Bor == nil {
-		go s.engineBackendRPC.Start(ctx, &httpRpcCfg, s.chainDB, s.blockReader, ff, stateCache, s.engine, ethRpcClient, txPoolRpcClient, miningRpcClient)
+		go s.engineBackendRPC.Start(ctx, &httpRpcCfg, s.chainDB, s.blockReader, s.rpcFilters, s.rpcDaemonStateCache, s.engine, s.ethRpcClient, s.txPoolRpcClient, s.miningRpcClient)
 	}
 
 	// Register the backend on the node

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -84,7 +84,7 @@ type handler struct {
 
 type callProc struct {
 	ctx       context.Context
-	notifiers []*Notifier
+	notifiers []*RemoteNotifier
 }
 
 func HandleError(err error, stream *jsoniter.Stream) {
@@ -305,7 +305,7 @@ func (h *handler) cancelAllRequests(err error, inflightReq *requestOp) {
 	}
 }
 
-func (h *handler) addSubscriptions(nn []*Notifier) {
+func (h *handler) addSubscriptions(nn []*RemoteNotifier) {
 	h.subLock.Lock()
 	defer h.subLock.Unlock()
 
@@ -521,9 +521,9 @@ func (h *handler) handleSubscribe(cp *callProc, msg *jsonrpcMessage, stream *jso
 	args = args[1:]
 
 	// Install notifier in context so the subscription handler can find it.
-	n := &Notifier{h: h, namespace: namespace}
+	n := &RemoteNotifier{h: h, namespace: namespace}
 	cp.notifiers = append(cp.notifiers, n)
-	ctx := context.WithValue(cp.ctx, notifierKey{}, n)
+	ctx := ContextWithNotifier(cp.ctx, n)
 
 	return h.runMethod(ctx, msg, callb, args, stream)
 }

--- a/rpc/subscription.go
+++ b/rpc/subscription.go
@@ -85,14 +85,76 @@ func encodeID(b []byte) ID {
 type notifierKey struct{}
 
 // NotifierFromContext returns the Notifier value stored in ctx, if any.
-func NotifierFromContext(ctx context.Context) (*Notifier, bool) {
-	n, ok := ctx.Value(notifierKey{}).(*Notifier)
+func NotifierFromContext(ctx context.Context) (Notifier, bool) {
+	n, ok := ctx.Value(notifierKey{}).(Notifier)
 	return n, ok
 }
 
-// Notifier is tied to a RPC connection that supports subscriptions.
-// Server callbacks use the notifier to send notifications.
-type Notifier struct {
+func ContextWithNotifier(ctx context.Context, n Notifier) context.Context {
+	return context.WithValue(ctx, notifierKey{}, n)
+}
+
+// Notifier is used by Server callbacks to send notifications.
+type Notifier interface {
+	CreateSubscription() *Subscription
+	Notify(id ID, data interface{}) error
+	Closed() <-chan interface{}
+}
+
+type LocalNotifier struct {
+	idgen     func() ID
+	namespace string
+	resc      chan<- any
+	closec    <-chan any
+	sub       *Subscription
+}
+
+func NewLocalNotifier(namespace string, resc chan<- any, closec <-chan any) *LocalNotifier {
+	return &LocalNotifier{
+		idgen:     randomIDGenerator(),
+		namespace: namespace,
+		resc:      resc,
+		closec:    closec,
+	}
+}
+
+func (n LocalNotifier) CreateSubscription() *Subscription {
+	if n.sub != nil {
+		panic("can't create multiple subscriptions with LocalNotifier")
+	}
+
+	n.sub = &Subscription{
+		ID:        n.idgen(),
+		namespace: n.namespace,
+		err:       make(chan error, 1),
+	}
+
+	return n.sub
+}
+
+func (n LocalNotifier) Notify(id ID, data interface{}) error {
+	if n.sub == nil {
+		panic("can't Notify before subscription is created")
+	} else if n.sub.ID != id {
+		panic("Notify with wrong ID")
+	}
+
+	select {
+	case <-n.closec:
+		return errDead
+	case n.resc <- data:
+		return nil
+	default:
+		return ErrSubscriptionQueueOverflow
+	}
+}
+
+func (n LocalNotifier) Closed() <-chan interface{} {
+	return n.closec
+}
+
+// RemoteNotifier is tied to a RPC connection that supports subscriptions.
+type RemoteNotifier struct {
 	h         *handler
 	namespace string
 
@@ -107,12 +169,12 @@ type Notifier struct {
 // RPC connection. By default subscriptions are inactive and notifications
 // are dropped until the subscription is marked as active. This is done
 // by the RPC server after the subscription ID is send to the client.
-func (n *Notifier) CreateSubscription() *Subscription {
+func (n *RemoteNotifier) CreateSubscription() *Subscription {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 
 	if n.sub != nil {
-		panic("can't create multiple subscriptions with Notifier")
+		panic("can't create multiple subscriptions with RemoteNotifier")
 	} else if n.callReturned {
 		panic("can't create subscription after subscribe call has returned")
 	}
@@ -122,7 +184,7 @@ func (n *Notifier) CreateSubscription() *Subscription {
 
 // Notify sends a notification to the client with the given data as payload.
 // If an error occurs the RPC connection is closed and the error is returned.
-func (n *Notifier) Notify(id ID, data interface{}) error {
+func (n *RemoteNotifier) Notify(id ID, data interface{}) error {
 	enc, err := json.Marshal(data)
 	if err != nil {
 		return err
@@ -145,13 +207,13 @@ func (n *Notifier) Notify(id ID, data interface{}) error {
 
 // Closed returns a channel that is closed when the RPC connection is closed.
 // Deprecated: use subscription error channel
-func (n *Notifier) Closed() <-chan interface{} {
+func (n *RemoteNotifier) Closed() <-chan interface{} {
 	return n.h.conn.closed()
 }
 
 // takeSubscription returns the subscription (if one has been created). No subscription can
 // be created after this call.
-func (n *Notifier) takeSubscription() *Subscription {
+func (n *RemoteNotifier) takeSubscription() *Subscription {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	n.callReturned = true
@@ -161,7 +223,7 @@ func (n *Notifier) takeSubscription() *Subscription {
 // activate is called after the subscription ID was sent to client. Notifications are
 // buffered before activation. This prevents notifications being sent to the client before
 // the subscription ID is sent to the client.
-func (n *Notifier) activate() error {
+func (n *RemoteNotifier) activate() error {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 
@@ -174,7 +236,7 @@ func (n *Notifier) activate() error {
 	return nil
 }
 
-func (n *Notifier) send(sub *Subscription, data json.RawMessage) error {
+func (n *RemoteNotifier) send(sub *Subscription, data json.RawMessage) error {
 	params, _ := json.Marshal(&subscriptionResult{ID: string(sub.ID), Result: data})
 	ctx := context.Background()
 	return n.h.conn.WriteJSON(ctx, &jsonrpcMessage{

--- a/rpc/subscription.go
+++ b/rpc/subscription.go
@@ -144,8 +144,6 @@ func (n LocalNotifier) Notify(id ID, data interface{}) error {
 		return errDead
 	case n.resc <- data:
 		return nil
-	default:
-		return ErrSubscriptionQueueOverflow
 	}
 }
 

--- a/turbo/jsonrpc/eth_api.go
+++ b/turbo/jsonrpc/eth_api.go
@@ -45,7 +45,7 @@ import (
 	"github.com/erigontech/erigon/core"
 	"github.com/erigontech/erigon/core/rawdb"
 	"github.com/erigontech/erigon/core/types"
-	ethFilters "github.com/erigontech/erigon/eth/filters"
+	"github.com/erigontech/erigon/eth/filters"
 	"github.com/erigontech/erigon/ethdb/prune"
 	"github.com/erigontech/erigon/polygon/bor/borcfg"
 	"github.com/erigontech/erigon/polygon/bridge"
@@ -75,7 +75,7 @@ type EthAPI interface {
 
 	// Receipt related (see ./eth_receipts.go)
 	GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error)
-	GetLogs(ctx context.Context, crit ethFilters.FilterCriteria) (types.Logs, error)
+	GetLogs(ctx context.Context, crit filters.FilterCriteria) (types.Logs, error)
 	GetBlockReceipts(ctx context.Context, numberOrHash rpc.BlockNumberOrHash) ([]map[string]interface{}, error)
 
 	// Uncle related (see ./eth_uncles.go)
@@ -87,10 +87,11 @@ type EthAPI interface {
 	// Filter related (see ./eth_filters.go)
 	NewPendingTransactionFilter(_ context.Context) (string, error)
 	NewBlockFilter(_ context.Context) (string, error)
-	NewFilter(_ context.Context, crit ethFilters.FilterCriteria) (string, error)
+	NewFilter(_ context.Context, crit filters.FilterCriteria) (string, error)
 	UninstallFilter(_ context.Context, index string) (bool, error)
 	GetFilterChanges(_ context.Context, index string) ([]any, error)
 	GetFilterLogs(_ context.Context, index string) ([]*types.Log, error)
+	Logs(ctx context.Context, crit filters.FilterCriteria) (*rpc.Subscription, error)
 
 	// Account related (see ./eth_accounts.go)
 	Accounts(ctx context.Context) ([]common.Address, error)

--- a/txnprovider/shutter/pool.go
+++ b/txnprovider/shutter/pool.go
@@ -22,7 +22,9 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/erigontech/erigon-lib/log/v3"
+	"github.com/erigontech/erigon/accounts/abi/bind"
 	"github.com/erigontech/erigon/core/types"
+	"github.com/erigontech/erigon/turbo/shards"
 	"github.com/erigontech/erigon/txnprovider"
 	"github.com/erigontech/erigon/txnprovider/shutter/proto"
 )
@@ -37,7 +39,13 @@ type Pool struct {
 	decryptionKeysProcessor DecryptionKeysProcessor
 }
 
-func NewPool(logger log.Logger, config Config, secondaryTxnProvider txnprovider.TxnProvider) *Pool {
+func NewPool(
+	logger log.Logger,
+	config Config,
+	secondaryTxnProvider txnprovider.TxnProvider,
+	chainEvents *shards.Events,
+	contractBackend bind.ContractBackend,
+) *Pool {
 	logger = logger.New("component", "shutter")
 	decryptionKeysListener := NewDecryptionKeysListener(logger, config)
 	decryptionKeysProcessor := NewDecryptionKeysProcessor(logger)

--- a/txnprovider/shutter/pool.go
+++ b/txnprovider/shutter/pool.go
@@ -24,7 +24,6 @@ import (
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/accounts/abi/bind"
 	"github.com/erigontech/erigon/core/types"
-	"github.com/erigontech/erigon/turbo/shards"
 	"github.com/erigontech/erigon/txnprovider"
 	"github.com/erigontech/erigon/txnprovider/shutter/proto"
 )
@@ -43,7 +42,6 @@ func NewPool(
 	logger log.Logger,
 	config Config,
 	secondaryTxnProvider txnprovider.TxnProvider,
-	chainEvents *shards.Events,
 	contractBackend bind.ContractBackend,
 ) *Pool {
 	logger = logger.New("component", "shutter")


### PR DESCRIPTION
relates to https://github.com/erigontech/erigon/issues/13383
takes a chunk of changes out of bigger shutter PR https://github.com/erigontech/erigon/pull/13553 in which we collect data from various shutter smart contracts

context on this PR:
- smart contracts objects generated by `abigen` rely on `bind.ContractBackend` in order to be used
- we currently do not have an implementation of that interface in Erigon (apart from `SimulatedBackend` which is used in testing - inherited from Geth)
- in this PR im adding an implementation of `ContractBackend` which uses the `EthApi` jsonrpc object and directly calls it instead of going via http rpc and/or websocket (for log update subscriptions) - this is analogous to how we have `direct` and `remote` grpc clients for our grpc-based components
- ive also wired the new contract backend to the shutter pool - this will be used in a subsequent PR (check the aforementioned PR https://github.com/erigontech/erigon/pull/13553 for usages)

note that this is needed also for @shohamc1 's work for native AA which is why it will be good to merge it in main