### PR TITLE
Fix release workflow dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,7 +289,7 @@ jobs:
     name: Debian packages
     needs: [ build-release, test-release ]
     if: always() && contains(needs.build-release.result, 'success') && !contains(needs.test-release.result, 'failure')
-    uses: erigontech/erigon/.github/workflows/reusable-release-build-debian-pkg.yml@main
+    uses: erigontech/erigon/.github/workflows/reusable-release-build-debian-pkg.yml@bcc599a26545492005a73ba870e0e3aea557653a
     with:
       application: ${{ needs.build-release.outputs.application }}
       version: ${{ needs.build-release.outputs.parsed-version }}


### PR DESCRIPTION
For debian packages use commit suitable for the workflow in the release/3.0 branch