### PR TITLE
Use 1hr EMA for average mgas/sec

### DIFF
--- a/turbo/execution/eth1/ethereum_execution.go
+++ b/turbo/execution/eth1/ethereum_execution.go
@@ -85,8 +85,7 @@ type EthereumExecutionModule struct {
 	doingPostForkchoice atomic.Bool
 
 	// metrics for average mgas/sec
-	avgMgasSec      float64
-	recordedMgasSec uint64
+	avgMgasSec float64
 
 	execution.UnimplementedExecutionServer
 }

--- a/turbo/execution/eth1/forkchoice.go
+++ b/turbo/execution/eth1/forkchoice.go
@@ -533,6 +533,10 @@ func (e *EthereumExecutionModule) updateForkChoice(ctx context.Context, original
 
 			const blockRange = 300 // ~1 hour
 			const alpha = 2.0 / (blockRange + 1)
+
+			if e.avgMgasSec == 0 {
+				e.avgMgasSec = mgasPerSec
+			}
 			e.avgMgasSec = alpha*mgasPerSec + (1-alpha)*e.avgMgasSec
 			e.recordedMgasSec++
 			logArgs = append(logArgs, "execution", blockTimings[engine_helpers.BlockTimingsValidationIndex], "mgas/s", fmt.Sprintf("%.2f", mgasPerSec), "average mgas/s", fmt.Sprintf("%.2f", e.avgMgasSec))

--- a/turbo/execution/eth1/forkchoice.go
+++ b/turbo/execution/eth1/forkchoice.go
@@ -538,7 +538,6 @@ func (e *EthereumExecutionModule) updateForkChoice(ctx context.Context, original
 				e.avgMgasSec = mgasPerSec
 			}
 			e.avgMgasSec = alpha*mgasPerSec + (1-alpha)*e.avgMgasSec
-			e.recordedMgasSec++
 			logArgs = append(logArgs, "execution", blockTimings[engine_helpers.BlockTimingsValidationIndex], "mgas/s", fmt.Sprintf("%.2f", mgasPerSec), "average mgas/s", fmt.Sprintf("%.2f", e.avgMgasSec))
 			if !e.syncCfg.ParallelStateFlushing {
 				logArgs = append(logArgs, "flushing", blockTimings[engine_helpers.BlockTimingsFlushExtendingFork])

--- a/turbo/execution/eth1/forkchoice.go
+++ b/turbo/execution/eth1/forkchoice.go
@@ -530,7 +530,10 @@ func (e *EthereumExecutionModule) updateForkChoice(ctx context.Context, original
 			gasUsedMgas := float64(fcuHeader.GasUsed) / 1e6
 			mgasPerSec := gasUsedMgas / totalTime.Seconds()
 			metrics.ChainTipMgasPerSec.Add(mgasPerSec)
-			e.avgMgasSec = (e.avgMgasSec*float64(e.recordedMgasSec) + mgasPerSec) / float64(e.recordedMgasSec+1)
+
+			const blockRange = 300 // ~1 hour
+			const alpha = 2.0 / (blockRange + 1)
+			e.avgMgasSec = alpha*mgasPerSec + (1-alpha)*e.avgMgasSec
 			e.recordedMgasSec++
 			logArgs = append(logArgs, "execution", blockTimings[engine_helpers.BlockTimingsValidationIndex], "mgas/s", fmt.Sprintf("%.2f", mgasPerSec), "average mgas/s", fmt.Sprintf("%.2f", e.avgMgasSec))
 			if !e.syncCfg.ParallelStateFlushing {


### PR DESCRIPTION
The current implementation calculates a cumulative average of all measurements, which becomes less meaningful over time due to historical bias.

Using a 1 hour EMA allows for a more live view of performance as it gives significantly more weight to recent measurements, while smoothing out extreme fluctuations.