### PR TITLE
fix path to error-codes articel

### DIFF
--- a/execution/abi/bind/backends/simulated.go
+++ b/execution/abi/bind/backends/simulated.go
@@ -537,7 +537,7 @@ type revertError struct {
 }
 
 // ErrorCode returns the JSON error code for a revert.
-// See: https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal
+// See: https://github.com/ethereum/eth-wiki/blob/master/json-rpc/error-codes-improvement-proposal.md
 func (e *revertError) ErrorCode() int {
 	return 3
 }

--- a/rpc/ethapi/api.go
+++ b/rpc/ethapi/api.go
@@ -282,7 +282,7 @@ type RevertError struct {
 }
 
 // ErrorCode returns the JSON error code for a revertal.
-// See: https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal
+// See: https://github.com/ethereum/eth-wiki/blob/master/json-rpc/error-codes-improvement-proposal.md
 func (e *RevertError) ErrorCode() int {
 	return 3
 }


### PR DESCRIPTION
ethereum has renamed their repo to eth-wiki so if we want to keep link working propely  we need to update it too.  