### PR TITLE
Added validation of ordering and consistency for state sync events inside the scraper

### DIFF
--- a/polygon/bridge/service.go
+++ b/polygon/bridge/service.go
@@ -208,6 +208,32 @@ func (s *Service) Run(ctx context.Context) error {
 			continue
 		}
 
+		orderedAndNoGaps := true
+		knownEventID := lastProcessedEventId
+
+		for i := 0; i < len(events); i++ {
+			if events[i].ID == knownEventID+1 {
+				knownEventID = events[i].ID
+				continue
+			}
+
+			orderedAndNoGaps = false
+		}
+
+		if !orderedAndNoGaps {
+			s.logger.Warn(
+				bridgeLogPrefix("fetched new events are not ordered or contain gaps"),
+				"count", len(events),
+				"lastKnownEventId", lastFetchedEventId,
+			)
+
+			if err := libcommon.Sleep(ctx, time.Second); err != nil {
+				return err
+			}
+
+			continue
+		}
+
 		// we've received new events
 		s.reachedTip.Store(false)
 		if err := s.store.PutEvents(ctx, events); err != nil {


### PR DESCRIPTION
Cherry pick of this commit: https://github.com/erigontech/erigon/pull/16226