### PR TITLE
[DO-NOT-MERGE] execution/bbd: el backward block downloader v2 - add back

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1132,6 +1132,11 @@ var (
 		Usage:   "Enables blazing fast eth_getProof for executed block",
 		Aliases: []string{"experimental.commitment-history"},
 	}
+	ElBlockDownloaderV2 = cli.BoolFlag{
+		Name:  "el.block.downloader.v2",
+		Usage: "Enables the EL engine v2 block downloader",
+		Value: false,
+	}
 )
 
 var MetricFlags = []cli.Flag{&MetricsEnabledFlag, &MetricsHTTPFlag, &MetricsPortFlag, &DiagDisabledFlag, &DiagEndpointAddrFlag, &DiagEndpointPortFlag, &DiagSpeedTestFlag}
@@ -1974,6 +1979,7 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 	setCaplin(ctx, cfg)
 
 	cfg.AllowAA = ctx.Bool(AAFlag.Name)
+	cfg.ElBlockDownloaderV2 = ctx.Bool(ElBlockDownloaderV2.Name)
 	cfg.Ethstats = ctx.String(EthStatsURLFlag.Name)
 
 	if ctx.Bool(ExperimentalConcurrentCommitmentFlag.Name) {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -713,7 +713,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		}
 	}
 
-	sentryMcDisableBlockDownload := chainConfig.Bor != nil
+	sentryMcDisableBlockDownload := chainConfig.Bor != nil || config.ElBlockDownloaderV2
 	backend.sentriesClient, err = sentry_multi_client.NewMultiClient(
 		backend.chainDB,
 		chainConfig,
@@ -1041,7 +1041,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		engine_block_downloader.NewEngineBlockDownloader(ctx,
 			logger, backend.sentriesClient.Hd, executionRpc,
 			backend.sentriesClient.Bd, backend.sentriesClient.BroadcastNewBlock, backend.sentriesClient.SendBodyRequest, blockReader,
-			backend.chainDB, chainConfig, tmpdir, config.Sync),
+			backend.chainDB, chainConfig, tmpdir, config.Sync, config.ElBlockDownloaderV2, sentryMux(sentries), statusDataProvider),
 		config.InternalCL && !config.CaplinConfig.EnableEngineAPI, // If the chain supports the engine API, then we should not make the server fail.
 		false,
 		config.Miner.EnabledPOS,
@@ -1079,7 +1079,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 			config,
 			logger,
 			chainConfig,
-			polygonSyncSentry(sentries),
+			sentryMux(sentries),
 			p2pConfig.MaxPeers,
 			statusDataProvider,
 			executionRpc,
@@ -1144,7 +1144,9 @@ func (s *Ethereum) Init(stack *node.Node, config *ethconfig.Config, chainConfig 
 	var err error
 
 	if chainConfig.Bor == nil {
-		s.sentriesClient.Hd.StartPoSDownloader(s.sentryCtx, s.sentriesClient.SendHeaderRequest, s.sentriesClient.Penalize)
+		if !config.ElBlockDownloaderV2 {
+			s.sentriesClient.Hd.StartPoSDownloader(s.sentryCtx, s.sentriesClient.SendHeaderRequest, s.sentriesClient.Penalize)
+		}
 	}
 
 	emptyBadHash := config.BadBlockHash == common.Hash{}
@@ -1908,7 +1910,7 @@ func setBorDefaultTxPoolPriceLimit(chainConfig *chain.Config, config txpoolcfg.C
 	}
 }
 
