### PR TITLE
agg: remove `salt` pointer from `tx` objects

### DIFF
--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -545,7 +545,7 @@ type DomainRoTx struct {
 	name     kv.Domain
 	stepSize uint64
 	ht       *HistoryRoTx
-	salt     *uint32
+	salt     uint32
 
 	d *Domain
 
@@ -618,7 +618,7 @@ func (d *Domain) BeginFilesRo() *DomainRoTx {
 		ht:       d.History.BeginFilesRo(),
 		visible:  d._visible,
 		files:    d._visible.files,
-		salt:     d.salt.Load(),
+		salt:     *d.salt.Load(),
 	}
 }
 

--- a/db/state/inverted_index.go
+++ b/db/state/inverted_index.go
@@ -440,7 +440,7 @@ func (ii *InvertedIndex) BeginFilesRo() *InvertedIndexRoTx {
 		files:    files,
 		stepSize: ii.stepSize,
 		name:     ii.Name,
-		salt:     ii.salt.Load(),
+		salt:     *ii.salt.Load(),
 	}
 }
 func (iit *InvertedIndexRoTx) Close() {
@@ -509,7 +509,7 @@ type InvertedIndexRoTx struct {
 
 	// TODO: retrofit recent optimization in main and reenable the next line
 	// ef *multiencseq.SequenceBuilder // re-usable
-	salt     *uint32
+	salt     uint32
 	stepSize uint64
 }
 
@@ -517,7 +517,7 @@ type InvertedIndexRoTx struct {
 func (iit *InvertedIndexRoTx) hashKey(k []byte) (uint64, uint64) {
 	// this inlinable alloc-free version, it's faster than pre-allocated `hasher` object
 	// because `hasher` object is interface and need call many methods on it
-	return murmur3.Sum128WithSeed(k, *iit.salt)
+	return murmur3.Sum128WithSeed(k, iit.salt)
 }
 
 func (iit *InvertedIndexRoTx) statelessGetter(i int) *seg.Reader {

--- a/db/state/merge.go
+++ b/db/state/merge.go
@@ -554,7 +554,7 @@ func (dt *DomainRoTx) mergeFiles(ctx context.Context, domainFiles, indexFiles, h
 		if toStep == 0 && dt.d.FilenameBase == "commitment" {
 			btM = 128
 		}
-		valuesIn.bindex, err = CreateBtreeIndexWithDecompressor(btPath, btM, dt.dataReader(valuesIn.decompressor), *dt.salt, ps, dt.d.dirs.Tmp, dt.d.logger, dt.d.noFsync, dt.d.Accessors)
+		valuesIn.bindex, err = CreateBtreeIndexWithDecompressor(btPath, btM, dt.dataReader(valuesIn.decompressor), dt.salt, ps, dt.d.dirs.Tmp, dt.d.logger, dt.d.noFsync, dt.d.Accessors)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("merge %s btindex [%d-%d]: %w", dt.d.FilenameBase, r.values.from, r.values.to, err)
 		}


### PR DESCRIPTION
keep pointer in `db` object for now