### PR TITLE
EthGetLogsInvariants: wait for pending work

### DIFF
--- a/cmd/rpctest/rpctest/bench_ethgetlogs.go
+++ b/cmd/rpctest/rpctest/bench_ethgetlogs.go
@@ -282,7 +282,7 @@ func EthGetLogsInvariants(ctx context.Context, erigonURL, gethURL string, needCo
 			return nil
 		})
 
-		if bn%1000 == 0 {
+		if bn%1000 == 0 || bn == blockTo-1 {
 			if err := eg.Wait(); err != nil {
 				return err
 			}

--- a/eth/integrity/receipts_no_duplicates.go
+++ b/eth/integrity/receipts_no_duplicates.go
@@ -166,7 +166,7 @@ func ReceiptsNoDupsRange(ctx context.Context, fromBlock, toBlock uint64, tx kv.T
 		}
 
 		monotonicLogIdx := logIdx >= prevLogIdx
-		if !monotonicLogIdx {
+		if !monotonicLogIdx && txNum != _min && txNum != _max {
 			err := fmt.Errorf("CheckReceiptsNoDups: non-monotonic logIndex at txnum: %d, block: %d(%d-%d), logIdx=%d, prevLogIdx=%d", txNum, blockNum, _min, _max, logIdx, prevLogIdx)
 			if failFast {
 				return err

--- a/execution/stagedsync/stage_custom_trace.go
+++ b/execution/stagedsync/stage_custom_trace.go
@@ -417,7 +417,7 @@ func customTraceBatch(ctx context.Context, produce Produce, cfg *exec3.ExecArgs,
 				if prevTxNumLog > 0 {
 					dbg.ReadMemStats(&m)
 					txsPerSec := (txTask.TxNum - prevTxNumLog) / uint64(logPeriod.Seconds())
-					log.Info(fmt.Sprintf("[%s] Scanned", logPrefix), "block", fmt.Sprintf("%.1fm", float64(txTask.BlockNum)/1_000_000), "tx/s", fmt.Sprintf("%dK", txsPerSec/1_000), "alloc", common.ByteCount(m.Alloc), "sys", common.ByteCount(m.Sys))
+					log.Info(fmt.Sprintf("[%s] Scanned", logPrefix), "block", fmt.Sprintf("%.3fm", float64(txTask.BlockNum)/1_000_000), "tx/s", fmt.Sprintf("%.1fK", float64(txsPerSec)/1_000.0), "alloc", common.ByteCount(m.Alloc), "sys", common.ByteCount(m.Sys))
 				}
 				prevTxNumLog = txTask.TxNum
 			default:


### PR DESCRIPTION
also, don't check `logIdx` in `ReceiptsNoDupsRange`; since final systemTx has logindex=0.