### PR TITLE
ethstats: optimize regex compilation by moving it to package level

### DIFF
--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -55,6 +55,11 @@ const (
 	historyUpdateRange = 50
 )
 
+var (
+	// urlRegex is a regular expression for parsing netstats connection URL
+	urlRegex = regexp.MustCompile("([^:@]*)(:([^@]*))?@(.+)")
+)
+
 // Service implements an Ethereum netstats reporting daemon that pushes local
 // chain statistics up to a monitoring server.
 type Service struct {
@@ -130,8 +135,7 @@ func (w *connWrapper) Close() error {
 func New(node *node.Node, servers []*sentry.GrpcServer, chainDB kv.RoDB, blockReader services.FullBlockReader,
 	engine consensus.Engine, url string, networkid uint64, quitCh <-chan struct{}, headCh chan [][]byte, txPoolRpcClient txpool.TxpoolClient) error {
 	// Parse the netstats connection url
-	re := regexp.MustCompile("([^:@]*)(:([^@]*))?@(.+)")
-	parts := re.FindStringSubmatch(url)
+	parts := urlRegex.FindStringSubmatch(url)
 	if len(parts) != 5 {
 		return fmt.Errorf("invalid netstats url: \"%s\", should be nodename:secret@host:port", url)
 	}


### PR DESCRIPTION
Move the regex compilation for netstats URL parsing from the New function to the package level as a global variable. This avoids recompiling the regular expression on each function call, improving performance when the function is called multiple times.