### PR TITLE
erigon-db/rawdb: fix prune table periodic log

### DIFF
--- a/erigon-db/rawdb/accessors_chain.go
+++ b/erigon-db/rawdb/accessors_chain.go
@@ -1107,7 +1107,7 @@ func PruneTable(tx kv.RwTx, table string, pruneTo uint64, ctx context.Context, l
 
 		select {
 		case <-logEvery.C:
-			logger.Info(fmt.Sprintf("[%s] pruning table periodic progress", logPrefix), table, "blockNum", blockNum)
+			logger.Info(fmt.Sprintf("[%s] pruning table periodic progress", logPrefix), "table", table, "blockNum", blockNum)
 		default:
 		}
 


### PR DESCRIPTION
fixes:
```
[INFO] [07-14|10:52:37.471] [4/6 Execution Prune] pruning table periodic progress ChangeSets3=blockNum LOG15_ERROR= LOG15_ERROR="Normalized odd number of arguments by adding nil"
```
