### PR TITLE
remove `nofuzz` build tag

### DIFF
--- a/db/recsplit/eliasfano16/elias_fano_fuzz_test.go
+++ b/db/recsplit/eliasfano16/elias_fano_fuzz_test.go
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Erigon. If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !nofuzz
-
 package eliasfano16
 
 import (

--- a/db/recsplit/eliasfano32/elias_fano_fuzz_test.go
+++ b/db/recsplit/eliasfano32/elias_fano_fuzz_test.go
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Erigon. If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !nofuzz
-
 package eliasfano32
 
 import (

--- a/db/recsplit/recsplit_fuzz_test.go
+++ b/db/recsplit/recsplit_fuzz_test.go
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Erigon. If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !nofuzz
-
 package recsplit
 
 import (

--- a/db/seg/compress_fuzz_test.go
+++ b/db/seg/compress_fuzz_test.go
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Erigon. If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !nofuzz
-
 package seg
 
 import (

--- a/db/seg/patricia/patricia_fuzz_test.go
+++ b/db/seg/patricia/patricia_fuzz_test.go
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Erigon. If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !nofuzz
-
 package patricia
 
 import (

--- a/db/state/aggregator_fuzz_test.go
+++ b/db/state/aggregator_fuzz_test.go
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Erigon. If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !nofuzz
-
 package state
 
 import (

--- a/erigon-lib/Makefile
+++ b/erigon-lib/Makefile
@@ -9,7 +9,6 @@ endif
 
 GOINSTALL = CGO_CXXFLAGS="$(CGO_CXXFLAGS)" go install -trimpath
 GOTEST = CGO_CXXFLAGS="$(CGO_CXXFLAGS)" go test -trimpath
-GOTEST_NOFUZZ = CGO_CXXFLAGS="$(CGO_CXXFLAGS)" go test -trimpath --tags=nofuzz
 
 OS = $(shell uname -s)
 ARCH = $(shell uname -m)
@@ -108,7 +107,7 @@ lint-deps: lintci-deps
 lint: lintci lint-mod-tidy
 
 test-short:
-	$(GOTEST_NOFUZZ) -short ./...
+	$(GOTEST) -short ./...
 
 test-all:
 	$(GOTEST) -coverprofile=coverage-test-all.out ./...

--- a/execution/commitment/hex_patricia_hashed_fuzz_test.go
+++ b/execution/commitment/hex_patricia_hashed_fuzz_test.go
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Erigon. If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !nofuzz
-
 package commitment
 
 import (

--- a/txnprovider/txpool/pool_fuzz_test.go
+++ b/txnprovider/txpool/pool_fuzz_test.go
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Erigon. If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !nofuzz
-
 package txpool
 
 import (

--- a/txnprovider/txpool/pool_txn_packets_fuzz_test.go
+++ b/txnprovider/txpool/pool_txn_packets_fuzz_test.go
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Erigon. If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !nofuzz
-
 package txpool
 
 import (

--- a/txnprovider/txpool/pool_txn_types_fuzz_test.go
+++ b/txnprovider/txpool/pool_txn_types_fuzz_test.go
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Erigon. If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !nofuzz
-
 package txpool
 
 import (


### PR DESCRIPTION
fuzz tests in normal during tests runs - do not fuzz (do not do heavy) - but do run known test-cases (from saved testdata)
so, in my head it must not impact `-race` or `-short` speed