### PR TITLE
Engine-API: Extend fcu waiting to 12 seconds from 500 milliseconds when building block

### DIFF
--- a/turbo/engineapi/engine_server.go
+++ b/turbo/engineapi/engine_server.go
@@ -628,8 +628,9 @@ func (s *EngineServer) forkchoiceUpdated(ctx context.Context, forkchoiceState *e
 	}
 
 	var resp *execution.AssembleBlockResponse
-
-	execBusy, err := waitForStuff(500*time.Millisecond, func() (bool, error) {
+	// Wait for the execution service to be ready to assemble a block. Wait a full slot duration (12 seconds) to ensure that the execution service is not busy.
+	// Blocks are important and 0.5 seconds is not enough to wait for the execution service to be ready.
+	execBusy, err := waitForStuff(12*time.Second, func() (bool, error) {
 		resp, err = s.executionService.AssembleBlock(ctx, req)
 		if err != nil {
 			return false, err

--- a/turbo/engineapi/engine_server.go
+++ b/turbo/engineapi/engine_server.go
@@ -630,7 +630,7 @@ func (s *EngineServer) forkchoiceUpdated(ctx context.Context, forkchoiceState *e
 	var resp *execution.AssembleBlockResponse
 	// Wait for the execution service to be ready to assemble a block. Wait a full slot duration (12 seconds) to ensure that the execution service is not busy.
 	// Blocks are important and 0.5 seconds is not enough to wait for the execution service to be ready.
-	execBusy, err := waitForStuff(12*time.Second, func() (bool, error) {
+	execBusy, err := waitForStuff(time.Duration(s.config.SecondsPerSlot())*time.Second, func() (bool, error) {
 		resp, err = s.executionService.AssembleBlock(ctx, req)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
Block building is critical, 500ms is too little. I pick 12s because it is the slot duration of ETH 2.0