### PR TITLE
qa-tests: repair rpc-integration tests 

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -11,9 +11,6 @@ on:
       - main
       - 'release/3.*'
     types:
-      - opened
-      - reopened
-      - synchronize
       - ready_for_review
 
 jobs:
@@ -21,7 +18,7 @@ jobs:
     runs-on: [ self-hosted, qa, RpcSpecific ]
     env:
       ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version/datadir
-      ERIGON_TESTBED_DATA_DIR: /opt/erigon-testbed/datadir
+      ERIGON_TESTBED_AREA: /opt/erigon-testbed
       ERIGON_QA_PATH: /home/qarunner/erigon-qa
       RPC_PAST_TEST_DIR: /opt/rpc-past-tests
       CHAIN: mainnet
@@ -49,6 +46,12 @@ jobs:
       - name: Pause the Erigon instance dedicated to db maintenance
         run: |
           python3 $ERIGON_QA_PATH/test_system/db-producer/pause_production.py || true
+
+      - name: Save Erigon Chaindata Directory
+        id: save_chaindata_step
+        run: |
+          rm -rf $ERIGON_TESTBED_AREA/chaindata-prev || true
+          mv $ERIGON_REFERENCE_DATA_DIR/chaindata $ERIGON_TESTBED_AREA/chaindata-prev
 
       - name: Run RpcDaemon
         working-directory: ${{ github.workspace }}/build/bin
@@ -104,7 +107,7 @@ jobs:
           test_exit_status=$?
           
           # Save the subsection reached status
-          echo "::set-output name=test_executed::true"
+          echo "test_executed=true" >> $GITHUB_OUTPUT
           
           # Check test runner exit status
           if [ $test_exit_status -eq 0 ]; then
@@ -131,7 +134,16 @@ jobs:
             echo "RpcDaemon has already terminated"
           fi
 
+      - name: Restore Erigon Chaindata Directory
+        if: ${{ always() }}
+        run: |
+          if [ -d "$ERIGON_TESTBED_AREA/chaindata-prev" ] && [ "${{ steps.save_chaindata_step.outcome }}" == "success" ]; then
+          rm -rf $ERIGON_REFERENCE_DATA_DIR/chaindata
+          mv $ERIGON_TESTBED_AREA/chaindata-prev $ERIGON_REFERENCE_DATA_DIR/chaindata
+          fi
+
       - name: Resume the Erigon instance dedicated to db maintenance
+        if: ${{ always() }}
         run: |
           python3 $ERIGON_QA_PATH/test_system/db-producer/resume_production.py || true
 
@@ -154,6 +166,14 @@ jobs:
           fi
           
           python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py --repo erigon --commit $(git rev-parse HEAD) --branch ${{ github.ref_name }} --test_name rpc-integration-tests --chain $CHAIN --runner ${{ runner.name }} --db_version $db_version --outcome $TEST_RESULT #--result_file ${{ github.workspace }}/result-$CHAIN.json
+
+      - name: Action to check failure condition
+        if: failure()
+        run: |
+          if [ "${{ steps.test_step.outputs.test_executed }}" != "true" ]; then
+            echo "::error::Test not executed, workflow failed for infrastructure reasons"
+          fi
+          exit 1
 
       - name: Action for Success
         if: steps.test_step.outputs.TEST_RESULT == 'success'


### PR DESCRIPTION
1) execute only on ready-for-review PRs; 
2) protect the pre-built db backing up and restoring the chaindata; 
3) check infrastructure failure

Implement https://github.com/erigontech/erigon-qa/issues/99