### PR TITLE
engineapi: add jsonrpc client

### DIFF
--- a/cl/phase1/execution_client/execution_client_rpc.go
+++ b/cl/phase1/execution_client/execution_client_rpc.go
@@ -25,11 +25,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/erigontech/erigon-lib/common/hexutil"
-
-	"github.com/erigontech/erigon-lib/log/v3"
-
 	libcommon "github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/common/hexutil"
+	"github.com/erigontech/erigon-lib/jwt"
+	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/phase1/execution_client/rpc_helper"
@@ -47,7 +46,7 @@ type ExecutionClientRpc struct {
 }
 
 func NewExecutionClientRPC(jwtSecret []byte, addr string, port int) (*ExecutionClientRpc, error) {
-	roundTripper := rpc_helper.NewJWTRoundTripper(jwtSecret)
+	roundTripper := jwt.NewHttpRoundTripper(http.DefaultTransport, jwtSecret)
 	client := &http.Client{Timeout: DefaultRPCHTTPTimeout, Transport: roundTripper}
 
 	isHTTPpecified := strings.HasPrefix(addr, "http")

--- a/erigon-lib/go.mod
+++ b/erigon-lib/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/erigontech/speedtest v0.0.2
 	github.com/go-stack/stack v1.8.1
 	github.com/gofrs/flock v0.12.1
+	github.com/golang-jwt/jwt/v4 v4.5.1
 	github.com/google/btree v1.1.3
 	github.com/gorilla/websocket v1.5.3
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0

--- a/erigon-lib/go.sum
+++ b/erigon-lib/go.sum
@@ -209,6 +209,8 @@ github.com/gofrs/flock v0.12.1/go.mod h1:9zxTsyu5xtJ9DK+1tFZyibEV7y3uwDxPPfbxeeH
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v4 v4.5.1 h1:JdqV9zKUdtaa9gdPlywC3aeoEsR681PlKC+4F5gQgeo=
+github.com/golang-jwt/jwt/v4 v4.5.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/erigon-lib/jwt/http_round_tripper.go
+++ b/erigon-lib/jwt/http_round_tripper.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Erigon. If not, see <http://www.gnu.org/licenses/>.
 
-package rpc_helper
+package jwt
 
 import (
 	"fmt"
@@ -24,16 +24,16 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 )
 
-type JWTRoundTripper struct {
-	underlyingTransport http.RoundTripper
-	jwtSecret           []byte
+type HttpRoundTripper struct {
+	base      http.RoundTripper
+	jwtSecret []byte
 }
 
-func NewJWTRoundTripper(jwtSecret []byte) *JWTRoundTripper {
-	return &JWTRoundTripper{underlyingTransport: http.DefaultTransport, jwtSecret: jwtSecret}
+func NewHttpRoundTripper(base http.RoundTripper, jwtSecret []byte) *HttpRoundTripper {
+	return &HttpRoundTripper{base: base, jwtSecret: jwtSecret}
 }
 
-func (t *JWTRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+func (t *HttpRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"iat": time.Now().Unix(),
 	})
@@ -44,5 +44,5 @@ func (t *JWTRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	req.Header.Set("Authorization", "Bearer "+tokenString)
-	return t.underlyingTransport.RoundTrip(req)
+	return t.base.RoundTrip(req)
 }

--- a/turbo/engineapi/engine_api_jsonrpc_client.go
+++ b/turbo/engineapi/engine_api_jsonrpc_client.go
@@ -1,0 +1,209 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package engineapi
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	libcommon "github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/common/hexutil"
+	"github.com/erigontech/erigon-lib/jwt"
+	"github.com/erigontech/erigon-lib/log/v3"
+	"github.com/erigontech/erigon/rpc"
+	enginetypes "github.com/erigontech/erigon/turbo/engineapi/engine_types"
+)
+
+type JsonRpcClient struct {
+	rpcClient *rpc.Client
+}
+
+func DialJsonRpcClient(url string, jwtSecret []byte, logger log.Logger) (*JsonRpcClient, error) {
+	jwtRoundTripper := jwt.NewHttpRoundTripper(http.DefaultTransport, jwtSecret)
+	httpClient := &http.Client{Timeout: 30 * time.Second, Transport: jwtRoundTripper}
+	client, err := rpc.DialHTTPWithClient(url, httpClient, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	return &JsonRpcClient{rpcClient: client}, nil
+}
+
+func (c *JsonRpcClient) NewPayloadV1(ctx context.Context, payload *enginetypes.ExecutionPayload) (*enginetypes.PayloadStatus, error) {
+	var result enginetypes.PayloadStatus
+	err := c.rpcClient.CallContext(ctx, &result, "engine_newPayloadV1", payload)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *JsonRpcClient) NewPayloadV2(ctx context.Context, payload *enginetypes.ExecutionPayload) (*enginetypes.PayloadStatus, error) {
+	var result enginetypes.PayloadStatus
+	err := c.rpcClient.CallContext(ctx, &result, "engine_newPayloadV2", payload)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *JsonRpcClient) NewPayloadV3(
+	ctx context.Context,
+	executionPayload *enginetypes.ExecutionPayload,
+	expectedBlobHashes []libcommon.Hash,
+	parentBeaconBlockRoot *libcommon.Hash,
+) (*enginetypes.PayloadStatus, error) {
+	var result enginetypes.PayloadStatus
+	err := c.rpcClient.CallContext(
+		ctx,
+		&result,
+		"engine_newPayloadV3",
+		executionPayload,
+		expectedBlobHashes,
+		parentBeaconBlockRoot,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *JsonRpcClient) NewPayloadV4(
+	ctx context.Context,
+	executionPayload *enginetypes.ExecutionPayload,
+	expectedBlobHashes []libcommon.Hash,
+	parentBeaconBlockRoot *libcommon.Hash,
+	executionRequests []hexutil.Bytes,
+) (*enginetypes.PayloadStatus, error) {
+	var result enginetypes.PayloadStatus
+	err := c.rpcClient.CallContext(
+		ctx,
+		&result,
+		"engine_newPayloadV4",
+		executionPayload,
+		expectedBlobHashes,
+		parentBeaconBlockRoot,
+		executionRequests,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *JsonRpcClient) ForkchoiceUpdatedV1(
+	ctx context.Context,
+	forkChoiceState *enginetypes.ForkChoiceState,
+	payloadAttributes *enginetypes.PayloadAttributes,
+) (*enginetypes.ForkChoiceUpdatedResponse, error) {
+	var result enginetypes.ForkChoiceUpdatedResponse
+	err := c.rpcClient.CallContext(ctx, &result, "engine_forkchoiceUpdatedV1", forkChoiceState, payloadAttributes)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *JsonRpcClient) ForkchoiceUpdatedV2(
+	ctx context.Context,
+	forkChoiceState *enginetypes.ForkChoiceState,
+	payloadAttributes *enginetypes.PayloadAttributes,
+) (*enginetypes.ForkChoiceUpdatedResponse, error) {
+	var result enginetypes.ForkChoiceUpdatedResponse
+	err := c.rpcClient.CallContext(ctx, &result, "engine_forkchoiceUpdatedV2", forkChoiceState, payloadAttributes)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *JsonRpcClient) ForkchoiceUpdatedV3(
+	ctx context.Context,
+	forkChoiceState *enginetypes.ForkChoiceState,
+	payloadAttributes *enginetypes.PayloadAttributes,
+) (*enginetypes.ForkChoiceUpdatedResponse, error) {
+	var result enginetypes.ForkChoiceUpdatedResponse
+	err := c.rpcClient.CallContext(ctx, &result, "engine_forkchoiceUpdatedV3", forkChoiceState, payloadAttributes)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *JsonRpcClient) GetPayloadV1(ctx context.Context, payloadID hexutil.Bytes) (*enginetypes.ExecutionPayload, error) {
+	var result enginetypes.ExecutionPayload
+	err := c.rpcClient.CallContext(ctx, &result, "engine_getPayloadV1", payloadID)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *JsonRpcClient) GetPayloadV2(ctx context.Context, payloadID hexutil.Bytes) (*enginetypes.GetPayloadResponse, error) {
+	var result enginetypes.GetPayloadResponse
+	err := c.rpcClient.CallContext(ctx, &result, "engine_getPayloadV2", payloadID)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *JsonRpcClient) GetPayloadV3(ctx context.Context, payloadID hexutil.Bytes) (*enginetypes.GetPayloadResponse, error) {
+	var result enginetypes.GetPayloadResponse
+	err := c.rpcClient.CallContext(ctx, &result, "engine_getPayloadV3", payloadID)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *JsonRpcClient) GetPayloadV4(ctx context.Context, payloadID hexutil.Bytes) (*enginetypes.GetPayloadResponse, error) {
+	var result enginetypes.GetPayloadResponse
+	err := c.rpcClient.CallContext(ctx, &result, "engine_getPayloadV4", payloadID)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *JsonRpcClient) GetPayloadBodiesByHashV1(ctx context.Context, hashes []libcommon.Hash) ([]*enginetypes.ExecutionPayloadBody, error) {
+	var result []*enginetypes.ExecutionPayloadBody
+	err := c.rpcClient.CallContext(ctx, &result, "engine_getPayloadBodiesByHashV1", hashes)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *JsonRpcClient) GetPayloadBodiesByRangeV1(ctx context.Context, start, count hexutil.Uint64) ([]*enginetypes.ExecutionPayloadBody, error) {
+	var result []*enginetypes.ExecutionPayloadBody
+	err := c.rpcClient.CallContext(ctx, &result, "engine_getPayloadBodiesByRangeV1", start, count)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *JsonRpcClient) GetClientVersionV1(ctx context.Context, callerVersion *enginetypes.ClientVersionV1) ([]enginetypes.ClientVersionV1, error) {
+	var result []enginetypes.ClientVersionV1
+	err := c.rpcClient.CallContext(ctx, &result, "engine_getClientVersionV1", callerVersion)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/turbo/engineapi/engine_types/jsonrpc.go
+++ b/turbo/engineapi/engine_types/jsonrpc.go
@@ -133,14 +133,26 @@ func NewStringifiedErrorFromString(err string) *StringifiedError {
 	return &StringifiedError{err: errors.New(err)}
 }
 
-func (e StringifiedError) MarshalJSON() ([]byte, error) {
+func (e *StringifiedError) MarshalJSON() ([]byte, error) {
 	if e.err == nil {
 		return json.Marshal(nil)
 	}
 	return json.Marshal(e.err.Error())
 }
 
-func (e StringifiedError) Error() error {
+func (e *StringifiedError) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || string(data) == "null" {
+		return nil
+	}
+	var errStr string
+	if err := json.Unmarshal(data, &errStr); err != nil {
+		return err
+	}
+	e.err = errors.New(errStr)
+	return nil
+}
+
+func (e *StringifiedError) Error() error {
 	return e.err
 }
 


### PR DESCRIPTION
used in https://github.com/erigontech/erigon/pull/13983
taking a cohesive unit of logic out of the bigger PR for ease of reviewing
adds a json rpc client for interacting with the engine api

the gist is:
- we have an integration test which starts up Erigon as EL only
- we drive Erigon with a MockCl
- in order to be able to drive Erigon we need to access it's engine api json rpc (for this we need an engine api client)
- analogous to that, we need a json rpc api client for the rpcdaemon publicly exposed apis (e.g. the "eth_" namespace, "debug_", etc.)
- this is a black box test where we feed Erigon inputs via the public api surface and check the end result again via the public api surface