### PR TITLE
cmd/prometheus: update erigon_internals with new dashboards

### DIFF
--- a/cmd/prometheus/dashboards/erigon_internals.json
+++ b/cmd/prometheus/dashboards/erigon_internals.json
@@ -33,7 +33,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "11.6.0-84846"
+      "version": "12.1.0-91038.patch3-91166"
     },
     {
       "type": "panel",
@@ -96,6 +96,796 @@
         "x": 0,
         "y": 0
       },
+      "id": 277,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 1
+          },
+          "id": 270,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "devops_erigon_dirs_size_total{directory=\"/erigon-data/snapshots\", instance=~\"$nodo\"}",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              }
+            }
+          ],
+          "title": "<datadir>/SNAPSHOTS TOTAL SIZE (GB)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 1
+          },
+          "id": 279,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "devops_erigon_dirs_size_total{directory=\"/erigon-data/chaindata\", instance=~\"$nodo\"}",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              }
+            }
+          ],
+          "title": "<datadir>/CHAINDATA size (GB)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 400
+          },
+          "id": 278,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "devops_erigon_dirs_size_total{directory=\"/erigon-data/temp\", instance=~\"$nodo\"}",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              }
+            }
+          ],
+          "title": "<datadir>/TEMP size (GB)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 400
+          },
+          "id": 276,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "devops_erigon_dirs_subdir_size_total{directory=\"/erigon-data/snapshots\", dir_label=\"erigon-data_snapshots\", subdir=\"idx\",instance=~\"$nodo\"}",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              }
+            }
+          ],
+          "title": "<datadir>/snapshots/IDX size (GB)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 439
+          },
+          "id": 273,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "devops_erigon_dirs_subdir_size_total{directory=\"/erigon-data/snapshots\", dir_label=\"erigon-data_snapshots\", subdir=\"caplin\",instance=~\"$nodo\"}",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              }
+            }
+          ],
+          "title": "<datadir>/snasphots/CAPLIN size (GB)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 439
+          },
+          "id": 275,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "devops_erigon_dirs_subdir_size_total{directory=\"/erigon-data/snapshots\", dir_label=\"erigon-data_snapshots\", subdir=\"history\",instance=~\"$nodo\"}",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              }
+            }
+          ],
+          "title": "<datadir>/snapshots/HISTORY size (GB)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 447
+          },
+          "id": 274,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "devops_erigon_dirs_subdir_size_total{directory=\"/erigon-data/snapshots\", dir_label=\"erigon-data_snapshots\", subdir=\"domain\",instance=~\"$nodo\"}",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              }
+            }
+          ],
+          "title": "<datadir>/snapshots/DOMAIN size (GB)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 447
+          },
+          "id": 272,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "devops_erigon_dirs_subdir_size_total{directory=\"/erigon-data/snapshots\", dir_label=\"erigon-data_snapshots\", subdir=\"accessor\",instance=~\"$nodo\"}",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              }
+            }
+          ],
+          "title": "<datadir>/snapshots/ACCESSOR size (GB)",
+          "type": "timeseries"
+        }
+      ],
+      "title": "<datadir>/snapshots STORAGE SIZE [snapshotters]",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
       "id": 248,
       "panels": [
         {
@@ -103,7 +893,7 @@
             "type": "prometheus",
             "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
           },
-          "description": "If you select (on the top drop-down \"instance\" menu) a small number of machines then you can even use the following, nice GRAPHICAL METHOD: hover your mouse on any row in the legenda which is related to any machine's ERIGON_BRANCH and you will find the corresponding PIE SECTOR: the geometrically-symmetrical pie sector represents the same machine's ERIGON_COMMIT!!!\nSuch graphical method is not suitable if many machines are selected (default: \"All\" machines are selected).\n\nData is refreshed every 10 minutes.",
+          "description": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -219,7 +1009,7 @@
             "h": 20,
             "w": 24,
             "x": 0,
-            "y": 9
+            "y": 2
           },
           "id": 247,
           "interval": "600s",
@@ -243,7 +1033,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "editorMode": "code",
@@ -260,7 +1050,7 @@
               }
             }
           ],
-          "title": "Branches/commits - click on the INFO icon on my right!! --> --> -->",
+          "title": "Branches/commits [snaphotters and validators]",
           "type": "piechart"
         }
       ],
@@ -273,7 +1063,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 1
+        "y": 2
       },
       "id": 241,
       "panels": [
@@ -319,7 +1109,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 953
+            "y": 3
           },
           "id": 240,
           "options": {
@@ -349,7 +1139,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "editorMode": "code",
@@ -391,7 +1181,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 2
+        "y": 3
       },
       "id": 218,
       "panels": [
@@ -410,7 +1200,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -425,7 +1216,7 @@
             "h": 4,
             "w": 12,
             "x": 0,
-            "y": 954
+            "y": 4
           },
           "id": 219,
           "options": {
@@ -443,7 +1234,7 @@
             "showThresholdMarkers": true,
             "sizing": "auto"
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "editorMode": "code",
@@ -508,7 +1299,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -524,7 +1316,7 @@
             "h": 12,
             "w": 12,
             "x": 12,
-            "y": 954
+            "y": 4
           },
           "id": 220,
           "options": {
@@ -542,7 +1334,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "editorMode": "code",
@@ -626,7 +1418,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -641,7 +1434,7 @@
             "h": 4,
             "w": 12,
             "x": 0,
-            "y": 1512
+            "y": 354
           },
           "id": 222,
           "options": {
@@ -661,7 +1454,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "editorMode": "code",
@@ -693,7 +1486,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -708,7 +1502,7 @@
             "h": 4,
             "w": 12,
             "x": 0,
-            "y": 1516
+            "y": 435
           },
           "id": 223,
           "options": {
@@ -728,7 +1522,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "editorMode": "code",
@@ -755,7 +1549,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 3
+        "y": 4
       },
       "id": 212,
       "panels": [
@@ -785,7 +1579,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 955
+            "y": 5
           },
           "id": 232,
           "options": {
@@ -814,7 +1608,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "editorMode": "code",
@@ -931,7 +1725,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -947,7 +1742,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 955
+            "y": 5
           },
           "id": 230,
           "options": {
@@ -965,7 +1760,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "editorMode": "code",
@@ -1030,7 +1825,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -1046,7 +1842,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1005
+            "y": 436
           },
           "id": 229,
           "options": {
@@ -1064,7 +1860,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "editorMode": "code",
@@ -1096,7 +1892,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -1112,7 +1909,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1005
+            "y": 436
           },
           "id": 215,
           "options": {
@@ -1132,7 +1929,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -1189,7 +1986,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -1205,7 +2003,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1013
+            "y": 444
           },
           "id": 236,
           "options": {
@@ -1230,7 +2028,7 @@
             "xTickLabelRotation": 0,
             "xTickLabelSpacing": 0
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -1266,7 +2064,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -1282,7 +2081,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1013
+            "y": 444
           },
           "id": 214,
           "options": {
@@ -1302,7 +2101,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -1338,7 +2137,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -1354,7 +2154,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1021
+            "y": 452
           },
           "id": 235,
           "options": {
@@ -1374,7 +2174,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -1443,7 +2243,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -1459,7 +2260,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1021
+            "y": 452
           },
           "id": 210,
           "options": {
@@ -1475,7 +2276,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -1511,7 +2312,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -1527,7 +2329,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1029
+            "y": 460
           },
           "id": 234,
           "options": {
@@ -1547,7 +2349,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -1616,7 +2418,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -1657,7 +2460,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1029
+            "y": 460
           },
           "id": 211,
           "options": {
@@ -1673,7 +2476,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "editorMode": "code",
@@ -1738,7 +2541,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -1754,7 +2558,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1037
+            "y": 468
           },
           "id": 231,
           "options": {
@@ -1772,7 +2576,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "editorMode": "code",
@@ -1825,7 +2629,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -1841,7 +2646,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1037
+            "y": 468
           },
           "id": 221,
           "options": {
@@ -1868,7 +2673,7 @@
             "xTickLabelRotation": 0,
             "xTickLabelSpacing": 0
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "editorMode": "code",
@@ -2011,7 +2816,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -2027,7 +2833,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1045
+            "y": 476
           },
           "id": 216,
           "options": {
@@ -2045,7 +2851,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -2114,7 +2920,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -2155,7 +2962,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1045
+            "y": 476
           },
           "id": 217,
           "options": {
@@ -2171,7 +2978,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "editorMode": "code",
@@ -2236,7 +3043,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -2252,7 +3060,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1053
+            "y": 484
           },
           "id": 228,
           "options": {
@@ -2268,7 +3076,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "editorMode": "code",
@@ -2300,7 +3108,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -2316,7 +3125,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1053
+            "y": 484
           },
           "id": 213,
           "options": {
@@ -2336,7 +3145,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -2372,7 +3181,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -2388,7 +3198,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1061
+            "y": 492
           },
           "id": 226,
           "options": {
@@ -2408,7 +3218,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -2477,7 +3287,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -2493,7 +3304,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1061
+            "y": 492
           },
           "id": 227,
           "options": {
@@ -2509,7 +3320,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -2578,7 +3389,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -2618,7 +3430,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 1069
+            "y": 500
           },
           "id": 224,
           "options": {
@@ -2634,7 +3446,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "editorMode": "code",
@@ -2712,7 +3524,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -2753,7 +3566,7 @@
             "h": 12,
             "w": 24,
             "x": 0,
-            "y": 1078
+            "y": 509
           },
           "id": 209,
           "options": {
@@ -2771,7 +3584,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -2814,7 +3627,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 4
+        "y": 5
       },
       "id": 205,
       "panels": [
@@ -2866,7 +3679,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -2882,7 +3696,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 573
+            "y": 6
           },
           "id": 204,
           "options": {
@@ -2900,7 +3714,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "editorMode": "code",
@@ -2965,7 +3779,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -2981,7 +3796,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 573
+            "y": 6
           },
           "id": 203,
           "options": {
@@ -2999,7 +3814,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "editorMode": "code",
@@ -3064,7 +3879,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -3079,7 +3895,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 665
+            "y": 437
           },
           "id": 238,
           "options": {
@@ -3095,7 +3911,7 @@
               "sort": "asc"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "editorMode": "code",
@@ -3154,7 +3970,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -3167,10 +3984,10 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 3,
+            "h": 8,
             "w": 12,
-            "x": 0,
-            "y": 673
+            "x": 12,
+            "y": 437
           },
           "id": 239,
           "options": {
@@ -3190,7 +4007,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "editorMode": "code",
@@ -3217,10 +4034,95 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 6
       },
       "id": 171,
       "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "decimals": 2,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "__systemRef": "hideSeriesFrom",
