### PR TITLE
[r30] no greedy prune on chain-tip

### DIFF
--- a/erigon-lib/state/aggregator_files.go
+++ b/erigon-lib/state/aggregator_files.go
@@ -48,19 +48,19 @@ func (sf SelectedStaticFilesV3) Close() {
 	}
 }
 
-func (ac *AggregatorRoTx) staticFilesInRange(r *RangesV3) (*SelectedStaticFilesV3, error) {
+func (at *AggregatorRoTx) staticFilesInRange(r *RangesV3) (*SelectedStaticFilesV3, error) {
 	sf := &SelectedStaticFilesV3{ii: make([][]*filesItem, len(r.invertedIndex))}
-	for id := range ac.d {
+	for id := range at.d {
 		if !r.domain[id].any() {
 			continue
 		}
-		sf.d[id], sf.dIdx[id], sf.dHist[id] = ac.d[id].staticFilesInRange(r.domain[id])
+		sf.d[id], sf.dIdx[id], sf.dHist[id] = at.d[id].staticFilesInRange(r.domain[id])
 	}
 	for id, rng := range r.invertedIndex {
 		if rng == nil || !rng.needMerge {
 			continue
 		}
-		sf.ii[id] = ac.iis[id].staticFilesInRange(rng.from, rng.to)
+		sf.ii[id] = at.iis[id].staticFilesInRange(rng.from, rng.to)
 	}
 	return sf, nil
 }

--- a/erigon-lib/state/aggregator_fuzz_test.go
+++ b/erigon-lib/state/aggregator_fuzz_test.go
@@ -21,9 +21,10 @@ package state
 import (
 	"context"
 	"encoding/binary"
-	"github.com/erigontech/erigon-lib/types/accounts"
 	"testing"
 	"time"
+
+	"github.com/erigontech/erigon-lib/types/accounts"
 
 	"github.com/c2h5oh/datasize"
 	"github.com/erigontech/erigon-lib/common"
@@ -147,7 +148,7 @@ func Fuzz_AggregatorV3_Merge(f *testing.F) {
 
 		logEvery := time.NewTicker(30 * time.Second)
 		defer logEvery.Stop()
-		stat, err := ac.Prune(context.Background(), rwTx, 0, logEvery)
+		stat, err := ac.prune(context.Background(), rwTx, 0, logEvery)
 		require.NoError(t, err)
 		t.Logf("Prune: %s", stat)
 
@@ -266,7 +267,7 @@ func Fuzz_AggregatorV3_MergeValTransform(f *testing.F) {
 
 		logEvery := time.NewTicker(30 * time.Second)
 		defer logEvery.Stop()
-		stat, err := ac.Prune(context.Background(), rwTx, 0, logEvery)
+		stat, err := ac.prune(context.Background(), rwTx, 0, logEvery)
 		require.NoError(t, err)
 		t.Logf("Prune: %s", stat)
 

--- a/erigon-lib/state/aggregator_test.go
+++ b/erigon-lib/state/aggregator_test.go
@@ -145,7 +145,7 @@ func TestAggregatorV3_Merge(t *testing.T) {
 
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
-	stat, err := ac.Prune(context.Background(), rwTx, 0, logEvery)
+	stat, err := ac.prune(context.Background(), rwTx, 0, logEvery)
 	require.NoError(t, err)
 	t.Logf("Prune: %s", stat)
 
@@ -260,7 +260,7 @@ func TestAggregatorV3_MergeValTransform(t *testing.T) {
 
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
-	stat, err := ac.Prune(context.Background(), rwTx, 0, logEvery)
+	stat, err := ac.prune(context.Background(), rwTx, 0, logEvery)
 	require.NoError(t, err)
 	t.Logf("Prune: %s", stat)
 

--- a/erigon-lib/state/domain_shared_test.go
+++ b/erigon-lib/state/domain_shared_test.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"github.com/erigontech/erigon-lib/common"
-	accounts3 "github.com/erigontech/erigon-lib/types/accounts"
 	"testing"
 	"time"
+
+	"github.com/erigontech/erigon-lib/common"
+	accounts3 "github.com/erigontech/erigon-lib/types/accounts"
 
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
@@ -333,7 +334,7 @@ func TestSharedDomain_IteratePrefix(t *testing.T) {
 		require.NoError(err)
 		defer rwTx.Rollback()
 
-		_, err := ac.Prune(ctx, rwTx, 0, nil)
+		_, err := ac.prune(ctx, rwTx, 0, nil)
 		require.NoError(err)
 
 		wrwTx = WrapTxWithCtx(rwTx, ac)

--- a/erigon-lib/state/integrity.go
+++ b/erigon-lib/state/integrity.go
@@ -17,50 +17,50 @@ import (
 )
 
 // search key in all files of all domains and print file names
-func (ac *AggregatorRoTx) IntegrityKey(domain kv.Domain, k []byte) error {
-	l, err := ac.d[domain].IntegrityDomainFilesWithKey(k)
+func (at *AggregatorRoTx) IntegrityKey(domain kv.Domain, k []byte) error {
+	l, err := at.d[domain].IntegrityDomainFilesWithKey(k)
 	if err != nil {
 		return err
 	}
 	if len(l) > 0 {
-		ac.a.logger.Info("[dbg] found in", "files", l)
+		at.a.logger.Info("[dbg] found in", "files", l)
 	}
 	return nil
 }
-func (ac *AggregatorRoTx) IntegirtyInvertedIndexKey(domain kv.Domain, k []byte) error {
-	return ac.d[domain].IntegrityKey(k)
+func (at *AggregatorRoTx) IntegirtyInvertedIndexKey(domain kv.Domain, k []byte) error {
+	return at.d[domain].IntegrityKey(k)
 }
 
-func (ac *AggregatorRoTx) IntegrityInvertedIndexAllValuesAreInRange(ctx context.Context, name kv.InvertedIdx, failFast bool, fromStep uint64) error {
+func (at *AggregatorRoTx) IntegrityInvertedIndexAllValuesAreInRange(ctx context.Context, name kv.InvertedIdx, failFast bool, fromStep uint64) error {
 	switch name {
 	case kv.AccountsHistoryIdx:
-		err := ac.d[kv.AccountsDomain].ht.iit.IntegrityInvertedIndexAllValuesAreInRange(ctx, failFast, fromStep)
+		err := at.d[kv.AccountsDomain].ht.iit.IntegrityInvertedIndexAllValuesAreInRange(ctx, failFast, fromStep)
 		if err != nil {
 			return err
 		}
 	case kv.StorageHistoryIdx:
-		err := ac.d[kv.CodeDomain].ht.iit.IntegrityInvertedIndexAllValuesAreInRange(ctx, failFast, fromStep)
+		err := at.d[kv.CodeDomain].ht.iit.IntegrityInvertedIndexAllValuesAreInRange(ctx, failFast, fromStep)
 		if err != nil {
 			return err
 		}
 	case kv.CodeHistoryIdx:
-		err := ac.d[kv.StorageDomain].ht.iit.IntegrityInvertedIndexAllValuesAreInRange(ctx, failFast, fromStep)
+		err := at.d[kv.StorageDomain].ht.iit.IntegrityInvertedIndexAllValuesAreInRange(ctx, failFast, fromStep)
 		if err != nil {
 			return err
 		}
 	case kv.CommitmentHistoryIdx:
-		err := ac.d[kv.CommitmentDomain].ht.iit.IntegrityInvertedIndexAllValuesAreInRange(ctx, failFast, fromStep)
+		err := at.d[kv.CommitmentDomain].ht.iit.IntegrityInvertedIndexAllValuesAreInRange(ctx, failFast, fromStep)
 		if err != nil {
 			return err
 		}
 	case kv.ReceiptHistoryIdx:
-		err := ac.d[kv.ReceiptDomain].ht.iit.IntegrityInvertedIndexAllValuesAreInRange(ctx, failFast, fromStep)
+		err := at.d[kv.ReceiptDomain].ht.iit.IntegrityInvertedIndexAllValuesAreInRange(ctx, failFast, fromStep)
 		if err != nil {
 			return err
 		}
 	default:
 		// check the ii
-		if v := ac.searchII(name); v != nil {
+		if v := at.searchII(name); v != nil {
 			return v.IntegrityInvertedIndexAllValuesAreInRange(ctx, failFast, fromStep)
 		}
 		panic(fmt.Sprintf("unexpected: %s", name))

--- a/erigon-lib/state/merge.go
+++ b/erigon-lib/state/merge.go
@@ -1022,10 +1022,10 @@ func hasCoverVisibleFile(visibleFiles []visibleFile, item *filesItem) bool {
 	return false
 }
 
-func (ac *AggregatorRoTx) DbgDomain(idx kv.Domain) *DomainRoTx         { return ac.d[idx] }
-func (ac *AggregatorRoTx) DbgII(idx kv.InvertedIdx) *InvertedIndexRoTx { return ac.searchII(idx) }
-func (ac *AggregatorRoTx) searchII(idx kv.InvertedIdx) *InvertedIndexRoTx {
-	for _, iit := range ac.iis {
+func (at *AggregatorRoTx) DbgDomain(idx kv.Domain) *DomainRoTx         { return at.d[idx] }
+func (at *AggregatorRoTx) DbgII(idx kv.InvertedIdx) *InvertedIndexRoTx { return at.searchII(idx) }
+func (at *AggregatorRoTx) searchII(idx kv.InvertedIdx) *InvertedIndexRoTx {
+	for _, iit := range at.iis {
 		if iit.name == idx {
 			return iit
 		}

--- a/erigon-lib/state/squeeze.go
+++ b/erigon-lib/state/squeeze.go
@@ -105,8 +105,8 @@ func (a *Aggregator) sqeezeDomainFile(ctx context.Context, domain kv.Domain, fro
 
 // SqueezeCommitmentFiles should be called only when NO EXECUTION is running.
 // Removes commitment files and suppose following aggregator shutdown and restart  (to integrate new files and rebuild indexes)
-func (ac *AggregatorRoTx) SqueezeCommitmentFiles() error {
-	if !ac.a.commitmentValuesTransform {
+func (at *AggregatorRoTx) SqueezeCommitmentFiles() error {
+	if !at.a.commitmentValuesTransform {
 		return nil
 	}
 
@@ -116,23 +116,23 @@ func (ac *AggregatorRoTx) SqueezeCommitmentFiles() error {
 				name:    kv.AccountsDomain,
 				values:  MergeRange{"", true, 0, math.MaxUint64},
 				history: HistoryRanges{},
-				aggStep: ac.a.StepSize(),
+				aggStep: at.a.StepSize(),
 			},
 			kv.StorageDomain: {
 				name:    kv.StorageDomain,
 				values:  MergeRange{"", true, 0, math.MaxUint64},
 				history: HistoryRanges{},
-				aggStep: ac.a.StepSize(),
+				aggStep: at.a.StepSize(),
 			},
 			kv.CommitmentDomain: {
 				name:    kv.CommitmentDomain,
 				values:  MergeRange{"", true, 0, math.MaxUint64},
 				history: HistoryRanges{},
-				aggStep: ac.a.StepSize(),
+				aggStep: at.a.StepSize(),
 			},
 		},
 	}
-	sf, err := ac.staticFilesInRange(rng)
+	sf, err := at.staticFilesInRange(rng)
 	if err != nil {
 		return err
 	}
@@ -172,9 +172,9 @@ func (ac *AggregatorRoTx) SqueezeCommitmentFiles() error {
 		processedFiles int
 		sizeDelta      = datasize.B
 		sqExt          = ".squeezed"
-		commitment     = ac.d[kv.CommitmentDomain]
-		accounts       = ac.d[kv.AccountsDomain]
-		storage        = ac.d[kv.StorageDomain]
+		commitment     = at.d[kv.CommitmentDomain]
+		accounts       = at.d[kv.AccountsDomain]
+		storage        = at.d[kv.StorageDomain]
 		logEvery       = time.NewTicker(30 * time.Second)
 	)
 	defer logEvery.Stop()
@@ -198,18 +198,18 @@ func (ac *AggregatorRoTx) SqueezeCommitmentFiles() error {
 		cf.decompressor.EnableMadvNormal()
 
 		err = func() error {
-			steps := cf.endTxNum/ac.a.aggregationStep - cf.startTxNum/ac.a.aggregationStep
+			steps := cf.endTxNum/at.a.aggregationStep - cf.startTxNum/at.a.aggregationStep
 			compression := commitment.d.Compression
 			if steps < DomainMinStepsToCompress {
 				compression = seg.CompressNone
 			}
-			ac.a.logger.Info("[squeeze_migration] file start", "original", cf.decompressor.FileName(),
+			at.a.logger.Info("[squeeze_migration] file start", "original", cf.decompressor.FileName(),
 				"progress", fmt.Sprintf("%d/%d", ri+1, len(ranges)), "compress_cfg", commitment.d.CompressCfg, "compress", compression)
 
 			originalPath := cf.decompressor.FilePath()
 			squeezedTmpPath := originalPath + sqExt + ".tmp"
 
-			squeezedCompr, err := seg.NewCompressor(context.Background(), "squeeze", squeezedTmpPath, ac.a.dirs.Tmp,
+			squeezedCompr, err := seg.NewCompressor(context.Background(), "squeeze", squeezedTmpPath, at.a.dirs.Tmp,
 				commitment.d.CompressCfg, log.LvlInfo, commitment.d.logger)
 			if err != nil {
 				return err
@@ -253,7 +253,7 @@ func (ac *AggregatorRoTx) SqueezeCommitmentFiles() error {
 
 				select {
 				case <-logEvery.C:
-					ac.a.logger.Info("[squeeze_migration]", "file", cf.decompressor.FileName(), "k", fmt.Sprintf("%x", k),
+					at.a.logger.Info("[squeeze_migration]", "file", cf.decompressor.FileName(), "k", fmt.Sprintf("%x", k),
 						"progress", fmt.Sprintf("%s/%s", common.PrettyCounter(ki), common.PrettyCounter(cf.decompressor.Count())))
 				default:
 				}
@@ -278,7 +278,7 @@ func (ac *AggregatorRoTx) SqueezeCommitmentFiles() error {
 			}
 			temporalFiles = append(temporalFiles, squeezedPath)
 
-			ac.a.logger.Info("[sqeeze_migration] file done", "original", filepath.Base(originalPath),
+			at.a.logger.Info("[sqeeze_migration] file done", "original", filepath.Base(originalPath),
 				"sizeDelta", fmt.Sprintf("%s (%.1f%%)", delta.HR(), deltaP))
 
 			processedFiles++
@@ -295,9 +295,9 @@ func (ac *AggregatorRoTx) SqueezeCommitmentFiles() error {
 		if err := os.Rename(path, strings.TrimSuffix(path, sqExt)); err != nil {
 			return err
 		}
-		ac.a.logger.Debug("[squeeze_migration] temporal file renaming", "path", path)
+		at.a.logger.Debug("[squeeze_migration] temporal file renaming", "path", path)
 	}
-	ac.a.logger.Info("[squeeze_migration] done", "sizeDelta", sizeDelta.HR(), "files", len(ranges))
+	at.a.logger.Info("[squeeze_migration] done", "sizeDelta", sizeDelta.HR(), "files", len(ranges))
 
 	return nil
 }

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -695,6 +695,10 @@ Loop:
 				t1 = time.Since(tt) + ts
 
 				tt = time.Now()
+				if err = aggregatorRo.GreedyPruneHistory(ctx, kv.CommitmentDomain, executor.tx()); err != nil {
+					return err
+				}
+
 				if _, err := aggregatorRo.PruneSmallBatches(ctx, 10*time.Hour, executor.tx()); err != nil {
 					return err
 				}
@@ -883,9 +887,6 @@ func flushAndCheckCommitmentV3(ctx context.Context, header *types.Header, applyT
 	}
 	if !inMemExec {
 		if err := doms.Flush(ctx, applyTx); err != nil {
-			return false, err
-		}
-		if err = applyTx.(state2.HasAggTx).AggTx().(*state2.AggregatorRoTx).PruneCommitHistory(ctx, applyTx, nil); err != nil {
 			return false, err
 		}
 	}

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -427,8 +427,13 @@ func PruneExecutionStage(s *PruneState, tx kv.RwTx, cfg ExecuteBlockCfg, ctx con
 	pruneTimeout := 250 * time.Millisecond
 	if s.CurrentSyncCycle.IsInitialCycle {
 		pruneTimeout = 12 * time.Hour
+
+		// allow greedy prune on non-chain-tip
+		if err = tx.(*temporal.Tx).AggTx().(*libstate.AggregatorRoTx).GreedyPruneHistory(ctx, kv.CommitmentDomain, tx); err != nil {
+			return err
+		}
 	}
-	if _, err = tx.(*temporal.Tx).AggTx().(*libstate.AggregatorRoTx).PruneSmallBatches(ctx, pruneTimeout, tx); err != nil { // prune part of retired data, before commit
+	if _, err := tx.(*temporal.Tx).AggTx().(*libstate.AggregatorRoTx).PruneSmallBatches(ctx, pruneTimeout, tx); err != nil {
 		return err
 	}
 

--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -1477,23 +1477,6 @@ func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 		return err
 	}
 
-	if err := db.UpdateNosync(ctx, func(tx kv.RwTx) error {
-		ac := agg.BeginFilesRo()
-		defer ac.Close()
-
-		logEvery := time.NewTicker(30 * time.Second)
-		defer logEvery.Stop()
-
-		stat, err := ac.prune(ctx, tx, math.MaxUint64, logEvery)
-		if err != nil {
-			return err
-		}
-		logger.Info("aftermath prune finished", "stat", stat.String())
-		return err
-	}); err != nil {
-		return err
-	}
-
 	for hasMoreToPrune := true; hasMoreToPrune; {
 		if err := db.Update(ctx, func(tx kv.RwTx) error {
 			ac := tx.(libstate.HasAggTx).AggTx().(*libstate.AggregatorRoTx)

--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -1484,7 +1484,7 @@ func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 		logEvery := time.NewTicker(30 * time.Second)
 		defer logEvery.Stop()
 
-		stat, err := ac.Prune(ctx, tx, math.MaxUint64, logEvery)
+		stat, err := ac.prune(ctx, tx, math.MaxUint64, logEvery)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
reason: greedy prune can hold erigon from executing new blocks ASAP (missed attestations, etc...)