### PR TITLE
`temporal.DomainPut`: remove `k2` parameter

### DIFF
--- a/core/test/domains_restart_test.go
+++ b/core/test/domains_restart_test.go
@@ -502,7 +502,7 @@ func TestCommit(t *testing.T) {
 		require.NoError(t, err)
 		loc[0] = byte(i)
 
-		err = domains.DomainPut(kv.StorageDomain, addr, loc, []byte("0401"), nil, 0)
+		err = domains.DomainPut(kv.StorageDomain, append(common.Copy(addr), loc...), nil, []byte("0401"), nil, 0)
 		require.NoError(t, err)
 	}
 

--- a/erigon-lib/state/aggregator_bench_test.go
+++ b/erigon-lib/state/aggregator_bench_test.go
@@ -87,7 +87,7 @@ func BenchmarkAggregator_Processing(b *testing.B) {
 		val := <-vals
 		txNum := uint64(i)
 		domains.SetTxNum(txNum)
-		err := domains.DomainPut(kv.StorageDomain, key[:length.Addr], key[length.Addr:], val, prev, 0)
+		err := domains.DomainPut(kv.StorageDomain, key, nil, val, prev, 0)
 		prev = val
 		require.NoError(b, err)
 

--- a/erigon-lib/state/aggregator_fuzz_test.go
+++ b/erigon-lib/state/aggregator_fuzz_test.go
@@ -91,7 +91,7 @@ func Fuzz_AggregatorV3_Merge(f *testing.F) {
 			err = domains.DomainPut(kv.AccountsDomain, addrs[txNum].Bytes(), nil, buf, nil, 0)
 			require.NoError(t, err)
 
-			err = domains.DomainPut(kv.StorageDomain, addrs[txNum].Bytes(), locs[txNum].Bytes(), []byte{addrs[txNum].Bytes()[0], locs[txNum].Bytes()[0]}, nil, 0)
+			err = domains.DomainPut(kv.StorageDomain, append(common.Copy(addrs[txNum].Bytes()), locs[txNum].Bytes()...), nil, []byte{addrs[txNum].Bytes()[0], locs[txNum].Bytes()[0]}, nil, 0)
 			require.NoError(t, err)
 
 			var v [8]byte
@@ -215,7 +215,7 @@ func Fuzz_AggregatorV3_MergeValTransform(f *testing.F) {
 			err = domains.DomainPut(kv.AccountsDomain, addrs[txNum].Bytes(), nil, buf, nil, 0)
 			require.NoError(t, err)
 
-			err = domains.DomainPut(kv.StorageDomain, addrs[txNum].Bytes(), locs[txNum].Bytes(), []byte{addrs[txNum].Bytes()[0], locs[txNum].Bytes()[0]}, nil, 0)
+			err = domains.DomainPut(kv.StorageDomain, composite(addrs[txNum].Bytes(), locs[txNum].Bytes()), nil, []byte{addrs[txNum].Bytes()[0], locs[txNum].Bytes()[0]}, nil, 0)
 			require.NoError(t, err)
 
 			if (txNum+1)%agg.StepSize() == 0 {

--- a/erigon-lib/state/aggregator_test.go
+++ b/erigon-lib/state/aggregator_test.go
@@ -106,7 +106,7 @@ func TestAggregatorV3_Merge(t *testing.T) {
 		err = domains.DomainPut(kv.AccountsDomain, addr, nil, buf, nil, 0)
 		require.NoError(t, err)
 
-		err = domains.DomainPut(kv.StorageDomain, addr, loc, []byte{addr[0], loc[0]}, nil, 0)
+		err = domains.DomainPut(kv.StorageDomain, append(common.Copy(addr), loc...), nil, []byte{addr[0], loc[0]}, nil, 0)
 		require.NoError(t, err)
 
 		var v [8]byte
@@ -232,7 +232,7 @@ func TestAggregatorV3_DirtyFilesRo(t *testing.T) {
 		err = domains.DomainPut(kv.AccountsDomain, addr, nil, buf, nil, 0)
 		require.NoError(t, err)
 
-		err = domains.DomainPut(kv.StorageDomain, addr, loc, []byte{addr[0], loc[0]}, nil, 0)
+		err = domains.DomainPut(kv.StorageDomain, composite(addr, loc), nil, []byte{addr[0], loc[0]}, nil, 0)
 		require.NoError(t, err)
 
 		var v [8]byte
@@ -362,7 +362,7 @@ func TestAggregatorV3_MergeValTransform(t *testing.T) {
 		err = domains.DomainPut(kv.AccountsDomain, addr, nil, buf, nil, 0)
 		require.NoError(t, err)
 
-		err = domains.DomainPut(kv.StorageDomain, addr, loc, []byte{addr[0], loc[0]}, nil, 0)
+		err = domains.DomainPut(kv.StorageDomain, composite(addr, loc), nil, []byte{addr[0], loc[0]}, nil, 0)
 		require.NoError(t, err)
 
 		if (txNum+1)%agg.StepSize() == 0 {
@@ -498,7 +498,7 @@ func aggregatorV3_RestartOnDatadir(t *testing.T, rc runCfg) {
 		err = domains.DomainPut(kv.AccountsDomain, addr, nil, buf, nil, 0)
 		require.NoError(t, err)
 
-		err = domains.DomainPut(kv.StorageDomain, addr, loc, []byte{addr[0], loc[0]}, nil, 0)
+		err = domains.DomainPut(kv.StorageDomain, composite(addr, loc), nil, []byte{addr[0], loc[0]}, nil, 0)
 		require.NoError(t, err)
 
 		err = domains.DomainPut(kv.CommitmentDomain, someKey, nil, aux[:], nil, 0)
@@ -919,7 +919,7 @@ func generateSharedDomainsUpdatesForTx(t *testing.T, domains *SharedDomains, txN
 				prev, step, err := domains.GetLatest(kv.StorageDomain, sk[:length.Addr])
 				require.NoError(t, err)
 
-				err = domains.DomainPut(kv.StorageDomain, sk[:length.Addr], sk[length.Addr:], uint256.NewInt(txNum).Bytes(), prev, step)
+				err = domains.DomainPut(kv.StorageDomain, sk, nil, uint256.NewInt(txNum).Bytes(), prev, step)
 				require.NoError(t, err)
 			}
 
@@ -982,7 +982,7 @@ func TestAggregatorV3_RestartOnFiles(t *testing.T) {
 		err = domains.DomainPut(kv.AccountsDomain, addr, nil, buf[:], nil, 0)
 		require.NoError(t, err)
 
-		err = domains.DomainPut(kv.StorageDomain, addr, loc, []byte{addr[0], loc[0]}, nil, 0)
+		err = domains.DomainPut(kv.StorageDomain, composite(addr, loc), nil, []byte{addr[0], loc[0]}, nil, 0)
 		require.NoError(t, err)
 
 		keys[txNum-1] = append(addr, loc...)
@@ -1142,7 +1142,7 @@ func TestAggregatorV3_ReplaceCommittedKeys(t *testing.T) {
 		require.NoError(t, err)
 		prev1 = buf
 
-		err = domains.DomainPut(kv.StorageDomain, addr, loc, []byte{addr[0], loc[0]}, prev2, 0)
+		err = domains.DomainPut(kv.StorageDomain, composite(addr, loc), nil, []byte{addr[0], loc[0]}, prev2, 0)
 		require.NoError(t, err)
 		prev2 = []byte{addr[0], loc[0]}
 
@@ -1157,7 +1157,7 @@ func TestAggregatorV3_ReplaceCommittedKeys(t *testing.T) {
 
 		prev, step, _, err := ac.d[kv.StorageDomain].GetLatest(keys[txNum-1-half], tx)
 		require.NoError(t, err)
-		err = domains.DomainPut(kv.StorageDomain, addr, loc, []byte{addr[0], loc[0]}, prev, step)
+		err = domains.DomainPut(kv.StorageDomain, composite(addr, loc), nil, []byte{addr[0], loc[0]}, prev, step)
 		require.NoError(t, err)
 	}
 

--- a/erigon-lib/state/domain_shared.go
+++ b/erigon-lib/state/domain_shared.go
@@ -736,6 +736,9 @@ func (sd *SharedDomains) getLatestFromFiles(domain kv.Domain, k, k2 []byte, ofMa
 //   - user can append k2 into k1, then underlying methods will not preform append
 //   - if `val == nil` it will call DomainDel
 func (sd *SharedDomains) DomainPut(domain kv.Domain, k1, k2 []byte, val, prevVal []byte, prevStep uint64) error {
+	if k2 != nil {
+		panic(1)
+	}
 	if val == nil {
 		return fmt.Errorf("DomainPut: %s, trying to put nil value. not allowed", domain)
 	}

--- a/erigon-lib/state/domain_shared_test.go
+++ b/erigon-lib/state/domain_shared_test.go
@@ -217,6 +217,9 @@ Loop:
 	goto Loop
 }
 
+func composite(k, k2 []byte) []byte {
+	return append(common.Copy(k), k2...)
+}
 func TestSharedDomain_IteratePrefix(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
@@ -274,7 +277,7 @@ func TestSharedDomain_IteratePrefix(t *testing.T) {
 		if err = domains.DomainPut(kv.AccountsDomain, addr, nil, acc(i), nil, 0); err != nil {
 			panic(err)
 		}
-		if err = domains.DomainPut(kv.StorageDomain, addr, st(i), acc(i), nil, 0); err != nil {
+		if err = domains.DomainPut(kv.StorageDomain, composite(addr, st(i)), nil, acc(i), nil, 0); err != nil {
 			panic(err)
 		}
 	}
@@ -309,7 +312,7 @@ func TestSharedDomain_IteratePrefix(t *testing.T) {
 			if err = domains.DomainPut(kv.AccountsDomain, addr, nil, acc(i), nil, 0); err != nil {
 				panic(err)
 			}
-			if err = domains.DomainPut(kv.StorageDomain, addr, st(i), acc(i), nil, 0); err != nil {
+			if err = domains.DomainPut(kv.StorageDomain, composite(addr, st(i)), nil, acc(i), nil, 0); err != nil {
 				panic(err)
 			}
 		}
@@ -458,7 +461,7 @@ func TestSharedDomain_StorageIter(t *testing.T) {
 				pv, step, err := domains.GetLatest(kv.AccountsDomain, append(k0, l0...))
 				require.NoError(t, err)
 
-				err = domains.DomainPut(kv.StorageDomain, k0, l0, l0[24:], pv, step)
+				err = domains.DomainPut(kv.StorageDomain, composite(k0, l0), nil, l0[24:], pv, step)
 				require.NoError(t, err)
 			}
 		}


### PR DESCRIPTION
next step will be: add txNum parameter (it will be step towards removing txNum from SD)
