### PR TITLE
cherry-pick: VeBlop: change span scraper timeout to 200 ms (#16877)

### DIFF
--- a/polygon/heimdall/service.go
+++ b/polygon/heimdall/service.go
@@ -92,7 +92,7 @@ func NewService(config ServiceConfig) *Service {
 		"spans",
 		store.Spans(),
 		spanFetcher,
-		1*time.Second,
+		200*time.Millisecond,
 		poshttp.TransientErrors,
 		logger,
 	)


### PR DESCRIPTION
Cherr-pick of https://github.com/erigontech/erigon/pull/16877

Per VeBlop specs (https://hackmd.io/pG_1DC3YSoaFTOngy92ffw) the span check interval is 200 ms.