### PR TITLE
cmd: fix erigon init cmd now generating salt-state

### DIFF
--- a/turbo/app/init_cmd.go
+++ b/turbo/app/init_cmd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/erigontech/erigon-lib/common/datadir"
 	"github.com/erigontech/erigon-lib/kv"
 	"github.com/erigontech/erigon-lib/log/v3"
+	"github.com/erigontech/erigon-lib/state"
 	"github.com/erigontech/erigon-lib/types"
 	"github.com/erigontech/erigon/cmd/utils"
 	"github.com/erigontech/erigon/core"
@@ -87,6 +88,12 @@ func initGenesis(cliCtx *cli.Context) error {
 	chaindb, err := node.OpenDatabase(cliCtx.Context, stack.Config(), kv.ChainDB, "", false, logger)
 	if err != nil {
 		utils.Fatalf("Failed to open database: %v", err)
+	}
+
+	// need to call this to initialise the state-salt if not present in the DB
+	_, err = state.GetStateIndicesSalt(stack.Config().Dirs, true, logger)
+	if err != nil {
+		utils.Fatalf("Failed to get state indices salt: %v", err)
 	}
 
 	if tracer != nil {


### PR DESCRIPTION
found on perfnet-1:
- called erigon init
- started erigon (but for perfnet-1 we do use the snapshot downloader, ie we do not run with `--no-downloader`)
- this caused a panic because the salt file for state snapshots never gets created

this PR enhances "erigon init" to always create salt for state files too if one doesn't exist already