### PR TITLE
double register url in hot-fix

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1523,7 +1523,7 @@ func (s *Ethereum) setUpSnapDownloader(ctx context.Context, nodeCfg *nodecfg.Con
 			return err
 		}
 
-		s.downloader.HandleTorrentClientStatus(nodeCfg.DebugMux)
+		//s.downloader.HandleTorrentClientStatus(nodeCfg.DebugMux)
 
 		bittorrentServer, err := downloader.NewGrpcServer(s.downloader)
 		if err != nil {


### PR DESCRIPTION
```
 ./build/bin/erigon --datadir /erigon-data/bormainnet31 --authrpc.jwtsecret /erigon-data/amoy31/jwt.hex  --prune.mode=minimal --chain=bor-mainnet --bor.heimdall="https://heimdall-api.polygon.technology" --log.console.verbosity=4 --torrent.download.rate=1g --pprof --pprof.port=6061 --http=false --txpool.disable --metrics --persist.receipts --db.pagesize=16kb > /erigon-logs/erigon-process.log 2>&1 &

panic: pattern "/downloader/torrentClientStatus" (registered at github.com/erigontech/erigon-db@v0.0.0-00010101000000-000000000000/downloader/downloader.go:1355) conflicts with pattern "/downloader/torrentClientStatus" (registered at github.com/erigontech/erigon-db@v0.0.0-00010101000000-000000000000/downloader/downloader.go:1353):
	/downloader/torrentClientStatus matches the same requests as /downloader/torrentClientStatus

goroutine 1 [running]:
net/http.(*ServeMux).register(...)
	net/http/server.go:2872
net/http.(*ServeMux).Handle(0x3199000?, {0x3199000?, 0x3aef220?}, {0x3aef220?, 0xc003492ef0?})
	net/http/server.go:2835 +0x4d
github.com/erigontech/erigon-db/downloader.(*Downloader).HandleTorrentClientStatus(0xc0001d4400, 0x69ab7e0)
	github.com/erigontech/erigon-db@v0.0.0-00010101000000-000000000000/downloader/downloader.go:1355 +0x9a
github.com/erigontech/erigon/eth.(*Ethereum).setUpSnapDownloader(0xc00354ea88, {0x3b13370, 0xc0013dc640}, 0xc001e26008, 0xc000591c80, 0xc000aa6b60)
	github.com/erigontech/erigon/eth/backend.go:1526 +0x1c7
github.com/erigontech/erigon/eth.New({0x3b12de0, 0x69dfd80}, 0xc0009fe7e0, 0xc0011fb008, {0x3b2e3d0, 0xc0005cf460}, 0x0)
	github.com/erigontech/erigon/eth/backend.go:428 +0x109c
github.com/erigontech/erigon/turbo/node.New({0x3b12de0, 0x69dfd80}, 0x3b2e3d0?, 0xc0011fb008, {0x3b2e3d0, 0xc0005cf460}, 0x0)
	github.com/erigontech/erigon/turbo/node/node.go:159 +0xbc
main.runErigon(0xc0021bc180)
	github.com/erigontech/erigon/cmd/erigon/main.go:107 +0x388
github.com/erigontech/erigon/turbo/app.MakeApp.func1(0xc0021bc180)
	github.com/erigontech/erigon/turbo/app/make_app.go:71 +0x17f
github.com/urfave/cli/v2.(*Command).Run(0xc000a1cb00, 0xc0021bc180, {0xc000050a20, 0x11, 0x12})
	github.com/urfave/cli/v2@v2.27.5/command.go:276 +0x7be
github.com/urfave/cli/v2.(*App).RunContext(0xc00184b000, {0x3b12de0, 0x69dfd80}, {0xc000050a20, 0x11, 0x12})
	github.com/urfave/cli/v2@v2.27.5/app.go:333 +0x5a5
github.com/urfave/cli/v2.(*App).Run(...)
	github.com/urfave/cli/v2@v2.27.5/app.go:307
main.main()
	github.com/erigontech/erigon/cmd/erigon/main.go:51 +0x67
Finished with result: exit-code
Main processes terminated with: code=exited/status=2
Service runtime: 3.598s
CPU time consumed: 1.295s
Memory peak: 324.0K
Memory swap peak: 0B
```