### PR TITLE
qa-tests: fix tip-tracking workflow under cancellation

### DIFF
--- a/.github/workflows/qa-tip-tracking.yml
+++ b/.github/workflows/qa-tip-tracking.yml
@@ -118,12 +118,15 @@ jobs:
         path: ${{ github.workspace }}/metrics-${{ env.CHAIN }}-plots*
 
     - name: Restore Erigon Chaindata Directory
-      if: steps.save_chaindata_step.outcome == 'success'
+      if: ${{ always() }}
       run: |
-        rm -rf $ERIGON_REFERENCE_DATA_DIR/chaindata
-        mv $ERIGON_TESTBED_AREA/chaindata-prev $ERIGON_REFERENCE_DATA_DIR/chaindata
+        if [ -d "$ERIGON_TESTBED_AREA/chaindata-prev" ]; then
+          rm -rf $ERIGON_REFERENCE_DATA_DIR/chaindata
+          mv $ERIGON_TESTBED_AREA/chaindata-prev $ERIGON_REFERENCE_DATA_DIR/chaindata
+        fi
 
     - name: Resume the Erigon instance dedicated to db maintenance
+      if: ${{ always() }}
       run: |
         python3 $ERIGON_QA_PATH/test_system/db-producer/resume_production.py || true
 


### PR DESCRIPTION
On cancellation the guard condition to restore the chaindata will fail even if the step was successful.
So we now use always() to handle workflow cancellation