### PR TITLE
qa-tests: disable polygon tip-tracking on main branch

### DIFF
--- a/.github/workflows/qa-tip-tracking-polygon.yml
+++ b/.github/workflows/qa-tip-tracking-polygon.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - 'release/3.*'
-  schedule:
-    - cron: '0 0 * * 1-6'  # Run every night at 00:00 AM UTC except Sunday
+  #schedule:
+  #  - cron: '0 0 * * 1-6'  # Run every night at 00:00 AM UTC except Sunday
   workflow_dispatch:     # Run manually
 
 jobs:


### PR DESCRIPTION
Erigon uses a different snapshot scheme for the main and release/3 branches, so we need two pre-built databases on the Test Runner.
However, there is no disk space to host two pre-built databases.
As this is an upgrade test, we are disabling the tests on the main branch.