### PR TITLE
erigon-lib: fix gRPC generation

### DIFF
--- a/erigon-lib/Makefile
+++ b/erigon-lib/Makefile
@@ -1,17 +1,15 @@
 GOBINREL = build/bin
 GOBIN = $(CURDIR)/$(GOBINREL)
 
-BUILD_TAGS =
-
 CGO_CXXFLAGS ?= $(shell go env CGO_CXXFLAGS 2>/dev/null)
 ifeq ($(CGO_CXXFLAGS),)
 	CGO_CXXFLAGS += -g
 	CGO_CXXFLAGS += -O2
 endif
 
-GOBUILD = CGO_CXXFLAGS="$(CGO_CXXFLAGS)" go build -trimpath -tags $(BUILD_TAGS)
-GOTEST = CGO_CXXFLAGS="$(CGO_CXXFLAGS)" go test -trimpath -tags $(BUILD_TAGS)
-GOTEST_NOFUZZ = CGO_CXXFLAGS="$(CGO_CXXFLAGS)" go test -trimpath --tags=$(BUILD_TAGS),nofuzz
+GOBUILD = CGO_CXXFLAGS="$(CGO_CXXFLAGS)" go build -trimpath
+GOTEST = CGO_CXXFLAGS="$(CGO_CXXFLAGS)" go test -trimpath
+GOTEST_NOFUZZ = CGO_CXXFLAGS="$(CGO_CXXFLAGS)" go test -trimpath --tags=nofuzz
 
 OS = $(shell uname -s)
 ARCH = $(shell uname -m)

