### PR TITLE
[r31] qa-tests: add migration procedure to the tip-tracking test

### DIFF
--- a/.github/workflows/qa-clean-exit-block-downloading.yml
+++ b/.github/workflows/qa-clean-exit-block-downloading.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   clean-exit-bd-test:
-    runs-on: [self-hosted, qa, Erigon3]
+    runs-on: [self-hosted, qa, Ethereum, tip-tracking]
     env:
       ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version/datadir
       ERIGON_TESTBED_AREA: /opt/erigon-testbed

--- a/.github/workflows/qa-constrained-tip-tracking.yml
+++ b/.github/workflows/qa-constrained-tip-tracking.yml
@@ -20,7 +20,7 @@ jobs:
             backend: Polygon
             cgroup_name: constrained_res_64G
             prune_mode: full_node
-    runs-on: [ self-hosted, qa, "${{ matrix.backend }}" ]
+    runs-on: [ self-hosted, qa, "${{ matrix.backend }}", tip-tracking ]
     env:
       ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version/datadir
       ERIGON_TESTBED_AREA: /opt/erigon-testbed

--- a/.github/workflows/qa-tip-tracking-gnosis.yml
+++ b/.github/workflows/qa-tip-tracking-gnosis.yml
@@ -3,9 +3,7 @@ name: QA - Tip tracking (Gnosis)
 on:
   push:
     branches:
-      - 'release/3.*'
-  schedule:
-    - cron: '0 0 * * 1-6'  # Run every night at 00:00 AM UTC except Sunday
+      - 'release/3.1'
   workflow_dispatch:     # Run manually
 
 concurrency:
@@ -17,8 +15,8 @@ jobs:
     runs-on: [self-hosted, qa, Gnosis, tip-tracking]
     timeout-minutes: 600
     env:
-      ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/gnosis-reference-version/datadir
-      ERIGON_TESTBED_AREA: /opt/erigon-testbed
+      ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/gnosis-reference-version-3.0/datadir
+      ERIGON_TESTBED_DATA_DIR: /opt/erigon-testbed/datadir
       ERIGON_QA_PATH: /home/qarunner/erigon-qa
       TRACKING_TIME_SECONDS: 14400 # 4 hours
       TOTAL_TIME_SECONDS: 28800 # 8 hours
@@ -41,10 +39,15 @@ jobs:
       run: |
         python3 $ERIGON_QA_PATH/test_system/db-producer/pause_production.py || true
 
-    - name: Save Erigon Chaindata Directory
+    - name: Restore Erigon Testbed Data Directory
       id: save_chaindata_step
       run: |
-        mv $ERIGON_REFERENCE_DATA_DIR/chaindata $ERIGON_TESTBED_AREA/chaindata-prev
+        rsync -a --delete $ERIGON_REFERENCE_DATA_DIR/ $ERIGON_TESTBED_DATA_DIR/
+
+    - name: Run the datadir upgrade procedure
+      working-directory: ${{ github.workspace }}
+      run: |
+        ./build/bin/erigon seg reset --datadir $ERIGON_TESTBED_DATA_DIR --chain $CHAIN
 
     - name: Run Erigon, wait sync and check ability to maintain sync
       id: test_step
@@ -55,7 +58,7 @@ jobs:
         # 2. Allow time for the Erigon to achieve synchronization
         # 3. Begin timing the duration that Erigon maintains synchronization
         python3 $ERIGON_QA_PATH/test_system/qa-tests/tip-tracking/run_and_check_tip_tracking.py \
-          ${{ github.workspace }}/build/bin $ERIGON_REFERENCE_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN
+          ${{ github.workspace }}/build/bin $ERIGON_TESTBED_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN
   
         # Capture monitoring script exit status
         test_exit_status=$?
@@ -119,7 +122,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: erigon-log
-        path: ${{ env.ERIGON_REFERENCE_DATA_DIR }}/logs/erigon.log
+        path: ${{ env.ERIGON_TESTBED_DATA_DIR }}/logs/erigon.log
 
     - name: Upload metric plots
       if: steps.test_step.outputs.test_executed == 'true'
@@ -128,12 +131,11 @@ jobs:
         name: metric-plots
         path: ${{ github.workspace }}/metrics-${{ env.CHAIN }}-plots*
 
-    - name: Restore Erigon Chaindata Directory
+    - name: Delete Erigon Testbed Data Directory
       if: ${{ always() }}
       run: |
-        if [ -d "$ERIGON_TESTBED_AREA/chaindata-prev" ]; then
-          rm -rf $ERIGON_REFERENCE_DATA_DIR/chaindata
-          mv $ERIGON_TESTBED_AREA/chaindata-prev $ERIGON_REFERENCE_DATA_DIR/chaindata
+        if [ -d "$ERIGON_TESTBED_DATA_DIR" ]; then
+          rm -rf $ERIGON_TESTBED_DATA_DIR
         fi
 
     - name: Resume the Erigon instance dedicated to db maintenance

