### PR TITLE
eth, execution: Use block level gasPool in serial execution (#14761)

### DIFF
--- a/cmd/state/exec3/state.go
+++ b/cmd/state/exec3/state.go
@@ -119,6 +119,10 @@ func (rw *Worker) ResetState(rs *state.StateV3, accumulator *shards.Accumulator)
 	rw.stateWriter = state.NewStateWriterV3(rs, accumulator)
 }
 
+func (rw *Worker) SetGaspool(gp *core.GasPool) {
+	rw.taskGasPool = gp
+}
+
 func (rw *Worker) Tx() kv.TemporalTx { return rw.chainTx }
 func (rw *Worker) DiscardReadList()  { rw.stateReader.DiscardReadList() }
 func (rw *Worker) ResetTx(chainTx kv.Tx) {
@@ -262,7 +266,8 @@ func (rw *Worker) RunTxTaskNoLock(txTask *state.TxTask, isMining, skipPostEvalua
 			}
 		}
 	default:
-		rw.taskGasPool.Reset(txTask.Tx.GetGas(), rw.chainConfig.GetMaxBlobGasPerBlock(header.Time))
+		// This doesn't make sense, but I am not sure if this wrong behaviour is needed somewhere else:
+		// rw.taskGasPool.Reset(txTask.Tx.GetGasLimit(), rw.chainConfig.GetMaxBlobGasPerBlock(header.Time))
 		rw.callTracer.Reset()
 		rw.vmCfg.SkipAnalysis = txTask.SkipAnalysis
 		ibs.SetTxContext(txTask.TxIndex)

--- a/eth/stagedsync/exec3_parallel.go
+++ b/eth/stagedsync/exec3_parallel.go
@@ -69,7 +69,7 @@ When rwLoop has nothing to do - it does Prune, or flush of WAL to RwTx (agg.rota
 */
 
 type executor interface {
-	execute(ctx context.Context, tasks []*state.TxTask) (bool, error)
+	execute(ctx context.Context, tasks []*state.TxTask, gp *core.GasPool) (bool, error)
 	status(ctx context.Context, commitThreshold uint64) error
 	wait() error
 	getHeader(ctx context.Context, hash common.Hash, number uint64) (h *types.Header)
@@ -531,7 +531,7 @@ func (pe *parallelExecutor) wait() error {
 	return nil
 }
 
-func (pe *parallelExecutor) execute(ctx context.Context, tasks []*state.TxTask) (bool, error) {
+func (pe *parallelExecutor) execute(ctx context.Context, tasks []*state.TxTask, gp *core.GasPool) (bool, error) {
 	for _, txTask := range tasks {
 		if txTask.Sender() != nil {
 			if ok := pe.rs.RegisterSender(txTask); ok {

--- a/eth/stagedsync/exec3_serial.go
+++ b/eth/stagedsync/exec3_serial.go
@@ -34,12 +34,14 @@ func (se *serialExecutor) status(ctx context.Context, commitThreshold uint64) er
 	return nil
 }
 
-func (se *serialExecutor) execute(ctx context.Context, tasks []*state.TxTask) (cont bool, err error) {
+func (se *serialExecutor) execute(ctx context.Context, tasks []*state.TxTask, gp *core.GasPool) (cont bool, err error) {
 	for _, txTask := range tasks {
 		if txTask.Error != nil {
 			return false, nil
 		}
-
+		if gp != nil {
+			se.applyWorker.SetGaspool(gp)
+		}
 		se.applyWorker.RunTxTaskNoLock(txTask, se.isMining, se.skipPostEvaluation)
 		if err := func() error {
 			if errors.Is(txTask.Error, context.Canceled) {


### PR DESCRIPTION
Block's gas limit should be used for the gasPool, for `state_transition` to work correctly

Cherry-pick #14761