### PR TITLE
jsonrpc: Fix nil ptr in trace_callMany 

### DIFF
--- a/rpc/jsonrpc/trace_adhoc.go
+++ b/rpc/jsonrpc/trace_adhoc.go
@@ -61,7 +61,7 @@ const (
 	TraceTypeVmTrace   = "vmTrace"
 )
 
-// TraceCallParam (see SendTxArgs -- this allows optional prams plus don't use MixedcaseAddress
+// TraceCallParam (see SendTxArgs -- this allows optional params plus don't use MixedcaseAddress
 type TraceCallParam struct {
 	From                 *common.Address   `json:"from"`
 	To                   *common.Address   `json:"to"`
@@ -195,7 +195,7 @@ func (args *TraceCallParam) ToMessage(globalGasCap uint64, baseFee *uint256.Int)
 			}
 			gasFeeCap, gasTipCap = gasPrice, gasPrice
 		} else {
-			// User specified 1559 gas feilds (or none), use those
+			// User specified 1559 gas fields (or none), use those
 			gasFeeCap = new(uint256.Int)
 			if args.MaxFeePerGas != nil {
 				overflow := gasFeeCap.SetFromBig(args.MaxFeePerGas.ToInt())
@@ -221,7 +221,7 @@ func (args *TraceCallParam) ToMessage(globalGasCap uint64, baseFee *uint256.Int)
 			}
 		}
 		if args.MaxFeePerBlobGas != nil {
-			maxFeePerBlobGas.SetFromBig(args.MaxFeePerBlobGas.ToInt())
+			maxFeePerBlobGas = uint256.MustFromBig(args.MaxFeePerBlobGas.ToInt())
 		}
 	}
 	value := new(uint256.Int)


### PR DESCRIPTION
Line 64:
Corrected typo in comment:
prams → params
Reason: Fixed a spelling mistake in a code comment to enhance clarity and maintain consistent documentation quality.

Line 198:
Corrected typo:
feilds → fields
Reason: Fixed a spelling error in the comment to improve readability and professionalism.

Line 224:
Replaced method:
maxFeePerBlobGas.SetFromBig(args.MaxFeePerBlobGas.ToInt()) →
maxFeePerBlobGas = uint256.MustFromBig(args.MaxFeePerBlobGas.ToInt())
Reason: Using MustFromBig is safer and more idiomatic. It avoids mutating an existing value and ensures proper initialization.