### PR TITLE
Fix DOWNLOADER_DISABLE_HTTP2 not working

### DIFF
--- a/erigon-db/downloader/downloader.go
+++ b/erigon-db/downloader/downloader.go
@@ -303,6 +303,7 @@ func configureHttp2(t *http.Transport) {
 	if os.Getenv("DOWNLOADER_DISABLE_HTTP2") != "" {
 		// Disable h2 being added automatically.
 		g.MakeMap(&t.TLSNextProto)
+		return
 	}
 	// Don't set the http2.Transport as the RoundTripper. It's hooked into the http.Transport by
 	// this call. Need to use external http2 library to get access to some config fields that


### PR DESCRIPTION
Accidentally broke this in 40ea287b3a43404eaff2559ec9f1b1150b4f2529.

It's not affecting normal operation since most users aren't running with this flag but it's there as an option.