### PR TITLE
[cmd/integration] fix: correct error handling in LogStats callback

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -1434,7 +1434,10 @@ func allSnapshots(ctx context.Context, db kv.RoDB, logger log.Logger) (*freezebl
 			defer ac.Close()
 			ac.LogStats(tx, func(endTxNumMinimax uint64) (uint64, error) {
 				_, histBlockNumProgress, err := txNums.FindBlockNum(tx, endTxNumMinimax)
-				return histBlockNumProgress, fmt.Errorf("findBlockNum(%d) fails: %w", endTxNumMinimax, err)
+				if err != nil {
+					return histBlockNumProgress, fmt.Errorf("findBlockNum(%d) fails: %w", endTxNumMinimax, err)
+				}
+				return histBlockNumProgress, nil
 			})
 			return nil
 		})


### PR DESCRIPTION
Fix the error handling in the LogStats callback function in stages.go. Previously, the function was unconditionally returning an error even when FindBlockNum succeeded, resulting in confusing error messages like findBlockNum(5046875000) fails: . Now the function only returns an error when FindBlockNum actually fails.

This improves error reporting and prevents misleading error messages when working with transaction numbers and block lookups.