### PR TITLE
rpcdaemon: eth_getLogs(): add check on pruning

### DIFF
--- a/rpc/jsonrpc/eth_receipts.go
+++ b/rpc/jsonrpc/eth_receipts.go
@@ -30,6 +30,7 @@ import (
 	"github.com/erigontech/erigon-lib/kv/stream"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon-lib/types"
+	"github.com/erigontech/erigon/core/state"
 	"github.com/erigontech/erigon/eth/ethutils"
 	"github.com/erigontech/erigon/eth/filters"
 	"github.com/erigontech/erigon/execution/exec3"
@@ -168,6 +169,11 @@ func applyFiltersV3(txNumsReader rawdbv3.TxNumsReader, tx kv.TemporalTx, begin, 
 		fromTxNum, err = txNumsReader.Min(tx, begin)
 		if err != nil {
 			return out, err
+		}
+		r := state.NewHistoryReaderV3()
+		r.SetTx(tx)
+		if fromTxNum < r.StateHistoryStartFrom() {
+			return out, state.PrunedError
 		}
 	}
 


### PR DESCRIPTION
If an eth_getLogs() request specifies neither an address nor topics, and the requested range falls on a pruned state, an error is returned to the client. While if the request includes an address and/or topics, no error is returned; instead, an empty log array is provided, which means the client is not directly informed of the problematic request context (i.e., querying a pruned state).
This happens because reverse index returns en empty list therefore becomes empty logs 