### PR TITLE
vm: Use bn254 gnark-based pairing check

### DIFF
--- a/erigon-lib/crypto/bn256/gnark_bn254.go
+++ b/erigon-lib/crypto/bn256/gnark_bn254.go
@@ -17,13 +17,14 @@
 package bn256
 
 import (
+	"encoding/binary"
 	"errors"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254"
 )
 
-// UnmarshalCurvePoint unmarshals a given input [32-byte X | 32-byte Y] slice to a G1Affine point
-func UnmarshalCurvePoint(input []byte, point *bn254.G1Affine) error {
+// UnmarshalCurvePointG1 unmarshals a given input [32-byte X | 32-byte Y] slice to a G1Affine point
+func UnmarshalCurvePointG1(input []byte, point *bn254.G1Affine) error {
 	if len(input) != 64 {
 		return errors.New("invalid input size")
 	}
@@ -54,11 +55,64 @@ func UnmarshalCurvePoint(input []byte, point *bn254.G1Affine) error {
 	return nil
 }
 
-// MarshalCurvePoint marshals a given G1Affine point to byte slice with [32-byte X | 32-byte Y] form
-func MarshalCurvePoint(point *bn254.G1Affine, ret []byte) []byte {
+// MarshalCurvePointG1 marshals a given G1Affine point to byte slice with [32-byte X | 32-byte Y] form
+func MarshalCurvePointG1(point *bn254.G1Affine, ret []byte) []byte {
 	xBytes := point.X.Bytes()
 	yBytes := point.Y.Bytes()
 	ret = append(ret, xBytes[:]...)
 	ret = append(ret, yBytes[:]...)
+	return ret
+}
+
+// UnmarshalCurvePointG2 unmarshals a given input [64-byte X | 64-byte Y] slice to a G2Affine point
+func UnmarshalCurvePointG2(input []byte, point *bn254.G2Affine) error {
+	if len(input) != 32*4 {
+		return errors.New("invalid input size")
+	}
+
+	isAllZeroes := true
+	for i := 0; i < 32*4; i += 8 {
+		if 0 != binary.BigEndian.Uint64(input[i:i+8]) {
+			isAllZeroes = false
+			break
+		}
+	}
+	if isAllZeroes {
+		return nil
+	}
+
+	// read X and Y coordinates
+	// p.X.A1 | p.X.A0
+	if err := point.X.A1.SetBytesCanonical(input[:32]); err != nil {
+		return err
+	}
+	if err := point.X.A0.SetBytesCanonical(input[32 : 32*2]); err != nil {
+		return err
+	}
+	// p.Y.A1 | p.Y.A0
+	if err := point.Y.A1.SetBytesCanonical(input[32*2 : 32*3]); err != nil {
+		return err
+	}
+	if err := point.Y.A0.SetBytesCanonical(input[32*3 : 32*4]); err != nil {
+		return err
+	}
+
+	// subgroup check
+	if !point.IsInSubGroup() {
+		return errors.New("invalid point: subgroup check failed")
+	}
+	return nil
+}
+
+// MarshalCurvePointG2 marshals a given G2Affine point to byte slice with [64-byte X | 64-byte Y] form
+func MarshalCurvePointG2(point *bn254.G2Affine, ret []byte) []byte {
+	x0Bytes := point.X.A0.Bytes()
+	x1Bytes := point.X.A1.Bytes()
+	y0Bytes := point.Y.A0.Bytes()
+	y1Bytes := point.Y.A1.Bytes()
+	ret = append(ret, x0Bytes[:]...)
+	ret = append(ret, x1Bytes[:]...)
+	ret = append(ret, y0Bytes[:]...)
+	ret = append(ret, y1Bytes[:]...)
 	return ret
 }


### PR DESCRIPTION
Before

```
Running tool: /usr/bin/go test -benchmem -run=^$ -bench ^BenchmarkPrecompiledBn256Pairing$ github.com/erigontech/erigon/core/vm -v

goos: linux
goarch: amd64
pkg: github.com/erigontech/erigon/core/vm
cpu: AMD Ryzen 9 7945HX with Radeon Graphics
BenchmarkPrecompiledBn256Pairing
BenchmarkPrecompiledBn256Pairing/jeff1-Gas=113000
BenchmarkPrecompiledBn256Pairing/jeff1-Gas=113000-32         	     789	   1502139 ns/op	    113000 gas/op	        75.22 mgas/s	   84528 B/op	     774 allocs/op
BenchmarkPrecompiledBn256Pairing/jeff2-Gas=113000
BenchmarkPrecompiledBn256Pairing/jeff2-Gas=113000-32         	     800	   1498122 ns/op	    113000 gas/op	        75.42 mgas/s	   84528 B/op	     774 allocs/op
BenchmarkPrecompiledBn256Pairing/jeff3-Gas=113000
BenchmarkPrecompiledBn256Pairing/jeff3-Gas=113000-32         	     784	   1510164 ns/op	    113000 gas/op	        74.82 mgas/s	   84528 B/op	     774 allocs/op
BenchmarkPrecompiledBn256Pairing/jeff4-Gas=147000
BenchmarkPrecompiledBn256Pairing/jeff4-Gas=147000-32         	     583	   2011649 ns/op	    147000 gas/op	        73.07 mgas/s	  126560 B/op	    1158 allocs/op
BenchmarkPrecompiledBn256Pairing/jeff5-Gas=147000
BenchmarkPrecompiledBn256Pairing/jeff5-Gas=147000-32         	     586	   2011572 ns/op	    147000 gas/op	        73.07 mgas/s	  126560 B/op	    1158 allocs/op
BenchmarkPrecompiledBn256Pairing/jeff6-Gas=113000
BenchmarkPrecompiledBn256Pairing/jeff6-Gas=113000-32         	     788	   1501236 ns/op	    113000 gas/op	        75.26 mgas/s	   84496 B/op	     773 allocs/op
BenchmarkPrecompiledBn256Pairing/empty_data-Gas=45000
BenchmarkPrecompiledBn256Pairing/empty_data-Gas=45000-32     	    2460	    475013 ns/op	     45000 gas/op	        94.73 mgas/s	     544 B/op	       6 allocs/op
BenchmarkPrecompiledBn256Pairing/one_point-Gas=79000
BenchmarkPrecompiledBn256Pairing/one_point-Gas=79000-32      	    1204	    994237 ns/op	     79000 gas/op	        79.45 mgas/s	   42496 B/op	     389 allocs/op
BenchmarkPrecompiledBn256Pairing/two_point_match_2-Gas=113000
BenchmarkPrecompiledBn256Pairing/two_point_match_2-Gas=113000-32         	     787	   1498495 ns/op	    113000 gas/op	        75.40 mgas/s	   84528 B/op	     774 allocs/op
BenchmarkPrecompiledBn256Pairing/two_point_match_3-Gas=113000
BenchmarkPrecompiledBn256Pairing/two_point_match_3-Gas=113000-32         	     788	   1509189 ns/op	    113000 gas/op	        74.87 mgas/s	   84528 B/op	     774 allocs/op
BenchmarkPrecompiledBn256Pairing/two_point_match_4-Gas=113000
BenchmarkPrecompiledBn256Pairing/two_point_match_4-Gas=113000-32         	     786	   1503046 ns/op	    113000 gas/op	        75.17 mgas/s	   84528 B/op	     774 allocs/op
BenchmarkPrecompiledBn256Pairing/ten_point_match_1-Gas=385000
BenchmarkPrecompiledBn256Pairing/ten_point_match_1-Gas=385000-32         	     212	   5600682 ns/op	    385000 gas/op	        68.73 mgas/s	  420721 B/op	    3836 allocs/op
BenchmarkPrecompiledBn256Pairing/ten_point_match_2-Gas=385000
BenchmarkPrecompiledBn256Pairing/ten_point_match_2-Gas=385000-32         	     211	   5609477 ns/op	    385000 gas/op	        68.63 mgas/s	  420721 B/op	    3836 allocs/op
BenchmarkPrecompiledBn256Pairing/ten_point_match_3-Gas=113000
BenchmarkPrecompiledBn256Pairing/ten_point_match_3-Gas=113000-32         	     776	   1505767 ns/op	    113000 gas/op	        75.04 mgas/s	   84528 B/op	     774 allocs/op
PASS
ok  	github.com/erigontech/erigon/core/vm	19.724s
```

After
```
Running tool: /usr/bin/go test -benchmem -run=^$ -bench ^BenchmarkPrecompiledBn256Pairing$ github.com/erigontech/erigon/core/vm -v

goos: linux
goarch: amd64
pkg: github.com/erigontech/erigon/core/vm
cpu: AMD Ryzen 9 7945HX with Radeon Graphics
BenchmarkPrecompiledBn256Pairing
BenchmarkPrecompiledBn256Pairing/jeff1-Gas=113000
BenchmarkPrecompiledBn256Pairing/jeff1-Gas=113000-32         	    2877	    405873 ns/op	    113000 gas/op	       278.4 mgas/s	    1408 B/op	       6 allocs/op
BenchmarkPrecompiledBn256Pairing/jeff2-Gas=113000
BenchmarkPrecompiledBn256Pairing/jeff2-Gas=113000-32         	    2859	    405907 ns/op	    113000 gas/op	       278.4 mgas/s	    1408 B/op	       6 allocs/op
BenchmarkPrecompiledBn256Pairing/jeff3-Gas=113000
BenchmarkPrecompiledBn256Pairing/jeff3-Gas=113000-32         	    2929	    406350 ns/op	    113000 gas/op	       278.1 mgas/s	    1408 B/op	       6 allocs/op
BenchmarkPrecompiledBn256Pairing/jeff4-Gas=147000
BenchmarkPrecompiledBn256Pairing/jeff4-Gas=147000-32         	    2250	    528377 ns/op	    147000 gas/op	       278.2 mgas/s	    2112 B/op	       6 allocs/op
BenchmarkPrecompiledBn256Pairing/jeff5-Gas=147000
BenchmarkPrecompiledBn256Pairing/jeff5-Gas=147000-32         	    2258	    529987 ns/op	    147000 gas/op	       277.4 mgas/s	    2112 B/op	       6 allocs/op
BenchmarkPrecompiledBn256Pairing/jeff6-Gas=113000
BenchmarkPrecompiledBn256Pairing/jeff6-Gas=113000-32         	    2953	    407988 ns/op	    113000 gas/op	       277.0 mgas/s	    1408 B/op	       6 allocs/op
BenchmarkPrecompiledBn256Pairing/empty_data-Gas=45000
BenchmarkPrecompiledBn256Pairing/empty_data-Gas=45000-32     	261375447	         4.598 ns/op	     45000 gas/op	   9787613 mgas/s	       0 B/op	       0 allocs/op
BenchmarkPrecompiledBn256Pairing/one_point-Gas=79000
BenchmarkPrecompiledBn256Pairing/one_point-Gas=79000-32      	    4152	    286744 ns/op	     79000 gas/op	       275.5 mgas/s	     704 B/op	       6 allocs/op
BenchmarkPrecompiledBn256Pairing/two_point_match_2-Gas=113000
BenchmarkPrecompiledBn256Pairing/two_point_match_2-Gas=113000-32         	    4113	    286579 ns/op	    113000 gas/op	       394.3 mgas/s	    1408 B/op	       6 allocs/op
BenchmarkPrecompiledBn256Pairing/two_point_match_3-Gas=113000
BenchmarkPrecompiledBn256Pairing/two_point_match_3-Gas=113000-32         	    2906	    407595 ns/op	    113000 gas/op	       277.2 mgas/s	    1408 B/op	       6 allocs/op
BenchmarkPrecompiledBn256Pairing/two_point_match_4-Gas=113000
BenchmarkPrecompiledBn256Pairing/two_point_match_4-Gas=113000-32         	    2916	    407833 ns/op	    113000 gas/op	       277.1 mgas/s	    1408 B/op	       6 allocs/op
BenchmarkPrecompiledBn256Pairing/ten_point_match_1-Gas=385000
BenchmarkPrecompiledBn256Pairing/ten_point_match_1-Gas=385000-32         	     955	   1255512 ns/op	    385000 gas/op	       306.6 mgas/s	    7168 B/op	       6 allocs/op
BenchmarkPrecompiledBn256Pairing/ten_point_match_2-Gas=385000
BenchmarkPrecompiledBn256Pairing/ten_point_match_2-Gas=385000-32         	     870	   1377637 ns/op	    385000 gas/op	       279.4 mgas/s	    7168 B/op	       6 allocs/op
BenchmarkPrecompiledBn256Pairing/ten_point_match_3-Gas=113000
BenchmarkPrecompiledBn256Pairing/ten_point_match_3-Gas=113000-32         	    2925	    407780 ns/op	    113000 gas/op	       277.1 mgas/s	    1408 B/op	       6 allocs/op
PASS
ok  	github.com/erigontech/erigon/core/vm	18.052s
```