-func polygonSyncSentry(sentries []protosentry.SentryClient) protosentry.SentryClient {
+func sentryMux(sentries []protosentry.SentryClient) protosentry.SentryClient {
 	return libsentry.NewSentryMultiplexer(sentries)
 }
 

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -268,6 +268,8 @@ type Config struct {
 
 	// Account Abstraction
 	AllowAA bool
+
+	ElBlockDownloaderV2 bool
 }
 
 type Sync struct {

--- a/execution/bbd/backward_block_downloader.go
+++ b/execution/bbd/backward_block_downloader.go
@@ -1,0 +1,649 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package bbd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/etl"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon-lib/kv/dbutils"
+	"github.com/erigontech/erigon-lib/log/v3"
+	"github.com/erigontech/erigon-lib/p2p/sentry"
+	"github.com/erigontech/erigon-lib/rlp"
+	"github.com/erigontech/erigon-lib/types"
+	"github.com/erigontech/erigon/p2p/protocols/eth"
+	"github.com/erigontech/erigon/polygon/p2p"
+)
+
+var ErrChainLengthExceedsLimit = errors.New("chain length exceeds limit")
+
+type BackwardBlockDownloader struct {
+	logger          log.Logger
+	fetcher         p2p.Fetcher
+	peerTracker     *p2p.PeerTracker
+	peerPenalizer   *p2p.PeerPenalizer
+	messageListener *p2p.MessageListener
+	headerReader    HeaderReader
+	tmpDir          string
+	stopped         atomic.Bool
+}
+
+func NewBackwardBlockDownloader(
+	logger log.Logger,
+	sentryClient sentryproto.SentryClient,
+	statusDataFactory sentry.StatusDataFactory,
+	headerReader HeaderReader,
+	tmpDir string,
+) *BackwardBlockDownloader {
+	peerPenalizer := p2p.NewPeerPenalizer(sentryClient)
+	messageListener := p2p.NewMessageListener(logger, sentryClient, statusDataFactory, peerPenalizer)
+	messageSender := p2p.NewMessageSender(sentryClient)
+	peerTracker := p2p.NewPeerTracker(logger, sentryClient, messageListener)
+	var fetcher p2p.Fetcher
+	fetcher = p2p.NewFetcher(logger, messageListener, messageSender)
+	fetcher = p2p.NewPenalizingFetcher(logger, fetcher, peerPenalizer)
+	fetcher = p2p.NewTrackingFetcher(fetcher, peerTracker)
+	return &BackwardBlockDownloader{
+		logger:          logger,
+		fetcher:         fetcher,
+		peerTracker:     peerTracker,
+		peerPenalizer:   peerPenalizer,
+		headerReader:    headerReader,
+		tmpDir:          tmpDir,
+		messageListener: messageListener,
+	}
+}
+
+func (bbd *BackwardBlockDownloader) Run(ctx context.Context) error {
+	bbd.logger.Debug("[backward-block-downloader] running")
+	defer func() {
+		bbd.logger.Debug("[backward-block-downloader] stopped")
+		bbd.stopped.Store(true)
+	}()
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		err := bbd.peerTracker.Run(ctx)
+		if err != nil {
+			return fmt.Errorf("backward block downloader peer tracker failed: %w", err)
+		}
+		return nil
+	})
+	eg.Go(func() error {
+		err := bbd.messageListener.Run(ctx)
+		if err != nil {
+			return fmt.Errorf("backward block downloader message listener failed: %w", err)
+		}
+		return nil
+	})
+	return eg.Wait()
+}
+
+// DownloadBlocksBackwards downloads blocks backwards given a starting block hash. It uses the underlying header reader
+// to figure out when a header chain connects with a header that we already have. The backward download can handle
+// chain lengths of unlimited size by using an etl for temporarily storing the headers. This is also enabled by a
+// paging-like ResultFeed, which can be used to return pages of blocks as they get fetched in batches.
+//
+// There are a number of Option-s that can be passed in to customise the behaviour of the request:
+//   - WithPeerId - in case the backward needs to happen from a specific peer only
+//     (default: distributes requests across all that have the initial block hash)
+//   - WithBlocksBatchSize - controls the size of the block batch that we fetch from all and send to the result feed
+//     (default: 500 blocks)
+//   - WithChainLengthLimit - terminate the download if the backward header chain goes beyond a certain length.
+//     (default: unlimited)
+//   - WithChainLengthCurrentHead - optional, can be used in conjunction with WithChainLengthLimit to enable a quick
+//     validation of chain length limit breach. With this we can terminate early after fetching the initial header from
+//     peers if the fetched header is too far ahead than the current head. This will prevent further batched backward
+//     fetches of headers until such a chain length limit is breached.
+func (bbd *BackwardBlockDownloader) DownloadBlocksBackwards(ctx context.Context, hash common.Hash, opts ...Option) (ResultFeed, error) {
+	if bbd.stopped.Load() {
+		return ResultFeed{}, errors.New("backward block downloader is stopped")
+	}
+	feed := ResultFeed{ch: make(chan BatchResult)}
+	go func() {
+		defer feed.close()
+		err := bbd.fetchBlocksBackwardsByHash(ctx, hash, feed, opts...)
+		if err != nil {
+			feed.consumeErr(ctx, err)
+		}
+	}()
+	return feed, nil
+}
+
+func (bbd *BackwardBlockDownloader) fetchBlocksBackwardsByHash(ctx context.Context, hash common.Hash, feed ResultFeed, opts ...Option) error {
+	bbd.logger.Debug("[backward-block-downloader] fetching blocks backwards by hash", "hash", hash)
+	// 1. Get all peers
+	config := applyOptions(opts...)
+	peers, err := bbd.loadPeers(config)
+	if err != nil {
+		return err
+	}
+
+	// 2. Check which peers have the header to build knowledge about which peers we can use for syncing
+	//    and to also terminate early if none of the peers have seen it
+	bbd.logger.Info("[backward-block-downloader] downloading initial header from all peers", "hash", hash)
+	initialHeader, err := bbd.downloadInitialHeader(ctx, hash, peers, config)
+	if err != nil {
+		return err
+	}
+
+	// 3. Download the header chain backwards in an etl collector until we connect it to a known local header.
+	//    Note we fetch headers in batches of min(config.blocksBatchSize,1024) from 1 peer and send every following
+	//    request to the next available peer (in rotating fashion) to distribute the requests across all peers.
+	bbd.logger.Info(
+		"[backward-block-downloader] downloading header chain backward from initial header",
+		"num", initialHeader.Number.Uint64(),
+		"hash", initialHeader.Hash(),
+	)
+	etlSortableBuf := etl.NewSortableBuffer(etl.BufferOptimalSize)
+	headerCollector := etl.NewCollector("backward-block-downloader", bbd.tmpDir, etlSortableBuf, bbd.logger)
+	defer headerCollector.Close()
+	connectionPoint, err := bbd.downloadHeaderChainBackwards(ctx, initialHeader, headerCollector, peers, config)
+	if err != nil {
+		return err
+	}
+
+	// 4. Start forward downloading the bodies in batches of config.blocksBatchSize from the next in-turn peer.
+	//    Upon every complete batch we construct the blocks and feed them to the result feed.
+	bbd.logger.Info(
+		"[backward-block-downloader] starting forward downloading of blocks",
+		"count", (initialHeader.Number.Uint64()-connectionPoint.Number.Uint64())+1,
+		"fromNum", connectionPoint.Number.Uint64(),
+		"fromHash", connectionPoint.Hash(),
+		"toNum", initialHeader.Number.Uint64(),
+		"toHash", initialHeader.Hash(),
+	)
+	return bbd.downloadBlocks(ctx, headerCollector, peers, config, feed)
+}
+
+func (bbd *BackwardBlockDownloader) loadPeers(config requestConfig) (peersContext, error) {
+	if config.peerId != nil {
+		return newPeersContext([]*p2p.PeerId{config.peerId}), nil
+	}
+
+	peers := bbd.peerTracker.ListPeers()
+	if len(peers) == 0 {
+		return peersContext{}, errors.New("no peers available")
+	}
+
+	return newPeersContext(peers), nil
+}
+
+func (bbd *BackwardBlockDownloader) downloadInitialHeader(
+	ctx context.Context,
+	hash common.Hash,
+	peers peersContext,
+	config requestConfig,
+) (*types.Header, error) {
+	peersHeadersResponses := make([][]*types.Header, len(peers.all))
+	eg := errgroup.Group{}
+	fetcherOpts := []p2p.FetcherOption{
+		p2p.WithResponseTimeout(config.initialHeaderFetchTimeout),
+		p2p.WithMaxRetries(config.initialHeaderFetchRetries),
+	}
+	for _, peer := range peers.all {
+		eg.Go(func() error {
+			peerIndex := peers.peerIdToIndex[*peer]
+			resp, err := bbd.fetcher.FetchHeadersBackwards(ctx, hash, 1, peer, fetcherOpts...)
+			if err != nil {
+				bbd.logger.Trace(
+					"[backward-block-downloader] peer does not have initial header",
+					"hash", hash,
+					"peer", peer,
+					"err", err,
+				)
+				peers.exhaustedPeers[peerIndex] = true
+				return nil
+			}
+			header := resp.Data[0]
+			peersHeadersResponses[peerIndex] = []*types.Header{header}
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		panic(err) // err not expected since we don't return any errors in the above goroutines
+	}
+	var header *types.Header
+	for _, headers := range peersHeadersResponses {
+		if len(headers) > 0 {
+			header = headers[0]
+			break
+		}
+	}
+	if header == nil {
+		return nil, fmt.Errorf("no peers have initial header hash for backward download: %s", hash)
+	}
+	headerNum := header.Number.Uint64()
+	if headerNum == 0 {
+		return nil, fmt.Errorf("asked to download hash at num 0: %s", hash)
+	}
+	currentHead := config.chainLengthCurrentHead
+	if currentHead != nil && *currentHead > headerNum && *currentHead-headerNum >= config.chainLengthLimit {
+		return nil, fmt.Errorf(
+			"%w: num=%d, hash=%s, currentHead=%d, limit=%d",
+			ErrChainLengthExceedsLimit,
+			headerNum,
+			hash,
+			*config.chainLengthCurrentHead,
+			config.chainLengthLimit,
+		)
+	}
+	return header, nil
+}
+
+func (bbd *BackwardBlockDownloader) downloadHeaderChainBackwards(
+	ctx context.Context,
+	initialHeader *types.Header,
+	headerCollector *etl.Collector,
+	peers peersContext,
+	config requestConfig,
+) (*types.Header, error) {
+	headerBytes, err := rlp.EncodeToBytes(initialHeader)
+	if err != nil {
+		return nil, err
+	}
+	err = headerCollector.Collect(dbutils.HeaderKey(initialHeader.Number.Uint64(), initialHeader.Hash()), headerBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	fetcherOpts := []p2p.FetcherOption{
+		p2p.WithResponseTimeout(config.headerChainBatchFetchTimeout),
+		p2p.WithMaxRetries(config.headerChainBatchFetchRetries),
+	}
+	logProgressTicker := time.NewTicker(30 * time.Second)
+	defer logProgressTicker.Stop()
+	chainLen := uint64(1)
+	lastHeader := initialHeader
+	maxHeadersBatchLen := min(config.blocksBatchSize, eth.MaxHeadersServe)
+	var connectionPoint *types.Header
+	for connectionPoint == nil && lastHeader.Number.Uint64() > 0 {
+		if chainLen >= config.chainLengthLimit {
+			return nil, fmt.Errorf(
+				"%w: num=%d, hash=%s, len=%d, limit=%d",
+				ErrChainLengthExceedsLimit,
+				initialHeader.Number.Uint64(),
+				initialHeader.Hash(),
+				chainLen,
+				config.chainLengthLimit,
+			)
+		}
+
+		parentHash := lastHeader.ParentHash
+		parentNum := lastHeader.Number.Uint64() - 1
+		amount := min(parentNum, maxHeadersBatchLen)
+		if amount == 0 {
+			// can't fetch 0 blocks, just check if the hash matches our genesis and if it does set the connecting point
+			h, err := bbd.headerReader.HeaderByHash(ctx, parentHash)
+			if err != nil {
+				return nil, err
+			}
+			if h != nil {
+				connectionPoint = lastHeader
+			}
+			break
+		}
+
+		peerId, err := peers.nextAvailablePeer()
+		if err != nil {
+			return nil, fmt.Errorf(
+				"no peers available before reaching connection point num=%d, hash=%s: %w",
+				parentNum,
+				parentHash,
+				err,
+			)
+		}
+
+		progressLogArgs := []interface{}{
+			"num", parentNum,
+			"hash", parentHash,
+			"amount", amount,
+			"peerId", peerId.String(),
+		}
+		select {
+		case <-logProgressTicker.C:
+			bbd.logger.Info("[backward-block-downloader] fetching headers backward periodic progress", progressLogArgs...)
+		default:
+			bbd.logger.Trace("[backward-block-downloader] fetching headers backward", progressLogArgs...)
+		}
+
+		peerIndex := peers.peerIdToIndex[peerId]
+		resp, err := bbd.fetcher.FetchHeadersBackwards(ctx, parentHash, amount, &peerId, fetcherOpts...)
+		if err != nil {
+			bbd.logger.Debug(
+				"[backward-block-downloader] could not fetch headers batch from peer",
+				"num", parentNum,
+				"hash", parentHash,
+				"amount", amount,
+				"peerId", peerId.String(),
+				"err", err,
+			)
+			peers.exhaustedPeers[peerIndex] = true
+			continue
+		}
+
+		// collect the headers batch into the etl and check for a connecting point
+		headers := resp.Data
+		for i := len(headers) - 1; i >= 0; i-- {
+			header := headers[i]
+			headerNum := header.Number.Uint64()
+			if headerNum == 0 {
+				break
+			}
+			headerBytes, err = rlp.EncodeToBytes(header)
+			if err != nil {
+				return nil, err
+			}
+			err = headerCollector.Collect(dbutils.HeaderKey(headerNum, header.Hash()), headerBytes)
+			if err != nil {
+				return nil, err
+			}
+			chainLen++
+			lastHeader = header
+			h, err := bbd.headerReader.HeaderByHash(ctx, header.ParentHash)
+			if err != nil {
+				return nil, err
+			}
+			if h != nil {
+				connectionPoint = header
+				break
+			}
+		}
+	}
+	if connectionPoint == nil {
+		return nil, fmt.Errorf("connection point not found: num=%d, hash=%s", initialHeader.Number.Uint64(), initialHeader.Hash())
+	}
+	return connectionPoint, nil
+}
+
+func (bbd *BackwardBlockDownloader) downloadBlocks(
+	ctx context.Context,
+	headerCollector *etl.Collector,
+	peers peersContext,
+	config requestConfig,
+	feed ResultFeed,
+) error {
+	logProgressTicker := time.NewTicker(30 * time.Second)
+	defer logProgressTicker.Stop()
+	headers := make([]*types.Header, 0, config.blocksBatchSize)
+	headerCollectorLoadFunc := func(k, v []byte, table etl.CurrentTableReader, next etl.LoadNextFunc) error {
+		var header types.Header
+		err := rlp.DecodeBytes(v, &header)
+		if err != nil {
+			return err
+		}
+		headers = append(headers, &header)
+		if uint64(len(headers)) < config.blocksBatchSize {
+			return nil // keep accumulating headers
+		}
+		// we've accumulated enough headers in the batch - time to fetch them from peers and send to the result feed
+		err = bbd.downloadBlocksForHeaders(ctx, headers, peers, config, logProgressTicker, feed)
+		if err != nil {
+			return err
+		}
+		headers = headers[:0]
+		return nil
+	}
+	err := headerCollector.Load(nil, "", headerCollectorLoadFunc, etl.TransformArgs{Quit: ctx.Done()})
+	if err != nil {
+		return err
+	}
+	if len(headers) == 0 {
+		return feed.consumeData(ctx, nil)
+	}
+	// make sure to download blocks for the remaining incomplete header batch after the etl collector has been loaded
+	return bbd.downloadBlocksForHeaders(ctx, headers, peers, config, logProgressTicker, feed)
+}
+
+// downloadBlocksForHeaders downloads the bodies for the corresponding headers in parallel across all available peers
+// and constructs the corresponding blocks which get fed to the result feed.
+func (bbd *BackwardBlockDownloader) downloadBlocksForHeaders(
+	ctx context.Context,
+	headers []*types.Header,
+	peers peersContext,
+	config requestConfig,
+	logProgressTicker *time.Ticker,
+	feed ResultFeed,
+) error {
+	// split the headers into batches
+	neededPeers := min(len(headers), config.maxParallelBodyDownloads)
+	availablePeers, err := peers.nextAvailablePeers(neededPeers)
+	if err != nil {
+		return err
+	}
+	batchSize := (len(headers) + len(availablePeers) - 1) / len(availablePeers)
+	batchesCount := (len(headers) + batchSize - 1) / batchSize
+	progressLogArgs := []interface{}{
+		"fromNum", headers[0].Number.Uint64(),
+		"fromHash", headers[0].Hash(),
+		"toNum", headers[len(headers)-1].Number.Uint64(),
+		"toHash", headers[len(headers)-1].Hash(),
+		"numHeaders", len(headers),
+		"neededPeers", neededPeers,
+		"availablePeers", len(availablePeers),
+		"batchSize", batchSize,
+		"batchesCount", batchesCount,
+	}
+	select {
+	case <-logProgressTicker.C:
+		bbd.logger.Info("[backward-block-downloader] downloading blocks for headers batch periodic progress", progressLogArgs...)
+	default:
+		bbd.logger.Trace("[backward-block-downloader] downloading blocks for headers batch", progressLogArgs...)
+	}
+	headerBatches := make([][]*types.Header, batchesCount)
+	for i := range headerBatches {
+		headerStartIndex := i * batchSize
+		headerEndIndex := min(headerStartIndex+batchSize, len(headers))
+		headerBatches[i] = headers[headerStartIndex:headerEndIndex]
+	}
+
+	// download from available peers until all batches are downloaded
+	fetcherOpts := []p2p.FetcherOption{
+		p2p.WithResponseTimeout(config.bodiesBatchFetchTimeout),
+		p2p.WithMaxRetries(config.bodiesBatchFetchRetries),
+	}
+	type batchAssignment struct {
+		peerId     p2p.PeerId
+		batchIndex int
+	}
+	batchAssignments := make([]batchAssignment, 0, len(headerBatches))
+	blockBatches := make([][]*types.Block, len(availablePeers))
+	pendingBatches := true
+	attempts := 1
+	for pendingBatches {
+		// assign remaining batches to available peers
+		var peerIndex int
+		batchAssignments = batchAssignments[:0]
+		for batchIndex := range headerBatches {
+			if blockBatches[batchIndex] != nil {
+				continue // already fetched
+			}
+			if peerIndex == len(availablePeers) {
+				break
+			}
+			batchAssignments = append(batchAssignments, batchAssignment{
+				peerId:     availablePeers[peerIndex],
+				batchIndex: batchIndex,
+			})
+			peerIndex++
+		}
+		eg := errgroup.Group{}
+		for _, assignment := range batchAssignments {
+			peerId := assignment.peerId
+			batchIndex := assignment.batchIndex
+			headerBatch := headerBatches[batchIndex]
+			bbd.logger.Trace(
+				"[backward-block-downloader] fetching bodies for headerBatch",
+				"attempt", attempts,
+				"fromNum", headerBatch[0].Number.Uint64(),
+				"fromHash", headerBatch[0].Hash(),
+				"toNum", headerBatch[len(headerBatch)-1].Number.Uint64(),
+				"toHash", headerBatch[len(headerBatch)-1].Hash(),
+				"peerId", peerId.String(),
+			)
+
+			eg.Go(func() error {
+				bodiesResponse, err := bbd.fetcher.FetchBodies(ctx, headerBatch, &peerId, fetcherOpts...)
+				if err != nil {
+					bbd.logger.Debug(
+						"[backward-block-downloader] could not fetch bodies batch",
+						"fromNum", headerBatch[0].Number.Uint64(),
+						"fromHash", headerBatch[0].Hash(),
+						"toNum", headerBatch[len(headerBatch)-1].Number.Uint64(),
+						"toHash", headerBatch[len(headerBatch)-1].Hash(),
+						"peerId", peerId.String(),
+						"err", err,
+					)
+					return nil
+				}
+
+				bodies := bodiesResponse.Data
+				blockBatch := make([]*types.Block, 0, len(headerBatch))
+				for i, header := range headerBatch {
+					block := types.NewBlockFromNetwork(header, bodies[i])
+					err = block.HashCheck(true)
+					if err == nil {
+						blockBatch = append(blockBatch, block)
+						continue
+					}
+
+					bbd.logger.Debug(
+						"[backward-block-downloader] block hash check failed, penalizing peer",
+						"num", block.NumberU64(),
+						"hash", block.Hash(),
+						"peerId", peerId.String(),
+						"err", err,
+					)
+
+					err = bbd.peerPenalizer.Penalize(ctx, &peerId)
+					if err != nil {
+						bbd.logger.Debug(
+							"[backward-block-downloader] could not penalize peer",
+							"peerId", peerId.String(),
+							"err", err,
+						)
+					}
+
+					break
+				}
+				if len(blockBatch) == len(headerBatch) {
+					blockBatches[batchIndex] = blockBatch
+				}
+				return nil
+			})
+		}
+		if err := eg.Wait(); err != nil {
+			panic(err) // workers do not return errs
+		}
+		// mark peers as exhausted for those that had unsuccessful fetches
+		var incompleteBatches int
+		for _, assignment := range batchAssignments {
+			if blockBatches[assignment.batchIndex] == nil {
+				peers.exhaustedPeers[peers.peerIdToIndex[assignment.peerId]] = true
+				incompleteBatches++
+			}
+		}
+		if incompleteBatches > 0 {
+			attempts++
+			// recalculate the available peers as some have become exhausted
+			availablePeers, err = peers.nextAvailablePeers(incompleteBatches)
+			if err != nil {
+				return err
+			}
+		} else {
+			pendingBatches = false
+		}
+	}
+
+	blocks := make([]*types.Block, 0, len(headers))
+	for _, blocksBatch := range blockBatches {
+		blocks = append(blocks, blocksBatch...)
+	}
+
+	err = feed.consumeData(ctx, blocks)
+	if err != nil {
+		return fmt.Errorf("result feed could not consume blocks batch: %w", err)
+	}
+
+	return nil
+}
+
+func newPeersContext(peers []*p2p.PeerId) peersContext {
+	peerIdToIndex := make(map[p2p.PeerId]int, len(peers))
+	peerIndexToId := make(map[int]p2p.PeerId, len(peers))
+	for i, peer := range peers {
+		peerIdToIndex[*peer] = i
+		peerIndexToId[i] = *peer
+	}
+	return peersContext{
+		all:            peers,
+		peerIdToIndex:  peerIdToIndex,
+		peerIndexToId:  peerIndexToId,
+		exhaustedPeers: make([]bool, len(peers)),
+	}
+}
+
+type peersContext struct {
+	all              []*p2p.PeerId
+	peerIdToIndex    map[p2p.PeerId]int
+	peerIndexToId    map[int]p2p.PeerId
+	exhaustedPeers   []bool
+	currentPeerIndex int
+}
+
+func (pc *peersContext) nextAvailablePeer() (p2p.PeerId, error) {
+	var iterations int
+	for pc.exhaustedPeers[pc.currentPeerIndex] {
+		pc.incrementCurrentPeerIndex()
+		if iterations == len(pc.exhaustedPeers) {
+			return p2p.PeerId{}, errors.New("all peers exhausted")
+		}
+		iterations++
+	}
+	peer := pc.peerIndexToId[pc.currentPeerIndex]
+	pc.incrementCurrentPeerIndex()
+	return peer, nil
+}
+
+func (pc *peersContext) nextAvailablePeers(n int) ([]p2p.PeerId, error) {
+	peers := make([]p2p.PeerId, 0, n)
+	unique := make(map[p2p.PeerId]struct{}, n)
+	for len(peers) < n {
+		pid, err := pc.nextAvailablePeer()
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := unique[pid]; ok {
+			break // we've done a full rotation across all available peers
+		}
+		unique[pid] = struct{}{}
+		peers = append(peers, pid)
+	}
+	return peers, nil
+}
+
+func (pc *peersContext) incrementCurrentPeerIndex() {
+	pc.currentPeerIndex++
+	pc.currentPeerIndex %= len(pc.exhaustedPeers)
+}

--- a/execution/bbd/header_reader.go
+++ b/execution/bbd/header_reader.go
@@ -1,0 +1,28 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package bbd
+
+import (
+	"context"
+
+	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/types"
+)
+
+type HeaderReader interface {
+	HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error)
+}

--- a/execution/bbd/options.go
+++ b/execution/bbd/options.go
@@ -1,0 +1,89 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package bbd
+
+import (
+	"math"
+	"time"
+
+	"github.com/erigontech/erigon/polygon/p2p"
+)
+
+type Option func(requestConfig) requestConfig
+
+func WithPeerId(peerId *p2p.PeerId) Option {
+	return func(config requestConfig) requestConfig {
+		config.peerId = peerId
+		return config
+	}
+}
+
+func WithBlocksBatchSize(blocksBatchSize uint64) Option {
+	return func(config requestConfig) requestConfig {
+		config.blocksBatchSize = blocksBatchSize
+		return config
+	}
+}
+
+func WithChainLengthLimit(limit uint64) Option {
+	return func(config requestConfig) requestConfig {
+		config.chainLengthLimit = limit
+		return config
+	}
+}
+
+func WithChainLengthCurrentHead(head uint64) Option {
+	return func(config requestConfig) requestConfig {
+		config.chainLengthCurrentHead = &head
+		return config
+	}
+}
+
+func applyOptions(opts ...Option) requestConfig {
+	config := defaultRequestConfig
+	for _, opt := range opts {
+		config = opt(config)
+	}
+	return config
+}
+
+type requestConfig struct {
+	peerId                       *p2p.PeerId
+	blocksBatchSize              uint64
+	chainLengthLimit             uint64
+	chainLengthCurrentHead       *uint64
+	maxParallelBodyDownloads     int
+	initialHeaderFetchTimeout    time.Duration
+	initialHeaderFetchRetries    uint64
+	headerChainBatchFetchTimeout time.Duration
+	headerChainBatchFetchRetries uint64
+	bodiesBatchFetchTimeout      time.Duration
+	bodiesBatchFetchRetries      uint64
+}
+
+var defaultRequestConfig = requestConfig{
+	peerId:                       nil,
+	blocksBatchSize:              500,
+	chainLengthLimit:             math.MaxUint64,
+	maxParallelBodyDownloads:     10,
+	initialHeaderFetchTimeout:    time.Second, // note we want initial header fetch to be quick, so we terminate quickly
+	initialHeaderFetchRetries:    0,           // in case of chainLengthLimit+chainLengthCurrentHead early termination
+	headerChainBatchFetchTimeout: 10 * time.Second,
+	headerChainBatchFetchRetries: 1,
+	bodiesBatchFetchTimeout:      30 * time.Second,
+	bodiesBatchFetchRetries:      1,
+}

--- a/execution/bbd/result_feed.go
+++ b/execution/bbd/result_feed.go
@@ -1,0 +1,65 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package bbd
+
+import (
+	"context"
+
+	"github.com/erigontech/erigon-lib/types"
+)
+
+type ResultFeed struct {
+	ch chan BatchResult
+}
+
+func (rf ResultFeed) Next(ctx context.Context) ([]*types.Block, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case batch, ok := <-rf.ch:
+		if !ok {
+			return nil, nil
+		}
+		return batch.Blocks, batch.Err
+	}
+}
+
+func (rf ResultFeed) consumeData(ctx context.Context, blocks []*types.Block) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case rf.ch <- BatchResult{Blocks: blocks}:
+		return nil
+	}
+}
+
+func (rf ResultFeed) consumeErr(ctx context.Context, err error) {
+	select {
+	case <-ctx.Done():
+		return
+	case rf.ch <- BatchResult{Err: err}:
+	}
+}
+
+func (rf ResultFeed) close() {
+	close(rf.ch)
+}
+
+type BatchResult struct {
+	Blocks []*types.Block
+	Err    error
+}

