### PR TITLE
Change `bn256Add` to use consensys gnark-bn254 lib

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -31,6 +31,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/holiman/uint256"
 
+	"github.com/consensys/gnark-crypto/ecc/bn254"
 	"github.com/erigontech/erigon-lib/chain"
 	"github.com/erigontech/erigon-lib/chain/params"
 	"github.com/erigontech/erigon-lib/common"
@@ -38,7 +39,6 @@ import (
 	"github.com/erigontech/erigon-lib/crypto"
 	"github.com/erigontech/erigon-lib/crypto/blake2b"
 	"github.com/erigontech/erigon-lib/crypto/bn256"
-	"github.com/consensys/gnark-crypto/ecc/bn254"
 	libkzg "github.com/erigontech/erigon-lib/crypto/kzg"
 	"github.com/erigontech/erigon-lib/crypto/secp256r1"
 	"github.com/erigontech/erigon/core/tracing"

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,6 @@ require (
 	github.com/dop251/goja v0.0.0-20220405120441-9037c2b61cbf
 	github.com/edsrzf/mmap-go v1.2.0
 	github.com/emicklei/dot v1.6.2
-	github.com/erigontech/evmone_precompiles v0.0.0-20250610054925-d60899dfa819
 	github.com/felixge/fgprof v0.9.3
 	github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c
 	github.com/gballet/go-verkle v0.0.0-20221121182333-31427a1f2d35

--- a/go.sum
+++ b/go.sum
@@ -272,8 +272,6 @@ github.com/erigontech/erigon-snapshot v1.3.1-0.20250501041114-4a48ac232c83 h1:q/
 github.com/erigontech/erigon-snapshot v1.3.1-0.20250501041114-4a48ac232c83/go.mod h1:ooHlCl+eEYzebiPu+FP6Q6SpPUeMADn8Jxabv3IKb9M=
 github.com/erigontech/erigonwatch v0.0.0-20240718131902-b6576bde1116 h1:KCFa2uXEfZoBjV4buzjWmCmoqVLXiGCq0ZmQ2OjeRvQ=
 github.com/erigontech/erigonwatch v0.0.0-20240718131902-b6576bde1116/go.mod h1:8vQ+VjvLu2gkPs8EwdPrOTAAo++WuLuBi54N7NuAF0I=
-github.com/erigontech/evmone_precompiles v0.0.0-20250610054925-d60899dfa819 h1:Up5uuHxp1WCz2ntD8/X3uWrrWoAzDuStacel1wFke/g=
-github.com/erigontech/evmone_precompiles v0.0.0-20250610054925-d60899dfa819/go.mod h1:WQvAqmoairhdM5RFNFDKK9oT6dzuZEbWMJH+ZdRTjP0=
 github.com/erigontech/go-kzg-4844 v0.0.0-20250130131058-ce13be60bc86 h1:UKcIbFZUGIKzK4aQbkv/dYiOVxZSUuD3zKadhmfwdwU=
 github.com/erigontech/go-kzg-4844 v0.0.0-20250130131058-ce13be60bc86/go.mod h1:JolLjpSff1tCCJKaJx4psrlEdlXuJEC996PL3tTAFks=
 github.com/erigontech/mdbx-go v0.39.8 h1:Hp2pjywZexBA3EQQSU9KM1nUpHIppMNHbX8OMGc5tlM=


### PR DESCRIPTION
**Before**
```
Running tool: /usr/bin/go test -benchmem -run=^$ -bench ^BenchmarkPrecompiledBn256Add$ github.com/erigontech/erigon/core/vm -v

goos: linux
goarch: amd64
pkg: github.com/erigontech/erigon/core/vm
cpu: Intel(R) Core(TM) Ultra 5 135H
BenchmarkPrecompiledBn256Add
BenchmarkPrecompiledBn256Add/chfast1-Gas=150
BenchmarkPrecompiledBn256Add/chfast1-Gas=150-18 102675 11298 ns/op 150.0 gas/op 13.27 mgas/s 64 B/op 1 allocs/op
BenchmarkPrecompiledBn256Add/chfast2-Gas=150
BenchmarkPrecompiledBn256Add/chfast2-Gas=150-18 171644 9354 ns/op 150.0 gas/op 16.03 mgas/s 64 B/op 1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio1-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio1-Gas=150-18 8909247 146.8 ns/op 150.0 gas/op 1022 mgas/s 64 B/op 1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio2-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio2-Gas=150-18 6094868 187.3 ns/op 150.0 gas/op 800.6 mgas/s 128 B/op 2 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio3-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio3-Gas=150-18 6233622 187.6 ns/op 150.0 gas/op 799.5 mgas/s 128 B/op 2 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio4-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio4-Gas=150-18 5243091 217.9 ns/op 150.0 gas/op 688.2 mgas/s 192 B/op 3 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio5-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio5-Gas=150-18 7803562 153.3 ns/op 150.0 gas/op 978.5 mgas/s 64 B/op 1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio6-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio6-Gas=150-18 2442933 487.8 ns/op 150.0 gas/op 307.4 mgas/s 64 B/op 1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio7-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio7-Gas=150-18 2357460 489.8 ns/op 150.0 gas/op 306.2 mgas/s 64 B/op 1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio8-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio8-Gas=150-18 2245977 537.0 ns/op 150.0 gas/op 279.3 mgas/s 128 B/op 2 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio9-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio9-Gas=150-18 2516496 496.2 ns/op 150.0 gas/op 302.2 mgas/s 64 B/op 1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio10-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio10-Gas=150-18 2578932 479.2 ns/op 150.0 gas/op 313.0 mgas/s 64 B/op 1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio11-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio11-Gas=150-18 88420 11387 ns/op 150.0 gas/op 13.17 mgas/s 64 B/op 1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio12-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio12-Gas=150-18 164791 10379 ns/op 150.0 gas/op 14.45 mgas/s 64 B/op 1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio13-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio13-Gas=150-18 119004 8710 ns/op 150.0 gas/op 17.21 mgas/s 64 B/op 1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio14-Gas=150
BenchmarkPrecompiledBn256Add/cdetrio14-Gas=150-18 1064320 1044 ns/op 150.0 gas/op 143.7 mgas/s 64 B/op 1 allocs/op
PASS
ok github.com/erigontech/erigon/core/vm 27.885s
```

After
```
go test -benchmem -run=^$ -bench ^BenchmarkPrecompiledBn256Add$ github.com/erigontech/erigon/core/vm
goos: linux
goarch: amd64
pkg: github.com/erigontech/erigon/core/vm
cpu: Intel(R) Core(TM) Ultra 5 135H
BenchmarkPrecompiledBn256Add/chfast1-Gas=150-18                   804166              2196 ns/op               150.0 gas/op             68.31 mgas/s            64 B/op          1 allocs/op
BenchmarkPrecompiledBn256Add/chfast2-Gas=150-18                   527400              2167 ns/op               150.0 gas/op             69.21 mgas/s            64 B/op          1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio1-Gas=150-18                 7054803               183.0 ns/op             150.0 gas/op            819.7 mgas/s             64 B/op          1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio2-Gas=150-18                 5020600               221.4 ns/op             150.0 gas/op            677.3 mgas/s            128 B/op          2 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio3-Gas=150-18                 5155070               223.8 ns/op             150.0 gas/op            670.3 mgas/s            128 B/op          2 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio4-Gas=150-18                 4588369               250.0 ns/op             150.0 gas/op            600.0 mgas/s            192 B/op          3 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio5-Gas=150-18                 5841339               188.9 ns/op             150.0 gas/op            794.0 mgas/s             64 B/op          1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio6-Gas=150-18                 3856808               333.6 ns/op             150.0 gas/op            449.6 mgas/s             64 B/op          1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio7-Gas=150-18                 4168516               262.5 ns/op             150.0 gas/op            571.4 mgas/s             64 B/op          1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio8-Gas=150-18                 3208616               363.1 ns/op             150.0 gas/op            413.1 mgas/s            128 B/op          2 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio9-Gas=150-18                 3771111               313.9 ns/op             150.0 gas/op            477.8 mgas/s             64 B/op          1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio10-Gas=150-18                3774422               314.9 ns/op             150.0 gas/op            476.3 mgas/s             64 B/op          1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio11-Gas=150-18                 557440              2208 ns/op               150.0 gas/op             67.92 mgas/s            64 B/op          1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio12-Gas=150-18                 637453              2220 ns/op               150.0 gas/op             67.58 mgas/s            64 B/op          1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio13-Gas=150-18                 839908              1620 ns/op               150.0 gas/op             92.60 mgas/s            64 B/op          1 allocs/op
BenchmarkPrecompiledBn256Add/cdetrio14-Gas=150-18                3151356               374.3 ns/op             150.0 gas/op            400.7 mgas/s             64 B/op          1 allocs/op
BenchmarkPrecompiledBn256Add/add12-Gas=150-18                     446739              2364 ns/op               150.0 gas/op             63.45 mgas/s            64 B/op          1 allocs/op
PASS
ok      github.com/erigontech/erigon/core/vm    30.125s
```