### PR TITLE
execution/stagedsync: add debug timing logs to exec prune steps

### DIFF
--- a/execution/stagedsync/stage_execute.go
+++ b/execution/stagedsync/stage_execute.go
@@ -424,15 +424,17 @@ func PruneExecutionStage(s *PruneState, tx kv.RwTx, cfg ExecuteBlockCfg, ctx con
 		}
 		defer tx.Rollback()
 	}
+	quickPruneTimeout := 250 * time.Millisecond
 	if s.ForwardProgress > uint64(dbg.MaxReorgDepth) && !cfg.syncCfg.AlwaysGenerateChangesets {
 		// (chunkLen is 8Kb) * (1_000 chunks) = 8mb
 		// Some blocks on bor-mainnet have 400 chunks of diff = 3mb
 		var pruneDiffsLimitOnChainTip = 1_000
-		pruneTimeout := 250 * time.Millisecond
+		pruneTimeout := quickPruneTimeout
 		if s.CurrentSyncCycle.IsInitialCycle {
 			pruneDiffsLimitOnChainTip = math.MaxInt
 			pruneTimeout = time.Hour
 		}
+		pruneChangeSetsStartTime := time.Now()
 		if err := rawdb.PruneTable(
 			tx,
 			kv.ChangeSets3,
@@ -444,6 +446,14 @@ func PruneExecutionStage(s *PruneState, tx kv.RwTx, cfg ExecuteBlockCfg, ctx con
 			s.LogPrefix(),
 		); err != nil {
 			return err
+		}
+		if duration := time.Since(pruneChangeSetsStartTime); duration > quickPruneTimeout {
+			logger.Debug(
+				fmt.Sprintf("[%s] prune changesets timing", s.LogPrefix()),
+				"duration", duration,
+				"initialCycle", s.CurrentSyncCycle.IsInitialCycle,
+				"externalTx", useExternalTx,
+			)
 		}
 	}
 
@@ -457,18 +467,36 @@ func PruneExecutionStage(s *PruneState, tx kv.RwTx, cfg ExecuteBlockCfg, ctx con
 	//  - stop prune when `tx.SpaceDirty()` is big
 	//  - and set ~500ms timeout
 	// because on slow disks - prune is slower. but for now - let's tune for nvme first, and add `tx.SpaceDirty()` check later https://github.com/erigontech/erigon/issues/11635
-	pruneTimeout := 250 * time.Millisecond
+	pruneTimeout := quickPruneTimeout
 	if s.CurrentSyncCycle.IsInitialCycle {
 		pruneTimeout = 12 * time.Hour
 
 		// allow greedy prune on non-chain-tip
+		greedyPruneHistoryStartTime := time.Now()
 		if err = tx.(kv.TemporalRwTx).GreedyPruneHistory(ctx, kv.CommitmentDomain); err != nil {
 			return err
 		}
+		if duration := time.Since(greedyPruneHistoryStartTime); duration > quickPruneTimeout {
+			logger.Debug(
+				fmt.Sprintf("[%s] greedy prune history timing", s.LogPrefix()),
+				"duration", duration,
+				"initialCycle", s.CurrentSyncCycle.IsInitialCycle,
+				"externalTx", useExternalTx,
+			)
+		}
 	}
 
+	pruneSmallBatchesStartTime := time.Now()
 	if _, err := tx.(kv.TemporalRwTx).PruneSmallBatches(ctx, pruneTimeout); err != nil {
 		return err
+	}
+	if duration := time.Since(pruneSmallBatchesStartTime); duration > quickPruneTimeout {
+		logger.Debug(
+			fmt.Sprintf("[%s] prune small batches timing", s.LogPrefix()),
+			"duration", duration,
+			"initialCycle", s.CurrentSyncCycle.IsInitialCycle,
+			"externalTx", useExternalTx,
+		)
 	}
 
 	if err = s.Done(tx); err != nil {

--- a/execution/stagedsync/stage_execute.go
+++ b/execution/stagedsync/stage_execute.go
@@ -472,13 +472,13 @@ func PruneExecutionStage(s *PruneState, tx kv.RwTx, cfg ExecuteBlockCfg, ctx con
 		pruneTimeout = 12 * time.Hour
 
 		// allow greedy prune on non-chain-tip
-		greedyPruneHistoryStartTime := time.Now()
+		greedyPruneCommitmentHistoryStartTime := time.Now()
 		if err = tx.(kv.TemporalRwTx).GreedyPruneHistory(ctx, kv.CommitmentDomain); err != nil {
 			return err
 		}
-		if duration := time.Since(greedyPruneHistoryStartTime); duration > quickPruneTimeout {
+		if duration := time.Since(greedyPruneCommitmentHistoryStartTime); duration > quickPruneTimeout {
 			logger.Debug(
-				fmt.Sprintf("[%s] greedy prune history timing", s.LogPrefix()),
+				fmt.Sprintf("[%s] greedy prune commitment history timing", s.LogPrefix()),
 				"duration", duration,
 				"initialCycle", s.CurrentSyncCycle.IsInitialCycle,
 				"externalTx", useExternalTx,


### PR DESCRIPTION
sometimes on chain tip prune execution takes a long time (on my slow laptop's eth perfnet node I sometimes see 50s spent in pruning execution at chain tip) - adding these logs to pinpoint easily which part of the prune doesn't adhere to the 250ms timeout as a first step