### PR TITLE
Cherry-pick: Fix failure in block production (#13840)

### DIFF
--- a/cl/aggregation/pool_impl.go
+++ b/cl/aggregation/pool_impl.go
@@ -19,12 +19,12 @@ package aggregation
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 
 	"github.com/Giulio2002/bls"
 	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
 	"github.com/erigontech/erigon/cl/phase1/core/state/lru"
@@ -44,7 +44,7 @@ type aggregationPoolImpl struct {
 	netConfig      *clparams.NetworkConfig
 	ethClock       eth_clock.EthereumClock
 	aggregatesLock sync.RWMutex
-	aggregates     map[common.Hash]*solid.Attestation
+	aggregates     map[common.Hash]*solid.Attestation // don't need this anymore after electra upgrade
 	// aggregationInCommittee is a cache for aggregation in committee, which is used after electra upgrade
 	aggregatesInCommittee *lru.CacheWithTTL[keyAggrInCommittee, *solid.Attestation]
 }
@@ -78,37 +78,37 @@ func (p *aggregationPoolImpl) AddAttestation(inAtt *solid.Attestation) error {
 	if err != nil {
 		return err
 	}
-	p.aggregatesLock.Lock()
-	defer p.aggregatesLock.Unlock()
-	att, ok := p.aggregates[hashRoot]
-	if !ok {
-		p.aggregates[hashRoot] = inAtt.Copy()
-		return nil
-	}
 
-	if utils.IsOverlappingSSZBitlist(att.AggregationBits.Bytes(), inAtt.AggregationBits.Bytes()) {
-		// the on bit is already set, so ignore
-		return ErrIsSuperset
-	}
-
-	// merge signature
-	baseSig := att.Signature
-	inSig := inAtt.Signature
-	merged, err := blsAggregate([][]byte{baseSig[:], inSig[:]})
-	if err != nil {
-		return err
-	}
-	if len(merged) != 96 {
-		return errors.New("merged signature is too long")
-	}
-	var mergedSig [96]byte
-	copy(mergedSig[:], merged)
-
-	epoch := p.ethClock.GetEpochAtSlot(att.Data.Slot)
+	epoch := p.ethClock.GetEpochAtSlot(inAtt.Data.Slot)
 	clversion := p.ethClock.StateVersionByEpoch(epoch)
 	if clversion.BeforeOrEqual(clparams.DenebVersion) {
+		p.aggregatesLock.Lock()
+		defer p.aggregatesLock.Unlock()
+		att, ok := p.aggregates[hashRoot]
+		if !ok {
+			p.aggregates[hashRoot] = inAtt.Copy()
+			return nil
+		}
+
+		if utils.IsOverlappingSSZBitlist(att.AggregationBits.Bytes(), inAtt.AggregationBits.Bytes()) {
+			// the on bit is already set, so ignore
+			return ErrIsSuperset
+		}
+		// merge signature
+		baseSig := att.Signature
+		inSig := inAtt.Signature
+		merged, err := blsAggregate([][]byte{baseSig[:], inSig[:]})
+		if err != nil {
+			return err
+		}
+		if len(merged) != 96 {
+			return errors.New("merged signature is too long")
+		}
+		var mergedSig [96]byte
+		copy(mergedSig[:], merged)
+
 		// merge aggregation bits
-		mergedBits, err := att.AggregationBits.Union(inAtt.AggregationBits)
+		mergedBits, err := att.AggregationBits.Merge(inAtt.AggregationBits)
 		if err != nil {
 			return err
 		}
@@ -119,27 +119,7 @@ func (p *aggregationPoolImpl) AddAttestation(inAtt *solid.Attestation) error {
 			Signature:       mergedSig,
 		}
 	} else {
-		// Electra and after case
-		aggrBitSize := p.beaconConfig.MaxCommitteesPerSlot * p.beaconConfig.MaxValidatorsPerCommittee
-		mergedAggrBits, err := att.AggregationBits.Union(inAtt.AggregationBits)
-		if err != nil {
-			return err
-		}
-		if mergedAggrBits.Cap() != int(aggrBitSize) {
-			return fmt.Errorf("incorrect aggregation bits size: %d", mergedAggrBits.Cap())
-		}
-		mergedCommitteeBits, err := att.CommitteeBits.Union(inAtt.CommitteeBits)
-		if err != nil {
-			return err
-		}
-		p.aggregates[hashRoot] = &solid.Attestation{
-			AggregationBits: mergedAggrBits,
-			CommitteeBits:   mergedCommitteeBits,
-			Data:            att.Data,
-			Signature:       mergedSig,
-		}
-
-		// aggregate by committee
+		// Electra and after case, aggregate by committee
 		p.aggregateByCommittee(inAtt)
 	}
 	return nil
@@ -166,9 +146,15 @@ func (p *aggregationPoolImpl) aggregateByCommittee(inAtt *solid.Attestation) err
 		return nil
 	}
 
-	// merge aggregation bits and signature
-	mergedAggrBits, err := att.AggregationBits.Union(inAtt.AggregationBits)
+	if utils.IsOverlappingSSZBitlist(att.AggregationBits.Bytes(), inAtt.AggregationBits.Bytes()) {
+		// the on bit is already set, so ignore
+		return ErrIsSuperset
+	}
+
+	// It's fine to directly merge aggregation bits here, because the attestation is from the same committee
+	mergedAggrBits, err := att.AggregationBits.Merge(inAtt.AggregationBits)
 	if err != nil {
+		log.Debug("failed to merge aggregation bits", "err", err)
 		return err
 	}
 	merged, err := blsAggregate([][]byte{att.Signature[:], inAtt.Signature[:]})

--- a/cl/aggregation/pool_test.go
+++ b/cl/aggregation/pool_test.go
@@ -40,22 +40,22 @@ var (
 		},
 	}
 	att1_1 = &solid.Attestation{
-		AggregationBits: solid.BitlistFromBytes([]byte{0b00000001, 0, 0, 0}, 2048),
+		AggregationBits: solid.BitlistFromBytes([]byte{0b00000011}, 2048),
 		Data:            attData1,
 		Signature:       [96]byte{'a', 'b', 'c', 'd', 'e', 'f'},
 	}
 	att1_2 = &solid.Attestation{
-		AggregationBits: solid.BitlistFromBytes([]byte{0b00000001, 0, 0, 0}, 2048),
+		AggregationBits: solid.BitlistFromBytes([]byte{0b00000011}, 2048),
 		Data:            attData1,
 		Signature:       [96]byte{'d', 'e', 'f', 'g', 'h', 'i'},
 	}
 	att1_3 = &solid.Attestation{
-		AggregationBits: solid.BitlistFromBytes([]byte{0b00000100, 0, 0, 0}, 2048),
+		AggregationBits: solid.BitlistFromBytes([]byte{0b00001100}, 2048),
 		Data:            attData1,
 		Signature:       [96]byte{'g', 'h', 'i', 'j', 'k', 'l'},
 	}
 	att1_4 = &solid.Attestation{
-		AggregationBits: solid.BitlistFromBytes([]byte{0b00100000, 0, 0, 0}, 2048),
+		AggregationBits: solid.BitlistFromBytes([]byte{0b01100000}, 2048),
 		Data:            attData1,
 		Signature:       [96]byte{'m', 'n', 'o', 'p', 'q', 'r'},
 	}
