### PR TITLE
block_building: Fix Request format in `getPayload`

### DIFF
--- a/turbo/execution/eth1/block_building.go
+++ b/turbo/execution/eth1/block_building.go
@@ -204,7 +204,7 @@ func (e *EthereumExecutionModule) GetAssembledBlock(ctx context.Context, req *ex
 		requestsBundle = &types2.RequestsBundle{}
 		requests := make([][]byte, 0)
 		for _, r := range blockWithReceipts.Requests {
-			requests = append(requests, r.RequestData)
+			requests = append(requests, r.Encode())
 		}
 		requestsBundle.Requests = requests
 	}


### PR DESCRIPTION
Previously due to a change the prefix was getting omitted from built payload