### PR TITLE
qa-tests: avoid job cancellation in the sync-with-extcl test

### DIFF
--- a/.github/workflows/qa-sync-with-externalcl.yml
+++ b/.github/workflows/qa-sync-with-externalcl.yml
@@ -8,8 +8,9 @@ on:
 jobs:
   sync-with-externalcl:
     runs-on: [self-hosted, qa, linux, X64]
-    timeout-minutes: 500 # 8+ hours
+    timeout-minutes: 1440 # 24 hours
     strategy:
+      fail-fast: false
       matrix:
         client: [lighthouse, prysm]
         chain: [mainnet, gnosis]


### PR DESCRIPTION
Avoid job cancelation in the presence of failed jobs