### PR TITLE
add randomness to temp file names - to remove race condition (#17010)

### DIFF
--- a/db/datastruct/existence/existence_filter.go
+++ b/db/datastruct/existence/existence_filter.go
@@ -109,8 +109,7 @@ func (b *Filter) Build() error {
 	}
 
 	log.Trace("[agg] write file", "file", b.FileName)
-	tmpFilePath := b.FilePath + ".tmp"
-	cf, err := os.Create(tmpFilePath)
+	cf, err := dir.CreateTemp(b.FilePath)
 	if err != nil {
 		return err
 	}
@@ -125,7 +124,7 @@ func (b *Filter) Build() error {
 	if err = cf.Close(); err != nil {
 		return err
 	}
-	if err := os.Rename(tmpFilePath, b.FilePath); err != nil {
+	if err := os.Rename(cf.Name(), b.FilePath); err != nil {
 		return err
 	}
 	return nil

--- a/db/seg/compress.go
+++ b/db/seg/compress.go
@@ -36,6 +36,7 @@ import (
 	"github.com/c2h5oh/datasize"
 
 	"github.com/erigontech/erigon-lib/common"
+	"github.com/erigontech/erigon-lib/common/dir"
 	dir2 "github.com/erigontech/erigon-lib/common/dir"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/etl"
@@ -105,7 +106,6 @@ type Compressor struct {
 
 	outputFileName   string
 	outputFile       string // File where to output the dictionary and compressed data
-	tmpOutFilePath   string // File where to output the dictionary and compressed data
 	suffixCollectors []*etl.Collector
 	// Buffer for "superstring" - transformation of superstrings where each byte of a word, say b,
 	// is turned into 2 bytes, 0x01 and b, and two zero bytes 0x00 0x00 are inserted after each word
@@ -124,11 +124,7 @@ type Compressor struct {
 func NewCompressor(ctx context.Context, logPrefix, outputFile, tmpDir string, cfg Cfg, lvl log.Lvl, logger log.Logger) (*Compressor, error) {
 	workers := cfg.Workers
 	dir2.MustExist(tmpDir)
-	dir, fileName := filepath.Split(outputFile)
-
-	// tmpOutFilePath is a ".seg.tmp" file which will be renamed to ".seg" if everything succeeds.
-	// It allows to atomically create a ".seg" file (the downloader will not see partial ".seg" files).
-	tmpOutFilePath := filepath.Join(dir, fileName) + ".tmp"
+	_, fileName := filepath.Split(outputFile)
 
 	uncompressedPath := filepath.Join(tmpDir, fileName) + ".idt"
 	uncompressedFile, err := NewRawWordsFile(uncompressedPath)
@@ -153,7 +149,6 @@ func NewCompressor(ctx context.Context, logPrefix, outputFile, tmpDir string, cf
 	return &Compressor{
 		Cfg:              cfg,
 		uncompressedFile: uncompressedFile,
-		tmpOutFilePath:   tmpOutFilePath,
 		outputFile:       outputFile,
 		outputFileName:   outputFileName,
 		tmpDir:           tmpDir,
@@ -262,15 +257,16 @@ func (c *Compressor) Compress() error {
 			return err
 		}
 	}
-	defer dir2.RemoveFile(c.tmpOutFilePath)
 
-	cf, err := os.Create(c.tmpOutFilePath)
+	cf, err := dir.CreateTemp(c.outputFile)
 	if err != nil {
 		return err
 	}
+	tmpFileName := cf.Name()
+	defer dir.RemoveFile(tmpFileName)
 	defer cf.Close()
 	t := time.Now()
-	if err := compressWithPatternCandidates(c.ctx, c.trace, c.Cfg, c.logPrefix, c.tmpOutFilePath, cf, c.uncompressedFile, db, c.lvl, c.logger); err != nil {
+	if err := compressWithPatternCandidates(c.ctx, c.trace, c.Cfg, c.logPrefix, tmpFileName, cf, c.uncompressedFile, db, c.lvl, c.logger); err != nil {
 		return err
 	}
 	if err = c.fsync(cf); err != nil {
@@ -279,7 +275,7 @@ func (c *Compressor) Compress() error {
 	if err = cf.Close(); err != nil {
 		return err
 	}
-	if err := os.Rename(c.tmpOutFilePath, c.outputFile); err != nil {
+	if err := os.Rename(tmpFileName, c.outputFile); err != nil {
 		return fmt.Errorf("renaming: %w", err)
 	}
 
@@ -305,7 +301,7 @@ func (c *Compressor) fsync(f *os.File) error {
 		return nil
 	}
 	if err := f.Sync(); err != nil {
-		c.logger.Warn("couldn't fsync", "err", err, "file", c.tmpOutFilePath)
+		c.logger.Warn("couldn't fsync", "err", err, "file", f.Name())
 		return err
 	}
 	return nil

--- a/db/seg/parallel_compress.go
+++ b/db/seg/parallel_compress.go
@@ -31,6 +31,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/erigontech/erigon-lib/common/dir"
+
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/assert"
 	"github.com/erigontech/erigon-lib/common/dir"
@@ -294,12 +296,13 @@ func compressWithPatternCandidates(ctx context.Context, trace bool, cfg Cfg, log
 	t := time.Now()
 
 	var err error
-	intermediatePath := segmentFilePath + ".tmp"
-	defer dir.RemoveFile(intermediatePath)
+
 	var intermediateFile *os.File
-	if intermediateFile, err = os.Create(intermediatePath); err != nil {
+	if intermediateFile, err = dir.CreateTemp(segmentFilePath); err != nil {
 		return fmt.Errorf("create intermediate file: %w", err)
 	}
+	intermediatePath := intermediateFile.Name()
+	defer dir.RemoveFile(intermediatePath)
 	defer intermediateFile.Close()
 	intermediateW := bufio.NewWriterSize(intermediateFile, 8*etl.BufIOSize)
 

--- a/db/seg/parallel_compress.go
+++ b/db/seg/parallel_compress.go
@@ -31,8 +31,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/erigontech/erigon-lib/common/dir"
-
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/assert"
 	"github.com/erigontech/erigon-lib/common/dir"

--- a/db/state/btree_index.go
+++ b/db/state/btree_index.go
@@ -37,6 +37,7 @@ import (
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/common/background"
 	"github.com/erigontech/erigon-lib/common/dbg"
+	"github.com/erigontech/erigon-lib/common/dir"
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/datastruct/existence"
 	"github.com/erigontech/erigon/db/etl"
@@ -153,7 +154,6 @@ type BtIndexWriter struct {
 	args BtIndexWriterArgs
 
 	indexFileName string
-	tmpFilePath   string
 
 	numBuf      [8]byte
 	keysWritten uint64
@@ -185,8 +185,7 @@ func NewBtIndexWriter(args BtIndexWriterArgs, logger log.Logger) (*BtIndexWriter
 		args.Lvl = log.LvlTrace
 	}
 
-	btw := &BtIndexWriter{lvl: args.Lvl, logger: logger, args: args,
-		tmpFilePath: args.IndexFile + ".tmp"}
+	btw := &BtIndexWriter{lvl: args.Lvl, logger: logger, args: args}
 
 	_, fname := filepath.Split(btw.args.IndexFile)
 	btw.indexFileName = fname
@@ -237,8 +236,8 @@ func (btw *BtIndexWriter) Build() error {
 		return errors.New("already built")
 	}
 	var err error
-	if btw.indexF, err = os.Create(btw.tmpFilePath); err != nil {
-		return fmt.Errorf("create index file %s: %w", btw.args.IndexFile, err)
+	if btw.indexF, err = dir.CreateTemp(btw.args.IndexFile); err != nil {
+		return fmt.Errorf("create temp index file for %s: %w", btw.args.IndexFile, err)
 	}
 	defer btw.indexF.Close()
 	btw.indexW = bufio.NewWriterSize(btw.indexF, etl.BufIOSize)
@@ -284,7 +283,7 @@ func (btw *BtIndexWriter) Build() error {
 	if err = btw.indexF.Close(); err != nil {
 		return err
 	}
-	if err = os.Rename(btw.tmpFilePath, btw.args.IndexFile); err != nil {
+	if err = os.Rename(btw.indexF.Name(), btw.args.IndexFile); err != nil {
 		return err
 	}
 	return nil
@@ -300,7 +299,7 @@ func (btw *BtIndexWriter) fsync() error {
 		return nil
 	}
 	if err := btw.indexF.Sync(); err != nil {
-		btw.logger.Warn("couldn't fsync", "err", err, "file", btw.tmpFilePath)
+		btw.logger.Warn("couldn't fsync", "err", err, "file", btw.indexF.Name())
 		return err
 	}
 	return nil

--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -95,6 +95,7 @@ func testDbAndDomainOfStep(t *testing.T, aggStep uint64, logger log.Logger) (kv.
 	d.DisableFsync()
 	return db, d
 }
+
 func TestDomain_CollationBuild(t *testing.T) {
 	if testing.Short() {
 		t.Skip()

--- a/erigon-lib/common/dir/rw_dir.go
+++ b/erigon-lib/common/dir/rw_dir.go
@@ -187,5 +187,9 @@ func CreateTemp(file string) (*os.File, error) {
 func CreateTempWithExtension(file string, extension string) (*os.File, error) {
 	directory := filepath.Dir(file)
 	filename := filepath.Base(file)
-	return os.CreateTemp(directory, fmt.Sprintf("%s.*.%s", filename, extension))
+	pattern := fmt.Sprintf("%s.*.%s", filename, extension)
+	if !strings.HasSuffix(pattern, ".tmp") {
+		return nil, fmt.Errorf("extension must end with .tmp, erigon cleans these up at restart. pattern: %s", pattern)
+	}
+	return os.CreateTemp(directory, pattern)
 }

--- a/erigon-lib/common/dir/rw_dir.go
+++ b/erigon-lib/common/dir/rw_dir.go
@@ -17,6 +17,7 @@
 package dir
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -176,4 +177,15 @@ func RemoveAll(path string) error {
 		log.Debug("[removing] removing dir", "path", path, "stack", dbg.Stack())
 	}
 	return os.RemoveAll(path)
+}
+
+// CreateTemp creates a temporary file using `file` as base
+func CreateTemp(file string) (*os.File, error) {
+	return CreateTempWithExtension(file, "tmp")
+}
+
+func CreateTempWithExtension(file string, extension string) (*os.File, error) {
+	directory := filepath.Dir(file)
+	filename := filepath.Base(file)
+	return os.CreateTemp(directory, fmt.Sprintf("%s.*.%s", filename, extension))
 }

--- a/erigon-lib/common/dir/rw_dir_test.go
+++ b/erigon-lib/common/dir/rw_dir_test.go
@@ -1,0 +1,42 @@
+// Copyright 2021 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package dir
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_CreateTemp(t *testing.T) {
+	dir := t.TempDir()
+	ogfile := filepath.Join(dir, "hello_world")
+	tmpfile, err := CreateTemp(ogfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tmpfile.Close()
+	dir1 := filepath.Dir(tmpfile.Name())
+	dir2 := filepath.Dir(ogfile)
+	require.True(t, dir1 == dir2)
+
+	base1 := filepath.Base(tmpfile.Name())
+	base2 := filepath.Base(ogfile)
+	require.True(t, strings.HasPrefix(base1, base2))
+}

--- a/erigon-lib/common/dir/rw_dir_test.go
+++ b/erigon-lib/common/dir/rw_dir_test.go
@@ -45,10 +45,10 @@ func Test_CreateTempWithExt(t *testing.T) {
 	dir := t.TempDir()
 	ogfile := filepath.Join(dir, "hello_world")
 
-	tmpfile, err := CreateTempWithExtension(ogfile, "existence")
+	_, err := CreateTempWithExtension(ogfile, "existence")
 	require.Error(t, err)
 
-	tmpfile, err = CreateTempWithExtension(ogfile, "existence.tmp")
+	tmpfile, err := CreateTempWithExtension(ogfile, "existence.tmp")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/erigon-lib/common/dir/rw_dir_test.go
+++ b/erigon-lib/common/dir/rw_dir_test.go
@@ -40,3 +40,24 @@ func Test_CreateTemp(t *testing.T) {
 	base2 := filepath.Base(ogfile)
 	require.True(t, strings.HasPrefix(base1, base2))
 }
+
+func Test_CreateTempWithExt(t *testing.T) {
+	dir := t.TempDir()
+	ogfile := filepath.Join(dir, "hello_world")
+
+	tmpfile, err := CreateTempWithExtension(ogfile, "existence")
+	require.Error(t, err)
+
+	tmpfile, err = CreateTempWithExtension(ogfile, "existence.tmp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tmpfile.Close()
+	dir1 := filepath.Dir(tmpfile.Name())
+	dir2 := filepath.Dir(ogfile)
+	require.True(t, dir1 == dir2)
+
+	base1 := filepath.Base(tmpfile.Name())
+	base2 := filepath.Base(ogfile)
+	require.True(t, strings.HasPrefix(base1, base2))
+}


### PR DESCRIPTION
two recsplit creation triggered for same file:
- the first one finishes build and closes (along with doing `rm tmpFile`)
- `tmpFile` is not removed immediately because it's also `Build` by second trigger.
- when second trigger is done, it closes file (which `rm tmpFile` for real) and then tries to rename, which fails.
- this PR adds a random number to the filename so that different triggers on same file end up having different filenames. In case there's still clash, we can ask user to try again.

Possibly the two triggers are: `MergeLoop` in backend.go and `BuildMissedAccessors` in SnapshotsStage (after ottersync is finished)

cp: https://github.com/erigontech/erigon/pull/17010