### PR TITLE
Dont wait for downoader if none

### DIFF
--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -410,8 +410,14 @@ func RemoteServices(ctx context.Context, cfg *httpcfg.HttpCfg, logger log.Logger
 		}
 
 		// Configure sapshots
-		allSnapshots = freezeblocks.NewRoSnapshots(cfg.Snap, cfg.Dirs.Snap, 0, logger)
-		allBorSnapshots = heimdall.NewRoSnapshots(cfg.Snap, cfg.Dirs.Snap, 0, logger)
+
+		snapCfg := cfg.Snap
+		// this assumed the rpc deamon never runs with a downloader - if this is
+		// not the case we'll need to adjust the defaults of the --no-downlaoder
+		// flag to the faulse by default
+		snapCfg.NoDownloader = true
+		allSnapshots = freezeblocks.NewRoSnapshots(snapCfg, cfg.Dirs.Snap, 0, logger)
+		allBorSnapshots = heimdall.NewRoSnapshots(snapCfg, cfg.Dirs.Snap, 0, logger)
 
 		if polygonSync {
 			heimdallStore = heimdall.NewSnapshotStore(heimdall.NewMdbxStore(logger, cfg.Dirs.DataDir, roTxLimit), allBorSnapshots)

--- a/turbo/snapshotsync/snapshots.go
+++ b/turbo/snapshotsync/snapshots.go
@@ -569,6 +569,10 @@ func newRoSnapshots(cfg ethconfig.BlocksFreezing, snapDir string, types []snapty
 	s.segmentsMin.Store(segmentsMin)
 	s.recalcVisibleFiles()
 
+	if cfg.NoDownloader {
+		s.DownloadComplete()
+	}
+
 	return s
 }
 


### PR DESCRIPTION
Fixes:  https://github.com/erigontech/erigon/issues/13663

If there is downloader we need to call DownloadComplete in the snapshot constructor so that users of the Ready flag don't hang waiting.

This fix assumes that the rpcdeamon never runs with a downloader