### PR TITLE
add randomness to temp file names - to remove race condition

### DIFF
--- a/erigon-lib/common/dir/rw_dir.go
+++ b/erigon-lib/common/dir/rw_dir.go
@@ -17,6 +17,7 @@
 package dir
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -217,4 +218,11 @@ func RemoveAll(path string) error {
 		log.Debug("[removing] removing dir", "path", path, "stack", dbg.Stack())
 	}
 	return os.RemoveAll(path)
+}
+
+// CreateTemp creates a temporal file using `file` as base
+func CreateTemp(file string) (*os.File, error) {
+	directory := filepath.Dir(file)
+	filename := filepath.Base(file)
+	return os.CreateTemp(directory, fmt.Sprintf("%s.*.tmp", filename))
 }

--- a/erigon-lib/common/dir/rw_dir.go
+++ b/erigon-lib/common/dir/rw_dir.go
@@ -222,7 +222,11 @@ func RemoveAll(path string) error {
 
 // CreateTemp creates a temporary file using `file` as base
 func CreateTemp(file string) (*os.File, error) {
+	return CreateTempWithExtension(file, "tmp")
+}
+
+func CreateTempWithExtension(file string, extension string) (*os.File, error) {
 	directory := filepath.Dir(file)
 	filename := filepath.Base(file)
-	return os.CreateTemp(directory, fmt.Sprintf("%s.*.tmp", filename))
+	return os.CreateTemp(directory, fmt.Sprintf("%s.*.%s", filename, extension))
 }

--- a/erigon-lib/common/dir/rw_dir.go
+++ b/erigon-lib/common/dir/rw_dir.go
@@ -220,7 +220,7 @@ func RemoveAll(path string) error {
 	return os.RemoveAll(path)
 }
 
-// CreateTemp creates a temporal file using `file` as base
+// CreateTemp creates a temporary file using `file` as base
 func CreateTemp(file string) (*os.File, error) {
 	directory := filepath.Dir(file)
 	filename := filepath.Base(file)

--- a/erigon-lib/common/dir/rw_dir_test.go
+++ b/erigon-lib/common/dir/rw_dir_test.go
@@ -1,0 +1,42 @@
+// Copyright 2021 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package dir
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_CreateTemp(t *testing.T) {
+	dir := t.TempDir()
+	ogfile := filepath.Join(dir, "hello_world")
+	tmpfile, err := CreateTemp(ogfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tmpfile.Close()
+	dir1 := filepath.Dir(tmpfile.Name())
+	dir2 := filepath.Dir(ogfile)
+	require.True(t, dir1 == dir2)
+
+	base1 := filepath.Base(tmpfile.Name())
+	base2 := filepath.Base(ogfile)
+	require.True(t, strings.HasPrefix(base1, base2))
+}

--- a/erigon-lib/datastruct/existence/existence_filter.go
+++ b/erigon-lib/datastruct/existence/existence_filter.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"fmt"
 	"hash"
-	randv2 "math/rand/v2"
 	"os"
 	"path/filepath"
 
@@ -110,8 +109,7 @@ func (b *Filter) Build() error {
 	}
 
 	log.Trace("[agg] write file", "file", b.FileName)
-	tmpFilePath := b.FilePath + fmt.Sprintf("%d", randv2.UintN(10000)) + ".tmp"
-	cf, err := os.Create(tmpFilePath)
+	cf, err := dir.CreateTemp(b.FilePath)
 	if err != nil {
 		return err
 	}
@@ -126,7 +124,7 @@ func (b *Filter) Build() error {
 	if err = cf.Close(); err != nil {
 		return err
 	}
-	if err := os.Rename(tmpFilePath, b.FilePath); err != nil {
+	if err := os.Rename(cf.Name(), b.FilePath); err != nil {
 		return err
 	}
 	return nil

--- a/erigon-lib/datastruct/existence/existence_filter.go
+++ b/erigon-lib/datastruct/existence/existence_filter.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"fmt"
 	"hash"
+	randv2 "math/rand/v2"
 	"os"
 	"path/filepath"
 
@@ -109,7 +110,7 @@ func (b *Filter) Build() error {
 	}
 
 	log.Trace("[agg] write file", "file", b.FileName)
-	tmpFilePath := b.FilePath + ".tmp"
+	tmpFilePath := b.FilePath + fmt.Sprintf("%d", randv2.UintN(10000)) + ".tmp"
 	cf, err := os.Create(tmpFilePath)
 	if err != nil {
 		return err

--- a/erigon-lib/datastruct/fusefilter/fusefilter_writer.go
+++ b/erigon-lib/datastruct/fusefilter/fusefilter_writer.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	randv2 "math/rand/v2"
 	"os"
 	"path/filepath"
 	"unsafe"
@@ -28,8 +27,7 @@ type WriterOffHeap struct {
 }
 
 func NewWriterOffHeap(filePath string) (*WriterOffHeap, error) {
-	tmpFilePath := filePath + fmt.Sprintf("%d", randv2.UintN(10000)) + ".existence.tmp"
-	f, err := os.Create(tmpFilePath)
+	f, err := dir.CreateTempWithExtension(filePath, "existence.tmp")
 	if err != nil {
 		return nil, err
 	}
@@ -37,7 +35,7 @@ func NewWriterOffHeap(filePath string) (*WriterOffHeap, error) {
 	if IsLittleEndian {
 		features |= IsLittleEndianFeature
 	}
-	return &WriterOffHeap{tmpFile: f, features: features, tmpFilePath: tmpFilePath}, nil
+	return &WriterOffHeap{tmpFile: f, features: features, tmpFilePath: f.Name()}, nil
 }
 
 func (w *WriterOffHeap) Close() {

--- a/erigon-lib/recsplit/recsplit.go
+++ b/erigon-lib/recsplit/recsplit.go
@@ -19,13 +19,13 @@ package recsplit
 import (
 	"bufio"
 	"context"
-	"crypto/rand"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
 	"math"
 	"math/bits"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 
@@ -172,7 +172,7 @@ func NewRecSplit(args RecSplitArgs, logger log.Logger) (*RecSplit, error) {
 	rs := &RecSplit{
 		version:    args.Version,
 		bucketSize: args.BucketSize, keyExpectedCount: uint64(args.KeyCount), bucketCount: uint64(bucketCount),
-		tmpDir: args.TmpDir, filePath: args.IndexFile, tmpFilePath: args.IndexFile + ".tmp",
+		tmpDir: args.TmpDir, filePath: args.IndexFile, tmpFilePath: args.IndexFile + fmt.Sprintf("%d", rand.UintN(10000)) + ".tmp",
 		enums:              args.Enums,
 		baseDataID:         args.BaseDataID,
 		lessFalsePositives: args.LessFalsePositives,

--- a/erigon-lib/recsplit/recsplit.go
+++ b/erigon-lib/recsplit/recsplit.go
@@ -19,13 +19,14 @@ package recsplit
 import (
 	"bufio"
 	"context"
+	"crypto/rand"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
 	"math"
 	"math/bits"
-	"math/rand/v2"
+	randv2 "math/rand/v2"
 	"os"
 	"path/filepath"
 
@@ -172,7 +173,7 @@ func NewRecSplit(args RecSplitArgs, logger log.Logger) (*RecSplit, error) {
 	rs := &RecSplit{
 		version:    args.Version,
 		bucketSize: args.BucketSize, keyExpectedCount: uint64(args.KeyCount), bucketCount: uint64(bucketCount),
-		tmpDir: args.TmpDir, filePath: args.IndexFile, tmpFilePath: args.IndexFile + fmt.Sprintf("%d", rand.UintN(10000)) + ".tmp",
+		tmpDir: args.TmpDir, filePath: args.IndexFile, tmpFilePath: args.IndexFile + fmt.Sprintf("%d", randv2.UintN(10000)) + ".tmp",
 		enums:              args.Enums,
 		baseDataID:         args.BaseDataID,
 		lessFalsePositives: args.LessFalsePositives,

--- a/erigon-lib/recsplit/recsplit.go
+++ b/erigon-lib/recsplit/recsplit.go
@@ -26,7 +26,6 @@ import (
 	"io"
 	"math"
 	"math/bits"
-	randv2 "math/rand/v2"
 	"os"
 	"path/filepath"
 
@@ -86,8 +85,8 @@ type RecSplit struct {
 	offsetEf        *eliasfano32.EliasFano // Elias Fano instance for encoding the offsets
 	bucketCollector *etl.Collector         // Collector that sorts by buckets
 
-	fileName              string
-	filePath, tmpFilePath string
+	fileName string
+	filePath string
 
 	tmpDir            string
 	gr                GolombRice // Helper object to encode the tree of hash function salts using Golomb-Rice code.
@@ -173,7 +172,7 @@ func NewRecSplit(args RecSplitArgs, logger log.Logger) (*RecSplit, error) {
 	rs := &RecSplit{
 		version:    args.Version,
 		bucketSize: args.BucketSize, keyExpectedCount: uint64(args.KeyCount), bucketCount: uint64(bucketCount),
-		tmpDir: args.TmpDir, filePath: args.IndexFile, tmpFilePath: args.IndexFile + fmt.Sprintf("%d", randv2.UintN(10000)) + ".tmp",
+		tmpDir: args.TmpDir, filePath: args.IndexFile,
 		enums:              args.Enums,
 		baseDataID:         args.BaseDataID,
 		lessFalsePositives: args.LessFalsePositives,
@@ -645,7 +644,7 @@ func (rs *RecSplit) Build(ctx context.Context) error {
 		return fmt.Errorf("rs %s expected keys %d, got %d", rs.fileName, rs.keyExpectedCount, rs.keysAdded)
 	}
 	var err error
-	if rs.indexF, err = os.Create(rs.tmpFilePath); err != nil {
+	if rs.indexF, err = dir.CreateTemp(rs.filePath); err != nil {
 		return fmt.Errorf("create index file %s: %w", rs.filePath, err)
 	}
 
@@ -783,8 +782,8 @@ func (rs *RecSplit) Build(ctx context.Context) error {
 		return err
 	}
 
-	if err = os.Rename(rs.tmpFilePath, rs.filePath); err != nil {
-		rs.logger.Warn("[index] rename", "file", rs.tmpFilePath, "err", err)
+	if err = os.Rename(rs.indexF.Name(), rs.filePath); err != nil {
+		rs.logger.Warn("[index] rename", "file", rs.indexF.Name(), "err", err)
 		return err
 	}
 	rs.logger.Debug("[index] created", "file", rs.fileName)
@@ -833,7 +832,7 @@ func (rs *RecSplit) fsync() error {
 		return nil
 	}
 	if err := rs.indexF.Sync(); err != nil {
-		rs.logger.Warn("couldn't fsync", "err", err, "file", rs.tmpFilePath)
+		rs.logger.Warn("couldn't fsync", "err", err, "file", rs.indexF.Name())
 		return err
 	}
 	return nil

--- a/erigon-lib/seg/compress.go
+++ b/erigon-lib/seg/compress.go
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"io"
 	"math/bits"
-	randv2 "math/rand/v2"
 	"os"
 	"path/filepath"
 	"slices"
@@ -37,6 +36,7 @@ import (
 	"github.com/c2h5oh/datasize"
 
 	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/common/dir"
 	dir2 "github.com/erigontech/erigon-lib/common/dir"
 	"github.com/erigontech/erigon-lib/etl"
 	"github.com/erigontech/erigon-lib/log/v3"
@@ -106,7 +106,6 @@ type Compressor struct {
 
 	outputFileName   string
 	outputFile       string // File where to output the dictionary and compressed data
-	tmpOutFilePath   string // File where to output the dictionary and compressed data
 	suffixCollectors []*etl.Collector
 	// Buffer for "superstring" - transformation of superstrings where each byte of a word, say b,
 	// is turned into 2 bytes, 0x01 and b, and two zero bytes 0x00 0x00 are inserted after each word
@@ -125,11 +124,7 @@ type Compressor struct {
 func NewCompressor(ctx context.Context, logPrefix, outputFile, tmpDir string, cfg Cfg, lvl log.Lvl, logger log.Logger) (*Compressor, error) {
 	workers := cfg.Workers
 	dir2.MustExist(tmpDir)
-	dir, fileName := filepath.Split(outputFile)
-
-	// tmpOutFilePath is a ".seg.<random_string>.tmp" file which will be renamed to ".seg" if everything succeeds.
-	// It allows to atomically create a ".seg" file (the downloader will not see partial ".seg" files).
-	tmpOutFilePath := filepath.Join(dir, fileName) + fmt.Sprintf("%d", randv2.UintN(10000)) + ".tmp"
+	_, fileName := filepath.Split(outputFile)
 
 	uncompressedPath := filepath.Join(tmpDir, fileName) + ".idt"
 	uncompressedFile, err := NewRawWordsFile(uncompressedPath)
@@ -154,7 +149,6 @@ func NewCompressor(ctx context.Context, logPrefix, outputFile, tmpDir string, cf
 	return &Compressor{
 		Cfg:              cfg,
 		uncompressedFile: uncompressedFile,
-		tmpOutFilePath:   tmpOutFilePath,
 		outputFile:       outputFile,
 		outputFileName:   outputFileName,
 		tmpDir:           tmpDir,
@@ -263,15 +257,16 @@ func (c *Compressor) Compress() error {
 			return err
 		}
 	}
-	defer dir2.RemoveFile(c.tmpOutFilePath)
 
-	cf, err := os.Create(c.tmpOutFilePath)
+	cf, err := dir.CreateTemp(c.outputFile)
 	if err != nil {
 		return err
 	}
+	tmpFileName := cf.Name()
+	defer dir.RemoveFile(tmpFileName)
 	defer cf.Close()
 	t := time.Now()
-	if err := compressWithPatternCandidates(c.ctx, c.trace, c.Cfg, c.logPrefix, c.tmpOutFilePath, cf, c.uncompressedFile, db, c.lvl, c.logger); err != nil {
+	if err := compressWithPatternCandidates(c.ctx, c.trace, c.Cfg, c.logPrefix, tmpFileName, cf, c.uncompressedFile, db, c.lvl, c.logger); err != nil {
 		return err
 	}
 	if err = c.fsync(cf); err != nil {
@@ -280,7 +275,7 @@ func (c *Compressor) Compress() error {
 	if err = cf.Close(); err != nil {
 		return err
 	}
-	if err := os.Rename(c.tmpOutFilePath, c.outputFile); err != nil {
+	if err := os.Rename(tmpFileName, c.outputFile); err != nil {
 		return fmt.Errorf("renaming: %w", err)
 	}
 
@@ -306,7 +301,7 @@ func (c *Compressor) fsync(f *os.File) error {
 		return nil
 	}
 	if err := f.Sync(); err != nil {
-		c.logger.Warn("couldn't fsync", "err", err, "file", c.tmpOutFilePath)
+		c.logger.Warn("couldn't fsync", "err", err, "file", f.Name())
 		return err
 	}
 	return nil

--- a/erigon-lib/seg/compress.go
+++ b/erigon-lib/seg/compress.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"io"
 	"math/bits"
+	randv2 "math/rand/v2"
 	"os"
 	"path/filepath"
 	"slices"
@@ -126,9 +127,9 @@ func NewCompressor(ctx context.Context, logPrefix, outputFile, tmpDir string, cf
 	dir2.MustExist(tmpDir)
 	dir, fileName := filepath.Split(outputFile)
 
-	// tmpOutFilePath is a ".seg.tmp" file which will be renamed to ".seg" if everything succeeds.
+	// tmpOutFilePath is a ".seg.<random_string>.tmp" file which will be renamed to ".seg" if everything succeeds.
 	// It allows to atomically create a ".seg" file (the downloader will not see partial ".seg" files).
-	tmpOutFilePath := filepath.Join(dir, fileName) + ".tmp"
+	tmpOutFilePath := filepath.Join(dir, fileName) + fmt.Sprintf("%d", randv2.UintN(10000)) + ".tmp"
 
 	uncompressedPath := filepath.Join(tmpDir, fileName) + ".idt"
 	uncompressedFile, err := NewRawWordsFile(uncompressedPath)

--- a/erigon-lib/seg/parallel_compress.go
+++ b/erigon-lib/seg/parallel_compress.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	randv2 "math/rand/v2"
 	"os"
 	"slices"
 	"strconv"
@@ -296,12 +295,13 @@ func compressWithPatternCandidates(ctx context.Context, trace bool, cfg Cfg, log
 	t := time.Now()
 
 	var err error
-	intermediatePath := segmentFilePath + fmt.Sprintf("%d", randv2.UintN(10000)) + ".tmp"
-	defer dir.RemoveFile(intermediatePath)
+
 	var intermediateFile *os.File
-	if intermediateFile, err = os.Create(intermediatePath); err != nil {
+	if intermediateFile, err = dir.CreateTemp(segmentFilePath); err != nil {
 		return fmt.Errorf("create intermediate file: %w", err)
 	}
+	intermediatePath := intermediateFile.Name()
+	defer dir.RemoveFile(intermediatePath)
 	defer intermediateFile.Close()
 	intermediateW := bufio.NewWriterSize(intermediateFile, 8*etl.BufIOSize)
 

--- a/erigon-lib/seg/parallel_compress.go
+++ b/erigon-lib/seg/parallel_compress.go
@@ -23,14 +23,16 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/erigontech/erigon-lib/common/dir"
 	"io"
+	randv2 "math/rand/v2"
 	"os"
 	"slices"
 	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/erigontech/erigon-lib/common/dir"
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/assert"
@@ -294,7 +296,7 @@ func compressWithPatternCandidates(ctx context.Context, trace bool, cfg Cfg, log
 	t := time.Now()
 
 	var err error
-	intermediatePath := segmentFilePath + ".tmp"
+	intermediatePath := segmentFilePath + fmt.Sprintf("%d", randv2.UintN(10000)) + ".tmp"
 	defer dir.RemoveFile(intermediatePath)
 	var intermediateFile *os.File
 	if intermediateFile, err = os.Create(intermediatePath); err != nil {

--- a/erigon-lib/state/btree_index.go
+++ b/erigon-lib/state/btree_index.go
@@ -22,7 +22,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	randv2 "math/rand/v2"
 	"os"
 	"path"
 	"path/filepath"
@@ -38,6 +37,7 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/background"
 	"github.com/erigontech/erigon-lib/common/dbg"
+	"github.com/erigontech/erigon-lib/common/dir"
 	"github.com/erigontech/erigon-lib/datastruct/existence"
 	"github.com/erigontech/erigon-lib/etl"
 	"github.com/erigontech/erigon-lib/log/v3"
@@ -153,7 +153,6 @@ type BtIndexWriter struct {
 	args BtIndexWriterArgs
 
 	indexFileName string
-	tmpFilePath   string
 
 	numBuf      [8]byte
 	keysWritten uint64
@@ -185,8 +184,7 @@ func NewBtIndexWriter(args BtIndexWriterArgs, logger log.Logger) (*BtIndexWriter
 		args.Lvl = log.LvlTrace
 	}
 
-	btw := &BtIndexWriter{lvl: args.Lvl, logger: logger, args: args,
-		tmpFilePath: args.IndexFile + fmt.Sprintf("%d", randv2.UintN(10000)) + ".tmp"}
+	btw := &BtIndexWriter{lvl: args.Lvl, logger: logger, args: args}
 
 	_, fname := filepath.Split(btw.args.IndexFile)
 	btw.indexFileName = fname
@@ -237,8 +235,8 @@ func (btw *BtIndexWriter) Build() error {
 		return errors.New("already built")
 	}
 	var err error
-	if btw.indexF, err = os.Create(btw.tmpFilePath); err != nil {
-		return fmt.Errorf("create index file %s: %w", btw.args.IndexFile, err)
+	if btw.indexF, err = dir.CreateTemp(btw.args.IndexFile); err != nil {
+		return fmt.Errorf("create temp index file for %s: %w", btw.args.IndexFile, err)
 	}
 	defer btw.indexF.Close()
 	btw.indexW = bufio.NewWriterSize(btw.indexF, etl.BufIOSize)
@@ -284,7 +282,7 @@ func (btw *BtIndexWriter) Build() error {
 	if err = btw.indexF.Close(); err != nil {
 		return err
 	}
-	if err = os.Rename(btw.tmpFilePath, btw.args.IndexFile); err != nil {
+	if err = os.Rename(btw.indexF.Name(), btw.args.IndexFile); err != nil {
 		return err
 	}
 	return nil
@@ -300,7 +298,7 @@ func (btw *BtIndexWriter) fsync() error {
 		return nil
 	}
 	if err := btw.indexF.Sync(); err != nil {
-		btw.logger.Warn("couldn't fsync", "err", err, "file", btw.tmpFilePath)
+		btw.logger.Warn("couldn't fsync", "err", err, "file", btw.indexF.Name())
 		return err
 	}
 	return nil

--- a/erigon-lib/state/btree_index.go
+++ b/erigon-lib/state/btree_index.go
@@ -22,6 +22,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	randv2 "math/rand/v2"
 	"os"
 	"path"
 	"path/filepath"
@@ -185,7 +186,7 @@ func NewBtIndexWriter(args BtIndexWriterArgs, logger log.Logger) (*BtIndexWriter
 	}
 
 	btw := &BtIndexWriter{lvl: args.Lvl, logger: logger, args: args,
-		tmpFilePath: args.IndexFile + ".tmp"}
+		tmpFilePath: args.IndexFile + fmt.Sprintf("%d", randv2.UintN(10000)) + ".tmp"}
 
 	_, fname := filepath.Split(btw.args.IndexFile)
 	btw.indexFileName = fname

--- a/erigon-lib/state/domain_test.go
+++ b/erigon-lib/state/domain_test.go
@@ -95,6 +95,7 @@ func testDbAndDomainOfStep(t *testing.T, aggStep uint64, logger log.Logger) (kv.
 	d.DisableFsync()
 	return db, d
 }
+
 func TestDomain_CollationBuild(t *testing.T) {
 	if testing.Short() {
 		t.Skip()


### PR DESCRIPTION
two recsplit creation triggered for same file:
- the first one finishes build and closes (along with doing `rm tmpFile`)
- `tmpFile` is not removed immediately because it's also `Build` by second trigger.
- when second trigger is done, it closes file (which `rm tmpFile` for real) and then tries to rename, which fails.
- this PR adds a random number to the filename so that different triggers on same file end up having different filenames. In case there's still clash, we can ask user to try again.


Possibly the two triggers are: `MergeLoop` in backend.go and `BuildMissedAccessors` in SnapshotsStage (after ottersync is finished)
