### PR TITLE
Clean up custom chain webseed and preverified accesses

### DIFF
--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -236,9 +236,7 @@ func Downloader(ctx context.Context, logger log.Logger) error {
 	version := "erigon: " + params.VersionWithCommit(params.GitCommit)
 
 	webseedsList := common.CliString2Array(webseeds)
-	if known, ok := snapcfg.KnownWebseeds[chain]; ok {
-		webseedsList = append(webseedsList, known...)
-	}
+	webseedsList = append(webseedsList, snapcfg.GetWebseeds(chain)...)
 	if seedbox {
 		_, err = downloadercfg.LoadSnapshotsHashes(ctx, dirs, chain)
 		if err != nil {
@@ -443,14 +441,12 @@ var torrentMagnet = &cobra.Command{
 func manifestVerify(ctx context.Context, logger log.Logger) error {
 	webseedsList := common.CliString2Array(webseeds)
 	if len(webseedsList) == 0 { // fallback to default if exact list not passed
-		if known, ok := snapcfg.KnownWebseeds[chain]; ok {
-			for _, s := range known {
-				//TODO: enable validation of this buckets also. skipping to make CI useful.k
-				if strings.Contains(s, "erigon2-v2") {
-					continue
-				}
-				webseedsList = append(webseedsList, s)
+		for _, s := range snapcfg.GetWebseeds(chain) {
+			//TODO: enable validation of this buckets also. skipping to make CI useful.k
+			if strings.Contains(s, "erigon2-v2") {
+				continue
 			}
+			webseedsList = append(webseedsList, s)
 		}
 	}
 

--- a/cmd/snapshots/sync/sync.go
+++ b/cmd/snapshots/sync/sync.go
@@ -208,10 +208,7 @@ func NewTorrentClient(ctx context.Context, config CreateNewTorrentClientConfig) 
 	dirs := datadir.New(torrentDir)
 
 	webseedsList := common.CliString2Array(config.WebSeeds)
-
-	if known, ok := snapcfg.KnownWebseeds[config.Chain]; ok {
-		webseedsList = append(webseedsList, known...)
-	}
+	webseedsList = append(webseedsList, snapcfg.GetWebseeds(config.Chain)...)
 
 	var downloadRate, uploadRate datasize.ByteSize
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2076,9 +2076,7 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 		logger.Info("torrent verbosity", "level", lvl.LogString())
 		version := "erigon: " + params2.VersionWithCommit(params2.GitCommit)
 		webseedsList := common.CliString2Array(ctx.String(WebSeedsFlag.Name))
-		if known, ok := snapcfg.KnownWebseeds[chain]; ok {
-			webseedsList = append(webseedsList, known...)
-		}
+		webseedsList = append(webseedsList, snapcfg.GetWebseeds(chain)...)
 		cfg.Downloader, err = downloadercfg2.New(ctx.Context, cfg.Dirs, version, lvl, downloadRate, uploadRate,
 			ctx.Int(TorrentPortFlag.Name), ctx.Int(TorrentConnsPerFileFlag.Name), ctx.Int(TorrentDownloadSlotsFlag.Name),
 			common.CliString2Array(ctx.String(TorrentStaticPeersFlag.Name)),

--- a/diagnostics/setup.go
+++ b/diagnostics/setup.go
@@ -71,9 +71,7 @@ func Setup(ctx *cli.Context, node *node.ErigonNode, metricsMux *http.ServeMux, p
 
 	chain := ctx.String(chainFlag)
 	webseedsList := common.CliString2Array(ctx.String(webSeedsFlag))
-	if known, ok := snapcfg.KnownWebseeds[chain]; ok {
-		webseedsList = append(webseedsList, known...)
-	}
+	webseedsList = append(webseedsList, snapcfg.GetWebseeds(chain)...)
 
 	speedTest := ctx.Bool(diagnoticsSpeedTestFlag)
 	diagnostic, err := diaglib.NewDiagnosticClient(ctx.Context, diagMux, node.Backend().DataDir(), speedTest, webseedsList)

--- a/erigon-lib/chain/networkname/network_name.go
+++ b/erigon-lib/chain/networkname/network_name.go
@@ -16,6 +16,7 @@
 
 package networkname
 
+// TODO: These should be strongly/new-typed.
 const (
 	Mainnet             = "mainnet"
 	Holesky             = "holesky"

--- a/erigon-lib/chain/snapcfg/util.go
+++ b/erigon-lib/chain/snapcfg/util.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pelletier/go-toml/v2"
 	"github.com/tidwall/btree"
 
-	"github.com/erigontech/erigon-lib/chain/networkname"
 	"github.com/erigontech/erigon-lib/common/dbg"
 	"github.com/erigontech/erigon-lib/downloader/snaptype"
 	"github.com/erigontech/erigon-lib/log/v3"
@@ -40,16 +39,6 @@ import (
 )
 
 var snapshotGitBranch = dbg.EnvString("SNAPS_GIT_BRANCH", version.DefaultSnapshotGitBranch)
-
-var (
-	Mainnet    = fromToml(snapshothashes.Mainnet)
-	Holesky    = fromToml(snapshothashes.Holesky)
-	Sepolia    = fromToml(snapshothashes.Sepolia)
-	Amoy       = fromToml(snapshothashes.Amoy)
-	BorMainnet = fromToml(snapshothashes.BorMainnet)
-	Gnosis     = fromToml(snapshothashes.Gnosis)
-	Chiado     = fromToml(snapshothashes.Chiado)
-)
 
 type PreverifiedItem struct {
 	Name string
@@ -454,15 +443,7 @@ func (c Cfg) MergeLimit(t snaptype.Enum, fromBlock uint64) uint64 {
 	return c.MergeLimit(snaptype.MinCoreEnum, fromBlock)
 }
 
-var knownPreverified = map[string]Preverified{
-	networkname.Mainnet:    Mainnet,
-	networkname.Holesky:    Holesky,
-	networkname.Sepolia:    Sepolia,
-	networkname.Amoy:       Amoy,
-	networkname.BorMainnet: BorMainnet,
-	networkname.Gnosis:     Gnosis,
-	networkname.Chiado:     Chiado,
-}
+var knownPreverified = map[string]Preverified{}
 
 func RegisterKnownTypes(networkName string, types []snaptype.Type) {
 	knownTypes[networkName] = types
@@ -533,14 +514,16 @@ func VersionedCfg(networkName string, preferred snaptype.Version, _min snaptype.
 	return newCfg(networkName, c.Versioned(preferred, _min))
 }
 
-var KnownWebseeds = map[string][]string{
-	networkname.Mainnet:    webseedsParse(webseed.Mainnet),
-	networkname.Sepolia:    webseedsParse(webseed.Sepolia),
-	networkname.Amoy:       webseedsParse(webseed.Amoy),
-	networkname.BorMainnet: webseedsParse(webseed.BorMainnet),
-	networkname.Gnosis:     webseedsParse(webseed.Gnosis),
-	networkname.Chiado:     webseedsParse(webseed.Chiado),
-	networkname.Holesky:    webseedsParse(webseed.Holesky),
+// These are never updated by a remote. This is a cache of parsed webseed tomls.
+var knownWebseeds = map[string][]string{}
+
+// Get known webseeds, parsing if not parsed before.
+func GetWebseeds(chain string) []string {
+	ret, ok := knownWebseeds[chain]
+	if !ok {
+		knownWebseeds[chain] = webseedsParse(webseed.ForChain(chain))
+	}
+	return ret
 }
 
 func webseedsParse(in []byte) (res []string) {
@@ -555,73 +538,23 @@ func webseedsParse(in []byte) (res []string) {
 	return res
 }
 
-func LoadRemotePreverified(ctx context.Context) (loaded bool, err error) {
-	loaded, err = snapshothashes.LoadSnapshots(ctx, snapshothashes.R2, snapshotGitBranch)
+// Obtain the latest preverified snapshot bytes. They're set in the package globals at the same
+// time. The bytes are returned for callers to save them for future sessions.
+func LoadRemotePreverified(ctx context.Context, chain string) (data []byte, err error) {
+	data, err = snapshothashes.FetchSnapshotHashes(ctx, snapshothashes.R2, snapshotGitBranch, chain)
 	if err != nil {
 		log.Root().Warn("Failed to load snapshot hashes from R2; falling back to GitHub", "err", err)
-
 		// Fallback to github if R2 fails
-		loaded, err = snapshothashes.LoadSnapshots(ctx, snapshothashes.Github, snapshotGitBranch)
+		data, err = snapshothashes.FetchSnapshotHashes(ctx, snapshothashes.Github, snapshotGitBranch, chain)
 		if err != nil {
-			return false, err
+			return
 		}
 	}
-
-	// Re-load the preverified hashes
-	Mainnet = fromToml(snapshothashes.Mainnet)
-	Holesky = fromToml(snapshothashes.Holesky)
-	Sepolia = fromToml(snapshothashes.Sepolia)
-	Amoy = fromToml(snapshothashes.Amoy)
-	BorMainnet = fromToml(snapshothashes.BorMainnet)
-	Gnosis = fromToml(snapshothashes.Gnosis)
-	Chiado = fromToml(snapshothashes.Chiado)
-	// Update the known preverified hashes
-	KnownWebseeds = map[string][]string{
-		networkname.Mainnet:    webseedsParse(webseed.Mainnet),
-		networkname.Sepolia:    webseedsParse(webseed.Sepolia),
-		networkname.Amoy:       webseedsParse(webseed.Amoy),
-		networkname.BorMainnet: webseedsParse(webseed.BorMainnet),
-		networkname.Gnosis:     webseedsParse(webseed.Gnosis),
-		networkname.Chiado:     webseedsParse(webseed.Chiado),
-		networkname.Holesky:    webseedsParse(webseed.Holesky),
-	}
-
-	knownPreverified = map[string]Preverified{
-		networkname.Mainnet:    Mainnet,
-		networkname.Holesky:    Holesky,
-		networkname.Sepolia:    Sepolia,
-		networkname.Amoy:       Amoy,
-		networkname.BorMainnet: BorMainnet,
-		networkname.Gnosis:     Gnosis,
-		networkname.Chiado:     Chiado,
-	}
-	return loaded, nil
+	knownPreverified[chain] = fromToml(data)
+	return
 }
 
+// Set preverified from external byte source, like a cached local file.
 func SetToml(networkName string, toml []byte) {
-	if _, ok := knownPreverified[networkName]; !ok {
-		return
-	}
 	knownPreverified[networkName] = fromToml(toml)
-}
-
-func GetToml(networkName string) []byte {
-	switch networkName {
-	case networkname.Mainnet:
-		return snapshothashes.Mainnet
-	case networkname.Holesky:
-		return snapshothashes.Holesky
-	case networkname.Sepolia:
-		return snapshothashes.Sepolia
-	case networkname.Amoy:
-		return snapshothashes.Amoy
-	case networkname.BorMainnet:
-		return snapshothashes.BorMainnet
-	case networkname.Gnosis:
-		return snapshothashes.Gnosis
-	case networkname.Chiado:
-		return snapshothashes.Chiado
-	default:
-		return nil
-	}
 }

--- a/erigon-lib/downloader/downloadercfg/downloadercfg.go
+++ b/erigon-lib/downloader/downloadercfg/downloadercfg.go
@@ -255,7 +255,7 @@ func LoadSnapshotsHashes(ctx context.Context, dirs datadir.Dirs, chainName strin
 		tomlBytes, err = snapcfg.LoadRemotePreverified(ctx, chainName)
 		if err != nil {
 			log.Root().Crit("Snapshot hashes for supported networks was not loaded. Please check your network connection and/or GitHub status here https://www.githubstatus.com/", "chain", chainName, "err", err)
-			return nil, fmt.Errorf("failed to fetch remote snapshot hashes for chain %w", chainName)
+			return nil, fmt.Errorf("failed to fetch remote snapshot hashes for chain %q: %w", chainName, err)
 		}
 		if err := dir.WriteFileWithFsync(preverifiedPath, tomlBytes, 0644); err != nil {
 			return nil, err

--- a/go.mod
+++ b/go.mod
@@ -185,7 +185,7 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/elastic/gosigar v0.14.3 // indirect
-	github.com/erigontech/erigon-snapshot v1.3.1-0.20250501041114-4a48ac232c83 // indirect
+	github.com/erigontech/erigon-snapshot v1.3.1-0.20250506043316-3253a3fefeec // indirect
 	github.com/flynn/noise v1.1.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -264,8 +264,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/erigontech/erigon-snapshot v1.3.1-0.20250501041114-4a48ac232c83 h1:q/bh24/m3V0FIHdLU+eYwoFtHd1x4khYyHhujDaiWek=
-github.com/erigontech/erigon-snapshot v1.3.1-0.20250501041114-4a48ac232c83/go.mod h1:ooHlCl+eEYzebiPu+FP6Q6SpPUeMADn8Jxabv3IKb9M=
+github.com/erigontech/erigon-snapshot v1.3.1-0.20250506043316-3253a3fefeec h1:RiqHBKYVAmsuNKkz38rHd1sjeMl920jCf3lN5uARDJE=
+github.com/erigontech/erigon-snapshot v1.3.1-0.20250506043316-3253a3fefeec/go.mod h1:k7vLIf2dwKVG6KTgy/pOXZSDBonLKnNbpFUS95qgtJA=
 github.com/erigontech/erigonwatch v0.0.0-20240718131902-b6576bde1116 h1:KCFa2uXEfZoBjV4buzjWmCmoqVLXiGCq0ZmQ2OjeRvQ=
 github.com/erigontech/erigonwatch v0.0.0-20240718131902-b6576bde1116/go.mod h1:8vQ+VjvLu2gkPs8EwdPrOTAAo++WuLuBi54N7NuAF0I=
 github.com/erigontech/go-kzg-4844 v0.0.0-20250130131058-ce13be60bc86 h1:UKcIbFZUGIKzK4aQbkv/dYiOVxZSUuD3zKadhmfwdwU=

--- a/turbo/snapshotsync/snapshotsync_test.go
+++ b/turbo/snapshotsync/snapshotsync_test.go
@@ -17,6 +17,7 @@
 package snapshotsync
 
 import (
+	"github.com/erigontech/erigon-lib/chain/networkname"
 	"strings"
 	"testing"
 
@@ -25,7 +26,8 @@ import (
 )
 
 func TestBlackListForPruning(t *testing.T) {
-	preverified := snapcfg.Mainnet
+	// Reuse the same public API everyone else is using. Note we aren't loading remote here now.
+	preverified := snapcfg.KnownCfg(networkname.Mainnet).Preverified
 
 	maxStep, err := getMaxStepRangeInSnapshots(preverified)
 	if err != nil {


### PR DESCRIPTION
This pull request introduces a refactor to streamline the handling of webseeds and preverified snapshot data, alongside minor dependency updates and cleanup. The most significant changes involve replacing hardcoded maps with dynamic functions, improving maintainability and flexibility. Below are the key changes:

### Refactoring Webseed Handling
* Replaced the `KnownWebseeds` map with a new `GetWebseeds` function, which dynamically retrieves webseeds for a given chain. This change simplifies the code and avoids maintaining static lists. (`cmd/downloader/main.go`, `cmd/snapshots/sync/sync.go`, `cmd/utils/flags.go`, `diagnostics/setup.go`, `erigon-lib/chain/snapcfg/util.go`) [[1]](diffhunk://#diff-f8d06fc882d9a29b9f203794098aba4890f5ba3949ca102e6d4f792f7b821dc7L239-R239) [[2]](diffhunk://#diff-f8d06fc882d9a29b9f203794098aba4890f5ba3949ca102e6d4f792f7b821dc7L446-L455) [[3]](diffhunk://#diff-d0e79d8330fd1bf40d08243350a17df71984c51b46551e352358f0fb1ce3257fL211-R211) [[4]](diffhunk://#diff-7aa83061ca1c69a8ab9203da49a7581bad6e7cc80ecb96582e7fb09c0b8f6534L2079-R2079) [[5]](diffhunk://#diff-b027321637e7586bd2d5130c2e5285aab9d71377b71686a02c1d6c13cca65f98L74-R74) [[6]](diffhunk://#diff-3e3fc89a6f761892766ea455eb859bb1bb06aaeb0348706e76ca7e988cc56109L536-R526)

### Refactoring Preverified Snapshot Handling
* Removed static preverified snapshot data and replaced it with dynamic loading through `LoadRemotePreverified`, allowing for per-chain fetching and better error handling. (`erigon-lib/chain/snapcfg/util.go`, `erigon-lib/downloader/downloadercfg/downloadercfg.go`) [[1]](diffhunk://#diff-3e3fc89a6f761892766ea455eb859bb1bb06aaeb0348706e76ca7e988cc56109L558-L627) [[2]](diffhunk://#diff-770c5dff85f20a3a1cafca7aa4a1d51c1c53230951e81bc8298cc32339e7d918R251-R266)

### Dependency Updates
* Updated the `erigon-snapshot` dependency to a newer version, ensuring compatibility with the latest features and fixes. (`go.mod`)

### Code Cleanup
* Removed unused imports and variables, such as the `networkname` import in `util.go` and redundant preverified snapshot data. (`erigon-lib/chain/snapcfg/util.go`) [[1]](diffhunk://#diff-3e3fc89a6f761892766ea455eb859bb1bb06aaeb0348706e76ca7e988cc56109L35) [[2]](diffhunk://#diff-3e3fc89a6f761892766ea455eb859bb1bb06aaeb0348706e76ca7e988cc56109L44-L53) [[3]](diffhunk://#diff-3e3fc89a6f761892766ea455eb859bb1bb06aaeb0348706e76ca7e988cc56109L457-R446)
* Added TODO comments for future improvements, such as strong typing for network names. (`erigon-lib/chain/networkname/network_name.go`)

### Test Adjustments
* Updated tests to use the new dynamic API for preverified snapshots, ensuring they align with the refactored implementation. (`turbo/snapshotsync/snapshotsync_test.go`) [[1]](diffhunk://#diff-e272e3b412e9fc05cf15bdc4c78e05f8dacd0af5e07cb9ef070f735d320b0bf4R20) [[2]](diffhunk://#diff-e272e3b412e9fc05cf15bdc4c78e05f8dacd0af5e07cb9ef070f735d320b0bf4L28-R30)