### PR TITLE
"less direct agg use": remove `sd.aggTx.d[kv.CommitmentDomain].Files()` add API `Files(domain)`

### DIFF
--- a/cmd/state/exec3/historical_trace_worker.go
+++ b/cmd/state/exec3/historical_trace_worker.go
@@ -79,7 +79,7 @@ type HistoricalTraceWorker struct {
 type TraceConsumer struct {
 	NewTracer func() GenericTracer
 	//Reduce receiving results of execution. They are sorted and have no gaps.
-	Reduce func(task *state.TxTask, tx kv.Tx) error
+	Reduce func(task *state.TxTask, tx kv.TemporalTx) error
 }
 
 func NewHistoricalTraceWorker(

--- a/erigon-lib/kv/kv_interface.go
+++ b/erigon-lib/kv/kv_interface.go
@@ -566,6 +566,13 @@ type TemporalTx interface {
 	// HistoryRange - producing "state patch" - sorted list of keys updated at [fromTs,toTs) with their most-recent value.
 	//   no duplicates
 	HistoryRange(name Domain, fromTs, toTs int, asc order.By, limit int) (it stream.KV, err error)
+
+	FreezeInfo() FreezeInfo
+}
+
+type FreezeInfo interface {
+	AllFiles() []string
+	Files(domainName Domain) []string
 }
 
 type TemporalRwTx interface {

--- a/erigon-lib/kv/kv_interface.go
+++ b/erigon-lib/kv/kv_interface.go
@@ -539,6 +539,7 @@ type TemporalGetter interface {
 type TemporalTx interface {
 	Tx
 	TemporalGetter
+	WithFreezeInfo
 
 	// return the earliest known txnum in history of a given domain
 	HistoryStartFrom(domainName Domain) uint64
@@ -566,7 +567,9 @@ type TemporalTx interface {
 	// HistoryRange - producing "state patch" - sorted list of keys updated at [fromTs,toTs) with their most-recent value.
 	//   no duplicates
 	HistoryRange(name Domain, fromTs, toTs int, asc order.By, limit int) (it stream.KV, err error)
+}
 
+type WithFreezeInfo interface {
 	FreezeInfo() FreezeInfo
 }
 

--- a/erigon-lib/kv/membatchwithdb/memory_mutation.go
+++ b/erigon-lib/kv/membatchwithdb/memory_mutation.go
@@ -750,3 +750,6 @@ func (m *MemoryMutation) HistoryRange(name kv.Domain, fromTs, toTs int, asc orde
 func (m *MemoryMutation) HistoryStartFrom(name kv.Domain) uint64 {
 	return m.db.(kv.TemporalTx).HistoryStartFrom(name)
 }
+func (m *MemoryMutation) FreezeInfo() kv.FreezeInfo {
+	panic("not supported")
+}

--- a/erigon-lib/kv/remotedb/kv_remote.go
+++ b/erigon-lib/kv/remotedb/kv_remote.go
@@ -228,6 +228,7 @@ func (db *DB) Update(ctx context.Context, f func(tx kv.RwTx) error) (err error) 
 func (db *DB) UpdateNosync(ctx context.Context, f func(tx kv.RwTx) error) (err error) {
 	return errors.New("remote db provider doesn't support .UpdateNosync method")
 }
+func (tx *tx) FreezeInfo() kv.FreezeInfo  { panic("not implemented") }
 func (db *DB) OnFreeze(f kv.OnFreezeFunc) { panic("not implemented") }
 
 func (tx *tx) ViewID() uint64  { return tx.viewID }

--- a/erigon-lib/kv/temporal/kv_temporal.go
+++ b/erigon-lib/kv/temporal/kv_temporal.go
@@ -171,6 +171,7 @@ func (tx *Tx) ForceReopenAggCtx() {
 	tx.filesTx.Close()
 	tx.filesTx = tx.Agg().BeginFilesRo()
 }
+func (tx *Tx) FreezeInfo() kv.FreezeInfo { return tx.filesTx }
 
 func (tx *Tx) WarmupDB(force bool) error { return tx.MdbxTx.WarmupDB(force) }
 func (tx *Tx) LockDBInRam() error        { return tx.MdbxTx.LockDBInRam() }

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -357,6 +357,7 @@ func (ac *AggregatorRoTx) AllFiles() []string {
 	return res
 }
 func (ac *AggregatorRoTx) Files(domain kv.Domain) []string { return ac.d[domain].Files() }
+func (ac *AggregatorRoTx) StepSize() uint64                { return ac.a.StepSize() }
 
 func (a *Aggregator) Files() []string {
 	ac := a.BeginFilesRo()

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -343,7 +343,7 @@ func (a *Aggregator) HasBackgroundFilesBuild2() bool {
 func (a *Aggregator) HasBackgroundFilesBuild() bool { return a.ps.Has() }
 func (a *Aggregator) BackgroundProgress() string    { return a.ps.String() }
 
-func (ac *AggregatorRoTx) Files() []string {
+func (ac *AggregatorRoTx) AllFiles() []string {
 	var res []string
 	if ac == nil {
 		return res
@@ -356,10 +356,12 @@ func (ac *AggregatorRoTx) Files() []string {
 	}
 	return res
 }
+func (ac *AggregatorRoTx) Files(domain kv.Domain) []string { return ac.d[domain].Files() }
+
 func (a *Aggregator) Files() []string {
 	ac := a.BeginFilesRo()
 	defer ac.Close()
-	return ac.Files()
+	return ac.AllFiles()
 }
 func (a *Aggregator) LS() {
 	doLS := func(dirtyFiles *btree.BTreeG[*filesItem]) {

--- a/erigon-lib/state/domain_shared.go
+++ b/erigon-lib/state/domain_shared.go
@@ -184,10 +184,10 @@ func (sd *SharedDomains) AggTx() any { return sd.aggTx }
 
 // aggregator context should call aggTx.Unwind before this one.
 func (sd *SharedDomains) Unwind(ctx context.Context, rwTx kv.RwTx, blockUnwindTo, txUnwindTo uint64, changeset *[kv.DomainLen][]DomainEntryDiff) error {
-	step := txUnwindTo / sd.aggTx.a.StepSize()
+	step := txUnwindTo / sd.StepSize()
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
-	sd.aggTx.a.logger.Info("aggregator unwind", "step", step,
+	sd.logger.Info("aggregator unwind", "step", step,
 		"txUnwindTo", txUnwindTo, "stepsRangeInDB", sd.aggTx.a.StepsRangeInDBAsStr(rwTx))
 	//fmt.Printf("aggregator unwind step %d txUnwindTo %d stepsRangeInDB %s\n", step, txUnwindTo, sd.aggTx.a.StepsRangeInDBAsStr(rwTx))
 	sf := time.Now()
@@ -392,7 +392,7 @@ func (sd *SharedDomains) ClearRam(resetCommitment bool) {
 func (sd *SharedDomains) put(domain kv.Domain, key string, val []byte) {
 	// disable mutex - because work on parallel execution postponed after E3 release.
 	//sd.muMaps.Lock()
-	valWithPrevStep := dataWithPrevStep{data: val, prevStep: sd.txNum / sd.aggTx.a.StepSize()}
+	valWithPrevStep := dataWithPrevStep{data: val, prevStep: sd.txNum / sd.StepSize()}
 	if domain == kv.StorageDomain {
 		if old, ok := sd.storage.Set(key, valWithPrevStep); ok {
 			sd.estSize += len(val) - len(old.data)
@@ -457,7 +457,7 @@ func (sd *SharedDomains) LatestCommitment(prefix []byte) ([]byte, uint64, error)
 	}
 
 	if !sd.aggTx.a.commitmentValuesTransform || bytes.Equal(prefix, keyCommitmentState) {
-		return v, endTx / sd.aggTx.a.StepSize(), nil
+		return v, endTx / sd.StepSize(), nil
 	}
 
 	// replace shortened keys in the branch with full keys to allow HPH work seamlessly
@@ -465,7 +465,7 @@ func (sd *SharedDomains) LatestCommitment(prefix []byte) ([]byte, uint64, error)
 	if err != nil {
 		return nil, 0, err
 	}
-	return rv, endTx / sd.aggTx.a.StepSize(), nil
+	return rv, endTx / sd.StepSize(), nil
 }
 
 // replaceShortenedKeysInBranch replaces shortened keys in the branch with full keys
@@ -537,7 +537,7 @@ func (sd *SharedDomains) replaceShortenedKeysInBranch(prefix []byte, branch comm
 		}
 		apkBuf, found := acc.lookupByShortenedKey(key, accountGetter)
 		if !found {
-			s0, s1 := fStartTxNum/sd.aggTx.a.StepSize(), fEndTxNum/sd.aggTx.a.StepSize()
+			s0, s1 := fStartTxNum/sd.StepSize(), fEndTxNum/sd.StepSize()
 			sd.logger.Crit("replace back lost account full key", "shortened", fmt.Sprintf("%x", key),
 				"decoded", fmt.Sprintf("step %d-%d; offt %d", s0, s1, decodeShorterKey(key)))
 			return nil, fmt.Errorf("replace back lost account full key: %x", key)
@@ -690,7 +690,7 @@ func (sd *SharedDomains) SetTx(tx kv.Tx) {
 	}
 }
 
-func (sd *SharedDomains) StepSize() uint64 { return sd.aggTx.a.StepSize() }
+func (sd *SharedDomains) StepSize() uint64 { return sd.aggTx.StepSize() }
 
 // SetTxNum sets txNum for all domains as well as common txNum for all domains
 // Requires for sd.rwTx because of commitment evaluation in shared domains if aggregationStep is reached
@@ -1286,10 +1286,6 @@ func (sdc *SharedDomainsCommitmentContext) Reset() {
 	if !sdc.justRestored.Load() {
 		sdc.patriciaTrie.Reset()
 	}
-}
-
-func (sdc *SharedDomainsCommitmentContext) TempDir() string {
-	return sdc.sharedDomains.aggTx.a.dirs.Tmp
 }
 
 func (sdc *SharedDomainsCommitmentContext) KeysCount() uint64 {

--- a/erigon-lib/state/domain_shared.go
+++ b/erigon-lib/state/domain_shared.go
@@ -118,7 +118,7 @@ func NewSharedDomains(tx kv.Tx, logger log.Logger) (*SharedDomains, error) {
 		storage: btree2.NewMap[string, dataWithPrevStep](128),
 		//trace:   true,
 	}
-	sd.SetTx(tx.(kv.TemporalTx)) //TODO: propagate interface to higher-level code
+	sd.SetTx(tx)
 	sd.iiWriters = make([]*invertedIndexBufferedWriter, len(sd.aggTx.iis))
 
 	sd.aggTx.a.DiscardHistory(kv.CommitmentDomain)

--- a/erigon-lib/state/domain_shared.go
+++ b/erigon-lib/state/domain_shared.go
@@ -677,7 +677,7 @@ func (sd *SharedDomains) SetTx(tx kv.Tx) {
 	if tx == nil {
 		panic("tx is nil")
 	}
-	sd.roTx = tx.(kv.TemporalTx)
+	sd.roTx = tx
 
 	casted, ok := tx.(HasAggTx)
 	if !ok {

--- a/erigon-lib/state/domain_shared.go
+++ b/erigon-lib/state/domain_shared.go
@@ -261,7 +261,7 @@ func (sd *SharedDomains) RebuildCommitmentShard(ctx context.Context, next func()
 	sd.DiscardWrites(kv.StorageDomain)
 	sd.DiscardWrites(kv.CodeDomain)
 
-	visComFiles := sd.roTx.(kv.TemporalTx).FreezeInfo().Files(kv.CommitmentDomain)
+	visComFiles := sd.roTx.(kv.WithFreezeInfo).FreezeInfo().Files(kv.CommitmentDomain)
 	sd.logger.Info("starting commitment", "shard", fmt.Sprintf("%d-%d", cfg.StepFrom, cfg.StepTo),
 		"totalKeys", common.PrettyCounter(cfg.Keys), "block", sd.BlockNum(),
 		"commitment files before dump step", cfg.StepTo,

--- a/erigon-lib/state/domain_shared.go
+++ b/erigon-lib/state/domain_shared.go
@@ -81,10 +81,9 @@ type dataWithPrevStep struct {
 }
 
 type SharedDomains struct {
-	aggTx *AggregatorRoTx
-	sdCtx *SharedDomainsCommitmentContext
-
-	roTx   kv.TemporalTx
+	aggTx  *AggregatorRoTx
+	sdCtx  *SharedDomainsCommitmentContext
+	roTx   kv.Tx
 	logger log.Logger
 
 	txNum    uint64
@@ -262,7 +261,7 @@ func (sd *SharedDomains) RebuildCommitmentShard(ctx context.Context, next func()
 	sd.DiscardWrites(kv.StorageDomain)
 	sd.DiscardWrites(kv.CodeDomain)
 
-	visComFiles := sd.roTx.FreezeInfo().Files(kv.CommitmentDomain)
+	visComFiles := sd.roTx.(kv.TemporalTx).FreezeInfo().Files(kv.CommitmentDomain)
 	sd.logger.Info("starting commitment", "shard", fmt.Sprintf("%d-%d", cfg.StepFrom, cfg.StepTo),
 		"totalKeys", common.PrettyCounter(cfg.Keys), "block", sd.BlockNum(),
 		"commitment files before dump step", cfg.StepTo,

--- a/erigon-lib/state/squeeze.go
+++ b/erigon-lib/state/squeeze.go
@@ -309,7 +309,8 @@ type wrappedTxWithCtx struct {
 	ac *AggregatorRoTx
 }
 
-func (w *wrappedTxWithCtx) AggTx() any { return w.ac }
+func (w *wrappedTxWithCtx) AggTx() any                { return w.ac }
+func (w *wrappedTxWithCtx) FreezeInfo() kv.FreezeInfo { return w.ac }
 
 func wrapTxWithCtxForTest(tx kv.Tx, ctx *AggregatorRoTx) *wrappedTxWithCtx {
 	return &wrappedTxWithCtx{Tx: tx, ac: ctx}

--- a/eth/stagedsync/stage_custom_trace.go
+++ b/eth/stagedsync/stage_custom_trace.go
@@ -43,7 +43,7 @@ import (
 
 type CustomTraceCfg struct {
 	tmpdir   string
-	db       kv.RwDB
+	db       kv.TemporalRwDB
 	prune    prune.Mode
 	execArgs *exec3.ExecArgs
 }
@@ -125,17 +125,22 @@ func SpawnCustomTrace(cfg CustomTraceCfg, ctx context.Context, logger log.Logger
 	return nil
 }
 
-func customTraceBatchProduce(ctx context.Context, cfg *exec3.ExecArgs, db kv.RwDB, fromBlock, toBlock uint64, logPrefix string, logger log.Logger) error {
+func customTraceBatchProduce(ctx context.Context, cfg *exec3.ExecArgs, db kv.TemporalRwDB, fromBlock, toBlock uint64, logPrefix string, logger log.Logger) error {
 	var lastTxNum uint64
-	if err := db.Update(ctx, func(tx kv.RwTx) error {
-		ttx := tx.(kv.TemporalRwTx)
+	{
+		tx, err := db.BeginTemporalRw(ctx)
+		defer tx.Rollback()
+		if err != nil {
+			return err
+		}
+
 		doms, err := state2.NewSharedDomains(tx, logger)
 		if err != nil {
 			return err
 		}
 		defer doms.Close()
 
-		if err := customTraceBatch(ctx, cfg, ttx, doms, fromBlock, toBlock, logPrefix, logger); err != nil {
+		if err := customTraceBatch(ctx, cfg, tx, doms, fromBlock, toBlock, logPrefix, logger); err != nil {
 			return err
 		}
 
@@ -145,7 +150,7 @@ func customTraceBatchProduce(ctx context.Context, cfg *exec3.ExecArgs, db kv.RwD
 		}
 
 		if cfg.ChainConfig.Bor == nil { //assert
-			if err = AssertReceipts(ctx, cfg, ttx, fromBlock, toBlock); err != nil {
+			if err = AssertReceipts(ctx, cfg, tx, fromBlock, toBlock); err != nil {
 				return err
 			}
 		}
@@ -154,9 +159,6 @@ func customTraceBatchProduce(ctx context.Context, cfg *exec3.ExecArgs, db kv.RwD
 		if err := tx.Commit(); err != nil {
 			return err
 		}
-		return nil
-	}); err != nil {
-		return err
 	}
 
 	agg := db.(state2.HasAgg).Agg().(*state2.Aggregator)
@@ -262,7 +264,7 @@ func customTraceBatch(ctx context.Context, cfg *exec3.ExecArgs, tx kv.TemporalRw
 	var m runtime.MemStats
 	if err := exec3.CustomTraceMapReduce(fromBlock, toBlock, exec3.TraceConsumer{
 		NewTracer: func() exec3.GenericTracer { return nil },
-		Reduce: func(txTask *state.TxTask, tx kv.Tx) error {
+		Reduce: func(txTask *state.TxTask, tx kv.TemporalTx) error {
 			if txTask.Error != nil {
 				return txTask.Error
 			}

--- a/eth/stagedsync/stage_custom_trace.go
+++ b/eth/stagedsync/stage_custom_trace.go
@@ -129,10 +129,10 @@ func customTraceBatchProduce(ctx context.Context, cfg *exec3.ExecArgs, db kv.Tem
 	var lastTxNum uint64
 	{
 		tx, err := db.BeginTemporalRw(ctx)
-		defer tx.Rollback()
 		if err != nil {
 			return err
 		}
+		defer tx.Rollback()
 
 		doms, err := state2.NewSharedDomains(tx, logger)
 		if err != nil {

--- a/turbo/jsonrpc/eth_call.go
+++ b/turbo/jsonrpc/eth_call.go
@@ -612,7 +612,7 @@ func (api *BaseAPI) getWitness(ctx context.Context, db kv.RoDB, blockNrOrHash rp
 
 	// define these keys as "updates", but we are not really updating anything, we just want to load them into the grid,
 	// so this is just to satisfy the current hex patricia trie api.
-	updates := commitment.NewUpdates(commitment.ModeDirect, sdCtx.TempDir(), commitment.KeyToHexNibbleHash)
+	updates := commitment.NewUpdates(commitment.ModeDirect, api.dirs.Tmp, commitment.KeyToHexNibbleHash)
 	for _, key := range touchedPlainKeys {
 		updates.TouchPlainKey(string(key), nil, updates.TouchAccount)
 	}


### PR DESCRIPTION
discussed in https://github.com/erigontech/erigon/issues/13261