### PR TITLE
Feat/add to externalcl workflow lighthouse and gnosis support

### DIFF
--- a/.github/workflows/qa-sync-with-externalcl.yml
+++ b/.github/workflows/qa-sync-with-externalcl.yml
@@ -12,13 +12,13 @@ jobs:
     strategy:
       matrix:
         client: [lighthouse, prysm]
+        chain: [mainnet, gnosis]
     env:
       ERIGON_DATA_DIR: ${{ github.workspace }}/erigon_data
       CL_DATA_DIR: ${{ github.workspace }}/consensus
       ERIGON_QA_PATH: /home/qarunner/erigon-qa
       TRACKING_TIME_SECONDS: 7200 # 2 hours
       TOTAL_TIME_SECONDS: 18000 # 5 hours
-      CHAIN: mainnet
 
     steps:
       - name: Check out repository
@@ -58,7 +58,7 @@ jobs:
           
           # Run Erigon, wait sync and check ability to maintain sync
           python3 $ERIGON_QA_PATH/test_system/qa-tests/tip-tracking/run_and_check_tip_tracking.py \
-            ${{ github.workspace }}/build/bin $ERIGON_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN minimal_node no_statistics ${{ matrix.client }} $CL_DATA_DIR
+            ${{ github.workspace }}/build/bin $ERIGON_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 ${{ matrix.chain }} minimal_node no_statistics ${{ matrix.client }} $CL_DATA_DIR
           
           # Capture monitoring script exit status
           test_exit_status=$?
@@ -85,10 +85,10 @@ jobs:
             --commit $(git rev-parse HEAD) \
             --branch ${{ github.ref_name }} \
             --test_name sync-from-scratch-${{ matrix.client }}-minimal-node \
-            --chain $CHAIN \
+            --chain ${{ matrix.chain }} \
             --runner ${{ runner.name }} \
             --outcome $TEST_RESULT \
-            --result_file ${{ github.workspace }}/result-$CHAIN.json
+            --result_file ${{ github.workspace }}/result-${{ matrix.chain }}.json
 
       - name: Upload test results
         if: steps.test_step.outputs.test_executed == 'true'
@@ -96,7 +96,7 @@ jobs:
         with:
           name: test-results-${{ matrix.client }}
           path: |
-            ${{ github.workspace }}/result-${{ env.CHAIN }}.json
+            ${{ github.workspace }}/result-${{ matrix.chain }}.json
             ${{ github.workspace }}/erigon_data/logs/erigon.log
 
       - name: Clean up Erigon data directory

--- a/.github/workflows/qa-sync-with-externalcl.yml
+++ b/.github/workflows/qa-sync-with-externalcl.yml
@@ -102,6 +102,7 @@ jobs:
             ${{ github.workspace }}/result-${{ matrix.chain }}.json
             ${{ github.workspace }}/erigon_data/logs/erigon.log
             ${{ matrix.client == 'lighthouse' && '$CL_DATA_DIR/data/beacon/logs/beacon.log' || '' }}
+            ${{ matrix.client == 'lighthouse' && '$CL_DATA_DIR/data/beacon.log' || '' }}
 
       - name: Clean up Erigon data directory
         if: always()

--- a/.github/workflows/qa-sync-with-externalcl.yml
+++ b/.github/workflows/qa-sync-with-externalcl.yml
@@ -79,7 +79,7 @@ jobs:
             --repo erigon \
             --commit $(git rev-parse HEAD) \
             --branch ${{ github.ref_name }} \
-            --test_name sync-from-scratch-prysm-minimal-node \
+            --test_name sync-from-scratch-lighthouse-minimal-node \
             --chain $CHAIN \
             --runner ${{ runner.name }} \
             --outcome $TEST_RESULT \

--- a/.github/workflows/qa-sync-with-externalcl.yml
+++ b/.github/workflows/qa-sync-with-externalcl.yml
@@ -6,9 +6,12 @@ on:
   workflow_dispatch:     # Run manually
 
 jobs:
