### PR TITLE
txnprovider/txpool: unblock p.lastSeenCond.Wait on shutdown

### DIFF
--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -780,6 +780,12 @@ func (p *TxPool) Started() bool {
 func (p *TxPool) best(ctx context.Context, n int, txns *TxnsRlp, onTopOf, availableGas, availableBlobGas uint64, yielded mapset.Set[[32]byte], availableRlpSpace int) (bool, int, error) {
 	p.lock.Lock()
 	for last := p.lastSeenBlock.Load(); last < onTopOf; last = p.lastSeenBlock.Load() {
+		select {
+		case <-ctx.Done():
+			return false, 0, ctx.Err()
+		default:
+			// continue
+		}
 		p.logger.Debug("[txpool] Waiting for block", "expecting", onTopOf, "lastSeen", last, "txRequested", n, "pending", p.pending.Len(), "baseFee", p.baseFee.Len(), "queued", p.queued.Len())
 		p.lastSeenCond.Wait()
 	}
@@ -2192,6 +2198,7 @@ func (p *TxPool) promote(pendingBaseFee uint64, pendingBlobFee uint64, announcem
 // reorgs
 func (p *TxPool) Run(ctx context.Context) error {
 	defer p.logger.Info("[txpool] stopped")
+	defer p.lastSeenCond.Broadcast() // to unblock .best() wait on cond
 	defer p.poolDB.Close()
 	p.p2pFetcher.ConnectCore()
 	p.p2pFetcher.ConnectSentries()


### PR DESCRIPTION
noticed we have unclean shutdown in txpool in https://github.com/erigontech/erigon/issues/16749 (note this doesn't fix the reported issue in there, just the unclean shutdown)