### PR TITLE
engineapi, txpool: Fix `engine_getBlobsV1` nil response

### DIFF
--- a/turbo/engineapi/engine_api_methods.go
+++ b/turbo/engineapi/engine_api_methods.go
@@ -28,6 +28,7 @@ var ourCapabilities = []string{
 	"engine_getPayloadBodiesByHashV1",
 	"engine_getPayloadBodiesByRangeV1",
 	"engine_getClientVersionV1",
+	"engine_getBlobsV1",
 }
 
 // Returns the most recent version of the payload(for the payloadID) at the time of receiving the call
@@ -169,7 +170,16 @@ func (e *EngineServer) ExchangeCapabilities(fromCl []string) []string {
 }
 
 func (e *EngineServer) GetBlobsV1(ctx context.Context, blobHashes []libcommon.Hash) ([]*txpoolproto.BlobAndProofV1, error) {
-	e.logger.Debug("[engine_getBlobsV1] Received Reuqust", "hashes", len(blobHashes))
-	return e.getBlobs(ctx, blobHashes)
+	e.logger.Debug("[GetBlobsV1] Received Request", "hashes", len(blobHashes))
+	res, err := e.getBlobs(ctx, blobHashes)
+	e.logger.Debug("[GetBlobsV1] Received Response",)
+	for i, r := range res {
+		if r != nil {
+			e.logger.Debug("- ", "hash", blobHashes[i], "len(blob)", len(r.Blob), "len(r.Proof)", len(r.Proof))
+		} else {
+			e.logger.Debug("- nil")
+		}
+	}
+	return res, err
 
 }

--- a/turbo/engineapi/engine_api_methods.go
+++ b/turbo/engineapi/engine_api_methods.go
@@ -172,7 +172,7 @@ func (e *EngineServer) ExchangeCapabilities(fromCl []string) []string {
 func (e *EngineServer) GetBlobsV1(ctx context.Context, blobHashes []libcommon.Hash) ([]*txpoolproto.BlobAndProofV1, error) {
 	e.logger.Debug("[GetBlobsV1] Received Request", "hashes", len(blobHashes))
 	res, err := e.getBlobs(ctx, blobHashes)
-	e.logger.Debug("[GetBlobsV1] Received Response",)
+	e.logger.Debug("[GetBlobsV1] Received Response")
 	for i, r := range res {
 		if r != nil {
 			e.logger.Debug("- ", "hash", blobHashes[i], "len(blob)", len(r.Blob), "len(r.Proof)", len(r.Proof))

--- a/turbo/engineapi/engine_server_test.go
+++ b/turbo/engineapi/engine_server_test.go
@@ -119,7 +119,7 @@ func TestGetBlobsV1(t *testing.T) {
 	_, err = api.SendRawTransaction(ctx, buf.Bytes())
 	require.NoError(err)
 
-	blobHashes := append([]common.Hash{common.Hash{}}, wrappedTxn.Tx.BlobVersionedHashes... )
+	blobHashes := append([]common.Hash{{}}, wrappedTxn.Tx.BlobVersionedHashes...)
 	blobsResp, err := engineServer.GetBlobsV1(ctx, blobHashes)
 	require.NoError(err)
 	require.True(blobsResp[0] == nil)

--- a/turbo/engineapi/engine_server_test.go
+++ b/turbo/engineapi/engine_server_test.go
@@ -119,10 +119,12 @@ func TestGetBlobsV1(t *testing.T) {
 	_, err = api.SendRawTransaction(ctx, buf.Bytes())
 	require.NoError(err)
 
-	blobsResp, err := engineServer.GetBlobsV1(ctx, wrappedTxn.Tx.BlobVersionedHashes)
+	blobHashes := append([]common.Hash{common.Hash{}}, wrappedTxn.Tx.BlobVersionedHashes... )
+	blobsResp, err := engineServer.GetBlobsV1(ctx, blobHashes)
 	require.NoError(err)
-	require.Equal(blobsResp[0].Blob, wrappedTxn.Blobs[0][:])
-	require.Equal(blobsResp[1].Blob, wrappedTxn.Blobs[1][:])
-	require.Equal(blobsResp[0].Proof, wrappedTxn.Proofs[0][:])
-	require.Equal(blobsResp[1].Proof, wrappedTxn.Proofs[1][:])
+	require.True(blobsResp[0] == nil)
+	require.Equal(blobsResp[1].Blob, wrappedTxn.Blobs[0][:])
+	require.Equal(blobsResp[2].Blob, wrappedTxn.Blobs[1][:])
+	require.Equal(blobsResp[1].Proof, wrappedTxn.Proofs[0][:])
+	require.Equal(blobsResp[2].Proof, wrappedTxn.Proofs[1][:])
 }

--- a/txnprovider/txpool/txpool_grpc_server.go
+++ b/txnprovider/txpool/txpool_grpc_server.go
@@ -240,9 +240,13 @@ func (s *GrpcServer) GetBlobs(ctx context.Context, in *txpool_proto.GetBlobsRequ
 	}
 	blobs, proofs := s.txPool.GetBlobs(hashes)
 	reply := &txpool_proto.GetBlobsReply{BlobsAndProofs: make([]*txpool_proto.BlobAndProofV1, len(blobs))}
-
+	blobsAndProofs := make([]*txpool_proto.BlobAndProofV1, len(blobs))
 	for i := range blobs {
-		reply.BlobsAndProofs[i] = &txpool_proto.BlobAndProofV1{Blob: blobs[i], Proof: proofs[i]}
+		if blobs[i] == nil || proofs[i] == nil {
+			blobsAndProofs[i] = nil
+		} else {
+			reply.BlobsAndProofs[i] = &txpool_proto.BlobAndProofV1{Blob: blobs[i], Proof: proofs[i]}
+		}
 	}
 	return reply, nil
 }


### PR DESCRIPTION
Fix an issue where the response would contain non-nil items with nil blob bytes when blobHash not found in the pool