### PR TITLE
nil ptr in gen bor logs

### DIFF
--- a/turbo/jsonrpc/eth_receipts.go
+++ b/turbo/jsonrpc/eth_receipts.go
@@ -303,6 +303,10 @@ func (api *BaseAPI) getLogsV3(ctx context.Context, tx kv.TemporalTx, begin, end 
 					return logs, err
 				}
 
+				if len(events) == 0 {
+					continue
+				}
+
 				borLogs, err := api.borReceiptGenerator.GenerateBorLogs(ctx, events, txNumsReader, tx, header, chainConfig, txIndex, len(logs))
 				if err != nil {
 					return logs, err


### PR DESCRIPTION
can reproduce on amoy/bor, `release/3.0` and `main`, by:
```
curl 'http://localhost:8545' -H 'Content-Type: application/json' --data '{"id": 1, "jsonrpc": "2.0", "method": "eth_getLogs", "params": [ {"fromBlock": "14300401","toBlock": "14300501"} ]}'
```

```
`EROR[03-06|03:25:55.613] RPC method eth_getLogs crashed: runtime error: index out of range [0] with length 0
[service.go:223 panic.go:785 panic.go:115 bor_receipts_generator.go:86 eth_receipts.go:306 eth_receipts.go:143 value.go:581 value.go:365 service.go:228 handler.go:534 handler.go:484 handler.go:425 handler.go:245 handler.go:338 asm_amd64.s:1700]` 
```
