### PR TITLE
feat(opt): use a.StepSize() instead of a.aggregationStep

### DIFF
--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -1545,7 +1545,7 @@ func (a *Aggregator) BuildFilesInBackground(txNum uint64) chan struct{} {
 		return fin
 	}
 
-	if (txNum + 1) <= a.visibleFilesMinimaxTxNum.Load()+a.aggregationStep {
+	if (txNum + 1) <= a.visibleFilesMinimaxTxNum.Load() + a.StepSize() {
 		close(fin)
 		return fin
 	}


### PR DESCRIPTION
In the function `BuildFilesInBackground`, about the `aggregationStep` there are two different implementations?
```
if (txNum + 1) <= a.visibleFilesMinimaxTxNum.Load()+a.aggregationStep {
```
and 

```
step := a.visibleFilesMinimaxTxNum.Load() / a.StepSize()
```
.

They are in the same function, having the same meaning, but existing two different implementations, it is a little confusing.

Using a.StepSize() instead of a.aggregationStep, or a.aggregationStep instead of a.StepSize().


 
