### PR TITLE
crypto: add IsOnCurve check

### DIFF
--- a/erigon-lib/crypto/crypto.go
+++ b/erigon-lib/crypto/crypto.go
@@ -189,6 +189,9 @@ func UnmarshalPubkeyStd(pub []byte) (*ecdsa.PublicKey, error) {
 	if x == nil {
 		return nil, errInvalidPubkey
 	}
+	if !S256().IsOnCurve(x, y) {
+		return nil, errInvalidPubkey
+	}
 	return &ecdsa.PublicKey{Curve: S256(), X: x, Y: y}, nil
 }
 


### PR DESCRIPTION
Fixes [CVE-2025-24883](https://nvd.nist.gov/vuln/detail/CVE-2025-24883)

See https://github.com/ethereum/go-ethereum/pull/31100