### PR TITLE
[r31] downloader: inverse verify flag use

### DIFF
--- a/erigon-db/downloader/downloader.go
+++ b/erigon-db/downloader/downloader.go
@@ -380,9 +380,7 @@ func (d *Downloader) AddTorrentsFromDisk(ctx context.Context) error {
 		return err
 	}
 
-	for _, t := range d.torrentClient.Torrents() {
-		d.afterAdd(t)
-	}
+	d.afterAdd()
 	return nil
 }
 

--- a/erigon-db/downloader/downloader.go
+++ b/erigon-db/downloader/downloader.go
@@ -381,10 +381,7 @@ func (d *Downloader) AddTorrentsFromDisk(ctx context.Context) error {
 	}
 
 	for _, t := range d.torrentClient.Torrents() {
-		t.AllowDataDownload()
-		t.AllowDataUpload()
-		t.AddTrackers(Trackers)
-		t.AddWebSeeds(d.cfg.WebSeedUrls, d.addWebSeedOpts...)
+		d.afterAdd(t)
 	}
 	return nil
 }

--- a/erigon-db/downloader/downloader.go
+++ b/erigon-db/downloader/downloader.go
@@ -350,7 +350,7 @@ func (d *Downloader) AddTorrentsFromDisk(ctx context.Context) error {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 	// Does WalkDir do path or filepath?
-	return fs.WalkDir(
+	if err := fs.WalkDir(
 		os.DirFS(d.SnapDir()),
 		".",
 		func(path string, de fs.DirEntry, err error) error {
@@ -376,7 +376,17 @@ func (d *Downloader) AddTorrentsFromDisk(ctx context.Context) error {
 			}
 			return nil
 		},
-	)
+	); err != nil {
+		return err
+	}
+
+	for _, t := range d.torrentClient.Torrents() {
+		t.AllowDataDownload()
+		t.AllowDataUpload()
+		t.AddTrackers(Trackers)
+		t.AddWebSeeds(d.cfg.WebSeedUrls, d.addWebSeedOpts...)
+	}
+	return nil
 }
 
 // This should only be called once...?
@@ -906,15 +916,16 @@ func (d *Downloader) RequestSnapshot(
 	// The infohash to use if there isn't one on disk. If there isn't one on disk then we can't proceed.
 	infoHash metainfo.Hash,
 	name string,
-) (err error) {
+) error {
 	d.lock.Lock()
+	defer d.lock.Unlock()
 	t, err := d.addPreverifiedTorrent(g.Some(infoHash), name)
-	if err == nil {
-		g.MakeMapIfNil(&d.requiredTorrents)
-		g.MapInsert(d.requiredTorrents, t, struct{}{})
+	if err != nil {
+		return err
 	}
-	d.lock.Unlock()
-	return
+	g.MakeMapIfNil(&d.requiredTorrents)
+	g.MapInsert(d.requiredTorrents, t, struct{}{})
+	return nil
 }
 
 // Add a torrent with a known info hash. Either someone else made it, or it was on disk. This might

--- a/erigon-db/downloader/downloader_grpc_server.go
+++ b/erigon-db/downloader/downloader_grpc_server.go
@@ -102,6 +102,10 @@ func (s *GrpcServer) Add(ctx context.Context, request *proto_downloader.AddReque
 			}
 		}
 	}
+	for _, t := range s.d.torrentClient.Torrents() {
+		t.AllowDataDownload()
+		t.AllowDataUpload()
+	}
 	progress.Store(int32(len(request.Items)))
 
 	return &emptypb.Empty{}, nil

--- a/erigon-db/downloader/downloader_grpc_server.go
+++ b/erigon-db/downloader/downloader_grpc_server.go
@@ -75,7 +75,9 @@ func (s *GrpcServer) Add(ctx context.Context, request *proto_downloader.AddReque
 			case <-ctx.Done():
 				return
 			case <-time.After(interval):
-				interval *= 2
+				if interval < time.Minute {
+					interval *= 2
+				}
 			}
 			logProgress()
 		}

--- a/erigon-db/downloader/downloader_grpc_server.go
+++ b/erigon-db/downloader/downloader_grpc_server.go
@@ -105,10 +105,7 @@ func (s *GrpcServer) Add(ctx context.Context, request *proto_downloader.AddReque
 		}
 	}
 	for _, t := range s.d.torrentClient.Torrents() {
-		t.AllowDataDownload()
-		t.AllowDataUpload()
-		t.AddTrackers(Trackers)
-		t.AddWebSeeds(s.d.cfg.WebSeedUrls, s.d.addWebSeedOpts...)
+		s.d.afterAdd(t)
 	}
 	progress.Store(int32(len(request.Items)))
 

--- a/erigon-db/downloader/downloader_grpc_server.go
+++ b/erigon-db/downloader/downloader_grpc_server.go
@@ -104,9 +104,7 @@ func (s *GrpcServer) Add(ctx context.Context, request *proto_downloader.AddReque
 			}
 		}
 	}
