### PR TITLE
Log  Erigon Startup command

### DIFF
--- a/cmd/erigon/main.go
+++ b/cmd/erigon/main.go
@@ -57,6 +57,9 @@ func runErigon(cliCtx *cli.Context) (err error) {
 
 	debugMux := cmp.Or(metricsMux, pprofMux)
 
+	// Log the full command used to start the program (with sensitive info like URLs and IP addresses redacted)
+	logger.Info("Startup command", "cmd", log.RedactArgs(os.Args))
+
 	// initializing the node and providing the current git commit there
 
 	logger.Info("Build info", "git_branch", params.GitBranch, "git_tag", params.GitTag, "git_commit", params.GitCommit)

--- a/erigon-lib/log/v3/redact.go
+++ b/erigon-lib/log/v3/redact.go
@@ -1,0 +1,39 @@
+package log
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Precompiled regexes for redaction
+var (
+	reHTTP  = regexp.MustCompile(`(?i)http://\S+`)
+	reHTTPS = regexp.MustCompile(`(?i)https://\S+`)
+	reWS    = regexp.MustCompile(`(?i)ws://\S+`)
+	reWSS   = regexp.MustCompile(`(?i)wss://\S+`)
+	reIPv4  = regexp.MustCompile(`(^|[^\w-])((?:\d{1,3}\.){3}\d{1,3}(?::\d{1,5})?)\b`)
+	reIPv6  = regexp.MustCompile(`(^|[^\w-])(\[[0-9a-fA-F:]+\](?::\d{1,5})?)\b`)
+)
+
+// RedactArgs redacts sensitive information like HTTP(S), WS(S) urls and IP addresses from command line arguments
+func RedactArgs(args []string) string {
+	if len(args) == 0 {
+		return ""
+	}
+	s := strings.Join(args, " ")
+	return RedactString(s)
+}
+
+// RedactString redacts sensitive substrings in the provided string.
+func RedactString(s string) string {
+	// Redact URLs
+	s = reHTTP.ReplaceAllString(s, "http://[redacted]")
+	s = reHTTPS.ReplaceAllString(s, "https://[redacted]")
+	s = reWS.ReplaceAllString(s, "ws://[redacted]")
+	s = reWSS.ReplaceAllString(s, "wss://[redacted]")
+
+	// redact IPs
+	s = reIPv6.ReplaceAllString(s, "$1[redacted-ipv6]")
+	s = reIPv4.ReplaceAllString(s, "$1[redacted-ip]")
+	return s
+}

--- a/erigon-lib/log/v3/redact_test.go
+++ b/erigon-lib/log/v3/redact_test.go
@@ -1,0 +1,78 @@
+package log
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRedactArgsPreservesFlagsAndRedactsValues(t *testing.T) {
+	in := []string{
+		"./build/bin/erigon",
+		"--chain=bor",
+		"--datadir=~/erigon-data/bor-archive",
+		"--log.dir.verbosity", "debug",
+		"--torrent.conns.perfile", "100",
+		"--torrent.maxpeers", "1000",
+		"--torrent.download.slots", "10",
+		"--torrent.download.rate", "1G",
+		"--http.addr", "0.0.0.0",
+		"--http.port", "8545",
+		"--bor.heimdall", "https://polygon-heimdall-rest.publicnode.com",
+		"--prune.mode=archive",
+	}
+
+	out := RedactArgs(in)
+
+	// Flags must be preserved
+	mustContain(t, out, "--chain=bor")
+	mustContain(t, out, "--datadir=~/erigon-data/bor-archive")
+	mustContain(t, out, "--log.dir.verbosity")
+	mustContain(t, out, "--torrent.conns.perfile")
+	mustContain(t, out, "--torrent.maxpeers")
+	mustContain(t, out, "--torrent.download.slots")
+	mustContain(t, out, "--torrent.download.rate")
+	mustContain(t, out, "--bor.heimdall")
+	mustContain(t, out, "--prune.mode=archive")
+
+	// Values that are not sensitive should remain
+	mustContain(t, out, "debug")
+	mustContain(t, out, "100")
+	mustContain(t, out, "1000")
+	mustContain(t, out, "10")
+	mustContain(t, out, "1G")
+
+	// Sensitive URL must be redacted
+	if strings.Contains(out, "polygon-heimdall-rest.publicnode.com") {
+		t.Fatalf("expected url to be redacted, got: %s", out)
+	}
+	mustContain(t, out, "https://[redacted]")
+
+	// 0.0.0.0 must be redacted
+	if strings.Contains(out, "0.0.0.0") {
+		t.Fatalf("expected host IP to be redacted, got: %s", out)
+	}
+	mustContain(t, out, "--http.addr [redacted-ip]")
+
+}
+
+func TestRedactArgsStandaloneValues(t *testing.T) {
+	in := []string{
+		"cmd", "localhost:8545", "192.168.0.1:30303", "[::1]:8545", "wss://foo.bar:8443/path",
+		"http://foo.com", "ws://foo.bar",
+	}
+	out := RedactArgs(in)
+	mustContain(t, out, "localhost")
+	mustContain(t, out, "[redacted-ip]")
+	mustContain(t, out, "[redacted-ipv6]")
+	mustContain(t, out, "wss://[redacted]")
+	mustContain(t, out, "http://[redacted]")
+	mustContain(t, out, "ws://[redacted]")
+}
+
+// helpers
+func mustContain(t *testing.T, s, sub string) {
+	t.Helper()
+	if !strings.Contains(s, sub) {
+		t.Fatalf("expected output to contain %q, got: %s", sub, s)
+	}
+}


### PR DESCRIPTION
For better troubleshooting it helps to have the full command used + any flags in the logs. This PR prints the startup command while redacting potentially sensitive values like HTTP(S), WS(S) urls and IP addresses.