### PR TITLE
docs: update dead link in `db_faq.md`

### DIFF
--- a/docs/programmers_guide/db_faq.md
+++ b/docs/programmers_guide/db_faq.md
@@ -27,7 +27,7 @@ We have Go, Rust and C++ implementations of `RoKV` interface.
 
 Rationale and Architecture of DB interface: [./../../ethdb/Readme.md](../../ethdb/Readme.md)
 
-MDBX: [docs](https://libmdbx.website.yandexcloud.net)
+MDBX: [docs](https://libmdbx.dqdkfa.ru/)
 and [mdbx.h](https://github.com/erigontech/libmdbx/blob/master/mdbx.h)
 
 


### PR DESCRIPTION
Hi! The link to the MDBX documentation in `db_faq.md` was pointing to a dead domain (`https://libmdbx.website.yandexcloud.net`), which no longer resolves.  