### PR TITLE
qa-tests: less strict error handling in RPC Performance Tests

### DIFF
--- a/.github/workflows/qa-rpc-performance-tests.yml
+++ b/.github/workflows/qa-rpc-performance-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout RPC Tests Repository & Install Requirements
         run: |
           rm -rf ${{runner.workspace}}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch v1.58.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
+          git -c advice.detachedHead=false clone --depth 1 --branch v1.78.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
           cd ${{runner.workspace}}/rpc-tests
 
       - name: Clean Erigon Build Directory


### PR DESCRIPTION
Ignore connection errors returned by Vegeta load testing tool if success rate is still 100%