### PR TITLE
[r31] avoid extraneous commitment logs in rm-state

### DIFF
--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -541,12 +541,13 @@ func doRmStateSnapshots(cliCtx *cli.Context) error {
 	}
 
 	// Step 2: Process each candidate file (already parsed)
+	doesRmCommitment := !cliCtx.IsSet("domain") || slices.Contains(cliCtx.StringSlice("domain"), "commitment")
 	for _, candidate := range candidateFiles {
 		res := candidate.fileInfo
 
 		// check that commitment file has state in it
 		// When domains are "compacted", we want to keep latest commitment file with state key in it
-		if strings.Contains(res.Path, "commitment") && strings.HasSuffix(res.Path, ".kv") {
+		if doesRmCommitment && strings.Contains(res.Path, "commitment") && strings.HasSuffix(res.Path, ".kv") {
 			hasState, broken, err := checkCommitmentFileHasRoot(res.Path)
 			if err != nil {
 				return err


### PR DESCRIPTION
- issue: https://github.com/erigontech/erigon/issues/16767
- when `rm-state --domain=rcache` etc. provided, commitment state key is still checked and some logs done around that. This PR avoids it.

```
./build/bin/erigon seg rm-state --datadir /erigon-data/chiado --domain=rcache,receipt
INFO[08-22|06:39:19.426] logging to file system                   log dir=/home/erigon/.local/share/erigon/logs file prefix=erigon log level=info json=false
found state key with kvi /erigon-data/chiado/snapshots/domain/v1.1-commitment.0-32.kv
found state key with kvi /erigon-data/chiado/snapshots/domain/v1.1-commitment.32-34.kv
removed 52 state snapshot segments files
```