### PR TITLE
jsonrpc: remove index length <32 check from `eth_getStorageAt`

### DIFF
--- a/turbo/jsonrpc/eth_accounts.go
+++ b/turbo/jsonrpc/eth_accounts.go
@@ -117,9 +117,7 @@ func (api *APIImpl) GetCode(ctx context.Context, address libcommon.Address, bloc
 func (api *APIImpl) GetStorageAt(ctx context.Context, address libcommon.Address, index string, blockNrOrHash rpc.BlockNumberOrHash) (string, error) {
 	var empty []byte
 	indexBytes := hexutil.FromHex(index)
-	if len(indexBytes) < 32 {
-		return "", errors.New("unable to decode storage key: hex string invalid")
-	}
+
 	if len(indexBytes) > 32 {
 		return "", errors.New("unable to decode storage key: hex string too long, want at most 32 bytes")
 	}


### PR DESCRIPTION
This was done earlier to align with a hive test, but there is no need for this check.