### PR TITLE
rpcdaemon: Re enable test on pruning 

### DIFF
--- a/erigon-lib/kv/remotedb/kv_remote.go
+++ b/erigon-lib/kv/remotedb/kv_remote.go
@@ -190,6 +190,8 @@ func (db *DB) ReloadSalt() error                                   { panic("not 
 func (db *DB) InvertedIdxTables(domain ...kv.InvertedIdx) []string { panic("not implemented") }
 func (db *DB) ReloadFiles() error                                  { panic("not implemented") }
 func (db *DB) BuildMissedAccessors(_ context.Context, _ int) error { panic("not implemented") }
+func (db *DB) EnableReadAhead() kv.TemporalDebugDB                 { panic("not implemented") }
+func (db *DB) DisableReadAhead()                                   { panic("not implemented") }
 
 func (db *DB) BeginTemporalRo(ctx context.Context) (kv.TemporalTx, error) {
 	t, err := db.BeginRo(ctx) //nolint:gocritic

--- a/erigon-lib/kv/remotedb/kv_remote.go
+++ b/erigon-lib/kv/remotedb/kv_remote.go
@@ -190,8 +190,6 @@ func (db *DB) ReloadSalt() error                                   { panic("not 
 func (db *DB) InvertedIdxTables(domain ...kv.InvertedIdx) []string { panic("not implemented") }
 func (db *DB) ReloadFiles() error                                  { panic("not implemented") }
 func (db *DB) BuildMissedAccessors(_ context.Context, _ int) error { panic("not implemented") }
-func (db *DB) EnableReadAhead() kv.TemporalDebugDB                 { panic("not implemented") }
-func (db *DB) DisableReadAhead()                                   { panic("not implemented") }
 
 func (db *DB) BeginTemporalRo(ctx context.Context) (kv.TemporalTx, error) {
 	t, err := db.BeginRo(ctx) //nolint:gocritic
@@ -237,9 +235,28 @@ func (db *DB) UpdateNosync(ctx context.Context, f func(tx kv.RwTx) error) (err e
 	return errors.New("remote db provider doesn't support .UpdateNosync method")
 }
 
-func (tx *tx) AggTx() any                       { panic("not implemented") }
-func (tx *tx) Debug() kv.TemporalDebugTx        { panic("not implemented") }
-func (tx *tx) FreezeInfo() kv.FreezeInfo        { panic("not implemented") }
+func (tx *tx) AggTx() any                           { panic("not implemented") }
+func (tx *tx) Debug() kv.TemporalDebugTx            { return kv.TemporalDebugTx(tx) }
+func (tx *tx) FreezeInfo() kv.FreezeInfo            { panic("not implemented") }
+func (tx *tx) CanUnwindToBlockNum() (uint64, error) { panic("not implemented") }
+func (tx *tx) CanUnwindBeforeBlockNum(blockNum uint64) (unwindableBlockNum uint64, ok bool, err error) {
+	panic("not implemented")
+}
+func (tx *tx) DomainFiles(domain ...kv.Domain) kv.VisibleFiles { panic("not implemented") }
+func (tx *tx) DomainProgress(domain kv.Domain) uint64          { panic("not implemented") }
+func (tx *tx) GetLatestFromDB(domain kv.Domain, k []byte) (v []byte, step uint64, found bool, err error) {
+	panic("not implemented")
+}
+func (tx *tx) GetLatestFromFiles(domain kv.Domain, k []byte, maxTxNum uint64) (v []byte, found bool, fileStartTxNum uint64, fileEndTxNum uint64, err error) {
+	panic("not implemented")
+}
+func (tx *tx) IIProgress(domain kv.InvertedIdx) uint64 { panic("not implemented") }
+func (tx *tx) RangeLatest(domain kv.Domain, from, to []byte, limit int) (stream.KV, error) {
+	panic("not implemented")
+}
+func (tx *tx) StepSize() uint64                                     { panic("not implemented") }
+func (tx *tx) TxNumsInFiles(domains ...kv.Domain) (minTxNum uint64) { panic("not implemented") }
+
 func (db *DB) OnFilesChange(f kv.OnFilesChange) { panic("not implemented") }
 
 func (tx *tx) ViewID() uint64  { return tx.viewID }

--- a/rpc/rpchelper/helper.go
+++ b/rpc/rpchelper/helper.go
@@ -170,9 +170,9 @@ func CreateHistoryStateReader(tx kv.TemporalTx, blockNumber uint64, txnIndex int
 	}
 	txNum := uint64(int(minTxNum) + txnIndex + /* 1 system txNum in beginning of block */ 1)
 
-	//if txNum < r.StateHistoryStartFrom() {
-	//	return r, state.PrunedError
-	//}
+	if txNum < r.StateHistoryStartFrom() {
+		return r, state.PrunedError
+	}
 	r.SetTxNum(txNum)
 	return r, nil
 }


### PR DESCRIPTION
Implemented the Debug() interface method on remoteKV to permit to re-enable test on pruning