--- a/erigon-lib/gointerfaces/downloaderproto/downloader.pb.go
+++ b/erigon-lib/gointerfaces/downloaderproto/downloader.pb.go
@@ -30,7 +30,6 @@ type AddItem struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Path          string                 `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
 	TorrentHash   *typesproto.H160       `protobuf:"bytes,2,opt,name=torrent_hash,json=torrentHash,proto3" json:"torrent_hash,omitempty"` // will be resolved as magnet link
-	Verify        bool                   `protobuf:"varint,3,opt,name=verify,proto3" json:"verify,omitempty"`                             // Ignore cached piece state. Force reverification.
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -77,13 +76,6 @@ func (x *AddItem) GetTorrentHash() *typesproto.H160 {
 		return x.TorrentHash
 	}
 	return nil
-}
-
-func (x *AddItem) GetVerify() bool {
-	if x != nil {
-		return x.Verify
-	}
-	return false
 }
 
 type AddRequest struct {
@@ -470,60 +462,15 @@ func (x *TorrentCompletedReply) GetHash() *typesproto.H160 {
 	return nil
 }
 
-type CommitPreverifiedRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	TomlBytes     []byte                 `protobuf:"bytes,1,opt,name=toml_bytes,json=tomlBytes,proto3" json:"toml_bytes,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *CommitPreverifiedRequest) Reset() {
-	*x = CommitPreverifiedRequest{}
-	mi := &file_downloader_downloader_proto_msgTypes[10]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *CommitPreverifiedRequest) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*CommitPreverifiedRequest) ProtoMessage() {}
-
-func (x *CommitPreverifiedRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_downloader_downloader_proto_msgTypes[10]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use CommitPreverifiedRequest.ProtoReflect.Descriptor instead.
-func (*CommitPreverifiedRequest) Descriptor() ([]byte, []int) {
-	return file_downloader_downloader_proto_rawDescGZIP(), []int{10}
-}
-
-func (x *CommitPreverifiedRequest) GetTomlBytes() []byte {
-	if x != nil {
-		return x.TomlBytes
-	}
-	return nil
-}
-
 var File_downloader_downloader_proto protoreflect.FileDescriptor
 
 const file_downloader_downloader_proto_rawDesc = "" +
 	"\n" +
 	"\x1bdownloader/downloader.proto\x12\n" +
-	"downloader\x1a\x1bgoogle/protobuf/empty.proto\x1a\x11types/types.proto\"e\n" +
+	"downloader\x1a\x1bgoogle/protobuf/empty.proto\x1a\x11types/types.proto\"M\n" +
 	"\aAddItem\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12.\n" +
-	"\ftorrent_hash\x18\x02 \x01(\v2\v.types.H160R\vtorrentHash\x12\x16\n" +
-	"\x06verify\x18\x03 \x01(\bR\x06verify\"7\n" +
+	"\ftorrent_hash\x18\x02 \x01(\v2\v.types.H160R\vtorrentHash\"7\n" +
 	"\n" +
 	"AddRequest\x12)\n" +
 	"\x05items\x18\x01 \x03(\v2\x13.downloader.AddItemR\x05items\"%\n" +
@@ -540,17 +487,16 @@ const file_downloader_downloader_proto_rawDesc = "" +
 	"\x17TorrentCompletedRequest\"L\n" +
 	"\x15TorrentCompletedReply\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1f\n" +
-	"\x04hash\x18\x02 \x01(\v2\v.types.H160R\x04hash\"9\n" +
-	"\x18CommitPreverifiedRequest\x12\x1d\n" +
+	"\x04hash\x18\x02 \x01(\v2\v.types.H160R\x04hash2\x90\x04\n" +
 	"\n" +
-	"toml_bytes\x18\x01 \x01(\fR\ttomlBytes2\xed\x02\n" +
-	"\n" +
-	"Downloader\x127\n" +
+	"Downloader\x12Y\n" +
+	"\x14ProhibitNewDownloads\x12'.downloader.ProhibitNewDownloadsRequest\x1a\x16.google.protobuf.Empty\"\x00\x127\n" +
 	"\x03Add\x12\x16.downloader.AddRequest\x1a\x16.google.protobuf.Empty\"\x00\x12=\n" +
-	"\x06Delete\x12\x19.downloader.DeleteRequest\x1a\x16.google.protobuf.Empty\"\x00\x12I\n" +
+	"\x06Delete\x12\x19.downloader.DeleteRequest\x1a\x16.google.protobuf.Empty\"\x00\x12=\n" +
+	"\x06Verify\x12\x19.downloader.VerifyRequest\x1a\x16.google.protobuf.Empty\"\x00\x12I\n" +
 	"\fSetLogPrefix\x12\x1f.downloader.SetLogPrefixRequest\x1a\x16.google.protobuf.Empty\"\x00\x12G\n" +
-	"\tCompleted\x12\x1c.downloader.CompletedRequest\x1a\x1a.downloader.CompletedReply\"\x00\x12S\n" +
-	"\x11CommitPreverified\x12$.downloader.CommitPreverifiedRequest\x1a\x16.google.protobuf.Empty\"\x00B\x1eZ\x1c./downloader;downloaderprotob\x06proto3"
+	"\tCompleted\x12\x1c.downloader.CompletedRequest\x1a\x1a.downloader.CompletedReply\"\x00\x12\\\n" +
+	"\x10TorrentCompleted\x12#.downloader.TorrentCompletedRequest\x1a!.downloader.TorrentCompletedReply0\x01B\x1eZ\x1c./downloader;downloaderprotob\x06proto3"
 
 var (
 	file_downloader_downloader_proto_rawDescOnce sync.Once
@@ -564,7 +510,7 @@ func file_downloader_downloader_proto_rawDescGZIP() []byte {
 	return file_downloader_downloader_proto_rawDescData
 }
 
-var file_downloader_downloader_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
+var file_downloader_downloader_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_downloader_downloader_proto_goTypes = []any{
 	(*AddItem)(nil),                     // 0: downloader.AddItem
 	(*AddRequest)(nil),                  // 1: downloader.AddRequest
@@ -576,26 +522,29 @@ var file_downloader_downloader_proto_goTypes = []any{
 	(*CompletedReply)(nil),              // 7: downloader.CompletedReply
 	(*TorrentCompletedRequest)(nil),     // 8: downloader.TorrentCompletedRequest
 	(*TorrentCompletedReply)(nil),       // 9: downloader.TorrentCompletedReply
-	(*CommitPreverifiedRequest)(nil),    // 10: downloader.CommitPreverifiedRequest
-	(*typesproto.H160)(nil),             // 11: types.H160
-	(*emptypb.Empty)(nil),               // 12: google.protobuf.Empty
+	(*typesproto.H160)(nil),             // 10: types.H160
+	(*emptypb.Empty)(nil),               // 11: google.protobuf.Empty
 }
 var file_downloader_downloader_proto_depIdxs = []int32{
-	11, // 0: downloader.AddItem.torrent_hash:type_name -> types.H160
+	10, // 0: downloader.AddItem.torrent_hash:type_name -> types.H160
 	0,  // 1: downloader.AddRequest.items:type_name -> downloader.AddItem
-	11, // 2: downloader.TorrentCompletedReply.hash:type_name -> types.H160
-	1,  // 3: downloader.Downloader.Add:input_type -> downloader.AddRequest
-	2,  // 4: downloader.Downloader.Delete:input_type -> downloader.DeleteRequest
-	5,  // 5: downloader.Downloader.SetLogPrefix:input_type -> downloader.SetLogPrefixRequest
-	6,  // 6: downloader.Downloader.Completed:input_type -> downloader.CompletedRequest
-	10, // 7: downloader.Downloader.CommitPreverified:input_type -> downloader.CommitPreverifiedRequest
-	12, // 8: downloader.Downloader.Add:output_type -> google.protobuf.Empty
-	12, // 9: downloader.Downloader.Delete:output_type -> google.protobuf.Empty
-	12, // 10: downloader.Downloader.SetLogPrefix:output_type -> google.protobuf.Empty
-	7,  // 11: downloader.Downloader.Completed:output_type -> downloader.CompletedReply
-	12, // 12: downloader.Downloader.CommitPreverified:output_type -> google.protobuf.Empty
-	8,  // [8:13] is the sub-list for method output_type
-	3,  // [3:8] is the sub-list for method input_type
+	10, // 2: downloader.TorrentCompletedReply.hash:type_name -> types.H160
+	4,  // 3: downloader.Downloader.ProhibitNewDownloads:input_type -> downloader.ProhibitNewDownloadsRequest
+	1,  // 4: downloader.Downloader.Add:input_type -> downloader.AddRequest
+	2,  // 5: downloader.Downloader.Delete:input_type -> downloader.DeleteRequest
+	3,  // 6: downloader.Downloader.Verify:input_type -> downloader.VerifyRequest
+	5,  // 7: downloader.Downloader.SetLogPrefix:input_type -> downloader.SetLogPrefixRequest
+	6,  // 8: downloader.Downloader.Completed:input_type -> downloader.CompletedRequest
+	8,  // 9: downloader.Downloader.TorrentCompleted:input_type -> downloader.TorrentCompletedRequest
+	11, // 10: downloader.Downloader.ProhibitNewDownloads:output_type -> google.protobuf.Empty
+	11, // 11: downloader.Downloader.Add:output_type -> google.protobuf.Empty
+	11, // 12: downloader.Downloader.Delete:output_type -> google.protobuf.Empty
+	11, // 13: downloader.Downloader.Verify:output_type -> google.protobuf.Empty
+	11, // 14: downloader.Downloader.SetLogPrefix:output_type -> google.protobuf.Empty
+	7,  // 15: downloader.Downloader.Completed:output_type -> downloader.CompletedReply
+	9,  // 16: downloader.Downloader.TorrentCompleted:output_type -> downloader.TorrentCompletedReply
+	10, // [10:17] is the sub-list for method output_type
+	3,  // [3:10] is the sub-list for method input_type
 	3,  // [3:3] is the sub-list for extension type_name
 	3,  // [3:3] is the sub-list for extension extendee
 	0,  // [0:3] is the sub-list for field type_name
@@ -612,7 +561,7 @@ func file_downloader_downloader_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_downloader_downloader_proto_rawDesc), len(file_downloader_downloader_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   11,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/erigon-lib/gointerfaces/downloaderproto/downloader_client_mock.go
+++ b/erigon-lib/gointerfaces/downloaderproto/downloader_client_mock.go
@@ -25,11 +25,6 @@ type MockDownloaderClient struct {
 	isgomock struct{}
 }
 
-func (m *MockDownloaderClient) CommitPreverified(ctx context.Context, in *CommitPreverifiedRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
-	//TODO implement me
-	panic("implement me")
-}
-
 // MockDownloaderClientMockRecorder is the mock recorder for MockDownloaderClient.
 type MockDownloaderClientMockRecorder struct {
 	mock *MockDownloaderClient

--- a/erigon-lib/gointerfaces/downloaderproto/downloader_grpc.pb.go
+++ b/erigon-lib/gointerfaces/downloaderproto/downloader_grpc.pb.go
@@ -20,25 +20,34 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	Downloader_Add_FullMethodName               = "/downloader.Downloader/Add"
-	Downloader_Delete_FullMethodName            = "/downloader.Downloader/Delete"
-	Downloader_SetLogPrefix_FullMethodName      = "/downloader.Downloader/SetLogPrefix"
-	Downloader_Completed_FullMethodName         = "/downloader.Downloader/Completed"
-	Downloader_CommitPreverified_FullMethodName = "/downloader.Downloader/CommitPreverified"
+	Downloader_ProhibitNewDownloads_FullMethodName = "/downloader.Downloader/ProhibitNewDownloads"
+	Downloader_Add_FullMethodName                  = "/downloader.Downloader/Add"
+	Downloader_Delete_FullMethodName               = "/downloader.Downloader/Delete"
+	Downloader_Verify_FullMethodName               = "/downloader.Downloader/Verify"
+	Downloader_SetLogPrefix_FullMethodName         = "/downloader.Downloader/SetLogPrefix"
+	Downloader_Completed_FullMethodName            = "/downloader.Downloader/Completed"
+	Downloader_TorrentCompleted_FullMethodName     = "/downloader.Downloader/TorrentCompleted"
 )
 
 // DownloaderClient is the client API for Downloader service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type DownloaderClient interface {
+	// Erigon "download once" - means restart/upgrade/downgrade will not download files (and will be fast)
+	// After "download once" - Erigon will produce and seed new files
+	// Downloader will able: seed new files (already existing on FS), download uncomplete parts of existing files (if Verify found some bad parts)
+	ProhibitNewDownloads(ctx context.Context, in *ProhibitNewDownloadsRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// Adding new file to downloader: non-existing files it will download, existing - seed
 	Add(ctx context.Context, in *AddRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	Delete(ctx context.Context, in *DeleteRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// Trigger verification of files
+	// If some part of file is bad - such part will be re-downloaded (without returning error)
+	Verify(ctx context.Context, in *VerifyRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// Set log prefix for downloader
 	SetLogPrefix(ctx context.Context, in *SetLogPrefixRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// Get is download completed
 	Completed(ctx context.Context, in *CompletedRequest, opts ...grpc.CallOption) (*CompletedReply, error)
-	CommitPreverified(ctx context.Context, in *CommitPreverifiedRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	TorrentCompleted(ctx context.Context, in *TorrentCompletedRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[TorrentCompletedReply], error)
 }
 
 type downloaderClient struct {
@@ -47,6 +56,16 @@ type downloaderClient struct {
 
 func NewDownloaderClient(cc grpc.ClientConnInterface) DownloaderClient {
 	return &downloaderClient{cc}
+}
+
+func (c *downloaderClient) ProhibitNewDownloads(ctx context.Context, in *ProhibitNewDownloadsRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(emptypb.Empty)
+	err := c.cc.Invoke(ctx, Downloader_ProhibitNewDownloads_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (c *downloaderClient) Add(ctx context.Context, in *AddRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
@@ -63,6 +82,16 @@ func (c *downloaderClient) Delete(ctx context.Context, in *DeleteRequest, opts .
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(emptypb.Empty)
 	err := c.cc.Invoke(ctx, Downloader_Delete_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *downloaderClient) Verify(ctx context.Context, in *VerifyRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(emptypb.Empty)
+	err := c.cc.Invoke(ctx, Downloader_Verify_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -89,28 +118,44 @@ func (c *downloaderClient) Completed(ctx context.Context, in *CompletedRequest, 
 	return out, nil
 }
 
-func (c *downloaderClient) CommitPreverified(ctx context.Context, in *CommitPreverifiedRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+func (c *downloaderClient) TorrentCompleted(ctx context.Context, in *TorrentCompletedRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[TorrentCompletedReply], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(emptypb.Empty)
-	err := c.cc.Invoke(ctx, Downloader_CommitPreverified_FullMethodName, in, out, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &Downloader_ServiceDesc.Streams[0], Downloader_TorrentCompleted_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
-	return out, nil
+	x := &grpc.GenericClientStream[TorrentCompletedRequest, TorrentCompletedReply]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
 }
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type Downloader_TorrentCompletedClient = grpc.ServerStreamingClient[TorrentCompletedReply]
 
 // DownloaderServer is the server API for Downloader service.
 // All implementations must embed UnimplementedDownloaderServer
 // for forward compatibility.
 type DownloaderServer interface {
+	// Erigon "download once" - means restart/upgrade/downgrade will not download files (and will be fast)
+	// After "download once" - Erigon will produce and seed new files
+	// Downloader will able: seed new files (already existing on FS), download uncomplete parts of existing files (if Verify found some bad parts)
+	ProhibitNewDownloads(context.Context, *ProhibitNewDownloadsRequest) (*emptypb.Empty, error)
 	// Adding new file to downloader: non-existing files it will download, existing - seed
 	Add(context.Context, *AddRequest) (*emptypb.Empty, error)
 	Delete(context.Context, *DeleteRequest) (*emptypb.Empty, error)
+	// Trigger verification of files
+	// If some part of file is bad - such part will be re-downloaded (without returning error)
+	Verify(context.Context, *VerifyRequest) (*emptypb.Empty, error)
 	// Set log prefix for downloader
 	SetLogPrefix(context.Context, *SetLogPrefixRequest) (*emptypb.Empty, error)
 	// Get is download completed
 	Completed(context.Context, *CompletedRequest) (*CompletedReply, error)
-	CommitPreverified(context.Context, *CommitPreverifiedRequest) (*emptypb.Empty, error)
+	TorrentCompleted(*TorrentCompletedRequest, grpc.ServerStreamingServer[TorrentCompletedReply]) error
 	mustEmbedUnimplementedDownloaderServer()
 }
 
@@ -121,11 +166,17 @@ type DownloaderServer interface {
 // pointer dereference when methods are called.
 type UnimplementedDownloaderServer struct{}
 
+func (UnimplementedDownloaderServer) ProhibitNewDownloads(context.Context, *ProhibitNewDownloadsRequest) (*emptypb.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ProhibitNewDownloads not implemented")
+}
 func (UnimplementedDownloaderServer) Add(context.Context, *AddRequest) (*emptypb.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Add not implemented")
 }
 func (UnimplementedDownloaderServer) Delete(context.Context, *DeleteRequest) (*emptypb.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Delete not implemented")
+}
+func (UnimplementedDownloaderServer) Verify(context.Context, *VerifyRequest) (*emptypb.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Verify not implemented")
 }
 func (UnimplementedDownloaderServer) SetLogPrefix(context.Context, *SetLogPrefixRequest) (*emptypb.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SetLogPrefix not implemented")
@@ -133,8 +184,8 @@ func (UnimplementedDownloaderServer) SetLogPrefix(context.Context, *SetLogPrefix
 func (UnimplementedDownloaderServer) Completed(context.Context, *CompletedRequest) (*CompletedReply, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Completed not implemented")
 }
-func (UnimplementedDownloaderServer) CommitPreverified(context.Context, *CommitPreverifiedRequest) (*emptypb.Empty, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method CommitPreverified not implemented")
+func (UnimplementedDownloaderServer) TorrentCompleted(*TorrentCompletedRequest, grpc.ServerStreamingServer[TorrentCompletedReply]) error {
+	return status.Errorf(codes.Unimplemented, "method TorrentCompleted not implemented")
 }
 func (UnimplementedDownloaderServer) mustEmbedUnimplementedDownloaderServer() {}
 func (UnimplementedDownloaderServer) testEmbeddedByValue()                    {}
@@ -155,6 +206,24 @@ func RegisterDownloaderServer(s grpc.ServiceRegistrar, srv DownloaderServer) {
 		t.testEmbeddedByValue()
 	}
 	s.RegisterService(&Downloader_ServiceDesc, srv)
+}
+
+func _Downloader_ProhibitNewDownloads_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ProhibitNewDownloadsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DownloaderServer).ProhibitNewDownloads(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Downloader_ProhibitNewDownloads_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DownloaderServer).ProhibitNewDownloads(ctx, req.(*ProhibitNewDownloadsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
 func _Downloader_Add_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
@@ -189,6 +258,24 @@ func _Downloader_Delete_Handler(srv interface{}, ctx context.Context, dec func(i
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(DownloaderServer).Delete(ctx, req.(*DeleteRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Downloader_Verify_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(VerifyRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DownloaderServer).Verify(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Downloader_Verify_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DownloaderServer).Verify(ctx, req.(*VerifyRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -229,23 +316,16 @@ func _Downloader_Completed_Handler(srv interface{}, ctx context.Context, dec fun
 	return interceptor(ctx, in, info, handler)
 }
 
-func _Downloader_CommitPreverified_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(CommitPreverifiedRequest)
-	if err := dec(in); err != nil {
-		return nil, err
+func _Downloader_TorrentCompleted_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(TorrentCompletedRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
 	}
-	if interceptor == nil {
-		return srv.(DownloaderServer).CommitPreverified(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: Downloader_CommitPreverified_FullMethodName,
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DownloaderServer).CommitPreverified(ctx, req.(*CommitPreverifiedRequest))
-	}
-	return interceptor(ctx, in, info, handler)
+	return srv.(DownloaderServer).TorrentCompleted(m, &grpc.GenericServerStream[TorrentCompletedRequest, TorrentCompletedReply]{ServerStream: stream})
 }
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type Downloader_TorrentCompletedServer = grpc.ServerStreamingServer[TorrentCompletedReply]
 
 // Downloader_ServiceDesc is the grpc.ServiceDesc for Downloader service.
 // It's only intended for direct use with grpc.RegisterService,
@@ -255,12 +335,20 @@ var Downloader_ServiceDesc = grpc.ServiceDesc{
 	HandlerType: (*DownloaderServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
+			MethodName: "ProhibitNewDownloads",
+			Handler:    _Downloader_ProhibitNewDownloads_Handler,
+		},
+		{
 			MethodName: "Add",
 			Handler:    _Downloader_Add_Handler,
 		},
 		{
 			MethodName: "Delete",
 			Handler:    _Downloader_Delete_Handler,
+		},
+		{
+			MethodName: "Verify",
+			Handler:    _Downloader_Verify_Handler,
 		},
 		{
 			MethodName: "SetLogPrefix",
@@ -270,11 +358,13 @@ var Downloader_ServiceDesc = grpc.ServiceDesc{
 			MethodName: "Completed",
 			Handler:    _Downloader_Completed_Handler,
 		},
+	},
+	Streams: []grpc.StreamDesc{
 		{
-			MethodName: "CommitPreverified",
-			Handler:    _Downloader_CommitPreverified_Handler,
+			StreamName:    "TorrentCompleted",
+			Handler:       _Downloader_TorrentCompleted_Handler,
+			ServerStreams: true,
 		},
 	},
-	Streams:  []grpc.StreamDesc{},
 	Metadata: "downloader/downloader.proto",
 }


### PR DESCRIPTION
The command `make -C erigon-lib` fails after #15912 because of empty BUILD_TAGS in erigon-lib.

Changes:
- remove BUILD_TAGS from erigon-lib (not sure about this, do we need to pass them from command-line sometimes?)
- update some Downloader files after successful generation