### PR TITLE
shutter: move cfg to dedicated `shuttercfg` package

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/c2h5oh/datasize"
+	"github.com/erigontech/erigon/txnprovider/shutter/shuttercfg"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/urfave/cli/v2"
@@ -66,7 +67,6 @@ import (
 	"github.com/erigontech/erigon/polygon/heimdall"
 	"github.com/erigontech/erigon/rpc/rpccfg"
 	"github.com/erigontech/erigon/turbo/logging"
-	"github.com/erigontech/erigon/txnprovider/shutter"
 	"github.com/erigontech/erigon/txnprovider/txpool/txpoolcfg"
 )
 
@@ -1628,7 +1628,7 @@ func setShutter(ctx *cli.Context, chainName string, nodeConfig *nodecfg.Config, 
 		return
 	}
 
-	config := shutter.ConfigByChainName(chainName)
+	config := shuttercfg.ConfigByChainName(chainName)
 	config.PrivateKey = nodeConfig.P2P.PrivateKey
 	// check for cli overrides
 	if ctx.IsSet(ShutterP2pBootstrapNodesFlag.Name) {

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/c2h5oh/datasize"
+	"github.com/erigontech/erigon/txnprovider/shutter/shuttercfg"
 
 	"github.com/erigontech/erigon-lib/chain"
 	"github.com/erigontech/erigon-lib/common"
@@ -43,7 +44,6 @@ import (
 	"github.com/erigontech/erigon/execution/consensus/ethash/ethashcfg"
 	"github.com/erigontech/erigon/params"
 	"github.com/erigontech/erigon/rpc"
-	"github.com/erigontech/erigon/txnprovider/shutter"
 	"github.com/erigontech/erigon/txnprovider/txpool/txpoolcfg"
 )
 
@@ -212,7 +212,7 @@ type Config struct {
 
 	// Transaction pool options
 	TxPool  txpoolcfg.Config
-	Shutter shutter.Config
+	Shutter shuttercfg.Config
 
 	// Gas Price Oracle options
 	GPO gaspricecfg.Config

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -12,11 +12,11 @@ import (
 	"github.com/erigontech/erigon-lib/downloader/downloadercfg"
 	"github.com/erigontech/erigon-lib/kv/prune"
 	"github.com/erigontech/erigon/cl/clparams"
-	"github.com/erigontech/erigon/execution/consensus/ethash/ethashcfg"
 	"github.com/erigontech/erigon/core/types"
 	"github.com/erigontech/erigon/eth/gasprice/gaspricecfg"
+	"github.com/erigontech/erigon/execution/consensus/ethash/ethashcfg"
 	"github.com/erigontech/erigon/params"
-	"github.com/erigontech/erigon/txnprovider/shutter"
+	"github.com/erigontech/erigon/txnprovider/shutter/shuttercfg"
 	"github.com/erigontech/erigon/txnprovider/txpool/txpoolcfg"
 )
 
@@ -41,7 +41,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		Clique                              params.ConsensusSnapshotConfig
 		Aura                                chain.AuRaConfig
 		TxPool                              txpoolcfg.Config
-		Shutter                             shutter.Config
+		Shutter                             shuttercfg.Config
 		GPO                                 gaspricecfg.Config
 		RPCGasCap                           uint64  `toml:",omitempty"`
 		RPCTxFeeCap                         float64 `toml:",omitempty"`
@@ -141,7 +141,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		Clique                              *params.ConsensusSnapshotConfig
 		Aura                                *chain.AuRaConfig
 		TxPool                              *txpoolcfg.Config
-		Shutter                             *shutter.Config
+		Shutter                             *shuttercfg.Config
 		GPO                                 *gaspricecfg.Config
 		RPCGasCap                           *uint64  `toml:",omitempty"`
 		RPCTxFeeCap                         *float64 `toml:",omitempty"`

--- a/txnprovider/shutter/block_building_integration_test.go
+++ b/txnprovider/shutter/block_building_integration_test.go
@@ -30,6 +30,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/erigontech/erigon/txnprovider/shutter/shuttercfg"
 	"github.com/holiman/uint256"
 	libp2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -229,7 +230,7 @@ type blockBuildingUniverse struct {
 	acc5                 libcommon.Address
 	transactor           testhelpers.EncryptedTransactor
 	txnInclusionVerifier testhelpers.TxnInclusionVerifier
-	shutterConfig        shutter.Config
+	shutterConfig        shuttercfg.Config
 	shutterCoordinator   testhelpers.ShutterBlockBuildingCoordinator
 }
 
@@ -296,7 +297,7 @@ func initBlockBuildingUniverse(ctx context.Context, t *testing.T) blockBuildingU
 	contractDeployerPrivKey, err := crypto.GenerateKey()
 	require.NoError(t, err)
 	contractDeployer := crypto.PubkeyToAddress(contractDeployerPrivKey.PublicKey)
-	shutterConfig := shutter.ConfigByChainName(params.ChiadoChainConfig.ChainName)
+	shutterConfig := shuttercfg.ConfigByChainName(params.ChiadoChainConfig.ChainName)
 	shutterConfig.Enabled = false // first we need to deploy the shutter smart contracts
 	shutterConfig.BootstrapNodes = []string{decryptionKeySenderPeerAddr}
 	shutterConfig.PrivateKey = nodeKey

--- a/txnprovider/shutter/decryption_keys_listener.go
+++ b/txnprovider/shutter/decryption_keys_listener.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/erigontech/erigon/txnprovider/shutter/shuttercfg"
 	"github.com/libp2p/go-libp2p"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	libp2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
@@ -46,12 +47,12 @@ const (
 
 type DecryptionKeysListener struct {
 	logger    log.Logger
-	config    Config
+	config    shuttercfg.Config
 	validator pubsub.ValidatorEx
 	observers *event.Observers[*proto.DecryptionKeys]
 }
 
-func NewDecryptionKeysListener(logger log.Logger, config Config, validator pubsub.ValidatorEx) *DecryptionKeysListener {
+func NewDecryptionKeysListener(logger log.Logger, config shuttercfg.Config, validator pubsub.ValidatorEx) *DecryptionKeysListener {
 	return &DecryptionKeysListener{
 		logger:    logger,
 		config:    config,

--- a/txnprovider/shutter/decryption_keys_processor.go
+++ b/txnprovider/shutter/decryption_keys_processor.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/erigontech/erigon/txnprovider/shutter/shuttercfg"
 	"golang.org/x/sync/errgroup"
 
 	libcommon "github.com/erigontech/erigon-lib/common"
@@ -41,7 +42,7 @@ import (
 
 type DecryptionKeysProcessor struct {
 	logger            log.Logger
-	config            Config
+	config            shuttercfg.Config
 	encryptedTxnsPool *EncryptedTxnsPool
 	decryptedTxnsPool *DecryptedTxnsPool
 	blockListener     *BlockListener
@@ -54,7 +55,7 @@ type DecryptionKeysProcessor struct {
 
 func NewDecryptionKeysProcessor(
 	logger log.Logger,
-	config Config,
+	config shuttercfg.Config,
 	encryptedTxnsPool *EncryptedTxnsPool,
 	decryptedTxnsPool *DecryptedTxnsPool,
 	blockListener *BlockListener,

--- a/txnprovider/shutter/decryption_keys_validator.go
+++ b/txnprovider/shutter/decryption_keys_validator.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/erigontech/erigon/txnprovider/shutter/shuttercfg"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
 
@@ -56,12 +57,12 @@ var (
 )
 
 type DecryptionKeysValidator struct {
-	config         Config
+	config         shuttercfg.Config
 	slotCalculator SlotCalculator
 	eonTracker     EonTracker
 }
 
-func NewDecryptionKeysValidator(config Config, sc SlotCalculator, et EonTracker) DecryptionKeysValidator {
+func NewDecryptionKeysValidator(config shuttercfg.Config, sc SlotCalculator, et EonTracker) DecryptionKeysValidator {
 	return DecryptionKeysValidator{
 		config:         config,
 		slotCalculator: sc,
@@ -263,7 +264,7 @@ func (v DecryptionKeysValidator) validateEonIndex(msg *proto.DecryptionKeys) (Eo
 	return eon, nil
 }
 
-func NewDecryptionKeysExtendedValidator(logger log.Logger, config Config, sc SlotCalculator, et EonTracker) pubsub.ValidatorEx {
+func NewDecryptionKeysExtendedValidator(logger log.Logger, config shuttercfg.Config, sc SlotCalculator, et EonTracker) pubsub.ValidatorEx {
 	dkv := NewDecryptionKeysValidator(config, sc, et)
 	validator := func(ctx context.Context, id peer.ID, msg *pubsub.Message) pubsub.ValidationResult {
 		if topic := msg.GetTopic(); topic != DecryptionKeysTopic {

--- a/txnprovider/shutter/decryption_keys_validator_test.go
+++ b/txnprovider/shutter/decryption_keys_validator_test.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/erigontech/erigon/txnprovider/shutter/shuttercfg"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/stretchr/testify/require"
 
@@ -36,7 +37,7 @@ func TestDecryptionKeysValidators(t *testing.T) {
 
 	instanceId := uint64(123)
 	maxNumKeysPerMessage := uint64(10)
-	config := shutter.Config{
+	config := shuttercfg.Config{
 		InstanceId:           instanceId,
 		MaxNumKeysPerMessage: maxNumKeysPerMessage,
 	}
@@ -599,7 +600,7 @@ func TestDecryptionKeysValidators(t *testing.T) {
 
 type decryptionKeysValidationTestCase struct {
 	name                  string
-	config                shutter.Config
+	config                shuttercfg.Config
 	msg                   *pubsub.Message
 	slotCalculator        func(t *testing.T) *testhelpers.MockSlotCalculator
 	eonTracker            func(t *testing.T) *testhelpers.MockEonTracker

--- a/txnprovider/shutter/encrypted_txns_pool.go
+++ b/txnprovider/shutter/encrypted_txns_pool.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/erigontech/erigon/txnprovider/shutter/shuttercfg"
 	"github.com/google/btree"
 	"golang.org/x/sync/errgroup"
 
@@ -35,7 +36,7 @@ import (
 
 type EncryptedTxnsPool struct {
 	logger            log.Logger
-	config            Config
+	config            shuttercfg.Config
 	sequencerContract *contracts.Sequencer
 	blockListener     *BlockListener
 	mu                sync.RWMutex
@@ -43,7 +44,7 @@ type EncryptedTxnsPool struct {
 	initialLoadDone   chan struct{}
 }
 
-func NewEncryptedTxnsPool(logger log.Logger, config Config, cb bind.ContractBackend, bl *BlockListener) *EncryptedTxnsPool {
+func NewEncryptedTxnsPool(logger log.Logger, config shuttercfg.Config, cb bind.ContractBackend, bl *BlockListener) *EncryptedTxnsPool {
 	sequencerContractAddress := libcommon.HexToAddress(config.SequencerContractAddress)
 	sequencerContract, err := contracts.NewSequencer(sequencerContractAddress, cb)
 	if err != nil {

--- a/txnprovider/shutter/eon_tracker.go
+++ b/txnprovider/shutter/eon_tracker.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/erigontech/erigon/txnprovider/shutter/shuttercfg"
 	"github.com/google/btree"
 	"golang.org/x/sync/errgroup"
 
@@ -54,7 +55,7 @@ type KsmEonTracker struct {
 	lastCleanupBlockNum  uint64
 }
 
-func NewKsmEonTracker(logger log.Logger, config Config, bl *BlockListener, cb bind.ContractBackend) *KsmEonTracker {
+func NewKsmEonTracker(logger log.Logger, config shuttercfg.Config, bl *BlockListener, cb bind.ContractBackend) *KsmEonTracker {
 	ksmContractAddr := libcommon.HexToAddress(config.KeyperSetManagerContractAddress)
 	ksmContract, err := contracts.NewKeyperSetManager(ksmContractAddr, cb)
 	if err != nil {

--- a/txnprovider/shutter/pool.go
+++ b/txnprovider/shutter/pool.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/erigontech/erigon/txnprovider/shutter/shuttercfg"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/erigontech/erigon-lib/log/v3"
@@ -37,7 +38,7 @@ var _ txnprovider.TxnProvider = (*Pool)(nil)
 
 type Pool struct {
 	logger                  log.Logger
-	config                  Config
+	config                  shuttercfg.Config
 	baseTxnProvider         txnprovider.TxnProvider
 	blockListener           *BlockListener
 	blockTracker            *BlockTracker
@@ -51,7 +52,7 @@ type Pool struct {
 
 func NewPool(
 	logger log.Logger,
-	config Config,
+	config shuttercfg.Config,
 	baseTxnProvider txnprovider.TxnProvider,
 	contractBackend bind.ContractBackend,
 	stateChangesClient stateChangesClient,

--- a/txnprovider/shutter/shuttercfg/config.go
+++ b/txnprovider/shutter/shuttercfg/config.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Erigon. If not, see <http://www.gnu.org/licenses/>.
 
-package shutter
+package shuttercfg
 
 import (
 	"crypto/ecdsa"


### PR DESCRIPTION
reason: `ethconfig` package must be `light-weight` (must not import big packages with many complex dependencies). 
So, to achieve it - config objects must live in own packages `downloadercfg`, `txpoolcfg`, etc...
Otherwise: easy to face cyclic-imports