### PR TITLE
parent nil ptr fix

### DIFF
--- a/turbo/execution/eth1/ethereum_execution.go
+++ b/turbo/execution/eth1/ethereum_execution.go
@@ -167,8 +167,7 @@ func (e *EthereumExecutionModule) unwindToCommonCanonical(tx kv.RwTx, header *ty
 	currentHeader := header
 
 	for isCanonical, err := e.isCanonicalHash(e.bacgroundCtx, tx, currentHeader.Hash()); !isCanonical && err == nil; isCanonical, err = e.isCanonicalHash(e.bacgroundCtx, tx, currentHeader.Hash()) {
-		parentBlockHash := currentHeader.ParentHash
-		parentBlockNum := currentHeader.Number.Uint64() - 1
+		parentBlockHash, parentBlockNum := currentHeader.ParentHash, currentHeader.Number.Uint64()-1
 		currentHeader, err = e.getHeader(e.bacgroundCtx, tx, parentBlockHash, parentBlockNum)
 		if err != nil {
 			return err

--- a/turbo/execution/eth1/ethereum_execution.go
+++ b/turbo/execution/eth1/ethereum_execution.go
@@ -167,12 +167,14 @@ func (e *EthereumExecutionModule) unwindToCommonCanonical(tx kv.RwTx, header *ty
 	currentHeader := header
 
 	for isCanonical, err := e.isCanonicalHash(e.bacgroundCtx, tx, currentHeader.Hash()); !isCanonical && err == nil; isCanonical, err = e.isCanonicalHash(e.bacgroundCtx, tx, currentHeader.Hash()) {
-		currentHeader, err = e.getHeader(e.bacgroundCtx, tx, currentHeader.ParentHash, currentHeader.Number.Uint64()-1)
+		parentBlockHash := currentHeader.ParentHash
+		parentBlockNum := currentHeader.Number.Uint64() - 1
+		currentHeader, err = e.getHeader(e.bacgroundCtx, tx, parentBlockHash, parentBlockNum)
 		if err != nil {
 			return err
 		}
 		if currentHeader == nil {
-			return fmt.Errorf("header %v not found", currentHeader.Hash())
+			return fmt.Errorf("header %d, %x not found", parentBlockNum, parentBlockHash)
 		}
 	}
 	if err := e.hook.BeforeRun(tx, true); err != nil {


### PR DESCRIPTION
```
[DBUG] [01-31|15:55:48.356] Inserted block                           hash=0x3ba1f6f721c32def207c318dc049e765eeb87d1e4b81c78a8e6574bb200057b9 number=7611267
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x2a8 pc=0x1184f4f]

goroutine 270390026 [running]:
github.com/erigontech/erigon/core/types.(*Header).Hash(0x0)
    github.com/erigontech/erigon/core/types/block.go:584 +0x2f
github.com/erigontech/erigon/turbo/execution/eth1.(*EthereumExecutionModule).unwindToCommonCanonical(0xc000c043c0, {0x34c19c0, 0xc1c1982780}, 0xc0862da2c8)
    github.com/erigontech/erigon/turbo/execution/eth1/ethereum_execution.go:175 +0x425
github.com/erigontech/erigon/turbo/execution/eth1.(*EthereumExecutionModule).ValidateChain.func2({0x34c19c0?, 0xc1c1982780?})
    github.com/erigontech/erigon/turbo/execution/eth1/ethereum_execution.go:240 +0x31
github.com/erigontech/erigon-lib/kv/temporal.(*DB).Update(0xc000bb0510?, {0x348d478?, 0xc00334a230?}, 0xc2a2755a58)
    github.com/erigontech/erigon-lib@v0.0.0-00010101000000-000000000000/kv/temporal/kv_temporal.go:124 +0xb5
github.com/erigontech/erigon/turbo/execution/eth1.(*EthereumExecutionModule).ValidateChain(
    github.com/erigontech/erigon/turbo/execution/eth1/ethereum_execution.go:239 +0x52b
github.com/erigontech/erigon-lib/direct.(*ExecutionClientDirect).ValidateChain(0xc060ba0ae0?, {0x348d478?, 0xc00334a230?}, 0xc000c043c0?, {0x348d478?, 0xc00334a230?, 0x1?})
    github.com/erigontech/erigon-lib@v0.0.0-00010101000000-000000000000/direct/execution_client.go:63 +0x28
github.com/erigontech/erigon/turbo/execution/eth1/eth1_chain_reader.ChainReaderWriterEth1.ValidateChain(
```