### PR TITLE
Fix concurrent map read/write and change to file verification

### DIFF
--- a/erigon-db/downloader/downloader.go
+++ b/erigon-db/downloader/downloader.go
@@ -40,6 +40,7 @@ import (
 	"github.com/anacrolix/chansync"
 	"github.com/anacrolix/torrent/types/infohash"
 	"github.com/c2h5oh/datasize"
+	"github.com/puzpuzpuz/xsync/v4"
 	"golang.org/x/sync/semaphore"
 
 	// Make Go expvars available to Prometheus for diagnostics.
@@ -90,8 +91,9 @@ type Downloader struct {
 	startTime time.Time
 
 	lock sync.RWMutex
-	// Pieces having extra verification due to file size mismatches.
-	piecesBeingVerified   map[*torrent.Piece]struct{}
+	// Files having extra verification due to file size mismatches. Use atomics for this map since
+	// locking requirements are mixed, and it's not coupled to anything else.
+	filesBeingVerified    *xsync.Map[*torrent.File, struct{}]
 	verificationOccurring chansync.Flag
 	// Torrents that block completion. They were requested specifically. Torrents added from disk
 	// that aren't subsequently requested are not required to satisfy the sync stage.
@@ -331,14 +333,14 @@ func New(ctx context.Context, cfg *downloadercfg.Cfg, logger log.Logger, verbosi
 	}
 
 	d := &Downloader{
-		cfg:            cfg,
-		torrentStorage: m,
-		torrentClient:  torrentClient,
-		stats:          stats,
-		logger:         logger,
-		verbosity:      verbosity,
-		torrentFS:      &AtomicTorrentFS{dir: cfg.Dirs.Snap},
-		logPrefix:      "",
+		cfg:                cfg,
+		torrentStorage:     m,
+		torrentClient:      torrentClient,
+		stats:              stats,
+		logger:             logger,
+		verbosity:          verbosity,
+		torrentFS:          &AtomicTorrentFS{dir: cfg.Dirs.Snap},
+		filesBeingVerified: xsync.NewMap[*torrent.File, struct{}](),
 	}
 
 	if len(cfg.WebSeedUrls) == 0 {
@@ -487,9 +489,9 @@ func (d *Downloader) allTorrentsComplete() (ret bool) {
 		}
 		// TODO: Should we write the torrent files here instead of in the goroutine spawned in addTorrentSpec?
 	}
-	// Require that we're not waiting on any piece verification. NB this isn't just requiredTorrent
+	// Require that we're not waiting on any file verification. NB this isn't just requiredTorrent
 	// pieces, but that might be best.
-	if len(d.piecesBeingVerified) != 0 {
+	if d.filesBeingVerified.Size() != 0 {
 		ret = false
 	}
 	return
@@ -531,33 +533,31 @@ func (d *Downloader) validateCompletedSnapshot(t *torrent.Torrent) (passed bool)
 			d.logger.Crit("torrent file is present but data is incomplete", "name", f.Path(), "err", err)
 		}
 		passed = false
-		d.verifyPieces(f)
+		d.verifyFile(f)
 	}
 	return
 }
 
 // Run verification for pieces of the file that aren't already being verified.
