### PR TITLE
[e30] reduce default `--torrent.download.slots` 

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -700,7 +700,7 @@ var (
 	}
 	TorrentDownloadSlotsFlag = cli.IntFlag{
 		Name:  "torrent.download.slots",
-		Value: 128,
+		Value: 32,
 		Usage: "Amount of files to download in parallel.",
 	}
 	TorrentStaticPeersFlag = cli.StringFlag{

--- a/turbo/execution/eth1/forkchoice.go
+++ b/turbo/execution/eth1/forkchoice.go
@@ -481,7 +481,9 @@ func (e *EthereumExecutionModule) updateForkChoice(ctx context.Context, original
 	firstCycle := false
 	if _, err := e.executionPipeline.Run(e.db, wrap.TxContainer{Tx: tx}, initialCycle, firstCycle); err != nil {
 		err = fmt.Errorf("updateForkChoice: %w", err)
-		e.logger.Warn("Cannot update chain head", "hash", blockHash, "err", err)
+		if !errors.Is(err, context.Canceled) {
+			e.logger.Warn("Cannot update chain head", "hash", blockHash, "err", err)
+		}
 		sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, err, stateFlushingInParallel)
 		return
 	}


### PR DESCRIPTION
Still can see `1Gb/s`. But `sys` goes down from `20Gb` to `8Gb`
(on ethmainnet)