-  lighthouse-minimal-node-sync-from-scratch-test:
-    runs-on: self-hosted
+  sync-from-scratch-test:
+    runs-on: [self-hosted, linux, X64]
     timeout-minutes: 360 # 6 hours
+    strategy:
+      matrix:
+        client: [lighthouse, prysm]
     env:
       ERIGON_DATA_DIR: ${{ github.workspace }}/erigon_data
       CL_DATA_DIR: ${{ github.workspace }}/consensus
@@ -26,15 +29,17 @@ jobs:
           make clean
           rm -rf $ERIGON_DATA_DIR
 
-      - name: Install Lighthouse and generate JWT secret
+      - name: Install ${{ matrix.client }} and generate JWT secret
         run: |
           mkdir -p $CL_DATA_DIR
-          cd $CL_DATA_DIR
-          curl -LO https://github.com/sigp/lighthouse/releases/download/v4.0.1/lighthouse-v4.0.1-x86_64-unknown-linux-gnu.tar.gz
-          tar -xvf lighthouse-v4.0.1-x86_64-unknown-linux-gnu.tar.gz
-          rm lighthouse-v4.0.1-x86_64-unknown-linux-gnu.tar.gz
-
-          # Generate JWT secret
+          if [ "${{ matrix.client }}" == "lighthouse" ]; then
+            curl -LO https://github.com/sigp/lighthouse/releases/download/v4.0.1/lighthouse-v4.0.1-x86_64-unknown-linux-gnu.tar.gz
+            tar -xvf lighthouse-v4.0.1-x86_64-unknown-linux-gnu.tar.gz -C $CL_DATA_DIR
+            rm lighthouse-v4.0.1-x86_64-unknown-linux-gnu.tar.gz
+          elif [ "${{ matrix.client }}" == "prysm" ]; then
+            curl -L https://raw.githubusercontent.com/prysmaticlabs/prysm/master/prysm.sh -o $CL_DATA_DIR/prysm.sh
+            chmod +x $CL_DATA_DIR/prysm.sh
+          fi
           openssl rand -hex 32 > $CL_DATA_DIR/jwt.hex
 
       - name: Build Erigon
@@ -53,7 +58,7 @@ jobs:
           
           # Run Erigon, wait sync and check ability to maintain sync
           python3 $ERIGON_QA_PATH/test_system/qa-tests/tip-tracking/run_and_check_tip_tracking.py \
-            ${{ github.workspace }}/build/bin $ERIGON_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN minimal_node no_statistics lighthouse $CL_DATA_DIR
+            ${{ github.workspace }}/build/bin $ERIGON_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN minimal_node no_statistics ${{ matrix.client }} $CL_DATA_DIR
           
           # Capture monitoring script exit status
           test_exit_status=$?
@@ -79,7 +84,7 @@ jobs:
             --repo erigon \
             --commit $(git rev-parse HEAD) \
             --branch ${{ github.ref_name }} \
-            --test_name sync-from-scratch-lighthouse-minimal-node \
+            --test_name sync-from-scratch-${{ matrix.client }}-minimal-node \
             --chain $CHAIN \
             --runner ${{ runner.name }} \
             --outcome $TEST_RESULT \
@@ -89,117 +94,7 @@ jobs:
         if: steps.test_step.outputs.test_executed == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: test-results
