### PR TITLE
[r30] qa: improve RPC Integration Tests + add Gnosis/Polygon workflows

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests-gnosis.yml
+++ b/.github/workflows/qa-rpc-integration-tests-gnosis.yml
@@ -1,0 +1,204 @@
+name: QA - RPC Integration Tests (Gnosis)
+
+on:
+  workflow_dispatch:     # Run manually
+  push:
+    branches:
+      - main
+      - 'release/3.*'
+  pull_request:
+    branches:
+      - main
+      - 'release/3.*'
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+
+jobs:
+  gnosis-rpc-integ-tests:
+    concurrency:
+      group: >-
+        ${{
+          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && 
+          format('{0}-{1}', github.workflow, github.run_id) ||
+          format('{0}-{1}', github.workflow, github.ref)
+        }}
+      cancel-in-progress: true
+    runs-on: [ self-hosted, qa, rpc-integration, Gnosis ]
+    env:
+      ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/gnosis-reference-version/datadir
+      ERIGON_TESTBED_AREA: /opt/erigon-testbed
+      ERIGON_QA_PATH: /home/qarunner/erigon-qa
+      ERIGON_ASSERT: true
+      RPC_PAST_TEST_DIR: /opt/rpc-past-tests
+      CHAIN: gnosis
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Checkout RPC Tests Repository & Install Requirements
+        run: |
+          rm -rf ${{ runner.workspace }}/rpc-tests
+          git -c advice.detachedHead=false clone --depth 1 --branch main https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
+          cd ${{ runner.workspace }}/rpc-tests
+          pip3 install -r requirements.txt
+
+      - name: Clean Erigon Build Directory
+        run: |
+          make clean
+
+      - name: Build Erigon RPCDaemon
+        run: |
+          make rpcdaemon
+        working-directory: ${{ github.workspace }}
+
+      - name: Pause the Erigon instance dedicated to db maintenance
+        run: |
+          python3 $ERIGON_QA_PATH/test_system/db-producer/pause_production.py || true
+
+      - name: Save Erigon Chaindata Directory
+        id: save_chaindata_step
+        run: |
+          rm -rf $ERIGON_TESTBED_AREA/chaindata-prev || true
+          echo "Backup chaindata"
+          cp -r $ERIGON_REFERENCE_DATA_DIR/chaindata $ERIGON_TESTBED_AREA/chaindata-prev
+
+      - name: Run RpcDaemon
+        working-directory: ${{ github.workspace }}/build/bin
+        run: |
+          echo "Starting RpcDaemon..."
+          
+          ./rpcdaemon --datadir $ERIGON_REFERENCE_DATA_DIR --http.api admin,debug,eth,parity,erigon,trace,web3,txpool,ots,net --ws > erigon.log 2>&1 &
+
+          RPC_DAEMON_PID=$!          
+          RPC_DAEMON_EXIT_STATUS=$?
+          echo "RPC_DAEMON_PID=$RPC_DAEMON_PID" >> $GITHUB_ENV
+          echo "rpc_daemon_started=true" >> $GITHUB_OUTPUT
+          
+          sleep 5
+          tail erigon.log
+          
+          if [ $RPC_DAEMON_EXIT_STATUS -ne 0 ]; then            
+            echo "RpcDaemon failed to start"
+            echo "::error::Error detected during tests: RpcDaemon failed to start"
+            exit 1
+          fi
+          echo "RpcDaemon started"
+
+      - name: Wait for port 8545 to be opened
+        run: |
+          for i in {1..30}; do
+            if nc -z localhost 8545; then
+              echo "Port 8545 is open"
+              break
+            fi
+            echo "Waiting for port 8545 to open..."
+            sleep 10
+          done
+          if ! nc -z localhost 8545; then
+            echo "Port 8545 did not open in time"
+            echo "::error::Error detected during tests: Port 8545 did not open in time"
+            exit 1
+          fi
+
+      - name: Run RPC Integration Tests
+        id: test_step
+        run: |
+          set +e # Disable exit on error
+          commit=$(git -C ${{runner.workspace}}/erigon rev-parse --short HEAD)
+
+          cd ${{ runner.workspace }}/rpc-tests/integration
+          rm -rf ./gnosis/results/
+                    
+          # Run RPC integration test runner via http
+          chmod +x ${{ runner.workspace }}/erigon/.github/workflows/scripts/run_rpc_tests_gnosis.sh
+          ${{ runner.workspace }}/erigon/.github/workflows/scripts/run_rpc_tests_gnosis.sh
+          
+          # Capture test runner script exit status
+          test_exit_status=$?
+          
+          # Save the subsection reached status
+          echo "test_executed=true" >> $GITHUB_OUTPUT
+          
+          # Check test runner exit status
+          if [ $test_exit_status -eq 0 ]; then
+            echo "tests completed successfully"
+            echo
+            echo "TEST_RESULT=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "error detected during tests"
+            echo "TEST_RESULT=failure" >> "$GITHUB_OUTPUT"
+          
+            # Save failed results to a directory with timestamp and commit hash
+            cp -r ${{ runner.workspace }}/rpc-tests/integration/gnosis/results/ $RPC_PAST_TEST_DIR/gnosis_$(date +%Y%m%d_%H%M%S)_integration_$commit_http/
+          fi
+
+      - name: Stop Erigon RpcDaemon
+        if: always()
+        working-directory: ${{ github.workspace }}/build/bin
+        run: |
+          # Clean up rpcdaemon process if it's still running
+          if [ -n "$RPC_DAEMON_PID" ] && kill -0 $RPC_DAEMON_PID 2> /dev/null; then
+            echo "RpcDaemon stopping..."
+            kill $RPC_DAEMON_PID
+            echo "RpcDaemon stopped"
+          else
+            echo "RpcDaemon has already terminated"
+          fi
+
+      - name: Restore Erigon Chaindata Directory
+        if: ${{ always() }}
+        run: |
+          if [ -d "$ERIGON_TESTBED_AREA/chaindata-prev" ] && [ "${{ steps.save_chaindata_step.outcome }}" == "success" ]; then
+          rm -rf $ERIGON_REFERENCE_DATA_DIR/chaindata
+          echo "Restore chaindata"
+          mv $ERIGON_TESTBED_AREA/chaindata-prev $ERIGON_REFERENCE_DATA_DIR/chaindata
+          fi
+
+      - name: Resume the Erigon instance dedicated to db maintenance
+        if: ${{ always() }}
+        run: |
+          python3 $ERIGON_QA_PATH/test_system/db-producer/resume_production.py || true
+
+      - name: Upload test results
+        if: steps.test_step.outputs.test_executed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: ${{ runner.workspace }}/rpc-tests/integration/gnosis/results/
+
+      - name: Save test results
+        if: steps.test_step.outputs.test_executed == 'true'
+        working-directory: ${{ github.workspace }}
+        env:
+          TEST_RESULT: ${{ steps.test_step.outputs.TEST_RESULT }}
+        run: |
+          db_version=$(python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/prod_info.py $ERIGON_REFERENCE_DATA_DIR/../production.ini production erigon_repo_commit)
+          if [ -z "$db_version" ]; then
+            db_version="no-version"
+          fi
+          
+          python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py --repo erigon --commit $(git rev-parse HEAD) --branch ${{ github.ref_name }} --test_name rpc-integration-tests --chain $CHAIN --runner ${{ runner.name }} --db_version $db_version --outcome $TEST_RESULT #--result_file ${{ github.workspace }}/result-$CHAIN.json
+
+      - name: Action to check failure condition
+        if: failure()
+        run: |
+          if [ "${{ steps.test_step.outputs.test_executed }}" != "true" ]; then
+            echo "::error::Test not executed, workflow failed for infrastructure reasons"
+          fi
+          exit 1
+
+      - name: Action for Success
+        if: steps.test_step.outputs.TEST_RESULT == 'success'
+        run: echo "::notice::Tests completed successfully"
+
+      - name: Action for Failure
+        if: steps.test_step.outputs.TEST_RESULT != 'success'
+        run: |
+          echo "::error::Error detected during tests: some tests failed, check the logs or the artifacts for more details"
+          exit 1
+