+                "matcher": {
+                  "id": "byNames",
+                  "options": {
+                    "mode": "exclude",
+                    "names": [
+                      "execution: validator-bm-holesky-e3caplin-cluster1-n1"
+                    ],
+                    "prefix": "All except:",
+                    "readOnly": true
+                  }
+                },
+                "properties": []
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 7
+          },
+          "id": 196,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "sizing": "auto"
+          },
+          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "editorMode": "code",
+              "expr": "sync{instance=~\"$instance\",stage=\"execution\"} > 0 ",
+              "instant": false,
+              "legendFormat": "{{ stage }}: {{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Sync Stages progress",
+          "type": "gauge"
+        },
         {
           "datasource": {
             "type": "prometheus",
@@ -3249,142 +4151,13 @@
                 },
                 "insertNulls": false,
                 "lineInterpolation": "linear",
-                "lineStyle": {
-                  "fill": "solid"
-                },
                 "lineWidth": 1,
                 "pointSize": 5,
                 "scaleDistribution": {
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "decimals": 2,
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": [
-              {
-                "__systemRef": "hideSeriesFrom",
-                "matcher": {
-                  "id": "byNames",
-                  "options": {
-                    "mode": "exclude",
-                    "names": [
-                      "execution: validator-bm-holesky-e3caplin-cluster1-n1"
-                    ],
-                    "prefix": "All except:",
-                    "readOnly": true
-                  }
-                },
-                "properties": [
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": true
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 8,
-            "x": 0,
-            "y": 422
-          },
-          "id": 196,
-          "options": {
-            "legend": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.6.0-84846",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "editorMode": "code",
-              "expr": "sync{instance=~\"$instance\",stage=\"execution\"} > 0 ",
-              "instant": false,
-              "legendFormat": "{{ stage }}: {{instance}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Sync Stages progress",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true,
+                "spanNulls": 3600000,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -3398,7 +4171,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -3411,12 +4185,12 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 6,
-            "w": 8,
-            "x": 8,
-            "y": 422
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 7
           },
-          "id": 206,
+          "id": 158,
           "options": {
             "legend": {
               "calcs": [
@@ -3432,7 +4206,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
@@ -3441,16 +4215,16 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(exec_gas{instance=~\"$instance\"}[$__rate_interval])",
+              "expr": "rate(sync{instance=~\"$instance\",stage=\"execution\"}[$__rate_interval]) ",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "gas/s {{instance}}",
+              "legendFormat": "{{ stage }}:  {{instance}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Exec throughput",
+          "title": "Sync Stages progress rate",
           "type": "timeseries"
         },
         {
@@ -3501,7 +4275,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -3511,38 +4286,13 @@
               },
               "unit": "s"
             },
-            "overrides": [
-              {
-                "__systemRef": "hideSeriesFrom",
-                "matcher": {
-                  "id": "byNames",
-                  "options": {
-                    "mode": "exclude",
-                    "names": [
-                      "dev-bm-e3-multichain-n1 blocks "
-                    ],
-                    "prefix": "All except:",
-                    "readOnly": true
-                  }
-                },
-                "properties": [
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": true
-                    }
-                  }
-                ]
-              }
-            ]
+            "overrides": []
           },
           "gridPos": {
-            "h": 6,
-            "w": 8,
-            "x": 16,
-            "y": 422
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 16
           },
           "id": 200,
           "options": {
@@ -3554,11 +4304,11 @@
             },
             "tooltip": {
               "hideZeros": false,
-              "mode": "single",
+              "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
@@ -3576,6 +4326,95 @@
           "title": "Prune, seconds",
           "transparent": true,
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 16
+          },
+          "id": 202,
+          "options": {
+            "displayMode": "lcd",
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "maxVizHeight": 81,
+            "minVizHeight": 16,
+            "minVizWidth": 8,
+            "namePlacement": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "sizing": "manual",
+            "valueMode": "color"
+          },
+          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "editorMode": "code",
+              "expr": "domain_prunable{instance=~\"$instance\",type=\"domain\"}",
+              "hide": false,
+              "legendFormat": "{{instance}} {{type}}-{{table}}",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "editorMode": "code",
+              "expr": "domain_prunable{instance=~\"$instance\",type=\"history\",table!=\"commitment\"}/1562500",
+              "hide": false,
+              "legendFormat": "{{instance}} {{type}}-{{table}}",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "pruning availability, steps",
+          "transparent": true,
+          "type": "bargauge"
         },
         {
           "datasource": {
@@ -3628,7 +4467,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -3641,10 +4481,10 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 8,
+            "h": 10,
             "w": 8,
             "x": 0,
-            "y": 428
+            "y": 25
           },
           "id": 197,
           "options": {
@@ -3660,7 +4500,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
@@ -3757,7 +4597,7 @@
                 "barAlignment": 0,
                 "barWidthFactor": 0.6,
                 "drawStyle": "line",
-                "fillOpacity": 10,
+                "fillOpacity": 0,
                 "gradientMode": "none",
                 "hideFrom": {
                   "legend": false,
@@ -3765,14 +4605,14 @@
                   "viz": false
                 },
                 "insertNulls": false,
-                "lineInterpolation": "linear",
+                "lineInterpolation": "smooth",
                 "lineWidth": 1,
                 "pointSize": 5,
                 "scaleDistribution": {
                   "type": "linear"
                 },
-                "showPoints": "never",
-                "spanNulls": true,
+                "showPoints": "auto",
+                "spanNulls": false,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -3786,107 +4626,12 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
                     "value": 80
-                  }
-                ]
-              },
-              "unit": "ops"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 8,
-            "x": 8,
-            "y": 428
-          },
-          "id": 207,
-          "options": {
-            "legend": {
-              "calcs": [
-                "mean"
-              ],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.6.0-84846",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "rate(exec_txs_done{instance=~\"$instance\"}[$__rate_interval])",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "txs apply:  {{instance}}",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "editorMode": "code",
-              "expr": "rate(exec_txns{instance=~\"$instance\"}[$__rate_interval])",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "txn/s {{instance}}",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "editorMode": "code",
-              "expr": "rate(exec_txs_done{instance=~\"$instance\"}[$__rate_interval]) > 0",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "C"
-            }
-          ],
-          "title": "Exec v3: txs/s ",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 2
                   }
                 ]
               }
@@ -3894,37 +4639,26 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 6,
+            "h": 10,
             "w": 8,
-            "x": 16,
-            "y": 428
+            "x": 8,
+            "y": 25
           },
-          "id": 202,
+          "id": 198,
           "options": {
-            "displayMode": "lcd",
             "legend": {
               "calcs": [],
               "displayMode": "list",
               "placement": "bottom",
-              "showLegend": false
+              "showLegend": true
             },
-            "maxVizHeight": 81,
-            "minVizHeight": 16,
-            "minVizWidth": 8,
-            "namePlacement": "auto",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showUnfilled": true,
-            "sizing": "manual",
-            "valueMode": "color"
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
@@ -3932,9 +4666,20 @@
                 "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
               },
               "editorMode": "code",
-              "expr": "domain_prunable{instance=~\"$instance\",type=\"domain\"}",
+              "expr": "domain_running_merges{instance=~\"$instance\"}",
+              "legendFormat": "running merges: {{instance}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "editorMode": "code",
+              "expr": "domain_running_collations{instance=~\"$instance\"}",
               "hide": false,
-              "legendFormat": "{{instance}} {{type}}-{{table}}",
+              "legendFormat": "running collations: {{instance}}",
               "range": true,
               "refId": "B"
             },
@@ -3944,220 +4689,52 @@
                 "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
               },
               "editorMode": "code",
-              "expr": "domain_prunable{instance=~\"$instance\",type=\"history\",table!=\"commitment\"}/1562500",
+              "expr": "domain_pruning_progress{instance=~\"$instance\"}",
               "hide": false,
-              "legendFormat": "{{instance}} {{type}}-{{table}}",
+              "legendFormat": "running prunes: {{instance}}",
               "range": true,
               "refId": "C"
-            }
-          ],
-          "title": "pruning availability, steps",
-          "transparent": true,
-          "type": "bargauge"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": 3600000,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "ops"
             },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 8,
-            "x": 8,
-            "y": 434
-          },
-          "id": 158,
-          "options": {
-            "legend": {
-              "calcs": [
-                "mean"
-              ],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.6.0-84846",
-          "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
               },
               "editorMode": "code",
-              "exemplar": true,
-              "expr": "rate(sync{instance=~\"$instance\",stage=\"execution\"}[$__rate_interval]) ",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "{{ stage }}:  {{instance}}",
+              "expr": "domain_running_commitment{instance=~\"$instance\"}",
+              "hide": false,
+              "legendFormat": "running commitment: {{instance}}",
               "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Sync Stages progress rate",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "s"
+              "refId": "D"
             },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 8,
-            "x": 16,
-            "y": 434
-          },
-          "id": 199,
-          "options": {
-            "legend": {
-              "calcs": [
-                "mean",
-                "lastNotNull"
-              ],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.6.0-84846",
-          "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
               },
-              "exemplar": true,
-              "expr": "chain_execution_seconds{quantile=\"$quantile\",instance=~\"$instance\"}",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "execution: {{instance}}",
-              "refId": "A"
+              "editorMode": "code",
+              "expr": "domain_running_files_building{instance=~\"$instance\"}",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "running files building: {{instance}}",
+              "range": true,
+              "refId": "E"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "editorMode": "code",
+              "expr": "domain_wal_flushes{instance=~\"$instance\"}",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "WAL flushes {{instance}}",
+              "range": true,
+              "refId": "F"
             }
           ],
