### PR TITLE
 [r31] fuse_filter: keep in app's memory instead of `mmap` 

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -859,33 +859,34 @@ func stageExec(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) error
 		return nil
 	}
 
-	if chainTipMode {
-		var sendersProgress, execProgress uint64
-		if err := db.ViewTemporal(ctx, func(tx kv.TemporalTx) error {
-			var err error
-			if execProgress, err = stages.GetStageProgress(tx, stages.Execution); err != nil {
-				return err
-			}
-			if execProgress == 0 {
-				doms, err := libstate.NewSharedDomains(tx, log.New())
-				if err != nil {
-					panic(err)
-				}
-				execProgress = doms.BlockNum()
-				doms.Close()
-			}
-
-			if sendersProgress, err = stages.GetStageProgress(tx, stages.Senders); err != nil {
-				return err
-			}
-			return nil
-		}); err != nil {
+	var sendersProgress, execProgress uint64
+	if err := db.ViewTemporal(ctx, func(tx kv.TemporalTx) error {
+		var err error
+		if execProgress, err = stages.GetStageProgress(tx, stages.Execution); err != nil {
 			return err
 		}
-		if block == 0 {
-			block = sendersProgress
+		if execProgress == 0 {
+			doms, err := libstate.NewSharedDomains(tx, log.New())
+			if err != nil {
+				panic(err)
+			}
+			execProgress = doms.BlockNum()
+			doms.Close()
 		}
 
+		if sendersProgress, err = stages.GetStageProgress(tx, stages.Senders); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if block == 0 {
+		block = sendersProgress
+	}
+
+	if chainTipMode {
 		if noCommit {
 			tx, err := db.BeginTemporalRw(ctx)
 			if err != nil {
@@ -914,11 +915,16 @@ func stageExec(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) error
 		return nil
 	}
 
-	if err := stagedsync.SpawnExecuteBlocksStage(s, sync, txc, block, ctx, cfg, logger); err != nil {
-		return err
+	for {
+		if err := stagedsync.SpawnExecuteBlocksStage(s, sync, txc, block, ctx, cfg, logger); err != nil {
+			var errExhausted *stagedsync.ErrLoopExhausted
+			if errors.As(err, &errExhausted) {
+				continue // has more blocks to exec
+			}
+			return err // fail
+		}
+		return nil // Exec finished
 	}
-
-	return nil
 }
 
 func stageCustomTrace(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) error {

--- a/cmd/rpctest/main.go
+++ b/cmd/rpctest/main.go
@@ -21,10 +21,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/erigontech/erigon-lib/common/mem"
 	"github.com/spf13/cobra"
 
 	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/common/mem"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cmd/rpctest/rpctest"
 	"github.com/erigontech/erigon/cmd/utils"

--- a/erigon-lib/datastruct/existence/existence_filter.go
+++ b/erigon-lib/datastruct/existence/existence_filter.go
@@ -23,11 +23,12 @@ import (
 	"os"
 	"path/filepath"
 
+	bloomfilter "github.com/holiman/bloomfilter/v2"
+
 	"github.com/erigontech/erigon-lib/common/dbg"
 	"github.com/erigontech/erigon-lib/common/dir"
 	"github.com/erigontech/erigon-lib/datastruct/fusefilter"
 	"github.com/erigontech/erigon-lib/log/v3"
-	bloomfilter "github.com/holiman/bloomfilter/v2"
 )
 
 type Filter struct {
@@ -199,6 +200,12 @@ func OpenFilter(filePath string, useFuse bool) (idx *Filter, err error) {
 			return nil, fmt.Errorf("OpenFilter: %w, %s", err, fileName)
 		}
 		validationPassed = true
+		if fuseMadvWillNeed {
+			idx.fuseReader.MadvWillNeed()
+		}
+		if fuseMadvNormal {
+			idx.fuseReader.MadvWillNeed()
+		}
 		return idx, nil
 	}
 	filter := new(bloomfilter.Filter)
@@ -217,3 +224,6 @@ func (b *Filter) Close() {
 	}
 	b.fuseReader.Close()
 }
+
+var fuseMadvWillNeed = dbg.EnvBool("FUSE_MADV_WILLNEED", true)
+var fuseMadvNormal = dbg.EnvBool("FUSE_MADV_NORMAL", false)

--- a/erigon-lib/datastruct/existence/existence_filter.go
+++ b/erigon-lib/datastruct/existence/existence_filter.go
@@ -200,12 +200,6 @@ func OpenFilter(filePath string, useFuse bool) (idx *Filter, err error) {
 			return nil, fmt.Errorf("OpenFilter: %w, %s", err, fileName)
 		}
 		validationPassed = true
-		if fuseMadvWillNeed {
-			idx.fuseReader.MadvWillNeed()
-		}
-		if fuseMadvNormal {
-			idx.fuseReader.MadvWillNeed()
-		}
 		return idx, nil
 	}
 	filter := new(bloomfilter.Filter)
@@ -224,6 +218,3 @@ func (b *Filter) Close() {
 	}
 	b.fuseReader.Close()
 }
-
-var fuseMadvWillNeed = dbg.EnvBool("FUSE_MADV_WILLNEED", true)
-var fuseMadvNormal = dbg.EnvBool("FUSE_MADV_NORMAL", false)

--- a/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
+++ b/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
@@ -38,6 +38,9 @@ type Reader struct {
 
 var fuseMem = dbg.EnvBool("FUSE_MEM", false)
 
+var fuseMadvWillNeed = dbg.EnvBool("FUSE_MADV_WILLNEED", true)
+var fuseMadvNormal = dbg.EnvBool("FUSE_MADV_NORMAL", false)
+
 func NewReader(filePath string) (*Reader, error) {
 	f, err := os.Open(filePath)
 	if err != nil {
@@ -76,6 +79,12 @@ func NewReader(filePath string) (*Reader, error) {
 	r.keepInMem = fuseMem
 	r.fileName = fileName
 
+	if fuseMadvWillNeed {
+		r.MadvWillNeed()
+	}
+	if fuseMadvNormal {
+		r.MadvNormal()
+	}
 	return r, nil
 }
 

--- a/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
+++ b/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
@@ -11,6 +11,7 @@ import (
 	"unsafe"
 
 	"github.com/FastFilter/xorfilter"
+	"github.com/c2h5oh/datasize"
 	"github.com/edsrzf/mmap-go"
 
 	"github.com/erigontech/erigon-lib/common/dbg"
@@ -51,7 +52,7 @@ func NewReader(filePath string) (*Reader, error) {
 	var m mmap.MMap
 	var content []byte
 	if fuseMem {
-		content, err = io.ReadAll(bufio.NewReader(f))
+		content, err = io.ReadAll(bufio.NewReaderSize(f, int(64*datasize.KB)))
 		if err != nil {
 			_ = f.Close() //nolint
 			return nil, err

--- a/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
+++ b/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
@@ -36,10 +36,11 @@ type Reader struct {
 	version uint8
 }
 
-var fuseMem = dbg.EnvBool("FUSE_MEM", true)
-
-var fuseMadvWillNeed = dbg.EnvBool("FUSE_MADV_WILLNEED", false)
-var fuseMadvNormal = dbg.EnvBool("FUSE_MADV_NORMAL", false)
+var (
+	InMemByDefault        = dbg.EnvBool("FUSE_MEM", true)
+	MadvWillNeedByDefault = dbg.EnvBool("FUSE_MADV_WILLNEED", false)
+	MadvNormalByDefault   = dbg.EnvBool("FUSE_MADV_NORMAL", false)
+)
 
 func NewReader(filePath string) (*Reader, error) {
 	f, err := os.Open(filePath)
@@ -54,7 +55,7 @@ func NewReader(filePath string) (*Reader, error) {
 	sz := int(st.Size())
 	var m mmap.MMap
 	var content []byte
-	if fuseMem {
+	if InMemByDefault {
 		content, err = io.ReadAll(bufio.NewReaderSize(f, int(128*datasize.KB)))
 		if err != nil {
 			_ = f.Close() //nolint
@@ -76,7 +77,7 @@ func NewReader(filePath string) (*Reader, error) {
 	}
 	r.f = f
 	r.m = m
-	r.keepInMem = fuseMem
+	r.keepInMem = InMemByDefault
 	r.fileName = fileName
 	r.Init()
 	return r, nil
@@ -110,10 +111,10 @@ func NewReaderOnBytes(m []byte, fName string) (*Reader, int, error) {
 }
 
 func (r *Reader) Init() {
-	if fuseMadvWillNeed {
+	if MadvWillNeedByDefault {
 		r.MadvWillNeed()
 	}
-	if fuseMadvNormal {
+	if MadvNormalByDefault {
 		r.MadvNormal()
 	}
 }

--- a/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
+++ b/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
@@ -11,8 +11,12 @@ import (
 	"github.com/FastFilter/xorfilter"
 	"github.com/edsrzf/mmap-go"
 
+	"github.com/erigontech/erigon-lib/common/dbg"
 	mm "github.com/erigontech/erigon-lib/mmap"
 )
+
+var madvWillNeed = dbg.EnvBool("FUSE_MADV_WILLNEED", true)
+var madvNormal = dbg.EnvBool("FUSE_MADV_NORMAL", false)
 
 type Features uint32
 
@@ -47,8 +51,15 @@ func NewReader(filePath string) (*Reader, error) {
 		return nil, err
 	}
 
-	if err := mm.MadviseWillNeed(m); err != nil {
-		return nil, err
+	if madvWillNeed {
+		if err := mm.MadviseWillNeed(m); err != nil {
+			return nil, err
+		}
+	}
+	if madvNormal {
+		if err := mm.MadviseNormal(m); err != nil {
+			return nil, err
+		}
 	}
 
 	_, fileName := filepath.Split(filePath)

--- a/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
+++ b/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/FastFilter/xorfilter"
 	"github.com/edsrzf/mmap-go"
+
 	mm "github.com/erigontech/erigon-lib/mmap"
 )
 
@@ -45,6 +46,11 @@ func NewReader(filePath string) (*Reader, error) {
 		_ = f.Close() //nolint
 		return nil, err
 	}
+
+	if err := mm.MadviseWillNeed(m); err != nil {
+		return nil, err
+	}
+
 	_, fileName := filepath.Split(filePath)
 	r, _, err := NewReaderOnBytes(m, fileName)
 	if err != nil {

--- a/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
+++ b/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
@@ -102,12 +102,7 @@ func (r *Reader) ForceInMem() {
 }
 
 func (r *Reader) Init() {
-	if MadvWillNeedByDefault {
-		r.MadvWillNeed()
-	}
-	if MadvNormalByDefault {
-		r.MadvNormal()
-	}
+
 }
 
 func (r *Reader) MadvWillNeed() {

--- a/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
+++ b/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
@@ -36,9 +36,9 @@ type Reader struct {
 	version uint8
 }
 
-var fuseMem = dbg.EnvBool("FUSE_MEM", false)
+var fuseMem = dbg.EnvBool("FUSE_MEM", true)
 
-var fuseMadvWillNeed = dbg.EnvBool("FUSE_MADV_WILLNEED", true)
+var fuseMadvWillNeed = dbg.EnvBool("FUSE_MADV_WILLNEED", false)
 var fuseMadvNormal = dbg.EnvBool("FUSE_MADV_NORMAL", false)
 
 func NewReader(filePath string) (*Reader, error) {

--- a/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
+++ b/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
@@ -9,6 +9,7 @@ import (
 	"unsafe"
 
 	"github.com/FastFilter/xorfilter"
+	"github.com/c2h5oh/datasize"
 	"github.com/edsrzf/mmap-go"
 
 	"github.com/erigontech/erigon-lib/common/dbg"
@@ -95,9 +96,10 @@ func NewReaderOnBytes(m []byte, fName string) (*Reader, int, error) {
 	return &Reader{inner: filter, version: v, features: features, m: m}, headerSize + fingerprintsLen, nil
 }
 
-func (r *Reader) ForceInMem() {
+func (r *Reader) ForceInMem() datasize.ByteSize {
 	r.inner.Fingerprints = bytes.Clone(r.inner.Fingerprints)
 	r.keepInMem = true
+	return datasize.ByteSize(len(r.inner.Fingerprints))
 }
 
 func (r *Reader) MadvWillNeed() {

--- a/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
+++ b/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
@@ -65,7 +65,6 @@ func NewReader(filePath string) (*Reader, error) {
 	r.f = f
 	r.m = m
 	r.fileName = fileName
-	r.Init()
 	return r, nil
 }
 

--- a/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
+++ b/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
@@ -26,7 +26,7 @@ const (
 
 type Reader struct {
 	inner     *xorfilter.BinaryFuse[uint8]
-	keepInMem bool
+	keepInMem bool // keep it in mem insted of mmap
 
 	fileName string
 	f        *os.File
@@ -116,7 +116,7 @@ func NewReaderOnBytes(m []byte, fName string) (*Reader, int, error) {
 }
 
 func (r *Reader) MadvWillNeed() {
-	if r == nil || r.m == nil || len(r.m) == 0 {
+	if r == nil || r.m == nil || len(r.m) == 0 || r.keepInMem {
 		return
 	}
 	if err := mm.MadviseWillNeed(r.m); err != nil {
@@ -124,7 +124,7 @@ func (r *Reader) MadvWillNeed() {
 	}
 }
 func (r *Reader) MadvNormal() {
-	if r == nil || r.m == nil || len(r.m) == 0 {
+	if r == nil || r.m == nil || len(r.m) == 0 || r.keepInMem {
 		return
 	}
 	if err := mm.MadviseNormal(r.m); err != nil {

--- a/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
+++ b/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
@@ -101,10 +101,6 @@ func (r *Reader) ForceInMem() {
 	r.keepInMem = true
 }
 
-func (r *Reader) Init() {
-
-}
-
 func (r *Reader) MadvWillNeed() {
 	if r == nil || r.m == nil || len(r.m) == 0 || r.keepInMem {
 		return

--- a/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
+++ b/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
@@ -110,6 +110,10 @@ func NewReaderOnBytes(m []byte, fName string) (*Reader, int, error) {
 	return &Reader{inner: filter, version: v, features: features, m: m}, headerSize + fingerprintsLen, nil
 }
 
+func (r *Reader) ForceInMem() {
+	r.inner.Fingerprints = bytes.Clone(r.inner.Fingerprints)
+}
+
 func (r *Reader) Init() {
 	if MadvWillNeedByDefault {
 		r.MadvWillNeed()

--- a/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
+++ b/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
@@ -52,7 +52,7 @@ func NewReader(filePath string) (*Reader, error) {
 	var m mmap.MMap
 	var content []byte
 	if fuseMem {
-		content, err = io.ReadAll(bufio.NewReaderSize(f, int(64*datasize.KB)))
+		content, err = io.ReadAll(bufio.NewReaderSize(f, int(128*datasize.KB)))
 		if err != nil {
 			_ = f.Close() //nolint
 			return nil, err

--- a/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
+++ b/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
@@ -78,13 +78,7 @@ func NewReader(filePath string) (*Reader, error) {
 	r.m = m
 	r.keepInMem = fuseMem
 	r.fileName = fileName
-
-	if fuseMadvWillNeed {
-		r.MadvWillNeed()
-	}
-	if fuseMadvNormal {
-		r.MadvNormal()
-	}
+	r.Init()
 	return r, nil
 }
 
@@ -113,6 +107,15 @@ func NewReaderOnBytes(m []byte, fName string) (*Reader, int, error) {
 
 	filter.Fingerprints = data[:fingerprintsLen]
 	return &Reader{inner: filter, version: v, features: features, m: m}, headerSize + fingerprintsLen, nil
+}
+
+func (r *Reader) Init() {
+	if fuseMadvWillNeed {
+		r.MadvWillNeed()
+	}
+	if fuseMadvNormal {
+		r.MadvNormal()
+	}
 }
 
 func (r *Reader) MadvWillNeed() {

--- a/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
+++ b/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
@@ -11,12 +11,8 @@ import (
 	"github.com/FastFilter/xorfilter"
 	"github.com/edsrzf/mmap-go"
 
-	"github.com/erigontech/erigon-lib/common/dbg"
 	mm "github.com/erigontech/erigon-lib/mmap"
 )
-
-var madvWillNeed = dbg.EnvBool("FUSE_MADV_WILLNEED", true)
-var madvNormal = dbg.EnvBool("FUSE_MADV_NORMAL", false)
 
 type Features uint32
 
@@ -58,12 +54,6 @@ func NewReader(filePath string) (*Reader, error) {
 	}
 	r.f = f
 	r.fileName = fileName
-	if madvWillNeed {
-		r.MadvWillNeed()
-	}
-	if madvNormal {
-		r.MadvNormal()
-	}
 
 	return r, nil
 }

--- a/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
+++ b/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
@@ -51,17 +51,6 @@ func NewReader(filePath string) (*Reader, error) {
 		return nil, err
 	}
 
-	if madvWillNeed {
-		if err := mm.MadviseWillNeed(m); err != nil {
-			return nil, err
-		}
-	}
-	if madvNormal {
-		if err := mm.MadviseNormal(m); err != nil {
-			return nil, err
-		}
-	}
-
 	_, fileName := filepath.Split(filePath)
 	r, _, err := NewReaderOnBytes(m, fileName)
 	if err != nil {
@@ -69,6 +58,13 @@ func NewReader(filePath string) (*Reader, error) {
 	}
 	r.f = f
 	r.fileName = fileName
+	if madvWillNeed {
+		r.MadvWillNeed()
+	}
+	if madvNormal {
+		r.MadvNormal()
+	}
+
 	return r, nil
 }
 
@@ -104,6 +100,14 @@ func (r *Reader) MadvWillNeed() {
 		return
 	}
 	if err := mm.MadviseWillNeed(r.m); err != nil {
+		panic(err)
+	}
+}
+func (r *Reader) MadvNormal() {
+	if r == nil || r.m == nil || len(r.m) == 0 {
+		return
+	}
+	if err := mm.MadviseNormal(r.m); err != nil {
 		panic(err)
 	}
 }

--- a/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
+++ b/erigon-lib/datastruct/fusefilter/fusefilter_reader.go
@@ -1,17 +1,14 @@
 package fusefilter
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"unsafe"
 
 	"github.com/FastFilter/xorfilter"
-	"github.com/c2h5oh/datasize"
 	"github.com/edsrzf/mmap-go"
 
 	"github.com/erigontech/erigon-lib/common/dbg"
@@ -37,7 +34,6 @@ type Reader struct {
 }
 
 var (
-	InMemByDefault        = dbg.EnvBool("FUSE_MEM", true)
 	MadvWillNeedByDefault = dbg.EnvBool("FUSE_MADV_WILLNEED", false)
 	MadvNormalByDefault   = dbg.EnvBool("FUSE_MADV_NORMAL", false)
 )
@@ -53,22 +49,13 @@ func NewReader(filePath string) (*Reader, error) {
 		return nil, err
 	}
 	sz := int(st.Size())
-	var m mmap.MMap
 	var content []byte
-	if InMemByDefault {
-		content, err = io.ReadAll(bufio.NewReaderSize(f, int(128*datasize.KB)))
-		if err != nil {
-			_ = f.Close() //nolint
-			return nil, err
-		}
-	} else {
-		m, err = mmap.MapRegion(f, sz, mmap.RDONLY, 0, 0)
-		if err != nil {
-			_ = f.Close() //nolint
-			return nil, err
-		}
-		content = m
+	m, err := mmap.MapRegion(f, sz, mmap.RDONLY, 0, 0)
+	if err != nil {
+		_ = f.Close() //nolint
+		return nil, err
 	}
+	content = m
 
 	_, fileName := filepath.Split(filePath)
 	r, _, err := NewReaderOnBytes(content, fileName)
@@ -77,7 +64,6 @@ func NewReader(filePath string) (*Reader, error) {
 	}
 	r.f = f
 	r.m = m
-	r.keepInMem = InMemByDefault
 	r.fileName = fileName
 	r.Init()
 	return r, nil
@@ -112,6 +98,7 @@ func NewReaderOnBytes(m []byte, fName string) (*Reader, int, error) {
 
 func (r *Reader) ForceInMem() {
 	r.inner.Fingerprints = bytes.Clone(r.inner.Fingerprints)
+	r.keepInMem = true
 }
 
 func (r *Reader) Init() {

--- a/erigon-lib/recsplit/index.go
+++ b/erigon-lib/recsplit/index.go
@@ -248,6 +248,7 @@ func (idx *Index) init() (err error) {
 		if err != nil {
 			return fmt.Errorf("NewReaderOnBytes: %w, %s", err, idx.fileName)
 		}
+		idx.existenceV1.Init()
 		offset += sz
 	}
 

--- a/erigon-lib/recsplit/index.go
+++ b/erigon-lib/recsplit/index.go
@@ -281,10 +281,11 @@ func (idx *Index) init() (err error) {
 	return nil
 }
 
-func (idx *Index) ForceExistenceFilterInRAM() {
+func (idx *Index) ForceExistenceFilterInRAM() datasize.ByteSize {
 	if idx.version >= 1 && idx.lessFalsePositives && idx.keyCount > 0 {
-		idx.existenceV1.ForceInMem()
+		return idx.existenceV1.ForceInMem()
 	}
+	return 0
 }
 
 func onlyKnownFeatures(features Features) error {

--- a/erigon-lib/recsplit/index.go
+++ b/erigon-lib/recsplit/index.go
@@ -248,7 +248,12 @@ func (idx *Index) init() (err error) {
 		if err != nil {
 			return fmt.Errorf("NewReaderOnBytes: %w, %s", err, idx.fileName)
 		}
-		idx.existenceV1.Init()
+		if fusefilter.MadvWillNeedByDefault {
+			idx.existenceV1.MadvWillNeed()
+		}
+		if fusefilter.MadvNormalByDefault {
+			idx.existenceV1.MadvNormal()
+		}
 		offset += sz
 	}
 

--- a/erigon-lib/recsplit/index.go
+++ b/erigon-lib/recsplit/index.go
@@ -244,7 +244,11 @@ func (idx *Index) init() (err error) {
 
 	if idx.version >= 1 && idx.lessFalsePositives && idx.keyCount > 0 {
 		var sz int
-		idx.existenceV1, sz, err = fusefilter.NewReaderOnBytes(idx.data[offset:], idx.fileName)
+		fuseContent := idx.data[offset:]
+		if fusefilter.InMemByDefault {
+			fuseContent = bytes.Clone(fuseContent)
+		}
+		idx.existenceV1, sz, err = fusefilter.NewReaderOnBytes(fuseContent, idx.fileName)
 		if err != nil {
 			return fmt.Errorf("NewReaderOnBytes: %w, %s", err, idx.fileName)
 		}

--- a/erigon-lib/recsplit/index.go
+++ b/erigon-lib/recsplit/index.go
@@ -244,11 +244,7 @@ func (idx *Index) init() (err error) {
 
 	if idx.version >= 1 && idx.lessFalsePositives && idx.keyCount > 0 {
 		var sz int
-		fuseContent := idx.data[offset:]
-		if fusefilter.InMemByDefault {
-			fuseContent = bytes.Clone(fuseContent)
-		}
-		idx.existenceV1, sz, err = fusefilter.NewReaderOnBytes(fuseContent, idx.fileName)
+		idx.existenceV1, sz, err = fusefilter.NewReaderOnBytes(idx.data[offset:], idx.fileName)
 		if err != nil {
 			return fmt.Errorf("NewReaderOnBytes: %w, %s", err, idx.fileName)
 		}
@@ -278,6 +274,12 @@ func (idx *Index) init() (err error) {
 	idx.ef.Read(idx.data[offset:])
 	validationPassed = true
 	return nil
+}
+
+func (idx *Index) ForceExistenceFilterInRAM() {
+	if idx.version >= 1 && idx.lessFalsePositives && idx.keyCount > 0 {
+		idx.existenceV1.ForceInMem()
+	}
 }
 
 func onlyKnownFeatures(features Features) error {

--- a/erigon-lib/recsplit/index.go
+++ b/erigon-lib/recsplit/index.go
@@ -32,6 +32,7 @@ import (
 	"unsafe"
 
 	"github.com/c2h5oh/datasize"
+
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/dbg"
 	"github.com/erigontech/erigon-lib/datastruct/fusefilter"
@@ -143,16 +144,16 @@ func OpenIndex(indexFilePath string) (idx *Index, err error) {
 	}
 
 	// dontt know how to madv part of file in golang yet
-	//if idx.version == 0 && idx.lessFalsePositives && idx.enums && idx.keyCount > 0 {
-	//	if len(idx.existence) > 0 {
+	//if idx.version == 1 && idx.lessFalsePositives {
+	//	if len(idx.existenceV1) > 0 {
 	//		if err := mmap.MadviseWillNeed(idx.existence); err != nil {
 	//			panic(err)
 	//		}
 	//	}
-	//	pos := 1 + 8 + idx.bytesPerRec*int(idx.keyCount)
-	//	if err := mmap.MadviseWillNeed(idx.data[:pos]); err != nil {
-	//		panic(err)
-	//	}
+	//	//pos := 1 + 8 + idx.bytesPerRec*int(idx.keyCount)
+	//	//if err := mmap.MadviseWillNeed(idx.data[:pos]); err != nil {
+	//	//	panic(err)
+	//	//}
 	//}
 
 	idx.readers = &sync.Pool{

--- a/erigon-lib/state/domain.go
+++ b/erigon-lib/state/domain.go
@@ -37,7 +37,6 @@ import (
 	"github.com/erigontech/erigon-lib/common/dbg"
 	"github.com/erigontech/erigon-lib/common/dir"
 	"github.com/erigontech/erigon-lib/datastruct/existence"
-	"github.com/erigontech/erigon-lib/datastruct/fusefilter"
 	"github.com/erigontech/erigon-lib/etl"
 	"github.com/erigontech/erigon-lib/kv"
 	"github.com/erigontech/erigon-lib/kv/order"
@@ -451,12 +450,14 @@ func (d *Domain) openDirtyFiles() (err error) {
 	return nil
 }
 
+var domainExistenceForceInMem = dbg.EnvBool("DOMAIN_EXISTENCE_MEM", true)
+
 func (d *Domain) openHashMapAccessor(fPath string) (*recsplit.Index, error) {
 	accessor, err := recsplit.OpenIndex(fPath)
 	if err != nil {
 		return nil, err
 	}
-	if fusefilter.InMemByDefault {
+	if domainExistenceForceInMem {
 		accessor.ForceExistenceFilterInRAM()
 	}
 	return accessor, nil

--- a/erigon-lib/state/history.go
+++ b/erigon-lib/state/history.go
@@ -943,7 +943,7 @@ func (h *History) buildFiles(ctx context.Context, step uint64, collation History
 		return HistoryFiles{}, fmt.Errorf("build %s .vi: %w", h.filenameBase, err)
 	}
 
-	if historyIdx, err = recsplit.OpenIndex(historyIdxPath); err != nil {
+	if historyIdx, err = h.openHashMapAccessor(historyIdxPath); err != nil {
 		return HistoryFiles{}, fmt.Errorf("open idx: %w", err)
 	}
 	closeComp = false

--- a/erigon-lib/state/history.go
+++ b/erigon-lib/state/history.go
@@ -159,6 +159,14 @@ func (h *History) vAccessorFilePathMask(fromStep, toStep uint64) string {
 	return filepath.Join(h.dirs.SnapAccessors, fmt.Sprintf("*-%s.%d-%d.vi", h.filenameBase, fromStep, toStep))
 }
 
+func (h *History) openHashMapAccessor(fPath string) (*recsplit.Index, error) {
+	accessor, err := recsplit.OpenIndex(fPath)
+	if err != nil {
+		return nil, err
+	}
+	return accessor, nil
+}
+
 // openList - main method to open list of files.
 // It's ok if some files was open earlier.
 // If some file already open: noop.
@@ -268,7 +276,7 @@ func (h *History) openDirtyFiles() error {
 						_, fName := filepath.Split(fPath)
 						versionTooLowPanic(fName, h.version.AccessorVI)
 					}
-					if item.index, err = recsplit.OpenIndex(fPath); err != nil {
+					if item.index, err = h.openHashMapAccessor(fPath); err != nil {
 						_, fName := filepath.Split(fPath)
 						h.logger.Warn("[agg] History.openDirtyFiles", "err", err, "f", fName)
 						// don't interrupt on error. other files may be good
@@ -919,7 +927,7 @@ func (h *History) buildFiles(ctx context.Context, step uint64, collation History
 		if err := h.InvertedIndex.buildMapAccessor(ctx, step, step+1, h.InvertedIndex.dataReader(efHistoryDecomp), ps); err != nil {
 			return HistoryFiles{}, fmt.Errorf("build %s .ef history idx: %w", h.filenameBase, err)
 		}
-		if efHistoryIdx, err = recsplit.OpenIndex(h.InvertedIndex.efAccessorNewFilePath(step, step+1)); err != nil {
+		if efHistoryIdx, err = h.InvertedIndex.openHashMapAccessor(h.InvertedIndex.efAccessorNewFilePath(step, step+1)); err != nil {
 			return HistoryFiles{}, err
 		}
 	}

--- a/erigon-lib/state/integrity.go
+++ b/erigon-lib/state/integrity.go
@@ -10,15 +10,15 @@ import (
 	"github.com/erigontech/erigon-lib/common/dbg"
 	"github.com/erigontech/erigon-lib/version"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/dir"
 	"github.com/erigontech/erigon-lib/estimate"
 	"github.com/erigontech/erigon-lib/kv"
 	"github.com/erigontech/erigon-lib/kv/stream"
 	"github.com/erigontech/erigon-lib/log/v3"
-	"github.com/erigontech/erigon-lib/recsplit"
 	"github.com/erigontech/erigon-lib/recsplit/multiencseq"
-	"golang.org/x/sync/errgroup"
 )
 
 // search key in all files of all domains and print file names
@@ -111,7 +111,7 @@ func (dt *DomainRoTx) IntegrityKey(k []byte) error {
 				}
 				if exists {
 					var err error
-					accessor, err = recsplit.OpenIndex(fPath)
+					accessor, err = dt.d.openHashMapAccessor(fPath)
 					if err != nil {
 						_, fName := filepath.Split(fPath)
 						dt.d.logger.Warn("[agg] InvertedIndex.openDirtyFiles", "err", err, "f", fName)

--- a/erigon-lib/state/merge.go
+++ b/erigon-lib/state/merge.go
@@ -560,7 +560,7 @@ func (dt *DomainRoTx) mergeFiles(ctx context.Context, domainFiles, indexFiles, h
 		if err = dt.d.buildHashMapAccessor(ctx, fromStep, toStep, dt.dataReader(valuesIn.decompressor), ps); err != nil {
 			return nil, nil, nil, fmt.Errorf("merge %s buildHashMapAccessor [%d-%d]: %w", dt.d.filenameBase, r.values.from, r.values.to, err)
 		}
-		if valuesIn.index, err = recsplit.OpenIndex(dt.d.kviAccessorNewFilePath(fromStep, toStep)); err != nil {
+		if valuesIn.index, err = dt.d.openHashMapAccessor(dt.d.kviAccessorNewFilePath(fromStep, toStep)); err != nil {
 			return nil, nil, nil, fmt.Errorf("merge %s buildHashMapAccessor [%d-%d]: %w", dt.d.filenameBase, r.values.from, r.values.to, err)
 		}
 	}

--- a/erigon-lib/state/merge.go
+++ b/erigon-lib/state/merge.go
@@ -868,7 +868,7 @@ func (ht *HistoryRoTx) mergeFiles(ctx context.Context, indexFiles, historyFiles 
 			return nil, nil, err
 		}
 
-		if index, err = recsplit.OpenIndex(idxPath); err != nil {
+		if index, err = ht.h.openHashMapAccessor(idxPath); err != nil {
 			return nil, nil, fmt.Errorf("open %s idx: %w", ht.h.filenameBase, err)
 		}
 		historyIn = newFilesItem(r.history.from, r.history.to, ht.aggStep)

--- a/erigon-lib/state/merge.go
+++ b/erigon-lib/state/merge.go
@@ -728,7 +728,7 @@ func (iit *InvertedIndexRoTx) mergeFiles(ctx context.Context, files []*FilesItem
 	if err := iit.ii.buildMapAccessor(ctx, fromStep, toStep, iit.dataReader(outItem.decompressor), ps); err != nil {
 		return nil, fmt.Errorf("merge %s buildHashMapAccessor [%d-%d]: %w", iit.ii.filenameBase, startTxNum, endTxNum, err)
 	}
-	if outItem.index, err = recsplit.OpenIndex(iit.ii.efAccessorNewFilePath(fromStep, toStep)); err != nil {
+	if outItem.index, err = iit.ii.openHashMapAccessor(iit.ii.efAccessorNewFilePath(fromStep, toStep)); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
We may experiment with MADV_WILL_NEED in future versions of Erigon

Reason: without it perf of commitment is much lower (Mark reported 10x slowdown).
Cons: +1G RAM use by Erigon
 