--- a/.github/workflows/qa-rpc-integration-tests-gnosis.yml
+++ b/.github/workflows/qa-rpc-integration-tests-gnosis.yml
@@ -40,13 +40,6 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Checkout RPC Tests Repository & Install Requirements
-        run: |
-          rm -rf ${{ runner.workspace }}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch main https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
-          cd ${{ runner.workspace }}/rpc-tests
-          pip3 install -r requirements.txt
-
       - name: Clean Erigon Build Directory
         run: |
           make clean
@@ -108,33 +101,26 @@ jobs:
       - name: Run RPC Integration Tests
         id: test_step
         run: |
-          set +e # Disable exit on error
           commit=$(git -C ${{runner.workspace}}/erigon rev-parse --short HEAD)
+          TEST_RESULT_DIR="$RPC_PAST_TEST_DIR/gnosis_$(date +%Y%m%d_%H%M%S)_integration_${commit}_http/"
+          echo "TEST_RESULT_DIR=$TEST_RESULT_DIR" >> $GITHUB_ENV
 
-          cd ${{ runner.workspace }}/rpc-tests/integration
-          rm -rf ./gnosis/results/
-                    
-          # Run RPC integration test runner via http
           chmod +x ${{ runner.workspace }}/erigon/.github/workflows/scripts/run_rpc_tests_gnosis.sh
-          ${{ runner.workspace }}/erigon/.github/workflows/scripts/run_rpc_tests_gnosis.sh
-          
-          # Capture test runner script exit status
-          test_exit_status=$?
-          
-          # Save the subsection reached status
+
+          set +e # Disable exit on error for test run
+          ${{ runner.workspace }}/erigon/.github/workflows/scripts/run_rpc_tests_gnosis.sh ${{ runner.workspace }} $TEST_RESULT_DIR
+          test_exit_status=$? # Capture test runner script exit status
+          set -e # Re-enable exit on error after test run
+
           echo "test_executed=true" >> $GITHUB_OUTPUT
-          
-          # Check test runner exit status
+
+          echo
           if [ $test_exit_status -eq 0 ]; then
-            echo "tests completed successfully"
-            echo
+            echo "RPC tests completed successfully"
             echo "TEST_RESULT=success" >> "$GITHUB_OUTPUT"
           else
-            echo "error detected during tests"
+            echo "Error detected during RPC tests"
             echo "TEST_RESULT=failure" >> "$GITHUB_OUTPUT"
-          
-            # Save failed results to a directory with timestamp and commit hash
-            cp -r ${{ runner.workspace }}/rpc-tests/integration/gnosis/results/ $RPC_PAST_TEST_DIR/gnosis_$(date +%Y%m%d_%H%M%S)_integration_$commit_http/
           fi
 
       - name: Stop Erigon RpcDaemon
@@ -169,7 +155,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-results
-          path: ${{ runner.workspace }}/rpc-tests/integration/gnosis/results/
+          path: $TEST_RESULT_DIR
 
       - name: Save test results
         if: steps.test_step.outputs.test_executed == 'true'

