### PR TITLE
Fixed sprint length check in block processing

### DIFF
--- a/polygon/bridge/service.go
+++ b/polygon/bridge/service.go
@@ -317,7 +317,7 @@ func (s *Service) ProcessNewBlocks(ctx context.Context, blocks []*types.Block) e
 			continue
 		}
 
-		expectedNextBlockNum := lastProcessedBlockInfo.BlockNum + s.borConfig.CalculateSprintLength(blockNum)
+		expectedNextBlockNum := lastProcessedBlockInfo.BlockNum + s.borConfig.CalculateSprintLength(lastProcessedBlockInfo.BlockNum)
 		if blockNum != expectedNextBlockNum {
 			return fmt.Errorf("nonsequential block in bridge processing: %d != %d", blockNum, expectedNextBlockNum)
 		}


### PR DESCRIPTION
I am fixing this error:

```
[EROR] [06-27|13:28:09.522] background component error               err="pos sync failed: nonsequential block in bridge processing: 38189056 != 38189008"
```

 It happens because we have dynamic sprint length in mainnet network:
 ```
     "sprint": {
      "0": 64,
      "38189056": 16
    },
 ```
 
When we apply the sprint length to the prev processed block - yweu should apply sprint length which this block was produced for
