### PR TITLE
Inverted Index: fix check for file existence

### DIFF
--- a/erigon-lib/state/inverted_index.go
+++ b/erigon-lib/state/inverted_index.go
@@ -296,7 +296,7 @@ func (ii *InvertedIndex) openDirtyFiles() error {
 					continue
 				}
 
-				if ok {
+				if !ok {
 					_, fName := filepath.Split(fPath)
 					ii.logger.Debug("[agg] InvertedIndex.openDirtyFiles: file does not exists", "f", fName)
 					invalidFileItemsLock.Lock()


### PR DESCRIPTION
I noticed that RPC Integration Tests started failing systematically after #15065, so I checked the changes in such PR and spotted this.

RPC Integration Tests are OK here: https://github.com/erigontech/erigon/actions/runs/15052494612