### PR TITLE
Use transaction index

### DIFF
--- a/cmd/devnet/services/polygon/heimdallsim/heimdall_simulator.go
+++ b/cmd/devnet/services/polygon/heimdallsim/heimdall_simulator.go
@@ -83,7 +83,7 @@ func (noopBridgeStore) EventTxnToBlockNum(ctx context.Context, borTxHash libcomm
 func (noopBridgeStore) Events(ctx context.Context, start, end uint64) ([][]byte, error) {
 	return nil, errors.New("noop")
 }
-func (noopBridgeStore) BlockEventIdsRange(ctx context.Context, blockNum uint64) (start uint64, end uint64, ok bool, err error) {
+func (noopBridgeStore) BlockEventIdsRange(ctx context.Context, blockHash libcommon.Hash, blockNum uint64) (start uint64, end uint64, ok bool, err error) {
 	return 0, 0, false, errors.New("noop")
 }
 func (noopBridgeStore) PutEventTxnToBlockNum(ctx context.Context, eventTxnToBlockNum map[libcommon.Hash]uint64) error {

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -109,7 +109,7 @@ type HeimdallReader interface {
 }
 
 type BridgeReader interface {
-	Events(ctx context.Context, blockNum uint64) ([]*types.Message, error)
+	Events(ctx context.Context, blockHash libcommon.Hash, blockNum uint64) ([]*types.Message, error)
 	EventTxnLookup(ctx context.Context, borTxHash libcommon.Hash) (uint64, bool, error)
 	Close()
 }

--- a/eth/stagedsync/stage_polygon_sync.go
+++ b/eth/stagedsync/stage_polygon_sync.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/erigontech/erigon-lib/chain"
 	"github.com/erigontech/erigon-lib/common"
+	libcommon "github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/generics"
 	"github.com/erigontech/erigon-lib/common/metrics"
 	"github.com/erigontech/erigon-lib/downloader/snaptype"
@@ -1119,7 +1120,7 @@ func (s polygonSyncStageBridgeStore) Events(context.Context, uint64, uint64) ([]
 	panic("polygonSyncStageBridgeStore.Events not supported")
 }
 
-func (s polygonSyncStageBridgeStore) BlockEventIdsRange(context.Context, uint64) (uint64, uint64, bool, error) {
+func (s polygonSyncStageBridgeStore) BlockEventIdsRange(context.Context, libcommon.Hash, uint64) (uint64, uint64, bool, error) {
 	// used for accessing events in execution
 	// astrid stage integration intends to use the bridge only for scrapping
 	// not for reading which remains the same in execution (via BlockReader)

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -258,7 +258,7 @@ type spanReader interface {
 }
 
 type bridgeReader interface {
-	Events(ctx context.Context, blockNum uint64) ([]*types.Message, error)
+	Events(ctx context.Context, blockHash libcommon.Hash, blockNum uint64) ([]*types.Message, error)
 	EventTxnLookup(ctx context.Context, borTxHash libcommon.Hash) (uint64, bool, error)
 }
 
@@ -1549,7 +1549,7 @@ func (c *Bor) CommitStates(
 	blockNum := header.Number.Uint64()
 
 	if c.useBridgeReader {
-		events, err := c.bridgeReader.Events(c.execCtx, blockNum)
+		events, err := c.bridgeReader.Events(c.execCtx, header.Hash(), blockNum)
 		if err != nil {
 			return err
 		}

--- a/polygon/bor/bor_internal_test.go
+++ b/polygon/bor/bor_internal_test.go
@@ -53,7 +53,7 @@ var _ bridgeReader = mockBridgeReader{}
 
 type mockBridgeReader struct{}
 
-func (m mockBridgeReader) Events(context.Context, uint64) ([]*types.Message, error) {
+func (m mockBridgeReader) Events(context.Context, libcommon.Hash,uint64) ([]*types.Message, error) {
 	panic("mock")
 }
 

--- a/polygon/bridge/mdbx_store.go
+++ b/polygon/bridge/mdbx_store.go
@@ -279,11 +279,11 @@ func (s *MdbxStore) PutBlockNumToEventId(ctx context.Context, blockNumToEventId 
 
 // BlockEventIdsRange returns the [start, end] event Id for the given block number
 // If the given block number is the first in the database, then the first uint64 (representing start Id) is 0.
-func (s *MdbxStore) BlockEventIdsRange(ctx context.Context, blockNum uint64) (uint64, uint64, bool, error) {
-	return s.blockEventIdsRange(ctx, blockNum, s.LastFrozenEventId())
+func (s *MdbxStore) BlockEventIdsRange(ctx context.Context, blockHash libcommon.Hash, blockNum uint64) (uint64, uint64, bool, error) {
+	return s.blockEventIdsRange(ctx, blockHash, blockNum, s.LastFrozenEventId())
 }
 
-func (s *MdbxStore) blockEventIdsRange(ctx context.Context, blockNum uint64, lastFrozenId uint64) (uint64, uint64, bool, error) {
+func (s *MdbxStore) blockEventIdsRange(ctx context.Context, blockHash libcommon.Hash, blockNum uint64, lastFrozenId uint64) (uint64, uint64, bool, error) {
 	var start, end uint64
 
 	tx, err := s.db.BeginRo(ctx)
@@ -292,7 +292,7 @@ func (s *MdbxStore) blockEventIdsRange(ctx context.Context, blockNum uint64, las
 	}
 	defer tx.Rollback()
 
-	return txStore{tx}.blockEventIdsRange(ctx, blockNum, lastFrozenId)
+	return txStore{tx}.blockEventIdsRange(ctx, blockHash, blockNum, lastFrozenId)
 }
 
 func (s *MdbxStore) Unwind(ctx context.Context, blockNum uint64) error {
@@ -560,13 +560,13 @@ func (s txStore) PutBlockNumToEventId(ctx context.Context, blockNumToEventId map
 	return nil
 }
 
-func (s txStore) BlockEventIdsRange(ctx context.Context, blockNum uint64) (uint64, uint64, bool, error) {
-	return s.blockEventIdsRange(ctx, blockNum, 0)
+func (s txStore) BlockEventIdsRange(ctx context.Context, blockHash libcommon.Hash, blockNum uint64) (uint64, uint64, bool, error) {
+	return s.blockEventIdsRange(ctx, blockHash, blockNum, 0)
 }
 
 // BlockEventIdsRange returns the [start, end] event Id for the given block number
 // If the given block number is the first in the database, then the first uint64 (representing start Id) is 0.
-func (s txStore) blockEventIdsRange(ctx context.Context, blockNum uint64, lastFrozenId uint64) (uint64, uint64, bool, error) {
+func (s txStore) blockEventIdsRange(ctx context.Context, blockHash libcommon.Hash, blockNum uint64, lastFrozenId uint64) (uint64, uint64, bool, error) {
 	var start, end uint64
 
 	kByte := make([]byte, 8)
@@ -605,7 +605,7 @@ func (s txStore) blockEventIdsRange(ctx context.Context, blockNum uint64, lastFr
 }
 
 func (s txStore) BorStartEventId(ctx context.Context, hash libcommon.Hash, blockHeight uint64) (uint64, error) {
-	startEventId, _, ok, err := s.blockEventIdsRange(ctx, blockHeight, 0)
+	startEventId, _, ok, err := s.blockEventIdsRange(ctx, hash, blockHeight, 0)
 	if !ok || err != nil {
 		return 0, err
 	}
@@ -613,7 +613,7 @@ func (s txStore) BorStartEventId(ctx context.Context, hash libcommon.Hash, block
 }
 
 func (s txStore) EventsByBlock(ctx context.Context, hash libcommon.Hash, blockHeight uint64) ([]rlp.RawValue, error) {
-	startEventId, endEventId, ok, err := s.blockEventIdsRange(ctx, blockHeight, 0)
+	startEventId, endEventId, ok, err := s.blockEventIdsRange(ctx, hash, blockHeight, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/polygon/bridge/reader.go
+++ b/polygon/bridge/reader.go
@@ -71,8 +71,8 @@ func (r *Reader) Prepare(ctx context.Context) error {
 }
 
 // Events returns all sync events at blockNum
-func (r *Reader) Events(ctx context.Context, blockNum uint64) ([]*types.Message, error) {
-	start, end, ok, err := r.store.BlockEventIdsRange(ctx, blockNum)
+func (r *Reader) Events(ctx context.Context, blockHash libcommon.Hash, blockNum uint64) ([]*types.Message, error) {
+	start, end, ok, err := r.store.BlockEventIdsRange(ctx, blockHash, blockNum)
 	if err != nil {
 		return nil, err
 	}
@@ -133,8 +133,10 @@ func NewRemoteReader(client remote.BridgeBackendClient) *RemoteReader {
 	}
 }
 
-func (r *RemoteReader) Events(ctx context.Context, blockNum uint64) ([]*types.Message, error) {
-	reply, err := r.client.BorEvents(ctx, &remote.BorEventsRequest{BlockNum: blockNum})
+func (r *RemoteReader) Events(ctx context.Context, blockHash libcommon.Hash, blockNum uint64) ([]*types.Message, error) {
+	reply, err := r.client.BorEvents(ctx, &remote.BorEventsRequest{
+		BlockNum:  blockNum,
+		BlockHash: gointerfaces.ConvertHashToH256(blockHash)})
 	if err != nil {
 		return nil, err
 	}

--- a/polygon/bridge/server.go
+++ b/polygon/bridge/server.go
@@ -29,7 +29,7 @@ import (
 )
 
 type bridgeReader interface {
-	Events(ctx context.Context, blockNum uint64) ([]*types.Message, error)
+	Events(ctx context.Context, blockHash libcommon.Hash, blockNum uint64) ([]*types.Message, error)
 	EventTxnLookup(ctx context.Context, borTxHash libcommon.Hash) (uint64, bool, error)
 }
 
@@ -66,7 +66,7 @@ func (b *BackendServer) BorTxnLookup(ctx context.Context, in *remoteproto.BorTxn
 }
 
 func (b *BackendServer) BorEvents(ctx context.Context, in *remoteproto.BorEventsRequest) (*remoteproto.BorEventsReply, error) {
-	events, err := b.bridgeReader.Events(ctx, in.BlockNum)
+	events, err := b.bridgeReader.Events(ctx, gointerfaces.ConvertH256ToHash(in.BlockHash), in.BlockNum)
 	if err != nil {
 		return nil, err
 	}

--- a/polygon/bridge/service.go
+++ b/polygon/bridge/service.go
@@ -422,8 +422,8 @@ func (s *Service) Unwind(ctx context.Context, blockNum uint64) error {
 }
 
 // Events returns all sync events at blockNum
-func (s *Service) Events(ctx context.Context, blockNum uint64) ([]*types.Message, error) {
-	return s.reader.Events(ctx, blockNum)
+func (s *Service) Events(ctx context.Context, blockHash libcommon.Hash, blockNum uint64) ([]*types.Message, error) {
+	return s.reader.Events(ctx, blockHash, blockNum)
 }
 
 func (s *Service) EventTxnLookup(ctx context.Context, borTxHash libcommon.Hash) (uint64, bool, error) {

--- a/polygon/bridge/service_test.go
+++ b/polygon/bridge/service_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	libcommon "github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/hexutil"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/core/types"
@@ -169,37 +170,37 @@ func TestService(t *testing.T) {
 	err = b.ProcessNewBlocks(ctx, blocks)
 	require.NoError(t, err)
 
-	res, err := b.Events(ctx, 2)
+	res, err := b.Events(ctx, blocks[1].Hash(), 2)
 	require.NoError(t, err)
 	require.Len(t, res, 0)
 
-	res, err = b.Events(ctx, 4)
+	res, err = b.Events(ctx, blocks[3].Hash(), 4)
 	require.NoError(t, err)
 	require.Len(t, res, 2)                      // have first two events
 	require.Equal(t, event1Data, res[0].Data()) // check data fields
 	require.Equal(t, event2Data, res[1].Data())
 
-	res, err = b.Events(ctx, 6)
+	res, err = b.Events(ctx, blocks[5].Hash(), 6)
 	require.NoError(t, err)
 	require.Len(t, res, 1)                      // have third event
 	require.Equal(t, event3Data, res[0].Data()) // check data fields
 
-	res, err = b.Events(ctx, 10)
+	res, err = b.Events(ctx, blocks[9].Hash(), 10)
 	require.NoError(t, err)
 	require.Len(t, res, 1)                      // have fourth event
 	require.Equal(t, event4Data, res[0].Data()) // check data fields
 
 	// get non-sprint block
-	res, err = b.Events(ctx, 1)
+	res, err = b.Events(ctx, blocks[0].Hash(), 1)
 	require.Equal(t, len(res), 0)
 	require.NoError(t, err)
 
-	res, err = b.Events(ctx, 3)
+	res, err = b.Events(ctx, blocks[2].Hash(), 3)
 	require.Equal(t, len(res), 0)
 	require.NoError(t, err)
 
 	// check block 0
-	res, err = b.Events(ctx, 0)
+	res, err = b.Events(ctx, libcommon.Hash{}, 0)
 	require.Equal(t, len(res), 0)
 	require.NoError(t, err)
 
@@ -281,26 +282,26 @@ func TestService_Unwind(t *testing.T) {
 	err = b.ProcessNewBlocks(ctx, blocks)
 	require.NoError(t, err)
 
-	res, err := b.Events(ctx, 4)
+	res, err := b.Events(ctx, blocks[3].Hash(), 4)
 	require.NoError(t, err)
 	require.Len(t, res, 2)
-	res, err = b.Events(ctx, 6)
+	res, err = b.Events(ctx, blocks[5].Hash(), 6)
 	require.NoError(t, err)
 	require.Len(t, res, 1)
-	res, err = b.Events(ctx, 10)
+	res, err = b.Events(ctx, blocks[9].Hash(), 10)
 	require.NoError(t, err)
 	require.Len(t, res, 1)
 
 	err = b.Unwind(ctx, 5)
 	require.NoError(t, err)
 
-	res, err = b.Events(ctx, 4)
+	res, err = b.Events(ctx, blocks[3].Hash(), 4)
 	require.NoError(t, err)
 	require.Len(t, res, 2)
-	res, err = b.Events(ctx, 6)
+	res, err = b.Events(ctx, blocks[5].Hash(), 6)
 	require.NoError(t, err)
 	require.Len(t, res, 0)
-	res, err = b.Events(ctx, 10)
+	res, err = b.Events(ctx, blocks[9].Hash(), 10)
 	require.NoError(t, err)
 	require.Len(t, res, 0)
 
@@ -308,7 +309,7 @@ func TestService_Unwind(t *testing.T) {
 	wg.Wait()
 }
 
-func setupOverrideTest(t *testing.T, ctx context.Context, borConfig borcfg.BorConfig, wg *sync.WaitGroup) *Service {
+func setupOverrideTest(t *testing.T, ctx context.Context, borConfig borcfg.BorConfig, wg *sync.WaitGroup) (*Service, []*types.Block) {
 	heimdallClient, b := setup(t, borConfig)
 	event1 := &heimdall.EventRecordWithTime{
 		EventRecord: heimdall.EventRecord{
@@ -382,7 +383,7 @@ func setupOverrideTest(t *testing.T, ctx context.Context, borConfig borcfg.BorCo
 	err = b.ProcessNewBlocks(ctx, blocks)
 	require.NoError(t, err)
 
-	return b
+	return b, blocks
 }
 
 func TestService_ProcessNewBlocksWithOverride(t *testing.T) {
@@ -392,17 +393,17 @@ func TestService_ProcessNewBlocksWithOverride(t *testing.T) {
 	var wg sync.WaitGroup
 	borCfg := defaultBorConfig
 	borCfg.OverrideStateSyncRecords = map[string]int{"4": 1}
-	b := setupOverrideTest(t, ctx, borCfg, &wg)
+	b, blocks := setupOverrideTest(t, ctx, borCfg, &wg)
 
-	res, err := b.Events(ctx, 4) // should only have event1 as event2 is skipped and is present in block 6
+	res, err := b.Events(ctx, blocks[3].Hash(), 4) // should only have event1 as event2 is skipped and is present in block 6
 	require.NoError(t, err)
 	require.Len(t, res, 1)
 
-	res, err = b.Events(ctx, 6)
+	res, err = b.Events(ctx, blocks[5].Hash(), 6)
 	require.NoError(t, err)
 	require.Len(t, res, 2)
 
-	res, err = b.Events(ctx, 10)
+	res, err = b.Events(ctx, blocks[9].Hash(), 10)
 	require.NoError(t, err)
 	require.Len(t, res, 1)
 
@@ -417,17 +418,17 @@ func TestService_ProcessNewBlocksWithZeroOverride(t *testing.T) {
 	var wg sync.WaitGroup
 	borCfg := defaultBorConfig
 	borCfg.OverrideStateSyncRecords = map[string]int{"4": 0}
-	b := setupOverrideTest(t, ctx, borCfg, &wg)
+	b, blocks := setupOverrideTest(t, ctx, borCfg, &wg)
 
-	res, err := b.Events(ctx, 4) // both event1 and event2 are in block 6
+	res, err := b.Events(ctx, blocks[3].Hash(), 4) // both event1 and event2 are in block 6
 	require.NoError(t, err)
 	require.Len(t, res, 0)
 
-	res, err = b.Events(ctx, 6)
+	res, err = b.Events(ctx, blocks[5].Hash(), 6)
 	require.NoError(t, err)
 	require.Len(t, res, 3)
 
-	res, err = b.Events(ctx, 10)
+	res, err = b.Events(ctx, blocks[9].Hash(), 10)
 	require.NoError(t, err)
 	require.Len(t, res, 1)
 

--- a/polygon/bridge/snapshot_store.go
+++ b/polygon/bridge/snapshot_store.go
@@ -29,6 +29,7 @@ import (
 	"github.com/erigontech/erigon-lib/kv"
 	"github.com/erigontech/erigon-lib/recsplit"
 	"github.com/erigontech/erigon-lib/rlp"
+	"github.com/erigontech/erigon/polygon/bor/types"
 	"github.com/erigontech/erigon/polygon/heimdall"
 	"github.com/erigontech/erigon/turbo/snapshotsync"
 )
@@ -222,7 +223,7 @@ func (s *SnapshotStore) EventTxnToBlockNum(ctx context.Context, txnHash libcommo
 	return blockNum, true, nil
 }
 
-func (s *SnapshotStore) BlockEventIdsRange(ctx context.Context, blockNum uint64) (uint64, uint64, bool, error) {
+func (s *SnapshotStore) BlockEventIdsRange(ctx context.Context, blockHash libcommon.Hash, blockNum uint64) (uint64, uint64, bool, error) {
 	maxBlockNumInFiles := s.snapshots.VisibleBlocksAvailable(heimdall.Events.Enum())
 	if maxBlockNumInFiles == 0 || blockNum > maxBlockNumInFiles {
 		return s.Store.(interface {
@@ -243,7 +244,21 @@ func (s *SnapshotStore) BlockEventIdsRange(ctx context.Context, blockNum uint64)
 			break
 		}
 
+		idxBorTxnHash := sn.Src().Index()
+		reader := recsplit.NewIndexReader(idxBorTxnHash)
+		txnHash := types.ComputeBorTxHash(blockNum, blockHash)
+		blockEventId, exists := reader.Lookup(txnHash[:])
+		var offset uint64
+
 		gg := sn.Src().MakeGetter()
+		if exists {
+			offset = idxBorTxnHash.OrdinalLookup(blockEventId)
+			gg.Reset(offset)
+			if !gg.MatchPrefix(txnHash[:]) {
+				continue
+			}
+		}
+		
 		var buf []byte
 		for gg.HasNext() {
 			buf, _ = gg.Next(buf[:0])
@@ -342,7 +357,7 @@ func (s *SnapshotStore) borBlockByEventHash(txnHash libcommon.Hash, segments []*
 }
 
 func (s *SnapshotStore) BorStartEventId(ctx context.Context, hash libcommon.Hash, blockHeight uint64) (uint64, error) {
-	startEventId, _, ok, err := s.BlockEventIdsRange(ctx, blockHeight)
+	startEventId, _, ok, err := s.BlockEventIdsRange(ctx, hash, blockHeight)
 	if !ok || err != nil {
 		return 0, err
 	}
@@ -350,7 +365,7 @@ func (s *SnapshotStore) BorStartEventId(ctx context.Context, hash libcommon.Hash
 }
 
 func (s *SnapshotStore) EventsByBlock(ctx context.Context, hash libcommon.Hash, blockHeight uint64) ([]rlp.RawValue, error) {
-	startEventId, endEventId, ok, err := s.BlockEventIdsRange(ctx, blockHeight)
+	startEventId, endEventId, ok, err := s.BlockEventIdsRange(ctx, hash, blockHeight)
 	if err != nil {
 		return nil, err
 	}

--- a/polygon/bridge/store.go
+++ b/polygon/bridge/store.go
@@ -38,7 +38,7 @@ type Store interface {
 
 	EventTxnToBlockNum(ctx context.Context, borTxHash libcommon.Hash) (uint64, bool, error)
 	Events(ctx context.Context, start, end uint64) ([][]byte, error)
-	BlockEventIdsRange(ctx context.Context, blockNum uint64) (start uint64, end uint64, ok bool, err error) // [start,end)
+	BlockEventIdsRange(ctx context.Context, blockHash libcommon.Hash, blockNum uint64) (start uint64, end uint64, ok bool, err error) // [start,end)
 
 	PutEventTxnToBlockNum(ctx context.Context, eventTxnToBlockNum map[libcommon.Hash]uint64) error
 	PutEvents(ctx context.Context, events []*heimdall.EventRecordWithTime) error

--- a/turbo/jsonrpc/eth_api.go
+++ b/turbo/jsonrpc/eth_api.go
@@ -302,7 +302,7 @@ func (api *BaseAPI) headerByRPCNumber(ctx context.Context, number rpc.BlockNumbe
 func (api *BaseAPI) stateSyncEvents(ctx context.Context, tx kv.Tx, blockHash common.Hash, blockNum uint64, chainConfig *chain.Config) ([]*types.Message, error) {
 	var stateSyncEvents []*types.Message
 	if api.useBridgeReader {
-		events, err := api.bridgeReader.Events(ctx, blockNum)
+		events, err := api.bridgeReader.Events(ctx, blockHash, blockNum)
 		if err != nil {
 			return nil, err
 		}
@@ -367,7 +367,7 @@ func (api *BaseAPI) pruneMode(tx kv.Tx) (*prune.Mode, error) {
 }
 
 type bridgeReader interface {
-	Events(ctx context.Context, blockNum uint64) ([]*types.Message, error)
+	Events(ctx context.Context, blockHash common.Hash, blockNum uint64) ([]*types.Message, error)
 	EventTxnLookup(ctx context.Context, borTxHash common.Hash) (uint64, bool, error)
 }
 

--- a/turbo/jsonrpc/eth_api_test.go
+++ b/turbo/jsonrpc/eth_api_test.go
@@ -267,7 +267,7 @@ var _ bridgeReader = mockBridgeReader{}
 
 type mockBridgeReader struct{}
 
-func (m mockBridgeReader) Events(context.Context, uint64) ([]*types.Message, error) {
+func (m mockBridgeReader) Events(context.Context, common.Hash, uint64) ([]*types.Message, error) {
 	panic("mock")
 }
 


### PR DESCRIPTION
This fixes this performance issue by using the transaction hash index rather than doing a file scan to get block events:

![image](https://github.com/user-attachments/assets/460464c2-2950-43fb-b8cc-4c602f9a4110)
 