### PR TITLE
Fixed calculation of start block number in snapshot retirement (#16902)

### DIFF
--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -468,7 +468,7 @@ func (br *BlockRetire) RetireBlocks(ctx context.Context, requestedMinBlockNum ui
 		}
 
 		if includeBor {
-			minBorBlockNum := max(br.blockReader.FrozenBorBlocks(false), requestedMinBlockNum)
+			minBorBlockNum := max(br.blockReader.FrozenBorBlocks(true), requestedMinBlockNum)
 			okBor, err = br.retireBorBlocks(ctx, minBorBlockNum, maxBlockNum, lvl, seedNewSnapshots, onDeleteSnapshots)
 			if err != nil {
 				return err


### PR DESCRIPTION
FrozenBorBlocks is used to calculate blockFrom number to use it as a left-end interval in block retirement process. The thing is - this function returns the highest known block in snapshots among bor related snapshots. For example if you have 3 snapshots:
```
1000-2000.spans
1000-2000.events
0000-1000.checkpoints
```

it returns 1999. And in that case we will never retire correctly checkpoints in interval [0000, 1000). It is possible that bor snapshots have different height, that's why using FrozenBorBlocks in a way like it did is wrong.

In previous my PRs I was fixing the similar problem which was causing race condition in block pruning. I introduced parameter align for the function, which changes it behaviour to return not just the highest block, but the highest aligned. In the example above it is 999.

So to prevent gaps in the code - we have to use align=true here as well as we already do in block pruning.