### PR TITLE
Engine-API: Faster recovery for the block downloader

### DIFF
--- a/turbo/engineapi/engine_server.go
+++ b/turbo/engineapi/engine_server.go
@@ -758,7 +758,7 @@ func (e *EngineServer) HandleNewPayload(
 		}
 
 		if currentHeadNumber != nil {
-			// wait for the slot duration for full download. we cannot expect the process to finish in 0.5s.
+			// wait for the slot duration for full download
 			waitTime := time.Duration(e.config.SecondsPerSlot()) * time.Second
 			// We try waiting until we finish downloading the PoS blocks if the distance from the head is enough,
 			// so that we will perform full validation.

--- a/turbo/engineapi/engine_server.go
+++ b/turbo/engineapi/engine_server.go
@@ -446,14 +446,14 @@ func (s *EngineServer) getQuickPayloadStatusIfPossible(ctx context.Context, bloc
 		if shouldWait, _ := waitForStuff(50*time.Millisecond, func() (bool, error) {
 			return parent == nil && s.hd.PosStatus() == headerdownload.Syncing, nil
 		}); shouldWait {
-			s.logger.Info(fmt.Sprintf("[%s] Downloading some other PoS blocks", prefix), "hash", blockHash)
+			s.logger.Debug(fmt.Sprintf("[%s] Downloading some other PoS blocks", prefix), "hash", blockHash)
 			return &engine_types.PayloadStatus{Status: engine_types.SyncingStatus}, nil
 		}
 	} else {
 		if shouldWait, _ := waitForStuff(50*time.Millisecond, func() (bool, error) {
 			return header == nil && s.hd.PosStatus() == headerdownload.Syncing, nil
 		}); shouldWait {
-			s.logger.Info(fmt.Sprintf("[%s] Downloading some other PoS stuff", prefix), "hash", blockHash)
+			s.logger.Debug(fmt.Sprintf("[%s] Downloading some other PoS stuff", prefix), "hash", blockHash)
 			return &engine_types.PayloadStatus{Status: engine_types.SyncingStatus}, nil
 		}
 
@@ -759,8 +759,8 @@ func (e *EngineServer) HandleNewPayload(
 
 		if currentHeadNumber != nil {
 			// We try waiting until we finish downloading the PoS blocks if the distance from the head is enough,
-			// so that we will perform full validation.
-			if stillSyncing, _ := waitForStuff(500*time.Millisecond, func() (bool, error) {
+			// so that we will perform full validation. Wait 3 seconds because it is a humane time.
+			if stillSyncing, _ := waitForStuff(3*time.Second, func() (bool, error) {
 				return e.blockDownloader.Status() != headerdownload.Synced, nil
 			}); stillSyncing {
 				return &engine_types.PayloadStatus{Status: engine_types.SyncingStatus}, nil

--- a/turbo/engineapi/engine_server.go
+++ b/turbo/engineapi/engine_server.go
@@ -758,9 +758,11 @@ func (e *EngineServer) HandleNewPayload(
 		}
 
 		if currentHeadNumber != nil {
+			// wait for the slot duration for full download. we cannot expect the process to finish in 0.5s.
+			waitTime := time.Duration(e.config.SecondsPerSlot()) * time.Second
 			// We try waiting until we finish downloading the PoS blocks if the distance from the head is enough,
-			// so that we will perform full validation. Wait 3 seconds because it is a humane time.
-			if stillSyncing, _ := waitForStuff(12*time.Second, func() (bool, error) {
+			// so that we will perform full validation.
+			if stillSyncing, _ := waitForStuff(waitTime, func() (bool, error) {
 				return e.blockDownloader.Status() != headerdownload.Synced, nil
 			}); stillSyncing {
 				return &engine_types.PayloadStatus{Status: engine_types.SyncingStatus}, nil

--- a/turbo/engineapi/engine_server.go
+++ b/turbo/engineapi/engine_server.go
@@ -760,7 +760,7 @@ func (e *EngineServer) HandleNewPayload(
 		if currentHeadNumber != nil {
 			// We try waiting until we finish downloading the PoS blocks if the distance from the head is enough,
 			// so that we will perform full validation. Wait 3 seconds because it is a humane time.
-			if stillSyncing, _ := waitForStuff(3*time.Second, func() (bool, error) {
+			if stillSyncing, _ := waitForStuff(12*time.Second, func() (bool, error) {
 				return e.blockDownloader.Status() != headerdownload.Synced, nil
 			}); stillSyncing {
 				return &engine_types.PayloadStatus{Status: engine_types.SyncingStatus}, nil


### PR DESCRIPTION
In real life, we cannot expect any block to be download in half a second because of latency. this is way too little. 