### PR TITLE
Possibly correct bad cancel in progress condition on unit test CI

### DIFF
--- a/.github/workflows/test-all-erigon.yml
+++ b/.github/workflows/test-all-erigon.yml
@@ -47,7 +47,6 @@ jobs:
       group: tests-mac-linux-${{ matrix.os }}-${{ github.ref }}
       cancel-in-progress: >-
         ${{
-          needs.source-of-changes.outputs.changed_files != 'true' &&
           !startsWith(github.ref, 'refs/heads/release/') &&
           github.ref != 'refs/heads/main'
         }}
@@ -108,7 +107,6 @@ jobs:
       group: tests-windows-${{ matrix.os }}-${{ github.ref }}
       cancel-in-progress: >-
         ${{
-          needs.source-of-changes.outputs.changed_files != 'true' &&
           !startsWith(github.ref, 'refs/heads/release/') &&
           github.ref != 'refs/heads/main'
         }}


### PR DESCRIPTION
Possible fix for https://github.com/erigontech/erigon/issues/15670. I don't know if maybe the `needs.source-of-changes.outputs.changed_files` condition is flipped, or maybe my observation about consecutive changed files trumps it altogether.