### PR TITLE
Updated ETL framework documentation link in README.md

### DIFF
--- a/erigon-lib/etl/README.md
+++ b/erigon-lib/etl/README.md
@@ -1,5 +1,5 @@
 # ETL
-ETL framework is most commonly used in [staged sync](https://github.com/erigontech/erigon/blob/main/eth/stagedsync/README.md).
+ETL framework is most commonly used in [staged sync](https://github.com/erigontech/erigon/blob/main/execution/stagedsync/README.md).
 
 It implements a pattern where we extract some data from a database, transform it,
 then put it into temp files and insert back to the database in sorted order.


### PR DESCRIPTION

Old link pointed to incorrect path: /eth/stagedsync/
New link points to correct path: /execution/stagedsync/

The change ensures developers are directed to the right documentation.
