### PR TITLE
Do not apply milestone if tip is behind it

### DIFF
--- a/eth/stagedsync/stage_polygon_sync.go
+++ b/eth/stagedsync/stage_polygon_sync.go
@@ -153,7 +153,6 @@ func NewPolygonSyncStageCfg(
 		polygonsync.NewCanonicalChainBuilderFactory(chainConfig, borConfig, heimdallService, signaturesCache, logger),
 		heimdallService,
 		bridgeService,
-		events.Events(),
 		events,
 		notifications,
 		sync.NewWiggleCalculator(borConfig, signaturesCache, heimdallService),

--- a/eth/stagedsync/stage_polygon_sync.go
+++ b/eth/stagedsync/stage_polygon_sync.go
@@ -154,6 +154,7 @@ func NewPolygonSyncStageCfg(
 		heimdallService,
 		bridgeService,
 		events.Events(),
+		events,
 		notifications,
 		sync.NewWiggleCalculator(borConfig, signaturesCache, heimdallService),
 		engineAPISwitcher,

--- a/polygon/sync/service.go
+++ b/polygon/sync/service.go
@@ -92,6 +92,7 @@ func NewService(
 		heimdallService,
 		bridgeService,
 		events.Events(),
+		events,
 		notifications,
 		NewWiggleCalculator(borConfig, signaturesCache, heimdallService),
 		engineAPISwitcher,

--- a/polygon/sync/service.go
+++ b/polygon/sync/service.go
@@ -91,7 +91,6 @@ func NewService(
 		ccBuilderFactory,
 		heimdallService,
 		bridgeService,
-		events.Events(),
 		events,
 		notifications,
 		NewWiggleCalculator(borConfig, signaturesCache, heimdallService),

--- a/polygon/sync/sync.go
+++ b/polygon/sync/sync.go
@@ -78,7 +78,8 @@ func NewSync(
 	ccBuilderFactory CanonicalChainBuilderFactory,
 	heimdallSync heimdallSynchronizer,
 	bridgeSync bridgeSynchronizer,
-	events chan Event,
+	events <-chan Event,
+	tipEvents *TipEvents,
 	notifications *shards.Notifications,
 	wiggleCalculator wiggleCalculator,
 	engineAPISwitcher EngineAPISwitcher,
@@ -101,6 +102,7 @@ func NewSync(
 		heimdallSync:      heimdallSync,
 		bridgeSync:        bridgeSync,
 		events:            events,
+		tipEvents:         tipEvents,
 		badBlocks:         badBlocksLru,
 		notifications:     notifications,
 		wiggleCalculator:  wiggleCalculator,
@@ -120,7 +122,8 @@ type Sync struct {
 	ccBuilderFactory  CanonicalChainBuilderFactory
 	heimdallSync      heimdallSynchronizer
 	bridgeSync        bridgeSynchronizer
-	events            chan Event
+	events            <-chan Event
+	tipEvents         *TipEvents
 	badBlocks         *simplelru.LRU[common.Hash, struct{}]
 	notifications     *shards.Notifications
 	wiggleCalculator  wiggleCalculator
@@ -230,7 +233,7 @@ func (s *Sync) applyNewMilestoneOnTip(ctx context.Context, event EventNewMilesto
 			"tipBlockNumber", ccb.Tip().Number.Uint64(),
 		)
 		// put the milestone back in the queue, so it can be processed at a later time
-		s.events <- Event{Type: EventTypeNewMilestone, newMilestone: event}
+		s.tipEvents.events.PushEvent(Event{Type: EventTypeNewMilestone, newMilestone: event})
 		return nil
 	}
 

--- a/polygon/sync/sync.go
+++ b/polygon/sync/sync.go
@@ -224,7 +224,7 @@ func (s *Sync) applyNewMilestoneOnTip(ctx context.Context, event EventNewMilesto
 
 	// milestone is ahead of our current tip
 	if milestone.EndBlock().Uint64() > ccb.Tip().Number.Uint64() {
-		s.logger.Warn(syncLogPrefix("putting milestone event back in the queue because our tip is behind the milestone"),
+		s.logger.Debug(syncLogPrefix("putting milestone event back in the queue because our tip is behind the milestone"),
 			"milestoneId", milestone.RawId(),
 			"milestoneStart", milestone.StartBlock().Uint64(),
 			"milestoneEnd", milestone.EndBlock().Uint64(),

--- a/polygon/sync/sync.go
+++ b/polygon/sync/sync.go
@@ -229,6 +229,7 @@ func (s *Sync) applyNewMilestoneOnTip(ctx context.Context, event EventNewMilesto
 			"milestoneRootHash", milestone.RootHash(),
 			"tipBlockNumber", ccb.Tip().Number.Uint64(),
 		)
+		return nil
 	}
 
 	s.logger.Info(

--- a/polygon/sync/sync.go
+++ b/polygon/sync/sync.go
@@ -220,6 +220,17 @@ func (s *Sync) applyNewMilestoneOnTip(ctx context.Context, event EventNewMilesto
 		return nil
 	}
 
+	// milestone is ahead of our current tip
+	if milestone.EndBlock().Uint64() > ccb.Tip().Number.Uint64() {
+		s.logger.Warn(syncLogPrefix("ignoring new milestone event because our tip is behind the milestone"),
+			"milestoneId", milestone.RawId(),
+			"milestoneStart", milestone.StartBlock().Uint64(),
+			"milestoneEnd", milestone.EndBlock().Uint64(),
+			"milestoneRootHash", milestone.RootHash(),
+			"tipBlockNumber", ccb.Tip().Number.Uint64(),
+		)
+	}
+
 	s.logger.Info(
 		syncLogPrefix("applying new milestone event"),
 		"milestoneId", milestone.RawId(),

--- a/polygon/sync/sync.go
+++ b/polygon/sync/sync.go
@@ -230,7 +230,7 @@ func (s *Sync) applyNewMilestoneOnTip(ctx context.Context, event EventNewMilesto
 			"tipBlockNumber", ccb.Tip().Number.Uint64(),
 		)
 		// put the milestone back in the queue, so it can be processed at a later time
-		go func() { s.tipEvents.events.PushEvent(Event{Type: EventTypeNewMilestone, newMilestone: event}) }()
+		s.tipEvents.events.PushEvent(Event{Type: EventTypeNewMilestone, newMilestone: event})
 		return nil
 	}
 

--- a/polygon/sync/tip_events.go
+++ b/polygon/sync/tip_events.go
@@ -142,7 +142,7 @@ type TipEvents struct {
 	blockEventsSpamGuard        blockEventsSpamGuard
 }
 
-func (te *TipEvents) Events() <-chan Event {
+func (te *TipEvents) Events() chan Event {
 	return te.events.Events()
 }
 
@@ -244,7 +244,7 @@ type TipEventsCompositeChannel struct {
 	events                chan Event
 }
 
-func (c TipEventsCompositeChannel) Events() <-chan Event {
+func (c TipEventsCompositeChannel) Events() chan Event {
 	return c.events
 }
 

--- a/polygon/sync/tip_events.go
+++ b/polygon/sync/tip_events.go
@@ -142,7 +142,7 @@ type TipEvents struct {
 	blockEventsSpamGuard        blockEventsSpamGuard
 }
 
-func (te *TipEvents) Events() chan Event {
+func (te *TipEvents) Events() <-chan Event {
 	return te.events.Events()
 }
 
@@ -244,7 +244,7 @@ type TipEventsCompositeChannel struct {
 	events                chan Event
 }
 
-func (c TipEventsCompositeChannel) Events() chan Event {
+func (c TipEventsCompositeChannel) Events() <-chan Event {
 	return c.events
 }
 


### PR DESCRIPTION
If the tip is behind the milestone end, then this triggers an unwind to the previous verified milestone and download of blocks from previous verified milestone block until new milestone end block. 

This is unnecessary since we can put the milestone back in the event queue, and it will be picked up later, and hopefully by that time the tip will be in sync with milestone. This is expected to reduce the number of unwinds.