### PR TITLE
Add versioning check for recovery

### DIFF
--- a/core/state/intra_block_state.go
+++ b/core/state/intra_block_state.go
@@ -124,13 +124,13 @@ func New(stateReader StateReader) *IntraBlockState {
 		balanceInc:        map[common.Address]*BalanceIncrease{},
 		txIndex:           0,
 		trace:             false,
+		dep:               -1,
 	}
 }
 
 func NewWithVersionMap(stateReader StateReader, mvhm *VersionMap) *IntraBlockState {
 	ibs := New(stateReader)
 	ibs.versionMap = mvhm
-	ibs.dep = -1
 	return ibs
 }
 
@@ -189,6 +189,10 @@ func (sdb *IntraBlockState) StorageReadCount() int64 {
 
 func (sdb *IntraBlockState) SetVersionMap(versionMap *VersionMap) {
 	sdb.versionMap = versionMap
+}
+
+func (sdb *IntraBlockState) IsVersioned() bool {
+	return sdb.versionMap != nil
 }
 
 func (sdb *IntraBlockState) SetHooks(hooks *tracing.Hooks) {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -425,22 +425,24 @@ func (st *StateTransition) ApplyFrame() (*evmtypes.ExecutionResult, error) {
 // However if any consensus issue encountered, return the error directly with
 // nil evm execution result.
 func (st *StateTransition) TransitionDb(refunds bool, gasBailout bool) (result *evmtypes.ExecutionResult, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			// Recover from dependency panic and retry the execution.
-			if r != state.ErrDependency {
-				log.Debug("Recovered from transition exec failure.", "Error:", r, "stack", dbg.Stack())
+	if st.evm.IntraBlockState().IsVersioned() {
+		defer func() {
+			if r := recover(); r != nil {
+				// Recover from dependency panic and retry the execution.
+				if r != state.ErrDependency {
+					log.Debug("Recovered from transition exec failure.", "Error:", r, "stack", dbg.Stack())
+				}
+				st.gp.AddGas(st.gasUsed())
+				depTxIndex := st.evm.IntraBlockState().DepTxIndex()
+				if depTxIndex < 0 {
+					err = fmt.Errorf("transition exec failure: %s at: %s", r, dbg.Stack())
+				}
+				err = ErrExecAbortError{
+					DependencyTxIndex: depTxIndex,
+					OriginError:       err}
 			}
-			st.gp.AddGas(st.gasUsed())
-			depTxIndex := st.evm.IntraBlockState().DepTxIndex()
-			if depTxIndex < 0 {
-				err = fmt.Errorf("transition exec failure: %s at: %s", r, dbg.Stack())
-			}
-			err = ErrExecAbortError{
-				DependencyTxIndex: depTxIndex,
-				OriginError:       err}
-		}
-	}()
+		}()
+	}
 
 	coinbase := st.evm.Context.Coinbase
 	senderInitBalance, err := st.state.GetBalance(st.msg.From())


### PR DESCRIPTION
The recover function in TransitionDB is specific to parallel processing 