### PR TITLE
Add syncbytes threshold to NodeDB

### DIFF
--- a/erigon-lib/go.mod
+++ b/erigon-lib/go.mod
@@ -11,7 +11,7 @@ replace (
 require (
 	github.com/erigontech/erigon-snapshot v1.3.1-0.20250121111444-6cc4c0c1fb89
 	github.com/erigontech/interfaces v0.0.0-20250218124515-7c4293b6afb3
-	github.com/erigontech/mdbx-go v0.38.6-0.20250205222432-e4dd01978d7f
+	github.com/erigontech/mdbx-go v0.38.6
 	github.com/erigontech/secp256k1 v1.1.0
 	github.com/rs/dnscache v0.0.0-20211102005908-e0241e321417
 )

--- a/erigon-lib/go.sum
+++ b/erigon-lib/go.sum
@@ -156,8 +156,8 @@ github.com/erigontech/go-kzg-4844 v0.0.0-20250130131058-ce13be60bc86 h1:UKcIbFZU
 github.com/erigontech/go-kzg-4844 v0.0.0-20250130131058-ce13be60bc86/go.mod h1:JolLjpSff1tCCJKaJx4psrlEdlXuJEC996PL3tTAFks=
 github.com/erigontech/interfaces v0.0.0-20250218124515-7c4293b6afb3 h1:Qwd3asRe5aeKzV/oHgADLu92db2417AM5ApjpT8MD1o=
 github.com/erigontech/interfaces v0.0.0-20250218124515-7c4293b6afb3/go.mod h1:N7OUkhkcagp9+7yb4ycHsG2VWCOmuJ1ONBecJshxtLE=
-github.com/erigontech/mdbx-go v0.38.6-0.20250205222432-e4dd01978d7f h1:2uZv1SGd7bIfdjUVx6GWdg9xNBWWc84iXSiOeeKpaOQ=
-github.com/erigontech/mdbx-go v0.38.6-0.20250205222432-e4dd01978d7f/go.mod h1:lkqHAZqXtFaIPlvTaGAx3VUDuGYZcuhve1l4JVVN1Z0=
+github.com/erigontech/mdbx-go v0.38.6 h1:uPqx9goWwNsvfdY44di2Pp0D1gAn2XsYaiVJSopVqjs=
+github.com/erigontech/mdbx-go v0.38.6/go.mod h1:lkqHAZqXtFaIPlvTaGAx3VUDuGYZcuhve1l4JVVN1Z0=
 github.com/erigontech/secp256k1 v1.1.0 h1:mO3YJMUSoASE15Ya//SoHiisptUhdXExuMUN1M0X9qY=
 github.com/erigontech/secp256k1 v1.1.0/go.mod h1:GokhPepsMB+EYDs7I5JZCprxHW6+yfOcJKaKtoZ+Fls=
 github.com/erigontech/speedtest v0.0.2 h1:W9Cvky/8AMUtUONwkLA/dZjeQ2XfkBdYfJzvhMZUO+U=

--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -355,10 +355,6 @@ func (opts MdbxOpts) Open(ctx context.Context) (kv.RwDB, error) {
 		}
 	}
 
