### PR TITLE
[r31] qa-tests: tip-tracking with seg update

### DIFF
--- a/.github/workflows/qa-tip-tracking-gnosis.yml
+++ b/.github/workflows/qa-tip-tracking-gnosis.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Run the datadir upgrade procedure
       working-directory: ${{ github.workspace }}
       run: |
-        ./build/bin/erigon seg reset --datadir $ERIGON_TESTBED_DATA_DIR --chain $CHAIN
+        ./build/bin/erigon seg update-to-new-ver-format --datadir $ERIGON_TESTBED_DATA_DIR --chain $CHAIN
 
     - name: Run Erigon, wait sync and check ability to maintain sync
       id: test_step

--- a/.github/workflows/qa-tip-tracking-polygon.yml
+++ b/.github/workflows/qa-tip-tracking-polygon.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Run the datadir upgrade procedure
       working-directory: ${{ github.workspace }}
       run: |
-        ./build/bin/erigon seg reset --datadir $ERIGON_TESTBED_DATA_DIR --chain $CHAIN
+        ./build/bin/erigon seg update-to-new-ver-format --datadir $ERIGON_TESTBED_DATA_DIR --chain $CHAIN
 
     - name: Run Erigon, wait sync and check ability to maintain sync
       id: test_step

--- a/.github/workflows/qa-tip-tracking.yml
+++ b/.github/workflows/qa-tip-tracking.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Run the datadir upgrade procedure
       working-directory: ${{ github.workspace }}
       run: |
-        ./build/bin/erigon seg reset --datadir $ERIGON_TESTBED_DATA_DIR --chain $CHAIN
+        ./build/bin/erigon seg update-to-new-ver-format --datadir $ERIGON_TESTBED_DATA_DIR --chain $CHAIN
 
     - name: Run Erigon, wait sync and check ability to maintain sync
       id: test_step


### PR DESCRIPTION
The tip-tracking test currently use a `seg reset` command before running. 
This PR change "seg reset" with the more conservative `seg update-to-new-ver-format` which is the method we expect to work for almost all customers and which is preferable because it is less expensive.