### PR TITLE
Expose downloader torrent client status to HTTP (#14639)

### DIFF
--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -269,6 +269,8 @@ func Downloader(ctx context.Context, logger log.Logger) error {
 	defer d.Close()
 	logger.Info("[snapshots] Start bittorrent server", "my_peer_id", fmt.Sprintf("%x", d.TorrentClient().PeerID()))
 
+	d.HandleTorrentClientStatus()
+
 	if len(_verifyFiles) > 0 {
 		verifyFiles = strings.Split(_verifyFiles, ",")
 	}

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -2898,3 +2898,11 @@ func (d *Downloader) CompletedTorrents() map[string]completedTorrentInfo {
 
 	return d.completedTorrents
 }
+
+// Expose torrent client status to HTTP on the public/default serve mux used by GOPPROF=http. Only
+// do this if you have a single instance.
+func (d *Downloader) HandleTorrentClientStatus() {
+	http.HandleFunc("/downloaderTorrentClientStatus", func(w http.ResponseWriter, r *http.Request) {
+		d.torrentClient.WriteStatus(w)
+	})
+}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1509,6 +1509,9 @@ func (s *Ethereum) setUpSnapDownloader(ctx context.Context, downloaderCfg *downl
 		if err != nil {
 			return err
 		}
+
+		s.downloader.HandleTorrentClientStatus()
+
 		bittorrentServer, err := downloader.NewGrpcServer(s.downloader)
 		if err != nil {
 			return fmt.Errorf("new server: %w", err)


### PR DESCRIPTION
Cherry pick for release. See issue referred in commit.

Per last #networking meeting, @mh0lt plans to expose through the conventional Erigon pprof as well but in the meanwhile this is still usable and worth having access to for diagnostics.