### PR TITLE
Add apply/async operations for transactions

### DIFF
--- a/erigon-lib/kv/kv_interface.go
+++ b/erigon-lib/kv/kv_interface.go
@@ -425,6 +425,8 @@ type Tx interface {
 	Count(bucket string) (uint64, error)
 
 	ListTables() ([]string, error)
+
+	Apply(ctx context.Context, f func(tx Tx) error) error
 }
 
 // RwTx
@@ -442,6 +444,8 @@ type RwTx interface {
 	RwCursorDupSort(table string) (RwCursorDupSort, error)
 
 	Commit() error // Commit all the operations of a transaction into the database.
+
+	ApplyRw(ctx context.Context, f func(tx RwTx) error) error
 }
 
 // Cursor - class for navigating through a database
@@ -583,8 +587,6 @@ type TemporalDebugTx interface {
 
 	DomainFiles(domain ...Domain) VisibleFiles
 
-	GreedyPruneHistory(ctx context.Context, domain Domain) error
-	PruneSmallBatches(ctx context.Context, timeout time.Duration) (haveMore bool, err error)
 	TxNumsInFiles(domains ...Domain) (minTxNum uint64)
 }
 
@@ -608,6 +610,8 @@ type TemporalRwTx interface {
 	TemporalTx
 	TemporalPutDel
 
+	GreedyPruneHistory(ctx context.Context, domain Domain) error
+	PruneSmallBatches(ctx context.Context, timeout time.Duration) (haveMore bool, err error)
 	Unwind(ctx context.Context, txNumUnwindTo uint64, changeset *[DomainLen][]DomainEntryDiff) error
 }
 

--- a/erigon-lib/kv/membatchwithdb/memory_mutation.go
+++ b/erigon-lib/kv/membatchwithdb/memory_mutation.go
@@ -701,6 +701,14 @@ func (m *MemoryMutation) Cursor(bucket string) (kv.Cursor, error) {
 	return m.makeCursor(bucket)
 }
 
+func (m *MemoryMutation) Apply(_ context.Context, f func(tx kv.Tx) error) error {
+	return f(m)
+}
+
+func (m *MemoryMutation) ApplyRw(_ context.Context,f func(tx kv.RwTx) error) error {
+	return f(m)
+}
+
 func (m *MemoryMutation) ViewID() uint64 {
 	panic("ViewID Not implemented")
 }

--- a/erigon-lib/kv/membatchwithdb/memory_mutation.go
+++ b/erigon-lib/kv/membatchwithdb/memory_mutation.go
@@ -705,7 +705,7 @@ func (m *MemoryMutation) Apply(_ context.Context, f func(tx kv.Tx) error) error 
 	return f(m)
 }
 
-func (m *MemoryMutation) ApplyRw(_ context.Context,f func(tx kv.RwTx) error) error {
+func (m *MemoryMutation) ApplyRw(_ context.Context, f func(tx kv.RwTx) error) error {
 	return f(m)
 }
 

--- a/erigon-lib/kv/remotedb/kv_remote.go
+++ b/erigon-lib/kv/remotedb/kv_remote.go
@@ -266,7 +266,7 @@ func (tx *tx) Rollback() {
 	}
 }
 
-func (tx *tx) Apply(ctx context.Context, f func(tx kv.Tx) error ) error {
+func (tx *tx) Apply(ctx context.Context, f func(tx kv.Tx) error) error {
 	return f(tx)
 }
 

--- a/erigon-lib/kv/remotedb/kv_remote.go
+++ b/erigon-lib/kv/remotedb/kv_remote.go
@@ -265,6 +265,11 @@ func (tx *tx) Rollback() {
 		c.Close()
 	}
 }
