### PR TITLE
downloader: same NetworkChunkSize as in Erigon2

### DIFF
--- a/erigon-lib/downloader/downloadercfg/downloadercfg.go
+++ b/erigon-lib/downloader/downloadercfg/downloadercfg.go
@@ -50,7 +50,7 @@ const DefaultPieceSize = 2 * 1024 * 1024
 
 // DefaultNetworkChunkSize - how much data request per 1 network call to peer.
 // default: 16Kb
-const DefaultNetworkChunkSize = 8 * 1024 * 1024
+const DefaultNetworkChunkSize = 256 * 1024
 
 type Cfg struct {
 	ClientConfig  *torrent.ClientConfig


### PR DESCRIPTION
I did set it high in E3 as an experiment when played with webseeds. But we don't need it. 