### PR TITLE
rpcdaemon: Don't set miner

### DIFF
--- a/turbo/jsonrpc/eth_block.go
+++ b/turbo/jsonrpc/eth_block.go
@@ -34,7 +34,6 @@ import (
 	"github.com/erigontech/erigon/core/state"
 	"github.com/erigontech/erigon/core/types"
 	"github.com/erigontech/erigon/core/vm"
-	"github.com/erigontech/erigon/polygon/bor/borcfg"
 	bortypes "github.com/erigontech/erigon/polygon/bor/types"
 	"github.com/erigontech/erigon/rpc"
 	"github.com/erigontech/erigon/turbo/adapter/ethapi"
@@ -260,11 +259,6 @@ func (api *APIImpl) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber
 		}
 	}
 
-	if chainConfig.Bor != nil {
-		borConfig := chainConfig.Bor.(*borcfg.BorConfig)
-		response["miner"], _ = ecrecover(b.Header(), borConfig)
-	}
-
 	return response, err
 }
 
@@ -329,11 +323,6 @@ func (api *APIImpl) GetBlockByHash(ctx context.Context, numberOrHash rpc.BlockNu
 		for _, field := range []string{"hash", "nonce", "miner"} {
 			response[field] = nil
 		}
-	}
-
-	if chainConfig.Bor != nil {
-		borConfig := chainConfig.Bor.(*borcfg.BorConfig)
-		response["miner"], _ = ecrecover(block.Header(), borConfig)
 	}
 
 	return response, err


### PR DESCRIPTION
Fixes incorrect patch for #12690

See: https://github.com/erigontech/erigon/issues/12690#issuecomment-2654978535

```
➜  curl --request POST \
  -s --url http://127.0.0.1:8545/ \
  --header 'Content-Type: application/json' \
  --data '{
        "method": "eth_getBlockByHash",
        "params": [
                "latest",
                false
        ],
        "id": 1,
        "jsonrpc": "2.0"
}' | jq '.result.miner'
"0x0000000000000000000000000000000000000000"
➜  curl --request POST \
  -s --url http://127.0.0.1:8545/ \
  --header 'Content-Type: application/json' \
  --data '{
        "method": "eth_getBlockByNumber",
        "params": [
                "latest",
                false
        ],
        "id": 1,
        "jsonrpc": "2.0"
}' | jq '.result.miner'
"0x0000000000000000000000000000000000000000"
```