### PR TITLE
refactor: use the built-in max to simplify the code

### DIFF
--- a/cmd/observer/observer/diplomat.go
+++ b/cmd/observer/observer/diplomat.go
@@ -132,11 +132,7 @@ func (diplomat *Diplomat) NextRetryDelay(handshakeErr *HandshakeError) time.Dura
 	}
 
 	backOffDelay := 2 * lastErrors[0].Time.Sub(lastErrors[1].Time)
-	if backOffDelay < diplomat.handshakeRetryDelay {
-		return diplomat.handshakeRetryDelay
-	}
-
-	return backOffDelay
+	return max(backOffDelay, diplomat.handshakeRetryDelay)
 }
 
 func (diplomat *Diplomat) transientError() *HandshakeError {

--- a/core/vm/memory_table.go
+++ b/core/vm/memory_table.go
@@ -78,10 +78,7 @@ func memoryCall(stack *stack.Stack) (uint64, bool) {
 	if overflow {
 		return 0, true
 	}
-	if x > y {
-		return x, false
-	}
-	return y, false
+	return max(x, y), false
 }
 func memoryDelegateCall(stack *stack.Stack) (uint64, bool) {
 	x, overflow := calcMemSize64(stack.Back(4), stack.Back(5))
@@ -92,10 +89,7 @@ func memoryDelegateCall(stack *stack.Stack) (uint64, bool) {
 	if overflow {
 		return 0, true
 	}
-	if x > y {
-		return x, false
-	}
-	return y, false
+	return max(x, y), false
 }
 
 func memoryStaticCall(stack *stack.Stack) (uint64, bool) {
@@ -107,10 +101,7 @@ func memoryStaticCall(stack *stack.Stack) (uint64, bool) {
 	if overflow {
 		return 0, true
 	}
-	if x > y {
-		return x, false
-	}
-	return y, false
+	return max(x, y), false
 }
 
 func memoryReturn(stack *stack.Stack) (uint64, bool) {

--- a/eth/tracers/js/goja.go
+++ b/eth/tracers/js/goja.go
@@ -983,10 +983,3 @@ func (l *steplog) setupObject() *goja.Object {
 	o.Set("contract", l.contract.setupObject())
 	return o
 }
-
-func min(a, b int64) int64 {
-	if a < b {
-		return a
-	}
-	return b
-}

--- a/polygon/bridge/snapshot_store.go
+++ b/polygon/bridge/snapshot_store.go
@@ -141,11 +141,8 @@ func (s *SnapshotStore) LastEventId(ctx context.Context) (uint64, error) {
 	}
 
 	snapshotLastEventId := s.LastFrozenEventId()
-	if snapshotLastEventId > lastEventId {
-		return snapshotLastEventId, nil
-	}
 
-	return lastEventId, nil
+	return max(snapshotLastEventId, lastEventId), nil
 }
 
 func (s *SnapshotStore) LastFrozenEventId() uint64 {
@@ -192,11 +189,8 @@ func (s *SnapshotStore) LastProcessedEventId(ctx context.Context) (uint64, error
 	}
 
 	snapshotLastEventId := s.LastFrozenEventId()
-	if snapshotLastEventId > lastEventId {
-		return snapshotLastEventId, nil
-	}
 
-	return lastEventId, nil
+	return max(snapshotLastEventId, lastEventId), nil
 }
 
 func (s *SnapshotStore) EventTxnToBlockNum(ctx context.Context, txnHash libcommon.Hash) (uint64, bool, error) {


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.