### PR TITLE
rpc: enable stack-based json stream

### DIFF
--- a/erigon-lib/jsonstream/factory.go
+++ b/erigon-lib/jsonstream/factory.go
@@ -1,0 +1,34 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package jsonstream
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+)
+
+const AutoCloseOnError = true
+const InitialBufferSize = 4096
+
+func New(out io.Writer) Stream {
+	stream := jsoniter.NewStream(jsoniter.ConfigDefault, out, InitialBufferSize)
+	if AutoCloseOnError {
+		return NewStackStream(stream)
+	}
+	return NewJsoniterStream(stream)
+}

--- a/erigon-lib/jsonstream/factory.go
+++ b/erigon-lib/jsonstream/factory.go
@@ -32,3 +32,10 @@ func New(out io.Writer) Stream {
 	}
 	return NewJsoniterStream(stream)
 }
+
+func Wrap(stream *jsoniter.Stream) Stream {
+	if AutoCloseOnError {
+		return NewStackStream(stream)
+	}
+	return NewJsoniterStream(stream)
+}

--- a/erigon-lib/jsonstream/stack_stream.go
+++ b/erigon-lib/jsonstream/stack_stream.go
@@ -238,11 +238,13 @@ func (s *StackStream) BufferAsString() (string, error) {
 // WriteEmptyArray writes an empty array into the underlying stream
 func (s *StackStream) WriteEmptyArray() {
 	s.stream.WriteEmptyArray()
+	s.popCommaOrField()
 }
 
 // WriteEmptyObject writes an empty object into the underlying stream
 func (s *StackStream) WriteEmptyObject() {
 	s.stream.WriteEmptyObject()
+	s.popCommaOrField()
 }
 
 // IsComplete checks if the JSON structure is currently complete without open elements

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -546,7 +546,6 @@ func (h *handler) runMethod(ctx context.Context, msg *jsonrpcMessage, callb *cal
 	stream.WriteObjectField("result")
 	_, err := callb.call(ctx, msg.Method, args, stream)
 	if err != nil {
-		writeNilIfNotPresent(stream)
 		_ = stream.ClosePending(1) // the enclosing JSON object is explicitly handled below
 		stream.WriteMore()
 		HandleError(err, stream)
@@ -554,51 +553,6 @@ func (h *handler) runMethod(ctx context.Context, msg *jsonrpcMessage, callb *cal
 	stream.WriteObjectEnd()
 	stream.Flush()
 	return nil
-}
-
-var nullAsBytes = []byte{110, 117, 108, 108}
-
-// there are many avenues that could lead to an error being handled in runMethod, so we need to check
-// if nil has already been written to the stream before writing it again here
-func writeNilIfNotPresent(stream jsonstream.Stream) {
-	if stream == nil {
-		return
-	}
-	b := stream.Buffer()
-	hasNil := true
-	if len(b) >= 4 {
-		b = b[len(b)-4:]
-		for i, v := range nullAsBytes {
-			if v != b[i] {
-				hasNil = false
-				break
-			}
-		}
-	} else {
-		hasNil = false
-	}
-	if hasNil {
-		// not needed
-		return
-	}
-
-	var validJsonEnd bool
-	if len(b) > 0 {
-		// assumption is that api call handlers would write valid json in case of errors
-		// we are not guaranteed that they did write valid json if last elem is "}" or "]"
-		// since we don't check json nested-ness
-		// however appending "null" after "}" or "]" does not help much either
-		lastIdx := len(b) - 1
-		validJsonEnd = b[lastIdx] == '}' || b[lastIdx] == ']'
-	}
-	if validJsonEnd {
-		// not needed
-		return
-	}
-
-	// does not have nil ending
-	// does not have valid json
-	stream.WriteNil()
 }
 
 // unsubscribe is the callback function for all *_unsubscribe calls.

--- a/rpc/handler_test.go
+++ b/rpc/handler_test.go
@@ -103,7 +103,7 @@ func TestHandlerDoesNotDoubleWriteNull(t *testing.T) {
 			}
 
 			var buf bytes.Buffer
-			stream := jsonstream.NewJsoniterStream(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
+			stream := jsonstream.New(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
 
 			h := handler{}
 			h.runMethod(context.Background(), &msg, cb, args, stream)

--- a/rpc/handler_test.go
+++ b/rpc/handler_test.go
@@ -47,9 +47,13 @@ func TestHandlerDoesNotDoubleWriteNull(t *testing.T) {
 			params:   []byte("[3]"),
 			expected: `{"jsonrpc":"2.0","id":1,"result":{}}`,
 		},
-		"err_with_valid_json": {
+		"err_with_valid_json_empty_array": {
 			params:   []byte("[4]"),
 			expected: `{"jsonrpc":"2.0","id":1,"result":{"structLogs":[]},"error":{"code":-32000,"message":"id 4"}}`,
+		},
+		"err_with_valid_json_empty_object": {
+			params:   []byte("[5]"),
+			expected: `{"jsonrpc":"2.0","id":1,"result":{"structLogs":{}},"error":{"code":-32000,"message":"id 4"}}`,
 		},
 	}
 
@@ -80,6 +84,13 @@ func TestHandlerDoesNotDoubleWriteNull(t *testing.T) {
 					stream.WriteObjectStart()
 					stream.WriteObjectField("structLogs")
 					stream.WriteEmptyArray()
+					stream.WriteObjectEnd()
+					return errors.New("id 4")
+				}
+				if id == 5 {
+					stream.WriteObjectStart()
+					stream.WriteObjectField("structLogs")
+					stream.WriteEmptyObject()
 					stream.WriteObjectEnd()
 					return errors.New("id 4")
 				}

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -281,7 +281,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer codec.Close()
 	var stream jsonstream.Stream
 	if !s.disableStreaming {
-		stream = newJsonStream(w)
+		stream = jsonstream.New(w)
 	}
 	s.serveSingleRequest(ctx, codec, stream)
 }

--- a/rpc/jsonrpc/call_traces_test.go
+++ b/rpc/jsonrpc/call_traces_test.go
@@ -75,7 +75,7 @@ func TestCallTraceOneByOne(t *testing.T) {
 	}
 	s := jsoniter.ConfigDefault.BorrowStream(nil)
 	defer jsoniter.ConfigDefault.ReturnStream(s)
-	stream := jsonstream.New(s)
+	stream := jsonstream.Wrap(s)
 	var fromBlock, toBlock uint64
 	fromBlock = 1
 	toBlock = 10
@@ -119,7 +119,7 @@ func TestCallTraceUnwind(t *testing.T) {
 	}
 	s := jsoniter.ConfigDefault.BorrowStream(nil)
 	defer jsoniter.ConfigDefault.ReturnStream(s)
-	stream := jsonstream.New(s)
+	stream := jsonstream.Wrap(s)
 	var fromBlock, toBlock uint64
 	fromBlock = 1
 	toBlock = 10
@@ -183,7 +183,7 @@ func TestFilterNoAddresses(t *testing.T) {
 	}
 	s := jsoniter.ConfigDefault.BorrowStream(nil)
 	defer jsoniter.ConfigDefault.ReturnStream(s)
-	stream := jsonstream.New(s)
+	stream := jsonstream.Wrap(s)
 	var fromBlock, toBlock uint64
 	fromBlock = 1
 	toBlock = 10
@@ -232,7 +232,7 @@ func TestFilterAddressIntersection(t *testing.T) {
 	t.Run("second", func(t *testing.T) {
 		s := jsoniter.ConfigDefault.BorrowStream(nil)
 		defer jsoniter.ConfigDefault.ReturnStream(s)
-		stream := jsonstream.New(s)
+		stream := jsonstream.Wrap(s)
 
 		traceReq1 := TraceFilterRequest{
 			FromBlock:   (*hexutil.Uint64)(&fromBlock),
@@ -249,7 +249,7 @@ func TestFilterAddressIntersection(t *testing.T) {
 	t.Run("first", func(t *testing.T) {
 		s := jsoniter.ConfigDefault.BorrowStream(nil)
 		defer jsoniter.ConfigDefault.ReturnStream(s)
-		stream := jsonstream.New(s)
+		stream := jsonstream.Wrap(s)
 
 		traceReq1 := TraceFilterRequest{
 			FromBlock:   (*hexutil.Uint64)(&fromBlock),
@@ -266,7 +266,7 @@ func TestFilterAddressIntersection(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		s := jsoniter.ConfigDefault.BorrowStream(nil)
 		defer jsoniter.ConfigDefault.ReturnStream(s)
-		stream := jsonstream.New(s)
+		stream := jsonstream.Wrap(s)
 
 		traceReq1 := TraceFilterRequest{
 			FromBlock:   (*hexutil.Uint64)(&fromBlock),

--- a/rpc/jsonrpc/call_traces_test.go
+++ b/rpc/jsonrpc/call_traces_test.go
@@ -75,7 +75,7 @@ func TestCallTraceOneByOne(t *testing.T) {
 	}
 	s := jsoniter.ConfigDefault.BorrowStream(nil)
 	defer jsoniter.ConfigDefault.ReturnStream(s)
-	stream := jsonstream.NewJsoniterStream(s)
+	stream := jsonstream.New(s)
 	var fromBlock, toBlock uint64
 	fromBlock = 1
 	toBlock = 10
@@ -119,7 +119,7 @@ func TestCallTraceUnwind(t *testing.T) {
 	}
 	s := jsoniter.ConfigDefault.BorrowStream(nil)
 	defer jsoniter.ConfigDefault.ReturnStream(s)
-	stream := jsonstream.NewJsoniterStream(s)
+	stream := jsonstream.New(s)
 	var fromBlock, toBlock uint64
 	fromBlock = 1
 	toBlock = 10
@@ -183,7 +183,7 @@ func TestFilterNoAddresses(t *testing.T) {
 	}
 	s := jsoniter.ConfigDefault.BorrowStream(nil)
 	defer jsoniter.ConfigDefault.ReturnStream(s)
-	stream := jsonstream.NewJsoniterStream(s)
+	stream := jsonstream.New(s)
 	var fromBlock, toBlock uint64
 	fromBlock = 1
 	toBlock = 10
@@ -232,7 +232,7 @@ func TestFilterAddressIntersection(t *testing.T) {
 	t.Run("second", func(t *testing.T) {
 		s := jsoniter.ConfigDefault.BorrowStream(nil)
 		defer jsoniter.ConfigDefault.ReturnStream(s)
-		stream := jsonstream.NewJsoniterStream(s)
+		stream := jsonstream.New(s)
 
 		traceReq1 := TraceFilterRequest{
 			FromBlock:   (*hexutil.Uint64)(&fromBlock),
@@ -249,7 +249,7 @@ func TestFilterAddressIntersection(t *testing.T) {
 	t.Run("first", func(t *testing.T) {
 		s := jsoniter.ConfigDefault.BorrowStream(nil)
 		defer jsoniter.ConfigDefault.ReturnStream(s)
-		stream := jsonstream.NewJsoniterStream(s)
+		stream := jsonstream.New(s)
 
 		traceReq1 := TraceFilterRequest{
 			FromBlock:   (*hexutil.Uint64)(&fromBlock),
@@ -266,7 +266,7 @@ func TestFilterAddressIntersection(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		s := jsoniter.ConfigDefault.BorrowStream(nil)
 		defer jsoniter.ConfigDefault.ReturnStream(s)
-		stream := jsonstream.NewJsoniterStream(s)
+		stream := jsonstream.New(s)
 
 		traceReq1 := TraceFilterRequest{
 			FromBlock:   (*hexutil.Uint64)(&fromBlock),

--- a/rpc/jsonrpc/debug_api_test.go
+++ b/rpc/jsonrpc/debug_api_test.go
@@ -81,7 +81,7 @@ func TestTraceBlockByNumber(t *testing.T) {
 	api := NewPrivateDebugAPI(baseApi, m.DB, 0)
 	for _, tt := range debugTraceTransactionTests {
 		var buf bytes.Buffer
-		s := jsonstream.NewJsoniterStream(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
+		s := jsonstream.New(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
 		tx, err := ethApi.GetTransactionByHash(m.Ctx, common.HexToHash(tt.txHash))
 		if err != nil {
 			t.Errorf("traceBlock %s: %v", tt.txHash, err)
@@ -112,7 +112,7 @@ func TestTraceBlockByNumber(t *testing.T) {
 		}
 	}
 	var buf bytes.Buffer
-	s := jsonstream.NewJsoniterStream(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
+	s := jsonstream.New(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
 	err := api.TraceBlockByNumber(m.Ctx, rpc.LatestBlockNumber, &tracersConfig.TraceConfig{}, s)
 	if err != nil {
 		t.Errorf("traceBlock %v: %v", rpc.LatestBlockNumber, err)
@@ -132,7 +132,7 @@ func TestTraceBlockByHash(t *testing.T) {
 	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, 0)
 	for _, tt := range debugTraceTransactionTests {
 		var buf bytes.Buffer
-		s := jsonstream.NewJsoniterStream(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
+		s := jsonstream.New(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
 		tx, err := ethApi.GetTransactionByHash(m.Ctx, common.HexToHash(tt.txHash))
 		if err != nil {
 			t.Errorf("traceBlock %s: %v", tt.txHash, err)
@@ -163,7 +163,7 @@ func TestTraceTransaction(t *testing.T) {
 	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, 0)
 	for _, tt := range debugTraceTransactionTests {
 		var buf bytes.Buffer
-		s := jsonstream.NewJsoniterStream(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
+		s := jsonstream.New(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
 		err := api.TraceTransaction(m.Ctx, common.HexToHash(tt.txHash), &tracersConfig.TraceConfig{}, s)
 		if err != nil {
 			t.Errorf("traceTransaction %s: %v", tt.txHash, err)
@@ -192,7 +192,7 @@ func TestTraceTransactionNoRefund(t *testing.T) {
 	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, 0)
 	for _, tt := range debugTraceTransactionNoRefundTests {
 		var buf bytes.Buffer
-		s := jsonstream.NewJsoniterStream(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
+		s := jsonstream.New(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
 		var norefunds = true
 		err := api.TraceTransaction(m.Ctx, common.HexToHash(tt.txHash), &tracersConfig.TraceConfig{NoRefunds: &norefunds}, s)
 		if err != nil {

--- a/rpc/jsonrpc/gen_traces_test.go
+++ b/rpc/jsonrpc/gen_traces_test.go
@@ -49,7 +49,7 @@ func TestGeneratedDebugApi(t *testing.T) {
 	baseApi := NewBaseApi(nil, stateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil)
 	api := NewPrivateDebugAPI(baseApi, m.DB, 0)
 	var buf bytes.Buffer
-	stream := jsonstream.NewJsoniterStream(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
+	stream := jsonstream.New(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
 	callTracer := "callTracer"
 	err := api.TraceBlockByNumber(context.Background(), rpc.BlockNumber(1), &tracersConfig.TraceConfig{Tracer: &callTracer}, stream)
 	if err != nil {

--- a/rpc/jsonrpc/tracing.go
+++ b/rpc/jsonrpc/tracing.go
@@ -56,19 +56,16 @@ func (api *PrivateDebugAPIImpl) TraceBlockByHash(ctx context.Context, hash commo
 func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash, config *tracersConfig.TraceConfig, stream jsonstream.Stream) error {
 	tx, err := api.db.BeginTemporalRo(ctx)
 	if err != nil {
-		stream.WriteNil()
 		return err
 	}
 	defer tx.Rollback()
 
 	blockNumber, hash, _, err := rpchelper.GetCanonicalBlockNumber(ctx, blockNrOrHash, tx, api._blockReader, api.filters)
 	if err != nil {
-		stream.WriteNil()
 		return err
 	}
 	block, err := api.blockWithSenders(ctx, tx, hash, blockNumber)
 	if err != nil {
-		stream.WriteNil()
 		return err
 	}
 	if block == nil {
@@ -80,7 +77,6 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 	// to save any red herring errors
 	err = api.BaseAPI.checkPruneHistory(ctx, tx, block.NumberU64())
 	if err != nil {
-		stream.WriteNil()
 		return err
 	}
 
@@ -95,14 +91,12 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 
 	chainConfig, err := api.chainConfig(ctx, tx)
 	if err != nil {
-		stream.WriteNil()
 		return err
 	}
 	engine := api.engine()
 
 	ibs, blockCtx, _, rules, signer, err := transactions.ComputeBlockContext(ctx, engine, block.HeaderNoCopy(), chainConfig, api._blockReader, api._txNumReader, tx, 0)
 	if err != nil {
-		stream.WriteNil()
 		return err
 	}
 
@@ -122,7 +116,6 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 			_, ok, err = api._blockReader.EventLookup(ctx, tx, borStateSyncTxHash)
 		}
 		if err != nil {
-			stream.WriteArrayEnd()
 			return err
 		}
 		if ok {
@@ -149,9 +142,6 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 		select {
 		default:
 		case <-ctx.Done():
-			stream.WriteNil()
-			stream.WriteObjectEnd()
-			stream.WriteArrayEnd()
 			return ctx.Err()
 		}
 		ibs.SetTxContext(blockCtx.BlockNumber, txnIndex)
@@ -235,20 +225,17 @@ func (api *PrivateDebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rp
 func (api *PrivateDebugAPIImpl) TraceTransaction(ctx context.Context, hash common.Hash, config *tracersConfig.TraceConfig, stream jsonstream.Stream) error {
 	tx, err := api.db.BeginTemporalRo(ctx)
 	if err != nil {
-		stream.WriteNil()
 		return err
 	}
 	defer tx.Rollback()
 	chainConfig, err := api.chainConfig(ctx, tx)
 	if err != nil {
-		stream.WriteNil()
 		return err
 	}
 	// Retrieve the transaction and assemble its EVM context
 	var isBorStateSyncTxn bool
 	blockNum, _, ok, err := api.txnLookup(ctx, tx, hash)
 	if err != nil {
-		stream.WriteNil()
 		return err
 	}
 	if !ok {
@@ -282,13 +269,11 @@ func (api *PrivateDebugAPIImpl) TraceTransaction(ctx context.Context, hash commo
 	// check pruning to ensure we have history at this block level
 	err = api.BaseAPI.checkPruneHistory(ctx, tx, blockNum)
 	if err != nil {
-		stream.WriteNil()
 		return err
 	}
 
 	block, err := api.blockByNumberWithSenders(ctx, tx, blockNum)
 	if err != nil {
-		stream.WriteNil()
 		return err
 	}
 	if block == nil {
@@ -318,7 +303,6 @@ func (api *PrivateDebugAPIImpl) TraceTransaction(ctx context.Context, hash commo
 
 	ibs, blockCtx, _, rules, signer, err := transactions.ComputeBlockContext(ctx, engine, block.HeaderNoCopy(), chainConfig, api._blockReader, api._txNumReader, tx, txnIndex)
 	if err != nil {
-		stream.WriteNil()
 		return err
 	}
 
@@ -347,7 +331,6 @@ func (api *PrivateDebugAPIImpl) TraceTransaction(ctx context.Context, hash commo
 
 	msg, txCtx, err := transactions.ComputeTxContext(ibs, engine, rules, signer, block, chainConfig, txnIndex)
 	if err != nil {
-		stream.WriteNil()
 		return err
 	}
 
@@ -464,13 +447,11 @@ func (api *PrivateDebugAPIImpl) TraceCallMany(ctx context.Context, bundles []Bun
 	overrideBlockHash = make(map[uint64]common.Hash)
 	tx, err := api.db.BeginTemporalRo(ctx)
 	if err != nil {
-		stream.WriteNil()
 		return err
 	}
 	defer tx.Rollback()
 	chainConfig, err := api.chainConfig(ctx, tx)
 	if err != nil {
-		stream.WriteNil()
 		return err
 	}
 	if len(bundles) == 0 {
@@ -493,7 +474,6 @@ func (api *PrivateDebugAPIImpl) TraceCallMany(ctx context.Context, bundles []Bun
 
 	blockNum, hash, _, err := rpchelper.GetBlockNumber(ctx, simulateContext.BlockNumber, tx, api._blockReader, api.filters)
 	if err != nil {
-		stream.WriteNil()
 		return err
 	}
 
@@ -504,11 +484,9 @@ func (api *PrivateDebugAPIImpl) TraceCallMany(ctx context.Context, bundles []Bun
 
 	block, err := api.blockByNumberWithSenders(ctx, tx, blockNum)
 	if err != nil {
-		stream.WriteNil()
 		return err
 	}
 	if block == nil {
-		stream.WriteNil()
 		return fmt.Errorf("block %d not found", blockNum)
 	}
 
@@ -526,7 +504,6 @@ func (api *PrivateDebugAPIImpl) TraceCallMany(ctx context.Context, bundles []Bun
 
 	stateReader, err := rpchelper.CreateStateReader(ctx, tx, api._blockReader, rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(blockNum-1)), transactionIndex, api.filters, api.stateCache, api._txNumReader)
 	if err != nil {
-		stream.WriteNil()
 		return err
 	}
 
@@ -560,7 +537,6 @@ func (api *PrivateDebugAPIImpl) TraceCallMany(ctx context.Context, bundles []Bun
 	if config.StateOverrides != nil {
 		err = config.StateOverrides.Override(ibs)
 		if err != nil {
-			stream.WriteNil()
 			return err
 		}
 	}
@@ -578,13 +554,10 @@ func (api *PrivateDebugAPIImpl) TraceCallMany(ctx context.Context, bundles []Bun
 			}
 			msg, err := txn.ToMessage(api.GasCap, blockCtx.BaseFee)
 			if err != nil {
-				stream.WriteArrayEnd()
-				stream.WriteArrayEnd()
 				return err
 			}
 			transaction, err := txn.ToTransaction(api.GasCap, blockCtx.BaseFee)
 			if err != nil {
-				stream.WriteNil()
 				return err
 			}
 			txCtx = core.NewEVMTxContext(msg)
@@ -592,8 +565,6 @@ func (api *PrivateDebugAPIImpl) TraceCallMany(ctx context.Context, bundles []Bun
 			ibs.SetTxContext(blockCtx.BlockNumber, txnIndex)
 			_, err = transactions.TraceTx(ctx, api.engine(), transaction, msg, blockCtx, txCtx, block.Hash(), txnIndex, evm.IntraBlockState(), config, chainConfig, stream, api.evmCallTimeout)
 			if err != nil {
-				stream.WriteArrayEnd()
-				stream.WriteArrayEnd()
 				return err
 			}
 

--- a/turbo/transactions/tracing.go
+++ b/turbo/transactions/tracing.go
@@ -211,10 +211,7 @@ func ExecuteTraceTx(
 
 	result, err := execCb(evm, refunds)
 	if err != nil {
-		if streaming {
-			stream.WriteArrayEnd()
-			stream.WriteObjectEnd()
-		} else {
+		if !streaming {
 			stream.WriteNil()
 		}
 		return fmt.Errorf("tracing failed: %w", err)


### PR DESCRIPTION
Continuation of #14994
Closes #10389

Summary of changes:
- move creation of JSON stream into `jsonstream/factory.go` and enable stack-based implementation
- fix empty array/object cases
- add `jsonstream.Wrap` to minimise changes in some tests
- remove unnecessary `writeNilIfNotPresent`
- remove unnecessary `.WriteXYZ` calls