### PR TITLE
core: MaxBlobsPerTxn is expected before nonce check

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -273,6 +273,10 @@ func CheckEip1559TxGasFeeCap(from common.Address, feeCap, tipCap, baseFee *uint2
 
 // DESCRIBED: docs/programmers_guide/guide.md#nonce
 func (st *StateTransition) preCheck(gasBailout bool) error {
+	if st.evm.ChainRules().IsOsaka && len(st.msg.BlobHashes()) > params.MaxBlobsPerTxn {
+		return fmt.Errorf("%w: address %v, blobs: %d", ErrTooManyBlobs, st.msg.From().Hex(), len(st.msg.BlobHashes()))
+	}
+
 	// Make sure this transaction's nonce is correct.
 	if st.msg.CheckNonce() {
 		stNonce, err := st.state.GetNonce(st.msg.From())
@@ -310,10 +314,6 @@ func (st *StateTransition) preCheck(gasBailout bool) error {
 					st.msg.From().Hex(), codeHash)
 			}
 		}
-	}
-
-	if st.evm.ChainRules().IsOsaka && len(st.msg.BlobHashes()) > params.MaxBlobsPerTxn {
-		return fmt.Errorf("%w: address %v, blobs: %d", ErrTooManyBlobs, st.msg.From().Hex(), len(st.msg.BlobHashes()))
 	}
 
 	// Make sure the transaction feeCap is greater than the block's baseFee.


### PR DESCRIPTION
This fixes the remaining test failure on https://hive.ethpandaops.io/#/group/fusaka-devnet-5.

Continuation of #16945.