### PR TITLE
Added merge command

### DIFF
--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -700,33 +700,6 @@ func (a *Aggregator) mergeLoopStep(ctx context.Context, toTxNum uint64) (somethi
 	return true, nil
 }
 
-func (a *Aggregator) RemoveOverlaps(ctx context.Context) (err error) {
-	a.logger.Debug("[agg] remove overlaps")
-
-	aggTx := a.BeginFilesRo()
-	defer aggTx.Close()
-
-	for _, tx := range aggTx.d {
-		if len(tx.files) > 0 {
-			overlaps := tx.garbage(tx.files[len(tx.files)-1].src)
-			deleteMergeFile(tx.d.dirtyFiles, overlaps, tx.d.filenameBase, tx.d.logger)
-		}
-		if len(tx.ht.files) > 0 {
-			overlaps := tx.ht.garbage(tx.ht.files[len(tx.ht.files)-1].src)
-			deleteMergeFile(tx.d.History.dirtyFiles, overlaps, tx.d.History.filenameBase, tx.d.logger)
-		}
-	}
-
-	for _, itx := range aggTx.iis {
-		if len(itx.files) > 0 {
-			overlaps := itx.garbage(itx.files[len(itx.files)-1].src)
-			deleteMergeFile(itx.ii.dirtyFiles, overlaps, itx.ii.filenameBase, itx.ii.logger)
-		}
-	}
-
-	return nil
-}
-
 func (a *Aggregator) MergeLoop(ctx context.Context) (err error) {
 	if dbg.NoMerge() || !a.mergingFiles.CompareAndSwap(false, true) {
 		return nil // currently merging or merge is prohibited

--- a/turbo/snapshotsync/freezeblocks/caplin_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/caplin_snapshots.go
@@ -285,6 +285,26 @@ Loop:
 	return nil
 }
 
+func (s *CaplinSnapshots) RemoveOverlaps() error {
+	list, _, err := snapshotsync.SegmentsCaplin(s.dir, 0)
+
+	if err != nil {
+		return err
+	}
+
+	if _, toRemove := snapshotsync.FindOverlaps(list); len(toRemove) > 0 {
+		filesToRemove := make([]string, 0, len(toRemove))
+
+		for _, info := range toRemove {
+			filesToRemove = append(filesToRemove, info.Path)
+		}
+
+		snapshotsync.RemoveOldFiles(filesToRemove, s.dir)
+	}
+
+	return nil
+}
+
 func (s *CaplinSnapshots) recalcVisibleFiles() {
 	defer func() {
 		s.idxMax.Store(s.idxAvailability())

--- a/turbo/snapshotsync/snapshots.go
+++ b/turbo/snapshotsync/snapshots.go
@@ -404,7 +404,7 @@ func (s *DirtySegment) closeAndRemoveFiles() {
 		s.closeSeg()
 
 		snapDir := filepath.Dir(f)
-		removeOldFiles([]string{f}, snapDir)
+		RemoveOldFiles([]string{f}, snapDir)
 	}
 }
 
@@ -1245,14 +1245,14 @@ func (s *RoSnapshots) RemoveOverlaps() error {
 			filesToRemove = append(filesToRemove, info.Path)
 		}
 
-		removeOldFiles(filesToRemove, s.dir)
+		RemoveOldFiles(filesToRemove, s.dir)
 	}
 
 	return nil
 }
 
 func (s *RoSnapshots) RemoveOldFiles(filesToRemove []string) {
-	removeOldFiles(filesToRemove, s.dir)
+	RemoveOldFiles(filesToRemove, s.dir)
 }
 
 type snapshotNotifier interface {
@@ -1568,7 +1568,7 @@ func sendDiagnostics(startIndexingTime time.Time, indexPercent map[string]int, a
 	})
 }
 
-func removeOldFiles(toDel []string, snapDir string) {
+func RemoveOldFiles(toDel []string, snapDir string) {
 	for _, f := range toDel {
 		_ = os.Remove(f)
 		_ = os.Remove(f + ".torrent")


### PR DESCRIPTION
This adds a snapshot command which can be run externally after erigon has shutdown to clean overlapping files from the snapshots directory.

It is intended to be run as part of the snapshots automation.

It has the following command line

```shell
erigon snapshots remove-overlaps --datadir /path
```
