### PR TITLE
Fixed typos

### DIFF
--- a/RELEASE_INSTRUCTIONS.md
+++ b/RELEASE_INSTRUCTIONS.md
@@ -32,9 +32,9 @@ In the file `ethdb/remote/remotedbserver/server.go` there is variable `KvService
 database schema, leading to data migrations.
 In most cases, it is enough to bump minor version. It is best to change both DB schema version and remove KV version together.
 
-## Purify the state domains if a regenration is done
+## Purify the state domains if a regeneration is done
 
-If a regenration is done, the state domains need to be purified. This can be done by running the following command:
+If a regeneration is done, the state domains need to be purified. This can be done by running the following command:
 ````
 make integration
 ./build/bin/integration purify_domains --datadir=<path to datadir> --replace-in-datadir

--- a/cmd/evm/testdata/9/readme.md
+++ b/cmd/evm/testdata/9/readme.md
@@ -23,13 +23,13 @@ There are two transactions, each invokes the contract above.
 Running it yields: 
 ```
 $ dir=./testdata/9 && ./evm t8n --state.fork=London --input.alloc=$dir/alloc.json --input.txs=$dir/txs.json --input.env=$dir/env.json --trace && cat trace-* | grep SLOAD
-{"pc":2,"op":84,"gas":"0x48c28","gasCost":"0x834","memory":"0x","memSize":0,"stack":["0x0","0x1"],"returnStack":null,"returnD
+{"pc":2,"op":84,"gas":"0x48c28","gasCost":"0x834","memory":"0x","memSize":0,"stack":["0x0","0x1"],"returnStack":null,"returned
 ata":"0x","depth":1,"refund":0,"opName":"SLOAD","error":""}
-{"pc":3,"op":84,"gas":"0x483f4","gasCost":"0x64","memory":"0x","memSize":0,"stack":["0x0","0x0"],"returnStack":null,"returnDa
+{"pc":3,"op":84,"gas":"0x483f4","gasCost":"0x64","memory":"0x","memSize":0,"stack":["0x0","0x0"],"returnStack":null,"returneda
 ta":"0x","depth":1,"refund":0,"opName":"SLOAD","error":""}
-{"pc":2,"op":84,"gas":"0x49cf4","gasCost":"0x834","memory":"0x","memSize":0,"stack":["0x0","0x1"],"returnStack":null,"returnD
+{"pc":2,"op":84,"gas":"0x49cf4","gasCost":"0x834","memory":"0x","memSize":0,"stack":["0x0","0x1"],"returnStack":null,"returned
 ata":"0x","depth":1,"refund":0,"opName":"SLOAD","error":""}
-{"pc":3,"op":84,"gas":"0x494c0","gasCost":"0x834","memory":"0x","memSize":0,"stack":["0x0","0x0"],"returnStack":null,"returnD
+{"pc":3,"op":84,"gas":"0x494c0","gasCost":"0x834","memory":"0x","memSize":0,"stack":["0x0","0x0"],"returnStack":null,"returned
 ata":"0x","depth":1,"refund":0,"opName":"SLOAD","error":""}
 ```
 

--- a/erigon-lib/downloader/README.md
+++ b/erigon-lib/downloader/README.md
@@ -43,7 +43,7 @@ the `well know` hash for a particular segment file in the following format.
 
 Where multiple version of files exists there may be several likes per segment and the code in the released Erigon version will select the version that it is interesting.
 
-As this file is versioned as part of the Erigon release process the file to hash mapping can potentially change between releases.  This can potentially cause an issue for running Erigon node which expect the downloads in the snapshots directory to remain constant, which is why a separate file is used to record the hases used by the process when it originally downloaded its files.
+As this file is versioned as part of the Erigon release process the file to hash mapping can potentially change between releases.  This can potentially cause an issue for running Erigon node which expect the downloads in the snapshots directory to remain constant, which is why a separate file is used to record the hashes used by the process when it originally downloaded its files.
 
 ## snapshot-lock.json
 


### PR DESCRIPTION
### Changes

1. **File:** `/RELEASE_INSTRUCTIONS.md`
    - Fixed `regenration` to `regeneration` (Line 37)
1. **File:** `/cmd/evm/testdata/9/readme.md`
    - Fixed `returnD` to `returned` (Line 26)
1. **File:** `/erigon-lib/downloader/README.md`
    - Fixed `hases` to `hashes` (Line 46)

### Purpose

- Enhanced the clarity and professionalism of the documentation.
- Fixed minor grammatical issues for better understanding.