### PR TITLE
[DO NOT MERGE] Update .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .git
 .github
 .cache
+Dockerfile*
 **/*_test.go
 **/*.a
 **/*.dylib

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,13 @@
+.DS_Store
+.git
+.github
+.cache
 **/*_test.go
 **/*.a
 **/*.dylib
 **/*.o
 **/*.dSYM
+**/.DS_Store
 
 build
 tests/testdata


### PR DESCRIPTION
It should improve docker builds as some changes in the repo would not affect layers which could be cached.