### PR TITLE
fix: correct error handling in CachedReader3.ReadAccountCode

### DIFF
--- a/core/state/cached_reader3.go
+++ b/core/state/cached_reader3.go
@@ -90,10 +90,13 @@ func (r *CachedReader3) HasStorage(address common.Address) (bool, error) {
 
 func (r *CachedReader3) ReadAccountCode(address common.Address) ([]byte, error) {
 	code, err := r.cache.GetCode(address[:])
+	if err != nil {
+		return nil, err
+	}
 	if len(code) == 0 {
 		return nil, nil
 	}
-	return code, err
+	return code, nil
 }
 
 func (r *CachedReader3) ReadAccountCodeSize(address common.Address) (int, error) {


### PR DESCRIPTION
Fix error handling in CachedReader3.ReadAccountCode

- Add proper error validation before length check
- Return code with nil error instead of code with error
- Align with Go error handling principles and other implementations