### PR TITLE
db.pageSize: 16kb

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -747,7 +747,7 @@ var (
 	DbPageSizeFlag = cli.StringFlag{
 		Name:  "db.pagesize",
 		Usage: "DB is splitted to 'pages' of fixed size. Can't change DB creation. Must be power of 2 and '256b <= pagesize <= 64kb'. Default: equal to OperationSystem's pageSize. Bigger pageSize causing: 1. More writes to disk during commit 2. Smaller b-tree high 3. Less fragmentation 4. Less overhead on 'free-pages list' maintainance (a bit faster Put/Commit) 5. If expecting DB-size > 8Tb then set pageSize >= 8Kb",
-		Value: "4KB",
+		Value: "16KB",
 	}
 	DbSizeLimitFlag = cli.StringFlag{
 		Name:  "db.size.limit",


### PR DESCRIPTION
Reason: eth defaults are growing - code 200Kb, txn 500kb. To avoid problems with FreeList increasing pagesize. 
