### PR TITLE
recsplit: add version inside file header

### DIFF
--- a/erigon-lib/recsplit/index.go
+++ b/erigon-lib/recsplit/index.go
@@ -18,6 +18,7 @@ package recsplit
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -76,11 +77,13 @@ type Index struct {
 	mmapHandle2        *[mmap.MaxMapSize]byte // mmap handle for windows (this is used to close mmap)
 	filePath, fileName string
 
-	grData             []uint64
-	data               []byte // slice of correct size for the index to work with
+	grData      []uint64
+	data        []byte // slice of correct size for the index to work with
+	mmapHandle1 []byte // mmap handle for unix (this is used to close mmap)
+	golombRice  []uint32
+
+	version            uint8
 	startSeed          []uint64
-	golombRice         []uint32
-	mmapHandle1        []byte // mmap handle for unix (this is used to close mmap)
 	ef                 eliasfano16.DoubleEliasFano
 	bucketSize         int
 	size               int64
@@ -97,7 +100,7 @@ type Index struct {
 	enums              bool
 
 	lessFalsePositives bool
-	existence          []byte
+	existenceV0        []byte
 
 	readers         *sync.Pool
 	readAheadRefcnt atomic.Int32 // ref-counter: allow enable/disable read-ahead from goroutines. only when refcnt=0 - disable read-ahead once
@@ -112,24 +115,11 @@ func MustOpen(indexFile string) *Index {
 }
 
 func OpenIndex(indexFilePath string) (idx *Index, err error) {
-	var validationPassed = false
 	_, fName := filepath.Split(indexFilePath)
 	idx = &Index{
 		filePath: indexFilePath,
 		fileName: fName,
 	}
-
-	defer func() {
-		// recover from panic if one occurred. Set err to nil if no panic
-		if rec := recover(); rec != nil {
-			// do r with only the stack trace
-			err = fmt.Errorf("incomplete file: %s, %+v, trace: %s", indexFilePath, rec, dbg.Stack())
-		}
-		if err != nil || !validationPassed {
-			idx.Close()
-			idx = nil
-		}
-	}()
 
 	idx.f, err = os.Open(indexFilePath)
 	if err != nil {
@@ -145,17 +135,61 @@ func OpenIndex(indexFilePath string) (idx *Index, err error) {
 		return nil, err
 	}
 	idx.data = idx.mmapHandle1[:idx.size]
+
+	if err := idx.init(); err != nil {
+		return nil, err
+	}
+
+	// dontt know how to madv part of file in golang yet
+	//if idx.version == 0 && idx.lessFalsePositives && idx.enums && idx.keyCount > 0 {
+	//	if len(idx.existence) > 0 {
+	//		if err := mmap.MadviseWillNeed(idx.existence); err != nil {
+	//			panic(err)
+	//		}
+	//	}
+	//	pos := 1 + 8 + idx.bytesPerRec*int(idx.keyCount)
+	//	if err := mmap.MadviseWillNeed(idx.data[:pos]); err != nil {
+	//		panic(err)
+	//	}
+	//}
+
+	idx.readers = &sync.Pool{
+		New: func() interface{} {
+			return NewIndexReader(idx)
+		},
+	}
+	return idx, nil
+}
+
+func (idx *Index) init() (err error) {
+	var validationPassed = false
+	defer func() {
+		// recover from panic if one occurred. Set err to nil if no panic
+		if rec := recover(); rec != nil {
+			// do r with only the stack trace
+			err = fmt.Errorf("incomplete file: %s, %+v, trace: %s", idx.fileName, rec, dbg.Stack())
+		}
+		if err != nil || !validationPassed {
+			idx.Close()
+			idx = nil
+		}
+	}()
+
 	defer idx.MadvSequential().DisableReadAhead()
 
-	// Read number of keys and bytes per record
-	idx.baseDataID = binary.BigEndian.Uint64(idx.data[:8])
-	idx.keyCount = binary.BigEndian.Uint64(idx.data[8:16])
+	// 1 byte: version, 7 bytes: app-specific minimal dataID (of current shard)
+	idx.version = idx.data[0]
+	baseDataBytes := bytes.Clone(idx.data[:8])
+	baseDataBytes[0] = 0
+	idx.baseDataID = binary.BigEndian.Uint64(baseDataBytes)
+
+	idx.keyCount = binary.BigEndian.Uint64(idx.data[8:])
 	idx.bytesPerRec = int(idx.data[16])
 	idx.recMask = (uint64(1) << (8 * idx.bytesPerRec)) - 1
 	offset := 16 + 1 + int(idx.keyCount)*idx.bytesPerRec
 
 	if offset < 0 {
-		return nil, fmt.Errorf("file %s %w. offset is: %d which is below zero", fName, IncompatibleErr, offset)
+		return fmt.Errorf("file %s %w. offset is: %d which is below zero", IncompatibleErr, offset)
 	}
 
 	// Bucket count, bucketSize, leafSize
@@ -184,7 +218,7 @@ func OpenIndex(indexFilePath string) (idx *Index, err error) {
 	}
 	features := Features(idx.data[offset])
 	if err := onlyKnownFeatures(features); err != nil {
-		return nil, fmt.Errorf("file %s %w", fName, err)
+		return fmt.Errorf("file %s %w", idx.fileName, err)
 	}
 
 	idx.enums = features&Enums != No
@@ -194,17 +228,17 @@ func OpenIndex(indexFilePath string) (idx *Index, err error) {
 		var size int
 		idx.offsetEf, size = eliasfano32.ReadEliasFano(idx.data[offset:])
 		offset += size
-
-		if idx.lessFalsePositives {
-			arrSz := binary.BigEndian.Uint64(idx.data[offset:])
-			offset += 8
-			if arrSz != idx.keyCount {
-				return nil, fmt.Errorf("%w. size of existence filter %d != keys count %d", IncompatibleErr, arrSz, idx.keyCount)
-			}
-			idx.existence = idx.data[offset : offset+int(arrSz)]
-			offset += int(arrSz)
-		}
 	}
+	if idx.version == 0 && idx.lessFalsePositives && idx.enums && idx.keyCount > 0 {
+		arrSz := binary.BigEndian.Uint64(idx.data[offset:])
+		offset += 8
+		if arrSz != idx.keyCount {
+			return fmt.Errorf("%w. size of existence filter %d != keys count %d", IncompatibleErr, arrSz, idx.keyCount)
+		}
+		idx.existenceV0 = idx.data[offset : offset+int(arrSz)]
+		offset += int(arrSz)
+	}
+
 	// Size of golomb rice params
 	golombParamSize := binary.BigEndian.Uint16(idx.data[offset:])
 	offset += 4
@@ -225,14 +259,8 @@ func OpenIndex(indexFilePath string) (idx *Index, err error) {
 	idx.grData = p[:l]
 	offset += 8 * int(l)
 	idx.ef.Read(idx.data[offset:])
-
-	idx.readers = &sync.Pool{
-		New: func() interface{} {
-			return NewIndexReader(idx)
-		},
-	}
 	validationPassed = true
-	return idx, nil
+	return nil
 }
 
 func onlyKnownFeatures(features Features) error {
@@ -258,7 +286,7 @@ func (idx *Index) Sizes() (total, offsets, ef, golombRice, existence, layer1 dat
 	}
 	ef = idx.ef.Size()
 	golombRice = datasize.ByteSize(len(idx.grData) * 8)
-	existence = datasize.ByteSize(len(idx.existence))
+	existence = datasize.ByteSize(len(idx.existenceV0))
 	layer1 = total - offsets - golombRice - existence
 	return
 }
@@ -349,6 +377,7 @@ func (idx *Index) Lookup(bucketHash, fingerprint uint64) (uint64, bool) {
 		}
 		level++
 	}
+
 	if m > idx.leafSize {
 		d := gr.ReadNext(idx.golombParam(m))
 		hmod := remap16(remix(fingerprint+idx.startSeed[level]+d), m)
@@ -370,8 +399,8 @@ func (idx *Index) Lookup(bucketHash, fingerprint uint64) (uint64, bool) {
 	pos := 1 + 8 + idx.bytesPerRec*(rec+1)
 
 	found := binary.BigEndian.Uint64(idx.data[pos:]) & idx.recMask
-	if idx.lessFalsePositives {
-		return found, idx.existence[found] == byte(bucketHash)
+	if idx.version == 0 && idx.lessFalsePositives {
+		return found, idx.existenceV0[found] == byte(bucketHash)
 	}
 	return found, true
 }
@@ -385,7 +414,7 @@ func (idx *Index) OrdinalLookup(i uint64) uint64 {
 
 func (idx *Index) Has(bucketHash, i uint64) bool {
 	if idx.lessFalsePositives {
-		return idx.existence[i] == byte(bucketHash)
+		return idx.existenceV0[i] == byte(bucketHash)
 	}
 	return true
 }

--- a/erigon-lib/recsplit/index.go
+++ b/erigon-lib/recsplit/index.go
@@ -189,7 +189,7 @@ func (idx *Index) init() (err error) {
 	offset := 16 + 1 + int(idx.keyCount)*idx.bytesPerRec
 
 	if offset < 0 {
-		return fmt.Errorf("file %s %w. offset is: %d which is below zero", IncompatibleErr, offset)
+		return fmt.Errorf("file %s %w. offset is: %d which is below zero", idx.fileName, IncompatibleErr, offset)
 	}
 
 	// Bucket count, bucketSize, leafSize

--- a/erigon-lib/recsplit/recsplit.go
+++ b/erigon-lib/recsplit/recsplit.go
@@ -64,15 +64,19 @@ func remix(z uint64) uint64 {
 // Recsplit: Minimal perfect hashing via recursive splitting. In 2020 Proceedings of the Symposium on Algorithm Engineering and Experiments (ALENEX),
 // pages 175−185. SIAM, 2020.
 type RecSplit struct {
+	// v=0 falsePositeves=true - as array of hashedKeys[0]. Requires `enum=true`. Problem: requires key number - which recsplit has but expensive to encode (~5bytes/key)
+	version uint8
+
+	//v0 fields
+	existenceFV0 *os.File
+	existenceWV0 *bufio.Writer
+
 	offsetCollector *etl.Collector // Collector that sorts by offsets
 
 	indexW          *bufio.Writer
 	indexF          *os.File
 	offsetEf        *eliasfano32.EliasFano // Elias Fano instance for encoding the offsets
 	bucketCollector *etl.Collector         // Collector that sorts by buckets
-
-	existenceF *os.File
-	existenceW *bufio.Writer
 
 	indexFileName          string
 	indexFile, tmpFilePath string
@@ -147,8 +151,17 @@ const DefaultBucketSize = 100 // typical from 100 to 2000, with smaller buckets 
 // salt parameters is used to randomise the hash function construction, to ensure that different Erigon instances (nodes)
 // are likely to use different hash function, to collision attacks are unlikely to slow down any meaningful number of nodes at the same time
 func NewRecSplit(args RecSplitArgs, logger log.Logger) (*RecSplit, error) {
+	if args.BaseDataID >= math.MaxUint64/2 {
+		return nil, fmt.Errorf("baseDataID %d is too large, must be less than %d", args.BaseDataID, math.MaxUint64/2)
+	}
+	const version uint8 = 0
+
 	bucketCount := (args.KeyCount + args.BucketSize - 1) / args.BucketSize
-	rs := &RecSplit{bucketSize: args.BucketSize, keyExpectedCount: uint64(args.KeyCount), bucketCount: uint64(bucketCount), lvl: log.LvlDebug, logger: logger}
+	rs := &RecSplit{
+		version:    version,
+		bucketSize: args.BucketSize, keyExpectedCount: uint64(args.KeyCount), bucketCount: uint64(bucketCount),
+		lvl: log.LvlDebug, logger: logger,
+	}
 	if len(args.StartSeed) == 0 {
 		args.StartSeed = []uint64{0x106393c187cae21a, 0x6453cec3f7376937, 0x643e521ddbd2be98, 0x3740c6412f6572cb, 0x717d47562f1ce470, 0x4cd6eb4c63befb7c, 0x9bfd8c5e18c8da73,
 			0x082f20e10092a9a3, 0x2ada2ce68d21defc, 0xe33cb4f3e7c6466b, 0x3980be458c509c59, 0xc466fd9584828e8c, 0x45f0aabe1a61ede6, 0xf6e7b8b33ad9b98d,
@@ -161,9 +174,9 @@ func NewRecSplit(args RecSplitArgs, logger log.Logger) (*RecSplit, error) {
 				rs.indexF.Close()
 				os.Remove(rs.indexF.Name())
 			}
-			if rs.existenceF != nil {
-				rs.existenceF.Close()
-				os.Remove(rs.existenceF.Name())
+			if rs.existenceFV0 != nil {
+				rs.existenceFV0.Close()
+				os.Remove(rs.existenceFV0.Name())
 			}
 		}
 	}()
@@ -192,14 +205,18 @@ func NewRecSplit(args RecSplitArgs, logger log.Logger) (*RecSplit, error) {
 		rs.offsetCollector.LogLvl(log.LvlDebug)
 	}
 	rs.lessFalsePositives = args.LessFalsePositives
+	var err error
 	if rs.enums && args.KeyCount > 0 && rs.lessFalsePositives {
-		bufferFile, err := os.CreateTemp(rs.tmpDir, "erigon-lfp-buf-")
-		if err != nil {
-			return nil, err
+		if rs.version == 0 {
+			rs.existenceFV0, err = os.CreateTemp(rs.tmpDir, "erigon-lfp-buf-")
+			if err != nil {
+				return nil, err
+			}
+			rs.existenceWV0 = bufio.NewWriter(rs.existenceFV0)
 		}
-		rs.existenceF = bufferFile
-		rs.existenceW = bufio.NewWriter(rs.existenceF)
+
 	}
+
 	rs.currentBucket = make([]uint64, 0, args.BucketSize)
 	rs.currentBucketOffs = make([]uint64, 0, args.BucketSize)
 	rs.maxOffset = 0
@@ -232,10 +249,10 @@ func (rs *RecSplit) Close() {
 		_ = os.Remove(rs.indexF.Name())
 		rs.indexF = nil
 	}
-	if rs.existenceF != nil {
-		rs.existenceF.Close()
-		_ = os.Remove(rs.existenceF.Name())
-		rs.existenceF = nil
+	if rs.existenceFV0 != nil {
+		rs.existenceFV0.Close()
+		_ = os.Remove(rs.existenceFV0.Name())
+		rs.existenceFV0 = nil
 	}
 	if rs.bucketCollector != nil {
 		rs.bucketCollector.Close()
@@ -390,17 +407,18 @@ func (rs *RecSplit) AddKey(key []byte, offset uint64) error {
 		if err := rs.bucketCollector.Collect(rs.bucketKeyBuf[:], rs.numBuf[:]); err != nil {
 			return err
 		}
-		if rs.lessFalsePositives {
-			//1 byte from each hashed key
-			if err := rs.existenceW.WriteByte(byte(hi)); err != nil {
-				return err
-			}
-		}
 	} else {
 		if err := rs.bucketCollector.Collect(rs.bucketKeyBuf[:], rs.numBuf[:]); err != nil {
 			return err
 		}
 	}
+	if rs.version == 0 && rs.lessFalsePositives && rs.enums {
+		//1 byte from each hashed key
+		if err := rs.existenceWV0.WriteByte(byte(hi)); err != nil {
+			return err
+		}
+	}
+
 	rs.keysAdded++
 	rs.prevOffset = offset
 	return nil
@@ -609,8 +627,9 @@ func (rs *RecSplit) Build(ctx context.Context) error {
 
 	defer rs.indexF.Close()
 	rs.indexW = bufio.NewWriterSize(rs.indexF, etl.BufIOSize)
-	// Write minimal app-specific dataID in this index file
+	// 1 byte: version, 7 bytes: app-specific minimal dataID (of current shard)
 	binary.BigEndian.PutUint64(rs.numBuf[:], rs.baseDataID)
+	rs.numBuf[0] = rs.version
 	if _, err = rs.indexW.Write(rs.numBuf[:]); err != nil {
 		return fmt.Errorf("write number of keys: %w", err)
 	}
@@ -750,26 +769,25 @@ func (rs *RecSplit) Build(ctx context.Context) error {
 }
 
 func (rs *RecSplit) flushExistenceFilter() error {
-	if !rs.enums || rs.keysAdded == 0 || !rs.lessFalsePositives {
-		return nil
-	}
-	defer rs.existenceF.Close()
+	if rs.version == 0 && rs.enums && rs.keysAdded > 0 && rs.lessFalsePositives {
+		defer rs.existenceFV0.Close()
 
-	//Write len of array
-	binary.BigEndian.PutUint64(rs.numBuf[:], rs.keysAdded)
-	if _, err := rs.indexW.Write(rs.numBuf[:]); err != nil {
-		return err
-	}
+		//Write len of array
+		binary.BigEndian.PutUint64(rs.numBuf[:], rs.keysAdded)
+		if _, err := rs.indexW.Write(rs.numBuf[:]); err != nil {
+			return err
+		}
 
-	// flush bufio and rewind before io.Copy, but no reason to fsync the file - it temporary
-	if err := rs.existenceW.Flush(); err != nil {
-		return err
-	}
-	if _, err := rs.existenceF.Seek(0, io.SeekStart); err != nil {
-		return err
-	}
-	if _, err := io.CopyN(rs.indexW, rs.existenceF, int64(rs.keysAdded)); err != nil {
-		return err
+		// flush bufio and rewind before io.Copy, but no reason to fsync the file - it temporary
+		if err := rs.existenceWV0.Flush(); err != nil {
+			return err
+		}
+		if _, err := rs.existenceFV0.Seek(0, io.SeekStart); err != nil {
+			return err
+		}
+		if _, err := io.CopyN(rs.indexW, rs.existenceFV0, int64(rs.keysAdded)); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/erigon-lib/state/btree_index.go
+++ b/erigon-lib/state/btree_index.go
@@ -360,17 +360,17 @@ func BuildBtreeIndexWithDecompressor(indexPath string, kv *seg.Reader, ps *backg
 	defer ps.Delete(p)
 
 	defer kv.MadvNormal().DisableReadAhead()
-	bloomPath := strings.TrimSuffix(indexPath, ".bt") + ".kvei"
+	existenceFilterPath := strings.TrimSuffix(indexPath, ".bt") + ".kvei"
 
-	var bloom *existence.Filter
+	var existenceFilter *existence.Filter
 	if accessors.Has(AccessorExistence) {
 		var err error
-		bloom, err = existence.NewFilter(uint64(kv.Count()/2), bloomPath)
+		existenceFilter, err = existence.NewFilter(uint64(kv.Count()/2), existenceFilterPath)
 		if err != nil {
 			return err
 		}
 		if noFsync {
-			bloom.DisableFsync()
+			existenceFilter.DisableFsync()
 		}
 	}
 
@@ -404,8 +404,8 @@ func BuildBtreeIndexWithDecompressor(indexPath string, kv *seg.Reader, ps *backg
 			return err
 		}
 		hi, _ := murmur3.Sum128WithSeed(key, salt)
-		if bloom != nil {
-			bloom.AddHash(hi)
+		if existenceFilter != nil {
+			existenceFilter.AddHash(hi)
 		}
 		pos, _ = kv.Skip()
 
@@ -416,8 +416,8 @@ func BuildBtreeIndexWithDecompressor(indexPath string, kv *seg.Reader, ps *backg
 		return err
 	}
 
-	if bloom != nil {
-		if err := bloom.Build(); err != nil {
+	if existenceFilter != nil {
+		if err := existenceFilter.Build(); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
- add version inside file header - `v0`
- prepare for future adding `v1`

PR is backward-compatible - no new functionality

this pr probably will go to `3.0` and `v1` will go to `main` - but will see (seems can release `v1` without re-sync)

related to: https://github.com/erigontech/erigon/issues/14371 and https://github.com/erigontech/erigon/issues/12852

`v1` likely will address 2 bottlenecks: txn_lookup_by_txn_hash, stage_history_get. 