### PR TITLE
Revert "polygon: use execution server start (#16485)" (#16676)

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -222,11 +222,12 @@ type Ethereum struct {
 	silkwormRPCDaemonService *silkworm.RpcDaemonService
 	silkwormSentryService    *silkworm.SentryService
 
-	polygonSyncService *polygonsync.Service
-	polygonBridge      *bridge.Service
-	heimdallService    *heimdall.Service
-	stopNode           func() error
-	bgComponentsEg     errgroup.Group
+	polygonSyncService  *polygonsync.Service
+	polygonDownloadSync *stagedsync.Sync
+	polygonBridge       *bridge.Service
+	heimdallService     *heimdall.Service
+	stopNode            func() error
+	bgComponentsEg      errgroup.Group
 }
 
 func splitAddrIntoHostAndPort(addr string) (host string, port int, err error) {
@@ -1089,6 +1090,18 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 			backend,
 		)
 
+		// we need to initiate download before the heimdall services start rather than
+		// waiting for the stage loop to start
+
+		if !config.Snapshot.NoDownloader && backend.downloaderClient == nil {
+			panic("expect to have non-nil downloaderClient")
+		}
+		backend.polygonDownloadSync = stagedsync.New(backend.config.Sync, stagedsync.DownloadSyncStages(
+			backend.sentryCtx, stagedsync.StageSnapshotsCfg(
+				backend.chainDB, backend.sentriesClient.ChainConfig, config.Sync, dirs, blockRetire, backend.downloaderClient,
+				blockReader, backend.notifications, false, false, false, backend.silkworm, config.Prune,
+			)), nil, nil, backend.logger, stages.ModeApplyingBlocks)
+
 		// these range extractors set the db to the local db instead of the chain db
 		// TODO this needs be refactored away by having a retire/merge component per
 		// snapshot instead of global processing in the stage loop
@@ -1651,9 +1664,24 @@ func (s *Ethereum) Start() error {
 	} else if s.chainConfig.Bor != nil {
 		diagnostics.Send(diagnostics.SyncStageList{StagesList: diagnostics.InitStagesFromList(s.stagedSync.StagesIdsList())})
 		s.waitForStageLoopStop = nil // Shutdown is handled by context
-		go s.eth1ExecutionServer.Start(s.sentryCtx)
 		s.bgComponentsEg.Go(func() error {
 			defer s.logger.Info("[polygon.sync] goroutine terminated")
+			// when we're running in stand alone mode we need to run the downloader before we start the
+			// polygon services because they will wait for it to complete before opening their stores
+			// which make use of snapshots and expect them to be initialize
+			// TODO: get the snapshots to call the downloader directly - which will avoid this
+			go func() {
+				err := stages2.StageLoopIteration(s.sentryCtx, s.chainDB, wrap.NewTxContainer(nil, nil), s.polygonDownloadSync, true, true, s.logger, s.blockReader, hook)
+
+				if err != nil && !errors.Is(err, context.Canceled) {
+					s.logger.Error("[polygon.sync] downloader stage crashed - stopping node", "err", err)
+					err = s.stopNode()
+					if err != nil {
+						s.logger.Error("could not stop node", "err", err)
+					}
+				}
+			}()
+
 			ctx := s.sentryCtx
 			err := s.polygonSyncService.Run(ctx)
 			if err == nil || errors.Is(err, context.Canceled) {


### PR DESCRIPTION
cherry-pick 542aacd

---

This reverts commit
https://github.com/erigontech/erigon/commit/26d43d57e2c080f8bdf58eaae5348f418248d29e.

We can't use `engine.Start` at the moment because currently Astrid manages when the Execution loop gets called. It makes sure that all relevant data from heimdall has been scraped and is available - via the BridgeService and HeimdallService.

The problem with calling `engine.Start` is that it completely circumvents the synchronisation logic that Astrid has to ensure that all relevant data is pre-fetched and ready before we call Execution (i.e. `ProcessFrozenBlocks` does not have any waiting logic as Astrid does before calling `UpdateForkChoice`) - Elton run into a problem as a result of this.


Additionally, calling `engine.Start` and `ProccesFrozenBlocks` is no longer necessary after https://github.com/erigontech/erigon/pull/16484 (sync.loop.block.limit exhaustion) since that will protect chaindata from unbounded growth.