### PR TITLE
Less verbose make erigon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ dbg:
 %.cmd:
 	@# Note: $* is replaced by the command name
 	@echo "Building $*"
-	cd ./cmd/$* && $(GOBUILD) -o $(GOBIN)/$*
+	@cd ./cmd/$* && $(GOBUILD) -o $(GOBIN)/$*
 	@echo "Run \"$(GOBIN)/$*\" to launch $*."
 
 ## geth:                              run erigon (TODO: remove?)


### PR DESCRIPTION
BEFORE:
````
andrew@andrews-macbook-pro erigon3 % make erigon
Building erigon
cd ./cmd/erigon &&  CGO_CFLAGS="-O2 -g  -DMDBX_FORCE_ASSERTIONS=0  -DMDBX_DISABLE_VALIDATION=0  -DMDBX_ENV_CHECKPID=0  -D__BLST_PORTABLE__ -Wno-unknown-warning-option -Wno-enum-int-mismatch -Wno-strict-prototypes -Wno-unused-but-set-variable -O3" CGO_LDFLAGS="-O2 -g -O3 -g" GOPRIVATE="github.com/erigontech/silkworm-go" go  build -trimpath -tags nosqlite,noboltdb, -buildvcs=false -ldflags "-X github.com/erigontech/erigon/params.GitCommit=923f157409e86afa6d134303cb4ed3263c4d0a52 -X github.com/erigontech/erigon/params.GitBranch=quiet_make -X github.com/erigontech/erigon/params.GitTag=v3.0.0-beta1-710-g923f157" -o /Users/andrew/erigon3/build/bin/erigon
Run "/Users/andrew/erigon3/build/bin/erigon" to launch erigon.
````

AFTER:
````
andrew@andrews-macbook-pro erigon3 % make erigon
Building erigon
Run "/Users/andrew/erigon3/build/bin/erigon" to launch erigon.
````

Partially reverts PR #14827