### PR TITLE
execution: make `Rules` a function of `BlockContext`

### DIFF
--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -44,6 +44,7 @@ import (
 	"github.com/erigontech/erigon/core/state"
 	"github.com/erigontech/erigon/core/tracing"
 	"github.com/erigontech/erigon/core/vm"
+	"github.com/erigontech/erigon/core/vm/evmtypes"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/rawdbv3"
@@ -313,7 +314,7 @@ func Main(ctx *cli.Context) error {
 	blockNum, txNum := uint64(0), uint64(0)
 	sd.SetTxNum(txNum)
 	sd.SetBlockNum(blockNum)
-	reader, writer := MakePreState(chainConfig.Rules(0, 0), tx, sd, prestate.Pre, blockNum, txNum)
+	reader, writer := MakePreState(evmtypes.Rules(chainConfig, 0, 0), tx, sd, prestate.Pre, blockNum, txNum)
 	blockNum, txNum = uint64(1), uint64(2)
 	sd.SetTxNum(txNum)
 	sd.SetBlockNum(blockNum)

--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -314,7 +314,7 @@ func Main(ctx *cli.Context) error {
 	blockNum, txNum := uint64(0), uint64(0)
 	sd.SetTxNum(txNum)
 	sd.SetBlockNum(blockNum)
-	reader, writer := MakePreState(evmtypes.Rules(chainConfig, 0, 0), tx, sd, prestate.Pre, blockNum, txNum)
+	reader, writer := MakePreState((&evmtypes.BlockContext{}).Rules(chainConfig), tx, sd, prestate.Pre, blockNum, txNum)
 	blockNum, txNum = uint64(1), uint64(2)
 	sd.SetTxNum(txNum)
 	sd.SetBlockNum(blockNum)

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -334,7 +334,11 @@ func runCmd(ctx *cli.Context) error {
 	if ctx.Bool(DumpFlag.Name) {
 		rules := &chain.Rules{}
 		if chainConfig != nil {
-			rules = evmtypes.Rules(chainConfig, runtimeConfig.BlockNumber.Uint64(), runtimeConfig.Time.Uint64())
+			blockContext := evmtypes.BlockContext{
+				BlockNumber: runtimeConfig.BlockNumber.Uint64(),
+				Time:        runtimeConfig.Time.Uint64(),
+			}
+			rules = blockContext.Rules(chainConfig)
 		}
 		if err = statedb.CommitBlock(rules, state.NewNoopWriter()); err != nil {
 			fmt.Println("Could not commit state: ", err)

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -45,6 +45,7 @@ import (
 	"github.com/erigontech/erigon/core"
 	"github.com/erigontech/erigon/core/state"
 	"github.com/erigontech/erigon/core/vm"
+	"github.com/erigontech/erigon/core/vm/evmtypes"
 	"github.com/erigontech/erigon/core/vm/runtime"
 	"github.com/erigontech/erigon/db/config3"
 	"github.com/erigontech/erigon/db/datadir"
@@ -333,7 +334,7 @@ func runCmd(ctx *cli.Context) error {
 	if ctx.Bool(DumpFlag.Name) {
 		rules := &chain.Rules{}
 		if chainConfig != nil {
-			rules = chainConfig.Rules(runtimeConfig.BlockNumber.Uint64(), runtimeConfig.Time.Uint64())
+			rules = evmtypes.Rules(chainConfig, runtimeConfig.BlockNumber.Uint64(), runtimeConfig.Time.Uint64())
 		}
 		if err = statedb.CommitBlock(rules, state.NewNoopWriter()); err != nil {
 			fmt.Println("Could not commit state: ", err)

--- a/cmd/state/commands/opcode_tracer.go
+++ b/cmd/state/commands/opcode_tracer.go
@@ -40,7 +40,6 @@ import (
 	"github.com/erigontech/erigon/core/state"
 	"github.com/erigontech/erigon/core/tracing"
 	"github.com/erigontech/erigon/core/vm"
-	"github.com/erigontech/erigon/core/vm/evmtypes"
 	"github.com/erigontech/erigon/db/config3"
 	datadir2 "github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
@@ -739,7 +738,8 @@ func runBlock(engine consensus.Engine, ibs *state.IntraBlockState, txnWriter sta
 	var receipts types.Receipts
 	core.InitializeBlockExecution(engine, nil, header, chainConfig, ibs, nil, logger, nil)
 	blockNum := block.NumberU64()
-	rules := evmtypes.Rules(chainConfig, blockNum, block.Time())
+	blockContext := core.NewBlockContext(header, engine, chainConfig)
+	rules := blockContext.Rules(chainConfig)
 	for i, txn := range block.Transactions() {
 		ibs.SetTxContext(blockNum, i)
 		receipt, _, err := core.ApplyTransaction(chainConfig, core.GetHashFn(header, getHeader), engine, nil, gp, ibs, txnWriter, header, txn, gasUsed, usedBlobGas, vmConfig)

--- a/cmd/state/commands/opcode_tracer.go
+++ b/cmd/state/commands/opcode_tracer.go
@@ -738,7 +738,7 @@ func runBlock(engine consensus.Engine, ibs *state.IntraBlockState, txnWriter sta
 	var receipts types.Receipts
 	core.InitializeBlockExecution(engine, nil, header, chainConfig, ibs, nil, logger, nil)
 	blockNum := block.NumberU64()
-	blockContext := core.NewBlockContext(header, engine, chainConfig)
+	blockContext := core.NewEVMBlockContextHelper(header, engine, chainConfig)
 	rules := blockContext.Rules(chainConfig)
 	for i, txn := range block.Transactions() {
 		ibs.SetTxContext(blockNum, i)

--- a/cmd/state/commands/opcode_tracer.go
+++ b/cmd/state/commands/opcode_tracer.go
@@ -40,6 +40,7 @@ import (
 	"github.com/erigontech/erigon/core/state"
 	"github.com/erigontech/erigon/core/tracing"
 	"github.com/erigontech/erigon/core/vm"
+	"github.com/erigontech/erigon/core/vm/evmtypes"
 	"github.com/erigontech/erigon/db/config3"
 	datadir2 "github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
@@ -738,7 +739,7 @@ func runBlock(engine consensus.Engine, ibs *state.IntraBlockState, txnWriter sta
 	var receipts types.Receipts
 	core.InitializeBlockExecution(engine, nil, header, chainConfig, ibs, nil, logger, nil)
 	blockNum := block.NumberU64()
-	rules := chainConfig.Rules(blockNum, block.Time())
+	rules := evmtypes.Rules(chainConfig, blockNum, block.Time())
 	for i, txn := range block.Transactions() {
 		ibs.SetTxContext(blockNum, i)
 		receipt, _, err := core.ApplyTransaction(chainConfig, core.GetHashFn(header, getHeader), engine, nil, gp, ibs, txnWriter, header, txn, gasUsed, usedBlobGas, vmConfig)

--- a/cmd/state/commands/opcode_tracer.go
+++ b/cmd/state/commands/opcode_tracer.go
@@ -738,7 +738,7 @@ func runBlock(engine consensus.Engine, ibs *state.IntraBlockState, txnWriter sta
 	var receipts types.Receipts
 	core.InitializeBlockExecution(engine, nil, header, chainConfig, ibs, nil, logger, nil)
 	blockNum := block.NumberU64()
-	blockContext := core.NewEVMBlockContextHelper(header, engine, chainConfig)
+	blockContext := core.NewEVMBlockContext(header, core.GetHashFn(header, nil), engine, nil, chainConfig)
 	rules := blockContext.Rules(chainConfig)
 	for i, txn := range block.Transactions() {
 		ibs.SetTxContext(blockNum, i)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -263,19 +263,8 @@ func rlpHash(x interface{}) (h common.Hash) {
 	return h
 }
 
-func NewBlockContext(header *types.Header, engine consensus.EngineReader, chainConfig *chain.Config) evmtypes.BlockContext {
-	isBor := chainConfig.Bor != nil
-	var author *common.Address
-	if isBor {
-		author = &header.Coinbase
-	} else {
-		author = &state.SystemAddress
-	}
-	return NewEVMBlockContext(header, GetHashFn(header, nil), engine, author, chainConfig)
-}
-
 func SysCallContract(contract common.Address, data []byte, chainConfig *chain.Config, ibs *state.IntraBlockState, header *types.Header, engine consensus.EngineReader, constCall bool, vmCfg vm.Config) (result []byte, err error) {
-	blockContext := NewBlockContext(header, engine, chainConfig)
+	blockContext := NewEVMBlockContextHelper(header, engine, chainConfig)
 	return SysCallContractWithBlockContext(contract, data, chainConfig, ibs, blockContext, constCall, vmCfg)
 }
 
@@ -373,7 +362,7 @@ func FinalizeBlockExecution(
 		return nil, nil, err
 	}
 
-	blockContext := NewBlockContext(header, engine, cc)
+	blockContext := NewEVMBlockContextHelper(header, engine, cc)
 	if err := ibs.CommitBlock(blockContext.Rules(cc), stateWriter); err != nil {
 		return nil, nil, fmt.Errorf("committing block %d failed: %w", header.Number.Uint64(), err)
 	}
@@ -391,7 +380,7 @@ func InitializeBlockExecution(engine consensus.Engine, chain consensus.ChainHead
 	if stateWriter == nil {
 		stateWriter = state.NewNoopWriter()
 	}
-	blockContext := NewBlockContext(header, engine, cc)
+	blockContext := NewEVMBlockContextHelper(header, engine, cc)
 	ibs.FinalizeTx(blockContext.Rules(cc), stateWriter)
 	return nil
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -369,7 +369,7 @@ func FinalizeBlockExecution(
 		return nil, nil, err
 	}
 
-	if err := ibs.CommitBlock(cc.Rules(header.Number.Uint64(), header.Time), stateWriter); err != nil {
+	if err := ibs.CommitBlock(evmtypes.Rules(cc, header.Number.Uint64(), header.Time), stateWriter); err != nil {
 		return nil, nil, fmt.Errorf("committing block %d failed: %w", header.Number.Uint64(), err)
 	}
 
@@ -386,7 +386,7 @@ func InitializeBlockExecution(engine consensus.Engine, chain consensus.ChainHead
 	if stateWriter == nil {
 		stateWriter = state.NewNoopWriter()
 	}
-	ibs.FinalizeTx(cc.Rules(header.Number.Uint64(), header.Time), stateWriter)
+	ibs.FinalizeTx(evmtypes.Rules(cc, header.Number.Uint64(), header.Time), stateWriter)
 	return nil
 }
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -263,7 +263,7 @@ func rlpHash(x interface{}) (h common.Hash) {
 	return h
 }
 
-func newBlockContext(header *types.Header, engine consensus.EngineReader, chainConfig *chain.Config) evmtypes.BlockContext {
+func NewBlockContext(header *types.Header, engine consensus.EngineReader, chainConfig *chain.Config) evmtypes.BlockContext {
 	isBor := chainConfig.Bor != nil
 	var author *common.Address
 	if isBor {
@@ -275,7 +275,7 @@ func newBlockContext(header *types.Header, engine consensus.EngineReader, chainC
 }
 
 func SysCallContract(contract common.Address, data []byte, chainConfig *chain.Config, ibs *state.IntraBlockState, header *types.Header, engine consensus.EngineReader, constCall bool, vmCfg vm.Config) (result []byte, err error) {
-	blockContext := newBlockContext(header, engine, chainConfig)
+	blockContext := NewBlockContext(header, engine, chainConfig)
 	return SysCallContractWithBlockContext(contract, data, chainConfig, ibs, blockContext, constCall, vmCfg)
 }
 
@@ -373,7 +373,7 @@ func FinalizeBlockExecution(
 		return nil, nil, err
 	}
 
-	blockContext := newBlockContext(header, engine, cc)
+	blockContext := NewBlockContext(header, engine, cc)
 	if err := ibs.CommitBlock(blockContext.Rules(cc), stateWriter); err != nil {
 		return nil, nil, fmt.Errorf("committing block %d failed: %w", header.Number.Uint64(), err)
 	}
@@ -391,7 +391,7 @@ func InitializeBlockExecution(engine consensus.Engine, chain consensus.ChainHead
 	if stateWriter == nil {
 		stateWriter = state.NewNoopWriter()
 	}
-	blockContext := newBlockContext(header, engine, cc)
+	blockContext := NewBlockContext(header, engine, cc)
 	ibs.FinalizeTx(blockContext.Rules(cc), stateWriter)
 	return nil
 }

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -29,7 +29,6 @@ import (
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/core/state"
 	"github.com/erigontech/erigon/core/vm"
-	"github.com/erigontech/erigon/core/vm/evmtypes"
 	"github.com/erigontech/erigon/db/kv"
 	dbstate "github.com/erigontech/erigon/db/state"
 	"github.com/erigontech/erigon/execution/chain"
@@ -375,7 +374,8 @@ func GenerateChain(config *chain.Config, parent *types.Block, engine consensus.E
 				return nil, nil, fmt.Errorf("call to FinaliseAndAssemble: %w", err)
 			}
 			// Write state changes to db
-			if err := ibs.CommitBlock(evmtypes.Rules(config, b.header.Number.Uint64(), b.header.Time), stateWriter); err != nil {
+			blockContext := NewBlockContext(b.header, b.engine, config)
+			if err := ibs.CommitBlock(blockContext.Rules(config), stateWriter); err != nil {
 				return nil, nil, fmt.Errorf("call to CommitBlock to stateWriter: %w", err)
 			}
 

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -374,7 +374,7 @@ func GenerateChain(config *chain.Config, parent *types.Block, engine consensus.E
 				return nil, nil, fmt.Errorf("call to FinaliseAndAssemble: %w", err)
 			}
 			// Write state changes to db
-			blockContext := NewEVMBlockContextHelper(b.header, b.engine, config)
+			blockContext := NewEVMBlockContext(b.header, GetHashFn(b.header, nil), b.engine, nil, config)
 			if err := ibs.CommitBlock(blockContext.Rules(config), stateWriter); err != nil {
 				return nil, nil, fmt.Errorf("call to CommitBlock to stateWriter: %w", err)
 			}

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -374,7 +374,7 @@ func GenerateChain(config *chain.Config, parent *types.Block, engine consensus.E
 				return nil, nil, fmt.Errorf("call to FinaliseAndAssemble: %w", err)
 			}
 			// Write state changes to db
-			blockContext := NewBlockContext(b.header, b.engine, config)
+			blockContext := NewEVMBlockContextHelper(b.header, b.engine, config)
 			if err := ibs.CommitBlock(blockContext.Rules(config), stateWriter); err != nil {
 				return nil, nil, fmt.Errorf("call to CommitBlock to stateWriter: %w", err)
 			}

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -29,6 +29,7 @@ import (
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/core/state"
 	"github.com/erigontech/erigon/core/vm"
+	"github.com/erigontech/erigon/core/vm/evmtypes"
 	"github.com/erigontech/erigon/db/kv"
 	dbstate "github.com/erigontech/erigon/db/state"
 	"github.com/erigontech/erigon/execution/chain"
@@ -374,7 +375,7 @@ func GenerateChain(config *chain.Config, parent *types.Block, engine consensus.E
 				return nil, nil, fmt.Errorf("call to FinaliseAndAssemble: %w", err)
 			}
 			// Write state changes to db
-			if err := ibs.CommitBlock(config.Rules(b.header.Number.Uint64(), b.header.Time), stateWriter); err != nil {
+			if err := ibs.CommitBlock(evmtypes.Rules(config, b.header.Number.Uint64(), b.header.Time), stateWriter); err != nil {
 				return nil, nil, fmt.Errorf("call to CommitBlock to stateWriter: %w", err)
 			}
 

--- a/core/evm.go
+++ b/core/evm.go
@@ -55,7 +55,7 @@ func NewEVMBlockContext(header *types.Header, blockHashFunc func(n uint64) (comm
 	}
 
 	var prevRandDao *common.Hash
-	if header.Difficulty.Cmp(merge.ProofOfStakeDifficulty) == 0 {
+	if header.Difficulty != nil && header.Difficulty.Cmp(merge.ProofOfStakeDifficulty) == 0 {
 		// EIP-4399. We use ProofOfStakeDifficulty (i.e. 0) as a telltale of Proof-of-Stake blocks.
 		prevRandDao = new(common.Hash)
 		*prevRandDao = header.MixDigest
@@ -79,7 +79,7 @@ func NewEVMBlockContext(header *types.Header, blockHashFunc func(n uint64) (comm
 		transferFunc = consensus.Transfer
 		postApplyMessageFunc = nil
 	}
-	return evmtypes.BlockContext{
+	blockContext := evmtypes.BlockContext{
 		CanTransfer:      CanTransfer,
 		Transfer:         transferFunc,
 		GetHash:          blockHashFunc,
@@ -87,12 +87,15 @@ func NewEVMBlockContext(header *types.Header, blockHashFunc func(n uint64) (comm
 		Coinbase:         beneficiary,
 		BlockNumber:      header.Number.Uint64(),
 		Time:             header.Time,
-		Difficulty:       new(big.Int).Set(header.Difficulty),
 		BaseFee:          &baseFee,
 		GasLimit:         header.GasLimit,
 		PrevRanDao:       prevRandDao,
 		BlobBaseFee:      blobBaseFee,
 	}
+	if header.Difficulty != nil {
+		blockContext.Difficulty = new(big.Int).Set(header.Difficulty)
+	}
+	return blockContext
 }
 
 // NewEVMTxContext creates a new transaction context for a single transaction.

--- a/core/evm.go
+++ b/core/evm.go
@@ -27,7 +27,6 @@ import (
 	"github.com/holiman/uint256"
 
 	"github.com/erigontech/erigon-lib/common"
-	"github.com/erigontech/erigon/core/state"
 	"github.com/erigontech/erigon/core/vm/evmtypes"
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/consensus"
@@ -97,17 +96,6 @@ func NewEVMBlockContext(header *types.Header, blockHashFunc func(n uint64) (comm
 		blockContext.Difficulty = new(big.Int).Set(header.Difficulty)
 	}
 	return blockContext
-}
-
-func NewEVMBlockContextHelper(header *types.Header, engine consensus.EngineReader, chainConfig *chain.Config) evmtypes.BlockContext {
-	isBor := chainConfig.Bor != nil
-	var author *common.Address
-	if isBor {
-		author = &header.Coinbase
-	} else {
-		author = &state.SystemAddress
-	}
-	return NewEVMBlockContext(header, GetHashFn(header, nil), engine, author, chainConfig)
 }
 
 // NewEVMTxContext creates a new transaction context for a single transaction.

--- a/core/evm.go
+++ b/core/evm.go
@@ -27,6 +27,7 @@ import (
 	"github.com/holiman/uint256"
 
 	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon/core/state"
 	"github.com/erigontech/erigon/core/vm/evmtypes"
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/consensus"
@@ -96,6 +97,17 @@ func NewEVMBlockContext(header *types.Header, blockHashFunc func(n uint64) (comm
 		blockContext.Difficulty = new(big.Int).Set(header.Difficulty)
 	}
 	return blockContext
+}
+
+func NewEVMBlockContextHelper(header *types.Header, engine consensus.EngineReader, chainConfig *chain.Config) evmtypes.BlockContext {
+	isBor := chainConfig.Bor != nil
+	var author *common.Address
+	if isBor {
+		author = &header.Coinbase
+	} else {
+		author = &state.SystemAddress
+	}
+	return NewEVMBlockContext(header, GetHashFn(header, nil), engine, author, chainConfig)
 }
 
 // NewEVMTxContext creates a new transaction context for a single transaction.

--- a/core/evm.go
+++ b/core/evm.go
@@ -55,7 +55,7 @@ func NewEVMBlockContext(header *types.Header, blockHashFunc func(n uint64) (comm
 	}
 
 	var prevRandDao *common.Hash
-	if header.Difficulty != nil && header.Difficulty.Cmp(merge.ProofOfStakeDifficulty) == 0 {
+	if header.Difficulty.Cmp(merge.ProofOfStakeDifficulty) == 0 {
 		// EIP-4399. We use ProofOfStakeDifficulty (i.e. 0) as a telltale of Proof-of-Stake blocks.
 		prevRandDao = new(common.Hash)
 		*prevRandDao = header.MixDigest
@@ -79,7 +79,7 @@ func NewEVMBlockContext(header *types.Header, blockHashFunc func(n uint64) (comm
 		transferFunc = consensus.Transfer
 		postApplyMessageFunc = nil
 	}
-	blockContext := evmtypes.BlockContext{
+	return evmtypes.BlockContext{
 		CanTransfer:      CanTransfer,
 		Transfer:         transferFunc,
 		GetHash:          blockHashFunc,
@@ -87,15 +87,12 @@ func NewEVMBlockContext(header *types.Header, blockHashFunc func(n uint64) (comm
 		Coinbase:         beneficiary,
 		BlockNumber:      header.Number.Uint64(),
 		Time:             header.Time,
+		Difficulty:       new(big.Int).Set(header.Difficulty),
 		BaseFee:          &baseFee,
 		GasLimit:         header.GasLimit,
 		PrevRanDao:       prevRandDao,
 		BlobBaseFee:      blobBaseFee,
 	}
-	if header.Difficulty != nil {
-		blockContext.Difficulty = new(big.Int).Set(header.Difficulty)
-	}
-	return blockContext
 }
 
 // NewEVMTxContext creates a new transaction context for a single transaction.

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -93,7 +93,7 @@ func NewEVM(blockCtx evmtypes.BlockContext, txCtx evmtypes.TxContext, ibs *state
 		intraBlockState: ibs,
 		config:          vmConfig,
 		chainConfig:     chainConfig,
-		chainRules:      evmtypes.Rules(chainConfig, blockCtx.BlockNumber, blockCtx.Time),
+		chainRules:      blockCtx.Rules(chainConfig),
 	}
 	if evm.config.JumpDestCache == nil {
 		evm.config.JumpDestCache = NewJumpDestCache(JumpDestCacheLimit)

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -93,7 +93,7 @@ func NewEVM(blockCtx evmtypes.BlockContext, txCtx evmtypes.TxContext, ibs *state
 		intraBlockState: ibs,
 		config:          vmConfig,
 		chainConfig:     chainConfig,
-		chainRules:      chainConfig.Rules(blockCtx.BlockNumber, blockCtx.Time),
+		chainRules:      evmtypes.Rules(chainConfig, blockCtx.BlockNumber, blockCtx.Time),
 	}
 	if evm.config.JumpDestCache == nil {
 		evm.config.JumpDestCache = NewJumpDestCache(JumpDestCacheLimit)

--- a/core/vm/evmtypes/rules.go
+++ b/core/vm/evmtypes/rules.go
@@ -1,0 +1,51 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package evmtypes
+
+import (
+	"math/big"
+
+	"github.com/erigontech/erigon/execution/chain"
+)
+
+// Rules ensures c's ChainID is not nil and returns a new Rules instance
+func Rules(c *chain.Config, num uint64, time uint64) *chain.Rules {
+	chainID := c.ChainID
+	if chainID == nil {
+		chainID = new(big.Int)
+	}
+
+	return &chain.Rules{
+		ChainID:            new(big.Int).Set(chainID),
+		IsHomestead:        c.IsHomestead(num),
+		IsTangerineWhistle: c.IsTangerineWhistle(num),
+		IsSpuriousDragon:   c.IsSpuriousDragon(num),
+		IsByzantium:        c.IsByzantium(num),
+		IsConstantinople:   c.IsConstantinople(num),
+		IsPetersburg:       c.IsPetersburg(num),
+		IsIstanbul:         c.IsIstanbul(num),
+		IsBerlin:           c.IsBerlin(num),
+		IsLondon:           c.IsLondon(num),
+		IsShanghai:         c.IsShanghai(time) || c.IsAgra(num),
+		IsCancun:           c.IsCancun(time),
+		IsNapoli:           c.IsNapoli(num),
+		IsBhilai:           c.IsBhilai(num),
+		IsPrague:           c.IsPrague(time) || c.IsBhilai(num),
+		IsOsaka:            c.IsOsaka(time),
+		IsAura:             c.Aura != nil,
+	}
+}

--- a/core/vm/evmtypes/rules.go
+++ b/core/vm/evmtypes/rules.go
@@ -23,7 +23,7 @@ import (
 )
 
 // Rules ensures c's ChainID is not nil and returns a new Rules instance
-func Rules(c *chain.Config, num uint64, time uint64) *chain.Rules {
+func (bc *BlockContext) Rules(c *chain.Config) *chain.Rules {
 	chainID := c.ChainID
 	if chainID == nil {
 		chainID = new(big.Int)
@@ -31,21 +31,21 @@ func Rules(c *chain.Config, num uint64, time uint64) *chain.Rules {
 
 	return &chain.Rules{
 		ChainID:            new(big.Int).Set(chainID),
-		IsHomestead:        c.IsHomestead(num),
-		IsTangerineWhistle: c.IsTangerineWhistle(num),
-		IsSpuriousDragon:   c.IsSpuriousDragon(num),
-		IsByzantium:        c.IsByzantium(num),
-		IsConstantinople:   c.IsConstantinople(num),
-		IsPetersburg:       c.IsPetersburg(num),
-		IsIstanbul:         c.IsIstanbul(num),
-		IsBerlin:           c.IsBerlin(num),
-		IsLondon:           c.IsLondon(num),
-		IsShanghai:         c.IsShanghai(time) || c.IsAgra(num),
-		IsCancun:           c.IsCancun(time),
-		IsNapoli:           c.IsNapoli(num),
-		IsBhilai:           c.IsBhilai(num),
-		IsPrague:           c.IsPrague(time) || c.IsBhilai(num),
-		IsOsaka:            c.IsOsaka(time),
+		IsHomestead:        c.IsHomestead(bc.BlockNumber),
+		IsTangerineWhistle: c.IsTangerineWhistle(bc.BlockNumber),
+		IsSpuriousDragon:   c.IsSpuriousDragon(bc.BlockNumber),
+		IsByzantium:        c.IsByzantium(bc.BlockNumber),
+		IsConstantinople:   c.IsConstantinople(bc.BlockNumber),
+		IsPetersburg:       c.IsPetersburg(bc.BlockNumber),
+		IsIstanbul:         c.IsIstanbul(bc.BlockNumber),
+		IsBerlin:           c.IsBerlin(bc.BlockNumber),
+		IsLondon:           c.IsLondon(bc.BlockNumber),
+		IsShanghai:         c.IsShanghai(bc.Time) || c.IsAgra(bc.BlockNumber),
+		IsCancun:           c.IsCancun(bc.Time),
+		IsNapoli:           c.IsNapoli(bc.BlockNumber),
+		IsBhilai:           c.IsBhilai(bc.BlockNumber),
+		IsPrague:           c.IsPrague(bc.Time) || c.IsBhilai(bc.BlockNumber),
+		IsOsaka:            c.IsOsaka(bc.Time),
 		IsAura:             c.Aura != nil,
 	}
 }

--- a/core/vm/gas_table_test.go
+++ b/core/vm/gas_table_test.go
@@ -144,13 +144,13 @@ func TestEIP2200(t *testing.T) {
 			s.SetCode(address, hexutil.MustDecode(tt.input))
 			s.SetState(address, common.Hash{}, *uint256.NewInt(uint64(tt.original)))
 
-			_ = s.CommitBlock(evmtypes.Rules(chain.AllProtocolChanges, 0, 0), w)
 			vmctx := evmtypes.BlockContext{
 				CanTransfer: func(evmtypes.IntraBlockState, common.Address, *uint256.Int) (bool, error) { return true, nil },
 				Transfer: func(evmtypes.IntraBlockState, common.Address, common.Address, *uint256.Int, bool) error {
 					return nil
 				},
 			}
+			_ = s.CommitBlock(vmctx.Rules(chain.AllProtocolChanges), w)
 			vmenv := vm.NewEVM(vmctx, evmtypes.TxContext{}, s, chain.AllProtocolChanges, vm.Config{ExtraEips: []int{2200}})
 
 			_, gas, err := vmenv.Call(vm.AccountRef(common.Address{}), address, nil, tt.gaspool, new(uint256.Int), false /* bailout */)
@@ -202,7 +202,6 @@ func TestCreateGas(t *testing.T) {
 		s := state.New(stateReader)
 		s.CreateAccount(address, true)
 		s.SetCode(address, hexutil.MustDecode(tt.code))
-		_ = s.CommitBlock(evmtypes.Rules(chain.TestChainConfig, 0, 0), stateWriter)
 
 		vmctx := evmtypes.BlockContext{
 			CanTransfer: func(evmtypes.IntraBlockState, common.Address, *uint256.Int) (bool, error) { return true, nil },
@@ -210,6 +209,7 @@ func TestCreateGas(t *testing.T) {
 				return nil
 			},
 		}
+		_ = s.CommitBlock(vmctx.Rules(chain.TestChainConfig), stateWriter)
 		config := vm.Config{}
 		if tt.eip3860 {
 			config.ExtraEips = []int{3860}

--- a/core/vm/gas_table_test.go
+++ b/core/vm/gas_table_test.go
@@ -144,7 +144,7 @@ func TestEIP2200(t *testing.T) {
 			s.SetCode(address, hexutil.MustDecode(tt.input))
 			s.SetState(address, common.Hash{}, *uint256.NewInt(uint64(tt.original)))
 
-			_ = s.CommitBlock(chain.AllProtocolChanges.Rules(0, 0), w)
+			_ = s.CommitBlock(evmtypes.Rules(chain.AllProtocolChanges, 0, 0), w)
 			vmctx := evmtypes.BlockContext{
 				CanTransfer: func(evmtypes.IntraBlockState, common.Address, *uint256.Int) (bool, error) { return true, nil },
 				Transfer: func(evmtypes.IntraBlockState, common.Address, common.Address, *uint256.Int, bool) error {
@@ -202,7 +202,7 @@ func TestCreateGas(t *testing.T) {
 		s := state.New(stateReader)
 		s.CreateAccount(address, true)
 		s.SetCode(address, hexutil.MustDecode(tt.code))
-		_ = s.CommitBlock(chain.TestChainConfig.Rules(0, 0), stateWriter)
+		_ = s.CommitBlock(evmtypes.Rules(chain.TestChainConfig, 0, 0), stateWriter)
 
 		vmctx := evmtypes.BlockContext{
 			CanTransfer: func(evmtypes.IntraBlockState, common.Address, *uint256.Int) (bool, error) { return true, nil },

--- a/eth/tracers/internal/tracetest/calltrace_test.go
+++ b/eth/tracers/internal/tracetest/calltrace_test.go
@@ -148,7 +148,7 @@ func testCallTracer(tracerName string, dirPath string, t *testing.T) {
 			if test.Context.BaseFee != nil {
 				context.BaseFee, _ = uint256.FromBig((*big.Int)(test.Context.BaseFee))
 			}
-			rules := evmtypes.Rules(test.Genesis.Config, context.BlockNumber, context.Time)
+			rules := context.Rules(test.Genesis.Config)
 
 			m := mock.Mock(t)
 			dbTx, err := m.DB.BeginTemporalRw(m.Ctx)
@@ -337,7 +337,7 @@ func TestZeroValueToNotExitCall(t *testing.T) {
 			Balance: big.NewInt(500000000000000),
 		},
 	}
-	rules := evmtypes.Rules(chainspec.MainnetChainConfig, context.BlockNumber, context.Time)
+	rules := context.Rules(chainspec.MainnetChainConfig)
 	m := mock.Mock(t)
 	dbTx, err := m.DB.BeginTemporalRw(m.Ctx)
 	require.NoError(t, err)

--- a/eth/tracers/internal/tracetest/calltrace_test.go
+++ b/eth/tracers/internal/tracetest/calltrace_test.go
@@ -148,7 +148,7 @@ func testCallTracer(tracerName string, dirPath string, t *testing.T) {
 			if test.Context.BaseFee != nil {
 				context.BaseFee, _ = uint256.FromBig((*big.Int)(test.Context.BaseFee))
 			}
-			rules := test.Genesis.Config.Rules(context.BlockNumber, context.Time)
+			rules := evmtypes.Rules(test.Genesis.Config, context.BlockNumber, context.Time)
 
 			m := mock.Mock(t)
 			dbTx, err := m.DB.BeginTemporalRw(m.Ctx)
@@ -337,7 +337,7 @@ func TestZeroValueToNotExitCall(t *testing.T) {
 			Balance: big.NewInt(500000000000000),
 		},
 	}
-	rules := chainspec.MainnetChainConfig.Rules(context.BlockNumber, context.Time)
+	rules := evmtypes.Rules(chainspec.MainnetChainConfig, context.BlockNumber, context.Time)
 	m := mock.Mock(t)
 	dbTx, err := m.DB.BeginTemporalRw(m.Ctx)
 	require.NoError(t, err)

--- a/eth/tracers/internal/tracetest/prestate_test.go
+++ b/eth/tracers/internal/tracetest/prestate_test.go
@@ -114,7 +114,7 @@ func testPrestateTracer(tracerName string, dirPath string, t *testing.T) {
 			if test.Context.BaseFee != nil {
 				context.BaseFee, _ = uint256.FromBig((*big.Int)(test.Context.BaseFee))
 			}
-			rules := evmtypes.Rules(test.Genesis.Config, context.BlockNumber, context.Time)
+			rules := context.Rules(test.Genesis.Config)
 			m := mock.Mock(t)
 			dbTx, err := m.DB.BeginTemporalRw(m.Ctx)
 			require.NoError(t, err)

--- a/eth/tracers/internal/tracetest/prestate_test.go
+++ b/eth/tracers/internal/tracetest/prestate_test.go
@@ -114,7 +114,7 @@ func testPrestateTracer(tracerName string, dirPath string, t *testing.T) {
 			if test.Context.BaseFee != nil {
 				context.BaseFee, _ = uint256.FromBig((*big.Int)(test.Context.BaseFee))
 			}
-			rules := test.Genesis.Config.Rules(context.BlockNumber, context.Time)
+			rules := evmtypes.Rules(test.Genesis.Config, context.BlockNumber, context.Time)
 			m := mock.Mock(t)
 			dbTx, err := m.DB.BeginTemporalRw(m.Ctx)
 			require.NoError(t, err)

--- a/eth/tracers/js/goja.go
+++ b/eth/tracers/js/goja.go
@@ -232,7 +232,11 @@ func (t *jsTracer) OnTxStart(env *tracing.VMContext, tx types.Transaction, from 
 
 	db := &dbObj{ibs: env.IntraBlockState, vm: t.vm, toBig: t.toBig, toBuf: t.toBuf, fromBuf: t.fromBuf}
 	t.dbValue = db.setupObject()
-	rules := evmtypes.Rules(env.ChainConfig, env.BlockNumber, env.Time)
+	blockContext := evmtypes.BlockContext{
+		BlockNumber: env.BlockNumber,
+		Time:        env.Time,
+	}
+	rules := blockContext.Rules(env.ChainConfig)
 	t.activePrecompiles = vm.ActivePrecompiles(rules)
 	t.ctx["block"] = t.vm.ToValue(t.env.BlockNumber)
 	t.ctx["gas"] = t.vm.ToValue(tx.GetGasLimit())

--- a/eth/tracers/js/goja.go
+++ b/eth/tracers/js/goja.go
@@ -33,6 +33,7 @@ import (
 	"github.com/erigontech/erigon-lib/crypto"
 	"github.com/erigontech/erigon/core/tracing"
 	"github.com/erigontech/erigon/core/vm"
+	"github.com/erigontech/erigon/core/vm/evmtypes"
 	"github.com/erigontech/erigon/eth/tracers"
 	jsassets "github.com/erigontech/erigon/eth/tracers/js/internal/tracers"
 	"github.com/erigontech/erigon/execution/types"
@@ -231,7 +232,7 @@ func (t *jsTracer) OnTxStart(env *tracing.VMContext, tx types.Transaction, from 
 
 	db := &dbObj{ibs: env.IntraBlockState, vm: t.vm, toBig: t.toBig, toBuf: t.toBuf, fromBuf: t.fromBuf}
 	t.dbValue = db.setupObject()
-	rules := env.ChainConfig.Rules(env.BlockNumber, env.Time)
+	rules := evmtypes.Rules(env.ChainConfig, env.BlockNumber, env.Time)
 	t.activePrecompiles = vm.ActivePrecompiles(rules)
 	t.ctx["block"] = t.vm.ToValue(t.env.BlockNumber)
 	t.ctx["gas"] = t.vm.ToValue(tx.GetGasLimit())

--- a/eth/tracers/native/4byte.go
+++ b/eth/tracers/native/4byte.go
@@ -92,7 +92,11 @@ func (t *fourByteTracer) store(id []byte, size int) {
 }
 
 func (t *fourByteTracer) OnTxStart(env *tracing.VMContext, tx types.Transaction, from common.Address) {
-	rules := evmtypes.Rules(env.ChainConfig, env.BlockNumber, env.Time)
+	blockContext := evmtypes.BlockContext{
+		BlockNumber: env.BlockNumber,
+		Time:        env.Time,
+	}
+	rules := blockContext.Rules(env.ChainConfig)
 	t.activePrecompiles = vm.ActivePrecompiles(rules)
 }
 

--- a/eth/tracers/native/4byte.go
+++ b/eth/tracers/native/4byte.go
@@ -29,6 +29,7 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon/core/tracing"
 	"github.com/erigontech/erigon/core/vm"
+	"github.com/erigontech/erigon/core/vm/evmtypes"
 	"github.com/erigontech/erigon/eth/tracers"
 	"github.com/erigontech/erigon/execution/types"
 )
@@ -91,7 +92,7 @@ func (t *fourByteTracer) store(id []byte, size int) {
 }
 
 func (t *fourByteTracer) OnTxStart(env *tracing.VMContext, tx types.Transaction, from common.Address) {
-	rules := env.ChainConfig.Rules(env.BlockNumber, env.Time)
+	rules := evmtypes.Rules(env.ChainConfig, env.BlockNumber, env.Time)
 	t.activePrecompiles = vm.ActivePrecompiles(rules)
 }
 

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -104,7 +104,7 @@ func TestPrestateTracerCreate2(t *testing.T) {
 	tx, err := m.DB.BeginTemporalRw(m.Ctx)
 	require.NoError(t, err)
 	defer tx.Rollback()
-	rules := chain.AllProtocolChanges.Rules(context.BlockNumber, context.Time)
+	rules := evmtypes.Rules(chain.AllProtocolChanges, context.BlockNumber, context.Time)
 	statedb, _ := tests.MakePreState(rules, tx, alloc, context.BlockNumber)
 
 	// Create the tracer, the EVM environment and run it

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -104,7 +104,7 @@ func TestPrestateTracerCreate2(t *testing.T) {
 	tx, err := m.DB.BeginTemporalRw(m.Ctx)
 	require.NoError(t, err)
 	defer tx.Rollback()
-	rules := evmtypes.Rules(chain.AllProtocolChanges, context.BlockNumber, context.Time)
+	rules := context.Rules(chain.AllProtocolChanges)
 	statedb, _ := tests.MakePreState(rules, tx, alloc, context.BlockNumber)
 
 	// Create the tracer, the EVM environment and run it

--- a/execution/chain/chain_config.go
+++ b/execution/chain/chain_config.go
@@ -687,34 +687,6 @@ type Rules struct {
 	IsAura                                            bool
 }
 
-// Rules ensures c's ChainID is not nil and returns a new Rules instance
-func (c *Config) Rules(num uint64, time uint64) *Rules {
-	chainID := c.ChainID
-	if chainID == nil {
-		chainID = new(big.Int)
-	}
-
-	return &Rules{
-		ChainID:            new(big.Int).Set(chainID),
-		IsHomestead:        c.IsHomestead(num),
-		IsTangerineWhistle: c.IsTangerineWhistle(num),
-		IsSpuriousDragon:   c.IsSpuriousDragon(num),
-		IsByzantium:        c.IsByzantium(num),
-		IsConstantinople:   c.IsConstantinople(num),
-		IsPetersburg:       c.IsPetersburg(num),
-		IsIstanbul:         c.IsIstanbul(num),
-		IsBerlin:           c.IsBerlin(num),
-		IsLondon:           c.IsLondon(num),
-		IsShanghai:         c.IsShanghai(time) || c.IsAgra(num),
-		IsCancun:           c.IsCancun(time),
-		IsNapoli:           c.IsNapoli(num),
-		IsBhilai:           c.IsBhilai(num),
-		IsPrague:           c.IsPrague(time) || c.IsBhilai(num),
-		IsOsaka:            c.IsOsaka(time),
-		IsAura:             c.Aura != nil,
-	}
-}
-
 // isForked returns whether a fork scheduled at block s is active at the given head block.
 func isForked(s *big.Int, head uint64) bool {
 	if s == nil {

--- a/execution/exec3/historical_trace_worker.go
+++ b/execution/exec3/historical_trace_worker.go
@@ -623,7 +623,7 @@ func CustomTraceMapReduce(fromBlock, toBlock uint64, consumer TraceConsumer, ctx
 				Header:          header,
 				Coinbase:        b.Coinbase(),
 				Uncles:          b.Uncles(),
-				Rules:           evmtypes.Rules(chainConfig, blockNum, b.Time()),
+				Rules:           blockContext.Rules(chainConfig),
 				Txs:             txs,
 				TxNum:           inputTxNum,
 				TxIndex:         txIndex,

--- a/execution/exec3/historical_trace_worker.go
+++ b/execution/exec3/historical_trace_worker.go
@@ -623,7 +623,7 @@ func CustomTraceMapReduce(fromBlock, toBlock uint64, consumer TraceConsumer, ctx
 				Header:          header,
 				Coinbase:        b.Coinbase(),
 				Uncles:          b.Uncles(),
-				Rules:           chainConfig.Rules(blockNum, b.Time()),
+				Rules:           evmtypes.Rules(chainConfig, blockNum, b.Time()),
 				Txs:             txs,
 				TxNum:           inputTxNum,
 				TxIndex:         txIndex,

--- a/execution/exec3/trace_worker.go
+++ b/execution/exec3/trace_worker.go
@@ -95,7 +95,7 @@ func (e *TraceWorker) ChangeBlock(header *types.Header) {
 	e.blockCtx = &blockCtx
 	e.blockHash = header.Hash()
 	e.header = header
-	e.rules = e.chainConfig.Rules(e.blockNum, header.Time)
+	e.rules = evmtypes.Rules(e.chainConfig, e.blockNum, header.Time)
 	e.signer = types.MakeSigner(e.chainConfig, e.blockNum, header.Time)
 	e.vmConfig.SkipAnalysis = core.SkipAnalysis(e.chainConfig, e.blockNum)
 }

--- a/execution/exec3/trace_worker.go
+++ b/execution/exec3/trace_worker.go
@@ -95,7 +95,7 @@ func (e *TraceWorker) ChangeBlock(header *types.Header) {
 	e.blockCtx = &blockCtx
 	e.blockHash = header.Hash()
 	e.header = header
-	e.rules = evmtypes.Rules(e.chainConfig, e.blockNum, header.Time)
+	e.rules = blockCtx.Rules(e.chainConfig)
 	e.signer = types.MakeSigner(e.chainConfig, e.blockNum, header.Time)
 	e.vmConfig.SkipAnalysis = core.SkipAnalysis(e.chainConfig, e.blockNum)
 }

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -36,7 +36,6 @@ import (
 	"github.com/erigontech/erigon/core"
 	"github.com/erigontech/erigon/core/state"
 	"github.com/erigontech/erigon/core/tracing"
-	"github.com/erigontech/erigon/core/vm/evmtypes"
 	"github.com/erigontech/erigon/db/config3"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/rawdbv3"
@@ -540,7 +539,7 @@ Loop:
 			accumulator.StartChange(header, txs, false)
 		}
 
-		rules := evmtypes.Rules(chainConfig, blockNum, b.Time())
+		rules := blockContext.Rules(chainConfig)
 		blockReceipts := make(types.Receipts, len(txs))
 		// During the first block execution, we may have half-block data in the snapshots.
 		// Thus, we need to skip the first txs in the block, however, this causes the GasUsed to be incorrect.

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -36,6 +36,7 @@ import (
 	"github.com/erigontech/erigon/core"
 	"github.com/erigontech/erigon/core/state"
 	"github.com/erigontech/erigon/core/tracing"
+	"github.com/erigontech/erigon/core/vm/evmtypes"
 	"github.com/erigontech/erigon/db/config3"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/rawdbv3"
@@ -539,7 +540,7 @@ Loop:
 			accumulator.StartChange(header, txs, false)
 		}
 
-		rules := chainConfig.Rules(blockNum, b.Time())
+		rules := evmtypes.Rules(chainConfig, blockNum, b.Time())
 		blockReceipts := make(types.Receipts, len(txs))
 		// During the first block execution, we may have half-block data in the snapshots.
 		// Thus, we need to skip the first txs in the block, however, this causes the GasUsed to be incorrect.

--- a/polygon/aa/aa_exec.go
+++ b/polygon/aa/aa_exec.go
@@ -13,7 +13,6 @@ import (
 	"github.com/erigontech/erigon/core/state"
 	"github.com/erigontech/erigon/core/tracing"
 	"github.com/erigontech/erigon/core/vm"
-	"github.com/erigontech/erigon/core/vm/evmtypes"
 	"github.com/erigontech/erigon/execution/abi"
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/chain/params"
@@ -54,7 +53,7 @@ func ValidateAATransaction(
 	}
 
 	vmConfig := evm.Config()
-	rules := evmtypes.Rules(chainConfig, header.Number.Uint64(), header.Time)
+	rules := evm.ChainRules()
 	hasEIP3860 := vmConfig.HasEip3860(rules)
 
 	preTxCost, err := tx.PreTransactionGasCost(rules, hasEIP3860)

--- a/polygon/aa/aa_exec.go
+++ b/polygon/aa/aa_exec.go
@@ -13,6 +13,7 @@ import (
 	"github.com/erigontech/erigon/core/state"
 	"github.com/erigontech/erigon/core/tracing"
 	"github.com/erigontech/erigon/core/vm"
+	"github.com/erigontech/erigon/core/vm/evmtypes"
 	"github.com/erigontech/erigon/execution/abi"
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/chain/params"
@@ -53,7 +54,7 @@ func ValidateAATransaction(
 	}
 
 	vmConfig := evm.Config()
-	rules := chainConfig.Rules(header.Number.Uint64(), header.Time)
+	rules := evmtypes.Rules(chainConfig, header.Number.Uint64(), header.Time)
 	hasEIP3860 := vmConfig.HasEip3860(rules)
 
 	preTxCost, err := tx.PreTransactionGasCost(rules, hasEIP3860)

--- a/polygon/tracer/trace_bor_state_sync_txn.go
+++ b/polygon/tracer/trace_bor_state_sync_txn.go
@@ -61,7 +61,7 @@ func TraceBorStateSyncTxnDebugAPI(
 	defer cancel()
 	stateReceiverContract := chainConfig.Bor.(*borcfg.BorConfig).StateReceiverContractAddress()
 	tracer = NewBorStateSyncTxnTracer(tracer, stateReceiverContract)
-	rules := chainConfig.Rules(blockNum, blockTime)
+	rules := evmtypes.Rules(chainConfig, blockNum, blockTime)
 	stateWriter := state.NewNoopWriter()
 	execCb := func(evm *vm.EVM, refunds bool) (*evmtypes.ExecutionResult, error) {
 		tracer.OnTxStart(evm.GetVMContext(), bortypes.NewBorTransaction(), common.Address{})
@@ -97,7 +97,7 @@ func TraceBorStateSyncTxnTraceAPI(
 	}
 
 	txCtx := initStateSyncTxContext(blockNum, blockHash)
-	rules := chainConfig.Rules(blockNum, blockTime)
+	rules := evmtypes.Rules(chainConfig, blockNum, blockTime)
 	evm := vm.NewEVM(blockCtx, txCtx, ibs, chainConfig, *vmConfig)
 
 	return traceBorStateSyncTxn(ctx, ibs, stateWriter, msgs, evm, rules, txCtx, true)

--- a/polygon/tracer/trace_bor_state_sync_txn.go
+++ b/polygon/tracer/trace_bor_state_sync_txn.go
@@ -61,7 +61,7 @@ func TraceBorStateSyncTxnDebugAPI(
 	defer cancel()
 	stateReceiverContract := chainConfig.Bor.(*borcfg.BorConfig).StateReceiverContractAddress()
 	tracer = NewBorStateSyncTxnTracer(tracer, stateReceiverContract)
-	rules := evmtypes.Rules(chainConfig, blockNum, blockTime)
+	rules := blockCtx.Rules(chainConfig)
 	stateWriter := state.NewNoopWriter()
 	execCb := func(evm *vm.EVM, refunds bool) (*evmtypes.ExecutionResult, error) {
 		tracer.OnTxStart(evm.GetVMContext(), bortypes.NewBorTransaction(), common.Address{})
@@ -97,8 +97,8 @@ func TraceBorStateSyncTxnTraceAPI(
 	}
 
 	txCtx := initStateSyncTxContext(blockNum, blockHash)
-	rules := evmtypes.Rules(chainConfig, blockNum, blockTime)
 	evm := vm.NewEVM(blockCtx, txCtx, ibs, chainConfig, *vmConfig)
+	rules := evm.ChainRules()
 
 	return traceBorStateSyncTxn(ctx, ibs, stateWriter, msgs, evm, rules, txCtx, true)
 }

--- a/rpc/jsonrpc/eth_block.go
+++ b/rpc/jsonrpc/eth_block.go
@@ -30,6 +30,7 @@ import (
 	"github.com/erigontech/erigon/core"
 	"github.com/erigontech/erigon/core/state"
 	"github.com/erigontech/erigon/core/vm"
+	"github.com/erigontech/erigon/core/vm/evmtypes"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/execution/types"
 	bortypes "github.com/erigontech/erigon/polygon/bor/types"
@@ -126,7 +127,7 @@ func (api *APIImpl) CallBundle(ctx context.Context, txHashes []common.Hash, stat
 	}
 
 	signer := types.MakeSigner(chainConfig, blockNumber, timestamp)
-	rules := chainConfig.Rules(blockNumber, timestamp)
+	rules := evmtypes.Rules(chainConfig, blockNumber, timestamp)
 	firstMsg, err := txs[0].AsMessage(*signer, nil, rules)
 	if err != nil {
 		return nil, err

--- a/rpc/jsonrpc/eth_block.go
+++ b/rpc/jsonrpc/eth_block.go
@@ -30,7 +30,6 @@ import (
 	"github.com/erigontech/erigon/core"
 	"github.com/erigontech/erigon/core/state"
 	"github.com/erigontech/erigon/core/vm"
-	"github.com/erigontech/erigon/core/vm/evmtypes"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/execution/types"
 	bortypes "github.com/erigontech/erigon/polygon/bor/types"
@@ -127,13 +126,13 @@ func (api *APIImpl) CallBundle(ctx context.Context, txHashes []common.Hash, stat
 	}
 
 	signer := types.MakeSigner(chainConfig, blockNumber, timestamp)
-	rules := evmtypes.Rules(chainConfig, blockNumber, timestamp)
+	blockCtx := transactions.NewEVMBlockContext(engine, header, stateBlockNumberOrHash.RequireCanonical, tx, api._blockReader, chainConfig)
+	rules := blockCtx.Rules(chainConfig)
 	firstMsg, err := txs[0].AsMessage(*signer, nil, rules)
 	if err != nil {
 		return nil, err
 	}
 
-	blockCtx := transactions.NewEVMBlockContext(engine, header, stateBlockNumberOrHash.RequireCanonical, tx, api._blockReader, chainConfig)
 	txCtx := core.NewEVMTxContext(firstMsg)
 	// Get a new instance of the EVM
 	evm := vm.NewEVM(blockCtx, txCtx, ibs, chainConfig, vm.Config{})

--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -37,6 +37,7 @@ import (
 	"github.com/erigontech/erigon/core"
 	"github.com/erigontech/erigon/core/state"
 	"github.com/erigontech/erigon/core/vm"
+	"github.com/erigontech/erigon/core/vm/evmtypes"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/dbutils"
 	"github.com/erigontech/erigon/db/kv/membatchwithdb"
@@ -826,7 +827,7 @@ func (api *APIImpl) CreateAccessList(ctx context.Context, args ethapi2.CallArgs,
 	}
 
 	// Retrieve the precompiles since they don't need to be added to the access list
-	precompiles := vm.ActivePrecompiles(chainConfig.Rules(blockNumber, header.Time))
+	precompiles := vm.ActivePrecompiles(evmtypes.Rules(chainConfig, blockNumber, header.Time))
 	excl := make(map[common.Address]struct{})
 	for _, pc := range precompiles {
 		excl[pc] = struct{}{}

--- a/rpc/jsonrpc/eth_callMany.go
+++ b/rpc/jsonrpc/eth_callMany.go
@@ -176,7 +176,7 @@ func (api *APIImpl) CallMany(ctx context.Context, bundles []Bundle, simulateCont
 	// Get a new instance of the EVM
 	evm = vm.NewEVM(blockCtx, txCtx, st, chainConfig, vm.Config{})
 	signer := types.MakeSigner(chainConfig, blockNum, blockCtx.Time)
-	rules := chainConfig.Rules(blockNum, blockCtx.Time)
+	rules := evmtypes.Rules(chainConfig, blockNum, blockCtx.Time)
 
 	timeoutMilliSeconds := int64(5000)
 

--- a/rpc/jsonrpc/eth_callMany.go
+++ b/rpc/jsonrpc/eth_callMany.go
@@ -176,7 +176,7 @@ func (api *APIImpl) CallMany(ctx context.Context, bundles []Bundle, simulateCont
 	// Get a new instance of the EVM
 	evm = vm.NewEVM(blockCtx, txCtx, st, chainConfig, vm.Config{})
 	signer := types.MakeSigner(chainConfig, blockNum, blockCtx.Time)
-	rules := evmtypes.Rules(chainConfig, blockNum, blockCtx.Time)
+	rules := evm.ChainRules()
 
 	timeoutMilliSeconds := int64(5000)
 

--- a/rpc/jsonrpc/eth_system.go
+++ b/rpc/jsonrpc/eth_system.go
@@ -326,7 +326,11 @@ func fillForkConfig(chainConfig *chain.Config, forkId [4]byte, activationTime ui
 	forkConfig.BlobSchedule = *chainConfig.GetBlobConfig(activationTime)
 	forkConfig.ChainId = hexutil.Uint(chainConfig.ChainID.Uint64())
 	forkConfig.ForkId = forkId[:]
-	precompiles := vm.Precompiles(evmtypes.Rules(chainConfig, math.MaxUint64, activationTime))
+	blockContext := evmtypes.BlockContext{
+		BlockNumber: math.MaxUint64,
+		Time:        activationTime,
+	}
+	precompiles := vm.Precompiles(blockContext.Rules(chainConfig))
 	forkConfig.Precompiles = make(map[string]common.Address, len(precompiles))
 	for addr, precompile := range precompiles {
 		forkConfig.Precompiles[precompile.Name()] = addr

--- a/rpc/jsonrpc/eth_system.go
+++ b/rpc/jsonrpc/eth_system.go
@@ -27,6 +27,7 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/hexutil"
 	"github.com/erigontech/erigon/core/vm"
+	"github.com/erigontech/erigon/core/vm/evmtypes"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/rawdb"
 	"github.com/erigontech/erigon/eth/ethconfig"
@@ -325,7 +326,7 @@ func fillForkConfig(chainConfig *chain.Config, forkId [4]byte, activationTime ui
 	forkConfig.BlobSchedule = *chainConfig.GetBlobConfig(activationTime)
 	forkConfig.ChainId = hexutil.Uint(chainConfig.ChainID.Uint64())
 	forkConfig.ForkId = forkId[:]
-	precompiles := vm.Precompiles(chainConfig.Rules(math.MaxUint64, activationTime))
+	precompiles := vm.Precompiles(evmtypes.Rules(chainConfig, math.MaxUint64, activationTime))
 	forkConfig.Precompiles = make(map[string]common.Address, len(precompiles))
 	for addr, precompile := range precompiles {
 		forkConfig.Precompiles[precompile.Name()] = addr

--- a/rpc/jsonrpc/otterscan_search_trace.go
+++ b/rpc/jsonrpc/otterscan_search_trace.go
@@ -25,7 +25,6 @@ import (
 	"github.com/erigontech/erigon/core"
 	"github.com/erigontech/erigon/core/state"
 	"github.com/erigontech/erigon/core/vm"
-	"github.com/erigontech/erigon/core/vm/evmtypes"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/eth/ethutils"
 	"github.com/erigontech/erigon/execution/chain"
@@ -98,7 +97,8 @@ func (api *OtterscanAPIImpl) traceBlock(dbtx kv.TemporalTx, ctx context.Context,
 		return false, nil, err
 	}
 	header := block.Header()
-	rules := evmtypes.Rules(chainConfig, block.NumberU64(), header.Time)
+	blockContext := core.NewEVMBlockContext(header, core.GetHashFn(header, getHeader), engine, nil, chainConfig)
+	rules := blockContext.Rules(chainConfig)
 	found := false
 	for idx, txn := range block.Transactions() {
 		select {
@@ -112,10 +112,9 @@ func (api *OtterscanAPIImpl) traceBlock(dbtx kv.TemporalTx, ctx context.Context,
 
 		tracer := NewTouchTracer(searchAddr)
 		ibs.SetHooks(tracer.TracingHooks())
-		BlockContext := core.NewEVMBlockContext(header, core.GetHashFn(header, getHeader), engine, nil, chainConfig)
-		TxContext := core.NewEVMTxContext(msg)
+		txContext := core.NewEVMTxContext(msg)
 
-		vmenv := vm.NewEVM(BlockContext, TxContext, ibs, chainConfig, vm.Config{Tracer: tracer.TracingHooks()})
+		vmenv := vm.NewEVM(blockContext, txContext, ibs, chainConfig, vm.Config{Tracer: tracer.TracingHooks()})
 		// FIXME (tracing): Geth has a new method ApplyEVMMessage or something like this that does the OnTxStart/OnTxEnd wrapping, let's port it too
 		if tracer != nil && tracer.TracingHooks().OnTxStart != nil {
 			tracer.TracingHooks().OnTxStart(vmenv.GetVMContext(), txn, msg.From())

--- a/rpc/jsonrpc/otterscan_search_trace.go
+++ b/rpc/jsonrpc/otterscan_search_trace.go
@@ -25,6 +25,7 @@ import (
 	"github.com/erigontech/erigon/core"
 	"github.com/erigontech/erigon/core/state"
 	"github.com/erigontech/erigon/core/vm"
+	"github.com/erigontech/erigon/core/vm/evmtypes"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/eth/ethutils"
 	"github.com/erigontech/erigon/execution/chain"
@@ -97,7 +98,7 @@ func (api *OtterscanAPIImpl) traceBlock(dbtx kv.TemporalTx, ctx context.Context,
 		return false, nil, err
 	}
 	header := block.Header()
-	rules := chainConfig.Rules(block.NumberU64(), header.Time)
+	rules := evmtypes.Rules(chainConfig, block.NumberU64(), header.Time)
 	found := false
 	for idx, txn := range block.Transactions() {
 		select {

--- a/rpc/jsonrpc/overlay_api.go
+++ b/rpc/jsonrpc/overlay_api.go
@@ -177,7 +177,7 @@ func (api *OverlayAPIImpl) CallConstructor(ctx context.Context, address common.A
 	// Get a new instance of the EVM
 	evm = vm.NewEVM(blockCtx, txCtx, statedb, chainConfig, vm.Config{})
 	signer := types.MakeSigner(chainConfig, blockNum, block.Time())
-	rules := chainConfig.Rules(blockNum, blockCtx.Time)
+	rules := evmtypes.Rules(chainConfig, blockNum, blockCtx.Time)
 
 	// Setup the gas pool (also for unmetered requests)
 	// and apply the message.
@@ -455,7 +455,7 @@ func (api *OverlayAPIImpl) replayBlock(ctx context.Context, blockNum uint64, sta
 	blockCtx = core.NewEVMBlockContext(header, getHash, api.engine(), nil, chainConfig)
 
 	signer := types.MakeSigner(chainConfig, blockNum, blockCtx.Time)
-	rules := chainConfig.Rules(blockNum, blockCtx.Time)
+	rules := evmtypes.Rules(chainConfig, blockNum, blockCtx.Time)
 
 	timeout := api.OverlayReplayBlockTimeout
 	// Setup context so it may be cancelled the call has completed

--- a/rpc/jsonrpc/overlay_api.go
+++ b/rpc/jsonrpc/overlay_api.go
@@ -177,7 +177,7 @@ func (api *OverlayAPIImpl) CallConstructor(ctx context.Context, address common.A
 	// Get a new instance of the EVM
 	evm = vm.NewEVM(blockCtx, txCtx, statedb, chainConfig, vm.Config{})
 	signer := types.MakeSigner(chainConfig, blockNum, block.Time())
-	rules := evmtypes.Rules(chainConfig, blockNum, blockCtx.Time)
+	rules := evm.ChainRules()
 
 	// Setup the gas pool (also for unmetered requests)
 	// and apply the message.
@@ -455,7 +455,7 @@ func (api *OverlayAPIImpl) replayBlock(ctx context.Context, blockNum uint64, sta
 	blockCtx = core.NewEVMBlockContext(header, getHash, api.engine(), nil, chainConfig)
 
 	signer := types.MakeSigner(chainConfig, blockNum, blockCtx.Time)
-	rules := evmtypes.Rules(chainConfig, blockNum, blockCtx.Time)
+	rules := blockCtx.Rules(chainConfig)
 
 	timeout := api.OverlayReplayBlockTimeout
 	// Setup context so it may be cancelled the call has completed

--- a/rpc/jsonrpc/trace_adhoc.go
+++ b/rpc/jsonrpc/trace_adhoc.go
@@ -1462,7 +1462,7 @@ func (api *TraceAPIImpl) doCallBlock(ctx context.Context, dbtx kv.Tx, stateReade
 			tracer.Hooks.OnTxEnd(&types.Receipt{GasUsed: execResult.GasUsed}, nil)
 		}
 
-		chainRules := evmtypes.Rules(chainConfig, blockCtx.BlockNumber, blockCtx.Time)
+		chainRules := blockCtx.Rules(chainConfig)
 		traceResult.Output = common.CopyBytes(execResult.ReturnData)
 		if traceTypeStateDiff {
 			initialIbs := state.New(cloneReader)
@@ -1662,7 +1662,7 @@ func (api *TraceAPIImpl) doCall(ctx context.Context, dbtx kv.Tx, stateReader sta
 		return nil, fmt.Errorf("first run for txIndex %d error: %w", txIndex, err)
 	}
 
-	chainRules := evmtypes.Rules(chainConfig, blockCtx.BlockNumber, blockCtx.Time)
+	chainRules := blockCtx.Rules(chainConfig)
 	traceResult.Output = common.CopyBytes(execResult.ReturnData)
 	if traceTypeStateDiff {
 		initialIbs := state.New(cloneReader)

--- a/rpc/jsonrpc/trace_adhoc.go
+++ b/rpc/jsonrpc/trace_adhoc.go
@@ -1462,7 +1462,7 @@ func (api *TraceAPIImpl) doCallBlock(ctx context.Context, dbtx kv.Tx, stateReade
 			tracer.Hooks.OnTxEnd(&types.Receipt{GasUsed: execResult.GasUsed}, nil)
 		}
 
-		chainRules := chainConfig.Rules(blockCtx.BlockNumber, blockCtx.Time)
+		chainRules := evmtypes.Rules(chainConfig, blockCtx.BlockNumber, blockCtx.Time)
 		traceResult.Output = common.CopyBytes(execResult.ReturnData)
 		if traceTypeStateDiff {
 			initialIbs := state.New(cloneReader)
@@ -1662,7 +1662,7 @@ func (api *TraceAPIImpl) doCall(ctx context.Context, dbtx kv.Tx, stateReader sta
 		return nil, fmt.Errorf("first run for txIndex %d error: %w", txIndex, err)
 	}
 
-	chainRules := chainConfig.Rules(blockCtx.BlockNumber, blockCtx.Time)
+	chainRules := evmtypes.Rules(chainConfig, blockCtx.BlockNumber, blockCtx.Time)
 	traceResult.Output = common.CopyBytes(execResult.ReturnData)
 	if traceTypeStateDiff {
 		initialIbs := state.New(cloneReader)

--- a/rpc/jsonrpc/trace_adhoc_test.go
+++ b/rpc/jsonrpc/trace_adhoc_test.go
@@ -403,7 +403,7 @@ func TestOeTracer(t *testing.T) {
 			if test.Context.BaseFee != nil {
 				context.BaseFee, _ = uint256.FromBig((*big.Int)(test.Context.BaseFee))
 			}
-			rules := evmtypes.Rules(test.Genesis.Config, context.BlockNumber, context.Time)
+			rules := context.Rules(test.Genesis.Config)
 
 			m := mock.Mock(t)
 			dbTx, err := m.DB.BeginTemporalRw(m.Ctx)

--- a/rpc/jsonrpc/trace_adhoc_test.go
+++ b/rpc/jsonrpc/trace_adhoc_test.go
@@ -403,7 +403,7 @@ func TestOeTracer(t *testing.T) {
 			if test.Context.BaseFee != nil {
 				context.BaseFee, _ = uint256.FromBig((*big.Int)(test.Context.BaseFee))
 			}
-			rules := test.Genesis.Config.Rules(context.BlockNumber, context.Time)
+			rules := evmtypes.Rules(test.Genesis.Config, context.BlockNumber, context.Time)
 
 			m := mock.Mock(t)
 			dbTx, err := m.DB.BeginTemporalRw(m.Ctx)

--- a/rpc/jsonrpc/trace_filtering.go
+++ b/rpc/jsonrpc/trace_filtering.go
@@ -427,7 +427,7 @@ func (api *TraceAPIImpl) filterV3(ctx context.Context, dbtx kv.TemporalTx, fromB
 
 			lastBlockHash = lastHeader.Hash()
 			lastSigner = types.MakeSigner(chainConfig, blockNum, lastHeader.Time)
-			lastRules = chainConfig.Rules(blockNum, lastHeader.Time)
+			lastRules = evmtypes.Rules(chainConfig, blockNum, lastHeader.Time)
 		}
 		if isFnalTxn {
 			// TODO(yperbasis) proper rewards for Gnosis
@@ -724,7 +724,7 @@ func (api *TraceAPIImpl) callBlock(
 	}
 
 	parentNo := rpc.BlockNumber(pNo)
-	rules := cfg.Rules(blockNumber, block.Time())
+	rules := evmtypes.Rules(cfg, blockNumber, block.Time())
 	header := block.Header()
 	txs := block.Transactions()
 	var borStateSyncTxn types.Transaction
@@ -835,7 +835,7 @@ func (api *TraceAPIImpl) callTransaction(
 	}
 
 	parentNo := rpc.BlockNumber(pNo)
-	rules := cfg.Rules(blockNumber, header.Time)
+	rules := evmtypes.Rules(cfg, blockNumber, header.Time)
 	var txn types.Transaction
 	var borStateSyncTxnHash common.Hash
 	isBorStateSyncTxn := txIndex == -1 && cfg.Bor != nil

--- a/rpc/jsonrpc/trace_filtering.go
+++ b/rpc/jsonrpc/trace_filtering.go
@@ -427,7 +427,8 @@ func (api *TraceAPIImpl) filterV3(ctx context.Context, dbtx kv.TemporalTx, fromB
 
 			lastBlockHash = lastHeader.Hash()
 			lastSigner = types.MakeSigner(chainConfig, blockNum, lastHeader.Time)
-			lastRules = evmtypes.Rules(chainConfig, blockNum, lastHeader.Time)
+			blockCtx := transactions.NewEVMBlockContext(engine, lastHeader, true /* requireCanonical */, dbtx, api._blockReader, chainConfig)
+			lastRules = blockCtx.Rules(chainConfig)
 		}
 		if isFnalTxn {
 			// TODO(yperbasis) proper rewards for Gnosis
@@ -724,8 +725,10 @@ func (api *TraceAPIImpl) callBlock(
 	}
 
 	parentNo := rpc.BlockNumber(pNo)
-	rules := evmtypes.Rules(cfg, blockNumber, block.Time())
 	header := block.Header()
+	engine := api.engine()
+	blockCtx := transactions.NewEVMBlockContext(engine, header, true /* requireCanonical */, dbtx, api._blockReader, cfg)
+	rules := blockCtx.Rules(cfg)
 	txs := block.Transactions()
 	var borStateSyncTxn types.Transaction
 	var borStateSyncTxnHash common.Hash
@@ -765,7 +768,6 @@ func (api *TraceAPIImpl) callBlock(
 	cachedWriter := state.NewCachedWriter(noop, stateCache)
 	ibs := state.New(cachedReader)
 
-	engine := api.engine()
 	consensusHeaderReader := consensuschain.NewReader(cfg, dbtx, nil, nil)
 	logger := log.New("trace_filtering")
 	err = core.InitializeBlockExecution(engine.(consensus.Engine), consensusHeaderReader, block.HeaderNoCopy(), cfg, ibs, nil, logger, nil)
@@ -835,7 +837,9 @@ func (api *TraceAPIImpl) callTransaction(
 	}
 
 	parentNo := rpc.BlockNumber(pNo)
-	rules := evmtypes.Rules(cfg, blockNumber, header.Time)
+	engine := api.engine()
+	blockCtx := transactions.NewEVMBlockContext(engine, header, true /* requireCanonical */, dbtx, api._blockReader, cfg)
+	rules := blockCtx.Rules(cfg)
 	var txn types.Transaction
 	var borStateSyncTxnHash common.Hash
 	isBorStateSyncTxn := txIndex == -1 && cfg.Bor != nil
@@ -878,7 +882,6 @@ func (api *TraceAPIImpl) callTransaction(
 	cachedWriter := state.NewCachedWriter(noop, stateCache)
 	ibs := state.New(cachedReader)
 
-	engine := api.engine()
 	consensusHeaderReader := consensuschain.NewReader(cfg, dbtx, nil, nil)
 	logger := log.New("trace_filtering")
 	err = core.InitializeBlockExecution(engine.(consensus.Engine), consensusHeaderReader, header, cfg, ibs, nil, logger, nil)

--- a/rpc/jsonrpc/tracing.go
+++ b/rpc/jsonrpc/tracing.go
@@ -519,7 +519,7 @@ func (api *DebugAPIImpl) TraceCallMany(ctx context.Context, bundles []Bundle, si
 	blockCtx = core.NewEVMBlockContext(header, getHash, api.engine(), nil /* author */, chainConfig)
 	// Get a new instance of the EVM
 	evm = vm.NewEVM(blockCtx, txCtx, ibs, chainConfig, vm.Config{})
-	rules := chainConfig.Rules(blockNum, blockCtx.Time)
+	rules := evmtypes.Rules(chainConfig, blockNum, blockCtx.Time)
 
 	// after replaying the txns, we want to overload the state
 	if config.StateOverrides != nil {

--- a/rpc/jsonrpc/tracing.go
+++ b/rpc/jsonrpc/tracing.go
@@ -519,7 +519,7 @@ func (api *DebugAPIImpl) TraceCallMany(ctx context.Context, bundles []Bundle, si
 	blockCtx = core.NewEVMBlockContext(header, getHash, api.engine(), nil /* author */, chainConfig)
 	// Get a new instance of the EVM
 	evm = vm.NewEVM(blockCtx, txCtx, ibs, chainConfig, vm.Config{})
-	rules := evmtypes.Rules(chainConfig, blockNum, blockCtx.Time)
+	rules := evm.ChainRules()
 
 	// after replaying the txns, we want to overload the state
 	if config.StateOverrides != nil {

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -239,7 +239,7 @@ func (t *StateTest) RunNoVerify(tx kv.TemporalRwTx, subtest StateSubtest, vmconf
 		if err != nil {
 			return nil, common.Hash{}, 0, err
 		}
-		msg, err = txn.AsMessage(*types.MakeSigner(config, 0, 0), baseFee, evmtypes.Rules(config, 0, 0))
+		msg, err = txn.AsMessage(*types.MakeSigner(config, 0, 0), baseFee, (&evmtypes.BlockContext{}).Rules(config))
 		if err != nil {
 			return nil, common.Hash{}, 0, err
 		}

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -45,6 +45,7 @@ import (
 	"github.com/erigontech/erigon/core/state"
 	"github.com/erigontech/erigon/core/tracing"
 	"github.com/erigontech/erigon/core/vm"
+	"github.com/erigontech/erigon/core/vm/evmtypes"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
 	dbstate "github.com/erigontech/erigon/db/state"
@@ -238,7 +239,7 @@ func (t *StateTest) RunNoVerify(tx kv.TemporalRwTx, subtest StateSubtest, vmconf
 		if err != nil {
 			return nil, common.Hash{}, 0, err
 		}
-		msg, err = txn.AsMessage(*types.MakeSigner(config, 0, 0), baseFee, config.Rules(0, 0))
+		msg, err = txn.AsMessage(*types.MakeSigner(config, 0, 0), baseFee, evmtypes.Rules(config, 0, 0))
 		if err != nil {
 			return nil, common.Hash{}, 0, err
 		}

--- a/tests/transaction_test_util.go
+++ b/tests/transaction_test_util.go
@@ -30,6 +30,7 @@ import (
 	"github.com/erigontech/erigon-lib/common/hexutil"
 	"github.com/erigontech/erigon-lib/common/math"
 	"github.com/erigontech/erigon/core"
+	"github.com/erigontech/erigon/core/vm/evmtypes"
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/fixedgas"
 	"github.com/erigontech/erigon/execution/testutil"
@@ -129,7 +130,7 @@ func (tt *TransactionTest) Run(chainID *big.Int) error {
 		{"Berlin", types.LatestSignerForChainID(chainID), tt.Forks.Berlin, testutil.Forks["Berlin"]},
 		{"London", types.LatestSignerForChainID(chainID), tt.Forks.London, testutil.Forks["London"]},
 	} {
-		sender, txhash, intrinsicGas, err := validateTx(tt.RLP, *testcase.signer, testcase.config.Rules(0, 0))
+		sender, txhash, intrinsicGas, err := validateTx(tt.RLP, *testcase.signer, evmtypes.Rules(testcase.config, 0, 0))
 
 		if testcase.fork.Exception != "" {
 			if err == nil {

--- a/tests/transaction_test_util.go
+++ b/tests/transaction_test_util.go
@@ -130,7 +130,7 @@ func (tt *TransactionTest) Run(chainID *big.Int) error {
 		{"Berlin", types.LatestSignerForChainID(chainID), tt.Forks.Berlin, testutil.Forks["Berlin"]},
 		{"London", types.LatestSignerForChainID(chainID), tt.Forks.London, testutil.Forks["London"]},
 	} {
-		sender, txhash, intrinsicGas, err := validateTx(tt.RLP, *testcase.signer, evmtypes.Rules(testcase.config, 0, 0))
+		sender, txhash, intrinsicGas, err := validateTx(tt.RLP, *testcase.signer, (&evmtypes.BlockContext{}).Rules(testcase.config))
 
 		if testcase.fork.Exception != "" {
 			if err == nil {

--- a/turbo/privateapi/ethbackend.go
+++ b/turbo/privateapi/ethbackend.go
@@ -481,7 +481,7 @@ func (s *EthBackendServer) AAValidation(ctx context.Context, req *remote.AAValid
 	ibs.SetHooks(validationTracer.Hooks())
 
 	vmConfig := evm.Config()
-	rules := s.chainConfig.Rules(header.Number.Uint64(), header.Time)
+	rules := evmtypes.Rules(s.chainConfig, header.Number.Uint64(), header.Time)
 	hasEIP3860 := vmConfig.HasEip3860(rules)
 
 	preTxCost, err := aaTxn.PreTransactionGasCost(rules, hasEIP3860)

--- a/turbo/privateapi/ethbackend.go
+++ b/turbo/privateapi/ethbackend.go
@@ -481,7 +481,7 @@ func (s *EthBackendServer) AAValidation(ctx context.Context, req *remote.AAValid
 	ibs.SetHooks(validationTracer.Hooks())
 
 	vmConfig := evm.Config()
-	rules := evmtypes.Rules(s.chainConfig, header.Number.Uint64(), header.Time)
+	rules := evm.ChainRules()
 	hasEIP3860 := vmConfig.HasEip3860(rules)
 
 	preTxCost, err := aaTxn.PreTransactionGasCost(rules, hasEIP3860)

--- a/turbo/transactions/tracing.go
+++ b/turbo/transactions/tracing.go
@@ -67,7 +67,7 @@ func ComputeBlockContext(ctx context.Context, engine consensus.EngineReader, hea
 	}
 
 	blockContext := core.NewEVMBlockContext(header, core.GetHashFn(header, getHeader), engine, nil, cfg)
-	rules := cfg.Rules(blockContext.BlockNumber, blockContext.Time)
+	rules := evmtypes.Rules(cfg, blockContext.BlockNumber, blockContext.Time)
 
 	// Recompute transactions up to the target index.
 	signer := types.MakeSigner(cfg, header.Number.Uint64(), header.Time)

--- a/turbo/transactions/tracing.go
+++ b/turbo/transactions/tracing.go
@@ -67,7 +67,7 @@ func ComputeBlockContext(ctx context.Context, engine consensus.EngineReader, hea
 	}
 
 	blockContext := core.NewEVMBlockContext(header, core.GetHashFn(header, getHeader), engine, nil, cfg)
-	rules := evmtypes.Rules(cfg, blockContext.BlockNumber, blockContext.Time)
+	rules := blockContext.Rules(cfg)
 
 	// Recompute transactions up to the target index.
 	signer := types.MakeSigner(cfg, header.Number.Uint64(), header.Time)


### PR DESCRIPTION
Arbitrum needs an extra piece of data, `arbosVersion`, to be passed to to correctly resolve `Rules`. With this change the change for Arbitrum (PR #15761) will be smaller. Part of Issue #15684.