### PR TITLE
qa-tests: fix workflow timeout value for polygon tip tracking test

### DIFF
--- a/.github/workflows/qa-tip-tracking-polygon.yml
+++ b/.github/workflows/qa-tip-tracking-polygon.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   tip-tracking-test:
     runs-on: [self-hosted, Polygon]
-    timeout-minutes: 600
+    timeout-minutes: 800
     env:
       ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version/datadir
       ERIGON_TESTBED_DATA_DIR: /opt/erigon-testbed/datadir


### PR DESCRIPTION
must be:
`workflow timeout   >   TOTAL_TIME_SECONDS`