### PR TITLE
stage_custom_trace: no BorSpan method fix

### DIFF
--- a/eth/consensuschain/consensus_chain_reader.go
+++ b/eth/consensuschain/consensus_chain_reader.go
@@ -28,6 +28,7 @@ import (
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon-lib/rlp"
 	"github.com/erigontech/erigon-lib/types"
+	"github.com/erigontech/erigon/polygon/heimdall"
 	"github.com/erigontech/erigon/turbo/services"
 )
 
@@ -124,4 +125,13 @@ func (cr Reader) BorEventsByBlock(hash common.Hash, number uint64) []rlp.RawValu
 		return nil
 	}
 	return events
+}
+
+func (cr Reader) BorSpan(spanId uint64) *heimdall.Span {
+	span, _, err := cr.blockReader.Span(context.Background(), cr.tx, spanId)
+	if err != nil {
+		log.Warn("BorSpan failed", "err", err)
+		return nil
+	}
+	return span
 }


### PR DESCRIPTION
```
[EROR] [07-04|04:47:36.105] WorkersPool: 'reduce worker' paniced: interface conversion: *consensuschain.Reader is not bor.ChainHeaderReader: missing method BorSpan, [historical_trace_worker.go:378 panic.go:792 iface.go:102 iface.go:474 bor.go:1530 bor.go:1494 bor.go:1104 historical_trace_worker.go:200 historical_trace_worker.go:458 historical_trace_worker.go:412 historical_trace_worker.go:381 errgroup.go:128 asm_amd64.s:1700]
```
not sure which reader is right - so, adding method back for now. It was removed here https://github.com/erigontech/erigon/pull/15687/files