### PR TITLE
filename parser fix

### DIFF
--- a/erigon-lib/downloader/snaptype/files.go
+++ b/erigon-lib/downloader/snaptype/files.go
@@ -112,7 +112,7 @@ func ParseFileName(dir, fileName string) (res FileInfo, isE3Seedable bool, ok bo
 	res.name = fileName
 	dirPart, fileName := filepath.Split(fileName)
 	caplin := false
-	if dirPart == "caplin" {
+	if dirPart == "caplin/" {
 		caplin = true
 	}
 	if isSaltFile(fileName) {
@@ -198,7 +198,7 @@ func ParseFileName(dir, fileName string) (res FileInfo, isE3Seedable bool, ok bo
 		res.Type, ok = ParseFileType(typeString)
 		if ok {
 			res.CaplinTypeString = res.Type.Name()
-		} else {
+		} else if !caplin {
 			return res, isStateFile, false
 		}
 	}

--- a/turbo/snapshotsync/snapshots_test.go
+++ b/turbo/snapshotsync/snapshots_test.go
@@ -599,13 +599,9 @@ func TestParseCompressedFileName(t *testing.T) {
 	require.Equal("bodies", f.TypeString)
 
 	var e3 bool
-	f, e3, ok = snaptype.ParseFileNameOld("", stat("caplin/v1.0-021150-021200-BlockRoot.seg"))
-	println(f.TypeString, ok)
-	f, e3, ok = snaptype.ParseFileName("", stat("caplin/v1.0-021150-021200-BlockRoot.seg"))
+	f, e3, ok = snaptype.ParseFileName("", "caplin/v1.0-021150-021200-BlockRoot.seg")
 	require.True(ok)
 	require.False(e3)
-	println(f.Type.Enum())
-	//require.Equal(f.Type.Enum(), coresnaptype.BlockSnapshotTypes.Enum())
 	require.Equal(21150000, int(f.From))
 	require.Equal(21200000, int(f.To))
 	require.Equal("BlockRoot", f.TypeString)

--- a/turbo/snapshotsync/snapshots_test.go
+++ b/turbo/snapshotsync/snapshots_test.go
@@ -570,6 +570,7 @@ func TestParseCompressedFileName(t *testing.T) {
 		"preverified.toml":                             &fstest.MapFile{},
 		"idx/v1-tracesto.40-44.ef":                     &fstest.MapFile{},
 		"v1.0-021700-021800-bodies.seg.torrent":        &fstest.MapFile{},
+		"caplin/v1.0-021150-021200-BlockRoot.seg":      &fstest.MapFile{},
 	}
 	stat := func(name string) string {
 		s, err := fs.Stat(name)
@@ -598,6 +599,17 @@ func TestParseCompressedFileName(t *testing.T) {
 	require.Equal("bodies", f.TypeString)
 
 	var e3 bool
+	f, e3, ok = snaptype.ParseFileNameOld("", stat("caplin/v1.0-021150-021200-BlockRoot.seg"))
+	println(f.TypeString, ok)
+	f, e3, ok = snaptype.ParseFileName("", stat("caplin/v1.0-021150-021200-BlockRoot.seg"))
+	require.True(ok)
+	require.False(e3)
+	println(f.Type.Enum())
+	//require.Equal(f.Type.Enum(), coresnaptype.BlockSnapshotTypes.Enum())
+	require.Equal(21150000, int(f.From))
+	require.Equal(21200000, int(f.To))
+	require.Equal("BlockRoot", f.TypeString)
+
 	f, e3, ok = snaptype.ParseFileName("", stat("v1.0-022695-022696-transactions-to-block.idx"))
 	require.True(ok)
 	require.False(e3)


### PR DESCRIPTION
Add crutch for caplin (it should return ok even if didn't find filetype and it's okay