### PR TITLE
snapshotsync: fix minimal nodes downloading all snapshots

### DIFF
--- a/turbo/snapshotsync/snapshotsync.go
+++ b/turbo/snapshotsync/snapshotsync.go
@@ -449,6 +449,10 @@ func SyncSnapshots(
 				continue
 			}
 
+			if _, ok := blackListForPruning[p.Name]; ok {
+				continue
+			}
+
 			downloadRequest = append(downloadRequest, DownloadRequest{
 				Path:        p.Name,
 				TorrentHash: p.Hash,


### PR DESCRIPTION
fixes https://github.com/erigontech/erigon/issues/16852

checking the `blackListForPruning` was accidentally removed in https://github.com/erigontech/erigon/pull/16648

diff of Downloader.Add logs (before/after fix): https://www.diffchecker.com/MoE9EsyG/