### PR TITLE
Add Instruction printer

### DIFF
--- a/core/state/intra_block_state.go
+++ b/core/state/intra_block_state.go
@@ -126,6 +126,18 @@ func (sdb *IntraBlockState) SetTrace(trace bool) {
 	sdb.trace = trace
 }
 
+func (sdb *IntraBlockState) Trace() bool {
+	return sdb.trace
+}
+
+func (sdb *IntraBlockState) TxIndex() int {
+	return sdb.txIndex
+}
+
+func (sdb *IntraBlockState) Incarnation() int {
+	return 0
+}
+
 // setErrorUnsafe sets error but should be called in medhods that already have locks
 // Deprecated: The IBS api now returns errors directly
 func (sdb *IntraBlockState) setErrorUnsafe(err error) {

--- a/core/vm/evmtypes/evmtypes.go
+++ b/core/vm/evmtypes/evmtypes.go
@@ -178,4 +178,7 @@ type IntraBlockState interface {
 	AddLog(*types.Log)
 
 	SetHooks(hooks *tracing.Hooks)
+	Trace() bool
+	TxIndex() int
+	Incarnation() int
 }

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -40,10 +40,20 @@ func opAdd(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte
 	return nil, nil
 }
 
+func stAdd(_ uint64, scope *ScopeContext) string {
+	x, y := scope.Stack.data[len(scope.Stack.data)-1], scope.Stack.data[len(scope.Stack.data)-2]
+	return fmt.Sprintf("%s %d %d", ADD, &x, &y)
+}
+
 func opSub(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	x, y := scope.Stack.pop(), scope.Stack.peek()
 	y.Sub(&x, y)
 	return nil, nil
+}
+
+func stSub(_ uint64, scope *ScopeContext) string {
+	x, y := scope.Stack.data[len(scope.Stack.data)-1], scope.Stack.data[len(scope.Stack.data)-2]
+	return fmt.Sprintf("%s %d %d", SUB, &x, &y)
 }
 
 func opMul(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -52,10 +62,20 @@ func opMul(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte
 	return nil, nil
 }
 
+func stMul(_ uint64, scope *ScopeContext) string {
+	x, y := scope.Stack.data[len(scope.Stack.data)-1], scope.Stack.data[len(scope.Stack.data)-2]
+	return fmt.Sprintf("%s %d %d", MUL, &x, &y)
+}
+
 func opDiv(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	x, y := scope.Stack.pop(), scope.Stack.peek()
 	y.Div(&x, y)
 	return nil, nil
+}
+
+func stDiv(_ uint64, scope *ScopeContext) string {
+	x, y := scope.Stack.data[len(scope.Stack.data)-1], scope.Stack.data[len(scope.Stack.data)-2]
+	return fmt.Sprintf("%s %d %d", DIV, &x, &y)
 }
 
 func opSdiv(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -64,16 +84,31 @@ func opSdiv(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 	return nil, nil
 }
 
+func stSdiv(_ uint64, scope *ScopeContext) string {
+	x, y := scope.Stack.data[len(scope.Stack.data)-1], scope.Stack.data[len(scope.Stack.data)-2]
+	return fmt.Sprintf("%s %d %d", SDIV, &x, &y)
+}
+
 func opMod(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	x, y := scope.Stack.pop(), scope.Stack.peek()
 	y.Mod(&x, y)
 	return nil, nil
 }
 
+func stMod(_ uint64, scope *ScopeContext) string {
+	x, y := scope.Stack.data[len(scope.Stack.data)-1], scope.Stack.data[len(scope.Stack.data)-2]
+	return fmt.Sprintf("%s %d %d", MOD, &x, &y)
+}
+
 func opSmod(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	x, y := scope.Stack.pop(), scope.Stack.peek()
 	y.SMod(&x, y)
 	return nil, nil
+}
+
+func stSmod(_ uint64, scope *ScopeContext) string {
+	x, y := scope.Stack.data[len(scope.Stack.data)-1], scope.Stack.data[len(scope.Stack.data)-2]
+	return fmt.Sprintf("%s %d %d", SMOD, &x, &y)
 }
 
 func opExp(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -117,6 +152,11 @@ func opNot(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte
 	return nil, nil
 }
 
+func stNot(_ uint64, scope *ScopeContext) string {
+	x := scope.Stack.peek()
+	return fmt.Sprintf("%s %d", NOT.String(), x)
+}
+
 func opLt(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	x, y := scope.Stack.pop(), scope.Stack.peek()
 	if x.Lt(y) {
@@ -125,6 +165,11 @@ func opLt(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte,
 		y.Clear()
 	}
 	return nil, nil
+}
+
+func stLt(_ uint64, scope *ScopeContext) string {
+	x, y := scope.Stack.data[len(scope.Stack.data)-1], scope.Stack.data[len(scope.Stack.data)-2]
+	return fmt.Sprintf("%s %d %d", LT, &x, &y)
 }
 
 func opGt(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -137,6 +182,11 @@ func opGt(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte,
 	return nil, nil
 }
 
+func stGt(_ uint64, scope *ScopeContext) string {
+	x, y := scope.Stack.data[len(scope.Stack.data)-1], scope.Stack.data[len(scope.Stack.data)-2]
+	return fmt.Sprintf("%s %d %d", GT, &x, &y)
+}
+
 func opSlt(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	x, y := scope.Stack.pop(), scope.Stack.peek()
 	if x.Slt(y) {
@@ -145,6 +195,11 @@ func opSlt(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte
 		y.Clear()
 	}
 	return nil, nil
+}
+
+func stSlt(_ uint64, scope *ScopeContext) string {
+	x, y := scope.Stack.data[len(scope.Stack.data)-1], scope.Stack.data[len(scope.Stack.data)-2]
+	return fmt.Sprintf("%s %d %d", SLT, &x, &y)
 }
 
 func opSgt(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -157,6 +212,11 @@ func opSgt(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte
 	return nil, nil
 }
 
+func stSgt(_ uint64, scope *ScopeContext) string {
+	x, y := scope.Stack.data[len(scope.Stack.data)-1], scope.Stack.data[len(scope.Stack.data)-2]
+	return fmt.Sprintf("%s %d %d", SLT, &x, &y)
+}
+
 func opEq(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	x, y := scope.Stack.pop(), scope.Stack.peek()
 	if x.Eq(y) {
@@ -165,6 +225,11 @@ func opEq(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte,
 		y.Clear()
 	}
 	return nil, nil
+}
+
+func stEq(_ uint64, scope *ScopeContext) string {
+	x, y := scope.Stack.data[len(scope.Stack.data)-1], scope.Stack.data[len(scope.Stack.data)-2]
+	return fmt.Sprintf("%s %d %d", EQ, &x, &y)
 }
 
 func opIszero(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -177,10 +242,20 @@ func opIszero(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 	return nil, nil
 }
 
+func stIsZero(_ uint64, scope *ScopeContext) string {
+	x := scope.Stack.data[len(scope.Stack.data)-1]
+	return fmt.Sprintf("%s %d", ISZERO, &x)
+}
+
 func opAnd(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	x, y := scope.Stack.pop(), scope.Stack.peek()
 	y.And(&x, y)
 	return nil, nil
+}
+
+func stAnd(_ uint64, scope *ScopeContext) string {
+	x, y := scope.Stack.data[len(scope.Stack.data)-1], scope.Stack.data[len(scope.Stack.data)-2]
+	return fmt.Sprintf("%s %d %d", AND, &x, &y)
 }
 
 func opOr(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -189,10 +264,20 @@ func opOr(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte,
 	return nil, nil
 }
 
+func stOr(_ uint64, scope *ScopeContext) string {
+	x, y := scope.Stack.data[len(scope.Stack.data)-1], scope.Stack.data[len(scope.Stack.data)-2]
+	return fmt.Sprintf("%s %d %d", OR, &x, &y)
+}
+
 func opXor(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	x, y := scope.Stack.pop(), scope.Stack.peek()
 	y.Xor(&x, y)
 	return nil, nil
+}
+
+func stXor(_ uint64, scope *ScopeContext) string {
+	x, y := scope.Stack.data[len(scope.Stack.data)-1], scope.Stack.data[len(scope.Stack.data)-2]
+	return fmt.Sprintf("%s %d %d", XOR, &x, &y)
 }
 
 func opByte(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -207,10 +292,20 @@ func opAddmod(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 	return nil, nil
 }
 
+func stAddmod(_ uint64, scope *ScopeContext) string {
+	x, y, z := scope.Stack.data[len(scope.Stack.data)-1], scope.Stack.data[len(scope.Stack.data)-2], scope.Stack.data[len(scope.Stack.data)-3]
+	return fmt.Sprintf("%s %d %d %d", ADDMOD, &x, &y, &z)
+}
+
 func opMulmod(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	x, y, z := scope.Stack.pop(), scope.Stack.pop(), scope.Stack.peek()
 	z.MulMod(&x, &y, z)
 	return nil, nil
+}
+
+func stMulmod(_ uint64, scope *ScopeContext) string {
+	x, y, z := scope.Stack.data[len(scope.Stack.data)-1], scope.Stack.data[len(scope.Stack.data)-2], scope.Stack.data[len(scope.Stack.data)-3]
+	return fmt.Sprintf("%s %d %d %d", MULMOD, &x, &y, &z)
 }
 
 // opSHL implements Shift Left
@@ -294,11 +389,12 @@ func opBalance(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 }
 
 func opOrigin(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	scope.Stack.push(new(uint256.Int).SetBytes(interpreter.evm.Origin.Bytes()))
+	scope.Stack.push(new(uint256.Int).SetBytes(interpreter.evm.Origin[:]))
 	return nil, nil
 }
 func opCaller(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	scope.Stack.push(new(uint256.Int).SetBytes(scope.Contract.Caller().Bytes()))
+	caller := scope.Contract.Caller()
+	scope.Stack.push(new(uint256.Int).SetBytes(caller[:]))
 	return nil, nil
 }
 
@@ -318,9 +414,23 @@ func opCallDataLoad(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 	return nil, nil
 }
 
+func stCallDataLoad(_ uint64, scope *ScopeContext) string {
+	x := *scope.Stack.peek()
+	var data []byte
+	if offset, overflow := x.Uint64WithOverflow(); !overflow {
+		data = getData(scope.Contract.Input, offset, 32)
+	}
+
+	return fmt.Sprintf("%s %d (%x)", CALLDATALOAD, &x, data)
+}
+
 func opCallDataSize(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	scope.Stack.push(new(uint256.Int).SetUint64(uint64(len(scope.Contract.Input))))
 	return nil, nil
+}
+
+func stCallDataSize(_ uint64, scope *ScopeContext) string {
+	return fmt.Sprintf("%s (%d)", CALLDATASIZE, new(uint256.Int).SetUint64(uint64(len(scope.Contract.Input))))
 }
 
 func opCallDataCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -338,6 +448,19 @@ func opCallDataCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 	length64 := length.Uint64()
 	scope.Memory.Set(memOffset64, length64, getData(scope.Contract.Input, dataOffset64, length64))
 	return nil, nil
+}
+
+func stCallDataCopy(_ uint64, scope *ScopeContext) string {
+	var (
+		memOffset  = scope.Stack.data[len(scope.Stack.data)-1]
+		dataOffset = scope.Stack.data[len(scope.Stack.data)-2]
+		length     = scope.Stack.data[len(scope.Stack.data)-3]
+	)
+	dataOffset64, overflow := dataOffset.Uint64WithOverflow()
+	if overflow {
+		dataOffset64 = math.MaxUint64
+	}
+	return fmt.Sprintf("%s %d %d %d (%x)", CALLDATACOPY, memOffset.Uint64(), dataOffset64, length.Uint64(), getData(scope.Contract.Input, dataOffset64, length.Uint64()))
 }
 
 func opReturnDataSize(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -369,6 +492,33 @@ func opReturnDataCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeConte
 	}
 	scope.Memory.Set(memOffset.Uint64(), length.Uint64(), interpreter.returnData[offset64:end64])
 	return nil, nil
+}
+
+func stReturnDataCopy(_ uint64, scope *ScopeContext) string {
+	var (
+		memOffset  = scope.Stack.data[len(scope.Stack.data)-1]
+		dataOffset = scope.Stack.data[len(scope.Stack.data)-2]
+		length     = scope.Stack.data[len(scope.Stack.data)-3]
+	)
+
+	offset64, overflow := dataOffset.Uint64WithOverflow()
+	if overflow {
+		return fmt.Sprintf("%s %d %d %d (%s)", RETURNDATACOPY, memOffset.Uint64(), offset64, length.Uint64(), ErrReturnDataOutOfBounds)
+	}
+	// we can reuse dataOffset now (aliasing it for clarity)
+	end := dataOffset
+	_, overflow = end.AddOverflow(&dataOffset, &length)
+	if overflow {
+		return fmt.Sprintf("%s %d %d %d (%s)", RETURNDATACOPY, memOffset.Uint64(), offset64, length.Uint64(), ErrReturnDataOutOfBounds)
+	}
+
+	//end64, overflow := end.Uint64WithOverflow()
+	//if overflow || uint64(len(interpreter.returnData)) < end64 {
+	//	return fmt.Sprintf("%s %d %d %d (%s)", RETURNDATACOPY, memOffset.Uint64(), offset64, length.Uint64(), ErrReturnDataOutOfBounds)
+	//}
+
+	// return fmt.Sprintf("%s %d %d %d (%x)", RETURNDATACOPY, memOffset.Uint64(), offset64, length.Uint64(), interpreter.returnData[offset64:end64])
+	return fmt.Sprintf("%s %d %d %d", RETURNDATACOPY, memOffset.Uint64(), offset64, length.Uint64())
 }
 
 func opExtCodeSize(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -504,11 +654,23 @@ func opBlockhash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) (
 		lower = upper - params.BlockHashOldWindow
 	}
 	if arg64 >= lower && arg64 < upper {
-		arg.SetBytes(interpreter.evm.Context.GetHash(arg64).Bytes())
+		hash := interpreter.evm.Context.GetHash(arg64)
+		// TODO uncomment after GetHash with error checkin
+		//if err != nil {
+		//	arg.Clear()
+		//	return nil, err
+		//}
+		arg.SetBytes(hash.Bytes())
 	} else {
 		arg.Clear()
 	}
+
 	return nil, nil
+}
+
+func stBlockhash(_ uint64, scope *ScopeContext) string {
+	x := *scope.Stack.peek()
+	return fmt.Sprintf("%s %d", BLOCKHASH, &x)
 }
 
 func opCoinbase(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -565,10 +727,21 @@ func opMload(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 	return nil, nil
 }
 
+func stMload(_ uint64, scope *ScopeContext) string {
+	v := scope.Stack.peek()
+	offset := v.Uint64()
+	return fmt.Sprintf("%s %d (%d)", MLOAD, offset, (&uint256.Int{}).SetBytes(scope.Memory.GetPtr(offset, 32)))
+}
+
 func opMstore(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	mStart, val := scope.Stack.pop(), scope.Stack.pop()
 	scope.Memory.Set32(mStart.Uint64(), &val)
 	return nil, nil
+}
+
+func stMstore(_ uint64, scope *ScopeContext) string {
+	mStart, val := scope.Stack.data[len(scope.Stack.data)-1], scope.Stack.data[len(scope.Stack.data)-2]
+	return fmt.Sprintf("%s %d %d", MSTORE, mStart.Uint64(), &val)
 }
 
 func opMstore8(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -579,8 +752,13 @@ func opMstore8(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 
 func opSload(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	loc := scope.Stack.peek()
-	interpreter.hasherBuf = loc.Bytes32()
-	return nil, interpreter.evm.IntraBlockState().GetState(scope.Contract.Address(), interpreter.hasherBuf, loc)
+	err := interpreter.evm.IntraBlockState().GetState(scope.Contract.Address(), loc.Bytes32(), loc)
+	return nil, err
+}
+
+func stSload(_ uint64, scope *ScopeContext) string {
+	loc := scope.Stack.peek()
+	return fmt.Sprintf("%s %d", SLOAD, loc)
 }
 
 func opSstore(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -589,8 +767,12 @@ func opSstore(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 	}
 	loc := scope.Stack.pop()
 	val := scope.Stack.pop()
-	interpreter.hasherBuf = loc.Bytes32()
-	return nil, interpreter.evm.IntraBlockState().SetState(scope.Contract.Address(), interpreter.hasherBuf, val)
+	return nil, interpreter.evm.IntraBlockState().SetState(scope.Contract.Address(), loc.Bytes32(), val)
+}
+
+func stSstore(_ uint64, scope *ScopeContext) string {
+	loc, val := scope.Stack.data[len(scope.Stack.data)-1], scope.Stack.data[len(scope.Stack.data)-2]
+	return fmt.Sprintf("%s %d %d", SSTORE, &loc, &val)
 }
 
 func opJump(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -613,6 +795,11 @@ func opJump(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 	}
 	*pc = pos.Uint64() - 1 // pc will be increased by the interpreter loop
 	return nil, nil
+}
+
+func stJump(_ uint64, scope *ScopeContext) string {
+	pos := scope.Stack.peek()
+	return fmt.Sprintf("%s %d", JUMP, pos)
 }
 
 func opJumpi(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -639,6 +826,11 @@ func opJumpi(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 	return nil, nil
 }
 
+func stJumpi(_ uint64, scope *ScopeContext) string {
+	pos, cond := scope.Stack.data[len(scope.Stack.data)-1], scope.Stack.data[len(scope.Stack.data)-2]
+	return fmt.Sprintf("%s %v %d", JUMPI, !cond.IsZero(), &pos)
+}
+
 func opJumpdest(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	return nil, nil
 }
@@ -646,6 +838,10 @@ func opJumpdest(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 func opPc(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	scope.Stack.push(new(uint256.Int).SetUint64(*pc))
 	return nil, nil
+}
+
+func stPc(pc uint64, scope *ScopeContext) string {
+	return fmt.Sprintf("%s %d", PC, pc)
 }
 
 func opMsize(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -846,6 +1042,7 @@ func opCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 	}
 	stack.push(&temp)
 	if err == nil || err == ErrExecutionReverted {
+		ret = common.CopyBytes(ret)
 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
 	}
 
@@ -853,6 +1050,16 @@ func opCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 
 	interpreter.returnData = ret
 	return ret, nil
+}
+
+func stCall(_ uint64, scope *ScopeContext) string {
+	stack := scope.Stack
+	addr, _, inOffset, inSize := stack.data[len(stack.data)-2], stack.data[len(stack.data)-3], stack.data[len(stack.data)-4], stack.data[len(stack.data)-5]
+	toAddr := common.Address(addr.Bytes20())
+	// Get the arguments from the memory.
+	args := scope.Memory.GetPtr(inOffset.Uint64(), inSize.Uint64())
+
+	return fmt.Sprintf("%s %x %x", CALL.String(), toAddr, args)
 }
 
 func opCallCode(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -879,6 +1086,7 @@ func opCallCode(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 	}
 	stack.push(&temp)
 	if err == nil || err == ErrExecutionReverted {
+		ret = common.CopyBytes(ret)
 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
 	}
 
@@ -886,6 +1094,16 @@ func opCallCode(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 
 	interpreter.returnData = ret
 	return ret, nil
+}
+
+func stCallCode(_ uint64, scope *ScopeContext) string {
+	stack := scope.Stack
+	addr, _, inOffset, inSize := stack.data[len(stack.data)-2], stack.data[len(stack.data)-3], stack.data[len(stack.data)-4], stack.data[len(stack.data)-5]
+	toAddr := common.Address(addr.Bytes20())
+	// Get the arguments from the memory.
+	args := scope.Memory.GetPtr(inOffset.Uint64(), inSize.Uint64())
+
+	return fmt.Sprintf("%s %x %x", CALLCODE.String(), toAddr, args)
 }
 
 func opDelegateCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -908,6 +1126,7 @@ func opDelegateCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 	}
 	stack.push(&temp)
 	if err == nil || err == ErrExecutionReverted {
+		ret = common.CopyBytes(ret)
 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
 	}
 
@@ -915,6 +1134,16 @@ func opDelegateCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 
 	interpreter.returnData = ret
 	return ret, nil
+}
+
+func stDelegateCall(_ uint64, scope *ScopeContext) string {
+	stack := scope.Stack
+	addr, _, inOffset, inSize := stack.data[len(stack.data)-2], stack.data[len(stack.data)-3], stack.data[len(stack.data)-4], stack.data[len(stack.data)-5]
+	toAddr := common.Address(addr.Bytes20())
+	// Get the arguments from the memory.
+	args := scope.Memory.GetPtr(inOffset.Uint64(), inSize.Uint64())
+
+	return fmt.Sprintf("%s %x %x", DELEGATECALL.String(), toAddr, args)
 }
 
 func opStaticCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -937,6 +1166,7 @@ func opStaticCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) 
 	}
 	stack.push(&temp)
 	if err == nil || err == ErrExecutionReverted {
+		ret = common.CopyBytes(ret)
 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
 	}
 
@@ -944,6 +1174,16 @@ func opStaticCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) 
 
 	interpreter.returnData = ret
 	return ret, nil
+}
+
+func stStaticCall(_ uint64, scope *ScopeContext) string {
+	stack := scope.Stack
+	addr, inOffset, inSize := stack.data[len(stack.data)-2], stack.data[len(stack.data)-3], stack.data[len(stack.data)-4]
+	toAddr := common.Address(addr.Bytes20())
+	// Get arguments from the memory.
+	args := scope.Memory.GetPtr(inOffset.Uint64(), inSize.Uint64())
+
+	return fmt.Sprintf("%s %x %x", STATICCALL.String(), toAddr, args)
 }
 
 func opReturn(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -979,11 +1219,10 @@ func opSelfdestruct(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 		return nil, err
 	}
 
-	balanceVal := *balance
 	interpreter.evm.IntraBlockState().AddBalance(beneficiaryAddr, balance, tracing.BalanceIncreaseSelfdestruct)
 	interpreter.evm.IntraBlockState().Selfdestruct(callerAddr)
 	if interpreter.evm.Config().Tracer != nil && interpreter.evm.Config().Tracer.OnEnter != nil {
-		interpreter.evm.Config().Tracer.OnEnter(interpreter.depth, byte(SELFDESTRUCT), scope.Contract.Address(), beneficiary.Bytes20(), false, []byte{}, 0, &balanceVal, nil)
+		interpreter.evm.Config().Tracer.OnEnter(interpreter.depth, byte(SELFDESTRUCT), scope.Contract.Address(), beneficiary.Bytes20(), false, []byte{}, 0, balance, nil)
 	}
 	if interpreter.evm.Config().Tracer != nil && interpreter.evm.Config().Tracer.OnExit != nil {
 		interpreter.evm.Config().Tracer.OnExit(interpreter.depth, []byte{}, 0, nil, false)
@@ -998,16 +1237,15 @@ func opSelfdestruct6780(pc *uint64, interpreter *EVMInterpreter, scope *ScopeCon
 	beneficiary := scope.Stack.pop()
 	callerAddr := scope.Contract.Address()
 	beneficiaryAddr := common.Address(beneficiary.Bytes20())
-	pbalance, err := interpreter.evm.IntraBlockState().GetBalance(callerAddr)
+	balance, err := interpreter.evm.IntraBlockState().GetBalance(callerAddr)
 	if err != nil {
 		return nil, err
 	}
-	balance := *pbalance
-	interpreter.evm.IntraBlockState().SubBalance(callerAddr, &balance, tracing.BalanceDecreaseSelfdestruct)
-	interpreter.evm.IntraBlockState().AddBalance(beneficiaryAddr, &balance, tracing.BalanceIncreaseSelfdestruct)
+	interpreter.evm.IntraBlockState().SubBalance(callerAddr, balance, tracing.BalanceDecreaseSelfdestruct)
+	interpreter.evm.IntraBlockState().AddBalance(beneficiaryAddr, balance, tracing.BalanceIncreaseSelfdestruct)
 	interpreter.evm.IntraBlockState().Selfdestruct6780(callerAddr)
 	if interpreter.evm.Config().Tracer != nil && interpreter.evm.Config().Tracer.OnEnter != nil {
-		interpreter.cfg.Tracer.OnEnter(interpreter.depth, byte(SELFDESTRUCT), scope.Contract.Address(), beneficiary.Bytes20(), false, []byte{}, 0, &balance, nil)
+		interpreter.cfg.Tracer.OnEnter(interpreter.depth, byte(SELFDESTRUCT), scope.Contract.Address(), beneficiary.Bytes20(), false, []byte{}, 0, balance, nil)
 	}
 	if interpreter.evm.Config().Tracer != nil && interpreter.evm.Config().Tracer.OnExit != nil {
 		interpreter.cfg.Tracer.OnExit(interpreter.depth, []byte{}, 0, nil, false)
@@ -1060,12 +1298,26 @@ func opPush1(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 	return nil, nil
 }
 
+func stPush1(pc uint64, scope *ScopeContext) string {
+	var (
+		codeLen = uint64(len(scope.Contract.Code))
+		integer = new(uint256.Int)
+	)
+	pc++
+	if pc < codeLen {
+		return fmt.Sprintf("%s %d", PUSH1.String(), integer.SetUint64(uint64(scope.Contract.Code[pc])))
+	}
+
+	return fmt.Sprintf("%s %d", PUSH1.String(), integer.Clear())
+}
+
 // opPush2 is a specialized version of pushN
 func opPush2(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	var (
 		codeLen = uint64(len(scope.Contract.Code))
 		integer = new(uint256.Int)
 	)
+
 	if *pc+2 < codeLen {
 		scope.Stack.push(integer.SetBytes2(scope.Contract.Code[*pc+1 : *pc+3]))
 	} else if *pc+1 < codeLen {
@@ -1101,10 +1353,41 @@ func makePush(size uint64, pushByteSize int) executionFunc {
 	}
 }
 
+func makePushStringer(size uint64, pushByteSize int) stringer {
+	return func(pc uint64, scope *ScopeContext) string {
+		codeLen := len(scope.Contract.Code)
+
+		startMin := int(pc + 1)
+		if startMin >= codeLen {
+			startMin = codeLen
+		}
+		endMin := startMin + pushByteSize
+		if startMin+pushByteSize >= codeLen {
+			endMin = codeLen
+		}
+
+		integer := new(uint256.Int)
+		integer.SetBytes(common.RightPadBytes(scope.Contract.Code[startMin:endMin], pushByteSize))
+		return fmt.Sprintf("%s%d %d", "PUSH", size, integer)
+	}
+}
+
 // make dup instruction function
 func makeDup(size int64) executionFunc {
 	return func(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 		scope.Stack.dup(int(size))
 		return nil, nil
+	}
+}
+
+func makeDupStringer(n int) stringer {
+	return func(pc uint64, scope *ScopeContext) string {
+		return fmt.Sprintf("DUP%d (%d)", n, &scope.Stack.data[len(scope.Stack.data)-n])
+	}
+}
+
+func makeSwapStringer(n int) stringer {
+	return func(pc uint64, scope *ScopeContext) string {
+		return fmt.Sprintf("SWAP%d (%d %d)", n, &scope.Stack.data[len(scope.Stack.data)-1], &scope.Stack.data[len(scope.Stack.data)-(n+1)])
 	}
 }

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/erigontech/erigon-lib/chain"
 	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/common/dbg"
 	"github.com/erigontech/erigon-lib/common/math"
 	"github.com/erigontech/erigon-lib/log/v3"
 
@@ -352,6 +353,19 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 				logged = true
 			}
 		}
+
+		// TODO - move this to a trace & set in the worker
+		if dbg.TraceInstructions && in.evm.intraBlockState.Trace() {
+			var str string
+			if operation.string != nil {
+				str = operation.string(*pc, callContext)
+			} else {
+				str = op.String()
+			}
+
+			fmt.Printf("(%d.%d) %5d %5d %s\n", in.evm.intraBlockState.TxIndex(), in.evm.intraBlockState.Incarnation(), _pc, cost, str)
+		}
+
 		if memorySize > 0 {
 			mem.Resize(memorySize)
 		}

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -30,6 +30,7 @@ type (
 	gasFunc       func(*EVM, *Contract, *Stack, *Memory, uint64) (uint64, error) // last parameter is the requested memory size as a uint64
 	// memorySizeFunc returns the required size, and whether the operation overflowed a uint64
 	memorySizeFunc func(*Stack) (size uint64, overflow bool)
+	stringer       func(pc uint64, callContext *ScopeContext) string
 )
 
 type operation struct {
@@ -50,6 +51,7 @@ type operation struct {
 	opNum   int // only for push, swap, dup
 	// memorySize returns the memory size required for the operation
 	memorySize memorySizeFunc
+	string     stringer
 }
 
 var (
@@ -212,6 +214,7 @@ func newByzantiumInstructionSet() JumpTable {
 		numPop:      6,
 		numPush:     1,
 		memorySize:  memoryStaticCall,
+		string:      stStaticCall,
 	}
 	instructionSet[RETURNDATASIZE] = &operation{
 		execute:     opReturnDataSize,
@@ -226,6 +229,7 @@ func newByzantiumInstructionSet() JumpTable {
 		numPop:      3,
 		numPush:     0,
 		memorySize:  memoryReturnDataCopy,
+		string:      stReturnDataCopy,
 	}
 	instructionSet[REVERT] = &operation{
 		execute:    opRevert,
@@ -272,6 +276,7 @@ func newHomesteadInstructionSet() JumpTable {
 		numPop:      6,
 		numPush:     1,
 		memorySize:  memoryDelegateCall,
+		string:      stDelegateCall,
 	}
 	validateAndFillMaxStack(&instructionSet)
 	return instructionSet
@@ -292,54 +297,63 @@ func newFrontierInstructionSet() JumpTable {
 			constantGas: GasFastestStep,
 			numPop:      2,
 			numPush:     1,
+			string:      stAdd,
 		},
 		MUL: {
 			execute:     opMul,
 			constantGas: GasFastStep,
 			numPop:      2,
 			numPush:     1,
+			string:      stMul,
 		},
 		SUB: {
 			execute:     opSub,
 			constantGas: GasFastestStep,
 			numPop:      2,
 			numPush:     1,
+			string:      stSub,
 		},
 		DIV: {
 			execute:     opDiv,
 			constantGas: GasFastStep,
 			numPop:      2,
 			numPush:     1,
+			string:      stDiv,
 		},
 		SDIV: {
 			execute:     opSdiv,
 			constantGas: GasFastStep,
 			numPop:      2,
 			numPush:     1,
+			string:      stSdiv,
 		},
 		MOD: {
 			execute:     opMod,
 			constantGas: GasFastStep,
 			numPop:      2,
 			numPush:     1,
+			string:      stMod,
 		},
 		SMOD: {
 			execute:     opSmod,
 			constantGas: GasFastStep,
 			numPop:      2,
 			numPush:     1,
+			string:      stSmod,
 		},
 		ADDMOD: {
 			execute:     opAddmod,
 			constantGas: GasMidStep,
 			numPop:      3,
 			numPush:     1,
+			string:      stAddmod,
 		},
 		MULMOD: {
 			execute:     opMulmod,
 			constantGas: GasMidStep,
 			numPop:      3,
 			numPush:     1,
+			string:      stMulmod,
 		},
 		EXP: {
 			execute:    opExp,
@@ -358,60 +372,70 @@ func newFrontierInstructionSet() JumpTable {
 			constantGas: GasFastestStep,
 			numPop:      2,
 			numPush:     1,
+			string:      stLt,
 		},
 		GT: {
 			execute:     opGt,
 			constantGas: GasFastestStep,
 			numPop:      2,
 			numPush:     1,
+			string:      stGt,
 		},
 		SLT: {
 			execute:     opSlt,
 			constantGas: GasFastestStep,
 			numPop:      2,
 			numPush:     1,
+			string:      stSlt,
 		},
 		SGT: {
 			execute:     opSgt,
 			constantGas: GasFastestStep,
 			numPop:      2,
 			numPush:     1,
+			string:      stSgt,
 		},
 		EQ: {
 			execute:     opEq,
 			constantGas: GasFastestStep,
 			numPop:      2,
 			numPush:     1,
+			string:      stEq,
 		},
 		ISZERO: {
 			execute:     opIszero,
 			constantGas: GasFastestStep,
 			numPop:      1,
 			numPush:     1,
+			string:      stIsZero,
 		},
 		AND: {
 			execute:     opAnd,
 			constantGas: GasFastestStep,
 			numPop:      2,
 			numPush:     1,
+			string:      stAnd,
 		},
 		XOR: {
 			execute:     opXor,
 			constantGas: GasFastestStep,
 			numPop:      2,
 			numPush:     1,
+			string:      stXor,
 		},
 		OR: {
 			execute:     opOr,
 			constantGas: GasFastestStep,
 			numPop:      2,
 			numPush:     1,
+			string:      stOr,
 		},
 		NOT: {
 			execute:     opNot,
 			constantGas: GasFastestStep,
 			numPop:      1,
 			numPush:     1,
+			string:      stNot,
 		},
 		BYTE: {
 			execute:     opByte,
@@ -462,12 +486,14 @@ func newFrontierInstructionSet() JumpTable {
 			constantGas: GasFastestStep,
 			numPop:      1,
 			numPush:     1,
+			string:      stCallDataLoad,
 		},
 		CALLDATASIZE: {
 			execute:     opCallDataSize,
 			constantGas: GasQuickStep,
 			numPop:      0,
 			numPush:     1,
+			string:      stCallDataSize,
 		},
 		CALLDATACOPY: {
 			execute:     opCallDataCopy,
@@ -476,6 +502,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPop:      3,
 			numPush:     0,
 			memorySize:  memoryCallDataCopy,
+			string:      stCallDataCopy,
 		},
 		CODESIZE: {
 			execute:     opCodeSize,
@@ -516,6 +543,7 @@ func newFrontierInstructionSet() JumpTable {
 			constantGas: GasExtStep,
 			numPop:      1,
 			numPush:     1,
+			string:      stBlockhash,
 		},
 		COINBASE: {
 			execute:     opCoinbase,
@@ -560,6 +588,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPop:      1,
 			numPush:     1,
 			memorySize:  memoryMLoad,
+			string:      stMload,
 		},
 		MSTORE: {
 			execute:     opMstore,
@@ -568,6 +597,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPop:      2,
 			numPush:     0,
 			memorySize:  memoryMStore,
+			string:      stMstore,
 		},
 		MSTORE8: {
 			execute:     opMstore8,
@@ -582,30 +612,35 @@ func newFrontierInstructionSet() JumpTable {
 			constantGas: params.SloadGasFrontier,
 			numPop:      1,
 			numPush:     1,
+			string:      stSload,
 		},
 		SSTORE: {
 			execute:    opSstore,
 			dynamicGas: gasSStore,
 			numPop:     2,
 			numPush:    0,
+			string:     stSstore,
 		},
 		JUMP: {
 			execute:     opJump,
 			constantGas: GasMidStep,
 			numPop:      1,
 			numPush:     0,
+			string:      stJump,
 		},
 		JUMPI: {
 			execute:     opJumpi,
 			constantGas: GasSlowStep,
 			numPop:      2,
 			numPush:     0,
+			string:      stJumpi,
 		},
 		PC: {
 			execute:     opPc,
 			constantGas: GasQuickStep,
 			numPop:      0,
 			numPush:     1,
+			string:      stPc,
 		},
 		MSIZE: {
 			execute:     opMsize,
@@ -632,6 +667,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       1,
+			string:      stPush1,
 		},
 		PUSH2: {
 			execute:     opPush2,
@@ -640,6 +676,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       2,
+			string:      makePushStringer(2, 2),
 		},
 		PUSH3: {
 			execute:     makePush(3, 3),
@@ -648,6 +685,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       3,
+			string:      makePushStringer(3, 3),
 		},
 		PUSH4: {
 			execute:     makePush(4, 4),
@@ -656,6 +694,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       4,
+			string:      makePushStringer(4, 4),
 		},
 		PUSH5: {
 			execute:     makePush(5, 5),
@@ -664,6 +703,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       5,
+			string:      makePushStringer(5, 5),
 		},
 		PUSH6: {
 			execute:     makePush(6, 6),
@@ -672,6 +712,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       6,
+			string:      makePushStringer(6, 6),
 		},
 		PUSH7: {
 			execute:     makePush(7, 7),
@@ -680,6 +721,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       7,
+			string:      makePushStringer(7, 7),
 		},
 		PUSH8: {
 			execute:     makePush(8, 8),
@@ -688,6 +730,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       8,
+			string:      makePushStringer(8, 8),
 		},
 		PUSH9: {
 			execute:     makePush(9, 9),
@@ -696,6 +739,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       9,
+			string:      makePushStringer(9, 9),
 		},
 		PUSH10: {
 			execute:     makePush(10, 10),
@@ -704,6 +748,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       10,
+			string:      makePushStringer(10, 10),
 		},
 		PUSH11: {
 			execute:     makePush(11, 11),
@@ -712,6 +757,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       11,
+			string:      makePushStringer(11, 11),
 		},
 		PUSH12: {
 			execute:     makePush(12, 12),
@@ -720,6 +766,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       12,
+			string:      makePushStringer(12, 12),
 		},
 		PUSH13: {
 			execute:     makePush(13, 13),
@@ -728,6 +775,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       13,
+			string:      makePushStringer(13, 13),
 		},
 		PUSH14: {
 			execute:     makePush(14, 14),
@@ -736,6 +784,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       14,
+			string:      makePushStringer(14, 14),
 		},
 		PUSH15: {
 			execute:     makePush(15, 15),
@@ -744,6 +793,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       15,
+			string:      makePushStringer(15, 15),
 		},
 		PUSH16: {
 			execute:     makePush(16, 16),
@@ -752,6 +802,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       16,
+			string:      makePushStringer(16, 16),
 		},
 		PUSH17: {
 			execute:     makePush(17, 17),
@@ -760,6 +811,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       17,
+			string:      makePushStringer(17, 17),
 		},
 		PUSH18: {
 			execute:     makePush(18, 18),
@@ -768,6 +820,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       18,
+			string:      makePushStringer(18, 18),
 		},
 		PUSH19: {
 			execute:     makePush(19, 19),
@@ -776,6 +829,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       19,
+			string:      makePushStringer(19, 19),
 		},
 		PUSH20: {
 			execute:     makePush(20, 20),
@@ -784,6 +838,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       20,
+			string:      makePushStringer(20, 20),
 		},
 		PUSH21: {
 			execute:     makePush(21, 21),
@@ -792,6 +847,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       21,
+			string:      makePushStringer(21, 21),
 		},
 		PUSH22: {
 			execute:     makePush(22, 22),
@@ -800,6 +856,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       22,
+			string:      makePushStringer(22, 22),
 		},
 		PUSH23: {
 			execute:     makePush(23, 23),
@@ -808,6 +865,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       23,
+			string:      makePushStringer(23, 23),
 		},
 		PUSH24: {
 			execute:     makePush(24, 24),
@@ -816,6 +874,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       24,
+			string:      makePushStringer(24, 24),
 		},
 		PUSH25: {
 			execute:     makePush(25, 25),
@@ -824,6 +883,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       25,
+			string:      makePushStringer(25, 25),
 		},
 		PUSH26: {
 			execute:     makePush(26, 26),
@@ -832,6 +892,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       26,
+			string:      makePushStringer(26, 26),
 		},
 		PUSH27: {
 			execute:     makePush(27, 27),
@@ -840,6 +901,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       27,
+			string:      makePushStringer(27, 27),
 		},
 		PUSH28: {
 			execute:     makePush(28, 28),
@@ -848,6 +910,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       28,
+			string:      makePushStringer(28, 28),
 		},
 		PUSH29: {
 			execute:     makePush(29, 29),
@@ -856,6 +919,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       29,
+			string:      makePushStringer(29, 29),
 		},
 		PUSH30: {
 			execute:     makePush(30, 30),
@@ -864,6 +928,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       30,
+			string:      makePushStringer(30, 30),
 		},
 		PUSH31: {
 			execute:     makePush(31, 31),
@@ -872,6 +937,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       31,
+			string:      makePushStringer(31, 31),
 		},
 		PUSH32: {
 			execute:     makePush(32, 32),
@@ -880,6 +946,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     1,
 			isPush:      true,
 			opNum:       32,
+			string:      makePushStringer(32, 32),
 		},
 		DUP1: {
 			execute:     makeDup(1),
@@ -888,6 +955,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     2,
 			isDup:       true,
 			opNum:       1,
+			string:      makeDupStringer(1),
 		},
 		DUP2: {
 			execute:     makeDup(2),
@@ -896,6 +964,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     3,
 			isDup:       true,
 			opNum:       2,
+			string:      makeDupStringer(2),
 		},
 		DUP3: {
 			execute:     makeDup(3),
@@ -904,6 +973,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     4,
 			isDup:       true,
 			opNum:       3,
+			string:      makeDupStringer(3),
 		},
 		DUP4: {
 			execute:     makeDup(4),
@@ -912,6 +982,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     5,
 			isDup:       true,
 			opNum:       4,
+			string:      makeDupStringer(4),
 		},
 		DUP5: {
 			execute:     makeDup(5),
@@ -920,6 +991,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     6,
 			isDup:       true,
 			opNum:       5,
+			string:      makeDupStringer(5),
 		},
 		DUP6: {
 			execute:     makeDup(6),
@@ -928,6 +1000,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     7,
 			isDup:       true,
 			opNum:       6,
+			string:      makeDupStringer(6),
 		},
 		DUP7: {
 			execute:     makeDup(7),
@@ -936,6 +1009,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     8,
 			isDup:       true,
 			opNum:       7,
+			string:      makeDupStringer(7),
 		},
 		DUP8: {
 			execute:     makeDup(8),
@@ -944,6 +1018,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     9,
 			isDup:       true,
 			opNum:       8,
+			string:      makeDupStringer(8),
 		},
 		DUP9: {
 			execute:     makeDup(9),
@@ -952,6 +1027,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     10,
 			isDup:       true,
 			opNum:       9,
+			string:      makeDupStringer(9),
 		},
 		DUP10: {
 			execute:     makeDup(10),
@@ -960,6 +1036,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     11,
 			isDup:       true,
 			opNum:       10,
+			string:      makeDupStringer(10),
 		},
 		DUP11: {
 			execute:     makeDup(11),
@@ -968,6 +1045,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     12,
 			isDup:       true,
 			opNum:       11,
+			string:      makeDupStringer(11),
 		},
 		DUP12: {
 			execute:     makeDup(12),
@@ -976,6 +1054,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     13,
 			isDup:       true,
 			opNum:       12,
+			string:      makeDupStringer(12),
 		},
 		DUP13: {
 			execute:     makeDup(13),
@@ -984,6 +1063,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     14,
 			isDup:       true,
 			opNum:       13,
+			string:      makeDupStringer(13),
 		},
 		DUP14: {
 			execute:     makeDup(14),
@@ -992,6 +1072,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     15,
 			isDup:       true,
 			opNum:       14,
+			string:      makeDupStringer(14),
 		},
 		DUP15: {
 			execute:     makeDup(15),
@@ -1000,6 +1081,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     16,
 			isDup:       true,
 			opNum:       15,
+			string:      makeDupStringer(15),
 		},
 		DUP16: {
 			execute:     makeDup(16),
@@ -1008,6 +1090,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     17,
 			isDup:       true,
 			opNum:       16,
+			string:      makeDupStringer(16),
 		},
 		SWAP1: {
 			execute:     opSwap1,
@@ -1016,6 +1099,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     2,
 			isSwap:      true,
 			opNum:       1,
+			string:      makeSwapStringer(1),
 		},
 		SWAP2: {
 			execute:     opSwap2,
@@ -1024,6 +1108,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     3,
 			isSwap:      true,
 			opNum:       2,
+			string:      makeSwapStringer(2),
 		},
 		SWAP3: {
 			execute:     opSwap3,
@@ -1032,6 +1117,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     4,
 			isSwap:      true,
 			opNum:       3,
+			string:      makeSwapStringer(3),
 		},
 		SWAP4: {
 			execute:     opSwap4,
@@ -1040,6 +1126,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     5,
 			isSwap:      true,
 			opNum:       4,
+			string:      makeSwapStringer(4),
 		},
 		SWAP5: {
 			execute:     opSwap5,
@@ -1048,6 +1135,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     6,
 			isSwap:      true,
 			opNum:       5,
+			string:      makeSwapStringer(5),
 		},
 		SWAP6: {
 			execute:     opSwap6,
@@ -1056,6 +1144,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     7,
 			isSwap:      true,
 			opNum:       6,
+			string:      makeSwapStringer(6),
 		},
 		SWAP7: {
 			execute:     opSwap7,
@@ -1064,6 +1153,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     8,
 			isSwap:      true,
 			opNum:       7,
+			string:      makeSwapStringer(7),
 		},
 		SWAP8: {
 			execute:     opSwap8,
@@ -1072,6 +1162,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     9,
 			isSwap:      true,
 			opNum:       8,
+			string:      makeSwapStringer(8),
 		},
 		SWAP9: {
 			execute:     opSwap9,
@@ -1080,6 +1171,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     10,
 			isSwap:      true,
 			opNum:       9,
+			string:      makeSwapStringer(9),
 		},
 		SWAP10: {
 			execute:     opSwap10,
@@ -1088,6 +1180,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     11,
 			isSwap:      true,
 			opNum:       10,
+			string:      makeSwapStringer(10),
 		},
 		SWAP11: {
 			execute:     opSwap11,
@@ -1096,6 +1189,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     12,
 			isSwap:      true,
 			opNum:       11,
+			string:      makeSwapStringer(11),
 		},
 		SWAP12: {
 			execute:     opSwap12,
@@ -1104,6 +1198,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     13,
 			isSwap:      true,
 			opNum:       12,
+			string:      makeSwapStringer(12),
 		},
 		SWAP13: {
 			execute:     opSwap13,
@@ -1112,6 +1207,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     14,
 			isSwap:      true,
 			opNum:       13,
+			string:      makeSwapStringer(13),
 		},
 		SWAP14: {
 			execute:     opSwap14,
@@ -1120,6 +1216,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     15,
 			isSwap:      true,
 			opNum:       14,
+			string:      makeSwapStringer(14),
 		},
 		SWAP15: {
 			execute:     opSwap15,
@@ -1128,6 +1225,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     16,
 			isSwap:      true,
 			opNum:       15,
+			string:      makeSwapStringer(15),
 		},
 		SWAP16: {
 			execute:     opSwap16,
@@ -1136,6 +1234,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPush:     17,
 			isSwap:      true,
 			opNum:       16,
+			string:      makeSwapStringer(16),
 		},
 		LOG0: {
 			execute:    makeLog(0),
@@ -1187,6 +1286,7 @@ func newFrontierInstructionSet() JumpTable {
 			numPop:      7,
 			numPush:     1,
 			memorySize:  memoryCall,
+			string:      stCall,
 		},
 		CALLCODE: {
 			execute:     opCallCode,


### PR DESCRIPTION
This adds stringers to opcodes and a trace function to the interpreter to optionally dump them during execution.  This is useful for debugging deep root mismatch issues where data discrepancies cause alternate execution paths to be taken by the interpreter. 