### PR TITLE
Revert "Add submodules update and lfs=true for windows case. (#17081)"

### DIFF
--- a/.github/workflows/test-all-erigon.yml
+++ b/.github/workflows/test-all-erigon.yml
@@ -125,10 +125,7 @@ jobs:
       - name: Checkout code on ${{ matrix.os }}
         if: needs.source-of-changes.outputs.changed_files != 'true'
         uses: actions/checkout@v5
-        with:
-          submodules: recursive
-          lfs: true
-
+        
       - name: Setup Go environment on ${{ matrix.os }}
         if: needs.source-of-changes.outputs.changed_files != 'true'
         uses: actions/setup-go@v6


### PR DESCRIPTION
This reverts commit 7cb2082dbb44b5c259604bc009100be81c182f9d.


looks like we didnt update submodules on windows CI on purpose - these tests are too slow on our win runner and also even cause mdmx errors (see https://github.com/erigontech/erigon/issues/17083)
