### PR TITLE
TestVerifyData: disable on win 

### DIFF
--- a/erigon-lib/downloader/downloader_test.go
+++ b/erigon-lib/downloader/downloader_test.go
@@ -89,6 +89,10 @@ func TestNoEscape(t *testing.T) {
 }
 
 func TestVerifyData(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fix me on win please")
+	}
+
 	require := require.New(t)
 	dirs := datadir.New(t.TempDir())
 	cfg, err := downloadercfg2.New(context.Background(), dirs, "", lg.Info, 0, 0, 0, 0, 0, nil, nil, "testnet", false, false)


### PR DESCRIPTION
```
--- FAIL: TestVerifyData (1.99s)
    downloader_test.go:97:
        	Error Trace:	github.com/erigontech/erigon-lib/downloader/downloader_test.go:97
        	Error:      	Received unexpected error:
        	            	openClient: torrentcfg.openClient: torrent.NewClient: subsequent listen: listen udp4 :53091: bind: An attempt was made to access a socket in a way forbidden by its access permissions.
        	Test:       	TestVerifyData
    testing.go:1232: TempDir RemoveAll cleanup: remove C:\Users\RUNNER~1\AppData\Local\Temp\TestVerifyData2884756745\001\downloader\mdbx.dat: The process cannot access the file because it is being used by another process.
FAIL
```
enable by: https://github.com/erigontech/erigon/issues/15096