### PR TITLE
refect(state): remove FirstEntityNumFetcher and read BaseDataID from index

### DIFF
--- a/core/test/unmarked_forkable_test.go
+++ b/core/test/unmarked_forkable_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
-	"github.com/erigontech/erigon/db/seg"
 	"github.com/erigontech/erigon/db/state"
 	"github.com/erigontech/erigon/polygon/heimdall"
 )
@@ -36,10 +35,10 @@ func setupBorSpans(t *testing.T, log log.Logger, dirs datadir.Dirs, db kv.RoDB) 
 	))
 	require.Equal(t, state.ForkableId(0), borspanId)
 
-	indexb := state.NewSimpleAccessorBuilder(state.NewAccessorArgs(true, false), borspanId, log)
-	indexb.SetFirstEntityNumFetcher(func(from, to RootNum, seg *seg.Decompressor) Num {
-		return Num(CustomSpanIdAt(uint64(from)))
-	})
+	indexb := state.NewSimpleAccessorBuilder(state.NewAccessorArgs(true, false), borspanId, log, 
+		state.WithCustomBaseDataIDFunc(func(from, to state.RootNum) uint64 {
+			return uint64(CustomSpanIdAt(uint64(from)))
+		}))
 
 	uma, err := state.NewUnmarkedForkable(borspanId,
 		kv.BorSpans,


### PR DESCRIPTION
Removes the legacy FirstEntityNumFetcher mechanism as indicated by the TODO. BaseDataID is now read directly from the snapshot index header where it's already stored.

- Removed `FirstEntityNumFetcher` type and `SetFirstEntityNumFetcher` method
- `GetInputDataQuery` now reads BaseDataID from existing `.idx` files first, falls back to `from` value
- Added `WithCustomBaseDataIDFunc` option for special cases (replaces the old fetcher for tests)
- Updated test to use new API, removed unused import