### PR TITLE
blocks retire: to use core rlp package instead of txpool's one

### DIFF
--- a/core/snaptype/block_types.go
+++ b/core/snaptype/block_types.go
@@ -23,8 +23,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/holiman/uint256"
-
 	"github.com/erigontech/erigon-lib/chain"
 	"github.com/erigontech/erigon-lib/chain/networkname"
 	"github.com/erigontech/erigon-lib/chain/snapcfg"
@@ -39,7 +37,6 @@ import (
 	"github.com/erigontech/erigon-lib/rlp"
 	"github.com/erigontech/erigon-lib/seg"
 	"github.com/erigontech/erigon-lib/types"
-	"github.com/erigontech/erigon/txnprovider/txpool"
 )
 
 func init() {
@@ -256,11 +253,6 @@ var (
 				txnHashIdx.LogLvl(log.LvlDebug)
 				txnHash2BlockNumIdx.LogLvl(log.LvlDebug)
 
-				chainId, _ := uint256.FromBig(chainConfig.ChainID)
-
-				parseCtx := txpool.NewTxnParseContext(*chainId)
-				parseCtx.WithSender(false)
-				slot := txpool.TxnSlot{}
 				bodyBuf, word := make([]byte, 0, 4096), make([]byte, 0, 4096)
 
 				defer d.EnableReadAhead().DisableReadAhead()
@@ -305,21 +297,21 @@ var (
 
 						firstTxByteAndlengthOfAddress := 21
 						isSystemTx := len(word) == 0
+						var txnHash common.Hash
 						if isSystemTx { // system-txs hash:pad32(txnID)
-							slot.IDHash = common.Hash{}
-							binary.BigEndian.PutUint64(slot.IDHash[:], baseTxnID.U64()+ti)
+							binary.BigEndian.PutUint64(txnHash[:], baseTxnID.U64()+ti)
 						} else {
-							tx, errDecode := types.UnmarshalTransactionFromBinary(word[firstTxByteAndlengthOfAddress:], false)
-							if errDecode != nil {
-								return fmt.Errorf("ParseTransaction: %w, blockNum: %d, i: %d", errDecode, blockNum, ti)
+							txn, err := types.DecodeTransaction(word[firstTxByteAndlengthOfAddress:])
+							if err != nil {
+								return fmt.Errorf("ParseTransaction: %w, blockNum: %d, i: %d", err, blockNum, ti)
 							}
-							slot.IDHash = tx.Hash()
+							txnHash = txn.Hash()
 						}
 
-						if err := txnHashIdx.AddKey(slot.IDHash[:], offset); err != nil {
+						if err := txnHashIdx.AddKey(txnHash[:], offset); err != nil {
 							return err
 						}
-						if err := txnHash2BlockNumIdx.AddKey(slot.IDHash[:], blockNum); err != nil {
+						if err := txnHash2BlockNumIdx.AddKey(txnHash[:], blockNum); err != nil {
 							return err
 						}
 

--- a/erigon-lib/downloader/snaptype/type.go
+++ b/erigon-lib/downloader/snaptype/type.go
@@ -609,7 +609,7 @@ func BuildIndexWithSnapName(ctx context.Context, info FileInfo, cfg recsplit.Rec
 func ExtractRange(ctx context.Context, f FileInfo, extractor RangeExtractor, indexBuilder IndexBuilder, firstKey FirstKeyGetter, chainDB kv.RoDB, chainConfig *chain.Config, tmpDir string, workers int, lvl log.Lvl, logger log.Logger) (uint64, error) {
 	var lastKeyValue uint64
 
-	sn, err := seg.NewCompressor(ctx, "Snapshot "+f.Type.Name(), f.Path, tmpDir, seg.DefaultCfg, log.LvlTrace, logger)
+	sn, err := seg.NewCompressor(ctx, "Snapshot "+f.Type.Name(), f.Path, tmpDir, seg.DefaultCfg, lvl, logger)
 
 	if err != nil {
 		return lastKeyValue, err

--- a/turbo/snapshotsync/freezeblocks/dump_test.go
+++ b/turbo/snapshotsync/freezeblocks/dump_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/erigontech/erigon/polygon/bor/borcfg"
 	"github.com/erigontech/erigon/turbo/snapshotsync/freezeblocks"
 	"github.com/erigontech/erigon/turbo/stages/mock"
-	"github.com/erigontech/erigon/txnprovider/txpool"
 )
 
 func nonceRange(from, to int) []uint64 {


### PR DESCRIPTION
pick https://github.com/erigontech/erigon/pull/14763