### PR TITLE
caplin: Fix config type

### DIFF
--- a/cl/clparams/config.go
+++ b/cl/clparams/config.go
@@ -31,6 +31,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/c2h5oh/datasize"
+
 	"github.com/erigontech/erigon-lib/chain/networkname"
 	libcommon "github.com/erigontech/erigon-lib/common"
 
@@ -578,12 +579,12 @@ type BeaconChainConfig struct {
 	PendingConsolidationsLimit            uint64 `yaml:"PENDING_CONSOLIDATIONS_LIMIT" spec:"true" json:"PENDING_CONSOLIDATIONS_LIMIT,string"`                             // PendingConsolidationsLimit defines the maximum number of pending consolidations.
 	MaxBlobsPerBlockElectra               uint64 `yaml:"MAX_BLOBS_PER_BLOCK_ELECTRA" spec:"true" json:"MAX_BLOBS_PER_BLOCK_ELECTRA,string"`                               // MaxBlobsPerBlockElectra defines the maximum number of blobs per block for Electra.
 	// Constants for the Electra fork.
-	UnsetDepositRequestsStartIndex uint64 `yaml:"UNSET_DEPOSIT_REQUESTS_START_INDEX" spec:"true" json:"UNSET_DEPOSIT_REQUESTS_START_INDEX,string"` // UnsetDepositRequestsStartIndex defines the start index for unset deposit requests.
-	FullExitRequestAmount          uint64 `yaml:"FULL_EXIT_REQUEST_AMOUNT" spec:"true" json:"FULL_EXIT_REQUEST_AMOUNT,string"`                     // FullExitRequestAmount defines the amount for a full exit request.
-	CompoundingWithdrawalPrefix    byte   `yaml:"COMPOUNDING_WITHDRAWAL_PREFIX" spec:"true" json:"COMPOUNDING_WITHDRAWAL_PREFIX"`                  // CompoundingWithdrawalPrefix is the prefix for compounding withdrawals.
-	DepositRequestType             byte   `yaml:"DEPOSIT_REQUEST_TYPE" spec:"true" json:"DEPOSIT_REQUEST_TYPE"`                                    // DepositRequestType is the type for deposit requests.
-	WithdrawalRequestType          byte   `yaml:"WITHDRAWAL_REQUEST_TYPE" spec:"true" json:"WITHDRAWAL_REQUEST_TYPE"`                              // WithdrawalRequestType is the type for withdrawal requests.
-	ConsolidationRequestType       byte   `yaml:"CONSOLIDATION_REQUEST_TYPE" spec:"true" json:"CONSOLIDATION_REQUEST_TYPE"`                        // ConsolidationRequestType is the type for consolidation requests.
+	UnsetDepositRequestsStartIndex uint64     `yaml:"UNSET_DEPOSIT_REQUESTS_START_INDEX" spec:"true" json:"UNSET_DEPOSIT_REQUESTS_START_INDEX,string"` // UnsetDepositRequestsStartIndex defines the start index for unset deposit requests.
+	FullExitRequestAmount          uint64     `yaml:"FULL_EXIT_REQUEST_AMOUNT" spec:"true" json:"FULL_EXIT_REQUEST_AMOUNT,string"`                     // FullExitRequestAmount defines the amount for a full exit request.
+	CompoundingWithdrawalPrefix    ConfigByte `yaml:"COMPOUNDING_WITHDRAWAL_PREFIX" spec:"true" json:"COMPOUNDING_WITHDRAWAL_PREFIX"`                  // CompoundingWithdrawalPrefix is the prefix for compounding withdrawals.
+	DepositRequestType             ConfigByte `yaml:"DEPOSIT_REQUEST_TYPE" spec:"true" json:"DEPOSIT_REQUEST_TYPE"`                                    // DepositRequestType is the type for deposit requests.
+	WithdrawalRequestType          ConfigByte `yaml:"WITHDRAWAL_REQUEST_TYPE" spec:"true" json:"WITHDRAWAL_REQUEST_TYPE"`                              // WithdrawalRequestType is the type for withdrawal requests.
+	ConsolidationRequestType       ConfigByte `yaml:"CONSOLIDATION_REQUEST_TYPE" spec:"true" json:"CONSOLIDATION_REQUEST_TYPE"`                        // ConsolidationRequestType is the type for consolidation requests.
 }
 
 func (b *BeaconChainConfig) RoundSlotToEpoch(slot uint64) uint64 {

--- a/cl/clparams/config.go
+++ b/cl/clparams/config.go
@@ -358,6 +358,12 @@ func (b ConfigByte) MarshalJSON() ([]byte, error) {
 	return []byte(fmt.Sprintf("\"0x%x\"", b)), nil
 }
 
+type RequestTypePrefix byte
+
+func (b RequestTypePrefix) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("\"0x%02x\"", b)), nil
+}
+
 type ConfigForkVersion uint32
 
 func (v ConfigForkVersion) MarshalJSON() ([]byte, error) {
@@ -579,12 +585,12 @@ type BeaconChainConfig struct {
 	PendingConsolidationsLimit            uint64 `yaml:"PENDING_CONSOLIDATIONS_LIMIT" spec:"true" json:"PENDING_CONSOLIDATIONS_LIMIT,string"`                             // PendingConsolidationsLimit defines the maximum number of pending consolidations.
 	MaxBlobsPerBlockElectra               uint64 `yaml:"MAX_BLOBS_PER_BLOCK_ELECTRA" spec:"true" json:"MAX_BLOBS_PER_BLOCK_ELECTRA,string"`                               // MaxBlobsPerBlockElectra defines the maximum number of blobs per block for Electra.
 	// Constants for the Electra fork.
-	UnsetDepositRequestsStartIndex uint64     `yaml:"UNSET_DEPOSIT_REQUESTS_START_INDEX" spec:"true" json:"UNSET_DEPOSIT_REQUESTS_START_INDEX,string"` // UnsetDepositRequestsStartIndex defines the start index for unset deposit requests.
-	FullExitRequestAmount          uint64     `yaml:"FULL_EXIT_REQUEST_AMOUNT" spec:"true" json:"FULL_EXIT_REQUEST_AMOUNT,string"`                     // FullExitRequestAmount defines the amount for a full exit request.
-	CompoundingWithdrawalPrefix    ConfigByte `yaml:"COMPOUNDING_WITHDRAWAL_PREFIX" spec:"true" json:"COMPOUNDING_WITHDRAWAL_PREFIX"`                  // CompoundingWithdrawalPrefix is the prefix for compounding withdrawals.
-	DepositRequestType             ConfigByte `yaml:"DEPOSIT_REQUEST_TYPE" spec:"true" json:"DEPOSIT_REQUEST_TYPE"`                                    // DepositRequestType is the type for deposit requests.
-	WithdrawalRequestType          ConfigByte `yaml:"WITHDRAWAL_REQUEST_TYPE" spec:"true" json:"WITHDRAWAL_REQUEST_TYPE"`                              // WithdrawalRequestType is the type for withdrawal requests.
-	ConsolidationRequestType       ConfigByte `yaml:"CONSOLIDATION_REQUEST_TYPE" spec:"true" json:"CONSOLIDATION_REQUEST_TYPE"`                        // ConsolidationRequestType is the type for consolidation requests.
+	UnsetDepositRequestsStartIndex uint64            `yaml:"UNSET_DEPOSIT_REQUESTS_START_INDEX" spec:"true" json:"UNSET_DEPOSIT_REQUESTS_START_INDEX,string"` // UnsetDepositRequestsStartIndex defines the start index for unset deposit requests.
+	FullExitRequestAmount          uint64            `yaml:"FULL_EXIT_REQUEST_AMOUNT" spec:"true" json:"FULL_EXIT_REQUEST_AMOUNT,string"`                     // FullExitRequestAmount defines the amount for a full exit request.
+	CompoundingWithdrawalPrefix    RequestTypePrefix `yaml:"COMPOUNDING_WITHDRAWAL_PREFIX" spec:"true" json:"COMPOUNDING_WITHDRAWAL_PREFIX"`                  // CompoundingWithdrawalPrefix is the prefix for compounding withdrawals.
+	DepositRequestType             RequestTypePrefix `yaml:"DEPOSIT_REQUEST_TYPE" spec:"true" json:"DEPOSIT_REQUEST_TYPE"`                                    // DepositRequestType is the type for deposit requests.
+	WithdrawalRequestType          RequestTypePrefix `yaml:"WITHDRAWAL_REQUEST_TYPE" spec:"true" json:"WITHDRAWAL_REQUEST_TYPE"`                              // WithdrawalRequestType is the type for withdrawal requests.
+	ConsolidationRequestType       RequestTypePrefix `yaml:"CONSOLIDATION_REQUEST_TYPE" spec:"true" json:"CONSOLIDATION_REQUEST_TYPE"`                        // ConsolidationRequestType is the type for consolidation requests.
 }
 
 func (b *BeaconChainConfig) RoundSlotToEpoch(slot uint64) uint64 {

--- a/cl/cltypes/beacon_block.go
+++ b/cl/cltypes/beacon_block.go
@@ -545,9 +545,9 @@ func (b *BeaconBody) GetExecutionRequestsList() []hexutility.Bytes {
 		typ      byte
 		requests ssz.EncodableSSZ
 	}{
-		{b.beaconCfg.DepositRequestType, r.Deposits},
-		{b.beaconCfg.WithdrawalRequestType, r.Withdrawals},
-		{b.beaconCfg.ConsolidationRequestType, r.Consolidations},
+		{byte(b.beaconCfg.DepositRequestType), r.Deposits},
+		{byte(b.beaconCfg.WithdrawalRequestType), r.Withdrawals},
+		{byte(b.beaconCfg.ConsolidationRequestType), r.Consolidations},
 	} {
 		ssz, err := r.requests.EncodeSSZ([]byte{})
 		if err != nil {

--- a/cl/phase1/core/state/util.go
+++ b/cl/phase1/core/state/util.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 
 	"github.com/Giulio2002/bls"
+
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon/cl/abstract"
 	"github.com/erigontech/erigon/cl/clparams"
@@ -77,7 +78,7 @@ func HasEth1WithdrawalCredential(validator solid.Validator, conf *clparams.Beaco
 
 func HasCompoundingWithdrawalCredential(validator solid.Validator, conf *clparams.BeaconChainConfig) bool {
 	withdrawalCredentials := validator.WithdrawalCredentials()
-	return withdrawalCredentials[0] == conf.CompoundingWithdrawalPrefix
+	return withdrawalCredentials[0] == byte(conf.CompoundingWithdrawalPrefix)
 }
 
 func HasExecutionWithdrawalCredential(validator solid.Validator, conf *clparams.BeaconChainConfig) bool {

--- a/cl/transition/impl/eth2/operations.go
+++ b/cl/transition/impl/eth2/operations.go
@@ -1267,7 +1267,7 @@ func switchToCompoundingValidator(s abstract.BeaconState, vindex uint64) error {
 	wc := validator.WithdrawalCredentials()
 	newWc := common.Hash{}
 	copy(newWc[:], wc[:])
-	newWc[0] = s.BeaconConfig().CompoundingWithdrawalPrefix
+	newWc[0] = byte(s.BeaconConfig().CompoundingWithdrawalPrefix)
 	validator.SetWithdrawalCredentials(newWc)
 	s.SetValidatorAtIndex(int(vindex), validator) // update the state
 	return state.QueueExcessActiveBalance(s, vindex, &validator)


### PR DESCRIPTION
Fixes an issue where the `/eth/v1/config/spec` was returning an incorrect output.

```bash
curl -s 0.0.0.0:5052/eth/v1/config/spec | jq '.data | with_entries(select(.key | test("REQUEST_TYPE$")))'
{
  "DEPOSIT_REQUEST_TYPE": "0x00",
  "WITHDRAWAL_REQUEST_TYPE": "0x01",
  "CONSOLIDATION_REQUEST_TYPE": "0x02"
}
```