### PR TITLE
refactor: use maps.Copy for cleaner map handling

### DIFF
--- a/cmd/devnet/devnet/node.go
+++ b/cmd/devnet/devnet/node.go
@@ -20,6 +20,7 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"maps"
 	"math/big"
 	"net/http"
 	"sync"
@@ -194,9 +195,7 @@ func (n *devnetNode) run(ctx *cli.Context) error {
 	n.nodeCfg.MdbxDBSizeLimit = 512 * datasize.MB
 
 	if n.network.Genesis != nil {
-		for addr, account := range n.network.Genesis.Alloc {
-			n.ethCfg.Genesis.Alloc[addr] = account
-		}
+		maps.Copy(n.ethCfg.Genesis.Alloc, n.network.Genesis.Alloc)
 
 		if n.network.Genesis.GasLimit != 0 {
 			n.ethCfg.Genesis.GasLimit = n.network.Genesis.GasLimit

--- a/cmd/rpctest/rpctest/bench1.go
+++ b/cmd/rpctest/rpctest/bench1.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 
@@ -285,9 +286,7 @@ func Bench1(erigonURL, gethURL string, needCompare bool, fullTest bool, blockFro
 					break
 				} else {
 					page = sr.Result.Next
-					for k, v := range sr.Result.Accounts {
-						accRangeErigon[k] = v
-					}
+					maps.Copy(accRangeErigon, sr.Result.Accounts)
 				}
 				if needCompare {
 					var srGeth DebugAccountRange
@@ -301,9 +300,7 @@ func Bench1(erigonURL, gethURL string, needCompare bool, fullTest bool, blockFro
 						break
 					} else {
 						pageGeth = srGeth.Result.Next
-						for k, v := range srGeth.Result.Accounts {
-							accRangeGeth[k] = v
-						}
+						maps.Copy(accRangeGeth, srGeth.Result.Accounts)
 					}
 					if !bytes.Equal(page, pageGeth) {
 						fmt.Printf("Different next page keys: %x geth %x", page, pageGeth)

--- a/cmd/rpctest/rpctest/bench3.go
+++ b/cmd/rpctest/rpctest/bench3.go
@@ -20,6 +20,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"maps"
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon/core/state"
@@ -49,9 +50,7 @@ func Bench3(erigon_url, geth_url string) error {
 			break
 		} else {
 			page = sr.Result.Next
-			for k, v := range sr.Result.Accounts {
-				accRangeTG[k] = v
-			}
+			maps.Copy(accRangeTG, sr.Result.Accounts)
 		}
 	}
 
@@ -69,9 +68,7 @@ func Bench3(erigon_url, geth_url string) error {
 			break
 		} else {
 			page = sr.Result.Next
-			for k, v := range sr.Result.Accounts {
-				accRangeTG[k] = v
-			}
+			maps.Copy(accRangeTG, sr.Result.Accounts)
 		}
 	}
 
@@ -135,9 +132,7 @@ func Bench3(erigon_url, geth_url string) error {
 			break
 		} else {
 			nextKey = sr.Result.NextKey
-			for k, v := range sr.Result.Storage {
-				sm[k] = v
-			}
+			maps.Copy(sm, sr.Result.Storage)
 		}
 	}
 	fmt.Printf("storageRange: %d\n", len(sm))
@@ -153,9 +148,7 @@ func Bench3(erigon_url, geth_url string) error {
 			break
 		} else {
 			nextKey = srg.Result.NextKey
-			for k, v := range srg.Result.Storage {
-				smg[k] = v
-			}
+			maps.Copy(smg, srg.Result.Storage)
 		}
 	}
 	fmt.Printf("storageRange g: %d\n", len(smg))

--- a/cmd/rpctest/rpctest/bench4.go
+++ b/cmd/rpctest/rpctest/bench4.go
@@ -18,6 +18,7 @@ package rpctest
 
 import (
 	"fmt"
+	"maps"
 
 	"github.com/erigontech/erigon-lib/common"
 )
@@ -66,9 +67,7 @@ func Bench4(erigon_url string) error {
 			break
 		} else {
 			nextKey = sr.Result.NextKey
-			for k, v := range sr.Result.Storage {
-				sm[k] = v
-			}
+			maps.Copy(sm, sr.Result.Storage)
 		}
 	}
 	fmt.Printf("storageRange: %d\n", len(sm))

--- a/cmd/rpctest/rpctest/bench9.go
+++ b/cmd/rpctest/rpctest/bench9.go
@@ -18,6 +18,7 @@ package rpctest
 
 import (
 	"fmt"
+	"maps"
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon/core/state"
@@ -59,9 +60,7 @@ func Bench9(erigonURL, gethURL string, needCompare bool) error {
 			break
 		} else {
 			page = sr.Result.Next
-			for k, v := range sr.Result.Accounts {
-				accRangeTG[k] = v
-			}
+			maps.Copy(accRangeTG, sr.Result.Accounts)
 		}
 		for address, dumpAcc := range accRangeTG {
 			var proof EthGetProof


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.