### PR TITLE
cp: cancel previous job runs in integration and qa-rpc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,15 @@ on:
     
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: ${{ !contains(fromJSON('[
-      "refs/heads/release/2.60",
-      "refs/heads/release/2.61",
-      "refs/heads/main"
-    ]'), github.ref) }}
-
 jobs:
-  tests:
+  linux:
+    concurrency:
+      group: ci-${{ matrix.os }}-${{ github.ref }}
+      cancel-in-progress: >-
+        ${{
+          !startsWith(github.ref, 'refs/heads/release/') &&
+          github.ref != 'refs/heads/main'
+        }}
     if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
     strategy:
       matrix:
@@ -76,7 +75,14 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         continue-on-error: true
 
-  tests-windows:
+  win:
+    concurrency:
+      group: ci-win-${{ matrix.os }}-${{ github.ref }}
+      cancel-in-progress: >-
+        ${{
+          !startsWith(github.ref, 'refs/heads/release/') &&
+          github.ref != 'refs/heads/main'
+        }}
     if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
     strategy:
       matrix:

--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -13,6 +13,15 @@ on:
     types:
       - ready_for_review
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: >-
+    ${{
+      !startsWith(github.ref, 'refs/heads/release/') &&
+      github.ref != 'refs/heads/main'
+    }}
+
+
 jobs:
   integration-test-suite:
     runs-on: [ self-hosted, qa, RpcSpecific ]

--- a/.github/workflows/test-integration-caplin.yml
+++ b/.github/workflows/test-integration-caplin.yml
@@ -13,7 +13,7 @@ on:
       - reopened
       - synchronize
       - ready_for_review
-    
+
 jobs:
   tests:
     strategy:

--- a/.github/workflows/test-integration-erigon.yml
+++ b/.github/workflows/test-integration-erigon.yml
@@ -43,6 +43,14 @@ jobs:
 
   tests-mac-linux:
     needs: source-of-changes
+    concurrency:
+      group: tests-mac-linux-${{ matrix.os }}-${{ github.ref }}
+      cancel-in-progress: >-
+        ${{
+          needs.source-of-changes.outputs.changed_files != 'true' &&
+          !startsWith(github.ref, 'refs/heads/release/') &&
+          github.ref != 'refs/heads/main'
+        }}
     strategy:
       matrix:
         os:
@@ -88,6 +96,14 @@ jobs:
 
   tests-windows:
     needs: source-of-changes
+    concurrency:
+      group: tests-windows-${{ matrix.os }}-${{ github.ref }}
+      cancel-in-progress: >-
+        ${{
+          needs.source-of-changes.outputs.changed_files != 'true' &&
+          !startsWith(github.ref, 'refs/heads/release/') &&
+          github.ref != 'refs/heads/main'
+        }}
     strategy:
       matrix:
         os: [ windows-2025 ]

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -133,7 +133,7 @@ func NewDomain(cfg domainCfg, logger log.Logger) (*Domain, error) {
 
 	d := &Domain{
 		domainCfg:  cfg,
-		dirtyFiles: btree2.NewBTreeGOptions[*filesItem](filesItemLess, btree2.Options{Degree: 128, NoLocks: false}),
+		dirtyFiles: btree2.NewBTreeGOptions(filesItemLess, btree2.Options{Degree: 128, NoLocks: false}),
 		_visible:   newDomainVisible(cfg.name, []visibleFile{}),
 	}
 


### PR DESCRIPTION
maybe helps with recent tests scheduling flakiness

---
when new commits are pushed into PR, the job runs of previous commits of the PR (in particular, qa-rpc and integration tests) should be cancelled.
This already happens with ci test. Just adding it for other two workflows.

It's just something to save unnecessary job runs.
NOTE: this doesn't effect job runs on main branch or release branches (these are the branches on which the requirement to know "which commit broke a test" is needed)

