### PR TITLE
ethstats: Fix nil ptr (#13794)

### DIFF
--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -595,9 +595,9 @@ func (s *Service) reportHistory(conn *connWrapper, list []uint64) error {
 	} else {
 		// No indexes requested, send back the top ones
 		headHash := rawdb.ReadHeadBlockHash(roTx)
-		headNumber, _ := s.blockReader.HeaderNumber(context.Background(), roTx, headHash)
-		if headNumber == nil {
-			return nil
+		headNumber, err := s.blockReader.HeaderNumber(context.Background(), roTx, headHash)
+		if headNumber == nil || err != nil {
+			return err
 		}
 		start := int(*headNumber - historyUpdateRange + 1)
 		if start < 0 {
@@ -615,12 +615,12 @@ func (s *Service) reportHistory(conn *connWrapper, list []uint64) error {
 		if err != nil {
 			return err
 		}
-		td, err := rawdb.ReadTd(roTx, block.Hash(), number)
-		if err != nil {
-			return err
-		}
 		// If we do have the block, add to the history and continue
 		if block != nil {
+			td, err := rawdb.ReadTd(roTx, block.Hash(), number)
+			if err != nil {
+				return err
+			}
 			history[len(history)-1-i] = s.assembleBlockStats(block, td)
 			continue
 		}


### PR DESCRIPTION
Fixes an issue on startaup:

```
2025-02-13 13:03:15.102
[INFO] [02-13|09:03:15.101] head updated                             hash=0x67f34674738b118c66deac95137e9e4c0f47411aed142bda9b7a452537e29ee3 number=396 age=0 execution=3.025816ms mgas/s=0.00 average mgas/s=0.00 commit=696.106µs alloc=41.2MB sys=87.1MB
2025-02-13 13:03:18.152
panic: runtime error: invalid memory address or nil pointer dereference
2025-02-13 13:03:18.152
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2409c54]
2025-02-13 13:03:18.152
goroutine 154 [running]:
2025-02-13 13:03:18.152
github.com/erigontech/erigon/core/types.(*Block).Hash(...)
2025-02-13 13:03:18.152
  github.com/erigontech/erigon/core/types/block.go:1483
2025-02-13 13:03:18.152
github.com/erigontech/erigon/ethstats.(*Service).reportHistory(0xc000174160, 0xc0018ae978, {0xc001e464e0, 0x32, 0x1b?})
2025-02-13 13:03:18.152
  github.com/erigontech/erigon/ethstats/ethstats.go:618 +0x274
2025-02-13 13:03:18.152
github.com/erigontech/erigon/ethstats.(*Service).loop(0xc000174160)
2025-02-13 13:03:18.152
  github.com/erigontech/erigon/ethstats/ethstats.go:240 +0x752
2025-02-13 13:03:18.152
created by github.com/erigontech/erigon/ethstats.(*Service).Start in goroutine 1
2025-02-13 13:03:18.152
  github.com/erigontech/erigon/ethstats/ethstats.go:162 +0x4f
```

Cherry-pick #13794 