### PR TITLE
Arb: use main branch for snapshot delivery

### DIFF
--- a/erigon-lib/chain/snapcfg/util.go
+++ b/erigon-lib/chain/snapcfg/util.go
@@ -40,7 +40,7 @@ import (
 	ver "github.com/erigontech/erigon-lib/version"
 )
 
-var snapshotGitBranch = dbg.EnvString("SNAPS_GIT_BRANCH", version.DefaultSnapshotGitBranch)
+var snapshotGitBranch = dbg.EnvString("SNAPS_GIT_BRANCH", version.SnapshotMainGitBranch)
 
 var (
 	Mainnet    = fromEmbeddedToml(snapshothashes.Mainnet)

--- a/erigon-lib/version/app.go
+++ b/erigon-lib/version/app.go
@@ -23,4 +23,5 @@ const (
 	Micro                    = 0             // Patch version component of the current release
 	Modifier                 = "dev"         // Modifier component of the current release
 	DefaultSnapshotGitBranch = "release/3.1" // Branch of erigontech/erigon-snapshot to use in OtterSync
+	SnapshotMainGitBranch    = "main"        // Branch of erigontech/erigon-snapshot to use in OtterSync for arb-sepolia snapshots
 )


### PR DESCRIPTION
Default is release/3.1
Will add snapshots into this branch as a part of next snapshot publication. 