### PR TITLE
types: Move wrapped blob txn marshal to different func

### DIFF
--- a/core/types/blob_tx_wrapper.go
+++ b/core/types/blob_tx_wrapper.go
@@ -388,7 +388,7 @@ func (txw *BlobTxWrapper) payloadSize() (payloadSize int) {
 	payloadSize += l + rlp.ListPrefixLen(l)
 	return
 }
-func (txw *BlobTxWrapper) MarshalBinary(w io.Writer) error {
+func (txw *BlobTxWrapper) MarshalBinaryWrapped(w io.Writer) error {
 	b := newEncodingBuf()
 	defer pooledBuf.Put(b)
 	// encode TxType
@@ -419,6 +419,9 @@ func (txw *BlobTxWrapper) MarshalBinary(w io.Writer) error {
 		return err
 	}
 	return nil
+}
+func (txw *BlobTxWrapper) MarshalBinary(w io.Writer) error {
+	return txw.Tx.MarshalBinary(w)
 }
 func (txw *BlobTxWrapper) EncodeRLP(w io.Writer) error {
 	return txw.Tx.EncodeRLP(w)

--- a/turbo/engineapi/engine_server_test.go
+++ b/turbo/engineapi/engine_server_test.go
@@ -114,7 +114,7 @@ func TestGetBlobsV1(t *testing.T) {
 	engineServer := NewEngineServer(mockSentry.Log, mockSentry.ChainConfig, executionRpc, mockSentry.HeaderDownload(), nil, false, true, false, true)
 	engineServer.Start(ctx, &httpcfg.HttpCfg{}, mockSentry.DB, mockSentry.BlockReader, ff, nil, mockSentry.Engine, eth, txPool, nil)
 
-	err = wrappedTxn.MarshalBinary(buf)
+	err = wrappedTxn.MarshalBinaryWrapped(buf)
 	require.NoError(err)
 	_, err = api.SendRawTransaction(ctx, buf.Bytes())
 	require.NoError(err)


### PR DESCRIPTION
Restores `MarshalBinary` contents from before https://github.com/erigontech/erigon/pull/13975
The full marshal of wrapped blobs are only used in a test, hence moved the logic to `MarshalBinaryWrapped`. This does make this different from other transaction types, as it only returns the marshalled bytes of the internal

Fixes an issue in which wrapped blobs were getting included to the returned payload.