### PR TITLE
receipts gen: dedup parallel re-exec of same block

### DIFF
--- a/turbo/jsonrpc/receipts/receipts_generator.go
+++ b/turbo/jsonrpc/receipts/receipts_generator.go
@@ -140,8 +140,8 @@ func (g *Generator) GetReceipt(ctx context.Context, cfg *chain.Config, tx kv.Tem
 	}
 
 	txnHash := txn.Hash()
-	mu := g.blockExecMutex.lock(txnHash)
-	defer g.blockExecMutex.unlock(mu, txnHash)
+	mu := g.txnExecMutex.lock(txnHash)
+	defer g.txnExecMutex.unlock(mu, txnHash)
 	if receipt, ok := g.receiptCache.Get(txnHash); ok {
 		return receipt, nil
 	}

--- a/turbo/jsonrpc/receipts/receipts_generator.go
+++ b/turbo/jsonrpc/receipts/receipts_generator.go
@@ -27,7 +27,10 @@ type Generator struct {
 	receiptsCache *lru.Cache[common.Hash, types.Receipts]
 	receiptCache  *lru.Cache[common.Hash, *types.Receipt]
 
-	blockExecMutex *loaderMutex[common.Hash] // only 1 block with current hash executed at a time - same parallel requests are waiting for results
+	// blockExecMutex ensuring that only 1 block with given hash
+	// executed at a time - all parallel requests for same hash will wait for results
+	// "Requesting near-chain-tip block receipts" - is very common RPC request, means we facing many similar parallel requrest
+	blockExecMutex *loaderMutex[common.Hash] // only
 	txnExecMutex   *loaderMutex[common.Hash] // only 1 txn with current hash executed at a time - same parallel requests are waiting for results
 
 	receiptsCacheTrace bool

--- a/turbo/jsonrpc/receipts/receipts_generator.go
+++ b/turbo/jsonrpc/receipts/receipts_generator.go
@@ -179,7 +179,7 @@ func (g *Generator) GetReceipt(ctx context.Context, cfg *chain.Config, tx kv.Tem
 
 func (g *Generator) GetReceipts(ctx context.Context, cfg *chain.Config, tx kv.TemporalTx, block *types.Block) (types.Receipts, error) {
 	blockHash := block.Hash()
-	mu := g.blockExecMutex.lock(blockHash) // only 1 block with current hash executed at a time - same parallel requests are waiting for results
+	mu := g.blockExecMutex.lock(blockHash)
 	defer g.blockExecMutex.unlock(mu, blockHash)
 
 	if receipts, ok := g.receiptsCache.Get(blockHash); ok {


### PR DESCRIPTION
- Latency impact: no impact. But 1 block executed once (even if multiple parallel requests) - means less CPU, means less chance to over-load server (what will increase latency).
- Throughput impact on "many parallel requests of same block" case (most of requests hit cache): benchmarks don't show throughput difference