### PR TITLE
execution/stagedsync: handle sync loop block limit exhaustion (#16268)

### DIFF
--- a/execution/eth1/forkchoice.go
+++ b/execution/eth1/forkchoice.go
@@ -449,11 +449,41 @@ func (e *EthereumExecutionModule) updateForkChoice(ctx context.Context, original
 	// Run the forkchoice
 	initialCycle := limitedBigJump
 	firstCycle := false
-	if _, err := e.executionPipeline.Run(e.db, wrap.NewTxContainer(tx, nil), initialCycle, firstCycle); err != nil {
-		err = fmt.Errorf("updateForkChoice: %w", err)
-		e.logger.Warn("Cannot update chain head", "hash", blockHash, "err", err)
-		sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, err, stateFlushingInParallel)
-		return
+	for {
+		hasMore, err := e.executionPipeline.Run(e.db, wrap.NewTxContainer(tx, nil), initialCycle, firstCycle)
+		if err != nil {
+			err = fmt.Errorf("updateForkChoice: %w", err)
+			e.logger.Warn("Cannot update chain head", "hash", blockHash, "err", err)
+			sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, err, stateFlushingInParallel)
+			return
+		}
+		if !hasMore {
+			break
+		}
+		err = e.executionPipeline.RunPrune(e.db, tx, initialCycle)
+		if err != nil {
+			err = fmt.Errorf("updateForkChoice: RunPrune after hasMore: %w", err)
+			e.logger.Warn("Cannot update chain head", "hash", blockHash, "err", err)
+			sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, err, stateFlushingInParallel)
+			return
+		}
+		err = tx.Commit()
+		if err != nil {
+			err = fmt.Errorf("updateForkChoice: tx commit after hasMore: %w", err)
+			e.logger.Warn("Cannot update chain head", "hash", blockHash, "err", err)
+			sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, err, stateFlushingInParallel)
+			return
+		}
+		tx, err = e.db.BeginTemporalRw(ctx)
+		if err != nil {
+			err = fmt.Errorf("updateForkChoice: begin tx after has more %w", err)
+			e.logger.Warn("Cannot update chain head", "hash", blockHash, "err", err)
+			sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, err, stateFlushingInParallel)
+			return
+		}
+		// note we already have defer tx.Rollback() on stack from earlier
+		// we update the same tx var so defer should see the latest tx
+		//(prev tx-es have commit called on them)
 	}
 
 	// if head hash was set then success otherwise no

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -450,6 +450,9 @@ func ExecV3(ctx context.Context,
 
 	// Only needed by bor chains
 	shouldGenerateChangesetsForLastBlocks := cfg.chainConfig.Bor != nil
+	startBlockNum := blockNum
+	blockLimit := uint64(cfg.syncCfg.LoopBlockLimit)
+	var errExhausted *ErrLoopExhausted
 
 Loop:
 	for ; blockNum <= maxBlockNum; blockNum++ {
@@ -729,9 +732,11 @@ Loop:
 
 				aggregatorRo := state2.AggTx(executor.tx())
 
-				needCalcRoot := executor.readState().SizeEstimate() >= commitThreshold ||
+				isBatchFull := executor.readState().SizeEstimate() >= commitThreshold
+				canPrune := aggregatorRo.CanPrune(executor.tx(), outputTxNum.Load())
+				needCalcRoot := isBatchFull ||
 					skipPostEvaluation || // If we skip post evaluation, then we should compute root hash ASAP for fail-fast
-					aggregatorRo.CanPrune(executor.tx(), outputTxNum.Load()) // if have something to prune - better prune ASAP to keep chaindata smaller
+					canPrune // if have something to prune - better prune ASAP to keep chaindata smaller
 				if !needCalcRoot {
 					break
 				}
@@ -774,15 +779,27 @@ Loop:
 				}
 
 				// on chain-tip: if batch is full then stop execution - to allow stages commit
-				if !initialCycle {
+				if !initialCycle && isBatchFull {
+					errExhausted = &ErrLoopExhausted{From: startBlockNum, To: blockNum, Reason: "block batch is full"}
 					break Loop
 				}
-				logger.Info("Committed", "time", time.Since(commitStart),
-					"block", outputBlockNum.GetValueUint64(), "txNum", inputTxNum,
-					"step", fmt.Sprintf("%.1f", float64(inputTxNum)/float64(agg.StepSize())),
-					"flush", flushDuration, "compute commitment", computeCommitmentDuration, "tx.commit", commitDuration, "prune", pruneDuration)
+				if !initialCycle && canPrune {
+					errExhausted = &ErrLoopExhausted{From: startBlockNum, To: blockNum, Reason: "block batch can be pruned"}
+					break Loop
+				}
+				if initialCycle {
+					logger.Info("Committed", "time", time.Since(commitStart),
+						"block", outputBlockNum.GetValueUint64(), "txNum", inputTxNum,
+						"step", fmt.Sprintf("%.1f", float64(inputTxNum)/float64(agg.StepSize())),
+						"flush", flushDuration, "compute commitment", computeCommitmentDuration, "tx.commit", commitDuration, "prune", pruneDuration)
+				}
 			default:
 			}
+		}
+
+		if blockLimit > 0 && blockNum-startBlockNum+1 >= blockLimit {
+			errExhausted = &ErrLoopExhausted{From: startBlockNum, To: blockNum, Reason: "block limit reached"}
+			break
 		}
 
 		select {
@@ -817,6 +834,12 @@ Loop:
 	}
 
 	agg.BuildFilesInBackground(outputTxNum.Load())
