### PR TITLE
fix bor_getAuthor

### DIFF
--- a/rpc/jsonrpc/bor_snapshot.go
+++ b/rpc/jsonrpc/bor_snapshot.go
@@ -133,7 +133,7 @@ func (api *BorImpl) GetAuthor(blockNrOrHash *rpc.BlockNumberOrHash) (*common.Add
 		}
 	}
 	if err1 != nil {
-		return nil, err
+		return nil, err1
 	}
 
 	// Ensure we have an actually valid block and return its snapshot

--- a/rpc/jsonrpc/bor_snapshot.go
+++ b/rpc/jsonrpc/bor_snapshot.go
@@ -117,9 +117,9 @@ func (api *BorImpl) GetAuthor(blockNrOrHash *rpc.BlockNumberOrHash) (*common.Add
 
 	//nolint:nestif
 	if blockNrOrHash == nil {
-		latestBlockNum, err := rpchelper.GetLatestBlockNumber(tx)
-		if err != nil {
-			return nil, err
+		latestBlockNum, err2 := rpchelper.GetLatestBlockNumber(tx)
+		if err2 != nil {
+			return nil, err2
 		}
 		header, err = api._blockReader.HeaderByNumber(ctx, tx, latestBlockNum)
 	} else {

--- a/rpc/jsonrpc/bor_snapshot.go
+++ b/rpc/jsonrpc/bor_snapshot.go
@@ -114,26 +114,22 @@ func (api *BorImpl) GetAuthor(blockNrOrHash *rpc.BlockNumberOrHash) (*common.Add
 
 	// Retrieve the requested block number (or current if none requested)
 	var header *types.Header
-	var err1 error
 
 	//nolint:nestif
 	if blockNrOrHash == nil {
-		latestBlockNum, err2 := rpchelper.GetLatestBlockNumber(tx)
-		if err2 != nil {
-			return nil, err2
+		latestBlockNum, err := rpchelper.GetLatestBlockNumber(tx)
+		if err != nil {
+			return nil, err
 		}
-		header, err1 = api._blockReader.HeaderByNumber(ctx, tx, latestBlockNum)
+		header, err = api._blockReader.HeaderByNumber(ctx, tx, latestBlockNum)
 	} else {
 		if blockNr, ok := blockNrOrHash.Number(); ok {
-			header, err1 = api._blockReader.HeaderByNumber(ctx, tx, uint64(blockNr))
+			header, err = api._blockReader.HeaderByNumber(ctx, tx, uint64(blockNr))
 		} else {
 			if blockHash, ok := blockNrOrHash.Hash(); ok {
-				header, err1 = rawdb.ReadHeaderByHash(tx, blockHash)
+				header, err = rawdb.ReadHeaderByHash(tx, blockHash)
 			}
 		}
-	}
-	if err1 != nil {
-		return nil, err1
 	}
 
 	// Ensure we have an actually valid block and return its snapshot


### PR DESCRIPTION
Fixes https://github.com/erigontech/erigon/issues/15285 .

The previously used `ReadHeaderByNumber` function only used MDBX and was not aware of snapshots.

Now using blockReader the header can be properly read.

I will create another task to investigate more places where we rely on `ReadHeaderByNumber` to make sure we are not getting wrong results.