### PR TITLE
AuRa: make IsServiceTransaction independent of Initialize

### DIFF
--- a/consensus/aura/aura.go
+++ b/consensus/aura/aura.go
@@ -230,7 +230,7 @@ func epochTransitionFor(chain consensus.ChainHeaderReader, e *NonTransactionalEp
 type AuRa struct {
 	e           *NonTransactionalEpochReader
 	exitCh      chan struct{}
-	signerMutex sync.RWMutex // Protects the signer fields
+	signerMutex sync.Mutex // Protects the signer fields
 
 	step PermissionedStep
 	// History of step hashes recently received from peers.
@@ -241,7 +241,7 @@ type AuRa struct {
 	EpochManager  *EpochManager // Mutex<EpochManager>,
 
 	certifier     *libcommon.Address // certifies service transactions
-	certifierLock sync.RWMutex
+	certifierLock sync.Mutex
 }
 
 func NewAuRa(spec *chain.AuRaConfig, db kv.RwDB) (*AuRa, error) {
@@ -1008,16 +1008,21 @@ func (c *AuRa) SealHash(header *types.Header) libcommon.Hash {
 // See https://openethereum.github.io/Permissioning.html#gas-price
 // This is thread-safe: it only accesses the `certifier` which is used behind a RWLock
 func (c *AuRa) IsServiceTransaction(sender libcommon.Address, syscall consensus.SystemCall) bool {
-	c.certifierLock.RLock()
-	defer c.certifierLock.RUnlock()
+	c.certifierLock.Lock()
+	if c.certifier == nil && c.cfg.Registrar != nil {
+		c.certifier = getCertifier(*c.cfg.Registrar, syscall)
+	}
 	if c.certifier == nil {
 		return false
 	}
+	certifier := *c.certifier
+	c.certifierLock.Unlock()
+
 	packed, err := certifierAbi().Pack("certified", sender)
 	if err != nil {
 		panic(err)
 	}
-	out, err := syscall(*c.certifier, packed)
+	out, err := syscall(certifier, packed)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Previously `IsServiceTransaction` relied on the `certifier` being set by `Initialize`. But in some contexts (e.g. Issue #13588) `IsServiceTransaction` is called w/o `Initialize`.