### PR TITLE
Expose debug mux to downstream components

### DIFF
--- a/cmd/devnet/devnet/node.go
+++ b/cmd/devnet/devnet/node.go
@@ -177,8 +177,10 @@ func (n *devnetNode) run(ctx *cli.Context) error {
 
 	debugMux := metricsMux
 
-	if debugMux==nil {
-		debugMux=pprofMux
+	if debugMux == nil {
+		debugMux = pprofMux
+	} else {
+		debugMux = http.DefaultServeMux
 	}
 
 	logger.Info("Build info", "git_branch", params.GitBranch, "git_tag", params.GitTag, "git_commit", params.GitCommit)

--- a/cmd/devnet/devnet/node.go
+++ b/cmd/devnet/devnet/node.go
@@ -175,9 +175,15 @@ func (n *devnetNode) run(ctx *cli.Context) error {
 		return err
 	}
 
+	debugMux := metricsMux
+
+	if debugMux==nil {
+		debugMux=pprofMux
+	}
+
 	logger.Info("Build info", "git_branch", params.GitBranch, "git_tag", params.GitTag, "git_commit", params.GitCommit)
 
-	nodeConf, err := enode.NewNodConfigUrfave(ctx, logger)
+	nodeConf, err := enode.NewNodConfigUrfave(ctx, debugMux, logger)
 	if err != nil {
 		return err
 	}

--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/fs"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -302,7 +303,7 @@ func Downloader(ctx context.Context, logger log.Logger) error {
 	defer d.Close()
 	logger.Info("[snapshots] Start bittorrent server", "my_peer_id", fmt.Sprintf("%x", d.TorrentClient().PeerID()))
 
-	d.HandleTorrentClientStatus()
+	d.HandleTorrentClientStatus(http.DefaultServeMux)
 
 	err = d.AddTorrentsFromDisk(ctx)
 	if err != nil {

--- a/cmd/erigon/main.go
+++ b/cmd/erigon/main.go
@@ -72,8 +72,10 @@ func runErigon(cliCtx *cli.Context) error {
 
 	if debugMux == nil {
 		debugMux = pprofMux
+	} else {
+		debugMux = http.DefaultServeMux
 	}
-	
+
 	// initializing the node and providing the current git commit there
 
 	logger.Info("Build info", "git_branch", params.GitBranch, "git_tag", params.GitTag, "git_commit", params.GitCommit)

--- a/cmd/erigon/main.go
+++ b/cmd/erigon/main.go
@@ -68,6 +68,12 @@ func runErigon(cliCtx *cli.Context) error {
 		return err
 	}
 
+	debugMux := metricsMux
+
+	if debugMux == nil {
+		debugMux = pprofMux
+	}
+	
 	// initializing the node and providing the current git commit there
 
 	logger.Info("Build info", "git_branch", params.GitBranch, "git_tag", params.GitTag, "git_commit", params.GitCommit)
@@ -86,7 +92,7 @@ func runErigon(cliCtx *cli.Context) error {
 	erigonInfoGauge := metrics.GetOrCreateGauge(fmt.Sprintf(`erigon_info{version="%s",commit="%s"}`, params.Version, params.GitCommit))
 	erigonInfoGauge.Set(1)
 
-	nodeCfg, err := node.NewNodConfigUrfave(cliCtx, logger)
+	nodeCfg, err := node.NewNodConfigUrfave(cliCtx, debugMux, logger)
 	if err != nil {
 		return err
 	}

--- a/cmd/sentry/main.go
+++ b/cmd/sentry/main.go
@@ -89,7 +89,7 @@ var rootCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		dirs := datadir.New(datadirCli)
-		nodeConfig := node2.NewNodeConfig()
+		nodeConfig := node2.NewNodeConfig(nil)
 		p2pConfig, err := utils.NewP2PConfig(
 			nodiscover,
 			dirs,

--- a/erigon-db/downloader/downloader.go
+++ b/erigon-db/downloader/downloader.go
@@ -1346,8 +1346,8 @@ func (d *Downloader) Completed() bool {
 
 // Expose torrent client status to HTTP on the public/default serve mux used by GOPPROF=http. Only
 // do this if you have a single instance.
-func (d *Downloader) HandleTorrentClientStatus() {
-	http.HandleFunc("/downloaderTorrentClientStatus", func(w http.ResponseWriter, r *http.Request) {
+func (d *Downloader) HandleTorrentClientStatus(debugMux *http.ServeMux) {
+	debugMux.HandleFunc("/downloader/torrents", func(w http.ResponseWriter, r *http.Request) {
 		d.torrentClient.WriteStatus(w)
 	})
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -420,7 +420,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 	}
 
 	// Can happen in some configurations
-	if err := backend.setUpSnapDownloader(ctx, config.Downloader, chainConfig); err != nil {
+	if err := backend.setUpSnapDownloader(ctx, stack.Config(), config.Downloader, chainConfig); err != nil {
 		return nil, err
 	}
 
@@ -1473,7 +1473,7 @@ func (s *Ethereum) NodesInfo(limit int) (*remote.NodesInfoReply, error) {
 }
 
 // sets up blockReader and client downloader
-func (s *Ethereum) setUpSnapDownloader(ctx context.Context, downloaderCfg *downloadercfg.Cfg, cc *chain.Config) error {
+func (s *Ethereum) setUpSnapDownloader(ctx context.Context, nodeCfg *nodecfg.Config, downloaderCfg *downloadercfg.Cfg, cc *chain.Config) error {
 	var err error
 	s.chainDB.OnFilesChange(func(frozenFileNames []string) {
 		s.logger.Warn("files changed...sending notification")
@@ -1518,7 +1518,7 @@ func (s *Ethereum) setUpSnapDownloader(ctx context.Context, downloaderCfg *downl
 			return err
 		}
 
-		s.downloader.HandleTorrentClientStatus()
+		s.downloader.HandleTorrentClientStatus(nodeCfg.DebugMux)
 
 		bittorrentServer, err := downloader.NewGrpcServer(s.downloader)
 		if err != nil {

--- a/node/nodecfg/config.go
+++ b/node/nodecfg/config.go
@@ -21,6 +21,7 @@ package nodecfg
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -171,6 +172,8 @@ type Config struct {
 	HealthCheck bool
 
 	Http httpcfg.HttpCfg
+
+	DebugMux *http.ServeMux
 }
 
 // IPCEndpoint resolves an IPC endpoint based on a configured value, taking into

--- a/turbo/app/import_cmd.go
+++ b/turbo/app/import_cmd.go
@@ -80,7 +80,7 @@ func importChain(cliCtx *cli.Context) error {
 		return err
 	}
 
-	nodeCfg, err := turboNode.NewNodConfigUrfave(cliCtx, logger)
+	nodeCfg, err := turboNode.NewNodConfigUrfave(cliCtx, nil, logger)
 	if err != nil {
 		return err
 	}

--- a/turbo/app/make_app.go
+++ b/turbo/app/make_app.go
@@ -167,7 +167,7 @@ func doMigrateFlags(ctx *cli.Context) {
 }
 
 func NewNodeConfig(ctx *cli.Context, logger log.Logger) (*nodecfg.Config, error) {
-	nodeConfig, err := enode.NewNodConfigUrfave(ctx, logger)
+	nodeConfig, err := enode.NewNodConfigUrfave(ctx, nil, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -1884,13 +1884,19 @@ func doUploaderCommand(cliCtx *cli.Context) error {
 		return err
 	}
 
+	debugMux := metricsMux
+
+	if debugMux == nil {
+		debugMux = pprofMux
+	}
+
 	// initializing the node and providing the current git commit there
 
 	logger.Info("Build info", "git_branch", params.GitBranch, "git_tag", params.GitTag, "git_commit", params.GitCommit)
 	erigonInfoGauge := metrics.GetOrCreateGauge(fmt.Sprintf(`erigon_info{version="%s",commit="%s"}`, params.Version, params.GitCommit))
 	erigonInfoGauge.Set(1)
 
-	nodeCfg, err := node.NewNodConfigUrfave(cliCtx, logger)
+	nodeCfg, err := node.NewNodConfigUrfave(cliCtx, debugMux, logger)
 	if err != nil {
 		return err
 	}

--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -1888,6 +1888,8 @@ func doUploaderCommand(cliCtx *cli.Context) error {
 
 	if debugMux == nil {
 		debugMux = pprofMux
+	} else {
+		debugMux = http.DefaultServeMux
 	}
 
 	// initializing the node and providing the current git commit there

--- a/turbo/node/node.go
+++ b/turbo/node/node.go
@@ -24,6 +24,7 @@ import "C"
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/urfave/cli/v2"
 
@@ -87,7 +88,7 @@ type Params struct {
 	CustomBuckets kv.TableCfg
 }
 
-func NewNodConfigUrfave(ctx *cli.Context, logger log.Logger) (*nodecfg.Config, error) {
+func NewNodConfigUrfave(ctx *cli.Context, debugMux *http.ServeMux, logger log.Logger) (*nodecfg.Config, error) {
 	// If we're running a known preset, log it for convenience.
 	chain := ctx.String(utils.ChainFlag.Name)
 	switch chain {
@@ -117,7 +118,7 @@ func NewNodConfigUrfave(ctx *cli.Context, logger log.Logger) (*nodecfg.Config, e
 		logger.Info("Starting Erigon on", "devnet", chain)
 	}
 
-	nodeConfig := NewNodeConfig()
+	nodeConfig := NewNodeConfig(debugMux)
 	if err := utils.SetNodeConfig(ctx, nodeConfig, logger); err != nil {
 		return nil, err
 	}
@@ -166,7 +167,7 @@ func New(
 	return &ErigonNode{stack: node, backend: ethereum}, nil
 }
 
-func NewNodeConfig() *nodecfg.Config {
+func NewNodeConfig(debugMux *http.ServeMux) *nodecfg.Config {
 	nodeConfig := nodecfg.DefaultConfig
 	// see similar changes in `cmd/geth/config.go#defaultNodeConfig`
 	if commit := params.GitCommit; commit != "" {
@@ -176,5 +177,6 @@ func NewNodeConfig() *nodecfg.Config {
 	}
 	nodeConfig.IPCPath = "" // force-disable IPC endpoint
 	nodeConfig.Name = "erigon"
+	nodeConfig.DebugMux = debugMux
 	return &nodeConfig
 }


### PR DESCRIPTION
This passes the metrics or pprof mux top the downloader for torrents handling. 

Note the handler url is changed to: `/downloader/torrents`

Fixes: https://github.com/erigontech/erigon/issues/14637

