### PR TITLE
Fix post hiemdall v2 sync stall

### DIFF
--- a/polygon/sync/sync.go
+++ b/polygon/sync/sync.go
@@ -306,7 +306,7 @@ func (s *Sync) applyNewBlockOnTip(ctx context.Context, event EventNewBlock, ccb 
 			}
 
 			blocks, err := s.p2pService.FetchBlocksBackwardsByHash(ctx, fetchHeaderHash, fetchAmount, event.PeerId, opts...)
-			if err != nil {
+			if err != nil || len(blocks.Data)==0 {
 				if s.ignoreFetchBlocksErrOnTipEvent(err) {
 					s.logger.Debug(
 						syncLogPrefix("applyNewBlockOnTip: failed to fetch complete blocks, ignoring event"),
@@ -322,8 +322,6 @@ func (s *Sync) applyNewBlockOnTip(ctx context.Context, event EventNewBlock, ccb 
 			}
 
 			blockChain = append(blocks.Data, blockChain...)
-
-			fmt.Println(len(blocks.Data))
 			fetchHeaderHash = blocks.Data[0].ParentHash()
 			amount -= uint64(len(blocks.Data))
 		}

--- a/polygon/sync/sync.go
+++ b/polygon/sync/sync.go
@@ -306,7 +306,7 @@ func (s *Sync) applyNewBlockOnTip(ctx context.Context, event EventNewBlock, ccb 
 			}
 
 			blocks, err := s.p2pService.FetchBlocksBackwardsByHash(ctx, fetchHeaderHash, fetchAmount, event.PeerId, opts...)
-			if err != nil || len(blocks.Data)==0 {
+			if err != nil || len(blocks.Data) == 0 {
 				if s.ignoreFetchBlocksErrOnTipEvent(err) {
 					s.logger.Debug(
 						syncLogPrefix("applyNewBlockOnTip: failed to fetch complete blocks, ignoring event"),
@@ -695,7 +695,7 @@ func (s *Sync) Run(ctx context.Context) error {
 	s.logger.Info(syncLogPrefix("running sync component"))
 
 	// This is set to disable heimdall checks casuing a pause during transition
-	// it can be removed post July 2025 where behavior can revert to previous 
+	// it can be removed post July 2025 where behavior can revert to previous
 	// behavior of waitiing for heimdall to sync
 	const HiemdalV1V2Transition = true
 


### PR DESCRIPTION
This fixes an issue with erigon during the Heimdall v1->V2 migration where 

1. Erigon waits for hiemdall to get into sync - which is not going to happen for a potentially long period of time (several hours)
2. On syncing Erigon stalls because it can't fetch enough backward headers due to loack of milestones and checkpoints