### PR TITLE
[pick] txpool: allow higher nonce in pool with existing SetcodeTxn (#14968)

### DIFF
--- a/.github/workflows/kurtosis/eip7702-test.io
+++ b/.github/workflows/kurtosis/eip7702-test.io
@@ -60,4 +60,4 @@ tasks:
   configVars:
     privateKey: "eoaPrivateKey"
     targetAddress: "testContractAddr"
-    authorizations: "| [ { codeAddress: .delegateContractAddr, signerPrivkey: .eoaPrivateKey } ]"
+    authorizations: "| [ { codeAddress: .delegateContractAddr, signerPrivkey: .eoaPrivateKey, nonce: 3 } ]"

--- a/.github/workflows/kurtosis/pectra.io
+++ b/.github/workflows/kurtosis/pectra.io
@@ -2,6 +2,7 @@ participants_matrix:
   el:
     - el_type: erigon
       el_image: test/erigon:current
+      el_log_level: "debug"
   cl:
     - cl_type: teku
       cl_image: consensys/teku:develop

--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -153,7 +153,7 @@ type TxPool struct {
 	newSlotsStreams         *NewSlotsStreams
 	builderNotifyNewTxns    func()
 	logger                  log.Logger
-	auths                   map[common.Address]*metaTxn // All accounts with a pooled authorization
+	auths                   map[AuthAndNonce]*metaTxn // All authority accounts with a pooled authorization
 	blobHashToTxn           map[common.Hash]struct {
 		index   int
 		txnHash common.Hash
@@ -235,11 +235,11 @@ func New(
 		builderNotifyNewTxns:    builderNotifyNewTxns,
 		newSlotsStreams:         newSlotsStreams,
 		logger:                  logger,
-		auths:                   map[common.Address]*metaTxn{},
-		blobHashToTxn: map[common.Hash]struct {
+		auths:                   make(map[AuthAndNonce]*metaTxn),
+		blobHashToTxn: make(map[common.Hash]struct {
 			index   int
 			txnHash common.Hash
-		}{},
+		}),
 	}
 
 	if shanghaiTime != nil {
@@ -759,7 +759,7 @@ func (p *TxPool) best(ctx context.Context, n int, txns *TxnsRlp, onTopOf, availa
 		// make sure we have enough gas in the caller to add this transaction.
 		// not an exact science using intrinsic gas but as close as we could hope for at
 		// this stage
-		authorizationLen := uint64(len(mt.TxnSlot.Authorities))
+		authorizationLen := uint64(len(mt.TxnSlot.AuthAndNonces))
 		intrinsicGas, floorGas, _ := fixedgas.CalcIntrinsicGas(uint64(mt.TxnSlot.DataLen), uint64(mt.TxnSlot.DataNonZeroLen), authorizationLen, uint64(mt.TxnSlot.AccessListAddrCount), uint64(mt.TxnSlot.AccessListStorCount), mt.TxnSlot.Creation, true, true, isEIP3860, isEIP7623)
 		if isEIP7623 && floorGas > intrinsicGas {
 			intrinsicGas = floorGas
@@ -919,7 +919,7 @@ func (p *TxPool) validateTx(txn *TxnSlot, isLocal bool, stateCache kvcache.Cache
 		}
 	}
 
-	authorizationLen := len(txn.Authorities)
+	authorizationLen := len(txn.AuthAndNonces)
 	if txn.Type == SetCodeTxnType {
 		if !isPrague {
 			return txpoolcfg.TypeNotActivated
@@ -982,6 +982,7 @@ func (p *TxPool) validateTx(txn *TxnSlot, isLocal bool, stateCache kvcache.Cache
 		}
 		return txpoolcfg.NonceTooLow
 	}
+
 	// Transactor should have enough funds to cover the costs
 	total := requiredBalance(txn)
 	if senderBalance.Cmp(total) < 0 {
@@ -1484,34 +1485,31 @@ func (p *TxPool) addLocked(mt *metaTxn, announcements *Announcements) txpoolcfg.
 		return txpoolcfg.FeeTooLow
 	}
 
-	// Do not allow transaction from if sender has authority
-	addr, ok := p.senders.getAddr(mt.TxnSlot.SenderID)
+	// Do not allow transaction from this same (sender + nonce) if sender has existing pooled authorization as authority
+	senderAddr, ok := p.senders.senderID2Addr[mt.TxnSlot.SenderID]
 	if !ok {
 		p.logger.Info("senderID not registered, discarding transaction for safety")
 		return txpoolcfg.InvalidSender
 	}
-	if _, ok := p.auths[addr]; ok {
+	if _, ok := p.auths[AuthAndNonce{senderAddr.String(), mt.TxnSlot.Nonce}]; ok {
 		return txpoolcfg.ErrAuthorityReserved
 	}
 
 	// Check if we have txn with same authorization in the pool
 	if mt.TxnSlot.Type == SetCodeTxnType {
-		foundDuplicate := false
-		for _, a := range mt.TxnSlot.Authorities {
-			p.logger.Debug("setCodeTxn ", "authority", a.String())
-			if _, ok := p.auths[*a]; ok {
-				foundDuplicate = true
-				p.logger.Debug("setCodeTxn ", "DUPLICATE authority", a.String(), "txn", fmt.Sprintf("%x", mt.TxnSlot.IDHash))
-				break
+		for _, a := range mt.TxnSlot.AuthAndNonces {
+			// Self authorization nonce should be senderNonce + 1
+			if a.authority == senderAddr.String() && a.nonce != mt.TxnSlot.Nonce+1 {
+				p.logger.Debug("Self authorization nonce should be senderNonce + 1", "authority", a.authority, "txn", fmt.Sprintf("%x", mt.TxnSlot.IDHash))
+				return txpoolcfg.NonceTooLow
+			}
+			if _, ok := p.auths[AuthAndNonce{a.authority, a.nonce}]; ok {
+				p.logger.Debug("setCodeTxn ", "DUPLICATE authority", a.authority, "at nonce", a.nonce, "txn", fmt.Sprintf("%x", mt.TxnSlot.IDHash))
+				return txpoolcfg.ErrAuthorityReserved
 			}
 		}
-
-		if foundDuplicate {
-			return txpoolcfg.ErrAuthorityReserved
-		} else {
-			for _, a := range mt.TxnSlot.Authorities {
-				p.auths[*a] = mt
-			}
+		for _, a := range mt.TxnSlot.AuthAndNonces {
+			p.auths[AuthAndNonce{a.authority, a.nonce}] = mt
 		}
 	}
 
@@ -1558,8 +1556,8 @@ func (p *TxPool) discardLocked(mt *metaTxn, reason txpoolcfg.DiscardReason) {
 		p.totalBlobsInPool.Store(t - uint64(len(mt.TxnSlot.BlobHashes)))
 	}
 	if mt.TxnSlot.Type == SetCodeTxnType {
-		for _, a := range mt.TxnSlot.Authorities {
-			delete(p.auths, *a)
+		for _, a := range mt.TxnSlot.AuthAndNonces {
+			delete(p.auths, a)
 		}
 	}
 }

--- a/txnprovider/txpool/pool_test.go
+++ b/txnprovider/txpool/pool_test.go
@@ -178,6 +178,134 @@ func TestNonceFromAddress(t *testing.T) {
 }
 
 func TestMultipleAuthorizations(t *testing.T) {
+	addrA := common.HexToAddress("0xa")
+	addrB := common.HexToAddress("0xb")
+	cases := []struct {
+		title          string
+		sender         common.Address
+		senderNonce    uint64
+		authority      *common.Address
+		authNonce      uint64
+		feecap         uint64
+		tipcap         uint64
+		expectedReason txpoolcfg.DiscardReason
+		replacedAuth   *AuthAndNonce
+	}{
+		{
+			title:          "a setcode txn with sender=A and authority=B",
+			sender:         addrA,
+			senderNonce:    0,
+			authority:      &addrB,
+			authNonce:      0,
+			feecap:         100_000,
+			tipcap:         100_000,
+			expectedReason: txpoolcfg.Success,
+		},
+		{
+			title:          "A's own authorization with correct sender nonce, and same nonce for authorization",
+			sender:         addrA,
+			senderNonce:    1,
+			authority:      &addrA,
+			authNonce:      1,
+			feecap:         100_000,
+			tipcap:         100_000,
+			expectedReason: txpoolcfg.NonceTooLow,
+		},
+		{
+			title:          "own authorization with correct sender nonce, and one higher authority nonce",
+			sender:         addrA,
+			senderNonce:    1,
+			authority:      &addrA,
+			authNonce:      2,
+			feecap:         100_000,
+			tipcap:         100_000,
+			expectedReason: txpoolcfg.Success,
+		},
+		{
+			title:          "A sends senderNonce=(prev auth nonce) wtih existing own authorization of A ",
+			sender:         addrA,
+			senderNonce:    2,
+			authority:      nil,
+			authNonce:      0,
+			feecap:         100_000,
+			tipcap:         100_000,
+			expectedReason: txpoolcfg.ErrAuthorityReserved,
+		},
+
+		{
+			title:          "B sends with nonce as B's auth nonce of existing authorization sent by A",
+			sender:         addrB,
+			senderNonce:    0,
+			authority:      nil,
+			authNonce:      0,
+			feecap:         100_000,
+			tipcap:         100_000,
+			expectedReason: txpoolcfg.ErrAuthorityReserved,
+		},
+		{
+			title:          "B sends non-setcode txn senderNonce=(auth nonce + 1) with existing own authorization sent by A",
+			sender:         addrB,
+			senderNonce:    1,
+			authority:      nil,
+			authNonce:      0,
+			feecap:         100_000,
+			tipcap:         100_000,
+			expectedReason: txpoolcfg.Success,
+		},
+		{
+			title:          "B's existing authorization in pool, B sends new setcode txn with higher nonce and auth nonce",
+			sender:         addrB,
+			senderNonce:    2,
+			authority:      &addrB,
+			authNonce:      3,
+			feecap:         100_000,
+			tipcap:         100_000,
+			expectedReason: txpoolcfg.Success,
+		},
+		{
+			title:          "replace setcode txn sent By B with B's authorization, with higher tipcap and A's authorization",
+			sender:         addrB,
+			senderNonce:    2,
+			authority:      &addrA,
+			authNonce:      3,
+			feecap:         200_000,
+			tipcap:         200_000,
+			expectedReason: txpoolcfg.Success,
+			replacedAuth:   &AuthAndNonce{addrB.String(), 3},
+		},
+		{
+			title:          "B sends to replace own setcode txn with non setcode txn, with higher tipcap",
+			sender:         addrB,
+			senderNonce:    2,
+			authority:      nil,
+			authNonce:      0,
+			feecap:         300_000,
+			tipcap:         300_000,
+			expectedReason: txpoolcfg.Success,
+			replacedAuth:   &AuthAndNonce{addrA.String(), 3},
+		},
+		{
+			title:          "B sends to replace non setcode txn, with setcode txn (A's auth) with higher tipcap",
+			sender:         addrB,
+			senderNonce:    2,
+			authority:      &addrA,
+			authNonce:      3,
+			feecap:         400_000,
+			tipcap:         400_000,
+			expectedReason: txpoolcfg.Success,
+		},
+		{
+			title:          "B sends another setcode txn with B's authorization after setcode txn for A's authorization",
+			sender:         addrB,
+			senderNonce:    3,
+			authority:      &addrB,
+			authNonce:      4,
+			feecap:         100_000,
+			tipcap:         100_000,
+			expectedReason: txpoolcfg.Success,
+		},
+	}
+
 	ch := make(chan Announcements, 100)
 	coreDB, _ := temporaltest.NewTestDB(t, datadir.New(t.TempDir()))
 	db := memdb.NewTestPoolDB(t)
@@ -191,13 +319,12 @@ func TestMultipleAuthorizations(t *testing.T) {
 	require.True(t, pool != nil)
 
 	var stateVersionID uint64 = 0
-	pendingBaseFee := uint64(200000)
-	// start blocks from 0, set empty hash - then kvcache will also work on this
+	pendingBaseFee := uint64(50_000)
 	h1 := gointerfaces.ConvertHashToH256([32]byte{})
 	change := &remote.StateChangeBatch{
 		StateVersionId:      stateVersionID,
 		PendingBlockBaseFee: pendingBaseFee,
-		BlockGasLimit:       1000000,
+		BlockGasLimit:       36_000_000,
 		ChangeBatch: []*remote.StateChange{
 			{BlockHeight: 0, BlockHash: h1},
 		},
@@ -207,186 +334,62 @@ func TestMultipleAuthorizations(t *testing.T) {
 	privateKey, err := crypto.GenerateKey()
 	assert.NoError(t, err)
 	authAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+	require.NoError(t, err)
 
-	var addr1, addr2 [20]byte
-	addr2[0] = 1
 	acc := accounts3.Account{
 		Nonce:       0,
-		Balance:     *uint256.NewInt(1 * common.Ether),
+		Balance:     *uint256.NewInt(10 * common.Ether),
 		CodeHash:    common.Hash{},
 		Incarnation: 1,
 	}
 	v := accounts3.SerialiseV3(&acc)
 	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remote.AccountChange{
 		Action:  remote.Action_UPSERT,
-		Address: gointerfaces.ConvertAddressToH160(addr1),
+		Address: gointerfaces.ConvertAddressToH160(addrA),
 		Data:    v,
 	})
 	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remote.AccountChange{
 		Action:  remote.Action_UPSERT,
-		Address: gointerfaces.ConvertAddressToH160(addr2),
+		Address: gointerfaces.ConvertAddressToH160(addrB),
 		Data:    v,
 	})
-	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remote.AccountChange{
-		Action:  remote.Action_UPSERT,
-		Address: gointerfaces.ConvertAddressToH160(authAddress),
-		Data:    v,
-	})
+
 	tx, err := db.BeginRw(ctx)
 	require.NoError(t, err)
 	defer tx.Rollback()
 	err = pool.OnNewBlock(ctx, change, TxnSlots{}, TxnSlots{}, TxnSlots{})
 	assert.NoError(t, err)
 
-	// Generate auth data for transactions
-	var b [33]byte
-	data := bytes.NewBuffer(b[:])
-	data.Reset()
-
-	authLen := rlp.U64Len(chainID)
-	authLen += 1 + length.Addr
-	authLen += rlp.U64Len(0)
-	assert.NoError(t, rlp.EncodeStructSizePrefix(authLen, data, b[:]))
-	assert.NoError(t, rlp.EncodeInt(chainID, data, b[:]))
-	assert.NoError(t, rlp.EncodeOptionalAddress(&authAddress, data, b[:]))
-	assert.NoError(t, rlp.EncodeInt(0, data, b[:]))
-
-	hashData := []byte{params.SetCodeMagicPrefix}
-	hashData = append(hashData, data.Bytes()...)
-	hash := crypto.Keccak256Hash(hashData)
-
-	sig, err := crypto.Sign(hash.Bytes(), privateKey)
-	assert.NoError(t, err)
-
-	r := uint256.NewInt(0).SetBytes(sig[:32])
-	s := uint256.NewInt(0).SetBytes(sig[32:64])
-	yParity := sig[64]
-
-	var auth Signature
-	auth.ChainID.Set(uint256.NewInt(chainID))
-	auth.V.Set(uint256.NewInt(uint64(yParity)))
-	auth.R.Set(r)
-	auth.S.Set(s)
-
-	logger := log.New()
-
-	// a new txn with authority same as one in an existing authorization should not be accepted
-	{
-		var txnSlots TxnSlots
-		txnSlot1 := &TxnSlot{
-			Tip:         *uint256.NewInt(300000),
-			FeeCap:      *uint256.NewInt(300000),
-			Gas:         100000,
-			Nonce:       0,
-			Authorities: []*common.Address{&authAddress},
-			Type:        SetCodeTxnType,
-		}
-		txnSlot1.IDHash[0] = 1
-		txnSlots.Append(txnSlot1, addr1[:], true)
-		reasons, err := pool.AddLocalTxns(ctx, txnSlots)
-		require.NoError(t, err)
-		assert.Equal(t, reasons, []txpoolcfg.DiscardReason{txpoolcfg.Success})
-
-		txnSlots = TxnSlots{}
-		txnSlot2 := &TxnSlot{
-			Tip:         *uint256.NewInt(300000),
-			FeeCap:      *uint256.NewInt(300000),
-			Gas:         100000,
-			Nonce:       0,
-			Authorities: []*common.Address{&authAddress},
-			Type:        SetCodeTxnType,
-		}
-		txnSlot2.IDHash[0] = 2
-		txnSlots.Append(txnSlot2, addr2[:], true)
-		require.NoError(t, pool.senders.registerNewSenders(&txnSlots, logger))
-		reasons, err = pool.AddLocalTxns(ctx, txnSlots)
-		require.NoError(t, err)
-		assert.Equal(t, reasons, []txpoolcfg.DiscardReason{txpoolcfg.ErrAuthorityReserved})
-
-		assert.Len(t, pool.auths, 1) // auth address should be in pool auth
-		_, ok := pool.auths[authAddress]
-		assert.True(t, ok)
-
-		err = pool.OnNewBlock(ctx, change, TxnSlots{}, TxnSlots{}, TxnSlots{[]*TxnSlot{txnSlot1}, Addresses{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, []bool{true}})
-		assert.NoError(t, err)
-
-		assert.Len(t, pool.auths, 0) // auth address should not be there after block has been mined
-	}
-
-	// fee bump
-	{
-		var txnSlots TxnSlots
-		txnSlot1 := &TxnSlot{
-			Tip:         *uint256.NewInt(300000),
-			FeeCap:      *uint256.NewInt(300000),
-			Gas:         100000,
-			Nonce:       1,
-			Authorities: []*common.Address{&authAddress},
-			Type:        SetCodeTxnType,
-		}
-		txnSlot1.IDHash[0] = 3
-		txnSlots.Append(txnSlot1, addr1[:], true)
-
-		assert.NoError(t, pool.senders.registerNewSenders(&txnSlots, logger))
-		reasons, err := pool.AddLocalTxns(ctx, txnSlots)
-		assert.NoError(t, err)
-		assert.Equal(t, reasons, []txpoolcfg.DiscardReason{txpoolcfg.Success})
-
-		txnSlots = TxnSlots{}
-		txnSlot2 := &TxnSlot{
-			Tip:         *uint256.NewInt(900000),
-			FeeCap:      *uint256.NewInt(900000),
-			Gas:         100000,
-			Nonce:       1,
-			Authorities: []*common.Address{&authAddress},
-			Type:        SetCodeTxnType,
-		}
-		txnSlot2.IDHash[0] = 4
-		txnSlots.Append(txnSlot2, addr1[:], true)
-
-		assert.NoError(t, pool.senders.registerNewSenders(&txnSlots, logger))
-		reasons, err = pool.AddLocalTxns(ctx, txnSlots)
-		assert.NoError(t, err)
-		assert.Equal(t, reasons, []txpoolcfg.DiscardReason{txpoolcfg.Success})
-		assert.Equal(t, pool.queued.Best().TxnSlot, txnSlot2)
-
-		err = pool.OnNewBlock(ctx, change, TxnSlots{}, TxnSlots{}, TxnSlots{[]*TxnSlot{txnSlot1}, Addresses{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, []bool{true}})
-		assert.NoError(t, err)
-	}
-
-	// do not allow transactions from a sender if there is a pending delegated txn its authority
-	{
-		var txnSlots TxnSlots
-		txnSlot1 := &TxnSlot{
-			Tip:         *uint256.NewInt(300000),
-			FeeCap:      *uint256.NewInt(300000),
-			Gas:         100000,
-			Nonce:       1,
-			Authorities: []*common.Address{&authAddress},
-			Type:        SetCodeTxnType,
-		}
-		txnSlot1.IDHash[0] = 5
-		txnSlots.Append(txnSlot1, addr1[:], true)
-
-		assert.NoError(t, pool.senders.registerNewSenders(&txnSlots, logger))
-		reasons, err := pool.AddLocalTxns(ctx, txnSlots)
-		assert.NoError(t, err)
-		assert.Equal(t, reasons, []txpoolcfg.DiscardReason{txpoolcfg.Success})
-
-		txnSlots = TxnSlots{}
-		txnSlot2 := &TxnSlot{
-			Tip:    *uint256.NewInt(300000),
-			FeeCap: *uint256.NewInt(300000),
-			Gas:    100000,
-			Nonce:  1,
-			Type:   DynamicFeeTxnType,
-		}
-		txnSlot2.IDHash[0] = 6
-
-		txnSlots.Append(txnSlot2, authAddress.Bytes(), true)
-		reasons, err = pool.AddLocalTxns(ctx, txnSlots)
-		assert.NoError(t, err)
-		assert.Equal(t, reasons, []txpoolcfg.DiscardReason{txpoolcfg.ErrAuthorityReserved})
+	idHash := 0
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
+			t.Log("\n--- Testing " + c.title)
+			var txnSlots TxnSlots
+			txnSlot1 := &TxnSlot{
+				Tip:    *uint256.NewInt(c.tipcap),
+				FeeCap: *uint256.NewInt(c.feecap),
+				Gas:    100000,
+				Nonce:  c.senderNonce,
+			}
+			if c.authority != nil {
+				txnSlot1.AuthAndNonces = []AuthAndNonce{{c.authority.String(), c.authNonce}}
+				txnSlot1.Type = SetCodeTxnType
+			}
+			txnSlot1.IDHash[0] = uint8(idHash)
+			idHash++
+			txnSlots.Append(txnSlot1, c.sender[:], true)
+			reasons, err := pool.AddLocalTxns(ctx, txnSlots)
+			require.NoError(t, err)
+			assert.Equal(t, []txpoolcfg.DiscardReason{c.expectedReason}, reasons)
+			if c.authority != nil && c.expectedReason == txpoolcfg.Success {
+				_, ok := pool.auths[AuthAndNonce{c.authority.String(), c.authNonce}]
+				assert.True(t, ok)
+			}
+			if c.replacedAuth != nil {
+				_, ok := pool.auths[*c.replacedAuth]
+				assert.False(t, ok)
+			}
+		})
 	}
 }
 
@@ -1062,13 +1065,12 @@ func TestSetCodeTxnValidationWithLargeAuthorizationValues(t *testing.T) {
 	assert.NoError(t, err)
 
 	txn := &TxnSlot{
-		FeeCap:      *uint256.NewInt(21000),
-		Gas:         500000,
-		SenderID:    0,
-		Type:        SetCodeTxnType,
-		Authorities: make([]*common.Address, 1),
+		FeeCap:        *uint256.NewInt(21000),
+		Gas:           500000,
+		SenderID:      0,
+		Type:          SetCodeTxnType,
+		AuthAndNonces: []AuthAndNonce{{nonce: 0, authority: common.Address{}.String()}},
 	}
-	txn.Authorities[0] = &common.Address{}
 
 	txns := TxnSlots{
 		Txns:    append([]*TxnSlot{}, txn),

--- a/txnprovider/txpool/pool_txn_parser.go
+++ b/txnprovider/txpool/pool_txn_parser.go
@@ -465,7 +465,7 @@ func (ctx *TxnParseContext) parseTransactionBody(payload []byte, pos, p0 int, sl
 		p = dataPos + dataLen
 	}
 	if slot.Type == SetCodeTxnType {
-		slot.Authorities = make([]*common.Address, 0)
+		slot.AuthAndNonces = make([]AuthAndNonce, 0)
 		dataPos, dataLen, err = rlp.ParseList(payload, p)
 		if err != nil {
 			return 0, fmt.Errorf("%w: authorizations len: %s", ErrParseTxn, err) //nolint
@@ -509,7 +509,7 @@ func (ctx *TxnParseContext) parseTransactionBody(payload []byte, pos, p0 int, sl
 			if err != nil {
 				return 0, fmt.Errorf("%w: recover authorization signer: %s", ErrParseTxn, err) //nolint
 			}
-			slot.Authorities = append(slot.Authorities, authority)
+			slot.AuthAndNonces = append(slot.AuthAndNonces, AuthAndNonce{authority.String(), auth.Nonce})
 			authPos += authLen
 			if authPos != p2 {
 				return 0, fmt.Errorf("%w: authorization: unexpected list items", ErrParseTxn)
@@ -667,6 +667,10 @@ func (ctx *TxnParseContext) parseTransactionBody(payload []byte, pos, p0 int, sl
 
 	return p, nil
 }
+type AuthAndNonce struct {
+	authority string
+	nonce     uint64
+}
 
 // TxnSlot contains information extracted from an Ethereum transaction, which is enough to manage it inside the transaction.
 // Also, it contains some auxiliary information, like ephemeral fields, and indices within priority queues
@@ -695,7 +699,7 @@ type TxnSlot struct {
 	Commitments []gokzg4844.KZGCommitment
 	Proofs      []gokzg4844.KZGProof
 
-	Authorities []*common.Address // Indexed authorization signers for EIP-7702 txns (type-4)
+	AuthAndNonces []AuthAndNonce // Indexed authorization signers + nonces for EIP-7702 txns (type-4)
 
 }
 

--- a/txnprovider/txpool/pool_txn_parser_test.go
+++ b/txnprovider/txpool/pool_txn_parser_test.go
@@ -325,8 +325,8 @@ func TestSetCodeAuthSignatureRecover(t *testing.T) {
 	setCodeTx := types.SetCodeTransaction{}
 	rlpStream := rlp.NewStream(bytes.NewBuffer(txnRlpBytes[1:]), uint64(len(txnRlpBytes)))
 	setCodeTx.DecodeRLP(rlpStream)
-	require.Len(t, txn.Authorities, 1)
-	require.Equal(t, expectedSigner, *txn.Authorities[0])
+	require.Len(t, txn.AuthAndNonces, 1)
+	require.Equal(t, expectedSigner.String(), txn.AuthAndNonces[0].authority)
 }
 
 func TestSetCodeTxnParsing(t *testing.T) {
@@ -344,7 +344,7 @@ func TestSetCodeTxnParsing(t *testing.T) {
 
 	_, err = ctx.ParseTransaction(bodyRlx, 0, &txn, nil, hasEnvelope, false, nil)
 	require.NoError(t, err)
-	assert.Equal(t, 2, len(txn.Authorities))
+	assert.Len(t, txn.AuthAndNonces, 2)
 	assert.Equal(t, SetCodeTxnType, txn.Type)
 
 	// test empty authorizations
@@ -360,7 +360,7 @@ func TestSetCodeTxnParsing(t *testing.T) {
 
 	_, err = ctx.ParseTransaction(bodyRlx, 0, &tx2, nil, hasEnvelope, false, nil)
 	require.NoError(t, err)
-	assert.Equal(t, 0, len(tx2.Authorities))
+	assert.Empty(t, tx2.AuthAndNonces)
 	assert.Equal(t, SetCodeTxnType, tx2.Type)
 
 	// generated using this in core/types/encdec_test.go


### PR DESCRIPTION
Enable the following scenarios
- Replace setCode txn's like usual txns
- Send txn's and authorizations with higher nonces even if there are existing authorizations with lower nonces
- Send AuthorityReserved only if an authority with the same nonce exists already

Cherry-pick  (#14968)