### PR TITLE
txnprovider/shutter: fix synctest issues with go1.25 (#16965)

### DIFF
--- a/erigon-lib/Makefile
+++ b/erigon-lib/Makefile
@@ -8,8 +8,8 @@ ifeq ($(CGO_CXXFLAGS),)
 endif
 
 GOBUILD = CGO_CXXFLAGS="$(CGO_CXXFLAGS)" go build -trimpath
-GOTEST = CGO_CXXFLAGS="$(CGO_CXXFLAGS)" go test -trimpath
-GOTEST_NOFUZZ = CGO_CXXFLAGS="$(CGO_CXXFLAGS)" go test -trimpath --tags=nofuzz
+GOTEST = CGO_CXXFLAGS="$(CGO_CXXFLAGS)" GOEXPERIMENT=synctest go test -trimpath
+GOTEST_NOFUZZ = CGO_CXXFLAGS="$(CGO_CXXFLAGS)" GOEXPERIMENT=synctest go test -trimpath --tags=nofuzz
 
 OS = $(shell uname -s)
 ARCH = $(shell uname -m)

--- a/erigon-lib/synctest/synctest.go
+++ b/erigon-lib/synctest/synctest.go
@@ -1,0 +1,30 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package synctest
+
+import (
+	"testing"
+	"testing/synctest"
+)
+
+//
+// NOTE: we can remove this pkg once go1.26 is out, and we've dropped support for go1.24
+//
+
+var Wait = synctest.Wait
+
+type testFunc func(t *testing.T, f func(*testing.T))

--- a/erigon-lib/synctest/synctest_go_1_24.go
+++ b/erigon-lib/synctest/synctest_go_1_24.go
@@ -1,0 +1,30 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build go1.24 && !go1.25
+
+package synctest
+
+import (
+	"testing"
+	"testing/synctest"
+)
+
+var Test testFunc = func(t *testing.T, f func(*testing.T)) {
+	synctest.Run(func() {
+		f(t)
+	})
+}

--- a/erigon-lib/synctest/synctest_go_1_25_and_beyond.go
+++ b/erigon-lib/synctest/synctest_go_1_25_and_beyond.go
@@ -1,0 +1,23 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build go1.25
+
+package synctest
+
+import "testing/synctest"
+
+var Test testFunc = synctest.Test

--- a/txnprovider/shutter/pool_test.go
+++ b/txnprovider/shutter/pool_test.go
@@ -27,7 +27,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
-	"testing/synctest"
 	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
@@ -45,6 +44,7 @@ import (
 	"github.com/erigontech/erigon-lib/crypto"
 	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
 	"github.com/erigontech/erigon-lib/log/v3"
+	"github.com/erigontech/erigon-lib/synctest"
 	"github.com/erigontech/erigon-lib/testlog"
 	"github.com/erigontech/erigon-lib/types"
 	"github.com/erigontech/erigon/rpc/contracts"
@@ -217,10 +217,10 @@ type PoolTest struct {
 }
 
 func (t PoolTest) Run(testCase func(ctx context.Context, t *testing.T, pool *shutter.Pool, handle PoolTestHandle)) {
-	synctest.Run(func() {
+	synctest.Test(t.T, func(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
-		logger := testlog.Logger(t.T, log.LvlTrace)
+		logger := testlog.Logger(t, log.LvlTrace)
 		logHandler := testhelpers.NewCollectingLogHandler(logger.GetHandler())
 		logger.SetHandler(logHandler)
 		config := shuttercfg.ConfigByChainName(networkname.Chiado)
@@ -245,7 +245,7 @@ func (t PoolTest) Run(testCase func(ctx context.Context, t *testing.T, pool *shu
 		)
 
 		contractBackend.PrepareMocks()
-		slotCalculator.PrepareMocks(t.T)
+		slotCalculator.PrepareMocks(t)
 		eg := errgroup.Group{}
 		eg.Go(func() error { return pool.Run(ctx) })
 		handle := PoolTestHandle{
@@ -260,7 +260,7 @@ func (t PoolTest) Run(testCase func(ctx context.Context, t *testing.T, pool *shu
 		}
 		// wait before calling the test case to ensure all pool background loops and subscriptions have been initialised
 		synctest.Wait()
-		testCase(ctx, t.T, pool, handle)
+		testCase(ctx, t, pool, handle)
 		cancel()
 		err := eg.Wait()
 		require.ErrorIs(t, err, context.Canceled)


### PR DESCRIPTION
cherry-pick 1554f550602fba78469241f0788030f8059b1838
(can wait for 3.1.1)

---

closes https://github.com/erigontech/erigon/issues/16916 
closes https://github.com/erigontech/erigon/issues/16917
