### PR TITLE
Nitro-erigon: Use ArbOS constants instead of literals

### DIFF
--- a/core/evm.go
+++ b/core/evm.go
@@ -79,7 +79,7 @@ func NewEVMBlockContext(header *types.Header, blockHashFunc func(n uint64) libco
 
 	// assert if network is ARB0 to change pervrandao
 	arbOsVersion := types.DeserializeHeaderExtraInformation(header).ArbOSFormatVersion
-	if arbOsVersion > 0 {
+	if arbOsVersion > chain.ArbosVersion_0 {
 		difficultyHash := libcommon.BigToHash(header.Difficulty)
 		prevRandDao = &difficultyHash
 	}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/holiman/uint256"
 
+	"github.com/erigontech/erigon-lib/chain"
 	"github.com/erigontech/erigon-lib/chain/params"
 	libcommon "github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/dbg"
@@ -210,7 +211,7 @@ func (st *StateTransition) buyGas(gasBailout bool) error {
 
 			isCancun := st.evm.ChainRules().IsCancun
 			if st.evm.ChainRules().IsArbitrum {
-				isCancun = isCancun && st.evm.Context.ArbOSVersion >= 20
+				isCancun = isCancun && st.evm.Context.ArbOSVersion >= chain.ArbosVersion_20
 			}
 			if isCancun {
 				maxBlobFee, overflow := new(uint256.Int).MulOverflow(st.msg.MaxFeePerBlobGas(), new(uint256.Int).SetUint64(st.msg.BlobGas()))
@@ -316,7 +317,7 @@ func (st *StateTransition) preCheck(gasBailout bool) error {
 	isCancun := st.evm.ChainRules().IsCancun
 	// st.evm.ChainConfig().IsCancun(st.evm.Context.Time)
 	if isArb {
-		isCancun = st.evm.Context.ArbOSVersion >= 20
+		isCancun = st.evm.Context.ArbOSVersion >= chain.ArbosVersion_20
 	}
 	if st.msg.BlobGas() > 0 && isCancun && !isArb {
 		blobGasPrice := st.evm.Context.BlobBaseFee

--- a/erigon-lib/chain/arbos_versions.go
+++ b/erigon-lib/chain/arbos_versions.go
@@ -16,6 +16,8 @@
 
 package chain
 
+const ArbosVersion_0 = uint64(0)
+const ArbosVersion_1 = uint64(1)
 const ArbosVersion_2 = uint64(2)
 const ArbosVersion_3 = uint64(3)
 const ArbosVersion_4 = uint64(4)

--- a/erigon-lib/chain/chain_config.go
+++ b/erigon-lib/chain/chain_config.go
@@ -762,7 +762,7 @@ func ArbitrumOneParams() ArbitrumChainParams {
 		EnableArbOS:               true,
 		AllowDebugPrecompiles:     false,
 		DataAvailabilityCommittee: false,
-		InitialArbOSVersion:       6,
+		InitialArbOSVersion:       ArbosVersion_6,
 		InitialChainOwner:         common.HexToAddress("0xd345e41ae2cb00311956aa7109fc801ae8c81a52"),
 	}
 }
@@ -772,7 +772,7 @@ func ArbitrumNovaParams() ArbitrumChainParams {
 		EnableArbOS:               true,
 		AllowDebugPrecompiles:     false,
 		DataAvailabilityCommittee: true,
-		InitialArbOSVersion:       1,
+		InitialArbOSVersion:       ArbosVersion_1,
 		InitialChainOwner:         common.HexToAddress("0x9C040726F2A657226Ed95712245DeE84b650A1b5"),
 	}
 }
@@ -782,7 +782,7 @@ func ArbitrumRollupGoerliTestnetParams() ArbitrumChainParams {
 		EnableArbOS:               true,
 		AllowDebugPrecompiles:     false,
 		DataAvailabilityCommittee: false,
-		InitialArbOSVersion:       2,
+		InitialArbOSVersion:       ArbosVersion_2,
 		InitialChainOwner:         common.HexToAddress("0x186B56023d42B2B4E7616589a5C62EEf5FCa21DD"),
 	}
 }
@@ -792,7 +792,7 @@ func ArbitrumDevTestParams() ArbitrumChainParams {
 		EnableArbOS:               true,
 		AllowDebugPrecompiles:     true,
 		DataAvailabilityCommittee: false,
-		InitialArbOSVersion:       32,
+		InitialArbOSVersion:       ArbosVersion_32,
 		InitialChainOwner:         common.Address{},
 	}
 }
@@ -802,7 +802,7 @@ func ArbitrumDevTestDASParams() ArbitrumChainParams {
 		EnableArbOS:               true,
 		AllowDebugPrecompiles:     true,
 		DataAvailabilityCommittee: true,
-		InitialArbOSVersion:       32,
+		InitialArbOSVersion:       ArbosVersion_32,
 		InitialChainOwner:         common.Address{},
 	}
 }
@@ -812,7 +812,7 @@ func ArbitrumAnytrustGoerliTestnetParams() ArbitrumChainParams {
 		EnableArbOS:               true,
 		AllowDebugPrecompiles:     false,
 		DataAvailabilityCommittee: true,
-		InitialArbOSVersion:       2,
+		InitialArbOSVersion:       ArbosVersion_2,
 		InitialChainOwner:         common.HexToAddress("0x186B56023d42B2B4E7616589a5C62EEf5FCa21DD"),
 	}
 }
