### PR TITLE
Update Erigon Blog URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Don't start services as separated processes unless you have clear reason for it:
 your own implementation, security.
 How to start Erigon's services as separated processes, see in [docker-compose.yml](./docker-compose.yml).
 Each service has own `./cmd/*/README.md` file.
-[Erigon Blog](https://erigon.substack.com/).
+[Erigon Blog](https://erigon.tech/news/).
 
 ### Embedded Consensus Layer
 

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Don't start services as separated processes unless you have clear reason for it:
 your own implementation, security.
 How to start Erigon's services as separated processes, see in [docker-compose.yml](./docker-compose.yml).
 Each service has own `./cmd/*/README.md` file.
-[Erigon Blog](https://erigon.tech/news/).
+[Erigon Blog](https://erigon.tech/blog/).
 
 ### Embedded Consensus Layer
 


### PR DESCRIPTION
Updates the Erigon Blog URL from https://erigon.substack.com to https://erigon.tech/news in the README.md file.

This change reflects the migration of the Erigon blog from Substack to their own domain.