--- a/execution/engineapi/engine_block_downloader/block_downloader.go
+++ b/execution/engineapi/engine_block_downloader/block_downloader.go
@@ -21,6 +21,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/big"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -77,6 +78,9 @@ type EngineBlockDownloader struct {
 	timeout int
 	config  *chain.Config
 	syncCfg ethconfig.Sync
+
+	// lock
+	lock sync.Mutex
 
 	// logs
 	logger log.Logger

--- a/execution/engineapi/engine_block_downloader/block_downloader.go
+++ b/execution/engineapi/engine_block_downloader/block_downloader.go
@@ -21,7 +21,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/big"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -30,14 +29,17 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/etl"
 	execution "github.com/erigontech/erigon-lib/gointerfaces/executionproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon-lib/kv"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon-lib/rlp"
 	"github.com/erigontech/erigon-lib/types"
 	"github.com/erigontech/erigon/eth/ethconfig"
+	"github.com/erigontech/erigon/execution/bbd"
 	"github.com/erigontech/erigon/execution/eth1/eth1_chain_reader"
 	"github.com/erigontech/erigon/execution/stages/bodydownload"
 	"github.com/erigontech/erigon/execution/stages/headerdownload"
+	"github.com/erigontech/erigon/p2p/sentry"
 	"github.com/erigontech/erigon/turbo/adapter"
 	"github.com/erigontech/erigon/turbo/services"
 )