@@ -822,7 +822,7 @@ func DisableArbitrumParams() ArbitrumChainParams {
 		EnableArbOS:               false,
 		AllowDebugPrecompiles:     false,
 		DataAvailabilityCommittee: false,
-		InitialArbOSVersion:       0,
+		InitialArbOSVersion:       ArbosVersion_0,
 		InitialChainOwner:         common.Address{},
 	}
 }

--- a/params/config_arbitrum.go
+++ b/params/config_arbitrum.go
@@ -28,7 +28,7 @@ func ArbitrumOneParams() chain.ArbitrumChainParams {
 		EnableArbOS:               true,
 		AllowDebugPrecompiles:     false,
 		DataAvailabilityCommittee: false,
-		InitialArbOSVersion:       6,
+		InitialArbOSVersion:       chain.ArbosVersion_6,
 		InitialChainOwner:         common.HexToAddress("0xd345e41ae2cb00311956aa7109fc801ae8c81a52"),
 	}
 }
@@ -38,7 +38,7 @@ func ArbitrumNovaParams() chain.ArbitrumChainParams {
 		EnableArbOS:               true,
 		AllowDebugPrecompiles:     false,
 		DataAvailabilityCommittee: true,
-		InitialArbOSVersion:       1,
+		InitialArbOSVersion:       chain.ArbosVersion_1,
 		InitialChainOwner:         common.HexToAddress("0x9C040726F2A657226Ed95712245DeE84b650A1b5"),
 	}
 }
@@ -48,7 +48,7 @@ func ArbitrumRollupGoerliTestnetParams() chain.ArbitrumChainParams {
 		EnableArbOS:               true,
 		AllowDebugPrecompiles:     false,
 		DataAvailabilityCommittee: false,
-		InitialArbOSVersion:       2,
+		InitialArbOSVersion:       chain.ArbosVersion_2,
 		InitialChainOwner:         common.HexToAddress("0x186B56023d42B2B4E7616589a5C62EEf5FCa21DD"),
 	}
 }
@@ -58,7 +58,7 @@ func ArbitrumDevTestParams() chain.ArbitrumChainParams {
 		EnableArbOS:               true,
 		AllowDebugPrecompiles:     true,
 		DataAvailabilityCommittee: false,
-		InitialArbOSVersion:       32,
+		InitialArbOSVersion:       chain.ArbosVersion_32,
 		InitialChainOwner:         common.Address{},
 	}
 }
@@ -68,7 +68,7 @@ func ArbitrumDevTestDASParams() chain.ArbitrumChainParams {
 		EnableArbOS:               true,
 		AllowDebugPrecompiles:     true,
 		DataAvailabilityCommittee: true,
-		InitialArbOSVersion:       32,
+		InitialArbOSVersion:       chain.ArbosVersion_32,
 		InitialChainOwner:         common.Address{},
 	}
 }
@@ -78,7 +78,7 @@ func ArbitrumAnytrustGoerliTestnetParams() chain.ArbitrumChainParams {
 		EnableArbOS:               true,
 		AllowDebugPrecompiles:     false,
 		DataAvailabilityCommittee: true,
-		InitialArbOSVersion:       2,
+		InitialArbOSVersion:       chain.ArbosVersion_2,
 		InitialChainOwner:         common.HexToAddress("0x186B56023d42B2B4E7616589a5C62EEf5FCa21DD"),
 	}
 }
@@ -88,7 +88,7 @@ func DisableArbitrumParams() chain.ArbitrumChainParams {
 		EnableArbOS:               false,
 		AllowDebugPrecompiles:     false,
 		DataAvailabilityCommittee: false,
-		InitialArbOSVersion:       0,
+		InitialArbOSVersion:       chain.ArbosVersion_0,
 		InitialChainOwner:         common.Address{},
 	}
 }


### PR DESCRIPTION
Replace number literals to `ArbosVersion_` constants

https://github.com/erigontech/nitro-erigon/issues/108

