### PR TITLE
workflows: Run `run_migrations` before running RPC tests

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests-gnosis.yml
+++ b/.github/workflows/qa-rpc-integration-tests-gnosis.yml
@@ -44,9 +44,9 @@ jobs:
         run: |
           make clean
 
-      - name: Build Erigon RPCDaemon
+      - name: Build Erigon RPCDaemon and integration
         run: |
-          make rpcdaemon
+          make rpcdaemon integration
         working-directory: ${{ github.workspace }}
 
       - name: Pause the Erigon instance dedicated to db maintenance
@@ -59,6 +59,12 @@ jobs:
           rm -rf $ERIGON_TESTBED_AREA/chaindata-prev || true
           echo "Backup chaindata"
           cp -r $ERIGON_REFERENCE_DATA_DIR/chaindata $ERIGON_TESTBED_AREA/chaindata-prev
+
+      - name: Run Migrations
+        working-directory: ${{ github.workspace }}/build/bin
+        run: |
+          echo "Running migrations on datadir..."
+          ./integration run_migrations --datadir $ERIGON_REFERENCE_DATA_DIR --chain $CHAIN
 
       - name: Run RpcDaemon
         working-directory: ${{ github.workspace }}/build/bin

--- a/.github/workflows/qa-rpc-integration-tests-polygon.yml
+++ b/.github/workflows/qa-rpc-integration-tests-polygon.yml
@@ -44,9 +44,9 @@ jobs:
         run: |
           make clean
 
-      - name: Build Erigon RPCDaemon
+      - name: Build Erigon RPCDaemon and integration
         run: |
-          make rpcdaemon
+          make rpcdaemon integration
         working-directory: ${{ github.workspace }}
 
       - name: Pause the Erigon instance dedicated to db maintenance
@@ -59,6 +59,12 @@ jobs:
           rm -rf $ERIGON_TESTBED_AREA/chaindata-prev || true
           echo "Backup chaindata"
           cp -r $ERIGON_REFERENCE_DATA_DIR/chaindata $ERIGON_TESTBED_AREA/chaindata-prev
+
+      - name: Run Migrations
+        working-directory: ${{ github.workspace }}/build/bin
+        run: |
+          echo "Running migrations on datadir..."
+          ./integration run_migrations --datadir $ERIGON_REFERENCE_DATA_DIR --chain $CHAIN
 
       - name: Run RpcDaemon
         working-directory: ${{ github.workspace }}/build/bin

--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -44,9 +44,9 @@ jobs:
         run: |
           make clean
 
-      - name: Build Erigon RPCDaemon
+      - name: Build Erigon RPCDaemon and integration
         run: |
-          make rpcdaemon
+          make rpcdaemon integration
         working-directory: ${{ github.workspace }}
 
       - name: Pause the Erigon instance dedicated to db maintenance
@@ -59,6 +59,12 @@ jobs:
           rm -rf $ERIGON_TESTBED_AREA/chaindata-prev || true
           echo "Backup chaindata"
           cp -r $ERIGON_REFERENCE_DATA_DIR/chaindata $ERIGON_TESTBED_AREA/chaindata-prev
+
+      - name: Run Migrations
+        working-directory: ${{ github.workspace }}/build/bin
+        run: |
+          echo "Running migrations on datadir..."
+          ./integration run_migrations --datadir $ERIGON_REFERENCE_DATA_DIR --chain $CHAIN
 
       - name: Run RpcDaemon
         working-directory: ${{ github.workspace }}/build/bin


### PR DESCRIPTION
Making changes to MDBX tables does not result in failing RPC tests.