### PR TITLE
tests: Increase `cmd/evm` tests  subprocess timeout to 30 sec

### DIFF
--- a/cmd/evm/t8n_test.go
+++ b/cmd/evm/t8n_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -254,7 +255,9 @@ func TestT8n(t *testing.T) {
 }
 
 func TestEvmRun(t *testing.T) {
-	t.Skip("issues #14975 and #14993")
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows tests require fixing.")
+	}
 	t.Parallel()
 	tt := cmdtest.NewTestCmd(t, nil)
 	for i, tc := range []struct {

--- a/turbo/cmdtest/test_cmd.go
+++ b/turbo/cmdtest/test_cmd.go
@@ -125,14 +125,14 @@ func (tt *TestCmd) Expect(tplsource string) {
 // Output reads all output from stdout, and returns the data.
 func (tt *TestCmd) Output() []byte {
 	var buf []byte
-	tt.withKillTimeout(func() { buf, _ = io.ReadAll(tt.stdout) })
+	tt.withKillTimeout(30*time.Second, func() { buf, _ = io.ReadAll(tt.stdout) })
 	return buf
 }
 
 func (tt *TestCmd) matchExactOutput(want []byte) error {
 	buf := make([]byte, len(want))
 	n := 0
-	tt.withKillTimeout(func() { n, _ = io.ReadFull(tt.stdout, buf) })
+	tt.withKillTimeout(30*time.Second, func() { n, _ = io.ReadFull(tt.stdout, buf) })
 	buf = buf[:n]
 	if n < len(want) || !bytes.Equal(buf, want) {
 		// Grab any additional buffered output in case of mismatch
@@ -167,7 +167,7 @@ func (tt *TestCmd) ExpectRegexp(regex string) (*regexp.Regexp, []string) {
 		rtee    = &runeTee{in: tt.stdout}
 		matches []int
 	)
-	tt.withKillTimeout(func() { matches = re.FindReaderSubmatchIndex(rtee) })
+	tt.withKillTimeout(5*time.Second, func() { matches = re.FindReaderSubmatchIndex(rtee) })
 	output := rtee.buf.Bytes()
 	if matches == nil {
 		tt.Fatalf("Output did not match:\n---------------- (stdout text)\n%s\n---------------- (regular expression)\n%s",
@@ -187,7 +187,7 @@ func (tt *TestCmd) ExpectRegexp(regex string) (*regexp.Regexp, []string) {
 // printing any additional text on stdout.
 func (tt *TestCmd) ExpectExit() {
 	var output []byte
-	tt.withKillTimeout(func() {
+	tt.withKillTimeout(5*time.Second, func() {
 		output, _ = io.ReadAll(tt.stdout)
 	})
 	tt.WaitExit()
@@ -244,8 +244,8 @@ func (tt *TestCmd) Kill() {
 	}
 }
 
-func (tt *TestCmd) withKillTimeout(fn func()) {
-	timeout := time.AfterFunc(5*time.Second, func() {
+func (tt *TestCmd) withKillTimeout(duration time.Duration, fn func()) {
+	timeout := time.AfterFunc(duration, func() {
 		tt.Log("killing the child process (timeout)")
 		tt.Kill()
 	})


### PR DESCRIPTION
Fixes: https://github.com/erigontech/erigon/issues/14993