### PR TITLE
tests/bor: attempt to fix flakey TestMiningBenchmark integration test

### DIFF
--- a/tests/bor/mining_test.go
+++ b/tests/bor/mining_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon-lib/chain/networkname"
 	"github.com/erigontech/erigon-lib/crypto"
@@ -74,6 +75,11 @@ func TestMiningBenchmark(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
+
+		t.Cleanup(func() {
+			err := stack.Close()
+			require.NoError(t, err)
+		})
 
 		if err := stack.Start(); err != nil {
 			panic(err)


### PR DESCRIPTION
example failure: https://github.com/erigontech/erigon/actions/runs/13968954264/job/39105830886

```
Time to execute 5000 txs: 12.984522584s
--- FAIL: TestMiningBenchmark (13.41s)
    testing.go:1232: TempDir RemoveAll cleanup: unlinkat /var/folders/bz/h4njq8yd7td8qk42rt_9f0p00000gn/T/TestMiningBenchmark3328505942/001: directory not empty
FAIL
FAIL	github.com/erigontech/erigon/tests/bor	13.965s
```