### PR TITLE
Fix minor inconsistencies in server and snapshot modules

### DIFF
--- a/cl/sentinel/httpreqresp/server.go
+++ b/cl/sentinel/httpreqresp/server.go
@@ -52,7 +52,7 @@ func Do(handler http.Handler, r *http.Request) (*http.Response, error) {
 	go func() {
 		res := httptest.NewRecorder()
 		handler.ServeHTTP(res, r)
-		// linter does not know we are passing the resposne through channel.
+		// linter does not know we are passing the response through channel.
 		// nolint: bodyclose
 		resp := res.Result()
 		ans <- resp

--- a/cl/sentinel/service/start.go
+++ b/cl/sentinel/service/start.go
@@ -210,7 +210,7 @@ func StartServe(
 	// Create a gRPC server
 	gRPCserver := grpc.NewServer(grpc.Creds(creds))
 	go server.ListenToGossip()
-	// Regiser our server as a gRPC server
+	// Register our server as a gRPC server
 	sentinelrpc.RegisterSentinelServer(gRPCserver, server)
 	if err := gRPCserver.Serve(lis); err != nil {
 		log.Warn("[Sentinel] could not serve service", "reason", err)

--- a/dashboards/erigon_custom_metrics/erigon_custom_metrics.internal.json
+++ b/dashboards/erigon_custom_metrics/erigon_custom_metrics.internal.json
@@ -133,7 +133,7 @@
               "refId": "B"
             }
           ],
-          "title": "Aggregate verificiation per slot",
+          "title": "Aggregate verification per slot",
           "type": "piechart"
         }
       ],

--- a/turbo/snapshotsync/snapshots.go
+++ b/turbo/snapshotsync/snapshots.go
@@ -532,11 +532,11 @@ type RoSnapshots struct {
 	cfg         ethconfig.BlocksFreezing
 	logger      log.Logger
 
-	// allows for pruning segments - this is the min availible segment
+	// allows for pruning segments - this is the min available segment
 	segmentsMin atomic.Uint64
 	ready       ready
 	operators   map[snaptype.Enum]*retireOperators
-	alignMin    bool // do we want to align all visible segments to min availible
+	alignMin    bool // do we want to align all visible segments to min available
 }
 
 // NewRoSnapshots - opens all snapshots. But to simplify everything:


### PR DESCRIPTION
- **Refined wording in documentation and logs:**  
  - `"resposne"` → `"response"` in `server.go`  
  - `"Regiser"` → `"Register"` in `start.go`  
  - `"verificiation"` → `"verification"` in `erigon_custom_metrics.internal.json`  
  - `"availible"` → `"available"` in `snapshots.go` 
