### PR TITLE
cp: fix polygon's ii and receipt values for system tx (#16360)

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -263,7 +263,7 @@ func rlpHash(x interface{}) (h common.Hash) {
 	return h
 }
 
-func SysCallContract(contract common.Address, data []byte, chainConfig *chain.Config, ibs *state.IntraBlockState, header *types.Header, engine consensus.EngineReader, constCall bool, tracing *tracing.Hooks, vmCfg vm.Config) (result []byte, err error) {
+func SysCallContract(contract common.Address, data []byte, chainConfig *chain.Config, ibs *state.IntraBlockState, header *types.Header, engine consensus.EngineReader, constCall bool, vmCfg vm.Config) (result []byte, err error) {
 	isBor := chainConfig.Bor != nil
 	var author *common.Address
 	if isBor {
@@ -272,10 +272,10 @@ func SysCallContract(contract common.Address, data []byte, chainConfig *chain.Co
 		author = &state.SystemAddress
 	}
 	blockContext := NewEVMBlockContext(header, GetHashFn(header, nil), engine, author, chainConfig)
-	return SysCallContractWithBlockContext(contract, data, chainConfig, ibs, blockContext, constCall, tracing, vmCfg)
+	return SysCallContractWithBlockContext(contract, data, chainConfig, ibs, blockContext, constCall, vmCfg)
 }
 
-func SysCallContractWithBlockContext(contract common.Address, data []byte, chainConfig *chain.Config, ibs *state.IntraBlockState, blockContext evmtypes.BlockContext, constCall bool, tracer *tracing.Hooks, vmCfg vm.Config) (result []byte, err error) {
+func SysCallContractWithBlockContext(contract common.Address, data []byte, chainConfig *chain.Config, ibs *state.IntraBlockState, blockContext evmtypes.BlockContext, constCall bool, vmCfg vm.Config) (result []byte, err error) {
 	isBor := chainConfig.Bor != nil
 	msg := types.NewMessage(
 		state.SystemAddress,
@@ -356,7 +356,7 @@ func FinalizeBlockExecution(
 	tracer *tracing.Hooks,
 ) (newBlock *types.Block, retRequests types.FlatRequests, err error) {
 	syscall := func(contract common.Address, data []byte) ([]byte, error) {
-		ret, err := SysCallContract(contract, data, cc, ibs, header, engine, false /* constCall */, tracer, vm.Config{})
+		ret, err := SysCallContract(contract, data, cc, ibs, header, engine, false /* constCall */, vm.Config{})
 		return ret, err
 	}
 
@@ -380,7 +380,7 @@ func InitializeBlockExecution(engine consensus.Engine, chain consensus.ChainHead
 	cc *chain.Config, ibs *state.IntraBlockState, stateWriter state.StateWriter, logger log.Logger, tracer *tracing.Hooks,
 ) error {
 	engine.Initialize(cc, chain, header, ibs, func(contract common.Address, data []byte, ibState *state.IntraBlockState, header *types.Header, constCall bool) ([]byte, error) {
-		ret, err := SysCallContract(contract, data, cc, ibState, header, engine, constCall, tracer, vm.Config{})
+		ret, err := SysCallContract(contract, data, cc, ibState, header, engine, constCall, vm.Config{})
 		return ret, err
 	}, logger, tracer)
 	if stateWriter == nil {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -160,7 +160,7 @@ func applyMessage(evm *vm.EVM, msg Message, gp *GasPool, refunds bool, gasBailou
 		blockContext := evm.Context
 		blockContext.Coinbase = state.SystemAddress
 		syscall := func(contract common.Address, data []byte) ([]byte, error) {
-			ret, err := SysCallContractWithBlockContext(contract, data, evm.ChainConfig(), evm.IntraBlockState(), blockContext, true, nil, evm.Config())
+			ret, err := SysCallContractWithBlockContext(contract, data, evm.ChainConfig(), evm.IntraBlockState(), blockContext, true, evm.Config())
 			return ret, err
 		}
 		msg.SetIsFree(engine.IsServiceTransaction(msg.From(), syscall))

--- a/erigon-lib/state/version_schema.go
+++ b/erigon-lib/state/version_schema.go
@@ -37,13 +37,13 @@ func InitSchemas() {
 	Schema.CommitmentDomain.hist.iiCfg.version.DataEF = version.V2_0_standart
 	Schema.CommitmentDomain.hist.iiCfg.version.AccessorEFI = version.V2_0_standart
 
-	Schema.ReceiptDomain.version.DataKV = version.V2_0_standart
-	Schema.ReceiptDomain.version.AccessorBT = version.V1_0_standart
-	Schema.ReceiptDomain.version.AccessorKVEI = version.V1_0_standart
-	Schema.ReceiptDomain.hist.version.DataV = version.V2_0_standart
-	Schema.ReceiptDomain.hist.version.AccessorVI = version.V1_0_standart
-	Schema.ReceiptDomain.hist.iiCfg.version.DataEF = version.V2_0_standart
-	Schema.ReceiptDomain.hist.iiCfg.version.AccessorEFI = version.V2_0_standart
+	Schema.ReceiptDomain.version.DataKV = version.V2_1_standart
+	Schema.ReceiptDomain.version.AccessorBT = version.V1_2_standart
+	Schema.ReceiptDomain.version.AccessorKVEI = version.V1_2_standart
+	Schema.ReceiptDomain.hist.version.DataV = version.V2_1_standart
+	Schema.ReceiptDomain.hist.version.AccessorVI = version.V1_2_standart
+	Schema.ReceiptDomain.hist.iiCfg.version.DataEF = version.V2_1_standart
+	Schema.ReceiptDomain.hist.iiCfg.version.AccessorEFI = version.V2_1_standart
 
 	Schema.RCacheDomain.version.DataKV = version.V2_0_standart
 	Schema.RCacheDomain.version.AccessorKVI = version.V2_0_standart
@@ -52,17 +52,17 @@ func InitSchemas() {
 	Schema.RCacheDomain.hist.iiCfg.version.DataEF = version.V2_0_standart
 	Schema.RCacheDomain.hist.iiCfg.version.AccessorEFI = version.V2_0_standart
 
-	Schema.LogAddrIdx.version.DataEF = version.V2_0_standart
-	Schema.LogAddrIdx.version.AccessorEFI = version.V2_0_standart
+	Schema.LogAddrIdx.version.DataEF = version.V2_1_standart
+	Schema.LogAddrIdx.version.AccessorEFI = version.V2_1_standart
 
-	Schema.LogTopicIdx.version.DataEF = version.V2_0_standart
-	Schema.LogTopicIdx.version.AccessorEFI = version.V2_0_standart
+	Schema.LogTopicIdx.version.DataEF = version.V2_1_standart
+	Schema.LogTopicIdx.version.AccessorEFI = version.V2_1_standart
 
-	Schema.TracesFromIdx.version.DataEF = version.V2_0_standart
-	Schema.TracesFromIdx.version.AccessorEFI = version.V2_0_standart
+	Schema.TracesFromIdx.version.DataEF = version.V2_1_standart
+	Schema.TracesFromIdx.version.AccessorEFI = version.V2_1_standart
 
-	Schema.TracesToIdx.version.DataEF = version.V2_0_standart
-	Schema.TracesToIdx.version.AccessorEFI = version.V2_0_standart
+	Schema.TracesToIdx.version.DataEF = version.V2_1_standart
+	Schema.TracesToIdx.version.AccessorEFI = version.V2_1_standart
 
 	SchemeMinSupportedVersions = map[string]map[string]snaptype.Version{
 		"accounts": {

--- a/erigon-lib/version/file_version.go
+++ b/erigon-lib/version/file_version.go
@@ -20,11 +20,15 @@ var (
 	ZeroVersion            = Version{}
 	V1_0          Version  = Version{1, 0}
 	V1_1          Version  = Version{1, 1}
+	V1_2          Version  = Version{1, 2}
 	V2_0          Version  = Version{2, 0}
+	V2_1          Version  = Version{2, 1}
 	V1_0_standart Versions = Versions{V1_0, V1_0}
 	V1_1_standart Versions = Versions{V1_1, V1_0}
+	V1_2_standart Versions = Versions{V1_2, V1_0}
 	V1_1_exact    Versions = Versions{V1_1, V1_1}
 	V2_0_standart Versions = Versions{V2_0, V1_0}
+	V2_1_standart Versions = Versions{V2_1, V1_0}
 )
 
 func (v Version) Less(rhd Version) bool {

--- a/execution/exec3/historical_trace_worker.go
+++ b/execution/exec3/historical_trace_worker.go
@@ -172,7 +172,7 @@ func (rw *HistoricalTraceWorker) RunTxTaskNoLock(txTask *state.TxTask) {
 		// Block initialisation
 		//fmt.Printf("txNum=%d, blockNum=%d, initialisation of the block\n", txTask.TxNum, txTask.BlockNum)
 		syscall := func(contract common.Address, data []byte, ibs *state.IntraBlockState, header *types.Header, constCall bool) ([]byte, error) {
-			ret, err := core.SysCallContract(contract, data, cc, ibs, header, rw.execArgs.Engine, constCall /* constCall */, hooks, *rw.vmCfg)
+			ret, err := core.SysCallContract(contract, data, cc, ibs, header, rw.execArgs.Engine, constCall /* constCall */, *rw.vmCfg)
 			return ret, err
 		}
 		rw.execArgs.Engine.Initialize(cc, rw.chain, header, ibs, syscall, rw.logger, hooks)
@@ -184,10 +184,14 @@ func (rw *HistoricalTraceWorker) RunTxTaskNoLock(txTask *state.TxTask) {
 		if rw.background { // `Final` system txn must be executed in reducer, because `consensus.Finalize` requires "all receipts of block" to be available
 			break
 		}
+		tracer := calltracer.NewCallTracer(nil)
+		vmCfg := *rw.vmCfg
+		vmCfg.Tracer = tracer.Tracer().Hooks
+		ibs.SetTxContext(txTask.BlockNum, txTask.TxIndex)
 
 		// End of block transaction in a block
 		syscall := func(contract common.Address, data []byte) ([]byte, error) {
-			ret, err := core.SysCallContract(contract, data, cc, ibs, header, rw.execArgs.Engine, false /* constCall */, hooks, *rw.vmCfg)
+			ret, err := core.SysCallContract(contract, data, cc, ibs, header, rw.execArgs.Engine, false /* constCall */, vmCfg)
 			if err != nil {
 				return nil, err
 			}
@@ -200,7 +204,15 @@ func (rw *HistoricalTraceWorker) RunTxTaskNoLock(txTask *state.TxTask) {
 		if err != nil {
 			txTask.Error = err
 		} else {
-			txTask.TraceTos = map[common.Address]struct{}{}
+			txTask.TraceFroms = tracer.Froms()
+			txTask.TraceTos = tracer.Tos()
+			if txTask.TraceFroms == nil {
+				txTask.TraceFroms = map[common.Address]struct{}{}
+			}
+			if txTask.TraceTos == nil {
+				txTask.TraceTos = map[common.Address]struct{}{}
+			}
+
 			txTask.TraceTos[txTask.Coinbase] = struct{}{}
 			for _, uncle := range txTask.Uncles {
 				txTask.TraceTos[uncle.Coinbase] = struct{}{}
@@ -210,8 +222,9 @@ func (rw *HistoricalTraceWorker) RunTxTaskNoLock(txTask *state.TxTask) {
 		tracer := calltracer.NewCallTracer(nil)
 
 		rw.taskGasPool.Reset(txTask.Tx.GetGasLimit(), cc.GetMaxBlobGasPerBlock(header.Time))
-		rw.vmCfg.SkipAnalysis = txTask.SkipAnalysis
-		rw.vmCfg.Tracer = tracer.Tracer().Hooks
+		vmCfg := *rw.vmCfg
+		vmCfg.SkipAnalysis = txTask.SkipAnalysis
+		vmCfg.Tracer = tracer.Tracer().Hooks
 		ibs.SetTxContext(txTask.BlockNum, txTask.TxIndex)
 		txn := txTask.Tx
 
@@ -227,20 +240,20 @@ func (rw *HistoricalTraceWorker) RunTxTaskNoLock(txTask *state.TxTask) {
 				break
 			}
 
-			rw.evm.ResetBetweenBlocks(txTask.EvmBlockContext, core.NewEVMTxContext(msg), ibs, *rw.vmCfg, rules)
+			rw.evm.ResetBetweenBlocks(txTask.EvmBlockContext, core.NewEVMTxContext(msg), ibs, vmCfg, rules)
 			rw.execAATxn(txTask, tracer)
 			break
 		}
 
 		msg := txTask.TxAsMessage
 		txContext := core.NewEVMTxContext(msg)
-		if rw.vmCfg.TraceJumpDest {
+		if vmCfg.TraceJumpDest {
 			txContext.TxHash = txn.Hash()
 		}
-		rw.evm.ResetBetweenBlocks(txTask.EvmBlockContext, txContext, ibs, *rw.vmCfg, rules)
-		if hooks != nil && hooks.OnTxStart != nil {
-			hooks.OnTxStart(rw.evm.GetVMContext(), txn, msg.From())
-		}
+		rw.evm.ResetBetweenBlocks(txTask.EvmBlockContext, txContext, ibs, vmCfg, rules)
+		// if hooks != nil && hooks.OnTxStart != nil {
+		// 	hooks.OnTxStart(rw.evm.GetVMContext(), txn, msg.From())
+		// }
 
 		// MA applytx
 		applyRes, err := core.ApplyMessage(rw.evm, msg, rw.taskGasPool, true /* refunds */, false /* gasBailout */, rw.execArgs.Engine)

--- a/execution/exec3/state.go
+++ b/execution/exec3/state.go
@@ -183,7 +183,7 @@ func (rw *Worker) SetReader(reader state.ResettableStateReader) {
 	}
 }
 
-func (rw *Worker) RunTxTaskNoLock(txTask *state.TxTask, isMining, skipPostEvaluaion bool) {
+func (rw *Worker) RunTxTaskNoLock(txTask *state.TxTask, isMining, skipPostEvaluation bool) {
 	if txTask.HistoryExecution && !rw.historyMode {
 		// in case if we cancelled execution and commitment happened in the middle of the block, we have to process block
 		// from the beginning until committed txNum and only then disable history mode.
@@ -219,7 +219,6 @@ func (rw *Worker) RunTxTaskNoLock(txTask *state.TxTask, isMining, skipPostEvalua
 
 	var err error
 	rules, header := txTask.Rules, txTask.Header
-
 	switch {
 	case txTask.TxIndex == -1:
 		if txTask.BlockNum == 0 {
@@ -237,7 +236,7 @@ func (rw *Worker) RunTxTaskNoLock(txTask *state.TxTask, isMining, skipPostEvalua
 		// Block initialisation
 		//fmt.Printf("txNum=%d, blockNum=%d, initialisation of the block\n", txTask.TxNum, txTask.BlockNum)
 		syscall := func(contract common.Address, data []byte, ibs *state.IntraBlockState, header *types.Header, constCall bool) ([]byte, error) {
-			ret, err := core.SysCallContract(contract, data, cc, ibs, header, rw.engine, constCall /* constCall */, hooks, rw.vmCfg)
+			ret, err := core.SysCallContract(contract, data, cc, ibs, header, rw.engine, constCall /* constCall */, rw.vmCfg)
 			return ret, err
 		}
 		rw.engine.Initialize(cc, rw.chain, header, ibs, syscall, rw.logger, hooks)
@@ -247,9 +246,12 @@ func (rw *Worker) RunTxTaskNoLock(txTask *state.TxTask, isMining, skipPostEvalua
 			break
 		}
 
+		rw.callTracer.Reset()
+		ibs.SetTxContext(txTask.BlockNum, txTask.TxIndex)
+
 		// End of block transaction in a block
 		syscall := func(contract common.Address, data []byte) ([]byte, error) {
-			ret, err := core.SysCallContract(contract, data, cc, ibs, header, rw.engine, false /* constCall */, hooks, rw.vmCfg)
+			ret, err := core.SysCallContract(contract, data, cc, ibs, header, rw.engine, false /* constCall */, rw.vmCfg)
 			txTask.Logs = append(txTask.Logs, ibs.GetRawLogs(txTask.TxIndex)...)
 			return ret, err
 		}
@@ -257,12 +259,19 @@ func (rw *Worker) RunTxTaskNoLock(txTask *state.TxTask, isMining, skipPostEvalua
 		if isMining {
 			_, _, err = rw.engine.FinalizeAndAssemble(cc, types.CopyHeader(header), ibs, txTask.Txs, txTask.Uncles, txTask.BlockReceipts, txTask.Withdrawals, rw.chain, syscall, nil, rw.logger)
 		} else {
-			_, err = rw.engine.Finalize(cc, types.CopyHeader(header), ibs, txTask.Txs, txTask.Uncles, txTask.BlockReceipts, txTask.Withdrawals, rw.chain, syscall, skipPostEvaluaion, rw.logger)
+			_, err = rw.engine.Finalize(cc, types.CopyHeader(header), ibs, txTask.Txs, txTask.Uncles, txTask.BlockReceipts, txTask.Withdrawals, rw.chain, syscall, skipPostEvaluation, rw.logger)
 		}
 		if err != nil {
 			txTask.Error = err
 		} else {
-			txTask.TraceTos = map[common.Address]struct{}{}
+			txTask.TraceFroms = rw.callTracer.Froms()
+			txTask.TraceTos = rw.callTracer.Tos()
+			if txTask.TraceFroms == nil {
+				txTask.TraceFroms = map[common.Address]struct{}{}
+			}
+			if txTask.TraceTos == nil {
+				txTask.TraceTos = map[common.Address]struct{}{}
+			}
 			txTask.TraceTos[txTask.Coinbase] = struct{}{}
 			for _, uncle := range txTask.Uncles {
 				txTask.TraceTos[uncle.Coinbase] = struct{}{}

--- a/rpc/jsonrpc/trace_filtering.go
+++ b/rpc/jsonrpc/trace_filtering.go
@@ -813,7 +813,7 @@ func (api *TraceAPIImpl) callBlock(
 		msgs[i] = msg
 	}
 
-	traces, tracingHooks, cmErr := api.doCallBlock(ctx, dbtx, stateReader, stateCache, cachedWriter, ibs, txs, msgs, callParams,
+	traces, _, cmErr := api.doCallBlock(ctx, dbtx, stateReader, stateCache, cachedWriter, ibs, txs, msgs, callParams,
 		&parentNrOrHash, header, gasBailOut /* gasBailout */, traceConfig)
 
 	if cmErr != nil {
@@ -821,7 +821,7 @@ func (api *TraceAPIImpl) callBlock(
 	}
 
 	syscall := func(contract common.Address, data []byte) ([]byte, error) {
-		ret, err := core.SysCallContract(contract, data, cfg, ibs, header, engine, false /* constCall */, tracingHooks, vm.Config{})
+		ret, err := core.SysCallContract(contract, data, cfg, ibs, header, engine, false /* constCall */, vm.Config{})
 		return ret, err
 	}
 


### PR DESCRIPTION
issue: https://github.com/erigontech/erigon/issues/16339

- enable tracer in final tx exec (for tracesfrom/tracesto)
- use `ibs.SetTxContext` in final tx exec: this was causing txTask.Logs to be incorrectly set to nil.
- remove unused hooks/tracers from fn signatures
- need to regen files after this -- logaddrs/logtopics/tracesfrom/tracesto/receipts.