### PR TITLE
Hot fix for EIP-7702 tx post polygon Bhilai HF

### DIFF
--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -49,6 +49,13 @@ func MakeSigner(config *chain.Config, blockNumber uint64, blockTime uint64) *Sig
 	}
 	signer.unprotected = true
 	switch {
+	case config.IsBhilai(blockNumber):
+		signer.protected = true
+		signer.accessList = true
+		signer.dynamicFee = true
+		signer.setCode = true
+		signer.chainID.Set(&chainId)
+		signer.chainIDMul.Mul(&chainId, u256.Num2)
 	case config.IsPrague(blockTime):
 		signer.protected = true
 		signer.accessList = true


### PR DESCRIPTION
Erigon isn't able to decode 7702 tx successfully after Bhilai HF, see error below. This PR adds setCode correctly for Polygon Bhilai HF.

```
Jun 13 20:30:01 rpc-alchemy-polygon-amoy-erigon-archive-prod-node-server-use1-2 erigon[2701954]: [EROR] [06-13|20:30:01.282] [3/6 Senders] Error recovering senders for block 22822930 57de0519615a1bf592aca8c31ab1475500c30a0b5bc806b1841edd2170decf31): invalid block: error recovering sender for tx=403ced2733e411cb2cee6b34d1f127fe9972577caf32ed937345acebbec38da4, setCode tx is not supported by signer Signer[chainId=80002,malleable=false,unprotected=true,protected=true,accessList=true,dynamicFee=true,blob=false,setCode=false
```