### PR TITLE
Cherry-Pick: More user-friendly logging (#14226)

### DIFF
--- a/cl/phase1/stages/forward_sync.go
+++ b/cl/phase1/stages/forward_sync.go
@@ -144,7 +144,6 @@ func processDownloadedBlockBatches(ctx context.Context, logger log.Logger, cfg *
 
 		// Process the block
 		if err = processBlock(ctx, cfg, cfg.indiciesDB, block, false, true, true); err != nil {
-			fmt.Println("EIP-4844 data not available", err, block.Block.Slot)
 			if errors.Is(err, forkchoice.ErrEIP4844DataNotAvailable) {
 				// Return an error if EIP-4844 data is not available
 				logger.Trace("[Caplin] forward sync EIP-4844 data not available", "blockSlot", block.Block.Slot)
@@ -243,6 +242,9 @@ func forwardSync(ctx context.Context, logger log.Logger, cfg *Cfg, args Args) er
 			estimatedTimeRemaining := 999 * time.Hour
 			if timeProgress > 0 {
 				estimatedTimeRemaining = time.Duration(float64(progressMade)/(float64(currentSlot.Load()-prevProgress)/float64(secsPerLog))) * time.Second
+			}
+			if distFromChainTip < 0 || estimatedTimeRemaining < 0 {
+				continue
 			}
 			prevProgress = currentSlot.Load()
 			logger.Info("[Caplin] Forward Sync", "progress", currentSlot.Load(), "distance-from-chain-tip", distFromChainTip, "estimated-time-remaining", estimatedTimeRemaining)

--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -91,11 +91,15 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 		cfg.caplinConfig.ArchiveBlocks = false // disable backfilling if not on a supported network
 	}
 
+	var hasFinishedDownloadingElBlocks atomic.Bool
+
 	// Start the procedure
 	logger.Info("Starting downloading History", "from", currentSlot)
 	// Setup slot and block root
 	cfg.downloader.SetSlotToDownload(currentSlot)
 	cfg.downloader.SetExpectedRoot(blockRoot)
+
+	var initialBeaconBlock *cltypes.SignedBeaconBlock
 
 	var currEth1Progress atomic.Int64
 
@@ -115,6 +119,10 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 			currEth1Progress.Store(int64(blk.Block.Body.ExecutionPayload.BlockNumber))
 		}
 
+		if initialBeaconBlock == nil {
+			initialBeaconBlock = blk
+		}
+
 		slot := blk.Block.Slot
 		isInCLSnapshots := cfg.sn.SegmentsMax() > blk.Block.Slot
 		// Skip blocks that are already in the snapshots
@@ -130,6 +138,7 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 			blocksToDownload := cfg.beaconCfg.MinSlotsForBlobsSidecarsRequest() * 2
 			hasDownloadEnoughForImmediateBlobsBackfilling = cfg.startingSlot < blocksToDownload || slot > cfg.startingSlot-blocksToDownload
 		}
+
 		if cfg.engine != nil && cfg.engine.SupportInsertion() && blk.Version() >= clparams.BellatrixVersion {
 			frozenBlocksInEL := cfg.engine.FrozenBlocks(ctx)
 
@@ -153,6 +162,9 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 			if hasELBlock && !cfg.caplinConfig.ArchiveBlocks {
 				return hasDownloadEnoughForImmediateBlobsBackfilling, tx.Commit()
 			}
+			hasFinishedDownloadingElBlocks.Store(hasELBlock)
+		} else {
+			hasFinishedDownloadingElBlocks.Store(true)
 		}
 		isInElSnapshots := true
 		if blk.Version() >= clparams.BellatrixVersion && cfg.engine != nil && cfg.engine.SupportInsertion() {
@@ -202,26 +214,59 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 				speed := blockProgress / ratio
 				prevProgress = currProgress
 
-				if speed == 0 {
+				if speed == 0 || initialBeaconBlock == nil {
 					continue
 				}
+
 				if cfg.sn != nil && cfg.sn.SegmentsMax() == 0 {
 					cfg.sn.OpenFolder()
 				}
+
+				highestBlockSeen := initialBeaconBlock.Block.Slot
+				lowestBlockToReach := cfg.sn.SegmentsMax()
+
 				logArgs = append(logArgs,
 					"slot", currProgress,
 					"blockNumber", currEth1Progress.Load(),
 					"blk/sec", fmt.Sprintf("%.1f", speed),
 					"snapshots", cfg.sn.SegmentsMax(),
 				)
+
+				isDownloadingForBeacon := (hasFinishedDownloadingElBlocks.Load() || cfg.caplinConfig.ArchiveBlocks) && clparams.SupportBackfilling(cfg.beaconCfg.DepositNetworkID)
+
 				if cfg.engine != nil && cfg.engine.SupportInsertion() {
 					logArgs = append(logArgs, "frozenBlocks", cfg.engine.FrozenBlocks(ctx))
+					if !isDownloadingForBeacon {
+						// If we are not backfilling, we are in the EL phase
+						highestBlockSeen = initialBeaconBlock.Block.Body.ExecutionPayload.BlockNumber
+
+						h, err := cfg.engine.CurrentHeader(ctx)
+						if err != nil || h == nil {
+							log.Debug("could not log progress", "err", err)
+							lowestBlockToReach = cfg.engine.FrozenBlocks(ctx)
+						} else {
+							lowestBlockToReach = h.Number.Uint64()
+						}
+					}
 				}
+
 				logMsg := "Node is still syncing... downloading past blocks"
 				if isBackfilling.Load() {
 					logMsg = "Node has finished syncing... full history is being downloaded for archiving purposes"
 				}
-				logger.Info(logMsg, logArgs...)
+				// Log the progress for debugging
+				logger.Debug(logMsg, logArgs...)
+
+				if !isDownloadingForBeacon {
+					log.Info("Downloading Execution History", "progress",
+						fmt.Sprintf("%d/%d", highestBlockSeen-uint64(currEth1Progress.Load()), highestBlockSeen-lowestBlockToReach),
+						"blk/sec", fmt.Sprintf("%.1f", speed))
+				} else {
+					log.Info("Downloading Beacon History", "progress",
+						fmt.Sprintf("%d/%d", highestBlockSeen-currProgress, highestBlockSeen-lowestBlockToReach),
+						"blk/sec", fmt.Sprintf("%.1f", speed))
+				}
+				// More UX-friendly logging
 			case <-finishCh:
 				return
 			case <-ctx.Done():
@@ -238,11 +283,8 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 			}
 		}
 		cfg.antiquary.NotifyBackfilled()
-		fmt.Println(cfg.caplinConfig.ArchiveBlocks)
 		if cfg.caplinConfig.ArchiveBlocks {
 			cfg.logger.Info("Full backfilling finished")
-		} else {
-			cfg.logger.Info("Missing blocks download finished (note: this does not mean that the history is complete, only that the missing blocks need for sync have been downloaded)")
 		}
 
 		close(finishCh)


### PR DESCRIPTION
- Removed logging of println around the code
- Made better and more readable loggings of downloading history
- Filtered out bad logs in `ForwardSync`