### PR TITLE
fix dependency test on windows

### DIFF
--- a/erigon-lib/state/aggregator_test.go
+++ b/erigon-lib/state/aggregator_test.go
@@ -1575,7 +1575,6 @@ func TestAggregator_CheckDependencyHistoryII(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, exist)
 	agg.closeDirtyFiles() // because windows
-	agg.OpenList([]string{}, false)
 
 	require.NoError(t, os.Remove(codeMergedFile))
 


### PR DESCRIPTION
somehow the previous pr got merged even after test failure