### PR TITLE
Fix eth_getProof on hisotry values

### DIFF
--- a/erigon-lib/state/commitment_context.go
+++ b/erigon-lib/state/commitment_context.go
@@ -393,7 +393,7 @@ type TrieContext struct {
 
 	limitReadAsOfTxNum uint64
 	stepSize           uint64
-	domainsOnly        bool // if true, do not use history reader and limit to domain files only
+	withHistory        bool // if true, do not use history reader and limit to domain files only
 	trace              bool
 }
 
@@ -404,15 +404,20 @@ func (sdc *TrieContext) Branch(pref []byte) ([]byte, uint64, error) {
 	//}
 	// Trie reads prefix during unfold and after everything is ready reads it again to Merge update.
 	// Keep dereferenced version inside sd commitmentDomain map ready to read again
-	if !sdc.domainsOnly && sdc.limitReadAsOfTxNum > 0 {
-		branch, _, err := sdc.roTtx.GetAsOf(kv.CommitmentDomain, pref, sdc.limitReadAsOfTxNum)
-		if sdc.trace {
-			fmt.Printf("[SDC] Branch @%d: %x: %x\n%s\n", sdc.limitReadAsOfTxNum, pref, branch, commitment.BranchData(branch).String())
-		}
+	if sdc.withHistory && sdc.limitReadAsOfTxNum > 0 {
+		v, hOk, err := sdc.roTtx.HistorySeek(kv.CommitmentDomain, pref, sdc.limitReadAsOfTxNum)
 		if err != nil {
-			return nil, 0, fmt.Errorf("branch history read failed: %w", err)
+			return nil, 0, fmt.Errorf("branch failed: %w", err)
 		}
-		return branch, sdc.limitReadAsOfTxNum / sdc.stepSize, nil
+		if hOk {
+			if len(v) == 0 { // if history successfuly found marker of key creation
+				return nil, 0, nil
+			}
+			if sdc.trace {
+				fmt.Printf("[SDC] Branch @%d: %x: %x\n%s\n", sdc.limitReadAsOfTxNum, pref, v, commitment.BranchData(v).String())
+			}
+			return v, 0, nil
+		}
 	}
 
 	// Trie reads prefix during unfold and after everything is ready reads it again to Merge update.
@@ -431,7 +436,7 @@ func (sdc *TrieContext) Branch(pref []byte) ([]byte, uint64, error) {
 }
 
 func (sdc *TrieContext) PutBranch(prefix []byte, data []byte, prevData []byte, prevStep uint64) error {
-	if sdc.limitReadAsOfTxNum > 0 && !sdc.domainsOnly { // do not store branches if explicitly operate on history
+	if sdc.limitReadAsOfTxNum > 0 && sdc.withHistory { // do not store branches if explicitly operate on history
 		return nil
 	}
 	if sdc.trace {
@@ -452,7 +457,7 @@ func (sdc *TrieContext) readDomain(d kv.Domain, plainKey []byte) (enc []byte, er
 	//}
 
 	if sdc.limitReadAsOfTxNum > 0 {
-		if sdc.domainsOnly {
+		if sdc.withHistory {
 			var ok bool
 			enc, ok, _, _, err = sdc.roTtx.Debug().GetLatestFromFiles(d, plainKey, sdc.limitReadAsOfTxNum)
 			if !ok {
@@ -537,5 +542,5 @@ func (sdc *TrieContext) Storage(plainKey []byte) (u *commitment.Update, err erro
 // If domainOnly=true and txNum > 0, then read operations will be limited to domain files only.
 func (sdc *TrieContext) SetLimitReadAsOfTxNum(txNum uint64, domainOnly bool) {
 	sdc.limitReadAsOfTxNum = txNum
-	sdc.domainsOnly = domainOnly
+	sdc.withHistory = !domainOnly
 }

--- a/erigon-lib/state/commitment_context.go
+++ b/erigon-lib/state/commitment_context.go
@@ -418,6 +418,7 @@ func (sdc *TrieContext) Branch(pref []byte) ([]byte, uint64, error) {
 			}
 			return v, 0, nil
 		}
+		return nil, 0, nil // no history found, so no branch
 	}
 
 	// Trie reads prefix during unfold and after everything is ready reads it again to Merge update.


### PR DESCRIPTION
allows to correctly dereference values during read from commitment history while building proof trie