### PR TITLE
trie, jsonrpc: Fix `eth_getProof` format

### DIFF
--- a/erigon-lib/trie/proof.go
+++ b/erigon-lib/trie/proof.go
@@ -338,7 +338,9 @@ func VerifyAccountProofByHash(stateRoot libcommon.Hash, accountKey libcommon.Has
 }
 
 func VerifyStorageProof(storageRoot libcommon.Hash, proof accounts.StorProofResult) error {
-	storageKey := crypto.Keccak256Hash(proof.Key[:])
+	keyhash := &libcommon.Hash{}
+	keyhash.SetBytes(hexutility.FromHex(proof.Key))
+	storageKey := crypto.Keccak256Hash(keyhash[:])
 	return VerifyStorageProofByHash(storageRoot, storageKey, proof)
 }
 
@@ -354,13 +356,13 @@ func VerifyStorageProofByHash(storageRoot libcommon.Hash, keyHash libcommon.Hash
 		// if it corresponds to empty storage tree, having value EmptyRoot above
 		// then proof should be RLP encoding of empty proof (0x80)
 		if storageRoot == EmptyRoot {
-			for i, _ := range proof.Proof {
+			for i := range proof.Proof {
 				if len(proof.Proof[i]) != 1 || proof.Proof[i][0] != 0x80 {
 					return errors.New("empty storage root should have RLP encoding of empty proof")
 				}
 			}
 		} else {
-			for i, _ := range proof.Proof {
+			for i := range proof.Proof {
 				if len(proof.Proof[i]) != 0 {
 					return errors.New("zero storage root should have empty proof")
 				}

--- a/erigon-lib/trie/retain_list.go
+++ b/erigon-lib/trie/retain_list.go
@@ -205,7 +205,7 @@ func (pr *DefaultProofRetainer) ProofResult() (*accounts.AccProofResult, error) 
 
 	result.StorageProof = make([]accounts.StorProofResult, len(pr.storageKeys))
 	for i, sk := range pr.storageKeys {
-		result.StorageProof[i].Key = sk
+		result.StorageProof[i].Key = uint256.NewInt(0).SetBytes(sk[:]).Hex()
 		hexKey := pr.storageHexKeys[i]
 		if !pr.acc.Initialised || result.StorageHash == EmptyRoot {
 			// The yellow paper makes it clear that the EmptyRoot is a special case

--- a/erigon-lib/trie/retain_list_test.go
+++ b/erigon-lib/trie/retain_list_test.go
@@ -134,17 +134,17 @@ func TestProofRetainerConstruction(t *testing.T) {
 	require.Equal(t, validKeys[7], []byte(accProof.AccountProof[2]))
 
 	require.Len(t, accProof.StorageProof, 3)
-	require.Equal(t, accProof.StorageProof[0].Key, libcommon.Hash{1})
+	require.Equal(t, libcommon.HexToHash(accProof.StorageProof[0].Key), libcommon.Hash{1})
 	require.Len(t, accProof.StorageProof[0].Proof, 2)
 	require.Equal(t, validKeys[6], []byte(accProof.StorageProof[0].Proof[0]))
 	require.Equal(t, validKeys[5], []byte(accProof.StorageProof[0].Proof[1]))
 
-	require.Equal(t, accProof.StorageProof[1].Key, libcommon.Hash{2})
+	require.Equal(t, libcommon.HexToHash(accProof.StorageProof[1].Key), libcommon.Hash{2})
 	require.Len(t, accProof.StorageProof[1].Proof, 2)
 	require.Equal(t, validKeys[4], []byte(accProof.StorageProof[1].Proof[0]))
 	require.Equal(t, validKeys[3], []byte(accProof.StorageProof[1].Proof[1]))
 
-	require.Equal(t, accProof.StorageProof[2].Key, libcommon.Hash{3})
+	require.Equal(t, libcommon.HexToHash(accProof.StorageProof[2].Key), libcommon.Hash{3})
 	require.Len(t, accProof.StorageProof[2].Proof, 3)
 	require.Equal(t, validKeys[2], []byte(accProof.StorageProof[2].Proof[0]))
 	require.Equal(t, validKeys[1], []byte(accProof.StorageProof[2].Proof[1]))

--- a/erigon-lib/types/accounts/account_proof.go
+++ b/erigon-lib/types/accounts/account_proof.go
@@ -33,7 +33,7 @@ type AccProofResult struct {
 	StorageProof []StorProofResult  `json:"storageProof"`
 }
 type StorProofResult struct {
-	Key   libcommon.Hash     `json:"key"`
+	Key   string             `json:"key"`
 	Value *hexutil.Big       `json:"value"`
 	Proof []hexutility.Bytes `json:"proof"`
 }

--- a/turbo/jsonrpc/eth_api.go
+++ b/turbo/jsonrpc/eth_api.go
@@ -112,7 +112,7 @@ type EthAPI interface {
 	SendTransaction(_ context.Context, txObject interface{}) (common.Hash, error)
 	Sign(ctx context.Context, _ common.Address, _ hexutility.Bytes) (hexutility.Bytes, error)
 	SignTransaction(_ context.Context, txObject interface{}) (common.Hash, error)
-	GetProof(ctx context.Context, address common.Address, storageKeys []common.Hash, blockNr rpc.BlockNumberOrHash) (*accounts.AccProofResult, error)
+	GetProof(ctx context.Context, address common.Address, storageKeys []hexutility.Bytes, blockNr rpc.BlockNumberOrHash) (*accounts.AccProofResult, error)
 	CreateAccessList(ctx context.Context, args ethapi.CallArgs, blockNrOrHash *rpc.BlockNumberOrHash, optimizeGas *bool) (*accessListResult, error)
 
 	// Mining related (see ./eth_mining.go)


### PR DESCRIPTION
Should be able to handle inputs less than 32-bytes and output values in a compact string format to align with geth