### PR TITLE
polygon/p2p: tune awaitResponse timeout for initial sync to tip block download

### DIFF
--- a/polygon/p2p/fetcher_config.go
+++ b/polygon/p2p/fetcher_config.go
@@ -22,7 +22,7 @@ import (
 )
 
 var defaultFetcherConfig = FetcherConfig{
-	responseTimeout:    5 * time.Second,
+	responseTimeout:    15 * time.Second,
 	retryBackOff:       time.Second,
 	maxRetries:         1,
 	requestIdGenerator: rand.Uint64,

--- a/polygon/p2p/fetcher_config.go
+++ b/polygon/p2p/fetcher_config.go
@@ -22,7 +22,7 @@ import (
 )
 
 var defaultFetcherConfig = FetcherConfig{
-	responseTimeout:    15 * time.Second,
+	responseTimeout:    10 * time.Second,
 	retryBackOff:       time.Second,
 	maxRetries:         1,
 	requestIdGenerator: rand.Uint64,


### PR DESCRIPTION
got a few `await *eth.BlockBodiesPacket66 response interrupted: context deadline exceeded` errors while testing stuff on Amoy for https://github.com/erigontech/erigon/pull/13689

bumping up the `responseTimeout` for the block download within the initial sync to tip by x2 to 10 secs (on chain tip we have a lower 1 sec responseTimeout - less blocks to download there in a batch)

this is safe to do so and some further tweaking may be useful in the future if we still get frequent response timeouts from peers - it is a balance between not stalling for too long when hitting slow peers but also not missing out on too many peers because our timeout is too aggressive
