### PR TITLE
txnprovider/shutter: remove libp2p todos as they are not needed

### DIFF
--- a/txnprovider/shutter/decryption_keys_listener.go
+++ b/txnprovider/shutter/decryption_keys_listener.go
@@ -90,15 +90,6 @@ func (dkl DecryptionKeysListener) Run(ctx context.Context) error {
 		return err
 	}
 
-	//
-	// TODO play around with go-libp2p-kad-dht for routing and discovery analogous to rolling-shutter
-	//      check if it improves number of peers for topic
-	//
-
-	//
-	// TODO persist connected nodes to be able to re-use on restart
-	//
-
 	eg, ctx := errgroup.WithContext(ctx)
 
 	eg.Go(func() error {


### PR DESCRIPTION
closes https://github.com/erigontech/erigon/issues/13379
closes https://github.com/erigontech/erigon/issues/13380

not needed, go-libp2p-pubsub manages the peers well enough with our current approach of connecting to boot nodes
peers are quickly populated to up to 7 on startup and are maintained as per libp2p pubsub spec