### PR TITLE
tests: remove `agg scandir` bottleneck

### DIFF
--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -304,7 +304,36 @@ func (a *Aggregator) OpenFolder() error {
 	return nil
 }
 
+// TODO: convert this func to `map` or struct instead of 4 return params
+func scanDirs(dirs datadir.Dirs) (r *ScanDirsResult, err error) {
+	r = &ScanDirsResult{}
+	r.iiFiles, err = filesFromDir(dirs.SnapIdx)
+	if err != nil {
+		return
+	}
+	r.iiFiles, err = filesFromDir(dirs.SnapHistory)
+	if err != nil {
+		return
+	}
+	r.domainFiles, err = filesFromDir(dirs.SnapDomain)
+	if err != nil {
+		return
+	}
+	return r, nil
+}
+
+type ScanDirsResult struct {
+	domainFiles  []string
+	historyFiles []string
+	iiFiles      []string
+}
+
 func (a *Aggregator) openFolder() error {
+	scanDirsRes, err := scanDirs(a.dirs)
+	if err != nil {
+		return err
+	}
+
 	eg := &errgroup.Group{}
 	for _, d := range a.d {
 		if d.Disable {
@@ -318,7 +347,7 @@ func (a *Aggregator) openFolder() error {
 				return a.ctx.Err()
 			default:
 			}
-			return d.openFolder()
+			return d.openFolder(scanDirsRes)
 		})
 	}
 	for _, ii := range a.iis {
@@ -326,7 +355,7 @@ func (a *Aggregator) openFolder() error {
 			continue
 		}
 		ii := ii
-		eg.Go(func() error { return ii.openFolder() })
+		eg.Go(func() error { return ii.openFolder(scanDirsRes) })
 	}
 	if err := eg.Wait(); err != nil {
 		return fmt.Errorf("openFolder: %w", err)

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -311,7 +311,7 @@ func scanDirs(dirs datadir.Dirs) (r *ScanDirsResult, err error) {
 	if err != nil {
 		return
 	}
-	r.iiFiles, err = filesFromDir(dirs.SnapHistory)
+	r.historyFiles, err = filesFromDir(dirs.SnapHistory)
 	if err != nil {
 		return
 	}

--- a/db/state/dirty_files.go
+++ b/db/state/dirty_files.go
@@ -226,7 +226,7 @@ func (i *FilesItem) closeFilesAndRemove() {
 	}
 }
 
-func scanDirtyFiles(fileNames []string, stepSize uint64, filenameBase, ext string, logger log.Logger) (res []*FilesItem) {
+func filterDirtyFiles(fileNames []string, stepSize uint64, filenameBase, ext string, logger log.Logger) (res []*FilesItem) {
 	re := regexp.MustCompile(`^v(\d+(?:\.\d+)?)-` + filenameBase + `\.(\d+)-(\d+)\.` + ext + `$`)
 	var err error
 

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -231,16 +231,12 @@ func (d *Domain) protectFromHistoryFilesAheadOfDomainFiles() {
 	d.closeFilesAfterStep(d.dirtyFilesEndTxNumMinimax() / d.stepSize)
 }
 
-func (d *Domain) openFolder() error {
+func (d *Domain) openFolder(r *ScanDirsResult) error {
 	if d.Disable {
 		return nil
 	}
 
-	idx, histFiles, domainFiles, err := d.fileNamesOnDisk()
-	if err != nil {
-		return fmt.Errorf("Domain(%s).openFolder: %w", d.FilenameBase, err)
-	}
-	if err := d.OpenList(idx, histFiles, domainFiles); err != nil {
+	if err := d.OpenList(r.iiFiles, r.historyFiles, r.domainFiles); err != nil {
 		return err
 	}
 	return nil
@@ -303,7 +299,7 @@ func (d *Domain) scanDirtyFiles(fileNames []string) (garbageFiles []*FilesItem) 
 	if d.FilenameBase == "" {
 		panic("assert: empty `filenameBase`")
 	}
-	l := scanDirtyFiles(fileNames, d.stepSize, d.FilenameBase, "kv", d.logger)
+	l := filterDirtyFiles(fileNames, d.stepSize, d.FilenameBase, "kv", d.logger)
 	for _, dirtyFile := range l {
 		dirtyFile.frozen = false
 

--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -130,7 +130,9 @@ func TestDomain_OpenFolder(t *testing.T) {
 	err = os.WriteFile(fn, make([]byte, 33), 0644)
 	require.NoError(t, err)
 
-	err = d.openFolder()
+	scanDirsRes, err := scanDirs(d.dirs)
+	require.NoError(t, err)
+	err = d.openFolder(scanDirsRes)
 	require.NoError(t, err)
 	d.Close()
 }
@@ -602,7 +604,9 @@ func TestDomain_ScanFiles(t *testing.T) {
 	dc := d.BeginFilesRo()
 	defer dc.Close()
 	d.closeWhatNotInList([]string{})
-	require.NoError(t, d.openFolder())
+	scanDirsRes, err := scanDirs(d.dirs)
+	require.NoError(t, err)
+	require.NoError(t, d.openFolder(scanDirsRes))
 
 	// Check the history
 	checkHistory(t, db, d, txs)
@@ -994,7 +998,9 @@ func TestDomain_OpenFilesWithDeletions(t *testing.T) {
 	}
 	dom.Close()
 
-	err = dom.openFolder()
+	scanDirsRes, err := scanDirs(dom.dirs)
+	require.NoError(t, err)
+	err = dom.openFolder(scanDirsRes)
 	dom.reCalcVisibleFiles(dom.dirtyFilesEndTxNumMinimax())
 
 	require.NoError(t, err)

--- a/db/state/history.go
+++ b/db/state/history.go
@@ -138,12 +138,8 @@ func (h *History) openList(idxFiles, histNames []string) error {
 	return nil
 }
 
-func (h *History) openFolder() error {
-	idxFiles, histFiles, _, err := h.fileNamesOnDisk()
-	if err != nil {
-		return err
-	}
-	return h.openList(idxFiles, histFiles)
+func (h *History) openFolder(scanDirsRes *ScanDirsResult) error {
+	return h.openList(scanDirsRes.iiFiles, scanDirsRes.historyFiles)
 }
 
 func (h *History) scanDirtyFiles(fileNames []string) {
@@ -153,7 +149,7 @@ func (h *History) scanDirtyFiles(fileNames []string) {
 	if h.stepSize == 0 {
 		panic("assert: empty `stepSize`")
 	}
-	for _, dirtyFile := range scanDirtyFiles(fileNames, h.stepSize, h.FilenameBase, "v", h.logger) {
+	for _, dirtyFile := range filterDirtyFiles(fileNames, h.stepSize, h.FilenameBase, "v", h.logger) {
 		if _, has := h.dirtyFiles.Get(dirtyFile); !has {
 			h.dirtyFiles.Set(dirtyFile)
 		}

--- a/db/state/history_test.go
+++ b/db/state/history_test.go
@@ -982,7 +982,9 @@ func TestHistoryScanFiles(t *testing.T) {
 		hc := h.BeginFilesRo()
 		defer hc.Close()
 		// Recreate domain and re-scan the files
-		require.NoError(h.openFolder())
+		scanDirsRes, err := scanDirs(h.dirs)
+		require.NoError(err)
+		require.NoError(h.openFolder(scanDirsRes))
 		// Check the history
 		checkHistoryHistory(t, h, txs)
 	}
@@ -1545,7 +1547,9 @@ func TestHistory_OpenFolder(t *testing.T) {
 	err = os.WriteFile(fn, make([]byte, 33), 0644)
 	require.NoError(t, err)
 
-	err = h.openFolder()
+	scanDirsRes, err := scanDirs(h.dirs)
+	require.NoError(t, err)
+	err = h.openFolder(scanDirsRes)
 	require.NoError(t, err)
 	h.Close()
 }

--- a/db/state/inverted_index.go
+++ b/db/state/inverted_index.go
@@ -170,21 +170,6 @@ func filesFromDir(dir string) ([]string, error) {
 	}
 	return filtered, nil
 }
-func (ii *InvertedIndex) fileNamesOnDisk() (idx, hist, domain []string, err error) {
-	idx, err = filesFromDir(ii.dirs.SnapIdx)
-	if err != nil {
-		return
-	}
-	hist, err = filesFromDir(ii.dirs.SnapHistory)
-	if err != nil {
-		return
-	}
-	domain, err = filesFromDir(ii.dirs.SnapDomain)
-	if err != nil {
-		return
-	}
-	return
-}
 
 func (ii *InvertedIndex) openList(fNames []string) error {
 	ii.closeWhatNotInList(fNames)
@@ -195,15 +180,11 @@ func (ii *InvertedIndex) openList(fNames []string) error {
 	return nil
 }
 
-func (ii *InvertedIndex) openFolder() error {
+func (ii *InvertedIndex) openFolder(r *ScanDirsResult) error {
 	if ii.Disable {
 		return nil
 	}
-	idxFiles, _, _, err := ii.fileNamesOnDisk()
-	if err != nil {
-		return err
-	}
-	return ii.openList(idxFiles)
+	return ii.openList(r.iiFiles)
 }
 
 func (ii *InvertedIndex) scanDirtyFiles(fileNames []string) {
@@ -213,7 +194,7 @@ func (ii *InvertedIndex) scanDirtyFiles(fileNames []string) {
 	if ii.stepSize == 0 {
 		panic("assert: empty `stepSize`")
 	}
-	for _, dirtyFile := range scanDirtyFiles(fileNames, ii.stepSize, ii.FilenameBase, "ef", ii.logger) {
+	for _, dirtyFile := range filterDirtyFiles(fileNames, ii.stepSize, ii.FilenameBase, "ef", ii.logger) {
 		if _, has := ii.dirtyFiles.Get(dirtyFile); !has {
 			ii.dirtyFiles.Set(dirtyFile)
 		}

--- a/db/state/inverted_index_test.go
+++ b/db/state/inverted_index_test.go
@@ -614,7 +614,10 @@ func TestInvIndexScanFiles(t *testing.T) {
 	require.NoError(err)
 	defer ii.Close()
 	ii.salt.Store(&salt)
-	err = ii.openFolder()
+
+	scanDirsRes, err := scanDirs(ii.dirs)
+	require.NoError(err)
+	err = ii.openFolder(scanDirsRes)
 	require.NoError(err)
 
 	mergeInverted(t, db, ii, txs)
@@ -802,7 +805,9 @@ func TestInvIndex_OpenFolder(t *testing.T) {
 	err = os.WriteFile(fn, make([]byte, 33), 0644)
 	require.NoError(t, err)
 
-	err = ii.openFolder()
+	scanDirsRes, err := scanDirs(ii.dirs)
+	require.NoError(t, err)
+	err = ii.openFolder(scanDirsRes)
 	require.NoError(t, err)
 	ii.Close()
 }

--- a/execution/stages/mock/mock_sentry.go
+++ b/execution/stages/mock/mock_sentry.go
@@ -871,24 +871,8 @@ func (ms *MockSentry) InsertChain(chain *core.ChainPack) error {
 	}
 
 	if ms.sentriesClient.Hd.IsBadHeader(chain.TopBlock.Hash()) {
-		fmt.Printf("a3\n")
 		return fmt.Errorf("block %d %x was invalid", chain.TopBlock.NumberU64(), chain.TopBlock.Hash())
 	}
-	//if ms.HistoryV3 {
-	//if err := ms.agg.BuildFiles(ms.Ctx, ms.DB); err != nil {
-	//	return err
-	//}
-	//if err := ms.DB.UpdateNosync(ms.Ctx, func(tx kv.RwTx) error {
-	//	ms.agg.SetTx(tx)
-	//	if err := ms.agg.Prune(ms.Ctx, math.MaxUint64); err != nil {
-	//		return err
-	//	}
-	//	return nil
-	//}); err != nil {
-	//	return err
-	//}
-	//}
-
 	return nil
 }
 

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -125,7 +125,6 @@ func (bt *BlockTest) Run(t *testing.T) error {
 
 	engine := ethconsensusconfig.CreateConsensusEngineBareBones(context.Background(), config, log.New())
 	m := mock.MockWithGenesisEngine(t, bt.genesis(config), engine, false)
-	defer m.Close()
 
 	bt.br = m.BlockReader
 	// import pre accounts & construct test genesis block & state root


### PR DESCRIPTION
now agg does scandir for each domain/ii. but once per agg.OpenFolder() is enough. 
it was 8% of `go test -run=TestLegacyBlockchain`
next bottlenecks are: `BlockTest.Run -> mock.Mock -> datadir.New -> MkdirAll` and `memdb.Close -> RemoveAll`