--- a/.github/workflows/qa-rpc-integration-tests-polygon.yml
+++ b/.github/workflows/qa-rpc-integration-tests-polygon.yml
@@ -1,0 +1,176 @@
+name: QA - RPC Integration Tests (Polygon)
+
+on:
+  workflow_dispatch:     # Run manually
+  push:
+    branches:
+      - main
+      - 'release/3.*'
+  pull_request:
+    branches:
+      - main
+      - 'release/3.*'
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  integration-test-suite:
+    runs-on: [ self-hosted, qa, Polygon ]
+    timeout-minutes: 15
+    env:
+      ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version/datadir
+      ERIGON_TESTBED_DATA_DIR: /opt/erigon-testbed/datadir
+      ERIGON_QA_PATH: /home/qarunner/erigon-qa
+      RPC_PAST_TEST_DIR: /opt/rpc-past-tests
+      CHAIN: bor-mainnet
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Checkout RPC Tests Repository & Install Requirements
+        run: |
+          rm -rf ${{ runner.workspace }}/rpc-tests
+          git -c advice.detachedHead=false clone --depth 1 --branch v1.55.1 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
+          cd ${{ runner.workspace }}/rpc-tests
+          pip3 install -r requirements.txt
+
+      - name: Clean Erigon Build Directory
+        run: |
+          make clean
+
+      - name: Build Erigon RPCDaemon
+        run: |
+          make rpcdaemon
+        working-directory: ${{ github.workspace }}
+
+      - name: Pause the Erigon instance dedicated to db maintenance
+        run: |
+          python3 $ERIGON_QA_PATH/test_system/db-producer/pause_production.py || true
+
+      - name: Run RpcDaemon
+        working-directory: ${{ github.workspace }}/build/bin
+        run: |
+          echo "Starting RpcDaemon..."
+          
+          ./rpcdaemon --datadir $ERIGON_REFERENCE_DATA_DIR --http.api bor,admin,debug,eth,parity,erigon,trace,web3,txpool,ots,net --ws > erigon.log 2>&1 &
+
+          RPC_DAEMON_PID=$!          
+          RPC_DAEMON_EXIT_STATUS=$?
+          echo "RPC_DAEMON_PID=$RPC_DAEMON_PID" >> $GITHUB_ENV
+          
+          sleep 5
+          tail erigon.log
+          
+          if [ $RPC_DAEMON_EXIT_STATUS -ne 0 ]; then            
+            echo "RpcDaemon failed to start"
+            echo "::error::Error detected during tests: RpcDaemon failed to start"
+            exit 1
+          fi
+          echo "RpcDaemon started"
+
+      - name: Wait for port 8545 to be opened
+        run: |
+          for i in {1..30}; do
+            if nc -z localhost 8545; then
+              echo "Port 8545 is open"
+              break
+            fi
+            echo "Waiting for port 8545 to open..."
+            sleep 10
+          done
+          if ! nc -z localhost 8545; then
+            echo "Port 8545 did not open in time"
+            echo "::error::Error detected during tests: Port 8545 did not open in time"
+            exit 1
+          fi
+
+      - name: Run RPC Integration Tests
+        id: test_step
+        run: |
+          set +e # Disable exit on error
+          commit=$(git -C ${{runner.workspace}}/erigon rev-parse --short HEAD)
+
+          cd ${{ runner.workspace }}/rpc-tests/integration
+          rm -rf ./polygon-pos/results/
+                    
+          # Run RPC integration test runner via http
+          chmod +x ${{ runner.workspace }}/erigon/.github/workflows/scripts/run_rpc_tests_polygon.sh
+          ${{ runner.workspace }}/erigon/.github/workflows/scripts/run_rpc_tests_polygon.sh
+          
+          # Capture test runner script exit status
+          test_exit_status=$?
+          
+          # Save the subsection reached status
+          echo "test_executed=true" >> $GITHUB_OUTPUT
+          
+          # Check test runner exit status
+          if [ $test_exit_status -eq 0 ]; then
+            echo "tests completed successfully"
+            echo
+            echo "TEST_RESULT=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "error detected during tests"
+            echo "TEST_RESULT=failure" >> "$GITHUB_OUTPUT"
+          
+            # Save failed results to a directory with timestamp and commit hash
+            cp -r ${{ runner.workspace }}/rpc-tests/integration/polygon-pos/results/ $RPC_PAST_TEST_DIR/polygon-pos_$(date +%Y%m%d_%H%M%S)_integration_$commit_http/
+          fi
+
+      - name: Stop Erigon RpcDaemon
+        working-directory: ${{ github.workspace }}/build/bin
+        run: |
+          # Clean up rpcdaemon process if it's still running
+          if kill -0 $RPC_DAEMON_PID 2> /dev/null; then
+            echo "RpcDaemon stopping..."
+            kill $RPC_DAEMON_PID
+            echo "RpcDaemon stopped"
+          else
+            echo "RpcDaemon has already terminated"
+          fi
+
+      - name: Resume the Erigon instance dedicated to db maintenance
+        run: |
+          python3 $ERIGON_QA_PATH/test_system/db-producer/resume_production.py || true
+
+      - name: Upload test results
+        if: steps.test_step.outputs.test_executed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: ${{ runner.workspace }}/rpc-tests/integration/polygon-pos/results/
+
+      - name: Save test results
+        if: steps.test_step.outputs.test_executed == 'true'
+        working-directory: ${{ github.workspace }}
+        env:
+          TEST_RESULT: ${{ steps.test_step.outputs.TEST_RESULT }}
+        run: |
+          db_version=$(python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/prod_info.py $ERIGON_REFERENCE_DATA_DIR/../production.ini production erigon_repo_commit)
+          if [ -z "$db_version" ]; then
+            db_version="no-version"
+          fi
+          
+          python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py --repo erigon --commit $(git rev-parse HEAD) --branch ${{ github.ref_name }} --test_name rpc-integration-tests --chain $CHAIN --runner ${{ runner.name }} --db_version $db_version --outcome $TEST_RESULT #--result_file ${{ github.workspace }}/result-$CHAIN.json
+
+      - name: Action to check failure condition
+        if: failure()
+        run: |
+          if [ "${{ steps.test_step.outputs.test_executed }}" != "true" ]; then
+            echo "::warning::Test not executed, workflow failed for infrastructure reasons"
+          fi
+          #exit 1
+          
+      - name: Action for Success
+        if: steps.test_step.outputs.TEST_RESULT == 'success'
+        run: echo "::notice::Tests completed successfully"
+
+      - name: Action for Failure
+        if: steps.test_step.outputs.TEST_RESULT != 'success'
+        run: |
+          echo "::error::Error detected during tests: some tests failed, check the logs or the artifacts for more details"
+          exit 1
+

--- a/.github/workflows/qa-rpc-integration-tests-polygon.yml
+++ b/.github/workflows/qa-rpc-integration-tests-polygon.yml
@@ -16,14 +16,23 @@ on:
       - synchronize
       - ready_for_review
 
+
 jobs:
