### PR TITLE
add benchmark for BeginFilesRo

### DIFF
--- a/erigon-lib/state/aggregator_bench_test.go
+++ b/erigon-lib/state/aggregator_bench_test.go
@@ -289,15 +289,27 @@ func Benchmark_Recsplit_Find_ExternalFile(b *testing.B) {
 	}
 }
 
+func BenchmarkAggregator_BeginFilesRo_Latency(b *testing.B) {
+	//BenchmarkAggregator_BeginFilesRo/begin_files_ro-16  1737404  737.3 ns/op  3216 B/op  21 allocs/op
+	aggStep := uint64(100_00)
+	_, agg := testDbAndAggregatorBench(b, aggStep)
+
+	b.Run("begin_files_ro", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			agg.BeginFilesRo()
+		}
+	})
+}
+
 var parallel = flag.Int("bench.parallel", 1, "parallelism value") // runs 1 *maxprocs
 var loopv = flag.Int("bench.loopv", 100000, "loop value")
 
-func BenchmarkAggregator_BeginFilesRo(b *testing.B) {
+func BenchmarkAggregator_BeginFilesRo_Throughput(b *testing.B) {
+	// trying to find BeginFilesRo throughput
 	if !flag.Parsed() {
 		flag.Parse()
 	}
-
-	//b.Logf("Running with parallel=%d work=%d", *parallel, *loopv)
+	//b.Logf("Running with parallel=%d work=%d, #goroutines:%d", *parallel, *loopv, *parallel*runtime.GOMAXPROCS(0))
 
 	aggStep := uint64(100_00)
 	_, agg := testDbAndAggregatorBench(b, aggStep)
@@ -313,6 +325,5 @@ func BenchmarkAggregator_BeginFilesRo(b *testing.B) {
 			}
 			tx.Close()
 		}
-
 	})
 }

--- a/erigon-lib/state/aggregator_bench_test.go
+++ b/erigon-lib/state/aggregator_bench_test.go
@@ -289,7 +289,7 @@ func Benchmark_Recsplit_Find_ExternalFile(b *testing.B) {
 }
 
 func BenchmarkAggregator_BeginFilesRo(b *testing.B) {
-	// BenchmarkAggregator_BeginFilesRo/begin_files_ro-16 1490890 850.0 ns/op 3280 B/op 22 allocs/op
+	//BenchmarkAggregator_BeginFilesRo/begin_files_ro-16 1688707 712.3 ns/op 3216 B/op 21 allocs/op
 	aggStep := uint64(100_00)
 	_, agg := testDbAndAggregatorBench(b, aggStep)
 

--- a/erigon-lib/state/aggregator_bench_test.go
+++ b/erigon-lib/state/aggregator_bench_test.go
@@ -338,19 +338,19 @@ func BenchmarkAggregator_BeginFilesRo_Throughput(b *testing.B) {
 	})
 }
 