-          "title": "Block Execution speed ",
+          "title": "State: running collate/merge/prune",
           "type": "timeseries"
         },
         {
@@ -4209,7 +4786,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -4247,10 +4825,10 @@
             ]
           },
           "gridPos": {
-            "h": 12,
+            "h": 10,
             "w": 8,
-            "x": 0,
-            "y": 436
+            "x": 16,
+            "y": 25
           },
           "id": 112,
           "options": {
@@ -4268,7 +4846,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
@@ -4385,165 +4963,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 9,
-            "w": 8,
-            "x": 8,
-            "y": 439
-          },
-          "id": 198,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "pluginVersion": "11.6.0-84846",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "editorMode": "code",
-              "expr": "domain_running_merges{instance=~\"$instance\"}",
-              "legendFormat": "running merges: {{instance}}",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "editorMode": "code",
-              "expr": "domain_running_collations{instance=~\"$instance\"}",
-              "hide": false,
-              "legendFormat": "running collations: {{instance}}",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "editorMode": "code",
-              "expr": "domain_pruning_progress{instance=~\"$instance\"}",
-              "hide": false,
-              "legendFormat": "running prunes: {{instance}}",
-              "range": true,
-              "refId": "C"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "editorMode": "code",
-              "expr": "domain_running_commitment{instance=~\"$instance\"}",
-              "hide": false,
-              "legendFormat": "running commitment: {{instance}}",
-              "range": true,
-              "refId": "D"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "editorMode": "code",
-              "expr": "domain_running_files_building{instance=~\"$instance\"}",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "running files building: {{instance}}",
-              "range": true,
-              "refId": "E"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "editorMode": "code",
-              "expr": "domain_wal_flushes{instance=~\"$instance\"}",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "WAL flushes {{instance}}",
-              "range": true,
-              "refId": "F"
-            }
-          ],
-          "title": "State: running collate/merge/prune",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "smooth",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -4556,10 +4977,10 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 9,
-            "w": 8,
-            "x": 16,
-            "y": 439
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 35
           },
           "id": 201,
           "options": {
@@ -4575,7 +4996,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
@@ -4662,6 +5083,111 @@
                 "scaleDistribution": {
                   "type": "linear"
                 },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 35
+          },
+          "id": 199,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull"
+              ],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "editorMode": "builder",
+              "exemplar": true,
+              "expr": "chain_execution_seconds{quantile=\"$quantile\",instance=~\"$instance\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "execution: {{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Block Execution speed ",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
                 "showPoints": "auto",
                 "spanNulls": false,
                 "stacking": {
@@ -4677,7 +5203,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -4692,7 +5219,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 448
+            "y": 45
           },
           "id": 245,
           "options": {
@@ -4708,15 +5235,15 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "update_fork_choice{type=\"fork_depth\", instance=\"$instance\", quantile=\"$quantile\"}",
+              "expr": "update_fork_choice{type=\"fork_depth\", instance=~\"$instance\", quantile=\"$quantile\"}",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
-              "legendFormat": "fork_depth $instance",
+              "legendFormat": "fork_depth {{instance}}",
               "range": true,
               "refId": "A",
               "useBackend": false,
@@ -4777,7 +5304,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -4793,7 +5321,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 448
+            "y": 45
           },
           "id": 246,
           "options": {
@@ -4809,7 +5337,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -4833,12 +5361,12 @@
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "update_fork_choice{instance=\"$instance\", quantile=\"$quantile\", type=\"execution_duration\"}",
+              "expr": "update_fork_choice{instance=~\"$instance\", quantile=\"$quantile\", type=\"execution_duration\"}",
               "fullMetaSearch": false,
               "hide": false,
               "includeNullMetadata": true,
               "instant": false,
-              "legendFormat": "execution_duration $instance",
+              "legendFormat": "execution_duration {{instance}}",
               "range": true,
               "refId": "B",
               "useBackend": false
@@ -4855,14 +5383,403 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "continuous-BlPu"
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 53
+          },
+          "id": 206,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean"
+              ],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "rate(exec_gas{instance=~\"$instance\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "gas/s {{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Exec throughput",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 53
+          },
+          "id": 207,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean"
+              ],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "rate(exec_txs_done{instance=~\"$instance\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "txs apply:  {{instance}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "editorMode": "code",
+              "expr": "rate(exec_txns{instance=~\"$instance\"}[$__rate_interval])",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "txn/s {{instance}}",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "editorMode": "code",
+              "expr": "rate(exec_txs_done{instance=~\"$instance\"}[$__rate_interval]) > 0",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Exec v3: txs/s ",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "decimals": 2,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 53
+          },
+          "id": 194,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean"
+              ],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "rate(exec_repeats{instance=~\"$instance\"}[$__rate_interval])/rate(exec_txs_done{instance=~\"$instance\"}[$__rate_interval])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "repeats: {{instance}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "rate(exec_triggers{instance=~\"$instance\"}[$__rate_interval])/rate(exec_txs_done{instance=~\"$instance\"}[$__rate_interval])",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "triggers: {{instance}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Exec v3",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -4894,27 +5811,25 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 456
+            "y": 61
           },
           "id": 208,
           "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
+            "legend": {
               "calcs": [
                 "mean"
               ],
-              "fields": "",
-              "values": false
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
             },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
@@ -4933,7 +5848,7 @@
             }
           ],
           "title": "mgas/s ",
-          "type": "stat"
+          "type": "timeseries"
         }
       ],
       "title": "Blocks execution",
@@ -4945,7 +5860,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 6
+        "y": 7
       },
       "id": 242,
       "panels": [
@@ -4997,7 +5912,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -5012,7 +5928,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2497
+            "y": 70
           },
           "id": 243,
           "options": {
@@ -5028,15 +5944,15 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "waypoint_length{type=\"milestone\", instance=\"$instance\"}",
+              "expr": "waypoint_length{type=\"milestone\", instance=~\"$instance\"}",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
-              "legendFormat": "milestone_length $instance",
+              "legendFormat": "milestone_length {{instance}}",
               "range": true,
               "refId": "A",
               "useBackend": false,
@@ -5052,12 +5968,12 @@
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "waypoint_length{type=\"checkpoint\", instance=\"$instance\"}",
+              "expr": "waypoint_length{type=\"checkpoint\", instance=~\"$instance\"}",
               "fullMetaSearch": false,
               "hide": false,
               "includeNullMetadata": true,
               "instant": false,
-              "legendFormat": "checkpoint_length $instance",
+              "legendFormat": "checkpoint_length {{instance}}",
               "range": true,
               "refId": "B",
               "useBackend": false
@@ -5114,7 +6030,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -5130,7 +6047,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2497
+            "y": 70
           },
           "id": 244,
           "options": {
@@ -5146,15 +6063,15 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "wiggle_duration{instance=\"$instance\", quantile=\"$quantile\"}",
+              "expr": "wiggle_duration{instance=~\"$instance\", quantile=\"$quantile\"}",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
-              "legendFormat": "wiggle_duration $instance",
+              "legendFormat": "wiggle_duration {{instance}}",
               "range": true,
               "refId": "A",
               "useBackend": false,
@@ -5177,7 +6094,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 7
+        "y": 8
       },
       "id": 17,
       "panels": [
@@ -5215,7 +6132,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": false,
+                "spanNulls": true,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -5225,12 +6142,12 @@
                 }
               },
               "mappings": [],
-              "min": 0.001,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -5238,17 +6155,17 @@
                   }
                 ]
               },
-              "unit": "ops"
+              "unit": "decbytes"
             },
             "overrides": []
           },
           "gridPos": {
-            "h": 5,
+            "h": 9,
             "w": 8,
             "x": 0,
-            "y": 2085
+            "y": 9
           },
-          "id": 141,
+          "id": 159,
           "options": {
             "legend": {
               "calcs": [],
@@ -5262,7 +6179,335 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "expr": "db_size{instance=~\"$instance\"}",
+              "interval": "",
+              "legendFormat": "size: {{instance}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "editorMode": "code",
+              "expr": "db_mi_last_pgno{instance=~\"$instance\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "db_mi_last_pgno: {{instance}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "DB Size",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 9
+          },
+          "id": 280,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "targets": [
+            {
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "db_table_size_bytes{instance=~\"$instance\"}",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "legendFormat": "{{db}} {{table}} {{instance}}",
+              "range": true,
+              "refId": "A",
+              "useBackend": false,
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              }
+            }
+          ],
+          "title": "Table Sizes",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 16,
+            "y": 9
+          },
+          "id": 167,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean"
+              ],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "editorMode": "code",
+              "expr": "tx_limit{instance=~\"$instance\"}",
+              "interval": "",
+              "legendFormat": "limit: {{instance}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "editorMode": "code",
+              "expr": "tx_dirty{instance=~\"$instance\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "dirty: {{instance}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Tx Size",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 0,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 18
+          },
+          "id": 169,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean"
+              ],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
@@ -5271,14 +6516,42 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(db_commit_seconds_count{phase=\"total\",instance=~\"$instance\"}[$__rate_interval]) > 0 ",
+              "expr": "db_gc_leaf{instance=~\"$instance\"} > 0",
               "interval": "",
-              "legendFormat": "commit: {{instance}}",
+              "legendFormat": "gc_leaf: {{instance}}",
               "range": true,
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "db_gc_overflow{instance=~\"$instance\"} > 0",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "gc_overflow: {{instance}}",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "exec_steps_in_db{instance=~\"$instance\"}/100 > 0",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "exec_steps_in_db: {{instance}}",
+              "range": true,
+              "refId": "E"
             }
           ],
-          "title": "Commit",
+          "title": "GC and State",
           "type": "timeseries"
         },
         {
@@ -5331,7 +6604,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -5341,13 +6615,39 @@
               },
               "unit": "s"
             },
-            "overrides": []
+            "overrides": [
+              {
+                "__systemRef": "hideSeriesFrom",
+                "matcher": {
+                  "id": "byNames",
+                  "options": {
+                    "mode": "exclude",
+                    "names": [
+                      "sync: dev-bm-e3-ethmainnet-n1",
+                      "sync: dev-bm-e3-gnosis-n1"
+                    ],
+                    "prefix": "All except:",
+                    "readOnly": true
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
           },
           "gridPos": {
             "h": 9,
-            "w": 16,
+            "w": 8,
             "x": 8,
-            "y": 2085
+            "y": 18
           },
           "id": 166,
           "options": {
@@ -5365,7 +6665,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
@@ -5474,7 +6774,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true,
+                "spanNulls": false,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -5484,11 +6784,13 @@
                 }
               },
               "mappings": [],
+              "min": 0.001,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -5496,17 +6798,17 @@
                   }
                 ]
               },
-              "unit": "decbytes"
+              "unit": "ops"
             },
             "overrides": []
           },
           "gridPos": {
-            "h": 5,
+            "h": 9,
             "w": 8,
-            "x": 0,
-            "y": 2090
+            "x": 16,
+            "y": 18
           },
-          "id": 159,
+          "id": 141,
           "options": {
             "legend": {
               "calcs": [],
@@ -5520,33 +6822,23 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
               },
-              "expr": "db_size{instance=~\"$instance\"}",
-              "interval": "",
-              "legendFormat": "size: {{instance}}",
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
               "editorMode": "code",
-              "expr": "db_mi_last_pgno{instance=~\"$instance\"}",
-              "hide": false,
+              "exemplar": true,
+              "expr": "rate(db_commit_seconds_count{phase=\"total\",instance=~\"$instance\"}[$__rate_interval]) > 0 ",
               "interval": "",
-              "legendFormat": "db_mi_last_pgno: {{instance}}",
+              "legendFormat": "commit: {{instance}}",
               "range": true,
-              "refId": "B"
+              "refId": "A"
             }
           ],
-          "title": "DB Size",
+          "title": "Commit",
           "type": "timeseries"
         },
         {
@@ -5597,7 +6889,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -5610,10 +6903,10 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 7,
-            "w": 16,
-            "x": 8,
-            "y": 2094
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 27
           },
           "id": 168,
           "options": {
@@ -5631,7 +6924,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
@@ -5846,484 +7139,6 @@
           ],
           "title": "DB Pages Ops/sec",
           "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "decbytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 8,
-            "x": 0,
-            "y": 2095
-          },
-          "id": 167,
-          "options": {
-            "legend": {
-              "calcs": [
-                "mean"
-              ],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.6.0-83314",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "editorMode": "code",
-              "expr": "tx_limit{instance=~\"$instance\"}",
-              "interval": "",
-              "legendFormat": "limit: {{instance}}",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "editorMode": "code",
-              "expr": "tx_dirty{instance=~\"$instance\"}",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "dirty: {{instance}}",
-              "range": true,
-              "refId": "B"
-            }
-          ],
-          "title": "Tx Size",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 0,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 8,
-            "x": 0,
-            "y": 2101
-          },
-          "id": 169,
-          "options": {
-            "legend": {
-              "calcs": [
-                "mean"
-              ],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.6.0-83314",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "db_gc_leaf{instance=~\"$instance\"} > 0",
-              "interval": "",
-              "legendFormat": "gc_leaf: {{instance}}",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "db_gc_overflow{instance=~\"$instance\"} > 0",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "gc_overflow: {{instance}}",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "exec_steps_in_db{instance=~\"$instance\"}/100 > 0",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "exec_steps_in_db: {{instance}}",
-              "range": true,
-              "refId": "E"
-            }
-          ],
-          "title": "GC and State",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 16,
-            "x": 8,
-            "y": 2101
-          },
-          "id": 150,
-          "options": {
-            "legend": {
-              "calcs": [
-                "mean"
-              ],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.6.0-83314",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "rate(process_minor_pagefaults_total{instance=~\"$instance\"}[$__rate_interval]) > 0",
-              "interval": "",
-              "legendFormat": "soft: {{instance}}",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "rate(process_major_pagefaults_total{instance=~\"$instance\"}[$__rate_interval]) > 0",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "hard: {{instance}}",
-              "range": true,
-              "refId": "B"
-            }
-          ],
-          "title": "getrusage: minflt - soft page faults (reclaims), majflt - hard faults",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "decimals": 2,
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "percentunit"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 8,
-            "x": 0,
-            "y": 2107
-          },
-          "id": 194,
-          "options": {
-            "legend": {
-              "calcs": [
-                "mean"
-              ],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.6.0-83314",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "rate(exec_repeats{instance=~\"$instance\"}[$__rate_interval])/rate(exec_txs_done{instance=~\"$instance\"}[$__rate_interval])",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "repeats: {{instance}}",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "rate(exec_triggers{instance=~\"$instance\"}[$__rate_interval])/rate(exec_txs_done{instance=~\"$instance\"}[$__rate_interval])",
-              "format": "time_series",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "triggers: {{instance}}",
-              "range": true,
-              "refId": "B"
-            }
-          ],
-          "title": "Exec v3",
-          "type": "timeseries"
         }
       ],
       "title": "Database",
@@ -6335,300 +7150,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 8
+        "y": 9
       },
       "id": 134,
       "panels": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "none"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 8,
