### PR TITLE
RPCd: Add arbitrum specific getBlock changes

### DIFF
--- a/rpc/ethapi/api.go
+++ b/rpc/ethapi/api.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/holiman/uint256"
 
-	"github.com/erigontech/erigon-lib/chain"
 	libcommon "github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/hexutil"
 	"github.com/erigontech/erigon-lib/common/math"
@@ -420,11 +419,11 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 // RPCMarshalBlock converts the given block to the RPC output which depends on fullTx. If inclTx is true transactions are
 // returned. When fullTx is true the returned block contains full transaction details, otherwise it will only contain
 // transaction hashes.
-func RPCMarshalBlockDeprecated(block *types.Block, inclTx bool, fullTx bool, chainConfig *chain.Config) (map[string]interface{}, error) {
-	return RPCMarshalBlockExDeprecated(block, inclTx, fullTx, nil, libcommon.Hash{}, chainConfig)
+func RPCMarshalBlockDeprecated(block *types.Block, inclTx bool, fullTx bool, isArbitrumNitro bool) (map[string]interface{}, error) {
+	return RPCMarshalBlockExDeprecated(block, inclTx, fullTx, nil, libcommon.Hash{}, isArbitrumNitro)
 }
 
-func RPCMarshalBlockExDeprecated(block *types.Block, inclTx bool, fullTx bool, borTx types.Transaction, borTxHash libcommon.Hash, chainConfig *chain.Config) (map[string]interface{}, error) {
+func RPCMarshalBlockExDeprecated(block *types.Block, inclTx bool, fullTx bool, borTx types.Transaction, borTxHash libcommon.Hash, isArbitrumNitro bool) (map[string]interface{}, error) {
 	fields := RPCMarshalHeader(block.Header())
 	fields["size"] = hexutil.Uint64(block.Size())
 	if _, ok := fields["transactions"]; !ok {
@@ -469,7 +468,7 @@ func RPCMarshalBlockExDeprecated(block *types.Block, inclTx bool, fullTx bool, b
 	if block.Withdrawals() != nil {
 		fields["withdrawals"] = block.Withdrawals()
 	}
-	if chainConfig.IsArbitrumNitro(block.Header().Number) {
+	if isArbitrumNitro {
 		fillArbitrumHeaderInfo(block.Header(), fields)
 	}
 	return fields, nil

--- a/rpc/ethapi/api.go
+++ b/rpc/ethapi/api.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/holiman/uint256"
 
+	"github.com/erigontech/erigon-lib/chain"
 	libcommon "github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/hexutil"
 	"github.com/erigontech/erigon-lib/common/math"
@@ -54,7 +55,7 @@ type CallArgs struct {
 	ChainID              *hexutil.Big              `json:"chainId,omitempty"`
 	AuthorizationList    []types.JsonAuthorization `json:"authorizationList"`
 
-	SkipL1Charging       *bool                     `json:"skipL1Charging"` // Arbitrum
+	SkipL1Charging *bool `json:"skipL1Charging"` // Arbitrum
 }
 
 // from retrieves the transaction sender address.
@@ -259,6 +260,7 @@ func (args *CallArgs) L2OnlyGasCap(gasCap uint64, header *types.Header) (uint64,
 
 // Allows ArbOS to update the gas cap so that it ignores the message's specific L1 poster costs.
 var InterceptRPCGasCap = func(gascap *uint64, msg *types.Message, header *types.Header) {}
+
 // End arbitrum
 
 // Account indicates the overriding fields of account during the execution of
@@ -418,11 +420,11 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 // RPCMarshalBlock converts the given block to the RPC output which depends on fullTx. If inclTx is true transactions are
 // returned. When fullTx is true the returned block contains full transaction details, otherwise it will only contain
 // transaction hashes.
-func RPCMarshalBlockDeprecated(block *types.Block, inclTx bool, fullTx bool) (map[string]interface{}, error) {
-	return RPCMarshalBlockExDeprecated(block, inclTx, fullTx, nil, libcommon.Hash{})
+func RPCMarshalBlockDeprecated(block *types.Block, inclTx bool, fullTx bool, chainConfig *chain.Config) (map[string]interface{}, error) {
+	return RPCMarshalBlockExDeprecated(block, inclTx, fullTx, nil, libcommon.Hash{}, chainConfig)
 }
 
-func RPCMarshalBlockExDeprecated(block *types.Block, inclTx bool, fullTx bool, borTx types.Transaction, borTxHash libcommon.Hash) (map[string]interface{}, error) {
+func RPCMarshalBlockExDeprecated(block *types.Block, inclTx bool, fullTx bool, borTx types.Transaction, borTxHash libcommon.Hash, chainConfig *chain.Config) (map[string]interface{}, error) {
 	fields := RPCMarshalHeader(block.Header())
 	fields["size"] = hexutil.Uint64(block.Size())
 	if _, ok := fields["transactions"]; !ok {
@@ -467,8 +469,17 @@ func RPCMarshalBlockExDeprecated(block *types.Block, inclTx bool, fullTx bool, b
 	if block.Withdrawals() != nil {
 		fields["withdrawals"] = block.Withdrawals()
 	}
-
+	if chainConfig.IsArbitrumNitro(block.Header().Number) {
+		fillArbitrumHeaderInfo(block.Header(), fields)
+	}
 	return fields, nil
+}
+
+func fillArbitrumHeaderInfo(header *types.Header, fields map[string]interface{}) {
+	info := types.DeserializeHeaderExtraInformation(header)
+	fields["l1BlockNumber"] = hexutil.Uint64(info.L1BlockNumber)
+	fields["sendRoot"] = info.SendRoot
+	fields["sendCount"] = hexutil.Uint64(info.SendCount)
 }
 
 // RPCTransaction represents a transaction that will serialize to the RPC representation of a transaction

--- a/rpc/ethapi/internal.go
+++ b/rpc/ethapi/internal.go
@@ -18,14 +18,15 @@ package ethapi
 
 // This file stores proxy-objects for `internal` package
 import (
+	"github.com/erigontech/erigon-lib/chain"
 	libcommon "github.com/erigontech/erigon-lib/common"
 
 	"github.com/erigontech/erigon/core/types"
 )
 
 // nolint
-func RPCMarshalBlock(b *types.Block, inclTx bool, fullTx bool, additional map[string]interface{}) (map[string]interface{}, error) {
-	fields, err := RPCMarshalBlockDeprecated(b, inclTx, fullTx)
+func RPCMarshalBlock(b *types.Block, inclTx bool, fullTx bool, additional map[string]interface{}, chainConfig *chain.Config) (map[string]interface{}, error) {
+	fields, err := RPCMarshalBlockDeprecated(b, inclTx, fullTx, chainConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -38,8 +39,8 @@ func RPCMarshalBlock(b *types.Block, inclTx bool, fullTx bool, additional map[st
 }
 
 // nolint
-func RPCMarshalBlockEx(b *types.Block, inclTx bool, fullTx bool, borTx types.Transaction, borTxHash libcommon.Hash, additional map[string]interface{}) (map[string]interface{}, error) {
-	fields, err := RPCMarshalBlockExDeprecated(b, inclTx, fullTx, borTx, borTxHash)
+func RPCMarshalBlockEx(b *types.Block, inclTx bool, fullTx bool, borTx types.Transaction, borTxHash libcommon.Hash, additional map[string]interface{}, chainConfig *chain.Config) (map[string]interface{}, error) {
+	fields, err := RPCMarshalBlockExDeprecated(b, inclTx, fullTx, borTx, borTxHash, chainConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/ethapi/internal.go
+++ b/rpc/ethapi/internal.go
@@ -18,15 +18,14 @@ package ethapi
 
 // This file stores proxy-objects for `internal` package
 import (
-	"github.com/erigontech/erigon-lib/chain"
 	libcommon "github.com/erigontech/erigon-lib/common"
 
 	"github.com/erigontech/erigon/core/types"
 )
 
 // nolint
-func RPCMarshalBlock(b *types.Block, inclTx bool, fullTx bool, additional map[string]interface{}, chainConfig *chain.Config) (map[string]interface{}, error) {
-	fields, err := RPCMarshalBlockDeprecated(b, inclTx, fullTx, chainConfig)
+func RPCMarshalBlock(b *types.Block, inclTx bool, fullTx bool, additional map[string]interface{}, isArbitrumNitro bool) (map[string]interface{}, error) {
+	fields, err := RPCMarshalBlockDeprecated(b, inclTx, fullTx, isArbitrumNitro)
 	if err != nil {
 		return nil, err
 	}
@@ -39,8 +38,8 @@ func RPCMarshalBlock(b *types.Block, inclTx bool, fullTx bool, additional map[st
 }
 
 // nolint
-func RPCMarshalBlockEx(b *types.Block, inclTx bool, fullTx bool, borTx types.Transaction, borTxHash libcommon.Hash, additional map[string]interface{}, chainConfig *chain.Config) (map[string]interface{}, error) {
-	fields, err := RPCMarshalBlockExDeprecated(b, inclTx, fullTx, borTx, borTxHash, chainConfig)
+func RPCMarshalBlockEx(b *types.Block, inclTx bool, fullTx bool, borTx types.Transaction, borTxHash libcommon.Hash, additional map[string]interface{}, isArbitrumNitro bool) (map[string]interface{}, error) {
+	fields, err := RPCMarshalBlockExDeprecated(b, inclTx, fullTx, borTx, borTxHash, isArbitrumNitro)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/jsonrpc/debug_api.go
+++ b/rpc/jsonrpc/debug_api.go
@@ -472,7 +472,7 @@ func (api *PrivateDebugAPIImpl) GetBadBlocks(ctx context.Context) ([]map[string]
 			blockRlp = fmt.Sprintf("%#x", rlpBytes)
 		}
 
-		blockJson, err := ethapi.RPCMarshalBlock(block, true, true, nil, chainConfig)
+		blockJson, err := ethapi.RPCMarshalBlock(block, true, true, nil, chainConfig.IsArbitrumNitro(block.Number()))
 		if err != nil {
 			log.Error("Failed to marshal block", "err", err)
 			blockJson = map[string]interface{}{}

--- a/rpc/jsonrpc/debug_api.go
+++ b/rpc/jsonrpc/debug_api.go
@@ -458,6 +458,10 @@ func (api *PrivateDebugAPIImpl) GetBadBlocks(ctx context.Context) ([]map[string]
 	if err != nil || len(blocks) == 0 {
 		return nil, err
 	}
+	chainConfig, err := api.chainConfig(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
 
 	results := make([]map[string]interface{}, 0, len(blocks))
 	for _, block := range blocks {
@@ -468,7 +472,7 @@ func (api *PrivateDebugAPIImpl) GetBadBlocks(ctx context.Context) ([]map[string]
 			blockRlp = fmt.Sprintf("%#x", rlpBytes)
 		}
 
-		blockJson, err := ethapi.RPCMarshalBlock(block, true, true, nil)
+		blockJson, err := ethapi.RPCMarshalBlock(block, true, true, nil, chainConfig)
 		if err != nil {
 			log.Error("Failed to marshal block", "err", err)
 			blockJson = map[string]interface{}{}

--- a/rpc/jsonrpc/erigon_block.go
+++ b/rpc/jsonrpc/erigon_block.go
@@ -202,7 +202,7 @@ func buildBlockResponse(ctx context.Context, br services.FullBlockReader, db kv.
 
 	additionalFields := make(map[string]interface{})
 
-	response, err := ethapi.RPCMarshalBlockEx(block, true, fullTx, nil, common.Hash{}, additionalFields, chainConfig)
+	response, err := ethapi.RPCMarshalBlockEx(block, true, fullTx, nil, common.Hash{}, additionalFields, chainConfig.IsArbitrumNitro(block.Number()))
 
 	if err == nil && rpc.BlockNumber(block.NumberU64()) == rpc.PendingBlockNumber {
 		// Pending blocks need to nil out a few fields

--- a/rpc/jsonrpc/eth_call_test.go
+++ b/rpc/jsonrpc/eth_call_test.go
@@ -244,7 +244,7 @@ func TestGetBlockByTimestampLatestTime(t *testing.T) {
 	assert.NoError(t, err)
 	latestBlock, err := m.BlockReader.CurrentBlock(tx)
 	require.NoError(t, err)
-	response, err := ethapi.RPCMarshalBlockDeprecated(latestBlock, true, false, chainConfig)
+	response, err := ethapi.RPCMarshalBlockDeprecated(latestBlock, true, false, chainConfig.IsArbitrumNitro(latestBlock.Number()))
 
 	if err != nil {
 		t.Error("couldn't get the rpc marshal block")
@@ -284,7 +284,7 @@ func TestGetBlockByTimestampOldestTime(t *testing.T) {
 
 	chainConfig, err := api.chainConfig(ctx, tx)
 	assert.NoError(t, err)
-	response, err := ethapi.RPCMarshalBlockDeprecated(oldestBlock, true, false, chainConfig)
+	response, err := ethapi.RPCMarshalBlockDeprecated(oldestBlock, true, false, chainConfig.IsArbitrumNitro(oldestBlock.Number()))
 
 	if err != nil {
 		t.Error("couldn't get the rpc marshal block")
@@ -322,7 +322,7 @@ func TestGetBlockByTimeHigherThanLatestBlock(t *testing.T) {
 
 	chainConfig, err := api.chainConfig(ctx, tx)
 	assert.NoError(t, err)
-	response, err := ethapi.RPCMarshalBlockDeprecated(latestBlock, true, false, chainConfig)
+	response, err := ethapi.RPCMarshalBlockDeprecated(latestBlock, true, false, chainConfig.IsArbitrumNitro(latestBlock.Number()))
 
 	if err != nil {
 		t.Error("couldn't get the rpc marshal block")
@@ -372,7 +372,7 @@ func TestGetBlockByTimeMiddle(t *testing.T) {
 
 	chainConfig, err := api.chainConfig(ctx, tx)
 	assert.NoError(t, err)
-	response, err := ethapi.RPCMarshalBlockDeprecated(middleBlock, true, false, chainConfig)
+	response, err := ethapi.RPCMarshalBlockDeprecated(middleBlock, true, false, chainConfig.IsArbitrumNitro(middleBlock.Number()))
 
 	if err != nil {
 		t.Error("couldn't get the rpc marshal block")
@@ -415,7 +415,7 @@ func TestGetBlockByTimestamp(t *testing.T) {
 	}
 	chainConfig, err := api.chainConfig(ctx, tx)
 	assert.NoError(t, err)
-	response, err := ethapi.RPCMarshalBlockDeprecated(pickedBlock, true, false, chainConfig)
+	response, err := ethapi.RPCMarshalBlockDeprecated(pickedBlock, true, false, chainConfig.IsArbitrumNitro(pickedBlock.Number()))
 
 	if err != nil {
 		t.Error("couldn't get the rpc marshal block")

--- a/rpc/jsonrpc/eth_call_test.go
+++ b/rpc/jsonrpc/eth_call_test.go
@@ -240,9 +240,11 @@ func TestGetBlockByTimestampLatestTime(t *testing.T) {
 	defer tx.Rollback()
 	api := NewErigonAPI(newBaseApiForTest(m), m.DB, nil)
 
+	chainConfig, err := api.chainConfig(ctx, tx)
+	assert.NoError(t, err)
 	latestBlock, err := m.BlockReader.CurrentBlock(tx)
 	require.NoError(t, err)
-	response, err := ethapi.RPCMarshalBlockDeprecated(latestBlock, true, false)
+	response, err := ethapi.RPCMarshalBlockDeprecated(latestBlock, true, false, chainConfig)
 
 	if err != nil {
 		t.Error("couldn't get the rpc marshal block")
@@ -280,7 +282,9 @@ func TestGetBlockByTimestampOldestTime(t *testing.T) {
 		t.Error("couldn't retrieve oldest block")
 	}
 
-	response, err := ethapi.RPCMarshalBlockDeprecated(oldestBlock, true, false)
+	chainConfig, err := api.chainConfig(ctx, tx)
+	assert.NoError(t, err)
+	response, err := ethapi.RPCMarshalBlockDeprecated(oldestBlock, true, false, chainConfig)
 
 	if err != nil {
 		t.Error("couldn't get the rpc marshal block")
@@ -316,7 +320,9 @@ func TestGetBlockByTimeHigherThanLatestBlock(t *testing.T) {
 	latestBlock, err := m.BlockReader.CurrentBlock(tx)
 	require.NoError(t, err)
 
-	response, err := ethapi.RPCMarshalBlockDeprecated(latestBlock, true, false)
+	chainConfig, err := api.chainConfig(ctx, tx)
+	assert.NoError(t, err)
+	response, err := ethapi.RPCMarshalBlockDeprecated(latestBlock, true, false, chainConfig)
 
 	if err != nil {
 		t.Error("couldn't get the rpc marshal block")
@@ -364,7 +370,9 @@ func TestGetBlockByTimeMiddle(t *testing.T) {
 		t.Error("couldn't retrieve middle block")
 	}
 
-	response, err := ethapi.RPCMarshalBlockDeprecated(middleBlock, true, false)
+	chainConfig, err := api.chainConfig(ctx, tx)
+	assert.NoError(t, err)
+	response, err := ethapi.RPCMarshalBlockDeprecated(middleBlock, true, false, chainConfig)
 
 	if err != nil {
 		t.Error("couldn't get the rpc marshal block")
@@ -405,7 +413,9 @@ func TestGetBlockByTimestamp(t *testing.T) {
 	if pickedBlock == nil {
 		t.Error("couldn't retrieve picked block")
 	}
-	response, err := ethapi.RPCMarshalBlockDeprecated(pickedBlock, true, false)
+	chainConfig, err := api.chainConfig(ctx, tx)
+	assert.NoError(t, err)
+	response, err := ethapi.RPCMarshalBlockDeprecated(pickedBlock, true, false, chainConfig)
 
 	if err != nil {
 		t.Error("couldn't get the rpc marshal block")

--- a/rpc/jsonrpc/eth_uncles.go
+++ b/rpc/jsonrpc/eth_uncles.go
@@ -44,6 +44,7 @@ func (api *APIImpl) GetUncleByBlockNumberAndIndex(ctx context.Context, number rp
 	if err != nil {
 		return nil, err
 	}
+	// For Nitro it should return here as arbitrum chain does not have uncles
 	if block == nil {
 		return nil, nil // not error, see https://github.com/erigontech/erigon/issues/1645
 	}
@@ -54,8 +55,12 @@ func (api *APIImpl) GetUncleByBlockNumberAndIndex(ctx context.Context, number rp
 		log.Trace("Requested uncle not found", "number", block.Number(), "hash", hash, "index", index)
 		return nil, nil
 	}
+	chainConfig, err := api.chainConfig(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
 	uncle := types.NewBlockWithHeader(uncles[index])
-	return ethapi.RPCMarshalBlock(uncle, false, false, additionalFields)
+	return ethapi.RPCMarshalBlock(uncle, false, false, additionalFields, chainConfig)
 }
 
 // GetUncleByBlockHashAndIndex implements eth_getUncleByBlockHashAndIndex. Returns information about an uncle given a block's hash and the index of the uncle.
@@ -70,6 +75,7 @@ func (api *APIImpl) GetUncleByBlockHashAndIndex(ctx context.Context, hash common
 	if err != nil {
 		return nil, err
 	}
+	// For Nitro it should return here as arbitrum chain does not have uncles
 	if block == nil {
 		return nil, nil // not error, see https://github.com/erigontech/erigon/issues/1645
 	}
@@ -80,9 +86,14 @@ func (api *APIImpl) GetUncleByBlockHashAndIndex(ctx context.Context, hash common
 		log.Trace("Requested uncle not found", "number", block.Number(), "hash", hash, "index", index)
 		return nil, nil
 	}
+
+	chainConfig, err := api.chainConfig(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
 	uncle := types.NewBlockWithHeader(uncles[index])
 
-	return ethapi.RPCMarshalBlock(uncle, false, false, additionalFields)
+	return ethapi.RPCMarshalBlock(uncle, false, false, additionalFields, chainConfig)
 }
 
 // GetUncleCountByBlockNumber implements eth_getUncleCountByBlockNumber. Returns the number of uncles in the block, if any.

--- a/rpc/jsonrpc/eth_uncles.go
+++ b/rpc/jsonrpc/eth_uncles.go
@@ -60,7 +60,7 @@ func (api *APIImpl) GetUncleByBlockNumberAndIndex(ctx context.Context, number rp
 		return nil, err
 	}
 	uncle := types.NewBlockWithHeader(uncles[index])
-	return ethapi.RPCMarshalBlock(uncle, false, false, additionalFields, chainConfig)
+	return ethapi.RPCMarshalBlock(uncle, false, false, additionalFields, chainConfig.IsArbitrumNitro(uncle.Number()))
 }
 
 // GetUncleByBlockHashAndIndex implements eth_getUncleByBlockHashAndIndex. Returns information about an uncle given a block's hash and the index of the uncle.
@@ -93,7 +93,7 @@ func (api *APIImpl) GetUncleByBlockHashAndIndex(ctx context.Context, hash common
 	}
 	uncle := types.NewBlockWithHeader(uncles[index])
 
-	return ethapi.RPCMarshalBlock(uncle, false, false, additionalFields, chainConfig)
+	return ethapi.RPCMarshalBlock(uncle, false, false, additionalFields, chainConfig.IsArbitrumNitro(uncle.Number()))
 }
 
 // GetUncleCountByBlockNumber implements eth_getUncleCountByBlockNumber. Returns the number of uncles in the block, if any.

--- a/rpc/jsonrpc/graphql_api.go
+++ b/rpc/jsonrpc/graphql_api.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/erigontech/erigon-lib/chain"
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/hexutil"
 	"github.com/erigontech/erigon-lib/kv"
@@ -78,12 +79,12 @@ func (api *GraphQLAPIImpl) GetBlockDetails(ctx context.Context, blockNumber rpc.
 		return nil, nil
 	}
 
-	getBlockRes, err := api.delegateGetBlockByNumber(tx, block, blockNumber, false)
+	chainConfig, err := api.chainConfig(ctx, tx)
 	if err != nil {
 		return nil, err
 	}
 
-	chainConfig, err := api.chainConfig(ctx, tx)
+	getBlockRes, err := api.delegateGetBlockByNumber(tx, block, blockNumber, false, chainConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -146,9 +147,9 @@ func (api *GraphQLAPIImpl) getBlockWithSenders(ctx context.Context, number rpc.B
 	return block, block.Body().SendersFromTxs(), nil
 }
 
-func (api *GraphQLAPIImpl) delegateGetBlockByNumber(tx kv.Tx, b *types.Block, number rpc.BlockNumber, inclTx bool) (map[string]interface{}, error) {
+func (api *GraphQLAPIImpl) delegateGetBlockByNumber(tx kv.Tx, b *types.Block, number rpc.BlockNumber, inclTx bool, chainConfig *chain.Config) (map[string]interface{}, error) {
 	additionalFields := make(map[string]interface{})
-	response, err := ethapi.RPCMarshalBlock(b, inclTx, inclTx, additionalFields)
+	response, err := ethapi.RPCMarshalBlock(b, inclTx, inclTx, additionalFields, chainConfig)
 	if !inclTx {
 		delete(response, "transactions") // workaround for https://github.com/erigontech/erigon/issues/4989#issuecomment-1218415666
 	}

--- a/rpc/jsonrpc/graphql_api.go
+++ b/rpc/jsonrpc/graphql_api.go
@@ -149,7 +149,7 @@ func (api *GraphQLAPIImpl) getBlockWithSenders(ctx context.Context, number rpc.B
 
 func (api *GraphQLAPIImpl) delegateGetBlockByNumber(tx kv.Tx, b *types.Block, number rpc.BlockNumber, inclTx bool, chainConfig *chain.Config) (map[string]interface{}, error) {
 	additionalFields := make(map[string]interface{})
-	response, err := ethapi.RPCMarshalBlock(b, inclTx, inclTx, additionalFields, chainConfig)
+	response, err := ethapi.RPCMarshalBlock(b, inclTx, inclTx, additionalFields, chainConfig.IsArbitrumNitro(b.Number()))
 	if !inclTx {
 		delete(response, "transactions") // workaround for https://github.com/erigontech/erigon/issues/4989#issuecomment-1218415666
 	}

--- a/rpc/jsonrpc/otterscan_api.go
+++ b/rpc/jsonrpc/otterscan_api.go
@@ -283,7 +283,7 @@ func (api *OtterscanAPIImpl) traceBlocks(ctx context.Context, addr common.Addres
 
 func delegateGetBlockByNumber(tx kv.Tx, b *types.Block, number rpc.BlockNumber, inclTx bool, chainConfig *chain.Config) (map[string]interface{}, error) {
 	additionalFields := make(map[string]interface{})
-	response, err := ethapi.RPCMarshalBlock(b, inclTx, inclTx, additionalFields, chainConfig)
+	response, err := ethapi.RPCMarshalBlock(b, inclTx, inclTx, additionalFields, chainConfig.IsArbitrumNitro(b.Number()))
 	if !inclTx {
 		delete(response, "transactions") // workaround for https://github.com/erigontech/erigon/issues/4989#issuecomment-1218415666
 	}

--- a/rpc/jsonrpc/otterscan_api.go
+++ b/rpc/jsonrpc/otterscan_api.go
@@ -281,9 +281,9 @@ func (api *OtterscanAPIImpl) traceBlocks(ctx context.Context, addr common.Addres
 	return results[:totalBlocksTraced], hasMore, nil
 }
 
-func delegateGetBlockByNumber(tx kv.Tx, b *types.Block, number rpc.BlockNumber, inclTx bool) (map[string]interface{}, error) {
+func delegateGetBlockByNumber(tx kv.Tx, b *types.Block, number rpc.BlockNumber, inclTx bool, chainConfig *chain.Config) (map[string]interface{}, error) {
 	additionalFields := make(map[string]interface{})
-	response, err := ethapi.RPCMarshalBlock(b, inclTx, inclTx, additionalFields)
+	response, err := ethapi.RPCMarshalBlock(b, inclTx, inclTx, additionalFields, chainConfig)
 	if !inclTx {
 		delete(response, "transactions") // workaround for https://github.com/erigontech/erigon/issues/4989#issuecomment-1218415666
 	}
@@ -403,7 +403,7 @@ func (api *OtterscanAPIImpl) GetBlockTransactions(ctx context.Context, number rp
 		return nil, err
 	}
 
-	getBlockRes, err := delegateGetBlockByNumber(tx, b, number, true)
+	getBlockRes, err := delegateGetBlockByNumber(tx, b, number, true, chainConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/jsonrpc/otterscan_block_details.go
+++ b/rpc/jsonrpc/otterscan_block_details.go
@@ -80,7 +80,7 @@ func (api *OtterscanAPIImpl) getBlockDetailsImpl(ctx context.Context, tx kv.Temp
 		return nil, err
 	}
 
-	getBlockRes, err := delegateGetBlockByNumber(tx, b, number, false)
+	getBlockRes, err := delegateGetBlockByNumber(tx, b, number, false, chainConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
https://github.com/erigontech/nitro-erigon/issues/154

adding support for 
`l1BlockNumber`, `sendCount`, `sendRoot`, as described in https://docs.arbitrum.io/build-decentralized-apps/arbitrum-vs-ethereum/rpc-methods#additional-fields-2

Additionally, for legacy Arbitrum Classic blocks, before Nitro, `sendCount` and `sendRoot` weren't used, `l1BlockNumber` was different, which is also implemented


