### PR TITLE
consensus: engine to close consensus db for AuRa and Clique

### DIFF
--- a/consensus/aura/aura.go
+++ b/consensus/aura/aura.go
@@ -242,6 +242,7 @@ type AuRa struct {
 
 	certifier     *libcommon.Address // certifies service transactions
 	certifierLock sync.Mutex
+	db            kv.RwDB
 }
 
 func NewAuRa(spec *chain.AuRaConfig, db kv.RwDB) (*AuRa, error) {
@@ -317,6 +318,7 @@ func NewAuRa(spec *chain.AuRaConfig, db kv.RwDB) (*AuRa, error) {
 		cfg:                auraParams,
 		receivedStepHashes: ReceivedStepHashes{},
 		EpochManager:       NewEpochManager(),
+		db:                 db,
 	}
 	c.step.canPropose.Store(true)
 
@@ -1040,6 +1042,7 @@ func (c *AuRa) IsServiceTransaction(sender libcommon.Address, syscall consensus.
 
 // Close implements consensus.Engine. It's a noop for clique as there are no background threads.
 func (c *AuRa) Close() error {
+	c.db.Close()
 	libcommon.SafeClose(c.exitCh)
 	return nil
 }

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -514,6 +514,7 @@ func (c *Clique) IsServiceTransaction(sender libcommon.Address, syscall consensu
 
 // Close implements consensus.Engine. It's a noop for clique as there are no background threads.
 func (c *Clique) Close() error {
+	c.DB.Close()
 	libcommon.SafeClose(c.exitCh)
 	return nil
 }


### PR DESCRIPTION
found in https://github.com/erigontech/erigon/pull/13983
we aren't closing consensus db for AuRa and Clique 
this PR adds this as part of Engine.Close (consensus engine is the owner of the consensus db so makes sense to do it there; also Bor already does it there)