### PR TITLE
fix for stage_custom_trace failure after ii/hist dependency

### DIFF
--- a/cmd/scripts/mirror-datadir.sh
+++ b/cmd/scripts/mirror-datadir.sh
@@ -25,7 +25,10 @@ fi
 source="${source%/}"
 destination="${destination%/}"
 
-echo "Syncing symlinks from '$source' to '$destination'"
+# Determine optimal number of parallel jobs (default to number of CPU cores)
+num_jobs=$(nproc 2>/dev/null || echo 4)
+
+echo "Syncing files from '$source' to '$destination' using $num_jobs parallel jobs"
 
 # Create the destination directory if it doesn't exist
 mkdir -p "$destination"
@@ -34,43 +37,73 @@ mkdir -p "$destination"
 echo "Creating directory structure..."
 find "$source" -type d | sed "s|^$source|$destination|" | xargs -I{} mkdir -p {}
 
-# Then create symbolic links for all files (or copy specific ones)
-echo "Creating symbolic links and copying special files..."
-find "$source" -type f | while read file; do
+# Function to process individual files
+process_file() {
+    local file="$1"
+    local source="$2"
+    local destination="$3"
+
     rel_path="${file#$source}"
     filename=$(basename "$file")
-    
-    # Skip erigon.log entirely
-    if [ "$filename" = "erigon.log" ]; then
+
+    # Skip these files entirely
+    if [ "$filename" = "erigon.log" ] || [ "$filename" = ".DS_Store" ]; then
         echo "Skipping: $file"
-        continue
+        return
     fi
-    
+
     # Copy these files instead of symlinking
     if [ "$filename" = "mdbx.dat" ] || [ "$filename" = "mdbx.lck" ] || [ "$filename" = "jwt.hex" ] || [ "$filename" = "LOCK" ] || [ "$filename" = "prohibit_new_downloads.lock" ] || [ "$filename" = "nodekey" ]; then
-        echo "Copying: $file"
-        cp "$file" "$destination$rel_path"
+        if cmp -s "$file" "$destination$rel_path" 2>/dev/null; then
+            echo "Already up-to-date: $file"
+        else
+            echo "Copying: $file"
+            cp "$file" "$destination$rel_path" 2>/dev/null || {
+                echo "Copying: $file"
+                cp "$file" "$destination$rel_path"
+            }
+        fi
     else
         # Symlink all other files
-        ln -sf "$file" "$destination$rel_path"
+        if [ "$(readlink "$destination$rel_path" 2>/dev/null)" != "$file" ]; then
+            echo "Linking: $file"
+            ln -sf "$file" "$destination$rel_path"
+        fi
     fi
-done
+}
 
-# Remove files in destination that don't exist in source (except erigon.log which we skip)
-echo "Cleaning up orphaned links..."
-find "$destination" -type f -o -type l | while read file; do
+# Export function for parallel execution
+export -f process_file
+
+# Process files in parallel
+echo "Creating symbolic links and copying files..."
+find "$source" -type f | xargs -I{} -P"$num_jobs" bash -c 'process_file "$1" "$2" "$3"' _ {} "$source" "$destination"
+
+# Function to clean orphaned files
+cleanup_file() {
+    local file="$1"
+    local source="$2"
+    local destination="$3"
+
     rel_path="${file#$destination}"
     filename=$(basename "$file")
-    
-    # Skip erigon.log cleanup since we don't sync it
-    if [ "$filename" = "erigon.log" ]; then
-        continue
+
+    # Skip these files in cleanup since we don't sync them
+    if [ "$filename" = "erigon.log" ] || [ "$filename" = ".DS_Store" ]; then
+        return
     fi
-    
+
     if [ ! -e "$source$rel_path" ]; then
         echo "Removing orphaned: $file"
         rm "$file"
     fi
-done
+}
+
+# Export cleanup function for parallel execution
+export -f cleanup_file
+
+# Remove files in destination that don't exist in source (except erigon.log which we skip)
+echo "Cleaning up orphaned links..."
+find "$destination" -type f -o -type l | xargs -I{} -P"$num_jobs" bash -c 'cleanup_file "$1" "$2" "$3"' _ {} "$source" "$destination"
 
 echo "Sync complete!"

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -263,7 +263,7 @@ func (a *Aggregator) AddDependencyBtwnHistoryII(domain kv.Domain) {
 	// ii has checker on history dirtyFiles (same domain)
 	dd := a.d[domain]
 	if dd.histCfg.snapshotsDisabled || dd.histCfg.historyDisabled || dd.disable {
-		a.logger.Info("history or ii disabled, can't register dependency", "domain", domain.String())
+		a.logger.Debug("history or ii disabled, can't register dependency", "domain", domain.String())
 		return
 	}
 

--- a/erigon-lib/state/entity_integrity_check.go
+++ b/erigon-lib/state/entity_integrity_check.go
@@ -10,12 +10,12 @@ import (
 	btree2 "github.com/tidwall/btree"
 )
 
-// high 16 bits specific domain/ii/forkables;
-// low 16 bits identifies "category" domain(0)/ii(1)/history(2)/forkables(3) etc.
+// high 16 bits: specify domain/ii/forkables identifier
+// low 16 bits: category - domain(0x0)/history(0x1)/ii(0x2)/forkables(0x3) etc.
 // e.g.
-// 0x0000000000000001 0000000000000000  - storage domain
-// 0x0000000000000001 0000000000000001  - storage history
-// 0x0000000000000001 0000000000000010  - storage ii
+// 0x0001 0000 - storage domain
+// 0x0001 0001 - storage history
+// 0x0001 0002 - storage ii
 
 type UniversalEntity uint32
 
@@ -24,18 +24,18 @@ func FromDomain(d kv.Domain) UniversalEntity {
 }
 
 func FromII(ii kv.InvertedIdx) UniversalEntity {
-	return UniversalEntity(uint32(ii)<<16 | 0x10)
+	return UniversalEntity(uint32(ii)<<16 | 0x02)
 }
 
 func (ue UniversalEntity) String() string {
 	category := ue & 0xFFFF
-	if category == 0 {
+	if category == 0x0 {
 		return fmt.Sprintf("domain:%s", kv.Domain(ue>>16))
 	}
-	if category == 1 {
+	if category == 0x1 {
 		return fmt.Sprintf("history:%s", kv.InvertedIdx(ue>>16))
 	}
-	if category == 2 {
+	if category == 0x2 {
 		return fmt.Sprintf("ii:%s", kv.InvertedIdx(ue>>16))
 	}
 	return fmt.Sprintf("unknown:%d", ue)

--- a/erigon-lib/state/history.go
+++ b/erigon-lib/state/history.go
@@ -134,7 +134,7 @@ func NewHistory(cfg histCfg, aggStep uint64, logger log.Logger) (*History, error
 	if h.version.AccessorVI.IsZero() {
 		panic(fmt.Errorf("assert: forgot to set version of %s", h.name))
 	}
-	h.InvertedIndex.name = h.name
+	h.InvertedIndex.name = h.historyIdx
 
 	return &h, nil
 }


### PR DESCRIPTION
https://github.com/erigontech/erigon/issues/15531

- key issue: `iifCfg.name` (denoting inverted index) was not set properly when initializing InvertedIndex, leading to incorrect maps in entity_checker.

- other small changes: changed the `mirror-datadir` script to copy in parallel, make it fast; 
- consistency in comments and code in `UniversalEntity` 