### PR TITLE
rpcdaemon: Fix issue 13238 ots get transaction by sender and nonce

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout RPC Tests Repository & Install Requirements
         run: |
           rm -rf ${{ runner.workspace }}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch v1.59.0  https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
+          git -c advice.detachedHead=false clone --depth 1 --branch v1.60.0  https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
           cd ${{ runner.workspace }}/rpc-tests
           pip3 install -r requirements.txt
 

--- a/rpc/jsonrpc/otterscan_transaction_by_sender_and_nonce.go
+++ b/rpc/jsonrpc/otterscan_transaction_by_sender_and_nonce.go
@@ -80,19 +80,15 @@ func (api *OtterscanAPIImpl) GetTransactionBySenderAndNonce(ctx context.Context,
 		prevTxnID = txnID
 	}
 
-	// The sort.Search function finds the first block where the incarnation has
-	// changed to the desired one, so we get the previous block from the bitmap;
-	// however if the creationTxnID block is already the first one from the bitmap, it means
-	// the block we want is the max block from the previous shard.
-	var creationTxnID uint64
+	var nonceTxnID uint64
 	var searchErr error
 
 	if nextTxnID == 0 {
 		nextTxnID = prevTxnID + 1
 	}
-	// Binary search in [prevTxnID, nextTxnID] range; get first block where desired incarnation appears
-	// can be replaced by full-scan over ttx.HistoryRange([prevTxnID, nextTxnID])?
-	idx := sort.Search(int(nextTxnID-prevTxnID), func(i int) bool {
+	// Binary search in [prevTxnID, nextTxnID + 1] range; get first block where desired nonce appears
+	// can be replaced by full-scan over ttx.HistoryRange([prevTxnID, nextTxnID + 1])?
+	idx := sort.Search(int(nextTxnID-prevTxnID+1), func(i int) bool {
 		txnID := uint64(i) + prevTxnID
 		v, ok, err := tx.HistorySeek(kv.AccountsDomain, addr[:], txnID)
 		if err != nil {
@@ -103,7 +99,7 @@ func (api *OtterscanAPIImpl) GetTransactionBySenderAndNonce(ctx context.Context,
 			return false
 		}
 		if len(v) == 0 {
-			creationTxnID = max(creationTxnID, txnID)
+			nonceTxnID = max(nonceTxnID, txnID)
 			return false
 		}
 
@@ -117,7 +113,7 @@ func (api *OtterscanAPIImpl) GetTransactionBySenderAndNonce(ctx context.Context,
 		// previous history block contains the actual change; it may contain multiple
 		// nonce changes.
 		if acc.Nonce <= nonce {
-			creationTxnID = max(creationTxnID, txnID)
+			nonceTxnID = max(nonceTxnID, txnID)
 			return false
 		}
 		return true
@@ -126,21 +122,21 @@ func (api *OtterscanAPIImpl) GetTransactionBySenderAndNonce(ctx context.Context,
 	if searchErr != nil {
 		return nil, searchErr
 	}
-	if creationTxnID == 0 {
+	if nonceTxnID == 0 {
 		return nil, nil
 	}
-	ok, bn, err := api._txNumReader.FindBlockNum(tx, creationTxnID)
+	ok, bn, err := api._txNumReader.FindBlockNum(tx, nonceTxnID)
 	if err != nil {
 		return nil, err
 	}
 	if !ok {
-		return nil, fmt.Errorf("block not found by txnID=%d", creationTxnID)
+		return nil, fmt.Errorf("block not found by txnID=%d", nonceTxnID)
 	}
 	minTxNum, err := api._txNumReader.Min(tx, bn)
 	if err != nil {
 		return nil, err
 	}
-	txIndex := int(creationTxnID) - int(minTxNum) - 1 /* system-tx */
+	txIndex := int(nonceTxnID) - int(minTxNum) - 1 /* system-tx */
 	if txIndex == -1 {
 		txIndex = (idx + int(prevTxnID)) - int(minTxNum) - 1
 	}


### PR DESCRIPTION
closes #13238
Fix on range nextTxnID-prevTxnID+1
If the change is in the tx identified by nextTxnId, the transaction is not considered and the API returns null (as described in the issue) (because txn.GetNonce() != nonce)
Added two integration tests to verify the resolution of the problem (with the previous software version, the new RPC tests failed).