### PR TITLE
[r31] fix for bor events prune

### DIFF
--- a/polygon/bridge/mdbx_store.go
+++ b/polygon/bridge/mdbx_store.go
@@ -342,7 +342,17 @@ func (s *MdbxStore) PruneEvents(ctx context.Context, blocksTo uint64, blocksDele
 	}
 	defer tx.Rollback()
 
-	return txStore{tx}.PruneEvents(ctx, blocksTo, blocksDeleteLimit)
+	deleted, err = txStore{tx}.PruneEvents(ctx, blocksTo, blocksDeleteLimit)
+	if err != nil {
+		return 0, err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return 0, err
+	}
+
+	return deleted, nil
 }
 
 func NewTxStore(tx kv.Tx) txStore {


### PR DESCRIPTION
it was causing `seg retire` to just continue looping on prune