### PR TITLE
core, vm, evmtypes: added SetBalance to IntraBlockState interface

### DIFF
--- a/core/vm/evmtypes/evmtypes.go
+++ b/core/vm/evmtypes/evmtypes.go
@@ -123,6 +123,7 @@ type IntraBlockState interface {
 
 	SubBalance(common.Address, *uint256.Int, tracing.BalanceChangeReason) error
 	AddBalance(common.Address, *uint256.Int, tracing.BalanceChangeReason) error
+	SetBalance(common.Address, *uint256.Int, tracing.BalanceChangeReason) error
 	GetBalance(common.Address) (*uint256.Int, error)
 
 	GetNonce(common.Address) (uint64, error)


### PR DESCRIPTION
SetBalance is declared with AddBalance and SubBalance  in core/state/intra_block_state.go but missing from interface in core/state/intra_block_state.go but missing from interface declaration in core/vm/evmtypes/evmtypes.go