### PR TITLE
blocks retire: to use core rlp package instead of txpool's one

### DIFF
--- a/erigon-lib/downloader/snaptype/type.go
+++ b/erigon-lib/downloader/snaptype/type.go
@@ -554,7 +554,7 @@ func BuildIndexWithSnapName(ctx context.Context, info FileInfo, cfg recsplit.Rec
 func ExtractRange(ctx context.Context, f FileInfo, extractor RangeExtractor, indexBuilder IndexBuilder, firstKey FirstKeyGetter, chainDB kv.RoDB, chainConfig *chain.Config, tmpDir string, workers int, lvl log.Lvl, logger log.Logger) (uint64, error) {
 	var lastKeyValue uint64
 
-	sn, err := seg.NewCompressor(ctx, "Snapshot "+f.Type.Name(), f.Path, tmpDir, seg.DefaultCfg, log.LvlTrace, logger)
+	sn, err := seg.NewCompressor(ctx, "Snapshot "+f.Type.Name(), f.Path, tmpDir, seg.DefaultCfg, lvl, logger)
 
 	if err != nil {
 		return lastKeyValue, err

--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -31,7 +31,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/holiman/uint256"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 
@@ -63,7 +62,6 @@ import (
 	"github.com/erigontech/erigon/polygon/heimdall"
 	"github.com/erigontech/erigon/turbo/services"
 	"github.com/erigontech/erigon/turbo/snapshotsync"
-	"github.com/erigontech/erigon/txnprovider/txpool"
 )
 
 type RoSnapshots struct {
@@ -587,29 +585,35 @@ func DumpTxs(ctx context.Context, db kv.RoDB, chainConfig *chain.Config, blockFr
 	warmupCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	chainID, _ := uint256.FromBig(chainConfig.ChainID)
-
 	numBuf := make([]byte, 8)
 
-	parse := func(ctx *txpool.TxnParseContext, v, valueBuf []byte, senders []common2.Address, j int) ([]byte, error) {
+	parse := func(v, valueBuf []byte, senders []common2.Address, j int) ([]byte, error) {
 		var sender [20]byte
-		slot := txpool.TxnSlot{}
-
-		if _, err := ctx.ParseTransaction(v, 0, &slot, sender[:], false /* hasEnvelope */, false /* wrappedWithBlobs */, nil); err != nil {
-			return valueBuf, err
+		txn2, err := types.DecodeTransaction(v)
+		if err != nil {
+			return nil, err
 		}
+		hash := txn2.Hash()
+		hashFirstByte := hash[:1]
 		if len(senders) > 0 {
+			txn2.SetSender(senders[j])
 			sender = senders[j]
+		} else {
+			signer := types.LatestSignerForChainID(chainConfig.ChainID)
+			sender, err = txn2.Sender(*signer)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		valueBuf = valueBuf[:0]
-		valueBuf = append(valueBuf, slot.IDHash[:1]...)
+		valueBuf = append(valueBuf, hashFirstByte...)
 		valueBuf = append(valueBuf, sender[:]...)
 		valueBuf = append(valueBuf, v...)
 		return valueBuf, nil
 	}
 
-	addSystemTx := func(ctx *txpool.TxnParseContext, tx kv.Tx, txId types.BaseTxnID) error {
+	addSystemTx := func(tx kv.Tx, txId types.BaseTxnID) error {
 		binary.BigEndian.PutUint64(numBuf, txId.U64())
 		tv, err := tx.GetOne(kv.EthTx, numBuf)
 		if err != nil {
@@ -622,12 +626,10 @@ func DumpTxs(ctx context.Context, db kv.RoDB, chainConfig *chain.Config, blockFr
 			return nil
 		}
 
-		ctx.WithSender(false)
-
 		valueBuf := bufPool.Get().(*[16 * 4096]byte)
 		defer bufPool.Put(valueBuf)
 
-		parsed, err := parse(ctx, tv, valueBuf[:], nil, 0)
+		parsed, err := parse(tv, valueBuf[:], nil, 0)
 		if err != nil {
 			return err
 		}
@@ -689,16 +691,14 @@ func DumpTxs(ctx context.Context, db kv.RoDB, chainConfig *chain.Config, blockFr
 		parsers.SetLimit(workers)
 
 		valueBufs := make([][]byte, workers)
-		parseCtxs := make([]*txpool.TxnParseContext, workers)
 
 		for i := 0; i < workers; i++ {
 			valueBuf := bufPool.Get().(*[16 * 4096]byte)
 			defer bufPool.Put(valueBuf)
 			valueBufs[i] = valueBuf[:]
-			parseCtxs[i] = txpool.NewTxnParseContext(*chainID)
 		}
 
-		if err := addSystemTx(parseCtxs[0], tx, body.BaseTxnID); err != nil {
+		if err := addSystemTx(tx, body.BaseTxnID); err != nil {
 			return false, err
 		}
 
@@ -715,14 +715,9 @@ func DumpTxs(ctx context.Context, db kv.RoDB, chainConfig *chain.Config, blockFr
 			j++
 
 			parsers.Go(func() error {
-				parseCtx := parseCtxs[tx%workers]
-
-				parseCtx.WithSender(len(senders) == 0)
-				parseCtx.WithAllowPreEip2s(blockNum <= chainConfig.HomesteadBlock.Uint64())
-
-				valueBuf, err := parse(parseCtx, tv, valueBufs[tx%workers], senders, tx)
-
+				valueBuf, err := parse(tv, valueBufs[tx%workers], senders, tx)
 				if err != nil {
+					log.Warn("[snapshots] DumpTxs parsing", "err", err, "blockNum", blockNum, "rlp", hex.EncodeToString(v))
 					return fmt.Errorf("%w, block: %d", err, blockNum)
 				}
 
@@ -753,7 +748,7 @@ func DumpTxs(ctx context.Context, db kv.RoDB, chainConfig *chain.Config, blockFr
 			return false, fmt.Errorf("ForAmount parser: %w", err)
 		}
 
-		if err := addSystemTx(parseCtxs[0], tx, types.BaseTxnID(body.BaseTxnID.LastSystemTx(body.TxCount))); err != nil {
+		if err := addSystemTx(tx, types.BaseTxnID(body.BaseTxnID.LastSystemTx(body.TxCount))); err != nil {
 			return false, err
 		}
 
@@ -761,13 +756,13 @@ func DumpTxs(ctx context.Context, db kv.RoDB, chainConfig *chain.Config, blockFr
 		case <-ctx.Done():
 			return false, ctx.Err()
 		case <-logEvery.C:
-			var m runtime.MemStats
 			if lvl >= log.LvlInfo {
+				var m runtime.MemStats
 				dbg.ReadMemStats(&m)
+				logger.Log(lvl, "[snapshots] Dumping txs", "block num", blockNum, "alloc", common2.ByteCount(m.Alloc), "sys", common2.ByteCount(m.Sys))
+			} else {
+				logger.Log(lvl, "[snapshots] Dumping txs", "block num", blockNum)
 			}
-			logger.Log(lvl, "[snapshots] Dumping txs", "block num", blockNum,
-				"alloc", common2.ByteCount(m.Alloc), "sys", common2.ByteCount(m.Sys),
-			)
 		default:
 		}
 		return true, nil

--- a/turbo/snapshotsync/freezeblocks/dump_test.go
+++ b/turbo/snapshotsync/freezeblocks/dump_test.go
@@ -32,8 +32,6 @@ import (
 	"github.com/erigontech/erigon-lib/common/math"
 	"github.com/erigontech/erigon-lib/crypto"
 	"github.com/erigontech/erigon-lib/log/v3"
-	"github.com/erigontech/erigon/txnprovider/txpool"
-
 	"github.com/erigontech/erigon-lib/rlp"
 	"github.com/erigontech/erigon/core"
 	"github.com/erigontech/erigon/core/types"
@@ -119,24 +117,21 @@ func TestDump(t *testing.T) {
 
 	for _, test := range tests {
 		m := createDumpTestKV(t, test.chainConfig, test.chainSize)
-		chainID, _ := uint256.FromBig(m.ChainConfig.ChainID)
 		t.Run("txs", func(t *testing.T) {
 			require := require.New(t)
-			slot := txpool.TxnSlot{}
-			parseCtx := txpool.NewTxnParseContext(*chainID)
-			parseCtx.WithSender(false)
-			var sender [20]byte
 
 			var systemTxs int
 			var nonceList []uint64
+
 			_, err := freezeblocks.DumpTxs(m.Ctx, m.DB, m.ChainConfig, 0, uint64(2*test.chainSize), nil, func(v []byte) error {
 				if v == nil {
 					systemTxs++
 				} else {
-					if _, err := parseCtx.ParseTransaction(v[1+20:], 0, &slot, sender[:], false /* hasEnvelope */, false /* wrappedWithBlobs */, nil); err != nil {
+					txn, err := types.DecodeTransaction(v[1+20:])
+					if err != nil {
 						return err
 					}
-					nonceList = append(nonceList, slot.Nonce)
+					nonceList = append(nonceList, txn.GetNonce())
 				}
 				return nil
 			}, 1, log.LvlInfo, log.New())
@@ -147,10 +142,6 @@ func TestDump(t *testing.T) {
 		})
 		t.Run("txs_not_from_zero", func(t *testing.T) {
 			require := require.New(t)
-			slot := txpool.TxnSlot{}
-			parseCtx := txpool.NewTxnParseContext(*chainID)
-			parseCtx.WithSender(false)
-			var sender [20]byte
 
 			var systemTxs int
 			var nonceList []uint64
@@ -158,10 +149,11 @@ func TestDump(t *testing.T) {
 				if v == nil {
 					systemTxs++
 				} else {
-					if _, err := parseCtx.ParseTransaction(v[1+20:], 0, &slot, sender[:], false /* hasEnvelope */, false /* wrappedWithBlobs */, nil); err != nil {
+					txn, err := types.DecodeTransaction(v[1+20:])
+					if err != nil {
 						return err
 					}
-					nonceList = append(nonceList, slot.Nonce)
+					nonceList = append(nonceList, txn.GetNonce())
 				}
 				return nil
 			}, 1, log.LvlInfo, log.New())


### PR DESCRIPTION
for https://github.com/erigontech/erigon/issues/14762

After this PR: Erigon doesn't use erigon-lib's RLP package anymore. (only TxPool does)