### PR TITLE
rpcdaemon: align response (block not found or txnHash not found) in case remote conf with local one (embedded or stand-alone) 

### DIFF
--- a/turbo/privateapi/ethbackend.go
+++ b/turbo/privateapi/ethbackend.go
@@ -310,7 +310,7 @@ func (s *EthBackendServer) Block(ctx context.Context, req *remote.BlockRequest) 
 	}
 
 	var sendersBytes []byte
-	if sendersBytes != nil {
+	if senders != nil {
 		sendersBytes = make([]byte, 20*len(senders))
 		for i, sender := range senders {
 			copy(sendersBytes[i*20:], sender[:])

--- a/turbo/privateapi/ethbackend.go
+++ b/turbo/privateapi/ethbackend.go
@@ -300,13 +300,21 @@ func (s *EthBackendServer) Block(ctx context.Context, req *remote.BlockRequest) 
 	if err != nil {
 		return nil, err
 	}
-	blockRlp, err := rlp.EncodeToBytes(block)
-	if err != nil {
-		return nil, err
+
+	var blockRlp []byte
+	if block != nil {
+		blockRlp, err = rlp.EncodeToBytes(block)
+		if err != nil {
+			return nil, err
+		}
 	}
-	sendersBytes := make([]byte, 20*len(senders))
-	for i, sender := range senders {
-		copy(sendersBytes[i*20:], sender[:])
+
+	var sendersBytes []byte
+	if sendersBytes != nil {
+		sendersBytes = make([]byte, 20*len(senders))
+		for i, sender := range senders {
+			copy(sendersBytes[i*20:], sender[:])
+		}
 	}
 	return &remote.BlockReply{BlockRlp: blockRlp, Senders: sendersBytes}, nil
 }

--- a/turbo/privateapi/ethbackend.go
+++ b/turbo/privateapi/ethbackend.go
@@ -301,20 +301,18 @@ func (s *EthBackendServer) Block(ctx context.Context, req *remote.BlockRequest) 
 		return nil, err
 	}
 
-	var blockRlp []byte
-	if block != nil {
-		blockRlp, err = rlp.EncodeToBytes(block)
-		if err != nil {
-			return nil, err
-		}
+	if block == nil {
+		return &remote.BlockReply{}, nil
 	}
 
-	var sendersBytes []byte
-	if senders != nil {
-		sendersBytes = make([]byte, 20*len(senders))
-		for i, sender := range senders {
-			copy(sendersBytes[i*20:], sender[:])
-		}
+	blockRlp, err := rlp.EncodeToBytes(block)
+	if err != nil {
+		return nil, err
+	}
+
+	sendersBytes := make([]byte, 20*len(senders))
+	for i, sender := range senders {
+		copy(sendersBytes[i*20:], sender[:])
 	}
 	return &remote.BlockReply{BlockRlp: blockRlp, Senders: sendersBytes}, nil
 }

--- a/turbo/snapshotsync/freezeblocks/block_reader.go
+++ b/turbo/snapshotsync/freezeblocks/block_reader.go
@@ -193,6 +193,7 @@ func (r *RemoteBlockReader) TxnLookup(ctx context.Context, tx kv.Getter, txnHash
 	if reply.BlockNumber == 0 && reply.TxNumber == 0 {
 		return reply.BlockNumber, reply.TxNumber, false, nil
 	}
+
 	return reply.BlockNumber, reply.TxNumber, true, nil
 }
 
@@ -229,13 +230,12 @@ func (r *RemoteBlockReader) BlockWithSenders(ctx context.Context, _ kv.Getter, h
 	if err != nil {
 		return nil, nil, err
 	}
-
-	block = &types.Block{}
-	if (len(reply.BlockRlp)) == 0 {
+	if len(reply.BlockRlp) == 0 {
 		// block not found
 		return nil, nil, nil
 	}
 
+	block = &types.Block{}
 	err = rlp.DecodeBytes(reply.BlockRlp, block)
 	if err != nil {
 		return nil, nil, err

--- a/turbo/snapshotsync/freezeblocks/block_reader.go
+++ b/turbo/snapshotsync/freezeblocks/block_reader.go
@@ -188,6 +188,11 @@ func (r *RemoteBlockReader) TxnLookup(ctx context.Context, tx kv.Getter, txnHash
 	if reply == nil {
 		return 0, 0, false, nil
 	}
+
+	// Not a perfect solution, assumes there are no transactions in block 0 (same check on server side)
+	if reply.BlockNumber == 0 && reply.TxNumber == 0 {
+		return reply.BlockNumber, reply.TxNumber, false, nil
+	}
 	return reply.BlockNumber, reply.TxNumber, true, nil
 }
 

--- a/turbo/snapshotsync/freezeblocks/block_reader.go
+++ b/turbo/snapshotsync/freezeblocks/block_reader.go
@@ -226,6 +226,11 @@ func (r *RemoteBlockReader) BlockWithSenders(ctx context.Context, _ kv.Getter, h
 	}
 
 	block = &types.Block{}
+	if (len(reply.BlockRlp)) == 0 {
+		// block not found
+		return nil, nil, nil
+	}
+
 	err = rlp.DecodeBytes(reply.BlockRlp, block)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
In case of block not found in remote configuration (grpc) the response was different (end of list in decoding) 

In case of txnHash not found in remote configuration (grpc) the response was different.