### PR TITLE
txnprovider: align txns id filter behaviour between devp2p pool and shutter (#16646)

### DIFF
--- a/txnprovider/provider.go
+++ b/txnprovider/provider.go
@@ -99,10 +99,10 @@ func ApplyProvideOptions(opts ...ProvideOption) ProvideOptions {
 }
 
 var defaultProvideOptions = ProvideOptions{
-	ParentBlockNum:    0,                         // no parent block to wait for by default
-	Amount:            math.MaxInt,               // all transactions by default
-	GasTarget:         math.MaxUint64,            // all transactions by default
-	BlobGasTarget:     math.MaxUint64,            // all transactions by default
-	TxnIdsFilter:      mapset.NewSet[[32]byte](), // no filter by default
-	AvailableRlpSpace: math.MaxInt,               // unlimited by default
+	ParentBlockNum:    0,              // no parent block to wait for by default
+	Amount:            math.MaxInt,    // all transactions by default
+	GasTarget:         math.MaxUint64, // all transactions by default
+	BlobGasTarget:     math.MaxUint64, // all transactions by default
+	TxnIdsFilter:      nil,            // no filter by default
+	AvailableRlpSpace: math.MaxInt,    // unlimited by default
 }

--- a/txnprovider/shutter/pool.go
+++ b/txnprovider/shutter/pool.go
@@ -285,7 +285,7 @@ func (p *Pool) ProvideTxns(ctx context.Context, opts ...txnprovider.ProvideOptio
 	txns := make([]types.Transaction, 0, len(decryptedTxns.Transactions))
 	decryptedTxnsGas := uint64(0)
 	for _, txn := range decryptedTxns.Transactions {
-		if txnsIdFilter.Contains(txn.Hash()) {
+		if txnsIdFilter != nil && txnsIdFilter.Contains(txn.Hash()) {
 			continue
 		}
 		if txn.GetGasLimit() > availableGas {
@@ -294,6 +294,9 @@ func (p *Pool) ProvideTxns(ctx context.Context, opts ...txnprovider.ProvideOptio
 		availableGas -= txn.GetGasLimit()
 		decryptedTxnsGas += txn.GetGasLimit()
 		txns = append(txns, txn)
+		if txnsIdFilter != nil {
+			txnsIdFilter.Add(txn.Hash())
+		}
 	}
 
 	p.logger.Debug("providing decrypted txns", "count", len(txns), "gas", decryptedTxnsGas)

--- a/txnprovider/shutter/pool_test.go
+++ b/txnprovider/shutter/pool_test.go
@@ -199,7 +199,6 @@ func TestPoolProvideTxnsUsesGasTargetAndTxnsIdFilter(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Len(t, txnsRes1, 1)
-		txnsIdFilter.Add(txnsRes1[0].Hash())
 		txnsRes2, err := pool.ProvideTxns(
 			ctx,
 			txnprovider.WithBlockTime(handle.nextBlockTime),
@@ -209,7 +208,6 @@ func TestPoolProvideTxnsUsesGasTargetAndTxnsIdFilter(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Len(t, txnsRes2, 1)
-		txnsIdFilter.Add(txnsRes2[0].Hash())
 		require.Equal(t, 2, txnsIdFilter.Cardinality())
 	})
 }

--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -817,7 +817,7 @@ func (p *TxPool) best(ctx context.Context, n int, txns *TxnsRlp, onTopOf, availa
 
 		mt := best.ms[i]
 
-		if yielded.Contains(mt.TxnSlot.IDHash) {
+		if yielded != nil && yielded.Contains(mt.TxnSlot.IDHash) {
 			continue
 		}
 
@@ -874,7 +874,9 @@ func (p *TxPool) best(ctx context.Context, n int, txns *TxnsRlp, onTopOf, availa
 		txns.Txns[count] = rlpTxn
 		copy(txns.Senders.At(count), sender.Bytes())
 		txns.IsLocal[count] = isLocal
-		yielded.Add(mt.TxnSlot.IDHash)
+		if yielded != nil {
+			yielded.Add(mt.TxnSlot.IDHash)
+		}
 		count++
 	}
 


### PR DESCRIPTION
cherry-pick 2437ffa

---

found that there is a discrepancy in logic in how the the txn ids filter option is handled in shutter and devp2p pool:
- shutter expects the caller to populate the filter with yielded transactions
- devp2p pool fills the filter with the yielded transactions itself
- this PR changes the shutter logic to follow the devp2p pool logic
- additionally fixes the default - original intention was for it to be none by default but that change was forgotten (all prod code paths use a filter option so no logical change here)