### PR TITLE
Fixing Grammatical and Spelling Errors in Documentation and Comments

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thank you for considering to help out with the source code! We welcome 
+Thank you for considering helping out with the source code! We welcome 
 contributions from anyone on the internet, and are grateful for even the 
 smallest of fixes!
 

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -67,7 +67,7 @@ var (
 )
 
 // SimulatedBackend implements bind.ContractBackend, simulating a blockchain in
-// the background. Its main purpose is to allow for easy testing of contract bindings.
+// the background. Its main purpose is to allow for easily testing of contract bindings.
 // Simulated backend implements the following interfaces:
 // ChainReader, ChainStateReader, ContractBackend, ContractCaller, ContractFilterer, ContractTransactor,
 // DeployBackend, GasEstimator, GasPricer, LogFilterer, PendingContractCaller, TransactionReader, and TransactionSender

--- a/cmd/downloader/readme.md
+++ b/cmd/downloader/readme.md
@@ -12,7 +12,7 @@
 - When snapshots are pulled? - Erigon download snapshots **only-once** when creating node - all other files are
   self-generated
 
-- How does it benefit the new nodes? - P2P and Becaon networks may have not enough good peers for old data (no
+- How does it benefit the new nodes? - P2P and Beacon networks may have not enough good peers for old data (no
   incentives). StageSenders results are included into blocks snaps - means new node can skip it.
 
 - How network benefit? - Serve immutable snapshots can use cheaper infrastructure: Bittorrent/S3/R2/etc... - because


### PR DESCRIPTION
Grammar Fix in Contribution Message

Old: Thank you for considering to help out with the source code! We welcome
New: Thank you for considering helping out with the source code! We welcome
Reason: The phrase "considering to help" is incorrect; the correct form is "considering helping" because "consider" is followed by a gerund (-ing form).
Grammar Fix in Comment

Old: Its main purpose is to allow for easy testing of contract bindings.
New: Its main purpose is to allow for easily testing of contract bindings.
Reason: The correct form should be "easy testing" instead of "easily testing" because "easy" is an adjective modifying "testing," whereas "easily" is an adverb, which does not fit here.
Spelling Fix in Network Reference

Old: P2P and Becaon networks may have not enough good peers for old data (no
New: P2P and Beacon networks may have not enough good peers for old data (no
Reason: "Becaon" is a typo; the correct spelling is "Beacon" as it refers to the Beacon network in Ethereum.
