### PR TITLE
execution: debug log for ufc domain ahead of blocks err

### DIFF
--- a/turbo/execution/eth1/forkchoice.go
+++ b/turbo/execution/eth1/forkchoice.go
@@ -69,9 +69,10 @@ func sendForkchoiceErrorWithoutWaiting(logger log.Logger, ch chan forkchoiceOutc
 	}
 }
 
-func isDomainAheadOfBlocks(tx kv.RwTx) bool {
-	doms, err := state.NewSharedDomains(tx, log.New())
+func isDomainAheadOfBlocks(tx kv.RwTx, logger log.Logger) bool {
+	doms, err := state.NewSharedDomains(tx, logger)
 	if err != nil {
+		logger.Debug("domain ahead of blocks", "err", err)
 		return errors.Is(err, state.ErrBehindCommitment)
 	}
 	defer doms.Close()
@@ -395,7 +396,7 @@ func (e *EthereumExecutionModule) updateForkChoice(ctx context.Context, original
 			}
 		}
 	}
-	if isDomainAheadOfBlocks(tx) {
+	if isDomainAheadOfBlocks(tx, e.logger) {
 		if err := tx.Commit(); err != nil {
 			sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, err, false)
 			return


### PR DESCRIPTION
ErrBehindCommitment is wrapped with extra info: "TxNums index is at block %d and behind commitment %d"

would be helpful to see that to figure out Astrid "validationErr='domain ahead of blocks'" which happens sometimes after "rm -rf chaindata && polygon-bridge && heimdall".

current theory is that this could happen when domains is ahead of blocks with more than 5,000 blocks because on startup when we call executionModule.CurrentHeader we insert N+1, N+2, ... -> but we limit how much we insert (using LoopBlockLimit which is 5,000 blocks) before we call UpdateForkChoice on the batch