### PR TITLE
rpcdaemon: use header instead of blockWithSenders() (debug_traceCall() debug_traceCallMany())

### DIFF
--- a/rpc/jsonrpc/tracing.go
+++ b/rpc/jsonrpc/tracing.go
@@ -483,7 +483,11 @@ func (api *DebugAPIImpl) TraceCallMany(ctx context.Context, bundles []Bundle, si
 		return err
 	}
 
-	header, err := api.headerByRPCNumber(ctx, rpc.BlockNumber(blockNum), tx)
+	var header *types.Header
+	header, err = api.headerByRPCNumber(ctx, rpc.BlockNumber(blockNum), tx)
+	if err != nil {
+		return err
+	}
 	if header == nil {
 		stream.WriteNil()
 		return fmt.Errorf("block %d(%x) not found", blockNum, hash)


### PR DESCRIPTION
This PR contains:
- align debug_traceCallMany() to debug_traceCall()
- avoid to load block with all txs and senders but only headers
-  debug_tarceCall use api that check before if the data are in the cache
