### PR TITLE
move salt not found error to `GetIndexSalt`

### DIFF
--- a/cmd/capcli/cli.go
+++ b/cmd/capcli/cli.go
@@ -394,7 +394,7 @@ func (c *DumpSnapshots) Run(ctx *Context) error {
 		return
 	})
 
-	salt, err := snaptype.GetIndexSalt(dirs.Snap)
+	salt, err := snaptype.GetIndexSalt(dirs.Snap, log.Root())
 
 	if err != nil {
 		return err
@@ -1038,7 +1038,7 @@ func (c *DumpBlobsSnapshots) Run(ctx *Context) error {
 	})
 	from := ((beaconConfig.DenebForkEpoch * beaconConfig.SlotsPerEpoch) / snaptype.CaplinMergeLimit) * snaptype.CaplinMergeLimit
 
-	salt, err := snaptype.GetIndexSalt(dirs.Snap)
+	salt, err := snaptype.GetIndexSalt(dirs.Snap, log.Root())
 
 	if err != nil {
 		return err
@@ -1272,7 +1272,7 @@ func (c *DumpStateSnapshots) Run(ctx *Context) error {
 	freezingCfg := ethconfig.Defaults.Snapshot
 	freezingCfg.ChainName = c.Chain
 
-	salt, err := snaptype.GetIndexSalt(dirs.Snap)
+	salt, err := snaptype.GetIndexSalt(dirs.Snap, log.Root())
 
 	if err != nil {
 		return err

--- a/db/snaptype/type.go
+++ b/db/snaptype/type.go
@@ -71,7 +71,7 @@ func (f IndexBuilderFunc) Build(ctx context.Context, info FileInfo, salt uint32,
 var saltMap = map[string]uint32{}
 var saltLock sync.RWMutex
 
-func LoadSalt(baseDir string, autoCreate bool) (uint32, error) {
+func LoadSalt(baseDir string, autoCreate bool, logger log.Logger) (*uint32, error) {
 	// issue: https://github.com/erigontech/erigon/issues/14300
 	// NOTE: The salt value from this is read after snapshot stage AND the value is not
 	// cached before snapshot stage (which downloads salt-blocks.txt too), and therefore
@@ -79,24 +79,25 @@ func LoadSalt(baseDir string, autoCreate bool) (uint32, error) {
 	fpath := filepath.Join(baseDir, "salt-blocks.txt")
 	exists, err := dir.FileExist(fpath)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
 	if !exists {
 		if !autoCreate {
-			return 0, errors.New("salt file not found + autoCreate disabled")
+			logger.Debug("snaptype salt file not found + autocreate disabled")
+			return nil, nil
 		}
 		dir.MustExist(baseDir)
 
 		saltBytes := make([]byte, 4)
 		binary.BigEndian.PutUint32(saltBytes, randUint32())
 		if err := dir.WriteFileWithFsync(fpath, saltBytes, os.ModePerm); err != nil {
-			return 0, err
+			return nil, err
 		}
 	}
 	saltBytes, err := os.ReadFile(fpath)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 	if len(saltBytes) != 4 {
 		dir.MustExist(baseDir)
@@ -104,18 +105,19 @@ func LoadSalt(baseDir string, autoCreate bool) (uint32, error) {
 		saltBytes := make([]byte, 4)
 		binary.BigEndian.PutUint32(saltBytes, randUint32())
 		if err := dir.WriteFileWithFsync(fpath, saltBytes, os.ModePerm); err != nil {
-			return 0, err
+			return nil, err
 		}
 	}
 
-	return binary.BigEndian.Uint32(saltBytes), nil
+	salt := binary.BigEndian.Uint32(saltBytes)
+	return &salt, nil
 
 }
 
 // GetIndicesSalt - try read salt for all indices from DB. Or fall-back to new salt creation.
 // if db is Read-Only (for example remote RPCDaemon or utilities) - we will not create new indices -
 // and existing indices have salt in metadata.
-func GetIndexSalt(baseDir string) (uint32, error) {
+func GetIndexSalt(baseDir string, logger log.Logger) (uint32, error) {
 	saltLock.RLock()
 	salt, ok := saltMap[baseDir]
 	saltLock.RUnlock()
@@ -123,10 +125,15 @@ func GetIndexSalt(baseDir string) (uint32, error) {
 		return salt, nil
 	}
 
-	salt, err := LoadSalt(baseDir, false)
+	saltp, err := LoadSalt(baseDir, false, logger)
 	if err != nil {
 		return 0, err
 	}
+	if saltp == nil {
+		logger.Error("salt not found", "stack", dbg.Stack())
+		return 0, errors.New("salt not found in GetIndexSalt")
+	}
+	salt = *saltp
 
 	saltLock.Lock()
 	saltMap[baseDir] = salt
@@ -264,7 +271,7 @@ func (s snapType) Indexes() []Index {
 }
 
 func (s snapType) BuildIndexes(ctx context.Context, info FileInfo, indexBuilder IndexBuilder, chainConfig *chain.Config, tmpDir string, p *background.Progress, lvl log.Lvl, logger log.Logger) error {
-	salt, err := GetIndexSalt(info.Dir())
+	salt, err := GetIndexSalt(info.Dir(), logger)
 
 	if err != nil {
 		return err

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -150,7 +150,7 @@ func GetStateIndicesSalt(dirs datadir.Dirs, genNew bool, logger log.Logger) (sal
 	// Initialize salt if it doesn't exist
 	if !fexists {
 		if !genNew {
-			logger.Info("not generating new salt file as genNew=false")
+			logger.Debug("not generating new state-salt file as genNew=false")
 			// Using nil salt for now, actual value should be injected when salt file is downloaded
 			return nil, nil
 		}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1572,7 +1572,7 @@ func setUpBlockReader(ctx context.Context, db kv.RwDB, dirs datadir.Dirs, snConf
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, err
 	}
-	if _, err := snaptype.LoadSalt(dirs.Snap, createNewSaltFileIfNeeded); err != nil {
+	if _, err := snaptype.LoadSalt(dirs.Snap, createNewSaltFileIfNeeded, logger); err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, err
 	}
 	agg, err := state.NewAggregator2(ctx, dirs, config3.DefaultStepSize, salt, db, logger)

--- a/turbo/snapshotsync/snapshots.go
+++ b/turbo/snapshotsync/snapshots.go
@@ -1408,7 +1408,7 @@ func (s *RoSnapshots) buildMissedIndices(logPrefix string, ctx context.Context, 
 		return nil
 	}
 
-	if _, err := snaptype.GetIndexSalt(dirs.Snap); err != nil {
+	if _, err := snaptype.GetIndexSalt(dirs.Snap, logger); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
- `LoadSalt` to not give error if salt not found
- closer parity with salt-state logic (reloadSalt throws error; `GetIndicesSalt` doesn't)