@@ -72,7 +72,7 @@ var (
 		},
 	}
 	att2_1 = &solid.Attestation{
-		AggregationBits: solid.BitlistFromBytes([]byte{0b00000001, 0, 0, 0}, 2048),
+		AggregationBits: solid.BitlistFromBytes([]byte{0b00000001}, 2048),
 		Data:            attData2,
 		Signature:       [96]byte{'t', 'e', 's', 't', 'i', 'n'},
 	}
@@ -107,21 +107,21 @@ func (t *PoolTestSuite) TearDownTest() {
 
 func (t *PoolTestSuite) TestAddAttestationElectra() {
 	cBits1 := solid.NewBitVector(64)
-	cBits1.SetBitAt(0, true)
+	cBits1.SetBitAt(10, true)
 	cBits2 := solid.NewBitVector(64)
 	cBits2.SetBitAt(10, true)
 	expectedCommitteeBits := solid.NewBitVector(64)
-	expectedCommitteeBits.SetBitAt(0, true)
+	expectedCommitteeBits.SetBitAt(10, true)
 	expectedCommitteeBits.SetBitAt(10, true)
 
 	att1 := &solid.Attestation{
-		AggregationBits: solid.BitlistFromBytes([]byte{0b00000001, 0, 0, 0}, 2048*64),
+		AggregationBits: solid.BitlistFromBytes([]byte{0b00000011}, 2048*64),
 		Data:            attData1,
 		Signature:       [96]byte{'a', 'b', 'c', 'd', 'e', 'f'},
 		CommitteeBits:   cBits1,
 	}
 	att2 := &solid.Attestation{
-		AggregationBits: solid.BitlistFromBytes([]byte{0b00000000, 0b00001000, 0, 0}, 2048*64),
+		AggregationBits: solid.BitlistFromBytes([]byte{0b00001100}, 2048*64),
 		Data:            attData1,
 		Signature:       [96]byte{'d', 'e', 'f', 'g', 'h', 'i'},
 		CommitteeBits:   cBits2,
@@ -141,11 +141,11 @@ func (t *PoolTestSuite) TestAddAttestationElectra() {
 			},
 			hashRoot: attData1Root,
 			mockFunc: func() {
-				t.mockEthClock.EXPECT().GetEpochAtSlot(gomock.Any()).Return(uint64(1)).Times(1)
-				t.mockEthClock.EXPECT().StateVersionByEpoch(gomock.Any()).Return(clparams.ElectraVersion).Times(1)
+				t.mockEthClock.EXPECT().GetEpochAtSlot(gomock.Any()).Return(uint64(1)).Times(2)
+				t.mockEthClock.EXPECT().StateVersionByEpoch(gomock.Any()).Return(clparams.ElectraVersion).Times(2)
 			},
 			expect: &solid.Attestation{
-				AggregationBits: solid.BitlistFromBytes([]byte{0b0000001, 0b00001000, 0, 0}, 2048*64),
+				AggregationBits: solid.BitlistFromBytes([]byte{0b00001101}, 2048*64),
 				Data:            attData1,
 				Signature:       mockAggrResult,
 				CommitteeBits:   expectedCommitteeBits,
@@ -162,9 +162,7 @@ func (t *PoolTestSuite) TestAddAttestationElectra() {
 		for i := range tc.atts {
 			pool.AddAttestation(tc.atts[i])
 		}
-		att := pool.GetAggregatationByRoot(tc.hashRoot)
-		//h1, _ := tc.expect.HashSSZ()
-		//h2, _ := att.HashSSZ()
+		att := pool.GetAggregatationByRootAndCommittee(tc.hashRoot, 10)
 		t.Equal(tc.expect, att, tc.name)
 	}
 }
@@ -184,7 +182,11 @@ func (t *PoolTestSuite) TestAddAttestation() {
 				att2_1,
 			},
 			hashRoot: attData1Root,
-			expect:   att1_1,
+			mockFunc: func() {
+				t.mockEthClock.EXPECT().GetEpochAtSlot(gomock.Any()).Return(uint64(1)).AnyTimes()
+				t.mockEthClock.EXPECT().StateVersionByEpoch(gomock.Any()).Return(clparams.DenebVersion).AnyTimes()
+			},
+			expect: att1_1,
 		},
 		{
 			name: "att1_2 is a super set of att1_1. skip att1_1",
@@ -194,7 +196,11 @@ func (t *PoolTestSuite) TestAddAttestation() {
 				att2_1, // none of its business
 			},
 			hashRoot: attData1Root,
-			expect:   att1_2,
+			mockFunc: func() {
+				t.mockEthClock.EXPECT().GetEpochAtSlot(gomock.Any()).Return(uint64(1)).AnyTimes()
+				t.mockEthClock.EXPECT().StateVersionByEpoch(gomock.Any()).Return(clparams.DenebVersion).AnyTimes()
+			},
+			expect: att1_2,
 		},
 		{
 			name: "merge att1_2, att1_3, att1_4",
@@ -209,7 +215,7 @@ func (t *PoolTestSuite) TestAddAttestation() {
 				t.mockEthClock.EXPECT().StateVersionByEpoch(gomock.Any()).Return(clparams.DenebVersion).AnyTimes()
 			},
 			expect: &solid.Attestation{
-				AggregationBits: solid.BitlistFromBytes([]byte{0b00100101, 0, 0, 0}, 2048),
+				AggregationBits: solid.BitlistFromBytes([]byte{0b01100101}, 2048),
 				Data:            attData1,
 				Signature:       mockAggrResult,
 			},
@@ -226,8 +232,6 @@ func (t *PoolTestSuite) TestAddAttestation() {
 			pool.AddAttestation(tc.atts[i])
 		}
 		att := pool.GetAggregatationByRoot(tc.hashRoot)
-		//h1, _ := tc.expect.HashSSZ()
-		//h2, _ := att.HashSSZ()
 		t.Equal(tc.expect, att, tc.name)
 	}
 }

--- a/cl/clparams/config.go
+++ b/cl/clparams/config.go
@@ -533,6 +533,8 @@ type BeaconChainConfig struct {
 	DenebForkEpoch       uint64            `yaml:"DENEB_FORK_EPOCH" spec:"true" json:"DENEB_FORK_EPOCH,string"`         // DenebForkEpoch is used to represent the assigned fork epoch for Deneb.
 	ElectraForkVersion   ConfigForkVersion `yaml:"ELECTRA_FORK_VERSION" spec:"true" json:"ELECTRA_FORK_VERSION"`        // ElectraForkVersion is used to represent the fork version for Electra.
 	ElectraForkEpoch     uint64            `yaml:"ELECTRA_FORK_EPOCH" spec:"true" json:"ELECTRA_FORK_EPOCH,string"`     // ElectraForkEpoch is used to represent the assigned fork epoch for Electra.
+	FuluForkVersion      ConfigForkVersion `yaml:"FULU_FORK_VERSION" spec:"true" json:"FULU_FORK_VERSION"`              // FuluForkVersion is used to represent the fork version for Fulu.
+	FuluForkEpoch        uint64            `yaml:"FULU_FORK_EPOCH" spec:"true" json:"FULU_FORK_EPOCH,string"`           // FuluForkEpoch is used to represent the assigned fork epoch for Fulu.
 
 	ForkVersionSchedule map[libcommon.Bytes4]VersionScheduleEntry `json:"-"` // Schedule of fork epochs by version.
 
@@ -823,6 +825,8 @@ var MainnetBeaconConfig BeaconChainConfig = BeaconChainConfig{
 	DenebForkEpoch:       269568,
 	ElectraForkVersion:   0x05000000,
 	ElectraForkEpoch:     math.MaxUint64,
+	FuluForkVersion:      0x06000000,
+	FuluForkEpoch:        math.MaxUint64,
 
 	// New values introduced in Altair hard fork 1.
 	// Participation flag indices.

--- a/cl/cltypes/beacon_block.go
+++ b/cl/cltypes/beacon_block.go
@@ -162,10 +162,6 @@ func (b *BeaconBlock) Version() clparams.StateVersion {
 	return b.Body.Version
 }
 
-func (b *BeaconBlock) SetVersion(version clparams.StateVersion) {
-	b.Body.SetVersion(version)
-}
-
 func (b *BeaconBlock) EncodeSSZ(buf []byte) (dst []byte, err error) {
 	return ssz2.MarshalSSZ(buf, b.Slot, b.ProposerIndex, b.ParentRoot[:], b.StateRoot[:], b.Body)
 }
@@ -247,8 +243,8 @@ func NewBeaconBody(beaconCfg *clparams.BeaconChainConfig, version clparams.State
 	)
 	if version.AfterOrEqual(clparams.ElectraVersion) {
 		// upgrade to electra
-		maxAttSlashing = MaxAttesterSlashingsElectra
-		maxAttestation = MaxAttestationsElectra
+		maxAttSlashing = int(beaconCfg.MaxAttesterSlashingsElectra)
+		maxAttestation = int(beaconCfg.MaxAttestationsElectra)
 		executionRequests = NewExecutionRequests(beaconCfg)
 	}
 
@@ -265,15 +261,6 @@ func NewBeaconBody(beaconCfg *clparams.BeaconChainConfig, version clparams.State
 		BlobKzgCommitments: solid.NewStaticListSSZ[*KZGCommitment](MaxBlobsCommittmentsPerBlock, 48),
 		ExecutionRequests:  executionRequests,
 		Version:            version,
-	}
-}
-func (b *BeaconBody) SetVersion(version clparams.StateVersion) {
-	b.Version = version
-	b.ExecutionPayload.SetVersion(version)
-	if version.AfterOrEqual(clparams.ElectraVersion) {
-		b.AttesterSlashings = solid.NewDynamicListSSZ[*AttesterSlashing](MaxAttesterSlashingsElectra)
-		b.Attestations = solid.NewDynamicListSSZ[*solid.Attestation](MaxAttestationsElectra)
-		b.ExecutionRequests = NewExecutionRequests(b.beaconCfg)
 	}
 }
 
@@ -616,7 +603,7 @@ func (b *DenebBeaconBlock) GetParentRoot() libcommon.Hash {
 }
 
 func (b *DenebBeaconBlock) GetBody() GenericBeaconBody {
-	return b.Block.GetBody()
+	return b.Block.Body
 }
 
 type DenebSignedBeaconBlock struct {

--- a/cl/cltypes/block_production.go
+++ b/cl/cltypes/block_production.go
@@ -69,7 +69,6 @@ func (b *BlindOrExecutionBeaconBlock) ToExecution() *DenebBeaconBlock {
 	}
 	DenebBeaconBlock := NewDenebBeaconBlock(b.Cfg, b.Version())
 	DenebBeaconBlock.Block = beaconBlock
-	DenebBeaconBlock.Block.SetVersion(b.Version())
 	for _, kzgProof := range b.KzgProofs {
 		proof := KZGProof{}
 		copy(proof[:], kzgProof[:])

--- a/cl/cltypes/eth1_block.go
+++ b/cl/cltypes/eth1_block.go
@@ -110,10 +110,6 @@ func NewEth1BlockFromHeaderAndBody(header *types.Header, body *types.RawBody, be
 	return block
 }
 
-func (b *Eth1Block) SetVersion(version clparams.StateVersion) {
-	b.version = version
-}
-
 func (*Eth1Block) Static() bool {
 	return false
 }

--- a/cl/cltypes/solid/attestation.go
+++ b/cl/cltypes/solid/attestation.go
@@ -173,8 +173,8 @@ func (a *Attestation) UnmarshalJSON(data []byte) error {
 //	data: AttestationData
 //	signature: BLSSignature
 type SingleAttestation struct {
-	CommitteeIndex uint64            `json:"committee_index"`
-	AttesterIndex  uint64            `json:"attester_index"`
+	CommitteeIndex uint64            `json:"committee_index,string"`
+	AttesterIndex  uint64            `json:"attester_index,string"`
 	Data           *AttestationData  `json:"data"`
 	Signature      libcommon.Bytes96 `json:"signature"`
 }

--- a/cl/cltypes/solid/bitlist_test.go
+++ b/cl/cltypes/solid/bitlist_test.go
@@ -125,19 +125,32 @@ func TestBitListCap(t *testing.T) {
 
 // Add more tests as needed for other functions in the BitList struct.
 
-func TestBitlistUnion(t *testing.T) {
+func TestBitlistMerge(t *testing.T) {
 	require := require.New(t)
 
-	b1 := solid.NewBitList(5, 10)
-	b2 := solid.NewBitList(5, 10)
+	b1 := solid.BitlistFromBytes([]byte{0b11010000}, 10)
+	b2 := solid.BitlistFromBytes([]byte{0b00001101}, 10)
 
-	b1.Set(0, byte(0b11010000))
-	b2.Set(0, byte(0b00001101))
-
-	merged, err := b1.Union(b2)
+	merged, err := b1.Merge(b2)
 	require.NoError(err)
 
-	require.Equal(5, merged.Length(), "BitList Union did not return the expected length")
-	require.Equal(byte(0b11011101), merged.Get(0), "BitList Union did not return the expected value")
-	require.Equal(byte(0b00000000), merged.Get(1), "BitList Union did not return the expected value")
+	require.Equal(7, merged.Bits(), "BitList Merge did not return the expected number of bits")
+	require.Equal(1, merged.Length(), "BitList Union did not return the expected length")
+	require.Equal(byte(0b11010101), merged.Get(0), "BitList Union did not return the expected value")
+}
+
+func TestBitSlice(t *testing.T) {
+	require := require.New(t)
+
+	bs := solid.NewBitSlice()
+
+	bs.AppendBit(true)
+	bs.AppendBit(false)
+	bs.AppendBit(true)
+	bs.AppendBit(false)
+
+	bytes := bs.Bytes()
+
+	require.Equal([]byte{0b00000101}, bytes, "BitSlice AppendBit did not append the bits correctly")
+	require.Equal(4, bs.Length(), "BitSlice AppendBit did not increment the length correctly")
 }

--- a/cl/cltypes/solid/bitvector.go
+++ b/cl/cltypes/solid/bitvector.go
@@ -168,3 +168,13 @@ func (b *BitVector) Union(other *BitVector) (*BitVector, error) {
 	}
 	return new, nil
 }
+
+func (b *BitVector) IsOverlap(other *BitVector) bool {
+	// check by bytes
+	for i := 0; i < len(b.container) && i < len(other.container); i++ {
+		if b.container[i]&other.container[i] != 0 {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
- After Electra, the aggregation bits indicate the bit-maps that appear only in the committee bits, so merge them in a way similar to merge sort
- Fix bugs in BitList structure
- Remove the problematic SetVersion() function that leads to the empty attestation bug