### PR TITLE
Provide 'totalGasLimit' to the 'ValidateAATransaction' gas pool; comment out sub gas

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -358,9 +358,9 @@ func (st *StateTransition) ApplyFrame(validateFrame func(ibs evmtypes.IntraBlock
 		OnEnter: epc.OnEnter,
 	})
 
-	if err := st.buyGas(false); err != nil {
-		return nil, err
-	}
+	//if err := st.buyGas(false); err != nil {
+	//	return nil, err
+	//}
 
 	msg := st.msg
 	sender := vm.AccountRef(msg.From())

--- a/turbo/privateapi/ethbackend.go
+++ b/turbo/privateapi/ethbackend.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"math"
 
+	"github.com/erigontech/erigon-lib/common/fixedgas"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/erigontech/erigon-lib/chain"
@@ -458,8 +459,8 @@ func (s *EthBackendServer) AAValidation(ctx context.Context, req *remote.AAValid
 
 	ot := commands.NewOpcodeTracer(header.Number.Uint64(), true, false)
 	evm := vm.NewEVM(blockContext, evmtypes.TxContext{}, ibs, s.chainConfig, vm.Config{Tracer: ot.Tracer().Hooks, ReadOnly: true})
-	validationGasLimit := aaTxn.ValidationGasLimit + aaTxn.PaymasterValidationGasLimit
-	_, _, err = aa.ValidateAATransaction(aaTxn, ibs, new(core.GasPool).AddGas(validationGasLimit), header, evm, s.chainConfig)
+	totalGasLimit := fixedgas.TxAAGas + aaTxn.ValidationGasLimit + aaTxn.PaymasterValidationGasLimit + aaTxn.GasLimit + aaTxn.PostOpGasLimit
+	_, _, err = aa.ValidateAATransaction(aaTxn, ibs, new(core.GasPool).AddGas(totalGasLimit), header, evm, s.chainConfig)
 	log.Info("err", "err", err.Error())
 	if err != nil {
 		return &remote.AAValidationReply{Valid: false}, nil


### PR DESCRIPTION
Notice that succesfull pre-charging the entire transaction gas limit is part of the transaction validity condition.
Also, as this empties the gas pool, it is not clear how to re-charge the gas for individual frames in that scenario. I assume only one of the gas subtractions can be kept, while the other should be discarded.