### PR TITLE
rpcdaemon: remove check to avoid panic when access to Debug() method of KV remote

### DIFF
--- a/rpc/rpchelper/helper.go
+++ b/rpc/rpchelper/helper.go
@@ -169,9 +169,10 @@ func CreateHistoryStateReader(tx kv.TemporalTx, blockNumber uint64, txnIndex int
 		return nil, err
 	}
 	txNum := uint64(int(minTxNum) + txnIndex + /* 1 system txNum in beginning of block */ 1)
-	if txNum < r.StateHistoryStartFrom() {
-		return r, state.PrunedError
-	}
+
+	//if txNum < r.StateHistoryStartFrom() {
+	//	return r, state.PrunedError
+	//}
 	r.SetTxNum(txNum)
 	return r, nil
 }


### PR DESCRIPTION
remove same check on 3.0

fixes #15632