### PR TITLE
execution/stagedsync: measure time spent in initial cycle

### DIFF
--- a/execution/stagedsync/metrics.go
+++ b/execution/stagedsync/metrics.go
@@ -5,6 +5,8 @@ import (
 	"github.com/erigontech/erigon/execution/stagedsync/stages"
 )
 
+var initialSyncDurationSecs = metrics.GetOrCreateGauge("initial_sync_duration_secs")
+
 type metricsCache struct {
 	stageRunDurationSummaries    map[stages.SyncStage]metrics.Summary
 	stagePruneDurationSummaries  map[stages.SyncStage]metrics.Summary

--- a/execution/stagedsync/metrics.go
+++ b/execution/stagedsync/metrics.go
@@ -5,7 +5,7 @@ import (
 	"github.com/erigontech/erigon/execution/stagedsync/stages"
 )
 
-var initialSyncDurationSecs = metrics.GetOrCreateGauge("initial_sync_duration_secs")
+var initialCycleDurationSecs = metrics.GetOrCreateGauge("initial_cycle_duration_secs")
 
 type metricsCache struct {
 	stageRunDurationSummaries    map[stages.SyncStage]metrics.Summary

--- a/execution/stagedsync/stage_finish.go
+++ b/execution/stagedsync/stage_finish.go
@@ -38,12 +38,12 @@ type FinishCfg struct {
 }
 
 func StageFinishCfg(db kv.RwDB, tmpDir string, forkValidator *engine_helpers.ForkValidator) FinishCfg {
-	initialSyncStart := time.Now()
+	initialCycleStart := time.Now()
 	return FinishCfg{
 		db:                db,
 		tmpDir:            tmpDir,
 		forkValidator:     forkValidator,
-		initialCycleStart: &initialSyncStart,
+		initialCycleStart: &initialCycleStart,
 	}
 }
 

--- a/execution/stagedsync/stage_finish.go
+++ b/execution/stagedsync/stage_finish.go
@@ -31,24 +31,24 @@ import (
 )
 
 type FinishCfg struct {
-	db               kv.RwDB
-	tmpDir           string
-	forkValidator    *engine_helpers.ForkValidator
-	initialSyncStart *time.Time
+	db                kv.RwDB
+	tmpDir            string
+	forkValidator     *engine_helpers.ForkValidator
+	initialCycleStart *time.Time
 }
 
 func StageFinishCfg(db kv.RwDB, tmpDir string, forkValidator *engine_helpers.ForkValidator) FinishCfg {
 	initialSyncStart := time.Now()
 	return FinishCfg{
-		db:               db,
-		tmpDir:           tmpDir,
-		forkValidator:    forkValidator,
-		initialSyncStart: &initialSyncStart,
+		db:                db,
+		tmpDir:            tmpDir,
+		forkValidator:     forkValidator,
+		initialCycleStart: &initialSyncStart,
 	}
 }
 
 func FinishForward(s *StageState, tx kv.RwTx, cfg FinishCfg) error {
-	defer updateInitialSyncDuration(s, cfg)
+	defer updateInitialCycleDuration(s, cfg)
 	useExternalTx := tx != nil
 	if !useExternalTx {
 		var err error
@@ -95,12 +95,12 @@ func FinishForward(s *StageState, tx kv.RwTx, cfg FinishCfg) error {
 	return nil
 }
 
-func updateInitialSyncDuration(s *StageState, cfg FinishCfg) {
+func updateInitialCycleDuration(s *StageState, cfg FinishCfg) {
 	if s.CurrentSyncCycle.IsInitialCycle {
-		initialSyncDurationSecs.Set(time.Since(*cfg.initialSyncStart).Seconds())
+		initialCycleDurationSecs.Set(time.Since(*cfg.initialCycleStart).Seconds())
 	} else {
-		*cfg.initialSyncStart = time.Now()
-		initialSyncDurationSecs.Set(0)
+		*cfg.initialCycleStart = time.Now()
+		initialCycleDurationSecs.Set(0)
 	}
 }
 


### PR DESCRIPTION
allows us to measure how long it takes us to do the initial sync
one metric that is good to have/requested for bloatnet