### PR TITLE
rpctest invariantsEthGetLogs: speedup by checking each addr only once in each block

### DIFF
--- a/cmd/rpctest/rpctest/bench_ethgetlogs.go
+++ b/cmd/rpctest/rpctest/bench_ethgetlogs.go
@@ -197,6 +197,7 @@ func EthGetLogsInvariants(erigonURL, gethURL string, needCompare bool, blockFrom
 						return fmt.Errorf("eth_getLogs: at blockNum=%d account %x not indexed", bn, l.Address)
 					}
 
+					//invariant2: if `log` visible without filter - then must be visible with filter. (in another words: `topic` must be indexed well)
 					if len(l.Topics) == 0 {
 						continue
 					}
@@ -206,7 +207,6 @@ func EthGetLogsInvariants(erigonURL, gethURL string, needCompare bool, blockFrom
 					}
 					sawTopic[l.Topics[0]] = struct{}{}
 
-					//invariant2: if `log` visible without filter - then must be visible with filter. (in another words: `topic` must be indexed well)
 					res = reqGen.Erigon("eth_getLogs", reqGen.getLogs1(prevBn, bn, l.Address, l.Topics[0]), &resp)
 					if res.Err != nil {
 						return fmt.Errorf("Could not get modified accounts (Erigon): %v\n", res.Err)

--- a/cmd/rpctest/rpctest/bench_ethgetlogs.go
+++ b/cmd/rpctest/rpctest/bench_ethgetlogs.go
@@ -177,12 +177,13 @@ func EthGetLogsInvariants(erigonURL, gethURL string, needCompare bool, blockFrom
 					return fmt.Errorf("Error getting modified accounts (Erigon): %d %s\n", resp.Error.Code, resp.Error.Message)
 				}
 
-				saw := map[common.Address]struct{}{}
+				sawAddr := map[common.Address]struct{}{}
+				sawTopic := map[common.Hash]struct{}{}
 				for _, l := range resp.Result {
-					if _, ok := saw[l.Address]; ok {
+					if _, ok := sawAddr[l.Address]; ok {
 						continue
 					}
-					saw[l.Address] = struct{}{}
+					sawAddr[l.Address] = struct{}{}
 
 					res = reqGen.Erigon("eth_getLogs", reqGen.getLogs(prevBn, bn, l.Address), &resp)
 					if res.Err != nil {
@@ -199,6 +200,11 @@ func EthGetLogsInvariants(erigonURL, gethURL string, needCompare bool, blockFrom
 					if len(l.Topics) == 0 {
 						continue
 					}
+
+					if _, ok := sawTopic[l.Topics[0]]; ok {
+						continue
+					}
+					sawTopic[l.Topics[0]] = struct{}{}
 
 					//invariant2: if `log` visible without filter - then must be visible with filter. (in another words: `topic` must be indexed well)
 					//res = reqGen.Erigon("eth_getLogs", reqGen.getLogs1(prevBn, bn, l.Address, l.Topics[0]), &resp)

--- a/cmd/rpctest/rpctest/bench_ethgetlogs.go
+++ b/cmd/rpctest/rpctest/bench_ethgetlogs.go
@@ -176,6 +176,7 @@ func EthGetLogsInvariants(erigonURL, gethURL string, needCompare bool, blockFrom
 				if resp.Error != nil {
 					return fmt.Errorf("Error getting modified accounts (Erigon): %d %s\n", resp.Error.Code, resp.Error.Message)
 				}
+
 				saw := map[common.Address]struct{}{}
 				for _, l := range resp.Result {
 					if _, ok := saw[l.Address]; ok {

--- a/cmd/rpctest/rpctest/bench_ethgetlogs.go
+++ b/cmd/rpctest/rpctest/bench_ethgetlogs.go
@@ -193,16 +193,16 @@ func EthGetLogsInvariants(erigonURL, gethURL string, needCompare bool, blockFrom
 					}
 
 					//invariant2: if `log` visible without filter - then must be visible with filter. (in another words: `topic` must be indexed well)
-					res = reqGen.Erigon("eth_getLogs", reqGen.getLogs1(prevBn, bn, l.Address, l.Topics[0]), &resp)
-					if res.Err != nil {
-						return fmt.Errorf("Could not get modified accounts (Erigon): %v\n", res.Err)
-					}
-					if resp.Error != nil {
-						return fmt.Errorf("Error getting modified accounts (Erigon): %d %s\n", resp.Error.Code, resp.Error.Message)
-					}
-					if len(resp.Result) == 0 {
-						return fmt.Errorf("eth_getLogs: at blockNum=%d account %x, topic %x not indexed", bn, l.Address, l.Topics[0])
-					}
+					//res = reqGen.Erigon("eth_getLogs", reqGen.getLogs1(prevBn, bn, l.Address, l.Topics[0]), &resp)
+					//if res.Err != nil {
+					//	return fmt.Errorf("Could not get modified accounts (Erigon): %v\n", res.Err)
+					//}
+					//if resp.Error != nil {
+					//	return fmt.Errorf("Error getting modified accounts (Erigon): %d %s\n", resp.Error.Code, resp.Error.Message)
+					//}
+					//if len(resp.Result) == 0 {
+					//	return fmt.Errorf("eth_getLogs: at blockNum=%d account %x, topic %x not indexed", bn, l.Address, l.Topics[0])
+					//}
 				}
 
 				select {

--- a/cmd/rpctest/rpctest/bench_ethgetlogs.go
+++ b/cmd/rpctest/rpctest/bench_ethgetlogs.go
@@ -24,6 +24,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"golang.org/x/sync/errgroup"
 )
@@ -175,7 +176,13 @@ func EthGetLogsInvariants(erigonURL, gethURL string, needCompare bool, blockFrom
 				if resp.Error != nil {
 					return fmt.Errorf("Error getting modified accounts (Erigon): %d %s\n", resp.Error.Code, resp.Error.Message)
 				}
+				saw := map[common.Address]struct{}{}
 				for _, l := range resp.Result {
+					if _, ok := saw[l.Address]; ok {
+						continue
+					}
+					saw[l.Address] = struct{}{}
+
 					res = reqGen.Erigon("eth_getLogs", reqGen.getLogs(prevBn, bn, l.Address), &resp)
 					if res.Err != nil {
 						return fmt.Errorf("Could not get modified accounts (Erigon): %v\n", res.Err)

--- a/cmd/rpctest/rpctest/bench_ethgetlogs.go
+++ b/cmd/rpctest/rpctest/bench_ethgetlogs.go
@@ -207,16 +207,16 @@ func EthGetLogsInvariants(erigonURL, gethURL string, needCompare bool, blockFrom
 					sawTopic[l.Topics[0]] = struct{}{}
 
 					//invariant2: if `log` visible without filter - then must be visible with filter. (in another words: `topic` must be indexed well)
-					//res = reqGen.Erigon("eth_getLogs", reqGen.getLogs1(prevBn, bn, l.Address, l.Topics[0]), &resp)
-					//if res.Err != nil {
-					//	return fmt.Errorf("Could not get modified accounts (Erigon): %v\n", res.Err)
-					//}
-					//if resp.Error != nil {
-					//	return fmt.Errorf("Error getting modified accounts (Erigon): %d %s\n", resp.Error.Code, resp.Error.Message)
-					//}
-					//if len(resp.Result) == 0 {
-					//	return fmt.Errorf("eth_getLogs: at blockNum=%d account %x, topic %x not indexed", bn, l.Address, l.Topics[0])
-					//}
+					res = reqGen.Erigon("eth_getLogs", reqGen.getLogs1(prevBn, bn, l.Address, l.Topics[0]), &resp)
+					if res.Err != nil {
+						return fmt.Errorf("Could not get modified accounts (Erigon): %v\n", res.Err)
+					}
+					if resp.Error != nil {
+						return fmt.Errorf("Error getting modified accounts (Erigon): %d %s\n", resp.Error.Code, resp.Error.Message)
+					}
+					if len(resp.Result) == 0 {
+						return fmt.Errorf("eth_getLogs: at blockNum=%d account %x, topic %x not indexed", bn, l.Address, l.Topics[0])
+					}
 				}
 
 				select {

--- a/cmd/rpctest/rpctest/bench_ethgetlogs.go
+++ b/cmd/rpctest/rpctest/bench_ethgetlogs.go
@@ -177,7 +177,7 @@ func EthGetLogsInvariants(erigonURL, gethURL string, needCompare bool, blockFrom
 					return fmt.Errorf("Error getting modified accounts (Erigon): %d %s\n", resp.Error.Code, resp.Error.Message)
 				}
 
-				sawAddr := map[common.Address]struct{}{}
+				sawAddr := map[common.Address]struct{}{} // don't check same addr in this block
 				sawTopic := map[common.Hash]struct{}{}
 				for _, l := range resp.Result {
 					if _, ok := sawAddr[l.Address]; ok {


### PR DESCRIPTION
optimize `go run ./cmd/rpctest invariantsEthGetLogs` to not check same address twice in same block
on bor-mainnet it gives ~100x