### PR TITLE
polygon/sync: tweak fetch blocks backwards timeout (#15328)

### DIFF
--- a/polygon/sync/sync.go
+++ b/polygon/sync/sync.go
@@ -290,7 +290,7 @@ func (s *Sync) applyNewBlockOnTip(ctx context.Context, event EventNewBlock, ccb 
 			amount = 1024
 		}
 
-		opts := []p2p.FetcherOption{p2p.WithMaxRetries(0), p2p.WithResponseTimeout(time.Second)}
+		opts := []p2p.FetcherOption{p2p.WithMaxRetries(0), p2p.WithResponseTimeout(5 * time.Second)}
 		blocks, err := s.p2pService.FetchBlocksBackwardsByHash(ctx, newBlockHeaderHash, amount, event.PeerId, opts...)
 		if err != nil {
 			if s.ignoreFetchBlocksErrOnTipEvent(err) {


### PR DESCRIPTION
noticed some `response interrupted: context deadline exceeded` errs on Amoy in a case where there were no milestones for over 4 hours and right after initial sync-to-tip finished we had to backwards connect a new block event with around 700 blocks gap