### PR TITLE
kv: add HasPrefix to TemporalTx and SharedDomains

### DIFF
--- a/core/state/rw_v3.go
+++ b/core/state/rw_v3.go
@@ -377,9 +377,9 @@ func (w *StateWriterBufferedV3) UpdateAccountData(address common.Address, origin
 		if err := w.rs.domains.DomainDel(kv.CodeDomain, address[:], nil, nil, 0); err != nil {
 			return err
 		}
-		if err := w.rs.domains.IterateStoragePrefix(address[:], func(k, v []byte, step uint64) error {
+		if err := w.rs.domains.IterateStoragePrefix(address[:], func(k, v []byte, step uint64) (bool, error) {
 			w.writeLists[kv.StorageDomain.String()].Push(string(k), nil)
-			return nil
+			return true, nil
 		}); err != nil {
 			return err
 		}

--- a/erigon-lib/kv/kv_interface.go
+++ b/erigon-lib/kv/kv_interface.go
@@ -25,10 +25,11 @@ import (
 	"unsafe"
 
 	"github.com/c2h5oh/datasize"
+	"github.com/erigontech/mdbx-go/mdbx"
+
 	"github.com/erigontech/erigon-lib/kv/order"
 	"github.com/erigontech/erigon-lib/kv/stream"
 	"github.com/erigontech/erigon-lib/metrics"
-	"github.com/erigontech/mdbx-go/mdbx"
 )
 
 //Variables Naming:
@@ -536,6 +537,7 @@ type (
 
 type TemporalGetter interface {
 	GetLatest(name Domain, k []byte) (v []byte, step uint64, err error)
+	HasPrefix(name Domain, prefix []byte) (firstKey []byte, ok bool, err error)
 }
 type TemporalTx interface {
 	Tx

--- a/erigon-lib/kv/membatchwithdb/memory_mutation.go
+++ b/erigon-lib/kv/membatchwithdb/memory_mutation.go
@@ -727,6 +727,10 @@ func (m *MemoryMutation) GetAsOf(name kv.Domain, k []byte, ts uint64) (v []byte,
 	return m.db.(kv.TemporalTx).GetAsOf(name, k, ts)
 }
 
+func (m *MemoryMutation) HasPrefix(name kv.Domain, prefix []byte) (firstKey []byte, ok bool, err error) {
+	return m.db.(kv.TemporalTx).HasPrefix(name, prefix)
+}
+
 func (m *MemoryMutation) RangeAsOf(name kv.Domain, fromKey, toKey []byte, ts uint64, asc order.By, limit int) (it stream.KV, err error) {
 	// panic("not supported")
 	return m.db.(kv.TemporalTx).RangeAsOf(name, fromKey, toKey, ts, asc, limit)

--- a/erigon-lib/kv/remotedb/kv_remote.go
+++ b/erigon-lib/kv/remotedb/kv_remote.go
@@ -660,6 +660,11 @@ func (tx *tx) GetLatest(name kv.Domain, k []byte) (v []byte, step uint64, err er
 	return reply.V, 0, nil
 }
 
+func (tx *tx) HasPrefix(domain kv.Domain, prefix []byte) (firstKey []byte, ok bool, err error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (tx *tx) RangeAsOf(name kv.Domain, fromKey, toKey []byte, ts uint64, asc order.By, limit int) (it stream.KV, err error) {
 	return stream.PaginateKV(func(pageToken string) (keys, vals [][]byte, nextPageToken string, err error) {
 		reply, err := tx.db.remoteKV.RangeAsOf(tx.ctx, &remote.RangeAsOfReq{TxId: tx.id, Table: name.String(), FromKey: fromKey, ToKey: toKey, Ts: ts, OrderAscend: bool(asc), Limit: int64(limit), PageToken: pageToken})

--- a/erigon-lib/kv/temporal/kv_temporal.go
+++ b/erigon-lib/kv/temporal/kv_temporal.go
@@ -224,6 +224,25 @@ func (tx *Tx) RangeAsOf(name kv.Domain, fromKey, toKey []byte, asOfTs uint64, as
 	return it, nil
 }
 
+func (tx *Tx) HasPrefix(name kv.Domain, prefix []byte) ([]byte, bool, error) {
+	it, err := tx.Debug().RangeLatest(name, prefix, nil, 1)
+	if err != nil {
+		return nil, false, err
+	}
+
+	defer it.Close()
+	if !it.HasNext() {
+		return nil, false, nil
+	}
+
+	k, _, err := it.Next()
+	if err != nil {
+		return nil, false, err
+	}
+
+	return k, true, nil
+}
+
 func (tx *Tx) GetLatest(name kv.Domain, k []byte) (v []byte, step uint64, err error) {
 	v, step, ok, err := tx.aggtx.GetLatest(name, k, tx.MdbxTx)
 	if err != nil {

--- a/erigon-lib/state/domain_shared_test.go
+++ b/erigon-lib/state/domain_shared_test.go
@@ -232,9 +232,9 @@ func TestSharedDomain_IteratePrefix(t *testing.T) {
 
 	iterCount := func(domains *SharedDomains) int {
 		var list [][]byte
-		require.NoError(domains.IterateStoragePrefix(nil, func(k []byte, v []byte, step uint64) error {
+		require.NoError(domains.IterateStoragePrefix(nil, func(k []byte, v []byte, step uint64) (bool, error) {
 			list = append(list, k)
-			return nil
+			return true, nil
 		}))
 		return len(list)
 	}
@@ -514,18 +514,18 @@ func TestSharedDomain_StorageIter(t *testing.T) {
 		require.NoError(t, err)
 
 		existed := make(map[string]struct{})
-		err = domains.IterateStoragePrefix(k0, func(k []byte, v []byte, step uint64) error {
+		err = domains.IterateStoragePrefix(k0, func(k []byte, v []byte, step uint64) (bool, error) {
 			existed[string(k)] = struct{}{}
-			return nil
+			return true, nil
 		})
 		require.NoError(t, err)
 
 		missed := 0
-		err = domains.IterateStoragePrefix(k0, func(k []byte, v []byte, step uint64) error {
+		err = domains.IterateStoragePrefix(k0, func(k []byte, v []byte, step uint64) (bool, error) {
 			if _, been := existed[string(k)]; !been {
 				missed++
 			}
-			return nil
+			return true, nil
 		})
 		require.NoError(t, err)
 		require.Zero(t, missed)
@@ -534,12 +534,12 @@ func TestSharedDomain_StorageIter(t *testing.T) {
 		require.NoError(t, err)
 
 		notRemoved := 0
-		err = domains.IterateStoragePrefix(k0, func(k []byte, v []byte, step uint64) error {
+		err = domains.IterateStoragePrefix(k0, func(k []byte, v []byte, step uint64) (bool, error) {
 			notRemoved++
 			if _, been := existed[string(k)]; !been {
 				missed++
 			}
-			return nil
+			return true, nil
 		})
 		require.NoError(t, err)
 		require.Zero(t, missed)

--- a/erigon-lib/state/domain_stream.go
+++ b/erigon-lib/state/domain_stream.go
@@ -22,13 +22,14 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	btree2 "github.com/tidwall/btree"
+
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/kv"
 	"github.com/erigontech/erigon-lib/kv/order"
 	"github.com/erigontech/erigon-lib/kv/stream"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon-lib/seg"
-	btree2 "github.com/tidwall/btree"
 )
 
 type CursorType uint8
@@ -300,14 +301,11 @@ func (hi *DomainLatestIterFile) Next() ([]byte, []byte, error) {
 }
 
 // debugIteratePrefix iterates over key-value pairs of the storage domain that start with given prefix
-// Such iteration is not intended to be used in public API, therefore it uses read-write transaction
-// inside the domain. Another version of this for public API use needs to be created, that uses
-// roTx instead and supports ending the iterations before it reaches the end.
 //
 // k and v lifetime is bounded by the lifetime of the iterator
 func (dt *DomainRoTx) debugIteratePrefix(prefix []byte, haveRamUpdates bool,
 	ramIter btree2.MapIter[string, dataWithPrevStep],
-	it func(k []byte, v []byte, step uint64) error,
+	it func(k []byte, v []byte, step uint64) (cont bool, err error),
 	txNum, stepSize uint64,
 	roTx kv.Tx,
 ) error {
@@ -439,8 +437,12 @@ func (dt *DomainRoTx) debugIteratePrefix(prefix []byte, haveRamUpdates bool,
 			}
 		}
 		if len(lastVal) > 0 {
-			if err := it(lastKey, lastVal, lastStep); err != nil {
+			cont, err := it(lastKey, lastVal, lastStep)
+			if err != nil {
 				return err
+			}
+			if !cont {
+				return nil
 			}
 		}
 	}

--- a/erigon-lib/state/kv_temporal_copy_test.go
+++ b/erigon-lib/state/kv_temporal_copy_test.go
@@ -223,6 +223,10 @@ func (tx *Tx) RangeAsOf(name kv.Domain, fromKey, toKey []byte, asOfTs uint64, as
 	return it, nil
 }
 
+func (tx *Tx) HasPrefix(domain kv.Domain, prefix []byte) (firstKey []byte, ok bool, err error) {
+	panic("implement me pls. or use SharedDomains")
+}
+
 func (tx *Tx) GetLatest(name kv.Domain, k []byte) (v []byte, step uint64, err error) {
 	v, step, ok, err := tx.aggtx.GetLatest(name, k, tx.MdbxTx)
 	if err != nil {


### PR DESCRIPTION
adding a new `HasPrefix(domain, prefix) (firstKey []byte, ok bool, err error)` api to `TemporalGetter`

this will be used later on to implement eip-7610 `HasStorage` check in the various StateReader implementations that we have

in a subsequent PR I will also add an implementation for `HasPrefix` for the remote kv

note: the reason for `firstKey` return is that in `ReaderParallelV3` we record the read list so that will be used there to record a touch of the first storage slot (this is a bit of a question mark - not sure if we have to do it or not yet - waiting for response from Alex - but either way the API is probably most useful like this)