### PR TITLE
Don't add preverified hashes after initial sync completed

### DIFF
--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -321,7 +321,7 @@ func Downloader(ctx context.Context, logger log.Logger) error {
 	d.MainLoopInBackground(false)
 	if seedbox {
 		var downloadItems []*proto_downloader.AddItem
-		for _, it := range snapcfg.KnownCfg(chain).Preverified {
+		for _, it := range snapcfg.KnownCfg(chain).Preverified.Items {
 			downloadItems = append(downloadItems, &proto_downloader.AddItem{
 				Path:        it.Name,
 				TorrentHash: downloadergrpc.String2Proto(it.Hash),

--- a/cmd/snapshots/sync/sync.go
+++ b/cmd/snapshots/sync/sync.go
@@ -486,7 +486,7 @@ func (s *torrentSession) Label() string {
 
 func NewTorrentSession(cli *TorrentClient, chain string) *torrentSession {
 	session := &torrentSession{cli, map[string]snapcfg.PreverifiedItem{}}
-	for _, it := range snapcfg.KnownCfg(chain).Preverified {
+	for _, it := range snapcfg.KnownCfg(chain).Preverified.Items {
 		session.items[it.Name] = it
 	}
 

--- a/erigon-lib/chain/snapcfg/util.go
+++ b/erigon-lib/chain/snapcfg/util.go
@@ -43,31 +43,45 @@ import (
 var snapshotGitBranch = dbg.EnvString("SNAPS_GIT_BRANCH", version.DefaultSnapshotGitBranch)
 
 var (
-	Mainnet    = fromToml(snapshothashes.Mainnet)
-	Holesky    = fromToml(snapshothashes.Holesky)
-	Sepolia    = fromToml(snapshothashes.Sepolia)
-	Amoy       = fromToml(snapshothashes.Amoy)
-	BorMainnet = fromToml(snapshothashes.BorMainnet)
-	Gnosis     = fromToml(snapshothashes.Gnosis)
-	Chiado     = fromToml(snapshothashes.Chiado)
+	Mainnet    = fromEmbeddedToml(snapshothashes.Mainnet)
+	Holesky    = fromEmbeddedToml(snapshothashes.Holesky)
+	Sepolia    = fromEmbeddedToml(snapshothashes.Sepolia)
+	Amoy       = fromEmbeddedToml(snapshothashes.Amoy)
+	BorMainnet = fromEmbeddedToml(snapshothashes.BorMainnet)
+	Gnosis     = fromEmbeddedToml(snapshothashes.Gnosis)
+	Chiado     = fromEmbeddedToml(snapshothashes.Chiado)
 )
+
+func fromEmbeddedToml(in []byte) Preverified {
+	items := fromToml(in)
+	return Preverified{
+		Local: false,
+		Items: items,
+	}
+}
 
 type PreverifiedItem struct {
 	Name string
 	Hash string
 }
-type Preverified []PreverifiedItem
+
+type PreverifiedItems []PreverifiedItem
+
+type Preverified struct {
+	Local bool
+	Items PreverifiedItems
+}
 
 func (p Preverified) Get(name string) (PreverifiedItem, bool) {
-	i := sort.Search(len(p), func(i int) bool { return p[i].Name >= name })
-	if i >= len(p) || p[i].Name != name {
+	i := sort.Search(len(p.Items), func(i int) bool { return p.Items[i].Name >= name })
+	if i >= len(p.Items) || p.Items[i].Name != name {
 		return PreverifiedItem{}, false
 	}
 
-	return p[i], true
+	return p.Items[i], true
 }
 
-func (p Preverified) Contains(name string, ignoreVersion ...bool) bool {
+func (p PreverifiedItems) Contains(name string, ignoreVersion ...bool) bool {
 	if len(ignoreVersion) > 0 && ignoreVersion[0] {
 		_, name, _ := strings.Cut(name, "-")
 		for _, item := range p {
@@ -86,7 +100,7 @@ func (p Preverified) Contains(name string, ignoreVersion ...bool) bool {
 func (p Preverified) Typed(types []snaptype.Type) Preverified {
 	var bestVersions btree.Map[string, PreverifiedItem]
 
-	for _, p := range p {
+	for _, p := range p.Items {
 		if strings.HasPrefix(p.Name, "salt") && strings.HasSuffix(p.Name, "txt") {
 			bestVersions.Set(p.Name, p)
 			continue
@@ -169,20 +183,21 @@ func (p Preverified) Typed(types []snaptype.Type) Preverified {
 		}
 	}
 
-	var versioned Preverified
+	var versioned []PreverifiedItem
 
 	bestVersions.Scan(func(key string, value PreverifiedItem) bool {
 		versioned = append(versioned, value)
 		return true
 	})
 
-	return versioned
+	p.Items = versioned
+	return p
 }
 
-func (p Preverified) Versioned(preferredVersion ver.Version, minVersion ver.Version, types ...snaptype.Enum) Preverified {
+func (p Preverified) Versioned(preferredVersion ver.Version, minVersion ver.Version, types ...snaptype.Enum) []PreverifiedItem {
 	var bestVersions btree.Map[string, PreverifiedItem]
 
-	for _, p := range p {
+	for _, p := range p.Items {
 		v, name, ok := strings.Cut(p.Name, "-")
 		if !ok {
 			if strings.HasPrefix(p.Name, "domain") || strings.HasPrefix(p.Name, "history") || strings.HasPrefix(p.Name, "idx") || strings.HasPrefix(p.Name, "accessor") {
@@ -242,7 +257,7 @@ func (p Preverified) Versioned(preferredVersion ver.Version, minVersion ver.Vers
 		}
 	}
 
-	var versioned Preverified
+	var versioned []PreverifiedItem
 
 	bestVersions.Scan(func(key string, value PreverifiedItem) bool {
 		versioned = append(versioned, value)
@@ -254,7 +269,7 @@ func (p Preverified) Versioned(preferredVersion ver.Version, minVersion ver.Vers
 
 func (p Preverified) MaxBlock(version ver.Version) (uint64, error) {
 	_max := uint64(0)
-	for _, p := range p {
+	for _, p := range p.Items {
 		_, fileName := filepath.Split(p.Name)
 		ext := filepath.Ext(fileName)
 		if ext != ".seg" {
@@ -328,7 +343,7 @@ func ExtractBlockFromName(name string, v ver.Version) (block uint64, err error) 
 	return block, nil
 }
 
-func (p Preverified) MarshalJSON() ([]byte, error) {
+func (p PreverifiedItems) MarshalJSON() ([]byte, error) {
 	out := map[string]string{}
 
 	for _, i := range p {
@@ -338,7 +353,7 @@ func (p Preverified) MarshalJSON() ([]byte, error) {
 	return json.Marshal(out)
 }
 
-func (p *Preverified) UnmarshalJSON(data []byte) error {
+func (p *PreverifiedItems) UnmarshalJSON(data []byte) error {
 	var outMap map[string]string
 
 	if err := json.Unmarshal(data, &outMap); err != nil {
@@ -349,7 +364,7 @@ func (p *Preverified) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func fromToml(in []byte) (out Preverified) {
+func fromToml(in []byte) PreverifiedItems {
 	var outMap map[string]string
 	if err := toml.Unmarshal(in, &outMap); err != nil {
 		panic(err)
@@ -357,8 +372,8 @@ func fromToml(in []byte) (out Preverified) {
 	return doSort(outMap)
 }
 
-func doSort(in map[string]string) Preverified {
-	out := make(Preverified, 0, len(in))
+func doSort(in map[string]string) []PreverifiedItem {
+	out := make([]PreverifiedItem, 0, len(in))
 	for k, v := range in {
 		out = append(out, PreverifiedItem{k, v})
 	}
@@ -368,9 +383,14 @@ func doSort(in map[string]string) Preverified {
 
 func newCfg(networkName string, preverified Preverified) *Cfg {
 	maxBlockNum, _ := preverified.MaxBlock(ver.ZeroVersion)
-	cfg := &Cfg{ExpectBlocks: maxBlockNum, Preverified: preverified, networkName: networkName}
-	cfg.PreverifiedParsed = make([]*snaptype.FileInfo, len(preverified))
-	for i, p := range cfg.Preverified {
+	cfg := &Cfg{
+		ExpectBlocks: maxBlockNum,
+		Preverified:  preverified,
+		networkName:  networkName,
+		Local:        preverified.Local,
+	}
+	cfg.PreverifiedParsed = make([]*snaptype.FileInfo, len(preverified.Items))
+	for i, p := range cfg.Preverified.Items {
 		info, _, ok := snaptype.ParseFileName("", p.Name)
 		if !ok {
 			continue
@@ -388,7 +408,10 @@ type Cfg struct {
 	ExpectBlocks      uint64
 	Preverified       Preverified          // immutable
 	PreverifiedParsed []*snaptype.FileInfo //Preverified field after `snaptype.ParseFileName("", p.Name)`
-	networkName       string
+	// The preverified list were loaded from local storage. That means they were committed after an
+	// initial sync completed successfully.
+	Local       bool
+	networkName string
 }
 
 // Seedable - can seed it over Bittorrent network to other nodes
@@ -511,16 +534,6 @@ func KnownCfg(networkName string) *Cfg {
 	return newCfg(networkName, c.Typed(knownTypes[networkName]))
 }
 
-func VersionedCfg(networkName string, preferred snaptype.Version, _min snaptype.Version) *Cfg {
-	c, ok := knownPreverified[networkName]
-
-	if !ok {
-		return newCfg(networkName, Preverified{})
-	}
-
-	return newCfg(networkName, c.Versioned(preferred, _min))
-}
-
 var KnownWebseeds = map[string][]string{
 	networkname.Mainnet:    webseedsParse(webseed.Mainnet),
 	networkname.Sepolia:    webseedsParse(webseed.Sepolia),
@@ -556,13 +569,13 @@ func LoadRemotePreverified(ctx context.Context) (loaded bool, err error) {
 	}
 
 	// Re-load the preverified hashes
-	Mainnet = fromToml(snapshothashes.Mainnet)
-	Holesky = fromToml(snapshothashes.Holesky)
-	Sepolia = fromToml(snapshothashes.Sepolia)
-	Amoy = fromToml(snapshothashes.Amoy)
-	BorMainnet = fromToml(snapshothashes.BorMainnet)
-	Gnosis = fromToml(snapshothashes.Gnosis)
-	Chiado = fromToml(snapshothashes.Chiado)
+	Mainnet = fromEmbeddedToml(snapshothashes.Mainnet)
+	Holesky = fromEmbeddedToml(snapshothashes.Holesky)
+	Sepolia = fromEmbeddedToml(snapshothashes.Sepolia)
+	Amoy = fromEmbeddedToml(snapshothashes.Amoy)
+	BorMainnet = fromEmbeddedToml(snapshothashes.BorMainnet)
+	Gnosis = fromEmbeddedToml(snapshothashes.Gnosis)
+	Chiado = fromEmbeddedToml(snapshothashes.Chiado)
 	// Update the known preverified hashes
 	KnownWebseeds = map[string][]string{
 		networkname.Mainnet:    webseedsParse(webseed.Mainnet),
@@ -586,11 +599,15 @@ func LoadRemotePreverified(ctx context.Context) (loaded bool, err error) {
 	return loaded, nil
 }
 
-func SetToml(networkName string, toml []byte) {
+func SetToml(networkName string, toml []byte, local bool) {
 	if _, ok := knownPreverified[networkName]; !ok {
 		return
 	}
-	knownPreverified[networkName] = fromToml(toml)
+	value := Preverified{
+		Local: local,
+		Items: fromToml(toml),
+	}
+	knownPreverified[networkName] = value
 }
 
 func GetToml(networkName string) []byte {

--- a/erigon-lib/downloader/downloader.go
+++ b/erigon-lib/downloader/downloader.go
@@ -1149,7 +1149,7 @@ func SeedableFiles(dirs datadir.Dirs, chainName string, all bool) ([]string, err
 	return slices.Concat(files, l1, l2, l3, l4, l5), nil
 }
 
-func (d *Downloader) BuildTorrentFilesIfNeed(ctx context.Context, chain string, ignore snapcfg.Preverified) error {
+func (d *Downloader) BuildTorrentFilesIfNeed(ctx context.Context, chain string, ignore snapcfg.PreverifiedItems) error {
 	_, err := BuildTorrentFilesIfNeed(ctx, d.cfg.Dirs, d.torrentFS, chain, ignore, false)
 	return err
 }

--- a/erigon-lib/downloader/downloadercfg/downloadercfg.go
+++ b/erigon-lib/downloader/downloadercfg/downloadercfg.go
@@ -348,7 +348,7 @@ func LoadSnapshotsHashes(ctx context.Context, dirs datadir.Dirs, chainName strin
 		if err != nil {
 			return nil, err
 		}
-		snapcfg.SetToml(chainName, haveToml)
+		snapcfg.SetToml(chainName, haveToml, true)
 	} else {
 		// Fetch the snapshot hashes from the web
 		fetched, err := snapcfg.LoadRemotePreverified(ctx)
@@ -361,7 +361,9 @@ func LoadSnapshotsHashes(ctx context.Context, dirs datadir.Dirs, chainName strin
 			return nil, fmt.Errorf("remote snapshot hashes was not fetched for chain %s", chainName)
 		}
 	}
-	return snapcfg.KnownCfg(chainName), nil
+	cfg := snapcfg.KnownCfg(chainName)
+	cfg.Local = exists
+	return cfg, nil
 }
 
 // Saves snapshot hashes. This is done only after the full set of snapshots is completed so that

--- a/erigon-lib/downloader/util.go
+++ b/erigon-lib/downloader/util.go
@@ -182,7 +182,7 @@ func BuildTorrentIfNeed(ctx context.Context, fName, root string, torrentFiles *A
 }
 
 // BuildTorrentFilesIfNeed - create .torrent files from .seg files (big IO) - if .seg files were added manually
-func BuildTorrentFilesIfNeed(ctx context.Context, dirs datadir.Dirs, torrentFiles *AtomicTorrentFS, chain string, ignore snapcfg.Preverified, all bool) (int, error) {
+func BuildTorrentFilesIfNeed(ctx context.Context, dirs datadir.Dirs, torrentFiles *AtomicTorrentFS, chain string, ignore snapcfg.PreverifiedItems, all bool) (int, error) {
 	logEvery := time.NewTicker(20 * time.Second)
 	defer logEvery.Stop()
 

--- a/erigon-lib/state/entity_extras/registry.go
+++ b/erigon-lib/state/entity_extras/registry.go
@@ -46,7 +46,7 @@ var mu sync.RWMutex
 // dirs: directory where snapshots have to reside
 // salt: for creation of indexes.
 // pre: preverified files are snapshot file lists that gets downloaded initially.
-func RegisterForkable(name string, dirs datadir.Dirs, pre snapcfg.Preverified, options ...EntityIdOption) ForkableId {
+func RegisterForkable(name string, dirs datadir.Dirs, pre snapcfg.PreverifiedItems, options ...EntityIdOption) ForkableId {
 	h := &holder{
 		name: name,
 		dirs: dirs,

--- a/erigon-lib/state/entity_extras/snap_config.go
+++ b/erigon-lib/state/entity_extras/snap_config.go
@@ -80,7 +80,7 @@ func (s *SnapshotConfig) StepsInFrozenFile() uint64 {
 	return s.MergeStages[len(s.MergeStages)-1] / s.RootNumPerStep
 }
 
-func (s *SnapshotConfig) LoadPreverified(pre snapcfg.Preverified) {
+func (s *SnapshotConfig) LoadPreverified(pre snapcfg.PreverifiedItems) {
 	if s.PreverifiedParsed != nil {
 		return
 	}
@@ -102,7 +102,7 @@ type SnapInfo struct {
 	Name     string // filename
 	FileType string
 	// Path     string // full path
-	Ext string // extenstion
+	Ext string // extension
 }
 
 type Version = version.Version

--- a/eth/stagedsync/stage_snapshots.go
+++ b/eth/stagedsync/stage_snapshots.go
@@ -718,7 +718,7 @@ func (u *snapshotUploader) seedable(fi snaptype.FileInfo) bool {
 	}
 
 	if checkKnownSizes {
-		for _, it := range snapcfg.KnownCfg(u.cfg.chainConfig.ChainName).Preverified {
+		for _, it := range snapcfg.KnownCfg(u.cfg.chainConfig.ChainName).Preverified.Items {
 			info, _, _ := snaptype.ParseFileName("", it.Name)
 
 			if fi.From == info.From {

--- a/turbo/snapshotsync/snapshotsync.go
+++ b/turbo/snapshotsync/snapshotsync.go
@@ -174,7 +174,11 @@ func canSnapshotBePruned(name string) bool {
 	return isStateHistory(name) || strings.Contains(name, "transactions")
 }
 
-func buildBlackListForPruning(pruneMode bool, stepPrune, minBlockToDownload, blockPrune uint64, preverified snapcfg.Preverified) (map[string]struct{}, error) {
+func buildBlackListForPruning(
+	pruneMode bool,
+	stepPrune, minBlockToDownload, blockPrune uint64,
+	preverified snapcfg.Preverified,
+) (map[string]struct{}, error) {
 
 	blackList := make(map[string]struct{})
 	if !pruneMode {
@@ -182,7 +186,7 @@ func buildBlackListForPruning(pruneMode bool, stepPrune, minBlockToDownload, blo
 	}
 	stepPrune = adjustStepPrune(stepPrune)
 	blockPrune = adjustBlockPrune(blockPrune, minBlockToDownload)
-	for _, p := range preverified {
+	for _, p := range preverified.Items {
 		name := p.Name
 		// Don't prune unprunable files
 		if !canSnapshotBePruned(name) {
@@ -262,7 +266,7 @@ func getMinimumBlocksToDownload(tx kv.Tx, blockReader blockReader, minStep uint6
 
 func getMaxStepRangeInSnapshots(preverified snapcfg.Preverified) (uint64, error) {
 	maxTo := uint64(0)
-	for _, p := range preverified {
+	for _, p := range preverified.Items {
 		// take the "to" from "domain" snapshot
 		if !strings.HasPrefix(p.Name, "domain") {
 			continue
@@ -330,7 +334,7 @@ func WaitForDownloader(
 	// send all hashes to the Downloader service
 	snapCfg := snapcfg.KnownCfg(cc.ChainName)
 	preverifiedBlockSnapshots := snapCfg.Preverified
-	downloadRequest := make([]DownloadRequest, 0, len(preverifiedBlockSnapshots))
+	downloadRequest := make([]DownloadRequest, 0, len(preverifiedBlockSnapshots.Items))
 
 	blockPrune, historyPrune := computeBlocksToPrune(blockReader, prune)
 	blackListForPruning := make(map[string]struct{})
@@ -352,7 +356,7 @@ func WaitForDownloader(
 	}
 
 	// build all download requests
-	for _, p := range preverifiedBlockSnapshots {
+	for _, p := range preverifiedBlockSnapshots.Items {
 		if caplin == NoCaplin && (strings.Contains(p.Name, "beaconblocks") || strings.Contains(p.Name, "blobsidecars") || strings.Contains(p.Name, "caplin")) {
 			continue
 		}
@@ -390,36 +394,39 @@ func WaitForDownloader(
 		})
 	}
 
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-		if err := RequestSnapshotsDownload(ctx, downloadRequest, snapshotDownloader, logPrefix); err != nil {
-			log.Error(fmt.Sprintf("[%s] call downloader", logPrefix), "err", err)
-			time.Sleep(10 * time.Second)
-			continue
-		}
-		break
-	}
-
-	// Check for completion immediately, then growing intervals.
-	interval := time.Second
-	for {
-		completedResp, err := snapshotDownloader.Completed(ctx, &proto_downloader.CompletedRequest{})
-		if err != nil {
-			return fmt.Errorf("waiting for snapshot download: %w", err)
-		}
-		if completedResp.GetCompleted() {
+	// Only add the preverified hashes until the initial sync completed for the first time.
+	if !snapCfg.Local {
+		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+			if err := RequestSnapshotsDownload(ctx, downloadRequest, snapshotDownloader, logPrefix); err != nil {
+				log.Error(fmt.Sprintf("[%s] call downloader", logPrefix), "err", err)
+				time.Sleep(10 * time.Second)
+				continue
+			}
 			break
 		}
-		select {
-		case <-ctx.Done():
-			return context.Cause(ctx)
-		case <-time.After(interval):
+
+		// Check for completion immediately, then growing intervals.
+		interval := time.Second
+		for {
+			completedResp, err := snapshotDownloader.Completed(ctx, &proto_downloader.CompletedRequest{})
+			if err != nil {
+				return fmt.Errorf("waiting for snapshot download: %w", err)
+			}
+			if completedResp.GetCompleted() {
+				break
+			}
+			select {
+			case <-ctx.Done():
+				return context.Cause(ctx)
+			case <-time.After(interval):
+			}
+			interval = min(interval*2, 20*time.Second)
 		}
-		interval = min(interval*2, 20*time.Second)
 	}
 
 	if !headerchain {


### PR DESCRIPTION
This is to complete an item from https://github.com/erigontech/erigon/pull/15043:

> Don't redownload files after preverified.toml is committed if they go missing. This occurs due to merges etc.

At node startup, the preverified.toml that was committed locally from a previous initial sync is scanned and the torrents in it are requested from the downloader. If in a previous run, torrents were removed due to merges, the torrents in the final snapshot will be added again (to my understanding). I can see two ways to deal with this:

1. Mark manually removed torrents with a file like name.removed, or
2. Once the preverified.toml is committed, don't request any torrents from it any longer.

The second option removes a lot of the logic from the downloader, where it doesn't belong. This PR implements that. The only downside I can see here is it makes it harder to manually repair a snapshot dir, for example you could "resync" a dir by removing all the `.removed` files in 1. However you could also sync to the latest initial snapshot by removing whatever preverified.toml you have, possibly wiping any .torrent files, and let the node resync (it will reuse existing data now too since #15043).

I'm working on a sequence diagram that should describe how it fits together so it's clear and easy to work with the downloader snapshot dir and to check this logic.

