### PR TITLE
debug api for appendables

### DIFF
--- a/core/test/marked_appendable_test.go
+++ b/core/test/marked_appendable_test.go
@@ -113,15 +113,15 @@ func TestMarked_PutToDb(t *testing.T) {
 
 	err = ma_tx.Put(num, hash, value, rwtx)
 	require.NoError(t, err)
-	returnv, err := ma_tx.GetDb(num, nil, rwtx)
+	returnv, err := ma_tx.Get(num, rwtx)
 	require.NoError(t, err)
 	require.Equal(t, value, returnv)
 
-	returnv, err = ma_tx.GetDb(num, hash, rwtx)
+	returnv, err = ma_tx.DebugDb().GetDb(num, hash, rwtx)
 	require.NoError(t, err)
 	require.Equal(t, value, returnv)
 
-	returnv, err = ma_tx.GetDb(num, []byte{1}, rwtx)
+	returnv, err = ma_tx.DebugDb().GetDb(num, []byte{1}, rwtx)
 	require.NoError(t, err)
 	require.True(t, returnv == nil) // Equal fails
 
@@ -253,7 +253,7 @@ func TestBuildFiles_Marked(t *testing.T) {
 	defer rwtx.Rollback()
 	require.NoError(t, err)
 
-	firstRootNumNotInSnap := ma_tx.VisibleFilesMaxRootNum()
+	firstRootNumNotInSnap := ma_tx.DebugFiles().VisibleFilesMaxRootNum()
 	del, err := ma_tx.Prune(ctx, firstRootNumNotInSnap, 1000, rwtx)
 	require.NoError(t, err)
 	require.Equal(t, del, uint64(firstRootNumNotInSnap)-uint64(ma.PruneFrom()))
@@ -268,7 +268,7 @@ func TestBuildFiles_Marked(t *testing.T) {
 	// check unified interface
 	for i := range int(entries_count) {
 		num, hash, value := getData(i)
-		returnv, err := ma_tx.GetDb(num, nil, rwtx)
+		returnv, err := ma_tx.DebugDb().GetDb(num, nil, rwtx)
 		require.NoError(t, err)
 		if num < Num(firstRootNumNotInSnap) && num >= ma.PruneFrom() {
 			require.True(t, returnv == nil)
@@ -279,7 +279,7 @@ func TestBuildFiles_Marked(t *testing.T) {
 		// just look in db....
 		if num < ma.PruneFrom() || num >= Num(firstRootNumNotInSnap) {
 			// these should be in db
-			returnv, err = ma_tx.GetDb(num, hash, rwtx)
+			returnv, err = ma_tx.DebugDb().GetDb(num, hash, rwtx)
 			require.NoError(t, err)
 			require.Equal(t, value, returnv)
 

--- a/core/test/unmarked_appendable_test.go
+++ b/core/test/unmarked_appendable_test.go
@@ -83,11 +83,11 @@ func TestUnmarked_PutToDb(t *testing.T) {
 
 	err = uma_tx.Append(num, value, rwtx)
 	require.NoError(t, err)
-	returnv, err := uma_tx.GetDb(num, rwtx)
+	returnv, err := uma_tx.Get(num, rwtx)
 	require.NoError(t, err)
 	require.Equal(t, value, returnv)
 
-	returnv, err = uma_tx.GetDb(Num(1), rwtx)
+	returnv, err = uma_tx.Get(Num(1), rwtx)
 	require.NoError(t, err)
 	//require.True(t, returnv == nil)a
 	require.True(t, returnv == nil)
@@ -188,7 +188,7 @@ func TestBuildFiles_Unmarked(t *testing.T) {
 	defer rwtx.Rollback()
 	require.NoError(t, err)
 
-	firstRootNumNotInSnap := uma_tx.VisibleFilesMaxRootNum()
+	firstRootNumNotInSnap := uma_tx.DebugFiles().VisibleFilesMaxRootNum()
 	firstSpanIdNotInSnap := Num(heimdall.SpanIdAt(uint64(firstRootNumNotInSnap)))
 	del, err := uma_tx.Prune(ctx, firstRootNumNotInSnap, 1000, rwtx)
 	require.NoError(t, err)
@@ -203,7 +203,7 @@ func TestBuildFiles_Unmarked(t *testing.T) {
 
 	for i := range int(entries_count) {
 		num, value := getData(i)
-		returnv, err := uma_tx.GetDb(num, rwtx)
+		returnv, err := uma_tx.DebugDb().GetDb(num, rwtx)
 		require.NoError(t, err)
 		if num < firstSpanIdNotInSnap {
 			require.True(t, returnv == nil)
@@ -211,7 +211,7 @@ func TestBuildFiles_Unmarked(t *testing.T) {
 			require.Equal(t, returnv, value)
 		}
 
-		returnv, found, err := uma_tx.GetFromFiles(num)
+		returnv, found, _, err := uma_tx.DebugFiles().GetFromFiles(num)
 		require.NoError(t, err)
 		if num < firstSpanIdNotInSnap {
 			require.True(t, found)

--- a/erigon-lib/state/appendable_interfaces.go
+++ b/erigon-lib/state/appendable_interfaces.go
@@ -79,7 +79,11 @@ type AppendableBaseTxI interface {
 	AppendableDbCommonTxI
 	AppendableTemporalCommonTxI
 	Get(num Num, tx kv.Tx) (Bytes, error)
+}
+
+type AppendableDebugAPI[T AppendableDbCommonTxI] interface {
 	DebugFiles() AppendableFilesTxI
+	DebugDb() T
 }
 
 // marked
@@ -91,8 +95,8 @@ type MarkedDbTxI interface {
 
 type MarkedTxI interface {
 	AppendableBaseTxI
+	AppendableDebugAPI[MarkedDbTxI]
 	Put(num Num, hash []byte, value Bytes, tx kv.RwTx) error
-	DebugDb() MarkedDbTxI
 }
 
 // unmarked
@@ -104,8 +108,8 @@ type UnmarkedDbTxI interface {
 
 type UnmarkedTxI interface {
 	AppendableBaseTxI
+	AppendableDebugAPI[UnmarkedDbTxI]
 	Append(entityNum Num, value Bytes, tx kv.RwTx) error
-	DebugDb() UnmarkedDbTxI
 }
 
 // buffer values before writing to db supposed to store only canonical values
@@ -119,10 +123,10 @@ type BufferedDbTxI interface {
 
 type BufferedTxI interface {
 	AppendableBaseTxI
+	AppendableDebugAPI[BufferedDbTxI]
 	Get(Num, kv.Tx) (Bytes, error)
 	Put(Num, Bytes) error
 	Flush(context.Context, kv.RwTx) error
-	DebugDb() BufferedDbTxI
 }
 
 type CanonicityStrategy uint8

--- a/erigon-lib/state/proto_appendable.go
+++ b/erigon-lib/state/proto_appendable.go
@@ -265,6 +265,8 @@ func (a *ProtoAppendableTx) VisibleFilesMaxNum() Num {
 	return Num(idx.BaseDataID() + idx.KeyCount())
 }
 
+// if either found=false or err != nil, then fileIdx = -1
+// can get FileItem on which entityNum was found by a.Files()[fileIdx] etc.
 func (a *ProtoAppendableTx) GetFromFiles(entityNum Num) (b Bytes, found bool, fileIdx int, err error) {
 	a.NoFilesCheck()
 	ap := a.a
@@ -275,7 +277,7 @@ func (a *ProtoAppendableTx) GetFromFiles(entityNum Num) (b Bytes, found bool, fi
 			return idx.BaseDataID()+idx.KeyCount() > uint64(entityNum)
 		})
 		if index == -1 {
-			return nil, false, -1, fmt.Errorf("entity get error: snapshot expected but now found: (%s, %d)", ap.a.Name(), entityNum)
+			return nil, false, -1, fmt.Errorf("entity get error: snapshot expected but not found: (%s, %d)", ap.a.Name(), entityNum)
 		}
 
 		v, f, err := a.GetFromFile(entityNum, index)

--- a/erigon-lib/state/proto_appendable.go
+++ b/erigon-lib/state/proto_appendable.go
@@ -265,7 +265,7 @@ func (a *ProtoAppendableTx) VisibleFilesMaxNum() Num {
 	return Num(idx.BaseDataID() + idx.KeyCount())
 }
 
-func (a *ProtoAppendableTx) GetFromFiles(entityNum Num) (b Bytes, found bool, err error) {
+func (a *ProtoAppendableTx) GetFromFiles(entityNum Num) (b Bytes, found bool, fileIdx int, err error) {
 	a.NoFilesCheck()
 	ap := a.a
 	lastNum := a.VisibleFilesMaxNum()
@@ -275,13 +275,14 @@ func (a *ProtoAppendableTx) GetFromFiles(entityNum Num) (b Bytes, found bool, er
 			return idx.BaseDataID()+idx.KeyCount() > uint64(entityNum)
 		})
 		if index == -1 {
-			return nil, false, fmt.Errorf("entity get error: snapshot expected but now found: (%s, %d)", ap.a.Name(), entityNum)
+			return nil, false, -1, fmt.Errorf("entity get error: snapshot expected but now found: (%s, %d)", ap.a.Name(), entityNum)
 		}
 
-		return a.GetFromFile(entityNum, index)
+		v, f, err := a.GetFromFile(entityNum, index)
+		return v, f, index, err
 	}
 
-	return nil, false, nil
+	return nil, false, -1, nil
 }
 
 func (a *ProtoAppendableTx) Files() []FilesItem {


### PR DESCRIPTION
- MarkedTxI is consolidated "temporal" interface using `Get()`
- can use DebugFiles() or DebugDb() to get fine-grained api which can query at db level (`GetDb`) or files level (`GetFromFiles` etc.)