### PR TITLE
fix use of `erigon snapshots retire --from/to` flags

### DIFF
--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -1383,10 +1383,12 @@ func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 		if ok {
 			from, to, every = from2, to2, to2-from2
 		}
+	} else {
+		forwardProgress = to
 	}
 
 	logger.Info("Params", "from", from, "to", to, "every", every)
-	if err := br.RetireBlocks(ctx, 0, forwardProgress, log.LvlInfo, nil, nil, nil); err != nil {
+	if err := br.RetireBlocks(ctx, from, forwardProgress, log.LvlInfo, nil, nil, nil); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
From is always set to 0 and ignoring parameter;
To is checked in db if not given, but if its given, `forwardProgress` is always 0.