-	for _, t := range s.d.torrentClient.Torrents() {
-		s.d.afterAdd(t)
-	}
+	s.d.afterAdd()
 	progress.Store(int32(len(request.Items)))
 
 	return &emptypb.Empty{}, nil

--- a/erigon-db/downloader/downloader_grpc_server.go
+++ b/erigon-db/downloader/downloader_grpc_server.go
@@ -107,6 +107,8 @@ func (s *GrpcServer) Add(ctx context.Context, request *proto_downloader.AddReque
 	for _, t := range s.d.torrentClient.Torrents() {
 		t.AllowDataDownload()
 		t.AllowDataUpload()
+		t.AddTrackers(Trackers)
+		t.AddWebSeeds(s.d.cfg.WebSeedUrls, s.d.addWebSeedOpts...)
 	}
 	progress.Store(int32(len(request.Items)))
 

--- a/erigon-db/downloader/util.go
+++ b/erigon-db/downloader/util.go
@@ -332,7 +332,7 @@ func (d *Downloader) addTorrentSpec(
 	// completion data? We might want to clobber any piece completion and force the client to accept
 	// what we provide, assuming we trust our own metainfo generation more.
 	ts.IgnoreUnverifiedPieceCompletion = d.cfg.VerifyTorrentData
-	ts.DisableInitialPieceCheck = d.cfg.ManualDataVerification
+	ts.DisableInitialPieceCheck = !d.cfg.ManualDataVerification
 	// Non-zero chunk size is not allowed for existing torrents. If this breaks I will fix
 	// anacrolix/torrent instead of working around it. See torrent.Client.AddTorrentOpt.
 	t, first, err = d.torrentClient.AddTorrentSpec(ts)

--- a/erigon-db/downloader/util.go
+++ b/erigon-db/downloader/util.go
@@ -328,6 +328,8 @@ func (d *Downloader) addTorrentSpec(
 	ts.ChunkSize = downloadercfg.DefaultNetworkChunkSize
 	ts.Trackers = Trackers
 	ts.Webseeds = nil
+	ts.DisallowDataDownload = true
+	ts.DisallowDataUpload = true
 	// I wonder how this should be handled for AddNewSeedableFile. What if there's bad piece
 	// completion data? We might want to clobber any piece completion and force the client to accept
 	// what we provide, assuming we trust our own metainfo generation more.

--- a/erigon-db/downloader/util.go
+++ b/erigon-db/downloader/util.go
@@ -347,6 +347,13 @@ func (d *Downloader) addTorrentSpec(
 	return
 }
 
+func (d *Downloader) afterAdd(t *torrent.Torrent) {
+	t.AllowDataDownload()
+	t.AllowDataUpload()
+	t.AddTrackers(Trackers)
+	t.AddWebSeeds(d.cfg.WebSeedUrls, d.addWebSeedOpts...)
+}
+
 func savePeerID(db kv.RwDB, peerID torrent.PeerID) error {
 	return db.Update(context.Background(), func(tx kv.RwTx) error {
 		return tx.Put(kv.BittorrentInfo, []byte(kv.BittorrentPeerID), peerID[:])

--- a/erigon-db/downloader/util.go
+++ b/erigon-db/downloader/util.go
@@ -326,7 +326,7 @@ func (d *Downloader) addTorrentSpec(
 	name string,
 ) (t *torrent.Torrent, first bool, err error) {
 	ts.ChunkSize = downloadercfg.DefaultNetworkChunkSize
-	ts.Trackers = Trackers
+	ts.Trackers = nil
 	ts.Webseeds = nil
 	ts.DisallowDataDownload = true
 	ts.DisallowDataUpload = true
@@ -344,7 +344,6 @@ func (d *Downloader) addTorrentSpec(
 	g.MakeMapIfNil(&d.torrentsByName)
 	hadOld := g.MapInsert(d.torrentsByName, name, t).Ok
 	panicif.Eq(first, hadOld)
-	t.AddWebSeeds(d.cfg.WebSeedUrls, d.addWebSeedOpts...)
 	return
 }
 


### PR DESCRIPTION
solution for slow `[snapshots] initializing downloads       torrents=2724/7061`:
- probably there is some race between adding torrents and starting some background activities which taking mutex for long time. moving any line from `afterAdd()` to `addTorrentSpec` making  `initializing downloads` slow. 
- `ts.DisableInitialPieceCheck` - need initial check only if manual verification requested. 
- and seems this PR solving problem download-rate `1mb/s` -> ` 126MB/s` (non-header-chain). (monitoring of machine shows 1gb/s - but it's another story. rclone shows 600mb/s).

example of race: 
- if web seeds list came from trackers first - then `t.AddWebSeeds` will ignore `opts`. (no solution in this PR)
- probably there are more logical races (this is reason why this PR helps) 
