### PR TITLE
Fixed caplin blob archive on devnet-3 tentaitively

### DIFF
--- a/cl/das/mock_services/peer_das_mock.go
+++ b/cl/das/mock_services/peer_das_mock.go
@@ -23,7 +23,6 @@ import (
 type MockPeerDas struct {
 	ctrl     *gomock.Controller
 	recorder *MockPeerDasMockRecorder
-	isgomock struct{}
 }
 
 // MockPeerDasMockRecorder is the mock recorder for MockPeerDas.
@@ -44,17 +43,17 @@ func (m *MockPeerDas) EXPECT() *MockPeerDasMockRecorder {
 }
 
 // DownloadColumnsAndRecoverBlobs mocks base method.
-func (m *MockPeerDas) DownloadColumnsAndRecoverBlobs(ctx context.Context, blocks []*cltypes.SignedBeaconBlock) error {
+func (m *MockPeerDas) DownloadColumnsAndRecoverBlobs(arg0 context.Context, arg1 []*cltypes.SignedBlindedBeaconBlock) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DownloadColumnsAndRecoverBlobs", ctx, blocks)
+	ret := m.ctrl.Call(m, "DownloadColumnsAndRecoverBlobs", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DownloadColumnsAndRecoverBlobs indicates an expected call of DownloadColumnsAndRecoverBlobs.
-func (mr *MockPeerDasMockRecorder) DownloadColumnsAndRecoverBlobs(ctx, blocks any) *MockPeerDasDownloadColumnsAndRecoverBlobsCall {
+func (mr *MockPeerDasMockRecorder) DownloadColumnsAndRecoverBlobs(arg0, arg1 any) *MockPeerDasDownloadColumnsAndRecoverBlobsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadColumnsAndRecoverBlobs", reflect.TypeOf((*MockPeerDas)(nil).DownloadColumnsAndRecoverBlobs), ctx, blocks)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadColumnsAndRecoverBlobs", reflect.TypeOf((*MockPeerDas)(nil).DownloadColumnsAndRecoverBlobs), arg0, arg1)
 	return &MockPeerDasDownloadColumnsAndRecoverBlobsCall{Call: call}
 }
 
@@ -70,29 +69,29 @@ func (c *MockPeerDasDownloadColumnsAndRecoverBlobsCall) Return(arg0 error) *Mock
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockPeerDasDownloadColumnsAndRecoverBlobsCall) Do(f func(context.Context, []*cltypes.SignedBeaconBlock) error) *MockPeerDasDownloadColumnsAndRecoverBlobsCall {
+func (c *MockPeerDasDownloadColumnsAndRecoverBlobsCall) Do(f func(context.Context, []*cltypes.SignedBlindedBeaconBlock) error) *MockPeerDasDownloadColumnsAndRecoverBlobsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockPeerDasDownloadColumnsAndRecoverBlobsCall) DoAndReturn(f func(context.Context, []*cltypes.SignedBeaconBlock) error) *MockPeerDasDownloadColumnsAndRecoverBlobsCall {
+func (c *MockPeerDasDownloadColumnsAndRecoverBlobsCall) DoAndReturn(f func(context.Context, []*cltypes.SignedBlindedBeaconBlock) error) *MockPeerDasDownloadColumnsAndRecoverBlobsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // DownloadOnlyCustodyColumns mocks base method.
-func (m *MockPeerDas) DownloadOnlyCustodyColumns(ctx context.Context, blocks []*cltypes.SignedBeaconBlock) error {
+func (m *MockPeerDas) DownloadOnlyCustodyColumns(arg0 context.Context, arg1 []*cltypes.SignedBlindedBeaconBlock) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DownloadOnlyCustodyColumns", ctx, blocks)
+	ret := m.ctrl.Call(m, "DownloadOnlyCustodyColumns", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DownloadOnlyCustodyColumns indicates an expected call of DownloadOnlyCustodyColumns.
-func (mr *MockPeerDasMockRecorder) DownloadOnlyCustodyColumns(ctx, blocks any) *MockPeerDasDownloadOnlyCustodyColumnsCall {
+func (mr *MockPeerDasMockRecorder) DownloadOnlyCustodyColumns(arg0, arg1 any) *MockPeerDasDownloadOnlyCustodyColumnsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadOnlyCustodyColumns", reflect.TypeOf((*MockPeerDas)(nil).DownloadOnlyCustodyColumns), ctx, blocks)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadOnlyCustodyColumns", reflect.TypeOf((*MockPeerDas)(nil).DownloadOnlyCustodyColumns), arg0, arg1)
 	return &MockPeerDasDownloadOnlyCustodyColumnsCall{Call: call}
 }
 
@@ -108,13 +107,13 @@ func (c *MockPeerDasDownloadOnlyCustodyColumnsCall) Return(arg0 error) *MockPeer
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockPeerDasDownloadOnlyCustodyColumnsCall) Do(f func(context.Context, []*cltypes.SignedBeaconBlock) error) *MockPeerDasDownloadOnlyCustodyColumnsCall {
+func (c *MockPeerDasDownloadOnlyCustodyColumnsCall) Do(f func(context.Context, []*cltypes.SignedBlindedBeaconBlock) error) *MockPeerDasDownloadOnlyCustodyColumnsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockPeerDasDownloadOnlyCustodyColumnsCall) DoAndReturn(f func(context.Context, []*cltypes.SignedBeaconBlock) error) *MockPeerDasDownloadOnlyCustodyColumnsCall {
+func (c *MockPeerDasDownloadOnlyCustodyColumnsCall) DoAndReturn(f func(context.Context, []*cltypes.SignedBlindedBeaconBlock) error) *MockPeerDasDownloadOnlyCustodyColumnsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -158,17 +157,17 @@ func (c *MockPeerDasIsArchivedModeCall) DoAndReturn(f func() bool) *MockPeerDasI
 }
 
 // IsBlobAlreadyRecovered mocks base method.
-func (m *MockPeerDas) IsBlobAlreadyRecovered(blockRoot common.Hash) bool {
+func (m *MockPeerDas) IsBlobAlreadyRecovered(arg0 common.Hash) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsBlobAlreadyRecovered", blockRoot)
+	ret := m.ctrl.Call(m, "IsBlobAlreadyRecovered", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // IsBlobAlreadyRecovered indicates an expected call of IsBlobAlreadyRecovered.
-func (mr *MockPeerDasMockRecorder) IsBlobAlreadyRecovered(blockRoot any) *MockPeerDasIsBlobAlreadyRecoveredCall {
+func (mr *MockPeerDasMockRecorder) IsBlobAlreadyRecovered(arg0 any) *MockPeerDasIsBlobAlreadyRecoveredCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsBlobAlreadyRecovered", reflect.TypeOf((*MockPeerDas)(nil).IsBlobAlreadyRecovered), blockRoot)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsBlobAlreadyRecovered", reflect.TypeOf((*MockPeerDas)(nil).IsBlobAlreadyRecovered), arg0)
 	return &MockPeerDasIsBlobAlreadyRecoveredCall{Call: call}
 }
 
@@ -196,17 +195,17 @@ func (c *MockPeerDasIsBlobAlreadyRecoveredCall) DoAndReturn(f func(common.Hash) 
 }
 
 // IsColumnOverHalf mocks base method.
-func (m *MockPeerDas) IsColumnOverHalf(blockRoot common.Hash) bool {
+func (m *MockPeerDas) IsColumnOverHalf(arg0 common.Hash) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsColumnOverHalf", blockRoot)
+	ret := m.ctrl.Call(m, "IsColumnOverHalf", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // IsColumnOverHalf indicates an expected call of IsColumnOverHalf.
-func (mr *MockPeerDasMockRecorder) IsColumnOverHalf(blockRoot any) *MockPeerDasIsColumnOverHalfCall {
+func (mr *MockPeerDasMockRecorder) IsColumnOverHalf(arg0 any) *MockPeerDasIsColumnOverHalfCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsColumnOverHalf", reflect.TypeOf((*MockPeerDas)(nil).IsColumnOverHalf), blockRoot)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsColumnOverHalf", reflect.TypeOf((*MockPeerDas)(nil).IsColumnOverHalf), arg0)
 	return &MockPeerDasIsColumnOverHalfCall{Call: call}
 }
 
@@ -234,18 +233,18 @@ func (c *MockPeerDasIsColumnOverHalfCall) DoAndReturn(f func(common.Hash) bool) 
 }
 
 // IsDataAvailable mocks base method.
-func (m *MockPeerDas) IsDataAvailable(blockRoot common.Hash) (bool, error) {
+func (m *MockPeerDas) IsDataAvailable(arg0 common.Hash) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsDataAvailable", blockRoot)
+	ret := m.ctrl.Call(m, "IsDataAvailable", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // IsDataAvailable indicates an expected call of IsDataAvailable.
-func (mr *MockPeerDasMockRecorder) IsDataAvailable(blockRoot any) *MockPeerDasIsDataAvailableCall {
+func (mr *MockPeerDasMockRecorder) IsDataAvailable(arg0 any) *MockPeerDasIsDataAvailableCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDataAvailable", reflect.TypeOf((*MockPeerDas)(nil).IsDataAvailable), blockRoot)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDataAvailable", reflect.TypeOf((*MockPeerDas)(nil).IsDataAvailable), arg0)
 	return &MockPeerDasIsDataAvailableCall{Call: call}
 }
 
@@ -273,17 +272,17 @@ func (c *MockPeerDasIsDataAvailableCall) DoAndReturn(f func(common.Hash) (bool, 
 }
 
 // Prune mocks base method.
-func (m *MockPeerDas) Prune(keepSlotDistance uint64) error {
+func (m *MockPeerDas) Prune(arg0 uint64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Prune", keepSlotDistance)
+	ret := m.ctrl.Call(m, "Prune", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Prune indicates an expected call of Prune.
-func (mr *MockPeerDasMockRecorder) Prune(keepSlotDistance any) *MockPeerDasPruneCall {
+func (mr *MockPeerDasMockRecorder) Prune(arg0 any) *MockPeerDasPruneCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prune", reflect.TypeOf((*MockPeerDas)(nil).Prune), keepSlotDistance)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prune", reflect.TypeOf((*MockPeerDas)(nil).Prune), arg0)
 	return &MockPeerDasPruneCall{Call: call}
 }
 
@@ -349,17 +348,17 @@ func (c *MockPeerDasStateReaderCall) DoAndReturn(f func() peerdasstate.PeerDasSt
 }
 
 // TryScheduleRecover mocks base method.
-func (m *MockPeerDas) TryScheduleRecover(slot uint64, blockRoot common.Hash) error {
+func (m *MockPeerDas) TryScheduleRecover(arg0 uint64, arg1 common.Hash) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TryScheduleRecover", slot, blockRoot)
+	ret := m.ctrl.Call(m, "TryScheduleRecover", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // TryScheduleRecover indicates an expected call of TryScheduleRecover.
-func (mr *MockPeerDasMockRecorder) TryScheduleRecover(slot, blockRoot any) *MockPeerDasTryScheduleRecoverCall {
+func (mr *MockPeerDasMockRecorder) TryScheduleRecover(arg0, arg1 any) *MockPeerDasTryScheduleRecoverCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TryScheduleRecover", reflect.TypeOf((*MockPeerDas)(nil).TryScheduleRecover), slot, blockRoot)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TryScheduleRecover", reflect.TypeOf((*MockPeerDas)(nil).TryScheduleRecover), arg0, arg1)
 	return &MockPeerDasTryScheduleRecoverCall{Call: call}
 }
 
@@ -387,15 +386,15 @@ func (c *MockPeerDasTryScheduleRecoverCall) DoAndReturn(f func(uint64, common.Ha
 }
 
 // UpdateValidatorsCustody mocks base method.
-func (m *MockPeerDas) UpdateValidatorsCustody(cgc uint64) {
+func (m *MockPeerDas) UpdateValidatorsCustody(arg0 uint64) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UpdateValidatorsCustody", cgc)
+	m.ctrl.Call(m, "UpdateValidatorsCustody", arg0)
 }
 
 // UpdateValidatorsCustody indicates an expected call of UpdateValidatorsCustody.
-func (mr *MockPeerDasMockRecorder) UpdateValidatorsCustody(cgc any) *MockPeerDasUpdateValidatorsCustodyCall {
+func (mr *MockPeerDasMockRecorder) UpdateValidatorsCustody(arg0 any) *MockPeerDasUpdateValidatorsCustodyCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateValidatorsCustody", reflect.TypeOf((*MockPeerDas)(nil).UpdateValidatorsCustody), cgc)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateValidatorsCustody", reflect.TypeOf((*MockPeerDas)(nil).UpdateValidatorsCustody), arg0)
 	return &MockPeerDasUpdateValidatorsCustodyCall{Call: call}
 }
 

--- a/cl/das/peer_das.go
+++ b/cl/das/peer_das.go
@@ -26,8 +26,8 @@ import (
 
 //go:generate mockgen -typed=true -destination=mock_services/peer_das_mock.go -package=mock_services . PeerDas
 type PeerDas interface {
-	DownloadColumnsAndRecoverBlobs(ctx context.Context, blocks []*cltypes.SignedBeaconBlock) error
-	DownloadOnlyCustodyColumns(ctx context.Context, blocks []*cltypes.SignedBeaconBlock) error
+	DownloadColumnsAndRecoverBlobs(ctx context.Context, blocks []*cltypes.SignedBlindedBeaconBlock) error
+	DownloadOnlyCustodyColumns(ctx context.Context, blocks []*cltypes.SignedBlindedBeaconBlock) error
 	IsDataAvailable(blockRoot common.Hash) (bool, error)
 	Prune(keepSlotDistance uint64) error
 	UpdateValidatorsCustody(cgc uint64)
@@ -388,7 +388,7 @@ var (
 )
 
 // DownloadMissingColumns downloads the missing columns for the given blocks but not recover the blobs
-func (d *peerdas) DownloadOnlyCustodyColumns(ctx context.Context, blocks []*cltypes.SignedBeaconBlock) error {
+func (d *peerdas) DownloadOnlyCustodyColumns(ctx context.Context, blocks []*cltypes.SignedBlindedBeaconBlock) error {
 	custodyColumns, err := d.state.GetMyCustodyColumns()
 	if err != nil {
 		return err
@@ -400,9 +400,9 @@ func (d *peerdas) DownloadOnlyCustodyColumns(ctx context.Context, blocks []*clty
 	return d.runDownload(ctx, req, false)
 }
 
-func (d *peerdas) DownloadColumnsAndRecoverBlobs(ctx context.Context, blocks []*cltypes.SignedBeaconBlock) error {
+func (d *peerdas) DownloadColumnsAndRecoverBlobs(ctx context.Context, blocks []*cltypes.SignedBlindedBeaconBlock) error {
 	// filter out blocks that don't need to be processed
-	blocksToProcess := []*cltypes.SignedBeaconBlock{}
+	blocksToProcess := []*cltypes.SignedBlindedBeaconBlock{}
 	for _, block := range blocks {
 		if block.Version() < clparams.FuluVersion ||
 			block.Block.Body.BlobKzgCommitments == nil ||
@@ -604,19 +604,19 @@ mainloop:
 type downloadRequest struct {
 	beaconConfig           *clparams.BeaconChainConfig
 	mutex                  sync.RWMutex
-	blockRootToBeaconBlock map[common.Hash]*cltypes.SignedBeaconBlock
+	blockRootToBeaconBlock map[common.Hash]*cltypes.SignedBlindedBeaconBlock
 	downloadTable          map[common.Hash]map[uint64]bool
 	cacheRequest           *solid.ListSSZ[*cltypes.DataColumnsByRootIdentifier]
 }
 
 func initializeDownloadRequest(
-	blocks []*cltypes.SignedBeaconBlock,
+	blocks []*cltypes.SignedBlindedBeaconBlock,
 	beaconConfig *clparams.BeaconChainConfig,
 	columnStorage blob_storage.DataColumnStorage,
 	expectedColumns map[cltypes.CustodyIndex]bool,
 ) (*downloadRequest, error) {
 	downloadTable := make(map[common.Hash]map[uint64]bool)
-	blockRootToBeaconBlock := make(map[common.Hash]*cltypes.SignedBeaconBlock)
+	blockRootToBeaconBlock := make(map[common.Hash]*cltypes.SignedBlindedBeaconBlock)
 	for _, block := range blocks {
 		if block.Version() < clparams.FuluVersion {
 			continue

--- a/cl/das/state/mock_services/peer_das_state_reader_mock.go
+++ b/cl/das/state/mock_services/peer_das_state_reader_mock.go
@@ -19,7 +19,6 @@ import (
 type MockPeerDasStateReader struct {
 	ctrl     *gomock.Controller
 	recorder *MockPeerDasStateReaderMockRecorder
-	isgomock struct{}
 }
 
 // MockPeerDasStateReaderMockRecorder is the mock recorder for MockPeerDasStateReader.

--- a/cl/phase1/stages/chain_tip_sync.go
+++ b/cl/phase1/stages/chain_tip_sync.go
@@ -94,12 +94,17 @@ func fetchBlocksFromReqResp(ctx context.Context, cfg *Cfg, from uint64, count ui
 			wg.Add(1)
 			go func(block *cltypes.SignedBeaconBlock) {
 				defer wg.Done()
+				blinded, err := block.Blinded()
+				if err != nil {
+					log.Warn("[chainTipSync] failed to get blinded block", "err", err)
+					return
+				}
 				if cfg.caplinConfig.ArchiveBlobs || cfg.caplinConfig.ImmediateBlobsBackfilling {
-					if err := cfg.peerDas.DownloadColumnsAndRecoverBlobs(ctx, []*cltypes.SignedBeaconBlock{block}); err != nil {
+					if err := cfg.peerDas.DownloadColumnsAndRecoverBlobs(ctx, []*cltypes.SignedBlindedBeaconBlock{blinded}); err != nil {
 						log.Warn("[chainTipSync] failed to download columns and recover blobs", "err", err)
 					}
 				} else {
-					if err := cfg.peerDas.DownloadOnlyCustodyColumns(ctx, []*cltypes.SignedBeaconBlock{block}); err != nil {
+					if err := cfg.peerDas.DownloadOnlyCustodyColumns(ctx, []*cltypes.SignedBlindedBeaconBlock{blinded}); err != nil {
 						log.Warn("[chainTipSync] failed to download only custody columns", "err", err)
 					}
 				}

--- a/cl/phase1/stages/clstages.go
+++ b/cl/phase1/stages/clstages.go
@@ -252,7 +252,7 @@ func ConsensusClStages(ctx context.Context,
 					startingSlot := cfg.state.LatestBlockHeader().Slot
 					downloader := network2.NewBackwardBeaconDownloader(ctx, cfg.rpc, cfg.sn, cfg.executionClient, cfg.indiciesDB)
 
-					if err := SpawnStageHistoryDownload(StageHistoryReconstruction(downloader, cfg.antiquary, cfg.sn, cfg.indiciesDB, cfg.executionClient, cfg.beaconCfg, cfg.caplinConfig, false, startingRoot, startingSlot, cfg.dirs.Tmp, 600*time.Millisecond, cfg.blockCollector, cfg.blockReader, cfg.blobStore, logger), context.Background(), logger); err != nil {
+					if err := SpawnStageHistoryDownload(StageHistoryReconstruction(downloader, cfg.antiquary, cfg.sn, cfg.indiciesDB, cfg.executionClient, cfg.beaconCfg, cfg.caplinConfig, false, startingRoot, startingSlot, cfg.dirs.Tmp, 600*time.Millisecond, cfg.blockCollector, cfg.blockReader, cfg.blobStore, cfg.forkChoice, logger), context.Background(), logger); err != nil {
 						cfg.hasDownloaded = false
 						return err
 					}

--- a/cl/phase1/stages/forward_sync.go
+++ b/cl/phase1/stages/forward_sync.go
@@ -133,7 +133,12 @@ func downloadBlobs(ctx context.Context, logger log.Logger, cfg *Cfg, highestBloc
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				blocks := []*cltypes.SignedBeaconBlock{fuluBlocks[i]}
+				blinded, err := fuluBlocks[i].Blinded()
+				if err != nil {
+					logger.Warn("[Caplin] failed to get blinded block", "err", err)
+					return
+				}
+				blocks := []*cltypes.SignedBlindedBeaconBlock{blinded}
 				if cfg.caplinConfig.ArchiveBlobs || cfg.caplinConfig.ImmediateBlobsBackfilling {
 					if err = cfg.peerDas.DownloadColumnsAndRecoverBlobs(ctx, blocks); err != nil {
 						logger.Warn("[Caplin] Failed to download columns and recover blobs", "err", err)

--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -476,6 +476,7 @@ func downloadBlobHistoryWorker(cfg StageHistoryReconstructionCfg, ctx context.Co
 				}
 			}
 		}
+		time.Sleep(cfg.backfillingThrottling) // throttle to 0.6 second for backfilling
 	}
 
 	if shouldLog {

--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -418,7 +418,7 @@ func downloadBlobHistoryWorker(cfg StageHistoryReconstructionCfg, ctx context.Co
 		default:
 		}
 
-		// separate pre-fulu blocks from post-fulu blocks (this will be legacy code 10mins post-hardfork but we need so this looks ugly)
+		// separate pre-fulu blocks from post-fulu blocks (this will be legacy code 10mins post-hardfork but we need it for now so this looks ugly)
 		preFuluBlocks := make([]*cltypes.SignedBlindedBeaconBlock, 0, len(batch))
 		postFuluBlocks := make([]*cltypes.SignedBlindedBeaconBlock, 0, len(batch))
 		for _, block := range batch {

--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -463,11 +463,11 @@ func downloadBlobHistoryWorker(cfg StageHistoryReconstructionCfg, ctx context.Co
 		// WIP: easy but need to think about this.
 
 		if len(postFuluBlocks) > 0 {
-			peerdas := cfg.forkchoiceState.GetPeerDas()
-			if err := peerdas.DownloadColumnsAndRecoverBlobs(ctx, postFuluBlocks); err != nil {
+			if err := cfg.forkchoiceState.GetPeerDas().DownloadColumnsAndRecoverBlobs(ctx, postFuluBlocks); err != nil {
 				return fmt.Errorf("error downloading blobs for post-fulu blocks: %w", err)
 			}
 		}
+		fmt.Println("[Blobs-Downloader] Downloaded blobs for slot", "blocks", len(batch), "postFuluBlocks", len(postFuluBlocks), "preFuluBlocks", len(preFuluBlocks), "currentSlot", currentSlot)
 		time.Sleep(cfg.backfillingThrottling) // throttle to 0.6 second for backfilling
 	}
 

--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -476,7 +476,7 @@ func downloadBlobHistoryWorker(cfg StageHistoryReconstructionCfg, ctx context.Co
 				}
 			}
 		}
-		fmt.Println("[Blobs-Downloader] Downloaded blobs for slot", "blocks", len(batch), "postFuluBlocks", len(postFuluBlocks), "preFuluBlocks", len(preFuluBlocks), "currentSlot", currentSlot)
+		//fmt.Println("[Blobs-Downloader] Downloaded blobs for slot", "blocks", len(batch), "postFuluBlocks", len(postFuluBlocks), "preFuluBlocks", len(preFuluBlocks), "currentSlot", currentSlot)
 		time.Sleep(cfg.backfillingThrottling) // throttle to 0.6 second for backfilling
 	}
 

--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -476,7 +476,6 @@ func downloadBlobHistoryWorker(cfg StageHistoryReconstructionCfg, ctx context.Co
 				}
 			}
 		}
-		//fmt.Println("[Blobs-Downloader] Downloaded blobs for slot", "blocks", len(batch), "postFuluBlocks", len(postFuluBlocks), "preFuluBlocks", len(preFuluBlocks), "currentSlot", currentSlot)
 		time.Sleep(cfg.backfillingThrottling) // throttle to 0.6 second for backfilling
 	}
 

--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -350,7 +350,6 @@ func downloadBlobHistoryWorker(cfg StageHistoryReconstructionCfg, ctx context.Co
 	if !cfg.caplinConfig.ArchiveBlobs && cfg.caplinConfig.ImmediateBlobsBackfilling {
 		targetSlot = currentSlot - min(currentSlot, cfg.beaconCfg.MinSlotsForBlobsSidecarsRequest())
 	}
-	time.Sleep(1000 * time.Hour)
 	logger.Info("[Blobs-Downloader] Downloading blobs backwards", "slot", currentSlot)
 
 	for currentSlot >= targetSlot {

--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -476,7 +476,6 @@ func downloadBlobHistoryWorker(cfg StageHistoryReconstructionCfg, ctx context.Co
 				}
 			}
 		}
-		time.Sleep(cfg.backfillingThrottling) // throttle to 0.6 second for backfilling
 	}
 
 	if shouldLog {

--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -347,6 +347,7 @@ func downloadBlobHistoryWorker(cfg StageHistoryReconstructionCfg, ctx context.Co
 	if !cfg.caplinConfig.ArchiveBlobs && cfg.caplinConfig.ImmediateBlobsBackfilling {
 		targetSlot = currentSlot - min(currentSlot, cfg.beaconCfg.MinSlotsForBlobsSidecarsRequest())
 	}
+	time.Sleep(1000 * time.Hour)
 	logger.Info("[Blobs-Downloader] Downloading blobs backwards", "slot", currentSlot)
 
 	for currentSlot >= targetSlot {
@@ -409,6 +410,7 @@ func downloadBlobHistoryWorker(cfg StageHistoryReconstructionCfg, ctx context.Co
 			logger.Info("[Blobs-Downloader] Downloading blobs backwards", "slot", currentSlot, "blks/sec", blkSecStr)
 		default:
 		}
+
 		// Generate the request
 		req, err := network.BlobsIdentifiersFromBlindedBlocks(batch, cfg.beaconCfg)
 		if err != nil {

--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -462,12 +462,12 @@ func downloadBlobHistoryWorker(cfg StageHistoryReconstructionCfg, ctx context.Co
 		}
 		// WIP: easy but need to think about this.
 
-		// if len(postFuluBlocks) > 0 {
-		// 	peerdas := cfg.forkchoiceState.GetPeerDas()
-		// 	if err := peerdas.DownloadColumnsAndRecoverBlobs(ctx, postFuluBlocks); err != nil {
-		// 		return fmt.Errorf("error downloading blobs for post-fulu blocks: %w", err)
-		// 	}
-		// }
+		if len(postFuluBlocks) > 0 {
+			peerdas := cfg.forkchoiceState.GetPeerDas()
+			if err := peerdas.DownloadColumnsAndRecoverBlobs(ctx, postFuluBlocks); err != nil {
+				return fmt.Errorf("error downloading blobs for post-fulu blocks: %w", err)
+			}
+		}
 		time.Sleep(cfg.backfillingThrottling) // throttle to 0.6 second for backfilling
 	}
 

--- a/cl/rpc/rpc.go
+++ b/cl/rpc/rpc.go
@@ -129,7 +129,7 @@ func (b *BeaconRpcP2P) SendColumnSidecarsByRootIdentifierReq(
 	}
 
 	data := common.CopyBytes(buffer.Bytes())
-	responsePacket, pid, err := b.sendRequestWithPeer(ctx, communication.DataColumnSidecarsByRootProtocolV1, data, pid)
+	responsePacket, pid, err := b.sendRequest(ctx, communication.DataColumnSidecarsByRootProtocolV1, data)
 	fmt.Println("responsePacket", responsePacket, "pid", pid, "cgc", cgc, err)
 	if err != nil {
 		return nil, pid, 0, err

--- a/cl/rpc/rpc.go
+++ b/cl/rpc/rpc.go
@@ -130,7 +130,7 @@ func (b *BeaconRpcP2P) SendColumnSidecarsByRootIdentifierReq(
 
 	data := common.CopyBytes(buffer.Bytes())
 	responsePacket, pid, err := b.sendRequest(ctx, communication.DataColumnSidecarsByRootProtocolV1, data)
-	fmt.Println("responsePacket", len(responsePacket), "pid", pid, "cgc", cgc, err)
+	//fmt.Println("responsePacket", len(responsePacket), "pid", pid, "cgc", cgc, err)
 	if err != nil {
 		return nil, pid, 0, err
 	}

--- a/cl/rpc/rpc.go
+++ b/cl/rpc/rpc.go
@@ -133,6 +133,7 @@ func (b *BeaconRpcP2P) SendColumnSidecarsByRootIdentifierReq(
 	if err != nil {
 		return nil, pid, 0, err
 	}
+	fmt.Println("responsePacket", responsePacket, "pid", pid, "cgc", cgc)
 
 	ColumnSidecars := []*cltypes.DataColumnSidecar{}
 	for _, data := range responsePacket {

--- a/cl/rpc/rpc.go
+++ b/cl/rpc/rpc.go
@@ -129,7 +129,7 @@ func (b *BeaconRpcP2P) SendColumnSidecarsByRootIdentifierReq(
 	}
 
 	data := common.CopyBytes(buffer.Bytes())
-	responsePacket, pid, err := b.sendRequestWithPeer(ctx, communication.DataColumnSidecarsByRootProtocolV1, data, pid)
+	responsePacket, pid, err := b.sendRequest(ctx, communication.DataColumnSidecarsByRootProtocolV1, data)
 	fmt.Println("responsePacket", len(responsePacket), "pid", pid, "cgc", cgc, err)
 	if err != nil {
 		return nil, pid, 0, err

--- a/cl/rpc/rpc.go
+++ b/cl/rpc/rpc.go
@@ -129,7 +129,7 @@ func (b *BeaconRpcP2P) SendColumnSidecarsByRootIdentifierReq(
 	}
 
 	data := common.CopyBytes(buffer.Bytes())
-	responsePacket, pid, err := b.sendRequest(ctx, communication.DataColumnSidecarsByRootProtocolV1, data)
+	responsePacket, pid, err := b.sendRequestWithPeer(ctx, communication.DataColumnSidecarsByRootProtocolV1, data, pid)
 	fmt.Println("responsePacket", len(responsePacket), "pid", pid, "cgc", cgc, err)
 	if err != nil {
 		return nil, pid, 0, err

--- a/cl/rpc/rpc.go
+++ b/cl/rpc/rpc.go
@@ -130,10 +130,10 @@ func (b *BeaconRpcP2P) SendColumnSidecarsByRootIdentifierReq(
 
 	data := common.CopyBytes(buffer.Bytes())
 	responsePacket, pid, err := b.sendRequestWithPeer(ctx, communication.DataColumnSidecarsByRootProtocolV1, data, pid)
+	fmt.Println("responsePacket", responsePacket, "pid", pid, "cgc", cgc, err)
 	if err != nil {
 		return nil, pid, 0, err
 	}
-	fmt.Println("responsePacket", responsePacket, "pid", pid, "cgc", cgc)
 
 	ColumnSidecars := []*cltypes.DataColumnSidecar{}
 	for _, data := range responsePacket {

--- a/cl/rpc/rpc.go
+++ b/cl/rpc/rpc.go
@@ -130,7 +130,7 @@ func (b *BeaconRpcP2P) SendColumnSidecarsByRootIdentifierReq(
 
 	data := common.CopyBytes(buffer.Bytes())
 	responsePacket, pid, err := b.sendRequest(ctx, communication.DataColumnSidecarsByRootProtocolV1, data)
-	fmt.Println("responsePacket", responsePacket, "pid", pid, "cgc", cgc, err)
+	fmt.Println("responsePacket", len(responsePacket), "pid", pid, "cgc", cgc, err)
 	if err != nil {
 		return nil, pid, 0, err
 	}

--- a/cl/sentinel/handlers/handlers.go
+++ b/cl/sentinel/handlers/handlers.go
@@ -123,7 +123,7 @@ func NewConsensusHandlers(
 		communication.PingProtocolV1:                        c.pingHandler,
 		communication.GoodbyeProtocolV1:                     c.goodbyeHandler,
 		communication.StatusProtocolV1:                      c.statusHandler,
-		communication.StatusProtocolV2:                      c.statusHandler,
+		communication.StatusProtocolV2:                      c.statusHandler2,
 		communication.MetadataProtocolV1:                    c.metadataV1Handler,
 		communication.MetadataProtocolV2:                    c.metadataV2Handler,
 		communication.MetadataProtocolV3:                    c.metadataV3Handler,

--- a/cl/sentinel/handlers/handlers.go
+++ b/cl/sentinel/handlers/handlers.go
@@ -123,7 +123,7 @@ func NewConsensusHandlers(
 		communication.PingProtocolV1:                        c.pingHandler,
 		communication.GoodbyeProtocolV1:                     c.goodbyeHandler,
 		communication.StatusProtocolV1:                      c.statusHandler,
-		communication.StatusProtocolV2:                      c.statusHandler2,
+		communication.StatusProtocolV2:                      c.statusHandler,
 		communication.MetadataProtocolV1:                    c.metadataV1Handler,
 		communication.MetadataProtocolV2:                    c.metadataV2Handler,
 		communication.MetadataProtocolV3:                    c.metadataV3Handler,

--- a/cl/sentinel/handlers/heartbeats.go
+++ b/cl/sentinel/handlers/heartbeats.go
@@ -17,7 +17,6 @@
 package handlers
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/libp2p/go-libp2p/core/network"
@@ -121,7 +120,6 @@ func (c *ConsensusHandlers) metadataV3Handler(s network.Stream) error {
 }
 
 func (c *ConsensusHandlers) statusHandler2(s network.Stream) error {
-	fmt.Println("statusHandler2 called")
 	return ssz_snappy.EncodeAndWrite(s, c.hs.Status(), SuccessfulResponsePrefix)
 }
 

--- a/cl/sentinel/handlers/heartbeats.go
+++ b/cl/sentinel/handlers/heartbeats.go
@@ -17,6 +17,7 @@
 package handlers
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/libp2p/go-libp2p/core/network"
@@ -119,7 +120,11 @@ func (c *ConsensusHandlers) metadataV3Handler(s network.Stream) error {
 	}, SuccessfulResponsePrefix)
 }
 
-// TODO: Actually respond with proper status
+func (c *ConsensusHandlers) statusHandler2(s network.Stream) error {
+	fmt.Println("statusHandler2 called")
+	return ssz_snappy.EncodeAndWrite(s, c.hs.Status(), SuccessfulResponsePrefix)
+}
+
 func (c *ConsensusHandlers) statusHandler(s network.Stream) error {
 	return ssz_snappy.EncodeAndWrite(s, c.hs.Status(), SuccessfulResponsePrefix)
 }

--- a/cl/sentinel/handlers/heartbeats.go
+++ b/cl/sentinel/handlers/heartbeats.go
@@ -119,10 +119,6 @@ func (c *ConsensusHandlers) metadataV3Handler(s network.Stream) error {
 	}, SuccessfulResponsePrefix)
 }
 
-func (c *ConsensusHandlers) statusHandler2(s network.Stream) error {
-	return ssz_snappy.EncodeAndWrite(s, c.hs.Status(), SuccessfulResponsePrefix)
-}
-
 func (c *ConsensusHandlers) statusHandler(s network.Stream) error {
 	return ssz_snappy.EncodeAndWrite(s, c.hs.Status(), SuccessfulResponsePrefix)
 }

--- a/cl/sentinel/service/service.go
+++ b/cl/sentinel/service/service.go
@@ -88,6 +88,10 @@ func extractSubnetIndexByGossipTopic(name string) int {
 
 func (s *SentinelServer) BanPeer(_ context.Context, p *sentinelrpc.Peer) (*sentinelrpc.EmptyMessage, error) {
 	var pid peer.ID
+	active, _, _ := s.sentinel.GetPeersCount()
+	if active < gracePeerCount {
+		return &sentinelrpc.EmptyMessage{}, nil
+	}
 	if err := pid.UnmarshalText([]byte(p.Pid)); err != nil {
 		return nil, err
 	}

--- a/cmd/capcli/cli.go
+++ b/cmd/capcli/cli.go
@@ -186,7 +186,7 @@ func (c *Chain) Run(ctx *Context) error {
 	}
 
 	downloader := network.NewBackwardBeaconDownloader(ctx, beacon, nil, nil, db)
-	cfg := stages.StageHistoryReconstruction(downloader, antiquary.NewAntiquary(ctx, nil, nil, nil, nil, dirs, nil, nil, nil, nil, nil, nil, nil, false, false, false, false, nil), csn, db, nil, beaconConfig, clparams.CaplinConfig{}, true, bRoot, bs.Slot(), "/tmp", 300*time.Millisecond, nil, nil, blobStorage, log.Root())
+	cfg := stages.StageHistoryReconstruction(downloader, antiquary.NewAntiquary(ctx, nil, nil, nil, nil, dirs, nil, nil, nil, nil, nil, nil, nil, false, false, false, false, nil), csn, db, nil, beaconConfig, clparams.CaplinConfig{}, true, bRoot, bs.Slot(), "/tmp", 300*time.Millisecond, nil, nil, blobStorage, nil, log.Root())
 	return stages.SpawnStageHistoryDownload(cfg, ctx, log.Root())
 }
 


### PR DESCRIPTION
Code flexibility changes:

* `PeerDas` data structure to work with `blinded` blocks.

Core changes:

* adjusted the rate limiter to be more forgiving if we are subscribed to many column sidecar subnets
* added fulu handling to the backward downloader
* momentairly stopped using the pickPeerRoundRobin (maybe this change is not needed)