### PR TITLE
[r3.1] downgrade now remove new version unsupported files

### DIFF
--- a/erigon-lib/common/datadir/dirs.go
+++ b/erigon-lib/common/datadir/dirs.go
@@ -19,6 +19,7 @@ package datadir
 import (
 	"errors"
 	"fmt"
+	"github.com/erigontech/erigon-lib/kv"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -389,6 +390,23 @@ func (d Dirs) RenameNewVersions() error {
 
 	log.Info(fmt.Sprintf("Renamed %d directories to old format and removed %d unsupported files", renamed, removed))
 
+	//eliminate polygon-bridge && heimdall && chaindata just in case
+	if d.DataDir != "" {
+		if err := dir.RemoveAll(filepath.Join(d.DataDir, kv.PolygonBridgeDB)); err != nil {
+			return err
+		}
+		log.Info(fmt.Sprintf("Removed polygon-bridge directory: %s", filepath.Join(d.DataDir, kv.PolygonBridgeDB)))
+		if err := dir.RemoveAll(filepath.Join(d.DataDir, kv.HeimdallDB)); err != nil {
+			return err
+		}
+		log.Info(fmt.Sprintf("Removed heimdall directory: %s", filepath.Join(d.DataDir, kv.HeimdallDB)))
+		if d.Chaindata != "" {
+			if err := dir.RemoveAll(d.Chaindata); err != nil {
+				return err
+			}
+			log.Info(fmt.Sprintf("Removed chaindata directory: %s", d.Chaindata))
+		}
+	}
 	return nil
 }
 

--- a/erigon-lib/common/datadir/dirs.go
+++ b/erigon-lib/common/datadir/dirs.go
@@ -331,6 +331,7 @@ func (d Dirs) RenameNewVersions() error {
 		d.SnapAccessors, d.SnapCaplin, d.Downloader, d.TxPool, d.Snap,
 		d.Nodes, d.CaplinBlobs, d.CaplinIndexing, d.CaplinLatest, d.CaplinGenesis, d.CaplinColumnData,
 	}
+	var renamed, removed int
 
 	for _, dirPath := range directories {
 		// renaming v1.0- => v1-
@@ -346,6 +347,7 @@ func (d Dirs) RenameNewVersions() error {
 					if err := dir.RemoveFile(path); err != nil {
 						return fmt.Errorf("failed to remove file %s: %w", path, err)
 					}
+					removed++
 					return nil
 				}
 				newName := strings.Replace(dirEntry.Name(), "v1.0-", "v1-", 1)
@@ -355,6 +357,7 @@ func (d Dirs) RenameNewVersions() error {
 				if err := os.Rename(oldPath, newPath); err != nil {
 					return err
 				}
+				renamed++
 			}
 			return nil
 		})
@@ -374,6 +377,7 @@ func (d Dirs) RenameNewVersions() error {
 				if err != nil {
 					return fmt.Errorf("failed to remove file %s: %w", path, err)
 				}
+				removed++
 			}
 
 			return nil
@@ -382,6 +386,8 @@ func (d Dirs) RenameNewVersions() error {
 			return err
 		}
 	}
+
+	log.Info(fmt.Sprintf("Renamed %d directories to old format and removed %d unsupported files", renamed, removed))
 
 	return nil
 }

