### PR TITLE
Cherry pick snapshot overriding and downloader.verify fixes from 3.1

### DIFF
--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -383,6 +383,9 @@ func New(ctx context.Context, cfg *downloadercfg.Cfg, logger log.Logger, verbosi
 	d.ctx, d.stopMainLoop = context.WithCancel(context.Background())
 
 	if d.cfg.AddTorrentsFromDisk {
+		if d.cfg.VerifyTorrentData {
+			return nil, errors.New("must add torrents from disk synchronously if downloader verify enabled")
+		}
 		d.spawn(func() {
 			err := d.AddTorrentsFromDisk(d.ctx)
 			if err == nil || ctx.Err() != nil {
@@ -931,11 +934,15 @@ func (d *Downloader) RequestSnapshot(
 	if err != nil {
 		return err
 	}
+	d.addRequired(t)
+	return nil
+}
+
+func (d *Downloader) addRequired(t *torrent.Torrent) {
 	panicif.Nil(t)
 	g.MakeMapIfNil(&d.requiredTorrents)
 	g.MapInsert(d.requiredTorrents, t, struct{}{})
 	d.setStartTime()
-	return nil
 }
 
 // Add a torrent with a known info hash. Either someone else made it, or it was on disk. This might
@@ -995,6 +1002,10 @@ func (d *Downloader) addPreverifiedTorrent(
 	}
 	if !ok {
 		return
+	}
+
+	if d.cfg.VerifyTorrentData {
+		d.addRequired(t)
 	}
 
 	metainfoOnDisk := diskSpecOpt.Ok

--- a/db/snapcfg/util.go
+++ b/db/snapcfg/util.go
@@ -17,6 +17,7 @@
 package snapcfg
 
 import (
+	"bytes"
 	"context"
 	_ "embed"
 	"encoding/json"
@@ -53,16 +54,16 @@ var (
 	Chiado     = fromEmbeddedToml(snapshothashes.Chiado)
 	Hoodi      = fromEmbeddedToml(snapshothashes.Hoodi)
 
-	// Need to fix this already.
-	allPreverified = []*Preverified{
-		&Mainnet,
-		&Holesky,
-		&Sepolia,
-		&Amoy,
-		&BorMainnet,
-		&Gnosis,
-		&Chiado,
-		&Hoodi,
+	// This belongs in a generic embed.FS or something.
+	allSnapshotHashes = []*[]byte{
+		&snapshothashes.Mainnet,
+		&snapshothashes.Holesky,
+		&snapshothashes.Sepolia,
+		&snapshothashes.Amoy,
+		&snapshothashes.BorMainnet,
+		&snapshothashes.Gnosis,
+		&snapshothashes.Chiado,
+		&snapshothashes.Hoodi,
 	}
 )
 
@@ -523,25 +524,28 @@ func webseedsParse(in []byte) (res []string) {
 
 func LoadRemotePreverified(ctx context.Context) (err error) {
 	if s, ok := os.LookupEnv("ERIGON_REMOTE_PREVERIFIED"); ok {
+		log.Info("Loading local preverified override file", "file", s)
+
 		b, err := os.ReadFile(s)
 		if err != nil {
 			return fmt.Errorf("reading remote preverified override file: %w", err)
 		}
-		for _, p := range allPreverified {
-			*p = fromEmbeddedToml(b)
+		for _, sh := range allSnapshotHashes {
+			*sh = bytes.Clone(b)
 		}
-		return nil
-	}
-	// Can't log in erigon-snapshot repo due to erigon-lib module import path.
-	log.Info("Loading remote snapshot hashes")
-	err = snapshothashes.LoadSnapshots(ctx, snapshothashes.R2, snapshotGitBranch)
-	if err != nil {
-		log.Root().Warn("Failed to load snapshot hashes from R2; falling back to GitHub", "err", err)
+	} else {
+		// Can't log in erigon-snapshot repo due to erigon-lib module import path.
+		log.Info("Loading remote snapshot hashes")
 
-		// Fallback to GitHub if R2 fails
-		err = snapshothashes.LoadSnapshots(ctx, snapshothashes.Github, snapshotGitBranch)
+		err = snapshothashes.LoadSnapshots(ctx, snapshothashes.R2, snapshotGitBranch)
 		if err != nil {
-			return err
+			log.Root().Warn("Failed to load snapshot hashes from R2; falling back to GitHub", "err", err)
+
+			// Fallback to GitHub if R2 fails
+			err = snapshothashes.LoadSnapshots(ctx, snapshothashes.Github, snapshotGitBranch)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1450,8 +1450,12 @@ func (s *Ethereum) NodesInfo(limit int) (*remote.NodesInfoReply, error) {
 }
 
 // sets up blockReader and client downloader
-func (s *Ethereum) setUpSnapDownloader(ctx context.Context, nodeCfg *nodecfg.Config, downloaderCfg *downloadercfg.Cfg) error {
-	var err error
+func (s *Ethereum) setUpSnapDownloader(
+	ctx context.Context,
+	nodeCfg *nodecfg.Config,
+	downloaderCfg *downloadercfg.Cfg,
+	cc *chain.Config,
+) (err error) {
 	s.chainDB.OnFilesChange(func(frozenFileNames []string) {
 		s.logger.Warn("files changed...sending notification")
 		events := s.notifications.Events
@@ -1480,17 +1484,22 @@ func (s *Ethereum) setUpSnapDownloader(ctx context.Context, nodeCfg *nodecfg.Con
 		if downloaderCfg == nil || downloaderCfg.ChainName == "" {
 			return nil
 		}
-		// start embedded Downloader
-		if uploadFs := s.config.Sync.UploadLocation; len(uploadFs) > 0 {
-			downloaderCfg.AddTorrentsFromDisk = false
-		}
+		// Always disable the asynchronous adder. We will do it here to support downloader.verify.
+		downloaderCfg.AddTorrentsFromDisk = false
 
 		s.downloader, err = downloader.New(ctx, downloaderCfg, s.logger, log.LvlDebug)
 		if err != nil {
 			return err
 		}
-
 		s.downloader.HandleTorrentClientStatus(nodeCfg.DebugMux)
+
+		// start embedded Downloader
+		if uploadFs := s.config.Sync.UploadLocation; len(uploadFs) == 0 {
+			err = s.downloader.AddTorrentsFromDisk(ctx)
+			if err != nil {
+				return fmt.Errorf("adding torrents from disk: %w", err)
+			}
+		}
 
 		bittorrentServer, err := downloader.NewGrpcServer(s.downloader)
 		if err != nil {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -418,7 +418,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 	backend.chainDB = temporalDb
 
 	// Can happen in some configurations
-	if err := backend.setUpSnapDownloader(ctx, stack.Config(), config.Downloader); err != nil {
+	if err := backend.setUpSnapDownloader(ctx, stack.Config(), config.Downloader, chainConfig); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
- **Fix snapshot overriding (#16624)**
- **Require torrents added from disk to complete on `downloader.verify` (#16655)**
