### PR TITLE
[r30] qa-tests: disable rpc integration tests on polygon 

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests-polygon.yml
+++ b/.github/workflows/qa-rpc-integration-tests-polygon.yml
@@ -19,6 +19,7 @@ on:
 
 jobs:
   bor-mainnet-rpc-integ-tests:
+    if: false # disabled
     concurrency:
       group: >-
         ${{


### PR DESCRIPTION
For disk space reasons, we are disabling tests on the 3.0 branch on the test runner.