### PR TITLE
snapshotsync: return txnSeg file err

### DIFF
--- a/turbo/snapshotsync/freezeblocks/block_reader.go
+++ b/turbo/snapshotsync/freezeblocks/block_reader.go
@@ -870,10 +870,8 @@ func (r *BlockReader) blockWithSenders(ctx context.Context, tx kv.Getter, hash c
 	if txCount != 0 {
 		txnSeg, ok, release := r.sn.ViewSingleFile(coresnaptype.Transactions, blockHeight)
 		if !ok {
-			if dbgLogs {
-				log.Info(dbgPrefix+"no transactions file for this block num", "r.sn.BlocksAvailable()", r.sn.BlocksAvailable())
-			}
-			return
+			err = fmt.Errorf("no transactions snapshot file for blockNum=%d, BlocksAvailable=%d", blockHeight, r.sn.BlocksAvailable())
+			return nil, nil, err
 		}
 		defer release()
 		txs, senders, err = r.txsFromSnapshot(baseTxnId, txCount, txnSeg, buf)


### PR DESCRIPTION
This err return is important if the file is really needed to return the block for the calling function. Also to be noted that whether the file was supposed to be there was already checked above