-            "x": 8,
-            "y": 2499
-          },
-          "id": 155,
-          "options": {
-            "legend": {
-              "calcs": [
-                "mean"
-              ],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.6.0-83314",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "rate(process_io_write_syscalls_total{instance=~\"$instance\"}[$__rate_interval]) > 0",
-              "format": "time_series",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "in: {{instance}}",
-              "range": true,
-              "refId": "C"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "rate(process_io_read_syscalls_total{instance=~\"$instance\"}[$__rate_interval]) > 0",
-              "format": "time_series",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "out: {{instance}}",
-              "range": true,
-              "refId": "D"
-            }
-          ],
-          "title": "Read/Write syscall/sec",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": 300000,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "decbytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 8,
-            "x": 16,
-            "y": 2499
-          },
-          "id": 148,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max"
-              ],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.6.0-83314",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "exemplar": true,
-              "expr": "process_virtual_memory_bytes{instance=~\"$instance\"}",
-              "hide": true,
-              "interval": "",
-              "legendFormat": "resident virtual mem: {{instance}}",
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "exemplar": true,
-              "expr": "process_resident_memory_anon_bytes{instance=~\"$instance\"}",
-              "hide": true,
-              "interval": "",
-              "legendFormat": "resident anon mem: {{instance}}",
-              "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "exemplar": true,
-              "expr": "process_resident_memory_bytes{instance=~\"$instance\"}",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "resident mem: {{instance}}",
-              "refId": "C"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "expr": "mem_data{instance=~\"$instance\"}",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "data: {{instance}}",
-              "refId": "D"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "expr": "mem_stack{instance=~\"$instance\"}",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "stack: {{instance}}",
-              "refId": "E"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "expr": "mem_locked{instance=~\"$instance\"}",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "locked: {{instance}}",
-              "refId": "F"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "expr": "mem_swap{instance=~\"$instance\"}",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "swap: {{instance}}",
-              "refId": "G"
-            }
-          ],
-          "title": "mem: resident set size",
-          "type": "timeseries"
-        },
         {
           "datasource": {
             "type": "prometheus",
@@ -6678,7 +7203,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -6691,10 +7217,10 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 5,
+            "h": 8,
             "w": 8,
-            "x": 16,
-            "y": 2575
+            "x": 0,
+            "y": 10
           },
           "id": 106,
           "options": {
@@ -6712,22 +7238,26 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
               },
-              "editorMode": "code",
+              "disableTextWrap": false,
+              "editorMode": "builder",
               "exemplar": true,
-              "expr": "increase(process_cpu_seconds_total{instance=~\"$instance\"}[1m])",
+              "expr": "rate(process_cpu_seconds_total{instance=~\"$instance\"}[$__rate_interval])",
               "format": "time_series",
+              "fullMetaSearch": false,
+              "includeNullMetadata": false,
               "interval": "",
               "intervalFactor": 1,
               "legendFormat": "system: {{instance}}",
               "range": true,
-              "refId": "A"
+              "refId": "A",
+              "useBackend": false
             }
           ],
           "title": "CPU",
@@ -6767,7 +7297,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": false,
+                "spanNulls": 300000,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -6781,7 +7311,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -6789,166 +7320,20 @@
                   }
                 ]
               },
-              "unit": "decbytes"
-            },
-            "overrides": [
-              {
-                "__systemRef": "hideSeriesFrom",
-                "matcher": {
-                  "id": "byNames",
-                  "options": {
-                    "mode": "exclude",
-                    "names": [
-                      "write: dev-bm-e3-ethmainnet-n1"
-                    ],
-                    "prefix": "All except:",
-                    "readOnly": true
-                  }
-                },
-                "properties": [
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": true
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 8,
-            "x": 8,
-            "y": 2576
-          },
-          "id": 85,
-          "options": {
-            "legend": {
-              "calcs": [
-                "mean"
-              ],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.6.0-83314",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "rate(process_io_storage_read_bytes_total{instance=~\"$instance\"}[$__rate_interval]) > 0",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "read: {{instance}}",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "rate(process_io_storage_written_bytes_total{instance=~\"$instance\"}[$__rate_interval]) > 0",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "write: {{instance}}",
-              "range": true,
-              "refId": "B"
-            }
-          ],
-          "title": "Disk bytes/sec",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "cps"
+              "unit": "none"
             },
             "overrides": []
           },
           "gridPos": {
-            "h": 6,
+            "h": 8,
             "w": 8,
-            "x": 16,
-            "y": 2580
+            "x": 8,
+            "y": 10
           },
-          "id": 153,
+          "id": 128,
           "options": {
             "legend": {
-              "calcs": [
-                "mean"
-              ],
+              "calcs": [],
               "displayMode": "list",
               "placement": "bottom",
               "showLegend": true
@@ -6959,7 +7344,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
@@ -6967,15 +7352,26 @@
                 "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
               },
               "editorMode": "code",
-              "exemplar": true,
-              "expr": "rate(go_cgo_calls_count{instance=~\"$instance\"}[$__rate_interval]) > 0",
+              "expr": "go_goroutines{instance=~\"$instance\"}",
+              "instant": false,
               "interval": "",
-              "legendFormat": "cgo_calls_count: {{instance}}",
-              "range": true,
+              "legendFormat": "goroutines: {{instance}}",
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "editorMode": "code",
+              "expr": "go_threads{instance=~\"$instance\"}",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "threads: {{instance}}",
+              "refId": "B"
             }
           ],
-          "title": "cgo calls",
+          "title": "GO Goroutines and Threads",
           "type": "timeseries"
         },
         {
@@ -7027,7 +7423,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -7040,10 +7437,10 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 6,
+            "h": 8,
             "w": 8,
-            "x": 8,
-            "y": 2582
+            "x": 16,
+            "y": 10
           },
           "id": 154,
           "options": {
@@ -7061,7 +7458,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
@@ -7167,6 +7564,7 @@
             "type": "prometheus",
             "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
           },
+          "description": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -7210,7 +7608,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -7218,20 +7617,22 @@
                   }
                 ]
               },
-              "unit": "none"
+              "unit": "short"
             },
             "overrides": []
           },
           "gridPos": {
-            "h": 6,
+            "h": 8,
             "w": 8,
-            "x": 16,
-            "y": 2586
+            "x": 0,
+            "y": 18
           },
-          "id": 128,
+          "id": 86,
           "options": {
             "legend": {
-              "calcs": [],
+              "calcs": [
+                "mean"
+              ],
               "displayMode": "list",
               "placement": "bottom",
               "showLegend": true
@@ -7242,7 +7643,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
@@ -7250,10 +7651,13 @@
                 "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
               },
               "editorMode": "code",
-              "expr": "go_goroutines{instance=~\"$instance\"}",
-              "instant": false,
+              "exemplar": true,
+              "expr": "rate(go_memstats_mallocs_total{instance=~\"$instance\"}[$__rate_interval])",
+              "format": "time_series",
               "interval": "",
-              "legendFormat": "goroutines: {{instance}}",
+              "intervalFactor": 1,
+              "legendFormat": "memstats_mallocs_total: {{ instance }}",
+              "range": true,
               "refId": "A"
             },
             {
@@ -7262,14 +7666,18 @@
                 "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
               },
               "editorMode": "code",
-              "expr": "go_threads{instance=~\"$instance\"}",
-              "instant": false,
+              "exemplar": true,
+              "expr": "rate(go_memstats_frees_total{instance=~\"$instance\"}[$__rate_interval])",
+              "format": "time_series",
+              "hide": false,
               "interval": "",
-              "legendFormat": "threads: {{instance}}",
+              "intervalFactor": 1,
+              "legendFormat": "memstats_frees_total: {{ instance }}",
+              "range": true,
               "refId": "B"
             }
           ],
-          "title": "GO Goroutines and Threads",
+          "title": "Process Mem: allocate objects/sec, free",
           "type": "timeseries"
         },
         {
@@ -7321,7 +7729,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -7329,21 +7738,21 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "decbytes"
             },
             "overrides": []
           },
           "gridPos": {
-            "h": 5,
+            "h": 8,
             "w": 8,
             "x": 8,
-            "y": 2588
+            "y": 18
           },
-          "id": 86,
+          "id": 148,
           "options": {
             "legend": {
               "calcs": [
-                "mean"
+                "max"
               ],
               "displayMode": "list",
               "placement": "bottom",
@@ -7355,21 +7764,18 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
               },
-              "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(go_memstats_mallocs_total{instance=~\"$instance\"}[$__rate_interval])",
-              "format": "time_series",
+              "expr": "process_virtual_memory_bytes{instance=~\"$instance\"}",
+              "hide": true,
               "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "memstats_mallocs_total: {{ instance }}",
-              "range": true,
+              "legendFormat": "resident virtual mem: {{instance}}",
               "refId": "A"
             },
             {
@@ -7377,19 +7783,71 @@
                 "type": "prometheus",
                 "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
               },
-              "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(go_memstats_frees_total{instance=~\"$instance\"}[$__rate_interval])",
-              "format": "time_series",
+              "expr": "process_resident_memory_anon_bytes{instance=~\"$instance\"}",
+              "hide": true,
+              "interval": "",
+              "legendFormat": "resident anon mem: {{instance}}",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "exemplar": true,
+              "expr": "process_resident_memory_bytes{instance=~\"$instance\"}",
               "hide": false,
               "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "memstats_frees_total: {{ instance }}",
-              "range": true,
-              "refId": "B"
+              "legendFormat": "resident mem: {{instance}}",
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "expr": "mem_data{instance=~\"$instance\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "data: {{instance}}",
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "expr": "mem_stack{instance=~\"$instance\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "stack: {{instance}}",
+              "refId": "E"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "expr": "mem_locked{instance=~\"$instance\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "locked: {{instance}}",
+              "refId": "F"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "expr": "mem_swap{instance=~\"$instance\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "swap: {{instance}}",
+              "refId": "G"
             }
           ],
