### PR TITLE
Engine-API: Fixed `context canceled`

### DIFF
--- a/execution/eth1/ethereum_execution.go
+++ b/execution/eth1/ethereum_execution.go
@@ -372,15 +372,15 @@ func (e *EthereumExecutionModule) Start(ctx context.Context) {
 
 func (e *EthereumExecutionModule) Ready(ctx context.Context, _ *emptypb.Empty) (*execution.ReadyResponse, error) {
 
-	if err := <-e.blockReader.Ready(ctx); err != nil {
-		return &execution.ReadyResponse{Ready: false}, err
-	}
-
 	if !e.semaphore.TryAcquire(1) {
 		e.logger.Trace("ethereumExecutionModule.Ready: ExecutionStatus_Busy")
 		return &execution.ReadyResponse{Ready: false}, nil
 	}
 	defer e.semaphore.Release(1)
+
+	if err := <-e.blockReader.Ready(ctx); err != nil {
+		return &execution.ReadyResponse{Ready: false}, err
+	}
 	return &execution.ReadyResponse{Ready: true}, nil
 }
 

--- a/turbo/snapshotsync/snapshots.go
+++ b/turbo/snapshotsync/snapshots.go
@@ -700,7 +700,7 @@ func (r *ready) set() {
 	if r.state.Load() {
 		return
 	}
-	r.state.Store(true)
+	r.state.CompareAndSwap(false, true)
 	close(r.on)
 }
 

--- a/turbo/snapshotsync/snapshots.go
+++ b/turbo/snapshotsync/snapshots.go
@@ -674,7 +674,7 @@ func (s *RoSnapshots) HasType(in snaptype.Type) bool {
 type ready struct {
 	mu     sync.Mutex
 	on     chan struct{}
-	state  bool
+	state  atomic.Bool
 	inited bool
 }
 
@@ -697,15 +697,20 @@ func (r *ready) set() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.init()
-	if r.state {
+	if r.state.Load() {
 		return
 	}
-	r.state = true
+	r.state.Store(true)
 	close(r.on)
 }
 
 func (s *RoSnapshots) Ready(ctx context.Context) <-chan error {
 	errc := make(chan error)
+
+	if s.ready.state.Load() {
+		close(errc)
+		return errc
+	}
 
 	go func() {
 		select {

--- a/turbo/snapshotsync/snapshots.go
+++ b/turbo/snapshotsync/snapshots.go
@@ -700,8 +700,9 @@ func (r *ready) set() {
 	if r.state.Load() {
 		return
 	}
-	r.state.CompareAndSwap(false, true)
-	close(r.on)
+	if r.state.CompareAndSwap(false, true) {
+		close(r.on)
+	}
 }
 
 func (s *RoSnapshots) Ready(ctx context.Context) <-chan error {


### PR DESCRIPTION
also skip making a goroutine in the average case