### PR TITLE
qa-tests: increase timeout of the sync-from-scratch based bisection tool

### DIFF
--- a/.github/workflows/qa-sync-test-bisection-tool.yml
+++ b/.github/workflows/qa-sync-test-bisection-tool.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   bisect:
     runs-on: [self-hosted, qa, long-running]
+    timeout-minutes: 7200  # 5 days
     env:
       ERIGON_DATA_DIR: ${{ github.workspace }}/erigon_data
       ERIGON_QA_PATH: /home/qarunner/erigon-qa


### PR DESCRIPTION
The default timeout is 2 days. This PR increases the timeout to 5 days.