### PR TITLE
Cherrypick: Caplin: Fix misc issues after electra (#14910)

### DIFF
--- a/cl/aggregation/pool_test.go
+++ b/cl/aggregation/pool_test.go
@@ -40,17 +40,17 @@ var (
 		},
 	}
 	att1_1 = &solid.Attestation{
-		AggregationBits: solid.BitlistFromBytes([]byte{0b00000011}, 2048),
+		AggregationBits: solid.BitlistFromBytes([]byte{0b01000001}, 2048),
 		Data:            attData1,
 		Signature:       [96]byte{'a', 'b', 'c', 'd', 'e', 'f'},
 	}
 	att1_2 = &solid.Attestation{
-		AggregationBits: solid.BitlistFromBytes([]byte{0b00000011}, 2048),
+		AggregationBits: solid.BitlistFromBytes([]byte{0b01000001}, 2048),
 		Data:            attData1,
 		Signature:       [96]byte{'d', 'e', 'f', 'g', 'h', 'i'},
 	}
 	att1_3 = &solid.Attestation{
-		AggregationBits: solid.BitlistFromBytes([]byte{0b00001100}, 2048),
+		AggregationBits: solid.BitlistFromBytes([]byte{0b01000100}, 2048),
 		Data:            attData1,
 		Signature:       [96]byte{'g', 'h', 'i', 'j', 'k', 'l'},
 	}
