### PR TITLE
Added more logs

### DIFF
--- a/erigon-lib/kv/kvcache/cache.go
+++ b/erigon-lib/kv/kvcache/cache.go
@@ -32,6 +32,7 @@ import (
 	"golang.org/x/crypto/sha3"
 
 	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/common/dbg"
 	"github.com/erigontech/erigon-lib/gointerfaces"
 	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
 	"github.com/erigontech/erigon-lib/kv"
@@ -328,37 +329,54 @@ func (c *Coherent) OnNewBlock(stateChanges *remote.StateChangeBatch) {
 }
 
 func (c *Coherent) View(ctx context.Context, tx kv.Tx) (CacheView, error) {
-	fmt.Printf("[View] View called for txID %d\n", tx.ViewID())
+	if dbg.Enabled(ctx) {
+		fmt.Printf("[View] View called for txID %d\n", tx.ViewID())
+	}
 	id, err := tx.ReadSequence(string(kv.PlainStateVersion))
 	if err != nil {
 		return nil, err
 	}
-	fmt.Printf("[View] Got state version for txID %d\n", tx.ViewID())
+	if dbg.Enabled(ctx) {
+		fmt.Printf("[View] Got state version for txID %d\n", tx.ViewID())
+	}
 
 	r := c.selectOrCreateRoot(id)
-	fmt.Printf("[View] Selected/created root for txID %d, readyChanClosed: %v\n", tx.ViewID(), r.readyChanClosed.Load())
+	if dbg.Enabled(ctx) {
+		fmt.Printf("[View] Selected/created root for txID %d, readyChanClosed: %v\n", tx.ViewID(), r.readyChanClosed.Load())
+	}
 
 	if !c.cfg.WaitForNewBlock || c.waitExceededCount.Load() >= MAX_WAITS {
-		fmt.Printf("[View] Skipping wait for txID %d - WaitForNewBlock: %v, waitExceededCount: %d\n",
-			tx.ViewID(), c.cfg.WaitForNewBlock, c.waitExceededCount.Load())
+		if dbg.Enabled(ctx) {
+			fmt.Printf("[View] Skipping wait for txID %d - WaitForNewBlock: %v, waitExceededCount: %d\n",
+				tx.ViewID(), c.cfg.WaitForNewBlock, c.waitExceededCount.Load())
+		}
 		return &CoherentView{stateVersionID: id, tx: tx, cache: c}, nil
 	}
 
 	if r.readyChanClosed.Load() {
-		fmt.Printf("[View] Ready channel already closed for txID %d\n", tx.ViewID())
+		if dbg.Enabled(ctx) {
+			fmt.Printf("[View] Ready channel already closed for txID %d\n", tx.ViewID())
+		}
 		return &CoherentView{stateVersionID: id, tx: tx, cache: c}, nil
 	}
 
-	fmt.Printf("[View] Waiting for ready channel for txID %d (timeout: %v)\n", tx.ViewID(), c.cfg.NewBlockWait)
+	if dbg.Enabled(ctx) {
+		fmt.Printf("[View] Waiting for ready channel for txID %d (timeout: %v)\n", tx.ViewID(), c.cfg.NewBlockWait)
+	}
 	select {
 	case <-r.ready:
-		fmt.Printf("[View] Ready channel received for txID %d\n", tx.ViewID())
+		if dbg.Enabled(ctx) {
+			fmt.Printf("[View] Ready channel received for txID %d\n", tx.ViewID())
 		return &CoherentView{stateVersionID: id, tx: tx, cache: c}, nil
 	case <-ctx.Done():
-		fmt.Printf("[View] Context cancelled for txID %d: %v\n", tx.ViewID(), ctx.Err())
+		if dbg.Enabled(ctx) {
+			fmt.Printf("[View] Context cancelled for txID %d: %v\n", tx.ViewID(), ctx.Err())
+		}
 		return nil, fmt.Errorf("kvcache rootNum=%x, %w", tx.ViewID(), ctx.Err())
 	case <-time.After(c.cfg.NewBlockWait):
-		fmt.Printf("[View] Timeout waiting for ready channel for txID %d\n", tx.ViewID())
+		if dbg.Enabled(ctx) {
+			fmt.Printf("[View] Timeout waiting for ready channel for txID %d\n", tx.ViewID())
+		}
 		c.timeout.Inc()
 		c.waitExceededCount.Add(1)
 		return &CoherentView{stateVersionID: id, tx: tx, cache: c}, nil
@@ -389,23 +407,33 @@ func (c *Coherent) getFromCache(k []byte, id uint64, code bool) (*Element, *Cohe
 	return it, r, nil
 }
 func (c *Coherent) Get(k []byte, tx kv.Tx, id uint64) (v []byte, err error) {
-	fmt.Printf("[Get] Get started for key %x, txID %d\n", k, tx.ViewID())
+	if dbg.Enabled(ctx) {
+		fmt.Printf("[Get] Get started for key %x, txID %d\n", k, tx.ViewID())
+	}
 	it, r, err := c.getFromCache(k, id, false)
 	if err != nil {
-		fmt.Printf("[Get] Get cache error for key %x, txID %d: %v\n", k, tx.ViewID(), err)
+		if dbg.Enabled(ctx) {
+			fmt.Printf("[Get] Get cache error for key %x, txID %d: %v\n", k, tx.ViewID(), err)
+		}
 		return nil, err
 	}
 
 	if it != nil {
 		//fmt.Printf("from cache:  %#x,%x\n", k, it.(*Element).V)
-		fmt.Printf("[Get] Cache hit for key %x, txID %d\n", k, tx.ViewID())
+		if dbg.Enabled(ctx) {
+			fmt.Printf("[Get] Cache hit for key %x, txID %d\n", k, tx.ViewID())
+		}
 		c.hits.Inc()
 		return it.V, nil
 	}
-	fmt.Printf("[Get] Cache miss for key %x, txID %d\n", k, tx.ViewID())
+	if dbg.Enabled(ctx) {
+		fmt.Printf("[Get] Cache miss for key %x, txID %d\n", k, tx.ViewID())
+	}
 	c.miss.Inc()
 
-	fmt.Printf("[Get] Attempting to get from DB for key %x, txID %d\n", k, tx.ViewID())
+	if dbg.Enabled(ctx) {
+		fmt.Printf("[Get] Attempting to get from DB for key %x, txID %d\n", k, tx.ViewID())
+	}
 	if c.cfg.StateV3 {
 		if len(k) == 20 {
 			v, _, err = tx.(kv.TemporalTx).GetLatest(kv.AccountsDomain, k)
@@ -416,25 +444,37 @@ func (c *Coherent) Get(k []byte, tx kv.Tx, id uint64) (v []byte, err error) {
 		v, err = tx.GetOne(kv.PlainState, k)
 	}
 	if err != nil {
-		fmt.Printf("[Get] DB error for key %x, txID %d: %v\n", k, tx.ViewID(), err)
+		if dbg.Enabled(ctx) {
+			fmt.Printf("[Get] DB error for key %x, txID %d: %v\n", k, tx.ViewID(), err)
+		}
 		return nil, err
 	}
 	if len(v) == 0 {
-		fmt.Printf("[Get] Empty value from DB for key %x, txID %d\n", k, tx.ViewID())
+		if dbg.Enabled(ctx) {
+			fmt.Printf("[Get] Empty value from DB for key %x, txID %d\n", k, tx.ViewID())
+		}
 		return v, nil
 	}
 	//fmt.Printf("from db: %#x,%x\n", k, v)
 
-	fmt.Printf("[Get] Attempting to acquire lock for key %x, txID %d\n", k, tx.ViewID())
+	if dbg.Enabled(ctx) {
+		fmt.Printf("[Get] Attempting to acquire lock for key %x, txID %d\n", k, tx.ViewID())
+	}
 	c.lock.Lock()
-	fmt.Printf("[Get] Lock acquired for key %x, txID %d\n", k, tx.ViewID())
+	if dbg.Enabled(ctx) {
+		fmt.Printf("[Get] Lock acquired for key %x, txID %d\n", k, tx.ViewID())
+	}
 	defer func() {
 		c.lock.Unlock()
-		fmt.Printf("[Get] Lock released for key %x, txID %d\n", k, tx.ViewID())
+		if dbg.Enabled(ctx) {
+			fmt.Printf("[Get] Lock released for key %x, txID %d\n", k, tx.ViewID())
+		}
 	}()
 
 	v = c.add(common.Copy(k), common.Copy(v), r, id).V
-	fmt.Printf("[Get] Get completed for key %x, txID %d\n", k, tx.ViewID())
+	if dbg.Enabled(ctx) {
+		fmt.Printf("[Get] Get completed for key %x, txID %d\n", k, tx.ViewID())
+	}
 	return v, nil
 }
 

--- a/erigon-lib/kv/kvcache/cache.go
+++ b/erigon-lib/kv/kvcache/cache.go
@@ -328,27 +328,37 @@ func (c *Coherent) OnNewBlock(stateChanges *remote.StateChangeBatch) {
 }
 
 func (c *Coherent) View(ctx context.Context, tx kv.Tx) (CacheView, error) {
+	fmt.Printf("[View] View called for txID %d\n", tx.ViewID())
 	id, err := tx.ReadSequence(string(kv.PlainStateVersion))
 	if err != nil {
 		return nil, err
 	}
+	fmt.Printf("[View] Got state version for txID %d\n", tx.ViewID())
 
 	r := c.selectOrCreateRoot(id)
+	fmt.Printf("[View] Selected/created root for txID %d, readyChanClosed: %v\n", tx.ViewID(), r.readyChanClosed.Load())
 
 	if !c.cfg.WaitForNewBlock || c.waitExceededCount.Load() >= MAX_WAITS {
+		fmt.Printf("[View] Skipping wait for txID %d - WaitForNewBlock: %v, waitExceededCount: %d\n",
+			tx.ViewID(), c.cfg.WaitForNewBlock, c.waitExceededCount.Load())
 		return &CoherentView{stateVersionID: id, tx: tx, cache: c}, nil
 	}
 
 	if r.readyChanClosed.Load() {
+		fmt.Printf("[View] Ready channel already closed for txID %d\n", tx.ViewID())
 		return &CoherentView{stateVersionID: id, tx: tx, cache: c}, nil
 	}
 
+	fmt.Printf("[View] Waiting for ready channel for txID %d (timeout: %v)\n", tx.ViewID(), c.cfg.NewBlockWait)
 	select {
 	case <-r.ready:
+		fmt.Printf("[View] Ready channel received for txID %d\n", tx.ViewID())
 		return &CoherentView{stateVersionID: id, tx: tx, cache: c}, nil
 	case <-ctx.Done():
+		fmt.Printf("[View] Context cancelled for txID %d: %v\n", tx.ViewID(), ctx.Err())
 		return nil, fmt.Errorf("kvcache rootNum=%x, %w", tx.ViewID(), ctx.Err())
 	case <-time.After(c.cfg.NewBlockWait):
+		fmt.Printf("[View] Timeout waiting for ready channel for txID %d\n", tx.ViewID())
 		c.timeout.Inc()
 		c.waitExceededCount.Add(1)
 		return &CoherentView{stateVersionID: id, tx: tx, cache: c}, nil
@@ -379,18 +389,23 @@ func (c *Coherent) getFromCache(k []byte, id uint64, code bool) (*Element, *Cohe
 	return it, r, nil
 }
 func (c *Coherent) Get(k []byte, tx kv.Tx, id uint64) (v []byte, err error) {
+	fmt.Printf("[Get] Get started for key %x, txID %d\n", k, tx.ViewID())
 	it, r, err := c.getFromCache(k, id, false)
 	if err != nil {
+		fmt.Printf("[Get] Get cache error for key %x, txID %d: %v\n", k, tx.ViewID(), err)
 		return nil, err
 	}
 
 	if it != nil {
 		//fmt.Printf("from cache:  %#x,%x\n", k, it.(*Element).V)
+		fmt.Printf("[Get] Cache hit for key %x, txID %d\n", k, tx.ViewID())
 		c.hits.Inc()
 		return it.V, nil
 	}
+	fmt.Printf("[Get] Cache miss for key %x, txID %d\n", k, tx.ViewID())
 	c.miss.Inc()
 
+	fmt.Printf("[Get] Attempting to get from DB for key %x, txID %d\n", k, tx.ViewID())
 	if c.cfg.StateV3 {
 		if len(k) == 20 {
 			v, _, err = tx.(kv.TemporalTx).GetLatest(kv.AccountsDomain, k)
@@ -401,16 +416,25 @@ func (c *Coherent) Get(k []byte, tx kv.Tx, id uint64) (v []byte, err error) {
 		v, err = tx.GetOne(kv.PlainState, k)
 	}
 	if err != nil {
+		fmt.Printf("[Get] DB error for key %x, txID %d: %v\n", k, tx.ViewID(), err)
 		return nil, err
 	}
 	if len(v) == 0 {
+		fmt.Printf("[Get] Empty value from DB for key %x, txID %d\n", k, tx.ViewID())
 		return v, nil
 	}
 	//fmt.Printf("from db: %#x,%x\n", k, v)
 
+	fmt.Printf("[Get] Attempting to acquire lock for key %x, txID %d\n", k, tx.ViewID())
 	c.lock.Lock()
-	defer c.lock.Unlock()
+	fmt.Printf("[Get] Lock acquired for key %x, txID %d\n", k, tx.ViewID())
+	defer func() {
+		c.lock.Unlock()
+		fmt.Printf("[Get] Lock released for key %x, txID %d\n", k, tx.ViewID())
+	}()
+
 	v = c.add(common.Copy(k), common.Copy(v), r, id).V
+	fmt.Printf("[Get] Get completed for key %x, txID %d\n", k, tx.ViewID())
 	return v, nil
 }
 

--- a/erigon-lib/kv/kvcache/cache_test.go
+++ b/erigon-lib/kv/kvcache/cache_test.go
@@ -363,7 +363,7 @@ func TestAPI(t *testing.T) {
 	}()
 	fmt.Printf("-----3\n")
 	txID4 := put(k1[:], account2Enc)
-	time.Sleep(1 * time.Second)
+	time.Sleep(10 * time.Second)
 
 	c.OnNewBlock(&remote.StateChangeBatch{
 		StateVersionId:      txID4,

--- a/erigon-lib/kv/kvcache/cache_test.go
+++ b/erigon-lib/kv/kvcache/cache_test.go
@@ -129,10 +129,10 @@ func TestEviction(t *testing.T) {
 		_ = tx.Put(kv.Sequence, kv.PlainStateVersion, versionID[:])
 		cacheView, _ := c.View(ctx, tx)
 		view := cacheView.(*CoherentView)
-		_, _ = c.Get(k1[:], tx, view.stateVersionID)
-		_, _ = c.Get([]byte{1}, tx, view.stateVersionID)
-		_, _ = c.Get([]byte{2}, tx, view.stateVersionID)
-		_, _ = c.Get([]byte{3}, tx, view.stateVersionID)
+		_, _ = c.Get(ctx, k1[:], tx, view.stateVersionID)
+		_, _ = c.Get(ctx, []byte{1}, tx, view.stateVersionID)
+		_, _ = c.Get(ctx, []byte{2}, tx, view.stateVersionID)
+		_, _ = c.Get(ctx, []byte{3}, tx, view.stateVersionID)
 		//require.Equal(c.roots[c.latestViewID].cache.Len(), c.stateEvict.Len())
 		return nil
 	})
@@ -162,10 +162,10 @@ func TestEviction(t *testing.T) {
 		binary.BigEndian.PutUint64(versionID[:], id)
 		_ = tx.Put(kv.Sequence, kv.PlainStateVersion, versionID[:])
 		view := cacheView.(*CoherentView)
-		_, _ = c.Get(k1[:], tx, view.stateVersionID)
-		_, _ = c.Get(k2[:], tx, view.stateVersionID)
-		_, _ = c.Get([]byte{5}, tx, view.stateVersionID)
-		_, _ = c.Get([]byte{6}, tx, view.stateVersionID)
+		_, _ = c.Get(ctx, k1[:], tx, view.stateVersionID)
+		_, _ = c.Get(ctx, k2[:], tx, view.stateVersionID)
+		_, _ = c.Get(ctx, []byte{5}, tx, view.stateVersionID)
+		_, _ = c.Get(ctx, []byte{6}, tx, view.stateVersionID)
 		return nil
 	})
 	require.Equal(c.roots[c.latestStateVersionID].cache.Len(), c.stateEvict.Len())
@@ -207,7 +207,7 @@ func TestAPI(t *testing.T) {
 					if err != nil {
 						panic(err)
 					}
-					v, err := c.Get(key[:], tx, view.stateVersionID)
+					v, err := c.Get(ctx, key[:], tx, view.stateVersionID)
 					if err != nil {
 						panic(err)
 					}

--- a/erigon-lib/kv/kvcache/cache_test.go
+++ b/erigon-lib/kv/kvcache/cache_test.go
@@ -188,7 +188,10 @@ func TestAPI(t *testing.T) {
 		}
 
 		err = pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
-		require.NoError(t, err)
+		if err != nil {
+			fmt.Println("error writing pprof", err)
+			return
+		}
 	}()
 
 	require := require.New(t)

--- a/erigon-lib/kv/kvcache/cache_test.go
+++ b/erigon-lib/kv/kvcache/cache_test.go
@@ -211,7 +211,7 @@ func TestAPI(t *testing.T) {
 					if err != nil {
 						panic(err)
 					}
-					fmt.Println("get", key, v)
+					fmt.Println("tx", tx.ViewID(), "get", key, v)
 					out <- common.Copy(v)
 					return nil
 				})

--- a/erigon-lib/kv/kvcache/cache_test.go
+++ b/erigon-lib/kv/kvcache/cache_test.go
@@ -175,7 +175,7 @@ func TestEviction(t *testing.T) {
 
 func TestAPI(t *testing.T) {
 	if runtime.GOOS != "linux" {
-		t.Skip("fix me on win please")
+		//t.Skip("fix me on win please")
 	}
 
 	require := require.New(t)

--- a/erigon-lib/kv/kvcache/cache_test.go
+++ b/erigon-lib/kv/kvcache/cache_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -174,10 +173,6 @@ func TestEviction(t *testing.T) {
 }
 
 func TestAPI(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		//t.Skip("fix me on win please")
-	}
-
 	require := require.New(t)
 	c := New(DefaultCoherentConfig)
 	k1, k2 := [20]byte{1}, [20]byte{2}
@@ -351,7 +346,7 @@ func TestAPI(t *testing.T) {
 	}()
 	fmt.Printf("-----3\n")
 	txID4 := put(k1[:], account2Enc)
-	time.Sleep(10 * time.Second)
+	time.Sleep(1 * time.Second)
 
 	c.OnNewBlock(&remote.StateChangeBatch{
 		StateVersionId:      txID4,


### PR DESCRIPTION
- Added more logs to the `Coherent` cache implementation in the `erigon-lib/kv/kvcache/cache.go`
- Added a goroutine dump mechanism in the test suite