### PR TITLE
Fix 404 link to validator lifecycle test file

### DIFF
--- a/.github/workflows/kurtosis/fast_lifecycle.io
+++ b/.github/workflows/kurtosis/fast_lifecycle.io
@@ -20,4 +20,4 @@ assertoor_params:
   run_stability_check: false
   run_block_proposal_check: false
   tests:
-    - file: https://raw.githubusercontent.com/erigontech/erigon/refs/heads/som/kurtosis_lifecycle/.github/workflows/kurtosis/validator-lifecycle-test-v3.io
+    - file: https://raw.githubusercontent.com/erigontech/erigon/refs/heads/main/.github/workflows/kurtosis/validator-lifecycle-test-v3.io


### PR DESCRIPTION
Replaced a broken URL that returned 404 (som/kurtosis_lifecycle) with the correct path to main branch.
This ensures the workflow can load validator-lifecycle-test-v3.io properly.