### PR TITLE
Add support to `eth_blobBaseFee`, `eth_baseFee` and EIP4844 support to `eth_feeHistory`

### DIFF
--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -84,18 +84,13 @@ func (f eip1559Calculator) CurrentFees(chainConfig *chain.Config, db kv.Getter) 
 		}
 
 		if currentHeader.ExcessBlobGas != nil {
-			var nextHeaderTime = currentHeader.Time + 1 // Speculative - Next header must be at least 1 second ahead
-			parentHeader := rawdb.ReadHeaderByNumber(db, currentHeader.Number.Uint64()-1)
-			if parentHeader != nil {
-				nextHeaderTime = currentHeader.Time + (currentHeader.Time - parentHeader.Time) // This difference should be close enough to seconds per slot
-			}
-			excessBlobGas := CalcExcessBlobGas(chainConfig, currentHeader, nextHeaderTime)
-			b, err := GetBlobGasPrice(chainConfig, excessBlobGas, nextHeaderTime)
-			if err == nil {
-				blobFee = b.Uint64()
-			} else {
+			nextBlockTime := currentHeader.Time + chainConfig.SecondsPerSlot()
+			excessBlobGas := CalcExcessBlobGas(chainConfig, currentHeader, nextBlockTime)
+			b, err := GetBlobGasPrice(chainConfig, excessBlobGas, nextBlockTime)
+			if err != nil {
 				return 0, 0, 0, 0, err
 			}
+			blobFee = b.Uint64()
 		}
 	}
 

--- a/erigon-lib/chain/chain_config.go
+++ b/erigon-lib/chain/chain_config.go
@@ -364,6 +364,16 @@ func (c *Config) GetMaxBlobsPerBlock(time uint64) uint64 {
 	return c.GetMaxBlobGasPerBlock(time) / fixedgas.BlobGasPerBlob
 }
 
