### PR TITLE
historical re-exec: re-used EliasFano object

### DIFF
--- a/erigon-lib/recsplit/eliasfano32/elias_fano.go
+++ b/erigon-lib/recsplit/eliasfano32/elias_fano.go
@@ -226,11 +226,9 @@ func (ef *EliasFano) upper(i uint64) uint64 {
 	return currWord*64 + uint64(sel) - i
 }
 
-// TODO: optimize me - to avoid object allocation
 func Seek(data []byte, n uint64) (uint64, bool) {
-	ef, _ := ReadEliasFano(data)
-	//TODO: if startTxNum==0, can do ef.Get(0)
-	return ef.Search(n)
+	ef, _ := ReadEliasFano(data) //for better perf: app-code can use ef.Reset(data).Seek(n)
+	return ef.Seek(n)
 }
 
 func (ef *EliasFano) search(v uint64, reverse bool) (nextV uint64, nextI uint64, ok bool) {
@@ -277,7 +275,7 @@ func (ef *EliasFano) search(v uint64, reverse bool) (nextV uint64, nextI uint64,
 }
 
 // Search returns the value in the sequence, equal or greater than given value
-func (ef *EliasFano) Search(v uint64) (uint64, bool) {
+func (ef *EliasFano) Seek(v uint64) (uint64, bool) {
 	n, _, ok := ef.search(v, false /* reverse */)
 	return n, ok
 }
@@ -541,12 +539,13 @@ func ReadEliasFano(r []byte) (*EliasFano, int) {
 }
 
 // Reset - like ReadEliasFano, but for existing object
-func (ef *EliasFano) Reset(r []byte) {
+func (ef *EliasFano) Reset(r []byte) *EliasFano {
 	ef.count = binary.BigEndian.Uint64(r[:8])
 	ef.u = binary.BigEndian.Uint64(r[8:16])
 	ef.data = unsafe.Slice((*uint64)(unsafe.Pointer(&r[16])), (len(r)-16)/uint64Size)
 	ef.maxOffset = ef.u - 1
 	ef.deriveFields()
+	return ef
 }
 
 func Max(r []byte) uint64   { return binary.BigEndian.Uint64(r[8:16]) - 1 }

--- a/erigon-lib/recsplit/eliasfano32/elias_fano_test.go
+++ b/erigon-lib/recsplit/eliasfano32/elias_fano_test.go
@@ -145,7 +145,7 @@ func TestEliasFanoSeek(t *testing.T) {
 	})
 
 	{
-		v2, ok2 := ef.Search(ef.Max())
+		v2, ok2 := ef.Seek(ef.Max())
 		require.True(t, ok2, v2)
 		require.Equal(t, int(ef.Max()), int(v2))
 		it := ef.Iterator()
@@ -170,7 +170,7 @@ func TestEliasFanoSeek(t *testing.T) {
 	}
 
 	{
-		v2, ok2 := ef.Search(ef.Min())
+		v2, ok2 := ef.Seek(ef.Min())
 		require.True(t, ok2, v2)
 		require.Equal(t, int(ef.Min()), int(v2))
 		it := ef.Iterator()
@@ -182,7 +182,7 @@ func TestEliasFanoSeek(t *testing.T) {
 	}
 
 	{
-		v2, ok2 := ef.Search(0)
+		v2, ok2 := ef.Seek(0)
 		require.True(t, ok2, v2)
 		require.Equal(t, int(ef.Min()), int(v2))
 		it := ef.Iterator()
@@ -194,7 +194,7 @@ func TestEliasFanoSeek(t *testing.T) {
 	}
 
 	{
-		v2, ok2 := ef.Search(math.MaxUint32)
+		v2, ok2 := ef.Seek(math.MaxUint32)
 		require.False(t, ok2, v2)
 		it := ef.Iterator()
 		it.Seek(math.MaxUint32)
@@ -202,7 +202,7 @@ func TestEliasFanoSeek(t *testing.T) {
 	}
 
 	{
-		v2, ok2 := ef.Search((count+1)*123 + 1)
+		v2, ok2 := ef.Seek((count+1)*123 + 1)
 		require.False(t, ok2, v2)
 		it := ef.Iterator()
 		it.Seek((count+1)*123 + 1)
@@ -212,7 +212,7 @@ func TestEliasFanoSeek(t *testing.T) {
 	t.Run("search and seek can't return smaller", func(t *testing.T) {
 		for i := uint64(0); i < count; i++ {
 			search := i * 123
-			v, ok2 := ef.Search(search)
+			v, ok2 := ef.Seek(search)
 			require.True(t, ok2, search)
 			require.GreaterOrEqual(t, int(v), int(search))
 			it := ef.Iterator()
@@ -243,15 +243,15 @@ func TestEliasFano(t *testing.T) {
 		offset1 := ef.Get(uint64(i))
 		assert.Equal(t, offset, offset1, "offset")
 	}
-	v, ok := ef.Search(37)
+	v, ok := ef.Seek(37)
 	assert.True(t, ok, "search1")
 	assert.Equal(t, uint64(37), v, "search1")
-	v, ok = ef.Search(0)
+	v, ok = ef.Seek(0)
 	assert.True(t, ok, "search2")
 	assert.Equal(t, uint64(1), v, "search2")
-	_, ok = ef.Search(100)
+	_, ok = ef.Seek(100)
 	assert.False(t, ok, "search3")
-	v, ok = ef.Search(11)
+	v, ok = ef.Seek(11)
 	assert.True(t, ok, "search4")
 	assert.Equal(t, uint64(14), v, "search4")
 


### PR DESCRIPTION
`seekInFiles` is in top of heap alloc_objects profiling 

```
BenchmarkRead/read.seek  	 9455366	       121.3 ns/op
BenchmarkRead/reset.seek 	15614156	        77.01 ns/op
```