### PR TITLE
Fix snapshot file creation

### DIFF
--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -1396,9 +1396,9 @@ func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 		return err
 	}
 	blockReader, _ := br.IO()
-	from2, to2, ok := freezeblocks.CanRetire(to, blockReader.FrozenBlocks(), coresnaptype.Enums.Headers, nil)
+	from2, _, ok := freezeblocks.CanRetire(to, blockReader.FrozenBlocks(), coresnaptype.Enums.Headers, nil)
 	if ok {
-		from, to = from2, to2
+		from = from2
 	}
 	if err := br.RetireBlocks(ctx, from, to, log.LvlInfo, nil, nil, nil); err != nil {
 		return err


### PR DESCRIPTION
Decided to pick up different route (simpler). Effectively it was an issue with the tool, not the process.

The tool unnecessarily computed the new range `Retire Process` should operate on, but it should just give a point where to start from (the last block in the snapshot). The actual range is calculated in a loop in the:

```
if err := br.RetireBlocks(ctx, from, to, log.LvlInfo, nil, nil, nil); err != nil {
        return err
}
```
 
The tool precomputed the entire range before running the retirement process, but giving it already narrowed range.
The `RetireBlock` function computes the range itself, it just needs to know where to start from.