### PR TITLE
trackPeerStatistics reduced memory usage

### DIFF
--- a/p2p/sentry/sentry_grpc_server.go
+++ b/p2p/sentry/sentry_grpc_server.go
@@ -756,10 +756,8 @@ func (ss *GrpcServer) removePeer(peerID [64]byte, reason *p2p.PeerError) {
 
 func (ss *GrpcServer) writePeer(logPrefix string, peerInfo *PeerInfo, msgcode uint64, data []byte, ttl time.Duration) {
 	peerInfo.Async(func() {
-
-		cap := p2p.Cap{Name: eth.ProtocolName, Version: peerInfo.protocol}
-		msgType := eth.ToProto[cap.Version][msgcode]
-		trackPeerStatistics(peerInfo.peer.Fullname(), peerInfo.peer.ID().String(), false, msgType.String(), cap.String(), len(data))
+		msgType := eth.ToProto[peerInfo.protocol][msgcode]
+		trackPeerStatistics(peerInfo.peer.Fullname(), peerInfo.peer.ID().String(), false, msgType.String(), fmt.Sprintf("%s/%d", eth.ProtocolName, peerInfo.protocol), len(data))
 
 		err := peerInfo.rw.WriteMsg(p2p.Msg{Code: msgcode, Size: uint32(len(data)), Payload: bytes.NewReader(data)})
 		if err != nil {


### PR DESCRIPTION
Avoid creating temporal struct.