### PR TITLE
relax state prune calculation in snapshot download

### DIFF
--- a/cmd/scripts/mirror-datadir.sh
+++ b/cmd/scripts/mirror-datadir.sh
@@ -67,7 +67,7 @@ process_file() {
         # Symlink all other files
         if [ "$(readlink "$destination$rel_path" 2>/dev/null)" != "$file" ]; then
             echo "Linking: $file"
-            ln -sf "$file" "$destination$rel_path"
+            ln -f "$file" "$destination$rel_path"
         fi
     fi
 }

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -140,6 +140,9 @@ func (se *serialExecutor) execute(ctx context.Context, tasks []*state.TxTask, gp
 						prevTask.Final = false
 						prevTask.HistoryExecution = true
 						se.applyWorker.RunTxTaskNoLock(&prevTask, se.isMining, se.skipPostEvaluation)
+						if prevTask.Error != nil {
+							return false, fmt.Errorf("error while finding last receipt: %w", prevTask.Error)
+						}
 						prevTask.CreateReceipt(se.applyTx.(kv.TemporalTx))
 						lastReceipt = txTask.BlockReceipts[txTask.TxIndex-1]
 					} else {


### PR DESCRIPTION
- fast fail if fallback lastTx exec produces errors
- remove `adjustStepPrune` -- it's rounding "state prune point" to greater values for certain inputs. But now the logic needs to be more stringent as mechanisms like receipt fallback rely on history files being actually present. e.g. amoy has last state step 48, which was rounded to 64. 


issue: https://github.com/erigontech/erigon/issues/16004

