### PR TITLE
Fix/externalcl gnosis lightouse wf

### DIFF
--- a/.github/workflows/qa-sync-with-externalcl.yml
+++ b/.github/workflows/qa-sync-with-externalcl.yml
@@ -20,7 +20,7 @@ jobs:
             runner: Erigon2
             reference_data_dir: /opt/erigon-versions/reference-version/datadir
           - chain: gnosis
-            client: prysm
+            client: lighthouse
             runner: Gnosis
             reference_data_dir: /opt/erigon-versions/reference-version-2/datadir
     runs-on: [ self-hosted, "${{ matrix.runner }}" ]


### PR DESCRIPTION
This PR updates the **QA sync workflow** to replace **Prysm** with **Lighthouse** as the consensus client for the **Gnosis** chain.  

### Changes  
- Modified `.github/workflows/qa-sync-with-externalcl.yml`  
  - **Updated**: `client: prysm` → `client: lighthouse` for Gnosis  
