### PR TITLE
retire: more merge threads

### DIFF
--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -350,8 +350,9 @@ var manifestCmd = &cobra.Command{
 }
 
 var manifestVerifyCmd = &cobra.Command{
-	Use:     "manifest-verify",
-	Example: "go run ./cmd/downloader manifest-verify --chain <chain> [--webseed 'a','b','c']",
+	Use:     "manifest_verify",
+	Aliases: []string{"manifest-verify"},
+	Example: "go run ./cmd/downloader manifest_verify --chain <chain> [--webseed 'a','b','c']",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		logger := debug.SetupCobra(cmd, "downloader")
 		if err := manifestVerify(cmd.Context(), logger); err != nil {

--- a/cmd/integration/Readme.md
+++ b/cmd/integration/Readme.md
@@ -5,7 +5,7 @@ etc...
 
 All commands require parameter `--datadir=<datadir>` - I will skip it for readability.
 
-```
+```sh
 integration --help
 integration print_stages
 
@@ -44,7 +44,7 @@ Pre-requirements of `state_stages` command:
 - Headers/Bodies must be downloaded
 - TxSenders stage must be executed
 
-```
+```sh
 make all
 ./build/bin/integration state_stages --datadir=<datadir> --unwind=10 --unwind.every=20 --pprof
 integration reset_state # drops all stages after Senders stage (including it's db tables DB tables)
@@ -52,7 +52,7 @@ integration reset_state # drops all stages after Senders stage (including it's d
 
 For example:
 
-```
+```sh
 --unwind=1 --unwind.every=10  # 10 blocks forward, 1 block back, 10 blocks forward, ...
 --unwind=10 --unwind.every=1  # 1 block forward, 10 blocks back, 1 blocks forward, ...
 --unwind=10  # 10 blocks back, then stop
@@ -71,7 +71,7 @@ until https://github.com/erigontech/erigon/issues/13674 is fixed)
 In Erigon3 - better do `rm -rf chaindata` (for bor maybe also need remove `polygon-bridge`, `bor`, `heimdall` folders
 until https://github.com/erigontech/erigon/issues/13674 is fixed)
 
-```
+```sh
 0. You will need 2x disk space (can be different disks).
 1. Stop Erigon
 2. Create new db with new --db.pagesize:
@@ -89,7 +89,7 @@ If you face db-open error like `MDBX_PROBLEM: Unexpected internal error`. First:
 like https://www.memtest86.com to test RAM and tools like https://www.smartmontools.org to test Disk. If hardware is
 fine: can try manually recover db (see `./build/bin/mdbx_chk -h` for more details):
 
-```
+```sh
 make db-tools
 
 ./build/bin/mdbx_chk -0 -d /erigon/chaindata
@@ -115,7 +115,7 @@ It allows to process this blocks again
 
 ## How to re-exec all blocks
 
-```cgo
+```sh
 # Option 1 (on empty datadir):
 erigon --snap.skip-state-snapshot-download
 
@@ -129,7 +129,7 @@ integration stage_exec
 
 ## How to re-generate some Domain/Index
 
-```cgo
+```sh
 # By parallel executing blocks on existing historical state. Can be 1 or many domains:
 erigon seg rm-state-snapshots --domain=rcache,logtopics,logaddrs,tracesfrom,tracesto
 integration stage_custom_trace --domain=rcache,logindex,traceindex --reset
@@ -138,9 +138,27 @@ integration stage_custom_trace --domain=rcache,logindex,traceindex
 
 ## How to re-gen bor checkpoints
 
-```cgo
+```sh
 rm -rf datadir/heimdall
 rm -rf datadir/snapshots/*borch*
 # Start erigon, it will gen. Then:
 erigon seg integrity --datadir /erigon-data/ --check=BorCheckpoints
+```
+
+## See tables size
+
+```sh
+./build/bin/mdbx_stat -efa /erigon-data/chaindata/   | awk '
+    BEGIN { pagesize = 4096 }
+    /^  Pagesize:/ { pagesize = $2 }
+    /^Status of/ { table = $3 }
+    /Branch pages:/ { branch = $3 }
+    /Leaf pages:/ { leaf = $3 }
+    /Overflow pages:/ { overflow = $3 }
+    /Entries:/ {
+      total_pages = branch + leaf + overflow
+      size_gb = (total_pages * pagesize) / (1024^3)
+      printf "%-30s %.3fG\n", table, size_gb
+    }
+  ' | grep -v '0.000G'
 ```

--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -1010,9 +1010,9 @@ func stageCustomTrace(db kv.TemporalRwDB, ctx context.Context, logger log.Logger
 	//defer agg.MadvNormal().DisableReadAhead()
 	blockSnapBuildSema := semaphore.NewWeighted(int64(runtime.NumCPU()))
 	agg.SetSnapshotBuildSema(blockSnapBuildSema)
-	agg.SetCollateAndBuildWorkers(estimate.StateV3Collate.Workers())
-	agg.SetMergeWorkers(2)
-	agg.SetCompressWorkers(estimate.CompressSnapshot.WorkersHalf())
+	agg.SetCollateAndBuildWorkers(min(4, estimate.StateV3Collate.Workers()))
+	agg.SetMergeWorkers(min(4, estimate.StateV3Collate.Workers()))
+	agg.SetCompressWorkers(estimate.CompressSnapshot.Workers())
 	agg.PeriodicalyPrintProcessSet(ctx)
 
 	err := stagedsync.SpawnCustomTrace(cfg, ctx, logger)

--- a/cmd/scripts/mirror-datadir.sh
+++ b/cmd/scripts/mirror-datadir.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+## create backup of a datadir for experiments/debugging etc.
+## it creates copy of editable files like mdbx.dat 
+## and symlinks to immutable files like snapshots
+
+# Check if correct number of arguments provided
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <source_directory> <destination_directory>"
+    echo "Example: $0 /path/to/source /path/to/destination"
+    exit 1
+fi
+
+# Get source and destination from command line arguments
+source="$1"
+destination="$2"
+
+# Validate that source directory exists
+if [ ! -d "$source" ]; then
+    echo "Error: Source directory '$source' does not exist"
+    exit 1
+fi
+
+# Remove trailing slashes for consistent path handling
+source="${source%/}"
+destination="${destination%/}"
+
+echo "Syncing symlinks from '$source' to '$destination'"
+
+# Create the destination directory if it doesn't exist
+mkdir -p "$destination"
+
+# First create the directory structure
+echo "Creating directory structure..."
+find "$source" -type d | sed "s|^$source|$destination|" | xargs -I{} mkdir -p {}
+
+# Then create symbolic links for all files (or copy specific ones)
+echo "Creating symbolic links and copying special files..."
+find "$source" -type f | while read file; do
+    rel_path="${file#$source}"
+    filename=$(basename "$file")
+    
+    # Skip erigon.log entirely
+    if [ "$filename" = "erigon.log" ]; then
+        echo "Skipping: $file"
+        continue
+    fi
+    
+    # Copy these files instead of symlinking
+    if [ "$filename" = "mdbx.dat" ] || [ "$filename" = "mdbx.lck" ] || [ "$filename" = "jwt.hex" ] || [ "$filename" = "LOCK" ] || [ "$filename" = "prohibit_new_downloads.lock" ] || [ "$filename" = "nodekey" ]; then
+        echo "Copying: $file"
+        cp "$file" "$destination$rel_path"
+    else
+        # Symlink all other files
+        ln -sf "$file" "$destination$rel_path"
+    fi
+done
+
+# Remove files in destination that don't exist in source (except erigon.log which we skip)
+echo "Cleaning up orphaned links..."
+find "$destination" -type f -o -type l | while read file; do
+    rel_path="${file#$destination}"
+    filename=$(basename "$file")
+    
+    # Skip erigon.log cleanup since we don't sync it
+    if [ "$filename" = "erigon.log" ]; then
+        continue
+    fi
+    
+    if [ ! -e "$source$rel_path" ]; then
+        echo "Removing orphaned: $file"
+        rm "$file"
+    fi
+done
+
+echo "Sync complete!"

--- a/core/vm/stack.go
+++ b/core/vm/stack.go
@@ -47,7 +47,6 @@ func New() *Stack {
 	}
 	return stack
 }
-
 func (st *Stack) push(d *uint256.Int) {
 	// NOTE push limit (1024) is checked in baseCheck
 	st.data = append(st.data, *d)

--- a/erigon-lib/etl/buffers.go
+++ b/erigon-lib/etl/buffers.go
@@ -23,8 +23,10 @@ import (
 	"io"
 	"sort"
 	"strconv"
+	"sync"
 
 	"github.com/c2h5oh/datasize"
+	"github.com/erigontech/erigon-lib/common/dbg"
 
 	"github.com/erigontech/erigon-lib/common"
 )
@@ -42,7 +44,21 @@ const (
 	BufIOSize = 128 * 4096
 )
 
-var BufferOptimalSize = 256 * datasize.MB /*  var because we want to sometimes change it from tests or command-line flags */
+var BufferOptimalSize = dbg.EnvDataSize("ETL_OPTIMAL", 256*datasize.MB) /*  var because we want to sometimes change it from tests or command-line flags */
+
+// 3_domains * 2 + 3_history * 1 + 4_indices * 2 = 17 etl collectors, 17*(256Mb/8) = 512Mb - for all collectros
+var etlSmallBufRAM = dbg.EnvDataSize("ETL_SMALL", BufferOptimalSize/8)
+var SmallSortableBuffers = NewAllocator(&sync.Pool{
+	New: func() interface{} {
+		return NewSortableBuffer(etlSmallBufRAM).Prealloc(1_024, int(etlSmallBufRAM/32))
+	},
+})
+var etlLargeBufRAM = BufferOptimalSize
+var LargeSortableBuffers = NewAllocator(&sync.Pool{
+	New: func() interface{} {
+		return NewSortableBuffer(etlLargeBufRAM).Prealloc(1_024, int(etlLargeBufRAM/32))
+	},
+})
 
 type Buffer interface {
 	// Put does copy `k` and `v`

--- a/erigon-lib/etl/etl.go
+++ b/erigon-lib/etl/etl.go
@@ -21,12 +21,9 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"sync"
 	"time"
 
 	"github.com/c2h5oh/datasize"
-	"github.com/erigontech/erigon-lib/common/dbg"
-
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/kv"
 	"github.com/erigontech/erigon-lib/log/v3"
@@ -177,17 +174,3 @@ var IdentityLoadFunc LoadFunc = func(k []byte, value []byte, _ CurrentTableReade
 func isIdentityLoadFunc(f LoadFunc) bool {
 	return f == nil || reflect.ValueOf(IdentityLoadFunc).Pointer() == reflect.ValueOf(f).Pointer()
 }
-
-// 3_domains * 2 + 3_history * 1 + 4_indices * 2 = 17 etl collectors, 17*(256Mb/8) = 512Mb - for all collectros
-var etlSmallBufRAM = dbg.EnvDataSize("ETL_SMALL_BUFS_RAM", BufferOptimalSize/8)
-var SmallSortableBuffers = NewAllocator(&sync.Pool{
-	New: func() interface{} {
-		return NewSortableBuffer(etlSmallBufRAM).Prealloc(1_024, int(etlSmallBufRAM/32))
-	},
-})
-var etlLargeBufRAM = dbg.EnvDataSize("ETL_LARGE_BUFS_RAM", BufferOptimalSize)
-var LargeSortableBuffers = NewAllocator(&sync.Pool{
-	New: func() interface{} {
-		return NewSortableBuffer(etlLargeBufRAM).Prealloc(1_024, int(etlLargeBufRAM/32))
-	},
-})

--- a/erigon-lib/kv/membatch/mapmutation.go
+++ b/erigon-lib/kv/membatch/mapmutation.go
@@ -305,9 +305,10 @@ func (m *Mapmutation) doCommit(tx kv.RwTx) error {
 
 	keyCount, total := 0, m.count
 	for table, bucket := range m.puts {
-		collector := etl.NewCollector("", m.tmpdir, etl.NewSortableBuffer(etl.BufferOptimalSize/2), m.logger)
+		collector := etl.NewCollectorWithAllocator("", m.tmpdir, etl.LargeSortableBuffers, m.logger)
 		defer collector.Close()
 		collector.SortAndFlushInBackground(true)
+		collector.LogLvl(log.LvlDebug)
 		for key, value := range bucket {
 			if err := collector.Collect([]byte(key), value); err != nil {
 				return err

--- a/erigon-lib/recsplit/recsplit.go
+++ b/erigon-lib/recsplit/recsplit.go
@@ -283,7 +283,7 @@ func (rs *RecSplit) ResetNextSalt() {
 	rs.bucketCollector.LogLvl(log.LvlDebug)
 	if rs.offsetCollector != nil {
 		rs.offsetCollector.Close()
-		rs.offsetCollector = etl.NewCollector(RecSplitLogPrefix+" "+rs.indexFileName, rs.tmpDir, etl.SmallSortableBuffers, rs.logger)
+		rs.offsetCollector = etl.NewCollectorWithAllocator(RecSplitLogPrefix+" "+rs.indexFileName, rs.tmpDir, etl.SmallSortableBuffers, rs.logger)
 		rs.offsetCollector.SortAndFlushInBackground(true)
 		rs.bucketCollector.LogLvl(log.LvlDebug)
 	}

--- a/erigon-lib/recsplit/recsplit.go
+++ b/erigon-lib/recsplit/recsplit.go
@@ -29,7 +29,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/c2h5oh/datasize"
 	"github.com/spaolacci/murmur3"
 
 	"github.com/erigontech/erigon-lib/common"
@@ -103,7 +102,6 @@ type RecSplit struct {
 	currentBucketIdx   uint64 // Current bucket being accumulated
 	baseDataID         uint64 // Minimal app-specific ID of entries of this index - helps app understand what data stored in given shard - persistent field
 	bucketCount        uint64 // Number of buckets
-	etlBufLimit        datasize.ByteSize
 	salt               uint32 // Murmur3 hash used for converting keys to 64-bit values and assigning to buckets
 	leafSize           uint16 // Leaf size for recursive split algorithm
 	secondaryAggrBound uint16 // The lower bound for secondary key aggregation (computed from leadSize)

--- a/erigon-lib/rules.go
+++ b/erigon-lib/rules.go
@@ -101,6 +101,9 @@ func closeCollector(m dsl.Matcher) {
 	m.Match(`$c := etl.NewCollector($*_); $close`).
 		Where(!m["close"].Text.Matches(`defer .*\.Close()`)).
 		Report(`Add "defer $c.Close()" right after collector creation`)
+	m.Match(`$c := etl.NewCollectorWithAllocator($*_); $close`).
+		Where(!m["close"].Text.Matches(`defer .*\.Close()`)).
+		Report(`Add "defer $c.Close()" right after collector creation`)
 }
 
 func closeLockedDir(m dsl.Matcher) {

--- a/erigon-lib/seg/compress.go
+++ b/erigon-lib/seg/compress.go
@@ -188,6 +188,8 @@ func (c *Compressor) ReadFrom(g *Getter) error {
 	return nil
 }
 
+var superStringsPool = sync.Pool{New: func() any { return make([]byte, 0, superstringLimit) }}
+
 func (c *Compressor) AddWord(word []byte) error {
 	c.wordsCount++
 	if c.wordsCount%1024 == 0 {
@@ -204,7 +206,7 @@ func (c *Compressor) AddWord(word []byte) error {
 			c.superstrings <- c.superstring
 		}
 		c.superstringCount++
-		c.superstring = make([]byte, 0, superstringLimit)
+		c.superstring = superStringsPool.Get().([]byte)[:0]
 	}
 
 	if c.superstringCount%c.SamplingFactor == 0 {

--- a/erigon-lib/seg/compress.go
+++ b/erigon-lib/seg/compress.go
@@ -112,7 +112,6 @@ type Compressor struct {
 	superstring      []byte
 	wordsCount       uint64
 	superstringCount uint64
-	superstringLen   int
 	Ratio            CompressionRatio
 	lvl              log.Lvl
 	trace            bool
@@ -141,7 +140,7 @@ func NewCompressor(ctx context.Context, logPrefix, outputFile, tmpDir string, cf
 	wg.Add(workers)
 	suffixCollectors := make([]*etl.Collector, workers)
 	for i := 0; i < workers; i++ {
-		collector := etl.NewCollector(logPrefix+"_dict", tmpDir, etl.NewSortableBuffer(etl.BufferOptimalSize/4), logger) //nolint:gocritic
+		collector := etl.NewCollectorWithAllocator(logPrefix+"_dict", tmpDir, etl.SmallSortableBuffers, logger) //nolint:gocritic
 		collector.SortAndFlushInBackground(true)
 		collector.LogLvl(lvl)
 
@@ -190,23 +189,23 @@ func (c *Compressor) ReadFrom(g *Getter) error {
 }
 
 func (c *Compressor) AddWord(word []byte) error {
-	select {
-	case <-c.ctx.Done():
-		return c.ctx.Err()
-	default:
+	c.wordsCount++
+	if c.wordsCount%1024 == 0 {
+		select {
+		case <-c.ctx.Done():
+			return c.ctx.Err()
+		default:
+		}
 	}
 
-	c.wordsCount++
 	l := 2*len(word) + 2
-	if c.superstringLen+l > superstringLimit {
+	if len(c.superstring)+l > superstringLimit {
 		if c.superstringCount%c.SamplingFactor == 0 {
 			c.superstrings <- c.superstring
 		}
 		c.superstringCount++
-		c.superstring = make([]byte, 0, 1024*1024)
-		c.superstringLen = 0
+		c.superstring = make([]byte, 0, superstringLimit)
 	}
-	c.superstringLen += l
 
 	if c.superstringCount%c.SamplingFactor == 0 {
 		for _, a := range word {
@@ -219,13 +218,15 @@ func (c *Compressor) AddWord(word []byte) error {
 }
 
 func (c *Compressor) AddUncompressedWord(word []byte) error {
-	select {
-	case <-c.ctx.Done():
-		return c.ctx.Err()
-	default:
+	c.wordsCount++
+	if c.wordsCount%1024 == 0 {
+		select {
+		case <-c.ctx.Done():
+			return c.ctx.Err()
+		default:
+		}
 	}
 
-	c.wordsCount++
 	return c.uncompressedFile.AppendUncompressed(word)
 }
 
@@ -355,11 +356,21 @@ func (db *DictionaryBuilder) Pop() interface{} {
 }
 
 func (db *DictionaryBuilder) processWord(chars []byte, score uint64) {
-	heap.Push(db, &Pattern{word: common.Copy(chars), score: score})
-	if db.Len() > db.softLimit {
-		// Remove the element with smallest score
-		heap.Pop(db)
+	if db.Len()+1 <= db.softLimit {
+		heap.Push(db, &Pattern{word: common.Copy(chars), score: score})
+		return
 	}
+
+	// Remove the element with smallest score
+	elem := heap.Pop(db).(*Pattern)
+	if elem == nil {
+		heap.Push(db, &Pattern{word: common.Copy(chars), score: score})
+		return
+	}
+	elem.word = append(elem.word[:0], chars...)
+	elem.score = score
+	heap.Push(db, elem)
+	return
 }
 
 func (db *DictionaryBuilder) loadFunc(k, v []byte, table etl.CurrentTableReader, next etl.LoadNextFunc) error {

--- a/erigon-lib/seg/parallel_compress.go
+++ b/erigon-lib/seg/parallel_compress.go
@@ -915,7 +915,7 @@ func extractPatternsInSuperstrings(ctx context.Context, superstringCh chan []byt
 
 func DictionaryBuilderFromCollectors(ctx context.Context, cfg Cfg, logPrefix, tmpDir string, collectors []*etl.Collector, lvl log.Lvl, logger log.Logger) (*DictionaryBuilder, error) {
 	t := time.Now()
-	dictCollector := etl.NewCollector(logPrefix+"_collectDict", tmpDir, etl.NewSortableBuffer(etl.BufferOptimalSize/4), logger)
+	dictCollector := etl.NewCollectorWithAllocator(logPrefix+"_collectDict", tmpDir, etl.SmallSortableBuffers, logger)
 	defer dictCollector.Close()
 	dictCollector.SortAndFlushInBackground(true)
 	dictCollector.LogLvl(lvl)

--- a/erigon-lib/seg/parallel_compress.go
+++ b/erigon-lib/seg/parallel_compress.go
@@ -910,6 +910,8 @@ func extractPatternsInSuperstrings(ctx context.Context, superstringCh chan []byt
 				break
 			}
 		}
+
+		superStringsPool.Put(superstring)
 	}
 }
 

--- a/erigon-lib/seg/parallel_compress.go
+++ b/erigon-lib/seg/parallel_compress.go
@@ -306,12 +306,17 @@ func compressWithPatternCandidates(ctx context.Context, trace bool, cfg Cfg, log
 	var numBuf [binary.MaxVarintLen64]byte
 	totalWords := uncompressedFile.count
 
+	ii := 0
 	if err = uncompressedFile.ForEach(func(v []byte, compression bool) error {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
+		ii++
+		if ii%1024 == 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
 		}
+
 		if cfg.Workers > 1 {
 			// take processed words in non-blocking way and push them to the queue
 		outer:

--- a/erigon-lib/seg/parallel_compress.go
+++ b/erigon-lib/seg/parallel_compress.go
@@ -313,6 +313,10 @@ func compressWithPatternCandidates(ctx context.Context, trace bool, cfg Cfg, log
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
+			case <-logEvery.C:
+				if lvl < log.LvlTrace {
+					logger.Log(lvl, fmt.Sprintf("[%s] Replacement preprocessing", logPrefix), "processed", fmt.Sprintf("%.2f%%", 100*float64(outCount)/float64(totalWords)), "ch", len(ch), "queue", compressionQueue.Len(), "workers", cfg.Workers)
+				}
 			default:
 			}
 		}
@@ -402,13 +406,6 @@ func compressWithPatternCandidates(ctx context.Context, trace bool, cfg Cfg, log
 			emptyWordsCount++
 		}
 
-		select {
-		case <-logEvery.C:
-			if lvl < log.LvlTrace {
-				logger.Log(lvl, fmt.Sprintf("[%s] Replacement preprocessing", logPrefix), "processed", fmt.Sprintf("%.2f%%", 100*float64(outCount)/float64(totalWords)), "ch", len(ch), "queue", compressionQueue.Len(), "workers", cfg.Workers)
-			}
-		default:
-		}
 		return nil
 	}); err != nil {
 		return err

--- a/erigon-lib/seg/parallel_compress.go
+++ b/erigon-lib/seg/parallel_compress.go
@@ -917,7 +917,7 @@ func extractPatternsInSuperstrings(ctx context.Context, superstringCh chan []byt
 
 func DictionaryBuilderFromCollectors(ctx context.Context, cfg Cfg, logPrefix, tmpDir string, collectors []*etl.Collector, lvl log.Lvl, logger log.Logger) (*DictionaryBuilder, error) {
 	t := time.Now()
-	dictCollector := etl.NewCollectorWithAllocator(logPrefix+"_collectDict", tmpDir, etl.SmallSortableBuffers, logger)
+	dictCollector := etl.NewCollectorWithAllocator(logPrefix+"_collectDict", tmpDir, etl.LargeSortableBuffers, logger)
 	defer dictCollector.Close()
 	dictCollector.SortAndFlushInBackground(true)
 	dictCollector.LogLvl(lvl)

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -991,13 +991,24 @@ func (at *AggregatorRoTx) PruneSmallBatches(ctx context.Context, timeout time.Du
 		case <-localTimeout.C: //must be first to improve responsivness
 			return true, nil
 		case <-logEvery.C:
-			at.a.logger.Info("[snapshots] pruning state",
-				"until commit", time.Until(started.Add(timeout)).String(),
-				//"pruneLimit", pruneLimit,
-				"aggregatedStep", at.StepsInFiles(kv.AccountsDomain),
-				"stepsRangeInDB", at.stepsRangeInDBAsStr(tx),
-				//"pruned", fullStat.String(),
-			)
+			if furiousPrune {
+				at.a.logger.Info("[snapshots] pruning state",
+					//"until commit", time.Until(started.Add(timeout)).String(),
+					//"pruneLimit", pruneLimit,
+					//"aggregatedStep", at.StepsInFiles(kv.AccountsDomain),
+					"stepsRangeInDB", at.stepsRangeInDBAsStr(tx),
+					//"pruned", fullStat.String(),
+				)
+			} else {
+				at.a.logger.Info("[snapshots] pruning state",
+					"until commit", time.Until(started.Add(timeout)).String(),
+					//"pruneLimit", pruneLimit,
+					//"aggregatedStep", at.StepsInFiles(kv.AccountsDomain),
+					"stepsRangeInDB", at.stepsRangeInDBAsStr(tx),
+					//"pruned", fullStat.String(),
+				)
+			}
+
 		case <-ctx.Done():
 			return false, ctx.Err()
 		default:

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -1264,6 +1264,9 @@ func (at *AggregatorRoTx) findMergeRange(maxEndTxNum, maxSpan uint64) *Ranges {
 		}
 	}
 	for id, d := range at.d {
+		if d.d.disable {
+			continue
+		}
 		r.domain[id] = d.findMergeRange(maxEndTxNum, maxSpan)
 	}
 
@@ -1304,6 +1307,9 @@ func (at *AggregatorRoTx) findMergeRange(maxEndTxNum, maxSpan uint64) *Ranges {
 	}
 
 	for id, ii := range at.iis {
+		if ii.ii.disable {
+			continue
+		}
 		r.invertedIndex[id] = ii.findMergeRange(maxEndTxNum, maxSpan)
 	}
 
@@ -1333,6 +1339,9 @@ func (at *AggregatorRoTx) mergeFiles(ctx context.Context, files *SelectedStaticF
 	accStorageMerged := new(sync.WaitGroup)
 
 	for id := range at.d {
+		if at.d[id].d.disable {
+			continue
+		}
 		if !r.domain[id].any() {
 			continue
 		}
@@ -1367,6 +1376,10 @@ func (at *AggregatorRoTx) mergeFiles(ctx context.Context, files *SelectedStaticF
 	}
 
 	for id, rng := range r.invertedIndex {
+		if at.iis[id].ii.disable {
+			continue
+		}
+
 		if !rng.needMerge {
 			continue
 		}

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -994,7 +994,7 @@ func (at *AggregatorRoTx) PruneSmallBatches(ctx context.Context, timeout time.Du
 			at.a.logger.Info("[snapshots] pruning state",
 				"until commit", time.Until(started.Add(timeout)).String(),
 				"pruneLimit", pruneLimit,
-				"aggregatedStep", at.StepsInFiles(kv.StateDomains...),
+				"aggregatedStep", at.StepsInFiles(kv.AccountsDomain),
 				"stepsRangeInDB", at.stepsRangeInDBAsStr(tx),
 				"pruned", fullStat.String(),
 			)

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -286,6 +286,10 @@ func (a *Aggregator) OpenFolder() error {
 func (a *Aggregator) openFolder() error {
 	eg := &errgroup.Group{}
 	for _, d := range a.d {
+		if d.disable {
+			continue
+		}
+
 		d := d
 		eg.Go(func() error {
 			select {
@@ -297,6 +301,9 @@ func (a *Aggregator) openFolder() error {
 		})
 	}
 	for _, ii := range a.iis {
+		if ii.disable {
+			continue
+		}
 		ii := ii
 		eg.Go(func() error { return ii.openFolder() })
 	}
@@ -1407,10 +1414,16 @@ func (a *Aggregator) IntegrateMergedDirtyFiles(outs *SelectedStaticFiles, in *Me
 	defer a.dirtyFilesLock.Unlock()
 
 	for id, d := range a.d {
+		if d.disable {
+			continue
+		}
 		d.integrateMergedDirtyFiles(in.d[id], in.dIdx[id], in.dHist[id])
 	}
 
 	for id, ii := range a.iis {
+		if ii.disable {
+			continue
+		}
 		ii.integrateMergedDirtyFiles(in.iis[id])
 	}
 
@@ -1425,6 +1438,9 @@ func (a *Aggregator) cleanAfterMerge(in *MergedFilesV3) {
 	defer a.dirtyFilesLock.Unlock()
 
 	for id, d := range at.d {
+		if d.d.disable {
+			continue
+		}
 		if in == nil {
 			d.cleanAfterMerge(nil, nil, nil)
 		} else {
@@ -1432,6 +1448,9 @@ func (a *Aggregator) cleanAfterMerge(in *MergedFilesV3) {
 		}
 	}
 	for id, ii := range at.iis {
+		if ii.ii.disable {
+			continue
+		}
 		if in == nil {
 			ii.cleanAfterMerge(nil)
 		} else {

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -992,7 +992,7 @@ func (at *AggregatorRoTx) PruneSmallBatches(ctx context.Context, timeout time.Du
 			return true, nil
 		case <-logEvery.C:
 			if furiousPrune {
-				at.a.logger.Info("[snapshots] pruning state",
+				at.a.logger.Info("[prune] state",
 					//"until commit", time.Until(started.Add(timeout)).String(),
 					//"pruneLimit", pruneLimit,
 					//"aggregatedStep", at.StepsInFiles(kv.AccountsDomain),
@@ -1000,7 +1000,7 @@ func (at *AggregatorRoTx) PruneSmallBatches(ctx context.Context, timeout time.Du
 					//"pruned", fullStat.String(),
 				)
 			} else {
-				at.a.logger.Info("[snapshots] pruning state",
+				at.a.logger.Info("[prune] state",
 					"until commit", time.Until(started.Add(timeout)).String(),
 					//"pruneLimit", pruneLimit,
 					//"aggregatedStep", at.StepsInFiles(kv.AccountsDomain),

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -993,7 +993,7 @@ func (at *AggregatorRoTx) PruneSmallBatches(ctx context.Context, timeout time.Du
 		case <-logEvery.C:
 			at.a.logger.Info("[snapshots] pruning state",
 				"until commit", time.Until(started.Add(timeout)).String(),
-				"pruneLimit", pruneLimit,
+				//"pruneLimit", pruneLimit,
 				"aggregatedStep", at.StepsInFiles(kv.AccountsDomain),
 				"stepsRangeInDB", at.stepsRangeInDBAsStr(tx),
 				//"pruned", fullStat.String(),

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -996,7 +996,7 @@ func (at *AggregatorRoTx) PruneSmallBatches(ctx context.Context, timeout time.Du
 				"pruneLimit", pruneLimit,
 				"aggregatedStep", at.StepsInFiles(kv.AccountsDomain),
 				"stepsRangeInDB", at.stepsRangeInDBAsStr(tx),
-				"pruned", fullStat.String(),
+				//"pruned", fullStat.String(),
 			)
 		case <-ctx.Done():
 			return false, ctx.Err()

--- a/erigon-lib/state/aggregator2.go
+++ b/erigon-lib/state/aggregator2.go
@@ -324,7 +324,7 @@ var DomainCompressCfg = seg.Cfg{
 	MinPatternLen:        20,
 	MaxPatternLen:        128,
 	SamplingFactor:       4,
-	MaxDictPatterns:      64 * 1024 * 2,
+	MaxDictPatterns:      64 * 1024,
 	Workers:              1,
 }
 

--- a/erigon-lib/state/aggregator2.go
+++ b/erigon-lib/state/aggregator2.go
@@ -323,7 +323,7 @@ var DomainCompressCfg = seg.Cfg{
 	DictReducerSoftLimit: 2000000,
 	MinPatternLen:        20,
 	MaxPatternLen:        128,
-	SamplingFactor:       4,
+	SamplingFactor:       1,
 	MaxDictPatterns:      64 * 1024,
 	Workers:              1,
 }

--- a/erigon-lib/state/aggregator_files.go
+++ b/erigon-lib/state/aggregator_files.go
@@ -68,12 +68,18 @@ func (sf *SelectedStaticFiles) Close() {
 func (at *AggregatorRoTx) FilesInRange(r *Ranges) (*SelectedStaticFiles, error) {
 	sf := &SelectedStaticFiles{ii: make([][]*filesItem, len(r.invertedIndex))}
 	for id := range at.d {
+		if at.d[id].d.disable {
+			continue
+		}
 		if !r.domain[id].any() {
 			continue
 		}
 		sf.d[id], sf.dIdx[id], sf.dHist[id] = at.d[id].staticFilesInRange(r.domain[id])
 	}
 	for id, rng := range r.invertedIndex {
+		if at.iis[id].ii.disable {
+			continue
+		}
 		if rng == nil || !rng.needMerge {
 			continue
 		}

--- a/erigon-lib/state/aggregator_test.go
+++ b/erigon-lib/state/aggregator_test.go
@@ -257,16 +257,9 @@ func TestAggregatorV3_DirtyFilesRo(t *testing.T) {
 			expectedLen = 0
 		}
 
-		names := func() (r []string) {
-			for _, f := range dirtyFiles {
-				r = append(r, f.decompressor.FileName())
-			}
-			return r
-		}
-
 		require.Len(t, dirtyFiles, expectedLen, name)
 		for _, f := range dirtyFiles {
-			require.Equal(t, int32(expectedRefCnt), f.refcount.Load(), name, names())
+			require.Equal(t, int32(expectedRefCnt), f.refcount.Load(), name)
 		}
 	}
 

--- a/erigon-lib/state/aggregator_test.go
+++ b/erigon-lib/state/aggregator_test.go
@@ -257,9 +257,16 @@ func TestAggregatorV3_DirtyFilesRo(t *testing.T) {
 			expectedLen = 0
 		}
 
+		names := func() (r []string) {
+			for _, f := range dirtyFiles {
+				r = append(r, f.decompressor.FileName())
+			}
+			return r
+		}
+
 		require.Len(t, dirtyFiles, expectedLen, name)
 		for _, f := range dirtyFiles {
-			require.Equal(t, int32(expectedRefCnt), f.refcount.Load(), name)
+			require.Equal(t, int32(expectedRefCnt), f.refcount.Load(), name, names())
 		}
 	}
 

--- a/erigon-lib/state/btree_index.go
+++ b/erigon-lib/state/btree_index.go
@@ -190,7 +190,7 @@ func NewBtIndexWriter(args BtIndexWriterArgs, logger log.Logger) (*BtIndexWriter
 	_, fname := filepath.Split(btw.args.IndexFile)
 	btw.indexFileName = fname
 
-	btw.collector = etl.NewCollectorWithAllocator(BtreeLogPrefix+" "+fname, btw.args.TmpDir, etl.SmallSortableBuffers, logger)
+	btw.collector = etl.NewCollectorWithAllocator(BtreeLogPrefix+" "+fname, btw.args.TmpDir, etl.LargeSortableBuffers, logger)
 	btw.collector.SortAndFlushInBackground(true)
 	btw.collector.LogLvl(btw.args.Lvl)
 

--- a/erigon-lib/state/btree_index.go
+++ b/erigon-lib/state/btree_index.go
@@ -190,7 +190,8 @@ func NewBtIndexWriter(args BtIndexWriterArgs, logger log.Logger) (*BtIndexWriter
 	_, fname := filepath.Split(btw.args.IndexFile)
 	btw.indexFileName = fname
 
-	btw.collector = etl.NewCollector(BtreeLogPrefix+" "+fname, btw.args.TmpDir, etl.NewSortableBuffer(btw.args.EtlBufLimit), logger)
+	btw.collector = etl.NewCollectorWithAllocator(BtreeLogPrefix+" "+fname, btw.args.TmpDir, etl.SmallSortableBuffers, logger)
+	btw.collector.SortAndFlushInBackground(true)
 	btw.collector.LogLvl(btw.args.Lvl)
 
 	return btw, nil

--- a/erigon-lib/state/history.go
+++ b/erigon-lib/state/history.go
@@ -418,6 +418,8 @@ func (h *History) buildVI(ctx context.Context, historyIdxPath string, hist, efHi
 	defer rs.Close()
 	rs.LogLvl(log.LvlTrace)
 
+	seq := multiencseq.ReadMultiEncSeq(0, nil)
+
 	i := 0
 	for {
 		histReader.Reset(0)
@@ -431,7 +433,7 @@ func (h *History) buildVI(ctx context.Context, historyIdxPath string, hist, efHi
 
 			// fmt.Printf("ef key %x\n", keyBuf)
 
-			seq := multiencseq.ReadMultiEncSeq(efBaseTxNum, valBuf)
+			seq.Reset(efBaseTxNum, valBuf)
 			it := seq.Iterator(0)
 			for it.HasNext() {
 				txNum, err := it.Next()

--- a/erigon-lib/state/history.go
+++ b/erigon-lib/state/history.go
@@ -28,8 +28,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/erigontech/erigon-lib/version"
-
 	btree2 "github.com/tidwall/btree"
 	"golang.org/x/sync/errgroup"
 
@@ -46,6 +44,7 @@ import (
 	"github.com/erigontech/erigon-lib/recsplit"
 	"github.com/erigontech/erigon-lib/recsplit/multiencseq"
 	"github.com/erigontech/erigon-lib/seg"
+	"github.com/erigontech/erigon-lib/version"
 )
 
 type History struct {

--- a/erigon-lib/state/history.go
+++ b/erigon-lib/state/history.go
@@ -418,7 +418,7 @@ func (h *History) buildVI(ctx context.Context, historyIdxPath string, hist, efHi
 	defer rs.Close()
 	rs.LogLvl(log.LvlTrace)
 
-	seq := multiencseq.ReadMultiEncSeq(0, nil)
+	seq := &multiencseq.SequenceReader{}
 
 	i := 0
 	for {

--- a/erigon-lib/state/merge.go
+++ b/erigon-lib/state/merge.go
@@ -440,7 +440,7 @@ func (dt *DomainRoTx) mergeFiles(ctx context.Context, domainFiles, indexFiles, h
 		cnt += item.decompressor.Count()
 	}
 
-	p := ps.AddNew("merge "+path.Base(kvFilePath), uint64(cnt))
+	p := ps.AddNew("merge "+path.Base(kvFilePath), uint64(cnt)*2) // *2 because after adding words - will happen compression (which also slow)
 	defer ps.Delete(p)
 
 	var cp CursorHeap

--- a/erigon-lib/state/merge.go
+++ b/erigon-lib/state/merge.go
@@ -434,7 +434,13 @@ func (dt *DomainRoTx) mergeFiles(ctx context.Context, domainFiles, indexFiles, h
 	if dt.d.noFsync {
 		kvWriter.DisableFsync()
 	}
-	p := ps.AddNew("merge "+path.Base(kvFilePath), 1)
+
+	cnt := 0
+	for _, item := range domainFiles {
+		cnt += item.decompressor.Count()
+	}
+
+	p := ps.AddNew("merge "+path.Base(kvFilePath), uint64(cnt))
 	defer ps.Delete(p)
 
 	var cp CursorHeap
@@ -464,12 +470,14 @@ func (dt *DomainRoTx) mergeFiles(ctx context.Context, domainFiles, indexFiles, h
 	var keyBuf, valBuf []byte
 	var lastKey, lastVal []byte
 	var keyFileStartTxNum, keyFileEndTxNum uint64
+	i := uint64(0)
 	for cp.Len() > 0 {
 		lastKey = append(lastKey[:0], cp[0].key...)
 		lastVal = append(lastVal[:0], cp[0].val...)
 		lastFileStartTxNum, lastFileEndTxNum := cp[0].startTxNum, cp[0].endTxNum
 		// Advance all the items that have this key (including the top)
 		for cp.Len() > 0 && bytes.Equal(cp[0].key, lastKey) {
+			i++
 			ci1 := heap.Pop(&cp).(*CursorItem)
 			if ci1.idx.HasNext() {
 				ci1.key, _ = ci1.idx.Next(ci1.key[:0])
@@ -480,27 +488,29 @@ func (dt *DomainRoTx) mergeFiles(ctx context.Context, domainFiles, indexFiles, h
 
 		// For the rest of types, empty value means deletion
 		deleted := r.values.from == 0 && len(lastVal) == 0
-		if !deleted {
-			if keyBuf != nil {
-				if vt != nil {
-					if !bytes.Equal(keyBuf, keyCommitmentState) { // no replacement for state key
-						valBuf, err = vt(valBuf, keyFileStartTxNum, keyFileEndTxNum)
-						if err != nil {
-							return nil, nil, nil, fmt.Errorf("merge: valTransform failed: %w", err)
-						}
+		if deleted {
+			continue
+		}
+		if keyBuf != nil {
+			if vt != nil {
+				if !bytes.Equal(keyBuf, keyCommitmentState) { // no replacement for state key
+					valBuf, err = vt(valBuf, keyFileStartTxNum, keyFileEndTxNum)
+					if err != nil {
+						return nil, nil, nil, fmt.Errorf("merge: valTransform failed: %w", err)
 					}
 				}
-				if _, err = kvWriter.Write(keyBuf); err != nil {
-					return nil, nil, nil, err
-				}
-				if _, err = kvWriter.Write(valBuf); err != nil {
-					return nil, nil, nil, err
-				}
 			}
-			keyBuf = append(keyBuf[:0], lastKey...)
-			valBuf = append(valBuf[:0], lastVal...)
-			keyFileStartTxNum, keyFileEndTxNum = lastFileStartTxNum, lastFileEndTxNum
+			if _, err = kvWriter.Write(keyBuf); err != nil {
+				return nil, nil, nil, err
+			}
+			if _, err = kvWriter.Write(valBuf); err != nil {
+				return nil, nil, nil, err
+			}
 		}
+		keyBuf = append(keyBuf[:0], lastKey...)
+		valBuf = append(valBuf[:0], lastVal...)
+		keyFileStartTxNum, keyFileEndTxNum = lastFileStartTxNum, lastFileEndTxNum
+		p.Processed.Store(i)
 	}
 	if keyBuf != nil {
 		if vt != nil {

--- a/erigon-lib/state/squeeze.go
+++ b/erigon-lib/state/squeeze.go
@@ -84,7 +84,7 @@ func (a *Aggregator) sqeezeDomainFile(ctx context.Context, domain kv.Domain, fro
 	}
 	defer decompressor.Close()
 	defer decompressor.MadvSequential().DisableReadAhead()
-	r := seg.NewReader(decompressor.MakeGetter(), seg.DetectCompressType(decompressor.MakeGetter()))
+	r := seg.NewReader(decompressor.MakeGetter(), compression)
 
 	c, err := seg.NewCompressor(ctx, "sqeeze", to, a.dirs.Tmp, compressCfg, log.LvlInfo, a.logger)
 	if err != nil {

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -240,13 +240,13 @@ func ExecV3(ctx context.Context,
 	agg := cfg.db.(state2.HasAgg).Agg().(*state2.Aggregator)
 	if !inMemExec && !isMining {
 		if initialCycle {
-			agg.SetCollateAndBuildWorkers(min(4, estimate.StateV3Collate.Workers()))
-			agg.SetMergeWorkers(min(4, estimate.StateV3Collate.Workers()))
+			agg.SetCollateAndBuildWorkers(min(2, estimate.StateV3Collate.Workers()))
+			agg.SetMergeWorkers(min(2, estimate.StateV3Collate.Workers()))
 			agg.SetCompressWorkers(estimate.CompressSnapshot.Workers())
 		} else {
-			agg.SetCompressWorkers(1)
-			agg.SetMergeWorkers(1)
 			agg.SetCollateAndBuildWorkers(1)
+			agg.SetMergeWorkers(1)
+			agg.SetCompressWorkers(1)
 		}
 	}
 
@@ -764,15 +764,6 @@ Loop:
 				t3 = time.Since(tt)
 
 				t2, err := executor.(*serialExecutor).commit(ctx, inputTxNum, outputBlockNum.GetValueUint64(), useExternalTx)
-				if err != nil {
-					return err
-				}
-
-				if _, err := executor.tx().(kv.TemporalRwTx).PruneSmallBatches(ctx, 10*time.Hour); err != nil {
-					return err
-				}
-
-				_, err = executor.(*serialExecutor).commit(ctx, inputTxNum, outputBlockNum.GetValueUint64(), useExternalTx)
 				if err != nil {
 					return err
 				}

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -241,7 +241,7 @@ func ExecV3(ctx context.Context,
 	if !inMemExec && !isMining {
 		if initialCycle {
 			agg.SetCollateAndBuildWorkers(min(2, estimate.StateV3Collate.Workers()))
-			agg.SetMergeWorkers(min(2, estimate.StateV3Collate.Workers()))
+			agg.SetMergeWorkers(min(1, estimate.StateV3Collate.Workers()))
 			agg.SetCompressWorkers(estimate.CompressSnapshot.Workers())
 		} else {
 			agg.SetCollateAndBuildWorkers(1)

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -276,9 +276,10 @@ func unwindExec3State(ctx context.Context, tx kv.TemporalRwTx, sd *libstate.Shar
 		return nil
 	}
 
-	stateChanges := etl.NewCollector("", "", etl.NewOldestEntryBuffer(etl.BufferOptimalSize), logger)
+	stateChanges := etl.NewCollectorWithAllocator("unwind", "", etl.SmallSortableBuffers, logger)
 	defer stateChanges.Close()
 	stateChanges.SortAndFlushInBackground(true)
+	stateChanges.LogLvl(log.LvlDebug)
 
 	accountDiffs := changeset[kv.AccountsDomain]
 	for _, kv := range accountDiffs {

--- a/eth/stagedsync/stage_senders.go
+++ b/eth/stagedsync/stage_senders.go
@@ -136,8 +136,10 @@ func SpawnRecoverSendersStage(cfg SendersCfg, s *StageState, u Unwinder, tx kv.R
 		}(i)
 	}
 
-	collectorSenders := etl.NewCollector(logPrefix, cfg.tmpdir, etl.NewSortableBuffer(etl.BufferOptimalSize), logger)
+	collectorSenders := etl.NewCollectorWithAllocator(logPrefix, cfg.tmpdir, etl.SmallSortableBuffers, logger)
 	defer collectorSenders.Close()
+	collectorSenders.SortAndFlushInBackground(true)
+	collectorSenders.LogLvl(log.LvlDebug)
 
 	errCh := make(chan senderRecoveryError)
 	go func() {

--- a/rules.go
+++ b/rules.go
@@ -100,6 +100,9 @@ func closeCollector(m dsl.Matcher) {
 	m.Match(`$c := etl.NewCollector($*_); $close`).
 		Where(!m["close"].Text.Matches(`defer .*\.Close()`)).
 		Report(`Add "defer $c.Close()" right after collector creation`)
+	m.Match(`$c := etl.NewCollectorWithAllocator($*_); $close`).
+		Where(!m["close"].Text.Matches(`defer .*\.Close()`)).
+		Report(`Add "defer $c.Close()" right after collector creation`)
 }
 
 func closeLockedDir(m dsl.Matcher) {

--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -281,7 +281,7 @@ var snapshotCommand = cli.Command{
 			Action: doSqueeze,
 			Flags: joinFlags([]cli.Flag{
 				&utils.DataDirFlag,
-				&cli.StringFlag{Name: "type", Required: true},
+				&cli.StringFlag{Name: "type", Required: true, Aliases: []string{"domain"}},
 			}),
 		},
 		{
@@ -1736,8 +1736,8 @@ func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 	agg.SetSnapshotBuildSema(blockSnapBuildSema)
 
 	// `erigon retire` command is designed to maximize resouces utilization. But `Erigon itself` does minimize background impact (because not in rush).
-	agg.SetCollateAndBuildWorkers(estimate.StateV3Collate.Workers())
-	agg.SetMergeWorkers(2)
+	agg.SetCollateAndBuildWorkers(min(8, estimate.StateV3Collate.Workers()))
+	agg.SetMergeWorkers(min(8, estimate.StateV3Collate.Workers()))
 	agg.SetCompressWorkers(estimate.CompressSnapshot.Workers())
 	agg.PeriodicalyPrintProcessSet(ctx)
 


### PR DESCRIPTION
In PR:
- `seg.compress` to use ETL buffs pool (small buffs for workers, large bufs for Dict reducer)
- `recsplit` to use ETL buffs pool
- `bt` to use ETL buffs pool
- `seg.compress` rare check `ctx` in `AddWord`
- `seg.compress` no superstrings `growslice` in `AddWord`
- `DictionaryBuilder.processWord` re-use objects - less `common.Copy(chars)` (which does `make([]byte)`)
- mergeFiles: reduce code depth
- mergeFiles: report progress of merge
- exec3: to use 2 merge threads (when not on chain-tip)
- retire: to use 4 merge threads
- linter for `NewCollectorWithAllocator` defer close


