### PR TITLE
fill in recsplit.close() at different places

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ test-erigon-ext:
 	@cd tests/erigon-ext-test && ./test.sh $(GIT_COMMIT)
 
 ## test:                      run short tests with a 10m timeout
-test: test-erigon-lib test-erigon-db
+test: #test-erigon-lib test-erigon-db
 	$(GOTEST) -short --timeout 10m -coverprofile=coverage-test.out
 
 ## test-all:                  run all tests with a 1h timeout

--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ test-erigon-ext:
 	@cd tests/erigon-ext-test && ./test.sh $(GIT_COMMIT)
 
 ## test:                      run short tests with a 10m timeout
-test: #test-erigon-lib test-erigon-db
+test: test-erigon-lib test-erigon-db
 	$(GOTEST) -short --timeout 10m -coverprofile=coverage-test.out
 
 ## test-all:                  run all tests with a 1h timeout

--- a/core/snaptype/block_types.go
+++ b/core/snaptype/block_types.go
@@ -238,6 +238,7 @@ var (
 				if err != nil {
 					return err
 				}
+				defer txnHashIdx.Close()
 
 				txnHash2BlockNumIdx, err := recsplit.NewRecSplit(recsplit.RecSplitArgs{
 					KeyCount:   d.Count(),
@@ -251,6 +252,7 @@ var (
 				if err != nil {
 					return err
 				}
+				defer txnHash2BlockNumIdx.Close()
 				txnHashIdx.LogLvl(log.LvlDebug)
 				txnHash2BlockNumIdx.LogLvl(log.LvlDebug)
 

--- a/erigon-lib/downloader/snaptype/type.go
+++ b/erigon-lib/downloader/snaptype/type.go
@@ -431,6 +431,7 @@ func BuildIndex(ctx context.Context, info FileInfo, cfg recsplit.RecSplitArgs, l
 	if err != nil {
 		return err
 	}
+	defer rs.Close()
 	rs.LogLvl(lvl)
 
 	defer d.MadvSequential().DisableReadAhead()
@@ -492,6 +493,7 @@ func BuildIndexWithSnapName(ctx context.Context, info FileInfo, cfg recsplit.Rec
 	if err != nil {
 		return err
 	}
+	defer rs.Close()
 	rs.LogLvl(lvl)
 
 	defer d.MadvSequential().DisableReadAhead()

--- a/erigon-lib/recsplit/index_test.go
+++ b/erigon-lib/recsplit/index_test.go
@@ -46,6 +46,7 @@ func TestReWriteIndex(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer rs.Close()
 	for i := 0; i < 100; i++ {
 		if err = rs.AddKey([]byte(fmt.Sprintf("key %d", i)), uint64(i*17)); err != nil {
 			t.Fatal(err)

--- a/erigon-lib/recsplit/recsplit.go
+++ b/erigon-lib/recsplit/recsplit.go
@@ -238,10 +238,12 @@ func (rs *RecSplit) Close() {
 	if rs.indexF != nil {
 		rs.indexF.Close()
 		_ = os.Remove(rs.indexF.Name())
+		rs.indexF = nil
 	}
 	if rs.existenceF != nil {
 		rs.existenceF.Close()
 		_ = os.Remove(rs.existenceF.Name())
+		rs.existenceF = nil
 	}
 	if rs.bucketCollector != nil {
 		rs.bucketCollector.Close()

--- a/erigon-lib/recsplit/recsplit_fuzz_test.go
+++ b/erigon-lib/recsplit/recsplit_fuzz_test.go
@@ -66,6 +66,7 @@ func FuzzRecSplit(f *testing.F) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		defer rs.Close()
 		var off uint64
 		for i = 0; i < len(in)-l; i += l {
 			if err := rs.AddKey(in[i:i+l], off); err != nil {

--- a/erigon-lib/recsplit/recsplit_test.go
+++ b/erigon-lib/recsplit/recsplit_test.go
@@ -41,6 +41,7 @@ func TestRecSplit2(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer rs.Close()
 	if err = rs.AddKey([]byte("first_key"), 0); err != nil {
 		t.Error(err)
 	}
@@ -76,6 +77,7 @@ func TestRecSplitDuplicate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer rs.Close()
 	if err := rs.AddKey([]byte("first_key"), 0); err != nil {
 		t.Error(err)
 	}
@@ -123,6 +125,7 @@ func TestIndexLookup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer rs.Close()
 	for i := 0; i < 100; i++ {
 		if err = rs.AddKey([]byte(fmt.Sprintf("key %d", i)), uint64(i*17)); err != nil {
 			t.Fatal(err)
@@ -162,6 +165,7 @@ func TestTwoLayerIndex(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer rs.Close()
 	for i := 0; i < N; i++ {
 		if err = rs.AddKey([]byte(fmt.Sprintf("key %d", i)), uint64(i*17)); err != nil {
 			t.Fatal(err)

--- a/erigon-lib/state/simple_index_builder.go
+++ b/erigon-lib/state/simple_index_builder.go
@@ -177,6 +177,7 @@ func (s *SimpleAccessorBuilder) Build(ctx context.Context, from, to RootNum, p *
 	if err != nil {
 		return nil, err
 	}
+	defer rs.Close()
 
 	s.kf.Refresh()
 	defer s.kf.Close()

--- a/erigon-lib/state/snap_repo_test.go
+++ b/erigon-lib/state/snap_repo_test.go
@@ -692,6 +692,7 @@ func populateFiles(t *testing.T, dirs datadir.Dirs, name string, extensions []st
 			if err != nil {
 				t.Fatal(err)
 			}
+			defer rs.Close()
 
 			if err = rs.AddKey([]byte("first_key"), 0); err != nil {
 				t.Error(err)

--- a/polygon/heimdall/types.go
+++ b/polygon/heimdall/types.go
@@ -208,6 +208,7 @@ var (
 				if err != nil {
 					return err
 				}
+				defer rs.Close()
 				rs.LogLvl(log.LvlInfo)
 
 				defer d.MadvSequential().DisableReadAhead()
@@ -490,6 +491,7 @@ func buildValueIndex(ctx context.Context, sn snaptype.FileInfo, salt uint32, d *
 	if err != nil {
 		return err
 	}
+	defer rs.Close()
 	rs.LogLvl(log.LvlInfo)
 
 	defer d.MadvSequential().DisableReadAhead()


### PR DESCRIPTION
keep finding erigon-lfp-buf* files in temp/; this PR cleans them up once done