### PR TITLE
execution: fix and simplify block consumer exec delays

### DIFF
--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -31,7 +31,6 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/cmp"
 	"github.com/erigontech/erigon-lib/common/dbg"
-	metrics2 "github.com/erigontech/erigon-lib/common/metrics"
 	"github.com/erigontech/erigon-lib/config3"
 	"github.com/erigontech/erigon-lib/kv"
 	"github.com/erigontech/erigon-lib/kv/rawdbv3"
@@ -490,11 +489,6 @@ Loop:
 			return fmt.Errorf("nil block %d", blockNum)
 		}
 
-		if execStage.SyncMode() == stages.ModeApplyingBlocks ||
-			execStage.SyncMode() == stages.ModeForkValidation {
-			metrics2.UpdateBlockConsumerPreExecutionDelay(b.Time(), blockNum, logger)
-		}
-
 		txs := b.Transactions()
 		header := b.HeaderNoCopy()
 		skipAnalysis := core.SkipAnalysis(chainConfig, blockNum)
@@ -649,11 +643,6 @@ Loop:
 
 		// MA commitTx
 		if !parallel {
-			if execStage.SyncMode() == stages.ModeApplyingBlocks ||
-				execStage.SyncMode() == stages.ModeForkValidation {
-				metrics2.UpdateBlockConsumerPostExecutionDelay(b.Time(), blockNum, logger)
-			}
-
 			select {
 			case <-logEvery.C:
 				if inMemExec || isMining {

--- a/turbo/execution/eth1/forkchoice.go
+++ b/turbo/execution/eth1/forkchoice.go
@@ -244,6 +244,8 @@ func (e *EthereumExecutionModule) updateForkChoice(ctx context.Context, original
 	}
 
 	UpdateForkChoiceArrivalDelay(fcuHeader.Time)
+	metrics.UpdateBlockConsumerPreExecutionDelay(fcuHeader.Time, fcuHeader.Number.Uint64(), e.logger)
+	defer metrics.UpdateBlockConsumerPostExecutionDelay(fcuHeader.Time, fcuHeader.Number.Uint64(), e.logger)
 
 	limitedBigJump := e.syncCfg.LoopBlockLimit > 0 && finishProgressBefore > 0 && fcuHeader.Number.Uint64()-finishProgressBefore > uint64(e.syncCfg.LoopBlockLimit-2)
 	isSynced := finishProgressBefore > 0 && finishProgressBefore > e.blockReader.FrozenBlocks() && finishProgressBefore == headersProgressBefore


### PR DESCRIPTION
Now that we are using Astrid by default it means that all of our block consumers for all chains (Ethereum/Gnosis/Polygon) use the same flow for execution - UpdateForkChoice.

This means we can simplify when/where we call `UpdateBlockConsumerPreExecutionDelay` and `UpdateBlockConsumerPostExecutionDelay`.

This should also resolve the inconsistencies that @mriccobene has seen between Polygon/Ethereum.