### PR TITLE
rpc: Apply batch limit to WebSocket/IPC connections

### DIFF
--- a/rpc/batch_limit_ws_test.go
+++ b/rpc/batch_limit_ws_test.go
@@ -42,19 +42,19 @@ func TestBatchLimit_WebSocket_Exceeded(t *testing.T) {
 
 	// Send batch request
 	err = client.BatchCall(batch)
-	
+
 	// With the current implementation, conn.close is called on batch limit exceeded
 	// This should result in a connection error (websocket close)
 	if err == nil {
 		t.Fatal("expected connection error due to batch limit exceeded, got nil")
 	}
-	
+
 	// The error should be a websocket close error or EOF
 	// The specific batch limit error message is not propagated through the websocket close
 	if !strings.Contains(err.Error(), "websocket:") && !strings.Contains(err.Error(), "EOF") {
 		t.Fatalf("expected websocket close error, got: %v", err)
 	}
-	
+
 	// Verify the connection is closed by trying another request
 	err2 := client.Call(nil, "test_echo", "test")
 	if err2 == nil {

--- a/rpc/batch_limit_ws_test.go
+++ b/rpc/batch_limit_ws_test.go
@@ -1,0 +1,63 @@
+package rpc
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/erigontech/erigon-lib/log/v3"
+)
+
+func TestBatchLimit_WebSocket_Exceeded(t *testing.T) {
+	t.Parallel()
+	logger := log.New()
+
+	// Create server with batch limit
+	srv := newTestServer(logger)
+	srv.SetBatchLimit(10) // Set limit to 10
+
+	// Start HTTP server with WebSocket support
+	httpsrv := httptest.NewServer(srv.WebsocketHandler([]string{"*"}, nil, false, logger))
+	wsURL := "ws:" + strings.TrimPrefix(httpsrv.URL, "http:")
+	defer srv.Stop()
+	defer httpsrv.Close()
+
+	// Connect WebSocket client
+	client, err := DialWebsocket(context.Background(), wsURL, "", logger)
+	if err != nil {
+		t.Fatalf("failed to dial websocket: %v", err)
+	}
+	defer client.Close()
+
+	// Create batch exceeding limit (20 > 10)
+	var batch []BatchElem
+	for i := 0; i < 20; i++ {
+		batch = append(batch, BatchElem{
+			Method: "test_echo",
+			Args:   []interface{}{"hello"},
+			Result: new(echoResult),
+		})
+	}
+
+	// Send batch request
+	err = client.BatchCall(batch)
+	
+	// With the current implementation, conn.close is called on batch limit exceeded
+	// This should result in a connection error (websocket close)
+	if err == nil {
+		t.Fatal("expected connection error due to batch limit exceeded, got nil")
+	}
+	
+	// The error should be a websocket close error or EOF
+	// The specific batch limit error message is not propagated through the websocket close
+	if !strings.Contains(err.Error(), "websocket:") && !strings.Contains(err.Error(), "EOF") {
+		t.Fatalf("expected websocket close error, got: %v", err)
+	}
+	
+	// Verify the connection is closed by trying another request
+	err2 := client.Call(nil, "test_echo", "test")
+	if err2 == nil {
+		t.Fatal("expected error on closed connection, got nil")
+	}
+}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -110,7 +110,7 @@ func (s *Server) ServeCodec(codec ServerCodec, options CodecOption) {
 	s.codecs.Add(codec)
 	defer s.codecs.Remove(codec)
 
-	c := initClient(codec, s.idgen, &s.services, s.logger)
+	c := initClient(codec, s.idgen, &s.services, s.batchLimit, s.logger)
 	<-codec.closed()
 	c.Close()
 }


### PR DESCRIPTION

## Summary
- Extends the existing `--rpc.batch.limit` flag to WebSocket and IPC connections
- Previously, batch size limits were only enforced for HTTP connections
- Adds consistent batch limit enforcement across all RPC transport methods

## Implementation Details

### Changes Made
1. **Modified `rpc/client.go`**:
   - Added `batchLimit` field to the `Client` struct
   - Implemented batch size check in the `dispatch` method for WebSocket/IPC connections
   - When limit is exceeded: logs warning, sends error response, and closes connection

2. **Modified `rpc/server.go`**:
   - Updated `initClient` call to pass `batchLimit` parameter for WebSocket/IPC connections

3. **Added `rpc/batch_limit_ws_test.go`**:
   - New test to verify batch limit enforcement for WebSocket connections
   - Tests that batches exceeding the limit result in connection closure

### Behavior
- When a WebSocket/IPC batch request exceeds the configured limit:
  1. A warning is logged: `[WARN] [rpc] batch limit exceeded limit=X requested=Y`
  2. An error response is sent: `batch limit X exceeded (can increase by --rpc.batch.limit). Requested: Y`
  3. The connection is closed to prevent further abuse

### Compatibility
- No breaking changes to existing API
- HTTP batch limit behavior remains unchanged
- Default behavior (no limit) is preserved when `--rpc.batch.limit` is not set

## Testing
- Added new test case `TestBatchLimit_WebSocket_Exceeded` (Test command: `go test ./rpc -run TestBatchLimit_WebSocket_Exceeded -v`)
- All existing tests pass without modification
- Verified no regressions in RPC functionality

## Motivation
This change improves security and resource management by preventing large batch requests from overwhelming the server through WebSocket/IPC connections, matching the protection already in place for HTTP connections.
