### PR TITLE
refactor: use a more straightforward return value

### DIFF
--- a/cl/phase1/core/state/ssz.go
+++ b/cl/phase1/core/state/ssz.go
@@ -28,7 +28,7 @@ func (b *CachingBeaconState) EncodeSSZ(buf []byte) ([]byte, error) {
 	}
 	sz := metrics.NewHistTimer("encode_ssz_beacon_state_size")
 	sz.Observe(float64(len(bts)))
-	return bts, err
+	return bts, nil
 }
 
 func (b *CachingBeaconState) DecodeSSZ(buf []byte, version int) error {

--- a/cmd/devnet/blocks/fees.go
+++ b/cmd/devnet/blocks/fees.go
@@ -31,5 +31,5 @@ func BaseFeeFromBlock(ctx context.Context) (uint64, error) {
 		return 0, fmt.Errorf("failed to get base fee from block: %v\n", err)
 	}
 
-	return res.BaseFee.Uint64(), err
+	return res.BaseFee.Uint64(), nil
 }


### PR DESCRIPTION
use a more straightforward return value