### PR TITLE
rlp: use .ReadBytes() in other places

### DIFF
--- a/erigon-lib/types/access_list_tx.go
+++ b/erigon-lib/types/access_list_tx.go
@@ -310,13 +310,9 @@ func decodeAccessList(al *AccessList, s *rlp.Stream) error {
 		// decode tuple
 		*al = append(*al, AccessTuple{StorageKeys: []common.Hash{}})
 		tuple := &(*al)[len(*al)-1]
-		if b, err = s.Bytes(); err != nil {
+		if err = s.ReadBytes(tuple.Address[:]); err != nil {
 			return fmt.Errorf("read Address: %w", err)
 		}
-		if len(b) != 20 {
-			return fmt.Errorf("wrong size for AccessTuple address: %d", len(b))
-		}
-		copy(tuple.Address[:], b)
 		if _, err = s.List(); err != nil {
 			return fmt.Errorf("open StorageKeys: %w", err)
 		}

--- a/erigon-lib/types/block.go
+++ b/erigon-lib/types/block.go
@@ -334,55 +334,27 @@ func (h *Header) DecodeRLP(s *rlp.Stream) error {
 		// return fmt.Errorf("open header struct: %w", err)
 	}
 	var b []byte
-	if b, err = s.Bytes(); err != nil {
+	if err = s.ReadBytes(h.ParentHash[:]); err != nil {
 		return fmt.Errorf("read ParentHash: %w", err)
 	}
-	if len(b) != 32 {
-		return fmt.Errorf("wrong size for ParentHash: %d", len(b))
-	}
-	copy(h.ParentHash[:], b)
-	if b, err = s.Bytes(); err != nil {
+	if err = s.ReadBytes(h.UncleHash[:]); err != nil {
 		return fmt.Errorf("read UncleHash: %w", err)
 	}
-	if len(b) != 32 {
-		return fmt.Errorf("wrong size for UncleHash: %d", len(b))
-	}
-	copy(h.UncleHash[:], b)
-	if b, err = s.Bytes(); err != nil {
+	if err = s.ReadBytes(h.Coinbase[:]); err != nil {
 		return fmt.Errorf("read Coinbase: %w", err)
 	}
-	if len(b) != 20 {
-		return fmt.Errorf("wrong size for Coinbase: %d", len(b))
-	}
-	copy(h.Coinbase[:], b)
-	if b, err = s.Bytes(); err != nil {
+	if err = s.ReadBytes(h.Root[:]); err != nil {
 		return fmt.Errorf("read Root: %w", err)
 	}
-	if len(b) != 32 {
-		return fmt.Errorf("wrong size for Root: %d", len(b))
-	}
-	copy(h.Root[:], b)
-	if b, err = s.Bytes(); err != nil {
+	if err = s.ReadBytes(h.TxHash[:]); err != nil {
 		return fmt.Errorf("read TxHash: %w", err)
 	}
-	if len(b) != 32 {
-		return fmt.Errorf("wrong size for TxHash: %d", len(b))
-	}
-	copy(h.TxHash[:], b)
-	if b, err = s.Bytes(); err != nil {
+	if err = s.ReadBytes(h.ReceiptHash[:]); err != nil {
 		return fmt.Errorf("read ReceiptHash: %w", err)
 	}
-	if len(b) != 32 {
-		return fmt.Errorf("wrong size for ReceiptHash: %d", len(b))
-	}
-	copy(h.ReceiptHash[:], b)
-	if b, err = s.Bytes(); err != nil {
+	if err = s.ReadBytes(h.Bloom[:]); err != nil {
 		return fmt.Errorf("read Bloom: %w", err)
 	}
-	if len(b) != 256 {
-		return fmt.Errorf("wrong size for Bloom: %d", len(b))
-	}
-	copy(h.Bloom[:], b)
 	if b, err = s.Uint256Bytes(); err != nil {
 		return fmt.Errorf("read Difficulty: %w", err)
 	}
@@ -416,17 +388,12 @@ func (h *Header) DecodeRLP(s *rlp.Stream) error {
 			return fmt.Errorf("read AuRaSeal: %w", err)
 		}
 	} else {
-		if b, err = s.Bytes(); err != nil {
+		if err = s.ReadBytes(h.MixDigest[:]); err != nil {
 			return fmt.Errorf("read MixDigest: %w", err)
 		}
-		copy(h.MixDigest[:], b)
-		if b, err = s.Bytes(); err != nil {
+		if err = s.ReadBytes(h.Nonce[:]); err != nil {
 			return fmt.Errorf("read Nonce: %w", err)
 		}
-		if len(b) != 8 {
-			return fmt.Errorf("wrong size for Nonce: %d", len(b))
-		}
-		copy(h.Nonce[:], b)
 	}
 
 	// BaseFee

--- a/erigon-lib/types/bloom9.go
+++ b/erigon-lib/types/bloom9.go
@@ -119,7 +119,7 @@ func CreateBloom(receipts Receipts) Bloom {
 	var bin Bloom
 	for _, receipt := range receipts {
 		for _, log := range receipt.Logs {
-			bin.add(log.Address.Bytes(), buf)
+			bin.add(log.Address[:], buf)
 			for _, b := range log.Topics {
 				bin.add(b[:], buf)
 			}
@@ -133,7 +133,7 @@ func LogsBloom(logs []*Log) Bloom {
 	buf := make([]byte, 6)
 	var bin Bloom
 	for _, log := range logs {
-		bin.add(log.Address.Bytes(), buf)
+		bin.add(log.Address[:], buf)
 		for _, b := range log.Topics {
 			bin.add(b[:], buf)
 		}

--- a/erigon-lib/types/encdec_test.go
+++ b/erigon-lib/types/encdec_test.go
@@ -657,11 +657,22 @@ func BenchmarkHeaderRLP(b *testing.B) {
 	tr := NewTRand()
 	header := tr.RandHeader()
 	var buf bytes.Buffer
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	b.Run(`Encode`, func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			header.EncodeRLP(&buf)
+		}
+	})
+	b.Run(`Decode`, func(b *testing.B) {
+		b.ReportAllocs()
 		buf.Reset()
 		header.EncodeRLP(&buf)
-	}
+		var v Header
+		for i := 0; i < b.N; i++ {
+			rlp.DecodeBytes(buf.Bytes(), &v)
+		}
+	})
 }
 
 func BenchmarkLegacyTxRLP(b *testing.B) {

--- a/erigon-lib/types/log.go
+++ b/erigon-lib/types/log.go
@@ -255,13 +255,13 @@ func (l *Log) Copy() *Log {
 		return nil
 	}
 	return &Log{
-		Address:     common.BytesToAddress(l.Address.Bytes()),
+		Address:     l.Address,
 		Topics:      slices.Clone(l.Topics),
 		Data:        slices.Clone(l.Data),
 		BlockNumber: l.BlockNumber,
-		TxHash:      common.BytesToHash(l.TxHash.Bytes()),
+		TxHash:      l.TxHash,
 		TxIndex:     l.TxIndex,
-		BlockHash:   common.BytesToHash(l.BlockHash.Bytes()),
+		BlockHash:   l.BlockHash,
 		Index:       l.Index,
 		Removed:     l.Removed,
 	}

--- a/erigon-lib/types/receipt.go
+++ b/erigon-lib/types/receipt.go
@@ -212,13 +212,9 @@ func (r *Receipt) decodePayload(s *rlp.Stream) error {
 	if r.CumulativeGasUsed, err = s.Uint(); err != nil {
 		return fmt.Errorf("read CumulativeGasUsed: %w", err)
 	}
-	if b, err = s.Bytes(); err != nil {
+	if err = s.ReadBytes(r.Bloom[:]); err != nil {
 		return fmt.Errorf("read Bloom: %w", err)
 	}
-	if len(b) != 256 {
-		return fmt.Errorf("wrong size for Bloom: %d", len(b))
-	}
-	copy(r.Bloom[:], b)
 	// decode logs
 	if _, err = s.List(); err != nil {
 		return fmt.Errorf("open Logs: %w", err)
@@ -229,13 +225,9 @@ func (r *Receipt) decodePayload(s *rlp.Stream) error {
 	for _, err = s.List(); err == nil; _, err = s.List() {
 		r.Logs = append(r.Logs, &Log{})
 		log := r.Logs[len(r.Logs)-1]
-		if b, err = s.Bytes(); err != nil {
+		if err = s.ReadBytes(log.Address[:]); err != nil {
 			return fmt.Errorf("read Address: %w", err)
 		}
-		if len(b) != 20 {
-			return fmt.Errorf("wrong size for Log address: %d", len(b))
-		}
-		copy(log.Address[:], b)
 		if _, err = s.List(); err != nil {
 			return fmt.Errorf("open Topics: %w", err)
 		}
@@ -349,12 +341,12 @@ func (r *Receipt) Copy() *Receipt {
 		PostState:         slices.Clone(r.PostState),
 		Status:            r.Status,
 		CumulativeGasUsed: r.CumulativeGasUsed,
-		Bloom:             BytesToBloom(r.Bloom.Bytes()),
+		Bloom:             r.Bloom,
 		Logs:              r.Logs.Copy(),
-		TxHash:            common.BytesToHash(r.TxHash.Bytes()),
-		ContractAddress:   common.BytesToAddress(r.ContractAddress.Bytes()),
+		TxHash:            r.TxHash,
+		ContractAddress:   r.ContractAddress,
 		GasUsed:           r.GasUsed,
-		BlockHash:         common.BytesToHash(r.BlockHash.Bytes()),
+		BlockHash:         r.BlockHash,
 		BlockNumber:       big.NewInt(0).Set(r.BlockNumber),
 		TransactionIndex:  r.TransactionIndex,
 

--- a/erigon-lib/types/withdrawal.go
+++ b/erigon-lib/types/withdrawal.go
@@ -107,16 +107,9 @@ func (obj *Withdrawal) DecodeRLP(s *rlp.Stream) error {
 	if obj.Validator, err = s.Uint(); err != nil {
 		return fmt.Errorf("read Validator: %w", err)
 	}
-
-	var b []byte
-	if b, err = s.Bytes(); err != nil {
+	if err = s.ReadBytes(obj.Address[:]); err != nil {
 		return fmt.Errorf("read Address: %w", err)
 	}
-	if len(b) != 20 {
-		return fmt.Errorf("wrong size for Address: %d", len(b))
-	}
-	copy(obj.Address[:], b)
-
 	if obj.Amount, err = s.Uint(); err != nil {
 		return fmt.Errorf("read Amount: %w", err)
 	}


### PR DESCRIPTION
hope it will help for withdrawals - now their decoding is 25% of allocs
headers: 25 -> 15 allocs