### PR TITLE
[exp] warmup next commitment read

### DIFF
--- a/erigon-lib/commitment/commitment.go
+++ b/erigon-lib/commitment/commitment.go
@@ -1152,7 +1152,8 @@ func (t *Updates) Close() {
 
 type fnNextKey func(hashed, plain []byte, update *Update) error
 
-var COM_WARMUP = dbg.EnvBool("COM_WARMUP", false)
+// TODO remove experimental feature
+var COM_WARMUP = dbg.EnvBool("ERIGON_COM_WARMUP", false)
 
 func (t *Updates) WarmupHashSort(ctx context.Context, fn, warmup fnNextKey) error {
 	if !COM_WARMUP {

--- a/erigon-lib/commitment/commitment.go
+++ b/erigon-lib/commitment/commitment.go
@@ -1155,6 +1155,9 @@ type fnNextKey func(hashed, plain []byte, update *Update) error
 var COM_WARMUP = dbg.EnvBool("COM_WARMUP", false)
 
 func (t *Updates) WarmupHashSort(ctx context.Context, fn, warmup fnNextKey) error {
+	if !COM_WARMUP {
+		return t.HashSort(ctx, fn)
+	}
 	//if t.mode != ModeUpdateWarmup {
 	//	panic("WarmupHashSort should be called only in ModeUpdateWarmup")
 	//}

--- a/erigon-lib/commitment/hex_patricia_hashed.go
+++ b/erigon-lib/commitment/hex_patricia_hashed.go
@@ -2174,6 +2174,9 @@ func (hph *HexPatriciaHashed) Process(ctx context.Context, updates *Updates, log
 		warmupTrie.readOnly = true // do not produce updates on traversal
 		warmupFN = warmupTrie.followAndUpdate
 	}
+	defer func() {
+		log.Debug("commitment finished", "keys", common.PrettyCounter(ki), "spent", time.Since(start), "warmup", COM_WARMUP)
+	}()
 
 	//err = updates.HashSort(ctx, func(hashedKey, plainKey []byte, stateUpdate *Update) error {
 	err = updates.WarmupHashSort(ctx, func(hashedKey, plainKey []byte, stateUpdate *Update) error {


### PR DESCRIPTION
For testing only, created env `ERIGON_COM_WARMUP=true|false` regulating if warmup function is going to be called or previous version would be used. In this implementation, processing and warmup is sequential aand they are using same hph.ctx for acess database.