### PR TITLE
Fixed snapshot downloader inconsistency for minimal mode node (#15429)

### DIFF
--- a/eth/stagedsync/stage_snapshots.go
+++ b/eth/stagedsync/stage_snapshots.go
@@ -280,7 +280,7 @@ func DownloadAndIndexSnapshotsIfNeed(s *StageState, ctx context.Context, tx kv.R
 		return err
 	}
 
-	if err := cfg.blockReader.Snapshots().OpenSegments([]snaptype.Type{coresnaptype.Headers, coresnaptype.Bodies}, true); err != nil {
+	if err := cfg.blockReader.Snapshots().OpenSegments([]snaptype.Type{coresnaptype.Headers, coresnaptype.Bodies}, true, false); err != nil {
 		return err
 	}
 

--- a/p2p/sentry/simulator/sentry_simulator.go
+++ b/p2p/sentry/simulator/sentry_simulator.go
@@ -408,7 +408,7 @@ func (s *server) getHeader(ctx context.Context, blockNum uint64) (*coretypes.Hea
 			}
 		}
 
-		s.activeSnapshots.OpenSegments([]snaptype.Type{coresnaptype.Headers}, true)
+		s.activeSnapshots.OpenSegments([]snaptype.Type{coresnaptype.Headers}, true, true)
 
 		header, err = s.blockReader.Header(ctx, nil, common.Hash{}, blockNum)
 

--- a/turbo/snapshotsync/merger.go
+++ b/turbo/snapshotsync/merger.go
@@ -205,7 +205,7 @@ func (m *Merger) Merge(ctx context.Context, snapshots *RoSnapshots, snapTypes []
 }
 
 func (m *Merger) integrateMergedDirtyFiles(snapshots *RoSnapshots, in, out map[snaptype.Enum][]*DirtySegment) {
-	defer snapshots.recalcVisibleFiles()
+	defer snapshots.recalcVisibleFiles(snapshots.alignMin)
 
 	snapshots.dirtyLock.Lock()
 	defer snapshots.dirtyLock.Unlock()

--- a/turbo/snapshotsync/snapshots_test.go
+++ b/turbo/snapshotsync/snapshots_test.go
@@ -227,7 +227,7 @@ func TestMergeSnapshots(t *testing.T) {
 	{
 		merger := NewMerger(dir, 1, log.LvlInfo, nil, params.MainnetChainConfig, logger)
 		merger.DisableFsync()
-		s.OpenSegments(coresnaptype.BlockSnapshotTypes, false)
+		s.OpenSegments(coresnaptype.BlockSnapshotTypes, false, true)
 		Ranges := merger.FindMergeRanges(s.Ranges(), s.SegmentsMax())
 		require.Equal(3, len(Ranges))
 		err := merger.Merge(context.Background(), s, coresnaptype.BlockSnapshotTypes, Ranges, s.Dir(), false, nil, nil)
@@ -376,7 +376,7 @@ func TestRemoveOverlaps(t *testing.T) {
 	//corner case: small header.seg was removed, but header.idx left as garbage. such garbage must be cleaned.
 	os.Remove(filepath.Join(s.Dir(), list[15].Name()))
 
-	require.NoError(s.OpenSegments(coresnaptype.BlockSnapshotTypes, false))
+	require.NoError(s.OpenSegments(coresnaptype.BlockSnapshotTypes, false, true))
 	require.NoError(s.RemoveOverlaps())
 
 	list, err = snaptype.Segments(s.Dir())
@@ -420,7 +420,7 @@ func TestRemoveOverlaps_CrossingTypeString(t *testing.T) {
 	require.NoError(err)
 	require.Equal(4, len(list))
 
-	require.NoError(s.OpenSegments(coresnaptype.BlockSnapshotTypes, false))
+	require.NoError(s.OpenSegments(coresnaptype.BlockSnapshotTypes, false, true))
 	require.NoError(s.RemoveOverlaps())
 
 	list, err = snaptype.Segments(s.Dir())
@@ -488,7 +488,7 @@ func TestOpenAllSnapshot(t *testing.T) {
 		err = s.OpenFolder()
 		require.NoError(err)
 		require.NotNil(s.visible[coresnaptype.Enums.Headers])
-		s.OpenSegments(coresnaptype.BlockSnapshotTypes, false)
+		s.OpenSegments(coresnaptype.BlockSnapshotTypes, false, true)
 		// require.Equal(1, len(getSegs(coresnaptype.Enums.Headers]))
 		s.Close()
 

--- a/turbo/snapshotsync/snapshotsync.go
+++ b/turbo/snapshotsync/snapshotsync.go
@@ -226,7 +226,7 @@ type blockReader interface {
 }
 
 // getMinimumBlocksToDownload - get the minimum number of blocks to download
-func getMinimumBlocksToDownload(tx kv.Tx, blockReader blockReader, minStep uint64, blockPruneTo, historyPruneTo uint64) (uint64, uint64, error) {
+func getMinimumBlocksToDownload(tx kv.Tx, blockReader blockReader, minStep uint64, historyPruneTo uint64) (uint64, uint64, error) {
 	frozenBlocks := blockReader.Snapshots().SegmentsMax()
 	minToDownload := uint64(math.MaxUint64)
 	minStepToDownload := uint64(math.MaxUint32)
@@ -320,7 +320,7 @@ func WaitForDownloader(ctx context.Context, logPrefix string, dirs datadir.Dirs,
 		if err != nil {
 			return err
 		}
-		minBlockToDownload, minStepToDownload, err := getMinimumBlocksToDownload(tx, blockReader, minStep, blockPrune, historyPrune)
+		minBlockToDownload, minStepToDownload, err := getMinimumBlocksToDownload(tx, blockReader, minStep, historyPrune)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Michele reported that a minimal node for the Amoy validator encounters an error after syncing from scratch:

```
[EROR] [05-28|13:04:52.818] [sync] waypoint execution err            lastCorrectTipNum=22134999 lastCorrectTipHash=0xc0ee90a99bc09918f402c5f2811f3d7fa8a64f859417163990ac4659228da34f execErr="updateForkChoice: [4/6 Execution] nil block 21638397"
```

Upon investigation, I found that the issue is related to inconsistent snapshot folder contents. Specifically, for minimal nodes, we filter out too many transaction snapshots.

The last commitment domain snapshot contained block number 21,638,396, but the first transaction snapshot started from block number 22,000,000. This discrepancy arises because minimal nodes retain snapshots only within a ~100K block range.

As a result, there is a gap and inconsistency for blocks between 21,638,397 and 21,999,999.

A more correct algorithm would avoid relying solely on a fixed distance to delete "unnecessary" snapshots. Instead, it should also consider what is available in the domains folder. In fact, this logic already exists in our code:

```
if stateTxNum <= baseTxNum { // only cosnider the block if it
    return nil
}
```

However, this condition was never triggered during the downloading stage because we had alignMin == true in the snapshot block reader.

The PR addresses this issue.

It may also resolve the following issue:
https://github.com/erigontech/erigon-qa/issues/131. However, further verification is needed. The gap was obvious in Amoy due to the low transaction count per block (about 4), but on Bormainnet, each block contains an average of 60+ transactions. This means that 100K blocks always include more than the domain step of 1,562,500 transactions, so the problem is less likely to occur there.