### PR TITLE
VeBlop: Update span index lookup and add more unit tests

### DIFF
--- a/polygon/heimdall/snapshot_store_test.go
+++ b/polygon/heimdall/snapshot_store_test.go
@@ -127,9 +127,9 @@ func TestHeimdallStoreEntity(t *testing.T) {
 		actualSpan, ok, err := heimdallStore.spans.Entity(t.Context(), expectedSpan.RawId())
 		require.NoError(t, err)
 		require.True(t, ok)
-		require.Equal(t, actualSpan.Id, expectedSpan.Id)
-		require.Equal(t, actualSpan.StartBlock, expectedSpan.StartBlock)
-		require.Equal(t, actualSpan.EndBlock, expectedSpan.EndBlock)
+		require.Equal(t, expectedSpan.Id, actualSpan.Id)
+		require.Equal(t, expectedSpan.StartBlock, actualSpan.StartBlock)
+		require.Equal(t, expectedSpan.EndBlock, actualSpan.EndBlock)
 	}
 }
 
@@ -157,7 +157,7 @@ func TestHeimdallStoreLastFrozenIdWithSpanRotations(t *testing.T) {
 	lastFrozenId, found, err := heimdallStore.spans.LastFrozenEntityId()
 	require.NoError(t, err)
 	require.True(t, found)
-	require.Equal(t, lastFrozenId, uint64(9))
+	require.Equal(t, uint64(9), lastFrozenId)
 }
 
 func TestHeimdallStoreEntityWithSpanRotations(t *testing.T) {
@@ -358,54 +358,54 @@ var spanDataForTesting = []Span{
 
 // span data that is irregular, containing possible span rotations
 var spanDataWithRotations = []Span{
-	Span{
+	Span{ // first  span
 		Id:         0,
 		StartBlock: 0,
 		EndBlock:   999,
 	},
-	Span{
+	Span{ // new span announced
 		Id:         1,
+		StartBlock: 1000,
+		EndBlock:   1999,
+	},
+	Span{ // span rotation
+		Id:         2,
+		StartBlock: 4,
+		EndBlock:   1999,
+	},
+	Span{ // span rotation
+		Id:         3,
 		StartBlock: 5,
 		EndBlock:   1999,
 	},
-	Span{
-		Id:         2,
-		StartBlock: 1988,
+	Span{ // span rotation
+		Id:         4,
+		StartBlock: 6,
+		EndBlock:   1999,
+	},
+	Span{ // new span announced
+		Id:         5,
+		StartBlock: 2000,
 		EndBlock:   2999,
 	},
-	Span{
-		Id:         3,
-		StartBlock: 3000,
-		EndBlock:   3999,
+	Span{ // span rotation
+		Id:         6,
+		StartBlock: 11,
+		EndBlock:   1999,
 	},
-	Span{
-		Id:         4,
-		StartBlock: 3500,
+	Span{ // new span announced, this will have duplicate StartBlock
+		Id:         7,
+		StartBlock: 2000,
+		EndBlock:   2999,
+	},
+	Span{ // span rotation
+		Id:         8,
+		StartBlock: 3100,
 		EndBlock:   4999,
 	},
-	Span{
-		Id:         5,
-		StartBlock: 5000,
-		EndBlock:   5999,
-	},
-	Span{
-		Id:         6,
-		StartBlock: 5500,
-		EndBlock:   6999,
-	},
-	Span{
-		Id:         7,
-		StartBlock: 7000,
-		EndBlock:   7999,
-	},
-	Span{
-		Id:         8,
-		StartBlock: 7001,
-		EndBlock:   8999,
-	},
-	Span{
+	Span{ // span rotation
 		Id:         9,
-		StartBlock: 7002,
-		EndBlock:   9999,
+		StartBlock: 4600,
+		EndBlock:   5999,
 	},
 }

--- a/polygon/heimdall/span_range_index.go
+++ b/polygon/heimdall/span_range_index.go
@@ -97,7 +97,7 @@ func (i *txSpanRangeIndex) Put(ctx context.Context, r ClosedRange, id uint64) er
 	return tx.Put(i.table, key[:], valuePair[:])
 }
 
-// Returns max span.Id such that span.StartBlock <= blockNum && span.EndBlock <= blockNum
+// Returns max span.Id such that span.StartBlock <= blockNum &&  blockNum <= span.EndBlock
 func (i *txSpanRangeIndex) Lookup(ctx context.Context, blockNum uint64) (uint64, bool, error) {
 	cursor, err := i.tx.Cursor(i.table)
 	if err != nil {

--- a/polygon/heimdall/span_range_index.go
+++ b/polygon/heimdall/span_range_index.go
@@ -97,6 +97,7 @@ func (i *txSpanRangeIndex) Put(ctx context.Context, r ClosedRange, id uint64) er
 	return tx.Put(i.table, key[:], valuePair[:])
 }
 
+// Returns max span.Id such that span.StartBlock <= blockNum && span.EndBlock <= blockNum
 func (i *txSpanRangeIndex) Lookup(ctx context.Context, blockNum uint64) (uint64, bool, error) {
 	cursor, err := i.tx.Cursor(i.table)
 	if err != nil {
@@ -104,12 +105,13 @@ func (i *txSpanRangeIndex) Lookup(ctx context.Context, blockNum uint64) (uint64,
 	}
 	defer cursor.Close()
 
+	// use Seek(blockNum) as the starting point for the search.
 	key := rangeIndexKey(blockNum)
 	startBlockRaw, valuePair, err := cursor.Seek(key[:])
 	if err != nil {
 		return 0, false, err
 	}
-	// seek not found, we check the last entry
+	// seek not found, check the last entry as the only candidate
 	if valuePair == nil {
 		// get latest then
 		lastStartBlockRaw, lastValuePair, err := cursor.Last()
@@ -131,33 +133,34 @@ func (i *txSpanRangeIndex) Lookup(ctx context.Context, blockNum uint64) (uint64,
 
 	}
 
+	var lastSpanIdInRange = uint64(0)
 	currStartBlock := rangeIndexKeyParse(startBlockRaw)
-	// If currStartBlock == blockNum, then this span contains blockNum, and no need to do the .Prev() below
-	if currStartBlock == blockNum {
-		currSpanId, currEndBlock := rangeIndexValuePairParse(valuePair)
-		// sanityCheck
-		isInRange := blockNumInRange(blockNum, currStartBlock, currEndBlock)
-		if !isInRange {
-			return 0, false, fmt.Errorf("SpanIndexLookup(%d) returns Span{Id:%d, StartBlock:%d, EndBlock:%d } not containing blockNum=%d", blockNum, currSpanId, currStartBlock, currEndBlock, blockNum)
-		}
-		// happy case
-		return currSpanId, true, nil
+	currSpanId, currEndBlock := rangeIndexValuePairParse(valuePair)
+	isInRange := blockNumInRange(blockNum, currStartBlock, currEndBlock)
+	if isInRange { // cursor.Seek(blockNum) is in range
+		lastSpanIdInRange = currSpanId
 	}
 
-	// Prev should contain the appropriate span containing blockNum
-	prevStartBlockRaw, prevValuePair, err := cursor.Prev()
-	if err != nil {
-		return 0, false, err
+	for { // from this point walk backwards the table until the blockNum is out of range
+		prevStartBlockRaw, prevValuePair, err := cursor.Prev()
+		if err != nil {
+			return 0, false, err
+		}
+		// this could happen if we've walked all the way to the first entry in the table, and there is no more Prev()
+		if prevValuePair == nil {
+			break
+		}
+		prevStartBlock := rangeIndexKeyParse(prevStartBlockRaw)
+		prevSpanId, prevBlock := rangeIndexValuePairParse(prevValuePair)
+		isInRange := blockNumInRange(blockNum, prevStartBlock, prevBlock)
+		if !isInRange {
+			break // we have walked out of range, break to return current known lastSpanIdInRange
+		}
+		if isInRange && prevSpanId > lastSpanIdInRange { // a span in range with higher span id was found
+			lastSpanIdInRange = prevSpanId
+		}
 	}
-	prevStartBlock := rangeIndexKeyParse(prevStartBlockRaw)
-	spanId, endBlock := rangeIndexValuePairParse(prevValuePair)
-	// sanity check
-	isInRange := blockNumInRange(blockNum, prevStartBlock, endBlock)
-	if !isInRange {
-		return 0, false, fmt.Errorf("SpanIndexLookup(%d) returns Span{Id:%d, StartBlock:%d, EndBlock:%d } not containing blockNum=%d", blockNum, spanId, prevStartBlock, endBlock, blockNum)
-	}
-	// happy case
-	return spanId, true, nil
+	return lastSpanIdInRange, true, nil
 }
 
 // last key in the index

--- a/polygon/heimdall/span_range_index_test.go
+++ b/polygon/heimdall/span_range_index_test.go
@@ -121,12 +121,12 @@ func TestSpanRangeIndexNonOverlappingSpans(t *testing.T) {
 			actualId, found, err := test.index.Lookup(ctx, blockNum)
 			require.NoError(t, err)
 			require.True(t, found)
-			assert.Equal(t, actualId, span.RawId())
+			assert.Equal(t, span.RawId(), actualId)
 		}
 	}
 }
 
-func TestSpanRangeIndexOverlappingSpans(t *testing.T) {
+func TestSpanRangeIndexSpanRotation(t *testing.T) {
 	t.Parallel()
 	test := newSpanRangeIndexTest(t)
 	ctx := test.ctx
@@ -139,49 +139,14 @@ func TestSpanRangeIndexOverlappingSpans(t *testing.T) {
 			EndBlock:   999,
 		},
 		Span{
-			Id:         1,
-			StartBlock: 5,
+			Id:         1, // new span announced
+			StartBlock: 1000,
 			EndBlock:   1999,
 		},
 		Span{
-			Id:         2,
-			StartBlock: 1988,
-			EndBlock:   2999,
-		},
-		Span{
-			Id:         3,
-			StartBlock: 3000,
-			EndBlock:   3999,
-		},
-		Span{
-			Id:         4,
-			StartBlock: 3500,
-			EndBlock:   4999,
-		},
-		Span{
-			Id:         5,
-			StartBlock: 5000,
-			EndBlock:   5999,
-		},
-		Span{
-			Id:         6,
-			StartBlock: 5500,
-			EndBlock:   6999,
-		},
-		Span{
-			Id:         7,
-			StartBlock: 7000,
-			EndBlock:   7999,
-		},
-		Span{
-			Id:         8,
-			StartBlock: 7001,
-			EndBlock:   8999,
-		},
-		Span{
-			Id:         9,
-			StartBlock: 7002,
-			EndBlock:   9999,
+			Id:         2, // span rotation
+			StartBlock: 5,
+			EndBlock:   1999,
 		},
 	}
 
@@ -196,39 +161,179 @@ func TestSpanRangeIndexOverlappingSpans(t *testing.T) {
 		0:    0,
 		1:    0,
 		4:    0,
-		5:    1,
-		999:  1,
-		100:  1,
-		1988: 2,
-		1999: 2,
-		3200: 3,
-		3500: 4,
-		3600: 4,
-		3988: 4,
-		5200: 5,
-		5900: 6,
-		6501: 6,
-		7000: 7,
-		7001: 8,
-		7002: 9,
-		8000: 9,
-		8998: 9,
-		9000: 9,
-		9998: 9,
-		9999: 9,
+		5:    2,
+		1000: 2,
 	}
 
 	for blockNum, expectedId := range expectedLookupVals {
 		actualId, found, err := test.index.Lookup(ctx, blockNum)
 		require.NoError(t, err)
 		require.True(t, found)
-		assert.Equal(t, actualId, expectedId)
+		assert.Equal(t, expectedId, actualId, "Lookup(blockNum=%d) returned %d instead of %d", blockNum, actualId, expectedId)
 	}
 
 	// additional test cases for out of range lookups
 	_, _, err := test.index.Lookup(ctx, 12000)
 	require.Error(t, err)
 
+}
+
+func TestSpanRangeIndexComplicatedSpanRotations(t *testing.T) {
+	t.Parallel()
+	test := newSpanRangeIndexTest(t)
+	ctx := test.ctx
+
+	// span data that is irregular, containing possible span rotations
+	var spans = []Span{
+		Span{ // first  span
+			Id:         0,
+			StartBlock: 0,
+			EndBlock:   999,
+		},
+		Span{ // new span announced
+			Id:         1,
+			StartBlock: 1000,
+			EndBlock:   1999,
+		},
+		Span{ // span rotation
+			Id:         2,
+			StartBlock: 4,
+			EndBlock:   1999,
+		},
+		Span{ // span rotation
+			Id:         3,
+			StartBlock: 5,
+			EndBlock:   1999,
+		},
+		Span{ // span rotation
+			Id:         4,
+			StartBlock: 6,
+			EndBlock:   1999,
+		},
+		Span{ // new span announced
+			Id:         5,
+			StartBlock: 2000,
+			EndBlock:   2999,
+		},
+		Span{ // span rotation
+			Id:         6,
+			StartBlock: 11,
+			EndBlock:   1999,
+		},
+		Span{ // new span announced, this will have duplicate StartBlock
+			Id:         7,
+			StartBlock: 2000,
+			EndBlock:   2999,
+		},
+		Span{ // span rotation
+			Id:         8,
+			StartBlock: 3100,
+			EndBlock:   4999,
+		},
+		Span{ // span rotation
+			Id:         9,
+			StartBlock: 4600,
+			EndBlock:   5999,
+		},
+		Span{ // span rotation
+			Id:         10,
+			StartBlock: 5400,
+			EndBlock:   6999,
+		},
+		Span{ // new span announced
+			Id:         11,
+			StartBlock: 7000,
+			EndBlock:   7999,
+		},
+	}
+
+	for _, span := range spans {
+		spanId := span.RawId()
+		r := ClosedRange{Start: span.StartBlock, End: span.EndBlock}
+		require.NoError(t, test.index.Put(ctx, r, spanId))
+	}
+
+	// expected blockNum -> spanId lookups
+	expectedLookupVals := map[uint64]uint64{
+		3:    0,
+		4:    2,
+		5:    3,
+		6:    4,
+		7:    4,
+		12:   6,
+		11:   6,
+		100:  6,
+		1000: 6,
+		2000: 7,
+		3101: 8,
+		4800: 9,
+	}
+
+	for blockNum, expectedId := range expectedLookupVals {
+		actualId, found, err := test.index.Lookup(ctx, blockNum)
+		require.NoError(t, err)
+		require.True(t, found)
+		assert.Equal(t, expectedId, actualId, "Lookup(blockNum=%d) returned %d instead of %d", blockNum, actualId, expectedId)
+
+	}
+}
+
+func TestSpanRangeIndexEvenMoreComplicatedSpanRotations(t *testing.T) {
+	t.Parallel()
+	test := newSpanRangeIndexTest(t)
+	ctx := test.ctx
+
+	// span data that is irregular, containing possible span rotations
+	var spans = []Span{
+		Span{
+			Id:         7,
+			StartBlock: 1000,
+			EndBlock:   2999,
+		},
+		Span{
+			Id:         8,
+			StartBlock: 3000, // new span announced
+			EndBlock:   4999,
+		},
+		Span{
+			Id:         9, // span rotation
+			StartBlock: 1005,
+			EndBlock:   4999,
+		},
+		Span{
+			Id:         10, // new span announced
+			StartBlock: 5000,
+			EndBlock:   6999,
+		},
+		Span{
+			Id:         11, // span rotation
+			StartBlock: 4997,
+			EndBlock:   6999,
+		},
+	}
+
+	for _, span := range spans {
+		spanId := span.RawId()
+		r := ClosedRange{Start: span.StartBlock, End: span.EndBlock}
+		require.NoError(t, test.index.Put(ctx, r, spanId))
+	}
+
+	// expected blockNum -> spanId lookups
+	expectedLookupVals := map[uint64]uint64{
+		1000: 7,
+		3500: 9,
+		4000: 9,
+		4996: 9,
+		5000: 11,
+	}
+
+	for blockNum, expectedId := range expectedLookupVals {
+		actualId, found, err := test.index.Lookup(ctx, blockNum)
+		require.NoError(t, err)
+		require.True(t, found)
+		assert.Equal(t, expectedId, actualId, "Lookup(blockNum=%d) returned %d instead of %d", blockNum, actualId, expectedId)
+
+	}
 }
 
 func TestSpanRangeIndexSingletonLookup(t *testing.T) {


### PR DESCRIPTION
Follow-up to : https://github.com/erigontech/erigon/pull/16683

The previous PR relied on the assumption that `span.StartBlock` is monotonically increasing, but it turns out that assumption is not true due to a future span being announced in advance from Heimdall and a span rotation taking place before the announced span.

e.g.

```Go
var spans = []Span{
		Span{
			Id:         0,
			StartBlock: 0,
			EndBlock:   999,
		},
		Span{
			Id:         1, // new span announced
			StartBlock: 1000,
			EndBlock:   1999,
		},
		Span{
			Id:         2, // span rotation
			StartBlock: 5,
			EndBlock:   1999,
		},
	}
```

Therefore, this PR adapts the lookup algorithm by starting the search from `entry := cursor.Seek(blockNum)` and walking the `BorSpans` table backwards using `cursor.Prev()` while recording the highest span id which is in range,  until an out-of-range span is reached, at which point we break and return the highest span id seen.

This lookup algorithm relies on the assumption that there won't ever be more than 2 consecutive spans for which `span1.Id < span2.Id` and `span1.StartBlock > span2.StartBlock` . If this assumption were ever to be broken, we would have to fall back on brute-force linear search.

Also, another detail to take into account is that due to the span rotations multiple spans with the same `StartBlock` could be produced, therefore overwriting the value of the index table at that block number. This is not a problem, because if this happens, then the previous span value will become entirely obsolete and no block number could have the old span associated with it.