### PR TITLE
core: Fix signature mismatch issues due to authorization encoding

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -361,7 +361,7 @@ func (st *StateTransition) TransitionDb(refunds bool, gasBailout bool) (*evmtype
 		if contractCreation {
 			return nil, errors.New("contract creation not allowed with type4 txs")
 		}
-		var b [33]byte
+		var b [32]byte
 		data := bytes.NewBuffer(nil)
 		for i, auth := range auths {
 			data.Reset()

--- a/core/types/authorization_test.go
+++ b/core/types/authorization_test.go
@@ -1,0 +1,52 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/holiman/uint256"
+
+	libcommon "github.com/erigontech/erigon-lib/common"
+)
+
+// Tests that the correct signer is recovered from an Authorization object
+// The data here was obtained from a pectra devnet
+func TestRecoverSigner(t *testing.T) {
+	t.Parallel()
+
+	auth := Authorization{
+		ChainID: *uint256.NewInt(7088110746),
+		Address: libcommon.Address{180, 125, 156, 99, 77, 80, 241, 96, 13, 77, 247, 103, 233, 71, 76, 37, 160, 48, 52, 40},
+		Nonce:   1,
+		YParity: 1,
+		R:       uint256.Int{11238962557009670571, 14017651393191758745, 18358999445216475025, 5549385460848219779},
+		S:       uint256.Int{6390522493159340108, 17630603794136184458, 14442462445950880280, 846710983706847255},
+	}
+	var b [32]byte
+	data := bytes.NewBuffer(nil)
+	authorityPtr, err := auth.RecoverSigner(data, b[:])
+	if err != nil {
+		t.Error(err)
+	}
+	expectedSigner := libcommon.HexToAddress("0x8ED5ABe9DE62dB2F266b06b86203f71e4C1e357f")
+	if *authorityPtr != expectedSigner {
+		t.Errorf("mismatch in recovered signer: got %v, want %v", *authorityPtr, expectedSigner)
+	}
+
+}


### PR DESCRIPTION
A recent [RLP related commit](https://github.com/erigontech/erigon/pull/12869/files#diff-ec3e5ec81bd7c4746ee5d895260767e2282f268684ffc0de73d4a7018975493c) created a uint256 encoding that assumes len = 32 for the passed in buffered byte array. However, this PR doesn't fix any inherent issues with [that approach](https://github.com/erigontech/erigon/pull/12869) itself. This PR fixes one issue found in `pectra_devnet_5` that creates a mismatched recovered signer address.