### PR TITLE
docs: Fix grammar mistakes

### DIFF
--- a/docs/merry-go-round-sync.md
+++ b/docs/merry-go-round-sync.md
@@ -13,7 +13,7 @@ node might like to do in the beginning).
 
 The process of syncing happens in cycles. During each cycle, all participants attempt to distribute the entire content of the
 Ethereum state to each other. Therefore the duration of one cycle for the Ethereum mainnet is likely to be some hours.
-Cycle is divided into ticks. For convenience, we can say that each ticks starts after the mining of certain block, and lasts
+Cycle is divided into ticks. For convenience, we can say that each tick starts after the mining of a certain block, and lasts
 for some predetermined amount of time, let's say, 30 seconds. This definition means that the ticks will often overlap, but not
 always, as shown on the picture below.
 


### PR DESCRIPTION
Noticed and fixed a couple of grammar issues:  

- "each ticks starts" → "each tick starts" (each requires a singular noun)  
- "the mining of certain block" → "the mining of a certain block" (a is needed before a singular countable noun)  
