### PR TITLE
[r3.0] Big Beautiful Speedup (integrity ReceiptsNoDups) cp

### DIFF
--- a/eth/integrity/receipts_no_duplicates.go
+++ b/eth/integrity/receipts_no_duplicates.go
@@ -156,8 +156,6 @@ func ReceiptsNoDupsRange(ctx context.Context, fromBlock, toBlock uint64, tx kv.T
 			prevLogIdx = 0
 		}
 
-		_max, _ = txNumsReader.Max(tx, blockNum)
-
 		strongMonotonicCumGasUsed := int(cumUsedGas) > prevCumUsedGas
 		if !strongMonotonicCumGasUsed && txNum != _min && txNum != _max { // system tx can be skipped
 			err := fmt.Errorf("CheckReceiptsNoDups: non-monotonic cumGasUsed at txnum: %d, block: %d(%d-%d), cumGasUsed=%d, prevCumGasUsed=%d", txNum, blockNum, _min, _max, cumUsedGas, prevCumUsedGas)


### PR DESCRIPTION
On sepolia's staging (`main`) integrity ReceiptsNoDups:
```
INFO[07-01|09:30:23.641] [integrity] ReceiptsNoDups starting      fromBlock=1 toBlock=8668050
INFO[07-01|10:21:49.795] [integrity] ReceiptsNoDups: done         err=nil
```
50 mins

on this branch the same:

```
INFO[07-01|13:04:02.623] [integrity] ReceiptsNoDups starting      fromBlock=1 toBlock=8669114
INFO[07-01|13:07:06.487] [integrity] ReceiptsNoDups: done         err=nil
```
3 mins)

Co-authored-by: JkLondon <ilya@mikheev.fun>

(cherry picked from commit a7697bde824b430a8e6e9f2694c6ede52d3276ec)