### PR TITLE
history: describe semantic

### DIFF
--- a/erigon-lib/kv/stream/stream.go
+++ b/erigon-lib/kv/stream/stream.go
@@ -100,7 +100,6 @@ func (it *ReverseRangeIter[T]) Next() (T, error) {
 	return v, nil
 }
 
-// UnionUno
 type UnionUno[T cmp.Ordered] struct {
 	x, y           Uno[T]
 	asc            bool
@@ -110,6 +109,8 @@ type UnionUno[T cmp.Ordered] struct {
 	limit          int
 }
 
+// Union - returns all elements that are in A, or in B, or in both. When duplicate elements - first stream (x) takes precedence.
+// in Set Theory: A ∪ B = {x | x ∈ A ∨ x ∈ B}
 func Union[T cmp.Ordered](x, y Uno[T], asc order.By, limit int) Uno[T] {
 	if x == nil && y == nil {
 		return &Empty[T]{}
@@ -206,6 +207,8 @@ type Intersected[T cmp.Ordered] struct {
 	err                error
 }
 
+// Intersect - returns only elements that exist in BOTH A AND B
+// Set Theory Definition: A ∩ B = {x | x ∈ A ∧ x ∈ B}
 func Intersect[T cmp.Ordered](x, y Uno[T], asc order.By, limit int) Uno[T] {
 	if x == nil || y == nil || !x.HasNext() || !y.HasNext() {
 		return &Empty[T]{}

--- a/erigon-lib/state/history.go
+++ b/erigon-lib/state/history.go
@@ -1367,6 +1367,7 @@ func (ht *HistoryRoTx) iterateChangedRecent(fromTxNum, toTxNum int, asc order.By
 	return s, nil
 }
 
+// HistoryRange producing state-patch for Unwind - return state-patch for Unwind: "what keys changed between `[from, to)` and what was their value BEFORE txNum"
 func (ht *HistoryRoTx) HistoryRange(fromTxNum, toTxNum int, asc order.By, limit int, roTx kv.Tx) (stream.KV, error) {
 	if asc == order.Desc {
 		panic("not supported yet")
@@ -1379,7 +1380,7 @@ func (ht *HistoryRoTx) HistoryRange(fromTxNum, toTxNum int, asc order.By, limit 
 	if err != nil {
 		return nil, err
 	}
-	return stream.IntersectKV(itOnDB, itOnFiles, limit), nil
+	return stream.UnionKV(itOnDB, itOnFiles, limit), nil
 }
 
 func (ht *HistoryRoTx) idxRangeOnDB(key []byte, startTxNum, endTxNum int, asc order.By, limit int, roTx kv.Tx) (stream.U64, error) {

--- a/erigon-lib/state/history_stream.go
+++ b/erigon-lib/state/history_stream.go
@@ -376,7 +376,7 @@ func (hi *HistoryRangeAsOfDB) Next() ([]byte, []byte, error) {
 	return common.Copy(hi.kBackup), common.Copy(hi.vBackup), nil
 }
 
-// HistoryChangesIterFiles - producing state-patch for Unwind: "what keys changed between `[from, to)` and what was their value BEFORE txNum"
+// HistoryChangesIterFiles - producing state-patch for Unwind - return state-patch for Unwind: "what keys changed between `[from, to)` and what was their value BEFORE txNum"
 // Performs multi-way Union of frozen files. Later files override earlier files for same key
 type HistoryChangesIterFiles struct {
 	hc         *HistoryRoTx

--- a/erigon-lib/state/history_stream.go
+++ b/erigon-lib/state/history_stream.go
@@ -32,7 +32,9 @@ import (
 	"github.com/erigontech/erigon-lib/seg"
 )
 
-// StateAsOfIter - returns state range at given time in history
+// HistoryRangeAsOfFiles - Returns the state as it existed AT a specific txNum (before txNum executed)
+// For each key, finds the latest value that was valid at startTxNum.
+// USAGE: RangeAsOf() - "What was the state at txNum=X?" - so we can execute txNum=X on this state
 type HistoryRangeAsOfFiles struct {
 	hc    *HistoryRoTx
 	limit int
@@ -116,7 +118,7 @@ func (hi *HistoryRangeAsOfFiles) advanceInFiles() error {
 			continue
 		}
 
-		if bytes.Equal(key, hi.nextKey) {
+		if bytes.Equal(key, hi.nextKey) { // deduplication
 			continue
 		}
 
@@ -374,11 +376,13 @@ func (hi *HistoryRangeAsOfDB) Next() ([]byte, []byte, error) {
 	return common.Copy(hi.kBackup), common.Copy(hi.vBackup), nil
 }
 
+// HistoryChangesIterFiles - producing state-patch for Unwind: "what keys changed between `[from, to)` and what was their value BEFORE txNum"
+// Performs multi-way Union of frozen files. Later files override earlier files for same key
 type HistoryChangesIterFiles struct {
 	hc         *HistoryRoTx
 	nextVal    []byte
 	nextKey    []byte
-	h          ReconHeap
+	h          ReconHeap // Multi-way merge heap across frozen files
 	startTxNum uint64
 	endTxNum   int
 	startTxKey [8]byte
@@ -405,7 +409,7 @@ func (hi *HistoryChangesIterFiles) advance() error {
 			heap.Push(&hi.h, top)
 		}
 
-		if bytes.Equal(key, hi.nextKey) {
+		if bytes.Equal(key, hi.nextKey) { // deduplication
 			continue
 		}
 		txNum, ok := multiencseq.Seek(top.startTxNum, idxVal, hi.startTxNum)


### PR DESCRIPTION
- seems `stream.IntercectKV` was exactly same as `UnionKV`. (while `stream.Intersect` is correct). Removed it.
- added more docs to `HistoryRange` method 
- don't rename methods much now - to not disturb cherry-picks between `3.1` and `main`. will do after `3.1.1` release - in both places.