### PR TITLE
Support overriding remote preverified hashes and clobbering webseeds

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2065,9 +2065,14 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 			panic(err)
 		}
 		version := "erigon: " + params2.VersionWithCommit(params2.GitCommit)
-		webseedsList := common.CliString2Array(ctx.String(WebSeedsFlag.Name))
-		if known, ok := snapcfg.KnownWebseeds[chain]; ok {
-			webseedsList = append(webseedsList, known...)
+		var webseedsList []string
+		if ctx.IsSet(WebSeedsFlag.Name) {
+			// Unfortunately we don't take webseed URL here in the native format.
+			webseedsList = common.CliString2Array(ctx.String(WebSeedsFlag.Name))
+		} else {
+			if known, ok := snapcfg.KnownWebseeds[chain]; ok {
+				webseedsList = append(webseedsList, known...)
+			}
 		}
 		cfg.Downloader, err = downloadercfg.New(
 			ctx.Context,

--- a/db/downloader/downloadercfg/downloadercfg.go
+++ b/db/downloader/downloadercfg/downloadercfg.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/anacrolix/torrent/metainfo"
 	"golang.org/x/time/rate"
 
 	g "github.com/anacrolix/generics"
@@ -139,6 +140,10 @@ func New(
 	opts NewCfgOpts,
 ) (_ *Cfg, err error) {
 	torrentConfig := defaultTorrentClientConfig()
+
+	torrentConfig.MetainfoSourcesMerger = func(t *torrent.Torrent, info *metainfo.MetaInfo) error {
+		return t.SetInfoBytes(info.InfoBytes)
+	}
 
 	//torrentConfig.PieceHashersPerTorrent = runtime.NumCPU()
 	torrentConfig.DataDir = dirs.Snap // `DataDir` of torrent-client-lib is different from Erigon's `DataDir`. Just same naming.

--- a/db/snapcfg/util.go
+++ b/db/snapcfg/util.go
@@ -21,6 +21,8 @@ import (
 	_ "embed"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"os"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -51,6 +53,18 @@ var (
 	Gnosis     = fromEmbeddedToml(snapshothashes.Gnosis)
 	Chiado     = fromEmbeddedToml(snapshothashes.Chiado)
 	Hoodi      = fromEmbeddedToml(snapshothashes.Hoodi)
+
+	// Need to fix this already.
+	allPreverified = []*Preverified{
+		&Mainnet,
+		&Holesky,
+		&Sepolia,
+		&Amoy,
+		&BorMainnet,
+		&Gnosis,
+		&Chiado,
+		&Hoodi,
+	}
 )
 
 func fromEmbeddedToml(in []byte) Preverified {
@@ -509,6 +523,16 @@ func webseedsParse(in []byte) (res []string) {
 }
 
 func LoadRemotePreverified(ctx context.Context) (err error) {
+	if s, ok := os.LookupEnv("ERIGON_REMOTE_PREVERIFIED"); ok {
+		b, err := os.ReadFile(s)
+		if err != nil {
+			return fmt.Errorf("reading remote preverified override file: %w", err)
+		}
+		for _, p := range allPreverified {
+			*p = fromEmbeddedToml(b)
+		}
+		return nil
+	}
 	// Can't log in erigon-snapshot repo due to erigon-lib module import path.
 	log.Info("Loading remote snapshot hashes")
 	err = snapshothashes.LoadSnapshots(ctx, snapshothashes.R2, snapshotGitBranch)

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/anacrolix/go-libutp v1.3.2
 	github.com/anacrolix/log v0.16.1-0.20250526073428-5cb74e15092b
 	github.com/anacrolix/missinggo/v2 v2.10.0
-	github.com/anacrolix/torrent v1.58.2-0.20250811011913-5c778813ff6d
+	github.com/anacrolix/torrent v1.58.2-0.20250812132736-231b02a64d10
 	github.com/c2h5oh/datasize v0.0.0-20231215233829-aa82cc1e6500
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/consensys/gnark-crypto v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/anacrolix/sync v0.5.4/go.mod h1:21cUWerw9eiu/3T3kyoChu37AVO+YFue1/H15
 github.com/anacrolix/tagflag v0.0.0-20180109131632-2146c8d41bf0/go.mod h1:1m2U/K6ZT+JZG0+bdMK6qauP49QT4wE5pmhJXOKKCHw=
 github.com/anacrolix/tagflag v1.0.0/go.mod h1:1m2U/K6ZT+JZG0+bdMK6qauP49QT4wE5pmhJXOKKCHw=
 github.com/anacrolix/tagflag v1.1.0/go.mod h1:Scxs9CV10NQatSmbyjqmqmeQNwGzlNe0CMUMIxqHIG8=
-github.com/anacrolix/torrent v1.58.2-0.20250811011913-5c778813ff6d h1:qLxiSh9zntUgojbtWWAW+TNTVJ2Y64fAcKTS83ugUuo=
-github.com/anacrolix/torrent v1.58.2-0.20250811011913-5c778813ff6d/go.mod h1:0r+Z8uhOf5vRYL8a0hnrN4lLehhPmDFlwfsQeEOUFss=
+github.com/anacrolix/torrent v1.58.2-0.20250812132736-231b02a64d10 h1:eY67v1U6EPpU5PGam1CLRcLChFpLi0OJUxv3AXNjmEU=
+github.com/anacrolix/torrent v1.58.2-0.20250812132736-231b02a64d10/go.mod h1:0r+Z8uhOf5vRYL8a0hnrN4lLehhPmDFlwfsQeEOUFss=
 github.com/anacrolix/upnp v0.1.4 h1:+2t2KA6QOhm/49zeNyeVwDu1ZYS9dB9wfxyVvh/wk7U=
 github.com/anacrolix/upnp v0.1.4/go.mod h1:Qyhbqo69gwNWvEk1xNTXsS5j7hMHef9hdr984+9fIic=
 github.com/anacrolix/utp v0.1.0 h1:FOpQOmIwYsnENnz7tAGohA+r6iXpRjrq8ssKSre2Cp4=


### PR DESCRIPTION
Modifies `--webseed` to set the webseeds to *only* those URLs. Fixes anacrolix/torrent from automatically merging in webseeds from metainfos which made `--webseed` unreliable.

ERIGON_REMOTE_PREVERIFIED is the location of a file that contains preverified snapshot hashes. It is returned for all chains rather than using R2 or GitHub. Very useful for testing webseeds among other things.