### PR TITLE
Add NodeDB metrics for DbSize and DirtySpace

### DIFF
--- a/erigon-lib/kv/kv_interface.go
+++ b/erigon-lib/kv/kv_interface.go
@@ -25,6 +25,7 @@ import (
 	"github.com/erigontech/erigon-lib/kv/order"
 	"github.com/erigontech/erigon-lib/kv/stream"
 	"github.com/erigontech/erigon-lib/metrics"
+	"github.com/erigontech/mdbx-go/mdbx"
 )
 
 //Variables Naming:
@@ -227,6 +228,8 @@ type Putter interface {
 	// CollectMetrics - does collect all DB-related and Tx-related metrics
 	// this method exists only in RwTx to avoid concurrency
 	CollectMetrics()
+	EnvInfo() (*mdbx.EnvInfo, error)
+	TxInfo() (*mdbx.TxInfo, error)
 }
 
 type Closer interface {

--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -458,6 +458,8 @@ func (db *MdbxKV) Path() string                { return db.opts.path }
 func (db *MdbxKV) PageSize() datasize.ByteSize { return db.opts.pageSize }
 func (db *MdbxKV) ReadOnly() bool              { return db.opts.HasFlag(mdbx.Readonly) }
 func (db *MdbxKV) Accede() bool                { return db.opts.HasFlag(mdbx.Accede) }
+func (db *MdbxKV) Opts() MdbxOpts              { return db.opts }
+func (db *MdbxKV) MetricsEnabled() bool        { return db.opts.metrics }
 
 func (db *MdbxKV) CHandle() unsafe.Pointer {
 	return db.env.CHandle()
@@ -671,6 +673,14 @@ func (tx *MdbxTx) Count(bucket string) (uint64, error) {
 		return 0, err
 	}
 	return st.Entries, nil
+}
+
+func (tx *MdbxTx) EnvInfo() (*mdbx.EnvInfo, error) {
+	return tx.db.env.Info(tx.tx)
+}
+
+func (tx *MdbxTx) TxInfo() (*mdbx.TxInfo, error) {
+	return tx.tx.Info(true)
 }
 
 func (tx *MdbxTx) CollectMetrics() {

--- a/erigon-lib/kv/membatchwithdb/memory_mutation.go
+++ b/erigon-lib/kv/membatchwithdb/memory_mutation.go
@@ -29,6 +29,7 @@ import (
 	"github.com/erigontech/erigon-lib/kv/order"
 	"github.com/erigontech/erigon-lib/kv/stream"
 	"github.com/erigontech/erigon-lib/log/v3"
+	mdbxgo "github.com/erigontech/mdbx-go/mdbx"
 )
 
 type MemoryMutation struct {
@@ -749,4 +750,12 @@ func (m *MemoryMutation) HistoryRange(name kv.Domain, fromTs, toTs int, asc orde
 
 func (m *MemoryMutation) HistoryStartFrom(name kv.Domain) uint64 {
 	return m.db.(kv.TemporalTx).HistoryStartFrom(name)
+}
+
+func (m *MemoryMutation) EnvInfo() (*mdbxgo.EnvInfo, error) {
+	panic("not implemented")
+}
+
+func (m *MemoryMutation) TxInfo() (*mdbxgo.TxInfo, error) {
+	panic("not implemented")
 }

--- a/p2p/enode/metrics.go
+++ b/p2p/enode/metrics.go
@@ -1,0 +1,8 @@
+package enode
+
+import "github.com/erigontech/erigon-lib/metrics"
+
+var (
+	NodeDbDbSize  = metrics.GetOrCreateGauge(`nodedb_db_size`)  //nolint
+	NodeDbTxDirty = metrics.GetOrCreateGauge(`nodedb_tx_dirty`) //nolint
+)

--- a/p2p/enode/nodedb.go
+++ b/p2p/enode/nodedb.go
@@ -263,6 +263,10 @@ func (db *DB) storeInt64(key []byte, n int64) error {
 	blob := make([]byte, binary.MaxVarintLen64)
 	blob = blob[:binary.PutVarint(blob, n)]
 	return db.kv.Batch(func(tx kv.RwTx) error {
+		metricsEnabled := db.kv.MetricsEnabled()
+		if metricsEnabled {
+			db.CollectMetrics(tx)
+		}
 		return tx.Put(kv.Inodes, key, blob)
 	})
 }
@@ -288,6 +292,10 @@ func (db *DB) fetchUint64(key []byte) uint64 {
 // storeUint64 stores an integer in the given key.
 func (db *DB) storeUint64(key []byte, n uint64) error {
 	return db.kv.Batch(func(tx kv.RwTx) error {
+		metricsEnabled := db.kv.MetricsEnabled()
+		if metricsEnabled {
+			db.CollectMetrics(tx)
+		}
 		return db._storeUint64(tx, key, n)
 	})
 }
@@ -387,6 +395,10 @@ func (db *DB) DeleteNode(id ID) {
 
 func (db *DB) deleteRange(prefix []byte) {
 	if err := db.kv.Batch(func(tx kv.RwTx) error {
+		metricsEnabled := db.kv.MetricsEnabled()
+		if metricsEnabled {
+			db.CollectMetrics(tx)
+		}
 		for bucket := range bucketsConfig(nil) {
 			if err := deleteRangeInBucket(tx, prefix, bucket); err != nil {
 				return err


### PR DESCRIPTION
This is to enable comparison of different SyncPeriod parameters for NodeDB to understand the impact on performance and select the appropriate parameter value. Related task: https://github.com/erigontech/erigon/issues/13550

The only problem is that I cannot directly use  `MdbxKV.CollectMetrics()` since that would overwrite the metrics collected from the main MDBX instance.
