### PR TITLE
refactor: using slices.Contains to simplify the code

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -22,6 +22,7 @@ package vm
 import (
 	"fmt"
 	"hash"
+	"slices"
 	"sync"
 
 	"github.com/erigontech/erigon-lib/log/v3"
@@ -58,12 +59,7 @@ var pool = sync.Pool{
 }
 
 func (vmConfig *Config) HasEip3860(rules *chain.Rules) bool {
-	for _, eip := range vmConfig.ExtraEips {
-		if eip == 3860 {
-			return true
-		}
-	}
-	return rules.IsShanghai
+	return slices.Contains(vmConfig.ExtraEips, 3860) || rules.IsShanghai
 }
 
 // Interpreter is used to run Ethereum based contracts and will utilise the


### PR DESCRIPTION
This is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.