### PR TITLE
chore: fixed gramm error in txDeferRollback function comment

### DIFF
--- a/rules.go
+++ b/rules.go
@@ -60,7 +60,7 @@ func txDeferRollback(m dsl.Matcher) {
 		Where(!m["rollback"].Text.Matches(`defer .*\.Rollback()`)).
 		//At(m["rollback"]).
 		Report(`Add "defer $tx.Rollback()" right after transaction creation error check. 
-			If you are in the loop - consider use "$db.View" or "$db.Update" or extract whole transaction to function.
+			If you are in the loop - consider using "$db.View" or "$db.Update" or extracting the whole transaction to a function.
 			Without rollback in defer - app can deadlock on error or panic.
 			Rules are in ./rules.go file.
 			`)


### PR DESCRIPTION
I’ve corrected a minor grammatical mistake in the comment inside the `txDeferRollback` function.
The original phrasing “consider use” was adjusted to “consider using” for clarity and correctness.