### PR TITLE
Versioned IBS Implementation

### DIFF
--- a/cmd/devnet/services/polygon/proofgenerator_test.go
+++ b/cmd/devnet/services/polygon/proofgenerator_test.go
@@ -170,10 +170,10 @@ func (rg *requestGenerator) GetTransactionReceipt(ctx context.Context, hash comm
 	}
 
 	header := block.Header()
-
+	blockNum := block.NumberU64()
+	
 	for i, txn := range block.Transactions() {
-
-		ibs.SetTxContext(i)
+		ibs.SetTxContext(blockNum, i)
 
 		receipt, _, err := core.ApplyTransaction(chainConfig, core.GetHashFn(header, getHeader), engine, nil, gp, ibs, noopWriter, header, txn, &gasUsed, &usedBlobGas, vm.Config{})
 

--- a/cmd/devnet/services/polygon/proofgenerator_test.go
+++ b/cmd/devnet/services/polygon/proofgenerator_test.go
@@ -171,7 +171,7 @@ func (rg *requestGenerator) GetTransactionReceipt(ctx context.Context, hash comm
 
 	header := block.Header()
 	blockNum := block.NumberU64()
-	
+
 	for i, txn := range block.Transactions() {
 		ibs.SetTxContext(blockNum, i)
 

--- a/cmd/state/commands/opcode_tracer.go
+++ b/cmd/state/commands/opcode_tracer.go
@@ -738,9 +738,10 @@ func runBlock(engine consensus.Engine, ibs *state.IntraBlockState, txnWriter sta
 	usedBlobGas := new(uint64)
 	var receipts types.Receipts
 	core.InitializeBlockExecution(engine, nil, header, chainConfig, ibs, nil, logger, nil)
-	rules := chainConfig.Rules(block.NumberU64(), block.Time())
+	blockNum := block.NumberU64()
+	rules := chainConfig.Rules(blockNum, block.Time())
 	for i, txn := range block.Transactions() {
-		ibs.SetTxContext(i)
+		ibs.SetTxContext(blockNum,i)
 		receipt, _, err := core.ApplyTransaction(chainConfig, core.GetHashFn(header, getHeader), engine, nil, gp, ibs, txnWriter, header, txn, gasUsed, usedBlobGas, vmConfig)
 		if err != nil {
 			return nil, fmt.Errorf("could not apply txn %d [%x] failed: %w", i, txn.Hash(), err)

--- a/cmd/state/commands/opcode_tracer.go
+++ b/cmd/state/commands/opcode_tracer.go
@@ -741,7 +741,7 @@ func runBlock(engine consensus.Engine, ibs *state.IntraBlockState, txnWriter sta
 	blockNum := block.NumberU64()
 	rules := chainConfig.Rules(blockNum, block.Time())
 	for i, txn := range block.Transactions() {
-		ibs.SetTxContext(blockNum,i)
+		ibs.SetTxContext(blockNum, i)
 		receipt, _, err := core.ApplyTransaction(chainConfig, core.GetHashFn(header, getHeader), engine, nil, gp, ibs, txnWriter, header, txn, gasUsed, usedBlobGas, vmConfig)
 		if err != nil {
 			return nil, fmt.Errorf("could not apply txn %d [%x] failed: %w", i, txn.Hash(), err)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -124,8 +124,10 @@ func ExecuteBlockEphemerally(
 	var rejectedTxs []*RejectedTx
 	includedTxs := make(types.Transactions, 0, block.Transactions().Len())
 	receipts := make(types.Receipts, 0, block.Transactions().Len())
+	blockNum := block.NumberU64()
+
 	for i, txn := range block.Transactions() {
-		ibs.SetTxContext(i)
+		ibs.SetTxContext(blockNum, i)
 		writeTrace := false
 		if vmConfig.Tracer == nil && getTracer != nil {
 			tracer, err := getTracer(i, txn.Hash())

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -122,7 +122,7 @@ func (b *BlockGen) AddTxWithChain(getHeader func(hash common.Hash, number uint64
 	if b.gasPool == nil {
 		b.SetCoinbase(common.Address{})
 	}
-	b.ibs.SetTxContext(len(b.txs))
+	b.ibs.SetTxContext(b.header.Number.Uint64(), len(b.txs))
 	receipt, _, err := ApplyTransaction(b.config, GetHashFn(b.header, getHeader), engine, &b.header.Coinbase, b.gasPool, b.ibs, state.NewNoopWriter(), b.header, txn, &b.header.GasUsed, b.header.BlobGasUsed, vm.Config{})
 	if err != nil {
 		panic(err)
@@ -138,7 +138,7 @@ func (b *BlockGen) AddFailedTxWithChain(getHeader func(hash common.Hash, number 
 	if b.gasPool == nil {
 		b.SetCoinbase(common.Address{})
 	}
-	b.ibs.SetTxContext(len(b.txs))
+	b.ibs.SetTxContext(b.header.Number.Uint64(), len(b.txs))
 	receipt, _, err := ApplyTransaction(b.config, GetHashFn(b.header, getHeader), engine, &b.header.Coinbase, b.gasPool, b.ibs, state.NewNoopWriter(), b.header, txn, &b.header.GasUsed, b.header.BlobGasUsed, vm.Config{})
 	_ = err // accept failed transactions
 	b.txs = append(b.txs, txn)

--- a/core/genesis_write.go
+++ b/core/genesis_write.go
@@ -504,7 +504,7 @@ func GenesisToBlock(g *types.Genesis, dirs datadir.Dirs, logger log.Logger) (*ty
 			if overflow {
 				panic("overflow at genesis allocs")
 			}
-			statedb.AddBalance(addr, balance, tracing.BalanceIncreaseGenesisBalance)
+			statedb.AddBalance(addr, *balance, tracing.BalanceIncreaseGenesisBalance)
 			statedb.SetCode(addr, account.Code)
 			statedb.SetNonce(addr, account.Nonce)
 			for key, value := range account.Storage {

--- a/core/state/access_list_test.go
+++ b/core/state/access_list_test.go
@@ -72,13 +72,10 @@ func verifySlots(t *testing.T, s *IntraBlockState, addrString string, slotString
 		}
 	}
 	// Check that no extra elements are in the access list
-	index := s.accessList.addresses[address]
-	if index >= 0 {
-		stateSlots := s.accessList.slots[index]
-		for s := range stateSlots {
-			if _, slotPresent := slotMap[s]; !slotPresent {
-				t.Fatalf("scope has extra slot %v (address %v)", s, addrString)
-			}
+	stateSlots := s.accessList.addresses[address]
+	for s := range stateSlots {
+		if _, slotPresent := slotMap[s]; !slotPresent {
+			t.Fatalf("scope has extra slot %v (address %v)", s, addrString)
 		}
 	}
 }
@@ -111,9 +108,6 @@ func TestAccessList(t *testing.T) {
 	verifyAddrs(t, state, "aa", "bb")
 	verifySlots(t, state, "bb", "01", "02")
 	if got, exp := len(state.accessList.addresses), 2; got != exp {
-		t.Fatalf("expected empty, got %d", got)
-	}
-	if got, exp := len(state.accessList.slots), 1; got != exp {
 		t.Fatalf("expected empty, got %d", got)
 	}
 
@@ -197,9 +191,6 @@ func TestAccessList(t *testing.T) {
 		t.Fatalf("addr present, expected missing")
 	}
 	if got, exp := len(state.accessList.addresses), 0; got != exp {
-		t.Fatalf("expected empty, got %d", got)
-	}
-	if got, exp := len(state.accessList.slots), 0; got != exp {
 		t.Fatalf("expected empty, got %d", got)
 	}
 }

--- a/core/state/database_test.go
+++ b/core/state/database_test.go
@@ -946,13 +946,13 @@ func TestReproduceCrash(t *testing.T) {
 		t.Errorf("error finalising 1st tx: %v", err)
 	}
 	// Start the 3rd transaction
-	intraBlockState.AddBalance(contract, uint256.NewInt(1000000000), tracing.BalanceChangeUnspecified)
+	intraBlockState.AddBalance(contract, *uint256.NewInt(1000000000), tracing.BalanceChangeUnspecified)
 	intraBlockState.SetState(contract, storageKey2, *value2)
 	if err := intraBlockState.FinalizeTx(&chain.Rules{}, tsw); err != nil {
 		t.Errorf("error finalising 1st tx: %v", err)
 	}
 	// Start the 4th transaction - clearing both storage cells
-	intraBlockState.SubBalance(contract, uint256.NewInt(1000000000), tracing.BalanceChangeUnspecified)
+	intraBlockState.SubBalance(contract, *uint256.NewInt(1000000000), tracing.BalanceChangeUnspecified)
 	intraBlockState.SetState(contract, storageKey1, *value0)
 	intraBlockState.SetState(contract, storageKey2, *value0)
 	if err := intraBlockState.FinalizeTx(&chain.Rules{}, tsw); err != nil {
@@ -1020,7 +1020,7 @@ func TestEip2200Gas(t *testing.T) {
 		t.Fatalf("generate blocks: %v", err)
 	}
 
-	var balanceBefore *uint256.Int
+	var balanceBefore uint256.Int
 	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(address); err != nil {
@@ -1363,7 +1363,7 @@ func TestChangeAccountCodeBetweenBlocks(t *testing.T) {
 	oldCode := []byte{0x01, 0x02, 0x03, 0x04}
 
 	intraBlockState.SetCode(contract, oldCode)
-	intraBlockState.AddBalance(contract, uint256.NewInt(1000000000), tracing.BalanceChangeUnspecified)
+	intraBlockState.AddBalance(contract, *uint256.NewInt(1000000000), tracing.BalanceChangeUnspecified)
 	if err := intraBlockState.FinalizeTx(&chain.Rules{}, tsw); err != nil {
 		t.Errorf("error finalising 1st tx: %v", err)
 	}
@@ -1413,7 +1413,7 @@ func TestCacheCodeSizeSeparately(t *testing.T) {
 	code := []byte{0x01, 0x02, 0x03, 0x04}
 
 	intraBlockState.SetCode(contract, code)
-	intraBlockState.AddBalance(contract, uint256.NewInt(1000000000), tracing.BalanceChangeUnspecified)
+	intraBlockState.AddBalance(contract, *uint256.NewInt(1000000000), tracing.BalanceChangeUnspecified)
 	if err := intraBlockState.FinalizeTx(&chain.Rules{}, w); err != nil {
 		t.Errorf("error finalising 1st tx: %v", err)
 	}
@@ -1453,7 +1453,7 @@ func TestCacheCodeSizeInTrie(t *testing.T) {
 	code := []byte{0x01, 0x02, 0x03, 0x04}
 
 	intraBlockState.SetCode(contract, code)
-	intraBlockState.AddBalance(contract, uint256.NewInt(1000000000), tracing.BalanceChangeUnspecified)
+	intraBlockState.AddBalance(contract, *uint256.NewInt(1000000000), tracing.BalanceChangeUnspecified)
 	if err := intraBlockState.FinalizeTx(&chain.Rules{}, w); err != nil {
 		t.Errorf("error finalising 1st tx: %v", err)
 	}

--- a/core/state/intra_block_state.go
+++ b/core/state/intra_block_state.go
@@ -75,13 +75,6 @@ type IntraBlockState struct {
 
 	nilAccounts map[common.Address]struct{} // Remember non-existent account to avoid reading them again
 
-	// DB error.
-	// State objects are used by the consensus core and VM which are
-	// unable to deal with database-level errors. Any error that occurs
-	// during a database read is memoized here and will eventually be returned
-	// by IntraBlockState.Commit.
-	savedErr error
-
 	// The refund counter, also used by state transitioning.
 	refund uint64
 
@@ -100,7 +93,7 @@ type IntraBlockState struct {
 	// Snapshot and RevertToSnapshot.
 	journal        *journal
 	validRevisions []revision
-	nextRevisionID int
+	nextRevisionId int
 	trace          bool
 	tracingHooks   *tracing.Hooks
 	balanceInc     map[common.Address]*BalanceIncrease // Map of balance increases (without first reading the account)
@@ -130,8 +123,72 @@ func New(stateReader StateReader) *IntraBlockState {
 		transientStorage:  newTransientStorage(),
 		balanceInc:        map[common.Address]*BalanceIncrease{},
 		txIndex:           0,
-		//trace:             true,
+		trace:             false,
 	}
+}
+
+func NewWithVersionMap(stateReader StateReader, mvhm *VersionMap) *IntraBlockState {
+	ibs := New(stateReader)
+	ibs.versionMap = mvhm
+	ibs.dep = -1
+	return ibs
+}
+
+// Copy intra block state
+func (sdb *IntraBlockState) Copy() *IntraBlockState {
+	state := New(sdb.stateReader)
+	state.stateObjects = make(map[common.Address]*stateObject, len(sdb.stateObjectsDirty))
+	state.stateObjectsDirty = make(map[common.Address]struct{}, len(sdb.stateObjectsDirty))
+
+	for addr := range sdb.journal.dirties {
+		if object, exist := sdb.stateObjects[addr]; exist {
+			state.stateObjects[addr] = object.deepCopy(state)
+
+			state.stateObjectsDirty[addr] = struct{}{} // Mark the copy dirty to force internal (code/state) commits
+		}
+	}
+
+	state.validRevisions = append(state.validRevisions, sdb.validRevisions...)
+	state.refund = sdb.refund
+
+	for addr := range sdb.stateObjectsDirty {
+		if _, exist := state.stateObjects[addr]; !exist {
+			state.stateObjects[addr] = sdb.stateObjects[addr].deepCopy(state)
+		}
+		state.stateObjectsDirty[addr] = struct{}{}
+	}
+
+	state.logs = make([]types.Logs, len(sdb.logs))
+	for hash, logs := range sdb.logs {
+		cpy := make([]*types.Log, len(logs))
+		for i, l := range logs {
+			cpy[i] = new(types.Log)
+			*cpy[i] = *l
+		}
+		state.logs[hash] = cpy
+	}
+
+	state.accessList = sdb.accessList.Copy()
+
+	state.txIndex = sdb.txIndex
+
+	if sdb.versionMap != nil {
+		state.versionMap = sdb.versionMap
+	}
+
+	return state
+}
+
+func (sdb *IntraBlockState) StorageReadDuration() time.Duration {
+	return sdb.storageReadDuration
+}
+
+func (sdb *IntraBlockState) StorageReadCount() int64 {
+	return sdb.storageReadCount
+}
+
+func (sdb *IntraBlockState) SetVersionMap(versionMap *VersionMap) {
+	sdb.versionMap = versionMap
 }
 
 func (sdb *IntraBlockState) SetHooks(hooks *tracing.Hooks) {
@@ -142,78 +199,43 @@ func (sdb *IntraBlockState) SetTrace(trace bool) {
 	sdb.trace = trace
 }
 
-func (sdb *IntraBlockState) Trace() bool {
-	return sdb.trace
-}
-
-func (sdb *IntraBlockState) TxIndex() int {
-	return sdb.txIndex
-}
-
-func (sdb *IntraBlockState) Incarnation() int {
-	return sdb.version
-}
-
-// setErrorUnsafe sets error but should be called in medhods that already have locks
-// Deprecated: The IBS api now returns errors directly
-func (sdb *IntraBlockState) setErrorUnsafe(err error) {
-	if sdb.savedErr == nil {
-		sdb.savedErr = err
-	}
-}
-
-// Deprecated: The IBS api now returns errors directly
-func (sdb *IntraBlockState) Error() error {
-	return sdb.savedErr
-}
-
 // Reset clears out all ephemeral state objects from the state db, but keeps
 // the underlying state trie to avoid reloading data for the next operations.
 func (sdb *IntraBlockState) Reset() {
-	//if len(sdb.nilAccounts) == 0 || len(sdb.stateObjects) == 0 || len(sdb.stateObjectsDirty) == 0 || len(sdb.balanceInc) == 0 {
-	//	log.Warn("zero", "len(sdb.nilAccounts)", len(sdb.nilAccounts),
-	//		"len(sdb.stateObjects)", len(sdb.stateObjects),
-	//		"len(sdb.stateObjectsDirty)", len(sdb.stateObjectsDirty),
-	//		"len(sdb.balanceInc)", len(sdb.balanceInc))
-	//}
-
-	/*
-		sdb.nilAccounts = make(map[common.Address]struct{})
-		sdb.stateObjects = make(map[common.Address]*stateObject)
-		sdb.stateObjectsDirty = make(map[common.Address]struct{})
-		sdb.logs = make(map[common.Hash][]*types.Log)
-		sdb.balanceInc = make(map[common.Address]*BalanceIncrease)
-	*/
-
-	sdb.nilAccounts = make(map[common.Address]struct{})
-	//clear(sdb.nilAccounts)
-	sdb.stateObjects = make(map[common.Address]*stateObject)
-	//clear(sdb.stateObjects)
-	sdb.stateObjectsDirty = make(map[common.Address]struct{})
-	//clear(sdb.stateObjectsDirty)
+	sdb.nilAccounts = map[common.Address]struct{}{}
+	sdb.stateObjects = map[common.Address]*stateObject{}
+	sdb.stateObjectsDirty = map[common.Address]struct{}{}
 	for i := range sdb.logs {
 		clear(sdb.logs[i]) // free p¬ointers
 		sdb.logs[i] = sdb.logs[i][:0]
 	}
-	sdb.logs = sdb.logs[:0]
-	sdb.balanceInc = make(map[common.Address]*BalanceIncrease)
-	//clear(sdb.balanceInc)
+	sdb.balanceInc = map[common.Address]*BalanceIncrease{}
+	sdb.journal.Reset()
+	sdb.nextRevisionId = 0
+	sdb.validRevisions = sdb.validRevisions[:0]
+	sdb.refund = 0
 	sdb.txIndex = 0
 	sdb.logSize = 0
+	sdb.versionMap = nil
+	sdb.versionedReads = nil
+	sdb.versionedWrites = nil
+	sdb.storageReadDuration = 0
+	sdb.storageReadCount = 0
+	sdb.dep = -1
 }
 
-func (sdb *IntraBlockState) AddLog(log2 *types.Log) {
+func (sdb *IntraBlockState) AddLog(log *types.Log) {
 	sdb.journal.append(addLogChange{txIndex: sdb.txIndex})
-	log2.TxIndex = uint(sdb.txIndex)
-	log2.Index = sdb.logSize
+	log.TxIndex = uint(sdb.txIndex)
+	log.Index = sdb.logSize
 	if sdb.tracingHooks != nil && sdb.tracingHooks.OnLog != nil {
-		sdb.tracingHooks.OnLog(log2)
+		sdb.tracingHooks.OnLog(log)
 	}
 	sdb.logSize++
 	for len(sdb.logs) <= sdb.txIndex {
 		sdb.logs = append(sdb.logs, nil)
 	}
-	sdb.logs[sdb.txIndex] = append(sdb.logs[sdb.txIndex], log2)
+	sdb.logs[sdb.txIndex] = append(sdb.logs[sdb.txIndex], log)
 }
 
 func (sdb *IntraBlockState) GetLogs(txIndex int, txnHash common.Hash, blockNumber uint64, blockHash common.Hash) types.Logs {
@@ -254,12 +276,13 @@ func (sdb *IntraBlockState) AddRefund(gas uint64) {
 
 // SubRefund removes gas from the refund counter.
 // This method will panic if the refund counter goes below zero
-func (sdb *IntraBlockState) SubRefund(gas uint64) {
+func (sdb *IntraBlockState) SubRefund(gas uint64) error {
 	sdb.journal.append(refundChange{prev: sdb.refund})
 	if gas > sdb.refund {
-		sdb.setErrorUnsafe(errors.New("refund counter below zero"))
+		return errors.New("refund counter below zero")
 	}
 	sdb.refund -= gas
+	return nil
 }
 
 // Exist reports whether the given account address exists in the state.
@@ -284,27 +307,37 @@ func (sdb *IntraBlockState) Empty(addr common.Address) (bool, error) {
 
 // GetBalance retrieves the balance from the given address or 0 if object not found
 // DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
-func (sdb *IntraBlockState) GetBalance(addr common.Address) (*uint256.Int, error) {
-	stateObject, err := sdb.getStateObject(addr)
-	if err != nil {
-		return nil, err
-	}
-	if stateObject != nil && !stateObject.deleted {
-		return stateObject.Balance(), nil
-	}
-	return u256.Num0, nil
+func (sdb *IntraBlockState) GetBalance(addr common.Address) (uint256.Int, error) {
+	balance, _, err := versionedRead(sdb, addr, BalancePath, common.Hash{}, false, *u256.Num0,
+		func(v uint256.Int) uint256.Int {
+			return v
+		},
+		func(s *stateObject) (uint256.Int, error) {
+			if s != nil && !s.deleted {
+				return s.Balance(), nil
+			}
+			return uint256.Int{}, nil
+		})
+
+	return balance, err
 }
 
 // DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) GetNonce(addr common.Address) (uint64, error) {
-	stateObject, err := sdb.getStateObject(addr)
-	if err != nil {
-		return 0, err
+	nonce, _, err := versionedRead(sdb, addr, NoncePath, common.Hash{}, false, 0,
+		func(v uint64) uint64 { return v },
+		func(s *stateObject) (uint64, error) {
+			if s != nil && !s.deleted {
+				return s.Nonce(), nil
+			}
+			return 0, nil
+		})
+
+	if sdb.trace || traceAccount(addr) {
+		fmt.Printf("%d (%d.%d) GetNonce %x: %d\n", sdb.blockNum, sdb.txIndex, sdb.version, addr, nonce)
 	}
-	if stateObject != nil && !stateObject.deleted {
-		return stateObject.Nonce(), nil
-	}
-	return 0, nil
+
+	return nonce, err
 }
 
 // TxIndex returns the current transaction index set by Prepare.
@@ -314,55 +347,67 @@ func (sdb *IntraBlockState) TxnIndex() int {
 
 // DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) GetCode(addr common.Address) ([]byte, error) {
-	stateObject, err := sdb.getStateObject(addr)
-	if err != nil {
-		return nil, err
+	code, source, err := versionedRead(sdb, addr, CodePath, common.Hash{}, false, nil,
+		func(v []byte) []byte {
+			return v
+		},
+		func(s *stateObject) ([]byte, error) {
+			if s != nil && !s.deleted {
+				code, err := s.Code()
+				return code, err
+			}
+			return nil, nil
+		})
+
+	if sdb.trace || traceAccount(addr) {
+		fmt.Printf("%d (%d.%d) GetCode (%s) %x: size: %d\n", sdb.blockNum, sdb.txIndex, sdb.version, source, addr, len(code))
 	}
-	if stateObject != nil && !stateObject.deleted {
-		if sdb.trace {
-			fmt.Printf("GetCode %x, returned %d\n", addr, len(stateObject.Code()))
-		}
-		return stateObject.Code(), nil
-	}
-	if sdb.trace {
-		fmt.Printf("GetCode %x, returned nil\n", addr)
-	}
-	return nil, nil
+
+	return code, err
 }
 
 // DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) GetCodeSize(addr common.Address) (int, error) {
-	stateObject, err := sdb.getStateObject(addr)
-	if err != nil {
-		return 0, err
+	size, source, err := versionedRead(sdb, addr, CodeSizePath, common.Hash{}, false, 0,
+		func(v int) int { return v },
+		func(s *stateObject) (int, error) {
+			if s == nil || s.deleted {
+				return 0, nil
+			}
+			if s.code != nil {
+				return len(s.code), nil
+			}
+			if s.data.CodeHash == empty.CodeHash {
+				return 0, nil
+			}
+			readStart := time.Now()
+			l, err := sdb.stateReader.ReadAccountCodeSize(addr)
+			sdb.storageReadDuration += time.Since(readStart)
+			sdb.storageReadCount++
+			if err != nil {
+				return l, err
+			}
+			return l, err
+		})
+
+	if sdb.trace || traceAccount(addr) {
+		fmt.Printf("%d (%d.%d) GetCodeSize (%s) %x: %d\n", sdb.blockNum, sdb.txIndex, sdb.version, source, addr, size)
 	}
-	if stateObject == nil || stateObject.deleted {
-		return 0, nil
-	}
-	if stateObject.code != nil {
-		return len(stateObject.code), nil
-	}
-	if stateObject.data.CodeHash == empty.CodeHash {
-		return 0, nil
-	}
-	l, err := sdb.stateReader.ReadAccountCodeSize(addr)
-	if err != nil {
-		sdb.setErrorUnsafe(err)
-		return l, err
-	}
-	return l, err
+
+	return size, err
 }
 
 // DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) GetCodeHash(addr common.Address) (common.Hash, error) {
-	stateObject, err := sdb.getStateObject(addr)
-	if err != nil {
-		return common.Hash{}, err
-	}
-	if stateObject == nil || stateObject.deleted {
-		return common.Hash{}, nil
-	}
-	return stateObject.data.CodeHash, nil
+	hash, _, err := versionedRead(sdb, addr, CodeHashPath, common.Hash{}, false, common.Hash{},
+		func(v common.Hash) common.Hash { return v },
+		func(s *stateObject) (common.Hash, error) {
+			if s == nil || s.deleted {
+				return common.Hash{}, nil
+			}
+			return s.data.CodeHash, nil
+		})
+	return hash, err
 }
 
 func (sdb *IntraBlockState) ResolveCodeHash(addr common.Address) (common.Hash, error) {
@@ -407,93 +452,170 @@ func (sdb *IntraBlockState) GetDelegatedDesignation(addr common.Address) (common
 // GetState retrieves a value from the given account's storage trie.
 // DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) GetState(addr common.Address, key common.Hash, value *uint256.Int) error {
-	stateObject, err := sdb.getStateObject(addr)
-	if err != nil {
-		return err
+	versionedValue, source, err := versionedRead(sdb, addr, StatePath, key, false, *u256.N0,
+		func(v uint256.Int) uint256.Int {
+			return v
+		},
+		func(s *stateObject) (uint256.Int, error) {
+			var value uint256.Int
+			if s != nil && !s.deleted {
+				s.GetState(key, &value)
+			}
+			return value, nil
+		})
+
+	*value = versionedValue
+
+	if sdb.trace || (traceAccount(addr) && traceKey(key)) {
+		fmt.Printf("%d (%d.%d) GetState (%s) %x, %x=%x\n", sdb.blockNum, sdb.txIndex, sdb.version, source, addr, key, value)
 	}
-	if stateObject != nil && !stateObject.deleted {
-		stateObject.GetState(key, value)
-	} else {
-		value.Clear()
-	}
-	return nil
+
+	return err
 }
 
 // GetCommittedState retrieves a value from the given account's committed storage trie.
 // DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) GetCommittedState(addr common.Address, key common.Hash, value *uint256.Int) error {
-	stateObject, err := sdb.getStateObject(addr)
-	if err != nil {
-		return err
+	versionedValue, source, err := versionedRead(sdb, addr, StatePath, key, true, *u256.N0,
+		func(v uint256.Int) uint256.Int {
+			return v
+		},
+		func(s *stateObject) (uint256.Int, error) {
+			var value uint256.Int
+			if s != nil && !s.deleted {
+				s.GetCommittedState(key, &value)
+			}
+			return value, nil
+		})
+
+	*value = versionedValue
+
+	if sdb.trace || traceAccount(addr) {
+		fmt.Printf("%d (%d.%d) GetCommittedState (%s) %x, %x=%x\n", sdb.blockNum, sdb.txIndex, sdb.version, source, addr, key, value)
 	}
-	if stateObject != nil && !stateObject.deleted {
-		stateObject.GetCommittedState(key, value)
-	} else {
-		value.Clear()
-	}
-	return nil
+
+	return err
 }
 
 func (sdb *IntraBlockState) HasSelfdestructed(addr common.Address) (bool, error) {
-	stateObject, err := sdb.getStateObject(addr)
-	if err != nil {
-		return false, err
-	}
-	if stateObject == nil {
-		return false, nil
-	}
-	if stateObject.deleted {
-		return false, nil
-	}
-	if stateObject.createdContract {
-		return false, nil
-	}
-	return stateObject.selfdestructed, nil
+	destructed, _, err := versionedRead(sdb, addr, SelfDestructPath, common.Hash{}, false, false,
+		func(v bool) bool { return v },
+		func(s *stateObject) (bool, error) {
+			if s == nil {
+				return false, nil
+			}
+			if s.deleted {
+				return false, nil
+			}
+			if s.createdContract {
+				return false, nil
+			}
+			return s.selfdestructed, nil
+		})
+
+	return destructed, err
 }
 
-/*
- * SETTERS
- */
+func (sdb *IntraBlockState) ReadVersion(addr common.Address, path AccountPath, key common.Hash, txIdx int) ReadResult {
+	return sdb.versionMap.Read(addr, path, key, txIdx)
+}
 
 // AddBalance adds amount to the account associated with addr.
 // DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
-func (sdb *IntraBlockState) AddBalance(addr common.Address, amount *uint256.Int, reason tracing.BalanceChangeReason) error {
-	if sdb.trace {
-		fmt.Printf("AddBalance %x, %d\n", addr, amount)
+func (sdb *IntraBlockState) AddBalance(addr common.Address, amount uint256.Int, reason tracing.BalanceChangeReason) error {
+	if sdb.trace || traceAccount(addr) {
+		prev0, _ := sdb.GetBalance(addr)
+
+		defer func() {
+			bal, _ := sdb.GetBalance(addr)
+			expected := (&uint256.Int{}).Add(&prev0, &amount)
+			if bal.Cmp(expected) != 0 {
+				panic(fmt.Sprintf("add failed: expected: %d got: %d", expected, &bal))
+			}
+			fmt.Printf("%d (%d.%d) AddBalance %x, %d+%d=%d\n", sdb.blockNum, sdb.txIndex, sdb.version, addr, &prev0, amount, &bal)
+		}()
 	}
 
-	// If this account has not been read, add to the balance increment map
-	_, needAccount := sdb.stateObjects[addr]
-	if !needAccount && addr == ripemd && amount.IsZero() {
-		needAccount = true
-	}
-	if !needAccount {
-		sdb.journal.append(balanceIncrease{
-			account:  addr,
-			increase: *amount,
-		})
+	if sdb.versionMap == nil {
+		// If this account has not been read, add to the balance increment map
+		if _, needAccount := sdb.stateObjects[addr]; !needAccount && addr == ripemd && amount.IsZero() {
+			sdb.journal.append(balanceIncrease{
+				account:  &addr,
+				increase: amount,
+			})
 
-		bi, ok := sdb.balanceInc[addr]
-		if !ok {
-			bi = &BalanceIncrease{}
-			sdb.balanceInc[addr] = bi
-		}
-
-		if !amount.IsZero() && sdb.tracingHooks != nil && sdb.tracingHooks.OnBalanceChange != nil {
-			// TODO: discuss if we should ignore error
-			prev := new(uint256.Int)
-			account, _ := sdb.stateReader.ReadAccountDataForDebug(addr)
-			if account != nil {
-				prev.Add(&account.Balance, &bi.increase)
-			} else {
-				prev.Add(prev, &bi.increase)
+			bi, ok := sdb.balanceInc[addr]
+			if !ok {
+				bi = &BalanceIncrease{}
+				sdb.balanceInc[addr] = bi
 			}
 
-			sdb.tracingHooks.OnBalanceChange(addr, *prev, *new(uint256.Int).Add(prev, amount), reason)
+			if sdb.tracingHooks != nil && sdb.tracingHooks.OnBalanceChange != nil {
+				// TODO: discuss if we should ignore error
+				prev := new(uint256.Int)
+
+				readStart := time.Now()
+				account, _ := sdb.stateReader.ReadAccountDataForDebug(addr)
+				sdb.storageReadDuration += time.Since(readStart)
+				sdb.storageReadCount++
+
+				if account != nil {
+					prev.Add(&account.Balance, &bi.increase)
+				} else {
+					prev.Add(prev, &bi.increase)
+				}
+
+				sdb.tracingHooks.OnBalanceChange(addr, *prev, *(new(uint256.Int).Add(prev, &amount)), reason)
+			}
+
+			bi.increase.Add(&bi.increase, &amount)
+			bi.count++
+			return nil
+		}
+	}
+
+	stateObject, err := sdb.GetOrNewStateObject(addr)
+	if err != nil {
+		return err
+	}
+
+	prev, err := sdb.GetBalance(addr)
+	if err != nil {
+		return err
+	}
+
+	// EIP161: We must check emptiness for the objects such that the account
+	// clearing (0,0,0 objects) can take effect.
+	if amount.IsZero() {
+		if stateObject.empty() {
+			sdb.versionWritten(addr, BalancePath, common.Hash{}, prev)
+			if dbg.TraceTransactionIO && (sdb.trace || traceAccount(addr)) {
+				fmt.Printf("%d (%d.%d) Touch %x %s\n", sdb.blockNum, sdb.txIndex, sdb.version, addr, AccountKey{Path: BalancePath})
+			}
+			stateObject.touch()
 		}
 
-		bi.increase.Add(&bi.increase, amount)
-		bi.count++
+		return nil
+	}
+
+	update := new(uint256.Int).Add(&prev, &amount)
+	stateObject.SetBalance(*update, reason)
+	sdb.versionWritten(addr, BalancePath, common.Hash{}, *update)
+	return nil
+}
+
+// SubBalance subtracts amount from the account associated with addr.
+// DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
+func (sdb *IntraBlockState) SubBalance(addr common.Address, amount uint256.Int, reason tracing.BalanceChangeReason) error {
+	if sdb.trace || traceAccount(addr) {
+		prev, _ := sdb.GetBalance(addr)
+		defer func() {
+			bal, _ := sdb.GetBalance(addr)
+			fmt.Printf("%d (%d.%d) SubBalance %x, %d-%d=%d\n", sdb.blockNum, sdb.txIndex, sdb.version, addr, &prev, amount, &bal)
+		}()
+	}
+
+	if amount.IsZero() {
 		return nil
 	}
 
@@ -501,72 +623,133 @@ func (sdb *IntraBlockState) AddBalance(addr common.Address, amount *uint256.Int,
 	if err != nil {
 		return err
 	}
-	stateObject.AddBalance(amount, reason)
-	return nil
-}
 
-// SubBalance subtracts amount from the account associated with addr.
-// DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
-func (sdb *IntraBlockState) SubBalance(addr common.Address, amount *uint256.Int, reason tracing.BalanceChangeReason) error {
-	if sdb.trace {
-		fmt.Printf("SubBalance %x, %d\n", addr, amount)
-	}
-
-	stateObject, err := sdb.GetOrNewStateObject(addr)
+	prev, err := sdb.GetBalance(addr)
 	if err != nil {
 		return err
 	}
-	if stateObject != nil {
-		stateObject.SubBalance(amount, reason)
-	}
+
+	update := new(uint256.Int).Sub(&prev, &amount)
+	stateObject.SetBalance(*update, reason)
+	sdb.versionWritten(addr, BalancePath, common.Hash{}, *update)
+
 	return nil
 }
 
 // DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) SetBalance(addr common.Address, amount uint256.Int, reason tracing.BalanceChangeReason) error {
+	if sdb.trace || traceAccount(addr) {
+		fmt.Printf("%d (%d.%d) SetBalance %x, %d\n", sdb.blockNum, sdb.txIndex, sdb.version, addr, amount)
+	}
 	stateObject, err := sdb.GetOrNewStateObject(addr)
 	if err != nil {
 		return err
 	}
-	if stateObject != nil {
-		stateObject.SetBalance(amount, reason)
-	}
+	stateObject.SetBalance(amount, reason)
+	sdb.versionWritten(addr, BalancePath, common.Hash{}, stateObject.Balance())
 	return nil
 }
 
 // DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) SetNonce(addr common.Address, nonce uint64) error {
+	if sdb.trace || traceAccount(addr) {
+		fmt.Printf("%d (%d.%d) SetNonce %x, %d\n", sdb.blockNum, sdb.txIndex, sdb.version, addr, nonce)
+	}
+
 	stateObject, err := sdb.GetOrNewStateObject(addr)
 	if err != nil {
 		return err
 	}
-	if stateObject != nil {
-		stateObject.SetNonce(nonce)
-	}
+
+	stateObject.SetNonce(nonce)
+	sdb.versionWritten(addr, NoncePath, common.Hash{}, stateObject.Nonce())
 	return nil
 }
 
 // DESCRIBED: docs/programmers_guide/guide.md#code-hash
 // DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) SetCode(addr common.Address, code []byte) error {
+	if sdb.trace || traceAccount(addr) {
+		v := code
+		lenv := len(code)
+		if lenv > 41 {
+			v = v[0:40]
+		}
+		fmt.Printf("%d (%d.%d) SetCode %x, %d: %x...\n", sdb.blockNum, sdb.txIndex, sdb.version, addr, lenv, v)
+	}
+
 	stateObject, err := sdb.GetOrNewStateObject(addr)
 	if err != nil {
 		return err
 	}
-	if stateObject != nil {
-		stateObject.SetCode(crypto.Keccak256Hash(code), code)
-	}
+	codeHash := crypto.Keccak256Hash(code)
+	stateObject.SetCode(codeHash, code)
+	sdb.versionWritten(addr, CodePath, common.Hash{}, code)
+	sdb.versionWritten(addr, CodeHashPath, common.Hash{}, codeHash)
+	sdb.versionWritten(addr, CodeSizePath, common.Hash{}, len(code))
 	return nil
+}
+
+var tracedKeys map[common.Hash]struct{}
+
+func traceKey(key common.Hash) bool {
+	if tracedKeys == nil {
+		tracedKeys = map[common.Hash]struct{}{}
+		for _, key := range dbg.TraceStateKeys {
+			key, _ = strings.CutPrefix(strings.ToLower(key), "Ox")
+			tracedKeys[common.HexToHash(key)] = struct{}{}
+		}
+	}
+	_, ok := tracedKeys[key]
+	return len(tracedKeys) == 0 || ok
+}
+
+var tracedAccounts map[common.Address]struct{} = func() map[common.Address]struct{} {
+	ta := map[common.Address]struct{}{}
+	for _, account := range dbg.TraceAccounts {
+		account, _ = strings.CutPrefix(strings.ToLower(account), "Ox")
+		ta[common.HexToAddress(account)] = struct{}{}
+	}
+	return ta
+}()
+
+func traceAccount(addr common.Address) bool {
+	_, ok := tracedAccounts[addr]
+	return ok
+}
+
+func (sdb *IntraBlockState) TraceAccount(addr common.Address) bool {
+	return traceAccount(addr)
+}
+
+func (sdb *IntraBlockState) Trace() bool {
+	return sdb.trace
+}
+
+func (sdb *IntraBlockState) TxIndex() int {
+	return sdb.txIndex
+}
+
+func (sdb *IntraBlockState) Incarnation() int {
+	return sdb.version
 }
 
 // DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) SetState(addr common.Address, key common.Hash, value uint256.Int) error {
+	return sdb.setState(addr, key, value, false)
+}
+
+func (sdb *IntraBlockState) setState(addr common.Address, key common.Hash, value uint256.Int, force bool) error {
+	if sdb.trace || (traceAccount(addr) && traceKey(key)) {
+		fmt.Printf("%d (%d.%d) SetState %x, %x=%s\n", sdb.blockNum, sdb.txIndex, sdb.version, addr, key[:], value.Hex())
+	}
+
 	stateObject, err := sdb.GetOrNewStateObject(addr)
 	if err != nil {
 		return err
 	}
-	if stateObject != nil {
-		stateObject.SetState(key, value)
+	if stateObject.SetState(key, value, force) {
+		sdb.versionWritten(addr, StatePath, key, value)
 	}
 	return nil
 }
@@ -586,6 +769,10 @@ func (sdb *IntraBlockState) SetStorage(addr common.Address, storage Storage) err
 
 // SetIncarnation sets incarnation for account if account exists
 func (sdb *IntraBlockState) SetIncarnation(addr common.Address, incarnation uint64) error {
+	if sdb.trace || traceAccount(addr) {
+		fmt.Printf("%d (%d.%d) SetIncarnation %x, %d\n", sdb.blockNum, sdb.txIndex, sdb.version, addr, incarnation)
+	}
+
 	stateObject, err := sdb.GetOrNewStateObject(addr)
 	if err != nil {
 		return err
@@ -613,6 +800,9 @@ func (sdb *IntraBlockState) GetIncarnation(addr common.Address) (uint64, error) 
 // The account's state object is still available until the state is committed,
 // getStateObject will return a non-nil account after Suicide.
 func (sdb *IntraBlockState) Selfdestruct(addr common.Address) (bool, error) {
+	if sdb.trace || traceAccount(addr) {
+		fmt.Printf("%d (%d.%d) SelfDestruct %x\n", sdb.blockNum, sdb.txIndex, sdb.version, addr)
+	}
 	stateObject, err := sdb.getStateObject(addr)
 	if err != nil {
 		return false, err
@@ -620,10 +810,9 @@ func (sdb *IntraBlockState) Selfdestruct(addr common.Address) (bool, error) {
 	if stateObject == nil || stateObject.deleted {
 		return false, nil
 	}
-
-	prevBalance := *stateObject.Balance()
+	prevBalance := stateObject.Balance()
 	sdb.journal.append(selfdestructChange{
-		account:     addr,
+		account:     &addr,
 		prev:        stateObject.selfdestructed,
 		prevbalance: prevBalance,
 	})
@@ -635,6 +824,9 @@ func (sdb *IntraBlockState) Selfdestruct(addr common.Address) (bool, error) {
 	stateObject.markSelfdestructed()
 	stateObject.createdContract = false
 	stateObject.data.Balance.Clear()
+
+	sdb.versionWritten(addr, SelfDestructPath, common.Hash{}, stateObject.selfdestructed)
+	sdb.versionWritten(addr, BalancePath, common.Hash{}, uint256.Int{})
 
 	return true, nil
 }
@@ -690,40 +882,90 @@ func (sdb *IntraBlockState) GetTransientState(addr common.Address, key common.Ha
 	return sdb.transientStorage.Get(addr, key)
 }
 
-func (sdb *IntraBlockState) getStateObject(addr common.Address) (stateObject *stateObject, err error) {
-	// Prefer 'live' objects.
-	if obj := sdb.stateObjects[addr]; obj != nil {
-		return obj, nil
+func (sdb *IntraBlockState) getStateObject(addr common.Address) (*stateObject, error) {
+	if so, ok := sdb.stateObjects[addr]; ok {
+		return so, nil
 	}
 
 	// Load the object from the database.
 	if _, ok := sdb.nilAccounts[addr]; ok {
-		if bi, ok := sdb.balanceInc[addr]; ok && !bi.transferred {
-			return sdb.createObject(addr, nil), nil
-		}
-		return nil, nil
-	}
-	account, err := sdb.stateReader.ReadAccountData(addr)
-	if err != nil {
-		sdb.setErrorUnsafe(err)
-		return nil, err
-	}
-	if account == nil {
-		sdb.nilAccounts[addr] = struct{}{}
-		if bi, ok := sdb.balanceInc[addr]; ok && !bi.transferred {
+		if bi, ok := sdb.balanceInc[addr]; ok && !bi.transferred && sdb.versionMap == nil {
 			return sdb.createObject(addr, nil), nil
 		}
 		return nil, nil
 	}
 
+	readStart := time.Now()
+	readAccount, err := sdb.stateReader.ReadAccountData(addr)
+	sdb.storageReadDuration += time.Since(readStart)
+	sdb.storageReadCount++
+
+	if err != nil {
+		return nil, err
+	}
+
+	if readAccount == nil {
+		if sdb.versionMap != nil {
+			readAccount, _, err = versionedRead[*accounts.Account](sdb, addr, AddressPath, common.Hash{}, false, nil, nil, nil)
+
+			if readAccount == nil || err != nil {
+				return nil, err
+			}
+		} else {
+			sdb.nilAccounts[addr] = struct{}{}
+			if bi, ok := sdb.balanceInc[addr]; ok && !bi.transferred {
+				return sdb.createObject(addr, nil), nil
+			}
+			return nil, nil
+		}
+	}
+
+	var code []byte
+
+	account := readAccount
+	if sdb.versionMap != nil {
+		// need to do a versioned read of balance/nonce/codehash
+		if balance, _, _ := versionedRead(sdb, addr, BalancePath, common.Hash{}, false, account.Balance, nil, nil); balance.Cmp(&account.Balance) != 0 {
+			if account == readAccount {
+				account = &accounts.Account{}
+				account.Copy(readAccount)
+			}
+			account.Balance = balance
+		}
+
+		if nonce, _, _ := versionedRead[uint64](sdb, addr, NoncePath, common.Hash{}, false, 0, nil, nil); nonce > account.Nonce {
+			if account == readAccount {
+				account = &accounts.Account{}
+				account.Copy(readAccount)
+			}
+			account.Nonce = nonce
+		}
+
+		if codeHash, _, _ := versionedRead(sdb, addr, CodeHashPath, common.Hash{}, false, common.Hash{}, nil, nil); (codeHash != common.Hash{}) {
+			if account == readAccount {
+				account = &accounts.Account{}
+				account.Copy(readAccount)
+			}
+			account.CodeHash = codeHash
+		}
+
+		code, _, _ = versionedRead[[]byte](sdb, addr, CodePath, common.Hash{}, false, nil, nil, nil)
+	}
+
+	sdb.accountRead(addr, account)
 	// Insert into the live set.
 	obj := newObject(sdb, addr, account, account)
+
+	if code != nil {
+		obj.code = code
+	}
+
 	sdb.setStateObject(addr, obj)
 	return obj, nil
 }
 
 func (sdb *IntraBlockState) setStateObject(addr common.Address, object *stateObject) {
-	if bi, ok := sdb.balanceInc[addr]; ok && !bi.transferred {
+	if bi, ok := sdb.balanceInc[addr]; ok && !bi.transferred && sdb.versionMap == nil {
 		object.data.Balance.Add(&object.data.Balance, &bi.increase)
 		bi.transferred = true
 		sdb.journal.append(balanceIncreaseTransfer{bi: bi})
@@ -746,13 +988,14 @@ func (sdb *IntraBlockState) GetOrNewStateObject(addr common.Address) (*stateObje
 // createObject creates a new state object. If there is an existing account with
 // the given address, it is overwritten.
 func (sdb *IntraBlockState) createObject(addr common.Address, previous *stateObject) (newobj *stateObject) {
-	account := new(accounts.Account)
+	account := &accounts.Account{}
 	var original *accounts.Account
 	if previous == nil {
 		original = &accounts.Account{}
 	} else {
 		original = &previous.original
 	}
+
 	account.Root.SetBytes(trie.EmptyRoot[:]) // old storage should be ignored
 	newobj = newObject(sdb, addr, account, original)
 	newobj.setNonce(0) // sets the object to dirty
@@ -763,6 +1006,8 @@ func (sdb *IntraBlockState) createObject(addr common.Address, previous *stateObj
 	}
 	newobj.newlyCreated = true
 	sdb.setStateObject(addr, newobj)
+	data := newobj.data
+	sdb.versionWritten(addr, AddressPath, common.Hash{}, &data)
 	return newobj
 }
 
@@ -785,7 +1030,7 @@ func (sdb *IntraBlockState) CreateAccount(addr common.Address, contractCreation 
 	if previous != nil && previous.selfdestructed {
 		prevInc = previous.data.Incarnation
 	} else {
-		prevInc = 0 // sdb.stateReader.ReadAccountIncarnation(addr)
+		prevInc = 0
 	}
 	if previous != nil && prevInc < previous.data.PrevIncarnation {
 		prevInc = previous.data.PrevIncarnation
@@ -804,31 +1049,75 @@ func (sdb *IntraBlockState) CreateAccount(addr common.Address, contractCreation 
 	} else {
 		newObj.selfdestructed = false
 	}
+
+	data := newObj.data
+	// for newly created files these synthetic reads are used so that account
+	// creation clashes between trnascations get detected
+	sdb.versionRead(addr, AddressPath, common.Hash{}, StorageRead, &data)
+	sdb.versionRead(addr, BalancePath, common.Hash{}, StorageRead, newObj.Balance())
+
+	sdb.versionWritten(addr, AddressPath, common.Hash{}, &data)
+	sdb.versionWritten(addr, BalancePath, common.Hash{}, newObj.Balance())
 	return nil
 }
 
 // Snapshot returns an identifier for the current revision of the state.
 func (sdb *IntraBlockState) Snapshot() int {
-	id := sdb.nextRevisionID
-	sdb.nextRevisionID++
+	id := sdb.nextRevisionId
+	sdb.nextRevisionId++
 	sdb.validRevisions = append(sdb.validRevisions, revision{id, sdb.journal.length()})
 	return id
 }
 
 // RevertToSnapshot reverts all state changes made since the given revision.
-func (sdb *IntraBlockState) RevertToSnapshot(revid int) {
+func (sdb *IntraBlockState) RevertToSnapshot(revid int, err error) {
+	var traced bool
+	for addr := range tracedAccounts {
+		if _, isDirty := sdb.journal.dirties[addr]; !isDirty {
+			traced = true
+			if err == nil {
+				fmt.Printf("%d (%d.%d) Reverted %x, %d\n", sdb.blockNum, sdb.txIndex, sdb.version, addr, revid)
+			} else {
+				fmt.Printf("%d (%d.%d) Reverted %x, %d: %s\n", sdb.blockNum, sdb.txIndex, sdb.version, addr, revid, err)
+			}
+		}
+	}
+
 	// Find the snapshot in the stack of valid snapshots.
 	idx := sort.Search(len(sdb.validRevisions), func(i int) bool {
 		return sdb.validRevisions[i].id >= revid
 	})
 	if idx == len(sdb.validRevisions) || sdb.validRevisions[idx].id != revid {
-		panic(fmt.Errorf("revision id %v cannot be reverted", revid))
+		var id int
+		if idx < len(sdb.validRevisions) {
+			id = sdb.validRevisions[idx].id
+		}
+		panic(fmt.Errorf("revision id %v cannot be reverted (idx=%v,len=%v,id=%v)", revid, idx, len(sdb.validRevisions), id))
 	}
 	snapshot := sdb.validRevisions[idx].journalIndex
 
 	// Replay the journal to undo changes and remove invalidated snapshots
 	sdb.journal.revert(sdb, snapshot)
 	sdb.validRevisions = sdb.validRevisions[:idx]
+
+	if sdb.versionMap != nil {
+		var reverted []common.Address
+
+		for addr := range sdb.versionedWrites {
+			if _, isDirty := sdb.journal.dirties[addr]; !isDirty {
+				reverted = append(reverted, addr)
+			}
+		}
+
+		for _, addr := range reverted {
+			sdb.versionMap.DeleteAll(addr, sdb.txIndex)
+			delete(sdb.versionedWrites, addr)
+		}
+	}
+
+	if traced && sdb.txIndex == 8 && sdb.version == 1 {
+		fmt.Printf("%d (%d.%d) Reverted: %d:%d\n", sdb.blockNum, sdb.txIndex, sdb.version, revid, snapshot)
+	}
 }
 
 // GetRefund returns the current value of the refund counter.
@@ -836,11 +1125,15 @@ func (sdb *IntraBlockState) GetRefund() uint64 {
 	return sdb.refund
 }
 
-func updateAccount(EIP161Enabled bool, isAura bool, stateWriter StateWriter, addr common.Address, stateObject *stateObject, isDirty bool, tracingHooks *tracing.Hooks) error {
+func updateAccount(EIP161Enabled bool, isAura bool, stateWriter StateWriter, addr common.Address, stateObject *stateObject, isDirty bool, trace bool, tracingHooks *tracing.Hooks) error {
 	emptyRemoval := EIP161Enabled && stateObject.empty() && (!isAura || addr != SystemAddress)
 	if stateObject.selfdestructed || (isDirty && emptyRemoval) {
-		if tracingHooks != nil && tracingHooks.OnBalanceChange != nil && !stateObject.Balance().IsZero() && stateObject.selfdestructed {
-			tracingHooks.OnBalanceChange(stateObject.address, stateObject.data.Balance, zeroBalance, tracing.BalanceDecreaseSelfdestructBurn)
+		balance := stateObject.Balance()
+		if tracingHooks != nil && tracingHooks.OnBalanceChange != nil && !(&balance).IsZero() && stateObject.selfdestructed {
+			tracingHooks.OnBalanceChange(stateObject.address, balance, *uint256.NewInt(0), tracing.BalanceDecreaseSelfdestructBurn)
+		}
+		if dbg.TraceTransactionIO && (trace || traceAccount(addr)) {
+			fmt.Printf("%d (%d.%d) Delete Account: %x selfdestructed=%v\n", stateObject.db.blockNum, stateObject.db.txIndex, stateObject.db.version, addr, stateObject.selfdestructed)
 		}
 		if err := stateWriter.DeleteAccount(addr, &stateObject.original); err != nil {
 			return err
@@ -860,9 +1153,13 @@ func updateAccount(EIP161Enabled bool, isAura bool, stateWriter StateWriter, add
 				return err
 			}
 		}
-		if err := stateObject.updateTrie(stateWriter); err != nil {
+		if err := stateObject.updateStotage(stateWriter); err != nil {
 			return err
 		}
+		if dbg.TraceTransactionIO && (trace || traceAccount(addr)) {
+			fmt.Printf("%d (%d.%d) Update Account Data: %x, balance=%d, nonce=%d codehash=%x\n", stateObject.db.blockNum, stateObject.db.txIndex, stateObject.db.version, addr, &stateObject.data.Balance, stateObject.data.Nonce, stateObject.data.CodeHash)
+		}
+
 		if err := stateWriter.UpdateAccountData(addr, &stateObject.original, &stateObject.data); err != nil {
 			return err
 		}
@@ -884,12 +1181,7 @@ func printAccount(EIP161Enabled bool, addr common.Address, stateObject *stateObj
 			fmt.Printf("CreateContract: %x\n", addr)
 		}
 		stateObject.printTrie()
-		if stateObject.data.Balance.IsUint64() {
-			fmt.Printf("UpdateAccountData: %x, balance=%d, nonce=%d\n", addr, stateObject.data.Balance.Uint64(), stateObject.data.Nonce)
-		} else {
-			div := uint256.NewInt(1_000_000_000)
-			fmt.Printf("UpdateAccountData: %x, balance=%d*%d, nonce=%d\n", addr, uint256.NewInt(0).Div(&stateObject.data.Balance, div).Uint64(), div.Uint64(), stateObject.data.Nonce)
-		}
+		fmt.Printf("UpdateAccountData: %x, balance=%d, nonce=%d\n", addr, &stateObject.data.Balance, stateObject.data.Nonce)
 	}
 }
 
@@ -912,8 +1204,7 @@ func (sdb *IntraBlockState) FinalizeTx(chainRules *chain.Rules, stateWriter Stat
 			continue
 		}
 
-		//fmt.Printf("FinalizeTx: %x, balance=%d %T\n", addr, so.data.Balance.Uint64(), stateWriter)
-		if err := updateAccount(chainRules.IsSpuriousDragon, chainRules.IsAura, stateWriter, addr, so, true, sdb.tracingHooks); err != nil {
+		if err := updateAccount(chainRules.IsSpuriousDragon, chainRules.IsAura, stateWriter, addr, so, true, sdb.trace, sdb.tracingHooks); err != nil {
 			return err
 		}
 		so.newlyCreated = false
@@ -969,28 +1260,59 @@ func (sdb *IntraBlockState) MakeWriteSet(chainRules *chain.Rules, stateWriter St
 	}
 	for addr, stateObject := range sdb.stateObjects {
 		_, isDirty := sdb.stateObjectsDirty[addr]
-		if err := updateAccount(chainRules.IsSpuriousDragon, chainRules.IsAura, stateWriter, addr, stateObject, isDirty, sdb.tracingHooks); err != nil {
+		if traceAccount(addr) {
+			var updated *uint256.Int
+			if sdb.versionedWrites != nil {
+				if w, ok := sdb.versionedWrites[addr][AccountKey{Path: BalancePath}]; ok {
+					val := w.Val.(uint256.Int)
+					updated = &val
+				}
+			}
+			if updated != nil {
+				fmt.Printf("%d (%d.%d) Balance: %x (%v): %d (%d)\n", sdb.blockNum, sdb.txIndex, sdb.version, addr, isDirty, &stateObject.data.Balance, &updated)
+			} else {
+				fmt.Printf("%d (%d.%d) Balance: %x (%v): %d\n", sdb.blockNum, sdb.txIndex, sdb.version, addr, isDirty, &stateObject.data.Balance)
+			}
+		}
+		if dbg.TraceTransactionIO && (sdb.trace || traceAccount(addr)) {
+			fmt.Printf("%d (%d.%d) Update Account %x\n", sdb.blockNum, sdb.txIndex, sdb.version, addr)
+		}
+		if err := updateAccount(chainRules.IsSpuriousDragon, chainRules.IsAura, stateWriter, addr, stateObject, isDirty, sdb.trace, sdb.tracingHooks); err != nil {
 			return err
 		}
 	}
+
+	var reverted []common.Address
+
+	for addr := range sdb.versionedWrites {
+		if _, isDirty := sdb.stateObjectsDirty[addr]; !isDirty {
+			reverted = append(reverted, addr)
+		}
+	}
+
+	for _, addr := range reverted {
+		sdb.versionMap.DeleteAll(addr, sdb.txIndex)
+		delete(sdb.versionedWrites, addr)
+	}
+
 	// Invalidate journal because reverting across transactions is not allowed.
 	sdb.clearJournalAndRefund()
 	return nil
 }
 
-func (sdb *IntraBlockState) Print(chainRules chain.Rules) {
+func (sdb *IntraBlockState) Print(chainRules chain.Rules, all bool) {
 	for addr, stateObject := range sdb.stateObjects {
 		_, isDirty := sdb.stateObjectsDirty[addr]
 		_, isDirty2 := sdb.journal.dirties[addr]
 
-		printAccount(chainRules.IsSpuriousDragon, addr, stateObject, isDirty || isDirty2)
+		printAccount(chainRules.IsSpuriousDragon, addr, stateObject, all || isDirty || isDirty2)
 	}
 }
 
 // SetTxContext sets the current transaction index which
 // used when the EVM emits new state logs. It should be invoked before
 // transaction execution.
-func (sdb *IntraBlockState) SetTxContext(ti int) {
+func (sdb *IntraBlockState) SetTxContext(bn uint64, ti int) {
 	if len(sdb.logs) > 0 && ti == 0 {
 		err := fmt.Errorf("seems you forgot `ibs.Reset` or `ibs.TxIndex()`. len(sdb.logs)=%d, ti=%d", len(sdb.logs), ti)
 		panic(err)
@@ -1000,6 +1322,7 @@ func (sdb *IntraBlockState) SetTxContext(ti int) {
 		panic(err)
 	}
 	sdb.txIndex = ti
+	sdb.blockNum = bn
 }
 
 // no not lock
@@ -1029,8 +1352,8 @@ func (sdb *IntraBlockState) clearJournalAndRefund() {
 // - Add delegated designation (if it exists for dst) to access list (EIP-7702)
 func (sdb *IntraBlockState) Prepare(rules *chain.Rules, sender, coinbase common.Address, dst *common.Address,
 	precompiles []common.Address, list types.AccessList, authorities []common.Address) error {
-	if sdb.trace {
-		fmt.Printf("ibs.Prepare %x, %x, %x, %x, %v, %v, %v\n", sender, coinbase, dst, precompiles, list, rules, authorities)
+	if sdb.trace || traceAccount(sender) || dst != nil && traceAccount(*dst) {
+		fmt.Printf("%d (%d.%d) ibs.Prepare: sender: %x, coinbase: %x, dest: %x, %x, %v, %v, %v\n", sdb.blockNum, sdb.txIndex, sdb.version, sender, coinbase, dst, precompiles, list, rules, authorities)
 	}
 	if rules.IsBerlin {
 		// Clear out any leftover from previous executions
@@ -1243,38 +1566,42 @@ func (ibs *IntraBlockState) VersionedWrites(checkDirty bool) VersionedWrites {
 	return writes
 }
 
-// nolint
-var tracedKeys map[common.Hash]struct{} //nolint
+// Apply entries in a given write set to StateDB. Note that this function does not change MVHashMap nor write set
+// of the current StateDB.
+func (s *IntraBlockState) ApplyVersionedWrites(writes VersionedWrites) error {
+	for i := range writes {
+		path := writes[i].Path
+		val := writes[i].Val
+		addr := writes[i].Address
 
-// nolint
-func traceKey(key common.Hash) bool {
-	if tracedKeys == nil {
-		tracedKeys = map[common.Hash]struct{}{}
-		for _, key := range dbg.TraceStateKeys {
-			key, _ = strings.CutPrefix(strings.ToLower(key), "Ox")
-			tracedKeys[common.HexToHash(key)] = struct{}{}
+		if val != nil {
+			switch path {
+			case AddressPath:
+				continue
+			case StatePath:
+				stateKey := writes[i].Key
+				state := val.(uint256.Int)
+				s.setState(addr, stateKey, state, true)
+			case BalancePath:
+				balance := val.(uint256.Int)
+				s.SetBalance(addr, balance, writes[i].Reason)
+			case NoncePath:
+				nonce := val.(uint64)
+				s.SetNonce(addr, nonce)
+			case CodePath:
+				code := val.([]byte)
+				s.SetCode(addr, code)
+			case CodeHashPath, CodeSizePath:
+				// set by SetCode
+			case SelfDestructPath:
+				deleted := val.(bool)
+				if deleted {
+					s.Selfdestruct(addr)
+				}
+			default:
+				panic(fmt.Errorf("unknown key type: %d", path))
+			}
 		}
 	}
-	_, ok := tracedKeys[key]
-	return len(tracedKeys) == 0 || ok
-}
-
-// nolint
-var tracedAccounts map[common.Address]struct{} = func() map[common.Address]struct{} {
-	ta := map[common.Address]struct{}{}
-	for _, account := range dbg.TraceAccounts {
-		account, _ = strings.CutPrefix(strings.ToLower(account), "Ox")
-		ta[common.HexToAddress(account)] = struct{}{}
-	}
-	return ta
-}()
-
-// nolint
-func traceAccount(addr common.Address) bool {
-	_, ok := tracedAccounts[addr]
-	return ok
-}
-
-func (sdb *IntraBlockState) TraceAccount(addr common.Address) bool {
-	return traceAccount(addr)
+	return nil
 }

--- a/core/state/intra_block_state.go
+++ b/core/state/intra_block_state.go
@@ -1327,6 +1327,7 @@ func (sdb *IntraBlockState) Print(chainRules chain.Rules, all bool) {
 // used when the EVM emits new state logs. It should be invoked before
 // transaction execution.
 func (sdb *IntraBlockState) SetTxContext(bn uint64, ti int) {
+	/* Not sure what this test is for it seems to break some tests
 	if len(sdb.logs) > 0 && ti == 0 {
 		err := fmt.Errorf("seems you forgot `ibs.Reset` or `ibs.TxIndex()`. len(sdb.logs)=%d, ti=%d", len(sdb.logs), ti)
 		panic(err)
@@ -1335,6 +1336,7 @@ func (sdb *IntraBlockState) SetTxContext(bn uint64, ti int) {
 		err := fmt.Errorf("seems you forgot `ibs.Reset` or `ibs.TxIndex()`. sdb.txIndex=%d, ti=%d", sdb.txIndex, ti)
 		panic(err)
 	}
+	*/
 	sdb.txIndex = ti
 	sdb.blockNum = bn
 }

--- a/core/state/intra_block_state.go
+++ b/core/state/intra_block_state.go
@@ -308,6 +308,17 @@ func (sdb *IntraBlockState) Empty(addr common.Address) (bool, error) {
 // GetBalance retrieves the balance from the given address or 0 if object not found
 // DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) GetBalance(addr common.Address) (uint256.Int, error) {
+	if sdb.versionMap == nil {
+		stateObject, err := sdb.getStateObject(addr)
+		if err != nil {
+			return *u256.Num0, err
+		}
+		if stateObject != nil && !stateObject.deleted {
+			return stateObject.Balance(), nil
+		}
+		return *u256.Num0, nil
+	}
+
 	balance, _, err := versionedRead(sdb, addr, BalancePath, common.Hash{}, false, *u256.Num0,
 		func(v uint256.Int) uint256.Int {
 			return v
@@ -324,6 +335,17 @@ func (sdb *IntraBlockState) GetBalance(addr common.Address) (uint256.Int, error)
 
 // DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) GetNonce(addr common.Address) (uint64, error) {
+	if sdb.versionMap == nil {
+		stateObject, err := sdb.getStateObject(addr)
+		if err != nil {
+			return 0, err
+		}
+		if stateObject != nil && !stateObject.deleted {
+			return stateObject.Nonce(), nil
+		}
+		return 0, nil
+	}
+
 	nonce, _, err := versionedRead(sdb, addr, NoncePath, common.Hash{}, false, 0,
 		func(v uint64) uint64 { return v },
 		func(s *stateObject) (uint64, error) {
@@ -347,6 +369,23 @@ func (sdb *IntraBlockState) TxnIndex() int {
 
 // DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) GetCode(addr common.Address) ([]byte, error) {
+	if sdb.versionMap == nil {
+		stateObject, err := sdb.getStateObject(addr)
+		if err != nil {
+			return nil, err
+		}
+		if stateObject != nil && !stateObject.deleted {
+			code, err := stateObject.Code()
+			if sdb.trace {
+				fmt.Printf("GetCode %x, returned %d\n", addr, len(code))
+			}
+			return code, err
+		}
+		if sdb.trace {
+			fmt.Printf("GetCode %x, returned nil\n", addr)
+		}
+		return nil, nil
+	}
 	code, source, err := versionedRead(sdb, addr, CodePath, common.Hash{}, false, nil,
 		func(v []byte) []byte {
 			return v
@@ -368,6 +407,23 @@ func (sdb *IntraBlockState) GetCode(addr common.Address) ([]byte, error) {
 
 // DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) GetCodeSize(addr common.Address) (int, error) {
+	if sdb.versionMap == nil {
+		stateObject, err := sdb.getStateObject(addr)
+		if err != nil {
+			return 0, err
+		}
+		if stateObject == nil || stateObject.deleted {
+			return 0, nil
+		}
+		if stateObject.code != nil {
+			return len(stateObject.code), nil
+		}
+		if stateObject.data.CodeHash == empty.CodeHash {
+			return 0, nil
+		}
+		return sdb.stateReader.ReadAccountCodeSize(addr)
+	}
+
 	size, source, err := versionedRead(sdb, addr, CodeSizePath, common.Hash{}, false, 0,
 		func(v int) int { return v },
 		func(s *stateObject) (int, error) {
@@ -399,6 +455,17 @@ func (sdb *IntraBlockState) GetCodeSize(addr common.Address) (int, error) {
 
 // DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) GetCodeHash(addr common.Address) (common.Hash, error) {
+	if sdb.versionMap == nil {
+		stateObject, err := sdb.getStateObject(addr)
+		if err != nil {
+			return common.Hash{}, err
+		}
+		if stateObject == nil || stateObject.deleted {
+			return common.Hash{}, nil
+		}
+		return stateObject.data.CodeHash, nil
+	}
+
 	hash, _, err := versionedRead(sdb, addr, CodeHashPath, common.Hash{}, false, common.Hash{},
 		func(v common.Hash) common.Hash { return v },
 		func(s *stateObject) (common.Hash, error) {

--- a/core/state/intra_block_state_logger_test.go
+++ b/core/state/intra_block_state_logger_test.go
@@ -41,8 +41,8 @@ func TestStateLogger(t *testing.T) {
 		{
 			name: "multiple add balance",
 			run: func(state *IntraBlockState) {
-				state.AddBalance(common.Address{}, uint256.NewInt(2), tracing.BalanceChangeUnspecified)
-				state.AddBalance(common.Address{}, uint256.NewInt(1), tracing.BalanceChangeUnspecified)
+				state.AddBalance(common.Address{}, *uint256.NewInt(2), tracing.BalanceChangeUnspecified)
+				state.AddBalance(common.Address{}, *uint256.NewInt(1), tracing.BalanceChangeUnspecified)
 			},
 			checker: func(t *testing.T, stateDB *IntraBlockState) {
 				bi, ok := stateDB.balanceInc[common.Address{}]
@@ -92,8 +92,8 @@ func TestStateLogger(t *testing.T) {
 		{
 			name: "sub balance",
 			run: func(state *IntraBlockState) {
-				state.AddBalance(common.Address{}, uint256.NewInt(2), tracing.BalanceChangeUnspecified)
-				state.SubBalance(common.Address{}, uint256.NewInt(1), tracing.BalanceChangeUnspecified)
+				state.AddBalance(common.Address{}, *uint256.NewInt(2), tracing.BalanceChangeUnspecified)
+				state.SubBalance(common.Address{}, *uint256.NewInt(1), tracing.BalanceChangeUnspecified)
 			},
 			checker: func(t *testing.T, stateDB *IntraBlockState) {
 				so, err := stateDB.GetOrNewStateObject(common.Address{})

--- a/core/state/intra_block_state_logger_test.go
+++ b/core/state/intra_block_state_logger_test.go
@@ -81,7 +81,8 @@ func TestStateLogger(t *testing.T) {
 				so, err := stateDB.GetOrNewStateObject(common.Address{})
 				require.NoError(t, err)
 				if !reflect.DeepEqual(so.Balance(), uint256.NewInt(3)) {
-					t.Errorf("Incorrect Balance for  %s expectedBalance: %s, got:%s", common.Address{}, uint256.NewInt(3), so.Balance())
+					balance := so.Balance()
+					t.Errorf("Incorrect Balance for  %s expectedBalance: %s, got:%s", common.Address{}, uint256.NewInt(3), &balance)
 				}
 			},
 			wantBalanceChangeTraces: []balanceChangeTrace{
@@ -99,7 +100,8 @@ func TestStateLogger(t *testing.T) {
 				so, err := stateDB.GetOrNewStateObject(common.Address{})
 				require.NoError(t, err)
 				if !reflect.DeepEqual(so.Balance(), uint256.NewInt(1)) {
-					t.Errorf("Incorrect Balance for  %s expectedBalance: %s, got:%s", common.Address{}, uint256.NewInt(1), so.Balance())
+					balance := so.Balance()
+					t.Errorf("Incorrect Balance for  %s expectedBalance: %s, got:%s", common.Address{}, uint256.NewInt(1), &balance)
 				}
 			},
 			wantBalanceChangeTraces: []balanceChangeTrace{

--- a/core/state/intra_block_state_test.go
+++ b/core/state/intra_block_state_test.go
@@ -33,14 +33,16 @@ import (
 	"testing/quick"
 
 	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
 
+	"github.com/erigontech/erigon-lib/chain"
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/datadir"
 	"github.com/erigontech/erigon-lib/kv/memdb"
 	"github.com/erigontech/erigon-lib/kv/rawdbv3"
 	"github.com/erigontech/erigon-lib/kv/temporal"
 	"github.com/erigontech/erigon-lib/log/v3"
-	stateLib "github.com/erigontech/erigon-lib/state"
+	libstate "github.com/erigontech/erigon-lib/state"
 	"github.com/erigontech/erigon-lib/types"
 	"github.com/erigontech/erigon/core/tracing"
 )
@@ -99,7 +101,7 @@ func newTestAction(addr common.Address, r *rand.Rand) testAction {
 		{
 			name: "AddBalance",
 			fn: func(a testAction, s *IntraBlockState) {
-				s.AddBalance(addr, uint256.NewInt(uint64(a.args[0])), tracing.BalanceChangeUnspecified)
+				s.AddBalance(addr, *uint256.NewInt(uint64(a.args[0])), tracing.BalanceChangeUnspecified)
 			},
 			args: make([]int64, 1),
 		},
@@ -242,7 +244,7 @@ func (test *snapshotTest) run() bool {
 	db := memdb.NewStateDB("")
 	defer db.Close()
 
-	agg, err := stateLib.NewAggregator(context.Background(), datadir.New(""), 16, db, log.New())
+	agg, err := libstate.NewAggregator(context.Background(), datadir.New(""), 16, db, log.New())
 	if err != nil {
 		test.err = err
 		return false
@@ -286,7 +288,7 @@ func (test *snapshotTest) run() bool {
 		for _, action := range test.actions[:test.snapshots[sindex]] {
 			action.fn(action, checkstate)
 		}
-		state.RevertToSnapshot(snapshotRevs[sindex])
+		state.RevertToSnapshot(snapshotRevs[sindex], nil)
 		if err := test.checkEqual(state, checkstate); err != nil {
 			test.err = fmt.Errorf("state mismatch after revert to snapshot %d\n%w", sindex, err)
 			return false
@@ -443,4 +445,604 @@ func TestTransientStorage(t *testing.T) {
 	if got, exp := state.GetTransientState(addr, key), (*uint256.NewInt(0)); exp != got {
 		t.Fatalf("transient storage mismatch: have %x, want %x", got, exp)
 	}
+}
+
+func TestVersionMapReadWriteDelete(t *testing.T) {
+	t.Parallel()
+
+	db := memdb.NewStateDB("")
+	defer db.Close()
+
+	agg, err := libstate.NewAggregator(context.Background(), datadir.New(""), 16, db, log.New())
+	assert.NoError(t, err)
+	defer agg.Close()
+
+	_db, err := temporal.New(db, agg)
+	assert.NoError(t, err)
+
+	tx, err := _db.BeginTemporalRw(context.Background()) //nolint:gocritic
+	assert.NoError(t, err)
+	defer tx.Rollback()
+
+	domains, err := libstate.NewSharedDomains(tx, log.New())
+	assert.NoError(t, err)
+	defer domains.Close()
+
+	domains.SetTxNum(1)
+	domains.SetBlockNum(1)
+	mvhm := NewVersionMap()
+
+	s := NewWithVersionMap(NewReaderV3(domains.AsGetter(tx)), mvhm)
+
+	states := []*IntraBlockState{s}
+
+	// Create copies of the original state for each transition
+	for i := 1; i <= 4; i++ {
+		sCopy := s.Copy()
+		sCopy.txIndex = i
+		states = append(states, sCopy)
+	}
+
+	addr := common.HexToAddress("0x01")
+	key := common.HexToHash("0x01")
+	val := *uint256.NewInt(1)
+	balance := uint256.NewInt(100)
+
+	var v uint256.Int
+
+	// Tx0 read
+	states[0].GetState(addr, key, &v)
+
+	assert.Equal(t, *uint256.NewInt(0), v)
+
+	// Tx1 write
+	states[1].GetOrNewStateObject(addr)
+	states[1].SetState(addr, key, val)
+	states[1].SetBalance(addr, *balance, tracing.BalanceChangeUnspecified)
+	states[1].versionMap.FlushVersionedWrites(states[1].VersionedWrites(true), true, "")
+
+	// Tx1 read
+	states[1].GetState(addr, key, &v)
+	b, err := states[1].GetBalance(addr)
+	assert.NoError(t, err)
+	assert.Equal(t, val, v)
+	assert.Equal(t, balance, b)
+
+	// Tx2 read
+	states[2].GetState(addr, key, &v)
+	b, err = states[2].GetBalance(addr)
+	assert.NoError(t, err)
+	assert.Equal(t, val, v)
+	assert.Equal(t, balance, b)
+
+	// Tx3 delete
+	states[3].Selfdestruct(addr)
+
+	// Within Tx 3, the state should not change before finalize
+	states[3].GetState(addr, key, &v)
+	assert.Equal(t, val, v)
+
+	// After finalizing Tx 3, the state will change
+	states[3].FinalizeTx(&chain.Rules{}, NewWriter(domains.AsPutDel(tx), nil, 0))
+	states[3].GetState(addr, key, &v)
+	assert.Equal(t, *uint256.NewInt(0), v)
+	states[3].versionMap.FlushVersionedWrites(states[3].VersionedWrites(true), true, "")
+
+	// Tx4 read
+	states[4].GetState(addr, key, &v)
+	b, err = states[4].GetBalance(addr)
+	assert.NoError(t, err)
+	assert.Equal(t, *uint256.NewInt(0), v)
+	assert.Equal(t, uint256.NewInt(0), b)
+}
+
+func TestVersionMapRevert(t *testing.T) {
+	t.Parallel()
+
+	db := memdb.NewStateDB("")
+	defer db.Close()
+
+	agg, err := libstate.NewAggregator(context.Background(), datadir.New(""), 16, db, log.New())
+	assert.NoError(t, err)
+	defer agg.Close()
+
+	_db, err := temporal.New(db, agg)
+	assert.NoError(t, err)
+
+	tx, err := _db.BeginTemporalRw(context.Background()) //nolint:gocritic
+	assert.NoError(t, err)
+	defer tx.Rollback()
+
+	domains, err := libstate.NewSharedDomains(tx, log.New())
+	assert.NoError(t, err)
+	defer domains.Close()
+	domains.SetTxNum(1)
+	domains.SetBlockNum(1)
+	assert.NoError(t, err)
+	mvhm := NewVersionMap()
+	s := NewWithVersionMap(NewReaderV3(domains.AsGetter(tx)), mvhm)
+
+	states := []*IntraBlockState{s}
+
+	// Create copies of the original state for each transition
+	for i := 1; i <= 4; i++ {
+		sCopy := s.Copy()
+		sCopy.txIndex = i
+		states = append(states, sCopy)
+	}
+
+	addr := common.HexToAddress("0x01")
+	key := common.HexToHash("0x01")
+	val := *uint256.NewInt(1)
+	balance := uint256.NewInt(100)
+
+	// Tx0 write
+	states[0].GetOrNewStateObject(addr)
+	states[0].SetState(addr, key, val)
+	states[0].SetBalance(addr, *balance, tracing.BalanceChangeUnspecified)
+	states[0].versionMap.FlushVersionedWrites(states[0].VersionedWrites(true), true, "")
+
+	var v uint256.Int
+
+	// Tx1 perform some ops and then revert
+	snapshot := states[1].Snapshot()
+	states[1].AddBalance(addr, *uint256.NewInt(100), tracing.BalanceChangeUnspecified)
+	states[1].SetState(addr, key, *uint256.NewInt(1))
+	states[1].GetState(addr, key, &v)
+	b, err := states[1].GetBalance(addr)
+	assert.NoError(t, err)
+	assert.Equal(t, uint256.NewInt(200), b)
+	assert.Equal(t, *uint256.NewInt(1), v)
+
+	states[1].Selfdestruct(addr)
+
+	states[1].RevertToSnapshot(snapshot, nil)
+
+	states[1].GetState(addr, key, &v)
+	b, err = states[1].GetBalance(addr)
+	assert.NoError(t, err)
+	assert.Equal(t, val, v)
+	assert.Equal(t, balance, b)
+	states[1].FinalizeTx(&chain.Rules{}, NewWriter(domains.AsPutDel(tx), nil, 0))
+	states[1].versionMap.FlushVersionedWrites(states[1].VersionedWrites(true), true, "")
+
+	// Tx2 check the state and balance
+	states[2].GetState(addr, key, &v)
+	b, err = states[2].GetBalance(addr)
+	assert.NoError(t, err)
+	assert.Equal(t, val, v)
+	assert.Equal(t, balance, b)
+}
+
+func TestVersionMapMarkEstimate(t *testing.T) {
+	t.Parallel()
+
+	db := memdb.NewStateDB("")
+	defer db.Close()
+
+	agg, err := libstate.NewAggregator(context.Background(), datadir.New(""), 16, db, log.New())
+	assert.NoError(t, err)
+	defer agg.Close()
+
+	_db, err := temporal.New(db, agg)
+	assert.NoError(t, err)
+
+	tx, err := _db.BeginTemporalRw(context.Background()) //nolint:gocritic
+	assert.NoError(t, err)
+	defer tx.Rollback()
+
+	domains, err := libstate.NewSharedDomains(tx, log.New())
+	assert.NoError(t, err)
+	defer domains.Close()
+
+	domains.SetTxNum(1)
+	domains.SetBlockNum(1)
+	assert.NoError(t, err)
+	mvhm := NewVersionMap()
+	s := NewWithVersionMap(NewReaderV3(domains.AsGetter(tx)), mvhm)
+	states := []*IntraBlockState{s}
+
+	// Create copies of the original state for each transition
+	for i := 1; i <= 4; i++ {
+		sCopy := s.Copy()
+		sCopy.txIndex = i
+		states = append(states, sCopy)
+	}
+
+	addr := common.HexToAddress("0x01")
+	key := common.HexToHash("0x01")
+	val := *uint256.NewInt(1)
+	balance := uint256.NewInt(100)
+
+	var v uint256.Int
+
+	// Tx0 read
+	states[0].GetState(addr, key, &v)
+	assert.Equal(t, *uint256.NewInt(0), v)
+
+	// Tx0 write
+	states[0].SetState(addr, key, val)
+	states[0].GetState(addr, key, &v)
+	assert.Equal(t, val, v)
+	states[0].versionMap.FlushVersionedWrites(states[0].VersionedWrites(true), true, "")
+
+	// Tx1 write
+	states[1].GetOrNewStateObject(addr)
+	states[1].SetState(addr, key, val)
+	states[1].SetBalance(addr, *balance, tracing.BalanceChangeUnspecified)
+	states[1].versionMap.FlushVersionedWrites(states[1].VersionedWrites(true), true, "")
+
+	// Tx2 read
+	states[2].GetState(addr, key, &v)
+	b, err := states[2].GetBalance(addr)
+	assert.NoError(t, err)
+	assert.Equal(t, val, v)
+	assert.Equal(t, balance, b)
+
+	// Tx1 mark estimate
+	for _, v := range states[1].VersionedWrites(true) {
+		mvhm.MarkEstimate(v.Address, v.Path, v.Key, 1)
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("The code did not panic")
+		} else {
+			t.Log("Recovered in f", r)
+		}
+	}()
+
+	// Tx2 read again should get default (empty) vals because its dependency Tx1 is marked as estimate
+	states[2].GetState(addr, key, &v)
+	states[2].GetBalance(addr)
+
+	// Tx1 read again should get Tx0 vals
+	states[1].GetState(addr, key, &v)
+	assert.Equal(t, val, v)
+}
+
+func TestVersionMapOverwrite(t *testing.T) {
+	t.Parallel()
+
+	db := memdb.NewStateDB("")
+	defer db.Close()
+
+	agg, err := libstate.NewAggregator(context.Background(), datadir.New(""), 16, db, log.New())
+	assert.NoError(t, err)
+	defer agg.Close()
+
+	_db, err := temporal.New(db, agg)
+	assert.NoError(t, err)
+
+	tx, err := _db.BeginTemporalRw(context.Background()) //nolint:gocritic
+	assert.NoError(t, err)
+	defer tx.Rollback()
+
+	domains, err := libstate.NewSharedDomains(tx, log.New())
+	assert.NoError(t, err)
+	defer domains.Close()
+
+	domains.SetTxNum(1)
+	domains.SetBlockNum(1)
+	assert.NoError(t, err)
+	mvhm := NewVersionMap()
+	s := NewWithVersionMap(NewReaderV3(domains.AsGetter(tx)), mvhm)
+
+	states := []*IntraBlockState{s}
+
+	// Create copies of the original state for each transition
+	for i := 1; i <= 4; i++ {
+		sCopy := s.Copy()
+		sCopy.txIndex = i
+		states = append(states, sCopy)
+	}
+
+	addr := common.HexToAddress("0x01")
+	key := common.HexToHash("0x01")
+	val1 := *uint256.NewInt(1)
+	balance1 := uint256.NewInt(100)
+	val2 := *uint256.NewInt(2)
+	balance2 := uint256.NewInt(200)
+
+	var v uint256.Int
+
+	// Tx0 write
+	states[0].GetOrNewStateObject(addr)
+	states[0].SetState(addr, key, val1)
+	states[0].SetBalance(addr, *balance1, tracing.BalanceChangeUnspecified)
+	states[0].versionMap.FlushVersionedWrites(states[0].VersionedWrites(true), true, "")
+
+	// Tx1 write
+	states[1].SetState(addr, key, val2)
+	states[1].SetBalance(addr, *balance2, tracing.BalanceChangeUnspecified)
+	states[1].GetState(addr, key, &v)
+	b, err := states[1].GetBalance(addr)
+	assert.NoError(t, err)
+	states[1].versionMap.FlushVersionedWrites(states[1].VersionedWrites(true), true, "")
+
+	assert.Equal(t, val2, v)
+	assert.Equal(t, balance2, b)
+
+	// Tx2 read should get Tx1's value
+	states[2].GetState(addr, key, &v)
+	b, err = states[2].GetBalance(addr)
+	assert.NoError(t, err)
+	assert.Equal(t, val2, v)
+	assert.Equal(t, balance2, b)
+
+	// Tx1 delete
+	states[1].versionedWrites.Scan(func(v *VersionedWrite) bool {
+		mvhm.Delete(v.Address, v.Path, v.Key, 1, true)
+		return true
+	})
+	states[1].versionedWrites = nil
+
+	// Tx2 read should get Tx0's value
+	states[2].GetState(addr, key, &v)
+	b, err = states[2].GetBalance(addr)
+	assert.NoError(t, err)
+	assert.Equal(t, val1, v)
+	assert.Equal(t, balance1, b)
+
+	// Tx1 read should get Tx0's value
+	states[1].GetState(addr, key, &v)
+	b, err = states[1].GetBalance(addr)
+	assert.NoError(t, err)
+	assert.Equal(t, val1, v)
+	assert.Equal(t, balance1, b)
+
+	// Tx0 delete
+	states[0].versionedWrites.Scan(func(v *VersionedWrite) bool {
+		mvhm.Delete(v.Address, v.Path, v.Key, 1, true)
+		return true
+	})
+	states[0].versionedWrites = nil
+
+	// Tx2 read again should get default vals
+	states[2].GetState(addr, key, &v)
+	b, err = states[2].GetBalance(addr)
+	assert.NoError(t, err)
+	assert.Equal(t, *uint256.NewInt(0), v)
+	assert.Equal(t, uint256.NewInt(0), b)
+}
+
+func TestVersionMapWriteNoConflict(t *testing.T) {
+	t.Parallel()
+
+	db := memdb.NewStateDB("")
+	defer db.Close()
+
+	agg, err := libstate.NewAggregator(context.Background(), datadir.New(""), 16, db, log.New())
+	assert.NoError(t, err)
+	defer agg.Close()
+
+	_db, err := temporal.New(db, agg)
+	assert.NoError(t, err)
+
+	tx, err := _db.BeginTemporalRw(context.Background()) //nolint:gocritic
+	assert.NoError(t, err)
+	defer tx.Rollback()
+
+	domains, err := libstate.NewSharedDomains(tx, log.New())
+	assert.NoError(t, err)
+	defer domains.Close()
+
+	domains.SetTxNum(1)
+	domains.SetBlockNum(1)
+	assert.NoError(t, err)
+	mvhm := NewVersionMap()
+	s := NewWithVersionMap(NewReaderV3(domains.AsGetter(tx)), mvhm)
+
+	states := []*IntraBlockState{s}
+
+	// Create copies of the original state for each transition
+	for i := 1; i <= 4; i++ {
+		sCopy := s.Copy()
+		sCopy.txIndex = i
+		states = append(states, sCopy)
+	}
+
+	addr := common.HexToAddress("0x01")
+	key1 := common.HexToHash("0x01")
+	key2 := common.HexToHash("0x02")
+	val1 := *uint256.NewInt(1)
+	balance1 := uint256.NewInt(100)
+	val2 := *uint256.NewInt(2)
+
+	// Tx0 write
+	states[0].GetOrNewStateObject(addr)
+	states[0].versionMap.FlushVersionedWrites(states[0].VersionedWrites(true), true, "")
+
+	// Tx2 write
+	states[2].SetState(addr, key2, val2)
+	states[2].versionMap.FlushVersionedWrites(states[2].VersionedWrites(true), true, "")
+
+	// Tx1 write
+	tx1Snapshot := states[1].Snapshot()
+	states[1].SetState(addr, key1, val1)
+	states[1].SetBalance(addr, *balance1, tracing.BalanceChangeUnspecified)
+	states[1].versionMap.FlushVersionedWrites(states[1].VersionedWrites(true), true, "")
+
+	var v uint256.Int
+
+	// Tx1 read
+	states[1].GetState(addr, key1, &v)
+	assert.Equal(t, val1, v)
+	b, err := states[1].GetBalance(addr)
+	assert.NoError(t, err)
+	assert.Equal(t, balance1, b)
+	// Tx1 should see empty value in key2
+	states[1].GetState(addr, key2, &v)
+	assert.Equal(t, *uint256.NewInt(0), v)
+
+	// Tx2 read
+	states[2].GetState(addr, key2, &v)
+	assert.Equal(t, val2, v)
+	// Tx2 should see values written by Tx1
+	states[2].GetState(addr, key1, &v)
+	assert.Equal(t, val1, v)
+	b, err = states[2].GetBalance(addr)
+	assert.NoError(t, err)
+	assert.Equal(t, balance1, b)
+
+	// Tx3 read
+	states[3].GetState(addr, key1, &v)
+	assert.Equal(t, val1, v)
+	states[3].GetState(addr, key2, &v)
+	assert.Equal(t, val2, v)
+	b, err = states[3].GetBalance(addr)
+	assert.NoError(t, err)
+	assert.Equal(t, balance1, b)
+
+	// Tx2 delete
+	states[2].versionedWrites.Scan(func(v *VersionedWrite) bool {
+		mvhm.Delete(v.Address, v.Path, v.Key, 1, true)
+		return true
+	})
+	states[2].versionedWrites = nil
+
+	// Tx3 read
+	states[3].GetState(addr, key1, &v)
+	assert.Equal(t, val1, v)
+	b, err = states[3].GetBalance(addr)
+	assert.NoError(t, err)
+	assert.Equal(t, balance1, b)
+	// Tx3 should see empty value in key2
+	states[3].GetState(addr, key2, &v)
+	assert.Equal(t, *uint256.NewInt(0), v)
+
+	// Tx1 revert
+	states[1].RevertToSnapshot(tx1Snapshot, nil)
+	states[1].versionMap.FlushVersionedWrites(states[1].VersionedWrites(true), true, "")
+
+	// Tx3 read
+	states[3].GetState(addr, key1, &v)
+	assert.Equal(t, *uint256.NewInt(0), v)
+	states[3].GetState(addr, key2, &v)
+	assert.Equal(t, *uint256.NewInt(0), v)
+	b, err = states[3].GetBalance(addr)
+	assert.NoError(t, err)
+	assert.Equal(t, uint256.NewInt(0), b)
+
+	// Tx1 delete
+	states[1].versionedWrites.Scan(func(v *VersionedWrite) bool {
+		mvhm.Delete(v.Address, v.Path, v.Key, 1, true)
+		return true
+	})
+	states[1].versionedWrites = nil
+
+	// Tx3 read
+	states[3].GetState(addr, key1, &v)
+	assert.Equal(t, *uint256.NewInt(0), v)
+	states[3].GetState(addr, key2, &v)
+	assert.Equal(t, *uint256.NewInt(0), v)
+	b, err = states[3].GetBalance(addr)
+	assert.NoError(t, err)
+	assert.Equal(t, uint256.NewInt(0), b)
+}
+
+func TestApplyVersionedWrites(t *testing.T) {
+	t.Parallel()
+
+	db := memdb.NewStateDB("")
+	defer db.Close()
+
+	agg, err := libstate.NewAggregator(context.Background(), datadir.New(""), 16, db, log.New())
+	assert.NoError(t, err)
+	defer agg.Close()
+
+	_db, err := temporal.New(db, agg)
+	assert.NoError(t, err)
+
+	tx, err := _db.BeginTemporalRw(context.Background()) //nolint:gocritic
+	assert.NoError(t, err)
+	defer tx.Rollback()
+
+	domains, err := libstate.NewSharedDomains(tx, log.New())
+	assert.NoError(t, err)
+	defer domains.Close()
+	domains.SetTxNum(1)
+	domains.SetBlockNum(1)
+	assert.NoError(t, err)
+	mvhm := NewVersionMap()
+	s := NewWithVersionMap(NewReaderV3(domains.AsGetter(tx)), mvhm)
+
+	sClean := s.Copy()
+	sClean.versionMap = nil
+
+	sSingleProcess := sClean.Copy()
+
+	states := []*IntraBlockState{s}
+
+	// Create copies of the original state for each transition
+	for i := 1; i <= 4; i++ {
+		sCopy := s.Copy()
+		sCopy.txIndex = i
+		states = append(states, sCopy)
+	}
+
+	addr1 := common.HexToAddress("0x01")
+	addr2 := common.HexToAddress("0x02")
+	addr3 := common.HexToAddress("0x03")
+	key1 := common.HexToHash("0x01")
+	key2 := common.HexToHash("0x02")
+	val1 := *uint256.NewInt(1)
+	balance1 := uint256.NewInt(100)
+	val2 := *uint256.NewInt(2)
+	balance2 := uint256.NewInt(200)
+	code := []byte{1, 2, 3}
+
+	// Tx0 write
+	states[0].GetOrNewStateObject(addr1)
+	states[0].SetState(addr1, key1, val1)
+	states[0].SetBalance(addr1, *balance1, tracing.BalanceChangeUnspecified)
+	states[0].SetState(addr2, key2, val2)
+	states[0].GetOrNewStateObject(addr3)
+	states[0].FinalizeTx(&chain.Rules{}, NewWriter(domains.AsPutDel(tx), nil, 0))
+	states[0].versionMap.FlushVersionedWrites(states[0].VersionedWrites(true), true, "")
+
+	sSingleProcess.GetOrNewStateObject(addr1)
+	sSingleProcess.SetState(addr1, key1, val1)
+	sSingleProcess.SetBalance(addr1, *balance1, tracing.BalanceChangeUnspecified)
+	sSingleProcess.SetState(addr2, key2, val2)
+	sSingleProcess.GetOrNewStateObject(addr3)
+
+	sClean.ApplyVersionedWrites(states[0].VersionedWrites(true))
+
+	// Tx1 write
+	states[1].SetState(addr1, key2, val2)
+	states[1].SetBalance(addr1, *balance2, tracing.BalanceChangeUnspecified)
+	states[1].SetNonce(addr1, 1)
+	states[1].FinalizeTx(&chain.Rules{}, NewWriter(domains.AsPutDel(tx), nil, 0))
+	states[1].versionMap.FlushVersionedWrites(states[1].VersionedWrites(true), true, "")
+
+	sSingleProcess.SetState(addr1, key2, val2)
+	sSingleProcess.SetBalance(addr1, *balance2, tracing.BalanceChangeUnspecified)
+	sSingleProcess.SetNonce(addr1, 1)
+
+	sClean.ApplyVersionedWrites(states[1].VersionedWrites(true))
+
+	// Tx2 write
+	states[2].SetState(addr1, key1, val2)
+	states[2].SetBalance(addr1, *balance2, tracing.BalanceChangeUnspecified)
+	states[2].SetNonce(addr1, 2)
+	states[2].FinalizeTx(&chain.Rules{}, NewWriter(domains.AsPutDel(tx), nil, 0))
+	states[2].versionMap.FlushVersionedWrites(states[2].VersionedWrites(true), true, "")
+
+	sSingleProcess.SetState(addr1, key1, val2)
+	sSingleProcess.SetBalance(addr1, *balance2, tracing.BalanceChangeUnspecified)
+	sSingleProcess.SetNonce(addr1, 2)
+
+	sClean.ApplyVersionedWrites(states[2].VersionedWrites(true))
+
+	// Tx3 write
+	states[3].Selfdestruct(addr2)
+	states[3].SetCode(addr1, code)
+	states[3].FinalizeTx(&chain.Rules{}, NewWriter(domains.AsPutDel(tx), nil, 0))
+	states[3].versionMap.FlushVersionedWrites(states[3].VersionedWrites(true), true, "")
+
+	sSingleProcess.Selfdestruct(addr2)
+	sSingleProcess.SetCode(addr1, code)
+
+	sClean.ApplyVersionedWrites(states[3].VersionedWrites(true))
 }

--- a/core/state/intra_block_state_test.go
+++ b/core/state/intra_block_state_test.go
@@ -251,13 +251,13 @@ func (test *snapshotTest) run() bool {
 	}
 	defer agg.Close()
 
-	_db, err := temporal.New(db, agg)
+	tdb, err := temporal.New(db, agg)
 	if err != nil {
 		test.err = err
 		return false
 	}
 
-	tx, err := _db.BeginTemporalRw(context.Background()) //nolint:gocritic
+	tx, err := tdb.BeginTemporalRw(context.Background()) //nolint:gocritic
 	if err != nil {
 		test.err = err
 		return false
@@ -457,10 +457,10 @@ func TestVersionMapReadWriteDelete(t *testing.T) {
 	assert.NoError(t, err)
 	defer agg.Close()
 
-	_db, err := temporal.New(db, agg)
+	tdb, err := temporal.New(db, agg)
 	assert.NoError(t, err)
 
-	tx, err := _db.BeginTemporalRw(context.Background()) //nolint:gocritic
+	tx, err := tdb.BeginTemporalRw(context.Background()) //nolint:gocritic
 	assert.NoError(t, err)
 	defer tx.Rollback()
 
@@ -486,7 +486,7 @@ func TestVersionMapReadWriteDelete(t *testing.T) {
 	addr := common.HexToAddress("0x01")
 	key := common.HexToHash("0x01")
 	val := *uint256.NewInt(1)
-	balance := uint256.NewInt(100)
+	balance := *uint256.NewInt(100)
 
 	var v uint256.Int
 
@@ -498,7 +498,7 @@ func TestVersionMapReadWriteDelete(t *testing.T) {
 	// Tx1 write
 	states[1].GetOrNewStateObject(addr)
 	states[1].SetState(addr, key, val)
-	states[1].SetBalance(addr, *balance, tracing.BalanceChangeUnspecified)
+	states[1].SetBalance(addr, balance, tracing.BalanceChangeUnspecified)
 	states[1].versionMap.FlushVersionedWrites(states[1].VersionedWrites(true), true, "")
 
 	// Tx1 read
@@ -533,7 +533,7 @@ func TestVersionMapReadWriteDelete(t *testing.T) {
 	b, err = states[4].GetBalance(addr)
 	assert.NoError(t, err)
 	assert.Equal(t, *uint256.NewInt(0), v)
-	assert.Equal(t, uint256.NewInt(0), b)
+	assert.Equal(t, *uint256.NewInt(0), b)
 }
 
 func TestVersionMapRevert(t *testing.T) {
@@ -546,10 +546,10 @@ func TestVersionMapRevert(t *testing.T) {
 	assert.NoError(t, err)
 	defer agg.Close()
 
-	_db, err := temporal.New(db, agg)
+	tdb, err := temporal.New(db, agg)
 	assert.NoError(t, err)
 
-	tx, err := _db.BeginTemporalRw(context.Background()) //nolint:gocritic
+	tx, err := tdb.BeginTemporalRw(context.Background()) //nolint:gocritic
 	assert.NoError(t, err)
 	defer tx.Rollback()
 
@@ -574,12 +574,12 @@ func TestVersionMapRevert(t *testing.T) {
 	addr := common.HexToAddress("0x01")
 	key := common.HexToHash("0x01")
 	val := *uint256.NewInt(1)
-	balance := uint256.NewInt(100)
+	balance := *uint256.NewInt(100)
 
 	// Tx0 write
 	states[0].GetOrNewStateObject(addr)
 	states[0].SetState(addr, key, val)
-	states[0].SetBalance(addr, *balance, tracing.BalanceChangeUnspecified)
+	states[0].SetBalance(addr, balance, tracing.BalanceChangeUnspecified)
 	states[0].versionMap.FlushVersionedWrites(states[0].VersionedWrites(true), true, "")
 
 	var v uint256.Int
@@ -591,7 +591,7 @@ func TestVersionMapRevert(t *testing.T) {
 	states[1].GetState(addr, key, &v)
 	b, err := states[1].GetBalance(addr)
 	assert.NoError(t, err)
-	assert.Equal(t, uint256.NewInt(200), b)
+	assert.Equal(t, *uint256.NewInt(200), b)
 	assert.Equal(t, *uint256.NewInt(1), v)
 
 	states[1].Selfdestruct(addr)
@@ -624,10 +624,10 @@ func TestVersionMapMarkEstimate(t *testing.T) {
 	assert.NoError(t, err)
 	defer agg.Close()
 
-	_db, err := temporal.New(db, agg)
+	tdb, err := temporal.New(db, agg)
 	assert.NoError(t, err)
 
-	tx, err := _db.BeginTemporalRw(context.Background()) //nolint:gocritic
+	tx, err := tdb.BeginTemporalRw(context.Background()) //nolint:gocritic
 	assert.NoError(t, err)
 	defer tx.Rollback()
 
@@ -677,7 +677,7 @@ func TestVersionMapMarkEstimate(t *testing.T) {
 	b, err := states[2].GetBalance(addr)
 	assert.NoError(t, err)
 	assert.Equal(t, val, v)
-	assert.Equal(t, balance, b)
+	assert.Equal(t, *balance, b)
 
 	// Tx1 mark estimate
 	for _, v := range states[1].VersionedWrites(true) {
@@ -711,10 +711,10 @@ func TestVersionMapOverwrite(t *testing.T) {
 	assert.NoError(t, err)
 	defer agg.Close()
 
-	_db, err := temporal.New(db, agg)
+	tdb, err := temporal.New(db, agg)
 	assert.NoError(t, err)
 
-	tx, err := _db.BeginTemporalRw(context.Background()) //nolint:gocritic
+	tx, err := tdb.BeginTemporalRw(context.Background()) //nolint:gocritic
 	assert.NoError(t, err)
 	defer tx.Rollback()
 
@@ -816,10 +816,10 @@ func TestVersionMapWriteNoConflict(t *testing.T) {
 	assert.NoError(t, err)
 	defer agg.Close()
 
-	_db, err := temporal.New(db, agg)
+	tdb, err := temporal.New(db, agg)
 	assert.NoError(t, err)
 
-	tx, err := _db.BeginTemporalRw(context.Background()) //nolint:gocritic
+	tx, err := tdb.BeginTemporalRw(context.Background()) //nolint:gocritic
 	assert.NoError(t, err)
 	defer tx.Rollback()
 
@@ -846,7 +846,7 @@ func TestVersionMapWriteNoConflict(t *testing.T) {
 	key1 := common.HexToHash("0x01")
 	key2 := common.HexToHash("0x02")
 	val1 := *uint256.NewInt(1)
-	balance1 := uint256.NewInt(100)
+	balance1 := *uint256.NewInt(100)
 	val2 := *uint256.NewInt(2)
 
 	// Tx0 write
@@ -860,7 +860,7 @@ func TestVersionMapWriteNoConflict(t *testing.T) {
 	// Tx1 write
 	tx1Snapshot := states[1].Snapshot()
 	states[1].SetState(addr, key1, val1)
-	states[1].SetBalance(addr, *balance1, tracing.BalanceChangeUnspecified)
+	states[1].SetBalance(addr, balance1, tracing.BalanceChangeUnspecified)
 	states[1].versionMap.FlushVersionedWrites(states[1].VersionedWrites(true), true, "")
 
 	var v uint256.Int
@@ -922,7 +922,7 @@ func TestVersionMapWriteNoConflict(t *testing.T) {
 	assert.Equal(t, *uint256.NewInt(0), v)
 	b, err = states[3].GetBalance(addr)
 	assert.NoError(t, err)
-	assert.Equal(t, uint256.NewInt(0), b)
+	assert.Equal(t, *uint256.NewInt(0), b)
 
 	// Tx1 delete
 	states[1].versionedWrites.Scan(func(v *VersionedWrite) bool {
@@ -938,7 +938,7 @@ func TestVersionMapWriteNoConflict(t *testing.T) {
 	assert.Equal(t, *uint256.NewInt(0), v)
 	b, err = states[3].GetBalance(addr)
 	assert.NoError(t, err)
-	assert.Equal(t, uint256.NewInt(0), b)
+	assert.Equal(t, *uint256.NewInt(0), b)
 }
 
 func TestApplyVersionedWrites(t *testing.T) {
@@ -951,10 +951,10 @@ func TestApplyVersionedWrites(t *testing.T) {
 	assert.NoError(t, err)
 	defer agg.Close()
 
-	_db, err := temporal.New(db, agg)
+	tdb, err := temporal.New(db, agg)
 	assert.NoError(t, err)
 
-	tx, err := _db.BeginTemporalRw(context.Background()) //nolint:gocritic
+	tx, err := tdb.BeginTemporalRw(context.Background()) //nolint:gocritic
 	assert.NoError(t, err)
 	defer tx.Rollback()
 

--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -239,6 +239,7 @@ func (ch balanceChange) revert(s *IntraBlockState) error {
 	if s.versionMap != nil {
 		if obj.original.Balance == ch.prev {
 			s.versionedWrites.Delete(*ch.account, AccountKey{Path: BalancePath})
+			s.versionMap.Delete(*ch.account, BalancePath, common.Hash{}, s.txIndex, false)
 		} else {
 			if v, ok := s.versionedWrites[*ch.account][AccountKey{Path: BalancePath}]; ok {
 				v.Val = ch.prev
@@ -334,6 +335,7 @@ func (ch storageChange) revert(s *IntraBlockState) error {
 	if s.versionMap != nil {
 		if ch.wasCommited {
 			s.versionedWrites.Delete(*ch.account, AccountKey{Path: StatePath, Key: ch.key})
+			s.versionMap.Delete(*ch.account, StatePath, ch.key, s.txIndex, false)
 		} else {
 			if v, ok := s.versionedWrites[*ch.account][AccountKey{Path: StatePath, Key: ch.key}]; ok {
 				v.Val = ch.prevalue

--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -20,6 +20,8 @@
 package state
 
 import (
+	"fmt"
+
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/holiman/uint256"
 )
@@ -50,7 +52,6 @@ func newJournal() *journal {
 }
 func (j *journal) Reset() {
 	j.entries = j.entries[:0]
-	//j.dirties = make(map[common.Address]int, len(j.dirties)/2)
 	clear(j.dirties)
 }
 
@@ -101,39 +102,40 @@ type (
 		prev    *stateObject
 	}
 	selfdestructChange struct {
-		account     common.Address
+		account     *common.Address
 		prev        bool // whether account had already selfdestructed
 		prevbalance uint256.Int
 	}
 
 	// Changes to individual accounts.
 	balanceChange struct {
-		account common.Address
+		account *common.Address
 		prev    uint256.Int
 	}
 	balanceIncrease struct {
-		account  common.Address
+		account  *common.Address
 		increase uint256.Int
 	}
 	balanceIncreaseTransfer struct {
 		bi *BalanceIncrease
 	}
 	nonceChange struct {
-		account common.Address
+		account *common.Address
 		prev    uint64
 	}
 	storageChange struct {
-		account  common.Address
-		key      common.Hash
-		prevalue uint256.Int
+		account     *common.Address
+		key         common.Hash
+		prevalue    uint256.Int
+		wasCommited bool
 	}
 	fakeStorageChange struct {
-		account  common.Address
+		account  *common.Address
 		key      common.Hash
 		prevalue uint256.Int
 	}
 	codeChange struct {
-		account  common.Address
+		account  *common.Address
 		prevcode []byte
 		prevhash common.Hash
 	}
@@ -191,7 +193,7 @@ func (ch resetObjectChange) dirtied() *common.Address {
 }
 
 func (ch selfdestructChange) revert(s *IntraBlockState) error {
-	obj, err := s.getStateObject(ch.account)
+	obj, err := s.getStateObject(*ch.account)
 	if err != nil {
 		return err
 	}
@@ -199,11 +201,22 @@ func (ch selfdestructChange) revert(s *IntraBlockState) error {
 		obj.selfdestructed = ch.prev
 		obj.setBalance(ch.prevbalance)
 	}
+	if s.versionMap != nil {
+		if obj.original.Balance == ch.prevbalance {
+			s.versionedWrites.Delete(*ch.account, AccountKey{Path: BalancePath})
+		} else {
+			if v, ok := s.versionedWrites[*ch.account][AccountKey{Path: BalancePath}]; ok {
+				v.Val = ch.prev
+			}
+		}
+		s.versionedWrites.Delete(*ch.account, AccountKey{Path: SelfDestructPath})
+	}
+
 	return nil
 }
 
 func (ch selfdestructChange) dirtied() *common.Address {
-	return &ch.account
+	return ch.account
 }
 
 var ripemd = common.HexToAddress("0000000000000000000000000000000000000003")
@@ -215,31 +228,44 @@ func (ch touchChange) revert(s *IntraBlockState) error {
 func (ch touchChange) dirtied() *common.Address { return &ch.account }
 
 func (ch balanceChange) revert(s *IntraBlockState) error {
-	obj, err := s.getStateObject(ch.account)
+	obj, err := s.getStateObject(*ch.account)
 	if err != nil {
 		return err
 	}
+	if traceAccount(*ch.account) {
+		fmt.Printf("Revert Balance %x: %d, prev: %d, orig: %d\n", *ch.account, obj.data.Balance, ch.prev, obj.original.Balance)
+	}
 	obj.setBalance(ch.prev)
+	if s.versionMap != nil {
+		if obj.original.Balance == ch.prev {
+			s.versionedWrites.Delete(*ch.account, AccountKey{Path: BalancePath})
+		} else {
+			if v, ok := s.versionedWrites[*ch.account][AccountKey{Path: BalancePath}]; ok {
+				v.Val = ch.prev
+			}
+		}
+	}
+
 	return nil
 }
 
 func (ch balanceChange) dirtied() *common.Address {
-	return &ch.account
+	return ch.account
 }
 
 func (ch balanceIncrease) revert(s *IntraBlockState) error {
-	if bi, ok := s.balanceInc[ch.account]; ok {
+	if bi, ok := s.balanceInc[*ch.account]; ok {
 		bi.increase.Sub(&bi.increase, &ch.increase)
 		bi.count--
 		if bi.count == 0 {
-			delete(s.balanceInc, ch.account)
+			delete(s.balanceInc, *ch.account)
 		}
 	}
 	return nil
 }
 
 func (ch balanceIncrease) dirtied() *common.Address {
-	return &ch.account
+	return ch.account
 }
 
 func (ch balanceIncreaseTransfer) dirtied() *common.Address {
@@ -251,46 +277,79 @@ func (ch balanceIncreaseTransfer) revert(s *IntraBlockState) error {
 	return nil
 }
 func (ch nonceChange) revert(s *IntraBlockState) error {
-	obj, err := s.getStateObject(ch.account)
+	obj, err := s.getStateObject(*ch.account)
 	if err != nil {
 		return err
 	}
 	obj.setNonce(ch.prev)
+	if s.versionMap != nil {
+		if obj.original.Nonce == ch.prev {
+			s.versionedWrites.Delete(*ch.account, AccountKey{Path: NoncePath})
+		} else {
+			if v, ok := s.versionedWrites[*ch.account][AccountKey{Path: NoncePath}]; ok {
+				v.Val = ch.prev
+			}
+		}
+	}
+
 	return nil
 }
 
 func (ch nonceChange) dirtied() *common.Address {
-	return &ch.account
+	return ch.account
 }
 
 func (ch codeChange) revert(s *IntraBlockState) error {
-	obj, err := s.getStateObject(ch.account)
+	obj, err := s.getStateObject(*ch.account)
 	if err != nil {
 		return err
 	}
 	obj.setCode(ch.prevhash, ch.prevcode)
+	if s.versionMap != nil {
+		if obj.original.CodeHash == ch.prevhash {
+			s.versionedWrites.Delete(*ch.account, AccountKey{Path: CodePath})
+			s.versionedWrites.Delete(*ch.account, AccountKey{Path: CodeHashPath})
+		} else {
+			if v, ok := s.versionedWrites[*ch.account][AccountKey{Path: CodePath}]; ok {
+				v.Val = ch.prevcode
+			}
+			if v, ok := s.versionedWrites[*ch.account][AccountKey{Path: CodeHashPath}]; ok {
+				v.Val = ch.prevhash
+			}
+		}
+	}
 	return nil
 }
 
 func (ch codeChange) dirtied() *common.Address {
-	return &ch.account
+	return ch.account
 }
 
 func (ch storageChange) revert(s *IntraBlockState) error {
-	obj, err := s.getStateObject(ch.account)
+	obj, err := s.getStateObject(*ch.account)
 	if err != nil {
 		return err
+	}
+
+	if s.versionMap != nil {
+		if ch.wasCommited {
+			s.versionedWrites.Delete(*ch.account, AccountKey{Path: StatePath, Key: ch.key})
+		} else {
+			if v, ok := s.versionedWrites[*ch.account][AccountKey{Path: StatePath, Key: ch.key}]; ok {
+				v.Val = ch.prevalue
+			}
+		}
 	}
 	obj.setState(ch.key, ch.prevalue)
 	return nil
 }
 
 func (ch storageChange) dirtied() *common.Address {
-	return &ch.account
+	return ch.account
 }
 
 func (ch fakeStorageChange) revert(s *IntraBlockState) error {
-	obj, err := s.getStateObject(ch.account)
+	obj, err := s.getStateObject(*ch.account)
 	if err != nil {
 		return err
 	}
@@ -299,7 +358,7 @@ func (ch fakeStorageChange) revert(s *IntraBlockState) error {
 }
 
 func (ch fakeStorageChange) dirtied() *common.Address {
-	return &ch.account
+	return ch.account
 }
 
 func (ch transientStorageChange) revert(s *IntraBlockState) error {
@@ -321,6 +380,9 @@ func (ch refundChange) dirtied() *common.Address {
 }
 
 func (ch addLogChange) revert(s *IntraBlockState) error {
+	if ch.txIndex >= len(s.logs) {
+		panic(fmt.Sprintf("can't revert log index %v, max: %v", ch.txIndex, len(s.logs)-1))
+	}
 	txnLogs := s.logs[ch.txIndex]
 	s.logs[ch.txIndex] = txnLogs[:len(txnLogs)-1] // revert 1 log
 	if len(s.logs[ch.txIndex]) == 0 {

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -24,11 +24,13 @@ import (
 	"io"
 	"maps"
 	"math/big"
+	"time"
 
 	"github.com/holiman/uint256"
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/empty"
+	"github.com/erigontech/erigon-lib/common/u256"
 	"github.com/erigontech/erigon-lib/rlp"
 	"github.com/erigontech/erigon-lib/types/accounts"
 	"github.com/erigontech/erigon/core/tracing"
@@ -92,6 +94,22 @@ func (so *stateObject) empty() bool {
 	return so.data.Nonce == 0 && so.data.Balance.IsZero() && (so.data.CodeHash == empty.CodeHash)
 }
 
+func (s *stateObject) deepCopy(db *IntraBlockState) *stateObject {
+	stateObject := &stateObject{db: db, address: s.address}
+	stateObject.data.Copy(&s.data)
+	stateObject.original.Copy(&s.original)
+	stateObject.code = s.code
+	stateObject.dirtyStorage = s.dirtyStorage.Copy()
+	stateObject.originStorage = s.originStorage.Copy()
+	stateObject.blockOriginStorage = s.blockOriginStorage.Copy()
+	stateObject.selfdestructed = s.selfdestructed
+	stateObject.dirtyCode = s.dirtyCode
+	stateObject.deleted = s.deleted
+	stateObject.newlyCreated = s.newlyCreated
+	stateObject.createdContract = s.createdContract
+	return stateObject
+}
+
 // newObject creates a state object.
 func newObject(db *IntraBlockState, address common.Address, data, original *accounts.Account) *stateObject {
 	var so = stateObject{
@@ -121,13 +139,6 @@ func (so *stateObject) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, so.data)
 }
 
-// setError remembers the first non-nil error it is called with.
-func (so *stateObject) setError(err error) {
-	if so.db.savedErr == nil {
-		so.db.savedErr = err
-	}
-}
-
 func (so *stateObject) markSelfdestructed() {
 	so.selfdestructed = true
 }
@@ -144,84 +155,106 @@ func (so *stateObject) touch() {
 }
 
 // GetState returns a value from account storage.
-func (so *stateObject) GetState(key common.Hash, out *uint256.Int) {
+func (so *stateObject) GetState(key common.Hash, out *uint256.Int) bool {
 	// If the fake storage is set, only lookup the state here(in the debugging mode)
 	if so.fakeStorage != nil {
 		*out = so.fakeStorage[key]
-		return
+		return false
 	}
 	value, dirty := so.dirtyStorage[key]
 	if dirty {
 		*out = value
-		return
+		return false
 	}
 	// Otherwise return the entry's original value
 	so.GetCommittedState(key, out)
+	return true
 }
 
 // GetCommittedState retrieves a value from the committed account storage trie.
-func (so *stateObject) GetCommittedState(key common.Hash, out *uint256.Int) {
+func (so *stateObject) GetCommittedState(key common.Hash, out *uint256.Int) error {
 	// If the fake storage is set, only lookup the state here(in the debugging mode)
 	if so.fakeStorage != nil {
 		*out = so.fakeStorage[key]
-		return
+		return nil
 	}
 	// If we have the original value cached, return that
 	{
 		value, cached := so.originStorage[key]
 		if cached {
 			*out = value
-			return
+			return nil
 		}
 	}
 	if so.createdContract {
 		out.Clear()
-		return
+		return nil
 	}
 	// Load from DB in case it is missing.
-	enc, err := so.db.stateReader.ReadAccountStorage(so.address, key)
+	readStart := time.Now()
+	res, ok, err := so.db.stateReader.ReadAccountStorage(so.address, key)
+	so.db.storageReadDuration += time.Since(readStart)
+	so.db.storageReadCount++
+
 	if err != nil {
-		so.setError(err)
 		out.Clear()
-		return
+		return err
 	}
-	if enc != nil {
-		out.SetBytes(enc)
-	} else {
-		out.Clear()
+	if ok {
+		*out = res
+		so.originStorage[key] = res
+		so.blockOriginStorage[key] = res
 	}
-	so.originStorage[key] = *out
-	so.blockOriginStorage[key] = *out
+	return nil
 }
 
 // SetState updates a value in account storage.
-func (so *stateObject) SetState(key common.Hash, value uint256.Int) {
+func (so *stateObject) SetState(key common.Hash, value uint256.Int, force bool) bool {
 	// If the fake storage is set, put the temporary state update here.
 	if so.fakeStorage != nil {
 		so.db.journal.append(fakeStorageChange{
-			account:  so.address,
+			account:  &so.address,
 			key:      key,
 			prevalue: so.fakeStorage[key],
 		})
 		so.fakeStorage[key] = value
-		return
+		return true
 	}
 	// If the new value is the same as old, don't set
 	var prev uint256.Int
-	so.GetState(key, &prev)
-	if prev == value {
-		return
+	var commited bool
+
+	// we need to use versioned read here otherwise we will miss versionmap entries
+	prev, _, _ = versionedRead(so.db, so.address, StatePath, key, false, *u256.N0,
+		func(v uint256.Int) uint256.Int {
+			return v
+		},
+		func(s *stateObject) (uint256.Int, error) {
+			var value uint256.Int
+			if s != nil && !s.deleted {
+				commited = s.GetState(key, &value)
+			}
+			return value, nil
+		})
+
+	if !force && prev == value {
+		return false
 	}
+
 	// New value is different, update and journal the change
 	so.db.journal.append(storageChange{
-		account:  so.address,
-		key:      key,
-		prevalue: prev,
+		account:     &so.address,
+		key:         key,
+		prevalue:    prev,
+		wasCommited: commited,
 	})
+
 	if so.db.tracingHooks != nil && so.db.tracingHooks.OnStorageChange != nil {
 		so.db.tracingHooks.OnStorageChange(so.address, key, prev, value)
 	}
 	so.setState(key, value)
+
+	return true
 }
 
 // SetStorage replaces the entire state storage with the given one.
@@ -246,8 +279,8 @@ func (so *stateObject) setState(key common.Hash, value uint256.Int) {
 	so.dirtyStorage[key] = value
 }
 
-// updateTrie writes cached storage modifications into the object's storage trie.
-func (so *stateObject) updateTrie(stateWriter StateWriter) error {
+// updateStotage writes cached storage modifications into the object's storage trie.
+func (so *stateObject) updateStotage(stateWriter StateWriter) error {
 	for key, value := range so.dirtyStorage {
 		if err := stateWriter.WriteAccountStorage(so.address, so.data.GetIncarnation(), key, so.blockOriginStorage[key], value); err != nil {
 			return err
@@ -262,37 +295,9 @@ func (so *stateObject) printTrie() {
 	}
 }
 
-// AddBalance adds amount to so's balance.
-// It is used to add funds to the destination account of a transfer.
-func (so *stateObject) AddBalance(amount *uint256.Int, reason tracing.BalanceChangeReason) {
-	// EIP161: We must check emptiness for the objects such that the account
-	// clearing (0,0,0 objects) can take effect.
-	if amount.IsZero() {
-		if so.empty() {
-			so.touch()
-		}
-
-		return
-	}
-	var newBalance uint256.Int
-	newBalance.Add(so.Balance(), amount)
-	so.SetBalance(newBalance, reason)
-}
-
-// SubBalance removes amount from so's balance.
-// It is used to remove funds from the origin account of a transfer.
-func (so *stateObject) SubBalance(amount *uint256.Int, reason tracing.BalanceChangeReason) {
-	if amount.IsZero() {
-		return
-	}
-	var newBalance uint256.Int
-	newBalance.Sub(so.Balance(), amount)
-	so.SetBalance(newBalance, reason)
-}
-
 func (so *stateObject) SetBalance(amount uint256.Int, reason tracing.BalanceChangeReason) {
 	so.db.journal.append(balanceChange{
-		account: so.address,
+		account: &so.address,
 		prev:    so.data.Balance,
 	})
 	if so.db.tracingHooks != nil && so.db.tracingHooks.OnBalanceChange != nil {
@@ -323,25 +328,33 @@ func (so *stateObject) Address() common.Address {
 }
 
 // Code returns the contract code associated with this object, if any.
-func (so *stateObject) Code() []byte {
+func (so *stateObject) Code() ([]byte, error) {
 	if so.code != nil {
-		return so.code
+		return so.code, nil
 	}
 	if so.data.CodeHash == empty.CodeHash {
-		return nil
+		return nil, nil
 	}
+
+	readStart := time.Now()
 	code, err := so.db.stateReader.ReadAccountCode(so.Address())
+	so.db.storageReadDuration += time.Since(readStart)
+	so.db.storageReadCount++
+
 	if err != nil {
-		so.setError(fmt.Errorf("can't load code hash %x: %w", so.data.CodeHash, err))
+		return nil, fmt.Errorf("can't code for %x: %w", so.Address(), err)
 	}
 	so.code = code
-	return code
+	return code, nil
 }
 
-func (so *stateObject) SetCode(codeHash common.Hash, code []byte) {
-	prevcode := so.Code()
+func (so *stateObject) SetCode(codeHash common.Hash, code []byte) error {
+	prevcode, err := so.Code()
+	if err != nil {
+		return err
+	}
 	so.db.journal.append(codeChange{
-		account:  so.address,
+		account:  &so.address,
 		prevhash: so.data.CodeHash,
 		prevcode: prevcode,
 	})
@@ -349,6 +362,7 @@ func (so *stateObject) SetCode(codeHash common.Hash, code []byte) {
 		so.db.tracingHooks.OnCodeChange(so.address, so.data.CodeHash, prevcode, codeHash, code)
 	}
 	so.setCode(codeHash, code)
+	return nil
 }
 
 func (so *stateObject) setCode(codeHash common.Hash, code []byte) {
@@ -359,7 +373,7 @@ func (so *stateObject) setCode(codeHash common.Hash, code []byte) {
 
 func (so *stateObject) SetNonce(nonce uint64) {
 	so.db.journal.append(nonceChange{
-		account: so.address,
+		account: &so.address,
 		prev:    so.data.Nonce,
 	})
 	if so.db.tracingHooks != nil && so.db.tracingHooks.OnNonceChange != nil {
@@ -372,12 +386,16 @@ func (so *stateObject) setNonce(nonce uint64) {
 	so.data.Nonce = nonce
 }
 
-func (so *stateObject) Balance() *uint256.Int {
-	return &so.data.Balance
+func (so *stateObject) Balance() uint256.Int {
+	return so.data.Balance
 }
 
 func (so *stateObject) Nonce() uint64 {
 	return so.data.Nonce
+}
+
+func (so *stateObject) IsDirty() bool {
+	return so.dirtyCode || len(so.dirtyStorage) > 0 || so.data != so.original
 }
 
 // Never called, but must be present to allow stateObject to be used

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -208,6 +208,8 @@ func (so *stateObject) GetCommittedState(key common.Hash, out *uint256.Int) erro
 
 	so.originStorage[key] = *out
 	so.blockOriginStorage[key] = *out
+
+	return err
 }
 
 // SetState updates a value in account storage.

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/erigontech/erigon-lib/kv/temporal"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon-lib/state"
-	stateLib "github.com/erigontech/erigon-lib/state"
 	"github.com/erigontech/erigon-lib/types/accounts"
 	"github.com/erigontech/erigon/core/tracing"
 )
@@ -59,7 +58,7 @@ func (s *StateSuite) TestDump(c *checker.C) {
 	// generate a few entries
 	obj1, err := s.state.GetOrNewStateObject(toAddr([]byte{0x01}))
 	c.Check(err, checker.IsNil)
-	obj1.AddBalance(uint256.NewInt(22), tracing.BalanceChangeUnspecified)
+	s.state.AddBalance(toAddr([]byte{0x01}), *uint256.NewInt(22), tracing.BalanceChangeUnspecified)
 	obj2, err := s.state.GetOrNewStateObject(toAddr([]byte{0x01, 0x02}))
 	c.Check(err, checker.IsNil)
 	obj2.SetCode(crypto.Keccak256Hash([]byte{3, 3, 3, 3, 3, 3, 3}), []byte{3, 3, 3, 3, 3, 3, 3})
@@ -122,7 +121,7 @@ func (s *StateSuite) SetUpTest(c *checker.C) {
 	db := memdb.NewStateDB("")
 	defer db.Close()
 
-	agg, err := stateLib.NewAggregator(context.Background(), datadir.New(""), 16, db, log.New())
+	agg, err := state.NewAggregator(context.Background(), datadir.New(""), 16, db, log.New())
 	if err != nil {
 		panic(err)
 	}
@@ -139,7 +138,7 @@ func (s *StateSuite) SetUpTest(c *checker.C) {
 	}
 	defer tx.Rollback()
 
-	domains, err := stateLib.NewSharedDomains(tx, log.New())
+	domains, err := state.NewSharedDomains(tx, log.New())
 	if err != nil {
 		panic(err)
 	}
@@ -199,12 +198,12 @@ func (s *StateSuite) TestTouchDelete(c *checker.C) {
 	s.state.Reset()
 
 	snapshot := s.state.Snapshot()
-	s.state.AddBalance(common.Address{}, new(uint256.Int), tracing.BalanceChangeUnspecified)
+	s.state.AddBalance(common.Address{}, uint256.Int{}, tracing.BalanceChangeUnspecified)
 
 	if len(s.state.journal.dirties) != 1 {
 		c.Fatal("expected one dirty state object")
 	}
-	s.state.RevertToSnapshot(snapshot)
+	s.state.RevertToSnapshot(snapshot, nil)
 	if len(s.state.journal.dirties) != 0 {
 		c.Fatal("expected no dirty state object")
 	}
@@ -225,7 +224,7 @@ func (s *StateSuite) TestSnapshot(c *checker.C) {
 
 	// set a new state object value, revert it and ensure correct content
 	s.state.SetState(stateobjaddr, storageaddr, *data2)
-	s.state.RevertToSnapshot(snapshot)
+	s.state.RevertToSnapshot(snapshot, nil)
 
 	var value uint256.Int
 	s.state.GetState(stateobjaddr, storageaddr, &value)
@@ -234,7 +233,7 @@ func (s *StateSuite) TestSnapshot(c *checker.C) {
 	c.Assert(value, checker.DeepEquals, common.Hash{})
 
 	// revert up to the genesis state and ensure correct content
-	s.state.RevertToSnapshot(genesis)
+	s.state.RevertToSnapshot(genesis, nil)
 	s.state.GetState(stateobjaddr, storageaddr, &value)
 	c.Assert(value, checker.DeepEquals, common.Hash{})
 	s.state.GetCommittedState(stateobjaddr, storageaddr, &value)
@@ -242,7 +241,7 @@ func (s *StateSuite) TestSnapshot(c *checker.C) {
 }
 
 func (s *StateSuite) TestSnapshotEmpty(c *checker.C) {
-	s.state.RevertToSnapshot(s.state.Snapshot())
+	s.state.RevertToSnapshot(s.state.Snapshot(), nil)
 }
 
 // use testing instead of checker because checker does not support
@@ -252,7 +251,7 @@ func TestSnapshot2(t *testing.T) {
 	t.Parallel()
 	_, tx, _ := NewTestTemporalDb(t)
 
-	domains, err := stateLib.NewSharedDomains(tx, log.New())
+	domains, err := state.NewSharedDomains(tx, log.New())
 	require.NoError(t, err)
 	defer domains.Close()
 
@@ -317,7 +316,7 @@ func TestSnapshot2(t *testing.T) {
 	}
 
 	snapshot := state.Snapshot()
-	state.RevertToSnapshot(snapshot)
+	state.RevertToSnapshot(snapshot, nil)
 
 	so0Restored, err := state.getStateObject(stateobjaddr0)
 	if err != nil {
@@ -344,7 +343,9 @@ func compareStateObjects(so0, so1 *stateObject, t *testing.T) {
 	if so0.Address() != so1.Address() {
 		t.Fatalf("Address mismatch: have %v, want %v", so0.address, so1.address)
 	}
-	if so0.Balance().Cmp(so1.Balance()) != 0 {
+	bal0 := so0.Balance()
+	bal1 := so1.Balance()
+	if bal0.Cmp(&bal1) != 0 {
 		t.Fatalf("Balance mismatch: have %v, want %v", so0.Balance(), so1.Balance())
 	}
 	if so0.Nonce() != so1.Nonce() {
@@ -432,7 +433,7 @@ func TestDump(t *testing.T) {
 	// generate a few entries
 	obj1, err := st.GetOrNewStateObject(toAddr([]byte{0x01}))
 	require.NoError(t, err)
-	obj1.AddBalance(uint256.NewInt(22), tracing.BalanceChangeUnspecified)
+	st.AddBalance(toAddr([]byte{0x01}), *uint256.NewInt(22), tracing.BalanceChangeUnspecified)
 	obj2, err := st.GetOrNewStateObject(toAddr([]byte{0x01, 0x02}))
 	require.NoError(t, err)
 	obj2.SetCode(crypto.Keccak256Hash([]byte{3, 3, 3, 3, 3, 3, 3}), []byte{3, 3, 3, 3, 3, 3, 3})

--- a/core/state/versionedio.go
+++ b/core/state/versionedio.go
@@ -1,8 +1,10 @@
 package state
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/dbg"
@@ -174,13 +176,13 @@ func valueString(path AccountPath, value any) string {
 		num := value.(uint256.Int)
 		return fmt.Sprintf("%x", &num)
 	case NoncePath:
-		return fmt.Sprintf("%d", value.(uint64))
+		return strconv.FormatUint(value.(uint64), 10)
 	case CodePath:
 		l := len(value.([]byte))
 		if l > 40 {
 			l = 40
 		}
-		return fmt.Sprintf("%x", value.([]byte)[0:l])
+		return hex.EncodeToString(value.([]byte)[0:l])
 	}
 
 	return fmt.Sprint(value)

--- a/core/tracing/hooks.go
+++ b/core/tracing/hooks.go
@@ -44,7 +44,7 @@ type OpContext interface {
 
 // IntraBlockState gives tracers access to the whole state.
 type IntraBlockState interface {
-	GetBalance(common.Address) (*uint256.Int, error)
+	GetBalance(common.Address) (uint256.Int, error)
 	GetNonce(common.Address) (uint64, error)
 	GetCode(common.Address) ([]byte, error)
 	GetState(addr common.Address, key common.Hash, value *uint256.Int) error

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -98,7 +98,7 @@ func opSelfBalance(pc *uint64, interpreter *EVMInterpreter, callContext *ScopeCo
 	if err != nil {
 		return nil, err
 	}
-	callContext.Stack.push(balance)
+	callContext.Stack.push(&balance)
 	return nil, nil
 }
 

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -246,7 +246,7 @@ func (evm *EVM) call(typ OpCode, caller ContractRef, addr common.Address, input 
 		// This doesn't matter on Mainnet, where all empties are gone at the time of Byzantium,
 		// but is the correct thing to do and matters on other networks, in tests, and potential
 		// future scenarios
-		evm.intraBlockState.AddBalance(addr, u256.Num0, tracing.BalanceChangeTouchAccount)
+		evm.intraBlockState.AddBalance(addr, *u256.Num0, tracing.BalanceChangeTouchAccount)
 	}
 
 	// It is allowed to call precompiles, even via delegatecall
@@ -288,7 +288,7 @@ func (evm *EVM) call(typ OpCode, caller ContractRef, addr common.Address, input 
 	// above we revert to the snapshot and consume any gas remaining. Additionally
 	// when we're in Homestead this also counts for code storage gas errors.
 	if err != nil || evm.config.RestoreState {
-		evm.intraBlockState.RevertToSnapshot(snapshot)
+		evm.intraBlockState.RevertToSnapshot(snapshot, err)
 		if err != ErrExecutionReverted {
 			if evm.config.Tracer != nil && evm.config.Tracer.OnGasChange != nil {
 				evm.Config().Tracer.OnGasChange(gas, 0, tracing.GasChangeCallFailedExecution)
@@ -467,7 +467,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gasRemainin
 	// above we revert to the snapshot and consume any gas remaining. Additionally
 	// when we're in homestead this also counts for code storage gas errors.
 	if err != nil && (evm.chainRules.IsHomestead || err != ErrCodeStoreOutOfGas) {
-		evm.intraBlockState.RevertToSnapshot(snapshot)
+		evm.intraBlockState.RevertToSnapshot(snapshot, nil)
 		if err != ErrExecutionReverted {
 			contract.UseGas(contract.Gas, evm.Config().Tracer, tracing.GasChangeCallFailedExecution)
 		}

--- a/core/vm/evmtypes/evmtypes.go
+++ b/core/vm/evmtypes/evmtypes.go
@@ -64,14 +64,16 @@ type TxContext struct {
 // ExecutionResult includes all output after executing given evm
 // message no matter the execution itself is successful or not.
 type ExecutionResult struct {
-	GasUsed             uint64 // Total used gas but include the refunded gas
-	Err                 error  // Any error encountered during the execution(listed in core/vm/errors.go)
-	Reverted            bool   // Whether the execution was aborted by `REVERT`
-	ReturnData          []byte // Returned data from evm(function result or data supplied with revert opcode)
-	SenderInitBalance   *uint256.Int
-	CoinbaseInitBalance *uint256.Int
-	FeeTipped           *uint256.Int
-	EvmRefund           uint64 // Gas refunded by EVM without considering refundQuotient
+	GasUsed              uint64 // Total used gas but include the refunded gas
+	Err                  error  // Any error encountered during the execution(listed in core/vm/errors.go)
+	Reverted             bool   // Whether the execution was aborted by `REVERT`
+	ReturnData           []byte // Returned data from evm(function result or data supplied with revert opcode)
+	SenderInitBalance    uint256.Int
+	CoinbaseInitBalance  uint256.Int
+	FeeTipped            uint256.Int
+	FeeBurnt             uint256.Int
+	BurntContractAddress common.Address
+	EvmRefund            uint64 // Gas refunded by EVM without considering refundQuotient
 }
 
 // Unwrap returns the internal evm error which allows us for further
@@ -119,9 +121,9 @@ type (
 
 // IntraBlockState is an EVM database for full state querying.
 type IntraBlockState interface {
-	SubBalance(common.Address, *uint256.Int, tracing.BalanceChangeReason) error
-	AddBalance(common.Address, *uint256.Int, tracing.BalanceChangeReason) error
-	GetBalance(common.Address) (*uint256.Int, error)
+	SubBalance(common.Address, uint256.Int, tracing.BalanceChangeReason) error
+	AddBalance(common.Address, uint256.Int, tracing.BalanceChangeReason) error
+	GetBalance(common.Address) (uint256.Int, error)
 
 	AddLog(*types.Log)
 

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -384,7 +384,7 @@ func opBalance(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
 	}
-	slot.Set(balance)
+	slot.Set(&balance)
 	return nil, nil
 }
 
@@ -1218,7 +1218,7 @@ func opSelfdestruct(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 		return nil, err
 	}
 
-	balanceVal := *balance
+	balanceVal := balance
 	interpreter.evm.IntraBlockState().AddBalance(beneficiaryAddr, balance, tracing.BalanceIncreaseSelfdestruct)
 	interpreter.evm.IntraBlockState().Selfdestruct(callerAddr)
 	if interpreter.evm.Config().Tracer != nil && interpreter.evm.Config().Tracer.OnEnter != nil {
@@ -1241,9 +1241,9 @@ func opSelfdestruct6780(pc *uint64, interpreter *EVMInterpreter, scope *ScopeCon
 	if err != nil {
 		return nil, err
 	}
-	balanceVal := *balance
-	interpreter.evm.IntraBlockState().SubBalance(callerAddr, &balanceVal, tracing.BalanceDecreaseSelfdestruct)
-	interpreter.evm.IntraBlockState().AddBalance(beneficiaryAddr, &balanceVal, tracing.BalanceIncreaseSelfdestruct)
+	balanceVal := balance
+	interpreter.evm.IntraBlockState().SubBalance(callerAddr, balanceVal, tracing.BalanceDecreaseSelfdestruct)
+	interpreter.evm.IntraBlockState().AddBalance(beneficiaryAddr, balanceVal, tracing.BalanceIncreaseSelfdestruct)
 	interpreter.evm.IntraBlockState().Selfdestruct6780(callerAddr)
 	if interpreter.evm.Config().Tracer != nil && interpreter.evm.Config().Tracer.OnEnter != nil {
 		interpreter.cfg.Tracer.OnEnter(interpreter.depth, byte(SELFDESTRUCT), scope.Contract.Address(), beneficiary.Bytes20(), false, []byte{}, 0, &balanceVal, nil)

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -254,6 +254,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		logged  bool   // deferred Tracer should ignore already logged steps
 		res     []byte // result of the opcode execution function
 		debug   = in.cfg.Tracer != nil && (in.cfg.Tracer.OnOpcode != nil || in.cfg.Tracer.OnGasChange != nil || in.cfg.Tracer.OnFault != nil)
+		trace   = dbg.TraceInstructions && in.evm.intraBlockState.Trace()
 	)
 
 	contract.Input = input
@@ -290,9 +291,10 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 	// the execution of one of the operations or until the done flag is set by the
 	// parent context.
 	steps := 0
+
 	for {
 		steps++
-		if steps%1000 == 0 && in.evm.Cancelled() {
+		if steps%5000 == 0 && in.evm.Cancelled() {
 			break
 		}
 		if debug {
@@ -357,7 +359,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		}
 
 		// TODO - move this to a trace & set in the worker
-		if dbg.TraceInstructions && in.evm.intraBlockState.Trace() {
+		if trace {
 			var str string
 			if operation.string != nil {
 				str = operation.string(*pc, callContext)

--- a/eth/stagedsync/stage_mining_exec.go
+++ b/eth/stagedsync/stage_mining_exec.go
@@ -442,7 +442,7 @@ func addTransactionsToMiningBlock(
 	noop := state.NewNoopWriter()
 
 	var miningCommitTx = func(txn types.Transaction, coinbase common.Address, vmConfig *vm.Config, chainConfig *chain.Config, ibs *state.IntraBlockState, current *MiningBlock) ([]*types.Log, error) {
-		ibs.SetTxContext(current.Header.Number.Uint64(),txnIdx)
+		ibs.SetTxContext(current.Header.Number.Uint64(), txnIdx)
 		gasSnap := gasPool.Gas()
 		blobGasSnap := gasPool.BlobGas()
 		snap := ibs.Snapshot()

--- a/eth/tracers/internal/tracetest/calltrace_test.go
+++ b/eth/tracers/internal/tracetest/calltrace_test.go
@@ -283,7 +283,7 @@ func benchTracer(b *testing.B, tracerName string, test *callTracerTest) {
 		if _, err = tracer.GetResult(); err != nil {
 			b.Fatal(err)
 		}
-		statedb.RevertToSnapshot(snap)
+		statedb.RevertToSnapshot(snap, nil)
 	}
 }
 

--- a/execution/abi/bind/backends/simulated.go
+++ b/execution/abi/bind/backends/simulated.go
@@ -215,7 +215,8 @@ func (b *SimulatedBackend) BalanceAt(ctx context.Context, contract common.Addres
 	}
 	defer tx.Rollback()
 	stateDB := b.stateByBlockNumber(tx, blockNumber)
-	return stateDB.GetBalance(contract)
+	balance, err := stateDB.GetBalance(contract)
+	return &balance, err
 }
 
 // NonceAt returns the nonce of a certain account in the blockchain.
@@ -576,7 +577,7 @@ func (b *SimulatedBackend) CallContract(ctx context.Context, call ethereum.CallM
 func (b *SimulatedBackend) PendingCallContract(ctx context.Context, call ethereum.CallMsg) ([]byte, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	defer b.pendingState.RevertToSnapshot(b.pendingState.Snapshot())
+	defer b.pendingState.RevertToSnapshot(b.pendingState.Snapshot(), nil)
 
 	res, err := b.callContract(ctx, call, b.pendingBlock, b.pendingState)
 	if err != nil {
@@ -646,7 +647,7 @@ func (b *SimulatedBackend) EstimateGas(ctx context.Context, call ethereum.CallMs
 		}
 	}
 	gasCap = hi
-	b.pendingState.SetTxContext(len(b.pendingBlock.Transactions()))
+	b.pendingState.SetTxContext(b.pendingBlock.Copy().NumberU64(), len(b.pendingBlock.Transactions()))
 
 	// Create a helper to check if a gas allowance results in an executable transaction
 	executable := func(gas uint64) (bool, *evmtypes.ExecutionResult, error) {
@@ -654,7 +655,7 @@ func (b *SimulatedBackend) EstimateGas(ctx context.Context, call ethereum.CallMs
 
 		snapshot := b.pendingState.Snapshot()
 		res, err := b.callContract(ctx, call, b.pendingBlock, b.pendingState)
-		b.pendingState.RevertToSnapshot(snapshot)
+		b.pendingState.RevertToSnapshot(snapshot, nil)
 
 		if err != nil {
 			if errors.Is(err, core.ErrIntrinsicGas) {
@@ -761,7 +762,7 @@ func (b *SimulatedBackend) SendTransaction(ctx context.Context, txn types.Transa
 		return fmt.Errorf("invalid transaction nonce: got %d, want %d", txn.GetNonce(), nonce)
 	}
 
-	b.pendingState.SetTxContext(len(b.pendingBlock.Transactions()))
+	b.pendingState.SetTxContext(b.pendingBlock.NumberU64(), len(b.pendingBlock.Transactions()))
 	//fmt.Printf("==== Start producing block %d, header: %d\n", b.pendingBlock.NumberU64(), b.pendingHeader.Number.Uint64())
 	if _, _, err := core.ApplyTransaction(
 		b.m.ChainConfig, core.GetHashFn(b.pendingHeader, b.getHeader), b.m.Engine,

--- a/execution/consensus/aura/aura.go
+++ b/execution/consensus/aura/aura.go
@@ -709,7 +709,7 @@ func (c *AuRa) applyRewards(header *types.Header, state *state.IntraBlockState, 
 		return err
 	}
 	for _, r := range rewards {
-		state.AddBalance(r.Beneficiary, &r.Amount, tracing.BalanceIncreaseRewardMineBlock)
+		state.AddBalance(r.Beneficiary, r.Amount, tracing.BalanceIncreaseRewardMineBlock)
 	}
 	return nil
 }

--- a/execution/consensus/consensus.go
+++ b/execution/consensus/consensus.go
@@ -208,10 +208,10 @@ type PoW interface {
 // Transfer subtracts amount from sender and adds amount to recipient using the given Db
 func Transfer(db evmtypes.IntraBlockState, sender, recipient common.Address, amount *uint256.Int, bailout bool) error {
 	if !bailout {
-		err := db.SubBalance(sender, amount, tracing.BalanceChangeTransfer)
+		err := db.SubBalance(sender, *amount, tracing.BalanceChangeTransfer)
 		if err != nil {
 			return err
 		}
 	}
-	return db.AddBalance(recipient, amount, tracing.BalanceChangeTransfer)
+	return db.AddBalance(recipient, *amount, tracing.BalanceChangeTransfer)
 }

--- a/execution/consensus/ethash/consensus.go
+++ b/execution/consensus/ethash/consensus.go
@@ -673,8 +673,8 @@ func accumulateRewards(config *chain.Config, state *state.IntraBlockState, heade
 	minerReward, uncleRewards := AccumulateRewards(config, header, uncles)
 	for i, uncle := range uncles {
 		if i < len(uncleRewards) {
-			state.AddBalance(uncle.Coinbase, &uncleRewards[i], tracing.BalanceIncreaseRewardMineUncle)
+			state.AddBalance(uncle.Coinbase, uncleRewards[i], tracing.BalanceIncreaseRewardMineUncle)
 		}
 	}
-	state.AddBalance(header.Coinbase, &minerReward, tracing.BalanceIncreaseRewardMineBlock)
+	state.AddBalance(header.Coinbase, minerReward, tracing.BalanceIncreaseRewardMineBlock)
 }

--- a/execution/consensus/merge/merge.go
+++ b/execution/consensus/merge/merge.go
@@ -164,11 +164,11 @@ func (s *Merge) Finalize(config *chain.Config, header *types.Header, state *stat
 	for _, r := range rewards {
 		switch r.Kind {
 		case consensus.RewardAuthor:
-			state.AddBalance(r.Beneficiary, &r.Amount, tracing.BalanceIncreaseRewardMineBlock)
+			state.AddBalance(r.Beneficiary, r.Amount, tracing.BalanceIncreaseRewardMineBlock)
 		case consensus.RewardUncle:
-			state.AddBalance(r.Beneficiary, &r.Amount, tracing.BalanceIncreaseRewardMineUncle)
+			state.AddBalance(r.Beneficiary, r.Amount, tracing.BalanceIncreaseRewardMineUncle)
 		default:
-			state.AddBalance(r.Beneficiary, &r.Amount, tracing.BalanceChangeUnspecified)
+			state.AddBalance(r.Beneficiary, r.Amount, tracing.BalanceChangeUnspecified)
 		}
 	}
 
@@ -180,7 +180,7 @@ func (s *Merge) Finalize(config *chain.Config, header *types.Header, state *stat
 		} else {
 			for _, w := range withdrawals {
 				amountInWei := new(uint256.Int).Mul(uint256.NewInt(w.Amount), uint256.NewInt(common.GWei))
-				state.AddBalance(w.Address, amountInWei, tracing.BalanceIncreaseWithdrawal)
+				state.AddBalance(w.Address, *amountInWei, tracing.BalanceIncreaseWithdrawal)
 			}
 		}
 	}

--- a/execution/exec3/historical_trace_worker.go
+++ b/execution/exec3/historical_trace_worker.go
@@ -214,7 +214,7 @@ func (rw *HistoricalTraceWorker) RunTxTaskNoLock(txTask *state.TxTask) {
 		rw.vmCfg.SkipAnalysis = txTask.SkipAnalysis
 		txTask.Tracer.Reset() // txTask is retryable
 		rw.vmCfg.Tracer = txTask.Tracer.Tracer().Hooks
-		ibs.SetTxContext(txTask.BlockNum,txTask.TxIndex)
+		ibs.SetTxContext(txTask.BlockNum, txTask.TxIndex)
 		txn := txTask.Tx
 
 		if txTask.Tx.Type() == types.AccountAbstractionTxType {

--- a/execution/exec3/historical_trace_worker.go
+++ b/execution/exec3/historical_trace_worker.go
@@ -214,7 +214,7 @@ func (rw *HistoricalTraceWorker) RunTxTaskNoLock(txTask *state.TxTask) {
 		rw.vmCfg.SkipAnalysis = txTask.SkipAnalysis
 		txTask.Tracer.Reset() // txTask is retryable
 		rw.vmCfg.Tracer = txTask.Tracer.Tracer().Hooks
-		ibs.SetTxContext(txTask.TxIndex)
+		ibs.SetTxContext(txTask.BlockNum,txTask.TxIndex)
 		txn := txTask.Tx
 
 		if txTask.Tx.Type() == types.AccountAbstractionTxType {

--- a/execution/exec3/state.go
+++ b/execution/exec3/state.go
@@ -271,7 +271,7 @@ func (rw *Worker) RunTxTaskNoLock(txTask *state.TxTask, isMining, skipPostEvalua
 	default:
 		rw.callTracer.Reset()
 		rw.vmCfg.SkipAnalysis = txTask.SkipAnalysis
-		ibs.SetTxContext(txTask.TxIndex)
+		ibs.SetTxContext(txTask.BlockNum, txTask.TxIndex)
 		txn := txTask.Tx
 
 		if txTask.Tx.Type() == types.AccountAbstractionTxType {

--- a/execution/exec3/trace_worker.go
+++ b/execution/exec3/trace_worker.go
@@ -108,7 +108,7 @@ func (e *TraceWorker) GetLogs(txIndex int, txnHash common.Hash, blockNumber uint
 func (e *TraceWorker) ExecTxn(txNum uint64, txIndex int, txn types.Transaction, gasBailout bool) error {
 	e.stateReader.SetTxNum(txNum)
 	e.ibs.Reset()
-	e.ibs.SetTxContext(txIndex)
+	e.ibs.SetTxContext(e.blockNum, txIndex)
 
 	msg, err := txn.AsMessage(*e.signer, e.header.BaseFee, e.rules)
 	if txn.Type() != types.AccountAbstractionTxType && err != nil {
@@ -137,9 +137,9 @@ func (e *TraceWorker) ExecTxn(txNum uint64, txIndex int, txn types.Transaction, 
 			return err
 		}
 	} else {
-		_, err = core.ApplyMessage(e.evm, msg, gp, true /* refunds */, gasBailout /* gasBailout */, e.engine)
+		result, err := core.ApplyMessage(e.evm, msg, gp, true /* refunds */, gasBailout /* gasBailout */, e.engine)
 		if err != nil {
-			return fmt.Errorf("%w: blockNum=%d, txNum=%d, %s", err, e.blockNum, txNum, e.ibs.Error())
+			return fmt.Errorf("%w: blockNum=%d, txNum=%d, %s", err, e.blockNum, txNum, result.Err)
 		}
 	}
 

--- a/polygon/aa/aa_gas.go
+++ b/polygon/aa/aa_gas.go
@@ -39,7 +39,7 @@ func chargeGas(
 		return fmt.Errorf("%w: RIP-7560 address %v have %v want %v", core.ErrInsufficientFunds, chargeFrom.Hex(), balance, preCharge)
 	}
 
-	if err := ibs.SubBalance(*chargeFrom, preCharge, 0); err != nil {
+	if err := ibs.SubBalance(*chargeFrom, *preCharge, 0); err != nil {
 		return err
 	}
 
@@ -68,7 +68,7 @@ func refundGas(
 
 	chargeFrom := tx.GasPayer()
 
-	if err := ibs.AddBalance(*chargeFrom, refund, tracing.BalanceIncreaseGasReturn); err != nil {
+	if err := ibs.AddBalance(*chargeFrom, *refund, tracing.BalanceIncreaseGasReturn); err != nil {
 		return err
 	}
 
@@ -91,5 +91,5 @@ func payCoinbase(
 
 	amount := new(uint256.Int).SetUint64(gasUsed)
 	amount.Mul(amount, effectiveTip)
-	return ibs.AddBalance(coinbase, amount, tracing.BalanceIncreaseRewardTransactionFee)
+	return ibs.AddBalance(coinbase, *amount, tracing.BalanceIncreaseRewardTransactionFee)
 }

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -1770,19 +1770,19 @@ func BorTransfer(db evmtypes.IntraBlockState, sender, recipient common.Address, 
 	if err != nil {
 		return err
 	}
-	input1 = input1.Clone()
+	input1 = *input1.Clone()
 	input2, err := db.GetBalance(recipient)
 	if err != nil {
 		return err
 	}
-	input2 = input2.Clone()
+	input2 = *input2.Clone()
 	if !bailout {
-		err := db.SubBalance(sender, amount, tracing.BalanceChangeTransfer)
+		err := db.SubBalance(sender, *amount, tracing.BalanceChangeTransfer)
 		if err != nil {
 			return err
 		}
 	}
-	err = db.AddBalance(recipient, amount, tracing.BalanceChangeTransfer)
+	err = db.AddBalance(recipient, *amount, tracing.BalanceChangeTransfer)
 	if err != nil {
 		return err
 	}
@@ -1791,14 +1791,14 @@ func BorTransfer(db evmtypes.IntraBlockState, sender, recipient common.Address, 
 	if err != nil {
 		return err
 	}
-	output1 = output1.Clone()
+	output1 = *output1.Clone()
 	output2, err := db.GetBalance(recipient)
 	if err != nil {
 		return err
 	}
-	output2 = output2.Clone()
+	output2 = *output2.Clone()
 	// add transfer log into state
-	addTransferLog(db, transferLogSig, sender, recipient, amount, input1, input2, output1, output2)
+	addTransferLog(db, transferLogSig, sender, recipient, amount, &input1, &input2, &output1, &output2)
 	return nil
 }
 
@@ -1816,11 +1816,11 @@ func AddFeeTransferLog(ibs evmtypes.IntraBlockState, sender common.Address, coin
 		transferFeeLogSig,
 		sender,
 		coinbase,
-		result.FeeTipped,
-		result.SenderInitBalance,
-		result.CoinbaseInitBalance,
-		output1.Sub(output1, result.FeeTipped),
-		output2.Add(output2, result.FeeTipped),
+		&result.FeeTipped,
+		&result.SenderInitBalance,
+		&result.CoinbaseInitBalance,
+		output1.Sub(output1, &result.FeeTipped),
+		output2.Add(output2, &result.FeeTipped),
 	)
 
 }

--- a/rpc/jsonrpc/eth_callMany.go
+++ b/rpc/jsonrpc/eth_callMany.go
@@ -208,7 +208,7 @@ func (api *APIImpl) CallMany(ctx context.Context, bundles []Bundle, simulateCont
 	// and apply the message.
 	gp := new(core.GasPool).AddGas(math.MaxUint64).AddBlobGas(math.MaxUint64)
 	for idx, txn := range replayTransactions {
-		st.SetTxContext(blockNum,idx)
+		st.SetTxContext(blockNum, idx)
 		msg, err := txn.AsMessage(*signer, block.BaseFee(), rules)
 		if err != nil {
 			return nil, err

--- a/rpc/jsonrpc/eth_callMany.go
+++ b/rpc/jsonrpc/eth_callMany.go
@@ -208,7 +208,7 @@ func (api *APIImpl) CallMany(ctx context.Context, bundles []Bundle, simulateCont
 	// and apply the message.
 	gp := new(core.GasPool).AddGas(math.MaxUint64).AddBlobGas(math.MaxUint64)
 	for idx, txn := range replayTransactions {
-		st.SetTxContext(idx)
+		st.SetTxContext(blockNum,idx)
 		msg, err := txn.AsMessage(*signer, block.BaseFee(), rules)
 		if err != nil {
 			return nil, err

--- a/rpc/jsonrpc/otterscan_search_trace.go
+++ b/rpc/jsonrpc/otterscan_search_trace.go
@@ -105,7 +105,7 @@ func (api *OtterscanAPIImpl) traceBlock(dbtx kv.TemporalTx, ctx context.Context,
 			return false, nil, ctx.Err()
 		default:
 		}
-		ibs.SetTxContext(idx)
+		ibs.SetTxContext(blockNum, idx)
 
 		msg, _ := txn.AsMessage(*signer, header.BaseFee, rules)
 

--- a/rpc/jsonrpc/overlay_api.go
+++ b/rpc/jsonrpc/overlay_api.go
@@ -183,7 +183,7 @@ func (api *OverlayAPIImpl) CallConstructor(ctx context.Context, address common.A
 	// and apply the message.
 	gp := new(core.GasPool).AddGas(math.MaxUint64).AddBlobGas(math.MaxUint64)
 	for idx, txn := range replayTransactions {
-		statedb.SetTxContext(idx)
+		statedb.SetTxContext(blockNum, idx)
 		msg, err := txn.AsMessage(*signer, block.BaseFee(), rules)
 		if err != nil {
 			return nil, err
@@ -200,7 +200,7 @@ func (api *OverlayAPIImpl) CallConstructor(ctx context.Context, address common.A
 	}
 
 	creationTx := block.Transactions()[transactionIndex]
-	statedb.SetTxContext(transactionIndex)
+	statedb.SetTxContext(blockNum, transactionIndex)
 
 	// CREATE2: keep original message so we match the existing contract address, code will be replaced later
 	msg, err := creationTx.AsMessage(*signer, block.BaseFee(), rules)
@@ -522,7 +522,7 @@ func (api *OverlayAPIImpl) replayBlock(ctx context.Context, blockNum uint64, sta
 			}
 		}
 
-		statedb.SetTxContext(idx)
+		statedb.SetTxContext(blockNum, idx)
 		txCtx = core.NewEVMTxContext(msg)
 		evm.TxContext = txCtx
 

--- a/rpc/jsonrpc/receipts/receipts_generator.go
+++ b/rpc/jsonrpc/receipts/receipts_generator.go
@@ -255,9 +255,10 @@ func (g *Generator) GetReceipts(ctx context.Context, cfg *chain.Config, tx kv.Te
 		return nil, err
 	}
 	//genEnv.ibs.SetTrace(true)
+	blockNum := block.NumberU64()
 
 	for i, txn := range block.Transactions() {
-		genEnv.ibs.SetTxContext(i)
+		genEnv.ibs.SetTxContext(blockNum, i)
 		receipt, _, err := core.ApplyTransaction(cfg, core.GetHashFn(genEnv.header, genEnv.getHeader), g.engine, nil, genEnv.gp, genEnv.ibs, genEnv.noopWriter, genEnv.header, txn, genEnv.gasUsed, genEnv.usedBlobGas, vm.Config{})
 		if err != nil {
 			return nil, fmt.Errorf("ReceiptGen.GetReceipts: bn=%d, txnIdx=%d, %w", block.NumberU64(), i, err)

--- a/rpc/jsonrpc/trace_adhoc.go
+++ b/rpc/jsonrpc/trace_adhoc.go
@@ -1146,7 +1146,7 @@ func (api *TraceAPIImpl) Call(ctx context.Context, args TraceCallParam, traceTyp
 
 	gp := new(core.GasPool).AddGas(msg.Gas()).AddBlobGas(msg.BlobGas())
 	var execResult *evmtypes.ExecutionResult
-	ibs.SetTxContext(0)
+	ibs.SetTxContext(blockCtx.BlockNumber, 0)
 	ibs.SetHooks(ot.Tracer().Hooks)
 
 	if ot.Tracer() != nil && ot.Tracer().Hooks.OnTxStart != nil {
@@ -1449,7 +1449,7 @@ func (api *TraceAPIImpl) doCallBlock(ctx context.Context, dbtx kv.Tx, stateReade
 				tracer,
 			)
 		} else {
-			ibs.SetTxContext(txIndex)
+			ibs.SetTxContext(blockCtx.BlockNumber, txIndex)
 			if tracer != nil {
 				ibs.SetHooks(tracer.Hooks)
 			}
@@ -1662,7 +1662,7 @@ func (api *TraceAPIImpl) doCall(ctx context.Context, dbtx kv.Tx, stateReader sta
 			tracer,
 		)
 	} else {
-		ibs.SetTxContext(txIndex)
+		ibs.SetTxContext(blockCtx.BlockNumber, txIndex)
 		txCtx := core.NewEVMTxContext(msg)
 		evm := vm.NewEVM(blockCtx, txCtx, ibs, chainConfig, vmConfig)
 		gp := new(core.GasPool).AddGas(msg.Gas()).AddBlobGas(msg.BlobGas())

--- a/rpc/jsonrpc/trace_filtering.go
+++ b/rpc/jsonrpc/trace_filtering.go
@@ -597,7 +597,7 @@ func (api *TraceAPIImpl) filterV3(ctx context.Context, dbtx kv.TemporalTx, fromB
 		evm := vm.NewEVM(blockCtx, txCtx, ibs, chainConfig, vmConfig)
 
 		gp := new(core.GasPool).AddGas(msg.Gas()).AddBlobGas(msg.BlobGas())
-		ibs.SetTxContext(txIndex)
+		ibs.SetTxContext(blockNum, txIndex)
 		ibs.SetHooks(ot.Tracer().Hooks)
 
 		if ot.Tracer() != nil && ot.Tracer().Hooks.OnTxStart != nil {

--- a/rpc/jsonrpc/tracing.go
+++ b/rpc/jsonrpc/tracing.go
@@ -154,7 +154,7 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 			stream.WriteArrayEnd()
 			return ctx.Err()
 		}
-		ibs.SetTxContext(txnIndex)
+		ibs.SetTxContext(blockCtx.BlockNumber, txnIndex)
 		msg, _ := txn.AsMessage(*signer, block.BaseFee(), rules)
 
 		txCtx := evmtypes.TxContext{
@@ -569,7 +569,7 @@ func (api *PrivateDebugAPIImpl) TraceCallMany(ctx context.Context, bundles []Bun
 			}
 			txCtx = core.NewEVMTxContext(msg)
 			ibs := evm.IntraBlockState()
-			ibs.SetTxContext(txnIndex)
+			ibs.SetTxContext(blockCtx.BlockNumber, txnIndex)
 			_, err = transactions.TraceTx(ctx, api.engine(), transaction, msg, blockCtx, txCtx, block.Hash(), txnIndex, evm.IntraBlockState(), config, chainConfig, stream, api.evmCallTimeout)
 			if err != nil {
 				stream.WriteArrayEnd()

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -278,7 +278,7 @@ func (t *StateTest) RunNoVerify(tx kv.TemporalRwTx, subtest StateSubtest, vmconf
 	gaspool.AddGas(block.GasLimit()).AddBlobGas(config.GetMaxBlobGasPerBlock(header.Time))
 	res, err := core.ApplyMessage(evm, msg, gaspool, true /* refunds */, false /* gasBailout */, nil /* engine */)
 	if err != nil {
-		statedb.RevertToSnapshot(snapshot)
+		statedb.RevertToSnapshot(snapshot, err)
 	}
 	if vmconfig.Tracer != nil && vmconfig.Tracer.OnTxEnd != nil {
 		vmconfig.Tracer.OnTxEnd(&types.Receipt{GasUsed: res.GasUsed}, nil)
@@ -302,7 +302,7 @@ func (t *StateTest) RunNoVerify(tx kv.TemporalRwTx, subtest StateSubtest, vmconf
 func MakePreState(rules *chain.Rules, tx kv.TemporalRwTx, accounts types.GenesisAlloc, blockNr uint64) (*state.IntraBlockState, error) {
 	r := rpchelper.NewLatestStateReader(tx)
 	statedb := state.New(r)
-	statedb.SetTxContext(0)
+	statedb.SetTxContext(blockNr, 0)
 	for addr, a := range accounts {
 		statedb.SetCode(addr, a.Code)
 		statedb.SetNonce(addr, a.Nonce)

--- a/turbo/stages/blockchain_test.go
+++ b/turbo/stages/blockchain_test.go
@@ -2281,7 +2281,7 @@ func TestEIP1559Transition(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		actual = new(uint256.Int).Sub(funds, balance)
+		actual = *new(uint256.Int).Sub(funds, &balance)
 		expected = new(uint256.Int).SetUint64(block.GasUsed() * (block.Transactions()[0].GetTipCap().Uint64() + block.BaseFee().Uint64()))
 		if actual.Cmp(expected) != 0 {
 			t.Fatalf("sender expenditure incorrect: expected %d, got %d", expected, actual)
@@ -2331,7 +2331,7 @@ func TestEIP1559Transition(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		actual = new(uint256.Int).Sub(funds, balance)
+		actual = *new(uint256.Int).Sub(funds, &balance)
 		expected = new(uint256.Int).SetUint64(block.GasUsed() * (effectiveTip + baseFee.Uint64()))
 		if actual.Cmp(expected) != 0 {
 			t.Fatalf("sender balance incorrect: expected %d, got %d", expected, actual)

--- a/turbo/stages/chain_makers_test.go
+++ b/turbo/stages/chain_makers_test.go
@@ -122,21 +122,21 @@ func TestGenerateChain(t *testing.T) {
 		t.Error(err)
 	}
 	if !uint256.NewInt(989000).Eq(&balance) {
-		t.Errorf("wrong balance of addr1: %s", balance)
+		t.Errorf("wrong balance of addr1: %s", &balance)
 	}
 	balance, err = st.GetBalance(addr2)
 	if err != nil {
 		t.Error(err)
 	}
 	if !uint256.NewInt(10000).Eq(&balance) {
-		t.Errorf("wrong balance of addr2: %s", balance)
+		t.Errorf("wrong balance of addr2: %s", &balance)
 	}
 	balance, err = st.GetBalance(addr3)
 	if err != nil {
 		t.Error(err)
 	}
-	if fmt.Sprintf("%s", balance) != "19687500000000001000" { //nolint
-		t.Errorf("wrong balance of addr3: %s", balance)
+	if fmt.Sprintf("%s", &balance) != "19687500000000001000" { //nolint
+		t.Errorf("wrong balance of addr3: %s", &balance)
 	}
 
 	// Test of receipts

--- a/turbo/stages/chain_makers_test.go
+++ b/turbo/stages/chain_makers_test.go
@@ -121,14 +121,14 @@ func TestGenerateChain(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if !uint256.NewInt(989000).Eq(balance) {
+	if !uint256.NewInt(989000).Eq(&balance) {
 		t.Errorf("wrong balance of addr1: %s", balance)
 	}
 	balance, err = st.GetBalance(addr2)
 	if err != nil {
 		t.Error(err)
 	}
-	if !uint256.NewInt(10000).Eq(balance) {
+	if !uint256.NewInt(10000).Eq(&balance) {
 		t.Errorf("wrong balance of addr2: %s", balance)
 	}
 	balance, err = st.GetBalance(addr3)

--- a/turbo/transactions/tracing.go
+++ b/turbo/transactions/tracing.go
@@ -79,7 +79,7 @@ func ComputeBlockContext(ctx context.Context, engine consensus.EngineReader, hea
 // ComputeTxContext returns the execution environment of a certain transaction.
 func ComputeTxContext(statedb *state.IntraBlockState, engine consensus.EngineReader, rules *chain.Rules, signer *types.Signer, block *types.Block, cfg *chain.Config, txIndex int) (core.Message, evmtypes.TxContext, error) {
 	txn := block.Transactions()[txIndex]
-	statedb.SetTxContext(txIndex)
+	statedb.SetTxContext(block.NumberU64(), txIndex)
 	msg, _ := txn.AsMessage(*signer, block.BaseFee(), rules)
 	txContext := core.NewEVMTxContext(msg)
 	return msg, txContext, nil


### PR DESCRIPTION
Versioned IBS is used by parallel processing to keep track of reads and writes between parallel threads running on the same block.

If the versionedMap is set on the IBS it will use this to mediate read and write activity to make sure that there dependency clash between transactions running in parallel.  If a dependency is encountered execution will be stopped with a dependency panic which is handled by the parallel scheduler which re-schedules execution after the dependencies have been resolves.

Note that this version of the IBS has a block in in its context.  This is not functional it is purely used for tracing.   This is because differences in state setting can have subtle side effects which can cause issues several blocks later.  Having the block in the trace output makes it easier to tie together cause and effect.