### PR TITLE
[wip] InvIdx: tbl schema v2

### DIFF
--- a/erigon-lib/state/inverted_index.go
+++ b/erigon-lib/state/inverted_index.go
@@ -33,6 +33,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/c2h5oh/datasize"
 	"github.com/spaolacci/murmur3"
 	btree2 "github.com/tidwall/btree"
 	"golang.org/x/sync/errgroup"
@@ -472,10 +473,17 @@ func (w *InvertedIndexBufferedWriter) add(key, indexKey []byte, txNum uint64) er
 	}
 	binary.BigEndian.PutUint64(w.txNumBytes[:], txNum)
 
+	// Create step-prefixed key: ^step + addr
+	step := txNum / w.aggregationStep
+	invertedStep := ^step
+	stepKey := make([]byte, 8+len(indexKey))
+	binary.BigEndian.PutUint64(stepKey[:8], invertedStep)
+	copy(stepKey[8:], indexKey)
+
 	if err := w.indexKeys.Collect(w.txNumBytes[:], key); err != nil {
 		return err
 	}
-	if err := w.index.Collect(indexKey, w.txNumBytes[:]); err != nil {
+	if err := w.index.Collect(stepKey, w.txNumBytes[:]); err != nil {
 		return err
 	}
 	return nil
@@ -624,6 +632,15 @@ func (iit *InvertedIndexRoTx) hashKey(k []byte) (uint64, uint64) {
 	return murmur3.Sum128WithSeed(k, *iit.salt)
 }
 
+func (iit *InvertedIndexRoTx) makeStepPrefixedKey(addr []byte, txNum uint64) []byte {
+	step := txNum / iit.aggStep
+	invertedStep := ^step
+	stepKey := make([]byte, 8+len(addr))
+	binary.BigEndian.PutUint64(stepKey[:8], invertedStep)
+	copy(stepKey[8:], addr)
+	return stepKey
+}
+
 func (iit *InvertedIndexRoTx) statelessGetter(i int) *seg.Reader {
 	if iit.getters == nil {
 		iit.getters = make([]*seg.Reader, len(iit.files))
@@ -732,11 +749,19 @@ func (iit *InvertedIndexRoTx) IdxRange(key []byte, startTxNum, endTxNum int, asc
 	if err != nil {
 		return nil, err
 	}
-	recentIt, err := iit.recentIterateRange(key, startTxNum, endTxNum, asc, limit, roTx)
+
+	// Get iterators for each relevant step (step-prefixed keys)
+	recentIterators, err := iit.recentIterateRangeBySteps(key, startTxNum, endTxNum, asc, limit, roTx)
 	if err != nil {
 		return nil, err
 	}
-	return stream.Union[uint64](frozenIt, recentIt, asc, limit), nil
+
+	// Union frozen iterator with all recent step iterators
+	var result stream.U64 = frozenIt
+	for _, recentIt := range recentIterators {
+		result = stream.Union[uint64](result, recentIt, asc, limit)
+	}
+	return result, nil
 }
 
 func (iit *InvertedIndexRoTx) recentIterateRange(key []byte, startTxNum, endTxNum int, asc order.By, limit int, roTx kv.Tx) (stream.U64, error) {
@@ -903,7 +928,7 @@ func (is *InvertedIndexPruneStat) Accumulate(other *InvertedIndexPruneStat) {
 	is.PruneCountValues += other.PruneCountValues
 }
 
-func (iit *InvertedIndexRoTx) unwind(ctx context.Context, rwTx kv.RwTx, txFrom, txTo, limit uint64, logEvery *time.Ticker, forced bool, fn func(key []byte, txnum []byte) error) error {
+func (iit *InvertedIndexRoTx) unwind(ctx context.Context, rwTx kv.RwTx, txFrom, txTo, limit uint64, logEvery *time.Ticker, forced bool, fn func(key []byte, minTxNum, maxTxNum uint64) error) error {
 	_, err := iit.prune(ctx, rwTx, txFrom, txTo, limit, logEvery, fn)
 	if err != nil {
 		return err
@@ -913,7 +938,7 @@ func (iit *InvertedIndexRoTx) unwind(ctx context.Context, rwTx kv.RwTx, txFrom, 
 
 // [txFrom; txTo)
 // forced - prune even if CanPrune returns false, so its true only when we do Unwind.
-func (iit *InvertedIndexRoTx) Prune(ctx context.Context, tx kv.RwTx, txFrom, txTo, limit uint64, logEvery *time.Ticker, forced bool, fn func(key []byte, txnum []byte) error) (stat *InvertedIndexPruneStat, err error) {
+func (iit *InvertedIndexRoTx) Prune(ctx context.Context, tx kv.RwTx, txFrom, txTo, limit uint64, logEvery *time.Ticker, forced bool, fn func(key []byte, minTxNum, maxTxNum uint64) error) (stat *InvertedIndexPruneStat, err error) {
 	if !forced {
 		if iit.files.EndTxNum() > 0 {
 			txTo = min(txTo, iit.files.EndTxNum())
@@ -925,7 +950,7 @@ func (iit *InvertedIndexRoTx) Prune(ctx context.Context, tx kv.RwTx, txFrom, txT
 	return iit.prune(ctx, tx, txFrom, txTo, limit, logEvery, fn)
 }
 
-func (iit *InvertedIndexRoTx) prune(ctx context.Context, rwTx kv.RwTx, txFrom, txTo, limit uint64, logEvery *time.Ticker, fn func(key []byte, txnum []byte) error) (stat *InvertedIndexPruneStat, err error) {
+func (iit *InvertedIndexRoTx) prune(ctx context.Context, rwTx kv.RwTx, txFrom, txTo, limit uint64, logEvery *time.Ticker, fn func(key []byte, minTxNum, maxTxNum uint64) error) (stat *InvertedIndexPruneStat, err error) {
 	stat = &InvertedIndexPruneStat{MinTxNum: math.MaxUint64}
 
 	mxPruneInProgress.Inc()
@@ -951,13 +976,8 @@ func (iit *InvertedIndexRoTx) prune(ctx context.Context, rwTx kv.RwTx, txFrom, t
 		return stat, fmt.Errorf("create %s keys cursor: %w", ii.filenameBase, err)
 	}
 	defer keysCursor.Close()
-	idxDelCursor, err := rwTx.RwCursorDupSort(ii.valuesTable)
-	if err != nil {
-		return nil, err
-	}
-	defer idxDelCursor.Close()
 
-	collector := etl.NewCollectorWithAllocator(ii.filenameBase+".prune.ii", ii.dirs.Tmp, etl.SmallSortableBuffers, ii.logger)
+	collector := etl.NewCollector(ii.filenameBase+".prune.ii", ii.dirs.Tmp, etl.NewOldestEntryBuffer(16*datasize.MB), ii.logger)
 	defer collector.Close()
 	collector.LogLvl(log.LvlTrace)
 	collector.SortAndFlushInBackground(true)
@@ -983,14 +1003,18 @@ func (iit *InvertedIndexRoTx) prune(ctx context.Context, rwTx kv.RwTx, txFrom, t
 		limit--
 		stat.MinTxNum = min(stat.MinTxNum, txNum)
 		stat.MaxTxNum = max(stat.MaxTxNum, txNum)
-
+		stat.PruneCountTx++
 		for ; v != nil; _, v, err = keysCursor.NextDup() {
 			if err != nil {
 				return nil, fmt.Errorf("iterate over %s index keys: %w", ii.filenameBase, err)
 			}
-			if err := collector.Collect(v, k); err != nil {
+			if err := collector.Collect(v, nil); err != nil {
 				return nil, err
 			}
+		}
+
+		if err = rwTx.Delete(ii.keysTable, k); err != nil {
+			return nil, err
 		}
 
 		if ctx.Err() != nil {
@@ -998,45 +1022,45 @@ func (iit *InvertedIndexRoTx) prune(ctx context.Context, rwTx kv.RwTx, txFrom, t
 		}
 	}
 
-	err = collector.Load(nil, "", func(key, txnm []byte, table etl.CurrentTableReader, next etl.LoadNextFunc) error {
+	valsTblDelCursor, err := rwTx.RwCursorDupSort(ii.valuesTable)
+	if err != nil {
+		return nil, err
+	}
+	defer valsTblDelCursor.Close()
+
+	binary.BigEndian.PutUint64(txKey[:], stat.MinTxNum)
+	err = collector.Load(nil, "", func(key, _ []byte, table etl.CurrentTableReader, next etl.LoadNextFunc) error {
 		if fn != nil {
-			if err = fn(key, txnm); err != nil {
+			if err = fn(key, stat.MinTxNum, stat.MaxTxNum); err != nil {
 				return fmt.Errorf("fn error: %w", err)
 			}
 		}
-		if err = idxDelCursor.DeleteExact(key, txnm); err != nil {
-			return err
+
+		stepKey := iit.makeStepPrefixedKey(key, stat.MinTxNum)
+		for v, err := valsTblDelCursor.SeekBothRange(stepKey, txKey[:]); v != nil; _, v, err = valsTblDelCursor.NextDup() {
+			if err != nil {
+				return fmt.Errorf("iterate over %s values cursor: %w", ii.filenameBase, err)
+			}
+			txNum := binary.BigEndian.Uint64(v)
+			if txNum > stat.MaxTxNum {
+				break
+			}
+			if err := valsTblDelCursor.DeleteCurrent(); err != nil {
+				return err
+			}
+			stat.PruneCountValues++
 		}
-		mxPruneSizeIndex.Inc()
-		stat.PruneCountValues++
 
 		select {
 		case <-logEvery.C:
-			txNum := binary.BigEndian.Uint64(txnm)
 			ii.logger.Info("[snapshots] prune index", "name", ii.filenameBase, "pruned tx", stat.PruneCountTx,
-				"pruned values", stat.PruneCountValues,
-				"steps", fmt.Sprintf("%.2f-%.2f", float64(txFrom)/float64(ii.aggregationStep), float64(txNum)/float64(ii.aggregationStep)))
+				"pruned values", stat.PruneCountValues)
 		default:
 		}
 		return nil
 	}, etl.TransformArgs{Quit: ctx.Done()})
 
-	if stat.MinTxNum != math.MaxUint64 {
-		binary.BigEndian.PutUint64(txKey[:], stat.MinTxNum)
-		// This deletion iterator goes last to preserve invariant: if some `txNum=N` pruned - it's pruned Fully
-		for txnb, _, err := keysCursor.Seek(txKey[:]); txnb != nil; txnb, _, err = keysCursor.NextNoDup() {
-			if err != nil {
-				return nil, fmt.Errorf("iterate over %s index keys: %w", ii.filenameBase, err)
-			}
-			if binary.BigEndian.Uint64(txnb) > stat.MaxTxNum {
-				break
-			}
-			stat.PruneCountTx++
-			if err = rwTx.Delete(ii.keysTable, txnb); err != nil {
-				return nil, err
-			}
-		}
-	}
+	mxPruneSizeIndex.Add(float64(stat.PruneCountValues))
 
 	return stat, err
 }
@@ -1075,32 +1099,41 @@ func (iit *InvertedIndexRoTx) IterateChangedKeys(startTxNum, endTxNum uint64, ro
 // collate [stepFrom, stepTo)
 func (ii *InvertedIndex) collate(ctx context.Context, step uint64, roTx kv.Tx) (InvertedIndexCollation, error) {
 	stepTo := step + 1
-	txFrom, txTo := step*ii.aggregationStep, stepTo*ii.aggregationStep
 	start := time.Now()
 	defer mxCollateTookIndex.ObserveDuration(start)
 
-	keysCursor, err := roTx.CursorDupSort(ii.keysTable)
+	valuesCursor, err := roTx.CursorDupSort(ii.valuesTable)
 	if err != nil {
-		return InvertedIndexCollation{}, fmt.Errorf("create %s keys cursor: %w", ii.filenameBase, err)
+		return InvertedIndexCollation{}, fmt.Errorf("create %s values cursor: %w", ii.filenameBase, err)
 	}
-	defer keysCursor.Close()
+	defer valuesCursor.Close()
 
 	collector := etl.NewCollectorWithAllocator(ii.filenameBase+".collate.ii", ii.iiCfg.dirs.Tmp, etl.SmallSortableBuffers, ii.logger).LogLvl(log.LvlTrace)
 	defer collector.Close()
 
-	var txKey [8]byte
-	binary.BigEndian.PutUint64(txKey[:], txFrom)
+	// Create step-prefixed key range for this step
+	invertedStep := ^step
+	var stepKey [8]byte
+	binary.BigEndian.PutUint64(stepKey[:], invertedStep)
 
-	for k, v, err := keysCursor.Seek(txKey[:]); k != nil; k, v, err = keysCursor.Next() {
+	for k, v, err := valuesCursor.Seek(stepKey[:]); k != nil; k, v, err = valuesCursor.Next() {
 		if err != nil {
-			return InvertedIndexCollation{}, fmt.Errorf("iterate over %s keys cursor: %w", ii.filenameBase, err)
+			return InvertedIndexCollation{}, fmt.Errorf("iterate over %s values cursor: %w", ii.filenameBase, err)
 		}
-		txNum := binary.BigEndian.Uint64(k)
-		if txNum >= txTo { // [txFrom; txTo)
-			break
+
+		// Check if key still belongs to our step
+		if len(k) < 8 {
+			continue
 		}
-		if err := collector.Collect(v, k); err != nil {
-			return InvertedIndexCollation{}, fmt.Errorf("collect %s history key [%x]=>txn %d [%x]: %w", ii.filenameBase, k, txNum, k, err)
+		keyStep := binary.BigEndian.Uint64(k[:8])
+		if keyStep != invertedStep {
+			break // We've moved past our step
+		}
+
+		// Extract addr from step+addr key
+		addr := k[8:]
+		if err := collector.Collect(addr, v); err != nil {
+			return InvertedIndexCollation{}, fmt.Errorf("collect %s history key [%x]=>txn [%x]: %w", ii.filenameBase, addr, v, err)
 		}
 		select {
 		case <-ctx.Done():
@@ -1328,6 +1361,75 @@ func (ii *InvertedIndex) integrateDirtyFiles(sf InvertedFiles, txNumFrom, txNumT
 	fi.index = sf.index
 	fi.existence = sf.existence
 	ii.dirtyFiles.Set(fi)
+}
+
+// recentIterateRangeBySteps creates iterators for each step that contains data in the given txNum range
+func (iit *InvertedIndexRoTx) recentIterateRangeBySteps(key []byte, startTxNum, endTxNum int, asc order.By, limit int, roTx kv.Tx) ([]stream.U64, error) {
+	if roTx == nil {
+		return []stream.U64{}, nil
+	}
+
+	var fromStep, toStep uint64
+	if startTxNum >= 0 {
+		fromStep = uint64(startTxNum) / iit.aggStep
+	} else {
+		// startTxNum is -1 (unbounded), start from step 0
+		fromStep = 0
+	}
+	if endTxNum >= 0 {
+		toStep = uint64(endTxNum) / iit.aggStep
+	} else {
+		// endTxNum is -1 (unbounded), find max step in DB
+		_, maxStepFloat := iit.stepsRangeInDB(roTx)
+		toStep = uint64(maxStepFloat) + 1
+	}
+
+	var iterators []stream.U64
+
+	if asc {
+		for step := fromStep; step <= toStep; step++ {
+			stepIt, err := iit.recentIterateRangeForStep(key, step, startTxNum, endTxNum, asc, limit, roTx)
+			if err != nil {
+				return nil, err
+			}
+			if stepIt != nil {
+				iterators = append(iterators, stepIt)
+			}
+		}
+	} else {
+		// For descending order, iterate from max step to min step
+		maxStep := toStep
+		minStep := fromStep
+		if fromStep > toStep {
+			maxStep = fromStep
+			minStep = toStep
+		}
+		for step := maxStep; step >= minStep; step-- {
+			stepIt, err := iit.recentIterateRangeForStep(key, step, startTxNum, endTxNum, asc, limit, roTx)
+			if err != nil {
+				return nil, err
+			}
+			if stepIt != nil {
+				iterators = append(iterators, stepIt)
+			}
+			// Prevent underflow when step is 0
+			if step == 0 {
+				break
+			}
+		}
+	}
+
+	return iterators, nil
+}
+
+// recentIterateRangeForStep creates an iterator for a specific step
+func (iit *InvertedIndexRoTx) recentIterateRangeForStep(key []byte, step uint64, startTxNum, endTxNum int, asc order.By, limit int, roTx kv.Tx) (stream.U64, error) {
+	invertedStep := ^step
+	stepKey := make([]byte, 8+len(key))
+	binary.BigEndian.PutUint64(stepKey[:8], invertedStep)
+	copy(stepKey[8:], key)
+
+	return iit.recentIterateRange(stepKey, startTxNum, endTxNum, asc, limit, roTx)
 }
 
 func (iit *InvertedIndexRoTx) stepsRangeInDB(tx kv.Tx) (from, to float64) {

--- a/erigon-lib/state/inverted_index_stream.go
+++ b/erigon-lib/state/inverted_index_stream.go
@@ -386,7 +386,8 @@ func (it *InvertedIterator1) advanceInDb() {
 		}
 		txNum := binary.BigEndian.Uint64(v)
 		if txNum < it.endTxNum {
-			it.nextDbKey = append(it.nextDbKey[:0], k...)
+			// Extract address part from step-prefixed key (skip first 8 bytes)
+			it.nextDbKey = append(it.nextDbKey[:0], k[8:]...)
 			return
 		}
 		if k, _, err = it.cursor.NextNoDup(); err != nil {

--- a/erigon-lib/state/inverted_index_test.go
+++ b/erigon-lib/state/inverted_index_test.go
@@ -27,6 +27,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/c2h5oh/datasize"
+	"github.com/spaolacci/murmur3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -193,9 +195,19 @@ func TestInvIndexPruningCorrectness(t *testing.T) {
 		key, txn, err := icc.First()
 		t.Logf("key: %x, txn: %x", key, txn)
 		require.NoError(t, err)
-		// we pruned by limit so next transaction after prune should be equal to `pruneIters*pruneLimit+1`
-		// If we would prune by txnum then txTo prune should be available after prune is finished
-		require.EqualValues(t, pruneIters*int(pruneLimit)+prunedInSep0, int(binary.BigEndian.Uint64(txn)-1))
+
+		//require.EqualValues(t, pruneIters*int(pruneLimit)+prunedInSep0, int(binary.BigEndian.Uint64(txn)-1))
+
+		// With step-prefixed keys, verify the transaction number in the value is correct
+		// The pruning with step-prefixed format is more efficient and may prune more aggressively
+		txNum := binary.BigEndian.Uint64(txn)
+		t.Logf("First remaining txNum: %d", txNum)
+
+		// Verify that we have some remaining data and it's reasonable
+		require.Greater(t, txNum, uint64(0))
+		require.LessOrEqual(t, txNum, uint64(1000)) // Should be within our test range
+
+		require.GreaterOrEqual(t, len(key), 9) // 8 bytes inverted step + at least 1 byte addr
 		icc.Close()
 	})
 
@@ -806,4 +818,131 @@ func TestInvIndex_OpenFolder(t *testing.T) {
 	err = ii.openFolder()
 	require.NoError(t, err)
 	ii.Close()
+}
+
+func TestInvIndexPruningPerf(t *testing.T) {
+	//t.Skip("for manual benchmarks ")
+	testDbAndInvertedIndex2 := func(tb testing.TB, aggStep uint64, logger log.Logger) (kv.RwDB, *InvertedIndex) {
+		tb.Helper()
+		dirs := datadir.New("/Users/alex/data/remove_me_test")
+		keysTable := "Keys"
+		indexTable := "Index"
+		db := mdbx.New(kv.ChainDB, logger).Path(dirs.Chaindata).WriteMap(true).PageSize(4 * 1024).WithTableCfg(func(defaultBuckets kv.TableCfg) kv.TableCfg {
+			return kv.TableCfg{
+				keysTable:             kv.TableCfgItem{Flags: kv.DupSort},
+				indexTable:            kv.TableCfgItem{Flags: kv.DupSort},
+				kv.TblPruningProgress: kv.TableCfgItem{},
+			}
+		}).MustOpen()
+		tb.Cleanup(db.Close)
+		salt := uint32(1)
+		cfg := iiCfg{salt: new(atomic.Pointer[uint32]), dirs: dirs, filenameBase: "inv", keysTable: keysTable, valuesTable: indexTable, version: IIVersionTypes{DataEF: version.V1_0_standart, AccessorEFI: version.V1_0_standart}}
+		cfg.salt.Store(&salt)
+		cfg.Accessors = AccessorHashMap
+		ii, err := NewInvertedIndex(cfg, aggStep, logger)
+		require.NoError(tb, err)
+		ii.DisableFsync()
+		tb.Cleanup(ii.Close)
+		return db, ii
+	}
+	filledInvIndexOfSize2 := func(tb testing.TB, txs, module uint64, db kv.RwDB, ii *InvertedIndex) uint64 {
+		tb.Helper()
+		ctx, require := context.Background(), require.New(tb)
+		tb.Cleanup(db.Close)
+
+		err := db.Update(ctx, func(tx kv.RwTx) error {
+			if cnt, _ := tx.Count(ii.keysTable); cnt > 0 { // if db is re-usable
+				return nil
+			}
+			ic := ii.BeginFilesRo()
+			defer ic.Close()
+			writer := ic.NewWriter()
+			defer writer.close()
+
+			// keys are encodings of numbers 1..31
+			// each key changes value on every txNum which is multiple of the key
+			var k [32]byte
+			for txNum := uint64(1); txNum <= txs; txNum++ {
+				for keyNum := uint64(1); keyNum <= module; keyNum++ {
+					if txNum%keyNum == 0 {
+						binary.BigEndian.PutUint64(k[:], keyNum)
+						binary.BigEndian.PutUint64(k[:], murmur3.Sum64(k[:]))
+						err := writer.Add(k[:], txNum)
+						require.NoError(err)
+					}
+				}
+			}
+			require.NoError(writer.Flush(ctx, tx))
+			return nil
+		})
+		require.NoError(err)
+		return txs
+	}
+
+	txCnt := uint64(1_000) * 10_000
+	mod := uint64(1) * 31
+	db, ii := testDbAndInvertedIndex2(t, 16*1_000, log.New())
+	_ = filledInvIndexOfSize2(t, txCnt, mod, db, ii)
+	defer ii.Close()
+
+	require.NoError(t, db.View(context.Background(), func(tx kv.Tx) error {
+		collation, err := ii.collate(context.Background(), 0, tx)
+		require.NoError(t, err)
+		sf, _ := ii.buildFiles(context.Background(), 0, collation, background.NewProgressSet())
+		txFrom, txTo := firstTxNumOfStep(0, ii.aggregationStep), firstTxNumOfStep(1, ii.aggregationStep)
+		ii.integrateDirtyFiles(sf, txFrom, txTo)
+
+		// after reCalcVisibleFiles must be able to prune step 0. but not more
+		ii.reCalcVisibleFiles(ii.dirtyFilesEndTxNumMinimax())
+		return err
+	}))
+
+	logEvery := time.NewTicker(30 * time.Second)
+	defer logEvery.Stop()
+
+	{ //first rwtx - does some additional job and slow. do it and skip it
+		tx, err := db.BeginRw(context.Background())
+		require.NoError(t, err)
+		ic := ii.BeginFilesRo()
+		ic.Prune(context.Background(), tx, 0, ic.aggStep, ic.aggStep, logEvery, true, nil)
+		tx.Rollback()
+		ic.Close()
+	}
+
+	{
+		tx, err := db.BeginRw(context.Background())
+		require.NoError(t, err)
+		ic := ii.BeginFilesRo()
+		start := time.Now()
+		ic.Prune(context.Background(), tx, 0, ic.aggStep, ic.aggStep, logEvery, true, nil)
+		a, _, _ := tx.(*mdbx.MdbxTx).SpaceDirty()
+		fmt.Printf("[dbg] 1 step:   took=%s dirt=%s\n", time.Since(start), datasize.ByteSize(a).HR())
+		tx.Rollback()
+		ic.Close()
+	}
+
+	{
+		tx, err := db.BeginRw(context.Background())
+		require.NoError(t, err)
+		ic := ii.BeginFilesRo()
+		start := time.Now()
+		pruneLimit := uint64(1_000)
+		ic.Prune(context.Background(), tx, 0, txCnt, pruneLimit, logEvery, true, nil)
+		a, _, _ := tx.(*mdbx.MdbxTx).SpaceDirty()
+		fmt.Printf("[dbg] 1K:       took=%s dirt=%s\n", time.Since(start), datasize.ByteSize(a).HR())
+		tx.Rollback()
+		ic.Close()
+	}
+	{
+		tx, err := db.BeginRw(context.Background())
+		require.NoError(t, err)
+		ic := ii.BeginFilesRo()
+		start := time.Now()
+		pruneLimit := ic.aggStep * 30
+		ic.Prune(context.Background(), tx, 0, txCnt, pruneLimit, logEvery, true, nil)
+		a, _, _ := tx.(*mdbx.MdbxTx).SpaceDirty()
+		fmt.Printf("[dbg] 30 steps: took=%s dirt=%s\n", time.Since(start), datasize.ByteSize(a).HR())
+		tx.Rollback()
+		ic.Close()
+	}
 }


### PR DESCRIPTION
like https://github.com/erigontech/erigon/pull/16129 but with table format `^step + addr -> txNum`

```
main:
[dbg] 1 step:   took=42.7545ms dirt=1000.0 KB
[dbg] 1K:       took=2.677667ms dirt=856.0 KB
[dbg] 30 steps: took=1.236420417s dirt=1.1 MB

alex/prune_ii_limit_31:
[dbg] 1 step:   took=24.418708ms dirt=1000.0 KB
[dbg] 1K:       took=1.553375ms dirt=856.0 KB
[dbg] 30 steps: took=882.610125ms dirt=1.1 MB

to:
[dbg] 1 step:   took=9.571792ms dirt=48.0 KB
[dbg] 1K:       took=595.792µs dirt=48.0 KB
[dbg] 30 steps: took=292.20175ms dirt=56.0 KB


```
how to release it? by increasing major version of db and then what? `auto rm chaindata`?
