### PR TITLE
VM OPSwap optimisation

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -658,6 +658,86 @@ func opGas(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte
 	return nil, nil
 }
 
+func opSwap1(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	scope.Stack.Swap1()
+	return nil, nil
+}
+
+func opSwap2(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	scope.Stack.Swap2()
+	return nil, nil
+}
+
+func opSwap3(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	scope.Stack.Swap3()
+	return nil, nil
+}
+
+func opSwap4(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	scope.Stack.Swap4()
+	return nil, nil
+}
+
+func opSwap5(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	scope.Stack.Swap5()
+	return nil, nil
+}
+
+func opSwap6(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	scope.Stack.Swap6()
+	return nil, nil
+}
+
+func opSwap7(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	scope.Stack.Swap7()
+	return nil, nil
+}
+
+func opSwap8(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	scope.Stack.Swap8()
+	return nil, nil
+}
+
+func opSwap9(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	scope.Stack.Swap9()
+	return nil, nil
+}
+
+func opSwap10(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	scope.Stack.Swap10()
+	return nil, nil
+}
+
+func opSwap11(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	scope.Stack.Swap11()
+	return nil, nil
+}
+
+func opSwap12(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	scope.Stack.Swap12()
+	return nil, nil
+}
+
+func opSwap13(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	scope.Stack.Swap13()
+	return nil, nil
+}
+
+func opSwap14(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	scope.Stack.Swap14()
+	return nil, nil
+}
+
+func opSwap15(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	scope.Stack.Swap15()
+	return nil, nil
+}
+
+func opSwap16(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	scope.Stack.Swap16()
+	return nil, nil
+}
+
 func opCreate(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	if interpreter.readOnly {
 		return nil, ErrWriteProtection
@@ -1008,16 +1088,6 @@ func makePush(size uint64, pushByteSize int) executionFunc {
 func makeDup(size int64) executionFunc {
 	return func(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 		scope.Stack.Dup(int(size))
-		return nil, nil
-	}
-}
-
-// make swap instruction function
-func makeSwap(size int64) executionFunc {
-	// switch n + 1 otherwise n would be swapped with n
-	size++
-	return func(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-		scope.Stack.Swap(int(size))
 		return nil, nil
 	}
 }

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -1011,7 +1011,7 @@ func newFrontierInstructionSet() JumpTable {
 			opNum:       16,
 		},
 		SWAP1: {
-			execute:     makeSwap(1),
+			execute:     opSwap1,
 			constantGas: GasFastestStep,
 			numPop:      2,
 			numPush:     2,
@@ -1019,7 +1019,7 @@ func newFrontierInstructionSet() JumpTable {
 			opNum:       1,
 		},
 		SWAP2: {
-			execute:     makeSwap(2),
+			execute:     opSwap2,
 			constantGas: GasFastestStep,
 			numPop:      3,
 			numPush:     3,
@@ -1027,7 +1027,7 @@ func newFrontierInstructionSet() JumpTable {
 			opNum:       2,
 		},
 		SWAP3: {
-			execute:     makeSwap(3),
+			execute:     opSwap3,
 			constantGas: GasFastestStep,
 			numPop:      4,
 			numPush:     4,
@@ -1035,7 +1035,7 @@ func newFrontierInstructionSet() JumpTable {
 			opNum:       3,
 		},
 		SWAP4: {
-			execute:     makeSwap(4),
+			execute:     opSwap4,
 			constantGas: GasFastestStep,
 			numPop:      5,
 			numPush:     5,
@@ -1043,7 +1043,7 @@ func newFrontierInstructionSet() JumpTable {
 			opNum:       4,
 		},
 		SWAP5: {
-			execute:     makeSwap(5),
+			execute:     opSwap5,
 			constantGas: GasFastestStep,
 			numPop:      6,
 			numPush:     6,
@@ -1051,7 +1051,7 @@ func newFrontierInstructionSet() JumpTable {
 			opNum:       5,
 		},
 		SWAP6: {
-			execute:     makeSwap(6),
+			execute:     opSwap6,
 			constantGas: GasFastestStep,
 			numPop:      7,
 			numPush:     7,
@@ -1059,7 +1059,7 @@ func newFrontierInstructionSet() JumpTable {
 			opNum:       6,
 		},
 		SWAP7: {
-			execute:     makeSwap(7),
+			execute:     opSwap7,
 			constantGas: GasFastestStep,
 			numPop:      8,
 			numPush:     8,
@@ -1067,7 +1067,7 @@ func newFrontierInstructionSet() JumpTable {
 			opNum:       7,
 		},
 		SWAP8: {
-			execute:     makeSwap(8),
+			execute:     opSwap8,
 			constantGas: GasFastestStep,
 			numPop:      9,
 			numPush:     9,
@@ -1075,7 +1075,7 @@ func newFrontierInstructionSet() JumpTable {
 			opNum:       8,
 		},
 		SWAP9: {
-			execute:     makeSwap(9),
+			execute:     opSwap9,
 			constantGas: GasFastestStep,
 			numPop:      10,
 			numPush:     10,
@@ -1083,7 +1083,7 @@ func newFrontierInstructionSet() JumpTable {
 			opNum:       9,
 		},
 		SWAP10: {
-			execute:     makeSwap(10),
+			execute:     opSwap10,
 			constantGas: GasFastestStep,
 			numPop:      11,
 			numPush:     11,
@@ -1091,7 +1091,7 @@ func newFrontierInstructionSet() JumpTable {
 			opNum:       10,
 		},
 		SWAP11: {
-			execute:     makeSwap(11),
+			execute:     opSwap11,
 			constantGas: GasFastestStep,
 			numPop:      12,
 			numPush:     12,
@@ -1099,7 +1099,7 @@ func newFrontierInstructionSet() JumpTable {
 			opNum:       11,
 		},
 		SWAP12: {
-			execute:     makeSwap(12),
+			execute:     opSwap12,
 			constantGas: GasFastestStep,
 			numPop:      13,
 			numPush:     13,
@@ -1107,7 +1107,7 @@ func newFrontierInstructionSet() JumpTable {
 			opNum:       12,
 		},
 		SWAP13: {
-			execute:     makeSwap(13),
+			execute:     opSwap13,
 			constantGas: GasFastestStep,
 			numPop:      14,
 			numPush:     14,
@@ -1115,7 +1115,7 @@ func newFrontierInstructionSet() JumpTable {
 			opNum:       13,
 		},
 		SWAP14: {
-			execute:     makeSwap(14),
+			execute:     opSwap14,
 			constantGas: GasFastestStep,
 			numPop:      15,
 			numPush:     15,
@@ -1123,7 +1123,7 @@ func newFrontierInstructionSet() JumpTable {
 			opNum:       14,
 		},
 		SWAP15: {
-			execute:     makeSwap(15),
+			execute:     opSwap15,
 			constantGas: GasFastestStep,
 			numPop:      16,
 			numPush:     16,
@@ -1131,7 +1131,7 @@ func newFrontierInstructionSet() JumpTable {
 			opNum:       15,
 		},
 		SWAP16: {
-			execute:     makeSwap(16),
+			execute:     opSwap16,
 			constantGas: GasFastestStep,
 			numPop:      17,
 			numPush:     17,

--- a/core/vm/stack/stack.go
+++ b/core/vm/stack/stack.go
@@ -69,8 +69,53 @@ func (st *Stack) Cap() int {
 	return cap(st.Data)
 }
 
-func (st *Stack) Swap(n int) {
-	st.Data[len(st.Data)-n], st.Data[len(st.Data)-1] = st.Data[len(st.Data)-1], st.Data[len(st.Data)-n]
+func (st *Stack) Swap1() {
+	st.Data[st.Len()-2], st.Data[st.Len()-1] = st.Data[st.Len()-1], st.Data[st.Len()-2]
+}
+func (st *Stack) Swap2() {
+	st.Data[st.Len()-3], st.Data[st.Len()-1] = st.Data[st.Len()-1], st.Data[st.Len()-3]
+}
+func (st *Stack) Swap3() {
+	st.Data[st.Len()-4], st.Data[st.Len()-1] = st.Data[st.Len()-1], st.Data[st.Len()-4]
+}
+func (st *Stack) Swap4() {
+	st.Data[st.Len()-5], st.Data[st.Len()-1] = st.Data[st.Len()-1], st.Data[st.Len()-5]
+}
+func (st *Stack) Swap5() {
+	st.Data[st.Len()-6], st.Data[st.Len()-1] = st.Data[st.Len()-1], st.Data[st.Len()-6]
+}
+func (st *Stack) Swap6() {
+	st.Data[st.Len()-7], st.Data[st.Len()-1] = st.Data[st.Len()-1], st.Data[st.Len()-7]
+}
+func (st *Stack) Swap7() {
+	st.Data[st.Len()-8], st.Data[st.Len()-1] = st.Data[st.Len()-1], st.Data[st.Len()-8]
+}
+func (st *Stack) Swap8() {
+	st.Data[st.Len()-9], st.Data[st.Len()-1] = st.Data[st.Len()-1], st.Data[st.Len()-9]
+}
+func (st *Stack) Swap9() {
+	st.Data[st.Len()-10], st.Data[st.Len()-1] = st.Data[st.Len()-1], st.Data[st.Len()-10]
+}
+func (st *Stack) Swap10() {
+	st.Data[st.Len()-11], st.Data[st.Len()-1] = st.Data[st.Len()-1], st.Data[st.Len()-11]
+}
+func (st *Stack) Swap11() {
+	st.Data[st.Len()-12], st.Data[st.Len()-1] = st.Data[st.Len()-1], st.Data[st.Len()-12]
+}
+func (st *Stack) Swap12() {
+	st.Data[st.Len()-13], st.Data[st.Len()-1] = st.Data[st.Len()-1], st.Data[st.Len()-13]
+}
+func (st *Stack) Swap13() {
+	st.Data[st.Len()-14], st.Data[st.Len()-1] = st.Data[st.Len()-1], st.Data[st.Len()-14]
+}
+func (st *Stack) Swap14() {
+	st.Data[st.Len()-15], st.Data[st.Len()-1] = st.Data[st.Len()-1], st.Data[st.Len()-15]
+}
+func (st *Stack) Swap15() {
+	st.Data[st.Len()-16], st.Data[st.Len()-1] = st.Data[st.Len()-1], st.Data[st.Len()-16]
+}
+func (st *Stack) Swap16() {
+	st.Data[st.Len()-17], st.Data[st.Len()-1] = st.Data[st.Len()-1], st.Data[st.Len()-17]
 }
 
 func (st *Stack) Dup(n int) {


### PR DESCRIPTION
closes #15114
benchmark vs main
```
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/core/vm/runtime
cpu: Apple M3 Max
                 │   old.txt   │              new.txt               │
                 │   sec/op    │   sec/op     vs base               │
EVM_SWAP1/10k-16   63.24µ ± 2%   59.99µ ± 2%  -5.14% (p=0.000 n=10)

                 │   old.txt    │            new.txt             │
                 │     B/op     │     B/op      vs base          │
EVM_SWAP1/10k-16   4.280Ki ± 4%   4.327Ki ± 4%  ~ (p=0.391 n=10)

                 │  old.txt   │            new.txt             │
                 │ allocs/op  │ allocs/op   vs base            │
EVM_SWAP1/10k-16   49.00 ± 0%   49.00 ± 0%  ~ (p=1.000 n=10) ¹
```