### PR TITLE
qa-tests: fix tip-tracking scheduling

### DIFF
--- a/.github/workflows/qa-clean-exit-block-downloading.yml
+++ b/.github/workflows/qa-clean-exit-block-downloading.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   clean-exit-bd-test:
-    runs-on: [self-hosted, qa, Erigon3]
+    runs-on: [self-hosted, qa, Ethereum, tip-tracking]
     env:
       ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version/datadir
       ERIGON_TESTBED_AREA: /opt/erigon-testbed

--- a/.github/workflows/qa-constrained-tip-tracking.yml
+++ b/.github/workflows/qa-constrained-tip-tracking.yml
@@ -20,7 +20,7 @@ jobs:
             backend: Polygon
             cgroup_name: constrained_res_64G
             prune_mode: full_node
-    runs-on: [ self-hosted, qa, "${{ matrix.backend }}" ]
+    runs-on: [ self-hosted, qa, "${{ matrix.backend }}", tip-tracking ]
     env:
       ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version/datadir
       ERIGON_TESTBED_AREA: /opt/erigon-testbed

--- a/.github/workflows/qa-tip-tracking-gnosis.yml
+++ b/.github/workflows/qa-tip-tracking-gnosis.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   gnosis-tip-tracking-test:
-    runs-on: [self-hosted, qa, Gnosis]
+    runs-on: [self-hosted, qa, Gnosis, tip-tracking]
     timeout-minutes: 600
     env:
       ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/gnosis-reference-version/datadir

--- a/.github/workflows/qa-tip-tracking-polygon.yml
+++ b/.github/workflows/qa-tip-tracking-polygon.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   bor-mainnet-tip-tracking-test:
-    runs-on: [self-hosted, qa, Polygon]
+    runs-on: [self-hosted, qa, Polygon, tip-tracking]
     timeout-minutes: 800
     env:
       ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version/datadir

--- a/.github/workflows/qa-tip-tracking.yml
+++ b/.github/workflows/qa-tip-tracking.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   mainnet-tip-tracking-test:
-    runs-on: [self-hosted, qa, Erigon3]
+    runs-on: [self-hosted, qa, Ethereum, tip-tracking]
     timeout-minutes: 600
     env:
       ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version/datadir


### PR DESCRIPTION
The new test scheduling policy, which is made up of a combination of two labels ('chain' and 'test-type'), failed to address the tip-tracking tests.
This PR fixes this issue.