### PR TITLE
Caplin: add stricter timeouts to p2p handling

### DIFF
--- a/cl/sentinel/handlers/handlers.go
+++ b/cl/sentinel/handlers/handlers.go
@@ -188,6 +188,12 @@ func (c *ConsensusHandlers) wrapStreamHandler(name string, fn func(s network.Str
 				l["agent"] = str
 			}
 		}
+
+		streamDeadline := time.Now().Add(5 * time.Second)
+		s.SetReadDeadline(streamDeadline)
+		s.SetWriteDeadline(streamDeadline)
+		s.SetDeadline(streamDeadline)
+
 		if err := fn(s); err != nil {
 			if errors.Is(err, ErrResourceUnavailable) {
 				// write resource unavailable prefix


### PR DESCRIPTION
Our current timeouts cause some minor memory spikes. better limit them properly