### PR TITLE
polygon/heimdall: fix snapshot store last entity to check in snapshots too (#13845)

### DIFF
--- a/polygon/heimdall/snapshot_store.go
+++ b/polygon/heimdall/snapshot_store.go
@@ -189,6 +189,10 @@ func (s *SpanSnapshotStore) LastEntityId(ctx context.Context) (uint64, bool, err
 	return lastId, ok, err
 }
 
+func (s *SpanSnapshotStore) LastEntity(ctx context.Context) (*Span, bool, error) {
+	return snapshotStoreLastEntity(ctx, s)
+}
+
 func (s *SpanSnapshotStore) ValidateSnapshots(logger log.Logger, failFast bool) error {
 	return validateSnapshots(logger, failFast, s.snapshots, s.SnapType(), generics.New[Span])
 }
@@ -312,6 +316,10 @@ func (s *MilestoneSnapshotStore) Entity(ctx context.Context, id uint64) (*Milest
 	return nil, false, fmt.Errorf("%w: %w", ErrMilestoneNotFound, err)
 }
 
+func (s *MilestoneSnapshotStore) LastEntity(ctx context.Context) (*Milestone, bool, error) {
+	return snapshotStoreLastEntity(ctx, s)
+}
+
 func (s *MilestoneSnapshotStore) ValidateSnapshots(logger log.Logger, failFast bool) error {
 	return validateSnapshots(logger, failFast, s.snapshots, s.SnapType(), generics.New[Milestone])
 }
@@ -345,7 +353,7 @@ func (s *CheckpointSnapshotStore) WithTx(tx kv.Tx) EntityStore[*Checkpoint] {
 	return &CheckpointSnapshotStore{txEntityStore[*Checkpoint]{s.EntityStore.(*mdbxEntityStore[*Checkpoint]), tx}, s.snapshots}
 }
 
-func (s *CheckpointSnapshotStore) LastCheckpointId(ctx context.Context, tx kv.Tx) (uint64, bool, error) {
+func (s *CheckpointSnapshotStore) LastEntityId(ctx context.Context) (uint64, bool, error) {
 	lastId, ok, err := s.EntityStore.LastEntityId(ctx)
 
 	snapshotLastCheckpointId := s.LastFrozenEntityId()
@@ -425,6 +433,10 @@ func (s *CheckpointSnapshotStore) LastFrozenEntityId() uint64 {
 	return index.BaseDataID() + index.KeyCount() - 1
 }
 
+func (s *CheckpointSnapshotStore) LastEntity(ctx context.Context) (*Checkpoint, bool, error) {
+	return snapshotStoreLastEntity(ctx, s)
+}
+
 func (s *CheckpointSnapshotStore) ValidateSnapshots(logger log.Logger, failFast bool) error {
 	return validateSnapshots(logger, failFast, s.snapshots, s.SnapType(), generics.New[Checkpoint])
 }
@@ -481,4 +493,13 @@ func validateSnapshots[T Entity](logger log.Logger, failFast bool, snaps *RoSnap
 	}
 
 	return accumulatedErr
+}
+
+func snapshotStoreLastEntity[T Entity](ctx context.Context, store EntityStore[T]) (T, bool, error) {
+	entityId, ok, err := store.LastEntityId(ctx)
+	if err != nil || !ok {
+		return generics.Zero[T](), false, err
+	}
+
+	return store.Entity(ctx, entityId)
 }


### PR DESCRIPTION
cherry-pick https://github.com/erigontech/erigon/pull/13845 patch into release/3.0

highlighted by https://github.com/erigontech/erigon/issues/13746 
relates to https://github.com/erigontech/erigon/pull/13844#discussion_r1958403527 snapshot store should return last entity from snapshots if there are none in the db