### PR TITLE
polygon/bridge: remove unnecessary synchronize logic

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,7 @@ ChangeLog
   - `pos sync failed: fork choice update failure: status=5, validationErr=''` - should be fixed
   - `external rpc daemon getting stuck` - should be fixed
   - `process not exiting in a clean way (getting stuck) upon astrid errs` - should be fixed
+  - `very rare chance of bridge deadlock while at chain tip due to forking` - should be fixed
 
 ### TODO
 

--- a/polygon/bridge/service_test.go
+++ b/polygon/bridge/service_test.go
@@ -169,9 +169,6 @@ func TestService(t *testing.T) {
 	err = b.ProcessNewBlocks(ctx, blocks)
 	require.NoError(t, err)
 
-	err = b.Synchronize(ctx, 6)
-	require.NoError(t, err)
-
 	res, err := b.Events(ctx, 2)
 	require.NoError(t, err)
 	require.Len(t, res, 0)
@@ -284,9 +281,6 @@ func TestService_Unwind(t *testing.T) {
 	err = b.ProcessNewBlocks(ctx, blocks)
 	require.NoError(t, err)
 
-	err = b.Synchronize(ctx, 10)
-	require.NoError(t, err)
-
 	res, err := b.Events(ctx, 4)
 	require.NoError(t, err)
 	require.Len(t, res, 2)
@@ -386,9 +380,6 @@ func setupOverrideTest(t *testing.T, ctx context.Context, borConfig borcfg.BorCo
 
 	blocks := getBlocks(t, 10)
 	err = b.ProcessNewBlocks(ctx, blocks)
-	require.NoError(t, err)
-
-	err = b.Synchronize(ctx, 10)
 	require.NoError(t, err)
 
 	return b


### PR DESCRIPTION
Last week my Amoy node deadlocked (logs and explanation at the end). It was due to an edge case in `handleBridgeOnBlocksInsertAheadOfTip` and calling `bridge.Synchronize`.

Coincidentally, the logic in `bridge.Synchronize` is no longer needed (it is actually useless, pretty much no-op) after it was superseded by the logic in `bridge.waitForScraper` which does its job but I never had the time to delete it. Additionally, calling `bridge.Synchronize` in the `Sync` component is not needed as we are covered by calling `store.Flush` anyway - it ensures all pending writes to both execution engine and the bridge have finished.

Now that I noticed it got us into a deadlock it is about time to remove it.

The logs for it are:
```
[DBUG] [02-04|01:42:47.088] [bridge] processing new blocks           from=17652271 to=17652271 lastProcessedBlockNum=17652256 lastProcessedBlockTime=1738633269 lastProcessedEventId=4681
[DBUG] [02-04|01:42:47.088] [sync] inserted blocks                   from=17652271 to=17652271 blocks=1 duration=298.627µs blks/sec=3348.098
[DBUG] [02-04|01:42:48.551] [txpool] Commit                          written_kb=176 in=422.799µs
[DBUG] [02-04|01:42:51.047] [sync] applying new block hash event     blockNum=17652272 blockHash=0x39f02367aee29cdc271d3de7077e919250b2834213118693e0b4478ff9268c9f
[WARN] [02-04|01:42:51.140] [rpc] served                             conn=185.87.48.4:58560 method=eth_coinbase reqid=2 err="etherbase must be explicitly specified"
[WARN] [02-04|01:42:51.276] [rpc] served                             conn=194.67.206.50:56008 method=net_version reqid=7 err="the method net_version does not exist/is not available"
[WARN] [02-04|01:42:51.276] [rpc] served                             conn=194.67.206.50:56008 method=web3_clientVersion reqid=3 err="the method web3_clientVersion does not exist/is not available"
[WARN] [02-04|01:42:51.276] Sanitizing invalid bor gasprice oracle ignore price app=gasPriceOracle provided=2 updated=25
[DBUG] [02-04|01:42:51.277] [sync] applying new block event          blockNum=17652272 blockHash=0x39f02367aee29cdc271d3de7077e919250b2834213118693e0b4478ff9268c9f source=p2p-new-block-hashes-source paren
tBlockHash=0x59220290f3de9435d3bdb323681a101db0c9a2c4603fd4ecb50d8e241e8901ba
[DBUG] [02-04|01:42:51.277] [bor.heimdall] producers api timing      blockNum=17652272 time=5.41µs increments=1
[DBUG] [02-04|01:42:51.277] [bor.heimdall] producers api timing      blockNum=17652272 time=812ns increments=0
[INFO] [02-04|01:42:51.277] [sync] unwinding bridge due to inserting headers past the tip tip=17652271 lastInsertedNum=17652272
[DBUG] [02-04|01:42:51.277] [bor.heimdall] producers api timing      blockNum=17652272 time=1.482µs increments=0
[DBUG] [02-04|01:42:51.277] [bridge] processing new blocks           from=17652272 to=17652272 lastProcessedBlockNum=17652256 lastProcessedBlockTime=1738633269 lastProcessedEventId=4681
[DBUG] [02-04|01:42:51.278] [sync] inserted blocks                   from=17652272 to=17652272 blocks=1 duration=390.249µs blks/sec=2562.270
[DBUG] [02-04|01:42:51.278] [bridge] synchronizing events...         blockNum=17652272 lastProcessedBlockNum=17652272
[INFO] [02-04|01:42:51.278] [bridge] unwinding                       blockNum=17652271
[DBUG] [02-04|01:42:51.278] [bridge] last processed block after unwind blockNum=17652256 blockTime=1738633269
[WARN] [02-04|01:42:51.496] [rpc] served                             conn=194.67.206.43:39240 method=eth_accounts reqid=2 err="the method has been deprecated: eth_accounts"
[DBUG] [02-04|01:42:53.042] [sync] applying new block hash event     blockNum=17652273 blockHash=0x431696f073201df6af73cce81e45cb101fed592fd5ee7bb3ee33f643f7f78d14
[DBUG] [02-04|01:42:53.271] [sync] applying new block event          blockNum=17652273 blockHash=0x431696f073201df6af73cce81e45cb101fed592fd5ee7bb3ee33f643f7f78d14 source=p2p-new-block-hashes-source paren
tBlockHash=0x39f02367aee29cdc271d3de7077e919250b2834213118693e0b4478ff9268c9f
[DBUG] [02-04|01:42:53.271] [bor.heimdall] producers api timing      blockNum=17652273 time=2.815µs increments=0
[DBUG] [02-04|01:42:53.271] [bor.heimdall] producers api timing      blockNum=17652273 time=741ns increments=0
[DBUG] [02-04|01:42:53.271] [bor.heimdall] producers api timing      blockNum=17652273 time=1.723µs increments=0
[INFO] [02-04|01:42:53.271] [sync] unwinding bridge due to inserting headers past the tip tip=17652271 lastInsertedNum=17652273
[DBUG] [02-04|01:42:53.271] [bridge] processing new blocks           from=17652273 to=17652273 lastProcessedBlockNum=17652256 lastProcessedBlockTime=1738633269 lastProcessedEventId=4681
[DBUG] [02-04|01:42:53.271] [sync] inserted blocks                   from=17652273 to=17652273 blocks=1 duration=306.532µs blks/sec=3261.770
[DBUG] [02-04|01:42:53.271] [bridge] synchronizing events...         blockNum=17652273 lastProcessedBlockNum=17652256
[DBUG] [02-04|01:42:53.271] [bridge] waiting for block processing to catch up blockNum=17652272 lastProcessedBlockNum=17652256
...
Nothing happens - process is deadlocked
....
```

What happened here is we were inserting blocks on a lower priority fork (tip didn't change) and that fork went ahead of tip. In this case we trigger the `handleBridgeOnBlocksInsertAheadOfTip` case to handle bridge data consistency. That works fine the first time, but the second time it deadlocks because:
- the first block processing in the bridge ahead of tip was for `17652272` 
- that was a sprint start and after it was process it set the new `lastProcessedBlockNum=17652272`
- then it got unwinded back to `17652271` because it is ahead of tip
- this then set `lastProcessedBlockNum=17652256 ` - which is as expected - the previous sprint start
- then we had another block inserted on the same fork with lower difficulty of our main fork - ahead of tip - block  `17652273` - because this block in particular is not a sprint start block the bridge just ignores it and `lastProcessedBlockNum=17652256` remains
- then the bridge synchronise was called and it was waiting for `waiting for block processing to catch up blockNum=17652272 lastProcessedBlockNum=17652256` - which will never happen because the main writer thread is now blocked
- this situation is completely remedied by removing bridge.Synchronize
