### PR TITLE
db: don't LoadSnapshotsHashes if NoDownloader

### DIFF
--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -255,7 +255,7 @@ func Downloader(ctx context.Context, logger log.Logger) error {
 		webseedsList = append(webseedsList, known...)
 	}
 	if seedbox {
-		_, err = downloadercfg.LoadSnapshotsHashes(ctx, dirs, chain)
+		err = downloadercfg.LoadSnapshotsHashes(ctx, dirs, chain)
 		if err != nil {
 			return err
 		}

--- a/db/downloader/downloadercfg/downloadercfg.go
+++ b/db/downloader/downloadercfg/downloadercfg.go
@@ -276,12 +276,6 @@ func New(
 		"webseedHttpProviders", webseedHttpProviders,
 		"webseedUrlsOrFiles", webseedUrlsOrFiles)
 
-	// TODO: constructor must not do http requests
-	err = LoadSnapshotsHashes(ctx, dirs, chainName)
-	if err != nil {
-		return nil, err
-	}
-
 	cfg := Cfg{
 		Dirs:                dirs,
 		ChainName:           chainName,

--- a/db/snapcfg/util.go
+++ b/db/snapcfg/util.go
@@ -363,10 +363,6 @@ func newCfg(networkName string, preverified Preverified) *Cfg {
 	return cfg
 }
 
-func NewNonSeededCfg(networkName string) *Cfg {
-	return newCfg(networkName, Preverified{})
-}
-
 type Cfg struct {
 	ExpectBlocks      uint64
 	Preverified       Preverified          // immutable

--- a/db/snapshotsync/snapshots.go
+++ b/db/snapshotsync/snapshots.go
@@ -668,13 +668,6 @@ func (s *RoSnapshots) LogStat(label string) {
 		"alloc", common.ByteCount(m.Alloc), "sys", common.ByteCount(m.Sys))
 }
 
-func (s *RoSnapshots) EnsureExpectedBlocksAreAvailable(cfg *snapcfg.Cfg) error {
-	if s.BlocksAvailable() < cfg.ExpectBlocks {
-		return fmt.Errorf("app must wait until all expected snapshots are available. Expected: %d, Available: %d", cfg.ExpectBlocks, s.BlocksAvailable())
-	}
-	return nil
-}
-
 func (s *RoSnapshots) Types() []snaptype.Type { return s.types }
 func (s *RoSnapshots) HasType(in snaptype.Type) bool {
 	for _, t := range s.enums {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1510,6 +1510,10 @@ func (s *Ethereum) setUpSnapDownloader(
 		return nil
 	}
 
+	if err := downloadercfg.LoadSnapshotsHashes(ctx, downloaderCfg.Dirs, downloaderCfg.ChainName); err != nil {
+		return err
+	}
+
 	if s.config.Snapshot.DownloaderAddr != "" {
 		// connect to external Downloader
 		s.downloaderClient, err = downloadergrpc.NewClient(ctx, s.config.Snapshot.DownloaderAddr)


### PR DESCRIPTION
This should help with Hive tests [stalling](https://hive.ethpandaops.io/#/logs/fusaka-devnet-5/1756909285-d08347bf9c588e2468e0a2ba0b7f6095/erigon_default%2Fclient-95ef2ede0647544c78467104edb84cd67ad67638ef1cd5d175a2e4cab53fd6e6.log) on "Loading remote snapshot hashes".