### PR TITLE
polygon/bridge: keep events debug log in execution but not in rpcdaemon

### DIFF
--- a/cmd/devnet/services/polygon/heimdallsim/heimdall_simulator.go
+++ b/cmd/devnet/services/polygon/heimdallsim/heimdall_simulator.go
@@ -80,8 +80,8 @@ func (noopBridgeStore) LastFrozenEventBlockNum() uint64 {
 func (noopBridgeStore) EventTxnToBlockNum(ctx context.Context, borTxHash libcommon.Hash) (uint64, bool, error) {
 	return 0, false, errors.New("noop")
 }
-func (noopBridgeStore) EventsByTimeframe(ctx context.Context, timeFrom, timeTo uint64) ([][]byte, error) {
-	return nil, errors.New("noop")
+func (noopBridgeStore) EventsByTimeframe(ctx context.Context, timeFrom, timeTo uint64) ([][]byte, []uint64, error) {
+	return nil, nil, errors.New("noop")
 }
 func (noopBridgeStore) Events(ctx context.Context, start, end uint64) ([][]byte, error) {
 	return nil, errors.New("noop")

--- a/eth/stagedsync/stage_polygon_sync.go
+++ b/eth/stagedsync/stage_polygon_sync.go
@@ -1120,7 +1120,7 @@ func (s polygonSyncStageBridgeStore) Events(context.Context, uint64, uint64) ([]
 	panic("polygonSyncStageBridgeStore.Events not supported")
 }
 
-func (s polygonSyncStageBridgeStore) EventsByTimeframe(ctx context.Context, timeFrom, timeTo uint64) ([][]byte, error) {
+func (s polygonSyncStageBridgeStore) EventsByTimeframe(ctx context.Context, timeFrom, timeTo uint64) ([][]byte, []uint64, error) {
 	// used for accessing events in execution
 	// astrid stage integration intends to use the bridge only for scrapping
 	// not for reading which remains the same in execution (via BlockReader)

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -1567,6 +1567,7 @@ func (c *Bor) CommitStates(
 		var events []*types.Message
 		var err error
 
+		ctx := dbg.ContextWithDebug(c.execCtx, true)
 		if fetchEventsWithingTime {
 			sprintLength := c.config.CalculateSprintLength(blockNum)
 
@@ -1595,12 +1596,12 @@ func (c *Bor) CommitStates(
 				timeTo = time.Unix(int64(prevSprintStart.Time), 0)
 			}
 
-			events, err = c.bridgeReader.EventsWithinTime(c.execCtx, timeFrom, timeTo)
+			events, err = c.bridgeReader.EventsWithinTime(ctx, timeFrom, timeTo)
 			if err != nil {
 				return err
 			}
 		} else {
-			events, err = c.bridgeReader.Events(c.execCtx, blockNum)
+			events, err = c.bridgeReader.Events(ctx, blockNum)
 			if err != nil {
 				return err
 			}

--- a/polygon/bridge/mdbx_store.go
+++ b/polygon/bridge/mdbx_store.go
@@ -249,10 +249,10 @@ func (s *MdbxStore) PutEvents(ctx context.Context, events []*heimdall.EventRecor
 	return tx.Commit()
 }
 
-func (s *MdbxStore) EventsByTimeframe(ctx context.Context, timeFrom, timeTo uint64) ([][]byte, error) {
+func (s *MdbxStore) EventsByTimeframe(ctx context.Context, timeFrom, timeTo uint64) ([][]byte, []uint64, error) {
 	tx, err := s.db.BeginRo(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer tx.Rollback()
 
@@ -522,9 +522,10 @@ func (s txStore) PutEvents(ctx context.Context, events []*heimdall.EventRecordWi
 	return nil
 }
 
-// returns events withing [timeFrom, timeTo) interval.
-func (s txStore) EventsByTimeframe(ctx context.Context, timeFrom, timeTo uint64) ([][]byte, error) {
+// EventsByTimeframe returns events withing [timeFrom, timeTo) interval.
+func (s txStore) EventsByTimeframe(ctx context.Context, timeFrom, timeTo uint64) ([][]byte, []uint64, error) {
 	var events [][]byte
+	var ids []uint64
 
 	kStart := make([]byte, 8)
 	binary.BigEndian.PutUint64(kStart, timeFrom)
@@ -534,24 +535,25 @@ func (s txStore) EventsByTimeframe(ctx context.Context, timeFrom, timeTo uint64)
 
 	it, err := s.tx.Range(kv.BorEventTimes, kStart, kEnd, order.Asc, kv.Unlim)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	for it.HasNext() {
 		_, evID, err := it.Next()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		v, err := s.tx.GetOne(kv.BorEvents, evID)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		events = append(events, bytes.Clone(v))
+		ids = append(ids, binary.BigEndian.Uint64(evID))
 	}
 
-	return events, nil
+	return events, ids, nil
 }
 
 // Events gets raw events, start inclusive, end exclusive

--- a/polygon/bridge/store.go
+++ b/polygon/bridge/store.go
@@ -38,8 +38,8 @@ type Store interface {
 
 	EventTxnToBlockNum(ctx context.Context, borTxHash libcommon.Hash) (uint64, bool, error)
 	Events(ctx context.Context, start, end uint64) ([][]byte, error)
-	BlockEventIdsRange(ctx context.Context, blockNum uint64) (start uint64, end uint64, ok bool, err error) // [start,end)
-	EventsByTimeframe(ctx context.Context, timeFrom, timeTo uint64) ([][]byte, error)                       // [timeFrom, timeTo)
+	BlockEventIdsRange(ctx context.Context, blockNum uint64) (start uint64, end uint64, ok bool, err error)         // [start,end]
+	EventsByTimeframe(ctx context.Context, timeFrom, timeTo uint64) (events [][]byte, eventIds []uint64, err error) // [timeFrom, timeTo)
 
 	PutEventTxnToBlockNum(ctx context.Context, eventTxnToBlockNum map[libcommon.Hash]uint64) error
 	PutEvents(ctx context.Context, events []*heimdall.EventRecordWithTime) error


### PR DESCRIPTION
follow up after https://github.com/erigontech/erigon/pull/14511

-we want to keep that log in execution because it has been very useful several times to help with state root/receipts hash mismatches due to incorrect events from heimdall
- but as Alex says we don't want it in rpcdaemon
- we can solve this using a dbg flag in the `ctx` (we already have the mechanism for this) - set dbg in bor consensus engine ctx and leave it unset for rpcdaemon's ctx
- this PR adds this and adds the log back
- also adds a similar log to the new EventsWithinTime API
