### PR TITLE
get salt-blocks load/create logic parity with salt-state

### DIFF
--- a/db/snaptype/type.go
+++ b/db/snaptype/type.go
@@ -71,7 +71,7 @@ func (f IndexBuilderFunc) Build(ctx context.Context, info FileInfo, salt uint32,
 var saltMap = map[string]uint32{}
 var saltLock sync.RWMutex
 
-func ReadAndCreateSaltIfNeeded(baseDir string) (uint32, error) {
+func LoadSalt(baseDir string, autoCreate bool) (uint32, error) {
 	// issue: https://github.com/erigontech/erigon/issues/14300
 	// NOTE: The salt value from this is read after snapshot stage AND the value is not
 	// cached before snapshot stage (which downloads salt-blocks.txt too), and therefore
@@ -83,6 +83,9 @@ func ReadAndCreateSaltIfNeeded(baseDir string) (uint32, error) {
 	}
 
 	if !exists {
+		if !autoCreate {
+			return 0, errors.New("salt file not found + autoCreate disabled")
+		}
 		dir.MustExist(baseDir)
 
 		saltBytes := make([]byte, 4)
@@ -120,7 +123,7 @@ func GetIndexSalt(baseDir string) (uint32, error) {
 		return salt, nil
 	}
 
-	salt, err := ReadAndCreateSaltIfNeeded(baseDir)
+	salt, err := LoadSalt(baseDir, false)
 	if err != nil {
 		return 0, err
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1572,6 +1572,9 @@ func setUpBlockReader(ctx context.Context, db kv.RwDB, dirs datadir.Dirs, snConf
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, err
 	}
+	if _, err := snaptype.LoadSalt(dirs.Snap, createNewSaltFileIfNeeded); err != nil {
+		return nil, nil, nil, nil, nil, nil, nil, err
+	}
 	agg, err := state.NewAggregator2(ctx, dirs, config3.DefaultStepSize, salt, db, logger)
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, err

--- a/turbo/snapshotsync/snapshots.go
+++ b/turbo/snapshotsync/snapshots.go
@@ -1408,7 +1408,7 @@ func (s *RoSnapshots) buildMissedIndices(logPrefix string, ctx context.Context, 
 		return nil
 	}
 
-	if _, err := snaptype.ReadAndCreateSaltIfNeeded(dirs.Snap); err != nil {
+	if _, err := snaptype.GetIndexSalt(dirs.Snap); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
- divide salt-blocks.txt api to two functions - 
  - `GetIndexSalt`: this expects salt-blocks file to be there
  - `LoadSalt`: this allows optional creation of salt file, if not present. 

- use same param which determine if salt-state should be created, to decide if salt-blocks should be created. 