### PR TITLE
Fix Broken Link in Mining Documentation

### DIFF
--- a/docs/mining.md
+++ b/docs/mining.md
@@ -12,7 +12,7 @@ Support only remote-miners.
 
 ## Implementation details
 
-* mining implemented as independent 🔬[Staged Sync](/eth/stagedsync/)
+* mining implemented as independent 🔬[Staged Sync](/execution/stagedsync/)
 * stages are declared in `eth/stagedsync/stagebuilder.go:MiningStages`
 * mining work done inside 1 db transaction which RollingBack after block prepared and `--miner.notify` notifications
   sent


### PR DESCRIPTION


```markdown
## 🔗 Fix Broken Link in Mining Documentation

### What was fixed:
- Updated broken link reference from `/eth/stagedsync/` to `/execution/stagedsync/` in `docs/mining.md`

### Why:
- The `/eth/stagedsync/` directory no longer exists after codebase reorganization
- The correct path is now `/execution/stagedsync/`
- This ensures documentation links work properly for developers

### Changes:
- ✅ Fixed link in line 15 of `docs/mining.md`
- ✅ Maintains proper documentation navigation


```

