### PR TITLE
params: move bhilai fork to bor config

### DIFF
--- a/p2p/forkid/forkid_test.go
+++ b/p2p/forkid/forkid_test.go
@@ -190,7 +190,7 @@ func TestCreation(t *testing.T) {
 				{14750000, 0, ID{Hash: ChecksumToBytes(0x66e26adb), Next: 23850000}}, // First Berlin block
 				{23850000, 0, ID{Hash: ChecksumToBytes(0x4f2f71cc), Next: 50523000}}, // First London block
 				{50523000, 0, ID{Hash: ChecksumToBytes(0xdc08865c), Next: 54876000}}, // First Agra block
-				{54876000, 0, ID{Hash: ChecksumToBytes(0xf097bc13), Next: 0}},        // First Napoli block
+				{54876000, 0, ID{Hash: ChecksumToBytes(0xf097bc13), Next: 73440256}}, // First Napoli block
 			},
 		},
 	}

--- a/params/chainspecs/bor-mainnet.json
+++ b/params/chainspecs/bor-mainnet.json
@@ -12,7 +12,6 @@
   "muirGlacierBlock": 3395000,
   "berlinBlock": 14750000,
   "londonBlock": 23850000,
-  "bhilaiBlock": 73440256,
   "burntContract": {
     "23850000": "0x70bca57f4579f58670ab2d18ef16e02c17553c38",
     "50523000": "0x7A8ed27F4C30512326878652d20fC85727401854"
@@ -81,6 +80,7 @@
     "indoreBlock": 44934656,
     "agraBlock": 50523000,
     "napoliBlock": 54876000,
-    "ahmedabadBlock": 62278656
+    "ahmedabadBlock": 62278656,
+    "bhilaiBlock": 73440256
   }
 }


### PR DESCRIPTION
Move the `bhilaiBlock` to bor config instead of global in polygon mainnet genesis. 