### PR TITLE
ci: fix and enable TestEthSubscribe

### DIFF
--- a/rpc/jsonrpc/eth_subscribe_test.go
+++ b/rpc/jsonrpc/eth_subscribe_test.go
@@ -18,7 +18,7 @@ package jsonrpc
 
 import (
 	"context"
-	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -40,7 +40,6 @@ import (
 )
 
 func TestEthSubscribe(t *testing.T) {
-	t.Skip("issue #14546")
 	m, require := mock.Mock(t), require.New(t)
 	chain, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 7, func(i int, b *core.BlockGen) {
 		b.SetCoinbase(common.Address{1})
@@ -57,14 +56,23 @@ func TestEthSubscribe(t *testing.T) {
 	for _, err = range m.Send(&sentry.InboundMessage{Id: sentry.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
 		require.NoError(err)
 	}
-	m.ReceiveWg.Wait() // Wait for all messages to be processed before we proceeed
+	m.ReceiveWg.Wait() // Wait for all messages to be processed before we proceed
 
 	ctx := context.Background()
 	logger := log.New()
 	backendServer := privateapi.NewEthBackendServer(ctx, nil, m.DB, m.Notifications, m.BlockReader, logger, builder.NewLatestBlockBuiltStore(), nil)
 	backendClient := direct.NewEthBackendClientDirect(backendServer)
 	backend := rpcservices.NewRemoteBackend(backendClient, m.DB, m.BlockReader)
-	ff := rpchelper.New(ctx, rpchelper.DefaultFiltersConfig, backend, nil, nil, func() {}, m.Log)
+	// Creating a new filter will set up new internal subscription channels actively managed by subscription tasks.
+	// We must wait for the first NEW_SNAPSHOT notification, which is always sent unconditionally by EthBackendServer
+	// at the start of Subscribe, to be sure that the subscription is ready, otherwise we could miss some events.
+	subscriptionReadyWg := sync.WaitGroup{}
+	subscriptionReadyWg.Add(1)
+	onNewSnapshot := func() {
+		subscriptionReadyWg.Done()
+	}
+	ff := rpchelper.New(ctx, rpchelper.DefaultFiltersConfig, backend, nil, nil, onNewSnapshot, m.Log)
+	subscriptionReadyWg.Wait() // This is needed *before* stages.StageLoopIteration, which sends NEW_HEADER events
 
 	newHeads, id := ff.SubscribeNewHeads(16)
 	defer ff.UnsubscribeHeads(id)
@@ -79,7 +87,6 @@ func TestEthSubscribe(t *testing.T) {
 
 	for i := uint64(1); i <= highestSeenHeader; i++ {
 		header := <-newHeads
-		fmt.Printf("Got header %d\n", header.Number.Uint64())
 		require.Equal(i, header.Number.Uint64())
 	}
 }

--- a/turbo/privateapi/ethbackend.go
+++ b/turbo/privateapi/ethbackend.go
@@ -104,7 +104,7 @@ func NewEthBackendServer(ctx context.Context, eth EthBackend, db kv.RwDB, notifi
 		defer func() {
 			if err != nil {
 				if !errors.Is(err, context.Canceled) {
-					logger.Warn("[rpc] terminted subscription to `logs` events", "reason", err)
+					logger.Warn("[rpc] terminated subscription to `logs` events", "reason", err)
 				}
 			}
 		}()
@@ -237,7 +237,7 @@ func (s *EthBackendServer) Subscribe(r *remote.SubscribeRequest, subscribeServer
 	defer func() {
 		if err != nil {
 			if !errors.Is(err, context.Canceled) {
-				s.logger.Warn("[rpc] terminted subscription to `newHeaders` events", "reason", err)
+				s.logger.Warn("[rpc] terminated subscription to `newHeaders` events", "reason", err)
 			}
 		}
 	}()


### PR DESCRIPTION
Fixes #14546 

The main task executing `TestEthSubscribe` sporadically gets blocked waiting for new headers in case the anonymous task created and started in `rpchelper.New` running the subscription loop has not yet reached the `Subscribe` call, when `stages.StageLoopIteration` completes its execution. In such a case, the internal subscription channels in `Events` have not been created yet and thus the NEW_HEADER notifications are not sent.

A simple solution, not touching the production code, is relying on the initial NEW_SNAPSHOT notification that is sent unconditionally by `EthBackendServer` after creating the internal subscription channels.
