### PR TITLE
[r30] qa-tests: rename workflow jobs  (#15488) 

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -23,7 +23,7 @@ concurrency:
 
 
 jobs:
-  integration-test-suite:
+  mainnet-rpc-integ-tests:
     runs-on: [ self-hosted, qa, RpcSpecific ]
     env:
       ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version-3/datadir

--- a/.github/workflows/qa-rpc-performance-tests.yml
+++ b/.github/workflows/qa-rpc-performance-tests.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  performance-test-suite:
+  mainnet-rpc-perf-tests:
     strategy:
       matrix:
         include:

--- a/.github/workflows/qa-rpc-test-bisection-tool.yml
+++ b/.github/workflows/qa-rpc-test-bisection-tool.yml
@@ -14,8 +14,8 @@ on:
         required: true
 
 jobs:
-  bisect:
-    runs-on: [self-hosted, qa, Erigon3]
+  rpc-test-bisect:
+    runs-on: [self-hosted, qa, RpcSpecific]
     env:
       ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version/datadir
       ERIGON_QA_PATH: /home/qarunner/erigon-qa

--- a/.github/workflows/qa-tip-tracking-gnosis.yml
+++ b/.github/workflows/qa-tip-tracking-gnosis.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  tip-tracking-test:
+  gnosis-tip-tracking-test:
     runs-on: [self-hosted, qa, Gnosis]
     timeout-minutes: 600
     env:

--- a/.github/workflows/qa-tip-tracking-polygon.yml
+++ b/.github/workflows/qa-tip-tracking-polygon.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  tip-tracking-test:
+  bor-mainnet-tip-tracking-test:
     runs-on: [self-hosted, qa, Polygon]
     timeout-minutes: 800
     env:

--- a/.github/workflows/qa-tip-tracking.yml
+++ b/.github/workflows/qa-tip-tracking.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  tip-tracking-test:
+  mainnet-tip-tracking-test:
     runs-on: [self-hosted, qa, Erigon3]
     timeout-minutes: 600
     env:


### PR DESCRIPTION
1. avoid job name clash
2. add chain name to jobs

(cherry picked from commit eb4c44b611bd17baa3f7b6e19dea8ba2990aa4b7)