### PR TITLE
adjust receipt data files version

### DIFF
--- a/erigon-db/rawdb/rawtemporaldb/accessors_receipt.go
+++ b/erigon-db/rawdb/rawtemporaldb/accessors_receipt.go
@@ -90,9 +90,9 @@ func uvarint(in []byte) (res uint64) {
 
 func ReceiptStoresFirstLogIdx(tx kv.TemporalTx) bool {
 	// this stored firstLogIdx;
-	// latter versions (v1_1 onwards) stores lastLogIdx
+	// latter versions (v2_0 onwards) stores lastLogIdx
 	// this check allows to put some ifchecks to handle
 	// both cases and maintain backward compatibility of
 	// snapshots.
-	return tx.Debug().CurrentDomainVersion(kv.ReceiptDomain).Eq(version.V1_0)
+	return tx.Debug().CurrentDomainVersion(kv.ReceiptDomain).Less(version.V1_1)
 }

--- a/erigon-lib/state/aggregator2.go
+++ b/erigon-lib/state/aggregator2.go
@@ -15,6 +15,7 @@ import (
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon-lib/seg"
 	"github.com/erigontech/erigon-lib/snaptype"
+	"github.com/erigontech/erigon-lib/version"
 )
 
 // this is supposed to register domains/iis
@@ -34,6 +35,9 @@ func NewAggregator2(ctx context.Context, dirs datadir.Dirs, aggregationStep uint
 	}
 	a, err := newAggregatorOld(ctx, dirs, aggregationStep, db, logger)
 	if err != nil {
+		return nil, err
+	}
+	if err := AdjustReceiptCurrentVersionIfNeeded(dirs, logger); err != nil {
 		return nil, err
 	}
 	if err := a.registerDomain(kv.AccountsDomain, salt, dirs, logger); err != nil {
@@ -335,6 +339,60 @@ func EnableHistoricalCommitment() {
 	cfg.hist.historyDisabled = false
 	cfg.hist.snapshotsDisabled = false
 	Schema.CommitmentDomain = cfg
+}
+
+/*
+  - v1.0 -> v2.0  is a breaking change. It causes a change in interpretation of "logFirstIdx" stored in receipt domain.
+  - We wanted backwards compatibility however, so that was done with if checks, See `ReceiptStoresFirstLogIdx`
+  - This brings problem that data coming from v1.0 vs v2.0 is interpreted by app in different ways,
+    and so the version needs to be floated up to the application.
+  - So to simplify matters, we need to do- v1.0 files, if it appears, must appear alone (no v2.0 etc.)
+  - This function updates current version to v1.1  (to differentiate file created from 3.0 vs 3.1 erigon)
+    issue: https://github.com/erigontech/erigon/issues/16293
+
+Use this before creating aggregator.
+*/
+func AdjustReceiptCurrentVersionIfNeeded(dirs datadir.Dirs, logger log.Logger) error {
+	found := false
+	return filepath.WalkDir(dirs.SnapDomain, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if found {
+			return nil
+		}
+		if entry.IsDir() {
+			return nil
+		}
+
+		name := entry.Name()
+		res, isE3Seedable, ok := snaptype.ParseFileName(path, name)
+		if !isE3Seedable {
+			return nil
+		}
+		if !ok {
+			return fmt.Errorf("[adjust_receipt] couldn't parse: %s at %s", name, path)
+		}
+
+		if res.TypeString != "receipt" || res.Ext != ".kv" {
+			return nil
+		}
+
+		found = true
+
+		if res.Version.Cmp(version.V2_0) >= 0 {
+			return nil
+		}
+
+		logger.Info("adjusting receipt current version to v1.1")
+
+		// else v1.0 -- need to adjust version
+		Schema.ReceiptDomain.version.DataKV = version.V1_1_standart
+		Schema.ReceiptDomain.hist.version.DataV = version.V1_1_standart
+
+		return nil
+	})
 }
 
 var DomainCompressCfg = seg.Cfg{

--- a/erigon-lib/state/aggregator_test.go
+++ b/erigon-lib/state/aggregator_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
@@ -51,6 +52,7 @@ import (
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon-lib/seg"
 	"github.com/erigontech/erigon-lib/types/accounts"
+	"github.com/erigontech/erigon-lib/version"
 )
 
 func TestAggregatorV3_Merge(t *testing.T) {
@@ -1677,6 +1679,129 @@ func TestAggregator_CheckDependencyBtwnDomains(t *testing.T) {
 	checkFn(aggTx.d[kv.CodeDomain].files, true)
 	checkFn(aggTx.d[kv.StorageDomain].files, false)
 	checkFn(aggTx.d[kv.CommitmentDomain].files, false)
+}
+
+func TestReceiptFilesVersionAdjust(t *testing.T) {
+	touchFn := func(t *testing.T, dirs datadir.Dirs, file string) {
+		fullpath := filepath.Join(dirs.SnapDomain, file)
+		ofile, err := os.Create(fullpath)
+		require.NoError(t, err)
+		ofile.Close()
+	}
+
+	t.Run("v1.0 files", func(t *testing.T) {
+		// Schema is global and edited by subtests
+		backup := Schema
+		t.Cleanup(func() {
+			Schema = backup
+		})
+		require, logger := require.New(t), log.New()
+		dirs := datadir.New(t.TempDir())
+
+		db := mdbx.New(kv.ChainDB, logger).InMem(dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
+		t.Cleanup(db.Close)
+
+		touchFn(t, dirs, "v1.0-receipt.0-2048.kv")
+		touchFn(t, dirs, "v1.0-receipt.2048-2049.kv")
+
+		salt, err := GetStateIndicesSalt(dirs, true, logger)
+		require.NoError(err)
+		agg, err := NewAggregator2(context.Background(), dirs, config3.DefaultStepSize, salt, db, logger)
+		require.NoError(err)
+		t.Cleanup(agg.Close)
+
+		kv_versions := agg.d[kv.ReceiptDomain].version.DataKV
+		v_versions := agg.d[kv.ReceiptDomain].hist.version.DataV
+
+		require.Equal(kv_versions.Current, version.V1_1)
+		require.Equal(kv_versions.MinSupported, version.V1_0)
+		require.Equal(v_versions.Current, version.V1_1)
+		require.Equal(v_versions.MinSupported, version.V1_0)
+	})
+
+	t.Run("v1.1 files", func(t *testing.T) {
+		backup := Schema
+		t.Cleanup(func() {
+			Schema = backup
+		})
+		require, logger := require.New(t), log.New()
+		dirs := datadir.New(t.TempDir())
+
+		db := mdbx.New(kv.ChainDB, logger).InMem(dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
+		t.Cleanup(db.Close)
+
+		touchFn(t, dirs, "v1.1-receipt.0-2048.kv")
+		touchFn(t, dirs, "v1.1-receipt.2048-2049.kv")
+
+		salt, err := GetStateIndicesSalt(dirs, true, logger)
+		require.NoError(err)
+		agg, err := NewAggregator2(context.Background(), dirs, config3.DefaultStepSize, salt, db, logger)
+		require.NoError(err)
+		t.Cleanup(agg.Close)
+
+		kv_versions := agg.d[kv.ReceiptDomain].version.DataKV
+		v_versions := agg.d[kv.ReceiptDomain].hist.version.DataV
+
+		require.Equal(kv_versions.Current, version.V1_1)
+		require.Equal(kv_versions.MinSupported, version.V1_0)
+		require.Equal(v_versions.Current, version.V1_1)
+		require.Equal(v_versions.MinSupported, version.V1_0)
+	})
+
+	t.Run("v2.0 files", func(t *testing.T) {
+		backup := Schema
+		t.Cleanup(func() {
+			Schema = backup
+		})
+		require, logger := require.New(t), log.New()
+		dirs := datadir.New(t.TempDir())
+
+		db := mdbx.New(kv.ChainDB, logger).InMem(dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
+		t.Cleanup(db.Close)
+
+		touchFn(t, dirs, "v2.0-receipt.0-2048.kv")
+		touchFn(t, dirs, "v2.0-receipt.2048-2049.kv")
+
+		salt, err := GetStateIndicesSalt(dirs, true, logger)
+		require.NoError(err)
+		agg, err := NewAggregator2(context.Background(), dirs, config3.DefaultStepSize, salt, db, logger)
+		require.NoError(err)
+		t.Cleanup(agg.Close)
+
+		kv_versions := agg.d[kv.ReceiptDomain].version.DataKV
+		v_versions := agg.d[kv.ReceiptDomain].hist.version.DataV
+
+		require.True(kv_versions.Current.Cmp(version.V2_1) >= 0)
+		require.Equal(kv_versions.MinSupported, version.V1_0)
+		require.True(v_versions.Current.Cmp(version.V2_1) >= 0)
+		require.Equal(v_versions.MinSupported, version.V1_0)
+	})
+
+	t.Run("empty files", func(t *testing.T) {
+		backup := Schema
+		t.Cleanup(func() {
+			Schema = backup
+		})
+		require, logger := require.New(t), log.New()
+		dirs := datadir.New(t.TempDir())
+
+		db := mdbx.New(kv.ChainDB, logger).InMem(dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
+		t.Cleanup(db.Close)
+		salt, err := GetStateIndicesSalt(dirs, true, logger)
+		require.NoError(err)
+		agg, err := NewAggregator2(context.Background(), dirs, config3.DefaultStepSize, salt, db, logger)
+		require.NoError(err)
+		t.Cleanup(agg.Close)
+
+		kv_versions := agg.d[kv.ReceiptDomain].version.DataKV
+		v_versions := agg.d[kv.ReceiptDomain].hist.version.DataV
+
+		require.True(kv_versions.Current.Cmp(version.V2_1) >= 0)
+		require.Equal(kv_versions.MinSupported, version.V1_0)
+		require.True(v_versions.Current.Cmp(version.V2_1) >= 0)
+		require.Equal(v_versions.MinSupported, version.V1_0)
+	})
+
 }
 
 func generateDomainFiles(t *testing.T, name string, dirs datadir.Dirs, ranges []testFileRange) {

--- a/erigon-lib/state/aggregator_test.go
+++ b/erigon-lib/state/aggregator_test.go
@@ -1683,6 +1683,7 @@ func TestAggregator_CheckDependencyBtwnDomains(t *testing.T) {
 
 func TestReceiptFilesVersionAdjust(t *testing.T) {
 	touchFn := func(t *testing.T, dirs datadir.Dirs, file string) {
+		t.Helper()
 		fullpath := filepath.Join(dirs.SnapDomain, file)
 		ofile, err := os.Create(fullpath)
 		require.NoError(t, err)


### PR DESCRIPTION
  - v1.0 -> v2.0  is a breaking change. It causes a change in interpretation of "logFirstIdx" stored in receipt domain.
  - We wanted backwards compatibility however, so that was done with if checks, See `ReceiptStoresFirstLogIdx`
  - This brings problem that data coming from v1.0 vs v2.0 is interpreted by app in different ways,
    and so the version needs to be floated up to the application.
  - So to simplify matters, we need to do- v1.0 files, if it appears, must appear alone (no v2.0 etc.)
  - This function updates current version to v1.1  (to differentiate file created from 3.0 vs 3.1 erigon)
    issue: https://github.com/erigontech/erigon/issues/16293
    
    
 closes: https://github.com/erigontech/erigon/issues/16647