--- a/.github/workflows/qa-tip-tracking-gnosis.yml
+++ b/.github/workflows/qa-tip-tracking-gnosis.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   gnosis-tip-tracking-test:
-    runs-on: [self-hosted, qa, Gnosis]
+    runs-on: [self-hosted, qa, Gnosis, tip-tracking]
     timeout-minutes: 600
     env:
       ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/gnosis-reference-version/datadir

--- a/.github/workflows/qa-tip-tracking-polygon.yml
+++ b/.github/workflows/qa-tip-tracking-polygon.yml
@@ -3,10 +3,8 @@ name: QA - Tip tracking (Polygon)
 on:
   push:
     branches:
-      - 'release/3.*'
-  schedule:
-    - cron: '0 0 * * 1-6'  # Run every night at 00:00 AM UTC except Sunday
-  workflow_dispatch:      # Run manually
+      - 'release/3.1'
+  workflow_dispatch:     # Run manually
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -17,8 +15,8 @@ jobs:
     runs-on: [self-hosted, qa, Polygon, tip-tracking]
     timeout-minutes: 800
     env:
-      ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version/datadir
-      ERIGON_TESTBED_AREA: /opt/erigon-testbed
+      ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version-3.0/datadir
+      ERIGON_TESTBED_DATA_DIR: /opt/erigon-testbed/datadir
       ERIGON_QA_PATH: /home/qarunner/erigon-qa
       TRACKING_TIME_SECONDS: 21600 # 6 hours
       TOTAL_TIME_SECONDS: 43200 # 12 hours
@@ -41,10 +39,15 @@ jobs:
       run: |
         python3 $ERIGON_QA_PATH/test_system/db-producer/pause_production.py || true
 
-    - name: Save Erigon Chaindata Directory
+    - name: Restore Erigon Testbed Data Directory
       id: save_chaindata_step
       run: |
-        mv $ERIGON_REFERENCE_DATA_DIR/chaindata $ERIGON_TESTBED_AREA/chaindata-prev
+        rsync -a --delete $ERIGON_REFERENCE_DATA_DIR/ $ERIGON_TESTBED_DATA_DIR/
+
+    - name: Run the datadir upgrade procedure
+      working-directory: ${{ github.workspace }}
+      run: |
+        ./build/bin/erigon seg reset --datadir $ERIGON_TESTBED_DATA_DIR --chain $CHAIN
 
     - name: Run Erigon, wait sync and check ability to maintain sync
       id: test_step
@@ -55,7 +58,7 @@ jobs:
         # 2. Allow time for the Erigon to achieve synchronization
         # 3. Begin timing the duration that Erigon maintains synchronization
         python3 $ERIGON_QA_PATH/test_system/qa-tests/tip-tracking/run_and_check_tip_tracking.py \
-          ${{ github.workspace }}/build/bin $ERIGON_REFERENCE_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN
+          ${{ github.workspace }}/build/bin $ERIGON_TESTBED_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN
   
         # Capture monitoring script exit status
         test_exit_status=$?
@@ -119,7 +122,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: erigon-log
-        path: ${{ env.ERIGON_REFERENCE_DATA_DIR }}/logs/erigon.log
+        path: ${{ env.ERIGON_TESTBED_DATA_DIR }}/logs/erigon.log
 
     - name: Upload metric plots
       if: steps.test_step.outputs.test_executed == 'true'
@@ -128,12 +131,11 @@ jobs:
         name: metric-plots
         path: ${{ github.workspace }}/metrics-${{ env.CHAIN }}-plots*
 
-    - name: Restore Erigon Chaindata Directory
+    - name: Delete Erigon Testbed Data Directory
       if: ${{ always() }}
       run: |
-        if [ -d "$ERIGON_TESTBED_AREA/chaindata-prev" ]; then
-          rm -rf $ERIGON_REFERENCE_DATA_DIR/chaindata
-          mv $ERIGON_TESTBED_AREA/chaindata-prev $ERIGON_REFERENCE_DATA_DIR/chaindata
+        if [ -d "$ERIGON_TESTBED_DATA_DIR" ]; then
+          rm -rf $ERIGON_TESTBED_DATA_DIR
         fi
 
     - name: Resume the Erigon instance dedicated to db maintenance

--- a/.github/workflows/qa-tip-tracking-polygon.yml
+++ b/.github/workflows/qa-tip-tracking-polygon.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   bor-mainnet-tip-tracking-test:
-    runs-on: [self-hosted, qa, Polygon]
+    runs-on: [self-hosted, qa, Polygon, tip-tracking]
     timeout-minutes: 800
     env:
       ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version/datadir

