### PR TITLE
Add Depth Inc/Dec methods to allow change contract stack depth outside of interpreter

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -585,3 +585,12 @@ func (evm *EVM) captureEnd(depth int, typ OpCode, startGas uint64, leftOverGas u
 		tracer.OnExit(depth, ret, startGas-leftOverGas, VMErrorFromErr(err), reverted)
 	}
 }
+
+// Depth returns the current depth
+func (evm *EVM) Depth() int {
+	return evm.interpreter.Depth()
+}
+
+func (evm *EVM) IncDepth() { evm.interpreter.IncDepth() }
+
+func (evm *EVM) DecDepth() { evm.interpreter.DecDepth() }

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -1221,10 +1221,10 @@ func opSelfdestruct(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 	interpreter.evm.IntraBlockState().AddBalance(beneficiaryAddr, balance, tracing.BalanceIncreaseSelfdestruct)
 	interpreter.evm.IntraBlockState().Selfdestruct(callerAddr)
 	if interpreter.evm.Config().Tracer != nil && interpreter.evm.Config().Tracer.OnEnter != nil {
-		interpreter.evm.Config().Tracer.OnEnter(interpreter.depth, byte(SELFDESTRUCT), scope.Contract.Address(), beneficiary.Bytes20(), false, []byte{}, 0, &balance, nil)
+		interpreter.evm.Config().Tracer.OnEnter(interpreter.Depth(), byte(SELFDESTRUCT), scope.Contract.Address(), beneficiary.Bytes20(), false, []byte{}, 0, &balance, nil)
 	}
 	if interpreter.evm.Config().Tracer != nil && interpreter.evm.Config().Tracer.OnExit != nil {
-		interpreter.evm.Config().Tracer.OnExit(interpreter.depth, []byte{}, 0, nil, false)
+		interpreter.evm.Config().Tracer.OnExit(interpreter.Depth(), []byte{}, 0, nil, false)
 	}
 	return nil, errStopToken
 }
@@ -1244,10 +1244,10 @@ func opSelfdestruct6780(pc *uint64, interpreter *EVMInterpreter, scope *ScopeCon
 	interpreter.evm.IntraBlockState().AddBalance(beneficiaryAddr, balance, tracing.BalanceIncreaseSelfdestruct)
 	interpreter.evm.IntraBlockState().Selfdestruct6780(callerAddr)
 	if interpreter.evm.Config().Tracer != nil && interpreter.evm.Config().Tracer.OnEnter != nil {
-		interpreter.cfg.Tracer.OnEnter(interpreter.depth, byte(SELFDESTRUCT), scope.Contract.Address(), beneficiary.Bytes20(), false, []byte{}, 0, &balance, nil)
+		interpreter.cfg.Tracer.OnEnter(interpreter.Depth(), byte(SELFDESTRUCT), scope.Contract.Address(), beneficiary.Bytes20(), false, []byte{}, 0, &balance, nil)
 	}
 	if interpreter.evm.Config().Tracer != nil && interpreter.evm.Config().Tracer.OnExit != nil {
-		interpreter.cfg.Tracer.OnExit(interpreter.depth, []byte{}, 0, nil, false)
+		interpreter.cfg.Tracer.OnExit(interpreter.Depth(), []byte{}, 0, nil, false)
 	}
 	return nil, errStopToken
 }

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -64,9 +64,9 @@ type Interpreter interface {
 	// Run loops and evaluates the contract's code with the given input data and returns
 	// the return byte-slice and an error if one occurred.
 	Run(contract *Contract, input []byte, static bool) ([]byte, error)
-
-	// `Depth` returns the current call stack's depth.
-	Depth() int
+	Depth() int // `Depth` returns the current call stack's depth.
+	IncDepth()  // Increments the current call stack's depth.
+	DecDepth()  // Decrements the current call stack's depth
 }
 
 // ScopeContext contains the things that are per-call, such as stack and memory,
@@ -132,13 +132,6 @@ type keccakState interface {
 	Read([]byte) (int, error)
 }
 
