### PR TITLE
fix: correct typos across codebase

### DIFF
--- a/cl/sentinel/discovery.go
+++ b/cl/sentinel/discovery.go
@@ -229,7 +229,7 @@ func (s *Sentinel) onConnection(net network.Network, conn network.Conn) {
 			s.host.Network().ClosePeer(peerId)
 			s.peers.RemovePeer(peerId)
 		} else {
-			// we were able to succesfully connect, so add this peer to our pool
+			// we were able to successfully connect, so add this peer to our pool
 			s.peers.AddPeer(peerId)
 		}
 	}()

--- a/cl/utils/bls/signature.go
+++ b/cl/utils/bls/signature.go
@@ -22,7 +22,7 @@ const (
 // ETH2 uses BLS12381-G2 Curve
 var eth2Curve = []byte("BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_")
 
-// Signature wraps CGO object repressenting the signature.
+// Signature wraps CGO object representing the signature.
 type Signature struct {
 	affine *blst.P2Affine
 }

--- a/db/snaptype/type.go
+++ b/db/snaptype/type.go
@@ -203,7 +203,7 @@ type snapType struct {
 	rangeExtractor RangeExtractor
 }
 
-// These are raw maps with no mutex protection becuase they are
+// These are raw maps with no mutex protection because they are
 // expected to be written to once during program initialization
 // and them be readonly
 var registeredTypes = map[Enum]Type{}

--- a/db/state/aggregator_test.go
+++ b/db/state/aggregator_test.go
@@ -153,7 +153,7 @@ func TestAggregatorV3_Merge(t *testing.T) {
 
 		onChangeCalls++
 		if onChangeCalls == 1 {
-			mustSeeFile(newFiles, "domain", "accounts.0-2.kv") //TODO: when we build `accounts.0-1.kv` - we sending empty notifcation
+			mustSeeFile(newFiles, "domain", "accounts.0-2.kv") //TODO: when we build `accounts.0-1.kv` - we sending empty notification
 			require.False(t, filepath.IsAbs(newFiles[0]))      // expecting non-absolute paths (relative as of snapshots dir)
 		}
 	}, func(deletedFiles []string) {

--- a/execution/abi/bind/bind_test.go
+++ b/execution/abi/bind/bind_test.go
@@ -1680,7 +1680,7 @@ var bindTests = []struct {
 			}
 			sim.Commit()
 
-			// This test the existence of the free retreiver call for view and pure functions
+			// This test the existence of the free retriever call for view and pure functions
 			if num, err := pav.PureFunc(nil); err != nil {
 				t.Fatalf("Failed to call anonymous field retriever: %v", err)
 			} else if num.Cmp(big.NewInt(42)) != 0 {

--- a/execution/consensus/clique/snapshot_test.go
+++ b/execution/consensus/clique/snapshot_test.go
@@ -362,7 +362,7 @@ func TestClique(t *testing.T) {
 			},
 			failure: clique.ErrUnauthorizedSigner,
 		}, {
-			name:    "An authorized signer that signed recenty should not be able to sign again",
+			name:    "An authorized signer that signed recently should not be able to sign again",
 			signers: []string{"A", "B"},
 			votes: []testerVote{
 				{signer: "A"},

--- a/execution/consensus/consensus.go
+++ b/execution/consensus/consensus.go
@@ -122,7 +122,7 @@ type EngineReader interface {
 	// engine is based on signatures.
 	Author(header *types.Header) (common.Address, error)
 
-	// Dependencies retrives the dependencies between transactions
+	// Dependencies retrieves the dependencies between transactions
 	// included in the block accosiated with this header a nil return
 	// implies no dependencies are known
 	TxDependencies(header *types.Header) [][]int

--- a/execution/consensus/misc/eip6110.go
+++ b/execution/consensus/misc/eip6110.go
@@ -50,7 +50,7 @@ var (
 	)
 )
 
-// field type overrides for abi upacking
+// field type overrides for abi unpacking
 type depositUnpacking struct {
 	Pubkey                []byte
 	WithdrawalCredentials []byte

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -62,7 +62,7 @@ func (se *serialExecutor) execute(ctx context.Context, tasks []*state.TxTask, gp
 
 			if txTask.Final {
 				if !se.isMining && !se.skipPostEvaluation && !se.execStage.CurrentSyncCycle.IsInitialCycle {
-					// note this assumes the bloach reciepts is a fixed array shared by
+					// note this assumes the bloach receipts is a fixed array shared by
 					// all tasks - if that changes this will need to change - robably need to
 					// add this to the executor
 					se.cfg.notifications.RecentLogs.Add(txTask.BlockReceipts)

--- a/execution/stagedsync/sync_test.go
+++ b/execution/stagedsync/sync_test.go
@@ -507,7 +507,7 @@ func TestStateSyncInterruptRestart(t *testing.T) {
 
 func TestSyncInterruptLongUnwind(t *testing.T) {
 	// interrupt a stage that is too big to fit in one batch,
-	// so the db is in inconsitent state, so we have to restart with that
+	// so the db is in inconsistent state, so we have to restart with that
 	flow := make([]stages.SyncStage, 0)
 	unwound := false
 	interrupted := false

--- a/execution/stages/blockchain_test.go
+++ b/execution/stages/blockchain_test.go
@@ -1105,7 +1105,7 @@ func TestDoubleAccountRemoval(t *testing.T) {
 			require.NoError(t, err)
 			block.AddTx(txn)
 
-			// sending kill messsage to an already suicided account
+			// sending kill message to an already suicided account
 			txn, err = types.SignTx(types.NewTransaction(nonce+1, theAddr, new(uint256.Int), 90000, new(uint256.Int), kill), *signer, bankKey)
 			require.NoError(t, err)
 			block.AddTx(txn)

--- a/execution/stages/mock/accessors_chain_test.go
+++ b/execution/stages/mock/accessors_chain_test.go
@@ -374,7 +374,7 @@ func TestCanonicalMappingStorage(t *testing.T) {
 	defer tx.Rollback()
 	br := m.BlockReader
 
-	// Create a test canonical number and assinged hash to move around
+	// Create a test canonical number and assigned hash to move around
 	hash, number := common.Hash{0: 0xff}, uint64(314)
 	entry, _, err := br.CanonicalHash(m.Ctx, tx, number)
 	if err != nil {

--- a/node/rpcstack_test.go
+++ b/node/rpcstack_test.go
@@ -111,7 +111,7 @@ func TestWebsocketOrigins(t *testing.T) {
 			expFail: []string{
 				"test",                                // no scheme, required by spec
 				"http://test",                         // wrong scheme
-				"http://test.foo", "https://a.test.x", // subdomain variatoins
+				"http://test.foo", "https://a.test.x", // subdomain variations
 				"http://testx:8540", "https://xtest:8540"},
 		},
 		// ip tests

--- a/p2p/discover/v5wire/encoding.go
+++ b/p2p/discover/v5wire/encoding.go
@@ -534,7 +534,7 @@ func (c *Codec) decodeHandshake(fromAddr string, head *Header) (n *enode.Node, a
 	if err != nil {
 		return nil, auth, nil, errInvalidAuthKey
 	}
-	// Derive sesssion keys.
+	// Derive session keys.
 	session := deriveKeys(sha256.New, c.privkey, ephkey, auth.h.SrcID, c.localnode.ID(), cdata)
 	session = session.keysFlipped()
 	return n, auth, session, nil

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -1077,7 +1077,7 @@ func (c *Bor) IsServiceTransaction(sender common.Address, syscall consensus.Syst
 	return false
 }
 
-// Depricated: To get the API use jsonrpc.APIList
+// Deprecated: To get the API use jsonrpc.APIList
 func (c *Bor) APIs(chain consensus.ChainHeaderReader) []rpc.API {
 	return []rpc.API{}
 }

--- a/polygon/bridge/event_fetch_test.go
+++ b/polygon/bridge/event_fetch_test.go
@@ -42,7 +42,7 @@ func TestOver50EventBlockFetch(t *testing.T) {
 	}
 
 	if len(events) != 113 {
-		t.Fatal("Unexpected event count, exptected: 113, got:", len(events))
+		t.Fatal("Unexpected event count, expected: 113, got:", len(events))
 	}
 
 	// block :=  23893568
@@ -55,7 +55,7 @@ func TestOver50EventBlockFetch(t *testing.T) {
 	}
 
 	if len(events) != 9417 {
-		t.Fatal("Unexpected event count, exptected: 9417, got:", len(events))
+		t.Fatal("Unexpected event count, expected: 9417, got:", len(events))
 	}
 
 }

--- a/polygon/bridge/snapshot_store.go
+++ b/polygon/bridge/snapshot_store.go
@@ -470,7 +470,7 @@ func ValidateEvents(ctx context.Context, config *borcfg.BorConfig, db kv.RoDB, b
 			switch {
 			case eventId < prevEventId:
 				if failFast {
-					return prevEventId, fmt.Errorf("invaid bor event %d (prev=%d) at block=%d", eventId, prevEventId, block)
+					return prevEventId, fmt.Errorf("invalid bor event %d (prev=%d) at block=%d", eventId, prevEventId, block)
 				}
 
 				log.Error("[integrity] NoGapsInBorEvents: invalid bor event", "event", eventId, "prev", prevEventId, "block", block)

--- a/polygon/sync/sync.go
+++ b/polygon/sync/sync.go
@@ -668,7 +668,7 @@ func (s *Sync) Run(ctx context.Context) error {
 	s.logger.Info(syncLogPrefix("waiting for execution client"))
 
 	for {
-		// we have to check if the heimdall we are connected to is synchonised with the chain
+		// we have to check if the heimdall we are connected to is synchronised with the chain
 		// to prevent getting empty list of checkpoints/milestones during the sync
 
 		catchingUp, err := s.heimdallSync.IsCatchingUp(ctx)

--- a/rpc/jsonrpc/receipts/receipts_generator.go
+++ b/rpc/jsonrpc/receipts/receipts_generator.go
@@ -35,7 +35,7 @@ type Generator struct {
 
 	// blockExecMutex ensuring that only 1 block with given hash
 	// executed at a time - all parallel requests for same hash will wait for results
-	// "Requesting near-chain-tip block receipts" - is very common RPC request, means we facing many similar parallel requrest
+	// "Requesting near-chain-tip block receipts" - is very common RPC request, means we facing many similar parallel request
 	blockExecMutex *loaderMutex[common.Hash] // only
 	txnExecMutex   *loaderMutex[common.Hash] // only 1 txn with current hash executed at a time - same parallel requests are waiting for results
 


### PR DESCRIPTION
This PR addresses minor spelling errors found in comments and error messages throughout the codebase.