-	// if err := env.SetOption(mdbx.OptSyncBytes, uint64(math2.MaxUint64)); err != nil {
-	// 	return nil, err
-	// }
-
 	if opts.roTxsLimiter == nil {
 		targetSemCount := int64(runtime.GOMAXPROCS(-1) * 16)
 		opts.roTxsLimiter = semaphore.NewWeighted(targetSemCount) // 1 less than max to allow unlocking to happen

--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -66,6 +66,7 @@ type MdbxOpts struct {
 	bucketsCfg      TableCfgFunc
 	path            string
 	syncPeriod      time.Duration
+	syncBytes       *uint
 	mapSize         datasize.ByteSize
 	growthStep      datasize.ByteSize
 	shrinkThreshold int
@@ -118,6 +119,7 @@ func (opts MdbxOpts) PageSize(v datasize.ByteSize) MdbxOpts       { opts.pageSiz
 func (opts MdbxOpts) GrowthStep(v datasize.ByteSize) MdbxOpts     { opts.growthStep = v; return opts }
 func (opts MdbxOpts) Path(path string) MdbxOpts                   { opts.path = path; return opts }
 func (opts MdbxOpts) SyncPeriod(period time.Duration) MdbxOpts    { opts.syncPeriod = period; return opts }
+func (opts MdbxOpts) SyncBytes(threshold uint) MdbxOpts           { opts.syncBytes = &threshold; return opts }
 func (opts MdbxOpts) DBVerbosity(v kv.DBVerbosityLvl) MdbxOpts    { opts.verbosity = v; return opts }
 func (opts MdbxOpts) MapSize(sz datasize.ByteSize) MdbxOpts       { opts.mapSize = sz; return opts }
 func (opts MdbxOpts) WriteMergeThreshold(v uint64) MdbxOpts       { opts.mergeThreshold = v; return opts }
@@ -345,9 +347,17 @@ func (opts MdbxOpts) Open(ctx context.Context) (kv.RwDB, error) {
 			return nil, err
 		}
 	}
-	//if err := env.SetOption(mdbx.OptSyncBytes, uint64(math2.MaxUint64)); err != nil {
-	//	return nil, err
-	//}
+
+	if opts.syncBytes != nil {
+		if err = env.SetSyncBytes(*opts.syncBytes); err != nil {
+			env.Close()
+			return nil, err
+		}
+	}
+
+	// if err := env.SetOption(mdbx.OptSyncBytes, uint64(math2.MaxUint64)); err != nil {
+	// 	return nil, err
+	// }
 
 	if opts.roTxsLimiter == nil {
 		targetSemCount := int64(runtime.GOMAXPROCS(-1) * 16)

--- a/erigon-lib/kv/mdbx/kv_mdbx_test.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx_test.go
@@ -1112,7 +1112,7 @@ func BenchmarkDB_ResetSequence(b *testing.B) {
 }
 
 func TestMdbxWithSyncBytes(t *testing.T) {
-	_, err := New(kv.TemporaryDB, log.Root()).
+	db, err := New(kv.TemporaryDB, log.Root()).
 		Path(t.TempDir()).
 		MapSize(8 * datasize.GB).
 		GrowthStep(16 * datasize.MB).
@@ -1125,4 +1125,5 @@ func TestMdbxWithSyncBytes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open mdbx")
 	}
+	t.Cleanup(db.Close)
 }

--- a/go.sum
+++ b/go.sum
@@ -271,8 +271,6 @@ github.com/erigontech/go-kzg-4844 v0.0.0-20250130131058-ce13be60bc86 h1:UKcIbFZU
 github.com/erigontech/go-kzg-4844 v0.0.0-20250130131058-ce13be60bc86/go.mod h1:JolLjpSff1tCCJKaJx4psrlEdlXuJEC996PL3tTAFks=
 github.com/erigontech/mdbx-go v0.38.6 h1:uPqx9goWwNsvfdY44di2Pp0D1gAn2XsYaiVJSopVqjs=
 github.com/erigontech/mdbx-go v0.38.6/go.mod h1:lkqHAZqXtFaIPlvTaGAx3VUDuGYZcuhve1l4JVVN1Z0=
-github.com/erigontech/mdbx-go v0.39.2 h1:XxzAcWAifhAYuMZdW/KIiiLxmlLBjjY+gzSTbnF3bFA=
-github.com/erigontech/mdbx-go v0.39.2/go.mod h1:ncKVXcwnMpZ+wIye89HLVglDwXFXbEY2L1OI1Iahgzk=
 github.com/erigontech/secp256k1 v1.1.0 h1:mO3YJMUSoASE15Ya//SoHiisptUhdXExuMUN1M0X9qY=
 github.com/erigontech/secp256k1 v1.1.0/go.mod h1:GokhPepsMB+EYDs7I5JZCprxHW6+yfOcJKaKtoZ+Fls=
 github.com/erigontech/silkworm-go v0.24.0 h1:fFe74CjQM5LI7ouMYjmqfFaqIFzQTpMrt+ls+a5PxpE=

--- a/go.sum
+++ b/go.sum
@@ -271,6 +271,8 @@ github.com/erigontech/go-kzg-4844 v0.0.0-20250130131058-ce13be60bc86 h1:UKcIbFZU
 github.com/erigontech/go-kzg-4844 v0.0.0-20250130131058-ce13be60bc86/go.mod h1:JolLjpSff1tCCJKaJx4psrlEdlXuJEC996PL3tTAFks=
 github.com/erigontech/mdbx-go v0.38.6 h1:uPqx9goWwNsvfdY44di2Pp0D1gAn2XsYaiVJSopVqjs=
 github.com/erigontech/mdbx-go v0.38.6/go.mod h1:lkqHAZqXtFaIPlvTaGAx3VUDuGYZcuhve1l4JVVN1Z0=
+github.com/erigontech/mdbx-go v0.39.2 h1:XxzAcWAifhAYuMZdW/KIiiLxmlLBjjY+gzSTbnF3bFA=
+github.com/erigontech/mdbx-go v0.39.2/go.mod h1:ncKVXcwnMpZ+wIye89HLVglDwXFXbEY2L1OI1Iahgzk=
 github.com/erigontech/secp256k1 v1.1.0 h1:mO3YJMUSoASE15Ya//SoHiisptUhdXExuMUN1M0X9qY=
 github.com/erigontech/secp256k1 v1.1.0/go.mod h1:GokhPepsMB+EYDs7I5JZCprxHW6+yfOcJKaKtoZ+Fls=
 github.com/erigontech/silkworm-go v0.24.0 h1:fFe74CjQM5LI7ouMYjmqfFaqIFzQTpMrt+ls+a5PxpE=

--- a/p2p/enode/nodedb.go
+++ b/p2p/enode/nodedb.go
@@ -62,9 +62,10 @@ const (
 )
 
 const (
-	dbNodeExpiration = 24 * time.Hour // Time after which an unseen node should be dropped.
-	dbCleanupCycle   = time.Hour      // Time period for running the expiration task.
-	dbVersion        = 10
+	dbNodeExpiration     = 24 * time.Hour // Time after which an unseen node should be dropped.
+	dbCleanupCycle       = time.Hour      // Time period for running the expiration task.
+	dbVersion            = 10
+	dbSyncBytesThreshold = 20_000 // if we have about 20kb of dirty data , then flush to disk
 )
 
 var (
@@ -124,7 +125,8 @@ func newPersistentDB(ctx context.Context, logger log.Logger, path string) (*DB, 
 		WithTableCfg(bucketsConfig).
 		MapSize(8 * datasize.GB).
 		GrowthStep(16 * datasize.MB).
-		Flags(func(f uint) uint { return f ^ mdbx1.Durable | mdbx1.SafeNoSync }).
+		Flags(func(f uint) uint { return f&^mdbx1.Durable | mdbx1.SafeNoSync }).
+		SyncBytes(dbSyncBytesThreshold).
 		SyncPeriod(2 * time.Second).
 		DirtySpace(uint64(64 * datasize.MB)).
 		// WithMetrics().


### PR DESCRIPTION
Dirty data will be flushed to disk automatically when the size threshold of `syncBytes` is reached or when  the time period of `syncPeriod` is reached.