### PR TITLE
preparing snap_repo for use outside erigon-lib/state

### DIFF
--- a/erigon-lib/state/appendable_extras/snap_config.go
+++ b/erigon-lib/state/appendable_extras/snap_config.go
@@ -73,6 +73,10 @@ func (s *SnapshotConfig) validate() {
 }
 
 func (s *SnapshotConfig) StepsInFrozenFile() uint64 {
+	if len(s.MergeStages) == 0 {
+		return s.MinimumSize / s.RootNumPerStep
+	}
+
 	return s.MergeStages[len(s.MergeStages)-1] / s.RootNumPerStep
 }
 

--- a/erigon-lib/state/appendable_extras/snap_schema.go
+++ b/erigon-lib/state/appendable_extras/snap_schema.go
@@ -227,6 +227,7 @@ func NewE3SnapSchemaBuilder(accessors Accessors, stepSize uint64) *E3SnapSchemaB
 func (b *E3SnapSchemaBuilder) Data(dataFolder string, dataFileTag string, dataExtension DataExtension, compression seg.FileCompression) *E3SnapSchemaBuilder {
 	b.e.dataFileTag = dataFileTag
 	b.e.dataExtension = dataExtension
+	b.e.dataFileCompression = compression
 	b.e.dataFileMetadata = &_fileMetadata{
 		folder:    dataFolder,
 		supported: true,

--- a/erigon-lib/state/appendable_extras/snap_schema.go
+++ b/erigon-lib/state/appendable_extras/snap_schema.go
@@ -28,12 +28,13 @@ type SnapNameSchema interface {
 
 	// these give out full filepath, not just filename
 	DataFile(version Version, from, to RootNum) string
-	AccessorIdxFile(version Version, from, to RootNum, idxPos uint64) string           // index or accessor file (recsplit typically)
-	BtIdxFile(version Version, from, to RootNum) (filename string, params BtIdxParams) // hack to pass params required for opening btree index
+	AccessorIdxFile(version Version, from, to RootNum, idxPos uint64) string // index or accessor file (recsplit typically)
+	BtIdxFile(version Version, from, to RootNum) string                      // hack to pass params required for opening btree index
 	ExistenceFile(version Version, from, to RootNum) string
 
 	AccessorIdxCount() uint64
 	DataDirectory() string
+	DataFileCompression() seg.FileCompression
 }
 
 type _fileMetadata struct {
@@ -155,7 +156,7 @@ func (s *E2SnapSchema) AccessorIdxFile(version Version, from, to RootNum, idxPos
 	return filepath.Join(s.indexFileMetadata.folder, fmt.Sprintf("%s-%06d-%06d-%s%s", version, from/RootNum(s.stepSize), to/RootNum(s.stepSize), s.indexFileTags[idxPos], string(AccessorExtensionIdx)))
 }
 
-func (s *E2SnapSchema) BtIdxFile(version Version, from, to RootNum) (string, BtIdxParams) {
+func (s *E2SnapSchema) BtIdxFile(version Version, from, to RootNum) string {
 	panic("unsupported")
 }
 
@@ -187,14 +188,19 @@ func (s *E2SnapSchema) DataDirectory() string {
 	return s.dataFileMetadata.folder
 }
 
+func (s *E2SnapSchema) DataFileCompression() seg.FileCompression {
+	return seg.CompressNone
+}
+
 // E3 Schema
 
 type E3SnapSchema struct {
 	stepSize uint64
 
-	dataExtension DataExtension
-	dataFileTag   string
-	accessors     Accessors
+	dataExtension       DataExtension
+	dataFileTag         string
+	dataFileCompression seg.FileCompression
+	accessors           Accessors
 
 	accessorIdxExtension AccessorExtension
 	// caches
@@ -202,9 +208,6 @@ type E3SnapSchema struct {
 	indexFileMetadata     *_fileMetadata
 	btIdxFileMetadata     *_fileMetadata
 	existenceFileMetadata *_fileMetadata
-
-	// misc
-	btParams *BtIdxParams
 }
 
 type E3SnapSchemaBuilder struct {
@@ -221,7 +224,7 @@ func NewE3SnapSchemaBuilder(accessors Accessors, stepSize uint64) *E3SnapSchemaB
 	return &eschema
 }
 
-func (b *E3SnapSchemaBuilder) Data(dataFolder string, dataFileTag string, dataExtension DataExtension) *E3SnapSchemaBuilder {
+func (b *E3SnapSchemaBuilder) Data(dataFolder string, dataFileTag string, dataExtension DataExtension, compression seg.FileCompression) *E3SnapSchemaBuilder {
 	b.e.dataFileTag = dataFileTag
 	b.e.dataExtension = dataExtension
 	b.e.dataFileMetadata = &_fileMetadata{
@@ -233,10 +236,7 @@ func (b *E3SnapSchemaBuilder) Data(dataFolder string, dataFileTag string, dataEx
 
 // currently assumes dataFolder as the folder
 // So, Data() should be called first
-func (b *E3SnapSchemaBuilder) BtIndex(fileCompression seg.FileCompression) *E3SnapSchemaBuilder {
-	b.e.btParams = &BtIdxParams{
-		Compression: fileCompression,
-	}
+func (b *E3SnapSchemaBuilder) BtIndex() *E3SnapSchemaBuilder {
 	b.e.btIdxFileMetadata = &_fileMetadata{
 		folder:    b.e.dataFileMetadata.folder, // assuming "data" and btindex in same folder, which is currently the case
 		supported: true,
@@ -244,12 +244,25 @@ func (b *E3SnapSchemaBuilder) BtIndex(fileCompression seg.FileCompression) *E3Sn
 	return b
 }
 
-func (b *E3SnapSchemaBuilder) Accessor(accessorFolder string, accessorExtension AccessorExtension) *E3SnapSchemaBuilder {
+func (b *E3SnapSchemaBuilder) Accessor(accessorFolder string) *E3SnapSchemaBuilder {
 	b.e.indexFileMetadata = &_fileMetadata{
 		folder:    accessorFolder,
 		supported: true,
 	}
-	b.e.accessorIdxExtension = accessorExtension
+
+	var ex AccessorExtension
+	switch b.e.dataExtension {
+	case DataExtensionKv:
+		ex = AccessorExtensionKvi
+	case DataExtensionV:
+		ex = AccessorExtensionVi
+	case DataExtensionEf:
+		ex = AccessorExtensionEfi
+	default:
+		panic(fmt.Sprintf("unsupported data extension: %s", b.e.dataExtension))
+	}
+
+	b.e.accessorIdxExtension = ex
 	return b
 }
 
@@ -353,11 +366,11 @@ func (s *E3SnapSchema) AccessorIdxFile(version Version, from, to RootNum, idxPos
 	return filepath.Join(s.indexFileMetadata.folder, fmt.Sprintf("%s-%s.%d-%d%s", version, s.dataFileTag, from/RootNum(s.stepSize), to/RootNum(s.stepSize), s.accessorIdxExtension))
 }
 
-func (s *E3SnapSchema) BtIdxFile(version Version, from, to RootNum) (string, BtIdxParams) {
+func (s *E3SnapSchema) BtIdxFile(version Version, from, to RootNum) string {
 	if !s.btIdxFileMetadata.supported {
 		panic(fmt.Sprintf("%s not supported for %s", AccessorBTree, s.dataFileTag))
 	}
-	return filepath.Join(s.btIdxFileMetadata.folder, fmt.Sprintf("%s-%s.%d-%d.bt", version, s.dataFileTag, from/RootNum(s.stepSize), to/RootNum(s.stepSize))), *s.btParams
+	return filepath.Join(s.btIdxFileMetadata.folder, fmt.Sprintf("%s-%s.%d-%d.bt", version, s.dataFileTag, from/RootNum(s.stepSize), to/RootNum(s.stepSize)))
 }
 
 func (s *E3SnapSchema) ExistenceFile(version Version, from, to RootNum) string {
@@ -384,6 +397,10 @@ func (s *E3SnapSchema) AccessorIdxCount() uint64 {
 
 func (s *E3SnapSchema) DataDirectory() string {
 	return s.dataFileMetadata.folder
+}
+
+func (s *E3SnapSchema) DataFileCompression() seg.FileCompression {
+	return s.dataFileCompression
 }
 
 // debug method for getting all file extensions for this schema

--- a/erigon-lib/state/appendable_extras/snap_schema_test.go
+++ b/erigon-lib/state/appendable_extras/snap_schema_test.go
@@ -105,8 +105,8 @@ func TestE3SnapSchemaForDomain1(t *testing.T) {
 	dirs := setup(t)
 	stepSize := uint64(config3.DefaultStepSize)
 	p := NewE3SnapSchemaBuilder(AccessorBTree|AccessorExistence, stepSize).
-		Data(dirs.SnapDomain, "accounts", DataExtensionKv).
-		BtIndex(seg.CompressNone).
+		Data(dirs.SnapDomain, "accounts", DataExtensionKv, seg.CompressKeys).
+		BtIndex().
 		Existence().Build()
 
 	stepFrom := RootNum(stepSize * 288)
@@ -141,8 +141,7 @@ func TestE3SnapSchemaForDomain1(t *testing.T) {
 	dataFileFull := p.DataFile(Version(1), stepFrom, stepTo)
 	_, fName := filepath.Split(dataFileFull)
 	require.Equal(t, "v1-accounts.288-296.kv", fName)
-	accFull, params := p.BtIdxFile(Version(1), stepFrom, stepTo)
-	require.Equal(t, seg.CompressNone, params.Compression)
+	accFull := p.BtIdxFile(Version(1), stepFrom, stepTo)
 	_, fName = filepath.Split(accFull)
 	require.Equal(t, "v1-accounts.288-296.bt", fName)
 
@@ -163,8 +162,8 @@ func TestE3SnapSchemaForCommitmentDomain(t *testing.T) {
 	dirs := setup(t)
 	stepSize := uint64(config3.DefaultStepSize)
 	p := NewE3SnapSchemaBuilder(AccessorHashMap, stepSize).
-		Data(dirs.SnapDomain, "commitments", DataExtensionKv).
-		Accessor(dirs.SnapDomain, AccessorExtensionKvi).Build()
+		Data(dirs.SnapDomain, "commitments", DataExtensionKv, seg.CompressKeys).
+		Accessor(dirs.SnapDomain).Build()
 
 	stepFrom := RootNum(stepSize * 288)
 	stepTo := RootNum(stepSize * 296)
@@ -209,8 +208,8 @@ func TestE3SnapSchemaForHistory(t *testing.T) {
 	dirs := setup(t)
 	stepSize := uint64(config3.DefaultStepSize)
 	p := NewE3SnapSchemaBuilder(AccessorHashMap, stepSize).
-		Data(dirs.SnapHistory, "accounts", DataExtensionV).
-		Accessor(dirs.SnapAccessors, AccessorExtensionVi).Build()
+		Data(dirs.SnapHistory, "accounts", DataExtensionV, seg.CompressKeys).
+		Accessor(dirs.SnapAccessors).Build()
 
 	stepFrom, stepTo := RootNum(stepSize*192), RootNum(stepSize*256)
 	info, ok := p.Parse("v1-accounts.192-256.v")
@@ -258,8 +257,8 @@ func TestE3SnapSchemaForII(t *testing.T) {
 	dirs := setup(t)
 	stepSize := uint64(config3.DefaultStepSize)
 	p := NewE3SnapSchemaBuilder(AccessorHashMap, stepSize).
-		Data(dirs.SnapIdx, "logaddrs", DataExtensionEf).
-		Accessor(dirs.SnapAccessors, AccessorExtensionEfi).Build()
+		Data(dirs.SnapIdx, "logaddrs", DataExtensionEf, seg.CompressNone).
+		Accessor(dirs.SnapAccessors).Build()
 
 	stepFrom, stepTo := RootNum(stepSize*128), RootNum(stepSize*192)
 	info, ok := p.Parse("v1-logaddrs.128-192.ef")

--- a/erigon-lib/state/files_item.go
+++ b/erigon-lib/state/files_item.go
@@ -271,7 +271,7 @@ func (i *visibleFile) isSubSetOf(j *visibleFile) bool { return i.src.isProperSub
 func (i *visibleFile) isSubsetOf(j *visibleFile) bool { return i.src.isProperSubsetOf(j.src) } //nolint
 
 func (i visibleFile) Filename() string {
-	return i.src.decompressor.FileName1
+	return i.src.decompressor.FilePath()
 }
 
 func (i visibleFile) StartTxNum() uint64 {

--- a/erigon-lib/state/files_item.go
+++ b/erigon-lib/state/files_item.go
@@ -270,6 +270,18 @@ type visibleFile struct {
 func (i *visibleFile) isSubSetOf(j *visibleFile) bool { return i.src.isProperSubsetOf(j.src) } //nolint
 func (i *visibleFile) isSubsetOf(j *visibleFile) bool { return i.src.isProperSubsetOf(j.src) } //nolint
 
+func (i visibleFile) Filename() string {
+	return i.src.decompressor.FileName1
+}
+
+func (i visibleFile) StartTxNum() uint64 {
+	return i.startTxNum
+}
+
+func (i visibleFile) EndTxNum() uint64 {
+	return i.endTxNum
+}
+
 func calcVisibleFiles(files *btree2.BTreeG[*filesItem], l Accessors, trace bool, toTxNum uint64) (roItems []visibleFile) {
 	newVisibleFiles := make([]visibleFile, 0, files.Len())
 	// trace = true

--- a/erigon-lib/state/proto_appendable.go
+++ b/erigon-lib/state/proto_appendable.go
@@ -147,7 +147,7 @@ type ProtoAppendableTx struct {
 }
 
 func (a *ProtoAppendable) BeginFilesRo() *ProtoAppendableTx {
-	visibleFiles := a.snaps.VisibleFiles()
+	visibleFiles := a.snaps.visibleFiles()
 	for i := range visibleFiles {
 		src := visibleFiles[i].src
 		if src.frozen {


### PR DESCRIPTION
- remove fileCompression from btindex, as it's property of seg file and not btindex
- no need to take AccessorExtension as input from user
- `VisibleFile` interfcae to expose some minimal information outside erigon-lib/state (e.g [pull#14601](https://github.com/erigontech/erigon/pull/14601/files))