### PR TITLE
qa-tests: use 1.67 rpc-test version and enable erigon_getHeaderByHash and number

### DIFF
--- a/.github/workflows/scripts/run_rpc_tests_ethereum.sh
+++ b/.github/workflows/scripts/run_rpc_tests_ethereum.sh
@@ -8,9 +8,6 @@ RESULT_DIR="$2"
 
 # Disabled tests for Ethereum mainnet
 DISABLED_TEST_LIST=(
-  # Erigon3 temporary disable waiting fix on expected test on rpc-test (PR https://github.com/erigontech/rpc-tests/pull/411)
-  erigon_getHeaderByNumber
-  erigon_getHeaderByHash
   # Failing after the PR https://github.com/erigontech/erigon/pull/13617 that fixed this incompatibility
   # issues https://hive.pectra-devnet-5.ethpandaops.io/suite.html?suiteid=1738266984-51ae1a2f376e5de5e9ba68f034f80e32.json&suitename=rpc-compat
   net_listening/test_1.json
@@ -44,4 +41,4 @@ DISABLED_TEST_LIST=(
 DISABLED_TESTS=$(IFS=,; echo "${DISABLED_TEST_LIST[*]}")
 
 # Call the main test runner script with the required and optional parameters
-"$(dirname "$0")/run_rpc_tests.sh" mainnet v1.66.0 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR"
+"$(dirname "$0")/run_rpc_tests.sh" mainnet v1.67.0 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR"


### PR DESCRIPTION
enable tests erigon_getHeaderByNumber () and erigon_getHeaderByHash() without Verkle fields 