### PR TITLE
polygon/sync: tolerate domain ahead of blocks err on initial sync to tip 

### DIFF
--- a/polygon/sync/execution_client.go
+++ b/polygon/sync/execution_client.go
@@ -37,6 +37,7 @@ import (
 var ErrForkChoiceUpdateFailure = errors.New("fork choice update failure")
 var ErrForkChoiceUpdateBadBlock = errors.New("fork choice update bad block")
 var ErrExecutionClientBusy = errors.New("execution client busy")
+var ErrUfcTooFarBehind = errors.New("ufc too far behind")
 
 type ExecutionClient interface {
 	Prepare(ctx context.Context) error
@@ -124,6 +125,8 @@ func (e *executionClient) UpdateForkChoice(ctx context.Context, tip *types.Heade
 			return fmt.Errorf("%w: status=%d, validationErr='%s'", ErrForkChoiceUpdateBadBlock, r.Status, r.ValidationError)
 		case executionproto.ExecutionStatus_Busy:
 			return ErrExecutionClientBusy // gets retried
+		case executionproto.ExecutionStatus_TooFarAway:
+			return ErrUfcTooFarBehind
 		default:
 			return fmt.Errorf("%w: status=%d, validationErr='%s'", ErrForkChoiceUpdateFailure, r.Status, r.ValidationError)
 		}

--- a/polygon/sync/sync.go
+++ b/polygon/sync/sync.go
@@ -928,10 +928,17 @@ func (s *Sync) sync(
 		}
 
 		if err := s.commitExecution(ctx, newTip, newTip); err != nil {
-			// note: if we face a failure during execution of finalized waypoints blocks, it means that
-			// we're wrong and the blocks are not considered as bad blocks, so we should terminate
-			err = s.handleWaypointExecutionErr(ctx, tip, err)
-			return syncToTipResult{}, false, err
+			if errors.Is(err, ErrUfcTooFarBehind) {
+				s.logger.Warn(
+					syncLogPrefix("ufc skipped during sync to tip - likely due to domain ahead of blocks"),
+					"err", err,
+				)
+			} else {
+				// note: if we face a failure during execution of finalized waypoints blocks, it means that
+				// we're wrong and the blocks are not considered as bad blocks, so we should terminate
+				err = s.handleWaypointExecutionErr(ctx, tip, err)
+				return syncToTipResult{}, false, err
+			}
 		}
 
 		tip = newTip


### PR DESCRIPTION
Relates to improving our support of "rm -rf chaindata" (somewhat relates to https://github.com/erigontech/erigon/issues/13674)

After adding more debug logs in https://github.com/erigontech/erigon/pull/14414 it is now clear why with Astrid we sometimes get "domain ahead of blocks" err sometimes after "rm -rf chaindata" during "sync to tip" and it is also clear what the fix should be.

The theory I had previously of when this err could happen is confirmed:
- when we insert N+1, N+2, ... -> we limit how much we insert using LoopBlockLimit which is 5,000 blocks before we call UpdateForkChoice on the batch 
- so if domains is ahead of blocks with more than 5,000 blocks we will hit this error 
- this is confirmed with below logs 
- you can see we insert around ~5000 from 21069939 to 21075570
- but still get the "domain ahead of blocks" err response because the domains are at 21078133 (which is another 3000 blocks ahead, so 8000 in total)
- this was simulated after "rm -rf chaindata" and some manual removal of block snapshots

Note this is exactly how the Ethereum block downloader behaves with regards to this situation - can see the code [here](https://github.com/erigontech/erigon/blob/main/turbo/engineapi/engine_block_downloader/core.go#L119-L123).

Logs:
```
[DBUG] [04-30|16:36:01.684] [sync] inserted blocks                   from=21069939 to=21070706 blocks=768 duration=15.816292ms blks/sec=48557.399
...
[DBUG] [04-30|16:36:01.812] [sync] inserted blocks                   from=21070707 to=21071218 blocks=512 duration=28.455292ms blks/sec=17993.138
...
[DBUG] [04-30|16:36:02.018] [sync] inserted blocks                   from=21071219 to=21071986 blocks=768 duration=33.321791ms blks/sec=23047.981
...
[DBUG] [04-30|16:36:02.131] [sync] inserted blocks                   from=21071987 to=21072498 blocks=512 duration=33.397625ms blks/sec=15330.412
...
[DBUG] [04-30|16:36:02.254] [sync] inserted blocks                   from=21072499 to=21073010 blocks=512 duration=32.745541ms blks/sec=15635.717
...
[DBUG] [04-30|16:36:02.361] [sync] inserted blocks                   from=21073011 to=21073778 blocks=768 duration=32.462375ms blks/sec=23658.128
...
[DBUG] [04-30|16:36:02.545] [sync] inserted blocks                   from=21073779 to=21074290 blocks=512 duration=35.408667ms blks/sec=14459.737
...
[DBUG] [04-30|16:36:02.748] [sync] inserted blocks                   from=21074291 to=21074802 blocks=512 duration=38.315416ms blks/sec=13362.768
...
[DBUG] [04-30|16:36:02.917] [sync] inserted blocks                   from=21074803 to=21075570 blocks=768 duration=37.507958ms blks/sec=20475.655
...
[INFO] [04-30|16:36:02.917] [sync] update fork choice                block=21075570 hash=0xd9ad3000135916a1f354be04e79382cee4a609e939188af606092547f45e2281 age=13h36m11s
[INFO] [04-30|16:36:02.932] Reorg requested too low, capping to the minimum unwindable block unwindTarget=21069999 minUnwindableBlock=21078133
[DBUG] [04-30|16:36:02.932] UnwindTo                                 block=21078133 stack="[sync.go:174 forkchoice.go:373 asm_arm64.s:1223]"
[DBUG] [04-30|16:36:02.971] domain ahead of blocks                   err="behind commitment: TxNums index is at block 21075570 and behind commitment 21078133"
[EROR] [04-30|16:36:02.980] failed to update fork choice             latestValidHash=0x0000000000000000000000000000000000000000000000000000000000000000 err="fork choice update failure: status=2, validationErr='domain ahead of blocks'"
```
