### PR TITLE
Revert "polygon: use execution server start (#16485)"

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1082,7 +1082,6 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 
 		// we need to initiate download before the heimdall services start rather than
 		// waiting for the stage loop to start
-		// TODO although this works we probably want to call engine.Start instead
 
 		if !config.Snapshot.NoDownloader && backend.downloaderClient == nil {
 			panic("expect to have non-nil downloaderClient")


### PR DESCRIPTION
This reverts commit https://github.com/erigontech/erigon/commit/26d43d57e2c080f8bdf58eaae5348f418248d29e.

We can't use `engine.Start` at the moment because currently Astrid manages when the Execution loop gets called. It makes sure that all relevant data from heimdall has been scraped and is available - via the BridgeService and HeimdallService. 

The problem with calling `engine.Start` is that it completely circumvents the synchronisation logic that Astrid has to ensure that all relevant data is pre-fetched and ready before we call Execution (i.e. `ProcessFrozenBlocks` does not have any waiting logic as Astrid does before calling `UpdateForkChoice`) - Elton run into a problem as a result of this.


Additionally, calling `engine.Start` and `ProccesFrozenBlocks` is no longer necessary after https://github.com/erigontech/erigon/pull/16484 (sync.loop.block.limit exhaustion) since that will protect chaindata from unbounded growth.