### PR TITLE
kv: add periodic table size metrics and logs

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -30,13 +30,12 @@ import (
 	"time"
 
 	"github.com/c2h5oh/datasize"
+	"github.com/erigontech/mdbx-go/mdbx"
+	"github.com/erigontech/secp256k1"
 	lru "github.com/hashicorp/golang-lru/arc/v2"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
-
-	"github.com/erigontech/mdbx-go/mdbx"
-	"github.com/erigontech/secp256k1"
 
 	"github.com/erigontech/erigon-db/downloader"
 	"github.com/erigontech/erigon-db/rawdb"
@@ -309,28 +308,9 @@ var cmdPrintTableSizes = &cobra.Command{
 		}
 		defer db.Close()
 
-		allTablesCfg := db.AllTables()
-		allTables := make([]string, 0, len(allTablesCfg))
-		for table, cfg := range allTablesCfg {
-			if cfg.IsDeprecated {
-				continue
-			}
-
-			allTables = append(allTables, table)
-		}
-
-		var tableSizes []interface{}
-		err = db.View(cmd.Context(), func(tx kv.Tx) error {
-			tableSizes = stagedsync.CollectTableSizes(db, tx, allTables)
-			return nil
-		})
+		tableSizes, err := kv.CollectTableSizes(cmd.Context(), db)
 		if err != nil {
 			logger.Error("error while collecting table sizes", "err", err)
-			return
-		}
-
-		if len(tableSizes)%2 != 0 {
-			logger.Error("table sizes len not even", "len", len(tableSizes))
 			return
 		}
 
@@ -339,10 +319,10 @@ var cmdPrintTableSizes = &cobra.Command{
 		sb.WriteRune(',')
 		sb.WriteString("Size")
 		sb.WriteRune('\n')
-		for i := 0; i < len(tableSizes)/2; i++ {
-			sb.WriteString(tableSizes[i*2].(string))
+		for _, t := range tableSizes {
+			sb.WriteString(t.Name)
 			sb.WriteRune(',')
-			sb.WriteString(tableSizes[i*2+1].(string))
+			sb.WriteString(common.ByteCount(t.Size))
 			sb.WriteRune('\n')
 		}
 

--- a/erigon-lib/kv/table_sizes.go
+++ b/erigon-lib/kv/table_sizes.go
@@ -87,7 +87,7 @@ func CollectTableSizesPeriodically(ctx context.Context, db TemporalRoDB, label L
 		case <-ticker.C:
 			tableSizes, err := CollectTableSizes(ctx, db)
 			if err != nil {
-				logger.Error("[dbstats] failed to collect table sizes", "err", err)
+				logger.Error("[kv] failed to collect table sizes", "err", err)
 				continue
 			}
 
@@ -104,7 +104,7 @@ func CollectTableSizesPeriodically(ctx context.Context, db TemporalRoDB, label L
 				sb.WriteRune(',')
 			}
 
-			logger.Debug("[dbstats] table sizes", "all", sb.String())
+			logger.Debug("[kv] table sizes", "all", sb.String())
 		}
 	}
 }

--- a/erigon-lib/kv/table_sizes.go
+++ b/erigon-lib/kv/table_sizes.go
@@ -77,6 +77,7 @@ func CollectTableSizesPeriodically(ctx context.Context, db TemporalRoDB, label L
 		return
 	}
 
+	debugLogging := logger.Enabled(ctx, log.LvlDebug)
 	ticker := time.NewTicker(collectTableSizesFrequency)
 	defer ticker.Stop()
 
@@ -94,7 +95,7 @@ func CollectTableSizesPeriodically(ctx context.Context, db TemporalRoDB, label L
 			var sb strings.Builder
 			for _, t := range tableSizes {
 				dbTableSizeBytes.WithLabelValues(string(label), t.Name).Set(float64(t.Size))
-				if t.Size == 0 {
+				if t.Size == 0 || !debugLogging {
 					continue
 				}
 

--- a/erigon-lib/kv/table_sizes.go
+++ b/erigon-lib/kv/table_sizes.go
@@ -1,0 +1,110 @@
+package kv
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/common/dbg"
+	"github.com/erigontech/erigon-lib/log/v3"
+	"github.com/erigontech/erigon-lib/metrics"
+)
+
+var (
+	collectTableSizesPeriodically = dbg.EnvBool("COLLECT_TABLE_SIZES", true)
+	collectTableSizesFrequency    = dbg.EnvDuration("COLLECT_TABLE_SIZES_FREQUENCY", 5*time.Minute)
+	dbTableSizeBytes              = metrics.GetOrCreateGaugeVec("db_table_size_bytes", []string{"db", "table"})
+)
+
+type TableSize struct {
+	Name string
+	Size uint64
+}
+
+func CollectTableSizes(ctx context.Context, db RoDB) ([]TableSize, error) {
+	allTablesCfg := db.AllTables()
+	allTables := make([]string, 0, len(allTablesCfg))
+	for table, cfg := range allTablesCfg {
+		if cfg.IsDeprecated {
+			continue
+		}
+
+		allTables = append(allTables, table)
+	}
+
+	var freeListSize uint64
+	var err error
+	tableSizes := make([]TableSize, 0, len(allTables))
+	err = db.View(ctx, func(tx Tx) error {
+		for _, table := range allTables {
+			sz, err := tx.BucketSize(table)
+			if err != nil {
+				return err
+			}
+
+			tableSizes = append(tableSizes, TableSize{Name: table, Size: sz})
+		}
+
+		freeListSize, err = tx.BucketSize("freelist")
+		if err != nil {
+			return err
+		}
+
+		tableSizes = append(tableSizes, TableSize{Name: "Freelist", Size: freeListSize})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	amountOfFreePagesInDb := freeListSize / 4 // page_id encoded as bigEndian_u32
+	tableSizes = append(tableSizes, TableSize{
+		Name: "ReclaimableSpace",
+		Size: amountOfFreePagesInDb * db.PageSize().Bytes(),
+	})
+
+	sort.Slice(tableSizes, func(i, j int) bool {
+		return tableSizes[i].Size > tableSizes[j].Size
+	})
+
+	return tableSizes, nil
+}
+
+func CollectTableSizesPeriodically(ctx context.Context, db TemporalRoDB, label Label, logger log.Logger) {
+	if !collectTableSizesPeriodically {
+		return
+	}
+
+	ticker := time.NewTicker(collectTableSizesFrequency)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tableSizes, err := CollectTableSizes(ctx, db)
+			if err != nil {
+				logger.Error("[dbstats] failed to collect table sizes", "err", err)
+				continue
+			}
+
+			var sb strings.Builder
+			for _, t := range tableSizes {
+				dbTableSizeBytes.WithLabelValues(string(label), t.Name).Set(float64(t.Size))
+				if t.Size == 0 {
+					continue
+				}
+
+				sb.WriteString(t.Name)
+				sb.WriteRune(':')
+				sb.WriteString(common.ByteCount(t.Size))
+				sb.WriteRune(',')
+			}
+
+			logger.Debug("[dbstats] table sizes", "all", sb.String())
+		}
+	}
+}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -36,6 +36,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/erigontech/mdbx-go/mdbx"
 	lru "github.com/hashicorp/golang-lru/arc/v2"
 	"github.com/holiman/uint256"
 	"golang.org/x/sync/errgroup"
@@ -43,8 +44,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/protobuf/types/known/emptypb"
-
-	"github.com/erigontech/mdbx-go/mdbx"
 
 	"github.com/erigontech/erigon-db/downloader"
 	"github.com/erigontech/erigon-db/downloader/downloadercfg"
@@ -579,6 +578,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 	go mem.LogMemStats(ctx, logger)
 	go disk.UpdateDiskStats(ctx, logger)
 	go dbg.SaveHeapProfileNearOOMPeriodically(ctx, dbg.SaveHeapWithLogger(&logger))
+	go kv.CollectTableSizesPeriodically(ctx, backend.chainDB, kv.ChainDB, logger)
 
 	var currentBlock *types.Block
 	if err := backend.chainDB.View(context.Background(), func(tx kv.Tx) error {

--- a/execution/stagedsync/sync.go
+++ b/execution/stagedsync/sync.go
@@ -490,32 +490,6 @@ func (s *Sync) PrintTimings() []interface{} {
 	return logCtx
 }
 
-func CollectTableSizes(db kv.RoDB, tx kv.Tx, buckets []string) []interface{} {
-	if tx == nil {
-		return nil
-	}
-	bucketSizes := make([]interface{}, 0, 2*(len(buckets)+2))
-	for _, bucket := range buckets {
-		sz, err1 := tx.BucketSize(bucket)
-		if err1 != nil {
-			return bucketSizes
-		}
-		bucketSizes = append(bucketSizes, bucket, common.ByteCount(sz))
-	}
-
-	sz, err1 := tx.BucketSize("freelist")
-	if err1 != nil {
-		return bucketSizes
-	}
-	bucketSizes = append(bucketSizes, "FreeList", common.ByteCount(sz))
-	amountOfFreePagesInDb := sz / 4 // page_id encoded as bigEndian_u32
-	if db != nil {
-		bucketSizes = append(bucketSizes, "ReclaimableSpace", common.ByteCount(amountOfFreePagesInDb*db.PageSize().Bytes()))
-	}
-
-	return bucketSizes
-}
-
 func (s *Sync) runStage(stage *Stage, db kv.RwDB, txc wrap.TxContainer, initialCycle, firstCycle bool, badBlockUnwind bool) (err error) {
 	start := time.Now()
 	s.logger.Debug(fmt.Sprintf("[%s] Starting Stage run", s.LogPrefix()))


### PR DESCRIPTION
in bloatnet we're exploding the chaindata db size up to 500GB on chain tip - something is not right

this PR aims to make it easy to see what is happening by adding periodic table size metric collection for grafana chart and debug logs (collect every 5 mins - configurable)