### PR TITLE
enr, rplx, abi, merkle_tree, base_encodin, cmdtest, types: enabled makezero linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,6 @@ linters:
     - wrapcheck
     - err113
     - unparam
-    - makezero #TODO: enable me
     - noctx #TODO: enable me
     - nilerr #TODO: enable me
     - errorlint #TODO: enable me
@@ -40,6 +39,7 @@ linters:
 #    - revive
 #    - forcetypeassert
 #    - stylecheck
+    - makezero
 
 linters-settings:
   gocritic: # see https://golangci-lint.run/usage/linters/#gocritic and https://go-critic.github.io/overview#checks-overview

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -361,7 +361,7 @@ func TestInputVariableInputLength(t *testing.T) {
 	length := make([]byte, 32)
 	length[31] = byte(len(strin))
 	value := common.RightPadBytes([]byte(strin), 32)
-	exp := append(offset, append(length, value...)...)
+	exp := append(offset, append(length, value...)...) // nozero
 
 	// ignore first 4 bytes of the output. This is the function identifier
 	strpack = strpack[4:]
@@ -400,9 +400,9 @@ func TestInputVariableInputLength(t *testing.T) {
 	length2[31] = byte(len(str2))
 	value2 := common.RightPadBytes([]byte(str2), 32)
 
-	exp2 := append(offset1, offset2...)
-	exp2 = append(exp2, append(length1, value1...)...)
-	exp2 = append(exp2, append(length2, value2...)...)
+	exp2 := append(offset1, offset2...)                // nozero
+	exp2 = append(exp2, append(length1, value1...)...) // nozero
+	exp2 = append(exp2, append(length2, value2...)...) // nozero
 
 	// ignore first 4 bytes of the output. This is the function identifier
 	str2pack = str2pack[4:]
@@ -424,9 +424,9 @@ func TestInputVariableInputLength(t *testing.T) {
 	value1 = common.RightPadBytes([]byte(str1), 64)
 	offset2[31] = 160
 
-	exp2 = append(offset1, offset2...)
-	exp2 = append(exp2, append(length1, value1...)...)
-	exp2 = append(exp2, append(length2, value2...)...)
+	exp2 = append(offset1, offset2...)                 // nozero
+	exp2 = append(exp2, append(length1, value1...)...) // nozero
+	exp2 = append(exp2, append(length2, value2...)...) // nozero
 
 	// ignore first 4 bytes of the output. This is the function identifier
 	str2pack = str2pack[4:]
@@ -454,9 +454,9 @@ func TestInputVariableInputLength(t *testing.T) {
 	length2[31] = byte(len(str2))
 	value2 = common.RightPadBytes([]byte(str2), 64)
 
-	exp2 = append(offset1, offset2...)
-	exp2 = append(exp2, append(length1, value1...)...)
-	exp2 = append(exp2, append(length2, value2...)...)
+	exp2 = append(offset1, offset2...)                 // nozero
+	exp2 = append(exp2, append(length1, value1...)...) // nozero
+	exp2 = append(exp2, append(length2, value2...)...) // nozero
 
 	// ignore first 4 bytes of the output. This is the function identifier
 	str2pack = str2pack[4:]
@@ -487,9 +487,9 @@ func TestInputFixedArrayAndVariableInputLength(t *testing.T) {
 	strvalue := common.RightPadBytes([]byte(strin), 32)
 	arrinvalue1 := common.LeftPadBytes(arrin[0].Bytes(), 32)
 	arrinvalue2 := common.LeftPadBytes(arrin[1].Bytes(), 32)
-	exp := append(offset, arrinvalue1...)
+	exp := append(offset, arrinvalue1...) // nozero
 	exp = append(exp, arrinvalue2...)
-	exp = append(exp, append(length, strvalue...)...)
+	exp = append(exp, append(length, strvalue...)...) // nozero
 
 	// ignore first 4 bytes of the output. This is the function identifier
 	fixedArrStrPack = fixedArrStrPack[4:]
@@ -513,9 +513,9 @@ func TestInputFixedArrayAndVariableInputLength(t *testing.T) {
 	strvalue = common.RightPadBytes([]byte(strin), 32)
 	arrinvalue1 = common.LeftPadBytes(arrin[0].Bytes(), 32)
 	arrinvalue2 = common.LeftPadBytes(arrin[1].Bytes(), 32)
-	exp = append(offset, arrinvalue1...)
+	exp = append(offset, arrinvalue1...) // nozero
 	exp = append(exp, arrinvalue2...)
-	exp = append(exp, append(length, strvalue...)...)
+	exp = append(exp, append(length, strvalue...)...) // nozero
 
 	// ignore first 4 bytes of the output. This is the function identifier
 	fixedArrBytesPack = fixedArrBytesPack[4:]
@@ -547,11 +547,11 @@ func TestInputFixedArrayAndVariableInputLength(t *testing.T) {
 	dynarrinvalue1 := common.LeftPadBytes(dynarrin[0].Bytes(), 32)
 	dynarrinvalue2 := common.LeftPadBytes(dynarrin[1].Bytes(), 32)
 	dynarrinvalue3 := common.LeftPadBytes(dynarrin[2].Bytes(), 32)
-	exp = append(stroffset, fixedarrinvalue1...)
+	exp = append(stroffset, fixedarrinvalue1...) // nozero
 	exp = append(exp, fixedarrinvalue2...)
 	exp = append(exp, dynarroffset...)
-	exp = append(exp, append(strlength, strvalue...)...)
-	dynarrarg := append(dynarrlength, dynarrinvalue1...)
+	exp = append(exp, append(strlength, strvalue...)...) // nozero
+	dynarrarg := append(dynarrlength, dynarrinvalue1...) // nozero
 	dynarrarg = append(dynarrarg, dynarrinvalue2...)
 	dynarrarg = append(dynarrarg, dynarrinvalue3...)
 	exp = append(exp, dynarrarg...)
@@ -582,12 +582,12 @@ func TestInputFixedArrayAndVariableInputLength(t *testing.T) {
 	fixedarrin2value1 := common.LeftPadBytes(fixedarrin2[0].Bytes(), 32)
 	fixedarrin2value2 := common.LeftPadBytes(fixedarrin2[1].Bytes(), 32)
 	fixedarrin2value3 := common.LeftPadBytes(fixedarrin2[2].Bytes(), 32)
-	exp = append(stroffset, fixedarrin1value1...)
+	exp = append(stroffset, fixedarrin1value1...) // nozero
 	exp = append(exp, fixedarrin1value2...)
 	exp = append(exp, fixedarrin2value1...)
 	exp = append(exp, fixedarrin2value2...)
 	exp = append(exp, fixedarrin2value3...)
-	exp = append(exp, append(strlength, strvalue...)...)
+	exp = append(exp, append(strlength, strvalue...)...) // nozero
 
 	// ignore first 4 bytes of the output. This is the function identifier
 	doubleFixedArrStrPack = doubleFixedArrStrPack[4:]
@@ -621,14 +621,14 @@ func TestInputFixedArrayAndVariableInputLength(t *testing.T) {
 	fixedarrin2value1 = common.LeftPadBytes(fixedarrin2[0].Bytes(), 32)
 	fixedarrin2value2 = common.LeftPadBytes(fixedarrin2[1].Bytes(), 32)
 	fixedarrin2value3 = common.LeftPadBytes(fixedarrin2[2].Bytes(), 32)
-	exp = append(stroffset, fixedarrin1value1...)
+	exp = append(stroffset, fixedarrin1value1...) // nozero
 	exp = append(exp, fixedarrin1value2...)
 	exp = append(exp, dynarroffset...)
 	exp = append(exp, fixedarrin2value1...)
 	exp = append(exp, fixedarrin2value2...)
 	exp = append(exp, fixedarrin2value3...)
-	exp = append(exp, append(strlength, strvalue...)...)
-	dynarrarg = append(dynarrlength, dynarrinvalue1...)
+	exp = append(exp, append(strlength, strvalue...)...) // nozero
+	dynarrarg = append(dynarrlength, dynarrinvalue1...)  // nozero
 	dynarrarg = append(dynarrarg, dynarrinvalue2...)
 	exp = append(exp, dynarrarg...)
 

--- a/cl/merkle_tree/list.go
+++ b/cl/merkle_tree/list.go
@@ -60,7 +60,7 @@ func MerkleizeVectorFlat(in []byte, limit uint64) ([32]byte, error) {
 		// Sequential
 		layerLen := len(elements)
 		if layerLen%64 == 32 {
-			elements = append(elements, ZeroHashes[i][:]...)
+			elements = append(elements, ZeroHashes[i][:]...) // nozero
 		}
 		outputLen := len(elements) / 2
 		if err := HashByteSlice(elements, elements); err != nil {

--- a/cl/merkle_tree/merkle_tree_test.go
+++ b/cl/merkle_tree/merkle_tree_test.go
@@ -56,7 +56,7 @@ func TestMerkleTreeAppendLeaf(t *testing.T) {
 	}, nil)
 	// Test AppendLeaf
 	mt.AppendLeaf()
-	testBuffer = append(testBuffer, make([]byte, 4*length.Hash)...)
+	testBuffer = append(testBuffer, make([]byte, 4*length.Hash)...) // nozero
 	testBuffer[128] = 5
 	expectedRoot1 := getExpectedRoot(testBuffer)
 	require.Equal(t, mt.ComputeRoot(), expectedRoot1)
@@ -97,7 +97,7 @@ func TestMerkleTreeAppendLeafWithLowMaxDepth(t *testing.T) {
 	}, nil)
 	// Test AppendLeaf
 	mt.AppendLeaf()
-	testBuffer = append(testBuffer, make([]byte, 4*length.Hash)...)
+	testBuffer = append(testBuffer, make([]byte, 4*length.Hash)...) // nozero
 	testBuffer[128] = 5
 	expectedRoot := getExpectedRoot(testBuffer)
 	require.Equal(t, mt.ComputeRoot(), expectedRoot)
@@ -137,7 +137,7 @@ func TestMerkleTreeAppendLeafWithLowMaxDepthAndLimitAndTestWR(t *testing.T) {
 	}, &lm)
 	// Test AppendLeaf
 	mt.AppendLeaf()
-	testBuffer = append(testBuffer, make([]byte, 4*length.Hash)...)
+	testBuffer = append(testBuffer, make([]byte, 4*length.Hash)...) // nozero
 	testBuffer[128] = 5
 	expectedRoot := getExpectedRootWithLimit(testBuffer, int(lm))
 	require.Equal(t, mt.ComputeRoot(), expectedRoot)

--- a/cl/persistence/base_encoding/uint64_diff.go
+++ b/cl/persistence/base_encoding/uint64_diff.go
@@ -347,7 +347,7 @@ func ApplyCompressedSerializedValidatorListDiff(in, out []byte, diff []byte, rev
 		if n != 121 {
 			return nil, fmt.Errorf("read %d bytes, expected 121", n)
 		}
-		out = append(out, currValidator...)
+		out = append(out, currValidator...) // nozero
 	}
 
 	return out, nil

--- a/core/gdbme/gdbme_darwin.go
+++ b/core/gdbme/gdbme_darwin.go
@@ -25,12 +25,12 @@ func RestartUnderGDB() {
 	args := os.Args[1:]
 	filteredArgs := []string{}
 	for _, arg := range args {
-		if arg != fmt.Sprintf("--%s", utils.GDBMeFlag.Name) {
+		if arg != "--"+utils.GDBMeFlag.Name {
 			filteredArgs = append(filteredArgs, arg)
 		}
 	}
 
-	runCommand := fmt.Sprintf("run %s", formatArgsForLLDB(filteredArgs))
+	runCommand := "run " + formatArgsForLLDB(filteredArgs)
 
 	// maybe in future it would be a script in a separate file
 	//TODO: discover some more features from lldb and add it here

--- a/core/gdbme/gdbme_darwin.go
+++ b/core/gdbme/gdbme_darwin.go
@@ -4,11 +4,12 @@ package gdbme
 
 import (
 	"fmt"
-	"github.com/erigontech/erigon/cmd/utils"
 	"os"
 	"os/exec"
 	"strings"
 	"syscall"
+
+	"github.com/erigontech/erigon/cmd/utils"
 )
 
 const lldbPath = "/usr/bin/lldb"
@@ -25,12 +26,12 @@ func RestartUnderGDB() {
 	args := os.Args[1:]
 	filteredArgs := []string{}
 	for _, arg := range args {
-		if arg != "--"+utils.GDBMeFlag.Name {
+		if arg != fmt.Sprintf("--%s", utils.GDBMeFlag.Name) {
 			filteredArgs = append(filteredArgs, arg)
 		}
 	}
 
-	runCommand := "run " + formatArgsForLLDB(filteredArgs)
+	runCommand := fmt.Sprintf("run %s", formatArgsForLLDB(filteredArgs))
 
 	// maybe in future it would be a script in a separate file
 	//TODO: discover some more features from lldb and add it here

--- a/core/types/aa_transaction.go
+++ b/core/types/aa_transaction.go
@@ -568,10 +568,10 @@ func (tx *AccountAbstractionTransaction) PreTransactionGasCost() (uint64, error)
 
 	// data should have tx.Authorizations, tx.DeployerData, tx.ExecutionData, tx.PaymasterData
 	data := make([]byte, len(authorizationsBytes.Bytes())+len(tx.DeployerData)+len(tx.ExecutionData)+len(tx.PaymasterData))
-	data = append(data, authorizationsBytes.Bytes()...)
-	data = append(data, tx.DeployerData...)
-	data = append(data, tx.ExecutionData...)
-	data = append(data, tx.PaymasterData...)
+	data = append(data, authorizationsBytes.Bytes()...)                                                                                                                            // nozero
+	data = append(data, tx.DeployerData...)                                                                                                                                        // nozero
+	data = append(data, tx.ExecutionData...)                                                                                                                                       // nozero
+	data = append(data, tx.PaymasterData...)                                                                                                                                       // nozero
 	gas, _, overflow := fixedgas.IntrinsicGas(data, uint64(len(tx.AccessList)), uint64(tx.AccessList.StorageKeys()), true, true, true, true, true, uint64(len(tx.Authorizations))) // NOTE: should read homestead and 2028 config from chainconfig
 
 	if overflow {

--- a/p2p/enr/enr.go
+++ b/p2p/enr/enr.go
@@ -148,12 +148,12 @@ func (r *Record) Set(e Entry) {
 	case i < len(r.pairs):
 		// insert pair before i-th elem
 		el := pair{e.ENRKey(), blob}
-		pairs = append(pairs, pair{})
+		pairs = append(pairs, pair{}) // nozero
 		copy(pairs[i+1:], pairs[i:])
 		pairs[i] = el
 	default:
 		// element should be placed at the end of r.pairs
-		pairs = append(pairs, pair{e.ENRKey(), blob})
+		pairs = append(pairs, pair{e.ENRKey(), blob}) // nozero
 	}
 	r.pairs = pairs
 }

--- a/p2p/rlpx/rlpx.go
+++ b/p2p/rlpx/rlpx.go
@@ -637,11 +637,11 @@ func (h *handshakeState) sealEIP8(msg interface{}) ([]byte, error) {
 	// the message distinguishable from pre-EIP-8 handshakes.
 	h.wbuf.appendZero(mrand.Intn(100) + 100) //nolint:gosec
 
-	prefix := make([]byte, 2)
+	prefix := make([]byte, 2) // nozero
 	binary.BigEndian.PutUint16(prefix, uint16(len(h.wbuf.data)+eciesOverhead))
 
 	enc, err := ecies.Encrypt(rand.Reader, h.remote, h.wbuf.data, nil, prefix)
-	return append(prefix, enc...), err
+	return append(prefix, enc...), err // nozero
 }
 
 // importPublicKey unmarshals 64 or 65 bytes long public keys.

--- a/turbo/cmdtest/test_cmd.go
+++ b/turbo/cmdtest/test_cmd.go
@@ -137,7 +137,7 @@ func (tt *TestCmd) matchExactOutput(want []byte) error {
 	if n < len(want) || !bytes.Equal(buf, want) {
 		// Grab any additional buffered output in case of mismatch
 		// because it might help with debugging.
-		buf = append(buf, make([]byte, tt.stdout.Buffered())...)
+		buf = append(buf, make([]byte, tt.stdout.Buffered())...) // nozero
 		tt.stdout.Read(buf[n:])
 		// Find the mismatch position.
 		for i := 0; i < n; i++ {


### PR DESCRIPTION
#Enabled makezero Linter

Enabled the makezero linter across multiple packages to enforce best practices for zero-value assignments. Updated relevant code in the following packages:

- enr
- rplx
- abi
- merkle_tree
- base_encoding
- cmdtest
- types

Ensured existing functionality remains unchanged.