### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/programmers_guide/witness_formal_spec.md
+++ b/docs/programmers_guide/witness_formal_spec.md
@@ -585,7 +585,7 @@ format: `ACCOUNT_LEAF key:[]byte flags [nonce:uint64] [balance:[]byte]`
 
 encoded as `[ 0x05 CBOR(ENCODE_KEY(key))... flags /CBOR(nonce).../ /CBOR(balance).../ ]`
 
-*flags* is a bitset encoded in a single bit (see [`witness_operators_test.go`](../../trie/witness_operators_test.go) to see flags in action).
+*flags* is a bitset encoded in a single bit (see [`witness_operators_test.go`](../../erigon-lib/trie/witness_operators_test.go) to see flags in action).
 * bit 0 defines if **code** is present; if set to 1, then `has_code=true`;
 * bit 1 defines if **storage** is present; if set to 1, then `has_storage=true`;
 * bit 2 defines if **nonce** is not 0; if set to 0, *nonce* field is not encoded;


### PR DESCRIPTION
- Updated reference to witness_operators_test.go in witness_formal_spec.md to point to erigon-lib/trie/witness_operators_test.go instead of trie/witness_operators_test.go
- Updated reference to witness_operators_test.go in witness_format.md to point to erigon-lib/trie/witness_operators_test.go
- Updated reference to witness_operators.go in witness_format.md to point to erigon-lib/trie/witness_operators.go