-func BenchmarkAggregator_BeginFilesRo_Throughput2(b *testing.B) {
+func BenchmarkDb_BeginFiles_Throughput(b *testing.B) {
 	/**
 	for cpu in $(seq 0 20); do
 	    cpus=$((1 << $cpu))  # Same as 2^cpu
 	    echo -n "($cpus, "
-	    echo -n $(go test -benchmem -run=^$ -bench ^BenchmarkAggregator_BeginFilesRo_Throughput2$ github.com/erigontech/erigon-lib/state  \
-		-bench.parallel=$cpus -bench.loopv=1000 | grep 'BenchmarkAggregator_BeginFilesRo_Throughput2' | cut -f3 | xargs|cut -d' ' -f1)
+	    echo -n $(go test -benchmem -run=^$ -bench ^BenchmarkDb_BeginFiles_Throughput$ github.com/erigontech/erigon-lib/state  \
+		-bench.parallel=$cpus -bench.loopv=1000 | grep 'BenchmarkDb_BeginFiles_Throughput' | cut -f3 | xargs|cut -d' ' -f1)
 	    echo -n "), "
 	done
 	**/
 
-	// result: deteriorates after 2^21 goroutines.
 	// trying to find BeginFilesRo and Rollback throughput
+	// result: deteriorates after 2^21 goroutines.
 	if !flag.Parsed() {
 		flag.Parse()
 	}

--- a/erigon-lib/state/aggregator_bench_test.go
+++ b/erigon-lib/state/aggregator_bench_test.go
@@ -305,7 +305,17 @@ var parallel = flag.Int("bench.parallel", 1, "parallelism value") // runs 1 *max
 var loopv = flag.Int("bench.loopv", 100000, "loop value")
 
 func BenchmarkAggregator_BeginFilesRo_Throughput(b *testing.B) {
+	/**
+	for cpu in $(seq 0 20); do
+		cpus=$((1 << $cpu))  # Same as 2^cpu
+		echo -n "($cpus, "
+		echo -n $(go test -benchmem -run=^$ -bench ^BenchmarkAggregator_BeginFilesRo_Throughput$ github.com/erigontech/erigon-lib/state  \
+		-bench.parallel=$cpus -bench.loopv=1000 | grep 'BenchmarkAggregator_BeginFilesRo_Throughput' | cut -f3 | xargs|cut -d' ' -f1)
+		echo -n "), "
+	done
+	**/
 	// trying to find BeginFilesRo throughput
+	// result: deteriorates after 2^21 goroutines.
 	if !flag.Parsed() {
 		flag.Parse()
 	}
@@ -324,6 +334,45 @@ func BenchmarkAggregator_BeginFilesRo_Throughput(b *testing.B) {
 				foo /= 2
 			}
 			tx.Close()
+		}
+	})
+}
+
+func BenchmarkAggregator_BeginFilesRo_Throughput2(b *testing.B) {
+	/**
+	for cpu in $(seq 0 20); do
+	    cpus=$((1 << $cpu))  # Same as 2^cpu
+	    echo -n "($cpus, "
+	    echo -n $(go test -benchmem -run=^$ -bench ^BenchmarkAggregator_BeginFilesRo_Throughput2$ github.com/erigontech/erigon-lib/state  \
+		-bench.parallel=$cpus -bench.loopv=1000 | grep 'BenchmarkAggregator_BeginFilesRo_Throughput2' | cut -f3 | xargs|cut -d' ' -f1)
+	    echo -n "), "
+	done
+	**/
+
+	// result: deteriorates after 2^21 goroutines.
+	// trying to find BeginFilesRo and Rollback throughput
+	if !flag.Parsed() {
+		flag.Parse()
+	}
+	//b.Logf("Running with parallel=%d work=%d, #goroutines:%d", *parallel, *loopv, *parallel*runtime.GOMAXPROCS(0))
+
+	aggStep := uint64(100_00)
+	db, _ := testDbAndAggregatorBench(b, aggStep)
+	ctx := context.Background()
+
+	b.SetParallelism(*parallel) // p * maxprocs
+	b.RunParallel(func(pb *testing.PB) {
+		foo := 0
+		for pb.Next() {
+			tx, err := db.BeginRo(ctx)
+			if err != nil {
+				b.Fatalf("%v", err)
+			}
+			for i := 0; i < *loopv; i++ {
+				foo *= 2
+				foo /= 2
+			}
+			tx.Rollback()
 		}
 	})
 }

--- a/erigon-lib/state/aggregator_bench_test.go
+++ b/erigon-lib/state/aggregator_bench_test.go
@@ -289,7 +289,7 @@ func Benchmark_Recsplit_Find_ExternalFile(b *testing.B) {
 }
 
 func BenchmarkAggregator_BeginFilesRo(b *testing.B) {
-	//BenchmarkAggregator_BeginFilesRo/begin_files_ro-16 1688707 712.3 ns/op 3216 B/op 21 allocs/op
+	//BenchmarkAggregator_BeginFilesRo/begin_files_ro-16  1737404  737.3 ns/op  3216 B/op  21 allocs/op
 	aggStep := uint64(100_00)
 	_, agg := testDbAndAggregatorBench(b, aggStep)
 

--- a/erigon-lib/state/aggregator_bench_test.go
+++ b/erigon-lib/state/aggregator_bench_test.go
@@ -287,3 +287,15 @@ func Benchmark_Recsplit_Find_ExternalFile(b *testing.B) {
 		require.EqualValues(b, keys[p], key)
 	}
 }
+
+func BenchmarkAggregator_BeginFilesRo(b *testing.B) {
+	// BenchmarkAggregator_BeginFilesRo/begin_files_ro-16 1490890 850.0 ns/op 3280 B/op 22 allocs/op
+	aggStep := uint64(100_00)
+	_, agg := testDbAndAggregatorBench(b, aggStep)
+
+	b.Run("begin_files_ro", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			agg.BeginFilesRo()
+		}
+	})
+}


### PR DESCRIPTION
throughput benchmark

![benchmark](https://github.com/user-attachments/assets/69d55ab3-f46f-4d88-8834-1b08ec2b9b0a)

work = loopv value (more time spent on iteration, longer living rotx)
I didn't plot for goroutines < 2^16, since the value remains the same pretty much (no deterioration till 2^16 goroutines).
Tested on Apple M3 map (16 core).

`number of goroutines = *parallel*runtime.GOMAXPROCS(0)`

conclusion -- as **number of goroutines** starts to go above from 2^20 (1 million), perf starts to deteriorate. Specially beyond 2^21 (2 million rotxs), performance degrades significantly. 
even for loopv=10^7, same observation (above 2^21 goroutines, significant deterioration); same scenario for loopv=1.

The work done inside rotx is computational intensive, and not accessing db. 