### PR TITLE
Update RLP documentation link to official ethereum.org page

### DIFF
--- a/erigon-lib/rlp/encode.go
+++ b/erigon-lib/rlp/encode.go
@@ -32,7 +32,7 @@ import (
 	"github.com/holiman/uint256"
 )
 
-// https://github.com/ethereum/wiki/wiki/RLP
+// https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/
 const (
 	// EmptyStringCode is the RLP code for empty strings.
 	EmptyStringCode = 0x80


### PR DESCRIPTION
Replaced the outdated RLP specification link (GitHub Wiki) with the current official documentation at https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/. This ensures that references in the codebase point to an up-to-date and maintained source for RLP encoding rules and examples.