### PR TITLE
agg: configs immutability

### DIFF
--- a/db/kv/tables.go
+++ b/db/kv/tables.go
@@ -201,14 +201,6 @@ const (
 	// and `Tbl{Account,Storage,Code,Commitment}Idx` for inverted indices
 	TblPruningProgress = "PruningProgress"
 
-	//State Reconstitution
-	PlainStateR    = "PlainStateR"    // temporary table for PlainState reconstitution
-	PlainStateD    = "PlainStateD"    // temporary table for PlainStare reconstitution, deletes
-	CodeR          = "CodeR"          // temporary table for Code reconstitution
-	CodeD          = "CodeD"          // temporary table for Code reconstitution, deletes
-	PlainContractR = "PlainContractR" // temporary table for PlainContract reconstitution
-	PlainContractD = "PlainContractD" // temporary table for PlainContract reconstitution, deletes
-
 	// Erigon-CL Objects
 
 	// [slot + block root] => [signature + block without execution payload]
@@ -481,14 +473,6 @@ var DownloaderTables = []string{
 	BittorrentCompletion,
 	BittorrentInfo,
 }
-var ReconTables = []string{
-	PlainStateR,
-	PlainStateD,
-	CodeR,
-	CodeD,
-	PlainContractR,
-	PlainContractD,
-}
 
 // ChaindataDeprecatedTables - list of buckets which can be programmatically deleted - for example after migration
 var ChaindataDeprecatedTables = []string{}
@@ -614,11 +598,6 @@ var DownloaderTablesCfg = TableCfg{}
 var DiagnosticsTablesCfg = TableCfg{}
 var HeimdallTablesCfg = TableCfg{}
 var PolygonBridgeTablesCfg = TableCfg{}
-var ReconTablesCfg = TableCfg{
-	PlainStateD:    {Flags: DupSort},
-	CodeD:          {Flags: DupSort},
-	PlainContractD: {Flags: DupSort},
-}
 
 func TablesCfgByLabel(label Label) TableCfg {
 	switch label {
@@ -697,13 +676,6 @@ func reinit() {
 		_, ok := DownloaderTablesCfg[name]
 		if !ok {
 			DownloaderTablesCfg[name] = TableCfgItem{}
-		}
-	}
-
-	for _, name := range ReconTables {
-		_, ok := ReconTablesCfg[name]
-		if !ok {
-			ReconTablesCfg[name] = TableCfgItem{}
 		}
 	}
 

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -176,9 +176,7 @@ func GetStateIndicesSalt(dirs datadir.Dirs, genNew bool, logger log.Logger) (sal
 }
 
 func (a *Aggregator) registerDomain(cfg domainCfg, salt *uint32, dirs datadir.Dirs, logger log.Logger) (err error) {
-	//TODO: move dynamic part of config to InvertedIndex
-	cfg.hist.iiCfg.dirs = dirs
-	a.d[cfg.name], err = NewDomain(cfg, a.stepSize, logger)
+	a.d[cfg.name], err = NewDomain(cfg, a.stepSize, dirs, logger)
 	if err != nil {
 		return err
 	}
@@ -188,11 +186,10 @@ func (a *Aggregator) registerDomain(cfg domainCfg, salt *uint32, dirs datadir.Di
 }
 
 func (a *Aggregator) registerII(cfg iiCfg, salt *uint32, dirs datadir.Dirs, logger log.Logger) error {
-	cfg.dirs = dirs
 	if ii := a.searchII(cfg.name); ii != nil {
 		return fmt.Errorf("inverted index %s already registered", cfg.name)
 	}
-	ii, err := NewInvertedIndex(cfg, a.stepSize, logger)
+	ii, err := NewInvertedIndex(cfg, a.stepSize, dirs, logger)
 	if err != nil {
 		return err
 	}

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -175,29 +175,27 @@ func GetStateIndicesSalt(dirs datadir.Dirs, genNew bool, logger log.Logger) (sal
 	return salt, nil
 }
 
-func (a *Aggregator) registerDomain(name kv.Domain, salt *uint32, dirs datadir.Dirs, logger log.Logger) (err error) {
-	cfg := Schema.GetDomainCfg(name)
+func (a *Aggregator) registerDomain(cfg domainCfg, salt *uint32, dirs datadir.Dirs, logger log.Logger) (err error) {
 	//TODO: move dynamic part of config to InvertedIndex
 	cfg.hist.iiCfg.salt.Store(salt)
 	cfg.hist.iiCfg.dirs = dirs
-	a.d[name], err = NewDomain(cfg, a.stepSize, logger)
+	a.d[cfg.name], err = NewDomain(cfg, a.stepSize, logger)
 	if err != nil {
 		return err
 	}
-	a.AddDependencyBtwnHistoryII(name)
+	a.AddDependencyBtwnHistoryII(cfg.name)
 	return nil
 }
 
-func (a *Aggregator) registerII(idx kv.InvertedIdx, salt *uint32, dirs datadir.Dirs, logger log.Logger) error {
-	idxCfg := Schema.GetIICfg(idx)
-	idxCfg.salt.Store(salt)
-	idxCfg.dirs = dirs
+func (a *Aggregator) registerII(cfg iiCfg, salt *uint32, dirs datadir.Dirs, logger log.Logger) error {
+	cfg.salt.Store(salt)
+	cfg.dirs = dirs
 
-	if ii := a.searchII(idx); ii != nil {
-		return fmt.Errorf("inverted index %s already registered", idx)
+	if ii := a.searchII(cfg.name); ii != nil {
+		return fmt.Errorf("inverted index %s already registered", cfg.name)
 	}
 
-	ii, err := NewInvertedIndex(idxCfg, a.stepSize, logger)
+	ii, err := NewInvertedIndex(cfg, a.stepSize, logger)
 	if err != nil {
 		return err
 	}

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -177,28 +177,26 @@ func GetStateIndicesSalt(dirs datadir.Dirs, genNew bool, logger log.Logger) (sal
 
 func (a *Aggregator) registerDomain(cfg domainCfg, salt *uint32, dirs datadir.Dirs, logger log.Logger) (err error) {
 	//TODO: move dynamic part of config to InvertedIndex
-	cfg.hist.iiCfg.salt.Store(salt)
 	cfg.hist.iiCfg.dirs = dirs
 	a.d[cfg.name], err = NewDomain(cfg, a.stepSize, logger)
 	if err != nil {
 		return err
 	}
+	a.d[cfg.name].salt.Store(salt)
 	a.AddDependencyBtwnHistoryII(cfg.name)
 	return nil
 }
 
 func (a *Aggregator) registerII(cfg iiCfg, salt *uint32, dirs datadir.Dirs, logger log.Logger) error {
-	cfg.salt.Store(salt)
 	cfg.dirs = dirs
-
 	if ii := a.searchII(cfg.name); ii != nil {
 		return fmt.Errorf("inverted index %s already registered", cfg.name)
 	}
-
 	ii, err := NewInvertedIndex(cfg, a.stepSize, logger)
 	if err != nil {
 		return err
 	}
+	ii.salt.Store(salt)
 	a.iis = append(a.iis, ii)
 	return nil
 }
@@ -229,13 +227,11 @@ func (a *Aggregator) reloadSalt() error {
 	}
 
 	for _, d := range a.d {
-		d.hist.iiCfg.salt.Store(salt)
-		d.History.histCfg.iiCfg.salt.Store(salt)
-		d.History.InvertedIndex.iiCfg.salt.Store(salt)
+		d.salt.Store(salt)
 	}
 
 	for _, ii := range a.iis {
-		ii.iiCfg.salt.Store(salt)
+		ii.salt.Store(salt)
 	}
 
 	return nil

--- a/db/state/aggregator2.go
+++ b/db/state/aggregator2.go
@@ -16,6 +16,7 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/seg"
 	"github.com/erigontech/erigon/db/snaptype"
+	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/db/version"
 )
 
@@ -88,7 +89,7 @@ var dbgCommBtIndex = dbg.EnvBool("AGG_COMMITMENT_BT", false)
 
 func init() {
 	if dbgCommBtIndex {
-		Schema.CommitmentDomain.Accessors = AccessorBTree | AccessorExistence
+		Schema.CommitmentDomain.Accessors = statecfg.AccessorBTree | statecfg.AccessorExistence
 	}
 	InitSchemas()
 }
@@ -176,7 +177,7 @@ var Schema = SchemaGen{
 		name: kv.AccountsDomain, valuesTable: kv.TblAccountVals,
 		CompressCfg: DomainCompressCfg, Compression: seg.CompressNone,
 
-		Accessors: AccessorBTree | AccessorExistence,
+		Accessors: statecfg.AccessorBTree | statecfg.AccessorExistence,
 
 		hist: histCfg{
 			valuesTable:   kv.TblAccountHistoryVals,
@@ -188,7 +189,7 @@ var Schema = SchemaGen{
 			iiCfg: iiCfg{
 				filenameBase: kv.AccountsDomain.String(), keysTable: kv.TblAccountHistoryKeys, valuesTable: kv.TblAccountIdx,
 				CompressorCfg: seg.DefaultCfg,
-				Accessors:     AccessorHashMap,
+				Accessors:     statecfg.AccessorHashMap,
 			},
 		},
 	},
@@ -196,7 +197,7 @@ var Schema = SchemaGen{
 		name: kv.StorageDomain, valuesTable: kv.TblStorageVals,
 		CompressCfg: DomainCompressCfg, Compression: seg.CompressKeys,
 
-		Accessors: AccessorBTree | AccessorExistence,
+		Accessors: statecfg.AccessorBTree | statecfg.AccessorExistence,
 
 		hist: histCfg{
 			valuesTable:   kv.TblStorageHistoryVals,
@@ -208,7 +209,7 @@ var Schema = SchemaGen{
 			iiCfg: iiCfg{
 				filenameBase: kv.StorageDomain.String(), keysTable: kv.TblStorageHistoryKeys, valuesTable: kv.TblStorageIdx,
 				CompressorCfg: seg.DefaultCfg,
-				Accessors:     AccessorHashMap,
+				Accessors:     statecfg.AccessorHashMap,
 			},
 		},
 	},
@@ -216,7 +217,7 @@ var Schema = SchemaGen{
 		name: kv.CodeDomain, valuesTable: kv.TblCodeVals,
 		CompressCfg: DomainCompressCfg, Compression: seg.CompressVals, // compressing Code with keys doesn't show any benefits. Compression of values shows 4x ratio on eth-mainnet and 2.5x ratio on bor-mainnet
 
-		Accessors:   AccessorBTree | AccessorExistence,
+		Accessors:   statecfg.AccessorBTree | statecfg.AccessorExistence,
 		largeValues: true,
 
 		hist: histCfg{
@@ -229,7 +230,7 @@ var Schema = SchemaGen{
 			iiCfg: iiCfg{
 				filenameBase: kv.CodeDomain.String(), keysTable: kv.TblCodeHistoryKeys, valuesTable: kv.TblCodeIdx,
 				CompressorCfg: seg.DefaultCfg,
-				Accessors:     AccessorHashMap,
+				Accessors:     statecfg.AccessorHashMap,
 			},
 		},
 	},
@@ -237,7 +238,7 @@ var Schema = SchemaGen{
 		name: kv.CommitmentDomain, valuesTable: kv.TblCommitmentVals,
 		CompressCfg: DomainCompressCfg, Compression: seg.CompressKeys,
 
-		Accessors:           AccessorHashMap,
+		Accessors:           statecfg.AccessorHashMap,
 		replaceKeysInValues: AggregatorSqueezeCommitmentValues,
 
 		hist: histCfg{
@@ -254,7 +255,7 @@ var Schema = SchemaGen{
 			iiCfg: iiCfg{
 				filenameBase: kv.CommitmentDomain.String(), keysTable: kv.TblCommitmentHistoryKeys, valuesTable: kv.TblCommitmentIdx,
 				CompressorCfg: seg.DefaultCfg,
-				Accessors:     AccessorHashMap,
+				Accessors:     statecfg.AccessorHashMap,
 			},
 		},
 	},
@@ -263,7 +264,7 @@ var Schema = SchemaGen{
 		CompressCfg: seg.DefaultCfg, Compression: seg.CompressNone,
 		largeValues: false,
 
-		Accessors: AccessorBTree | AccessorExistence,
+		Accessors: statecfg.AccessorBTree | statecfg.AccessorExistence,
 
 		hist: histCfg{
 			valuesTable:   kv.TblReceiptHistoryVals,
@@ -275,7 +276,7 @@ var Schema = SchemaGen{
 			iiCfg: iiCfg{
 				filenameBase: kv.ReceiptDomain.String(), keysTable: kv.TblReceiptHistoryKeys, valuesTable: kv.TblReceiptIdx,
 				CompressorCfg: seg.DefaultCfg,
-				Accessors:     AccessorHashMap,
+				Accessors:     statecfg.AccessorHashMap,
 			},
 		},
 	},
@@ -283,7 +284,7 @@ var Schema = SchemaGen{
 		name: kv.RCacheDomain, valuesTable: kv.TblRCacheVals,
 		largeValues: true,
 
-		Accessors:   AccessorHashMap,
+		Accessors:   statecfg.AccessorHashMap,
 		CompressCfg: DomainCompressCfg, Compression: seg.CompressNone, //seg.CompressKeys | seg.CompressVals,
 
 		hist: histCfg{
@@ -300,7 +301,7 @@ var Schema = SchemaGen{
 				disable:      true, // disable everything by default
 				filenameBase: kv.RCacheDomain.String(), keysTable: kv.TblRCacheHistoryKeys, valuesTable: kv.TblRCacheIdx,
 				CompressorCfg: seg.DefaultCfg,
-				Accessors:     AccessorHashMap,
+				Accessors:     statecfg.AccessorHashMap,
 			},
 		},
 	},
@@ -310,28 +311,28 @@ var Schema = SchemaGen{
 
 		Compression: seg.CompressNone,
 		name:        kv.LogAddrIdx,
-		Accessors:   AccessorHashMap,
+		Accessors:   statecfg.AccessorHashMap,
 	},
 	LogTopicIdx: iiCfg{
 		filenameBase: kv.FileLogTopicsIdx, keysTable: kv.TblLogTopicsKeys, valuesTable: kv.TblLogTopicsIdx,
 
 		Compression: seg.CompressNone,
 		name:        kv.LogTopicIdx,
-		Accessors:   AccessorHashMap,
+		Accessors:   statecfg.AccessorHashMap,
 	},
 	TracesFromIdx: iiCfg{
 		filenameBase: kv.FileTracesFromIdx, keysTable: kv.TblTracesFromKeys, valuesTable: kv.TblTracesFromIdx,
 
 		Compression: seg.CompressNone,
 		name:        kv.TracesFromIdx,
-		Accessors:   AccessorHashMap,
+		Accessors:   statecfg.AccessorHashMap,
 	},
 	TracesToIdx: iiCfg{
 		filenameBase: kv.FileTracesToIdx, keysTable: kv.TblTracesToKeys, valuesTable: kv.TblTracesToIdx,
 
 		Compression: seg.CompressNone,
 		name:        kv.TracesToIdx,
-		Accessors:   AccessorHashMap,
+		Accessors:   statecfg.AccessorHashMap,
 	},
 }
 

--- a/db/state/aggregator2.go
+++ b/db/state/aggregator2.go
@@ -42,34 +42,34 @@ func NewAggregator2(ctx context.Context, dirs datadir.Dirs, aggregationStep uint
 	if err := AdjustReceiptCurrentVersionIfNeeded(dirs, logger); err != nil {
 		return nil, err
 	}
-	if err := a.registerDomain(kv.AccountsDomain, salt, dirs, logger); err != nil {
+	if err := a.registerDomain(Schema.GetDomainCfg(kv.AccountsDomain), salt, dirs, logger); err != nil {
 		return nil, err
 	}
-	if err := a.registerDomain(kv.StorageDomain, salt, dirs, logger); err != nil {
+	if err := a.registerDomain(Schema.GetDomainCfg(kv.StorageDomain), salt, dirs, logger); err != nil {
 		return nil, err
 	}
-	if err := a.registerDomain(kv.CodeDomain, salt, dirs, logger); err != nil {
+	if err := a.registerDomain(Schema.GetDomainCfg(kv.CodeDomain), salt, dirs, logger); err != nil {
 		return nil, err
 	}
-	if err := a.registerDomain(kv.CommitmentDomain, salt, dirs, logger); err != nil {
+	if err := a.registerDomain(Schema.GetDomainCfg(kv.CommitmentDomain), salt, dirs, logger); err != nil {
 		return nil, err
 	}
-	if err := a.registerDomain(kv.ReceiptDomain, salt, dirs, logger); err != nil {
+	if err := a.registerDomain(Schema.GetDomainCfg(kv.ReceiptDomain), salt, dirs, logger); err != nil {
 		return nil, err
 	}
-	if err := a.registerDomain(kv.RCacheDomain, salt, dirs, logger); err != nil {
+	if err := a.registerDomain(Schema.GetDomainCfg(kv.RCacheDomain), salt, dirs, logger); err != nil {
 		return nil, err
 	}
-	if err := a.registerII(kv.LogAddrIdx, salt, dirs, logger); err != nil {
+	if err := a.registerII(Schema.GetIICfg(kv.LogAddrIdx), salt, dirs, logger); err != nil {
 		return nil, err
 	}
-	if err := a.registerII(kv.LogTopicIdx, salt, dirs, logger); err != nil {
+	if err := a.registerII(Schema.GetIICfg(kv.LogTopicIdx), salt, dirs, logger); err != nil {
 		return nil, err
 	}
-	if err := a.registerII(kv.TracesFromIdx, salt, dirs, logger); err != nil {
+	if err := a.registerII(Schema.GetIICfg(kv.TracesFromIdx), salt, dirs, logger); err != nil {
 		return nil, err
 	}
-	if err := a.registerII(kv.TracesToIdx, salt, dirs, logger); err != nil {
+	if err := a.registerII(Schema.GetIICfg(kv.TracesToIdx), salt, dirs, logger); err != nil {
 		return nil, err
 	}
 

--- a/db/state/aggregator2.go
+++ b/db/state/aggregator2.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync/atomic"
 
 	"github.com/erigontech/erigon-lib/common/dbg"
 	"github.com/erigontech/erigon-lib/log/v3"
@@ -148,7 +147,6 @@ func (s *SchemaGen) GetDomainCfg(name kv.Domain) domainCfg {
 	default:
 		v = domainCfg{}
 	}
-	v.hist.iiCfg.salt = new(atomic.Pointer[uint32])
 	return v
 }
 
@@ -166,7 +164,6 @@ func (s *SchemaGen) GetIICfg(name kv.InvertedIdx) iiCfg {
 	default:
 		v = iiCfg{}
 	}
-	v.salt = new(atomic.Pointer[uint32])
 	return v
 }
 

--- a/db/state/aggregator_debug.go
+++ b/db/state/aggregator_debug.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/state/statecfg"
 )
 
 type aggDirtyFilesRoTx struct {
@@ -141,9 +142,9 @@ func (d *Domain) DebugBeginDirtyFilesRo() *domainDirtyFilesRoTx {
 
 func (d *domainDirtyFilesRoTx) FilesWithMissedAccessors() (mf *MissedAccessorDomainFiles) {
 	return &MissedAccessorDomainFiles{
-		files: map[Accessors][]*FilesItem{
-			AccessorBTree:   d.d.missedBtreeAccessors(d.files),
-			AccessorHashMap: d.d.missedMapAccessors(d.files),
+		files: map[statecfg.Accessors][]*FilesItem{
+			statecfg.AccessorBTree:   d.d.missedBtreeAccessors(d.files),
+			statecfg.AccessorHashMap: d.d.missedMapAccessors(d.files),
 		},
 		history: d.history.FilesWithMissedAccessors(),
 	}
@@ -180,8 +181,8 @@ func (h *History) DebugBeginDirtyFilesRo() *historyDirtyFilesRoTx {
 func (f *historyDirtyFilesRoTx) FilesWithMissedAccessors() (mf *MissedAccessorHistoryFiles) {
 	return &MissedAccessorHistoryFiles{
 		ii: f.ii.FilesWithMissedAccessors(),
-		files: map[Accessors][]*FilesItem{
-			AccessorHashMap: f.h.missedMapAccessors(f.files),
+		files: map[statecfg.Accessors][]*FilesItem{
+			statecfg.AccessorHashMap: f.h.missedMapAccessors(f.files),
 		},
 	}
 }
@@ -215,8 +216,8 @@ func (ii *InvertedIndex) DebugBeginDirtyFilesRo() *iiDirtyFilesRoTx {
 
 func (f *iiDirtyFilesRoTx) FilesWithMissedAccessors() (mf *MissedAccessorIIFiles) {
 	return &MissedAccessorIIFiles{
-		files: map[Accessors][]*FilesItem{
-			AccessorHashMap: f.ii.missedMapAccessors(f.files),
+		files: map[statecfg.Accessors][]*FilesItem{
+			statecfg.AccessorHashMap: f.ii.missedMapAccessors(f.files),
 		},
 	}
 }
@@ -250,7 +251,7 @@ func (a *Aggregator) PeriodicalyPrintProcessSet(ctx context.Context) {
 }
 
 // fileItems collection of missed files
-type MissedFilesMap map[Accessors][]*FilesItem
+type MissedFilesMap map[statecfg.Accessors][]*FilesItem
 type MissedAccessorAggFiles struct {
 	domain map[kv.Domain]*MissedAccessorDomainFiles
 	ii     map[kv.InvertedIdx]*MissedAccessorIIFiles
@@ -280,11 +281,11 @@ type MissedAccessorDomainFiles struct {
 }
 
 func (m *MissedAccessorDomainFiles) missedBtreeAccessors() []*FilesItem {
-	return m.files[AccessorBTree]
+	return m.files[statecfg.AccessorBTree]
 }
 
 func (m *MissedAccessorDomainFiles) missedMapAccessors() []*FilesItem {
-	return m.files[AccessorHashMap]
+	return m.files[statecfg.AccessorHashMap]
 }
 
 func (m *MissedAccessorDomainFiles) IsEmpty() bool {
@@ -305,7 +306,7 @@ type MissedAccessorHistoryFiles struct {
 }
 
 func (m *MissedAccessorHistoryFiles) missedMapAccessors() []*FilesItem {
-	return m.files[AccessorHashMap]
+	return m.files[statecfg.AccessorHashMap]
 }
 
 func (m *MissedAccessorHistoryFiles) IsEmpty() bool {
@@ -325,7 +326,7 @@ type MissedAccessorIIFiles struct {
 }
 
 func (m *MissedAccessorIIFiles) missedMapAccessors() []*FilesItem {
-	return m.files[AccessorHashMap]
+	return m.files[statecfg.AccessorHashMap]
 }
 
 func (m *MissedAccessorIIFiles) IsEmpty() bool {

--- a/db/state/aggregator_test.go
+++ b/db/state/aggregator_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/erigontech/erigon/db/kv/rawdbv3"
 	"github.com/erigontech/erigon/db/kv/stream"
 	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/db/version"
 	"github.com/erigontech/erigon/execution/commitment"
 	"github.com/erigontech/erigon/execution/types/accounts"
@@ -1237,7 +1238,7 @@ func generateKV(tb testing.TB, tmp string, keySize, valueSize, keyCount int, log
 
 	IndexFile := filepath.Join(tmp, fmt.Sprintf("%dk.bt", keyCount/1000))
 	r := seg.NewReader(decomp.MakeGetter(), compressFlags)
-	err = BuildBtreeIndexWithDecompressor(IndexFile, r, ps, tb.TempDir(), 777, logger, true, AccessorBTree|AccessorExistence)
+	err = BuildBtreeIndexWithDecompressor(IndexFile, r, ps, tb.TempDir(), 777, logger, true, statecfg.AccessorBTree|statecfg.AccessorExistence)
 	require.NoError(tb, err)
 
 	return compPath
@@ -1767,7 +1768,7 @@ func TestReceiptFilesVersionAdjust(t *testing.T) {
 func generateDomainFiles(t *testing.T, name string, dirs datadir.Dirs, ranges []testFileRange) {
 	t.Helper()
 	domainR := setupAggSnapRepo(t, dirs, func(stepSize uint64, dirs datadir.Dirs) (dn string, schema SnapNameSchema) {
-		accessors := AccessorBTree | AccessorExistence
+		accessors := statecfg.AccessorBTree | statecfg.AccessorExistence
 		schema = NewE3SnapSchemaBuilder(accessors, stepSize).
 			Data(dirs.SnapDomain, name, DataExtensionKv, seg.CompressNone).
 			BtIndex().Existence().
@@ -1778,7 +1779,7 @@ func generateDomainFiles(t *testing.T, name string, dirs datadir.Dirs, ranges []
 	populateFiles2(t, dirs, domainR, ranges)
 
 	domainHR := setupAggSnapRepo(t, dirs, func(stepSize uint64, dirs datadir.Dirs) (dn string, schema SnapNameSchema) {
-		accessors := AccessorHashMap
+		accessors := statecfg.AccessorHashMap
 		schema = NewE3SnapSchemaBuilder(accessors, stepSize).
 			Data(dirs.SnapHistory, name, DataExtensionV, seg.CompressNone).
 			Accessor(dirs.SnapAccessors).
@@ -1789,7 +1790,7 @@ func generateDomainFiles(t *testing.T, name string, dirs datadir.Dirs, ranges []
 	populateFiles2(t, dirs, domainHR, ranges)
 
 	domainII := setupAggSnapRepo(t, dirs, func(stepSize uint64, dirs datadir.Dirs) (dn string, schema SnapNameSchema) {
-		accessors := AccessorHashMap
+		accessors := statecfg.AccessorHashMap
 		schema = NewE3SnapSchemaBuilder(accessors, stepSize).
 			Data(dirs.SnapIdx, name, DataExtensionEf, seg.CompressNone).
 			Accessor(dirs.SnapAccessors).
@@ -1818,7 +1819,7 @@ func generateStorageFile(t *testing.T, dirs datadir.Dirs, ranges []testFileRange
 func generateCommitmentFile(t *testing.T, dirs datadir.Dirs, ranges []testFileRange) {
 	t.Helper()
 	commitmentR := setupAggSnapRepo(t, dirs, func(stepSize uint64, dirs datadir.Dirs) (name string, schema SnapNameSchema) {
-		accessors := AccessorHashMap
+		accessors := statecfg.AccessorHashMap
 		name = "commitment"
 		schema = NewE3SnapSchemaBuilder(accessors, stepSize).
 			Data(dirs.SnapDomain, name, DataExtensionKv, seg.CompressNone).

--- a/db/state/btree_index.go
+++ b/db/state/btree_index.go
@@ -42,6 +42,7 @@ import (
 	"github.com/erigontech/erigon/db/etl"
 	"github.com/erigontech/erigon/db/recsplit/eliasfano32"
 	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/state/statecfg"
 )
 
 const BtreeLogPrefix = "btree"
@@ -330,7 +331,7 @@ type BtIndex struct {
 }
 
 // Decompressor should be managed by caller (could be closed after index is built). When index is built, external getter should be passed to seekInFiles function
-func CreateBtreeIndexWithDecompressor(indexPath string, M uint64, decompressor *seg.Reader, seed uint32, ps *background.ProgressSet, tmpdir string, logger log.Logger, noFsync bool, accessors Accessors) (*BtIndex, error) {
+func CreateBtreeIndexWithDecompressor(indexPath string, M uint64, decompressor *seg.Reader, seed uint32, ps *background.ProgressSet, tmpdir string, logger log.Logger, noFsync bool, accessors statecfg.Accessors) (*BtIndex, error) {
 	err := BuildBtreeIndexWithDecompressor(indexPath, decompressor, ps, tmpdir, seed, logger, noFsync, accessors)
 	if err != nil {
 		return nil, err
@@ -354,7 +355,7 @@ func OpenBtreeIndexAndDataFile(indexPath, dataPath string, M uint64, compressed 
 	return d, bt, nil
 }
 
-func BuildBtreeIndexWithDecompressor(indexPath string, kv *seg.Reader, ps *background.ProgressSet, tmpdir string, salt uint32, logger log.Logger, noFsync bool, accessors Accessors) error {
+func BuildBtreeIndexWithDecompressor(indexPath string, kv *seg.Reader, ps *background.ProgressSet, tmpdir string, salt uint32, logger log.Logger, noFsync bool, accessors statecfg.Accessors) error {
 	_, indexFileName := filepath.Split(indexPath)
 	p := ps.AddNew(indexFileName, uint64(kv.Count()/2))
 	defer ps.Delete(p)
@@ -363,7 +364,7 @@ func BuildBtreeIndexWithDecompressor(indexPath string, kv *seg.Reader, ps *backg
 	existenceFilterPath := strings.TrimSuffix(indexPath, ".bt") + ".kvei"
 
 	var existenceFilter *existence.Filter
-	if accessors.Has(AccessorExistence) {
+	if accessors.Has(statecfg.AccessorExistence) {
 		var err error
 		useFuse := false
 		existenceFilter, err = existence.NewFilter(uint64(kv.Count()/2), existenceFilterPath, useFuse)

--- a/db/state/btree_index_test.go
+++ b/db/state/btree_index_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/recsplit/eliasfano32"
 	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/state/statecfg"
 )
 
 func Test_BtreeIndex_Init(t *testing.T) {
@@ -44,7 +45,7 @@ func Test_BtreeIndex_Init(t *testing.T) {
 	defer decomp.Close()
 
 	r := seg.NewReader(decomp.MakeGetter(), seg.CompressNone)
-	err = BuildBtreeIndexWithDecompressor(filepath.Join(tmp, "a.bt"), r, background.NewProgressSet(), tmp, 1, logger, true, AccessorBTree|AccessorExistence)
+	err = BuildBtreeIndexWithDecompressor(filepath.Join(tmp, "a.bt"), r, background.NewProgressSet(), tmp, 1, logger, true, statecfg.AccessorBTree|statecfg.AccessorExistence)
 	require.NoError(t, err)
 
 	bt, err := OpenBtreeIndexWithDecompressor(filepath.Join(tmp, "a.bt"), M, r)
@@ -193,7 +194,7 @@ func buildBtreeIndex(tb testing.TB, dataPath, indexPath string, compressed seg.F
 	defer decomp.Close()
 
 	r := seg.NewReader(decomp.MakeGetter(), compressed)
-	err = BuildBtreeIndexWithDecompressor(indexPath, r, background.NewProgressSet(), filepath.Dir(indexPath), seed, logger, noFsync, AccessorBTree|AccessorExistence)
+	err = BuildBtreeIndexWithDecompressor(indexPath, r, background.NewProgressSet(), filepath.Dir(indexPath), seed, logger, noFsync, statecfg.AccessorBTree|statecfg.AccessorExistence)
 	require.NoError(tb, err)
 }
 

--- a/db/state/dirty_files.go
+++ b/db/state/dirty_files.go
@@ -27,6 +27,8 @@ import (
 	"sync/atomic"
 
 	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/state/statecfg"
+
 	btree2 "github.com/tidwall/btree"
 
 	"github.com/erigontech/erigon-lib/common/dir"
@@ -334,7 +336,7 @@ func (d *Domain) openDirtyFiles() (err error) {
 				}
 			}
 
-			if item.index == nil && d.Accessors.Has(AccessorHashMap) {
+			if item.index == nil && d.Accessors.Has(statecfg.AccessorHashMap) {
 				fPathMask := d.kviAccessorFilePathMask(fromStep, toStep)
 				fPath, fileVer, ok, err := version.FindFilesWithVersionsByPattern(fPathMask)
 				if err != nil {
@@ -353,7 +355,7 @@ func (d *Domain) openDirtyFiles() (err error) {
 					}
 				}
 			}
-			if item.bindex == nil && d.Accessors.Has(AccessorBTree) {
+			if item.bindex == nil && d.Accessors.Has(statecfg.AccessorBTree) {
 				fPathMask := d.kvBtAccessorFilePathMask(fromStep, toStep)
 				fPath, fileVer, ok, err := version.FindFilesWithVersionsByPattern(fPathMask)
 				if err != nil {
@@ -372,7 +374,7 @@ func (d *Domain) openDirtyFiles() (err error) {
 					}
 				}
 			}
-			if item.existence == nil && d.Accessors.Has(AccessorExistence) {
+			if item.existence == nil && d.Accessors.Has(statecfg.AccessorExistence) {
 				fPathMask := d.kvExistenceIdxFilePathMask(fromStep, toStep)
 				fPath, fileVer, ok, err := version.FindFilesWithVersionsByPattern(fPathMask)
 				if err != nil {
@@ -595,7 +597,7 @@ func (i visibleFile) EndRootNum() uint64 {
 	return i.endTxNum
 }
 
-func calcVisibleFiles(files *btree2.BTreeG[*FilesItem], l Accessors, checker func(startTxNum, endTxNum uint64) bool, trace bool, toTxNum uint64) (roItems []visibleFile) {
+func calcVisibleFiles(files *btree2.BTreeG[*FilesItem], l statecfg.Accessors, checker func(startTxNum, endTxNum uint64) bool, trace bool, toTxNum uint64) (roItems []visibleFile) {
 	newVisibleFiles := make([]visibleFile, 0, files.Len())
 	// trace = true
 	if trace {
@@ -643,7 +645,7 @@ func calcVisibleFiles(files *btree2.BTreeG[*FilesItem], l Accessors, checker fun
 	return newVisibleFiles
 }
 
-func checkForVisibility(item *FilesItem, l Accessors, trace bool) (canBeVisible bool) {
+func checkForVisibility(item *FilesItem, l statecfg.Accessors, trace bool) (canBeVisible bool) {
 	if item.canDelete.Load() {
 		if trace {
 			log.Warn("[dbg] canDelete=true", "f", item.decompressor.FileName())
@@ -656,21 +658,21 @@ func checkForVisibility(item *FilesItem, l Accessors, trace bool) (canBeVisible 
 		}
 		return false
 	}
-	if l.Has(AccessorBTree) && item.bindex == nil {
+	if l.Has(statecfg.AccessorBTree) && item.bindex == nil {
 		if trace {
 			log.Warn("[dbg] checkForVisibility: BTindex not opened", "f", item.decompressor.FileName())
 		}
 		//panic(fmt.Errorf("btindex nil: %s", item.decompressor.FileName()))
 		return false
 	}
-	if l.Has(AccessorHashMap) && item.index == nil {
+	if l.Has(statecfg.AccessorHashMap) && item.index == nil {
 		if trace {
 			log.Warn("[dbg] checkForVisibility: RecSplit not opened", "f", item.decompressor.FileName())
 		}
 		//panic(fmt.Errorf("index nil: %s", item.decompressor.FileName()))
 		return false
 	}
-	if l.Has(AccessorExistence) && item.existence == nil {
+	if l.Has(statecfg.AccessorExistence) && item.existence == nil {
 		if trace {
 			log.Warn("[dbg] checkForVisibility: Existence not opened", "f", item.decompressor.FileName())
 		}

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -45,6 +45,7 @@ import (
 	"github.com/erigontech/erigon/db/kv/stream"
 	"github.com/erigontech/erigon/db/recsplit"
 	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/db/version"
 )
 
@@ -96,8 +97,8 @@ type domainCfg struct {
 	name        kv.Domain
 	Compression seg.FileCompression
 	CompressCfg seg.Cfg
-	Accessors   Accessors // list of indexes for given domain
-	valuesTable string    // bucket to store domain values; key -> inverted_step + values (Dupsort)
+	Accessors   statecfg.Accessors // list of indexes for given domain
+	valuesTable string             // bucket to store domain values; key -> inverted_step + values (Dupsort)
 	largeValues bool
 
 	// replaceKeysInValues allows to replace commitment branch values with shorter keys.
@@ -147,13 +148,13 @@ func NewDomain(cfg domainCfg, stepSize uint64, logger log.Logger) (*Domain, erro
 	if d.version.DataKV.IsZero() {
 		panic(fmt.Errorf("assert: forgot to set version of %s", d.name))
 	}
-	if d.Accessors.Has(AccessorBTree) && d.version.AccessorBT.IsZero() {
+	if d.Accessors.Has(statecfg.AccessorBTree) && d.version.AccessorBT.IsZero() {
 		panic(fmt.Errorf("assert: forgot to set version of %s", d.name))
 	}
-	if d.Accessors.Has(AccessorHashMap) && d.version.AccessorKVI.IsZero() {
+	if d.Accessors.Has(statecfg.AccessorHashMap) && d.version.AccessorKVI.IsZero() {
 		panic(fmt.Errorf("assert: forgot to set version of %s", d.name))
 	}
-	if d.Accessors.Has(AccessorExistence) && d.version.AccessorKVEI.IsZero() {
+	if d.Accessors.Has(statecfg.AccessorExistence) && d.version.AccessorKVEI.IsZero() {
 		panic(fmt.Errorf("assert: forgot to set version of %s", d.name))
 	}
 
@@ -602,7 +603,7 @@ func (dt *DomainRoTx) getLatestFromFile(i int, filekey []byte) (v []byte, ok boo
 		defer domainReadMetric(dt.name, i).ObserveDuration(time.Now())
 	}
 
-	if dt.d.Accessors.Has(AccessorBTree) {
+	if dt.d.Accessors.Has(statecfg.AccessorBTree) {
 		_, v, offset, ok, err = dt.statelessBtree(i).Get(filekey, dt.reusableReader(i))
 		if err != nil || !ok {
 			return nil, false, 0, err
@@ -610,7 +611,7 @@ func (dt *DomainRoTx) getLatestFromFile(i int, filekey []byte) (v []byte, ok boo
 		//fmt.Printf("getLatestFromBtreeColdFiles key %x shard %d %x\n", filekey, exactColdShard, v)
 		return v, true, offset, nil
 	}
-	if dt.d.Accessors.Has(AccessorHashMap) {
+	if dt.d.Accessors.Has(statecfg.AccessorHashMap) {
 		reader := dt.statelessIdxReader(i)
 		if reader.Empty() {
 			return nil, false, 0, nil
@@ -994,7 +995,7 @@ func (d *Domain) buildFileRange(ctx context.Context, stepFrom, stepTo kv.Step, c
 		return StaticFiles{}, fmt.Errorf("open %s values decompressor: %w", d.filenameBase, err)
 	}
 
-	if d.Accessors.Has(AccessorHashMap) {
+	if d.Accessors.Has(statecfg.AccessorHashMap) {
 		if err = d.buildHashMapAccessor(ctx, stepFrom, stepTo, d.dataReader(valuesDecomp), ps); err != nil {
 			return StaticFiles{}, fmt.Errorf("build %s values idx: %w", d.filenameBase, err)
 		}
@@ -1004,14 +1005,14 @@ func (d *Domain) buildFileRange(ctx context.Context, stepFrom, stepTo kv.Step, c
 		}
 	}
 
-	if d.Accessors.Has(AccessorBTree) {
+	if d.Accessors.Has(statecfg.AccessorBTree) {
 		btPath := d.kvBtAccessorNewFilePath(stepFrom, stepTo)
 		bt, err = CreateBtreeIndexWithDecompressor(btPath, DefaultBtreeM, d.dataReader(valuesDecomp), *d.salt.Load(), ps, d.dirs.Tmp, d.logger, d.noFsync, d.Accessors)
 		if err != nil {
 			return StaticFiles{}, fmt.Errorf("build %s .bt idx: %w", d.filenameBase, err)
 		}
 	}
-	if d.Accessors.Has(AccessorExistence) {
+	if d.Accessors.Has(statecfg.AccessorExistence) {
 		fPath := d.kvExistenceIdxNewFilePath(stepFrom, stepTo)
 		exists, err := dir.FileExist(fPath)
 		if err != nil {
@@ -1096,7 +1097,7 @@ func (d *Domain) buildFiles(ctx context.Context, step kv.Step, collation Collati
 		return StaticFiles{}, fmt.Errorf("open %s values decompressor: %w", d.filenameBase, err)
 	}
 
-	if d.Accessors.Has(AccessorHashMap) {
+	if d.Accessors.Has(statecfg.AccessorHashMap) {
 		if err = d.buildHashMapAccessor(ctx, step, step+1, d.dataReader(valuesDecomp), ps); err != nil {
 			return StaticFiles{}, fmt.Errorf("build %s values idx: %w", d.filenameBase, err)
 		}
@@ -1106,14 +1107,14 @@ func (d *Domain) buildFiles(ctx context.Context, step kv.Step, collation Collati
 		}
 	}
 
-	if d.Accessors.Has(AccessorBTree) {
+	if d.Accessors.Has(statecfg.AccessorBTree) {
 		btPath := d.kvBtAccessorNewFilePath(step, step+1)
 		bt, err = CreateBtreeIndexWithDecompressor(btPath, DefaultBtreeM, d.dataReader(valuesDecomp), *d.salt.Load(), ps, d.dirs.Tmp, d.logger, d.noFsync, d.Accessors)
 		if err != nil {
 			return StaticFiles{}, fmt.Errorf("build %s .bt idx: %w", d.filenameBase, err)
 		}
 	}
-	if d.Accessors.Has(AccessorExistence) {
+	if d.Accessors.Has(statecfg.AccessorExistence) {
 		fPath := d.kvExistenceIdxNewFilePath(step, step+1)
 		exists, err := dir.FileExist(fPath)
 		if err != nil {
@@ -1158,7 +1159,7 @@ func (d *Domain) MissedBtreeAccessors() (l []*FilesItem) {
 }
 
 func (d *Domain) missedBtreeAccessors(source []*FilesItem) (l []*FilesItem) {
-	if !d.Accessors.Has(AccessorBTree) {
+	if !d.Accessors.Has(statecfg.AccessorBTree) {
 		return nil
 	}
 	return fileItemsWithMissedAccessors(source, d.stepSize, func(fromStep, toStep kv.Step) []string {
@@ -1179,7 +1180,7 @@ func (d *Domain) MissedMapAccessors() (l []*FilesItem) {
 }
 
 func (d *Domain) missedMapAccessors(source []*FilesItem) (l []*FilesItem) {
-	if !d.Accessors.Has(AccessorHashMap) {
+	if !d.Accessors.Has(statecfg.AccessorHashMap) {
 		return nil
 	}
 	return fileItemsWithMissedAccessors(source, d.stepSize, func(fromStep, toStep kv.Step) []string {
@@ -1403,7 +1404,7 @@ func (dt *DomainRoTx) getLatestFromFiles(k []byte, maxTxNum uint64) (v []byte, f
 	if maxTxNum == 0 {
 		maxTxNum = math.MaxUint64
 	}
-	useExistenceFilter := dt.d.Accessors.Has(AccessorExistence)
+	useExistenceFilter := dt.d.Accessors.Has(statecfg.AccessorExistence)
 	useCache := dt.name != kv.CommitmentDomain && maxTxNum == math.MaxUint64
 
 	hi, _ := dt.ht.iit.hashKey(k)

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -38,6 +38,7 @@ import (
 	"github.com/erigontech/erigon-lib/common/dir"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon-lib/metrics"
+	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/datastruct/existence"
 	"github.com/erigontech/erigon/db/etl"
 	"github.com/erigontech/erigon/db/kv"
@@ -126,8 +127,8 @@ type domainVisible struct {
 	caches *sync.Pool
 }
 
-func NewDomain(cfg domainCfg, stepSize uint64, logger log.Logger) (*Domain, error) {
-	if cfg.hist.iiCfg.dirs.SnapDomain == "" {
+func NewDomain(cfg domainCfg, stepSize uint64, dirs datadir.Dirs, logger log.Logger) (*Domain, error) {
+	if dirs.SnapDomain == "" {
 		panic("assert: empty `dirs`")
 	}
 	if cfg.hist.iiCfg.filenameBase == "" {
@@ -141,7 +142,7 @@ func NewDomain(cfg domainCfg, stepSize uint64, logger log.Logger) (*Domain, erro
 	}
 
 	var err error
-	if d.History, err = NewHistory(cfg.hist, stepSize, logger); err != nil {
+	if d.History, err = NewHistory(cfg.hist, stepSize, dirs, logger); err != nil {
 		return nil, err
 	}
 

--- a/db/state/domain_committed.go
+++ b/db/state/domain_committed.go
@@ -31,6 +31,7 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/recsplit"
 	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/execution/commitment"
 )
 
@@ -245,7 +246,7 @@ func (dt *DomainRoTx) findShortenedKey(fullKey []byte, itemGetter *seg.Reader, i
 		}
 		return encodeShorterKey(nil, offset), true
 	}
-	if dt.d.Accessors.Has(AccessorBTree) {
+	if dt.d.Accessors.Has(statecfg.AccessorBTree) {
 		if item.bindex == nil {
 			dt.d.logger.Warn("[agg] commitment branch key replacement: file doesn't have index", "name", item.decompressor.FileName())
 		}

--- a/db/state/domain_stream.go
+++ b/db/state/domain_stream.go
@@ -31,6 +31,7 @@ import (
 	"github.com/erigontech/erigon/db/kv/order"
 	"github.com/erigontech/erigon/db/kv/stream"
 	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/state/statecfg"
 )
 
 type CursorType uint8
@@ -384,7 +385,7 @@ func (dt *DomainRoTx) debugIteratePrefixLatest(prefix []byte, ramIter btree2.Map
 				}
 			case FILE_CURSOR:
 				indexList := dt.d.Accessors
-				if indexList.Has(AccessorBTree) {
+				if indexList.Has(statecfg.AccessorBTree) {
 					if ci1.btCursor.Next() {
 						ci1.key = ci1.btCursor.Key()
 						if ci1.key != nil && bytes.HasPrefix(ci1.key, prefix) {
@@ -395,7 +396,7 @@ func (dt *DomainRoTx) debugIteratePrefixLatest(prefix []byte, ramIter btree2.Map
 						ci1.btCursor.Close()
 					}
 				}
-				if indexList.Has(AccessorHashMap) {
+				if indexList.Has(statecfg.AccessorHashMap) {
 					ci1.idx.Reset(ci1.latestOffset)
 					if !ci1.idx.HasNext() {
 						break

--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -31,7 +31,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -79,7 +78,6 @@ func testDbAndDomainOfStep(t *testing.T, aggStep uint64, logger log.Logger) (kv.
 	t.Helper()
 	dirs := datadir2.New(t.TempDir())
 	cfg := Schema.AccountsDomain
-	cfg.hist.iiCfg.salt = new(atomic.Pointer[uint32])
 
 	db := mdbx.New(kv.ChainDB, logger).InMem(dirs.Chaindata).MustOpen()
 	t.Cleanup(db.Close)
@@ -87,9 +85,9 @@ func testDbAndDomainOfStep(t *testing.T, aggStep uint64, logger log.Logger) (kv.
 
 	cfg.hist.iiCfg.version = IIVersionTypes{version.V1_0_standart, version.V1_0_standart}
 	cfg.hist.iiCfg.dirs = dirs
-	cfg.hist.iiCfg.salt.Store(&salt)
 	//cfg.hist.historyValuesOnCompressedPage = 16
 	d, err := NewDomain(cfg, aggStep, logger)
+	d.salt.Store(&salt)
 	require.NoError(t, err)
 	d.DisableFsync()
 	t.Cleanup(d.Close)
@@ -1052,10 +1050,6 @@ func emptyTestDomain(aggStep uint64) *Domain {
 	cfg := Schema.AccountsDomain
 
 	salt := uint32(1)
-	if cfg.hist.iiCfg.salt == nil {
-		cfg.hist.iiCfg.salt = new(atomic.Pointer[uint32])
-	}
-	cfg.hist.iiCfg.salt.Store(&salt)
 	cfg.hist.iiCfg.dirs = datadir2.New(os.TempDir())
 	cfg.hist.iiCfg.name = kv.InvertedIdx(0)
 	cfg.hist.iiCfg.version = IIVersionTypes{version.V1_0_standart, version.V1_0_standart}
@@ -1065,6 +1059,7 @@ func emptyTestDomain(aggStep uint64) *Domain {
 	if err != nil {
 		panic(err)
 	}
+	d.salt.Store(&salt)
 
 	return d
 }

--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -84,9 +84,8 @@ func testDbAndDomainOfStep(t *testing.T, aggStep uint64, logger log.Logger) (kv.
 	salt := uint32(1)
 
 	cfg.hist.iiCfg.version = IIVersionTypes{version.V1_0_standart, version.V1_0_standart}
-	cfg.hist.iiCfg.dirs = dirs
 	//cfg.hist.historyValuesOnCompressedPage = 16
-	d, err := NewDomain(cfg, aggStep, logger)
+	d, err := NewDomain(cfg, aggStep, dirs, logger)
 	d.salt.Store(&salt)
 	require.NoError(t, err)
 	d.DisableFsync()
@@ -1050,12 +1049,12 @@ func emptyTestDomain(aggStep uint64) *Domain {
 	cfg := Schema.AccountsDomain
 
 	salt := uint32(1)
-	cfg.hist.iiCfg.dirs = datadir2.New(os.TempDir())
+	dirs := datadir2.New(os.TempDir())
 	cfg.hist.iiCfg.name = kv.InvertedIdx(0)
 	cfg.hist.iiCfg.version = IIVersionTypes{version.V1_0_standart, version.V1_0_standart}
 	cfg.hist.iiCfg.Accessors = statecfg.AccessorHashMap
 
-	d, err := NewDomain(cfg, aggStep, log.New())
+	d, err := NewDomain(cfg, aggStep, dirs, log.New())
 	if err != nil {
 		panic(err)
 	}

--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/erigontech/erigon/db/kv/order"
 	"github.com/erigontech/erigon/db/kv/stream"
 	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/db/version"
 	accounts3 "github.com/erigontech/erigon/execution/types/accounts"
 )
@@ -1058,7 +1059,7 @@ func emptyTestDomain(aggStep uint64) *Domain {
 	cfg.hist.iiCfg.dirs = datadir2.New(os.TempDir())
 	cfg.hist.iiCfg.name = kv.InvertedIdx(0)
 	cfg.hist.iiCfg.version = IIVersionTypes{version.V1_0_standart, version.V1_0_standart}
-	cfg.hist.iiCfg.Accessors = AccessorHashMap
+	cfg.hist.iiCfg.Accessors = statecfg.AccessorHashMap
 
 	d, err := NewDomain(cfg, aggStep, log.New())
 	if err != nil {

--- a/db/state/entity_integrity_check.go
+++ b/db/state/entity_integrity_check.go
@@ -8,6 +8,7 @@ import (
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/state/statecfg"
 )
 
 // high 16 bits: specify domain/ii/forkables identifier
@@ -81,7 +82,7 @@ type DependencyIntegrityChecker struct {
 type DependentInfo struct {
 	entity      UniversalEntity
 	filesGetter DirtyFilesGetter
-	accessors   Accessors
+	accessors   statecfg.Accessors
 }
 
 // dependency/referred: account/storage

--- a/db/state/history.go
+++ b/db/state/history.go
@@ -27,9 +27,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/erigontech/erigon/db/version"
 	btree2 "github.com/tidwall/btree"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/erigontech/erigon/db/state/statecfg"
+	"github.com/erigontech/erigon/db/version"
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/background"
@@ -93,7 +95,7 @@ type histCfg struct {
 
 	historyValuesOnCompressedPage int // when collating .v files: concat 16 values and snappy them
 
-	Accessors     Accessors
+	Accessors     statecfg.Accessors
 	CompressorCfg seg.Cfg             // Compression settings for history files
 	Compression   seg.FileCompression // defines type of Compression for history files
 	historyIdx    kv.InvertedIdx
@@ -111,7 +113,7 @@ func (h histCfg) GetVersions() VersionTypes {
 func NewHistory(cfg histCfg, stepSize uint64, logger log.Logger) (*History, error) {
 	//if cfg.compressorCfg.MaxDictPatterns == 0 && cfg.compressorCfg.MaxPatternLen == 0 {
 	if cfg.Accessors == 0 {
-		cfg.Accessors = AccessorHashMap
+		cfg.Accessors = statecfg.AccessorHashMap
 	}
 
 	h := History{
@@ -243,7 +245,7 @@ func (h *History) MissedMapAccessors() (l []*FilesItem) {
 }
 
 func (h *History) missedMapAccessors(source []*FilesItem) (l []*FilesItem) {
-	if !h.Accessors.Has(AccessorHashMap) {
+	if !h.Accessors.Has(statecfg.AccessorHashMap) {
 		return nil
 	}
 	return fileItemsWithMissedAccessors(source, h.stepSize, func(fromStep, toStep kv.Step) []string {

--- a/db/state/history.go
+++ b/db/state/history.go
@@ -30,6 +30,7 @@ import (
 	btree2 "github.com/tidwall/btree"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/db/version"
 
@@ -110,7 +111,7 @@ func (h histCfg) GetVersions() VersionTypes {
 	}
 }
 
-func NewHistory(cfg histCfg, stepSize uint64, logger log.Logger) (*History, error) {
+func NewHistory(cfg histCfg, stepSize uint64, dirs datadir.Dirs, logger log.Logger) (*History, error) {
 	//if cfg.compressorCfg.MaxDictPatterns == 0 && cfg.compressorCfg.MaxPatternLen == 0 {
 	if cfg.Accessors == 0 {
 		cfg.Accessors = statecfg.AccessorHashMap
@@ -123,7 +124,7 @@ func NewHistory(cfg histCfg, stepSize uint64, logger log.Logger) (*History, erro
 	}
 
 	var err error
-	h.InvertedIndex, err = NewInvertedIndex(cfg.iiCfg, stepSize, logger)
+	h.InvertedIndex, err = NewInvertedIndex(cfg.iiCfg, stepSize, dirs, logger)
 	if err != nil {
 		return nil, fmt.Errorf("NewHistory: %s, %w", cfg.iiCfg.filenameBase, err)
 	}

--- a/db/state/history_test.go
+++ b/db/state/history_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/erigontech/erigon/db/recsplit"
 	"github.com/erigontech/erigon/db/recsplit/multiencseq"
 	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/state/statecfg"
 )
 
 func testDbAndHistory(tb testing.TB, largeValues bool, logger log.Logger) (kv.RwDB, *History) {
@@ -61,7 +62,7 @@ func testDbAndHistory(tb testing.TB, largeValues bool, logger log.Logger) (kv.Rw
 		cfg.hist.iiCfg.salt = new(atomic.Pointer[uint32])
 	}
 	cfg.hist.iiCfg.salt.Store(&salt)
-	cfg.hist.iiCfg.Accessors = AccessorHashMap
+	cfg.hist.iiCfg.Accessors = statecfg.AccessorHashMap
 	cfg.hist.historyLargeValues = largeValues
 
 	//perf of tests
@@ -260,7 +261,7 @@ func TestHistoryCollationBuild(t *testing.T) {
 		for i := 0; i < len(keyWords); i++ {
 			var offset uint64
 			var ok bool
-			if h.InvertedIndex.Accessors.Has(AccessorExistence) {
+			if h.InvertedIndex.Accessors.Has(statecfg.AccessorExistence) {
 				offset, ok = r.Lookup([]byte(keyWords[i]))
 				if !ok {
 					continue

--- a/db/state/history_test.go
+++ b/db/state/history_test.go
@@ -58,7 +58,6 @@ func testDbAndHistory(tb testing.TB, largeValues bool, logger log.Logger) (kv.Rw
 	salt := uint32(1)
 	cfg := Schema.AccountsDomain
 
-	cfg.hist.iiCfg.dirs = dirs
 	cfg.hist.iiCfg.Accessors = statecfg.AccessorHashMap
 	cfg.hist.historyLargeValues = largeValues
 
@@ -67,7 +66,7 @@ func testDbAndHistory(tb testing.TB, largeValues bool, logger log.Logger) (kv.Rw
 	cfg.hist.Compression = seg.CompressNone
 	//cfg.hist.historyValuesOnCompressedPage = 16
 	aggregationStep := uint64(16)
-	h, err := NewHistory(cfg.hist, aggregationStep, logger)
+	h, err := NewHistory(cfg.hist, aggregationStep, dirs, logger)
 	require.NoError(tb, err)
 	tb.Cleanup(h.Close)
 	h.salt.Store(&salt)

--- a/db/state/integrity_checker_test.go
+++ b/db/state/integrity_checker_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/recsplit"
 	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/state/statecfg"
 )
 
 func TestDependency(t *testing.T) {
@@ -35,7 +36,7 @@ func TestDependency(t *testing.T) {
 	dinfo := &DependentInfo{
 		entity:      CommitmentDomainUniversal,
 		filesGetter: fg,
-		accessors:   AccessorHashMap,
+		accessors:   statecfg.AccessorHashMap,
 	}
 
 	checker := NewDependencyIntegrityChecker(dirs, logger)
@@ -77,7 +78,7 @@ func TestDependency_UnindexedMerged(t *testing.T) {
 	dinfo := &DependentInfo{
 		entity:      CommitmentDomainUniversal,
 		filesGetter: fg,
-		accessors:   AccessorHashMap,
+		accessors:   statecfg.AccessorHashMap,
 	}
 
 	checker := NewDependencyIntegrityChecker(dirs, logger)

--- a/db/state/inverted_index.go
+++ b/db/state/inverted_index.go
@@ -57,6 +57,7 @@ import (
 
 type InvertedIndex struct {
 	iiCfg
+	salt    *atomic.Pointer[uint32]
 	noFsync bool // fsync is enabled by default, but tests can manually disable
 
 	stepSize uint64 // amount of transactions inside single aggregation step
@@ -81,7 +82,6 @@ type InvertedIndex struct {
 }
 
 type iiCfg struct {
-	salt    *atomic.Pointer[uint32]
 	dirs    datadir.Dirs
 	disable bool // totally disable Domain/History/InvertedIndex - ignore all writes, don't produce files
 
@@ -130,6 +130,7 @@ func NewInvertedIndex(cfg iiCfg, stepSize uint64, logger log.Logger) (*InvertedI
 		logger:     logger,
 
 		stepSize: stepSize,
+		salt:     &atomic.Pointer[uint32]{},
 	}
 	if ii.stepSize == 0 {
 		panic("assert: empty `stepSize`")

--- a/db/state/inverted_index_stream.go
+++ b/db/state/inverted_index_stream.go
@@ -28,6 +28,7 @@ import (
 	"github.com/erigontech/erigon/db/kv/order"
 	"github.com/erigontech/erigon/db/kv/stream"
 	"github.com/erigontech/erigon/db/recsplit/multiencseq"
+	"github.com/erigontech/erigon/db/state/statecfg"
 )
 
 // InvertedIdxStreamFiles allows iteration over range of txn numbers
@@ -49,7 +50,7 @@ type InvertedIdxStreamFiles struct {
 	err     error
 
 	seq       *multiencseq.SequenceReader
-	accessors Accessors
+	accessors statecfg.Accessors
 	ii        *InvertedIndexRoTx
 }
 

--- a/db/state/inverted_index_test.go
+++ b/db/state/inverted_index_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/erigontech/erigon/db/recsplit"
 	"github.com/erigontech/erigon/db/recsplit/multiencseq"
 	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/db/version"
 )
 
@@ -61,7 +62,7 @@ func testDbAndInvertedIndex(tb testing.TB, aggStep uint64, logger log.Logger) (k
 	salt := uint32(1)
 	cfg := iiCfg{salt: new(atomic.Pointer[uint32]), dirs: dirs, filenameBase: "inv", keysTable: keysTable, valuesTable: indexTable, version: IIVersionTypes{DataEF: version.V1_0_standart, AccessorEFI: version.V1_0_standart}}
 	cfg.salt.Store(&salt)
-	cfg.Accessors = AccessorHashMap
+	cfg.Accessors = statecfg.AccessorHashMap
 	ii, err := NewInvertedIndex(cfg, aggStep, logger)
 	require.NoError(tb, err)
 	ii.DisableFsync()

--- a/db/state/inverted_index_test.go
+++ b/db/state/inverted_index_test.go
@@ -59,9 +59,9 @@ func testDbAndInvertedIndex(tb testing.TB, aggStep uint64, logger log.Logger) (k
 	}).MustOpen()
 	tb.Cleanup(db.Close)
 	salt := uint32(1)
-	cfg := iiCfg{dirs: dirs, filenameBase: "inv", keysTable: keysTable, valuesTable: indexTable, version: IIVersionTypes{DataEF: version.V1_0_standart, AccessorEFI: version.V1_0_standart}}
+	cfg := iiCfg{filenameBase: "inv", keysTable: keysTable, valuesTable: indexTable, version: IIVersionTypes{DataEF: version.V1_0_standart, AccessorEFI: version.V1_0_standart}}
 	cfg.Accessors = statecfg.AccessorHashMap
-	ii, err := NewInvertedIndex(cfg, aggStep, logger)
+	ii, err := NewInvertedIndex(cfg, aggStep, dirs, logger)
 	require.NoError(tb, err)
 	tb.Cleanup(ii.Close)
 	ii.salt.Store(&salt)
@@ -610,7 +610,7 @@ func TestInvIndexScanFiles(t *testing.T) {
 	cfg := ii.iiCfg
 
 	var err error
-	ii, err = NewInvertedIndex(cfg, 16, logger)
+	ii, err = NewInvertedIndex(cfg, 16, ii.dirs, logger)
 	require.NoError(err)
 	defer ii.Close()
 	ii.salt.Store(&salt)

--- a/db/state/merge.go
+++ b/db/state/merge.go
@@ -37,6 +37,7 @@ import (
 	"github.com/erigontech/erigon/db/recsplit"
 	"github.com/erigontech/erigon/db/recsplit/multiencseq"
 	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/state/statecfg"
 )
 
 func (d *Domain) dirtyFilesEndTxNumMinimax() uint64 {
@@ -547,7 +548,7 @@ func (dt *DomainRoTx) mergeFiles(ctx context.Context, domainFiles, indexFiles, h
 		return nil, nil, nil, fmt.Errorf("merge %s decompressor [%d-%d]: %w", dt.d.filenameBase, r.values.from, r.values.to, err)
 	}
 
-	if dt.d.Accessors.Has(AccessorBTree) {
+	if dt.d.Accessors.Has(statecfg.AccessorBTree) {
 		btPath := dt.d.kvBtAccessorNewFilePath(fromStep, toStep)
 		btM := DefaultBtreeM
 		if toStep == 0 && dt.d.filenameBase == "commitment" {
@@ -558,7 +559,7 @@ func (dt *DomainRoTx) mergeFiles(ctx context.Context, domainFiles, indexFiles, h
 			return nil, nil, nil, fmt.Errorf("merge %s btindex [%d-%d]: %w", dt.d.filenameBase, r.values.from, r.values.to, err)
 		}
 	}
-	if dt.d.Accessors.Has(AccessorHashMap) {
+	if dt.d.Accessors.Has(statecfg.AccessorHashMap) {
 		if err = dt.d.buildHashMapAccessor(ctx, fromStep, toStep, dt.dataReader(valuesIn.decompressor), ps); err != nil {
 			return nil, nil, nil, fmt.Errorf("merge %s buildHashMapAccessor [%d-%d]: %w", dt.d.filenameBase, r.values.from, r.values.to, err)
 		}
@@ -567,7 +568,7 @@ func (dt *DomainRoTx) mergeFiles(ctx context.Context, domainFiles, indexFiles, h
 		}
 	}
 
-	if dt.d.Accessors.Has(AccessorExistence) {
+	if dt.d.Accessors.Has(statecfg.AccessorExistence) {
 		bloomIndexPath := dt.d.kvExistenceIdxNewFilePath(fromStep, toStep)
 		exists, err := dir.FileExist(bloomIndexPath)
 		if err != nil {

--- a/db/state/merge_test.go
+++ b/db/state/merge_test.go
@@ -115,8 +115,8 @@ func emptyTestInvertedIndex(aggStep uint64) *InvertedIndex {
 	salt := uint32(1)
 	cfg := Schema.AccountsDomain.hist.iiCfg
 
-	cfg.dirs = datadir.New(os.TempDir())
-	ii, err := NewInvertedIndex(cfg, aggStep, log.New())
+	dirs := datadir.New(os.TempDir())
+	ii, err := NewInvertedIndex(cfg, aggStep, dirs, log.New())
 	ii.Accessors = 0
 	ii.salt.Store(&salt)
 	if err != nil {
@@ -617,11 +617,11 @@ func TestMergeFilesWithDependency(t *testing.T) {
 		cfg := Schema.GetDomainCfg(dom)
 
 		salt := uint32(1)
-		cfg.hist.iiCfg.dirs = datadir.New(os.TempDir())
+		dirs := datadir.New(os.TempDir())
 		cfg.hist.iiCfg.name = kv.InvertedIdx(0)
 		cfg.hist.iiCfg.version = IIVersionTypes{version.V1_0_standart, version.V1_0_standart}
 
-		d, err := NewDomain(cfg, 1, log.New())
+		d, err := NewDomain(cfg, 1, dirs, log.New())
 		if err != nil {
 			panic(err)
 		}
@@ -635,7 +635,7 @@ func TestMergeFilesWithDependency(t *testing.T) {
 
 	setup := func() (account, storage, commitment *Domain) {
 		account, storage, commitment = newTestDomain(0), newTestDomain(1), newTestDomain(3)
-		checker := NewDependencyIntegrityChecker(account.hist.iiCfg.dirs, log.New())
+		checker := NewDependencyIntegrityChecker(account.dirs, log.New())
 		info := &DependentInfo{
 			entity: FromDomain(commitment.name),
 			filesGetter: func() *btree2.BTreeG[*FilesItem] {

--- a/db/state/merge_test.go
+++ b/db/state/merge_test.go
@@ -878,7 +878,7 @@ func TestHistoryAndIIAlignment(t *testing.T) {
 
 	agg, _ := newAggregatorOld(context.Background(), dirs, 1, db, logger)
 	setup := func() (account *Domain) {
-		agg.registerDomain(kv.AccountsDomain, nil, dirs, logger)
+		agg.registerDomain(Schema.GetDomainCfg(kv.AccountsDomain), nil, dirs, logger)
 		domain := agg.d[kv.AccountsDomain]
 		domain.History.InvertedIndex.Accessors = 0
 		domain.History.Accessors = 0

--- a/db/state/merge_test.go
+++ b/db/state/merge_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -116,14 +115,10 @@ func emptyTestInvertedIndex(aggStep uint64) *InvertedIndex {
 	salt := uint32(1)
 	cfg := Schema.AccountsDomain.hist.iiCfg
 
-	if cfg.salt == nil {
-		cfg.salt = new(atomic.Pointer[uint32])
-	}
-	cfg.salt.Store(&salt)
 	cfg.dirs = datadir.New(os.TempDir())
-
 	ii, err := NewInvertedIndex(cfg, aggStep, log.New())
 	ii.Accessors = 0
+	ii.salt.Store(&salt)
 	if err != nil {
 		panic(err)
 	}
@@ -622,10 +617,6 @@ func TestMergeFilesWithDependency(t *testing.T) {
 		cfg := Schema.GetDomainCfg(dom)
 
 		salt := uint32(1)
-		if cfg.hist.iiCfg.salt == nil {
-			cfg.hist.iiCfg.salt = new(atomic.Pointer[uint32])
-		}
-		cfg.hist.iiCfg.salt.Store(&salt)
 		cfg.hist.iiCfg.dirs = datadir.New(os.TempDir())
 		cfg.hist.iiCfg.name = kv.InvertedIdx(0)
 		cfg.hist.iiCfg.version = IIVersionTypes{version.V1_0_standart, version.V1_0_standart}
@@ -634,6 +625,7 @@ func TestMergeFilesWithDependency(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
+		d.salt.Store(&salt)
 
 		d.History.InvertedIndex.Accessors = 0
 		d.History.Accessors = 0

--- a/db/state/snap_repo.go
+++ b/db/state/snap_repo.go
@@ -12,6 +12,7 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/recsplit"
 	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/db/version"
 )
 
@@ -40,7 +41,7 @@ type SnapshotRepo struct {
 
 	cfg       *SnapshotConfig
 	schema    SnapNameSchema
-	accessors Accessors
+	accessors statecfg.Accessors
 	stepSize  uint64
 
 	logger log.Logger
@@ -166,7 +167,7 @@ func (f *SnapshotRepo) GetFreezingRange(from RootNum, to RootNum) (freezeFrom Ro
 }
 
 func (f *SnapshotRepo) DirtyFilesWithNoBtreeAccessors() (l []*FilesItem) {
-	if !f.accessors.Has(AccessorBTree) {
+	if !f.accessors.Has(statecfg.AccessorBTree) {
 		return nil
 	}
 	p := f.schema
@@ -181,7 +182,7 @@ func (f *SnapshotRepo) DirtyFilesWithNoBtreeAccessors() (l []*FilesItem) {
 }
 
 func (f *SnapshotRepo) DirtyFilesWithNoHashAccessors() (l []*FilesItem) {
-	if !f.accessors.Has(AccessorHashMap) {
+	if !f.accessors.Has(statecfg.AccessorHashMap) {
 		return nil
 	}
 	p := f.schema
@@ -355,7 +356,7 @@ func (f *SnapshotRepo) openDirtyFiles() error {
 
 			accessors := p.AccessorList()
 
-			if item.index == nil && accessors.Has(AccessorHashMap) {
+			if item.index == nil && accessors.Has(statecfg.AccessorHashMap) {
 				fPathGen := p.AccessorIdxFile(version.V1_0, RootNum(item.startTxNum), RootNum(item.endTxNum), 0)
 				fPathMask, _ := version.ReplaceVersionWithMask(fPathGen)
 				fPath, _, ok, err := version.FindFilesWithVersionsByPattern(fPathMask)
@@ -373,7 +374,7 @@ func (f *SnapshotRepo) openDirtyFiles() error {
 				}
 			}
 
-			if item.bindex == nil && accessors.Has(AccessorBTree) {
+			if item.bindex == nil && accessors.Has(statecfg.AccessorBTree) {
 				fPathGen := p.BtIdxFile(version.V1_0, RootNum(item.startTxNum), RootNum(item.endTxNum))
 				fPathMask, _ := version.ReplaceVersionWithMask(fPathGen)
 				fPath, _, ok, err := version.FindFilesWithVersionsByPattern(fPathMask)
@@ -390,7 +391,7 @@ func (f *SnapshotRepo) openDirtyFiles() error {
 					}
 				}
 			}
-			if item.existence == nil && accessors.Has(AccessorExistence) {
+			if item.existence == nil && accessors.Has(statecfg.AccessorExistence) {
 				fPathGen := p.ExistenceFile(version.V1_0, RootNum(item.startTxNum), RootNum(item.endTxNum))
 				fPathMask, _ := version.ReplaceVersionWithMask(fPathGen)
 				fPath, _, ok, err := version.FindFilesWithVersionsByPattern(fPathMask)

--- a/db/state/snap_repo_test.go
+++ b/db/state/snap_repo_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/recsplit"
 	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/db/version"
 )
 
@@ -34,7 +35,7 @@ func TestOpenFolder_AccountsDomain(t *testing.T) {
 
 	dirs := datadir.New(t.TempDir())
 	name, repo := setupEntity(t, dirs, func(stepSize uint64, dirs datadir.Dirs) (name string, schema SnapNameSchema) {
-		accessors := AccessorBTree | AccessorExistence
+		accessors := statecfg.AccessorBTree | statecfg.AccessorExistence
 		name = "accounts"
 		schema = NewE3SnapSchemaBuilder(accessors, stepSize).
 			Data(dirs.SnapDomain, name, DataExtensionKv, seg.CompressNone).
@@ -87,7 +88,7 @@ func TestOpenFolder_CodeII(t *testing.T) {
 
 	dirs := datadir.New(t.TempDir())
 	name, repo := setupEntity(t, dirs, func(stepSize uint64, dirs datadir.Dirs) (name string, schema SnapNameSchema) {
-		accessors := AccessorHashMap
+		accessors := statecfg.AccessorHashMap
 		name = "code"
 		schema = NewE3SnapSchemaBuilder(accessors, stepSize).
 			Data(dirs.SnapIdx, name, DataExtensionEf, seg.CompressNone).
@@ -143,7 +144,7 @@ func TestIntegrateDirtyFile(t *testing.T) {
 	// check presence of dirty file
 	dirs := datadir.New(t.TempDir())
 	_, repo := setupEntity(t, dirs, func(stepSize uint64, dirs datadir.Dirs) (name string, schema SnapNameSchema) {
-		accessors := AccessorBTree | AccessorExistence
+		accessors := statecfg.AccessorBTree | statecfg.AccessorExistence
 		name = "accounts"
 		schema = NewE3SnapSchemaBuilder(accessors, stepSize).
 			Data(dirs.SnapDomain, name, DataExtensionKv, seg.CompressNone).
@@ -189,7 +190,7 @@ func TestCloseFilesAfterRootNum(t *testing.T) {
 	// set various root numbers and check if the right files are closed
 	dirs := datadir.New(t.TempDir())
 	_, repo := setupEntity(t, dirs, func(stepSize uint64, dirs datadir.Dirs) (name string, schema SnapNameSchema) {
-		accessors := AccessorBTree | AccessorExistence
+		accessors := statecfg.AccessorBTree | statecfg.AccessorExistence
 		name = "accounts"
 		schema = NewE3SnapSchemaBuilder(accessors, stepSize).
 			Data(dirs.SnapDomain, name, DataExtensionKv, seg.CompressNone).
@@ -243,7 +244,7 @@ func TestMergeRangeSnapRepo(t *testing.T) {
 
 	dirs := datadir.New(t.TempDir())
 	_, repo := setupEntity(t, dirs, func(stepSize uint64, dirs datadir.Dirs) (name string, schema SnapNameSchema) {
-		accessors := AccessorBTree | AccessorExistence
+		accessors := statecfg.AccessorBTree | statecfg.AccessorExistence
 		name = "accounts"
 		schema = NewE3SnapSchemaBuilder(accessors, stepSize).
 			Data(dirs.SnapDomain, name, DataExtensionKv, seg.CompressNone).
@@ -319,7 +320,7 @@ func TestMergeRangeSnapRepo(t *testing.T) {
 func TestReferencingIntegrityChecker(t *testing.T) {
 	dirs := datadir.New(t.TempDir())
 	_, accountsR := setupEntity(t, dirs, func(stepSize uint64, dirs datadir.Dirs) (name string, schema SnapNameSchema) {
-		accessors := AccessorBTree | AccessorExistence
+		accessors := statecfg.AccessorBTree | statecfg.AccessorExistence
 		name = "accounts"
 		schema = NewE3SnapSchemaBuilder(accessors, stepSize).
 			Data(dirs.SnapDomain, name, DataExtensionKv, seg.CompressNone).
@@ -331,7 +332,7 @@ func TestReferencingIntegrityChecker(t *testing.T) {
 	defer accountsR.Close()
 
 	_, commitmentR := setupEntity(t, dirs, func(stepSize uint64, dirs datadir.Dirs) (name string, schema SnapNameSchema) {
-		accessors := AccessorHashMap
+		accessors := statecfg.AccessorHashMap
 		name = "commitment"
 		schema = NewE3SnapSchemaBuilder(accessors, stepSize).
 			Data(dirs.SnapDomain, name, DataExtensionKv, seg.CompressNone).
@@ -433,7 +434,7 @@ func TestRecalcVisibleFilesAfterMerge(t *testing.T) {
 
 	dirs := datadir.New(t.TempDir())
 	_, repo := setupEntity(t, dirs, func(stepSize uint64, dirs datadir.Dirs) (name string, schema SnapNameSchema) {
-		accessors := AccessorBTree | AccessorExistence
+		accessors := statecfg.AccessorBTree | statecfg.AccessorExistence
 		name = "accounts"
 		schema = NewE3SnapSchemaBuilder(accessors, stepSize).
 			Data(dirs.SnapDomain, name, DataExtensionKv, seg.CompressNone).
@@ -614,13 +615,13 @@ func populateFiles2(t *testing.T, dirs datadir.Dirs, repo *SnapshotRepo, ranges 
 	for _, r := range ranges {
 		from, to := RootNum(r.fromStep*repo.stepSize), RootNum(r.toStep*repo.stepSize)
 		allFiles = append(allFiles, repo.schema.DataFile(v, from, to))
-		if acc.Has(AccessorBTree) {
+		if acc.Has(statecfg.AccessorBTree) {
 			allFiles = append(allFiles, repo.schema.BtIdxFile(v, from, to))
 		}
-		if acc.Has(AccessorExistence) {
+		if acc.Has(statecfg.AccessorExistence) {
 			allFiles = append(allFiles, repo.schema.ExistenceFile(v, from, to))
 		}
-		if acc.Has(AccessorHashMap) {
+		if acc.Has(statecfg.AccessorHashMap) {
 			allFiles = append(allFiles, repo.schema.AccessorIdxFile(v, from, to, 0))
 		}
 	}
@@ -673,7 +674,7 @@ func populateFiles(t *testing.T, dirs datadir.Dirs, schema SnapNameSchema, allFi
 			require.NoError(t, err)
 
 			r := seg.NewReader(seg3.MakeGetter(), seg.CompressNone)
-			btindex, err := CreateBtreeIndexWithDecompressor(filename, 128, r, uint32(1), background.NewProgressSet(), dirs.Tmp, log.New(), true, AccessorBTree|AccessorExistence)
+			btindex, err := CreateBtreeIndexWithDecompressor(filename, 128, r, uint32(1), background.NewProgressSet(), dirs.Tmp, log.New(), true, statecfg.AccessorBTree|statecfg.AccessorExistence)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/db/state/snap_schema.go
+++ b/db/state/snap_schema.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/db/version"
 )
 
@@ -23,7 +24,7 @@ import (
 // each entity holds one schema.
 type SnapNameSchema interface {
 	DataTag() string
-	AccessorList() Accessors
+	AccessorList() statecfg.Accessors
 	Parse(filename string) (f *SnapInfo, ok bool)
 
 	// these give out full filepath, not just filename
@@ -57,7 +58,7 @@ type E2SnapSchema struct {
 	dataFileTag   string
 	indexFileTags []string
 
-	accessors Accessors
+	accessors statecfg.Accessors
 
 	// caches
 	dataFileMetadata      *_fileMetadata
@@ -81,7 +82,7 @@ func NewE2SnapSchemaWithStep(dirs datadir.Dirs, dataFileTag string, indexFileTag
 		stepSize:      stepSize,
 		dataFileTag:   dataFileTag,
 		indexFileTags: indexFileTags,
-		accessors:     AccessorHashMap,
+		accessors:     statecfg.AccessorHashMap,
 
 		dataFileMetadata: &_fileMetadata{
 			folder:    dirs.Snap,
@@ -100,7 +101,7 @@ func (s *E2SnapSchema) DataTag() string {
 	return s.dataFileTag
 }
 
-func (a *E2SnapSchema) AccessorList() Accessors {
+func (a *E2SnapSchema) AccessorList() statecfg.Accessors {
 	return a.accessors
 }
 
@@ -200,7 +201,7 @@ type E3SnapSchema struct {
 	dataExtension       DataExtension
 	dataFileTag         string
 	dataFileCompression seg.FileCompression
-	accessors           Accessors
+	accessors           statecfg.Accessors
 
 	accessorIdxExtension AccessorExtension
 	// caches
@@ -214,7 +215,7 @@ type E3SnapSchemaBuilder struct {
 	e *E3SnapSchema
 }
 
-func NewE3SnapSchemaBuilder(accessors Accessors, stepSize uint64) *E3SnapSchemaBuilder {
+func NewE3SnapSchemaBuilder(accessors statecfg.Accessors, stepSize uint64) *E3SnapSchemaBuilder {
 	eschema := E3SnapSchemaBuilder{
 		e: &E3SnapSchema{},
 	}
@@ -282,13 +283,13 @@ func (b *E3SnapSchemaBuilder) Build() *E3SnapSchema {
 		panic("dataFileMetadata not set")
 	}
 
-	e.btIdxFileMetadata = b.checkPresence(AccessorBTree, e.btIdxFileMetadata)
-	e.indexFileMetadata = b.checkPresence(AccessorHashMap, e.indexFileMetadata)
-	e.existenceFileMetadata = b.checkPresence(AccessorExistence, e.existenceFileMetadata)
+	e.btIdxFileMetadata = b.checkPresence(statecfg.AccessorBTree, e.btIdxFileMetadata)
+	e.indexFileMetadata = b.checkPresence(statecfg.AccessorHashMap, e.indexFileMetadata)
+	e.existenceFileMetadata = b.checkPresence(statecfg.AccessorExistence, e.existenceFileMetadata)
 	return e
 }
 
-func (b *E3SnapSchemaBuilder) checkPresence(check Accessors, met *_fileMetadata) *_fileMetadata {
+func (b *E3SnapSchemaBuilder) checkPresence(check statecfg.Accessors, met *_fileMetadata) *_fileMetadata {
 	if b.e.accessors&check == 0 && met != nil {
 		panic(fmt.Sprintf("accessor %s is not meant to be supported for %s", check, b.e.dataFileTag))
 	} else if b.e.accessors&check != 0 && met == nil {
@@ -359,7 +360,7 @@ func (s *E3SnapSchema) DataFile(version Version, from, to RootNum) string {
 
 func (s *E3SnapSchema) AccessorIdxFile(version Version, from, to RootNum, idxPos uint64) string {
 	if !s.indexFileMetadata.supported {
-		panic(fmt.Sprintf("%s not supported for %s", AccessorHashMap, s.dataFileTag))
+		panic(fmt.Sprintf("%s not supported for %s", statecfg.AccessorHashMap, s.dataFileTag))
 	}
 	if idxPos > 0 {
 		panic("e3 accessor idx pos should be 0")
@@ -369,14 +370,14 @@ func (s *E3SnapSchema) AccessorIdxFile(version Version, from, to RootNum, idxPos
 
 func (s *E3SnapSchema) BtIdxFile(version Version, from, to RootNum) string {
 	if !s.btIdxFileMetadata.supported {
-		panic(fmt.Sprintf("%s not supported for %s", AccessorBTree, s.dataFileTag))
+		panic(fmt.Sprintf("%s not supported for %s", statecfg.AccessorBTree, s.dataFileTag))
 	}
 	return filepath.Join(s.btIdxFileMetadata.folder, fmt.Sprintf("%s-%s.%d-%d.bt", version, s.dataFileTag, from/RootNum(s.stepSize), to/RootNum(s.stepSize)))
 }
 
 func (s *E3SnapSchema) ExistenceFile(version Version, from, to RootNum) string {
 	if !s.existenceFileMetadata.supported {
-		panic(fmt.Sprintf("%s not supported for %s", AccessorExistence, s.dataFileTag))
+		panic(fmt.Sprintf("%s not supported for %s", statecfg.AccessorExistence, s.dataFileTag))
 	}
 	return filepath.Join(s.existenceFileMetadata.folder, fmt.Sprintf("%s-%s.%d-%d.kvei", version, s.dataFileTag, from/RootNum(s.stepSize), to/RootNum(s.stepSize)))
 }
@@ -385,7 +386,7 @@ func (s *E3SnapSchema) DataTag() string {
 	return s.dataFileTag
 }
 
-func (s *E3SnapSchema) AccessorList() Accessors {
+func (s *E3SnapSchema) AccessorList() statecfg.Accessors {
 	return s.accessors
 }
 

--- a/db/state/snap_schema_test.go
+++ b/db/state/snap_schema_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/erigontech/erigon/db/config3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/db/version"
 )
 
@@ -106,7 +107,7 @@ func TestE3SnapSchemaForDomain1(t *testing.T) {
 
 	dirs := setup(t)
 	stepSize := uint64(config3.DefaultStepSize)
-	p := NewE3SnapSchemaBuilder(AccessorBTree|AccessorExistence, stepSize).
+	p := NewE3SnapSchemaBuilder(statecfg.AccessorBTree|statecfg.AccessorExistence, stepSize).
 		Data(dirs.SnapDomain, "accounts", DataExtensionKv, seg.CompressKeys).
 		BtIndex().
 		Existence().Build()
@@ -163,7 +164,7 @@ func TestE3SnapSchemaForDomain1(t *testing.T) {
 func TestE3SnapSchemaForCommitmentDomain(t *testing.T) {
 	dirs := setup(t)
 	stepSize := uint64(config3.DefaultStepSize)
-	p := NewE3SnapSchemaBuilder(AccessorHashMap, stepSize).
+	p := NewE3SnapSchemaBuilder(statecfg.AccessorHashMap, stepSize).
 		Data(dirs.SnapDomain, "commitments", DataExtensionKv, seg.CompressKeys).
 		Accessor(dirs.SnapDomain).Build()
 
@@ -209,7 +210,7 @@ func TestE3SnapSchemaForCommitmentDomain(t *testing.T) {
 func TestE3SnapSchemaForHistory(t *testing.T) {
 	dirs := setup(t)
 	stepSize := uint64(config3.DefaultStepSize)
-	p := NewE3SnapSchemaBuilder(AccessorHashMap, stepSize).
+	p := NewE3SnapSchemaBuilder(statecfg.AccessorHashMap, stepSize).
 		Data(dirs.SnapHistory, "accounts", DataExtensionV, seg.CompressKeys).
 		Accessor(dirs.SnapAccessors).Build()
 
@@ -258,7 +259,7 @@ func TestE3SnapSchemaForHistory(t *testing.T) {
 func TestE3SnapSchemaForII(t *testing.T) {
 	dirs := setup(t)
 	stepSize := uint64(config3.DefaultStepSize)
-	p := NewE3SnapSchemaBuilder(AccessorHashMap, stepSize).
+	p := NewE3SnapSchemaBuilder(statecfg.AccessorHashMap, stepSize).
 		Data(dirs.SnapIdx, "logaddrs", DataExtensionEf, seg.CompressNone).
 		Accessor(dirs.SnapAccessors).Build()
 

--- a/db/state/statecfg/accessors.go
+++ b/db/state/statecfg/accessors.go
@@ -1,4 +1,4 @@
-package state
+package statecfg
 
 import "strings"
 

--- a/db/state/statecfg/statecfg.go
+++ b/db/state/statecfg/statecfg.go
@@ -1,0 +1,1 @@
+package statecfg

--- a/db/state/version_schema.go
+++ b/db/state/version_schema.go
@@ -7,63 +7,6 @@ import (
 
 func InitSchemas() {
 	InitSchemasGen()
-	//Schema.AccountsDomain.version.DataKV = version.V1_1_standart
-	//Schema.AccountsDomain.version.AccessorBT = version.V1_1_standart
-	//Schema.AccountsDomain.version.AccessorKVEI = version.V1_1_standart
-	//Schema.AccountsDomain.hist.version.DataV = version.V1_1_standart
-	//Schema.AccountsDomain.hist.version.AccessorVI = version.V1_1_standart
-	//Schema.AccountsDomain.hist.iiCfg.version.DataEF = version.V2_0_standart
-	//Schema.AccountsDomain.hist.iiCfg.version.AccessorEFI = version.V2_0_standart
-	//
-	//Schema.StorageDomain.version.DataKV = version.V1_1_standart
-	//Schema.StorageDomain.version.AccessorBT = version.V1_1_standart
-	//Schema.StorageDomain.version.AccessorKVEI = version.V1_1_standart
-	//Schema.StorageDomain.hist.version.DataV = version.V1_1_standart
-	//Schema.StorageDomain.hist.version.AccessorVI = version.V1_1_standart
-	//Schema.StorageDomain.hist.iiCfg.version.DataEF = version.V2_0_standart
-	//Schema.StorageDomain.hist.iiCfg.version.AccessorEFI = version.V2_0_standart
-	//
-	//Schema.CodeDomain.version.DataKV = version.V1_1_standart
-	//Schema.CodeDomain.version.AccessorBT = version.V1_1_standart
-	//Schema.CodeDomain.version.AccessorKVEI = version.V1_1_standart
-	//Schema.CodeDomain.hist.version.DataV = version.V1_1_standart
-	//Schema.CodeDomain.hist.version.AccessorVI = version.V1_1_standart
-	//Schema.CodeDomain.hist.iiCfg.version.DataEF = version.V2_0_standart
-	//Schema.CodeDomain.hist.iiCfg.version.AccessorEFI = version.V2_0_standart
-	//
-	//Schema.CommitmentDomain.version.DataKV = version.V1_1_standart
-	//Schema.CommitmentDomain.version.AccessorKVI = version.V2_0_standart
-	//Schema.CommitmentDomain.hist.version.DataV = version.V1_1_standart
-	//Schema.CommitmentDomain.hist.version.AccessorVI = version.V1_1_standart
-	//Schema.CommitmentDomain.hist.iiCfg.version.DataEF = version.V2_0_standart
-	//Schema.CommitmentDomain.hist.iiCfg.version.AccessorEFI = version.V2_0_standart
-	//
-	//Schema.ReceiptDomain.version.DataKV = version.V2_1_standart
-	//Schema.ReceiptDomain.version.AccessorBT = version.V1_2_standart
-	//Schema.ReceiptDomain.version.AccessorKVEI = version.V1_2_standart
-	//Schema.ReceiptDomain.hist.version.DataV = version.V2_1_standart
-	//Schema.ReceiptDomain.hist.version.AccessorVI = version.V1_2_standart
-	//Schema.ReceiptDomain.hist.iiCfg.version.DataEF = version.V2_1_standart
-	//Schema.ReceiptDomain.hist.iiCfg.version.AccessorEFI = version.V2_1_standart
-	//
-	//Schema.RCacheDomain.version.DataKV = version.V2_0_standart
-	//Schema.RCacheDomain.version.AccessorKVI = version.V2_0_standart
-	//Schema.RCacheDomain.hist.version.DataV = version.V2_0_standart
-	//Schema.RCacheDomain.hist.version.AccessorVI = version.V1_1_standart
-	//Schema.RCacheDomain.hist.iiCfg.version.DataEF = version.V2_0_standart
-	//Schema.RCacheDomain.hist.iiCfg.version.AccessorEFI = version.V2_0_standart
-	//
-	//Schema.LogAddrIdx.version.DataEF = version.V2_1_standart
-	//Schema.LogAddrIdx.version.AccessorEFI = version.V2_1_standart
-	//
-	//Schema.LogTopicIdx.version.DataEF = version.V2_1_standart
-	//Schema.LogTopicIdx.version.AccessorEFI = version.V2_1_standart
-	//
-	//Schema.TracesFromIdx.version.DataEF = version.V2_1_standart
-	//Schema.TracesFromIdx.version.AccessorEFI = version.V2_1_standart
-	//
-	//Schema.TracesToIdx.version.DataEF = version.V2_1_standart
-	//Schema.TracesToIdx.version.AccessorEFI = version.V2_1_standart
 
 	SchemeMinSupportedVersions = map[string]map[string]snaptype.Version{
 		"accounts": {

--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -64,6 +64,7 @@ import (
 	"github.com/erigontech/erigon/db/snaptype"
 	"github.com/erigontech/erigon/db/snaptype2"
 	"github.com/erigontech/erigon/db/state"
+	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/db/state/stats"
 	"github.com/erigontech/erigon/db/version"
 	"github.com/erigontech/erigon/diagnostics"
@@ -1074,7 +1075,7 @@ func checkIfStateSnapshotsPublishable(dirs datadir.Dirs) error {
 
 			oldVersion = newVersion
 			// check that the index file exist
-			if state.Schema.GetDomainCfg(snapType).Accessors.Has(state.AccessorBTree) {
+			if state.Schema.GetDomainCfg(snapType).Accessors.Has(statecfg.AccessorBTree) {
 				newVersion = state.Schema.GetDomainCfg(snapType).GetVersions().Domain.AccessorBT.Current
 				fileName := strings.Replace(expectedFileName, ".kv", ".bt", 1)
 				fileName = version.ReplaceVersion(fileName, oldVersion, newVersion)
@@ -1086,7 +1087,7 @@ func checkIfStateSnapshotsPublishable(dirs datadir.Dirs) error {
 					return fmt.Errorf("missing file %s", fileName)
 				}
 			}
-			if state.Schema.GetDomainCfg(snapType).Accessors.Has(state.AccessorExistence) {
+			if state.Schema.GetDomainCfg(snapType).Accessors.Has(statecfg.AccessorExistence) {
 				newVersion = state.Schema.GetDomainCfg(snapType).GetVersions().Domain.AccessorKVEI.Current
 				fileName := strings.Replace(expectedFileName, ".kv", ".kvei", 1)
 				fileName = version.ReplaceVersion(fileName, oldVersion, newVersion)
@@ -1098,7 +1099,7 @@ func checkIfStateSnapshotsPublishable(dirs datadir.Dirs) error {
 					return fmt.Errorf("missing file %s", fileName)
 				}
 			}
-			if state.Schema.GetDomainCfg(snapType).Accessors.Has(state.AccessorHashMap) {
+			if state.Schema.GetDomainCfg(snapType).Accessors.Has(statecfg.AccessorHashMap) {
 				newVersion = state.Schema.GetDomainCfg(snapType).GetVersions().Domain.AccessorKVI.Current
 				fileName := strings.Replace(expectedFileName, ".kv", ".kvi", 1)
 				fileName = version.ReplaceVersion(fileName, oldVersion, newVersion)


### PR DESCRIPTION
moved `salt` out of config objects 
and `dirs` too (not compile-time-known field)