### PR TITLE
fix: correct path to fork configurations in EVM README

### DIFF
--- a/cmd/evm/README.md
+++ b/cmd/evm/README.md
@@ -214,7 +214,7 @@ exitcode:3 OK
 
 The chain configuration to be used for a transition is specified via the
 `--state.fork` CLI flag. A list of possible values and configurations can be
-found in [`tests/init.go`](../../tests/init.go).
+found in [`execution/testutil/forks.go`](../../execution/testutil/forks.go).
 
 #### Examples
 ##### Basic usage


### PR DESCRIPTION
Fix broken link to fork configurations - point to execution/testutil/forks.go
instead of non-existent tests/init.go.