### PR TITLE
contracts: add jsonrpc backend

### DIFF
--- a/cmd/devnet/requests/transaction.go
+++ b/cmd/devnet/requests/transaction.go
@@ -103,7 +103,6 @@ func (reqGen *requestGenerator) EstimateGas(args ethereum.CallMsg, blockRef Bloc
 		return 0, fmt.Errorf("EstimateGas rpc failed: %w", b.Error)
 	}
 
-	fmt.Println("EST GAS", b.Number)
 	return uint64(b.Number), nil
 }
 

--- a/contracts/jsonrpc_backend.go
+++ b/contracts/jsonrpc_backend.go
@@ -1,0 +1,80 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package contracts
+
+import (
+	"context"
+	"math/big"
+
+	ethereum "github.com/erigontech/erigon"
+	libcommon "github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/log/v3"
+	"github.com/erigontech/erigon/cmd/devnet/requests"
+	"github.com/erigontech/erigon/core/types"
+	"github.com/erigontech/erigon/rpc"
+)
+
+func NewJsonRpcBackend(url string, logger log.Logger) JsonRpcBackend {
+	return JsonRpcBackend{
+		client: requests.NewRequestGenerator(url, logger),
+	}
+}
+
+type JsonRpcBackend struct {
+	client requests.RequestGenerator
+}
+
+func (b JsonRpcBackend) CodeAt(ctx context.Context, contract libcommon.Address, blockNum *big.Int) ([]byte, error) {
+	return b.client.GetCode(contract, rpc.BlockReference(BlockNumArg(blockNum)))
+}
+
+func (b JsonRpcBackend) CallContract(ctx context.Context, call ethereum.CallMsg, blockNum *big.Int) ([]byte, error) {
+	return b.client.Call(CallArgsFromCallMsg(call), rpc.BlockReference(BlockNumArg(blockNum)), nil)
+}
+
+func (b JsonRpcBackend) PendingCodeAt(ctx context.Context, account libcommon.Address) ([]byte, error) {
+	return b.client.GetCode(account, rpc.PendingBlock)
+}
+
+func (b JsonRpcBackend) PendingNonceAt(ctx context.Context, account libcommon.Address) (uint64, error) {
+	res, err := b.client.GetTransactionCount(account, rpc.PendingBlock)
+	if err != nil {
+		return 0, err
+	}
+	return res.Uint64(), nil
+}
+
+func (b JsonRpcBackend) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
+	return b.client.GasPrice()
+}
+
+func (b JsonRpcBackend) EstimateGas(ctx context.Context, call ethereum.CallMsg) (uint64, error) {
+	return b.client.EstimateGas(call, requests.BlockNumbers.Pending)
+}
+
+func (b JsonRpcBackend) SendTransaction(ctx context.Context, txn types.Transaction) error {
+	_, err := b.client.SendTransaction(txn)
+	return err
+}
+
+func (b JsonRpcBackend) FilterLogs(ctx context.Context, query ethereum.FilterQuery) ([]types.Log, error) {
+	return b.client.FilterLogs(ctx, query)
+}
+
+func (b JsonRpcBackend) SubscribeFilterLogs(ctx context.Context, query ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
+	return b.client.SubscribeFilterLogs(ctx, query, ch)
+}


### PR DESCRIPTION
used in https://github.com/erigontech/erigon/pull/13983 
taking a cohesive unit of logic out of the bigger PR for ease of reviewing
a jsonrpc based contracts backend is something that will be useful for future use cases, hence putting in the `contracts` pkg 
