### PR TITLE
[r30] increase in-mem db limit 

### DIFF
--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -149,7 +149,7 @@ func (opts MdbxOpts) InMem(tmpDir string) MdbxOpts {
 	opts.inMem = true
 	opts.flags = mdbx.UtterlyNoSync | mdbx.NoMetaSync | mdbx.NoMemInit
 	opts.growthStep = 2 * datasize.MB
-	opts.mapSize = 512 * datasize.MB
+	opts.mapSize = 16 * datasize.GB
 	opts.dirtySpace = uint64(32 * datasize.MB)
 	opts.shrinkThreshold = 0 // disable
 	opts.pageSize = 4096


### PR DESCRIPTION
Reason: CL using it as in-mem batch for blocks - and seems we touched the limit - it's ok to increase it. 