--- a/.github/workflows/qa-tip-tracking.yml
+++ b/.github/workflows/qa-tip-tracking.yml
@@ -1,11 +1,9 @@
-name: QA - Tip tracking
+name: QA - Tip tracking & migration
 
 on:
   push:
     branches:
-      - 'release/3.*'
-  schedule:
-    - cron: '0 20 * * 1-6'  # Run every night at 08:00 PM UTC except Sunday
+      - 'release/3.1'
   workflow_dispatch:     # Run manually
 
 concurrency:
@@ -17,8 +15,8 @@ jobs:
     runs-on: [self-hosted, qa, Ethereum, tip-tracking]
     timeout-minutes: 600
     env:
-      ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version/datadir
-      ERIGON_TESTBED_AREA: /opt/erigon-testbed
+      ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version-3.0/datadir
+      ERIGON_TESTBED_DATA_DIR: /opt/erigon-testbed/datadir
       ERIGON_QA_PATH: /home/qarunner/erigon-qa
       TRACKING_TIME_SECONDS: 14400 # 4 hours
       TOTAL_TIME_SECONDS: 28800 # 8 hours
@@ -41,10 +39,15 @@ jobs:
       run: |
         python3 $ERIGON_QA_PATH/test_system/db-producer/pause_production.py || true
 
-    - name: Save Erigon Chaindata Directory
+    - name: Restore Erigon Testbed Data Directory
       id: save_chaindata_step
       run: |
-        mv $ERIGON_REFERENCE_DATA_DIR/chaindata $ERIGON_TESTBED_AREA/chaindata-prev
+        rsync -a --delete $ERIGON_REFERENCE_DATA_DIR/ $ERIGON_TESTBED_DATA_DIR/
+
+    - name: Run the datadir upgrade procedure
+      working-directory: ${{ github.workspace }}
+      run: |
+        ./build/bin/erigon seg reset --datadir $ERIGON_TESTBED_DATA_DIR --chain $CHAIN
 
     - name: Run Erigon, wait sync and check ability to maintain sync
       id: test_step
@@ -55,7 +58,7 @@ jobs:
         # 2. Allow time for the Erigon to achieve synchronization
         # 3. Begin timing the duration that Erigon maintains synchronization
         python3 $ERIGON_QA_PATH/test_system/qa-tests/tip-tracking/run_and_check_tip_tracking.py \
-          ${{ github.workspace }}/build/bin $ERIGON_REFERENCE_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN
+          ${{ github.workspace }}/build/bin $ERIGON_TESTBED_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN
   
         # Capture monitoring script exit status
         test_exit_status=$?
@@ -118,7 +121,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: erigon-log
-        path: ${{ env.ERIGON_REFERENCE_DATA_DIR }}/logs/erigon.log
+        path: ${{ env.ERIGON_TESTBED_DATA_DIR }}/logs/erigon.log
 
     - name: Upload metric plots
       if: steps.test_step.outputs.test_executed == 'true'
@@ -127,12 +130,11 @@ jobs:
         name: metric-plots
         path: ${{ github.workspace }}/metrics-${{ env.CHAIN }}-plots*
 
-    - name: Restore Erigon Chaindata Directory
+    - name: Delete Erigon Testbed Data Directory
       if: ${{ always() }}
       run: |
-        if [ -d "$ERIGON_TESTBED_AREA/chaindata-prev" ]; then
-          rm -rf $ERIGON_REFERENCE_DATA_DIR/chaindata
-          mv $ERIGON_TESTBED_AREA/chaindata-prev $ERIGON_REFERENCE_DATA_DIR/chaindata
+        if [ -d "$ERIGON_TESTBED_DATA_DIR" ]; then
+          rm -rf $ERIGON_TESTBED_DATA_DIR
         fi
 
     - name: Resume the Erigon instance dedicated to db maintenance

--- a/.github/workflows/qa-tip-tracking.yml
+++ b/.github/workflows/qa-tip-tracking.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   mainnet-tip-tracking-test:
-    runs-on: [self-hosted, qa, Erigon3]
+    runs-on: [self-hosted, qa, Ethereum, tip-tracking]
     timeout-minutes: 600
     env:
       ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version/datadir


### PR DESCRIPTION
This PR address 2 tip-tracking issues:

1) The new test scheduling policy, which is made up of a combination of two labels ('chain' and 'test-type'), failed to address the tip-tracking tests. This PR fixes this issue.

2) The tip-tracking test has been superseded by the sync-from-scratch test that is a sync from scratch plus a tip tracking, running erigon for 2 hours on the tip.
The tip-tracking test requires a pre-built database, and it is difficult to ensure the correct database while there are many backward incompatible changes on the main and release branches (MDBx versions, new tables, different snapshot formats, etc.).
We will therefore transform the tip-tracking test into a "migrate + tip-tracking" to test the migration procedure from Release 3.0 to Release 3.1.
This PR add the migration procedure to the tip-tracking test.