### PR TITLE
integration_test: Update qa integration test for beta1

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout RPC Tests Repository & Install Requirements
         run: |
           rm -rf ${{ runner.workspace }}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch v1.27.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
+          git -c advice.detachedHead=false clone --depth 1 --branch v1.38.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
           cd ${{ runner.workspace }}/rpc-tests
           pip3 install -r requirements.txt
 

--- a/.github/workflows/scripts/run_rpc_tests.sh
+++ b/.github/workflows/scripts/run_rpc_tests.sh
@@ -6,10 +6,17 @@ set +e # Disable exit on error
 disabled_tests=(
     # Erigon2 and Erigon3 never supported this api methods
     trace_rawTransaction
+    debug_getRawTransaction
     # to investigate
     engine_exchangeCapabilities/test_1.json
     engine_exchangeTransitionConfigurationV1/test_01.json
     engine_getClientVersionV1/test_1.json
+    # these tests require Fix on erigon DM on repeipts domain
+    eth_getLogs/test_16
+    eth_getLogs/test_17
+    eth_getLogs/test_18
+    eth_getLogs/test_19
+    eth_getLogs/test_20
     # these tests requires Erigon active
     admin_nodeInfo/test_01.json
     admin_peers/test_01.json


### PR DESCRIPTION
This PR contains:
- new label of RPC-tests (new tests, integration tests runned in parallel)
- create exception list valid also for beta1