### PR TITLE
polygon/sync: retry ufc on busy response

### DIFF
--- a/polygon/sync/execution_client.go
+++ b/polygon/sync/execution_client.go
@@ -91,7 +91,7 @@ func (e *executionClient) InsertBlocks(ctx context.Context, blocks []*types.Bloc
 		case executionproto.ExecutionStatus_Busy:
 			return ErrExecutionClientBusy // gets retried
 		default:
-			return backoff.Permanent(fmt.Errorf("executionClient.InsertBlocks failure status: %s", status.String()))
+			return fmt.Errorf("executionClient.InsertBlocks failure status: %s", status.String())
 		}
 	})
 }
@@ -125,8 +125,7 @@ func (e *executionClient) UpdateForkChoice(ctx context.Context, tip *types.Heade
 		case executionproto.ExecutionStatus_Busy:
 			return ErrExecutionClientBusy // gets retried
 		default:
-			return fmt.Errorf(
-				"%w: status=%d, validationErr='%s'", ErrForkChoiceUpdateFailure, r.Status, r.ValidationError)
+			return fmt.Errorf("%w: status=%d, validationErr='%s'", ErrForkChoiceUpdateFailure, r.Status, r.ValidationError)
 		}
 	})
 

--- a/polygon/sync/execution_client.go
+++ b/polygon/sync/execution_client.go
@@ -23,17 +23,20 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/gointerfaces"
 	"github.com/erigontech/erigon-lib/gointerfaces/executionproto"
+	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/core/types"
 	eth1utils "github.com/erigontech/erigon/turbo/execution/eth1/eth1_utils"
 )
 
 var ErrForkChoiceUpdateFailure = errors.New("fork choice update failure")
 var ErrForkChoiceUpdateBadBlock = errors.New("fork choice update bad block")
