### PR TITLE
Avoid nil pointer when chain is unknown

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1724,7 +1724,7 @@ func setBorConfig(ctx *cli.Context, cfg *ethconfig.Config, nodeConfig *nodecfg.C
 	heimdall.RecordWayPoints(cfg.WithHeimdallWaypointRecording || cfg.PolygonSync || cfg.PolygonSyncStage)
 
 	chainConfig := params.ChainConfigByChainName(ctx.String(ChainFlag.Name))
-	if chainConfig.Bor != nil && !ctx.IsSet(MaxPeersFlag.Name) {
+	if chainConfig != nil && chainConfig.Bor != nil && !ctx.IsSet(MaxPeersFlag.Name) {
 		// override default max devp2p peers for polygon as per
 		// https://forum.polygon.technology/t/introducing-our-new-dns-discovery-for-polygon-pos-faster-smarter-more-connected/19871
 		// which encourages high peer count


### PR DESCRIPTION
Start erigon with something like `--chain=xxx`

BEFORE:
```
[EROR] [03-05|16:11:59.146] catch panic                              err="runtime error: invalid memory address or nil pointer dereference" stack="[main.go:46 panic.go:787 panic.go:262 signal_unix.go:925 flags.go:1722 flags.go:1942 node.go:121 main.go:96 make_app.go:71 command.go:276 app.go:333 app.go:307 main.go:51 proc.go:283 asm_amd64.s:1700]"
```

AFTER:
```
Fatal: ChainDB name is not recognized: xxx
```