### PR TITLE
params: Use no padding in minor version (#14588)

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -46,7 +46,7 @@ const (
 
 // Version holds the textual version string.
 var Version = func() string {
-	return fmt.Sprintf("%d.%02d.%d", VersionMajor, VersionMinor, VersionMicro)
+	return fmt.Sprintf("%d.%d.%d", VersionMajor, VersionMinor, VersionMicro)
 }()
 
 // VersionWithMeta holds the textual version string including the metadata.


### PR DESCRIPTION
Padded 2 decimals is not desirable for minor version
Cherry-pick #14588