+
+	if errExhausted != nil && blockNum < maxBlockNum {
+		// special err allows the loop to continue, caller will call us again to continue from where we left off
+		// only return it if we haven't reached the maxBlockNum
+		return errExhausted
+	}
 
 	return nil
 }

--- a/execution/stagedsync/sync.go
+++ b/execution/stagedsync/sync.go
@@ -293,7 +293,8 @@ func (s *Sync) RunUnwind(db kv.RwDB, txc wrap.TxContainer) error {
 	return nil
 }
 
-func (s *Sync) RunNoInterrupt(db kv.RwDB, txc wrap.TxContainer) error {
+func (s *Sync) RunNoInterrupt(db kv.RwDB, txc wrap.TxContainer) (bool, error) {
+	var hasMore bool
 	initialCycle, firstCycle := false, false
 	s.prevUnwindPoint = nil
 	s.timings = s.timings[:0]
@@ -306,7 +307,7 @@ func (s *Sync) RunNoInterrupt(db kv.RwDB, txc wrap.TxContainer) error {
 					continue
 				}
 				if err := s.unwindStage(initialCycle, s.unwindOrder[j], db, txc); err != nil {
-					return err
+					return false, err
 				}
 			}
 			s.prevUnwindPoint = s.unwindPoint
@@ -316,7 +317,7 @@ func (s *Sync) RunNoInterrupt(db kv.RwDB, txc wrap.TxContainer) error {
 			}
 			s.unwindReason = UnwindReason{}
 			if err := s.SetCurrentStage(s.stages[0].ID); err != nil {
-				return err
+				return false, err
 			}
 			// If there were unwinds at the start, a heavier but invalid chain may be present, so
 			// we relax the rules for Stage1
@@ -327,7 +328,7 @@ func (s *Sync) RunNoInterrupt(db kv.RwDB, txc wrap.TxContainer) error {
 
 		if string(stage.ID) == dbg.StopBeforeStage() { // stop process for debugging reasons
 			s.logger.Warn("STOP_BEFORE_STAGE env flag forced to stop app")
-			return common.ErrStopped
+			return false, common.ErrStopped
 		}
 
 		if stage.Disabled || stage.Forward == nil {
@@ -337,13 +338,17 @@ func (s *Sync) RunNoInterrupt(db kv.RwDB, txc wrap.TxContainer) error {
 			continue
 		}
 
-		if err := s.runStage(stage, db, txc, initialCycle, firstCycle, badBlockUnwind); err != nil {
-			return err
+		stageHasMore, err := s.runStage(stage, db, txc, initialCycle, firstCycle, badBlockUnwind)
+		if err != nil {
+			return false, err
+		}
+		if stageHasMore {
+			hasMore = true
 		}
 
 		if string(stage.ID) == dbg.StopAfterStage() { // stop process for debugging reasons
 			s.logger.Warn("STOP_AFTER_STAGE env flag forced to stop app")
-			return common.ErrStopped
+			return false, common.ErrStopped
 		}
 
 		if string(stage.ID) == s.cfg.BreakAfterStage { // break process loop
@@ -355,11 +360,28 @@ func (s *Sync) RunNoInterrupt(db kv.RwDB, txc wrap.TxContainer) error {
 	}
 
 	if err := s.SetCurrentStage(s.stages[0].ID); err != nil {
-		return err
+		return false, err
 	}
 
 	s.currentStage = 0
-	return nil
+	return hasMore, nil
+}
+
+// ErrLoopExhausted is used to allow the sync loop to continue when one of the stages has thrown it due to reaching
+// some loop iteration limit.
+type ErrLoopExhausted struct {
+	From   uint64
+	To     uint64
+	Reason string
+}
+
+func (e *ErrLoopExhausted) Error() string {
+	return fmt.Sprintf("loop exhausted: from=%d, to=%d, reason=%s", e.From, e.To, e.Reason)
+}
+
+func (e *ErrLoopExhausted) Is(err error) bool {
+	var errExhausted *ErrLoopExhausted
+	return errors.As(err, &errExhausted)
 }
 
 func (s *Sync) Run(db kv.RwDB, txc wrap.TxContainer, initialCycle, firstCycle bool) (bool, error) {
@@ -409,8 +431,12 @@ func (s *Sync) Run(db kv.RwDB, txc wrap.TxContainer, initialCycle, firstCycle bo
 			s.NextStage()
 			continue
 		}
-		if err := s.runStage(stage, db, txc, initialCycle, firstCycle, badBlockUnwind); err != nil {
+		stageHasMore, err := s.runStage(stage, db, txc, initialCycle, firstCycle, badBlockUnwind)
+		if err != nil {
 			return false, err
+		}
+		if stageHasMore {
+			hasMore = true
 		}
 
 		if string(stage.ID) == dbg.StopAfterStage() { // stop process for debugging reasons
@@ -492,20 +518,30 @@ func (s *Sync) PrintTimings() []interface{} {
 	return logCtx
 }
 
-func (s *Sync) runStage(stage *Stage, db kv.RwDB, txc wrap.TxContainer, initialCycle, firstCycle bool, badBlockUnwind bool) (err error) {
+func (s *Sync) runStage(stage *Stage, db kv.RwDB, txc wrap.TxContainer, initialCycle, firstCycle bool, badBlockUnwind bool) (bool, error) {
 	start := time.Now()
 	s.logger.Debug(fmt.Sprintf("[%s] Starting Stage run", s.LogPrefix()))
 	stageState, err := s.StageState(stage.ID, txc.Tx, db, initialCycle, firstCycle)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	if err = stage.Forward(badBlockUnwind, stageState, s, txc, s.logger); err != nil {
-		wrappedError := fmt.Errorf("[%s] %w", s.LogPrefix(), err)
-		s.logger.Debug("Error while executing stage", "err", wrappedError)
-		return wrappedError
+		var errExhausted *ErrLoopExhausted
+		if errors.As(err, &errExhausted) {
+			s.logger.Debug(fmt.Sprintf("[%s] loop exhausted", s.LogPrefix()), "msg", err.Error())
+			s.logRunStageDone(stageState, start)
+			return true, nil
+		}
+		s.logger.Debug(fmt.Sprintf("[%s] error while executing stage", s.LogPrefix()), "err", err)
+		return false, fmt.Errorf("[%s] %w", s.LogPrefix(), err)
 	}
 
+	s.logRunStageDone(stageState, start)
+	return false, nil
+}
+
+func (s *Sync) logRunStageDone(stageState *StageState, start time.Time) {
 	took := time.Since(start)
 	logPrefix := s.LogPrefix()
 	if took > 60*time.Second {
@@ -513,9 +549,8 @@ func (s *Sync) runStage(stage *Stage, db kv.RwDB, txc wrap.TxContainer, initialC
 	} else {
 		s.logger.Debug(fmt.Sprintf("[%s] DONE", logPrefix), "in", took)
 	}
-	s.timings = append(s.timings, Timing{stage: stage.ID, took: took})
-	s.metricsCache.stageRunDurationSummary(stage.ID).Observe(took.Seconds())
-	return nil
+	s.timings = append(s.timings, Timing{stage: stageState.ID, took: took})
+	s.metricsCache.stageRunDurationSummary(stageState.ID).Observe(took.Seconds())
 }
 
 func (s *Sync) unwindStage(initialCycle bool, stage *Stage, db kv.RwDB, txc wrap.TxContainer) error {

--- a/execution/stages/stageloop.go
+++ b/execution/stages/stageloop.go
@@ -23,7 +23,6 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/erigontech/erigon-lib/common/debug"
 	lru "github.com/hashicorp/golang-lru/arc/v2"
 
 	"github.com/erigontech/erigon-db/rawdb"
@@ -32,6 +31,7 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/datadir"
 	"github.com/erigontech/erigon-lib/common/dbg"
+	"github.com/erigontech/erigon-lib/common/debug"
 	"github.com/erigontech/erigon-lib/common/metrics"
 	proto_downloader "github.com/erigontech/erigon-lib/gointerfaces/downloaderproto"
 	"github.com/erigontech/erigon-lib/kv"
@@ -207,10 +207,21 @@ func StageLoopIteration(ctx context.Context, db kv.RwDB, txc wrap.TxContainer, s
 	// avoid crash because Erigon's core does many things
 	defer debug.RecoverPanicIntoError(logger, &err)
 
+	hasMore := true
+	for hasMore {
+		hasMore, err = stageLoopIteration(ctx, db, txc, sync, initialCycle, firstCycle, logger, blockReader, hook)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func stageLoopIteration(ctx context.Context, db kv.RwDB, txc wrap.TxContainer, sync *stagedsync.Sync, initialCycle, firstCycle bool, logger log.Logger, blockReader services.FullBlockReader, hook *Hook) (hasMore bool, err error) {
 	externalTx := txc.Tx != nil
 	finishProgressBefore, borProgressBefore, headersProgressBefore, gasUsed, err := stagesHeadersAndFinish(db, txc.Tx)
 	if err != nil {
-		return err
+		return false, err
 	}
 	// Sync from scratch must be able Commit partial progress
 	// In all other cases - process blocks batch in 1 RwTx
@@ -240,17 +251,17 @@ func StageLoopIteration(ctx context.Context, db kv.RwDB, txc wrap.TxContainer, s
 	if canRunCycleInOneTransaction && !externalTx {
 		txc.Tx, err = db.BeginRwNosync(ctx)
 		if err != nil {
-			return err
+			return false, err
 		}
 		defer txc.Tx.Rollback()
 	}
 
 	if err = hook.BeforeRun(txc.Tx, isSynced); err != nil {
-		return err
+		return false, err
 	}
-	_, err = sync.Run(db, txc, initialCycle, firstCycle)
+	hasMore, err = sync.Run(db, txc, initialCycle, firstCycle)
 	if err != nil {
-		return err
+		return false, err
 	}
 	logCtx := sync.PrintTimings()
 	//var tableSizes []interface{}
@@ -261,14 +272,14 @@ func StageLoopIteration(ctx context.Context, db kv.RwDB, txc wrap.TxContainer, s
 		errTx := txc.Tx.Commit()
 		txc = wrap.NewTxContainer(nil, txc.Doms)
 		if errTx != nil {
-			return errTx
+			return false, errTx
 		}
 		commitTime = time.Since(commitStart)
 	}
 
 	// -- send notifications START
 	if err = hook.AfterRun(txc.Tx, finishProgressBefore); err != nil {
-		return err
+		return false, err
 	}
 	if canRunCycleInOneTransaction && !externalTx && commitTime > 500*time.Millisecond {
 		logger.Info("Commit cycle", "in", commitTime)
@@ -312,10 +323,10 @@ func StageLoopIteration(ctx context.Context, db kv.RwDB, txc wrap.TxContainer, s
 	}
 
 	if err != nil {
-		return err
+		return false, err
 	}
 
-	return nil
+	return hasMore, nil
 }
 
 func stagesHeadersAndFinish(db kv.RoDB, tx kv.Tx) (head, polygonSync, fin uint64, gasUsed uint64, err error) {
@@ -512,8 +523,12 @@ func MiningStep(ctx context.Context, db kv.RwDB, mining *stagedsync.Sync, tmpDir
 	defer sd.Close()
 	txc.Doms = sd
 
-	if _, err = mining.Run(nil, txc, false /* firstCycle */, false); err != nil {
+	hasMore, err := mining.Run(nil, txc, false /* firstCycle */, false)
+	if err != nil {
 		return err
+	}
+	if hasMore {
+		return errors.New("unexpected mining step has more work")
 	}
 	return nil
 }
@@ -611,12 +626,20 @@ func StateStep(ctx context.Context, chainReader consensus.ChainReader, engine co
 		}
 		// Run state sync
 		if !test {
-			if err = stateSync.RunNoInterrupt(nil, txc); err != nil {
+			hasMore, err := stateSync.RunNoInterrupt(nil, txc)
+			if err != nil {
 				if err := cleanupProgressIfNeeded(txc.Tx, currentHeader); err != nil {
 					return err
 
 				}
 				return err
+			}
+			if hasMore {
+				// should not ever happen since we exec blocks 1 by 1
+				if err := cleanupProgressIfNeeded(txc.Tx, currentHeader); err != nil {
+					return err
+				}
+				return errors.New("unexpected state step has more work")
 			}
 		}
 
@@ -631,13 +654,23 @@ func StateStep(ctx context.Context, chainReader consensus.ChainReader, engine co
 		return err
 	}
 
-	if err = stateSync.RunNoInterrupt(nil, txc); err != nil {
+	hasMore, err := stateSync.RunNoInterrupt(nil, txc)
+	if err != nil {
 		if !test {
 			if err := cleanupProgressIfNeeded(txc.Tx, header); err != nil {
 				return err
 			}
 		}
 		return err
+	}
+	if hasMore {
+		// should not ever happen since we exec blocks 1 by 1
+		if !test {
+			if err := cleanupProgressIfNeeded(txc.Tx, header); err != nil {
+				return err
+			}
+		}
+		return errors.New("unexpected state step has more work")
 	}
 
 	return nil


### PR DESCRIPTION
cherry-pick dc3413d32211c7d00b046d0d97e70da2688cb1a6

ProcessNewBlocks runs 10,000 blocks on start up after rm chaindata (doesn't take into account sync.loop.block.limit) - causes quite a lot of bloat on bloatnet
Also Mark reported similar issue while working on parallel exec but for UpdateForkChoice
Leaving this in draft for now - need to run some more tests