### PR TITLE
tests: fix panic db closed in TestDump

### DIFF
--- a/execution/stagedsync/stage_snapshots.go
+++ b/execution/stagedsync/stage_snapshots.go
@@ -479,6 +479,10 @@ func SnapshotsPrune(s *PruneState, cfg SnapshotsCfg, ctx context.Context, tx kv.
 				cfg.notifier.Events.OnNewSnapshot()
 			}
 			return err
+		}, func() {
+			if cfg.notifier != nil {
+				cfg.notifier.Events.OnRetirementDone()
+			}
 		})
 
 		//	cfg.agg.BuildFilesInBackground()

--- a/turbo/services/interfaces.go
+++ b/turbo/services/interfaces.go
@@ -149,7 +149,15 @@ type FullBlockReader interface {
 // BlockRetire - freezing blocks: moving old data from DB to snapshot files
 type BlockRetire interface {
 	PruneAncientBlocks(tx kv.RwTx, limit int, timeout time.Duration) (deleted int, err error)
-	RetireBlocksInBackground(ctx context.Context, miBlockNum uint64, maxBlockNum uint64, lvl log.Lvl, seedNewSnapshots func(downloadRequest []snapshotsync.DownloadRequest) error, onDelete func(l []string) error, onFinishRetire func() error)
+	RetireBlocksInBackground(
+		ctx context.Context,
+		miBlockNum uint64,
+		maxBlockNum uint64,
+		lvl log.Lvl,
+		seedNewSnapshots func(downloadRequest []snapshotsync.DownloadRequest) error,
+		onDelete func(l []string) error,
+		onFinishRetire func() error,
+		onDone func())
 	BuildMissedIndicesIfNeed(ctx context.Context, logPrefix string, notifier DBEventNotifier) error
 	SetWorkers(workers int)
 	GetWorkers() int

--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -390,7 +390,16 @@ func (br *BlockRetire) PruneAncientBlocks(tx kv.RwTx, limit int, timeout time.Du
 	return deleted, nil
 }
 
-func (br *BlockRetire) RetireBlocksInBackground(ctx context.Context, minBlockNum, maxBlockNum uint64, lvl log.Lvl, seedNewSnapshots func(downloadRequest []snapshotsync.DownloadRequest) error, onDeleteSnapshots func(l []string) error, onFinishRetire func() error) {
+func (br *BlockRetire) RetireBlocksInBackground(
+	ctx context.Context,
+	minBlockNum,
+	maxBlockNum uint64,
+	lvl log.Lvl,
+	seedNewSnapshots func(downloadRequest []snapshotsync.DownloadRequest) error,
+	onDeleteSnapshots func(l []string) error,
+	onFinishRetire func() error,
+	onDone func(),
+) {
 	if maxBlockNum > br.maxScheduledBlock.Load() {
 		br.maxScheduledBlock.Store(maxBlockNum)
 	}
@@ -400,6 +409,7 @@ func (br *BlockRetire) RetireBlocksInBackground(ctx context.Context, minBlockNum
 	}
 
 	go func() {
+		defer onDone()
 		defer br.working.Store(false)
 
 		if br.snBuildAllowed != nil {


### PR DESCRIPTION
Fixes #15427 

The root cause:
- `freezeblocks.RetireBlocksInBackground` starts a goroutine doing the retirement of blocks in background, but there's no way to wait for completion of such goroutine
- `TestDump` contains a loop creating a test chain at each iteration through `MockSentry` and running a staged sync iteration over it, which triggers the retirement of blocks (even if it's a no-op). The test database gets closed at the end of the test by `tb.Cleanup(mock.Close)`

Hence, there's an unlikely race condition between the `TestDump` goroutine closing the db and the background retirement goroutine accessing the db, which may be already closed.

The changes:
- add `onDone` callback to signal the completion of background retirement
- add `retirementDoneSubscription` in `Events` publish-subscribe bus
- keep `RetirementDone` channel in `MockSentry` subscribed to receive notifications of retirement completions
- register a `testing.TB.Cleanup` hook using the `RetirementDone` channel to wait for background retirement completion when `stages2.StageLoopIteration` is called in `MockSentry` (i.e. when `MockSentry.InsertChain` is called)
