### PR TITLE
rpcdaemon:  in case of ParseError set the HttpStatus to BadRequest as spec

### DIFF
--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -407,6 +407,9 @@ func (h *handler) handleResponse(msg *jsonrpcMessage) {
 
 // handleCallMsg executes a call message and returns the answer.
 func (h *handler) handleCallMsg(ctx *callProc, msg *jsonrpcMessage, stream jsonstream.Stream) *jsonrpcMessage {
+	if !msg.hasMethod() || !msg.hasVersion() {
+		return msg.errorResponse(&invalidRequestError{"invalid request"})
+	}
 	switch {
 	case msg.isNotification():
 		h.handleCall(ctx, msg, stream)

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -407,9 +407,6 @@ func (h *handler) handleResponse(msg *jsonrpcMessage) {
 
 // handleCallMsg executes a call message and returns the answer.
 func (h *handler) handleCallMsg(ctx *callProc, msg *jsonrpcMessage, stream jsonstream.Stream) *jsonrpcMessage {
-	if !msg.hasMethod() || !msg.hasVersion() {
-		return msg.errorResponse(&invalidRequestError{"invalid request"})
-	}
 	switch {
 	case msg.isNotification():
 		h.handleCall(ctx, msg, stream)

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -283,7 +283,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if !s.disableStreaming {
 		stream = newJsonStream(w)
 	}
-	s.serveSingleRequest(ctx, codec, stream)
+
+	errorMsg := s.serveSingleRequest(ctx, codec, stream)
+	if errorMsg != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		codec.WriteJSON(ctx, errorMsg)
+	}
 }
 
 // validateRequest returns a non-zero response code and error message if the

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -272,7 +272,7 @@ func parseMessage(raw json.RawMessage) ([]*jsonrpcMessage, bool, error) {
 		msgs := []*jsonrpcMessage{{}}
 		err := json.Unmarshal(raw, &msgs[0])
 		if err != nil {
-			return nil, false, fmt.Errorf("unmarshall error")
+			return nil, false, err
 		}
 		return msgs, false, nil
 	}

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -223,7 +223,7 @@ func (c *jsonCodec) ReadBatch() (messages []*jsonrpcMessage, batch bool, err err
 	// This verifies basic syntax, etc.
 	var rawmsg json.RawMessage
 	if err := c.decode(&rawmsg); err != nil {
-		return nil, false, fmt.Errorf("parsing error")
+		return nil, false, err
 	}
 	messages, batch, err = parseMessage(rawmsg)
 	if err != nil {

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -64,6 +64,14 @@ func (msg *jsonrpcMessage) isNotification() bool {
 	return msg.ID == nil && msg.Method != ""
 }
 
+func (msg *jsonrpcMessage) hasVersion() bool {
+	return msg.Version != ""
+}
+
+func (msg *jsonrpcMessage) hasMethod() bool {
+	return msg.Method != ""
+}
+
 func (msg *jsonrpcMessage) isCall() bool {
 	return msg.hasValidID() && msg.Method != ""
 }
@@ -215,9 +223,12 @@ func (c *jsonCodec) ReadBatch() (messages []*jsonrpcMessage, batch bool, err err
 	// This verifies basic syntax, etc.
 	var rawmsg json.RawMessage
 	if err := c.decode(&rawmsg); err != nil {
+		return nil, false, fmt.Errorf("parsing error")
+	}
+	messages, batch, err = parseMessage(rawmsg)
+	if err != nil {
 		return nil, false, err
 	}
-	messages, batch = parseMessage(rawmsg)
 	for i, msg := range messages {
 		if msg == nil {
 			// Message is JSON 'null'. Replace with zero value so it
@@ -256,11 +267,14 @@ func (c *jsonCodec) closed() <-chan interface{} {
 // checks in this function because the raw message has already been syntax-checked when it
 // is called. Any non-JSON-RPC messages in the input return the zero value of
 // jsonrpcMessage.
-func parseMessage(raw json.RawMessage) ([]*jsonrpcMessage, bool) {
+func parseMessage(raw json.RawMessage) ([]*jsonrpcMessage, bool, error) {
 	if !isBatch(raw) {
 		msgs := []*jsonrpcMessage{{}}
-		json.Unmarshal(raw, &msgs[0])
-		return msgs, false
+		err := json.Unmarshal(raw, &msgs[0])
+		if err != nil {
+			return nil, false, fmt.Errorf("unmarshall error")
+		}
+		return msgs, false, nil
 	}
 	dec := json.NewDecoder(bytes.NewReader(raw))
 	dec.Token() // skip '['
@@ -269,7 +283,7 @@ func parseMessage(raw json.RawMessage) ([]*jsonrpcMessage, bool) {
 		msgs = append(msgs, new(jsonrpcMessage))
 		dec.Decode(&msgs[len(msgs)-1])
 	}
-	return msgs, true
+	return msgs, true, nil
 }
 
 // isBatch returns true when the first non-whitespace characters is '['

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -112,7 +112,7 @@ func runTestScript(t *testing.T, file string, logger log.Logger) {
 				t.Fatalf("read error: %v", err)
 			}
 			sent = strings.TrimRight(sent, "\r\n")
-			msgs, batch := parseMessage(json.RawMessage(sent))
+			msgs, batch, _ := parseMessage(json.RawMessage(sent))
 			if batch {
 				sort.Slice(msgs, func(i, j int) bool {
 					return string(msgs[i].ID) < string(msgs[j].ID)
@@ -122,7 +122,7 @@ func runTestScript(t *testing.T, file string, logger log.Logger) {
 					panic(err)
 				}
 				sent = string(b)
-				msgs, _ = parseMessage(json.RawMessage(want))
+				msgs, _, _ = parseMessage(json.RawMessage(want))
 				sort.Slice(msgs, func(i, j int) bool {
 					return string(msgs[i].ID) < string(msgs[j].ID)
 				})

--- a/rpc/testdata/invalid-nonobj.js
+++ b/rpc/testdata/invalid-nonobj.js
@@ -1,6 +1,6 @@
 // This test checks behavior for invalid requests.
 
---> 1
+--> {}
 <-- {"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"invalid request"}}
 
 --> null


### PR DESCRIPTION
This PR contains fixes  in case malformed JSON returns "parse error" with httpStatus BadRequest(400) instead of OK(200)