### PR TITLE
make: add make stringer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -311,8 +311,13 @@ grpc:
 	@cd erigon-lib && $(MAKE) grpc
 	@cd txnprovider/shutter && $(MAKE) proto
 
+## stringer:                          generate stringer code
+stringer:
+	$(GOBUILD) -o $(GOBIN)/stringer golang.org/x/tools/cmd/stringer
+	PATH="$(GOBIN):$(PATH)" go generate -run "stringer" ./...
+
 ## gen:                               generate all auto-generated code in the codebase
-gen: mocks solc abigen gencodec graphql grpc
+gen: mocks solc abigen gencodec graphql grpc stringer
 	@cd erigon-lib && $(MAKE) gen
 
 ## bindings:                          generate test contracts and core contracts

--- a/tools.go
+++ b/tools.go
@@ -38,5 +38,6 @@ import (
 	_ "github.com/fjl/gencodec"
 	_ "go.uber.org/mock/mockgen"
 	_ "go.uber.org/mock/mockgen/model"
+	_ "golang.org/x/tools/cmd/stringer"
 	_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
 )


### PR DESCRIPTION
https://github.com/erigontech/erigon/pull/10783 has added a new `//go:generate stringer` directive for code gen - this PR adds a `make stringer` cmd and also adds `stringer` to `make gen` for easy code re-gen 