### PR TITLE
[r31] `downloader.Delete`: `.idx` files are missed

### DIFF
--- a/erigon-lib/state/aggregator_test.go
+++ b/erigon-lib/state/aggregator_test.go
@@ -134,7 +134,7 @@ func TestAggregatorV3_Merge(t *testing.T) {
 	err = rwTx.Commit()
 	require.NoError(t, err)
 
-	mustSeeFile := func(files []string, folderName, fileNameWithoutVersion string) bool {
+	mustSeeFile := func(files []string, folderName, fileNameWithoutVersion string) bool { //file-version agnostic
 		for _, f := range files {
 			if strings.HasPrefix(f, folderName) && strings.HasSuffix(f, fileNameWithoutVersion) {
 				return true

--- a/erigon-lib/state/aggregator_test.go
+++ b/erigon-lib/state/aggregator_test.go
@@ -152,6 +152,7 @@ func TestAggregatorV3_Merge(t *testing.T) {
 		onChangeCalls++
 		if onChangeCalls == 1 {
 			mustSeeFile(newFiles, "domain", "accounts.0-2.kv") //TODO: when we build `accounts.0-1.kv` - we sending empty notifcation
+			require.False(t, filepath.IsAbs(newFiles[0]))      // expecting non-absolute paths (relative as of snapshots dir)
 		}
 	}, func(deletedFiles []string) {
 		if len(deletedFiles) == 0 {
@@ -166,6 +167,7 @@ func TestAggregatorV3_Merge(t *testing.T) {
 			mustSeeFile(deletedFiles, "accessor", "accounts.0-1.vi")
 
 			mustSeeFile(deletedFiles, "domain", "accounts.1-2.kv")
+			require.False(t, filepath.IsAbs(deletedFiles[0])) // expecting non-absolute paths (relative as of snapshots dir)
 		}
 	})
 

--- a/erigon-lib/state/files_item.go
+++ b/erigon-lib/state/files_item.go
@@ -148,30 +148,27 @@ func (i *FilesItem) closeFiles() {
 	}
 }
 
-func (i *FilesItem) FilePaths(relative string) (paths []string) {
+func (i *FilesItem) FilePaths(basePath string) (relativePaths []string) {
 	if i.decompressor != nil {
-		paths = append(paths, i.decompressor.FilePath())
+		relativePaths = append(relativePaths, i.decompressor.FilePath())
 	}
 	if i.index != nil {
-		paths = append(paths, i.index.FilePath())
+		relativePaths = append(relativePaths, i.index.FilePath())
 	}
 	if i.bindex != nil {
-		paths = append(paths, i.bindex.FilePath())
+		relativePaths = append(relativePaths, i.bindex.FilePath())
 	}
 	if i.existence != nil {
-		paths = append(paths, i.existence.FilePath)
-	}
-	if len(relative) == 0 {
-		return paths
+		relativePaths = append(relativePaths, i.existence.FilePath)
 	}
 	var err error
-	for i := 0; i < len(paths); i++ {
-		paths[i], err = filepath.Rel(relative, paths[i])
+	for i := 0; i < len(relativePaths); i++ {
+		relativePaths[i], err = filepath.Rel(basePath, relativePaths[i])
 		if err != nil {
-			log.Warn("FilesItem.FilePaths: can't make relative path", "err", err, "relative", relative, "path", paths[i])
+			log.Warn("FilesItem.FilePaths: can't make basePath path", "err", err, "basePath", basePath, "path", relativePaths[i])
 		}
 	}
-	return paths
+	return relativePaths
 }
 
 func (i *FilesItem) closeFilesAndRemove() {

--- a/execution/stagedsync/stage_snapshots.go
+++ b/execution/stagedsync/stage_snapshots.go
@@ -583,6 +583,7 @@ func pruneBlockSnapshots(ctx context.Context, cfg SnapshotsCfg, logger log.Logge
 		return false, nil
 	}
 
+	//TODO: push-down this logic into `blockRetire`: instead of work on raw file names - we must work on dirtySegments. Instead of calling downloader.Del(file) we must call `downloader.Del(dirtySegment.Paths(snapDir)`
 	snapshotFileNames := cfg.blockReader.FrozenFiles()
 	filesDeleted := false
 	// Prune blocks snapshots if necessary

--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -2078,7 +2078,7 @@ func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 		return err
 	}
 
-	if err := br.RemoveOverlaps(); err != nil {
+	if err := br.RemoveOverlaps(nil); err != nil {
 		return err
 	}
 

--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -333,7 +333,7 @@ func (br *BlockRetire) MergeBlocks(ctx context.Context, lvl log.Lvl, seedNewSnap
 	}
 
 	// remove old garbage files
-	if err = snapshots.RemoveOverlaps(); err != nil {
+	if err = snapshots.RemoveOverlaps(onDelete); err != nil {
 		return false, err
 	}
 	return
@@ -500,13 +500,13 @@ func (br *BlockRetire) BuildMissedIndicesIfNeed(ctx context.Context, logPrefix s
 
 	return nil
 }
-func (br *BlockRetire) RemoveOverlaps() error {
-	if err := br.snapshots().RemoveOverlaps(); err != nil {
+func (br *BlockRetire) RemoveOverlaps(onDelete func(l []string) error) error {
+	if err := br.snapshots().RemoveOverlaps(onDelete); err != nil {
 		return err
 	}
 
 	if br.chainConfig.Bor != nil {
-		if err := br.borSnapshots().RoSnapshots.RemoveOverlaps(); err != nil {
+		if err := br.borSnapshots().RoSnapshots.RemoveOverlaps(onDelete); err != nil {
 			return err
 		}
 	}

--- a/turbo/snapshotsync/merger.go
+++ b/turbo/snapshotsync/merger.go
@@ -185,6 +185,7 @@ func (m *Merger) Merge(ctx context.Context, snapshots *RoSnapshots, snapTypes []
 			}
 		}
 
+		//TODO: or move it inside `integrateMergedDirtyFiles`, or move `integrateMergedDirtyFiles` here. Merge can be long
 		toMergeFileNames := make([]string, 0, 16)
 		for _, segments := range toMerge {
 			for _, segment := range segments {

--- a/turbo/snapshotsync/merger.go
+++ b/turbo/snapshotsync/merger.go
@@ -189,6 +189,9 @@ func (m *Merger) Merge(ctx context.Context, snapshots *RoSnapshots, snapTypes []
 			if len(toMerge[t.Enum()]) == 0 {
 				continue
 			}
+
+			fmt.Printf("[dbg] %s\n", t.IdxFileNames())
+
 			toMergeFileNames := make([]string, 0, len(toMerge[t.Enum()]))
 			for _, f := range toMerge[t.Enum()] {
 				toMergeFileNames = append(toMergeFileNames, f.FileName())

--- a/turbo/snapshotsync/merger.go
+++ b/turbo/snapshotsync/merger.go
@@ -185,7 +185,7 @@ func (m *Merger) Merge(ctx context.Context, snapshots *RoSnapshots, snapTypes []
 			}
 		}
 
-		//TODO: or move it inside `integrateMergedDirtyFiles`, or move `integrateMergedDirtyFiles` here. Merge can be long
+		//TODO: or move it inside `integrateMergedDirtyFiles`, or move `integrateMergedDirtyFiles` here. Merge can be long - means call `integrateMergedDirtyFiles` earliear can make sense.
 		toMergeFileNames := make([]string, 0, 16)
 		for _, segments := range toMerge {
 			for _, segment := range segments {

--- a/turbo/snapshotsync/merger.go
+++ b/turbo/snapshotsync/merger.go
@@ -185,21 +185,15 @@ func (m *Merger) Merge(ctx context.Context, snapshots *RoSnapshots, snapTypes []
 			}
 		}
 
-		for _, t := range snapTypes {
-			if len(toMerge[t.Enum()]) == 0 {
-				continue
+		toMergeFileNames := make([]string, 0, 16)
+		for _, segments := range toMerge {
+			for _, segment := range segments {
+				toMergeFileNames = append(toMergeFileNames, segment.FilePaths(snapDir)...)
 			}
-
-			fmt.Printf("[dbg] %s\n", t.IdxFileNames())
-
-			toMergeFileNames := make([]string, 0, len(toMerge[t.Enum()]))
-			for _, f := range toMerge[t.Enum()] {
-				toMergeFileNames = append(toMergeFileNames, f.FileName())
-			}
-			if onDelete != nil {
-				if err := onDelete(toMergeFileNames); err != nil {
-					return err
-				}
+		}
+		if onDelete != nil {
+			if err := onDelete(toMergeFileNames); err != nil {
+				return err
 			}
 		}
 	}

--- a/turbo/snapshotsync/merger.go
+++ b/turbo/snapshotsync/merger.go
@@ -194,7 +194,7 @@ func (m *Merger) Merge(ctx context.Context, snapshots *RoSnapshots, snapTypes []
 		}
 		if onDelete != nil {
 			if err := onDelete(toMergeFileNames); err != nil {
-				return err
+				return fmt.Errorf("merger.Merge: onDelete: %w", err)
 			}
 		}
 	}

--- a/turbo/snapshotsync/snapshots.go
+++ b/turbo/snapshotsync/snapshots.go
@@ -526,7 +526,7 @@ type BlockSnapshots interface {
 	SetSegmentsMin(uint64)
 
 	DownloadComplete()
-	RemoveOverlaps() error
+	RemoveOverlaps(onDelete func(l []string) error) error
 	DownloadReady() bool
 	Ready(context.Context) <-chan error
 }

--- a/turbo/snapshotsync/snapshots.go
+++ b/turbo/snapshotsync/snapshots.go
@@ -356,37 +356,25 @@ func (s *DirtySegment) FileName() string {
 	return s.Type().FileName(s.version, s.from, s.to)
 }
 
-func (s *DirtySegment) FilePaths(rel string) (relativePaths []string {
-
-	return s.Type().FileName(s.version, s.from, s.to)
-}
-
-func (i *FilesItem) FilePaths(relative string) (paths []string) {
-	if i.decompressor != nil {
-		paths = append(paths, i.decompressor.FilePath())
+func (s *DirtySegment) FilePaths(basePath string) (relativePaths []string) {
+	if s.Decompressor != nil {
+		relativePaths = append(relativePaths, s.Decompressor.FilePath())
 	}
-	if i.index != nil {
-		paths = append(paths, i.index.FilePath())
-	}
-	if i.bindex != nil {
-		paths = append(paths, i.bindex.FilePath())
-	}
-	if i.existence != nil {
-		paths = append(paths, i.existence.FilePath)
-	}
-	if len(relative) == 0 {
-		return paths
+	for _, index := range s.indexes {
+		if index == nil {
+			continue
+		}
+		relativePaths = append(relativePaths, index.FilePath())
 	}
 	var err error
-	for i := 0; i < len(paths); i++ {
-		paths[i], err = filepath.Rel(relative, paths[i])
+	for i := 0; i < len(relativePaths); i++ {
+		relativePaths[i], err = filepath.Rel(basePath, relativePaths[i])
 		if err != nil {
-			log.Warn("FilesItem.FilePaths: can't make relative path", "err", err, "relative", relative, "path", paths[i])
+			log.Warn("FilesItem.FilePaths: can't make basePath path", "err", err, "basePath", basePath, "path", relativePaths[i])
 		}
 	}
-	return paths
+	return relativePaths
 }
-
 
 func (s *DirtySegment) FileInfo(dir string) snaptype.FileInfo {
 	return s.Type().FileInfo(dir, s.from, s.to)

--- a/turbo/snapshotsync/snapshots.go
+++ b/turbo/snapshotsync/snapshots.go
@@ -1281,13 +1281,15 @@ func (s *RoSnapshots) RemoveOverlaps(onDelete func(l []string) error) error {
 		toRemove = append(toRemove, info.Path)
 	}
 
-	relativePaths, err := toRelativePaths(s.dir, toRemove)
-	if err != nil {
-		return err
-	}
-	if onDelete != nil {
-		if err := onDelete(relativePaths); err != nil {
-			return fmt.Errorf("onDelete: %w", err)
+	{
+		relativePaths, err := toRelativePaths(s.dir, toRemove)
+		if err != nil {
+			return err
+		}
+		if onDelete != nil {
+			if err := onDelete(relativePaths); err != nil {
+				return fmt.Errorf("onDelete: %w", err)
+			}
 		}
 	}
 	removeOldFiles(toRemove)

--- a/turbo/snapshotsync/snapshots.go
+++ b/turbo/snapshotsync/snapshots.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/erigontech/erigon-lib/common/dir"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -29,6 +28,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/erigontech/erigon-lib/common/dir"
 
 	"github.com/tidwall/btree"
 	"golang.org/x/sync/errgroup"
@@ -354,6 +355,38 @@ func (s *DirtySegment) IsIndexed() bool {
 func (s *DirtySegment) FileName() string {
 	return s.Type().FileName(s.version, s.from, s.to)
 }
+
+func (s *DirtySegment) FilePaths(rel string) (relativePaths []string {
+
+	return s.Type().FileName(s.version, s.from, s.to)
+}
+
+func (i *FilesItem) FilePaths(relative string) (paths []string) {
+	if i.decompressor != nil {
+		paths = append(paths, i.decompressor.FilePath())
+	}
+	if i.index != nil {
+		paths = append(paths, i.index.FilePath())
+	}
+	if i.bindex != nil {
+		paths = append(paths, i.bindex.FilePath())
+	}
+	if i.existence != nil {
+		paths = append(paths, i.existence.FilePath)
+	}
+	if len(relative) == 0 {
+		return paths
+	}
+	var err error
+	for i := 0; i < len(paths); i++ {
+		paths[i], err = filepath.Rel(relative, paths[i])
+		if err != nil {
+			log.Warn("FilesItem.FilePaths: can't make relative path", "err", err, "relative", relative, "path", paths[i])
+		}
+	}
+	return paths
+}
+
 
 func (s *DirtySegment) FileInfo(dir string) snaptype.FileInfo {
 	return s.Type().FileInfo(dir, s.from, s.to)

--- a/turbo/snapshotsync/snapshots.go
+++ b/turbo/snapshotsync/snapshots.go
@@ -1292,6 +1292,7 @@ func (s *RoSnapshots) RemoveOverlaps(onDelete func(l []string) error) error {
 			}
 		}
 	}
+
 	removeOldFiles(toRemove)
 
 	// remove .tmp files

--- a/turbo/snapshotsync/snapshots_test.go
+++ b/turbo/snapshotsync/snapshots_test.go
@@ -399,16 +399,16 @@ func TestRemoveOverlaps(t *testing.T) {
 	dir2.RemoveFile(filepath.Join(s.Dir(), list[15].Name()))
 
 	require.NoError(s.OpenSegments(coresnaptype.BlockSnapshotTypes, false, true))
-	require.NoError(s.RemoveOverlaps(func(delList []string) error {
-		require.Len(delList, 69)
-		mustSeeFile(delList, "000000-000010-bodies.seg")
-		mustSeeFile(delList, "000000-000010-bodies.idx")
-		mustSeeFile(delList, "000000-000010-headers.seg")
-		mustSeeFile(delList, "000000-000010-transactions.seg")
-		mustSeeFile(delList, "000000-000010-transactions.seg")
-		mustSeeFile(delList, "000000-000010-transactions-to-block.idx")
-		mustSeeFile(delList, "000170-000180-transactions-to-block.idx")
-		require.False(filepath.IsAbs(delList[0])) // expecting non-absolute paths (relative as of snapshots dir)
+	require.NoError(s.RemoveOverlaps(func(delFiles []string) error {
+		require.Len(delFiles, 69)
+		mustSeeFile(delFiles, "000000-000010-bodies.seg")
+		mustSeeFile(delFiles, "000000-000010-bodies.idx")
+		mustSeeFile(delFiles, "000000-000010-headers.seg")
+		mustSeeFile(delFiles, "000000-000010-transactions.seg")
+		mustSeeFile(delFiles, "000000-000010-transactions.seg")
+		mustSeeFile(delFiles, "000000-000010-transactions-to-block.idx")
+		mustSeeFile(delFiles, "000170-000180-transactions-to-block.idx")
+		require.False(filepath.IsAbs(delFiles[0])) // expecting non-absolute paths (relative as of snapshots dir)
 		return nil
 	}))
 

--- a/turbo/snapshotsync/snapshots_test.go
+++ b/turbo/snapshotsync/snapshots_test.go
@@ -455,7 +455,7 @@ func TestRemoveOverlaps_CrossingTypeString(t *testing.T) {
 
 	require.NoError(s.OpenSegments(coresnaptype.BlockSnapshotTypes, false, true))
 	require.NoError(s.RemoveOverlaps(func(delList []string) error {
-		require.Len(delList, 3)
+		require.Len(delList, 0)
 		return nil
 	}))
 

--- a/turbo/snapshotsync/snapshots_test.go
+++ b/turbo/snapshotsync/snapshots_test.go
@@ -408,6 +408,7 @@ func TestRemoveOverlaps(t *testing.T) {
 		mustSeeFile(delList, "000000-000010-transactions.seg")
 		mustSeeFile(delList, "000000-000010-transactions-to-block.idx")
 		mustSeeFile(delList, "000170-000180-transactions-to-block.idx")
+		require.False(filepath.IsAbs(delList[0])) // expecting non-absolute paths (relative as of snapshots dir)
 		return nil
 	}))
 

--- a/turbo/snapshotsync/snapshots_test.go
+++ b/turbo/snapshotsync/snapshots_test.go
@@ -18,11 +18,13 @@ package snapshotsync
 
 import (
 	"context"
-	dir2 "github.com/erigontech/erigon-lib/common/dir"
+	"fmt"
 	"path/filepath"
 	"slices"
 	"testing"
 	"testing/fstest"
+
+	dir2 "github.com/erigontech/erigon-lib/common/dir"
 
 	"github.com/stretchr/testify/require"
 
@@ -389,7 +391,11 @@ func TestRemoveOverlaps(t *testing.T) {
 	dir2.RemoveFile(filepath.Join(s.Dir(), list[15].Name()))
 
 	require.NoError(s.OpenSegments(coresnaptype.BlockSnapshotTypes, false, true))
-	require.NoError(s.RemoveOverlaps())
+	require.NoError(s.RemoveOverlaps(func(delList []string) error {
+		fmt.Printf("[dbg] %s\n", delList)
+		require.Len(delList, 69)
+		return nil
+	}))
 
 	list, err = snaptype.Segments(s.Dir())
 	require.NoError(err)
@@ -433,7 +439,10 @@ func TestRemoveOverlaps_CrossingTypeString(t *testing.T) {
 	require.Equal(4, len(list))
 
 	require.NoError(s.OpenSegments(coresnaptype.BlockSnapshotTypes, false, true))
-	require.NoError(s.RemoveOverlaps())
+	require.NoError(s.RemoveOverlaps(func(delList []string) error {
+		require.Len(delList, 3)
+		return nil
+	}))
 
 	list, err = snaptype.Segments(s.Dir())
 	require.NoError(err)

--- a/turbo/snapshotsync/snapshots_test.go
+++ b/turbo/snapshotsync/snapshots_test.go
@@ -18,7 +18,6 @@ package snapshotsync
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -409,7 +408,6 @@ func TestRemoveOverlaps(t *testing.T) {
 		mustSeeFile(delList, "000000-000010-transactions.seg")
 		mustSeeFile(delList, "000000-000010-transactions-to-block.idx")
 		mustSeeFile(delList, "000170-000180-transactions-to-block.idx")
-		fmt.Printf("delList: %v\n", delList)
 		return nil
 	}))
 

--- a/turbo/snapshotsync/snapshots_test.go
+++ b/turbo/snapshotsync/snapshots_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -345,6 +346,14 @@ func TestRemoveOverlaps(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
+	mustSeeFile := func(files []string, fileNameWithoutVersion string) bool { //file-version agnostic
+		for _, f := range files {
+			if strings.HasSuffix(f, fileNameWithoutVersion) {
+				return true
+			}
+		}
+		return false
+	}
 
 	logger := log.New()
 	dir, require := t.TempDir(), require.New(t)
@@ -392,8 +401,15 @@ func TestRemoveOverlaps(t *testing.T) {
 
 	require.NoError(s.OpenSegments(coresnaptype.BlockSnapshotTypes, false, true))
 	require.NoError(s.RemoveOverlaps(func(delList []string) error {
-		fmt.Printf("[dbg] %s\n", delList)
 		require.Len(delList, 69)
+		mustSeeFile(delList, "000000-000010-bodies.seg")
+		mustSeeFile(delList, "000000-000010-bodies.idx")
+		mustSeeFile(delList, "000000-000010-headers.seg")
+		mustSeeFile(delList, "000000-000010-transactions.seg")
+		mustSeeFile(delList, "000000-000010-transactions.seg")
+		mustSeeFile(delList, "000000-000010-transactions-to-block.idx")
+		mustSeeFile(delList, "000170-000180-transactions-to-block.idx")
+		fmt.Printf("delList: %v\n", delList)
 		return nil
 	}))
 


### PR DESCRIPTION
- also `RemoveOverlaps` didn't call onDelete
- closing https://github.com/erigontech/erigon/issues/16658