### PR TITLE
Properly handle file close errors when writing LLDB script

### DIFF
--- a/core/gdbme/gdbme_darwin.go
+++ b/core/gdbme/gdbme_darwin.go
@@ -70,9 +70,9 @@ quit
 	defer os.Remove(tmpFile.Name())
 
 	_, err = tmpFile.WriteString(lldbScript)
-	tmpFile.Close()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error: could not write LLDB script:", err)
+	closeErr := tmpFile.Close()
+	if err != nil || closeErr != nil {
+		fmt.Fprintln(os.Stderr, "Error: could not write or close LLDB script:", err, closeErr)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION


**Description:**  
This PR improves reliability by checking and handling errors not only when writing, but also when closing the temporary file for the LLDB script. This prevents silent failures in case the file is not fully written to disk due to system issues.