### PR TITLE
Remove dead code from `bor.go`

### DIFF
--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -36,7 +36,6 @@ import (
 	"github.com/holiman/uint256"
 	"github.com/xsleonard/go-merkle"
 	"golang.org/x/crypto/sha3"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/erigontech/erigon-db/rawdb"
 	"github.com/erigontech/erigon-lib/chain"
@@ -46,7 +45,6 @@ import (
 	"github.com/erigontech/erigon-lib/common/empty"
 	"github.com/erigontech/erigon-lib/common/length"
 	"github.com/erigontech/erigon-lib/crypto"
-	"github.com/erigontech/erigon-lib/estimate"
 	"github.com/erigontech/erigon-lib/kv"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon-lib/rlp"
@@ -349,7 +347,6 @@ type Bor struct {
 	spanner         Spanner
 	stateReceiver   StateReceiver
 	HeimdallClient  heimdall.Client
-	useSpanReader   bool
 	spanReader      spanReader
 	useBridgeReader bool
 	bridgeReader    bridgeReader
@@ -358,12 +355,11 @@ type Bor struct {
 	// The fields below are for testing only
 	fakeDiff bool // Skip difficulty verifications
 
-	closeOnce           sync.Once
-	logger              log.Logger
-	closeCh             chan struct{} // Channel to signal the background processes to exit
-	frozenSnapshotsInit sync.Once
-	rootHashCache       *lru.ARCCache[string, string]
-	headerProgress      HeaderProgress
+	closeOnce      sync.Once
+	logger         log.Logger
+	closeCh        chan struct{} // Channel to signal the background processes to exit
+	rootHashCache  *lru.ARCCache[string, string]
+	headerProgress HeaderProgress
 }
 
 type signer struct {
@@ -412,7 +408,6 @@ func New(
 		closeCh:         make(chan struct{}),
 		useBridgeReader: bridgeReader != nil && !reflect.ValueOf(bridgeReader).IsNil(), // needed for interface nil caveat
 		bridgeReader:    bridgeReader,
-		useSpanReader:   spanReader != nil && !reflect.ValueOf(spanReader).IsNil(), // needed for interface nil caveat
 		spanReader:      spanReader,
 	}
 
@@ -680,189 +675,6 @@ func ValidateHeaderGas(header *types.Header, parent *types.Header, chainConfig *
 	return nil
 }
 
-func (c *Bor) initFrozenSnapshot(chain ChainHeaderReader, number uint64, logEvery *time.Ticker) (snap *Snapshot, err error) {
-	c.logger.Info("Initializing frozen snapshots to", "number", number)
-	defer func() {
-		c.logger.Info("Done initializing frozen snapshots to", "number", number, "err", err)
-	}()
-
-	// Special handling of the headers in the snapshot
-	zeroHeader := chain.GetHeaderByNumber(0)
-
-	if zeroHeader != nil {
-		// get checkpoint data
-		hash := zeroHeader.Hash()
-
-		// get validators and current span
-		var validators []*valset.Validator
-
-		validators, err = c.spanner.GetCurrentValidators(0, chain)
-
-		if err != nil {
-			return nil, err
-		}
-
-		// new snap shot
-		snap = NewSnapshot(c.config, c.Signatures, 0, hash, validators, c.logger)
-
-		if err = snap.Store(c.DB); err != nil {
-			return nil, err
-		}
-
-		c.logger.Info("Stored proposer snapshot to disk", "number", 0, "hash", hash)
-
-		g := errgroup.Group{}
-		g.SetLimit(estimate.AlmostAllCPUs())
-		defer g.Wait()
-
-		batchSize := 128 // must be < inmemorySignatures
-		initialHeaders := make([]*types.Header, 0, batchSize)
-
-		for i := uint64(1); i <= number; i++ {
-			header := chain.GetHeaderByNumber(i)
-			{
-				// `snap.apply` bottleneck - is recover of signer.
-				// to speedup: recover signer in background goroutines and save in `sigcache`
-				// `batchSize` < `inmemorySignatures`: means all current batch will fit in cache - and `snap.apply` will find it there.
-				snap := snap
-				g.Go(func() error {
-					_, _ = Ecrecover(header, snap.sigcache, snap.config)
-					return nil
-				})
-			}
-			initialHeaders = append(initialHeaders, header)
-			if len(initialHeaders) == cap(initialHeaders) {
-				snap, err = snap.Apply(nil, initialHeaders, c.logger)
-
-				if err != nil {
-					return nil, err
-				}
-
-				initialHeaders = initialHeaders[:0]
-			}
-			select {
-			case <-logEvery.C:
-				log.Info("Computing validator proposer prorities (forward)", "blockNum", i)
-			default:
-			}
-		}
-
-		if snap, err = snap.Apply(nil, initialHeaders, c.logger); err != nil {
-			return nil, err
-		}
-	}
-
-	return snap, nil
-}
-
-// snapshot retrieves the authorization snapshot at a given point in time.
-func (c *Bor) snapshot(chain ChainHeaderReader, number uint64, hash common.Hash, parents []*types.Header) (*Snapshot, error) {
-	logEvery := time.NewTicker(logInterval)
-	defer logEvery.Stop()
-	// Search for a snapshot in memory or on disk for checkpoints
-	var snap *Snapshot
-
-	headers := make([]*types.Header, 0, 16)
-
-	//nolint:govet
-	for snap == nil {
-		// If an in-memory snapshot was found, use that
-		if s, ok := c.Recents.Get(hash); ok {
-			snap = s
-			break
-		}
-
-		// If an on-disk snapshot can be found, use that
-		if number%snapshotPersistInterval == 0 {
-			if s, err := LoadSnapshot(c.config, c.Signatures, c.DB, hash); err == nil {
-				c.logger.Trace("Loaded snapshot from disk", "number", number, "hash", hash)
-
-				snap = s
-				break
-			}
-		}
-
-		// No snapshot for this header, gather the header and move backward
-		var header *types.Header
-		if len(parents) > 0 {
-			// If we have explicit parents, pick from there (enforced)
-			header = parents[len(parents)-1]
-			if header.Hash() != hash || header.Number.Uint64() != number {
-				return nil, consensus.ErrUnknownAncestor
-			}
-
-			parents = parents[:len(parents)-1]
-		} else {
-			// No explicit parents (or no more left), reach out to the database
-			if chain == nil {
-				break
-			}
-
-			header = chain.GetHeader(hash, number)
-
-			if header == nil {
-				return nil, consensus.ErrUnknownAncestor
-			}
-		}
-
-		if number == 0 {
-			break
-		}
-
-		headers = append(headers, header)
-		number, hash = number-1, header.ParentHash
-
-		if chain != nil && number < chain.FrozenBlocks() {
-			break
-		}
-
-		select {
-		case <-logEvery.C:
-			log.Info("Gathering headers for validator proposer prorities (backwards)", "blockNum", number)
-		default:
-		}
-	}
-
-	if snap == nil && chain != nil && number <= chain.FrozenBlocks() {
-		var err error
-		c.frozenSnapshotsInit.Do(func() {
-			snap, err = c.initFrozenSnapshot(chain, number, logEvery)
-		})
-
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// check if snapshot is nil
-	if snap == nil {
-		return nil, fmt.Errorf("%w at block number %v", errUnknownSnapshot, number)
-	}
-
-	// Previous snapshot found, apply any pending headers on top of it
-	for i := 0; i < len(headers)/2; i++ {
-		headers[i], headers[len(headers)-1-i] = headers[len(headers)-1-i], headers[i]
-	}
-
-	var err error
-	if snap, err = snap.Apply(nil, headers, c.logger); err != nil {
-		return nil, err
-	}
-
-	c.Recents.Add(snap.Hash, snap)
-
-	// If we've generated a new persistent snapshot, save to disk
-	if snap.Number%snapshotPersistInterval == 0 && len(headers) > 0 {
-		if err = snap.Store(c.DB); err != nil {
-			return nil, err
-		}
-
-		c.logger.Trace("Stored proposer snapshot to disk", "number", snap.Number, "hash", snap.Hash)
-	}
-
-	return snap, err
-}
-
 // VerifyUncles implements consensus.Engine, always returning an error for any
 // uncles as this consensus mechanism doesn't permit uncles.
 func (c *Bor) VerifyUncles(_ consensus.ChainReader, _ *types.Header, uncles []*types.Header) error {
@@ -872,24 +684,12 @@ func (c *Bor) VerifyUncles(_ consensus.ChainReader, _ *types.Header, uncles []*t
 // VerifySeal implements consensus.Engine, checking whether the signature contained
 // in the header satisfies the consensus protocol requirements.
 func (c *Bor) VerifySeal(chain ChainHeaderReader, header *types.Header) error {
-	var validatorSet *valset.ValidatorSet
-	if c.useSpanReader {
-		v, err := c.spanReader.Producers(context.Background(), header.Number.Uint64())
-		if err != nil {
-			return err
-		}
-
-		validatorSet = v
-	} else {
-		s, err := c.snapshot(chain, header.Number.Uint64()-1, header.ParentHash, nil)
-		if err != nil {
-			return err
-		}
-
-		validatorSet = s.ValidatorSet
+	v, err := c.spanReader.Producers(context.Background(), header.Number.Uint64())
+	if err != nil {
+		return err
 	}
 
-	return c.verifySeal(chain, header, nil, validatorSet)
+	return c.verifySeal(chain, header, nil, v)
 }
 
 // verifySeal checks whether the signature contained in the header satisfies the
@@ -939,21 +739,9 @@ func (c *Bor) Prepare(chain consensus.ChainHeaderReader, header *types.Header, s
 
 	number := header.Number.Uint64()
 	// Assemble the validator snapshot to check which votes make sense
-	var validatorSet *valset.ValidatorSet
-	if c.useSpanReader {
-		v, err := c.spanReader.Producers(context.Background(), header.Number.Uint64())
-		if err != nil {
-			return err
-		}
-
-		validatorSet = v
-	} else {
-		snap, err := c.snapshot(chain.(ChainHeaderReader), number-1, header.ParentHash, nil)
-		if err != nil {
-			return err
-		}
-
-		validatorSet = snap.ValidatorSet
+	validatorSet, err := c.spanReader.Producers(context.Background(), header.Number.Uint64())
+	if err != nil {
+		return err
 	}
 
 	// Set the correct difficulty
@@ -973,23 +761,11 @@ func (c *Bor) Prepare(chain consensus.ChainHeaderReader, header *types.Header, s
 	// in Erigon, use directly the `GetCurrentProducers` function.
 	if c.config.IsSprintEnd(number) {
 		var newValidators []*valset.Validator
-
-		if c.useSpanReader {
-			validators, err := c.spanReader.Producers(context.Background(), number+1)
-			if err != nil {
-				return err
-			}
-
-			newValidators = validators.Validators
-		} else {
-			var err error
-			spanID := uint64(heimdall.SpanIdAt(number + 1))
-
-			newValidators, err = c.spanner.GetCurrentProducers(spanID, chain.(ChainHeaderReader))
-			if err != nil {
-				return errUnknownValidators
-			}
+		validators, err := c.spanReader.Producers(context.Background(), number+1)
+		if err != nil {
+			return err
 		}
+		newValidators = validators.Validators
 
 		// sort validator by address
 		sort.Sort(valset.ValidatorsByAddress(newValidators))
@@ -1046,7 +822,6 @@ func (c *Bor) Prepare(chain consensus.ChainHeaderReader, header *types.Header, s
 	}
 
 	var succession int
-	var err error
 	signer := c.authorizedSigner.Load().signer
 	// if signer is not empty
 	if !bytes.Equal(signer.Bytes(), common.Address{}.Bytes()) {
@@ -1238,26 +1013,15 @@ func (c *Bor) Seal(chain consensus.ChainHeaderReader, blockWithReceipts *types.B
 	signer, signFn := currentSigner.signer, currentSigner.signFn
 
 	var successionNumber int
-	if c.useSpanReader {
-		validatorSet, err := c.spanReader.Producers(context.Background(), number)
-		if err != nil {
-			return err
-		}
 
-		successionNumber, err = validatorSet.GetSignerSuccessionNumber(signer, number)
-		if err != nil {
-			return err
-		}
-	} else {
-		snap, err := c.snapshot(chain.(ChainHeaderReader), number-1, header.ParentHash, nil)
-		if err != nil {
-			return err
-		}
+	validatorSet, err := c.spanReader.Producers(context.Background(), number)
+	if err != nil {
+		return err
+	}
 
-		successionNumber, err = snap.ValidatorSet.GetSignerSuccessionNumber(signer, number)
-		if err != nil {
-			return err
-		}
+	successionNumber, err = validatorSet.GetSignerSuccessionNumber(signer, number)
+	if err != nil {
+		return err
 	}
 
 	var delay time.Duration
@@ -1334,25 +1098,12 @@ func (c *Bor) IsValidator(header *types.Header) (bool, error) {
 
 	currentSigner := c.authorizedSigner.Load()
 
-	if c.useSpanReader {
-		validatorSet, err := c.spanReader.Producers(context.Background(), number)
-		if err != nil {
-			return false, err
-		}
-		return validatorSet.HasAddress(currentSigner.signer), nil
-	}
-
-	snap, err := c.snapshot(nil, number-1, header.ParentHash, nil)
-
+	validatorSet, err := c.spanReader.Producers(context.Background(), number)
 	if err != nil {
-		if errors.Is(err, errUnknownSnapshot) {
-			return false, nil
-		}
-
 		return false, err
 	}
+	return validatorSet.HasAddress(currentSigner.signer), nil
 
-	return snap.ValidatorSet.HasAddress(currentSigner.signer), nil
 }
 
 // IsProposer returns true if this instance is the proposer for this block
@@ -1364,20 +1115,9 @@ func (c *Bor) IsProposer(header *types.Header) (bool, error) {
 
 	signer := c.authorizedSigner.Load().signer
 
-	var validatorSet *valset.ValidatorSet
-	var err error
-	if c.useSpanReader {
-		validatorSet, err = c.spanReader.Producers(context.Background(), number)
-		if err != nil {
-			return false, err
-		}
-	} else {
-		snap, err := c.snapshot(nil, number-1, header.ParentHash, nil)
-		if err != nil {
-			return false, err
-		}
-
-		validatorSet = snap.ValidatorSet
+	validatorSet, err := c.spanReader.Producers(context.Background(), number)
+	if err != nil {
+		return false, err
 	}
 
 	successionNumber, err := validatorSet.GetSignerSuccessionNumber(signer, number)
@@ -1390,21 +1130,13 @@ func (c *Bor) IsProposer(header *types.Header) (bool, error) {
 func (c *Bor) CalcDifficulty(chain consensus.ChainHeaderReader, _, _ uint64, _ *big.Int, parentNumber uint64, parentHash, _ common.Hash, _ uint64) *big.Int {
 	signer := c.authorizedSigner.Load().signer
 
-	if c.useSpanReader {
-		validatorSet, err := c.spanReader.Producers(context.Background(), parentNumber+1)
-		if err != nil {
-			return nil
-		}
-
-		return big.NewInt(int64(validatorSet.SafeDifficulty(signer)))
-	}
-
-	snap, err := c.snapshot(chain.(ChainHeaderReader), parentNumber, parentHash, nil)
+	validatorSet, err := c.spanReader.Producers(context.Background(), parentNumber+1)
 	if err != nil {
 		return nil
 	}
 
-	return new(big.Int).SetUint64(snap.ValidatorSet.SafeDifficulty(signer))
+	return big.NewInt(int64(validatorSet.SafeDifficulty(signer)))
+
 }
 
 // SealHash returns the hash of a block prior to it being sealed.
@@ -1506,28 +1238,12 @@ func (c *Bor) fetchAndCommitSpan(
 	chain statefull.ChainContext,
 	syscall consensus.SystemCall,
 ) error {
-	var heimdallSpan *heimdall.Span
-
-	if c.HeimdallClient == nil {
-		// fixme: move to a new mock or fake and remove c.HeimdallClient completely
-		s, err := c.getNextHeimdallSpanForTest(newSpanID, state, header, chain, syscall)
-		if err != nil {
-			return err
-		}
-
-		heimdallSpan = s
-	} else if c.useSpanReader {
-		span, ok, err := c.spanReader.Span(context.Background(), newSpanID)
-		if err != nil {
-			return err
-		}
-		if !ok {
-			return errors.New(fmt.Sprintf("error fetching span %v", newSpanID))
-		}
-
-		heimdallSpan = span
-	} else {
-		heimdallSpan = chain.Chain.(ChainHeaderReader).BorSpan(newSpanID)
+	heimdallSpan, ok, err := c.spanReader.Span(context.Background(), newSpanID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errors.New(fmt.Sprintf("error fetching span %v", newSpanID))
 	}
 
 	// check if chain id matches with heimdall span
@@ -1728,22 +1444,9 @@ func (c *Bor) getNextHeimdallSpanForTest(
 		return nil, err
 	}
 
-	// Retrieve the snapshot needed to verify this header and cache it
-	var validatorSet *valset.ValidatorSet
-	if c.useSpanReader {
-		v, err := c.spanReader.Producers(context.Background(), headerNumber)
-		if err != nil {
-			return nil, err
-		}
-
-		validatorSet = v
-	} else {
-		snap, err := c.snapshot(chain.Chain.(ChainHeaderReader), headerNumber-1, header.ParentHash, nil)
-		if err != nil {
-			return nil, err
-		}
-
-		validatorSet = snap.ValidatorSet
+	validatorSet, err := c.spanReader.Producers(context.Background(), headerNumber)
+	if err != nil {
+		return nil, err
 	}
 
 	// new span

--- a/polygon/bor/bor_internal_test.go
+++ b/polygon/bor/bor_internal_test.go
@@ -45,16 +45,6 @@ func TestUseBridgeReader(t *testing.T) {
 	require.True(t, bor.useBridgeReader)
 }
 
-func TestUseSpanReader(t *testing.T) {
-	// test for Go's interface nil-ness caveat - https://codefibershq.com/blog/golang-why-nil-is-not-always-nil
-	var sr *mockSpanReader
-	b := New(polychain.AmoyChainConfig, nil, nil, nil, nil, nil, nil, nil, sr)
-	require.False(t, b.useSpanReader)
-	sr = &mockSpanReader{}
-	b = New(polychain.AmoyChainConfig, nil, nil, nil, nil, nil, nil, nil, sr)
-	require.True(t, b.useSpanReader)
-}
-
 var _ bridgeReader = mockBridgeReader{}
 
 type mockBridgeReader struct{}


### PR DESCRIPTION
This removes dead code from `bor.go` (primarily `bor.snapshot()` which is no longer used in any flow), and also removes the `useSpanReader` flag, as the span reader is always used.