### PR TITLE
Improve snapshots reset action

### DIFF
--- a/.github/workflows/qa-tip-tracking.yml
+++ b/.github/workflows/qa-tip-tracking.yml
@@ -199,7 +199,7 @@ jobs:
     - name: Run the datadir downgrade procedure
       working-directory: ${{ github.workspace }}
       run: |
-        ./build/bin/erigon seg reset-to-old-ver-format --datadir $ERIGON_TESTBED_DATA_DIR
+        ./build/bin/erigon --datadir $ERIGON_TESTBED_DATA_DIR snapshots reset-to-old-ver-format 
 
     - name: Print datadir contents after downgrade (for debugging)
       working-directory: ${{ github.workspace }}

--- a/erigon-lib/common/datadir/dirs.go
+++ b/erigon-lib/common/datadir/dirs.go
@@ -320,7 +320,7 @@ func (d *Dirs) RenameOldVersions(cmdCommand bool) error {
 	}
 	if renamed > 0 || removed > 0 {
 		log.Warn("Your snapshots are compatible but old. We recommend you (for better experience) " +
-			"upgrade them by `./build/bin/erigon snapshots reset --datadir /your` command, after this command: next Erigon start - will download latest files (but re-use unchanged files) - likely will take many hours")
+			"upgrade them by `./build/bin/erigon --datadir /your/datadir snapshots reset ` command, after this command: next Erigon start - will download latest files (but re-use unchanged files) - likely will take many hours")
 	}
 	if d.Downloader != "" && (renamed > 0 || removed > 0) {
 		if err := dir.RemoveAll(d.Downloader); err != nil && !os.IsNotExist(err) {

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -2130,5 +2130,10 @@ func (dt *DomainRoTx) Name() kv.Domain { return dt.name }
 func (dt *DomainRoTx) HistoryProgress(tx kv.Tx) uint64 { return dt.ht.iit.Progress(tx) }
 
 func versionTooLowPanic(filename string, version version.Versions) {
-	panic(fmt.Sprintf("Version is too low, try to run snapshot reset: `erigon snapshots reset --datadir $DATADIR --chain $CHAIN`. file=%s, min_supported=%s, current=%s", filename, version.MinSupported, version.Current))
+	panic(fmt.Sprintf(
+		"Version is too low, try to run snapshot reset: `erigon --datadir $DATADIR --chain $CHAIN snapshots reset`. file=%s, min_supported=%s, current=%s",
+		filename,
+		version.MinSupported,
+		version.Current,
+	))
 }

--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -92,19 +92,38 @@ func joinFlags(lists ...[]cli.Flag) (res []cli.Flag) {
 	return res
 }
 
+// This needs to run *after* subcommand arguments are parsed, in case they alter root flags like data dir.
+func commonBeforeSnapshotCommand(cliCtx *cli.Context) error {
+	go mem.LogMemStats(cliCtx.Context, log.New())
+	go disk.UpdateDiskStats(cliCtx.Context, log.New())
+	_, _, _, _, err := debug.Setup(cliCtx, true /* rootLogger */)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func init() {
+	// Inject commonBeforeSnapshotCommand into all snapshot subcommands Before handlers.
+	for _, cmd := range snapshotCommand.Subcommands {
+		oldBefore := cmd.Before
+		cmd.Before = func(cliCtx *cli.Context) error {
+			err := commonBeforeSnapshotCommand(cliCtx)
+			if err != nil {
+				return fmt.Errorf("common before snapshot subcommand: %w", err)
+			}
+			if oldBefore == nil {
+				return nil
+			}
+			return oldBefore(cliCtx)
+		}
+	}
+}
+
 var snapshotCommand = cli.Command{
 	Name:    "snapshots",
 	Aliases: []string{"seg", "snapshot", "segments", "segment"},
 	Usage:   `Managing historical data segments (partitions)`,
-	Before: func(cliCtx *cli.Context) error {
-		go mem.LogMemStats(cliCtx.Context, log.New())
-		go disk.UpdateDiskStats(cliCtx.Context, log.New())
-		_, _, _, _, err := debug.Setup(cliCtx, true /* rootLogger */)
-		if err != nil {
-			return err
-		}
-		return nil
-	},
 	Subcommands: []*cli.Command{
 		{
 			Name: "ls",
@@ -282,6 +301,8 @@ var snapshotCommand = cli.Command{
 			// environment variable? Followup: It would not go here, as it could modify behaviour in
 			// parent commands.
 			Flags: []cli.Flag{
+				&utils.DataDirFlag,
+				&utils.ChainFlag,
 				&dryRunFlag,
 				&removeLocalFlag,
 			},

--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -278,14 +278,13 @@ var snapshotCommand = cli.Command{
 			Name:   "reset",
 			Usage:  "Reset state to resumable initial sync",
 			Action: resetCliAction,
-			// Something to alter snapcfg.snapshotGitBranch would go here, or should you set the environment variable?
-			Flags: append(
-				slices.Clone(logging.Flags),
-				&utils.DataDirFlag,
-				&utils.ChainFlag,
+			// Something to alter snapcfg.snapshotGitBranch would go here, or should you set the
+			// environment variable? Followup: It would not go here, as it could modify behaviour in
+			// parent commands.
+			Flags: []cli.Flag{
 				&dryRunFlag,
 				&removeLocalFlag,
-			),
+			},
 		},
 		{
 			Name:    "rm-state-snapshots",


### PR DESCRIPTION
- Handles missing or obsolete format chaindata (Fixes #16717 and https://discord.com/channels/1133875232453693480/1356926710502916096/1407195677930295348).
- Fixes double logging setup (observed on Discord a few times but I missed it).
- Correctly loads _explicit_ chain flag "IsSet" setup from parent CLI contexts.
- Logs datadir operated on (so default datadir action is clear).