### PR TITLE
fix(etl): use correct buffer size when creating new buffer in background flush

### DIFF
--- a/db/etl/collector.go
+++ b/db/etl/collector.go
@@ -129,7 +129,7 @@ func (c *Collector) flushBuffer(canStoreInRam bool) error {
 				c.buf = c.allocator.Get()
 			} else {
 				prevLen, prevSize := fullBuf.Len(), fullBuf.SizeLimit()
-				c.buf = getBufferByType(c.bufType, datasize.ByteSize(c.buf.SizeLimit()))
+				c.buf = getBufferByType(c.bufType, datasize.ByteSize(fullBuf.SizeLimit()))
 				c.buf.Prealloc(prevLen/8, prevSize/8)
 			}
 			provider, err = FlushToDiskAsync(c.logPrefix, fullBuf, c.tmpdir, c.logLvl, c.allocator)


### PR DESCRIPTION
Fixed a bug in the ETL collector's flushBuffer method where the wrong buffer reference was used when creating a new buffer for background flushing operations. The code was incorrectly using c.buf.SizeLimit() instead of fullBuf.SizeLimit(), which could result in creating buffers with incorrect size limits when sortAndFlushInBackground is enabled. This fix ensures proper buffer size allocation and prevents potential performance degradation or memory allocation issues during ETL operations.