-          path: |
-            ${{ github.workspace }}/result-${{ env.CHAIN }}.json
-            ${{ github.workspace }}/erigon_data/logs/erigon.log
-
-      - name: Clean up Erigon data directory
-        if: always()
-        run: |
-          rm -rf $ERIGON_DATA_DIR
-
-      - name: Cleanup consensus runner directory
-        if: always()
-        run: |
-          rm -rf $CL_DATA_DIR
-
-      - name: Resume the Erigon instance dedicated to db maintenance
-        run: |
-          python3 $ERIGON_QA_PATH/test_system/db-producer/resume_production.py || true
-
-      - name: Action for Success
-        if: steps.test_step.outputs.TEST_RESULT == 'success'
-        run: echo "::notice::Tests completed successfully"
-
-      - name: Action for Not Success
-        if: steps.test_step.outputs.TEST_RESULT != 'success'
-        run: |
-          echo "::error::Error detected during tests"
-          exit 1
-
-  prysm-minimal-node-sync-from-scratch-test:
-    runs-on: self-hosted
-    timeout-minutes: 360 # 6 hours
-    env:
-      ERIGON_DATA_DIR: ${{ github.workspace }}/erigon_data
-      CL_DATA_DIR: ${{ github.workspace }}/consensus
-      ERIGON_QA_PATH: /home/qarunner/erigon-qa
-      TRACKING_TIME_SECONDS: 7200 # 2 hours
-      TOTAL_TIME_SECONDS: 18000 # 5 hours
-      CHAIN: mainnet
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Clean Erigon Build & Data Directories
-        run: |
-          make clean
-          rm -rf $ERIGON_DATA_DIR
-
-      - name: Install Prysm and generate JWT secret
-        run: |
-          mkdir -p $CL_DATA_DIR
-          curl -L https://raw.githubusercontent.com/prysmaticlabs/prysm/master/prysm.sh -o $CL_DATA_DIR/prysm.sh
-          chmod +x $CL_DATA_DIR/prysm.sh
-
-          # Generate JWT secret
-          openssl rand -hex 32 > $CL_DATA_DIR/jwt.hex
-
-      - name: Build Erigon
-        run: |
-          make erigon
-        working-directory: ${{ github.workspace }}
-
-      - name: Pause the Erigon instance dedicated to db maintenance
-        run: |
-          python3 $ERIGON_QA_PATH/test_system/db-producer/pause_production.py || true
-
-      - name: Run Erigon and monitor chain sync
-        id: test_step
-        run: |
-          set +e # Disable exit on error
-          
-          # Run Erigon, wait sync and check ability to maintain sync
-          python3 $ERIGON_QA_PATH/test_system/qa-tests/tip-tracking/run_and_check_tip_tracking.py \
-            ${{ github.workspace }}/build/bin $ERIGON_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN minimal_node no_statistics prysm $CL_DATA_DIR
-          
-          # Capture monitoring script exit status
-          test_exit_status=$?
-          
-          # Save the subsection reached status
-          echo "::set-output name=test_executed::true"
-          
-          # Check test runner script exit status
-          if [ $test_exit_status -eq 0 ]; then
-            echo "Tests completed successfully"
-            echo "TEST_RESULT=success" >> "$GITHUB_OUTPUT"
-          else
-            echo "Error detected during tests"
-            echo "TEST_RESULT=failure" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Save test results
-        if: steps.test_step.outputs.test_executed == 'true'
-        env:
-          TEST_RESULT: ${{ steps.test_step.outputs.TEST_RESULT }}
-        run: |
-          python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py \
-            --repo erigon \
-            --commit $(git rev-parse HEAD) \
-            --branch ${{ github.ref_name }} \
-            --test_name sync-from-scratch-prysm-minimal-node \
-            --chain $CHAIN \
-            --runner ${{ runner.name }} \
-            --outcome $TEST_RESULT \
-            --result_file ${{ github.workspace }}/result-$CHAIN.json
-
-      - name: Upload test results
-        if: steps.test_step.outputs.test_executed == 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results
+          name: test-results-${{ matrix.client }}
           path: |
             ${{ github.workspace }}/result-${{ env.CHAIN }}.json
             ${{ github.workspace }}/erigon_data/logs/erigon.log

--- a/.github/workflows/qa-sync-with-externalcl.yml
+++ b/.github/workflows/qa-sync-with-externalcl.yml
@@ -6,6 +6,118 @@ on:
   workflow_dispatch:     # Run manually
 
 jobs:
