### PR TITLE
eth/stagedsync: Fix UploaderPipelineStages function comment format

### DIFF
--- a/eth/stagedsync/default_stages.go
+++ b/eth/stagedsync/default_stages.go
@@ -274,7 +274,7 @@ func PipelineStages(ctx context.Context, snapshots SnapshotsCfg, blockHashCfg Bl
 	}
 }
 
-// when uploading - potentially from zero we need to include headers and bodies stages otherwise we won't recover the POW portion of the chain
+// UploaderPipelineStages when uploading - potentially from zero we need to include headers and bodies stages otherwise we won't recover the POW portion of the chain
 func UploaderPipelineStages(ctx context.Context, snapshots SnapshotsCfg, headers HeadersCfg, blockHashCfg BlockHashesCfg, senders SendersCfg, bodies BodiesCfg, exec ExecuteBlockCfg, txLookup TxLookupCfg, finish FinishCfg, test bool) []*Stage {
 	return []*Stage{
 		{


### PR DESCRIPTION
when debug syncstage process check this comment hint:
![image](https://github.com/user-attachments/assets/e4f5d084-4bed-4f18-b238-5064d8821f65)
