### PR TITLE
agg and dhii readahead flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ test-erigon-ext:
 	@cd tests/erigon-ext-test && ./test.sh $(GIT_COMMIT)
 
 ## test:                      run short tests with a 10m timeout
-test: #test-erigon-lib test-erigon-db test-p2
+test: test-erigon-lib test-erigon-db test-p2
 	$(GOTEST) -short --timeout 10m -coverprofile=coverage-test.out | grep -v '=== CONT ' | grep -v '=== RUN' | grep -v '=== PAUSE' | grep -v 'PASS: '
 
 ## test-all:                  run all tests with a 1h timeout

--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ test-erigon-ext:
 	@cd tests/erigon-ext-test && ./test.sh $(GIT_COMMIT)
 
 ## test:                      run short tests with a 10m timeout
-test: test-erigon-lib test-erigon-db test-p2
+test: #test-erigon-lib test-erigon-db test-p2
 	$(GOTEST) -short --timeout 10m -coverprofile=coverage-test.out | grep -v '=== CONT ' | grep -v '=== RUN' | grep -v '=== PAUSE' | grep -v 'PASS: '
 
 ## test-all:                  run all tests with a 1h timeout

--- a/erigon-lib/kv/kv_interface.go
+++ b/erigon-lib/kv/kv_interface.go
@@ -596,6 +596,9 @@ type TemporalDebugDB interface {
 	ReloadSalt() error
 	BuildMissedAccessors(ctx context.Context, workers int) error
 	ReloadFiles() error
+
+	MadvNormal() TemporalDebugDB
+	DisableReadAhead()
 }
 
 type WithFreezeInfo interface {

--- a/erigon-lib/kv/remotedb/kv_remote.go
+++ b/erigon-lib/kv/remotedb/kv_remote.go
@@ -190,6 +190,8 @@ func (db *DB) ReloadSalt() error                                   { panic("not 
 func (db *DB) InvertedIdxTables(domain ...kv.InvertedIdx) []string { panic("not implemented") }
 func (db *DB) ReloadFiles() error                                  { panic("not implemented") }
 func (db *DB) BuildMissedAccessors(_ context.Context, _ int) error { panic("not implemented") }
+func (db *DB) MadvNormal() kv.TemporalDebugDB                      { panic("not implemented") }
+func (db *DB) DisableReadAhead()                                   { panic("not implemented") }
 
 func (db *DB) BeginTemporalRo(ctx context.Context) (kv.TemporalTx, error) {
 	t, err := db.BeginRo(ctx) //nolint:gocritic

--- a/erigon-lib/kv/temporal/kv_temporal.go
+++ b/erigon-lib/kv/temporal/kv_temporal.go
@@ -538,6 +538,11 @@ func (db *DB) ReloadFiles() error { return db.agg.ReloadFiles() }
 func (db *DB) BuildMissedAccessors(ctx context.Context, workers int) error {
 	return db.agg.BuildMissedAccessors(ctx, workers)
 }
+func (db *DB) MadvNormal() kv.TemporalDebugDB {
+	db.agg.MadvNormal()
+	return db
+}
+func (db *DB) DisableReadAhead() { db.agg.DisableReadAhead() }
 
 func (tx *Tx) DomainFiles(domain ...kv.Domain) kv.VisibleFiles {
 	return tx.aggtx.DomainFiles(domain...)

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -94,7 +94,8 @@ type Aggregator struct {
 
 	produce bool
 
-	checker *DependencyIntegrityChecker
+	checker         *DependencyIntegrityChecker
+	enableReadAhead atomic.Bool
 }
 
 const AggregatorSqueezeCommitmentValues = true
@@ -1746,7 +1747,11 @@ func (at *AggregatorRoTx) DisableReadAhead() {
 func (at *Aggregator) MadvNormal() *Aggregator {
 	at.dirtyFilesLock.Lock()
 	defer at.dirtyFilesLock.Unlock()
+	at.enableReadAhead.Store(true)
 	for _, d := range at.d {
+		d.enableReadAhead.Store(true)
+		d.History.enableReadAhead.Store(true)
+		d.History.InvertedIndex.enableReadAhead.Store(true)
 		for _, f := range d.dirtyFiles.Items() {
 			f.MadvNormal()
 		}
@@ -1758,6 +1763,7 @@ func (at *Aggregator) MadvNormal() *Aggregator {
 		}
 	}
 	for _, ii := range at.iis {
+		ii.enableReadAhead.Store(true)
 		for _, f := range ii.dirtyFiles.Items() {
 			f.MadvNormal()
 		}
@@ -1767,7 +1773,11 @@ func (at *Aggregator) MadvNormal() *Aggregator {
 func (at *Aggregator) DisableReadAhead() {
 	at.dirtyFilesLock.Lock()
 	defer at.dirtyFilesLock.Unlock()
+	at.enableReadAhead.Store(false)
 	for _, d := range at.d {
+		d.enableReadAhead.Store(false)
+		d.History.enableReadAhead.Store(false)
+		d.History.InvertedIndex.enableReadAhead.Store(false)
 		for _, f := range d.dirtyFiles.Items() {
 			f.DisableReadAhead()
 		}
@@ -1779,6 +1789,7 @@ func (at *Aggregator) DisableReadAhead() {
 		}
 	}
 	for _, ii := range at.iis {
+		ii.enableReadAhead.Store(false)
 		for _, f := range ii.dirtyFiles.Items() {
 			f.DisableReadAhead()
 		}

--- a/erigon-lib/state/aggregator2.go
+++ b/erigon-lib/state/aggregator2.go
@@ -58,8 +58,8 @@ func NewAggregator2(ctx context.Context, dirs datadir.Dirs, aggregationStep uint
 		return nil, err
 	}
 
-	a.AddDependency(kv.AccountsDomain, kv.CommitmentDomain)
-	a.AddDependency(kv.StorageDomain, kv.CommitmentDomain)
+	a.AddDependencyBtwnDomains(kv.AccountsDomain, kv.CommitmentDomain)
+	a.AddDependencyBtwnDomains(kv.StorageDomain, kv.CommitmentDomain)
 
 	a.KeepRecentTxnsOfHistoriesWithDisabledSnapshots(100_000) // ~1k blocks of history
 

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -492,8 +492,9 @@ func (d *Domain) closeWhatNotInList(fNames []string) {
 func (d *Domain) reCalcVisibleFiles(toTxNum uint64) {
 	var checker func(startTxNum, endTxNum uint64) bool
 	if d.checker != nil {
+		ue := FromDomain(d.name)
 		checker = func(startTxNum, endTxNum uint64) bool {
-			return d.checker.CheckDependentPresent(d.name, All, startTxNum, endTxNum)
+			return d.checker.CheckDependentPresent(ue, All, startTxNum, endTxNum)
 		}
 	}
 	d._visible = newDomainVisible(d.name, calcVisibleFiles(d.dirtyFiles, d.Accessors, checker, false, toTxNum))

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/erigontech/erigon-lib/version"
@@ -87,7 +88,8 @@ type Domain struct {
 	// underlying array is immutable - means it's ready for zero-copy use
 	_visible *domainVisible
 
-	checker *DependencyIntegrityChecker
+	checker         *DependencyIntegrityChecker
+	enableReadAhead atomic.Bool
 }
 
 type domainCfg struct {
@@ -453,6 +455,10 @@ func (d *Domain) openDirtyFiles() (err error) {
 						// don't interrupt on error. other files may be good
 					}
 				}
+			}
+
+			if d.enableReadAhead.Load() {
+				item.MadvNormal()
 			}
 		}
 		return true
@@ -1410,6 +1416,9 @@ func (d *Domain) integrateDirtyFiles(sf StaticFiles, txNumFrom, txNumTo uint64) 
 	fi.index = sf.valuesIdx
 	fi.bindex = sf.valuesBt
 	fi.existence = sf.bloom
+	if d.enableReadAhead.Load() {
+		fi.MadvNormal()
+	}
 	d.dirtyFiles.Set(fi)
 }
 

--- a/erigon-lib/state/entity_integrity_check.go
+++ b/erigon-lib/state/entity_integrity_check.go
@@ -1,12 +1,45 @@
 package state
 
 import (
+	"fmt"
+
 	"github.com/erigontech/erigon-lib/log/v3"
 
 	"github.com/erigontech/erigon-lib/common/datadir"
 	"github.com/erigontech/erigon-lib/kv"
 	btree2 "github.com/tidwall/btree"
 )
+
+// high 16 bits specific domain/ii/forkables;
+// low 16 bits identifies "category" domain(0)/ii(1)/history(2)/forkables(3) etc.
+// e.g.
+// 0x0000000000000001 0000000000000000  - storage domain
+// 0x0000000000000001 0000000000000001  - storage history
+// 0x0000000000000001 0000000000000010  - storage ii
+
+type UniversalEntity uint32
+
+func FromDomain(d kv.Domain) UniversalEntity {
+	return UniversalEntity(uint32(d) << 16)
+}
+
+func FromII(ii kv.InvertedIdx) UniversalEntity {
+	return UniversalEntity(uint32(ii)<<16 | 0x10)
+}
+
+func (ue UniversalEntity) String() string {
+	category := ue & 0xFFFF
+	if category == 0 {
+		return fmt.Sprintf("domain:%s", kv.Domain(ue>>16))
+	}
+	if category == 1 {
+		return fmt.Sprintf("history:%s", kv.InvertedIdx(ue>>16))
+	}
+	if category == 2 {
+		return fmt.Sprintf("ii:%s", kv.InvertedIdx(ue>>16))
+	}
+	return fmt.Sprintf("unknown:%d", ue)
+}
 
 type DirtyFilesGetter func() *btree2.BTreeG[*filesItem]
 
@@ -16,7 +49,7 @@ type DirtyFilesGetter func() *btree2.BTreeG[*filesItem]
 // instance should be held by dependency domain
 // (accounts in this example)
 type DependencyIntegrityChecker struct {
-	dependencyMap map[kv.Domain][]*DependentInfo
+	dependencyMap map[UniversalEntity][]*DependentInfo
 	dirs          datadir.Dirs
 	trace         bool
 	logger        log.Logger
@@ -24,7 +57,7 @@ type DependencyIntegrityChecker struct {
 }
 
 type DependentInfo struct {
-	domain      kv.Domain
+	entity      UniversalEntity
 	filesGetter DirtyFilesGetter
 	accessors   Accessors
 }
@@ -33,7 +66,7 @@ type DependentInfo struct {
 // dependent/referencing: commitment
 func NewDependencyIntegrityChecker(dirs datadir.Dirs, logger log.Logger) *DependencyIntegrityChecker {
 	return &DependencyIntegrityChecker{
-		dependencyMap: make(map[kv.Domain][]*DependentInfo),
+		dependencyMap: make(map[UniversalEntity][]*DependentInfo),
 		dirs:          dirs,
 		logger:        logger,
 		//		trace:         true,
@@ -44,7 +77,7 @@ func (d *DependencyIntegrityChecker) SetTrace(trace bool) {
 	d.trace = trace
 }
 
-func (d *DependencyIntegrityChecker) AddDependency(dependency kv.Domain, dependent *DependentInfo) {
+func (d *DependencyIntegrityChecker) AddDependency(dependency UniversalEntity, dependent *DependentInfo) {
 	arr, ok := d.dependencyMap[dependency]
 	if !ok {
 		arr = make([]*DependentInfo, 0)
@@ -70,7 +103,7 @@ func (d *DependencyIntegrityChecker) Disable() {
 // is (dependent) commitment.0-2 present?
 // - if no (or !checkVisibility), don't use it for visibleFiles.
 // - Also don't consider it for "consuming" (deleting) the smaller files commitment.0-1, 1-2
-func (d *DependencyIntegrityChecker) CheckDependentPresent(dependency kv.Domain, allOrAny Quantifier, startTxNum, endTxNum uint64) (IsPresent bool) {
+func (d *DependencyIntegrityChecker) CheckDependentPresent(dependency UniversalEntity, allOrAny Quantifier, startTxNum, endTxNum uint64) (IsPresent bool) {
 	arr, ok := d.dependencyMap[dependency]
 	if !ok || d.disable {
 		return true
@@ -89,7 +122,7 @@ func (d *DependencyIntegrityChecker) CheckDependentPresent(dependency kv.Domain,
 			// all dependent (e.g. commitment) file should be present as well as visible-able
 			if !found || !checkForVisibility(file, dependent.accessors, d.trace) {
 				if d.trace {
-					d.logger.Warn("[dbg: Depic]", "dependent", dependent.domain.String(), "startTxNum", startTxNum, "endTxNum", endTxNum, "found", found)
+					d.logger.Warn("[dbg: Depic]", "dependent", dependent.entity.String(), "startTxNum", startTxNum, "endTxNum", endTxNum, "found", found)
 				}
 				return false
 			}
@@ -98,7 +131,7 @@ func (d *DependencyIntegrityChecker) CheckDependentPresent(dependency kv.Domain,
 			// any dependent (e.g. commiment) file is present => dependency file can't be deleted
 			if found {
 				if d.trace {
-					d.logger.Warn("[dbg: Depic]", "dependent", dependent.domain.String(), "startTxNum", startTxNum, "endTxNum", endTxNum, "found", true)
+					d.logger.Warn("[dbg: Depic]", "dependent", dependent.entity.String(), "startTxNum", startTxNum, "endTxNum", endTxNum, "found", true)
 				}
 				return true
 			}

--- a/erigon-lib/state/history.go
+++ b/erigon-lib/state/history.go
@@ -135,6 +135,7 @@ func NewHistory(cfg histCfg, aggStep uint64, logger log.Logger) (*History, error
 	if h.version.AccessorVI.IsZero() {
 		panic(fmt.Errorf("assert: forgot to set version of %s", h.name))
 	}
+	h.InvertedIndex.name = h.name
 
 	return &h, nil
 }

--- a/erigon-lib/state/history.go
+++ b/erigon-lib/state/history.go
@@ -26,6 +26,7 @@ import (
 	"math"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/erigontech/erigon-lib/version"
@@ -69,7 +70,8 @@ type History struct {
 
 	// _visibleFiles - underscore in name means: don't use this field directly, use BeginFilesRo()
 	// underlying array is immutable - means it's ready for zero-copy use
-	_visibleFiles []visibleFile
+	_visibleFiles   []visibleFile
+	enableReadAhead atomic.Bool
 }
 
 type histCfg struct {
@@ -283,6 +285,10 @@ func (h *History) openDirtyFiles() error {
 						// don't interrupt on error. other files may be good
 					}
 				}
+			}
+
+			if h.enableReadAhead.Load() {
+				item.MadvNormal()
 			}
 		}
 		return true
@@ -964,6 +970,9 @@ func (h *History) integrateDirtyFiles(sf HistoryFiles, txNumFrom, txNumTo uint64
 	fi := newFilesItem(txNumFrom, txNumTo, h.aggregationStep)
 	fi.decompressor = sf.historyDecomp
 	fi.index = sf.historyIdx
+	if h.enableReadAhead.Load() {
+		fi.MadvNormal()
+	}
 	h.dirtyFiles.Set(fi)
 }
 

--- a/erigon-lib/state/integrity_checker_test.go
+++ b/erigon-lib/state/integrity_checker_test.go
@@ -33,19 +33,19 @@ func TestDependency(t *testing.T) {
 	}
 
 	dinfo := &DependentInfo{
-		domain:      kv.CommitmentDomain,
+		entity:      FromDomain(kv.CommitmentDomain),
 		filesGetter: fg,
 		accessors:   AccessorHashMap,
 	}
 
 	checker := NewDependencyIntegrityChecker(dirs, logger)
-	checker.AddDependency(kv.AccountsDomain, dinfo)
+	checker.AddDependency(FromDomain(kv.AccountsDomain), dinfo)
 	// not adding dependency for storage
 
 	assertFn := func(startTxNum, endTxNum uint64, resultC, resultA, resultS bool) {
-		require.Equal(t, resultA, checker.CheckDependentPresent(kv.AccountsDomain, All, startTxNum, endTxNum))
-		require.Equal(t, resultS, checker.CheckDependentPresent(kv.StorageDomain, All, startTxNum, endTxNum))
-		require.Equal(t, resultC, checker.CheckDependentPresent(kv.CommitmentDomain, All, startTxNum, endTxNum))
+		require.Equal(t, resultA, checker.CheckDependentPresent(FromDomain(kv.AccountsDomain), All, startTxNum, endTxNum))
+		require.Equal(t, resultS, checker.CheckDependentPresent(FromDomain(kv.StorageDomain), All, startTxNum, endTxNum))
+		require.Equal(t, resultC, checker.CheckDependentPresent(FromDomain(kv.CommitmentDomain), All, startTxNum, endTxNum))
 
 	}
 
@@ -75,19 +75,19 @@ func TestDependency_UnindexedMerged(t *testing.T) {
 	}
 
 	dinfo := &DependentInfo{
-		domain:      kv.CommitmentDomain,
+		entity:      FromDomain(kv.CommitmentDomain),
 		filesGetter: fg,
 		accessors:   AccessorHashMap,
 	}
 
 	checker := NewDependencyIntegrityChecker(dirs, logger)
-	checker.AddDependency(kv.AccountsDomain, dinfo)
+	checker.AddDependency(FromDomain(kv.AccountsDomain), dinfo)
 	// not adding dependency for storage
 
 	assertFn := func(startTxNum, endTxNum uint64, resultC, resultA, resultS bool) {
-		require.Equal(t, resultA, checker.CheckDependentPresent(kv.AccountsDomain, All, startTxNum, endTxNum))
-		require.Equal(t, resultS, checker.CheckDependentPresent(kv.StorageDomain, All, startTxNum, endTxNum))
-		require.Equal(t, resultC, checker.CheckDependentPresent(kv.CommitmentDomain, All, startTxNum, endTxNum))
+		require.Equal(t, resultA, checker.CheckDependentPresent(FromDomain(kv.AccountsDomain), All, startTxNum, endTxNum))
+		require.Equal(t, resultS, checker.CheckDependentPresent(FromDomain(kv.StorageDomain), All, startTxNum, endTxNum))
+		require.Equal(t, resultC, checker.CheckDependentPresent(FromDomain(kv.CommitmentDomain), All, startTxNum, endTxNum))
 
 	}
 

--- a/erigon-lib/state/inverted_index.go
+++ b/erigon-lib/state/inverted_index.go
@@ -77,7 +77,8 @@ type InvertedIndex struct {
 	_visible *iiVisible
 	logger   log.Logger
 
-	checker *DependencyIntegrityChecker
+	checker         *DependencyIntegrityChecker
+	enableReadAhead atomic.Bool
 }
 
 type iiCfg struct {
@@ -358,6 +359,10 @@ func (ii *InvertedIndex) openDirtyFiles() error {
 						// don't interrupt on error. other files may be good
 					}
 				}
+			}
+
+			if ii.enableReadAhead.Load() {
+				item.MadvNormal()
 			}
 		}
 
@@ -1289,6 +1294,9 @@ func (ii *InvertedIndex) integrateDirtyFiles(sf InvertedFiles, txNumFrom, txNumT
 	fi.decompressor = sf.decomp
 	fi.index = sf.index
 	fi.existence = sf.existence
+	if ii.enableReadAhead.Load() {
+		fi.MadvNormal()
+	}
 	ii.dirtyFiles.Set(fi)
 }
 

--- a/erigon-lib/state/kv_temporal_copy_test.go
+++ b/erigon-lib/state/kv_temporal_copy_test.go
@@ -537,6 +537,11 @@ func (db *DB) ReloadFiles() error { return db.agg.ReloadFiles() }
 func (db *DB) BuildMissedAccessors(ctx context.Context, workers int) error {
 	return db.agg.BuildMissedAccessors(ctx, workers)
 }
+func (db *DB) MadvNormal() kv.TemporalDebugDB {
+	db.agg.MadvNormal()
+	return db
+}
+func (db *DB) DisableReadAhead() { db.agg.DisableReadAhead() }
 
 func (tx *Tx) DomainFiles(domain ...kv.Domain) kv.VisibleFiles {
 	return tx.aggtx.DomainFiles(domain...)

--- a/erigon-lib/state/merge.go
+++ b/erigon-lib/state/merge.go
@@ -921,8 +921,9 @@ func (dt *DomainRoTx) garbage(merged *filesItem) (outs []*filesItem) {
 	dchecker := dt.d.checker
 	dname := dt.d.name
 	if dchecker != nil {
+		ue := FromDomain(dname)
 		checker = func(startTxNum, endTxNum uint64) bool {
-			return dchecker.CheckDependentPresent(dname, Any, startTxNum, endTxNum)
+			return dchecker.CheckDependentPresent(ue, Any, startTxNum, endTxNum)
 		}
 	}
 	return garbage(dt.d.dirtyFiles, dt.files, merged, checker)
@@ -934,7 +935,16 @@ func (ht *HistoryRoTx) garbage(merged *filesItem) (outs []*filesItem) {
 }
 
 func (iit *InvertedIndexRoTx) garbage(merged *filesItem) (outs []*filesItem) {
-	return garbage(iit.ii.dirtyFiles, iit.files, merged, nil)
+	var checker func(startTxNum, endTxNum uint64) bool
+	dchecker := iit.ii.checker
+
+	if dchecker != nil {
+		ue := FromII(iit.ii.name)
+		checker = func(startTxNum, endTxNum uint64) bool {
+			return dchecker.CheckDependentPresent(ue, Any, startTxNum, endTxNum)
+		}
+	}
+	return garbage(iit.ii.dirtyFiles, iit.files, merged, checker)
 }
 
 func garbage(dirtyFiles *btree.BTreeG[*filesItem], visibleFiles []visibleFile, merged *filesItem, checker func(startTxNum, endTxNum uint64) bool) (outs []*filesItem) {

--- a/erigon-lib/state/merge_test.go
+++ b/erigon-lib/state/merge_test.go
@@ -570,14 +570,14 @@ func TestMergeFilesWithDependency(t *testing.T) {
 		account, storage, commitment = newTestDomain(0), newTestDomain(1), newTestDomain(3)
 		checker := NewDependencyIntegrityChecker(account.hist.iiCfg.dirs, log.New())
 		info := &DependentInfo{
-			domain: commitment.name,
+			entity: FromDomain(commitment.name),
 			filesGetter: func() *btree2.BTreeG[*filesItem] {
 				return commitment.dirtyFiles
 			},
 			accessors: commitment.Accessors,
 		}
-		checker.AddDependency(account.name, info)
-		checker.AddDependency(storage.name, info)
+		checker.AddDependency(FromDomain(account.name), info)
+		checker.AddDependency(FromDomain(storage.name), info)
 		account.SetDependency(checker)
 		storage.SetDependency(checker)
 		return


### PR DESCRIPTION
https://github.com/erigontech/erigon/issues/15338

- not perfect solution - if multiple `agg.MadviceNormal()` called, newly integrated dirtyFiles will only have refcnt 1. But seems okay. 
- agg.MadviceNormal should be debug method...