### PR TITLE
[wip] receipt persistance: step1

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -1268,8 +1268,8 @@ func ReadReceipts(db kv.Tx, blockHash common.Hash, blockNum uint64) (res types.R
 }
 
 // PruneReceipts removes all receipt for given block number or newer - used for Unwind
-func PruneReceipts(tx kv.RwTx, number uint64) error {
-	rng, err := tx.Prefix(kv.Receipts, hexutil.EncodeTs(number))
+func PruneReceipts(tx kv.RwTx, blockNum uint64) error {
+	rng, err := tx.Prefix(kv.Receipts, hexutil.EncodeTs(blockNum))
 	if err != nil {
 		return err
 	}

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -1246,7 +1246,7 @@ func ReadReceipt(db kv.Tx, blockNum uint64, blockHash common.Hash, txnIndex uint
 	return res, nil
 }
 
-func ReadReceipts(db kv.Tx, blockNum uint64, blockHash common.Hash) (res types.Receipts, err error) {
+func ReadReceipts(db kv.Tx, blockHash common.Hash, blockNum uint64) (res types.Receipts, err error) {
 	fmt.Printf("[dbg] a: %d, %x, %x\n", blockNum, blockHash, dbutils.HeaderKey(blockNum, blockHash))
 
 	rng, err := db.Prefix(kv.Receipts, dbutils.HeaderKey(blockNum, blockHash))
@@ -1270,8 +1270,8 @@ func ReadReceipts(db kv.Tx, blockNum uint64, blockHash common.Hash) (res types.R
 }
 
 // PruneReceipts removes all receipt for given block number or newer - used for Unwind
-func PruneReceipts(db kv.RwTx, number uint64) error {
-	rng, err := db.Prefix(kv.Receipts, hexutil.EncodeTs(number))
+func PruneReceipts(tx kv.RwTx, number uint64) error {
+	rng, err := tx.Prefix(kv.Receipts, hexutil.EncodeTs(number))
 	if err != nil {
 		return err
 	}
@@ -1280,7 +1280,7 @@ func PruneReceipts(db kv.RwTx, number uint64) error {
 		if err != nil {
 			return err
 		}
-		if err := db.Delete(kv.Receipts, k); err != nil {
+		if err := tx.Delete(kv.Receipts, k); err != nil {
 			return err
 		}
 	}

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -35,6 +35,7 @@ import (
 	"github.com/erigontech/erigon-lib/common/length"
 	"github.com/erigontech/erigon-lib/kv"
 	"github.com/erigontech/erigon-lib/kv/dbutils"
+	"github.com/erigontech/erigon-lib/kv/order"
 	"github.com/erigontech/erigon-lib/kv/rawdbv3"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon-lib/rlp"
@@ -1251,6 +1252,7 @@ func ReadReceipts(db kv.Tx, blockHash common.Hash, blockNum uint64) (res types.R
 	if err != nil {
 		return nil, err
 	}
+	defer rng.Close()
 
 	for rng.HasNext() {
 		_, v, err := rng.Next()
@@ -1268,18 +1270,31 @@ func ReadReceipts(db kv.Tx, blockHash common.Hash, blockNum uint64) (res types.R
 }
 
 // PruneReceipts removes all receipt for given block number or newer - used for Unwind
-func PruneReceipts(tx kv.RwTx, blockNum uint64) error {
-	rng, err := tx.Prefix(kv.Receipts, hexutil.EncodeTs(blockNum))
+func PruneReceipts(tx kv.RwTx, blockNum uint64, pruneLimit int) error {
+	rng, err := tx.Range(kv.Receipts, nil, hexutil.EncodeTs(blockNum), order.Asc, -1)
 	if err != nil {
 		return err
 	}
+	defer rng.Close()
+
+	var prevBlockNum uint64
 	for rng.HasNext() {
 		k, _, err := rng.Next()
 		if err != nil {
 			return fmt.Errorf("prune receipts for block %d: %w", blockNum, err)
 		}
+		blockNum = binary.BigEndian.Uint64(k)
 		if err := tx.Delete(kv.Receipts, k); err != nil {
 			return fmt.Errorf("prune receipts for block %d: %w", blockNum, err)
+		}
+
+		if prevBlockNum != blockNum {
+			prevBlockNum = blockNum
+			pruneLimit--
+
+			if pruneLimit <= 0 {
+				break
+			}
 		}
 	}
 	return nil
@@ -1287,14 +1302,33 @@ func PruneReceipts(tx kv.RwTx, blockNum uint64) error {
 
 // WriteReceipts stores all the transaction receipts belonging to a block.
 func WriteReceipts(tx kv.RwTx, blockNum uint64, blockHash common.Hash, receipts types.Receipts) error {
+	if ok, err := HasReceipt(tx, blockNum, blockHash, 0); err != nil { // if exists don't write
+		return err
+	} else if ok {
+		return nil
+	}
+
 	for txnIndex, r := range receipts {
-		bytes, err := rlp.EncodeToBytes(r)
-		if err != nil {
-			return fmt.Errorf("writing logs for block %d: %w", blockNum, err)
-		}
-		if err = tx.Put(kv.Receipts, dbutils.ReceiptKey(blockNum, blockHash, uint32(txnIndex)), bytes); err != nil {
+		if err := WriteReceipt(tx, blockNum, blockHash, uint32(txnIndex), r); err != nil {
 			return fmt.Errorf("writing logs for block %d: %w", blockNum, err)
 		}
 	}
 	return nil
+}
+
+// WriteReceipt stores all the transaction receipts belonging to a block.
+func WriteReceipt(tx kv.RwTx, blockNum uint64, blockHash common.Hash, txnIndex uint32, receipt *types.Receipt) error {
+	bytes, err := rlp.EncodeToBytes(receipt)
+	if err != nil {
+		return fmt.Errorf("writing logs for block %d: %w", blockNum, err)
+	}
+	if err = tx.Put(kv.Receipts, dbutils.ReceiptKey(blockNum, blockHash, txnIndex), bytes); err != nil {
+		return fmt.Errorf("writing logs for block %d: %w", blockNum, err)
+	}
+	return nil
+}
+
+// HasReceipt stores all the transaction receipts belonging to a block.
+func HasReceipt(tx kv.Tx, blockNum uint64, blockHash common.Hash, txnIndex uint32) (bool, error) {
+	return tx.Has(kv.Receipts, dbutils.ReceiptKey(blockNum, blockHash, txnIndex))
 }

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -1247,8 +1247,6 @@ func ReadReceipt(db kv.Tx, blockNum uint64, blockHash common.Hash, txnIndex uint
 }
 
 func ReadReceipts(db kv.Tx, blockHash common.Hash, blockNum uint64) (res types.Receipts, err error) {
-	fmt.Printf("[dbg] a: %d, %x, %x\n", blockNum, blockHash, dbutils.HeaderKey(blockNum, blockHash))
-
 	rng, err := db.Prefix(kv.Receipts, dbutils.HeaderKey(blockNum, blockHash))
 	if err != nil {
 		return nil, err
@@ -1278,10 +1276,10 @@ func PruneReceipts(tx kv.RwTx, number uint64) error {
 	for rng.HasNext() {
 		k, _, err := rng.Next()
 		if err != nil {
-			return err
+			return fmt.Errorf("prune receipts for block %d: %w", blockNum, err)
 		}
 		if err := tx.Delete(kv.Receipts, k); err != nil {
-			return err
+			return fmt.Errorf("prune receipts for block %d: %w", blockNum, err)
 		}
 	}
 	return nil
@@ -1292,9 +1290,8 @@ func WriteReceipts(tx kv.RwTx, blockNum uint64, blockHash common.Hash, receipts 
 	for txnIndex, r := range receipts {
 		bytes, err := rlp.EncodeToBytes(r)
 		if err != nil {
-			log.Crit("Failed to encode block receipts", "err", err)
+			return fmt.Errorf("writing logs for block %d: %w", blockNum, err)
 		}
-		fmt.Printf("[dbg] a: %d, %x, %x\n", blockNum, blockHash, dbutils.ReceiptKey(blockNum, blockHash, uint32(txnIndex)))
 		if err = tx.Put(kv.Receipts, dbutils.ReceiptKey(blockNum, blockHash, uint32(txnIndex)), bytes); err != nil {
 			return fmt.Errorf("writing logs for block %d: %w", blockNum, err)
 		}

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -30,15 +30,13 @@ import (
 
 	"github.com/gballet/go-verkle"
 
-	"github.com/erigontech/erigon-lib/log/v3"
-
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/hexutil"
 	"github.com/erigontech/erigon-lib/common/length"
 	"github.com/erigontech/erigon-lib/kv"
 	"github.com/erigontech/erigon-lib/kv/dbutils"
 	"github.com/erigontech/erigon-lib/kv/rawdbv3"
-
+	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon-lib/rlp"
 	"github.com/erigontech/erigon/core/rawdb/utils"
 	"github.com/erigontech/erigon/core/types"
@@ -1224,4 +1222,82 @@ func ReadDBSchemaVersion(tx kv.Tx) (major, minor, patch uint32, ok bool, err err
 	minor = binary.BigEndian.Uint32(existingVersion[4:])
 	patch = binary.BigEndian.Uint32(existingVersion[8:])
 	return major, minor, patch, true, nil
+}
+
+// ReadReceipts retrieves all the transaction receipts belonging to a block, including
+// its corresponding metadata fields. If it is unable to populate these metadata
+// fields then nil is returned.
+//
+// The current implementation populates these metadata fields by reading the receipts'
+// corresponding block body, so if the block body is not found it will return nil even
+// if the receipt itself is stored.
+func ReadReceipt(db kv.Tx, blockNum uint64, blockHash common.Hash, txnIndex uint32) (*types.Receipt, error) {
+	data, err := db.GetOne(kv.Receipts, dbutils.ReceiptKey(blockNum, blockHash, txnIndex))
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert the receipts from their storage form to their internal representation
+	res := &types.Receipt{}
+	if err := rlp.DecodeBytes(data, res); err != nil {
+		return nil, fmt.Errorf("%w, of block %d, %x\n", err, blockNum, blockHash)
+	}
+
+	return res, nil
+}
+
+func ReadReceipts(db kv.Tx, blockNum uint64, blockHash common.Hash) (res types.Receipts, err error) {
+	fmt.Printf("[dbg] a: %d, %x, %x\n", blockNum, blockHash, dbutils.HeaderKey(blockNum, blockHash))
+
+	rng, err := db.Prefix(kv.Receipts, dbutils.HeaderKey(blockNum, blockHash))
+	if err != nil {
+		return nil, err
+	}
+
+	for rng.HasNext() {
+		_, v, err := rng.Next()
+		if err != nil {
+			return nil, err
+		}
+		// Convert the receipts from their storage form to their internal representation
+		receipt := &types.Receipt{}
+		if err := rlp.DecodeBytes(v, receipt); err != nil {
+			return nil, fmt.Errorf("%w, of block %d, %x\n", err, blockNum, blockHash)
+		}
+		res = append(res, receipt)
+	}
+	return res, nil
+}
+
+// PruneReceipts removes all receipt for given block number or newer - used for Unwind
+func PruneReceipts(db kv.RwTx, number uint64) error {
+	rng, err := db.Prefix(kv.Receipts, hexutil.EncodeTs(number))
+	if err != nil {
+		return err
+	}
+	for rng.HasNext() {
+		k, _, err := rng.Next()
+		if err != nil {
+			return err
+		}
+		if err := db.Delete(kv.Receipts, k); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// WriteReceipts stores all the transaction receipts belonging to a block.
+func WriteReceipts(tx kv.RwTx, blockNum uint64, blockHash common.Hash, receipts types.Receipts) error {
+	for txnIndex, r := range receipts {
+		bytes, err := rlp.EncodeToBytes(r)
+		if err != nil {
+			log.Crit("Failed to encode block receipts", "err", err)
+		}
+		fmt.Printf("[dbg] a: %d, %x, %x\n", blockNum, blockHash, dbutils.ReceiptKey(blockNum, blockHash, uint32(txnIndex)))
+		if err = tx.Put(kv.Receipts, dbutils.ReceiptKey(blockNum, blockHash, uint32(txnIndex)), bytes); err != nil {
+			return fmt.Errorf("writing logs for block %d: %w", blockNum, err)
+		}
+	}
+	return nil
 }

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -521,7 +521,7 @@ func TestBlockReceiptStorage(t *testing.T) {
 	b, _, err := br.BlockWithSenders(ctx, tx, hash, 1)
 	require.NoError(err)
 	require.NotNil(b)
-	rs, err := rawdb.ReadReceipts(tx, 1, hash)
+	rs, err := rawdb.ReadReceipts(tx, hash, 1)
 	require.NoError(err)
 	require.NotNil(rs)
 
@@ -539,12 +539,12 @@ func TestBlockReceiptStorage(t *testing.T) {
 	require.NoError(err)
 	require.Nil(b)
 
-	rs, err = rawdb.ReadReceipts(tx, b.NumberU64(), b.Hash())
+	rs, err = rawdb.ReadReceipts(tx, hash, 1)
 	require.NoError(err)
 	require.NotNil(rs)
 
 	// Ensure that receipts without metadata can be returned without the block body too
-	rFromDB, err := rawdb.ReadReceipts(tx, 1, hash)
+	rFromDB, err := rawdb.ReadReceipts(tx, hash, 1)
 	require.NoError(err)
 	if err := checkReceiptsRLP(rFromDB, receipts); err != nil {
 		t.Fatal(err)
@@ -557,9 +557,9 @@ func TestBlockReceiptStorage(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(b)
 
-	rs, err = rawdb.ReadReceipts(tx, b.NumberU64(), b.Hash())
+	rs, err = rawdb.ReadReceipts(tx, hash, 1)
 	require.NoError(err)
-	require.Nil(b)
+	require.Nil(rs)
 	if len(rs) != 0 {
 		t.Fatalf("deleted receipts returned: %v", rs)
 	}

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -460,6 +460,111 @@ func TestHeadStorage(t *testing.T) {
 	}
 }
 
+// Tests that receipts associated with a single block can be stored and retrieved.
+func TestBlockReceiptStorage(t *testing.T) {
+	t.Parallel()
+	m := mock.Mock(t)
+	tx, err := m.DB.BeginRw(m.Ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+	br := m.BlockReader
+	require := require.New(t)
+	ctx := m.Ctx
+
+	// Create a live block since we need metadata to reconstruct the receipt
+	tx1 := types.NewTransaction(1, libcommon.HexToAddress("0x1"), u256.Num1, 1, u256.Num1, nil)
+	tx2 := types.NewTransaction(2, libcommon.HexToAddress("0x2"), u256.Num2, 2, u256.Num2, nil)
+
+	body := &types.Body{Transactions: types.Transactions{tx1, tx2}}
+
+	// Create the two receipts to manage afterwards
+	receipt1 := &types.Receipt{
+		Status:            types.ReceiptStatusFailed,
+		CumulativeGasUsed: 1,
+		Logs: []*types.Log{
+			{Address: libcommon.BytesToAddress([]byte{0x11})},
+			{Address: libcommon.BytesToAddress([]byte{0x01, 0x11})},
+		},
+		TxHash:          tx1.Hash(),
+		ContractAddress: libcommon.BytesToAddress([]byte{0x01, 0x11, 0x11}),
+		GasUsed:         111111,
+	}
+	//receipt1.Bloom = types.CreateBloom(types.Receipts{receipt1})
+
+	receipt2 := &types.Receipt{
+		PostState:         libcommon.Hash{2}.Bytes(),
+		CumulativeGasUsed: 2,
+		Logs: []*types.Log{
+			{Address: libcommon.BytesToAddress([]byte{0x22})},
+			{Address: libcommon.BytesToAddress([]byte{0x02, 0x22})},
+		},
+		TxHash:          tx2.Hash(),
+		ContractAddress: libcommon.BytesToAddress([]byte{0x02, 0x22, 0x22}),
+		GasUsed:         222222,
+	}
+	//receipt2.Bloom = types.CreateBloom(types.Receipts{receipt2})
+	receipts := []*types.Receipt{receipt1, receipt2}
+	header := &types.Header{Number: big.NewInt(1)}
+
+	// Check that no receipt entries are in a pristine database
+	hash := header.Hash() //libcommon.BytesToHash([]byte{0x03, 0x14})
+
+	rawdb.WriteCanonicalHash(tx, header.Hash(), header.Number.Uint64())
+	rawdb.WriteHeader(tx, header)
+	// Insert the body that corresponds to the receipts
+	require.NoError(rawdb.WriteBody(tx, hash, 1, body))
+	require.NoError(rawdb.WriteSenders(tx, hash, 1, body.SendersFromTxs()))
+
+	// Insert the receipt slice into the database and check presence
+	require.NoError(rawdb.WriteReceipts(tx, 1, hash, receipts))
+
+	b, _, err := br.BlockWithSenders(ctx, tx, hash, 1)
+	require.NoError(err)
+	require.NotNil(b)
+	rs, err := rawdb.ReadReceipts(tx, 1, hash)
+	require.NoError(err)
+	require.NotNil(rs)
+
+	if len(rs) == 0 {
+		t.Fatalf("no receipts returned")
+	} else {
+		if err := checkReceiptsRLP(rs, receipts); err != nil {
+			t.Fatalf(err.Error())
+		}
+	}
+	// Delete the body and ensure that the receipts are no longer returned (metadata can't be recomputed)
+	rawdb.DeleteHeader(tx, hash, 1)
+	rawdb.DeleteBody(tx, hash, 1)
+	b, _, err = br.BlockWithSenders(ctx, tx, hash, 1)
+	require.NoError(err)
+	require.Nil(b)
+
+	rs, err = rawdb.ReadReceipts(tx, b.NumberU64(), b.Hash())
+	require.NoError(err)
+	require.NotNil(rs)
+
+	// Ensure that receipts without metadata can be returned without the block body too
+	rFromDB, err := rawdb.ReadReceipts(tx, 1, hash)
+	require.NoError(err)
+	if err := checkReceiptsRLP(rFromDB, receipts); err != nil {
+		t.Fatal(err)
+	}
+	rawdb.WriteHeader(tx, header)
+	// Sanity check that body alone without the receipt is a full purge
+	require.NoError(rawdb.WriteBody(tx, hash, 1, body))
+	require.NoError(rawdb.PruneReceipts(tx, 1))
+	b, _, err = br.BlockWithSenders(ctx, tx, hash, 1)
+	require.NoError(err)
+	require.NotNil(b)
+
+	rs, err = rawdb.ReadReceipts(tx, b.NumberU64(), b.Hash())
+	require.NoError(err)
+	require.Nil(b)
+	if len(rs) != 0 {
+		t.Fatalf("deleted receipts returned: %v", rs)
+	}
+}
+
 // Tests block storage and retrieval operations with withdrawals.
 func TestBlockWithdrawalsStorage(t *testing.T) {
 	t.Parallel()

--- a/erigon-lib/kv/dbutils/composite_keys.go
+++ b/erigon-lib/kv/dbutils/composite_keys.go
@@ -59,11 +59,12 @@ func BlockBodyKey(number uint64, hash libcommon.Hash) []byte {
 	return k
 }
 
-// LogKey = blockN (uint64 big endian) + txId (uint32 big endian)
-func LogKey(blockNumber uint64, txId uint32) []byte {
-	newK := make([]byte, 8+4)
+// ReceiptKey
+func ReceiptKey(blockNumber uint64, blockHash libcommon.Hash, txnIndex uint32) []byte {
+	newK := make([]byte, 8+32+4)
 	binary.BigEndian.PutUint64(newK, blockNumber)
-	binary.BigEndian.PutUint32(newK[8:], txId)
+	copy(newK[8:], blockHash[:])
+	binary.BigEndian.PutUint32(newK[8+32:], txnIndex)
 	return newK
 }
 

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -395,40 +395,28 @@ func PruneExecutionStage(s *PruneState, tx kv.RwTx, cfg ExecuteBlockCfg, ctx con
 		}
 		defer tx.Rollback()
 	}
-	if s.ForwardProgress > uint64(dbg.MaxReorgDepth) {
-
-		if !cfg.syncCfg.AlwaysGenerateChangesets {
-			// (chunkLen is 8Kb) * (1_000 chunks) = 8mb
-			// Some blocks on bor-mainnet have 400 chunks of diff = 3mb
-			var pruneDiffsLimitOnChainTip = 1_000
-			pruneTimeout := 250 * time.Millisecond
-			if s.CurrentSyncCycle.IsInitialCycle {
-				pruneDiffsLimitOnChainTip = math.MaxInt
-				pruneTimeout = time.Hour
-			}
-			if err := rawdb.PruneTable(
-				tx,
-				kv.ChangeSets3,
-				s.ForwardProgress-uint64(dbg.MaxReorgDepth),
-				ctx,
-				pruneDiffsLimitOnChainTip,
-				pruneTimeout,
-				logger,
-				s.LogPrefix(),
-			); err != nil {
-				return err
-			}
+	if s.ForwardProgress > uint64(dbg.MaxReorgDepth) && !cfg.syncCfg.AlwaysGenerateChangesets {
+		// (chunkLen is 8Kb) * (1_000 chunks) = 8mb
+		// Some blocks on bor-mainnet have 400 chunks of diff = 3mb
+		var pruneDiffsLimitOnChainTip = 1_000
+		pruneTimeout := 250 * time.Millisecond
+		if s.CurrentSyncCycle.IsInitialCycle {
+			pruneDiffsLimitOnChainTip = math.MaxInt
+			pruneTimeout = time.Hour
+		}
+		if err := rawdb.PruneTable(
+			tx,
+			kv.ChangeSets3,
+			s.ForwardProgress-uint64(dbg.MaxReorgDepth),
+			ctx,
+			pruneDiffsLimitOnChainTip,
+			pruneTimeout,
+			logger,
+			s.LogPrefix(),
+		); err != nil {
+			return err
 		}
 
-		{
-			pruneLimit := 10
-			if s.CurrentSyncCycle.IsInitialCycle {
-				pruneLimit = 10_000
-			}
-			if err := rawdb.PruneReceipts(tx, s.ForwardProgress-uint64(dbg.MaxReorgDepth), pruneLimit); err != nil {
-				return err
-			}
-		}
 	}
 
 	mxExecStepsInDB.Set(rawdbhelpers.IdxStepsCountV3(tx) * 100)
@@ -447,6 +435,18 @@ func PruneExecutionStage(s *PruneState, tx kv.RwTx, cfg ExecuteBlockCfg, ctx con
 	}
 	if _, err = tx.(*temporal.Tx).AggTx().(*libstate.AggregatorRoTx).PruneSmallBatches(ctx, pruneTimeout, tx); err != nil { // prune part of retired data, before commit
 		return err
+	}
+
+	// prune receipts
+	const PersistReceipts = 90_000
+	if s.ForwardProgress > PersistReceipts {
+		pruneLimit := 10
+		if s.CurrentSyncCycle.IsInitialCycle {
+			pruneLimit = 10_000
+		}
+		if err := rawdb.PruneReceipts(tx, s.ForwardProgress-PersistReceipts, pruneLimit); err != nil {
+			return err
+		}
 	}
 
 	if err = s.Done(tx); err != nil {

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -395,26 +395,39 @@ func PruneExecutionStage(s *PruneState, tx kv.RwTx, cfg ExecuteBlockCfg, ctx con
 		}
 		defer tx.Rollback()
 	}
-	if s.ForwardProgress > uint64(dbg.MaxReorgDepth) && !cfg.syncCfg.AlwaysGenerateChangesets {
-		// (chunkLen is 8Kb) * (1_000 chunks) = 8mb
-		// Some blocks on bor-mainnet have 400 chunks of diff = 3mb
-		var pruneDiffsLimitOnChainTip = 1_000
-		pruneTimeout := 250 * time.Millisecond
-		if s.CurrentSyncCycle.IsInitialCycle {
-			pruneDiffsLimitOnChainTip = math.MaxInt
-			pruneTimeout = time.Hour
+	if s.ForwardProgress > uint64(dbg.MaxReorgDepth) {
+
+		if !cfg.syncCfg.AlwaysGenerateChangesets {
+			// (chunkLen is 8Kb) * (1_000 chunks) = 8mb
+			// Some blocks on bor-mainnet have 400 chunks of diff = 3mb
+			var pruneDiffsLimitOnChainTip = 1_000
+			pruneTimeout := 250 * time.Millisecond
+			if s.CurrentSyncCycle.IsInitialCycle {
+				pruneDiffsLimitOnChainTip = math.MaxInt
+				pruneTimeout = time.Hour
+			}
+			if err := rawdb.PruneTable(
+				tx,
+				kv.ChangeSets3,
+				s.ForwardProgress-uint64(dbg.MaxReorgDepth),
+				ctx,
+				pruneDiffsLimitOnChainTip,
+				pruneTimeout,
+				logger,
+				s.LogPrefix(),
+			); err != nil {
+				return err
+			}
 		}
-		if err := rawdb.PruneTable(
-			tx,
-			kv.ChangeSets3,
-			s.ForwardProgress-uint64(dbg.MaxReorgDepth),
-			ctx,
-			pruneDiffsLimitOnChainTip,
-			pruneTimeout,
-			logger,
-			s.LogPrefix(),
-		); err != nil {
-			return err
+
+		{
+			pruneLimit := 10
+			if s.CurrentSyncCycle.IsInitialCycle {
+				pruneLimit = 10_000
+			}
+			if err := rawdb.PruneReceipts(tx, s.ForwardProgress-uint64(dbg.MaxReorgDepth), pruneLimit); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Decided to not subscribe RPCD to new Erigon's receipts. Instead of this:
- store receipts in chaindata (and prune later)
- it will make new receipts available for readers immediately (on gap in async event delivery)
- it will remove need of re-exec recent blocks
- we can afford to store "denormalized, and non-optimized" version of receipt - not like in E2 - because we do store not much receipts
- receipts LRU doesn't need to cache receipts if we found it in DB. because DB it's already kind-of cache (small, mmaped, hot file). It means - receipts LRU will cover only old receipts - which has different access pattern from recent. 



