### PR TITLE
Support state sync events in `eth_getLogs`, set correct log indices

### DIFF
--- a/eth/stagedsync/stage_custom_trace.go
+++ b/eth/stagedsync/stage_custom_trace.go
@@ -292,6 +292,25 @@ func customTraceBatch(ctx context.Context, cfg *exec3.ExecArgs, tx kv.TemporalRw
 			}
 
 			if txTask.Final { // block changed
+				if cfg.ChainConfig.Bor != nil && txTask.TxIndex >= 1 {
+					// get last receipt and store the last log index + 1
+					lastReceipt := txTask.BlockReceipts[txTask.TxIndex-1]
+					if lastReceipt == nil {
+						return fmt.Errorf("receipt is nil but should be populated, txIndex=%d, block=%d", txTask.TxIndex-1, txTask.BlockNum)
+					}
+					if len(lastReceipt.Logs) > 0 {
+						firstIndex := lastReceipt.Logs[len(lastReceipt.Logs)-1].Index + 1
+						receipt := types.Receipt{
+							CumulativeGasUsed:        lastReceipt.CumulativeGasUsed,
+							FirstLogIndexWithinBlock: uint32(firstIndex),
+						}
+
+						if err := rawtemporaldb.AppendReceipt(doms, &receipt, cumulativeBlobGasUsedInBlock); err != nil {
+							return err
+						}
+					}
+				}
+
 				cumulativeBlobGasUsedInBlock = 0
 			}
 

--- a/eth/stagedsync/stage_custom_trace.go
+++ b/eth/stagedsync/stage_custom_trace.go
@@ -219,11 +219,15 @@ func AssertReceipts(ctx context.Context, cfg *exec3.ExecArgs, tx kv.TemporalRwTx
 		if int(cumGasUsed) == prevCumGasUsed && cumGasUsed != 0 && blockNum == prevBN {
 			_min, _ := txNumsReader.Min(tx, blockNum)
 			_max, _ := txNumsReader.Max(tx, blockNum)
-			err := fmt.Errorf("bad receipt at txnum: %d, block: %d(%d-%d), cumGasUsed=%d, prevCumGasUsed=%d", txNum, blockNum, _min, _max, cumGasUsed, prevCumGasUsed)
-			log.Warn(err.Error())
-			return err
-			//panic(err)
+
+			if txNum != _max && cfg.ChainConfig.Bor != nil {
+				err := fmt.Errorf("bad receipt at txnum: %d, block: %d(%d-%d), cumGasUsed=%d, prevCumGasUsed=%d", txNum, blockNum, _min, _max, cumGasUsed, prevCumGasUsed)
+				log.Warn(err.Error())
+				return err
+				//panic(err)
+			}
 		}
+
 		prevCumGasUsed = int(cumGasUsed)
 		prevBN = blockNum
 

--- a/eth/stagedsync/stage_custom_trace.go
+++ b/eth/stagedsync/stage_custom_trace.go
@@ -220,7 +220,7 @@ func AssertReceipts(ctx context.Context, cfg *exec3.ExecArgs, tx kv.TemporalRwTx
 			_min, _ := txNumsReader.Min(tx, blockNum)
 			_max, _ := txNumsReader.Max(tx, blockNum)
 
-			if txNum != _max && cfg.ChainConfig.Bor != nil {
+			if cfg.ChainConfig.Bor == nil || (cfg.ChainConfig.Bor != nil && txNum != _max) {
 				err := fmt.Errorf("bad receipt at txnum: %d, block: %d(%d-%d), cumGasUsed=%d, prevCumGasUsed=%d", txNum, blockNum, _min, _max, cumGasUsed, prevCumGasUsed)
 				log.Warn(err.Error())
 				return err

--- a/turbo/jsonrpc/eth_receipts.go
+++ b/turbo/jsonrpc/eth_receipts.go
@@ -37,7 +37,6 @@ import (
 	"github.com/erigontech/erigon/eth/ethutils"
 	"github.com/erigontech/erigon/eth/filters"
 	bortypes "github.com/erigontech/erigon/polygon/bor/types"
-	"github.com/erigontech/erigon/polygon/heimdall"
 	"github.com/erigontech/erigon/rpc"
 	"github.com/erigontech/erigon/turbo/rpchelper"
 	"github.com/erigontech/erigon/turbo/snapshotsync/freezeblocks"
@@ -389,7 +388,7 @@ func (api *BaseAPI) getLogsV3(ctx context.Context, tx kv.TemporalTx, begin, end 
 			if err != nil {
 				return nil, err
 			}
-			txIndex := lastTxNum - firstTxNum
+			txIndex := lastTxNum - firstTxNum - 1 // -1 to account for "final tx"
 
 			_, _, logIndex, err := rawtemporaldb.ReceiptAsOf(tx, lastTxNum+1)
 			if err != nil {

--- a/turbo/jsonrpc/receipts/bor_receipts_generator.go
+++ b/turbo/jsonrpc/receipts/bor_receipts_generator.go
@@ -61,7 +61,7 @@ func (g *BorGenerator) GenerateBorReceipt(ctx context.Context, tx kv.TemporalTx,
 		return nil, err
 	}
 
-	cumGasUsedInLastBlock, _, _, err := rawtemporaldb.ReceiptAsOf(tx, txNum)
+	cumGasUsedInLastBlock, _, firstLogIndex, err := rawtemporaldb.ReceiptAsOf(tx, txNum+1)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func (g *BorGenerator) GenerateBorReceipt(ctx context.Context, tx kv.TemporalTx,
 	gp := new(core.GasPool).AddGas(msgs[0].Gas() * uint64(len(msgs))).AddBlobGas(msgs[0].BlobGas() * uint64(len(msgs)))
 	evm := vm.NewEVM(blockContext, evmtypes.TxContext{}, ibs, chainConfig, vm.Config{})
 
-	receipt, err := applyBorTransaction(msgs, evm, gp, ibs, block, cumGasUsedInLastBlock, 0)
+	receipt, err := applyBorTransaction(msgs, evm, gp, ibs, block, cumGasUsedInLastBlock, uint(firstLogIndex))
 	if err != nil {
 		return nil, err
 	}

--- a/turbo/jsonrpc/receipts/bor_receipts_generator.go
+++ b/turbo/jsonrpc/receipts/bor_receipts_generator.go
@@ -2,6 +2,7 @@ package receipts
 
 import (
 	"context"
+
 	"github.com/erigontech/erigon/core/rawdb/rawtemporaldb"
 
 	lru "github.com/hashicorp/golang-lru/v2"


### PR DESCRIPTION
Workaround to support state sync events in `eth_getLogs` and correct log indices in receipts. Requires re-generation of receipts domain (using `stage_custom_trace`).