### PR TITLE
[r31] Revert "[3.0 pick] downloader: same NetworkChunkSize as in Erigon2" 

### DIFF
--- a/erigon-lib/downloader/downloadercfg/downloadercfg.go
+++ b/erigon-lib/downloader/downloadercfg/downloadercfg.go
@@ -50,7 +50,7 @@ const DefaultPieceSize = 2 * 1024 * 1024
 
 // DefaultNetworkChunkSize - how much data request per 1 network call to peer.
 // default: 16Kb
-const DefaultNetworkChunkSize = 256 * 1024
+const DefaultNetworkChunkSize = 8 * 1024 * 1024
 
 type Cfg struct {
 	ClientConfig  *torrent.ClientConfig


### PR DESCRIPTION
pick https://github.com/erigontech/erigon/pull/14958