### PR TITLE
[DO NOT MERGE] core: switch Bn256Mul precompile to evmone

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -644,13 +644,14 @@ func (c *bn256AddByzantium) Run(input []byte) ([]byte, error) {
 // runBn256ScalarMul implements the Bn256ScalarMul precompile, referenced by
 // both Byzantium and Istanbul operations.
 func runBn256ScalarMul(input []byte) ([]byte, error) {
-	p, err := newCurvePoint(getData(input, 0, 64))
-	if err != nil {
-		return nil, err
+	x := getData(input, 0, 64)
+	s := getData(input, 64, 32)
+	var out [64]byte
+	if evmone.EcMul(&out, (*[64]byte)(x), (*[32]byte)(s)) {
+		return out[:], nil
+	} else {
+		return nil, errors.New("bn256: invalid point")
 	}
-	res := new(bn256.G1)
-	res.ScalarMult(p, new(big.Int).SetBytes(getData(input, 64, 32)))
-	return res.Marshal(), nil
 }
 
 // bn256ScalarMulIstanbul implements a native elliptic curve scalar

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/dop251/goja v0.0.0-20220405120441-9037c2b61cbf
 	github.com/edsrzf/mmap-go v1.2.0
 	github.com/emicklei/dot v1.6.2
-	github.com/erigontech/evmone_precompiles v0.0.0-20250611044558-a006eab03b47
+	github.com/erigontech/evmone_precompiles v0.0.0-20250611125707-a851adc08d4f
 	github.com/felixge/fgprof v0.9.3
 	github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c
 	github.com/gballet/go-verkle v0.0.0-20221121182333-31427a1f2d35

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/dop251/goja v0.0.0-20220405120441-9037c2b61cbf
 	github.com/edsrzf/mmap-go v1.2.0
 	github.com/emicklei/dot v1.6.2
-	github.com/erigontech/evmone_precompiles v0.0.0-20250610054925-d60899dfa819
+	github.com/erigontech/evmone_precompiles v0.0.0-20250611044558-a006eab03b47
 	github.com/felixge/fgprof v0.9.3
 	github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c
 	github.com/gballet/go-verkle v0.0.0-20221121182333-31427a1f2d35

--- a/go.sum
+++ b/go.sum
@@ -272,8 +272,8 @@ github.com/erigontech/erigon-snapshot v1.3.1-0.20250501041114-4a48ac232c83 h1:q/
 github.com/erigontech/erigon-snapshot v1.3.1-0.20250501041114-4a48ac232c83/go.mod h1:ooHlCl+eEYzebiPu+FP6Q6SpPUeMADn8Jxabv3IKb9M=
 github.com/erigontech/erigonwatch v0.0.0-20240718131902-b6576bde1116 h1:KCFa2uXEfZoBjV4buzjWmCmoqVLXiGCq0ZmQ2OjeRvQ=
 github.com/erigontech/erigonwatch v0.0.0-20240718131902-b6576bde1116/go.mod h1:8vQ+VjvLu2gkPs8EwdPrOTAAo++WuLuBi54N7NuAF0I=
-github.com/erigontech/evmone_precompiles v0.0.0-20250610054925-d60899dfa819 h1:Up5uuHxp1WCz2ntD8/X3uWrrWoAzDuStacel1wFke/g=
-github.com/erigontech/evmone_precompiles v0.0.0-20250610054925-d60899dfa819/go.mod h1:WQvAqmoairhdM5RFNFDKK9oT6dzuZEbWMJH+ZdRTjP0=
+github.com/erigontech/evmone_precompiles v0.0.0-20250611044558-a006eab03b47 h1:xQr8ySmHkw6ia13uasDwWk6M2maxSBzamxy8Mf85t8g=
+github.com/erigontech/evmone_precompiles v0.0.0-20250611044558-a006eab03b47/go.mod h1:WQvAqmoairhdM5RFNFDKK9oT6dzuZEbWMJH+ZdRTjP0=
 github.com/erigontech/go-kzg-4844 v0.0.0-20250130131058-ce13be60bc86 h1:UKcIbFZUGIKzK4aQbkv/dYiOVxZSUuD3zKadhmfwdwU=
 github.com/erigontech/go-kzg-4844 v0.0.0-20250130131058-ce13be60bc86/go.mod h1:JolLjpSff1tCCJKaJx4psrlEdlXuJEC996PL3tTAFks=
 github.com/erigontech/mdbx-go v0.39.8 h1:Hp2pjywZexBA3EQQSU9KM1nUpHIppMNHbX8OMGc5tlM=

--- a/go.sum
+++ b/go.sum
@@ -272,8 +272,8 @@ github.com/erigontech/erigon-snapshot v1.3.1-0.20250501041114-4a48ac232c83 h1:q/
 github.com/erigontech/erigon-snapshot v1.3.1-0.20250501041114-4a48ac232c83/go.mod h1:ooHlCl+eEYzebiPu+FP6Q6SpPUeMADn8Jxabv3IKb9M=
 github.com/erigontech/erigonwatch v0.0.0-20240718131902-b6576bde1116 h1:KCFa2uXEfZoBjV4buzjWmCmoqVLXiGCq0ZmQ2OjeRvQ=
 github.com/erigontech/erigonwatch v0.0.0-20240718131902-b6576bde1116/go.mod h1:8vQ+VjvLu2gkPs8EwdPrOTAAo++WuLuBi54N7NuAF0I=
-github.com/erigontech/evmone_precompiles v0.0.0-20250611044558-a006eab03b47 h1:xQr8ySmHkw6ia13uasDwWk6M2maxSBzamxy8Mf85t8g=
-github.com/erigontech/evmone_precompiles v0.0.0-20250611044558-a006eab03b47/go.mod h1:WQvAqmoairhdM5RFNFDKK9oT6dzuZEbWMJH+ZdRTjP0=
+github.com/erigontech/evmone_precompiles v0.0.0-20250611125707-a851adc08d4f h1:jGZtyCqg0kg0Q9ry2qesqodEpD5/3q/dmOCOUE4zNAo=
+github.com/erigontech/evmone_precompiles v0.0.0-20250611125707-a851adc08d4f/go.mod h1:WQvAqmoairhdM5RFNFDKK9oT6dzuZEbWMJH+ZdRTjP0=
 github.com/erigontech/go-kzg-4844 v0.0.0-20250130131058-ce13be60bc86 h1:UKcIbFZUGIKzK4aQbkv/dYiOVxZSUuD3zKadhmfwdwU=
 github.com/erigontech/go-kzg-4844 v0.0.0-20250130131058-ce13be60bc86/go.mod h1:JolLjpSff1tCCJKaJx4psrlEdlXuJEC996PL3tTAFks=
 github.com/erigontech/mdbx-go v0.39.8 h1:Hp2pjywZexBA3EQQSU9KM1nUpHIppMNHbX8OMGc5tlM=


### PR DESCRIPTION
Prerequisite: https://github.com/erigontech/evmone_precompiles/pull/1

BEFORE
```
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^BenchmarkPrecompiledBn256ScalarMul$ github.com/erigontech/erigon/core/vm


goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/core/vm
cpu: Apple M2 Max
BenchmarkPrecompiledBn256ScalarMul/chfast1-Gas=6000-12             25912         46088 ns/op          6000 gas/op          130.2 mgas/s     1280 B/op         25 allocs/op
BenchmarkPrecompiledBn256ScalarMul/chfast2-Gas=6000-12             23901         50040 ns/op          6000 gas/op          119.9 mgas/s     1472 B/op         26 allocs/op
BenchmarkPrecompiledBn256ScalarMul/chfast3-Gas=6000-12             24816         48238 ns/op          6000 gas/op          124.4 mgas/s     1472 B/op         26 allocs/op
BenchmarkPrecompiledBn256ScalarMul/cdetrio1-Gas=6000-12            23089         51227 ns/op          6000 gas/op          117.1 mgas/s     1504 B/op         26 allocs/op
BenchmarkPrecompiledBn256ScalarMul/cdetrio6-Gas=6000-12            23217         51276 ns/op          6000 gas/op          117.0 mgas/s     1504 B/op         26 allocs/op
BenchmarkPrecompiledBn256ScalarMul/cdetrio11-Gas=6000-12           23320         51604 ns/op          6000 gas/op          116.3 mgas/s     1504 B/op         26 allocs/op
PASS
ok      github.com/erigontech/erigon/core/vm    10.872s
```

AFTER
```
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^BenchmarkPrecompiledBn256ScalarMul$ github.com/erigontech/erigon/core/vm

goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/core/vm
cpu: Apple M2 Max
BenchmarkPrecompiledBn256ScalarMul/chfast1-Gas=6000-12         	   56040	     21167 ns/op	      6000 gas/op	       283.4 mgas/s	      64 B/op	       1 allocs/op
BenchmarkPrecompiledBn256ScalarMul/chfast2-Gas=6000-12         	   24253	     50114 ns/op	      6000 gas/op	       119.7 mgas/s	      64 B/op	       1 allocs/op
BenchmarkPrecompiledBn256ScalarMul/chfast3-Gas=6000-12         	   22110	     55195 ns/op	      6000 gas/op	       108.7 mgas/s	      64 B/op	       1 allocs/op
BenchmarkPrecompiledBn256ScalarMul/cdetrio1-Gas=6000-12        	   21633	     55445 ns/op	      6000 gas/op	       108.2 mgas/s	      64 B/op	       1 allocs/op
BenchmarkPrecompiledBn256ScalarMul/cdetrio6-Gas=6000-12        	   21849	     54347 ns/op	      6000 gas/op	       110.4 mgas/s	      64 B/op	       1 allocs/op
BenchmarkPrecompiledBn256ScalarMul/cdetrio11-Gas=6000-12       	   22059	     54936 ns/op	      6000 gas/op	       109.2 mgas/s	      64 B/op	       1 allocs/op
PASS
ok  	github.com/erigontech/erigon/core/vm	10.863s
```