### PR TITLE
qa-tests: temporarily disable tests that fail after PR #13617

### DIFF
--- a/.github/workflows/scripts/run_rpc_tests.sh
+++ b/.github/workflows/scripts/run_rpc_tests.sh
@@ -4,6 +4,22 @@ set +e # Disable exit on error
 
 # Array of disabled tests
 disabled_tests=(
+    # Failing after the PR https://github.com/erigontech/erigon/pull/13617 that fixed this incompatibility
+    # issues https://hive.pectra-devnet-5.ethpandaops.io/suite.html?suiteid=1738266984-51ae1a2f376e5de5e9ba68f034f80e32.json&suitename=rpc-compat
+    eth_createAccessList/test_07.json
+    eth_createAccessList/test_08.json
+    eth_createAccessList/test_09.json
+    eth_createAccessList/test_10.json
+    eth_createAccessList/test_12.json
+    eth_createAccessList/test_14.json
+    eth_createAccessList/test_17.json
+    eth_getStorageAt/test_01.json
+    eth_getStorageAt/test_02.json
+    eth_getStorageAt/test_03.json
+    eth_getStorageAt/test_04.json
+    eth_getStorageAt/test_05.json
+    eth_getStorageAt/test_06.json
+    net_listening/test_1.json
     # Erigon2 and Erigon3 never supported this api methods
     trace_rawTransaction
     debug_getRawTransaction

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -31,7 +31,6 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/cmp"
 	"github.com/erigontech/erigon-lib/common/dbg"
-	metrics2 "github.com/erigontech/erigon-lib/common/metrics"
 	"github.com/erigontech/erigon-lib/config3"
 	"github.com/erigontech/erigon-lib/kv"
 	"github.com/erigontech/erigon-lib/kv/rawdbv3"
@@ -490,11 +489,6 @@ Loop:
 			return fmt.Errorf("nil block %d", blockNum)
 		}
 
-		if execStage.SyncMode() == stages.ModeApplyingBlocks ||
-			execStage.SyncMode() == stages.ModeForkValidation {
-			metrics2.UpdateBlockConsumerPreExecutionDelay(b.Time(), blockNum, logger)
-		}
-
 		txs := b.Transactions()
 		header := b.HeaderNoCopy()
 		skipAnalysis := core.SkipAnalysis(chainConfig, blockNum)
@@ -649,11 +643,6 @@ Loop:
 
 		// MA commitTx
 		if !parallel {
-			if execStage.SyncMode() == stages.ModeApplyingBlocks ||
-				execStage.SyncMode() == stages.ModeForkValidation {
-				metrics2.UpdateBlockConsumerPostExecutionDelay(b.Time(), blockNum, logger)
-			}
-
 			select {
 			case <-logEvery.C:
 				if inMemExec || isMining {

--- a/turbo/execution/eth1/forkchoice.go
+++ b/turbo/execution/eth1/forkchoice.go
@@ -244,6 +244,8 @@ func (e *EthereumExecutionModule) updateForkChoice(ctx context.Context, original
 	}
 
 	UpdateForkChoiceArrivalDelay(fcuHeader.Time)
+	metrics.UpdateBlockConsumerPreExecutionDelay(fcuHeader.Time, fcuHeader.Number.Uint64(), e.logger)
+	defer metrics.UpdateBlockConsumerPostExecutionDelay(fcuHeader.Time, fcuHeader.Number.Uint64(), e.logger)
 
 	limitedBigJump := e.syncCfg.LoopBlockLimit > 0 && finishProgressBefore > 0 && fcuHeader.Number.Uint64()-finishProgressBefore > uint64(e.syncCfg.LoopBlockLimit-2)
 	isSynced := finishProgressBefore > 0 && finishProgressBefore > e.blockReader.FrozenBlocks() && finishProgressBefore == headersProgressBefore


### PR DESCRIPTION
The PR  https://github.com/erigontech/erigon/pull/13617 fixed some important incompatibilities between Erigon RPC and other clients RPC as listed here: https://hive.pectra-devnet-5.ethpandaops.io/suite.html?suiteid=1738266984-51ae1a2f376e5de5e9ba68f034f80e32.json&suitename=rpc-compat

While we wait to change the tests in the suite, let's disable the ones that fail.