### PR TITLE
qa-tests: rename workflow jobs 

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests-polygon.yml
+++ b/.github/workflows/qa-rpc-integration-tests-polygon.yml
@@ -17,7 +17,7 @@ on:
       - ready_for_review
 
 jobs:
-  integration-test-suite:
+  bor-mainnet-rpc-integ-tests:
     runs-on: [ self-hosted, qa, Polygon ]
     timeout-minutes: 15
     env:

--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -17,7 +17,7 @@ on:
       - ready_for_review
 
 jobs:
-  integration-test-suite:
+  mainnet-rpc-integ-tests:
     runs-on: [ self-hosted, qa, RpcSpecific ]
     env:
       ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version/datadir

--- a/.github/workflows/qa-rpc-performance-tests.yml
+++ b/.github/workflows/qa-rpc-performance-tests.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  performance-test-suite:
+  mainnet-rpc-perf-tests:
     strategy:
       matrix:
         include:

--- a/.github/workflows/qa-rpc-test-bisection-tool.yml
+++ b/.github/workflows/qa-rpc-test-bisection-tool.yml
@@ -14,7 +14,7 @@ on:
         required: true
 
 jobs:
-  bisect:
+  rpc-test-bisect:
     runs-on: [self-hosted, qa, RpcSpecific]
     env:
       ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version/datadir

--- a/.github/workflows/qa-sync-test-bisection-tool.yml
+++ b/.github/workflows/qa-sync-test-bisection-tool.yml
@@ -15,7 +15,7 @@ on:
         default: 'mainnet'
 
 jobs:
-  bisect:
+  sync-test-bisect:
     runs-on: [self-hosted, qa, long-running]
     timeout-minutes: 7200  # 5 days
     env:

--- a/.github/workflows/qa-tip-tracking-gnosis.yml
+++ b/.github/workflows/qa-tip-tracking-gnosis.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  tip-tracking-test:
+  gnosis-tip-tracking-test:
     runs-on: [self-hosted, qa, Gnosis]
     timeout-minutes: 600
     env:

--- a/.github/workflows/qa-tip-tracking-polygon.yml
+++ b/.github/workflows/qa-tip-tracking-polygon.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  tip-tracking-test:
+  bor-mainnet-tip-tracking-test:
     runs-on: [self-hosted, qa, Polygon]
     timeout-minutes: 800
     env:

--- a/.github/workflows/qa-tip-tracking.yml
+++ b/.github/workflows/qa-tip-tracking.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  tip-tracking-test:
+  mainnet-tip-tracking-test:
     runs-on: [self-hosted, qa, Erigon3]
     timeout-minutes: 600
     env:


### PR DESCRIPTION
1. avoid job name clash
2. add chain name to jobs