### PR TITLE
[r3.1] fix of flocking on 3.1 integrity

### DIFF
--- a/erigon-lib/common/datadir/dirs.go
+++ b/erigon-lib/common/datadir/dirs.go
@@ -124,7 +124,6 @@ var (
 func convertFileLockError(err error) error {
 	//nolint
 	if errno, ok := err.(syscall.Errno); ok && datadirInUseErrNos[uint(errno)] {
-		println("conv file lock error")
 		return ErrDataDirLocked
 	}
 	return err
@@ -153,7 +152,6 @@ func (dirs Dirs) MustFlock() (Dirs, *flock.Flock, error) {
 		return dirs, l, err
 	}
 	if !locked {
-		println("flock")
 		return dirs, l, ErrDataDirLocked
 	}
 	return dirs, l, nil
@@ -179,7 +177,6 @@ func (dirs *Dirs) TryFlock() (unlock func(), err error) {
 			panicif.Err(f.Unlock())
 		}
 	} else {
-		println("another flock")
 		err = ErrDataDirLocked
 	}
 	return

--- a/erigon-lib/common/datadir/dirs.go
+++ b/erigon-lib/common/datadir/dirs.go
@@ -152,6 +152,7 @@ func (dirs Dirs) MustFlock() (Dirs, *flock.Flock, error) {
 		return dirs, l, err
 	}
 	if !locked {
+		println("here")
 		return dirs, l, ErrDataDirLocked
 	}
 	return dirs, l, nil

--- a/erigon-lib/common/datadir/dirs.go
+++ b/erigon-lib/common/datadir/dirs.go
@@ -152,7 +152,6 @@ func (dirs Dirs) MustFlock() (Dirs, *flock.Flock, error) {
 		return dirs, l, err
 	}
 	if !locked {
-		println("here")
 		return dirs, l, ErrDataDirLocked
 	}
 	return dirs, l, nil

--- a/erigon-lib/common/datadir/dirs.go
+++ b/erigon-lib/common/datadir/dirs.go
@@ -124,6 +124,7 @@ var (
 func convertFileLockError(err error) error {
 	//nolint
 	if errno, ok := err.(syscall.Errno); ok && datadirInUseErrNos[uint(errno)] {
+		println("conv file lock error")
 		return ErrDataDirLocked
 	}
 	return err
@@ -152,6 +153,7 @@ func (dirs Dirs) MustFlock() (Dirs, *flock.Flock, error) {
 		return dirs, l, err
 	}
 	if !locked {
+		println("flock")
 		return dirs, l, ErrDataDirLocked
 	}
 	return dirs, l, nil
@@ -177,6 +179,7 @@ func (dirs *Dirs) TryFlock() (unlock func(), err error) {
 			panicif.Err(f.Unlock())
 		}
 	} else {
+		println("another flock")
 		err = ErrDataDirLocked
 	}
 	return

--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -332,11 +332,6 @@ var snapshotCommand = cli.Command{
 		{
 			Name: "integrity",
 			Action: func(cliCtx *cli.Context) error {
-				_, l, err := datadir.New(cliCtx.String(utils.DataDirFlag.Name)).MustFlock()
-				if err != nil {
-					return err
-				}
-				defer l.Unlock()
 				if err := doIntegrity(cliCtx); err != nil {
 					log.Error("[integrity]", "err", err)
 					return err


### PR DESCRIPTION
Flock disallows you to run integrity while node is running.