### PR TITLE
Removed milestones from snapshots scheme and and added pruning for milestones on start

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -629,6 +629,15 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 				EventFetcher: heimdallClient,
 			})
 
+			if err := heimdallStore.Milestones().Prepare(ctx); err != nil {
+				return nil, err
+			}
+
+			_, err := heimdallStore.Milestones().DeleteFromBlockNum(ctx, 0)
+			if err != nil {
+				return nil, err
+			}
+
 			heimdallService = heimdall.NewService(heimdall.ServiceConfig{
 				Store:     heimdallStore,
 				BorConfig: borConfig,

--- a/polygon/bor/bordb/prune.go
+++ b/polygon/bor/bordb/prune.go
@@ -121,13 +121,13 @@ func UnwindHeimdall(ctx context.Context, heimdallStore heimdall.Store, bridgeSto
 		}
 	}
 
-	if heimdall.CheckpointsEnabled() && !unwindCfg.KeepCheckpoints {
+	if heimdall.WaypointsEnabled() && !unwindCfg.KeepCheckpoints {
 		if err := UnwindCheckpoints(ctx, heimdallStore, tx, unwindPoint); err != nil {
 			return err
 		}
 	}
 
-	if heimdall.MilestonesEnabled() && !unwindCfg.KeepMilestones {
+	if heimdall.WaypointsEnabled() && !unwindCfg.KeepMilestones {
 		if err := UnwindMilestones(ctx, heimdallStore, tx, unwindPoint); err != nil {
 			return err
 		}
@@ -220,7 +220,7 @@ func PruneHeimdall(ctx context.Context, heimdallStore heimdall.Store, bridgeStor
 		return deleted, err
 	}
 
-	if heimdall.CheckpointsEnabled() {
+	if heimdall.WaypointsEnabled() {
 		checkpointStore := heimdallStore.Checkpoints()
 
 		if tx != nil {
@@ -240,7 +240,7 @@ func PruneHeimdall(ctx context.Context, heimdallStore heimdall.Store, bridgeStor
 		}
 	}
 
-	if heimdall.MilestonesEnabled() {
+	if heimdall.WaypointsEnabled() {
 		milestoneStore := heimdallStore.Milestones()
 
 		if tx != nil {

--- a/polygon/heimdall/entity_store.go
+++ b/polygon/heimdall/entity_store.go
@@ -473,7 +473,7 @@ func (s txEntityStore[TEntity]) DeleteFromBlockNum(ctx context.Context, unwindPo
 	}
 
 	defer cursor.Close()
-	lastEntityToKeep, ok, err := s.EntityIdFromBlockNum(ctx, unwindPoint)
+	firstEntityToDelete, ok, err := s.EntityIdFromBlockNum(ctx, unwindPoint+1)
 	if err != nil {
 		return 0, err
 	}
@@ -482,7 +482,7 @@ func (s txEntityStore[TEntity]) DeleteFromBlockNum(ctx context.Context, unwindPo
 		return 0, nil
 	}
 
-	var entityKey = entityStoreKey(lastEntityToKeep + 1)
+	var entityKey = entityStoreKey(firstEntityToDelete)
 	var k []byte
 	var deleted int
 	for k, _, err = cursor.Seek(entityKey[:]); err == nil && k != nil; k, _, err = cursor.Next() {

--- a/polygon/heimdall/snapshot_store.go
+++ b/polygon/heimdall/snapshot_store.go
@@ -23,7 +23,7 @@ func NewSnapshotStore(base Store, snapshots *RoSnapshots) *SnapshotStore {
 	return &SnapshotStore{
 		Store:                       base,
 		checkpoints:                 NewCheckpointSnapshotStore(base.Checkpoints(), snapshots),
-		milestones:                  NewMilestoneSnapshotStore(base.Milestones(), snapshots),
+		milestones:                  base.Milestones(),
 		spans:                       NewSpanSnapshotStore(base.Spans(), snapshots),
 		spanBlockProducerSelections: base.SpanBlockProducerSelections(),
 	}

--- a/polygon/heimdall/types.go
+++ b/polygon/heimdall/types.go
@@ -425,25 +425,15 @@ func RecordWayPoints(value bool) {
 
 func SnapshotTypes() []snaptype.Type {
 	if recordWaypoints {
-		return []snaptype.Type{Events, Spans, Checkpoints, Milestones}
+		return []snaptype.Type{Events, Spans, Checkpoints}
 	}
 
 	return []snaptype.Type{Events, Spans}
 }
 
-func CheckpointsEnabled() bool {
+func WaypointsEnabled() bool {
 	for _, snapType := range SnapshotTypes() {
 		if snapType.Enum() == Checkpoints.Enum() {
-			return true
-		}
-	}
-
-	return false
-}
-
-func MilestonesEnabled() bool {
-	for _, snapType := range SnapshotTypes() {
-		if snapType.Enum() == Milestones.Enum() {
 			return true
 		}
 	}


### PR DESCRIPTION
Heimdall V2 upgrade resets milestone ID counter, which means we can not use anymore IDs for milestones before the upgrade. It also breaks our assumptions about the sequence of milestone IDs, which leads to performance issues (since we can not finalise the blocks and keep them much longer in memory).

This PR fixes the issue described above.