### PR TITLE
AddNewSeedableFile was skipping lock and bypassing checks

### DIFF
--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -882,15 +882,15 @@ func (d *Downloader) AddNewSeedableFile(ctx context.Context, name string) error 
 	// if we don't have the torrent file we build it if we have the .seg file
 	_, err := BuildTorrentIfNeed(ctx, name, d.SnapDir(), d.torrentFS)
 	if err != nil {
-		return fmt.Errorf("AddNewSeedableFile: %w", err)
+		return fmt.Errorf("building metainfo for new seedable file: %w", err)
 	}
-	ts, err := d.torrentFS.LoadByName(name)
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	// The above BuildTorrentIfNeed should put the metainfo in the right place for name.
+	// addPreverifiedTorrent is the correct wrapper to check for existing torrents in the client.
+	_, err = d.addPreverifiedTorrent(g.None[metainfo.Hash](), name)
 	if err != nil {
-		return fmt.Errorf("AddNewSeedableFile: %w", err)
-	}
-	_, _, err = d.addTorrentSpec(ts, name)
-	if err != nil {
-		return fmt.Errorf("addTorrentSpec: %w", err)
+		return fmt.Errorf("adding torrent: %w", err)
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/anacrolix/go-libutp v1.3.2
 	github.com/anacrolix/log v0.16.1-0.20250526073428-5cb74e15092b
 	github.com/anacrolix/missinggo/v2 v2.10.0
-	github.com/anacrolix/torrent v1.58.2-0.20250808032922-b6e9e69c96b4
+	github.com/anacrolix/torrent v1.58.2-0.20250811011913-5c778813ff6d
 	github.com/c2h5oh/datasize v0.0.0-20231215233829-aa82cc1e6500
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/consensys/gnark-crypto v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/anacrolix/sync v0.5.4/go.mod h1:21cUWerw9eiu/3T3kyoChu37AVO+YFue1/H15
 github.com/anacrolix/tagflag v0.0.0-20180109131632-2146c8d41bf0/go.mod h1:1m2U/K6ZT+JZG0+bdMK6qauP49QT4wE5pmhJXOKKCHw=
 github.com/anacrolix/tagflag v1.0.0/go.mod h1:1m2U/K6ZT+JZG0+bdMK6qauP49QT4wE5pmhJXOKKCHw=
 github.com/anacrolix/tagflag v1.1.0/go.mod h1:Scxs9CV10NQatSmbyjqmqmeQNwGzlNe0CMUMIxqHIG8=
-github.com/anacrolix/torrent v1.58.2-0.20250808032922-b6e9e69c96b4 h1:Er6x7YQQfTPclQQtU4Ixc6de9bo0/jF6p2pul/SxNUo=
-github.com/anacrolix/torrent v1.58.2-0.20250808032922-b6e9e69c96b4/go.mod h1:0r+Z8uhOf5vRYL8a0hnrN4lLehhPmDFlwfsQeEOUFss=
+github.com/anacrolix/torrent v1.58.2-0.20250811011913-5c778813ff6d h1:qLxiSh9zntUgojbtWWAW+TNTVJ2Y64fAcKTS83ugUuo=
+github.com/anacrolix/torrent v1.58.2-0.20250811011913-5c778813ff6d/go.mod h1:0r+Z8uhOf5vRYL8a0hnrN4lLehhPmDFlwfsQeEOUFss=
 github.com/anacrolix/upnp v0.1.4 h1:+2t2KA6QOhm/49zeNyeVwDu1ZYS9dB9wfxyVvh/wk7U=
 github.com/anacrolix/upnp v0.1.4/go.mod h1:Qyhbqo69gwNWvEk1xNTXsS5j7hMHef9hdr984+9fIic=
 github.com/anacrolix/utp v0.1.0 h1:FOpQOmIwYsnENnz7tAGohA+r6iXpRjrq8ssKSre2Cp4=


### PR DESCRIPTION
Also pulls change in anacrolix/torrent to be less pedantic about chunk size when adding torrents that already exist in the client.

Fixes #16481.

Needs to be cherry-picked to 3.1 after merge.