### PR TITLE
Qa/sync with external + tip tracking summary

### DIFF
--- a/.github/workflows/qa-sync-with-externalcl.yml
+++ b/.github/workflows/qa-sync-with-externalcl.yml
@@ -85,6 +85,13 @@ jobs:
           else
             echo "Error detected during tests"
             echo "TEST_RESULT=failure" >> "$GITHUB_OUTPUT"
+            
+            # Read result file and create GitHub summary for failures
+            if [ -f "${{ github.workspace }}/result-$CHAIN.json" ]; then
+              outcome=$(python3 -c "import json; data=json.load(open('${{ github.workspace }}/result-$CHAIN.json')); print(data.get('outcome', 'unknown outcome'))")
+              reason=$(python3 -c "import json; data=json.load(open('${{ github.workspace }}/result-$CHAIN.json')); print(data.get('reason', 'no reason provided'))")
+              echo "::error::${outcome} - ${reason}"
+            fi
           fi
 
       - name: Save test results

--- a/.github/workflows/qa-tip-tracking-gnosis.yml
+++ b/.github/workflows/qa-tip-tracking-gnosis.yml
@@ -76,6 +76,13 @@ jobs:
         else
           echo "Error detected during tests"
           echo "TEST_RESULT=failure" >> "$GITHUB_OUTPUT"
+          
+          # Read result file and create GitHub summary for failures
+          if [ -f "${{ github.workspace }}/result-$CHAIN.json" ]; then
+            outcome=$(python3 -c "import json; data=json.load(open('${{ github.workspace }}/result-$CHAIN.json')); print(data.get('outcome', 'unknown outcome'))")
+            reason=$(python3 -c "import json; data=json.load(open('${{ github.workspace }}/result-$CHAIN.json')); print(data.get('reason', 'no reason provided'))")
+            echo "::error::${outcome} - ${reason}"
+          fi
         fi
 
     - name: Save test results

--- a/.github/workflows/qa-tip-tracking-polygon.yml
+++ b/.github/workflows/qa-tip-tracking-polygon.yml
@@ -77,6 +77,13 @@ jobs:
         else
           echo "Error detected during tests"
           echo "TEST_RESULT=failure" >> "$GITHUB_OUTPUT"
+          
+          # Read result file and create GitHub summary for failures
+          if [ -f "${{ github.workspace }}/result-$CHAIN.json" ]; then
+            outcome=$(python3 -c "import json; data=json.load(open('${{ github.workspace }}/result-$CHAIN.json')); print(data.get('outcome', 'unknown outcome'))")
+            reason=$(python3 -c "import json; data=json.load(open('${{ github.workspace }}/result-$CHAIN.json')); print(data.get('reason', 'no reason provided'))")
+            echo "::error::${outcome} - ${reason}"
+          fi
         fi
 
     - name: Save test results

--- a/.github/workflows/qa-tip-tracking.yml
+++ b/.github/workflows/qa-tip-tracking.yml
@@ -77,6 +77,13 @@ jobs:
         else
           echo "Error detected during tests"
           echo "TEST_RESULT=failure" >> "$GITHUB_OUTPUT"
+          
+          # Read result file and create GitHub summary for failures
+          if [ -f "${{ github.workspace }}/result-$CHAIN.json" ]; then
+            outcome=$(python3 -c "import json; data=json.load(open('${{ github.workspace }}/result-$CHAIN.json')); print(data.get('outcome', 'unknown outcome'))")
+            reason=$(python3 -c "import json; data=json.load(open('${{ github.workspace }}/result-$CHAIN.json')); print(data.get('reason', 'no reason provided'))")
+            echo "::error::${outcome} - ${reason}"
+          fi
         fi
 
     - name: Save test results


### PR DESCRIPTION
### Qa/sync with external + tip tracking summary

This pull request enhances the GitHub Actions workflows for QA testing by improving error reporting on test failures.

**Changes include:**

* After detecting test failures in the workflows (`qa-sync-with-externalcl.yml`, `qa-tip-tracking.yml`, `qa-tip-tracking-gnosis.yml`, and `qa-tip-tracking-polygon.yml`), the workflow now:

  * Checks for the presence of a JSON result file (`result-$CHAIN.json`) in the workspace.
  * Parses this file using Python to extract detailed failure information: the `outcome` and `reason`.
  * Adds a GitHub Actions error annotation (`::error::`) with these details to create a clear and immediate summary of the failure directly in the workflow logs and UI.

This improvement allows quicker diagnosis and easier identification of failure causes during CI runs by surfacing structured test failure information prominently in GitHub Actions.

