### PR TITLE
Run CI tests with `-race` only after PR is merged

### DIFF
--- a/.github/workflows/test-all-erigon-race.yml
+++ b/.github/workflows/test-all-erigon-race.yml
@@ -2,16 +2,9 @@ name: All tests
 
 on:
   push:
-  pull_request:
-    branches:
-      - main 
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
-  schedule:
-    - cron: '20 16 * * *' # daily at 16:20 UTC
+   branches:
+        - release/*
+        - main
   workflow_dispatch:
 
 jobs:
@@ -89,7 +82,7 @@ jobs:
         env:
           SKIP_FLAKY_TESTS: 'true'
         if: needs.source-of-changes.outputs.changed_files != 'true'
-        run: GOGC=80 make test-all-race
+        run: GOGC=80 make test-all
 
       - name: SonarCloud scan in case OS Linux and changed_files is not true
         if: runner.os == 'Linux' && needs.source-of-changes.outputs.changed_files != 'true'
@@ -146,7 +139,7 @@ jobs:
 
       - name: Run all tests on ${{ matrix.os }}
         if: needs.source-of-changes.outputs.changed_files != 'true'
-        run: .\wmake.ps1 test-all
+        run: .\wmake.ps1 test-all-race
 
       - name: This ${{ matrix.os }} check does not make sense for changes within out-of-scope directories
         if: needs.source-of-changes.outputs.changed_files == 'true'

--- a/wmake.ps1
+++ b/wmake.ps1
@@ -544,7 +544,17 @@ if ($BuildTarget -eq "db-tools") {
     } else {
         Write-Host "`n Tests completed"
     }
-
+} elseif ($BuildTarget -eq "test-all-race") {
+     Write-Host " Running all tests ..."
+    $env:GODEBUG = "cgocheck=0"
+    $TestCommand = "go test $($Erigon.BuildFlags) --timeout 60m -race ./..."
+    Invoke-Expression -Command $TestCommand | Out-Host
+    if (!($?)) {
+        Write-Host " ERROR : Tests failed"
+        exit 1
+    } else {
+        Write-Host "`n Tests completed"
+    }
 } else {
 
     # This has a naive assumption every target has a compilation unit with the same name


### PR DESCRIPTION
Due to `make test-all-race` take more than an hour compared to `make test-all` which takes just 13 minutes, we can run `make test-all` on PRs, and the longer `make test-all-race` after a PR has been pushed to `main` or to a `release/*` branch.