### PR TITLE
mapReduce: final txn must be executed in `reduecer` because require "all receipts of block" 

### DIFF
--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -342,16 +342,29 @@ func blocksReadAheadFunc(ctx context.Context, tx kv.Tx, cfg *ExecuteBlockCfg, bl
 
 	for _, txn := range block.Transactions() {
 		to := txn.GetTo()
-		if to == nil {
-			continue
+		if to != nil {
+			a, _ := stateReader.ReadAccountData(*to)
+			if a == nil {
+				continue
+			}
+			//if account != nil && !bytes.Equal(account.CodeHash, types.EmptyCodeHash.Bytes()) {
+			//	reader.Code(*tx.To(), common.BytesToHash(account.CodeHash))
+			//}
+			if code, _ := stateReader.ReadAccountCode(*to); len(code) > 0 {
+				_, _ = code[0], code[len(code)-1]
+			}
+
+			for _, list := range txn.GetAccessList() {
+				stateReader.ReadAccountData(list.Address)
+				if len(list.StorageKeys) > 0 {
+					for _, slot := range list.StorageKeys {
+						stateReader.ReadAccountStorage(list.Address, slot)
+					}
+				}
+			}
+			//TODO: exec txn and pre-fetch commitment keys. see also: `func (p *statePrefetcher) Prefetch` in geth
 		}
-		a, _ := stateReader.ReadAccountData(*to)
-		if a == nil {
-			continue
-		}
-		if code, _ := stateReader.ReadAccountCode(*to); len(code) > 0 {
-			_, _ = code[0], code[len(code)-1]
-		}
+
 	}
 	_, _ = stateReader.ReadAccountData(block.Coinbase())
 

--- a/execution/exec3/historical_trace_worker.go
+++ b/execution/exec3/historical_trace_worker.go
@@ -438,8 +438,6 @@ func processResultQueueHistorical(consumer TraceConsumer, rws *state.ResultsQueu
 			applyWorker.RunTxTaskNoLock(txTask.Reset())
 		}
 
-		txTask.CreateReceipt(tx)
-
 		hooks := txTask.Tracer.TracingHooks()
 		if txTask.Error != nil {
 			if hooks != nil && hooks.OnTxEnd != nil {
@@ -447,6 +445,8 @@ func processResultQueueHistorical(consumer TraceConsumer, rws *state.ResultsQueu
 			}
 			return outputTxNum, false, fmt.Errorf("bn=%d, tn=%d: %w", txTask.BlockNum, txTask.TxNum, txTask.Error)
 		}
+		txTask.CreateReceipt(tx)
+
 		if hooks != nil && hooks.OnTxEnd != nil {
 			hooks.OnTxEnd(txTask.BlockReceipts[txTask.TxIndex], nil)
 		}

--- a/execution/exec3/historical_trace_worker.go
+++ b/execution/exec3/historical_trace_worker.go
@@ -369,12 +369,15 @@ func NewHistoricalTraceWorkers(consumer TraceConsumer, cfg *ExecArgs, ctx contex
 				err = fmt.Errorf("'reduce worker' paniced: %s, %s", rec, dbg.Stack())
 			}
 		}()
-		return doHistoryReduce(consumer, cfg.ChainDB, ctx, toTxNum, outputTxNum, rws)
+		return doHistoryReduce(consumer, cfg, ctx, toTxNum, outputTxNum, rws, logger)
 	})
 	return g
 }
 