-func (d *Downloader) verifyPieces(f *torrent.File) {
-	for p := range f.Pieces() {
-		if g.MapContains(d.piecesBeingVerified, p) {
-			continue
-		}
-		g.MakeMapIfNil(&d.piecesBeingVerified)
-		if !g.MapInsert(d.piecesBeingVerified, p, struct{}{}).Ok {
-			d.updateVerificationOccurring()
-			d.spawn(func() {
-				err := p.VerifyDataContext(d.ctx)
-				d.lock.Lock()
-				defer d.lock.Unlock()
-				g.MustDelete(d.piecesBeingVerified, p)
-				d.updateVerificationOccurring()
-				if d.ctx.Err() != nil {
-					return
-				}
-				panicif.Err(err)
-			})
-		}
+func (d *Downloader) verifyFile(f *torrent.File) {
+	_, loaded := d.filesBeingVerified.LoadOrStore(f, struct{}{})
+	if loaded {
+		return
 	}
+	d.updateVerificationOccurring()
+	d.spawn(func() {
+		for p := range f.Pieces() {
+			err := p.VerifyDataContext(d.ctx)
+			if d.ctx.Err() != nil {
+				return
+			}
+			panicif.Err(err)
+		}
+		_, loaded := d.filesBeingVerified.LoadAndDelete(f)
+		// We should be the ones removing this value.
+		panicif.False(loaded)
+		d.updateVerificationOccurring()
+	})
 }
 
 // Interval is how long between recalcs.
@@ -1067,12 +1067,12 @@ func (d *Downloader) saveMetainfoWhenComplete(t *torrent.Torrent) {
 		case <-d.ctx.Done():
 			return
 		case <-d.verificationOccurring.Off():
-			// This could be filtered to only pieces we care about...
+			// This could be filtered to only files we care about...
 		}
 		if func() (done bool) {
 			d.lock.Lock()
 			defer d.lock.Unlock()
-			if !t.Complete().Bool() || len(d.piecesBeingVerified) != 0 {
+			if !t.Complete().Bool() || d.filesBeingVerified.Size() != 0 {
 				return
 			}
 			err := d.saveMetainfoPrecheck(t)
@@ -1352,7 +1352,7 @@ func (d *Downloader) spawn(f func()) {
 }
 
 func (d *Downloader) updateVerificationOccurring() {
-	d.verificationOccurring.SetBool(len(d.piecesBeingVerified) != 0)
+	d.verificationOccurring.SetBool(d.filesBeingVerified.Size() != 0)
 }
 
 // Delete - stop seeding, remove file, remove .torrent

--- a/erigon-db/go.mod
+++ b/erigon-db/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/gballet/go-verkle v0.0.0-20221121182333-31427a1f2d35
 	github.com/go-quicktest/qt v1.101.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
+	github.com/puzpuzpuz/xsync/v4 v4.1.0
 	github.com/rs/dnscache v0.0.0-20211102005908-e0241e321417
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/stretchr/testify v1.10.0

--- a/erigon-db/go.sum
+++ b/erigon-db/go.sum
@@ -400,6 +400,8 @@ github.com/protolambda/ctxlock v0.1.0 h1:rCUY3+vRdcdZXqT07iXgyr744J2DU2LCBIXowYA
 github.com/protolambda/ctxlock v0.1.0/go.mod h1:vefhX6rIZH8rsg5ZpOJfEDYQOppZi19SfPiGOFrNnwM=
 github.com/protolambda/ztyp v0.2.2 h1:rVcL3vBu9W/aV646zF6caLS/dyn9BN8NYiuJzicLNyY=
 github.com/protolambda/ztyp v0.2.2/go.mod h1:9bYgKGqg3wJqT9ac1gI2hnVb0STQq7p/1lapqrqY1dU=
+github.com/puzpuzpuz/xsync/v4 v4.1.0 h1:x9eHRl4QhZFIPJ17yl4KKW9xLyVWbb3/Yq4SXpjF71U=
+github.com/puzpuzpuz/xsync/v4 v4.1.0/go.mod h1:VJDmTCJMBt8igNxnkQd86r+8KUeN1quSfNKu5bLYFQo=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=

--- a/go.mod
+++ b/go.mod
@@ -116,6 +116,8 @@ require (
 	sigs.k8s.io/yaml v1.4.0
 )
 
+require github.com/puzpuzpuz/xsync/v4 v4.1.0 // indirect
+
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -786,6 +786,8 @@ github.com/prysmaticlabs/go-bitfield v0.0.0-20240618144021-706c95b2dd15 h1:lC8ki
 github.com/prysmaticlabs/go-bitfield v0.0.0-20240618144021-706c95b2dd15/go.mod h1:8svFBIKKu31YriBG/pNizo9N0Jr9i5PQ+dFkxWg3x5k=
 github.com/prysmaticlabs/gohashtree v0.0.4-beta h1:H/EbCuXPeTV3lpKeXGPpEV9gsUpkqOOVnWapUyeWro4=
 github.com/prysmaticlabs/gohashtree v0.0.4-beta/go.mod h1:BFdtALS+Ffhg3lGQIHv9HDWuHS8cTvHZzrHWxwOtGOs=
+github.com/puzpuzpuz/xsync/v4 v4.1.0 h1:x9eHRl4QhZFIPJ17yl4KKW9xLyVWbb3/Yq4SXpjF71U=
+github.com/puzpuzpuz/xsync/v4 v4.1.0/go.mod h1:VJDmTCJMBt8igNxnkQd86r+8KUeN1quSfNKu5bLYFQo=
 github.com/quasilyte/go-ruleguard/dsl v0.3.22 h1:wd8zkOhSNr+I+8Qeciml08ivDt1pSXe60+5DqOpCjPE=
 github.com/quasilyte/go-ruleguard/dsl v0.3.22/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/quic-go/qpack v0.5.1 h1:giqksBPnT/HDtZ6VhtFKgoLOWmlyo9Ei6u9PqzIMbhI=


### PR DESCRIPTION
Fix a concurrent map read/write spotted by @AskAlexSharov. It occurred in one of the three code paths that called into this function. I switched to an atomic Map, and cleaned up the file verification which I noticed could cause conceivably cause pieces to be indefinitely added to verification. Guarding by file should prevent that possibility. Atomic map might be overkill but there's very little synchronization required.