### PR TITLE
Backport: Fix datadir execution permissions for multi-user setups (#15594)

### DIFF
--- a/erigon-lib/common/dir/rw_dir.go
+++ b/erigon-lib/common/dir/rw_dir.go
@@ -25,7 +25,10 @@ import (
 )
 
 func MustExist(path ...string) {
-	const perm = 0764 // user rwx, group rw, other r
+	// user rwx, group rwx, other rx
+	// x is required to navigate through directories. umask 0o022 is the default and will mask final
+	// permissions to 0o755 for newly created files (and directories).
+	const perm = 0o775
 	for _, p := range path {
 		exist, err := Exist(p)
 		if err != nil {


### PR DESCRIPTION
Backport of #15594. I guess just merge when/if people are happy with behaviour of patch on main.

(cherry picked from commit 4122f833cab250cc77fb214c9f7887036aa8aff3)