### PR TITLE
docs: fix formatting error in witness operator description

### DIFF
--- a/docs/programmers_guide/witness_format.md
+++ b/docs/programmers_guide/witness_format.md
@@ -87,7 +87,7 @@ pushes a leaf with specified parameters to the stack; if flags show, before that
 
 format: `OpAccountLeaf key:[]byte flags [nonce:uint64] [balance:[]byte]` 
 
-encoded as `[ 0x05 CBOR(key|[]byte)... flags /CBOR(nonce).../ /CBOR(balance).../ ]`
+encoded as `[ 0x05 CBOR(key:[]byte)... flags /CBOR(nonce).../ /CBOR(balance).../ ]`
   
 *flags* is a bitset encoded in a single bit (see [`witness_operators_test.go`](../../trie/witness_operators_test.go) to see flags in action).
 * bit 0 defines if **code** is present; if set to 1 it assumes that either `OpCode` or `OpHash` already put something on the stack;


### PR DESCRIPTION
I noticed a formatting issue in the documentation. Specifically, the expression "key|[]byte" was used, which seems to be a typo. It should be "key:[]byte" to correctly reflect the expected format for the data structure.
I've updated this to ensure consistency and clarity in the documentation.