### PR TITLE
kv/mdbx: revert nosync periodic flusher

### DIFF
--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -60,57 +60,6 @@ func WithChaindataTables(defaultBuckets kv.TableCfg) kv.TableCfg {
 	return defaultBuckets
 }
 
-// handles background process of periodically flushing commits to disk
-type PeriodicFlusher struct {
-	env              *mdbx.Env // mdbx environment to flush to
-	opts             MdbxOpts
-	ticker           *time.Ticker  // set ticker
-	syncPeriod       time.Duration // how often to flush
-	quitFlushingChan chan struct{} // to signal end of flushing
-	closed           atomic.Bool
-}
-
-func newPeriodicFlusher(env *mdbx.Env, opts MdbxOpts, syncPeriod time.Duration) *PeriodicFlusher {
-	return &PeriodicFlusher{
-		env:              env,
-		opts:             opts,
-		ticker:           time.NewTicker(syncPeriod),
-		syncPeriod:       syncPeriod,
-		quitFlushingChan: make(chan struct{}),
-	}
-}
-
-func (flusher *PeriodicFlusher) Close() {
-	swapped := flusher.closed.CompareAndSwap(false, true)
-	if !swapped {
-		return
-	}
-	if flusher.ticker != nil {
-		flusher.ticker.Stop() // Stop the ticker
-	}
-	close(flusher.quitFlushingChan) //  close channel to signal quit
-}
-
-func (flusher *PeriodicFlusher) FlushInBackground(ctx context.Context) {
-	for {
-		select {
-		case <-flusher.ticker.C:
-			if err := flusher.env.Sync(true, false); err != nil {
-				flusher.opts.log.Error("Error during periodic mdbx sync", "err", err, "dbName", flusher.opts.label)
-			}
-		case _, ok := <-flusher.quitFlushingChan:
-			if !ok {
-				return
-			}
-		case <-ctx.Done():
-			// here the flusher is not closed explicitly from outside,
-			// so we must close it from within
-			flusher.ticker.Stop()
-			return
-		}
-	}
-}
-
 type MdbxOpts struct {
 	// must be in the range from 12.5% (almost empty) to 50% (half empty)
 	// which corresponds to the range from 8192 and to 32768 in units respectively
@@ -425,9 +374,19 @@ func (opts MdbxOpts) Open(ctx context.Context) (kv.RwDB, error) {
 	}
 
 	if opts.HasFlag(mdbx.SafeNoSync) && opts.syncPeriod != 0 {
-		db.periodicFlusher = newPeriodicFlusher(env, opts, opts.syncPeriod)
+		db.ticker = time.NewTicker(opts.syncPeriod) // set ticker
 		go func(ctx context.Context) { // start goroutine periodically flushing to disk
-			db.periodicFlusher.FlushInBackground(ctx) // start flushing in background
+			defer db.ticker.Stop()
+			for {
+				select {
+				case <-db.ticker.C:
+					if err := env.Sync(false, true); err != nil {
+						opts.log.Error("Error during periodic mdbx sync", "err", err)
+					}
+				case <-ctx.Done():
+					return
+				}
+			}
 		}(ctx)
 	}
 
@@ -529,8 +488,7 @@ type MdbxKV struct {
 	batchMu sync.Mutex
 	batch   *batch
 
-	periodicFlusher *PeriodicFlusher // only used when opts.syncPeriod is set, to periodically flush to disk committed changes
-
+	ticker *time.Ticker // only used when opts.syncPeriod is set, to periodically flush to disk committed changes
 }
 
 func (db *MdbxKV) Path() string                { return db.opts.path }
@@ -619,9 +577,7 @@ func (db *MdbxKV) Close() {
 		return
 	}
 	db.waitTxsAllDoneOnClose()
-	if db.periodicFlusher != nil {
-		db.periodicFlusher.Close()
-	}
+
 	db.env.Close()
 	db.env = nil
 

--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -67,7 +67,6 @@ type PeriodicFlusher struct {
 	ticker     *time.Ticker  // set ticker
 	syncPeriod time.Duration // how often to flush
 	closed     atomic.Bool
-	quitChan   chan struct{} // channel to signal closing
 	doneWg     sync.WaitGroup
 }
 
@@ -77,7 +76,6 @@ func newPeriodicFlusher(env *mdbx.Env, opts MdbxOpts, syncPeriod time.Duration) 
 		opts:       opts,
 		ticker:     time.NewTicker(syncPeriod),
 		syncPeriod: syncPeriod,
-		quitChan:   make(chan struct{}, 1),
 		doneWg:     sync.WaitGroup{},
 	}
 }
