### PR TITLE
Make a failing stress test a proper benchmark

### DIFF
--- a/erigon-lib/testlog/testlog.go
+++ b/erigon-lib/testlog/testlog.go
@@ -53,7 +53,7 @@ func (h *handler) Enabled(ctx context.Context, lvl log.Lvl) bool {
 // helpers, so the file and line number in unit test output correspond to the call site
 // which emitted the log message.
 type logger struct {
-	t   *testing.T
+	t   testing.TB
 	log log.Logger
 	mu  *sync.Mutex
 	h   *bufHandler
@@ -74,7 +74,7 @@ func (h *bufHandler) Enabled(ctx context.Context, lvl log.Lvl) bool {
 }
 
 // Logger returns a logger which logs to the unit test log of t.
-func Logger(t *testing.T, level log.Lvl) log.Logger {
+func Logger(t testing.TB, level log.Lvl) log.Logger {
 	t.Helper()
 
 	l := &logger{

--- a/tests/bor/mining_test.go
+++ b/tests/bor/mining_test.go
@@ -67,9 +67,9 @@ var (
 )
 
 // CGO_CFLAGS="-D__BLST_PORTABLE__" : flag required for go test.
-// Example : CGO_CFLAGS="-D__BLST_PORTABLE__" go test -run ^TestMiningBenchmark$ github.com/erigontech/erigon/tests/bor -v -count=1
-// In TestMiningBenchmark, we will test the mining performance. We will initialize a single node devnet and fire 5000 txs. We will measure the time it takes to include all the txs. This can be made more advcanced by increasing blockLimit and txsInTxpool.
-func TestMiningBenchmark(t *testing.T) {
+// Example : CGO_CFLAGS="-D__BLST_PORTABLE__" go test -run @ -bench /BenchmarkMining github.com/erigontech/erigon/tests/bor -v -count 1
+// Initialize a single node devnet and fire 5000 txs. We will measure the time it takes to include all the txs. This can be made more advanced by increasing blockLimit and txsInTxpool.
+func BenchmarkMining(t *testing.B) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -80,7 +80,7 @@ func TestMiningBenchmark(t *testing.T) {
 	}
 
 	//usually 15sec is enough
-	ctx, clean := context.WithTimeout(context.Background(), time.Minute)
+	ctx, clean := context.WithTimeout(t.Context(), time.Minute)
 	defer clean()
 
 	logger := testlog.Logger(t, log.LvlInfo)


### PR DESCRIPTION
Trying to stop the leaking tests. This one failed for something unrelated, it looks like a stress test that's not suitable to run as a unit test.