### PR TITLE
engineapi: Add request ascending order check

### DIFF
--- a/turbo/engineapi/engine_server.go
+++ b/turbo/engineapi/engine_server.go
@@ -220,10 +220,12 @@ func (s *EngineServer) newPayload(ctx context.Context, req *engine_types.Executi
 	}
 	if version >= clparams.ElectraVersion {
 		requests = make(types.FlatRequests, 0)
+		lastReqType := -1
 		for i, r := range executionRequests {
-			if len(r) <= 1 {
+			if len(r) <= 1 && lastReqType >= 0 && int(r[0]) <= lastReqType {
 				return nil, &rpc.InvalidParamsError{Message: fmt.Sprintf("Invalid Request at index %d", i)}
 			}
+			lastReqType = int(r[0])
 			requests = append(requests, types.FlatRequest{Type: r[0], RequestData: r[1:]})
 		}
 		rh := requests.Hash()

--- a/turbo/engineapi/engine_server.go
+++ b/turbo/engineapi/engine_server.go
@@ -222,7 +222,7 @@ func (s *EngineServer) newPayload(ctx context.Context, req *engine_types.Executi
 		requests = make(types.FlatRequests, 0)
 		lastReqType := -1
 		for i, r := range executionRequests {
-			if len(r) <= 1 && lastReqType >= 0 && int(r[0]) <= lastReqType {
+			if len(r) <= 1 || lastReqType >= 0 && int(r[0]) <= lastReqType {
 				return nil, &rpc.InvalidParamsError{Message: fmt.Sprintf("Invalid Request at index %d", i)}
 			}
 			lastReqType = int(r[0])


### PR DESCRIPTION
As per updated specs, this check should preemptively return -32602 
See https://github.com/ethereum/execution-apis/blob/main/src/engine/prague.md#engine_newpayloadv4