### PR TITLE
Refactor: replace receipt.TxHash with txnHash in events.go

### DIFF
--- a/turbo/shards/events.go
+++ b/turbo/shards/events.go
@@ -278,7 +278,7 @@ func (r *RecentLogs) Notify(n *Events, from, to uint64, isUnwind bool) {
 					Data:             l.Data,
 					LogIndex:         uint64(l.Index),
 					Topics:           make([]*types2.H256, 0, len(l.Topics)),
-					TransactionHash:  gointerfaces.ConvertHashToH256(receipt.TxHash),
+					TransactionHash:  gointerfaces.ConvertHashToH256(txnHash),
 					TransactionIndex: uint64(l.TxIndex),
 					Removed:          isUnwind,
 				}

--- a/turbo/shards/events.go
+++ b/turbo/shards/events.go
@@ -271,6 +271,7 @@ func (r *RecentLogs) Notify(n *Events, from, to uint64, isUnwind bool) {
 			//}
 
 			for _, l := range receipt.Logs {
+                            txnHash := receipt.TxHash
 				res := &remote.SubscribeLogsReply{
 					Address:          gointerfaces.ConvertAddressToH160(l.Address),
 					BlockHash:        gointerfaces.ConvertHashToH256(receipt.BlockHash),


### PR DESCRIPTION
This PR resolves the issue described in #16302 

The remaining use of receipt.TxHash in turbo/shards/events.go has been updated to txnHash for consistency with the rest of the codebase. As mentioned in the issue, this helps to make the code more readable and less error-prone.