### PR TITLE
purify: return meaningful error when have commitment.kv files but they all purified

### DIFF
--- a/erigon-lib/kv/kv_interface.go
+++ b/erigon-lib/kv/kv_interface.go
@@ -581,7 +581,7 @@ type TemporalDebugTx interface {
 	DomainFiles(domain ...Domain) []string
 
 	PruneSmallBatches(ctx context.Context, timeout time.Duration) (haveMore bool, err error)
-	TxNumsInFiles(entitySet ...Domain) (minTxNum uint64)
+	TxNumsInFiles(domains ...Domain) (minTxNum uint64)
 }
 
 type TemporalDebugDB interface {

--- a/erigon-lib/kv/kv_interface.go
+++ b/erigon-lib/kv/kv_interface.go
@@ -581,6 +581,7 @@ type TemporalDebugTx interface {
 	DomainFiles(domain ...Domain) []string
 
 	PruneSmallBatches(ctx context.Context, timeout time.Duration) (haveMore bool, err error)
+	TxNumsInFiles(entitySet ...Domain) (minTxNum uint64)
 }
 
 type TemporalDebugDB interface {

--- a/erigon-lib/kv/temporal/kv_temporal.go
+++ b/erigon-lib/kv/temporal/kv_temporal.go
@@ -286,6 +286,9 @@ func (tx *Tx) GetLatestFromFiles(domain kv.Domain, k []byte, maxTxNum uint64) (v
 func (tx *Tx) DomainTables(domain ...kv.Domain) []string { return tx.db.agg.DomainTables(domain...) }
 func (db *DB) DomainTables(domain ...kv.Domain) []string { return db.agg.DomainTables(domain...) }
 func (tx *Tx) DomainFiles(domain ...kv.Domain) []string  { return tx.aggtx.DomainFiles(domain...) }
+func (tx *Tx) TxNumsInFiles(domains ...kv.Domain) (minTxNum uint64) {
+	return tx.aggtx.TxNumsInFiles(domains...)
+}
 func (tx *Tx) PruneSmallBatches(ctx context.Context, timeout time.Duration) (haveMore bool, err error) {
 	return tx.aggtx.PruneSmallBatches(ctx, timeout, tx.MdbxTx)
 }

--- a/erigon-lib/state/domain_shared.go
+++ b/erigon-lib/state/domain_shared.go
@@ -1214,6 +1214,9 @@ func (sdc *SharedDomainsCommitmentContext) LatestCommitmentState() (blockNum, tx
 		return 0, 0, nil, err
 	}
 	if len(state) < 16 {
+		if sdc.sharedDomains.roTtx.Debug().TxNumsInFiles(kv.CommitmentDomain) > 0 {
+			return 0, 0, nil, fmt.Errorf("assert: special key `state` not found in commitment files (but we have them), probably files are `purified`")
+		}
 		return 0, 0, nil, nil
 	}
 


### PR DESCRIPTION
before: silently return 0 and node start working from 0