### PR TITLE
params: Use no padding in minor version

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -42,7 +42,7 @@ const (
 
 // Version holds the textual version string.
 var Version = func() string {
-	return fmt.Sprintf("%d.%02d.%d", version.Major, version.Minor, version.Micro)
+	return fmt.Sprintf("%d.%d.%d", version.Major, version.Minor, version.Micro)
 }()
 
 // VersionWithMeta holds the textual version string including the metadata.


### PR DESCRIPTION
Padded 2 decimals is not desirable for minor version