### PR TITLE
Saner txn gas names

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -717,8 +717,8 @@ func (b *SimulatedBackend) callContract(_ context.Context, call ethereum.CallMsg
 	if call.FeeCap == nil {
 		call.FeeCap = uint256.NewInt(baseFeeUpperLimit)
 	}
-	if call.Tip == nil {
-		call.Tip = uint256.NewInt(baseFeeUpperLimit)
+	if call.TipCap == nil {
+		call.TipCap = uint256.NewInt(baseFeeUpperLimit)
 	}
 	if call.Gas == 0 {
 		call.Gas = 50000000
@@ -849,7 +849,7 @@ func (m callMsg) CheckNonce() bool                      { return false }
 func (m callMsg) To() *libcommon.Address                { return m.CallMsg.To }
 func (m callMsg) GasPrice() *uint256.Int                { return m.CallMsg.GasPrice }
 func (m callMsg) FeeCap() *uint256.Int                  { return m.CallMsg.FeeCap }
-func (m callMsg) Tip() *uint256.Int                     { return m.CallMsg.Tip }
+func (m callMsg) TipCap() *uint256.Int                  { return m.CallMsg.TipCap }
 func (m callMsg) Gas() uint64                           { return m.CallMsg.Gas }
 func (m callMsg) Value() *uint256.Int                   { return m.CallMsg.Value }
 func (m callMsg) Data() []byte                          { return m.CallMsg.Data }

--- a/cmd/devnet/requests/transaction.go
+++ b/cmd/devnet/requests/transaction.go
@@ -48,11 +48,11 @@ func (reqGen *requestGenerator) EstimateGas(args ethereum.CallMsg, blockRef Bloc
 		gasPrice = &big
 	}
 
-	var tip *hexutil.Big
+	var tipCap *hexutil.Big
 
-	if args.Tip != nil {
-		big := hexutil.Big(*args.Tip.ToBig())
-		tip = &big
+	if args.TipCap != nil {
+		big := hexutil.Big(*args.TipCap.ToBig())
+		tipCap = &big
 	}
 
 	var feeCap *hexutil.Big
@@ -81,7 +81,7 @@ func (reqGen *requestGenerator) EstimateGas(args ethereum.CallMsg, blockRef Bloc
 		To:                   args.To,
 		Gas:                  &gas,
 		GasPrice:             gasPrice,
-		MaxPriorityFeePerGas: tip,
+		MaxPriorityFeePerGas: tipCap,
 		MaxFeePerGas:         feeCap,
 		Value:                value,
 		Data:                 data,

--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -413,11 +413,11 @@ func getTransaction(txJson ethapi.RPCTransaction) (types.Transaction, error) {
 	}
 
 	commonTx := types.CommonTx{
-		Nonce: uint64(txJson.Nonce),
-		To:    txJson.To,
-		Value: value,
-		Gas:   uint64(txJson.Gas),
-		Data:  txJson.Input,
+		Nonce:    uint64(txJson.Nonce),
+		To:       txJson.To,
+		Value:    value,
+		GasLimit: uint64(txJson.Gas),
+		Data:     txJson.Input,
 	}
 
 	commonTx.V.SetFromBig(txJson.V.ToInt())

--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -441,17 +441,17 @@ func getTransaction(txJson ethapi.RPCTransaction) (types.Transaction, error) {
 			AccessList: *txJson.Accesses,
 		}, nil
 	} else if txJson.Type == types.DynamicFeeTxType || txJson.Type == types.SetCodeTxType {
-		var tip *uint256.Int
+		var tipCap *uint256.Int
 		var feeCap *uint256.Int
-		if txJson.Tip != nil {
-			tip, overflow = uint256.FromBig(txJson.Tip.ToInt())
+		if txJson.MaxPriorityFeePerGas != nil {
+			tipCap, overflow = uint256.FromBig(txJson.MaxPriorityFeePerGas.ToInt())
 			if overflow {
 				return nil, errors.New("maxPriorityFeePerGas field caused an overflow (uint256)")
 			}
 		}
 
-		if txJson.FeeCap != nil {
-			feeCap, overflow = uint256.FromBig(txJson.FeeCap.ToInt())
+		if txJson.MaxFeePerGas != nil {
+			feeCap, overflow = uint256.FromBig(txJson.MaxFeePerGas.ToInt())
 			if overflow {
 				return nil, errors.New("maxFeePerGas field caused an overflow (uint256)")
 			}
@@ -461,7 +461,7 @@ func getTransaction(txJson ethapi.RPCTransaction) (types.Transaction, error) {
 			//it's ok to copy here - because it's constructor of object - no parallel access yet
 			CommonTx:   commonTx, //nolint
 			ChainID:    chainId,
-			Tip:        tip,
+			TipCap:     tipCap,
 			FeeCap:     feeCap,
 			AccessList: *txJson.Accesses,
 		}

--- a/cmd/snapshots/genfromrpc/genfromrpc.go
+++ b/cmd/snapshots/genfromrpc/genfromrpc.go
@@ -130,7 +130,7 @@ func parseCommonTx(rawTx map[string]interface{}) (*types.CommonTx, error) {
 	if !ok {
 		return nil, errors.New("missing gas")
 	}
-	commonTx.Gas = convertHexToBigInt(gasStr).Uint64()
+	commonTx.GasLimit = convertHexToBigInt(gasStr).Uint64()
 
 	if toStr, ok := rawTx["to"].(string); ok && toStr != "" {
 		addr := common.HexToAddress(toStr)
@@ -194,14 +194,14 @@ func decodeBlobVersionedHashes(rawVersionedHashes []string) []common.Hash {
 func makeLegacyTx(commonTx *types.CommonTx, rawTx map[string]interface{}) types.Transaction {
 	tx := &types.LegacyTx{
 		CommonTx: types.CommonTx{
-			Nonce: commonTx.Nonce,
-			Gas:   commonTx.Gas,
-			To:    commonTx.To,
-			Value: commonTx.Value,
-			Data:  commonTx.Data,
-			V:     commonTx.V,
-			R:     commonTx.R,
-			S:     commonTx.S,
+			Nonce:    commonTx.Nonce,
+			GasLimit: commonTx.GasLimit,
+			To:       commonTx.To,
+			Value:    commonTx.Value,
+			Data:     commonTx.Data,
+			V:        commonTx.V,
+			R:        commonTx.R,
+			S:        commonTx.S,
 		},
 		GasPrice: getUint256FromField(rawTx, "gasPrice"),
 	}
@@ -213,14 +213,14 @@ func makeAccessListTx(commonTx *types.CommonTx, rawTx map[string]interface{}) ty
 	tx := &types.AccessListTx{
 		LegacyTx: types.LegacyTx{
 			CommonTx: types.CommonTx{
-				Nonce: commonTx.Nonce,
-				Gas:   commonTx.Gas,
-				To:    commonTx.To,
-				Value: commonTx.Value,
-				Data:  commonTx.Data,
-				V:     commonTx.V,
-				R:     commonTx.R,
-				S:     commonTx.S,
+				Nonce:    commonTx.Nonce,
+				GasLimit: commonTx.GasLimit,
+				To:       commonTx.To,
+				Value:    commonTx.Value,
+				Data:     commonTx.Data,
+				V:        commonTx.V,
+				R:        commonTx.R,
+				S:        commonTx.S,
 			},
 			GasPrice: getUint256FromField(rawTx, "gasPrice"),
 		},
@@ -237,14 +237,14 @@ func makeAccessListTx(commonTx *types.CommonTx, rawTx map[string]interface{}) ty
 // makeEip1559Tx builds an EIP-1559 dynamic fee transaction.
 func makeEip1559Tx(commonTx *types.CommonTx, rawTx map[string]interface{}) types.Transaction {
 	tx := &types.DynamicFeeTransaction{CommonTx: types.CommonTx{
-		Nonce: commonTx.Nonce,
-		Gas:   commonTx.Gas,
-		To:    commonTx.To,
-		Value: commonTx.Value,
-		Data:  commonTx.Data,
-		V:     commonTx.V,
-		R:     commonTx.R,
-		S:     commonTx.S,
+		Nonce:    commonTx.Nonce,
+		GasLimit: commonTx.GasLimit,
+		To:       commonTx.To,
+		Value:    commonTx.Value,
+		Data:     commonTx.Data,
+		V:        commonTx.V,
+		R:        commonTx.R,
+		S:        commonTx.S,
 	}}
 	buildDynamicFeeFields(tx, rawTx)
 	return tx
@@ -254,14 +254,14 @@ func makeEip1559Tx(commonTx *types.CommonTx, rawTx map[string]interface{}) types
 func makeEip4844Tx(commonTx *types.CommonTx, rawTx map[string]interface{}) types.Transaction {
 	blobTx := &types.BlobTx{
 		DynamicFeeTransaction: types.DynamicFeeTransaction{CommonTx: types.CommonTx{
-			Nonce: commonTx.Nonce,
-			Gas:   commonTx.Gas,
-			To:    commonTx.To,
-			Value: commonTx.Value,
-			Data:  commonTx.Data,
-			V:     commonTx.V,
-			R:     commonTx.R,
-			S:     commonTx.S,
+			Nonce:    commonTx.Nonce,
+			GasLimit: commonTx.GasLimit,
+			To:       commonTx.To,
+			Value:    commonTx.Value,
+			Data:     commonTx.Data,
+			V:        commonTx.V,
+			R:        commonTx.R,
+			S:        commonTx.S,
 		}},
 	}
 	buildDynamicFeeFields(&blobTx.DynamicFeeTransaction, rawTx)
@@ -284,14 +284,14 @@ func makeEip4844Tx(commonTx *types.CommonTx, rawTx map[string]interface{}) types
 func makeEip7702Tx(commonTx *types.CommonTx, rawTx map[string]interface{}) types.Transaction {
 	tx := &types.SetCodeTransaction{
 		DynamicFeeTransaction: types.DynamicFeeTransaction{CommonTx: types.CommonTx{
-			Nonce: commonTx.Nonce,
-			Gas:   commonTx.Gas,
-			To:    commonTx.To,
-			Value: commonTx.Value,
-			Data:  commonTx.Data,
-			V:     commonTx.V,
-			R:     commonTx.R,
-			S:     commonTx.S,
+			Nonce:    commonTx.Nonce,
+			GasLimit: commonTx.GasLimit,
+			To:       commonTx.To,
+			Value:    commonTx.Value,
+			Data:     commonTx.Data,
+			V:        commonTx.V,
+			R:        commonTx.R,
+			S:        commonTx.S,
 		}},
 	}
 	buildDynamicFeeFields(&tx.DynamicFeeTransaction, rawTx)

--- a/cmd/snapshots/genfromrpc/genfromrpc.go
+++ b/cmd/snapshots/genfromrpc/genfromrpc.go
@@ -108,8 +108,8 @@ func buildDynamicFeeFields(tx *types.DynamicFeeTransaction, rawTx map[string]int
 	if accessListRaw, ok := rawTx["accessList"].([]interface{}); ok {
 		tx.AccessList = decodeAccessList(accessListRaw)
 	}
-	if tip := getUint256FromField(rawTx, "maxPriorityFeePerGas"); tip != nil {
-		tx.Tip = tip
+	if tipCap := getUint256FromField(rawTx, "maxPriorityFeePerGas"); tipCap != nil {
+		tx.TipCap = tipCap
 	}
 	if feeCap := getUint256FromField(rawTx, "maxFeePerGas"); feeCap != nil {
 		tx.FeeCap = feeCap

--- a/cmd/state/exec3/historical_trace_worker.go
+++ b/cmd/state/exec3/historical_trace_worker.go
@@ -185,7 +185,7 @@ func (rw *HistoricalTraceWorker) RunTxTask(txTask *state.TxTask) {
 			txTask.Error = err
 		}
 	default:
-		rw.taskGasPool.Reset(txTask.Tx.GetGas(), txTask.Tx.GetBlobGas())
+		rw.taskGasPool.Reset(txTask.Tx.GetGasLimit(), txTask.Tx.GetBlobGas())
 		if tracer := rw.consumer.NewTracer(); tracer != nil {
 			rw.vmConfig.Debug = true
 			rw.vmConfig.Tracer = tracer

--- a/cmd/state/exec3/state.go
+++ b/cmd/state/exec3/state.go
@@ -263,7 +263,7 @@ func (rw *Worker) RunTxTaskNoLock(txTask *state.TxTask, isMining bool) {
 			}
 		}
 	default:
-		rw.taskGasPool.Reset(txTask.Tx.GetGas(), rw.chainConfig.GetMaxBlobGasPerBlock(header.Time))
+		rw.taskGasPool.Reset(txTask.Tx.GetGasLimit(), rw.chainConfig.GetMaxBlobGasPerBlock(header.Time))
 		rw.callTracer.Reset()
 		rw.vmCfg.SkipAnalysis = txTask.SkipAnalysis
 		ibs.SetTxContext(txTask.TxIndex)

--- a/cmd/state/exec3/trace_worker.go
+++ b/cmd/state/exec3/trace_worker.go
@@ -121,7 +121,7 @@ func (e *TraceWorker) ExecTxn(txNum uint64, txIndex int, txn types.Transaction, 
 	}
 	e.evm.ResetBetweenBlocks(*e.blockCtx, txContext, e.ibs, *e.vmConfig, e.rules)
 
-	gp := new(core.GasPool).AddGas(txn.GetGas()).AddBlobGas(txn.GetBlobGas())
+	gp := new(core.GasPool).AddGas(txn.GetGasLimit()).AddBlobGas(txn.GetBlobGas())
 	res, err := core.ApplyMessage(e.evm, msg, gp, true /* refunds */, gasBailout /* gasBailout */, e.engine)
 	if err != nil {
 		return nil, fmt.Errorf("%w: blockNum=%d, txNum=%d, %s", err, e.blockNum, txNum, e.ibs.Error())

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -231,7 +231,7 @@ func CheckEip1559TxGasFeeCap(from libcommon.Address, feeCap, tipCap, baseFee *ui
 			from.Hex(), tipCap, feeCap)
 	}
 	if baseFee != nil && feeCap.Lt(baseFee) && !isFree {
-		return fmt.Errorf("%w: address %v, feeCap: %s baseFee: %s", ErrFeeCapTooLow,
+		return fmt.Errorf("%w: address %v, gasFeeCap: %s baseFee: %s", ErrFeeCapTooLow,
 			from.Hex(), feeCap, baseFee)
 	}
 	return nil

--- a/core/types/access_list_tx.go
+++ b/core/types/access_list_tx.go
@@ -66,7 +66,7 @@ func (tx *AccessListTx) copy() *AccessListTx {
 				Nonce:           tx.Nonce,
 				To:              tx.To, // TODO: copy pointed-to address
 				Data:            libcommon.CopyBytes(tx.Data),
-				Gas:             tx.Gas,
+				GasLimit:        tx.GasLimit,
 				// These are copied below.
 				Value: new(uint256.Int),
 			},
@@ -124,7 +124,7 @@ func (tx *AccessListTx) payloadSize() (payloadSize int, nonceLen, gasLen, access
 	payloadSize += rlp.Uint256LenExcludingHead(tx.GasPrice)
 	// size of Gas
 	payloadSize++
-	gasLen = rlp.IntLenExcludingHead(tx.Gas)
+	gasLen = rlp.IntLenExcludingHead(tx.GasLimit)
 	payloadSize += gasLen
 	// size of To
 	payloadSize++
@@ -227,8 +227,8 @@ func (tx *AccessListTx) encodePayload(w io.Writer, b []byte, payloadSize, nonceL
 	if err := rlp.EncodeUint256(tx.GasPrice, w, b); err != nil {
 		return err
 	}
-	// encode Gas
-	if err := rlp.EncodeInt(tx.Gas, w, b); err != nil {
+	// encode GasLimit
+	if err := rlp.EncodeInt(tx.GasLimit, w, b); err != nil {
 		return err
 	}
 	// encode To
@@ -366,8 +366,8 @@ func (tx *AccessListTx) DecodeRLP(s *rlp.Stream) error {
 		return fmt.Errorf("read GasPrice: %w", err)
 	}
 	tx.GasPrice = new(uint256.Int).SetBytes(b)
-	if tx.Gas, err = s.Uint(); err != nil {
-		return fmt.Errorf("read Gas: %w", err)
+	if tx.GasLimit, err = s.Uint(); err != nil {
+		return fmt.Errorf("read GasLimit: %w", err)
 	}
 	if b, err = s.Bytes(); err != nil {
 		return fmt.Errorf("read To: %w", err)
@@ -414,7 +414,7 @@ func (tx *AccessListTx) DecodeRLP(s *rlp.Stream) error {
 func (tx *AccessListTx) AsMessage(s Signer, _ *big.Int, rules *chain.Rules) (*Message, error) {
 	msg := Message{
 		nonce:      tx.Nonce,
-		gasLimit:   tx.Gas,
+		gasLimit:   tx.GasLimit,
 		gasPrice:   *tx.GasPrice,
 		tip:        *tx.GasPrice,
 		feeCap:     *tx.GasPrice,
@@ -456,7 +456,7 @@ func (tx *AccessListTx) Hash() libcommon.Hash {
 		tx.ChainID,
 		tx.Nonce,
 		tx.GasPrice,
-		tx.Gas,
+		tx.GasLimit,
 		tx.To,
 		tx.Value,
 		tx.Data,
@@ -474,7 +474,7 @@ func (tx *AccessListTx) SigningHash(chainID *big.Int) libcommon.Hash {
 			chainID,
 			tx.Nonce,
 			tx.GasPrice,
-			tx.Gas,
+			tx.GasLimit,
 			tx.To,
 			tx.Value,
 			tx.Data,

--- a/core/types/access_list_tx.go
+++ b/core/types/access_list_tx.go
@@ -122,7 +122,7 @@ func (tx *AccessListTx) payloadSize() (payloadSize int, nonceLen, gasLen, access
 	// size of GasPrice
 	payloadSize++
 	payloadSize += rlp.Uint256LenExcludingHead(tx.GasPrice)
-	// size of Gas
+	// size of GasLimit
 	payloadSize++
 	gasLen = rlp.IntLenExcludingHead(tx.GasLimit)
 	payloadSize += gasLen

--- a/core/types/access_list_tx.go
+++ b/core/types/access_list_tx.go
@@ -416,7 +416,7 @@ func (tx *AccessListTx) AsMessage(s Signer, _ *big.Int, rules *chain.Rules) (*Me
 		nonce:      tx.Nonce,
 		gasLimit:   tx.GasLimit,
 		gasPrice:   *tx.GasPrice,
-		tip:        *tx.GasPrice,
+		tipCap:     *tx.GasPrice,
 		feeCap:     *tx.GasPrice,
 		to:         tx.To,
 		amount:     *tx.Value,

--- a/core/types/blob_tx.go
+++ b/core/types/blob_tx.go
@@ -67,7 +67,7 @@ func (stx *BlobTx) AsMessage(s Signer, baseFee *big.Int, rules *chain.Rules) (*M
 		nonce:      stx.Nonce,
 		gasLimit:   stx.GasLimit,
 		gasPrice:   *stx.FeeCap,
-		tip:        *stx.Tip,
+		tipCap:     *stx.TipCap,
 		feeCap:     *stx.FeeCap,
 		to:         stx.To,
 		amount:     *stx.Value,
@@ -84,7 +84,7 @@ func (stx *BlobTx) AsMessage(s Signer, baseFee *big.Int, rules *chain.Rules) (*M
 			return nil, errors.New("gasPrice higher than 2^256-1")
 		}
 	}
-	msg.gasPrice.Add(&msg.gasPrice, stx.Tip)
+	msg.gasPrice.Add(&msg.gasPrice, stx.TipCap)
 	if msg.gasPrice.Gt(stx.FeeCap) {
 		msg.gasPrice.Set(stx.FeeCap)
 	}
@@ -124,7 +124,7 @@ func (stx *BlobTx) Hash() libcommon.Hash {
 	hash := prefixedRlpHash(BlobTxType, []interface{}{
 		stx.ChainID,
 		stx.Nonce,
-		stx.Tip,
+		stx.TipCap,
 		stx.FeeCap,
 		stx.GasLimit,
 		stx.To,
@@ -145,7 +145,7 @@ func (stx *BlobTx) SigningHash(chainID *big.Int) libcommon.Hash {
 		[]interface{}{
 			chainID,
 			stx.Nonce,
-			stx.Tip,
+			stx.TipCap,
 			stx.FeeCap,
 			stx.GasLimit,
 			stx.To,
@@ -201,7 +201,7 @@ func (stx *BlobTx) encodePayload(w io.Writer, b []byte, payloadSize, nonceLen, g
 		return err
 	}
 	// encode MaxPriorityFeePerGas
-	if err := rlp.EncodeUint256(stx.Tip, w, b); err != nil {
+	if err := rlp.EncodeUint256(stx.TipCap, w, b); err != nil {
 		return err
 	}
 	// encode MaxFeePerGas
@@ -323,7 +323,7 @@ func (stx *BlobTx) DecodeRLP(s *rlp.Stream) error {
 	if b, err = s.Uint256Bytes(); err != nil {
 		return err
 	}
-	stx.Tip = new(uint256.Int).SetBytes(b)
+	stx.TipCap = new(uint256.Int).SetBytes(b)
 
 	if b, err = s.Uint256Bytes(); err != nil {
 		return err

--- a/core/types/blob_tx.go
+++ b/core/types/blob_tx.go
@@ -65,7 +65,7 @@ func (stx *BlobTx) GetBlobGas() uint64 {
 func (stx *BlobTx) AsMessage(s Signer, baseFee *big.Int, rules *chain.Rules) (*Message, error) {
 	msg := Message{
 		nonce:      stx.Nonce,
-		gasLimit:   stx.Gas,
+		gasLimit:   stx.GasLimit,
 		gasPrice:   *stx.FeeCap,
 		tip:        *stx.Tip,
 		feeCap:     *stx.FeeCap,
@@ -126,7 +126,7 @@ func (stx *BlobTx) Hash() libcommon.Hash {
 		stx.Nonce,
 		stx.Tip,
 		stx.FeeCap,
-		stx.Gas,
+		stx.GasLimit,
 		stx.To,
 		stx.Value,
 		stx.Data,
@@ -147,7 +147,7 @@ func (stx *BlobTx) SigningHash(chainID *big.Int) libcommon.Hash {
 			stx.Nonce,
 			stx.Tip,
 			stx.FeeCap,
-			stx.Gas,
+			stx.GasLimit,
 			stx.To,
 			stx.Value,
 			stx.Data,
@@ -208,8 +208,8 @@ func (stx *BlobTx) encodePayload(w io.Writer, b []byte, payloadSize, nonceLen, g
 	if err := rlp.EncodeUint256(stx.FeeCap, w, b); err != nil {
 		return err
 	}
-	// encode Gas
-	if err := rlp.EncodeInt(stx.Gas, w, b); err != nil {
+	// encode GasLimit
+	if err := rlp.EncodeInt(stx.GasLimit, w, b); err != nil {
 		return err
 	}
 	// encode To
@@ -330,7 +330,7 @@ func (stx *BlobTx) DecodeRLP(s *rlp.Stream) error {
 	}
 	stx.FeeCap = new(uint256.Int).SetBytes(b)
 
-	if stx.Gas, err = s.Uint(); err != nil {
+	if stx.GasLimit, err = s.Uint(); err != nil {
 		return err
 	}
 

--- a/core/types/blob_tx_wrapper.go
+++ b/core/types/blob_tx_wrapper.go
@@ -307,7 +307,7 @@ func (txw *BlobTxWrapper) GetFeeCap() *uint256.Int { return txw.Tx.GetFeeCap() }
 
 func (txw *BlobTxWrapper) GetBlobHashes() []libcommon.Hash { return txw.Tx.GetBlobHashes() }
 
-func (txw *BlobTxWrapper) GetGas() uint64            { return txw.Tx.GetGas() }
+func (txw *BlobTxWrapper) GetGasLimit() uint64       { return txw.Tx.GetGasLimit() }
 func (txw *BlobTxWrapper) GetBlobGas() uint64        { return txw.Tx.GetBlobGas() }
 func (txw *BlobTxWrapper) GetValue() *uint256.Int    { return txw.Tx.GetValue() }
 func (txw *BlobTxWrapper) GetTo() *libcommon.Address { return txw.Tx.GetTo() }

--- a/core/types/blob_tx_wrapper.go
+++ b/core/types/blob_tx_wrapper.go
@@ -298,7 +298,6 @@ func (txw *BlobTxWrapper) ValidateBlobTransactionWrapper() error {
 func (txw *BlobTxWrapper) Type() byte               { return txw.Tx.Type() }
 func (txw *BlobTxWrapper) GetChainID() *uint256.Int { return txw.Tx.GetChainID() }
 func (txw *BlobTxWrapper) GetNonce() uint64         { return txw.Tx.GetNonce() }
-func (txw *BlobTxWrapper) GetPrice() *uint256.Int   { return txw.Tx.GetPrice() }
 func (txw *BlobTxWrapper) GetTip() *uint256.Int     { return txw.Tx.GetTip() }
 func (txw *BlobTxWrapper) GetEffectiveGasTip(baseFee *uint256.Int) *uint256.Int {
 	return txw.Tx.GetEffectiveGasTip(baseFee)

--- a/core/types/blob_tx_wrapper.go
+++ b/core/types/blob_tx_wrapper.go
@@ -298,7 +298,7 @@ func (txw *BlobTxWrapper) ValidateBlobTransactionWrapper() error {
 func (txw *BlobTxWrapper) Type() byte               { return txw.Tx.Type() }
 func (txw *BlobTxWrapper) GetChainID() *uint256.Int { return txw.Tx.GetChainID() }
 func (txw *BlobTxWrapper) GetNonce() uint64         { return txw.Tx.GetNonce() }
-func (txw *BlobTxWrapper) GetTip() *uint256.Int     { return txw.Tx.GetTip() }
+func (txw *BlobTxWrapper) GetTipCap() *uint256.Int  { return txw.Tx.GetTipCap() }
 func (txw *BlobTxWrapper) GetEffectiveGasTip(baseFee *uint256.Int) *uint256.Int {
 	return txw.Tx.GetEffectiveGasTip(baseFee)
 }

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -200,10 +200,10 @@ func TestEIP1559BlockEncoding(t *testing.T) {
 	feeCap, _ := uint256.FromBig(block.BaseFee())
 	var tx2 Transaction = &DynamicFeeTransaction{
 		CommonTx: CommonTx{
-			Nonce: 0,
-			To:    &to,
-			Gas:   123457,
-			Data:  []byte{},
+			Nonce:    0,
+			To:       &to,
+			GasLimit: 123457,
+			Data:     []byte{},
 		},
 		ChainID:    u256.Num1,
 		FeeCap:     feeCap,
@@ -256,10 +256,10 @@ func TestEIP2718BlockEncoding(t *testing.T) {
 	ten := new(uint256.Int).SetUint64(10)
 	var tx1 Transaction = &LegacyTx{
 		CommonTx: CommonTx{
-			Nonce: 0,
-			To:    &to,
-			Value: ten,
-			Gas:   50000,
+			Nonce:    0,
+			To:       &to,
+			Value:    ten,
+			GasLimit: 50000,
 		},
 		GasPrice: ten,
 	}
@@ -273,9 +273,9 @@ func TestEIP2718BlockEncoding(t *testing.T) {
 		ChainID: chainID,
 		LegacyTx: LegacyTx{
 			CommonTx: CommonTx{
-				Nonce: 0,
-				To:    &to,
-				Gas:   123457,
+				Nonce:    0,
+				To:       &to,
+				GasLimit: 123457,
 			},
 			GasPrice: ten,
 		},
@@ -348,7 +348,7 @@ func makeBenchBlock() *Block {
 			panic(err)
 		}
 		txs[i] = signedTx
-		receipts[i] = NewReceipt(false, tx.GetGas())
+		receipts[i] = NewReceipt(false, tx.GetGasLimit())
 	}
 	for i := range uncles {
 		uncles[i] = &Header{
@@ -585,10 +585,10 @@ func TestCopyTxs(t *testing.T) {
 	var txs Transactions
 	txs = append(txs, &LegacyTx{
 		CommonTx: CommonTx{
-			Nonce: 0,
-			Value: new(uint256.Int).SetUint64(10000),
-			Gas:   50000,
-			Data:  []byte("Sparta"),
+			Nonce:    0,
+			Value:    new(uint256.Int).SetUint64(10000),
+			GasLimit: 50000,
+			Data:     []byte("Sparta"),
 		},
 		GasPrice: new(uint256.Int).SetUint64(10),
 	})

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -207,7 +207,7 @@ func TestEIP1559BlockEncoding(t *testing.T) {
 		},
 		ChainID:    u256.Num1,
 		FeeCap:     feeCap,
-		Tip:        u256.Num0,
+		TipCap:     u256.Num0,
 		AccessList: accesses,
 	}
 	tx2, err := tx2.WithSignature(*LatestSignerForChainID(big.NewInt(1)), libcommon.Hex2Bytes("fe38ca4e44a30002ac54af7cf922a6ac2ba11b7d22f548e8ecb3f51f41cb31b06de6a5cbae13c0c856e33acf021b51819636cfc009d39eafb9f606d546e305a800"))

--- a/core/types/dynamic_fee_tx.go
+++ b/core/types/dynamic_fee_tx.go
@@ -40,7 +40,6 @@ type DynamicFeeTransaction struct {
 	AccessList AccessList
 }
 
-func (tx *DynamicFeeTransaction) GetPrice() *uint256.Int  { return tx.Tip }
 func (tx *DynamicFeeTransaction) GetFeeCap() *uint256.Int { return tx.FeeCap }
 func (tx *DynamicFeeTransaction) GetTip() *uint256.Int    { return tx.Tip }
 func (tx *DynamicFeeTransaction) GetEffectiveGasTip(baseFee *uint256.Int) *uint256.Int {

--- a/core/types/dynamic_fee_tx.go
+++ b/core/types/dynamic_fee_tx.go
@@ -124,7 +124,7 @@ func (tx *DynamicFeeTransaction) payloadSize() (payloadSize int, nonceLen, gasLe
 	// size of MaxFeePerGas
 	payloadSize++
 	payloadSize += rlp.Uint256LenExcludingHead(tx.FeeCap)
-	// size of Gas
+	// size of GasLimit
 	payloadSize++
 	gasLen = rlp.IntLenExcludingHead(tx.GasLimit)
 	payloadSize += gasLen

--- a/core/types/dynamic_fee_tx.go
+++ b/core/types/dynamic_fee_tx.go
@@ -72,7 +72,7 @@ func (tx *DynamicFeeTransaction) copy() *DynamicFeeTransaction {
 			Nonce:           tx.Nonce,
 			To:              tx.To, // TODO: copy pointed-to address
 			Data:            libcommon.CopyBytes(tx.Data),
-			Gas:             tx.Gas,
+			GasLimit:        tx.GasLimit,
 			// These are copied below.
 			Value: new(uint256.Int),
 		},
@@ -126,7 +126,7 @@ func (tx *DynamicFeeTransaction) payloadSize() (payloadSize int, nonceLen, gasLe
 	payloadSize += rlp.Uint256LenExcludingHead(tx.FeeCap)
 	// size of Gas
 	payloadSize++
-	gasLen = rlp.IntLenExcludingHead(tx.Gas)
+	gasLen = rlp.IntLenExcludingHead(tx.GasLimit)
 	payloadSize += gasLen
 	// size of To
 	payloadSize++
@@ -205,8 +205,8 @@ func (tx *DynamicFeeTransaction) encodePayload(w io.Writer, b []byte, payloadSiz
 	if err := rlp.EncodeUint256(tx.FeeCap, w, b); err != nil {
 		return err
 	}
-	// encode Gas
-	if err := rlp.EncodeInt(tx.Gas, w, b); err != nil {
+	// encode GasLimit
+	if err := rlp.EncodeInt(tx.GasLimit, w, b); err != nil {
 		return err
 	}
 	// encode To
@@ -286,7 +286,7 @@ func (tx *DynamicFeeTransaction) DecodeRLP(s *rlp.Stream) error {
 		return err
 	}
 	tx.FeeCap = new(uint256.Int).SetBytes(b)
-	if tx.Gas, err = s.Uint(); err != nil {
+	if tx.GasLimit, err = s.Uint(); err != nil {
 		return err
 	}
 	if b, err = s.Bytes(); err != nil {
@@ -331,7 +331,7 @@ func (tx *DynamicFeeTransaction) DecodeRLP(s *rlp.Stream) error {
 func (tx *DynamicFeeTransaction) AsMessage(s Signer, baseFee *big.Int, rules *chain.Rules) (*Message, error) {
 	msg := Message{
 		nonce:      tx.Nonce,
-		gasLimit:   tx.Gas,
+		gasLimit:   tx.GasLimit,
 		gasPrice:   *tx.FeeCap,
 		tip:        *tx.Tip,
 		feeCap:     *tx.FeeCap,
@@ -370,7 +370,7 @@ func (tx *DynamicFeeTransaction) Hash() libcommon.Hash {
 		tx.Nonce,
 		tx.Tip,
 		tx.FeeCap,
-		tx.Gas,
+		tx.GasLimit,
 		tx.To,
 		tx.Value,
 		tx.Data,
@@ -389,7 +389,7 @@ func (tx *DynamicFeeTransaction) SigningHash(chainID *big.Int) libcommon.Hash {
 			tx.Nonce,
 			tx.Tip,
 			tx.FeeCap,
-			tx.Gas,
+			tx.GasLimit,
 			tx.To,
 			tx.Value,
 			tx.Data,
@@ -433,11 +433,11 @@ func (tx *DynamicFeeTransaction) Sender(signer Signer) (libcommon.Address, error
 func NewEIP1559Transaction(chainID uint256.Int, nonce uint64, to libcommon.Address, amount *uint256.Int, gasLimit uint64, gasPrice *uint256.Int, gasTip *uint256.Int, gasFeeCap *uint256.Int, data []byte) *DynamicFeeTransaction {
 	return &DynamicFeeTransaction{
 		CommonTx: CommonTx{
-			Nonce: nonce,
-			To:    &to,
-			Value: amount,
-			Gas:   gasLimit,
-			Data:  data,
+			Nonce:    nonce,
+			To:       &to,
+			Value:    amount,
+			GasLimit: gasLimit,
+			Data:     data,
 		},
 		ChainID: &chainID,
 		Tip:     gasTip,

--- a/core/types/encdec_test.go
+++ b/core/types/encdec_test.go
@@ -242,14 +242,14 @@ func (tr *TRand) RandTransaction(_type int) Transaction {
 		to = nil
 	}
 	commonTx := CommonTx{
-		Nonce: *tr.RandUint64(),
-		Gas:   *tr.RandUint64(),
-		To:    to,
-		Value: uint256.NewInt(*tr.RandUint64()), // wei amount
-		Data:  tr.RandBytes(tr.RandIntInRange(128, 1024)),
-		V:     *tr.RandUint256(),
-		R:     *tr.RandUint256(),
-		S:     *tr.RandUint256(),
+		Nonce:    *tr.RandUint64(),
+		GasLimit: *tr.RandUint64(),
+		To:       to,
+		Value:    uint256.NewInt(*tr.RandUint64()), // wei amount
+		Data:     tr.RandBytes(tr.RandIntInRange(128, 1024)),
+		V:        *tr.RandUint256(),
+		R:        *tr.RandUint256(),
+		S:        *tr.RandUint256(),
 	}
 	switch txType {
 	case LegacyTxType:
@@ -445,7 +445,7 @@ func compareTransactions(t *testing.T, a, b Transaction) {
 	check(t, "Tx.GetTip", a.GetTip(), b.GetTip())
 	check(t, "Tx.GetFeeCap", a.GetFeeCap(), b.GetFeeCap())
 	check(t, "Tx.GetBlobHashes", a.GetBlobHashes(), b.GetBlobHashes())
-	check(t, "Tx.GetGas", a.GetGas(), b.GetGas())
+	check(t, "Tx.GetGasLimit", a.GetGasLimit(), b.GetGasLimit())
 	check(t, "Tx.GetBlobGas", a.GetBlobGas(), b.GetBlobGas())
 	check(t, "Tx.GetValue", a.GetValue(), b.GetValue())
 	check(t, "Tx.GetTo", a.GetTo(), b.GetTo())

--- a/core/types/encdec_test.go
+++ b/core/types/encdec_test.go
@@ -441,7 +441,6 @@ func compareTransactions(t *testing.T, a, b Transaction) {
 	check(t, "Tx.Type", a.Type(), b.Type())
 	check(t, "Tx.GetChainID", a.GetChainID(), b.GetChainID())
 	check(t, "Tx.GetNonce", a.GetNonce(), b.GetNonce())
-	check(t, "Tx.GetPrice", a.GetPrice(), b.GetPrice())
 	check(t, "Tx.GetTip", a.GetTip(), b.GetTip())
 	check(t, "Tx.GetFeeCap", a.GetFeeCap(), b.GetFeeCap())
 	check(t, "Tx.GetBlobHashes", a.GetBlobHashes(), b.GetBlobHashes())

--- a/core/types/encdec_test.go
+++ b/core/types/encdec_test.go
@@ -270,7 +270,7 @@ func (tr *TRand) RandTransaction(_type int) Transaction {
 		return &DynamicFeeTransaction{
 			CommonTx:   commonTx, //nolint
 			ChainID:    uint256.NewInt(*tr.RandUint64()),
-			Tip:        uint256.NewInt(*tr.RandUint64()),
+			TipCap:     uint256.NewInt(*tr.RandUint64()),
 			FeeCap:     uint256.NewInt(*tr.RandUint64()),
 			AccessList: tr.RandAccessList(tr.RandIntInRange(1, 5)),
 		}
@@ -280,7 +280,7 @@ func (tr *TRand) RandTransaction(_type int) Transaction {
 			DynamicFeeTransaction: DynamicFeeTransaction{
 				CommonTx:   commonTx, //nolint
 				ChainID:    uint256.NewInt(*tr.RandUint64()),
-				Tip:        uint256.NewInt(*tr.RandUint64()),
+				TipCap:     uint256.NewInt(*tr.RandUint64()),
 				FeeCap:     uint256.NewInt(*tr.RandUint64()),
 				AccessList: tr.RandAccessList(tr.RandIntInRange(1, 5)),
 			},
@@ -292,7 +292,7 @@ func (tr *TRand) RandTransaction(_type int) Transaction {
 			DynamicFeeTransaction: DynamicFeeTransaction{
 				CommonTx:   commonTx, //nolint
 				ChainID:    uint256.NewInt(*tr.RandUint64()),
-				Tip:        uint256.NewInt(*tr.RandUint64()),
+				TipCap:     uint256.NewInt(*tr.RandUint64()),
 				FeeCap:     uint256.NewInt(*tr.RandUint64()),
 				AccessList: tr.RandAccessList(tr.RandIntInRange(1, 5)),
 			},
@@ -441,7 +441,7 @@ func compareTransactions(t *testing.T, a, b Transaction) {
 	check(t, "Tx.Type", a.Type(), b.Type())
 	check(t, "Tx.GetChainID", a.GetChainID(), b.GetChainID())
 	check(t, "Tx.GetNonce", a.GetNonce(), b.GetNonce())
-	check(t, "Tx.GetTip", a.GetTip(), b.GetTip())
+	check(t, "Tx.GetTipCap", a.GetTipCap(), b.GetTipCap())
 	check(t, "Tx.GetFeeCap", a.GetFeeCap(), b.GetFeeCap())
 	check(t, "Tx.GetBlobHashes", a.GetBlobHashes(), b.GetBlobHashes())
 	check(t, "Tx.GetGasLimit", a.GetGasLimit(), b.GetGasLimit())

--- a/core/types/legacy_tx.go
+++ b/core/types/legacy_tx.go
@@ -97,7 +97,6 @@ type LegacyTx struct {
 	GasPrice *uint256.Int // wei per gas
 }
 
-func (tx *LegacyTx) GetPrice() *uint256.Int  { return tx.GasPrice }
 func (tx *LegacyTx) GetTip() *uint256.Int    { return tx.GasPrice }
 func (tx *LegacyTx) GetFeeCap() *uint256.Int { return tx.GasPrice }
 func (tx *LegacyTx) GetEffectiveGasTip(baseFee *uint256.Int) *uint256.Int {

--- a/core/types/legacy_tx.go
+++ b/core/types/legacy_tx.go
@@ -97,11 +97,11 @@ type LegacyTx struct {
 	GasPrice *uint256.Int // wei per gas
 }
 
-func (tx *LegacyTx) GetTip() *uint256.Int    { return tx.GasPrice }
+func (tx *LegacyTx) GetTipCap() *uint256.Int { return tx.GasPrice }
 func (tx *LegacyTx) GetFeeCap() *uint256.Int { return tx.GasPrice }
 func (tx *LegacyTx) GetEffectiveGasTip(baseFee *uint256.Int) *uint256.Int {
 	if baseFee == nil {
-		return tx.GetTip()
+		return tx.GetTipCap()
 	}
 	gasFeeCap := tx.GetFeeCap()
 	// return 0 because effectiveFee cant be < 0
@@ -109,8 +109,8 @@ func (tx *LegacyTx) GetEffectiveGasTip(baseFee *uint256.Int) *uint256.Int {
 		return uint256.NewInt(0)
 	}
 	effectiveFee := new(uint256.Int).Sub(gasFeeCap, baseFee)
-	if tx.GetTip().Lt(effectiveFee) {
-		return tx.GetTip()
+	if tx.GetTipCap().Lt(effectiveFee) {
+		return tx.GetTipCap()
 	} else {
 		return effectiveFee
 	}
@@ -347,7 +347,7 @@ func (tx *LegacyTx) AsMessage(s Signer, _ *big.Int, _ *chain.Rules) (*Message, e
 		nonce:      tx.Nonce,
 		gasLimit:   tx.GasLimit,
 		gasPrice:   *tx.GasPrice,
-		tip:        *tx.GasPrice,
+		tipCap:     *tx.GasPrice,
 		feeCap:     *tx.GasPrice,
 		to:         tx.To,
 		amount:     *tx.Value,

--- a/core/types/legacy_tx.go
+++ b/core/types/legacy_tx.go
@@ -35,12 +35,12 @@ import (
 type CommonTx struct {
 	TransactionMisc
 
-	Nonce   uint64             // nonce of sender account
-	Gas     uint64             // gas limit
-	To      *libcommon.Address `rlp:"nil"` // nil means contract creation
-	Value   *uint256.Int       // wei amount
-	Data    []byte             // contract invocation input data
-	V, R, S uint256.Int        // signature values
+	Nonce    uint64             // nonce of sender account
+	GasLimit uint64             // gas limit
+	To       *libcommon.Address `rlp:"nil"` // nil means contract creation
+	Value    *uint256.Int       // wei amount
+	Data     []byte             // contract invocation input data
+	V, R, S  uint256.Int        // signature values
 }
 
 func (ct *CommonTx) GetNonce() uint64 {
@@ -55,8 +55,8 @@ func (ct *CommonTx) GetBlobGas() uint64 {
 	return 0
 }
 
-func (ct *CommonTx) GetGas() uint64 {
-	return ct.Gas
+func (ct *CommonTx) GetGasLimit() uint64 {
+	return ct.GasLimit
 }
 
 func (ct *CommonTx) GetValue() *uint256.Int {
@@ -134,11 +134,11 @@ func (tx *LegacyTx) Unwrap() Transaction {
 func NewTransaction(nonce uint64, to libcommon.Address, amount *uint256.Int, gasLimit uint64, gasPrice *uint256.Int, data []byte) *LegacyTx {
 	return &LegacyTx{
 		CommonTx: CommonTx{
-			Nonce: nonce,
-			To:    &to,
-			Value: amount,
-			Gas:   gasLimit,
-			Data:  data,
+			Nonce:    nonce,
+			To:       &to,
+			Value:    amount,
+			GasLimit: gasLimit,
+			Data:     data,
 		},
 		GasPrice: gasPrice,
 	}
@@ -149,10 +149,10 @@ func NewTransaction(nonce uint64, to libcommon.Address, amount *uint256.Int, gas
 func NewContractCreation(nonce uint64, amount *uint256.Int, gasLimit uint64, gasPrice *uint256.Int, data []byte) *LegacyTx {
 	return &LegacyTx{
 		CommonTx: CommonTx{
-			Nonce: nonce,
-			Value: amount,
-			Gas:   gasLimit,
-			Data:  data,
+			Nonce:    nonce,
+			Value:    amount,
+			GasLimit: gasLimit,
+			Data:     data,
 		},
 		GasPrice: gasPrice,
 	}
@@ -166,7 +166,7 @@ func (tx *LegacyTx) copy() *LegacyTx {
 			Nonce:           tx.Nonce,
 			To:              tx.To, // TODO: copy pointed-to address
 			Data:            libcommon.CopyBytes(tx.Data),
-			Gas:             tx.Gas,
+			GasLimit:        tx.GasLimit,
 			// These are initialized below.
 			Value: new(uint256.Int),
 		},
@@ -196,7 +196,7 @@ func (tx *LegacyTx) payloadSize() (payloadSize int, nonceLen, gasLen int) {
 	payloadSize++
 	payloadSize += rlp.Uint256LenExcludingHead(tx.GasPrice)
 	payloadSize++
-	gasLen = rlp.IntLenExcludingHead(tx.Gas)
+	gasLen = rlp.IntLenExcludingHead(tx.GasLimit)
 	payloadSize += gasLen
 	payloadSize++
 	if tx.To != nil {
@@ -246,7 +246,7 @@ func (tx *LegacyTx) encodePayload(w io.Writer, b []byte, payloadSize, nonceLen, 
 	if err := rlp.EncodeUint256(tx.GasPrice, w, b); err != nil {
 		return err
 	}
-	if err := rlp.EncodeInt(tx.Gas, w, b); err != nil {
+	if err := rlp.EncodeInt(tx.GasLimit, w, b); err != nil {
 		return err
 	}
 	if tx.To == nil {
@@ -304,8 +304,8 @@ func (tx *LegacyTx) DecodeRLP(s *rlp.Stream) error {
 		return fmt.Errorf("read GasPrice: %w", err)
 	}
 	tx.GasPrice = new(uint256.Int).SetBytes(b)
-	if tx.Gas, err = s.Uint(); err != nil {
-		return fmt.Errorf("read Gas: %w", err)
+	if tx.GasLimit, err = s.Uint(); err != nil {
+		return fmt.Errorf("read GasLimit: %w", err)
 	}
 	if b, err = s.Bytes(); err != nil {
 		return fmt.Errorf("read To: %w", err)
@@ -346,7 +346,7 @@ func (tx *LegacyTx) DecodeRLP(s *rlp.Stream) error {
 func (tx *LegacyTx) AsMessage(s Signer, _ *big.Int, _ *chain.Rules) (*Message, error) {
 	msg := Message{
 		nonce:      tx.Nonce,
-		gasLimit:   tx.Gas,
+		gasLimit:   tx.GasLimit,
 		gasPrice:   *tx.GasPrice,
 		tip:        *tx.GasPrice,
 		feeCap:     *tx.GasPrice,
@@ -382,7 +382,7 @@ func (tx *LegacyTx) Hash() libcommon.Hash {
 	hash := rlpHash([]interface{}{
 		tx.Nonce,
 		tx.GasPrice,
-		tx.Gas,
+		tx.GasLimit,
 		tx.To,
 		tx.Value,
 		tx.Data,
@@ -397,7 +397,7 @@ func (tx *LegacyTx) SigningHash(chainID *big.Int) libcommon.Hash {
 		return rlpHash([]interface{}{
 			tx.Nonce,
 			tx.GasPrice,
-			tx.Gas,
+			tx.GasLimit,
 			tx.To,
 			tx.Value,
 			tx.Data,
@@ -407,7 +407,7 @@ func (tx *LegacyTx) SigningHash(chainID *big.Int) libcommon.Hash {
 	return rlpHash([]interface{}{
 		tx.Nonce,
 		tx.GasPrice,
-		tx.Gas,
+		tx.GasLimit,
 		tx.To,
 		tx.Value,
 		tx.Data,

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -141,28 +141,28 @@ func TestDeriveFields(t *testing.T) {
 	txs := Transactions{
 		&LegacyTx{
 			CommonTx: CommonTx{
-				Nonce: 1,
-				Value: u256.Num1,
-				Gas:   1,
+				Nonce:    1,
+				Value:    u256.Num1,
+				GasLimit: 1,
 			},
 			GasPrice: u256.Num1,
 		},
 		&LegacyTx{
 			CommonTx: CommonTx{
-				To:    &to2,
-				Nonce: 2,
-				Value: u256.Num2,
-				Gas:   2,
+				To:       &to2,
+				Nonce:    2,
+				Value:    u256.Num2,
+				GasLimit: 2,
 			},
 			GasPrice: u256.Num2,
 		},
 		&AccessListTx{
 			LegacyTx: LegacyTx{
 				CommonTx: CommonTx{
-					To:    &to3,
-					Nonce: 3,
-					Value: uint256.NewInt(3),
-					Gas:   3,
+					To:       &to3,
+					Nonce:    3,
+					Value:    uint256.NewInt(3),
+					GasLimit: 3,
 				},
 				GasPrice: uint256.NewInt(3),
 			},
@@ -237,8 +237,8 @@ func TestDeriveFields(t *testing.T) {
 			if r.TransactionIndex != uint(i) {
 				t.Errorf("receipts[%d].TransactionIndex = %d, want %d", i, r.TransactionIndex, i)
 			}
-			if r.GasUsed != txs[i].GetGas() {
-				t.Errorf("receipts[%d].GasUsed = %d, want %d", i, r.GasUsed, txs[i].GetGas())
+			if r.GasUsed != txs[i].GetGasLimit() {
+				t.Errorf("receipts[%d].GasUsed = %d, want %d", i, r.GasUsed, txs[i].GetGasLimit())
 			}
 			if txs[i].GetTo() != nil && r.ContractAddress != (libcommon.Address{}) {
 				t.Errorf("receipts[%d].ContractAddress = %s, want %s", i, r.ContractAddress.String(), (libcommon.Address{}).String())
@@ -300,8 +300,8 @@ func TestDeriveFields(t *testing.T) {
 	//		if r.TransactionIndex != uint(i) {
 	//			t.Errorf("receipts[%d].TransactionIndex = %d, want %d", i, r.TransactionIndex, i)
 	//		}
-	//		if r.GasUsed != txs[i].GetGas() {
-	//			t.Errorf("receipts[%d].GasUsed = %d, want %d", i, r.GasUsed, txs[i].GetGas())
+	//		if r.GasUsed != txs[i].GetGasLimit() {
+	//			t.Errorf("receipts[%d].GasUsed = %d, want %d", i, r.GasUsed, txs[i].GetGasLimit())
 	//		}
 	//		if txs[i].GetTo() != nil && r.ContractAddress != (libcommon.Address{}) {
 	//			t.Errorf("receipts[%d].ContractAddress = %s, want %s", i, r.ContractAddress.String(), (libcommon.Address{}).String())

--- a/core/types/set_code_tx.go
+++ b/core/types/set_code_tx.go
@@ -117,7 +117,7 @@ func (tx *SetCodeTransaction) MarshalBinary(w io.Writer) error {
 func (tx *SetCodeTransaction) AsMessage(s Signer, baseFee *big.Int, rules *chain.Rules) (*Message, error) {
 	msg := Message{
 		nonce:      tx.Nonce,
-		gasLimit:   tx.Gas,
+		gasLimit:   tx.GasLimit,
 		gasPrice:   *tx.FeeCap,
 		tip:        *tx.Tip,
 		feeCap:     *tx.FeeCap,
@@ -174,7 +174,7 @@ func (tx *SetCodeTransaction) Hash() libcommon.Hash {
 		tx.Nonce,
 		tx.Tip,
 		tx.FeeCap,
-		tx.Gas,
+		tx.GasLimit,
 		tx.To,
 		tx.Value,
 		tx.Data,
@@ -194,7 +194,7 @@ func (tx *SetCodeTransaction) SigningHash(chainID *big.Int) libcommon.Hash {
 			tx.Nonce,
 			tx.Tip,
 			tx.FeeCap,
-			tx.Gas,
+			tx.GasLimit,
 			tx.To,
 			tx.Value,
 			tx.Data,
@@ -245,7 +245,7 @@ func (tx *SetCodeTransaction) DecodeRLP(s *rlp.Stream) error {
 		return err
 	}
 	tx.FeeCap = new(uint256.Int).SetBytes(b)
-	if tx.Gas, err = s.Uint(); err != nil {
+	if tx.GasLimit, err = s.Uint(); err != nil {
 		return err
 	}
 	if b, err = s.Bytes(); err != nil {
@@ -312,8 +312,8 @@ func (tx *SetCodeTransaction) encodePayload(w io.Writer, b []byte, payloadSize, 
 	if err := rlp.EncodeUint256(tx.FeeCap, w, b); err != nil {
 		return err
 	}
-	// encode Gas
-	if err := rlp.EncodeInt(tx.Gas, w, b); err != nil {
+	// encode GasLimit
+	if err := rlp.EncodeInt(tx.GasLimit, w, b); err != nil {
 		return err
 	}
 	// encode To

--- a/core/types/set_code_tx.go
+++ b/core/types/set_code_tx.go
@@ -119,7 +119,7 @@ func (tx *SetCodeTransaction) AsMessage(s Signer, baseFee *big.Int, rules *chain
 		nonce:      tx.Nonce,
 		gasLimit:   tx.GasLimit,
 		gasPrice:   *tx.FeeCap,
-		tip:        *tx.Tip,
+		tipCap:     *tx.TipCap,
 		feeCap:     *tx.FeeCap,
 		to:         tx.To,
 		amount:     *tx.Value,
@@ -136,7 +136,7 @@ func (tx *SetCodeTransaction) AsMessage(s Signer, baseFee *big.Int, rules *chain
 			return nil, errors.New("gasPrice higher than 2^256-1")
 		}
 	}
-	msg.gasPrice.Add(&msg.gasPrice, tx.Tip)
+	msg.gasPrice.Add(&msg.gasPrice, tx.TipCap)
 	if msg.gasPrice.Gt(tx.FeeCap) {
 		msg.gasPrice.Set(tx.FeeCap)
 	}
@@ -172,7 +172,7 @@ func (tx *SetCodeTransaction) Hash() libcommon.Hash {
 	hash := prefixedRlpHash(SetCodeTxType, []interface{}{
 		tx.ChainID,
 		tx.Nonce,
-		tx.Tip,
+		tx.TipCap,
 		tx.FeeCap,
 		tx.GasLimit,
 		tx.To,
@@ -192,7 +192,7 @@ func (tx *SetCodeTransaction) SigningHash(chainID *big.Int) libcommon.Hash {
 		[]interface{}{
 			chainID,
 			tx.Nonce,
-			tx.Tip,
+			tx.TipCap,
 			tx.FeeCap,
 			tx.GasLimit,
 			tx.To,
@@ -240,7 +240,7 @@ func (tx *SetCodeTransaction) DecodeRLP(s *rlp.Stream) error {
 	if b, err = s.Uint256Bytes(); err != nil {
 		return err
 	}
-	tx.Tip = new(uint256.Int).SetBytes(b)
+	tx.TipCap = new(uint256.Int).SetBytes(b)
 	if b, err = s.Uint256Bytes(); err != nil {
 		return err
 	}
@@ -305,7 +305,7 @@ func (tx *SetCodeTransaction) encodePayload(w io.Writer, b []byte, payloadSize, 
 		return err
 	}
 	// encode MaxPriorityFeePerGas
-	if err := rlp.EncodeUint256(tx.Tip, w, b); err != nil {
+	if err := rlp.EncodeUint256(tx.TipCap, w, b); err != nil {
 		return err
 	}
 	// encode MaxFeePerGas

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -406,7 +406,7 @@ func (m *Message) From() libcommon.Address         { return m.from }
 func (m *Message) To() *libcommon.Address          { return m.to }
 func (m *Message) GasPrice() *uint256.Int          { return &m.gasPrice }
 func (m *Message) FeeCap() *uint256.Int            { return &m.feeCap }
-func (m *Message) Tip() *uint256.Int               { return &m.tipCap }
+func (m *Message) TipCap() *uint256.Int            { return &m.tipCap }
 func (m *Message) Value() *uint256.Int             { return &m.amount }
 func (m *Message) Gas() uint64                     { return m.gasLimit }
 func (m *Message) Nonce() uint64                   { return m.nonce }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -65,7 +65,7 @@ type Transaction interface {
 	GetEffectiveGasTip(baseFee *uint256.Int) *uint256.Int
 	GetFeeCap() *uint256.Int
 	GetBlobHashes() []libcommon.Hash
-	GetGas() uint64
+	GetGasLimit() uint64
 	GetBlobGas() uint64
 	GetValue() *uint256.Int
 	GetTo() *libcommon.Address

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -60,9 +60,9 @@ type Transaction interface {
 	Type() byte
 	GetChainID() *uint256.Int
 	GetNonce() uint64
-	GetTip() *uint256.Int
+	GetTipCap() *uint256.Int // max_priority_fee_per_gas in EIP-1559
 	GetEffectiveGasTip(baseFee *uint256.Int) *uint256.Int
-	GetFeeCap() *uint256.Int
+	GetFeeCap() *uint256.Int // max_fee_per_gas in EIP-1559
 	GetBlobHashes() []libcommon.Hash
 	GetGasLimit() uint64
 	GetBlobGas() uint64
@@ -362,7 +362,7 @@ type Message struct {
 	gasLimit         uint64
 	gasPrice         uint256.Int
 	feeCap           uint256.Int
-	tip              uint256.Int
+	tipCap           uint256.Int
 	maxFeePerBlobGas uint256.Int
 	data             []byte
 	accessList       AccessList
@@ -373,7 +373,7 @@ type Message struct {
 }
 
 func NewMessage(from libcommon.Address, to *libcommon.Address, nonce uint64, amount *uint256.Int, gasLimit uint64,
-	gasPrice *uint256.Int, feeCap, tip *uint256.Int, data []byte, accessList AccessList, checkNonce bool,
+	gasPrice *uint256.Int, feeCap, tipCap *uint256.Int, data []byte, accessList AccessList, checkNonce bool,
 	isFree bool, maxFeePerBlobGas *uint256.Int,
 ) *Message {
 	m := Message{
@@ -390,8 +390,8 @@ func NewMessage(from libcommon.Address, to *libcommon.Address, nonce uint64, amo
 	if gasPrice != nil {
 		m.gasPrice.Set(gasPrice)
 	}
-	if tip != nil {
-		m.tip.Set(tip)
+	if tipCap != nil {
+		m.tipCap.Set(tipCap)
 	}
 	if feeCap != nil {
 		m.feeCap.Set(feeCap)
@@ -406,7 +406,7 @@ func (m *Message) From() libcommon.Address         { return m.from }
 func (m *Message) To() *libcommon.Address          { return m.to }
 func (m *Message) GasPrice() *uint256.Int          { return &m.gasPrice }
 func (m *Message) FeeCap() *uint256.Int            { return &m.feeCap }
-func (m *Message) Tip() *uint256.Int               { return &m.tip }
+func (m *Message) Tip() *uint256.Int               { return &m.tipCap }
 func (m *Message) Value() *uint256.Int             { return &m.amount }
 func (m *Message) Gas() uint64                     { return m.gasLimit }
 func (m *Message) Nonce() uint64                   { return m.nonce }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -60,9 +60,9 @@ type Transaction interface {
 	Type() byte
 	GetChainID() *uint256.Int
 	GetNonce() uint64
-	GetTipCap() *uint256.Int // max_priority_fee_per_gas in EIP-1559
-	GetEffectiveGasTip(baseFee *uint256.Int) *uint256.Int
-	GetFeeCap() *uint256.Int // max_fee_per_gas in EIP-1559
+	GetTipCap() *uint256.Int                              // max_priority_fee_per_gas in EIP-1559
+	GetEffectiveGasTip(baseFee *uint256.Int) *uint256.Int // effective_gas_price in EIP-1559
+	GetFeeCap() *uint256.Int                              // max_fee_per_gas in EIP-1559
 	GetBlobHashes() []libcommon.Hash
 	GetGasLimit() uint64
 	GetBlobGas() uint64

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -60,7 +60,6 @@ type Transaction interface {
 	Type() byte
 	GetChainID() *uint256.Int
 	GetNonce() uint64
-	GetPrice() *uint256.Int
 	GetTip() *uint256.Int
 	GetEffectiveGasTip(baseFee *uint256.Int) *uint256.Int
 	GetFeeCap() *uint256.Int

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -37,17 +37,17 @@ type txJSON struct {
 	Type hexutil.Uint64 `json:"type"`
 
 	// Common transaction fields:
-	Nonce    *hexutil.Uint64    `json:"nonce"`
-	GasPrice *hexutil.Big       `json:"gasPrice"`
-	FeeCap   *hexutil.Big       `json:"maxFeePerGas"`
-	Tip      *hexutil.Big       `json:"maxPriorityFeePerGas"`
-	Gas      *hexutil.Uint64    `json:"gas"`
-	Value    *hexutil.Big       `json:"value"`
-	Data     *hexutil.Bytes     `json:"input"`
-	V        *hexutil.Big       `json:"v"`
-	R        *hexutil.Big       `json:"r"`
-	S        *hexutil.Big       `json:"s"`
-	To       *libcommon.Address `json:"to"`
+	Nonce                *hexutil.Uint64    `json:"nonce"`
+	GasPrice             *hexutil.Big       `json:"gasPrice"`
+	MaxFeePerGas         *hexutil.Big       `json:"maxFeePerGas"`
+	MaxPriorityFeePerGas *hexutil.Big       `json:"maxPriorityFeePerGas"`
+	Gas                  *hexutil.Uint64    `json:"gas"`
+	Value                *hexutil.Big       `json:"value"`
+	Data                 *hexutil.Bytes     `json:"input"`
+	V                    *hexutil.Big       `json:"v"`
+	R                    *hexutil.Big       `json:"r"`
+	S                    *hexutil.Big       `json:"s"`
+	To                   *libcommon.Address `json:"to"`
 
 	// Access list transaction fields:
 	ChainID        *hexutil.Big         `json:"chainId,omitempty"`
@@ -162,8 +162,8 @@ func (tx *DynamicFeeTransaction) MarshalJSON() ([]byte, error) {
 	enc.AccessList = &tx.AccessList
 	enc.Nonce = (*hexutil.Uint64)(&tx.Nonce)
 	enc.Gas = (*hexutil.Uint64)(&tx.GasLimit)
-	enc.FeeCap = (*hexutil.Big)(tx.FeeCap.ToBig())
-	enc.Tip = (*hexutil.Big)(tx.Tip.ToBig())
+	enc.MaxFeePerGas = (*hexutil.Big)(tx.FeeCap.ToBig())
+	enc.MaxPriorityFeePerGas = (*hexutil.Big)(tx.TipCap.ToBig())
 	enc.Value = (*hexutil.Big)(tx.Value.ToBig())
 	enc.Data = (*hexutil.Bytes)(&tx.Data)
 	enc.To = tx.To
@@ -182,8 +182,8 @@ func toBlobTxJSON(tx *BlobTx) *txJSON {
 	enc.AccessList = &tx.AccessList
 	enc.Nonce = (*hexutil.Uint64)(&tx.Nonce)
 	enc.Gas = (*hexutil.Uint64)(&tx.GasLimit)
-	enc.FeeCap = (*hexutil.Big)(tx.FeeCap.ToBig())
-	enc.Tip = (*hexutil.Big)(tx.Tip.ToBig())
+	enc.MaxFeePerGas = (*hexutil.Big)(tx.FeeCap.ToBig())
+	enc.MaxPriorityFeePerGas = (*hexutil.Big)(tx.TipCap.ToBig())
 	enc.Value = (*hexutil.Big)(tx.Value.ToBig())
 	enc.Data = (*hexutil.Bytes)(&tx.Data)
 	enc.To = tx.To
@@ -426,11 +426,11 @@ func (tx *DynamicFeeTransaction) unmarshalJson(dec txJSON) error {
 	if dec.GasPrice == nil {
 		return errors.New("missing required field 'gasPrice' in transaction")
 	}
-	tx.Tip, overflow = uint256.FromBig(dec.Tip.ToInt())
+	tx.TipCap, overflow = uint256.FromBig(dec.MaxPriorityFeePerGas.ToInt())
 	if overflow {
 		return errors.New("'tip' in transaction does not fit in 256 bits")
 	}
-	tx.FeeCap, overflow = uint256.FromBig(dec.FeeCap.ToInt())
+	tx.FeeCap, overflow = uint256.FromBig(dec.MaxFeePerGas.ToInt())
 	if overflow {
 		return errors.New("'feeCap' in transaction does not fit in 256 bits")
 	}
@@ -537,11 +537,11 @@ func UnmarshalBlobTxJSON(input []byte) (Transaction, error) {
 		return nil, errors.New("missing required field 'nonce' in transaction")
 	}
 	tx.Nonce = uint64(*dec.Nonce)
-	tx.Tip, overflow = uint256.FromBig(dec.Tip.ToInt())
+	tx.TipCap, overflow = uint256.FromBig(dec.MaxPriorityFeePerGas.ToInt())
 	if overflow {
 		return nil, errors.New("'tip' in transaction does not fit in 256 bits")
 	}
-	tx.FeeCap, overflow = uint256.FromBig(dec.FeeCap.ToInt())
+	tx.FeeCap, overflow = uint256.FromBig(dec.MaxFeePerGas.ToInt())
 	if overflow {
 		return nil, errors.New("'feeCap' in transaction does not fit in 256 bits")
 	}

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -120,7 +120,7 @@ func (tx *LegacyTx) MarshalJSON() ([]byte, error) {
 	enc.Hash = tx.Hash()
 	enc.Type = hexutil.Uint64(tx.Type())
 	enc.Nonce = (*hexutil.Uint64)(&tx.Nonce)
-	enc.Gas = (*hexutil.Uint64)(&tx.Gas)
+	enc.Gas = (*hexutil.Uint64)(&tx.GasLimit)
 	enc.GasPrice = (*hexutil.Big)(tx.GasPrice.ToBig())
 	enc.Value = (*hexutil.Big)(tx.Value.ToBig())
 	enc.Data = (*hexutil.Bytes)(&tx.Data)
@@ -142,7 +142,7 @@ func (tx *AccessListTx) MarshalJSON() ([]byte, error) {
 	enc.ChainID = (*hexutil.Big)(tx.ChainID.ToBig())
 	enc.AccessList = &tx.AccessList
 	enc.Nonce = (*hexutil.Uint64)(&tx.Nonce)
-	enc.Gas = (*hexutil.Uint64)(&tx.Gas)
+	enc.Gas = (*hexutil.Uint64)(&tx.GasLimit)
 	enc.GasPrice = (*hexutil.Big)(tx.GasPrice.ToBig())
 	enc.Value = (*hexutil.Big)(tx.Value.ToBig())
 	enc.Data = (*hexutil.Bytes)(&tx.Data)
@@ -161,7 +161,7 @@ func (tx *DynamicFeeTransaction) MarshalJSON() ([]byte, error) {
 	enc.ChainID = (*hexutil.Big)(tx.ChainID.ToBig())
 	enc.AccessList = &tx.AccessList
 	enc.Nonce = (*hexutil.Uint64)(&tx.Nonce)
-	enc.Gas = (*hexutil.Uint64)(&tx.Gas)
+	enc.Gas = (*hexutil.Uint64)(&tx.GasLimit)
 	enc.FeeCap = (*hexutil.Big)(tx.FeeCap.ToBig())
 	enc.Tip = (*hexutil.Big)(tx.Tip.ToBig())
 	enc.Value = (*hexutil.Big)(tx.Value.ToBig())
@@ -181,7 +181,7 @@ func toBlobTxJSON(tx *BlobTx) *txJSON {
 	enc.ChainID = (*hexutil.Big)(tx.ChainID.ToBig())
 	enc.AccessList = &tx.AccessList
 	enc.Nonce = (*hexutil.Uint64)(&tx.Nonce)
-	enc.Gas = (*hexutil.Uint64)(&tx.Gas)
+	enc.Gas = (*hexutil.Uint64)(&tx.GasLimit)
 	enc.FeeCap = (*hexutil.Big)(tx.FeeCap.ToBig())
 	enc.Tip = (*hexutil.Big)(tx.Tip.ToBig())
 	enc.Value = (*hexutil.Big)(tx.Value.ToBig())
@@ -282,7 +282,7 @@ func (tx *LegacyTx) UnmarshalJSON(input []byte) error {
 	if dec.Gas == nil {
 		return errors.New("missing required field 'gas' in transaction")
 	}
-	tx.Gas = uint64(*dec.Gas)
+	tx.GasLimit = uint64(*dec.Gas)
 	if dec.Value == nil {
 		return errors.New("missing required field 'value' in transaction")
 	}
@@ -361,7 +361,7 @@ func (tx *AccessListTx) UnmarshalJSON(input []byte) error {
 	if dec.Gas == nil {
 		return errors.New("missing required field 'gas' in transaction")
 	}
-	tx.Gas = uint64(*dec.Gas)
+	tx.GasLimit = uint64(*dec.Gas)
 	if dec.Value == nil {
 		return errors.New("missing required field 'value' in transaction")
 	}
@@ -437,7 +437,7 @@ func (tx *DynamicFeeTransaction) unmarshalJson(dec txJSON) error {
 	if dec.Gas == nil {
 		return errors.New("missing required field 'gas' in transaction")
 	}
-	tx.Gas = uint64(*dec.Gas)
+	tx.GasLimit = uint64(*dec.Gas)
 	if dec.Value == nil {
 		return errors.New("missing required field 'value' in transaction")
 	}
@@ -548,7 +548,7 @@ func UnmarshalBlobTxJSON(input []byte) (Transaction, error) {
 	if dec.Gas == nil {
 		return nil, errors.New("missing required field 'gas' in transaction")
 	}
-	tx.Gas = uint64(*dec.Gas)
+	tx.GasLimit = uint64(*dec.Gas)
 	if dec.Value == nil {
 		return nil, errors.New("missing required field 'value' in transaction")
 	}

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -71,11 +71,11 @@ var (
 		ChainID: u256.Num1,
 		LegacyTx: LegacyTx{
 			CommonTx: CommonTx{
-				Nonce: 3,
-				To:    &testAddr,
-				Value: uint256.NewInt(10),
-				Gas:   25000,
-				Data:  libcommon.FromHex("5544"),
+				Nonce:    3,
+				To:       &testAddr,
+				Value:    uint256.NewInt(10),
+				GasLimit: 25000,
+				Data:     libcommon.FromHex("5544"),
 			},
 			GasPrice: uint256.NewInt(1),
 		},
@@ -88,11 +88,11 @@ var (
 
 	dynFeeTx = &DynamicFeeTransaction{
 		CommonTx: CommonTx{
-			Nonce: 3,
-			To:    &testAddr,
-			Value: uint256.NewInt(10),
-			Gas:   25000,
-			Data:  libcommon.FromHex("5544"),
+			Nonce:    3,
+			To:       &testAddr,
+			Value:    uint256.NewInt(10),
+			GasLimit: 25000,
+			Data:     libcommon.FromHex("5544"),
 		},
 		ChainID: u256.Num1,
 		Tip:     uint256.NewInt(1),
@@ -382,10 +382,10 @@ func TestTransactionCoding(t *testing.T) {
 			// Legacy tx.
 			txdata = &LegacyTx{
 				CommonTx: CommonTx{
-					Nonce: i,
-					To:    &recipient,
-					Gas:   1,
-					Data:  []byte("abcdef"),
+					Nonce:    i,
+					To:       &recipient,
+					GasLimit: 1,
+					Data:     []byte("abcdef"),
 				},
 				GasPrice: u256.Num2,
 			}
@@ -393,9 +393,9 @@ func TestTransactionCoding(t *testing.T) {
 			// Legacy txn contract creation.
 			txdata = &LegacyTx{
 				CommonTx: CommonTx{
-					Nonce: i,
-					Gas:   1,
-					Data:  []byte("abcdef"),
+					Nonce:    i,
+					GasLimit: 1,
+					Data:     []byte("abcdef"),
 				},
 				GasPrice: u256.Num2,
 			}
@@ -405,10 +405,10 @@ func TestTransactionCoding(t *testing.T) {
 				ChainID: uint256.NewInt(1),
 				LegacyTx: LegacyTx{
 					CommonTx: CommonTx{
-						Nonce: i,
-						To:    &recipient,
-						Gas:   123457,
-						Data:  []byte("abcdef"),
+						Nonce:    i,
+						To:       &recipient,
+						GasLimit: 123457,
+						Data:     []byte("abcdef"),
 					},
 					GasPrice: uint256.NewInt(10),
 				},
@@ -420,10 +420,10 @@ func TestTransactionCoding(t *testing.T) {
 				ChainID: uint256.NewInt(1),
 				LegacyTx: LegacyTx{
 					CommonTx: CommonTx{
-						Nonce: i,
-						To:    &recipient,
-						Gas:   123457,
-						Data:  []byte("abcdef"),
+						Nonce:    i,
+						To:       &recipient,
+						GasLimit: 123457,
+						Data:     []byte("abcdef"),
 					},
 					GasPrice: uint256.NewInt(10),
 				},
@@ -434,8 +434,8 @@ func TestTransactionCoding(t *testing.T) {
 				ChainID: uint256.NewInt(1),
 				LegacyTx: LegacyTx{
 					CommonTx: CommonTx{
-						Nonce: i,
-						Gas:   123457,
+						Nonce:    i,
+						GasLimit: 123457,
 					},
 					GasPrice: uint256.NewInt(10),
 				},
@@ -596,14 +596,14 @@ func randData() []byte {
 func newRandBlobTx() *BlobTx {
 	stx := &BlobTx{DynamicFeeTransaction: DynamicFeeTransaction{
 		CommonTx: CommonTx{
-			Nonce: rand.Uint64(),
-			Gas:   rand.Uint64(),
-			To:    randAddr(),
-			Value: uint256.NewInt(rand.Uint64()),
-			Data:  randData(),
-			V:     *uint256.NewInt(0),
-			R:     *uint256.NewInt(rand.Uint64()),
-			S:     *uint256.NewInt(rand.Uint64()),
+			Nonce:    rand.Uint64(),
+			GasLimit: rand.Uint64(),
+			To:       randAddr(),
+			Value:    uint256.NewInt(rand.Uint64()),
+			Data:     randData(),
+			V:        *uint256.NewInt(0),
+			R:        *uint256.NewInt(rand.Uint64()),
+			S:        *uint256.NewInt(rand.Uint64()),
 		},
 		ChainID:    uint256.NewInt(rand.Uint64()),
 		Tip:        uint256.NewInt(rand.Uint64()),
@@ -622,7 +622,7 @@ func printSTX(stx *BlobTx) {
 	fmt.Printf("Nonce: %v\n", stx.Nonce)
 	fmt.Printf("MaxPriorityFeePerGas: %v\n", stx.Tip)
 	fmt.Printf("MaxFeePerGas: %v\n", stx.FeeCap)
-	fmt.Printf("Gas: %v\n", stx.Gas)
+	fmt.Printf("Gas: %v\n", stx.GasLimit)
 	fmt.Printf("To: %v\n", stx.To)
 	fmt.Printf("Value: %v\n", stx.Value)
 	fmt.Printf("Data: %v\n", stx.Data)

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -95,7 +95,7 @@ var (
 			Data:     libcommon.FromHex("5544"),
 		},
 		ChainID: u256.Num1,
-		Tip:     uint256.NewInt(1),
+		TipCap:  uint256.NewInt(1),
 		FeeCap:  uint256.NewInt(1),
 	}
 
@@ -606,7 +606,7 @@ func newRandBlobTx() *BlobTx {
 			S:        *uint256.NewInt(rand.Uint64()),
 		},
 		ChainID:    uint256.NewInt(rand.Uint64()),
-		Tip:        uint256.NewInt(rand.Uint64()),
+		TipCap:     uint256.NewInt(rand.Uint64()),
 		FeeCap:     uint256.NewInt(rand.Uint64()),
 		AccessList: randAccessList(),
 	},
@@ -620,7 +620,7 @@ func printSTX(stx *BlobTx) {
 	fmt.Println("--BlobTx")
 	fmt.Printf("ChainID: %v\n", stx.ChainID)
 	fmt.Printf("Nonce: %v\n", stx.Nonce)
-	fmt.Printf("MaxPriorityFeePerGas: %v\n", stx.Tip)
+	fmt.Printf("MaxPriorityFeePerGas: %v\n", stx.TipCap)
 	fmt.Printf("MaxFeePerGas: %v\n", stx.FeeCap)
 	fmt.Printf("Gas: %v\n", stx.GasLimit)
 	fmt.Printf("To: %v\n", stx.To)

--- a/eth/ethutils/receipt.go
+++ b/eth/ethutils/receipt.go
@@ -70,7 +70,7 @@ func MarshalReceipt(
 	}
 
 	if !chainConfig.IsLondon(header.Number.Uint64()) {
-		fields["effectiveGasPrice"] = (*hexutil.Big)(txn.GetTip().ToBig())
+		fields["effectiveGasPrice"] = (*hexutil.Big)(txn.GetTipCap().ToBig())
 	} else {
 		baseFee, _ := uint256.FromBig(header.BaseFee)
 		gasPrice := new(big.Int).Add(header.BaseFee, txn.GetEffectiveGasTip(baseFee).ToBig())

--- a/eth/ethutils/receipt.go
+++ b/eth/ethutils/receipt.go
@@ -70,7 +70,7 @@ func MarshalReceipt(
 	}
 
 	if !chainConfig.IsLondon(header.Number.Uint64()) {
-		fields["effectiveGasPrice"] = (*hexutil.Big)(txn.GetPrice().ToBig())
+		fields["effectiveGasPrice"] = (*hexutil.Big)(txn.GetTip().ToBig())
 	} else {
 		baseFee, _ := uint256.FromBig(header.BaseFee)
 		gasPrice := new(big.Int).Add(header.BaseFee, txn.GetEffectiveGasTip(baseFee).ToBig())

--- a/eth/stagedsync/stage_bodies_test.go
+++ b/eth/stagedsync/stage_bodies_test.go
@@ -38,7 +38,7 @@ import (
 func testingHeaderBody(t *testing.T) (h *types.Header, b *types.RawBody) {
 	t.Helper()
 
-	txn := &types.DynamicFeeTransaction{Tip: u256.N1, FeeCap: u256.N1, ChainID: u256.N1, CommonTx: types.CommonTx{Value: u256.N1, GasLimit: 1, Nonce: 1}}
+	txn := &types.DynamicFeeTransaction{TipCap: u256.N1, FeeCap: u256.N1, ChainID: u256.N1, CommonTx: types.CommonTx{Value: u256.N1, GasLimit: 1, Nonce: 1}}
 	buf := bytes.NewBuffer(nil)
 	err := txn.MarshalBinary(buf)
 	require.NoError(t, err)

--- a/eth/stagedsync/stage_bodies_test.go
+++ b/eth/stagedsync/stage_bodies_test.go
@@ -38,7 +38,7 @@ import (
 func testingHeaderBody(t *testing.T) (h *types.Header, b *types.RawBody) {
 	t.Helper()
 
-	txn := &types.DynamicFeeTransaction{Tip: u256.N1, FeeCap: u256.N1, ChainID: u256.N1, CommonTx: types.CommonTx{Value: u256.N1, Gas: 1, Nonce: 1}}
+	txn := &types.DynamicFeeTransaction{Tip: u256.N1, FeeCap: u256.N1, ChainID: u256.N1, CommonTx: types.CommonTx{Value: u256.N1, GasLimit: 1, Nonce: 1}}
 	buf := bytes.NewBuffer(nil)
 	err := txn.MarshalBinary(buf)
 	require.NoError(t, err)

--- a/eth/stagedsync/stage_mining_exec.go
+++ b/eth/stagedsync/stage_mining_exec.go
@@ -373,13 +373,13 @@ func filterBadTransactions(transactions []types.Transaction, chainID *uint256.In
 				}
 			}
 		}
-		txnGas := transaction.GetGas()
+		txnGasLimit := transaction.GetGasLimit()
 		txnPrice := transaction.GetPrice()
 		value := transaction.GetValue()
 		accountBalance := account.Balance
 
 		want := uint256.NewInt(0)
-		want.SetUint64(txnGas)
+		want.SetUint64(txnGasLimit)
 		want, overflow := want.MulOverflow(want, txnPrice)
 		if overflow {
 			transactions = transactions[1:]
@@ -388,7 +388,7 @@ func filterBadTransactions(transactions []types.Transaction, chainID *uint256.In
 		}
 
 		if transaction.GetFeeCap() != nil {
-			want.SetUint64(txnGas)
+			want.SetUint64(txnGasLimit)
 			want, overflow = want.MulOverflow(want, transaction.GetFeeCap())
 			if overflow {
 				transactions = transactions[1:]

--- a/eth/stagedsync/stage_mining_exec.go
+++ b/eth/stagedsync/stage_mining_exec.go
@@ -365,8 +365,8 @@ func filterBadTransactions(transactions []types.Transaction, chainID *uint256.In
 				return nil, fmt.Errorf("bad baseFee %s", header.BaseFee)
 			}
 			// Make sure the transaction gasFeeCap is greater than the block's baseFee.
-			if !transaction.GetFeeCap().IsZero() || !transaction.GetTip().IsZero() {
-				if err := core.CheckEip1559TxGasFeeCap(sender, transaction.GetFeeCap(), transaction.GetTip(), baseFee256, false /* isFree */); err != nil {
+			if !transaction.GetFeeCap().IsZero() || !transaction.GetTipCap().IsZero() {
+				if err := core.CheckEip1559TxGasFeeCap(sender, transaction.GetFeeCap(), transaction.GetTipCap(), baseFee256, false /* isFree */); err != nil {
 					transactions = transactions[1:]
 					feeTooLowCnt++
 					continue

--- a/eth/stagedsync/stage_senders_test.go
+++ b/eth/stagedsync/stage_senders_test.go
@@ -66,10 +66,10 @@ func TestSenders(t *testing.T) {
 			mustSign(&types.AccessListTx{
 				LegacyTx: types.LegacyTx{
 					CommonTx: types.CommonTx{
-						Nonce: 1,
-						To:    &testAddr,
-						Value: u256.Num1,
-						Gas:   1,
+						Nonce:    1,
+						To:       &testAddr,
+						Value:    u256.Num1,
+						GasLimit: 1,
 					},
 					GasPrice: u256.Num1,
 				},
@@ -77,10 +77,10 @@ func TestSenders(t *testing.T) {
 			mustSign(&types.AccessListTx{
 				LegacyTx: types.LegacyTx{
 					CommonTx: types.CommonTx{
-						Nonce: 2,
-						To:    &testAddr,
-						Value: u256.Num1,
-						Gas:   2,
+						Nonce:    2,
+						To:       &testAddr,
+						Value:    u256.Num1,
+						GasLimit: 2,
 					},
 					GasPrice: u256.Num1,
 				},
@@ -98,10 +98,10 @@ func TestSenders(t *testing.T) {
 			mustSign(&types.AccessListTx{
 				LegacyTx: types.LegacyTx{
 					CommonTx: types.CommonTx{
-						Nonce: 3,
-						To:    &testAddr,
-						Value: u256.Num1,
-						Gas:   3,
+						Nonce:    3,
+						To:       &testAddr,
+						Value:    u256.Num1,
+						GasLimit: 3,
 					},
 					GasPrice: u256.Num1,
 				},
@@ -109,10 +109,10 @@ func TestSenders(t *testing.T) {
 			mustSign(&types.AccessListTx{
 				LegacyTx: types.LegacyTx{
 					CommonTx: types.CommonTx{
-						Nonce: 4,
-						To:    &testAddr,
-						Value: u256.Num1,
-						Gas:   4,
+						Nonce:    4,
+						To:       &testAddr,
+						Value:    u256.Num1,
+						GasLimit: 4,
 					},
 					GasPrice: u256.Num1,
 				},
@@ -120,10 +120,10 @@ func TestSenders(t *testing.T) {
 			mustSign(&types.AccessListTx{
 				LegacyTx: types.LegacyTx{
 					CommonTx: types.CommonTx{
-						Nonce: 5,
-						To:    &testAddr,
-						Value: u256.Num1,
-						Gas:   5,
+						Nonce:    5,
+						To:       &testAddr,
+						Value:    u256.Num1,
+						GasLimit: 5,
 					},
 					GasPrice: u256.Num1,
 				},

--- a/eth/tracers/internal/tracetest/calltrace_test.go
+++ b/eth/tracers/internal/tracetest/calltrace_test.go
@@ -246,7 +246,7 @@ func benchTracer(b *testing.B, tracerName string, test *callTracerTest) {
 	origin, _ := signer.Sender(tx)
 	txContext := evmtypes.TxContext{
 		Origin:   origin,
-		GasPrice: tx.GetPrice(),
+		GasPrice: tx.GetTip(),
 	}
 	context := evmtypes.BlockContext{
 		CanTransfer: core.CanTransfer,

--- a/eth/tracers/internal/tracetest/calltrace_test.go
+++ b/eth/tracers/internal/tracetest/calltrace_test.go
@@ -165,7 +165,7 @@ func testCallTracer(tracerName string, dirPath string, t *testing.T) {
 			}
 			txContext := core.NewEVMTxContext(msg)
 			evm := vm.NewEVM(context, txContext, statedb, test.Genesis.Config, vm.Config{Debug: true, Tracer: tracer})
-			vmRet, err := core.ApplyMessage(evm, msg, new(core.GasPool).AddGas(tx.GetGas()).AddBlobGas(tx.GetBlobGas()), true /* refunds */, false /* gasBailout */, nil /* engine */)
+			vmRet, err := core.ApplyMessage(evm, msg, new(core.GasPool).AddGas(tx.GetGasLimit()).AddBlobGas(tx.GetBlobGas()), true /* refunds */, false /* gasBailout */, nil /* engine */)
 			if err != nil {
 				t.Fatalf("failed to execute transaction: %v", err)
 			}
@@ -272,7 +272,7 @@ func benchTracer(b *testing.B, tracerName string, test *callTracerTest) {
 		}
 		evm := vm.NewEVM(context, txContext, statedb, test.Genesis.Config, vm.Config{Debug: true, Tracer: tracer})
 		snap := statedb.Snapshot()
-		st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.GetGas()).AddBlobGas(tx.GetBlobGas()))
+		st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.GetGasLimit()).AddBlobGas(tx.GetBlobGas()))
 		if _, err = st.TransitionDb(true /* refunds */, false /* gasBailout */); err != nil {
 			b.Fatalf("failed to execute transaction: %v", err)
 		}
@@ -296,8 +296,8 @@ func TestZeroValueToNotExitCall(t *testing.T) {
 	tx, err := types.SignNewTx(privkey, *signer, &types.LegacyTx{
 		GasPrice: uint256.NewInt(0),
 		CommonTx: types.CommonTx{
-			Gas: 50000,
-			To:  &to,
+			GasLimit: 50000,
+			To:       &to,
 		},
 	})
 	if err != nil {
@@ -349,7 +349,7 @@ func TestZeroValueToNotExitCall(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to prepare transaction for tracing: %v", err)
 	}
-	st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.GetGas()).AddBlobGas(tx.GetBlobGas()))
+	st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.GetGasLimit()).AddBlobGas(tx.GetBlobGas()))
 	if _, err = st.TransitionDb(true /* refunds */, false /* gasBailout */); err != nil {
 		t.Fatalf("failed to execute transaction: %v", err)
 	}

--- a/eth/tracers/internal/tracetest/calltrace_test.go
+++ b/eth/tracers/internal/tracetest/calltrace_test.go
@@ -244,9 +244,10 @@ func benchTracer(b *testing.B, tracerName string, test *callTracerTest) {
 		b.Fatalf("failed to prepare transaction for tracing: %v", err)
 	}
 	origin, _ := signer.Sender(tx)
+	baseFee := uint256.MustFromBig((*big.Int)(test.Context.BaseFee))
 	txContext := evmtypes.TxContext{
 		Origin:   origin,
-		GasPrice: tx.GetTipCap(),
+		GasPrice: tx.GetEffectiveGasTip(baseFee),
 	}
 	context := evmtypes.BlockContext{
 		CanTransfer: core.CanTransfer,

--- a/eth/tracers/internal/tracetest/calltrace_test.go
+++ b/eth/tracers/internal/tracetest/calltrace_test.go
@@ -246,7 +246,7 @@ func benchTracer(b *testing.B, tracerName string, test *callTracerTest) {
 	origin, _ := signer.Sender(tx)
 	txContext := evmtypes.TxContext{
 		Origin:   origin,
-		GasPrice: tx.GetTip(),
+		GasPrice: tx.GetTipCap(),
 	}
 	context := evmtypes.BlockContext{
 		CanTransfer: core.CanTransfer,

--- a/eth/tracers/internal/tracetest/prestate_test.go
+++ b/eth/tracers/internal/tracetest/prestate_test.go
@@ -130,7 +130,7 @@ func testPrestateTracer(tracerName string, dirPath string, t *testing.T) {
 			}
 			txContext := core.NewEVMTxContext(msg)
 			evm := vm.NewEVM(context, txContext, statedb, test.Genesis.Config, vm.Config{Debug: true, Tracer: tracer})
-			st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.GetGas()).AddBlobGas(tx.GetBlobGas()))
+			st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.GetGasLimit()).AddBlobGas(tx.GetBlobGas()))
 			if _, err = st.TransitionDb(true /* refunds */, false /* gasBailout */); err != nil {
 				t.Fatalf("failed to execute transaction: %v", err)
 			}

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -118,7 +118,7 @@ func TestPrestateTracerCreate2(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to prepare transaction for tracing: %v", err)
 	}
-	st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(txn.GetGas()).AddBlobGas(txn.GetBlobGas()))
+	st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(txn.GetGasLimit()).AddBlobGas(txn.GetBlobGas()))
 	if _, err = st.TransitionDb(false, false); err != nil {
 		t.Fatalf("failed to execute transaction: %v", err)
 	}

--- a/interfaces.go
+++ b/interfaces.go
@@ -126,11 +126,11 @@ type CallMsg struct {
 	Value            *uint256.Int       // amount of wei sent along with the call
 	Data             []byte             // input data, usually an ABI-encoded contract method invocation
 
-	FeeCap         *uint256.Int          // EIP-1559 fee cap per gas.
-	Tip            *uint256.Int          // EIP-1559 tip per gas.
-	AccessList     types.AccessList      // EIP-2930 access list.
-	BlobHashes     []libcommon.Hash      // EIP-4844 versioned blob hashes.
-	Authorizations []types.Authorization // EIP-3074 authorizations.
+	FeeCap         *uint256.Int          // EIP-1559 max_fee_per_gas
+	TipCap         *uint256.Int          // EIP-1559 max_priority_fee_per_gas
+	AccessList     types.AccessList      // EIP-2930 access list
+	BlobHashes     []libcommon.Hash      // EIP-4844 versioned blob hashes
+	Authorizations []types.Authorization // EIP-3074 authorizations
 }
 
 // A ContractCaller provides contract calls, essentially transactions that are executed by

--- a/tests/transaction_test_util.go
+++ b/tests/transaction_test_util.go
@@ -91,7 +91,7 @@ func (tt *TransactionTest) Run(chainID *big.Int) error {
 
 		if rules.IsLondon {
 			// EIP-1559 gas fee cap
-			err = core.CheckEip1559TxGasFeeCap(sender, msg.FeeCap(), msg.Tip(), nil, false /* isFree */)
+			err = core.CheckEip1559TxGasFeeCap(sender, msg.FeeCap(), msg.TipCap(), nil, false /* isFree */)
 			if err != nil {
 				return nil, nil, 0, err
 			}

--- a/tests/txpool/pool_test.go
+++ b/tests/txpool/pool_test.go
@@ -8,14 +8,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
 	"github.com/erigontech/erigon-lib/crypto"
 	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cmd/devnet/requests"
 	"github.com/erigontech/erigon/core/types"
 	"github.com/erigontech/erigon/tests/txpool/helper"
-	"github.com/holiman/uint256"
-	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -60,11 +61,11 @@ func TestSimpleLocalTxThroughputBenchmark(t *testing.T) {
 			signedTx, err := types.SignTx(
 				&types.LegacyTx{
 					CommonTx: types.CommonTx{
-						Nonce: uint64(i),
-						Gas:   21000,
-						To:    &addr2,
-						Value: uint256.NewInt(100),
-						Data:  nil,
+						Nonce:    uint64(i),
+						GasLimit: 21000,
+						To:       &addr2,
+						Value:    uint256.NewInt(100),
+						Data:     nil,
 					},
 					GasPrice: uint256.NewInt(1),
 				},
@@ -132,11 +133,11 @@ func TestSimpleLocalTxLatencyBenchmark(t *testing.T) {
 		signedTx, err := types.SignTx(
 			&types.LegacyTx{
 				CommonTx: types.CommonTx{
-					Nonce: uint64(i),
-					Gas:   21000,
-					To:    &addr2,
-					Value: uint256.NewInt(100),
-					Data:  nil,
+					Nonce:    uint64(i),
+					GasLimit: 21000,
+					To:       &addr2,
+					Value:    uint256.NewInt(100),
+					Data:     nil,
 				},
 				GasPrice: uint256.NewInt(1),
 			},

--- a/turbo/adapter/ethapi/api.go
+++ b/turbo/adapter/ethapi/api.go
@@ -426,7 +426,7 @@ func NewRPCTransaction(txn types.Transaction, blockHash libcommon.Hash, blockNum
 		if !chainId.IsZero() {
 			result.ChainID = (*hexutil.Big)(chainId.ToBig())
 		}
-		result.GasPrice = (*hexutil.Big)(txn.GetPrice().ToBig())
+		result.GasPrice = (*hexutil.Big)(txn.GetTip().ToBig())
 	} else {
 		chainId.Set(txn.GetChainID())
 		result.ChainID = (*hexutil.Big)(chainId.ToBig())
@@ -435,7 +435,7 @@ func NewRPCTransaction(txn types.Transaction, blockHash libcommon.Hash, blockNum
 		result.Accesses = &acl
 
 		if txn.Type() == types.AccessListTxType {
-			result.GasPrice = (*hexutil.Big)(txn.GetPrice().ToBig())
+			result.GasPrice = (*hexutil.Big)(txn.GetTip().ToBig())
 		} else {
 			result.GasPrice = computeGasPrice(txn, blockHash, baseFee)
 			result.Tip = (*hexutil.Big)(txn.GetTip().ToBig())

--- a/turbo/adapter/ethapi/api.go
+++ b/turbo/adapter/ethapi/api.go
@@ -404,7 +404,7 @@ func NewRPCTransaction(txn types.Transaction, blockHash libcommon.Hash, blockNum
 	chainId := uint256.NewInt(0)
 	result := &RPCTransaction{
 		Type:  hexutil.Uint64(txn.Type()),
-		Gas:   hexutil.Uint64(txn.GetGas()),
+		Gas:   hexutil.Uint64(txn.GetGasLimit()),
 		Hash:  txn.Hash(),
 		Input: hexutil.Bytes(txn.GetData()),
 		Nonce: hexutil.Uint64(txn.GetNonce()),
@@ -489,7 +489,7 @@ func NewRPCBorTransaction(opaqueTxn types.Transaction, txHash libcommon.Hash, bl
 		Type:     hexutil.Uint64(txn.Type()),
 		ChainID:  (*hexutil.Big)(new(big.Int)),
 		GasPrice: (*hexutil.Big)(txn.GasPrice.ToBig()),
-		Gas:      hexutil.Uint64(txn.GetGas()),
+		Gas:      hexutil.Uint64(txn.GetGasLimit()),
 		Hash:     txHash,
 		Input:    hexutil.Bytes(txn.GetData()),
 		Nonce:    hexutil.Uint64(txn.GetNonce()),

--- a/turbo/execution/eth1/eth1_utils/grpc_test.go
+++ b/turbo/execution/eth1/eth1_utils/grpc_test.go
@@ -58,7 +58,7 @@ func makeBlock(txCount, uncleCount, withdrawalCount int) *types.Block {
 			panic(err)
 		}
 		txs[i] = signedTx
-		receipts[i] = types.NewReceipt(false, tx.GetGas())
+		receipts[i] = types.NewReceipt(false, tx.GetGasLimit())
 	}
 	for i := range uncles {
 		uncles[i] = &types.Header{

--- a/turbo/jsonrpc/otterscan_api.go
+++ b/turbo/jsonrpc/otterscan_api.go
@@ -337,7 +337,7 @@ func delegateBlockFees(ctx context.Context, tx kv.Tx, block *types.Block, sender
 		txn := block.Transactions()[receipt.TransactionIndex]
 		var effectiveGasPrice uint64
 		if !chainConfig.IsLondon(block.NumberU64()) {
-			effectiveGasPrice = txn.GetTip().Uint64()
+			effectiveGasPrice = txn.GetTipCap().Uint64()
 		} else {
 			baseFee, _ := uint256.FromBig(block.BaseFee())
 			gasPrice := new(big.Int).Add(block.BaseFee(), txn.GetEffectiveGasTip(baseFee).ToBig())

--- a/turbo/jsonrpc/otterscan_api.go
+++ b/turbo/jsonrpc/otterscan_api.go
@@ -337,7 +337,7 @@ func delegateBlockFees(ctx context.Context, tx kv.Tx, block *types.Block, sender
 		txn := block.Transactions()[receipt.TransactionIndex]
 		var effectiveGasPrice uint64
 		if !chainConfig.IsLondon(block.NumberU64()) {
-			effectiveGasPrice = txn.GetPrice().Uint64()
+			effectiveGasPrice = txn.GetTip().Uint64()
 		} else {
 			baseFee, _ := uint256.FromBig(block.BaseFee())
 			gasPrice := new(big.Int).Add(block.BaseFee(), txn.GetEffectiveGasTip(baseFee).ToBig())

--- a/turbo/jsonrpc/otterscan_search_trace.go
+++ b/turbo/jsonrpc/otterscan_search_trace.go
@@ -121,7 +121,7 @@ func (api *OtterscanAPIImpl) traceBlock(dbtx kv.TemporalTx, ctx context.Context,
 		TxContext := core.NewEVMTxContext(msg)
 
 		vmenv := vm.NewEVM(BlockContext, TxContext, ibs, chainConfig, vm.Config{Debug: true, Tracer: tracer})
-		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(txn.GetGas()).AddBlobGas(txn.GetBlobGas()), true /* refunds */, false /* gasBailout */, engine); err != nil {
+		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(txn.GetGasLimit()).AddBlobGas(txn.GetBlobGas()), true /* refunds */, false /* gasBailout */, engine); err != nil {
 			return false, nil, err
 		}
 		_ = ibs.FinalizeTx(rules, cachedWriter)

--- a/turbo/jsonrpc/overlay_api.go
+++ b/turbo/jsonrpc/overlay_api.go
@@ -213,7 +213,7 @@ func (api *OverlayAPIImpl) CallConstructor(ctx context.Context, address common.A
 	contractAddr := crypto.CreateAddress(msg.From(), msg.Nonce())
 	if creationTx.GetTo() == nil && contractAddr == address {
 		// CREATE: adapt message with new code so it's replaced instantly
-		msg = types.NewMessage(msg.From(), msg.To(), msg.Nonce(), msg.Value(), api.GasCap, msg.GasPrice(), msg.FeeCap(), msg.Tip(), *code, msg.AccessList(), msg.CheckNonce(), msg.IsFree(), msg.MaxFeePerBlobGas())
+		msg = types.NewMessage(msg.From(), msg.To(), msg.Nonce(), msg.Value(), api.GasCap, msg.GasPrice(), msg.FeeCap(), msg.TipCap(), *code, msg.AccessList(), msg.CheckNonce(), msg.IsFree(), msg.MaxFeePerBlobGas())
 	} else {
 		msg.ChangeGas(api.GasCap, api.GasCap)
 	}

--- a/turbo/jsonrpc/send_transaction.go
+++ b/turbo/jsonrpc/send_transaction.go
@@ -23,7 +23,7 @@ func (api *APIImpl) SendRawTransaction(ctx context.Context, encodedTx hexutil.By
 
 	// If the transaction fee cap is already specified, ensure the
 	// fee of the given transaction is _reasonable_.
-	if err := checkTxFee(txn.GetPrice().ToBig(), txn.GetGas(), api.FeeCap); err != nil {
+	if err := checkTxFee(txn.GetPrice().ToBig(), txn.GetGasLimit(), api.FeeCap); err != nil {
 		return common.Hash{}, err
 	}
 	if !txn.Protected() && !api.AllowUnprotectedTxs {

--- a/turbo/jsonrpc/trace_adhoc_test.go
+++ b/turbo/jsonrpc/trace_adhoc_test.go
@@ -423,7 +423,7 @@ func TestOeTracer(t *testing.T) {
 			require.NoError(t, err)
 			evm := vm.NewEVM(context, txContext, statedb, test.Genesis.Config, vm.Config{Debug: true, Tracer: &tracer})
 
-			st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.GetGas()).AddBlobGas(tx.GetBlobGas()))
+			st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.GetGasLimit()).AddBlobGas(tx.GetBlobGas()))
 			_, err = st.TransitionDb(true /* refunds */, false /* gasBailout */)
 			require.NoError(t, err)
 

--- a/turbo/stages/blockchain_test.go
+++ b/turbo/stages/blockchain_test.go
@@ -2209,7 +2209,7 @@ func TestEIP1559Transition(t *testing.T) {
 				},
 				ChainID:    &chainID,
 				FeeCap:     new(uint256.Int).Mul(new(uint256.Int).SetUint64(5), new(uint256.Int).SetUint64(params.GWei)),
-				Tip:        u256.Num2,
+				TipCap:     u256.Num2,
 				AccessList: accesses,
 			}
 			txn, _ = types.SignTx(txn, *signer, key1)
@@ -2243,7 +2243,7 @@ func TestEIP1559Transition(t *testing.T) {
 			return err
 		}
 		expected := new(uint256.Int).Add(
-			new(uint256.Int).SetUint64(block.GasUsed()*block.Transactions()[0].GetTip().Uint64()),
+			new(uint256.Int).SetUint64(block.GasUsed()*block.Transactions()[0].GetTipCap().Uint64()),
 			ethash.ConstantinopleBlockReward,
 		)
 		if actual.Cmp(expected) != 0 {
@@ -2256,7 +2256,7 @@ func TestEIP1559Transition(t *testing.T) {
 			return err
 		}
 		actual = new(uint256.Int).Sub(funds, balance)
-		expected = new(uint256.Int).SetUint64(block.GasUsed() * (block.Transactions()[0].GetTip().Uint64() + block.BaseFee().Uint64()))
+		expected = new(uint256.Int).SetUint64(block.GasUsed() * (block.Transactions()[0].GetTipCap().Uint64() + block.BaseFee().Uint64()))
 		if actual.Cmp(expected) != 0 {
 			t.Fatalf("sender expenditure incorrect: expected %d, got %d", expected, actual)
 		}

--- a/turbo/stages/blockchain_test.go
+++ b/turbo/stages/blockchain_test.go
@@ -2306,7 +2306,7 @@ func TestEIP1559Transition(t *testing.T) {
 			return err
 		}
 		actual = new(uint256.Int).Sub(funds, balance)
-		expected = new(uint256.Int).SetUint64(block.GasUsed() * (effectiveTip + block.BaseFee().Uint64()))
+		expected = new(uint256.Int).SetUint64(block.GasUsed() * (effectiveTip + baseFee.Uint64()))
 		if actual.Cmp(expected) != 0 {
 			t.Fatalf("sender balance incorrect: expected %d, got %d", expected, actual)
 		}

--- a/turbo/stages/blockchain_test.go
+++ b/turbo/stages/blockchain_test.go
@@ -2100,9 +2100,9 @@ func TestEIP2718Transition(t *testing.T) {
 			ChainID: chainID,
 			LegacyTx: types.LegacyTx{
 				CommonTx: types.CommonTx{
-					Nonce: 0,
-					To:    &aa,
-					Gas:   30000,
+					Nonce:    0,
+					To:       &aa,
+					GasLimit: 30000,
 				},
 				GasPrice: gasPrice,
 			},
@@ -2202,10 +2202,10 @@ func TestEIP1559Transition(t *testing.T) {
 			chainID.SetFromBig(gspec.Config.ChainID)
 			var txn types.Transaction = &types.DynamicFeeTransaction{
 				CommonTx: types.CommonTx{
-					Nonce: 0,
-					To:    &aa,
-					Gas:   30000,
-					Data:  []byte{},
+					Nonce:    0,
+					To:       &aa,
+					GasLimit: 30000,
+					Data:     []byte{},
 				},
 				ChainID:    &chainID,
 				FeeCap:     new(uint256.Int).Mul(new(uint256.Int).SetUint64(5), new(uint256.Int).SetUint64(params.GWei)),

--- a/txnprovider/shutter/decryption_keys_processor.go
+++ b/txnprovider/shutter/decryption_keys_processor.go
@@ -225,8 +225,8 @@ func (dkp DecryptionKeysProcessor) decryptTxn(keys map[TxnIndex]*proto.Key, sub 
 		return nil, errors.New("blob txns not allowed in shutter")
 	}
 
-	if subGasLimit := sub.GasLimit.Uint64(); txn.GetGas() != subGasLimit {
-		return nil, fmt.Errorf("txn gas limit mismatch: txn=%d, encryptedTxnSubmission=%d", txn.GetGas(), subGasLimit)
+	if subGasLimit := sub.GasLimit.Uint64(); txn.GetGasLimit() != subGasLimit {
+		return nil, fmt.Errorf("txn gas limit mismatch: txn=%d, encryptedTxnSubmission=%d", txn.GetGasLimit(), subGasLimit)
 	}
 
 	return txn, nil


### PR DESCRIPTION
Better align names with [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559):

- rename `Tip` to `TipCap` (similar to the existing `FeeCap`)
- rename txn `Gas` to `GasLimit`

`FeeCap` corresponds to `max_fee_per_gas` in EIP-1559 and `TipCap` corresponds to `max_priority_fee_per_gas`.

Also remove misleading `txn.GetPrice()`.