### PR TITLE
refactor: use maps.Copy for cleaner map handling

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -239,9 +239,7 @@ func (so *stateObject) SetStorage(storage Storage) {
 	if so.fakeStorage == nil {
 		so.fakeStorage = make(Storage)
 	}
-	for key, value := range storage {
-		so.fakeStorage[key] = value
-	}
+	maps.Copy(so.fakeStorage, storage)
 	// Don't bother journal since this function should only be used for
 	// debugging and the `fake` storage won't be committed to database.
 }

--- a/core/state/triedb_state.go
+++ b/core/state/triedb_state.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
+	"maps"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -108,9 +109,7 @@ func (b *Buffer) merge(other *Buffer) {
 			m = make(map[libcommon.Hash][]byte)
 			b.storageUpdates[addrHash] = m
 		}
-		for keyHash, v := range om {
-			m[keyHash] = v
-		}
+		maps.Copy(m, om)
 	}
 	for addrHash, incarnation := range other.storageIncarnation {
 		b.storageIncarnation[addrHash] = incarnation


### PR DESCRIPTION
since go.1.21 support map.Copy 
ref: https://pkg.go.dev/maps#Copy