### PR TITLE
doc(cmd/rpcdaemon): add eth_blobBaseFee, eth_baseFee

### DIFF
--- a/cmd/rpcdaemon/README.md
+++ b/cmd/rpcdaemon/README.md
@@ -255,6 +255,8 @@ The following table shows the current implementation status of Erigon's RPC daem
 | eth_gasPrice                               | Yes     |                                      |
 | eth_maxPriorityFeePerGas                   | Yes     |                                      |
 | eth_feeHistory                             | Yes     |                                      |
+| eth_baseFee                                | Yes     |                                      |
+| eth_blobBaseFee                            | Yes     |                                      |
 |                                            |         |                                      |
 | eth_getBlockByHash                         | Yes     |                                      |
 | eth_getBlockByNumber                       | Yes     |                                      |

--- a/turbo/jsonrpc/eth_system.go
+++ b/turbo/jsonrpc/eth_system.go
@@ -153,6 +153,7 @@ type feeHistoryResult struct {
 	BlobGasUsedRatio []float64        `json:"blobGasUsedRatio,omitempty"`
 }
 
+// FeeHistory implements eth_feeHistory. Returns the fee history of the last N blocks.
 func (api *APIImpl) FeeHistory(ctx context.Context, blockCount rpc.DecimalOrHex, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*feeHistoryResult, error) {
 	tx, err := api.db.BeginTemporalRo(ctx)
 	if err != nil {
@@ -196,7 +197,7 @@ func (api *APIImpl) FeeHistory(ctx context.Context, blockCount rpc.DecimalOrHex,
 	return results, nil
 }
 
-// BlobBaseFee returns the base fee for blob gas at the current head.
+// BlobBaseFee implements eth_blobBaseFee. Returns the base fee for blob gas at the current head.
 func (api *APIImpl) BlobBaseFee(ctx context.Context) (*hexutil.Big, error) {
 	// read current header
 	tx, err := api.db.BeginTemporalRo(ctx)
@@ -223,7 +224,7 @@ func (api *APIImpl) BlobBaseFee(ctx context.Context) (*hexutil.Big, error) {
 	return (*hexutil.Big)(ret256.ToBig()), nil
 }
 
-// BaseFee returns the base fee at the current head.
+// BaseFee implements eth_baseFee. Returns the base fee at the current head.
 func (api *APIImpl) BaseFee(ctx context.Context) (*hexutil.Big, error) {
 	// read current header
 	tx, err := api.db.BeginTemporalRo(ctx)


### PR DESCRIPTION
https://github.com/erigontech/erigon/pull/11992 supports `eth_blobBaseFee, eth_baseFee` 

But I didn't see the support eth_* lists when I checked the cmd/rpcdaemon readme.