-  integration-test-suite:
+  bor-mainnet-rpc-integ-tests:
+    concurrency:
+      group: >-
+        ${{
+          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && 
+          format('{0}-{1}', github.workflow, github.run_id) ||
+          format('{0}-{1}', github.workflow, github.ref)
+        }}
+      cancel-in-progress: true
     runs-on: [ self-hosted, qa, Polygon ]
-    timeout-minutes: 15
     env:
       ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version/datadir
-      ERIGON_TESTBED_DATA_DIR: /opt/erigon-testbed/datadir
+      ERIGON_TESTBED_AREA: /opt/erigon-testbed
       ERIGON_QA_PATH: /home/qarunner/erigon-qa
+      ERIGON_ASSERT: true
       RPC_PAST_TEST_DIR: /opt/rpc-past-tests
       CHAIN: bor-mainnet
 
@@ -51,6 +60,13 @@ jobs:
         run: |
           python3 $ERIGON_QA_PATH/test_system/db-producer/pause_production.py || true
 
+      - name: Save Erigon Chaindata Directory
+        id: save_chaindata_step
+        run: |
+          rm -rf $ERIGON_TESTBED_AREA/chaindata-prev || true
+          echo "Backup chaindata"
+          cp -r $ERIGON_REFERENCE_DATA_DIR/chaindata $ERIGON_TESTBED_AREA/chaindata-prev
+
       - name: Run RpcDaemon
         working-directory: ${{ github.workspace }}/build/bin
         run: |
@@ -61,6 +77,7 @@ jobs:
           RPC_DAEMON_PID=$!          
           RPC_DAEMON_EXIT_STATUS=$?
           echo "RPC_DAEMON_PID=$RPC_DAEMON_PID" >> $GITHUB_ENV
+          echo "rpc_daemon_started=true" >> $GITHUB_OUTPUT
           
           sleep 5
           tail erigon.log
@@ -121,10 +138,11 @@ jobs:
           fi
 
       - name: Stop Erigon RpcDaemon
+        if: always()
         working-directory: ${{ github.workspace }}/build/bin
         run: |
           # Clean up rpcdaemon process if it's still running
-          if kill -0 $RPC_DAEMON_PID 2> /dev/null; then
+          if [ -n "$RPC_DAEMON_PID" ] && kill -0 $RPC_DAEMON_PID 2> /dev/null; then
             echo "RpcDaemon stopping..."
             kill $RPC_DAEMON_PID
             echo "RpcDaemon stopped"
@@ -132,7 +150,17 @@ jobs:
             echo "RpcDaemon has already terminated"
           fi
 
+      - name: Restore Erigon Chaindata Directory
+        if: ${{ always() }}
+        run: |
+          if [ -d "$ERIGON_TESTBED_AREA/chaindata-prev" ] && [ "${{ steps.save_chaindata_step.outcome }}" == "success" ]; then
+          rm -rf $ERIGON_REFERENCE_DATA_DIR/chaindata
+          echo "Restore chaindata"
+          mv $ERIGON_TESTBED_AREA/chaindata-prev $ERIGON_REFERENCE_DATA_DIR/chaindata
+          fi
+
       - name: Resume the Erigon instance dedicated to db maintenance
+        if: ${{ always() }}
         run: |
           python3 $ERIGON_QA_PATH/test_system/db-producer/resume_production.py || true
 
@@ -160,10 +188,10 @@ jobs:
         if: failure()
         run: |
           if [ "${{ steps.test_step.outputs.test_executed }}" != "true" ]; then
-            echo "::warning::Test not executed, workflow failed for infrastructure reasons"
+            echo "::error::Test not executed, workflow failed for infrastructure reasons"
           fi
-          #exit 1
-          
+          exit 1
+
       - name: Action for Success
         if: steps.test_step.outputs.TEST_RESULT == 'success'
         run: echo "::notice::Tests completed successfully"

--- a/.github/workflows/qa-rpc-integration-tests-polygon.yml
+++ b/.github/workflows/qa-rpc-integration-tests-polygon.yml
@@ -40,13 +40,6 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Checkout RPC Tests Repository & Install Requirements
-        run: |
-          rm -rf ${{ runner.workspace }}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch v1.55.1 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
-          cd ${{ runner.workspace }}/rpc-tests
-          pip3 install -r requirements.txt
-
       - name: Clean Erigon Build Directory
         run: |
           make clean
@@ -108,33 +101,26 @@ jobs:
       - name: Run RPC Integration Tests
         id: test_step
         run: |
-          set +e # Disable exit on error
           commit=$(git -C ${{runner.workspace}}/erigon rev-parse --short HEAD)
+          TEST_RESULT_DIR="$RPC_PAST_TEST_DIR/polygon_$(date +%Y%m%d_%H%M%S)_integration_${commit}_http/"
+          echo "TEST_RESULT_DIR=$TEST_RESULT_DIR" >> $GITHUB_ENV
 
-          cd ${{ runner.workspace }}/rpc-tests/integration
-          rm -rf ./polygon-pos/results/
-                    
-          # Run RPC integration test runner via http
           chmod +x ${{ runner.workspace }}/erigon/.github/workflows/scripts/run_rpc_tests_polygon.sh
-          ${{ runner.workspace }}/erigon/.github/workflows/scripts/run_rpc_tests_polygon.sh
           
-          # Capture test runner script exit status
-          test_exit_status=$?
-          
-          # Save the subsection reached status
+          set +e # Disable exit on error for test run
+          ${{ runner.workspace }}/erigon/.github/workflows/scripts/run_rpc_tests_polygon.sh ${{ runner.workspace }} $TEST_RESULT_DIR
+          test_exit_status=$? # Capture test runner script exit status
+          set -e # Re-enable exit on error after test run
+
           echo "test_executed=true" >> $GITHUB_OUTPUT
-          
-          # Check test runner exit status
+
+          echo
           if [ $test_exit_status -eq 0 ]; then
-            echo "tests completed successfully"
-            echo
+            echo "RPC tests completed successfully"
             echo "TEST_RESULT=success" >> "$GITHUB_OUTPUT"
           else
