### PR TITLE
move commitment and changeset db format outside of `db/state` package

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -54,6 +54,7 @@ import (
 	"github.com/erigontech/erigon/db/migrations"
 	"github.com/erigontech/erigon/db/rawdb"
 	"github.com/erigontech/erigon/db/rawdb/blockio"
+	"github.com/erigontech/erigon/db/rawdb/rawtemporaldb"
 	"github.com/erigontech/erigon/db/snapshotsync/freezeblocks"
 	dbstate "github.com/erigontech/erigon/db/state"
 	"github.com/erigontech/erigon/db/state/statecfg"
@@ -882,7 +883,7 @@ func stageExec(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) error
 
 	if unwind > 0 {
 		if err := db.ViewTemporal(ctx, func(tx kv.TemporalTx) error {
-			minUnwindableBlockNum, _, err := tx.Debug().CanUnwindBeforeBlockNum(s.BlockNumber - unwind)
+			minUnwindableBlockNum, _, err := rawtemporaldb.CanUnwindBeforeBlockNum(s.BlockNumber-unwind, tx)
 			if err != nil {
 				return err
 			}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -761,7 +761,7 @@ var (
 	DbPageSizeFlag = cli.StringFlag{
 		Name:  "db.pagesize",
 		Usage: "DB is splitted to 'pages' of fixed size. Can't change DB creation. Must be power of 2 and '256b <= pagesize <= 64kb'. Default: equal to OperationSystem's pageSize. Bigger pageSize causing: 1. More writes to disk during commit 2. Smaller b-tree high 3. Less fragmentation 4. Less overhead on 'free-pages list' maintainance (a bit faster Put/Commit) 5. If expecting DB-size > 8Tb then set pageSize >= 8Kb",
-		Value: "16KB",
+		Value: ethconfig.DefaultChainDBPageSize.HR(),
 	}
 	DbSizeLimitFlag = cli.StringFlag{
 		Name:  "db.size.limit",

--- a/db/kv/kv_interface.go
+++ b/db/kv/kv_interface.go
@@ -444,8 +444,8 @@ type TemporalDebugTx interface {
 	StepSize() uint64
 	Dirs() datadir.Dirs
 
-	CanUnwindToBlockNum() (uint64, error)
-	CanUnwindBeforeBlockNum(blockNum uint64) (unwindableBlockNum uint64, ok bool, err error)
+	//CanUnwindToBlockNum() (uint64, error)
+	//CanUnwindBeforeBlockNum(blockNum uint64) (unwindableBlockNum uint64, ok bool, err error)
 }
 
 type TemporalDebugDB interface {

--- a/db/kv/kv_interface.go
+++ b/db/kv/kv_interface.go
@@ -443,9 +443,6 @@ type TemporalDebugTx interface {
 	IIProgress(name InvertedIdx) (txNum uint64)
 	StepSize() uint64
 	Dirs() datadir.Dirs
-
-	//CanUnwindToBlockNum() (uint64, error)
-	//CanUnwindBeforeBlockNum(blockNum uint64) (unwindableBlockNum uint64, ok bool, err error)
 }
 
 type TemporalDebugDB interface {

--- a/db/kv/kv_interface.go
+++ b/db/kv/kv_interface.go
@@ -28,6 +28,7 @@ import (
 	"github.com/erigontech/mdbx-go/mdbx"
 
 	"github.com/erigontech/erigon-lib/metrics"
+	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv/order"
 	"github.com/erigontech/erigon/db/kv/stream"
 	"github.com/erigontech/erigon/db/version"
@@ -441,6 +442,7 @@ type TemporalDebugTx interface {
 	DomainProgress(domain Domain) (txNum uint64)
 	IIProgress(name InvertedIdx) (txNum uint64)
 	StepSize() uint64
+	Dirs() datadir.Dirs
 
 	CanUnwindToBlockNum() (uint64, error)
 	CanUnwindBeforeBlockNum(blockNum uint64) (unwindableBlockNum uint64, ok bool, err error)

--- a/db/kv/remotedb/kv_remote.go
+++ b/db/kv/remotedb/kv_remote.go
@@ -239,10 +239,11 @@ func (db *DB) UpdateNosync(ctx context.Context, f func(tx kv.RwTx) error) (err e
 	return errors.New("remote db provider doesn't support .UpdateNosync method")
 }
 
-func (tx *tx) AggTx() any                           { panic("not implemented") }
-func (tx *tx) Debug() kv.TemporalDebugTx            { return kv.TemporalDebugTx(tx) }
-func (tx *tx) FreezeInfo() kv.FreezeInfo            { panic("not implemented") }
-func (tx *tx) CanUnwindToBlockNum() (uint64, error) { panic("not implemented") }
+func (tx *tx) AggTx() any                { panic("not implemented") }
+func (tx *tx) Debug() kv.TemporalDebugTx { return kv.TemporalDebugTx(tx) }
+func (tx *tx) FreezeInfo() kv.FreezeInfo { panic("not implemented") }
+
+// func (tx *tx) CanUnwindToBlockNum() (uint64, error) { panic("not implemented") }
 func (tx *tx) CanUnwindBeforeBlockNum(blockNum uint64) (unwindableBlockNum uint64, ok bool, err error) {
 	panic("not implemented")
 }

--- a/db/kv/remotedb/kv_remote.go
+++ b/db/kv/remotedb/kv_remote.go
@@ -243,10 +243,6 @@ func (tx *tx) AggTx() any                { panic("not implemented") }
 func (tx *tx) Debug() kv.TemporalDebugTx { return kv.TemporalDebugTx(tx) }
 func (tx *tx) FreezeInfo() kv.FreezeInfo { panic("not implemented") }
 
-// func (tx *tx) CanUnwindToBlockNum() (uint64, error) { panic("not implemented") }
-func (tx *tx) CanUnwindBeforeBlockNum(blockNum uint64) (unwindableBlockNum uint64, ok bool, err error) {
-	panic("not implemented")
-}
 func (tx *tx) DomainFiles(domain ...kv.Domain) kv.VisibleFiles       { panic("not implemented") }
 func (tx *tx) CurrentDomainVersion(domain kv.Domain) version.Version { panic("not implemented") }
 func (tx *tx) DomainProgress(domain kv.Domain) uint64                { panic("not implemented") }

--- a/db/kv/remotedb/kv_remote.go
+++ b/db/kv/remotedb/kv_remote.go
@@ -33,6 +33,7 @@ import (
 	"github.com/erigontech/erigon-lib/gointerfaces/grpcutil"
 	"github.com/erigontech/erigon-lib/gointerfaces/remoteproto"
 	"github.com/erigontech/erigon-lib/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/order"
 	"github.com/erigontech/erigon/db/kv/stream"
@@ -259,6 +260,7 @@ func (tx *tx) RangeLatest(domain kv.Domain, from, to []byte, limit int) (stream.
 	panic("not implemented")
 }
 func (tx *tx) StepSize() uint64                                     { panic("not implemented") }
+func (tx *tx) Dirs() datadir.Dirs                                   { panic("not implemented") }
 func (tx *tx) TxNumsInFiles(domains ...kv.Domain) (minTxNum uint64) { panic("not implemented") }
 
 func (db *DB) OnFilesChange(onChange, onDel kv.OnFilesChange) { panic("not implemented") }

--- a/db/kv/temporal/kv_temporal.go
+++ b/db/kv/temporal/kv_temporal.go
@@ -661,15 +661,15 @@ func (tx *RwTx) StepSize() uint64 {
 	return tx.stepSize()
 }
 
-func (tx *Tx) CanUnwindToBlockNum() (uint64, error) {
-	return tx.aggtx.CanUnwindToBlockNum(tx.Tx)
-}
-func (tx *RwTx) CanUnwindToBlockNum() (uint64, error) {
-	return tx.aggtx.CanUnwindToBlockNum(tx.RwTx)
-}
-func (tx *Tx) CanUnwindBeforeBlockNum(blockNum uint64) (unwindableBlockNum uint64, ok bool, err error) {
-	return tx.aggtx.CanUnwindBeforeBlockNum(blockNum, tx.Tx)
-}
-func (tx *RwTx) CanUnwindBeforeBlockNum(blockNum uint64) (unwindableBlockNum uint64, ok bool, err error) {
-	return tx.aggtx.CanUnwindBeforeBlockNum(blockNum, tx.RwTx)
-}
+//	func (tx *Tx) CanUnwindToBlockNum() (uint64, error) {
+//		return tx.aggtx.CanUnwindToBlockNum(tx.Tx)
+//	}
+//func (tx *RwTx) CanUnwindToBlockNum() (uint64, error) {
+//	return tx.aggtx.CanUnwindToBlockNum(tx.RwTx)
+//}
+//func (tx *Tx) CanUnwindBeforeBlockNum(blockNum uint64) (unwindableBlockNum uint64, ok bool, err error) {
+//	return tx.aggtx.CanUnwindBeforeBlockNum(blockNum, tx.Tx)
+//}
+//func (tx *RwTx) CanUnwindBeforeBlockNum(blockNum uint64) (unwindableBlockNum uint64, ok bool, err error) {
+//	return tx.aggtx.CanUnwindBeforeBlockNum(blockNum, tx.RwTx)
+//}

--- a/db/kv/temporal/kv_temporal.go
+++ b/db/kv/temporal/kv_temporal.go
@@ -660,16 +660,3 @@ func (tx *Tx) StepSize() uint64 { return tx.stepSize() }
 func (tx *RwTx) StepSize() uint64 {
 	return tx.stepSize()
 }
-
-//	func (tx *Tx) CanUnwindToBlockNum() (uint64, error) {
-//		return tx.aggtx.CanUnwindToBlockNum(tx.Tx)
-//	}
-//func (tx *RwTx) CanUnwindToBlockNum() (uint64, error) {
-//	return tx.aggtx.CanUnwindToBlockNum(tx.RwTx)
-//}
-//func (tx *Tx) CanUnwindBeforeBlockNum(blockNum uint64) (unwindableBlockNum uint64, ok bool, err error) {
-//	return tx.aggtx.CanUnwindBeforeBlockNum(blockNum, tx.Tx)
-//}
-//func (tx *RwTx) CanUnwindBeforeBlockNum(blockNum uint64) (unwindableBlockNum uint64, ok bool, err error) {
-//	return tx.aggtx.CanUnwindBeforeBlockNum(blockNum, tx.RwTx)
-//}

--- a/db/kv/temporal/kv_temporal.go
+++ b/db/kv/temporal/kv_temporal.go
@@ -649,9 +649,9 @@ func (tx *RwTx) IIProgress(domain kv.InvertedIdx) uint64 {
 	return tx.aggtx.IIProgress(domain, tx.RwTx)
 }
 
-func (tx *tx) dirs() datadir.Dirs { return tx.aggtx.Dirs() }
-func (tx *Tx) Dirs() uint64       { return tx.stepSize() }
-func (tx *RwTx) Dirs() uint64     { return tx.stepSize() }
+func (tx *tx) dirs() datadir.Dirs   { return tx.aggtx.Dirs() }
+func (tx *Tx) Dirs() datadir.Dirs   { return tx.dirs() }
+func (tx *RwTx) Dirs() datadir.Dirs { return tx.dirs() }
 
 func (tx *tx) stepSize() uint64 {
 	return tx.aggtx.StepSize()

--- a/db/kv/temporal/kv_temporal.go
+++ b/db/kv/temporal/kv_temporal.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/mdbx"
 	"github.com/erigontech/erigon/db/kv/order"
@@ -647,12 +648,15 @@ func (tx *Tx) IIProgress(domain kv.InvertedIdx) uint64 {
 func (tx *RwTx) IIProgress(domain kv.InvertedIdx) uint64 {
 	return tx.aggtx.IIProgress(domain, tx.RwTx)
 }
+
+func (tx *tx) dirs() datadir.Dirs { return tx.aggtx.Dirs() }
+func (tx *Tx) Dirs() uint64       { return tx.stepSize() }
+func (tx *RwTx) Dirs() uint64     { return tx.stepSize() }
+
 func (tx *tx) stepSize() uint64 {
 	return tx.aggtx.StepSize()
 }
-func (tx *Tx) StepSize() uint64 {
-	return tx.stepSize()
-}
+func (tx *Tx) StepSize() uint64 { return tx.stepSize() }
 func (tx *RwTx) StepSize() uint64 {
 	return tx.stepSize()
 }

--- a/db/rawdb/rawtemporaldb/accessors_commitment.go
+++ b/db/rawdb/rawtemporaldb/accessors_commitment.go
@@ -14,10 +14,11 @@ func CanUnwindToBlockNum(tx kv.TemporalTx) (uint64, error) {
 		return 0, err
 	}
 	if minUnwindale == math.MaxUint64 { // no unwindable block found
-		return commitmentdb.CanUnwindToBlockNum(tx)
+		return commitmentdb.LatestBlockNumWithCommitment(tx)
 	}
 	return minUnwindale, nil
 }
+
 func CanUnwindBeforeBlockNum(blockNum uint64, tx kv.TemporalTx) (unwindableBlockNum uint64, ok bool, err error) {
 	_minUnwindableBlockNum, err := CanUnwindToBlockNum(tx)
 	if err != nil {

--- a/db/rawdb/rawtemporaldb/accessors_commitment.go
+++ b/db/rawdb/rawtemporaldb/accessors_commitment.go
@@ -1,0 +1,30 @@
+package rawtemporaldb
+
+import (
+	"math"
+
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/state/changeset"
+	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
+)
+
+func CanUnwindToBlockNum(tx kv.TemporalTx) (uint64, error) {
+	minUnwindale, err := changeset.ReadLowestUnwindableBlock(tx)
+	if err != nil {
+		return 0, err
+	}
+	if minUnwindale == math.MaxUint64 { // no unwindable block found
+		return commitmentdb.CanUnwindToBlockNum(tx)
+	}
+	return minUnwindale, nil
+}
+func CanUnwindBeforeBlockNum(blockNum uint64, tx kv.TemporalTx) (unwindableBlockNum uint64, ok bool, err error) {
+	_minUnwindableBlockNum, err := CanUnwindToBlockNum(tx)
+	if err != nil {
+		return 0, false, err
+	}
+	if blockNum < _minUnwindableBlockNum {
+		return _minUnwindableBlockNum, false, nil
+	}
+	return blockNum, true, nil
+}

--- a/db/rawdb/rawtemporaldb/accessors_receipt_test.go
+++ b/db/rawdb/rawtemporaldb/accessors_receipt_test.go
@@ -1,7 +1,8 @@
-package rawtemporaldb
+package rawtemporaldb_test
 
 import (
 	"context"
+	"encoding/binary"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,6 +11,7 @@ import (
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/temporal/temporaltest"
+	"github.com/erigontech/erigon/db/rawdb/rawtemporaldb"
 	"github.com/erigontech/erigon/db/state"
 )
 
@@ -25,22 +27,22 @@ func TestAppendReceipt(t *testing.T) {
 	require.NoError(err)
 	defer doms.Close()
 
-	doms.SetTxNum(0)                                     // block1
-	err = AppendReceipt(doms.AsPutDel(ttx), 1, 10, 0, 0) // 1 log
+	doms.SetTxNum(0)                                                   // block1
+	err = rawtemporaldb.AppendReceipt(doms.AsPutDel(ttx), 1, 10, 0, 0) // 1 log
 	require.NoError(err)
 
-	doms.SetTxNum(1)                                     // block1
-	err = AppendReceipt(doms.AsPutDel(ttx), 1, 11, 0, 1) // 0 log
+	doms.SetTxNum(1)                                                   // block1
+	err = rawtemporaldb.AppendReceipt(doms.AsPutDel(ttx), 1, 11, 0, 1) // 0 log
 	require.NoError(err)
 
 	doms.SetTxNum(2) // block1
 
-	doms.SetTxNum(3)                                     // block2
-	err = AppendReceipt(doms.AsPutDel(ttx), 4, 12, 0, 3) // 3 logs
+	doms.SetTxNum(3)                                                   // block2
+	err = rawtemporaldb.AppendReceipt(doms.AsPutDel(ttx), 4, 12, 0, 3) // 3 logs
 	require.NoError(err)
 
-	doms.SetTxNum(4)                                     // block2
-	err = AppendReceipt(doms.AsPutDel(ttx), 4, 14, 0, 4) // 0 log
+	doms.SetTxNum(4)                                                   // block2
+	err = rawtemporaldb.AppendReceipt(doms.AsPutDel(ttx), 4, 14, 0, 4) // 0 log
 	require.NoError(err)
 
 	doms.SetTxNum(5) // block2
@@ -48,66 +50,70 @@ func TestAppendReceipt(t *testing.T) {
 	err = doms.Flush(context.Background(), tx)
 	require.NoError(err)
 
-	v, ok, err := ttx.HistorySeek(kv.ReceiptDomain, LogIndexAfterTxKey, 0)
+	v, ok, err := ttx.HistorySeek(kv.ReceiptDomain, rawtemporaldb.LogIndexAfterTxKey, 0)
 	require.NoError(err)
 	require.True(ok)
 	require.Empty(v)
 
-	v, ok, err = ttx.HistorySeek(kv.ReceiptDomain, LogIndexAfterTxKey, 1)
+	v, ok, err = ttx.HistorySeek(kv.ReceiptDomain, rawtemporaldb.LogIndexAfterTxKey, 1)
 	require.NoError(err)
 	require.True(ok)
 	require.Equal(uint64(1), uvarint(v))
 
-	v, ok, err = ttx.HistorySeek(kv.ReceiptDomain, LogIndexAfterTxKey, 2)
+	v, ok, err = ttx.HistorySeek(kv.ReceiptDomain, rawtemporaldb.LogIndexAfterTxKey, 2)
 	require.NoError(err)
 	require.True(ok)
 	require.Equal(uint64(1), uvarint(v))
 
-	v, ok, err = ttx.HistorySeek(kv.ReceiptDomain, LogIndexAfterTxKey, 3)
+	v, ok, err = ttx.HistorySeek(kv.ReceiptDomain, rawtemporaldb.LogIndexAfterTxKey, 3)
 	require.NoError(err)
 	require.True(ok)
 	require.Equal(uint64(1), uvarint(v))
 
-	_, ok, err = ttx.HistorySeek(kv.ReceiptDomain, LogIndexAfterTxKey, 4)
+	_, ok, err = ttx.HistorySeek(kv.ReceiptDomain, rawtemporaldb.LogIndexAfterTxKey, 4)
 	require.NoError(err)
 	require.False(ok)
 
-	_, ok, err = ttx.HistorySeek(kv.ReceiptDomain, LogIndexAfterTxKey, 5)
+	_, ok, err = ttx.HistorySeek(kv.ReceiptDomain, rawtemporaldb.LogIndexAfterTxKey, 5)
 	require.NoError(err)
 	require.False(ok)
 
 	//block1
-	cumGasUsed, _, logIdxAfterTx, err := ReceiptAsOf(ttx, 0)
+	cumGasUsed, _, logIdxAfterTx, err := rawtemporaldb.ReceiptAsOf(ttx, 0)
 	require.NoError(err)
 	require.Equal(uint32(0), logIdxAfterTx)
 	require.Equal(uint64(0), cumGasUsed)
 
-	cumGasUsed, _, logIdxAfterTx, err = ReceiptAsOf(ttx, 1)
+	cumGasUsed, _, logIdxAfterTx, err = rawtemporaldb.ReceiptAsOf(ttx, 1)
 	require.NoError(err)
 	require.Equal(uint32(1), logIdxAfterTx)
 	require.Equal(uint64(10), cumGasUsed)
 
-	cumGasUsed, _, logIdxAfterTx, err = ReceiptAsOf(ttx, 2)
+	cumGasUsed, _, logIdxAfterTx, err = rawtemporaldb.ReceiptAsOf(ttx, 2)
 	require.NoError(err)
 	require.Equal(uint32(1), logIdxAfterTx)
 	require.Equal(uint64(11), cumGasUsed)
 
 	//block2
-	cumGasUsed, _, logIdxAfterTx, err = ReceiptAsOf(ttx, 3)
+	cumGasUsed, _, logIdxAfterTx, err = rawtemporaldb.ReceiptAsOf(ttx, 3)
 	require.NoError(err)
 	require.Equal(uint32(1), logIdxAfterTx)
 	require.Equal(uint64(11), cumGasUsed)
 
-	cumGasUsed, _, logIdxAfterTx, err = ReceiptAsOf(ttx, 4)
+	cumGasUsed, _, logIdxAfterTx, err = rawtemporaldb.ReceiptAsOf(ttx, 4)
 	require.NoError(err)
 	require.Equal(uint32(4), logIdxAfterTx)
 	require.Equal(uint64(12), cumGasUsed)
 
-	cumGasUsed, _, logIdxAfterTx, err = ReceiptAsOf(ttx, 5)
+	cumGasUsed, _, logIdxAfterTx, err = rawtemporaldb.ReceiptAsOf(ttx, 5)
 	require.NoError(err)
 	require.Equal(uint32(4), logIdxAfterTx)
 	require.Equal(uint64(14), cumGasUsed)
 
 	// reader
 
+}
+func uvarint(in []byte) (res uint64) {
+	res, _ = binary.Uvarint(in)
+	return res
 }

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -954,36 +954,6 @@ func (at *AggregatorRoTx) CanPrune(tx kv.Tx, untilTx uint64) bool {
 	return false
 }
 
-//func (at *AggregatorRoTx) CanUnwindToBlockNum(tx kv.Tx) (uint64, error) {
-//	minUnwindale, err := ReadLowestUnwindableBlock(tx)
-//	if err != nil {
-//		return 0, err
-//	}
-//	if minUnwindale == math.MaxUint64 { // no unwindable block found
-//		stateVal, _, _, err := at.d[kv.CommitmentDomain].GetLatest(KeyCommitmentState, tx)
-//		if err != nil {
-//			return 0, err
-//		}
-//		if len(stateVal) == 0 {
-//			return 0, nil
-//		}
-//		_, minUnwindale = commitment._decodeTxBlockNums(stateVal)
-//	}
-//	return minUnwindale, nil
-//}
-
-// CanUnwindBeforeBlockNum - returns `true` if can unwind to requested `blockNum`, otherwise returns nearest `unwindableBlockNum`
-//func (at *AggregatorRoTx) CanUnwindBeforeBlockNum(blockNum uint64, tx kv.Tx) (unwindableBlockNum uint64, ok bool, err error) {
-//	_minUnwindableBlockNum, err := at.CanUnwindToBlockNum(tx)
-//	if err != nil {
-//		return 0, false, err
-//	}
-//	if blockNum < _minUnwindableBlockNum {
-//		return _minUnwindableBlockNum, false, nil
-//	}
-//	return blockNum, true, nil
-//}
-
 // PruneSmallBatches is not cancellable, it's over when it's over or failed.
 // It fills whole timeout with pruning by small batches (of 100 keys) and making some progress
 func (at *AggregatorRoTx) PruneSmallBatches(ctx context.Context, timeout time.Duration, tx kv.RwTx) (haveMore bool, err error) {

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -1742,7 +1742,7 @@ func (at *AggregatorRoTx) DomainProgress(name kv.Domain, tx kv.Tx) uint64 {
 		// terms of exact txNum
 		return at.d[name].d.maxStepInDBNoHistory(tx).ToTxNum(at.a.stepSize)
 	}
-	return at.d[name].HistoryProgress(tx)
+	return at.d[name].ht.iit.Progress(tx)
 }
 func (at *AggregatorRoTx) IIProgress(name kv.InvertedIdx, tx kv.Tx) uint64 {
 	return at.searchII(name).Progress(tx)

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -1762,9 +1762,7 @@ func (a *Aggregator) BeginFilesRo() *AggregatorRoTx {
 	return ac
 }
 
-// func (at *AggregatorRoTx) DomainProgress(name kv.Domain, tx kv.Tx) uint64 {
-// 	return at.d[name].d.maxTxNumInDB(tx)
-// }
+func (at *AggregatorRoTx) Dirs() datadir.Dirs { return at.a.dirs }
 
 func (at *AggregatorRoTx) DomainProgress(name kv.Domain, tx kv.Tx) uint64 {
 	d := at.d[name]

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -954,35 +954,35 @@ func (at *AggregatorRoTx) CanPrune(tx kv.Tx, untilTx uint64) bool {
 	return false
 }
 
-func (at *AggregatorRoTx) CanUnwindToBlockNum(tx kv.Tx) (uint64, error) {
-	minUnwindale, err := ReadLowestUnwindableBlock(tx)
-	if err != nil {
-		return 0, err
-	}
-	if minUnwindale == math.MaxUint64 { // no unwindable block found
-		stateVal, _, _, err := at.d[kv.CommitmentDomain].GetLatest(keyCommitmentState, tx)
-		if err != nil {
-			return 0, err
-		}
-		if len(stateVal) == 0 {
-			return 0, nil
-		}
-		_, minUnwindale = _decodeTxBlockNums(stateVal)
-	}
-	return minUnwindale, nil
-}
+//func (at *AggregatorRoTx) CanUnwindToBlockNum(tx kv.Tx) (uint64, error) {
+//	minUnwindale, err := ReadLowestUnwindableBlock(tx)
+//	if err != nil {
+//		return 0, err
+//	}
+//	if minUnwindale == math.MaxUint64 { // no unwindable block found
+//		stateVal, _, _, err := at.d[kv.CommitmentDomain].GetLatest(KeyCommitmentState, tx)
+//		if err != nil {
+//			return 0, err
+//		}
+//		if len(stateVal) == 0 {
+//			return 0, nil
+//		}
+//		_, minUnwindale = commitment._decodeTxBlockNums(stateVal)
+//	}
+//	return minUnwindale, nil
+//}
 
 // CanUnwindBeforeBlockNum - returns `true` if can unwind to requested `blockNum`, otherwise returns nearest `unwindableBlockNum`
-func (at *AggregatorRoTx) CanUnwindBeforeBlockNum(blockNum uint64, tx kv.Tx) (unwindableBlockNum uint64, ok bool, err error) {
-	_minUnwindableBlockNum, err := at.CanUnwindToBlockNum(tx)
-	if err != nil {
-		return 0, false, err
-	}
-	if blockNum < _minUnwindableBlockNum {
-		return _minUnwindableBlockNum, false, nil
-	}
-	return blockNum, true, nil
-}
+//func (at *AggregatorRoTx) CanUnwindBeforeBlockNum(blockNum uint64, tx kv.Tx) (unwindableBlockNum uint64, ok bool, err error) {
+//	_minUnwindableBlockNum, err := at.CanUnwindToBlockNum(tx)
+//	if err != nil {
+//		return 0, false, err
+//	}
+//	if blockNum < _minUnwindableBlockNum {
+//		return _minUnwindableBlockNum, false, nil
+//	}
+//	return blockNum, true, nil
+//}
 
 // PruneSmallBatches is not cancellable, it's over when it's over or failed.
 // It fills whole timeout with pruning by small batches (of 100 keys) and making some progress

--- a/db/state/aggregator_test.go
+++ b/db/state/aggregator_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,27 +42,6 @@ import (
 	"github.com/erigontech/erigon/db/version"
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
-
-func Test_EncodeCommitmentState(t *testing.T) {
-	t.Parallel()
-	cs := commitmentState{
-		txNum:     rand.Uint64(),
-		trieState: make([]byte, 1024),
-	}
-	n, err := rand.Read(cs.trieState)
-	require.NoError(t, err)
-	require.Equal(t, len(cs.trieState), n)
-
-	buf, err := cs.Encode()
-	require.NoError(t, err)
-	require.NotEmpty(t, buf)
-
-	var dec commitmentState
-	err = dec.Decode(buf)
-	require.NoError(t, err)
-	require.Equal(t, cs.txNum, dec.txNum)
-	require.Equal(t, cs.trieState, dec.trieState)
-}
 
 // takes first 100k keys from file
 func pivotKeysFromKV(dataPath string) ([][]byte, error) {

--- a/db/state/changeset/state_changeset_test.go
+++ b/db/state/changeset/state_changeset_test.go
@@ -41,7 +41,7 @@ func TestOverflowPages(t *testing.T) {
 	tx, err := db.BeginRw(ctx)
 	require.NoError(t, err)
 	defer tx.Rollback()
-	k, v := make([]byte, changeset.DiffChunkKeyLen), make([]byte, changeset.DiffChunkKeyLen)
+	k, v := make([]byte, changeset.DiffChunkKeyLen), make([]byte, changeset.DiffChunkLen)
 	k[0] = 0
 	_ = tx.Put(kv.ChangeSets3, k, v)
 	k[0] = 1

--- a/db/state/changeset/state_changeset_test.go
+++ b/db/state/changeset/state_changeset_test.go
@@ -49,14 +49,9 @@ func TestOverflowPages(t *testing.T) {
 	st, err := tx.(*mdbx.MdbxTx).BucketStat(kv.ChangeSets3)
 	require.NoError(t, err)
 	// 16 kb
-	require.Equal(t, 0, int(st.OverflowPages))
+	require.Equal(t, 0, int(st.OverflowPages)) // no ofverflow pages: no problems with FreeList maintainance costs
 	require.Equal(t, 1, int(st.LeafPages))
 	require.Equal(t, 2, int(st.Entries))
-
-	// 4 kb
-	//require.Equal(t, 2, int(st.OverflowPages))
-	//require.Equal(t, 1, int(st.LeafPages))
-	//require.Equal(t, 2, int(st.Entries))
 }
 
 func TestSerializeDeserializeDiff(t *testing.T) {

--- a/db/state/changeset/state_changeset_test.go
+++ b/db/state/changeset/state_changeset_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/c2h5oh/datasize"
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon-lib/log/v3"
@@ -30,11 +29,12 @@ import (
 	"github.com/erigontech/erigon/db/kv/dbcfg"
 	"github.com/erigontech/erigon/db/kv/mdbx"
 	"github.com/erigontech/erigon/db/state/changeset"
+	"github.com/erigontech/erigon/eth/ethconfig"
 )
 
 func TestOverflowPages(t *testing.T) {
 	dirs := datadir.New(t.TempDir())
-	db := mdbx.New(dbcfg.ChainDB, log.Root()).InMem(t, dirs.Chaindata).PageSize(16 * datasize.KB).MustOpen()
+	db := mdbx.New(dbcfg.ChainDB, log.Root()).InMem(t, dirs.Chaindata).PageSize(ethconfig.DefaultChainDBPageSize).MustOpen()
 	t.Cleanup(db.Close)
 
 	ctx := context.Background()

--- a/db/state/changeset/state_changeset_test.go
+++ b/db/state/changeset/state_changeset_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/erigontech/erigon/eth/ethconfig"
 )
 
-func TestOverflowPages(t *testing.T) {
+func TestNoOverflowPages(t *testing.T) {
 	dirs := datadir.New(t.TempDir())
 	db := mdbx.New(dbcfg.ChainDB, log.Root()).InMem(t, dirs.Chaindata).PageSize(ethconfig.DefaultChainDBPageSize).MustOpen()
 	t.Cleanup(db.Close)
@@ -48,8 +48,9 @@ func TestOverflowPages(t *testing.T) {
 	_ = tx.Put(kv.ChangeSets3, k, v)
 	st, err := tx.(*mdbx.MdbxTx).BucketStat(kv.ChangeSets3)
 	require.NoError(t, err)
-	// 16 kb
-	require.Equal(t, 0, int(st.OverflowPages)) // no ofverflow pages: no problems with FreeList maintainance costs
+
+	// no ofverflow pages: no problems with FreeList maintainance costs
+	require.Equal(t, 0, int(st.OverflowPages))
 	require.Equal(t, 1, int(st.LeafPages))
 	require.Equal(t, 2, int(st.Entries))
 }

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1970,8 +1970,6 @@ func (dt *DomainRoTx) Files() (res VisibleFiles) {
 }
 func (dt *DomainRoTx) Name() kv.Domain { return dt.name }
 
-func (dt *DomainRoTx) HistoryProgress(tx kv.Tx) uint64 { return dt.ht.iit.Progress(tx) }
-
 func versionTooLowPanic(filename string, version version.Versions) {
 	panic(fmt.Sprintf(
 		"Version is too low, try to run snapshot reset: `erigon --datadir $DATADIR --chain $CHAIN snapshots reset`. file=%s, min_supported=%s, current=%s",

--- a/db/state/domain_shared.go
+++ b/db/state/domain_shared.go
@@ -27,10 +27,11 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/assert"
 	"github.com/erigontech/erigon-lib/log/v3"
-	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/state/changeset"
 	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/execution/commitment"
+	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
 )
 
 // KvList sort.Interface to sort write list by keys
@@ -58,7 +59,7 @@ func (l *KvList) Swap(i, j int) {
 }
 
 type SharedDomains struct {
-	sdCtx *SharedDomainsCommitmentContext
+	sdCtx *commitmentdb.SharedDomainsCommitmentContext
 
 	stepSize uint64
 
@@ -74,9 +75,6 @@ type SharedDomains struct {
 type HasAgg interface {
 	Agg() any
 }
-type HasDirs interface {
-	Dirs() datadir.Dirs
-}
 
 func NewSharedDomains(tx kv.TemporalTx, logger log.Logger) (*SharedDomains, error) {
 	sd := &SharedDomains{
@@ -84,7 +82,6 @@ func NewSharedDomains(tx kv.TemporalTx, logger log.Logger) (*SharedDomains, erro
 		//trace:   true,
 		mem: newTemporalMemBatch(tx),
 	}
-	aggTx := AggTx(tx)
 	sd.stepSize = tx.Debug().StepSize()
 
 	tv := commitment.VariantHexPatriciaTrie
@@ -92,7 +89,7 @@ func NewSharedDomains(tx kv.TemporalTx, logger log.Logger) (*SharedDomains, erro
 		tv = commitment.VariantConcurrentHexPatricia
 	}
 
-	sd.sdCtx = NewSharedDomainsCommitmentContext(sd, tx, commitment.ModeDirect, tv, aggTx.(HasDirs).Dirs().Tmp)
+	sd.sdCtx = commitmentdb.NewSharedDomainsCommitmentContext(sd, tx, commitment.ModeDirect, tv, tx.Debug().Dirs().Tmp)
 
 	if err := sd.SeekCommitment(context.Background(), tx); err != nil {
 		return nil, err
@@ -121,7 +118,7 @@ func (pd *temporalPutDel) DomainDelPrefix(domain kv.Domain, prefix []byte, txNum
 func (sd *SharedDomains) AsPutDel(tx kv.TemporalTx) kv.TemporalPutDel {
 	return &temporalPutDel{sd, tx}
 }
-func (sd *SharedDomains) TrieCtxForTests() *SharedDomainsCommitmentContext {
+func (sd *SharedDomains) TrieCtxForTests() *commitmentdb.SharedDomainsCommitmentContext {
 	return sd.sdCtx
 }
 
@@ -142,11 +139,11 @@ func (sd *SharedDomains) AsGetter(tx kv.TemporalTx) kv.TemporalGetter {
 	return &temporalGetter{sd, tx}
 }
 
-func (sd *SharedDomains) SetChangesetAccumulator(acc *StateChangeSet) {
+func (sd *SharedDomains) SetChangesetAccumulator(acc *changeset.StateChangeSet) {
 	sd.mem.SetChangesetAccumulator(acc)
 }
 
-func (sd *SharedDomains) SavePastChangesetAccumulator(blockHash common.Hash, blockNumber uint64, acc *StateChangeSet) {
+func (sd *SharedDomains) SavePastChangesetAccumulator(blockHash common.Hash, blockNumber uint64, acc *changeset.StateChangeSet) {
 	sd.mem.SavePastChangesetAccumulator(blockHash, blockNumber, acc)
 }
 
@@ -156,8 +153,7 @@ func (sd *SharedDomains) GetDiffset(tx kv.RwTx, blockHash common.Hash, blockNumb
 
 func (sd *SharedDomains) ClearRam(resetCommitment bool) {
 	if resetCommitment {
-		sd.sdCtx.updates.Reset()
-		sd.sdCtx.Reset()
+		sd.sdCtx.ClearRam()
 	}
 	sd.mem.ClearRam()
 }
@@ -178,7 +174,7 @@ func (sd *SharedDomains) StepSize() uint64 { return sd.stepSize }
 // Requires for sd.rwTx because of commitment evaluation in shared domains if stepSize is reached
 func (sd *SharedDomains) SetTxNum(txNum uint64) {
 	sd.txNum = txNum
-	sd.sdCtx.mainTtx.txNum = txNum
+	sd.sdCtx.SetTxNum(txNum)
 }
 
 func (sd *SharedDomains) TxNum() uint64 { return sd.txNum }

--- a/db/state/domain_shared_test.go
+++ b/db/state/domain_shared_test.go
@@ -55,7 +55,7 @@ func TestSharedDomain_Unwind(t *testing.T) {
 	require.NoError(t, err)
 	defer domains.Close()
 
-	stateChangeset := &state.StateChangeSet{}
+	stateChangeset := &StateChangeSet{}
 	domains.SetChangesetAccumulator(stateChangeset)
 
 	maxTx := stepSize

--- a/db/state/domain_shared_test.go
+++ b/db/state/domain_shared_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/rawdbv3"
 	"github.com/erigontech/erigon/db/state"
+	"github.com/erigontech/erigon/db/state/changeset"
 	accounts3 "github.com/erigontech/erigon/execution/types/accounts"
 )
 
@@ -55,7 +56,7 @@ func TestSharedDomain_Unwind(t *testing.T) {
 	require.NoError(t, err)
 	defer domains.Close()
 
-	stateChangeset := &StateChangeSet{}
+	stateChangeset := &changeset.StateChangeSet{}
 	domains.SetChangesetAccumulator(stateChangeset)
 
 	maxTx := stepSize

--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/erigontech/erigon/db/kv/order"
 	"github.com/erigontech/erigon/db/kv/stream"
 	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/state/changeset"
 	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/db/version"
 	accounts3 "github.com/erigontech/erigon/execution/types/accounts"
@@ -2064,7 +2065,7 @@ func TestDomain_Unwind(t *testing.T) {
 			fmt.Println(currTx)
 			for currentTxNum := currTx - 1; currentTxNum >= unwindTo; currentTxNum-- {
 				d := diffSetMap[currentTxNum]
-				totalDiff = MergeDiffSets(totalDiff, d)
+				totalDiff = changeset.MergeDiffSets(totalDiff, d)
 			}
 		}
 

--- a/db/state/history_test.go
+++ b/db/state/history_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/erigontech/erigon/db/recsplit/multiencseq"
 	"github.com/erigontech/erigon/db/seg"
 	"github.com/erigontech/erigon/db/state/statecfg"
+	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
 )
 
 func testDbAndHistory(tb testing.TB, largeValues bool, logger log.Logger) (kv.RwDB, *History) {
@@ -1421,7 +1422,7 @@ func writeSomeHistory(tb testing.TB, largeValues bool, logger log.Logger) (kv.Rw
 		common.FromHex("a4dba136b5541817a78b160dd140190d9676d0f0"),
 		common.FromHex("01"),
 		common.FromHex("00"),
-		keyCommitmentState,
+		commitmentdb.KeyCommitmentState,
 		common.FromHex("8240a92799b51e7d99d3ef53c67bca7d068bd8d64e895dd56442c4ac01c9a27d"),
 		common.FromHex("cedce3c4eb5e0eedd505c33fd0f8c06d1ead96e63d6b3a27b5186e4901dce59e"),
 	}

--- a/db/state/merge.go
+++ b/db/state/merge.go
@@ -38,6 +38,7 @@ import (
 	"github.com/erigontech/erigon/db/recsplit/multiencseq"
 	"github.com/erigontech/erigon/db/seg"
 	"github.com/erigontech/erigon/db/state/statecfg"
+	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
 )
 
 func (d *Domain) dirtyFilesEndTxNumMinimax() uint64 {
@@ -500,7 +501,7 @@ func (dt *DomainRoTx) mergeFiles(ctx context.Context, domainFiles, indexFiles, h
 		}
 		if keyBuf != nil {
 			if vt != nil {
-				if !bytes.Equal(keyBuf, keyCommitmentState) { // no replacement for state key
+				if !bytes.Equal(keyBuf, commitmentdb.KeyCommitmentState) { // no replacement for state key
 					valBuf, err = vt(valBuf, keyFileStartTxNum, keyFileEndTxNum)
 					if err != nil {
 						return nil, nil, nil, fmt.Errorf("merge: valTransform failed: %w", err)
@@ -521,7 +522,7 @@ func (dt *DomainRoTx) mergeFiles(ctx context.Context, domainFiles, indexFiles, h
 	}
 	if keyBuf != nil {
 		if vt != nil {
-			if !bytes.Equal(keyBuf, keyCommitmentState) { // no replacement for state key
+			if !bytes.Equal(keyBuf, commitmentdb.KeyCommitmentState) { // no replacement for state key
 				valBuf, err = vt(valBuf, keyFileStartTxNum, keyFileEndTxNum)
 				if err != nil {
 					return nil, nil, nil, fmt.Errorf("merge: valTransform failed: %w", err)

--- a/db/state/metrics.go
+++ b/db/state/metrics.go
@@ -56,8 +56,6 @@ var (
 	mxBuildTook            = metrics.GetOrCreateSummary("domain_build_files_took")
 	mxStepTook             = metrics.GetOrCreateSummary("domain_step_took")
 	mxFlushTook            = metrics.GetOrCreateSummary("domain_flush_took")
-	mxCommitmentRunning    = metrics.GetOrCreateGauge("domain_running_commitment")
-	mxCommitmentTook       = metrics.GetOrCreateSummary("domain_commitment_took")
 )
 
 var (

--- a/db/state/squeeze.go
+++ b/db/state/squeeze.go
@@ -111,6 +111,7 @@ func (a *Aggregator) sqeezeDomainFile(ctx context.Context, domain kv.Domain, fro
 // Removes commitment files and suppose following aggregator shutdown and restart  (to integrate new files and rebuild indexes)
 func SqueezeCommitmentFiles(ctx context.Context, at *AggregatorRoTx, logger log.Logger) error {
 	stepSize := at.StepSize()
+	dirs := at.Dirs()
 
 	commitmentUseReferencedBranches := at.a.Cfg(kv.CommitmentDomain).ReplaceKeysInValues
 	if !commitmentUseReferencedBranches {
@@ -216,7 +217,7 @@ func SqueezeCommitmentFiles(ctx context.Context, at *AggregatorRoTx, logger log.
 			originalPath := cf.decompressor.FilePath()
 			squeezedTmpPath := originalPath + sqExt + ".tmp"
 
-			squeezedCompr, err := seg.NewCompressor(ctx, "squeeze", squeezedTmpPath, at.a.dirs.Tmp,
+			squeezedCompr, err := seg.NewCompressor(ctx, "squeeze", squeezedTmpPath, dirs.Tmp,
 				commitment.d.CompressCfg, log.LvlInfo, commitment.d.logger)
 			if err != nil {
 				return err

--- a/db/state/squeeze.go
+++ b/db/state/squeeze.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/erigontech/erigon/db/state/statecfg"
+	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
 
 	"github.com/c2h5oh/datasize"
 
@@ -242,7 +243,7 @@ func SqueezeCommitmentFiles(ctx context.Context, at *AggregatorRoTx, logger log.
 					continue
 				}
 
-				if !bytes.Equal(k, keyCommitmentState) {
+				if !bytes.Equal(k, commitmentdb.KeyCommitmentState) {
 					v, err = vt(v, af.startTxNum, af.endTxNum)
 					if err != nil {
 						return fmt.Errorf("failed to transform commitment value: %w", err)

--- a/db/state/squeeze_test.go
+++ b/db/state/squeeze_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/erigontech/erigon/db/kv/rawdbv3"
 	"github.com/erigontech/erigon/db/kv/temporal"
 	"github.com/erigontech/erigon/db/state"
+	"github.com/erigontech/erigon/db/state/changeset"
 	"github.com/erigontech/erigon/execution/commitment"
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
@@ -224,7 +225,7 @@ func TestAggregator_SqueezeCommitment(t *testing.T) {
 // by that key stored latest root hash and tree state
 const keyCommitmentStateS = "state"
 
-var keyCommitmentState = []byte(keyCommitmentStateS)
+var KeyCommitmentState = []byte(keyCommitmentStateS)
 
 func TestAggregator_RebuildCommitmentBasedOnFiles(t *testing.T) {
 	if testing.Short() {
@@ -245,7 +246,7 @@ func TestAggregator_RebuildCommitmentBasedOnFiles(t *testing.T) {
 		ac := state.AggTx(tx)
 
 		// collect latest root from each available file
-		stateVal, ok, _, _, _ := ac.DebugGetLatestFromFiles(kv.CommitmentDomain, keyCommitmentState, math.MaxUint64)
+		stateVal, ok, _, _, _ := ac.DebugGetLatestFromFiles(kv.CommitmentDomain, KeyCommitmentState, math.MaxUint64)
 		require.True(t, ok)
 		rootInFiles, err = commitment.HexTrieExtractStateRoot(stateVal)
 		require.NoError(t, err)
@@ -459,8 +460,8 @@ func TestAggregatorV3_SharedDomains(t *testing.T) {
 	domains, err := state.NewSharedDomains(rwTx, log.New())
 	require.NoError(t, err)
 	defer domains.Close()
-	changesetAt5 := &state.StateChangeSet{}
-	changesetAt3 := &state.StateChangeSet{}
+	changesetAt5 := &changeset.StateChangeSet{}
+	changesetAt3 := &changeset.StateChangeSet{}
 
 	keys, vals := generateInputData(t, 20, 4, 10)
 	keys = keys[:2]

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -118,6 +118,8 @@ var Defaults = Config{
 	},
 }
 
+const DefaultChainDBPageSize = 16 * datasize.KB
+
 func init() {
 	home := os.Getenv("HOME")
 	if home == "" {

--- a/execution/commitment/commitmentdb/commitment_context.go
+++ b/execution/commitment/commitmentdb/commitment_context.go
@@ -590,7 +590,7 @@ func (cs *commitmentState) Encode() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func LatestBlockNumWithCommitment(tx kv.TemporalTx) (uint64, error) {
+func LatestBlockNumWithCommitment(tx kv.TemporalGetter) (uint64, error) {
 	stateVal, _, err := tx.GetLatest(kv.CommitmentDomain, KeyCommitmentState)
 	if err != nil {
 		return 0, err

--- a/execution/commitment/commitmentdb/commitment_context.go
+++ b/execution/commitment/commitmentdb/commitment_context.go
@@ -590,7 +590,7 @@ func (cs *commitmentState) Encode() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func CanUnwindToBlockNum(tx kv.TemporalTx) (uint64, error) {
+func LatestBlockNumWithCommitment(tx kv.TemporalTx) (uint64, error) {
 	stateVal, _, err := tx.GetLatest(kv.CommitmentDomain, KeyCommitmentState)
 	if err != nil {
 		return 0, err

--- a/execution/commitment/commitmentdb/commitment_context.go
+++ b/execution/commitment/commitmentdb/commitment_context.go
@@ -1,4 +1,4 @@
-package state
+package commitmentdb
 
 import (
 	"bytes"
@@ -16,6 +16,7 @@ import (
 	"github.com/erigontech/erigon-lib/common/empty"
 	"github.com/erigontech/erigon-lib/crypto"
 	"github.com/erigontech/erigon-lib/log/v3"
+	"github.com/erigontech/erigon-lib/metrics"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/order"
 	"github.com/erigontech/erigon/db/kv/rawdbv3"
@@ -25,9 +26,21 @@ import (
 	witnesstypes "github.com/erigontech/erigon/execution/types/witness"
 )
 
+var (
+	mxCommitmentRunning = metrics.GetOrCreateGauge("domain_running_commitment")
+	mxCommitmentTook    = metrics.GetOrCreateSummary("domain_commitment_took")
+)
+
+type sd interface {
+	SetBlockNum(blockNum uint64)
+	SetTxNum(blockNum uint64)
+	AsGetter(tx kv.TemporalTx) kv.TemporalGetter
+	AsPutDel(tx kv.TemporalTx) kv.TemporalPutDel
+	StepSize() uint64
+}
+
 type SharedDomainsCommitmentContext struct {
-	//mu            sync.Mutex // protects reads from sharedDomains when trie is concurrent
-	sharedDomains *SharedDomains
+	sharedDomains sd
 	mainTtx       *TrieContext
 
 	updates      *commitment.Updates
@@ -43,7 +56,7 @@ func (sdc *SharedDomainsCommitmentContext) SetLimitReadAsOfTxNum(txNum uint64, d
 	sdc.mainTtx.SetLimitReadAsOfTxNum(txNum, domainOnly)
 }
 
-func NewSharedDomainsCommitmentContext(sd *SharedDomains, tx kv.TemporalTx, mode commitment.Mode, trieVariant commitment.TrieVariant, tmpDir string) *SharedDomainsCommitmentContext {
+func NewSharedDomainsCommitmentContext(sd sd, tx kv.TemporalTx, mode commitment.Mode, trieVariant commitment.TrieVariant, tmpDir string) *SharedDomainsCommitmentContext {
 	ctx := &SharedDomainsCommitmentContext{
 		sharedDomains: sd,
 	}
@@ -69,6 +82,14 @@ func (sdc *SharedDomainsCommitmentContext) Reset() {
 	if !sdc.justRestored.Load() {
 		sdc.patriciaTrie.Reset()
 	}
+}
+func (sdc *SharedDomainsCommitmentContext) ClearRam() {
+	sdc.updates.Reset()
+	sdc.Reset()
+}
+
+func (sdc *SharedDomainsCommitmentContext) SetTxNum(txNum uint64) {
+	sdc.mainTtx.txNum = txNum
 }
 
 func (sdc *SharedDomainsCommitmentContext) KeysCount() uint64 {
@@ -148,7 +169,7 @@ func (sdc *SharedDomainsCommitmentContext) ComputeCommitment(ctx context.Context
 // by that key stored latest root hash and tree state
 const keyCommitmentStateS = "state"
 
-var keyCommitmentState = []byte(keyCommitmentStateS)
+var KeyCommitmentState = []byte(keyCommitmentStateS)
 
 var ErrBehindCommitment = errors.New("behind commitment")
 
@@ -162,7 +183,7 @@ func (sdc *SharedDomainsCommitmentContext) LatestCommitmentState() (blockNum, tx
 	if sdc.patriciaTrie.Variant() != commitment.VariantHexPatriciaTrie && sdc.patriciaTrie.Variant() != commitment.VariantConcurrentHexPatricia {
 		return 0, 0, nil, errors.New("state storing is only supported hex patricia trie")
 	}
-	state, _, err = sdc.mainTtx.Branch(keyCommitmentState)
+	state, _, err = sdc.mainTtx.Branch(KeyCommitmentState)
 	if err != nil {
 		return 0, 0, nil, err
 	}
@@ -259,7 +280,7 @@ func (sdc *SharedDomainsCommitmentContext) encodeAndStoreCommitmentState(blockNu
 	if err != nil {
 		return err
 	}
-	prevState, prevStep, err := sdc.mainTtx.Branch(keyCommitmentState)
+	prevState, prevStep, err := sdc.mainTtx.Branch(KeyCommitmentState)
 	if err != nil {
 		return err
 	}
@@ -275,7 +296,7 @@ func (sdc *SharedDomainsCommitmentContext) encodeAndStoreCommitmentState(blockNu
 	}
 
 	log.Debug("[commitment] store state", "block", blockNum, "txNum", txNum, "rootHash", hex.EncodeToString(rootHash))
-	return sdc.mainTtx.PutBranch(keyCommitmentState, encodedState, prevState, prevStep)
+	return sdc.mainTtx.PutBranch(KeyCommitmentState, encodedState, prevState, prevStep)
 }
 
 // Encodes current trie state and returns it
@@ -521,4 +542,62 @@ func (sdc *TrieContext) Storage(plainKey []byte) (u *commitment.Update, err erro
 func (sdc *TrieContext) SetLimitReadAsOfTxNum(txNum uint64, domainOnly bool) {
 	sdc.limitReadAsOfTxNum = txNum
 	sdc.withHistory = !domainOnly
+}
+
+type ValueMerger func(prev, current []byte) (merged []byte, err error)
+
+// TODO revisit encoded commitmentState.
+//   - Add versioning
+//   - add trie variant marker
+//   - simplify decoding. Rn it's 3 embedded structure: RootNode encoded, Trie state encoded and commitmentState wrapper for search.
+//     | search through states seems mostly useless so probably commitmentState should become header of trie state.
+type commitmentState struct {
+	txNum     uint64
+	blockNum  uint64
+	trieState []byte
+}
+
+func (cs *commitmentState) Decode(buf []byte) error {
+	if len(buf) < 10 {
+		return fmt.Errorf("ivalid commitment state buffer size %d, expected at least 10b", len(buf))
+	}
+	pos := 0
+	cs.txNum = binary.BigEndian.Uint64(buf[pos : pos+8])
+	pos += 8
+	cs.blockNum = binary.BigEndian.Uint64(buf[pos : pos+8])
+	pos += 8
+	cs.trieState = make([]byte, binary.BigEndian.Uint16(buf[pos:pos+2]))
+	pos += 2
+	if len(cs.trieState) == 0 && len(buf) == 10 {
+		return nil
+	}
+	copy(cs.trieState, buf[pos:pos+len(cs.trieState)])
+	return nil
+}
+
+func (cs *commitmentState) Encode() ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+	var v [18]byte
+	binary.BigEndian.PutUint64(v[:], cs.txNum)
+	binary.BigEndian.PutUint64(v[8:16], cs.blockNum)
+	binary.BigEndian.PutUint16(v[16:18], uint16(len(cs.trieState)))
+	if _, err := buf.Write(v[:]); err != nil {
+		return nil, err
+	}
+	if _, err := buf.Write(cs.trieState); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func CanUnwindToBlockNum(tx kv.TemporalTx) (uint64, error) {
+	stateVal, _, err := tx.GetLatest(kv.CommitmentDomain, KeyCommitmentState)
+	if err != nil {
+		return 0, err
+	}
+	if len(stateVal) == 0 {
+		return 0, nil
+	}
+	_, minUnwindale := _decodeTxBlockNums(stateVal)
+	return minUnwindale, nil
 }

--- a/execution/commitment/commitmentdb/commitment_context_test.go
+++ b/execution/commitment/commitmentdb/commitment_context_test.go
@@ -1,0 +1,29 @@
+package commitmentdb
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_EncodeCommitmentState(t *testing.T) {
+	t.Parallel()
+	cs := commitmentState{
+		txNum:     rand.Uint64(),
+		trieState: make([]byte, 1024),
+	}
+	n, err := rand.Read(cs.trieState)
+	require.NoError(t, err)
+	require.Equal(t, len(cs.trieState), n)
+
+	buf, err := cs.Encode()
+	require.NoError(t, err)
+	require.NotEmpty(t, buf)
+
+	var dec commitmentState
+	err = dec.Decode(buf)
+	require.NoError(t, err)
+	require.Equal(t, cs.txNum, dec.txNum)
+	require.Equal(t, cs.trieState, dec.trieState)
+}

--- a/execution/eth1/forkchoice.go
+++ b/execution/eth1/forkchoice.go
@@ -33,6 +33,7 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/rawdbv3"
 	"github.com/erigontech/erigon/db/rawdb"
+	"github.com/erigontech/erigon/db/rawdb/rawtemporaldb"
 	"github.com/erigontech/erigon/db/state"
 	"github.com/erigontech/erigon/db/wrap"
 	"github.com/erigontech/erigon/eth/consensuschain"
@@ -168,10 +169,6 @@ func writeForkChoiceHashes(tx kv.RwTx, blockHash, safeHash, finalizedHash common
 	}
 	rawdb.WriteHeadBlockHash(tx, blockHash)
 	rawdb.WriteForkchoiceHead(tx, blockHash)
-}
-
-func minUnwindableBlock(tx kv.TemporalTx, number uint64) (uint64, error) {
-	return tx.Debug().CanUnwindToBlockNum()
 }
 
 func (e *EthereumExecutionModule) updateForkChoice(ctx context.Context, originalBlockHash, safeHash, finalizedHash common.Hash, outcomeCh chan forkchoiceOutcome) {
@@ -329,7 +326,7 @@ func (e *EthereumExecutionModule) updateForkChoice(ctx context.Context, original
 		}
 
 		unwindTarget := currentParentNumber
-		minUnwindableBlock, err := minUnwindableBlock(tx, unwindTarget)
+		minUnwindableBlock, err := rawtemporaldb.CanUnwindToBlockNum(tx)
 		if err != nil {
 			sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, err, false)
 			return

--- a/execution/eth1/forkchoice.go
+++ b/execution/eth1/forkchoice.go
@@ -36,6 +36,7 @@ import (
 	"github.com/erigontech/erigon/db/state"
 	"github.com/erigontech/erigon/db/wrap"
 	"github.com/erigontech/erigon/eth/consensuschain"
+	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
 	"github.com/erigontech/erigon/execution/engineapi/engine_helpers"
 	"github.com/erigontech/erigon/execution/stagedsync"
 	"github.com/erigontech/erigon/execution/stagedsync/stages"
@@ -74,7 +75,7 @@ func isDomainAheadOfBlocks(tx kv.TemporalRwTx, logger log.Logger) bool {
 	doms, err := state.NewSharedDomains(tx, logger)
 	if err != nil {
 		logger.Debug("domain ahead of blocks", "err", err)
-		return errors.Is(err, state.ErrBehindCommitment)
+		return errors.Is(err, commitmentdb.ErrBehindCommitment)
 	}
 	defer doms.Close()
 	return false

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -44,6 +44,7 @@ import (
 	"github.com/erigontech/erigon/db/rawdb/rawtemporaldb"
 	dbstate "github.com/erigontech/erigon/db/state"
 	"github.com/erigontech/erigon/db/wrap"
+	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
 	"github.com/erigontech/erigon/execution/exec3"
 	"github.com/erigontech/erigon/execution/stagedsync/stages"
 	"github.com/erigontech/erigon/execution/types"
@@ -263,7 +264,7 @@ func ExecV3(ctx context.Context,
 		doms, err = dbstate.NewSharedDomains(temporalTx, log.New())
 		// if we are behind the commitment, we can't execute anything
 		// this can heppen if progress in domain is higher than progress in blocks
-		if errors.Is(err, dbstate.ErrBehindCommitment) {
+		if errors.Is(err, commitmentdb.ErrBehindCommitment) {
 			return nil
 		}
 		if err != nil {
@@ -696,7 +697,7 @@ Loop:
 			if shouldGenerateChangesets {
 				executor.domains().SavePastChangesetAccumulator(b.Hash(), blockNum, changeset)
 				if !inMemExec {
-					if err := dbstate.WriteDiffSet(executor.tx(), blockNum, b.Hash(), changeset); err != nil {
+					if err := changeset.WriteDiffSet(executor.tx(), blockNum, b.Hash(), changeset); err != nil {
 						return err
 					}
 				}
@@ -907,7 +908,7 @@ func handleIncorrectRootHashError(header *types.Header, applyTx kv.TemporalRwTx,
 		return false, nil
 	}
 
-	unwindToLimit, err := applyTx.Debug().CanUnwindToBlockNum()
+	unwindToLimit, err := dbstate.CanUnwindToBlockNum(applyTx)
 	if err != nil {
 		return false, err
 	}
@@ -918,7 +919,7 @@ func handleIncorrectRootHashError(header *types.Header, applyTx kv.TemporalRwTx,
 	unwindTo := maxBlockNum - jump
 
 	// protect from too far unwind
-	allowedUnwindTo, ok, err := applyTx.Debug().CanUnwindBeforeBlockNum(unwindTo)
+	allowedUnwindTo, ok, err := dbstate.CanUnwindBeforeBlockNum(unwindTo, applyTx)
 	if err != nil {
 		return false, err
 	}

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -43,6 +43,7 @@ import (
 	"github.com/erigontech/erigon/db/rawdb/rawdbhelpers"
 	"github.com/erigontech/erigon/db/rawdb/rawtemporaldb"
 	dbstate "github.com/erigontech/erigon/db/state"
+	changeset2 "github.com/erigontech/erigon/db/state/changeset"
 	"github.com/erigontech/erigon/db/wrap"
 	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
 	"github.com/erigontech/erigon/execution/exec3"
@@ -469,9 +470,9 @@ Loop:
 			computeCommitmentDuration += time.Since(start)
 			shouldGenerateChangesets = true // now we can generate changesets for the safety net
 		}
-		changeset := &dbstate.StateChangeSet{}
+		changeSet := &changeset2.StateChangeSet{}
 		if shouldGenerateChangesets && blockNum > 0 {
-			executor.domains().SetChangesetAccumulator(changeset)
+			executor.domains().SetChangesetAccumulator(changeSet)
 		}
 		if !parallel {
 			select {
@@ -695,9 +696,9 @@ Loop:
 
 			computeCommitmentDuration += time.Since(start)
 			if shouldGenerateChangesets {
-				executor.domains().SavePastChangesetAccumulator(b.Hash(), blockNum, changeset)
+				executor.domains().SavePastChangesetAccumulator(b.Hash(), blockNum, changeSet)
 				if !inMemExec {
-					if err := changeset.WriteDiffSet(executor.tx(), blockNum, b.Hash(), changeset); err != nil {
+					if err := changeset2.WriteDiffSet(executor.tx(), blockNum, b.Hash(), changeSet); err != nil {
 						return err
 					}
 				}
@@ -908,7 +909,7 @@ func handleIncorrectRootHashError(header *types.Header, applyTx kv.TemporalRwTx,
 		return false, nil
 	}
 
-	unwindToLimit, err := dbstate.CanUnwindToBlockNum(applyTx)
+	unwindToLimit, err := rawtemporaldb.CanUnwindToBlockNum(applyTx)
 	if err != nil {
 		return false, err
 	}
@@ -919,7 +920,7 @@ func handleIncorrectRootHashError(header *types.Header, applyTx kv.TemporalRwTx,
 	unwindTo := maxBlockNum - jump
 
 	// protect from too far unwind
-	allowedUnwindTo, ok, err := dbstate.CanUnwindBeforeBlockNum(unwindTo, applyTx)
+	allowedUnwindTo, ok, err := rawtemporaldb.CanUnwindBeforeBlockNum(unwindTo, applyTx)
 	if err != nil {
 		return false, err
 	}

--- a/execution/stagedsync/stage_execute.go
+++ b/execution/stagedsync/stage_execute.go
@@ -38,7 +38,9 @@ import (
 	"github.com/erigontech/erigon/db/kv/prune"
 	"github.com/erigontech/erigon/db/rawdb"
 	"github.com/erigontech/erigon/db/rawdb/rawdbhelpers"
+	"github.com/erigontech/erigon/db/rawdb/rawtemporaldb"
 	"github.com/erigontech/erigon/db/state"
+	"github.com/erigontech/erigon/db/state/changeset"
 	"github.com/erigontech/erigon/db/wrap"
 	"github.com/erigontech/erigon/eth/ethconfig"
 	"github.com/erigontech/erigon/execution/chain"
@@ -193,7 +195,7 @@ func unwindExec3(u *UnwindState, s *StageState, txc wrap.TxContainer, ctx contex
 	}
 
 	t := time.Now()
-	var changeset *[kv.DomainLen][]kv.DomainEntryDiff
+	var changeSet *[kv.DomainLen][]kv.DomainEntryDiff
 	for currentBlock := u.CurrentBlockNumber; currentBlock > u.UnwindPoint; currentBlock-- {
 		currentHash, ok, err := br.CanonicalHash(ctx, tx, currentBlock)
 		if err != nil {
@@ -210,15 +212,15 @@ func unwindExec3(u *UnwindState, s *StageState, txc wrap.TxContainer, ctx contex
 		if err != nil {
 			return err
 		}
-		if changeset == nil {
-			changeset = &currentKeys
+		if changeSet == nil {
+			changeSet = &currentKeys
 		} else {
 			for i := range currentKeys {
-				changeset[i] = state.MergeDiffSets(changeset[i], currentKeys[i])
+				changeSet[i] = changeset.MergeDiffSets(changeSet[i], currentKeys[i])
 			}
 		}
 	}
-	if err := unwindExec3State(ctx, tx, domains, u.UnwindPoint, txNum, accumulator, changeset, logger); err != nil {
+	if err := unwindExec3State(ctx, tx, domains, u.UnwindPoint, txNum, accumulator, changeSet, logger); err != nil {
 		return fmt.Errorf("ParallelExecutionState.Unwind(%d->%d): %w, took %s", s.BlockNumber, u.UnwindPoint, err, time.Since(t))
 	}
 	if err := rawdb.DeleteNewerEpochs(tx, u.UnwindPoint+1); err != nil {
@@ -362,7 +364,7 @@ func UnwindExecutionStage(u *UnwindState, s *StageState, txc wrap.TxContainer, c
 	logPrefix := u.LogPrefix()
 	logger.Info(fmt.Sprintf("[%s] Unwind Execution", logPrefix), "from", s.BlockNumber, "to", u.UnwindPoint)
 
-	unwindToLimit, ok, err := txc.Ttx.Debug().CanUnwindBeforeBlockNum(u.UnwindPoint)
+	unwindToLimit, ok, err := rawtemporaldb.CanUnwindBeforeBlockNum(u.UnwindPoint, txc.Ttx)
 	if err != nil {
 		return err
 	}

--- a/execution/stagedsync/sync.go
+++ b/execution/stagedsync/sync.go
@@ -29,6 +29,7 @@ import (
 	"github.com/erigontech/erigon/db/state"
 	"github.com/erigontech/erigon/db/wrap"
 	"github.com/erigontech/erigon/eth/ethconfig"
+	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
 	"github.com/erigontech/erigon/execution/stagedsync/stages"
 )
 
@@ -154,7 +155,7 @@ func (s *Sync) UnwindTo(unwindPoint uint64, reason UnwindReason, tx kv.Tx) error
 			unwindPointWithCommitment, ok, err := aggTx.CanUnwindBeforeBlockNum(unwindPoint, tx)
 			// Ignore in the case that snapshots are ahead of commitment, it will be resolved later.
 			// This can be a problem if snapshots include a wrong chain so it is ok to ignore it.
-			if errors.Is(err, state.ErrBehindCommitment) {
+			if errors.Is(err, commitmentdb.ErrBehindCommitment) {
 				return nil
 			}
 			if err != nil {


### PR DESCRIPTION

- move `changeset` from `state` to own package
- move `commitment_context.go` to `execution/commitmentdb` package
- move remove Unwind methods from `Agg` - because they did contain biz-logic (serialization format of Commitment) to `temporalrawdb` package (maybe will merge it to `rawdb` pkg in future - doesn't matter). 
- no functional changes
- `commitment_context.go` to use `interface` instead of exact `SharedDomains` type (maybe in future we will somehow break circular dependency here - but it's small already)

step towards: move biz-logic outsize of `state` pkg

