### PR TITLE
Add metric for unsynced bytes

### DIFF
--- a/erigon-lib/go.mod
+++ b/erigon-lib/go.mod
@@ -11,7 +11,7 @@ replace (
 require (
 	github.com/erigontech/erigon-snapshot v1.3.1-0.20250121111444-6cc4c0c1fb89
 	github.com/erigontech/interfaces v0.0.0-20250218124515-7c4293b6afb3
-	github.com/erigontech/mdbx-go v0.38.6
+	github.com/erigontech/mdbx-go v0.38.7-0.20250227143208-9f6b2b116132
 	github.com/erigontech/secp256k1 v1.1.0
 	github.com/rs/dnscache v0.0.0-20211102005908-e0241e321417
 )

--- a/erigon-lib/go.sum
+++ b/erigon-lib/go.sum
@@ -156,8 +156,6 @@ github.com/erigontech/go-kzg-4844 v0.0.0-20250130131058-ce13be60bc86 h1:UKcIbFZU
 github.com/erigontech/go-kzg-4844 v0.0.0-20250130131058-ce13be60bc86/go.mod h1:JolLjpSff1tCCJKaJx4psrlEdlXuJEC996PL3tTAFks=
 github.com/erigontech/interfaces v0.0.0-20250218124515-7c4293b6afb3 h1:Qwd3asRe5aeKzV/oHgADLu92db2417AM5ApjpT8MD1o=
 github.com/erigontech/interfaces v0.0.0-20250218124515-7c4293b6afb3/go.mod h1:N7OUkhkcagp9+7yb4ycHsG2VWCOmuJ1ONBecJshxtLE=
-github.com/erigontech/mdbx-go v0.38.6 h1:uPqx9goWwNsvfdY44di2Pp0D1gAn2XsYaiVJSopVqjs=
-github.com/erigontech/mdbx-go v0.38.6/go.mod h1:lkqHAZqXtFaIPlvTaGAx3VUDuGYZcuhve1l4JVVN1Z0=
 github.com/erigontech/mdbx-go v0.38.7-0.20250227143208-9f6b2b116132 h1:gs1UlANYPBZX1FiR7y3kr9y8VCMDcWLkpfYEWYVitmQ=
 github.com/erigontech/mdbx-go v0.38.7-0.20250227143208-9f6b2b116132/go.mod h1:lkqHAZqXtFaIPlvTaGAx3VUDuGYZcuhve1l4JVVN1Z0=
 github.com/erigontech/secp256k1 v1.1.0 h1:mO3YJMUSoASE15Ya//SoHiisptUhdXExuMUN1M0X9qY=

--- a/erigon-lib/go.sum
+++ b/erigon-lib/go.sum
@@ -158,6 +158,8 @@ github.com/erigontech/interfaces v0.0.0-20250218124515-7c4293b6afb3 h1:Qwd3asRe5
 github.com/erigontech/interfaces v0.0.0-20250218124515-7c4293b6afb3/go.mod h1:N7OUkhkcagp9+7yb4ycHsG2VWCOmuJ1ONBecJshxtLE=
 github.com/erigontech/mdbx-go v0.38.6 h1:uPqx9goWwNsvfdY44di2Pp0D1gAn2XsYaiVJSopVqjs=
 github.com/erigontech/mdbx-go v0.38.6/go.mod h1:lkqHAZqXtFaIPlvTaGAx3VUDuGYZcuhve1l4JVVN1Z0=
+github.com/erigontech/mdbx-go v0.38.7-0.20250227143208-9f6b2b116132 h1:gs1UlANYPBZX1FiR7y3kr9y8VCMDcWLkpfYEWYVitmQ=
+github.com/erigontech/mdbx-go v0.38.7-0.20250227143208-9f6b2b116132/go.mod h1:lkqHAZqXtFaIPlvTaGAx3VUDuGYZcuhve1l4JVVN1Z0=
 github.com/erigontech/secp256k1 v1.1.0 h1:mO3YJMUSoASE15Ya//SoHiisptUhdXExuMUN1M0X9qY=
 github.com/erigontech/secp256k1 v1.1.0/go.mod h1:GokhPepsMB+EYDs7I5JZCprxHW6+yfOcJKaKtoZ+Fls=
 github.com/erigontech/speedtest v0.0.2 h1:W9Cvky/8AMUtUONwkLA/dZjeQ2XfkBdYfJzvhMZUO+U=

--- a/erigon-lib/kv/kv_interface.go
+++ b/erigon-lib/kv/kv_interface.go
@@ -82,12 +82,13 @@ const ReadersLimit = 32000 // MDBX_READERS_LIMIT=32767
 const dbLabelName = "db"
 
 type DBGauges struct { // these gauges are shared by all MDBX instances, but need to be filtered by label
-	DbSize    *metrics.GaugeVec
-	TxLimit   *metrics.GaugeVec
-	TxSpill   *metrics.GaugeVec
-	TxUnspill *metrics.GaugeVec
-	TxDirty   *metrics.GaugeVec
-	TxRetired *metrics.GaugeVec
+	DbSize        *metrics.GaugeVec
+	TxLimit       *metrics.GaugeVec
+	TxSpill       *metrics.GaugeVec
+	TxUnspill     *metrics.GaugeVec
+	TxDirty       *metrics.GaugeVec
+	TxRetired     *metrics.GaugeVec
+	UnsyncedBytes *metrics.GaugeVec
 
 	DbPgopsNewly   *metrics.GaugeVec
 	DbPgopsCow     *metrics.GaugeVec
@@ -119,6 +120,7 @@ func InitMDBXMGauges() *DBGauges {
 		TxSpill:        metrics.GetOrCreateGaugeVec(`tx_spill`, []string{dbLabelName}),
 		TxUnspill:      metrics.GetOrCreateGaugeVec(`tx_unspill`, []string{dbLabelName}),
 		TxDirty:        metrics.GetOrCreateGaugeVec(`tx_dirty`, []string{dbLabelName}),
+		UnsyncedBytes:  metrics.GetOrCreateGaugeVec(`unsynced_bytes`, []string{dbLabelName}),
 		TxRetired:      metrics.GetOrCreateGaugeVec(`tx_retired`, []string{dbLabelName}),
 		DbPgopsNewly:   metrics.GetOrCreateGaugeVec(`db_pgops{phase="newly"}`, []string{dbLabelName}),
 		DbPgopsCow:     metrics.GetOrCreateGaugeVec(`db_pgops{phase="cow"}`, []string{dbLabelName}),

--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -724,6 +724,7 @@ func (tx *MdbxTx) CollectMetrics() {
 	kv.MDBXGauges.DbPgopsSpill.WithLabelValues(dbLabel).SetUint64(info.PageOps.Spill)
 	kv.MDBXGauges.DbPgopsUnspill.WithLabelValues(dbLabel).SetUint64(info.PageOps.Unspill)
 	kv.MDBXGauges.DbPgopsWops.WithLabelValues(dbLabel).SetUint64(info.PageOps.Wops)
+	kv.MDBXGauges.UnsyncedBytes.WithLabelValues(dbLabel).SetUint64(uint64(info.UnsyncedBytes))
 
 	txInfo, err := tx.tx.Info(true)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ replace (
 
 require (
 	github.com/erigontech/erigonwatch v0.0.0-20240718131902-b6576bde1116
-	github.com/erigontech/mdbx-go v0.38.6
+	github.com/erigontech/mdbx-go v0.38.7-0.20250227143208-9f6b2b116132
 	github.com/erigontech/secp256k1 v1.1.0
 	github.com/erigontech/silkworm-go v0.24.0
 )

--- a/go.sum
+++ b/go.sum
@@ -269,8 +269,6 @@ github.com/erigontech/erigonwatch v0.0.0-20240718131902-b6576bde1116 h1:KCFa2uXE
 github.com/erigontech/erigonwatch v0.0.0-20240718131902-b6576bde1116/go.mod h1:8vQ+VjvLu2gkPs8EwdPrOTAAo++WuLuBi54N7NuAF0I=
 github.com/erigontech/go-kzg-4844 v0.0.0-20250130131058-ce13be60bc86 h1:UKcIbFZUGIKzK4aQbkv/dYiOVxZSUuD3zKadhmfwdwU=
 github.com/erigontech/go-kzg-4844 v0.0.0-20250130131058-ce13be60bc86/go.mod h1:JolLjpSff1tCCJKaJx4psrlEdlXuJEC996PL3tTAFks=
-github.com/erigontech/mdbx-go v0.38.6 h1:uPqx9goWwNsvfdY44di2Pp0D1gAn2XsYaiVJSopVqjs=
-github.com/erigontech/mdbx-go v0.38.6/go.mod h1:lkqHAZqXtFaIPlvTaGAx3VUDuGYZcuhve1l4JVVN1Z0=
 github.com/erigontech/mdbx-go v0.38.7-0.20250227143208-9f6b2b116132 h1:gs1UlANYPBZX1FiR7y3kr9y8VCMDcWLkpfYEWYVitmQ=
 github.com/erigontech/mdbx-go v0.38.7-0.20250227143208-9f6b2b116132/go.mod h1:lkqHAZqXtFaIPlvTaGAx3VUDuGYZcuhve1l4JVVN1Z0=
 github.com/erigontech/secp256k1 v1.1.0 h1:mO3YJMUSoASE15Ya//SoHiisptUhdXExuMUN1M0X9qY=

--- a/go.sum
+++ b/go.sum
@@ -271,6 +271,8 @@ github.com/erigontech/go-kzg-4844 v0.0.0-20250130131058-ce13be60bc86 h1:UKcIbFZU
 github.com/erigontech/go-kzg-4844 v0.0.0-20250130131058-ce13be60bc86/go.mod h1:JolLjpSff1tCCJKaJx4psrlEdlXuJEC996PL3tTAFks=
 github.com/erigontech/mdbx-go v0.38.6 h1:uPqx9goWwNsvfdY44di2Pp0D1gAn2XsYaiVJSopVqjs=
 github.com/erigontech/mdbx-go v0.38.6/go.mod h1:lkqHAZqXtFaIPlvTaGAx3VUDuGYZcuhve1l4JVVN1Z0=
+github.com/erigontech/mdbx-go v0.38.7-0.20250227143208-9f6b2b116132 h1:gs1UlANYPBZX1FiR7y3kr9y8VCMDcWLkpfYEWYVitmQ=
+github.com/erigontech/mdbx-go v0.38.7-0.20250227143208-9f6b2b116132/go.mod h1:lkqHAZqXtFaIPlvTaGAx3VUDuGYZcuhve1l4JVVN1Z0=
 github.com/erigontech/secp256k1 v1.1.0 h1:mO3YJMUSoASE15Ya//SoHiisptUhdXExuMUN1M0X9qY=
 github.com/erigontech/secp256k1 v1.1.0/go.mod h1:GokhPepsMB+EYDs7I5JZCprxHW6+yfOcJKaKtoZ+Fls=
 github.com/erigontech/silkworm-go v0.24.0 h1:fFe74CjQM5LI7ouMYjmqfFaqIFzQTpMrt+ls+a5PxpE=


### PR DESCRIPTION
Task: https://github.com/erigontech/erigon/issues/13996

This allows us to track how much data has been committed but not yet flushed to disk when `mdbx.SafeNoSync` flag is used.