### PR TITLE
agg: move `CheckSnapshotsCompatibility` outside of `NewAgg`  as test's bottleneck

### DIFF
--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -426,6 +426,9 @@ func RemoteServices(ctx context.Context, cfg *httpcfg.HttpCfg, logger log.Logger
 		blockReader = freezeblocks.NewBlockReader(allSnapshots, allBorSnapshots)
 		txNumsReader := blockReader.TxnumReader(ctx)
 
+		if err := dbstate.CheckSnapshotsCompatibility(cfg.Dirs); err != nil {
+			return nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, err
+		}
 		agg, err := dbstate.NewAggregator(ctx, cfg.Dirs, config3.DefaultStepSize, rawDB, logger)
 		if err != nil {
 			return nil, nil, nil, nil, nil, nil, nil, ff, nil, nil, fmt.Errorf("create aggregator: %w", err)

--- a/db/state/aggregator2.go
+++ b/db/state/aggregator2.go
@@ -25,10 +25,6 @@ func NewAggregator(ctx context.Context, dirs datadir.Dirs, aggregationStep uint6
 }
 
 func NewAggregator2(ctx context.Context, dirs datadir.Dirs, aggregationStep uint64, salt *uint32, db kv.RoDB, logger log.Logger) (*Aggregator, error) {
-	err := checkSnapshotsCompatibility(dirs)
-	if err != nil {
-		return nil, err
-	}
 	a, err := newAggregatorOld(ctx, dirs, aggregationStep, db, logger)
 	if err != nil {
 		return nil, err
@@ -44,7 +40,7 @@ func NewAggregator2(ctx context.Context, dirs datadir.Dirs, aggregationStep uint
 	return a, nil
 }
 
-func checkSnapshotsCompatibility(d datadir.Dirs) error {
+func CheckSnapshotsCompatibility(d datadir.Dirs) error {
 	directories := []string{
 		d.Chaindata, d.Tmp, d.SnapIdx, d.SnapHistory, d.SnapDomain,
 		d.SnapAccessors, d.SnapCaplin, d.Downloader, d.TxPool, d.Snap,

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1565,6 +1565,9 @@ func setUpBlockReader(ctx context.Context, db kv.RwDB, dirs datadir.Dirs, snConf
 	if _, err := snaptype.LoadSalt(dirs.Snap, createNewSaltFileIfNeeded, logger); err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, err
 	}
+	if err := state.CheckSnapshotsCompatibility(dirs); err != nil {
+		return nil, nil, nil, nil, nil, nil, nil, err
+	}
 	agg, err := state.NewAggregator2(ctx, dirs, config3.DefaultStepSize, salt, db, logger)
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, err

--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -2265,6 +2265,9 @@ func dbCfg(label kv.Label, path string) mdbx.MdbxOpts {
 		Accede(true) // integration tool: open db without creation and without blocking erigon
 }
 func openAgg(ctx context.Context, dirs datadir.Dirs, chainDB kv.RwDB, logger log.Logger) *state.Aggregator {
+	if err := state.CheckSnapshotsCompatibility(dirs); err != nil {
+		panic(err)
+	}
 	agg, err := state.NewAggregator(ctx, dirs, config3.DefaultStepSize, chainDB, logger)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
`go test -count=1  -cpuprofile=cpu.out -run=TestState/stStaticCall ./tests`

<img width="2340" height="1043" alt="Screenshot 2025-09-02 at 15 41 35" src="https://github.com/user-attachments/assets/f6f54761-e318-45fa-87aa-3737897cb423" />
