### PR TITLE
Set withdrawls for bor genesis blocks

### DIFF
--- a/core/genesis_write.go
+++ b/core/genesis_write.go
@@ -476,7 +476,7 @@ func GenesisToBlock(g *types.Genesis, dirs datadir.Dirs, logger log.Logger) (*ty
 	}
 
 	var withdrawals []*types.Withdrawal
-	if g.Config != nil && g.Config.IsShanghai(g.Timestamp) {
+	if g.Config != nil && (g.Config.IsShanghai(g.Timestamp) || g.Config.Bor != nil && g.Config.Bor.IsAgra(0)) {
 		withdrawals = []*types.Withdrawal{}
 	}
 


### PR DESCRIPTION
On genesis for Bor if IsAgra is set it needs to write a zero array to Withdrawls rather than leaving it nil.  Without this erigon can't join bor testnests due to a genesis hash mismatch.

Note this does not affect existing chains. 