### PR TITLE
Reset each context

### DIFF
--- a/erigon-lib/commitment/hex_patricia_hashed.go
+++ b/erigon-lib/commitment/hex_patricia_hashed.go
@@ -2856,6 +2856,7 @@ func (p *ParallelPatriciaHashed) ResetContext(ctx PatriciaContext) {
 	p.root.ctx = ctx
 	for i := 0; i < len(p.mounts); i++ {
 		p.mounts[i].ResetContext(ctx)
+		p.ctx[i] = ctx
 	}
 }
 


### PR DESCRIPTION
We need to set those contexts because in the line `p.mounts[i].ctx = p.ctx[i]` of the function `unfoldRoot`

`p.mounts[i].ctx` becomes `nil`