### PR TITLE
tests: more explicit make target names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           fi
 
       - name: Test
-        run: make test
+        run: make test-short
 
   win:
     if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
@@ -107,13 +107,13 @@ jobs:
         run: .\wmake.ps1 all
 
       - name: Test
-        run: .\wmake.ps1 test
+        run: .\wmake.ps1 test-short
 
       - name: Test erigon-lib
-        run: cd erigon-lib && make test
+        run: cd erigon-lib && make test-short
 
       - name: Test erigon-db
-        run: cd erigon-db && make test
+        run: cd erigon-db && make test-short
 
       - name: Test p2p
-        run: cd p2p && make test
+        run: cd p2p && make test-short

--- a/.github/workflows/test-all-erigon.yml
+++ b/.github/workflows/test-all-erigon.yml
@@ -79,7 +79,7 @@ jobs:
         
       - name: Run all tests on ${{ matrix.os }}
         if: needs.source-of-changes.outputs.changed_files != 'true'
-        run: GOGC=80 make test-all
+        run: GOGC=80 make test-all-race
 
       - name: SonarCloud
         if: runner.os == 'Linux' && needs.source-of-changes.outputs.changed_files != 'true'

--- a/Makefile
+++ b/Makefile
@@ -168,33 +168,46 @@ db-tools:
 	rm -rf vendor
 	@echo "Run \"$(GOBIN)/mdbx_stat -h\" to get info about mdbx db file."
 
-test-erigon-lib:
-	@cd erigon-lib && $(MAKE) test
+test-erigon-lib-short:
+	@cd erigon-lib && $(MAKE) test-short
 
 test-erigon-lib-all:
 	@cd erigon-lib && $(MAKE) test-all
 
-test-erigon-db:
-	@cd erigon-db && $(MAKE) test
+test-erigon-lib-all-race:
+	@cd erigon-lib && $(MAKE) test-all-race
+
+test-erigon-db-short:
+	@cd erigon-db && $(MAKE) test-short
 
 test-erigon-db-all:
 	@cd erigon-db && $(MAKE) test-all
 
-test-p2:
-	@cd p2p && $(MAKE) test
+test-erigon-db-all-race:
+	@cd erigon-db && $(MAKE) test-all-race
+
+test-p2-short:
+	@cd p2p && $(MAKE) test-short
 
 test-p2p-all:
 	@cd p2p && $(MAKE) test-all
 
+test-p2p-all-race:
+	@cd p2p && $(MAKE) test-all-race
+
 test-erigon-ext:
 	@cd tests/erigon-ext-test && ./test.sh $(GIT_COMMIT)
 
-## test:                      run short tests with a 10m timeout
-test: test-erigon-lib test-erigon-db test-p2
+## test-short:                run short tests with a 10m timeout
+test-short: test-erigon-lib-short test-erigon-db-short test-p2-short
 	$(GOTEST) -short --timeout 10m -coverprofile=coverage-test.out
 
 ## test-all:                  run all tests with a 1h timeout
 test-all: test-erigon-lib-all test-erigon-db-all test-p2p-all
+	$(GOTEST) --timeout 60m -coverprofile=coverage-test-all.out
+
+## test-all-race:             run all tests with the race flag
+test-all-race: test-erigon-lib-all-race test-erigon-db-all-race test-p2p-all-race
 	$(GOTEST) --timeout 60m -coverprofile=coverage-test-all.out -race
 
 ## test-hive						run the hive tests locally off nektos/act workflows simulator

--- a/erigon-db/Makefile
+++ b/erigon-db/Makefile
@@ -6,8 +6,11 @@ endif
 
 GOTEST = CGO_CXXFLAGS="$(CGO_CXXFLAGS)" go test -trimpath
 
-test:
+test-short:
 	$(GOTEST) -short -coverprofile=coverage-test.out ./...
 
 test-all:
+	$(GOTEST) -coverprofile=coverage-test-all.out ./...
+
+test-all-race:
 	$(GOTEST) -coverprofile=coverage-test-all.out -race ./...

--- a/erigon-lib/Makefile
+++ b/erigon-lib/Makefile
@@ -109,8 +109,11 @@ lint-mod-tidy:
 lint-deps: lintci-deps
 lint: lintci lint-mod-tidy
 
-test:
+test-short:
 	$(GOTEST_NOFUZZ) -short -coverprofile=coverage-test.out ./...
 
 test-all:
+	$(GOTEST) -coverprofile=coverage-test-all.out ./...
+
+test-all-race:
 	$(GOTEST) -coverprofile=coverage-test-all.out -race ./...

--- a/p2p/Makefile
+++ b/p2p/Makefile
@@ -6,8 +6,11 @@ endif
 
 GOTEST = CGO_CXXFLAGS="$(CGO_CXXFLAGS)" go test -trimpath
 
-test:
+test-short:
 	$(GOTEST) -short -coverprofile=coverage-test.out ./...
 
 test-all:
+	$(GOTEST) -coverprofile=coverage-test-all.out ./...
+
+test-all-race:
 	$(GOTEST) -coverprofile=coverage-test-all.out -race ./...

--- a/wmake.ps1
+++ b/wmake.ps1
@@ -35,7 +35,7 @@ Param(
         "rpctest",
         "sentry",
         "state",
-        "test",
+        "test-short",
         "test-all",
         "txpool",
         "all"
@@ -519,7 +519,7 @@ if ($BuildTarget -eq "db-tools") {
     # Clear go cache
     go.exe clean -cache
 
-} elseif ($BuildTarget -eq "test") {
+} elseif ($BuildTarget -eq "test-short") {
     Write-Host " Running short tests ..."
     $env:GODEBUG = "cgocheck=0"
     $TestCommand = "go test $($Erigon.BuildFlags) -short --timeout 10m ./..."


### PR DESCRIPTION
We decided at the QA call today to rename the make targets since it wasn't clear that `make test` runs only a subset of tests. So now it's one of the following:

- `make test-short`
- `make test-all`
- `make test-all-race`