### PR TITLE
[r31] move RCacheNoDups into default integrity

### DIFF
--- a/eth/integrity/integrity_action_type.go
+++ b/eth/integrity/integrity_action_type.go
@@ -32,9 +32,8 @@ const (
 )
 
 var AllChecks = []Check{
-	Blocks, HeaderNoGaps, BlocksTxnID, InvertedIndex, HistoryNoSystemTxs, ReceiptsNoDups, BorEvents, BorSpans, BorCheckpoints,
+	Blocks, HeaderNoGaps, BlocksTxnID, InvertedIndex, HistoryNoSystemTxs, ReceiptsNoDups, BorEvents,
+	BorSpans, BorCheckpoints, RCacheNoDups,
 }
 
-var NonDefaultChecks = []Check{
-	RCacheNoDups,
-}
+var NonDefaultChecks = []Check{}


### PR DESCRIPTION
snapshotters always have rcache; 
lets do this, so integrity command becomes simpler as well