-func doHistoryReduce(consumer TraceConsumer, db kv.TemporalRoDB, ctx context.Context, toTxNum uint64, outputTxNum *atomic.Uint64, rws *state.ResultsQueue) error {
+func doHistoryReduce(consumer TraceConsumer, cfg *ExecArgs, ctx context.Context, toTxNum uint64, outputTxNum *atomic.Uint64, rws *state.ResultsQueue, logger log.Logger) error {
+	db := cfg.ChainDB
+	applyWorker := NewHistoricalTraceWorker(consumer, nil, rws, true, ctx, cfg, log.New())
+
 	tx, err := db.BeginTemporalRo(ctx)
 	if err != nil {
 		return err
@@ -387,7 +390,7 @@ func doHistoryReduce(consumer TraceConsumer, db kv.TemporalRoDB, ctx context.Con
 			return err
 		}
 
-		processedTxNum, _, err := processResultQueueHistorical(consumer, rws, outputTxNum.Load(), tx, true)
+		processedTxNum, _, err := processResultQueueHistorical(consumer, rws, outputTxNum.Load(), tx, true, applyWorker)
 		if err != nil {
 			return fmt.Errorf("processResultQueueHistorical: %w", err)
 		}
@@ -421,7 +424,7 @@ func doHistoryMap(consumer TraceConsumer, cfg *ExecArgs, ctx context.Context, in
 	return mapGroup.Wait()
 }
 
-func processResultQueueHistorical(consumer TraceConsumer, rws *state.ResultsQueue, outputTxNumIn uint64, tx kv.TemporalTx, forceStopAtBlockEnd bool) (outputTxNum uint64, stopedAtBlockEnd bool, err error) {
+func processResultQueueHistorical(consumer TraceConsumer, rws *state.ResultsQueue, outputTxNumIn uint64, tx kv.TemporalTx, forceStopAtBlockEnd bool, applyWorker *HistoricalTraceWorker) (outputTxNum uint64, stopedAtBlockEnd bool, err error) {
 	rwsIt := rws.Iter()
 	defer rwsIt.Close()
 
@@ -431,18 +434,26 @@ func processResultQueueHistorical(consumer TraceConsumer, rws *state.ResultsQueu
 		outputTxNum++
 		stopedAtBlockEnd = txTask.Final
 
-		hooks := txTask.Tracer.TracingHooks()
-		if txTask.Error != nil {
-			if hooks != nil && hooks.OnTxEnd != nil {
-				hooks.OnTxEnd(nil, err)
-			}
-			return outputTxNum, false, fmt.Errorf("bn=%d, tn=%d: %w", txTask.BlockNum, txTask.TxNum, txTask.Error)
+		if txTask.Final { // final txn must be executed here, because `consensus.Finalize` requires "all receipts of block" to be available
+			applyWorker.RunTxTaskNoLock(txTask.Reset())
 		}
 
 		txTask.CreateReceipt(tx)
-		if hooks != nil && hooks.OnTxEnd != nil {
-			hooks.OnTxEnd(txTask.BlockReceipts[txTask.TxIndex], nil)
+
+		isSystemTxn := txTask.TxIndex < 0 || txTask.Final
+		if !isSystemTxn { // system txs - it's Erigon's internal concept - must not trigger hooks
+			hooks := txTask.Tracer.TracingHooks()
+			if txTask.Error != nil {
+				if hooks != nil && hooks.OnTxEnd != nil {
+					hooks.OnTxEnd(nil, err)
+				}
+				return outputTxNum, false, fmt.Errorf("bn=%d, tn=%d: %w", txTask.BlockNum, txTask.TxNum, txTask.Error)
+			}
+			if hooks != nil && hooks.OnTxEnd != nil {
+				hooks.OnTxEnd(txTask.BlockReceipts[txTask.TxIndex], nil)
+			}
 		}
+
 		if err := consumer.Reduce(txTask, tx); err != nil {
 			return outputTxNum, false, err
 		}
@@ -508,12 +519,15 @@ func CustomTraceMapReduce(fromBlock, toBlock uint64, consumer TraceConsumer, ctx
 	outTxNum := &atomic.Uint64{}
 	outTxNum.Store(fromTxNum)
 
+	ctx, cancleCtx := context.WithCancel(ctx)
 	workers := NewHistoricalTraceWorkers(consumer, cfg, ctx, toTxNum, in, WorkerCount, outTxNum, logger)
 	defer workers.Wait()
 
 	workersExited := &atomic.Bool{}
 	go func() {
-		workers.Wait()
+		if err := workers.Wait(); err != nil {
+			cancleCtx()
+		}
 		workersExited.Store(true)
 	}()
 

--- a/execution/exec3/historical_trace_worker.go
+++ b/execution/exec3/historical_trace_worker.go
@@ -440,18 +440,15 @@ func processResultQueueHistorical(consumer TraceConsumer, rws *state.ResultsQueu
 
 		txTask.CreateReceipt(tx)
 
-		isSystemTxn := txTask.TxIndex < 0 || txTask.Final
-		if !isSystemTxn { // system txs - it's Erigon's internal concept - must not trigger hooks
-			hooks := txTask.Tracer.TracingHooks()
-			if txTask.Error != nil {
-				if hooks != nil && hooks.OnTxEnd != nil {
-					hooks.OnTxEnd(nil, err)
-				}
-				return outputTxNum, false, fmt.Errorf("bn=%d, tn=%d: %w", txTask.BlockNum, txTask.TxNum, txTask.Error)
-			}
+		hooks := txTask.Tracer.TracingHooks()
+		if txTask.Error != nil {
 			if hooks != nil && hooks.OnTxEnd != nil {
-				hooks.OnTxEnd(txTask.BlockReceipts[txTask.TxIndex], nil)
+				hooks.OnTxEnd(nil, err)
 			}
+			return outputTxNum, false, fmt.Errorf("bn=%d, tn=%d: %w", txTask.BlockNum, txTask.TxNum, txTask.Error)
+		}
+		if hooks != nil && hooks.OnTxEnd != nil {
+			hooks.OnTxEnd(txTask.BlockReceipts[txTask.TxIndex], nil)
 		}
 
 		if err := consumer.Reduce(txTask, tx); err != nil {


### PR DESCRIPTION
- also added access list to warmup