### PR TITLE
fix(integrity): correct error message when block body is missing

### DIFF
--- a/eth/integrity/no_gaps_in_canonical_headers.go
+++ b/eth/integrity/no_gaps_in_canonical_headers.go
@@ -68,7 +68,7 @@ func NoGapsInCanonicalHeaders(ctx context.Context, db kv.RoDB, br services.FullB
 		}
 		body, _, _ := rawdb.ReadBody(tx, hash, i)
 		if body == nil {
-			err = fmt.Errorf("header not found: %d", i)
+			err = fmt.Errorf("body not found: %d", i)
 			if failFast {
 				return err
 			}


### PR DESCRIPTION
Fixed error message in NoGapsInCanonicalHeaders: if there is no body, “body not found” is now logged instead of “header not found.”