### PR TITLE
agg: optimize etl.Collect

### DIFF
--- a/erigon-lib/etl/buffers.go
+++ b/erigon-lib/etl/buffers.go
@@ -151,10 +151,11 @@ func (b *sortableBuffer) Get(i int, keyBuf, valBuf []byte) ([]byte, []byte) {
 	return keyBuf, valBuf
 }
 
-func (b *sortableBuffer) Prealloc(predictKeysAmount, predictDataSize int) {
+func (b *sortableBuffer) Prealloc(predictKeysAmount, predictDataSize int) *sortableBuffer {
 	b.lens = make([]int, 0, predictKeysAmount)
 	b.offsets = make([]int, 0, predictKeysAmount)
 	b.data = make([]byte, 0, predictDataSize)
+	return b
 }
 
 func (b *sortableBuffer) Reset() {

--- a/erigon-lib/etl/buffers.go
+++ b/erigon-lib/etl/buffers.go
@@ -98,7 +98,7 @@ func (b *sortableBuffer) Put(k, v []byte) {
 	b.data = append(b.data, k...)
 	b.offsets = append(b.offsets, len(b.data))
 	b.data = append(b.data, v...)
-	b.size += lk + lv + 32 // size = len(b.data) // + 8*len(b.offsets) + 8*len(b.lens)
+	b.size += lk + lv + 32 // size = len(b.data) + 8*len(b.offsets) + 8*len(b.lens)
 }
 
 func (b *sortableBuffer) Size() int { return b.size }

--- a/erigon-lib/etl/buffers.go
+++ b/erigon-lib/etl/buffers.go
@@ -78,6 +78,7 @@ type sortableBuffer struct {
 	offsets     []int
 	lens        []int
 	data        []byte
+	size        int
 	optimalSize int
 }
 
@@ -97,11 +98,10 @@ func (b *sortableBuffer) Put(k, v []byte) {
 	b.data = append(b.data, k...)
 	b.offsets = append(b.offsets, len(b.data))
 	b.data = append(b.data, v...)
+	b.size += lk + lv + 32 // size = len(b.data) // + 8*len(b.offsets) + 8*len(b.lens)
 }
 
-func (b *sortableBuffer) Size() int {
-	return len(b.data) + 8*len(b.offsets) + 8*len(b.lens)
-}
+func (b *sortableBuffer) Size() int { return b.size }
 
 func (b *sortableBuffer) Len() int {
 	return len(b.offsets) / 2
@@ -162,6 +162,7 @@ func (b *sortableBuffer) Reset() {
 	b.offsets = b.offsets[:0]
 	b.lens = b.lens[:0]
 	b.data = b.data[:0]
+	b.size = 0
 }
 func (b *sortableBuffer) SizeLimit() int { return b.optimalSize }
 func (b *sortableBuffer) Sort() {

--- a/erigon-lib/etl/buffers.go
+++ b/erigon-lib/etl/buffers.go
@@ -51,7 +51,7 @@ type Buffer interface {
 	Len() int
 	Reset()
 	SizeLimit() int
-	Prealloc(predictKeysAmount, predictDataAmount int)
+	Prealloc(predictKeysAmount, predictDataAmount int) Buffer
 	Write(io.Writer) error
 	Sort()
 	CheckFlushSize() bool
@@ -151,7 +151,7 @@ func (b *sortableBuffer) Get(i int, keyBuf, valBuf []byte) ([]byte, []byte) {
 	return keyBuf, valBuf
 }
 
-func (b *sortableBuffer) Prealloc(predictKeysAmount, predictDataSize int) *sortableBuffer {
+func (b *sortableBuffer) Prealloc(predictKeysAmount, predictDataSize int) Buffer {
 	b.lens = make([]int, 0, predictKeysAmount)
 	b.offsets = make([]int, 0, predictKeysAmount)
 	b.data = make([]byte, 0, predictDataSize)
@@ -248,9 +248,10 @@ func (b *appendSortableBuffer) Reset() {
 	b.entries = make(map[string][]byte)
 	b.size = 0
 }
-func (b *appendSortableBuffer) Prealloc(predictKeysAmount, predictDataSize int) {
+func (b *appendSortableBuffer) Prealloc(predictKeysAmount, predictDataSize int) Buffer {
 	b.entries = make(map[string][]byte, predictKeysAmount)
 	b.sortedBuf = make([]sortableBufferEntry, 0, predictKeysAmount*2)
+	return b
 }
 
 func (b *appendSortableBuffer) Write(w io.Writer) error {
@@ -345,9 +346,10 @@ func (b *oldestEntrySortableBuffer) Reset() {
 	b.entries = make(map[string][]byte)
 	b.size = 0
 }
-func (b *oldestEntrySortableBuffer) Prealloc(predictKeysAmount, predictDataSize int) {
+func (b *oldestEntrySortableBuffer) Prealloc(predictKeysAmount, predictDataSize int) Buffer {
 	b.entries = make(map[string][]byte, predictKeysAmount)
 	b.sortedBuf = make([]sortableBufferEntry, 0, predictKeysAmount*2)
+	return b
 }
 
 func (b *oldestEntrySortableBuffer) Write(w io.Writer) error {

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -28,6 +28,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/c2h5oh/datasize"
 	"github.com/erigontech/erigon-lib/version"
 
 	btree2 "github.com/tidwall/btree"
@@ -50,7 +51,7 @@ import (
 
 var sortableBuffersPoolForPruning = sync.Pool{
 	New: func() interface{} {
-		return etl.NewSortableBuffer(etl.BufferOptimalSize / 8)
+		return etl.NewSortableBuffer(etl.BufferOptimalSize/8).Prealloc(1_000, int(2*datasize.MB))
 	},
 }
 

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -51,7 +51,7 @@ import (
 
 var sortableBuffersPoolForPruning = sync.Pool{
 	New: func() interface{} {
-		return etl.NewSortableBuffer(etl.BufferOptimalSize/8).Prealloc(1_000, int(1*datasize.MB))
+		return etl.NewSortableBuffer(etl.BufferOptimalSize/8).Prealloc(2_000, int(2*datasize.MB))
 	},
 }
 

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -51,7 +51,7 @@ import (
 
 var sortableBuffersPoolForPruning = sync.Pool{
 	New: func() interface{} {
-		return etl.NewSortableBuffer(etl.BufferOptimalSize/8).Prealloc(1_000, int(2*datasize.MB))
+		return etl.NewSortableBuffer(etl.BufferOptimalSize/8).Prealloc(1_000, int(1*datasize.MB))
 	},
 }
 


### PR DESCRIPTION
- much growslicde (use sync pool of buffers with prealloc)
- too often buf.Size() calls (make them cheaper)