### PR TITLE
fix(params): adjust BLOB_BASE_COST according to EIP-7918

### DIFF
--- a/erigon-lib/chain/params/protocol.go
+++ b/erigon-lib/chain/params/protocol.go
@@ -186,7 +186,7 @@ const (
 	FieldElementsPerBlob        = 4096 // each field element is 32 bytes
 	BlobSize                    = FieldElementsPerBlob * 32
 	GasPerBlob           uint64 = 1 << 17
-	BlobBaseCost         uint64 = 1 << 14 // EIP-7918: Blob base fee bounded by execution cost
+	BlobBaseCost         uint64 = 1 << 13 // EIP-7918: Blob base fee bounded by execution cost
 
 	// EIP-7594: PeerDAS - Peer Data Availability Sampling
 	// See https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/polynomial-commitments-sampling.md


### PR DESCRIPTION
If I'm not mistaken, this should reflect `1 << 13`, according to [EIP-7918](https://eips.ethereum.org/EIPS/eip-7918) for Fusaka.

In this #15399 , it was set to `1 << 14`.