+
+func (tx *tx) Apply(ctx context.Context, f func(tx kv.Tx) error ) error {
+	return f(tx)
+}
+
 func (tx *tx) DBSize() (uint64, error) { panic("not implemented") }
 
 func (tx *tx) statelessCursor(bucket string) (kv.Cursor, error) {

--- a/erigon-lib/state/domain_shared.go
+++ b/erigon-lib/state/domain_shared.go
@@ -479,7 +479,7 @@ func (sd *SharedDomains) Flush(ctx context.Context, tx kv.RwTx) error {
 		}
 	}
 	if dbg.PruneOnFlushTimeout != 0 {
-		if _, err := tx.(kv.TemporalRwTx).Debug().PruneSmallBatches(ctx, dbg.PruneOnFlushTimeout); err != nil {
+		if _, err := tx.(kv.TemporalRwTx).PruneSmallBatches(ctx, dbg.PruneOnFlushTimeout); err != nil {
 			return err
 		}
 	}

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -767,11 +767,11 @@ Loop:
 				tt = time.Now()
 
 				// allow greedy prune on non-chain-tip
-				if err = executor.tx().(kv.TemporalRwTx).Debug().GreedyPruneHistory(ctx, kv.CommitmentDomain); err != nil {
+				if err = executor.tx().(kv.TemporalRwTx).GreedyPruneHistory(ctx, kv.CommitmentDomain); err != nil {
 					return err
 				}
 
-				if _, err := executor.tx().(kv.TemporalRwTx).Debug().PruneSmallBatches(ctx, 10*time.Hour); err != nil {
+				if _, err := executor.tx().(kv.TemporalRwTx).PruneSmallBatches(ctx, 10*time.Hour); err != nil {
 					return err
 				}
 				t3 = time.Since(tt)

--- a/eth/stagedsync/exec3_parallel.go
+++ b/eth/stagedsync/exec3_parallel.go
@@ -257,7 +257,7 @@ func (pe *parallelExecutor) rwLoop(ctx context.Context, maxTxNum uint64, logger 
 				if err != nil {
 					return err
 				}
-				if _, err := tx.(kv.TemporalRwTx).Debug().PruneSmallBatches(ctx, dbg.PruneOnFlushTimeout); err != nil {
+				if _, err := tx.(kv.TemporalRwTx).PruneSmallBatches(ctx, dbg.PruneOnFlushTimeout); err != nil {
 					return err
 				}
 				if !pe.inMemExec {

--- a/eth/stagedsync/stage_custom_trace.go
+++ b/eth/stagedsync/stage_custom_trace.go
@@ -268,10 +268,10 @@ func customTraceBatchProduce(ctx context.Context, produce Produce, cfg *exec3.Ex
 	}
 
 	if err := db.Update(ctx, func(tx kv.RwTx) error {
-		if err := tx.(kv.TemporalRwTx).Debug().GreedyPruneHistory(ctx, kv.CommitmentDomain); err != nil {
+		if err := tx.(kv.TemporalRwTx).GreedyPruneHistory(ctx, kv.CommitmentDomain); err != nil {
 			return err
 		}
-		if _, err := tx.(kv.TemporalRwTx).Debug().PruneSmallBatches(ctx, 10*time.Hour); err != nil {
+		if _, err := tx.(kv.TemporalRwTx).PruneSmallBatches(ctx, 10*time.Hour); err != nil {
 			return err
 		}
 		return nil

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -474,12 +474,12 @@ func PruneExecutionStage(s *PruneState, tx kv.RwTx, cfg ExecuteBlockCfg, ctx con
 		pruneTimeout = 12 * time.Hour
 
 		// allow greedy prune on non-chain-tip
-		if err = tx.(kv.TemporalRwTx).Debug().GreedyPruneHistory(ctx, kv.CommitmentDomain); err != nil {
+		if err = tx.(kv.TemporalRwTx).GreedyPruneHistory(ctx, kv.CommitmentDomain); err != nil {
 			return err
 		}
 	}
 
-	if _, err := tx.(kv.TemporalRwTx).Debug().PruneSmallBatches(ctx, pruneTimeout); err != nil {
+	if _, err := tx.(kv.TemporalRwTx).PruneSmallBatches(ctx, pruneTimeout); err != nil {
 		return err
 	}
 

--- a/eth/stagedsync/stage_snapshots.go
+++ b/eth/stagedsync/stage_snapshots.go
@@ -292,7 +292,7 @@ func DownloadAndIndexSnapshotsIfNeed(s *StageState, ctx context.Context, tx kv.R
 		return err
 	}
 
-	if temporal, ok := tx.(*temporal.Tx); ok {
+	if temporal, ok := tx.(*temporal.RwTx); ok {
 		temporal.ForceReopenAggCtx() // otherwise next stages will not see just-indexed-files
 	}
 
@@ -326,7 +326,7 @@ func DownloadAndIndexSnapshotsIfNeed(s *StageState, ctx context.Context, tx kv.R
 		return fmt.Errorf("FillDBFromSnapshots: %w", err)
 	}
 
-	if temporal, ok := tx.(*temporal.Tx); ok {
+	if temporal, ok := tx.(*temporal.RwTx); ok {
 		temporal.ForceReopenAggCtx() // otherwise next stages will not see just-indexed-files
 	}
 

--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -1795,13 +1795,13 @@ func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 
 	logger.Info("Prune state history")
 	if err := db.Update(ctx, func(tx kv.RwTx) error {
-		return tx.(kv.TemporalRwTx).Debug().GreedyPruneHistory(ctx, kv.CommitmentDomain)
+		return tx.(kv.TemporalRwTx).GreedyPruneHistory(ctx, kv.CommitmentDomain)
 	}); err != nil {
 		return err
 	}
 	for hasMoreToPrune := true; hasMoreToPrune; {
 		if err := db.Update(ctx, func(tx kv.RwTx) error {
-			hasMoreToPrune, err = tx.(kv.TemporalRwTx).Debug().PruneSmallBatches(ctx, 30*time.Second)
+			hasMoreToPrune, err = tx.(kv.TemporalRwTx).PruneSmallBatches(ctx, 30*time.Second)
 			return err
 		}); err != nil {
 			return err


### PR DESCRIPTION
This change adds an Apply(tx) function to transactions and an AsyncTx which uses a channel to pass the apply function between go-routines.

It is used to enable parallel workers to access the headers/blocks on the main RW execution thread, even with an external tx whilst maintaining their own read only transaction for state access.

There is an overhead in doing this - but so long as the main execution thread remains live in its wait loop this does not impact processing due to the relative rareness of these types of call from the evm.