-          "title": "Process Mem: allocate objects/sec, free",
+          "title": "mem: resident set size",
           "type": "timeseries"
         },
         {
@@ -7440,7 +7898,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -7453,10 +7912,10 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 5,
+            "h": 8,
             "w": 8,
             "x": 16,
-            "y": 2592
+            "y": 18
           },
           "id": 124,
           "options": {
@@ -7472,7 +7931,114 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "exemplar": true,
+              "expr": "rate(go_gc_duration_seconds{quantile=\"0.75\", instance=~\"$instance\"}[$__rate_interval])",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "interval": "",
+              "legendFormat": "{{instance}}",
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "GC Stop the World per sec",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "cps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 26
+          },
+          "id": 153,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean"
+              ],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
@@ -7481,14 +8047,423 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(go_gc_duration_seconds{quantile=\"0.75\",instance=~\"$instance\"}[$__rate_interval])",
-              "instant": false,
+              "expr": "rate(go_cgo_calls_count{instance=~\"$instance\"}[$__rate_interval]) > 0",
               "interval": "",
-              "legendFormat": "",
+              "legendFormat": "cgo_calls_count: {{instance}}",
+              "range": true,
               "refId": "A"
             }
           ],
-          "title": "GC Stop the World per sec",
+          "title": "cgo calls",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 26
+          },
+          "id": 155,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean"
+              ],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "rate(process_io_write_syscalls_total{instance=~\"$instance\"}[$__rate_interval]) > 0",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "in: {{instance}}",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "rate(process_io_read_syscalls_total{instance=~\"$instance\"}[$__rate_interval]) > 0",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "out: {{instance}}",
+              "range": true,
+              "refId": "D"
+            }
+          ],
+          "title": "Read/Write syscall/sec",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "__systemRef": "hideSeriesFrom",
+                "matcher": {
+                  "id": "byNames",
+                  "options": {
+                    "mode": "exclude",
+                    "names": [
+                      "soft: dev-bm-e3-gnosis-n1",
+                      "soft: dev-bm-e3-ethmainnet-n1"
+                    ],
+                    "prefix": "All except:",
+                    "readOnly": true
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 26
+          },
+          "id": 150,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean"
+              ],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "rate(process_minor_pagefaults_total{instance=~\"$instance\"}[$__rate_interval]) > 0",
+              "interval": "",
+              "legendFormat": "soft: {{instance}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "rate(process_major_pagefaults_total{instance=~\"$instance\"}[$__rate_interval]) > 0",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "hard: {{instance}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "getrusage: minflt - soft page faults (reclaims), majflt - hard faults",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": [
+              {
+                "__systemRef": "hideSeriesFrom",
+                "matcher": {
+                  "id": "byNames",
+                  "options": {
+                    "mode": "exclude",
+                    "names": [
+                      "write: dev-bm-e3-ethmainnet-n1"
+                    ],
+                    "prefix": "All except:",
+                    "readOnly": true
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 34
+          },
+          "id": 85,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean"
+              ],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "rate(process_io_storage_read_bytes_total{instance=~\"$instance\"}[$__rate_interval]) > 0",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "read: {{instance}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "rate(process_io_storage_written_bytes_total{instance=~\"$instance\"}[$__rate_interval]) > 0",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "write: {{instance}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Disk bytes/sec",
           "type": "timeseries"
         }
       ],
@@ -7501,7 +8476,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 9
+        "y": 10
       },
       "id": 183,
       "panels": [
@@ -7553,7 +8528,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -7569,7 +8545,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1371
+            "y": 1417
           },
           "id": 185,
           "options": {
@@ -7588,30 +8564,42 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
               },
+              "disableTextWrap": false,
+              "editorMode": "builder",
               "exemplar": true,
-              "expr": "rate(rpc_duration_seconds_count{instance=~\"$instance\",success=\"success\"}[1m])",
+              "expr": "rate(rpc_duration_seconds_count{instance=~\"$instance\", success=\"success\"}[$__rate_interval])",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
               "interval": "",
               "legendFormat": "success {{ method }} {{ instance }} ",
-              "refId": "A"
+              "range": true,
+              "refId": "A",
+              "useBackend": false
             },
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
               },
+              "disableTextWrap": false,
+              "editorMode": "builder",
               "exemplar": true,
-              "expr": "rate(rpc_duration_seconds_count{instance=~\"$instance\",success=\"failure\"}[1m])",
+              "expr": "rate(rpc_duration_seconds_count{instance=~\"$instance\", success=\"failure\"}[$__rate_interval])",
+              "fullMetaSearch": false,
               "hide": false,
+              "includeNullMetadata": true,
               "interval": "",
               "legendFormat": "failure {{ method }} {{ instance }} ",
-              "refId": "B"
+              "range": true,
+              "refId": "B",
+              "useBackend": false
             }
           ],
           "title": "RPS",
@@ -7665,7 +8653,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -7681,7 +8670,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1371
+            "y": 1417
           },
           "id": 186,
           "options": {
@@ -7700,7 +8689,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
@@ -7765,7 +8754,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -7781,7 +8771,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1379
+            "y": 1425
           },
           "id": 187,
           "options": {
@@ -7800,7 +8790,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
@@ -7865,7 +8855,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -7881,7 +8872,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1379
+            "y": 1425
           },
           "id": 188,
           "options": {
@@ -7897,7 +8888,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
@@ -7973,7 +8964,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -7986,10 +8978,10 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 6,
-            "w": 8,
-            "x": 8,
-            "y": 1387
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 1433
           },
           "id": 189,
           "options": {
@@ -8008,18 +9000,20 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
               },
+              "editorMode": "builder",
               "exemplar": true,
               "expr": "cache_keys_total{name=\"rpc\",instance=~\"$instance\"}",
               "hide": false,
               "interval": "",
               "legendFormat": "keys: {{ instance }} ",
+              "range": true,
               "refId": "A"
             },
             {
@@ -8027,11 +9021,13 @@
                 "type": "prometheus",
                 "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
               },
+              "editorMode": "builder",
               "exemplar": true,
               "expr": "cache_list_total{name=\"rpc\",instance=~\"$instance\"}",
               "hide": false,
               "interval": "",
               "legendFormat": "list: {{ instance }} ",
+              "range": true,
               "refId": "B"
             },
             {
@@ -8039,11 +9035,13 @@
                 "type": "prometheus",
                 "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
               },
+              "editorMode": "builder",
               "exemplar": true,
               "expr": "cache_code_keys_total{name=\"rpc\",instance=~\"$instance\"}",
               "hide": false,
               "interval": "",
               "legendFormat": "code_keys: {{ instance }} ",
+              "range": true,
               "refId": "C"
             },
             {
@@ -8051,11 +9049,13 @@
                 "type": "prometheus",
                 "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
               },
+              "editorMode": "builder",
               "exemplar": true,
               "expr": "cache_code_list_total{name=\"rpc\",instance=~\"$instance\"}",
               "hide": false,
               "interval": "",
               "legendFormat": "code_list: {{ instance }} ",
+              "range": true,
               "refId": "D"
             }
           ],
@@ -8110,7 +9110,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -8122,10 +9123,10 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 6,
-            "w": 8,
-            "x": 16,
-            "y": 1387
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 1433
           },
           "id": 184,
           "options": {
@@ -8144,7 +9145,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
@@ -8186,7 +9187,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 11
       },
       "id": 75,
       "panels": [
@@ -8238,7 +9239,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -8280,7 +9282,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 2501
+            "y": 1418
           },
           "id": 96,
           "options": {
@@ -8301,7 +9303,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
@@ -8386,7 +9388,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -8402,7 +9405,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 2501
+            "y": 1418
           },
           "id": 77,
           "options": {
@@ -8423,7 +9426,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-83314",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
@@ -8479,7 +9482,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 11
+        "y": 12
       },
       "id": 173,
       "panels": [
@@ -8531,7 +9534,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -8547,7 +9551,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 12
+            "y": 1419
           },
           "id": 175,
           "options": {
@@ -8566,7 +9570,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
@@ -8691,7 +9695,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -8707,7 +9712,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 12
+            "y": 1419
           },
           "id": 177,
           "options": {
@@ -8726,7 +9731,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
@@ -8850,24 +9855,26 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
                     "value": 80
                   }
                 ]
-              }
+              },
+              "unit": "binBps"
             },
             "overrides": []
           },
           "gridPos": {
             "h": 6,
-            "w": 8,
+            "w": 12,
             "x": 0,
-            "y": 100
+            "y": 1427
           },
-          "id": 176,
+          "id": 178,
           "options": {
             "legend": {
               "calcs": [
@@ -8884,22 +9891,24 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
               },
+              "editorMode": "code",
               "exemplar": true,
-              "expr": "sum(delta(cache_total{result=\"hit\",name=\"txpool\",instance=~\"$instance\"}[1m]))/sum(delta(cache_total{name=\"txpool\",instance=~\"$instance\"}[1m])) ",
+              "expr": "rate(pool_write_to_db_bytes{instance=~\"$instance\"}[$__rate_interval])",
               "hide": false,
               "interval": "",
-              "legendFormat": "hit rate: {{ instance }} ",
+              "legendFormat": "pool_write_to_db_bytes: {{ instance }}",
+              "range": true,
               "refId": "A"
             }
           ],
-          "title": "Cache hit-rate",
+          "title": "DB",
           "type": "timeseries"
         },
         {
@@ -8950,7 +9959,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -8963,9 +9973,9 @@
           },
           "gridPos": {
             "h": 6,
-            "w": 8,
-            "x": 8,
-            "y": 100
+            "w": 12,
+            "x": 12,
+            "y": 1427
           },
           "id": 180,
           "options": {
@@ -8984,7 +9994,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
@@ -9062,25 +10072,25 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
                     "value": 80
                   }
                 ]
-              },
-              "unit": "short"
+              }
             },
             "overrides": []
           },
           "gridPos": {
             "h": 6,
-            "w": 8,
-            "x": 16,
-            "y": 100
+            "w": 12,
+            "x": 0,
+            "y": 1433
           },
-          "id": 181,
+          "id": 176,
           "options": {
             "legend": {
               "calcs": [
@@ -9097,7 +10107,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
@@ -9105,26 +10115,14 @@
                 "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
               },
               "exemplar": true,
-              "expr": "cache_keys_total{name=\"txpool\",instance=~\"$instance\"}",
+              "expr": "sum(delta(cache_total{result=\"hit\",name=\"txpool\",instance=~\"$instance\"}[1m]))/sum(delta(cache_total{name=\"txpool\",instance=~\"$instance\"}[1m])) ",
               "hide": false,
               "interval": "",
-              "legendFormat": "keys: {{ instance }} ",
+              "legendFormat": "hit rate: {{ instance }} ",
               "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "exemplar": true,
-              "expr": "cache_list_total{name=\"txpool\",instance=~\"$instance\"}",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "list: {{ instance }} ",
-              "refId": "B"
             }
           ],
-          "title": "Cache keys",
+          "title": "Cache hit-rate",
           "type": "timeseries"
         },
         {
@@ -9175,7 +10173,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -9183,17 +10182,17 @@
                   }
                 ]
               },
-              "unit": "binBps"
+              "unit": "short"
             },
             "overrides": []
           },
           "gridPos": {
             "h": 6,
-            "w": 8,
-            "x": 0,
-            "y": 106
+            "w": 12,
+            "x": 12,
+            "y": 1433
           },
