### PR TITLE
txnprovider/shutter: fixes to identity preimage hash ssz and logging

### DIFF
--- a/txnprovider/shutter/decryption_keys_signature_data.go
+++ b/txnprovider/shutter/decryption_keys_signature_data.go
@@ -42,15 +42,15 @@ const (
 
 type IdentityPreimage [identityPreimageSize]byte
 
-func (ip IdentityPreimage) EncodingSizeSSZ() int {
+func (ip *IdentityPreimage) EncodingSizeSSZ() int {
 	return identityPreimageSize
 }
 
-func (ip IdentityPreimage) EncodeSSZ(dst []byte) ([]byte, error) {
+func (ip *IdentityPreimage) EncodeSSZ(dst []byte) ([]byte, error) {
 	return append(dst, ip[:]...), nil
 }
 
-func (ip IdentityPreimage) DecodeSSZ(buf []byte, _ int) error {
+func (ip *IdentityPreimage) DecodeSSZ(buf []byte, _ int) error {
 	if len(buf) != identityPreimageSize {
 		return fmt.Errorf("%w: len=%d", ErrIncorrectIdentityPreimageSize, len(ip))
 	}
@@ -59,28 +59,28 @@ func (ip IdentityPreimage) DecodeSSZ(buf []byte, _ int) error {
 	return nil
 }
 
-func (ip IdentityPreimage) Clone() clonable.Clonable {
+func (ip *IdentityPreimage) Clone() clonable.Clonable {
 	clone := IdentityPreimage(slices.Clone(ip[:]))
 	return &clone
 }
 
-func (ip IdentityPreimage) HashSSZ() ([32]byte, error) {
+func (ip *IdentityPreimage) HashSSZ() ([32]byte, error) {
 	return merkletree.BytesRoot(ip[:])
 }
 
-func (ip IdentityPreimage) String() string {
+func (ip *IdentityPreimage) String() string {
 	return hexutil.Encode(ip[:])
 }
 
-func IdentityPreimageFromBytes(b []byte) (IdentityPreimage, error) {
+func IdentityPreimageFromBytes(b []byte) (*IdentityPreimage, error) {
 	var ip IdentityPreimage
 	err := ip.DecodeSSZ(b, 0)
-	return ip, err
+	return &ip, err
 }
 
-type IdentityPreimages []IdentityPreimage
+type IdentityPreimages []*IdentityPreimage
 
-func (ips IdentityPreimages) ToListSSZ() *solid.ListSSZ[IdentityPreimage] {
+func (ips IdentityPreimages) ToListSSZ() *solid.ListSSZ[*IdentityPreimage] {
 	return solid.NewStaticListSSZFromList(ips, identityPreimagesLimit, identityPreimageSize)
 }
 
@@ -89,7 +89,7 @@ type DecryptionKeysSignatureData struct {
 	Eon               EonIndex
 	Slot              uint64
 	TxnPointer        uint64
-	IdentityPreimages *solid.ListSSZ[IdentityPreimage]
+	IdentityPreimages *solid.ListSSZ[*IdentityPreimage]
 }
 
 func (d DecryptionKeysSignatureData) HashSSZ() ([32]byte, error) {

--- a/txnprovider/shutter/decryption_keys_signature_data_test.go
+++ b/txnprovider/shutter/decryption_keys_signature_data_test.go
@@ -49,7 +49,7 @@ func TestDecryptionKeysSignatureDataWithInvalidPreimagesLength(t *testing.T) {
 	require.ErrorIs(t, err, shutter.ErrTooManyIdentityPreimages)
 }
 
-func TestDecryptionKeysSignatureDataHashSsz(t *testing.T) {
+func TestDecryptionKeysSignatureDataHashSSZ(t *testing.T) {
 	// cross-referencing the hash that is produced by github.com/shutter-network/rolling-shutter
 	// for the same signature data input
 	want := "259bf7718b7430abc238ec0ac3260574dd73d23005adec26eed1a655ccdcc1ec"

--- a/txnprovider/shutter/decryption_keys_signature_data_test.go
+++ b/txnprovider/shutter/decryption_keys_signature_data_test.go
@@ -1,6 +1,7 @@
 package shutter_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -46,4 +47,22 @@ func TestDecryptionKeysSignatureDataWithInvalidPreimagesLength(t *testing.T) {
 	require.ErrorIs(t, err, shutter.ErrTooManyIdentityPreimages)
 	_, err = sigData.Sign(nil)
 	require.ErrorIs(t, err, shutter.ErrTooManyIdentityPreimages)
+}
+
+func TestDecryptionKeysSignatureDataHashSsz(t *testing.T) {
+	// cross-referencing the hash that is produced by github.com/shutter-network/rolling-shutter
+	// for the same signature data input
+	want := "259bf7718b7430abc238ec0ac3260574dd73d23005adec26eed1a655ccdcc1ec"
+	slot := uint64(6336)
+	sigData := shutter.DecryptionKeysSignatureData{
+		InstanceId:        123,
+		Eon:               76,
+		Slot:              slot,
+		TxnPointer:        556,
+		IdentityPreimages: testhelpers.MockIdentityPreimagesWithSlotIp(t, slot, 2).ToListSSZ(),
+	}
+
+	have, err := sigData.HashSSZ()
+	require.NoError(t, err)
+	require.Equal(t, want, fmt.Sprintf("%x", have))
 }

--- a/txnprovider/shutter/eon_tracker.go
+++ b/txnprovider/shutter/eon_tracker.go
@@ -158,7 +158,7 @@ func (et *KsmEonTracker) handleBlockEvent(blockEvent BlockEvent) error {
 		return err
 	}
 
-	if et.currentEon.Index != eon.Index {
+	if et.currentEon == nil || et.currentEon.Index != eon.Index {
 		et.logger.Debug("current eon at block", "blockNum", blockEvent.LatestBlockNum, "eonIndex", eon.Index)
 	}
 

--- a/txnprovider/shutter/eon_tracker.go
+++ b/txnprovider/shutter/eon_tracker.go
@@ -158,7 +158,10 @@ func (et *KsmEonTracker) handleBlockEvent(blockEvent BlockEvent) error {
 		return err
 	}
 
-	et.logger.Debug("current eon at block", "blockNum", blockEvent.LatestBlockNum, "eonIndex", eon.Index)
+	if et.currentEon.Index != eon.Index {
+		et.logger.Debug("current eon at block", "blockNum", blockEvent.LatestBlockNum, "eonIndex", eon.Index)
+	}
+
 	et.currentEon = &eon
 	et.recentEons.ReplaceOrInsert(eon)
 	et.maybeCleanup(blockEvent.LatestBlockNum)
@@ -174,7 +177,7 @@ func (et *KsmEonTracker) readEonAtNewBlockEvent(blockNum uint64) (Eon, error) {
 			return
 		}
 
-		et.logger.Debug("readEonAtNewBlockEvent timing", "blockNum", blockNum, "cached", cached, "duration", time.Since(startTime))
+		et.logger.Trace("readEonAtNewBlockEvent timing", "blockNum", blockNum, "cached", cached, "duration", time.Since(startTime))
 	}()
 
 	callOpts := &bind.CallOpts{BlockNumber: new(big.Int).SetUint64(blockNum)}

--- a/txnprovider/shutter/internal/testhelpers/eon_key_generation_mock_data.go
+++ b/txnprovider/shutter/internal/testhelpers/eon_key_generation_mock_data.go
@@ -68,7 +68,7 @@ func (ekg EonKeyGeneration) DecryptionKeys(t *testing.T, signers []Keyper, ips s
 	return keys
 }
 
-func (ekg EonKeyGeneration) EpochSecretKey(t *testing.T, signers []Keyper, ip shutter.IdentityPreimage) *shuttercrypto.EpochSecretKey {
+func (ekg EonKeyGeneration) EpochSecretKey(t *testing.T, signers []Keyper, ip *shutter.IdentityPreimage) *shuttercrypto.EpochSecretKey {
 	epochSecretKeyShares := make([]*shuttercrypto.EpochSecretKeyShare, len(signers))
 	keyperIndices := make([]int, len(signers))
 	for i, keyper := range signers {
@@ -96,7 +96,7 @@ func (k Keyper) Address() libcommon.Address {
 	return crypto.PubkeyToAddress(k.PublicKey())
 }
 
-func (k Keyper) EpochSecretKeyShare(ip shutter.IdentityPreimage) *shuttercrypto.EpochSecretKeyShare {
+func (k Keyper) EpochSecretKeyShare(ip *shutter.IdentityPreimage) *shuttercrypto.EpochSecretKeyShare {
 	id := shuttercrypto.ComputeEpochID(ip[:])
 	return shuttercrypto.ComputeEpochSecretKeyShare(k.EonSecretKeyShare, id)
 }

--- a/txnprovider/shutter/internal/testhelpers/identity_preimage_mock_data.go
+++ b/txnprovider/shutter/internal/testhelpers/identity_preimage_mock_data.go
@@ -33,7 +33,7 @@ func MockIdentityPreimagesWithSlotIp(t *testing.T, slot uint64, count uint64) sh
 }
 
 func MockIdentityPreimages(t *testing.T, count uint64) shutter.IdentityPreimages {
-	ips := make([]shutter.IdentityPreimage, count)
+	ips := make([]*shutter.IdentityPreimage, count)
 	for i := uint64(0); i < count; i++ {
 		ips[i] = Uint64ToIdentityPreimage(t, i)
 	}
@@ -41,7 +41,7 @@ func MockIdentityPreimages(t *testing.T, count uint64) shutter.IdentityPreimages
 	return ips
 }
 
-func MakeSlotIdentityPreimage(t *testing.T, slot uint64) shutter.IdentityPreimage {
+func MakeSlotIdentityPreimage(t *testing.T, slot uint64) *shutter.IdentityPreimage {
 	// 32 bytes of zeros plus the block number as 20 byte big endian (ie starting with lots of
 	// zeros as well). This ensures the block identity preimage is always alphanumerically before
 	// any transaction identity preimages, because sender addresses cannot be that small.
@@ -53,7 +53,7 @@ func MakeSlotIdentityPreimage(t *testing.T, slot uint64) shutter.IdentityPreimag
 	return ip
 }
 
-func Uint64ToIdentityPreimage(t *testing.T, i uint64) shutter.IdentityPreimage {
+func Uint64ToIdentityPreimage(t *testing.T, i uint64) *shutter.IdentityPreimage {
 	buf := make([]byte, 52)
 	binary.BigEndian.PutUint64(buf[:8], i)
 	ip, err := shutter.IdentityPreimageFromBytes(buf)


### PR DESCRIPTION
found a few issues during testing:
- fix identity preimage hash ssz
- logging verbosity (was too chatty)