### PR TITLE
qa-tests: fix the cause of rpc tests failing intermittently

### DIFF
--- a/.github/workflows/qa-tip-tracking.yml
+++ b/.github/workflows/qa-tip-tracking.yml
@@ -37,6 +37,7 @@ jobs:
         python3 $ERIGON_QA_PATH/test_system/db-producer/pause_production.py || true
 
     - name: Save Erigon Chaindata Directory
+      id: save_chaindata_step
       run: |
         mv $ERIGON_REFERENCE_DATA_DIR/chaindata $ERIGON_TESTBED_AREA/chaindata-prev
 
@@ -116,7 +117,7 @@ jobs:
         path: ${{ github.workspace }}/metrics-${{ env.CHAIN }}-plots*
 
     - name: Restore Erigon Chaindata Directory
-      if: always()
+      if: steps.save_chaindata_step.outcome == 'success'
       run: |
         rm -rf $ERIGON_REFERENCE_DATA_DIR/chaindata
         mv $ERIGON_TESTBED_AREA/chaindata-prev $ERIGON_REFERENCE_DATA_DIR/chaindata

--- a/.github/workflows/qa-tip-tracking.yml
+++ b/.github/workflows/qa-tip-tracking.yml
@@ -36,9 +36,9 @@ jobs:
       run: |
         python3 $ERIGON_QA_PATH/test_system/db-producer/pause_production.py || true
 
-    - name: Clean Erigon Chaindata Directory
+    - name: Save Erigon Chaindata Directory
       run: |
-        rm -rf $ERIGON_REFERENCE_DATA_DIR/chaindata
+        mv $ERIGON_REFERENCE_DATA_DIR/chaindata $ERIGON_TESTBED_AREA/chaindata-prev
 
     - name: Run Erigon, wait sync and check ability to maintain sync
       id: test_step
@@ -115,10 +115,11 @@ jobs:
         name: metric-plots
         path: ${{ github.workspace }}/metrics-${{ env.CHAIN }}-plots*
 
-    - name: Clean Erigon Chaindata Directory
+    - name: Restore Erigon Chaindata Directory
       if: always()
       run: |
         rm -rf $ERIGON_REFERENCE_DATA_DIR/chaindata
+        mv $ERIGON_TESTBED_AREA/chaindata-prev $ERIGON_REFERENCE_DATA_DIR/chaindata
 
     - name: Resume the Erigon instance dedicated to db maintenance
       run: |


### PR DESCRIPTION
After a tip-tracking test the prebuilt db is left empty but Erigon is started to bring it back to the tip.
However if it starts immediately after another test the db remains almost empty; in this condition the rpc-integration tests fail.
In this PR we try to save and then restore the previous chaindata.
This is a tentative solution to https://github.com/erigontech/erigon-qa/issues/61