### PR TITLE
core: switch Bn256Add precompile to evmone

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -31,6 +31,8 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/holiman/uint256"
 
+	evmone "github.com/erigontech/evmone_precompiles"
+
 	"github.com/erigontech/erigon-lib/chain"
 	"github.com/erigontech/erigon-lib/chain/params"
 	"github.com/erigontech/erigon-lib/common"
@@ -603,17 +605,14 @@ func newTwistPoint(blob []byte) (*bn256.G2, error) {
 // runBn256Add implements the Bn256Add precompile, referenced by both
 // Byzantium and Istanbul operations.
 func runBn256Add(input []byte) ([]byte, error) {
-	x, err := newCurvePoint(getData(input, 0, 64))
-	if err != nil {
-		return nil, err
+	x := getData(input, 0, 64)
+	y := getData(input, 64, 64)
+	var out [64]byte
+	if evmone.EcAdd(&out, (*[64]byte)(x), (*[64]byte)(y)) {
+		return out[:], nil
+	} else {
+		return nil, errors.New("bn256: invalid point")
 	}
-	y, err := newCurvePoint(getData(input, 64, 64))
-	if err != nil {
-		return nil, err
-	}
-	res := new(bn256.G1)
-	res.Add(x, y)
-	return res.Marshal(), nil
 }
 
 // bn256Add implements a native elliptic curve point addition conforming to

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/dop251/goja v0.0.0-20220405120441-9037c2b61cbf
 	github.com/edsrzf/mmap-go v1.2.0
 	github.com/emicklei/dot v1.6.2
+	github.com/erigontech/evmone_precompiles v0.0.0-20250610054925-d60899dfa819
 	github.com/felixge/fgprof v0.9.3
 	github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c
 	github.com/gballet/go-verkle v0.0.0-20221121182333-31427a1f2d35

--- a/go.sum
+++ b/go.sum
@@ -272,6 +272,8 @@ github.com/erigontech/erigon-snapshot v1.3.1-0.20250501041114-4a48ac232c83 h1:q/
 github.com/erigontech/erigon-snapshot v1.3.1-0.20250501041114-4a48ac232c83/go.mod h1:ooHlCl+eEYzebiPu+FP6Q6SpPUeMADn8Jxabv3IKb9M=
 github.com/erigontech/erigonwatch v0.0.0-20240718131902-b6576bde1116 h1:KCFa2uXEfZoBjV4buzjWmCmoqVLXiGCq0ZmQ2OjeRvQ=
 github.com/erigontech/erigonwatch v0.0.0-20240718131902-b6576bde1116/go.mod h1:8vQ+VjvLu2gkPs8EwdPrOTAAo++WuLuBi54N7NuAF0I=
+github.com/erigontech/evmone_precompiles v0.0.0-20250610054925-d60899dfa819 h1:Up5uuHxp1WCz2ntD8/X3uWrrWoAzDuStacel1wFke/g=
+github.com/erigontech/evmone_precompiles v0.0.0-20250610054925-d60899dfa819/go.mod h1:WQvAqmoairhdM5RFNFDKK9oT6dzuZEbWMJH+ZdRTjP0=
 github.com/erigontech/go-kzg-4844 v0.0.0-20250130131058-ce13be60bc86 h1:UKcIbFZUGIKzK4aQbkv/dYiOVxZSUuD3zKadhmfwdwU=
 github.com/erigontech/go-kzg-4844 v0.0.0-20250130131058-ce13be60bc86/go.mod h1:JolLjpSff1tCCJKaJx4psrlEdlXuJEC996PL3tTAFks=
 github.com/erigontech/mdbx-go v0.39.8 h1:Hp2pjywZexBA3EQQSU9KM1nUpHIppMNHbX8OMGc5tlM=


### PR DESCRIPTION
BEFORE
```
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^BenchmarkPrecompiledBn256Add$ github.com/erigontech/erigon/core/vm


goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/core/vm
cpu: Apple M2 Max
BenchmarkPrecompiledBn256Add/chfast1-Gas=150-12               183022          6503 ns/op           150.0 gas/op         23.06 mgas/s         768 B/op         14 allocs/op
BenchmarkPrecompiledBn256Add/chfast2-Gas=150-12               182602          6497 ns/op           150.0 gas/op         23.08 mgas/s         768 B/op         14 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio1-Gas=150-12             3201098           370.5 ns/op         150.0 gas/op        404.9 mgas/s      608 B/op          9 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio2-Gas=150-12             3098544           387.3 ns/op         150.0 gas/op        387.3 mgas/s      672 B/op         10 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio3-Gas=150-12             3072292           390.2 ns/op         150.0 gas/op        384.4 mgas/s      672 B/op         10 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio4-Gas=150-12             2969287           408.5 ns/op         150.0 gas/op        367.2 mgas/s      736 B/op         11 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio5-Gas=150-12             3103767           377.7 ns/op         150.0 gas/op        397.1 mgas/s      608 B/op          9 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio6-Gas=150-12             2444664           488.3 ns/op         150.0 gas/op        307.2 mgas/s      608 B/op          9 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio7-Gas=150-12             2432989           496.9 ns/op         150.0 gas/op        301.9 mgas/s      608 B/op          9 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio8-Gas=150-12             2357029           588.1 ns/op         150.0 gas/op        255.1 mgas/s      672 B/op         10 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio9-Gas=150-12             2363187           499.0 ns/op         150.0 gas/op        300.6 mgas/s      608 B/op          9 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio10-Gas=150-12            2382141           507.2 ns/op         150.0 gas/op        295.7 mgas/s      608 B/op          9 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio11-Gas=150-12             178112          6554 ns/op           150.0 gas/op         22.88 mgas/s         768 B/op         14 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio12-Gas=150-12             182529          6550 ns/op           150.0 gas/op         22.89 mgas/s         768 B/op         14 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio13-Gas=150-12             180505          6543 ns/op           150.0 gas/op         22.92 mgas/s         768 B/op         14 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio14-Gas=150-12            1419463           846.1 ns/op         150.0 gas/op        177.3 mgas/s      736 B/op         13 allocs/op
PASS
ok      github.com/erigontech/erigon/core/vm    25.723s
```

AFTER
```
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^BenchmarkPrecompiledBn256Add$ github.com/erigontech/erigon/core/vm


goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/core/vm
cpu: Apple M2 Max
BenchmarkPrecompiledBn256Add/chfast1-Gas=150-12               873568          1414 ns/op           150.0 gas/op        106.0 mgas/s       64 B/op          1 allocs/op
BenchmarkPrecompiledBn256Add/chfast2-Gas=150-12               861238          1405 ns/op           150.0 gas/op        106.8 mgas/s       64 B/op          1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio1-Gas=150-12            19167580            60.76 ns/op        150.0 gas/op       2469 mgas/s         64 B/op          1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio2-Gas=150-12            15366990            76.44 ns/op        150.0 gas/op       1962 mgas/s        128 B/op          2 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio3-Gas=150-12            15354816            77.02 ns/op        150.0 gas/op       1947 mgas/s        128 B/op          2 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio4-Gas=150-12            13247036            89.48 ns/op        150.0 gas/op       1676 mgas/s        192 B/op          3 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio5-Gas=150-12            18637748            63.38 ns/op        150.0 gas/op       2367 mgas/s         64 B/op          1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio6-Gas=150-12             7828333           149.3 ns/op         150.0 gas/op       1005 mgas/s         64 B/op          1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio7-Gas=150-12             7530609           153.0 ns/op         150.0 gas/op        980.0 mgas/s       64 B/op          1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio8-Gas=150-12             7185157           162.5 ns/op         150.0 gas/op        923.0 mgas/s      128 B/op          2 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio9-Gas=150-12             7850294           147.3 ns/op         150.0 gas/op       1018 mgas/s         64 B/op          1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio10-Gas=150-12            8075858           148.9 ns/op         150.0 gas/op       1008 mgas/s         64 B/op          1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio11-Gas=150-12             830109          1462 ns/op           150.0 gas/op        102.6 mgas/s       64 B/op          1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio12-Gas=150-12             825044          1467 ns/op           150.0 gas/op        102.2 mgas/s       64 B/op          1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio13-Gas=150-12             883749          1404 ns/op           150.0 gas/op        106.8 mgas/s       64 B/op          1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio14-Gas=150-12            3722090           318.6 ns/op         150.0 gas/op        470.7 mgas/s       64 B/op          1 allocs/op
PASS
ok      github.com/erigontech/erigon/core/vm    21.362s
```