+var ErrExecutionClientBusy = errors.New("execution client busy")
 
 type ExecutionClient interface {
 	Prepare(ctx context.Context) error
@@ -44,11 +47,15 @@ type ExecutionClient interface {
 	GetTd(ctx context.Context, blockNum uint64, blockHash common.Hash) (*big.Int, error)
 }
 
-func newExecutionClient(client executionproto.ExecutionClient) *executionClient {
-	return &executionClient{client}
+func newExecutionClient(logger log.Logger, client executionproto.ExecutionClient) *executionClient {
+	return &executionClient{
+		logger: logger,
+		client: client,
+	}
 }
 
 type executionClient struct {
+	logger log.Logger
 	client executionproto.ExecutionClient
 }
 
@@ -71,7 +78,7 @@ func (e *executionClient) InsertBlocks(ctx context.Context, blocks []*types.Bloc
 		Blocks: eth1utils.ConvertBlocksToRPC(blocks),
 	}
 
-	for {
+	return e.retryBusy("insertBlocks", func() error {
 		response, err := e.client.InsertBlocks(ctx, request)
 		if err != nil {
 			return err
@@ -82,20 +89,11 @@ func (e *executionClient) InsertBlocks(ctx context.Context, blocks []*types.Bloc
 		case executionproto.ExecutionStatus_Success:
 			return nil
 		case executionproto.ExecutionStatus_Busy:
-			// retry after sleep
-			func() {
-				delayTimer := time.NewTimer(100 * time.Millisecond)
-				defer delayTimer.Stop()
-
-				select {
-				case <-delayTimer.C:
-				case <-ctx.Done():
-				}
-			}()
+			return ErrExecutionClientBusy // gets retried
 		default:
-			return fmt.Errorf("executionClient.InsertBlocks failed with response status: %s", status.String())
+			return backoff.Permanent(fmt.Errorf("executionClient.InsertBlocks failure status: %s", status.String()))
 		}
-	}
+	})
 }
 
 func (e *executionClient) UpdateForkChoice(ctx context.Context, tip *types.Header, finalizedHeader *types.Header) (common.Hash, error) {
@@ -108,34 +106,31 @@ func (e *executionClient) UpdateForkChoice(ctx context.Context, tip *types.Heade
 		Timeout:            0,
 	}
 
-	response, err := e.client.UpdateForkChoice(ctx, &request)
-	if err != nil {
-		return common.Hash{}, err
-	}
-
 	var latestValidHash common.Hash
-	if response.LatestValidHash != nil {
-		latestValidHash = gointerfaces.ConvertH256ToHash(response.LatestValidHash)
-	}
+	err := e.retryBusy("updateForkChoice", func() error {
+		r, err := e.client.UpdateForkChoice(ctx, &request)
+		if err != nil {
+			return err
+		}
 
-	switch response.Status {
-	case executionproto.ExecutionStatus_Success:
-		return latestValidHash, nil
-	case executionproto.ExecutionStatus_BadBlock:
-		return latestValidHash, fmt.Errorf(
-			"%w: status=%d, validationErr='%s'",
-			ErrForkChoiceUpdateBadBlock,
-			response.Status,
-			response.ValidationError,
-		)
-	default:
-		return latestValidHash, fmt.Errorf(
-			"%w: status=%d, validationErr='%s'",
-			ErrForkChoiceUpdateFailure,
-			response.Status,
-			response.ValidationError,
-		)
-	}
+		if r.LatestValidHash != nil {
+			latestValidHash = gointerfaces.ConvertH256ToHash(r.LatestValidHash)
+		}
+
+		switch r.Status {
+		case executionproto.ExecutionStatus_Success:
+			return nil
+		case executionproto.ExecutionStatus_BadBlock:
+			return fmt.Errorf("%w: status=%d, validationErr='%s'", ErrForkChoiceUpdateBadBlock, r.Status, r.ValidationError)
+		case executionproto.ExecutionStatus_Busy:
+			return ErrExecutionClientBusy // gets retried
+		default:
+			return fmt.Errorf(
+				"%w: status=%d, validationErr='%s'", ErrForkChoiceUpdateFailure, r.Status, r.ValidationError)
+		}
+	})
+
+	return latestValidHash, err
 }
 
 func (e *executionClient) CurrentHeader(ctx context.Context) (*types.Header, error) {
@@ -178,4 +173,29 @@ func (e *executionClient) GetTd(ctx context.Context, blockNum uint64, blockHash 
 	}
 
 	return eth1utils.ConvertBigIntFromRpc(response.GetTd()), nil
+}
+
+func (e *executionClient) retryBusy(label string, f func() error) error {
+	backOff := 50 * time.Millisecond
+	logEvery := 5 * time.Second
+	logEveryXAttempt := int64(logEvery / backOff)
+	attempt := int64(1)
+	operation := func() error {
+		err := f()
+		if err == nil {
+			return nil
+		}
+
+		if errors.Is(err, ErrExecutionClientBusy) {
+			if attempt%logEveryXAttempt == 1 {
+				e.logger.Debug("execution client busy - retrying", "in", backOff, "label", label, "attempt", attempt)
+			}
+			attempt++
+			return err
+		}
+
+		return backoff.Permanent(err)
+	}
+
+	return backoff.Retry(operation, backoff.NewConstantBackOff(backOff))
 }

--- a/polygon/sync/service.go
+++ b/polygon/sync/service.go
@@ -54,7 +54,7 @@ func NewService(
 	milestoneVerifier := VerifyMilestoneHeaders
 	blocksVerifier := VerifyBlocks
 	p2pService := p2p.NewService(logger, maxPeers, sentryClient, statusDataProvider.GetStatusData)
-	execution := newExecutionClient(executionClient)
+	execution := newExecutionClient(logger, executionClient)
 
 	signaturesCache, err := lru.NewARC[common.Hash, common.Address](InMemorySignatures)
 	if err != nil {


### PR DESCRIPTION
a user on discord flagged the following issue (discord [link](https://discord.com/channels/687972960811745322/983710221308416010/1334851657355235358)): 
```
[INFO] [01-31|10:44:40.015] [sync] update fork choice done           in=807.13624ms
[INFO] [01-31|10:44:40.022] [sync] update fork choice                block=67365147 hash=0xb697ef9de67d61f300fda27367617ec270d9bcd15e9a7c73facdc253b6fc0273 age=3s
[EROR] [01-31|10:44:40.022] failed to update fork choice             latestValidHash=0x0000000000000000000000000000000000000000000000000000000000000000 err="fork choice update failure: status=5, validationErr=''"
[EROR] [01-31|10:44:40.038] runPostForkchoiceInBackground            error="[1/6 OtterSync] db closed"
[EROR] [01-31|10:44:43.029] polygon sync crashed - stopping node     err="pos sync failed: fork choice update failure: status=5, validationErr=''"
```

Note: `status=5` means `ExecutionStatus_Busy`

This can happen because there is a possibility that `runPostForkchoiceInBackground` acquires the execution engine semaphore after a successful UFC (line which says `update fork choice done           in=807.13624ms`) to do pruning. But very shortly after that there is another call to UFC (in this case 7ms after - line which says `update fork choice block=67365147`) which then fails with a `Busy` response since it can't acquire the semaphore (take by `runPostForkchoiceInBackground` for pruning).

This PR fixes this situation by adding retries on `Busy` response when calling UFC. Such a retry already existed when calling `InsertBlocks` so this is something that just got missed.