### PR TITLE
improvement(log): add call stack to func on the record

### DIFF
--- a/erigon-lib/log/v3/handler.go
+++ b/erigon-lib/log/v3/handler.go
@@ -135,7 +135,7 @@ func (h *closingHandler) Close() error {
 // the calling function to the context with key "caller".
 func CallerFileHandler(h Handler) Handler {
 	return FuncHandler(func(r *Record) error {
-		r.Ctx = append(r.Ctx, "caller", fmt.Sprint(r.Call))
+		r.Ctx = append(r.Ctx, "caller", fmt.Sprint(r.Call(6)))
 		return h.Log(r)
 	})
 }
@@ -144,7 +144,7 @@ func CallerFileHandler(h Handler) Handler {
 // the context with key "fn".
 func CallerFuncHandler(h Handler) Handler {
 	return FuncHandler(func(r *Record) error {
-		r.Ctx = append(r.Ctx, "fn", fmt.Sprintf("%+n", r.Call))
+		r.Ctx = append(r.Ctx, "fn", fmt.Sprintf("%+n", r.Call(6)))
 		return h.Log(r)
 	})
 }
@@ -156,7 +156,7 @@ func CallerFuncHandler(h Handler) Handler {
 // package github.com/go-stack/stack for the list of supported formats.
 func CallerStackHandler(format string, h Handler) Handler {
 	return FuncHandler(func(r *Record) error {
-		s := stack.Trace().TrimBelow(r.Call).TrimRuntime()
+		s := stack.Trace().TrimBelow(r.Call(6)).TrimRuntime()
 		if len(s) > 0 {
 			r.Ctx = append(r.Ctx, "stack", fmt.Sprintf(format, s))
 		}
@@ -313,7 +313,7 @@ func LazyHandler(h Handler) Handler {
 					r.Ctx[i] = err
 				} else {
 					if cs, ok := v.(stack.CallStack); ok {
-						v = cs.TrimBelow(r.Call).TrimRuntime()
+						v = cs.TrimBelow(r.Call(6)).TrimRuntime()
 					}
 					r.Ctx[i] = v
 				}

--- a/erigon-lib/log/v3/logger.go
+++ b/erigon-lib/log/v3/logger.go
@@ -78,8 +78,11 @@ type Record struct {
 	Lvl      Lvl
 	Msg      string
 	Ctx      []interface{}
-	Call     stack.Call
 	KeyNames RecordKeyNames
+}
+
+func (r *Record) Call(skip int) stack.Call {
+	return stack.Caller(skip)
 }
 
 // RecordKeyNames are the predefined names of the log props used by the Logger interface.
@@ -121,7 +124,6 @@ func (l *logger) write(msg string, lvl Lvl, ctx []interface{}) {
 		Lvl:  lvl,
 		Msg:  msg,
 		Ctx:  newContext(l.ctx, ctx),
-		Call: stack.Caller(2),
 		KeyNames: RecordKeyNames{
 			Time: timeKey,
 			Msg:  msgKey,


### PR DESCRIPTION
### Description

Moved the stack.Caller to a func on the Record. Calling the stack multiple times every log gets expensive even when you are logging under the level defined in config. This is because the call stack will get created every time the Log() func runs on the handlers, even if the call stack is not being used.

### Context

This issue came up in CDK Erigon saying the log was performing poorly in a pprof benchmark.

Issue 1: [1637](https://github.com/0xPolygonHermez/cdk-erigon/issues/1637)
Issue 2: [1770](https://github.com/0xPolygonHermez/cdk-erigon/issues/1770)

After running a bechmark pprof after this changeset, the call stack has gone from the flame graph and improves performance.

### CDK Erigon changeset

[1f4cca638da71ffec4490bf21fa84004984b3546](https://github.com/gateway-fm/log/commit/1f4cca638da71ffec4490bf21fa84004984b3546)