### PR TITLE
Use temporal db + views rather than cast tx

### DIFF
--- a/core/state/database_test.go
+++ b/core/state/database_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/erigontech/erigon-lib/crypto"
 	"github.com/erigontech/erigon-lib/kv"
 	"github.com/erigontech/erigon-lib/log/v3"
-	state3 "github.com/erigontech/erigon-lib/state"
+	libstate "github.com/erigontech/erigon-lib/state"
 	"github.com/erigontech/erigon-lib/types"
 	"github.com/erigontech/erigon/core"
 	"github.com/erigontech/erigon/core/state"
@@ -129,7 +129,7 @@ func TestCreate2Revive(t *testing.T) {
 		t.Fatalf("generate blocks: %v", err)
 	}
 
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(address); err != nil {
 			t.Error(err)
@@ -150,7 +150,7 @@ func TestCreate2Revive(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(contractAddress); err != nil {
 			t.Error(err)
@@ -168,7 +168,7 @@ func TestCreate2Revive(t *testing.T) {
 
 	var key2 common.Hash
 	var check2 uint256.Int
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(create2address); err != nil {
 			t.Error(err)
@@ -189,7 +189,7 @@ func TestCreate2Revive(t *testing.T) {
 	if err = m.InsertChain(chain.Slice(2, 3)); err != nil {
 		t.Fatal(err)
 	}
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(create2address); err != nil {
 			t.Error(err)
@@ -204,7 +204,7 @@ func TestCreate2Revive(t *testing.T) {
 	if err = m.InsertChain(chain.Slice(3, 4)); err != nil {
 		t.Fatal(err)
 	}
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(create2address); err != nil {
 			t.Error(err)
@@ -346,7 +346,7 @@ func TestCreate2Polymorth(t *testing.T) {
 		t.Fatalf("generate blocks: %v", err)
 	}
 
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(address); err != nil {
@@ -368,7 +368,7 @@ func TestCreate2Polymorth(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(contractAddress); err != nil {
 			t.Error(err)
@@ -384,7 +384,7 @@ func TestCreate2Polymorth(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(create2address); err != nil {
 			t.Error(err)
@@ -415,7 +415,7 @@ func TestCreate2Polymorth(t *testing.T) {
 	if err = m.InsertChain(chain.Slice(2, 3)); err != nil {
 		t.Fatal(err)
 	}
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(create2address); err != nil {
 			t.Error(err)
@@ -430,7 +430,7 @@ func TestCreate2Polymorth(t *testing.T) {
 	if err = m.InsertChain(chain.Slice(3, 4)); err != nil {
 		t.Fatal(err)
 	}
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(create2address); err != nil {
 			t.Error(err)
@@ -461,7 +461,7 @@ func TestCreate2Polymorth(t *testing.T) {
 	if err = m.InsertChain(chain.Slice(4, 5)); err != nil {
 		t.Fatal(err)
 	}
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(create2address); err != nil {
 			t.Error(err)
@@ -580,7 +580,7 @@ func TestReorgOverSelfDestruct(t *testing.T) {
 		t.Fatalf("generate long blocks")
 	}
 
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(address); err != nil {
@@ -603,7 +603,7 @@ func TestReorgOverSelfDestruct(t *testing.T) {
 
 	var key0 common.Hash
 	var correctValueX uint256.Int
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(contractAddress); err != nil {
 			t.Error(err)
@@ -623,7 +623,7 @@ func TestReorgOverSelfDestruct(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(contractAddress); err != nil {
 			t.Error(err)
@@ -637,7 +637,7 @@ func TestReorgOverSelfDestruct(t *testing.T) {
 	if err = m.InsertChain(longerChain.Slice(1, 4)); err != nil {
 		t.Fatal(err)
 	}
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(contractAddress); err != nil {
 			t.Error(err)
@@ -732,7 +732,7 @@ func TestReorgOverStateChange(t *testing.T) {
 		t.Fatalf("generate longer blocks: %v", err)
 	}
 
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(address); err != nil {
 			t.Error(err)
@@ -756,7 +756,7 @@ func TestReorgOverStateChange(t *testing.T) {
 
 	var key0 common.Hash
 	var correctValueX uint256.Int
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(contractAddress); err != nil {
 			t.Error(err)
@@ -780,7 +780,7 @@ func TestReorgOverStateChange(t *testing.T) {
 	if err = m.InsertChain(longerChain.Slice(1, 3)); err != nil {
 		t.Fatal(err)
 	}
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(contractAddress); err != nil {
 			t.Error(err)
@@ -872,7 +872,7 @@ func TestCreateOnExistingStorage(t *testing.T) {
 		t.Fatalf("generate blocks: %v", err)
 	}
 
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(address); err != nil {
 			t.Error(err)
@@ -893,7 +893,7 @@ func TestCreateOnExistingStorage(t *testing.T) {
 
 	var key0 common.Hash
 	var check0 uint256.Int
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(contractAddress); err != nil {
 			t.Error(err)
@@ -926,7 +926,7 @@ func TestReproduceCrash(t *testing.T) {
 	value2 := uint256.NewInt(0x58c00a51)
 
 	_, tx, _ := state.NewTestTemporalDb(t)
-	sd, err := state3.NewSharedDomains(tx, log.New())
+	sd, err := libstate.NewSharedDomains(tx, log.New())
 	require.NoError(t, err)
 	t.Cleanup(sd.Close)
 
@@ -1021,7 +1021,7 @@ func TestEip2200Gas(t *testing.T) {
 	}
 
 	var balanceBefore uint256.Int
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(address); err != nil {
 			t.Error(err)
@@ -1043,7 +1043,7 @@ func TestEip2200Gas(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(contractAddress); err != nil {
 			t.Error(err)
@@ -1118,7 +1118,7 @@ func TestWrongIncarnation(t *testing.T) {
 		t.Fatalf("generate blocks: %v", err)
 	}
 
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(address); err != nil {
 			t.Error(err)
@@ -1139,7 +1139,7 @@ func TestWrongIncarnation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		stateReader := m.NewStateReader(tx)
 		acc, err := stateReader.ReadAccountData(contractAddress)
 		if err != nil {
@@ -1167,7 +1167,7 @@ func TestWrongIncarnation(t *testing.T) {
 	if err = m.InsertChain(chain.Slice(1, 2)); err != nil {
 		t.Fatal(err)
 	}
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		stateReader := m.NewStateReader(tx)
 		acc, err := stateReader.ReadAccountData(contractAddress)
 		if err != nil {
@@ -1278,7 +1278,7 @@ func TestWrongIncarnation2(t *testing.T) {
 		t.Fatalf("generate longer blocks: %v", err)
 	}
 
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(address); err != nil {
 			t.Error(err)
@@ -1299,7 +1299,7 @@ func TestWrongIncarnation2(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(contractAddress); err != nil {
 			t.Error(err)
@@ -1326,7 +1326,7 @@ func TestWrongIncarnation2(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		stateReader := m.NewStateReader(tx)
 		acc, err := stateReader.ReadAccountData(contractAddress)
 		if err != nil {
@@ -1349,7 +1349,7 @@ func TestChangeAccountCodeBetweenBlocks(t *testing.T) {
 	contract := common.HexToAddress("0x71dd1027069078091B3ca48093B00E4735B20624")
 
 	_, tx, _ := state.NewTestTemporalDb(t)
-	sd, err := state3.NewSharedDomains(tx, log.New())
+	sd, err := libstate.NewSharedDomains(tx, log.New())
 	require.NoError(t, err)
 	t.Cleanup(sd.Close)
 	blockNum, txNum := uint64(1), uint64(3)
@@ -1398,7 +1398,7 @@ func TestCacheCodeSizeSeparately(t *testing.T) {
 	//root := common.HexToHash("0xb939e5bcf5809adfb87ab07f0795b05b95a1d64a90f0eddd0c3123ac5b433854")
 
 	_, tx, _ := state.NewTestTemporalDb(t)
-	sd, err := state3.NewSharedDomains(tx, log.New())
+	sd, err := libstate.NewSharedDomains(tx, log.New())
 	require.NoError(t, err)
 	t.Cleanup(sd.Close)
 	blockNum, txNum := uint64(1), uint64(3)
@@ -1438,7 +1438,7 @@ func TestCacheCodeSizeInTrie(t *testing.T) {
 	root := common.HexToHash("0xb939e5bcf5809adfb87ab07f0795b05b95a1d64a90f0eddd0c3123ac5b433854")
 
 	_, tx, _ := state.NewTestTemporalDb(t)
-	sd, err := state3.NewSharedDomains(tx, log.New())
+	sd, err := libstate.NewSharedDomains(tx, log.New())
 	require.NoError(t, err)
 	t.Cleanup(sd.Close)
 	blockNum := uint64(1)
@@ -1633,7 +1633,7 @@ func TestRecreateAndRewind(t *testing.T) {
 
 	var key0 common.Hash
 	var check0 uint256.Int
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(phoenixAddress); err != nil {
 			t.Error(err)
@@ -1653,7 +1653,7 @@ func TestRecreateAndRewind(t *testing.T) {
 	if err = m.InsertChain(chain.Slice(2, chain.Length())); err != nil {
 		t.Fatal(err)
 	}
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(phoenixAddress); err != nil {
@@ -1674,7 +1674,7 @@ func TestRecreateAndRewind(t *testing.T) {
 	if err = m.InsertChain(longerChain); err != nil {
 		t.Fatal(err)
 	}
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		if exist, err := st.Exist(phoenixAddress); err != nil {
 			t.Error(err)
@@ -1741,7 +1741,7 @@ func TestTxLookupUnwind(t *testing.T) {
 		t.Fatal(err)
 	}
 	var count uint64
-	if err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	if err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		var e error
 		if count, e = tx.Count(kv.TxLookup); e != nil {
 			return e

--- a/core/state/dump.go
+++ b/core/state/dump.go
@@ -135,7 +135,7 @@ func NewDumper(db kv.TemporalTx, txNumsReader rawdbv3.TxNumsReader, blockNumber 
 	}
 }
 
-var TooMuchIterations = errors.New("[rpc] dumper: too much iterations protection triggered")
+var ErrTooManyIterations = errors.New("[rpc] dumper: too many iterations protection triggered")
 
 func (d *Dumper) DumpToCollector(c DumpCollector, excludeCode, excludeStorage bool, startAddress common.Address, maxResults int) ([]byte, error) {
 	var emptyHash = common.Hash{}

--- a/rpc/jsonrpc/receipts/receipts_generator.go
+++ b/rpc/jsonrpc/receipts/receipts_generator.go
@@ -6,9 +6,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/google/go-cmp/cmp"
-	lru "github.com/hashicorp/golang-lru/v2"
-
 	"github.com/erigontech/erigon-db/rawdb"
 	"github.com/erigontech/erigon-db/rawdb/rawtemporaldb"
 	"github.com/erigontech/erigon-lib/chain"
@@ -27,6 +24,8 @@ import (
 	"github.com/erigontech/erigon/turbo/services"
 	"github.com/erigontech/erigon/turbo/snapshotsync/freezeblocks"
 	"github.com/erigontech/erigon/turbo/transactions"
+	"github.com/google/go-cmp/cmp"
+	lru "github.com/hashicorp/golang-lru/v2"
 )
 
 type Generator struct {

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -141,7 +141,7 @@ func (bt *BlockTest) Run(t *testing.T, checkStateRoot bool) error {
 		return err
 	}
 
-	tx, err := m.DB.BeginRo(m.Ctx)
+	tx, err := m.DB.BeginTemporalRo(m.Ctx)
 	if err != nil {
 		return err
 	}

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -43,7 +43,7 @@ import (
 	"github.com/erigontech/erigon-lib/kv"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon-lib/rlp"
-	state2 "github.com/erigontech/erigon-lib/state"
+	libstate "github.com/erigontech/erigon-lib/state"
 	"github.com/erigontech/erigon-lib/types"
 	"github.com/erigontech/erigon-lib/wrap"
 	"github.com/erigontech/erigon/core"
@@ -206,7 +206,7 @@ func (t *StateTest) RunNoVerify(tx kv.TemporalRwTx, subtest StateSubtest, vmconf
 	}
 
 	txc := wrap.NewTxContainer(tx, nil)
-	domains, err := state2.NewSharedDomains(txc.Ttx, log.New())
+	domains, err := libstate.NewSharedDomains(txc.Ttx, log.New())
 	if err != nil {
 		return nil, common.Hash{}, testutil.UnsupportedForkError{Name: subtest.Fork}
 	}
@@ -328,7 +328,7 @@ func MakePreState(rules *chain.Rules, tx kv.TemporalRwTx, accounts types.Genesis
 		}
 	}
 
-	domains, err := state2.NewSharedDomains(tx, log.New())
+	domains, err := libstate.NewSharedDomains(tx, log.New())
 	if err != nil {
 		return nil, err
 	}

--- a/tests/statedb_chain_test.go
+++ b/tests/statedb_chain_test.go
@@ -103,7 +103,7 @@ func TestSelfDestructReceive(t *testing.T) {
 	}
 
 	if err := m.DB.View(context.Background(), func(tx kv.Tx) error {
-		st := state.New(m.NewStateReader(tx))
+		st := state.New(m.NewStateReader(tx.(kv.TemporalTx)))
 		exist, err := st.Exist(address)
 		if err != nil {
 			return err
@@ -133,7 +133,7 @@ func TestSelfDestructReceive(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := m.DB.View(context.Background(), func(tx kv.Tx) error {
+	if err := m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		// If we got this far, the newly created blockchain (with empty trie cache) loaded trie from the database
 		// and that means that the state of the accounts written in the first block was correct.
 		// This test checks that the storage root of the account is properly set to the root of the empty tree

--- a/tests/statedb_insert_chain_transaction_test.go
+++ b/tests/statedb_insert_chain_transaction_test.go
@@ -87,7 +87,7 @@ func TestInsertIncorrectStateRootDifferentAccounts(t *testing.T) {
 	if err = m.InsertChain(chain); err != nil {
 		t.Fatal(err)
 	}
-	tx, err := m.DB.BeginRw(context.Background())
+	tx, err := m.DB.BeginTemporalRw(context.Background())
 	require.NoError(t, err)
 	defer tx.Rollback()
 
@@ -171,7 +171,7 @@ func TestInsertIncorrectStateRootSameAccount(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tx, err := m.DB.BeginRo(context.Background())
+	tx, err := m.DB.BeginTemporalRo(context.Background())
 	require.NoError(t, err)
 	defer tx.Rollback()
 
@@ -245,7 +245,7 @@ func TestInsertIncorrectStateRootSameAccountSameAmount(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tx, err := m.DB.BeginRo(context.Background())
+	tx, err := m.DB.BeginTemporalRo(context.Background())
 	require.NoError(t, err)
 	defer tx.Rollback()
 
@@ -319,7 +319,7 @@ func TestInsertIncorrectStateRootAllFundsRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tx, err := m.DB.BeginRo(context.Background())
+	tx, err := m.DB.BeginTemporalRw(context.Background())
 	require.NoError(t, err)
 	defer tx.Rollback()
 
@@ -393,7 +393,7 @@ func TestInsertIncorrectStateRootAllFunds(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tx, err := m.DB.BeginRo(context.Background())
+	tx, err := m.DB.BeginTemporalRw(context.Background())
 	require.NoError(t, err)
 	defer tx.Rollback()
 
@@ -449,7 +449,7 @@ func TestAccountDeployIncorrectRoot(t *testing.T) {
 	if err = m.InsertChain(chain.Slice(0, 1)); err != nil {
 		t.Fatal(err)
 	}
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		exist, err := st.Exist(from)
 		if err != nil {
@@ -479,7 +479,7 @@ func TestAccountDeployIncorrectRoot(t *testing.T) {
 		t.Fatal("should fail")
 	}
 
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		exist, err := st.Exist(from)
 		if err != nil {
@@ -505,7 +505,7 @@ func TestAccountDeployIncorrectRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		exist, err := st.Exist(from)
 		if err != nil {
@@ -559,7 +559,7 @@ func TestAccountCreateIncorrectRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		exist, err := st.Exist(from)
 		if err != nil {
@@ -585,7 +585,7 @@ func TestAccountCreateIncorrectRoot(t *testing.T) {
 	if err = m.InsertChain(chain.Slice(1, 2)); err != nil {
 		t.Fatal(err)
 	}
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		exist, err := st.Exist(from)
 		if err != nil {
@@ -659,7 +659,7 @@ func TestAccountUpdateIncorrectRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		exist, err := st.Exist(from)
 		if err != nil {
@@ -686,7 +686,7 @@ func TestAccountUpdateIncorrectRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		exist, err := st.Exist(from)
 		if err != nil {
@@ -764,7 +764,7 @@ func TestAccountDeleteIncorrectRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		exist, err := st.Exist(from)
 		if err != nil {
@@ -790,7 +790,7 @@ func TestAccountDeleteIncorrectRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = m.DB.View(context.Background(), func(tx kv.Tx) error {
+	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
 		exist, err := st.Exist(from)
 		if err != nil {

--- a/turbo/stages/blockchain_test.go
+++ b/turbo/stages/blockchain_test.go
@@ -1020,7 +1020,7 @@ func TestEIP161AccountRemoval(t *testing.T) {
 	if err = m.InsertChain(chain.Slice(0, 1)); err != nil {
 		t.Fatal(err)
 	}
-	tx, err := m.DB.BeginRw(m.Ctx)
+	tx, err := m.DB.BeginTemporalRw(m.Ctx)
 	if err != nil {
 		fmt.Printf("beginro error: %v\n", err)
 		return
@@ -1039,7 +1039,7 @@ func TestEIP161AccountRemoval(t *testing.T) {
 	if err = m.InsertChain(chain.Slice(1, 2)); err != nil {
 		t.Fatal(err)
 	}
-	if err = m.DB.View(m.Ctx, func(tx kv.Tx) error {
+	if err = m.DB.ViewTemporal(m.Ctx, func(tx kv.TemporalTx) error {
 		exist, err := state.New(m.NewStateReader(tx)).Exist(theAddr)
 		if err != nil {
 			return err
@@ -1056,7 +1056,7 @@ func TestEIP161AccountRemoval(t *testing.T) {
 	if err = m.InsertChain(chain.Slice(2, 3)); err != nil {
 		t.Fatal(err)
 	}
-	if err = m.DB.View(m.Ctx, func(tx kv.Tx) error {
+	if err = m.DB.ViewTemporal(m.Ctx, func(tx kv.TemporalTx) error {
 		exist, err := state.New(m.NewStateReader(tx)).Exist(theAddr)
 		if err != nil {
 			return err
@@ -1903,7 +1903,7 @@ func TestDeleteRecreateSlotsAcrossManyBlocks(t *testing.T) {
 		if err := m.InsertChain(chain.Slice(i, i+1)); err != nil {
 			t.Fatalf("block %d: failed to insert into chain: %v", i, err)
 		}
-		err = m.DB.View(m.Ctx, func(tx kv.Tx) error {
+		err = m.DB.ViewTemporal(m.Ctx, func(tx kv.TemporalTx) error {
 
 			statedb := state.New(m.NewStateReader(tx))
 			// If all is correct, then slot 1 and 2 are zero

--- a/turbo/stages/chain_makers_test.go
+++ b/turbo/stages/chain_makers_test.go
@@ -105,7 +105,7 @@ func TestGenerateChain(t *testing.T) {
 		return
 	}
 
-	tx, err := m.DB.BeginRw(m.Ctx)
+	tx, err := m.DB.BeginTemporalRw(m.Ctx)
 	if err != nil {
 		fmt.Printf("beginro error: %v\n", err)
 		return

--- a/turbo/stages/mock/mock_sentry.go
+++ b/turbo/stages/mock/mock_sentry.go
@@ -876,8 +876,8 @@ func (ms *MockSentry) NewHistoryStateReader(blockNum uint64, tx kv.TemporalTx) s
 	return r
 }
 
-func (ms *MockSentry) NewStateReader(tx kv.Tx) state.StateReader {
-	return state.NewReaderV3(tx.(kv.TemporalGetter))
+func (ms *MockSentry) NewStateReader(tx kv.TemporalGetter) state.StateReader {
+	return state.NewReaderV3(tx)
 }
 
 func (ms *MockSentry) BlocksIO() (services.FullBlockReader, *blockio.BlockWriter) {


### PR DESCRIPTION
This is a refactor to get tests to use `BeginTemporalRw` and `TemporalView` rather than blind casting `kv.Tx` to `TemporalGetter`.