### PR TITLE
fix(docs): correct broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ Quote your path if it has spaces.
 
 ### Dev Chain
 
-<code> 🔬 Detailed explanation is [DEV_CHAIN](/DEV_CHAIN.md).</code>
+<code> 🔬 Detailed explanation is [DEV_CHAIN](/docs/DEV_CHAIN.md).</code>
 
 Key features
 ============


### PR DESCRIPTION
The link to DEV_CHAIN.md in README.md was pointing to the root directory, but the file is located in the `docs` subdirectory.

This commit updates the link to point to the correct location:

- From: `[DEV_CHAIN](/DEV_CHAIN.md)`
- To:   `[DEV_CHAIN](/docs/DEV_CHAIN.md)`