### PR TITLE
tests: disable more slow tests in short testing

### DIFF
--- a/cl/phase1/forkchoice/fork_choice_test.go
+++ b/cl/phase1/forkchoice/fork_choice_test.go
@@ -128,6 +128,10 @@ func TestForkChoiceBasic(t *testing.T) {
 }
 
 func TestForkChoiceChainBellatrix(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	ctx := context.Background()
 	blocks, anchorState, _ := tests.GetBellatrixRandom()
 	cfg := clparams.MainnetBeaconConfig

--- a/cmd/evm/t8n_test.go
+++ b/cmd/evm/t8n_test.go
@@ -255,6 +255,10 @@ func TestT8n(t *testing.T) {
 }
 
 func TestEvmRun(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	tt := cmdtest.NewTestCmd(t, nil)
 	for i, tc := range []struct {

--- a/erigon-lib/types/encdec_test.go
+++ b/erigon-lib/types/encdec_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/erigontech/erigon-lib/rlp"
 )
 
-const RUNS = 10000 // for local tests increase this number
+const RUNS = 1000 // for local tests increase this number
 
 type TRand struct {
 	rnd *rand.Rand

--- a/p2p/dial_test.go
+++ b/p2p/dial_test.go
@@ -39,6 +39,10 @@ import (
 
 // This test checks that dynamic dials are launched from discovery results.
 func TestDialSchedDynDial(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	config := dialConfig{
@@ -296,6 +300,10 @@ func TestDialSchedRemoveStatic(t *testing.T) {
 
 // This test checks that past dials are not retried for some time.
 func TestDialSchedHistory(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	config := dialConfig{

--- a/p2p/nat/nat_test.go
+++ b/p2p/nat/nat_test.go
@@ -29,6 +29,10 @@ import (
 // consistent results when multiple goroutines call its methods
 // concurrently.
 func TestAutoDiscRace(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	ad := startautodisc("thing", func() Interface {
 		time.Sleep(500 * time.Millisecond)
 		return ExtIP{33, 44, 55, 66}

--- a/polygon/heimdall/client_http_test.go
+++ b/polygon/heimdall/client_http_test.go
@@ -42,6 +42,10 @@ func (ebrc emptyBodyReadCloser) Close() error {
 }
 
 func TestHeimdallClientFetchesTerminateUponTooManyErrors(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
 	requestHandler := NewMockhttpRequestHandler(ctrl)

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -387,6 +387,10 @@ func TestClientCloseUnsubscribeRace(t *testing.T) {
 // This test checks that Client doesn't lock up when a single subscriber
 // doesn't read subscription events.
 func TestClientNotificationStorm(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	logger := log.New()
 	server := newTestServer(logger)
 	defer server.Stop()

--- a/rpc/jsonrpc/send_transaction_test.go
+++ b/rpc/jsonrpc/send_transaction_test.go
@@ -91,6 +91,10 @@ func oneBlockStep(mockSentry *mock.MockSentry, require *require.Assertions, t *t
 }
 
 func TestSendRawTransaction(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	mockSentry, require := mock.MockWithTxPool(t), require.New(t)
 	logger := log.New()
 

--- a/tests/bor/mining_test.go
+++ b/tests/bor/mining_test.go
@@ -71,6 +71,10 @@ var (
 // Example : CGO_CFLAGS="-D__BLST_PORTABLE__" go test -run ^TestMiningBenchmark$ github.com/erigontech/erigon/tests/bor -v -count=1
 // In TestMiningBenchmark, we will test the mining performance. We will initialize a single node devnet and fire 5000 txs. We will measure the time it takes to include all the txs. This can be made more advcanced by increasing blockLimit and txsInTxpool.
 func TestMiningBenchmark(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	//usually 15sec is enough
 	ctx, clean := context.WithTimeout(context.Background(), time.Minute)
 	defer clean()

--- a/txnprovider/shutter/block_building_integration_test.go
+++ b/txnprovider/shutter/block_building_integration_test.go
@@ -62,6 +62,10 @@ import (
 )
 
 func TestShutterBlockBuilding(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 


### PR DESCRIPTION
Continuation of PR #14662. I used [gotestsum](https://github.com/gotestyourself/gotestsum#finding-and-skipping-slow-tests) with 500ms threshold.