### PR TITLE
refactor: use a more straightforward return value

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -526,7 +526,7 @@ func ReadBodyWithTransactions(db kv.Getter, hash common.Hash, number uint64) (*t
 	if err != nil {
 		return nil, err
 	}
-	return body, err
+	return body, nil
 }
 
 func RawTransactionsRange(db kv.Getter, from, to uint64) (res [][]byte, err error) {

--- a/core/state/intra_block_state.go
+++ b/core/state/intra_block_state.go
@@ -237,7 +237,7 @@ func (sdb *IntraBlockState) Exist(addr libcommon.Address) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return s != nil && !s.deleted, err
+	return s != nil && !s.deleted, nil
 }
 
 // Empty returns whether the state object is either non-existent


### PR DESCRIPTION
use a more straightforward return value