### PR TITLE
`seg retire`: remove external misleading check

### DIFF
--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -1788,11 +1788,6 @@ func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 		blocksInSnapshots = min(blocksInSnapshots, blockReader.FrozenBorBlocks())
 	}
 
-	from2, to2, ok := freezeblocks.CanRetire(to, blocksInSnapshots, coresnaptype.Enums.Headers, nil)
-	if ok {
-		from, to = from2, to2
-	}
-
 	if err := br.RetireBlocks(ctx, from, to, log.LvlInfo, nil, nil, nil); err != nil {
 		return err
 	}


### PR DESCRIPTION
So if block can be retired or not is decided inside RetireBlock with same function which updates To parameter. If keep this check, it can set 1k limit threshold which cannot pass this check again beacause `const keep = 1024` which is smaller therefore retire always exits this case.