### PR TITLE
resolve flaky TestSetupGenesis: different tmpdir for each parallel test

### DIFF
--- a/execution/stages/genesis_test.go
+++ b/execution/stages/genesis_test.go
@@ -55,20 +55,19 @@ func TestSetupGenesis(t *testing.T) {
 			},
 		}
 		oldcustomg = customg
-		tmpdir     = t.TempDir()
 	)
 	logger := log.New()
 	oldcustomg.Config = &chain.Config{ChainID: big.NewInt(1), HomesteadBlock: big.NewInt(2)}
 	tests := []struct {
 		wantErr    error
-		fn         func(t *testing.T, db kv.RwDB) (*chain.Config, *types.Block, error)
+		fn         func(t *testing.T, db kv.RwDB, tmpdir string) (*chain.Config, *types.Block, error)
 		wantConfig *chain.Config
 		name       string
 		wantHash   common.Hash
 	}{
 		{
 			name: "genesis without ChainConfig",
-			fn: func(t *testing.T, db kv.RwDB) (*chain.Config, *types.Block, error) {
+			fn: func(t *testing.T, db kv.RwDB, tmpdir string) (*chain.Config, *types.Block, error) {
 				return core.CommitGenesisBlock(db, new(types.Genesis), datadir.New(tmpdir), logger)
 			},
 			wantErr:    types.ErrGenesisNoConfig,
@@ -76,7 +75,7 @@ func TestSetupGenesis(t *testing.T) {
 		},
 		{
 			name: "no block in DB, genesis == nil",
-			fn: func(t *testing.T, db kv.RwDB) (*chain.Config, *types.Block, error) {
+			fn: func(t *testing.T, db kv.RwDB, tmpdir string) (*chain.Config, *types.Block, error) {
 				return core.CommitGenesisBlock(db, nil, datadir.New(tmpdir), logger)
 			},
 			wantHash:   chainspec.MainnetGenesisHash,
@@ -84,7 +83,7 @@ func TestSetupGenesis(t *testing.T) {
 		},
 		{
 			name: "mainnet block in DB, genesis == nil",
-			fn: func(t *testing.T, db kv.RwDB) (*chain.Config, *types.Block, error) {
+			fn: func(t *testing.T, db kv.RwDB, tmpdir string) (*chain.Config, *types.Block, error) {
 				return core.CommitGenesisBlock(db, nil, datadir.New(tmpdir), logger)
 			},
 			wantHash:   chainspec.MainnetGenesisHash,
@@ -92,7 +91,7 @@ func TestSetupGenesis(t *testing.T) {
 		},
 		{
 			name: "custom block in DB, genesis == nil",
-			fn: func(t *testing.T, db kv.RwDB) (*chain.Config, *types.Block, error) {
+			fn: func(t *testing.T, db kv.RwDB, tmpdir string) (*chain.Config, *types.Block, error) {
 				core.MustCommitGenesis(&customg, db, datadir.New(tmpdir), logger)
 				return core.CommitGenesisBlock(db, nil, datadir.New(tmpdir), logger)
 			},
@@ -101,7 +100,7 @@ func TestSetupGenesis(t *testing.T) {
 		},
 		{
 			name: "custom block in DB, genesis == sepolia",
-			fn: func(t *testing.T, db kv.RwDB) (*chain.Config, *types.Block, error) {
+			fn: func(t *testing.T, db kv.RwDB, tmpdir string) (*chain.Config, *types.Block, error) {
 				core.MustCommitGenesis(&customg, db, datadir.New(tmpdir), logger)
 				return core.CommitGenesisBlock(db, chainspec.SepoliaGenesisBlock(), datadir.New(tmpdir), logger)
 			},
@@ -111,7 +110,7 @@ func TestSetupGenesis(t *testing.T) {
 		},
 		{
 			name: "custom block in DB, genesis == bor-mainnet",
-			fn: func(t *testing.T, db kv.RwDB) (*chain.Config, *types.Block, error) {
+			fn: func(t *testing.T, db kv.RwDB, tmpdir string) (*chain.Config, *types.Block, error) {
 				core.MustCommitGenesis(&customg, db, datadir.New(tmpdir), logger)
 				return core.CommitGenesisBlock(db, polychain.BorMainnetGenesisBlock(), datadir.New(tmpdir), logger)
 			},
@@ -121,7 +120,7 @@ func TestSetupGenesis(t *testing.T) {
 		},
 		{
 			name: "custom block in DB, genesis == amoy",
-			fn: func(t *testing.T, db kv.RwDB) (*chain.Config, *types.Block, error) {
+			fn: func(t *testing.T, db kv.RwDB, tmpdir string) (*chain.Config, *types.Block, error) {
 				core.MustCommitGenesis(&customg, db, datadir.New(tmpdir), logger)
 				return core.CommitGenesisBlock(db, polychain.AmoyGenesisBlock(), datadir.New(tmpdir), logger)
 			},
@@ -131,7 +130,7 @@ func TestSetupGenesis(t *testing.T) {
 		},
 		{
 			name: "compatible config in DB",
-			fn: func(t *testing.T, db kv.RwDB) (*chain.Config, *types.Block, error) {
+			fn: func(t *testing.T, db kv.RwDB, tmpdir string) (*chain.Config, *types.Block, error) {
 				core.MustCommitGenesis(&oldcustomg, db, datadir.New(tmpdir), logger)
 				return core.CommitGenesisBlock(db, &customg, datadir.New(tmpdir), logger)
 			},
@@ -140,7 +139,7 @@ func TestSetupGenesis(t *testing.T) {
 		},
 		{
 			name: "incompatible config in DB",
-			fn: func(t *testing.T, db kv.RwDB) (*chain.Config, *types.Block, error) {
+			fn: func(t *testing.T, db kv.RwDB, tmpdir string) (*chain.Config, *types.Block, error) {
 				//if ethconfig.EnableHistoryV4InTest {
 				//	t.Skip("fix me")
 				//}
@@ -174,13 +173,14 @@ func TestSetupGenesis(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
+			tmpdir := t.TempDir()
 			dirs := datadir.New(tmpdir)
 			db := temporaltest.NewTestDB(t, dirs)
 			//cc := tool.ChainConfigFromDB(db)
 			freezingCfg := ethconfig.Defaults.Snapshot
 			//freezingCfg.ChainName = cc.ChainName //TODO: nil-pointer?
 			blockReader := freezeblocks.NewBlockReader(freezeblocks.NewRoSnapshots(freezingCfg, dirs.Snap, 0, log.New()), heimdall.NewRoSnapshots(freezingCfg, dirs.Snap, 0, log.New()), nil, nil)
-			config, genesis, err := test.fn(t, db)
+			config, genesis, err := test.fn(t, db, tmpdir)
 			// Check the return values.
 			if !reflect.DeepEqual(err, test.wantErr) {
 				spew := spew.ConfigState{DisablePointerAddresses: true, DisableCapacities: true}


### PR DESCRIPTION
issue: https://github.com/erigontech/erigon/issues/15976


can see from stacktrace that a temporaldb is closed, while salt is created by another goroutine. Better to use separate tmpdir since these are parallel tests.