### PR TITLE
seg: enhance integrity check for astrid snapshots

### DIFF
--- a/eth/integrity/bor_snapshots.go
+++ b/eth/integrity/bor_snapshots.go
@@ -135,26 +135,41 @@ func ValidateBorEvents(ctx context.Context, db kv.TemporalRoDB, blockReader serv
 	return nil
 }
 
-func ValidateBorSpans(logger log.Logger, dirs datadir.Dirs, snaps *heimdall.RoSnapshots, failFast bool) error {
+func ValidateBorSpans(ctx context.Context, logger log.Logger, dirs datadir.Dirs, snaps *heimdall.RoSnapshots, failFast bool) error {
 	baseStore := heimdall.NewMdbxStore(logger, dirs.DataDir, true, 32)
 	snapshotStore := heimdall.NewSpanSnapshotStore(baseStore.Spans(), snaps)
-	err := snapshotStore.ValidateSnapshots(logger, failFast)
+	err := snapshotStore.Prepare(ctx)
+	if err != nil {
+		return err
+	}
+	defer snapshotStore.Close()
+	err = snapshotStore.ValidateSnapshots(ctx, logger, failFast)
 	logger.Info("[integrity] ValidateBorSpans: done", "err", err)
 	return err
 }
 
-func ValidateBorCheckpoints(logger log.Logger, dirs datadir.Dirs, snaps *heimdall.RoSnapshots, failFast bool) error {
+func ValidateBorCheckpoints(ctx context.Context, logger log.Logger, dirs datadir.Dirs, snaps *heimdall.RoSnapshots, failFast bool) error {
 	baseStore := heimdall.NewMdbxStore(logger, dirs.DataDir, true, 32)
 	snapshotStore := heimdall.NewCheckpointSnapshotStore(baseStore.Checkpoints(), snaps)
-	err := snapshotStore.ValidateSnapshots(logger, failFast)
+	err := snapshotStore.Prepare(ctx)
+	if err != nil {
+		return err
+	}
+	defer snapshotStore.Close()
+	err = snapshotStore.ValidateSnapshots(ctx, logger, failFast)
 	logger.Info("[integrity] ValidateBorCheckpoints: done", "err", err)
 	return err
 }
 
-func ValidateBorMilestones(logger log.Logger, dirs datadir.Dirs, snaps *heimdall.RoSnapshots, failFast bool) error {
+func ValidateBorMilestones(ctx context.Context, logger log.Logger, dirs datadir.Dirs, snaps *heimdall.RoSnapshots, failFast bool) error {
 	baseStore := heimdall.NewMdbxStore(logger, dirs.DataDir, true, 32)
 	snapshotStore := heimdall.NewMilestoneSnapshotStore(baseStore.Milestones(), snaps)
-	err := snapshotStore.ValidateSnapshots(logger, failFast)
+	err := snapshotStore.Prepare(ctx)
+	if err != nil {
+		return err
+	}
+	defer snapshotStore.Close()
+	err = snapshotStore.ValidateSnapshots(ctx, logger, failFast)
 	logger.Info("[integrity] ValidateBorMilestones: done", "err", err)
 	return err
 }

--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -575,15 +575,15 @@ func doIntegrity(cliCtx *cli.Context) error {
 				return err
 			}
 		case integrity.BorSpans:
-			if err := integrity.ValidateBorSpans(logger, dirs, borSnaps, failFast); err != nil {
+			if err := integrity.ValidateBorSpans(ctx, logger, dirs, borSnaps, failFast); err != nil {
 				return err
 			}
 		case integrity.BorCheckpoints:
-			if err := integrity.ValidateBorCheckpoints(logger, dirs, borSnaps, failFast); err != nil {
+			if err := integrity.ValidateBorCheckpoints(ctx, logger, dirs, borSnaps, failFast); err != nil {
 				return err
 			}
 		case integrity.BorMilestones:
-			if err := integrity.ValidateBorMilestones(logger, dirs, borSnaps, failFast); err != nil {
+			if err := integrity.ValidateBorMilestones(ctx, logger, dirs, borSnaps, failFast); err != nil {
 				return err
 			}
 		case integrity.ReceiptsNoDups:
@@ -1165,6 +1165,7 @@ func openSnaps(ctx context.Context, cfg ethconfig.BlocksFreezing, dirs datadir.D
 	if chainConfig.Bor != nil {
 		const PolygonSync = true
 		if PolygonSync {
+			borSnaps.DownloadComplete() // mark as ready
 			bridgeStore = bridge.NewSnapshotStore(bridge.NewMdbxStore(dirs.DataDir, logger, true, 0), borSnaps, chainConfig.Bor)
 			heimdallStore = heimdall.NewSnapshotStore(heimdall.NewMdbxStore(logger, dirs.DataDir, true, 0), borSnaps)
 		} else {


### PR DESCRIPTION
reviving work on https://github.com/erigontech/erigon/pull/13689 to help @eastorski 

had a situation while testing where there were no gaps in seg files for checkpoints but there was a gap between last checkpoint in files and first in the db

this PR enhances the check for spans, milestones, checkpoints snapshots in "erigon seg integrity" to also check if there is a gap between the last snapshot in the seg files and the first one in the db if any (also adds a check for consecutiveness in the db as part of that because it is low effort and good extra info to have so why not)