### PR TITLE
Revert "Engine-API: Fixed `context canceled` (#15277)"

### DIFF
--- a/execution/eth1/ethereum_execution.go
+++ b/execution/eth1/ethereum_execution.go
@@ -372,15 +372,15 @@ func (e *EthereumExecutionModule) Start(ctx context.Context) {
 
 func (e *EthereumExecutionModule) Ready(ctx context.Context, _ *emptypb.Empty) (*execution.ReadyResponse, error) {
 
+	if err := <-e.blockReader.Ready(ctx); err != nil {
+		return &execution.ReadyResponse{Ready: false}, err
+	}
+
 	if !e.semaphore.TryAcquire(1) {
 		e.logger.Trace("ethereumExecutionModule.Ready: ExecutionStatus_Busy")
 		return &execution.ReadyResponse{Ready: false}, nil
 	}
 	defer e.semaphore.Release(1)
-
-	if err := <-e.blockReader.Ready(ctx); err != nil {
-		return &execution.ReadyResponse{Ready: false}, err
-	}
 	return &execution.ReadyResponse{Ready: true}, nil
 }
 

--- a/turbo/snapshotsync/snapshots.go
+++ b/turbo/snapshotsync/snapshots.go
@@ -674,7 +674,7 @@ func (s *RoSnapshots) HasType(in snaptype.Type) bool {
 type ready struct {
 	mu     sync.Mutex
 	on     chan struct{}
-	state  atomic.Bool
+	state  bool
 	inited bool
 }
 
@@ -697,21 +697,15 @@ func (r *ready) set() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.init()
-	if r.state.Load() {
+	if r.state {
 		return
 	}
-	if r.state.CompareAndSwap(false, true) {
-		close(r.on)
-	}
+	r.state = true
+	close(r.on)
 }
 
 func (s *RoSnapshots) Ready(ctx context.Context) <-chan error {
 	errc := make(chan error)
-
-	if s.ready.state.Load() {
-		close(errc)
-		return errc
-	}
 
 	go func() {
 		select {


### PR DESCRIPTION
This reverts commit b605ef07c1285d01e1ac08311074f003401ff2ec.

Revert is needed for Hive-EEST, unless another fix is available