+  lighthouse-minimal-node-sync-from-scratch-test:
+    runs-on: self-hosted
+    timeout-minutes: 360 # 6 hours
+    env:
+      ERIGON_DATA_DIR: ${{ github.workspace }}/erigon_data
+      CL_DATA_DIR: ${{ github.workspace }}/consensus
+      ERIGON_QA_PATH: /home/qarunner/erigon-qa
+      TRACKING_TIME_SECONDS: 7200 # 2 hours
+      TOTAL_TIME_SECONDS: 18000 # 5 hours
+      CHAIN: mainnet
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Clean Erigon Build & Data Directories
+        run: |
+          make clean
+          rm -rf $ERIGON_DATA_DIR
+
+      - name: Install Lighthouse and generate JWT secret
+        run: |
+          mkdir -p $CL_DATA_DIR
+          cd $CL_DATA_DIR
+          curl -LO https://github.com/sigp/lighthouse/releases/download/v4.0.1/lighthouse-v4.0.1-x86_64-unknown-linux-gnu.tar.gz
+          tar -xvf lighthouse-v4.0.1-x86_64-unknown-linux-gnu.tar.gz
+          rm lighthouse-v4.0.1-x86_64-unknown-linux-gnu.tar.gz
+
+          # Generate JWT secret
+          openssl rand -hex 32 > $CL_DATA_DIR/jwt.hex
+
+      - name: Build Erigon
+        run: |
+          make erigon
+        working-directory: ${{ github.workspace }}
+
+      - name: Pause the Erigon instance dedicated to db maintenance
+        run: |
+          python3 $ERIGON_QA_PATH/test_system/db-producer/pause_production.py || true
+
+      - name: Run Erigon and monitor chain sync
+        id: test_step
+        run: |
+          set +e # Disable exit on error
+          
+          # Run Erigon, wait sync and check ability to maintain sync
+          python3 $ERIGON_QA_PATH/test_system/qa-tests/tip-tracking/run_and_check_tip_tracking.py \
+            ${{ github.workspace }}/build/bin $ERIGON_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN minimal_node no_statistics lighthouse $CL_DATA_DIR
+          
+          # Capture monitoring script exit status
+          test_exit_status=$?
+          
+          # Save the subsection reached status
+          echo "::set-output name=test_executed::true"
+          
+          # Check test runner script exit status
+          if [ $test_exit_status -eq 0 ]; then
+            echo "Tests completed successfully"
+            echo "TEST_RESULT=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "Error detected during tests"
+            echo "TEST_RESULT=failure" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Save test results
+        if: steps.test_step.outputs.test_executed == 'true'
+        env:
+          TEST_RESULT: ${{ steps.test_step.outputs.TEST_RESULT }}
+        run: |
+          python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py \
+            --repo erigon \
+            --commit $(git rev-parse HEAD) \
+            --branch ${{ github.ref_name }} \
+            --test_name sync-from-scratch-prysm-minimal-node \
+            --chain $CHAIN \
+            --runner ${{ runner.name }} \
+            --outcome $TEST_RESULT \
+            --result_file ${{ github.workspace }}/result-$CHAIN.json
+
+      - name: Upload test results
+        if: steps.test_step.outputs.test_executed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: |
+            ${{ github.workspace }}/result-${{ env.CHAIN }}.json
+            ${{ github.workspace }}/erigon_data/logs/erigon.log
+
+      - name: Clean up Erigon data directory
+        if: always()
+        run: |
+          rm -rf $ERIGON_DATA_DIR
+
+      - name: Cleanup consensus runner directory
+        if: always()
+        run: |
+          rm -rf $CL_DATA_DIR
+
+      - name: Resume the Erigon instance dedicated to db maintenance
+        run: |
+          python3 $ERIGON_QA_PATH/test_system/db-producer/resume_production.py || true
+
+      - name: Action for Success
+        if: steps.test_step.outputs.TEST_RESULT == 'success'
+        run: echo "::notice::Tests completed successfully"
+
+      - name: Action for Not Success
+        if: steps.test_step.outputs.TEST_RESULT != 'success'
+        run: |
+          echo "::error::Error detected during tests"
+          exit 1
+
   prysm-minimal-node-sync-from-scratch-test:
     runs-on: self-hosted
     timeout-minutes: 360 # 6 hours

--- a/.github/workflows/qa-sync-with-externalcl.yml
+++ b/.github/workflows/qa-sync-with-externalcl.yml
@@ -101,6 +101,7 @@ jobs:
           path: |
             ${{ github.workspace }}/result-${{ matrix.chain }}.json
             ${{ github.workspace }}/erigon_data/logs/erigon.log
