### PR TITLE
Fix endId calculation logic

### DIFF
--- a/polygon/bridge/service.go
+++ b/polygon/bridge/service.go
@@ -390,7 +390,7 @@ func (s *Service) ProcessNewBlocks(ctx context.Context, blocks []*types.Block) e
 			if *eventLimit == 0 {
 				endId = 0
 			} else {
-				if endId > startId && endId-startId > *eventLimit {
+				if endId > startId && endId-startId >= *eventLimit {
 					endId = startId + *eventLimit - 1
 				}
 			}


### PR DESCRIPTION
This will make the `TestService_ProcessNewBlocksWithOverride` test pass.