### PR TITLE
fix for ReceiptsNoDupsRange 

### DIFF
--- a/eth/integrity/receipts_no_duplicates.go
+++ b/eth/integrity/receipts_no_duplicates.go
@@ -142,7 +142,7 @@ func ReceiptsNoDupsRange(ctx context.Context, fromBlock, toBlock uint64, tx kv.T
 	prevLogIdx := uint32(0)
 	prevBN := uint64(1)
 	for txNum := fromTxNum; txNum <= toTxNum; txNum++ {
-		cumUsedGas, _, logIdx, err := rawtemporaldb.ReceiptAsOf(tx, txNum)
+		cumUsedGas, _, logIdx, err := rawtemporaldb.ReceiptAsOf(tx, txNum+1)
 		if err != nil {
 			return err
 		}
@@ -157,7 +157,7 @@ func ReceiptsNoDupsRange(ctx context.Context, fromBlock, toBlock uint64, tx kv.T
 		_max, _ := txNumsReader.Max(tx, blockNum)
 
 		strongMonotonicCumGasUsed := int(cumUsedGas) > prevCumUsedGas
-		if !strongMonotonicCumGasUsed && cumUsedGas != 0 {
+		if !strongMonotonicCumGasUsed && txNum != _min && txNum != _max { // system tx can be skipped
 			err := fmt.Errorf("CheckReceiptsNoDups: non-monotonic cumGasUsed at txnum: %d, block: %d(%d-%d), cumGasUsed=%d, prevCumGasUsed=%d", txNum, blockNum, _min, _max, cumUsedGas, prevCumUsedGas)
 			if failFast {
 				return err


### PR DESCRIPTION
- use `txNum+1` in  `ReceiptAsOf` argument to get cumgas + logIdx for txNum.
- use `FindBlockNum` for faster ReceiptsNoDupsRange startup