-          "id": 178,
+          "id": 181,
           "options": {
             "legend": {
               "calcs": [
@@ -9210,24 +10209,34 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
               },
-              "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(pool_write_to_db_bytes{instance=~\"$instance\"}[$__rate_interval])",
+              "expr": "cache_keys_total{name=\"txpool\",instance=~\"$instance\"}",
               "hide": false,
               "interval": "",
-              "legendFormat": "pool_write_to_db_bytes: {{ instance }}",
-              "range": true,
+              "legendFormat": "keys: {{ instance }} ",
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "exemplar": true,
+              "expr": "cache_list_total{name=\"txpool\",instance=~\"$instance\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "list: {{ instance }} ",
+              "refId": "B"
             }
           ],
-          "title": "DB",
+          "title": "Cache keys",
           "type": "timeseries"
         }
       ],
@@ -9240,7 +10249,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 12
+        "y": 13
       },
       "id": 249,
       "panels": [
@@ -9292,7 +10301,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -9307,7 +10317,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 13
+            "y": 1420
           },
           "id": 268,
           "options": {
@@ -9323,7 +10333,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -9392,7 +10402,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -9407,7 +10418,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 13
+            "y": 1420
           },
           "id": 267,
           "options": {
@@ -9423,7 +10434,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -9509,7 +10520,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -9525,7 +10537,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 21
+            "y": 1428
           },
           "id": 266,
           "options": {
@@ -9541,7 +10553,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -9610,7 +10622,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -9626,7 +10639,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 21
+            "y": 1428
           },
           "id": 265,
           "options": {
@@ -9642,7 +10655,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -9711,7 +10724,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -9726,7 +10740,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 29
+            "y": 1436
           },
           "id": 264,
           "options": {
@@ -9742,7 +10756,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -9811,7 +10825,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -9826,7 +10841,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 29
+            "y": 1436
           },
           "id": 263,
           "options": {
@@ -9842,7 +10857,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -9928,7 +10943,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -9944,7 +10960,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 37
+            "y": 1444
           },
           "id": 262,
           "options": {
@@ -9960,7 +10976,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -10029,7 +11045,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -10045,7 +11062,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 37
+            "y": 1444
           },
           "id": 261,
           "options": {
@@ -10061,7 +11078,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -10130,7 +11147,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -10145,7 +11163,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 45
+            "y": 1452
           },
           "id": 259,
           "options": {
@@ -10161,7 +11179,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -10230,7 +11248,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -10245,7 +11264,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 45
+            "y": 1452
           },
           "id": 269,
           "options": {
@@ -10261,7 +11280,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
@@ -10347,7 +11366,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -10362,7 +11382,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 53
+            "y": 1460
           },
           "id": 255,
           "options": {
@@ -10378,7 +11398,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "datasource": {
@@ -10464,7 +11484,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -10479,7 +11500,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 53
+            "y": 1460
           },
           "id": 257,
           "options": {
@@ -10495,7 +11516,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -10564,7 +11585,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -10580,7 +11602,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 61
+            "y": 1468
           },
           "id": 260,
           "options": {
@@ -10596,7 +11618,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -10665,7 +11687,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -10681,7 +11704,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 61
+            "y": 1468
           },
           "id": 258,
           "options": {
@@ -10697,7 +11720,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -10766,7 +11789,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -10782,7 +11806,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 69
+            "y": 1476
           },
           "id": 254,
           "options": {
@@ -10798,7 +11822,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -10867,7 +11891,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -10882,7 +11907,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 69
+            "y": 1476
           },
           "id": 253,
           "options": {
@@ -10898,7 +11923,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -10984,7 +12009,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -11000,7 +12026,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 77
+            "y": 1484
           },
           "id": 252,
           "options": {
@@ -11016,7 +12042,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -11085,7 +12111,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -11100,7 +12127,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 77
+            "y": 1484
           },
           "id": 251,
           "options": {
@@ -11116,7 +12143,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -11202,7 +12229,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -11217,7 +12245,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 85
+            "y": 1492
           },
           "id": 256,
           "options": {
@@ -11233,7 +12261,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.0-84846",
+          "pluginVersion": "12.1.0-91038.patch3-91166",
           "targets": [
             {
               "disableTextWrap": false,
@@ -11259,7 +12287,7 @@
       "type": "row"
     }
   ],
-  "refresh": "10s",
+  "refresh": "30m",
   "schemaVersion": 41,
   "tags": [],
   "templating": {
@@ -11331,11 +12359,28 @@
         "refresh": 1,
         "regex": "/.*instance=\"([^\"]*).*/",
         "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "label_values(node_uname_info,instance)",
+        "includeAll": true,
+        "label": "nodo",
+        "multi": true,
+        "name": "nodo",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(node_uname_info,instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
       }
     ]
   },
   "time": {
-    "from": "now-30m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {
@@ -11354,6 +12399,6 @@
   "timezone": "",
   "title": "1. Erigon CUSTOM METRICS",
   "uid": "b42a61d7-02b1-416c-8ab4-b9c864356174",
-  "version": 390,
+  "version": 429,
   "weekStart": ""
 }

--- a/cmd/prometheus/dashboards/erigon_internals.json
+++ b/cmd/prometheus/dashboards/erigon_internals.json
@@ -85,6 +85,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
+  "id": null,
   "links": [],
   "panels": [
     {
@@ -355,7 +356,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 1535
+            "y": 2455
           },
           "id": 278,
           "options": {
@@ -452,7 +453,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1535
+            "y": 2455
           },
           "id": 276,
           "options": {
@@ -549,7 +550,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1574
+            "y": 2494
           },
           "id": 273,
           "options": {
@@ -646,7 +647,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1574
+            "y": 2494
           },
           "id": 275,
           "options": {
@@ -743,7 +744,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1582
+            "y": 2502
           },
           "id": 274,
           "options": {
@@ -840,7 +841,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1582
+            "y": 2502
           },
           "id": 272,
           "options": {
@@ -1433,7 +1434,7 @@
             "h": 4,
             "w": 12,
             "x": 0,
-            "y": 1489
+            "y": 2409
           },
           "id": 222,
           "options": {
@@ -1501,7 +1502,7 @@
             "h": 4,
             "w": 12,
             "x": 0,
-            "y": 1570
+            "y": 2490
           },
           "id": 223,
           "options": {
@@ -1841,7 +1842,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1571
+            "y": 2491
           },
           "id": 229,
           "options": {
@@ -1908,7 +1909,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1571
+            "y": 2491
           },
           "id": 215,
           "options": {
@@ -2002,7 +2003,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1579
+            "y": 2499
           },
           "id": 236,
           "options": {
@@ -2080,7 +2081,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1579
+            "y": 2499
           },
           "id": 214,
           "options": {
@@ -2153,7 +2154,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1587
+            "y": 2507
           },
           "id": 235,
           "options": {
@@ -2259,7 +2260,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1587
+            "y": 2507
           },
           "id": 210,
           "options": {
@@ -2328,7 +2329,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1595
+            "y": 2515
           },
           "id": 234,
           "options": {
@@ -2459,7 +2460,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1595
+            "y": 2515
           },
           "id": 211,
           "options": {
@@ -2557,7 +2558,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1603
+            "y": 2523
           },
           "id": 231,
           "options": {
@@ -2645,7 +2646,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1603
+            "y": 2523
           },
           "id": 221,
           "options": {
@@ -2832,7 +2833,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1611
+            "y": 2531
           },
           "id": 216,
           "options": {
@@ -2961,7 +2962,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1611
+            "y": 2531
           },
           "id": 217,
           "options": {
@@ -3059,7 +3060,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1619
+            "y": 2539
           },
           "id": 228,
           "options": {
@@ -3124,7 +3125,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1619
+            "y": 2539
           },
           "id": 213,
           "options": {
@@ -3197,7 +3198,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1627
+            "y": 2547
           },
           "id": 226,
           "options": {
@@ -3303,7 +3304,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1627
+            "y": 2547
           },
           "id": 227,
           "options": {
@@ -3429,7 +3430,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 1635
+            "y": 2555
           },
           "id": 224,
           "options": {
@@ -3565,7 +3566,7 @@
             "h": 12,
             "w": 24,
             "x": 0,
-            "y": 1644
+            "y": 2564
           },
           "id": 209,
           "options": {
@@ -3894,7 +3895,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 135
+            "y": 76
           },
           "id": 238,
           "options": {
@@ -3986,7 +3987,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 135
+            "y": 76
           },
           "id": 239,
           "options": {
@@ -4253,6 +4254,244 @@
                   "viz": false
                 },
                 "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 16
+          },
+          "id": 282,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-91295",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "run_stage_duration_secs{instance=~\"$instance\", quantile=\"$quantile\"}",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "run {{stage}} {{instance}}",
+              "range": true,
+              "refId": "B",
+              "useBackend": false
+            },
+            {
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "prune_stage_duration_secs{instance=~\"$instance\", quantile=\"$quantile\"}",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "legendFormat": "prune {{stage}} {{instance}}",
+              "range": true,
+              "refId": "A",
+              "useBackend": false,
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "unwind_stage_duration_secs{instance=~\"$instance\", quantile=\"$quantile\"}",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "unwind {{stage}} {{instance}}",
+              "range": true,
+              "refId": "C",
+              "useBackend": false
+            }
+          ],
+          "title": "Stage Durations",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 16
+          },
+          "id": 283,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-91295",
+          "targets": [
+            {
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "initial_cycle_duration_secs{instance=~\"$instance\"}",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A",
+              "useBackend": false,
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              }
+            }
+          ],
+          "title": "Time in initial cycle",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
                 "lineInterpolation": "smooth",
                 "lineWidth": 1,
                 "pointSize": 4,
@@ -4291,7 +4530,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 16
+            "y": 25
           },
           "id": 200,
           "options": {
@@ -4357,7 +4596,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 16
+            "y": 25
           },
           "id": 202,
           "options": {
@@ -4483,7 +4722,7 @@
             "h": 10,
             "w": 8,
             "x": 0,
-            "y": 25
+            "y": 34
           },
           "id": 197,
           "options": {
@@ -4641,7 +4880,7 @@
             "h": 10,
             "w": 8,
             "x": 8,
-            "y": 25
+            "y": 34
           },
           "id": 198,
           "options": {
@@ -4802,7 +5041,7 @@
             "h": 10,
             "w": 8,
             "x": 16,
-            "y": 25
+            "y": 34
           },
           "id": 112,
           "options": {
@@ -4954,7 +5193,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 35
+            "y": 44
           },
           "id": 201,
           "options": {
@@ -5089,7 +5328,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 35
+            "y": 44
           },
           "id": 199,
           "options": {
@@ -5194,7 +5433,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 45
+            "y": 54
           },
           "id": 206,
           "options": {
@@ -5298,7 +5537,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 45
+            "y": 54
           },
           "id": 207,
           "options": {
@@ -5429,7 +5668,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 45
+            "y": 54
           },
           "id": 194,
           "options": {
@@ -5549,7 +5788,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 53
+            "y": 62
           },
           "id": 246,
           "options": {
@@ -5668,7 +5907,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 53
+            "y": 62
           },
           "id": 281,
           "options": {
@@ -5769,7 +6008,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 53
+            "y": 62
           },
           "id": 245,
           "options": {
@@ -5887,7 +6126,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 61
+            "y": 70
           },
           "id": 208,
           "options": {
@@ -6004,7 +6243,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1404
+            "y": 2324
           },
           "id": 243,
           "options": {
@@ -6123,7 +6362,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1404
+            "y": 2324
           },
           "id": 244,
           "options": {
@@ -8289,33 +8528,7 @@
               },
               "unit": "short"
             },