@@ -115,13 +115,13 @@ func (t *PoolTestSuite) TestAddAttestationElectra() {
 	expectedCommitteeBits.SetBitAt(10, true)
 
 	att1 := &solid.Attestation{
-		AggregationBits: solid.BitlistFromBytes([]byte{0b00000011}, 2048*64),
+		AggregationBits: solid.BitlistFromBytes([]byte{0b00001001}, 2048*64),
 		Data:            attData1,
 		Signature:       [96]byte{'a', 'b', 'c', 'd', 'e', 'f'},
 		CommitteeBits:   cBits1,
 	}
 	att2 := &solid.Attestation{
-		AggregationBits: solid.BitlistFromBytes([]byte{0b00001101}, 2048*64),
+		AggregationBits: solid.BitlistFromBytes([]byte{0b00001100}, 2048*64),
 		Data:            attData1,
 		Signature:       [96]byte{'d', 'e', 'f', 'g', 'h', 'i'},
 		CommitteeBits:   cBits2,

--- a/cl/beacon/beaconevents/model.go
+++ b/cl/beacon/beaconevents/model.go
@@ -28,6 +28,7 @@ const (
 type (
 	// Operation event data types
 	AttestationData           = solid.Attestation
+	SingleAttestationData     = solid.SingleAttestation
 	VoluntaryExitData         = cltypes.SignedVoluntaryExit
 	ProposerSlashingData      = cltypes.ProposerSlashing
 	AttesterSlashingData      = cltypes.AttesterSlashing

--- a/cl/beacon/beaconevents/operation_feed.go
+++ b/cl/beacon/beaconevents/operation_feed.go
@@ -23,6 +23,13 @@ func (f *operationFeed) SendAttestation(value *AttestationData) int {
 	})
 }
 
+func (f *operationFeed) SendSingleAttestation(value *SingleAttestationData) int {
+	return f.feed.Send(&EventStream{
+		Event: OpAttestation,
+		Data:  value,
+	})
+}
+
 func (f *operationFeed) SendVoluntaryExit(value *VoluntaryExitData) int {
 	return f.feed.Send(&EventStream{
 		Event: OpVoluntaryExit,

--- a/cl/beacon/handler/pool.go
+++ b/cl/beacon/handler/pool.go
@@ -424,6 +424,14 @@ func (a *ApiHandler) PostEthV1ValidatorAggregatesAndProof(w http.ResponseWriter,
 			}
 		}
 	}
+
+	if len(failures) > 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(poolingError{Code: http.StatusBadRequest, Message: "some failures", Failures: failures})
+		return
+	}
+	// Only write 200
+	w.WriteHeader(http.StatusOK)
 }
 
 // PostEthV1BeaconPoolSyncCommittees is a handler for POST /eth/v1/beacon/pool/sync_committees.

--- a/cl/cltypes/solid/attestation.go
+++ b/cl/cltypes/solid/attestation.go
@@ -206,11 +206,14 @@ func (s *SingleAttestation) Static() bool {
 	return true
 }
 
-func (s *SingleAttestation) ToAttestation(memberIndexInCommittee int) *Attestation {
+func (s *SingleAttestation) ToAttestation(memberIndexInCommittee int, committeeLen int) *Attestation {
 	committeeBits := NewBitVector(maxCommitteesPerSlot)
 	committeeBits.SetBitAt(int(s.CommitteeIndex), true)
-	aggregationBits := NewBitList(0, aggregationBitsSizeElectra)
-	aggregationBits.SetOnBit(maxValidatorsPerCommittee*int(s.CommitteeIndex) + memberIndexInCommittee)
+	// flip the bit for the validator and also mark the last bit
+	bytes := make([]byte, committeeLen/8+1)
+	bytes[memberIndexInCommittee/8] |= 1 << (memberIndexInCommittee % 8)
+	bytes[committeeLen/8] |= 1 << (committeeLen % 8)
+	aggregationBits := BitlistFromBytes(bytes, aggregationBitsSizeElectra)
 	return &Attestation{
 		AggregationBits: aggregationBits,
 		Data:            s.Data,

--- a/cl/cltypes/solid/bitlist.go
+++ b/cl/cltypes/solid/bitlist.go
@@ -22,6 +22,7 @@ import (
 	"math/bits"
 
 	"github.com/erigontech/erigon-lib/common/hexutility"
+	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon-lib/types/clonable"
 	"github.com/erigontech/erigon/cl/merkle_tree"
 )
@@ -166,23 +167,6 @@ func (u *BitList) addMsb() int {
 	return byteLen
 }
 
-func (u *BitList) SetOnBit(bitIndex int) {
-	if bitIndex >= u.c {
-		return
-	}
-	// remove the last on bit if necessary
-	u.removeMsb()
-	// expand the bitlist if necessary
-	for len(u.u)*8 <= bitIndex {
-		u.u = append(u.u, 0)
-	}
-	// set the bit
-	u.u[bitIndex/8] |= 1 << uint(bitIndex%8)
-	// set last bit
-	byteLen := u.addMsb()
-	u.l = byteLen
-}
-
 // Length gives us the length of the bitlist, just like a roll call tells us how many Rangers there are.
 func (u *BitList) Length() int {
 	return u.l
@@ -269,24 +253,17 @@ func (u *BitList) UnmarshalJSON(input []byte) error {
 }
 
 func (u *BitList) Merge(other *BitList) (*BitList, error) {
-	if u.c != other.c {
-		return nil, errors.New("bitlist union: different capacity")
+	if u.Bits() != other.Bits() {
+		log.Warn("bitlist union: different length", "u", u.Bits(), "other", other.Bits())
+		return nil, errors.New("bitlist union: different length")
 	}
 	// copy by the longer one
 	var ret, unionFrom *BitList
-	if u.Bits() < other.Bits() {
-		ret = other.Copy()
-		unionFrom = u
-	} else {
-		ret = u.Copy()
-		unionFrom = other
-	}
-	// union
-	unionFrom.removeMsb()
-	for i := 0; i < unionFrom.l; i++ {
+	ret = other.Copy()
+	unionFrom = u
+	for i := 0; i < len(unionFrom.u); i++ {
 		ret.u[i] |= unionFrom.u[i]
 	}
-	unionFrom.addMsb()
 	return ret, nil
 }
 

--- a/cl/cltypes/solid/bitlist_test.go
+++ b/cl/cltypes/solid/bitlist_test.go
@@ -129,7 +129,7 @@ func TestBitlistMerge(t *testing.T) {
 	require := require.New(t)
 
 	b1 := solid.BitlistFromBytes([]byte{0b11010000}, 10)
-	b2 := solid.BitlistFromBytes([]byte{0b00001101}, 10)
+	b2 := solid.BitlistFromBytes([]byte{0b10000101}, 10)
 
 	merged, err := b1.Merge(b2)
 	require.NoError(err)

--- a/cl/phase1/core/state/cache_accessors.go
+++ b/cl/phase1/core/state/cache_accessors.go
@@ -416,7 +416,7 @@ func (b *CachingBeaconState) GetAttestingIndicies(
 		}
 		for i, member := range committee {
 			if i >= aggrBitsLen {
-				return nil, fmt.Errorf("GetAttestingIndicies: committee is too big, slot: %d, committeeIndex: %d, aggrBitsLen: %d, committeeSize: %d",
+				return nil, fmt.Errorf("GetAttestingIndicies: aggregation bits is too small, slot: %d, committeeIndex: %d, aggrBitsLen: %d, committeeSize: %d",
 					slot, committeeIndex, aggrBitsLen, len(committee))
 			}
 			if aggregationBits.GetBitAt(committeeOffset + i) {
@@ -424,9 +424,6 @@ func (b *CachingBeaconState) GetAttestingIndicies(
 			}
 		}
 		committeeOffset += len(committee)
-	}
-	if committeeOffset != aggrBitsLen {
-		return nil, fmt.Errorf("GetAttestingIndicies: aggregation bits length does not match committee length. agg bits size: %d, committeeOffset: %d", aggrBitsLen, committeeOffset)
 	}
 	return attesters, nil
 }

--- a/cl/phase1/network/services/attestation_service.go
+++ b/cl/phase1/network/services/attestation_service.go
@@ -234,7 +234,7 @@ func (s *attestationService) ProcessMessage(ctx context.Context, subnet *uint64,
 				return fmt.Errorf("attester is not a member of the committee. attester index %d committeeIndex %v", att.SingleAttestation.AttesterIndex, committeeIndex)
 			}
 			vIndex = att.SingleAttestation.AttesterIndex
-			attestation = att.SingleAttestation.ToAttestation(memIndexInCommittee)
+			attestation = att.SingleAttestation.ToAttestation(memIndexInCommittee, len(beaconCommittee))
 		}
 		// [IGNORE] There has been no other valid attestation seen on an attestation subnet that has an identical attestation.data.target.epoch and participating validator index.
 		// mark the validator as seen
@@ -290,16 +290,18 @@ func (s *attestationService) ProcessMessage(ctx context.Context, subnet *uint64,
 		F: func() {
 			start := time.Now()
 			defer monitor.ObserveAggregateAttestation(start)
-			err = s.committeeSubscribe.AggregateAttestation(attestation)
-			if errors.Is(err, aggregation.ErrIsSuperset) {
+			if err = s.committeeSubscribe.AggregateAttestation(attestation); errors.Is(err, aggregation.ErrIsSuperset) {
 				return
-			}
-
-			if err != nil {
+			} else if err != nil {
 				log.Warn("could not check aggregate attestation", "err", err)
 				return
 			}
-			s.emitters.Operation().SendAttestation(attestation)
+			// send to subscribers
+			if att.Attestation != nil {
+				s.emitters.Operation().SendAttestation(att.Attestation)
+			} else if att.SingleAttestation != nil {
+				s.emitters.Operation().SendSingleAttestation(att.SingleAttestation)
+			}
 		},
 	}
 

--- a/cl/phase1/network/services/sync_committee_messages_service.go
+++ b/cl/phase1/network/services/sync_committee_messages_service.go
@@ -133,10 +133,10 @@ func (s *syncCommitteeMessagesService) ProcessMessage(ctx context.Context, subne
 
 		if msg.ImmediateVerification {
 			return s.batchSignatureVerifier.ImmediateVerification(aggregateVerificationData)
+		} else {
+			// push the signatures to verify asynchronously and run final functions after that.
+			s.batchSignatureVerifier.AsyncVerifySyncCommitteeMessage(aggregateVerificationData)
 		}
-
-		// push the signatures to verify asynchronously and run final functions after that.
-		s.batchSignatureVerifier.AsyncVerifySyncCommitteeMessage(aggregateVerificationData)
 
 		// As the logic goes, if we return ErrIgnore there will be no peer banning and further publishing
 		// gossip data into the network by the gossip manager. That's what we want because we will be doing that ourselves

--- a/cl/phase1/network/services/sync_contribution_service.go
+++ b/cl/phase1/network/services/sync_contribution_service.go
@@ -174,7 +174,7 @@ func (s *syncContributionService) ProcessMessage(ctx context.Context, subnet *ui
 		// gossip data into the network by the gossip manager. That's what we want because we will be doing that ourselves
 		// in BatchVerification function. After validating signatures, if they are valid we will publish the
 		// gossip ourselves or ban the peer which sent that particular invalid signature.
-		return ErrIgnore
+		return nil
 	})
 }
 

--- a/cl/validator/sync_contribution_pool/sync_contribution_pool.go
+++ b/cl/validator/sync_contribution_pool/sync_contribution_pool.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/Giulio2002/bls"
 	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
@@ -156,6 +157,7 @@ func (s *syncContributionPoolImpl) AddSyncCommitteeMessage(headState *state.Cach
 		return err
 	}
 
+	signatures := [][]byte{}
 	committee := getSyncCommitteeFromState(headState).GetCommittee()
 	subCommitteeSize := cfg.SyncCommitteeSize / cfg.SyncCommitteeSubnetCount
 	startSubCommittee := subCommittee * subCommitteeSize
@@ -165,14 +167,17 @@ func (s *syncContributionPoolImpl) AddSyncCommitteeMessage(headState *state.Cach
 				return nil
 			}
 			utils.FlipBitOn(contribution.AggregationBits, int(i-startSubCommittee))
+			// Note: it's possible that one validator appears multiple times in the subcommittee.
+			signatures = append(signatures, common.CopyBytes(message.Signature[:]))
 		}
 	}
-
+	if len(signatures) == 0 {
+		log.Warn("Validator not found in sync committee", "validatorIndex", message.ValidatorIndex, "subCommittee", subCommittee, "slot", message.Slot, "beaconBlockRoot", message.BeaconBlockRoot)
+		return errors.New("validator not found in sync committee")
+	}
 	// Compute the aggregated signature.
-	aggregatedSignature, err := bls.AggregateSignatures([][]byte{
-		contribution.Signature[:],
-		message.Signature[:],
-	})
+	signatures = append(signatures, common.CopyBytes(contribution.Signature[:]))
+	aggregatedSignature, err := bls.AggregateSignatures(signatures)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Resolve bug in `SingleAttestation.ToAttestation` causing incorrect `aggregation_bits`.
- Fix "invalid bls verification" error caused by new sync_commitee [algo](https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#modified-get_next_sync_committee_indices), which results in duplicate validators within the sync subcommitee.
- relates to issue https://github.com/erigontech/erigon/issues/14830