### PR TITLE
Makefile: add nosqlite to tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ ifeq ($(shell uname -s), Darwin)
 endif
 
 # about netgo see: https://github.com/golang/go/issues/30310#issuecomment-471669125 and https://github.com/golang/go/issues/57757
-BUILD_TAGS = noboltdb
+BUILD_TAGS = nosqlite,noboltdb
 
 ifneq ($(shell "$(CURDIR)/turbo/silkworm/silkworm_compat_check.sh"),)
 	BUILD_TAGS := $(BUILD_TAGS),nosilkworm


### PR DESCRIPTION
Otherwise

```sh
make erigon
...
# github.com/go-llsqlite/crawshaw/c
In function ‘sqlite3Strlen30’,
    inlined from ‘sqlite3ColumnSetColl’ at sqlite3.c:122860:10:
sqlite3.c:35364:28: warning: ‘strlen’ reading 1 or more bytes from a region of size 0 [-Wstringop-overread]
35364 |   return 0x3fffffff & (int)strlen(z);
      |                            ^~~~~~~~~
In function ‘sqlite3ColumnSetColl’:
cc1: note: source object is likely at address zero
At top level:
cc1: note: unrecognized command-line option ‘-Wno-unknown-warning-option’ may have been intended to silence earlier diagnostics
```
