### PR TITLE
Caplin: Use common future lookahead for committee/attester duties. (#…

### DIFF
--- a/cl/beacon/handler/committees.go
+++ b/cl/beacon/handler/committees.go
@@ -91,8 +91,8 @@ func (a *ApiHandler) getCommittees(w http.ResponseWriter, r *http.Request) (*bea
 	if a.forkchoiceStore.LowestAvailableSlot() <= slot {
 		// non-finality case
 		if err := a.syncedData.ViewHeadState(func(s *state.CachingBeaconState) error {
-			if epoch > state.Epoch(s)+1 {
-				return beaconhttp.NewEndpointError(http.StatusBadRequest, fmt.Errorf("epoch %d is too far in the future", epoch))
+			if epoch > state.Epoch(s)+maxEpochsLookaheadForDuties {
+				return beaconhttp.NewEndpointError(http.StatusBadRequest, fmt.Errorf("sync committees duties: epoch %d is too far in the future", epoch))
 			}
 			// get active validator indicies
 			committeeCount := s.CommitteeCount(epoch)


### PR DESCRIPTION
…13927)

Prysm VC gave errors due to sync committee and attester duties max lookahead mismatching.