@@ -60,7 +62,7 @@ type EngineBlockDownloader struct {
 	bodyReqSend RequestBodyFunction
 
 	// current status of the downloading process, aka: is it doing anything?
-	status atomic.Value // it is a headerdownload.SyncStatus
+	status atomic.Value // it is a Status
 
 	// data reader
 	blockPropagator adapter.BlockPropagator
@@ -76,20 +78,30 @@ type EngineBlockDownloader struct {
 	config  *chain.Config
 	syncCfg ethconfig.Sync
 
-	// lock
-	lock sync.Mutex
-
 	// logs
 	logger log.Logger
+
+	// V2 downloader
+	v2    bool
+	bbdV2 *bbd.BackwardBlockDownloader
 }
 
 func NewEngineBlockDownloader(ctx context.Context, logger log.Logger, hd *headerdownload.HeaderDownload, executionClient execution.ExecutionClient,
 	bd *bodydownload.BodyDownload, blockPropagator adapter.BlockPropagator,
 	bodyReqSend RequestBodyFunction, blockReader services.FullBlockReader, db kv.RoDB, config *chain.Config,
-	tmpdir string, syncCfg ethconfig.Sync) *EngineBlockDownloader {
+	tmpdir string, syncCfg ethconfig.Sync,
+	v2 bool,
+	sentryClient sentryproto.SentryClient,
+	statusDataProvider *sentry.StatusDataProvider,
+) *EngineBlockDownloader {
 	timeout := syncCfg.BodyDownloadTimeoutSeconds
 	var s atomic.Value
-	s.Store(headerdownload.Idle)
+	s.Store(Idle)
+	var bbdV2 *bbd.BackwardBlockDownloader
+	if v2 {
+		hr := headerReader{db: db, blockReader: blockReader}
+		bbdV2 = bbd.NewBackwardBlockDownloader(logger, sentryClient, statusDataProvider.GetStatusData, hr, tmpdir)
+	}
 	return &EngineBlockDownloader{
 		bacgroundCtx:    ctx,
 		hd:              hd,
@@ -105,7 +117,18 @@ func NewEngineBlockDownloader(ctx context.Context, logger log.Logger, hd *header
 		timeout:         timeout,
 		bodyReqSend:     bodyReqSend,
 		chainRW:         eth1_chain_reader.NewChainReaderEth1(config, executionClient, forkchoiceTimeoutMillis),
+		v2:              v2,
+		bbdV2:           bbdV2,
 	}
+}
+
+func (e *EngineBlockDownloader) Run(ctx context.Context) error {
+	if e.v2 {
+		e.logger.Info("[EngineBlockDownloader] running")
+		defer e.logger.Info("[EngineBlockDownloader] stopped")
+		return e.bbdV2.Run(ctx)
+	}
+	return nil
 }
 
 func (e *EngineBlockDownloader) scheduleHeadersDownload(

--- a/execution/engineapi/engine_block_downloader/core.go
+++ b/execution/engineapi/engine_block_downloader/core.go
@@ -149,8 +149,8 @@ func (e *EngineBlockDownloader) download(
 	}
 	if status == execution.ExecutionStatus_BadBlock {
 		e.logger.Warn("[EngineBlockDownloader] block segments downloaded are invalid")
-		e.status.Store(Idle)
 		e.hd.ReportBadHeaderPoS(chainTip.Hash(), latestValidHash)
+		e.status.Store(Idle)
 		return
 	}
 	e.logger.Info("[EngineBlockDownloader] blocks verification successful")

--- a/execution/engineapi/engine_block_downloader/core.go
+++ b/execution/engineapi/engine_block_downloader/core.go
@@ -18,6 +18,7 @@ package engine_block_downloader
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -44,7 +45,15 @@ func (e *EngineBlockDownloader) download(
 ) {
 	if e.v2 {
 		req := BackwardDownloadRequest{MissingHash: hashToDownload, Trigger: trigger, ValidateChainTip: chainTip}
-		e.downloadV2(ctx, req)
+		err := e.downloadV2(ctx, req)
+		if err != nil {
+			args := append(req.LogArgs(), "err", err)
+			e.logger.Warn("[EngineBlockDownloader] could not process backward download request", args...)
+			e.status.Store(Idle)
+			return
+		}
+		e.logger.Info("[EngineBlockDownloader] backward download request successfully processed", req.LogArgs()...)
+		e.status.Store(Synced)
 		return
 	}
 	/* Start download process*/
@@ -121,7 +130,7 @@ func (e *EngineBlockDownloader) download(
 	tx.Rollback() // Discard the original db tx
 	e.logger.Info("[EngineBlockDownloader] Finished downloading blocks", "from", startBlock-1, "to", endBlock)
 	if chainTip == nil {
-		e.status.Store(Idle)
+		e.status.Store(Synced)
 		return
 	}
 	// Can fail, not an issue in this case.
@@ -145,46 +154,41 @@ func (e *EngineBlockDownloader) download(
 		return
 	}
 	e.logger.Info("[EngineBlockDownloader] blocks verification successful")
-	e.status.Store(Idle)
+	e.status.Store(Synced)
 }
 
-func (e *EngineBlockDownloader) downloadV2(ctx context.Context, req BackwardDownloadRequest) {
-	defer e.status.Store(Idle)
+func (e *EngineBlockDownloader) downloadV2(ctx context.Context, req BackwardDownloadRequest) error {
 	err := e.downloadBlocksV2(ctx, req)
 	if err != nil {
-		args := append(req.LogArgs(), "err", err)
-		e.logger.Warn("[EngineBlockDownloader] could not process backward download request", args...)
-		return
+		return fmt.Errorf("could not process backward download of blocks: %w", err)
 	}
-	e.logger.Info("[EngineBlockDownloader] backward download request processed successfully", req.LogArgs()...)
+	e.logger.Info("[EngineBlockDownloader] backward download of blocks finished successfully", req.LogArgs()...)
 	if req.ValidateChainTip == nil {
-		return
+		return nil
 	}
 	tip := req.ValidateChainTip
 	err = e.chainRW.InsertBlockAndWait(ctx, tip)
 	if err != nil {
-		e.logger.Warn("[EngineBlockDownloader] could not insert request chain tip for validation", "err", err)
-		return
+		return fmt.Errorf("could not insert request chain tip for validation: %w", err)
 	}
 	status, _, latestValidHash, err := e.chainRW.ValidateChain(ctx, tip.Hash(), tip.NumberU64())
 	if err != nil {
-		e.logger.Warn("[EngineBlockDownloader] block verification failed", "reason", err)
-		return
+		return fmt.Errorf("request chain tip validation failed: %w", err)
 	}
 	if status == execution.ExecutionStatus_TooFarAway || status == execution.ExecutionStatus_Busy {
 		e.logger.Info("[EngineBlockDownloader] block verification skipped")
-		return
+		return nil
 	}
 	if status == execution.ExecutionStatus_BadBlock {
-		e.logger.Warn("[EngineBlockDownloader] block segments downloaded are invalid")
 		e.hd.ReportBadHeaderPoS(tip.Hash(), latestValidHash)
-		return
+		return errors.New("block segments downloaded are invalid")
 	}
 	e.logger.Info("[EngineBlockDownloader] blocks verification successful")
+	return nil
 }
 
 func (e *EngineBlockDownloader) downloadBlocksV2(ctx context.Context, req BackwardDownloadRequest) error {
-	e.logger.Info("[EngineBlockDownloader] processing backward download request", req.LogArgs()...)
+	e.logger.Info("[EngineBlockDownloader] processing backward download of blocks", req.LogArgs()...)
 	opts := []bbd.Option{bbd.WithBlocksBatchSize(500)}
 	if req.Trigger == NewPayloadTrigger {
 		opts = append(opts, bbd.WithChainLengthLimit(uint64(dbg.MaxReorgDepth)))
@@ -287,9 +291,12 @@ func (e *EngineBlockDownloader) execDownloadedBatch(ctx context.Context, block *
 // StartDownloading triggers the download process and returns true if the process started or false if it could not.
 // chainTip is optional and should be the block tip of the download request, which will be inserted at the end of the procedure if specified.
 func (e *EngineBlockDownloader) StartDownloading(requestId int, hashToDownload common.Hash, heightToDownload uint64, chainTip *types.Block, trigger Trigger) bool {
-	if !e.status.CompareAndSwap(Idle, Busy) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	if e.status.Load() == Syncing {
 		return false
 	}
+	e.status.Store(Syncing)
 	go e.download(e.bacgroundCtx, hashToDownload, heightToDownload, requestId, chainTip, trigger)
 	return true
 }
@@ -302,5 +309,6 @@ type Status int
 
 const (
 	Idle Status = iota
-	Busy
+	Syncing
+	Synced
 )

--- a/execution/engineapi/engine_block_downloader/core.go
+++ b/execution/engineapi/engine_block_downloader/core.go
@@ -189,7 +189,8 @@ func (e *EngineBlockDownloader) downloadV2(ctx context.Context, req BackwardDown
 
 func (e *EngineBlockDownloader) downloadBlocksV2(ctx context.Context, req BackwardDownloadRequest) error {
 	e.logger.Info("[EngineBlockDownloader] processing backward download of blocks", req.LogArgs()...)
-	opts := []bbd.Option{bbd.WithBlocksBatchSize(500)}
+	blocksBatchSize := min(500, uint64(e.syncCfg.LoopBlockLimit))
+	opts := []bbd.Option{bbd.WithBlocksBatchSize(blocksBatchSize)}
 	if req.Trigger == NewPayloadTrigger {
 		opts = append(opts, bbd.WithChainLengthLimit(uint64(dbg.MaxReorgDepth)))
 		currentHeader := e.chainRW.CurrentHeader(ctx)

--- a/execution/engineapi/engine_block_downloader/core.go
+++ b/execution/engineapi/engine_block_downloader/core.go
@@ -18,13 +18,17 @@ package engine_block_downloader
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/erigontech/erigon-db/rawdb"
 	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/common/dbg"
 	execution "github.com/erigontech/erigon-lib/gointerfaces/executionproto"
 	"github.com/erigontech/erigon-lib/kv/mdbx"
 	"github.com/erigontech/erigon-lib/kv/membatchwithdb"
 	"github.com/erigontech/erigon-lib/types"
+	"github.com/erigontech/erigon/execution/bbd"
 	"github.com/erigontech/erigon/execution/stages/headerdownload"
 )
 
@@ -36,27 +40,33 @@ func (e *EngineBlockDownloader) download(
 	heightToDownload uint64,
 	requestId int,
 	chainTip *types.Block,
+	trigger Trigger,
 ) {
+	if e.v2 {
+		req := BackwardDownloadRequest{MissingHash: hashToDownload, Trigger: trigger, ValidateChainTip: chainTip}
+		e.downloadV2(ctx, req)
+		return
+	}
 	/* Start download process*/
 	// First we schedule the headers download process
 	if !e.scheduleHeadersDownload(requestId, hashToDownload, heightToDownload) {
 		e.logger.Warn("[EngineBlockDownloader] could not begin header download")
 		// could it be scheduled? if not nevermind.
-		e.status.Store(headerdownload.Idle)
+		e.status.Store(Idle)
 		return
 	}
 	// see the outcome of header download
 	headersStatus, err := e.waitForEndOfHeadersDownload(ctx)
 	if err != nil {
 		e.logger.Warn("[EngineBlockDownloader] Could not finish headers download", "err", err)
-		e.status.Store(headerdownload.Idle)
+		e.status.Store(Idle)
 		return
 	}
 
 	if headersStatus != headerdownload.Synced {
 		// Could not sync. Set to idle
 		e.logger.Warn("[EngineBlockDownloader] Header download did not yield success")
-		e.status.Store(headerdownload.Idle)
+		e.status.Store(Idle)
 		return
 	}
 	e.hd.SetPosStatus(headerdownload.Idle)
@@ -64,7 +74,7 @@ func (e *EngineBlockDownloader) download(
 	tx, err := e.db.BeginRo(ctx)
 	if err != nil {
 		e.logger.Warn("[EngineBlockDownloader] Could not begin tx", "err", err)
-		e.status.Store(headerdownload.Idle)
+		e.status.Store(Idle)
 		return
 	}
 	defer tx.Rollback()
@@ -72,14 +82,14 @@ func (e *EngineBlockDownloader) download(
 	tmpDb, err := mdbx.NewUnboundedTemporaryMdbx(ctx, e.tmpdir)
 	if err != nil {
 		e.logger.Warn("[EngineBlockDownloader] Could create temporary mdbx", "err", err)
-		e.status.Store(headerdownload.Idle)
+		e.status.Store(Idle)
 		return
 	}
 	defer tmpDb.Close()
 	tmpTx, err := tmpDb.BeginRw(ctx)
 	if err != nil {
 		e.logger.Warn("[EngineBlockDownloader] Could create temporary mdbx", "err", err)
-		e.status.Store(headerdownload.Idle)
+		e.status.Store(Idle)
 		return
 	}
 	defer tmpTx.Rollback()
@@ -91,27 +101,27 @@ func (e *EngineBlockDownloader) download(
 		err = rawdb.WriteCanonicalHash(memoryMutation, chainTip.Hash(), chainTip.NumberU64())
 		if err != nil {
 			e.logger.Warn("[EngineBlockDownloader] Could not make leading header canonical", "err", err)
-			e.status.Store(headerdownload.Idle)
+			e.status.Store(Idle)
 			return
 		}
 	}
 	startBlock, endBlock, err := e.loadDownloadedHeaders(memoryMutation)
 	if err != nil {
 		e.logger.Warn("[EngineBlockDownloader] Could not load headers", "err", err)
-		e.status.Store(headerdownload.Idle)
+		e.status.Store(Idle)
 		return
 	}
 
 	// bodiesCollector := etl.NewCollector("EngineBlockDownloader", e.tmpdir, etl.NewSortableBuffer(etl.BufferOptimalSize), e.logger)
 	if err := e.downloadAndLoadBodiesSyncronously(ctx, memoryMutation, startBlock, endBlock); err != nil {
 		e.logger.Warn("[EngineBlockDownloader] Could not download bodies", "err", err)
-		e.status.Store(headerdownload.Idle)
+		e.status.Store(Idle)
 		return
 	}
 	tx.Rollback() // Discard the original db tx
 	e.logger.Info("[EngineBlockDownloader] Finished downloading blocks", "from", startBlock-1, "to", endBlock)
 	if chainTip == nil {
-		e.status.Store(headerdownload.Idle)
+		e.status.Store(Idle)
 		return
 	}
 	// Can fail, not an issue in this case.
@@ -120,38 +130,177 @@ func (e *EngineBlockDownloader) download(
 	status, _, latestValidHash, err := e.chainRW.ValidateChain(ctx, chainTip.Hash(), chainTip.NumberU64())
 	if err != nil {
 		e.logger.Warn("[EngineBlockDownloader] block verification failed", "reason", err)
-		e.status.Store(headerdownload.Idle)
+		e.status.Store(Idle)
 		return
 	}
 	if status == execution.ExecutionStatus_TooFarAway || status == execution.ExecutionStatus_Busy {
 		e.logger.Info("[EngineBlockDownloader] block verification skipped")
-		e.status.Store(headerdownload.Synced)
+		e.status.Store(Idle)
 		return
 	}
 	if status == execution.ExecutionStatus_BadBlock {
 		e.logger.Warn("[EngineBlockDownloader] block segments downloaded are invalid")
-		e.status.Store(headerdownload.Idle)
+		e.status.Store(Idle)
 		e.hd.ReportBadHeaderPoS(chainTip.Hash(), latestValidHash)
 		return
 	}
 	e.logger.Info("[EngineBlockDownloader] blocks verification successful")
-	e.status.Store(headerdownload.Synced)
+	e.status.Store(Idle)
+}
 
+func (e *EngineBlockDownloader) downloadV2(ctx context.Context, req BackwardDownloadRequest) {
+	defer e.status.Store(Idle)
+	err := e.downloadBlocksV2(ctx, req)
+	if err != nil {
+		args := append(req.LogArgs(), "err", err)
+		e.logger.Warn("[EngineBlockDownloader] could not process backward download request", args...)
+		return
+	}
+	e.logger.Info("[EngineBlockDownloader] backward download request processed successfully", req.LogArgs()...)
+	if req.ValidateChainTip == nil {
+		return
+	}
+	tip := req.ValidateChainTip
+	err = e.chainRW.InsertBlockAndWait(ctx, tip)
+	if err != nil {
+		e.logger.Warn("[EngineBlockDownloader] could not insert request chain tip for validation", "err", err)
+		return
+	}
+	status, _, latestValidHash, err := e.chainRW.ValidateChain(ctx, tip.Hash(), tip.NumberU64())
+	if err != nil {
+		e.logger.Warn("[EngineBlockDownloader] block verification failed", "reason", err)
+		return
+	}
+	if status == execution.ExecutionStatus_TooFarAway || status == execution.ExecutionStatus_Busy {
+		e.logger.Info("[EngineBlockDownloader] block verification skipped")
+		return
+	}
+	if status == execution.ExecutionStatus_BadBlock {
+		e.logger.Warn("[EngineBlockDownloader] block segments downloaded are invalid")
+		e.hd.ReportBadHeaderPoS(tip.Hash(), latestValidHash)
+		return
+	}
+	e.logger.Info("[EngineBlockDownloader] blocks verification successful")
+}
+
+func (e *EngineBlockDownloader) downloadBlocksV2(ctx context.Context, req BackwardDownloadRequest) error {
+	e.logger.Info("[EngineBlockDownloader] processing backward download request", req.LogArgs()...)
+	opts := []bbd.Option{bbd.WithBlocksBatchSize(500)}
+	if req.Trigger == NewPayloadTrigger {
+		opts = append(opts, bbd.WithChainLengthLimit(uint64(dbg.MaxReorgDepth)))
+		currentHeader := e.chainRW.CurrentHeader(ctx)
+		if currentHeader != nil {
+			opts = append(opts, bbd.WithChainLengthCurrentHead(currentHeader.Number.Uint64()))
+		}
+	}
+	if req.Trigger == SegmentRecoveryTrigger {
+		opts = append(opts, bbd.WithChainLengthLimit(uint64(e.syncCfg.LoopBlockLimit)))
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel() // need to cancel the ctx so that we cancel the download request processing if we err out prematurely
+	feed, err := e.bbdV2.DownloadBlocksBackwards(ctx, req.MissingHash, opts...)
+	if err != nil {
+		return err
+	}
+
+	logProgressTicker := time.NewTicker(30 * time.Second)
+	defer logProgressTicker.Stop()
+
+	var blocks []*types.Block
+	var insertedBlocksWithoutExec int
+	for blocks, err = feed.Next(ctx); err == nil && len(blocks) > 0; blocks, err = feed.Next(ctx) {
+		progressLogArgs := []interface{}{
+			"from", blocks[0].NumberU64(),
+			"fromHash", blocks[0].Hash(),
+			"to", blocks[len(blocks)-1].NumberU64(),
+			"toHash", blocks[len(blocks)-1].Hash(),
+		}
+		select {
+		case <-logProgressTicker.C:
+			e.logger.Info("[EngineBlockDownloader] processing downloaded blocks periodic progress", progressLogArgs...)
+		default:
+			e.logger.Trace("[EngineBlockDownloader] processing downloaded blocks", progressLogArgs...)
+		}
+		err := e.chainRW.InsertBlocksAndWait(ctx, blocks)
+		if err != nil {
+			return err
+		}
+		insertedBlocksWithoutExec += len(blocks)
+		if req.Trigger == FcuTrigger && uint(insertedBlocksWithoutExec) >= e.syncCfg.LoopBlockLimit {
+			tip := blocks[len(blocks)-1]
+			e.logger.Info(
+				"[EngineBlockDownloader] executing downloaded batch as it reached sync loop block limit",
+				"to", tip.NumberU64(),
+				"toHash", tip.Hash(),
+			)
+			err = e.execDownloadedBatch(ctx, tip, req.MissingHash)
+			if err != nil {
+				return err
+			}
+			insertedBlocksWithoutExec = 0
+		}
+	}
+	return err
+}
+
+func (e *EngineBlockDownloader) execDownloadedBatch(ctx context.Context, block *types.Block, requested common.Hash) error {
+	status, _, lastValidHash, err := e.chainRW.ValidateChain(ctx, block.Hash(), block.NumberU64())
+	if err != nil {
+		return err
+	}
+	switch status {
+	case execution.ExecutionStatus_BadBlock:
+		e.hd.ReportBadHeaderPoS(block.Hash(), lastValidHash)
+		e.hd.ReportBadHeaderPoS(requested, lastValidHash)
+		return fmt.Errorf("bad block when validating batch download: tip=%s, latestValidHash=%s", block.Hash(), lastValidHash)
+	case execution.ExecutionStatus_TooFarAway:
+		e.logger.Debug(
+			"[EngineBlockDownloader] skipping validation of block batch download due to exec status too far away",
+			"tip", block.Hash(),
+			"latestValidHash", lastValidHash,
+		)
+	case execution.ExecutionStatus_Success: // proceed to UpdateForkChoice
+	default:
+		return fmt.Errorf(
+			"unsuccessful status when validating batch download: status=%s, tip=%s, latestValidHash=%s",
+			status,
+			block.Hash(),
+			lastValidHash,
+		)
+	}
+	fcuStatus, _, lastValidHash, err := e.chainRW.UpdateForkChoice(ctx, block.Hash(), common.Hash{}, common.Hash{}, 0)
+	if err != nil {
+		return err
+	}
+	if fcuStatus != execution.ExecutionStatus_Success {
+		return fmt.Errorf(
+			"unsuccessful status when updating fork choice for batch download: status=%s, tip=%s, latestValidHash=%s",
+			fcuStatus,
+			block.Hash(),
+			lastValidHash,
+		)
+	}
+	return nil
 }
 
 // StartDownloading triggers the download process and returns true if the process started or false if it could not.
 // chainTip is optional and should be the block tip of the download request, which will be inserted at the end of the procedure if specified.
-func (e *EngineBlockDownloader) StartDownloading(requestId int, hashToDownload common.Hash, heightToDownload uint64, chainTip *types.Block) bool {
-	e.lock.Lock()
-	defer e.lock.Unlock()
-	if e.status.Load() == headerdownload.Syncing {
+func (e *EngineBlockDownloader) StartDownloading(requestId int, hashToDownload common.Hash, heightToDownload uint64, chainTip *types.Block, trigger Trigger) bool {
+	if !e.status.CompareAndSwap(Idle, Busy) {
 		return false
 	}
-	e.status.Store(headerdownload.Syncing)
-	go e.download(e.bacgroundCtx, hashToDownload, heightToDownload, requestId, chainTip)
+	go e.download(e.bacgroundCtx, hashToDownload, heightToDownload, requestId, chainTip, trigger)
 	return true
 }
 
-func (e *EngineBlockDownloader) Status() headerdownload.SyncStatus {
-	return headerdownload.SyncStatus(e.status.Load().(int))
+func (e *EngineBlockDownloader) Status() Status {
+	return e.status.Load().(Status)
 }
+
+type Status int
+
+const (
+	Idle Status = iota
+	Busy
+)

--- a/execution/engineapi/engine_block_downloader/download_request.go
+++ b/execution/engineapi/engine_block_downloader/download_request.go
@@ -1,0 +1,45 @@
+package engine_block_downloader
+
+import (
+	"fmt"
+
+	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/types"
+)
+
+type BackwardDownloadRequest struct {
+	MissingHash common.Hash
+	Trigger     Trigger
+	// ValidateChainTip is optional - if provided, it will be inserted after the missing hash backward download
+	// is complete and will trigger an operation to validate the chain leading to it
+	ValidateChainTip *types.Block
+}
+
+func (r BackwardDownloadRequest) LogArgs() []interface{} {
+	args := []interface{}{"hash", r.MissingHash, "trigger", r.Trigger}
+	if r.ValidateChainTip != nil {
+		args = append(args, "chainTipNum", r.ValidateChainTip.Number().Uint64(), "chainTipHash", r.ValidateChainTip.Hash())
+	}
+	return args
+}
+
+type Trigger byte
+
+func (s Trigger) String() string {
+	switch s {
+	case NewPayloadTrigger:
+		return "NewPayloadTrigger"
+	case SegmentRecoveryTrigger:
+		return "SegmentRecoveryTrigger"
+	case FcuTrigger:
+		return "FcuTrigger"
+	default:
+		panic(fmt.Sprintf("unknown trigger: %d", s))
+	}
+}
+
+const (
+	NewPayloadTrigger Trigger = iota
+	SegmentRecoveryTrigger
+	FcuTrigger
+)

--- a/execution/engineapi/engine_block_downloader/header_reader.go
+++ b/execution/engineapi/engine_block_downloader/header_reader.go
@@ -1,0 +1,26 @@
+package engine_block_downloader
+
+import (
+	"context"
+
+	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/kv"
+	"github.com/erigontech/erigon-lib/types"
+	"github.com/erigontech/erigon/execution/bbd"
+	"github.com/erigontech/erigon/turbo/services"
+)
+
+var _ bbd.HeaderReader = (*headerReader)(nil)
+
+type headerReader struct {
+	db          kv.RoDB
+	blockReader services.HeaderReader
+}
+
+func (hr headerReader) HeaderByHash(ctx context.Context, hash common.Hash) (h *types.Header, err error) {
+	err = hr.db.View(ctx, func(tx kv.Tx) error {
+		h, err = hr.blockReader.HeaderByHash(ctx, tx, hash)
+		return err
+	})
+	return h, err
+}

--- a/execution/engineapi/engine_server.go
+++ b/execution/engineapi/engine_server.go
@@ -454,14 +454,14 @@ func (s *EngineServer) getQuickPayloadStatusIfPossible(ctx context.Context, bloc
 			return &engine_types.PayloadStatus{Status: engine_types.ValidStatus, LatestValidHash: &blockHash}, nil
 		}
 		if shouldWait, _ := waitForStuff(50*time.Millisecond, func() (bool, error) {
-			return parent == nil && s.blockDownloader.Status() == engine_block_downloader.Busy, nil
+			return parent == nil && s.blockDownloader.Status() == engine_block_downloader.Syncing, nil
 		}); shouldWait {
 			s.logger.Debug(fmt.Sprintf("[%s] Downloading some other PoS blocks", prefix), "hash", blockHash)
 			return &engine_types.PayloadStatus{Status: engine_types.SyncingStatus}, nil
 		}
 	} else {
 		if shouldWait, _ := waitForStuff(50*time.Millisecond, func() (bool, error) {
-			return header == nil && s.blockDownloader.Status() == engine_block_downloader.Busy, nil
+			return header == nil && s.blockDownloader.Status() == engine_block_downloader.Syncing, nil
 		}); shouldWait {
 			s.logger.Debug(fmt.Sprintf("[%s] Downloading some other PoS stuff", prefix), "hash", blockHash)
 			return &engine_types.PayloadStatus{Status: engine_types.SyncingStatus}, nil
@@ -789,7 +789,7 @@ func (e *EngineServer) HandleNewPayload(
 			// We try waiting until we finish downloading the PoS blocks if the distance from the head is enough,
 			// so that we will perform full validation.
 			if stillSyncing, _ := waitForStuff(waitTime, func() (bool, error) {
-				return e.blockDownloader.Status() == engine_block_downloader.Busy, nil
+				return e.blockDownloader.Status() != engine_block_downloader.Synced, nil
 			}); stillSyncing {
 				return &engine_types.PayloadStatus{Status: engine_types.SyncingStatus}, nil
 			}

--- a/execution/eth1/eth1_chain_reader/chain_reader.go
+++ b/execution/eth1/eth1_chain_reader/chain_reader.go
@@ -354,12 +354,16 @@ func (c ChainReaderWriterEth1) ValidateChain(ctx context.Context, hash common.Ha
 	return resp.ValidationStatus, validationError, gointerfaces.ConvertH256ToHash(resp.LatestValidHash), err
 }
 
-func (c ChainReaderWriterEth1) UpdateForkChoice(ctx context.Context, headHash, safeHash, finalizeHash common.Hash) (execution.ExecutionStatus, *string, common.Hash, error) {
+func (c ChainReaderWriterEth1) UpdateForkChoice(ctx context.Context, headHash, safeHash, finalizeHash common.Hash, timeoutOverride ...uint64) (execution.ExecutionStatus, *string, common.Hash, error) {
+	timeout := c.fcuTimeoutMillis
+	if len(timeoutOverride) > 0 {
+		timeout = timeoutOverride[0]
+	}
 	resp, err := c.executionModule.UpdateForkChoice(ctx, &execution.ForkChoice{
 		HeadBlockHash:      gointerfaces.ConvertHashToH256(headHash),
 		SafeBlockHash:      gointerfaces.ConvertHashToH256(safeHash),
 		FinalizedBlockHash: gointerfaces.ConvertHashToH256(finalizeHash),
-		Timeout:            c.fcuTimeoutMillis,
+		Timeout:            timeout,
 	})
 	if err != nil {
 		return 0, nil, common.Hash{}, err

--- a/polygon/p2p/fetcher.go
+++ b/polygon/p2p/fetcher.go
@@ -33,6 +33,16 @@ type Fetcher interface {
 		opts ...FetcherOption,
 	) (FetcherResponse[[]*types.Header], error)
 
+	// FetchHeadersBackwards fetches a given number of headers backwards from a hash from a peer.
+	// Blocks until data is received.
+	FetchHeadersBackwards(
+		ctx context.Context,
+		hash common.Hash,
+		amount uint64,
+		peerId *PeerId,
+		opts ...FetcherOption,
+	) (FetcherResponse[[]*types.Header], error)
+
 	// FetchBodies fetches block bodies for the given headers from a peer. Blocks until data is received.
 	FetchBodies(
 		ctx context.Context,

--- a/polygon/p2p/fetcher_errors.go
+++ b/polygon/p2p/fetcher_errors.go
@@ -26,6 +26,7 @@ import (
 )
 
 var ErrInvalidFetchBlocksAmount = errors.New("invalid fetch blocks amount")
+var ErrInvalidFetchHeadersAmount = errors.New("invalid fetch headers amount")
 
 type ErrInvalidFetchHeadersRange struct {
 	start uint64

--- a/polygon/p2p/fetcher_tracking.go
+++ b/polygon/p2p/fetcher_tracking.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/types"
 )
 
@@ -51,6 +52,22 @@ func (tf *TrackingFetcher) FetchHeaders(
 			tf.peerTracker.BlockNumMissing(peerId, start)
 		}
 
+		return FetcherResponse[[]*types.Header]{}, err
+	}
+
+	tf.peerTracker.BlockNumPresent(peerId, res.Data[len(res.Data)-1].Number.Uint64())
+	return res, nil
+}
+
+func (tf *TrackingFetcher) FetchHeadersBackwards(
+	ctx context.Context,
+	hash common.Hash,
+	amount uint64,
+	peerId *PeerId,
+	opts ...FetcherOption,
+) (FetcherResponse[[]*types.Header], error) {
+	res, err := tf.Fetcher.FetchHeadersBackwards(ctx, hash, amount, peerId, opts...)
+	if err != nil {
 		return FetcherResponse[[]*types.Header]{}, err
 	}
 

--- a/polygon/p2p/peer_tracker.go
+++ b/polygon/p2p/peer_tracker.go
@@ -110,6 +110,17 @@ func (pt *PeerTracker) Run(ctx context.Context) error {
 	return ctx.Err()
 }
 
+func (pt *PeerTracker) ListPeers() []*PeerId {
+	pt.mu.Lock()
+	defer pt.mu.Unlock()
+	peerIds := make([]*PeerId, 0, len(pt.peerSyncProgresses))
+	for _, peerSyncProgress := range pt.peerSyncProgresses {
+		peerIds = append(peerIds, peerSyncProgress.peerId)
+	}
+	pt.peerShuffle(peerIds)
+	return peerIds
+}
+
 func (pt *PeerTracker) ListPeersMayHaveBlockNum(blockNum uint64) []*PeerId {
 	pt.mu.Lock()
 	defer pt.mu.Unlock()

--- a/polygon/p2p/peer_tracker_test.go
+++ b/polygon/p2p/peer_tracker_test.go
@@ -54,6 +54,12 @@ func TestPeerTracker(t *testing.T) {
 	require.Equal(t, PeerIdFromUint64(1), peerIds[0])
 	require.Equal(t, PeerIdFromUint64(2), peerIds[1])
 
+	peerIds = peerTracker.ListPeers()
+	require.Len(t, peerIds, 2)
+	sortPeerIdsAssumingUints(peerIds)
+	require.Equal(t, PeerIdFromUint64(1), peerIds[0])
+	require.Equal(t, PeerIdFromUint64(2), peerIds[1])
+
 	peerTracker.BlockNumMissing(PeerIdFromUint64(1), 50)
 	peerIds = peerTracker.ListPeersMayHaveBlockNum(100)
 	require.Len(t, peerIds, 1)
@@ -69,6 +75,11 @@ func TestPeerTracker(t *testing.T) {
 	peerTracker.PeerDisconnected(PeerIdFromUint64(2))
 	peerIds = peerTracker.ListPeersMayHaveBlockNum(100)
 	require.Len(t, peerIds, 1)
+	require.Equal(t, PeerIdFromUint64(1), peerIds[0])
+
+	peerIds = peerTracker.ListPeers()
+	require.Len(t, peerIds, 1)
+	sortPeerIdsAssumingUints(peerIds)
 	require.Equal(t, PeerIdFromUint64(1), peerIds[0])
 
 	peerTracker.PeerConnected(PeerIdFromUint64(2))

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -251,4 +251,5 @@ var DefaultFlags = []cli.Flag{
 	&utils.GDBMeFlag,
 
 	&utils.ExperimentalConcurrentCommitmentFlag,
+	&utils.ElBlockDownloaderV2,
 }


### PR DESCRIPTION
adding back https://github.com/erigontech/erigon/pull/16073 (had to revert it because it broke hive tests)

closes https://github.com/erigontech/erigon/issues/15877
closes https://github.com/erigontech/erigon/issues/15879
relates to https://github.com/erigontech/erigon-qa/issues/74#issuecomment-2956232796 

This change is introduced with a feature flag `--el.block.downloader.v2` (off by default) until sufficient testing has been done. The old flow will be used until we enable it by default. This should minimise any breaking changes.

**Problems addressed**
1. We weren't able to join any of the perfnet shadow forks
   - problem is that when we send out "get header requests" over devp2p with sentry we always send it to the same 5 peers (due to a max limit of 5 peers when sending the message out) which causes issues for shadow forks
   - in a shadow fork environment we have very few peers that are on the shadow fork (e.g. 5 bootnodes) and majority of the other peers we are connected to are mainnet peers (the shadowfork uses the same networkid=1 as mainnet)
   - what ended up happening is that we would always hit the same 5 peers that were on mainnet instead of the shadowfork when trying to backward sync using the EL block downloader - leading to use being stuck indefinitely 
   - same issue happened for bodies download - there it was even worse because we only send bodies request to max 1 peer (and we always would hit the same peer)
   - my workaround/short-term fix to unblock the perfnet work on the `performance` branch was to always send all messages to all peers (which is bad for the network and so we can't merge that temp fix into main, hence we need a better solution which this PR is aspiring to be)
2. extreme chaindata growth for large backward chain downloads due to the el downloader not taking into account `--sync.loop.block.limit` batched execution (in batches of 5,000 blocks) for E3
3. extreme chaindata growth for large backward chain downloads due to a long-lived chaindata RoTx
   - the long-lived RoTx is used in `membatchwithdb.NewMemoryBatchWithCustomDB(tx, tmpDb, tmpTx)` after the headers have been downloaded into an ETL
   - even after point 2. above was fixed and we called execution every 5,000 block (in order for the pruning to kick in) the chaindata was still growing uncontrollably - this is because there is a long lived RoTx holding the data (even though it has been pruned by the execution loop)
   - this RoTx lives for the entirety of the backward chain download
4. issues with the EL block downloader getting stuck for gnosis as per: https://github.com/erigontech/erigon-qa/issues/74#issuecomment-2956232796 

**Solutions**
To address problem 1:
- We devise a new backward fetch algorithm which leverages the devp2p api I wrote for Astrid (it is a convenient wrapper on top of Sentry). It is a much better choice than the old `HeaderDownload` and `BodyDownload` approach because it gives the user more control over which peers to fetch from (e.g. it allows you to list peers and make smarter selections about which peers to download from) which makes a lot of the code simpler. It also allows us to do cool things like parallel body download from many peers which we weren't able to do in an easy way previously. Another convenience of the API is that it is blocking every time you send a request to a peer so you don't have to worry about the async nature of devp2p. Doing this will also allow us to remove `HeaderDownload`, `BodyDownload` and headers and bodies stage so that we can finally unify our devp2p code paths between Polygon and Ethereum 
- The algo looks like this:
```
1. List all peers
2. Try to download the initial header with the hash we need to download backwards from all peers so that we know which peers have this data and are available for future requests.
3. Send devp2p backward header requests in batches of 500 headers (configurable per request) to 1 peer at a time
  - Send every new batch to the next available peer (which has the initial header) in a circular fashion to distribute the requests
  - For every batch of headers that we receive, we traverse the headers backwards (in descending number) and check if the parent hash is available in our DB - if it is we have found a connection point and we stop otherwise we continue fetching headers backwards
  - We accumulate the headers in an ETL collector
  - if any of the available peers fail to respond to us we mark them as "exhausted" so we don't try to use them again
4. Once we have a connection point, we start doing a forward body download in batches of 500 (configurable per request) by traversing through the sorted ETL (without needing any temporary MDBX)
   - here we do some parallelisation (because we already know all the hashes) - depending on how many non-exhausted peers we have we split the batch of 500 headers into N smaller batches - where N is the number of non-exhausted peers
   - we fetch the bodies of these N batches in parallel (we have a configurable max workers property - currently set to 10)
   - if any of the peers fail to serve us the bodies we again mark them as exhausted so we don't try to use them again and retry the batch with the next available peer in a circular fashion
   - once we've downloaded the batch of 500 blocks we feed it to a `ResultFeed` where the caller can consume it (paging-like API)
```

To address problem 2:
- we change the logic in the EngineBlockDownloader in the following way
- if a backward downloaded header chain is > dbg.MaxReorgDepth (512 blocks) in NewPayload we abandon the download request
- the algo in the solution to problem 1 has an option to abandon the backward header download (step 3) early if the backward chain length exceeds a configurable number (512 in this case)
- the CL will eventually have to send a ForkChoiceUpdated request for that large backward chain if it is the canonical one - within a FCU we allow long backward downloads
- when doing these long backward downloads with FCU - we add logic to take into account --sync.loop.block.limit - so we insert blocks to chain data (in batches of 500 blocks as currently done) then when we reach 5,000 blocks inserted we call ValidateChain+UpdateForkChoice to trigger execution + pruning (to keep chaindata size low)
- note this works quite well with the `ResultFeed` paging approach in the solution for problem 1

To address problem 3:
- thanks to the solution to problem 1. we actually no longer need to use `membatchwithdb.NewMemoryBatchWithCustomDB(tx, tmpDb, tmpTx)` and a long-lived chaindata RoTx - we only need an ETL collector which can be used without a tx/db

To address problem 4:
- solved by the solution to problem 1. as well

**Future follow-ups**
- We should move the shared code from `polygon/p2p` to `p2p` package
- We should use the new `bbd.BackwardBlockDownloader` in Astrid too (there is 1 situation in the tip-sync mode there that may occasionally need to do long backward block downloads when handling long period of no milestones)
- Remove the old code path and `--el.block.downloader.v2` feature flag in EngineBlockDownloader