### PR TITLE
qa-tests: increase sync-from-scratch (minimal node) test time

### DIFF
--- a/.github/workflows/qa-sync-from-scratch-minimal-node.yml
+++ b/.github/workflows/qa-sync-from-scratch-minimal-node.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   minimal-node-sync-from-scratch-test:
     runs-on: [self-hosted, qa, long-running]
-    timeout-minutes: 740  # 12 hours plus 20 minutes
+    timeout-minutes: 1100  # 18 hours plus 20 minutes
     strategy:
       fail-fast: false
       matrix:
@@ -20,7 +20,7 @@ jobs:
       ERIGON_DATA_DIR: ${{ github.workspace }}/erigon_data
       ERIGON_QA_PATH: /home/qarunner/erigon-qa
       TRACKING_TIME_SECONDS: 7200 # 2 hours
-      TOTAL_TIME_SECONDS: 43200 # 12 hours
+      TOTAL_TIME_SECONDS: 64800 # 18 hours
       CHAIN: ${{ matrix.chain }}
 
     steps:


### PR DESCRIPTION
12 hours are not enough for polygon