### PR TITLE
Fix for: Add error to GetHashFn & GetHeaderFn

### DIFF
--- a/cmd/devnet/services/polygon/proofgenerator_test.go
+++ b/cmd/devnet/services/polygon/proofgenerator_test.go
@@ -165,12 +165,8 @@ func (rg *requestGenerator) GetTransactionReceipt(ctx context.Context, hash comm
 
 	noopWriter := state.NewNoopWriter()
 
-	getHeader := func(hash common.Hash, number uint64) *types.Header {
-		h, e := reader.Header(ctx, tx, hash, number)
-		if e != nil {
-			log.Error("getHeader error", "number", number, "hash", hash, "err", e)
-		}
-		return h
+	getHeader := func(hash common.Hash, number uint64) (*types.Header, error) {
+		return reader.Header(ctx, tx, hash, number)
 	}
 
 	header := block.Header()

--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -284,17 +284,15 @@ func Main(ctx *cli.Context) error {
 	}
 	block := types.NewBlock(header, txs, ommerHeaders, nil /* receipts */, prestate.Env.Withdrawals)
 
-	var hashError error
-	getHash := func(num uint64) common.Hash {
+	getHash := func(num uint64) (common.Hash, error) {
 		if prestate.Env.BlockHashes == nil {
-			hashError = fmt.Errorf("getHash(%d) invoked, no blockhashes provided", num)
-			return common.Hash{}
+			return common.Hash{}, fmt.Errorf("getHash(%d) invoked, no blockhashes provided", num)
 		}
 		h, ok := prestate.Env.BlockHashes[math.HexOrDecimal64(num)]
 		if !ok {
-			hashError = fmt.Errorf("getHash(%d) invoked, blockhash for that block not provided", num)
+			return common.Hash{}, fmt.Errorf("getHash(%d) invoked, blockhash for that block not provided", num)
 		}
-		return h
+		return h, nil
 	}
 
 	db := temporaltest.NewTestDB(nil, datadir.New(""))
@@ -327,9 +325,6 @@ func Main(ctx *cli.Context) error {
 	t8logger := log.New("t8ntool")
 	chainReader := consensuschain.NewReader(chainConfig, tx, nil, t8logger)
 	result, err := core.ExecuteBlockEphemerally(chainConfig, &vmConfig, getHash, engine, block, reader, writer, chainReader, getTracer, t8logger)
-	if hashError != nil {
-		return NewError(ErrorMissingBlockhash, fmt.Errorf("blockhash error: %v", err))
-	}
 
 	if err != nil {
 		return fmt.Errorf("error on EBE: %w", err)

--- a/cmd/state/commands/opcode_tracer.go
+++ b/cmd/state/commands/opcode_tracer.go
@@ -616,8 +616,8 @@ func OpcodeTracer(genesis *types.Genesis, blockNum uint64, chaindata string, num
 		}
 		intraBlockState := state.New(dbstate)
 
-		getHeader := func(hash common.Hash, number uint64) *types.Header {
-			return rawdb.ReadHeader(historyTx, hash, number)
+		getHeader := func(hash common.Hash, number uint64) (*types.Header, error) {
+			return rawdb.ReadHeader(historyTx, hash, number), nil
 		}
 		receipts, err1 := runBlock(ethash.NewFullFaker(), intraBlockState, noOpWriter, noOpWriter, chainConfig, getHeader, block, vmConfig, false, logger)
 		if err1 != nil {
@@ -730,7 +730,7 @@ func OpcodeTracer(genesis *types.Genesis, blockNum uint64, chaindata string, num
 }
 
 func runBlock(engine consensus.Engine, ibs *state.IntraBlockState, txnWriter state.StateWriter, blockWriter state.StateWriter,
-	chainConfig *chain2.Config, getHeader func(hash common.Hash, number uint64) *types.Header, block *types.Block, vmConfig vm.Config, trace bool, logger log.Logger) (types.Receipts, error) {
+	chainConfig *chain2.Config, getHeader func(hash common.Hash, number uint64) (*types.Header, error), block *types.Block, vmConfig vm.Config, trace bool, logger log.Logger) (types.Receipts, error) {
 	header := block.Header()
 	vmConfig.TraceJumpDest = true
 	gp := new(core.GasPool).AddGas(block.GasLimit()).AddBlobGas(chainConfig.GetMaxBlobGasPerBlock(header.Time))

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -84,7 +84,7 @@ type EphemeralExecResult struct {
 // writes the result to the provided stateWriter
 func ExecuteBlockEphemerally(
 	chainConfig *chain.Config, vmConfig *vm.Config,
-	blockHashFunc func(n uint64) common.Hash,
+	blockHashFunc func(n uint64) (common.Hash, error),
 	engine consensus.Engine, block *types.Block,
 	stateReader state.StateReader, stateWriter state.StateWriter,
 	chainReader consensus.ChainReader, getTracer func(txIndex int, txHash common.Hash) (*tracing.Hooks, error),

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -115,7 +115,7 @@ func (b *BlockGen) AddFailedTx(tx types.Transaction) {
 // further limitations on the content of transactions that can be
 // added. If contract code relies on the BLOCKHASH instruction,
 // the block in chain will be returned.
-func (b *BlockGen) AddTxWithChain(getHeader func(hash common.Hash, number uint64) *types.Header, engine consensus.Engine, txn types.Transaction) {
+func (b *BlockGen) AddTxWithChain(getHeader func(hash common.Hash, number uint64) (*types.Header, error), engine consensus.Engine, txn types.Transaction) {
 	if b.beforeAddTx != nil {
 		b.beforeAddTx()
 	}
@@ -131,7 +131,7 @@ func (b *BlockGen) AddTxWithChain(getHeader func(hash common.Hash, number uint64
 	b.receipts = append(b.receipts, receipt)
 }
 
-func (b *BlockGen) AddFailedTxWithChain(getHeader func(hash common.Hash, number uint64) *types.Header, engine consensus.Engine, txn types.Transaction) {
+func (b *BlockGen) AddFailedTxWithChain(getHeader func(hash common.Hash, number uint64) (*types.Header, error), engine consensus.Engine, txn types.Transaction) {
 	if b.beforeAddTx != nil {
 		b.beforeAddTx()
 	}

--- a/core/evm.go
+++ b/core/evm.go
@@ -131,22 +131,23 @@ func GetHashFn(ref *types.Header, getHeader func(hash common.Hash, number uint64
 		defer hashLookupCacheLock.Unlock()
 
 		if n == lastKnownNumber {
-			//fmt.Println("GH-LN", n, refHash)
+			fmt.Println("GH-LN", n, refHash)
 			return lastKnownHash, nil
 		}
 
 		if n == refNumber {
-			//fmt.Println("GH-RF", n, refHash)
+			fmt.Println("GH-RF", n, refHash)
 			return refHash, nil
 		}
 
 		if hash, ok := hashLookupCache.Get(n); ok {
-			//fmt.Println("GH-CA", n, hash)
+			fmt.Println("GH-CA", n, hash)
 			return hash, nil
 		}
 
 		if n > lastKnownNumber {
 			if n > refNumber {
+				fmt.Println("GH-RNG", n)
 				return common.Hash{}, fmt.Errorf("block number out of range: max=%d", refNumber)
 			}
 			lastKnownNumber = refNumber
@@ -164,7 +165,7 @@ func GetHashFn(ref *types.Header, getHeader func(hash common.Hash, number uint64
 				lastKnownHash = hash
 				lastKnownNumber = lastKnownNumber - 1
 				if n == lastKnownNumber {
-					//fmt.Println("GH-CA1", lastKnownNumber, lastKnownHash)
+					fmt.Println("GH-CA1", lastKnownNumber, lastKnownHash)
 					return lastKnownHash, nil
 				}
 			}
@@ -177,6 +178,7 @@ func GetHashFn(ref *types.Header, getHeader func(hash common.Hash, number uint64
 			}()
 
 			if err != nil {
+				fmt.Println("GH-ERR", n)
 				return common.Hash{}, err
 			}
 			if header == nil {
@@ -187,10 +189,11 @@ func GetHashFn(ref *types.Header, getHeader func(hash common.Hash, number uint64
 			hashLookupCache.Add(lastKnownNumber, lastKnownHash)
 
 			if n == lastKnownNumber {
-				//fmt.Println("GH-DB", lastKnownNumber, lastKnownHash)
+				fmt.Println("GH-DB", lastKnownNumber, lastKnownHash)
 				return lastKnownHash, nil
 			}
 		}
+		fmt.Println("GH-END", n)
 		return common.Hash{}, nil
 	}
 }

--- a/core/evm.go
+++ b/core/evm.go
@@ -20,21 +20,25 @@
 package core
 
 import (
+	"fmt"
 	"math/big"
+	"sync"
 
 	"github.com/holiman/uint256"
 
 	"github.com/erigontech/erigon-lib/chain"
 	"github.com/erigontech/erigon-lib/common"
+
 	"github.com/erigontech/erigon-lib/types"
 	"github.com/erigontech/erigon/core/vm/evmtypes"
 	"github.com/erigontech/erigon/execution/consensus"
 	"github.com/erigontech/erigon/execution/consensus/merge"
 	"github.com/erigontech/erigon/execution/consensus/misc"
+	lru "github.com/hashicorp/golang-lru/v2"
 )
 
 // NewEVMBlockContext creates a new context for use in the EVM.
-func NewEVMBlockContext(header *types.Header, blockHashFunc func(n uint64) common.Hash,
+func NewEVMBlockContext(header *types.Header, blockHashFunc func(n uint64) (common.Hash, error),
 	engine consensus.EngineReader, author *common.Address, config *chain.Config) evmtypes.BlockContext {
 	// If we don't have an explicit author (i.e. not mining), extract from the header
 	var beneficiary common.Address
@@ -101,37 +105,93 @@ func NewEVMTxContext(msg Message) evmtypes.TxContext {
 	}
 }
 
-// GetHashFn returns a GetHashFunc which retrieves header hashes by number
-func GetHashFn(ref *types.Header, getHeader func(hash common.Hash, number uint64) *types.Header) func(n uint64) common.Hash {
-	// Cache will initially contain [refHash.parent],
-	// Then fill up with [refHash.p, refHash.pp, refHash.ppp, ...]
-	var cache []common.Hash
+var hashLookupCache = func() *lru.Cache[uint64, common.Hash] {
+	// lru.New only returns err on -ve size
+	cache, _ := lru.New[uint64, common.Hash](8192)
+	return cache
+}()
+var hashLookupCacheLock sync.Mutex
 
-	return func(n uint64) common.Hash {
-		// If there's no hash cache yet, make one
-		if len(cache) == 0 {
-			cache = append(cache, ref.ParentHash)
+// GetHashFn returns a GetHashFunc which retrieves header hashes by number
+func GetHashFn(ref *types.Header, getHeader func(hash common.Hash, number uint64) (*types.Header, error)) func(n uint64) (common.Hash, error) {
+	refNumber := ref.Number.Uint64() - 1
+	refHash := ref.ParentHash
+	lastKnownNumber := refNumber
+	lastKnownHash := refHash
+
+	hashLookupCacheLock.Lock()
+	defer hashLookupCacheLock.Unlock()
+
+	if _, ok := hashLookupCache.Get(refNumber); !ok {
+		hashLookupCache.Add(refNumber, refHash)
+	}
+
+	return func(n uint64) (common.Hash, error) {
+		hashLookupCacheLock.Lock()
+		defer hashLookupCacheLock.Unlock()
+
+		if n == lastKnownNumber {
+			//fmt.Println("GH-LN", n, refHash)
+			return lastKnownHash, nil
 		}
-		if idx := ref.Number.Uint64() - n - 1; idx < uint64(len(cache)) {
-			return cache[idx]
+
+		if n == refNumber {
+			//fmt.Println("GH-RF", n, refHash)
+			return refHash, nil
 		}
-		// No luck in the cache, but we can start iterating from the last element we already know
-		lastKnownHash := cache[len(cache)-1]
-		lastKnownNumber := ref.Number.Uint64() - uint64(len(cache))
+
+		if hash, ok := hashLookupCache.Get(n); ok {
+			//fmt.Println("GH-CA", n, hash)
+			return hash, nil
+		}
+
+		if n > lastKnownNumber {
+			if n > refNumber {
+				return common.Hash{}, fmt.Errorf("block number out of range: max=%d", refNumber)
+			}
+			lastKnownNumber = refNumber
+			lastKnownHash = refHash
+		}
 
 		for {
-			header := getHeader(lastKnownHash, lastKnownNumber)
+			for {
+				hash, ok := hashLookupCache.Get(lastKnownNumber - 1)
+
+				if !ok {
+					break
+				}
+
+				lastKnownHash = hash
+				lastKnownNumber = lastKnownNumber - 1
+				if n == lastKnownNumber {
+					//fmt.Println("GH-CA1", lastKnownNumber, lastKnownHash)
+					return lastKnownHash, nil
+				}
+			}
+
+			header, err := func() (*types.Header, error) {
+				hash, num := lastKnownHash, lastKnownNumber
+				hashLookupCacheLock.Unlock()
+				defer hashLookupCacheLock.Lock()
+				return getHeader(hash, num)
+			}()
+
+			if err != nil {
+				return common.Hash{}, err
+			}
 			if header == nil {
 				break
 			}
-			cache = append(cache, header.ParentHash)
 			lastKnownHash = header.ParentHash
 			lastKnownNumber = header.Number.Uint64() - 1
+			hashLookupCache.Add(lastKnownNumber, lastKnownHash)
+
 			if n == lastKnownNumber {
-				return lastKnownHash
+				//fmt.Println("GH-DB", lastKnownNumber, lastKnownHash)
+				return lastKnownHash, nil
 			}
 		}
-		return common.Hash{}
+		return common.Hash{}, nil
 	}
 }
 

--- a/core/state/intra_block_state_test.go
+++ b/core/state/intra_block_state_test.go
@@ -261,23 +261,13 @@ func (test *snapshotTest) run() bool {
 		return false
 	}
 	defer tx.Rollback()
-
-	domains, err := stateLib.NewSharedDomains(tx, log.New())
-	if err != nil {
-		test.err = err
-		return false
-	}
-	defer domains.Close()
-
-	domains.SetTxNum(1)
-	domains.SetBlockNum(1)
 	err = rawdbv3.TxNums.Append(tx, 1, 1)
 	if err != nil {
 		test.err = err
 		return false
 	}
 	var (
-		state        = New(NewReaderV3(domains.AsGetter(tx)))
+		state        = New(NewReaderV3(tx))
 		snapshotRevs = make([]int, len(test.snapshots))
 		sindex       = 0
 	)

--- a/core/state/txtask.go
+++ b/core/state/txtask.go
@@ -64,7 +64,7 @@ type TxTask struct {
 	Final           bool
 	Failed          bool
 	Tx              types.Transaction
-	GetHashFn       func(n uint64) common.Hash
+	GetHashFn       func(n uint64) (common.Hash, error)
 	TxAsMessage     *types.Message
 	EvmBlockContext evmtypes.BlockContext
 

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -111,7 +111,7 @@ func applyTransaction(config *chain.Config, engine consensus.EngineReader, gp *G
 // and uses the input parameters for its environment. It returns the receipt
 // for the transaction, gas used and an error if the transaction failed,
 // indicating the block was invalid.
-func ApplyTransaction(config *chain.Config, blockHashFunc func(n uint64) common.Hash, engine consensus.EngineReader,
+func ApplyTransaction(config *chain.Config, blockHashFunc func(n uint64) (common.Hash, error), engine consensus.EngineReader,
 	author *common.Address, gp *GasPool, ibs *state.IntraBlockState, stateWriter state.StateWriter,
 	header *types.Header, txn types.Transaction, gasUsed, usedBlobGas *uint64, cfg vm.Config,
 ) (*types.Receipt, []byte, error) {

--- a/core/vm/evmtypes/evmtypes.go
+++ b/core/vm/evmtypes/evmtypes.go
@@ -110,7 +110,7 @@ type (
 
 	// GetHashFunc returns the nth block hash in the blockchain
 	// and is used by the BLOCKHASH EVM op code.
-	GetHashFunc func(uint64) common.Hash
+	GetHashFunc func(uint64) (common.Hash, error)
 
 	// PostApplyMessageFunc is an extension point to execute custom logic at the end of core.ApplyMessage.
 	// It's used in Bor for AddFeeTransferLog or in ethereum to clear out the authority code at end of tx.

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -654,12 +654,11 @@ func opBlockhash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) (
 		lower = upper - params.BlockHashOldWindow
 	}
 	if arg64 >= lower && arg64 < upper {
-		hash := interpreter.evm.Context.GetHash(arg64)
-		// TODO uncomment after GetHash with error checkin
-		//if err != nil {
-		//	arg.Clear()
-		//	return nil, err
-		//}
+		hash, err := interpreter.evm.Context.GetHash(arg64)
+		if err != nil {
+			arg.Clear()
+			return nil, err
+		}
 		arg.SetBytes(hash.Bytes())
 	} else {
 		arg.Clear()

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -62,7 +62,7 @@ type Config struct {
 	State *state.IntraBlockState
 
 	evm       *vm.EVM
-	GetHashFn func(n uint64) common.Hash
+	GetHashFn func(n uint64) (common.Hash, error)
 }
 
 // sets defaults on the config
@@ -108,8 +108,8 @@ func setDefaults(cfg *Config) {
 		cfg.BlockNumber = new(big.Int)
 	}
 	if cfg.GetHashFn == nil {
-		cfg.GetHashFn = func(n uint64) common.Hash {
-			return common.BytesToHash(crypto.Keccak256([]byte(new(big.Int).SetUint64(n).String())))
+		cfg.GetHashFn = func(n uint64) (common.Hash, error) {
+			return common.BytesToHash(crypto.Keccak256([]byte(new(big.Int).SetUint64(n).String()))), nil
 		}
 	}
 }

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -422,7 +422,7 @@ func (d *dummyChain) Engine() consensus.Engine {
 }
 
 // GetHeader returns the hash corresponding to their hash.
-func (d *dummyChain) GetHeader(h common.Hash, n uint64) *types.Header {
+func (d *dummyChain) GetHeader(h common.Hash, n uint64) (*types.Header, error) {
 	d.counter++
 	parentHash := common.Hash{}
 	s := common.LeftPadBytes(new(big.Int).SetUint64(n-1).Bytes(), 32)
@@ -430,7 +430,7 @@ func (d *dummyChain) GetHeader(h common.Hash, n uint64) *types.Header {
 
 	//parentHash := common.Hash{byte(n - 1)}
 	//fmt.Printf("GetHeader(%x, %d) => header with parent %x\n", h, n, parentHash)
-	return fakeHeader(n, parentHash)
+	return fakeHeader(n, parentHash), nil
 }
 
 // TestBlockhash tests the blockhash operation. It's a bit special, since it internally

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -506,7 +506,7 @@ Loop:
 		signer := *types.MakeSigner(chainConfig, blockNum, header.Time)
 
 		getHashFnMute := &sync.Mutex{}
-		getHashFn := core.GetHashFn(header, func(hash common.Hash, number uint64) (h *types.Header) {
+		getHashFn := core.GetHashFn(header, func(hash common.Hash, number uint64) (*types.Header, error) {
 			getHashFnMute.Lock()
 			defer getHashFnMute.Unlock()
 			return executor.getHeader(ctx, hash, number)

--- a/eth/stagedsync/exec3_parallel.go
+++ b/eth/stagedsync/exec3_parallel.go
@@ -72,7 +72,7 @@ type executor interface {
 	execute(ctx context.Context, tasks []*state.TxTask, gp *core.GasPool) (bool, error)
 	status(ctx context.Context, commitThreshold uint64) error
 	wait() error
-	getHeader(ctx context.Context, hash common.Hash, number uint64) (h *types.Header)
+	getHeader(ctx context.Context, hash common.Hash, number uint64) (*types.Header, error)
 
 	//these are reset by commit - so need to be read from the executor once its processing
 	tx() kv.RwTx
@@ -110,26 +110,22 @@ func (te *txExecutor) domains() *state2.SharedDomains {
 	return te.doms
 }
 
-func (te *txExecutor) getHeader(ctx context.Context, hash common.Hash, number uint64) (h *types.Header) {
-	var err error
+func (te *txExecutor) getHeader(ctx context.Context, hash common.Hash, number uint64) (*types.Header, error) {
 	if te.applyTx != nil {
-		h, err = te.cfg.blockReader.Header(ctx, te.applyTx, hash, number)
-		if err != nil {
-			panic(err)
-		}
-		return h
+		return te.cfg.blockReader.Header(ctx, te.applyTx, hash, number)
 	}
 
-	if err = te.cfg.db.View(ctx, func(tx kv.Tx) error {
+	var h *types.Header
+	var err error
+
+	err = te.cfg.db.View(ctx, func(tx kv.Tx) error {
 		h, err = te.cfg.blockReader.Header(ctx, tx, hash, number)
 		if err != nil {
 			return err
 		}
 		return nil
-	}); err != nil {
-		panic(err)
-	}
-	return h
+	})
+	return h, err
 }
 
 type parallelExecutor struct {

--- a/eth/stagedsync/stage_mining_exec.go
+++ b/eth/stagedsync/stage_mining_exec.go
@@ -112,15 +112,11 @@ func SpawnMiningExecStage(s *StageState, txc wrap.TxContainer, cfg MiningExecCfg
 	//}
 	execCfg.author = &cfg.miningState.MiningConfig.Etherbase
 
-	getHeader := func(hash common.Hash, number uint64) *types.Header {
+	getHeader := func(hash common.Hash, number uint64) (*types.Header, error) {
 		if execCfg.blockReader == nil {
-			return rawdb.ReadHeader(txc.Tx, hash, number)
+			return rawdb.ReadHeader(txc.Tx, hash, number), nil
 		}
-		header, err := execCfg.blockReader.Header(ctx, txc.Tx, hash, number)
-		if err != nil {
-			panic(fmt.Sprintf("cannot read header: %s", err))
-		}
-		return header
+		return execCfg.blockReader.Header(ctx, txc.Tx, hash, number)
 	}
 
 	mb := membatchwithdb.NewMemoryBatch(txc.Tx, cfg.tmpdir, logger)
@@ -425,7 +421,7 @@ func addTransactionsToMiningBlock(
 	current *MiningBlock,
 	chainConfig *chain.Config,
 	vmConfig *vm.Config,
-	getHeader func(hash common.Hash, number uint64) *types.Header,
+	getHeader func(hash common.Hash, number uint64) (*types.Header, error),
 	engine consensus.Engine,
 	txns types.Transactions,
 	coinbase common.Address,

--- a/eth/stagedsync/stage_witness.go
+++ b/eth/stagedsync/stage_witness.go
@@ -42,7 +42,7 @@ type WitnessStore struct {
 	TrieStateWriter *state.TrieStateWriter
 	Statedb         *state.IntraBlockState
 	ChainReader     *ChainReaderImpl
-	GetHashFn       func(n uint64) common.Hash
+	GetHashFn       func(n uint64) (common.Hash, error)
 }
 
 func StageWitnessCfg(enableWitnessGeneration bool, maxWitnessLimit uint64, chainConfig *chain.Config, engine consensus.Engine, blockReader services.FullBlockReader, dirs datadir.Dirs) WitnessCfg {
@@ -77,12 +77,8 @@ func PrepareForWitness(tx kv.TemporalTx, block *types.Block, prevRoot common.Has
 
 	chainReader := NewChainReaderImpl(cfg.chainConfig, tx, cfg.blockReader, logger)
 
-	getHeader := func(hash common.Hash, number uint64) *types.Header {
-		h, e := cfg.blockReader.Header(ctx, tx, hash, number)
-		if e != nil {
-			log.Error("getHeader error", "number", number, "hash", hash, "err", e)
-		}
-		return h
+	getHeader := func(hash common.Hash, number uint64) (*types.Header, error) {
+		return cfg.blockReader.Header(ctx, tx, hash, number)
 	}
 	getHashFn := core.GetHashFn(block.Header(), getHeader)
 
@@ -127,7 +123,7 @@ func RewindStagesForWitness(batch *membatchwithdb.MemoryMutation, blockNr, lates
 	return nil
 }
 
-func ExecuteBlockStatelessly(block *types.Block, prevHeader *types.Header, chainReader consensus.ChainReader, tds *state.TrieDbState, cfg *WitnessCfg, buf *bytes.Buffer, getHashFn func(n uint64) common.Hash, logger log.Logger) (common.Hash, error) {
+func ExecuteBlockStatelessly(block *types.Block, prevHeader *types.Header, chainReader consensus.ChainReader, tds *state.TrieDbState, cfg *WitnessCfg, buf *bytes.Buffer, getHashFn func(n uint64) (common.Hash, error), logger log.Logger) (common.Hash, error) {
 	blockNr := block.NumberU64()
 	nw, err := trie.NewWitnessFromReader(bytes.NewReader(buf.Bytes()), false)
 	if err != nil {

--- a/execution/consensus/clique/clique_test.go
+++ b/execution/consensus/clique/clique_test.go
@@ -67,14 +67,12 @@ func TestReimportMirroredState(t *testing.T) {
 	m := mock.MockWithGenesisEngine(t, genspec, engine, false, checkStateRoot)
 
 	// Generate a batch of blocks, each properly signed
-	getHeader := func(hash common.Hash, number uint64) (h *types.Header) {
-		if err := m.DB.View(m.Ctx, func(tx kv.Tx) (err error) {
+	getHeader := func(hash common.Hash, number uint64) (h *types.Header, err error) {
+		err = m.DB.View(m.Ctx, func(tx kv.Tx) (err error) {
 			h, err = m.BlockReader.Header(m.Ctx, tx, hash, number)
 			return err
-		}); err != nil {
-			panic(err)
-		}
-		return h
+		})
+		return h, err
 	}
 
 	chain, err := core.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 3, func(i int, block *core.BlockGen) {

--- a/rpc/jsonrpc/eth_callMany.go
+++ b/rpc/jsonrpc/eth_callMany.go
@@ -160,15 +160,15 @@ func (api *APIImpl) CallMany(ctx context.Context, bundles []Bundle, simulateCont
 		return nil, fmt.Errorf("block %d(%x) not found", blockNum, hash)
 	}
 
-	getHash := func(i uint64) common.Hash {
+	getHash := func(i uint64) (common.Hash, error) {
 		if hash, ok := overrideBlockHash[i]; ok {
-			return hash
+			return hash, nil
 		}
 		hash, ok, err := api._blockReader.CanonicalHash(ctx, tx, i)
 		if err != nil || !ok {
 			log.Debug("Can't get block hash by number", "number", i, "only-canonical", true, "err", err, "ok", ok)
 		}
-		return hash
+		return hash, err
 	}
 
 	blockCtx = core.NewEVMBlockContext(header, getHash, api.engine(), nil /* author */, chainConfig)

--- a/rpc/jsonrpc/otterscan_search_trace.go
+++ b/rpc/jsonrpc/otterscan_search_trace.go
@@ -87,12 +87,8 @@ func (api *OtterscanAPIImpl) traceBlock(dbtx kv.TemporalTx, ctx context.Context,
 	ibs := state.New(cachedReader)
 	signer := types.MakeSigner(chainConfig, blockNum, block.Time())
 
-	getHeader := func(hash common.Hash, number uint64) *types.Header {
-		h, e := api._blockReader.Header(ctx, dbtx, hash, number)
-		if e != nil {
-			log.Error("getHeader error", "number", number, "hash", hash, "err", e)
-		}
-		return h
+	getHeader := func(hash common.Hash, number uint64) (*types.Header, error) {
+		return api._blockReader.Header(ctx, dbtx, hash, number)
 	}
 	engine := api.engine()
 

--- a/rpc/jsonrpc/overlay_api.go
+++ b/rpc/jsonrpc/overlay_api.go
@@ -161,15 +161,15 @@ func (api *OverlayAPIImpl) CallConstructor(ctx context.Context, address common.A
 		return nil, fmt.Errorf("block %d(%x) not found", blockNum, block.Hash())
 	}
 
-	getHash := func(i uint64) common.Hash {
+	getHash := func(i uint64) (common.Hash, error) {
 		if hash, ok := overrideBlockHash[i]; ok {
-			return hash
+			return hash, nil
 		}
 		hash, ok, err := api._blockReader.CanonicalHash(ctx, tx, i)
 		if err != nil || !ok {
 			log.Debug("Can't get block hash by number", "number", i, "only-canonical", true, "err", err, "ok", ok)
 		}
-		return hash
+		return hash, err
 	}
 
 	blockCtx = core.NewEVMBlockContext(header, getHash, api.engine(), nil, chainConfig)
@@ -441,15 +441,15 @@ func (api *OverlayAPIImpl) replayBlock(ctx context.Context, blockNum uint64, sta
 		return nil, fmt.Errorf("block %d(%x) not found", blockNum, hash)
 	}
 
-	getHash := func(i uint64) common.Hash {
+	getHash := func(i uint64) (common.Hash, error) {
 		if hash, ok := overrideBlockHash[i]; ok {
-			return hash
+			return hash, nil
 		}
 		hash, ok, err := api._blockReader.CanonicalHash(ctx, tx, i)
 		if err != nil || !ok {
 			log.Debug("Can't get block hash by number", "number", i, "only-canonical", true, "err", err, "ok", ok)
 		}
-		return hash
+		return hash, err
 	}
 
 	blockCtx = core.NewEVMBlockContext(header, getHash, api.engine(), nil, chainConfig)

--- a/rpc/jsonrpc/receipts/receipts_generator.go
+++ b/rpc/jsonrpc/receipts/receipts_generator.go
@@ -53,7 +53,7 @@ type ReceiptEnv struct {
 	usedBlobGas *uint64
 	gp          *core.GasPool
 	noopWriter  *state.NoopWriter
-	getHeader   func(hash common.Hash, number uint64) *types.Header
+	getHeader   func(hash common.Hash, number uint64) (*types.Header, error)
 	header      *types.Header
 }
 
@@ -118,12 +118,12 @@ func (g *Generator) PrepareEnv(ctx context.Context, header *types.Header, cfg *c
 
 	noopWriter := state.NewNoopWriter()
 
-	getHeader := func(hash common.Hash, number uint64) *types.Header {
+	getHeader := func(hash common.Hash, number uint64) (*types.Header, error) {
 		h, e := g.blockReader.Header(ctx, tx, hash, number)
 		if e != nil {
 			log.Error("getHeader error", "number", number, "hash", hash, "err", e)
 		}
-		return h
+		return h, e
 	}
 	return &ReceiptEnv{
 		ibs:         ibs,

--- a/rpc/jsonrpc/tracing.go
+++ b/rpc/jsonrpc/tracing.go
@@ -519,15 +519,16 @@ func (api *PrivateDebugAPIImpl) TraceCallMany(ctx context.Context, bundles []Bun
 		return fmt.Errorf("block %d(%x) not found", blockNum, hash)
 	}
 
-	getHash := func(i uint64) common.Hash {
+	getHash := func(i uint64) (common.Hash, error) {
 		if hash, ok := overrideBlockHash[i]; ok {
-			return hash
+			return hash, nil
 		}
 		hash, ok, err := api._blockReader.CanonicalHash(ctx, tx, i)
 		if err != nil || !ok {
 			log.Debug("Can't get block hash by number", "number", i, "only-canonical", true, "err", err, "ok", ok)
+			return common.Hash{}, err
 		}
-		return hash
+		return hash, nil
 	}
 
 	blockCtx = core.NewEVMBlockContext(header, getHash, api.engine(), nil /* author */, chainConfig)

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -370,8 +370,8 @@ func rlpHash(x interface{}) (h common.Hash) {
 	return h
 }
 
-func vmTestBlockHash(n uint64) common.Hash {
-	return common.BytesToHash(crypto.Keccak256([]byte(new(big.Int).SetUint64(n).String())))
+func vmTestBlockHash(n uint64) (common.Hash, error) {
+	return common.BytesToHash(crypto.Keccak256([]byte(new(big.Int).SetUint64(n).String()))), nil
 }
 
 func toMessage(tx stTransaction, ps stPostState, baseFee *big.Int) (core.Message, error) {

--- a/turbo/transactions/call.go
+++ b/turbo/transactions/call.go
@@ -127,18 +127,18 @@ func NewEVMBlockContext(engine consensus.EngineReader, header *types.Header, req
 	return core.NewEVMBlockContext(header, blockHashFunc, engine, nil /* author */, config)
 }
 
-func MakeHeaderGetter(requireCanonical bool, tx kv.Getter, headerReader interfaces.HeaderReader) func(uint64) common.Hash {
-	return func(n uint64) common.Hash {
+func MakeHeaderGetter(requireCanonical bool, tx kv.Getter, headerReader interfaces.HeaderReader) func(uint64) (common.Hash, error) {
+	return func(n uint64) (common.Hash, error) {
 		h, err := headerReader.HeaderByNumber(context.Background(), tx, n)
 		if err != nil {
 			log.Error("Can't get block hash by number", "number", n, "only-canonical", requireCanonical)
-			return common.Hash{}
+			return common.Hash{}, err
 		}
 		if h == nil {
 			log.Warn("[evm] header is nil", "blockNum", n)
-			return common.Hash{}
+			return common.Hash{}, nil
 		}
-		return h.Hash()
+		return h.Hash(), nil
 	}
 }
 

--- a/turbo/transactions/tracing.go
+++ b/turbo/transactions/tracing.go
@@ -63,9 +63,8 @@ func ComputeBlockContext(ctx context.Context, engine consensus.EngineReader, hea
 	// Create the parent state database
 	statedb := state.New(reader)
 
-	getHeader := func(hash common.Hash, n uint64) *types.Header {
-		h, _ := headerReader.HeaderByNumber(ctx, dbtx, n)
-		return h
+	getHeader := func(hash common.Hash, n uint64) (*types.Header, error) {
+		return headerReader.HeaderByNumber(ctx, dbtx, n)
 	}
 
 	blockContext := core.NewEVMBlockContext(header, core.GetHashFn(header, getHeader), engine, nil, cfg)


### PR DESCRIPTION
https://github.com/erigontech/erigon/pull/15344 was failing tests due to their use of repeating block numbers which does not happen in normal operation.

This change fixes the tests at the cost of slightly worse memory usage and performance in normal operations as caching is now done at a block rather than process level.