### PR TITLE
fix: add missing return and fix AA bundle length log in execAATxn

### DIFF
--- a/execution/exec3/historical_trace_worker.go
+++ b/execution/exec3/historical_trace_worker.go
@@ -312,13 +312,14 @@ func (rw *HistoricalTraceWorker) execAATxn(txTask *state.TxTask, tracer *calltra
 			txTask.Error = outerErr
 			return
 		}
-		log.Info("✅[aa] validated AA bundle", "len", startIdx-endIdx)
+		log.Info("✅[aa] validated AA bundle", "len", endIdx-startIdx+1)
 
 		txTask.ValidationResults = validationResults
 	}
 
 	if len(txTask.ValidationResults) == 0 {
 		txTask.Error = fmt.Errorf("found RIP-7560 but no remaining validation results, txIndex %d", txTask.TxIndex)
+		return
 	}
 
 	aaTxn := txTask.Tx.(*types.AccountAbstractionTransaction) // type cast checked earlier

--- a/execution/exec3/state.go
+++ b/execution/exec3/state.go
@@ -385,13 +385,14 @@ func (rw *Worker) execAATxn(txTask *state.TxTask) {
 			txTask.Error = outerErr
 			return
 		}
-		log.Info("✅[aa] validated AA bundle", "len", startIdx-endIdx)
+		log.Info("✅[aa] validated AA bundle", "len", endIdx-startIdx+1)
 
 		txTask.ValidationResults = validationResults
 	}
 
 	if len(txTask.ValidationResults) == 0 {
 		txTask.Error = fmt.Errorf("found RIP-7560 but no remaining validation results, txIndex %d", txTask.TxIndex)
+		return
 	}
 
 	aaTxn := txTask.Tx.(*types.AccountAbstractionTransaction) // type cast checked earlier


### PR DESCRIPTION
Fix two issues in AA transaction execution:

1. Add missing return statement after setting txTask.Error when 
   ValidationResults is empty to prevent panic from accessing 
   empty slice and type assertion
2. Fix negative length calculation in "validated AA bundle" log 
   from (startIdx-endIdx) to (endIdx-startIdx+1)

