### PR TITLE
fix: verbosity debug level not works

### DIFF
--- a/turbo/logging/logging.go
+++ b/turbo/logging/logging.go
@@ -61,12 +61,16 @@ func SetupLoggerCtx(filePrefix string, ctx *cli.Context,
 
 	metrics.DelayLoggingEnabled = ctx.Bool(LogBlockDelayFlag.Name)
 
-	consoleLevel, lErr := tryGetLogLevel(ctx.String(LogConsoleVerbosityFlag.Name))
-	if lErr != nil {
-		// try verbosity flag
-		consoleLevel, lErr = tryGetLogLevel(ctx.String(LogVerbosityFlag.Name))
-		if lErr != nil {
-			consoleLevel = consoleDefaultLevel
+	consoleLevel := consoleDefaultLevel
+
+	// Priority: LogConsoleVerbosityFlag (if explicitly set) > LogVerbosityFlag (if explicitly set) > default
+	if ctx.IsSet(LogConsoleVerbosityFlag.Name) {
+		if level, err := tryGetLogLevel(ctx.String(LogConsoleVerbosityFlag.Name)); err == nil {
+			consoleLevel = level
+		}
+	} else if ctx.IsSet(LogVerbosityFlag.Name) {
+		if level, err := tryGetLogLevel(ctx.String(LogVerbosityFlag.Name)); err == nil {
+			consoleLevel = level
 		}
 	}
 


### PR DESCRIPTION
close:https://github.com/erigontech/erigon/issues/14041

current log flag Priority: LogConsoleVerbosityFlag (if explicitly set) > LogVerbosityFlag (if explicitly set) > default

after change:
![image](https://github.com/user-attachments/assets/5f7004b3-cc10-45c3-89c2-1b0c1c894afb)
