### PR TITLE
Fixed clique consensus mining process

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ make DIST=/opt/erigon install
 
 ### Run local devnet
 
-<code> 🔬 Detailed explanation is [here](/DEV_CHAIN.md).</code>
+<code> 🔬 Detailed explanation is [here](/docs/DEV_CHAIN.md).</code>
 
 ### Docker permissions error
 

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -418,6 +418,8 @@ func (c *Clique) Seal(chain consensus.ChainHeaderReader, blockWithReceipts *type
 	// For 0-period chains, refuse to seal empty blocks (no reward but would spin sealing)
 	if c.config.Period == 0 && len(block.Transactions()) == 0 {
 		c.logger.Info("Sealing paused, waiting for transactions")
+		results <- nil
+
 		return nil
 	}
 	// Don't hold the signer fields for the entire sealing procedure


### PR DESCRIPTION
We encountered an issue with producing blocks in the devnet environment when the --dev.period flag is set to 0, which is its default value. The issue was caused by an infinite wait on a channel read in one of the goroutines inside the `StartMining` function.

Additionally, in this PR, I removed the unused `noempty` variable from the `stage_mining_exec.go` file. The logic remains unchanged—I only removed if blocks that were never executed.
