### PR TITLE
tests: run TestShutterBlockBuilding and TestMiningBenchmark in medium tests

### DIFF
--- a/tests/bor/mining_test.go
+++ b/tests/bor/mining_test.go
@@ -14,9 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Erigon. If not, see <http://www.gnu.org/licenses/>.
 
-// Skip when running tests with race detector on macOS: see issue #15007
-//go:build !(darwin && race)
-
 package bor
 
 import (
@@ -24,6 +21,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"fmt"
+	"runtime"
 	"testing"
 	"time"
 
@@ -72,7 +70,11 @@ var (
 // In TestMiningBenchmark, we will test the mining performance. We will initialize a single node devnet and fire 5000 txs. We will measure the time it takes to include all the txs. This can be made more advcanced by increasing blockLimit and txsInTxpool.
 func TestMiningBenchmark(t *testing.T) {
 	if testing.Short() {
-		t.Skip("too slow for testing.Short")
+		t.Skip()
+	}
+	if runtime.GOOS == "darwin" {
+		// We run race detector for medium tests which fails on macOS.
+		t.Skip("issue #15007")
 	}
 
 	//usually 15sec is enough

--- a/txnprovider/shutter/block_building_integration_test.go
+++ b/txnprovider/shutter/block_building_integration_test.go
@@ -14,9 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Erigon. If not, see <http://www.gnu.org/licenses/>.
 
-// Skip when running tests with race detector: see issue #15007
-//go:build !race
-
 package shutter_test
 
 import (
@@ -26,6 +23,7 @@ import (
 	"fmt"
 	"math/big"
 	"path"
+	"runtime"
 	"testing"
 	"time"
 
@@ -63,7 +61,11 @@ import (
 
 func TestShutterBlockBuilding(t *testing.T) {
 	if testing.Short() {
-		t.Skip("too slow for testing.Short")
+		t.Skip()
+	}
+	if runtime.GOOS == "darwin" {
+		// We run race detector for medium tests which fails on macOS.
+		t.Skip("issue #15007")
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
PRs https://github.com/erigontech/erigon/pull/14972 and https://github.com/erigontech/erigon/pull/15144 have unintentionally disabled `TestMiningBenchmark` and `TestShutterBlockBuilding`:
- The first PR moved those tests from "medium" to "short" by introducing the `go:build !race` build tag
- Then, the second PR skipped them entirely because they were too slow

Instead we should just:
- skip the tests if we are running the "short" test suite
- skip the tests if we are running the "medium" test suite but the os is "darwin" until https://github.com/erigontech/erigon/issues/15007 gets resolved - this way the tests will be run on the linux and win "medium" test runs as opposed to never being run
