### PR TITLE
fix 500k file deletion on snapshotters

### DIFF
--- a/db/snapcfg/util.go
+++ b/db/snapcfg/util.go
@@ -372,7 +372,7 @@ func (c Cfg) Seedable(info snaptype.FileInfo) bool {
 // IsFrozen - can't be merged to bigger files
 func (c Cfg) IsFrozen(info snaptype.FileInfo) bool {
 	mergeLimit := c.MergeLimit(info.Type.Enum(), info.From)
-	return info.To-info.From == mergeLimit
+	return info.To-info.From >= mergeLimit
 }
 
 func (c Cfg) MergeLimit(t snaptype.Enum, fromBlock uint64) uint64 {


### PR DESCRIPTION
in `integrateMergedDirtyFiles`, non-frozen files before "new merged 100k file (frozen)" is collected for deletion. This caused deletion of 500k files which was merged offline. These ranges in preverified.toml are still 100k and `isFrozen` is strict. 
This PR extends the definition of `isFrozen`.