### PR TITLE
execution/builder: keep polling dry txnpool for txns until we are interrupted

### DIFF
--- a/execution/builder/block_builder.go
+++ b/execution/builder/block_builder.go
@@ -36,11 +36,13 @@ type BlockBuilder struct {
 	err       error
 }
 
-func NewBlockBuilder(build BlockBuilderFunc, param *core.BlockBuilderParameters) *BlockBuilder {
+func NewBlockBuilder(build BlockBuilderFunc, param *core.BlockBuilderParameters, maxBuildTimeSecs uint64) *BlockBuilder {
 	builder := new(BlockBuilder)
 	builder.syncCond = sync.NewCond(new(sync.Mutex))
+	terminated := make(chan struct{})
 
 	go func() {
+		defer close(terminated)
 		log.Info("Building block...")
 		t := time.Now()
 		result, err := build(param, &builder.interrupt)
@@ -56,6 +58,21 @@ func NewBlockBuilder(build BlockBuilderFunc, param *core.BlockBuilderParameters)
 		builder.result = result
 		builder.err = err
 		builder.syncCond.Broadcast()
+	}()
+
+	go func() {
+		timer := time.NewTimer(time.Duration(maxBuildTimeSecs) * time.Second)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+			log.Info("Stopping block builder due to max build time exceeded")
+			_, err := builder.Stop()
+			if err != nil {
+				log.Warn("Failed to stop block builder", "err", err)
+			}
+		case <-terminated:
+			return
+		}
 	}()
 
 	return builder

--- a/execution/builder/block_builder.go
+++ b/execution/builder/block_builder.go
@@ -65,11 +65,10 @@ func NewBlockBuilder(build BlockBuilderFunc, param *core.BlockBuilderParameters,
 		defer timer.Stop()
 		select {
 		case <-timer.C:
-			log.Info("Stopping block builder due to max build time exceeded")
-			_, err := builder.Stop()
-			if err != nil {
-				log.Warn("Failed to stop block builder", "err", err)
-			}
+			log.Warn("Stopping block builder due to max build time exceeded")
+			_, _ = builder.Stop()
+			log.Debug("Stopped block builder due to max build time exceeded")
+			return
 		case <-terminated:
 			return
 		}

--- a/execution/eth1/block_building.go
+++ b/execution/eth1/block_building.go
@@ -99,7 +99,7 @@ func (e *EthereumExecutionModule) AssembleBlock(ctx context.Context, req *execut
 	param.PayloadId = e.nextPayloadId
 	e.lastParameters = &param
 
-	e.builders[e.nextPayloadId] = builder.NewBlockBuilder(e.builderFunc, &param)
+	e.builders[e.nextPayloadId] = builder.NewBlockBuilder(e.builderFunc, &param, e.config.SecondsPerSlot())
 	e.logger.Info("[ForkChoiceUpdated] BlockBuilder added", "payload", e.nextPayloadId)
 
 	return &execution.AssembleBlockResponse{

--- a/execution/stagedsync/stage_mining_exec.go
+++ b/execution/stagedsync/stage_mining_exec.go
@@ -172,7 +172,7 @@ func SpawnMiningExecStage(s *StageState, txc wrap.TxContainer, cfg MiningExecCfg
 
 			// if we yielded less than the count we wanted, assume the txpool has run dry now and stop to save another loop
 			if len(txns) < amount {
-				if interrupt != nil && atomic.LoadInt32(interrupt) != 0 {
+				if interrupt != nil {
 					// if we are in interrupt mode, then keep on poking the txpool until we get interrupted
 					// since there may be new txns that can arrive
 					time.Sleep(50 * time.Millisecond)

--- a/execution/stagedsync/stage_mining_exec.go
+++ b/execution/stagedsync/stage_mining_exec.go
@@ -172,7 +172,7 @@ func SpawnMiningExecStage(s *StageState, txc wrap.TxContainer, cfg MiningExecCfg
 
 			// if we yielded less than the count we wanted, assume the txpool has run dry now and stop to save another loop
 			if len(txns) < amount {
-				if interrupt != nil {
+				if interrupt != nil && atomic.LoadInt32(interrupt) == 0 {
 					// if we are in interrupt mode, then keep on poking the txpool until we get interrupted
 					// since there may be new txns that can arrive
 					time.Sleep(50 * time.Millisecond)

--- a/execution/stagedsync/stage_mining_exec.go
+++ b/execution/stagedsync/stage_mining_exec.go
@@ -149,6 +149,7 @@ func SpawnMiningExecStage(s *StageState, txc wrap.TxContainer, cfg MiningExecCfg
 			return err
 		}
 
+		interrupt := cfg.interrupt
 		const amount = 50
 		for {
 			txns, err := getNextTransactions(ctx, cfg, chainID, current.Header, amount, executionAt, yielded, simStateReader, simStateWriter, logger)
@@ -157,7 +158,7 @@ func SpawnMiningExecStage(s *StageState, txc wrap.TxContainer, cfg MiningExecCfg
 			}
 
 			if len(txns) > 0 {
-				logs, stop, err := addTransactionsToMiningBlock(ctx, logPrefix, current, cfg.chainConfig, cfg.vmConfig, getHeader, cfg.engine, txns, cfg.miningState.MiningConfig.Etherbase, ibs, cfg.interrupt, cfg.payloadId, logger)
+				logs, stop, err := addTransactionsToMiningBlock(ctx, logPrefix, current, cfg.chainConfig, cfg.vmConfig, getHeader, cfg.engine, txns, cfg.miningState.MiningConfig.Etherbase, ibs, interrupt, cfg.payloadId, logger)
 				if err != nil {
 					return err
 				}
@@ -171,7 +172,13 @@ func SpawnMiningExecStage(s *StageState, txc wrap.TxContainer, cfg MiningExecCfg
 
 			// if we yielded less than the count we wanted, assume the txpool has run dry now and stop to save another loop
 			if len(txns) < amount {
-				break
+				if interrupt != nil && atomic.LoadInt32(interrupt) != 0 {
+					// if we are in interrupt mode, then keep on poking the txpool until we get interrupted
+					// since there may be new txns that can arrive
+					time.Sleep(50 * time.Millisecond)
+				} else {
+					break
+				}
 			}
 		}
 


### PR DESCRIPTION
Test `"Blob Transaction Ordering, Multiple Clients (Cancun) (erigon)"` is flaky (example run - https://github.com/erigontech/erigon/actions/runs/16647657985/job/47112094838)

the test setup is:
- 2 EL clients
- some blob txns are sent to client A others to client B
- after they are all sent, payloads are built by client A
- expectation is that each block will have 6 blob txns included

we flake because:
- we stop block building when the txpool dries out
- in the test the time between FCU and GetPayload is 2 seconds
- we do not wait the full 2 seconds
- sometimes we get the blob txns in time, other times we dont (depends on txpool propagation delay which can vary depending on hardware/resource consumption on the machine, note we run with --sim.parallelism 8 which can also affect this)
- if we keep on poking the txpool within the 2 seconds (driven by the CL) we will give more time for the txpool propagations to reach the builder


coincidentally, this may be one reason why we sometimes see Erigon produce emptier blocks on devnets as compared to other clients