### PR TITLE
core/types: Filter empty requests before hashing

### DIFF
--- a/core/types/eip7685_requests.go
+++ b/core/types/eip7685_requests.go
@@ -57,6 +57,9 @@ func (r FlatRequests) Hash() *libcommon.Hash {
 	}
 	sha := sha256.New()
 	for i, t := range r {
+		if len(t.RequestData) == 0 {
+			continue
+		}
 		hi := sha256.Sum256(append([]byte{t.Type}, r[i].RequestData...))
 		sha.Write(hi[:])
 	}

--- a/core/types/requests_test.go
+++ b/core/types/requests_test.go
@@ -27,4 +27,10 @@ func TestEmptyRequestsHashCalculation(t *testing.T) {
 	if *h != testH {
 		t.Errorf("Requests Hash calculation error for empty hash, expected: %v, got: %v", testH, h)
 	}
+
+	reqs = make(FlatRequests, 3)
+	h = reqs.Hash()
+	if *h != testH {
+		t.Errorf("Requests Hash calculation error for empty hash, expected: %v, got: %v", testH, h)
+	}
 }


### PR DESCRIPTION
Pro:
Follows the [EIP](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7685.md#block-header) to the letter 

Con:
In case empty requests pass through, the hash check would let it! (But it would not unless code is changed poorly)