### PR TITLE
tests for snap_repo and freezing ranges

### DIFF
--- a/core/test/marked_appendable_test.go
+++ b/core/test/marked_appendable_test.go
@@ -30,15 +30,13 @@ type UnmarkedTxI = state.UnmarkedTxI
 
 func registerEntity(dirs datadir.Dirs, name string) ae.AppendableId {
 	stepSize := uint64(10)
-	return registerEntityWithSnapshotConfig(dirs, name, &ae.SnapshotConfig{
-		SnapshotCreationConfig: &ae.SnapshotCreationConfig{
-			RootNumPerStep: 10,
-			MergeStages:    []uint64{20, 40},
-			MinimumSize:    10,
-			SafetyMargin:   5,
-		},
-		Schema: ae.NewE2SnapSchemaWithStep(dirs, name, []string{name}, stepSize),
-	})
+	return registerEntityWithSnapshotConfig(dirs, name, ae.NewSnapshotConfig(&ae.SnapshotCreationConfig{
+		RootNumPerStep: 10,
+		MergeStages:    []uint64{20, 40},
+		MinimumSize:    10,
+		SafetyMargin:   5,
+	}, ae.NewE2SnapSchemaWithStep(dirs, name, []string{name}, stepSize)))
+
 }
 
 func registerEntityWithSnapshotConfig(dirs datadir.Dirs, name string, cfg *ae.SnapshotConfig) ae.AppendableId {

--- a/core/test/unmarked_appendable_test.go
+++ b/core/test/unmarked_appendable_test.go
@@ -25,15 +25,15 @@ func (r *BorSpanRootRelation) RootNum2Num(from state.RootNum, tx kv.Tx) (state.N
 func setupBorSpans(t *testing.T, log log.Logger, dirs datadir.Dirs, db kv.RoDB) (AppendableId, *state.Appendable[UnmarkedTxI]) {
 	stepSize := uint64(10)
 	name := "borspans"
-	borspanId := registerEntityWithSnapshotConfig(dirs, name, &ae.SnapshotConfig{
-		SnapshotCreationConfig: &ae.SnapshotCreationConfig{
+	borspanId := registerEntityWithSnapshotConfig(dirs, name, ae.NewSnapshotConfig(
+		&ae.SnapshotCreationConfig{
 			RootNumPerStep: stepSize,
 			MergeStages:    []uint64{200, 400},
 			MinimumSize:    10,
 			SafetyMargin:   5,
 		},
-		Schema: ae.NewE2SnapSchemaWithStep(dirs, name, []string{name}, stepSize),
-	})
+		ae.NewE2SnapSchemaWithStep(dirs, name, []string{name}, stepSize),
+	))
 	require.Equal(t, ae.AppendableId(0), borspanId)
 
 	indexb := state.NewSimpleAccessorBuilder(state.NewAccessorArgs(true, false), borspanId, log)

--- a/erigon-lib/state/appendable_extras/snap_config.go
+++ b/erigon-lib/state/appendable_extras/snap_config.go
@@ -49,6 +49,27 @@ type SnapshotConfig struct {
 	Schema SnapNameSchema
 }
 
+func NewSnapshotConfig(cfg *SnapshotCreationConfig, schema SnapNameSchema) *SnapshotConfig {
+	c := &SnapshotConfig{
+		SnapshotCreationConfig: cfg,
+		Schema:                 schema,
+	}
+	c.validate()
+	return c
+}
+
+func (s *SnapshotConfig) validate() {
+	// some validation
+	for i := range s.MergeStages {
+		if s.MergeStages[i]%s.RootNumPerStep != 0 {
+			panic(fmt.Sprintf("MergeStages[%d] must be divisible by EntitiesPerStep", i))
+		}
+	}
+	if s.MinimumSize%s.RootNumPerStep != 0 {
+		panic(fmt.Sprintf("MinimumSize(%d) must be divisible by EntitiesPerStep(%d)", s.MinimumSize, s.RootNumPerStep))
+	}
+}
+
 func (s *SnapshotConfig) StepsInFrozenFile() uint64 {
 	return s.MergeStages[len(s.MergeStages)-1] / s.RootNumPerStep
 }
@@ -64,16 +85,6 @@ func (s *SnapshotConfig) LoadPreverified(pre snapcfg.Preverified) {
 			continue
 		}
 		s.PreverifiedParsed = append(s.PreverifiedParsed, res)
-	}
-
-	// some validation
-	for i := range s.MergeStages {
-		if s.MergeStages[i]%s.RootNumPerStep != 0 {
-			panic(fmt.Sprintf("MergeStages[%d] must be divisible by EntitiesPerStep", i))
-		}
-	}
-	if s.MinimumSize%s.RootNumPerStep != 0 {
-		panic(fmt.Sprintf("MinimumSize(%d) must be divisible by EntitiesPerStep(%d)", s.MinimumSize, s.RootNumPerStep))
 	}
 }
 

--- a/erigon-lib/state/appendable_extras/snap_config.go
+++ b/erigon-lib/state/appendable_extras/snap_config.go
@@ -62,11 +62,11 @@ func (s *SnapshotConfig) validate() {
 	// some validation
 	for i := range s.MergeStages {
 		if s.MergeStages[i]%s.RootNumPerStep != 0 {
-			panic(fmt.Sprintf("MergeStages[%d] must be divisible by EntitiesPerStep", i))
+			panic(fmt.Sprintf("MergeStages[%d] must be divisible by RootNumPerStep", i))
 		}
 	}
 	if s.MinimumSize%s.RootNumPerStep != 0 {
-		panic(fmt.Sprintf("MinimumSize(%d) must be divisible by EntitiesPerStep(%d)", s.MinimumSize, s.RootNumPerStep))
+		panic(fmt.Sprintf("MinimumSize(%d) must be divisible by RootNumPerStep(%d)", s.MinimumSize, s.RootNumPerStep))
 	}
 }
 

--- a/erigon-lib/state/appendable_extras/snap_schema_test.go
+++ b/erigon-lib/state/appendable_extras/snap_schema_test.go
@@ -104,7 +104,7 @@ func TestE3SnapSchemaForDomain1(t *testing.T) {
 
 	dirs := setup(t)
 	stepSize := uint64(config3.DefaultStepSize)
-	p := NewE3ParserBuilder(AccessorBTree|AccessorExistence, stepSize).
+	p := NewE3SnapSchemaBuilder(AccessorBTree|AccessorExistence, stepSize).
 		Data(dirs.SnapDomain, "accounts", DataExtensionKv).
 		BtIndex(seg.CompressNone).
 		Existence().Build()
@@ -162,7 +162,7 @@ func TestE3SnapSchemaForDomain1(t *testing.T) {
 func TestE3SnapSchemaForCommitmentDomain(t *testing.T) {
 	dirs := setup(t)
 	stepSize := uint64(config3.DefaultStepSize)
-	p := NewE3ParserBuilder(AccessorHashMap, stepSize).
+	p := NewE3SnapSchemaBuilder(AccessorHashMap, stepSize).
 		Data(dirs.SnapDomain, "commitments", DataExtensionKv).
 		Accessor(dirs.SnapDomain, AccessorExtensionKvi).Build()
 
@@ -208,7 +208,7 @@ func TestE3SnapSchemaForCommitmentDomain(t *testing.T) {
 func TestE3SnapSchemaForHistory(t *testing.T) {
 	dirs := setup(t)
 	stepSize := uint64(config3.DefaultStepSize)
-	p := NewE3ParserBuilder(AccessorHashMap, stepSize).
+	p := NewE3SnapSchemaBuilder(AccessorHashMap, stepSize).
 		Data(dirs.SnapHistory, "accounts", DataExtensionV).
 		Accessor(dirs.SnapAccessors, AccessorExtensionVi).Build()
 
@@ -257,7 +257,7 @@ func TestE3SnapSchemaForHistory(t *testing.T) {
 func TestE3SnapSchemaForII(t *testing.T) {
 	dirs := setup(t)
 	stepSize := uint64(config3.DefaultStepSize)
-	p := NewE3ParserBuilder(AccessorHashMap, stepSize).
+	p := NewE3SnapSchemaBuilder(AccessorHashMap, stepSize).
 		Data(dirs.SnapIdx, "logaddrs", DataExtensionEf).
 		Accessor(dirs.SnapAccessors, AccessorExtensionEfi).Build()
 

--- a/erigon-lib/state/history.go
+++ b/erigon-lib/state/history.go
@@ -1302,7 +1302,7 @@ func (ht *HistoryRoTx) RangeAsOf(ctx context.Context, startTxNum uint64, from, t
 }
 
 func (ht *HistoryRoTx) iterateChangedFrozen(fromTxNum, toTxNum int, asc order.By, limit int) (stream.KV, error) {
-	if asc == false {
+	if asc == order.Desc {
 		panic("not supported yet")
 	}
 	if len(ht.iit.files) == 0 {

--- a/erigon-lib/state/simple_index_builder.go
+++ b/erigon-lib/state/simple_index_builder.go
@@ -105,7 +105,7 @@ type AccessorBuilderOptions func(*SimpleAccessorBuilder)
 
 func WithIndexPos(indexPos uint64) AccessorBuilderOptions {
 	return func(s *SimpleAccessorBuilder) {
-		if int(s.indexPos) >= len(s.id.IndexPrefix()) {
+		if int(s.indexPos) >= len(s.id.IndexFileTag()) {
 			panic("indexPos greater than indexPrefix length")
 		}
 		s.indexPos = indexPos
@@ -144,7 +144,7 @@ func (s *SimpleAccessorBuilder) AllowsOrdinalLookupByNum() bool {
 func (s *SimpleAccessorBuilder) Build(ctx context.Context, from, to RootNum, p *background.Progress) (i *recsplit.Index, err error) {
 	defer func() {
 		if rec := recover(); rec != nil {
-			err = fmt.Errorf("%s: at=%d-%d, %v, %s", s.id.IndexPrefix()[s.indexPos], from, to, rec, dbg.Stack())
+			err = fmt.Errorf("%s: at=%d-%d, %v, %s", s.id.IndexFileTag()[s.indexPos], from, to, rec, dbg.Stack())
 		}
 	}()
 	iidq := s.GetInputDataQuery(from, to)

--- a/erigon-lib/state/snap_repo.go
+++ b/erigon-lib/state/snap_repo.go
@@ -64,7 +64,7 @@ func (f *SnapshotRepo) OpenFolder() error {
 	}
 
 	f.closeWhatNotInList(files)
-	f.scanDirtyFiles(files)
+	f.loadDirtyFiles(files)
 	if err := f.openDirtyFiles(); err != nil {
 		return fmt.Errorf("SnapshotRepo(%s).openFolder: %w", f.parser.DataTag(), err)
 	}
@@ -303,7 +303,7 @@ func (f *SnapshotRepo) closeWhatNotInList(fNames []string) {
 	}
 }
 
-func (f *SnapshotRepo) scanDirtyFiles(aps []string) {
+func (f *SnapshotRepo) loadDirtyFiles(aps []string) {
 	if f.stepSize == 0 {
 		panic(fmt.Sprintf("step size if 0 for %s", f.parser.DataTag()))
 	}

--- a/erigon-lib/state/snap_repo_config_test.go
+++ b/erigon-lib/state/snap_repo_config_test.go
@@ -1,0 +1,163 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/erigontech/erigon-lib/chain/snapcfg"
+	"github.com/erigontech/erigon-lib/common/datadir"
+	ae "github.com/erigontech/erigon-lib/state/appendable_extras"
+	"github.com/stretchr/testify/require"
+)
+
+// 1. safety margin is respected
+// 2. minimum size is respected
+// 3. merge stages work
+// 4. preverifiedparsed is respected
+
+func TestFreezingRangeNoPreverified(t *testing.T) {
+	cfg := createConfig(t)
+
+	cases := []struct {
+		testName           string
+		inputFrom, inputTo uint64
+		outFrom, outTo     uint64
+		canFreeze          bool
+	}{
+		{
+			"no safety margin1", 0, 999,
+			0, 0, false,
+		},
+		{
+			"no safety margin2", 0, 1000,
+			0, 0, false,
+		},
+		{
+			"no safety margin3", 0, 1004,
+			0, 0, false,
+		},
+		{
+			"min snap", 0, 1005,
+			0, 1000, true,
+		},
+		{
+			"min snap2", 0, 2005,
+			0, 1000, true,
+		},
+		{
+			"min snap3", 0, 10_000 + 5,
+			0, 10_000, true,
+		},
+		{
+			"min snap - from round off", 4, 10_000 + 5,
+			0, 10_000, true,
+		},
+		{
+			"biggest merge limit", 0, 100_000 + 5,
+			0, 100_000, true,
+		},
+		{
+			"from a different from", 250_000, 350_000 + 5,
+			250_000, 260_000, true,
+		},
+		{
+			"from a different from2", 400_000, 500_000 + 5,
+			400_000, 500_000, true,
+		},
+	}
+
+	for _, testCase := range cases {
+		from, to, canFreeze := getFreezingRange(RootNum(testCase.inputFrom), RootNum(testCase.inputTo), cfg)
+		require.Equal(t, testCase.canFreeze, canFreeze)
+		if canFreeze {
+			require.Equal(t, testCase.outFrom, uint64(from), testCase.testName)
+			require.Equal(t, testCase.outTo, uint64(to), testCase.testName)
+		}
+	}
+}
+
+func TestFreezingRangeWithPreverified(t *testing.T) {
+	cfg := createConfig(t)
+	cfg.LoadPreverified([]snapcfg.PreverifiedItem{
+		{
+			Name: "v1-000000-000500-bodies.seg",
+			Hash: "blahblah",
+		},
+	})
+
+	cases := []struct {
+		testName           string
+		inputFrom, inputTo uint64
+		outFrom, outTo     uint64
+		canFreeze          bool
+	}{
+		{
+			"no safety margin1", 0, 999,
+			0, 0, false,
+		},
+		{
+			"no safety margin2", 0, 1000,
+			0, 0, false,
+		},
+		{
+			"no safety margin3", 0, 1004,
+			0, 0, false,
+		},
+		{
+			"min snap", 0, 1005,
+			0, 1000, true,
+		},
+		{
+			"min snap2", 0, 2005,
+			0, 1000, true,
+		},
+		{
+			"min snap3", 0, 10_000 + 5,
+			0, 10_000, true,
+		},
+		{
+			"min snap - from round off", 4, 10_000 + 5,
+			0, 10_000, true,
+		},
+		{
+			"biggest merge limit - cfg", 0, 100_000 + 5,
+			0, 100_000, true,
+		},
+		{
+			"biggest merge limit - preverified (just short)", 0, 500_000,
+			0, 100_000, true,
+		},
+		{
+			"biggest merge limit - preverified", 0, 500_000 + 5,
+			0, 500_000, true,
+		},
+		{
+			"preverified size, but no preverified", 100_000, 600_000 + 5,
+			100_000, 200_000, true,
+		},
+	}
+
+	for _, testCase := range cases {
+		from, to, canFreeze := getFreezingRange(RootNum(testCase.inputFrom), RootNum(testCase.inputTo), cfg)
+		require.Equal(t, testCase.canFreeze, canFreeze)
+		if canFreeze {
+			require.Equal(t, testCase.outFrom, uint64(from), testCase.testName)
+			require.Equal(t, testCase.outTo, uint64(to), testCase.testName)
+		}
+	}
+}
+
+func createConfig(t *testing.T) *ae.SnapshotConfig {
+	t.Helper()
+	dirs := datadir.New(t.TempDir())
+	stepSize := uint64(1000)
+
+	return ae.NewSnapshotConfig(
+		&ae.SnapshotCreationConfig{
+			RootNumPerStep: stepSize,
+			MergeStages:    []uint64{10 * stepSize, 100 * stepSize},
+			MinimumSize:    stepSize,
+			SafetyMargin:   5,
+		},
+		ae.NewE2SnapSchema(dirs, "bodies"),
+	)
+}

--- a/erigon-lib/state/snap_repo_test.go
+++ b/erigon-lib/state/snap_repo_test.go
@@ -37,7 +37,7 @@ func TestOpenFolder_AccountsDomain(t *testing.T) {
 	})
 	extensions := repo.cfg.Schema.(*ae.E3SnapSchema).FileExtensions()
 	dataCount, btCount, existenceCount, accessorCount := populateFiles(t, dirs, name, extensions, dirs.SnapDomain)
-	require.True(t, dataCount > 0)
+	require.Positive(t, dataCount)
 
 	err := repo.OpenFolder()
 	require.NoError(t, err)
@@ -85,7 +85,7 @@ func TestOpenFolder_CodeII(t *testing.T) {
 	extensions := repo.cfg.Schema.(*ae.E3SnapSchema).FileExtensions()
 	dataCount, btCount, existenceCount, accessorCount := populateFiles(t, dirs, name, extensions, dirs.SnapIdx)
 
-	require.True(t, dataCount > 0)
+	require.Positive(t, dataCount)
 
 	err := repo.OpenFolder()
 	require.NoError(t, err)
@@ -139,7 +139,7 @@ func TestIntegrateDirtyFile(t *testing.T) {
 
 	extensions := repo.cfg.Schema.(*ae.E3SnapSchema).FileExtensions()
 	dataCount, _, _, _ := populateFiles(t, dirs, name, extensions, dirs.SnapDomain)
-	require.True(t, dataCount > 0)
+	require.Positive(t, dataCount)
 
 	err := repo.OpenFolder()
 	require.NoError(t, err)
@@ -179,46 +179,48 @@ func TestCloseFilesAfterRootNum(t *testing.T) {
 
 	extensions := repo.cfg.Schema.(*ae.E3SnapSchema).FileExtensions()
 	dataCount, _, _, _ := populateFiles(t, dirs, name, extensions, dirs.SnapDomain)
-	require.True(t, dataCount > 0)
+	require.Positive(t, dataCount)
 
 	// 0-256, 256-288, 288-296, 296-298
 
 	// all but 1
 	require.NoError(t, repo.OpenFolder())
 	repo.CloseFilesAfterRootNum(stepToRootNum(t, 10, repo))
-	require.Equal(t, len(repo.dirtyFiles.Items()), 1)
+	require.Len(t, repo.dirtyFiles.Items(), 1)
 
 	// all but 1
 	require.NoError(t, repo.OpenFolder())
 	repo.CloseFilesAfterRootNum(stepToRootNum(t, 256, repo))
-	require.Equal(t, len(repo.dirtyFiles.Items()), 1)
+	require.Len(t, repo.dirtyFiles.Items(), 1)
 
 	// all but 2
 	require.NoError(t, repo.OpenFolder())
 	repo.CloseFilesAfterRootNum(stepToRootNum(t, 270, repo))
-	require.Equal(t, len(repo.dirtyFiles.Items()), 2)
+	require.Len(t, repo.dirtyFiles.Items(), 2)
 
 	// all but 2
 	require.NoError(t, repo.OpenFolder())
 	repo.CloseFilesAfterRootNum(stepToRootNum(t, 288, repo))
-	require.Equal(t, len(repo.dirtyFiles.Items()), 2)
+	require.Len(t, repo.dirtyFiles.Items(), 2)
 
 	// all but 3
 	require.NoError(t, repo.OpenFolder())
 	repo.CloseFilesAfterRootNum(stepToRootNum(t, 290, repo))
-	require.Equal(t, len(repo.dirtyFiles.Items()), 3)
+	require.Len(t, repo.dirtyFiles.Items(), 3)
 
 	// all still open
 	require.NoError(t, repo.OpenFolder())
 	repo.CloseFilesAfterRootNum(stepToRootNum(t, 297, repo))
-	require.Equal(t, len(repo.dirtyFiles.Items()), 4)
+	require.Len(t, repo.dirtyFiles.Items(), 4)
 }
 
 func stepToRootNum(t *testing.T, step uint64, repo *SnapshotRepo) RootNum {
+	t.Helper()
 	return RootNum(repo.cfg.RootNumPerStep * step)
 }
 
 func setupEntity(t *testing.T, genRepo func(stepSize uint64, dirs datadir.Dirs) (name string, schema ae.SnapNameSchema)) (name string, dirs datadir.Dirs, repo *SnapshotRepo) {
+	t.Helper()
 	dirs = datadir.New(t.TempDir())
 	stepSize := uint64(10)
 	name, schema := genRepo(stepSize, dirs)
@@ -365,6 +367,7 @@ func touch(t *testing.T, folder string, files []string, fileGen func(filename st
 }
 
 func touchFile(t *testing.T, filename string) {
+	t.Helper()
 	file, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE, 0666)
 	if err != nil {
 		t.Fatalf("failed to open file %s: %v", filename, err)

--- a/erigon-lib/state/snap_repo_test.go
+++ b/erigon-lib/state/snap_repo_test.go
@@ -236,6 +236,7 @@ func setupEntity(t *testing.T, genRepo func(stepSize uint64, dirs datadir.Dirs) 
 
 	t.Cleanup(func() {
 		repo.Close()
+		os.RemoveAll(dirs.DataDir)
 	})
 
 	return name, dirs, repo

--- a/erigon-lib/state/snap_repo_test.go
+++ b/erigon-lib/state/snap_repo_test.go
@@ -1,0 +1,390 @@
+package state
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/erigontech/erigon-lib/common/background"
+	"github.com/erigontech/erigon-lib/common/datadir"
+	"github.com/erigontech/erigon-lib/downloader/snaptype"
+	"github.com/erigontech/erigon-lib/log/v3"
+	"github.com/erigontech/erigon-lib/recsplit"
+	"github.com/erigontech/erigon-lib/seg"
+	ae "github.com/erigontech/erigon-lib/state/appendable_extras"
+	"github.com/stretchr/testify/require"
+)
+
+// 1. create folder with content; OpenFolder contains all dirtyFiles (check the dirty files)
+// 1.1 dirty file integration
+// 2. CloseFilesAFterRootNum
+// 3. check freezing range logics (different file)
+// 4. merge files
+
+func TestOpenFolder_AccountsDomain(t *testing.T) {
+	name, dirs, repo := setupEntity(t, func(stepSize uint64, dirs datadir.Dirs) (name string, schema ae.SnapNameSchema) {
+		accessors := AccessorBTree | AccessorExistence
+		name = "accounts"
+		schema = ae.NewE3SnapSchemaBuilder(accessors, stepSize).
+			Data(dirs.SnapDomain, name, ae.DataExtensionKv).
+			BtIndex(seg.CompressNone).
+			Existence().
+			Build()
+
+		return name, schema
+	})
+	extensions := repo.cfg.Schema.(*ae.E3SnapSchema).FileExtensions()
+	dataCount, btCount, existenceCount, accessorCount := populateFiles(t, dirs, name, extensions, dirs.SnapDomain)
+	require.True(t, dataCount > 0)
+
+	err := repo.OpenFolder()
+	require.NoError(t, err)
+
+	// check dirty files
+	repo.dirtyFiles.Walk(func(items []*filesItem) bool {
+		for _, item := range items {
+			filename := item.decompressor.FileName1
+			require.Contains(t, filename, name)
+			require.NotContains(t, filename, "torrent")
+			dataCount--
+
+			if item.existence != nil {
+				existenceCount--
+			}
+
+			if item.bindex != nil {
+				btCount--
+			}
+
+			if item.index != nil {
+				accessorCount--
+			}
+		}
+
+		return true
+	})
+
+	require.Equal(t, 0, dataCount)
+	require.Equal(t, 0, btCount)
+	require.Equal(t, 0, existenceCount)
+	require.Equal(t, 0, accessorCount)
+}
+
+func TestOpenFolder_CodeII(t *testing.T) {
+	name, dirs, repo := setupEntity(t, func(stepSize uint64, dirs datadir.Dirs) (name string, schema ae.SnapNameSchema) {
+		accessors := AccessorHashMap
+		name = "code"
+		schema = ae.NewE3SnapSchemaBuilder(accessors, stepSize).
+			Data(dirs.SnapIdx, name, ae.DataExtensionEf).
+			Accessor(dirs.SnapAccessors, ae.AccessorExtensionEfi).Build()
+		return name, schema
+	})
+
+	extensions := repo.cfg.Schema.(*ae.E3SnapSchema).FileExtensions()
+	dataCount, btCount, existenceCount, accessorCount := populateFiles(t, dirs, name, extensions, dirs.SnapIdx)
+
+	require.True(t, dataCount > 0)
+
+	err := repo.OpenFolder()
+	require.NoError(t, err)
+
+	// check dirty files
+	repo.dirtyFiles.Walk(func(items []*filesItem) bool {
+		for _, item := range items {
+			filename := item.decompressor.FileName1
+			require.Contains(t, filename, name)
+			require.NotContains(t, filename, "torrent")
+			dataCount--
+
+			if item.existence != nil {
+				existenceCount--
+			}
+
+			if item.bindex != nil {
+				btCount--
+			}
+
+			if item.index != nil {
+				accessorCount--
+			}
+		}
+
+		return true
+	})
+
+	require.Equal(t, 0, dataCount)
+	require.Equal(t, 0, btCount)
+	require.Equal(t, 0, existenceCount)
+	require.Equal(t, 0, accessorCount)
+}
+
+func TestIntegrateDirtyFile(t *testing.T) {
+	// setup account
+	// add a dirty file
+	// check presence of dirty file
+
+	name, dirs, repo := setupEntity(t, func(stepSize uint64, dirs datadir.Dirs) (name string, schema ae.SnapNameSchema) {
+		accessors := AccessorBTree | AccessorExistence
+		name = "accounts"
+		schema = ae.NewE3SnapSchemaBuilder(accessors, stepSize).
+			Data(dirs.SnapDomain, name, ae.DataExtensionKv).
+			BtIndex(seg.CompressNone).
+			Existence().
+			Build()
+
+		return name, schema
+	})
+
+	extensions := repo.cfg.Schema.(*ae.E3SnapSchema).FileExtensions()
+	dataCount, _, _, _ := populateFiles(t, dirs, name, extensions, dirs.SnapDomain)
+	require.True(t, dataCount > 0)
+
+	err := repo.OpenFolder()
+	require.NoError(t, err)
+
+	filesItem := newFilesItemWithSnapConfig(0, 1024, repo.cfg)
+	filename := repo.parser.DataFile(snaptype.Version(1), 0, 1024)
+	comp, err := seg.NewCompressor(context.Background(), t.Name(), filename, dirs.Tmp, seg.DefaultCfg, log.LvlDebug, log.New())
+	require.NoError(t, err)
+	if err = comp.AddWord([]byte("word")); err != nil {
+		t.Fatal(err)
+	}
+	require.NoError(t, comp.Compress())
+	comp.Close()
+
+	filesItem.decompressor, err = seg.NewDecompressor(filename)
+	require.NoError(t, err)
+	// add dirty file
+	repo.IntegrateDirtyFile(filesItem)
+	_, found := repo.dirtyFiles.Get(filesItem)
+	require.True(t, found)
+}
+
+func TestCloseFilesAfterRootNum(t *testing.T) {
+	// setup account
+	// set various root numbers and check if the right files are closed
+
+	name, dirs, repo := setupEntity(t, func(stepSize uint64, dirs datadir.Dirs) (name string, schema ae.SnapNameSchema) {
+		accessors := AccessorBTree | AccessorExistence
+		name = "accounts"
+		schema = ae.NewE3SnapSchemaBuilder(accessors, stepSize).
+			Data(dirs.SnapDomain, name, ae.DataExtensionKv).
+			BtIndex(seg.CompressNone).
+			Existence().
+			Build()
+		return name, schema
+	})
+
+	extensions := repo.cfg.Schema.(*ae.E3SnapSchema).FileExtensions()
+	dataCount, _, _, _ := populateFiles(t, dirs, name, extensions, dirs.SnapDomain)
+	require.True(t, dataCount > 0)
+
+	// 0-256, 256-288, 288-296, 296-298
+
+	// all but 1
+	require.NoError(t, repo.OpenFolder())
+	repo.CloseFilesAfterRootNum(stepToRootNum(t, 10, repo))
+	require.Equal(t, len(repo.dirtyFiles.Items()), 1)
+
+	// all but 1
+	require.NoError(t, repo.OpenFolder())
+	repo.CloseFilesAfterRootNum(stepToRootNum(t, 256, repo))
+	require.Equal(t, len(repo.dirtyFiles.Items()), 1)
+
+	// all but 2
+	require.NoError(t, repo.OpenFolder())
+	repo.CloseFilesAfterRootNum(stepToRootNum(t, 270, repo))
+	require.Equal(t, len(repo.dirtyFiles.Items()), 2)
+
+	// all but 2
+	require.NoError(t, repo.OpenFolder())
+	repo.CloseFilesAfterRootNum(stepToRootNum(t, 288, repo))
+	require.Equal(t, len(repo.dirtyFiles.Items()), 2)
+
+	// all but 3
+	require.NoError(t, repo.OpenFolder())
+	repo.CloseFilesAfterRootNum(stepToRootNum(t, 290, repo))
+	require.Equal(t, len(repo.dirtyFiles.Items()), 3)
+
+	// all still open
+	require.NoError(t, repo.OpenFolder())
+	repo.CloseFilesAfterRootNum(stepToRootNum(t, 297, repo))
+	require.Equal(t, len(repo.dirtyFiles.Items()), 4)
+}
+
+func stepToRootNum(t *testing.T, step uint64, repo *SnapshotRepo) RootNum {
+	return RootNum(repo.cfg.RootNumPerStep * step)
+}
+
+func cleanup(t *testing.T, dirs datadir.Dirs) {
+	t.Cleanup(func() {
+		os.RemoveAll(dirs.Snap)
+		os.RemoveAll(dirs.Chaindata)
+		os.RemoveAll(dirs.SnapIdx)
+		os.RemoveAll(dirs.SnapAccessors)
+		os.RemoveAll(dirs.Tmp)
+		os.RemoveAll(dirs.SnapDomain)
+	})
+}
+
+func setupEntity(t *testing.T, genRepo func(stepSize uint64, dirs datadir.Dirs) (name string, schema ae.SnapNameSchema)) (name string, dirs datadir.Dirs, repo *SnapshotRepo) {
+	dirs = datadir.New(t.TempDir())
+	stepSize := uint64(10)
+	name, schema := genRepo(stepSize, dirs)
+
+	createConfig := ae.SnapshotCreationConfig{
+		RootNumPerStep: stepSize,
+		MergeStages:    []uint64{20, 40},
+		MinimumSize:    10,
+		SafetyMargin:   5,
+	}
+	repo = NewSnapshotRepo(name, &ae.SnapshotConfig{
+		SnapshotCreationConfig: &createConfig,
+		Schema:                 schema,
+	}, log.New())
+
+	cleanup(t, dirs)
+	return name, dirs, repo
+}
+
+func populateFiles(t *testing.T, dirs datadir.Dirs, name string, extensions []string, dataFolder string) (dataFileCount, btCount, existenceCount, accessorCount int) {
+	t.Helper()
+
+	// populate data files
+
+	// 1. account domain, history and ii
+
+	domainFolder := dirs.SnapDomain
+	domainFiles := []string{"v1-accounts.0-256.bt", "v1-accounts.0-256.bt.torrent", "v1-accounts.0-256.kv", "v1-accounts.0-256.kv.torrent", "v1-accounts.0-256.kvei", "v1-accounts.0-256.kvei.torrent", "v1-accounts.256-288.bt", "v1-accounts.256-288.bt.torrent", "v1-accounts.256-288.kv", "v1-accounts.256-288.kv.torrent", "v1-accounts.256-288.kvei", "v1-accounts.256-288.kvei.torrent", "v1-accounts.288-296.bt", "v1-accounts.288-296.bt.torrent", "v1-accounts.288-296.kv", "v1-accounts.288-296.kv.torrent", "v1-accounts.288-296.kvei", "v1-accounts.288-296.kvei.torrent", "v1-accounts.296-298.bt", "v1-accounts.296-298.bt.torrent", "v1-accounts.296-298.kv", "v1-accounts.296-298.kv.torrent", "v1-accounts.296-298.kvei", "v1-accounts.296-298.kvei.torrent", "v1-code.0-256.bt", "v1-code.0-256.bt.torrent", "v1-code.0-256.kv", "v1-code.0-256.kv.torrent", "v1-code.0-256.kvei", "v1-code.0-256.kvei.torrent", "v1-code.256-288.bt", "v1-code.256-288.bt.torrent", "v1-code.256-288.kv", "v1-code.256-288.kv.torrent", "v1-code.256-288.kvei", "v1-code.256-288.kvei.torrent", "v1-code.288-296.bt", "v1-code.288-296.bt.torrent", "v1-code.288-296.kv", "v1-code.288-296.kv.torrent", "v1-code.288-296.kvei", "v1-code.288-296.kvei.torrent", "v1-code.296-298.bt", "v1-code.296-298.bt.torrent", "v1-code.296-298.kv", "v1-code.296-298.kv.torrent", "v1-code.296-298.kvei", "v1-code.296-298.kvei.torrent", "v1-commitment.0-256.kv", "v1-commitment.0-256.kv.torrent", "v1-commitment.0-256.kvi", "v1-commitment.0-256.kvi.torrent", "v1-commitment.256-288.kv", "v1-commitment.256-288.kv.torrent", "v1-commitment.256-288.kvi", "v1-commitment.256-288.kvi.torrent", "v1-commitment.288-296.kv", "v1-commitment.288-296.kv.torrent", "v1-commitment.288-296.kvi", "v1-commitment.288-296.kvi.torrent", "v1-commitment.296-298.kv", "v1-commitment.296-298.kv.torrent", "v1-commitment.296-298.kvi", "v1-commitment.296-298.kvi.torrent", "v1-receipt.0-256.bt", "v1-receipt.0-256.bt.torrent", "v1-receipt.0-256.kv", "v1-receipt.0-256.kv.torrent", "v1-receipt.0-256.kvei", "v1-receipt.0-256.kvei.torrent", "v1-receipt.256-288.bt", "v1-receipt.256-288.bt.torrent", "v1-receipt.256-288.kv", "v1-receipt.256-288.kv.torrent", "v1-receipt.256-288.kvei", "v1-receipt.256-288.kvei.torrent", "v1-receipt.288-296.bt", "v1-receipt.288-296.bt.torrent", "v1-receipt.288-296.kv", "v1-receipt.288-296.kv.torrent", "v1-receipt.288-296.kvei", "v1-receipt.288-296.kvei.torrent", "v1-receipt.296-298.bt", "v1-receipt.296-298.bt.torrent", "v1-receipt.296-298.kv", "v1-receipt.296-298.kv.torrent", "v1-receipt.296-298.kvei", "v1-receipt.296-298.kvei.torrent", "v1-storage.0-256.bt", "v1-storage.0-256.bt.torrent", "v1-storage.0-256.kv", "v1-storage.0-256.kv.torrent", "v1-storage.0-256.kvei", "v1-storage.0-256.kvei.torrent", "v1-storage.256-288.bt", "v1-storage.256-288.bt.torrent", "v1-storage.256-288.kv", "v1-storage.256-288.kv.torrent", "v1-storage.256-288.kvei", "v1-storage.256-288.kvei.torrent", "v1-storage.288-296.bt", "v1-storage.288-296.bt.torrent", "v1-storage.288-296.kv", "v1-storage.288-296.kv.torrent", "v1-storage.288-296.kvei", "v1-storage.288-296.kvei.torrent", "v1-storage.296-298.bt", "v1-storage.296-298.bt.torrent", "v1-storage.296-298.kv", "v1-storage.296-298.kv.torrent", "v1-storage.296-298.kvei", "v1-storage.296-298.kvei.torrent"}
+
+	historyFolder := dirs.SnapHistory
+	historyFiles := []string{"v1-accounts.0-64.v", "v1-accounts.0-64.v.torrent", "v1-accounts.128-192.v", "v1-accounts.128-192.v.torrent", "v1-accounts.192-256.v", "v1-accounts.192-256.v.torrent", "v1-accounts.256-288.v", "v1-accounts.256-288.v.torrent", "v1-accounts.288-296.v", "v1-accounts.288-296.v.torrent", "v1-accounts.296-298.v", "v1-accounts.296-298.v.torrent", "v1-accounts.64-128.v", "v1-accounts.64-128.v.torrent", "v1-code.0-64.v", "v1-code.0-64.v.torrent", "v1-code.128-192.v", "v1-code.128-192.v.torrent", "v1-code.192-256.v", "v1-code.192-256.v.torrent", "v1-code.256-288.v", "v1-code.256-288.v.torrent", "v1-code.288-296.v", "v1-code.288-296.v.torrent", "v1-code.296-298.v", "v1-code.296-298.v.torrent", "v1-code.64-128.v", "v1-code.64-128.v.torrent", "v1-receipt.0-64.v", "v1-receipt.0-64.v.torrent", "v1-receipt.128-192.v", "v1-receipt.128-192.v.torrent", "v1-receipt.192-256.v", "v1-receipt.192-256.v.torrent", "v1-receipt.256-288.v", "v1-receipt.256-288.v.torrent", "v1-receipt.288-296.v", "v1-receipt.288-296.v.torrent", "v1-receipt.296-298.v", "v1-receipt.296-298.v.torrent", "v1-receipt.64-128.v", "v1-receipt.64-128.v.torrent", "v1-storage.0-64.v", "v1-storage.0-64.v.torrent", "v1-storage.128-192.v", "v1-storage.128-192.v.torrent", "v1-storage.192-256.v", "v1-storage.192-256.v.torrent", "v1-storage.256-288.v", "v1-storage.256-288.v.torrent", "v1-storage.288-296.v", "v1-storage.288-296.v.torrent", "v1-storage.296-298.v", "v1-storage.296-298.v.torrent", "v1-storage.64-128.v", "v1-storage.64-128.v.torrent"}
+
+	accessorFolder := dirs.SnapAccessors
+	accessorFiles := []string{"v1-accounts.0-64.efi", "v1-accounts.0-64.efi.torrent", "v1-accounts.0-64.vi", "v1-accounts.0-64.vi.torrent", "v1-accounts.128-192.efi", "v1-accounts.128-192.efi.torrent", "v1-accounts.128-192.vi", "v1-accounts.128-192.vi.torrent", "v1-accounts.192-256.efi", "v1-accounts.192-256.efi.torrent", "v1-accounts.192-256.vi", "v1-accounts.192-256.vi.torrent", "v1-accounts.256-288.efi", "v1-accounts.256-288.efi.torrent", "v1-accounts.256-288.vi", "v1-accounts.256-288.vi.torrent", "v1-accounts.288-296.efi", "v1-accounts.288-296.efi.torrent", "v1-accounts.288-296.vi", "v1-accounts.288-296.vi.torrent", "v1-accounts.296-298.efi", "v1-accounts.296-298.efi.torrent", "v1-accounts.296-298.vi", "v1-accounts.296-298.vi.torrent", "v1-accounts.64-128.efi", "v1-accounts.64-128.efi.torrent", "v1-accounts.64-128.vi", "v1-accounts.64-128.vi.torrent", "v1-code.0-64.efi", "v1-code.0-64.efi.torrent", "v1-code.0-64.vi", "v1-code.0-64.vi.torrent", "v1-code.128-192.efi", "v1-code.128-192.efi.torrent", "v1-code.128-192.vi", "v1-code.128-192.vi.torrent", "v1-code.192-256.efi", "v1-code.192-256.efi.torrent", "v1-code.192-256.vi", "v1-code.192-256.vi.torrent", "v1-code.256-288.efi", "v1-code.256-288.efi.torrent", "v1-code.256-288.vi", "v1-code.256-288.vi.torrent", "v1-code.288-296.efi", "v1-code.288-296.efi.torrent", "v1-code.288-296.vi", "v1-code.288-296.vi.torrent", "v1-code.296-298.efi", "v1-code.296-298.efi.torrent", "v1-code.296-298.vi", "v1-code.296-298.vi.torrent", "v1-code.64-128.efi", "v1-code.64-128.efi.torrent", "v1-code.64-128.vi", "v1-code.64-128.vi.torrent", "v1-logaddrs.0-64.efi", "v1-logaddrs.0-64.efi.torrent", "v1-logaddrs.128-192.efi", "v1-logaddrs.128-192.efi.torrent", "v1-logaddrs.192-256.efi", "v1-logaddrs.192-256.efi.torrent", "v1-logaddrs.256-288.efi", "v1-logaddrs.256-288.efi.torrent", "v1-logaddrs.288-296.efi", "v1-logaddrs.288-296.efi.torrent", "v1-logaddrs.296-298.efi", "v1-logaddrs.296-298.efi.torrent", "v1-logaddrs.64-128.efi", "v1-logaddrs.64-128.efi.torrent", "v1-logtopics.0-64.efi", "v1-logtopics.0-64.efi.torrent", "v1-logtopics.128-192.efi", "v1-logtopics.128-192.efi.torrent", "v1-logtopics.192-256.efi", "v1-logtopics.192-256.efi.torrent", "v1-logtopics.256-288.efi", "v1-logtopics.256-288.efi.torrent", "v1-logtopics.288-296.efi", "v1-logtopics.288-296.efi.torrent", "v1-logtopics.296-298.efi", "v1-logtopics.296-298.efi.torrent", "v1-logtopics.64-128.efi", "v1-logtopics.64-128.efi.torrent", "v1-receipt.0-64.efi", "v1-receipt.0-64.efi.torrent", "v1-receipt.0-64.vi", "v1-receipt.0-64.vi.torrent", "v1-receipt.128-192.efi", "v1-receipt.128-192.efi.torrent", "v1-receipt.128-192.vi", "v1-receipt.128-192.vi.torrent", "v1-receipt.192-256.efi", "v1-receipt.192-256.efi.torrent", "v1-receipt.192-256.vi", "v1-receipt.192-256.vi.torrent", "v1-receipt.256-288.efi", "v1-receipt.256-288.efi.torrent", "v1-receipt.256-288.vi", "v1-receipt.256-288.vi.torrent", "v1-receipt.288-296.efi", "v1-receipt.288-296.efi.torrent", "v1-receipt.288-296.vi", "v1-receipt.288-296.vi.torrent", "v1-receipt.296-298.efi", "v1-receipt.296-298.efi.torrent", "v1-receipt.296-298.vi", "v1-receipt.296-298.vi.torrent", "v1-receipt.64-128.efi", "v1-receipt.64-128.efi.torrent", "v1-receipt.64-128.vi", "v1-receipt.64-128.vi.torrent", "v1-storage.0-64.efi", "v1-storage.0-64.efi.torrent", "v1-storage.0-64.vi", "v1-storage.0-64.vi.torrent", "v1-storage.128-192.efi", "v1-storage.128-192.efi.torrent", "v1-storage.128-192.vi", "v1-storage.128-192.vi.torrent", "v1-storage.192-256.efi", "v1-storage.192-256.efi.torrent", "v1-storage.192-256.vi", "v1-storage.192-256.vi.torrent", "v1-storage.256-288.efi", "v1-storage.256-288.efi.torrent", "v1-storage.256-288.vi", "v1-storage.256-288.vi.torrent", "v1-storage.288-296.efi", "v1-storage.288-296.efi.torrent", "v1-storage.288-296.vi", "v1-storage.288-296.vi.torrent", "v1-storage.296-298.efi", "v1-storage.296-298.efi.torrent", "v1-storage.296-298.vi", "v1-storage.296-298.vi.torrent", "v1-storage.64-128.efi", "v1-storage.64-128.efi.torrent", "v1-storage.64-128.vi", "v1-storage.64-128.vi.torrent", "v1-tracesfrom.0-64.efi", "v1-tracesfrom.0-64.efi.torrent", "v1-tracesfrom.128-192.efi", "v1-tracesfrom.128-192.efi.torrent", "v1-tracesfrom.192-256.efi", "v1-tracesfrom.192-256.efi.torrent", "v1-tracesfrom.256-288.efi", "v1-tracesfrom.256-288.efi.torrent", "v1-tracesfrom.288-296.efi", "v1-tracesfrom.288-296.efi.torrent", "v1-tracesfrom.296-298.efi", "v1-tracesfrom.296-298.efi.torrent", "v1-tracesfrom.64-128.efi", "v1-tracesfrom.64-128.efi.torrent", "v1-tracesto.0-64.efi", "v1-tracesto.0-64.efi.torrent", "v1-tracesto.128-192.efi", "v1-tracesto.128-192.efi.torrent", "v1-tracesto.192-256.efi", "v1-tracesto.192-256.efi.torrent", "v1-tracesto.256-288.efi", "v1-tracesto.256-288.efi.torrent", "v1-tracesto.288-296.efi", "v1-tracesto.288-296.efi.torrent", "v1-tracesto.296-298.efi", "v1-tracesto.296-298.efi.torrent", "v1-tracesto.64-128.efi", "v1-tracesto.64-128.efi.torrent"}
+
+	idxFolder := dirs.SnapIdx
+	idxFiles := []string{"v1-accounts.0-64.ef", "v1-accounts.0-64.ef.torrent", "v1-accounts.128-192.ef", "v1-accounts.128-192.ef.torrent", "v1-accounts.192-256.ef", "v1-accounts.192-256.ef.torrent", "v1-accounts.256-288.ef", "v1-accounts.256-288.ef.torrent", "v1-accounts.288-296.ef", "v1-accounts.288-296.ef.torrent", "v1-accounts.296-298.ef", "v1-accounts.296-298.ef.torrent", "v1-accounts.64-128.ef", "v1-accounts.64-128.ef.torrent", "v1-code.0-64.ef", "v1-code.0-64.ef.torrent", "v1-code.128-192.ef", "v1-code.128-192.ef.torrent", "v1-code.192-256.ef", "v1-code.192-256.ef.torrent", "v1-code.256-288.ef", "v1-code.256-288.ef.torrent", "v1-code.288-296.ef", "v1-code.288-296.ef.torrent", "v1-code.296-298.ef", "v1-code.296-298.ef.torrent", "v1-code.64-128.ef", "v1-code.64-128.ef.torrent", "v1-logaddrs.0-64.ef", "v1-logaddrs.0-64.ef.torrent", "v1-logaddrs.128-192.ef", "v1-logaddrs.128-192.ef.torrent", "v1-logaddrs.192-256.ef", "v1-logaddrs.192-256.ef.torrent", "v1-logaddrs.256-288.ef", "v1-logaddrs.256-288.ef.torrent", "v1-logaddrs.288-296.ef", "v1-logaddrs.288-296.ef.torrent", "v1-logaddrs.296-298.ef", "v1-logaddrs.296-298.ef.torrent", "v1-logaddrs.64-128.ef", "v1-logaddrs.64-128.ef.torrent", "v1-logtopics.0-64.ef", "v1-logtopics.0-64.ef.torrent", "v1-logtopics.128-192.ef", "v1-logtopics.128-192.ef.torrent", "v1-logtopics.192-256.ef", "v1-logtopics.192-256.ef.torrent", "v1-logtopics.256-288.ef", "v1-logtopics.256-288.ef.torrent", "v1-logtopics.288-296.ef", "v1-logtopics.288-296.ef.torrent", "v1-logtopics.296-298.ef", "v1-logtopics.296-298.ef.torrent", "v1-logtopics.64-128.ef", "v1-logtopics.64-128.ef.torrent", "v1-receipt.0-64.ef", "v1-receipt.0-64.ef.torrent", "v1-receipt.128-192.ef", "v1-receipt.128-192.ef.torrent", "v1-receipt.192-256.ef", "v1-receipt.192-256.ef.torrent", "v1-receipt.256-288.ef", "v1-receipt.256-288.ef.torrent", "v1-receipt.288-296.ef", "v1-receipt.288-296.ef.torrent", "v1-receipt.296-298.ef", "v1-receipt.296-298.ef.torrent", "v1-receipt.64-128.ef", "v1-receipt.64-128.ef.torrent", "v1-storage.0-64.ef", "v1-storage.0-64.ef.torrent", "v1-storage.128-192.ef", "v1-storage.128-192.ef.torrent", "v1-storage.192-256.ef", "v1-storage.192-256.ef.torrent", "v1-storage.256-288.ef", "v1-storage.256-288.ef.torrent", "v1-storage.288-296.ef", "v1-storage.288-296.ef.torrent", "v1-storage.296-298.ef", "v1-storage.296-298.ef.torrent", "v1-storage.64-128.ef", "v1-storage.64-128.ef.torrent", "v1-tracesfrom.0-64.ef", "v1-tracesfrom.0-64.ef.torrent", "v1-tracesfrom.128-192.ef", "v1-tracesfrom.128-192.ef.torrent", "v1-tracesfrom.192-256.ef", "v1-tracesfrom.192-256.ef.torrent", "v1-tracesfrom.256-288.ef", "v1-tracesfrom.256-288.ef.torrent", "v1-tracesfrom.288-296.ef", "v1-tracesfrom.288-296.ef.torrent", "v1-tracesfrom.296-298.ef", "v1-tracesfrom.296-298.ef.torrent", "v1-tracesfrom.64-128.ef", "v1-tracesfrom.64-128.ef.torrent", "v1-tracesto.0-64.ef", "v1-tracesto.0-64.ef.torrent", "v1-tracesto.128-192.ef", "v1-tracesto.128-192.ef.torrent", "v1-tracesto.192-256.ef", "v1-tracesto.192-256.ef.torrent", "v1-tracesto.256-288.ef", "v1-tracesto.256-288.ef.torrent", "v1-tracesto.288-296.ef", "v1-tracesto.288-296.ef.torrent", "v1-tracesto.296-298.ef", "v1-tracesto.296-298.ef.torrent", "v1-tracesto.64-128.ef", "v1-tracesto.64-128.ef.torrent"}
+
+	fileGen := func(filename string) {
+		if strings.HasSuffix(filename, ".ef") || strings.HasSuffix(filename, ".v") || strings.HasSuffix(filename, ".kv") {
+			seg, err := seg.NewCompressor(context.Background(), t.Name(), filename, dirs.Tmp, seg.DefaultCfg, log.LvlDebug, log.New())
+			require.NoError(t, err)
+			if err = seg.AddWord([]byte("word")); err != nil {
+				t.Fatal(err)
+			}
+			require.NoError(t, seg.Compress())
+			seg.Close()
+
+			if strings.Contains(filename, name) && containsSubstring(t, filename, extensions) && strings.Contains(filename, dataFolder) {
+				dataFileCount++
+			}
+
+			return
+		}
+
+		if strings.HasSuffix(filename, ".bt") {
+			seg2, err := seg.NewCompressor(context.Background(), t.Name(), filename+".sample", dirs.Tmp, seg.DefaultCfg, log.LvlDebug, log.New())
+			require.NoError(t, err)
+			if err = seg2.AddWord([]byte("key")); err != nil {
+				t.Fatal(err)
+			}
+			if err = seg2.AddWord([]byte("value")); err != nil {
+				t.Fatal(err)
+			}
+			require.NoError(t, seg2.Compress())
+			defer seg2.Close()
+			seg3, err := seg.NewDecompressor(filename + ".sample")
+			require.NoError(t, err)
+			defer seg3.Close()
+
+			_, err = CreateBtreeIndexWithDecompressor(filename, 128, seg3, seg.CompressNone, uint32(1), background.NewProgressSet(), dirs.Tmp, log.New(), false)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if strings.Contains(filename, name) && containsSubstring(t, filename, extensions) {
+				btCount++
+			}
+
+			return
+		}
+
+		if strings.HasSuffix(filename, ".kvei") {
+			filter, err := NewExistenceFilter(0, filename)
+			require.NoError(t, err)
+			require.NoError(t, filter.Build())
+
+			if strings.Contains(filename, name) && containsSubstring(t, filename, extensions) {
+				existenceCount++
+			}
+
+			return
+		}
+
+		if strings.HasSuffix(filename, ".kvi") || strings.HasSuffix(filename, ".vi") || strings.HasSuffix(filename, ".efi") {
+			salt := uint32(1)
+			rs, err := recsplit.NewRecSplit(recsplit.RecSplitArgs{
+				KeyCount:   1,
+				BucketSize: 10,
+				Salt:       &salt,
+				TmpDir:     dirs.Tmp,
+				IndexFile:  filename,
+				LeafSize:   8,
+			}, log.New())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err = rs.AddKey([]byte("first_key"), 0); err != nil {
+				t.Error(err)
+			}
+			if err = rs.Build(context.Background()); err != nil {
+				t.Errorf("test is expected to fail, too few keys added")
+			}
+
+			rs.Close()
+			if strings.Contains(filename, name) && containsSubstring(t, filename, extensions) {
+				accessorCount++
+			}
+
+			return
+		}
+
+	}
+
+	touch(t, domainFolder, domainFiles, fileGen)
+	touch(t, historyFolder, historyFiles, fileGen)
+	touch(t, accessorFolder, accessorFiles, fileGen)
+	touch(t, idxFolder, idxFiles, fileGen)
+
+	return dataFileCount, btCount, existenceCount, accessorCount
+}
+
+func touch(t *testing.T, folder string, files []string, fileGen func(filename string)) {
+	t.Helper()
+	for _, f := range files {
+		filename := filepath.Join(folder, f)
+		touchFile(t, filename)
+		fileGen(filename)
+	}
+}
+
+func touchFile(t *testing.T, filename string) {
+	file, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		t.Fatalf("failed to open file %s: %v", filename, err)
+	}
+	defer file.Close()
+}
+
+func containsSubstring(t *testing.T, str string, list []string) bool {
+	t.Helper()
+	for _, s := range list {
+		if strings.Contains(str, s) {
+			return true
+		}
+	}
+	return false
+}

--- a/erigon-lib/state/snap_repo_test.go
+++ b/erigon-lib/state/snap_repo_test.go
@@ -218,17 +218,6 @@ func stepToRootNum(t *testing.T, step uint64, repo *SnapshotRepo) RootNum {
 	return RootNum(repo.cfg.RootNumPerStep * step)
 }
 
-func cleanup(t *testing.T, dirs datadir.Dirs) {
-	t.Cleanup(func() {
-		os.RemoveAll(dirs.Snap)
-		os.RemoveAll(dirs.Chaindata)
-		os.RemoveAll(dirs.SnapIdx)
-		os.RemoveAll(dirs.SnapAccessors)
-		os.RemoveAll(dirs.Tmp)
-		os.RemoveAll(dirs.SnapDomain)
-	})
-}
-
 func setupEntity(t *testing.T, genRepo func(stepSize uint64, dirs datadir.Dirs) (name string, schema ae.SnapNameSchema)) (name string, dirs datadir.Dirs, repo *SnapshotRepo) {
 	dirs = datadir.New(t.TempDir())
 	stepSize := uint64(10)
@@ -245,7 +234,10 @@ func setupEntity(t *testing.T, genRepo func(stepSize uint64, dirs datadir.Dirs) 
 		Schema:                 schema,
 	}, log.New())
 
-	cleanup(t, dirs)
+	t.Cleanup(func() {
+		repo.Close()
+	})
+
 	return name, dirs, repo
 }
 


### PR DESCRIPTION
- freezing range tests: given snapshotConfig (with or without preverified files), find the output freezing ranges for which snapshots should be build
- SnapshotRepo tests (`snap_repo_test.go`) -- openfolder, integrate dirty files, close files after root num
- pending: merge files test.