### PR TITLE
[r30] qa-tests: temporarily disable bor-mainnet from sync-from-scratch test 

### DIFF
--- a/.github/workflows/qa-sync-from-scratch-minimal-node.yml
+++ b/.github/workflows/qa-sync-from-scratch-minimal-node.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        chain: [ mainnet, bor-mainnet ]  # Chain name as specified on the erigon command line
+        chain: [ mainnet ]  # Chain name as specified on the erigon command line
     env:
       ERIGON_DATA_DIR: ${{ github.workspace }}/erigon_data
       ERIGON_QA_PATH: /home/qarunner/erigon-qa


### PR DESCRIPTION
We need to wait for the snapshots to be recreated.