### PR TITLE
fix zombie address protection marking

### DIFF
--- a/core/state/rw_v3.go
+++ b/core/state/rw_v3.go
@@ -158,7 +158,7 @@ func (rs *ParallelExecutionState) applyState(txTask *TxTask, domains *libstate.S
 		}
 		acc.Balance.Add(&acc.Balance, &increase)
 
-		if emptyRemoval && acc.Nonce == 0 && acc.Balance.IsZero() && acc.IsEmptyCodeHash() && !incr.IsEscrow {
+		if !incr.IsEscrow && emptyRemoval && acc.Nonce == 0 && acc.Balance.IsZero() && acc.IsEmptyCodeHash() {
 			if err := domains.DomainDel(kv.AccountsDomain, addrBytes, nil, enc0, step0); err != nil {
 				return err
 			}

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -1694,6 +1694,9 @@ func (dt *DomainRoTx) GetLatest(key []byte, roTx kv.Tx) ([]byte, uint64, bool, e
 	if err != nil {
 		return nil, 0, false, fmt.Errorf("getLatestFromFiles: %w", err)
 	}
+	if !foundInFile {
+		v = nil
+	}
 	return v, endTxNum / dt.d.aggregationStep, foundInFile, nil
 }
 

--- a/erigon-lib/types/accounts/account_test.go
+++ b/erigon-lib/types/accounts/account_test.go
@@ -46,6 +46,27 @@ func TestEmptyAccount(t *testing.T) {
 	isIncarnationEqual(t, a.Incarnation, decodedAcc.Incarnation)
 }
 
+func TestEmptyAcountEncoding(t *testing.T) {
+	t.Parallel()
+	emptyAcc := Account{
+		Initialised: true,
+		Nonce:       0,
+		Balance:     *new(uint256.Int),
+		Root:        emptyRoot,     // extAccount doesn't have Root value
+		CodeHash:    emptyCodeHash, // extAccount doesn't have CodeHash value
+		Incarnation: 0,
+	}
+
+	encodedAccount := SerialiseV3(&emptyAcc)
+
+	decodedAcc := Account{}
+	if err := DeserialiseV3(&decodedAcc, encodedAccount); err != nil {
+		t.Fatal("Can't decode the incarnation", err, encodedAccount)
+	}
+
+	isAccountsEqual(t, emptyAcc, decodedAcc)
+}
+
 func TestEmptyAccount2(t *testing.T) {
 	t.Parallel()
 	emptyAcc := Account{}


### PR DESCRIPTION
Zombie address is encoded to `0000` so during commitment it is empty, not Deleted