### PR TITLE
txnprovider/shutter: fix missing return on err in connectBootstrapNodes

### DIFF
--- a/txnprovider/shutter/decryption_keys_listener.go
+++ b/txnprovider/shutter/decryption_keys_listener.go
@@ -235,6 +235,7 @@ func (dkl DecryptionKeysListener) connectBootstrapNodes(ctx context.Context, hos
 			err = backoff.Retry(connect, backoff.WithContext(backoff.NewExponentialBackOff(), ctx))
 			if err != nil {
 				dkl.logger.Error("failed to connect to bootstrap node", "node", node, "err", err)
+				return nil
 			}
 
 			dkl.logger.Info("connected to bootstrap node", "node", node)


### PR DESCRIPTION
in case of connect err return early so that we dont increment `connected.Add(1)`