### PR TITLE
Move DefaultSnapshotGitBranch into version.go

### DIFF
--- a/RELEASE_INSTRUCTIONS.md
+++ b/RELEASE_INSTRUCTIONS.md
@@ -32,10 +32,17 @@ In the file `ethdb/remote/remotedbserver/server.go` there is variable `KvService
 database schema, leading to data migrations.
 In most cases, it is enough to bump minor version. It is best to change both DB schema version and remove KV version together.
 
-## Purify the state domains if a regenration is done
+## Purify the state domains if a regeneration is done
 
-If a regenration is done, the state domains need to be purified. This can be done by running the following command:
+If a regeneration is done, the state domains need to be purified. This can be done by running the following command:
 ````
 make integration
 ./build/bin/integration purify_domains --datadir=<path to datadir> --replace-in-datadir
 ````
+
+## Update version.go
+
+After a release branch has been created, update `erigon-lib/version/version.go`.
+Let's say you're releasing Erigon v3.1.0.
+Then in branch `release/3.1` of [erigon](https://github.com/erigontech/erigon) set `Major = 3`, `Minor = 1`, `Patch = 0`, `Modifier = ""`, and `DefaultSnapshotGitBranch = "release/3.1"`. (Don't forget to create branch `release/3.1` of [erigon-snapshot](https://github.com/erigontech/erigon-snapshot).)
+In branch `main` of [erigon](https://github.com/erigontech/erigon) set `Major = 3`, `Minor = 2`, `Patch = 0`, `Modifier = "dev"`, and `DefaultSnapshotGitBranch = "main"`.

--- a/cmd/erigon/main.go
+++ b/cmd/erigon/main.go
@@ -23,11 +23,11 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	"github.com/erigontech/erigon-lib/log/v3"
-
 	"github.com/erigontech/erigon-lib/common/datadir"
 	"github.com/erigontech/erigon-lib/common/dbg"
+	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon-lib/metrics"
+	"github.com/erigontech/erigon-lib/version"
 	"github.com/erigontech/erigon/diagnostics"
 	"github.com/erigontech/erigon/params"
 	erigonapp "github.com/erigontech/erigon/turbo/app"
@@ -70,7 +70,7 @@ func runErigon(cliCtx *cli.Context) error {
 	// initializing the node and providing the current git commit there
 
 	logger.Info("Build info", "git_branch", params.GitBranch, "git_tag", params.GitTag, "git_commit", params.GitCommit)
-	if params.VersionMajor == 3 {
+	if version.Major == 3 {
 		logger.Info(`
 	########b          oo                               d####b. 
 	##                                                      '## 

--- a/erigon-lib/chain/snapcfg/util.go
+++ b/erigon-lib/chain/snapcfg/util.go
@@ -26,9 +26,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/pelletier/go-toml/v2"
+	"github.com/pkg/errors"
 	"github.com/tidwall/btree"
 
 	snapshothashes "github.com/erigontech/erigon-snapshot"
@@ -37,12 +36,10 @@ import (
 	"github.com/erigontech/erigon-lib/chain/networkname"
 	"github.com/erigontech/erigon-lib/common/dbg"
 	"github.com/erigontech/erigon-lib/downloader/snaptype"
+	"github.com/erigontech/erigon-lib/version"
 )
 
-// TODO(yperbasis) move into params/version.go
-const DefaultSnapshotGitBranch = "main"
-
-var snapshotGitBranch = dbg.EnvString("SNAPS_GIT_BRANCH", DefaultSnapshotGitBranch)
+var snapshotGitBranch = dbg.EnvString("SNAPS_GIT_BRANCH", version.DefaultSnapshotGitBranch)
 
 var (
 	Mainnet    = fromToml(snapshothashes.Mainnet)

--- a/erigon-lib/version/version.go
+++ b/erigon-lib/version/version.go
@@ -1,0 +1,25 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package version
+
+// see https://calver.org
+const (
+	Major    = 3     // Major version component of the current release
+	Minor    = 1     // Minor version component of the current release
+	Micro    = 0     // Patch version component of the current release
+	Modifier = "dev" // Modifier component of the current release
+)

--- a/erigon-lib/version/version.go
+++ b/erigon-lib/version/version.go
@@ -18,8 +18,9 @@ package version
 
 // see https://calver.org
 const (
-	Major    = 3     // Major version component of the current release
-	Minor    = 1     // Minor version component of the current release
-	Micro    = 0     // Patch version component of the current release
-	Modifier = "dev" // Modifier component of the current release
+	Major                    = 3      // Major version component of the current release
+	Minor                    = 1      // Minor version component of the current release
+	Micro                    = 0      // Patch version component of the current release
+	Modifier                 = "dev"  // Modifier component of the current release
+	DefaultSnapshotGitBranch = "main" // Branch of erigontech/erigon-snapshot to use in OtterSync
 )

--- a/params/version.go
+++ b/params/version.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/erigontech/erigon-lib/kv"
+	"github.com/erigontech/erigon-lib/version"
 )
 
 var (
@@ -32,12 +33,7 @@ var (
 	GitTag    string
 )
 
-// see https://calver.org
 const (
-	VersionMajor       = 3     // Major version component of the current release
-	VersionMinor       = 1     // Minor version component of the current release
-	VersionMicro       = 0     // Patch version component of the current release
-	VersionModifier    = "dev" // Modifier component of the current release
 	VersionKeyCreated  = "ErigonVersionCreated"
 	VersionKeyFinished = "ErigonVersionFinished"
 	ClientName         = "erigon"
@@ -46,14 +42,14 @@ const (
 
 // Version holds the textual version string.
 var Version = func() string {
-	return fmt.Sprintf("%d.%02d.%d", VersionMajor, VersionMinor, VersionMicro)
+	return fmt.Sprintf("%d.%02d.%d", version.Major, version.Minor, version.Micro)
 }()
 
 // VersionWithMeta holds the textual version string including the metadata.
 var VersionWithMeta = func() string {
 	v := Version
-	if VersionModifier != "" {
-		v += "-" + VersionModifier
+	if version.Modifier != "" {
+		v += "-" + version.Modifier
 	}
 	return v
 }()


### PR DESCRIPTION
Rationale: `DefaultSnapshotGitBranch` should be updated alongside the version when a release branch is forked.