-            echo "error detected during tests"
+            echo "Error detected during RPC tests"
             echo "TEST_RESULT=failure" >> "$GITHUB_OUTPUT"
-          
-            # Save failed results to a directory with timestamp and commit hash
-            cp -r ${{ runner.workspace }}/rpc-tests/integration/polygon-pos/results/ $RPC_PAST_TEST_DIR/polygon-pos_$(date +%Y%m%d_%H%M%S)_integration_$commit_http/
           fi
 
       - name: Stop Erigon RpcDaemon
@@ -169,7 +155,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-results
-          path: ${{ runner.workspace }}/rpc-tests/integration/polygon-pos/results/
+          path: $TEST_RESULT_DIR
 
       - name: Save test results
         if: steps.test_step.outputs.test_executed == 'true'

--- a/.github/workflows/qa-rpc-integration-tests-polygon.yml
+++ b/.github/workflows/qa-rpc-integration-tests-polygon.yml
@@ -19,6 +19,7 @@ on:
 
 jobs:
   bor-mainnet-rpc-integ-tests:
+    if: false  # DISABLED WORKFLOW
     concurrency:
       group: >-
         ${{

--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -37,13 +37,6 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Checkout RPC Tests Repository & Install Requirements
-        run: |
-          rm -rf ${{ runner.workspace }}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch release/3.0  https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
-          cd ${{ runner.workspace }}/rpc-tests
-          pip3 install -r requirements.txt
-
       - name: Clean Erigon Build Directory
         run: |
           make clean
@@ -105,33 +98,26 @@ jobs:
       - name: Run RPC Integration Tests
         id: test_step
         run: |
-          set +e # Disable exit on error
           commit=$(git -C ${{runner.workspace}}/erigon rev-parse --short HEAD)
+          TEST_RESULT_DIR="$RPC_PAST_TEST_DIR/mainnet_$(date +%Y%m%d_%H%M%S)_integration_${commit}_http/"
+          echo "TEST_RESULT_DIR=$TEST_RESULT_DIR" >> $GITHUB_ENV
 
-          cd ${{ runner.workspace }}/rpc-tests/integration
-          rm -rf ./mainnet/results/
-                    
-          # Run RPC integration test runner via http
           chmod +x ${{ runner.workspace }}/erigon/.github/workflows/scripts/run_rpc_tests.sh
-          ${{ runner.workspace }}/erigon/.github/workflows/scripts/run_rpc_tests.sh
-          
+          set +e # Disable exit on error for test run
+          ${{ runner.workspace }}/erigon/.github/workflows/scripts/run_rpc_tests.sh ${{ runner.workspace }} $TEST_RESULT_DIR
           # Capture test runner script exit status
           test_exit_status=$?
-          
-          # Save the subsection reached status
+          set -e # Re-enable exit on error after test run
+
           echo "test_executed=true" >> $GITHUB_OUTPUT
-          
-          # Check test runner exit status
+
+          echo
           if [ $test_exit_status -eq 0 ]; then
-            echo "tests completed successfully"
-            echo
+            echo "RPC tests completed successfully"
             echo "TEST_RESULT=success" >> "$GITHUB_OUTPUT"
           else
-            echo "error detected during tests"
+            echo "Error detected during RPC tests"
             echo "TEST_RESULT=failure" >> "$GITHUB_OUTPUT"
-          
-            # Save failed results to a directory with timestamp and commit hash
-            cp -r ${{ runner.workspace }}/rpc-tests/integration/mainnet/results/ $RPC_PAST_TEST_DIR/mainnet_$(date +%Y%m%d_%H%M%S)_integration_$commit_http/
           fi
 
       - name: Stop Erigon RpcDaemon
@@ -166,7 +152,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-results
-          path: ${{ runner.workspace }}/rpc-tests/integration/mainnet/results/
+          path: $TEST_RESULT_DIR
 
       - name: Save test results
         if: steps.test_step.outputs.test_executed == 'true'

--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -102,11 +102,11 @@ jobs:
           TEST_RESULT_DIR="$RPC_PAST_TEST_DIR/mainnet_$(date +%Y%m%d_%H%M%S)_integration_${commit}_http/"
           echo "TEST_RESULT_DIR=$TEST_RESULT_DIR" >> $GITHUB_ENV
 
-          chmod +x ${{ runner.workspace }}/erigon/.github/workflows/scripts/run_rpc_tests.sh
+          chmod +x ${{ runner.workspace }}/erigon/.github/workflows/scripts/run_rpc_tests_ethereum.sh
+          
           set +e # Disable exit on error for test run
-          ${{ runner.workspace }}/erigon/.github/workflows/scripts/run_rpc_tests.sh ${{ runner.workspace }} $TEST_RESULT_DIR
-          # Capture test runner script exit status
-          test_exit_status=$?
+          ${{ runner.workspace }}/erigon/.github/workflows/scripts/run_rpc_tests_ethereum.sh ${{ runner.workspace }} $TEST_RESULT_DIR
+          test_exit_status=$? # Capture test runner script exit status
           set -e # Re-enable exit on error after test run
 
           echo "test_executed=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/qa-rpc-performance-tests.yml
+++ b/.github/workflows/qa-rpc-performance-tests.yml
@@ -14,21 +14,14 @@ concurrency:
 
 jobs:
   mainnet-rpc-perf-tests:
-    strategy:
-      matrix:
-        include:
-          - chain: mainnet
-            backend: RpcSpecific
-          #- chain: bor-mainnet
-          #  backend: Polygon
-    runs-on: [ self-hosted, qa, "${{ matrix.backend }}" ]
+    runs-on: [ self-hosted, qa, Ethereum, rpc-performance ]
     env:
       ERIGON_REFERENCE_DIR: /opt/erigon-versions/reference-version-3
       ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version-3/datadir
       ERIGON_TESTBED_AREA: /opt/erigon-testbed
       RPC_PAST_TEST_DIR: /opt/rpc-past-tests
       ERIGON_QA_PATH: /home/qarunner/erigon-qa
-      CHAIN: ${{ matrix.chain }}
+      CHAIN: mainnet
 
     steps:
       - name: Checkout Erigon repository

--- a/.github/workflows/scripts/run_rpc_tests.sh
+++ b/.github/workflows/scripts/run_rpc_tests.sh
@@ -1,18 +1,30 @@
 #!/bin/bash
-set -e
+set -e # Enable exit on error
 
-# Accept WORKSPACE as the first argument, default to /tmp directory if not provided
-WORKSPACE="${1:-/tmp}"
-# Accept RESULT_DIR as the second argument, do not set a default
-RESULT_DIR="$2"
+# Sanity check for mandatory parameters
+if [ -z "$1" ] || [ -z "$2" ]; then
+  echo "Usage: $0 <CHAIN> <RPC_VERSION> [DISABLED_TESTS] [WORKSPACE] [RESULT_DIR]"
+  echo
+  echo "  CHAIN:          The chain identifier (possible values: mainnet, gnosis, polygon)"
+  echo "  RPC_VERSION:    The rpc-tests repository version or branch (e.g., v1.66.0, main)"
+  echo "  DISABLED_TESTS: Comma-separated list of disabled tests (optional, default: empty)"
+  echo "  WORKSPACE:      Workspace directory (optional, default: /tmp)"
+  echo "  RESULT_DIR:     Result directory (optional, default: empty)"
+  echo
+  exit 1
+fi
 
-RPC_VERSION="v1.66.0"
+CHAIN="$1"
+RPC_VERSION="$2"
+DISABLED_TESTS="$3"
+WORKSPACE="${4:-/tmp}"
+RESULT_DIR="$5"
 
 echo "Setup the test execution environment..."
 
 # Clone rpc-tests repository at specific tag/branch
 rm -rf "$WORKSPACE/rpc-tests" >/dev/null 2>&1
-git -c advice.detachedHead=false clone --depth 1 --branch $RPC_VERSION https://github.com/erigontech/rpc-tests "$WORKSPACE/rpc-tests" >/dev/null 2>&1
+git -c advice.detachedHead=false clone --depth 1 --branch "$RPC_VERSION" https://github.com/erigontech/rpc-tests "$WORKSPACE/rpc-tests" >/dev/null 2>&1
 cd "$WORKSPACE/rpc-tests"
 
 # Try to create and activate a Python virtual environment or install packages globally if it fails
@@ -27,53 +39,18 @@ fi
 # Activate virtual environment if it was created
 if [ -f ".venv/bin/activate" ]; then
   source .venv/bin/activate
+  pip3 install --upgrade pip 1>/dev/null
   pip3 install -r requirements.txt 1>/dev/null
 fi
 
 # Remove the local results directory if any
 cd "$WORKSPACE/rpc-tests/integration"
-rm -rf ./mainnet/results/
-
-# Array of disabled tests
-disabled_tests=(
-    # Failing after the PR https://github.com/erigontech/erigon/pull/13903 - diff is only an error message in the result
-    eth_estimateGas/test_14.json
-    # Failing after the PR https://github.com/erigontech/erigon/pull/13617 that fixed this incompatibility
-    # issues https://hive.pectra-devnet-5.ethpandaops.io/suite.html?suiteid=1738266984-51ae1a2f376e5de5e9ba68f034f80e32.json&suitename=rpc-compat
-    net_listening/test_1.json
-    # Erigon2 and Erigon3 never supported this api methods
-    trace_rawTransaction
-    debug_getRawTransaction
-    # to investigate
-    engine_exchangeCapabilities/test_1.json
-    engine_exchangeTransitionConfigurationV1/test_01.json
-    engine_getClientVersionV1/test_1.json
-    # these tests requires Erigon active
-    admin_nodeInfo/test_01.json
-    admin_peers/test_01.json
-    erigon_nodeInfo/test_1.json
-    eth_coinbase/test_01.json
-    eth_createAccessList/test_16.json
-    eth_getTransactionByHash/test_02.json
-    # Small prune issue that leads to wrong ReceiptDomain data at 16999999 (probably at every million) block: https://github.com/erigontech/erigon/issues/13050
-    ots_searchTransactionsBefore/test_04.tar
-    eth_getWork/test_01.json
-    eth_mining/test_01.json
-    eth_protocolVersion/test_1.json
-    eth_submitHashrate/test_1.json
-    eth_submitWork/test_1.json
-    net_peerCount/test_1.json
-    net_version/test_1.json
-    txpool_status/test_1.json
-    web3_clientVersion/test_1.json)
-
-# Transform the array into a comma-separated string
-disabled_test_list=$(IFS=,; echo "${disabled_tests[*]}")
+rm -rf ./"$CHAIN"/results/
 
 # Run the RPC integration tests
 set +e # Disable exit on error for test run
 
-python3 ./run_tests.py --port 8545 --engine-port 8545 --continue -f --json-diff -x "$disabled_test_list"
+python3 ./run_tests.py --blockchain "$CHAIN" --port 8545 --engine-port 8545 --continue --display-only-fail --json-diff --exclude-api-list "$DISABLED_TESTS"
 RUN_TESTS_EXIT_CODE=$?
 
 set -e # Re-enable exit on error after test run
@@ -81,9 +58,9 @@ set -e # Re-enable exit on error after test run
 # Save any failed results to the requested result directory if provided
 if [ $RUN_TESTS_EXIT_CODE -ne 0 ] && [ -n "$RESULT_DIR" ]; then
   # Copy the results to the requested result directory
-  cp -r "$WORKSPACE/rpc-tests/integration/mainnet/results/" "$RESULT_DIR"
+  cp -r "$WORKSPACE/rpc-tests/integration/$CHAIN/results/" "$RESULT_DIR"
   # Clean up the local result directory
-  rm -rf "$WORKSPACE/rpc-tests/integration/mainnet/results/"
+  rm -rf "$WORKSPACE/rpc-tests/integration/$CHAIN/results/"
 fi
 
 # Deactivate the Python virtual environment if it was created

--- a/.github/workflows/scripts/run_rpc_tests.sh
+++ b/.github/workflows/scripts/run_rpc_tests.sh
@@ -1,21 +1,38 @@
 #!/bin/bash
+set -e
 
-set +e # Disable exit on error
+# Accept WORKSPACE as the first argument, default to /tmp directory if not provided
+WORKSPACE="${1:-/tmp}"
+# Accept RESULT_DIR as the second argument, do not set a default
+RESULT_DIR="$2"
 
-manual=false
-for arg in "$@"; do
-  if [[ $arg == "--manual" ]]; then
-    manual=true
-  fi
-done
+RPC_VERSION="v1.66.0"
 
-if $manual; then
-  echo "Running manual setup…"
-  python3 -m venv .venv
-  source .venv/bin/activate
-  pip3 install -r ../requirements.txt
-  echo "Manual setup complete."
+echo "Setup the test execution environment..."
+
+# Clone rpc-tests repository at specific tag/branch
+rm -rf "$WORKSPACE/rpc-tests" >/dev/null 2>&1
+git -c advice.detachedHead=false clone --depth 1 --branch $RPC_VERSION https://github.com/erigontech/rpc-tests "$WORKSPACE/rpc-tests" >/dev/null 2>&1
+cd "$WORKSPACE/rpc-tests"
+
+# Try to create and activate a Python virtual environment or install packages globally if it fails
+if python3 -m venv .venv >/dev/null 2>&1; then :
+elif python3 -m virtualenv .venv >/dev/null 2>&1; then :
+elif virtualenv .venv >/dev/null 2>&1; then :
+else
+  echo "Failed to create a virtual environment, installing packages globally."
+  pip3 install -r requirements.txt 1>/dev/null
 fi
+
+# Activate virtual environment if it was created
+if [ -f ".venv/bin/activate" ]; then
+  source .venv/bin/activate
+  pip3 install -r requirements.txt 1>/dev/null
+fi
+
+# Remove the local results directory if any
+cd "$WORKSPACE/rpc-tests/integration"
+rm -rf ./mainnet/results/
 
 # Array of disabled tests
 disabled_tests=(
@@ -53,11 +70,26 @@ disabled_tests=(
 # Transform the array into a comma-separated string
 disabled_test_list=$(IFS=,; echo "${disabled_tests[*]}")
 
-python3 ./run_tests.py -p 8545 --continue -f --json-diff -x "$disabled_test_list"
+# Run the RPC integration tests
+set +e # Disable exit on error for test run
+
+python3 ./run_tests.py --port 8545 --engine-port 8545 --continue -f --json-diff -x "$disabled_test_list"
 RUN_TESTS_EXIT_CODE=$?
-if $manual; then
-  echo "deactivating…"
-  deactivate 2>/dev/null || echo "No active virtualenv"
-  echo "deactivating complete."
+
+set -e # Re-enable exit on error after test run
+
+# Save any failed results to the requested result directory if provided
+if [ $RUN_TESTS_EXIT_CODE -ne 0 ] && [ -n "$RESULT_DIR" ]; then
+  # Copy the results to the requested result directory
+  cp -r "$WORKSPACE/rpc-tests/integration/mainnet/results/" "$RESULT_DIR"
+  # Clean up the local result directory
+  rm -rf "$WORKSPACE/rpc-tests/integration/mainnet/results/"
 fi
+
+# Deactivate the Python virtual environment if it was created
+cd "$WORKSPACE/rpc-tests"
+if [ -f ".venv/bin/activate" ]; then
+  deactivate 2>/dev/null || :
+fi
+
 exit $RUN_TESTS_EXIT_CODE

--- a/.github/workflows/scripts/run_rpc_tests_ethereum.sh
+++ b/.github/workflows/scripts/run_rpc_tests_ethereum.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e # Enable exit on error
+
+# The workspace directory, no default because run_rpc_tests has it
+WORKSPACE="$1"
+# The result directory, no default because run_rpc_tests has it
+RESULT_DIR="$2"
+
+# Disabled tests for Ethereum mainnet
+DISABLED_TEST_LIST=(
+  # Erigon3 temporary disable waiting fix on expected test on rpc-test (PR https://github.com/erigontech/rpc-tests/pull/411)
+  erigon_getHeaderByNumber
+  erigon_getHeaderByHash
+  # Failing after the PR https://github.com/erigontech/erigon/pull/13617 that fixed this incompatibility
+  # issues https://hive.pectra-devnet-5.ethpandaops.io/suite.html?suiteid=1738266984-51ae1a2f376e5de5e9ba68f034f80e32.json&suitename=rpc-compat
+  net_listening/test_1.json
+  # Erigon2 and Erigon3 never supported this api methods
+  trace_rawTransaction
+  # to investigate
+  engine_exchangeCapabilities/test_1.json
+  engine_exchangeTransitionConfigurationV1/test_01.json
+  engine_getClientVersionV1/test_1.json
+  # these tests requires Erigon active
+  admin_nodeInfo/test_01.json
+  admin_peers/test_01.json
+  erigon_nodeInfo/test_1.json
+  eth_coinbase/test_01.json
+  eth_createAccessList/test_16.json
+  eth_getTransactionByHash/test_02.json
+  # Small prune issue that leads to wrong ReceiptDomain data at 16999999 (probably at every million) block: https://github.com/erigontech/erigon/issues/13050
+  ots_searchTransactionsBefore/test_04.tar
+  eth_getWork/test_01.json
+  eth_mining/test_01.json
+  eth_protocolVersion/test_1.json
+  eth_submitHashrate/test_1.json
+  eth_submitWork/test_1.json
+  net_peerCount/test_1.json
+  net_version/test_1.json
+  txpool_status/test_1.json
+  web3_clientVersion/test_1.json
+)
+
+# Transform the array into a comma-separated string
+DISABLED_TESTS=$(IFS=,; echo "${DISABLED_TEST_LIST[*]}")
+
+# Call the main test runner script with the required and optional parameters
+"$(dirname "$0")/run_rpc_tests.sh" mainnet v1.66.0 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR"

--- a/.github/workflows/scripts/run_rpc_tests_ethereum.sh
+++ b/.github/workflows/scripts/run_rpc_tests_ethereum.sh
@@ -44,4 +44,4 @@ DISABLED_TEST_LIST=(
 DISABLED_TESTS=$(IFS=,; echo "${DISABLED_TEST_LIST[*]}")
 
 # Call the main test runner script with the required and optional parameters
-"$(dirname "$0")/run_rpc_tests.sh" mainnet v1.66.0 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR"
+"$(dirname "$0")/run_rpc_tests.sh" mainnet release/3.0 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR"

--- a/.github/workflows/scripts/run_rpc_tests_gnosis.sh
+++ b/.github/workflows/scripts/run_rpc_tests_gnosis.sh
@@ -1,34 +1,26 @@
 #!/bin/bash
+set -e # Enable exit on error
 
-set +e # Disable exit on error
+# The workspace directory, no default because run_rpc_tests has it
+WORKSPACE="$1"
+# The result directory, no default because run_rpc_tests has it
+RESULT_DIR="$2"
 
-manual=false
-for arg in "$@"; do
-  if [[ $arg == "--manual" ]]; then
-    manual=true
-  fi
-done
-
-if $manual; then
-  echo "Running manual setup…"
-  python3 -m venv .venv
-  source .venv/bin/activate
-  pip3 install -r ../requirements.txt
-  echo "Manual setup complete."
-fi
-
-# Array of disabled tests
-disabled_tests=(
+# Disabled tests for Gnosis chain
+DISABLED_TEST_LIST=(
+  # These tests require Erigon active
+  eth_mining
+  eth_submitHashrate
+  eth_submitWork
+  net_peerCount
+  net_listening
+  net_version
+  web3_clientVersion
 )
 
 # Transform the array into a comma-separated string
-disabled_test_list=$(IFS=,; echo "${disabled_tests[*]}")
+DISABLED_TESTS=$(IFS=,; echo "${DISABLED_TEST_LIST[*]}")
 
-python3 ./run_tests.py --blockchain gnosis --port 8545 --engine-port 8545 --continue -f --json-diff --serial -x "$disabled_test_list"
-RUN_TESTS_EXIT_CODE=$?
-if $manual; then
-  echo "deactivating…"
-  deactivate 2>/dev/null || echo "No active virtualenv"
-  echo "deactivating complete."
-fi
-exit $RUN_TESTS_EXIT_CODE
+# Call the main test runner script with the required and optional parameters
+"$(dirname "$0")/run_rpc_tests.sh" gnosis v1.68.0 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR"
+

--- a/.github/workflows/scripts/run_rpc_tests_gnosis.sh
+++ b/.github/workflows/scripts/run_rpc_tests_gnosis.sh
@@ -22,5 +22,5 @@ DISABLED_TEST_LIST=(
 DISABLED_TESTS=$(IFS=,; echo "${DISABLED_TEST_LIST[*]}")
 
 # Call the main test runner script with the required and optional parameters
-"$(dirname "$0")/run_rpc_tests.sh" gnosis v1.68.0 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR"
+"$(dirname "$0")/run_rpc_tests.sh" gnosis release/3.0 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR"
 

--- a/.github/workflows/scripts/run_rpc_tests_polygon.sh
+++ b/.github/workflows/scripts/run_rpc_tests_polygon.sh
@@ -1,35 +1,18 @@
 #!/bin/bash
+set -e # Enable exit on error
 
-set +e # Disable exit on error
+# The workspace directory, no default because run_rpc_tests has it
+WORKSPACE="$1"
+# The result directory, no default because run_rpc_tests has it
+RESULT_DIR="$2"
 
-manual=false
-for arg in "$@"; do
-  if [[ $arg == "--manual" ]]; then
-    manual=true
-  fi
-done
-
-if $manual; then
-  echo "Running manual setup…"
-  python3 -m venv .venv
-  source .venv/bin/activate
-  pip3 install -r ../requirements.txt
-  echo "Manual setup complete."
-fi
-
-# Array of disabled tests
-disabled_tests=(
+# Disabled tests for Polygon chain
+DISABLED_TEST_LIST=(
   bor_getAuthor
   bor_getSnapshot
 )
 # Transform the array into a comma-separated string
-disabled_test_list=$(IFS=,; echo "${disabled_tests[*]}")
+DISABLED_TESTS=$(IFS=,; echo "${DISABLED_TEST_LIST[*]}")
 
-python3 ./run_tests.py --blockchain polygon-pos --port 8545 --engine-port 8545 --continue -f --json-diff --serial -x "$disabled_test_list"
-RUN_TESTS_EXIT_CODE=$?
-if $manual; then
-  echo "deactivating…"
-  deactivate 2>/dev/null || echo "No active virtualenv"
-  echo "deactivating complete."
-fi
-exit $RUN_TESTS_EXIT_CODE
+# Call the main test runner script with the required and optional parameters
+"$(dirname "$0")/run_rpc_tests.sh" polygon-pos v1.68.0 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR"

--- a/.github/workflows/scripts/run_rpc_tests_polygon.sh
+++ b/.github/workflows/scripts/run_rpc_tests_polygon.sh
@@ -15,4 +15,4 @@ DISABLED_TEST_LIST=(
 DISABLED_TESTS=$(IFS=,; echo "${DISABLED_TEST_LIST[*]}")
 
 # Call the main test runner script with the required and optional parameters
-"$(dirname "$0")/run_rpc_tests.sh" polygon-pos v1.68.0 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR"
+"$(dirname "$0")/run_rpc_tests.sh" polygon-pos release/3.0 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR"


### PR DESCRIPTION
Porting of the recent changes done in `main` to improve and optimize QA RPC tests:
- add QA workflows for Gnosis and Polygon RPC Integration Tests
cherry-pick #14116
cherry-pick #15906 
cherry-pick #15907
- restructure the job distribution on self-hosted runners
cherry-pick #15913
- one-liner scripts for execution of RPC Integration Tests
cherry-pick #15978 
cherry-pick #15991 

Additional changes specific for `release/3.0` branch:
- use `release/3.0` branch for `rpc-tests` in all workflows
- keep Polygon RPC Integration Tests *disabled* for now