### PR TITLE
qa-tests/dispatch test wf to qa runners 3.0

### DIFF
--- a/.github/workflows/qa-clean-exit-snapshot-downloading.yml
+++ b/.github/workflows/qa-clean-exit-snapshot-downloading.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   clean-exit-sd-test:
-    runs-on: self-hosted
+    runs-on: [self-hosted, qa]
     env:
       ERIGON_DATA_DIR: ${{ github.workspace }}/erigon_data
       ERIGON_QA_PATH: /home/qarunner/erigon-qa

--- a/.github/workflows/qa-snap-download.yml
+++ b/.github/workflows/qa-snap-download.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   snap-download-test:
-    runs-on: self-hosted
+    runs-on: [self-hosted, qa]
     timeout-minutes: 500
     env:
       ERIGON_DATA_DIR: ${{ github.workspace }}/erigon_data

--- a/.github/workflows/qa-sync-from-scratch-minimal-node.yml
+++ b/.github/workflows/qa-sync-from-scratch-minimal-node.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   minimal-node-sync-from-scratch-test:
-    runs-on: self-hosted
+    runs-on: [self-hosted, qa]
     timeout-minutes: 360 # 6 hours
     env:
       ERIGON_DATA_DIR: ${{ github.workspace }}/erigon_data

--- a/.github/workflows/qa-sync-from-scratch.yml
+++ b/.github/workflows/qa-sync-from-scratch.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   sync-from-scratch-test:
-    runs-on: self-hosted
+    runs-on: [self-hosted, qa]
     timeout-minutes: 740  # 12 hours plus 20 minutes
     strategy:
       fail-fast: false

--- a/.github/workflows/qa-sync-with-externalcl.yml
+++ b/.github/workflows/qa-sync-with-externalcl.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   sync-with-externalcl:
-    runs-on: [self-hosted, linux, X64]
+    runs-on: [self-hosted, qa, linux, X64]
     timeout-minutes: 500 # 8+ hours
     strategy:
       matrix:


### PR DESCRIPTION
Require that tests only run on qa-labeled runners