### PR TITLE
evm: non-interface IntraBlockState

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -261,7 +261,7 @@ func rlpHash(x interface{}) (h common.Hash) {
 	return h
 }
 
-func SysCallContract(contract common.Address, data []byte, chainConfig *chain.Config, ibs evmtypes.IntraBlockState, header *types.Header, engine consensus.EngineReader, constCall bool, tracing *tracing.Hooks, vmCfg vm.Config) (result []byte, logs []*types.Log, err error) {
+func SysCallContract(contract common.Address, data []byte, chainConfig *chain.Config, ibs *state.IntraBlockState, header *types.Header, engine consensus.EngineReader, constCall bool, tracing *tracing.Hooks, vmCfg vm.Config) (result []byte, logs []*types.Log, err error) {
 	isBor := chainConfig.Bor != nil
 	var author *common.Address
 	if isBor {
@@ -273,7 +273,7 @@ func SysCallContract(contract common.Address, data []byte, chainConfig *chain.Co
 	return SysCallContractWithBlockContext(contract, data, chainConfig, ibs, blockContext, constCall, tracing, vmCfg)
 }
 
-func SysCallContractWithBlockContext(contract common.Address, data []byte, chainConfig *chain.Config, ibs evmtypes.IntraBlockState, blockContext evmtypes.BlockContext, constCall bool, tracer *tracing.Hooks, vmCfg vm.Config) (result []byte, logs []*types.Log, err error) {
+func SysCallContractWithBlockContext(contract common.Address, data []byte, chainConfig *chain.Config, ibs *state.IntraBlockState, blockContext evmtypes.BlockContext, constCall bool, tracer *tracing.Hooks, vmCfg vm.Config) (result []byte, logs []*types.Log, err error) {
 	innerTracer := &tracing.Hooks{}
 	if tracer != nil {
 		//innerTracer = tracer

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -84,3 +84,25 @@ func (nw *NoopWriter) WriteAccountStorage(address common.Address, incarnation ui
 func (nw *NoopWriter) CreateContract(address common.Address) error {
 	return nil
 }
+
+type NoopReader struct {
+}
+
+var noopReader = &NoopReader{}
+
+func NewNoopReader() *NoopReader {
+	return noopReader
+}
+
+func (*NoopReader) ReadAccountData(address common.Address) (*accounts.Account, error) {
+	return nil, nil
+}
+func (*NoopReader) ReadAccountDataForDebug(address common.Address) (*accounts.Account, error) {
+	return nil, nil
+}
+func (*NoopReader) ReadAccountStorage(address common.Address, key common.Hash) ([]byte, error) {
+	return nil, nil
+}
+func (*NoopReader) ReadAccountCode(address common.Address) ([]byte, error)        { return nil, nil }
+func (*NoopReader) ReadAccountCodeSize(address common.Address) (int, error)       { return 0, nil }
+func (*NoopReader) ReadAccountIncarnation(address common.Address) (uint64, error) { return 0, nil }

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -74,7 +74,7 @@ type StateTransition struct {
 	initialGas   uint64
 	value        *uint256.Int
 	data         []byte
-	state        evmtypes.IntraBlockState
+	state        *state.IntraBlockState
 	evm          *vm.EVM
 
 	//some pre-allocated intermediate variables

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -526,7 +526,7 @@ func (evm *EVM) ChainRules() *chain.Rules {
 }
 
 // IntraBlockState returns the EVM's IntraBlockState
-func (evm *EVM) IntraBlockState() evmtypes.IntraBlockState {
+func (evm *EVM) IntraBlockState() *state.IntraBlockState {
 	return evm.intraBlockState
 }
 

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -99,7 +99,7 @@ type EVM struct {
 
 // NewEVM returns a new EVM. The returned EVM is not thread safe and should
 // only ever be used *once*.
-func NewEVM(blockCtx evmtypes.BlockContext, txCtx evmtypes.TxContext, ibs evmtypes.IntraBlockState, chainConfig *chain.Config, vmConfig Config) *EVM {
+func NewEVM(blockCtx evmtypes.BlockContext, txCtx evmtypes.TxContext, ibs *state.IntraBlockState, chainConfig *chain.Config, vmConfig Config) *EVM {
 	if vmConfig.NoBaseFee {
 		if txCtx.GasPrice.IsZero() {
 			blockCtx.BaseFee = new(uint256.Int)
@@ -108,7 +108,7 @@ func NewEVM(blockCtx evmtypes.BlockContext, txCtx evmtypes.TxContext, ibs evmtyp
 	evm := &EVM{
 		Context:         blockCtx,
 		TxContext:       txCtx,
-		intraBlockState: ibs.(*state.IntraBlockState),
+		intraBlockState: ibs,
 		config:          vmConfig,
 		chainConfig:     chainConfig,
 		chainRules:      chainConfig.Rules(blockCtx.BlockNumber, blockCtx.Time),

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -124,15 +124,15 @@ func NewEVM(blockCtx evmtypes.BlockContext, txCtx evmtypes.TxContext, ibs *state
 
 // Reset resets the EVM with a new transaction context.Reset
 // This is not threadsafe and should only be done very cautiously.
-func (evm *EVM) Reset(txCtx evmtypes.TxContext, ibs evmtypes.IntraBlockState) {
+func (evm *EVM) Reset(txCtx evmtypes.TxContext, ibs *state.IntraBlockState) {
 	evm.TxContext = txCtx
-	evm.intraBlockState = ibs.(*state.IntraBlockState)
+	evm.intraBlockState = ibs
 
 	// ensure the evm is reset to be used again
 	evm.abort.Store(false)
 }
 
-func (evm *EVM) ResetBetweenBlocks(blockCtx evmtypes.BlockContext, txCtx evmtypes.TxContext, ibs evmtypes.IntraBlockState, vmConfig Config, chainRules *chain.Rules) {
+func (evm *EVM) ResetBetweenBlocks(blockCtx evmtypes.BlockContext, txCtx evmtypes.TxContext, ibs *state.IntraBlockState, vmConfig Config, chainRules *chain.Rules) {
 	if vmConfig.NoBaseFee {
 		if txCtx.GasPrice.IsZero() {
 			blockCtx.BaseFee = new(uint256.Int)
@@ -140,7 +140,7 @@ func (evm *EVM) ResetBetweenBlocks(blockCtx evmtypes.BlockContext, txCtx evmtype
 	}
 	evm.Context = blockCtx
 	evm.TxContext = txCtx
-	evm.intraBlockState = ibs.(*state.IntraBlockState)
+	evm.intraBlockState = ibs
 	if vmConfig.JumpDestCache == nil && evm.config.JumpDestCache != nil {
 		vmConfig.JumpDestCache = evm.config.JumpDestCache
 	}

--- a/core/vm/evm_test.go
+++ b/core/vm/evm_test.go
@@ -20,11 +20,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/holiman/uint256"
+	"pgregory.net/rapid"
+
 	"github.com/erigontech/erigon-lib/chain"
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon/core/vm/evmtypes"
-	"github.com/holiman/uint256"
-	"pgregory.net/rapid"
 )
 
 func TestInterpreterReadonly(t *testing.T) {

--- a/core/vm/evm_test.go
+++ b/core/vm/evm_test.go
@@ -28,10 +28,16 @@ import (
 )
 
 func TestInterpreterReadonly(t *testing.T) {
+	//tx, sd := testTemporalTxSD(t, testTemporalDB(t))
+	//defer tx.Rollback()
+	//
+	//r, w := state.NewReaderV3(sd), state.NewWriter(sd, nil)
+	//s := state.New(r)
+
 	t.Parallel()
 	c := NewJumpDestCache(128)
 	rapid.Check(t, func(t *rapid.T) {
-		env := NewEVM(evmtypes.BlockContext{}, evmtypes.TxContext{}, &dummyStatedb{}, chain.TestChainConfig, Config{})
+		env := NewEVM(evmtypes.BlockContext{}, evmtypes.TxContext{}, nil, chain.TestChainConfig, Config{})
 
 		isEVMSliceTest := rapid.SliceOfN(rapid.Bool(), 1, -1).Draw(t, "tevm")
 		readOnlySliceTest := rapid.SliceOfN(rapid.Bool(), len(isEVMSliceTest), len(isEVMSliceTest)).Draw(t, "readonly")
@@ -291,7 +297,7 @@ func TestReadonlyBasicCases(t *testing.T) {
 				t.Parallel()
 				readonlySliceTest := testcase.readonlySliceTest
 
-				env := NewEVM(evmtypes.BlockContext{}, evmtypes.TxContext{}, &dummyStatedb{}, chain.TestChainConfig, Config{})
+				env := NewEVM(evmtypes.BlockContext{}, evmtypes.TxContext{}, nil, chain.TestChainConfig, Config{})
 
 				readonliesGot := make([]*readOnlyState, len(testcase.readonlySliceTest))
 				isEVMGot := make([]bool, len(evmsTestcase.emvs))

--- a/core/vm/evm_test.go
+++ b/core/vm/evm_test.go
@@ -28,12 +28,6 @@ import (
 )
 
 func TestInterpreterReadonly(t *testing.T) {
-	//tx, sd := testTemporalTxSD(t, testTemporalDB(t))
-	//defer tx.Rollback()
-	//
-	//r, w := state.NewReaderV3(sd), state.NewWriter(sd, nil)
-	//s := state.New(r)
-
 	t.Parallel()
 	c := NewJumpDestCache(128)
 	rapid.Check(t, func(t *rapid.T) {

--- a/core/vm/evmtypes/evmtypes.go
+++ b/core/vm/evmtypes/evmtypes.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/holiman/uint256"
 
-	"github.com/erigontech/erigon-lib/chain"
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/types"
 	"github.com/erigontech/erigon/core/tracing"
@@ -120,60 +119,9 @@ type (
 
 // IntraBlockState is an EVM database for full state querying.
 type IntraBlockState interface {
-	CreateAccount(common.Address, bool) error
-
 	SubBalance(common.Address, *uint256.Int, tracing.BalanceChangeReason) error
 	AddBalance(common.Address, *uint256.Int, tracing.BalanceChangeReason) error
 	GetBalance(common.Address) (*uint256.Int, error)
-
-	GetNonce(common.Address) (uint64, error)
-	SetNonce(common.Address, uint64) error
-
-	GetCodeHash(common.Address) (common.Hash, error)
-	GetCode(common.Address) ([]byte, error)
-	SetCode(common.Address, []byte) error
-	GetCodeSize(common.Address) (int, error)
-
-	// eip-7702; delegated designations
-	ResolveCodeHash(common.Address) (common.Hash, error)
-	ResolveCode(common.Address) ([]byte, error)
-	GetDelegatedDesignation(common.Address) (common.Address, bool, error)
-
-	AddRefund(uint64)
-	SubRefund(uint64)
-	GetRefund() uint64
-
-	GetCommittedState(common.Address, common.Hash, *uint256.Int) error
-	GetState(address common.Address, slot common.Hash, outValue *uint256.Int) error
-	SetState(common.Address, common.Hash, uint256.Int) error
-
-	GetTransientState(addr common.Address, key common.Hash) uint256.Int
-	SetTransientState(addr common.Address, key common.Hash, value uint256.Int)
-
-	Selfdestruct(common.Address) (bool, error)
-	HasSelfdestructed(common.Address) (bool, error)
-	Selfdestruct6780(common.Address) error
-
-	// Exist reports whether the given account exists in state.
-	// Notably this should also return true for suicided accounts.
-	Exist(common.Address) (bool, error)
-	// Empty returns whether the given account is empty. Empty
-	// is defined according to EIP161 (balance = nonce = code = 0).
-	Empty(common.Address) (bool, error)
-
-	Prepare(rules *chain.Rules, sender, coinbase common.Address, dest *common.Address,
-		precompiles []common.Address, txAccesses types.AccessList, authorities []common.Address) error
-
-	AddressInAccessList(addr common.Address) bool
-	// AddAddressToAccessList adds the given address to the access list. This operation is safe to perform
-	// even if the feature/fork is not active yet
-	AddAddressToAccessList(addr common.Address) (addrMod bool)
-	// AddSlotToAccessList adds the given (address,slot) to the access list. This operation is safe to perform
-	// even if the feature/fork is not active yet
-	AddSlotToAccessList(addr common.Address, slot common.Hash) (addrMod, slotMod bool)
-
-	RevertToSnapshot(int)
-	Snapshot() int
 
 	AddLog(*types.Log)
 

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -22,12 +22,11 @@ package vm
 import (
 	"math/big"
 
-	"github.com/erigontech/erigon/core/state"
 	"github.com/holiman/uint256"
 
 	"github.com/erigontech/erigon-lib/chain"
 	"github.com/erigontech/erigon-lib/common"
-
+	"github.com/erigontech/erigon/core/state"
 	"github.com/erigontech/erigon/core/vm/evmtypes"
 )
 

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -22,6 +22,7 @@ package vm
 import (
 	"math/big"
 
+	"github.com/erigontech/erigon/core/state"
 	"github.com/holiman/uint256"
 
 	"github.com/erigontech/erigon-lib/chain"
@@ -45,7 +46,7 @@ type CallContext interface {
 
 // VMInterface exposes the EVM interface for external callers.
 type VMInterface interface {
-	Reset(txCtx evmtypes.TxContext, ibs evmtypes.IntraBlockState)
+	Reset(txCtx evmtypes.TxContext, ibs *state.IntraBlockState)
 	Create(caller ContractRef, code []byte, gas uint64, value *uint256.Int) (ret []byte, contractAddr common.Address, leftOverGas uint64, err error)
 	Call(caller ContractRef, addr common.Address, input []byte, gas uint64, value *uint256.Int, bailout bool) (ret []byte, leftOverGas uint64, err error)
 	Cancel()
@@ -53,7 +54,7 @@ type VMInterface interface {
 	ChainConfig() *chain.Config
 	ChainRules() *chain.Rules
 	Context() evmtypes.BlockContext
-	IntraBlockState() evmtypes.IntraBlockState
+	IntraBlockState() *state.IntraBlockState
 	TxContext() evmtypes.TxContext
 }
 

--- a/core/vm/mock_vm.go
+++ b/core/vm/mock_vm.go
@@ -23,7 +23,6 @@ import (
 	"github.com/holiman/uint256"
 
 	"github.com/erigontech/erigon-lib/common"
-	"github.com/erigontech/erigon/core/state"
 )
 
 type readonlyGetSetter interface {
@@ -110,9 +109,3 @@ func (d *dummyContractRef) AddBalance(amount *big.Int) {}
 func (d *dummyContractRef) SetBalance(*big.Int)        {}
 func (d *dummyContractRef) SetNonce(uint64)            {}
 func (d *dummyContractRef) Balance() *big.Int          { return new(big.Int) }
-
-type dummyStatedb struct {
-	state.IntraBlockState
-}
-
-func (*dummyStatedb) GetRefund() uint64 { return 1337 }

--- a/eth/tracers/js/tracer_test.go
+++ b/eth/tracers/js/tracer_test.go
@@ -51,15 +51,6 @@ func (account) Address() common.Address                             { return com
 func (account) SetCode(common.Hash, []byte)                         {}
 func (account) ForEachStorage(cb func(key, value common.Hash) bool) {}
 
-type dummyStatedb struct {
-	state.IntraBlockState
-}
-
-func (*dummyStatedb) GetRefund() uint64 { return 1337 }
-func (*dummyStatedb) GetBalance(addr common.Address) (*uint256.Int, error) {
-	return &uint256.Int{}, nil
-}
-
 type vmContext struct {
 	blockCtx evmtypes.BlockContext
 	txCtx    evmtypes.TxContext
@@ -72,7 +63,7 @@ func testCtx() *vmContext {
 func runTrace(tracer *tracers.Tracer, vmctx *vmContext, chaincfg *chain.Config, contractCode []byte) (json.RawMessage, error) {
 	c := vm.NewJumpDestCache(16)
 	var (
-		env             = vm.NewEVM(vmctx.blockCtx, vmctx.txCtx, &dummyStatedb{}, chaincfg, vm.Config{Tracer: tracer.Hooks})
+		env             = vm.NewEVM(vmctx.blockCtx, vmctx.txCtx, state.New(state.NewNoopReader()), chaincfg, vm.Config{Tracer: tracer.Hooks})
 		gasLimit uint64 = 31000
 		startGas uint64 = 10000
 		value           = uint256.NewInt(0)
@@ -198,7 +189,7 @@ func TestHaltBetweenSteps(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	env := vm.NewEVM(evmtypes.BlockContext{BlockNumber: 1}, evmtypes.TxContext{GasPrice: uint256.NewInt(1)}, &dummyStatedb{}, chain.TestChainConfig, vm.Config{Tracer: tracer.Hooks})
+	env := vm.NewEVM(evmtypes.BlockContext{BlockNumber: 1}, evmtypes.TxContext{GasPrice: uint256.NewInt(1)}, state.New(state.NewNoopReader()), chain.TestChainConfig, vm.Config{Tracer: tracer.Hooks})
 	scope := &vm.ScopeContext{
 		Contract: vm.NewContract(&account{}, common.Address{}, uint256.NewInt(0), 0, false /* skipAnalysis */, c),
 	}
@@ -223,7 +214,7 @@ func TestNoStepExec(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		env := vm.NewEVM(evmtypes.BlockContext{BlockNumber: 1}, evmtypes.TxContext{GasPrice: uint256.NewInt(100)}, &dummyStatedb{}, chain.TestChainConfig, vm.Config{Tracer: tracer.Hooks})
+		env := vm.NewEVM(evmtypes.BlockContext{BlockNumber: 1}, evmtypes.TxContext{GasPrice: uint256.NewInt(100)}, state.New(state.NewNoopReader()), chain.TestChainConfig, vm.Config{Tracer: tracer.Hooks})
 		tracer.OnTxStart(env.GetVMContext(), types.NewTransaction(0, common.Address{}, new(uint256.Int), 0, new(uint256.Int), nil), common.Address{})
 		tracer.OnEnter(0, byte(vm.CALL), common.Address{}, common.Address{}, false, []byte{}, 1000, uint256.NewInt(0), []byte{})
 		tracer.OnExit(0, nil, 0, nil, false)

--- a/eth/tracers/logger/access_list_tracer.go
+++ b/eth/tracers/logger/access_list_tracer.go
@@ -25,9 +25,9 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/crypto"
 	"github.com/erigontech/erigon-lib/types"
+	"github.com/erigontech/erigon/core/state"
 	"github.com/erigontech/erigon/core/tracing"
 	"github.com/erigontech/erigon/core/vm"
-	"github.com/erigontech/erigon/core/vm/evmtypes"
 	"github.com/erigontech/erigon/eth/tracers"
 )
 
@@ -140,7 +140,7 @@ func (al accessList) accessListSorted() types.AccessList {
 type AccessListTracer struct {
 	excl               map[common.Address]struct{} // Set of account to exclude from the list
 	list               accessList                  // Set of accounts and storage slots touched
-	state              evmtypes.IntraBlockState    // State for nonce calculation of created contracts
+	state              *state.IntraBlockState      // State for nonce calculation of created contracts
 	createdContracts   map[common.Address]struct{} // Set of all addresses of contracts created during txn execution
 	usedBeforeCreation map[common.Address]struct{} // Set of all contract addresses first used before creation
 }
@@ -150,7 +150,7 @@ type AccessListTracer struct {
 // the resulting accesslist.
 // An optional set of addresses to be excluded from the resulting accesslist can
 // also be specified.
-func NewAccessListTracer(acl types.AccessList, exclude map[common.Address]struct{}, state evmtypes.IntraBlockState) *AccessListTracer {
+func NewAccessListTracer(acl types.AccessList, exclude map[common.Address]struct{}, state *state.IntraBlockState) *AccessListTracer {
 	excl := make(map[common.Address]struct{})
 	if exclude != nil {
 		excl = exclude

--- a/eth/tracers/logger/logger_test.go
+++ b/eth/tracers/logger/logger_test.go
@@ -63,9 +63,12 @@ func (*dummyStatedb) GetCommittedState(common.Address, common.Hash, *uint256.Int
 
 func TestStoreCapture(t *testing.T) {
 	c := vm.NewJumpDestCache(128)
+	ibs := state.New(state.NewNoopReader())
+	ibs.AddRefund(1337)
+
 	var (
 		logger   = NewStructLogger(nil)
-		evm      = vm.NewEVM(evmtypes.BlockContext{}, evmtypes.TxContext{}, &dummyStatedb{}, chain.TestChainConfig, vm.Config{Tracer: logger.Hooks()})
+		evm      = vm.NewEVM(evmtypes.BlockContext{}, evmtypes.TxContext{}, ibs, chain.TestChainConfig, vm.Config{Tracer: logger.Hooks()})
 		contract = vm.NewContract(&dummyContractRef{}, common.Address{}, new(uint256.Int), 100000, false /* skipAnalysis */, c)
 	)
 	contract.Code = []byte{byte(vm.PUSH1), 0x1, byte(vm.PUSH1), 0x0, byte(vm.SSTORE)}

--- a/eth/tracers/logger/logger_test.go
+++ b/eth/tracers/logger/logger_test.go
@@ -49,18 +49,6 @@ func (d *dummyContractRef) SetBalance(*big.Int)        {}
 func (d *dummyContractRef) SetNonce(uint64)            {}
 func (d *dummyContractRef) Balance() *big.Int          { return new(big.Int) }
 
-type dummyStatedb struct {
-	state.IntraBlockState
-}
-
-func (*dummyStatedb) GetRefund() uint64                                              { return 1337 }
-func (*dummyStatedb) GetState(_ common.Address, _ common.Hash, _ *uint256.Int) error { return nil }
-func (*dummyStatedb) SetState(_ common.Address, _ common.Hash, _ uint256.Int) error  { return nil }
-func (*dummyStatedb) AddSlotToAccessList(_ common.Address, _ common.Hash) (addrMod, slotMod bool) {
-	return false, false
-}
-func (*dummyStatedb) GetCommittedState(common.Address, common.Hash, *uint256.Int) error { return nil }
-
 func TestStoreCapture(t *testing.T) {
 	c := vm.NewJumpDestCache(128)
 	ibs := state.New(state.NewNoopReader())

--- a/rpc/jsonrpc/eth_callMany.go
+++ b/rpc/jsonrpc/eth_callMany.go
@@ -232,7 +232,7 @@ func (api *APIImpl) CallMany(ctx context.Context, bundles []Bundle, simulateCont
 	// after replaying the txns, we want to overload the state
 	// overload state
 	if stateOverride != nil {
-		err = stateOverride.Override((evm.IntraBlockState()).(*state.IntraBlockState))
+		err = stateOverride.Override(evm.IntraBlockState())
 		if err != nil {
 			return nil, err
 		}

--- a/rpc/jsonrpc/tracing.go
+++ b/rpc/jsonrpc/tracing.go
@@ -567,7 +567,7 @@ func (api *PrivateDebugAPIImpl) TraceCallMany(ctx context.Context, bundles []Bun
 				return err
 			}
 			txCtx = core.NewEVMTxContext(msg)
-			ibs := evm.IntraBlockState().(*state.IntraBlockState)
+			ibs := evm.IntraBlockState()
 			ibs.SetTxContext(txnIndex)
 			_, err = transactions.TraceTx(ctx, api.engine(), transaction, msg, blockCtx, txCtx, block.Hash(), txnIndex, evm.IntraBlockState(), config, chainConfig, stream, api.evmCallTimeout)
 			if err != nil {

--- a/turbo/transactions/tracing.go
+++ b/turbo/transactions/tracing.go
@@ -98,7 +98,7 @@ func TraceTx(
 	txCtx evmtypes.TxContext,
 	blockHash common.Hash,
 	txnIndex int,
-	ibs evmtypes.IntraBlockState,
+	ibs *state.IntraBlockState,
 	config *tracersConfig.TraceConfig,
 	chainConfig *chain.Config,
 	stream *jsoniter.Stream,
@@ -188,7 +188,7 @@ func AssembleTracer(
 func ExecuteTraceTx(
 	blockCtx evmtypes.BlockContext,
 	txCtx evmtypes.TxContext,
-	ibs evmtypes.IntraBlockState,
+	ibs *state.IntraBlockState,
 	config *tracersConfig.TraceConfig,
 	chainConfig *chain.Config,
 	stream *jsoniter.Stream,


### PR DESCRIPTION
Mostly was motivated by seen `AccessList` methods in profiler
```
go test -bench=BenchmarkCall -run=Benchmark  ./core/vm/runtime -count=10 > new2.txt
go test -bench=BenchmarkCall -run=Benchmark  ./core/vm/runtime -count=10 > old2.txt

/home/erigon/go/bin/benchstat old2.txt new2.txt
goos: linux
goarch: amd64
pkg: github.com/erigontech/erigon/core/vm/runtime
cpu: AMD EPYC 4344P 8-Core Processor
        │  old2.txt   │              new2.txt              │
        │   sec/op    │   sec/op     vs base               │
Call-16   3.165m ± 0%   3.097m ± 1%  -2.13% (p=0.000 n=10)

        │   old2.txt   │              new2.txt               │
        │     B/op     │     B/op      vs base               │
Call-16   1.800Mi ± 0%   1.758Mi ± 0%  -2.34% (p=0.000 n=10)

        │  old2.txt   │            new2.txt             │
        │  allocs/op  │  allocs/op   vs base            │
Call-16   19.20k ± 0%   19.20k ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```

```
go test -bench=BenchmarkSimple -run=Benchmark  ./core/vm/runtime -count=10 > new2.txt
go test -bench=BenchmarkSimple -run=Benchmark  ./core/vm/runtime -count=10 > old2.txt


/home/erigon/go/bin/benchstat old.txt new.txt
goos: linux
goarch: amd64
pkg: github.com/erigontech/erigon/core/vm/runtime
cpu: AMD EPYC 4344P 8-Core Processor
                                       │   old.txt    │               new.txt               │
                                       │    sec/op    │    sec/op     vs base               │
SimpleLoop/staticcall-identity-100M-16   233.9m ± 12%   231.3m ±  2%       ~ (p=0.190 n=10)
SimpleLoop/call-identity-100M-16         338.1m ±  1%   327.9m ±  2%  -3.03% (p=0.000 n=10)
SimpleLoop/loop-100M-16                  264.7m ±  3%   261.7m ±  3%       ~ (p=0.218 n=10)
SimpleLoop/loop2-100M-16                 305.1m ±  3%   343.2m ± 19%       ~ (p=0.143 n=10)
SimpleLoop/call-nonexist-100M-16         309.5m ±  3%   315.1m ±  5%       ~ (p=0.105 n=10)
SimpleLoop/call-EOA-100M-16              348.1m ±  1%   328.5m ±  2%  -5.63% (p=0.001 n=10)
SimpleLoop/call-reverting-100M-16        503.7m ±  2%   472.6m ±  1%  -6.17% (p=0.000 n=10)
geomean                                  320.4m         318.6m        -0.56%

                                       │   old.txt    │               new.txt               │
                                       │     B/op     │     B/op      vs base               │
SimpleLoop/staticcall-identity-100M-16   67.94Mi ± 0%   67.94Mi ± 0%       ~ (p=0.075 n=10)
SimpleLoop/call-identity-100M-16         66.57Mi ± 0%   66.57Mi ± 0%  -0.00% (p=0.041 n=10)
SimpleLoop/loop-100M-16                  2.105Ki ± 7%   1.967Ki ± 7%  -6.59% (p=0.046 n=10)
SimpleLoop/loop2-100M-16                 2.105Ki ± 0%   2.105Ki ± 7%       ~ (p=0.582 n=10)
SimpleLoop/call-nonexist-100M-16         22.78Mi ± 0%   22.78Mi ± 0%       ~ (p=0.582 n=10)
SimpleLoop/call-EOA-100M-16              22.78Mi ± 0%   22.78Mi ± 0%  -0.00% (p=0.000 n=10)
SimpleLoop/call-reverting-100M-16        201.7Mi ± 0%   201.7Mi ± 0%  -0.00% (p=0.005 n=10)
geomean                                  2.962Mi        2.933Mi       -0.97%

                                       │   old.txt   │               new.txt                │
                                       │  allocs/op  │  allocs/op   vs base                 │
SimpleLoop/staticcall-identity-100M-16   2.740M ± 0%   2.740M ± 0%       ~ (p=0.582 n=10)
SimpleLoop/call-identity-100M-16         2.685M ± 0%   2.685M ± 0%       ~ (p=0.470 n=10)
SimpleLoop/loop-100M-16                   13.00 ± 0%    13.00 ± 0%       ~ (p=1.000 n=10) ¹
SimpleLoop/loop2-100M-16                  13.00 ± 0%    13.00 ± 0%       ~ (p=1.000 n=10) ¹
SimpleLoop/call-nonexist-100M-16         746.3k ± 0%   746.3k ± 0%       ~ (p=0.582 n=10)
SimpleLoop/call-EOA-100M-16              746.3k ± 0%   746.3k ± 0%  -0.00% (p=0.001 n=10)
SimpleLoop/call-reverting-100M-16        3.571M ± 0%   3.571M ± 0%  -0.00% (p=0.048 n=10)
geomean                                  58.94k        58.94k       -0.00%
¹ all samples are equal
```