### PR TITLE
workflows: run kurtosis on PRs and use fixed ethereum-package version

### DIFF
--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -9,7 +9,9 @@ on:
     branches:
         - main
         - 'release/**'
-        - docker_pectra
+  pull_request:
+    branches:
+      - main
   workflow_call:
   workflow_dispatch:
 
@@ -36,6 +38,7 @@ jobs:
         with:
             enclave_name: "kurtosis-run1-${{ github.run_id }}"
             ethereum_package_args: ".github/workflows/kurtosis/regular-assertoor.io"
+            ethereum_package_branch: "5.0.1"
             kurtosis_extra_args: --verbosity detailed --cli-log-level trace
             persistent_logs: "true"
 
@@ -61,5 +64,6 @@ jobs:
         with:
             enclave_name: "kurtosis-run2-${{ github.run_id }}"
             ethereum_package_args: ".github/workflows/kurtosis/pectra.io"
+            ethereum_package_branch: "5.0.1"
             kurtosis_extra_args: --verbosity detailed --cli-log-level trace
             persistent_logs: "true"


### PR DESCRIPTION
we want to run these checks on PRs (mandatory) before merging into main (used by EF DevOps for continuous deployment into fusaka devnets)

in order to minimise chances of this CI failing due to changes in ethereum-package or CLs we want to use fixed versions (we can update these when needed and/or periodically)