### PR TITLE
Use kev-gmp wrapper for modexp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "eest-fixtures"]
 	path = tests/execution-spec-tests
 	url = https://github.com/erigontech/eest-fixtures
+[submodule "erigon-lib/crypto/go-gmp"]
+	path = erigon-lib/crypto/go-gmp
+	url = https://github.com/kevaundray/go-gmp

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 replace (
 	github.com/crate-crypto/go-kzg-4844 => github.com/erigontech/go-kzg-4844 v0.0.0-20250130131058-ce13be60bc86
 	github.com/holiman/bloomfilter/v2 => github.com/AskAlexSharov/bloomfilter/v2 v2.0.9
+	github.com/kevaundray/go-gmp => ./erigon-lib/crypto/go-gmp
 )
 
 require (
@@ -69,6 +70,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.5.9
 	github.com/jinzhu/copier v0.4.0
 	github.com/json-iterator/go v1.1.12
+	github.com/kevaundray/go-gmp v0.0.0-00010101000000-000000000000
 	github.com/klauspost/compress v1.18.0
 	github.com/libp2p/go-libp2p v0.37.2
 	github.com/libp2p/go-libp2p-mplex v0.9.0


### PR DESCRIPTION
## Save Modexp

<br>

Kev\_GMP

```go
Running tool: /usr/bin/go test -benchmem -run=^$ -bench ^BenchmarkPrecompiledModExpEip7883$ github.com/erigontech/erigon/core/vm -v

goos: linux
goarch: amd64
pkg: github.com/erigontech/erigon/core/vm
cpu: AMD Ryzen 9 7945HX with Radeon Graphics
BenchmarkPrecompiledModExpEip7883
BenchmarkPrecompiledModExpEip7883/nagydani-1-square-Gas=500
BenchmarkPrecompiledModExpEip7883/nagydani-1-square-Gas=500-32         	  381579	      3265 ns/op	       500.0 gas/op	       153.1 mgas/s	     600 B/op	      17 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-1-qube-Gas=500
BenchmarkPrecompiledModExpEip7883/nagydani-1-qube-Gas=500-32           	  293965	      3975 ns/op	       500.0 gas/op	       125.8 mgas/s	     600 B/op	      17 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-1-pow0x10001-Gas=682
BenchmarkPrecompiledModExpEip7883/nagydani-1-pow0x10001-Gas=682-32     	  217688	      5236 ns/op	       682.0 gas/op	       130.2 mgas/s	     600 B/op	      17 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-2-square-Gas=500
BenchmarkPrecompiledModExpEip7883/nagydani-2-square-Gas=500-32         	  213771	      5355 ns/op	       500.0 gas/op	        93.36 mgas/s	     664 B/op	      17 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-2-qube-Gas=500
BenchmarkPrecompiledModExpEip7883/nagydani-2-qube-Gas=500-32           	  213031	      5765 ns/op	       500.0 gas/op	        86.73 mgas/s	     664 B/op	      17 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-2-pow0x10001-Gas=2730
BenchmarkPrecompiledModExpEip7883/nagydani-2-pow0x10001-Gas=2730-32    	  126565	      9226 ns/op	      2730 gas/op	       295.9 mgas/s	     664 B/op	      17 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-3-square-Gas=682
BenchmarkPrecompiledModExpEip7883/nagydani-3-square-Gas=682-32         	  147844	      8346 ns/op	       682.0 gas/op	        81.70 mgas/s	     792 B/op	      17 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-3-qube-Gas=682
BenchmarkPrecompiledModExpEip7883/nagydani-3-qube-Gas=682-32           	  128320	      9043 ns/op	       682.0 gas/op	        75.41 mgas/s	     792 B/op	      17 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-3-pow0x10001-Gas=10922
BenchmarkPrecompiledModExpEip7883/nagydani-3-pow0x10001-Gas=10922-32   	   56846	     20663 ns/op	     10922 gas/op	       528.6 mgas/s	     792 B/op	      17 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-4-square-Gas=2730
BenchmarkPrecompiledModExpEip7883/nagydani-4-square-Gas=2730-32        	   76582	     15830 ns/op	      2730 gas/op	       172.4 mgas/s	    1048 B/op	      17 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-4-qube-Gas=2730
BenchmarkPrecompiledModExpEip7883/nagydani-4-qube-Gas=2730-32          	   63066	     18643 ns/op	      2730 gas/op	       146.4 mgas/s	    1048 B/op	      17 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-4-pow0x10001-Gas=43690
BenchmarkPrecompiledModExpEip7883/nagydani-4-pow0x10001-Gas=43690-32   	   19635	     60687 ns/op	     43690 gas/op	       719.9 mgas/s	    1048 B/op	      17 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-5-square-Gas=10922
BenchmarkPrecompiledModExpEip7883/nagydani-5-square-Gas=10922-32       	   32479	     37036 ns/op	     10922 gas/op	       294.9 mgas/s	    1560 B/op	      17 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-5-qube-Gas=10922
BenchmarkPrecompiledModExpEip7883/nagydani-5-qube-Gas=10922-32         	   26271	     45187 ns/op	     10922 gas/op	       241.7 mgas/s	    1560 B/op	      17 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-5-pow0x10001-Gas=174762
BenchmarkPrecompiledModExpEip7883/nagydani-5-pow0x10001-Gas=174762-32  	    7572	    154199 ns/op	    174762 gas/op	      1133 mgas/s	    1560 B/op	      17 allocs/op
PASS
ok  	github.com/erigontech/erigon/core/vm	20.698s
```

<br>

Main branch

```go
Running tool: /usr/bin/go test -benchmem -run=^$ -bench ^BenchmarkPrecompiledModExpEip7883$ github.com/erigontech/erigon/core/vm -v

goos: linux
goarch: amd64
pkg: github.com/erigontech/erigon/core/vm
cpu: AMD Ryzen 9 7945HX with Radeon Graphics
BenchmarkPrecompiledModExpEip7883
BenchmarkPrecompiledModExpEip7883/nagydani-1-square-Gas=500
BenchmarkPrecompiledModExpEip7883/nagydani-1-square-Gas=500-32         	 1397978	       756.4 ns/op	       500.0 gas/op	       661.0 mgas/s	    1160 B/op	      18 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-1-qube-Gas=500
BenchmarkPrecompiledModExpEip7883/nagydani-1-qube-Gas=500-32           	 1266187	       926.3 ns/op	       500.0 gas/op	       539.8 mgas/s	    1448 B/op	      19 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-1-pow0x10001-Gas=682
BenchmarkPrecompiledModExpEip7883/nagydani-1-pow0x10001-Gas=682-32     	  240132	      4558 ns/op	       682.0 gas/op	       149.6 mgas/s	    1944 B/op	      22 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-2-square-Gas=500
BenchmarkPrecompiledModExpEip7883/nagydani-2-square-Gas=500-32         	 1077316	      1085 ns/op	       500.0 gas/op	       460.6 mgas/s	    1688 B/op	      18 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-2-qube-Gas=500
BenchmarkPrecompiledModExpEip7883/nagydani-2-qube-Gas=500-32           	  593110	      1730 ns/op	       500.0 gas/op	       289.1 mgas/s	    2232 B/op	      19 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-2-pow0x10001-Gas=2730
BenchmarkPrecompiledModExpEip7883/nagydani-2-pow0x10001-Gas=2730-32    	  117544	      9583 ns/op	      2730 gas/op	       284.9 mgas/s	    3129 B/op	      22 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-3-square-Gas=682
BenchmarkPrecompiledModExpEip7883/nagydani-3-square-Gas=682-32         	  501312	      2338 ns/op	       682.0 gas/op	       291.8 mgas/s	    2745 B/op	      18 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-3-qube-Gas=682
BenchmarkPrecompiledModExpEip7883/nagydani-3-qube-Gas=682-32           	  268306	      4014 ns/op	       682.0 gas/op	       169.9 mgas/s	    3961 B/op	      19 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-3-pow0x10001-Gas=10922
BenchmarkPrecompiledModExpEip7883/nagydani-3-pow0x10001-Gas=10922-32   	   45200	     26043 ns/op	     10922 gas/op	       419.4 mgas/s	    5690 B/op	      22 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-4-square-Gas=2730
BenchmarkPrecompiledModExpEip7883/nagydani-4-square-Gas=2730-32        	  188770	      6015 ns/op	      2730 gas/op	       453.9 mgas/s	    5018 B/op	      18 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-4-qube-Gas=2730
BenchmarkPrecompiledModExpEip7883/nagydani-4-qube-Gas=2730-32          	   89268	     12983 ns/op	      2730 gas/op	       210.3 mgas/s	   12062 B/op	      20 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-4-pow0x10001-Gas=43690
BenchmarkPrecompiledModExpEip7883/nagydani-4-pow0x10001-Gas=43690-32   	   13822	     86442 ns/op	     43690 gas/op	       505.4 mgas/s	   15519 B/op	      23 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-5-square-Gas=10922
BenchmarkPrecompiledModExpEip7883/nagydani-5-square-Gas=10922-32       	   69502	     16695 ns/op	     10922 gas/op	       654.2 mgas/s	    9696 B/op	      19 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-5-qube-Gas=10922
BenchmarkPrecompiledModExpEip7883/nagydani-5-qube-Gas=10922-32         	   30997	     37646 ns/op	     10922 gas/op	       290.1 mgas/s	   23660 B/op	      21 allocs/op
BenchmarkPrecompiledModExpEip7883/nagydani-5-pow0x10001-Gas=174762
BenchmarkPrecompiledModExpEip7883/nagydani-5-pow0x10001-Gas=174762-32  	    4497	    259884 ns/op	    174762 gas/op	       672.5 mgas/s	   32496 B/op	      39 allocs/op
PASS
ok  	github.com/erigontech/erigon/core/vm	23.357s
```

<br>