### PR TITLE
rcache integrity check

### DIFF
--- a/erigon-lib/kv/kv_interface.go
+++ b/erigon-lib/kv/kv_interface.go
@@ -605,6 +605,8 @@ type TemporalDebugDB interface {
 	ReloadSalt() error
 	BuildMissedAccessors(ctx context.Context, workers int) error
 	ReloadFiles() error
+	EnableReadAhead() TemporalDebugDB
+	DisableReadAhead()
 }
 
 type WithFreezeInfo interface {

--- a/erigon-lib/kv/remotedb/kv_remote.go
+++ b/erigon-lib/kv/remotedb/kv_remote.go
@@ -190,6 +190,8 @@ func (db *DB) ReloadSalt() error                                   { panic("not 
 func (db *DB) InvertedIdxTables(domain ...kv.InvertedIdx) []string { panic("not implemented") }
 func (db *DB) ReloadFiles() error                                  { panic("not implemented") }
 func (db *DB) BuildMissedAccessors(_ context.Context, _ int) error { panic("not implemented") }
+func (db *DB) EnableReadAhead() kv.TemporalDebugDB                 { panic("not implemented") }
+func (db *DB) DisableReadAhead()                                   { panic("not implemented") }
 
 func (db *DB) BeginTemporalRo(ctx context.Context) (kv.TemporalTx, error) {
 	t, err := db.BeginRo(ctx) //nolint:gocritic

--- a/erigon-lib/kv/temporal/kv_temporal.go
+++ b/erigon-lib/kv/temporal/kv_temporal.go
@@ -576,7 +576,7 @@ func (db *DB) BuildMissedAccessors(ctx context.Context, workers int) error {
 	return db.agg.BuildMissedAccessors(ctx, workers)
 }
 func (db *DB) EnableReadAhead() kv.TemporalDebugDB {
-	db.agg.EnableReadAhead()
+	db.agg.MadvNormal()
 	return db
 }
 

--- a/erigon-lib/kv/temporal/kv_temporal.go
+++ b/erigon-lib/kv/temporal/kv_temporal.go
@@ -575,6 +575,14 @@ func (db *DB) ReloadFiles() error { return db.agg.ReloadFiles() }
 func (db *DB) BuildMissedAccessors(ctx context.Context, workers int) error {
 	return db.agg.BuildMissedAccessors(ctx, workers)
 }
+func (db *DB) EnableReadAhead() kv.TemporalDebugDB {
+	db.agg.EnableReadAhead()
+	return db
+}
+
+func (db *DB) DisableReadAhead() {
+	db.agg.DisableReadAhead()
+}
 
 func (tx *Tx) DomainFiles(domain ...kv.Domain) kv.VisibleFiles {
 	return tx.aggtx.DomainFiles(domain...)

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -1866,26 +1866,6 @@ func (a *Aggregator) DisableReadAhead() {
 		}
 	}
 }
-func (a *Aggregator) EnableReadAhead() {
-	a.dirtyFilesLock.Lock()
-	defer a.dirtyFilesLock.Unlock()
-	for _, d := range a.d {
-		for _, f := range d.dirtyFiles.Items() {
-			f.EnableReadAhead()
-		}
-		for _, f := range d.History.dirtyFiles.Items() {
-			f.EnableReadAhead()
-		}
-		for _, f := range d.History.InvertedIndex.dirtyFiles.Items() {
-			f.EnableReadAhead()
-		}
-	}
-	for _, ii := range a.iis {
-		for _, f := range ii.dirtyFiles.Items() {
-			f.EnableReadAhead()
-		}
-	}
-}
 
 func (at *AggregatorRoTx) Close() {
 	if at == nil || at.a == nil { // invariant: it's safe to call Close multiple times

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -1866,6 +1866,26 @@ func (a *Aggregator) DisableReadAhead() {
 		}
 	}
 }
+func (a *Aggregator) EnableReadAhead() {
+	a.dirtyFilesLock.Lock()
+	defer a.dirtyFilesLock.Unlock()
+	for _, d := range a.d {
+		for _, f := range d.dirtyFiles.Items() {
+			f.EnableReadAhead()
+		}
+		for _, f := range d.History.dirtyFiles.Items() {
+			f.EnableReadAhead()
+		}
+		for _, f := range d.History.InvertedIndex.dirtyFiles.Items() {
+			f.EnableReadAhead()
+		}
+	}
+	for _, ii := range a.iis {
+		for _, f := range ii.dirtyFiles.Items() {
+			f.EnableReadAhead()
+		}
+	}
+}
 
 func (at *AggregatorRoTx) Close() {
 	if at == nil || at.a == nil { // invariant: it's safe to call Close multiple times

--- a/erigon-lib/state/files_item.go
+++ b/erigon-lib/state/files_item.go
@@ -101,6 +101,10 @@ func (i *FilesItem) MadvNormal() {
 	//i.bindex.MadvNormal()
 	//i.existence.MadvNormal()
 }
+func (i *FilesItem) EnableReadAhead() {
+	i.decompressor.MadvSequential()
+	i.index.MadvSequential()
+}
 func (i *FilesItem) DisableReadAhead() {
 	i.decompressor.DisableReadAhead()
 	i.index.DisableReadAhead()

--- a/erigon-lib/state/kv_temporal_copy_test.go
+++ b/erigon-lib/state/kv_temporal_copy_test.go
@@ -557,6 +557,14 @@ func (db *DB) ReloadFiles() error { return db.agg.ReloadFiles() }
 func (db *DB) BuildMissedAccessors(ctx context.Context, workers int) error {
 	return db.agg.BuildMissedAccessors(ctx, workers)
 }
+func (db *DB) EnableReadAhead() kv.TemporalDebugDB {
+	db.agg.EnableReadAhead()
+	return db
+}
+
+func (db *DB) DisableReadAhead() {
+	db.agg.DisableReadAhead()
+}
 
 func (tx *Tx) DomainFiles(domain ...kv.Domain) kv.VisibleFiles {
 	return tx.aggtx.DomainFiles(domain...)

--- a/erigon-lib/state/kv_temporal_copy_test.go
+++ b/erigon-lib/state/kv_temporal_copy_test.go
@@ -558,7 +558,7 @@ func (db *DB) BuildMissedAccessors(ctx context.Context, workers int) error {
 	return db.agg.BuildMissedAccessors(ctx, workers)
 }
 func (db *DB) EnableReadAhead() kv.TemporalDebugDB {
-	db.agg.EnableReadAhead()
+	db.agg.MadvNormal()
 	return db
 }
 

--- a/erigon-lib/types/receipt.go
+++ b/erigon-lib/types/receipt.go
@@ -596,7 +596,7 @@ func (r *Receipt) DeriveFieldsV3ForSingleReceipt(txnIdx int, blockHash common.Ha
 
 // DeriveFieldsV4ForCachedReceipt fills the receipts with their computed fields based on consensus
 // data and contextual infos like containing block and transactions.
-func (r *Receipt) DeriveFieldsV4ForCachedReceipt(blockHash common.Hash, blockNum uint64, txnHash common.Hash) {
+func (r *Receipt) DeriveFieldsV4ForCachedReceipt(blockHash common.Hash, blockNum uint64, txnHash common.Hash, calcBloom bool) {
 	logIndex := r.FirstLogIndexWithinBlock // logIdx is unique within the block and starts from 0
 
 	r.BlockHash = blockHash
@@ -612,7 +612,9 @@ func (r *Receipt) DeriveFieldsV4ForCachedReceipt(blockHash common.Hash, blockNum
 		r.Logs[j].Index = uint(logIndex)
 		logIndex++
 	}
-	r.Bloom = CreateBloom(Receipts{r})
+	if calcBloom {
+		r.Bloom = CreateBloom(Receipts{r})
+	}
 }
 
 // TODO: maybe make it more prettier (only for debug purposes)

--- a/eth/integrity/integrity_action_type.go
+++ b/eth/integrity/integrity_action_type.go
@@ -25,6 +25,7 @@ const (
 	InvertedIndex      Check = "InvertedIndex"
 	HistoryNoSystemTxs Check = "HistoryNoSystemTxs"
 	ReceiptsNoDups     Check = "ReceiptsNoDups"
+	RCacheNoDups       Check = "RCacheNoDups"
 	BorEvents          Check = "BorEvents"
 	BorSpans           Check = "BorSpans"
 	BorCheckpoints     Check = "BorCheckpoints"
@@ -37,4 +38,5 @@ var AllChecks = []Check{
 
 var NonDefaultChecks = []Check{
 	BorMilestones,
+	RCacheNoDups,
 }

--- a/eth/integrity/rcache_no_duplicates.go
+++ b/eth/integrity/rcache_no_duplicates.go
@@ -1,0 +1,213 @@
+package integrity
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sync/atomic"
+	"time"
+
+	"github.com/erigontech/erigon-db/rawdb"
+	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/kv"
+	"github.com/erigontech/erigon-lib/log/v3"
+	"github.com/erigontech/erigon/turbo/services"
+	"golang.org/x/sync/errgroup"
+)
+
+func CheckRCacheNoDups(ctx context.Context, db kv.TemporalRoDB, blockReader services.FullBlockReader, failFast bool) (err error) {
+	defer func() {
+		log.Info("[integrity] RCacheNoDups: done", "err", err)
+	}()
+
+	logEvery := time.NewTicker(10 * time.Second)
+	defer logEvery.Stop()
+
+	txNumsReader := blockReader.TxnumReader(ctx)
+
+	tx, err := db.BeginTemporalRo(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	rcacheDomainProgress := tx.Debug().DomainProgress(kv.RCacheDomain)
+	fromBlock := uint64(1)
+	toBlock, _, _ := txNumsReader.FindBlockNum(tx, rcacheDomainProgress)
+
+	{
+		log.Info("[integrity] RCacheNoDups starting", "fromBlock", fromBlock, "toBlock", toBlock)
+		accProgress := tx.Debug().DomainProgress(kv.AccountsDomain)
+		if accProgress != rcacheDomainProgress {
+			err := fmt.Errorf("[integrity] RCacheDomain=%d is behind AccountDomain=%d", rcacheDomainProgress, accProgress)
+			log.Warn(err.Error())
+			return err
+		}
+	}
+
+	tx.Rollback()
+
+	defer db.Debug().EnableReadAhead().DisableReadAhead()
+	return parallelChunkCheck(ctx, fromBlock, toBlock, db, blockReader, failFast, RCacheNoDupsRange)
+}
+
+func RCacheNoDupsRange(ctx context.Context, fromBlock, toBlock uint64, tx kv.TemporalTx, blockReader services.FullBlockReader, failFast bool) (err error) {
+	txNumsReader := blockReader.TxnumReader(ctx)
+	fromTxNum, err := txNumsReader.Min(tx, fromBlock)
+	if err != nil {
+		return err
+	}
+	if toBlock > 0 {
+		toBlock-- // [fromBlock,toBlock)
+	}
+
+	toTxNum, err := txNumsReader.Max(tx, toBlock)
+	if err != nil {
+		return err
+	}
+
+	prevCumUsedGas := -1
+	expectedFirstLogIdx := uint32(0)
+	blockNum := fromBlock
+	var _min, _max uint64
+	_min, _ = txNumsReader.Min(tx, fromBlock)
+	_max, _ = txNumsReader.Max(tx, fromBlock)
+	for txNum := fromTxNum; txNum <= toTxNum; txNum++ {
+		r, found, err := rawdb.ReadReceiptCacheV2(tx, rawdb.RCacheV2Query{
+			TxNum:         txNum,
+			BlockNum:      blockNum,
+			BlockHash:     common.Hash{}, // don't care about blockHash/txnHash
+			TxnHash:       common.Hash{},
+			DontCalcBloom: true, // we don't need bloom for this check
+		})
+		if err != nil {
+			return err
+		}
+		if !found {
+			if txNum == _max {
+				blockNum++
+				_min = _max + 1
+				_max, _ = txNumsReader.Max(tx, blockNum)
+				expectedFirstLogIdx = 0
+				prevCumUsedGas = -1
+				continue // skip system txs
+			}
+			if txNum == _min {
+				continue
+			}
+			if failFast {
+				return fmt.Errorf("[integrity] RCacheNoDups: missing receipt for block %d, txNum %d", blockNum, txNum)
+			}
+			log.Warn("[integrity] RCacheNoDups: missing receipt", "block", blockNum, "txNum", txNum)
+			continue
+		}
+
+		logIdx := r.FirstLogIndexWithinBlock
+		exactLogIdx := logIdx == expectedFirstLogIdx
+		if !exactLogIdx {
+			err := fmt.Errorf("RCacheNoDups: non-monotonic logIndex at txnum: %d, block: %d(%d-%d), logIdx=%d, expectedFirstLogIdx=%d", txNum, blockNum, _min, _max, logIdx, expectedFirstLogIdx)
+			if failFast {
+				return err
+			}
+			log.Error(err.Error())
+		}
+		expectedFirstLogIdx = logIdx + uint32(len(r.Logs))
+
+		cumUsedGas := r.CumulativeGasUsed
+		strongMonotonicCumGasUsed := int(cumUsedGas) > prevCumUsedGas
+		if !strongMonotonicCumGasUsed { // system tx can be skipped
+			err := fmt.Errorf("RCacheNoDups: non-monotonic cumUsedGas at txnum: %d, block: %d(%d-%d), cumUsedGas=%d, prevCumUsedGas=%d", txNum, blockNum, _min, _max, cumUsedGas, prevCumUsedGas)
+			if failFast {
+				return err
+			}
+			log.Error(err.Error())
+		}
+		prevCumUsedGas = int(cumUsedGas)
+
+		if txNum == _max {
+			fmt.Printf("never here: block %d, txNum %d, cumUsedGas %d, logIdx %d\n", blockNum, txNum, cumUsedGas, logIdx)
+			blockNum++
+			_min = _max + 1
+			_max, _ = txNumsReader.Max(tx, blockNum)
+			expectedFirstLogIdx = 0
+			prevCumUsedGas = -1
+		}
+
+		if txNum%1000 == 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+		}
+	}
+
+	return nil
+}
+
+type chunkFn func(ctx context.Context, fromBlock, toBlock uint64, tx kv.TemporalTx, blockReader services.FullBlockReader, failFast bool) error
+
+func parallelChunkCheck(ctx context.Context, fromBlock, toBlock uint64, db kv.TemporalRoDB, blockReader services.FullBlockReader, failFast bool, fn chunkFn) (err error) {
+	blockRange := toBlock - fromBlock + 1
+	if blockRange == 0 {
+		return nil
+	}
+
+	numWorkers := runtime.NumCPU() * 5
+	chunkSize := uint64(1000)
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(numWorkers)
+	var completedChunks atomic.Uint64
+	var totalChunks uint64 = (blockRange + chunkSize - 1) / chunkSize
+	log.Info("[integrity] parallel processing", "workers", numWorkers, "chunkSize", chunkSize, "blockRange", blockRange)
+
+	logEvery := time.NewTicker(20 * time.Second)
+	defer logEvery.Stop()
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-logEvery.C:
+				completed := completedChunks.Load()
+				progress := float64(completed) / float64(totalChunks) * 100
+				log.Info("[integrity] progress", "progress", fmt.Sprintf("%.1f%%", progress))
+			}
+		}
+	}()
+
+	// Process chunks in parallel
+	for start := fromBlock; start <= toBlock; start += chunkSize {
+		end := start + chunkSize - 1
+		if end > toBlock {
+			end = toBlock
+		}
+
+		chunkStart := start // Capture loop variable
+		chunkEnd := end     // Capture loop variable
+
+		g.Go(func() error {
+			tx, err := db.BeginTemporalRo(ctx)
+			if err != nil {
+				return err
+			}
+			defer tx.Rollback()
+
+			// chunkErr := ReceiptsNoDupsRange(ctx, chunkStart, chunkEnd, tx, blockReader, failFast)
+			chunkErr := fn(ctx, chunkStart, chunkEnd, tx, blockReader, failFast)
+			if chunkErr != nil {
+				return chunkErr
+			}
+
+			completedChunks.Add(1)
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/rpc/jsonrpc/receipts/receipts_generator.go
+++ b/rpc/jsonrpc/receipts/receipts_generator.go
@@ -167,10 +167,10 @@ func (g *Generator) GetReceipt(ctx context.Context, cfg *chain.Config, tx kv.Tem
 		var ok bool
 		var err error
 		receiptFromDB, ok, err = rawdb.ReadReceiptCacheV2(tx, rawdb.RCacheV2Query{
-			TxNum:         txNum,
-			BlockNum:      blockNum,
-			BlockHash:     blockHash,
-			TxnHash:       txnHash,
+			TxNum:     txNum,
+			BlockNum:  blockNum,
+			BlockHash: blockHash,
+			TxnHash:   txnHash,
 		})
 		if err != nil {
 			return nil, err

--- a/rpc/jsonrpc/receipts/receipts_generator.go
+++ b/rpc/jsonrpc/receipts/receipts_generator.go
@@ -166,7 +166,12 @@ func (g *Generator) GetReceipt(ctx context.Context, cfg *chain.Config, tx kv.Tem
 	if !rpcDisableRCache {
 		var ok bool
 		var err error
-		receiptFromDB, ok, err = rawdb.ReadReceiptCacheV2(tx, blockNum, blockHash, txnHash, txNum)
+		receiptFromDB, ok, err = rawdb.ReadReceiptCacheV2(tx, rawdb.RCacheV2Query{
+			TxNum:         txNum,
+			BlockNum:      blockNum,
+			BlockHash:     blockHash,
+			TxnHash:       txnHash,
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -759,6 +759,10 @@ func doIntegrity(cliCtx *cli.Context) error {
 			if err := integrity.CheckReceiptsNoDups(ctx, db, blockReader, failFast); err != nil {
 				return err
 			}
+		case integrity.RCacheNoDups:
+			if err := integrity.CheckRCacheNoDups(ctx, db, blockReader, failFast); err != nil {
+				return err
+			}
 		default:
 			return fmt.Errorf("unknown check: %s", chk)
 		}


### PR DESCRIPTION
- checks invariants of rcache domain: around `logIndex` and cumulative gas 
- since logs are available in rcache, it can do stricter check of logIndex. (more than monotonically increasing).
- executes faster than `invariantsEthGetLogs`;  also it doesn't catch rcache error around expected firstLogIdx, which this integrity check does,

```
-> time ./build/bin/erigon seg integrity --check RCacheNoDups --datadir /erigon-data/sepoli
a_ethlogs3_crash

....

INFO[07-07|07:36:57.024] [integrity] progress                     progress=97.8%
INFO[07-07|07:37:17.040] [integrity] progress                     progress=98.3%
INFO[07-07|07:37:34.629] [integrity] RCacheNoDups: done           err="RCacheNoDups: non-monotonic logIndex at txnum: 582812500, block: 8637385(582812
459-582812725), logIdx=61, prevLogIdx=64"
EROR[07-07|07:37:36.634] [integrity]                              err="RCacheNoDups: non-monotonic logIndex at txnum: 582812500, block: 8637385(582812
459-582812725), logIdx=61, prevLogIdx=64"
RCacheNoDups: non-monotonic logIndex at txnum: 582812500, block: 8637385(582812459-582812725), logIdx=61, prevLogIdx=64

real    13m23.123s
user    117m33.188s
sys     1m38.495s
```

