### PR TITLE
remove unsafe closing of subsumed files in mergeLoopStep

### DIFF
--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -679,6 +679,9 @@ func (a *Aggregator) mergeLoopStep(ctx context.Context, toTxNum uint64) (somethi
 
 	in, err := aggTx.mergeFiles(ctx, outs, r)
 	if err != nil {
+		if in != nil {
+			in.Close()
+		}
 		return true, err
 	}
 	a.IntegrateMergedDirtyFiles(outs, in)

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -666,7 +666,6 @@ func (a *Aggregator) mergeLoopStep(ctx context.Context, toTxNum uint64) (somethi
 	mxRunningMerges.Inc()
 	defer mxRunningMerges.Dec()
 
-	closeAll := true
 	maxSpan := config3.StepsInFrozenFile * a.StepSize()
 	r := aggTx.findMergeRange(toTxNum, maxSpan)
 	if !r.any() {
@@ -674,11 +673,6 @@ func (a *Aggregator) mergeLoopStep(ctx context.Context, toTxNum uint64) (somethi
 	}
 
 	outs, err := aggTx.FilesInRange(r)
-	defer func() {
-		if closeAll {
-			outs.Close()
-		}
-	}()
 	if err != nil {
 		return false, err
 	}
@@ -687,16 +681,10 @@ func (a *Aggregator) mergeLoopStep(ctx context.Context, toTxNum uint64) (somethi
 	if err != nil {
 		return true, err
 	}
-	defer func() {
-		if closeAll {
-			in.Close()
-		}
-	}()
 	a.IntegrateMergedDirtyFiles(outs, in)
 	a.cleanAfterMerge(in)
 
 	a.onFreeze(in.FrozenList())
-	closeAll = false
 	return true, nil
 }
 


### PR DESCRIPTION
https://github.com/erigontech/erigon/issues/14515

FilesInRange return visibleFiles which are managed by aggRoTx created at start of mergeLoopStep.
MergeFiles don't need to closed (except when aggTx.mergeFiles return err != nil)
