### PR TITLE
feehistory.go: optimize the high latency of eth_feeHistory.

### DIFF
--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -297,7 +297,7 @@ func (oracle *Oracle) FeeHistory(ctx context.Context, blocks int, unresolvedLast
 			if len(rewardPercentiles) != 0 {
 				fees.block, fees.err = oracle.backend.BlockByNumber(ctx, rpc.BlockNumber(blockNumber))
 				if fees.block != nil && fees.err == nil {
-					fees.receipts, fees.err = oracle.backend.GetReceiptsGasUsed(fees.block)
+					fees.receipts, fees.err = oracle.backend.GetReceiptsGasUsed(ctx, fees.block)
 				}
 			} else {
 				fees.header, fees.err = oracle.backend.HeaderByNumber(ctx, rpc.BlockNumber(blockNumber))

--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -297,7 +297,7 @@ func (oracle *Oracle) FeeHistory(ctx context.Context, blocks int, unresolvedLast
 			if len(rewardPercentiles) != 0 {
 				fees.block, fees.err = oracle.backend.BlockByNumber(ctx, rpc.BlockNumber(blockNumber))
 				if fees.block != nil && fees.err == nil {
-					fees.receipts, fees.err = oracle.backend.GetReceipts(ctx, fees.block)
+					fees.receipts, fees.err = oracle.backend.GetReceiptsGasUsed(fees.block)
 				}
 			} else {
 				fees.header, fees.err = oracle.backend.HeaderByNumber(ctx, rpc.BlockNumber(blockNumber))

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -44,7 +44,7 @@ type OracleBackend interface {
 	BlockByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Block, error)
 	ChainConfig() *chain.Config
 
-	GetReceipts(ctx context.Context, block *types.Block) (types.Receipts, error)
+	GetReceiptsGasUsed(block *types.Block) (types.Receipts, error)
 	PendingBlockAndReceipts() (*types.Block, types.Receipts)
 }
 

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -44,7 +44,7 @@ type OracleBackend interface {
 	BlockByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Block, error)
 	ChainConfig() *chain.Config
 
-	GetReceiptsGasUsed(block *types.Block) (types.Receipts, error)
+	GetReceiptsGasUsed(ctx context.Context, block *types.Block) (types.Receipts, error)
 	PendingBlockAndReceipts() (*types.Block, types.Receipts)
 }
 

--- a/eth/integrity/receipts_no_duplicates.go
+++ b/eth/integrity/receipts_no_duplicates.go
@@ -45,7 +45,6 @@ func ReceiptsNoDuplicates(ctx context.Context, db kv.TemporalRoDB, blockReader s
 		toBlock-- // [fromBlock,toBlock)
 	}
 
-	fromTxNum = 2763535659
 	ac := tx.(state.HasAggTx).AggTx().(*state.AggregatorRoTx)
 	//toTxNum := ac.DbgDomain(kv.ReceiptDomain).DbgMaxTxNumInDB(tx)
 	toTxNum, err := txNumsReader.Max(tx, toBlock)
@@ -73,7 +72,7 @@ func ReceiptsNoDuplicates(ctx context.Context, db kv.TemporalRoDB, blockReader s
 		}
 		//_, blockNum, _ := txNumsReader.FindBlockNum(tx, txNum)
 		blockNum := badFoundBlockNum(tx, prevBN-1, txNumsReader, txNum)
-		fmt.Printf("[dbg] cumGasUsed=%d, txNum=%d, blockNum=%d, prevCumGasUsed=%d\n", cumGasUsed, txNum, blockNum, prevCumGasUsed)
+		//fmt.Printf("[dbg] cumGasUsed=%d, txNum=%d, blockNum=%d, prevCumGasUsed=%d\n", cumGasUsed, txNum, blockNum, prevCumGasUsed)
 		if int(cumGasUsed) == prevCumGasUsed && cumGasUsed != 0 && blockNum == prevBN {
 			err := fmt.Errorf("bad receipt at txnum: %d, block: %d, cumGasUsed=%d, prevCumGasUsed=%d", txNum, blockNum, cumGasUsed, prevCumGasUsed)
 			panic(err)

--- a/eth/integrity/receipts_no_duplicates.go
+++ b/eth/integrity/receipts_no_duplicates.go
@@ -45,6 +45,7 @@ func ReceiptsNoDuplicates(ctx context.Context, db kv.TemporalRoDB, blockReader s
 		toBlock-- // [fromBlock,toBlock)
 	}
 
+	fromTxNum = 2763535659
 	ac := tx.(state.HasAggTx).AggTx().(*state.AggregatorRoTx)
 	//toTxNum := ac.DbgDomain(kv.ReceiptDomain).DbgMaxTxNumInDB(tx)
 	toTxNum, err := txNumsReader.Max(tx, toBlock)
@@ -72,7 +73,7 @@ func ReceiptsNoDuplicates(ctx context.Context, db kv.TemporalRoDB, blockReader s
 		}
 		//_, blockNum, _ := txNumsReader.FindBlockNum(tx, txNum)
 		blockNum := badFoundBlockNum(tx, prevBN-1, txNumsReader, txNum)
-		//fmt.Printf("[dbg] cumGasUsed=%d, txNum=%d, blockNum=%d, prevCumGasUsed=%d\n", cumGasUsed, txNum, blockNum, prevCumGasUsed)
+		fmt.Printf("[dbg] cumGasUsed=%d, txNum=%d, blockNum=%d, prevCumGasUsed=%d\n", cumGasUsed, txNum, blockNum, prevCumGasUsed)
 		if int(cumGasUsed) == prevCumGasUsed && cumGasUsed != 0 && blockNum == prevBN {
 			err := fmt.Errorf("bad receipt at txnum: %d, block: %d, cumGasUsed=%d, prevCumGasUsed=%d", txNum, blockNum, cumGasUsed, prevCumGasUsed)
 			panic(err)

--- a/turbo/jsonrpc/eth_receipts.go
+++ b/turbo/jsonrpc/eth_receipts.go
@@ -56,8 +56,9 @@ func (api *BaseAPI) getReceipt(ctx context.Context, cc *chain.Config, tx kv.Temp
 	return api.receiptsGenerator.GetReceipt(ctx, cc, tx, header, txn, index, txNum)
 }
 
-func (api *BaseAPI) getReceiptsGasUsed(tx kv.TemporalTx, block *types.Block) (types.Receipts, error) {
-	return api.receiptsGenerator.GetReceiptsGasUsed(tx, block)
+func (api *BaseAPI) getReceiptsGasUsed(ctx context.Context, tx kv.TemporalTx, block *types.Block) (types.Receipts, error) {
+	txNumsReader := rawdbv3.TxNums.WithCustomReadTxNumFunc(freezeblocks.ReadTxNumFuncFromBlockReader(ctx, api._blockReader))
+	return api.receiptsGenerator.GetReceiptsGasUsed(tx, block, txNumsReader)
 }
 
 func (api *BaseAPI) getCachedReceipt(ctx context.Context, hash common.Hash) (*types.Receipt, bool) {

--- a/turbo/jsonrpc/eth_receipts.go
+++ b/turbo/jsonrpc/eth_receipts.go
@@ -56,6 +56,10 @@ func (api *BaseAPI) getReceipt(ctx context.Context, cc *chain.Config, tx kv.Temp
 	return api.receiptsGenerator.GetReceipt(ctx, cc, tx, header, txn, index, txNum)
 }
 
+func (api *BaseAPI) getReceiptsGasUsed(tx kv.TemporalTx, block *types.Block) (types.Receipts, error) {
+	return api.receiptsGenerator.GetReceiptsGasUsed(tx, block)
+}
+
 func (api *BaseAPI) getCachedReceipt(ctx context.Context, hash common.Hash) (*types.Receipt, bool) {
 	return api.receiptsGenerator.GetCachedReceipt(ctx, hash)
 }

--- a/turbo/jsonrpc/eth_system.go
+++ b/turbo/jsonrpc/eth_system.go
@@ -281,6 +281,6 @@ func (b *GasPriceOracleBackend) PendingBlockAndReceipts() (*types.Block, types.R
 	return nil, nil
 }
 
-func (b *GasPriceOracleBackend) GetReceiptsGasUsed(block *types.Block) (types.Receipts, error) {
-	return b.baseApi.getReceiptsGasUsed(b.tx, block)
+func (b *GasPriceOracleBackend) GetReceiptsGasUsed(ctx context.Context, block *types.Block) (types.Receipts, error) {
+	return b.baseApi.getReceiptsGasUsed(ctx, b.tx, block)
 }

--- a/turbo/jsonrpc/eth_system.go
+++ b/turbo/jsonrpc/eth_system.go
@@ -280,3 +280,7 @@ func (b *GasPriceOracleBackend) GetReceipts(ctx context.Context, block *types.Bl
 func (b *GasPriceOracleBackend) PendingBlockAndReceipts() (*types.Block, types.Receipts) {
 	return nil, nil
 }
+
+func (b *GasPriceOracleBackend) GetReceiptsGasUsed(block *types.Block) (types.Receipts, error) {
+	return b.baseApi.getReceiptsGasUsed(b.tx, block)
+}

--- a/turbo/jsonrpc/receipts/receipts_generator.go
+++ b/turbo/jsonrpc/receipts/receipts_generator.go
@@ -195,7 +195,7 @@ func (g *Generator) GetReceiptsGasUsed(tx kv.TemporalTx, block *types.Block, txN
 
 	startTxNum, err := txNumsReader.Min(tx, block.NumberU64())
 	if err != nil {
-		return nil, fmt.Errorf("ReceiptGen.GetReceiptsGasUsed: get  min tx of block %d: %w", block.NumberU64(), err)
+		return nil, err
 	}
 
 	receipts := make(types.Receipts, len(block.Transactions()))

--- a/turbo/jsonrpc/receipts/receipts_generator.go
+++ b/turbo/jsonrpc/receipts/receipts_generator.go
@@ -188,12 +188,12 @@ func (g *Generator) GetReceipts(ctx context.Context, cfg *chain.Config, tx kv.Te
 	return receipts, nil
 }
 
-func (g *Generator) GetReceiptsGasUsed(tx kv.TemporalTx, block *types.Block) (types.Receipts, error) {
+func (g *Generator) GetReceiptsGasUsed(tx kv.TemporalTx, block *types.Block, txNumsReader rawdbv3.TxNumsReader) (types.Receipts, error) {
 	if receipts, ok := g.receiptsCache.Get(block.Hash()); ok {
 		return receipts, nil
 	}
 
-	startTxNum, err := rawdbv3.TxNums.Min(tx, block.NumberU64())
+	startTxNum, err := txNumsReader.Min(tx, block.NumberU64())
 	if err != nil {
 		return nil, fmt.Errorf("get min tx num: %w", err)
 	}

--- a/turbo/jsonrpc/receipts/receipts_generator.go
+++ b/turbo/jsonrpc/receipts/receipts_generator.go
@@ -195,7 +195,7 @@ func (g *Generator) GetReceiptsGasUsed(tx kv.TemporalTx, block *types.Block, txN
 
 	startTxNum, err := txNumsReader.Min(tx, block.NumberU64())
 	if err != nil {
-		return nil, fmt.Errorf("get min tx num: %w", err)
+		return nil, fmt.Errorf("ReceiptGen.GetReceiptsGasUsed: get  min tx of block %d: %w", block.NumberU64(), err)
 	}
 
 	receipts := make(types.Receipts, len(block.Transactions()))
@@ -206,13 +206,12 @@ func (g *Generator) GetReceiptsGasUsed(tx kv.TemporalTx, block *types.Block, txN
 		receipt := &types.Receipt{}
 		cumGasUsed, _, _, err := rawtemporaldb.ReceiptAsOf(tx, currentTxNum+1)
 		if err != nil {
-			return nil, fmt.Errorf("get receipt at tx %d (block %d, index %d): %w",
+			return nil, fmt.Errorf("ReceiptGen.GetReceiptsGasUsed: at tx %d (block %d, index %d): %w",
 				currentTxNum, block.NumberU64(), i, err)
 		}
 
 		receipt.GasUsed = cumGasUsed - prevCumGasUsed
 		receipts[i] = receipt
-		log.Info("eth_feeHistory", "blockNum", block.NumberU64(), "txIndex", i, "receipt.gasused", receipts[i].GasUsed, "txNum", currentTxNum, "cumGasUsed", cumGasUsed, "prevCumGasUsed", prevCumGasUsed)
 
 		prevCumGasUsed = cumGasUsed
 		currentTxNum++

--- a/turbo/jsonrpc/receipts/receipts_generator.go
+++ b/turbo/jsonrpc/receipts/receipts_generator.go
@@ -193,10 +193,6 @@ func (g *Generator) GetReceiptsGasUsed(tx kv.TemporalTx, block *types.Block) (ty
 		return receipts, nil
 	}
 
-	if block == nil || len(block.Transactions()) == 0 {
-		return types.Receipts{}, nil
-	}
-
 	startTxNum, err := rawdbv3.TxNums.Min(tx, block.NumberU64())
 	if err != nil {
 		return nil, fmt.Errorf("get min tx num: %w", err)
@@ -216,6 +212,7 @@ func (g *Generator) GetReceiptsGasUsed(tx kv.TemporalTx, block *types.Block) (ty
 
 		receipt.GasUsed = cumGasUsed - prevCumGasUsed
 		receipts[i] = receipt
+		log.Info("eth_feeHistory", "blockNum", block.NumberU64(), "txIndex", i, "receipt.gasused", receipts[i].GasUsed, "txNum", currentTxNum, "cumGasUsed", cumGasUsed, "prevCumGasUsed", prevCumGasUsed)
 
 		prevCumGasUsed = cumGasUsed
 		currentTxNum++


### PR DESCRIPTION
Currently, a significant amount of time is spent on re-executing transactions. However, in reality, only the gasused by the transaction is needed, which can be obtained through the `kv.ReceiptDomain`

Reproduce
```
curl --location --request POST 'localhost:8545' --header 'content-type: application/json' --data-raw '[
{ "method": "eth_feeHistory", "params": ["0x100", "0x2CA3220", [25,75]], "id": 1, "jsonrpc": "2.0" }
]'
```
Following this optimization, the latency has been dramatically reduced from minutes to milliseconds.