### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -401,11 +401,10 @@ jobs:
         for archive in *.tar; do gzip $archive; echo Artifact $archive compressed; done
         sha256sum *.tar.gz *.deb > ${HOME}/${{ env.APPLICATION }}_${{ inputs.release_version }}_checksums.txt
         gh release create \
-          --generate-notes \
           --target ${GITHUB_RELEASE_TARGET} \
           --draft=true \
           --title "${{ inputs.release_version }}" \
-          --notes "**Improvements:**<br>- ...coming soon <br><br>**Bugfixes:**<br><br>- ...coming soon<br><br>**Docker images:**<br><br>Docker image released:<br> ${{ env.DOCKER_TAGS }}<br><br>... coming soon<br>" \
+          --notes "**Please generate notes in WEB UI and copy-paste here**<br>**Improvements:**<br>- ...coming soon <br><br>**Bugfixes:**<br><br>- ...coming soon<br><br>**Docker images:**<br><br>Docker image released:<br> ${{ env.DOCKER_TAGS }}<br><br>... coming soon<br>" \
           "${{ inputs.release_version }}" \
           *.tar.gz *.deb ${HOME}/${{ env.APPLICATION }}_${{ inputs.release_version }}_checksums.txt
 


### PR DESCRIPTION
`--generate-notes` fails when there are too many changes due to the hard limit of 125000 chars in `gh` API request.

Sample error output:
```
HTTP 422: Validation Failed (https://api.github.com/repos/erigontech/erigon/releases)
body is too long (maximum is 125000 characters)
```

It does not happen when notes generated over Web UI.

Added note for the Release Engineer to not miss to perform this manual step.