### PR TITLE
reuse already prepared heimdall store in integrity check

### DIFF
--- a/eth/integrity/bor_snapshots.go
+++ b/eth/integrity/bor_snapshots.go
@@ -137,29 +137,27 @@ func ValidateBorEvents(ctx context.Context, db kv.TemporalRoDB, blockReader serv
 	return nil
 }
 
-func ValidateBorSpans(ctx context.Context, logger log.Logger, dirs datadir.Dirs, snaps *heimdall.RoSnapshots, failFast bool) error {
-	baseStore := heimdall.NewMdbxStore(logger, dirs.DataDir, true, 32)
-	snapshotStore := heimdall.NewSpanSnapshotStore(baseStore.Spans(), snaps)
+func ValidateBorSpans(ctx context.Context, logger log.Logger, dirs datadir.Dirs, heimdallStore heimdall.Store, snaps *heimdall.RoSnapshots, failFast bool) error {
+	//baseStore := heimdall.NewMdbxStore(logger, dirs.DataDir, true, 32)
+	snapshotStore := heimdall.NewSpanSnapshotStore(heimdallStore.Spans(), snaps)
 	err := snapshotStore.Prepare(ctx)
 	if err != nil {
 		return err
 	}
 	defer snapshotStore.Close()
-	defer baseStore.Close()
 	err = snapshotStore.ValidateSnapshots(ctx, logger, failFast)
 	logger.Info("[integrity] BorSpans: done", "err", err)
 	return err
 }
 
-func ValidateBorCheckpoints(ctx context.Context, logger log.Logger, dirs datadir.Dirs, snaps *heimdall.RoSnapshots, failFast bool) error {
-	baseStore := heimdall.NewMdbxStore(logger, dirs.DataDir, true, 32)
-	snapshotStore := heimdall.NewCheckpointSnapshotStore(baseStore.Checkpoints(), snaps)
+func ValidateBorCheckpoints(ctx context.Context, logger log.Logger, dirs datadir.Dirs, heimdallStore heimdall.Store, snaps *heimdall.RoSnapshots, failFast bool) error {
+	//baseStore := heimdall.NewMdbxStore(logger, dirs.DataDir, true, 32)
+	snapshotStore := heimdall.NewCheckpointSnapshotStore(heimdallStore.Checkpoints(), snaps)
 	err := snapshotStore.Prepare(ctx)
 	if err != nil {
 		return err
 	}
 	defer snapshotStore.Close()
-	defer baseStore.Close()
 	err = snapshotStore.ValidateSnapshots(ctx, logger, failFast)
 	logger.Info("[integrity] BorCheckpoints: done", "err", err)
 	return err

--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -804,6 +804,7 @@ func doIntegrity(cliCtx *cli.Context) error {
 	}
 
 	blockReader, _ := blockRetire.IO()
+	heimdallStore, bridgeStore := blockRetire.BorStore()
 	found := false
 	for _, chk := range checks {
 		if requestedCheck != "" && requestedCheck != chk {
@@ -845,7 +846,7 @@ func doIntegrity(cliCtx *cli.Context) error {
 				logger.Info("BorSpans skipped because not bor chain")
 				continue
 			}
-			if err := integrity.ValidateBorSpans(ctx, logger, dirs, borSnaps, failFast); err != nil {
+			if err := integrity.ValidateBorSpans(ctx, logger, dirs, heimdallStore, borSnaps, failFast); err != nil {
 				return err
 			}
 		case integrity.BorCheckpoints:
@@ -853,7 +854,7 @@ func doIntegrity(cliCtx *cli.Context) error {
 				logger.Info("BorCheckpoints skipped because not bor chain")
 				continue
 			}
-			if err := integrity.ValidateBorCheckpoints(ctx, logger, dirs, borSnaps, failFast); err != nil {
+			if err := integrity.ValidateBorCheckpoints(ctx, logger, dirs, heimdallStore, borSnaps, failFast); err != nil {
 				return err
 			}
 		case integrity.ReceiptsNoDups:

--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -804,7 +804,7 @@ func doIntegrity(cliCtx *cli.Context) error {
 	}
 
 	blockReader, _ := blockRetire.IO()
-	heimdallStore, bridgeStore := blockRetire.BorStore()
+	heimdallStore, _ := blockRetire.BorStore()
 	found := false
 	for _, chk := range checks {
 		if requestedCheck != "" && requestedCheck != chk {

--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -203,6 +203,10 @@ func (br *BlockRetire) IO() (services.FullBlockReader, *blockio.BlockWriter) {
 	return br.blockReader, br.blockWriter
 }
 
+func (br *BlockRetire) BorStore() (heimdall.Store, bridge.Store) {
+	return br.heimdallStore, br.bridgeStore
+}
+
 func (br *BlockRetire) Writer() *RoSnapshots { return br.blockReader.Snapshots().(*RoSnapshots) }
 
 func (br *BlockRetire) snapshots() *RoSnapshots { return br.blockReader.Snapshots().(*RoSnapshots) }


### PR DESCRIPTION
getting "temporarily unavailable" heimdall store error because it was opened twice (once in `openSnaps` then in `ValidateBorSpans` etc.)