### PR TITLE
make arbitrum header sync respect `sync.loop.block.limit`

### DIFF
--- a/execution/stagedsync/stage_headers.go
+++ b/execution/stagedsync/stage_headers.go
@@ -168,6 +168,7 @@ func SpawnStageHeaders(s *StageState, u Unwinder, ctx context.Context, tx kv.RwT
 	if firstBlock >= latestBlock.Uint64() {
 		return nil
 	}
+	latestBlock.SetUint64(min(latestBlock.Uint64(), firstBlock+uint64(cfg.syncConfig.LoopBlockLimit)))
 
 	if firstBlock+1 > latestBlock.Uint64() { // print only if 1+ blocks available
 		log.Info("[Arbitrum] Headers stage started", "from", firstBlock, "lastAvailableBlock", latestBlock.Uint64(), "extTx", useExternalTx)


### PR DESCRIPTION
It just created me 1TB dump for 150M blocks on arb-sepolia which was not what i expected