### PR TITLE
qa-tests: polygon tip-tracking with chaindata backup/restore

### DIFF
--- a/.github/workflows/qa-tip-tracking-polygon.yml
+++ b/.github/workflows/qa-tip-tracking-polygon.yml
@@ -37,9 +37,10 @@ jobs:
       run: |
         python3 $ERIGON_QA_PATH/test_system/db-producer/pause_production.py || true
 
-    - name: Restore Erigon Testbed Data Directory
+    - name: Save Erigon Chaindata Directory
+      id: save_chaindata_step
       run: |
-        rsync -a --delete $ERIGON_REFERENCE_DATA_DIR/ $ERIGON_TESTBED_DATA_DIR/
+        mv $ERIGON_REFERENCE_DATA_DIR/chaindata $ERIGON_TESTBED_AREA/chaindata-prev
 
     - name: Run Erigon, wait sync and check ability to maintain sync
       id: test_step
@@ -50,7 +51,7 @@ jobs:
         # 2. Allow time for the Erigon to achieve synchronization
         # 3. Begin timing the duration that Erigon maintains synchronization
         python3 $ERIGON_QA_PATH/test_system/qa-tests/tip-tracking/run_and_check_tip_tracking.py \
-          ${{ github.workspace }}/build/bin $ERIGON_TESTBED_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN full_node
+          ${{ github.workspace }}/build/bin $ERIGON_REFERENCE_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN
   
         # Capture monitoring script exit status
         test_exit_status=$?
@@ -107,7 +108,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: erigon-log
-        path: ${{ env.ERIGON_TESTBED_DATA_DIR }}/logs/erigon.log
+        path: ${{ env.ERIGON_REFERENCE_DATA_DIR }}/logs/erigon.log
 
     - name: Upload metric plots
       if: steps.test_step.outputs.test_executed == 'true'
@@ -116,12 +117,16 @@ jobs:
         name: metric-plots
         path: ${{ github.workspace }}/metrics-${{ env.CHAIN }}-plots*
 
-    - name: Delete Erigon Testbed Data Directory
-      if: always()
+    - name: Restore Erigon Chaindata Directory
+      if: ${{ always() }}
       run: |
-        rm -rf $ERIGON_TESTBED_DATA_DIR
+        if [ -d "$ERIGON_TESTBED_AREA/chaindata-prev" ]; then
+          rm -rf $ERIGON_REFERENCE_DATA_DIR/chaindata
+          mv $ERIGON_TESTBED_AREA/chaindata-prev $ERIGON_REFERENCE_DATA_DIR/chaindata
+        fi
 
     - name: Resume the Erigon instance dedicated to db maintenance
+      if: ${{ always() }}
       run: |
         python3 $ERIGON_QA_PATH/test_system/db-producer/resume_production.py || true
 


### PR DESCRIPTION
We are trying to use an archive node for polygon so that we can do rpc tests on historical data. 
But the archive node is bigger. It is possible to better manage the backup of the pre-built db as we did with the Ethereum mainnet i.e. avoid the complete backup of the pre-built db and only backup/restore the chaindata