### PR TITLE
txnprovider/shutter: fix flaky integration test failure due to jwt secret creation race

### DIFF
--- a/txnprovider/shutter/block_building_integration_test.go
+++ b/txnprovider/shutter/block_building_integration_test.go
@@ -366,6 +366,9 @@ func initBlockBuildingUniverse(ctx context.Context, t *testing.T) blockBuildingU
 	require.NoError(t, err)
 	chainDB.Close()
 
+	// note we need to create jwt secret before calling ethBackend.Init to avoid race conditions
+	jwtSecret, err := cli.ObtainJWTSecret(&httpConfig, logger)
+	require.NoError(t, err)
 	ethBackend, err := eth.New(ctx, ethNode, &ethConfig, logger, nil)
 	require.NoError(t, err)
 	err = ethBackend.Init(ethNode, &ethConfig, &chainConfig)
@@ -376,8 +379,6 @@ func initBlockBuildingUniverse(ctx context.Context, t *testing.T) blockBuildingU
 	rpcDaemonHttpUrl := fmt.Sprintf("%s:%d", httpConfig.HttpListenAddress, httpConfig.HttpPort)
 	rpcApiClient := requests.NewRequestGenerator(rpcDaemonHttpUrl, logger)
 	contractBackend := contracts.NewJsonRpcBackend(rpcDaemonHttpUrl, logger)
-	jwtSecret, err := cli.ObtainJWTSecret(&httpConfig, logger)
-	require.NoError(t, err)
 	//goland:noinspection HttpUrlsUsage
 	engineApiUrl := fmt.Sprintf("http://%s:%d", httpConfig.AuthRpcHTTPListenAddress, httpConfig.AuthRpcPort)
 	engineApiClient, err := engineapi.DialJsonRpcClient(


### PR DESCRIPTION
closes: https://github.com/erigontech/erigon/issues/15775

Flake example run after panic was fixed in a previous PR https://github.com/erigontech/erigon/pull/15792: https://github.com/erigontech/erigon/actions/runs/16028665192/job/45223206733

We can see the jwt file gets created twice (2 logs of `Generated JWT secret`) when it should be created once. The creations intertwine causing a `403 forbidden: invalid signature` because the client used a different signature than the server

```
   config.go:920: INFO[07-02|15:17:50.246] Reading JWT secret                       path=C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\TestShutterBlockBuilding3518186740\\001/jwt.hex
[WARN] [07-02|15:17:50.247] Sanitizing invalid HTTP read timeout     provided=0s updated=30s
[WARN] [07-02|15:17:50.247] Sanitizing invalid HTTP write timeout    provided=0s updated=30m0s
[WARN] [07-02|15:17:50.247] Sanitizing invalid HTTP idle timeout     provided=0s updated=2m0s
    config.go:868: INFO[07-02|15:17:50.247] [rpc] endpoint opened                    grpc=false http=true ws=false http.url=127.0.0.1:38526 http.compression=false
    config.go:920: INFO[07-02|15:17:50.265] Reading JWT secret                       path=C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\TestShutterBlockBuilding3518186740\\001/jwt.hex
    sync.go:521: DBUG[07-02|15:17:50.266] [1/6 OtterSync] Starting Stage run 
    pool.go:323: INFO[07-02|15:17:50.267] [txpool] Started 
    config.go:940: INFO[07-02|15:17:50.323] Generated JWT secret                     path=C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\TestShutterBlockBuilding3518186740\\001/jwt.hex
[WARN] [07-02|15:17:50.323] Sanitizing invalid HTTP read timeout     provided=0s updated=30s
[WARN] [07-02|15:17:50.323] Sanitizing invalid HTTP write timeout    provided=0s updated=30m0s
[WARN] [07-02|15:17:50.323] Sanitizing invalid HTTP idle timeout     provided=0s updated=2m0s
    config.go:1002: INFO[07-02|15:17:50.323] HTTP endpoint opened for Engine API      url=127.0.0.1:38525
    config.go:940: INFO[07-02|15:17:50.327] Generated JWT secret                     path=C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\TestShutterBlockBuilding3518186740\\001/jwt.hex
```