+func (c *Config) SecondsPerSlot() uint64 {
+	if c.Bor != nil {
+		return 2 // Polygon
+	}
+	if c.Aura != nil {
+		return 5 // Gnosis
+	}
+	return 12 // Ethereum
+}
+
 // CheckCompatible checks whether scheduled fork transitions have been imported
 // with a mismatching chain configuration.
 func (c *Config) CheckCompatible(newcfg *Config, height uint64) *ConfigCompatError {

--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -56,7 +56,6 @@ type blockFees struct {
 	blobBaseFee, nextBlobBaseFee *big.Int
 	gasUsedRatio                 float64
 	blobGasUsedRatio             float64
-	secondsPerSlot               uint64
 	err                          error
 }
 
@@ -98,7 +97,8 @@ func (oracle *Oracle) processBlock(bf *blockFees, percentiles []float64) {
 			bf.err = err
 			return
 		}
-		nextBlobBaseFee256, err := misc.GetBlobGasPrice(chainconfig, misc.CalcExcessBlobGas(chainconfig, bf.header, bf.header.Time+bf.secondsPerSlot), bf.header.Time+bf.secondsPerSlot)
+		nextBlockTime := bf.header.Time + chainconfig.SecondsPerSlot()
+		nextBlobBaseFee256, err := misc.GetBlobGasPrice(chainconfig, misc.CalcExcessBlobGas(chainconfig, bf.header, nextBlockTime), nextBlockTime)
 		if err != nil {
 			bf.err = err
 			return
@@ -167,26 +167,23 @@ func (oracle *Oracle) processBlock(bf *blockFees, percentiles []float64) {
 // also returned if requested and available.
 // Note: an error is only returned if retrieving the head header has failed. If there are no
 // retrievable blocks in the specified range then zero block count is returned with no error.
-func (oracle *Oracle) resolveBlockRange(ctx context.Context, lastBlock rpc.BlockNumber, blocks, maxHistory int) (*types.Block, []*types.Receipt, uint64, int, uint64, error) {
+func (oracle *Oracle) resolveBlockRange(ctx context.Context, lastBlock rpc.BlockNumber, blocks, maxHistory int) (*types.Block, []*types.Receipt, uint64, int, error) {
 	var (
 		headBlock       rpc.BlockNumber
 		pendingBlock    *types.Block
 		pendingReceipts types.Receipts
-		secondsPerSlot  uint64 // Time diff from parent block as an approx
-		lastBlockTime   uint64
 	)
 	// query either pending block or head header and set headBlock
 	if lastBlock == rpc.PendingBlockNumber {
 		if pendingBlock, pendingReceipts = oracle.backend.PendingBlockAndReceipts(); pendingBlock != nil {
 			lastBlock = rpc.BlockNumber(pendingBlock.NumberU64())
 			headBlock = lastBlock - 1
-			lastBlockTime = pendingBlock.Time()
 		} else {
 			// pending block not supported by backend, process until latest block
 			lastBlock = rpc.LatestBlockNumber
 			blocks--
 			if blocks == 0 {
-				return nil, nil, 0, 0, 0, nil
+				return nil, nil, 0, 0, nil
 			}
 		}
 	}
@@ -194,24 +191,14 @@ func (oracle *Oracle) resolveBlockRange(ctx context.Context, lastBlock rpc.Block
 		// if pending block is not fetched then we retrieve the head header to get the head block number
 		if latestHeader, err := oracle.backend.HeaderByNumber(ctx, rpc.LatestBlockNumber); err == nil {
 			headBlock = rpc.BlockNumber(latestHeader.Number.Uint64())
-			lastBlockTime = latestHeader.Time
 		} else {
-			return nil, nil, 0, 0, 0, err
+			return nil, nil, 0, 0, err
 		}
 	}
 	if lastBlock == rpc.LatestBlockNumber {
 		lastBlock = headBlock
 	} else if pendingBlock == nil && lastBlock > headBlock {
-		return nil, nil, 0, 0, 0, fmt.Errorf("%w: requested %d, head %d", ErrRequestBeyondHead, lastBlock, headBlock)
-	}
-	if lastBlock > 0 {
-		parentHeader, err := oracle.backend.HeaderByNumber(ctx, lastBlock-1)
-		if err != nil {
-			return nil, nil, 0, 0, 0, err
-		}
-		if parentHeader != nil {
-			secondsPerSlot = parentHeader.Time - lastBlockTime
-		}
+		return nil, nil, 0, 0, fmt.Errorf("%w: requested %d, head %d", ErrRequestBeyondHead, lastBlock, headBlock)
 	}
 	if maxHistory != 0 {
 		// limit retrieval to the given number of latest blocks
@@ -220,7 +207,7 @@ func (oracle *Oracle) resolveBlockRange(ctx context.Context, lastBlock rpc.Block
 			if int64(blocks) > tooOldCount {
 				blocks -= int(tooOldCount)
 			} else {
-				return nil, nil, 0, 0, 0, nil
+				return nil, nil, 0, 0, nil
 			}
 		}
 	}
@@ -228,7 +215,7 @@ func (oracle *Oracle) resolveBlockRange(ctx context.Context, lastBlock rpc.Block
 	if rpc.BlockNumber(blocks) > lastBlock+1 {
 		blocks = int(lastBlock + 1)
 	}
-	return pendingBlock, pendingReceipts, uint64(lastBlock), blocks, secondsPerSlot, nil
+	return pendingBlock, pendingReceipts, uint64(lastBlock), blocks, nil
 }
 
 // FeeHistory returns data relevant for fee estimation based on the specified range of blocks.
@@ -271,7 +258,7 @@ func (oracle *Oracle) FeeHistory(ctx context.Context, blocks int, unresolvedLast
 		pendingReceipts []*types.Receipt
 		err             error
 	)
-	pendingBlock, pendingReceipts, lastBlock, blocks, secondsPerSlot, err := oracle.resolveBlockRange(ctx, unresolvedLastBlock, blocks, maxHistory)
+	pendingBlock, pendingReceipts, lastBlock, blocks, err := oracle.resolveBlockRange(ctx, unresolvedLastBlock, blocks, maxHistory)
 	if err != nil || blocks == 0 {
 		return libcommon.Big0, nil, nil, nil, nil, nil, err
 	}
@@ -298,7 +285,7 @@ func (oracle *Oracle) FeeHistory(ctx context.Context, blocks int, unresolvedLast
 			continue
 		}
 
-		fees := &blockFees{blockNumber: blockNumber, secondsPerSlot: secondsPerSlot}
+		fees := &blockFees{blockNumber: blockNumber}
 		if pendingBlock != nil && blockNumber >= pendingBlock.NumberU64() {
 			fees.block, fees.receipts = pendingBlock, pendingReceipts
 		} else {

--- a/eth/gasprice/feehistory_test.go
+++ b/eth/gasprice/feehistory_test.go
@@ -62,7 +62,7 @@ func TestFeeHistory(t *testing.T) {
 		cache := jsonrpc.NewGasPriceCache()
 		oracle := gasprice.NewOracle(backend, config, cache)
 
-		first, reward, baseFee, ratio, err := oracle.FeeHistory(context.Background(), c.count, c.last, c.percent)
+		first, reward, baseFee, ratio, blobBaseFee, blobBaseFeeRatio, err := oracle.FeeHistory(context.Background(), c.count, c.last, c.percent)
 
 		expReward := c.expCount
 		if len(c.percent) == 0 {
@@ -84,6 +84,12 @@ func TestFeeHistory(t *testing.T) {
 		}
 		if len(ratio) != c.expCount {
 			t.Fatalf("Test case %d: gasUsedRatio array length mismatch, want %d, got %d", i, c.expCount, len(ratio))
+		}
+		if c.expCount != 0 && len(blobBaseFee) != c.expCount+1 {
+			t.Fatalf("Test case %d: blobBaseFee array length mismatch, want %d, got %d", i, c.expCount+1, len(blobBaseFee))
+		}
+		if len(blobBaseFeeRatio) != c.expCount {
+			t.Fatalf("Test case %d: blobBaseFeeRatio array length mismatch, want %d, got %d", i, c.expCount, len(blobBaseFeeRatio))
 		}
 		if err != c.expErr && !errors.Is(err, c.expErr) {
 			t.Fatalf("Test case %d: error mismatch, want %v, got %v", i, c.expErr, err)

--- a/turbo/jsonrpc/eth_block.go
+++ b/turbo/jsonrpc/eth_block.go
@@ -6,14 +6,11 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/erigontech/erigon-lib/log/v3"
-
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/hexutil"
 	"github.com/erigontech/erigon-lib/common/hexutility"
 	"github.com/erigontech/erigon-lib/kv"
-
-	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/common/math"
 	"github.com/erigontech/erigon/core"
 	"github.com/erigontech/erigon/core/rawdb"
@@ -103,7 +100,7 @@ func (api *APIImpl) CallBundle(ctx context.Context, txHashes []common.Hash, stat
 
 	blockNumber := stateBlockNumber + 1
 
-	timestamp := parent.Time + clparams.MainnetBeaconConfig.SecondsPerSlot
+	timestamp := parent.Time + chainConfig.SecondsPerSlot()
 
 	coinbase := parent.Coinbase
 	header := &types.Header{

--- a/turbo/jsonrpc/eth_system.go
+++ b/turbo/jsonrpc/eth_system.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"math/big"
 
-	"github.com/erigontech/erigon-lib/common/hexutil"
-
 	"github.com/erigontech/erigon-lib/chain"
+	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/common/hexutil"
 	"github.com/erigontech/erigon-lib/kv"
-
+	"github.com/erigontech/erigon/consensus/misc"
 	"github.com/erigontech/erigon/core/rawdb"
 	"github.com/erigontech/erigon/core/types"
 	"github.com/erigontech/erigon/eth/ethconfig"
@@ -142,10 +142,12 @@ func (api *APIImpl) MaxPriorityFeePerGas(ctx context.Context) (*hexutil.Big, err
 }
 
 type feeHistoryResult struct {
-	OldestBlock  *hexutil.Big     `json:"oldestBlock"`
-	Reward       [][]*hexutil.Big `json:"reward,omitempty"`
-	BaseFee      []*hexutil.Big   `json:"baseFeePerGas,omitempty"`
-	GasUsedRatio []float64        `json:"gasUsedRatio"`
+	OldestBlock      *hexutil.Big     `json:"oldestBlock"`
+	Reward           [][]*hexutil.Big `json:"reward,omitempty"`
+	BaseFee          []*hexutil.Big   `json:"baseFeePerGas,omitempty"`
+	GasUsedRatio     []float64        `json:"gasUsedRatio"`
+	BlobBaseFee      []*hexutil.Big   `json:"baseFeePerBlobGas,omitempty"`
+	BlobGasUsedRatio []float64        `json:"blobGasUsedRatio,omitempty"`
 }
 
 func (api *APIImpl) FeeHistory(ctx context.Context, blockCount rpc.DecimalOrHex, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*feeHistoryResult, error) {
@@ -156,7 +158,7 @@ func (api *APIImpl) FeeHistory(ctx context.Context, blockCount rpc.DecimalOrHex,
 	defer tx.Rollback()
 	oracle := gasprice.NewOracle(NewGasPriceOracleBackend(tx, api.BaseAPI), ethconfig.Defaults.GPO, api.gasCache)
 
-	oldest, reward, baseFee, gasUsed, err := oracle.FeeHistory(ctx, int(blockCount), lastBlock, rewardPercentiles)
+	oldest, reward, baseFee, gasUsed, blobBaseFee, blobGasUsedRatio, err := oracle.FeeHistory(ctx, int(blockCount), lastBlock, rewardPercentiles)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +181,67 @@ func (api *APIImpl) FeeHistory(ctx context.Context, blockCount rpc.DecimalOrHex,
 			results.BaseFee[i] = (*hexutil.Big)(v)
 		}
 	}
+	if blobBaseFee != nil {
+		results.BlobBaseFee = make([]*hexutil.Big, len(blobBaseFee))
+		for i, v := range blobBaseFee {
+			results.BlobBaseFee[i] = (*hexutil.Big)(v)
+		}
+	}
+	if blobGasUsedRatio != nil {
+		results.BlobGasUsedRatio = blobGasUsedRatio
+	}
 	return results, nil
+}
+
+// BlobBaseFee returns the base fee for blob gas at the current head.
+func (api *APIImpl) BlobBaseFee(ctx context.Context) (*hexutil.Big, error) {
+	// read current header
+	tx, err := api.db.BeginRo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+	header := rawdb.ReadCurrentHeader(tx)
+	if header == nil || header.BlobGasUsed == nil {
+		return (*hexutil.Big)(common.Big0), nil
+	}
+	config, err := api.BaseAPI.chainConfig(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	if config == nil {
+		return (*hexutil.Big)(common.Big0), nil
+	}
+	ret256, err := misc.GetBlobGasPrice(config, misc.CalcExcessBlobGas(config, header))
+	if err != nil {
+		return nil, err
+	}
+	return (*hexutil.Big)(ret256.ToBig()), nil
+}
+
+// BaseFee returns the base fee at the current head.
+func (api *APIImpl) BaseFee(ctx context.Context) (*hexutil.Big, error) {
+	// read current header
+	tx, err := api.db.BeginRo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+	header := rawdb.ReadCurrentHeader(tx)
+	if header == nil {
+		return (*hexutil.Big)(common.Big0), nil
+	}
+	config, err := api.BaseAPI.chainConfig(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	if config == nil {
+		return (*hexutil.Big)(common.Big0), nil
+	}
+	if !config.IsLondon(header.Number.Uint64() + 1) {
+		return (*hexutil.Big)(common.Big0), nil
+	}
+	return (*hexutil.Big)(misc.CalcBaseFee(config, header)), nil
 }
 
 type GasPriceOracleBackend struct {

--- a/turbo/jsonrpc/eth_system.go
+++ b/turbo/jsonrpc/eth_system.go
@@ -212,7 +212,8 @@ func (api *APIImpl) BlobBaseFee(ctx context.Context) (*hexutil.Big, error) {
 	if config == nil {
 		return (*hexutil.Big)(common.Big0), nil
 	}
-	ret256, err := misc.GetBlobGasPrice(config, misc.CalcExcessBlobGas(config, header))
+	nextBlockTime := header.Time + config.SecondsPerSlot()
+	ret256, err := misc.GetBlobGasPrice(config, misc.CalcExcessBlobGas(config, header, nextBlockTime), nextBlockTime)
 	if err != nil {
 		return nil, err
 	}

--- a/turbo/stages/stageloop.go
+++ b/turbo/stages/stageloop.go
@@ -302,11 +302,7 @@ func (h *Hook) sendNotifications(notifications *shards.Notifications, tx kv.Tx, 
 		pendingBaseFee := misc.CalcBaseFee(h.chainConfig, currentHeader)
 		pendingBlobFee := h.chainConfig.GetMinBlobGasPrice()
 		if currentHeader.ExcessBlobGas != nil {
-			nextBlockTime := currentHeader.Time + 1
-			parentHeader := rawdb.ReadHeaderByNumber(tx, currentHeader.Number.Uint64())
-			if parentHeader != nil {
-				nextBlockTime = currentHeader.Time + (currentHeader.Time - parentHeader.Time) // Approximately next block time
-			}
+			nextBlockTime := currentHeader.Time + h.chainConfig.SecondsPerSlot()
 			excessBlobGas := misc.CalcExcessBlobGas(h.chainConfig, currentHeader, nextBlockTime)
 			f, err := misc.GetBlobGasPrice(h.chainConfig, excessBlobGas, nextBlockTime)
 			if err != nil {


### PR DESCRIPTION
Cherry pick #11992 "Add support to `eth_blobBaseFee`, `eth_baseFee` and EIP4844 support to `eth_feeHistory`" into `release/2.61` and also #13467 "Make secondsPerSlot available in chain config"