-            "overrides": [
-              {
-                "__systemRef": "hideSeriesFrom",
-                "matcher": {
-                  "id": "byNames",
-                  "options": {
-                    "mode": "exclude",
-                    "names": [
-                      "soft: dev-bm-e3-gnosis-n1",
-                      "soft: dev-bm-e3-ethmainnet-n1"
-                    ],
-                    "prefix": "All except:",
-                    "readOnly": true
-                  }
-                },
-                "properties": [
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": true
-                    }
-                  }
-                ]
-              }
-            ]
+            "overrides": []
           },
           "gridPos": {
             "h": 8,
@@ -8431,32 +8644,7 @@
               },
               "unit": "decbytes"
             },
-            "overrides": [
-              {
-                "__systemRef": "hideSeriesFrom",
-                "matcher": {
-                  "id": "byNames",
-                  "options": {
-                    "mode": "exclude",
-                    "names": [
-                      "write: dev-bm-e3-ethmainnet-n1"
-                    ],
-                    "prefix": "All except:",
-                    "readOnly": true
-                  }
-                },
-                "properties": [
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": true
-                    }
-                  }
-                ]
-              }
-            ]
+            "overrides": []
           },
           "gridPos": {
             "h": 8,
@@ -8595,7 +8783,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2552
+            "y": 881
           },
           "id": 185,
           "options": {
@@ -8614,7 +8802,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -8720,7 +8908,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2552
+            "y": 881
           },
           "id": 186,
           "options": {
@@ -8739,7 +8927,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -8821,7 +9009,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2560
+            "y": 889
           },
           "id": 187,
           "options": {
@@ -8840,7 +9028,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -8922,7 +9110,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2560
+            "y": 889
           },
           "id": 188,
           "options": {
@@ -8938,7 +9126,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -9031,7 +9219,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 2568
+            "y": 897
           },
           "id": 189,
           "options": {
@@ -9050,7 +9238,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -9176,7 +9364,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 2568
+            "y": 897
           },
           "id": 184,
           "options": {
@@ -9195,7 +9383,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -9332,7 +9520,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 2553
+            "y": 3473
           },
           "id": 96,
           "options": {
@@ -9455,7 +9643,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 2553
+            "y": 3473
           },
           "id": 77,
           "options": {
@@ -9601,7 +9789,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2554
+            "y": 3474
           },
           "id": 175,
           "options": {
@@ -9762,7 +9950,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2554
+            "y": 3474
           },
           "id": 177,
           "options": {
@@ -9922,7 +10110,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 2562
+            "y": 3482
           },
           "id": 178,
           "options": {
@@ -10025,7 +10213,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 2562
+            "y": 3482
           },
           "id": 180,
           "options": {
@@ -10138,7 +10326,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 2568
+            "y": 3488
           },
           "id": 176,
           "options": {
@@ -10240,7 +10428,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 2568
+            "y": 3488
           },
           "id": 181,
           "options": {
@@ -10367,7 +10555,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2555
+            "y": 3475
           },
           "id": 268,
           "options": {
@@ -10468,7 +10656,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2555
+            "y": 3475
           },
           "id": 267,
           "options": {
@@ -10587,7 +10775,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2563
+            "y": 3483
           },
           "id": 266,
           "options": {
@@ -10689,7 +10877,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2563
+            "y": 3483
           },
           "id": 265,
           "options": {
@@ -10790,7 +10978,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2571
+            "y": 3491
           },
           "id": 264,
           "options": {
@@ -10891,7 +11079,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2571
+            "y": 3491
           },
           "id": 263,
           "options": {
@@ -11010,7 +11198,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2579
+            "y": 3499
           },
           "id": 262,
           "options": {
@@ -11112,7 +11300,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2579
+            "y": 3499
           },
           "id": 261,
           "options": {
@@ -11213,7 +11401,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2587
+            "y": 3507
           },
           "id": 259,
           "options": {
@@ -11314,7 +11502,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2587
+            "y": 3507
           },
           "id": 269,
           "options": {
@@ -11432,7 +11620,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2595
+            "y": 3515
           },
           "id": 255,
           "options": {
@@ -11550,7 +11738,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2595
+            "y": 3515
           },
           "id": 257,
           "options": {
@@ -11652,7 +11840,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2603
+            "y": 3523
           },
           "id": 260,
           "options": {
@@ -11754,7 +11942,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2603
+            "y": 3523
           },
           "id": 258,
           "options": {
@@ -11856,7 +12044,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2611
+            "y": 3531
           },
           "id": 254,
           "options": {
@@ -11957,7 +12145,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2611
+            "y": 3531
           },
           "id": 253,
           "options": {
@@ -12076,7 +12264,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2619
+            "y": 3539
           },
           "id": 252,
           "options": {
@@ -12177,7 +12365,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2619
+            "y": 3539
           },
           "id": 251,
           "options": {
@@ -12295,7 +12483,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2627
+            "y": 3547
           },
           "id": 256,
           "options": {
@@ -12337,15 +12525,15 @@
       "type": "row"
     }
   ],
-  "refresh": "30m",
+  "refresh": "30s",
   "schemaVersion": 41,
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "text": "0.99",
-          "value": "0.99"
+          "text": "0.97",
+          "value": "0.97"
         },
         "includeAll": false,
         "name": "quantile",
@@ -12371,12 +12559,12 @@
             "value": "0.9"
           },
           {
-            "selected": false,
+            "selected": true,
             "text": "0.97",
             "value": "0.97"
           },
           {
-            "selected": true,
+            "selected": false,
             "text": "0.99",
             "value": "0.99"
           },
@@ -12430,7 +12618,7 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {
@@ -12449,7 +12637,6 @@
   "timezone": "",
   "title": "1. Erigon CUSTOM METRICS",
   "uid": "b42a61d7-02b1-416c-8ab4-b9c864356174",
-  "version": 443,
-  "weekStart": "",
-  "id": null
+  "version": 448,
+  "weekStart": ""
 }

--- a/cmd/prometheus/dashboards/erigon_internals.json
+++ b/cmd/prometheus/dashboards/erigon_internals.json
@@ -33,7 +33,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "12.1.0-91038.patch3-91166"
+      "version": "12.1.0-91295"
     },
     {
       "type": "panel",
@@ -85,7 +85,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": null,
   "links": [],
   "panels": [
     {
@@ -356,7 +355,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 400
+            "y": 1535
           },
           "id": 278,
           "options": {
@@ -453,7 +452,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 400
+            "y": 1535
           },
           "id": 276,
           "options": {
@@ -550,7 +549,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 439
+            "y": 1574
           },
           "id": 273,
           "options": {
@@ -647,7 +646,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 439
+            "y": 1574
           },
           "id": 275,
           "options": {
@@ -744,7 +743,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 447
+            "y": 1582
           },
           "id": 274,
           "options": {
@@ -841,7 +840,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 447
+            "y": 1582
           },
           "id": 272,
           "options": {
@@ -1434,7 +1433,7 @@
             "h": 4,
             "w": 12,
             "x": 0,
-            "y": 354
+            "y": 1489
           },
           "id": 222,
           "options": {
@@ -1502,7 +1501,7 @@
             "h": 4,
             "w": 12,
             "x": 0,
-            "y": 435
+            "y": 1570
           },
           "id": 223,
           "options": {
@@ -1842,7 +1841,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 436
+            "y": 1571
           },
           "id": 229,
           "options": {
@@ -1909,7 +1908,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 436
+            "y": 1571
           },
           "id": 215,
           "options": {
@@ -2003,7 +2002,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 444
+            "y": 1579
           },
           "id": 236,
           "options": {
@@ -2081,7 +2080,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 444
+            "y": 1579
           },
           "id": 214,
           "options": {
@@ -2154,7 +2153,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 452
+            "y": 1587
           },
           "id": 235,
           "options": {
@@ -2260,7 +2259,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 452
+            "y": 1587
           },
           "id": 210,
           "options": {
@@ -2329,7 +2328,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 460
+            "y": 1595
           },
           "id": 234,
           "options": {
@@ -2460,7 +2459,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 460
+            "y": 1595
           },
           "id": 211,
           "options": {
@@ -2558,7 +2557,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 468
+            "y": 1603
           },
           "id": 231,
           "options": {
@@ -2646,7 +2645,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 468
+            "y": 1603
           },
           "id": 221,
           "options": {
@@ -2833,7 +2832,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 476
+            "y": 1611
           },
           "id": 216,
           "options": {
@@ -2962,7 +2961,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 476
+            "y": 1611
           },
           "id": 217,
           "options": {
@@ -3060,7 +3059,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 484
+            "y": 1619
           },
           "id": 228,
           "options": {
@@ -3125,7 +3124,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 484
+            "y": 1619
           },
           "id": 213,
           "options": {
@@ -3198,7 +3197,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 492
+            "y": 1627
           },
           "id": 226,
           "options": {
@@ -3304,7 +3303,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 492
+            "y": 1627
           },
           "id": 227,
           "options": {
@@ -3430,7 +3429,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 500
+            "y": 1635
           },
           "id": 224,
           "options": {
@@ -3566,7 +3565,7 @@
             "h": 12,
             "w": 24,
             "x": 0,
-            "y": 509
+            "y": 1644
           },
           "id": 209,
           "options": {
@@ -3714,7 +3713,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "editorMode": "code",
@@ -3814,7 +3813,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "editorMode": "code",
@@ -3895,7 +3894,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 437
+            "y": 135
           },
           "id": 238,
           "options": {
@@ -3911,7 +3910,7 @@
               "sort": "asc"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "editorMode": "code",
@@ -3987,7 +3986,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 437
+            "y": 135
           },
           "id": 239,
           "options": {
@@ -4007,7 +4006,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "editorMode": "code",
@@ -4105,7 +4104,7 @@
             "showThresholdMarkers": true,
             "sizing": "auto"
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -4206,7 +4205,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -4308,7 +4307,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -4385,7 +4384,7 @@
             "sizing": "manual",
             "valueMode": "color"
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -4500,7 +4499,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -4658,7 +4657,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -4797,32 +4796,7 @@
               },
               "unit": "s"
             },
-            "overrides": [
-              {
-                "__systemRef": "hideSeriesFrom",
-                "matcher": {
-                  "id": "byNames",
-                  "options": {
-                    "mode": "exclude",
-                    "names": [
-                      "commitment took: dev-bm-e3-ethmainnet-n1"
-                    ],
-                    "prefix": "All except:",
-                    "readOnly": true
-                  }
-                },
-                "properties": [
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": true
-                    }
-                  }
-                ]
-              }
-            ]
+            "overrides": []
           },
           "gridPos": {
             "h": 10,
@@ -4846,7 +4820,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -4996,7 +4970,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -5134,7 +5108,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -5153,226 +5127,6 @@
             }
           ],
           "title": "Block Execution speed ",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": 0
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 45
-          },
-          "id": 245,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
-          "targets": [
-            {
-              "disableTextWrap": false,
-              "editorMode": "builder",
-              "expr": "update_fork_choice{type=\"fork_depth\", instance=~\"$instance\", quantile=\"$quantile\"}",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "legendFormat": "fork_depth {{instance}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false,
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              }
-            }
-          ],
-          "title": "Update Fork Choice depth",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": 0
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "s"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 45
-          },
-          "id": 246,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
-          "targets": [
-            {
-              "disableTextWrap": false,
-              "editorMode": "builder",
-              "expr": "update_fork_choice{type=\"arrival_delay\", instance=\"$instance\", quantile=\"$quantile\"}",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "legendFormat": "arrival_delay $instance",
-              "range": true,
-              "refId": "A",
-              "useBackend": false,
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              }
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
-              },
-              "disableTextWrap": false,
-              "editorMode": "builder",
-              "expr": "update_fork_choice{instance=~\"$instance\", quantile=\"$quantile\", type=\"execution_duration\"}",
-              "fullMetaSearch": false,
-              "hide": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "legendFormat": "execution_duration {{instance}}",
-              "range": true,
-              "refId": "B",
-              "useBackend": false
-            }
-          ],
-          "title": "Update Fork Choice delays",
           "type": "timeseries"
         },
         {
@@ -5440,7 +5194,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 53
+            "y": 45
           },
           "id": 206,
           "options": {
@@ -5458,7 +5212,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -5544,7 +5298,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 53
+            "y": 45
           },
           "id": 207,
           "options": {
@@ -5562,7 +5316,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -5675,7 +5429,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 53
+            "y": 45
           },
           "id": 194,
           "options": {
@@ -5693,7 +5447,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -5728,6 +5482,328 @@
             }
           ],
           "title": "Exec v3",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 53
