### PR TITLE
rip: Log.DecodeRLP method

### DIFF
--- a/erigon-lib/types/log.go
+++ b/erigon-lib/types/log.go
@@ -283,19 +283,20 @@ func (l *LogForStorage) EncodeRLP(w io.Writer) error {
 func decodeTopics(s *rlp.Stream) (list []common.Hash, err error) {
 	l, err := s.List()
 	if err != nil {
-		return list, err
+		return nil, err
 	}
 	if l == 0 {
-		return list, s.ListEnd()
+		return nil, s.ListEnd()
 	}
 
-	list = make([]common.Hash, (l-1)/32)
-	for i := 0; s.MoreDataInList(); i++ {
+	list = make([]common.Hash, l/(1+32)) // rlpLenPrefix+32bytes
+	var i int
+	for ; s.MoreDataInList(); i++ {
 		if err = s.ReadBytes(list[i][:]); err != nil {
-			return list, err
+			return nil, err
 		}
 	}
-	return list, s.ListEnd()
+	return list[:i], s.ListEnd()
 }
 
 // DecodeRLP implements rlp.Decoder.

--- a/erigon-lib/types/log.go
+++ b/erigon-lib/types/log.go
@@ -292,6 +292,9 @@ func decodeTopics(s *rlp.Stream) (list []common.Hash, err error) {
 	list = make([]common.Hash, l/(1+32)) // rlpLenPrefix+32bytes
 	var i int
 	for ; s.MoreDataInList(); i++ {
+		if i == len(list) {
+			return nil, fmt.Errorf("too many elements in list")
+		}
 		if err = s.ReadBytes(list[i][:]); err != nil {
 			return nil, err
 		}

--- a/erigon-lib/types/log.go
+++ b/erigon-lib/types/log.go
@@ -288,8 +288,8 @@ func decodeTopics(s *rlp.Stream) (list []common.Hash, err error) {
 	if l == 0 {
 		return nil, s.ListEnd()
 	}
-
-	list = make([]common.Hash, l/(1+32)) // rlpLenPrefix+32bytes
+	listLen := l / (1 + 32) // rlpLenPrefix+32bytes
+	list = make([]common.Hash, listLen)
 	var i int
 	for ; s.MoreDataInList(); i++ {
 		if i == len(list) {

--- a/erigon-lib/types/receipt_test.go
+++ b/erigon-lib/types/receipt_test.go
@@ -647,8 +647,8 @@ func makeTestLog(topics int) *ReceiptForStorage {
 }
 
 func BenchmarkDecodeRLP(b *testing.B) {
-	for i := 0; i < 300; i++ {
-		r := makeTestLog(20)
+	for i := 0; i < 5000; i++ {
+		r := makeTestLog(i)
 		dataRlp, err := rlp.EncodeToBytes(r)
 		require.NoError(b, err)
 		var l ReceiptForStorage

--- a/erigon-lib/types/receipt_test.go
+++ b/erigon-lib/types/receipt_test.go
@@ -21,11 +21,9 @@ package types
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"math"
 	"math/big"
-	"os"
 	"reflect"
 	"testing"
 
@@ -614,55 +612,4 @@ func TestReceiptEncode(t *testing.T) {
 		require.Equal(t, len(r1.Logs), len(r2.Logs))
 		require.Equal(t, len(r1.Logs[0].Topics), len(r2.Logs[0].Topics))
 	})
-}
-
-func makeTestLog(topics int) *ReceiptForStorage {
-	// Create 20 topics
-	tl := make([]common.Hash, topics)
-	for i := 0; i < topics; i++ {
-		tl[i] = common.BytesToHash([]byte("topic" + string(rune(i+48))))
-	}
-	// Create 1024 bytes of data
-	data := make([]byte, 1024)
-	for i := range data {
-		data[i] = byte(i % 256)
-	}
-	return &ReceiptForStorage{
-		Logs: Logs{
-			&Log{
-				Address: common.BytesToAddress([]byte("testaddress123456")),
-				Topics:  tl,
-				Data:    data,
-			},
-		},
-	}
-}
-
-func BenchmarkDecodeRLP(b *testing.B) {
-	for i := 0; i < 5000; i++ {
-		r := makeTestLog(i)
-		dataRlp, err := rlp.EncodeToBytes(r)
-		require.NoError(b, err)
-		var l ReceiptForStorage
-		err = rlp.DecodeBytes(dataRlp, &l)
-		require.NoError(b, err)
-	}
-
-	//r := makeTestLog(20)
-	dataJson, err := os.ReadFile("./../../1.json")
-	require.NoError(b, err)
-	r := &ReceiptForStorage{}
-	err = json.Unmarshal(dataJson, r)
-	require.NoError(b, err)
-	dataRlp, err := rlp.EncodeToBytes(r)
-	require.NoError(b, err)
-
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		var l ReceiptForStorage
-		if err := rlp.DecodeBytes(dataRlp, &l); err != nil {
-			b.Fatalf("DecodeRLP failed: %v", err)
-		}
-	}
 }


### PR DESCRIPTION
real 20kb receipt from BorMainnet: 
```
from
51569 ns/op	  101299 B/op	    1395 allocs/op
to  
18759 ns/op	   37921 B/op	     304 allocs/op
```

it's small step towards rlpgen:
- introduced MoreDataInList and ReadBytes methods
- found that can pre-alloc: if list-item has known size. but attacker can craft big rlp prefix - and trigger huge pre-alloc. So, added limit.  
