### PR TITLE
Caplin: fix proposers snapshots using `epoch` as unit of measure

### DIFF
--- a/cl/antiquary/beacon_states_collector.go
+++ b/cl/antiquary/beacon_states_collector.go
@@ -136,8 +136,9 @@ func (i *beaconStatesCollector) addGenesisState(ctx context.Context, state *stat
 
 	slot := state.Slot()
 	epoch := slot / i.beaconCfg.SlotsPerEpoch
+
 	// Setup state events handlers
-	if err := i.proposersCollector.Collect(base_encoding.Encode64ToBytes4(epoch), getProposerDutiesValue(state)); err != nil {
+	if err := i.proposersCollector.Collect(base_encoding.Encode64ToBytes4(epoch*i.beaconCfg.SlotsPerEpoch), getProposerDutiesValue(state)); err != nil {
 		return err
 	}
 
@@ -266,7 +267,8 @@ func (i *beaconStatesCollector) collectActiveIndices(epoch uint64, activeIndices
 }
 
 func (i *beaconStatesCollector) collectFlattenedProposers(epoch uint64, proposers []byte) error {
-	return i.proposersCollector.Collect(base_encoding.Encode64ToBytes4(epoch), proposers)
+	slot := epoch * i.beaconCfg.SlotsPerEpoch
+	return i.proposersCollector.Collect(base_encoding.Encode64ToBytes4(slot), proposers)
 }
 
 func (i *beaconStatesCollector) collectCurrentSyncCommittee(slot uint64, committee *solid.SyncCommittee) error {

--- a/cl/beacon/handler/duties_proposer.go
+++ b/cl/beacon/handler/duties_proposer.go
@@ -57,7 +57,7 @@ func (a *ApiHandler) getDutiesProposer(w http.ResponseWriter, r *http.Request) (
 		view := a.caplinStateSnapshots.View()
 		defer view.Close()
 
-		indicies, err := state_accessors.ReadProposersInEpoch(state_accessors.GetValFnTxAndSnapshot(tx, view), epoch)
+		indicies, err := state_accessors.ReadProposersInEpoch(state_accessors.GetValFnTxAndSnapshot(tx, view), epoch+a.beaconChainCfg.SlotsPerEpoch)
 		if err != nil {
 			return nil, err
 		}

--- a/cl/persistence/state/state_accessors.go
+++ b/cl/persistence/state/state_accessors.go
@@ -175,8 +175,8 @@ func ReadActiveIndicies(getFn GetValFn, slot uint64) ([]uint64, error) {
 	return base_encoding.ReadRabbits(nil, buf)
 }
 
-func ReadProposersInEpoch(getFn GetValFn, epoch uint64) ([]uint64, error) {
-	key := base_encoding.Encode64ToBytes4(epoch)
+func ReadProposersInEpoch(getFn GetValFn, startEpochSlot uint64) ([]uint64, error) {
+	key := base_encoding.Encode64ToBytes4(startEpochSlot)
 
 	indiciesBytes, err := getFn(kv.Proposers, key)
 	if err != nil {


### PR DESCRIPTION
It should be slot