### PR TITLE
rpc: return empty code for store out-of-gas in CREATE calls

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -454,22 +454,26 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gasRemainin
 	if err == nil && evm.chainRules.IsLondon && len(ret) >= 1 && ret[0] == 0xEF {
 		err = ErrInvalidCode
 	}
-	// if the contract creation ran successfully and no errors were returned
+	// If the contract creation ran successfully and no errors were returned,
 	// calculate the gas required to store the code. If the code could not
-	// be stored due to not enough gas set an error and let it be handled
+	// be stored due to not enough gas, set an error when we're in Homestead and let it be handled
 	// by the error checking condition below.
 	if err == nil {
 		createDataGas := uint64(len(ret)) * params.CreateDataGas
 		if contract.UseGas(createDataGas, evm.Config().Tracer, tracing.GasChangeCallCodeStorage) {
 			evm.intraBlockState.SetCode(address, ret)
-		} else if evm.chainRules.IsHomestead {
-			err = ErrCodeStoreOutOfGas
+		} else {
+			// If we run out of gas, we do not store the code: the returned code must be empty.
+			ret = []byte{}
+			if evm.chainRules.IsHomestead {
+				err = ErrCodeStoreOutOfGas
+			}
 		}
 	}
 
 	// When an error was returned by the EVM or when setting the creation code
-	// above we revert to the snapshot and consume any gas remaining. Additionally
-	// when we're in homestead this also counts for code storage gas errors.
+	// above, we revert to the snapshot and consume any gas remaining. Additionally,
+	// when we're in Homestead, this also counts for code storage gas errors.
 	if err != nil && (evm.chainRules.IsHomestead || err != ErrCodeStoreOutOfGas) {
 		evm.intraBlockState.RevertToSnapshot(snapshot, nil)
 		if err != ErrExecutionReverted {


### PR DESCRIPTION
Fixes #10594 

If the contract code cannot be saved into state because gas is not enough for covering the storage cost, we must return empty code both in pre-Homestead case (tx successful, but code not deployed => silent failure) and in post-Homestead case (tx failed, error store out-of-gas).

See also new RPC integration tests in https://github.com/erigontech/rpc-tests/pull/384