### PR TITLE
tests: fix deadlock in TestBatchLimit_WebSocket_Exceeded on macOS

### DIFF
--- a/rpc/batch_limit_ws_test.go
+++ b/rpc/batch_limit_ws_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestBatchLimit_WebSocket_Exceeded(t *testing.T) {
-	t.Skip("TODO: https://github.com/erigontech/erigon/issues/16382")
 	t.Parallel()
 	logger := log.New()
 


### PR DESCRIPTION
Fixes #16382
Replaces #16431 