### PR TITLE
jsonrpc: remove index length <32 check from `eth_getStorageAt`

### DIFF
--- a/turbo/jsonrpc/eth_accounts.go
+++ b/turbo/jsonrpc/eth_accounts.go
@@ -18,7 +18,6 @@ package jsonrpc
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/big"
 

--- a/turbo/jsonrpc/eth_accounts.go
+++ b/turbo/jsonrpc/eth_accounts.go
@@ -18,6 +18,7 @@ package jsonrpc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -121,6 +122,12 @@ func (api *APIImpl) GetCode(ctx context.Context, address libcommon.Address, bloc
 func (api *APIImpl) GetStorageAt(ctx context.Context, address libcommon.Address, index string, blockNrOrHash rpc.BlockNumberOrHash) (string, error) {
 	var empty []byte
 	tx, err1 := api.db.BeginTemporalRo(ctx)
+
+	indexBytes := hexutility.FromHex(index)
+	if len(indexBytes) > 32 {
+		return "", errors.New("unable to decode storage key: hex string too long, want at most 32 bytes")
+	}
+
 	if err1 != nil {
 		return hexutility.Encode(libcommon.LeftPadBytes(empty, 32)), err1
 	}

--- a/turbo/jsonrpc/eth_accounts.go
+++ b/turbo/jsonrpc/eth_accounts.go
@@ -121,7 +121,7 @@ func (api *APIImpl) GetCode(ctx context.Context, address libcommon.Address, bloc
 // GetStorageAt implements eth_getStorageAt. Returns the value from a storage position at a given address.
 func (api *APIImpl) GetStorageAt(ctx context.Context, address libcommon.Address, index string, blockNrOrHash rpc.BlockNumberOrHash) (string, error) {
 	var empty []byte
-	indexBytes := libcommon.HexToHash(index)
+	indexBytes := libcommon.Hex2Bytes(index)
 	if len(indexBytes) < 32 {
 		return "", errors.New("unable to decode storage key: hex string invalid")
 	}

--- a/turbo/jsonrpc/eth_accounts.go
+++ b/turbo/jsonrpc/eth_accounts.go
@@ -121,13 +121,13 @@ func (api *APIImpl) GetCode(ctx context.Context, address libcommon.Address, bloc
 // GetStorageAt implements eth_getStorageAt. Returns the value from a storage position at a given address.
 func (api *APIImpl) GetStorageAt(ctx context.Context, address libcommon.Address, index string, blockNrOrHash rpc.BlockNumberOrHash) (string, error) {
 	var empty []byte
-	tx, err1 := api.db.BeginTemporalRo(ctx)
 
 	indexBytes := hexutility.FromHex(index)
 	if len(indexBytes) > 32 {
 		return "", errors.New("unable to decode storage key: hex string too long, want at most 32 bytes")
 	}
 
+	tx, err1 := api.db.BeginTemporalRo(ctx)
 	if err1 != nil {
 		return hexutility.Encode(libcommon.LeftPadBytes(empty, 32)), err1
 	}

--- a/turbo/jsonrpc/eth_accounts.go
+++ b/turbo/jsonrpc/eth_accounts.go
@@ -121,7 +121,7 @@ func (api *APIImpl) GetCode(ctx context.Context, address libcommon.Address, bloc
 // GetStorageAt implements eth_getStorageAt. Returns the value from a storage position at a given address.
 func (api *APIImpl) GetStorageAt(ctx context.Context, address libcommon.Address, index string, blockNrOrHash rpc.BlockNumberOrHash) (string, error) {
 	var empty []byte
-	indexBytes := hexutility.FromHex(index)
+	indexBytes := libcommon.HexToHash(index)
 	if len(indexBytes) < 32 {
 		return "", errors.New("unable to decode storage key: hex string invalid")
 	}

--- a/turbo/jsonrpc/eth_accounts.go
+++ b/turbo/jsonrpc/eth_accounts.go
@@ -121,7 +121,6 @@ func (api *APIImpl) GetCode(ctx context.Context, address libcommon.Address, bloc
 // GetStorageAt implements eth_getStorageAt. Returns the value from a storage position at a given address.
 func (api *APIImpl) GetStorageAt(ctx context.Context, address libcommon.Address, index string, blockNrOrHash rpc.BlockNumberOrHash) (string, error) {
 	var empty []byte
-
 	indexBytes := hexutility.FromHex(index)
 	if len(indexBytes) > 32 {
 		return "", errors.New("unable to decode storage key: hex string too long, want at most 32 bytes")

--- a/turbo/jsonrpc/eth_accounts.go
+++ b/turbo/jsonrpc/eth_accounts.go
@@ -121,14 +121,6 @@ func (api *APIImpl) GetCode(ctx context.Context, address libcommon.Address, bloc
 // GetStorageAt implements eth_getStorageAt. Returns the value from a storage position at a given address.
 func (api *APIImpl) GetStorageAt(ctx context.Context, address libcommon.Address, index string, blockNrOrHash rpc.BlockNumberOrHash) (string, error) {
 	var empty []byte
-	indexBytes := libcommon.Hex2Bytes(index)
-	if len(indexBytes) < 32 {
-		return "", errors.New("unable to decode storage key: hex string invalid")
-	}
-	if len(indexBytes) > 32 {
-		return "", errors.New("unable to decode storage key: hex string too long, want at most 32 bytes")
-	}
-
 	tx, err1 := api.db.BeginTemporalRo(ctx)
 	if err1 != nil {
 		return hexutility.Encode(libcommon.LeftPadBytes(empty, 32)), err1


### PR DESCRIPTION
This was done earlier to align with a hive test, but there is no need for this check.