### PR TITLE
Env vars to manage parallel execution and block tracing

### DIFF
--- a/erigon-lib/common/dbg/dbg_env.go
+++ b/erigon-lib/common/dbg/dbg_env.go
@@ -43,6 +43,23 @@ func EnvString(envVarName string, defaultVal string) string {
 	}
 	return defaultVal
 }
+
+func EnvStrings(envVarName string, sep string, defaultVal []string) []string {
+	v, _ := os.LookupEnv(envVarName)
+	if v != "" {
+		WarnOnErigonPrefix(envVarName)
+		log.Info("[env]", envVarName, v)
+		return strings.Split(v, sep)
+	}
+
+	v, _ = os.LookupEnv("ERIGON_" + envVarName)
+	if v != "" {
+		log.Info("[env]", envVarName, v)
+		return strings.Split(v, sep)
+	}
+	return defaultVal
+}
+
 func EnvBool(envVarName string, defaultVal bool) bool {
 	v, _ := os.LookupEnv(envVarName)
 	if v == "true" {
@@ -73,17 +90,84 @@ func EnvInt(envVarName string, defaultVal int) int {
 		WarnOnErigonPrefix(envVarName)
 		i := MustParseInt(v)
 		log.Info("[env]", envVarName, i)
-		return i
+		return int(i)
 	}
 
 	v, _ = os.LookupEnv("ERIGON_" + envVarName)
 	if v != "" {
 		i := MustParseInt(v)
 		log.Info("[env]", envVarName, i)
+		return int(i)
+	}
+	return defaultVal
+}
+
+func EnvUint(envVarName string, defaultVal uint64) uint64 {
+	v, _ := os.LookupEnv(envVarName)
+	if v != "" {
+		WarnOnErigonPrefix(envVarName)
+		i := MustParseUint(v)
+		log.Info("[env]", envVarName, i)
+		return i
+	}
+
+	v, _ = os.LookupEnv("ERIGON_" + envVarName)
+	if v != "" {
+		i := MustParseUint(v)
+		log.Info("[env]", envVarName, i)
 		return i
 	}
 	return defaultVal
 }
+
+func EnvInts(envVarName string, sep string, defaultVal []int64) []int64 {
+	v, _ := os.LookupEnv(envVarName)
+	if v != "" {
+		WarnOnErigonPrefix(envVarName)
+		log.Info("[env]", envVarName, v)
+		var ints []int64
+		for _, str := range strings.Split(v, sep) {
+			ints = append(ints, MustParseInt(str))
+		}
+		return ints
+	}
+
+	v, _ = os.LookupEnv("ERIGON_" + envVarName)
+	if v != "" {
+		log.Info("[env]", envVarName, v)
+		var ints []int64
+		for _, str := range strings.Split(v, sep) {
+			ints = append(ints, MustParseInt(str))
+		}
+		return ints
+	}
+	return defaultVal
+}
+
+func EnvUints(envVarName string, sep string, defaultVal []uint64) []uint64 {
+	v, _ := os.LookupEnv(envVarName)
+	if v != "" {
+		WarnOnErigonPrefix(envVarName)
+		log.Info("[env]", envVarName, v)
+		var ints []uint64
+		for _, str := range strings.Split(v, sep) {
+			ints = append(ints, MustParseUint(str))
+		}
+		return ints
+	}
+
+	v, _ = os.LookupEnv("ERIGON_" + envVarName)
+	if v != "" {
+		log.Info("[env]", envVarName, v)
+		var ints []uint64
+		for _, str := range strings.Split(v, sep) {
+			ints = append(ints, MustParseUint(str))
+		}
+		return ints
+	}
+	return defaultVal
+}
+
 func EnvDataSize(envVarName string, defaultVal datasize.ByteSize) datasize.ByteSize {
 	v, _ := os.LookupEnv(envVarName)
 	if v != "" {
@@ -137,11 +221,20 @@ func WarnOnErigonPrefix(envVarName string) {
 	}
 }
 
-func MustParseInt(strNum string) int {
+func MustParseInt(strNum string) int64 {
 	cleanNum := strings.ReplaceAll(strNum, "_", "")
 	parsed, err := strconv.ParseInt(cleanNum, 10, 64)
 	if err != nil {
 		panic(fmt.Errorf("%w, str: %s", err, strNum))
 	}
-	return int(parsed)
+	return parsed
+}
+
+func MustParseUint(strNum string) uint64 {
+	cleanNum := strings.ReplaceAll(strNum, "_", "")
+	parsed, err := strconv.ParseUint(cleanNum, 10, 64)
+	if err != nil {
+		panic(fmt.Errorf("%w, str: %s", err, strNum))
+	}
+	return parsed
 }

--- a/erigon-lib/common/dbg/experiments.go
+++ b/erigon-lib/common/dbg/experiments.go
@@ -69,6 +69,21 @@ var (
 	CommitEachStage = EnvBool("COMMIT_EACH_STAGE", false)
 
 	CaplinSyncedDataMangerDeadlockDetection = EnvBool("CAPLIN_SYNCED_DATA_MANAGER_DEADLOCK_DETECTION", false)
+
+	Exec3Parallel = EnvBool("EXEC3_PARALLEL", false)
+	numWorkers    = runtime.NumCPU() / 2
+	Exec3Workers  = EnvInt("EXEC3_WORKERS", numWorkers)
+
+	TraceAccounts        = EnvStrings("TRACE_ACCOUNTS", ",", nil)
+	TraceStateKeys       = EnvStrings("TRACE_STATE_KEYS", ",", nil)
+	TraceInstructions    = EnvBool("TRACE_INSTRUCTIONS", false)
+	TraceTransactionIO   = EnvBool("TRACE_TRANSACTION_IO", false)
+	TraceBlocks          = EnvUints("TRACE_BLOCKS", ",", nil)
+	TraceTxIndexes       = EnvInts("TRACE_TRANSACTIONS", ",", nil)
+	StopAfterBlock       = EnvUint("STOP_AFTER_BLOCK", 0)
+	BatchCommitments     = EnvBool("BATCH_COMMITMENTS", true)
+	CaplinEfficientReorg = EnvBool("CAPLIN_EFFICIENT_REORG", true)
+	UseTxDependencies    = EnvBool("USE_TX_DEPENDENCIES", false)
 )
 
 func ReadMemStats(m *runtime.MemStats) {

--- a/erigon-lib/common/dbg/leak_detector.go
+++ b/erigon-lib/common/dbg/leak_detector.go
@@ -57,12 +57,9 @@ func NewLeakDetector(name string, slowThreshold time.Duration) *LeakDetector {
 		logEvery := time.NewTicker(60 * time.Second)
 		defer logEvery.Stop()
 
-		for {
-			select {
-			case <-logEvery.C:
-				if list := d.slowList(); len(list) > 0 {
-					log.Info(fmt.Sprintf("[dbg.%s] long living resources", name), "list", strings.Join(d.slowList(), ", "))
-				}
+		for range logEvery.C {
+			if list := d.slowList(); len(list) > 0 {
+				log.Info(fmt.Sprintf("[dbg.%s] long living resources", name), "list", strings.Join(d.slowList(), ", "))
 			}
 		}
 	}()


### PR DESCRIPTION
This is support for the implementation of parallel processing.  Most of it is to enable environmental management of various levels of block tracing to work out the route cause of state root mismatches in parallel execution vs the serial flow. 