### PR TITLE
cmd/evm: Fix windows testing and refactor

### DIFF
--- a/cmd/evm/t8n_test.go
+++ b/cmd/evm/t8n_test.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -257,19 +258,19 @@ func TestEvmRun(t *testing.T) {
 	t.Parallel()
 	tt := cmdtest.NewTestCmd(t, nil)
 	for i, tc := range []struct {
-		input      []string
-		wantStdout string
-		wantStderr string
+		input          []string
+		wantStdoutFile string
+		wantStderrFile string
 	}{
 		{ // json tracing
-			input:      []string{"--json", "--code", "6040", "run"},
-			wantStdout: "./testdata/evmrun/1.out.1.txt",
-			wantStderr: "./testdata/evmrun/1.out.2.txt",
+			input:          []string{"--json", "--code", "6040", "run"},
+			wantStdoutFile: "./testdata/evmrun/1.out.1.txt",
+			wantStderrFile: "./testdata/evmrun/1.out.2.txt",
 		},
 		{ // Debug output
-			input:      []string{"--debug", "--code", "6040", "run"},
-			wantStdout: "./testdata/evmrun/2.out.1.txt",
-			wantStderr: "./testdata/evmrun/2.out.2.txt",
+			input:          []string{"--debug", "--code", "6040", "run"},
+			wantStdoutFile: "./testdata/evmrun/2.out.1.txt",
+			wantStderrFile: "./testdata/evmrun/2.out.2.txt",
 		},
 	} {
 		tt.Logf("args: go run ./cmd/evm %v\n", strings.Join(tc.input, " "))
@@ -277,24 +278,24 @@ func TestEvmRun(t *testing.T) {
 
 		haveStdOut := tt.Output()
 		tt.WaitExit()
-		haveStdErr := tt.StderrText()
+		haveStdErr := tt.Stderr()
 
-		if have, wantFile := haveStdOut, tc.wantStdout; wantFile != "" {
-			want, err := os.ReadFile(wantFile)
+		if len(tc.wantStdoutFile) > 0 {
+			want, err := os.ReadFile(tc.wantStdoutFile)
 			if err != nil {
 				t.Fatalf("test %d: could not read expected output: %v", i, err)
 			}
-			if string(haveStdOut) != string(want) {
-				t.Fatalf("test %d, output wrong, have \n%v\nwant\n%v\n", i, string(have), string(want))
+			if !bytes.Equal(haveStdOut, want) {
+				t.Fatalf("test %d, output wrong, have \n%v\nwant\n%v\n", i, string(haveStdOut), string(want))
 			}
 		}
-		if have, wantFile := haveStdErr, tc.wantStderr; wantFile != "" {
-			want, err := os.ReadFile(wantFile)
+		if len(tc.wantStderrFile) > 0 {
+			want, err := os.ReadFile(tc.wantStderrFile)
 			if err != nil {
 				t.Fatalf("test %d: could not read expected output: %v", i, err)
 			}
-			if have != string(want) {
-				t.Fatalf("test %d, output wrong\nhave %q\nwant %q\n", i, have, string(want))
+			if !bytes.Equal(haveStdErr, want) {
+				t.Fatalf("test %d, output wrong\nhave %q\nwant %q\n", i, string(haveStdErr), string(want))
 			}
 		}
 	}

--- a/turbo/cmdtest/test_cmd.go
+++ b/turbo/cmdtest/test_cmd.go
@@ -233,6 +233,15 @@ func (tt *TestCmd) StderrText() string {
 	return tt.stderr.buf.String()
 }
 
+// Stderr returns any stderr output written so far.
+// The returned bytes holds all log lines after ExpectExit has
+// returned.
+func (tt *TestCmd) Stderr() []byte {
+	tt.stderr.mu.Lock()
+	defer tt.stderr.mu.Unlock()
+	return tt.stderr.buf.Bytes()
+}
+
 func (tt *TestCmd) CloseStdin() {
 	tt.stdin.Close()
 }


### PR DESCRIPTION
This PR fixes CI windows target testing and applies some refactoring. It introduces additional `Stderr` interface to return strerr stream in bytes instead of string.