### PR TITLE
rpcdaemon: Set correct txnum for bridge txns

### DIFF
--- a/turbo/jsonrpc/debug_api.go
+++ b/turbo/jsonrpc/debug_api.go
@@ -520,7 +520,7 @@ func (api *PrivateDebugAPIImpl) GetRawTransaction(ctx context.Context, txnHash c
 				if err != nil {
 					return nil, err
 				}
-				txNum = txNumNextBlock - 1
+				txNum = txNumNextBlock
 			}
 		} else {
 			blockNum, ok, err = api._blockReader.EventLookup(ctx, tx, txnHash)

--- a/turbo/jsonrpc/eth_receipts.go
+++ b/turbo/jsonrpc/eth_receipts.go
@@ -481,7 +481,7 @@ func (api *APIImpl) GetTransactionReceipt(ctx context.Context, txnHash common.Ha
 				if err != nil {
 					return nil, err
 				}
-				txNum = txNumNextBlock - 1
+				txNum = txNumNextBlock
 			}
 		} else {
 			blockNum, ok, err = api._blockReader.EventLookup(ctx, tx, txnHash)

--- a/turbo/jsonrpc/eth_txs.go
+++ b/turbo/jsonrpc/eth_txs.go
@@ -66,7 +66,7 @@ func (api *APIImpl) GetTransactionByHash(ctx context.Context, txnHash common.Has
 				if err != nil {
 					return nil, err
 				}
-				txNum = txNumNextBlock - 1
+				txNum = txNumNextBlock
 			}
 		} else {
 			blockNum, ok, err = api._blockReader.EventLookup(ctx, tx, txnHash)

--- a/turbo/jsonrpc/trace_adhoc.go
+++ b/turbo/jsonrpc/trace_adhoc.go
@@ -838,7 +838,7 @@ func (api *TraceAPIImpl) ReplayTransaction(ctx context.Context, txHash libcommon
 				if err != nil {
 					return nil, err
 				}
-				txNum = txNumNextBlock - 1
+				txNum = txNumNextBlock
 			}
 		} else {
 			blockNum, ok, err = api._blockReader.EventLookup(ctx, tx, txHash)

--- a/turbo/jsonrpc/trace_filtering.go
+++ b/turbo/jsonrpc/trace_filtering.go
@@ -87,7 +87,7 @@ func (api *TraceAPIImpl) Transaction(ctx context.Context, txHash common.Hash, ga
 				if err != nil {
 					return nil, err
 				}
-				txNum = txNumNextBlock - 1
+				txNum = txNumNextBlock
 			}
 		} else {
 			blockNumber, ok, err = api._blockReader.EventLookup(ctx, tx, txHash)


### PR DESCRIPTION
```
curl --request POST \
  --url http://127.0.0.1:8545/ \
  --header 'Content-Type: application/json' \
  --data '{
        "method": "eth_getTransactionByHash",
        "params": [
                "0x617ca062a7f7a77593739a1d6d41ecdaa4f6562ce5981fcfad82c93f0e3734b8"
        ],
        "id": 1,
        "jsonrpc": "2.0"
}'
{"jsonrpc":"2.0","id":1,"result":{"blockHash":"0x1aa32445d0edc96679ea83205e7edd138b0a5bd1835897044940fe26bf1c17d6","blockNumber":"0x89b0","from":"0x0000000000000000000000000000000000000000","gas":"0x0","gasPrice":"0x0","hash":"0x617ca062a7f7a77593739a1d6d41ecdaa4f6562ce5981fcfad82c93f0e3734b8","input":"0x","nonce":"0x0","to":"0x0000000000000000000000000000000000000000","transactionIndex":"0x0","value":"0x0","type":"0x0","chainId":"0x13882","v":"0x0","r":"0x0","s":"0x0"}}
```

Fixes #14023