### PR TITLE
caplin: Omit marshalling if `nil`

### DIFF
--- a/cl/clparams/config.go
+++ b/cl/clparams/config.go
@@ -210,8 +210,8 @@ type NetworkConfig struct {
 	SyncCommsSubnetKey         string `yaml:"-" json:"-"` // SyncCommsSubnetKey is the ENR key of the sync committee subnet bitfield in the enr.
 	MinimumPeersInSubnetSearch uint64 `yaml:"-" json:"-"` // PeersInSubnetSearch is the required amount of peers that we need to be able to lookup in a subnet search.
 
-	BootNodes   []string
-	StaticPeers []string
+	BootNodes   []string `yaml:"-" json:"-"`
+	StaticPeers []string `yaml:"-" json:"-"`
 }
 
 var NetworkConfigs map[NetworkType]NetworkConfig = map[NetworkType]NetworkConfig{


### PR DESCRIPTION
Fixes issue using Caplin with `go-eth2-client` due to config JSON fields being set to `null`.