### PR TITLE
Updated docs link in the pre-built binaries installation message

### DIFF
--- a/.github/workflows/reusable-release-build-debian-pkg.yml
+++ b/.github/workflows/reusable-release-build-debian-pkg.yml
@@ -40,9 +40,9 @@ jobs:
           tar xzvf ${{ inputs.application }}_v${{ inputs.version }}_linux_arm64.tar.gz
           cat <<-END > postinst.template
           #!/bin/bash
-          echo "WARNING: erigon package does not install any configurations nor services."
-          echo "Use your specific way to configure and run erigon according to your needs."
-          echo "More details on how to run erigon could be found at https://erigon.gitbook.io/erigon ."
+          echo "WARNING: Erigon package does not install any configurations nor services."
+          echo "Use your specific way to configure and run Erigon according to your needs."
+          echo "More details on how to run Erigon could be found at https://docs.erigon.tech ."
           END
 
       # Creating directory structure


### PR DESCRIPTION
This pull request updates the link in the Erigon installation script to point to the new documentation site.