+            ${{ matrix.client == 'lighthouse' && '$CL_DATA_DIR/data/beacon/logs/beacon.log' || '' }}
 
       - name: Clean up Erigon data directory
         if: always()

--- a/.github/workflows/qa-sync-with-externalcl.yml
+++ b/.github/workflows/qa-sync-with-externalcl.yml
@@ -13,6 +13,9 @@ jobs:
       matrix:
         client: [lighthouse, prysm]
         chain: [mainnet, gnosis]
+        exclude:
+          - client: prysm
+            chain: gnosis
     env:
       ERIGON_DATA_DIR: ${{ github.workspace }}/erigon_data
       CL_DATA_DIR: ${{ github.workspace }}/consensus

--- a/.github/workflows/qa-sync-with-externalcl.yml
+++ b/.github/workflows/qa-sync-with-externalcl.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:     # Run manually
 
 jobs:
-  sync-from-scratch-test:
+  sync-with-externalcl:
     runs-on: [self-hosted, linux, X64]
     timeout-minutes: 360 # 6 hours
     strategy:

--- a/.github/workflows/qa-sync-with-externalcl.yml
+++ b/.github/workflows/qa-sync-with-externalcl.yml
@@ -11,6 +11,7 @@ jobs:
     timeout-minutes: 360 # 6 hours
     env:
       ERIGON_DATA_DIR: ${{ github.workspace }}/erigon_data
+      CL_DATA_DIR: ${{ github.workspace }}/consensus
       ERIGON_QA_PATH: /home/qarunner/erigon-qa
       TRACKING_TIME_SECONDS: 7200 # 2 hours
       TOTAL_TIME_SECONDS: 18000 # 5 hours
@@ -27,12 +28,12 @@ jobs:
 
       - name: Install Prysm and generate JWT secret
         run: |
-          mkdir -p /tmp/consensus
-          curl -L https://raw.githubusercontent.com/prysmaticlabs/prysm/master/prysm.sh -o /tmp/consensus/prysm.sh
-          chmod +x /tmp/consensus/prysm.sh
+          mkdir -p $CL_DATA_DIR
+          curl -L https://raw.githubusercontent.com/prysmaticlabs/prysm/master/prysm.sh -o $CL_DATA_DIR/prysm.sh
+          chmod +x $CL_DATA_DIR/prysm.sh
 
           # Generate JWT secret
-          openssl rand -hex 32 > /tmp/consensus/jwt.hex
+          openssl rand -hex 32 > $CL_DATA_DIR/jwt.hex
 
       - name: Build Erigon
         run: |
@@ -50,7 +51,7 @@ jobs:
           
           # Run Erigon, wait sync and check ability to maintain sync
           python3 $ERIGON_QA_PATH/test_system/qa-tests/tip-tracking/run_and_check_tip_tracking.py \
-            ${{ github.workspace }}/build/bin $ERIGON_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN minimal_node no_statistics prysm
+            ${{ github.workspace }}/build/bin $ERIGON_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN minimal_node no_statistics prysm $CL_DATA_DIR
           
           # Capture monitoring script exit status
           test_exit_status=$?
@@ -99,7 +100,7 @@ jobs:
       - name: Cleanup consensus runner directory
         if: always()
         run: |
-          rm -rf /tmp/consensus
+          rm -rf $CL_DATA_DIR
 
       - name: Resume the Erigon instance dedicated to db maintenance
         run: |

--- a/.github/workflows/qa-sync-with-externalcl.yml
+++ b/.github/workflows/qa-sync-with-externalcl.yml
@@ -87,6 +87,11 @@ jobs:
         run: |
           rm -rf $ERIGON_DATA_DIR
 
+      - name: Cleanup consensus runner directory
+        if: always()
+        run: |
+          rm -rf /tmp/consensus
+
       - name: Resume the Erigon instance dedicated to db maintenance
         run: |
           python3 $ERIGON_QA_PATH/test_system/db-producer/resume_production.py || true

