### PR TITLE
fix bug #14999, withlog tracerConfig param NOT work in debug_traceTnsaction API

### DIFF
--- a/turbo/transactions/tracing.go
+++ b/turbo/transactions/tracing.go
@@ -196,9 +196,10 @@ func ExecuteTraceTx(
 	streaming bool,
 	execCb func(evm *vm.EVM, refunds bool) (*evmtypes.ExecutionResult, error),
 ) error {
+	// Set the tracer hooks to the intra-block state before execute, so the OnLog hook may be set correctly.
+	ibs.SetHooks(tracer.Hooks)
 	// Run the transaction with tracing enabled.
 	evm := vm.NewEVM(blockCtx, txCtx, ibs, chainConfig, vm.Config{Tracer: tracer.Hooks, NoBaseFee: true})
-
 	var refunds = true
 	if config != nil && config.NoRefunds != nil && *config.NoRefunds {
 		refunds = false


### PR DESCRIPTION
# Pull Request Description

This PR resolves the issue reported in #14999, where the `debug_traceTransaction` API does not include event logs in the output, even when the `withLog = true` parameter is specified. The existing unit tests also failed to detect this issue, as they did not flag the missing event logs.

### Root Cause
After analyzing the API call and unit test workflows, the issue was traced to `turbo/transactions/tracing.go` at line 188 in the `ExecuteTraceTx` function. The function lacked a critical step to set hooks on `ibs` before executing the transaction. This caused the `OnLog` hook to remain unset, resulting in no event logs being included in the output, regardless of the `withLog` parameter.

### Changes Made
- Added the necessary hook-setting step at the beginning of the `ExecuteTraceTx` function to ensure the `OnLog` hook is properly configured.
- This fix ensures that event logs are included in the output when `withLog = true` is specified.

### Additional Notes
The unit tests for this functionality did not catch the issue, indicating a gap in test coverage. I recommend that additional test cases be added to verify the correct inclusion of event logs when `withLog = true`. Other contributors are encouraged to propose and implement these test cases to prevent similar issues in the future.

### Testing
- Manually verified that the API now correctly outputs event logs when `withLog = true`.
- Existing unit tests pass, but they need enhancement to cover this scenario.

### Verification

#### Call api command
```
curl "http://host:port" -s -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"debug_traceTransaction","params":["0x578cfbea5cfd2f737885e901e21256f7a3cb2884e1306ec5d917db908c40d1a9", {"tracer": "callTracer", "tracerConfig": {"withlog":true}}],"id":1}'
```

#### Result before bug fix:
```
{"jsonrpc":"2.0","id":1,"result":{"from":"0x319ae03215fc132c48fac4bd7fb6ac0571c7020e","gas":"0x7988","gasUsed":"0x6d22","to":"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2","input":"0xd0e30db0","value":"0x6a94d74f430000","type":"CALL"}}
```

#### Result after bug fix:
```
{"jsonrpc":"2.0","id":1,"result":{"from":"0x319ae03215fc132c48fac4bd7fb6ac0571c7020e","gas":"0x7988","gasUsed":"0x6d22","to":"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2","input":"0xd0e30db0","logs":[{"index":0,"address":"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2","topics":["0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c","0x000000000000000000000000319ae03215fc132c48fac4bd7fb6ac0571c7020e"],"data":"0x000000000000000000000000000000000000000000000000006a94d74f430000"}],"value":"0x6a94d74f430000","type":"CALL"}}
```