### PR TITLE
Make ReadAccountStorage return uint256 not []byte

### DIFF
--- a/cmd/integration/commands/state_domains.go
+++ b/cmd/integration/commands/state_domains.go
@@ -494,7 +494,7 @@ func requestDomains(chainDb, stateDb kv.RwDB, ctx context.Context, readDomain st
 	case kv.StorageDomain.String():
 		for _, addr := range addrs {
 			a, s := common.BytesToAddress(addr[:length.Addr]), common.BytesToHash(addr[length.Addr:])
-			st, err := r.ReadAccountStorage(a, s)
+			st, _, err := r.ReadAccountStorage(a, s)
 			if err != nil {
 				logger.Error("failed to read storage", "addr", a.String(), "key", s.String(), "err", err)
 				continue

--- a/core/state/cached_reader.go
+++ b/core/state/cached_reader.go
@@ -18,6 +18,7 @@ package state
 
 import (
 	"github.com/erigontech/erigon-lib/common"
+	"github.com/holiman/uint256"
 
 	"github.com/erigontech/erigon-lib/types/accounts"
 	"github.com/erigontech/erigon/turbo/shards"
@@ -59,21 +60,23 @@ func (cr *CachedReader) ReadAccountDataForDebug(address common.Address) (*accoun
 }
 
 // ReadAccountStorage is called when a storage item needs to be fetched from the state
-func (cr *CachedReader) ReadAccountStorage(address common.Address, key common.Hash) ([]byte, error) {
+func (cr *CachedReader) ReadAccountStorage(address common.Address, key common.Hash) (uint256.Int, bool, error) {
 	addrBytes := address.Bytes()
 	if s, ok := cr.cache.GetStorage(addrBytes, 1, key.Bytes()); ok {
-		return s, nil
+		var v uint256.Int
+		(&v).SetBytes(s)
+		return v, true, nil
 	}
-	v, err := cr.r.ReadAccountStorage(address, key)
+	v, ok, err := cr.r.ReadAccountStorage(address, key)
 	if err != nil {
-		return nil, err
+		return uint256.Int{}, false, err
 	}
-	if len(v) == 0 {
+	if !ok {
 		cr.cache.SetStorageAbsent(addrBytes, 1, key.Bytes())
 	} else {
-		cr.cache.SetStorageRead(addrBytes, 1, key.Bytes(), v)
+		cr.cache.SetStorageRead(addrBytes, 1, key.Bytes(), v.Bytes())
 	}
-	return v, nil
+	return v, ok, nil
 }
 
 // ReadAccountCode is called when code of an account needs to be fetched from the state

--- a/core/state/cached_reader3.go
+++ b/core/state/cached_reader3.go
@@ -20,6 +20,7 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/kv"
 	"github.com/erigontech/erigon-lib/kv/kvcache"
+	"github.com/holiman/uint256"
 
 	"github.com/erigontech/erigon-lib/types/accounts"
 )
@@ -69,16 +70,18 @@ func (r *CachedReader3) ReadAccountDataForDebug(address common.Address) (*accoun
 	return &a, nil
 }
 
-func (r *CachedReader3) ReadAccountStorage(address common.Address, key common.Hash) ([]byte, error) {
+func (r *CachedReader3) ReadAccountStorage(address common.Address, key common.Hash) (uint256.Int, bool, error) {
 	compositeKey := append(address[:], key[:]...)
 	enc, err := r.cache.Get(compositeKey)
 	if err != nil {
-		return nil, err
+		return uint256.Int{}, false, err
 	}
 	if len(enc) == 0 {
-		return nil, nil
+		return uint256.Int{}, false, err
 	}
-	return enc, nil
+	var v uint256.Int
+	(&v).SetBytes(enc)
+	return v, true, nil
 }
 
 func (r *CachedReader3) ReadAccountCode(address common.Address) ([]byte, error) {

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -20,6 +20,8 @@
 package state
 
 import (
+	"fmt"
+
 	"github.com/holiman/uint256"
 
 	"github.com/erigontech/erigon-lib/common"
@@ -37,7 +39,7 @@ const (
 type StateReader interface {
 	ReadAccountData(address common.Address) (*accounts.Account, error)
 	ReadAccountDataForDebug(address common.Address) (*accounts.Account, error)
-	ReadAccountStorage(address common.Address, key common.Hash) ([]byte, error)
+	ReadAccountStorage(address common.Address, key common.Hash) (uint256.Int, bool, error)
 	ReadAccountCode(address common.Address) ([]byte, error)
 	ReadAccountCodeSize(address common.Address) (int, error)
 	ReadAccountIncarnation(address common.Address) (uint64, error)
@@ -57,31 +59,53 @@ type StateWriter interface {
 }
 
 type NoopWriter struct {
+	trace bool
 }
 
 var noopWriter = &NoopWriter{}
 
-func NewNoopWriter() *NoopWriter {
-	return noopWriter
+func NewNoopWriter(trace ...bool) *NoopWriter {
+	if len(trace) == 0 {
+		return noopWriter
+	}
+	return &NoopWriter{trace[0]}
 }
 
 func (nw *NoopWriter) UpdateAccountData(address common.Address, original, account *accounts.Account) error {
+	if nw.trace {
+		fmt.Printf("acc %x: {Balance: %d, Nonce: %d, Inc: %d, CodeHash: %x}\n", address, &account.Balance, account.Nonce, account.Incarnation, account.CodeHash)
+	}
 	return nil
 }
 
 func (nw *NoopWriter) DeleteAccount(address common.Address, original *accounts.Account) error {
+	if nw.trace {
+		fmt.Printf("del acc: %x\n", address)
+	}
 	return nil
 }
 
 func (nw *NoopWriter) UpdateAccountCode(address common.Address, incarnation uint64, codeHash common.Hash, code []byte) error {
+	if nw.trace {
+		fmt.Printf("code: %x, %x, valLen: %d\n", address.Bytes(), codeHash, len(code))
+	}
 	return nil
 }
 
 func (nw *NoopWriter) WriteAccountStorage(address common.Address, incarnation uint64, key common.Hash, original, value uint256.Int) error {
+	if original == value {
+		return nil
+	}
+	if nw.trace {
+		fmt.Printf("storage: %x,%x,%x\n", address, key, &value)
+	}
 	return nil
 }
 
 func (nw *NoopWriter) CreateContract(address common.Address) error {
+	if nw.trace {
+		fmt.Printf("create contract: %x\n", address)
+	}
 	return nil
 }
 
@@ -100,8 +124,8 @@ func (*NoopReader) ReadAccountData(address common.Address) (*accounts.Account, e
 func (*NoopReader) ReadAccountDataForDebug(address common.Address) (*accounts.Account, error) {
 	return nil, nil
 }
-func (*NoopReader) ReadAccountStorage(address common.Address, key common.Hash) ([]byte, error) {
-	return nil, nil
+func (*NoopReader) ReadAccountStorage(address common.Address, key common.Hash) (uint256.Int, bool, error) {
+	return uint256.Int{}, false, nil
 }
 func (*NoopReader) ReadAccountCode(address common.Address) ([]byte, error)        { return nil, nil }
 func (*NoopReader) ReadAccountCodeSize(address common.Address) (int, error)       { return 0, nil }

--- a/core/state/rw_v3.go
+++ b/core/state/rw_v3.go
@@ -575,11 +575,13 @@ func (r *ReaderV3) ReadAccountDataForDebug(address common.Address) (*accounts.Ac
 	return r.ReadAccountData(address)
 }
 
-func (r *ReaderV3) ReadAccountStorage(address common.Address, key common.Hash) ([]byte, error) {
+func (r *ReaderV3) ReadAccountStorage(address common.Address, key common.Hash) (uint256.Int, bool, error) {
 	r.composite = append(append(r.composite[:0], address[:]...), key[:]...)
 	enc, _, err := r.tx.GetLatest(kv.StorageDomain, r.composite)
+	var res uint256.Int
+
 	if err != nil {
-		return nil, err
+		return res, false, err
 	}
 	if r.trace {
 		if enc == nil {
@@ -588,7 +590,12 @@ func (r *ReaderV3) ReadAccountStorage(address common.Address, key common.Hash) (
 			fmt.Printf("ReadAccountStorage [%x] => [%x], txNum: %d\n", r.composite, enc, r.txNum)
 		}
 	}
-	return enc, nil
+
+	ok := enc != nil
+	if ok {
+		(&res).SetBytes(enc)
+	}
+	return res, ok, err
 }
 
 func (r *ReaderV3) ReadAccountCode(address common.Address) ([]byte, error) {
@@ -695,11 +702,11 @@ func (r *ReaderParallelV3) ReadAccountDataForDebug(address common.Address) (*acc
 	return &acc, nil
 }
 
-func (r *ReaderParallelV3) ReadAccountStorage(address common.Address, key common.Hash) ([]byte, error) {
+func (r *ReaderParallelV3)  ReadAccountStorage(address common.Address, key common.Hash) (uint256.Int, bool, error) {
 	r.composite = append(append(r.composite[:0], address[:]...), key[:]...)
 	enc, _, err := r.sd.GetLatest(kv.StorageDomain, r.tx, r.composite)
 	if err != nil {
-		return nil, err
+		return uint256.Int{}, false, err
 	}
 	if !r.discardReadList {
 		r.readLists[kv.StorageDomain.String()].Push(string(r.composite), enc)
@@ -711,7 +718,9 @@ func (r *ReaderParallelV3) ReadAccountStorage(address common.Address, key common
 			fmt.Printf("ReadAccountStorage [%x] => [%x], txNum: %d\n", r.composite, enc, r.txNum)
 		}
 	}
-	return enc, nil
+	var res uint256.Int
+	(&res).SetBytes(enc)
+	return res, true, nil
 }
 
 func (r *ReaderParallelV3) ReadAccountCode(address common.Address) ([]byte, error) {

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -187,9 +187,12 @@ func (so *stateObject) GetCommittedState(key common.Hash, out *uint256.Int) {
 	}
 	if ok {
 		*out = res
-		so.originStorage[key] = res
-		so.blockOriginStorage[key] = res
+	} else {
+		out.Clear()
 	}
+
+	so.originStorage[key] = *out
+	so.blockOriginStorage[key] = *out
 }
 
 // SetState updates a value in account storage.

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -179,19 +179,17 @@ func (so *stateObject) GetCommittedState(key common.Hash, out *uint256.Int) {
 		return
 	}
 	// Load from DB in case it is missing.
-	enc, err := so.db.stateReader.ReadAccountStorage(so.address, key)
+	res, ok, err := so.db.stateReader.ReadAccountStorage(so.address, key)
 	if err != nil {
 		so.setError(err)
 		out.Clear()
 		return
 	}
-	if enc != nil {
-		out.SetBytes(enc)
-	} else {
-		out.Clear()
+	if ok {
+		*out = res
+		so.originStorage[key] = res
+		so.blockOriginStorage[key] = res
 	}
-	so.originStorage[key] = *out
-	so.blockOriginStorage[key] = *out
 }
 
 // SetState updates a value in account storage.

--- a/core/state/stateless.go
+++ b/core/state/stateless.go
@@ -111,25 +111,27 @@ func (s *Stateless) ReadAccountData(address common.Address) (*accounts.Account, 
 
 // ReadAccountStorage is a part of the StateReader interface
 // This implementation attempts to look up the storage in the state trie, and fails if it is not found
-func (s *Stateless) ReadAccountStorage(address common.Address, key common.Hash) ([]byte, error) {
+func (s *Stateless) ReadAccountStorage(address common.Address, key common.Hash) (uint256.Int, bool, error) {
 	if s.trace {
-		fmt.Printf("Stateless: ReadAccountStorage(address=%x, key=%x)\n", address.Bytes(), key.Bytes())
+		fmt.Printf("Stateless: ReadAccountStorage(address=%x, key=%x)\n", address[:], key[:])
 	}
 	seckey, err := common.HashData(key[:])
 	if err != nil {
-		return nil, err
+		return uint256.Int{}, false, err
 	}
 
 	addrHash, err := common.HashData(address[:])
 	if err != nil {
-		return nil, err
+		return uint256.Int{}, false, err
 	}
 
 	if enc, ok := s.t.Get(dbutils.GenerateCompositeTrieKey(addrHash, seckey)); ok {
-		return enc, nil
+		var res uint256.Int
+		(&res).SetBytes(enc)
+		return res, true, nil
 	}
 
-	return nil, nil
+	return uint256.Int{}, false, nil
 }
 
 // ReadAccountCode is a part of the StateReader interface

--- a/core/state/triedb_state.go
+++ b/core/state/triedb_state.go
@@ -657,21 +657,21 @@ func (tds *TrieDbState) ReadAccountData(address common.Address) (*accounts.Accou
 	return account, nil
 }
 
-func (tds *TrieDbState) ReadAccountStorage(address common.Address, key common.Hash) ([]byte, error) {
+func (tds *TrieDbState) ReadAccountStorage(address common.Address, key common.Hash) (uint256.Int, bool, error) {
 	addrHash := common.Hash(crypto.Keccak256(address.Bytes()))
 	if tds.currentBuffer != nil {
 		if _, ok := tds.currentBuffer.deleted[addrHash]; ok {
-			return nil, nil
+			return uint256.Int{}, false, nil
 		}
 	}
 	if tds.aggregateBuffer != nil {
 		if _, ok := tds.aggregateBuffer.deleted[addrHash]; ok {
-			return nil, nil
+			return uint256.Int{}, false, nil
 		}
 	}
 	seckey, err := common.HashData(key.Bytes())
 	if err != nil {
-		return nil, err
+		return uint256.Int{}, false, err
 	}
 
 	storagePlainKey := dbutils.GenerateStoragePlainKey(address, key)
@@ -686,14 +686,16 @@ func (tds *TrieDbState) ReadAccountStorage(address common.Address, key common.Ha
 	defer tds.tMu.Unlock()
 	enc, ok := tds.t.Get(dbutils.GenerateCompositeTrieKey(addrHash, seckey))
 	if !ok {
-		enc, err := tds.StateReader.ReadAccountStorage(address, key)
+		enc, ok, err := tds.StateReader.ReadAccountStorage(address, key)
 		if err != nil {
-			return nil, err
+			return uint256.Int{}, false, err
 		}
-		return enc, nil
+		return enc, ok, nil
 	}
 
-	return enc, nil
+	var res uint256.Int
+	(&res).SetBytes(enc)
+	return res, true, nil
 }
 
 func (tds *TrieDbState) readAccountCodeFromTrie(addrHash []byte) ([]byte, bool) {

--- a/core/state/versionedio.go
+++ b/core/state/versionedio.go
@@ -283,11 +283,7 @@ func (vr versionedStateReader) ReadAccountStorage(address common.Address, key co
 	}
 
 	if vr.stateReader != nil {
-		val, err := vr.stateReader.ReadAccountStorage(address, key)
-		if err != nil {
-			return uint256.Int{}, false, err
-		}
-		return *(&uint256.Int{}).SetBytes(val), true, nil
+		return vr.stateReader.ReadAccountStorage(address, key)
 	}
 
 	return uint256.Int{}, false, nil

--- a/rpc/jsonrpc/eth_accounts.go
+++ b/rpc/jsonrpc/eth_accounts.go
@@ -139,11 +139,8 @@ func (api *APIImpl) GetStorageAt(ctx context.Context, address common.Address, in
 	}
 
 	location := common.HexToHash(index)
-	res, err := reader.ReadAccountStorage(address, location)
-	if err != nil {
-		res = empty
-	}
-	return hexutil.Encode(common.LeftPadBytes(res, 32)), err
+	res, _, err := reader.ReadAccountStorage(address, location)
+	return hexutil.Encode(res.PaddedBytes(32)), err
 }
 
 // Exist returns whether an account for a given address exists in the database.

--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -449,14 +449,11 @@ func (api *APIImpl) getProof(ctx context.Context, roTx kv.TemporalTx, address co
 			return nil, errors.New("cannot verify store proof")
 		}
 
-		res, err := reader.ReadAccountStorage(address, keyHash)
+		res, _, err := reader.ReadAccountStorage(address, keyHash)
 		if err != nil {
-			res = []byte{}
 			logger.Warn(fmt.Sprintf("couldn't read account storage for the address %s\n", address.String()))
 		}
-		n := new(big.Int)
-		n.SetBytes(res)
-		proof.StorageProof[i].Value = (*hexutil.Big)(n)
+		proof.StorageProof[i].Value = (*hexutil.Big)(res.ToBig())
 
 		// 0x80 represents RLP encoding of an empty proof slice
 		proof.StorageProof[i].Proof = []hexutil.Bytes{[]byte{0x80}}

--- a/turbo/engineapi/engine_types/jsonrpc.go
+++ b/turbo/engineapi/engine_types/jsonrpc.go
@@ -96,7 +96,7 @@ type PayloadStatus struct {
 	Status          EngineStatus      `json:"status" gencodec:"required"`
 	ValidationError *StringifiedError `json:"validationError"`
 	LatestValidHash *common.Hash      `json:"latestValidHash"`
-	CriticalError   error
+	CriticalError   error             `json:"-"`
 }
 
 type ForkChoiceUpdatedResponse struct {


### PR DESCRIPTION
This is mainly to reduce garbage from IO when running the EVM.  This forces an early conversion to an [4]uint64 array which is then passed back via the stack rather than escaping to the heap.  This []byte escape is a significant source of garbage when the evm is running.  