### PR TITLE
tidy up proto imports

### DIFF
--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -26,7 +26,7 @@ import (
 
 	"golang.org/x/sync/semaphore"
 
-	proto_downloader "github.com/erigontech/erigon-lib/gointerfaces/downloaderproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/downloaderproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cl/beacon/synced_data"
 	"github.com/erigontech/erigon/cl/clparams"
@@ -48,7 +48,7 @@ type Antiquary struct {
 	mainDB                         kv.RwDB                  // this is the main DB
 	blobStorage                    blob_storage.BlobStorage // this is the blob storage
 	dirs                           datadir.Dirs
-	downloader                     proto_downloader.DownloaderClient
+	downloader                     downloaderproto.DownloaderClient
 	logger                         log.Logger
 	sn                             *freezeblocks.CaplinSnapshots
 	stateSn                        *snapshotsync.CaplinStateSnapshots
@@ -68,7 +68,7 @@ type Antiquary struct {
 	balances32   []byte
 }
 
-func NewAntiquary(ctx context.Context, blobStorage blob_storage.BlobStorage, genesisState *state.CachingBeaconState, validatorsTable *state_accessors.StaticValidatorTable, cfg *clparams.BeaconChainConfig, dirs datadir.Dirs, downloader proto_downloader.DownloaderClient, mainDB kv.RwDB, stateSn *snapshotsync.CaplinStateSnapshots, sn *freezeblocks.CaplinSnapshots, reader freezeblocks.BeaconSnapshotReader, syncedData synced_data.SyncedData, logger log.Logger, states, blocks, blobs, snapgen bool, snBuildSema *semaphore.Weighted) *Antiquary {
+func NewAntiquary(ctx context.Context, blobStorage blob_storage.BlobStorage, genesisState *state.CachingBeaconState, validatorsTable *state_accessors.StaticValidatorTable, cfg *clparams.BeaconChainConfig, dirs datadir.Dirs, downloader downloaderproto.DownloaderClient, mainDB kv.RwDB, stateSn *snapshotsync.CaplinStateSnapshots, sn *freezeblocks.CaplinSnapshots, reader freezeblocks.BeaconSnapshotReader, syncedData synced_data.SyncedData, logger log.Logger, states, blocks, blobs, snapgen bool, snBuildSema *semaphore.Weighted) *Antiquary {
 	backfilled := &atomic.Bool{}
 	blobBackfilled := &atomic.Bool{}
 	backfilled.Store(false)
@@ -126,7 +126,7 @@ func (a *Antiquary) Loop() error {
 		return nil
 	}
 	if a.downloader != nil {
-		completedReply, err := a.downloader.Completed(a.ctx, &proto_downloader.CompletedRequest{})
+		completedReply, err := a.downloader.Completed(a.ctx, &downloaderproto.CompletedRequest{})
 		if err != nil {
 			return err
 		}
@@ -137,7 +137,7 @@ func (a *Antiquary) Loop() error {
 		for (!completedReply.Completed || !doesSnapshotDirHaveBeaconBlocksFiles(a.dirs.Snap)) && !a.backfilled.Load() {
 			select {
 			case <-reCheckTicker.C:
-				completedReply, err = a.downloader.Completed(a.ctx, &proto_downloader.CompletedRequest{})
+				completedReply, err = a.downloader.Completed(a.ctx, &downloaderproto.CompletedRequest{})
 				if err != nil {
 					return err
 				}
@@ -337,15 +337,15 @@ func (a *Antiquary) antiquate() error {
 	}
 
 	paths := a.sn.SegFileNames(from, to)
-	downloadItems := make([]*proto_downloader.AddItem, len(paths))
+	downloadItems := make([]*downloaderproto.AddItem, len(paths))
 	for i, path := range paths {
-		downloadItems[i] = &proto_downloader.AddItem{
+		downloadItems[i] = &downloaderproto.AddItem{
 			Path: path,
 		}
 	}
 	if a.downloader != nil {
 		// Notify bittorent to seed the new snapshots
-		if _, err := a.downloader.Add(a.ctx, &proto_downloader.AddRequest{Items: downloadItems}); err != nil {
+		if _, err := a.downloader.Add(a.ctx, &downloaderproto.AddRequest{Items: downloadItems}); err != nil {
 			a.logger.Warn("[Antiquary] Failed to add items to bittorent", "err", err)
 		}
 	}
@@ -418,15 +418,15 @@ func (a *Antiquary) antiquateBlobs() error {
 	}
 
 	paths := a.sn.SegFileNames(currentBlobsProgress, to)
-	downloadItems := make([]*proto_downloader.AddItem, len(paths))
+	downloadItems := make([]*downloaderproto.AddItem, len(paths))
 	for i, path := range paths {
-		downloadItems[i] = &proto_downloader.AddItem{
+		downloadItems[i] = &downloaderproto.AddItem{
 			Path: path,
 		}
 	}
 	if a.downloader != nil {
 		// Notify bittorent to seed the new snapshots
-		if _, err := a.downloader.Add(a.ctx, &proto_downloader.AddRequest{Items: downloadItems}); err != nil {
+		if _, err := a.downloader.Add(a.ctx, &downloaderproto.AddRequest{Items: downloadItems}); err != nil {
 			a.logger.Warn("[Antiquary] Failed to add items to bittorent", "err", err)
 		}
 	}

--- a/cl/antiquary/state_antiquary.go
+++ b/cl/antiquary/state_antiquary.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/erigontech/erigon-lib/common"
-	proto_downloader "github.com/erigontech/erigon-lib/gointerfaces/downloaderproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/downloaderproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/clparams/initial_state"
@@ -568,15 +568,15 @@ func (s *Antiquary) IncrementBeaconState(ctx context.Context, to uint64) error {
 			return err
 		}
 		paths := s.stateSn.SegFileNames(from, to)
-		downloadItems := make([]*proto_downloader.AddItem, len(paths))
+		downloadItems := make([]*downloaderproto.AddItem, len(paths))
 		for i, path := range paths {
-			downloadItems[i] = &proto_downloader.AddItem{
+			downloadItems[i] = &downloaderproto.AddItem{
 				Path: path,
 			}
 		}
 		if s.downloader != nil {
 			// Notify bittorent to seed the new snapshots
-			if _, err := s.downloader.Add(s.ctx, &proto_downloader.AddRequest{Items: downloadItems}); err != nil {
+			if _, err := s.downloader.Add(s.ctx, &downloaderproto.AddRequest{Items: downloadItems}); err != nil {
 				s.logger.Warn("[Antiquary] Failed to add items to bittorent", "err", err)
 			}
 		}

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -38,7 +38,7 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/hexutil"
 	"github.com/erigontech/erigon-lib/common/length"
-	sentinel "github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cl/abstract"
 	"github.com/erigontech/erigon/cl/beacon/beaconhttp"
@@ -1273,7 +1273,7 @@ func (a *ApiHandler) broadcastBlock(ctx context.Context, blk *cltypes.SignedBeac
 		lenBlobs,
 	)
 	// Broadcast the block and its blobs
-	if _, err := a.sentinel.PublishGossip(ctx, &sentinel.GossipData{
+	if _, err := a.sentinel.PublishGossip(ctx, &sentinelproto.GossipData{
 		Name: gossip.TopicNameBeaconBlock,
 		Data: blkSSZ,
 	}); err != nil {
@@ -1283,7 +1283,7 @@ func (a *ApiHandler) broadcastBlock(ctx context.Context, blk *cltypes.SignedBeac
 	if blk.Version() < clparams.FuluVersion {
 		for idx, blob := range blobsSidecarsBytes {
 			idx64 := uint64(idx)
-			if _, err := a.sentinel.PublishGossip(ctx, &sentinel.GossipData{
+			if _, err := a.sentinel.PublishGossip(ctx, &sentinelproto.GossipData{
 				Name:     gossip.TopicNamePrefixBlobSidecar,
 				Data:     blob,
 				SubnetId: &idx64,
@@ -1301,7 +1301,7 @@ func (a *ApiHandler) broadcastBlock(ctx context.Context, blk *cltypes.SignedBeac
 				continue
 			}
 			subnet := das.ComputeSubnetForDataColumnSidecar(column.Index)
-			if _, err := a.sentinel.PublishGossip(ctx, &sentinel.GossipData{
+			if _, err := a.sentinel.PublishGossip(ctx, &sentinelproto.GossipData{
 				Name:     gossip.TopicNamePrefixDataColumnSidecar,
 				Data:     columnSSZ,
 				SubnetId: &subnet,

--- a/cl/beacon/handler/handler.go
+++ b/cl/beacon/handler/handler.go
@@ -24,7 +24,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/erigontech/erigon-lib/common"
-	sentinel "github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cl/aggregation"
 	"github.com/erigontech/erigon/cl/beacon/beacon_router_configuration"
@@ -75,7 +75,7 @@ type ApiHandler struct {
 	operationsPool       pool.OperationsPool
 	syncedData           synced_data.SyncedData
 	stateReader          *historical_states_reader.HistoricalStatesReader
-	sentinel             sentinel.SentinelClient
+	sentinel             sentinelproto.SentinelClient
 	blobStoage           blob_storage.BlobStorage
 	columnStorage        blob_storage.DataColumnStorage
 	caplinSnapshots      *freezeblocks.CaplinSnapshots
@@ -127,7 +127,7 @@ func NewApiHandler(
 	rcsn freezeblocks.BeaconSnapshotReader,
 	syncedData synced_data.SyncedData,
 	stateReader *historical_states_reader.HistoricalStatesReader,
-	sentinel sentinel.SentinelClient,
+	sentinel sentinelproto.SentinelClient,
 	version string,
 	routerCfg *beacon_router_configuration.RouterConfiguration,
 	emitters *beaconevents.EventEmitter,

--- a/cl/beacon/handler/node.go
+++ b/cl/beacon/handler/node.go
@@ -23,7 +23,7 @@ import (
 	"runtime"
 	"strconv"
 
-	sentinel "github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
 	"github.com/erigontech/erigon/cl/beacon/beaconhttp"
 )
 
@@ -68,7 +68,7 @@ func (a *ApiHandler) GetEthV1NodeVersion(w http.ResponseWriter, r *http.Request)
 }
 
 func (a *ApiHandler) GetEthV1NodePeerCount(w http.ResponseWriter, r *http.Request) (*beaconhttp.BeaconResponse, error) {
-	ret, err := a.sentinel.GetPeers(r.Context(), &sentinel.EmptyMessage{})
+	ret, err := a.sentinel.GetPeers(r.Context(), &sentinelproto.EmptyMessage{})
 	if err != nil {
 		return nil, beaconhttp.NewEndpointError(http.StatusInternalServerError, err)
 	}
@@ -94,7 +94,7 @@ func (a *ApiHandler) GetEthV1NodePeersInfos(w http.ResponseWriter, r *http.Reque
 		directionIn = &direction
 	}
 
-	ret, err := a.sentinel.PeersInfo(r.Context(), &sentinel.PeersInfoRequest{
+	ret, err := a.sentinel.PeersInfo(r.Context(), &sentinelproto.PeersInfoRequest{
 		Direction: directionIn,
 		State:     stateIn,
 	})
@@ -121,7 +121,7 @@ func (a *ApiHandler) GetEthV1NodePeerInfos(w http.ResponseWriter, r *http.Reques
 	if err != nil {
 		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
 	}
-	ret, err := a.sentinel.PeersInfo(r.Context(), &sentinel.PeersInfoRequest{})
+	ret, err := a.sentinel.PeersInfo(r.Context(), &sentinelproto.PeersInfoRequest{})
 	if err != nil {
 		return nil, beaconhttp.NewEndpointError(http.StatusInternalServerError, err)
 	}
@@ -143,7 +143,7 @@ func (a *ApiHandler) GetEthV1NodePeerInfos(w http.ResponseWriter, r *http.Reques
 }
 
 func (a *ApiHandler) GetEthV1NodeIdentity(w http.ResponseWriter, r *http.Request) (*beaconhttp.BeaconResponse, error) {
-	id, err := a.sentinel.Identity(r.Context(), &sentinel.EmptyMessage{})
+	id, err := a.sentinel.Identity(r.Context(), &sentinelproto.EmptyMessage{})
 	if err != nil {
 		return nil, beaconhttp.NewEndpointError(http.StatusInternalServerError, err)
 	}

--- a/cl/beacon/handler/pool.go
+++ b/cl/beacon/handler/pool.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 	"net/http"
 
-	sentinel "github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cl/beacon/beaconhttp"
 	"github.com/erigontech/erigon/cl/clparams"
@@ -146,7 +146,7 @@ func (a *ApiHandler) PostEthV1BeaconPoolAttestations(w http.ResponseWriter, r *h
 			continue
 		}
 		if a.sentinel != nil {
-			if _, err := a.sentinel.PublishGossip(r.Context(), &sentinel.GossipData{
+			if _, err := a.sentinel.PublishGossip(r.Context(), &sentinelproto.GossipData{
 				Data:     encodedSSZ,
 				Name:     gossip.TopicNamePrefixBeaconAttestation,
 				SubnetId: &subnet,
@@ -223,7 +223,7 @@ func (a *ApiHandler) PostEthV2BeaconPoolAttestations(w http.ResponseWriter, r *h
 			continue
 		}
 		if a.sentinel != nil {
-			if _, err := a.sentinel.PublishGossip(r.Context(), &sentinel.GossipData{
+			if _, err := a.sentinel.PublishGossip(r.Context(), &sentinelproto.GossipData{
 				Data:     encodedSSZ,
 				Name:     gossip.TopicNamePrefixBeaconAttestation,
 				SubnetId: &subnet,
@@ -269,7 +269,7 @@ func (a *ApiHandler) PostEthV1BeaconPoolVoluntaryExits(w http.ResponseWriter, r 
 	}
 	a.operationsPool.VoluntaryExitsPool.Insert(req.VoluntaryExit.ValidatorIndex, &req)
 	if a.sentinel != nil {
-		if _, err := a.sentinel.PublishGossip(r.Context(), &sentinel.GossipData{
+		if _, err := a.sentinel.PublishGossip(r.Context(), &sentinelproto.GossipData{
 			Data: encodedSSZ,
 			Name: gossip.TopicNameVoluntaryExit,
 		}); err != nil {
@@ -299,7 +299,7 @@ func (a *ApiHandler) PostEthV1BeaconPoolAttesterSlashings(w http.ResponseWriter,
 			beaconhttp.NewEndpointError(http.StatusInternalServerError, err).WriteTo(w)
 			return
 		}
-		if _, err := a.sentinel.PublishGossip(r.Context(), &sentinel.GossipData{
+		if _, err := a.sentinel.PublishGossip(r.Context(), &sentinelproto.GossipData{
 			Data: encodedSSZ,
 			Name: gossip.TopicNameAttesterSlashing,
 		}); err != nil {
@@ -327,7 +327,7 @@ func (a *ApiHandler) PostEthV1BeaconPoolProposerSlashings(w http.ResponseWriter,
 			beaconhttp.NewEndpointError(http.StatusInternalServerError, err).WriteTo(w)
 			return
 		}
-		if _, err := a.sentinel.PublishGossip(r.Context(), &sentinel.GossipData{
+		if _, err := a.sentinel.PublishGossip(r.Context(), &sentinelproto.GossipData{
 			Data: encodedSSZ,
 			Name: gossip.TopicNameProposerSlashing,
 		}); err != nil {
@@ -370,7 +370,7 @@ func (a *ApiHandler) PostEthV1BeaconPoolBlsToExecutionChanges(w http.ResponseWri
 			continue
 		}
 		if a.sentinel != nil {
-			if _, err := a.sentinel.PublishGossip(r.Context(), &sentinel.GossipData{
+			if _, err := a.sentinel.PublishGossip(r.Context(), &sentinelproto.GossipData{
 				Data: encodedSSZ,
 				Name: gossip.TopicNameBlsToExecutionChange,
 			}); err != nil {
@@ -416,7 +416,7 @@ func (a *ApiHandler) PostEthV1ValidatorAggregatesAndProof(w http.ResponseWriter,
 		}
 
 		if a.sentinel != nil {
-			if _, err := a.sentinel.PublishGossip(r.Context(), &sentinel.GossipData{
+			if _, err := a.sentinel.PublishGossip(r.Context(), &sentinelproto.GossipData{
 				Data: encodedSSZ,
 				Name: gossip.TopicNameBeaconAggregateAndProof,
 			}); err != nil {
@@ -478,7 +478,7 @@ func (a *ApiHandler) PostEthV1BeaconPoolSyncCommittees(w http.ResponseWriter, r 
 				break
 			}
 			if a.sentinel != nil {
-				if _, err := a.sentinel.PublishGossip(r.Context(), &sentinel.GossipData{
+				if _, err := a.sentinel.PublishGossip(r.Context(), &sentinelproto.GossipData{
 					Data:     encodedSSZ,
 					Name:     gossip.TopicNamePrefixSyncCommittee,
 					SubnetId: &subnetId,
@@ -528,7 +528,7 @@ func (a *ApiHandler) PostEthV1ValidatorContributionsAndProofs(w http.ResponseWri
 			continue
 		}
 		if a.sentinel != nil {
-			if _, err := a.sentinel.PublishGossip(r.Context(), &sentinel.GossipData{
+			if _, err := a.sentinel.PublishGossip(r.Context(), &sentinelproto.GossipData{
 				Data: encodedSSZ,
 				Name: gossip.TopicNameSyncCommitteeContributionAndProof,
 			}); err != nil {

--- a/cl/beacon/handler/subscription.go
+++ b/cl/beacon/handler/subscription.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"github.com/erigontech/erigon-lib/common"
-	sentinel "github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cl/beacon/beaconhttp"
 	"github.com/erigontech/erigon/cl/cltypes"
@@ -89,7 +89,7 @@ func (a *ApiHandler) PostEthV1ValidatorSyncCommitteeSubscriptions(w http.Respons
 
 		// subscribe to subnets
 		for _, subnet := range syncnets {
-			if _, err := a.sentinel.SetSubscribeExpiry(r.Context(), &sentinel.RequestSubscribeExpiry{
+			if _, err := a.sentinel.SetSubscribeExpiry(r.Context(), &sentinelproto.RequestSubscribeExpiry{
 				Topic:          gossip.TopicNameSyncCommittee(int(subnet)),
 				ExpiryUnixSecs: uint64(expiry.Unix()),
 			}); err != nil {

--- a/cl/phase1/execution_client/execution_client_direct.go
+++ b/cl/phase1/execution_client/execution_client_direct.go
@@ -24,9 +24,9 @@ import (
 	"math/big"
 	"time"
 
-	common "github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/hexutil"
-	execution "github.com/erigontech/erigon-lib/gointerfaces/executionproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/executionproto"
 	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
@@ -106,11 +106,11 @@ func (cc *ExecutionClientDirect) NewPayload(
 	monitor.ObserveExecutionClientValidateChain(startValidateChain)
 	// check status
 	switch status {
-	case execution.ExecutionStatus_BadBlock, execution.ExecutionStatus_InvalidForkchoice:
+	case executionproto.ExecutionStatus_BadBlock, executionproto.ExecutionStatus_InvalidForkchoice:
 		return PayloadStatusInvalidated, errors.New("bad block")
-	case execution.ExecutionStatus_Busy, execution.ExecutionStatus_MissingSegment, execution.ExecutionStatus_TooFarAway:
+	case executionproto.ExecutionStatus_Busy, executionproto.ExecutionStatus_MissingSegment, executionproto.ExecutionStatus_TooFarAway:
 		return PayloadStatusNotValidated, nil
-	case execution.ExecutionStatus_Success:
+	case executionproto.ExecutionStatus_Success:
 		return PayloadStatusValidated, nil
 	}
 	return PayloadStatusNone, errors.New("unexpected status")
@@ -121,10 +121,10 @@ func (cc *ExecutionClientDirect) ForkChoiceUpdate(ctx context.Context, finalized
 	if err != nil {
 		return nil, fmt.Errorf("execution Client RPC failed to retrieve ForkChoiceUpdate response, err: %w", err)
 	}
-	if status == execution.ExecutionStatus_InvalidForkchoice {
+	if status == executionproto.ExecutionStatus_InvalidForkchoice {
 		return nil, errors.New("forkchoice was invalid")
 	}
-	if status == execution.ExecutionStatus_BadBlock {
+	if status == executionproto.ExecutionStatus_BadBlock {
 		return nil, errors.New("bad block as forkchoice")
 	}
 	if attr == nil {

--- a/cl/phase1/execution_client/interface.go
+++ b/cl/phase1/execution_client/interface.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"math/big"
 
-	common "github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/hexutil"
 	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 	"github.com/erigontech/erigon/cl/cltypes"

--- a/cl/phase1/network/services/aggregate_and_proof_service.go
+++ b/cl/phase1/network/services/aggregate_and_proof_service.go
@@ -27,7 +27,7 @@ import (
 	"github.com/erigontech/erigon/cl/utils/bls"
 
 	"github.com/erigontech/erigon-lib/common"
-	sentinel "github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 
 	"github.com/erigontech/erigon/cl/beacon/synced_data"
@@ -47,11 +47,11 @@ import (
 // SignedAggregateAndProofData is passed to SignedAggregateAndProof service. The service does the signature verification
 // asynchronously. That's why we cannot wait for its ProcessMessage call to finish to check error. The service
 // will do re-publishing of the gossip or banning the peer in case of invalid signature by itself.
-// that's why we are passing sentinel.SentinelClient and *sentinel.GossipData to enable the service
+// that's why we are passing sentinelproto.SentinelClient and *sentinelproto.GossipData to enable the service
 // to do all of that by itself.
 type SignedAggregateAndProofForGossip struct {
 	SignedAggregateAndProof *cltypes.SignedAggregateAndProof
-	Receiver                *sentinel.Peer
+	Receiver                *sentinelproto.Peer
 	ImmediateProcess        bool
 }
 

--- a/cl/phase1/network/services/attestation_service.go
+++ b/cl/phase1/network/services/attestation_service.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/erigontech/erigon-lib/common"
-	sentinel "github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cl/aggregation"
 	"github.com/erigontech/erigon/cl/beacon/beaconevents"
@@ -65,7 +65,7 @@ type attestationService struct {
 type AttestationForGossip struct {
 	Attestation       *solid.Attestation
 	SingleAttestation *solid.SingleAttestation // New container after Electra
-	Receiver          *sentinel.Peer
+	Receiver          *sentinelproto.Peer
 	// ImmediateProcess indicates whether the attestation should be processed immediately or able to be scheduled for later processing.
 	ImmediateProcess bool
 }

--- a/cl/phase1/network/services/batch_signature_verification.go
+++ b/cl/phase1/network/services/batch_signature_verification.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"time"
 
-	sentinel "github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cl/monitor"
 	"github.com/erigontech/erigon/cl/utils/bls"
@@ -22,7 +22,7 @@ var (
 )
 
 type BatchSignatureVerifier struct {
-	sentinel                   sentinel.SentinelClient
+	sentinel                   sentinelproto.SentinelClient
 	attVerifyAndExecute        chan *AggregateVerificationData
 	aggregateProofVerify       chan *AggregateVerificationData
 	blsToExecutionChangeVerify chan *AggregateVerificationData
@@ -34,7 +34,7 @@ type BatchSignatureVerifier struct {
 
 var ErrInvalidBlsSignature = errors.New("invalid bls signature")
 
-// each AggregateVerification request has sentinel.SentinelClient and *sentinel.GossipData
+// each AggregateVerification request has sentinelproto.SentinelClient and *sentinelproto.GossipData
 // to make sure that we can validate it separately and in case of failure we ban corresponding
 // GossipData.Peer or simply run F and publish GossipData in case signature verification succeeds.
 type AggregateVerificationData struct {
@@ -42,10 +42,10 @@ type AggregateVerificationData struct {
 	SignRoots   [][]byte
 	Pks         [][]byte
 	F           func()
-	SendingPeer *sentinel.Peer
+	SendingPeer *sentinelproto.Peer
 }
 
-func NewBatchSignatureVerifier(ctx context.Context, sentinel sentinel.SentinelClient) *BatchSignatureVerifier {
+func NewBatchSignatureVerifier(ctx context.Context, sentinel sentinelproto.SentinelClient) *BatchSignatureVerifier {
 	return &BatchSignatureVerifier{
 		ctx:                        ctx,
 		sentinel:                   sentinel,

--- a/cl/phase1/network/services/bls_to_execution_change_service.go
+++ b/cl/phase1/network/services/bls_to_execution_change_service.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 
 	"github.com/erigontech/erigon-lib/common"
-	sentinel "github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
 	"github.com/erigontech/erigon/cl/beacon/beaconevents"
 	"github.com/erigontech/erigon/cl/beacon/synced_data"
 	"github.com/erigontech/erigon/cl/clparams"
@@ -37,7 +37,7 @@ import (
 // SignedBLSToExecutionChangeForGossip type represents SignedBLSToExecutionChange with the gossip data where it's coming from.
 type SignedBLSToExecutionChangeForGossip struct {
 	SignedBLSToExecutionChange *cltypes.SignedBLSToExecutionChange
-	Receiver                   *sentinel.Peer
+	Receiver                   *sentinelproto.Peer
 	ImmediateVerification      bool
 }
 

--- a/cl/phase1/network/services/sync_committee_messages_service.go
+++ b/cl/phase1/network/services/sync_committee_messages_service.go
@@ -22,7 +22,7 @@ import (
 	"slices"
 	"sync"
 
-	sentinel "github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
 	"github.com/erigontech/erigon/cl/beacon/synced_data"
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
@@ -53,7 +53,7 @@ type syncCommitteeMessagesService struct {
 
 type SyncCommitteeMessageForGossip struct {
 	SyncCommitteeMessage  *cltypes.SyncCommitteeMessage
-	Receiver              *sentinel.Peer
+	Receiver              *sentinelproto.Peer
 	ImmediateVerification bool
 }
 

--- a/cl/phase1/network/services/sync_contribution_service.go
+++ b/cl/phase1/network/services/sync_contribution_service.go
@@ -27,7 +27,7 @@ import (
 	"github.com/erigontech/erigon/cl/utils/bls"
 
 	"github.com/erigontech/erigon-lib/common"
-	sentinel "github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
 	"github.com/erigontech/erigon/cl/beacon/beaconevents"
 	"github.com/erigontech/erigon/cl/beacon/synced_data"
 	"github.com/erigontech/erigon/cl/clparams"
@@ -62,7 +62,7 @@ type syncContributionService struct {
 // SignedContributionAndProofWithGossipData type represents SignedContributionAndProof with the gossip data where it's coming from.
 type SignedContributionAndProofForGossip struct {
 	SignedContributionAndProof *cltypes.SignedContributionAndProof
-	Receiver                   *sentinel.Peer
+	Receiver                   *sentinelproto.Peer
 	ImmediateVerification      bool
 }
 

--- a/cl/phase1/network/services/voluntary_exit_service.go
+++ b/cl/phase1/network/services/voluntary_exit_service.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 
 	"github.com/erigontech/erigon-lib/common"
-	sentinel "github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
 	"github.com/erigontech/erigon/cl/beacon/beaconevents"
 	"github.com/erigontech/erigon/cl/beacon/synced_data"
 	"github.com/erigontech/erigon/cl/clparams"
@@ -46,7 +46,7 @@ type voluntaryExitService struct {
 // SignedVoluntaryExitForGossip type represents SignedVoluntaryExit with the gossip data where it's coming from.
 type SignedVoluntaryExitForGossip struct {
 	SignedVoluntaryExit   *cltypes.SignedVoluntaryExit
-	Receiver              *sentinel.Peer
+	Receiver              *sentinelproto.Peer
 	ImmediateVerification bool
 }
 

--- a/cl/rpc/peer_selection.go
+++ b/cl/rpc/peer_selection.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	sentinel "github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon-lib/types/ssz"
 	"github.com/erigontech/erigon/cl/clparams"
@@ -31,7 +31,7 @@ var (
 )
 
 type columnDataPeers struct {
-	sentinel      sentinel.SentinelClient
+	sentinel      sentinelproto.SentinelClient
 	beaconConfig  *clparams.BeaconChainConfig
 	ethClock      eth_clock.EthereumClock
 	peerMetaCache *lru.CacheWithTTL[peerDataKey, *peerData]
@@ -43,7 +43,7 @@ type columnDataPeers struct {
 }
 
 func newColumnPeers(
-	sentinel sentinel.SentinelClient,
+	sentinel sentinelproto.SentinelClient,
 	beaconConfig *clparams.BeaconChainConfig,
 	ethClock eth_clock.EthereumClock,
 	beaconState *state.CachingBeaconState,
@@ -80,7 +80,7 @@ func (c *columnDataPeers) refreshPeers(ctx context.Context) {
 		}
 		begin := time.Now()
 		state := "connected"
-		peers, err := c.sentinel.PeersInfo(ctx, &sentinel.PeersInfoRequest{
+		peers, err := c.sentinel.PeersInfo(ctx, &sentinelproto.PeersInfoRequest{
 			State: &state,
 		})
 		if err != nil {
@@ -173,7 +173,7 @@ func (c *columnDataPeers) refreshPeers(ctx context.Context) {
 }
 
 func (c *columnDataPeers) simpleReuqest(ctx context.Context, pid string, topic string, respContainer ssz.EncodableSSZ, payload []byte) error {
-	resp, err := c.sentinel.SendPeerRequest(ctx, &sentinel.RequestDataWithPeer{
+	resp, err := c.sentinel.SendPeerRequest(ctx, &sentinelproto.RequestDataWithPeer{
 		Pid:   pid,
 		Data:  payload,
 		Topic: topic,

--- a/cl/sentinel/sentinel.go
+++ b/cl/sentinel/sentinel.go
@@ -40,7 +40,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/erigontech/erigon-lib/crypto"
-	sentinelrpc "github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cl/cltypes"
 	peerdasstate "github.com/erigontech/erigon/cl/das/state"
@@ -501,13 +501,13 @@ func (s *Sentinel) GetPeersCount() (active int, connected int, disconnected int)
 	return
 }
 
-func (s *Sentinel) GetPeersInfos() *sentinelrpc.PeersInfoResponse {
+func (s *Sentinel) GetPeersInfos() *sentinelproto.PeersInfoResponse {
 	peers := s.host.Network().Peers()
 
-	out := &sentinelrpc.PeersInfoResponse{Peers: make([]*sentinelrpc.Peer, 0, len(peers))}
+	out := &sentinelproto.PeersInfoResponse{Peers: make([]*sentinelproto.Peer, 0, len(peers))}
 
 	for _, p := range peers {
-		entry := &sentinelrpc.Peer{}
+		entry := &sentinelproto.Peer{}
 		peerInfo := s.host.Network().Peerstore().PeerInfo(p)
 		if len(peerInfo.Addrs) == 0 {
 			continue

--- a/cl/sentinel/service/service.go
+++ b/cl/sentinel/service/service.go
@@ -32,7 +32,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	sentinelrpc "github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/gossip"
@@ -44,10 +44,10 @@ import (
 
 const gracePeerCount = 8
 
-var _ sentinelrpc.SentinelServer = (*SentinelServer)(nil)
+var _ sentinelproto.SentinelServer = (*SentinelServer)(nil)
 
 type SentinelServer struct {
-	sentinelrpc.UnimplementedSentinelServer
+	sentinelproto.UnimplementedSentinelServer
 
 	ctx            context.Context
 	sentinel       *sentinel.Sentinel
@@ -85,10 +85,10 @@ func extractSubnetIndexByGossipTopic(name string) int {
 
 //BanPeer(context.Context, *Peer) (*EmptyMessage, error)
 
-func (s *SentinelServer) BanPeer(_ context.Context, p *sentinelrpc.Peer) (*sentinelrpc.EmptyMessage, error) {
+func (s *SentinelServer) BanPeer(_ context.Context, p *sentinelproto.Peer) (*sentinelproto.EmptyMessage, error) {
 	active, _, _ := s.sentinel.GetPeersCount()
 	if active < gracePeerCount {
-		return &sentinelrpc.EmptyMessage{}, nil
+		return &sentinelproto.EmptyMessage{}, nil
 	}
 
 	var pid peer.ID
@@ -98,10 +98,10 @@ func (s *SentinelServer) BanPeer(_ context.Context, p *sentinelrpc.Peer) (*senti
 	s.sentinel.Peers().SetBanStatus(pid, true)
 	s.sentinel.Host().Peerstore().RemovePeer(pid)
 	s.sentinel.Host().Network().ClosePeer(pid)
-	return &sentinelrpc.EmptyMessage{}, nil
+	return &sentinelproto.EmptyMessage{}, nil
 }
 
-func (s *SentinelServer) PublishGossip(_ context.Context, msg *sentinelrpc.GossipData) (*sentinelrpc.EmptyMessage, error) {
+func (s *SentinelServer) PublishGossip(_ context.Context, msg *sentinelproto.GossipData) (*sentinelproto.EmptyMessage, error) {
 	manager := s.sentinel.GossipManager()
 	// Snappify payload before sending it to gossip
 	compressedData := utils.CompressSnappy(msg.Data)
@@ -143,16 +143,16 @@ func (s *SentinelServer) PublishGossip(_ context.Context, msg *sentinelrpc.Gossi
 			}
 			subscription = manager.GetMatchingSubscription(gossip.TopicNameDataColumnSidecar(*msg.SubnetId))
 		default:
-			return &sentinelrpc.EmptyMessage{}, fmt.Errorf("unknown topic %s", msg.Name)
+			return &sentinelproto.EmptyMessage{}, fmt.Errorf("unknown topic %s", msg.Name)
 		}
 	}
 	if subscription == nil {
-		return &sentinelrpc.EmptyMessage{}, fmt.Errorf("unknown topic %s", msg.Name)
+		return &sentinelproto.EmptyMessage{}, fmt.Errorf("unknown topic %s", msg.Name)
 	}
-	return &sentinelrpc.EmptyMessage{}, subscription.Publish(compressedData)
+	return &sentinelproto.EmptyMessage{}, subscription.Publish(compressedData)
 }
 
-func (s *SentinelServer) SubscribeGossip(data *sentinelrpc.SubscriptionData, stream sentinelrpc.Sentinel_SubscribeGossipServer) error {
+func (s *SentinelServer) SubscribeGossip(data *sentinelproto.SubscriptionData, stream sentinelproto.Sentinel_SubscribeGossipServer) error {
 	// first of all subscribe
 	ch, subId, err := s.gossipNotifier.addSubscriber()
 	if err != nil {
@@ -169,10 +169,10 @@ func (s *SentinelServer) SubscribeGossip(data *sentinelrpc.SubscriptionData, str
 			if !s.gossipMatchSubscription(packet, data) {
 				continue
 			}
-			if err := stream.Send(&sentinelrpc.GossipData{
+			if err := stream.Send(&sentinelproto.GossipData{
 				Data: packet.data,
 				Name: packet.t,
-				Peer: &sentinelrpc.Peer{
+				Peer: &sentinelproto.Peer{
 					Pid: packet.pid,
 				},
 				SubnetId: packet.subnetId,
@@ -183,7 +183,7 @@ func (s *SentinelServer) SubscribeGossip(data *sentinelrpc.SubscriptionData, str
 	}
 }
 
-func (s *SentinelServer) gossipMatchSubscription(obj gossipObject, data *sentinelrpc.SubscriptionData) bool {
+func (s *SentinelServer) gossipMatchSubscription(obj gossipObject, data *sentinelproto.SubscriptionData) bool {
 	if data.Filter != nil {
 		filter := data.GetFilter()
 		matched, err := path.Match(obj.t, filter)
@@ -211,7 +211,7 @@ func (s *SentinelServer) withTimeoutCtx(pctx context.Context, dur time.Duration)
 	return ctx, cn
 }
 
-func (s *SentinelServer) requestPeer(ctx context.Context, pid peer.ID, req *sentinelrpc.RequestData) (*sentinelrpc.ResponseData, error) {
+func (s *SentinelServer) requestPeer(ctx context.Context, pid peer.ID, req *sentinelproto.RequestData) (*sentinelproto.ResponseData, error) {
 	// prepare the http request
 	httpReq, err := http.NewRequest("GET", "http://service.internal/", bytes.NewBuffer(req.Data))
 	if err != nil {
@@ -268,10 +268,10 @@ func (s *SentinelServer) requestPeer(ctx context.Context, pid peer.ID, req *sent
 	if err != nil {
 		return nil, err
 	}
-	ans := &sentinelrpc.ResponseData{
+	ans := &sentinelproto.ResponseData{
 		Data:  data,
 		Error: !responseCode.Success(),
-		Peer: &sentinelrpc.Peer{
+		Peer: &sentinelproto.Peer{
 			Pid: pid.String(),
 		},
 	}
@@ -279,7 +279,7 @@ func (s *SentinelServer) requestPeer(ctx context.Context, pid peer.ID, req *sent
 
 }
 
-func (s *SentinelServer) SendRequest(ctx context.Context, req *sentinelrpc.RequestData) (*sentinelrpc.ResponseData, error) {
+func (s *SentinelServer) SendRequest(ctx context.Context, req *sentinelproto.RequestData) (*sentinelproto.ResponseData, error) {
 	// Try finding the data to our peers
 	// this is using return statements instead of continue, since it saves a few lines
 	// but me writing this comment has put them back.. oh no!!! anyways, returning true means we stop.
@@ -304,12 +304,12 @@ func (s *SentinelServer) SendRequest(ctx context.Context, req *sentinelrpc.Reque
 	return resp, nil
 }
 
-func (s *SentinelServer) SendPeerRequest(ctx context.Context, reqWithPeer *sentinelrpc.RequestDataWithPeer) (*sentinelrpc.ResponseData, error) {
+func (s *SentinelServer) SendPeerRequest(ctx context.Context, reqWithPeer *sentinelproto.RequestDataWithPeer) (*sentinelproto.ResponseData, error) {
 	pid, err := peer.Decode(reqWithPeer.Pid)
 	if err != nil {
 		return nil, err
 	}
-	req := &sentinelrpc.RequestData{
+	req := &sentinelproto.RequestData{
 		Data:  reqWithPeer.Data,
 		Topic: reqWithPeer.Topic,
 	}
@@ -327,15 +327,15 @@ func (s *SentinelServer) SendPeerRequest(ctx context.Context, reqWithPeer *senti
 	return resp, nil
 }
 
-func (s *SentinelServer) Identity(ctx context.Context, in *sentinelrpc.EmptyMessage) (*sentinelrpc.IdentityResponse, error) {
+func (s *SentinelServer) Identity(ctx context.Context, in *sentinelproto.EmptyMessage) (*sentinelproto.IdentityResponse, error) {
 	// call s.sentinel.Identity()
 	pid, enr, p2pAddresses, discoveryAddresses, metadata := s.sentinel.Identity()
-	return &sentinelrpc.IdentityResponse{
+	return &sentinelproto.IdentityResponse{
 		Pid:                pid,
 		Enr:                enr,
 		P2PAddresses:       p2pAddresses,
 		DiscoveryAddresses: discoveryAddresses,
-		Metadata: &sentinelrpc.Metadata{
+		Metadata: &sentinelproto.Metadata{
 			Seq:      metadata.SeqNumber,
 			Attnets:  fmt.Sprintf("%x", metadata.Attnets),
 			Syncnets: fmt.Sprintf("%x", *metadata.Syncnets),
@@ -344,7 +344,7 @@ func (s *SentinelServer) Identity(ctx context.Context, in *sentinelrpc.EmptyMess
 
 }
 
-func (s *SentinelServer) SetStatus(_ context.Context, req *sentinelrpc.Status) (*sentinelrpc.EmptyMessage, error) {
+func (s *SentinelServer) SetStatus(_ context.Context, req *sentinelproto.Status) (*sentinelproto.EmptyMessage, error) {
 	// Send the request and get the data if we get an answer.
 	s.sentinel.SetStatus(&cltypes.Status{
 		ForkDigest:     utils.Uint32ToBytes4(req.ForkDigest),
@@ -353,26 +353,26 @@ func (s *SentinelServer) SetStatus(_ context.Context, req *sentinelrpc.Status) (
 		FinalizedEpoch: req.FinalizedEpoch,
 		HeadSlot:       req.HeadSlot,
 	})
-	return &sentinelrpc.EmptyMessage{}, nil
+	return &sentinelproto.EmptyMessage{}, nil
 }
 
-func (s *SentinelServer) GetPeers(_ context.Context, _ *sentinelrpc.EmptyMessage) (*sentinelrpc.PeerCount, error) {
+func (s *SentinelServer) GetPeers(_ context.Context, _ *sentinelproto.EmptyMessage) (*sentinelproto.PeerCount, error) {
 	count, connected, disconnected := s.sentinel.GetPeersCount()
 	// Send the request and get the data if we get an answer.
-	return &sentinelrpc.PeerCount{
+	return &sentinelproto.PeerCount{
 		Active:       uint64(count),
 		Connected:    uint64(connected),
 		Disconnected: uint64(disconnected),
 	}, nil
 }
 
-func (s *SentinelServer) PeersInfo(ctx context.Context, r *sentinelrpc.PeersInfoRequest) (*sentinelrpc.PeersInfoResponse, error) {
+func (s *SentinelServer) PeersInfo(ctx context.Context, r *sentinelproto.PeersInfoRequest) (*sentinelproto.PeersInfoResponse, error) {
 	peersInfos := s.sentinel.GetPeersInfos()
 	if r.Direction == nil && r.State == nil {
 		return peersInfos, nil
 	}
-	filtered := &sentinelrpc.PeersInfoResponse{
-		Peers: make([]*sentinelrpc.Peer, 0, len(peersInfos.Peers)),
+	filtered := &sentinelproto.PeersInfoResponse{
+		Peers: make([]*sentinelproto.Peer, 0, len(peersInfos.Peers)),
 	}
 	for _, peer := range peersInfos.Peers {
 		if r.Direction != nil && peer.Direction != *r.Direction {
@@ -397,7 +397,7 @@ func (s *SentinelServer) ListenToGossip() {
 	}
 }
 
-func (s *SentinelServer) SetSubscribeExpiry(ctx context.Context, expiryReq *sentinelrpc.RequestSubscribeExpiry) (*sentinelrpc.EmptyMessage, error) {
+func (s *SentinelServer) SetSubscribeExpiry(ctx context.Context, expiryReq *sentinelproto.RequestSubscribeExpiry) (*sentinelproto.EmptyMessage, error) {
 	var (
 		topic      = expiryReq.GetTopic()
 		expiryTime = time.Unix(int64(expiryReq.GetExpiryUnixSecs()), 0)
@@ -407,7 +407,7 @@ func (s *SentinelServer) SetSubscribeExpiry(ctx context.Context, expiryReq *sent
 		return nil, errors.New("no such subscription")
 	}
 	subs.OverwriteSubscriptionExpiry(expiryTime)
-	return &sentinelrpc.EmptyMessage{}, nil
+	return &sentinelproto.EmptyMessage{}, nil
 }
 
 func (s *SentinelServer) handleGossipPacket(pkt *sentinel.GossipMessage) error {

--- a/cl/sentinel/service/start.go
+++ b/cl/sentinel/service/start.go
@@ -28,7 +28,7 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	"github.com/erigontech/erigon-lib/common/math"
-	sentinelrpc "github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cl/cltypes"
 	peerdasstate "github.com/erigontech/erigon/cl/das/state"
@@ -192,7 +192,7 @@ func StartSentinelService(
 	forkChoiceReader forkchoice.ForkChoiceStorageReader,
 	dataColumnStorage blob_storage.DataColumnStorage,
 	PeerDasStateReader peerdasstate.PeerDasStateReader,
-	logger log.Logger) (sentinelrpc.SentinelClient, *enode.LocalNode, error) {
+	logger log.Logger) (sentinelproto.SentinelClient, *enode.LocalNode, error) {
 	ctx := context.Background()
 	sent, localNode, err := createSentinel(
 		cfg,
@@ -232,7 +232,7 @@ func StartServe(
 	gRPCserver := grpc.NewServer(grpc.Creds(creds))
 	go server.ListenToGossip()
 	// Regiser our server as a gRPC server
-	sentinelrpc.RegisterSentinelServer(gRPCserver, server)
+	sentinelproto.RegisterSentinelServer(gRPCserver, server)
 	if err := gRPCserver.Serve(lis); err != nil {
 		log.Warn("[Sentinel] could not serve service", "reason", err)
 	}

--- a/cl/validator/committee_subscription/committee_subscription.go
+++ b/cl/validator/committee_subscription/committee_subscription.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	sentinel "github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cl/aggregation"
 	"github.com/erigontech/erigon/cl/beacon/synced_data"
@@ -53,7 +53,7 @@ type CommitteeSubscribeMgmt struct {
 	ethClock     eth_clock.EthereumClock
 	beaconConfig *clparams.BeaconChainConfig
 	netConfig    *clparams.NetworkConfig
-	sentinel     sentinel.SentinelClient
+	sentinel     sentinelproto.SentinelClient
 	state        *state.CachingBeaconState
 	syncedData   *synced_data.SyncedDataManager
 	// subscriptions
@@ -68,7 +68,7 @@ func NewCommitteeSubscribeManagement(
 	beaconConfig *clparams.BeaconChainConfig,
 	netConfig *clparams.NetworkConfig,
 	ethClock eth_clock.EthereumClock,
-	sentinel sentinel.SentinelClient,
+	sentinel sentinelproto.SentinelClient,
 	aggregationPool aggregation.AggregationPool,
 	syncedData *synced_data.SyncedDataManager,
 ) *CommitteeSubscribeMgmt {
@@ -124,7 +124,7 @@ func (c *CommitteeSubscribeMgmt) AddAttestationSubscription(ctx context.Context,
 
 	epochDuration := time.Duration(c.beaconConfig.SlotsPerEpoch) * time.Duration(c.beaconConfig.SecondsPerSlot) * time.Second
 	// set sentinel gossip expiration by subnet id
-	request := sentinel.RequestSubscribeExpiry{
+	request := sentinelproto.RequestSubscribeExpiry{
 		Topic:          gossip.TopicNameBeaconAttestation(subnetId),
 		ExpiryUnixSecs: uint64(time.Now().Add(epochDuration).Unix()), // expire after epoch
 	}

--- a/cmd/capcli/cli.go
+++ b/cmd/capcli/cli.go
@@ -37,7 +37,7 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/estimate"
-	sentinel "github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon-lib/metrics"
 	"github.com/erigontech/erigon/cl/antiquary"
@@ -114,13 +114,13 @@ func (w *withPPROF) withProfile() {
 	}
 }
 
-func (w *withSentinel) connectSentinel() (sentinel.SentinelClient, error) {
+func (w *withSentinel) connectSentinel() (sentinelproto.SentinelClient, error) {
 	// YOLO message size
 	gconn, err := grpc.Dial(w.Sentinel, grpc.WithInsecure(), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(math.MaxInt)))
 	if err != nil {
 		return nil, err
 	}
-	return sentinel.NewSentinelClient(gconn), nil
+	return sentinelproto.NewSentinelClient(gconn), nil
 }
 
 func openFs(fsName string, path string) (afero.Fs, error) {

--- a/cmd/caplin/caplin1/run.go
+++ b/cmd/caplin/caplin1/run.go
@@ -30,7 +30,7 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	"github.com/erigontech/erigon-lib/common/dir"
-	proto_downloader "github.com/erigontech/erigon-lib/gointerfaces/downloaderproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/downloaderproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cl/aggregation"
 	"github.com/erigontech/erigon/cl/antiquary"
@@ -127,7 +127,7 @@ func OpenCaplinDatabase(ctx context.Context,
 
 func RunCaplinService(ctx context.Context, engine execution_client.ExecutionEngine, config clparams.CaplinConfig,
 	dirs datadir.Dirs, eth1Getter snapshot_format.ExecutionBlockReaderByNumber,
-	snDownloader proto_downloader.DownloaderClient, creds credentials.TransportCredentials, snBuildSema *semaphore.Weighted) error {
+	snDownloader downloaderproto.DownloaderClient, creds credentials.TransportCredentials, snBuildSema *semaphore.Weighted) error {
 
 	var networkConfig *clparams.NetworkConfig
 	var beaconConfig *clparams.BeaconChainConfig

--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -46,7 +46,7 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/dbg"
 	"github.com/erigontech/erigon-lib/common/dir"
-	proto_downloader "github.com/erigontech/erigon-lib/gointerfaces/downloaderproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/downloaderproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cmd/downloader/downloadernat"
 	"github.com/erigontech/erigon/cmd/hack/tool"
@@ -333,15 +333,15 @@ func Downloader(ctx context.Context, logger log.Logger) error {
 	// I'm kinda curious... but it was false before.
 	d.MainLoopInBackground(true)
 	if seedbox {
-		var downloadItems []*proto_downloader.AddItem
+		var downloadItems []*downloaderproto.AddItem
 		snapCfg, _ := snapcfg.KnownCfg(chain)
 		for _, it := range snapCfg.Preverified.Items {
-			downloadItems = append(downloadItems, &proto_downloader.AddItem{
+			downloadItems = append(downloadItems, &downloaderproto.AddItem{
 				Path:        it.Name,
 				TorrentHash: downloadergrpc.String2Proto(it.Hash),
 			})
 		}
-		if _, err := bittorrentServer.Add(ctx, &proto_downloader.AddRequest{Items: downloadItems}); err != nil {
+		if _, err := bittorrentServer.Add(ctx, &downloaderproto.AddRequest{Items: downloadItems}); err != nil {
 			return err
 		}
 	}
@@ -693,7 +693,7 @@ func StartGrpc(snServer *downloader.GrpcServer, addr string, creds *credentials.
 	grpcServer := grpc.NewServer(opts...)
 	reflection.Register(grpcServer) // Register reflection service on gRPC server.
 	if snServer != nil {
-		proto_downloader.RegisterDownloaderServer(grpcServer, snServer)
+		downloaderproto.RegisterDownloaderServer(grpcServer, snServer)
 	}
 
 	//if metrics.Enabled {

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -41,8 +41,8 @@ import (
 	"github.com/erigontech/erigon-lib/common/hexutil"
 	"github.com/erigontech/erigon-lib/gointerfaces"
 	"github.com/erigontech/erigon-lib/gointerfaces/grpcutil"
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
-	txpool "github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cmd/rpcdaemon/cli/httpcfg"
 	"github.com/erigontech/erigon/cmd/rpcdaemon/graphql"
@@ -226,7 +226,7 @@ func RootCommand() (*cobra.Command, *httpcfg.HttpCfg) {
 }
 
 type StateChangesClient interface {
-	StateChanges(ctx context.Context, in *remote.StateChangeRequest, opts ...grpc.CallOption) (remote.KV_StateChangesClient, error)
+	StateChanges(ctx context.Context, in *remoteproto.StateChangeRequest, opts ...grpc.CallOption) (remoteproto.KV_StateChangesClient, error)
 }
 
 func subscribeToStateChangesLoop(ctx context.Context, client StateChangesClient, cache kvcache.Cache) {
@@ -251,7 +251,7 @@ func subscribeToStateChangesLoop(ctx context.Context, client StateChangesClient,
 func subscribeToStateChanges(ctx context.Context, client StateChangesClient, cache kvcache.Cache) error {
 	streamCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	stream, err := client.StateChanges(streamCtx, &remote.StateChangeRequest{WithStorage: true, WithTransactions: false}, grpc.WaitForReady(true))
+	stream, err := client.StateChanges(streamCtx, &remoteproto.StateChangeRequest{WithStorage: true, WithTransactions: false}, grpc.WaitForReady(true))
 	if err != nil {
 		return err
 	}
@@ -304,10 +304,10 @@ func checkDbCompatibility(ctx context.Context, db kv.RoDB) error {
 func EmbeddedServices(ctx context.Context,
 	erigonDB kv.RoDB, stateCacheCfg kvcache.CoherentConfig,
 	rpcFiltersConfig rpchelper.FiltersConfig,
-	blockReader services.FullBlockReader, ethBackendServer remote.ETHBACKENDServer, txPoolServer txpool.TxpoolServer,
-	miningServer txpool.MiningServer, stateDiffClient StateChangesClient,
+	blockReader services.FullBlockReader, ethBackendServer remoteproto.ETHBACKENDServer, txPoolServer txpoolproto.TxpoolServer,
+	miningServer txpoolproto.MiningServer, stateDiffClient StateChangesClient,
 	logger log.Logger,
-) (eth rpchelper.ApiBackend, txPool txpool.TxpoolClient, mining txpool.MiningClient, stateCache kvcache.Cache, ff *rpchelper.Filters) {
+) (eth rpchelper.ApiBackend, txPool txpoolproto.TxpoolClient, mining txpoolproto.MiningClient, stateCache kvcache.Cache, ff *rpchelper.Filters) {
 	if stateCacheCfg.CacheSize > 0 {
 		// notification about new blocks (state stream) doesn't work now inside erigon - because
 		// erigon does send this stream to privateAPI (erigon with enabled rpc, still have enabled privateAPI).
@@ -334,7 +334,7 @@ func EmbeddedServices(ctx context.Context,
 // RemoteServices - use when RPCDaemon run as independent process. Still it can use --datadir flag to enable
 // `cfg.WithDatadir` (mode when it on 1 machine with Erigon)
 func RemoteServices(ctx context.Context, cfg *httpcfg.HttpCfg, logger log.Logger, rootCancel context.CancelFunc) (
-	db kv.TemporalRoDB, eth rpchelper.ApiBackend, txPool txpool.TxpoolClient, mining txpool.MiningClient,
+	db kv.TemporalRoDB, eth rpchelper.ApiBackend, txPool txpoolproto.TxpoolClient, mining txpoolproto.MiningClient,
 	stateCache kvcache.Cache, blockReader services.FullBlockReader, engine consensus.EngineReader,
 	ff *rpchelper.Filters, bridgeReader BridgeReader, heimdallReader HeimdallReader, err error) {
 	if !cfg.WithDatadir && cfg.PrivateApiAddr == "" {
@@ -349,10 +349,10 @@ func RemoteServices(ctx context.Context, cfg *httpcfg.HttpCfg, logger log.Logger
 		return nil, nil, nil, nil, nil, nil, nil, ff, nil, nil, fmt.Errorf("could not connect to execution service privateApi: %w", err)
 	}
 
-	remoteBackendClient := remote.NewETHBACKENDClient(conn)
-	remoteBridgeClient := remote.NewBridgeBackendClient(conn)
-	remoteHeimdallClient := remote.NewHeimdallBackendClient(conn)
-	remoteKvClient := remote.NewKVClient(conn)
+	remoteBackendClient := remoteproto.NewETHBACKENDClient(conn)
+	remoteBridgeClient := remoteproto.NewBridgeBackendClient(conn)
+	remoteHeimdallClient := remoteproto.NewHeimdallBackendClient(conn)
+	remoteKvClient := remoteproto.NewKVClient(conn)
 	remoteKv, err := remotedb.NewRemote(gointerfaces.VersionFromProto(remotedbserver.KvServiceAPIVersion), logger, remoteKvClient).Open()
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, ff, nil, nil, fmt.Errorf("could not connect to remoteKv: %w", err)
@@ -529,9 +529,9 @@ func RemoteServices(ctx context.Context, cfg *httpcfg.HttpCfg, logger log.Logger
 		}
 	}
 
-	mining = txpool.NewMiningClient(txpoolConn)
+	mining = txpoolproto.NewMiningClient(txpoolConn)
 	miningService := rpcservices.NewMiningService(mining)
-	txPool = txpool.NewTxpoolClient(txpoolConn)
+	txPool = txpoolproto.NewTxpoolClient(txpoolConn)
 	txPoolService := rpcservices.NewTxPoolService(txPool)
 
 	if !cfg.WithDatadir {
@@ -996,7 +996,7 @@ func (e *remoteConsensusEngine) validateEngineReady() error {
 // service startup or in a background goroutine, so that we do not depend on the liveness of other services when
 // starting up rpcdaemon and do not block startup (avoiding "cascade outage" scenario). In this case the DB dependency
 // can be a remote DB service running on another machine.
-func (e *remoteConsensusEngine) init(db kv.RoDB, blockReader services.FullBlockReader, remoteKV remote.KVClient, logger log.Logger) error {
+func (e *remoteConsensusEngine) init(db kv.RoDB, blockReader services.FullBlockReader, remoteKV remoteproto.KVClient, logger log.Logger) error {
 	cc, err := readChainConfigFromDB(context.Background(), db)
 	if err != nil {
 		return err

--- a/cmd/rpcdaemon/rpcdaemontest/test_util.go
+++ b/cmd/rpcdaemon/rpcdaemontest/test_util.go
@@ -33,8 +33,8 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/u256"
 	"github.com/erigontech/erigon-lib/crypto"
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
-	txpool "github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/core"
 	"github.com/erigontech/erigon/core/vm"
@@ -309,10 +309,10 @@ func CreateTestGrpcConn(t *testing.T, m *mock.MockSentry) (context.Context, *grp
 	ethashApi := apis[1].Service.(*ethash.API)
 	server := grpc.NewServer()
 
-	remote.RegisterETHBACKENDServer(server, privateapi2.NewEthBackendServer(ctx, nil, m.DB, m.Notifications,
+	remoteproto.RegisterETHBACKENDServer(server, privateapi2.NewEthBackendServer(ctx, nil, m.DB, m.Notifications,
 		m.BlockReader, nil, log.New(), builder.NewLatestBlockBuiltStore(), nil))
-	txpool.RegisterTxpoolServer(server, m.TxPoolGrpcServer)
-	txpool.RegisterMiningServer(server, privateapi2.NewMiningServer(ctx, &IsMiningMock{}, ethashApi, m.Log))
+	txpoolproto.RegisterTxpoolServer(server, m.TxPoolGrpcServer)
+	txpoolproto.RegisterMiningServer(server, privateapi2.NewMiningServer(ctx, &IsMiningMock{}, ethashApi, m.Log))
 	listener := bufconn.Listen(1024 * 1024)
 
 	dialer := func() func(context.Context, string) (net.Conn, error) {

--- a/cmd/rpcdaemon/rpcservices/eth_backend.go
+++ b/cmd/rpcdaemon/rpcservices/eth_backend.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/rawdbv3"
@@ -48,14 +48,14 @@ import (
 var _ services.FullBlockReader = &RemoteBackend{}
 
 type RemoteBackend struct {
-	remoteEthBackend remote.ETHBACKENDClient
+	remoteEthBackend remoteproto.ETHBACKENDClient
 	log              log.Logger
 	version          gointerfaces.Version
 	db               kv.RoDB
 	blockReader      services.FullBlockReader
 }
 
-func NewRemoteBackend(client remote.ETHBACKENDClient, db kv.RoDB, blockReader services.FullBlockReader) *RemoteBackend {
+func NewRemoteBackend(client remoteproto.ETHBACKENDClient, db kv.RoDB, blockReader services.FullBlockReader) *RemoteBackend {
 	return &RemoteBackend{
 		remoteEthBackend: client,
 		version:          gointerfaces.VersionFromProto(privateapi.EthBackendAPIVersion),
@@ -149,7 +149,7 @@ func (back *RemoteBackend) EnsureVersionCompatibility() bool {
 }
 
 func (back *RemoteBackend) Etherbase(ctx context.Context) (common.Address, error) {
-	res, err := back.remoteEthBackend.Etherbase(ctx, &remote.EtherbaseRequest{})
+	res, err := back.remoteEthBackend.Etherbase(ctx, &remoteproto.EtherbaseRequest{})
 	if err != nil {
 		if s, ok := status.FromError(err); ok {
 			return common.Address{}, errors.New(s.Message())
@@ -160,7 +160,7 @@ func (back *RemoteBackend) Etherbase(ctx context.Context) (common.Address, error
 	return gointerfaces.ConvertH160toAddress(res.Address), nil
 }
 
-func (back *RemoteBackend) Syncing(ctx context.Context) (*remote.SyncingReply, error) {
+func (back *RemoteBackend) Syncing(ctx context.Context) (*remoteproto.SyncingReply, error) {
 	res, err := back.remoteEthBackend.Syncing(ctx, &emptypb.Empty{})
 	if err != nil {
 		if s, ok := status.FromError(err); ok {
@@ -173,7 +173,7 @@ func (back *RemoteBackend) Syncing(ctx context.Context) (*remote.SyncingReply, e
 }
 
 func (back *RemoteBackend) NetVersion(ctx context.Context) (uint64, error) {
-	res, err := back.remoteEthBackend.NetVersion(ctx, &remote.NetVersionRequest{})
+	res, err := back.remoteEthBackend.NetVersion(ctx, &remoteproto.NetVersionRequest{})
 	if err != nil {
 		if s, ok := status.FromError(err); ok {
 			return 0, errors.New(s.Message())
@@ -185,7 +185,7 @@ func (back *RemoteBackend) NetVersion(ctx context.Context) (uint64, error) {
 }
 
 func (back *RemoteBackend) NetPeerCount(ctx context.Context) (uint64, error) {
-	res, err := back.remoteEthBackend.NetPeerCount(ctx, &remote.NetPeerCountRequest{})
+	res, err := back.remoteEthBackend.NetPeerCount(ctx, &remoteproto.NetPeerCountRequest{})
 	if err != nil {
 		if s, ok := status.FromError(err); ok {
 			return 0, errors.New(s.Message())
@@ -215,7 +215,7 @@ func (back *RemoteBackend) PendingBlock(ctx context.Context) (*types.Block, erro
 }
 
 func (back *RemoteBackend) ProtocolVersion(ctx context.Context) (uint64, error) {
-	res, err := back.remoteEthBackend.ProtocolVersion(ctx, &remote.ProtocolVersionRequest{})
+	res, err := back.remoteEthBackend.ProtocolVersion(ctx, &remoteproto.ProtocolVersionRequest{})
 	if err != nil {
 		if s, ok := status.FromError(err); ok {
 			return 0, errors.New(s.Message())
@@ -227,7 +227,7 @@ func (back *RemoteBackend) ProtocolVersion(ctx context.Context) (uint64, error) 
 }
 
 func (back *RemoteBackend) ClientVersion(ctx context.Context) (string, error) {
-	res, err := back.remoteEthBackend.ClientVersion(ctx, &remote.ClientVersionRequest{})
+	res, err := back.remoteEthBackend.ClientVersion(ctx, &remoteproto.ClientVersionRequest{})
 	if err != nil {
 		if s, ok := status.FromError(err); ok {
 			return "", errors.New(s.Message())
@@ -238,8 +238,8 @@ func (back *RemoteBackend) ClientVersion(ctx context.Context) (string, error) {
 	return res.NodeName, nil
 }
 
-func (back *RemoteBackend) Subscribe(ctx context.Context, onNewEvent func(*remote.SubscribeReply)) error {
-	subscription, err := back.remoteEthBackend.Subscribe(ctx, &remote.SubscribeRequest{}, grpc.WaitForReady(true))
+func (back *RemoteBackend) Subscribe(ctx context.Context, onNewEvent func(*remoteproto.SubscribeReply)) error {
+	subscription, err := back.remoteEthBackend.Subscribe(ctx, &remoteproto.SubscribeRequest{}, grpc.WaitForReady(true))
 	if err != nil {
 		if s, ok := status.FromError(err); ok {
 			return errors.New(s.Message())
@@ -261,7 +261,7 @@ func (back *RemoteBackend) Subscribe(ctx context.Context, onNewEvent func(*remot
 	return nil
 }
 
-func (back *RemoteBackend) SubscribeLogs(ctx context.Context, onNewLogs func(reply *remote.SubscribeLogsReply), requestor *atomic.Value) error {
+func (back *RemoteBackend) SubscribeLogs(ctx context.Context, onNewLogs func(reply *remoteproto.SubscribeLogsReply), requestor *atomic.Value) error {
 	subscription, err := back.remoteEthBackend.SubscribeLogs(ctx, grpc.WaitForReady(true))
 	if err != nil {
 		if s, ok := status.FromError(err); ok {
@@ -333,7 +333,7 @@ func (back *RemoteBackend) TxnByIdxInBlock(ctx context.Context, tx kv.Getter, bl
 }
 
 func (back *RemoteBackend) NodeInfo(ctx context.Context, limit uint32) ([]p2p.NodeInfo, error) {
-	nodes, err := back.remoteEthBackend.NodeInfo(ctx, &remote.NodesInfoRequest{Limit: limit})
+	nodes, err := back.remoteEthBackend.NodeInfo(ctx, &remoteproto.NodesInfoRequest{Limit: limit})
 	if err != nil {
 		return nil, fmt.Errorf("nodes info request error: %w", err)
 	}
@@ -375,7 +375,7 @@ func (back *RemoteBackend) NodeInfo(ctx context.Context, limit uint32) ([]p2p.No
 	return ret, nil
 }
 
-func (back *RemoteBackend) AddPeer(ctx context.Context, request *remote.AddPeerRequest) (*remote.AddPeerReply, error) {
+func (back *RemoteBackend) AddPeer(ctx context.Context, request *remoteproto.AddPeerRequest) (*remoteproto.AddPeerReply, error) {
 	result, err := back.remoteEthBackend.AddPeer(ctx, request)
 	if err != nil {
 		return nil, fmt.Errorf("ETHBACKENDClient.AddPeer() error: %w", err)
@@ -383,7 +383,7 @@ func (back *RemoteBackend) AddPeer(ctx context.Context, request *remote.AddPeerR
 	return result, nil
 }
 
-func (back *RemoteBackend) RemovePeer(ctx context.Context, request *remote.RemovePeerRequest) (*remote.RemovePeerReply, error) {
+func (back *RemoteBackend) RemovePeer(ctx context.Context, request *remoteproto.RemovePeerRequest) (*remoteproto.RemovePeerReply, error) {
 	result, err := back.remoteEthBackend.RemovePeer(ctx, request)
 	if err != nil {
 		return nil, fmt.Errorf("ETHBACKENDClient.RemovePeer() error: %w", err)

--- a/cmd/rpcdaemon/rpcservices/eth_mining.go
+++ b/cmd/rpcdaemon/rpcservices/eth_mining.go
@@ -20,22 +20,22 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/erigontech/erigon/turbo/privateapi"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	txpool "github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon-lib/log/v3"
+	"github.com/erigontech/erigon/turbo/privateapi"
 )
 
 type MiningService struct {
-	txpool.MiningClient
+	txpoolproto.MiningClient
 	log     log.Logger
 	version gointerfaces.Version
 }
 
-func NewMiningService(client txpool.MiningClient) *MiningService {
+func NewMiningService(client txpoolproto.MiningClient) *MiningService {
 	return &MiningService{
 		MiningClient: client,
 		version:      gointerfaces.VersionFromProto(privateapi.MiningAPIVersion),

--- a/cmd/rpcdaemon/rpcservices/eth_txpool.go
+++ b/cmd/rpcdaemon/rpcservices/eth_txpool.go
@@ -24,24 +24,23 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 
-	txpool2 "github.com/erigontech/erigon/txnprovider/txpool"
-
 	"github.com/erigontech/erigon-lib/gointerfaces"
 	"github.com/erigontech/erigon-lib/gointerfaces/grpcutil"
-	txpooproto "github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon-lib/log/v3"
+	"github.com/erigontech/erigon/txnprovider/txpool"
 )
 
 type TxPoolService struct {
-	txpooproto.TxpoolClient
+	txpoolproto.TxpoolClient
 	log     log.Logger
 	version gointerfaces.Version
 }
 
-func NewTxPoolService(client txpooproto.TxpoolClient) *TxPoolService {
+func NewTxPoolService(client txpoolproto.TxpoolClient) *TxPoolService {
 	return &TxPoolService{
 		TxpoolClient: client,
-		version:      gointerfaces.VersionFromProto(txpool2.TxPoolAPIVersion),
+		version:      gointerfaces.VersionFromProto(txpool.TxPoolAPIVersion),
 		log:          log.New("remote_service", "tx_pool"),
 	}
 }
@@ -50,7 +49,7 @@ func (s *TxPoolService) EnsureVersionCompatibility() bool {
 Start:
 	versionReply, err := s.Version(context.Background(), &emptypb.Empty{}, grpc.WaitForReady(true))
 	if err != nil {
-		if grpcutil.ErrIs(err, txpool2.ErrPoolDisabled) {
+		if grpcutil.ErrIs(err, txpool.ErrPoolDisabled) {
 			time.Sleep(3 * time.Second)
 			goto Start
 		}

--- a/cmd/txpool/main.go
+++ b/cmd/txpool/main.go
@@ -29,8 +29,8 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/gointerfaces"
 	"github.com/erigontech/erigon-lib/gointerfaces/grpcutil"
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
-	proto_sentry "github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cmd/rpcdaemon/rpcdaemontest"
 	"github.com/erigontech/erigon/cmd/utils"
@@ -131,8 +131,8 @@ func doTxpool(ctx context.Context, logger log.Logger) error {
 		return fmt.Errorf("could not connect to remoteKv: %w", err)
 	}
 
-	ethBackendClient := remote.NewETHBACKENDClient(coreConn)
-	kvClient := remote.NewKVClient(coreConn)
+	ethBackendClient := remoteproto.NewETHBACKENDClient(coreConn)
+	kvClient := remoteproto.NewKVClient(coreConn)
 	coreDB, err := remotedb.NewRemote(gointerfaces.VersionFromProto(remotedbserver.KvServiceAPIVersion), log.New(), kvClient).Open()
 	if err != nil {
 		return fmt.Errorf("could not connect to remoteKv: %w", err)
@@ -140,7 +140,7 @@ func doTxpool(ctx context.Context, logger log.Logger) error {
 
 	log.Info("TxPool started", "db", filepath.Join(datadirCli, "txpool"))
 
-	sentryClients := make([]proto_sentry.SentryClient, len(sentryAddr))
+	sentryClients := make([]sentryproto.SentryClient, len(sentryAddr))
 	for i := range sentryAddr {
 		creds, err := grpcutil.TLS(TLSCACert, TLSCertfile, TLSKeyFile)
 		if err != nil {
@@ -151,7 +151,7 @@ func doTxpool(ctx context.Context, logger log.Logger) error {
 			return fmt.Errorf("could not connect to sentry: %w", err)
 		}
 
-		sentryClients[i] = direct.NewSentryClientRemote(proto_sentry.NewSentryClient(sentryConn))
+		sentryClients[i] = direct.NewSentryClientRemote(sentryproto.NewSentryClient(sentryConn))
 	}
 
 	cfg := txpoolcfg.DefaultConfig

--- a/db/downloader/downloader_test.go
+++ b/db/downloader/downloader_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	p "github.com/erigontech/erigon-lib/gointerfaces/downloaderproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/downloaderproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/downloader/downloadercfg"
@@ -130,54 +130,54 @@ func TestAddDel(t *testing.T) {
 
 	srever, _ := NewGrpcServer(d)
 	// Add: epxect relative paths
-	_, err = srever.Add(ctx, &p.AddRequest{Items: []*p.AddItem{{Path: f1Abs}}})
+	_, err = srever.Add(ctx, &downloaderproto.AddRequest{Items: []*downloaderproto.AddItem{{Path: f1Abs}}})
 	require.Error(err)
-	_, err = srever.Add(ctx, &p.AddRequest{Items: []*p.AddItem{{Path: f2Abs}}})
+	_, err = srever.Add(ctx, &downloaderproto.AddRequest{Items: []*downloaderproto.AddItem{{Path: f2Abs}}})
 	require.Error(err)
 	require.Equal(0, len(d.torrentClient.Torrents()))
 
 	f1, _ := filepath.Rel(dirs.Snap, f1Abs)
 	f2, _ := filepath.Rel(dirs.Snap, f2Abs)
-	_, err = srever.Add(ctx, &p.AddRequest{Items: []*p.AddItem{{Path: f1}}})
+	_, err = srever.Add(ctx, &downloaderproto.AddRequest{Items: []*downloaderproto.AddItem{{Path: f1}}})
 	require.NoError(err)
-	_, err = srever.Add(ctx, &p.AddRequest{Items: []*p.AddItem{{Path: f2}}})
+	_, err = srever.Add(ctx, &downloaderproto.AddRequest{Items: []*downloaderproto.AddItem{{Path: f2}}})
 	require.NoError(err)
 	require.Equal(2, len(d.torrentClient.Torrents()))
 
 	// add idempotency
-	_, err = srever.Add(ctx, &p.AddRequest{Items: []*p.AddItem{{Path: f1}}})
+	_, err = srever.Add(ctx, &downloaderproto.AddRequest{Items: []*downloaderproto.AddItem{{Path: f1}}})
 	require.NoError(err)
-	_, err = srever.Add(ctx, &p.AddRequest{Items: []*p.AddItem{{Path: f2}}})
+	_, err = srever.Add(ctx, &downloaderproto.AddRequest{Items: []*downloaderproto.AddItem{{Path: f2}}})
 	require.NoError(err)
 	require.Equal(2, len(d.torrentClient.Torrents()))
 
 	// Del: epxect relative paths
-	_, err = srever.Delete(ctx, &p.DeleteRequest{Paths: []string{f1Abs}})
+	_, err = srever.Delete(ctx, &downloaderproto.DeleteRequest{Paths: []string{f1Abs}})
 	require.Error(err)
-	_, err = srever.Delete(ctx, &p.DeleteRequest{Paths: []string{f2Abs}})
+	_, err = srever.Delete(ctx, &downloaderproto.DeleteRequest{Paths: []string{f2Abs}})
 	require.Error(err)
 	require.Equal(2, len(d.torrentClient.Torrents()))
 
 	// Del: idempotency
-	_, err = srever.Delete(ctx, &p.DeleteRequest{Paths: []string{f1}})
+	_, err = srever.Delete(ctx, &downloaderproto.DeleteRequest{Paths: []string{f1}})
 	require.NoError(err)
 	require.Equal(1, len(d.torrentClient.Torrents()))
-	_, err = srever.Delete(ctx, &p.DeleteRequest{Paths: []string{f1}})
+	_, err = srever.Delete(ctx, &downloaderproto.DeleteRequest{Paths: []string{f1}})
 	require.NoError(err)
 	require.Equal(1, len(d.torrentClient.Torrents()))
 
-	_, err = srever.Delete(ctx, &p.DeleteRequest{Paths: []string{f2}})
+	_, err = srever.Delete(ctx, &downloaderproto.DeleteRequest{Paths: []string{f2}})
 	require.NoError(err)
 	require.Equal(0, len(d.torrentClient.Torrents()))
-	_, err = srever.Delete(ctx, &p.DeleteRequest{Paths: []string{f2}})
+	_, err = srever.Delete(ctx, &downloaderproto.DeleteRequest{Paths: []string{f2}})
 	require.NoError(err)
 	require.Equal(0, len(d.torrentClient.Torrents()))
 
 	// Batch
-	_, err = srever.Add(ctx, &p.AddRequest{Items: []*p.AddItem{{Path: f1}, {Path: f2}}})
+	_, err = srever.Add(ctx, &downloaderproto.AddRequest{Items: []*downloaderproto.AddItem{{Path: f1}, {Path: f2}}})
 	require.NoError(err)
 	require.Equal(2, len(d.torrentClient.Torrents()))
-	_, err = srever.Delete(ctx, &p.DeleteRequest{Paths: []string{f1, f2}})
+	_, err = srever.Delete(ctx, &downloaderproto.DeleteRequest{Paths: []string{f1, f2}})
 	require.NoError(err)
 	require.Equal(0, len(d.torrentClient.Torrents()))
 

--- a/db/downloader/downloadergrpc/client.go
+++ b/db/downloader/downloadergrpc/client.go
@@ -24,16 +24,17 @@ import (
 
 	"github.com/anacrolix/torrent/metainfo"
 	"github.com/c2h5oh/datasize"
-	"github.com/erigontech/erigon-lib/gointerfaces"
-	proto_downloader "github.com/erigontech/erigon-lib/gointerfaces/downloaderproto"
-	prototypes "github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
+
+	"github.com/erigontech/erigon-lib/gointerfaces"
+	"github.com/erigontech/erigon-lib/gointerfaces/downloaderproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 )
 
-func NewClient(ctx context.Context, downloaderAddr string) (proto_downloader.DownloaderClient, error) {
+func NewClient(ctx context.Context, downloaderAddr string) (downloaderproto.DownloaderClient, error) {
 	// creating grpc client connection
 	var dialOpts []grpc.DialOption
 
@@ -51,11 +52,11 @@ func NewClient(ctx context.Context, downloaderAddr string) (proto_downloader.Dow
 	if err != nil {
 		return nil, fmt.Errorf("creating client connection to sentry P2P: %w", err)
 	}
-	return proto_downloader.NewDownloaderClient(conn), nil
+	return downloaderproto.NewDownloaderClient(conn), nil
 }
 
-func InfoHashes2Proto(in []metainfo.Hash) []*prototypes.H160 {
-	infoHashes := make([]*prototypes.H160, len(in))
+func InfoHashes2Proto(in []metainfo.Hash) []*typesproto.H160 {
+	infoHashes := make([]*typesproto.H160, len(in))
 	i := 0
 	for _, h := range in {
 		infoHashes[i] = gointerfaces.ConvertAddressToH160(h)
@@ -64,8 +65,8 @@ func InfoHashes2Proto(in []metainfo.Hash) []*prototypes.H160 {
 	return infoHashes
 }
 
-func Strings2Proto(in []string) []*prototypes.H160 {
-	infoHashes := make([]*prototypes.H160, len(in))
+func Strings2Proto(in []string) []*typesproto.H160 {
+	infoHashes := make([]*typesproto.H160, len(in))
 	i := 0
 	for _, h := range in {
 		infoHashes[i] = String2Proto(h)
@@ -74,14 +75,14 @@ func Strings2Proto(in []string) []*prototypes.H160 {
 	return infoHashes
 }
 
-func String2Proto(in string) *prototypes.H160 {
+func String2Proto(in string) *typesproto.H160 {
 	var infoHash [20]byte
 	inHex, _ := hex.DecodeString(in)
 	copy(infoHash[:], inHex)
 	return gointerfaces.ConvertAddressToH160(infoHash)
 }
 
-func Proto2String(in *prototypes.H160) string {
+func Proto2String(in *typesproto.H160) string {
 	addr := gointerfaces.ConvertH160toAddress(in)
 	return hex.EncodeToString(addr[:])
 }

--- a/db/kv/kvcache/cache_test.go
+++ b/db/kv/kvcache/cache_test.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
@@ -136,13 +136,13 @@ func TestEviction(t *testing.T) {
 	})
 	require.Equal(0, c.stateEvict.Len())
 	//require.Equal(c.roots[c.latestViewID].cache.Len(), c.stateEvict.Len())
-	c.OnNewBlock(&remote.StateChangeBatch{
+	c.OnNewBlock(&remoteproto.StateChangeBatch{
 		StateVersionId: id + 1,
-		ChangeBatch: []*remote.StateChange{
+		ChangeBatch: []*remoteproto.StateChange{
 			{
-				Direction: remote.Direction_FORWARD,
-				Changes: []*remote.AccountChange{{
-					Action:  remote.Action_UPSERT,
+				Direction: remoteproto.Direction_FORWARD,
+				Changes: []*remoteproto.AccountChange{{
+					Action:  remoteproto.Action_UPSERT,
 					Address: gointerfaces.ConvertAddressToH160(k1),
 					Data:    []byte{2},
 				}},
@@ -288,16 +288,16 @@ func TestAPI(t *testing.T) {
 	res3, res4 := get(k1, txID2), get(k2, txID2) // will see View of transaction 2
 	txID3 := put(k1[:], account2Enc)             // even if core already on block 3
 
-	c.OnNewBlock(&remote.StateChangeBatch{
+	c.OnNewBlock(&remoteproto.StateChangeBatch{
 		StateVersionId:      txID2,
 		PendingBlockBaseFee: 1,
-		ChangeBatch: []*remote.StateChange{
+		ChangeBatch: []*remoteproto.StateChange{
 			{
-				Direction:   remote.Direction_FORWARD,
+				Direction:   remoteproto.Direction_FORWARD,
 				BlockHeight: 2,
 				BlockHash:   gointerfaces.ConvertHashToH256([32]byte{}),
-				Changes: []*remote.AccountChange{{
-					Action:  remote.Action_UPSERT,
+				Changes: []*remoteproto.AccountChange{{
+					Action:  remoteproto.Action_UPSERT,
 					Address: gointerfaces.ConvertAddressToH160(k1),
 					Data:    account2Enc,
 				}},
@@ -333,16 +333,16 @@ func TestAPI(t *testing.T) {
 	fmt.Printf("-----2\n")
 
 	res5, res6 := get(k1, txID3), get(k2, txID3) // will see View of transaction 3, even if notification has not enough changes
-	c.OnNewBlock(&remote.StateChangeBatch{
+	c.OnNewBlock(&remoteproto.StateChangeBatch{
 		StateVersionId:      txID3,
 		PendingBlockBaseFee: 1,
-		ChangeBatch: []*remote.StateChange{
+		ChangeBatch: []*remoteproto.StateChange{
 			{
-				Direction:   remote.Direction_FORWARD,
+				Direction:   remoteproto.Direction_FORWARD,
 				BlockHeight: 3,
 				BlockHash:   gointerfaces.ConvertHashToH256([32]byte{}),
-				Changes: []*remote.AccountChange{{
-					Action:  remote.Action_UPSERT,
+				Changes: []*remoteproto.AccountChange{{
+					Action:  remoteproto.Action_UPSERT,
 					Address: gointerfaces.ConvertAddressToH160(k1),
 					Data:    account2Enc,
 				}},
@@ -380,16 +380,16 @@ func TestAPI(t *testing.T) {
 	fmt.Printf("-----3\n")
 	txID4 := put(k1[:], account2Enc)
 
-	c.OnNewBlock(&remote.StateChangeBatch{
+	c.OnNewBlock(&remoteproto.StateChangeBatch{
 		StateVersionId:      txID4,
 		PendingBlockBaseFee: 1,
-		ChangeBatch: []*remote.StateChange{
+		ChangeBatch: []*remoteproto.StateChange{
 			{
-				Direction:   remote.Direction_UNWIND,
+				Direction:   remoteproto.Direction_UNWIND,
 				BlockHeight: 2,
 				BlockHash:   gointerfaces.ConvertHashToH256([32]byte{}),
-				Changes: []*remote.AccountChange{{
-					Action:  remote.Action_UPSERT,
+				Changes: []*remoteproto.AccountChange{{
+					Action:  remoteproto.Action_UPSERT,
 					Address: gointerfaces.ConvertAddressToH160(k1),
 					Data:    account4Enc,
 				}},
@@ -398,16 +398,16 @@ func TestAPI(t *testing.T) {
 	})
 	fmt.Printf("-----4\n")
 	txID5 := put(k1[:], account4Enc) // reorg to new chain
-	c.OnNewBlock(&remote.StateChangeBatch{
+	c.OnNewBlock(&remoteproto.StateChangeBatch{
 		StateVersionId:      txID5,
 		PendingBlockBaseFee: 1,
-		ChangeBatch: []*remote.StateChange{
+		ChangeBatch: []*remoteproto.StateChange{
 			{
-				Direction:   remote.Direction_FORWARD,
+				Direction:   remoteproto.Direction_FORWARD,
 				BlockHeight: 3,
 				BlockHash:   gointerfaces.ConvertHashToH256([32]byte{2}),
-				Changes: []*remote.AccountChange{{
-					Action:  remote.Action_UPSERT,
+				Changes: []*remoteproto.AccountChange{{
+					Action:  remoteproto.Action_UPSERT,
 					Address: gointerfaces.ConvertAddressToH160(k1),
 					Data:    account4Enc,
 				}},

--- a/db/kv/kvcache/dummy.go
+++ b/db/kv/kvcache/dummy.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	"github.com/erigontech/erigon-lib/common"
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
 	"github.com/erigontech/erigon/db/kv"
 )
 
@@ -35,9 +35,9 @@ func NewDummy() *DummyCache { return &DummyCache{} }
 func (c *DummyCache) View(_ context.Context, tx kv.TemporalTx) (CacheView, error) {
 	return &DummyView{cache: c, tx: tx}, nil
 }
-func (c *DummyCache) OnNewBlock(sc *remote.StateChangeBatch) {}
-func (c *DummyCache) Evict() int                             { return 0 }
-func (c *DummyCache) Len() int                               { return 0 }
+func (c *DummyCache) OnNewBlock(sc *remoteproto.StateChangeBatch) {}
+func (c *DummyCache) Evict() int                                  { return 0 }
+func (c *DummyCache) Len() int                                    { return 0 }
 func (c *DummyCache) Get(k []byte, tx kv.TemporalTx, id uint64) ([]byte, error) {
 	if len(k) == 20 {
 		v, _, err := tx.GetLatest(kv.AccountsDomain, k)

--- a/db/kv/remotedb/kv_remote.go
+++ b/db/kv/remotedb/kv_remote.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/erigontech/erigon-lib/gointerfaces"
 	"github.com/erigontech/erigon-lib/gointerfaces/grpcutil"
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/order"
@@ -41,7 +41,7 @@ import (
 
 // generate the messages and services
 type remoteOpts struct {
-	remoteKV    remote.KVClient
+	remoteKV    remoteproto.KVClient
 	log         log.Logger
 	bucketsCfg  kv.TableCfg
 	DialAddress string
@@ -51,7 +51,7 @@ type remoteOpts struct {
 var _ kv.TemporalTx = (*tx)(nil)
 
 type DB struct {
-	remoteKV     remote.KVClient
+	remoteKV     remoteproto.KVClient
 	log          log.Logger
 	buckets      kv.TableCfg
 	roTxsLimiter *semaphore.Weighted
@@ -59,7 +59,7 @@ type DB struct {
 }
 
 type tx struct {
-	stream             remote.KV_TxClient
+	stream             remoteproto.KV_TxClient
 	ctx                context.Context
 	streamCancelFn     context.CancelFunc
 	db                 *DB
@@ -72,7 +72,7 @@ type tx struct {
 
 type remoteCursor struct {
 	ctx        context.Context
-	stream     remote.KV_TxClient
+	stream     remoteproto.KV_TxClient
 	tx         *tx
 	bucketName string
 	bucketCfg  kv.TableCfgItem
@@ -124,7 +124,7 @@ func (opts remoteOpts) MustOpen() kv.RwDB {
 // NewRemote defines new remove KV connection (without actually opening it)
 // version parameters represent the version the KV client is expecting,
 // compatibility check will be performed when the KV connection opens
-func NewRemote(v gointerfaces.Version, logger log.Logger, remoteKV remote.KVClient) remoteOpts {
+func NewRemote(v gointerfaces.Version, logger log.Logger, remoteKV remoteproto.KVClient) remoteOpts {
 	return remoteOpts{bucketsCfg: kv.ChaindataTablesCfg, version: v, log: logger, remoteKV: remoteKV}
 }
 
@@ -269,7 +269,7 @@ func (tx *tx) IncrementSequence(bucket string, amount uint64) (uint64, error) {
 	panic("not implemented yet")
 }
 func (tx *tx) ReadSequence(table string) (uint64, error) {
-	reply, err := tx.db.remoteKV.Sequence(tx.ctx, &remote.SequenceReq{TxId: tx.id, Table: table})
+	reply, err := tx.db.remoteKV.Sequence(tx.ctx, &remoteproto.SequenceReq{TxId: tx.id, Table: table})
 	if err != nil {
 		return 0, err
 	}
@@ -393,7 +393,7 @@ func (tx *tx) Cursor(bucket string) (kv.Cursor, error) {
 	b := tx.db.buckets[bucket]
 	c := &remoteCursor{tx: tx, ctx: tx.ctx, bucketName: bucket, bucketCfg: b, stream: tx.stream}
 	tx.cursors = append(tx.cursors, c)
-	if err := c.stream.Send(&remote.Cursor{Op: remote.Op_OPEN, BucketName: c.bucketName}); err != nil {
+	if err := c.stream.Send(&remoteproto.Cursor{Op: remoteproto.Op_OPEN, BucketName: c.bucketName}); err != nil {
 		return nil, err
 	}
 	msg, err := c.stream.Recv()
@@ -423,7 +423,7 @@ func (tx *tx) AggForkablesTx(id kv.ForkableId) any {
 // func (c *remoteCursor) DeleteCurrent() error                    { panic("not supported") }
 
 func (c *remoteCursor) first() ([]byte, []byte, error) {
-	if err := c.stream.Send(&remote.Cursor{Cursor: c.id, Op: remote.Op_FIRST}); err != nil {
+	if err := c.stream.Send(&remoteproto.Cursor{Cursor: c.id, Op: remoteproto.Op_FIRST}); err != nil {
 		return []byte{}, nil, err
 	}
 	pair, err := c.stream.Recv()
@@ -434,7 +434,7 @@ func (c *remoteCursor) first() ([]byte, []byte, error) {
 }
 
 func (c *remoteCursor) next() ([]byte, []byte, error) {
-	if err := c.stream.Send(&remote.Cursor{Cursor: c.id, Op: remote.Op_NEXT}); err != nil {
+	if err := c.stream.Send(&remoteproto.Cursor{Cursor: c.id, Op: remoteproto.Op_NEXT}); err != nil {
 		return []byte{}, nil, err
 	}
 	pair, err := c.stream.Recv()
@@ -444,7 +444,7 @@ func (c *remoteCursor) next() ([]byte, []byte, error) {
 	return pair.K, pair.V, nil
 }
 func (c *remoteCursor) nextDup() ([]byte, []byte, error) {
-	if err := c.stream.Send(&remote.Cursor{Cursor: c.id, Op: remote.Op_NEXT_DUP}); err != nil {
+	if err := c.stream.Send(&remoteproto.Cursor{Cursor: c.id, Op: remoteproto.Op_NEXT_DUP}); err != nil {
 		return []byte{}, nil, err
 	}
 	pair, err := c.stream.Recv()
@@ -454,7 +454,7 @@ func (c *remoteCursor) nextDup() ([]byte, []byte, error) {
 	return pair.K, pair.V, nil
 }
 func (c *remoteCursor) nextNoDup() ([]byte, []byte, error) {
-	if err := c.stream.Send(&remote.Cursor{Cursor: c.id, Op: remote.Op_NEXT_NO_DUP}); err != nil {
+	if err := c.stream.Send(&remoteproto.Cursor{Cursor: c.id, Op: remoteproto.Op_NEXT_NO_DUP}); err != nil {
 		return []byte{}, nil, err
 	}
 	pair, err := c.stream.Recv()
@@ -464,7 +464,7 @@ func (c *remoteCursor) nextNoDup() ([]byte, []byte, error) {
 	return pair.K, pair.V, nil
 }
 func (c *remoteCursor) prev() ([]byte, []byte, error) {
-	if err := c.stream.Send(&remote.Cursor{Cursor: c.id, Op: remote.Op_PREV}); err != nil {
+	if err := c.stream.Send(&remoteproto.Cursor{Cursor: c.id, Op: remoteproto.Op_PREV}); err != nil {
 		return []byte{}, nil, err
 	}
 	pair, err := c.stream.Recv()
@@ -474,7 +474,7 @@ func (c *remoteCursor) prev() ([]byte, []byte, error) {
 	return pair.K, pair.V, nil
 }
 func (c *remoteCursor) prevDup() ([]byte, []byte, error) {
-	if err := c.stream.Send(&remote.Cursor{Cursor: c.id, Op: remote.Op_PREV_DUP}); err != nil {
+	if err := c.stream.Send(&remoteproto.Cursor{Cursor: c.id, Op: remoteproto.Op_PREV_DUP}); err != nil {
 		return []byte{}, nil, err
 	}
 	pair, err := c.stream.Recv()
@@ -484,7 +484,7 @@ func (c *remoteCursor) prevDup() ([]byte, []byte, error) {
 	return pair.K, pair.V, nil
 }
 func (c *remoteCursor) prevNoDup() ([]byte, []byte, error) {
-	if err := c.stream.Send(&remote.Cursor{Cursor: c.id, Op: remote.Op_PREV_NO_DUP}); err != nil {
+	if err := c.stream.Send(&remoteproto.Cursor{Cursor: c.id, Op: remoteproto.Op_PREV_NO_DUP}); err != nil {
 		return []byte{}, nil, err
 	}
 	pair, err := c.stream.Recv()
@@ -494,7 +494,7 @@ func (c *remoteCursor) prevNoDup() ([]byte, []byte, error) {
 	return pair.K, pair.V, nil
 }
 func (c *remoteCursor) last() ([]byte, []byte, error) {
-	if err := c.stream.Send(&remote.Cursor{Cursor: c.id, Op: remote.Op_LAST}); err != nil {
+	if err := c.stream.Send(&remoteproto.Cursor{Cursor: c.id, Op: remoteproto.Op_LAST}); err != nil {
 		return []byte{}, nil, err
 	}
 	pair, err := c.stream.Recv()
@@ -504,7 +504,7 @@ func (c *remoteCursor) last() ([]byte, []byte, error) {
 	return pair.K, pair.V, nil
 }
 func (c *remoteCursor) setRange(k []byte) ([]byte, []byte, error) {
-	if err := c.stream.Send(&remote.Cursor{Cursor: c.id, Op: remote.Op_SEEK, K: k}); err != nil {
+	if err := c.stream.Send(&remoteproto.Cursor{Cursor: c.id, Op: remoteproto.Op_SEEK, K: k}); err != nil {
 		return []byte{}, nil, err
 	}
 	pair, err := c.stream.Recv()
@@ -514,7 +514,7 @@ func (c *remoteCursor) setRange(k []byte) ([]byte, []byte, error) {
 	return pair.K, pair.V, nil
 }
 func (c *remoteCursor) seekExact(k []byte) ([]byte, []byte, error) {
-	if err := c.stream.Send(&remote.Cursor{Cursor: c.id, Op: remote.Op_SEEK_EXACT, K: k}); err != nil {
+	if err := c.stream.Send(&remoteproto.Cursor{Cursor: c.id, Op: remoteproto.Op_SEEK_EXACT, K: k}); err != nil {
 		return []byte{}, nil, err
 	}
 	pair, err := c.stream.Recv()
@@ -524,7 +524,7 @@ func (c *remoteCursor) seekExact(k []byte) ([]byte, []byte, error) {
 	return pair.K, pair.V, nil
 }
 func (c *remoteCursor) getBothRange(k, v []byte) ([]byte, error) {
-	if err := c.stream.Send(&remote.Cursor{Cursor: c.id, Op: remote.Op_SEEK_BOTH, K: k, V: v}); err != nil {
+	if err := c.stream.Send(&remoteproto.Cursor{Cursor: c.id, Op: remoteproto.Op_SEEK_BOTH, K: k, V: v}); err != nil {
 		return nil, err
 	}
 	pair, err := c.stream.Recv()
@@ -534,7 +534,7 @@ func (c *remoteCursor) getBothRange(k, v []byte) ([]byte, error) {
 	return pair.V, nil
 }
 func (c *remoteCursor) seekBothExact(k, v []byte) ([]byte, []byte, error) {
-	if err := c.stream.Send(&remote.Cursor{Cursor: c.id, Op: remote.Op_SEEK_BOTH_EXACT, K: k, V: v}); err != nil {
+	if err := c.stream.Send(&remoteproto.Cursor{Cursor: c.id, Op: remoteproto.Op_SEEK_BOTH_EXACT, K: k, V: v}); err != nil {
 		return []byte{}, nil, err
 	}
 	pair, err := c.stream.Recv()
@@ -544,7 +544,7 @@ func (c *remoteCursor) seekBothExact(k, v []byte) ([]byte, []byte, error) {
 	return pair.K, pair.V, nil
 }
 func (c *remoteCursor) firstDup() ([]byte, error) {
-	if err := c.stream.Send(&remote.Cursor{Cursor: c.id, Op: remote.Op_FIRST_DUP}); err != nil {
+	if err := c.stream.Send(&remoteproto.Cursor{Cursor: c.id, Op: remoteproto.Op_FIRST_DUP}); err != nil {
 		return nil, err
 	}
 	pair, err := c.stream.Recv()
@@ -554,7 +554,7 @@ func (c *remoteCursor) firstDup() ([]byte, error) {
 	return pair.V, nil
 }
 func (c *remoteCursor) lastDup() ([]byte, error) {
-	if err := c.stream.Send(&remote.Cursor{Cursor: c.id, Op: remote.Op_LAST_DUP}); err != nil {
+	if err := c.stream.Send(&remoteproto.Cursor{Cursor: c.id, Op: remoteproto.Op_LAST_DUP}); err != nil {
 		return nil, err
 	}
 	pair, err := c.stream.Recv()
@@ -564,7 +564,7 @@ func (c *remoteCursor) lastDup() ([]byte, error) {
 	return pair.V, nil
 }
 func (c *remoteCursor) getCurrent() ([]byte, []byte, error) {
-	if err := c.stream.Send(&remote.Cursor{Cursor: c.id, Op: remote.Op_CURRENT}); err != nil {
+	if err := c.stream.Send(&remoteproto.Cursor{Cursor: c.id, Op: remoteproto.Op_CURRENT}); err != nil {
 		return []byte{}, nil, err
 	}
 	pair, err := c.stream.Recv()
@@ -636,7 +636,7 @@ func (c *remoteCursor) Close() {
 	}
 	st := c.stream
 	c.stream = nil
-	if err := st.Send(&remote.Cursor{Cursor: c.id, Op: remote.Op_CLOSE}); err == nil {
+	if err := st.Send(&remoteproto.Cursor{Cursor: c.id, Op: remoteproto.Op_CLOSE}); err == nil {
 		_, _ = st.Recv()
 	}
 }
@@ -645,7 +645,7 @@ func (tx *tx) CursorDupSort(bucket string) (kv.CursorDupSort, error) {
 	b := tx.db.buckets[bucket]
 	c := &remoteCursor{tx: tx, ctx: tx.ctx, bucketName: bucket, bucketCfg: b, stream: tx.stream}
 	tx.cursors = append(tx.cursors, c)
-	if err := c.stream.Send(&remote.Cursor{Op: remote.Op_OPEN_DUP_SORT, BucketName: c.bucketName}); err != nil {
+	if err := c.stream.Send(&remoteproto.Cursor{Op: remoteproto.Op_OPEN_DUP_SORT, BucketName: c.bucketName}); err != nil {
 		return nil, err
 	}
 	msg, err := c.stream.Recv()
@@ -680,7 +680,7 @@ func (c *remoteCursorDupSort) LastDup() ([]byte, error)           { return c.las
 // Temporal Methods
 
 func (tx *tx) HistoryStartFrom(name kv.Domain) uint64 {
-	reply, err := tx.db.remoteKV.HistoryStartFrom(tx.ctx, &remote.HistoryStartFromReq{TxId: tx.id, Domain: uint32(name)})
+	reply, err := tx.db.remoteKV.HistoryStartFrom(tx.ctx, &remoteproto.HistoryStartFromReq{TxId: tx.id, Domain: uint32(name)})
 	if err != nil {
 		return 0
 	}
@@ -688,7 +688,7 @@ func (tx *tx) HistoryStartFrom(name kv.Domain) uint64 {
 }
 
 func (tx *tx) GetAsOf(name kv.Domain, k []byte, ts uint64) (v []byte, ok bool, err error) {
-	reply, err := tx.db.remoteKV.GetLatest(tx.ctx, &remote.GetLatestReq{TxId: tx.id, Table: name.String(), K: k, Ts: ts})
+	reply, err := tx.db.remoteKV.GetLatest(tx.ctx, &remoteproto.GetLatestReq{TxId: tx.id, Table: name.String(), K: k, Ts: ts})
 	if err != nil {
 		return nil, false, err
 	}
@@ -696,7 +696,7 @@ func (tx *tx) GetAsOf(name kv.Domain, k []byte, ts uint64) (v []byte, ok bool, e
 }
 
 func (tx *tx) GetLatest(name kv.Domain, k []byte) (v []byte, step kv.Step, err error) {
-	reply, err := tx.db.remoteKV.GetLatest(tx.ctx, &remote.GetLatestReq{TxId: tx.id, Table: name.String(), K: k, Latest: true})
+	reply, err := tx.db.remoteKV.GetLatest(tx.ctx, &remoteproto.GetLatestReq{TxId: tx.id, Table: name.String(), K: k, Latest: true})
 	if err != nil {
 		return nil, 0, err
 	}
@@ -704,7 +704,7 @@ func (tx *tx) GetLatest(name kv.Domain, k []byte) (v []byte, step kv.Step, err e
 }
 
 func (tx *tx) HasPrefix(name kv.Domain, prefix []byte) ([]byte, []byte, bool, error) {
-	req := &remote.HasPrefixReq{TxId: tx.id, Table: name.String(), Prefix: prefix}
+	req := &remoteproto.HasPrefixReq{TxId: tx.id, Table: name.String(), Prefix: prefix}
 	reply, err := tx.db.remoteKV.HasPrefix(tx.ctx, req)
 	if err != nil {
 		return nil, nil, false, err
@@ -714,7 +714,7 @@ func (tx *tx) HasPrefix(name kv.Domain, prefix []byte) ([]byte, []byte, bool, er
 
 func (tx *tx) RangeAsOf(name kv.Domain, fromKey, toKey []byte, ts uint64, asc order.By, limit int) (it stream.KV, err error) {
 	return stream.PaginateKV(func(pageToken string) (keys, vals [][]byte, nextPageToken string, err error) {
-		reply, err := tx.db.remoteKV.RangeAsOf(tx.ctx, &remote.RangeAsOfReq{TxId: tx.id, Table: name.String(), FromKey: fromKey, ToKey: toKey, Ts: ts, OrderAscend: bool(asc), Limit: int64(limit), PageToken: pageToken})
+		reply, err := tx.db.remoteKV.RangeAsOf(tx.ctx, &remoteproto.RangeAsOfReq{TxId: tx.id, Table: name.String(), FromKey: fromKey, ToKey: toKey, Ts: ts, OrderAscend: bool(asc), Limit: int64(limit), PageToken: pageToken})
 		if err != nil {
 			return nil, nil, "", err
 		}
@@ -722,7 +722,7 @@ func (tx *tx) RangeAsOf(name kv.Domain, fromKey, toKey []byte, ts uint64, asc or
 	}), nil
 }
 func (tx *tx) HistorySeek(name kv.Domain, k []byte, ts uint64) (v []byte, ok bool, err error) {
-	reply, err := tx.db.remoteKV.HistorySeek(tx.ctx, &remote.HistorySeekReq{TxId: tx.id, Table: name.String(), K: k, Ts: ts})
+	reply, err := tx.db.remoteKV.HistorySeek(tx.ctx, &remoteproto.HistorySeekReq{TxId: tx.id, Table: name.String(), K: k, Ts: ts})
 	if err != nil {
 		return nil, false, err
 	}
@@ -730,7 +730,7 @@ func (tx *tx) HistorySeek(name kv.Domain, k []byte, ts uint64) (v []byte, ok boo
 }
 func (tx *tx) HistoryRange(name kv.Domain, fromTs, toTs int, asc order.By, limit int) (it stream.KV, err error) {
 	return stream.PaginateKV(func(pageToken string) (keys, vals [][]byte, nextPageToken string, err error) {
-		reply, err := tx.db.remoteKV.HistoryRange(tx.ctx, &remote.HistoryRangeReq{TxId: tx.id, Table: name.String(), FromTs: int64(fromTs), ToTs: int64(toTs), OrderAscend: bool(asc), Limit: int64(limit), PageToken: pageToken})
+		reply, err := tx.db.remoteKV.HistoryRange(tx.ctx, &remoteproto.HistoryRangeReq{TxId: tx.id, Table: name.String(), FromTs: int64(fromTs), ToTs: int64(toTs), OrderAscend: bool(asc), Limit: int64(limit), PageToken: pageToken})
 		if err != nil {
 			return nil, nil, "", err
 		}
@@ -740,7 +740,7 @@ func (tx *tx) HistoryRange(name kv.Domain, fromTs, toTs int, asc order.By, limit
 
 func (tx *tx) IndexRange(name kv.InvertedIdx, k []byte, fromTs, toTs int, asc order.By, limit int) (timestamps stream.U64, err error) {
 	return stream.PaginateU64(func(pageToken string) (arr []uint64, nextPageToken string, err error) {
-		req := &remote.IndexRangeReq{TxId: tx.id, Table: name.String(), K: k, FromTs: int64(fromTs), ToTs: int64(toTs), OrderAscend: bool(asc), Limit: int64(limit), PageToken: pageToken}
+		req := &remoteproto.IndexRangeReq{TxId: tx.id, Table: name.String(), K: k, FromTs: int64(fromTs), ToTs: int64(toTs), OrderAscend: bool(asc), Limit: int64(limit), PageToken: pageToken}
 		reply, err := tx.db.remoteKV.IndexRange(tx.ctx, req)
 		if err != nil {
 			return nil, "", err
@@ -759,7 +759,7 @@ func (tx *tx) Prefix(table string, prefix []byte) (stream.KV, error) {
 
 func (tx *tx) rangeOrderLimit(table string, fromPrefix, toPrefix []byte, asc order.By, limit int) (stream.KV, error) {
 	return stream.PaginateKV(func(pageToken string) (keys [][]byte, values [][]byte, nextPageToken string, err error) {
-		req := &remote.RangeReq{TxId: tx.id, Table: table, FromPrefix: fromPrefix, ToPrefix: toPrefix, OrderAscend: bool(asc), Limit: int64(limit)}
+		req := &remoteproto.RangeReq{TxId: tx.id, Table: table, FromPrefix: fromPrefix, ToPrefix: toPrefix, OrderAscend: bool(asc), Limit: int64(limit)}
 		reply, err := tx.db.remoteKV.Range(tx.ctx, req)
 		if err != nil {
 			return nil, nil, "", err

--- a/db/kv/tables.go
+++ b/db/kv/tables.go
@@ -21,14 +21,14 @@ import (
 	"sort"
 	"strings"
 
-	types "github.com/erigontech/erigon-lib/gointerfaces/typesproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 )
 
 // DBSchemaVersion versions list
 // 5.0 - BlockTransaction table now has canonical ids (txs of non-canonical blocks moving to NonCanonicalTransaction table)
 // 6.0 - BlockTransaction table now has system-txs before and after block (records are absent if block has no system-tx, but sequence increasing)
 // 6.1 - Canonical/NonCanonical/BadBlock transitions now stored in same table: kv.EthTx. Add kv.BadBlockNumber table
-var DBSchemaVersion = types.VersionReply{Major: 7, Minor: 0, Patch: 0}
+var DBSchemaVersion = typesproto.VersionReply{Major: 7, Minor: 0, Patch: 0}
 
 const ChangeSets3 = "ChangeSets3"
 

--- a/db/snapshotsync/freezeblocks/block_reader.go
+++ b/db/snapshotsync/freezeblocks/block_reader.go
@@ -26,7 +26,7 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/dbg"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/dbutils"
@@ -44,7 +44,7 @@ import (
 )
 
 type RemoteBlockReader struct {
-	client       remote.ETHBACKENDClient
+	client       remoteproto.ETHBACKENDClient
 	txBlockIndex *txBlockIndexWithBlockReader
 }
 
@@ -146,7 +146,7 @@ func (r *RemoteBlockReader) HeaderByHash(ctx context.Context, tx kv.Getter, hash
 }
 
 func (r *RemoteBlockReader) CanonicalHash(ctx context.Context, tx kv.Getter, blockHeight uint64) (h common.Hash, ok bool, err error) {
-	reply, err := r.client.CanonicalHash(ctx, &remote.CanonicalHashRequest{BlockNumber: blockHeight})
+	reply, err := r.client.CanonicalHash(ctx, &remoteproto.CanonicalHashRequest{BlockNumber: blockHeight})
 	if err != nil {
 		return common.Hash{}, false, err
 	}
@@ -158,7 +158,7 @@ func (r *RemoteBlockReader) CanonicalHash(ctx context.Context, tx kv.Getter, blo
 }
 
 func (r *RemoteBlockReader) BlockForTxNum(ctx context.Context, tx kv.Tx, txnNum uint64) (blockNum uint64, ok bool, err error) {
-	reply, err := r.client.BlockForTxNum(ctx, &remote.BlockForTxNumRequest{Txnum: txnNum})
+	reply, err := r.client.BlockForTxNum(ctx, &remoteproto.BlockForTxNumRequest{Txnum: txnNum})
 	if err != nil {
 		return 0, false, err
 	}
@@ -170,7 +170,7 @@ func (r *RemoteBlockReader) BlockForTxNum(ctx context.Context, tx kv.Tx, txnNum 
 
 var _ services.FullBlockReader = &RemoteBlockReader{}
 
-func NewRemoteBlockReader(client remote.ETHBACKENDClient) *RemoteBlockReader {
+func NewRemoteBlockReader(client remoteproto.ETHBACKENDClient) *RemoteBlockReader {
 	br := &RemoteBlockReader{
 		client: client,
 	}
@@ -180,7 +180,7 @@ func NewRemoteBlockReader(client remote.ETHBACKENDClient) *RemoteBlockReader {
 }
 
 func (r *RemoteBlockReader) TxnLookup(ctx context.Context, tx kv.Getter, txnHash common.Hash) (uint64, uint64, bool, error) {
-	reply, err := r.client.TxnLookup(ctx, &remote.TxnLookupRequest{TxnHash: gointerfaces.ConvertHashToH256(txnHash)})
+	reply, err := r.client.TxnLookup(ctx, &remoteproto.TxnLookupRequest{TxnHash: gointerfaces.ConvertHashToH256(txnHash)})
 	if err != nil {
 		return 0, 0, false, err
 	}
@@ -225,7 +225,7 @@ func (r *RemoteBlockReader) HasSenders(ctx context.Context, _ kv.Getter, hash co
 }
 
 func (r *RemoteBlockReader) BlockWithSenders(ctx context.Context, _ kv.Getter, hash common.Hash, blockHeight uint64) (block *types.Block, senders []common.Address, err error) {
-	reply, err := r.client.Block(ctx, &remote.BlockRequest{BlockHash: gointerfaces.ConvertHashToH256(hash), BlockHeight: blockHeight})
+	reply, err := r.client.Block(ctx, &remoteproto.BlockRequest{BlockHash: gointerfaces.ConvertHashToH256(hash), BlockHeight: blockHeight})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -294,7 +294,7 @@ func (r *RemoteBlockReader) BodyWithTransactions(ctx context.Context, tx kv.Gett
 	return block.Body(), nil
 }
 func (r *RemoteBlockReader) HeaderNumber(ctx context.Context, tx kv.Getter, hash common.Hash) (*uint64, error) {
-	resp, err := r.client.HeaderNumber(ctx, &remote.HeaderNumberRequest{Hash: gointerfaces.ConvertHashToH256(hash)})
+	resp, err := r.client.HeaderNumber(ctx, &remoteproto.HeaderNumberRequest{Hash: gointerfaces.ConvertHashToH256(hash)})
 	if err != nil {
 		return nil, err
 	}
@@ -324,7 +324,7 @@ func (r *RemoteBlockReader) Ready(ctx context.Context) <-chan error {
 }
 
 func (r *RemoteBlockReader) CanonicalBodyForStorage(ctx context.Context, tx kv.Getter, blockNum uint64) (body *types.BodyForStorage, err error) {
-	bdRaw, err := r.client.CanonicalBodyForStorage(ctx, &remote.CanonicalBodyForStorageRequest{BlockNumber: blockNum})
+	bdRaw, err := r.client.CanonicalBodyForStorage(ctx, &remoteproto.CanonicalBodyForStorageRequest{BlockNumber: blockNum})
 	if err != nil {
 		return nil, err
 	}

--- a/db/snapshotsync/snapshotsync.go
+++ b/db/snapshotsync/snapshotsync.go
@@ -27,7 +27,7 @@ import (
 
 	"google.golang.org/grpc"
 
-	proto_downloader "github.com/erigontech/erigon-lib/gointerfaces/downloaderproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/downloaderproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/config3"
 	"github.com/erigontech/erigon/db/downloader/downloadergrpc"
@@ -100,19 +100,19 @@ func NewDownloadRequest(path string, torrentHash string) DownloadRequest {
 	return DownloadRequest{Path: path, TorrentHash: torrentHash}
 }
 
-func BuildProtoRequest(downloadRequest []DownloadRequest) *proto_downloader.AddRequest {
-	req := &proto_downloader.AddRequest{Items: make([]*proto_downloader.AddItem, 0, len(snaptype2.BlockSnapshotTypes))}
+func BuildProtoRequest(downloadRequest []DownloadRequest) *downloaderproto.AddRequest {
+	req := &downloaderproto.AddRequest{Items: make([]*downloaderproto.AddItem, 0, len(snaptype2.BlockSnapshotTypes))}
 	for _, r := range downloadRequest {
 		if r.Path == "" {
 			continue
 		}
 		if r.TorrentHash != "" {
-			req.Items = append(req.Items, &proto_downloader.AddItem{
+			req.Items = append(req.Items, &downloaderproto.AddItem{
 				TorrentHash: downloadergrpc.String2Proto(r.TorrentHash),
 				Path:        r.Path,
 			})
 		} else {
-			req.Items = append(req.Items, &proto_downloader.AddItem{
+			req.Items = append(req.Items, &downloaderproto.AddItem{
 				Path: r.Path,
 			})
 		}
@@ -124,10 +124,10 @@ func BuildProtoRequest(downloadRequest []DownloadRequest) *proto_downloader.AddR
 func RequestSnapshotsDownload(
 	ctx context.Context,
 	downloadRequest []DownloadRequest,
-	downloader proto_downloader.DownloaderClient,
+	downloader downloaderproto.DownloaderClient,
 	logPrefix string,
 ) error {
-	preq := &proto_downloader.SetLogPrefixRequest{Prefix: logPrefix}
+	preq := &downloaderproto.SetLogPrefixRequest{Prefix: logPrefix}
 	downloader.SetLogPrefix(ctx, preq)
 	// start seed large .seg of large size
 	req := BuildProtoRequest(downloadRequest)
@@ -354,7 +354,7 @@ func SyncSnapshots(
 	tx kv.RwTx,
 	blockReader blockReader,
 	cc *chain.Config,
-	snapshotDownloader proto_downloader.DownloaderClient,
+	snapshotDownloader downloaderproto.DownloaderClient,
 	syncCfg ethconfig.Sync,
 ) error {
 	if blockReader.FreezingCfg().NoDownloader || snapshotDownloader == nil {
@@ -507,7 +507,7 @@ func SyncSnapshots(
 	// Check for completion immediately, then growing intervals.
 	interval := time.Second
 	for {
-		completedResp, err := snapshotDownloader.Completed(ctx, &proto_downloader.CompletedRequest{})
+		completedResp, err := snapshotDownloader.Completed(ctx, &downloaderproto.CompletedRequest{})
 		if err != nil {
 			return fmt.Errorf("waiting for snapshot download: %w", err)
 		}

--- a/erigon-lib/gointerfaces/remoteproto/sort.go
+++ b/erigon-lib/gointerfaces/remoteproto/sort.go
@@ -19,10 +19,10 @@ package remoteproto
 import (
 	"strings"
 
-	types "github.com/erigontech/erigon-lib/gointerfaces/typesproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 )
 
-func NodeInfoReplyCmp(i, j *types.NodeInfoReply) int {
+func NodeInfoReplyCmp(i, j *typesproto.NodeInfoReply) int {
 	if cmp := strings.Compare(i.Name, j.Name); cmp != 0 {
 		return cmp
 	}

--- a/erigon-lib/gointerfaces/remoteproto/sort_test.go
+++ b/erigon-lib/gointerfaces/remoteproto/sort_test.go
@@ -20,27 +20,28 @@ import (
 	"slices"
 	"testing"
 
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
-	types "github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 )
 
 func TestSort(t *testing.T) {
 	tests := []struct {
 		name string
-		got  *remote.NodesInfoReply
-		want *remote.NodesInfoReply
+		got  *remoteproto.NodesInfoReply
+		want *remoteproto.NodesInfoReply
 	}{
 		{
 			name: "sort by name",
-			got: &remote.NodesInfoReply{
-				NodesInfo: []*types.NodeInfoReply{
+			got: &remoteproto.NodesInfoReply{
+				NodesInfo: []*typesproto.NodeInfoReply{
 					{Name: "b", Enode: "c"},
 					{Name: "a", Enode: "d"},
 				},
 			},
-			want: &remote.NodesInfoReply{
-				NodesInfo: []*types.NodeInfoReply{
+			want: &remoteproto.NodesInfoReply{
+				NodesInfo: []*typesproto.NodeInfoReply{
 					{Name: "a", Enode: "d"},
 					{Name: "b", Enode: "c"},
 				},
@@ -48,14 +49,14 @@ func TestSort(t *testing.T) {
 		},
 		{
 			name: "sort by enode",
-			got: &remote.NodesInfoReply{
-				NodesInfo: []*types.NodeInfoReply{
+			got: &remoteproto.NodesInfoReply{
+				NodesInfo: []*typesproto.NodeInfoReply{
 					{Name: "a", Enode: "d"},
 					{Name: "a", Enode: "c"},
 				},
 			},
-			want: &remote.NodesInfoReply{
-				NodesInfo: []*types.NodeInfoReply{
+			want: &remoteproto.NodesInfoReply{
+				NodesInfo: []*typesproto.NodeInfoReply{
 					{Name: "a", Enode: "c"},
 					{Name: "a", Enode: "d"},
 				},
@@ -65,7 +66,7 @@ func TestSort(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			slices.SortFunc(tt.got.NodesInfo, remote.NodeInfoReplyCmp)
+			slices.SortFunc(tt.got.NodesInfo, remoteproto.NodeInfoReplyCmp)
 			assert.Equal(t, tt.want, tt.got)
 		})
 	}

--- a/erigon-lib/gointerfaces/type_utils.go
+++ b/erigon-lib/gointerfaces/type_utils.go
@@ -21,10 +21,10 @@ import (
 
 	"github.com/holiman/uint256"
 
-	types "github.com/erigontech/erigon-lib/gointerfaces/typesproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 )
 
-func ConvertH2048ToBloom(h2048 *types.H2048) [256]byte {
+func ConvertH2048ToBloom(h2048 *typesproto.H2048) [256]byte {
 	var bloom [256]byte
 	copy(bloom[:], ConvertH512ToBytes(h2048.Hi.Hi))
 	copy(bloom[64:], ConvertH512ToBytes(h2048.Hi.Lo))
@@ -33,20 +33,20 @@ func ConvertH2048ToBloom(h2048 *types.H2048) [256]byte {
 	return bloom
 }
 
-func ConvertBytesToH2048(data []byte) *types.H2048 {
-	return &types.H2048{
-		Hi: &types.H1024{
+func ConvertBytesToH2048(data []byte) *typesproto.H2048 {
+	return &typesproto.H2048{
+		Hi: &typesproto.H1024{
 			Hi: ConvertBytesToH512(data),
 			Lo: ConvertBytesToH512(data[64:]),
 		},
-		Lo: &types.H1024{
+		Lo: &typesproto.H1024{
 			Hi: ConvertBytesToH512(data[128:]),
 			Lo: ConvertBytesToH512(data[192:]),
 		},
 	}
 }
 
-func ConvertH256ToHash(h256 *types.H256) [32]byte {
+func ConvertH256ToHash(h256 *typesproto.H256) [32]byte {
 	var hash [32]byte
 	binary.BigEndian.PutUint64(hash[0:], h256.Hi.Hi)
 	binary.BigEndian.PutUint64(hash[8:], h256.Hi.Lo)
@@ -55,7 +55,7 @@ func ConvertH256ToHash(h256 *types.H256) [32]byte {
 	return hash
 }
 
-func ConvertH512ToHash(h512 *types.H512) [64]byte {
+func ConvertH512ToHash(h512 *typesproto.H512) [64]byte {
 	var b [64]byte
 	binary.BigEndian.PutUint64(b[0:], h512.Hi.Hi.Hi)
 	binary.BigEndian.PutUint64(b[8:], h512.Hi.Hi.Lo)
@@ -68,26 +68,26 @@ func ConvertH512ToHash(h512 *types.H512) [64]byte {
 	return b
 }
 
-func ConvertHashesToH256(hashes [][32]byte) []*types.H256 {
-	res := make([]*types.H256, len(hashes))
+func ConvertHashesToH256(hashes [][32]byte) []*typesproto.H256 {
+	res := make([]*typesproto.H256, len(hashes))
 	for i := range hashes {
 		res[i] = ConvertHashToH256(hashes[i])
 	}
 	return res
 }
 
-func ConvertHashToH256(hash [32]byte) *types.H256 {
-	return &types.H256{
-		Lo: &types.H128{Lo: binary.BigEndian.Uint64(hash[24:]), Hi: binary.BigEndian.Uint64(hash[16:])},
-		Hi: &types.H128{Lo: binary.BigEndian.Uint64(hash[8:]), Hi: binary.BigEndian.Uint64(hash[0:])},
+func ConvertHashToH256(hash [32]byte) *typesproto.H256 {
+	return &typesproto.H256{
+		Lo: &typesproto.H128{Lo: binary.BigEndian.Uint64(hash[24:]), Hi: binary.BigEndian.Uint64(hash[16:])},
+		Hi: &typesproto.H128{Lo: binary.BigEndian.Uint64(hash[8:]), Hi: binary.BigEndian.Uint64(hash[0:])},
 	}
 }
 
-func ConvertHashToH512(hash [64]byte) *types.H512 {
+func ConvertHashToH512(hash [64]byte) *typesproto.H512 {
 	return ConvertBytesToH512(hash[:])
 }
 
-func ConvertH160toAddress(h160 *types.H160) [20]byte {
+func ConvertH160toAddress(h160 *typesproto.H160) [20]byte {
 	var addr [20]byte
 	binary.BigEndian.PutUint64(addr[0:], h160.Hi.Hi)
 	binary.BigEndian.PutUint64(addr[8:], h160.Hi.Lo)
@@ -95,14 +95,14 @@ func ConvertH160toAddress(h160 *types.H160) [20]byte {
 	return addr
 }
 
-func ConvertAddressToH160(addr [20]byte) *types.H160 {
-	return &types.H160{
+func ConvertAddressToH160(addr [20]byte) *typesproto.H160 {
+	return &typesproto.H160{
 		Lo: binary.BigEndian.Uint32(addr[16:]),
-		Hi: &types.H128{Lo: binary.BigEndian.Uint64(addr[8:]), Hi: binary.BigEndian.Uint64(addr[0:])},
+		Hi: &typesproto.H128{Lo: binary.BigEndian.Uint64(addr[8:]), Hi: binary.BigEndian.Uint64(addr[0:])},
 	}
 }
 
-func ConvertH256ToUint256Int(h256 *types.H256) *uint256.Int {
+func ConvertH256ToUint256Int(h256 *typesproto.H256) *uint256.Int {
 	// Note: uint256.Int is an array of 4 uint64 in little-endian order, i.e. most significant word is [3]
 	var i uint256.Int
 	i[3] = h256.Hi.Hi
@@ -112,33 +112,33 @@ func ConvertH256ToUint256Int(h256 *types.H256) *uint256.Int {
 	return &i
 }
 
-func ConvertUint256IntToH256(i *uint256.Int) *types.H256 {
+func ConvertUint256IntToH256(i *uint256.Int) *typesproto.H256 {
 	// Note: uint256.Int is an array of 4 uint64 in little-endian order, i.e. most significant word is [3]
-	return &types.H256{
-		Lo: &types.H128{Lo: i[0], Hi: i[1]},
-		Hi: &types.H128{Lo: i[2], Hi: i[3]},
+	return &typesproto.H256{
+		Lo: &typesproto.H128{Lo: i[0], Hi: i[1]},
+		Hi: &typesproto.H128{Lo: i[2], Hi: i[3]},
 	}
 }
 
-func ConvertH512ToBytes(h512 *types.H512) []byte {
+func ConvertH512ToBytes(h512 *typesproto.H512) []byte {
 	b := ConvertH512ToHash(h512)
 	return b[:]
 }
 
-func ConvertBytesToH512(b []byte) *types.H512 {
+func ConvertBytesToH512(b []byte) *typesproto.H512 {
 	if len(b) < 64 {
 		var b1 [64]byte
 		copy(b1[:], b)
 		b = b1[:]
 	}
-	return &types.H512{
-		Lo: &types.H256{
-			Lo: &types.H128{Lo: binary.BigEndian.Uint64(b[56:]), Hi: binary.BigEndian.Uint64(b[48:])},
-			Hi: &types.H128{Lo: binary.BigEndian.Uint64(b[40:]), Hi: binary.BigEndian.Uint64(b[32:])},
+	return &typesproto.H512{
+		Lo: &typesproto.H256{
+			Lo: &typesproto.H128{Lo: binary.BigEndian.Uint64(b[56:]), Hi: binary.BigEndian.Uint64(b[48:])},
+			Hi: &typesproto.H128{Lo: binary.BigEndian.Uint64(b[40:]), Hi: binary.BigEndian.Uint64(b[32:])},
 		},
-		Hi: &types.H256{
-			Lo: &types.H128{Lo: binary.BigEndian.Uint64(b[24:]), Hi: binary.BigEndian.Uint64(b[16:])},
-			Hi: &types.H128{Lo: binary.BigEndian.Uint64(b[8:]), Hi: binary.BigEndian.Uint64(b[0:])},
+		Hi: &typesproto.H256{
+			Lo: &typesproto.H128{Lo: binary.BigEndian.Uint64(b[24:]), Hi: binary.BigEndian.Uint64(b[16:])},
+			Hi: &typesproto.H128{Lo: binary.BigEndian.Uint64(b[8:]), Hi: binary.BigEndian.Uint64(b[0:])},
 		},
 	}
 }

--- a/erigon-lib/gointerfaces/version.go
+++ b/erigon-lib/gointerfaces/version.go
@@ -19,19 +19,19 @@ package gointerfaces
 import (
 	"fmt"
 
-	types "github.com/erigontech/erigon-lib/gointerfaces/typesproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 )
 
 type Version struct {
 	Major, Minor, Patch uint32 // interface Version of the client - to perform compatibility check when opening
 }
 
-func VersionFromProto(r *types.VersionReply) Version {
+func VersionFromProto(r *typesproto.VersionReply) Version {
 	return Version{Major: r.Major, Minor: r.Minor, Patch: r.Patch}
 }
 
 // EnsureVersion - Default policy: allow only patch difference
-func EnsureVersion(local Version, remote *types.VersionReply) bool {
+func EnsureVersion(local Version, remote *typesproto.VersionReply) bool {
 	if remote.Major != local.Major {
 		return false
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -51,13 +51,13 @@ import (
 	"github.com/erigontech/erigon-lib/common/disk"
 	"github.com/erigontech/erigon-lib/crypto"
 	"github.com/erigontech/erigon-lib/event"
-	protodownloader "github.com/erigontech/erigon-lib/gointerfaces/downloaderproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/downloaderproto"
 	"github.com/erigontech/erigon-lib/gointerfaces/grpcutil"
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
-	rpcsentinel "github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
-	protosentry "github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
-	prototypes "github.com/erigontech/erigon-lib/gointerfaces/typesproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/persistence/format/snapshot_format/getters"
@@ -193,7 +193,7 @@ type Ethereum struct {
 	syncUnwindOrder    stagedsync.UnwindOrder
 	syncPruneOrder     stagedsync.PruneOrder
 
-	downloaderClient protodownloader.DownloaderClient
+	downloaderClient downloaderproto.DownloaderClient
 
 	notifications *shards.Notifications
 
@@ -216,7 +216,7 @@ type Ethereum struct {
 	kvRPC          *remotedbserver.KvServer
 	logger         log.Logger
 
-	sentinel rpcsentinel.SentinelClient
+	sentinel sentinelproto.SentinelClient
 
 	silkworm                 *silkworm.Silkworm
 	silkwormRPCDaemonService *silkworm.RpcDaemonService
@@ -442,7 +442,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 	}
 
 	p2pConfig := stack.Config().P2P
-	var sentries []protosentry.SentryClient
+	var sentries []sentryproto.SentryClient
 	if len(p2pConfig.SentryAddr) > 0 {
 		for _, addr := range p2pConfig.SentryAddr {
 			sentryClient, err := sentry_multi_client.GrpcClient(backend.sentryCtx, addr)
@@ -1288,14 +1288,14 @@ func (s *Ethereum) StartMining(ctx context.Context, db kv.RwDB, stateDiffClient 
 	}
 
 	streamCtx, streamCancel := context.WithCancel(ctx)
-	stream, err := stateDiffClient.StateChanges(streamCtx, &remote.StateChangeRequest{WithStorage: false, WithTransactions: true}, grpc.WaitForReady(true))
+	stream, err := stateDiffClient.StateChanges(streamCtx, &remoteproto.StateChangeRequest{WithStorage: false, WithTransactions: true}, grpc.WaitForReady(true))
 
 	if err != nil {
 		streamCancel()
 		return err
 	}
 
-	stateChangeCh := make(chan *remote.StateChange)
+	stateChangeCh := make(chan *remoteproto.StateChange)
 
 	go func() {
 		for req, err := stream.Recv(); ; req, err = stream.Recv() {
@@ -1430,7 +1430,7 @@ func (s *Ethereum) NetPeerCount() (uint64, error) {
 	s.logger.Trace("sentry", "peer count", sentryPc)
 	for _, sc := range s.sentriesClient.Sentries() {
 		ctx := context.Background()
-		reply, err := sc.PeerCount(ctx, &protosentry.PeerCountRequest{})
+		reply, err := sc.PeerCount(ctx, &sentryproto.PeerCountRequest{})
 		if err != nil {
 			s.logger.Warn("sentry", "err", err)
 			return 0, nil
@@ -1441,12 +1441,12 @@ func (s *Ethereum) NetPeerCount() (uint64, error) {
 	return sentryPc, nil
 }
 
-func (s *Ethereum) NodesInfo(limit int) (*remote.NodesInfoReply, error) {
+func (s *Ethereum) NodesInfo(limit int) (*remoteproto.NodesInfoReply, error) {
 	if limit == 0 || limit > len(s.sentriesClient.Sentries()) {
 		limit = len(s.sentriesClient.Sentries())
 	}
 
-	nodes := make([]*prototypes.NodeInfoReply, 0, limit)
+	nodes := make([]*typesproto.NodeInfoReply, 0, limit)
 	for i := 0; i < limit; i++ {
 		sc := s.sentriesClient.Sentries()[i]
 
@@ -1459,8 +1459,8 @@ func (s *Ethereum) NodesInfo(limit int) (*remote.NodesInfoReply, error) {
 		nodes = append(nodes, nodeInfo)
 	}
 
-	nodesInfo := &remote.NodesInfoReply{NodesInfo: nodes}
-	slices.SortFunc(nodesInfo.NodesInfo, remote.NodeInfoReplyCmp)
+	nodesInfo := &remoteproto.NodesInfoReply{NodesInfo: nodes}
+	slices.SortFunc(nodesInfo.NodesInfo, remoteproto.NodeInfoReplyCmp)
 
 	return nodesInfo, nil
 }
@@ -1483,9 +1483,9 @@ func (s *Ethereum) setUpSnapDownloader(
 			return
 		}
 
-		req := &protodownloader.AddRequest{Items: make([]*protodownloader.AddItem, 0, len(frozenFileNames))}
+		req := &downloaderproto.AddRequest{Items: make([]*downloaderproto.AddItem, 0, len(frozenFileNames))}
 		for _, fName := range frozenFileNames {
-			req.Items = append(req.Items, &protodownloader.AddItem{
+			req.Items = append(req.Items, &downloaderproto.AddItem{
 				Path: fName,
 			})
 		}
@@ -1500,7 +1500,7 @@ func (s *Ethereum) setUpSnapDownloader(
 			return
 		}
 
-		if _, err := s.downloaderClient.Delete(ctx, &protodownloader.DeleteRequest{Paths: deletedFiles}); err != nil {
+		if _, err := s.downloaderClient.Delete(ctx, &downloaderproto.DeleteRequest{Paths: deletedFiles}); err != nil {
 			s.logger.Warn("[snapshots] downloader.Delete", "err", err)
 		}
 	})
@@ -1599,8 +1599,8 @@ func setUpBlockReader(ctx context.Context, db kv.RwDB, dirs datadir.Dirs, snConf
 	return blockReader, blockWriter, allSnapshots, allBorSnapshots, bridgeStore, heimdallStore, temporalDb, nil
 }
 
-func (s *Ethereum) Peers(ctx context.Context) (*remote.PeersReply, error) {
-	var reply remote.PeersReply
+func (s *Ethereum) Peers(ctx context.Context) (*remoteproto.PeersReply, error) {
+	var reply remoteproto.PeersReply
 	for _, sentryClient := range s.sentriesClient.Sentries() {
 		peers, err := sentryClient.Peers(ctx, &emptypb.Empty{})
 		if err != nil {
@@ -1612,24 +1612,24 @@ func (s *Ethereum) Peers(ctx context.Context) (*remote.PeersReply, error) {
 	return &reply, nil
 }
 
-func (s *Ethereum) AddPeer(ctx context.Context, req *remote.AddPeerRequest) (*remote.AddPeerReply, error) {
+func (s *Ethereum) AddPeer(ctx context.Context, req *remoteproto.AddPeerRequest) (*remoteproto.AddPeerReply, error) {
 	for _, sentryClient := range s.sentriesClient.Sentries() {
-		_, err := sentryClient.AddPeer(ctx, &protosentry.AddPeerRequest{Url: req.Url})
+		_, err := sentryClient.AddPeer(ctx, &sentryproto.AddPeerRequest{Url: req.Url})
 		if err != nil {
 			return nil, fmt.Errorf("ethereum backend MultiClient.AddPeers error: %w", err)
 		}
 	}
-	return &remote.AddPeerReply{Success: true}, nil
+	return &remoteproto.AddPeerReply{Success: true}, nil
 }
 
-func (s *Ethereum) RemovePeer(ctx context.Context, req *remote.RemovePeerRequest) (*remote.RemovePeerReply, error) {
+func (s *Ethereum) RemovePeer(ctx context.Context, req *remoteproto.RemovePeerRequest) (*remoteproto.RemovePeerReply, error) {
 	for _, sentryClient := range s.sentriesClient.Sentries() {
-		_, err := sentryClient.RemovePeer(ctx, &protosentry.RemovePeerRequest{Url: req.Url})
+		_, err := sentryClient.RemovePeer(ctx, &sentryproto.RemovePeerRequest{Url: req.Url})
 		if err != nil {
 			return nil, fmt.Errorf("ethereum backend MultiClient.RemovePeers error: %w", err)
 		}
 	}
-	return &remote.RemovePeerReply{Success: true}, nil
+	return &remoteproto.RemovePeerReply{Success: true}, nil
 }
 
 // Protocols returns all the currently configured
@@ -1894,7 +1894,7 @@ func readCurrentTotalDifficulty(ctx context.Context, db kv.RwDB, blockReader ser
 	return currentTD, err
 }
 
-func (s *Ethereum) Sentinel() rpcsentinel.SentinelClient {
+func (s *Ethereum) Sentinel() sentinelproto.SentinelClient {
 	return s.sentinel
 }
 
@@ -1925,7 +1925,7 @@ func setBorDefaultTxPoolPriceLimit(chainConfig *chain.Config, config txpoolcfg.C
 	}
 }
 
-func sentryMux(sentries []protosentry.SentryClient) protosentry.SentryClient {
+func sentryMux(sentries []sentryproto.SentryClient) sentryproto.SentryClient {
 	return libsentry.NewSentryMultiplexer(sentries)
 }
 

--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -37,7 +37,7 @@ import (
 	"github.com/gorilla/websocket"
 
 	"github.com/erigontech/erigon-lib/common"
-	txpool "github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/rawdb"
@@ -79,7 +79,7 @@ type Service struct {
 	histCh chan []uint64 // History request block numbers are fed into this channel
 
 	blockReader services.FullBlockReader
-	txPool      txpool.TxpoolClient
+	txPool      txpoolproto.TxpoolClient
 }
 
 // connWrapper is a wrapper to prevent concurrent-write or concurrent-read on the
@@ -133,7 +133,7 @@ func (w *connWrapper) Close() error {
 
 // New returns a monitoring service ready for stats reporting.
 func New(node *node.Node, servers []*sentry.GrpcServer, chainDB kv.RoDB, blockReader services.FullBlockReader,
-	engine consensus.Engine, url string, networkid uint64, quitCh <-chan struct{}, headCh chan [][]byte, txPoolRpcClient txpool.TxpoolClient) error {
+	engine consensus.Engine, url string, networkid uint64, quitCh <-chan struct{}, headCh chan [][]byte, txPoolRpcClient txpoolproto.TxpoolClient) error {
 	// Parse the netstats connection url
 	parts := urlRegex.FindStringSubmatch(url)
 	if len(parts) != 5 {
@@ -654,7 +654,7 @@ type pendStats struct {
 // reportPending retrieves the current number of pending transactions and reports
 // it to the stats server.
 func (s *Service) reportPending(conn *connWrapper) error {
-	in := new(txpool.StatusRequest)
+	in := new(txpoolproto.StatusRequest)
 	status, err := s.txPool.Status(context.Background(), in)
 	if err != nil {
 		return err

--- a/execution/engineapi/engine_block_downloader/block_downloader.go
+++ b/execution/engineapi/engine_block_downloader/block_downloader.go
@@ -28,7 +28,7 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2"
 
 	"github.com/erigontech/erigon-lib/common"
-	execution "github.com/erigontech/erigon-lib/gointerfaces/executionproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/executionproto"
 	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/etl"
@@ -93,7 +93,7 @@ type EngineBlockDownloader struct {
 	badHeadersV2 *lru.Cache[common.Hash, common.Hash]
 }
 
-func NewEngineBlockDownloader(ctx context.Context, logger log.Logger, hd *headerdownload.HeaderDownload, executionClient execution.ExecutionClient,
+func NewEngineBlockDownloader(ctx context.Context, logger log.Logger, hd *headerdownload.HeaderDownload, executionClient executionproto.ExecutionClient,
 	bd *bodydownload.BodyDownload, blockPropagator adapter.BlockPropagator,
 	bodyReqSend RequestBodyFunction, blockReader services.FullBlockReader, db kv.RoDB, config *chain.Config,
 	tmpdir string, syncCfg ethconfig.Sync,

--- a/execution/engineapi/engine_block_downloader/core.go
+++ b/execution/engineapi/engine_block_downloader/core.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/dbg"
-	execution "github.com/erigontech/erigon-lib/gointerfaces/executionproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/executionproto"
 	"github.com/erigontech/erigon/db/kv/mdbx"
 	"github.com/erigontech/erigon/db/kv/membatchwithdb"
 	"github.com/erigontech/erigon/db/rawdb"
@@ -142,12 +142,12 @@ func (e *EngineBlockDownloader) download(
 		e.status.Store(Idle)
 		return
 	}
-	if status == execution.ExecutionStatus_TooFarAway || status == execution.ExecutionStatus_Busy {
+	if status == executionproto.ExecutionStatus_TooFarAway || status == executionproto.ExecutionStatus_Busy {
 		e.logger.Info("[EngineBlockDownloader] block verification skipped")
 		e.status.Store(Idle)
 		return
 	}
-	if status == execution.ExecutionStatus_BadBlock {
+	if status == executionproto.ExecutionStatus_BadBlock {
 		e.logger.Warn("[EngineBlockDownloader] block segments downloaded are invalid")
 		e.ReportBadHeader(chainTip.Hash(), latestValidHash)
 		e.status.Store(Idle)
@@ -175,11 +175,11 @@ func (e *EngineBlockDownloader) downloadV2(ctx context.Context, req BackwardDown
 	if err != nil {
 		return fmt.Errorf("request chain tip validation failed: %w", err)
 	}
-	if status == execution.ExecutionStatus_TooFarAway || status == execution.ExecutionStatus_Busy {
+	if status == executionproto.ExecutionStatus_TooFarAway || status == executionproto.ExecutionStatus_Busy {
 		e.logger.Info("[EngineBlockDownloader] block verification skipped")
 		return nil
 	}
-	if status == execution.ExecutionStatus_BadBlock {
+	if status == executionproto.ExecutionStatus_BadBlock {
 		e.ReportBadHeader(tip.Hash(), latestValidHash)
 		return errors.New("block segments downloaded are invalid")
 	}
@@ -255,17 +255,17 @@ func (e *EngineBlockDownloader) execDownloadedBatch(ctx context.Context, block *
 		return err
 	}
 	switch status {
-	case execution.ExecutionStatus_BadBlock:
+	case executionproto.ExecutionStatus_BadBlock:
 		e.ReportBadHeader(block.Hash(), lastValidHash)
 		e.ReportBadHeader(requested, lastValidHash)
 		return fmt.Errorf("bad block when validating batch download: tip=%s, latestValidHash=%s", block.Hash(), lastValidHash)
-	case execution.ExecutionStatus_TooFarAway:
+	case executionproto.ExecutionStatus_TooFarAway:
 		e.logger.Debug(
 			"[EngineBlockDownloader] skipping validation of block batch download due to exec status too far away",
 			"tip", block.Hash(),
 			"latestValidHash", lastValidHash,
 		)
-	case execution.ExecutionStatus_Success: // proceed to UpdateForkChoice
+	case executionproto.ExecutionStatus_Success: // proceed to UpdateForkChoice
 	default:
 		return fmt.Errorf(
 			"unsuccessful status when validating batch download: status=%s, tip=%s, latestValidHash=%s",
@@ -278,7 +278,7 @@ func (e *EngineBlockDownloader) execDownloadedBatch(ctx context.Context, block *
 	if err != nil {
 		return err
 	}
-	if fcuStatus != execution.ExecutionStatus_Success {
+	if fcuStatus != executionproto.ExecutionStatus_Success {
 		return fmt.Errorf(
 			"unsuccessful status when updating fork choice for batch download: status=%s, tip=%s, latestValidHash=%s",
 			fcuStatus,

--- a/execution/engineapi/engine_server_test.go
+++ b/execution/engineapi/engine_server_test.go
@@ -26,8 +26,8 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/hexutil"
-	sentry "github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
-	txpool "github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cmd/rpcdaemon/cli/httpcfg"
 	"github.com/erigontech/erigon/cmd/rpcdaemon/rpcdaemontest"
@@ -62,7 +62,7 @@ func oneBlockStep(mockSentry *mock.MockSentry, require *require.Assertions, t *t
 	require.NoError(err)
 
 	mockSentry.ReceiveWg.Add(1)
-	for _, err = range mockSentry.Send(&sentry.InboundMessage{Id: sentry.MessageId_NEW_BLOCK_66, Data: b, PeerId: mockSentry.PeerId}) {
+	for _, err = range mockSentry.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_NEW_BLOCK_66, Data: b, PeerId: mockSentry.PeerId}) {
 		require.NoError(err)
 	}
 	// Send all the headers
@@ -72,7 +72,7 @@ func oneBlockStep(mockSentry *mock.MockSentry, require *require.Assertions, t *t
 	})
 	require.NoError(err)
 	mockSentry.ReceiveWg.Add(1)
-	for _, err = range mockSentry.Send(&sentry.InboundMessage{Id: sentry.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: mockSentry.PeerId}) {
+	for _, err = range mockSentry.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: mockSentry.PeerId}) {
 		require.NoError(err)
 	}
 	mockSentry.ReceiveWg.Wait() // Wait for all messages to be processed before we proceed
@@ -106,7 +106,7 @@ func TestGetBlobsV1(t *testing.T) {
 	ctx, conn := rpcdaemontest.CreateTestGrpcConn(t, mockSentry)
 	txPool := direct.NewTxPoolClient(mockSentry.TxPoolGrpcServer)
 
-	ff := rpchelper.New(ctx, rpchelper.DefaultFiltersConfig, nil, txPool, txpool.NewMiningClient(conn), func() {}, mockSentry.Log)
+	ff := rpchelper.New(ctx, rpchelper.DefaultFiltersConfig, nil, txPool, txpoolproto.NewMiningClient(conn), func() {}, mockSentry.Log)
 	api := jsonrpc.NewEthAPI(newBaseApiForTest(mockSentry), mockSentry.DB, nil, txPool, nil, 5000000, ethconfig.Defaults.RPCTxFeeCap, 100_000, false, 100_000, 128, logger)
 
 	executionRpc := direct.NewExecutionClientDirect(mockSentry.Eth1ExecutionService)
@@ -147,7 +147,7 @@ func TestGetBlobsV2(t *testing.T) {
 	ctx, conn := rpcdaemontest.CreateTestGrpcConn(t, mockSentry)
 	txPool := direct.NewTxPoolClient(mockSentry.TxPoolGrpcServer)
 
-	ff := rpchelper.New(ctx, rpchelper.DefaultFiltersConfig, nil, txPool, txpool.NewMiningClient(conn), func() {}, mockSentry.Log)
+	ff := rpchelper.New(ctx, rpchelper.DefaultFiltersConfig, nil, txPool, txpoolproto.NewMiningClient(conn), func() {}, mockSentry.Log)
 	api := jsonrpc.NewEthAPI(newBaseApiForTest(mockSentry), mockSentry.DB, nil, txPool, nil, 5000000, ethconfig.Defaults.RPCTxFeeCap, 100_000, false, 100_000, 128, logger)
 
 	executionRpc := direct.NewExecutionClientDirect(mockSentry.Eth1ExecutionService)

--- a/execution/engineapi/engine_types/jsonrpc.go
+++ b/execution/engineapi/engine_types/jsonrpc.go
@@ -25,8 +25,8 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/hexutil"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	execution "github.com/erigontech/erigon-lib/gointerfaces/executionproto"
-	types2 "github.com/erigontech/erigon-lib/gointerfaces/typesproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/executionproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 	"github.com/erigontech/erigon/execution/types"
 )
 
@@ -162,7 +162,7 @@ func (e *StringifiedError) Error() error {
 	return e.err
 }
 
-func ConvertRpcBlockToExecutionPayload(payload *execution.Block) *ExecutionPayload {
+func ConvertRpcBlockToExecutionPayload(payload *executionproto.Block) *ExecutionPayload {
 	header := payload.Header
 	body := payload.Body
 
@@ -203,7 +203,7 @@ func ConvertRpcBlockToExecutionPayload(payload *execution.Block) *ExecutionPaylo
 	return res
 }
 
-func ConvertPayloadFromRpc(payload *types2.ExecutionPayload) *ExecutionPayload {
+func ConvertPayloadFromRpc(payload *typesproto.ExecutionPayload) *ExecutionPayload {
 	var bloom types.Bloom = gointerfaces.ConvertH2048ToBloom(payload.LogsBloom)
 	baseFee := gointerfaces.ConvertH256ToUint256Int(payload.BaseFeePerGas).ToBig()
 
@@ -241,7 +241,7 @@ func ConvertPayloadFromRpc(payload *types2.ExecutionPayload) *ExecutionPayload {
 	return res
 }
 
-func ConvertBlobsFromRpc(bundle *types2.BlobsBundleV1) *BlobsBundleV1 {
+func ConvertBlobsFromRpc(bundle *typesproto.BlobsBundleV1) *BlobsBundleV1 {
 	if bundle == nil {
 		return nil
 	}
@@ -262,13 +262,13 @@ func ConvertBlobsFromRpc(bundle *types2.BlobsBundleV1) *BlobsBundleV1 {
 	return res
 }
 
-func ConvertWithdrawalsToRpc(in []*types.Withdrawal) []*types2.Withdrawal {
+func ConvertWithdrawalsToRpc(in []*types.Withdrawal) []*typesproto.Withdrawal {
 	if in == nil {
 		return nil
 	}
-	out := make([]*types2.Withdrawal, 0, len(in))
+	out := make([]*typesproto.Withdrawal, 0, len(in))
 	for _, w := range in {
-		out = append(out, &types2.Withdrawal{
+		out = append(out, &typesproto.Withdrawal{
 			Index:          w.Index,
 			ValidatorIndex: w.Validator,
 			Address:        gointerfaces.ConvertAddressToH160(w.Address),
@@ -278,7 +278,7 @@ func ConvertWithdrawalsToRpc(in []*types.Withdrawal) []*types2.Withdrawal {
 	return out
 }
 
-func ConvertWithdrawalsFromRpc(in []*types2.Withdrawal) []*types.Withdrawal {
+func ConvertWithdrawalsFromRpc(in []*typesproto.Withdrawal) []*types.Withdrawal {
 	if in == nil {
 		return nil
 	}

--- a/execution/eth1/eth1_chain_reader/chain_reader.go
+++ b/execution/eth1/eth1_chain_reader/chain_reader.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	execution "github.com/erigontech/erigon-lib/gointerfaces/executionproto"
-	types2 "github.com/erigontech/erigon-lib/gointerfaces/typesproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/executionproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
@@ -42,12 +42,12 @@ import (
 
 type ChainReaderWriterEth1 struct {
 	cfg             *chain.Config
-	executionModule execution.ExecutionClient
+	executionModule executionproto.ExecutionClient
 
 	fcuTimeoutMillis uint64
 }
 
-func NewChainReaderEth1(cfg *chain.Config, executionModule execution.ExecutionClient, fcuTimeoutMillis uint64) ChainReaderWriterEth1 {
+func NewChainReaderEth1(cfg *chain.Config, executionModule executionproto.ExecutionClient, fcuTimeoutMillis uint64) ChainReaderWriterEth1 {
 	return ChainReaderWriterEth1{
 		cfg:              cfg,
 		executionModule:  executionModule,
@@ -77,7 +77,7 @@ func (c ChainReaderWriterEth1) CurrentHeader(ctx context.Context) *types.Header 
 }
 
 func (c ChainReaderWriterEth1) GetHeader(ctx context.Context, hash common.Hash, number uint64) *types.Header {
-	resp, err := c.executionModule.GetHeader(ctx, &execution.GetSegmentRequest{
+	resp, err := c.executionModule.GetHeader(ctx, &executionproto.GetSegmentRequest{
 		BlockNumber: &number,
 		BlockHash:   gointerfaces.ConvertHashToH256(hash),
 	})
@@ -103,7 +103,7 @@ func (c ChainReaderWriterEth1) GetBlockByHash(ctx context.Context, hash common.H
 	}
 
 	number := header.Number.Uint64()
-	resp, err := c.executionModule.GetBody(ctx, &execution.GetSegmentRequest{
+	resp, err := c.executionModule.GetBody(ctx, &executionproto.GetSegmentRequest{
 		BlockNumber: &number,
 		BlockHash:   gointerfaces.ConvertHashToH256(hash),
 	})
@@ -133,7 +133,7 @@ func (c ChainReaderWriterEth1) GetBlockByNumber(ctx context.Context, number uint
 		return nil
 	}
 
-	resp, err := c.executionModule.GetBody(ctx, &execution.GetSegmentRequest{
+	resp, err := c.executionModule.GetBody(ctx, &executionproto.GetSegmentRequest{
 		BlockNumber: &number,
 	})
 	if err != nil {
@@ -157,7 +157,7 @@ func (c ChainReaderWriterEth1) GetBlockByNumber(ctx context.Context, number uint
 }
 
 func (c ChainReaderWriterEth1) GetHeaderByHash(ctx context.Context, hash common.Hash) *types.Header {
-	resp, err := c.executionModule.GetHeader(ctx, &execution.GetSegmentRequest{
+	resp, err := c.executionModule.GetHeader(ctx, &executionproto.GetSegmentRequest{
 		BlockNumber: nil,
 		BlockHash:   gointerfaces.ConvertHashToH256(hash),
 	})
@@ -177,7 +177,7 @@ func (c ChainReaderWriterEth1) GetHeaderByHash(ctx context.Context, hash common.
 }
 
 func (c ChainReaderWriterEth1) GetHeaderByNumber(ctx context.Context, number uint64) *types.Header {
-	resp, err := c.executionModule.GetHeader(ctx, &execution.GetSegmentRequest{
+	resp, err := c.executionModule.GetHeader(ctx, &executionproto.GetSegmentRequest{
 		BlockNumber: &number,
 		BlockHash:   nil,
 	})
@@ -197,7 +197,7 @@ func (c ChainReaderWriterEth1) GetHeaderByNumber(ctx context.Context, number uin
 }
 
 func (c ChainReaderWriterEth1) GetTd(ctx context.Context, hash common.Hash, number uint64) *big.Int {
-	resp, err := c.executionModule.GetTD(ctx, &execution.GetSegmentRequest{
+	resp, err := c.executionModule.GetTD(ctx, &executionproto.GetSegmentRequest{
 		BlockNumber: &number,
 		BlockHash:   gointerfaces.ConvertHashToH256(hash),
 	})
@@ -212,11 +212,11 @@ func (c ChainReaderWriterEth1) GetTd(ctx context.Context, hash common.Hash, numb
 }
 
 func (c ChainReaderWriterEth1) GetBodiesByHashes(ctx context.Context, hashes []common.Hash) ([]*types.RawBody, error) {
-	grpcHashes := make([]*types2.H256, len(hashes))
+	grpcHashes := make([]*typesproto.H256, len(hashes))
 	for i := range grpcHashes {
 		grpcHashes[i] = gointerfaces.ConvertHashToH256(hashes[i])
 	}
-	resp, err := c.executionModule.GetBodiesByHashes(ctx, &execution.GetBodiesByHashesRequest{
+	resp, err := c.executionModule.GetBodiesByHashes(ctx, &executionproto.GetBodiesByHashesRequest{
 		Hashes: grpcHashes,
 	})
 	if err != nil {
@@ -233,7 +233,7 @@ func (c ChainReaderWriterEth1) GetBodiesByHashes(ctx context.Context, hashes []c
 }
 
 func (c ChainReaderWriterEth1) GetBodiesByRange(ctx context.Context, start, count uint64) ([]*types.RawBody, error) {
-	resp, err := c.executionModule.GetBodiesByRange(ctx, &execution.GetBodiesByRangeRequest{
+	resp, err := c.executionModule.GetBodiesByRange(ctx, &executionproto.GetBodiesByRangeRequest{
 		Start: start,
 		Count: count,
 	})
@@ -289,7 +289,7 @@ func (c ChainReaderWriterEth1) FrozenBlocks(ctx context.Context) (uint64, bool) 
 }
 
 func (c ChainReaderWriterEth1) InsertBlocksAndWait(ctx context.Context, blocks []*types.Block) error {
-	request := &execution.InsertBlocksRequest{
+	request := &executionproto.InsertBlocksRequest{
 		Blocks: eth1_utils.ConvertBlocksToRPC(blocks),
 	}
 	response, err := c.executionModule.InsertBlocks(ctx, request)
@@ -297,7 +297,7 @@ func (c ChainReaderWriterEth1) InsertBlocksAndWait(ctx context.Context, blocks [
 		return err
 	}
 
-	for response.Result == execution.ExecutionStatus_Busy {
+	for response.Result == executionproto.ExecutionStatus_Busy {
 		const retryDelay = 100 * time.Millisecond
 		select {
 		case <-time.After(retryDelay):
@@ -310,14 +310,14 @@ func (c ChainReaderWriterEth1) InsertBlocksAndWait(ctx context.Context, blocks [
 			return err
 		}
 	}
-	if response.Result != execution.ExecutionStatus_Success {
+	if response.Result != executionproto.ExecutionStatus_Success {
 		return fmt.Errorf("InsertBlocksAndWait: executionModule.InsertBlocks ExecutionStatus = %s", response.Result.String())
 	}
 	return nil
 }
 
 func (c ChainReaderWriterEth1) InsertBlocks(ctx context.Context, blocks []*types.Block) error {
-	request := &execution.InsertBlocksRequest{
+	request := &executionproto.InsertBlocksRequest{
 		Blocks: eth1_utils.ConvertBlocksToRPC(blocks),
 	}
 	response, err := c.executionModule.InsertBlocks(ctx, request)
@@ -325,10 +325,10 @@ func (c ChainReaderWriterEth1) InsertBlocks(ctx context.Context, blocks []*types
 		return err
 	}
 
-	if response.Result == execution.ExecutionStatus_Busy {
+	if response.Result == executionproto.ExecutionStatus_Busy {
 		return context.DeadlineExceeded
 	}
-	if response.Result != execution.ExecutionStatus_Success {
+	if response.Result != executionproto.ExecutionStatus_Success {
 		return fmt.Errorf("InsertBlocks: invalid code received from execution module: %s", response.Result.String())
 	}
 	return nil
@@ -339,8 +339,8 @@ func (c ChainReaderWriterEth1) InsertBlockAndWait(ctx context.Context, block *ty
 	return c.InsertBlocksAndWait(ctx, blocks)
 }
 
-func (c ChainReaderWriterEth1) ValidateChain(ctx context.Context, hash common.Hash, number uint64) (execution.ExecutionStatus, *string, common.Hash, error) {
-	resp, err := c.executionModule.ValidateChain(ctx, &execution.ValidationRequest{
+func (c ChainReaderWriterEth1) ValidateChain(ctx context.Context, hash common.Hash, number uint64) (executionproto.ExecutionStatus, *string, common.Hash, error) {
+	resp, err := c.executionModule.ValidateChain(ctx, &executionproto.ValidationRequest{
 		Hash:   gointerfaces.ConvertHashToH256(hash),
 		Number: number,
 	})
@@ -354,12 +354,12 @@ func (c ChainReaderWriterEth1) ValidateChain(ctx context.Context, hash common.Ha
 	return resp.ValidationStatus, validationError, gointerfaces.ConvertH256ToHash(resp.LatestValidHash), err
 }
 
-func (c ChainReaderWriterEth1) UpdateForkChoice(ctx context.Context, headHash, safeHash, finalizeHash common.Hash, timeoutOverride ...uint64) (execution.ExecutionStatus, *string, common.Hash, error) {
+func (c ChainReaderWriterEth1) UpdateForkChoice(ctx context.Context, headHash, safeHash, finalizeHash common.Hash, timeoutOverride ...uint64) (executionproto.ExecutionStatus, *string, common.Hash, error) {
 	timeout := c.fcuTimeoutMillis
 	if len(timeoutOverride) > 0 {
 		timeout = timeoutOverride[0]
 	}
-	resp, err := c.executionModule.UpdateForkChoice(ctx, &execution.ForkChoice{
+	resp, err := c.executionModule.UpdateForkChoice(ctx, &executionproto.ForkChoice{
 		HeadBlockHash:      gointerfaces.ConvertHashToH256(headHash),
 		SafeBlockHash:      gointerfaces.ConvertHashToH256(safeHash),
 		FinalizedBlockHash: gointerfaces.ConvertHashToH256(finalizeHash),
@@ -376,7 +376,7 @@ func (c ChainReaderWriterEth1) UpdateForkChoice(ctx context.Context, headHash, s
 }
 
 func (c ChainReaderWriterEth1) GetForkChoice(ctx context.Context) (headHash, finalizedHash, safeHash common.Hash, err error) {
-	var resp *execution.ForkChoice
+	var resp *executionproto.ForkChoice
 	resp, err = c.executionModule.GetForkChoice(ctx, &emptypb.Empty{})
 	if err != nil {
 		log.Warn("[engine] GetForkChoice", "err", err)
@@ -387,7 +387,7 @@ func (c ChainReaderWriterEth1) GetForkChoice(ctx context.Context) (headHash, fin
 }
 
 func (c ChainReaderWriterEth1) HasBlock(ctx context.Context, hash common.Hash) (bool, error) {
-	resp, err := c.executionModule.HasBlock(ctx, &execution.GetSegmentRequest{
+	resp, err := c.executionModule.HasBlock(ctx, &executionproto.GetSegmentRequest{
 		BlockHash: gointerfaces.ConvertHashToH256(hash),
 	})
 	if err != nil {
@@ -397,7 +397,7 @@ func (c ChainReaderWriterEth1) HasBlock(ctx context.Context, hash common.Hash) (
 }
 
 func (c ChainReaderWriterEth1) AssembleBlock(baseHash common.Hash, attributes *engine_types.PayloadAttributes) (id uint64, err error) {
-	request := &execution.AssembleBlockRequest{
+	request := &executionproto.AssembleBlockRequest{
 		Timestamp:             uint64(attributes.Timestamp),
 		PrevRandao:            gointerfaces.ConvertHashToH256(attributes.PrevRandao),
 		SuggestedFeeRecipient: gointerfaces.ConvertAddressToH160(attributes.SuggestedFeeRecipient),
@@ -417,8 +417,8 @@ func (c ChainReaderWriterEth1) AssembleBlock(baseHash common.Hash, attributes *e
 	return resp.Id, nil
 }
 
-func (c ChainReaderWriterEth1) GetAssembledBlock(id uint64) (*cltypes.Eth1Block, *engine_types.BlobsBundleV1, *types2.RequestsBundle, *big.Int, error) {
-	resp, err := c.executionModule.GetAssembledBlock(context.Background(), &execution.GetAssembledBlockRequest{
+func (c ChainReaderWriterEth1) GetAssembledBlock(id uint64) (*cltypes.Eth1Block, *engine_types.BlobsBundleV1, *typesproto.RequestsBundle, *big.Int, error) {
+	resp, err := c.executionModule.GetAssembledBlock(context.Background(), &executionproto.GetAssembledBlockRequest{
 		Id: id,
 	})
 	if err != nil {

--- a/execution/eth1/eth1_utils/grpc.go
+++ b/execution/eth1/eth1_utils/grpc.go
@@ -25,23 +25,23 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	execution "github.com/erigontech/erigon-lib/gointerfaces/executionproto"
-	types2 "github.com/erigontech/erigon-lib/gointerfaces/typesproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/executionproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 	"github.com/erigontech/erigon/execution/types"
 )
 
-func HeaderToHeaderRPC(header *types.Header) *execution.Header {
+func HeaderToHeaderRPC(header *types.Header) *executionproto.Header {
 	difficulty := new(uint256.Int)
 	difficulty.SetFromBig(header.Difficulty)
 
-	var baseFeeReply *types2.H256
+	var baseFeeReply *typesproto.H256
 	if header.BaseFee != nil {
 		var baseFee uint256.Int
 		baseFee.SetFromBig(header.BaseFee)
 		baseFeeReply = gointerfaces.ConvertUint256IntToH256(&baseFee)
 	}
 
-	h := &execution.Header{
+	h := &executionproto.Header{
 		ParentHash:      gointerfaces.ConvertHashToH256(header.ParentHash),
 		Coinbase:        gointerfaces.ConvertAddressToH160(header.Coinbase),
 		StateRoot:       gointerfaces.ConvertHashToH256(header.Root),
@@ -85,37 +85,37 @@ func HeaderToHeaderRPC(header *types.Header) *execution.Header {
 	return h
 }
 
-func HeadersToHeadersRPC(headers []*types.Header) []*execution.Header {
+func HeadersToHeadersRPC(headers []*types.Header) []*executionproto.Header {
 	if headers == nil {
 		return nil
 	}
-	ret := make([]*execution.Header, 0, len(headers))
+	ret := make([]*executionproto.Header, 0, len(headers))
 	for _, header := range headers {
 		ret = append(ret, HeaderToHeaderRPC(header))
 	}
 	return ret
 }
 
-func ConvertBlocksToRPC(blocks []*types.Block) []*execution.Block {
-	ret := []*execution.Block{}
+func ConvertBlocksToRPC(blocks []*types.Block) []*executionproto.Block {
+	ret := []*executionproto.Block{}
 	for _, block := range blocks {
 		ret = append(ret, ConvertBlockToRPC(block))
 	}
 	return ret
 }
 
-func ConvertBlockToRPC(block *types.Block) *execution.Block {
+func ConvertBlockToRPC(block *types.Block) *executionproto.Block {
 	h := HeaderToHeaderRPC(block.Header())
 	blockHash := block.Hash()
 	h.BlockHash = gointerfaces.ConvertHashToH256(blockHash)
 
-	return &execution.Block{
+	return &executionproto.Block{
 		Header: h,
 		Body:   ConvertRawBlockBodyToRpc(block.RawBody(), h.BlockNumber, blockHash),
 	}
 }
 
-func HeaderRpcToHeader(header *execution.Header) (*types.Header, error) {
+func HeaderRpcToHeader(header *executionproto.Header) (*types.Header, error) {
 	var blockNonce types.BlockNonce
 	binary.BigEndian.PutUint64(blockNonce[:], header.Nonce)
 	h := &types.Header{
@@ -164,7 +164,7 @@ func HeaderRpcToHeader(header *execution.Header) (*types.Header, error) {
 	return h, nil
 }
 
-func HeadersRpcToHeaders(headers []*execution.Header) ([]*types.Header, error) {
+func HeadersRpcToHeaders(headers []*executionproto.Header) ([]*types.Header, error) {
 	if headers == nil {
 		return nil, nil
 	}
@@ -179,7 +179,7 @@ func HeadersRpcToHeaders(headers []*execution.Header) ([]*types.Header, error) {
 	return out, nil
 }
 
-func ConvertWithdrawalsFromRpc(in []*types2.Withdrawal) []*types.Withdrawal {
+func ConvertWithdrawalsFromRpc(in []*typesproto.Withdrawal) []*types.Withdrawal {
 	if in == nil {
 		return nil
 	}
@@ -195,13 +195,13 @@ func ConvertWithdrawalsFromRpc(in []*types2.Withdrawal) []*types.Withdrawal {
 	return out
 }
 
-func ConvertWithdrawalsToRpc(in []*types.Withdrawal) []*types2.Withdrawal {
+func ConvertWithdrawalsToRpc(in []*types.Withdrawal) []*typesproto.Withdrawal {
 	if in == nil {
 		return nil
 	}
-	out := make([]*types2.Withdrawal, 0, len(in))
+	out := make([]*typesproto.Withdrawal, 0, len(in))
 	for _, w := range in {
-		out = append(out, &types2.Withdrawal{
+		out = append(out, &typesproto.Withdrawal{
 			Index:          w.Index,
 			ValidatorIndex: w.Validator,
 			Address:        gointerfaces.ConvertAddressToH160(w.Address),
@@ -211,12 +211,12 @@ func ConvertWithdrawalsToRpc(in []*types.Withdrawal) []*types2.Withdrawal {
 	return out
 }
 
-func ConvertRawBlockBodyToRpc(in *types.RawBody, blockNumber uint64, blockHash common.Hash) *execution.BlockBody {
+func ConvertRawBlockBodyToRpc(in *types.RawBody, blockNumber uint64, blockHash common.Hash) *executionproto.BlockBody {
 	if in == nil {
 		return nil
 	}
 
-	return &execution.BlockBody{
+	return &executionproto.BlockBody{
 		BlockNumber:  blockNumber,
 		BlockHash:    gointerfaces.ConvertHashToH256(blockHash),
 		Transactions: in.Transactions,
@@ -225,8 +225,8 @@ func ConvertRawBlockBodyToRpc(in *types.RawBody, blockNumber uint64, blockHash c
 	}
 }
 
-func ConvertRawBlockBodiesToRpc(in []*types.RawBody, blockNumbers []uint64, blockHashes []common.Hash) []*execution.BlockBody {
-	ret := []*execution.BlockBody{}
+func ConvertRawBlockBodiesToRpc(in []*types.RawBody, blockNumbers []uint64, blockHashes []common.Hash) []*executionproto.BlockBody {
+	ret := []*executionproto.BlockBody{}
 
 	for i, body := range in {
 		ret = append(ret, ConvertRawBlockBodyToRpc(body, blockNumbers[i], blockHashes[i]))
@@ -234,7 +234,7 @@ func ConvertRawBlockBodiesToRpc(in []*types.RawBody, blockNumbers []uint64, bloc
 	return ret
 }
 
-func ConvertRawBlockBodyFromRpc(in *execution.BlockBody) (*types.RawBody, error) {
+func ConvertRawBlockBodyFromRpc(in *executionproto.BlockBody) (*types.RawBody, error) {
 	if in == nil {
 		return nil, nil
 	}
@@ -249,7 +249,7 @@ func ConvertRawBlockBodyFromRpc(in *execution.BlockBody) (*types.RawBody, error)
 	}, nil
 }
 
-func ConvertBigIntFromRpc(in *types2.H256) *big.Int {
+func ConvertBigIntFromRpc(in *typesproto.H256) *big.Int {
 	if in == nil {
 		return nil
 	}
@@ -257,7 +257,7 @@ func ConvertBigIntFromRpc(in *types2.H256) *big.Int {
 	return base.ToBig()
 }
 
-func ConvertBigIntToRpc(in *big.Int) *types2.H256 {
+func ConvertBigIntToRpc(in *big.Int) *typesproto.H256 {
 	if in == nil {
 		return nil
 	}

--- a/execution/eth1/forkchoice.go
+++ b/execution/eth1/forkchoice.go
@@ -28,7 +28,7 @@ import (
 	"github.com/erigontech/erigon-lib/common/dbg"
 	"github.com/erigontech/erigon-lib/common/metrics"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	execution "github.com/erigontech/erigon-lib/gointerfaces/executionproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/executionproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/rawdbv3"
@@ -44,11 +44,11 @@ import (
 const startPruneFrom = 1024
 
 type forkchoiceOutcome struct {
-	receipt *execution.ForkChoiceReceipt
+	receipt *executionproto.ForkChoiceReceipt
 	err     error
 }
 
-func sendForkchoiceReceiptWithoutWaiting(ch chan forkchoiceOutcome, receipt *execution.ForkChoiceReceipt, alreadySent bool) {
+func sendForkchoiceReceiptWithoutWaiting(ch chan forkchoiceOutcome, receipt *executionproto.ForkChoiceReceipt, alreadySent bool) {
 	if alreadySent {
 		return
 	}
@@ -121,7 +121,7 @@ func (e *EthereumExecutionModule) verifyForkchoiceHashes(ctx context.Context, tx
 	return true, nil
 }
 
-func (e *EthereumExecutionModule) UpdateForkChoice(ctx context.Context, req *execution.ForkChoice) (*execution.ForkChoiceReceipt, error) {
+func (e *EthereumExecutionModule) UpdateForkChoice(ctx context.Context, req *executionproto.ForkChoice) (*executionproto.ForkChoiceReceipt, error) {
 	blockHash := gointerfaces.ConvertH256ToHash(req.HeadBlockHash)
 	safeHash := gointerfaces.ConvertH256ToHash(req.SafeBlockHash)
 	finalizedHash := gointerfaces.ConvertH256ToHash(req.FinalizedBlockHash)
@@ -137,9 +137,9 @@ func (e *EthereumExecutionModule) UpdateForkChoice(ctx context.Context, req *exe
 		select {
 		case <-fcuTimer.C:
 			e.logger.Debug("treating forkChoiceUpdated as asynchronous as it is taking too long")
-			return &execution.ForkChoiceReceipt{
+			return &executionproto.ForkChoiceReceipt{
 				LatestValidHash: gointerfaces.ConvertHashToH256(common.Hash{}),
-				Status:          execution.ExecutionStatus_Busy,
+				Status:          executionproto.ExecutionStatus_Busy,
 			}, nil
 		case outcome := <-outcomeCh:
 			return outcome.receipt, outcome.err
@@ -176,9 +176,9 @@ func minUnwindableBlock(tx kv.TemporalTx, number uint64) (uint64, error) {
 func (e *EthereumExecutionModule) updateForkChoice(ctx context.Context, originalBlockHash, safeHash, finalizedHash common.Hash, outcomeCh chan forkchoiceOutcome) {
 	if !e.semaphore.TryAcquire(1) {
 		e.logger.Trace("ethereumExecutionModule.updateForkChoice: ExecutionStatus_Busy")
-		sendForkchoiceReceiptWithoutWaiting(outcomeCh, &execution.ForkChoiceReceipt{
+		sendForkchoiceReceiptWithoutWaiting(outcomeCh, &executionproto.ForkChoiceReceipt{
 			LatestValidHash: gointerfaces.ConvertHashToH256(common.Hash{}),
-			Status:          execution.ExecutionStatus_Busy,
+			Status:          executionproto.ExecutionStatus_Busy,
 		}, false)
 		return
 	}
@@ -272,15 +272,15 @@ func (e *EthereumExecutionModule) updateForkChoice(ctx context.Context, original
 				return
 			}
 			if !valid {
-				sendForkchoiceReceiptWithoutWaiting(outcomeCh, &execution.ForkChoiceReceipt{
+				sendForkchoiceReceiptWithoutWaiting(outcomeCh, &executionproto.ForkChoiceReceipt{
 					LatestValidHash: gointerfaces.ConvertHashToH256(common.Hash{}),
-					Status:          execution.ExecutionStatus_InvalidForkchoice,
+					Status:          executionproto.ExecutionStatus_InvalidForkchoice,
 				}, false)
 				return
 			}
-			sendForkchoiceReceiptWithoutWaiting(outcomeCh, &execution.ForkChoiceReceipt{
+			sendForkchoiceReceiptWithoutWaiting(outcomeCh, &executionproto.ForkChoiceReceipt{
 				LatestValidHash: gointerfaces.ConvertHashToH256(blockHash),
-				Status:          execution.ExecutionStatus_Success,
+				Status:          executionproto.ExecutionStatus_Success,
 			}, false)
 			return
 		}
@@ -309,9 +309,9 @@ func (e *EthereumExecutionModule) updateForkChoice(ctx context.Context, original
 				return
 			}
 			if currentHeader == nil {
-				sendForkchoiceReceiptWithoutWaiting(outcomeCh, &execution.ForkChoiceReceipt{
+				sendForkchoiceReceiptWithoutWaiting(outcomeCh, &executionproto.ForkChoiceReceipt{
 					LatestValidHash: gointerfaces.ConvertHashToH256(common.Hash{}),
-					Status:          execution.ExecutionStatus_MissingSegment,
+					Status:          executionproto.ExecutionStatus_MissingSegment,
 				}, false)
 				return
 			}
@@ -403,9 +403,9 @@ func (e *EthereumExecutionModule) updateForkChoice(ctx context.Context, original
 			sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, err, false)
 			return
 		}
-		sendForkchoiceReceiptWithoutWaiting(outcomeCh, &execution.ForkChoiceReceipt{
+		sendForkchoiceReceiptWithoutWaiting(outcomeCh, &executionproto.ForkChoiceReceipt{
 			LatestValidHash: gointerfaces.ConvertHashToH256(common.Hash{}),
-			Status:          execution.ExecutionStatus_TooFarAway,
+			Status:          executionproto.ExecutionStatus_TooFarAway,
 			ValidationError: "domain ahead of blocks",
 		}, false)
 		return
@@ -435,9 +435,9 @@ func (e *EthereumExecutionModule) updateForkChoice(ctx context.Context, original
 		e.logger.Debug("[updateForkchoice] Fork choice update: flushing in-memory state (built by previous newPayload)")
 		if stateFlushingInParallel {
 			// Send forkchoice early (We already know the fork is valid)
-			sendForkchoiceReceiptWithoutWaiting(outcomeCh, &execution.ForkChoiceReceipt{
+			sendForkchoiceReceiptWithoutWaiting(outcomeCh, &executionproto.ForkChoiceReceipt{
 				LatestValidHash: gointerfaces.ConvertHashToH256(blockHash),
-				Status:          execution.ExecutionStatus_Success,
+				Status:          executionproto.ExecutionStatus_Success,
 				ValidationError: validationError,
 			}, false)
 		}
@@ -497,12 +497,12 @@ func (e *EthereumExecutionModule) updateForkChoice(ctx context.Context, original
 	log := headNumber != nil && e.logger != nil
 	// Update forks...
 	writeForkChoiceHashes(tx, blockHash, safeHash, finalizedHash)
-	status := execution.ExecutionStatus_Success
+	status := executionproto.ExecutionStatus_Success
 
 	if headHash != blockHash {
 		blockHashBlockNum, _ := e.blockReader.HeaderNumber(ctx, tx, blockHash)
 
-		status = execution.ExecutionStatus_BadBlock
+		status = executionproto.ExecutionStatus_BadBlock
 		validationError = "headHash and blockHash mismatch"
 		if log {
 			headNum := "unknown"
@@ -522,8 +522,8 @@ func (e *EthereumExecutionModule) updateForkChoice(ctx context.Context, original
 			return
 		}
 		if !valid {
-			sendForkchoiceReceiptWithoutWaiting(outcomeCh, &execution.ForkChoiceReceipt{
-				Status:          execution.ExecutionStatus_InvalidForkchoice,
+			sendForkchoiceReceiptWithoutWaiting(outcomeCh, &executionproto.ForkChoiceReceipt{
+				Status:          executionproto.ExecutionStatus_InvalidForkchoice,
 				LatestValidHash: gointerfaces.ConvertHashToH256(common.Hash{}),
 			}, stateFlushingInParallel)
 			return
@@ -599,7 +599,7 @@ func (e *EthereumExecutionModule) updateForkChoice(ctx context.Context, original
 		e.runPostForkchoiceInBackground(initialCycle)
 	}
 
-	sendForkchoiceReceiptWithoutWaiting(outcomeCh, &execution.ForkChoiceReceipt{
+	sendForkchoiceReceiptWithoutWaiting(outcomeCh, &executionproto.ForkChoiceReceipt{
 		LatestValidHash: gointerfaces.ConvertHashToH256(headHash),
 		Status:          status,
 		ValidationError: validationError,

--- a/execution/eth1/getters.go
+++ b/execution/eth1/getters.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	execution "github.com/erigontech/erigon-lib/gointerfaces/executionproto"
-	types2 "github.com/erigontech/erigon-lib/gointerfaces/typesproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/executionproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/rawdb"
 	"github.com/erigontech/erigon/execution/eth1/eth1_utils"
@@ -35,7 +35,7 @@ import (
 
 var errNotFound = errors.New("notfound")
 
-func (e *EthereumExecutionModule) parseSegmentRequest(ctx context.Context, tx kv.Tx, req *execution.GetSegmentRequest) (blockHash common.Hash, blockNumber uint64, err error) {
+func (e *EthereumExecutionModule) parseSegmentRequest(ctx context.Context, tx kv.Tx, req *executionproto.GetSegmentRequest) (blockHash common.Hash, blockNumber uint64, err error) {
 	switch {
 	// Case 1: Only hash is given.
 	case req.BlockHash != nil && req.BlockNumber == nil:
@@ -64,7 +64,7 @@ func (e *EthereumExecutionModule) parseSegmentRequest(ctx context.Context, tx kv
 	return
 }
 
-func (e *EthereumExecutionModule) GetBody(ctx context.Context, req *execution.GetSegmentRequest) (*execution.GetBodyResponse, error) {
+func (e *EthereumExecutionModule) GetBody(ctx context.Context, req *executionproto.GetSegmentRequest) (*executionproto.GetBodyResponse, error) {
 	// Invalid case: request is invalid.
 	if req == nil || (req.BlockHash == nil && req.BlockNumber == nil) {
 		return nil, errors.New("ethereumExecutionModule.GetBody: bad request")
@@ -77,7 +77,7 @@ func (e *EthereumExecutionModule) GetBody(ctx context.Context, req *execution.Ge
 
 	blockHash, blockNumber, err := e.parseSegmentRequest(ctx, tx, req)
 	if errors.Is(err, errNotFound) {
-		return &execution.GetBodyResponse{Body: nil}, nil
+		return &executionproto.GetBodyResponse{Body: nil}, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("ethereumExecutionModule.GetBody: parseSegmentRequest error %w", err)
@@ -87,14 +87,14 @@ func (e *EthereumExecutionModule) GetBody(ctx context.Context, req *execution.Ge
 		return nil, fmt.Errorf("ethereumExecutionModule.GetBody: getBody error %w", err)
 	}
 	if body == nil {
-		return &execution.GetBodyResponse{Body: nil}, nil
+		return &executionproto.GetBodyResponse{Body: nil}, nil
 	}
 	rawBody := body.RawBody()
 
-	return &execution.GetBodyResponse{Body: eth1_utils.ConvertRawBlockBodyToRpc(rawBody, blockNumber, blockHash)}, nil
+	return &executionproto.GetBodyResponse{Body: eth1_utils.ConvertRawBlockBodyToRpc(rawBody, blockNumber, blockHash)}, nil
 }
 
-func (e *EthereumExecutionModule) GetHeader(ctx context.Context, req *execution.GetSegmentRequest) (*execution.GetHeaderResponse, error) {
+func (e *EthereumExecutionModule) GetHeader(ctx context.Context, req *executionproto.GetSegmentRequest) (*executionproto.GetHeaderResponse, error) {
 	// Invalid case: request is invalid.
 	if req == nil || (req.BlockHash == nil && req.BlockNumber == nil) {
 		return nil, errors.New("ethereumExecutionModule.GetHeader: bad request")
@@ -107,7 +107,7 @@ func (e *EthereumExecutionModule) GetHeader(ctx context.Context, req *execution.
 
 	blockHash, blockNumber, err := e.parseSegmentRequest(ctx, tx, req)
 	if errors.Is(err, errNotFound) {
-		return &execution.GetHeaderResponse{Header: nil}, nil
+		return &executionproto.GetHeaderResponse{Header: nil}, nil
 	}
 
 	header, err := e.getHeader(ctx, tx, blockHash, blockNumber)
@@ -115,20 +115,20 @@ func (e *EthereumExecutionModule) GetHeader(ctx context.Context, req *execution.
 		return nil, fmt.Errorf("ethereumExecutionModule.GetHeader: getHeader error %w", err)
 	}
 	if header == nil {
-		return &execution.GetHeaderResponse{Header: nil}, nil
+		return &executionproto.GetHeaderResponse{Header: nil}, nil
 	}
 
-	return &execution.GetHeaderResponse{Header: eth1_utils.HeaderToHeaderRPC(header)}, nil
+	return &executionproto.GetHeaderResponse{Header: eth1_utils.HeaderToHeaderRPC(header)}, nil
 }
 
-func (e *EthereumExecutionModule) GetBodiesByHashes(ctx context.Context, req *execution.GetBodiesByHashesRequest) (*execution.GetBodiesBatchResponse, error) {
+func (e *EthereumExecutionModule) GetBodiesByHashes(ctx context.Context, req *executionproto.GetBodiesByHashesRequest) (*executionproto.GetBodiesBatchResponse, error) {
 	tx, err := e.db.BeginRo(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("ethereumExecutionModule.GetBodiesByHashes: could not begin database tx %w", err)
 	}
 	defer tx.Rollback()
 
-	bodies := make([]*execution.BlockBody, 0, len(req.Hashes))
+	bodies := make([]*executionproto.BlockBody, 0, len(req.Hashes))
 
 	for _, hash := range req.Hashes {
 		h := gointerfaces.ConvertH256ToHash(hash)
@@ -153,23 +153,23 @@ func (e *EthereumExecutionModule) GetBodiesByHashes(ctx context.Context, req *ex
 			return nil, fmt.Errorf("ethereumExecutionModule.GetBodiesByHashes: MarshalTransactionsBinary error %w", err)
 		}
 
-		bodies = append(bodies, &execution.BlockBody{
+		bodies = append(bodies, &executionproto.BlockBody{
 			Transactions: txs,
 			Withdrawals:  eth1_utils.ConvertWithdrawalsToRpc(body.Withdrawals),
 		})
 	}
 
-	return &execution.GetBodiesBatchResponse{Bodies: bodies}, nil
+	return &executionproto.GetBodiesBatchResponse{Bodies: bodies}, nil
 }
 
-func (e *EthereumExecutionModule) GetBodiesByRange(ctx context.Context, req *execution.GetBodiesByRangeRequest) (*execution.GetBodiesBatchResponse, error) {
+func (e *EthereumExecutionModule) GetBodiesByRange(ctx context.Context, req *executionproto.GetBodiesByRangeRequest) (*executionproto.GetBodiesBatchResponse, error) {
 	tx, err := e.db.BeginRo(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("ethereumExecutionModule.GetBodiesByRange: could not begin database tx %w", err)
 	}
 	defer tx.Rollback()
 
-	bodies := make([]*execution.BlockBody, 0, req.Count)
+	bodies := make([]*executionproto.BlockBody, 0, req.Count)
 
 	for i := uint64(0); i < req.Count; i++ {
 		hash, err := e.canonicalHash(ctx, tx, req.Start+i)
@@ -196,7 +196,7 @@ func (e *EthereumExecutionModule) GetBodiesByRange(ctx context.Context, req *exe
 			return nil, fmt.Errorf("ethereumExecutionModule.GetBodiesByRange: MarshalTransactionsBinary error %w", err)
 		}
 
-		bodies = append(bodies, &execution.BlockBody{
+		bodies = append(bodies, &executionproto.BlockBody{
 			Transactions: txs,
 			Withdrawals:  eth1_utils.ConvertWithdrawalsToRpc(body.Withdrawals),
 		})
@@ -209,12 +209,12 @@ func (e *EthereumExecutionModule) GetBodiesByRange(ctx context.Context, req *exe
 		}
 	}
 
-	return &execution.GetBodiesBatchResponse{
+	return &executionproto.GetBodiesBatchResponse{
 		Bodies: bodies,
 	}, nil
 }
 
-func (e *EthereumExecutionModule) GetHeaderHashNumber(ctx context.Context, req *types2.H256) (*execution.GetHeaderHashNumberResponse, error) {
+func (e *EthereumExecutionModule) GetHeaderHashNumber(ctx context.Context, req *typesproto.H256) (*executionproto.GetHeaderHashNumberResponse, error) {
 	tx, err := e.db.BeginRo(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("ethereumExecutionModule.GetHeaderHashNumber: could not begin database tx %w", err)
@@ -225,7 +225,7 @@ func (e *EthereumExecutionModule) GetHeaderHashNumber(ctx context.Context, req *
 	if err != nil {
 		return nil, fmt.Errorf("ethereumExecutionModule.GetHeaderHashNumber: HeaderNumber error %w", err)
 	}
-	return &execution.GetHeaderHashNumberResponse{BlockNumber: blockNumber}, nil
+	return &executionproto.GetHeaderHashNumberResponse{BlockNumber: blockNumber}, nil
 }
 
 func (e *EthereumExecutionModule) isCanonicalHash(ctx context.Context, tx kv.Tx, hash common.Hash) (bool, error) {
@@ -251,7 +251,7 @@ func (e *EthereumExecutionModule) isCanonicalHash(ctx context.Context, tx kv.Tx,
 	return expectedHash == hash, nil
 }
 
-func (e *EthereumExecutionModule) IsCanonicalHash(ctx context.Context, req *types2.H256) (*execution.IsCanonicalResponse, error) {
+func (e *EthereumExecutionModule) IsCanonicalHash(ctx context.Context, req *typesproto.H256) (*executionproto.IsCanonicalResponse, error) {
 	tx, err := e.db.BeginRo(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("ethereumExecutionModule.CanonicalHash: could not begin database tx %w", err)
@@ -263,10 +263,10 @@ func (e *EthereumExecutionModule) IsCanonicalHash(ctx context.Context, req *type
 		return nil, fmt.Errorf("ethereumExecutionModule.CanonicalHash: could not read canonical hash %w", err)
 	}
 
-	return &execution.IsCanonicalResponse{Canonical: isCanonical}, nil
+	return &executionproto.IsCanonicalResponse{Canonical: isCanonical}, nil
 }
 
-func (e *EthereumExecutionModule) CurrentHeader(ctx context.Context, _ *emptypb.Empty) (*execution.GetHeaderResponse, error) {
+func (e *EthereumExecutionModule) CurrentHeader(ctx context.Context, _ *emptypb.Empty) (*executionproto.GetHeaderResponse, error) {
 	tx, err := e.db.BeginRo(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("ethereumExecutionModule.CurrentHeader: could not begin database tx %w", err)
@@ -287,12 +287,12 @@ func (e *EthereumExecutionModule) CurrentHeader(ctx context.Context, _ *emptypb.
 	if h == nil {
 		return nil, errors.New("ethereumExecutionModule.CurrentHeader: no current header yet - probabably node not synced yet")
 	}
-	return &execution.GetHeaderResponse{
+	return &executionproto.GetHeaderResponse{
 		Header: eth1_utils.HeaderToHeaderRPC(h),
 	}, nil
 }
 
-func (e *EthereumExecutionModule) GetTD(ctx context.Context, req *execution.GetSegmentRequest) (*execution.GetTDResponse, error) {
+func (e *EthereumExecutionModule) GetTD(ctx context.Context, req *executionproto.GetSegmentRequest) (*executionproto.GetTDResponse, error) {
 	// Invalid case: request is invalid.
 	if req == nil || (req.BlockHash == nil && req.BlockNumber == nil) {
 		return nil, errors.New("ethereumExecutionModule.GetTD: bad request")
@@ -305,7 +305,7 @@ func (e *EthereumExecutionModule) GetTD(ctx context.Context, req *execution.GetS
 
 	blockHash, blockNumber, err := e.parseSegmentRequest(ctx, tx, req)
 	if errors.Is(err, errNotFound) {
-		return &execution.GetTDResponse{Td: nil}, nil
+		return &executionproto.GetTDResponse{Td: nil}, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("ethereumExecutionModule.GetTD: parseSegmentRequest error %w", err)
@@ -315,26 +315,26 @@ func (e *EthereumExecutionModule) GetTD(ctx context.Context, req *execution.GetS
 		return nil, fmt.Errorf("ethereumExecutionModule.GetTD: getTD error %w", err)
 	}
 	if td == nil {
-		return &execution.GetTDResponse{Td: nil}, nil
+		return &executionproto.GetTDResponse{Td: nil}, nil
 	}
 
-	return &execution.GetTDResponse{Td: eth1_utils.ConvertBigIntToRpc(td)}, nil
+	return &executionproto.GetTDResponse{Td: eth1_utils.ConvertBigIntToRpc(td)}, nil
 }
 
-func (e *EthereumExecutionModule) GetForkChoice(ctx context.Context, _ *emptypb.Empty) (*execution.ForkChoice, error) {
+func (e *EthereumExecutionModule) GetForkChoice(ctx context.Context, _ *emptypb.Empty) (*executionproto.ForkChoice, error) {
 	tx, err := e.db.BeginRo(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("ethereumExecutionModule.GetForkChoice: could not begin database tx %w", err)
 	}
 	defer tx.Rollback()
-	return &execution.ForkChoice{
+	return &executionproto.ForkChoice{
 		HeadBlockHash:      gointerfaces.ConvertHashToH256(rawdb.ReadForkchoiceHead(tx)),
 		FinalizedBlockHash: gointerfaces.ConvertHashToH256(rawdb.ReadForkchoiceFinalized(tx)),
 		SafeBlockHash:      gointerfaces.ConvertHashToH256(rawdb.ReadForkchoiceSafe(tx)),
 	}, nil
 }
 
-func (e *EthereumExecutionModule) FrozenBlocks(ctx context.Context, _ *emptypb.Empty) (*execution.FrozenBlocksResponse, error) {
+func (e *EthereumExecutionModule) FrozenBlocks(ctx context.Context, _ *emptypb.Empty) (*executionproto.FrozenBlocksResponse, error) {
 	tx, err := e.db.BeginRo(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("ethereumExecutionModule.GetForkChoice: could not begin database tx %w", err)
@@ -349,7 +349,7 @@ func (e *EthereumExecutionModule) FrozenBlocks(ctx context.Context, _ *emptypb.E
 	if ok {
 		gap = e.blockReader.Snapshots().SegmentsMax()+1 < firstNonGenesisBlockNumber
 	}
-	return &execution.FrozenBlocksResponse{
+	return &executionproto.FrozenBlocksResponse{
 		FrozenBlocks: e.blockReader.FrozenBlocks(),
 		HasGap:       gap,
 	}, nil

--- a/execution/eth1/inserters.go
+++ b/execution/eth1/inserters.go
@@ -22,17 +22,17 @@ import (
 	"math/big"
 
 	"github.com/erigontech/erigon-lib/common/metrics"
-	execution "github.com/erigontech/erigon-lib/gointerfaces/executionproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/executionproto"
 	"github.com/erigontech/erigon/db/rawdb"
 	"github.com/erigontech/erigon/execution/eth1/eth1_utils"
 	"github.com/erigontech/erigon/execution/types"
 )
 
-func (e *EthereumExecutionModule) InsertBlocks(ctx context.Context, req *execution.InsertBlocksRequest) (*execution.InsertionResult, error) {
+func (e *EthereumExecutionModule) InsertBlocks(ctx context.Context, req *executionproto.InsertBlocksRequest) (*executionproto.InsertionResult, error) {
 	if !e.semaphore.TryAcquire(1) {
 		e.logger.Trace("ethereumExecutionModule.InsertBlocks: ExecutionStatus_Busy")
-		return &execution.InsertionResult{
-			Result: execution.ExecutionStatus_Busy,
+		return &executionproto.InsertionResult{
+			Result: executionproto.ExecutionStatus_Busy,
 		}, nil
 	}
 	defer e.semaphore.Release(1)
@@ -95,7 +95,7 @@ func (e *EthereumExecutionModule) InsertBlocks(ctx context.Context, req *executi
 		return nil, fmt.Errorf("ethereumExecutionModule.InsertBlocks: could not commit: %s", err)
 	}
 
-	return &execution.InsertionResult{
-		Result: execution.ExecutionStatus_Success,
+	return &executionproto.InsertionResult{
+		Result: executionproto.ExecutionStatus_Success,
 	}, nil
 }

--- a/execution/stagedsync/stage_snapshots.go
+++ b/execution/stagedsync/stage_snapshots.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/erigontech/erigon-lib/common/dbg"
 	"github.com/erigontech/erigon-lib/estimate"
-	protodownloader "github.com/erigontech/erigon-lib/gointerfaces/downloaderproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/downloaderproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/downloader"
@@ -60,7 +60,7 @@ type SnapshotsCfg struct {
 	dirs        datadir.Dirs
 
 	blockRetire        services.BlockRetire
-	snapshotDownloader protodownloader.DownloaderClient
+	snapshotDownloader downloaderproto.DownloaderClient
 	blockReader        services.FullBlockReader
 	notifier           *shards.Notifications
 
@@ -77,7 +77,7 @@ func StageSnapshotsCfg(db kv.TemporalRwDB,
 	syncConfig ethconfig.Sync,
 	dirs datadir.Dirs,
 	blockRetire services.BlockRetire,
-	snapshotDownloader protodownloader.DownloaderClient,
+	snapshotDownloader downloaderproto.DownloaderClient,
 	blockReader services.FullBlockReader,
 	notifier *shards.Notifications,
 	caplin bool,
@@ -414,7 +414,7 @@ func SnapshotsPrune(s *PruneState, cfg SnapshotsCfg, ctx context.Context, tx kv.
 				if noDl {
 					return nil
 				}
-				if _, err := cfg.snapshotDownloader.Delete(ctx, &protodownloader.DeleteRequest{Paths: l}); err != nil {
+				if _, err := cfg.snapshotDownloader.Delete(ctx, &downloaderproto.DeleteRequest{Paths: l}); err != nil {
 					return err
 				}
 				return nil
@@ -507,7 +507,7 @@ func pruneBlockSnapshots(ctx context.Context, cfg SnapshotsCfg, logger log.Logge
 			if filepath.IsAbs(file) {
 				relativePathToFile, _ = filepath.Rel(cfg.dirs.Snap, file)
 			}
-			if _, err := cfg.snapshotDownloader.Delete(ctx, &protodownloader.DeleteRequest{Paths: []string{relativePathToFile}}); err != nil {
+			if _, err := cfg.snapshotDownloader.Delete(ctx, &downloaderproto.DeleteRequest{Paths: []string{relativePathToFile}}); err != nil {
 				return filesDeleted, err
 			}
 		}

--- a/execution/stagedsync/stagebuilder.go
+++ b/execution/stagedsync/stagebuilder.go
@@ -19,7 +19,7 @@ package stagedsync
 import (
 	"context"
 
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/wrap"
@@ -30,7 +30,7 @@ import (
 type ChainEventNotifier interface {
 	OnNewHeader(newHeadersRlp [][]byte)
 	OnNewPendingLogs(types.Logs)
-	OnLogs([]*remote.SubscribeLogsReply)
+	OnLogs([]*remoteproto.SubscribeLogsReply)
 	HasLogSubscriptions() bool
 }
 

--- a/execution/stages/blockchain_test.go
+++ b/execution/stages/blockchain_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/erigontech/erigon-lib/common/length"
 	"github.com/erigontech/erigon-lib/common/u256"
 	"github.com/erigontech/erigon-lib/crypto"
-	protosentry "github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/core"
 	"github.com/erigontech/erigon/core/state"
@@ -388,7 +388,7 @@ func testReorg(t *testing.T, first, second []int64, td int64) {
 	}
 
 	m.ReceiveWg.Add(1)
-	for _, err = range m.Send(&protosentry.InboundMessage{Id: protosentry.MessageId_GET_RECEIPTS_66, Data: b, PeerId: m.PeerId}) {
+	for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_GET_RECEIPTS_66, Data: b, PeerId: m.PeerId}) {
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -398,7 +398,7 @@ func testReorg(t *testing.T, first, second []int64, td int64) {
 
 	msg := m.SentMessage(0)
 
-	require.Equal(protosentry.MessageId_RECEIPTS_66, msg.Id)
+	require.Equal(sentryproto.MessageId_RECEIPTS_66, msg.Id)
 
 	encoded, err := rlp.EncodeToBytes(types.Receipts{})
 	require.NoError(err)

--- a/execution/stages/chain_makers_test.go
+++ b/execution/stages/chain_makers_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/crypto"
-	protosentry "github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/core"
 	"github.com/erigontech/erigon/core/state"
@@ -154,7 +154,7 @@ func TestGenerateChain(t *testing.T) {
 	}
 
 	m.ReceiveWg.Add(1)
-	for _, err = range m.Send(&protosentry.InboundMessage{Id: protosentry.MessageId_GET_RECEIPTS_66, Data: b, PeerId: m.PeerId}) {
+	for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_GET_RECEIPTS_66, Data: b, PeerId: m.PeerId}) {
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -164,8 +164,8 @@ func TestGenerateChain(t *testing.T) {
 
 	msg := m.SentMessage(0)
 
-	if protosentry.MessageId_RECEIPTS_66 != msg.Id {
-		t.Errorf("receipt id %d do not match the expected id %d", msg.Id, protosentry.MessageId_RECEIPTS_66)
+	if sentryproto.MessageId_RECEIPTS_66 != msg.Id {
+		t.Errorf("receipt id %d do not match the expected id %d", msg.Id, sentryproto.MessageId_RECEIPTS_66)
 	}
 	r1 := types.Receipt{Type: 0, PostState: []byte{}, Status: 1, CumulativeGasUsed: 21000, Bloom: [256]byte{}, Logs: types.Logs{}, TxHash: common.HexToHash("0x9ca7a9e6bf23353fc5ac37f5c5676db1accec4af83477ac64cdcaa37f3a837f9"), ContractAddress: common.HexToAddress("0x0000000000000000000000000000000000000000"), GasUsed: 21000, BlockHash: common.HexToHash("0x5c7909bf8d4d8db71f0f6091aa412129591a8e41ff2230369ddf77a00bf57149"), BlockNumber: big.NewInt(1), TransactionIndex: 0}
 	r2 := types.Receipt{Type: 0, PostState: []byte{}, Status: 1, CumulativeGasUsed: 21000, Bloom: [256]byte{}, Logs: types.Logs{}, TxHash: common.HexToHash("0xf190eed1578cdcfe69badd05b7ef183397f336dc3de37baa4adbfb4bc657c11e"), ContractAddress: common.HexToAddress("0x0000000000000000000000000000000000000000"), GasUsed: 21000, BlockHash: common.HexToHash("0xe4d4617526870ba7c5b81900e31bd2525c02f27fe06fd6c3caf7bed05f3271f4"), BlockNumber: big.NewInt(2), TransactionIndex: 0}

--- a/execution/stages/mock/mock_sentry.go
+++ b/execution/stages/mock/mock_sentry.go
@@ -36,11 +36,11 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/crypto"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	proto_downloader "github.com/erigontech/erigon-lib/gointerfaces/downloaderproto"
-	execution "github.com/erigontech/erigon-lib/gointerfaces/executionproto"
-	proto_sentry "github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/downloaderproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/executionproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
-	ptypes "github.com/erigontech/erigon-lib/gointerfaces/typesproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/core"
 	"github.com/erigontech/erigon/core/genesiswrite"
@@ -95,7 +95,7 @@ const MockInsertAsInitialCycle = false
 
 // MockSentry is a Netwrork Inverface mock. So, unit-tests can test many Erigon's components - but without net-interaction
 type MockSentry struct {
-	proto_sentry.UnimplementedSentryServer
+	sentryproto.UnimplementedSentryServer
 	Ctx                  context.Context
 	Log                  log.Logger
 	tb                   testing.TB
@@ -112,9 +112,9 @@ type MockSentry struct {
 	Key                  *ecdsa.PrivateKey
 	Genesis              *types.Block
 	SentryClient         direct.SentryClient
-	PeerId               *ptypes.H512
-	streams              map[proto_sentry.MessageId][]proto_sentry.Sentry_MessagesServer
-	sentMessages         []*proto_sentry.OutboundMessageData
+	PeerId               *typesproto.H512
+	streams              map[sentryproto.MessageId][]sentryproto.Sentry_MessagesServer
+	sentMessages         []*sentryproto.OutboundMessageData
 	StreamWg             sync.WaitGroup
 	ReceiveWg            sync.WaitGroup
 	Address              common.Address
@@ -155,7 +155,7 @@ func (ms *MockSentry) Close() {
 }
 
 // Stream returns stream, waiting if necessary
-func (ms *MockSentry) Send(req *proto_sentry.InboundMessage) (errs []error) {
+func (ms *MockSentry) Send(req *sentryproto.InboundMessage) (errs []error) {
 	ms.StreamWg.Wait()
 	for _, stream := range ms.streams[req.Id] {
 		if err := stream.Send(req); err != nil {
@@ -165,43 +165,43 @@ func (ms *MockSentry) Send(req *proto_sentry.InboundMessage) (errs []error) {
 	return errs
 }
 
-func (ms *MockSentry) SetStatus(context.Context, *proto_sentry.StatusData) (*proto_sentry.SetStatusReply, error) {
-	return &proto_sentry.SetStatusReply{}, nil
+func (ms *MockSentry) SetStatus(context.Context, *sentryproto.StatusData) (*sentryproto.SetStatusReply, error) {
+	return &sentryproto.SetStatusReply{}, nil
 }
 
-func (ms *MockSentry) PenalizePeer(context.Context, *proto_sentry.PenalizePeerRequest) (*emptypb.Empty, error) {
+func (ms *MockSentry) PenalizePeer(context.Context, *sentryproto.PenalizePeerRequest) (*emptypb.Empty, error) {
 	return nil, nil
 }
-func (ms *MockSentry) PeerMinBlock(context.Context, *proto_sentry.PeerMinBlockRequest) (*emptypb.Empty, error) {
+func (ms *MockSentry) PeerMinBlock(context.Context, *sentryproto.PeerMinBlockRequest) (*emptypb.Empty, error) {
 	return nil, nil
 }
 
-func (ms *MockSentry) HandShake(ctx context.Context, in *emptypb.Empty) (*proto_sentry.HandShakeReply, error) {
-	return &proto_sentry.HandShakeReply{Protocol: proto_sentry.Protocol_ETH68}, nil
+func (ms *MockSentry) HandShake(ctx context.Context, in *emptypb.Empty) (*sentryproto.HandShakeReply, error) {
+	return &sentryproto.HandShakeReply{Protocol: sentryproto.Protocol_ETH68}, nil
 }
-func (ms *MockSentry) SendMessageByMinBlock(_ context.Context, r *proto_sentry.SendMessageByMinBlockRequest) (*proto_sentry.SentPeers, error) {
+func (ms *MockSentry) SendMessageByMinBlock(_ context.Context, r *sentryproto.SendMessageByMinBlockRequest) (*sentryproto.SentPeers, error) {
 	ms.sentMessages = append(ms.sentMessages, r.Data)
 	return nil, nil
 }
-func (ms *MockSentry) SendMessageById(_ context.Context, r *proto_sentry.SendMessageByIdRequest) (*proto_sentry.SentPeers, error) {
+func (ms *MockSentry) SendMessageById(_ context.Context, r *sentryproto.SendMessageByIdRequest) (*sentryproto.SentPeers, error) {
 	ms.sentMessages = append(ms.sentMessages, r.Data)
 	return nil, nil
 }
-func (ms *MockSentry) SendMessageToRandomPeers(_ context.Context, r *proto_sentry.SendMessageToRandomPeersRequest) (*proto_sentry.SentPeers, error) {
+func (ms *MockSentry) SendMessageToRandomPeers(_ context.Context, r *sentryproto.SendMessageToRandomPeersRequest) (*sentryproto.SentPeers, error) {
 	ms.sentMessages = append(ms.sentMessages, r.Data)
 	return nil, nil
 }
-func (ms *MockSentry) SendMessageToAll(_ context.Context, r *proto_sentry.OutboundMessageData) (*proto_sentry.SentPeers, error) {
+func (ms *MockSentry) SendMessageToAll(_ context.Context, r *sentryproto.OutboundMessageData) (*sentryproto.SentPeers, error) {
 	ms.sentMessages = append(ms.sentMessages, r)
 	return nil, nil
 }
-func (ms *MockSentry) SentMessage(i int) *proto_sentry.OutboundMessageData {
+func (ms *MockSentry) SentMessage(i int) *sentryproto.OutboundMessageData {
 	return ms.sentMessages[i]
 }
 
-func (ms *MockSentry) Messages(req *proto_sentry.MessagesRequest, stream proto_sentry.Sentry_MessagesServer) error {
+func (ms *MockSentry) Messages(req *sentryproto.MessagesRequest, stream sentryproto.Sentry_MessagesServer) error {
 	if ms.streams == nil {
-		ms.streams = map[proto_sentry.MessageId][]proto_sentry.Sentry_MessagesServer{}
+		ms.streams = map[sentryproto.MessageId][]sentryproto.Sentry_MessagesServer{}
 	}
 
 	for _, id := range req.Ids {
@@ -216,20 +216,20 @@ func (ms *MockSentry) Messages(req *proto_sentry.MessagesRequest, stream proto_s
 	}
 }
 
-func (ms *MockSentry) Peers(context.Context, *emptypb.Empty) (*proto_sentry.PeersReply, error) {
-	return &proto_sentry.PeersReply{}, nil
+func (ms *MockSentry) Peers(context.Context, *emptypb.Empty) (*sentryproto.PeersReply, error) {
+	return &sentryproto.PeersReply{}, nil
 }
-func (ms *MockSentry) PeerCount(context.Context, *proto_sentry.PeerCountRequest) (*proto_sentry.PeerCountReply, error) {
-	return &proto_sentry.PeerCountReply{Count: 0}, nil
+func (ms *MockSentry) PeerCount(context.Context, *sentryproto.PeerCountRequest) (*sentryproto.PeerCountReply, error) {
+	return &sentryproto.PeerCountReply{Count: 0}, nil
 }
-func (ms *MockSentry) PeerById(context.Context, *proto_sentry.PeerByIdRequest) (*proto_sentry.PeerByIdReply, error) {
-	return &proto_sentry.PeerByIdReply{}, nil
+func (ms *MockSentry) PeerById(context.Context, *sentryproto.PeerByIdRequest) (*sentryproto.PeerByIdReply, error) {
+	return &sentryproto.PeerByIdReply{}, nil
 }
-func (ms *MockSentry) PeerEvents(req *proto_sentry.PeerEventsRequest, server proto_sentry.Sentry_PeerEventsServer) error {
+func (ms *MockSentry) PeerEvents(req *sentryproto.PeerEventsRequest, server sentryproto.Sentry_PeerEventsServer) error {
 	return nil
 }
 
-func (ms *MockSentry) NodeInfo(context.Context, *emptypb.Empty) (*ptypes.NodeInfoReply, error) {
+func (ms *MockSentry) NodeInfo(context.Context, *emptypb.Empty) (*typesproto.NodeInfoReply, error) {
 	return nil, nil
 }
 
@@ -348,7 +348,7 @@ func MockWithEverything(tb testing.TB, gspec *types.Genesis, key *ecdsa.PrivateK
 	penalize := func(context.Context, []headerdownload.PenaltyItem) {}
 
 	mock.SentryClient = direct.NewSentryClientDirect(direct.ETH68, mock)
-	sentries := []proto_sentry.SentryClient{mock.SentryClient}
+	sentries := []sentryproto.SentryClient{mock.SentryClient}
 
 	sendBodyRequest := func(context.Context, *bodydownload.BodyRequest) ([64]byte, bool) { return [64]byte{}, false }
 	blockPropagator := func(Ctx context.Context, header *types.Header, body *types.RawBody, td *big.Int) {}
@@ -596,8 +596,8 @@ func MockWithEverything(tb testing.TB, gspec *types.Genesis, key *ecdsa.PrivateK
 	return mock
 }
 
-func mockDownloader(ctrl *gomock.Controller) *proto_downloader.MockDownloaderClient {
-	snapDownloader := proto_downloader.NewMockDownloaderClient(ctrl)
+func mockDownloader(ctrl *gomock.Controller) *downloaderproto.MockDownloaderClient {
+	snapDownloader := downloaderproto.NewMockDownloaderClient(ctrl)
 
 	snapDownloader.EXPECT().
 		Add(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -609,7 +609,7 @@ func mockDownloader(ctrl *gomock.Controller) *proto_downloader.MockDownloaderCli
 		AnyTimes()
 	snapDownloader.EXPECT().
 		Completed(gomock.Any(), gomock.Any()).
-		Return(&proto_downloader.CompletedReply{Completed: true}, nil).
+		Return(&downloaderproto.CompletedReply{Completed: true}, nil).
 		AnyTimes()
 
 	return snapDownloader
@@ -741,7 +741,7 @@ func (ms *MockSentry) insertPoWBlocks(chain *core.ChainPack) error {
 		return err
 	}
 	ms.ReceiveWg.Add(1)
-	for _, err = range ms.Send(&proto_sentry.InboundMessage{Id: proto_sentry.MessageId_NEW_BLOCK_66, Data: b, PeerId: ms.PeerId}) {
+	for _, err = range ms.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_NEW_BLOCK_66, Data: b, PeerId: ms.PeerId}) {
 		if err != nil {
 			return err
 		}
@@ -756,7 +756,7 @@ func (ms *MockSentry) insertPoWBlocks(chain *core.ChainPack) error {
 		return err
 	}
 	ms.ReceiveWg.Add(1)
-	for _, err = range ms.Send(&proto_sentry.InboundMessage{Id: proto_sentry.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: ms.PeerId}) {
+	for _, err = range ms.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: ms.PeerId}) {
 		if err != nil {
 			return err
 		}
@@ -775,7 +775,7 @@ func (ms *MockSentry) insertPoWBlocks(chain *core.ChainPack) error {
 		return err
 	}
 	ms.ReceiveWg.Add(1)
-	for _, err = range ms.Send(&proto_sentry.InboundMessage{Id: proto_sentry.MessageId_BLOCK_BODIES_66, Data: b, PeerId: ms.PeerId}) {
+	for _, err = range ms.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_BLOCK_BODIES_66, Data: b, PeerId: ms.PeerId}) {
 		if err != nil {
 			return err
 		}
@@ -837,7 +837,7 @@ func (ms *MockSentry) insertPoSBlocks(chain *core.ChainPack) error {
 	}); err != nil {
 		return err
 	}
-	if status != execution.ExecutionStatus_Success {
+	if status != executionproto.ExecutionStatus_Success {
 		return fmt.Errorf("insertion failed for block %d, code: %s", chain.Blocks[chain.Length()-1].NumberU64(), status.String())
 	}
 

--- a/execution/stages/mock/sentry_mock_test.go
+++ b/execution/stages/mock/sentry_mock_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/u256"
-	sentry "github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/core"
 	"github.com/erigontech/erigon/db/wrap"
@@ -59,7 +59,7 @@ func TestHeaderStep(t *testing.T) {
 	})
 	require.NoError(t, err)
 	m.ReceiveWg.Add(1)
-	for _, err = range m.Send(&sentry.InboundMessage{Id: sentry.MessageId_NEW_BLOCK_66, Data: b, PeerId: m.PeerId}) {
+	for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_NEW_BLOCK_66, Data: b, PeerId: m.PeerId}) {
 		require.NoError(t, err)
 	}
 	// Send all the headers
@@ -69,7 +69,7 @@ func TestHeaderStep(t *testing.T) {
 	})
 	require.NoError(t, err)
 	m.ReceiveWg.Add(1)
-	for _, err = range m.Send(&sentry.InboundMessage{Id: sentry.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
+	for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
 		require.NoError(t, err)
 	}
 	m.ReceiveWg.Wait() // Wait for all messages to be processed before we proceed
@@ -98,7 +98,7 @@ func TestMineBlockWith1Tx(t *testing.T) {
 		})
 		require.NoError(err)
 		m.ReceiveWg.Add(1)
-		for _, err = range m.Send(&sentry.InboundMessage{Id: sentry.MessageId_NEW_BLOCK_66, Data: b, PeerId: m.PeerId}) {
+		for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_NEW_BLOCK_66, Data: b, PeerId: m.PeerId}) {
 			require.NoError(err)
 		}
 		// Send all the headers
@@ -108,7 +108,7 @@ func TestMineBlockWith1Tx(t *testing.T) {
 		})
 		require.NoError(err)
 		m.ReceiveWg.Add(1)
-		for _, err = range m.Send(&sentry.InboundMessage{Id: sentry.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
+		for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
 			require.NoError(err)
 		}
 		m.ReceiveWg.Wait() // Wait for all messages to be processed before we proceeed
@@ -131,7 +131,7 @@ func TestMineBlockWith1Tx(t *testing.T) {
 	b, err := rlp.EncodeToBytes(chain.TopBlock.Transactions())
 	require.NoError(err)
 	m.ReceiveWg.Add(1)
-	for _, err = range m.Send(&sentry.InboundMessage{Id: sentry.MessageId_TRANSACTIONS_66, Data: b, PeerId: m.PeerId}) {
+	for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_TRANSACTIONS_66, Data: b, PeerId: m.PeerId}) {
 		require.NoError(err)
 	}
 	m.ReceiveWg.Wait() // Wait for all messages to be processed before we proceed
@@ -164,7 +164,7 @@ func TestReorg(t *testing.T) {
 		t.Fatal(err)
 	}
 	m.ReceiveWg.Add(1)
-	for _, err = range m.Send(&sentry.InboundMessage{Id: sentry.MessageId_NEW_BLOCK_66, Data: b, PeerId: m.PeerId}) {
+	for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_NEW_BLOCK_66, Data: b, PeerId: m.PeerId}) {
 		require.NoError(t, err)
 	}
 
@@ -177,7 +177,7 @@ func TestReorg(t *testing.T) {
 		t.Fatal(err)
 	}
 	m.ReceiveWg.Add(1)
-	for _, err = range m.Send(&sentry.InboundMessage{Id: sentry.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
+	for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
 		require.NoError(t, err)
 	}
 	m.ReceiveWg.Wait() // Wait for all messages to be processed before we proceeed
@@ -217,7 +217,7 @@ func TestReorg(t *testing.T) {
 		t.Fatal(err)
 	}
 	m.ReceiveWg.Add(1)
-	for _, err = range m.Send(&sentry.InboundMessage{Id: sentry.MessageId_NEW_BLOCK_66, Data: b, PeerId: m.PeerId}) {
+	for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_NEW_BLOCK_66, Data: b, PeerId: m.PeerId}) {
 		require.NoError(t, err)
 	}
 
@@ -230,7 +230,7 @@ func TestReorg(t *testing.T) {
 		t.Fatal(err)
 	}
 	m.ReceiveWg.Add(1)
-	for _, err = range m.Send(&sentry.InboundMessage{Id: sentry.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
+	for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
 		require.NoError(t, err)
 	}
 	m.ReceiveWg.Wait() // Wait for all messages to be processed before we proceeed
@@ -248,7 +248,7 @@ func TestReorg(t *testing.T) {
 		t.Fatal(err)
 	}
 	m.ReceiveWg.Add(1)
-	for _, err = range m.Send(&sentry.InboundMessage{Id: sentry.MessageId_NEW_BLOCK_66, Data: b, PeerId: m.PeerId}) {
+	for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_NEW_BLOCK_66, Data: b, PeerId: m.PeerId}) {
 		require.NoError(t, err)
 	}
 
@@ -261,7 +261,7 @@ func TestReorg(t *testing.T) {
 		t.Fatal(err)
 	}
 	m.ReceiveWg.Add(1)
-	for _, err = range m.Send(&sentry.InboundMessage{Id: sentry.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
+	for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
 		require.NoError(t, err)
 	}
 
@@ -272,7 +272,7 @@ func TestReorg(t *testing.T) {
 	})
 	require.NoError(t, err)
 	m.ReceiveWg.Add(1)
-	for _, err = range m.Send(&sentry.InboundMessage{Id: sentry.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
+	for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
 		require.NoError(t, err)
 	}
 	m.ReceiveWg.Wait() // Wait for all messages to be processed before we proceeed
@@ -298,7 +298,7 @@ func TestReorg(t *testing.T) {
 	})
 	require.NoError(t, err)
 	m.ReceiveWg.Add(1)
-	for _, err = range m.Send(&sentry.InboundMessage{Id: sentry.MessageId_NEW_BLOCK_66, Data: b, PeerId: m.PeerId}) {
+	for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_NEW_BLOCK_66, Data: b, PeerId: m.PeerId}) {
 		require.NoError(t, err)
 	}
 
@@ -309,7 +309,7 @@ func TestReorg(t *testing.T) {
 	})
 	require.NoError(t, err)
 	m.ReceiveWg.Add(1)
-	for _, err = range m.Send(&sentry.InboundMessage{Id: sentry.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
+	for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
 		require.NoError(t, err)
 	}
 	m.ReceiveWg.Wait() // Wait for all messages to be processed before we proceeed
@@ -356,7 +356,7 @@ func TestAnchorReplace(t *testing.T) {
 	})
 	require.NoError(t, err)
 	m.ReceiveWg.Add(1)
-	for _, err = range m.Send(&sentry.InboundMessage{Id: sentry.MessageId_NEW_BLOCK_66, Data: b, PeerId: m.PeerId}) {
+	for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_NEW_BLOCK_66, Data: b, PeerId: m.PeerId}) {
 		require.NoError(t, err)
 	}
 
@@ -367,7 +367,7 @@ func TestAnchorReplace(t *testing.T) {
 	})
 	require.NoError(t, err)
 	m.ReceiveWg.Add(1)
-	for _, err = range m.Send(&sentry.InboundMessage{Id: sentry.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
+	for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
 		require.NoError(t, err)
 	}
 	require.NoError(t, err)
@@ -379,7 +379,7 @@ func TestAnchorReplace(t *testing.T) {
 	})
 	require.NoError(t, err)
 	m.ReceiveWg.Add(1)
-	for _, err = range m.Send(&sentry.InboundMessage{Id: sentry.MessageId_NEW_BLOCK_66, Data: b, PeerId: m.PeerId}) {
+	for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_NEW_BLOCK_66, Data: b, PeerId: m.PeerId}) {
 		require.NoError(t, err)
 	}
 	require.NoError(t, err)
@@ -391,7 +391,7 @@ func TestAnchorReplace(t *testing.T) {
 	})
 	require.NoError(t, err)
 	m.ReceiveWg.Add(1)
-	for _, err = range m.Send(&sentry.InboundMessage{Id: sentry.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
+	for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
 		require.NoError(t, err)
 	}
 
@@ -404,7 +404,7 @@ func TestAnchorReplace(t *testing.T) {
 	})
 	require.NoError(t, err)
 	m.ReceiveWg.Add(1)
-	for _, err = range m.Send(&sentry.InboundMessage{Id: sentry.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
+	for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
 		require.NoError(t, err)
 	}
 
@@ -452,7 +452,7 @@ func TestAnchorReplace2(t *testing.T) {
 	})
 	require.NoError(t, err)
 	m.ReceiveWg.Add(1)
-	for _, err = range m.Send(&sentry.InboundMessage{Id: sentry.MessageId_NEW_BLOCK_66, Data: b, PeerId: m.PeerId}) {
+	for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_NEW_BLOCK_66, Data: b, PeerId: m.PeerId}) {
 		require.NoError(t, err)
 	}
 
@@ -463,7 +463,7 @@ func TestAnchorReplace2(t *testing.T) {
 	})
 	require.NoError(t, err)
 	m.ReceiveWg.Add(1)
-	for _, err = range m.Send(&sentry.InboundMessage{Id: sentry.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
+	for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
 		require.NoError(t, err)
 	}
 
@@ -474,7 +474,7 @@ func TestAnchorReplace2(t *testing.T) {
 	})
 	require.NoError(t, err)
 	m.ReceiveWg.Add(1)
-	for _, err = range m.Send(&sentry.InboundMessage{Id: sentry.MessageId_NEW_BLOCK_66, Data: b, PeerId: m.PeerId}) {
+	for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_NEW_BLOCK_66, Data: b, PeerId: m.PeerId}) {
 		require.NoError(t, err)
 	}
 
@@ -485,7 +485,7 @@ func TestAnchorReplace2(t *testing.T) {
 	})
 	require.NoError(t, err)
 	m.ReceiveWg.Add(1)
-	for _, err = range m.Send(&sentry.InboundMessage{Id: sentry.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
+	for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
 		require.NoError(t, err)
 	}
 
@@ -496,7 +496,7 @@ func TestAnchorReplace2(t *testing.T) {
 	})
 	require.NoError(t, err)
 	m.ReceiveWg.Add(1)
-	for _, err = range m.Send(&sentry.InboundMessage{Id: sentry.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
+	for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
 		require.NoError(t, err)
 	}
 
@@ -509,7 +509,7 @@ func TestAnchorReplace2(t *testing.T) {
 	})
 	require.NoError(t, err)
 	m.ReceiveWg.Add(1)
-	for _, err = range m.Send(&sentry.InboundMessage{Id: sentry.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
+	for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
 		require.NoError(t, err)
 	}
 

--- a/execution/stages/stageloop.go
+++ b/execution/stages/stageloop.go
@@ -28,7 +28,7 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/dbg"
 	"github.com/erigontech/erigon-lib/common/metrics"
-	proto_downloader "github.com/erigontech/erigon-lib/gointerfaces/downloaderproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/downloaderproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/core/tracing"
 	"github.com/erigontech/erigon/core/vm"
@@ -675,7 +675,7 @@ func NewDefaultStages(ctx context.Context,
 	cfg *ethconfig.Config,
 	controlServer *sentry_multi_client.MultiClient,
 	notifications *shards.Notifications,
-	snapDownloader proto_downloader.DownloaderClient,
+	snapDownloader downloaderproto.DownloaderClient,
 	blockReader services.FullBlockReader,
 	blockRetire services.BlockRetire,
 	silkworm *silkworm.Silkworm,
@@ -711,7 +711,7 @@ func NewPipelineStages(ctx context.Context,
 	cfg *ethconfig.Config,
 	controlServer *sentry_multi_client.MultiClient,
 	notifications *shards.Notifications,
-	snapDownloader proto_downloader.DownloaderClient,
+	snapDownloader downloaderproto.DownloaderClient,
 	blockReader services.FullBlockReader,
 	blockRetire services.BlockRetire,
 	silkworm *silkworm.Silkworm,

--- a/node/direct/downloader_client.go
+++ b/node/direct/downloader_client.go
@@ -22,27 +22,27 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 
-	proto_downloader "github.com/erigontech/erigon-lib/gointerfaces/downloaderproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/downloaderproto"
 )
 
 type DownloaderClient struct {
-	server proto_downloader.DownloaderServer
+	server downloaderproto.DownloaderServer
 }
 
-func NewDownloaderClient(server proto_downloader.DownloaderServer) *DownloaderClient {
+func NewDownloaderClient(server downloaderproto.DownloaderServer) *DownloaderClient {
 	return &DownloaderClient{server: server}
 }
 
-func (c *DownloaderClient) Add(ctx context.Context, in *proto_downloader.AddRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+func (c *DownloaderClient) Add(ctx context.Context, in *downloaderproto.AddRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
 	return c.server.Add(ctx, in)
 }
 
-func (c *DownloaderClient) Delete(ctx context.Context, in *proto_downloader.DeleteRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+func (c *DownloaderClient) Delete(ctx context.Context, in *downloaderproto.DeleteRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
 	return c.server.Delete(ctx, in)
 }
-func (c *DownloaderClient) SetLogPrefix(ctx context.Context, in *proto_downloader.SetLogPrefixRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+func (c *DownloaderClient) SetLogPrefix(ctx context.Context, in *downloaderproto.SetLogPrefixRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
 	return c.server.SetLogPrefix(ctx, in)
 }
-func (c *DownloaderClient) Completed(ctx context.Context, in *proto_downloader.CompletedRequest, opts ...grpc.CallOption) (*proto_downloader.CompletedReply, error) {
+func (c *DownloaderClient) Completed(ctx context.Context, in *downloaderproto.CompletedRequest, opts ...grpc.CallOption) (*downloaderproto.CompletedReply, error) {
 	return c.server.Completed(ctx, in)
 }

--- a/node/direct/eth_backend_client.go
+++ b/node/direct/eth_backend_client.go
@@ -23,49 +23,49 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
-	types "github.com/erigontech/erigon-lib/gointerfaces/typesproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 )
 
 type EthBackendClientDirect struct {
-	server remote.ETHBACKENDServer
+	server remoteproto.ETHBACKENDServer
 }
 
-func NewEthBackendClientDirect(server remote.ETHBACKENDServer) *EthBackendClientDirect {
+func NewEthBackendClientDirect(server remoteproto.ETHBACKENDServer) *EthBackendClientDirect {
 	return &EthBackendClientDirect{server: server}
 }
 
-func (s *EthBackendClientDirect) Etherbase(ctx context.Context, in *remote.EtherbaseRequest, opts ...grpc.CallOption) (*remote.EtherbaseReply, error) {
+func (s *EthBackendClientDirect) Etherbase(ctx context.Context, in *remoteproto.EtherbaseRequest, opts ...grpc.CallOption) (*remoteproto.EtherbaseReply, error) {
 	return s.server.Etherbase(ctx, in)
 }
 
-func (s *EthBackendClientDirect) NetVersion(ctx context.Context, in *remote.NetVersionRequest, opts ...grpc.CallOption) (*remote.NetVersionReply, error) {
+func (s *EthBackendClientDirect) NetVersion(ctx context.Context, in *remoteproto.NetVersionRequest, opts ...grpc.CallOption) (*remoteproto.NetVersionReply, error) {
 	return s.server.NetVersion(ctx, in)
 }
 
-func (s *EthBackendClientDirect) NetPeerCount(ctx context.Context, in *remote.NetPeerCountRequest, opts ...grpc.CallOption) (*remote.NetPeerCountReply, error) {
+func (s *EthBackendClientDirect) NetPeerCount(ctx context.Context, in *remoteproto.NetPeerCountRequest, opts ...grpc.CallOption) (*remoteproto.NetPeerCountReply, error) {
 	return s.server.NetPeerCount(ctx, in)
 }
 
-func (s *EthBackendClientDirect) Version(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*types.VersionReply, error) {
+func (s *EthBackendClientDirect) Version(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*typesproto.VersionReply, error) {
 	return s.server.Version(ctx, in)
 }
 
-func (s *EthBackendClientDirect) Syncing(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*remote.SyncingReply, error) {
+func (s *EthBackendClientDirect) Syncing(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*remoteproto.SyncingReply, error) {
 	return s.server.Syncing(ctx, in)
 }
 
-func (s *EthBackendClientDirect) ProtocolVersion(ctx context.Context, in *remote.ProtocolVersionRequest, opts ...grpc.CallOption) (*remote.ProtocolVersionReply, error) {
+func (s *EthBackendClientDirect) ProtocolVersion(ctx context.Context, in *remoteproto.ProtocolVersionRequest, opts ...grpc.CallOption) (*remoteproto.ProtocolVersionReply, error) {
 	return s.server.ProtocolVersion(ctx, in)
 }
 
-func (s *EthBackendClientDirect) ClientVersion(ctx context.Context, in *remote.ClientVersionRequest, opts ...grpc.CallOption) (*remote.ClientVersionReply, error) {
+func (s *EthBackendClientDirect) ClientVersion(ctx context.Context, in *remoteproto.ClientVersionRequest, opts ...grpc.CallOption) (*remoteproto.ClientVersionReply, error) {
 	return s.server.ClientVersion(ctx, in)
 }
 
 // -- start Subscribe
 
-func (s *EthBackendClientDirect) Subscribe(ctx context.Context, in *remote.SubscribeRequest, opts ...grpc.CallOption) (remote.ETHBACKEND_SubscribeClient, error) {
+func (s *EthBackendClientDirect) Subscribe(ctx context.Context, in *remoteproto.SubscribeRequest, opts ...grpc.CallOption) (remoteproto.ETHBACKEND_SubscribeClient, error) {
 	ch := make(chan *subscribeReply, 16384)
 	streamServer := &SubscribeStreamS{ch: ch, ctx: ctx}
 	go func() {
@@ -76,7 +76,7 @@ func (s *EthBackendClientDirect) Subscribe(ctx context.Context, in *remote.Subsc
 }
 
 type subscribeReply struct {
-	r   *remote.SubscribeReply
+	r   *remoteproto.SubscribeReply
 	err error
 }
 type SubscribeStreamS struct {
@@ -85,7 +85,7 @@ type SubscribeStreamS struct {
 	grpc.ServerStream
 }
 
-func (s *SubscribeStreamS) Send(m *remote.SubscribeReply) error {
+func (s *SubscribeStreamS) Send(m *remoteproto.SubscribeReply) error {
 	s.ch <- &subscribeReply{r: m}
 	return nil
 }
@@ -103,7 +103,7 @@ type SubscribeStreamC struct {
 	grpc.ClientStream
 }
 
-func (c *SubscribeStreamC) Recv() (*remote.SubscribeReply, error) {
+func (c *SubscribeStreamC) Recv() (*remoteproto.SubscribeReply, error) {
 	select {
 	case m, ok := <-c.ch:
 		if !ok || m == nil {
@@ -121,7 +121,7 @@ func (c *SubscribeStreamC) Context() context.Context { return c.ctx }
 
 // -- SubscribeLogs
 
-func (s *EthBackendClientDirect) SubscribeLogs(ctx context.Context, opts ...grpc.CallOption) (remote.ETHBACKEND_SubscribeLogsClient, error) {
+func (s *EthBackendClientDirect) SubscribeLogs(ctx context.Context, opts ...grpc.CallOption) (remoteproto.ETHBACKEND_SubscribeLogsClient, error) {
 	subscribeLogsRequestChan := make(chan *subscribeLogsRequest, 16384)
 	subscribeLogsReplyChan := make(chan *subscribeLogsReply, 16384)
 	srv := &SubscribeLogsStreamS{
@@ -150,21 +150,21 @@ type SubscribeLogsStreamS struct {
 }
 
 type subscribeLogsReply struct {
-	r   *remote.SubscribeLogsReply
+	r   *remoteproto.SubscribeLogsReply
 	err error
 }
 
 type subscribeLogsRequest struct {
-	r   *remote.LogsFilterRequest
+	r   *remoteproto.LogsFilterRequest
 	err error
 }
 
-func (s *SubscribeLogsStreamS) Send(m *remote.SubscribeLogsReply) error {
+func (s *SubscribeLogsStreamS) Send(m *remoteproto.SubscribeLogsReply) error {
 	s.chSend <- &subscribeLogsReply{r: m}
 	return nil
 }
 
-func (s *SubscribeLogsStreamS) Recv() (*remote.LogsFilterRequest, error) {
+func (s *SubscribeLogsStreamS) Recv() (*remoteproto.LogsFilterRequest, error) {
 	select {
 	case m, ok := <-s.chRecv:
 		if !ok || m == nil {
@@ -190,12 +190,12 @@ type SubscribeLogsStreamC struct {
 	grpc.ClientStream
 }
 
-func (c *SubscribeLogsStreamC) Send(m *remote.LogsFilterRequest) error {
+func (c *SubscribeLogsStreamC) Send(m *remoteproto.LogsFilterRequest) error {
 	c.chSend <- &subscribeLogsRequest{r: m}
 	return nil
 }
 
-func (c *SubscribeLogsStreamC) Recv() (*remote.SubscribeLogsReply, error) {
+func (c *SubscribeLogsStreamC) Recv() (*remoteproto.SubscribeLogsReply, error) {
 	select {
 	case m, ok := <-c.chRecv:
 		if !ok || m == nil {
@@ -209,58 +209,58 @@ func (c *SubscribeLogsStreamC) Recv() (*remote.SubscribeLogsReply, error) {
 
 // -- end SubscribeLogs
 
-func (s *EthBackendClientDirect) CanonicalBodyForStorage(ctx context.Context, in *remote.CanonicalBodyForStorageRequest, opts ...grpc.CallOption) (*remote.CanonicalBodyForStorageReply, error) {
+func (s *EthBackendClientDirect) CanonicalBodyForStorage(ctx context.Context, in *remoteproto.CanonicalBodyForStorageRequest, opts ...grpc.CallOption) (*remoteproto.CanonicalBodyForStorageReply, error) {
 	return s.server.CanonicalBodyForStorage(ctx, in)
 }
 
-func (s *EthBackendClientDirect) CanonicalHash(ctx context.Context, in *remote.CanonicalHashRequest, opts ...grpc.CallOption) (*remote.CanonicalHashReply, error) {
+func (s *EthBackendClientDirect) CanonicalHash(ctx context.Context, in *remoteproto.CanonicalHashRequest, opts ...grpc.CallOption) (*remoteproto.CanonicalHashReply, error) {
 	return s.server.CanonicalHash(ctx, in)
 }
 
-func (s *EthBackendClientDirect) HeaderNumber(ctx context.Context, in *remote.HeaderNumberRequest, opts ...grpc.CallOption) (*remote.HeaderNumberReply, error) {
+func (s *EthBackendClientDirect) HeaderNumber(ctx context.Context, in *remoteproto.HeaderNumberRequest, opts ...grpc.CallOption) (*remoteproto.HeaderNumberReply, error) {
 	return s.server.HeaderNumber(ctx, in)
 }
 
-func (s *EthBackendClientDirect) Block(ctx context.Context, in *remote.BlockRequest, opts ...grpc.CallOption) (*remote.BlockReply, error) {
+func (s *EthBackendClientDirect) Block(ctx context.Context, in *remoteproto.BlockRequest, opts ...grpc.CallOption) (*remoteproto.BlockReply, error) {
 	return s.server.Block(ctx, in)
 }
 
-func (s *EthBackendClientDirect) TxnLookup(ctx context.Context, in *remote.TxnLookupRequest, opts ...grpc.CallOption) (*remote.TxnLookupReply, error) {
+func (s *EthBackendClientDirect) TxnLookup(ctx context.Context, in *remoteproto.TxnLookupRequest, opts ...grpc.CallOption) (*remoteproto.TxnLookupReply, error) {
 	return s.server.TxnLookup(ctx, in)
 }
 
-func (s *EthBackendClientDirect) NodeInfo(ctx context.Context, in *remote.NodesInfoRequest, opts ...grpc.CallOption) (*remote.NodesInfoReply, error) {
+func (s *EthBackendClientDirect) NodeInfo(ctx context.Context, in *remoteproto.NodesInfoRequest, opts ...grpc.CallOption) (*remoteproto.NodesInfoReply, error) {
 	return s.server.NodeInfo(ctx, in)
 }
 
-func (s *EthBackendClientDirect) Peers(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*remote.PeersReply, error) {
+func (s *EthBackendClientDirect) Peers(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*remoteproto.PeersReply, error) {
 	return s.server.Peers(ctx, in)
 }
 
-func (s *EthBackendClientDirect) AddPeer(ctx context.Context, in *remote.AddPeerRequest, opts ...grpc.CallOption) (*remote.AddPeerReply, error) {
+func (s *EthBackendClientDirect) AddPeer(ctx context.Context, in *remoteproto.AddPeerRequest, opts ...grpc.CallOption) (*remoteproto.AddPeerReply, error) {
 	return s.server.AddPeer(ctx, in)
 }
 
-func (s *EthBackendClientDirect) RemovePeer(ctx context.Context, in *remote.RemovePeerRequest, opts ...grpc.CallOption) (*remote.RemovePeerReply, error) {
+func (s *EthBackendClientDirect) RemovePeer(ctx context.Context, in *remoteproto.RemovePeerRequest, opts ...grpc.CallOption) (*remoteproto.RemovePeerReply, error) {
 	return s.server.RemovePeer(ctx, in)
 }
 
-func (s *EthBackendClientDirect) PendingBlock(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*remote.PendingBlockReply, error) {
+func (s *EthBackendClientDirect) PendingBlock(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*remoteproto.PendingBlockReply, error) {
 	return s.server.PendingBlock(ctx, in)
 }
 
-func (s *EthBackendClientDirect) BorTxnLookup(ctx context.Context, in *remote.BorTxnLookupRequest, opts ...grpc.CallOption) (*remote.BorTxnLookupReply, error) {
+func (s *EthBackendClientDirect) BorTxnLookup(ctx context.Context, in *remoteproto.BorTxnLookupRequest, opts ...grpc.CallOption) (*remoteproto.BorTxnLookupReply, error) {
 	return s.server.BorTxnLookup(ctx, in)
 }
 
-func (s *EthBackendClientDirect) BorEvents(ctx context.Context, in *remote.BorEventsRequest, opts ...grpc.CallOption) (*remote.BorEventsReply, error) {
+func (s *EthBackendClientDirect) BorEvents(ctx context.Context, in *remoteproto.BorEventsRequest, opts ...grpc.CallOption) (*remoteproto.BorEventsReply, error) {
 	return s.server.BorEvents(ctx, in)
 }
 
-func (s *EthBackendClientDirect) AAValidation(ctx context.Context, in *remote.AAValidationRequest, opts ...grpc.CallOption) (*remote.AAValidationReply, error) {
+func (s *EthBackendClientDirect) AAValidation(ctx context.Context, in *remoteproto.AAValidationRequest, opts ...grpc.CallOption) (*remoteproto.AAValidationReply, error) {
 	return s.server.AAValidation(ctx, in)
 }
 
-func (s *EthBackendClientDirect) BlockForTxNum(ctx context.Context, in *remote.BlockForTxNumRequest, opts ...grpc.CallOption) (*remote.BlockForTxNumResponse, error) {
+func (s *EthBackendClientDirect) BlockForTxNum(ctx context.Context, in *remoteproto.BlockForTxNumRequest, opts ...grpc.CallOption) (*remoteproto.BlockForTxNumResponse, error) {
 	return s.server.BlockForTxNum(ctx, in)
 }

--- a/node/direct/execution_client.go
+++ b/node/direct/execution_client.go
@@ -19,88 +19,89 @@ package direct
 import (
 	"context"
 
-	execution "github.com/erigontech/erigon-lib/gointerfaces/executionproto"
-	types "github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/erigontech/erigon-lib/gointerfaces/executionproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 )
 
 type ExecutionClientDirect struct {
-	server execution.ExecutionServer
+	server executionproto.ExecutionServer
 }
 
-func NewExecutionClientDirect(server execution.ExecutionServer) execution.ExecutionClient {
+func NewExecutionClientDirect(server executionproto.ExecutionServer) executionproto.ExecutionClient {
 	return &ExecutionClientDirect{server: server}
 }
 
-func (s *ExecutionClientDirect) AssembleBlock(ctx context.Context, in *execution.AssembleBlockRequest, opts ...grpc.CallOption) (*execution.AssembleBlockResponse, error) {
+func (s *ExecutionClientDirect) AssembleBlock(ctx context.Context, in *executionproto.AssembleBlockRequest, opts ...grpc.CallOption) (*executionproto.AssembleBlockResponse, error) {
 	return s.server.AssembleBlock(ctx, in)
 }
 
-func (s *ExecutionClientDirect) GetBodiesByHashes(ctx context.Context, in *execution.GetBodiesByHashesRequest, opts ...grpc.CallOption) (*execution.GetBodiesBatchResponse, error) {
+func (s *ExecutionClientDirect) GetBodiesByHashes(ctx context.Context, in *executionproto.GetBodiesByHashesRequest, opts ...grpc.CallOption) (*executionproto.GetBodiesBatchResponse, error) {
 	return s.server.GetBodiesByHashes(ctx, in)
 }
 
-func (s *ExecutionClientDirect) GetBodiesByRange(ctx context.Context, in *execution.GetBodiesByRangeRequest, opts ...grpc.CallOption) (*execution.GetBodiesBatchResponse, error) {
+func (s *ExecutionClientDirect) GetBodiesByRange(ctx context.Context, in *executionproto.GetBodiesByRangeRequest, opts ...grpc.CallOption) (*executionproto.GetBodiesBatchResponse, error) {
 	return s.server.GetBodiesByRange(ctx, in)
 }
 
-func (s *ExecutionClientDirect) HasBlock(ctx context.Context, in *execution.GetSegmentRequest, opts ...grpc.CallOption) (*execution.HasBlockResponse, error) {
+func (s *ExecutionClientDirect) HasBlock(ctx context.Context, in *executionproto.GetSegmentRequest, opts ...grpc.CallOption) (*executionproto.HasBlockResponse, error) {
 	return s.server.HasBlock(ctx, in)
 }
 
-func (s *ExecutionClientDirect) GetAssembledBlock(ctx context.Context, in *execution.GetAssembledBlockRequest, opts ...grpc.CallOption) (*execution.GetAssembledBlockResponse, error) {
+func (s *ExecutionClientDirect) GetAssembledBlock(ctx context.Context, in *executionproto.GetAssembledBlockRequest, opts ...grpc.CallOption) (*executionproto.GetAssembledBlockResponse, error) {
 	return s.server.GetAssembledBlock(ctx, in)
 }
 
 // Chain Putters.
-func (s *ExecutionClientDirect) InsertBlocks(ctx context.Context, in *execution.InsertBlocksRequest, opts ...grpc.CallOption) (*execution.InsertionResult, error) {
+func (s *ExecutionClientDirect) InsertBlocks(ctx context.Context, in *executionproto.InsertBlocksRequest, opts ...grpc.CallOption) (*executionproto.InsertionResult, error) {
 	return s.server.InsertBlocks(ctx, in)
 }
 
 // Chain Validation and ForkChoice.
-func (s *ExecutionClientDirect) ValidateChain(ctx context.Context, in *execution.ValidationRequest, opts ...grpc.CallOption) (*execution.ValidationReceipt, error) {
+func (s *ExecutionClientDirect) ValidateChain(ctx context.Context, in *executionproto.ValidationRequest, opts ...grpc.CallOption) (*executionproto.ValidationReceipt, error) {
 	return s.server.ValidateChain(ctx, in)
 
 }
 
-func (s *ExecutionClientDirect) UpdateForkChoice(ctx context.Context, in *execution.ForkChoice, opts ...grpc.CallOption) (*execution.ForkChoiceReceipt, error) {
+func (s *ExecutionClientDirect) UpdateForkChoice(ctx context.Context, in *executionproto.ForkChoice, opts ...grpc.CallOption) (*executionproto.ForkChoiceReceipt, error) {
 	return s.server.UpdateForkChoice(ctx, in)
 }
 
 // Chain Getters.
-func (s *ExecutionClientDirect) GetHeader(ctx context.Context, in *execution.GetSegmentRequest, opts ...grpc.CallOption) (*execution.GetHeaderResponse, error) {
+func (s *ExecutionClientDirect) GetHeader(ctx context.Context, in *executionproto.GetSegmentRequest, opts ...grpc.CallOption) (*executionproto.GetHeaderResponse, error) {
 	return s.server.GetHeader(ctx, in)
 }
 
-func (s *ExecutionClientDirect) CurrentHeader(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*execution.GetHeaderResponse, error) {
+func (s *ExecutionClientDirect) CurrentHeader(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*executionproto.GetHeaderResponse, error) {
 	return s.server.CurrentHeader(ctx, in)
 }
 
-func (s *ExecutionClientDirect) GetTD(ctx context.Context, in *execution.GetSegmentRequest, opts ...grpc.CallOption) (*execution.GetTDResponse, error) {
+func (s *ExecutionClientDirect) GetTD(ctx context.Context, in *executionproto.GetSegmentRequest, opts ...grpc.CallOption) (*executionproto.GetTDResponse, error) {
 	return s.server.GetTD(ctx, in)
 }
 
-func (s *ExecutionClientDirect) GetBody(ctx context.Context, in *execution.GetSegmentRequest, opts ...grpc.CallOption) (*execution.GetBodyResponse, error) {
+func (s *ExecutionClientDirect) GetBody(ctx context.Context, in *executionproto.GetSegmentRequest, opts ...grpc.CallOption) (*executionproto.GetBodyResponse, error) {
 	return s.server.GetBody(ctx, in)
 }
 
-func (s *ExecutionClientDirect) IsCanonicalHash(ctx context.Context, in *types.H256, opts ...grpc.CallOption) (*execution.IsCanonicalResponse, error) {
+func (s *ExecutionClientDirect) IsCanonicalHash(ctx context.Context, in *typesproto.H256, opts ...grpc.CallOption) (*executionproto.IsCanonicalResponse, error) {
 	return s.server.IsCanonicalHash(ctx, in)
 }
 
-func (s *ExecutionClientDirect) GetHeaderHashNumber(ctx context.Context, in *types.H256, opts ...grpc.CallOption) (*execution.GetHeaderHashNumberResponse, error) {
+func (s *ExecutionClientDirect) GetHeaderHashNumber(ctx context.Context, in *typesproto.H256, opts ...grpc.CallOption) (*executionproto.GetHeaderHashNumberResponse, error) {
 	return s.server.GetHeaderHashNumber(ctx, in)
 }
 
-func (s *ExecutionClientDirect) GetForkChoice(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*execution.ForkChoice, error) {
+func (s *ExecutionClientDirect) GetForkChoice(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*executionproto.ForkChoice, error) {
 	return s.server.GetForkChoice(ctx, in)
 }
 
-func (s *ExecutionClientDirect) Ready(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*execution.ReadyResponse, error) {
+func (s *ExecutionClientDirect) Ready(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*executionproto.ReadyResponse, error) {
 	return s.server.Ready(ctx, in)
 }
 
-func (s *ExecutionClientDirect) FrozenBlocks(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*execution.FrozenBlocksResponse, error) {
+func (s *ExecutionClientDirect) FrozenBlocks(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*executionproto.FrozenBlocksResponse, error) {
 	return s.server.FrozenBlocks(ctx, in)
 }

--- a/node/direct/mining_client.go
+++ b/node/direct/mining_client.go
@@ -20,29 +20,30 @@ import (
 	"context"
 	"io"
 
-	txpool_proto "github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
-	types "github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 )
 
-var _ txpool_proto.MiningClient = (*MiningClient)(nil)
+var _ txpoolproto.MiningClient = (*MiningClient)(nil)
 
 type MiningClient struct {
-	server txpool_proto.MiningServer
+	server txpoolproto.MiningServer
 }
 
-func NewMiningClient(server txpool_proto.MiningServer) *MiningClient {
+func NewMiningClient(server txpoolproto.MiningServer) *MiningClient {
 	return &MiningClient{server: server}
 }
 
-func (s *MiningClient) Version(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*types.VersionReply, error) {
+func (s *MiningClient) Version(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*typesproto.VersionReply, error) {
 	return s.server.Version(ctx, in)
 }
 
 // -- start OnPendingBlock
 
-func (s *MiningClient) OnPendingBlock(ctx context.Context, in *txpool_proto.OnPendingBlockRequest, opts ...grpc.CallOption) (txpool_proto.Mining_OnPendingBlockClient, error) {
+func (s *MiningClient) OnPendingBlock(ctx context.Context, in *txpoolproto.OnPendingBlockRequest, opts ...grpc.CallOption) (txpoolproto.Mining_OnPendingBlockClient, error) {
 	ch := make(chan *onPendigBlockReply, 16384)
 	streamServer := &MiningOnPendingBlockS{ch: ch, ctx: ctx}
 	go func() {
@@ -53,7 +54,7 @@ func (s *MiningClient) OnPendingBlock(ctx context.Context, in *txpool_proto.OnPe
 }
 
 type onPendigBlockReply struct {
-	r   *txpool_proto.OnPendingBlockReply
+	r   *txpoolproto.OnPendingBlockReply
 	err error
 }
 
@@ -63,7 +64,7 @@ type MiningOnPendingBlockS struct {
 	grpc.ServerStream
 }
 
-func (s *MiningOnPendingBlockS) Send(m *txpool_proto.OnPendingBlockReply) error {
+func (s *MiningOnPendingBlockS) Send(m *txpoolproto.OnPendingBlockReply) error {
 	s.ch <- &onPendigBlockReply{r: m}
 	return nil
 }
@@ -81,7 +82,7 @@ type MiningOnPendingBlockC struct {
 	grpc.ClientStream
 }
 
-func (c *MiningOnPendingBlockC) Recv() (*txpool_proto.OnPendingBlockReply, error) {
+func (c *MiningOnPendingBlockC) Recv() (*txpoolproto.OnPendingBlockReply, error) {
 	m, ok := <-c.ch
 	if !ok || m == nil {
 		return nil, io.EOF
@@ -93,7 +94,7 @@ func (c *MiningOnPendingBlockC) Context() context.Context { return c.ctx }
 // -- end OnPendingBlock
 // -- start OnMinedBlock
 
-func (s *MiningClient) OnMinedBlock(ctx context.Context, in *txpool_proto.OnMinedBlockRequest, opts ...grpc.CallOption) (txpool_proto.Mining_OnMinedBlockClient, error) {
+func (s *MiningClient) OnMinedBlock(ctx context.Context, in *txpoolproto.OnMinedBlockRequest, opts ...grpc.CallOption) (txpoolproto.Mining_OnMinedBlockClient, error) {
 	ch := make(chan *onMinedBlockReply, 16384)
 	streamServer := &MiningOnMinedBlockS{ch: ch, ctx: ctx}
 	go func() {
@@ -104,7 +105,7 @@ func (s *MiningClient) OnMinedBlock(ctx context.Context, in *txpool_proto.OnMine
 }
 
 type onMinedBlockReply struct {
-	r   *txpool_proto.OnMinedBlockReply
+	r   *txpoolproto.OnMinedBlockReply
 	err error
 }
 
@@ -114,7 +115,7 @@ type MiningOnMinedBlockS struct {
 	grpc.ServerStream
 }
 
-func (s *MiningOnMinedBlockS) Send(m *txpool_proto.OnMinedBlockReply) error {
+func (s *MiningOnMinedBlockS) Send(m *txpoolproto.OnMinedBlockReply) error {
 	s.ch <- &onMinedBlockReply{r: m}
 	return nil
 }
@@ -132,7 +133,7 @@ type MiningOnMinedBlockC struct {
 	grpc.ClientStream
 }
 
-func (c *MiningOnMinedBlockC) Recv() (*txpool_proto.OnMinedBlockReply, error) {
+func (c *MiningOnMinedBlockC) Recv() (*txpoolproto.OnMinedBlockReply, error) {
 	m, ok := <-c.ch
 	if !ok || m == nil {
 		return nil, io.EOF
@@ -144,7 +145,7 @@ func (c *MiningOnMinedBlockC) Context() context.Context { return c.ctx }
 // -- end OnMinedBlock
 // -- end OnPendingLogs
 
-func (s *MiningClient) OnPendingLogs(ctx context.Context, in *txpool_proto.OnPendingLogsRequest, opts ...grpc.CallOption) (txpool_proto.Mining_OnPendingLogsClient, error) {
+func (s *MiningClient) OnPendingLogs(ctx context.Context, in *txpoolproto.OnPendingLogsRequest, opts ...grpc.CallOption) (txpoolproto.Mining_OnPendingLogsClient, error) {
 	ch := make(chan *onPendingLogsReply, 16384)
 	streamServer := &MiningOnPendingLogsS{ch: ch, ctx: ctx}
 	go func() {
@@ -155,7 +156,7 @@ func (s *MiningClient) OnPendingLogs(ctx context.Context, in *txpool_proto.OnPen
 }
 
 type onPendingLogsReply struct {
-	r   *txpool_proto.OnPendingLogsReply
+	r   *txpoolproto.OnPendingLogsReply
 	err error
 }
 type MiningOnPendingLogsS struct {
@@ -164,7 +165,7 @@ type MiningOnPendingLogsS struct {
 	grpc.ServerStream
 }
 
-func (s *MiningOnPendingLogsS) Send(m *txpool_proto.OnPendingLogsReply) error {
+func (s *MiningOnPendingLogsS) Send(m *txpoolproto.OnPendingLogsReply) error {
 	s.ch <- &onPendingLogsReply{r: m}
 	return nil
 }
@@ -182,7 +183,7 @@ type MiningOnPendingLogsC struct {
 	grpc.ClientStream
 }
 
-func (c *MiningOnPendingLogsC) Recv() (*txpool_proto.OnPendingLogsReply, error) {
+func (c *MiningOnPendingLogsC) Recv() (*txpoolproto.OnPendingLogsReply, error) {
 	m, ok := <-c.ch
 	if !ok || m == nil {
 		return nil, io.EOF
@@ -193,22 +194,22 @@ func (c *MiningOnPendingLogsC) Context() context.Context { return c.ctx }
 
 // -- end OnPendingLogs
 
-func (s *MiningClient) GetWork(ctx context.Context, in *txpool_proto.GetWorkRequest, opts ...grpc.CallOption) (*txpool_proto.GetWorkReply, error) {
+func (s *MiningClient) GetWork(ctx context.Context, in *txpoolproto.GetWorkRequest, opts ...grpc.CallOption) (*txpoolproto.GetWorkReply, error) {
 	return s.server.GetWork(ctx, in)
 }
 
-func (s *MiningClient) SubmitWork(ctx context.Context, in *txpool_proto.SubmitWorkRequest, opts ...grpc.CallOption) (*txpool_proto.SubmitWorkReply, error) {
+func (s *MiningClient) SubmitWork(ctx context.Context, in *txpoolproto.SubmitWorkRequest, opts ...grpc.CallOption) (*txpoolproto.SubmitWorkReply, error) {
 	return s.server.SubmitWork(ctx, in)
 }
 
-func (s *MiningClient) SubmitHashRate(ctx context.Context, in *txpool_proto.SubmitHashRateRequest, opts ...grpc.CallOption) (*txpool_proto.SubmitHashRateReply, error) {
+func (s *MiningClient) SubmitHashRate(ctx context.Context, in *txpoolproto.SubmitHashRateRequest, opts ...grpc.CallOption) (*txpoolproto.SubmitHashRateReply, error) {
 	return s.server.SubmitHashRate(ctx, in)
 }
 
-func (s *MiningClient) HashRate(ctx context.Context, in *txpool_proto.HashRateRequest, opts ...grpc.CallOption) (*txpool_proto.HashRateReply, error) {
+func (s *MiningClient) HashRate(ctx context.Context, in *txpoolproto.HashRateRequest, opts ...grpc.CallOption) (*txpoolproto.HashRateReply, error) {
 	return s.server.HashRate(ctx, in)
 }
 
-func (s *MiningClient) Mining(ctx context.Context, in *txpool_proto.MiningRequest, opts ...grpc.CallOption) (*txpool_proto.MiningReply, error) {
+func (s *MiningClient) Mining(ctx context.Context, in *txpoolproto.MiningRequest, opts ...grpc.CallOption) (*txpoolproto.MiningReply, error) {
 	return s.server.Mining(ctx, in)
 }

--- a/node/direct/sentinel_client.go
+++ b/node/direct/sentinel_client.go
@@ -20,62 +20,63 @@ import (
 	"context"
 	"io"
 
-	sentinel "github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
 	"google.golang.org/grpc"
+
+	"github.com/erigontech/erigon-lib/gointerfaces/sentinelproto"
 )
 
 type SentinelClientDirect struct {
-	server sentinel.SentinelServer
+	server sentinelproto.SentinelServer
 }
 
-func NewSentinelClientDirect(sentinel sentinel.SentinelServer) sentinel.SentinelClient {
+func NewSentinelClientDirect(sentinel sentinelproto.SentinelServer) sentinelproto.SentinelClient {
 	return &SentinelClientDirect{server: sentinel}
 }
 
-func (s *SentinelClientDirect) SendRequest(ctx context.Context, in *sentinel.RequestData, opts ...grpc.CallOption) (*sentinel.ResponseData, error) {
+func (s *SentinelClientDirect) SendRequest(ctx context.Context, in *sentinelproto.RequestData, opts ...grpc.CallOption) (*sentinelproto.ResponseData, error) {
 	return s.server.SendRequest(ctx, in)
 }
 
-func (s *SentinelClientDirect) SendPeerRequest(ctx context.Context, in *sentinel.RequestDataWithPeer, opts ...grpc.CallOption) (*sentinel.ResponseData, error) {
+func (s *SentinelClientDirect) SendPeerRequest(ctx context.Context, in *sentinelproto.RequestDataWithPeer, opts ...grpc.CallOption) (*sentinelproto.ResponseData, error) {
 	return s.server.SendPeerRequest(ctx, in)
 }
 
-func (s *SentinelClientDirect) SetStatus(ctx context.Context, in *sentinel.Status, opts ...grpc.CallOption) (*sentinel.EmptyMessage, error) {
+func (s *SentinelClientDirect) SetStatus(ctx context.Context, in *sentinelproto.Status, opts ...grpc.CallOption) (*sentinelproto.EmptyMessage, error) {
 	return s.server.SetStatus(ctx, in)
 }
 
-func (s *SentinelClientDirect) GetPeers(ctx context.Context, in *sentinel.EmptyMessage, opts ...grpc.CallOption) (*sentinel.PeerCount, error) {
+func (s *SentinelClientDirect) GetPeers(ctx context.Context, in *sentinelproto.EmptyMessage, opts ...grpc.CallOption) (*sentinelproto.PeerCount, error) {
 	return s.server.GetPeers(ctx, in)
 }
 
-func (s *SentinelClientDirect) BanPeer(ctx context.Context, p *sentinel.Peer, opts ...grpc.CallOption) (*sentinel.EmptyMessage, error) {
+func (s *SentinelClientDirect) BanPeer(ctx context.Context, p *sentinelproto.Peer, opts ...grpc.CallOption) (*sentinelproto.EmptyMessage, error) {
 	return s.server.BanPeer(ctx, p)
 }
-func (s *SentinelClientDirect) UnbanPeer(ctx context.Context, p *sentinel.Peer, opts ...grpc.CallOption) (*sentinel.EmptyMessage, error) {
+func (s *SentinelClientDirect) UnbanPeer(ctx context.Context, p *sentinelproto.Peer, opts ...grpc.CallOption) (*sentinelproto.EmptyMessage, error) {
 	return s.server.UnbanPeer(ctx, p)
 }
-func (s *SentinelClientDirect) RewardPeer(ctx context.Context, p *sentinel.Peer, opts ...grpc.CallOption) (*sentinel.EmptyMessage, error) {
+func (s *SentinelClientDirect) RewardPeer(ctx context.Context, p *sentinelproto.Peer, opts ...grpc.CallOption) (*sentinelproto.EmptyMessage, error) {
 	return s.server.RewardPeer(ctx, p)
 }
-func (s *SentinelClientDirect) PenalizePeer(ctx context.Context, p *sentinel.Peer, opts ...grpc.CallOption) (*sentinel.EmptyMessage, error) {
+func (s *SentinelClientDirect) PenalizePeer(ctx context.Context, p *sentinelproto.Peer, opts ...grpc.CallOption) (*sentinelproto.EmptyMessage, error) {
 	return s.server.PenalizePeer(ctx, p)
 }
 
-func (s *SentinelClientDirect) PublishGossip(ctx context.Context, in *sentinel.GossipData, opts ...grpc.CallOption) (*sentinel.EmptyMessage, error) {
+func (s *SentinelClientDirect) PublishGossip(ctx context.Context, in *sentinelproto.GossipData, opts ...grpc.CallOption) (*sentinelproto.EmptyMessage, error) {
 	return s.server.PublishGossip(ctx, in)
 }
 
-func (s *SentinelClientDirect) Identity(ctx context.Context, in *sentinel.EmptyMessage, opts ...grpc.CallOption) (*sentinel.IdentityResponse, error) {
+func (s *SentinelClientDirect) Identity(ctx context.Context, in *sentinelproto.EmptyMessage, opts ...grpc.CallOption) (*sentinelproto.IdentityResponse, error) {
 	return s.server.Identity(ctx, in)
 }
 
-func (s *SentinelClientDirect) PeersInfo(ctx context.Context, in *sentinel.PeersInfoRequest, opts ...grpc.CallOption) (*sentinel.PeersInfoResponse, error) {
+func (s *SentinelClientDirect) PeersInfo(ctx context.Context, in *sentinelproto.PeersInfoRequest, opts ...grpc.CallOption) (*sentinelproto.PeersInfoResponse, error) {
 	return s.server.PeersInfo(ctx, in)
 }
 
 // Subscribe gossip part. the only complex section of this bullshit
 
-func (s *SentinelClientDirect) SubscribeGossip(ctx context.Context, in *sentinel.SubscriptionData, opts ...grpc.CallOption) (sentinel.Sentinel_SubscribeGossipClient, error) {
+func (s *SentinelClientDirect) SubscribeGossip(ctx context.Context, in *sentinelproto.SubscriptionData, opts ...grpc.CallOption) (sentinelproto.Sentinel_SubscribeGossipClient, error) {
 	ch := make(chan *gossipReply, 1<<16)
 	streamServer := &SentinelSubscribeGossipS{ch: ch, ctx: ctx}
 	go func() {
@@ -85,7 +86,7 @@ func (s *SentinelClientDirect) SubscribeGossip(ctx context.Context, in *sentinel
 	return &SentinelSubscribeGossipC{ch: ch, ctx: ctx}, nil
 }
 
-func (s *SentinelClientDirect) SetSubscribeExpiry(ctx context.Context, expiryReq *sentinel.RequestSubscribeExpiry, opts ...grpc.CallOption) (*sentinel.EmptyMessage, error) {
+func (s *SentinelClientDirect) SetSubscribeExpiry(ctx context.Context, expiryReq *sentinelproto.RequestSubscribeExpiry, opts ...grpc.CallOption) (*sentinelproto.EmptyMessage, error) {
 	return s.server.SetSubscribeExpiry(ctx, expiryReq)
 }
 
@@ -95,7 +96,7 @@ type SentinelSubscribeGossipC struct {
 	grpc.ClientStream
 }
 
-func (c *SentinelSubscribeGossipC) Recv() (*sentinel.GossipData, error) {
+func (c *SentinelSubscribeGossipC) Recv() (*sentinelproto.GossipData, error) {
 	m, ok := <-c.ch
 	if !ok || m == nil {
 		return nil, io.EOF
@@ -111,11 +112,11 @@ type SentinelSubscribeGossipS struct {
 }
 
 type gossipReply struct {
-	r   *sentinel.GossipData
+	r   *sentinelproto.GossipData
 	err error
 }
 
-func (s *SentinelSubscribeGossipS) Send(m *sentinel.GossipData) error {
+func (s *SentinelSubscribeGossipS) Send(m *sentinelproto.GossipData) error {
 	s.ch <- &gossipReply{r: m}
 	return nil
 }

--- a/node/direct/sentry_client.go
+++ b/node/direct/sentry_client.go
@@ -27,7 +27,7 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
-	types "github.com/erigontech/erigon-lib/gointerfaces/typesproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 	"github.com/erigontech/erigon/p2p/sentry/libsentry"
 )
 
@@ -321,7 +321,7 @@ func (c *SentryPeersStreamC) RecvMsg(anyMessage interface{}) error {
 
 // -- end Peers
 
-func (c *SentryClientDirect) NodeInfo(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*types.NodeInfoReply, error) {
+func (c *SentryClientDirect) NodeInfo(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*typesproto.NodeInfoReply, error) {
 	return c.server.NodeInfo(ctx, in)
 }
 

--- a/node/direct/txpool_client.go
+++ b/node/direct/txpool_client.go
@@ -20,49 +20,50 @@ import (
 	"context"
 	"io"
 
-	txpool_proto "github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
-	types "github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 )
 
-var _ txpool_proto.TxpoolClient = (*TxPoolClient)(nil)
+var _ txpoolproto.TxpoolClient = (*TxPoolClient)(nil)
 
 type TxPoolClient struct {
-	server txpool_proto.TxpoolServer
+	server txpoolproto.TxpoolServer
 }
 
-func NewTxPoolClient(server txpool_proto.TxpoolServer) *TxPoolClient {
+func NewTxPoolClient(server txpoolproto.TxpoolServer) *TxPoolClient {
 	return &TxPoolClient{server}
 }
 
-func (s *TxPoolClient) Version(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*types.VersionReply, error) {
+func (s *TxPoolClient) Version(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*typesproto.VersionReply, error) {
 	return s.server.Version(ctx, in)
 }
 
-func (s *TxPoolClient) FindUnknown(ctx context.Context, in *txpool_proto.TxHashes, opts ...grpc.CallOption) (*txpool_proto.TxHashes, error) {
+func (s *TxPoolClient) FindUnknown(ctx context.Context, in *txpoolproto.TxHashes, opts ...grpc.CallOption) (*txpoolproto.TxHashes, error) {
 	return s.server.FindUnknown(ctx, in)
 }
 
-func (s *TxPoolClient) Add(ctx context.Context, in *txpool_proto.AddRequest, opts ...grpc.CallOption) (*txpool_proto.AddReply, error) {
+func (s *TxPoolClient) Add(ctx context.Context, in *txpoolproto.AddRequest, opts ...grpc.CallOption) (*txpoolproto.AddReply, error) {
 	return s.server.Add(ctx, in)
 }
 
-func (s *TxPoolClient) Transactions(ctx context.Context, in *txpool_proto.TransactionsRequest, opts ...grpc.CallOption) (*txpool_proto.TransactionsReply, error) {
+func (s *TxPoolClient) Transactions(ctx context.Context, in *txpoolproto.TransactionsRequest, opts ...grpc.CallOption) (*txpoolproto.TransactionsReply, error) {
 	return s.server.Transactions(ctx, in)
 }
 
-func (s *TxPoolClient) All(ctx context.Context, in *txpool_proto.AllRequest, opts ...grpc.CallOption) (*txpool_proto.AllReply, error) {
+func (s *TxPoolClient) All(ctx context.Context, in *txpoolproto.AllRequest, opts ...grpc.CallOption) (*txpoolproto.AllReply, error) {
 	return s.server.All(ctx, in)
 }
 
-func (s *TxPoolClient) Pending(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*txpool_proto.PendingReply, error) {
+func (s *TxPoolClient) Pending(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*txpoolproto.PendingReply, error) {
 	return s.server.Pending(ctx, in)
 }
 
 // -- start OnAdd
 
-func (s *TxPoolClient) OnAdd(ctx context.Context, in *txpool_proto.OnAddRequest, opts ...grpc.CallOption) (txpool_proto.Txpool_OnAddClient, error) {
+func (s *TxPoolClient) OnAdd(ctx context.Context, in *txpoolproto.OnAddRequest, opts ...grpc.CallOption) (txpoolproto.Txpool_OnAddClient, error) {
 	ch := make(chan *onAddReply, 16384)
 	streamServer := &TxPoolOnAddS{ch: ch, ctx: ctx}
 	go func() {
@@ -73,7 +74,7 @@ func (s *TxPoolClient) OnAdd(ctx context.Context, in *txpool_proto.OnAddRequest,
 }
 
 type onAddReply struct {
-	r   *txpool_proto.OnAddReply
+	r   *txpoolproto.OnAddReply
 	err error
 }
 
@@ -83,7 +84,7 @@ type TxPoolOnAddS struct {
 	grpc.ServerStream
 }
 
-func (s *TxPoolOnAddS) Send(m *txpool_proto.OnAddReply) error {
+func (s *TxPoolOnAddS) Send(m *txpoolproto.OnAddReply) error {
 	s.ch <- &onAddReply{r: m}
 	return nil
 }
@@ -101,7 +102,7 @@ type TxPoolOnAddC struct {
 	grpc.ClientStream
 }
 
-func (c *TxPoolOnAddC) Recv() (*txpool_proto.OnAddReply, error) {
+func (c *TxPoolOnAddC) Recv() (*txpoolproto.OnAddReply, error) {
 	m, ok := <-c.ch
 	if !ok || m == nil {
 		return nil, io.EOF
@@ -112,14 +113,14 @@ func (c *TxPoolOnAddC) Context() context.Context { return c.ctx }
 
 // -- end OnAdd
 
-func (s *TxPoolClient) Status(ctx context.Context, in *txpool_proto.StatusRequest, opts ...grpc.CallOption) (*txpool_proto.StatusReply, error) {
+func (s *TxPoolClient) Status(ctx context.Context, in *txpoolproto.StatusRequest, opts ...grpc.CallOption) (*txpoolproto.StatusReply, error) {
 	return s.server.Status(ctx, in)
 }
 
-func (s *TxPoolClient) Nonce(ctx context.Context, in *txpool_proto.NonceRequest, opts ...grpc.CallOption) (*txpool_proto.NonceReply, error) {
+func (s *TxPoolClient) Nonce(ctx context.Context, in *txpoolproto.NonceRequest, opts ...grpc.CallOption) (*txpoolproto.NonceReply, error) {
 	return s.server.Nonce(ctx, in)
 }
 
-func (s *TxPoolClient) GetBlobs(ctx context.Context, in *txpool_proto.GetBlobsRequest, opts ...grpc.CallOption) (*txpool_proto.GetBlobsReply, error) {
+func (s *TxPoolClient) GetBlobs(ctx context.Context, in *txpoolproto.GetBlobsRequest, opts ...grpc.CallOption) (*txpoolproto.GetBlobsReply, error) {
 	return s.server.GetBlobs(ctx, in)
 }

--- a/p2p/protocol.go
+++ b/p2p/protocol.go
@@ -22,7 +22,7 @@ package p2p
 import (
 	"fmt"
 
-	proto_sentry "github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon/p2p/enode"
 	"github.com/erigontech/erigon/p2p/enr"
 )
@@ -66,8 +66,8 @@ type Protocol struct {
 	// Attributes contains protocol specific information for the node record.
 	Attributes []enr.Entry
 
-	FromProto map[proto_sentry.MessageId]uint64
-	ToProto   map[uint64]proto_sentry.MessageId
+	FromProto map[sentryproto.MessageId]uint64
+	ToProto   map[uint64]sentryproto.MessageId
 }
 
 func (p Protocol) cap() Cap {

--- a/p2p/protocols/eth/protocol.go
+++ b/p2p/protocols/eth/protocol.go
@@ -25,7 +25,7 @@ import (
 	"math/big"
 
 	"github.com/erigontech/erigon-lib/common"
-	proto_sentry "github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon/execution/rlp"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/node/direct"
@@ -64,65 +64,65 @@ const (
 	PooledTransactionsMsg         = 0x0a
 )
 
-var ToProto = map[uint]map[uint64]proto_sentry.MessageId{
+var ToProto = map[uint]map[uint64]sentryproto.MessageId{
 	direct.ETH67: {
-		GetBlockHeadersMsg:            proto_sentry.MessageId_GET_BLOCK_HEADERS_66,
-		BlockHeadersMsg:               proto_sentry.MessageId_BLOCK_HEADERS_66,
-		GetBlockBodiesMsg:             proto_sentry.MessageId_GET_BLOCK_BODIES_66,
-		BlockBodiesMsg:                proto_sentry.MessageId_BLOCK_BODIES_66,
-		GetReceiptsMsg:                proto_sentry.MessageId_GET_RECEIPTS_66,
-		ReceiptsMsg:                   proto_sentry.MessageId_RECEIPTS_66,
-		NewBlockHashesMsg:             proto_sentry.MessageId_NEW_BLOCK_HASHES_66,
-		NewBlockMsg:                   proto_sentry.MessageId_NEW_BLOCK_66,
-		TransactionsMsg:               proto_sentry.MessageId_TRANSACTIONS_66,
-		NewPooledTransactionHashesMsg: proto_sentry.MessageId_NEW_POOLED_TRANSACTION_HASHES_66,
-		GetPooledTransactionsMsg:      proto_sentry.MessageId_GET_POOLED_TRANSACTIONS_66,
-		PooledTransactionsMsg:         proto_sentry.MessageId_POOLED_TRANSACTIONS_66,
+		GetBlockHeadersMsg:            sentryproto.MessageId_GET_BLOCK_HEADERS_66,
+		BlockHeadersMsg:               sentryproto.MessageId_BLOCK_HEADERS_66,
+		GetBlockBodiesMsg:             sentryproto.MessageId_GET_BLOCK_BODIES_66,
+		BlockBodiesMsg:                sentryproto.MessageId_BLOCK_BODIES_66,
+		GetReceiptsMsg:                sentryproto.MessageId_GET_RECEIPTS_66,
+		ReceiptsMsg:                   sentryproto.MessageId_RECEIPTS_66,
+		NewBlockHashesMsg:             sentryproto.MessageId_NEW_BLOCK_HASHES_66,
+		NewBlockMsg:                   sentryproto.MessageId_NEW_BLOCK_66,
+		TransactionsMsg:               sentryproto.MessageId_TRANSACTIONS_66,
+		NewPooledTransactionHashesMsg: sentryproto.MessageId_NEW_POOLED_TRANSACTION_HASHES_66,
+		GetPooledTransactionsMsg:      sentryproto.MessageId_GET_POOLED_TRANSACTIONS_66,
+		PooledTransactionsMsg:         sentryproto.MessageId_POOLED_TRANSACTIONS_66,
 	},
 	direct.ETH68: {
-		GetBlockHeadersMsg:            proto_sentry.MessageId_GET_BLOCK_HEADERS_66,
-		BlockHeadersMsg:               proto_sentry.MessageId_BLOCK_HEADERS_66,
-		GetBlockBodiesMsg:             proto_sentry.MessageId_GET_BLOCK_BODIES_66,
-		BlockBodiesMsg:                proto_sentry.MessageId_BLOCK_BODIES_66,
-		GetReceiptsMsg:                proto_sentry.MessageId_GET_RECEIPTS_66,
-		ReceiptsMsg:                   proto_sentry.MessageId_RECEIPTS_66,
-		NewBlockHashesMsg:             proto_sentry.MessageId_NEW_BLOCK_HASHES_66,
-		NewBlockMsg:                   proto_sentry.MessageId_NEW_BLOCK_66,
-		TransactionsMsg:               proto_sentry.MessageId_TRANSACTIONS_66,
-		NewPooledTransactionHashesMsg: proto_sentry.MessageId_NEW_POOLED_TRANSACTION_HASHES_68, // Modified in eth/68
-		GetPooledTransactionsMsg:      proto_sentry.MessageId_GET_POOLED_TRANSACTIONS_66,
-		PooledTransactionsMsg:         proto_sentry.MessageId_POOLED_TRANSACTIONS_66,
+		GetBlockHeadersMsg:            sentryproto.MessageId_GET_BLOCK_HEADERS_66,
+		BlockHeadersMsg:               sentryproto.MessageId_BLOCK_HEADERS_66,
+		GetBlockBodiesMsg:             sentryproto.MessageId_GET_BLOCK_BODIES_66,
+		BlockBodiesMsg:                sentryproto.MessageId_BLOCK_BODIES_66,
+		GetReceiptsMsg:                sentryproto.MessageId_GET_RECEIPTS_66,
+		ReceiptsMsg:                   sentryproto.MessageId_RECEIPTS_66,
+		NewBlockHashesMsg:             sentryproto.MessageId_NEW_BLOCK_HASHES_66,
+		NewBlockMsg:                   sentryproto.MessageId_NEW_BLOCK_66,
+		TransactionsMsg:               sentryproto.MessageId_TRANSACTIONS_66,
+		NewPooledTransactionHashesMsg: sentryproto.MessageId_NEW_POOLED_TRANSACTION_HASHES_68, // Modified in eth/68
+		GetPooledTransactionsMsg:      sentryproto.MessageId_GET_POOLED_TRANSACTIONS_66,
+		PooledTransactionsMsg:         sentryproto.MessageId_POOLED_TRANSACTIONS_66,
 	},
 }
 
-var FromProto = map[uint]map[proto_sentry.MessageId]uint64{
+var FromProto = map[uint]map[sentryproto.MessageId]uint64{
 	direct.ETH67: {
-		proto_sentry.MessageId_GET_BLOCK_HEADERS_66:             GetBlockHeadersMsg,
-		proto_sentry.MessageId_BLOCK_HEADERS_66:                 BlockHeadersMsg,
-		proto_sentry.MessageId_GET_BLOCK_BODIES_66:              GetBlockBodiesMsg,
-		proto_sentry.MessageId_BLOCK_BODIES_66:                  BlockBodiesMsg,
-		proto_sentry.MessageId_GET_RECEIPTS_66:                  GetReceiptsMsg,
-		proto_sentry.MessageId_RECEIPTS_66:                      ReceiptsMsg,
-		proto_sentry.MessageId_NEW_BLOCK_HASHES_66:              NewBlockHashesMsg,
-		proto_sentry.MessageId_NEW_BLOCK_66:                     NewBlockMsg,
-		proto_sentry.MessageId_TRANSACTIONS_66:                  TransactionsMsg,
-		proto_sentry.MessageId_NEW_POOLED_TRANSACTION_HASHES_66: NewPooledTransactionHashesMsg,
-		proto_sentry.MessageId_GET_POOLED_TRANSACTIONS_66:       GetPooledTransactionsMsg,
-		proto_sentry.MessageId_POOLED_TRANSACTIONS_66:           PooledTransactionsMsg,
+		sentryproto.MessageId_GET_BLOCK_HEADERS_66:             GetBlockHeadersMsg,
+		sentryproto.MessageId_BLOCK_HEADERS_66:                 BlockHeadersMsg,
+		sentryproto.MessageId_GET_BLOCK_BODIES_66:              GetBlockBodiesMsg,
+		sentryproto.MessageId_BLOCK_BODIES_66:                  BlockBodiesMsg,
+		sentryproto.MessageId_GET_RECEIPTS_66:                  GetReceiptsMsg,
+		sentryproto.MessageId_RECEIPTS_66:                      ReceiptsMsg,
+		sentryproto.MessageId_NEW_BLOCK_HASHES_66:              NewBlockHashesMsg,
+		sentryproto.MessageId_NEW_BLOCK_66:                     NewBlockMsg,
+		sentryproto.MessageId_TRANSACTIONS_66:                  TransactionsMsg,
+		sentryproto.MessageId_NEW_POOLED_TRANSACTION_HASHES_66: NewPooledTransactionHashesMsg,
+		sentryproto.MessageId_GET_POOLED_TRANSACTIONS_66:       GetPooledTransactionsMsg,
+		sentryproto.MessageId_POOLED_TRANSACTIONS_66:           PooledTransactionsMsg,
 	},
 	direct.ETH68: {
-		proto_sentry.MessageId_GET_BLOCK_HEADERS_66:             GetBlockHeadersMsg,
-		proto_sentry.MessageId_BLOCK_HEADERS_66:                 BlockHeadersMsg,
-		proto_sentry.MessageId_GET_BLOCK_BODIES_66:              GetBlockBodiesMsg,
-		proto_sentry.MessageId_BLOCK_BODIES_66:                  BlockBodiesMsg,
-		proto_sentry.MessageId_GET_RECEIPTS_66:                  GetReceiptsMsg,
-		proto_sentry.MessageId_RECEIPTS_66:                      ReceiptsMsg,
-		proto_sentry.MessageId_NEW_BLOCK_HASHES_66:              NewBlockHashesMsg,
-		proto_sentry.MessageId_NEW_BLOCK_66:                     NewBlockMsg,
-		proto_sentry.MessageId_TRANSACTIONS_66:                  TransactionsMsg,
-		proto_sentry.MessageId_NEW_POOLED_TRANSACTION_HASHES_68: NewPooledTransactionHashesMsg,
-		proto_sentry.MessageId_GET_POOLED_TRANSACTIONS_66:       GetPooledTransactionsMsg,
-		proto_sentry.MessageId_POOLED_TRANSACTIONS_66:           PooledTransactionsMsg,
+		sentryproto.MessageId_GET_BLOCK_HEADERS_66:             GetBlockHeadersMsg,
+		sentryproto.MessageId_BLOCK_HEADERS_66:                 BlockHeadersMsg,
+		sentryproto.MessageId_GET_BLOCK_BODIES_66:              GetBlockBodiesMsg,
+		sentryproto.MessageId_BLOCK_BODIES_66:                  BlockBodiesMsg,
+		sentryproto.MessageId_GET_RECEIPTS_66:                  GetReceiptsMsg,
+		sentryproto.MessageId_RECEIPTS_66:                      ReceiptsMsg,
+		sentryproto.MessageId_NEW_BLOCK_HASHES_66:              NewBlockHashesMsg,
+		sentryproto.MessageId_NEW_BLOCK_66:                     NewBlockMsg,
+		sentryproto.MessageId_TRANSACTIONS_66:                  TransactionsMsg,
+		sentryproto.MessageId_NEW_POOLED_TRANSACTION_HASHES_68: NewPooledTransactionHashesMsg,
+		sentryproto.MessageId_GET_POOLED_TRANSACTIONS_66:       GetPooledTransactionsMsg,
+		sentryproto.MessageId_POOLED_TRANSACTIONS_66:           PooledTransactionsMsg,
 	},
 }
 

--- a/p2p/protocols/wit/protocol.go
+++ b/p2p/protocols/wit/protocol.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/erigontech/erigon-lib/common"
-	proto_sentry "github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon/core/stateless"
 	"github.com/erigontech/erigon/node/direct"
 )
@@ -121,20 +121,20 @@ func (w *NewWitnessPacket) Kind() byte   { return NewWitnessMsg }
 func (w *NewWitnessHashesPacket) Name() string { return "NewWitnessHashes" }
 func (w *NewWitnessHashesPacket) Kind() byte   { return NewWitnessHashesMsg }
 
-var ToProto = map[uint]map[uint64]proto_sentry.MessageId{
+var ToProto = map[uint]map[uint64]sentryproto.MessageId{
 	direct.WIT0: {
-		NewWitnessMsg:       proto_sentry.MessageId_NEW_WITNESS_W0,
-		NewWitnessHashesMsg: proto_sentry.MessageId_NEW_WITNESS_HASHES_W0,
-		GetWitnessMsg:       proto_sentry.MessageId_GET_BLOCK_WITNESS_W0,
-		WitnessMsg:          proto_sentry.MessageId_BLOCK_WITNESS_W0,
+		NewWitnessMsg:       sentryproto.MessageId_NEW_WITNESS_W0,
+		NewWitnessHashesMsg: sentryproto.MessageId_NEW_WITNESS_HASHES_W0,
+		GetWitnessMsg:       sentryproto.MessageId_GET_BLOCK_WITNESS_W0,
+		WitnessMsg:          sentryproto.MessageId_BLOCK_WITNESS_W0,
 	},
 }
 
-var FromProto = map[uint]map[proto_sentry.MessageId]uint64{
+var FromProto = map[uint]map[sentryproto.MessageId]uint64{
 	direct.WIT0: {
-		proto_sentry.MessageId_NEW_WITNESS_W0:        NewWitnessMsg,
-		proto_sentry.MessageId_NEW_WITNESS_HASHES_W0: NewWitnessHashesMsg,
-		proto_sentry.MessageId_GET_BLOCK_WITNESS_W0:  GetWitnessMsg,
-		proto_sentry.MessageId_BLOCK_WITNESS_W0:      WitnessMsg,
+		sentryproto.MessageId_NEW_WITNESS_W0:        NewWitnessMsg,
+		sentryproto.MessageId_NEW_WITNESS_HASHES_W0: NewWitnessHashesMsg,
+		sentryproto.MessageId_GET_BLOCK_WITNESS_W0:  GetWitnessMsg,
+		sentryproto.MessageId_BLOCK_WITNESS_W0:      WitnessMsg,
 	},
 }

--- a/p2p/sentry/eth_handshake.go
+++ b/p2p/sentry/eth_handshake.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	proto_sentry "github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon/p2p"
 	"github.com/erigontech/erigon/p2p/forkid"
 	"github.com/erigontech/erigon/p2p/protocols/eth"
@@ -28,7 +28,7 @@ import (
 
 func readAndValidatePeerStatusMessage(
 	rw p2p.MsgReadWriter,
-	status *proto_sentry.StatusData,
+	status *sentryproto.StatusData,
 	version uint,
 	minVersion uint,
 ) (*eth.StatusPacket, *p2p.PeerError) {
@@ -70,7 +70,7 @@ func tryDecodeStatusMessage(msg *p2p.Msg) (*eth.StatusPacket, error) {
 
 func checkPeerStatusCompatibility(
 	reply *eth.StatusPacket,
-	status *proto_sentry.StatusData,
+	status *sentryproto.StatusData,
 	version uint,
 	minVersion uint,
 ) error {

--- a/p2p/sentry/eth_handshake_test.go
+++ b/p2p/sentry/eth_handshake_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	proto_sentry "github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	chainspec "github.com/erigontech/erigon/execution/chain/spec"
 	"github.com/erigontech/erigon/node/direct"
 	"github.com/erigontech/erigon/p2p/forkid"
@@ -44,11 +44,11 @@ func TestCheckPeerStatusCompatibility(t *testing.T) {
 		Genesis:         chainspec.Mainnet.GenesisHash,
 		ForkID:          forkid.NewIDFromForks(heightForks, timeForks, chainspec.Mainnet.GenesisHash, 0, 0),
 	}
-	status := proto_sentry.StatusData{
+	status := sentryproto.StatusData{
 		NetworkId:       networkID,
 		TotalDifficulty: gointerfaces.ConvertUint256IntToH256(new(uint256.Int)),
 		BestHash:        nil,
-		ForkData: &proto_sentry.Forks{
+		ForkData: &sentryproto.Forks{
 			Genesis:     gointerfaces.ConvertHashToH256(chainspec.Mainnet.GenesisHash),
 			HeightForks: heightForks,
 			TimeForks:   timeForks,

--- a/p2p/sentry/sentry_grpc_server.go
+++ b/p2p/sentry/sentry_grpc_server.go
@@ -46,8 +46,8 @@ import (
 	"github.com/erigontech/erigon-lib/common/dir"
 	"github.com/erigontech/erigon-lib/gointerfaces"
 	"github.com/erigontech/erigon-lib/gointerfaces/grpcutil"
-	proto_sentry "github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
-	proto_types "github.com/erigontech/erigon-lib/gointerfaces/typesproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/diagnostics/diaglib"
@@ -285,7 +285,7 @@ func (pi *PeerInfo) AddKnownWitness(hash common.Hash) {
 
 // ConvertH512ToPeerID() ensures the return type is [64]byte
 // so that short variable declarations will still be formatted as hex in logs
-func ConvertH512ToPeerID(h512 *proto_types.H512) [64]byte {
+func ConvertH512ToPeerID(h512 *typesproto.H512) [64]byte {
 	return gointerfaces.ConvertH512ToHash(h512)
 }
 
@@ -312,7 +312,7 @@ func makeP2PServer(
 
 func handShake(
 	ctx context.Context,
-	status *proto_sentry.StatusData,
+	status *sentryproto.StatusData,
 	rw p2p.MsgReadWriter,
 	version uint,
 	minVersion uint,
@@ -381,8 +381,8 @@ func runPeer(
 	cap p2p.Cap,
 	rw p2p.MsgReadWriter,
 	peerInfo *PeerInfo,
-	send func(msgId proto_sentry.MessageId, peerID [64]byte, b []byte),
-	hasSubscribers func(msgId proto_sentry.MessageId) bool,
+	send func(msgId sentryproto.MessageId, peerID [64]byte, b []byte),
+	hasSubscribers func(msgId sentryproto.MessageId) bool,
 	logger log.Logger,
 ) *p2p.PeerError {
 	protocol := cap.Version
@@ -586,8 +586,8 @@ func runWitPeer(
 	peerID [64]byte,
 	rw p2p.MsgReadWriter,
 	peerInfo *PeerInfo,
-	send func(msgId proto_sentry.MessageId, peerID [64]byte, b []byte),
-	hasSubscribers func(msgId proto_sentry.MessageId) bool,
+	send func(msgId sentryproto.MessageId, peerID [64]byte, b []byte),
+	hasSubscribers func(msgId sentryproto.MessageId) bool,
 	getWitnessRequest func(hash common.Hash, peerID [64]byte) bool,
 	logger log.Logger,
 ) *p2p.PeerError {
@@ -714,7 +714,7 @@ func grpcSentryServer(ctx context.Context, sentryAddr string, ss *GrpcServer, he
 		return nil, fmt.Errorf("could not create Sentry P2P listener: %w, addr=%s", err, sentryAddr)
 	}
 	grpcServer := grpcutil.NewServer(100, nil)
-	proto_sentry.RegisterSentryServer(grpcServer, ss)
+	sentryproto.RegisterSentryServer(grpcServer, ss)
 	var healthServer *health.Server
 	if healthCheck {
 		healthServer = health.NewServer()
@@ -894,16 +894,16 @@ func Sentry(ctx context.Context, dirs datadir.Dirs, sentryAddr string, discovery
 }
 
 type GrpcServer struct {
-	proto_sentry.UnimplementedSentryServer
+	sentryproto.UnimplementedSentryServer
 	ctx                  context.Context
 	Protocols            []p2p.Protocol
 	goodPeersMu          sync.RWMutex
 	goodPeers            map[[64]byte]*PeerInfo
 	p2pServer            *p2p.Server
 	p2pServerLock        sync.RWMutex
-	statusData           *proto_sentry.StatusData
+	statusData           *sentryproto.StatusData
 	statusDataLock       sync.RWMutex
-	messageStreams       map[proto_sentry.MessageId]map[uint64]chan *proto_sentry.InboundMessage
+	messageStreams       map[sentryproto.MessageId]map[uint64]chan *sentryproto.InboundMessage
 	messagesSubscriberID uint64
 	messageStreamsLock   sync.RWMutex
 	peersStreams         *PeersStreams
@@ -1063,10 +1063,10 @@ func (ss *GrpcServer) getBlockHeaders(ctx context.Context, bestHash common.Hash,
 	if err != nil {
 		return fmt.Errorf("GrpcServer.getBlockHeaders encode packet failed: %w", err)
 	}
-	if _, err := ss.SendMessageById(ctx, &proto_sentry.SendMessageByIdRequest{
+	if _, err := ss.SendMessageById(ctx, &sentryproto.SendMessageByIdRequest{
 		PeerId: gointerfaces.ConvertHashToH512(peerID),
-		Data: &proto_sentry.OutboundMessageData{
-			Id:   proto_sentry.MessageId_GET_BLOCK_HEADERS_66,
+		Data: &sentryproto.OutboundMessageData{
+			Id:   sentryproto.MessageId_GET_BLOCK_HEADERS_66,
 			Data: b,
 		},
 	}); err != nil {
@@ -1075,7 +1075,7 @@ func (ss *GrpcServer) getBlockHeaders(ctx context.Context, bestHash common.Hash,
 	return nil
 }
 
-func (ss *GrpcServer) PenalizePeer(_ context.Context, req *proto_sentry.PenalizePeerRequest) (*emptypb.Empty, error) {
+func (ss *GrpcServer) PenalizePeer(_ context.Context, req *sentryproto.PenalizePeerRequest) (*emptypb.Empty, error) {
 	//log.Warn("Received penalty", "kind", req.GetPenalty().Descriptor().FullName, "from", fmt.Sprintf("%s", req.GetPeerId()))
 	peerID := ConvertH512ToPeerID(req.PeerId)
 	peerInfo := ss.getPeer(peerID)
@@ -1085,7 +1085,7 @@ func (ss *GrpcServer) PenalizePeer(_ context.Context, req *proto_sentry.Penalize
 	return &emptypb.Empty{}, nil
 }
 
-func (ss *GrpcServer) PeerMinBlock(_ context.Context, req *proto_sentry.PeerMinBlockRequest) (*emptypb.Empty, error) {
+func (ss *GrpcServer) PeerMinBlock(_ context.Context, req *sentryproto.PeerMinBlockRequest) (*emptypb.Empty, error) {
 	peerID := ConvertH512ToPeerID(req.PeerId)
 	if peerInfo := ss.getPeer(peerID); peerInfo != nil {
 		peerInfo.SetIncreasedHeight(req.MinBlock)
@@ -1152,8 +1152,8 @@ func (ss *GrpcServer) findPeerByMinBlock(minBlock uint64) (*PeerInfo, bool) {
 	return foundPeerInfo, maxPermits > 0
 }
 
-func (ss *GrpcServer) SendMessageByMinBlock(_ context.Context, inreq *proto_sentry.SendMessageByMinBlockRequest) (*proto_sentry.SentPeers, error) {
-	reply := &proto_sentry.SentPeers{}
+func (ss *GrpcServer) SendMessageByMinBlock(_ context.Context, inreq *sentryproto.SendMessageByMinBlockRequest) (*sentryproto.SentPeers, error) {
+	reply := &sentryproto.SentPeers{}
 	msgcode := eth.FromProto[ss.Protocols[0].Version][inreq.Data.Id]
 	if msgcode != eth.GetBlockHeadersMsg &&
 		msgcode != eth.GetBlockBodiesMsg &&
@@ -1164,12 +1164,12 @@ func (ss *GrpcServer) SendMessageByMinBlock(_ context.Context, inreq *proto_sent
 		peerInfo, found := ss.findPeerByMinBlock(inreq.MinBlock)
 		if found {
 			ss.writePeer("[sentry] sendMessageByMinBlock", peerInfo, msgcode, inreq.Data.Data, 30*time.Second)
-			reply.Peers = []*proto_types.H512{gointerfaces.ConvertHashToH512(peerInfo.ID())}
+			reply.Peers = []*typesproto.H512{gointerfaces.ConvertHashToH512(peerInfo.ID())}
 			return reply, nil
 		}
 	}
 	peerInfos := ss.findBestPeersWithPermit(int(inreq.MaxPeers))
-	reply.Peers = make([]*proto_types.H512, len(peerInfos))
+	reply.Peers = make([]*typesproto.H512, len(peerInfos))
 	for i, peerInfo := range peerInfos {
 		ss.writePeer("[sentry] sendMessageByMinBlock", peerInfo, msgcode, inreq.Data.Data, 15*time.Second)
 		reply.Peers[i] = gointerfaces.ConvertHashToH512(peerInfo.ID())
@@ -1177,8 +1177,8 @@ func (ss *GrpcServer) SendMessageByMinBlock(_ context.Context, inreq *proto_sent
 	return reply, nil
 }
 
-func (ss *GrpcServer) SendMessageById(_ context.Context, inreq *proto_sentry.SendMessageByIdRequest) (*proto_sentry.SentPeers, error) {
-	reply := &proto_sentry.SentPeers{}
+func (ss *GrpcServer) SendMessageById(_ context.Context, inreq *sentryproto.SendMessageByIdRequest) (*sentryproto.SentPeers, error) {
+	reply := &sentryproto.SentPeers{}
 
 	peerID := ConvertH512ToPeerID(inreq.PeerId)
 	peerInfo := ss.getPeer(peerID)
@@ -1194,11 +1194,11 @@ func (ss *GrpcServer) SendMessageById(_ context.Context, inreq *proto_sentry.Sen
 	}
 
 	ss.writePeer("[sentry] sendMessageById", peerInfo, msgcode, inreq.Data.Data, 0)
-	reply.Peers = []*proto_types.H512{inreq.PeerId}
+	reply.Peers = []*typesproto.H512{inreq.PeerId}
 	return reply, nil
 }
 
-func (ss *GrpcServer) messageCode(id proto_sentry.MessageId) (code uint64, protocolVersions mapset.Set[uint]) {
+func (ss *GrpcServer) messageCode(id sentryproto.MessageId) (code uint64, protocolVersions mapset.Set[uint]) {
 	protocolVersions = mapset.NewSet[uint]()
 	for i := 0; i < len(ss.Protocols); i++ {
 		version := ss.Protocols[i].Version
@@ -1210,7 +1210,7 @@ func (ss *GrpcServer) messageCode(id proto_sentry.MessageId) (code uint64, proto
 	return
 }
 
-func (ss *GrpcServer) protoMessageID(code uint64) (id proto_sentry.MessageId, protocolName string, protocolVersion uint) {
+func (ss *GrpcServer) protoMessageID(code uint64) (id sentryproto.MessageId, protocolName string, protocolVersion uint) {
 	for i := 0; i < len(ss.Protocols); i++ {
 		if val, ok := ss.Protocols[i].ToProto[code]; ok {
 			return val, ss.Protocols[i].Name, ss.Protocols[i].Version
@@ -1219,8 +1219,8 @@ func (ss *GrpcServer) protoMessageID(code uint64) (id proto_sentry.MessageId, pr
 	return
 }
 
-func (ss *GrpcServer) SendMessageToRandomPeers(ctx context.Context, req *proto_sentry.SendMessageToRandomPeersRequest) (*proto_sentry.SentPeers, error) {
-	reply := &proto_sentry.SentPeers{}
+func (ss *GrpcServer) SendMessageToRandomPeers(ctx context.Context, req *sentryproto.SendMessageToRandomPeersRequest) (*sentryproto.SentPeers, error) {
+	reply := &sentryproto.SentPeers{}
 
 	msgcode, protocolVersions := ss.messageCode(req.Data.Id)
 	if protocolVersions.Cardinality() == 0 ||
@@ -1258,8 +1258,8 @@ func (ss *GrpcServer) SendMessageToRandomPeers(ctx context.Context, req *proto_s
 	return reply, nil
 }
 
-func (ss *GrpcServer) SendMessageToAll(ctx context.Context, req *proto_sentry.OutboundMessageData) (*proto_sentry.SentPeers, error) {
-	reply := &proto_sentry.SentPeers{}
+func (ss *GrpcServer) SendMessageToAll(ctx context.Context, req *sentryproto.OutboundMessageData) (*sentryproto.SentPeers, error) {
+	reply := &sentryproto.SentPeers{}
 
 	msgcode, protocolVersions := ss.messageCode(req.Id)
 	if protocolVersions.Cardinality() == 0 ||
@@ -1280,13 +1280,13 @@ func (ss *GrpcServer) SendMessageToAll(ctx context.Context, req *proto_sentry.Ou
 	return reply, lastErr
 }
 
-func (ss *GrpcServer) HandShake(context.Context, *emptypb.Empty) (*proto_sentry.HandShakeReply, error) {
-	reply := &proto_sentry.HandShakeReply{}
+func (ss *GrpcServer) HandShake(context.Context, *emptypb.Empty) (*sentryproto.HandShakeReply, error) {
+	reply := &sentryproto.HandShakeReply{}
 	switch ss.Protocols[0].Version {
 	case direct.ETH67:
-		reply.Protocol = proto_sentry.Protocol_ETH67
+		reply.Protocol = sentryproto.Protocol_ETH67
 	case direct.ETH68:
-		reply.Protocol = proto_sentry.Protocol_ETH68
+		reply.Protocol = sentryproto.Protocol_ETH68
 	}
 	return reply, nil
 }
@@ -1332,10 +1332,10 @@ func (ss *GrpcServer) getP2PServer() *p2p.Server {
 	return ss.p2pServer
 }
 
-func (ss *GrpcServer) SetStatus(ctx context.Context, statusData *proto_sentry.StatusData) (*proto_sentry.SetStatusReply, error) {
+func (ss *GrpcServer) SetStatus(ctx context.Context, statusData *sentryproto.StatusData) (*sentryproto.SetStatusReply, error) {
 	genesisHash := gointerfaces.ConvertH256ToHash(statusData.ForkData.Genesis)
 
-	reply := &proto_sentry.SetStatusReply{}
+	reply := &sentryproto.SetStatusReply{}
 
 	ss.p2pServerLock.Lock()
 	defer ss.p2pServerLock.Unlock()
@@ -1358,7 +1358,7 @@ func (ss *GrpcServer) SetStatus(ctx context.Context, statusData *proto_sentry.St
 	return reply, nil
 }
 
-func (ss *GrpcServer) Peers(_ context.Context, _ *emptypb.Empty) (*proto_sentry.PeersReply, error) {
+func (ss *GrpcServer) Peers(_ context.Context, _ *emptypb.Empty) (*sentryproto.PeersReply, error) {
 	p2pServer := ss.getP2PServer()
 	if p2pServer == nil {
 		return nil, errors.New("p2p server was not started")
@@ -1366,11 +1366,11 @@ func (ss *GrpcServer) Peers(_ context.Context, _ *emptypb.Empty) (*proto_sentry.
 
 	peers := p2pServer.PeersInfo()
 
-	var reply proto_sentry.PeersReply
-	reply.Peers = make([]*proto_types.PeerInfo, 0, len(peers))
+	var reply sentryproto.PeersReply
+	reply.Peers = make([]*typesproto.PeerInfo, 0, len(peers))
 
 	for _, peer := range peers {
-		rpcPeer := proto_types.PeerInfo{
+		rpcPeer := typesproto.PeerInfo{
 			Id:             peer.ID,
 			Name:           peer.Name,
 			Enode:          peer.Enode,
@@ -1397,25 +1397,25 @@ func (ss *GrpcServer) SimplePeerCount() map[uint]int {
 	return counts
 }
 
-func (ss *GrpcServer) PeerCount(_ context.Context, req *proto_sentry.PeerCountRequest) (*proto_sentry.PeerCountReply, error) {
+func (ss *GrpcServer) PeerCount(_ context.Context, req *sentryproto.PeerCountRequest) (*sentryproto.PeerCountReply, error) {
 	counts := ss.SimplePeerCount()
-	reply := &proto_sentry.PeerCountReply{}
+	reply := &sentryproto.PeerCountReply{}
 	for protocol, count := range counts {
 		reply.Count += uint64(count)
-		reply.CountsPerProtocol = append(reply.CountsPerProtocol, &proto_sentry.PeerCountPerProtocol{Protocol: proto_sentry.Protocol(protocol), Count: uint64(count)})
+		reply.CountsPerProtocol = append(reply.CountsPerProtocol, &sentryproto.PeerCountPerProtocol{Protocol: sentryproto.Protocol(protocol), Count: uint64(count)})
 	}
 	return reply, nil
 }
 
-func (ss *GrpcServer) PeerById(_ context.Context, req *proto_sentry.PeerByIdRequest) (*proto_sentry.PeerByIdReply, error) {
+func (ss *GrpcServer) PeerById(_ context.Context, req *sentryproto.PeerByIdRequest) (*sentryproto.PeerByIdReply, error) {
 	peerID := ConvertH512ToPeerID(req.PeerId)
 
-	var rpcPeer *proto_types.PeerInfo
+	var rpcPeer *typesproto.PeerInfo
 	sentryPeer := ss.getPeer(peerID)
 
 	if sentryPeer != nil {
 		peer := sentryPeer.peer.Info()
-		rpcPeer = &proto_types.PeerInfo{
+		rpcPeer = &typesproto.PeerInfo{
 			Id:             peer.ID,
 			Name:           peer.Name,
 			Enode:          peer.Enode,
@@ -1429,7 +1429,7 @@ func (ss *GrpcServer) PeerById(_ context.Context, req *proto_sentry.PeerByIdRequ
 		}
 	}
 
-	return &proto_sentry.PeerByIdReply{Peer: rpcPeer}, nil
+	return &sentryproto.PeerByIdReply{Peer: rpcPeer}, nil
 }
 
 // setupDiscovery creates the node discovery source for the `eth` protocol.
@@ -1441,16 +1441,16 @@ func setupDiscovery(urls []string) (enode.Iterator, error) {
 	return client.NewIterator(urls...)
 }
 
-func (ss *GrpcServer) GetStatus() *proto_sentry.StatusData {
+func (ss *GrpcServer) GetStatus() *sentryproto.StatusData {
 	ss.statusDataLock.RLock()
 	defer ss.statusDataLock.RUnlock()
 	return ss.statusData
 }
 
-func (ss *GrpcServer) send(msgID proto_sentry.MessageId, peerID [64]byte, b []byte) {
+func (ss *GrpcServer) send(msgID sentryproto.MessageId, peerID [64]byte, b []byte) {
 	ss.messageStreamsLock.RLock()
 	defer ss.messageStreamsLock.RUnlock()
-	req := &proto_sentry.InboundMessage{
+	req := &sentryproto.InboundMessage{
 		PeerId: gointerfaces.ConvertHashToH512(peerID),
 		Id:     msgID,
 		Data:   b,
@@ -1471,25 +1471,25 @@ func (ss *GrpcServer) send(msgID proto_sentry.MessageId, peerID [64]byte, b []by
 	}
 }
 
-func (ss *GrpcServer) hasSubscribers(msgID proto_sentry.MessageId) bool {
+func (ss *GrpcServer) hasSubscribers(msgID sentryproto.MessageId) bool {
 	ss.messageStreamsLock.RLock()
 	defer ss.messageStreamsLock.RUnlock()
 	return ss.messageStreams[msgID] != nil && len(ss.messageStreams[msgID]) > 0
-	//	log.Error("Sending msg to core P2P failed", "msg", proto_sentry.MessageId_name[int32(streamMsg.msgId)], "err", err)
+	//	log.Error("Sending msg to core P2P failed", "msg", sentryproto.MessageId_name[int32(streamMsg.msgId)], "err", err)
 }
 
-func (ss *GrpcServer) addMessagesStream(ids []proto_sentry.MessageId, ch chan *proto_sentry.InboundMessage) func() {
+func (ss *GrpcServer) addMessagesStream(ids []sentryproto.MessageId, ch chan *sentryproto.InboundMessage) func() {
 	ss.messageStreamsLock.Lock()
 	defer ss.messageStreamsLock.Unlock()
 	if ss.messageStreams == nil {
-		ss.messageStreams = map[proto_sentry.MessageId]map[uint64]chan *proto_sentry.InboundMessage{}
+		ss.messageStreams = map[sentryproto.MessageId]map[uint64]chan *sentryproto.InboundMessage{}
 	}
 
 	ss.messagesSubscriberID++
 	for _, id := range ids {
 		m, ok := ss.messageStreams[id]
 		if !ok {
-			m = map[uint64]chan *proto_sentry.InboundMessage{}
+			m = map[uint64]chan *sentryproto.InboundMessage{}
 			ss.messageStreams[id] = m
 		}
 		m[ss.messagesSubscriberID] = ch
@@ -1506,9 +1506,9 @@ func (ss *GrpcServer) addMessagesStream(ids []proto_sentry.MessageId, ch chan *p
 }
 
 const MessagesQueueSize = 1024 // one such queue per client of .Messages stream
-func (ss *GrpcServer) Messages(req *proto_sentry.MessagesRequest, server proto_sentry.Sentry_MessagesServer) error {
+func (ss *GrpcServer) Messages(req *sentryproto.MessagesRequest, server sentryproto.Sentry_MessagesServer) error {
 	ss.logger.Trace("[Messages] new subscriber", "to", req.Ids)
-	ch := make(chan *proto_sentry.InboundMessage, MessagesQueueSize)
+	ch := make(chan *sentryproto.InboundMessage, MessagesQueueSize)
 	defer close(ch)
 	clean := ss.addMessagesStream(req.Ids, ch)
 	defer clean()
@@ -1536,28 +1536,28 @@ func (ss *GrpcServer) Close() {
 	}
 }
 
-func (ss *GrpcServer) sendNewPeerToClients(peerID *proto_types.H512) {
-	if err := ss.peersStreams.Broadcast(&proto_sentry.PeerEvent{PeerId: peerID, EventId: proto_sentry.PeerEvent_Connect}); err != nil {
+func (ss *GrpcServer) sendNewPeerToClients(peerID *typesproto.H512) {
+	if err := ss.peersStreams.Broadcast(&sentryproto.PeerEvent{PeerId: peerID, EventId: sentryproto.PeerEvent_Connect}); err != nil {
 		ss.logger.Warn("Sending new peer notice to core P2P failed", "err", err)
 	}
 }
 
-func (ss *GrpcServer) sendGonePeerToClients(peerID *proto_types.H512) {
-	if err := ss.peersStreams.Broadcast(&proto_sentry.PeerEvent{PeerId: peerID, EventId: proto_sentry.PeerEvent_Disconnect}); err != nil {
+func (ss *GrpcServer) sendGonePeerToClients(peerID *typesproto.H512) {
+	if err := ss.peersStreams.Broadcast(&sentryproto.PeerEvent{PeerId: peerID, EventId: sentryproto.PeerEvent_Disconnect}); err != nil {
 		ss.logger.Warn("Sending gone peer notice to core P2P failed", "err", err)
 	}
 }
 
-func (ss *GrpcServer) PeerEvents(req *proto_sentry.PeerEventsRequest, server proto_sentry.Sentry_PeerEventsServer) error {
+func (ss *GrpcServer) PeerEvents(req *sentryproto.PeerEventsRequest, server sentryproto.Sentry_PeerEventsServer) error {
 	clean := ss.peersStreams.Add(server)
 	defer clean()
 	// replay currently connected peers
 	eg, ctx := errgroup.WithContext(server.Context())
 	ss.rangePeers(func(peerInfo *PeerInfo) bool {
 		eg.Go(func() error {
-			return server.Send(&proto_sentry.PeerEvent{
+			return server.Send(&sentryproto.PeerEvent{
 				PeerId:  gointerfaces.ConvertHashToH512(peerInfo.ID()),
-				EventId: proto_sentry.PeerEvent_Connect,
+				EventId: sentryproto.PeerEvent_Connect,
 			})
 		})
 		select {
@@ -1578,7 +1578,7 @@ func (ss *GrpcServer) PeerEvents(req *proto_sentry.PeerEventsRequest, server pro
 	}
 }
 
-func (ss *GrpcServer) AddPeer(_ context.Context, req *proto_sentry.AddPeerRequest) (*proto_sentry.AddPeerReply, error) {
+func (ss *GrpcServer) AddPeer(_ context.Context, req *sentryproto.AddPeerRequest) (*sentryproto.AddPeerReply, error) {
 	node, err := enode.Parse(enode.ValidSchemes, req.Url)
 	if err != nil {
 		return nil, err
@@ -1590,10 +1590,10 @@ func (ss *GrpcServer) AddPeer(_ context.Context, req *proto_sentry.AddPeerReques
 	}
 	p2pServer.AddPeer(node)
 
-	return &proto_sentry.AddPeerReply{Success: true}, nil
+	return &sentryproto.AddPeerReply{Success: true}, nil
 }
 
-func (ss *GrpcServer) RemovePeer(_ context.Context, req *proto_sentry.RemovePeerRequest) (*proto_sentry.RemovePeerReply, error) {
+func (ss *GrpcServer) RemovePeer(_ context.Context, req *sentryproto.RemovePeerRequest) (*sentryproto.RemovePeerReply, error) {
 	node, err := enode.Parse(enode.ValidSchemes, req.Url)
 	if err != nil {
 		return nil, err
@@ -1605,22 +1605,22 @@ func (ss *GrpcServer) RemovePeer(_ context.Context, req *proto_sentry.RemovePeer
 	}
 	p2pServer.RemovePeer(node)
 
-	return &proto_sentry.RemovePeerReply{Success: true}, nil
+	return &sentryproto.RemovePeerReply{Success: true}, nil
 }
 
-func (ss *GrpcServer) NodeInfo(_ context.Context, _ *emptypb.Empty) (*proto_types.NodeInfoReply, error) {
+func (ss *GrpcServer) NodeInfo(_ context.Context, _ *emptypb.Empty) (*typesproto.NodeInfoReply, error) {
 	p2pServer := ss.getP2PServer()
 	if p2pServer == nil {
 		return nil, errors.New("p2p server was not started")
 	}
 
 	info := p2pServer.NodeInfo()
-	ret := &proto_types.NodeInfoReply{
+	ret := &typesproto.NodeInfoReply{
 		Id:    info.ID,
 		Name:  info.Name,
 		Enode: info.Enode,
 		Enr:   info.ENR,
-		Ports: &proto_types.NodeInfoPorts{
+		Ports: &typesproto.NodeInfoPorts{
 			Discovery: uint32(info.Ports.Discovery),
 			Listener:  uint32(info.Ports.Listener),
 		},
@@ -1640,18 +1640,18 @@ func (ss *GrpcServer) NodeInfo(_ context.Context, _ *emptypb.Empty) (*proto_type
 type PeersStreams struct {
 	mu      sync.RWMutex
 	id      uint
-	streams map[uint]proto_sentry.Sentry_PeerEventsServer
+	streams map[uint]sentryproto.Sentry_PeerEventsServer
 }
 
 func NewPeersStreams() *PeersStreams {
 	return &PeersStreams{}
 }
 
-func (s *PeersStreams) Add(stream proto_sentry.Sentry_PeerEventsServer) (remove func()) {
+func (s *PeersStreams) Add(stream sentryproto.Sentry_PeerEventsServer) (remove func()) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.streams == nil {
-		s.streams = make(map[uint]proto_sentry.Sentry_PeerEventsServer)
+		s.streams = make(map[uint]sentryproto.Sentry_PeerEventsServer)
 	}
 	s.id++
 	id := s.id
@@ -1659,7 +1659,7 @@ func (s *PeersStreams) Add(stream proto_sentry.Sentry_PeerEventsServer) (remove 
 	return func() { s.remove(id) }
 }
 
-func (s *PeersStreams) doBroadcast(reply *proto_sentry.PeerEvent) (ids []uint, errs []error) {
+func (s *PeersStreams) doBroadcast(reply *sentryproto.PeerEvent) (ids []uint, errs []error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	for id, stream := range s.streams {
@@ -1676,7 +1676,7 @@ func (s *PeersStreams) doBroadcast(reply *proto_sentry.PeerEvent) (ids []uint, e
 	return
 }
 
-func (s *PeersStreams) Broadcast(reply *proto_sentry.PeerEvent) (errs []error) {
+func (s *PeersStreams) Broadcast(reply *sentryproto.PeerEvent) (errs []error) {
 	var ids []uint
 	ids, errs = s.doBroadcast(reply)
 	if len(ids) > 0 {

--- a/p2p/sentry/sentry_grpc_server_test.go
+++ b/p2p/sentry/sentry_grpc_server_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	proto_sentry "github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/core/genesiswrite"
 	"github.com/erigontech/erigon/db/datadir"
@@ -55,13 +55,13 @@ func testSentryServer(db kv.Getter, genesis *types.Genesis, genesisHash common.H
 	headTd256 := new(uint256.Int)
 	headTd256.SetFromBig(headTd)
 	heightForks, timeForks := forkid.GatherForks(genesis.Config, genesis.Timestamp)
-	s.statusData = &proto_sentry.StatusData{
+	s.statusData = &sentryproto.StatusData{
 		NetworkId:       1,
 		TotalDifficulty: gointerfaces.ConvertUint256IntToH256(headTd256),
 		BestHash:        gointerfaces.ConvertHashToH256(head.Hash()),
 		MaxBlockHeight:  head.Number.Uint64(),
 		MaxBlockTime:    head.Time,
-		ForkData: &proto_sentry.Forks{
+		ForkData: &sentryproto.Forks{
 			Genesis:     gointerfaces.ConvertHashToH256(genesisHash),
 			HeightForks: heightForks,
 			TimeForks:   timeForks,
@@ -73,7 +73,7 @@ func testSentryServer(db kv.Getter, genesis *types.Genesis, genesisHash common.H
 
 func startHandshake(
 	ctx context.Context,
-	status *proto_sentry.StatusData,
+	status *sentryproto.StatusData,
 	pipe *p2p.MsgPipeRW,
 	protocolVersion uint,
 	errChan chan *p2p.PeerError,
@@ -197,16 +197,16 @@ func TestSentryServerImpl_SetStatusInitPanic(t *testing.T) {
 	genesisNoFork := genesiswrite.MustCommitGenesis(gspecNoFork, dbNoFork, datadir.New(t.TempDir()), log.Root())
 	ss := &GrpcServer{p2p: &p2p.Config{}}
 
-	_, err := ss.SetStatus(context.Background(), &proto_sentry.StatusData{
-		ForkData: &proto_sentry.Forks{Genesis: gointerfaces.ConvertHashToH256(genesisNoFork.Hash())},
+	_, err := ss.SetStatus(context.Background(), &sentryproto.StatusData{
+		ForkData: &sentryproto.Forks{Genesis: gointerfaces.ConvertHashToH256(genesisNoFork.Hash())},
 	})
 	if err == nil {
 		t.Fatalf("error expected")
 	}
 
 	// Should not panic here.
-	_, err = ss.SetStatus(context.Background(), &proto_sentry.StatusData{
-		ForkData: &proto_sentry.Forks{Genesis: gointerfaces.ConvertHashToH256(genesisNoFork.Hash())},
+	_, err = ss.SetStatus(context.Background(), &sentryproto.StatusData{
+		ForkData: &sentryproto.Forks{Genesis: gointerfaces.ConvertHashToH256(genesisNoFork.Hash())},
 	})
 	if err == nil {
 		t.Fatalf("error expected")

--- a/p2p/sentry/sentry_multi_client/broadcast.go
+++ b/p2p/sentry/sentry_multi_client/broadcast.go
@@ -24,7 +24,7 @@ import (
 
 	"google.golang.org/grpc"
 
-	proto_sentry "github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/execution/rlp"
 	"github.com/erigontech/erigon/execution/stages/headerdownload"
@@ -47,8 +47,8 @@ func (cs *MultiClient) PropagateNewBlockHashes(ctx context.Context, announces []
 		return
 	}
 
-	req66 := proto_sentry.OutboundMessageData{
-		Id:   proto_sentry.MessageId_NEW_BLOCK_HASHES_66,
+	req66 := sentryproto.OutboundMessageData{
+		Id:   sentryproto.MessageId_NEW_BLOCK_HASHES_66,
 		Data: data,
 	}
 
@@ -81,10 +81,10 @@ func (cs *MultiClient) BroadcastNewBlock(ctx context.Context, header *types.Head
 		return
 	}
 
-	req66 := proto_sentry.SendMessageToRandomPeersRequest{
+	req66 := sentryproto.SendMessageToRandomPeersRequest{
 		MaxPeers: uint64(cs.maxBlockBroadcastPeers(header)),
-		Data: &proto_sentry.OutboundMessageData{
-			Id:   proto_sentry.MessageId_NEW_BLOCK_66,
+		Data: &sentryproto.OutboundMessageData{
+			Id:   sentryproto.MessageId_NEW_BLOCK_66,
 			Data: data,
 		},
 	}

--- a/p2p/sentry/sentry_multi_client/sentry_api.go
+++ b/p2p/sentry/sentry_multi_client/sentry_api.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	proto_sentry "github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/execution/rlp"
 	"github.com/erigontech/erigon/execution/stages/bodydownload"
@@ -73,10 +73,10 @@ func (cs *MultiClient) SendBodyRequest(ctx context.Context, req *bodydownload.Bo
 			cs.logger.Error("Could not encode block bodies request", "err", err)
 			return [64]byte{}, false
 		}
-		outreq := proto_sentry.SendMessageByMinBlockRequest{
+		outreq := sentryproto.SendMessageByMinBlockRequest{
 			MinBlock: req.BlockNums[len(req.BlockNums)-1],
-			Data: &proto_sentry.OutboundMessageData{
-				Id:   proto_sentry.MessageId_GET_BLOCK_BODIES_66,
+			Data: &sentryproto.OutboundMessageData{
+				Id:   sentryproto.MessageId_GET_BLOCK_BODIES_66,
 				Data: bytes,
 			},
 			MaxPeers: 1,
@@ -147,10 +147,10 @@ func (cs *MultiClient) SendHeaderRequest(ctx context.Context, req *headerdownloa
 		}
 		minBlock := req.Number
 
-		outreq := proto_sentry.SendMessageByMinBlockRequest{
+		outreq := sentryproto.SendMessageByMinBlockRequest{
 			MinBlock: minBlock,
-			Data: &proto_sentry.OutboundMessageData{
-				Id:   proto_sentry.MessageId_GET_BLOCK_HEADERS_66,
+			Data: &sentryproto.OutboundMessageData{
+				Id:   sentryproto.MessageId_GET_BLOCK_HEADERS_66,
 				Data: bytes,
 			},
 			MaxPeers: 5,
@@ -205,9 +205,9 @@ func (cs *MultiClient) randSentryIndex() (int, bool, func() (int, bool)) {
 // sending list of penalties to all sentries
 func (cs *MultiClient) Penalize(ctx context.Context, penalties []headerdownload.PenaltyItem) {
 	for i := range penalties {
-		outreq := proto_sentry.PenalizePeerRequest{
+		outreq := sentryproto.PenalizePeerRequest{
 			PeerId:  gointerfaces.ConvertHashToH512(penalties[i].PeerID),
-			Penalty: proto_sentry.PenaltyKind_Kick, // TODO: Extend penalty kinds
+			Penalty: sentryproto.PenaltyKind_Kick, // TODO: Extend penalty kinds
 		}
 		for i, ok, next := cs.randSentryIndex(); ok; i, ok = next() {
 			if ready, ok := cs.sentries[i].(interface{ Ready() bool }); ok && !ready.Ready() {

--- a/p2p/sentry/sentry_multi_client/sentry_multi_client.go
+++ b/p2p/sentry/sentry_multi_client/sentry_multi_client.go
@@ -38,8 +38,8 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/dbg"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	proto_sentry "github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
-	proto_types "github.com/erigontech/erigon-lib/gointerfaces/typesproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/dbutils"
@@ -79,16 +79,16 @@ func (cs *MultiClient) StartStreamLoops(ctx context.Context) {
 
 func (cs *MultiClient) RecvUploadMessageLoop(
 	ctx context.Context,
-	sentry proto_sentry.SentryClient,
+	sentry sentryproto.SentryClient,
 	wg *sync.WaitGroup,
 ) {
-	ids := []proto_sentry.MessageId{
+	ids := []sentryproto.MessageId{
 		eth.ToProto[direct.ETH67][eth.GetBlockBodiesMsg],
 		eth.ToProto[direct.ETH67][eth.GetReceiptsMsg],
 		wit.ToProto[direct.WIT0][wit.GetWitnessMsg],
 	}
-	streamFactory := func(streamCtx context.Context, sentry proto_sentry.SentryClient) (grpc.ClientStream, error) {
-		return sentry.Messages(streamCtx, &proto_sentry.MessagesRequest{Ids: ids}, grpc.WaitForReady(true))
+	streamFactory := func(streamCtx context.Context, sentry sentryproto.SentryClient) (grpc.ClientStream, error) {
+		return sentry.Messages(streamCtx, &sentryproto.MessagesRequest{Ids: ids}, grpc.WaitForReady(true))
 	}
 
 	libsentry.ReconnectAndPumpStreamLoop(ctx, sentry, cs.makeStatusData, "RecvUploadMessage", streamFactory, MakeInboundMessage, cs.HandleInboundMessage, wg, cs.logger)
@@ -96,14 +96,14 @@ func (cs *MultiClient) RecvUploadMessageLoop(
 
 func (cs *MultiClient) RecvUploadHeadersMessageLoop(
 	ctx context.Context,
-	sentry proto_sentry.SentryClient,
+	sentry sentryproto.SentryClient,
 	wg *sync.WaitGroup,
 ) {
-	ids := []proto_sentry.MessageId{
+	ids := []sentryproto.MessageId{
 		eth.ToProto[direct.ETH67][eth.GetBlockHeadersMsg],
 	}
-	streamFactory := func(streamCtx context.Context, sentry proto_sentry.SentryClient) (grpc.ClientStream, error) {
-		return sentry.Messages(streamCtx, &proto_sentry.MessagesRequest{Ids: ids}, grpc.WaitForReady(true))
+	streamFactory := func(streamCtx context.Context, sentry sentryproto.SentryClient) (grpc.ClientStream, error) {
+		return sentry.Messages(streamCtx, &sentryproto.MessagesRequest{Ids: ids}, grpc.WaitForReady(true))
 	}
 
 	libsentry.ReconnectAndPumpStreamLoop(ctx, sentry, cs.makeStatusData, "RecvUploadHeadersMessage", streamFactory, MakeInboundMessage, cs.HandleInboundMessage, wg, cs.logger)
@@ -111,10 +111,10 @@ func (cs *MultiClient) RecvUploadHeadersMessageLoop(
 
 func (cs *MultiClient) RecvMessageLoop(
 	ctx context.Context,
-	sentry proto_sentry.SentryClient,
+	sentry sentryproto.SentryClient,
 	wg *sync.WaitGroup,
 ) {
-	ids := []proto_sentry.MessageId{
+	ids := []sentryproto.MessageId{
 		eth.ToProto[direct.ETH67][eth.BlockHeadersMsg],
 		eth.ToProto[direct.ETH67][eth.BlockBodiesMsg],
 		eth.ToProto[direct.ETH67][eth.NewBlockHashesMsg],
@@ -122,8 +122,8 @@ func (cs *MultiClient) RecvMessageLoop(
 		wit.ToProto[direct.WIT0][wit.NewWitnessMsg],
 		wit.ToProto[direct.WIT0][wit.WitnessMsg],
 	}
-	streamFactory := func(streamCtx context.Context, sentry proto_sentry.SentryClient) (grpc.ClientStream, error) {
-		return sentry.Messages(streamCtx, &proto_sentry.MessagesRequest{Ids: ids}, grpc.WaitForReady(true))
+	streamFactory := func(streamCtx context.Context, sentry sentryproto.SentryClient) (grpc.ClientStream, error) {
+		return sentry.Messages(streamCtx, &sentryproto.MessagesRequest{Ids: ids}, grpc.WaitForReady(true))
 	}
 
 	libsentry.ReconnectAndPumpStreamLoop(ctx, sentry, cs.makeStatusData, "RecvMessage", streamFactory, MakeInboundMessage, cs.HandleInboundMessage, wg, cs.logger)
@@ -131,14 +131,14 @@ func (cs *MultiClient) RecvMessageLoop(
 
 func (cs *MultiClient) PeerEventsLoop(
 	ctx context.Context,
-	sentry proto_sentry.SentryClient,
+	sentry sentryproto.SentryClient,
 	wg *sync.WaitGroup,
 ) {
-	streamFactory := func(streamCtx context.Context, sentry proto_sentry.SentryClient) (grpc.ClientStream, error) {
-		return sentry.PeerEvents(streamCtx, &proto_sentry.PeerEventsRequest{}, grpc.WaitForReady(true))
+	streamFactory := func(streamCtx context.Context, sentry sentryproto.SentryClient) (grpc.ClientStream, error) {
+		return sentry.PeerEvents(streamCtx, &sentryproto.PeerEventsRequest{}, grpc.WaitForReady(true))
 	}
-	messageFactory := func() *proto_sentry.PeerEvent {
-		return new(proto_sentry.PeerEvent)
+	messageFactory := func() *sentryproto.PeerEvent {
+		return new(sentryproto.PeerEvent)
 	}
 
 	libsentry.ReconnectAndPumpStreamLoop(ctx, sentry, cs.makeStatusData, "PeerEvents", streamFactory, messageFactory, cs.HandlePeerEvent, wg, cs.logger)
@@ -150,7 +150,7 @@ type MultiClient struct {
 	Hd                                *headerdownload.HeaderDownload
 	Bd                                *bodydownload.BodyDownload
 	IsMock                            bool
-	sentries                          []proto_sentry.SentryClient
+	sentries                          []sentryproto.SentryClient
 	ChainConfig                       *chain.Config
 	db                                kv.TemporalRoDB
 	WitnessBuffer                     *stagedsync.WitnessBuffer
@@ -176,7 +176,7 @@ func NewMultiClient(
 	db kv.TemporalRoDB,
 	chainConfig *chain.Config,
 	engine consensus.Engine,
-	sentries []proto_sentry.SentryClient,
+	sentries []sentryproto.SentryClient,
 	syncCfg ethconfig.Sync,
 	blockReader services.FullBlockReader,
 	blockBufferSize int,
@@ -248,9 +248,9 @@ func NewMultiClient(
 	return cs, nil
 }
 
-func (cs *MultiClient) Sentries() []proto_sentry.SentryClient { return cs.sentries }
+func (cs *MultiClient) Sentries() []sentryproto.SentryClient { return cs.sentries }
 
-func (cs *MultiClient) newBlockHashes66(ctx context.Context, req *proto_sentry.InboundMessage, sentry proto_sentry.SentryClient) error {
+func (cs *MultiClient) newBlockHashes66(ctx context.Context, req *sentryproto.InboundMessage, sentry sentryproto.SentryClient) error {
 	if cs.disableBlockDownload {
 		return nil
 	}
@@ -281,10 +281,10 @@ func (cs *MultiClient) newBlockHashes66(ctx context.Context, req *proto_sentry.I
 		if err != nil {
 			return fmt.Errorf("encode header request: %w", err)
 		}
-		outreq := proto_sentry.SendMessageByIdRequest{
+		outreq := sentryproto.SendMessageByIdRequest{
 			PeerId: req.PeerId,
-			Data: &proto_sentry.OutboundMessageData{
-				Id:   proto_sentry.MessageId_GET_BLOCK_HEADERS_66,
+			Data: &sentryproto.OutboundMessageData{
+				Id:   sentryproto.MessageId_GET_BLOCK_HEADERS_66,
 				Data: b,
 			},
 		}
@@ -299,7 +299,7 @@ func (cs *MultiClient) newBlockHashes66(ctx context.Context, req *proto_sentry.I
 	return nil
 }
 
-func (cs *MultiClient) blockHeaders66(ctx context.Context, in *proto_sentry.InboundMessage, sentry proto_sentry.SentryClient) error {
+func (cs *MultiClient) blockHeaders66(ctx context.Context, in *sentryproto.InboundMessage, sentry sentryproto.SentryClient) error {
 	// Parse the entire packet from scratch
 	var pkt eth.BlockHeadersPacket66
 	if err := rlp.DecodeBytes(in.Data, &pkt); err != nil {
@@ -319,7 +319,7 @@ func (cs *MultiClient) blockHeaders66(ctx context.Context, in *proto_sentry.Inbo
 	return cs.blockHeaders(ctx, pkt.BlockHeadersPacket, rlpStream, in.PeerId, sentry)
 }
 
-func (cs *MultiClient) blockHeaders(ctx context.Context, pkt eth.BlockHeadersPacket, rlpStream *rlp.Stream, peerID *proto_types.H512, sentryClient proto_sentry.SentryClient) error {
+func (cs *MultiClient) blockHeaders(ctx context.Context, pkt eth.BlockHeadersPacket, rlpStream *rlp.Stream, peerID *typesproto.H512, sentryClient sentryproto.SentryClient) error {
 	if cs.disableBlockDownload {
 		return nil
 	}
@@ -388,7 +388,7 @@ func (cs *MultiClient) blockHeaders(ctx context.Context, pkt eth.BlockHeadersPac
 			}
 		}
 	}
-	outreq := proto_sentry.PeerMinBlockRequest{
+	outreq := sentryproto.PeerMinBlockRequest{
 		PeerId:   peerID,
 		MinBlock: highestBlock,
 	}
@@ -398,7 +398,7 @@ func (cs *MultiClient) blockHeaders(ctx context.Context, pkt eth.BlockHeadersPac
 	return nil
 }
 
-func (cs *MultiClient) newBlock66(ctx context.Context, inreq *proto_sentry.InboundMessage, sentryClient proto_sentry.SentryClient) error {
+func (cs *MultiClient) newBlock66(ctx context.Context, inreq *sentryproto.InboundMessage, sentryClient sentryproto.SentryClient) error {
 	if cs.disableBlockDownload {
 		return nil
 	}
@@ -448,9 +448,9 @@ func (cs *MultiClient) newBlock66(ctx context.Context, inreq *proto_sentry.Inbou
 
 			cs.Hd.ProcessHeaders(segments, true /* newBlock */, sentry.ConvertH512ToPeerID(inreq.PeerId)) // There is only one segment in this case
 		} else {
-			outreq := proto_sentry.PenalizePeerRequest{
+			outreq := sentryproto.PenalizePeerRequest{
 				PeerId:  inreq.PeerId,
-				Penalty: proto_sentry.PenaltyKind_Kick, // TODO: Extend penalty kinds
+				Penalty: sentryproto.PenaltyKind_Kick, // TODO: Extend penalty kinds
 			}
 			for _, sentry := range cs.sentries {
 				// TODO does this method need to be moved to the grpc api ?
@@ -466,7 +466,7 @@ func (cs *MultiClient) newBlock66(ctx context.Context, inreq *proto_sentry.Inbou
 		return fmt.Errorf("singleHeaderAsSegment failed: %w", err)
 	}
 	cs.Bd.AddToPrefetch(request.Block.Header(), request.Block.RawBody())
-	outreq := proto_sentry.PeerMinBlockRequest{
+	outreq := sentryproto.PeerMinBlockRequest{
 		PeerId:   inreq.PeerId,
 		MinBlock: request.Block.NumberU64(),
 	}
@@ -477,7 +477,7 @@ func (cs *MultiClient) newBlock66(ctx context.Context, inreq *proto_sentry.Inbou
 	return nil
 }
 
-func (cs *MultiClient) blockBodies66(ctx context.Context, inreq *proto_sentry.InboundMessage, sentryClient proto_sentry.SentryClient) error {
+func (cs *MultiClient) blockBodies66(ctx context.Context, inreq *sentryproto.InboundMessage, sentryClient sentryproto.SentryClient) error {
 	if cs.disableBlockDownload {
 		return nil
 	}
@@ -495,11 +495,11 @@ func (cs *MultiClient) blockBodies66(ctx context.Context, inreq *proto_sentry.In
 	return nil
 }
 
-func (cs *MultiClient) receipts66(_ context.Context, _ *proto_sentry.InboundMessage, _ proto_sentry.SentryClient) error {
+func (cs *MultiClient) receipts66(_ context.Context, _ *sentryproto.InboundMessage, _ sentryproto.SentryClient) error {
 	return nil
 }
 
-func (cs *MultiClient) getBlockHeaders66(ctx context.Context, inreq *proto_sentry.InboundMessage, sentry proto_sentry.SentryClient) error {
+func (cs *MultiClient) getBlockHeaders66(ctx context.Context, inreq *sentryproto.InboundMessage, sentry sentryproto.SentryClient) error {
 	var query eth.GetBlockHeadersPacket66
 	if err := rlp.DecodeBytes(inreq.Data, &query); err != nil {
 		return fmt.Errorf("decoding getBlockHeaders66: %w, data: %x", err, inreq.Data)
@@ -529,10 +529,10 @@ func (cs *MultiClient) getBlockHeaders66(ctx context.Context, inreq *proto_sentr
 	if err != nil {
 		return fmt.Errorf("encode header response: %w", err)
 	}
-	outreq := proto_sentry.SendMessageByIdRequest{
+	outreq := sentryproto.SendMessageByIdRequest{
 		PeerId: inreq.PeerId,
-		Data: &proto_sentry.OutboundMessageData{
-			Id:   proto_sentry.MessageId_BLOCK_HEADERS_66,
+		Data: &sentryproto.OutboundMessageData{
+			Id:   sentryproto.MessageId_BLOCK_HEADERS_66,
 			Data: b,
 		},
 	}
@@ -547,7 +547,7 @@ func (cs *MultiClient) getBlockHeaders66(ctx context.Context, inreq *proto_sentr
 	return nil
 }
 
-func (cs *MultiClient) getBlockBodies66(ctx context.Context, inreq *proto_sentry.InboundMessage, sentry proto_sentry.SentryClient) error {
+func (cs *MultiClient) getBlockBodies66(ctx context.Context, inreq *sentryproto.InboundMessage, sentry sentryproto.SentryClient) error {
 	var query eth.GetBlockBodiesPacket66
 	if err := rlp.DecodeBytes(inreq.Data, &query); err != nil {
 		return fmt.Errorf("decoding getBlockBodies66: %w, data: %x", err, inreq.Data)
@@ -566,10 +566,10 @@ func (cs *MultiClient) getBlockBodies66(ctx context.Context, inreq *proto_sentry
 	if err != nil {
 		return fmt.Errorf("encode header response: %w", err)
 	}
-	outreq := proto_sentry.SendMessageByIdRequest{
+	outreq := sentryproto.SendMessageByIdRequest{
 		PeerId: inreq.PeerId,
-		Data: &proto_sentry.OutboundMessageData{
-			Id:   proto_sentry.MessageId_BLOCK_BODIES_66,
+		Data: &sentryproto.OutboundMessageData{
+			Id:   sentryproto.MessageId_BLOCK_BODIES_66,
 			Data: b,
 		},
 	}
@@ -584,7 +584,7 @@ func (cs *MultiClient) getBlockBodies66(ctx context.Context, inreq *proto_sentry
 	return nil
 }
 
-func (cs *MultiClient) getReceipts66(ctx context.Context, inreq *proto_sentry.InboundMessage, sentryClient proto_sentry.SentryClient) error {
+func (cs *MultiClient) getReceipts66(ctx context.Context, inreq *sentryproto.InboundMessage, sentryClient sentryproto.SentryClient) error {
 	var query eth.GetReceiptsPacket66
 	if err := rlp.DecodeBytes(inreq.Data, &query); err != nil {
 		return fmt.Errorf("decoding getReceipts66: %w, data: %x", err, inreq.Data)
@@ -622,10 +622,10 @@ func (cs *MultiClient) getReceipts66(ctx context.Context, inreq *proto_sentry.In
 	if err != nil {
 		return fmt.Errorf("encode header response: %w", err)
 	}
-	outreq := proto_sentry.SendMessageByIdRequest{
+	outreq := sentryproto.SendMessageByIdRequest{
 		PeerId: inreq.PeerId,
-		Data: &proto_sentry.OutboundMessageData{
-			Id:   proto_sentry.MessageId_RECEIPTS_66,
+		Data: &sentryproto.OutboundMessageData{
+			Id:   sentryproto.MessageId_RECEIPTS_66,
 			Data: b,
 		},
 	}
@@ -639,7 +639,7 @@ func (cs *MultiClient) getReceipts66(ctx context.Context, inreq *proto_sentry.In
 	return nil
 }
 
-func (cs *MultiClient) getBlockWitnesses(ctx context.Context, inreq *proto_sentry.InboundMessage, sentryClient proto_sentry.SentryClient) error {
+func (cs *MultiClient) getBlockWitnesses(ctx context.Context, inreq *sentryproto.InboundMessage, sentryClient sentryproto.SentryClient) error {
 	var req wit.GetWitnessPacket
 	if err := rlp.DecodeBytes(inreq.Data, &req); err != nil {
 		return fmt.Errorf("decoding GetWitnessPacket: %w, data: %x", err, inreq.Data)
@@ -745,10 +745,10 @@ func (cs *MultiClient) getBlockWitnesses(ctx context.Context, inreq *proto_sentr
 		return fmt.Errorf("encoding witness response: %w", err)
 	}
 
-	outreq := proto_sentry.SendMessageByIdRequest{
+	outreq := sentryproto.SendMessageByIdRequest{
 		PeerId: inreq.PeerId,
-		Data: &proto_sentry.OutboundMessageData{
-			Id:   proto_sentry.MessageId_BLOCK_WITNESS_W0,
+		Data: &sentryproto.OutboundMessageData{
+			Id:   sentryproto.MessageId_BLOCK_WITNESS_W0,
 			Data: b,
 		},
 	}
@@ -760,7 +760,7 @@ func (cs *MultiClient) getBlockWitnesses(ctx context.Context, inreq *proto_sentr
 }
 
 // addBlockWitnesses processes response to our getBlockWitnesses request
-func (cs *MultiClient) addBlockWitnesses(ctx context.Context, inreq *proto_sentry.InboundMessage, sentryClient proto_sentry.SentryClient) error {
+func (cs *MultiClient) addBlockWitnesses(ctx context.Context, inreq *sentryproto.InboundMessage, sentryClient sentryproto.SentryClient) error {
 	if cs.WitnessBuffer == nil {
 		return nil
 	}
@@ -825,10 +825,10 @@ func (cs *MultiClient) addBlockWitnesses(ctx context.Context, inreq *proto_sentr
 				}
 
 				// send request for missing pages to the same peer
-				request := &proto_sentry.SendMessageByIdRequest{
+				request := &sentryproto.SendMessageByIdRequest{
 					PeerId: inreq.PeerId,
-					Data: &proto_sentry.OutboundMessageData{
-						Id:   proto_sentry.MessageId_GET_BLOCK_WITNESS_W0,
+					Data: &sentryproto.OutboundMessageData{
+						Id:   sentryproto.MessageId_GET_BLOCK_WITNESS_W0,
 						Data: data,
 					},
 				}
@@ -838,9 +838,9 @@ func (cs *MultiClient) addBlockWitnesses(ctx context.Context, inreq *proto_sentr
 					// TODO: instead of sending to random peers, add new function to send to peers known to have witness
 					cs.logger.Info("failed to send GetWitnessMsg to original peer, trying random peers", "err", err, "hash", witnessHash)
 
-					fallbackRequest := &proto_sentry.SendMessageToRandomPeersRequest{
-						Data: &proto_sentry.OutboundMessageData{
-							Id:   proto_sentry.MessageId_GET_BLOCK_WITNESS_W0,
+					fallbackRequest := &sentryproto.SendMessageToRandomPeersRequest{
+						Data: &sentryproto.OutboundMessageData{
+							Id:   sentryproto.MessageId_GET_BLOCK_WITNESS_W0,
 							Data: data,
 						},
 						MaxPeers: 1,
@@ -886,7 +886,7 @@ func (cs *MultiClient) addBlockWitnesses(ctx context.Context, inreq *proto_sentr
 	return nil
 }
 
-func (cs *MultiClient) newWitness(ctx context.Context, inreq *proto_sentry.InboundMessage, sentryClient proto_sentry.SentryClient) error {
+func (cs *MultiClient) newWitness(ctx context.Context, inreq *sentryproto.InboundMessage, sentryClient sentryproto.SentryClient) error {
 	if cs.WitnessBuffer == nil {
 		return nil
 	}
@@ -911,11 +911,11 @@ func (cs *MultiClient) newWitness(ctx context.Context, inreq *proto_sentry.Inbou
 	return nil
 }
 
-func MakeInboundMessage() *proto_sentry.InboundMessage {
-	return new(proto_sentry.InboundMessage)
+func MakeInboundMessage() *sentryproto.InboundMessage {
+	return new(sentryproto.InboundMessage)
 }
 
-func (cs *MultiClient) HandleInboundMessage(ctx context.Context, message *proto_sentry.InboundMessage, sentry proto_sentry.SentryClient) (err error) {
+func (cs *MultiClient) HandleInboundMessage(ctx context.Context, message *sentryproto.InboundMessage, sentry sentryproto.SentryClient) (err error) {
 	defer func() {
 		if rec := recover(); rec != nil {
 			err = fmt.Errorf("%+v, msgID=%s, trace: %s", rec, message.Id.String(), dbg.Stack())
@@ -925,9 +925,9 @@ func (cs *MultiClient) HandleInboundMessage(ctx context.Context, message *proto_
 
 	if (err != nil) && rlp.IsInvalidRLPError(err) {
 		cs.logger.Debug("Kick peer for invalid RLP", "err", err)
-		penalizeRequest := proto_sentry.PenalizePeerRequest{
+		penalizeRequest := sentryproto.PenalizePeerRequest{
 			PeerId:  message.PeerId,
-			Penalty: proto_sentry.PenaltyKind_Kick, // TODO: Extend penalty kinds
+			Penalty: sentryproto.PenaltyKind_Kick, // TODO: Extend penalty kinds
 		}
 		if _, err1 := sentry.PenalizePeer(ctx, &penalizeRequest, &grpc.EmptyCallOption{}); err1 != nil {
 			cs.logger.Error("Could not send penalty", "err", err1)
@@ -937,38 +937,38 @@ func (cs *MultiClient) HandleInboundMessage(ctx context.Context, message *proto_
 	return err
 }
 
-func (cs *MultiClient) handleInboundMessage(ctx context.Context, inreq *proto_sentry.InboundMessage, sentry proto_sentry.SentryClient) error {
+func (cs *MultiClient) handleInboundMessage(ctx context.Context, inreq *sentryproto.InboundMessage, sentry sentryproto.SentryClient) error {
 	switch inreq.Id {
 	// ========= eth 66 ==========
 
-	case proto_sentry.MessageId_NEW_BLOCK_HASHES_66:
+	case sentryproto.MessageId_NEW_BLOCK_HASHES_66:
 		return cs.newBlockHashes66(ctx, inreq, sentry)
-	case proto_sentry.MessageId_BLOCK_HEADERS_66:
+	case sentryproto.MessageId_BLOCK_HEADERS_66:
 		return cs.blockHeaders66(ctx, inreq, sentry)
-	case proto_sentry.MessageId_NEW_BLOCK_66:
+	case sentryproto.MessageId_NEW_BLOCK_66:
 		return cs.newBlock66(ctx, inreq, sentry)
-	case proto_sentry.MessageId_BLOCK_BODIES_66:
+	case sentryproto.MessageId_BLOCK_BODIES_66:
 		return cs.blockBodies66(ctx, inreq, sentry)
-	case proto_sentry.MessageId_GET_BLOCK_HEADERS_66:
+	case sentryproto.MessageId_GET_BLOCK_HEADERS_66:
 		return cs.getBlockHeaders66(ctx, inreq, sentry)
-	case proto_sentry.MessageId_GET_BLOCK_BODIES_66:
+	case sentryproto.MessageId_GET_BLOCK_BODIES_66:
 		return cs.getBlockBodies66(ctx, inreq, sentry)
-	case proto_sentry.MessageId_RECEIPTS_66:
+	case sentryproto.MessageId_RECEIPTS_66:
 		return cs.receipts66(ctx, inreq, sentry)
-	case proto_sentry.MessageId_GET_RECEIPTS_66:
+	case sentryproto.MessageId_GET_RECEIPTS_66:
 		return cs.getReceipts66(ctx, inreq, sentry)
-	case proto_sentry.MessageId_NEW_WITNESS_W0:
+	case sentryproto.MessageId_NEW_WITNESS_W0:
 		return cs.newWitness(ctx, inreq, sentry)
-	case proto_sentry.MessageId_BLOCK_WITNESS_W0:
+	case sentryproto.MessageId_BLOCK_WITNESS_W0:
 		return cs.addBlockWitnesses(ctx, inreq, sentry)
-	case proto_sentry.MessageId_GET_BLOCK_WITNESS_W0:
+	case sentryproto.MessageId_GET_BLOCK_WITNESS_W0:
 		return cs.getBlockWitnesses(ctx, inreq, sentry)
 	default:
 		return fmt.Errorf("not implemented for message Id: %s", inreq.Id)
 	}
 }
 
-func (cs *MultiClient) HandlePeerEvent(ctx context.Context, event *proto_sentry.PeerEvent, sentryClient proto_sentry.SentryClient) error {
+func (cs *MultiClient) HandlePeerEvent(ctx context.Context, event *sentryproto.PeerEvent, sentryClient sentryproto.SentryClient) error {
 	eventID := event.EventId.String()
 	peerID := sentry.ConvertH512ToPeerID(event.PeerId)
 	peerIDStr := hex.EncodeToString(peerID[:])
@@ -981,8 +981,8 @@ func (cs *MultiClient) HandlePeerEvent(ctx context.Context, event *proto_sentry.
 	var nodeURL string
 	var clientID string
 	var capabilities []string
-	if event.EventId == proto_sentry.PeerEvent_Connect {
-		reply, err := sentryClient.PeerById(ctx, &proto_sentry.PeerByIdRequest{PeerId: event.PeerId})
+	if event.EventId == sentryproto.PeerEvent_Connect {
+		reply, err := sentryClient.PeerById(ctx, &sentryproto.PeerByIdRequest{PeerId: event.PeerId})
 		if err != nil {
 			cs.logger.Debug("sentry.PeerById failed", "err", err)
 		}
@@ -998,7 +998,7 @@ func (cs *MultiClient) HandlePeerEvent(ctx context.Context, event *proto_sentry.
 	return nil
 }
 
-func (cs *MultiClient) makeStatusData(ctx context.Context) (*proto_sentry.StatusData, error) {
+func (cs *MultiClient) makeStatusData(ctx context.Context) (*sentryproto.StatusData, error) {
 	return cs.statusDataProvider.GetStatusData(ctx)
 }
 
@@ -1020,5 +1020,5 @@ func GrpcClient(ctx context.Context, sentryAddr string) (*direct.SentryClientRem
 	if err != nil {
 		return nil, fmt.Errorf("creating client connection to sentry P2P: %w", err)
 	}
-	return direct.NewSentryClientRemote(proto_sentry.NewSentryClient(conn)), nil
+	return direct.NewSentryClientRemote(sentryproto.NewSentryClient(conn)), nil
 }

--- a/p2p/sentry/sentry_multi_client/witness_test.go
+++ b/p2p/sentry/sentry_multi_client/witness_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	proto_sentry "github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/core/stateless"
 	"github.com/erigontech/erigon/db/datadir"
@@ -108,8 +108,8 @@ func TestGetBlockWitnessesFunction(t *testing.T) {
 	multiClient, testDB := createTestMultiClient(t)
 
 	t.Run("Invalid RLP", func(t *testing.T) {
-		inboundMsg := &proto_sentry.InboundMessage{
-			Id:     proto_sentry.MessageId_GET_BLOCK_WITNESS_W0,
+		inboundMsg := &sentryproto.InboundMessage{
+			Id:     sentryproto.MessageId_GET_BLOCK_WITNESS_W0,
 			Data:   []byte{0xFF, 0xFF, 0xFF}, // Invalid RLP
 			PeerId: gointerfaces.ConvertHashToH512([64]byte{0x01, 0x02, 0x03}),
 		}
@@ -139,15 +139,15 @@ func TestGetBlockWitnessesFunction(t *testing.T) {
 		reqData, err := rlp.EncodeToBytes(&req)
 		require.NoError(t, err)
 
-		inboundMsg := &proto_sentry.InboundMessage{
-			Id:     proto_sentry.MessageId_GET_BLOCK_WITNESS_W0,
+		inboundMsg := &sentryproto.InboundMessage{
+			Id:     sentryproto.MessageId_GET_BLOCK_WITNESS_W0,
 			Data:   reqData,
 			PeerId: gointerfaces.ConvertHashToH512([64]byte{0x01, 0x02, 0x03}),
 		}
 
 		mockSentryClient.EXPECT().SendMessageById(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-			func(ctx context.Context, request *proto_sentry.SendMessageByIdRequest, opts ...grpc.CallOption) (*proto_sentry.SentPeers, error) {
-				require.Equal(t, proto_sentry.MessageId_BLOCK_WITNESS_W0, request.Data.Id)
+			func(ctx context.Context, request *sentryproto.SendMessageByIdRequest, opts ...grpc.CallOption) (*sentryproto.SentPeers, error) {
+				require.Equal(t, sentryproto.MessageId_BLOCK_WITNESS_W0, request.Data.Id)
 
 				var response wit.WitnessPacketRLPPacket
 				err := rlp.DecodeBytes(request.Data.Data, &response)
@@ -161,7 +161,7 @@ func TestGetBlockWitnessesFunction(t *testing.T) {
 				require.Equal(t, uint64(1), pageResp.TotalPages)
 				require.Equal(t, testWitnessData, pageResp.Data)
 
-				return &proto_sentry.SentPeers{}, nil
+				return &sentryproto.SentPeers{}, nil
 			},
 		).Times(1)
 
@@ -177,8 +177,8 @@ func TestNewWitnessFunction(t *testing.T) {
 	multiClient, _ := createTestMultiClient(t)
 
 	t.Run("Invalid RLP", func(t *testing.T) {
-		inboundMsg := &proto_sentry.InboundMessage{
-			Id:     proto_sentry.MessageId_NEW_WITNESS_W0,
+		inboundMsg := &sentryproto.InboundMessage{
+			Id:     sentryproto.MessageId_NEW_WITNESS_W0,
 			Data:   []byte{0xFF, 0xFF, 0xFF}, // Invalid RLP
 			PeerId: gointerfaces.ConvertHashToH512([64]byte{0x01, 0x02, 0x03}),
 		}
@@ -204,8 +204,8 @@ func TestNewWitnessFunction(t *testing.T) {
 		packetData, err := rlp.EncodeToBytes(&newWitnessPacket)
 		require.NoError(t, err)
 
-		inboundMsg := &proto_sentry.InboundMessage{
-			Id:     proto_sentry.MessageId_NEW_WITNESS_W0,
+		inboundMsg := &sentryproto.InboundMessage{
+			Id:     sentryproto.MessageId_NEW_WITNESS_W0,
 			Data:   packetData,
 			PeerId: gointerfaces.ConvertHashToH512([64]byte{0x01, 0x02, 0x03}),
 		}
@@ -258,13 +258,13 @@ func TestWitnessFunctionsThroughMessageHandler(t *testing.T) {
 		reqData, err := rlp.EncodeToBytes(&req)
 		require.NoError(t, err)
 
-		inboundMsg := &proto_sentry.InboundMessage{
-			Id:     proto_sentry.MessageId_GET_BLOCK_WITNESS_W0,
+		inboundMsg := &sentryproto.InboundMessage{
+			Id:     sentryproto.MessageId_GET_BLOCK_WITNESS_W0,
 			Data:   reqData,
 			PeerId: gointerfaces.ConvertHashToH512([64]byte{0x01, 0x02, 0x03}),
 		}
 
-		mockSentryClient.EXPECT().SendMessageById(gomock.Any(), gomock.Any(), gomock.Any()).Return(&proto_sentry.SentPeers{}, nil).Times(1)
+		mockSentryClient.EXPECT().SendMessageById(gomock.Any(), gomock.Any(), gomock.Any()).Return(&sentryproto.SentPeers{}, nil).Times(1)
 
 		err = multiClient.handleInboundMessage(ctx, inboundMsg, mockSentryClient)
 		require.NoError(t, err) // Should succeed with proper data
@@ -286,8 +286,8 @@ func TestWitnessFunctionsThroughMessageHandler(t *testing.T) {
 		packetData, err := rlp.EncodeToBytes(&newWitnessPacket)
 		require.NoError(t, err)
 
-		inboundMsg := &proto_sentry.InboundMessage{
-			Id:     proto_sentry.MessageId_NEW_WITNESS_W0,
+		inboundMsg := &sentryproto.InboundMessage{
+			Id:     sentryproto.MessageId_NEW_WITNESS_W0,
 			Data:   packetData,
 			PeerId: gointerfaces.ConvertHashToH512([64]byte{0x01, 0x02, 0x03}),
 		}
@@ -345,14 +345,14 @@ func TestWitnessPagination(t *testing.T) {
 		reqData, err := rlp.EncodeToBytes(&req)
 		require.NoError(t, err)
 
-		inboundMsg := &proto_sentry.InboundMessage{
-			Id:     proto_sentry.MessageId_GET_BLOCK_WITNESS_W0,
+		inboundMsg := &sentryproto.InboundMessage{
+			Id:     sentryproto.MessageId_GET_BLOCK_WITNESS_W0,
 			Data:   reqData,
 			PeerId: gointerfaces.ConvertHashToH512([64]byte{0x04, 0x05, 0x06}),
 		}
 
 		mockSentryClient.EXPECT().SendMessageById(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-			func(ctx context.Context, request *proto_sentry.SendMessageByIdRequest, opts ...grpc.CallOption) (*proto_sentry.SentPeers, error) {
+			func(ctx context.Context, request *sentryproto.SendMessageByIdRequest, opts ...grpc.CallOption) (*sentryproto.SentPeers, error) {
 				var response wit.WitnessPacketRLPPacket
 				err := rlp.DecodeBytes(request.Data.Data, &response)
 				require.NoError(t, err)
@@ -369,7 +369,7 @@ func TestWitnessPagination(t *testing.T) {
 				expectedFirstPage := largeWitnessData[:pageSize]
 				require.Equal(t, expectedFirstPage, pageResp.Data)
 
-				return &proto_sentry.SentPeers{}, nil
+				return &sentryproto.SentPeers{}, nil
 			},
 		).Times(1)
 
@@ -391,14 +391,14 @@ func TestWitnessPagination(t *testing.T) {
 		reqData, err := rlp.EncodeToBytes(&req)
 		require.NoError(t, err)
 
-		inboundMsg := &proto_sentry.InboundMessage{
-			Id:     proto_sentry.MessageId_GET_BLOCK_WITNESS_W0,
+		inboundMsg := &sentryproto.InboundMessage{
+			Id:     sentryproto.MessageId_GET_BLOCK_WITNESS_W0,
 			Data:   reqData,
 			PeerId: gointerfaces.ConvertHashToH512([64]byte{0x04, 0x05, 0x06}),
 		}
 
 		mockSentryClient.EXPECT().SendMessageById(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-			func(ctx context.Context, request *proto_sentry.SendMessageByIdRequest, opts ...grpc.CallOption) (*proto_sentry.SentPeers, error) {
+			func(ctx context.Context, request *sentryproto.SendMessageByIdRequest, opts ...grpc.CallOption) (*sentryproto.SentPeers, error) {
 				var response wit.WitnessPacketRLPPacket
 				err := rlp.DecodeBytes(request.Data.Data, &response)
 				require.NoError(t, err)
@@ -412,7 +412,7 @@ func TestWitnessPagination(t *testing.T) {
 				expectedSecondPage := largeWitnessData[pageSize : pageSize*2]
 				require.Equal(t, expectedSecondPage, pageResp.Data)
 
-				return &proto_sentry.SentPeers{}, nil
+				return &sentryproto.SentPeers{}, nil
 			},
 		).Times(1)
 
@@ -434,14 +434,14 @@ func TestWitnessPagination(t *testing.T) {
 		reqData, err := rlp.EncodeToBytes(&req)
 		require.NoError(t, err)
 
-		inboundMsg := &proto_sentry.InboundMessage{
-			Id:     proto_sentry.MessageId_GET_BLOCK_WITNESS_W0,
+		inboundMsg := &sentryproto.InboundMessage{
+			Id:     sentryproto.MessageId_GET_BLOCK_WITNESS_W0,
 			Data:   reqData,
 			PeerId: gointerfaces.ConvertHashToH512([64]byte{0x04, 0x05, 0x06}),
 		}
 
 		mockSentryClient.EXPECT().SendMessageById(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-			func(ctx context.Context, request *proto_sentry.SendMessageByIdRequest, opts ...grpc.CallOption) (*proto_sentry.SentPeers, error) {
+			func(ctx context.Context, request *sentryproto.SendMessageByIdRequest, opts ...grpc.CallOption) (*sentryproto.SentPeers, error) {
 				var response wit.WitnessPacketRLPPacket
 				err := rlp.DecodeBytes(request.Data.Data, &response)
 				require.NoError(t, err)
@@ -455,7 +455,7 @@ func TestWitnessPagination(t *testing.T) {
 				expectedThirdPage := largeWitnessData[pageSize*2:]
 				require.Equal(t, expectedThirdPage, pageResp.Data)
 
-				return &proto_sentry.SentPeers{}, nil
+				return &sentryproto.SentPeers{}, nil
 			},
 		).Times(1)
 
@@ -481,14 +481,14 @@ func TestWitnessPagination(t *testing.T) {
 		reqData, err := rlp.EncodeToBytes(&req)
 		require.NoError(t, err)
 
-		inboundMsg := &proto_sentry.InboundMessage{
-			Id:     proto_sentry.MessageId_GET_BLOCK_WITNESS_W0,
+		inboundMsg := &sentryproto.InboundMessage{
+			Id:     sentryproto.MessageId_GET_BLOCK_WITNESS_W0,
 			Data:   reqData,
 			PeerId: gointerfaces.ConvertHashToH512([64]byte{0x04, 0x05, 0x06}),
 		}
 
 		mockSentryClient.EXPECT().SendMessageById(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-			func(ctx context.Context, request *proto_sentry.SendMessageByIdRequest, opts ...grpc.CallOption) (*proto_sentry.SentPeers, error) {
+			func(ctx context.Context, request *sentryproto.SendMessageByIdRequest, opts ...grpc.CallOption) (*sentryproto.SentPeers, error) {
 				var response wit.WitnessPacketRLPPacket
 				err := rlp.DecodeBytes(request.Data.Data, &response)
 				require.NoError(t, err)
@@ -510,7 +510,7 @@ func TestWitnessPagination(t *testing.T) {
 				require.Equal(t, uint64(3), page2.TotalPages)
 				require.Equal(t, 1000, len(page2.Data))
 
-				return &proto_sentry.SentPeers{}, nil
+				return &sentryproto.SentPeers{}, nil
 			},
 		).Times(1)
 
@@ -532,14 +532,14 @@ func TestWitnessPagination(t *testing.T) {
 		reqData, err := rlp.EncodeToBytes(&req)
 		require.NoError(t, err)
 
-		inboundMsg := &proto_sentry.InboundMessage{
-			Id:     proto_sentry.MessageId_GET_BLOCK_WITNESS_W0,
+		inboundMsg := &sentryproto.InboundMessage{
+			Id:     sentryproto.MessageId_GET_BLOCK_WITNESS_W0,
 			Data:   reqData,
 			PeerId: gointerfaces.ConvertHashToH512([64]byte{0x04, 0x05, 0x06}),
 		}
 
 		mockSentryClient.EXPECT().SendMessageById(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-			func(ctx context.Context, request *proto_sentry.SendMessageByIdRequest, opts ...grpc.CallOption) (*proto_sentry.SentPeers, error) {
+			func(ctx context.Context, request *sentryproto.SendMessageByIdRequest, opts ...grpc.CallOption) (*sentryproto.SentPeers, error) {
 				var response wit.WitnessPacketRLPPacket
 				err := rlp.DecodeBytes(request.Data.Data, &response)
 				require.NoError(t, err)
@@ -550,7 +550,7 @@ func TestWitnessPagination(t *testing.T) {
 				require.Equal(t, uint64(3), pageResp.TotalPages)
 				require.Empty(t, pageResp.Data) // Should be empty for invalid page
 
-				return &proto_sentry.SentPeers{}, nil
+				return &sentryproto.SentPeers{}, nil
 			},
 		).Times(1)
 
@@ -591,14 +591,14 @@ func TestWitnessExactPageSize(t *testing.T) {
 	reqData, err := rlp.EncodeToBytes(&req)
 	require.NoError(t, err)
 
-	inboundMsg := &proto_sentry.InboundMessage{
-		Id:     proto_sentry.MessageId_GET_BLOCK_WITNESS_W0,
+	inboundMsg := &sentryproto.InboundMessage{
+		Id:     sentryproto.MessageId_GET_BLOCK_WITNESS_W0,
 		Data:   reqData,
 		PeerId: gointerfaces.ConvertHashToH512([64]byte{0x99, 0x99, 0x99}),
 	}
 
 	mockSentryClient.EXPECT().SendMessageById(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(ctx context.Context, request *proto_sentry.SendMessageByIdRequest, opts ...grpc.CallOption) (*proto_sentry.SentPeers, error) {
+		func(ctx context.Context, request *sentryproto.SendMessageByIdRequest, opts ...grpc.CallOption) (*sentryproto.SentPeers, error) {
 			var response wit.WitnessPacketRLPPacket
 			err := rlp.DecodeBytes(request.Data.Data, &response)
 			require.NoError(t, err)
@@ -613,7 +613,7 @@ func TestWitnessExactPageSize(t *testing.T) {
 			require.Equal(t, pageSize, len(pageResp.Data))   // Full page size
 			require.Equal(t, exactPageSizeData, pageResp.Data)
 
-			return &proto_sentry.SentPeers{}, nil
+			return &sentryproto.SentPeers{}, nil
 		},
 	).Times(1)
 

--- a/p2p/sentry/status_data_provider.go
+++ b/p2p/sentry/status_data_provider.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	proto_sentry "github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/rawdb"
@@ -102,14 +102,14 @@ func makeGenesisChainHead(genesis *types.Block) ChainHead {
 	}
 }
 
-func (s *StatusDataProvider) makeStatusData(head ChainHead) *proto_sentry.StatusData {
-	return &proto_sentry.StatusData{
+func (s *StatusDataProvider) makeStatusData(head ChainHead) *sentryproto.StatusData {
+	return &sentryproto.StatusData{
 		NetworkId:       s.networkId,
 		TotalDifficulty: gointerfaces.ConvertUint256IntToH256(head.HeadTd),
 		BestHash:        gointerfaces.ConvertHashToH256(head.HeadHash),
 		MaxBlockHeight:  head.HeadHeight,
 		MaxBlockTime:    head.HeadTime,
-		ForkData: &proto_sentry.Forks{
+		ForkData: &sentryproto.Forks{
 			Genesis:     gointerfaces.ConvertHashToH256(s.genesisHash),
 			HeightForks: s.heightForks,
 			TimeForks:   s.timeForks,
@@ -117,7 +117,7 @@ func (s *StatusDataProvider) makeStatusData(head ChainHead) *proto_sentry.Status
 	}
 }
 
-func (s *StatusDataProvider) GetStatusData(ctx context.Context) (*proto_sentry.StatusData, error) {
+func (s *StatusDataProvider) GetStatusData(ctx context.Context) (*sentryproto.StatusData, error) {
 	chainHead, err := ReadChainHead(ctx, s.db)
 	if err != nil {
 		if errors.Is(err, ErrNoHead) {

--- a/polygon/bridge/reader.go
+++ b/polygon/bridge/reader.go
@@ -28,7 +28,7 @@ import (
 	"github.com/erigontech/erigon-lib/common/dbg"
 	"github.com/erigontech/erigon-lib/common/u256"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/core"
 	"github.com/erigontech/erigon/core/state"
@@ -153,12 +153,12 @@ func (r *Reader) Close() {
 }
 
 type RemoteReader struct {
-	client  remote.BridgeBackendClient
+	client  remoteproto.BridgeBackendClient
 	logger  log.Logger
 	version gointerfaces.Version
 }
 
-func NewRemoteReader(client remote.BridgeBackendClient) *RemoteReader {
+func NewRemoteReader(client remoteproto.BridgeBackendClient) *RemoteReader {
 	return &RemoteReader{
 		client:  client,
 		logger:  log.New("remote_service", "bridge"),
@@ -167,7 +167,7 @@ func NewRemoteReader(client remote.BridgeBackendClient) *RemoteReader {
 }
 
 func (r *RemoteReader) Events(ctx context.Context, blockHash common.Hash, blockNum uint64) ([]*types.Message, error) {
-	reply, err := r.client.BorEvents(ctx, &remote.BorEventsRequest{
+	reply, err := r.client.BorEvents(ctx, &remoteproto.BorEventsRequest{
 		BlockNum:  blockNum,
 		BlockHash: gointerfaces.ConvertHashToH256(blockHash)})
 	if err != nil {
@@ -187,7 +187,7 @@ func (r *RemoteReader) Events(ctx context.Context, blockHash common.Hash, blockN
 }
 
 func (r *RemoteReader) EventTxnLookup(ctx context.Context, borTxHash common.Hash) (uint64, bool, error) {
-	reply, err := r.client.BorTxnLookup(ctx, &remote.BorTxnLookupRequest{BorTxHash: gointerfaces.ConvertHashToH256(borTxHash)})
+	reply, err := r.client.BorTxnLookup(ctx, &remoteproto.BorTxnLookupRequest{BorTxHash: gointerfaces.ConvertHashToH256(borTxHash)})
 	if err != nil {
 		return 0, false, err
 	}

--- a/polygon/heimdall/reader.go
+++ b/polygon/heimdall/reader.go
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/polygon/bor/borcfg"
 )
@@ -71,12 +71,12 @@ func (r *Reader) Close() {
 }
 
 type RemoteReader struct {
-	client  remote.HeimdallBackendClient
+	client  remoteproto.HeimdallBackendClient
 	logger  log.Logger
 	version gointerfaces.Version
 }
 
-func NewRemoteReader(client remote.HeimdallBackendClient) *RemoteReader {
+func NewRemoteReader(client remoteproto.HeimdallBackendClient) *RemoteReader {
 	return &RemoteReader{
 		client:  client,
 		logger:  log.New("remote_service", "heimdall"),
@@ -85,7 +85,7 @@ func NewRemoteReader(client remote.HeimdallBackendClient) *RemoteReader {
 }
 
 func (r *RemoteReader) Producers(ctx context.Context, blockNum uint64) (*ValidatorSet, error) {
-	reply, err := r.client.Producers(ctx, &remote.BorProducersRequest{BlockNum: blockNum})
+	reply, err := r.client.Producers(ctx, &remoteproto.BorProducersRequest{BlockNum: blockNum})
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +129,7 @@ func (r *RemoteReader) EnsureVersionCompatibility() bool {
 	return true
 }
 
-func decodeValidator(v *remote.Validator) *Validator {
+func decodeValidator(v *remoteproto.Validator) *Validator {
 	return &Validator{
 		ID:               v.Id,
 		Address:          gointerfaces.ConvertH160toAddress(v.Address),

--- a/polygon/p2p/message_sender_test.go
+++ b/polygon/p2p/message_sender_test.go
@@ -26,8 +26,8 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/erigontech/erigon-lib/common"
-	sentry "github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
-	erigonlibtypes "github.com/erigontech/erigon-lib/gointerfaces/typesproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 	"github.com/erigontech/erigon/execution/rlp"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/node/direct"
@@ -40,17 +40,17 @@ func TestMessageSenderSendGetBlockHeaders(t *testing.T) {
 	sentryClient := direct.NewMockSentryClient(ctrl)
 	sentryClient.EXPECT().
 		SendMessageById(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, request *sentry.SendMessageByIdRequest, _ ...grpc.CallOption) (*sentry.SentPeers, error) {
+		DoAndReturn(func(_ context.Context, request *sentryproto.SendMessageByIdRequest, _ ...grpc.CallOption) (*sentryproto.SentPeers, error) {
 			require.Equal(t, PeerIdFromUint64(123), PeerIdFromH512(request.PeerId))
-			require.Equal(t, sentry.MessageId_GET_BLOCK_HEADERS_66, request.Data.Id)
+			require.Equal(t, sentryproto.MessageId_GET_BLOCK_HEADERS_66, request.Data.Id)
 			var payload eth.GetBlockHeadersPacket66
 			err := rlp.DecodeBytes(request.Data.Data, &payload)
 			require.NoError(t, err)
 			require.Equal(t, uint64(10), payload.RequestId)
 			require.Equal(t, uint64(3), payload.Origin.Number)
 			require.Equal(t, uint64(5), payload.Amount)
-			return &sentry.SentPeers{
-				Peers: []*erigonlibtypes.H512{
+			return &sentryproto.SentPeers{
+				Peers: []*typesproto.H512{
 					PeerIdFromUint64(123).H512(),
 				},
 			}, nil
@@ -76,7 +76,7 @@ func TestMessageSenderSendGetBlockHeadersErrPeerNotFound(t *testing.T) {
 	sentryClient := direct.NewMockSentryClient(ctrl)
 	sentryClient.EXPECT().
 		SendMessageById(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&sentry.SentPeers{}, nil).
+		Return(&sentryproto.SentPeers{}, nil).
 		Times(1)
 
 	messageSender := NewMessageSender(sentryClient)
@@ -98,16 +98,16 @@ func TestMessageSenderSendGetBlockBodies(t *testing.T) {
 	sentryClient := direct.NewMockSentryClient(ctrl)
 	sentryClient.EXPECT().
 		SendMessageById(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, request *sentry.SendMessageByIdRequest, _ ...grpc.CallOption) (*sentry.SentPeers, error) {
+		DoAndReturn(func(_ context.Context, request *sentryproto.SendMessageByIdRequest, _ ...grpc.CallOption) (*sentryproto.SentPeers, error) {
 			require.Equal(t, PeerIdFromUint64(123), PeerIdFromH512(request.PeerId))
-			require.Equal(t, sentry.MessageId_GET_BLOCK_BODIES_66, request.Data.Id)
+			require.Equal(t, sentryproto.MessageId_GET_BLOCK_BODIES_66, request.Data.Id)
 			var payload eth.GetBlockBodiesPacket66
 			err := rlp.DecodeBytes(request.Data.Data, &payload)
 			require.NoError(t, err)
 			require.Equal(t, uint64(10), payload.RequestId)
 			require.Len(t, payload.GetBlockBodiesPacket, 1)
-			return &sentry.SentPeers{
-				Peers: []*erigonlibtypes.H512{
+			return &sentryproto.SentPeers{
+				Peers: []*typesproto.H512{
 					PeerIdFromUint64(123).H512(),
 				},
 			}, nil
@@ -128,7 +128,7 @@ func TestMessageSenderSendGetBlockBodiesErrPeerNotFound(t *testing.T) {
 	sentryClient := direct.NewMockSentryClient(ctrl)
 	sentryClient.EXPECT().
 		SendMessageById(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&sentry.SentPeers{}, nil).
+		Return(&sentryproto.SentPeers{}, nil).
 		Times(1)
 
 	messageSender := NewMessageSender(sentryClient)
@@ -145,17 +145,17 @@ func TestMessageSenderSendNewBlockHashes(t *testing.T) {
 	sentryClient := direct.NewMockSentryClient(ctrl)
 	sentryClient.EXPECT().
 		SendMessageById(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, request *sentry.SendMessageByIdRequest, _ ...grpc.CallOption) (*sentry.SentPeers, error) {
+		DoAndReturn(func(_ context.Context, request *sentryproto.SendMessageByIdRequest, _ ...grpc.CallOption) (*sentryproto.SentPeers, error) {
 			require.Equal(t, PeerIdFromUint64(123), PeerIdFromH512(request.PeerId))
-			require.Equal(t, sentry.MessageId_NEW_BLOCK_HASHES_66, request.Data.Id)
+			require.Equal(t, sentryproto.MessageId_NEW_BLOCK_HASHES_66, request.Data.Id)
 			var payload eth.NewBlockHashesPacket
 			err := rlp.DecodeBytes(request.Data.Data, &payload)
 			require.NoError(t, err)
 			require.Len(t, payload, 1)
 			require.Equal(t, uint64(1), payload[0].Number)
 			require.Equal(t, common.HexToHash("0x0"), payload[0].Hash)
-			return &sentry.SentPeers{
-				Peers: []*erigonlibtypes.H512{
+			return &sentryproto.SentPeers{
+				Peers: []*typesproto.H512{
 					PeerIdFromUint64(123).H512(),
 				},
 			}, nil
@@ -178,7 +178,7 @@ func TestMessageSenderSendNewBlockHashesErrPeerNotFound(t *testing.T) {
 	sentryClient := direct.NewMockSentryClient(ctrl)
 	sentryClient.EXPECT().
 		SendMessageById(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&sentry.SentPeers{}, nil).
+		Return(&sentryproto.SentPeers{}, nil).
 		Times(1)
 
 	messageSender := NewMessageSender(sentryClient)
@@ -198,16 +198,16 @@ func TestMessageSenderSendNewBlock(t *testing.T) {
 	sentryClient := direct.NewMockSentryClient(ctrl)
 	sentryClient.EXPECT().
 		SendMessageById(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, request *sentry.SendMessageByIdRequest, _ ...grpc.CallOption) (*sentry.SentPeers, error) {
+		DoAndReturn(func(_ context.Context, request *sentryproto.SendMessageByIdRequest, _ ...grpc.CallOption) (*sentryproto.SentPeers, error) {
 			require.Equal(t, PeerIdFromUint64(123), PeerIdFromH512(request.PeerId))
-			require.Equal(t, sentry.MessageId_NEW_BLOCK_66, request.Data.Id)
+			require.Equal(t, sentryproto.MessageId_NEW_BLOCK_66, request.Data.Id)
 			var payload eth.NewBlockPacket
 			err := rlp.DecodeBytes(request.Data.Data, &payload)
 			require.NoError(t, err)
 			require.Equal(t, uint64(123), payload.Block.NumberU64())
 			require.Equal(t, uint64(2), payload.TD.Uint64())
-			return &sentry.SentPeers{
-				Peers: []*erigonlibtypes.H512{
+			return &sentryproto.SentPeers{
+				Peers: []*typesproto.H512{
 					PeerIdFromUint64(123).H512(),
 				},
 			}, nil
@@ -229,7 +229,7 @@ func TestMessageSenderSendNewBlockErrPeerNotFound(t *testing.T) {
 	sentryClient := direct.NewMockSentryClient(ctrl)
 	sentryClient.EXPECT().
 		SendMessageById(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&sentry.SentPeers{}, nil).
+		Return(&sentryproto.SentPeers{}, nil).
 		Times(1)
 
 	messageSender := NewMessageSender(sentryClient)

--- a/rpc/jsonrpc/admin_api.go
+++ b/rpc/jsonrpc/admin_api.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"fmt"
 
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
 	"github.com/erigontech/erigon/p2p"
 	"github.com/erigontech/erigon/rpc/rpchelper"
 )
@@ -72,7 +72,7 @@ func (api *AdminAPIImpl) Peers(ctx context.Context) ([]*p2p.PeerInfo, error) {
 }
 
 func (api *AdminAPIImpl) AddPeer(ctx context.Context, url string) (bool, error) {
-	result, err := api.ethBackend.AddPeer(ctx, &remote.AddPeerRequest{Url: url})
+	result, err := api.ethBackend.AddPeer(ctx, &remoteproto.AddPeerRequest{Url: url})
 	if err != nil {
 		return false, err
 	}
@@ -83,7 +83,7 @@ func (api *AdminAPIImpl) AddPeer(ctx context.Context, url string) (bool, error) 
 }
 
 func (api *AdminAPIImpl) RemovePeer(ctx context.Context, url string) (bool, error) {
-	result, err := api.ethBackend.RemovePeer(ctx, &remote.RemovePeerRequest{Url: url})
+	result, err := api.ethBackend.RemovePeer(ctx, &remoteproto.RemovePeerRequest{Url: url})
 	if err != nil {
 		return false, err
 	}

--- a/rpc/jsonrpc/daemon.go
+++ b/rpc/jsonrpc/daemon.go
@@ -17,7 +17,7 @@
 package jsonrpc
 
 import (
-	txpool "github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cmd/rpcdaemon/cli/httpcfg"
 	"github.com/erigontech/erigon/db/kv"
@@ -31,7 +31,7 @@ import (
 )
 
 // APIList describes the list of available RPC apis
-func APIList(db kv.TemporalRoDB, eth rpchelper.ApiBackend, txPool txpool.TxpoolClient, mining txpool.MiningClient,
+func APIList(db kv.TemporalRoDB, eth rpchelper.ApiBackend, txPool txpoolproto.TxpoolClient, mining txpoolproto.MiningClient,
 	filters *rpchelper.Filters, stateCache kvcache.Cache,
 	blockReader services.FullBlockReader, cfg *httpcfg.HttpCfg, engine consensus.EngineReader,
 	logger log.Logger, bridgeReader bridgeReader, spanProducersReader spanProducersReader,

--- a/rpc/jsonrpc/eth_accounts.go
+++ b/rpc/jsonrpc/eth_accounts.go
@@ -21,14 +21,15 @@ import (
 	"fmt"
 	"math/big"
 
+	"google.golang.org/grpc"
+
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/hexutil"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	txpool_proto "github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/rpc"
 	"github.com/erigontech/erigon/rpc/rpchelper"
-	"google.golang.org/grpc"
 )
 
 // GetBalance implements eth_getBalance. Returns the balance of an account for a given address.
@@ -58,7 +59,7 @@ func (api *APIImpl) GetBalance(ctx context.Context, address common.Address, bloc
 // GetTransactionCount implements eth_getTransactionCount. Returns the number of transactions sent from an address (the nonce).
 func (api *APIImpl) GetTransactionCount(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (*hexutil.Uint64, error) {
 	if blockNrOrHash.BlockNumber != nil && *blockNrOrHash.BlockNumber == rpc.PendingBlockNumber {
-		reply, err := api.txPool.Nonce(ctx, &txpool_proto.NonceRequest{
+		reply, err := api.txPool.Nonce(ctx, &txpoolproto.NonceRequest{
 			Address: gointerfaces.ConvertAddressToH160(address),
 		}, &grpc.EmptyCallOption{})
 		if err != nil {

--- a/rpc/jsonrpc/eth_api.go
+++ b/rpc/jsonrpc/eth_api.go
@@ -30,7 +30,7 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/hexutil"
 	"github.com/erigontech/erigon-lib/common/math"
-	txpool "github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
@@ -393,8 +393,8 @@ type bridgeReader interface {
 type APIImpl struct {
 	*BaseAPI
 	ethBackend                  rpchelper.ApiBackend
-	txPool                      txpool.TxpoolClient
-	mining                      txpool.MiningClient
+	txPool                      txpoolproto.TxpoolClient
+	mining                      txpoolproto.MiningClient
 	gasCache                    *GasPriceCache
 	db                          kv.TemporalRoDB
 	GasCap                      uint64
@@ -407,7 +407,7 @@ type APIImpl struct {
 }
 
 // NewEthAPI returns APIImpl instance
-func NewEthAPI(base *BaseAPI, db kv.TemporalRoDB, eth rpchelper.ApiBackend, txPool txpool.TxpoolClient, mining txpool.MiningClient, gascap uint64, feecap float64, returnDataLimit int, allowUnprotectedTxs bool, maxGetProofRewindBlockCount int, subscribeLogsChannelSize int, logger log.Logger) *APIImpl {
+func NewEthAPI(base *BaseAPI, db kv.TemporalRoDB, eth rpchelper.ApiBackend, txPool txpoolproto.TxpoolClient, mining txpoolproto.MiningClient, gascap uint64, feecap float64, returnDataLimit int, allowUnprotectedTxs bool, maxGetProofRewindBlockCount int, subscribeLogsChannelSize int, logger log.Logger) *APIImpl {
 	if gascap == 0 {
 		gascap = uint64(math.MaxUint64 / 2)
 	}

--- a/rpc/jsonrpc/eth_block_test.go
+++ b/rpc/jsonrpc/eth_block_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/hexutil"
-	txpool "github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cmd/rpcdaemon/rpcdaemontest"
 	"github.com/erigontech/erigon/db/kv/kvcache"
@@ -87,8 +87,8 @@ func TestGetBlockByNumberWithPendingTag(t *testing.T) {
 	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
 
 	ctx, conn := rpcdaemontest.CreateTestGrpcConn(t, m)
-	txPool := txpool.NewTxpoolClient(conn)
-	ff := rpchelper.New(ctx, rpchelper.DefaultFiltersConfig, nil, txPool, txpool.NewMiningClient(conn), func() {}, m.Log)
+	txPool := txpoolproto.NewTxpoolClient(conn)
+	ff := rpchelper.New(ctx, rpchelper.DefaultFiltersConfig, nil, txPool, txpoolproto.NewMiningClient(conn), func() {}, m.Log)
 
 	expected := 1
 	header := &types.Header{
@@ -99,7 +99,7 @@ func TestGetBlockByNumberWithPendingTag(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed encoding the block: %s", err)
 	}
-	ff.HandlePendingBlock(&txpool.OnPendingBlockReply{
+	ff.HandlePendingBlock(&txpoolproto.OnPendingBlockReply{
 		RplBlock: rlpBlock,
 	})
 

--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -32,7 +32,7 @@ import (
 	"github.com/erigontech/erigon-lib/common/hexutil"
 	"github.com/erigontech/erigon-lib/crypto"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	txpool_proto "github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/core"
 	"github.com/erigontech/erigon/core/state"
@@ -797,7 +797,7 @@ func (api *APIImpl) CreateAccessList(ctx context.Context, args ethapi2.CallArgs,
 		// Require nonce to calculate address of created contract
 		if args.Nonce == nil {
 			var nonce uint64
-			reply, err := api.txPool.Nonce(ctx, &txpool_proto.NonceRequest{
+			reply, err := api.txPool.Nonce(ctx, &txpoolproto.NonceRequest{
 				Address: gointerfaces.ConvertAddressToH160(*args.From),
 			}, &grpc.EmptyCallOption{})
 			if err != nil {

--- a/rpc/jsonrpc/eth_call_test.go
+++ b/rpc/jsonrpc/eth_call_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/hexutil"
 	"github.com/erigontech/erigon-lib/crypto"
-	txpool "github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cmd/rpcdaemon/rpcdaemontest"
 	"github.com/erigontech/erigon/core"
@@ -54,7 +54,7 @@ func TestEstimateGas(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestSentry(t)
 	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
 	ctx, conn := rpcdaemontest.CreateTestGrpcConn(t, mock.Mock(t))
-	mining := txpool.NewMiningClient(conn)
+	mining := txpoolproto.NewMiningClient(conn)
 	ff := rpchelper.New(ctx, rpchelper.DefaultFiltersConfig, nil, nil, mining, func() {}, m.Log)
 	api := NewEthAPI(NewBaseApi(ff, stateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil), m.DB, nil, nil, nil, 5000000, ethconfig.Defaults.RPCTxFeeCap, 100_000, false, 100_000, 128, log.New())
 	var from = common.HexToAddress("0x71562b71999873db5b286df957af199ec94617f7")

--- a/rpc/jsonrpc/eth_filters_test.go
+++ b/rpc/jsonrpc/eth_filters_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/length"
-	txpool "github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cmd/rpcdaemon/rpcdaemontest"
 	"github.com/erigontech/erigon/db/kv/kvcache"
@@ -42,7 +42,7 @@ func TestNewFilters(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestSentry(t)
 	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
 	ctx, conn := rpcdaemontest.CreateTestGrpcConn(t, mock.Mock(t))
-	mining := txpool.NewMiningClient(conn)
+	mining := txpoolproto.NewMiningClient(conn)
 	ff := rpchelper.New(ctx, rpchelper.DefaultFiltersConfig, nil, nil, mining, func() {}, m.Log)
 	api := NewEthAPI(NewBaseApi(ff, stateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil), m.DB, nil, nil, nil, 5000000, ethconfig.Defaults.RPCTxFeeCap, 100_000, false, 100_000, 128, log.New())
 
@@ -71,7 +71,7 @@ func TestNewFilters(t *testing.T) {
 func TestLogsSubscribeAndUnsubscribe_WithoutConcurrentMapIssue(t *testing.T) {
 	m := mock.Mock(t)
 	ctx, conn := rpcdaemontest.CreateTestGrpcConn(t, m)
-	mining := txpool.NewMiningClient(conn)
+	mining := txpoolproto.NewMiningClient(conn)
 	ff := rpchelper.New(ctx, rpchelper.DefaultFiltersConfig, nil, nil, mining, func() {}, m.Log)
 
 	// generate some random topics

--- a/rpc/jsonrpc/eth_mining.go
+++ b/rpc/jsonrpc/eth_mining.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/hexutil"
-	txpool "github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon/execution/types"
 )
 
@@ -35,7 +35,7 @@ func (api *APIImpl) Coinbase(ctx context.Context) (common.Address, error) {
 
 // Hashrate implements eth_hashrate. Returns the number of hashes per second that the node is mining with.
 func (api *APIImpl) Hashrate(ctx context.Context) (uint64, error) {
-	repl, err := api.mining.HashRate(ctx, &txpool.HashRateRequest{})
+	repl, err := api.mining.HashRate(ctx, &txpoolproto.HashRateRequest{})
 	if err != nil {
 		if s, ok := status.FromError(err); ok {
 			return 0, errors.New(s.Message())
@@ -47,7 +47,7 @@ func (api *APIImpl) Hashrate(ctx context.Context) (uint64, error) {
 
 // Mining returns an indication if this node is currently mining.
 func (api *APIImpl) Mining(ctx context.Context) (bool, error) {
-	repl, err := api.mining.Mining(ctx, &txpool.MiningRequest{})
+	repl, err := api.mining.Mining(ctx, &txpoolproto.MiningRequest{})
 	if err != nil {
 		if s, ok := status.FromError(err); ok {
 			return false, errors.New(s.Message())
@@ -67,7 +67,7 @@ func (api *APIImpl) Mining(ctx context.Context) (bool, error) {
 //	result[3] - hex encoded block number
 func (api *APIImpl) GetWork(ctx context.Context) ([4]string, error) {
 	var res [4]string
-	repl, err := api.mining.GetWork(ctx, &txpool.GetWorkRequest{})
+	repl, err := api.mining.GetWork(ctx, &txpoolproto.GetWorkRequest{})
 	if err != nil {
 		if s, ok := status.FromError(err); ok {
 			return res, errors.New(s.Message())
@@ -85,7 +85,7 @@ func (api *APIImpl) GetWork(ctx context.Context) ([4]string, error) {
 // It returns an indication if the work was accepted.
 // Note either an invalid solution, a stale work a non-existent work will return false.
 func (api *APIImpl) SubmitWork(ctx context.Context, nonce types.BlockNonce, powHash, digest common.Hash) (bool, error) {
-	repl, err := api.mining.SubmitWork(ctx, &txpool.SubmitWorkRequest{BlockNonce: nonce[:], PowHash: powHash.Bytes(), Digest: digest.Bytes()})
+	repl, err := api.mining.SubmitWork(ctx, &txpoolproto.SubmitWorkRequest{BlockNonce: nonce[:], PowHash: powHash.Bytes(), Digest: digest.Bytes()})
 	if err != nil {
 		if s, ok := status.FromError(err); ok {
 			return false, errors.New(s.Message())
@@ -101,7 +101,7 @@ func (api *APIImpl) SubmitWork(ctx context.Context, nonce types.BlockNonce, powH
 //
 // It accepts the miner hash rate and an identifier which must be unique
 func (api *APIImpl) SubmitHashrate(ctx context.Context, hashRate hexutil.Uint64, id common.Hash) (bool, error) {
-	repl, err := api.mining.SubmitHashRate(ctx, &txpool.SubmitHashRateRequest{Rate: uint64(hashRate), Id: id.Bytes()})
+	repl, err := api.mining.SubmitHashRate(ctx, &txpoolproto.SubmitHashRateRequest{Rate: uint64(hashRate), Id: id.Bytes()})
 	if err != nil {
 		if s, ok := status.FromError(err); ok {
 			return false, errors.New(s.Message())

--- a/rpc/jsonrpc/eth_mining_test.go
+++ b/rpc/jsonrpc/eth_mining_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	txpool "github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cmd/rpcdaemon/rpcdaemontest"
 	"github.com/erigontech/erigon/db/kv/kvcache"
@@ -39,7 +39,7 @@ import (
 func TestPendingBlock(t *testing.T) {
 	m := mock.Mock(t)
 	ctx, conn := rpcdaemontest.CreateTestGrpcConn(t, mock.Mock(t))
-	mining := txpool.NewMiningClient(conn)
+	mining := txpoolproto.NewMiningClient(conn)
 	ff := rpchelper.New(ctx, rpchelper.DefaultFiltersConfig, nil, nil, mining, func() {}, m.Log)
 	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
 	engine := ethash.NewFaker()
@@ -50,7 +50,7 @@ func TestPendingBlock(t *testing.T) {
 	ch, id := ff.SubscribePendingBlock(1)
 	defer ff.UnsubscribePendingBlock(id)
 
-	ff.HandlePendingBlock(&txpool.OnPendingBlockReply{RplBlock: b})
+	ff.HandlePendingBlock(&txpoolproto.OnPendingBlockReply{RplBlock: b})
 	block := api.pendingBlock()
 
 	require.Equal(t, block.NumberU64(), expect)
@@ -65,7 +65,7 @@ func TestPendingBlock(t *testing.T) {
 func TestPendingLogs(t *testing.T) {
 	m := mock.Mock(t)
 	ctx, conn := rpcdaemontest.CreateTestGrpcConn(t, m)
-	mining := txpool.NewMiningClient(conn)
+	mining := txpoolproto.NewMiningClient(conn)
 	ff := rpchelper.New(ctx, rpchelper.DefaultFiltersConfig, nil, nil, mining, func() {}, m.Log)
 	expect := []byte{211}
 
@@ -74,7 +74,7 @@ func TestPendingLogs(t *testing.T) {
 
 	b, err := rlp.EncodeToBytes([]*types.Log{{Data: expect}})
 	require.NoError(t, err)
-	ff.HandlePendingLogs(&txpool.OnPendingLogsReply{RplLogs: b})
+	ff.HandlePendingLogs(&txpoolproto.OnPendingLogsReply{RplLogs: b})
 	select {
 	case logs := <-ch:
 		require.Equal(t, expect, logs[0].Data)

--- a/rpc/jsonrpc/eth_subscribe_test.go
+++ b/rpc/jsonrpc/eth_subscribe_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon-lib/common"
-	sentry "github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cmd/rpcdaemon/rpcservices"
 	"github.com/erigontech/erigon/core"
@@ -53,7 +53,7 @@ func TestEthSubscribe(t *testing.T) {
 	require.NoError(err)
 
 	m.ReceiveWg.Add(1)
-	for _, err = range m.Send(&sentry.InboundMessage{Id: sentry.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
+	for _, err = range m.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: m.PeerId}) {
 		require.NoError(err)
 	}
 	m.ReceiveWg.Wait() // Wait for all messages to be processed before we proceed

--- a/rpc/jsonrpc/eth_txs.go
+++ b/rpc/jsonrpc/eth_txs.go
@@ -25,10 +25,10 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/hexutil"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	txpool "github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
-	types "github.com/erigontech/erigon-lib/gointerfaces/typesproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 	"github.com/erigontech/erigon/db/rawdb"
-	types2 "github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/execution/types"
 	bortypes "github.com/erigontech/erigon/polygon/bor/types"
 	"github.com/erigontech/erigon/rpc"
 	"github.com/erigontech/erigon/rpc/ethapi"
@@ -113,12 +113,12 @@ func (api *APIImpl) GetTransactionByHash(ctx context.Context, txnHash common.Has
 	}
 
 	// No finalized transaction, try to retrieve it from the pool
-	reply, err := api.txPool.Transactions(ctx, &txpool.TransactionsRequest{Hashes: []*types.H256{gointerfaces.ConvertHashToH256(txnHash)}})
+	reply, err := api.txPool.Transactions(ctx, &txpoolproto.TransactionsRequest{Hashes: []*typesproto.H256{gointerfaces.ConvertHashToH256(txnHash)}})
 	if err != nil {
 		return nil, err
 	}
 	if len(reply.RlpTxs[0]) > 0 {
-		txn, err := types2.DecodeWrappedTransaction(reply.RlpTxs[0])
+		txn, err := types.DecodeWrappedTransaction(reply.RlpTxs[0])
 		if err != nil {
 			return nil, err
 		}
@@ -158,7 +158,7 @@ func (api *APIImpl) GetRawTransactionByHash(ctx context.Context, hash common.Has
 	if block == nil {
 		return nil, nil
 	}
-	var txn types2.Transaction
+	var txn types.Transaction
 	for _, transaction := range block.Transactions() {
 		if transaction.Hash() == hash {
 			txn = transaction
@@ -173,7 +173,7 @@ func (api *APIImpl) GetRawTransactionByHash(ctx context.Context, hash common.Has
 	}
 
 	// No finalized transaction, try to retrieve it from the pool
-	reply, err := api.txPool.Transactions(ctx, &txpool.TransactionsRequest{Hashes: []*types.H256{gointerfaces.ConvertHashToH256(hash)}})
+	reply, err := api.txPool.Transactions(ctx, &txpoolproto.TransactionsRequest{Hashes: []*typesproto.H256{gointerfaces.ConvertHashToH256(hash)}})
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +211,7 @@ func (api *APIImpl) GetTransactionByBlockHashAndIndex(ctx context.Context, block
 		if chainConfig.Bor == nil {
 			return nil, nil // not error
 		}
-		var borTx types2.Transaction
+		var borTx types.Transaction
 		possibleBorTxnHash := bortypes.ComputeBorTxHash(block.NumberU64(), block.Hash())
 		_, ok, err := api.bridgeReader.EventTxnLookup(ctx, possibleBorTxnHash)
 		if err != nil {
@@ -283,7 +283,7 @@ func (api *APIImpl) GetTransactionByBlockNumberAndIndex(ctx context.Context, blo
 		if chainConfig.Bor == nil {
 			return nil, nil // not error
 		}
-		var borTx types2.Transaction
+		var borTx types.Transaction
 		possibleBorTxnHash := bortypes.ComputeBorTxHash(blockNum, hash)
 		_, ok, err := api.bridgeReader.EventTxnLookup(ctx, possibleBorTxnHash)
 		if err != nil {

--- a/rpc/jsonrpc/receipts/handler_test.go
+++ b/rpc/jsonrpc/receipts/handler_test.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/crypto"
-	sentry "github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon/core"
 	"github.com/erigontech/erigon/db/rawdb"
 	"github.com/erigontech/erigon/execution/chain"
@@ -248,7 +248,7 @@ func TestGetBlockHeaders(t *testing.T) {
 		backend.ReceiveWg.Add(1)
 		encodedMessage, err := rlp.EncodeToBytes(eth.GetBlockHeadersPacket66{RequestId: 1, GetBlockHeadersPacket: tt.query})
 		require.NoError(t, err)
-		for _, err = range backend.Send(&sentry.InboundMessage{Id: eth.ToProto[direct.ETH68][eth.GetBlockHeadersMsg], Data: encodedMessage, PeerId: backend.PeerId}) {
+		for _, err = range backend.Send(&sentryproto.InboundMessage{Id: eth.ToProto[direct.ETH68][eth.GetBlockHeadersMsg], Data: encodedMessage, PeerId: backend.PeerId}) {
 			require.NoError(t, err)
 		}
 		expect, err := rlp.EncodeToBytes(eth.BlockHeadersPacket66{RequestId: 1, BlockHeadersPacket: expectedHeaders})
@@ -330,7 +330,7 @@ func TestGetBlockReceipts(t *testing.T) {
 
 	m.ReceiveWg.Add(1)
 	// Send the hash request and verify the response
-	for _, err = range m.Send(&sentry.InboundMessage{Id: eth.ToProto[direct.ETH67][eth.GetReceiptsMsg], Data: b, PeerId: m.PeerId}) {
+	for _, err = range m.Send(&sentryproto.InboundMessage{Id: eth.ToProto[direct.ETH67][eth.GetReceiptsMsg], Data: b, PeerId: m.PeerId}) {
 		require.NoError(t, err)
 	}
 

--- a/rpc/jsonrpc/send_transaction.go
+++ b/rpc/jsonrpc/send_transaction.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/hexutil"
-	txPoolProto "github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon/execution/types"
 )
 
@@ -52,13 +52,13 @@ func (api *APIImpl) SendRawTransaction(ctx context.Context, encodedTx hexutil.By
 	}
 
 	hash := txn.Hash()
-	res, err := api.txPool.Add(ctx, &txPoolProto.AddRequest{RlpTxs: [][]byte{encodedTx}})
+	res, err := api.txPool.Add(ctx, &txpoolproto.AddRequest{RlpTxs: [][]byte{encodedTx}})
 	if err != nil {
 		return common.Hash{}, err
 	}
 
-	if res.Imported[0] != txPoolProto.ImportResult_SUCCESS {
-		return hash, fmt.Errorf("%s: %s", txPoolProto.ImportResult_name[int32(res.Imported[0])], res.Errors[0])
+	if res.Imported[0] != txpoolproto.ImportResult_SUCCESS {
+		return hash, fmt.Errorf("%s: %s", txpoolproto.ImportResult_name[int32(res.Imported[0])], res.Errors[0])
 	}
 
 	return txn.Hash(), nil

--- a/rpc/jsonrpc/send_transaction_test.go
+++ b/rpc/jsonrpc/send_transaction_test.go
@@ -28,9 +28,8 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/u256"
-	sentry "github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
-	txpool "github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
-	txpool_proto "github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cmd/rpcdaemon/rpcdaemontest"
 	"github.com/erigontech/erigon/core"
@@ -61,7 +60,7 @@ func oneBlockStep(mockSentry *mock.MockSentry, require *require.Assertions, t *t
 	require.NoError(err)
 
 	mockSentry.ReceiveWg.Add(1)
-	for _, err = range mockSentry.Send(&sentry.InboundMessage{Id: sentry.MessageId_NEW_BLOCK_66, Data: b, PeerId: mockSentry.PeerId}) {
+	for _, err = range mockSentry.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_NEW_BLOCK_66, Data: b, PeerId: mockSentry.PeerId}) {
 		require.NoError(err)
 	}
 	// Send all the headers
@@ -71,7 +70,7 @@ func oneBlockStep(mockSentry *mock.MockSentry, require *require.Assertions, t *t
 	})
 	require.NoError(err)
 	mockSentry.ReceiveWg.Add(1)
-	for _, err = range mockSentry.Send(&sentry.InboundMessage{Id: sentry.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: mockSentry.PeerId}) {
+	for _, err = range mockSentry.Send(&sentryproto.InboundMessage{Id: sentryproto.MessageId_BLOCK_HEADERS_66, Data: b, PeerId: mockSentry.PeerId}) {
 		require.NoError(err)
 	}
 	mockSentry.ReceiveWg.Wait() // Wait for all messages to be processed before we proceed
@@ -97,8 +96,8 @@ func TestSendRawTransaction(t *testing.T) {
 	require.NoError(err)
 
 	ctx, conn := rpcdaemontest.CreateTestGrpcConn(t, mockSentry)
-	txPool := txpool.NewTxpoolClient(conn)
-	ff := rpchelper.New(ctx, rpchelper.DefaultFiltersConfig, nil, txPool, txpool.NewMiningClient(conn), func() {}, mockSentry.Log)
+	txPool := txpoolproto.NewTxpoolClient(conn)
+	ff := rpchelper.New(ctx, rpchelper.DefaultFiltersConfig, nil, txPool, txpoolproto.NewMiningClient(conn), func() {}, mockSentry.Log)
 	api := NewEthAPI(newBaseApiForTest(mockSentry), mockSentry.DB, nil, txPool, nil, 5000000, ethconfig.Defaults.RPCTxFeeCap, 100_000, false, 100_000, 128, logger)
 
 	buf := bytes.NewBuffer(nil)
@@ -124,7 +123,7 @@ func TestSendRawTransaction(t *testing.T) {
 	//send same txn second time and expect error
 	_, err = api.SendRawTransaction(ctx, buf.Bytes())
 	require.Error(err)
-	expectedErr := txpool_proto.ImportResult_name[int32(txpool_proto.ImportResult_ALREADY_EXISTS)] + ": " + txpoolcfg.AlreadyKnown.String()
+	expectedErr := txpoolproto.ImportResult_name[int32(txpoolproto.ImportResult_ALREADY_EXISTS)] + ": " + txpoolcfg.AlreadyKnown.String()
 	require.Equal(expectedErr, err.Error())
 	mockSentry.ReceiveWg.Wait()
 
@@ -153,8 +152,8 @@ func TestSendRawTransactionUnprotected(t *testing.T) {
 	require.NoError(err)
 
 	ctx, conn := rpcdaemontest.CreateTestGrpcConn(t, mockSentry)
-	txPool := txpool.NewTxpoolClient(conn)
-	ff := rpchelper.New(ctx, rpchelper.DefaultFiltersConfig, nil, txPool, txpool.NewMiningClient(conn), func() {}, mockSentry.Log)
+	txPool := txpoolproto.NewTxpoolClient(conn)
+	ff := rpchelper.New(ctx, rpchelper.DefaultFiltersConfig, nil, txPool, txpoolproto.NewMiningClient(conn), func() {}, mockSentry.Log)
 	api := NewEthAPI(newBaseApiForTest(mockSentry), mockSentry.DB, nil, txPool, nil, 5000000, ethconfig.Defaults.RPCTxFeeCap, 100_000, false, 100_000, 128, logger)
 
 	// Enable unproteced txs flag

--- a/rpc/jsonrpc/txpool_api.go
+++ b/rpc/jsonrpc/txpool_api.go
@@ -24,7 +24,7 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/hexutil"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	proto_txpool "github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/rawdb"
 	"github.com/erigontech/erigon/execution/types"
@@ -40,12 +40,12 @@ type TxPoolAPI interface {
 // TxPoolAPIImpl data structure to store things needed for net_ commands
 type TxPoolAPIImpl struct {
 	*BaseAPI
-	pool proto_txpool.TxpoolClient
+	pool txpoolproto.TxpoolClient
 	db   kv.TemporalRoDB
 }
 
 // NewTxPoolAPI returns NetAPIImplImpl instance
-func NewTxPoolAPI(base *BaseAPI, db kv.TemporalRoDB, pool proto_txpool.TxpoolClient) *TxPoolAPIImpl {
+func NewTxPoolAPI(base *BaseAPI, db kv.TemporalRoDB, pool txpoolproto.TxpoolClient) *TxPoolAPIImpl {
 	return &TxPoolAPIImpl{
 		BaseAPI: base,
 		pool:    pool,
@@ -54,7 +54,7 @@ func NewTxPoolAPI(base *BaseAPI, db kv.TemporalRoDB, pool proto_txpool.TxpoolCli
 }
 
 func (api *TxPoolAPIImpl) Content(ctx context.Context) (map[string]map[string]map[string]*ethapi.RPCTransaction, error) {
-	reply, err := api.pool.All(ctx, &proto_txpool.AllRequest{})
+	reply, err := api.pool.All(ctx, &txpoolproto.AllRequest{})
 	if err != nil {
 		return nil, err
 	}
@@ -75,17 +75,17 @@ func (api *TxPoolAPIImpl) Content(ctx context.Context) (map[string]map[string]ma
 		}
 		addr := gointerfaces.ConvertH160toAddress(reply.Txs[i].Sender)
 		switch reply.Txs[i].TxnType {
-		case proto_txpool.AllReply_PENDING:
+		case txpoolproto.AllReply_PENDING:
 			if _, ok := pending[addr]; !ok {
 				pending[addr] = make([]types.Transaction, 0, 4)
 			}
 			pending[addr] = append(pending[addr], txn)
-		case proto_txpool.AllReply_BASE_FEE:
+		case txpoolproto.AllReply_BASE_FEE:
 			if _, ok := baseFee[addr]; !ok {
 				baseFee[addr] = make([]types.Transaction, 0, 4)
 			}
 			baseFee[addr] = append(baseFee[addr], txn)
-		case proto_txpool.AllReply_QUEUED:
+		case txpoolproto.AllReply_QUEUED:
 			if _, ok := queued[addr]; !ok {
 				queued[addr] = make([]types.Transaction, 0, 4)
 			}
@@ -135,7 +135,7 @@ func (api *TxPoolAPIImpl) Content(ctx context.Context) (map[string]map[string]ma
 }
 
 func (api *TxPoolAPIImpl) ContentFrom(ctx context.Context, addr common.Address) (map[string]map[string]*ethapi.RPCTransaction, error) {
-	reply, err := api.pool.All(ctx, &proto_txpool.AllRequest{})
+	reply, err := api.pool.All(ctx, &txpoolproto.AllRequest{})
 	if err != nil {
 		return nil, err
 	}
@@ -160,11 +160,11 @@ func (api *TxPoolAPIImpl) ContentFrom(ctx context.Context, addr common.Address) 
 		}
 
 		switch reply.Txs[i].TxnType {
-		case proto_txpool.AllReply_PENDING:
+		case txpoolproto.AllReply_PENDING:
 			pending = append(pending, txn)
-		case proto_txpool.AllReply_BASE_FEE:
+		case txpoolproto.AllReply_BASE_FEE:
 			baseFee = append(baseFee, txn)
-		case proto_txpool.AllReply_QUEUED:
+		case txpoolproto.AllReply_QUEUED:
 			queued = append(queued, txn)
 		}
 	}
@@ -206,7 +206,7 @@ func (api *TxPoolAPIImpl) ContentFrom(ctx context.Context, addr common.Address) 
 
 // Status returns the number of pending and queued transaction in the pool.
 func (api *TxPoolAPIImpl) Status(ctx context.Context) (map[string]hexutil.Uint, error) {
-	reply, err := api.pool.Status(ctx, &proto_txpool.StatusRequest{})
+	reply, err := api.pool.Status(ctx, &txpoolproto.StatusRequest{})
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/jsonrpc/txpool_api_test.go
+++ b/rpc/jsonrpc/txpool_api_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/hexutil"
-	txpool "github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon/cmd/rpcdaemon/rpcdaemontest"
 	"github.com/erigontech/erigon/core"
 	"github.com/erigontech/erigon/db/kv/kvcache"
@@ -47,8 +47,8 @@ func TestTxPoolContent(t *testing.T) {
 	require.NoError(err)
 
 	ctx, conn := rpcdaemontest.CreateTestGrpcConn(t, m)
-	txPool := txpool.NewTxpoolClient(conn)
-	ff := rpchelper.New(ctx, rpchelper.DefaultFiltersConfig, nil, txPool, txpool.NewMiningClient(conn), func() {}, m.Log)
+	txPool := txpoolproto.NewTxpoolClient(conn)
+	ff := rpchelper.New(ctx, rpchelper.DefaultFiltersConfig, nil, txPool, txpoolproto.NewMiningClient(conn), func() {}, m.Log)
 	api := NewTxPoolAPI(NewBaseApi(ff, kvcache.New(kvcache.DefaultCoherentConfig), m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil), m.DB, txPool)
 
 	expectValue := uint64(1234)
@@ -59,10 +59,10 @@ func TestTxPoolContent(t *testing.T) {
 	err = txn.MarshalBinary(buf)
 	require.NoError(err)
 
-	reply, err := txPool.Add(ctx, &txpool.AddRequest{RlpTxs: [][]byte{buf.Bytes()}})
+	reply, err := txPool.Add(ctx, &txpoolproto.AddRequest{RlpTxs: [][]byte{buf.Bytes()}})
 	require.NoError(err)
 	for _, res := range reply.Imported {
-		require.Equal(txpool.ImportResult_SUCCESS, res, fmt.Sprintf("%s", reply.Errors))
+		require.Equal(txpoolproto.ImportResult_SUCCESS, res, fmt.Sprintf("%s", reply.Errors))
 	}
 
 	content, err := api.Content(ctx)

--- a/rpc/rpchelper/filters.go
+++ b/rpc/rpchelper/filters.go
@@ -35,8 +35,8 @@ import (
 	"github.com/erigontech/erigon-lib/common/concurrent"
 	"github.com/erigontech/erigon-lib/gointerfaces"
 	"github.com/erigontech/erigon-lib/gointerfaces/grpcutil"
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
-	txpool "github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/eth/filters"
 	"github.com/erigontech/erigon/execution/rlp"
@@ -71,7 +71,7 @@ type Filters struct {
 // New creates a new Filters instance, initializes it, and starts subscription goroutines for Ethereum events.
 // It requires a context, Ethereum backend, transaction pool client, mining client, snapshot callback function,
 // and a logger for logging events.
-func New(ctx context.Context, config FiltersConfig, ethBackend ApiBackend, txPool txpool.TxpoolClient, mining txpool.MiningClient, onNewSnapshot func(), logger log.Logger) *Filters {
+func New(ctx context.Context, config FiltersConfig, ethBackend ApiBackend, txPool txpoolproto.TxpoolClient, mining txpoolproto.MiningClient, onNewSnapshot func(), logger log.Logger) *Filters {
 	logger.Info("rpc filters: subscribing to Erigon events")
 
 	ff := &Filters{
@@ -235,8 +235,8 @@ func (ff *Filters) LastPendingBlock() *types.Block {
 
 // subscribeToPendingTransactions subscribes to pending transactions using the given transaction pool client.
 // It listens for new transactions and processes them as they arrive.
-func (ff *Filters) subscribeToPendingTransactions(ctx context.Context, txPool txpool.TxpoolClient) error {
-	subscription, err := txPool.OnAdd(ctx, &txpool.OnAddRequest{}, grpc.WaitForReady(true))
+func (ff *Filters) subscribeToPendingTransactions(ctx context.Context, txPool txpoolproto.TxpoolClient) error {
+	subscription, err := txPool.OnAdd(ctx, &txpoolproto.OnAddRequest{}, grpc.WaitForReady(true))
 	if err != nil {
 		return err
 	}
@@ -257,8 +257,8 @@ func (ff *Filters) subscribeToPendingTransactions(ctx context.Context, txPool tx
 
 // subscribeToPendingBlocks subscribes to pending blocks using the given mining client.
 // It listens for new pending blocks and processes them as they arrive.
-func (ff *Filters) subscribeToPendingBlocks(ctx context.Context, mining txpool.MiningClient) error {
-	subscription, err := mining.OnPendingBlock(ctx, &txpool.OnPendingBlockRequest{}, grpc.WaitForReady(true))
+func (ff *Filters) subscribeToPendingBlocks(ctx context.Context, mining txpoolproto.MiningClient) error {
+	subscription, err := mining.OnPendingBlock(ctx, &txpoolproto.OnPendingBlockRequest{}, grpc.WaitForReady(true))
 	if err != nil {
 		return err
 	}
@@ -285,7 +285,7 @@ func (ff *Filters) subscribeToPendingBlocks(ctx context.Context, mining txpool.M
 
 // HandlePendingBlock handles a new pending block received from the mining client.
 // It updates the internal state and notifies subscribers about the new block.
-func (ff *Filters) HandlePendingBlock(reply *txpool.OnPendingBlockReply) {
+func (ff *Filters) HandlePendingBlock(reply *txpoolproto.OnPendingBlockReply) {
 	b := &types.Block{}
 	if reply == nil || len(reply.RplBlock) == 0 {
 		return
@@ -306,8 +306,8 @@ func (ff *Filters) HandlePendingBlock(reply *txpool.OnPendingBlockReply) {
 
 // subscribeToPendingLogs subscribes to pending logs using the given mining client.
 // It listens for new pending logs and processes them as they arrive.
-func (ff *Filters) subscribeToPendingLogs(ctx context.Context, mining txpool.MiningClient) error {
-	subscription, err := mining.OnPendingLogs(ctx, &txpool.OnPendingLogsRequest{}, grpc.WaitForReady(true))
+func (ff *Filters) subscribeToPendingLogs(ctx context.Context, mining txpoolproto.MiningClient) error {
+	subscription, err := mining.OnPendingLogs(ctx, &txpoolproto.OnPendingLogsRequest{}, grpc.WaitForReady(true))
 	if err != nil {
 		return err
 	}
@@ -333,7 +333,7 @@ func (ff *Filters) subscribeToPendingLogs(ctx context.Context, mining txpool.Min
 
 // HandlePendingLogs handles new pending logs received from the mining client.
 // It updates the internal state and notifies subscribers about the new logs.
-func (ff *Filters) HandlePendingLogs(reply *txpool.OnPendingLogsReply) {
+func (ff *Filters) HandlePendingLogs(reply *txpoolproto.OnPendingLogsReply) {
 	if len(reply.RplLogs) == 0 {
 		return
 	}
@@ -501,7 +501,7 @@ func (ff *Filters) SubscribeLogs(size int, criteria filters.FilterCriteria) (<-c
 
 	loaded := ff.loadLogsRequester()
 	if loaded != nil {
-		if err := loaded.(func(*remote.LogsFilterRequest) error)(lfr); err != nil {
+		if err := loaded.(func(*remoteproto.LogsFilterRequest) error)(lfr); err != nil {
 			ff.logger.Warn("Could not update remote logs filter", "err", err)
 			ff.logsSubs.removeLogsFilter(id)
 		}
@@ -535,7 +535,7 @@ func (ff *Filters) UnsubscribeLogs(id LogsSubID) bool {
 	}
 	loaded := ff.loadLogsRequester()
 	if loaded != nil {
-		if err := loaded.(func(*remote.LogsFilterRequest) error)(lfr); err != nil {
+		if err := loaded.(func(*remoteproto.LogsFilterRequest) error)(lfr); err != nil {
 			ff.logger.Warn("Could not update remote logs filter", "err", err)
 			return isDeleted || ff.logsSubs.removeLogsFilter(id)
 		}
@@ -552,7 +552,7 @@ func (ff *Filters) deleteLogStore(id LogsSubID) {
 }
 
 // OnNewEvent is called when there is a new event from the remote and processes it.
-func (ff *Filters) OnNewEvent(event *remote.SubscribeReply) {
+func (ff *Filters) OnNewEvent(event *remoteproto.SubscribeReply) {
 	err := ff.onNewEvent(event)
 	if err != nil {
 		ff.logger.Warn("OnNewEvent Filters", "event", event.Type, "err", err)
@@ -560,16 +560,16 @@ func (ff *Filters) OnNewEvent(event *remote.SubscribeReply) {
 }
 
 // onNewEvent processes the given event from the remote and updates the internal state.
-func (ff *Filters) onNewEvent(event *remote.SubscribeReply) error {
+func (ff *Filters) onNewEvent(event *remoteproto.SubscribeReply) error {
 	switch event.Type {
-	case remote.Event_HEADER:
+	case remoteproto.Event_HEADER:
 		return ff.onNewHeader(event)
-	case remote.Event_NEW_SNAPSHOT:
+	case remoteproto.Event_NEW_SNAPSHOT:
 		ff.onNewSnapshot()
 		return nil
-	case remote.Event_PENDING_LOGS:
+	case remoteproto.Event_PENDING_LOGS:
 		return ff.onPendingLog(event)
-	case remote.Event_PENDING_BLOCK:
+	case remoteproto.Event_PENDING_BLOCK:
 		return ff.onPendingBlock(event)
 	default:
 		return errors.New("unsupported event type")
@@ -578,7 +578,7 @@ func (ff *Filters) onNewEvent(event *remote.SubscribeReply) error {
 
 // TODO: implement?
 // onPendingLog handles a new pending log event from the remote.
-func (ff *Filters) onPendingLog(event *remote.SubscribeReply) error {
+func (ff *Filters) onPendingLog(event *remoteproto.SubscribeReply) error {
 	//	payload := event.Data
 	//	var logs types.Logs
 	//	err := rlp.Decode(bytes.NewReader(payload), &logs)
@@ -595,7 +595,7 @@ func (ff *Filters) onPendingLog(event *remote.SubscribeReply) error {
 
 // TODO: implement?
 // onPendingBlock handles a new pending block event from the remote.
-func (ff *Filters) onPendingBlock(event *remote.SubscribeReply) error {
+func (ff *Filters) onPendingBlock(event *remoteproto.SubscribeReply) error {
 	//	payload := event.Data
 	//	var block types.Block
 	//	err := rlp.Decode(bytes.NewReader(payload), &block)
@@ -611,7 +611,7 @@ func (ff *Filters) onPendingBlock(event *remote.SubscribeReply) error {
 }
 
 // onNewHeader handles a new block header event from the remote and updates the internal state.
-func (ff *Filters) onNewHeader(event *remote.SubscribeReply) error {
+func (ff *Filters) onNewHeader(event *remoteproto.SubscribeReply) error {
 	payload := event.Data
 	var header types.Header
 	if len(payload) == 0 {
@@ -628,7 +628,7 @@ func (ff *Filters) onNewHeader(event *remote.SubscribeReply) error {
 }
 
 // OnNewTx handles a new transaction event from the transaction pool and processes it.
-func (ff *Filters) OnNewTx(reply *txpool.OnAddReply) {
+func (ff *Filters) OnNewTx(reply *txpoolproto.OnAddReply) {
 	txs := make([]types.Transaction, len(reply.RplTxs))
 	for i, rlpTx := range reply.RplTxs {
 		var decodeErr error
@@ -649,7 +649,7 @@ func (ff *Filters) OnNewTx(reply *txpool.OnAddReply) {
 }
 
 // OnNewLogs handles a new log event from the remote and processes it.
-func (ff *Filters) OnNewLogs(reply *remote.SubscribeLogsReply) {
+func (ff *Filters) OnNewLogs(reply *remoteproto.SubscribeLogsReply) {
 	ff.logsSubs.distributeLog(reply)
 }
 

--- a/rpc/rpchelper/filters_test.go
+++ b/rpc/rpchelper/filters_test.go
@@ -24,21 +24,21 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
-	types2 "github.com/erigontech/erigon-lib/gointerfaces/typesproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/eth/filters"
 	"github.com/erigontech/erigon/execution/types"
 )
 
-func createLog() *remote.SubscribeLogsReply {
-	return &remote.SubscribeLogsReply{
+func createLog() *remoteproto.SubscribeLogsReply {
+	return &remoteproto.SubscribeLogsReply{
 		Address:          gointerfaces.ConvertAddressToH160([20]byte{}),
 		BlockHash:        gointerfaces.ConvertHashToH256([32]byte{}),
 		BlockNumber:      0,
 		Data:             []byte{},
 		LogIndex:         0,
-		Topics:           []*types2.H256{gointerfaces.ConvertHashToH256([32]byte{99, 99})},
+		Topics:           []*typesproto.H256{gointerfaces.ConvertHashToH256([32]byte{99, 99})},
 		TransactionHash:  gointerfaces.ConvertHashToH256([32]byte{}),
 		TransactionIndex: 0,
 		Removed:          false,
@@ -97,7 +97,7 @@ func TestFilters_SingleSubscription_OnlyTopicsSubscribedAreBroadcast(t *testing.
 	}
 
 	// now a log that the subscription cares about
-	log.Topics = []*types2.H256{gointerfaces.ConvertHashToH256(subbedTopic)}
+	log.Topics = []*typesproto.H256{gointerfaces.ConvertHashToH256(subbedTopic)}
 
 	f.OnNewLogs(log)
 
@@ -131,7 +131,7 @@ func TestFilters_SingleSubscription_EmptyTopicsInCriteria_OnlyTopicsSubscribedAr
 	}
 
 	// now a log that the subscription cares about
-	log.Topics = []*types2.H256{gointerfaces.ConvertHashToH256(subbedTopic)}
+	log.Topics = []*typesproto.H256{gointerfaces.ConvertHashToH256(subbedTopic)}
 
 	f.OnNewLogs(log)
 
@@ -169,7 +169,7 @@ func TestFilters_TwoSubscriptionsWithDifferentCriteria(t *testing.T) {
 	}
 
 	// now a log that the subscription cares about
-	log.Topics = []*types2.H256{gointerfaces.ConvertHashToH256(topic1)}
+	log.Topics = []*typesproto.H256{gointerfaces.ConvertHashToH256(topic1)}
 
 	f.OnNewLogs(log)
 
@@ -236,7 +236,7 @@ func TestFilters_ThreeSubscriptionsWithDifferentCriteria(t *testing.T) {
 	}
 
 	log = createLog()
-	log.Topics = []*types2.H256{topic1H256}
+	log.Topics = []*typesproto.H256{topic1H256}
 	f.OnNewLogs(log)
 
 	if len(chan1) != 3 {
@@ -253,8 +253,8 @@ func TestFilters_ThreeSubscriptionsWithDifferentCriteria(t *testing.T) {
 
 func TestFilters_SubscribeLogsGeneratesCorrectLogFilterRequest(t *testing.T) {
 	t.Parallel()
-	var lastFilterRequest *remote.LogsFilterRequest
-	loadRequester := func(r *remote.LogsFilterRequest) error {
+	var lastFilterRequest *remoteproto.LogsFilterRequest
+	loadRequester := func(r *remoteproto.LogsFilterRequest) error {
 		lastFilterRequest = r
 		return nil
 	}

--- a/rpc/rpchelper/interface.go
+++ b/rpc/rpchelper/interface.go
@@ -21,7 +21,7 @@ import (
 	"sync/atomic"
 
 	"github.com/erigontech/erigon-lib/common"
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/p2p"
@@ -31,18 +31,18 @@ import (
 // implementation can work with local Ethereum object or with Remote (grpc-based) one
 // this is reason why all methods are accepting context and returning error
 type ApiBackend interface {
-	Syncing(ctx context.Context) (*remote.SyncingReply, error)
+	Syncing(ctx context.Context) (*remoteproto.SyncingReply, error)
 	Etherbase(ctx context.Context) (common.Address, error)
 	NetVersion(ctx context.Context) (uint64, error)
 	NetPeerCount(ctx context.Context) (uint64, error)
 	ProtocolVersion(ctx context.Context) (uint64, error)
 	ClientVersion(ctx context.Context) (string, error)
-	Subscribe(ctx context.Context, cb func(*remote.SubscribeReply)) error
-	SubscribeLogs(ctx context.Context, cb func(*remote.SubscribeLogsReply), requestor *atomic.Value) error
+	Subscribe(ctx context.Context, cb func(*remoteproto.SubscribeReply)) error
+	SubscribeLogs(ctx context.Context, cb func(*remoteproto.SubscribeLogsReply), requestor *atomic.Value) error
 	BlockWithSenders(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (block *types.Block, senders []common.Address, err error)
 	NodeInfo(ctx context.Context, limit uint32) ([]p2p.NodeInfo, error)
 	Peers(ctx context.Context) ([]*p2p.PeerInfo, error)
-	AddPeer(ctx context.Context, url *remote.AddPeerRequest) (*remote.AddPeerReply, error)
-	RemovePeer(ctx context.Context, url *remote.RemovePeerRequest) (*remote.RemovePeerReply, error)
+	AddPeer(ctx context.Context, url *remoteproto.AddPeerRequest) (*remoteproto.AddPeerReply, error)
+	RemovePeer(ctx context.Context, url *remoteproto.RemovePeerRequest) (*remoteproto.RemovePeerReply, error)
 	PendingBlock(ctx context.Context) (*types.Block, error)
 }

--- a/rpc/rpchelper/logsfilter.go
+++ b/rpc/rpchelper/logsfilter.go
@@ -22,7 +22,7 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/concurrent"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
 	"github.com/erigontech/erigon/execution/types"
 )
 
@@ -106,10 +106,10 @@ func (a *LogsFilterAggregator) removeLogsFilter(filterId LogsSubID) bool {
 
 // createFilterRequest creates a LogsFilterRequest from the current state of the LogsFilterAggregator.
 // It generates a request that represents the union of all current log filters.
-func (a *LogsFilterAggregator) createFilterRequest() *remote.LogsFilterRequest {
+func (a *LogsFilterAggregator) createFilterRequest() *remoteproto.LogsFilterRequest {
 	a.logsFilterLock.RLock()
 	defer a.logsFilterLock.RUnlock()
-	return &remote.LogsFilterRequest{
+	return &remoteproto.LogsFilterRequest{
 		AllAddresses: a.aggLogsFilter.allAddrs >= 1,
 		AllTopics:    a.aggLogsFilter.allTopics >= 1,
 	}
@@ -215,7 +215,7 @@ func (a *LogsFilterAggregator) getAggMaps() (map[common.Address]int, map[common.
 
 // distributeLog processes an event log and distributes it to all subscribed log filters.
 // It checks each filter to determine if the log should be sent based on the filter's address and topic settings.
-func (a *LogsFilterAggregator) distributeLog(eventLog *remote.SubscribeLogsReply) error {
+func (a *LogsFilterAggregator) distributeLog(eventLog *remoteproto.SubscribeLogsReply) error {
 	a.logsFilterLock.RLock()
 	defer a.logsFilterLock.RUnlock()
 

--- a/turbo/app/import_cmd.go
+++ b/turbo/app/import_cmd.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	execution "github.com/erigontech/erigon-lib/gointerfaces/executionproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/executionproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/cmd/utils"
 	"github.com/erigontech/erigon/core"
@@ -289,7 +289,7 @@ func insertPosChain(ethereum *eth.Ethereum, chain *core.ChainPack, logger log.Lo
 		rawdb.WriteHeadBlockHash(tx, lvh)
 		return nil
 	})
-	if status != execution.ExecutionStatus_Success {
+	if status != executionproto.ExecutionStatus_Success {
 		return fmt.Errorf("insertion failed for block %d, code: %s", chain.Blocks[chain.Length()-1].NumberU64(), status.String())
 	}
 

--- a/turbo/app/support_cmd.go
+++ b/turbo/app/support_cmd.go
@@ -35,8 +35,8 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/urfave/cli/v2"
 
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
-	types "github.com/erigontech/erigon-lib/gointerfaces/typesproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/rpc"
 	"github.com/erigontech/erigon/turbo/debug"
@@ -114,10 +114,10 @@ type tunnelInfo struct {
 }
 
 type tunnelEnode struct {
-	Enode        string               `json:"enode,omitempty"`
-	Enr          string               `json:"enr,omitempty"`
-	Ports        *types.NodeInfoPorts `json:"ports,omitempty"`
-	ListenerAddr string               `json:"listener_addr,omitempty"`
+	Enode        string                    `json:"enode,omitempty"`
+	Enr          string                    `json:"enr,omitempty"`
+	Ports        *typesproto.NodeInfoPorts `json:"ports,omitempty"`
+	ListenerAddr string                    `json:"listener_addr,omitempty"`
 }
 
 type requestAction struct {
@@ -353,7 +353,7 @@ func createConnections(ctx context.Context, codec rpc.ServerCodec, metricsClient
 // Attempt to query nodes specified by flag debug.addrs and return the response.
 // If the request fails, an error is returned, as we expect all nodes to be reachable.
 // TODO: maybe it make sense to think about allowing some nodes to be unreachable
-func queryNode(metricsClient *http.Client, debugURL string) (*remote.NodesInfoReply, error) {
+func queryNode(metricsClient *http.Client, debugURL string) (*remoteproto.NodesInfoReply, error) {
 	debugResponse, err := metricsClient.Get(debugURL + "/debug/diag/nodeinfo")
 
 	if err != nil {
@@ -364,7 +364,7 @@ func queryNode(metricsClient *http.Client, debugURL string) (*remote.NodesInfoRe
 		return nil, fmt.Errorf("debug request to %s failed: %s", debugURL, debugResponse.Status)
 	}
 
-	var reply remote.NodesInfoReply
+	var reply remoteproto.NodesInfoReply
 
 	err = json.NewDecoder(debugResponse.Body).Decode(&reply)
 

--- a/turbo/privateapi/all.go
+++ b/turbo/privateapi/all.go
@@ -26,7 +26,7 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/erigontech/erigon-lib/gointerfaces/grpcutil"
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
 	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/kv/remotedbserver"
@@ -44,7 +44,7 @@ func StartGrpc(kv *remotedbserver.KvServer, ethBackendSrv *EthBackendServer, txP
 	}
 
 	grpcServer := grpcutil.NewServer(rateLimit, creds)
-	remote.RegisterETHBACKENDServer(grpcServer, ethBackendSrv)
+	remoteproto.RegisterETHBACKENDServer(grpcServer, ethBackendSrv)
 	if txPoolServer != nil {
 		txpoolproto.RegisterTxpoolServer(grpcServer, txPoolServer)
 	}
@@ -52,13 +52,13 @@ func StartGrpc(kv *remotedbserver.KvServer, ethBackendSrv *EthBackendServer, txP
 		txpoolproto.RegisterMiningServer(grpcServer, miningServer)
 	}
 	if bridgeServer != nil {
-		remote.RegisterBridgeBackendServer(grpcServer, bridgeServer)
+		remoteproto.RegisterBridgeBackendServer(grpcServer, bridgeServer)
 	}
 	if heimdallServer != nil {
-		remote.RegisterHeimdallBackendServer(grpcServer, heimdallServer)
+		remoteproto.RegisterHeimdallBackendServer(grpcServer, heimdallServer)
 	}
 
-	remote.RegisterKVServer(grpcServer, kv)
+	remoteproto.RegisterKVServer(grpcServer, kv)
 	var healthServer *health.Server
 	if healthCheck {
 		healthServer = health.NewServer()

--- a/turbo/privateapi/logsfilter_test.go
+++ b/turbo/privateapi/logsfilter_test.go
@@ -25,17 +25,16 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
-	types2 "github.com/erigontech/erigon-lib/gointerfaces/typesproto"
-
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 	"github.com/erigontech/erigon/turbo/shards"
 )
 
 var (
 	address1   = common.HexToHash("0xdac17f958d2ee523a2206206994597c13d831ec7")
 	topic1     = common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef")
-	address160 *types2.H160
-	topic1H256 *types2.H256
+	address160 *typesproto.H160
+	topic1H256 *typesproto.H256
 )
 
 func init() {
@@ -46,18 +45,18 @@ func init() {
 }
 
 type testServer struct {
-	received         chan *remote.LogsFilterRequest
+	received         chan *remoteproto.LogsFilterRequest
 	receiveCompleted chan struct{}
-	sent             []*remote.SubscribeLogsReply
+	sent             []*remoteproto.SubscribeLogsReply
 	ctx              context.Context
 	grpc.ServerStream
 }
 
 func newTestServer(ctx context.Context) *testServer {
 	ts := &testServer{
-		received:         make(chan *remote.LogsFilterRequest, 256),
+		received:         make(chan *remoteproto.LogsFilterRequest, 256),
 		receiveCompleted: make(chan struct{}, 1),
-		sent:             make([]*remote.SubscribeLogsReply, 0),
+		sent:             make([]*remoteproto.SubscribeLogsReply, 0),
 		ctx:              ctx,
 		ServerStream:     nil,
 	}
@@ -68,12 +67,12 @@ func newTestServer(ctx context.Context) *testServer {
 	return ts
 }
 
-func (ts *testServer) Send(m *remote.SubscribeLogsReply) error {
+func (ts *testServer) Send(m *remoteproto.SubscribeLogsReply) error {
 	ts.sent = append(ts.sent, m)
 	return nil
 }
 
-func (ts *testServer) Recv() (*remote.LogsFilterRequest, error) {
+func (ts *testServer) Recv() (*remoteproto.LogsFilterRequest, error) {
 	// notify receive completed when the last request has been processed
 	if len(ts.received) == 0 {
 		ts.receiveCompleted <- struct{}{}
@@ -86,14 +85,14 @@ func (ts *testServer) Recv() (*remote.LogsFilterRequest, error) {
 	return request, nil
 }
 
-func createLog() *remote.SubscribeLogsReply {
-	return &remote.SubscribeLogsReply{
+func createLog() *remoteproto.SubscribeLogsReply {
+	return &remoteproto.SubscribeLogsReply{
 		Address:          gointerfaces.ConvertAddressToH160([20]byte{}),
 		BlockHash:        gointerfaces.ConvertHashToH256([32]byte{}),
 		BlockNumber:      0,
 		Data:             []byte{},
 		LogIndex:         0,
-		Topics:           []*types2.H256{gointerfaces.ConvertHashToH256([32]byte{99, 99})},
+		Topics:           []*typesproto.H256{gointerfaces.ConvertHashToH256([32]byte{99, 99})},
 		TransactionHash:  gointerfaces.ConvertHashToH256([32]byte{}),
 		TransactionIndex: 0,
 		Removed:          false,
@@ -107,7 +106,7 @@ func TestLogsFilter_EmptyFilter_DoesNotDistributeAnything(t *testing.T) {
 	ctx := t.Context()
 	srv := newTestServer(ctx)
 
-	req1 := &remote.LogsFilterRequest{
+	req1 := &remoteproto.LogsFilterRequest{
 		AllAddresses: false,
 		Addresses:    nil,
 		AllTopics:    false,
@@ -126,7 +125,7 @@ func TestLogsFilter_EmptyFilter_DoesNotDistributeAnything(t *testing.T) {
 
 	// now see if a log would be sent or not
 	log := createLog()
-	_ = agg.distributeLogs([]*remote.SubscribeLogsReply{log})
+	_ = agg.distributeLogs([]*remoteproto.SubscribeLogsReply{log})
 
 	if len(srv.sent) != 0 {
 		t.Error("expected the sent slice to be empty")
@@ -140,7 +139,7 @@ func TestLogsFilter_AllAddressesAndTopicsFilter_DistributesLogRegardless(t *test
 	ctx := t.Context()
 	srv := newTestServer(ctx)
 
-	req1 := &remote.LogsFilterRequest{
+	req1 := &remoteproto.LogsFilterRequest{
 		AllAddresses: true,
 		Addresses:    nil,
 		AllTopics:    true,
@@ -159,21 +158,21 @@ func TestLogsFilter_AllAddressesAndTopicsFilter_DistributesLogRegardless(t *test
 
 	// now see if a log would be sent or not
 	log := createLog()
-	_ = agg.distributeLogs([]*remote.SubscribeLogsReply{log})
+	_ = agg.distributeLogs([]*remoteproto.SubscribeLogsReply{log})
 	if len(srv.sent) != 1 {
 		t.Error("expected the sent slice to have the log present")
 	}
 
 	log = createLog()
-	log.Topics = []*types2.H256{topic1H256}
-	_ = agg.distributeLogs([]*remote.SubscribeLogsReply{log})
+	log.Topics = []*typesproto.H256{topic1H256}
+	_ = agg.distributeLogs([]*remoteproto.SubscribeLogsReply{log})
 	if len(srv.sent) != 2 {
 		t.Error("expected any topic to be allowed through the filter")
 	}
 
 	log = createLog()
 	log.Address = address160
-	_ = agg.distributeLogs([]*remote.SubscribeLogsReply{log})
+	_ = agg.distributeLogs([]*remoteproto.SubscribeLogsReply{log})
 	if len(srv.sent) != 3 {
 		t.Error("expected any address to be allowed through the filter")
 	}
@@ -186,11 +185,11 @@ func TestLogsFilter_TopicFilter_OnlyAllowsThatTopicThrough(t *testing.T) {
 	ctx := t.Context()
 	srv := newTestServer(ctx)
 
-	req1 := &remote.LogsFilterRequest{
+	req1 := &remoteproto.LogsFilterRequest{
 		AllAddresses: true, // need to allow all addresses on the request else it will filter on them
 		Addresses:    nil,
 		AllTopics:    false,
-		Topics:       []*types2.H256{topic1H256},
+		Topics:       []*typesproto.H256{topic1H256},
 	}
 	srv.received <- req1
 
@@ -205,14 +204,14 @@ func TestLogsFilter_TopicFilter_OnlyAllowsThatTopicThrough(t *testing.T) {
 
 	// now see if a log would be sent or not
 	log := createLog()
-	_ = agg.distributeLogs([]*remote.SubscribeLogsReply{log})
+	_ = agg.distributeLogs([]*remoteproto.SubscribeLogsReply{log})
 	if len(srv.sent) != 0 {
 		t.Error("the sent slice should be empty as the topic didn't match")
 	}
 
 	log = createLog()
-	log.Topics = []*types2.H256{topic1H256}
-	_ = agg.distributeLogs([]*remote.SubscribeLogsReply{log})
+	log.Topics = []*typesproto.H256{topic1H256}
+	_ = agg.distributeLogs([]*remoteproto.SubscribeLogsReply{log})
 	if len(srv.sent) != 1 {
 		t.Error("expected the log to be distributed as the topic matched")
 	}
@@ -225,11 +224,11 @@ func TestLogsFilter_AddressFilter_OnlyAllowsThatAddressThrough(t *testing.T) {
 	ctx := t.Context()
 	srv := newTestServer(ctx)
 
-	req1 := &remote.LogsFilterRequest{
+	req1 := &remoteproto.LogsFilterRequest{
 		AllAddresses: false,
-		Addresses:    []*types2.H160{address160},
+		Addresses:    []*typesproto.H160{address160},
 		AllTopics:    true,
-		Topics:       []*types2.H256{},
+		Topics:       []*typesproto.H256{},
 	}
 	srv.received <- req1
 
@@ -244,14 +243,14 @@ func TestLogsFilter_AddressFilter_OnlyAllowsThatAddressThrough(t *testing.T) {
 
 	// now see if a log would be sent or not
 	log := createLog()
-	_ = agg.distributeLogs([]*remote.SubscribeLogsReply{log})
+	_ = agg.distributeLogs([]*remoteproto.SubscribeLogsReply{log})
 	if len(srv.sent) != 0 {
 		t.Error("the sent slice should be empty as the address didn't match")
 	}
 
 	log = createLog()
 	log.Address = address160
-	_ = agg.distributeLogs([]*remote.SubscribeLogsReply{log})
+	_ = agg.distributeLogs([]*remoteproto.SubscribeLogsReply{log})
 	if len(srv.sent) != 1 {
 		t.Error("expected the log to be distributed as the address matched")
 	}

--- a/turbo/privateapi/mining.go
+++ b/turbo/privateapi/mining.go
@@ -26,8 +26,8 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/hexutil"
-	proto_txpool "github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
-	types2 "github.com/erigontech/erigon-lib/gointerfaces/typesproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/execution/consensus/ethash"
 	"github.com/erigontech/erigon/execution/rlp"
@@ -36,10 +36,10 @@ import (
 
 // MiningAPIVersion
 // 2.0.0 - move all mining-related methods to 'txpool/mining' server
-var MiningAPIVersion = &types2.VersionReply{Major: 1, Minor: 0, Patch: 0}
+var MiningAPIVersion = &typesproto.VersionReply{Major: 1, Minor: 0, Patch: 0}
 
 type MiningServer struct {
-	proto_txpool.UnimplementedMiningServer
+	txpoolproto.UnimplementedMiningServer
 	ctx                 context.Context
 	pendingLogsStreams  PendingLogsStreams
 	pendingBlockStreams PendingBlockStreams
@@ -57,11 +57,11 @@ func NewMiningServer(ctx context.Context, isMining IsMining, ethashApi *ethash.A
 	return &MiningServer{ctx: ctx, isMining: isMining, ethash: ethashApi, logger: logger}
 }
 
-func (s *MiningServer) Version(context.Context, *emptypb.Empty) (*types2.VersionReply, error) {
+func (s *MiningServer) Version(context.Context, *emptypb.Empty) (*typesproto.VersionReply, error) {
 	return MiningAPIVersion, nil
 }
 
-func (s *MiningServer) GetWork(context.Context, *proto_txpool.GetWorkRequest) (*proto_txpool.GetWorkReply, error) {
+func (s *MiningServer) GetWork(context.Context, *txpoolproto.GetWorkRequest) (*txpoolproto.GetWorkReply, error) {
 	if s.ethash == nil {
 		return nil, errors.New("not supported, consensus engine is not ethash")
 	}
@@ -69,42 +69,42 @@ func (s *MiningServer) GetWork(context.Context, *proto_txpool.GetWorkRequest) (*
 	if err != nil {
 		return nil, err
 	}
-	return &proto_txpool.GetWorkReply{HeaderHash: res[0], SeedHash: res[1], Target: res[2], BlockNumber: res[3]}, nil
+	return &txpoolproto.GetWorkReply{HeaderHash: res[0], SeedHash: res[1], Target: res[2], BlockNumber: res[3]}, nil
 }
 
-func (s *MiningServer) SubmitWork(_ context.Context, req *proto_txpool.SubmitWorkRequest) (*proto_txpool.SubmitWorkReply, error) {
+func (s *MiningServer) SubmitWork(_ context.Context, req *txpoolproto.SubmitWorkRequest) (*txpoolproto.SubmitWorkReply, error) {
 	if s.ethash == nil {
 		return nil, errors.New("not supported, consensus engine is not ethash")
 	}
 	var nonce types.BlockNonce
 	copy(nonce[:], req.BlockNonce)
 	ok := s.ethash.SubmitWork(nonce, common.BytesToHash(req.PowHash), common.BytesToHash(req.Digest))
-	return &proto_txpool.SubmitWorkReply{Ok: ok}, nil
+	return &txpoolproto.SubmitWorkReply{Ok: ok}, nil
 }
 
-func (s *MiningServer) SubmitHashRate(_ context.Context, req *proto_txpool.SubmitHashRateRequest) (*proto_txpool.SubmitHashRateReply, error) {
+func (s *MiningServer) SubmitHashRate(_ context.Context, req *txpoolproto.SubmitHashRateRequest) (*txpoolproto.SubmitHashRateReply, error) {
 	if s.ethash == nil {
 		return nil, errors.New("not supported, consensus engine is not ethash")
 	}
 	ok := s.ethash.SubmitHashRate(hexutil.Uint64(req.Rate), common.BytesToHash(req.Id))
-	return &proto_txpool.SubmitHashRateReply{Ok: ok}, nil
+	return &txpoolproto.SubmitHashRateReply{Ok: ok}, nil
 }
 
-func (s *MiningServer) GetHashRate(_ context.Context, req *proto_txpool.HashRateRequest) (*proto_txpool.HashRateReply, error) {
+func (s *MiningServer) GetHashRate(_ context.Context, req *txpoolproto.HashRateRequest) (*txpoolproto.HashRateReply, error) {
 	if s.ethash == nil {
 		return nil, errors.New("not supported, consensus engine is not ethash")
 	}
-	return &proto_txpool.HashRateReply{HashRate: s.ethash.GetHashrate()}, nil
+	return &txpoolproto.HashRateReply{HashRate: s.ethash.GetHashrate()}, nil
 }
 
-func (s *MiningServer) Mining(_ context.Context, req *proto_txpool.MiningRequest) (*proto_txpool.MiningReply, error) {
+func (s *MiningServer) Mining(_ context.Context, req *txpoolproto.MiningRequest) (*txpoolproto.MiningReply, error) {
 	if s.ethash == nil {
 		return nil, errors.New("not supported, consensus engine is not ethash")
 	}
-	return &proto_txpool.MiningReply{Enabled: s.isMining.IsMining(), Running: true}, nil
+	return &txpoolproto.MiningReply{Enabled: s.isMining.IsMining(), Running: true}, nil
 }
 
-func (s *MiningServer) OnPendingLogs(req *proto_txpool.OnPendingLogsRequest, reply proto_txpool.Mining_OnPendingLogsServer) error {
+func (s *MiningServer) OnPendingLogs(req *txpoolproto.OnPendingLogsRequest, reply txpoolproto.Mining_OnPendingLogsServer) error {
 	remove := s.pendingLogsStreams.Add(reply)
 	defer remove()
 	<-reply.Context().Done()
@@ -116,12 +116,12 @@ func (s *MiningServer) BroadcastPendingLogs(l types.Logs) error {
 	if err != nil {
 		return err
 	}
-	reply := &proto_txpool.OnPendingBlockReply{RplBlock: b}
+	reply := &txpoolproto.OnPendingBlockReply{RplBlock: b}
 	s.pendingBlockStreams.Broadcast(reply, s.logger)
 	return nil
 }
 
-func (s *MiningServer) OnPendingBlock(req *proto_txpool.OnPendingBlockRequest, reply proto_txpool.Mining_OnPendingBlockServer) error {
+func (s *MiningServer) OnPendingBlock(req *txpoolproto.OnPendingBlockRequest, reply txpoolproto.Mining_OnPendingBlockServer) error {
 	remove := s.pendingBlockStreams.Add(reply)
 	defer remove()
 	select {
@@ -137,12 +137,12 @@ func (s *MiningServer) BroadcastPendingBlock(block *types.Block) error {
 	if err := block.EncodeRLP(&buf); err != nil {
 		return err
 	}
-	reply := &proto_txpool.OnPendingBlockReply{RplBlock: buf.Bytes()}
+	reply := &txpoolproto.OnPendingBlockReply{RplBlock: buf.Bytes()}
 	s.pendingBlockStreams.Broadcast(reply, s.logger)
 	return nil
 }
 
-func (s *MiningServer) OnMinedBlock(req *proto_txpool.OnMinedBlockRequest, reply proto_txpool.Mining_OnMinedBlockServer) error {
+func (s *MiningServer) OnMinedBlock(req *txpoolproto.OnMinedBlockRequest, reply txpoolproto.Mining_OnMinedBlockServer) error {
 	remove := s.minedBlockStreams.Add(reply)
 	defer remove()
 	<-reply.Context().Done()
@@ -155,24 +155,24 @@ func (s *MiningServer) BroadcastMinedBlock(block *types.Block) error {
 	if err := block.EncodeRLP(&buf); err != nil {
 		return err
 	}
-	reply := &proto_txpool.OnMinedBlockReply{RplBlock: buf.Bytes()}
+	reply := &txpoolproto.OnMinedBlockReply{RplBlock: buf.Bytes()}
 	s.minedBlockStreams.Broadcast(reply, s.logger)
 	return nil
 }
 
 // MinedBlockStreams - it's safe to use this class as non-pointer
 type MinedBlockStreams struct {
-	chans  map[uint]proto_txpool.Mining_OnMinedBlockServer
+	chans  map[uint]txpoolproto.Mining_OnMinedBlockServer
 	id     uint
 	mu     sync.Mutex
 	logger log.Logger
 }
 
-func (s *MinedBlockStreams) Add(stream proto_txpool.Mining_OnMinedBlockServer) (remove func()) {
+func (s *MinedBlockStreams) Add(stream txpoolproto.Mining_OnMinedBlockServer) (remove func()) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.chans == nil {
-		s.chans = make(map[uint]proto_txpool.Mining_OnMinedBlockServer)
+		s.chans = make(map[uint]txpoolproto.Mining_OnMinedBlockServer)
 	}
 	s.id++
 	id := s.id
@@ -180,7 +180,7 @@ func (s *MinedBlockStreams) Add(stream proto_txpool.Mining_OnMinedBlockServer) (
 	return func() { s.remove(id) }
 }
 
-func (s *MinedBlockStreams) Broadcast(reply *proto_txpool.OnMinedBlockReply, logger log.Logger) {
+func (s *MinedBlockStreams) Broadcast(reply *txpoolproto.OnMinedBlockReply, logger log.Logger) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for id, stream := range s.chans {
@@ -208,16 +208,16 @@ func (s *MinedBlockStreams) remove(id uint) {
 
 // PendingBlockStreams - it's safe to use this class as non-pointer
 type PendingBlockStreams struct {
-	chans map[uint]proto_txpool.Mining_OnPendingBlockServer
+	chans map[uint]txpoolproto.Mining_OnPendingBlockServer
 	mu    sync.Mutex
 	id    uint
 }
 
-func (s *PendingBlockStreams) Add(stream proto_txpool.Mining_OnPendingBlockServer) (remove func()) {
+func (s *PendingBlockStreams) Add(stream txpoolproto.Mining_OnPendingBlockServer) (remove func()) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.chans == nil {
-		s.chans = make(map[uint]proto_txpool.Mining_OnPendingBlockServer)
+		s.chans = make(map[uint]txpoolproto.Mining_OnPendingBlockServer)
 	}
 	s.id++
 	id := s.id
@@ -225,7 +225,7 @@ func (s *PendingBlockStreams) Add(stream proto_txpool.Mining_OnPendingBlockServe
 	return func() { s.remove(id) }
 }
 
-func (s *PendingBlockStreams) Broadcast(reply *proto_txpool.OnPendingBlockReply, logger log.Logger) {
+func (s *PendingBlockStreams) Broadcast(reply *txpoolproto.OnPendingBlockReply, logger log.Logger) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for id, stream := range s.chans {
@@ -253,16 +253,16 @@ func (s *PendingBlockStreams) remove(id uint) {
 
 // PendingLogsStreams - it's safe to use this class as non-pointer
 type PendingLogsStreams struct {
-	chans map[uint]proto_txpool.Mining_OnPendingLogsServer
+	chans map[uint]txpoolproto.Mining_OnPendingLogsServer
 	mu    sync.Mutex
 	id    uint
 }
 
-func (s *PendingLogsStreams) Add(stream proto_txpool.Mining_OnPendingLogsServer) (remove func()) {
+func (s *PendingLogsStreams) Add(stream txpoolproto.Mining_OnPendingLogsServer) (remove func()) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.chans == nil {
-		s.chans = make(map[uint]proto_txpool.Mining_OnPendingLogsServer)
+		s.chans = make(map[uint]txpoolproto.Mining_OnPendingLogsServer)
 	}
 	s.id++
 	id := s.id
@@ -270,7 +270,7 @@ func (s *PendingLogsStreams) Add(stream proto_txpool.Mining_OnPendingLogsServer)
 	return func() { s.remove(id) }
 }
 
-func (s *PendingLogsStreams) Broadcast(reply *proto_txpool.OnPendingLogsReply, logger log.Logger) {
+func (s *PendingLogsStreams) Broadcast(reply *txpoolproto.OnPendingLogsReply, logger log.Logger) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for id, stream := range s.chans {

--- a/txnprovider/txpool/assemble.go
+++ b/txnprovider/txpool/assemble.go
@@ -22,7 +22,7 @@ import (
 	"github.com/c2h5oh/datasize"
 	"github.com/holiman/uint256"
 
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
 	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon-lib/log/v3"
@@ -41,7 +41,7 @@ func Assemble(
 	stateChangesClient StateChangesClient,
 	builderNotifyNewTxns func(),
 	logger log.Logger,
-	ethBackend remote.ETHBACKENDClient,
+	ethBackend remoteproto.ETHBACKENDClient,
 	opts ...Option,
 ) (*TxPool, txpoolproto.TxpoolServer, error) {
 	options := applyOpts(opts...)

--- a/txnprovider/txpool/fetch.go
+++ b/txnprovider/txpool/fetch.go
@@ -29,8 +29,8 @@ import (
 
 	"github.com/erigontech/erigon-lib/common/dbg"
 	"github.com/erigontech/erigon-lib/gointerfaces/grpcutil"
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
-	sentry "github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/execution/rlp"
@@ -48,14 +48,14 @@ type Fetch struct {
 	wg                       *sync.WaitGroup // used for synchronisation in the tests (nil when not in tests)
 	stateChangesParseCtx     *TxnParseContext
 	pooledTxnsParseCtx       *TxnParseContext
-	sentryClients            []sentry.SentryClient // sentry clients that will be used for accessing the network
+	sentryClients            []sentryproto.SentryClient // sentry clients that will be used for accessing the network
 	stateChangesParseCtxLock sync.Mutex
 	pooledTxnsParseCtxLock   sync.Mutex
 	logger                   log.Logger
 }
 
 type StateChangesClient interface {
-	StateChanges(ctx context.Context, in *remote.StateChangeRequest, opts ...grpc.CallOption) (remote.KV_StateChangesClient, error)
+	StateChanges(ctx context.Context, in *remoteproto.StateChangeRequest, opts ...grpc.CallOption) (remoteproto.KV_StateChangesClient, error)
 }
 
 // NewFetch creates a new fetch object that will work with given sentry clients. Since the
@@ -63,7 +63,7 @@ type StateChangesClient interface {
 // to implement all the functions of the SentryClient interface).
 func NewFetch(
 	ctx context.Context,
-	sentryClients []sentry.SentryClient,
+	sentryClients []sentryproto.SentryClient,
 	pool Pool,
 	stateChangesClient StateChangesClient,
 	db kv.RwDB,
@@ -132,7 +132,7 @@ func (f *Fetch) ConnectCore() {
 	}()
 }
 
-func (f *Fetch) receiveMessageLoop(sentryClient sentry.SentryClient) {
+func (f *Fetch) receiveMessageLoop(sentryClient sentryproto.SentryClient) {
 	for {
 		select {
 		case <-f.ctx.Done():
@@ -158,15 +158,15 @@ func (f *Fetch) receiveMessageLoop(sentryClient sentry.SentryClient) {
 	}
 }
 
-func (f *Fetch) receiveMessage(ctx context.Context, sentryClient sentry.SentryClient) error {
+func (f *Fetch) receiveMessage(ctx context.Context, sentryClient sentryproto.SentryClient) error {
 	streamCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	stream, err := sentryClient.Messages(streamCtx, &sentry.MessagesRequest{Ids: []sentry.MessageId{
-		sentry.MessageId_NEW_POOLED_TRANSACTION_HASHES_66,
-		sentry.MessageId_GET_POOLED_TRANSACTIONS_66,
-		sentry.MessageId_TRANSACTIONS_66,
-		sentry.MessageId_POOLED_TRANSACTIONS_66,
-		sentry.MessageId_NEW_POOLED_TRANSACTION_HASHES_68,
+	stream, err := sentryClient.Messages(streamCtx, &sentryproto.MessagesRequest{Ids: []sentryproto.MessageId{
+		sentryproto.MessageId_NEW_POOLED_TRANSACTION_HASHES_66,
+		sentryproto.MessageId_GET_POOLED_TRANSACTIONS_66,
+		sentryproto.MessageId_TRANSACTIONS_66,
+		sentryproto.MessageId_POOLED_TRANSACTIONS_66,
+		sentryproto.MessageId_NEW_POOLED_TRANSACTION_HASHES_68,
 	}}, grpc.WaitForReady(true))
 	if err != nil {
 		select {
@@ -176,7 +176,7 @@ func (f *Fetch) receiveMessage(ctx context.Context, sentryClient sentry.SentryCl
 		}
 		return err
 	}
-	var req *sentry.InboundMessage
+	var req *sentryproto.InboundMessage
 	for req, err = stream.Recv(); ; req, err = stream.Recv() {
 		if err != nil {
 			select {
@@ -202,7 +202,7 @@ func (f *Fetch) receiveMessage(ctx context.Context, sentryClient sentry.SentryCl
 	}
 }
 
-func (f *Fetch) handleInboundMessage(ctx context.Context, req *sentry.InboundMessage, sentryClient sentry.SentryClient) (err error) {
+func (f *Fetch) handleInboundMessage(ctx context.Context, req *sentryproto.InboundMessage, sentryClient sentryproto.SentryClient) (err error) {
 	defer func() {
 		if rec := recover(); rec != nil {
 			err = fmt.Errorf("%+v, trace: %s, rlp: %x", rec, dbg.Stack(), req.Data)
@@ -219,7 +219,7 @@ func (f *Fetch) handleInboundMessage(ctx context.Context, req *sentry.InboundMes
 	defer tx.Rollback()
 
 	switch req.Id {
-	case sentry.MessageId_NEW_POOLED_TRANSACTION_HASHES_66:
+	case sentryproto.MessageId_NEW_POOLED_TRANSACTION_HASHES_66:
 		hashCount, pos, err := ParseHashesCount(req.Data, 0)
 		if err != nil {
 			return fmt.Errorf("parsing NewPooledTransactionHashes: %w", err)
@@ -229,7 +229,7 @@ func (f *Fetch) handleInboundMessage(ctx context.Context, req *sentry.InboundMes
 		if hashCount > maxHashesPerMsg {
 			f.logger.Warn("Oversized hash announcement",
 				"peer", req.PeerId, "count", hashCount)
-			sentryClient.PenalizePeer(ctx, &sentry.PenalizePeerRequest{PeerId: req.PeerId, Penalty: sentry.PenaltyKind_Kick}) // Disconnect peer
+			sentryClient.PenalizePeer(ctx, &sentryproto.PenalizePeerRequest{PeerId: req.PeerId, Penalty: sentryproto.PenaltyKind_Kick}) // Disconnect peer
 			return nil
 		}
 
@@ -245,19 +245,19 @@ func (f *Fetch) handleInboundMessage(ctx context.Context, req *sentry.InboundMes
 		}
 		if len(unknownHashes) > 0 {
 			var encodedRequest []byte
-			var messageID sentry.MessageId
+			var messageID sentryproto.MessageId
 			if encodedRequest, err = EncodeGetPooledTransactions66(unknownHashes, uint64(1), nil); err != nil {
 				return err
 			}
-			messageID = sentry.MessageId_GET_POOLED_TRANSACTIONS_66
-			if _, err = sentryClient.SendMessageById(f.ctx, &sentry.SendMessageByIdRequest{
-				Data:   &sentry.OutboundMessageData{Id: messageID, Data: encodedRequest},
+			messageID = sentryproto.MessageId_GET_POOLED_TRANSACTIONS_66
+			if _, err = sentryClient.SendMessageById(f.ctx, &sentryproto.SendMessageByIdRequest{
+				Data:   &sentryproto.OutboundMessageData{Id: messageID, Data: encodedRequest},
 				PeerId: req.PeerId,
 			}, &grpc.EmptyCallOption{}); err != nil {
 				return err
 			}
 		}
-	case sentry.MessageId_NEW_POOLED_TRANSACTION_HASHES_68:
+	case sentryproto.MessageId_NEW_POOLED_TRANSACTION_HASHES_68:
 		_, _, hashes, _, err := rlp.ParseAnnouncements(req.Data, 0)
 		if err != nil {
 			return fmt.Errorf("parsing NewPooledTransactionHashes88: %w", err)
@@ -269,23 +269,23 @@ func (f *Fetch) handleInboundMessage(ctx context.Context, req *sentry.InboundMes
 
 		if len(unknownHashes) > 0 {
 			var encodedRequest []byte
-			var messageID sentry.MessageId
+			var messageID sentryproto.MessageId
 			if encodedRequest, err = EncodeGetPooledTransactions66(unknownHashes, uint64(1), nil); err != nil {
 				return err
 			}
-			messageID = sentry.MessageId_GET_POOLED_TRANSACTIONS_66
-			if _, err = sentryClient.SendMessageById(f.ctx, &sentry.SendMessageByIdRequest{
-				Data:   &sentry.OutboundMessageData{Id: messageID, Data: encodedRequest},
+			messageID = sentryproto.MessageId_GET_POOLED_TRANSACTIONS_66
+			if _, err = sentryClient.SendMessageById(f.ctx, &sentryproto.SendMessageByIdRequest{
+				Data:   &sentryproto.OutboundMessageData{Id: messageID, Data: encodedRequest},
 				PeerId: req.PeerId,
 			}, &grpc.EmptyCallOption{}); err != nil {
 				return err
 			}
 		}
-	case sentry.MessageId_GET_POOLED_TRANSACTIONS_66:
+	case sentryproto.MessageId_GET_POOLED_TRANSACTIONS_66:
 		//TODO: handleInboundMessage is single-threaded - means it can accept as argument couple buffers (or analog of txParseContext). Protobuf encoding will copy data anyway, but DirectClient doesn't
 		var encodedRequest []byte
-		var messageID sentry.MessageId
-		messageID = sentry.MessageId_POOLED_TRANSACTIONS_66
+		var messageID sentryproto.MessageId
+		messageID = sentryproto.MessageId_POOLED_TRANSACTIONS_66
 		requestID, hashes, _, err := ParseGetPooledTransactions66(req.Data, 0, nil)
 		if err != nil {
 			return err
@@ -324,13 +324,13 @@ func (f *Fetch) handleInboundMessage(ctx context.Context, req *sentry.InboundMes
 			log.Trace("txpool.Fetch.handleInboundMessage PooledTransactions reply exceeds p2pTxPacketLimit", "requested", len(hashes), "processed", processed)
 		}
 
-		if _, err := sentryClient.SendMessageById(f.ctx, &sentry.SendMessageByIdRequest{
-			Data:   &sentry.OutboundMessageData{Id: messageID, Data: encodedRequest},
+		if _, err := sentryClient.SendMessageById(f.ctx, &sentryproto.SendMessageByIdRequest{
+			Data:   &sentryproto.OutboundMessageData{Id: messageID, Data: encodedRequest},
 			PeerId: req.PeerId,
 		}, &grpc.EmptyCallOption{}); err != nil {
 			return err
 		}
-	case sentry.MessageId_POOLED_TRANSACTIONS_66, sentry.MessageId_TRANSACTIONS_66:
+	case sentryproto.MessageId_POOLED_TRANSACTIONS_66, sentryproto.MessageId_TRANSACTIONS_66:
 		txns := TxnSlots{}
 		if err := f.threadSafeParsePooledTxn(func(parseContext *TxnParseContext) error {
 			return nil
@@ -339,7 +339,7 @@ func (f *Fetch) handleInboundMessage(ctx context.Context, req *sentry.InboundMes
 		}
 
 		switch req.Id {
-		case sentry.MessageId_TRANSACTIONS_66:
+		case sentryproto.MessageId_TRANSACTIONS_66:
 			if err := f.threadSafeParsePooledTxn(func(parseContext *TxnParseContext) error {
 				if _, err := ParseTransactions(req.Data, 0, parseContext, &txns, func(hash []byte) error {
 					known, err := f.pool.IdHashKnown(tx, hash)
@@ -357,7 +357,7 @@ func (f *Fetch) handleInboundMessage(ctx context.Context, req *sentry.InboundMes
 			}); err != nil {
 				return err
 			}
-		case sentry.MessageId_POOLED_TRANSACTIONS_66:
+		case sentryproto.MessageId_POOLED_TRANSACTIONS_66:
 			if err := f.threadSafeParsePooledTxn(func(parseContext *TxnParseContext) error {
 				if _, _, err := ParsePooledTransactions66(req.Data, 0, parseContext, &txns, func(hash []byte) error {
 					known, err := f.pool.IdHashKnown(tx, hash)
@@ -390,7 +390,7 @@ func (f *Fetch) handleInboundMessage(ctx context.Context, req *sentry.InboundMes
 	return nil
 }
 
-func (f *Fetch) receivePeerLoop(sentryClient sentry.SentryClient) {
+func (f *Fetch) receivePeerLoop(sentryClient sentryproto.SentryClient) {
 	for {
 		select {
 		case <-f.ctx.Done():
@@ -418,11 +418,11 @@ func (f *Fetch) receivePeerLoop(sentryClient sentry.SentryClient) {
 	}
 }
 
-func (f *Fetch) receivePeer(sentryClient sentry.SentryClient) error {
+func (f *Fetch) receivePeer(sentryClient sentryproto.SentryClient) error {
 	streamCtx, cancel := context.WithCancel(f.ctx)
 	defer cancel()
 
-	stream, err := sentryClient.PeerEvents(streamCtx, &sentry.PeerEventsRequest{})
+	stream, err := sentryClient.PeerEvents(streamCtx, &sentryproto.PeerEventsRequest{})
 	if err != nil {
 		select {
 		case <-f.ctx.Done():
@@ -432,7 +432,7 @@ func (f *Fetch) receivePeer(sentryClient sentry.SentryClient) error {
 		return err
 	}
 
-	var req *sentry.PeerEvent
+	var req *sentryproto.PeerEvent
 	for req, err = stream.Recv(); ; req, err = stream.Recv() {
 		if err != nil {
 			return err
@@ -449,12 +449,12 @@ func (f *Fetch) receivePeer(sentryClient sentry.SentryClient) error {
 	}
 }
 
-func (f *Fetch) handleNewPeer(req *sentry.PeerEvent) error {
+func (f *Fetch) handleNewPeer(req *sentryproto.PeerEvent) error {
 	if req == nil {
 		return nil
 	}
 	switch req.EventId {
-	case sentry.PeerEvent_Connect:
+	case sentryproto.PeerEvent_Connect:
 		f.pool.AddNewGoodPeer(req.PeerId)
 	}
 
@@ -464,7 +464,7 @@ func (f *Fetch) handleNewPeer(req *sentry.PeerEvent) error {
 func (f *Fetch) handleStateChanges(ctx context.Context, client StateChangesClient) error {
 	streamCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	stream, err := client.StateChanges(streamCtx, &remote.StateChangeRequest{WithStorage: false, WithTransactions: true}, grpc.WaitForReady(true))
+	stream, err := client.StateChanges(streamCtx, &remoteproto.StateChangeRequest{WithStorage: false, WithTransactions: true}, grpc.WaitForReady(true))
 	if err != nil {
 		return err
 	}
@@ -485,10 +485,10 @@ func (f *Fetch) handleStateChanges(ctx context.Context, client StateChangesClien
 	}
 }
 
-func (f *Fetch) handleStateChangesRequest(ctx context.Context, req *remote.StateChangeBatch) error {
+func (f *Fetch) handleStateChangesRequest(ctx context.Context, req *remoteproto.StateChangeBatch) error {
 	var unwindTxns, unwindBlobTxns, minedTxns TxnSlots
 	for _, change := range req.ChangeBatch {
-		if change.Direction == remote.Direction_FORWARD {
+		if change.Direction == remoteproto.Direction_FORWARD {
 			minedTxns.Resize(uint(len(change.Txs)))
 			for i := range change.Txs {
 				minedTxns.Txns[i] = &TxnSlot{}
@@ -500,7 +500,7 @@ func (f *Fetch) handleStateChangesRequest(ctx context.Context, req *remote.State
 					continue // 1 txn handling error must not stop batch processing
 				}
 			}
-		} else if change.Direction == remote.Direction_UNWIND {
+		} else if change.Direction == remoteproto.Direction_UNWIND {
 			for i := range change.Txs {
 				if err := f.threadSafeParseStateChangeTxn(func(parseContext *TxnParseContext) error {
 					utx := &TxnSlot{}

--- a/txnprovider/txpool/fetch_test.go
+++ b/txnprovider/txpool/fetch_test.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/erigontech/erigon-lib/common/u256"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
 	"github.com/erigontech/erigon-lib/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 	"github.com/erigontech/erigon-lib/log/v3"
@@ -45,7 +45,7 @@ func TestFetch(t *testing.T) {
 	ctx := t.Context()
 
 	ctrl := gomock.NewController(t)
-	remoteKvClient := remote.NewMockKVClient(ctrl)
+	remoteKvClient := remoteproto.NewMockKVClient(ctrl)
 	sentryServer := sentryproto.NewMockSentryServer(ctrl)
 	pool := NewMockPool(ctrl)
 	pool.EXPECT().Started().Return(true)
@@ -230,18 +230,18 @@ func TestOnNewBlock(t *testing.T) {
 	_, db := memdb.NewTestDB(t, kv.ChainDB), memdb.NewTestDB(t, kv.TxPoolDB)
 	ctrl := gomock.NewController(t)
 
-	stream := remote.NewMockKV_StateChangesClient[*remote.StateChangeBatch](ctrl)
+	stream := remoteproto.NewMockKV_StateChangesClient[*remoteproto.StateChangeBatch](ctrl)
 	i := 0
 	stream.EXPECT().
 		Recv().
-		DoAndReturn(func() (*remote.StateChangeBatch, error) {
+		DoAndReturn(func() (*remoteproto.StateChangeBatch, error) {
 			if i > 0 {
 				return nil, io.EOF
 			}
 			i++
-			return &remote.StateChangeBatch{
+			return &remoteproto.StateChangeBatch{
 				StateVersionId: 1,
-				ChangeBatch: []*remote.StateChange{
+				ChangeBatch: []*remoteproto.StateChange{
 					{
 						Txs: [][]byte{
 							decodeHex(TxnParseMainnetTests[0].PayloadStr),
@@ -256,11 +256,11 @@ func TestOnNewBlock(t *testing.T) {
 		}).
 		AnyTimes()
 
-	stateChanges := remote.NewMockKVClient(ctrl)
+	stateChanges := remoteproto.NewMockKVClient(ctrl)
 	stateChanges.
 		EXPECT().
 		StateChanges(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ *remote.StateChangeRequest, _ ...grpc.CallOption) (remote.KV_StateChangesClient, error) {
+		DoAndReturn(func(_ context.Context, _ *remoteproto.StateChangeRequest, _ ...grpc.CallOption) (remoteproto.KV_StateChangesClient, error) {
 			return stream, nil
 		})
 
@@ -276,7 +276,7 @@ func TestOnNewBlock(t *testing.T) {
 	var minedTxns TxnSlots
 	pool.EXPECT().
 		OnNewBlock(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ *remote.StateChangeBatch, _ TxnSlots, _ TxnSlots, minedTxnsArg TxnSlots) error {
+		DoAndReturn(func(_ context.Context, _ *remoteproto.StateChangeBatch, _ TxnSlots, _ TxnSlots, minedTxnsArg TxnSlots) error {
 			minedTxns = minedTxnsArg
 			return nil
 		}).

--- a/txnprovider/txpool/pool_fuzz_test.go
+++ b/txnprovider/txpool/pool_fuzz_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/u256"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
@@ -479,10 +479,10 @@ func FuzzOnNewBlocks(f *testing.F) {
 			txID = tx.ViewID()
 			return nil
 		})
-		change := &remote.StateChangeBatch{
+		change := &remoteproto.StateChangeBatch{
 			StateVersionId:      txID,
 			PendingBlockBaseFee: pendingBaseFee,
-			ChangeBatch: []*remote.StateChange{
+			ChangeBatch: []*remoteproto.StateChange{
 				{BlockHeight: 0, BlockHash: h0},
 			},
 		}
@@ -490,8 +490,8 @@ func FuzzOnNewBlocks(f *testing.F) {
 			addr := pool.senders.senderID2Addr[id]
 			v := make([]byte, EncodeSenderLengthForStorage(sender.nonce, sender.balance))
 			EncodeSender(sender.nonce, sender.balance, v)
-			change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remote.AccountChange{
-				Action:  remote.Action_UPSERT,
+			change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remoteproto.AccountChange{
+				Action:  remoteproto.Action_UPSERT,
 				Address: gointerfaces.ConvertAddressToH160(addr),
 				Data:    v,
 			})
@@ -504,10 +504,10 @@ func FuzzOnNewBlocks(f *testing.F) {
 		checkNotify(txns1, TxnSlots{}, "fork1")
 
 		_, _, _ = p2pReceived, txns2, txns3
-		change = &remote.StateChangeBatch{
+		change = &remoteproto.StateChangeBatch{
 			StateVersionId:      txID,
 			PendingBlockBaseFee: pendingBaseFee,
-			ChangeBatch: []*remote.StateChange{
+			ChangeBatch: []*remoteproto.StateChange{
 				{BlockHeight: 1, BlockHash: h0},
 			},
 		}
@@ -517,11 +517,11 @@ func FuzzOnNewBlocks(f *testing.F) {
 		checkNotify(TxnSlots{}, txns2, "fork1 mined")
 
 		// unwind everything and switch to new fork (need unwind mined now)
-		change = &remote.StateChangeBatch{
+		change = &remoteproto.StateChangeBatch{
 			StateVersionId:      txID,
 			PendingBlockBaseFee: pendingBaseFee,
-			ChangeBatch: []*remote.StateChange{
-				{BlockHeight: 0, BlockHash: h0, Direction: remote.Direction_UNWIND},
+			ChangeBatch: []*remoteproto.StateChange{
+				{BlockHeight: 0, BlockHash: h0, Direction: remoteproto.Direction_UNWIND},
 			},
 		}
 		err = pool.OnNewBlock(ctx, change, txns2, TxnSlots{}, TxnSlots{})
@@ -529,10 +529,10 @@ func FuzzOnNewBlocks(f *testing.F) {
 		check(txns2, TxnSlots{}, "fork2")
 		checkNotify(txns2, TxnSlots{}, "fork2")
 
-		change = &remote.StateChangeBatch{
+		change = &remoteproto.StateChangeBatch{
 			StateVersionId:      txID,
 			PendingBlockBaseFee: pendingBaseFee,
-			ChangeBatch: []*remote.StateChange{
+			ChangeBatch: []*remoteproto.StateChange{
 				{BlockHeight: 1, BlockHash: h22},
 			},
 		}

--- a/txnprovider/txpool/pool_test.go
+++ b/txnprovider/txpool/pool_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/erigontech/erigon-lib/crypto"
 	"github.com/erigontech/erigon-lib/crypto/kzg"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
@@ -67,11 +67,11 @@ func TestNonceFromAddress(t *testing.T) {
 	pendingBaseFee := uint64(200000)
 	// start blocks from 0, set empty hash - then kvcache will also work on this
 	h1 := gointerfaces.ConvertHashToH256([32]byte{})
-	change := &remote.StateChangeBatch{
+	change := &remoteproto.StateChangeBatch{
 		StateVersionId:      stateVersionID,
 		PendingBlockBaseFee: pendingBaseFee,
 		BlockGasLimit:       1000000,
-		ChangeBatch: []*remote.StateChange{
+		ChangeBatch: []*remoteproto.StateChange{
 			{BlockHeight: 0, BlockHash: h1},
 		},
 	}
@@ -84,8 +84,8 @@ func TestNonceFromAddress(t *testing.T) {
 		Incarnation: 1,
 	}
 	v := accounts3.SerialiseV3(&acc)
-	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remote.AccountChange{
-		Action:  remote.Action_UPSERT,
+	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remoteproto.AccountChange{
+		Action:  remoteproto.Action_UPSERT,
 		Address: gointerfaces.ConvertAddressToH160(addr),
 		Data:    v,
 	})
@@ -321,11 +321,11 @@ func TestMultipleAuthorizations(t *testing.T) {
 	var stateVersionID uint64 = 0
 	pendingBaseFee := uint64(50_000)
 	h1 := gointerfaces.ConvertHashToH256([32]byte{})
-	change := &remote.StateChangeBatch{
+	change := &remoteproto.StateChangeBatch{
 		StateVersionId:      stateVersionID,
 		PendingBlockBaseFee: pendingBaseFee,
 		BlockGasLimit:       36_000_000,
-		ChangeBatch: []*remote.StateChange{
+		ChangeBatch: []*remoteproto.StateChange{
 			{BlockHeight: 0, BlockHash: h1},
 		},
 	}
@@ -338,13 +338,13 @@ func TestMultipleAuthorizations(t *testing.T) {
 		Incarnation: 1,
 	}
 	v := accounts3.SerialiseV3(&acc)
-	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remote.AccountChange{
-		Action:  remote.Action_UPSERT,
+	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remoteproto.AccountChange{
+		Action:  remoteproto.Action_UPSERT,
 		Address: gointerfaces.ConvertAddressToH160(addrA),
 		Data:    v,
 	})
-	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remote.AccountChange{
-		Action:  remote.Action_UPSERT,
+	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remoteproto.AccountChange{
+		Action:  remoteproto.Action_UPSERT,
 		Address: gointerfaces.ConvertAddressToH160(addrB),
 		Data:    v,
 	})
@@ -446,11 +446,11 @@ func TestReplaceWithHigherFee(t *testing.T) {
 	pendingBaseFee := uint64(200000)
 	// start blocks from 0, set empty hash - then kvcache will also work on this
 	h1 := gointerfaces.ConvertHashToH256([32]byte{})
-	change := &remote.StateChangeBatch{
+	change := &remoteproto.StateChangeBatch{
 		StateVersionId:      stateVersionID,
 		PendingBlockBaseFee: pendingBaseFee,
 		BlockGasLimit:       1000000,
-		ChangeBatch: []*remote.StateChange{
+		ChangeBatch: []*remoteproto.StateChange{
 			{BlockHeight: 0, BlockHash: h1},
 		},
 	}
@@ -463,8 +463,8 @@ func TestReplaceWithHigherFee(t *testing.T) {
 		Incarnation: 1,
 	}
 	v := accounts3.SerialiseV3(&acc)
-	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remote.AccountChange{
-		Action:  remote.Action_UPSERT,
+	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remoteproto.AccountChange{
+		Action:  remoteproto.Action_UPSERT,
 		Address: gointerfaces.ConvertAddressToH160(addr),
 		Data:    v,
 	})
@@ -569,11 +569,11 @@ func TestReverseNonces(t *testing.T) {
 	pendingBaseFee := uint64(1_000_000)
 	// start blocks from 0, set empty hash - then kvcache will also work on this
 	h1 := gointerfaces.ConvertHashToH256([32]byte{})
-	change := &remote.StateChangeBatch{
+	change := &remoteproto.StateChangeBatch{
 		StateVersionId:      stateVersionID,
 		PendingBlockBaseFee: pendingBaseFee,
 		BlockGasLimit:       1000000,
-		ChangeBatch: []*remote.StateChange{
+		ChangeBatch: []*remoteproto.StateChange{
 			{BlockHeight: 0, BlockHash: h1},
 		},
 	}
@@ -586,8 +586,8 @@ func TestReverseNonces(t *testing.T) {
 		Incarnation: 1,
 	}
 	v := accounts3.SerialiseV3(&acc)
-	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remote.AccountChange{
-		Action:  remote.Action_UPSERT,
+	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remoteproto.AccountChange{
+		Action:  remoteproto.Action_UPSERT,
 		Address: gointerfaces.ConvertAddressToH160(addr),
 		Data:    v,
 	})
@@ -699,11 +699,11 @@ func TestTxnPoke(t *testing.T) {
 	pendingBaseFee := uint64(200000)
 	// start blocks from 0, set empty hash - then kvcache will also work on this
 	h1 := gointerfaces.ConvertHashToH256([32]byte{})
-	change := &remote.StateChangeBatch{
+	change := &remoteproto.StateChangeBatch{
 		StateVersionId:      stateVersionID,
 		PendingBlockBaseFee: pendingBaseFee,
 		BlockGasLimit:       1000000,
-		ChangeBatch: []*remote.StateChange{
+		ChangeBatch: []*remoteproto.StateChange{
 			{BlockHeight: 0, BlockHash: h1},
 		},
 	}
@@ -716,8 +716,8 @@ func TestTxnPoke(t *testing.T) {
 		Incarnation: 1,
 	}
 	v := accounts3.SerialiseV3(&acc)
-	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remote.AccountChange{
-		Action:  remote.Action_UPSERT,
+	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remoteproto.AccountChange{
+		Action:  remoteproto.Action_UPSERT,
 		Address: gointerfaces.ConvertAddressToH160(addr),
 		Data:    v,
 	})
@@ -983,11 +983,11 @@ func TestTooHighGasLimitTxnValidation(t *testing.T) {
 	pendingBaseFee := uint64(200000)
 	// start blocks from 0, set empty hash - then kvcache will also work on this
 	h1 := gointerfaces.ConvertHashToH256([32]byte{})
-	change := &remote.StateChangeBatch{
+	change := &remoteproto.StateChangeBatch{
 		StateVersionId:      stateVersionID,
 		PendingBlockBaseFee: pendingBaseFee,
 		BlockGasLimit:       1000000,
-		ChangeBatch: []*remote.StateChange{
+		ChangeBatch: []*remoteproto.StateChange{
 			{BlockHeight: 0, BlockHash: h1},
 		},
 	}
@@ -1000,8 +1000,8 @@ func TestTooHighGasLimitTxnValidation(t *testing.T) {
 		Incarnation: 1,
 	}
 	v := accounts3.SerialiseV3(&acc)
-	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remote.AccountChange{
-		Action:  remote.Action_UPSERT,
+	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remoteproto.AccountChange{
+		Action:  remoteproto.Action_UPSERT,
 		Address: gointerfaces.ConvertAddressToH160(addr),
 		Data:    v,
 	})
@@ -1100,12 +1100,12 @@ func TestBlobTxnReplacement(t *testing.T) {
 	var stateVersionID uint64 = 0
 
 	h1 := gointerfaces.ConvertHashToH256([32]byte{})
-	change := &remote.StateChangeBatch{
+	change := &remoteproto.StateChangeBatch{
 		StateVersionId:       stateVersionID,
 		PendingBlockBaseFee:  200_000,
 		BlockGasLimit:        math.MaxUint64,
 		PendingBlobFeePerGas: 100_000,
-		ChangeBatch: []*remote.StateChange{
+		ChangeBatch: []*remoteproto.StateChange{
 			{BlockHeight: 0, BlockHash: h1},
 		},
 	}
@@ -1121,8 +1121,8 @@ func TestBlobTxnReplacement(t *testing.T) {
 	}
 	v := accounts3.SerialiseV3(&acc)
 
-	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remote.AccountChange{
-		Action:  remote.Action_UPSERT,
+	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remoteproto.AccountChange{
+		Action:  remoteproto.Action_UPSERT,
 		Address: gointerfaces.ConvertAddressToH160(addr),
 		Data:    v,
 	})
@@ -1288,11 +1288,11 @@ func TestDropRemoteAtNoGossip(t *testing.T) {
 	pendingBaseFee := uint64(1_000_000)
 	// start blocks from 0, set empty hash - then kvcache will also work on this
 	h1 := gointerfaces.ConvertHashToH256([32]byte{})
-	change := &remote.StateChangeBatch{
+	change := &remoteproto.StateChangeBatch{
 		StateVersionId:      stateVersionID,
 		PendingBlockBaseFee: pendingBaseFee,
 		BlockGasLimit:       1000000,
-		ChangeBatch: []*remote.StateChange{
+		ChangeBatch: []*remoteproto.StateChange{
 			{BlockHeight: 0, BlockHash: h1},
 		},
 	}
@@ -1305,8 +1305,8 @@ func TestDropRemoteAtNoGossip(t *testing.T) {
 		Incarnation: 1,
 	}
 	v := accounts3.SerialiseV3(&acc)
-	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remote.AccountChange{
-		Action:  remote.Action_UPSERT,
+	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remoteproto.AccountChange{
+		Action:  remoteproto.Action_UPSERT,
 		Address: gointerfaces.ConvertAddressToH160(addr),
 		Data:    v,
 	})
@@ -1394,12 +1394,12 @@ func TestBlobSlots(t *testing.T) {
 	var stateVersionID uint64 = 0
 
 	h1 := gointerfaces.ConvertHashToH256([32]byte{})
-	change := &remote.StateChangeBatch{
+	change := &remoteproto.StateChangeBatch{
 		StateVersionId:       stateVersionID,
 		PendingBlockBaseFee:  200_000,
 		BlockGasLimit:        math.MaxUint64,
 		PendingBlobFeePerGas: 100_000,
-		ChangeBatch: []*remote.StateChange{
+		ChangeBatch: []*remoteproto.StateChange{
 			{BlockHeight: 0, BlockHash: h1},
 		},
 	}
@@ -1416,8 +1416,8 @@ func TestBlobSlots(t *testing.T) {
 
 	for i := 0; i < 11; i++ {
 		addr[0] = uint8(i + 1)
-		change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remote.AccountChange{
-			Action:  remote.Action_UPSERT,
+		change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remoteproto.AccountChange{
+			Action:  remoteproto.Action_UPSERT,
 			Address: gointerfaces.ConvertAddressToH160(addr),
 			Data:    v,
 		})
@@ -1478,12 +1478,12 @@ func TestGetBlobsV1(t *testing.T) {
 	var stateVersionID uint64 = 0
 
 	h1 := gointerfaces.ConvertHashToH256([32]byte{})
-	change := &remote.StateChangeBatch{
+	change := &remoteproto.StateChangeBatch{
 		StateVersionId:       stateVersionID,
 		PendingBlockBaseFee:  200_000,
 		BlockGasLimit:        math.MaxUint64,
 		PendingBlobFeePerGas: 100_000,
-		ChangeBatch: []*remote.StateChange{
+		ChangeBatch: []*remoteproto.StateChange{
 			{BlockHeight: 0, BlockHash: h1},
 		},
 	}
@@ -1500,8 +1500,8 @@ func TestGetBlobsV1(t *testing.T) {
 
 	for i := 0; i < 11; i++ {
 		addr[0] = uint8(i + 1)
-		change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remote.AccountChange{
-			Action:  remote.Action_UPSERT,
+		change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remoteproto.AccountChange{
+			Action:  remoteproto.Action_UPSERT,
 			Address: gointerfaces.ConvertAddressToH160(addr),
 			Data:    v,
 		})
@@ -1576,16 +1576,16 @@ func TestGasLimitChanged(t *testing.T) {
 	require.NoError(err)
 	defer tx.Rollback()
 
-	change := &remote.StateChangeBatch{
+	change := &remoteproto.StateChangeBatch{
 		StateVersionId:      stateVersionID,
 		PendingBlockBaseFee: pendingBaseFee,
 		BlockGasLimit:       50_000,
-		ChangeBatch: []*remote.StateChange{
+		ChangeBatch: []*remoteproto.StateChange{
 			{BlockHeight: 0, BlockHash: h1},
 		},
 	}
-	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remote.AccountChange{
-		Action:  remote.Action_UPSERT,
+	change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remoteproto.AccountChange{
+		Action:  remoteproto.Action_UPSERT,
 		Address: gointerfaces.ConvertAddressToH160(addr),
 		Data:    v,
 	})
@@ -1652,11 +1652,11 @@ func BenchmarkProcessRemoteTxns(b *testing.B) {
 	var stateVersionID uint64 = 0
 	pendingBaseFee := uint64(200000)
 	h1 := gointerfaces.ConvertHashToH256([32]byte{})
-	change := &remote.StateChangeBatch{
+	change := &remoteproto.StateChangeBatch{
 		StateVersionId:      stateVersionID,
 		PendingBlockBaseFee: pendingBaseFee,
 		BlockGasLimit:       1000000,
-		ChangeBatch: []*remote.StateChange{
+		ChangeBatch: []*remoteproto.StateChange{
 			{BlockHeight: 0, BlockHash: h1},
 		},
 	}
@@ -1672,8 +1672,8 @@ func BenchmarkProcessRemoteTxns(b *testing.B) {
 			Incarnation: 1,
 		}
 		v := accounts3.SerialiseV3(&acc)
-		change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remote.AccountChange{
-			Action:  remote.Action_UPSERT,
+		change.ChangeBatch[0].Changes = append(change.ChangeBatch[0].Changes, &remoteproto.AccountChange{
+			Action:  remoteproto.Action_UPSERT,
 			Address: gointerfaces.ConvertAddressToH160(addr),
 			Data:    v,
 		})

--- a/txnprovider/txpool/senders.go
+++ b/txnprovider/txpool/senders.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	remote "github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/kv/kvcache"
 	"github.com/erigontech/erigon/execution/types/accounts"
@@ -249,7 +249,7 @@ func (sc *sendersBatch) registerNewSenders(newTxns *TxnSlots, logger log.Logger)
 	return nil
 }
 
-func (sc *sendersBatch) onNewBlock(stateChanges *remote.StateChangeBatch, unwindTxns, minedTxns TxnSlots, logger log.Logger) error {
+func (sc *sendersBatch) onNewBlock(stateChanges *remoteproto.StateChangeBatch, unwindTxns, minedTxns TxnSlots, logger log.Logger) error {
 	for _, diff := range stateChanges.ChangeBatch {
 		for _, change := range diff.Changes { // merge state changes
 			addrB := gointerfaces.ConvertH160toAddress(change.Address)

--- a/txnprovider/txpool/txpool_grpc_server.go
+++ b/txnprovider/txpool/txpool_grpc_server.go
@@ -38,7 +38,7 @@ import (
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/gointerfaces"
-	txpool_proto "github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon-lib/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon-lib/gointerfaces/typesproto"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/kv"
@@ -61,45 +61,45 @@ type txPool interface {
 	GetBlobs(blobhashes []common.Hash) (blobBundles []PoolBlobBundle)
 }
 
-var _ txpool_proto.TxpoolServer = (*GrpcServer)(nil)   // compile-time interface check
-var _ txpool_proto.TxpoolServer = (*GrpcDisabled)(nil) // compile-time interface check
+var _ txpoolproto.TxpoolServer = (*GrpcServer)(nil)   // compile-time interface check
+var _ txpoolproto.TxpoolServer = (*GrpcDisabled)(nil) // compile-time interface check
 
 var ErrPoolDisabled = errors.New("TxPool Disabled")
 
 type GrpcDisabled struct {
-	txpool_proto.UnimplementedTxpoolServer
+	txpoolproto.UnimplementedTxpoolServer
 }
 
 func (*GrpcDisabled) Version(ctx context.Context, empty *emptypb.Empty) (*typesproto.VersionReply, error) {
 	return nil, ErrPoolDisabled
 }
-func (*GrpcDisabled) FindUnknown(ctx context.Context, hashes *txpool_proto.TxHashes) (*txpool_proto.TxHashes, error) {
+func (*GrpcDisabled) FindUnknown(ctx context.Context, hashes *txpoolproto.TxHashes) (*txpoolproto.TxHashes, error) {
 	return nil, ErrPoolDisabled
 }
-func (*GrpcDisabled) Add(ctx context.Context, request *txpool_proto.AddRequest) (*txpool_proto.AddReply, error) {
+func (*GrpcDisabled) Add(ctx context.Context, request *txpoolproto.AddRequest) (*txpoolproto.AddReply, error) {
 	return nil, ErrPoolDisabled
 }
-func (*GrpcDisabled) Transactions(ctx context.Context, request *txpool_proto.TransactionsRequest) (*txpool_proto.TransactionsReply, error) {
+func (*GrpcDisabled) Transactions(ctx context.Context, request *txpoolproto.TransactionsRequest) (*txpoolproto.TransactionsReply, error) {
 	return nil, ErrPoolDisabled
 }
-func (*GrpcDisabled) All(ctx context.Context, request *txpool_proto.AllRequest) (*txpool_proto.AllReply, error) {
+func (*GrpcDisabled) All(ctx context.Context, request *txpoolproto.AllRequest) (*txpoolproto.AllReply, error) {
 	return nil, ErrPoolDisabled
 }
-func (*GrpcDisabled) Pending(ctx context.Context, empty *emptypb.Empty) (*txpool_proto.PendingReply, error) {
+func (*GrpcDisabled) Pending(ctx context.Context, empty *emptypb.Empty) (*txpoolproto.PendingReply, error) {
 	return nil, ErrPoolDisabled
 }
-func (*GrpcDisabled) OnAdd(request *txpool_proto.OnAddRequest, server txpool_proto.Txpool_OnAddServer) error {
+func (*GrpcDisabled) OnAdd(request *txpoolproto.OnAddRequest, server txpoolproto.Txpool_OnAddServer) error {
 	return ErrPoolDisabled
 }
-func (*GrpcDisabled) Status(ctx context.Context, request *txpool_proto.StatusRequest) (*txpool_proto.StatusReply, error) {
+func (*GrpcDisabled) Status(ctx context.Context, request *txpoolproto.StatusRequest) (*txpoolproto.StatusReply, error) {
 	return nil, ErrPoolDisabled
 }
-func (*GrpcDisabled) Nonce(ctx context.Context, request *txpool_proto.NonceRequest) (*txpool_proto.NonceReply, error) {
+func (*GrpcDisabled) Nonce(ctx context.Context, request *txpoolproto.NonceRequest) (*txpoolproto.NonceReply, error) {
 	return nil, ErrPoolDisabled
 }
 
 type GrpcServer struct {
-	txpool_proto.UnimplementedTxpoolServer
+	txpoolproto.UnimplementedTxpoolServer
 	ctx             context.Context
 	txPool          txPool
 	db              kv.RoDB
@@ -116,28 +116,28 @@ func NewGrpcServer(ctx context.Context, txPool txPool, db kv.RoDB, newSlotsStrea
 func (s *GrpcServer) Version(context.Context, *emptypb.Empty) (*typesproto.VersionReply, error) {
 	return TxPoolAPIVersion, nil
 }
-func convertSubPoolType(t SubPoolType) txpool_proto.AllReply_TxnType {
+func convertSubPoolType(t SubPoolType) txpoolproto.AllReply_TxnType {
 	switch t {
 	case PendingSubPool:
-		return txpool_proto.AllReply_PENDING
+		return txpoolproto.AllReply_PENDING
 	case BaseFeeSubPool:
-		return txpool_proto.AllReply_BASE_FEE
+		return txpoolproto.AllReply_BASE_FEE
 	case QueuedSubPool:
-		return txpool_proto.AllReply_QUEUED
+		return txpoolproto.AllReply_QUEUED
 	default:
 		panic("unknown")
 	}
 }
-func (s *GrpcServer) All(ctx context.Context, _ *txpool_proto.AllRequest) (*txpool_proto.AllReply, error) {
+func (s *GrpcServer) All(ctx context.Context, _ *txpoolproto.AllRequest) (*txpoolproto.AllReply, error) {
 	tx, err := s.db.BeginRo(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer tx.Rollback()
-	reply := &txpool_proto.AllReply{}
-	reply.Txs = make([]*txpool_proto.AllReply_Tx, 0, 32)
+	reply := &txpoolproto.AllReply{}
+	reply.Txs = make([]*txpoolproto.AllReply_Tx, 0, 32)
 	s.txPool.deprecatedForEach(ctx, func(rlp []byte, sender common.Address, t SubPoolType) {
-		reply.Txs = append(reply.Txs, &txpool_proto.AllReply_Tx{
+		reply.Txs = append(reply.Txs, &txpoolproto.AllReply_Tx{
 			Sender:  gointerfaces.ConvertAddressToH160(sender),
 			TxnType: convertSubPoolType(t),
 			RlpTx:   common.Copy(rlp),
@@ -146,9 +146,9 @@ func (s *GrpcServer) All(ctx context.Context, _ *txpool_proto.AllRequest) (*txpo
 	return reply, nil
 }
 
-func (s *GrpcServer) Pending(ctx context.Context, _ *emptypb.Empty) (*txpool_proto.PendingReply, error) {
-	reply := &txpool_proto.PendingReply{}
-	reply.Txs = make([]*txpool_proto.PendingReply_Tx, 0, 32)
+func (s *GrpcServer) Pending(ctx context.Context, _ *emptypb.Empty) (*txpoolproto.PendingReply, error) {
+	reply := &txpoolproto.PendingReply{}
+	reply.Txs = make([]*txpoolproto.PendingReply_Tx, 0, 32)
 	txnsRlp := TxnsRlp{}
 	if _, err := s.txPool.PeekBest(ctx, math.MaxInt16, &txnsRlp, 0 /* onTopOf */, math.MaxUint64 /* availableGas */, math.MaxUint64 /* availableBlobGas */, math.MaxInt /* availableRlpSpace */); err != nil {
 		return nil, err
@@ -156,7 +156,7 @@ func (s *GrpcServer) Pending(ctx context.Context, _ *emptypb.Empty) (*txpool_pro
 	var senderArr [20]byte
 	for i := range txnsRlp.Txns {
 		copy(senderArr[:], txnsRlp.Senders.At(i)) // TODO: optimize
-		reply.Txs = append(reply.Txs, &txpool_proto.PendingReply_Tx{
+		reply.Txs = append(reply.Txs, &txpoolproto.PendingReply_Tx{
 			Sender:  gointerfaces.ConvertAddressToH160(senderArr),
 			RlpTx:   txnsRlp.Txns[i],
 			IsLocal: txnsRlp.IsLocal[i],
@@ -165,11 +165,11 @@ func (s *GrpcServer) Pending(ctx context.Context, _ *emptypb.Empty) (*txpool_pro
 	return reply, nil
 }
 
-func (s *GrpcServer) FindUnknown(ctx context.Context, in *txpool_proto.TxHashes) (*txpool_proto.TxHashes, error) {
+func (s *GrpcServer) FindUnknown(ctx context.Context, in *txpoolproto.TxHashes) (*txpoolproto.TxHashes, error) {
 	return nil, errors.New("unimplemented")
 }
 
-func (s *GrpcServer) Add(ctx context.Context, in *txpool_proto.AddRequest) (*txpool_proto.AddReply, error) {
+func (s *GrpcServer) Add(ctx context.Context, in *txpoolproto.AddRequest) (*txpoolproto.AddReply, error) {
 	tx, err := s.db.BeginRo(ctx)
 	if err != nil {
 		return nil, err
@@ -180,7 +180,7 @@ func (s *GrpcServer) Add(ctx context.Context, in *txpool_proto.AddRequest) (*txp
 	parseCtx := NewTxnParseContext(s.chainID).ChainIDRequired()
 	parseCtx.ValidateRLP(s.txPool.ValidateSerializedTxn)
 
-	reply := &txpool_proto.AddReply{Imported: make([]txpool_proto.ImportResult, len(in.RlpTxs)), Errors: make([]string, len(in.RlpTxs))}
+	reply := &txpoolproto.AddReply{Imported: make([]txpoolproto.ImportResult, len(in.RlpTxs)), Errors: make([]string, len(in.RlpTxs))}
 
 	for i := 0; i < len(in.RlpTxs); i++ {
 		j := len(slots.Txns) // some incoming txns may be rejected, so - need second index
@@ -196,13 +196,13 @@ func (s *GrpcServer) Add(ctx context.Context, in *txpool_proto.AddRequest) (*txp
 			slots.Resize(uint(j))                // remove erroneous transaction
 			if errors.Is(err, ErrAlreadyKnown) { // Noop, but need to handle to not count these
 				reply.Errors[i] = txpoolcfg.AlreadyKnown.String()
-				reply.Imported[i] = txpool_proto.ImportResult_ALREADY_EXISTS
+				reply.Imported[i] = txpoolproto.ImportResult_ALREADY_EXISTS
 			} else if errors.Is(err, ErrRlpTooBig) { // Noop, but need to handle to not count these
 				reply.Errors[i] = txpoolcfg.RLPTooLong.String()
-				reply.Imported[i] = txpool_proto.ImportResult_INVALID
+				reply.Imported[i] = txpoolproto.ImportResult_INVALID
 			} else {
 				reply.Errors[i] = err.Error()
-				reply.Imported[i] = txpool_proto.ImportResult_INTERNAL_ERROR
+				reply.Imported[i] = txpoolproto.ImportResult_INTERNAL_ERROR
 			}
 		}
 	}
@@ -214,7 +214,7 @@ func (s *GrpcServer) Add(ctx context.Context, in *txpool_proto.AddRequest) (*txp
 
 	j := 0
 	for i := range reply.Imported {
-		if reply.Imported[i] != txpool_proto.ImportResult_SUCCESS {
+		if reply.Imported[i] != txpoolproto.ImportResult_SUCCESS {
 			j++
 			continue
 		}
@@ -226,7 +226,7 @@ func (s *GrpcServer) Add(ctx context.Context, in *txpool_proto.AddRequest) (*txp
 	return reply, nil
 }
 
-func (s *GrpcServer) GetBlobs(ctx context.Context, in *txpool_proto.GetBlobsRequest) (*txpool_proto.GetBlobsReply, error) {
+func (s *GrpcServer) GetBlobs(ctx context.Context, in *txpoolproto.GetBlobsRequest) (*txpoolproto.GetBlobsReply, error) {
 	tx, err := s.db.BeginRo(ctx)
 	if err != nil {
 		return nil, err
@@ -238,40 +238,40 @@ func (s *GrpcServer) GetBlobs(ctx context.Context, in *txpool_proto.GetBlobsRequ
 		hashes[i] = gointerfaces.ConvertH256ToHash(in.BlobHashes[i])
 	}
 	blobBundles := s.txPool.GetBlobs(hashes)
-	reply := make([]*txpool_proto.BlobAndProof, len(blobBundles))
+	reply := make([]*txpoolproto.BlobAndProof, len(blobBundles))
 	for i, bb := range blobBundles {
 		var proofs [][]byte
 		for _, p := range bb.Proofs {
 			proofs = append(proofs, p[:])
 		}
-		reply[i] = &txpool_proto.BlobAndProof{
+		reply[i] = &txpoolproto.BlobAndProof{
 			Blob:   bb.Blob,
 			Proofs: proofs,
 		}
 	}
-	return &txpool_proto.GetBlobsReply{BlobsWithProofs: reply}, nil
+	return &txpoolproto.GetBlobsReply{BlobsWithProofs: reply}, nil
 }
 
-func mapDiscardReasonToProto(reason txpoolcfg.DiscardReason) txpool_proto.ImportResult {
+func mapDiscardReasonToProto(reason txpoolcfg.DiscardReason) txpoolproto.ImportResult {
 	switch reason {
 	case txpoolcfg.Success:
-		return txpool_proto.ImportResult_SUCCESS
+		return txpoolproto.ImportResult_SUCCESS
 	case txpoolcfg.AlreadyKnown:
-		return txpool_proto.ImportResult_ALREADY_EXISTS
+		return txpoolproto.ImportResult_ALREADY_EXISTS
 	case txpoolcfg.UnderPriced, txpoolcfg.ReplaceUnderpriced, txpoolcfg.FeeTooLow:
-		return txpool_proto.ImportResult_FEE_TOO_LOW
+		return txpoolproto.ImportResult_FEE_TOO_LOW
 	case txpoolcfg.InvalidSender, txpoolcfg.NegativeValue, txpoolcfg.OversizedData, txpoolcfg.InitCodeTooLarge,
 		txpoolcfg.RLPTooLong, txpoolcfg.InvalidCreateTxn, txpoolcfg.NoBlobs, txpoolcfg.TooManyBlobs,
 		txpoolcfg.TypeNotActivated, txpoolcfg.UnequalBlobTxExt, txpoolcfg.BlobHashCheckFail,
 		txpoolcfg.UnmatchedBlobTxExt, txpoolcfg.NoAuthorizations:
 		// TODO(EIP-7702) TypeNotActivated may be transient (e.g. a set code transaction is submitted 1 sec prior to the Pectra activation)
-		return txpool_proto.ImportResult_INVALID
+		return txpoolproto.ImportResult_INVALID
 	default:
-		return txpool_proto.ImportResult_INTERNAL_ERROR
+		return txpoolproto.ImportResult_INTERNAL_ERROR
 	}
 }
 
-func (s *GrpcServer) OnAdd(req *txpool_proto.OnAddRequest, stream txpool_proto.Txpool_OnAddServer) error {
+func (s *GrpcServer) OnAdd(req *txpoolproto.OnAddRequest, stream txpoolproto.Txpool_OnAddServer) error {
 	s.logger.Info("New txns subscriber joined")
 	//txpool.Loop does send messages to this streams
 	remove := s.newSlotsStreams.Add(stream)
@@ -284,14 +284,14 @@ func (s *GrpcServer) OnAdd(req *txpool_proto.OnAddRequest, stream txpool_proto.T
 	}
 }
 
-func (s *GrpcServer) Transactions(ctx context.Context, in *txpool_proto.TransactionsRequest) (*txpool_proto.TransactionsReply, error) {
+func (s *GrpcServer) Transactions(ctx context.Context, in *txpoolproto.TransactionsRequest) (*txpoolproto.TransactionsReply, error) {
 	tx, err := s.db.BeginRo(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer tx.Rollback()
 
-	reply := &txpool_proto.TransactionsReply{RlpTxs: make([][]byte, len(in.Hashes))}
+	reply := &txpoolproto.TransactionsReply{RlpTxs: make([][]byte, len(in.Hashes))}
 	for i := range in.Hashes {
 		h := gointerfaces.ConvertH256ToHash(in.Hashes[i])
 		txnRlp, err := s.txPool.GetRlp(tx, h[:])
@@ -308,9 +308,9 @@ func (s *GrpcServer) Transactions(ctx context.Context, in *txpool_proto.Transact
 	return reply, nil
 }
 
-func (s *GrpcServer) Status(_ context.Context, _ *txpool_proto.StatusRequest) (*txpool_proto.StatusReply, error) {
+func (s *GrpcServer) Status(_ context.Context, _ *txpoolproto.StatusRequest) (*txpoolproto.StatusReply, error) {
 	pending, baseFee, queued := s.txPool.CountContent()
-	return &txpool_proto.StatusReply{
+	return &txpoolproto.StatusReply{
 		PendingCount: uint32(pending),
 		QueuedCount:  uint32(queued),
 		BaseFeeCount: uint32(baseFee),
@@ -318,10 +318,10 @@ func (s *GrpcServer) Status(_ context.Context, _ *txpool_proto.StatusRequest) (*
 }
 
 // returns nonce for address
-func (s *GrpcServer) Nonce(ctx context.Context, in *txpool_proto.NonceRequest) (*txpool_proto.NonceReply, error) {
+func (s *GrpcServer) Nonce(ctx context.Context, in *txpoolproto.NonceRequest) (*txpoolproto.NonceReply, error) {
 	addr := gointerfaces.ConvertH160toAddress(in.Address)
 	nonce, inPool := s.txPool.NonceFromAddress(addr)
-	return &txpool_proto.NonceReply{
+	return &txpoolproto.NonceReply{
 		Nonce: nonce,
 		Found: inPool,
 	}, nil
@@ -329,16 +329,16 @@ func (s *GrpcServer) Nonce(ctx context.Context, in *txpool_proto.NonceRequest) (
 
 // NewSlotsStreams - it's safe to use this class as non-pointer
 type NewSlotsStreams struct {
-	chans map[uint]txpool_proto.Txpool_OnAddServer
+	chans map[uint]txpoolproto.Txpool_OnAddServer
 	mu    sync.Mutex
 	id    uint
 }
 
-func (s *NewSlotsStreams) Add(stream txpool_proto.Txpool_OnAddServer) (remove func()) {
+func (s *NewSlotsStreams) Add(stream txpoolproto.Txpool_OnAddServer) (remove func()) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.chans == nil {
-		s.chans = make(map[uint]txpool_proto.Txpool_OnAddServer)
+		s.chans = make(map[uint]txpoolproto.Txpool_OnAddServer)
 	}
 	s.id++
 	id := s.id
@@ -346,7 +346,7 @@ func (s *NewSlotsStreams) Add(stream txpool_proto.Txpool_OnAddServer) (remove fu
 	return func() { s.remove(id) }
 }
 
-func (s *NewSlotsStreams) Broadcast(reply *txpool_proto.OnAddReply, logger log.Logger) {
+func (s *NewSlotsStreams) Broadcast(reply *txpoolproto.OnAddReply, logger log.Logger) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for id, stream := range s.chans {
@@ -372,7 +372,7 @@ func (s *NewSlotsStreams) remove(id uint) {
 	delete(s.chans, id)
 }
 
-func StartGrpc(txPoolServer txpool_proto.TxpoolServer, miningServer txpool_proto.MiningServer, addr string, creds *credentials.TransportCredentials, logger log.Logger) (*grpc.Server, error) {
+func StartGrpc(txPoolServer txpoolproto.TxpoolServer, miningServer txpoolproto.MiningServer, addr string, creds *credentials.TransportCredentials, logger log.Logger) (*grpc.Server, error) {
 	lis, err := net.Listen("tcp", addr)
 	if err != nil {
 		return nil, fmt.Errorf("could not create listener: %w, addr=%s", err, addr)
@@ -412,10 +412,10 @@ func StartGrpc(txPoolServer txpool_proto.TxpoolServer, miningServer txpool_proto
 	grpcServer := grpc.NewServer(opts...)
 	reflection.Register(grpcServer) // Register reflection service on gRPC server.
 	if txPoolServer != nil {
-		txpool_proto.RegisterTxpoolServer(grpcServer, txPoolServer)
+		txpoolproto.RegisterTxpoolServer(grpcServer, txPoolServer)
 	}
 	if miningServer != nil {
-		txpool_proto.RegisterMiningServer(grpcServer, miningServer)
+		txpoolproto.RegisterMiningServer(grpcServer, miningServer)
 	}
 
 	//if metrics.Enabled {


### PR DESCRIPTION
removes old import aliases for proto packages and aligns all imports across the codebase