### PR TITLE
handle case when manually triggered ci can cancel existing ci runs

### DIFF
--- a/.github/workflows/test-all-erigon.yml
+++ b/.github/workflows/test-all-erigon.yml
@@ -50,7 +50,7 @@ jobs:
       group: >-
         ${{
           (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && 
-          format('tests-all-erigon-{0}-{1}-{2}', matrix.os, github.ref, github.sha) ||
+          format('tests-all-erigon-{0}-{1}', matrix.os, github.run_id) ||
           format('tests-all-erigon-{0}-{1}', matrix.os, github.ref)
         }}
       cancel-in-progress: true

--- a/.github/workflows/test-all-erigon.yml
+++ b/.github/workflows/test-all-erigon.yml
@@ -108,13 +108,13 @@ jobs:
   tests-windows:
     needs: source-of-changes
     concurrency:
-      group: tests-windows-${{ matrix.os }}-${{ github.ref }}
-      cancel-in-progress: >-
+      group: >-
         ${{
-          needs.source-of-changes.outputs.changed_files != 'true' &&
-          !startsWith(github.ref, 'refs/heads/release/') &&
-          github.ref != 'refs/heads/main'
+          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && 
+          format('tests-all-erigon-{0}-{1}-{2}', matrix.os, github.run_id) ||
+          format('tests-all-erigon-{0}-{1}', matrix.os, github.ref)
         }}
+      cancel-in-progress: true
     strategy:
       matrix:
         os: [ windows-2025 ]


### PR DESCRIPTION
- manual runs like https://github.com/erigontech/erigon/actions/runs/15808632581 can cancel existing ci runs for commits on main.
- this change makes `github.run_id` part of concurrency group, such that each run is unique on main/release, and is never blocked by other runs. 