### PR TITLE
rpcdaemon: eth_call for future blocks should return an error (ssue 12850)

### DIFF
--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -82,7 +82,7 @@ func (api *APIImpl) Call(ctx context.Context, args ethapi2.CallArgs, blockNrOrHa
 		return nil, err
 	}
 	if header == nil {
-		return nil, nil
+		return nil, errors.New("header not found")
 	}
 
 	stateReader, err := rpchelper.CreateStateReader(ctx, tx, api._blockReader, blockNrOrHash, 0, api.filters, api.stateCache, chainConfig.ChainName)


### PR DESCRIPTION
closes #12850

eth_call(): for future blocks should return an error not null