### PR TITLE
[r3.1] qa-tests: improve tip-tracking timeout and error reporting 

### DIFF
--- a/.github/workflows/qa-tip-tracking.yml
+++ b/.github/workflows/qa-tip-tracking.yml
@@ -238,4 +238,4 @@ jobs:
            [[ "${{ steps.downgrade_test_step.outputs.TEST_RESULT }}" != "success" ]]; then
           echo "::error::Error detected during tests"
           exit 1
-        fi
+        fi 

--- a/.github/workflows/qa-tip-tracking.yml
+++ b/.github/workflows/qa-tip-tracking.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   mainnet-tip-tracking-test:
     runs-on: [self-hosted, qa, Ethereum, tip-tracking]
-    timeout-minutes: 600
+    timeout-minutes: 1000
     env:
       ERIGON_REFERENCE_DATA_DIR: /opt/erigon-versions/reference-version-3.0/datadir
       ERIGON_TESTBED_DATA_DIR: /opt/erigon-testbed/datadir
@@ -232,7 +232,10 @@ jobs:
         python3 $ERIGON_QA_PATH/test_system/db-producer/resume_production.py || true
 
     - name: Action for Not Success
-      if: steps.test_step.outputs.TEST_RESULT != 'success' || steps.downgrade_test_step.outputs.TEST_RESULT != 'success'
+      if: ${{ always() }}
       run: |
-        echo "::error::Error detected during tests"
-        exit 1
+        if [[ "${{ steps.test_step.outputs.TEST_RESULT }}" != "success" ]] || \
+           [[ "${{ steps.downgrade_test_step.outputs.TEST_RESULT }}" != "success" ]]; then
+          echo "::error::Error detected during tests"
+          exit 1
+        fi


### PR DESCRIPTION
The latest "tip-tracking & migration" executions show that it takes more than ten hours to run two erigon cycles, so this PR raises the timeout to more than 16 hours (8 hours are expected per cycle).
Furthermore, when the test is cancelled due to a timeout, GitHub displays a grey icon, which is misleading. This PR should change it to red, forcing a check to be performed. The error condition deliberately treats false positives as errors, i.e. the test not being performed on erigon during upgrades and downgrades.