### PR TITLE
execution: Fix request append out of range in block building

### DIFF
--- a/turbo/execution/eth1/block_building.go
+++ b/turbo/execution/eth1/block_building.go
@@ -219,9 +219,8 @@ func (e *EthereumExecutionModule) GetAssembledBlock(ctx context.Context, req *ex
 	if blockWithReceipts.Requests != nil {
 		requestsBundle = &types2.RequestsBundle{}
 		requests := make([][]byte, 0)
-		for i, r := range blockWithReceipts.Requests {
-			requests[i] = make([]byte, 0)
-			requests[i] = append(requests[i], r.RequestData...)
+		for _, r := range blockWithReceipts.Requests {
+			requests = append(requests, r.RequestData)
 		}
 		requestsBundle.Requests = requests
 	}


### PR DESCRIPTION
Fixes an issue reported for `devnet-5` with trace as follows
```
[INFO] [01-29|21:33:12.026] Received GetPayloadV4                    payloadId=369
[EROR] [01-29|21:33:12.026] RPC method engine_getPayloadV4 crashed: runtime error: index out of range [0] with length 0
[service.go:223 panic.go:770 panic.go:114 block_building.go:223 execution_client.go:53 engine_server.go:475 engine_api_methods.go:74 value.go:596 value.go:380 service.go:228 handler.go:534 handler.go:484 handler.go:425 handler.go:245 handler.go:338 asm_amd64.s:1695]
```