### PR TITLE
backend: create new salt file if unknown snap cfg for chain name

### DIFF
--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -333,7 +333,8 @@ func Downloader(ctx context.Context, logger log.Logger) error {
 	d.MainLoopInBackground(false)
 	if seedbox {
 		var downloadItems []*proto_downloader.AddItem
-		for _, it := range snapcfg.KnownCfg(chain).Preverified.Items {
+		snapCfg, _ := snapcfg.KnownCfg(chain)
+		for _, it := range snapCfg.Preverified.Items {
 			downloadItems = append(downloadItems, &proto_downloader.AddItem{
 				Path:        it.Name,
 				TorrentHash: downloadergrpc.String2Proto(it.Hash),

--- a/cmd/snapshots/sync/sync.go
+++ b/cmd/snapshots/sync/sync.go
@@ -32,6 +32,9 @@ import (
 	"github.com/anacrolix/torrent"
 	"github.com/anacrolix/torrent/metainfo"
 	"github.com/anacrolix/torrent/storage"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/erigontech/erigon-db/downloader"
 	"github.com/erigontech/erigon-db/downloader/downloadercfg"
 	"github.com/erigontech/erigon-lib/chain/snapcfg"
@@ -45,8 +48,6 @@ import (
 	"github.com/erigontech/erigon/cmd/utils"
 	"github.com/erigontech/erigon/p2p/nat"
 	"github.com/erigontech/erigon/params"
-	"github.com/urfave/cli/v2"
-	"golang.org/x/sync/errgroup"
 )
 
 type LType int
@@ -455,7 +456,8 @@ func (s *torrentSession) Label() string {
 
 func NewTorrentSession(cli *TorrentClient, chain string) *torrentSession {
 	session := &torrentSession{cli, map[string]snapcfg.PreverifiedItem{}}
-	for _, it := range snapcfg.KnownCfg(chain).Preverified.Items {
+	snapCfg, _ := snapcfg.KnownCfg(chain)
+	for _, it := range snapCfg.Preverified.Items {
 		session.items[it.Name] = it
 	}
 

--- a/erigon-db/downloader/downloadercfg/downloadercfg.go
+++ b/erigon-db/downloader/downloadercfg/downloadercfg.go
@@ -36,6 +36,7 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/anacrolix/torrent"
+
 	"github.com/erigontech/erigon-lib/chain/networkname"
 	"github.com/erigontech/erigon-lib/chain/snapcfg"
 	"github.com/erigontech/erigon-lib/common/datadir"
@@ -314,7 +315,7 @@ func LoadSnapshotsHashes(ctx context.Context, dirs datadir.Dirs, chainName strin
 			return nil, fmt.Errorf("remote snapshot hashes was not fetched for chain %s", chainName)
 		}
 	}
-	cfg := snapcfg.KnownCfg(chainName)
+	cfg, _ := snapcfg.KnownCfg(chainName)
 	cfg.Local = exists
 	return cfg, nil
 }

--- a/erigon-db/downloader/util.go
+++ b/erigon-db/downloader/util.go
@@ -76,7 +76,7 @@ func seedableSegmentFiles(dir string, chainName string, skipSeedableCheck bool) 
 		return nil, err
 	}
 
-	segConfig := snapcfg.KnownCfg(chainName)
+	segConfig, _ := snapcfg.KnownCfg(chainName)
 
 	res := make([]string, 0, len(files))
 	for _, fPath := range files {

--- a/erigon-lib/chain/snapcfg/util.go
+++ b/erigon-lib/chain/snapcfg/util.go
@@ -494,7 +494,8 @@ func Seedable(networkName string, info snaptype.FileInfo) bool {
 	if networkName == "" {
 		return false
 	}
-	return KnownCfg(networkName).Seedable(info)
+	snapCfg, _ := KnownCfg(networkName)
+	return snapCfg.Seedable(info)
 }
 
 func MergeLimitFromCfg(cfg *Cfg, snapType snaptype.Enum, fromBlock uint64) uint64 {
@@ -503,7 +504,7 @@ func MergeLimitFromCfg(cfg *Cfg, snapType snaptype.Enum, fromBlock uint64) uint6
 
 func MaxSeedableSegment(chain string, dir string) uint64 {
 	var _max uint64
-	segConfig := KnownCfg(chain)
+	segConfig, _ := KnownCfg(chain)
 	if list, err := snaptype.Segments(dir); err == nil {
 		for _, info := range list {
 			if segConfig.Seedable(info) && info.Type.Enum() == snaptype.MinCoreEnum && info.To > _max {
@@ -528,12 +529,12 @@ func MergeStepsFromCfg(cfg *Cfg, snapType snaptype.Enum, fromBlock uint64) []uin
 }
 
 // KnownCfg return list of preverified hashes for given network, but apply whiteList filter if it's not empty
-func KnownCfg(networkName string) *Cfg {
+func KnownCfg(networkName string) (*Cfg, bool) {
 	c, ok := knownPreverified[networkName]
 	if !ok {
-		return newCfg(networkName, Preverified{})
+		return newCfg(networkName, Preverified{}), false
 	}
-	return newCfg(networkName, c.Typed(knownTypes[networkName]))
+	return newCfg(networkName, c.Typed(knownTypes[networkName])), true
 }
 
 var KnownWebseeds = map[string][]string{

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1564,7 +1564,8 @@ func setUpBlockReader(ctx context.Context, db kv.RwDB, dirs datadir.Dirs, snConf
 	}
 	blockReader := freezeblocks.NewBlockReader(allSnapshots, allBorSnapshots, heimdallStore, bridgeStore)
 
-	createNewSaltFileIfNeeded := snConfig.Snapshot.NoDownloader || snConfig.Snapshot.DisableDownloadE3
+	_, knownSnapCfg := snapcfg.KnownCfg(chainConfig.ChainName)
+	createNewSaltFileIfNeeded := snConfig.Snapshot.NoDownloader || snConfig.Snapshot.DisableDownloadE3 || !knownSnapCfg
 	salt, err := libstate.GetStateIndicesSalt(dirs, createNewSaltFileIfNeeded, logger)
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, err

--- a/execution/stagedsync/stage_snapshots.go
+++ b/execution/stagedsync/stage_snapshots.go
@@ -719,7 +719,8 @@ func (u *snapshotUploader) seedable(fi snaptype.FileInfo) bool {
 	}
 
 	if checkKnownSizes {
-		for _, it := range snapcfg.KnownCfg(u.cfg.chainConfig.ChainName).Preverified.Items {
+		snapCfg, _ := snapcfg.KnownCfg(u.cfg.chainConfig.ChainName)
+		for _, it := range snapCfg.Preverified.Items {
 			info, _, _ := snaptype.ParseFileName("", it.Name)
 
 			if fi.From == info.From {

--- a/turbo/app/init_cmd.go
+++ b/turbo/app/init_cmd.go
@@ -25,7 +25,6 @@ import (
 	"github.com/erigontech/erigon-lib/common/datadir"
 	"github.com/erigontech/erigon-lib/kv"
 	"github.com/erigontech/erigon-lib/log/v3"
-	"github.com/erigontech/erigon-lib/state"
 	"github.com/erigontech/erigon-lib/types"
 	"github.com/erigontech/erigon/cmd/utils"
 	"github.com/erigontech/erigon/core"
@@ -88,12 +87,6 @@ func initGenesis(cliCtx *cli.Context) error {
 	chaindb, err := node.OpenDatabase(cliCtx.Context, stack.Config(), kv.ChainDB, "", false, logger)
 	if err != nil {
 		utils.Fatalf("Failed to open database: %v", err)
-	}
-
-	// need to call this to initialise the state-salt if not present
-	_, err = state.GetStateIndicesSalt(stack.Config().Dirs, true, logger)
-	if err != nil {
-		utils.Fatalf("Failed to get state indices salt: %v", err)
 	}
 
 	if tracer != nil {

--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -129,7 +129,8 @@ func chooseSegmentEnd(from, to uint64, snapType snaptype.Enum, chainConfig *chai
 	if chainConfig != nil {
 		chainName = chainConfig.ChainName
 	}
-	blocksPerFile := snapcfg.MergeLimitFromCfg(snapcfg.KnownCfg(chainName), snapType, from)
+	snapCfg, _ := snapcfg.KnownCfg(chainName)
+	blocksPerFile := snapcfg.MergeLimitFromCfg(snapCfg, snapType, from)
 
 	next := (from/blocksPerFile + 1) * blocksPerFile
 	to = min(next, to)

--- a/turbo/snapshotsync/freezeblocks/caplin_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/caplin_snapshots.go
@@ -581,7 +581,7 @@ func DumpBlobSidecarsRange(ctx context.Context, db kv.RoDB, storage blob_storage
 }
 
 func DumpBeaconBlocks(ctx context.Context, db kv.RoDB, fromSlot, toSlot uint64, salt uint32, dirs datadir.Dirs, workers int, lvl log.Lvl, logger log.Logger) error {
-	cfg := snapcfg.KnownCfg("")
+	cfg, _ := snapcfg.KnownCfg("")
 	for i := fromSlot; i < toSlot; i = chooseSegmentEnd(i, toSlot, snaptype.CaplinEnums.BeaconBlocks, nil) {
 		blocksPerFile := snapcfg.MergeLimitFromCfg(cfg, snaptype.CaplinEnums.BeaconBlocks, i)
 
@@ -600,7 +600,7 @@ func DumpBeaconBlocks(ctx context.Context, db kv.RoDB, fromSlot, toSlot uint64, 
 type BlobCountBySlotFn func(slot uint64) (uint64, error)
 
 func DumpBlobsSidecar(ctx context.Context, blobStorage blob_storage.BlobStorage, db kv.RoDB, fromSlot, toSlot uint64, salt uint32, dirs datadir.Dirs, compressWorkers int, blobCountFn BlobCountBySlotFn, lvl log.Lvl, logger log.Logger) error {
-	cfg := snapcfg.KnownCfg("")
+	cfg, _ := snapcfg.KnownCfg("")
 	for i := fromSlot; i < toSlot; i = chooseSegmentEnd(i, toSlot, snaptype.CaplinEnums.BlobSidecars, nil) {
 		blocksPerFile := snapcfg.MergeLimitFromCfg(cfg, snaptype.CaplinEnums.BlobSidecars, i)
 

--- a/turbo/snapshotsync/freezeblocks/dump_test.go
+++ b/turbo/snapshotsync/freezeblocks/dump_test.go
@@ -262,7 +262,7 @@ func TestDump(t *testing.T) {
 			logger := log.New()
 
 			tmpDir, snapDir := t.TempDir(), t.TempDir()
-			snConfig := snapcfg.KnownCfg(networkname.Mainnet)
+			snConfig, _ := snapcfg.KnownCfg(networkname.Mainnet)
 			snConfig.ExpectBlocks = math.MaxUint64
 
 			err := freezeblocks.DumpBlocks(m.Ctx, 0, uint64(test.chainSize), m.ChainConfig, tmpDir, snapDir, m.DB, 1, log.LvlInfo, logger, m.BlockReader)

--- a/turbo/snapshotsync/merger.go
+++ b/turbo/snapshotsync/merger.go
@@ -36,7 +36,7 @@ func NewMerger(tmpDir string, compressWorkers int, lvl log.Lvl, chainDB kv.RoDB,
 func (m *Merger) DisableFsync() { m.noFsync = true }
 
 func (m *Merger) FindMergeRanges(currentRanges []Range, maxBlockNum uint64) (toMerge []Range) {
-	cfg := snapcfg.KnownCfg(m.chainConfig.ChainName)
+	cfg, _ := snapcfg.KnownCfg(m.chainConfig.ChainName)
 	for i := len(currentRanges) - 1; i > 0; i-- {
 		r := currentRanges[i]
 		mergeLimit := cfg.MergeLimit(snaptype.Unknown, r.From())

--- a/turbo/snapshotsync/snapshots.go
+++ b/turbo/snapshotsync/snapshots.go
@@ -202,7 +202,8 @@ func CanRetire(from, to uint64, snapType snaptype.Enum, chainConfig *chain.Confi
 		chainName = chainConfig.ChainName
 	}
 
-	mergeLimit := snapcfg.MergeLimitFromCfg(snapcfg.KnownCfg(chainName), snapType, blockFrom)
+	snapCfg, _ := snapcfg.KnownCfg(chainName)
+	mergeLimit := snapcfg.MergeLimitFromCfg(snapCfg, snapType, blockFrom)
 
 	if blockFrom%mergeLimit == 0 {
 		maxJump = mergeLimit
@@ -1047,7 +1048,7 @@ func (s *RoSnapshots) openSegments(fileNames []string, open bool, optimistic boo
 	//fmt.Println("RS", s)
 	//defer fmt.Println("Done RS", s)
 
-	snConfig := snapcfg.KnownCfg(s.cfg.ChainName)
+	snConfig, _ := snapcfg.KnownCfg(s.cfg.ChainName)
 
 	for _, fName := range fileNames {
 		f, isState, ok := snaptype.ParseFileName(s.dir, fName)

--- a/turbo/snapshotsync/snapshots_test.go
+++ b/turbo/snapshotsync/snapshots_test.go
@@ -473,7 +473,7 @@ func TestOpenAllSnapshot(t *testing.T) {
 	for i, chain := range []string{networkname.Mainnet, networkname.Amoy} {
 		step := steps[i]
 		dir := filepath.Join(baseDir, chain)
-		chainSnapshotCfg := snapcfg.KnownCfg(chain)
+		chainSnapshotCfg, _ := snapcfg.KnownCfg(chain)
 		chainSnapshotCfg.ExpectBlocks = math.MaxUint64
 		cfg := ethconfig.BlocksFreezing{ChainName: chain}
 		createFile := func(from, to uint64, name snaptype.Type) {

--- a/turbo/snapshotsync/snapshotsync.go
+++ b/turbo/snapshotsync/snapshotsync.go
@@ -357,7 +357,7 @@ func SyncSnapshots(
 	// - After "download once" - Erigon will produce and seed new files
 
 	// send all hashes to the Downloader service
-	snapCfg := snapcfg.KnownCfg(cc.ChainName)
+	snapCfg, _ := snapcfg.KnownCfg(cc.ChainName)
 	preverifiedBlockSnapshots := snapCfg.Preverified
 	downloadRequest := make([]DownloadRequest, 0, len(preverifiedBlockSnapshots.Items))
 


### PR DESCRIPTION
closes https://github.com/erigontech/erigon/issues/15880
reverts https://github.com/erigontech/erigon/pull/15606

panic due to missing state salt file happened because the user run a testnet (e.g. with `--networkid=7032118028`) but they hadn't set `--no-downloader`

we can continue syncing even without `--no-downloader` (stage snapshots will be no-op since there is no snapshots toml file) so we should detect that and create the salt file on startup in this scenario