### PR TITLE
qa-tests: polygon tip-tracking with chaindata backup/restore (v3)

### DIFF
--- a/.github/workflows/qa-tip-tracking-polygon.yml
+++ b/.github/workflows/qa-tip-tracking-polygon.yml
@@ -6,7 +6,7 @@ on:
       - 'release/3.*'
   schedule:
     - cron: '0 0 * * 1-6'  # Run every night at 00:00 AM UTC except Sunday
-  workflow_dispatch:     # Run manually
+  workflow_dispatch:      # Run manually
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/qa-tip-tracking-polygon.yml
+++ b/.github/workflows/qa-tip-tracking-polygon.yml
@@ -14,7 +14,7 @@ concurrency:
   
 jobs:
   tip-tracking-test:
-    runs-on: [self-hosted, Polygon]
+    runs-on: [self-hosted, qa, Polygon]
     timeout-minutes: 800
     env:
       ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version/datadir
@@ -41,9 +41,10 @@ jobs:
       run: |
         python3 $ERIGON_QA_PATH/test_system/db-producer/pause_production.py || true
 
-    - name: Restore Erigon Testbed Data Directory
+    - name: Save Erigon Chaindata Directory
+      id: save_chaindata_step
       run: |
-        rsync -a --delete $ERIGON_REFERENCE_DATA_DIR/ $ERIGON_TESTBED_DATA_DIR/
+        mv $ERIGON_REFERENCE_DATA_DIR/chaindata $ERIGON_TESTBED_AREA/chaindata-prev
 
     - name: Run Erigon, wait sync and check ability to maintain sync
       id: test_step
@@ -54,7 +55,7 @@ jobs:
         # 2. Allow time for the Erigon to achieve synchronization
         # 3. Begin timing the duration that Erigon maintains synchronization
         python3 $ERIGON_QA_PATH/test_system/qa-tests/tip-tracking/run_and_check_tip_tracking.py \
-          ${{ github.workspace }}/build/bin $ERIGON_TESTBED_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN full_node
+          ${{ github.workspace }}/build/bin $ERIGON_REFERENCE_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN
   
         # Capture monitoring script exit status
         test_exit_status=$?
@@ -111,7 +112,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: erigon-log
-        path: ${{ env.ERIGON_TESTBED_DATA_DIR }}/logs/erigon.log
+        path: ${{ env.ERIGON_REFERENCE_DATA_DIR }}/logs/erigon.log
 
     - name: Upload metric plots
       if: steps.test_step.outputs.test_executed == 'true'
@@ -120,12 +121,16 @@ jobs:
         name: metric-plots
         path: ${{ github.workspace }}/metrics-${{ env.CHAIN }}-plots*
 
-    - name: Delete Erigon Testbed Data Directory
-      if: always()
+    - name: Restore Erigon Chaindata Directory
+      if: ${{ always() }}
       run: |
-        rm -rf $ERIGON_TESTBED_DATA_DIR
+        if [ -d "$ERIGON_TESTBED_AREA/chaindata-prev" ]; then
+          rm -rf $ERIGON_REFERENCE_DATA_DIR/chaindata
+          mv $ERIGON_TESTBED_AREA/chaindata-prev $ERIGON_REFERENCE_DATA_DIR/chaindata
+        fi
 
     - name: Resume the Erigon instance dedicated to db maintenance
+      if: ${{ always() }}
       run: |
         python3 $ERIGON_QA_PATH/test_system/db-producer/resume_production.py || true
 


### PR DESCRIPTION
We are trying to use an archive node for polygon so that we can do rpc tests on historical data.
But the archive node is bigger. It is possible to better manage the backup of the pre-built db as we did with the Ethereum mainnet i.e. avoid the complete backup of the pre-built db and only backup/restore the chaindata