### PR TITLE
qa-tests: de-schedule tip-tracking

### DIFF
--- a/.github/workflows/qa-tip-tracking-gnosis.yml
+++ b/.github/workflows/qa-tip-tracking-gnosis.yml
@@ -3,9 +3,7 @@ name: QA - Tip tracking (Gnosis)
 on:
   push:
     branches:
-      - 'release/3.*'
-  schedule:
-    - cron: '0 0 * * 1-6'  # Run every night at 00:00 AM UTC except Sunday
+      - 'release/3.1'
   workflow_dispatch:     # Run manually
 
 concurrency:

--- a/.github/workflows/qa-tip-tracking-polygon.yml
+++ b/.github/workflows/qa-tip-tracking-polygon.yml
@@ -3,9 +3,7 @@ name: QA - Tip tracking (Polygon)
 on:
   push:
     branches:
-      - 'release/3.*'
-  schedule:
-    - cron: '0 0 * * 1-6'  # Run every night at 00:00 AM UTC except Sunday
+      - 'release/3.1'
   workflow_dispatch:      # Run manually
 
 concurrency:

--- a/.github/workflows/qa-tip-tracking.yml
+++ b/.github/workflows/qa-tip-tracking.yml
@@ -3,9 +3,7 @@ name: QA - Tip tracking
 on:
   push:
     branches:
-      - 'release/3.*'
-  schedule:
-    - cron: '0 20 * * 1-6'  # Run every night at 08:00 PM UTC except Sunday
+      - 'release/3.1'
   workflow_dispatch:     # Run manually
 
 concurrency:


### PR DESCRIPTION
The tip-tracking test has been superseded by the sync-from-scratch test that is a sync from scratch plus a tip tracking, running erigon for 2 hours on the tip. 
The tip-tracking test requires a pre-built database, and it is difficult to ensure the correct database while there are many backward incompatible changes on the main and release branches (MDBx versions, new tables, different snapshot formats, etc.).
We will therefore transform the tip-tracking test into a "migrate + tip-tracking" to test the migration procedure from Release 3.0 to Release 3.1.
This PR remove the test scheduling from the main branch.