### PR TITLE
tests: disable non-compatible tests with race detector only when race mode is enabled

### DIFF
--- a/cmd/evm/t8n_test.go
+++ b/cmd/evm/t8n_test.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/erigontech/erigon-lib/common/race"
 	"github.com/erigontech/erigon/internal/reexec"
 	"github.com/erigontech/erigon/turbo/cmdtest"
 )
@@ -259,8 +260,8 @@ func TestEvmRun(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
-
-	if runtime.GOOS == "darwin" {
+	//goland:noinspection GoBoolExpressions
+	if race.Enabled && runtime.GOOS == "darwin" {
 		// We run race detector for medium tests which fails on macOS.
 		// This issue has already been reported for other tests.
 		// Important observation for further work on this: Only `statetest` test fails.

--- a/erigon-lib/common/race/race_disabled.go
+++ b/erigon-lib/common/race/race_disabled.go
@@ -1,0 +1,5 @@
+//go:build !race
+
+package race
+
+const Enabled = false

--- a/erigon-lib/common/race/race_enabled.go
+++ b/erigon-lib/common/race/race_enabled.go
@@ -1,0 +1,5 @@
+//go:build race
+
+package race
+
+const Enabled = true

--- a/tests/bor/mining_test.go
+++ b/tests/bor/mining_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/erigontech/erigon-lib/chain/params"
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/fdlimit"
+	"github.com/erigontech/erigon-lib/common/race"
 	"github.com/erigontech/erigon-lib/crypto"
 	"github.com/erigontech/erigon-lib/gointerfaces"
 	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
@@ -72,7 +73,8 @@ func TestMiningBenchmark(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	if runtime.GOOS == "darwin" {
+	//goland:noinspection GoBoolExpressions
+	if race.Enabled && runtime.GOOS == "darwin" {
 		// We run race detector for medium tests which fails on macOS.
 		t.Skip("issue #15007")
 	}

--- a/txnprovider/shutter/block_building_integration_test.go
+++ b/txnprovider/shutter/block_building_integration_test.go
@@ -37,6 +37,7 @@ import (
 	params2 "github.com/erigontech/erigon-lib/chain/params"
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/datadir"
+	"github.com/erigontech/erigon-lib/common/race"
 	"github.com/erigontech/erigon-lib/crypto"
 	"github.com/erigontech/erigon-lib/direct"
 	"github.com/erigontech/erigon-lib/kv"
@@ -65,7 +66,8 @@ func TestShutterBlockBuilding(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	if runtime.GOOS == "darwin" {
+	//goland:noinspection GoBoolExpressions
+	if race.Enabled && runtime.GOOS == "darwin" {
 		// We run race detector for medium tests which fails on macOS.
 		t.Skip("issue #15007")
 	}


### PR DESCRIPTION
follow up from previous PRs - only skip tests on macos that are non compatible with the race detector (due to issue: https://github.com/erigontech/erigon/issues/15007) when the race detector is enabled - this allows us to still run these tests (without having to uncomment the skip) locally on macos when not in race mode

before:
```
➜ go test -v -count 1 -run '^TestShutterBlockBuilding' ./txnprovider/shutter
=== RUN   TestShutterBlockBuilding
    block_building_integration_test.go:70: issue #15007
--- SKIP: TestShutterBlockBuilding (0.00s)
PASS
ok      github.com/erigontech/erigon/txnprovider/shutter        6.527s
```

after:
```
➜ go test -v -count 1 -run '^TestShutterBlockBuilding' ./txnprovider/shutter
=== RUN   TestShutterBlockBuilding/eon_1/build_shutter_block
=== NAME  TestShutterBlockBuilding
    eon_tracker.go:183: DBUG[06-30|17:12:49.750] current eon at block                     component=shutter blockNum=16 eonIndex=1
    request_generator.go:376: INFO[06-30|17:12:49.756] http://127.0.0.1:38526#eth_estimateGas   time=0.001
    decryption_keys_sender.go:147: DBUG[06-30|17:12:49.757] publishing decryption keys               component=decryption-key-sender slot=85903669 eon=1 txnPointer=5 keys=1
    block_building.go:103: INFO[06-30|17:12:49.758] [ForkChoiceUpdated] BlockBuilder added   payload=13
    kv_mdbx.go:399: DBUG[06-30|17:12:49.760] [db] open                                label=temporary sizeLimit=512GB pageSize=4KB
    sync.go:521: DBUG[06-30|17:12:49.761] [1/3 MiningCreateBlock] Starting Stage run 
    stage_mining_create_block.go:195: INFO[06-30|17:12:49.761] [1/3 MiningCreateBlock] Start mine       block=17 baseFee=115037312 gasLimit=10167293
    sync.go:538: DBUG[06-30|17:12:49.761] [1/3 MiningCreateBlock] DONE             in=79.833µs
    sync.go:521: DBUG[06-30|17:12:49.761] [2/3 MiningExecution] Starting Stage run 
    kv_mdbx.go:399: DBUG[06-30|17:12:49.762] [db] open                                label=temporary sizeLimit=512GB pageSize=4KB
    pool.go:204: DBUG[06-30|17:12:49.763] waiting for decryption keys              component=shutter slot=85903669 blockNum=17 eon=1 age=763.357ms timeout=902.643ms
    decryption_keys_processor.go:124: DBUG[06-30|17:12:49.763] processing decryption keys message       component=shutter instanceId=1234567890 eonIndex=1 slot=85903669 txnIndex=5 keys=1
    encrypted_txns_pool.go:94: DBUG[06-30|17:12:49.763] looking up encrypted txns for            component=shutter eon=1 from=5 to=5 gasLimit=63000
    pool.go:262: DBUG[06-30|17:12:49.763] providing decrypted txns                 component=shutter count=0 gas=0
    pool.go:801: DBUG[06-30|17:12:49.763] [txpool] Processing best request         last=16 txRequested=50 txAvailable=1 txProcessed=1 txReturned=1
    pool.go:274: DBUG[06-30|17:12:49.763] providing additional public txns         component=shutter count=1
    stage_mining_exec.go:414: INFO[06-30|17:12:49.763] Filtration                               initial=1 no sender=0 no account=0 nonce too low=0 nonceTooHigh=0 sender not EOA=0 fee too low=0 overflow=0 balance too low=0 bad chain id=0 filtered=1
    stage_mining_exec.go:181: DBUG[06-30|17:12:49.763] SpawnMiningExecStage                     block=17 txn=1 payload=13
    exec3.go:112: INFO[06-30|17:12:49.765] [2/3 MiningExecution] Done Commit every block blk=17 blks=2 blk/s=2047.9 txs=3 tx/s=3.07k gas/s=56.34M buf=9.5KB/0B stepsInDB=0.00 step=0.0 inMem=true alloc=119.2MB sys=228.7MB
    stage_mining_exec.go:246: INFO[06-30|17:12:49.765] FinalizeBlockExecution                   block=17 txn=1 gas=55025 receipt=1 payload=13
    sync.go:538: DBUG[06-30|17:12:49.777] [2/3 MiningExecution] DONE               in=15.912917ms
    sync.go:521: DBUG[06-30|17:12:49.777] [3/3 MiningFinish] Starting Stage run 
    stage_mining_finish.go:95: INFO[06-30|17:12:49.777] [3/3 MiningFinish] block ready for seal  block=17 transactions=1 gasUsed=55025 gasLimit=10167293 difficulty=0 header="&{ParentHash:0xa72310ac7ef6ecfab451677c3d276c40dd5a306c53afbed4ce268ab7eacccad8 UncleHash:0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347 Coinbase:0xB2690C27487a100ab0dB42927F6C674d0Dfb9A89 Root:0x097945290228db9552125dae9e3fab02900dcfe41eb61512ce8f7ac0cd84c284 TxHash:0x4243514d349768c93cb769962aa0cf0b6b462703d5d2d4db69962d7123d3346d ReceiptHash:0xbe1164206104f037caf1ab4a568e0ccd7d44038fa1e427eece209cd1d6c22111 Bloom:[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 128 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 4 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 32 0 0 0 0 8 0 0 0 0 0 0 0 0 0 0 0 0 0 64 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] Difficulty:+0 Number:+17 GasLimit:10167293 GasUsed:55025 Time:1751299969 Extra:[] MixDigest:0x0000000000000000000000000000000000000000000000000000000000000010 Nonce:[0 0 0 0 0 0 0 0] AuRaStep:0 AuRaSeal:[] BaseFee:+115037312 WithdrawalsHash:0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421 BlobGasUsed:0x44002e481c8 ExcessBlobGas:0x44002e481d0 ParentBeaconBlockRoot:0x0000000000000000000000000000000000000000000000000000000000002720 RequestsHash:0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 mutable:true hash:{_:[] _:{} v:<nil>}}"
    sync.go:538: DBUG[06-30|17:12:49.777] [3/3 MiningFinish] DONE                  in=184.958µs
    engine_api_methods.go:90: INFO[06-30|17:12:50.759] Received GetPayloadV4                    payloadId=13
    engine_server.go:498: DBUG[06-30|17:12:50.759] [GetPayload] acquiring lock 
    engine_server.go:501: DBUG[06-30|17:12:50.759] [GetPayload] lock acquired 
    engine_server.go:332: DBUG[06-30|17:12:50.759] [NewPayload] sending block               height=17 hash=0x9a35d312199baa0c53cac74c42a3fda0336b42569b609edaa42d30ceb4720234
    engine_server.go:754: INFO[06-30|17:12:50.759] [NewPayload] Handling new payload        height=17 hash=0x9a35d312199baa0c53cac74c42a3fda0336b42569b609edaa42d30ceb4720234
    engine_server.go:822: DBUG[06-30|17:12:50.760] [NewPayload] New payload begin verification 
    sync.go:172: DBUG[06-30|17:12:50.760] UnwindTo                                 block=16 stack="[sync.go:172 ethereum_execution.go:221 ethereum_execution.go:280 kv_temporal.go:154 ethereum_execution.go:279 execution_client.go:63 chain_reader.go:343 engine_server.go:823 engine_server.go:335 engine_api_methods.go:147 value.go:584 value.go:368 service.go:227 handler.go:530 handler.go:480 handler.go:421 handler.go:241 handler.go:334 asm_arm64.s:1223]"
    fork_validator.go:225: DBUG[06-30|17:12:50.760] Execution ForkValidator.ValidatePayload  foundCanonical=true currentHash=0xa72310ac7ef6ecfab451677c3d276c40dd5a306c53afbed4ce268ab7eacccad8 unwindPoint=16
    engine_server.go:824: DBUG[06-30|17:12:50.761] [NewPayload] New payload verification ended status=Success err=nil
    engine_server.go:345: DBUG[06-30|17:12:50.761] [NewPayload] got reply                   payloadStatus="&{Status:VALID ValidationError:<nil> LatestValidHash:0x9a35d312199baa0c53cac74c42a3fda0336b42569b609edaa42d30ceb4720234 CriticalError:<nil>}"
    engine_server.go:581: DBUG[06-30|17:12:50.762] [ForkChoiceUpdated] sending forkChoiceMessage head=0x9a35d312199baa0c53cac74c42a3fda0336b42569b609edaa42d30ceb4720234
    engine_server.go:881: DBUG[06-30|17:12:50.762] [ForkChoiceUpdated] Handling fork choice headerHash=0x9a35d312199baa0c53cac74c42a3fda0336b42569b609edaa42d30ceb4720234
    sync.go:172: DBUG[06-30|17:12:50.762] UnwindTo                                 block=16 stack="[sync.go:172 forkchoice.go:342 asm_arm64.s:1223]"
    forkchoice.go:435: DBUG[06-30|17:12:50.762] [updateForkchoice] Fork choice update: flushing in-memory state (built by previous newPayload) 
    sync.go:521: DBUG[06-30|17:12:50.762] [1/6 OtterSync] Starting Stage run 
    sync.go:538: DBUG[06-30|17:12:50.762] [1/6 OtterSync] DONE                     in=14.334µs
    sync.go:521: DBUG[06-30|17:12:50.762] [2/6 BlockHashes] Starting Stage run 
    sync.go:538: DBUG[06-30|17:12:50.762] [2/6 BlockHashes] DONE                   in=7.042µs
    sync.go:521: DBUG[06-30|17:12:50.762] [3/6 Senders] Starting Stage run 
    sync.go:538: DBUG[06-30|17:12:50.762] [3/6 Senders] DONE                       in=189.25µs
    sync.go:521: DBUG[06-30|17:12:50.762] [4/6 Execution] Starting Stage run 
    sync.go:538: DBUG[06-30|17:12:50.762] [4/6 Execution] DONE                     in=134.958µs
    sync.go:521: DBUG[06-30|17:12:50.762] [5/6 TxLookup] Starting Stage run 
    sync.go:538: DBUG[06-30|17:12:50.762] [5/6 TxLookup] DONE                      in=34.416µs
    sync.go:521: DBUG[06-30|17:12:50.762] [6/6 Finish] Starting Stage run 
    sync.go:538: DBUG[06-30|17:12:50.762] [6/6 Finish] DONE                        in=9.542µs
    stage_finish.go:160: DBUG[06-30|17:12:50.763] RPC Daemon notified of new headers       from=16 to=18 amount=1
    encrypted_txns_pool.go:216: DBUG[06-30|17:12:50.763] received encrypted txn submission event  component=shutter eonIndex=1 txnIndex=0 blockNum=17 unwind=false
    decryption_keys_processor.go:322: DBUG[06-30|17:12:50.763] cleaned up decrypted txns up to          component=shutter slot=85903669 decryptedMarkDeletions=1 decryptedTxnsDeletions=0
    block_tracker.go:86: DBUG[06-30|17:12:50.763] block tracker got block event            component=shutter blockNum=17
    forkchoice.go:565: INFO[06-30|17:12:50.763] head updated                             hash=0x9a35d312199baa0c53cac74c42a3fda0336b42569b609edaa42d30ceb4720234 number=17 txnum=72 age=1s execution=902.875µs mgas/s=53.69 average mgas/s=182.78 flushing=122.083µs commit=352.708µs alloc=123.6MB sys=228.7MB
    engine_server.go:595: DBUG[06-30|17:12:50.763] [ForkChoiceUpdated] got reply            payloadStatus="&{Status:VALID ValidationError:<nil> LatestValidHash:0x9a35d312199baa0c53cac74c42a3fda0336b42569b609edaa42d30ceb4720234 CriticalError:<nil>}"
    pool.go:1928: DBUG[06-30|17:12:50.763] Discarded transactions                   count=1 pending=1 baseFee=0 queued=0
    pool.go:369: DBUG[06-30|17:12:50.763] [txpool] New block                       block=17 unwound=0 mined=1 blockBaseFee=100813293 pending-pre=1 pending=0 baseFee=0 queued=0 err=nil
    decryption_keys_sender.go:147: DBUG[06-30|17:12:50.765] publishing decryption keys               component=decryption-key-sender slot=85903670 eon=1 txnPointer=5 keys=2
    block_building.go:103: INFO[06-30|17:12:50.766] [ForkChoiceUpdated] BlockBuilder added   payload=14
    kv_mdbx.go:399: DBUG[06-30|17:12:50.767] [db] open                                label=temporary sizeLimit=512GB pageSize=4KB
    sync.go:521: DBUG[06-30|17:12:50.768] [1/3 MiningCreateBlock] Starting Stage run 
    stage_mining_create_block.go:195: INFO[06-30|17:12:50.768] [1/3 MiningCreateBlock] Start mine       block=18 baseFee=100813293 gasLimit=10177220
    sync.go:538: DBUG[06-30|17:12:50.768] [1/3 MiningCreateBlock] DONE             in=61.708µs
    sync.go:521: DBUG[06-30|17:12:50.768] [2/3 MiningExecution] Starting Stage run 
    kv_mdbx.go:399: DBUG[06-30|17:12:50.769] [db] open                                label=temporary sizeLimit=512GB pageSize=4KB
    pool.go:204: DBUG[06-30|17:12:50.769] waiting for decryption keys              component=shutter slot=85903670 blockNum=18 eon=1 age=769.66ms timeout=896.34ms
    decryption_keys_processor.go:124: DBUG[06-30|17:12:50.772] processing decryption keys message       component=shutter instanceId=1234567890 eonIndex=1 slot=85903670 txnIndex=5 keys=2
    encrypted_txns_pool.go:94: DBUG[06-30|17:12:50.772] looking up encrypted txns for            component=shutter eon=1 from=5 to=6 gasLimit=63000
    pool.go:262: DBUG[06-30|17:12:50.772] providing decrypted txns                 component=shutter count=0 gas=0
    pool.go:801: DBUG[06-30|17:12:50.772] [txpool] Processing best request         last=17 txRequested=50 txAvailable=0 txProcessed=0 txReturned=0
    pool.go:274: DBUG[06-30|17:12:50.772] providing additional public txns         component=shutter count=0
    stage_mining_exec.go:414: INFO[06-30|17:12:50.772] Filtration                               initial=0 no sender=0 no account=0 nonce too low=0 nonceTooHigh=0 sender not EOA=0 fee too low=0 overflow=0 balance too low=0 bad chain id=0 filtered=0
    stage_mining_exec.go:181: DBUG[06-30|17:12:50.772] SpawnMiningExecStage                     block=18 txn=0 payload=14
    exec3.go:112: INFO[06-30|17:12:50.773] [2/3 MiningExecution] Done Commit every block blk=18 blks=2 blk/s=5677.8 txs=2 tx/s=5.67k gas/s=0 buf=0B/0B stepsInDB=0.00 step=0.0 inMem=true alloc=126.4MB sys=228.7MB
    stage_mining_exec.go:246: INFO[06-30|17:12:50.773] FinalizeBlockExecution                   block=18 txn=0 gas=0 receipt=0 payload=14
    sync.go:538: DBUG[06-30|17:12:50.784] [2/3 MiningExecution] DONE               in=15.915666ms
    sync.go:521: DBUG[06-30|17:12:50.784] [3/3 MiningFinish] Starting Stage run 
    sync.go:538: DBUG[06-30|17:12:50.784] [3/3 MiningFinish] DONE                  in=20.458µs
    engine_api_methods.go:90: INFO[06-30|17:12:51.766] Received GetPayloadV4                    payloadId=14
    engine_server.go:498: DBUG[06-30|17:12:51.766] [GetPayload] acquiring lock 
    engine_server.go:501: DBUG[06-30|17:12:51.766] [GetPayload] lock acquired 
    engine_server.go:332: DBUG[06-30|17:12:51.767] [NewPayload] sending block               height=18 hash=0x98022ad543fcf916a81323c1f2cfb8f1f9493328b2fbafb81b7c4f197a72432c
    engine_server.go:754: INFO[06-30|17:12:51.767] [NewPayload] Handling new payload        height=18 hash=0x98022ad543fcf916a81323c1f2cfb8f1f9493328b2fbafb81b7c4f197a72432c
    engine_server.go:822: DBUG[06-30|17:12:51.767] [NewPayload] New payload begin verification 
    sync.go:172: DBUG[06-30|17:12:51.767] UnwindTo                                 block=17 stack="[sync.go:172 ethereum_execution.go:221 ethereum_execution.go:280 kv_temporal.go:154 ethereum_execution.go:279 execution_client.go:63 chain_reader.go:343 engine_server.go:823 engine_server.go:335 engine_api_methods.go:147 value.go:584 value.go:368 service.go:227 handler.go:530 handler.go:480 handler.go:421 handler.go:241 handler.go:334 asm_arm64.s:1223]"
    fork_validator.go:225: DBUG[06-30|17:12:51.767] Execution ForkValidator.ValidatePayload  foundCanonical=true currentHash=0x9a35d312199baa0c53cac74c42a3fda0336b42569b609edaa42d30ceb4720234 unwindPoint=17
    engine_server.go:824: DBUG[06-30|17:12:51.768] [NewPayload] New payload verification ended status=Success err=nil
    engine_server.go:345: DBUG[06-30|17:12:51.768] [NewPayload] got reply                   payloadStatus="&{Status:VALID ValidationError:<nil> LatestValidHash:0x98022ad543fcf916a81323c1f2cfb8f1f9493328b2fbafb81b7c4f197a72432c CriticalError:<nil>}"
    engine_server.go:581: DBUG[06-30|17:12:51.769] [ForkChoiceUpdated] sending forkChoiceMessage head=0x98022ad543fcf916a81323c1f2cfb8f1f9493328b2fbafb81b7c4f197a72432c
    engine_server.go:881: DBUG[06-30|17:12:51.769] [ForkChoiceUpdated] Handling fork choice headerHash=0x98022ad543fcf916a81323c1f2cfb8f1f9493328b2fbafb81b7c4f197a72432c
    sync.go:172: DBUG[06-30|17:12:51.769] UnwindTo                                 block=17 stack="[sync.go:172 forkchoice.go:342 asm_arm64.s:1223]"
    forkchoice.go:435: DBUG[06-30|17:12:51.769] [updateForkchoice] Fork choice update: flushing in-memory state (built by previous newPayload) 
    sync.go:521: DBUG[06-30|17:12:51.769] [1/6 OtterSync] Starting Stage run 
    sync.go:538: DBUG[06-30|17:12:51.769] [1/6 OtterSync] DONE                     in=13.625µs
    sync.go:521: DBUG[06-30|17:12:51.769] [2/6 BlockHashes] Starting Stage run 
    sync.go:538: DBUG[06-30|17:12:51.769] [2/6 BlockHashes] DONE                   in=8.375µs
    sync.go:521: DBUG[06-30|17:12:51.769] [3/6 Senders] Starting Stage run 
    sync.go:538: DBUG[06-30|17:12:51.769] [3/6 Senders] DONE                       in=144.583µs
    sync.go:521: DBUG[06-30|17:12:51.769] [4/6 Execution] Starting Stage run 
    exec3.go:112: INFO[06-30|17:12:51.770] [4/6 Execution] Done Commit every block  blk=18 blks=2 blk/s=5166.8 txs=2 tx/s=5.16k gas/s=0 buf=0B/0B stepsInDB=0.00 step=0.0 inMem=false alloc=130.6MB sys=228.7MB
    sync.go:538: DBUG[06-30|17:12:51.770] [4/6 Execution] DONE                     in=559µs
    sync.go:521: DBUG[06-30|17:12:51.770] [5/6 TxLookup] Starting Stage run 
    sync.go:538: DBUG[06-30|17:12:51.770] [5/6 TxLookup] DONE                      in=23.833µs
    sync.go:521: DBUG[06-30|17:12:51.770] [6/6 Finish] Starting Stage run 
    sync.go:538: DBUG[06-30|17:12:51.770] [6/6 Finish] DONE                        in=12.417µs
    stage_finish.go:160: DBUG[06-30|17:12:51.770] RPC Daemon notified of new headers       from=17 to=19 amount=1
    pool.go:369: DBUG[06-30|17:12:51.770] [txpool] New block                       block=18 unwound=0 mined=0 blockBaseFee=88211632 pending-pre=0 pending=0 baseFee=0 queued=0 err=nil
    block_tracker.go:86: DBUG[06-30|17:12:51.770] block tracker got block event            component=shutter blockNum=18
    forkchoice.go:565: INFO[06-30|17:12:51.771] head updated                             hash=0x98022ad543fcf916a81323c1f2cfb8f1f9493328b2fbafb81b7c4f197a72432c number=18 txnum=74 age=1s execution=613.709µs mgas/s=0.00 average mgas/s=181.57 flushing=79.917µs commit=347.333µs alloc=130.6MB sys=228.7MB
    engine_server.go:595: DBUG[06-30|17:12:51.771] [ForkChoiceUpdated] got reply            payloadStatus="&{Status:VALID ValidationError:<nil> LatestValidHash:0x98022ad543fcf916a81323c1f2cfb8f1f9493328b2fbafb81b7c4f197a72432c CriticalError:<nil>}"
    decryption_keys_processor.go:322: DBUG[06-30|17:12:51.771] cleaned up decrypted txns up to          component=shutter slot=85903670 decryptedMarkDeletions=1 decryptedTxnsDeletions=0
    block_listener.go:82: INFO[06-30|17:12:51.771] block listener stopped                   component=shutter
    config.go:906: INFO[06-30|17:12:51.771] Exiting Engine... 
    server.go:155: INFO[06-30|17:12:51.771] RPC server shutting down 
    server.go:155: INFO[06-30|17:12:51.771] RPC server shutting down 
    config.go:902: INFO[06-30|17:12:51.771] Engine HTTP endpoint close               url=127.0.0.1:38525
    config.go:870: INFO[06-30|17:12:51.771] [rpc] Exiting... 
    config.go:804: INFO[06-30|17:12:51.771] HTTP endpoint closed                     url=127.0.0.1:38526
    server.go:155: INFO[06-30|17:12:51.771] RPC server shutting down 
    filters.go:274: DBUG[06-30|17:12:51.771] rpcdaemon: the subscription to pending blocks channel was closed 
    block_tracker.go:84: INFO[06-30|17:12:51.771] block tracker stopped                    component=shutter
    encrypted_txns_pool.go:86: INFO[06-30|17:12:51.771] encrypted txns pool stopped              component=shutter
    decryption_keys_processor.go:103: INFO[06-30|17:12:51.772] decryption keys processor stopped        component=shutter
    eon_tracker.go:104: INFO[06-30|17:12:51.772] eon tracker stopped                      component=shutter
    decryption_keys_listener.go:112: INFO[06-30|17:12:51.791] decryption keys listener stopped         component=shutter
    pool.go:152: INFO[06-30|17:12:51.791] pool stopped                             component=shutter
    backend.go:1716: INFO[06-30|17:12:51.792] [shutter] pool goroutine terminated 
    pool.go:2201: INFO[06-30|17:12:51.797] [txpool] stopped 
    backend.go:1705: INFO[06-30|17:12:51.797] [devp2p] txn pool goroutine terminated 
--- PASS: TestShutterBlockBuilding (18.91s)
    --- PASS: TestShutterBlockBuilding/eon_0 (4.08s)
        --- PASS: TestShutterBlockBuilding/eon_0/build_shutter_block (2.02s)
        --- PASS: TestShutterBlockBuilding/eon_0/build_shutter_block_without_breaching_encrypted_gas_limit (2.06s)
        --- PASS: TestShutterBlockBuilding/eon_0/build_shutter_block_without_blob_txns (0.00s)
    --- PASS: TestShutterBlockBuilding/eon_1 (6.22s)
        --- PASS: TestShutterBlockBuilding/eon_1/build_shutter_block (2.02s)
PASS
ok      github.com/erigontech/erigon/txnprovider/shutter        22.234s
```