### PR TITLE
cherry-pick: Do not apply milestone if tip is behind it (#16890)

### DIFF
--- a/polygon/sync/service.go
+++ b/polygon/sync/service.go
@@ -91,7 +91,7 @@ func NewService(
 		ccBuilderFactory,
 		heimdallService,
 		bridgeService,
-		events.Events(),
+		events,
 		notifications,
 		NewWiggleCalculator(borConfig, signaturesCache, heimdallService),
 		engineAPISwitcher,


### PR DESCRIPTION
cherry-pick of https://github.com/erigontech/erigon/pull/16803

If the tip is behind the milestone end, then this triggers an unwind to the previous verified milestone and download of blocks from previous verified milestone block until new milestone end block.

This is unnecessary since we can put the milestone back in the event queue, and it will be picked up later, and hopefully by that time the tip will be in sync with milestone. This is expected to reduce the number of unwinds.

---------