### PR TITLE
Fix Typos in Comments and Improve Clarity

### DIFF
--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -2636,9 +2636,9 @@ func (d *Downloader) addTorrentFilesFromDisk(quiet bool) error {
 		//	}
 		//}
 
-		// this check is performed here becuase t.MergeSpec in addTorrentFile will do a file
+		// this check is performed here because t.MergeSpec in addTorrentFile will do a file
 		// update in place when it opens its MemMap.  This is non destructive for the data
-		// but casues an update to the file which changes its size to the torrent length which
+		// but causes an update to the file which changes its size to the torrent length which
 		// invalidated the file length check
 		if info, err := d.torrentInfo(ts.DisplayName); err == nil {
 			if info.Completed != nil {

--- a/erigon-lib/state/domain_shared.go
+++ b/erigon-lib/state/domain_shared.go
@@ -523,7 +523,7 @@ func (sd *SharedDomains) GetLatest(domain kv.Domain, tx kv.Tx, k []byte) (v []by
 // DomainPut
 // Optimizations:
 //   - user can provide `prevVal != nil` - then it will not read prev value from storage
-//   - user can append k2 into k1, then underlying methods will not preform append
+//   - user can append k2 into k1, then underlying methods will not perform append
 //   - if `val == nil` it will call DomainDel
 func (sd *SharedDomains) DomainPut(domain kv.Domain, roTx kv.Tx, k, v []byte, txNum uint64, prevVal []byte, prevStep uint64) error {
 	if v == nil {
@@ -563,7 +563,7 @@ func (sd *SharedDomains) DomainPut(domain kv.Domain, roTx kv.Tx, k, v []byte, tx
 // DomainDel
 // Optimizations:
 //   - user can prvide `prevVal != nil` - then it will not read prev value from storage
-//   - user can append k2 into k1, then underlying methods will not preform append
+//   - user can append k2 into k1, then underlying methods will not perform append
 //   - if `val == nil` it will call DomainDel
 func (sd *SharedDomains) DomainDel(domain kv.Domain, tx kv.Tx, k []byte, txNum uint64, prevVal []byte, prevStep uint64) error {
 	if prevVal == nil {


### PR DESCRIPTION


Description:  
This pull request corrects minor typos in comments ("preform" → "perform", "causes" → "causes") and enhances the clarity of documentation in the downloader and state modules. 