### PR TITLE
downloader: avoid loading snapshot hashes for unsupported networks

### DIFF
--- a/erigon-db/downloader/downloadercfg/downloadercfg.go
+++ b/erigon-db/downloader/downloadercfg/downloadercfg.go
@@ -25,19 +25,15 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"slices"
 	"strings"
 	"time"
 
-	g "github.com/anacrolix/generics"
-
-	analog "github.com/anacrolix/log"
-
 	"golang.org/x/time/rate"
 
+	g "github.com/anacrolix/generics"
+	analog "github.com/anacrolix/log"
 	"github.com/anacrolix/torrent"
 
-	"github.com/erigontech/erigon-lib/chain/networkname"
 	"github.com/erigontech/erigon-lib/chain/snapcfg"
 	"github.com/erigontech/erigon-lib/common/datadir"
 	"github.com/erigontech/erigon-lib/common/dbg"
@@ -286,7 +282,7 @@ func New(
 // LoadSnapshotsHashes checks local preverified.toml. If file exists, used local hashes.
 // If there are no such file, try to fetch hashes from the web and create local file.
 func LoadSnapshotsHashes(ctx context.Context, dirs datadir.Dirs, chainName string) (*snapcfg.Cfg, error) {
-	if !slices.Contains(networkname.All, chainName) {
+	if _, known := snapcfg.KnownCfg(chainName); !known {
 		log.Root().Warn("No snapshot hashes for chain", "chain", chainName)
 		return snapcfg.NewNonSeededCfg(chainName), nil
 	}

--- a/polygon/chain/config.go
+++ b/polygon/chain/config.go
@@ -55,7 +55,9 @@ var (
 
 func init() {
 	chainspec.RegisterChain(networkname.Amoy, AmoyChainConfig, AmoyGenesisBlock(), AmoyGenesisHash, AmoyBootnodes, "")
-	chainspec.RegisterChain(networkname.BorDevnet, BorDevnetChainConfig, BorDevnetGenesisBlock(), BorDevnetGenesisHash, nil, "")
 	chainspec.RegisterChain(networkname.BorMainnet, BorMainnetChainConfig, BorMainnetGenesisBlock(), BorMainnetGenesisHash, BorMainnetBootnodes,
 		"enrtree://AKUEZKN7PSKVNR65FZDHECMKOJQSGPARGTPPBI7WS2VUL4EGR6XPC@pos.polygon-peers.io")
+
+	chainspec.RegisterChain(networkname.BorDevnet, BorDevnetChainConfig, BorDevnetGenesisBlock(), BorDevnetGenesisHash, nil, "")
+	delete(chainspec.NetworkNameByID, BorDevnetChainConfig.ChainID.Uint64()) // chain ID 1337 is used in non-Bor testing (e.g. Hive)
 }


### PR DESCRIPTION
Cherry pick PR #16348 into `release/3.1`