### PR TITLE
rpc: spam debug logs about events

### DIFF
--- a/polygon/bridge/reader.go
+++ b/polygon/bridge/reader.go
@@ -87,10 +87,6 @@ func (r *Reader) Events(ctx context.Context, blockNum uint64) ([]*types.Message,
 		return nil, err
 	}
 
-	if len(events) > 0 {
-		r.logger.Debug(bridgeLogPrefix("events for block"), "block", blockNum, "start", start, "end", end)
-	}
-
 	// convert to message
 	for _, event := range events {
 		msg := types.NewMessage(


### PR DESCRIPTION
when doing rpc requests - I see many:
```
DBUG[04-08|22:06:46.266] [bridge] events for block                block=70070560 start=3051918 end=3051918
DBUG[04-08|22:06:46.268] [bridge] events for block                block=70070560 start=3051918 end=3051918
DBUG[04-08|22:06:46.268] [bridge] events for block                block=70070560 start=3051918 end=3051918
```