--- a/erigon-lib/common/datadir/dirs_test.go
+++ b/erigon-lib/common/datadir/dirs_test.go
@@ -1,0 +1,93 @@
+package datadir
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/erigontech/erigon-lib/common/dir"
+	"github.com/erigontech/erigon-lib/kv"
+	"github.com/stretchr/testify/require"
+)
+
+// mustExist asserts that a regular file exists
+func mustExist(t *testing.T, p string) {
+	t.Helper()
+	exists, err := dir.FileExist(p)
+	require.NoError(t, err)
+	require.True(t, exists)
+}
+
+// mustNotExist asserts that a regular file does not exist
+func mustNotExist(t *testing.T, p string) {
+	t.Helper()
+	exists, err := dir.FileExist(p)
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
+// mustDirExist asserts that a directory exists
+func mustDirExist(t *testing.T, p string) {
+	t.Helper()
+	exists, err := dir.Exist(p)
+	require.NoError(t, err)
+	require.True(t, exists)
+}
+
+// mustDirNotExist asserts that a directory does not exist
+func mustDirNotExist(t *testing.T, p string) {
+	t.Helper()
+	exists, err := dir.Exist(p)
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
+// helper to create an empty file
+func touch(t *testing.T, p string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+	f, err := os.Create(p)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+}
+
+func Test_RenameNewVersions(t *testing.T) {
+	base := t.TempDir()
+	d := New(base)
+	bridgeDir := filepath.Join(d.DataDir, kv.PolygonBridgeDB)
+	heimdallDir := filepath.Join(d.DataDir, kv.HeimdallDB)
+	touch(t, bridgeDir)
+	touch(t, heimdallDir)
+
+	// 1) v1.0- file should be renamed to v1-
+	oldName := filepath.Join(d.Snap, "v1.0-000001-000002-headers.seg")
+	newName := filepath.Join(d.Snap, "v1-000001-000002-headers.seg")
+	touch(t, oldName)
+
+	// 2) commitment file in SnapIdx should be removed (not renamed)
+	oldName2 := filepath.Join(d.SnapDomain, "v1.0-accounts.3596-3597.kv")
+	newName2 := filepath.Join(d.SnapDomain, "v1-accounts.3596-3597.kv")
+	touch(t, oldName2)
+
+	// Erigon3.0 supports only v1 versions. expect remove v2 files
+	unsupported := filepath.Join(d.SnapHistory, "v2.0-000001-000002-headers.idx")
+	touch(t, unsupported)
+
+	// Sanity preconditions
+	mustExist(t, oldName)
+	mustExist(t, oldName2)
+	mustExist(t, unsupported)
+
+	require.NoError(t, d.RenameNewVersions())
+
+	mustNotExist(t, oldName)
+	mustNotExist(t, oldName2)
+	mustExist(t, newName)
+	mustExist(t, newName2)
+
+	mustNotExist(t, unsupported)
+
+	mustDirNotExist(t, bridgeDir)
+	mustDirNotExist(t, heimdallDir)
+	mustDirNotExist(t, d.Chaindata)
+}

--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -908,18 +908,24 @@ func checkIfBlockSnapshotsPublishable(snapDir string) error {
 		for _, snapType := range []string{"headers", "transactions", "bodies"} {
 			segName := strings.Replace(headerSegName, "headers", snapType, 1)
 			// check that the file exist
-			if _, err := os.Stat(filepath.Join(snapDir, segName)); err != nil {
+			if exists, err := dir2.FileExist(filepath.Join(snapDir, segName)); err != nil {
+				return err
+			} else if !exists {
 				return fmt.Errorf("missing file %s", segName)
 			}
 			// check that the index file exist
 			idxName := strings.Replace(segName, ".seg", ".idx", 1)
-			if _, err := os.Stat(filepath.Join(snapDir, idxName)); err != nil {
+			if exists, err := dir2.FileExist(filepath.Join(snapDir, idxName)); err != nil {
+				return err
+			} else if !exists {
 				return fmt.Errorf("missing index file %s", idxName)
 			}
 			if snapType == "transactions" {
 				// check that the tx index file exist
 				txIdxName := strings.Replace(segName, "transactions.seg", "transactions-to-block.idx", 1)
-				if _, err := os.Stat(filepath.Join(snapDir, txIdxName)); err != nil {
+				if exists, err := dir2.FileExist(filepath.Join(snapDir, txIdxName)); err != nil {
+					return err
+				} else if !exists {
 					return fmt.Errorf("missing tx index file %s", txIdxName)
 				}
 			}


### PR DESCRIPTION
If you downgrade after running node on old files for some time (i.e. until chaintip) erigon will create by itself some new files with new versions. So, the downgrade from that point w/o delete this files is impossible. FYI @AskAlexSharov 