### PR TITLE
revert rand source for salt

### DIFF
--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -22,7 +22,9 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	rand2 "math/rand/v2"
+
+	rand2 "golang.org/x/exp/rand"
+
 	"os"
 	"path/filepath"
 	"runtime"


### PR DESCRIPTION
https://github.com/erigontech/erigon/issues/14300

this will make the downloaded salt and the default salt have same values, and therefore fixing the above error