### PR TITLE
rpcdaemon: ots_getContractCreator() add check on tracer.found()

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout RPC Tests Repository & Install Requirements
         run: |
           rm -rf ${{ runner.workspace }}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch v1.62.0  https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
+          git -c advice.detachedHead=false clone --depth 1 --branch v1.63.0  https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
           cd ${{ runner.workspace }}/rpc-tests
           pip3 install -r requirements.txt
 

--- a/rpc/jsonrpc/otterscan_contract_creator.go
+++ b/rpc/jsonrpc/otterscan_contract_creator.go
@@ -181,6 +181,10 @@ func (api *OtterscanAPIImpl) GetContractCreator(ctx context.Context, addr common
 	if err := api.genericTracer(tx, ctx, bn, creationTxnID, txIndex, chainConfig, tracer); err != nil {
 		return nil, err
 	}
+
+	if !tracer.found {
+		return nil, fmt.Errorf("contract address not found in txnID=%d", creationTxnID)
+	}
 	return &ContractCreatorData{
 		Tx:      tracer.Tx.Hash(),
 		Creator: tracer.Creator,


### PR DESCRIPTION
- Add check on found() == false (if contractAddress not found in tracer)
- Use new rpc-test version contains:
a) integration_test: ots_getContractCreator() Add test with CREATE2 (wmitsuda)
b) integration_test: debug_traceCall() add test with BlockOverrides 