### PR TITLE
turbo/app: do not use caplin and snap downloader in import cmd

### DIFF
--- a/turbo/app/import_cmd.go
+++ b/turbo/app/import_cmd.go
@@ -84,8 +84,8 @@ func importChain(cliCtx *cli.Context) error {
 	}
 
 	ethCfg := node.NewEthConfigUrfave(cliCtx, nodeCfg, logger)
-	ethCfg.Snapshot.NoDownloader = true // no need to run this for import chain (used in hive eest/consume-rlp tests)
-	ethCfg.InternalCL = false           // no need to run this for import chain (used in hive eest/consume-rlp tests)
+	ethCfg.Snapshot.NoDownloader = true // no need to run this for import chain (also used in hive eest/consume-rlp tests)
+	ethCfg.InternalCL = false           // no need to run this for import chain (also used in hive eest/consume-rlp tests)
 	stack := makeConfigNode(cliCtx.Context, nodeCfg, logger)
 	defer stack.Close()
 

--- a/turbo/app/import_cmd.go
+++ b/turbo/app/import_cmd.go
@@ -58,6 +58,7 @@ var importCommand = cli.Command{
 	Flags: []cli.Flag{
 		&utils.DataDirFlag,
 		&utils.ChainFlag,
+		&utils.NetworkIdFlag,
 	},
 	//Category: "BLOCKCHAIN COMMANDS",
 	Description: `
@@ -84,7 +85,7 @@ func importChain(cliCtx *cli.Context) error {
 
 	ethCfg := node.NewEthConfigUrfave(cliCtx, nodeCfg, logger)
 	ethCfg.Snapshot.NoDownloader = true // no need to run this for import chain (used in hive eest/consume-rlp tests)
-	ethCfg.InternalCL = false           // no need to run this for import chain (used in hive eest/consume-rlp tests with --networkid=1)
+	ethCfg.InternalCL = false           // no need to run this for import chain (used in hive eest/consume-rlp tests)
 	stack := makeConfigNode(cliCtx.Context, nodeCfg, logger)
 	defer stack.Close()
 

--- a/turbo/app/import_cmd.go
+++ b/turbo/app/import_cmd.go
@@ -81,8 +81,10 @@ func importChain(cliCtx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	ethCfg := node.NewEthConfigUrfave(cliCtx, nodeCfg, logger)
 
+	ethCfg := node.NewEthConfigUrfave(cliCtx, nodeCfg, logger)
+	ethCfg.Snapshot.NoDownloader = true // no need to run this for import chain (used in hive eest/consume-rlp tests)
+	ethCfg.InternalCL = false           // no need to run this for import chain (used in hive eest/consume-rlp tests with --networkid=1)
 	stack := makeConfigNode(cliCtx.Context, nodeCfg, logger)
 	defer stack.Close()
 


### PR DESCRIPTION
fixes remaining 17 failures in eest/consume-rlp at https://hive.ethpandaops.io/#/test/fusaka-devnet-5/1757032589-b9bf2c1dc686584baa05a74da9ca4cd6

seeing lots of:
```
could not start caplin                   err="snappy: corrupt input"
```

caplin/snap downloader dont need to be run as part of "import" chain cmd which is what is used for consume-rlp tests

also note the eest/consume-rlp tests run the import cmd with --networkid=1 so adding that in too