-// EVMInterpreter represents an EVM interpreter
-type EVMInterpreter struct {
-	*VM
-	jt    *JumpTable // EVM instruction table
-	depth int
-}
-
 // structcheck doesn't see embedding
 //
 //nolint:structcheck
@@ -153,6 +146,20 @@ type VM struct {
 	returnData []byte // Last CALL's return data for subsequent reuse
 }
 
+func (vm *VM) setReadonly(outerReadonly bool) func() {
+	if outerReadonly && !vm.readOnly {
+		vm.readOnly = true
+		return func() {
+			vm.readOnly = false
+		}
+	}
+	return func() {}
+}
+
+func (vm *VM) getReadonly() bool {
+	return vm.readOnly
+}
+
 func copyJumpTable(jt *JumpTable) *JumpTable {
 	var copy JumpTable
 	for i, op := range jt {
@@ -162,6 +169,13 @@ func copyJumpTable(jt *JumpTable) *JumpTable {
 		}
 	}
 	return &copy
+}
+
+// EVMInterpreter represents an EVM interpreter
+type EVMInterpreter struct {
+	*VM
+	jt    *JumpTable // EVM instruction table
+	depth int
 }
 
 // NewEVMInterpreter returns a new instance of the Interpreter.
@@ -268,15 +282,15 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		in.readOnly = true
 	}
 	// Increment the call depth which is restricted to 1024
-	in.depth++
+	in.IncDepth()
 	defer func() {
 		// first: capture data/memory/state/depth/etc... then clenup them
 		if debug && err != nil {
 			if !logged && in.cfg.Tracer.OnOpcode != nil {
-				in.cfg.Tracer.OnOpcode(pcCopy, byte(op), gasCopy, cost, callContext, in.returnData, in.depth, VMErrorFromErr(err))
+				in.cfg.Tracer.OnOpcode(pcCopy, byte(op), gasCopy, cost, callContext, in.returnData, in.Depth(), VMErrorFromErr(err))
 			}
 			if logged && in.cfg.Tracer.OnFault != nil {
-				in.cfg.Tracer.OnFault(pcCopy, byte(op), gasCopy, cost, callContext, in.depth, VMErrorFromErr(err))
+				in.cfg.Tracer.OnFault(pcCopy, byte(op), gasCopy, cost, callContext, in.Depth(), VMErrorFromErr(err))
 			}
 		}
 		// this function must execute _after_: the `CaptureState` needs the stacks before
@@ -285,7 +299,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		if restoreReadonly {
 			in.readOnly = false
 		}
-		in.depth--
+		in.DecDepth()
 	}()
 
 	// The Interpreter main run loop (contextual). This loop runs until either an
@@ -355,7 +369,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 				in.cfg.Tracer.OnGasChange(gasCopy, gasCopy-cost, tracing.GasChangeCallOpCode)
 			}
 			if in.cfg.Tracer.OnOpcode != nil {
-				in.cfg.Tracer.OnOpcode(_pc, byte(op), gasCopy, cost, callContext, in.returnData, in.depth, VMErrorFromErr(err))
+				in.cfg.Tracer.OnOpcode(_pc, byte(op), gasCopy, cost, callContext, in.returnData, in.Depth(), VMErrorFromErr(err))
 				logged = true
 			}
 		}
@@ -394,20 +408,10 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 }
 
 // Depth returns the current call stack depth.
-func (in *EVMInterpreter) Depth() int {
-	return in.depth
-}
+func (in *EVMInterpreter) Depth() int { return in.depth }
 
-func (vm *VM) setReadonly(outerReadonly bool) func() {
-	if outerReadonly && !vm.readOnly {
-		vm.readOnly = true
-		return func() {
-			vm.readOnly = false
-		}
-	}
-	return func() {}
-}
+// Increments the current call stack's depth.
+func (in *EVMInterpreter) IncDepth() { in.depth++ }
 
-func (vm *VM) getReadonly() bool {
-	return vm.readOnly
-}
+// Decrements the current call stack's depth
+func (in *EVMInterpreter) DecDepth() { in.depth-- }


### PR DESCRIPTION
This change is useful for arbitrum and potentially for other networks desiring to control EVM run stack