### PR TITLE
feat: add --chain flag for init command

### DIFF
--- a/turbo/app/init_cmd.go
+++ b/turbo/app/init_cmd.go
@@ -41,6 +41,7 @@ var initCommand = cli.Command{
 	ArgsUsage: "<genesisPath>",
 	Flags: []cli.Flag{
 		&utils.DataDirFlag,
+		&utils.ChainFlag,
 	},
 	//Category: "BLOCKCHAIN COMMANDS",
 	Description: `


### PR DESCRIPTION
close:https://github.com/erigontech/erigon/issues/14142

run:
```
init
--datadir=erigon-data
--chain=xxx
/tmp/genesis/genesis.json
```
logs:

```
[INFO] [03-12|17:25:24.120] logging to file system                   log dir=erigon-data/logs file prefix=erigon log level=info json=false
[INFO] [03-12|17:25:36.500] Starting Erigon on                       devnet=xxx
[WARN] [03-12|17:25:36.504] No snapshot hashes for chain             chain=xxx
[INFO] [03-12|17:25:36.519] Maximum peer count                       total=32
[INFO] [03-12|17:25:36.520] starting HTTP APIs                       port=8545 APIs=eth,erigon,engine
```
