### PR TITLE
txpool: add more cases to return err instead of panicking on invalid Txn cases

### DIFF
--- a/txnprovider/txpool/txpoolcfg/txpoolcfg.go
+++ b/txnprovider/txpool/txpoolcfg/txpoolcfg.go
@@ -186,6 +186,12 @@ func (r DiscardReason) String() string {
 		return "gas limit is too high"
 	case BlobHashCheckFail:
 		return "KZGcommitment's versioned hash has to be equal to blob_versioned_hash at the same index"
+	case UnmatchedBlobTxExt:
+		return "KZGcommitments must match the corresponding blobs and proofs"
+	case UnequalBlobTxExt:
+		return "blob_versioned_hashes, blobs, commitments and proofs must have equal number"
+	case ErrAuthorityReserved:
+		return "EIP-7702 transaction with authority already reserved"
 	default:
 		panic(fmt.Sprintf("discard reason: %d", r))
 	}

--- a/txnprovider/txpool/txpoolcfg/txpoolcfg.go
+++ b/txnprovider/txpool/txpoolcfg/txpoolcfg.go
@@ -184,6 +184,8 @@ func (r DiscardReason) String() string {
 		return "EIP-7702 transactions with an empty authorization list are invalid"
 	case GasLimitTooHigh:
 		return "gas limit is too high"
+	case BlobHashCheckFail:
+		return "KZGcommitment's versioned hash has to be equal to blob_versioned_hash at the same index"
 	default:
 		panic(fmt.Sprintf("discard reason: %d", r))
 	}


### PR DESCRIPTION
This pull request includes updates to the `DiscardReason` function to handle additional discard reasons for transactions. The most important changes include adding new cases for different types of transaction validation errors.