### PR TITLE
changed exec metrics guard to use sync mode

### DIFF
--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -488,7 +488,12 @@ Loop:
 			// TODO: panic here and see that overall process deadlock
 			return fmt.Errorf("nil block %d", blockNum)
 		}
-		metrics2.UpdateBlockConsumerPreExecutionDelay(b.Time(), blockNum, logger)
+
+		if execStage.SyncMode() == stages.ModeApplyingBlocks ||
+			execStage.SyncMode() == stages.ModeForkValidation {
+			metrics2.UpdateBlockConsumerPreExecutionDelay(b.Time(), blockNum, logger)
+		}
+
 		txs := b.Transactions()
 		header := b.HeaderNoCopy()
 		skipAnalysis := core.SkipAnalysis(chainConfig, blockNum)
@@ -643,7 +648,8 @@ Loop:
 
 		// MA commitTx
 		if !parallel {
-			if !inMemExec && !isMining {
+			if execStage.SyncMode() == stages.ModeApplyingBlocks ||
+				execStage.SyncMode() == stages.ModeForkValidation {
 				metrics2.UpdateBlockConsumerPostExecutionDelay(b.Time(), blockNum, logger)
 			}
 


### PR DESCRIPTION
Exec latency checking is inconsistent for ethereum chains this fixes that by using  ModeForkValidation || ModeApplyingBlocks as the criteria for producing metrics.

`ModeApplyingBlocks` happens when we call `UpdateForkChoice` - that is when we should be calling UpdateBlockConsumerPreExecutionDelay and UpdateBlockConsumerPostExecutionDelay

`ModeForkValidation` happens when we call ValidateChain - we should be updating the above block consumer metrics here too for the following reasons:

* first ValidateChain is called => the block is valid and the extending fork hash is rememberred by the fork validator as per validateAndStorePayload - at this point the execution loop has been run with an in-mem db approach
* then UpdateForkChoice is called with hash==extendingForkHash from the previous ValidateChain run that was in memory - in this case there is  NO  execution with the real non-in-mem db because the previous result of ValidateChain is flushed by calling forkValidator.FlushExtendingFork()
* the code for this flushing is [here](https://github.com/erigontech/erigon/blob/main/turbo/execution/eth1/forkchoice.go#L427-L443)