@@ -92,7 +90,6 @@ func (flusher *PeriodicFlusher) shutdown() {
 	if flusher.ticker != nil {
 		flusher.ticker.Stop() // Stop the ticker
 	}
-	flusher.quitChan <- struct{}{} // non-blocking send due to buffered chan
 }
 
 func (flusher *PeriodicFlusher) Close() {
@@ -104,19 +101,18 @@ func (flusher *PeriodicFlusher) FlushInBackground(ctx context.Context) {
 	flusher.doneWg.Add(1)
 	go func(ctx context.Context) {
 		defer flusher.doneWg.Done()
-		for {
+		for !flusher.closed.Load() {
 			select {
 			case <-flusher.ticker.C:
 				if err := flusher.env.Sync(true, false); err != nil {
 					flusher.opts.log.Error("Error during periodic mdbx sync", "err", err, "dbName", flusher.opts.label)
 				}
-			case <-flusher.quitChan:
-				return
 			case <-ctx.Done():
 				// here the flusher is not closed explicitly from outside,
 				// so we must close it from within
 				flusher.shutdown()
 				return
+			default:
 			}
 		}
 	}(ctx)

--- a/erigon-lib/kv/mdbx/kv_mdbx.go
+++ b/erigon-lib/kv/mdbx/kv_mdbx.go
@@ -342,6 +342,13 @@ func (opts MdbxOpts) Open(ctx context.Context) (kv.RwDB, error) {
 		return nil, err
 	}
 
+	if opts.HasFlag(mdbx.SafeNoSync) && opts.syncPeriod != 0 {
+		if err = env.SetSyncPeriod(opts.syncPeriod); err != nil {
+			env.Close()
+			return nil, err
+		}
+	}
+
 	if opts.HasFlag(mdbx.SafeNoSync) && opts.syncBytes != nil {
 		if err = env.SetSyncBytes(*opts.syncBytes); err != nil {
 			env.Close()
@@ -371,23 +378,6 @@ func (opts MdbxOpts) Open(ctx context.Context) (kv.RwDB, error) {
 
 		MaxBatchSize:  DefaultMaxBatchSize,
 		MaxBatchDelay: DefaultMaxBatchDelay,
-	}
-
-	if opts.HasFlag(mdbx.SafeNoSync) && opts.syncPeriod != 0 {
-		db.ticker = time.NewTicker(opts.syncPeriod) // set ticker
-		go func(ctx context.Context) { // start goroutine periodically flushing to disk
-			defer db.ticker.Stop()
-			for {
-				select {
-				case <-db.ticker.C:
-					if err := env.Sync(false, true); err != nil {
-						opts.log.Error("Error during periodic mdbx sync", "err", err)
-					}
-				case <-ctx.Done():
-					return
-				}
-			}
-		}(ctx)
 	}
 
 	customBuckets := opts.bucketsCfg(kv.TablesCfgByLabel(opts.label))
@@ -487,8 +477,6 @@ type MdbxKV struct {
 
 	batchMu sync.Mutex
 	batch   *batch
-
-	ticker *time.Ticker // only used when opts.syncPeriod is set, to periodically flush to disk committed changes
 }
 
 func (db *MdbxKV) Path() string                { return db.opts.path }


### PR DESCRIPTION
reverts:
- https://github.com/erigontech/erigon/commit/b937120bb0c8596a0bcb715e3020a146e3162cc5
- https://github.com/erigontech/erigon/commit/c9480171d183bfef915c324071a243bf09b226ad
- https://github.com/erigontech/erigon/commit/9e8ecf229f4958ed0ad05adad648a456609cae36
- https://github.com/erigontech/erigon/commit/31551783c6b359efa2d071dbcef8f643328a0de5

kurtosis crashes with 3 different types of errors (vary per occasion) but all due to the `PeriodicFlusher`:
- ```mdbx:20786: dxb_sync_locked: Assertion `target == head.ptr_c || constmeta_txnid(target) < pending->unsafe_txnid' failed.```
- ```mdbx:20743: dxb_sync_locked: Assertion `legal4overwrite' failed.```
- ```Assertion failed: legal4overwrite (mdbx: dxb_sync_locked: 20743)```

Sample full error:
```
[el-08-erigon-lighthouse] Assertion failed: legal4overwrite (mdbx: dxb_sync_locked: 20743)
[el-08-erigon-lighthouse] SIGABRT: abort
[el-08-erigon-lighthouse] PC=0xffffb67a7ef4 m=17 sigcode=18446744073709551610
[el-08-erigon-lighthouse] signal arrived during cgo execution
[el-08-erigon-lighthouse] 
[el-08-erigon-lighthouse] goroutine 72 gp=0x4001ee2000 m=17 mp=0x4000595808 [syscall]:
[el-08-erigon-lighthouse] runtime.cgocall(0x2362380, 0x4001ed9e98)
[el-08-erigon-lighthouse] 	runtime/cgocall.go:167 +0x44 fp=0x4001ed9e60 sp=0x4001ed9e20 pc=0x49da74
[el-08-erigon-lighthouse] github.com/erigontech/mdbx-go/mdbx._Cfunc_mdbx_env_sync_ex(0xffffb62010b0, 0x1, 0x0)
[el-08-erigon-lighthouse] 	_cgo_gotypes.go:941 +0x34 fp=0x4001ed9e90 sp=0x4001ed9e60 pc=0x924e84
[el-08-erigon-lighthouse] github.com/erigontech/mdbx-go/mdbx.(*Env).Sync.func1(...)
[el-08-erigon-lighthouse] 	github.com/erigontech/mdbx-go@v0.39.8/mdbx/env.go:452
[el-08-erigon-lighthouse] github.com/erigontech/mdbx-go/mdbx.(*Env).Sync(0x4001ed9f48?, 0x1, 0x0)
[el-08-erigon-lighthouse] 	github.com/erigontech/mdbx-go@v0.39.8/mdbx/env.go:452 +0x64 fp=0x4001ed9ee0 sp=0x4001ed9e90 pc=0x928ac4
[el-08-erigon-lighthouse] github.com/erigontech/erigon-lib/kv/mdbx.(*PeriodicFlusher).FlushInBackground.func1({0x35f48f8, 0x4001ecc640})
[el-08-erigon-lighthouse] 	github.com/erigontech/erigon-lib@v0.0.0-00010101000000-000000000000/kv/mdbx/kv_mdbx.go:110 +0xe8 fp=0x4001ed9fb0 sp=0x4001ed9ee0 pc=0xa358e8
[el-08-erigon-lighthouse] github.com/erigontech/erigon-lib/kv/mdbx.(*PeriodicFlusher).FlushInBackground.gowrap1()
[el-08-erigon-lighthouse] 	github.com/erigontech/erigon-lib@v0.0.0-00010101000000-000000000000/kv/mdbx/kv_mdbx.go:122 +0x34 fp=0x4001ed9fd0 sp=0x4001ed9fb0 pc=0xa357c4
[el-08-erigon-lighthouse] runtime.goexit({})
[el-08-erigon-lighthouse] 	runtime/asm_arm64.s:1223 +0x4 fp=0x4001ed9fd0 sp=0x4001ed9fd0 pc=0x4a9a74
[el-08-erigon-lighthouse] created by github.com/erigontech/erigon-lib/kv/mdbx.(*PeriodicFlusher).FlushInBackground in goroutine 71
[el-08-erigon-lighthouse] 	github.com/erigontech/erigon-lib@v0.0.0-00010101000000-000000000000/kv/mdbx/kv_mdbx.go:105 +0xcc
```


To reproduce:
- `cd erigon`
- `docker build -t test/erigon:current .`
- `kurtosis run --enclave test-fusaka-devnet-3 github.com/ethpandaops/ethereum-package --args-file kurtosis-fusaka-devnet-3.yaml`

the `kurtosis-fusaka-devnet-3.yaml` file contains:
```
participants_matrix:
  el:
    - el_type: besu
      el_image: ethpandaops/besu:fusaka-devnet-3
    - el_type: reth
      el_image: ethpandaops/reth:fusaka-devnet-3
    - el_type: nimbus
      el_image: ethpandaops/nimbus-eth1:fusaka-devnet-3
    - el_type: erigon
      el_image: test/erigon:current
    - el_type: geth
      el_image: ethpandaops/geth:fusaka-devnet-3
    - el_type: nethermind
      el_image: ethpandaops/nethermind:fusaka-devnet-3
  cl:
    - cl_type: lighthouse
      cl_image: ethpandaops/lighthouse:fusaka-devnet-3
      supernode: true
      validator_count: 64
    - cl_type: lighthouse
      cl_image: ethpandaops/lighthouse:fusaka-devnet-3
      validator_count: 12


network_params:
  fulu_fork_epoch: 4
  bpo_1_epoch: 5
  withdrawal_type: "0x02"
  preset: minimal

additional_services:
  - dora
  - spamoor

spamoor_params:
  image: ethpandaops/spamoor:master
  max_mem: 4000
  spammers:
    - scenario: eoatx
      config:
        throughput: 200
    - scenario: blobs
      config:
        throughput: 20

global_log_level: debug
```