### PR TITLE
Upload all logs generated by erigon node in CI

### DIFF
--- a/.github/workflows/qa-constrained-tip-tracking.yml
+++ b/.github/workflows/qa-constrained-tip-tracking.yml
@@ -123,9 +123,9 @@ jobs:
       if: steps.test_step.outputs.test_executed == 'true'
       uses: actions/upload-artifact@v4
       with:
-        name: erigon-log-${{ env.CHAIN }}
+        name: erigon-logs-${{ env.CHAIN }}
         path: |
-          ${{ env.ERIGON_REFERENCE_DATA_DIR }}/logs/erigon.log
+          ${{ env.ERIGON_REFERENCE_DATA_DIR }}/logs/
           ${{ env.ERIGON_REFERENCE_DATA_DIR }}/proc_stat.log
 
     - name: Restore Erigon Chaindata Directory

--- a/.github/workflows/qa-snap-download.yml
+++ b/.github/workflows/qa-snap-download.yml
@@ -99,7 +99,7 @@ jobs:
         name: test-results
         path: |
           ${{ github.workspace }}/result-${{ env.CHAIN }}.json
-          ${{ github.workspace }}/erigon_data/logs/erigon.log
+          ${{ github.workspace }}/erigon_data/logs/
 
     - name: Clean up Erigon data directory
       if: always()

--- a/.github/workflows/qa-sync-from-scratch-minimal-node.yml
+++ b/.github/workflows/qa-sync-from-scratch-minimal-node.yml
@@ -99,7 +99,7 @@ jobs:
           name: test-results-${{ env.CHAIN }}
           path: |
             ${{ github.workspace }}/result-${{ env.CHAIN }}.json
-            ${{ github.workspace }}/erigon_data/logs/erigon.log
+            ${{ github.workspace }}/erigon_data/logs/
 
       - name: Clean up Erigon data directory
         if: always()

--- a/.github/workflows/qa-sync-from-scratch.yml
+++ b/.github/workflows/qa-sync-from-scratch.yml
@@ -99,7 +99,7 @@ jobs:
         name: test-results-${{ env.CHAIN }}
         path: |
           ${{ github.workspace }}/result-${{ env.CHAIN }}.json
-          ${{ github.workspace }}/erigon_data/logs/erigon.log
+          ${{ github.workspace }}/erigon_data/logs/
 
     - name: Clean up Erigon data directory
       if: always()

--- a/.github/workflows/qa-sync-with-externalcl.yml
+++ b/.github/workflows/qa-sync-with-externalcl.yml
@@ -109,7 +109,7 @@ jobs:
           name: test-results-${{ matrix.client }}-${{ matrix.chain }}
           path: |
             ${{ github.workspace }}/result-${{ matrix.chain }}.json
-            ${{ github.workspace }}/erigon_data/logs/erigon.log
+            ${{ github.workspace }}/erigon_data/logs/
             ${{ github.workspace }}/consensus/data/beacon/logs/beacon.log
 
       - name: Upload test results (Prysm)
@@ -119,7 +119,7 @@ jobs:
           name: test-results-${{ matrix.client }}-${{ matrix.chain }}
           path: |
             ${{ github.workspace }}/result-${{ matrix.chain }}.json
-            ${{ github.workspace }}/erigon_data/logs/erigon.log
+            ${{ github.workspace }}/erigon_data/logs/
             ${{ github.workspace }}/consensus/data/beacon.log
 
       - name: Clean up Erigon data directory

--- a/.github/workflows/qa-tip-tracking-gnosis.yml
+++ b/.github/workflows/qa-tip-tracking-gnosis.yml
@@ -117,12 +117,12 @@ jobs:
         name: test-results
         path: ${{ github.workspace }}/result-${{ env.CHAIN }}.json
 
-    - name: Upload erigon log
+    - name: Upload erigon logs
       if: steps.test_step.outputs.test_executed == 'true'
       uses: actions/upload-artifact@v4
       with:
-        name: erigon-log
-        path: ${{ env.ERIGON_TESTBED_DATA_DIR }}/logs/erigon.log
+        name: erigon-logs
+        path: ${{ env.ERIGON_TESTBED_DATA_DIR }}/logs/
 
     - name: Upload metric plots
       if: steps.test_step.outputs.test_executed == 'true'

--- a/.github/workflows/qa-tip-tracking-polygon.yml
+++ b/.github/workflows/qa-tip-tracking-polygon.yml
@@ -117,12 +117,12 @@ jobs:
         name: test-results
         path: ${{ github.workspace }}/result-${{ env.CHAIN }}.json
 
-    - name: Upload erigon log
+    - name: Upload erigon logs
       if: steps.test_step.outputs.test_executed == 'true'
       uses: actions/upload-artifact@v4
       with:
-        name: erigon-log
-        path: ${{ env.ERIGON_TESTBED_DATA_DIR }}/logs/erigon.log
+        name: erigon-logs
+        path: ${{ env.ERIGON_TESTBED_DATA_DIR }}/logs/
 
     - name: Upload metric plots
       if: steps.test_step.outputs.test_executed == 'true'

--- a/.github/workflows/qa-tip-tracking.yml
+++ b/.github/workflows/qa-tip-tracking.yml
@@ -175,12 +175,12 @@ jobs:
         name: test-results
         path: ${{ github.workspace }}/result-${{ env.CHAIN }}.json
 
-    - name: Upload erigon log
+    - name: Upload erigon logs
       if: steps.test_step.outputs.test_executed == 'true'
       uses: actions/upload-artifact@v4
       with:
-        name: erigon-log
-        path: ${{ env.ERIGON_TESTBED_DATA_DIR }}/logs/erigon.log
+        name: erigon-logs
+        path: ${{ env.ERIGON_TESTBED_DATA_DIR }}/logs/
 
     - name: Upload metric plots
       if: steps.test_step.outputs.test_executed == 'true'
@@ -246,12 +246,12 @@ jobs:
         name: torrent-client-status-downgrade-test
         path: torrent-client-status.txt
 
-    - name: Upload erigon log of the downgrade test
+    - name: Upload erigon logs of the downgrade test
       if: steps.downgrade_test_step.outputs.test_executed == 'true'
       uses: actions/upload-artifact@v4
       with:
-        name: erigon-log-downgrade-test
-        path: ${{ env.ERIGON_TESTBED_DATA_DIR }}/logs/erigon.log
+        name: erigon-logs-downgrade-test
+        path: ${{ env.ERIGON_TESTBED_DATA_DIR }}/logs/
 
     - name: Delete Erigon Testbed Data Directory
       if: ${{ always() }}


### PR DESCRIPTION
From QA meeting, we're missing the torrent logs for a snapshot download CI stalling.