+          },
+          "id": 246,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-91295",
+          "targets": [
+            {
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "update_fork_choice{type=\"arrival_delay\", instance=\"$instance\", quantile=\"$quantile\"}",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "legendFormat": "arrival_delay $instance",
+              "range": true,
+              "refId": "A",
+              "useBackend": false,
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              }
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "update_fork_choice{instance=~\"$instance\", quantile=\"$quantile\", type=\"execution_duration\"}",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "execution_duration {{instance}}",
+              "range": true,
+              "refId": "B",
+              "useBackend": false
+            }
+          ],
+          "title": "Update Fork Choice Delays",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 53
+          },
+          "id": 281,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-91295",
+          "targets": [
+            {
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "update_fork_choice{type=\"prune_duration\", instance=~\"$instance\", quantile=\"$quantile\"}",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "legendFormat": "{{type}} {{instance}}",
+              "range": true,
+              "refId": "A",
+              "useBackend": false,
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              }
+            }
+          ],
+          "title": "Update Fork Choice Prune Duration",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 53
+          },
+          "id": 245,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-91295",
+          "targets": [
+            {
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "update_fork_choice{type=\"fork_depth\", instance=~\"$instance\", quantile=\"$quantile\"}",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "legendFormat": "fork_depth {{instance}}",
+              "range": true,
+              "refId": "A",
+              "useBackend": false,
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
+              }
+            }
+          ],
+          "title": "Update Fork Choice Depth",
           "type": "timeseries"
         },
         {
@@ -5829,7 +5905,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -5928,7 +6004,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 70
+            "y": 1404
           },
           "id": 243,
           "options": {
@@ -6047,7 +6123,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 70
+            "y": 1404
           },
           "id": 244,
           "options": {
@@ -6163,7 +6239,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 9
+            "y": 71
           },
           "id": 159,
           "options": {
@@ -6179,7 +6255,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -6273,7 +6349,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 9
+            "y": 71
           },
           "id": 280,
           "options": {
@@ -6289,7 +6365,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "disableTextWrap": false,
@@ -6375,7 +6451,7 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 9
+            "y": 71
           },
           "id": 167,
           "options": {
@@ -6393,7 +6469,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -6489,7 +6565,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 18
+            "y": 80
           },
           "id": 169,
           "options": {
@@ -6507,7 +6583,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -6615,39 +6691,13 @@
               },
               "unit": "s"
             },
-            "overrides": [
-              {
-                "__systemRef": "hideSeriesFrom",
-                "matcher": {
-                  "id": "byNames",
-                  "options": {
-                    "mode": "exclude",
-                    "names": [
-                      "sync: dev-bm-e3-ethmainnet-n1",
-                      "sync: dev-bm-e3-gnosis-n1"
-                    ],
-                    "prefix": "All except:",
-                    "readOnly": true
-                  }
-                },
-                "properties": [
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": true
-                    }
-                  }
-                ]
-              }
-            ]
+            "overrides": []
           },
           "gridPos": {
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 18
+            "y": 80
           },
           "id": 166,
           "options": {
@@ -6665,7 +6715,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -6774,7 +6824,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": false,
+                "spanNulls": true,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -6806,7 +6856,7 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 18
+            "y": 80
           },
           "id": 141,
           "options": {
@@ -6822,7 +6872,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -6906,7 +6956,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 27
+            "y": 89
           },
           "id": 168,
           "options": {
@@ -6924,7 +6974,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -7220,7 +7270,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 10
+            "y": 72
           },
           "id": 106,
           "options": {
@@ -7238,7 +7288,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -7328,7 +7378,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 10
+            "y": 72
           },
           "id": 128,
           "options": {
@@ -7344,7 +7394,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -7440,7 +7490,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 10
+            "y": 72
           },
           "id": 154,
           "options": {
@@ -7458,7 +7508,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -7625,7 +7675,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 18
+            "y": 80
           },
           "id": 86,
           "options": {
@@ -7643,7 +7693,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -7746,7 +7796,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 18
+            "y": 80
           },
           "id": 148,
           "options": {
@@ -7764,7 +7814,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -7915,7 +7965,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 18
+            "y": 80
           },
           "id": 124,
           "options": {
@@ -7931,7 +7981,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -8020,7 +8070,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 26
+            "y": 88
           },
           "id": 153,
           "options": {
@@ -8038,7 +8088,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -8123,7 +8173,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 26
+            "y": 88
           },
           "id": 155,
           "options": {
@@ -8141,7 +8191,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -8271,7 +8321,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 26
+            "y": 88
           },
           "id": 150,
           "options": {
@@ -8289,7 +8339,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -8412,7 +8462,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 34
+            "y": 96
           },
           "id": 85,
           "options": {
@@ -8430,7 +8480,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-91038.patch3-91166",
+          "pluginVersion": "12.1.0-91295",
           "targets": [
             {
               "datasource": {
@@ -8545,7 +8595,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1417
+            "y": 2552
           },
           "id": 185,
           "options": {
@@ -8670,7 +8720,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1417
+            "y": 2552
           },
           "id": 186,
           "options": {
@@ -8771,7 +8821,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1425
+            "y": 2560
           },
           "id": 187,
           "options": {
@@ -8872,7 +8922,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1425
+            "y": 2560
           },
           "id": 188,
           "options": {
@@ -8981,7 +9031,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 1433
+            "y": 2568
           },
           "id": 189,
           "options": {
@@ -9126,7 +9176,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1433
+            "y": 2568
           },
           "id": 184,
           "options": {
@@ -9282,7 +9332,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 1418
+            "y": 2553
           },
           "id": 96,
           "options": {
@@ -9405,7 +9455,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 1418
+            "y": 2553
           },
           "id": 77,
           "options": {
@@ -9551,7 +9601,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1419
+            "y": 2554
           },
           "id": 175,
           "options": {
@@ -9712,7 +9762,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1419
+            "y": 2554
           },
           "id": 177,
           "options": {
@@ -9872,7 +9922,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 1427
+            "y": 2562
           },
           "id": 178,
           "options": {
@@ -9975,7 +10025,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 1427
+            "y": 2562
           },
           "id": 180,
           "options": {
@@ -10088,7 +10138,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 1433
+            "y": 2568
           },
           "id": 176,
           "options": {
@@ -10190,7 +10240,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 1433
+            "y": 2568
           },
           "id": 181,
           "options": {
@@ -10317,7 +10367,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1420
+            "y": 2555
           },
           "id": 268,
           "options": {
@@ -10418,7 +10468,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1420
+            "y": 2555
           },
           "id": 267,
           "options": {
@@ -10537,7 +10587,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1428
+            "y": 2563
           },
           "id": 266,
           "options": {
@@ -10639,7 +10689,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1428
+            "y": 2563
           },
           "id": 265,
           "options": {
@@ -10740,7 +10790,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1436
+            "y": 2571
           },
           "id": 264,
           "options": {
@@ -10841,7 +10891,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1436
+            "y": 2571
           },
           "id": 263,
           "options": {
@@ -10960,7 +11010,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1444
+            "y": 2579
           },
           "id": 262,
           "options": {
@@ -11062,7 +11112,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1444
+            "y": 2579
           },
           "id": 261,
           "options": {
@@ -11163,7 +11213,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1452
+            "y": 2587
           },
           "id": 259,
           "options": {
@@ -11264,7 +11314,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1452
+            "y": 2587
           },
           "id": 269,
           "options": {
@@ -11382,7 +11432,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1460
+            "y": 2595
           },
           "id": 255,
           "options": {
@@ -11500,7 +11550,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1460
+            "y": 2595
           },
           "id": 257,
           "options": {
@@ -11602,7 +11652,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1468
+            "y": 2603
           },
           "id": 260,
           "options": {
@@ -11704,7 +11754,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1468
+            "y": 2603
           },
           "id": 258,
           "options": {
@@ -11806,7 +11856,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1476
+            "y": 2611
           },
           "id": 254,
           "options": {
@@ -11907,7 +11957,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1476
+            "y": 2611
           },
           "id": 253,
           "options": {
@@ -12026,7 +12076,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1484
+            "y": 2619
           },
           "id": 252,
           "options": {
@@ -12127,7 +12177,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1484
+            "y": 2619
           },
           "id": 251,
           "options": {
@@ -12245,7 +12295,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1492
+            "y": 2627
           },
           "id": 256,
           "options": {
@@ -12380,7 +12430,7 @@
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {
@@ -12399,6 +12449,7 @@
   "timezone": "",
   "title": "1. Erigon CUSTOM METRICS",
   "uid": "b42a61d7-02b1-416c-8ab4-b9c864356174",
-  "version": 429,
-  "weekStart": ""
+  "version": 443,
+  "weekStart": "",
+  "id": null
 }


### PR DESCRIPTION
cmd/prometheus: update erigon_internals with new dashboards

adds:
- stage duration metrics
- time in initial sync cycle
- periodic mdbx table size
- update fork choice prune duration
- fixes issues with some existing dashboards for cpu, db size and few others

<img width="1120" height="347" alt="Screenshot 2025-07-17 at 14 32 55" src="https://github.com/user-attachments/assets/b991fbc2-04f8-4d6d-9d77-3acb35b3d520" />

<img width="386" height="347" alt="Screenshot 2025-07-17 at 14 34 18" src="https://github.com/user-attachments/assets/bbd7b269-5bca-45d2-abeb-00e553ac3f11" />

<img width="386" height="347" alt="Screenshot 2025-07-17 at 14 35 07" src="https://github.com/user-attachments/assets/7cdaafdc-123d-491c-81db-bc04ee939825" />
