### PR TITLE
Add nil check to blobschedule configs

### DIFF
--- a/erigon-lib/chain/chain_config.go
+++ b/erigon-lib/chain/chain_config.go
@@ -94,9 +94,9 @@ type Config struct {
 }
 
 type BlobConfig struct {
-	Target                uint64 `json:"target"`
-	Max                   uint64 `json:"max"`
-	BaseFeeUpdateFraction uint64 `json:"baseFeeUpdateFraction"`
+	Target                *uint64 `json:"target,omitempty"`
+	Max                   *uint64 `json:"max,omitempty"`
+	BaseFeeUpdateFraction *uint64 `json:"baseFeeUpdateFraction,omitempty"`
 }
 
 // See EIP-7840: Add blob schedule to EL config files
@@ -107,39 +107,39 @@ type BlobSchedule struct {
 
 func (b *BlobSchedule) TargetBlobsPerBlock(isPrague bool) uint64 {
 	if isPrague {
-		if b != nil && b.Prague != nil {
-			return b.Prague.Target
+		if b != nil && b.Prague != nil && b.Prague.Target != nil {
+			return *b.Prague.Target
 		}
 		return 6 // EIP-7691
 	}
-	if b != nil && b.Cancun != nil {
-		return b.Cancun.Target
+	if b != nil && b.Cancun != nil && b.Cancun.Target != nil {
+		return *b.Cancun.Target
 	}
 	return 3 // EIP-4844
 }
 
 func (b *BlobSchedule) MaxBlobsPerBlock(isPrague bool) uint64 {
 	if isPrague {
-		if b != nil && b.Prague != nil {
-			return b.Prague.Max
+		if b != nil && b.Prague != nil && b.Prague.Max != nil {
+			return *b.Prague.Max
 		}
 		return 9 // EIP-7691
 	}
-	if b != nil && b.Cancun != nil {
-		return b.Cancun.Max
+	if b != nil && b.Cancun != nil && b.Cancun.Max != nil {
+		return *b.Cancun.Max
 	}
 	return 6 // EIP-4844
 }
 
 func (b *BlobSchedule) BaseFeeUpdateFraction(isPrague bool) uint64 {
 	if isPrague {
-		if b != nil && b.Prague != nil {
-			return b.Prague.BaseFeeUpdateFraction
+		if b != nil && b.Prague != nil && b.Prague.BaseFeeUpdateFraction != nil {
+			return *b.Prague.BaseFeeUpdateFraction
 		}
 		return 5007716 // EIP-7691
 	}
-	if b != nil && b.Cancun != nil {
-		return b.Cancun.BaseFeeUpdateFraction
+	if b != nil && b.Cancun != nil && b.Cancun.BaseFeeUpdateFraction != nil {
+		return *b.Cancun.BaseFeeUpdateFraction
 	}
 	return 3338477 // EIP-4844
 }


### PR DESCRIPTION
Fixes issues where config files have some values and not all, or empty values for forks.

Note: This config is picked up for custom (unlisted) networks after `init` cmd is run using a correctly formatted `genesis.json` file (see [pectra-devnet-5 gensis](https://github.com/ethpandaops/pectra-devnets/blob/master/network-configs/devnet-5/metadata/genesis.json) file for example)