--- a/.github/workflows/qa-sync-with-externalcl.yml
+++ b/.github/workflows/qa-sync-with-externalcl.yml
@@ -102,7 +102,7 @@ jobs:
             ${{ github.workspace }}/result-${{ matrix.chain }}.json
             ${{ github.workspace }}/erigon_data/logs/erigon.log
             ${{ matrix.client == 'lighthouse' && '$CL_DATA_DIR/data/beacon/logs/beacon.log' || '' }}
-            ${{ matrix.client == 'lighthouse' && '$CL_DATA_DIR/data/beacon.log' || '' }}
+            ${{ matrix.client == 'prysm' && '$CL_DATA_DIR/data/beacon.log' || '' }}
 
       - name: Clean up Erigon data directory
         if: always()

--- a/.github/workflows/qa-sync-with-externalcl.yml
+++ b/.github/workflows/qa-sync-with-externalcl.yml
@@ -36,9 +36,9 @@ jobs:
         run: |
           mkdir -p $CL_DATA_DIR
           if [ "${{ matrix.client }}" == "lighthouse" ]; then
-            curl -LO https://github.com/sigp/lighthouse/releases/download/v4.0.1/lighthouse-v4.0.1-x86_64-unknown-linux-gnu.tar.gz
-            tar -xvf lighthouse-v4.0.1-x86_64-unknown-linux-gnu.tar.gz -C $CL_DATA_DIR
-            rm lighthouse-v4.0.1-x86_64-unknown-linux-gnu.tar.gz
+            curl -LO https://github.com/sigp/lighthouse/releases/download/v5.3.0/lighthouse-v5.3.0-x86_64-unknown-linux-gnu.tar.gz
+            tar -xvf lighthouse-v5.3.0-x86_64-unknown-linux-gnu.tar.gz -C $CL_DATA_DIR
+            rm lighthouse-v5.3.0-x86_64-unknown-linux-gnu.tar.gz
           elif [ "${{ matrix.client }}" == "prysm" ]; then
             curl -L https://raw.githubusercontent.com/prysmaticlabs/prysm/master/prysm.sh -o $CL_DATA_DIR/prysm.sh
             chmod +x $CL_DATA_DIR/prysm.sh

--- a/.github/workflows/qa-sync-with-externalcl.yml
+++ b/.github/workflows/qa-sync-with-externalcl.yml
@@ -25,6 +25,15 @@ jobs:
           make clean
           rm -rf $ERIGON_DATA_DIR
 
+      - name: Install Prysm and generate JWT secret
+        run: |
+          mkdir -p /tmp/consensus
+          curl -L https://raw.githubusercontent.com/prysmaticlabs/prysm/master/prysm.sh -o /tmp/consensus/prysm.sh
+          chmod +x /tmp/consensus/prysm.sh
+
+          # Generate JWT secret
+          openssl rand -hex 32 > /tmp/consensus/jwt.hex
+
       - name: Build Erigon
         run: |
           make erigon


### PR DESCRIPTION
This PR updates the **QA sync workflow** to improve flexibility and expand compatibility with different consensus clients and networks.

#### Key Changes:
1. **Renamed Job**:  
   - Changed `prysm-minimal-node-sync-from-scratch-test` → `sync-with-externalcl` for broader applicability.

2. **Matrix Strategy for Multiple Clients & Chains**:  
   - Introduced `matrix` configuration to run tests for:
     - Clients: **Lighthouse, Prysm**
     - Chains: **Mainnet, Gnosis**
   - **Exclusion**: Prysm + Gnosis is **not** tested.

3. **Client-Specific Setup**:  
   - Lighthouse and Prysm are now dynamically installed based on the matrix configuration.
   - JWT secret is generated per test run.

4. **Erigon Sync Execution Update**:  
   - Uses `${{ matrix.chain }}` and `${{ matrix.client }}` dynamically in test execution and result logging.

5. **Enhanced Logging & Artifacts**:  
   - Client-specific logs are now uploaded as artifacts.
   - Improved log handling for both Lighthouse and Prysm.

6. **Additional Cleanup Steps**:  
   - Removed consensus layer data (`CL_DATA_DIR`) after tests to free up disk space.
