### PR TITLE
Pull finishing webseed tweaks from anacrolix/torrent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/RoaringBitmap/roaring/v2 v2.5.0
 	github.com/alecthomas/kong v0.8.1
-	github.com/anacrolix/torrent v1.58.2-0.20250626125107-30f608beaf92
+	github.com/anacrolix/torrent v1.58.2-0.20250702075317-e83774fb4604
 	github.com/c2h5oh/datasize v0.0.0-20231215233829-aa82cc1e6500
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/consensys/gnark-crypto v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/anacrolix/sync v0.5.4/go.mod h1:21cUWerw9eiu/3T3kyoChu37AVO+YFue1/H15
 github.com/anacrolix/tagflag v0.0.0-20180109131632-2146c8d41bf0/go.mod h1:1m2U/K6ZT+JZG0+bdMK6qauP49QT4wE5pmhJXOKKCHw=
 github.com/anacrolix/tagflag v1.0.0/go.mod h1:1m2U/K6ZT+JZG0+bdMK6qauP49QT4wE5pmhJXOKKCHw=
 github.com/anacrolix/tagflag v1.1.0/go.mod h1:Scxs9CV10NQatSmbyjqmqmeQNwGzlNe0CMUMIxqHIG8=
-github.com/anacrolix/torrent v1.58.2-0.20250626125107-30f608beaf92 h1:AkK9sfdNtxd8QR97dIB3mcEvsV0SYHi0lFruvuGJTPE=
-github.com/anacrolix/torrent v1.58.2-0.20250626125107-30f608beaf92/go.mod h1:sQtehNz7aQ4x6pNtgKO0TtIQ82oOrzoAdgSp2jvzeow=
+github.com/anacrolix/torrent v1.58.2-0.20250702075317-e83774fb4604 h1:Rm5zFQTyiB8xNo7FDrkTVtQUT1pvmx20w9k6JuKfh1E=
+github.com/anacrolix/torrent v1.58.2-0.20250702075317-e83774fb4604/go.mod h1:sQtehNz7aQ4x6pNtgKO0TtIQ82oOrzoAdgSp2jvzeow=
 github.com/anacrolix/upnp v0.1.4 h1:+2t2KA6QOhm/49zeNyeVwDu1ZYS9dB9wfxyVvh/wk7U=
 github.com/anacrolix/upnp v0.1.4/go.mod h1:Qyhbqo69gwNWvEk1xNTXsS5j7hMHef9hdr984+9fIic=
 github.com/anacrolix/utp v0.1.0 h1:FOpQOmIwYsnENnz7tAGohA+r6iXpRjrq8ssKSre2Cp4=


### PR DESCRIPTION
This finishes out the pending tasks in https://github.com/erigontech/erigon/pull/15765.

> This moves performance from ~5-10MB/s up past the old limit of ~100-125MB/s to ~350+MB/s in my testing.

Performance remains high, it bounces between 200 and 450 MB/s in testing.

> In particular it's slow to finish up small files as it does requests on a timer.

Fixed.

> I haven't tested how it reacts to bad snapshots yet.

Still true.

> I haven't prune the boundaries of request extents to avoid a small amount of waste.

It now trims dirty chunks (already downloaded but not hashed) at the start of requests. Well tested.

> Webseed requests don't terminate early to avoid unnecessary downloads, they should just error out and then pick something else.

Requests are cancelled if it doesn't need the next chunks at the webseed response read head. This is fairly well tested, it regularly happens when regular BitTorrent peers step in and start uploading to us.

> This PR also doubles as a check that CI passes.

Also true.