### PR TITLE
Chain tip arbitrum testnet

### DIFF
--- a/cmd/integration/commands/flags.go
+++ b/cmd/integration/commands/flags.go
@@ -185,6 +185,10 @@ func withUnwindTypes(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVar(&unwindTypes, "unwind.types", nil, "types to unwind for polygon sync")
 }
 
+func withL2RPCaddress(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&cli.L2RPCAddrFlag.Name, "l2rpc", "", cli.L2RPCAddrFlag.Usage)
+}
+
 func withChaosMonkey(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&syncCfg.ChaosMonkey, utils.ChaosMonkeyFlag.Name, utils.ChaosMonkeyFlag.Value, utils.ChaosMonkeyFlag.Usage)
 }

--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -466,6 +466,7 @@ func init() {
 	withChain(cmdStageHeaders)
 	withHeimdall(cmdStageHeaders)
 	withChaosMonkey(cmdStageHeaders)
+	// cmdStageHeaders.Flags().StringVar()
 	rootCmd.AddCommand(cmdStageHeaders)
 
 	withConfig(cmdStageBodies)

--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -466,6 +466,7 @@ func init() {
 	withChain(cmdStageHeaders)
 	withHeimdall(cmdStageHeaders)
 	withChaosMonkey(cmdStageHeaders)
+	withL2RPCaddress(cmdStageHeaders)
 	// cmdStageHeaders.Flags().StringVar()
 	rootCmd.AddCommand(cmdStageHeaders)
 

--- a/cmd/integration/commands/state_stages.go
+++ b/cmd/integration/commands/state_stages.go
@@ -138,6 +138,7 @@ func init() {
 	withHeimdall(stateStages)
 	withWorkers(stateStages)
 	withChaosMonkey(stateStages)
+	withL2RPCaddress(stateStages)
 	rootCmd.AddCommand(stateStages)
 
 	withConfig(loopExecCmd)
@@ -148,6 +149,7 @@ func init() {
 	withHeimdall(loopExecCmd)
 	withWorkers(loopExecCmd)
 	withChaosMonkey(loopExecCmd)
+	withL2RPCaddress(loopExecCmd)
 	rootCmd.AddCommand(loopExecCmd)
 }
 

--- a/cmd/integration/commands/state_stages.go
+++ b/cmd/integration/commands/state_stages.go
@@ -137,7 +137,7 @@ func init() {
 	withChain(stateStages)
 	withHeimdall(stateStages)
 	withWorkers(stateStages)
-	withChaosMonkey(stateStages)
+	//withChaosMonkey(stateStages)
 	withL2RPCaddress(stateStages)
 	rootCmd.AddCommand(stateStages)
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2113,6 +2113,7 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 			},
 		)
 		if err != nil {
+			return
 			panic(err)
 		}
 		downloadernat.DoNat(nodeConfig.P2P.NAT, cfg.Downloader.ClientConfig, logger)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/erigontech/erigon/arb/ethdb/wasmdb"
 	"io/fs"
 	"math/big"
 	"net"
@@ -884,7 +885,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 				config.Genesis,
 				config.Sync,
 				stages2.SilkwormForExecutionStage(backend.silkworm, config),
-				nil,
+				wasmdb.OpenArbitrumWasmDB(ctx, dirs.ArbitrumWasm),
 			),
 			stagedsync.StageSendersCfg(backend.chainDB, chainConfig, config.Sync, false, dirs.Tmp, config.Prune, blockReader, backend.sentriesClient.Hd),
 			stagedsync.StageMiningExecCfg(backend.chainDB, miner, backend.notifications.Events, backend.chainConfig, backend.engine, &vm.Config{}, tmpdir, nil, 0, txnProvider, blockReader),

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -276,6 +276,8 @@ type Config struct {
 
 	// Account Abstraction
 	AllowAA bool
+
+	L2RPCAddr string
 }
 
 type Sync struct {

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -111,7 +111,7 @@ var Defaults = Config{
 	RPCTxFeeCap: 1, // 1 ether
 
 	ArbRPCEVMTimeout: 5 * time.Second,
-	L2RPCAddr:        "http://localhost:8547",
+	L2RPCAddr:        "", // arbitrum only field, url to connect to L2 RPC server
 
 	ImportMode: false,
 	Snapshot: BlocksFreezing{

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -111,6 +111,7 @@ var Defaults = Config{
 	RPCTxFeeCap: 1, // 1 ether
 
 	ArbRPCEVMTimeout: 5 * time.Second,
+	L2RPCAddr:        "http://localhost:8547",
 
 	ImportMode: false,
 	Snapshot: BlocksFreezing{

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -817,6 +817,7 @@ Loop:
 		if err = executor.tx().Commit(); err != nil {
 			return err
 		}
+		logger.Info("Committed", "blocks", inputBlockNum.Load())
 	}
 
 	agg.BuildFilesInBackground(outputTxNum.Load())

--- a/execution/stagedsync/stage_headers.go
+++ b/execution/stagedsync/stage_headers.go
@@ -164,6 +164,10 @@ func SpawnStageHeaders(s *StageState, u Unwinder, ctx context.Context, tx kv.RwT
 		curBlock++
 	}
 	firstBlock := curBlock
+
+	if firstBlock == latestBlock.Uint64() {
+		return nil
+	}
 	log.Info("[Arbitrum] Headers stage started", "firstBlock", firstBlock, "lastAvailableBlock", latestBlock.Uint64(), "extTx", useExternalTx)
 
 	var blockNumber big.Int

--- a/execution/stagedsync/stage_headers.go
+++ b/execution/stagedsync/stage_headers.go
@@ -223,6 +223,7 @@ func SpawnStageHeaders(s *StageState, u Unwinder, ctx context.Context, tx kv.RwT
 					log.Warn("Error committing transaction", "err", err)
 					return err
 				}
+				log.Info("Committed transaction", "block", blockNum, "hash", blk.Hash(), "extTx", useExternalTx)
 				tx, err = cfg.db.BeginRw(ctx)
 				if err != nil {
 					return err
@@ -270,6 +271,7 @@ func SpawnStageHeaders(s *StageState, u Unwinder, ctx context.Context, tx kv.RwT
 		if err != nil {
 			return err
 		}
+		log.Info("Committed transaction", "block", latestBlock.Uint64(), "extTx", useExternalTx)
 	}
 	log.Info("Headers stage completed", "from", firstBlock, "to", latestBlock.Uint64(), "latestProcessedBlock", latestProcessedBlock, "extTx", useExternalTx)
 	//if cfg.blockRetire != nil {

--- a/execution/stagedsync/stage_headers.go
+++ b/execution/stagedsync/stage_headers.go
@@ -93,8 +93,6 @@ func StageHeadersCfg(
 	notifications *shards.Notifications,
 	L2RPCAddr string, // L2 RPC address for Arbitrum
 ) HeadersCfg {
-	fmt.Printf("StageHeadersCfg: L2RPCAddr: %s\n", L2RPCAddr)
-	L2RPCAddr = "http://37.59.187.216:8547"
 	return HeadersCfg{
 		db:                db,
 		hd:                headerDownload,

--- a/execution/stagedsync/stage_headers.go
+++ b/execution/stagedsync/stage_headers.go
@@ -271,9 +271,10 @@ func SpawnStageHeaders(s *StageState, u Unwinder, ctx context.Context, tx kv.RwT
 			return err
 		}
 	}
-	if cfg.blockRetire != nil {
-		cfg.blockRetire.RetireBlocksInBackground(ctx, firstBlock, latestBlock.Uint64(), log.LvlInfo, nil, nil, nil)
-	}
+	log.Info("Headers stage completed", "from", firstBlock, "to", latestBlock.Uint64(), "latestProcessedBlock", latestProcessedBlock, "extTx", useExternalTx)
+	//if cfg.blockRetire != nil {
+	//	cfg.blockRetire.RetireBlocksInBackground(ctx, firstBlock, latestBlock.Uint64(), log.LvlInfo, nil, nil, nil)
+	//}
 	return nil
 }
 

--- a/execution/stagedsync/stage_headers.go
+++ b/execution/stagedsync/stage_headers.go
@@ -153,7 +153,7 @@ func SpawnStageHeaders(s *StageState, u Unwinder, ctx context.Context, tx kv.RwT
 	if curBlock > 0 {
 		curBlock++
 	}
-	fmt.Printf("requesting headerd from %d to %d\n", curBlock, latestBlock.Uint64())
+	fmt.Printf("requesting headers from %d to %d\n", curBlock, latestBlock.Uint64())
 
 	var blockNumber big.Int
 	// Process blocks from the starting block up to the latest.
@@ -184,7 +184,6 @@ func SpawnStageHeaders(s *StageState, u Unwinder, ctx context.Context, tx kv.RwT
 		if err := rawdb.WriteHeadHeaderHash(tx, blk.Hash()); err != nil {
 			return err
 		}
-
 		// Update the progress counter.
 		// i = blockNum + 1
 		select {
@@ -204,6 +203,9 @@ func SpawnStageHeaders(s *StageState, u Unwinder, ctx context.Context, tx kv.RwT
 			// fmt.Printf("Wrote block %d with hash %s\n", blockNum, blk.Hash().Hex())
 			if err := stages.SaveStageProgress(tx, stages.Senders, blockNum); err != nil {
 				return err
+			}
+			if err = s.Update(tx, blockNum); err != nil {
+				return fmt.Errorf("saving Headers progress: %w", err)
 			}
 
 			blkSec := float64(blockNum-prev) / 40.0

--- a/execution/stagedsync/stage_headers.go
+++ b/execution/stagedsync/stage_headers.go
@@ -260,6 +260,7 @@ func SpawnStageHeaders(s *StageState, u Unwinder, ctx context.Context, tx kv.RwT
 		return fmt.Errorf("saving Headers progress: %w", err)
 	}
 	if !useExternalTx {
+		cfg.hd.SetSynced()
 		err = tx.Commit()
 		if err != nil {
 			return err

--- a/execution/stagedsync/stage_headers.go
+++ b/execution/stagedsync/stage_headers.go
@@ -164,7 +164,7 @@ func SpawnStageHeaders(s *StageState, u Unwinder, ctx context.Context, tx kv.RwT
 		curBlock++
 	}
 	firstBlock := curBlock
-	fmt.Printf("requesting headers from %d to %d\n", curBlock, latestBlock.Uint64())
+	log.Info("[Arbitrum] Headers stage started", "firstBlock", firstBlock, "lastAvailableBlock", latestBlock.Uint64(), "extTx", useExternalTx)
 
 	var blockNumber big.Int
 	// Process blocks from the starting block up to the latest.
@@ -271,7 +271,7 @@ func SpawnStageHeaders(s *StageState, u Unwinder, ctx context.Context, tx kv.RwT
 		log.Info("Committed transaction", "block", latestBlock.Uint64(), "extTx", useExternalTx)
 	}
 
-	log.Info("Headers stage completed", "from", firstBlock, "to", latestBlock.Uint64(), "latestProcessedBlock", latestProcessedBlock, "extTx", useExternalTx)
+	log.Info("Headers stage completed", "from", firstBlock, "to", latestBlock.Uint64(), "latestProcessedBlock", latestProcessedBlock, "wasTxCommitted", !useExternalTx)
 	return nil
 }
 

--- a/execution/stagedsync/stage_headers.go
+++ b/execution/stagedsync/stage_headers.go
@@ -157,6 +157,7 @@ func SpawnStageHeaders(s *StageState, u Unwinder, ctx context.Context, tx kv.RwT
 	if curBlock > 0 {
 		curBlock++
 	}
+	firstBlock := curBlock
 	fmt.Printf("requesting headers from %d to %d\n", curBlock, latestBlock.Uint64())
 
 	var blockNumber big.Int
@@ -233,9 +234,6 @@ func SpawnStageHeaders(s *StageState, u Unwinder, ctx context.Context, tx kv.RwT
 			if err := cfg.blockWriter.FillHeaderNumberIndex(s.LogPrefix(), tx, os.TempDir(), prev, blockNum+1, ctx, logger); err != nil {
 				return err
 			}
-			if cfg.blockRetire != nil {
-				cfg.blockRetire.RetireBlocksInBackground(ctx, prev, blockNum, log.LvlInfo, nil, nil, nil)
-			}
 
 			prev = blockNum
 		default:
@@ -272,6 +270,9 @@ func SpawnStageHeaders(s *StageState, u Unwinder, ctx context.Context, tx kv.RwT
 		if err != nil {
 			return err
 		}
+	}
+	if cfg.blockRetire != nil {
+		cfg.blockRetire.RetireBlocksInBackground(ctx, firstBlock, latestBlock.Uint64(), log.LvlInfo, nil, nil, nil)
 	}
 	return nil
 }

--- a/execution/stagedsync/stage_headers.go
+++ b/execution/stagedsync/stage_headers.go
@@ -149,7 +149,7 @@ func SpawnStageHeaders(s *StageState, u Unwinder, ctx context.Context, tx kv.RwT
 		return err
 	}
 	var curBlock uint64
-	curBlock, err = stages.GetStageProgress(tx, stages.Bodies)
+	curBlock, err = stages.GetStageProgress(tx, stages.Headers)
 	if err != nil {
 		log.Warn("can't check current block", "err", err)
 	}

--- a/execution/stagedsync/stage_headers.go
+++ b/execution/stagedsync/stage_headers.go
@@ -161,7 +161,7 @@ func SpawnStageHeaders(s *StageState, u Unwinder, ctx context.Context, tx kv.RwT
 	// prev := i
 	prev := uint64(0)
 	timer := time.NewTicker(40 * time.Second)
-	latestBlock.SetUint64(6000)
+	latestBlock.SetUint64(60000)
 	// err = cfg.db.Update(context.TODO(), func(tx kv.RwTx) error {
 	for blockNum := curBlock; blockNum < latestBlock.Uint64(); blockNum++ {
 		blockNumber.SetUint64(blockNum)
@@ -235,7 +235,7 @@ func SpawnStageHeaders(s *StageState, u Unwinder, ctx context.Context, tx kv.RwT
 		log.Warn("Error updating db", "err", err)
 		return err
 	}
-	return nil
+	// return nil
 	// if !useExternalTx {
 	// 	var err error
 	// 	tx, err = cfg.db.BeginRw(ctx)

--- a/execution/stagedsync/stage_headers.go
+++ b/execution/stagedsync/stage_headers.go
@@ -277,7 +277,9 @@ func SpawnStageHeaders(s *StageState, u Unwinder, ctx context.Context, tx kv.RwT
 		log.Info("Committed transaction", "block", latestBlock.Uint64())
 	}
 
-	log.Info("[Arbitrum] Headers stage completed", "from", firstBlock, "to", latestBlock.Uint64(), "latestProcessedBlock", latestProcessedBlock, "wasTxCommitted", !useExternalTx)
+	if latestBlock.Uint64()-firstBlock > 1 {
+		log.Info("[Arbitrum] Headers stage completed", "from", firstBlock, "to", latestBlock.Uint64(), "latestProcessedBlock", latestProcessedBlock, "wasTxCommitted", !useExternalTx)
+	}
 	return nil
 }
 

--- a/execution/stagedsync/stage_headers.go
+++ b/execution/stagedsync/stage_headers.go
@@ -92,7 +92,7 @@ func StageHeadersCfg(
 	notifications *shards.Notifications,
 	L2RPCAddr string, // L2 RPC address for Arbitrum
 ) HeadersCfg {
-	L2RPCAddr = "http://37.59.187.216:8547"
+	L2RPCAddr = "http://0.0.0.0:8547"
 	fmt.Printf("StageHeadersCfg: L2RPCAddr: %s\n", L2RPCAddr)
 	return HeadersCfg{
 		db:                db,

--- a/execution/stagedsync/stage_headers.go
+++ b/execution/stagedsync/stage_headers.go
@@ -157,12 +157,9 @@ func SpawnStageHeaders(s *StageState, u Unwinder, ctx context.Context, tx kv.RwT
 
 	var blockNumber big.Int
 	// Process blocks from the starting block up to the latest.
-	// for i := curBlock; i < latestBlock.Uint64(); {
-	// prev := i
-	prev := uint64(0)
+	prev := curBlock
 	timer := time.NewTicker(40 * time.Second)
-	latestBlock.SetUint64(60000)
-	// err = cfg.db.Update(context.TODO(), func(tx kv.RwTx) error {
+	// latestBlock.SetUint64(curBlock + 6000)
 	for blockNum := curBlock; blockNum < latestBlock.Uint64(); blockNum++ {
 		blockNumber.SetUint64(blockNum)
 		blk, err := snapshots.GetBlockByNumber(client, &blockNumber, false)
@@ -187,27 +184,28 @@ func SpawnStageHeaders(s *StageState, u Unwinder, ctx context.Context, tx kv.RwT
 		if err := rawdb.WriteHeadHeaderHash(tx, blk.Hash()); err != nil {
 			return err
 		}
-		if err := stages.SaveStageProgress(tx, stages.Snapshots, blockNum); err != nil {
-			return err
-		}
-		if err := stages.SaveStageProgress(tx, stages.Headers, blockNum); err != nil {
-			return err
-		}
-		if err := stages.SaveStageProgress(tx, stages.BlockHashes, blockNum); err != nil {
-			return err
-		}
-		if err := stages.SaveStageProgress(tx, stages.Bodies, blockNum); err != nil {
-			return err
-		}
-		// fmt.Printf("Wrote block %d with hash %s\n", blockNum, blk.Hash().Hex())
-		if err := stages.SaveStageProgress(tx, stages.Senders, blockNum); err != nil {
-			return err
-		}
 
 		// Update the progress counter.
 		// i = blockNum + 1
 		select {
 		case <-timer.C:
+			if err := stages.SaveStageProgress(tx, stages.Snapshots, blockNum); err != nil {
+				return err
+			}
+			if err := stages.SaveStageProgress(tx, stages.Headers, blockNum); err != nil {
+				return err
+			}
+			if err := stages.SaveStageProgress(tx, stages.BlockHashes, blockNum); err != nil {
+				return err
+			}
+			if err := stages.SaveStageProgress(tx, stages.Bodies, blockNum); err != nil {
+				return err
+			}
+			// fmt.Printf("Wrote block %d with hash %s\n", blockNum, blk.Hash().Hex())
+			if err := stages.SaveStageProgress(tx, stages.Senders, blockNum); err != nil {
+				return err
+			}
+
 			blkSec := float64(blockNum-prev) / 40.0
 			log.Info("Block processed", "block", blockNum, "hash", blk.Hash(), "blk/s", fmt.Sprintf("%.2f", blkSec))
 			prev = blockNum
@@ -228,26 +226,21 @@ func SpawnStageHeaders(s *StageState, u Unwinder, ctx context.Context, tx kv.RwT
 			// continue processing without waiting
 		}
 	}
-	// 	return nil
-	// })
 	timer.Stop()
 	if err != nil {
 		log.Warn("Error updating db", "err", err)
 		return err
 	}
-	// return nil
-	// if !useExternalTx {
-	// 	var err error
-	// 	tx, err = cfg.db.BeginRw(ctx)
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// 	defer tx.Rollback()
-	// }
-	// return nil
-	// cfg.hd.Progress()
-	return HeadersPOW(s, u, ctx, tx, cfg, test, useExternalTx, logger)
-
+	if !useExternalTx {
+		var err error
+		tx, err = cfg.db.BeginRw(ctx)
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback()
+	}
+	return nil
+	// return HeadersPOW(s, u, ctx, tx, cfg, test, useExternalTx, logger)
 }
 
 // HeadersPOW progresses Headers stage for Proof-of-Work headers

--- a/execution/stagedsync/stage_headers.go
+++ b/execution/stagedsync/stage_headers.go
@@ -21,6 +21,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"github.com/erigontech/erigon/arb/ethdb"
 	"math/big"
 	"os"
 	"runtime"
@@ -267,6 +268,8 @@ func SpawnStageHeaders(s *StageState, u Unwinder, ctx context.Context, tx kv.RwT
 		}
 		log.Info("Committed transaction", "block", latestBlock.Uint64(), "extTx", useExternalTx)
 	}
+
+	ethdb.InitialiazeLocalWasmTarget()
 
 	log.Info("Headers stage completed", "from", firstBlock, "to", latestBlock.Uint64(), "latestProcessedBlock", latestProcessedBlock, "extTx", useExternalTx)
 	return nil

--- a/execution/stagedsync/stage_headers.go
+++ b/execution/stagedsync/stage_headers.go
@@ -169,7 +169,7 @@ func SpawnStageHeaders(s *StageState, u Unwinder, ctx context.Context, tx kv.RwT
 		return nil
 	}
 
-	if firstBlock+1 > latestBlock.Uint64()-1 { // print only if 1+ blocks available
+	if firstBlock+1 > latestBlock.Uint64() { // print only if 1+ blocks available
 		log.Info("[Arbitrum] Headers stage started", "from", firstBlock, "lastAvailableBlock", latestBlock.Uint64(), "extTx", useExternalTx)
 	}
 

--- a/execution/stagedsync/stage_headers.go
+++ b/execution/stagedsync/stage_headers.go
@@ -195,9 +195,9 @@ func SpawnStageHeaders(s *StageState, u Unwinder, ctx context.Context, tx kv.RwT
 			if err := rawdb.WriteCanonicalHash(tx, blk.Hash(), blockNum); err != nil {
 				return fmt.Errorf("error writing canonical hash %d: %w", blockNum, err)
 			}
-			//if err = cfg.blockWriter.MakeBodiesCanonical(tx, blockNum); err != nil {
-			//	return fmt.Errorf("failed to append canonical txnum %d: %w", blockNum, err)
-			//}
+			if err = cfg.blockWriter.MakeBodiesCanonical(tx, blockNum); err != nil {
+				return fmt.Errorf("failed to append canonical txnum %d: %w", blockNum, err)
+			}
 			rawdb.WriteHeadBlockHash(tx, blk.Hash())
 			if err := rawdb.WriteHeadHeaderHash(tx, blk.Hash()); err != nil {
 				return err
@@ -245,9 +245,9 @@ func SpawnStageHeaders(s *StageState, u Unwinder, ctx context.Context, tx kv.RwT
 			return err
 		}
 	}
-	// TODO need tor ead progress and fill header number index?
-	cfg.hd.ReadProgressFromDb(tx)
-
+	//// TODO need tor ead progress and fill header number index?
+	//cfg.hd.ReadProgressFromDb(tx)
+	//
 	if err := cfg.blockWriter.FillHeaderNumberIndex(s.LogPrefix(), tx, os.TempDir(), firstBlock+1, latestProcessedBlock, ctx, logger); err != nil {
 		return err
 	}
@@ -260,6 +260,8 @@ func SpawnStageHeaders(s *StageState, u Unwinder, ctx context.Context, tx kv.RwT
 	if err := cfg.blockWriter.MakeBodiesCanonical(tx, prev); err != nil {
 		return fmt.Errorf("failed to make bodies canonical %d: %w", prev, err)
 	}
+	ethdb.InitialiazeLocalWasmTarget()
+
 	if !useExternalTx {
 		cfg.hd.SetSynced()
 		err = tx.Commit()
@@ -268,8 +270,6 @@ func SpawnStageHeaders(s *StageState, u Unwinder, ctx context.Context, tx kv.RwT
 		}
 		log.Info("Committed transaction", "block", latestBlock.Uint64(), "extTx", useExternalTx)
 	}
-
-	ethdb.InitialiazeLocalWasmTarget()
 
 	log.Info("Headers stage completed", "from", firstBlock, "to", latestBlock.Uint64(), "latestProcessedBlock", latestProcessedBlock, "extTx", useExternalTx)
 	return nil

--- a/execution/stages/headerdownload/header_algos.go
+++ b/execution/stages/headerdownload/header_algos.go
@@ -680,6 +680,10 @@ func (hd *HeaderDownload) SetHeaderToDownloadPoS(hash common.Hash, height uint64
 	}
 }
 
+func (hd *HeaderDownload) SetSynced() {
+	hd.posStatus = Synced
+}
+
 func (hd *HeaderDownload) ProcessHeadersPOS(csHeaders []ChainSegmentHeader, tx kv.Getter, peerId [64]byte) ([]PenaltyItem, error) {
 	if len(csHeaders) == 0 {
 		return nil, nil

--- a/execution/stages/mock/mock_sentry.go
+++ b/execution/stages/mock/mock_sentry.go
@@ -514,7 +514,7 @@ func MockWithEverything(tb testing.TB, gspec *types.Genesis, key *ecdsa.PrivateK
 		cfg.Sync,
 		stagedsync.DefaultStages(mock.Ctx,
 			stagedsync.StageSnapshotsCfg(mock.DB, mock.ChainConfig, cfg.Sync, dirs, blockRetire, snapDownloader, mock.BlockReader, mock.Notifications, false, false, false, nil, prune),
-			stagedsync.StageHeadersCfg(mock.DB, mock.sentriesClient.Hd, mock.sentriesClient.Bd, mock.ChainConfig, cfg.Sync, sendHeaderRequest, propagateNewBlockHashes, penalize, cfg.BatchSize, false, mock.BlockReader, blockWriter, dirs.Tmp, mock.Notifications),
+			stagedsync.StageHeadersCfg(mock.DB, mock.sentriesClient.Hd, mock.sentriesClient.Bd, mock.ChainConfig, cfg.Sync, sendHeaderRequest, propagateNewBlockHashes, penalize, cfg.BatchSize, false, mock.BlockReader, blockWriter, dirs.Tmp, mock.Notifications, ""),
 			stagedsync.StageBlockHashesCfg(mock.DB, mock.Dirs.Tmp, mock.ChainConfig, blockWriter),
 			stagedsync.StageBodiesCfg(mock.DB, mock.sentriesClient.Bd, sendBodyRequest, penalize, blockPropagator, cfg.Sync.BodyDownloadTimeoutSeconds, mock.ChainConfig, mock.BlockReader, blockWriter),
 			stagedsync.StageSendersCfg(mock.DB, mock.ChainConfig, cfg.Sync, false, dirs.Tmp, prune, mock.BlockReader, mock.sentriesClient.Hd), stagedsync.StageExecuteBlocksCfg(

--- a/execution/stages/stageloop.go
+++ b/execution/stages/stageloop.go
@@ -688,7 +688,7 @@ func NewDefaultStages(ctx context.Context,
 
 	return stagedsync.DefaultStages(ctx,
 		stagedsync.StageSnapshotsCfg(db, controlServer.ChainConfig, cfg.Sync, dirs, blockRetire, snapDownloader, blockReader, notifications, cfg.InternalCL && cfg.CaplinConfig.ArchiveBlocks, cfg.CaplinConfig.ArchiveBlobs, cfg.CaplinConfig.ArchiveStates, silkworm, cfg.Prune),
-		stagedsync.StageHeadersCfg(db, controlServer.Hd, controlServer.Bd, controlServer.ChainConfig, cfg.Sync, controlServer.SendHeaderRequest, controlServer.PropagateNewBlockHashes, controlServer.Penalize, cfg.BatchSize, p2pCfg.NoDiscovery, blockReader, blockWriter, dirs.Tmp, notifications),
+		stagedsync.StageHeadersCfg(db, controlServer.Hd, controlServer.Bd, controlServer.ChainConfig, cfg.Sync, controlServer.SendHeaderRequest, controlServer.PropagateNewBlockHashes, controlServer.Penalize, cfg.BatchSize, p2pCfg.NoDiscovery, blockReader, blockWriter, dirs.Tmp, notifications, cfg.L2RPCAddr),
 		stagedsync.StageBlockHashesCfg(db, dirs.Tmp, controlServer.ChainConfig, blockWriter),
 		stagedsync.StageBodiesCfg(db, controlServer.Bd, controlServer.SendBodyRequest, controlServer.Penalize, controlServer.BroadcastNewBlock, cfg.Sync.BodyDownloadTimeoutSeconds, controlServer.ChainConfig, blockReader, blockWriter),
 		stagedsync.StageSendersCfg(db, controlServer.ChainConfig, cfg.Sync, false, dirs.Tmp, cfg.Prune, blockReader, controlServer.Hd),
@@ -741,7 +741,7 @@ func NewPipelineStages(ctx context.Context,
 
 	return stagedsync.UploaderPipelineStages(ctx,
 		stagedsync.StageSnapshotsCfg(db, controlServer.ChainConfig, cfg.Sync, dirs, blockRetire, snapDownloader, blockReader, notifications, cfg.InternalCL && cfg.CaplinConfig.ArchiveBlocks, cfg.CaplinConfig.ArchiveBlobs, cfg.CaplinConfig.ArchiveStates, silkworm, cfg.Prune),
-		stagedsync.StageHeadersCfg(db, controlServer.Hd, controlServer.Bd, controlServer.ChainConfig, cfg.Sync, controlServer.SendHeaderRequest, controlServer.PropagateNewBlockHashes, controlServer.Penalize, cfg.BatchSize, p2pCfg.NoDiscovery, blockReader, blockWriter, dirs.Tmp, notifications),
+		stagedsync.StageHeadersCfg(db, controlServer.Hd, controlServer.Bd, controlServer.ChainConfig, cfg.Sync, controlServer.SendHeaderRequest, controlServer.PropagateNewBlockHashes, controlServer.Penalize, cfg.BatchSize, p2pCfg.NoDiscovery, blockReader, blockWriter, dirs.Tmp, notifications, cfg.L2RPCAddr),
 		stagedsync.StageBlockHashesCfg(db, dirs.Tmp, controlServer.ChainConfig, blockWriter),
 		stagedsync.StageSendersCfg(db, controlServer.ChainConfig, cfg.Sync, false, dirs.Tmp, cfg.Prune, blockReader, controlServer.Hd),
 		stagedsync.StageBodiesCfg(db, controlServer.Bd, controlServer.SendBodyRequest, controlServer.Penalize, controlServer.BroadcastNewBlock, cfg.Sync.BodyDownloadTimeoutSeconds, controlServer.ChainConfig, blockReader, blockWriter),
@@ -754,7 +754,7 @@ func NewInMemoryExecution(ctx context.Context, db kv.RwDB, cfg *ethconfig.Config
 	silkworm *silkworm.Silkworm, logger log.Logger) *stagedsync.Sync {
 	return stagedsync.New(
 		cfg.Sync,
-		stagedsync.StateStages(ctx, stagedsync.StageHeadersCfg(db, controlServer.Hd, controlServer.Bd, controlServer.ChainConfig, cfg.Sync, controlServer.SendHeaderRequest, controlServer.PropagateNewBlockHashes, controlServer.Penalize, cfg.BatchSize, false, blockReader, blockWriter, dirs.Tmp, nil),
+		stagedsync.StateStages(ctx, stagedsync.StageHeadersCfg(db, controlServer.Hd, controlServer.Bd, controlServer.ChainConfig, cfg.Sync, controlServer.SendHeaderRequest, controlServer.PropagateNewBlockHashes, controlServer.Penalize, cfg.BatchSize, false, blockReader, blockWriter, dirs.Tmp, nil, cfg.L2RPCAddr),
 			stagedsync.StageBodiesCfg(db, controlServer.Bd, controlServer.SendBodyRequest, controlServer.Penalize, controlServer.BroadcastNewBlock, cfg.Sync.BodyDownloadTimeoutSeconds, controlServer.ChainConfig, blockReader, blockWriter), stagedsync.StageBlockHashesCfg(db, dirs.Tmp, controlServer.ChainConfig, blockWriter), stagedsync.StageSendersCfg(db, controlServer.ChainConfig, cfg.Sync, true, dirs.Tmp, cfg.Prune, blockReader, controlServer.Hd),
 			stagedsync.StageExecuteBlocksCfg(db, cfg.Prune, cfg.BatchSize, controlServer.ChainConfig, controlServer.Engine, &vm.Config{}, notifications, cfg.StateStream, true, cfg.Dirs, blockReader, controlServer.Hd, cfg.Genesis, cfg.Sync, SilkwormForExecutionStage(silkworm, cfg), wasmdb.OpenArbitrumWasmDB(ctx, dirs.ArbitrumWasm))),
 		stagedsync.StateUnwindOrder,

--- a/execution/stages/stageloop.go
+++ b/execution/stages/stageloop.go
@@ -688,7 +688,7 @@ func NewDefaultStages(ctx context.Context,
 
 	return stagedsync.DefaultStages(ctx,
 		stagedsync.StageSnapshotsCfg(db, controlServer.ChainConfig, cfg.Sync, dirs, blockRetire, snapDownloader, blockReader, notifications, cfg.InternalCL && cfg.CaplinConfig.ArchiveBlocks, cfg.CaplinConfig.ArchiveBlobs, cfg.CaplinConfig.ArchiveStates, silkworm, cfg.Prune),
-		stagedsync.StageHeadersCfg(db, controlServer.Hd, controlServer.Bd, controlServer.ChainConfig, cfg.Sync, controlServer.SendHeaderRequest, controlServer.PropagateNewBlockHashes, controlServer.Penalize, cfg.BatchSize, p2pCfg.NoDiscovery, blockReader, blockWriter, dirs.Tmp, notifications, cfg.L2RPCAddr, blockRetire),
+		stagedsync.StageHeadersCfg(db, controlServer.Hd, controlServer.Bd, controlServer.ChainConfig, cfg.Sync, controlServer.SendHeaderRequest, controlServer.PropagateNewBlockHashes, controlServer.Penalize, cfg.BatchSize, p2pCfg.NoDiscovery, blockReader, blockWriter, dirs.Tmp, notifications, cfg.L2RPCAddr),
 		stagedsync.StageBlockHashesCfg(db, dirs.Tmp, controlServer.ChainConfig, blockWriter),
 		stagedsync.StageBodiesCfg(db, controlServer.Bd, controlServer.SendBodyRequest, controlServer.Penalize, controlServer.BroadcastNewBlock, cfg.Sync.BodyDownloadTimeoutSeconds, controlServer.ChainConfig, blockReader, blockWriter),
 		stagedsync.StageSendersCfg(db, controlServer.ChainConfig, cfg.Sync, false, dirs.Tmp, cfg.Prune, blockReader, controlServer.Hd),
@@ -741,7 +741,7 @@ func NewPipelineStages(ctx context.Context,
 
 	return stagedsync.UploaderPipelineStages(ctx,
 		stagedsync.StageSnapshotsCfg(db, controlServer.ChainConfig, cfg.Sync, dirs, blockRetire, snapDownloader, blockReader, notifications, cfg.InternalCL && cfg.CaplinConfig.ArchiveBlocks, cfg.CaplinConfig.ArchiveBlobs, cfg.CaplinConfig.ArchiveStates, silkworm, cfg.Prune),
-		stagedsync.StageHeadersCfg(db, controlServer.Hd, controlServer.Bd, controlServer.ChainConfig, cfg.Sync, controlServer.SendHeaderRequest, controlServer.PropagateNewBlockHashes, controlServer.Penalize, cfg.BatchSize, p2pCfg.NoDiscovery, blockReader, blockWriter, dirs.Tmp, notifications, cfg.L2RPCAddr, blockRetire),
+		stagedsync.StageHeadersCfg(db, controlServer.Hd, controlServer.Bd, controlServer.ChainConfig, cfg.Sync, controlServer.SendHeaderRequest, controlServer.PropagateNewBlockHashes, controlServer.Penalize, cfg.BatchSize, p2pCfg.NoDiscovery, blockReader, blockWriter, dirs.Tmp, notifications, cfg.L2RPCAddr),
 		stagedsync.StageBlockHashesCfg(db, dirs.Tmp, controlServer.ChainConfig, blockWriter),
 		stagedsync.StageSendersCfg(db, controlServer.ChainConfig, cfg.Sync, false, dirs.Tmp, cfg.Prune, blockReader, controlServer.Hd),
 		stagedsync.StageBodiesCfg(db, controlServer.Bd, controlServer.SendBodyRequest, controlServer.Penalize, controlServer.BroadcastNewBlock, cfg.Sync.BodyDownloadTimeoutSeconds, controlServer.ChainConfig, blockReader, blockWriter),
@@ -754,7 +754,7 @@ func NewInMemoryExecution(ctx context.Context, db kv.RwDB, cfg *ethconfig.Config
 	silkworm *silkworm.Silkworm, logger log.Logger) *stagedsync.Sync {
 	return stagedsync.New(
 		cfg.Sync,
-		stagedsync.StateStages(ctx, stagedsync.StageHeadersCfg(db, controlServer.Hd, controlServer.Bd, controlServer.ChainConfig, cfg.Sync, controlServer.SendHeaderRequest, controlServer.PropagateNewBlockHashes, controlServer.Penalize, cfg.BatchSize, false, blockReader, blockWriter, dirs.Tmp, nil, cfg.L2RPCAddr, nil),
+		stagedsync.StateStages(ctx, stagedsync.StageHeadersCfg(db, controlServer.Hd, controlServer.Bd, controlServer.ChainConfig, cfg.Sync, controlServer.SendHeaderRequest, controlServer.PropagateNewBlockHashes, controlServer.Penalize, cfg.BatchSize, false, blockReader, blockWriter, dirs.Tmp, nil, cfg.L2RPCAddr),
 			stagedsync.StageBodiesCfg(db, controlServer.Bd, controlServer.SendBodyRequest, controlServer.Penalize, controlServer.BroadcastNewBlock, cfg.Sync.BodyDownloadTimeoutSeconds, controlServer.ChainConfig, blockReader, blockWriter), stagedsync.StageBlockHashesCfg(db, dirs.Tmp, controlServer.ChainConfig, blockWriter), stagedsync.StageSendersCfg(db, controlServer.ChainConfig, cfg.Sync, true, dirs.Tmp, cfg.Prune, blockReader, controlServer.Hd),
 			stagedsync.StageExecuteBlocksCfg(db, cfg.Prune, cfg.BatchSize, controlServer.ChainConfig, controlServer.Engine, &vm.Config{}, notifications, cfg.StateStream, true, cfg.Dirs, blockReader, controlServer.Hd, cfg.Genesis, cfg.Sync, SilkwormForExecutionStage(silkworm, cfg), wasmdb.OpenArbitrumWasmDB(ctx, dirs.ArbitrumWasm))),
 		stagedsync.StateUnwindOrder,

--- a/execution/stages/stageloop.go
+++ b/execution/stages/stageloop.go
@@ -302,7 +302,7 @@ func StageLoopIteration(ctx context.Context, db kv.RwDB, txc wrap.TxContainer, s
 		}
 	}
 	logCtx = append(logCtx, "alloc", common.ByteCount(m.Alloc), "sys", common.ByteCount(m.Sys))
-	logger.Info("Timings (slower than 50ms)", logCtx...)
+	//logger.Info("Timings (slower than 50ms)", logCtx...)
 	//if len(tableSizes) > 0 {
 	//	logger.Info("Tables", tableSizes...)
 	//}

--- a/execution/stages/stageloop.go
+++ b/execution/stages/stageloop.go
@@ -688,7 +688,7 @@ func NewDefaultStages(ctx context.Context,
 
 	return stagedsync.DefaultStages(ctx,
 		stagedsync.StageSnapshotsCfg(db, controlServer.ChainConfig, cfg.Sync, dirs, blockRetire, snapDownloader, blockReader, notifications, cfg.InternalCL && cfg.CaplinConfig.ArchiveBlocks, cfg.CaplinConfig.ArchiveBlobs, cfg.CaplinConfig.ArchiveStates, silkworm, cfg.Prune),
-		stagedsync.StageHeadersCfg(db, controlServer.Hd, controlServer.Bd, controlServer.ChainConfig, cfg.Sync, controlServer.SendHeaderRequest, controlServer.PropagateNewBlockHashes, controlServer.Penalize, cfg.BatchSize, p2pCfg.NoDiscovery, blockReader, blockWriter, dirs.Tmp, notifications, cfg.L2RPCAddr),
+		stagedsync.StageHeadersCfg(db, controlServer.Hd, controlServer.Bd, controlServer.ChainConfig, cfg.Sync, controlServer.SendHeaderRequest, controlServer.PropagateNewBlockHashes, controlServer.Penalize, cfg.BatchSize, p2pCfg.NoDiscovery, blockReader, blockWriter, dirs.Tmp, notifications, cfg.L2RPCAddr, blockRetire),
 		stagedsync.StageBlockHashesCfg(db, dirs.Tmp, controlServer.ChainConfig, blockWriter),
 		stagedsync.StageBodiesCfg(db, controlServer.Bd, controlServer.SendBodyRequest, controlServer.Penalize, controlServer.BroadcastNewBlock, cfg.Sync.BodyDownloadTimeoutSeconds, controlServer.ChainConfig, blockReader, blockWriter),
 		stagedsync.StageSendersCfg(db, controlServer.ChainConfig, cfg.Sync, false, dirs.Tmp, cfg.Prune, blockReader, controlServer.Hd),
@@ -741,7 +741,7 @@ func NewPipelineStages(ctx context.Context,
 
 	return stagedsync.UploaderPipelineStages(ctx,
 		stagedsync.StageSnapshotsCfg(db, controlServer.ChainConfig, cfg.Sync, dirs, blockRetire, snapDownloader, blockReader, notifications, cfg.InternalCL && cfg.CaplinConfig.ArchiveBlocks, cfg.CaplinConfig.ArchiveBlobs, cfg.CaplinConfig.ArchiveStates, silkworm, cfg.Prune),
-		stagedsync.StageHeadersCfg(db, controlServer.Hd, controlServer.Bd, controlServer.ChainConfig, cfg.Sync, controlServer.SendHeaderRequest, controlServer.PropagateNewBlockHashes, controlServer.Penalize, cfg.BatchSize, p2pCfg.NoDiscovery, blockReader, blockWriter, dirs.Tmp, notifications, cfg.L2RPCAddr),
+		stagedsync.StageHeadersCfg(db, controlServer.Hd, controlServer.Bd, controlServer.ChainConfig, cfg.Sync, controlServer.SendHeaderRequest, controlServer.PropagateNewBlockHashes, controlServer.Penalize, cfg.BatchSize, p2pCfg.NoDiscovery, blockReader, blockWriter, dirs.Tmp, notifications, cfg.L2RPCAddr, blockRetire),
 		stagedsync.StageBlockHashesCfg(db, dirs.Tmp, controlServer.ChainConfig, blockWriter),
 		stagedsync.StageSendersCfg(db, controlServer.ChainConfig, cfg.Sync, false, dirs.Tmp, cfg.Prune, blockReader, controlServer.Hd),
 		stagedsync.StageBodiesCfg(db, controlServer.Bd, controlServer.SendBodyRequest, controlServer.Penalize, controlServer.BroadcastNewBlock, cfg.Sync.BodyDownloadTimeoutSeconds, controlServer.ChainConfig, blockReader, blockWriter),
@@ -754,7 +754,7 @@ func NewInMemoryExecution(ctx context.Context, db kv.RwDB, cfg *ethconfig.Config
 	silkworm *silkworm.Silkworm, logger log.Logger) *stagedsync.Sync {
 	return stagedsync.New(
 		cfg.Sync,
-		stagedsync.StateStages(ctx, stagedsync.StageHeadersCfg(db, controlServer.Hd, controlServer.Bd, controlServer.ChainConfig, cfg.Sync, controlServer.SendHeaderRequest, controlServer.PropagateNewBlockHashes, controlServer.Penalize, cfg.BatchSize, false, blockReader, blockWriter, dirs.Tmp, nil, cfg.L2RPCAddr),
+		stagedsync.StateStages(ctx, stagedsync.StageHeadersCfg(db, controlServer.Hd, controlServer.Bd, controlServer.ChainConfig, cfg.Sync, controlServer.SendHeaderRequest, controlServer.PropagateNewBlockHashes, controlServer.Penalize, cfg.BatchSize, false, blockReader, blockWriter, dirs.Tmp, nil, cfg.L2RPCAddr, nil),
 			stagedsync.StageBodiesCfg(db, controlServer.Bd, controlServer.SendBodyRequest, controlServer.Penalize, controlServer.BroadcastNewBlock, cfg.Sync.BodyDownloadTimeoutSeconds, controlServer.ChainConfig, blockReader, blockWriter), stagedsync.StageBlockHashesCfg(db, dirs.Tmp, controlServer.ChainConfig, blockWriter), stagedsync.StageSendersCfg(db, controlServer.ChainConfig, cfg.Sync, true, dirs.Tmp, cfg.Prune, blockReader, controlServer.Hd),
 			stagedsync.StageExecuteBlocksCfg(db, cfg.Prune, cfg.BatchSize, controlServer.ChainConfig, controlServer.Engine, &vm.Config{}, notifications, cfg.StateStream, true, cfg.Dirs, blockReader, controlServer.Hd, cfg.Genesis, cfg.Sync, SilkwormForExecutionStage(silkworm, cfg), wasmdb.OpenArbitrumWasmDB(ctx, dirs.ArbitrumWasm))),
 		stagedsync.StateUnwindOrder,

--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -1788,10 +1788,10 @@ func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 		blocksInSnapshots = min(blocksInSnapshots, blockReader.FrozenBorBlocks())
 	}
 
-	from2, to2, ok := freezeblocks.CanRetire(to, blocksInSnapshots, coresnaptype.Enums.Headers, nil)
-	if ok {
-		from, to = from2, to2
-	}
+	// from2, to2, ok := freezeblocks.CanRetire(to, blocksInSnapshots, coresnaptype.Enums.Headers, nil)
+	// if ok {
+	// 	from, to = from2, to2
+	// -}
 
 	if err := br.RetireBlocks(ctx, from, to, log.LvlInfo, nil, nil, nil); err != nil {
 		return err

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -40,6 +40,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.TxPoolTraceSendersFlag,
 	&utils.TxPoolCommitEveryFlag,
 	&PruneDistanceFlag,
+	&L2RPCAddrFlag,
 	&PruneBlocksDistanceFlag,
 	&PruneModeFlag,
 	&utils.KeepExecutionProofsFlag,

--- a/turbo/cli/flags.go
+++ b/turbo/cli/flags.go
@@ -76,6 +76,12 @@ var (
 		Value: kv.ReadersLimit - 128,
 	}
 
+	L2RPCAddrFlag = cli.StringFlag{
+		Name:  "l2rpc",
+		Usage: "address of arbitrum L2 rpc server to get blocks and transactions from",
+		Value: "",
+	}
+
 	PruneModeFlag = cli.StringFlag{
 		Name: "prune.mode",
 		Usage: `Choose a pruning preset to run onto. Available values: "full", "archive", "minimal", "blocks".
@@ -374,6 +380,9 @@ func ApplyFlagsForEthConfigCobra(f *pflag.FlagSet, cfg *ethconfig.Config) {
 	}
 
 	cfg.Prune = mode
+
+	l2RPC := f.String(L2RPCAddrFlag.Name, L2RPCAddrFlag.DefaultText, "")
+	cfg.L2RPCAddr = *l2RPC
 
 	if v := f.String(BatchSizeFlag.Name, BatchSizeFlag.Value, BatchSizeFlag.Usage); v != nil {
 		err := cfg.BatchSize.UnmarshalText([]byte(*v))

--- a/turbo/cli/flags.go
+++ b/turbo/cli/flags.go
@@ -268,6 +268,9 @@ func ApplyFlagsForEthConfig(ctx *cli.Context, cfg *ethconfig.Config, logger log.
 	}
 	_ = chainId
 
+	cfg.L2RPCAddr = ctx.String(L2RPCAddrFlag.Name)
+	fmt.Printf("Using L2 RPC address: %s\n", cfg.L2RPCAddr)
+
 	blockDistance := ctx.Uint64(PruneBlocksDistanceFlag.Name)
 	distance := ctx.Uint64(PruneDistanceFlag.Name)
 

--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -807,6 +807,7 @@ func DumpTxs(ctx context.Context, db kv.RoDB, chainConfig *chain.Config, blockFr
 }
 
 func DumpHeaders(ctx context.Context, db kv.RoDB, _ *chain.Config, blockFrom, blockTo uint64, _ firstKeyGetter, collect func([]byte) error, workers int, lvl log.Lvl, logger log.Logger) (uint64, error) {
+	fmt.Printf("DumpHeaders: %d-%d\n", blockFrom, blockTo)
 	return DumpHeadersRaw(ctx, db, nil, blockFrom, blockTo, nil, collect, workers, lvl, logger, false)
 }
 

--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -633,8 +633,10 @@ func DumpTxs(ctx context.Context, db kv.RoDB, chainConfig *chain.Config, blockFr
 			txn2.SetSender(senders[j])
 			sender = senders[j]
 		} else {
-			signer := types.LatestSignerForChainID(chainConfig.ChainID)
-			sender, err = txn2.Sender(*signer)
+			signerEth := types.LatestSignerForChainID(chainConfig.ChainID)
+			signerArb := types.NewArbitrumSigner(*signerEth)
+
+			sender, err = signerArb.Sender(txn2)
 			if err != nil {
 				return nil, err
 			}

--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -212,12 +212,12 @@ func (br *BlockRetire) borSnapshots() *heimdall.RoSnapshots {
 }
 
 func CanRetire(curBlockNum uint64, blocksInSnapshots uint64, snapType snaptype.Enum, chainConfig *chain.Config) (blockFrom, blockTo uint64, can bool) {
-	var keep uint64 = 1024 //TODO: we will increase it to params.FullImmutabilityThreshold after some db optimizations
-	if curBlockNum <= keep {
-		return
-	}
+	// var keep uint64 = 1024 //TODO: we will increase it to params.FullImmutabilityThreshold after some db optimizations
+	// if curBlockNum <= keep {
+	// 	return
+	// }
 	blockFrom = blocksInSnapshots + 1
-	return snapshotsync.CanRetire(blockFrom, curBlockNum-keep, snapType, chainConfig)
+	return snapshotsync.CanRetire(blockFrom, curBlockNum, snapType, chainConfig)
 }
 
 func CanDeleteTo(curBlockNum uint64, blocksInSnapshots uint64) (blockTo uint64) {

--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -225,7 +225,7 @@ func CanDeleteTo(curBlockNum uint64, blocksInSnapshots uint64) (blockTo uint64) 
 		return 0
 	}
 
-	var keep uint64 = 1024 // params.FullImmutabilityThreshold //TODO: we will increase this value after db optimizations - about on-chain-tip prune speed
+	var keep uint64 = 0 //1024 // params.FullImmutabilityThreshold //TODO: we will increase this value after db optimizations - about on-chain-tip prune speed
 	if curBlockNum+999 < keep {
 		// To prevent overflow of uint64 below
 		return blocksInSnapshots + 1
@@ -809,7 +809,6 @@ func DumpTxs(ctx context.Context, db kv.RoDB, chainConfig *chain.Config, blockFr
 }
 
 func DumpHeaders(ctx context.Context, db kv.RoDB, _ *chain.Config, blockFrom, blockTo uint64, _ firstKeyGetter, collect func([]byte) error, workers int, lvl log.Lvl, logger log.Logger) (uint64, error) {
-	fmt.Printf("DumpHeaders: %d-%d\n", blockFrom, blockTo)
 	return DumpHeadersRaw(ctx, db, nil, blockFrom, blockTo, nil, collect, workers, lvl, logger, false)
 }
 


### PR DESCRIPTION
so until sequencer feed is not done, rely on fetching blocks and transactions from external L2 (pruned node is fine) RPC. 

New flag for erigon: `--l2rpc` allows to pass a host for rpc queries called in Headers stage and then triggering dump blocks and execution.