### PR TITLE
Fix  mdbx summaries initialization

### DIFF
--- a/erigon-lib/kv/kv_interface.go
+++ b/erigon-lib/kv/kv_interface.go
@@ -156,7 +156,7 @@ func InitSummaries(dbLabel Label) {
 }
 
 func RecordSummaries(dbLabel Label, latency mdbx.CommitLatency) error {
-	_summaries, ok := MDBXSummaries.Load(dbLabel)
+	_summaries, ok := MDBXSummaries.Load(string(dbLabel))
 	if !ok {
 		return fmt.Errorf("MDBX summaries not initialized yet for db=%s", string(dbLabel))
 	}

--- a/erigon-lib/kv/kv_interface.go
+++ b/erigon-lib/kv/kv_interface.go
@@ -137,11 +137,6 @@ func InitMDBXMGauges() *DBGauges {
 
 // initialize summaries for a particular MDBX instance
 func InitSummaries(dbLabel Label) {
-	// just in case the global singleton map is not already initialized
-	// if MDBXSummaries == nil {
-	// 	MDBXSummaries = make(map[Label]*DBSummaries)
-	// }
-
 	_, ok := MDBXSummaries.Load(dbLabel)
 	if !ok {
 		dbName := string(dbLabel)

--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -101,9 +101,6 @@ func New(label kv.Label, log log.Logger) MdbxOpts {
 	if label == kv.ChainDB {
 		opts = opts.RemoveFlags(mdbx.NoReadahead) // enable readahead for chaindata by default. Erigon3 require fast updates and prune. Also it's chaindata is small (doesen GB)
 	}
-	if opts.metrics {
-		kv.InitSummaries(label)
-	}
 	return opts
 }
 
@@ -188,6 +185,10 @@ func (opts MdbxOpts) Open(ctx context.Context) (kv.RwDB, error) {
 	}
 	if dbg.MergeTr() > 0 {
 		opts = opts.WriteMergeThreshold(uint64(dbg.MergeTr() * 8192)) //nolint
+	}
+
+	if opts.metrics {
+		kv.InitSummaries(opts.label)
 	}
 	if opts.HasFlag(mdbx.Accede) || opts.HasFlag(mdbx.Readonly) {
 		for retry := 0; ; retry++ {


### PR DESCRIPTION
- Moved the MDBX metric summaries initialization to `Open()` .
- Because the concurrent map is not statically typed, there was an issue when the Put was on key of type `string`  but Get was on a key of type `kv.Label`. Now I made both cases have type string.