### PR TITLE
Add DB label to MDBX metrics

### DIFF
--- a/erigon-lib/kv/kv_interface.go
+++ b/erigon-lib/kv/kv_interface.go
@@ -143,10 +143,11 @@ func InitSummaries(dbLabel Label) {
 	if !ok {
 		dbName := string(dbLabel)
 		MDBXSummaries[dbLabel] = &DBSummaries{
-			DbCommitWrite:  metrics.GetOrCreateSummaryWithLabels(`db_commit_seconds`, []string{dbLabelName, "phase"}, []string{dbName, "write"}),
-			DbCommitSync:   metrics.GetOrCreateSummaryWithLabels(`db_commit_seconds`, []string{dbLabelName, "phase"}, []string{dbName, "sync"}),
-			DbCommitEnding: metrics.GetOrCreateSummaryWithLabels(`db_commit_seconds`, []string{dbLabelName, "phase"}, []string{dbName, "ending"}),
-			DbCommitTotal:  metrics.GetOrCreateSummaryWithLabels(`db_commit_seconds`, []string{dbLabelName, "phase"}, []string{dbName, "total"}),
+			DbCommitPreparation: metrics.GetOrCreateSummaryWithLabels(`db_commit_seconds`, []string{dbLabelName, "phase"}, []string{dbName, "preparation"}),
+			DbCommitWrite:       metrics.GetOrCreateSummaryWithLabels(`db_commit_seconds`, []string{dbLabelName, "phase"}, []string{dbName, "write"}),
+			DbCommitSync:        metrics.GetOrCreateSummaryWithLabels(`db_commit_seconds`, []string{dbLabelName, "phase"}, []string{dbName, "sync"}),
+			DbCommitEnding:      metrics.GetOrCreateSummaryWithLabels(`db_commit_seconds`, []string{dbLabelName, "phase"}, []string{dbName, "ending"}),
+			DbCommitTotal:       metrics.GetOrCreateSummaryWithLabels(`db_commit_seconds`, []string{dbLabelName, "phase"}, []string{dbName, "total"}),
 		}
 	}
 }

--- a/erigon-lib/kv/kv_interface.go
+++ b/erigon-lib/kv/kv_interface.go
@@ -160,7 +160,6 @@ type Label string
 const (
 	Unknown         = "unknown"
 	ChainDB         = "chaindata"
-	NodeDB          = "nodedb"
 	TxPoolDB        = "txpool"
 	SentryDB        = "sentry"
 	ConsensusDB     = "consensus"

--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -902,9 +902,8 @@ func (tx *MdbxTx) Commit() error {
 		return fmt.Errorf("label: %s, %w", tx.db.opts.label, err)
 	}
 
-	dbLabel := tx.db.opts.label
-
 	if tx.db.opts.metrics {
+		dbLabel := tx.db.opts.label
 		kv.MDBXSummaries[dbLabel].DbCommitPreparation.Observe(latency.Preparation.Seconds())
 		kv.MDBXSummaries[dbLabel].DbCommitWrite.Observe(latency.Write.Seconds())
 		kv.MDBXSummaries[dbLabel].DbCommitSync.Observe(latency.Sync.Seconds())

--- a/erigon-lib/metrics/gaugevec.go
+++ b/erigon-lib/metrics/gaugevec.go
@@ -1,0 +1,60 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// Since we wrapped prometheus.Gauge into a custom interface, we need to wrap prometheus.GaugeVec into a custom struct
+type GaugeVec struct {
+	*prometheus.GaugeVec
+}
+
+func (gv *GaugeVec) Collect(ch chan<- prometheus.Metric) {
+	gv.MetricVec.Collect(ch)
+}
+
+func (gv *GaugeVec) CurryWith(labels prometheus.Labels) (*GaugeVec, error) {
+	gv2, err := gv.GaugeVec.CurryWith(labels)
+	return &GaugeVec{gv2}, err
+
+}
+
+func (gv *GaugeVec) Delete(labels prometheus.Labels) bool {
+	return gv.GaugeVec.MetricVec.Delete(labels)
+}
+
+func (gv *GaugeVec) DeleteLabelValues(lvs ...string) bool {
+	return gv.GaugeVec.MetricVec.DeleteLabelValues(lvs...)
+}
+
+func (gv *GaugeVec) DeletePartialMatch(labels prometheus.Labels) int {
+	return gv.GaugeVec.MetricVec.DeletePartialMatch(labels)
+}
+
+func (gv *GaugeVec) Describe(ch chan<- *prometheus.Desc) {
+	gv.GaugeVec.MetricVec.Describe(ch)
+}
+
+func (gv *GaugeVec) GetMetricWith(labels prometheus.Labels) (Gauge, error) {
+	g, err := gv.GaugeVec.GetMetricWith(labels)
+	return &gauge{g}, err
+}
+
+func (gv *GaugeVec) GetMetricWithLabelValues(lvs ...string) (Gauge, error) {
+	g, err := gv.GaugeVec.GetMetricWithLabelValues(lvs...)
+	return &gauge{g}, err
+}
+
+func (gv *GaugeVec) MustCurryWith(labels prometheus.Labels) *GaugeVec {
+	return &GaugeVec{gv.GaugeVec.MustCurryWith(labels)}
+}
+
+func (gv *GaugeVec) Reset() {
+	gv.GaugeVec.MetricVec.Reset()
+}
+
+func (gv *GaugeVec) With(labels prometheus.Labels) Gauge {
+	return &gauge{gv.GaugeVec.With(labels)}
+}
+
+func (gv *GaugeVec) WithLabelValues(lvs ...string) Gauge {
+	return &gauge{gv.GaugeVec.WithLabelValues(lvs...)}
+}


### PR DESCRIPTION
Currently the MDBX metrics recorded by `CollectMetrics()` are hardcoded , and work only for the main `chaindata`  MDBX instance. 

In this PR I add a label to the MDBX metrics to denote the DB instance for which the metrics are collected. 

This will enable me to tune the performance of node DB :  https://github.com/erigontech/erigon/issues/13550

