### PR TITLE
fix node failure after eth_call with state override

### DIFF
--- a/core/state/intra_block_state.go
+++ b/core/state/intra_block_state.go
@@ -138,7 +138,7 @@ func New(stateReader StateReader) *IntraBlockState {
 		trace:             false,
 		dep:               -1,
 		arbExtraData: &ArbitrumExtraData{
-			unexpectedBalanceDelta: common.Num0,
+			unexpectedBalanceDelta: uint256.NewInt(0),
 			userWasms:              UserWasms{},
 			openWasmPages:          0,
 			everWasmPages:          0,

--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -62,9 +62,6 @@ const estimateGasErrorRatio = 0.015
 
 // Call implements eth_call. Executes a new message call immediately without creating a transaction on the block chain.
 func (api *APIImpl) Call(ctx context.Context, args ethapi2.CallArgs, requestedBlock *rpc.BlockNumberOrHash, overrides *ethapi2.StateOverrides) (hexutil.Bytes, error) {
-	if overrides != nil {
-		return nil, errors.New("state overrides are not supported in eth_call now")
-	}
 	tx, err := api.db.BeginTemporalRo(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
fixing this
https://github.com/erigontech/nitro-erigon/issues/247


Passing `common.Num0` by reference to `ArbitrumExtraData` could overwrite it (turning 0 into something else), which breaks things.