### PR TITLE
optimize: reduce sortedAllocKeys memory allocations

### DIFF
--- a/core/genesis_performance_test.go
+++ b/core/genesis_performance_test.go
@@ -1,0 +1,35 @@
+package core
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/types"
+)
+
+func BenchmarkSortedAllocKeys(b *testing.B) {
+	alloc := make(types.GenesisAlloc)
+	for i := 0; i < 1000000; i++ {
+		addr := common.BytesToAddress([]byte{byte(i), byte(i >> 8), byte(i >> 16)})
+		alloc[addr] = types.GenesisAccount{
+			Balance: big.NewInt(1000000),
+			Nonce:   0,
+		}
+	}
+
+	b.Run("Origin:StringKeysAndToAddress", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			keys := sortedAllocKeys(alloc)
+			for _, key := range keys {
+				_ = common.BytesToAddress([]byte(key))
+			}
+		}
+	})
+
+	b.Run("Optimized:AddressKeys", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = sortedAllocAddresses(alloc)
+		}
+	})
+}


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/core
cpu: Apple M2
BenchmarkSortedAllocKeys/Origin:StringKeysAndToAddress-8         	       5	 207266858 ns/op	40007168 B/op	 1000001 allocs/op
BenchmarkSortedAllocKeys/Optimized:AddressKeys-8                 	       5	 209972800 ns/op	20004960 B/op	       4 allocs/op
PASS
ok  	github.com/erigontech/erigon/core	5.106s
```