### PR TITLE
cmd: Increase default `db.size.limit`

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -746,7 +746,7 @@ var (
 	DbSizeLimitFlag = cli.StringFlag{
 		Name:  "db.size.limit",
 		Usage: "Runtime limit of chaindata db size (can change at any time)",
-		Value: (200 * datasize.GB).String(),
+		Value: (1 * datasize.TB).String(),
 	}
 	DbWriteMapFlag = cli.BoolFlag{
 		Name:  "db.writemap",


### PR DESCRIPTION
- Hoodi that's without snapshots right now easily hits this limit after 2-3 months on "archive"
- This is really an artificial limit, may wanna increase it further. Having a very high limit, that's only 1% used is better than having a very low limit that can be hit 20% of the use cases