### PR TITLE
Add internal_ namespace + internal_getTxNumInfo method

### DIFF
--- a/rpc/jsonrpc/daemon.go
+++ b/rpc/jsonrpc/daemon.go
@@ -65,6 +65,7 @@ func APIList(db kv.TemporalRoDB, eth rpchelper.ApiBackend, txPool txpool.TxpoolC
 	}
 
 	otsImpl := NewOtterscanAPI(base, db, cfg.OtsMaxPageSize)
+	internalImpl := NewInternalAPI(base, db)
 	gqlImpl := NewGraphQLAPI(base, db)
 	overlayImpl := NewOverlayAPI(base, db, cfg.Gascap, cfg.OverlayGetLogsTimeout, cfg.OverlayReplayBlockTimeout, otsImpl)
 
@@ -163,6 +164,13 @@ func APIList(db kv.TemporalRoDB, eth rpchelper.ApiBackend, txPool txpool.TxpoolC
 				Namespace: "ots",
 				Public:    true,
 				Service:   OtterscanAPI(otsImpl),
+				Version:   "1.0",
+			})
+		case "internal":
+			list = append(list, rpc.API{
+				Namespace: "internal",
+				Public:    true,
+				Service:   InternalAPI(internalImpl),
 				Version:   "1.0",
 			})
 		case "clique":

--- a/rpc/jsonrpc/internal_api.go
+++ b/rpc/jsonrpc/internal_api.go
@@ -1,0 +1,65 @@
+package jsonrpc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/erigontech/erigon-lib/kv"
+	"github.com/erigontech/erigon-lib/kv/rawdbv3"
+	"github.com/erigontech/erigon/turbo/snapshotsync/freezeblocks"
+)
+
+// Defines the `internal_` JSON-RPC namespace.
+//
+// The methods defined here are for exposing internal Erigon info and meant to serve as development support if you are
+// working on Erigon code. They can be added/changed/removed without further notice.
+type InternalAPI interface {
+	GetTxNumInfo(ctx context.Context, txNum uint64) (*TxNumInfo, error)
+}
+
+type TxNumInfo struct {
+	BlockNum uint64 `json:"blockNum"`
+	Idx      uint64 `json:"idx"`
+}
+
+type InternalAPIImpl struct {
+	*BaseAPI
+	db kv.TemporalRoDB
+}
+
+func NewInternalAPI(base *BaseAPI, db kv.TemporalRoDB) *InternalAPIImpl {
+	return &InternalAPIImpl{
+		BaseAPI: base,
+		db:      db,
+	}
+}
+
+func (api *InternalAPIImpl) GetTxNumInfo(ctx context.Context, txNum uint64) (*TxNumInfo, error) {
+	tx, err := api.db.BeginTemporalRo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+	txNumsReader := rawdbv3.TxNums.WithCustomReadTxNumFunc(freezeblocks.ReadTxNumFuncFromBlockReader(ctx, api._blockReader))
+
+	ok, bn, err := txNumsReader.FindBlockNum(tx, txNum)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("block not found by txnID=%d", txNum)
+	}
+	minTxNum, err := txNumsReader.Min(tx, bn)
+	if err != nil {
+		return nil, err
+	}
+	txIndex := int(txNum) - int(minTxNum) - 1 /* system-tx */
+	if txIndex == -1 {
+		return nil, nil
+	}
+
+	return &TxNumInfo{
+		BlockNum: bn,
+		Idx:      uint64(txIndex),
+	}, nil
+}


### PR DESCRIPTION
This is a 2-in-1 PR proposal based on some recurring code snipet I've been keeping in private branches, so I'd like to propose:

1 - Adding and `internal_` JSONRPC namespace

Reserve an `internal_` JSONRPC namespace to attach internal, not supported, Erigon-only, "hacky" tools to quickly get info from a node.

It would have similar purpose to `integration` and `hack` binaries, but in a RPC form and with the following differences:

- Adding some quick and dirty feature to integration for example requires adding a lot of boilerplate code for setting up CLI args, open mdbx, open snapshots, etc., while adding a new JSON is more direct, usually the BaseImpl already gives you the node DB ready to use (counterpoint would be integration binary could provide a better boilerplate)
- `integration` and `hack` requires running it locally, which could be cumbersome in remote dev machines, while exposing such tool via JSONRPC would only require enabling the `internal_` namespace on Erigon start (that could be done by default on dev servers), and you could easily inspect such state remotely without requiring logging into dev servers.
- By exposing via JSONRPC such queries can be easily done using standard dev tooling like forge (see example below).

2 - Add a `internal_getTxNumInfo` method

Erigon 3 uses txnum for everything internally, but very often I need to compare/debug some data with other nodes and that requires translating txnum -> block+idx. I quite often need to replicate such translation code.

So, I'd like to add such method to the new internal namespace in order to quickly inspect txNum -> block+idx for a live node.

By merging this PR, one could use forge to:

```
cast rpc internal_getTxNumInfo 62608387 -r <rpc-endpoint> | jq -C
{
  "blockNum": 19113533,
  "idx": 5
}
```
