### PR TITLE
cherry-pick: VeBlop: Skip span sorting by StartBlock in EntityFetcher (#16815)

### DIFF
--- a/polygon/heimdall/entity_fetcher.go
+++ b/polygon/heimdall/entity_fetcher.go
@@ -159,14 +159,19 @@ func (f *EntityFetcher[TEntity]) FetchAllEntities(ctx context.Context) ([]TEntit
 		}
 	}
 
-	slices.SortFunc(entities, func(e1, e2 TEntity) int {
-		n1 := e1.BlockNumRange().Start
-		n2 := e2.BlockNumRange().Start
-		return cmp.Compare(n1, n2)
-	})
-
-	for i, entity := range entities {
-		entity.SetRawId(uint64(i + 1))
+	// Due to VeBlop, span.StartBlock is no longer strictly increasing,
+	// so this kind of breaks the "Entity" abstraction.
+	// So for spans we skip the sorting and just rely on span.Id for the ordering.
+	var entity TEntity
+	if _, ok := any(entity).(*Span); !ok {
+		slices.SortFunc(entities, func(e1, e2 TEntity) int {
+			n1 := e1.BlockNumRange().Start
+			n2 := e2.BlockNumRange().Start
+			return cmp.Compare(n1, n2)
+		})
+		for i, entity := range entities {
+			entity.SetRawId(uint64(i + 1))
+		}
 	}
 
 	f.logger.Debug(


### PR DESCRIPTION
Due the Veblop hard fork the span sorting by `span.StartBlock` does not make sense because the `StartBlock` will not be strictly increasing. The sorting by `StartBlock` resulted in a span id gap in `ObserveSpan()` due to a span with a lower Id but higher StartBlock being relocated to higher indexes in the sorted array of fetched spans.

Therefore, this PR disables the sorting, and just relies on the `span.Id` for the order.

---------