### PR TITLE
Cherry-pick: Fix receipts dangling from reorged blocks (#15401)

### DIFF
--- a/turbo/execution/eth1/forkchoice.go
+++ b/turbo/execution/eth1/forkchoice.go
@@ -43,7 +43,7 @@ import (
 // This is the range in which we sanity check and potentially fix the canonical chain if it is broken.
 // a broken canonical chain is very dangerous, as it can lead to a situation where the RPC and snapshots break down.
 // better to have an hack than to regenerate all chains.
-const fixCanonicalFailsafeRange = 512
+const fixCanonicalFailsafeRange = 16
 
 const startPruneFrom = 1024
 

--- a/turbo/jsonrpc/receipts/receipts_generator.go
+++ b/turbo/jsonrpc/receipts/receipts_generator.go
@@ -172,7 +172,10 @@ func (g *Generator) GetReceipt(ctx context.Context, cfg *chain.Config, tx kv.Tem
 	mu := g.txnExecMutex.lock(txnHash)
 	defer g.txnExecMutex.unlock(mu, txnHash)
 	if receipt, ok := g.receiptCache.Get(txnHash); ok {
-		return receipt, nil
+		if receipt.BlockHash == blockHash { // elegant way to handle reorgs
+			return receipt, nil
+		}
+		g.receiptCache.Remove(txnHash) // remove old receipt with same hash, but different blockHash
 	}
 
 	var receipt *types.Receipt


### PR DESCRIPTION
Basically, need to regen if the block was reorged.