### PR TITLE
R3 Polygon Bhilai Fork Updates

### DIFF
--- a/cmd/devnet/main.go
+++ b/cmd/devnet/main.go
@@ -301,7 +301,7 @@ func allScenarios(cliCtx *cli.Context, runCtx devnet.Context) scenarios.Scenario
 	const sendValue uint64 = 10000
 
 	return scenarios.Scenarios{
-		"dynamic-tx-node-0": {
+		"dynamic-tx-node-0": &scenarios.Scenario{
 			Context: runCtx.WithCurrentNetwork(0).WithCurrentNode(0),
 			Steps: []*scenarios.Step{
 				{Text: "InitSubscriptions", Args: []any{[]requests.SubMethod{requests.Methods.ETHNewHeads}}},
@@ -311,7 +311,7 @@ func allScenarios(cliCtx *cli.Context, runCtx devnet.Context) scenarios.Scenario
 				{Text: "AwaitBlocks", Args: []any{2 * time.Second}},
 			},
 		},
-		"dynamic-tx-any-node": {
+		"dynamic-tx-any-node": &scenarios.Scenario{
 			Context: runCtx.WithCurrentNetwork(0),
 			Steps: []*scenarios.Step{
 				{Text: "InitSubscriptions", Args: []any{[]requests.SubMethod{requests.Methods.ETHNewHeads}}},
@@ -321,14 +321,14 @@ func allScenarios(cliCtx *cli.Context, runCtx devnet.Context) scenarios.Scenario
 				{Text: "AwaitBlocks", Args: []any{2 * time.Second}},
 			},
 		},
-		"call-contract": {
+		"call-contract": &scenarios.Scenario{
 			Context: runCtx.WithCurrentNetwork(0),
 			Steps: []*scenarios.Step{
 				{Text: "InitSubscriptions", Args: []any{[]requests.SubMethod{requests.Methods.ETHNewHeads}}},
 				{Text: "DeployAndCallLogSubscriber", Args: []any{accounts.DevAddress}},
 			},
 		},
-		"state-sync": {
+		"state-sync": &scenarios.Scenario{
 			Steps: []*scenarios.Step{
 				{Text: "InitSubscriptions", Args: []any{[]requests.SubMethod{requests.Methods.ETHNewHeads}}},
 				{Text: "CreateAccountWithFunds", Args: []any{networkname.Dev, "root-funder", 200.0}},
@@ -340,7 +340,7 @@ func allScenarios(cliCtx *cli.Context, runCtx devnet.Context) scenarios.Scenario
 				{Text: "BatchProcessRootTransfers", Args: []any{"root-funder", 1, 10, 2, 2}},
 			},
 		},
-		"child-chain-exit": {
+		"child-chain-exit": &scenarios.Scenario{
 			Steps: []*scenarios.Step{
 				{Text: "CreateAccountWithFunds", Args: []any{networkname.Dev, "root-funder", 200.0}},
 				{Text: "CreateAccountWithFunds", Args: []any{networkname.BorDevnet, "child-funder", 200.0}},
@@ -350,7 +350,7 @@ func allScenarios(cliCtx *cli.Context, runCtx devnet.Context) scenarios.Scenario
 				//{Text: "BatchProcessTransfers", Args: []any{"child-funder", 1, 10, 2, 2}},
 			},
 		},
-		"block-production": {
+		"block-production": &scenarios.Scenario{
 			Steps: []*scenarios.Step{
 				{Text: "SendTxLoad", Args: []any{recipientAddress, accounts.DevAddress, sendValue, cliCtx.Uint(txCountFlag.Name)}},
 			},

--- a/cmd/integration/commands/flags.go
+++ b/cmd/integration/commands/flags.go
@@ -65,7 +65,7 @@ func withConfig(cmd *cobra.Command) {
 func withMining(cmd *cobra.Command) {
 	cmd.Flags().Bool("mine", false, "Enable mining")
 	cmd.Flags().StringArray("miner.notify", nil, "Comma separated HTTP URL list to notify of new work packages")
-	cmd.Flags().Uint64("miner.gaslimit", ethconfig.Defaults.Miner.GasLimit, "Target gas limit for mined blocks")
+	cmd.Flags().Uint64("miner.gaslimit", ethconfig.DefaultMinerGasLimit, "Target gas limit for mined blocks")
 	cmd.Flags().Int64("miner.gasprice", ethconfig.Defaults.Miner.GasPrice.Int64(), "Target gas price for mined blocks")
 	cmd.Flags().String("miner.etherbase", "0", "Public address for block mining rewards (default = first account")
 	cmd.Flags().String("miner.extradata", "", "Block extra data set by the miner (default = client version)")

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1670,11 +1670,12 @@ func SetupMinerCobra(cmd *cobra.Command, cfg *params.MiningConfig) {
 		panic(err)
 	}
 	cfg.ExtraData = []byte(extraDataStr)
-	gasLimit, err := flags.GetUint64(MinerGasLimitFlag.Name)
-	if _, ok := err.(*strconv.NumError); ok || err == nil {
+	if flags.Changed(MinerGasLimitFlag.Name) {
+		gasLimit, err := flags.GetUint64(MinerGasLimitFlag.Name)
+		if err != nil {
+			panic(err)
+		}
 		cfg.GasLimit = &gasLimit
-	} else {
-		panic(err)
 	}
 	price, err := flags.GetInt64(MinerGasPriceFlag.Name)
 	if err != nil {

--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -145,8 +145,13 @@ func CalcBaseFee(config *chain.Config, parent *types.Header) *big.Int {
 
 func getBaseFeeChangeDenominator(borConfig chain.BorConfig, number uint64) uint64 {
 	// If we're running bor based chain post delhi hardfork, return the new value
-	if borConfig, ok := borConfig.(*borcfg.BorConfig); ok && borConfig.IsDelhi(number) {
-		return params.BaseFeeChangeDenominatorPostDelhi
+	if borConfig, ok := borConfig.(*borcfg.BorConfig); ok {
+		switch {
+		case borConfig.IsBhilai(number):
+			return params.BaseFeeChangeDenominatorPostBhilai
+		case borConfig.IsDelhi(number):
+			return params.BaseFeeChangeDenominatorPostDelhi
+		}
 	}
 
 	// Return the original once for other chains and pre-fork cases

--- a/core/forkid/forkid.go
+++ b/core/forkid/forkid.go
@@ -254,6 +254,9 @@ func GatherForks(config *chain.Config, genesisTime uint64) (heightForks []uint64
 		if config.Bor.GetNapoliBlock() != nil {
 			heightForks = append(heightForks, config.Bor.GetNapoliBlock().Uint64())
 		}
+		if config.Bor.GetBhilaiBlock() != nil {
+			heightForks = append(heightForks, config.Bor.GetBhilaiBlock().Uint64())
+		}
 	}
 
 	// Sort the fork block numbers & times to permit chronological XOR

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -139,7 +139,6 @@ var PrecompiledContractsBhilai = map[libcommon.Address]PrecompiledContract{
 	libcommon.BytesToAddress([]byte{0x07}):       &bn256ScalarMulIstanbul{},
 	libcommon.BytesToAddress([]byte{0x08}):       &bn256PairingIstanbul{},
 	libcommon.BytesToAddress([]byte{0x09}):       &blake2F{},
-	libcommon.BytesToAddress([]byte{0x01, 0x00}): &p256Verify{},
 	libcommon.BytesToAddress([]byte{0x0b}):       &bls12381G1Add{},
 	libcommon.BytesToAddress([]byte{0x0c}):       &bls12381G1MultiExp{},
 	libcommon.BytesToAddress([]byte{0x0d}):       &bls12381G2Add{},
@@ -147,6 +146,7 @@ var PrecompiledContractsBhilai = map[libcommon.Address]PrecompiledContract{
 	libcommon.BytesToAddress([]byte{0x0f}):       &bls12381Pairing{},
 	libcommon.BytesToAddress([]byte{0x10}):       &bls12381MapFpToG1{},
 	libcommon.BytesToAddress([]byte{0x11}):       &bls12381MapFp2ToG2{},
+	libcommon.BytesToAddress([]byte{0x01, 0x00}): &p256Verify{},
 }
 
 var PrecompiledContractsPrague = map[libcommon.Address]PrecompiledContract{

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -211,10 +211,10 @@ func init() {
 // ActivePrecompiles returns the precompiles enabled with the current configuration.
 func ActivePrecompiles(rules *chain.Rules) []libcommon.Address {
 	switch {
-	case rules.IsPrague:
-		return PrecompiledAddressesPrague
 	case rules.IsBhilai:
 		return PrecompiledAddressesBhilai
+	case rules.IsPrague:
+		return PrecompiledAddressesPrague
 	case rules.IsNapoli:
 		return PrecompiledAddressesNapoli
 	case rules.IsCancun:

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -129,6 +129,26 @@ var PrecompiledContractsNapoli = map[libcommon.Address]PrecompiledContract{
 	libcommon.BytesToAddress([]byte{0x01, 0x00}): &p256Verify{},
 }
 
+var PrecompiledContractsBhilai = map[libcommon.Address]PrecompiledContract{
+	libcommon.BytesToAddress([]byte{0x01}):       &ecrecover{},
+	libcommon.BytesToAddress([]byte{0x02}):       &sha256hash{},
+	libcommon.BytesToAddress([]byte{0x03}):       &ripemd160hash{},
+	libcommon.BytesToAddress([]byte{0x04}):       &dataCopy{},
+	libcommon.BytesToAddress([]byte{0x05}):       &bigModExp{eip2565: true},
+	libcommon.BytesToAddress([]byte{0x06}):       &bn256AddIstanbul{},
+	libcommon.BytesToAddress([]byte{0x07}):       &bn256ScalarMulIstanbul{},
+	libcommon.BytesToAddress([]byte{0x08}):       &bn256PairingIstanbul{},
+	libcommon.BytesToAddress([]byte{0x09}):       &blake2F{},
+	libcommon.BytesToAddress([]byte{0x01, 0x00}): &p256Verify{},
+	libcommon.BytesToAddress([]byte{0x0b}):       &bls12381G1Add{},
+	libcommon.BytesToAddress([]byte{0x0c}):       &bls12381G1MultiExp{},
+	libcommon.BytesToAddress([]byte{0x0d}):       &bls12381G2Add{},
+	libcommon.BytesToAddress([]byte{0x0e}):       &bls12381G2MultiExp{},
+	libcommon.BytesToAddress([]byte{0x0f}):       &bls12381Pairing{},
+	libcommon.BytesToAddress([]byte{0x10}):       &bls12381MapFpToG1{},
+	libcommon.BytesToAddress([]byte{0x11}):       &bls12381MapFp2ToG2{},
+}
+
 var PrecompiledContractsPrague = map[libcommon.Address]PrecompiledContract{
 	libcommon.BytesToAddress([]byte{0x01}): &ecrecover{},
 	libcommon.BytesToAddress([]byte{0x02}): &sha256hash{},
@@ -150,8 +170,10 @@ var PrecompiledContractsPrague = map[libcommon.Address]PrecompiledContract{
 }
 
 var (
+	PrecompiledAddressesOsaka     []libcommon.Address
 	PrecompiledAddressesPrague    []libcommon.Address
 	PrecompiledAddressesNapoli    []libcommon.Address
+	PrecompiledAddressesBhilai    []libcommon.Address
 	PrecompiledAddressesCancun    []libcommon.Address
 	PrecompiledAddressesBerlin    []libcommon.Address
 	PrecompiledAddressesIstanbul  []libcommon.Address
@@ -178,6 +200,9 @@ func init() {
 	for k := range PrecompiledContractsNapoli {
 		PrecompiledAddressesNapoli = append(PrecompiledAddressesNapoli, k)
 	}
+	for k := range PrecompiledContractsBhilai {
+		PrecompiledAddressesBhilai = append(PrecompiledAddressesBhilai, k)
+	}
 	for k := range PrecompiledContractsPrague {
 		PrecompiledAddressesPrague = append(PrecompiledAddressesPrague, k)
 	}
@@ -188,6 +213,8 @@ func ActivePrecompiles(rules *chain.Rules) []libcommon.Address {
 	switch {
 	case rules.IsPrague:
 		return PrecompiledAddressesPrague
+	case rules.IsBhilai:
+		return PrecompiledAddressesBhilai
 	case rules.IsNapoli:
 		return PrecompiledAddressesNapoli
 	case rules.IsCancun:

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -40,6 +40,8 @@ var emptyHash = libcommon.Hash{}
 func (evm *EVM) precompile(addr libcommon.Address) (PrecompiledContract, bool) {
 	var precompiles map[libcommon.Address]PrecompiledContract
 	switch {
+	case evm.chainRules.IsBhilai:
+		precompiles = PrecompiledContractsBhilai
 	case evm.chainRules.IsPrague:
 		precompiles = PrecompiledContractsPrague
 	case evm.chainRules.IsNapoli:

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -129,12 +129,12 @@ func copyJumpTable(jt *JumpTable) *JumpTable {
 func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
 	var jt *JumpTable
 	switch {
+	case evm.ChainRules().IsBhilai:
+		jt = &bhilaiInstructionSet
 	case evm.ChainRules().IsPrague:
 		jt = &pragueInstructionSet
 	case evm.ChainRules().IsCancun:
 		jt = &cancunInstructionSet
-	case evm.ChainRules().IsBhilai:
-		jt = &bhilaiInstructionSet
 	case evm.ChainRules().IsNapoli:
 		jt = &napoliInstructionSet
 	case evm.ChainRules().IsShanghai:

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -133,6 +133,8 @@ func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
 		jt = &pragueInstructionSet
 	case evm.ChainRules().IsCancun:
 		jt = &cancunInstructionSet
+	case evm.ChainRules().IsBhilai:
+		jt = &bhilaiInstructionSet
 	case evm.ChainRules().IsNapoli:
 		jt = &napoliInstructionSet
 	case evm.ChainRules().IsShanghai:

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -65,6 +65,7 @@ var (
 	londonInstructionSet           = newLondonInstructionSet()
 	shanghaiInstructionSet         = newShanghaiInstructionSet()
 	napoliInstructionSet           = newNapoliInstructionSet()
+	bhilaiInstructionSet           = newBhilaiInstructionSet()
 	cancunInstructionSet           = newCancunInstructionSet()
 	pragueInstructionSet           = newPragueInstructionSet()
 )
@@ -107,6 +108,13 @@ func newCancunInstructionSet() JumpTable {
 	instructionSet := newNapoliInstructionSet()
 	enable4844(&instructionSet) // BLOBHASH opcode
 	enable7516(&instructionSet) // BLOBBASEFEE opcode
+	validateAndFillMaxStack(&instructionSet)
+	return instructionSet
+}
+
+func newBhilaiInstructionSet() JumpTable {
+	instructionSet := newNapoliInstructionSet()
+	enable7702(&instructionSet) // EIP-7702: set code tx
 	validateAndFillMaxStack(&instructionSet)
 	return instructionSet
 }

--- a/erigon-lib/chain/chain_config.go
+++ b/erigon-lib/chain/chain_config.go
@@ -621,7 +621,7 @@ func (c *Config) Rules(num uint64, time uint64) *Rules {
 		IsCancun:           c.IsCancun(time),
 		IsNapoli:           c.IsNapoli(num),
 		IsBhilai:           c.IsBhilai(num),
-		IsPrague:           c.IsPrague(time),
+		IsPrague:           c.IsPrague(time) || c.IsBhilai(num),
 		IsOsaka:            c.IsOsaka(time),
 		IsAura:             c.Aura != nil,
 	}

--- a/erigon-lib/chain/chain_config.go
+++ b/erigon-lib/chain/chain_config.go
@@ -152,6 +152,8 @@ type BorConfig interface {
 	GetNapoliBlock() *big.Int
 	IsAhmedabad(number uint64) bool
 	GetAhmedabadBlock() *big.Int
+	IsBhilai(num uint64) bool
+	GetBhilaiBlock() *big.Int
 	StateReceiverContractAddress() common.Address
 	CalculateSprintNumber(number uint64) uint64
 	CalculateSprintLength(number uint64) uint64
@@ -169,11 +171,12 @@ func (c *Config) String() string {
 	engine := c.getEngine()
 
 	if c.Bor != nil {
-		return fmt.Sprintf("{ChainID: %v, Agra: %v, Napoli: %v, Ahmedabad: %v, Engine: %v}",
+		return fmt.Sprintf("{ChainID: %v, Agra: %v, Napoli: %v, Ahmedabad: %v, Bhilai: %v, Engine: %v}",
 			c.ChainID,
 			c.Bor.GetAgraBlock(),
 			c.Bor.GetNapoliBlock(),
 			c.Bor.GetAhmedabadBlock(),
+			c.Bor.GetBhilaiBlock(),
 			engine,
 		)
 	}
@@ -287,6 +290,11 @@ func (c *Config) IsAgra(num uint64) bool {
 // Refer to https://forum.polygon.technology/t/pip-33-napoli-upgrade
 func (c *Config) IsNapoli(num uint64) bool {
 	return (c != nil) && (c.Bor != nil) && c.Bor.IsNapoli(num)
+}
+
+// Refer to https://forum.polygon.technology/t/pip-63-bhilai-hardfork
+func (c *Config) IsBhilai(num uint64) bool {
+	return (c != nil) && (c.Bor != nil) && c.Bor.IsBhilai(num)
 }
 
 // IsCancun returns whether time is either equal to the Cancun fork time or greater.
@@ -586,7 +594,7 @@ type Rules struct {
 	IsHomestead, IsTangerineWhistle, IsSpuriousDragon bool
 	IsByzantium, IsConstantinople, IsPetersburg       bool
 	IsIstanbul, IsBerlin, IsLondon, IsShanghai        bool
-	IsCancun, IsNapoli                                bool
+	IsCancun, IsNapoli, IsBhilai                      bool
 	IsPrague, IsOsaka                                 bool
 	IsAura                                            bool
 }
@@ -612,6 +620,7 @@ func (c *Config) Rules(num uint64, time uint64) *Rules {
 		IsShanghai:         c.IsShanghai(time) || c.IsAgra(num),
 		IsCancun:           c.IsCancun(time),
 		IsNapoli:           c.IsNapoli(num),
+		IsBhilai:           c.IsBhilai(num),
 		IsPrague:           c.IsPrague(time),
 		IsOsaka:            c.IsOsaka(time),
 		IsAura:             c.Aura != nil,

--- a/erigon-lib/common/fixedgas/intrinsic_gas.go
+++ b/erigon-lib/common/fixedgas/intrinsic_gas.go
@@ -1,3 +1,22 @@
+// Copyright 2014 The go-ethereum Authors
+// (original work)
+// Copyright 2024 The Erigon Authors
+// (modifications)
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
 package fixedgas
 
 import (
@@ -6,7 +25,7 @@ import (
 
 // IntrinsicGas computes the 'intrinsic gas' for a message with the given data.
 // TODO: convert the input to a struct
-func IntrinsicGas(data []byte, accessListLen, storageKeysLen uint64, isContractCreation bool, isHomestead, isEIP2028, isEIP3860, isPrague bool, authorizationsLen uint64) (uint64, uint64, bool) {
+func IntrinsicGas(data []byte, accessListLen, storageKeysLen uint64, isContractCreation bool, isEIP2, isEIP2028, isEIP3860, isEIP7623, isAATxn bool, authorizationsLen uint64) (uint64, uint64, bool) {
 	// Zero and non-zero bytes are priced differently
 	dataLen := uint64(len(data))
 	dataNonZeroLen := uint64(0)
@@ -16,14 +35,16 @@ func IntrinsicGas(data []byte, accessListLen, storageKeysLen uint64, isContractC
 		}
 	}
 
-	return CalcIntrinsicGas(dataLen, dataNonZeroLen, authorizationsLen, accessListLen, storageKeysLen, isContractCreation, isHomestead, isEIP2028, isEIP3860, isPrague)
+	return CalcIntrinsicGas(dataLen, dataNonZeroLen, authorizationsLen, accessListLen, storageKeysLen, isContractCreation, isEIP2, isEIP2028, isEIP3860, isEIP7623, isAATxn)
 }
 
 // CalcIntrinsicGas computes the 'intrinsic gas' for a message with the given data.
-func CalcIntrinsicGas(dataLen, dataNonZeroLen, authorizationsLen, accessListLen, storageKeysLen uint64, isContractCreation, isHomestead, isEIP2028, isShanghai, isPrague bool) (gas uint64, floorGas7623 uint64, overflow bool) {
+func CalcIntrinsicGas(dataLen, dataNonZeroLen, authorizationsLen, accessListLen, storageKeysLen uint64, isContractCreation, isEIP2, isEIP2028, isEIP3860, isEIP7623, isAATxn bool) (gas uint64, floorGas7623 uint64, overflow bool) {
 	// Set the starting gas for the raw transaction
-	if isContractCreation && isHomestead {
-		gas = TxGasContractCreation
+	if isContractCreation && isEIP2 {
+		gas = params.TxGasContractCreation
+	} else if isAATxn {
+		gas = params.TxAAGas
 	} else {
 		gas = TxGas
 	}
@@ -58,7 +79,7 @@ func CalcIntrinsicGas(dataLen, dataNonZeroLen, authorizationsLen, accessListLen,
 			return 0, 0, true
 		}
 
-		if isContractCreation && isShanghai {
+		if isContractCreation && isEIP3860 {
 			numWords := toWordSize(dataLen)
 			product, overflow = math.SafeMul(numWords, InitCodeWordGas)
 			if overflow {
@@ -70,8 +91,7 @@ func CalcIntrinsicGas(dataLen, dataNonZeroLen, authorizationsLen, accessListLen,
 			}
 		}
 
-		// EIP-7623
-		if isPrague {
+		if isEIP7623 {
 			tokenLen := dataLen + 3*nz
 			dataGas, overflow := math.SafeMul(tokenLen, TxTotalCostFloorPerToken)
 			if overflow {

--- a/erigon-lib/common/fixedgas/intrinsic_gas.go
+++ b/erigon-lib/common/fixedgas/intrinsic_gas.go
@@ -25,7 +25,7 @@ import (
 
 // IntrinsicGas computes the 'intrinsic gas' for a message with the given data.
 // TODO: convert the input to a struct
-func IntrinsicGas(data []byte, accessListLen, storageKeysLen uint64, isContractCreation bool, isEIP2, isEIP2028, isEIP3860, isEIP7623, isAATxn bool, authorizationsLen uint64) (uint64, uint64, bool) {
+func IntrinsicGas(data []byte, accessListLen, storageKeysLen uint64, isContractCreation bool, isEIP2, isEIP2028, isEIP3860, isEIP7623 bool, authorizationsLen uint64) (uint64, uint64, bool) {
 	// Zero and non-zero bytes are priced differently
 	dataLen := uint64(len(data))
 	dataNonZeroLen := uint64(0)
@@ -35,16 +35,14 @@ func IntrinsicGas(data []byte, accessListLen, storageKeysLen uint64, isContractC
 		}
 	}
 
-	return CalcIntrinsicGas(dataLen, dataNonZeroLen, authorizationsLen, accessListLen, storageKeysLen, isContractCreation, isEIP2, isEIP2028, isEIP3860, isEIP7623, isAATxn)
+	return CalcIntrinsicGas(dataLen, dataNonZeroLen, authorizationsLen, accessListLen, storageKeysLen, isContractCreation, isEIP2, isEIP2028, isEIP3860, isEIP7623)
 }
 
 // CalcIntrinsicGas computes the 'intrinsic gas' for a message with the given data.
-func CalcIntrinsicGas(dataLen, dataNonZeroLen, authorizationsLen, accessListLen, storageKeysLen uint64, isContractCreation, isEIP2, isEIP2028, isEIP3860, isEIP7623, isAATxn bool) (gas uint64, floorGas7623 uint64, overflow bool) {
+func CalcIntrinsicGas(dataLen, dataNonZeroLen, authorizationsLen, accessListLen, storageKeysLen uint64, isContractCreation, isEIP2, isEIP2028, isEIP3860, isEIP7623 bool) (gas uint64, floorGas7623 uint64, overflow bool) {
 	// Set the starting gas for the raw transaction
 	if isContractCreation && isEIP2 {
-		gas = params.TxGasContractCreation
-	} else if isAATxn {
-		gas = params.TxAAGas
+		gas = TxGasContractCreation
 	} else {
 		gas = TxGas
 	}

--- a/erigon-lib/common/fixedgas/intrinsic_gas_test.go
+++ b/erigon-lib/common/fixedgas/intrinsic_gas_test.go
@@ -1,3 +1,19 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
 package fixedgas
 
 import (

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -382,6 +382,8 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 	backend.genesisBlock = genesis
 	backend.genesisHash = genesis.Hash()
 
+	setDefaultMinerGasLimit(chainConfig, config, logger)
+
 	setBorDefaultMinerGasPrice(chainConfig, config, logger)
 	setBorDefaultTxPoolPriceLimit(chainConfig, config.TxPool, logger)
 
@@ -1907,6 +1909,20 @@ func setBorDefaultMinerGasPrice(chainConfig *chain.Config, config *ethconfig.Con
 	if chainConfig.Bor != nil && (config.Miner.GasPrice == nil || config.Miner.GasPrice.Cmp(ethconfig.BorDefaultMinerGasPrice) != 0) {
 		logger.Warn("Sanitizing invalid bor miner gas price", "provided", config.Miner.GasPrice, "updated", ethconfig.BorDefaultMinerGasPrice)
 		config.Miner.GasPrice = ethconfig.BorDefaultMinerGasPrice
+	}
+}
+
+func setDefaultMinerGasLimit(chainConfig *chain.Config, config *ethconfig.Config, logger log.Logger) {
+	if chainConfig.Bor != nil {
+		if config.Miner.GasLimit == nil {
+			gasLimit := ethconfig.BorDefaultMinerGasLimit
+			config.Miner.GasLimit = &gasLimit
+		}
+	} else {
+		if config.Miner.GasLimit == nil {
+			gasLimit := ethconfig.DefaultMinerGasLimit
+			config.Miner.GasLimit = &gasLimit
+		}
 	}
 }
 

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -48,7 +48,10 @@ import (
 )
 
 // BorDefaultMinerGasPrice defines the minimum gas price for bor validators to mine a transaction.
-var BorDefaultMinerGasPrice = big.NewInt(25 * params.GWei)
+var BorDefaultMinerGasPrice = big.NewInt(25 * common.GWei)
+var BorDefaultMinerGasLimit uint64 = 45_000_000
+
+var DefaultMinerGasLimit uint64 = 36_000_000
 
 // FullNodeGPO contains default gasprice oracle settings for full node.
 var FullNodeGPO = gaspricecfg.Config{
@@ -91,8 +94,7 @@ var Defaults = Config{
 	NetworkID: 1,
 	Prune:     prune.DefaultMode,
 	Miner: params.MiningConfig{
-		GasLimit: 36_000_000,
-		GasPrice: big.NewInt(params.GWei),
+		GasPrice: big.NewInt(common.GWei),
 		Recommit: 3 * time.Second,
 	},
 	TxPool:      txpoolcfg.DefaultConfig,

--- a/eth/stagedsync/stage_mining_create_block.go
+++ b/eth/stagedsync/stage_mining_create_block.go
@@ -185,7 +185,7 @@ func SpawnMiningCreateBlockStage(s *StageState, txc wrap.TxContainer, cfg Mining
 		uncles:    mapset.NewSet[libcommon.Hash](),
 	}
 
-	header := core.MakeEmptyHeader(parent, &cfg.chainConfig, timestamp, &cfg.miner.MiningConfig.GasLimit)
+	header := core.MakeEmptyHeader(parent, &cfg.chainConfig, timestamp, cfg.miner.MiningConfig.GasLimit)
 	if err := misc.VerifyGaslimit(parent.GasLimit, header.GasLimit); err != nil {
 		logger.Warn("Failed to verify gas limit given by the validator, defaulting to parent gas limit", "err", err)
 		header.GasLimit = parent.GasLimit

--- a/eth/stagedsync/stage_mining_exec.go
+++ b/eth/stagedsync/stage_mining_exec.go
@@ -341,7 +341,7 @@ func filterBadTransactions(transactions []types.Transaction, chainID *uint256.In
 		// Make sure the sender is an EOA (EIP-3607)
 		if !account.IsEmptyCodeHash() {
 			isEoaCodeAllowed := false
-			if config.IsPrague(header.Time) ||  config.IsBhilai(header.Number.Uint64()) {
+			if config.IsPrague(header.Time) || config.IsBhilai(header.Number.Uint64()) {
 				code, err := simStateReader.ReadAccountCode(sender, account.Incarnation)
 				if err != nil {
 					return nil, err

--- a/eth/stagedsync/stage_mining_exec.go
+++ b/eth/stagedsync/stage_mining_exec.go
@@ -341,7 +341,7 @@ func filterBadTransactions(transactions []types.Transaction, chainID *uint256.In
 		// Make sure the sender is an EOA (EIP-3607)
 		if !account.IsEmptyCodeHash() {
 			isEoaCodeAllowed := false
-			if config.IsPrague(header.Time) {
+			if config.IsPrague(header.Time) ||  config.IsBhilai(header.Number.Uint64()) {
 				code, err := simStateReader.ReadAccountCode(sender, account.Incarnation)
 				if err != nil {
 					return nil, err

--- a/eth/stagedsync/stagedsynctest/harness.go
+++ b/eth/stagedsync/stagedsynctest/harness.go
@@ -289,8 +289,7 @@ func (h *Harness) SetMiningBlockEmptyHeader(ctx context.Context, t *testing.T, p
 	require.NotNil(t, parent)
 
 	timestamp := uint64(time.Now().Unix())
-	gasLimit := &h.miningState.MiningConfig.GasLimit
-	h.miningState.MiningBlock.Header = core.MakeEmptyHeader(parent, h.chainConfig, timestamp, gasLimit)
+	h.miningState.MiningBlock.Header = core.MakeEmptyHeader(parent, h.chainConfig, timestamp, h.miningState.MiningConfig.GasLimit)
 }
 
 func (h *Harness) ReadSpansFromDB(ctx context.Context) (spans []*heimdall.Span, err error) {

--- a/params/mining.go
+++ b/params/mining.go
@@ -33,8 +33,8 @@ type MiningConfig struct {
 	Etherbase  libcommon.Address `toml:",omitempty"` // Public address for block mining rewards
 	SigKey     *ecdsa.PrivateKey // ECDSA private key for signing blocks
 	Notify     []string          `toml:",omitempty"` // HTTP URL list to be notified of new work packages(only useful in ethash).
-	ExtraData  hexutility.Bytes  `toml:",omitempty"` // Block extra data set by the miner
-	GasLimit   uint64            // Target gas limit for mined blocks.
+	ExtraData  hexutility.Bytes     `toml:",omitempty"` // Block extra data set by the miner
+	GasLimit   *uint64           // Target gas limit for mined blocks.
 	GasPrice   *big.Int          // Minimum gas price for mining a transaction
 	Recommit   time.Duration     // The time interval for miner to re-create mining work.
 }

--- a/params/mining.go
+++ b/params/mining.go
@@ -33,7 +33,7 @@ type MiningConfig struct {
 	Etherbase  libcommon.Address `toml:",omitempty"` // Public address for block mining rewards
 	SigKey     *ecdsa.PrivateKey // ECDSA private key for signing blocks
 	Notify     []string          `toml:",omitempty"` // HTTP URL list to be notified of new work packages(only useful in ethash).
-	ExtraData  hexutility.Bytes     `toml:",omitempty"` // Block extra data set by the miner
+	ExtraData  hexutility.Bytes  `toml:",omitempty"` // Block extra data set by the miner
 	GasLimit   *uint64           // Target gas limit for mined blocks.
 	GasPrice   *big.Int          // Minimum gas price for mining a transaction
 	Recommit   time.Duration     // The time interval for miner to re-create mining work.

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -125,10 +125,11 @@ const (
 	// Introduced in Tangerine Whistle (Eip 150)
 	CreateBySelfdestructGas uint64 = 25000
 
-	BaseFeeChangeDenominator          = 8          // Bounds the amount the base fee can change between blocks.
-	BaseFeeChangeDenominatorPostDelhi = 16         // Bounds the amount the base fee can change between blocks post delhi hard fork for polygon networks.
-	ElasticityMultiplier              = 2          // Bounds the maximum gas limit an EIP-1559 block may have.
-	InitialBaseFee                    = 1000000000 // Initial base fee for EIP-1559 blocks.
+	BaseFeeChangeDenominator           = 8          // Bounds the amount the base fee can change between blocks.
+	BaseFeeChangeDenominatorPostDelhi  = 16         // Bounds the amount the base fee can change between blocks post delhi hard fork for polygon networks.
+	BaseFeeChangeDenominatorPostBhilai = 64         // Bounds the amount the base fee can change between blocks post bhilai hard fork for polygon networks.
+	ElasticityMultiplier               = 2          // Bounds the maximum gas limit an EIP-1559 block may have.
+	InitialBaseFee                     = 1000000000 // Initial base fee for EIP-1559 blocks.
 
 	MaxCodeSize              = 24576           // Maximum bytecode to permit for a contract
 	MaxCodeSizePostAhmedabad = 32768           // Maximum bytecode to permit for a contract post Ahmedabad hard fork (bor / polygon pos) (32KB)

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -275,12 +275,12 @@ func ValidateHeaderTime(
 		// early block announcements. Note that this is a loose check and would allow early blocks
 		// from non-primary producer. Such blocks will be rejected later when we know the succession
 		// number of the signer in the current sprint.
-		if header.Time-config.CalculatePeriod(header.Number.Uint64()) > uint64(time.Now().Unix()) {
+		if header.Time-config.CalculatePeriod(header.Number.Uint64()) > uint64(now.Unix()) {
 			return fmt.Errorf("%w: expected: %s(%s), got: %s", consensus.ErrFutureBlock, time.Unix(now.Unix(), 0), now, time.Unix(int64(header.Time), 0))
 		}
 	} else {
 		// Don't waste time checking blocks from the future
-		if header.Time > uint64(time.Now().Unix()) {
+		if header.Time > uint64(now.Unix()) {
 			return fmt.Errorf("%w: expected: %s(%s), got: %s", consensus.ErrFutureBlock, time.Unix(now.Unix(), 0), now, time.Unix(int64(header.Time), 0))
 		}
 	}
@@ -301,7 +301,7 @@ func ValidateHeaderTime(
 
 	// Post Bhilai HF, reject blocks form non-primary producers if they're earlier than the expected time
 	if config.IsBhilai(header.Number.Uint64()) && succession != 0 {
-		if header.Time > uint64(time.Now().Unix()) {
+		if header.Time > uint64(now.Unix()) {
 			return fmt.Errorf("%w: expected: %s(%s), got: %s", consensus.ErrFutureBlock, time.Unix(now.Unix(), 0), now, time.Unix(int64(header.Time), 0))
 		}
 	}
@@ -1035,8 +1035,9 @@ func (c *Bor) Prepare(chain consensus.ChainHeaderReader, header *types.Header, s
 	}
 
 	header.Time = MinNextBlockTime(parent, succession, c.config)
-	if header.Time < uint64(time.Now().Unix()) {
-		header.Time = uint64(time.Now().Unix())
+	now := time.Now()
+	if header.Time < uint64(now.Unix()) {
+		header.Time = uint64(now.Unix())
 	} else {
 		// For primary validators, wait until the current block production window
 		// starts. This prevents bor from starting to build next block before time
@@ -1239,13 +1240,10 @@ func (c *Bor) Seal(chain consensus.ChainHeaderReader, blockWithReceipts *types.B
 
 	var delay time.Duration
 	// Sweet, the protocol permits us to sign the block, wait for our time
-	if c.config.IsBhilai(header.Number.Uint64()) {
-		delay = time.Until(time.Unix(int64(header.Time), 0)) // Wait until we reach header time for non-primary validators
-		if successionNumber == 0 {
-			// For primary producers, set the delay to `header.Time - block time` instead of `header.Time`
-			// for early block announcement instead of waiting for full block time.
-			delay = time.Until(time.Unix(int64(header.Time-c.config.CalculatePeriod(number)), 0))
-		}
+	if c.config.IsBhilai(header.Number.Uint64()) && successionNumber == 0 {
+		// For primary producers, set the delay to `header.Time - block time` instead of `header.Time`
+		// for early block announcement instead of waiting for full block time.
+		delay = time.Until(time.Unix(int64(header.Time-c.config.CalculatePeriod(number)), 0))
 	} else {
 		delay = time.Until(time.Unix(int64(header.Time), 0)) // Wait until we reach header time
 	}

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -1135,6 +1135,9 @@ func (c *Bor) FinalizeAndAssemble(chainConfig *chain.Config, header *types.Heade
 
 func (c *Bor) Initialize(config *chain.Config, chain consensus.ChainHeaderReader, header *types.Header,
 	state *state.IntraBlockState, syscall consensus.SysCallCustom, logger log.Logger, tracer *tracing.Hooks) {
+	if chain.Config().IsBhilai(header.Time) {
+		misc.StoreBlockHashesEip2935(header, state, config, chain)
+	}
 }
 
 // Authorize injects a private key into the consensus engine to mint new blocks

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -275,7 +275,7 @@ func ValidateHeaderTime(
 		// early block announcements. Note that this is a loose check and would allow early blocks
 		// from non-primary producer. Such blocks will be rejected later when we know the succession
 		// number of the signer in the current sprint.
-		if header.Time-config.CalculatePeriod(header.Number.Uint64()) > uint64(now.Unix()) {
+		if header.Time > uint64(now.Unix())+config.CalculatePeriod(header.Number.Uint64()) {
 			return fmt.Errorf("%w: expected: %s(%s), got: %s", consensus.ErrFutureBlock, time.Unix(now.Unix(), 0), now, time.Unix(int64(header.Time), 0))
 		}
 	} else {
@@ -524,7 +524,7 @@ func (c *Bor) verifyHeader(chain consensus.ChainHeaderReader, header *types.Head
 		// early block announcements. Note that this is a loose check and would allow early blocks
 		// from non-primary producer. Such blocks will be rejected later when we know the succession
 		// number of the signer in the current sprint.
-		if header.Time-c.config.CalculatePeriod(number) > uint64(now) {
+		if header.Time > uint64(now)+c.config.CalculatePeriod(number) {
 			return fmt.Errorf("%w: expected: %s, got: %s", consensus.ErrFutureBlock, time.Unix(now, 0), time.Unix(int64(header.Time), 0))
 		}
 	} else {
@@ -1045,7 +1045,7 @@ func (c *Bor) Prepare(chain consensus.ChainHeaderReader, header *types.Header, s
 		// need a check for hard fork as it doesn't change any consensus rules, we
 		// still keep it for safety and testing.
 		if c.config.IsBhilai(number) && succession == 0 {
-			startTime := time.Unix(int64(header.Time-c.config.CalculatePeriod(number)), 0)
+			startTime := time.Unix(int64(header.Time)-int64(c.config.CalculatePeriod(number)), 0)
 			time.Sleep(time.Until(startTime))
 		}
 	}
@@ -1243,7 +1243,7 @@ func (c *Bor) Seal(chain consensus.ChainHeaderReader, blockWithReceipts *types.B
 	if c.config.IsBhilai(header.Number.Uint64()) && successionNumber == 0 {
 		// For primary producers, set the delay to `header.Time - block time` instead of `header.Time`
 		// for early block announcement instead of waiting for full block time.
-		delay = time.Until(time.Unix(int64(header.Time-c.config.CalculatePeriod(number)), 0))
+		delay = time.Until(time.Unix(int64(header.Time)-int64(c.config.CalculatePeriod(number)), 0))
 	} else {
 		delay = time.Until(time.Unix(int64(header.Time), 0)) // Wait until we reach header time
 	}

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -270,8 +270,19 @@ func ValidateHeaderTime(
 	config *borcfg.BorConfig,
 	signaturesCache *lru.ARCCache[libcommon.Hash, libcommon.Address],
 ) error {
-	if header.Time > uint64(now.Unix()) {
-		return consensus.ErrFutureBlock
+	if config.IsBhilai(header.Number.Uint64()) {
+		// Don't waste time checking blocks from the future but allow a buffer of block time for
+		// early block announcements. Note that this is a loose check and would allow early blocks
+		// from non-primary producer. Such blocks will be rejected later when we know the succession
+		// number of the signer in the current sprint.
+		if header.Time-config.CalculatePeriod(header.Number.Uint64()) > uint64(time.Now().Unix()) {
+			return fmt.Errorf("%w: expected: %s(%s), got: %s", consensus.ErrFutureBlock, time.Unix(now.Unix(), 0), now, time.Unix(int64(header.Time), 0))
+		}
+	} else {
+		// Don't waste time checking blocks from the future
+		if header.Time > uint64(time.Now().Unix()) {
+			return fmt.Errorf("%w: expected: %s(%s), got: %s", consensus.ErrFutureBlock, time.Unix(now.Unix(), 0), now, time.Unix(int64(header.Time), 0))
+		}
 	}
 
 	if parent == nil {
@@ -288,7 +299,14 @@ func ValidateHeaderTime(
 		return err
 	}
 
-	if header.Time < MinNextBlockTime(parent, succession, config) {
+	// Post Bhilai HF, reject blocks form non-primary producers if they're earlier than the expected time
+	if config.IsBhilai(header.Number.Uint64()) && succession != 0 {
+		if header.Time > uint64(time.Now().Unix()) {
+			return fmt.Errorf("%w: expected: %s(%s), got: %s", consensus.ErrFutureBlock, time.Unix(now.Unix(), 0), now, time.Unix(int64(header.Time), 0))
+		}
+	}
+
+	if parent != nil && header.Time < MinNextBlockTime(parent, succession, config) {
 		return &BlockTooSoonError{header.Number.Uint64(), succession}
 	}
 
@@ -495,11 +513,25 @@ func (c *Bor) verifyHeader(chain consensus.ChainHeaderReader, header *types.Head
 	if header.Number == nil {
 		return errUnknownBlock
 	}
+
 	number := header.Number.Uint64()
+	now := time.Now().Unix()
 
 	// Don't waste time checking blocks from the future
-	if header.Time > uint64(time.Now().Unix()) {
-		return consensus.ErrFutureBlock
+	// Allow early blocks if Bhilai HF is enabled
+	if c.config.IsBhilai(number) {
+		// Don't waste time checking blocks from the future but allow a buffer of block time for
+		// early block announcements. Note that this is a loose check and would allow early blocks
+		// from non-primary producer. Such blocks will be rejected later when we know the succession
+		// number of the signer in the current sprint.
+		if header.Time-c.config.CalculatePeriod(number) > uint64(now) {
+			return fmt.Errorf("%w: expected: %s, got: %s", consensus.ErrFutureBlock, time.Unix(now, 0), time.Unix(int64(header.Time), 0))
+		}
+	} else {
+		// Don't waste time checking blocks from the future
+		if header.Time > uint64(now) {
+			return fmt.Errorf("%w: expected: %s, got: %s", consensus.ErrFutureBlock, time.Unix(now, 0), time.Unix(int64(header.Time), 0))
+		}
 	}
 
 	if err := ValidateHeaderUnusedFields(header); err != nil {
@@ -1005,6 +1037,16 @@ func (c *Bor) Prepare(chain consensus.ChainHeaderReader, header *types.Header, s
 	header.Time = MinNextBlockTime(parent, succession, c.config)
 	if header.Time < uint64(time.Now().Unix()) {
 		header.Time = uint64(time.Now().Unix())
+	} else {
+		// For primary validators, wait until the current block production window
+		// starts. This prevents bor from starting to build next block before time
+		// as we'd like to wait for new transactions. Although this change doesn't
+		// need a check for hard fork as it doesn't change any consensus rules, we
+		// still keep it for safety and testing.
+		if c.config.IsBhilai(number) && succession == 0 {
+			startTime := time.Unix(int64(header.Time-c.config.CalculatePeriod(number)), 0)
+			time.Sleep(time.Until(startTime))
+		}
 	}
 
 	return nil
@@ -1195,8 +1237,18 @@ func (c *Bor) Seal(chain consensus.ChainHeaderReader, blockWithReceipts *types.B
 		}
 	}
 
+	var delay time.Duration
 	// Sweet, the protocol permits us to sign the block, wait for our time
-	delay := time.Until(time.Unix(int64(header.Time), 0))
+	if c.config.IsBhilai(header.Number.Uint64()) {
+		delay = time.Until(time.Unix(int64(header.Time), 0)) // Wait until we reach header time for non-primary validators
+		if successionNumber == 0 {
+			// For primary producers, set the delay to `header.Time - block time` instead of `header.Time`
+			// for early block announcement instead of waiting for full block time.
+			delay = time.Until(time.Unix(int64(header.Time-c.config.CalculatePeriod(number)), 0))
+		}
+	} else {
+		delay = time.Until(time.Unix(int64(header.Time), 0)) // Wait until we reach header time
+	}
 	// wiggle was already accounted for in header.Time, this is just for logging
 	wiggle := time.Duration(successionNumber) * time.Duration(c.config.CalculateBackupMultiplier(number)) * time.Second
 

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -1177,7 +1177,7 @@ func (c *Bor) FinalizeAndAssemble(chainConfig *chain.Config, header *types.Heade
 
 func (c *Bor) Initialize(config *chain.Config, chain consensus.ChainHeaderReader, header *types.Header,
 	state *state.IntraBlockState, syscall consensus.SysCallCustom, logger log.Logger, tracer *tracing.Hooks) {
-	if chain.Config().IsBhilai(header.Time) {
+	if chain != nil && chain.Config().IsBhilai(header.Number.Uint64()) {
 		misc.StoreBlockHashesEip2935(header, state, config, chain)
 	}
 }

--- a/polygon/bor/borcfg/bor_config.go
+++ b/polygon/bor/borcfg/bor_config.go
@@ -43,6 +43,7 @@ type BorConfig struct {
 	AgraBlock                  *big.Int          `json:"agraBlock"`                  // Agra switch block (nil = no fork, 0 = already on Agra)
 	NapoliBlock                *big.Int          `json:"napoliBlock"`                // Napoli switch block (nil = no fork, 0 = already on Napoli)
 	AhmedabadBlock             *big.Int          `json:"ahmedabadBlock"`             // Ahmedabad switch block (nil = no fork, 0 = already on Ahmedabad)
+	BhilaiBlock                *big.Int          `json:"bhilaiBlock"`                // Bhilai switch block (nil = no fork, 0 = already on Ahmedabad)
 	StateSyncConfirmationDelay map[string]uint64 `json:"stateSyncConfirmationDelay"` // StateSync Confirmation Delay, in seconds, to calculate `to`
 
 	sprints sprints
@@ -166,6 +167,14 @@ func (c *BorConfig) IsAhmedabad(number uint64) bool {
 
 func (c *BorConfig) GetAhmedabadBlock() *big.Int {
 	return c.AhmedabadBlock
+}
+
+func (c *BorConfig) IsBhilai(number uint64) bool {
+	return isForked(c.BhilaiBlock, number)
+}
+
+func (c *BorConfig) GetBhilaiBlock() *big.Int {
+	return c.BhilaiBlock
 }
 
 func (c *BorConfig) CalculateStateSyncDelay(number uint64) uint64 {

--- a/tests/bor/helper/miner.go
+++ b/tests/bor/helper/miner.go
@@ -136,7 +136,7 @@ func InitMiner(ctx context.Context, dirName string, genesis *types.Genesis, priv
 		GPO:       ethconfig.Defaults.GPO,
 		Miner: params.MiningConfig{
 			Etherbase:  crypto.PubkeyToAddress(privKey.PublicKey),
-			GasLimit:   genesis.GasLimit,
+			GasLimit:   &genesis.GasLimit,
 			GasPrice:   big.NewInt(1),
 			Recommit:   125 * time.Second,
 			SigKey:     privKey,

--- a/txnprovider/txpool/assemble.go
+++ b/txnprovider/txpool/assemble.go
@@ -58,8 +58,10 @@ func Assemble(
 
 	shanghaiTime := chainConfig.ShanghaiTime
 	var agraBlock *big.Int
+	var bhilaiBlock *big.Int
 	if chainConfig.Bor != nil {
 		agraBlock = chainConfig.Bor.GetAgraBlock()
+		bhilaiBlock = chainConfig.Bor.GetBhilaiBlock()
 	}
 	cancunTime := chainConfig.CancunTime
 	pragueTime := chainConfig.PragueTime
@@ -79,6 +81,7 @@ func Assemble(
 		*chainID,
 		shanghaiTime,
 		agraBlock,
+		bhilaiBlock,
 		cancunTime,
 		pragueTime,
 		chainConfig.BlobSchedule,

--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -257,7 +257,7 @@ func New(
 	}
 	if bhilaiBlock != nil {
 		if !bhilaiBlock.IsUint64() {
-			return nil, errors.New("agraBlock overflow")
+			return nil, errors.New("bhilaiBlock overflow")
 		}
 		bhilaiBlockU64 := bhilaiBlock.Uint64()
 		res.bhilaiBlock = &bhilaiBlockU64

--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -56,6 +56,7 @@ import (
 	"github.com/erigontech/erigon-lib/kv/order"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/core/types"
+	"github.com/erigontech/erigon/params"
 	"github.com/erigontech/erigon/txnprovider"
 	"github.com/erigontech/erigon/txnprovider/txpool/txpoolcfg"
 )
@@ -139,8 +140,8 @@ type TxPool struct {
 	isPostShanghai          atomic.Bool
 	agraBlock               *uint64
 	isPostAgra              atomic.Bool
-	bhilaiBlock               *uint64
-	isPostBhilai              atomic.Bool
+	bhilaiBlock             *uint64
+	isPostBhilai            atomic.Bool
 	cancunTime              *uint64
 	isPostCancun            atomic.Bool
 	pragueTime              *uint64
@@ -758,7 +759,7 @@ func (p *TxPool) best(ctx context.Context, n int, txns *TxnsRlp, onTopOf, availa
 		// make sure we have enough gas in the caller to add this transaction.
 		// not an exact science using intrinsic gas but as close as we could hope for at
 		// this stage
-		authorizationLen := uint64(len(mt.TxnSlot.AuthAndNonces))
+		authorizationLen := uint64(len(mt.TxnSlot.Authorities))
 		intrinsicGas, floorGas, _ := fixedgas.CalcIntrinsicGas(uint64(mt.TxnSlot.DataLen), uint64(mt.TxnSlot.DataNonZeroLen), authorizationLen, uint64(mt.TxnSlot.AccessListAddrCount), uint64(mt.TxnSlot.AccessListStorCount), mt.TxnSlot.Creation, true, true, isEIP3860, isEIP7623)
 		if isEIP7623 && floorGas > intrinsicGas {
 			intrinsicGas = floorGas

--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -139,6 +139,8 @@ type TxPool struct {
 	isPostShanghai          atomic.Bool
 	agraBlock               *uint64
 	isPostAgra              atomic.Bool
+	bhilaiBlock               *uint64
+	isPostBhilai              atomic.Bool
 	cancunTime              *uint64
 	isPostCancun            atomic.Bool
 	pragueTime              *uint64
@@ -171,6 +173,7 @@ func New(
 	chainID uint256.Int,
 	shanghaiTime *big.Int,
 	agraBlock *big.Int,
+	bhilaiBlock *big.Int,
 	cancunTime *big.Int,
 	pragueTime *big.Int,
 	blobSchedule *chain.BlobSchedule,
@@ -251,6 +254,13 @@ func New(
 		}
 		agraBlockU64 := agraBlock.Uint64()
 		res.agraBlock = &agraBlockU64
+	}
+	if bhilaiBlock != nil {
+		if !bhilaiBlock.IsUint64() {
+			return nil, errors.New("agraBlock overflow")
+		}
+		bhilaiBlockU64 := bhilaiBlock.Uint64()
+		res.bhilaiBlock = &bhilaiBlockU64
 	}
 	if cancunTime != nil {
 		if !cancunTime.IsUint64() {
@@ -695,7 +705,7 @@ func (p *TxPool) best(ctx context.Context, n int, txns *TxnsRlp, onTopOf, availa
 	best := p.pending.best
 
 	isShanghai := p.isShanghai() || p.isAgra()
-	isPrague := p.isPrague()
+	isPrague := p.isPrague() || p.isBhilai()
 
 	txns.Resize(uint(min(n, len(best.ms))))
 	var toRemove []*metaTxn
@@ -1074,6 +1084,42 @@ func (p *TxPool) isAgra() bool {
 	activated := (*headBlock + 1) >= agraBlock
 	if activated {
 		p.isPostAgra.Swap(true)
+	}
+	return activated
+}
+
+func (p *TxPool) isBhilai() bool {
+	// once this flag has been set for the first time we no longer need to check the block
+	set := p.isPostBhilai.Load()
+	if set {
+		return true
+	}
+	if p.bhilaiBlock == nil {
+		return false
+	}
+	bhilaiBlock := *p.bhilaiBlock
+
+	// a zero here means Bhilai is always active
+	if bhilaiBlock == 0 {
+		p.isPostBhilai.Swap(true)
+		return true
+	}
+
+	tx, err := p._chainDB.BeginRo(context.Background())
+	if err != nil {
+		return false
+	}
+	defer tx.Rollback()
+
+	headBlock, err := chain.CurrentBlockNumber(tx)
+	if headBlock == nil || err != nil {
+		return false
+	}
+	// A new block is built on top of the head block, so when the head is bhilaiBlock-1,
+	// the new block should use the Bhilai rules.
+	activated := (*headBlock + 1) >= bhilaiBlock
+	if activated {
+		p.isPostBhilai.Swap(true)
 	}
 	return activated
 }

--- a/txnprovider/txpool/pool_fuzz_test.go
+++ b/txnprovider/txpool/pool_fuzz_test.go
@@ -324,7 +324,7 @@ func FuzzOnNewBlocks(f *testing.F) {
 
 		cfg := txpoolcfg.DefaultConfig
 		sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
-		pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
+		pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
 		assert.NoError(err)
 
 		err = pool.start(ctx)
@@ -550,7 +550,7 @@ func FuzzOnNewBlocks(f *testing.F) {
 		check(p2pReceived, TxnSlots{}, "after_flush")
 		checkNotify(p2pReceived, TxnSlots{}, "after_flush")
 
-		p2, err := New(ctx, ch, db, coreDB, txpoolcfg.DefaultConfig, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
+		p2, err := New(ctx, ch, db, coreDB, txpoolcfg.DefaultConfig, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
 		assert.NoError(err)
 
 		p2.senders = pool.senders // senders are not persisted

--- a/txnprovider/txpool/pool_test.go
+++ b/txnprovider/txpool/pool_test.go
@@ -1042,7 +1042,7 @@ func TestSetCodeTxnValidationWithLargeAuthorizationValues(t *testing.T) {
 	chainID := *maxUint256
 	cache := kvcache.NewDummy()
 	logger := log.New()
-	pool, err := New(ctx, ch, nil, coreDB, cfg, cache, chainID, common.Big0 /* shanghaiTime */, nil, /* agraBlock */ nil, /* bhiliaBlock */
+	pool, err := New(ctx, ch, nil, coreDB, cfg, cache, chainID, common.Big0 /* shanghaiTime */, nil /* agraBlock */, nil, /* bhiliaBlock */
 		common.Big0 /* cancunTime */, common.Big0 /* pragueTime */, nil, nil, nil, func() {}, nil, logger, WithFeeCalculator(nil))
 	assert.NoError(t, err)
 	pool.blockGasLimit.Store(30_000_000)

--- a/txnprovider/txpool/pool_test.go
+++ b/txnprovider/txpool/pool_test.go
@@ -61,8 +61,8 @@ func TestNonceFromAddress(t *testing.T) {
 	cfg := txpoolcfg.DefaultConfig
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
 	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
-	require.NoError(err)
-	require.NotEqual(pool, nil)
+	assert.NoError(err)
+	require.True(pool != nil)
 	var stateVersionID uint64 = 0
 	pendingBaseFee := uint64(200000)
 	// start blocks from 0, set empty hash - then kvcache will also work on this
@@ -186,9 +186,9 @@ func TestMultipleAuthorizations(t *testing.T) {
 
 	cfg := txpoolcfg.DefaultConfig
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
-	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, common.Big0 /* shanghaiTime */, nil /* agraBlock */, nil /* bhilaiBlock */, common.Big0 /* cancunTime */, common.Big0 /* pragueTime */, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
-	require.NoError(t, err)
-	require.NotEqual(t, pool, nil)
+	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, common.Big0 /* shanghaiTime */, nil /* agraBlock */, nil /* bhiliaBlock */, common.Big0 /* cancunTime */, common.Big0 /* pragueTime */, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
+	assert.NoError(t, err)
+	require.True(t, pool != nil)
 
 	var stateVersionID uint64 = 0
 	pendingBaseFee := uint64(200000)
@@ -442,8 +442,8 @@ func TestReplaceWithHigherFee(t *testing.T) {
 	cfg := txpoolcfg.DefaultConfig
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
 	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
-	require.NoError(err)
-	require.NotNil(pool)
+	assert.NoError(err)
+	require.NotEqual(nil, pool)
 	var stateVersionID uint64 = 0
 	pendingBaseFee := uint64(200000)
 	// start blocks from 0, set empty hash - then kvcache will also work on this
@@ -565,8 +565,8 @@ func TestReverseNonces(t *testing.T) {
 	cfg := txpoolcfg.DefaultConfig
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
 	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
-	require.NoError(err)
-	require.NotEqual(pool, nil)
+	assert.NoError(err)
+	require.True(pool != nil)
 	var stateVersionID uint64 = 0
 	pendingBaseFee := uint64(1_000_000)
 	// start blocks from 0, set empty hash - then kvcache will also work on this
@@ -695,8 +695,8 @@ func TestTxnPoke(t *testing.T) {
 	cfg := txpoolcfg.DefaultConfig
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
 	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
-	require.NoError(err)
-	require.NotEqual(pool, nil)
+	assert.NoError(err)
+	require.True(pool != nil)
 	var stateVersionID uint64 = 0
 	pendingBaseFee := uint64(200000)
 	// start blocks from 0, set empty hash - then kvcache will also work on this
@@ -931,7 +931,7 @@ func TestShanghaiValidateTxn(t *testing.T) {
 			asrt.NoError(err)
 			defer sd.Close()
 			cache := kvcache.NewDummy()
-			pool, err := New(ctx, ch, nil, coreDB, cfg, cache, *u256.N1, shanghaiTime, nil /* agraBlock */, nil /* bhilaiBlock */, nil /* cancunTime */, nil, nil, nil, nil, func() {}, nil, logger, WithFeeCalculator(nil))
+			pool, err := New(ctx, ch, nil, coreDB, cfg, cache, *u256.N1, shanghaiTime, nil /* agraBlock */, nil /* cancunTime */, nil, nil, nil, nil, nil, func() {}, nil, logger, WithFeeCalculator(nil))
 			asrt.NoError(err)
 
 			sndr := accounts3.Account{Nonce: 0, Balance: *uint256.NewInt(math.MaxUint64)}
@@ -978,8 +978,8 @@ func TestTooHighGasLimitTxnValidation(t *testing.T) {
 	cfg := txpoolcfg.DefaultConfig
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
 	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
-	require.NoError(err)
-	require.NotEqual(pool, nil)
+	assert.NoError(err)
+	require.True(pool != nil)
 	var stateVersionID uint64 = 0
 	pendingBaseFee := uint64(200000)
 	// start blocks from 0, set empty hash - then kvcache will also work on this
@@ -1042,9 +1042,9 @@ func TestSetCodeTxnValidationWithLargeAuthorizationValues(t *testing.T) {
 	chainID := *maxUint256
 	cache := kvcache.NewDummy()
 	logger := log.New()
-	pool, err := New(ctx, ch, nil, coreDB, cfg, cache, chainID, common.Big0 /* shanghaiTime */, nil /* agraBlock */, nil, /* bhilaiBlock */
+	pool, err := New(ctx, ch, nil, coreDB, cfg, cache, chainID, common.Big0 /* shanghaiTime */, nil, /* agraBlock */ nil, /* bhiliaBlock */
 		common.Big0 /* cancunTime */, common.Big0 /* pragueTime */, nil, nil, nil, func() {}, nil, logger, WithFeeCalculator(nil))
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	pool.blockGasLimit.Store(30_000_000)
 	tx, err := coreDB.BeginRw(ctx)
 	defer tx.Rollback()
@@ -1093,8 +1093,8 @@ func TestBlobTxnReplacement(t *testing.T) {
 	t.Cleanup(cancel)
 	cfg := txpoolcfg.DefaultConfig
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
-	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, common.Big0, nil, common.Big0, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
-	require.NoError(err)
+	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, common.Big0, nil, nil, common.Big0, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
+	assert.NoError(err)
 
 	require.True(pool != nil)
 	var stateVersionID uint64 = 0
@@ -1278,8 +1278,8 @@ func TestDropRemoteAtNoGossip(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	txnPool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, nil, nil, func() {}, nil, logger, WithFeeCalculator(nil))
-	require.NoError(err)
-	require.NotEqual(txnPool, nil)
+	assert.NoError(err)
+	require.True(txnPool != nil)
 
 	err = txnPool.start(ctx)
 	assert.NoError(err)
@@ -1388,9 +1388,9 @@ func TestBlobSlots(t *testing.T) {
 	cfg.TotalBlobPoolLimit = 20
 
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
-	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, common.Big0, nil, common.Big0, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
-	require.NoError(err)
-	require.NotEqual(pool, nil)
+	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, common.Big0, nil, nil, common.Big0, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
+	assert.NoError(err)
+	require.True(pool != nil)
 	var stateVersionID uint64 = 0
 
 	h1 := gointerfaces.ConvertHashToH256([32]byte{})
@@ -1471,9 +1471,9 @@ func TestGetBlobsV1(t *testing.T) {
 	cfg.TotalBlobPoolLimit = 20
 
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
-	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, common.Big0, nil, common.Big0, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
-	require.NoError(err)
-	require.NotEqual(pool, nil)
+	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, common.Big0, nil, nil, common.Big0, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
+	assert.NoError(err)
+	require.True(pool != nil)
 	pool.blockGasLimit.Store(30000000)
 	var stateVersionID uint64 = 0
 
@@ -1547,8 +1547,8 @@ func TestGasLimitChanged(t *testing.T) {
 	cfg := txpoolcfg.DefaultConfig
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
 	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
-	require.NoError(err)
-	require.NotEqual(pool, nil)
+	assert.NoError(err)
+	require.True(pool != nil)
 	var stateVersionID uint64 = 0
 	pendingBaseFee := uint64(200000)
 	// start blocks from 0, set empty hash - then kvcache will also work on this

--- a/txnprovider/txpool/pool_test.go
+++ b/txnprovider/txpool/pool_test.go
@@ -60,9 +60,9 @@ func TestNonceFromAddress(t *testing.T) {
 	db := memdb.NewTestPoolDB(t)
 	cfg := txpoolcfg.DefaultConfig
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
-	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
-	assert.NoError(err)
-	require.True(pool != nil)
+	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
+	require.NoError(err)
+	require.NotEqual(pool, nil)
 	var stateVersionID uint64 = 0
 	pendingBaseFee := uint64(200000)
 	// start blocks from 0, set empty hash - then kvcache will also work on this
@@ -186,9 +186,9 @@ func TestMultipleAuthorizations(t *testing.T) {
 
 	cfg := txpoolcfg.DefaultConfig
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
-	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, common.Big0 /* shanghaiTime */, nil /* agraBlock */, common.Big0 /* cancunTime */, common.Big0 /* pragueTime */, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
-	assert.NoError(t, err)
-	require.True(t, pool != nil)
+	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, common.Big0 /* shanghaiTime */, nil /* agraBlock */, nil /* bhilaiBlock */, common.Big0 /* cancunTime */, common.Big0 /* pragueTime */, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
+	require.NoError(t, err)
+	require.NotEqual(t, pool, nil)
 
 	var stateVersionID uint64 = 0
 	pendingBaseFee := uint64(200000)
@@ -441,9 +441,9 @@ func TestReplaceWithHigherFee(t *testing.T) {
 	t.Cleanup(cancel)
 	cfg := txpoolcfg.DefaultConfig
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
-	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
-	assert.NoError(err)
-	require.NotEqual(nil, pool)
+	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
+	require.NoError(err)
+	require.NotNil(pool)
 	var stateVersionID uint64 = 0
 	pendingBaseFee := uint64(200000)
 	// start blocks from 0, set empty hash - then kvcache will also work on this
@@ -564,9 +564,9 @@ func TestReverseNonces(t *testing.T) {
 	t.Cleanup(cancel)
 	cfg := txpoolcfg.DefaultConfig
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
-	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
-	assert.NoError(err)
-	require.True(pool != nil)
+	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
+	require.NoError(err)
+	require.NotEqual(pool, nil)
 	var stateVersionID uint64 = 0
 	pendingBaseFee := uint64(1_000_000)
 	// start blocks from 0, set empty hash - then kvcache will also work on this
@@ -694,9 +694,9 @@ func TestTxnPoke(t *testing.T) {
 	t.Cleanup(cancel)
 	cfg := txpoolcfg.DefaultConfig
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
-	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
-	assert.NoError(err)
-	require.True(pool != nil)
+	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
+	require.NoError(err)
+	require.NotEqual(pool, nil)
 	var stateVersionID uint64 = 0
 	pendingBaseFee := uint64(200000)
 	// start blocks from 0, set empty hash - then kvcache will also work on this
@@ -931,7 +931,7 @@ func TestShanghaiValidateTxn(t *testing.T) {
 			asrt.NoError(err)
 			defer sd.Close()
 			cache := kvcache.NewDummy()
-			pool, err := New(ctx, ch, nil, coreDB, cfg, cache, *u256.N1, shanghaiTime, nil /* agraBlock */, nil /* cancunTime */, nil, nil, nil, nil, func() {}, nil, logger, WithFeeCalculator(nil))
+			pool, err := New(ctx, ch, nil, coreDB, cfg, cache, *u256.N1, shanghaiTime, nil /* agraBlock */, nil /* bhilaiBlock */, nil /* cancunTime */, nil, nil, nil, nil, func() {}, nil, logger, WithFeeCalculator(nil))
 			asrt.NoError(err)
 
 			sndr := accounts3.Account{Nonce: 0, Balance: *uint256.NewInt(math.MaxUint64)}
@@ -977,9 +977,9 @@ func TestTooHighGasLimitTxnValidation(t *testing.T) {
 	t.Cleanup(cancel)
 	cfg := txpoolcfg.DefaultConfig
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
-	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
-	assert.NoError(err)
-	require.True(pool != nil)
+	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
+	require.NoError(err)
+	require.NotEqual(pool, nil)
 	var stateVersionID uint64 = 0
 	pendingBaseFee := uint64(200000)
 	// start blocks from 0, set empty hash - then kvcache will also work on this
@@ -1042,9 +1042,9 @@ func TestSetCodeTxnValidationWithLargeAuthorizationValues(t *testing.T) {
 	chainID := *maxUint256
 	cache := kvcache.NewDummy()
 	logger := log.New()
-	pool, err := New(ctx, ch, nil, coreDB, cfg, cache, chainID, common.Big0 /* shanghaiTime */, nil, /* agraBlock */
+	pool, err := New(ctx, ch, nil, coreDB, cfg, cache, chainID, common.Big0 /* shanghaiTime */, nil /* agraBlock */, nil, /* bhilaiBlock */
 		common.Big0 /* cancunTime */, common.Big0 /* pragueTime */, nil, nil, nil, func() {}, nil, logger, WithFeeCalculator(nil))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	pool.blockGasLimit.Store(30_000_000)
 	tx, err := coreDB.BeginRw(ctx)
 	defer tx.Rollback()
@@ -1093,8 +1093,8 @@ func TestBlobTxnReplacement(t *testing.T) {
 	t.Cleanup(cancel)
 	cfg := txpoolcfg.DefaultConfig
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
-	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, common.Big0, nil, common.Big0, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
-	assert.NoError(err)
+	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, common.Big0, nil, common.Big0, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
+	require.NoError(err)
 
 	require.True(pool != nil)
 	var stateVersionID uint64 = 0
@@ -1277,9 +1277,9 @@ func TestDropRemoteAtNoGossip(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	txnPool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, nil, func() {}, nil, logger, WithFeeCalculator(nil))
-	assert.NoError(err)
-	require.True(txnPool != nil)
+	txnPool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, nil, nil, func() {}, nil, logger, WithFeeCalculator(nil))
+	require.NoError(err)
+	require.NotEqual(txnPool, nil)
 
 	err = txnPool.start(ctx)
 	assert.NoError(err)
@@ -1388,9 +1388,9 @@ func TestBlobSlots(t *testing.T) {
 	cfg.TotalBlobPoolLimit = 20
 
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
-	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, common.Big0, nil, common.Big0, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
-	assert.NoError(err)
-	require.True(pool != nil)
+	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, common.Big0, nil, common.Big0, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
+	require.NoError(err)
+	require.NotEqual(pool, nil)
 	var stateVersionID uint64 = 0
 
 	h1 := gointerfaces.ConvertHashToH256([32]byte{})
@@ -1471,9 +1471,9 @@ func TestGetBlobsV1(t *testing.T) {
 	cfg.TotalBlobPoolLimit = 20
 
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
-	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, common.Big0, nil, common.Big0, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
-	assert.NoError(err)
-	require.True(pool != nil)
+	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, common.Big0, nil, common.Big0, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
+	require.NoError(err)
+	require.NotEqual(pool, nil)
 	pool.blockGasLimit.Store(30000000)
 	var stateVersionID uint64 = 0
 
@@ -1546,9 +1546,9 @@ func TestGasLimitChanged(t *testing.T) {
 	db := memdb.NewTestPoolDB(t)
 	cfg := txpoolcfg.DefaultConfig
 	sendersCache := kvcache.New(kvcache.DefaultCoherentConfig)
-	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
-	assert.NoError(err)
-	require.True(pool != nil)
+	pool, err := New(ctx, ch, db, coreDB, cfg, sendersCache, *u256.N1, nil, nil, nil, nil, nil, nil, nil, nil, func() {}, nil, log.New(), WithFeeCalculator(nil))
+	require.NoError(err)
+	require.NotEqual(pool, nil)
 	var stateVersionID uint64 = 0
 	pendingBaseFee := uint64(200000)
 	// start blocks from 0, set empty hash - then kvcache will also work on this


### PR DESCRIPTION
This is a cherry pick from main of the https://github.com/erigontech/erigon/pull/15261: Which implements the Bhilai fork changes as specified in:

[PIP-63](https://github.com/maticnetwork/Polygon-Improvement-Proposals/blob/main/PIPs/PIP-63.md)

and also the feature to allow early block announcements specified in:

[PIP-66](https://github.com/maticnetwork/Polygon-Improvement-Proposals/blob/main/PIPs/PIP-66.md)

The individual changes included here are:

[PIP-60: Increase gas limit to 45M](https://github.com/maticnetwork/Polygon-Improvement-Proposals/blob/main/PIPs/PIP-60.md)
[PIP-58: Increase BaseFeeChangeDenominator to 64](https://github.com/maticnetwork/Polygon-Improvement-Proposals/blob/main/PIPs/PIP-58.md)
[EIP-2537: Precompile for BLS12-381 curve operations](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2537.md)
[EIP-2935: Save historical block hashes in state](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2935.md)
[EIP-7623: Increase calldata cost](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7623.md)
[EIP-7702: Set EOA account code](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7702.md) [(PIP-51)](https://github.com/maticnetwork/Polygon-Improvement-Proposals/blob/main/PIPs/PIP-51.md)
[PIP-66: Allow early block announcements](https://github.com/maticnetwork/Polygon-Improvement-Proposals/blob/main/PIPs/PIP-66.md)