### PR TITLE
Update the bn256 crypto lib.

### DIFF
--- a/erigon-lib/crypto/bn256/cloudflare/gfp12.go
+++ b/erigon-lib/crypto/bn256/cloudflare/gfp12.go
@@ -105,8 +105,8 @@ func (e *gfP12) Mul(a, b *gfP12) *gfP12 {
 }
 
 func (e *gfP12) MulScalar(a *gfP12, b *gfP6) *gfP12 {
-	e.x.Mul(&e.x, b)
-	e.y.Mul(&e.y, b)
+	e.x.Mul(&a.x, b)
+	e.y.Mul(&a.y, b)
 	return e
 }
 

--- a/erigon-lib/crypto/bn256/google/gfp12.go
+++ b/erigon-lib/crypto/bn256/google/gfp12.go
@@ -125,8 +125,8 @@ func (e *gfP12) Mul(a, b *gfP12, pool *bnPool) *gfP12 {
 }
 
 func (e *gfP12) MulScalar(a *gfP12, b *gfP6, pool *bnPool) *gfP12 {
-	e.x.Mul(e.x, b, pool)
-	e.y.Mul(e.y, b, pool)
+	e.x.Mul(a.x, b, pool)
+	e.y.Mul(a.y, b, pool)
 	return e
 }
 


### PR DESCRIPTION
### Description 
Update the Erigon-Lib.
Fix a simple known bug in gfp12.MulScalar in the `erigon-lib/crypto`.

### Reference
The problem has been patched in related repos.
* https://cs.opensource.google/go/x/crypto/+/8d7daa0c54b357f3071e11eaef7efc4e19a417e2
* https://github.com/cloudflare/bn256/pull/33
* https://github.com/ethereum/go-ethereum/pull/30974