### PR TITLE
Invalidate potentially stale header hash

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -1011,7 +1011,6 @@ func (bb *Body) DecodeRLP(s *rlp.Stream) error {
 // the given txs, uncles, receipts, and withdrawals.
 func NewBlock(header *Header, txs []Transaction, uncles []*Header, receipts []*Receipt, withdrawals []*Withdrawal) *Block {
 	b := &Block{header: CopyHeader(header)}
-	b.header.mutable = true // temporarily make header mutable for modifications below
 
 	// TODO: panic if len(txs) != len(receipts)
 	if len(txs) == 0 {
@@ -1056,8 +1055,6 @@ func NewBlock(header *Header, txs []Transaction, uncles []*Header, receipts []*R
 	}
 
 	b.header.ParentBeaconBlockRoot = header.ParentBeaconBlockRoot
-	hash := b.header.Hash() // recalculate since the modifications above may invalidate the copied cached hash
-	b.header.hash.Store(&hash)
 	b.header.mutable = false //Force immutability of block and header. Use `NewBlockForAsembling` if you need mutable block
 	return b
 }

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -518,7 +518,7 @@ func TestWithdrawalsEncoding(t *testing.T) {
 	var decoded Block
 	require.NoError(t, rlp.DecodeBytes(encoded, &decoded))
 
-	assert.Equal(t, block, &decoded)
+	assert.Equal(t, block.Hash(), decoded.Hash())
 
 	// Now test with empty withdrawals
 	block2 := NewBlock(&header, nil, nil, nil, []*Withdrawal{})
@@ -530,7 +530,7 @@ func TestWithdrawalsEncoding(t *testing.T) {
 	var decoded2 Block
 	require.NoError(t, rlp.DecodeBytes(encoded2, &decoded2))
 
-	assert.Equal(t, block2, &decoded2)
+	assert.Equal(t, block2.Hash(), decoded2.Hash())
 }
 
 func TestBlockRawBodyPreShanghai(t *testing.T) {


### PR DESCRIPTION
There are scenarios where we copy an immutable header, apply changes to it, then calculate the new hash, but because the cached value is also copied over in `CopyHeader()`, then we end up calculating a stale hash.

This could happen due to the modifications in `NewBlock()` which invalidate the copied over cached hash. 

Likewise `*Block.WithSeal()` makes a mutable header immutable, however it doesn't ensure to refresh the cached hash.

These scenarios are covered in this PR by refreshing the cached header hash.
