### PR TITLE
use already opened heimdall store

### DIFF
--- a/polygon/heimdall/snapshot_integrity.go
+++ b/polygon/heimdall/snapshot_integrity.go
@@ -7,8 +7,8 @@ import (
 	"github.com/erigontech/erigon-lib/log/v3"
 )
 
-func ValidateBorSpans(ctx context.Context, logger log.Logger, dirs datadir.Dirs, snaps *RoSnapshots, failFast bool) error {
-	baseStore := NewMdbxStore(logger, dirs.DataDir, true, 32)
+func ValidateBorSpans(ctx context.Context, logger log.Logger, dirs datadir.Dirs, baseStore Store, snaps *RoSnapshots, failFast bool) error {
+	//baseStore := NewMdbxStore(logger, dirs.DataDir, true, 32)
 	snapshotStore := NewSpanSnapshotStore(baseStore.Spans(), snaps)
 	err := snapshotStore.Prepare(ctx)
 	if err != nil {
@@ -20,8 +20,8 @@ func ValidateBorSpans(ctx context.Context, logger log.Logger, dirs datadir.Dirs,
 	return err
 }
 
-func ValidateBorCheckpoints(ctx context.Context, logger log.Logger, dirs datadir.Dirs, snaps *RoSnapshots, failFast bool) error {
-	baseStore := NewMdbxStore(logger, dirs.DataDir, true, 32)
+func ValidateBorCheckpoints(ctx context.Context, logger log.Logger, dirs datadir.Dirs, baseStore Store, snaps *RoSnapshots, failFast bool) error {
+	//baseStore := NewMdbxStore(logger, dirs.DataDir, true, 32)
 	snapshotStore := NewCheckpointSnapshotStore(baseStore.Checkpoints(), snaps)
 	err := snapshotStore.Prepare(ctx)
 	if err != nil {

--- a/turbo/app/snapshots_cmd.go
+++ b/turbo/app/snapshots_cmd.go
@@ -889,7 +889,8 @@ func doIntegrity(cliCtx *cli.Context) error {
 				logger.Info("BorSpans skipped because not bor chain")
 				continue
 			}
-			if err := heimdall.ValidateBorSpans(ctx, logger, dirs, borSnaps, failFast); err != nil {
+			heimdallStore, _ := blockRetire.BorStore()
+			if err := heimdall.ValidateBorSpans(ctx, logger, dirs, heimdallStore, borSnaps, failFast); err != nil {
 				return err
 			}
 		case integrity.BorCheckpoints:
@@ -897,7 +898,8 @@ func doIntegrity(cliCtx *cli.Context) error {
 				logger.Info("BorCheckpoints skipped because not bor chain")
 				continue
 			}
-			if err := heimdall.ValidateBorCheckpoints(ctx, logger, dirs, borSnaps, failFast); err != nil {
+			heimdallStore, _ := blockRetire.BorStore()
+			if err := heimdall.ValidateBorCheckpoints(ctx, logger, dirs, heimdallStore, borSnaps, failFast); err != nil {
 				return err
 			}
 		case integrity.ReceiptsNoDups:


### PR DESCRIPTION
was getting error:


```
mdbx_env_open: resource temporarily unavailable, label: heimdall, trace: [kv_mdbx.go:323 database.go:79 database.go:86 once.go:78 once.go:69 database.go:85 entity_store.go:137 once.go:78 once.go:69 entity_store.go:136 snapshot_store.go:74 snapshot_integrity.go:13 snapshots_cmd.go:892 snapshots_cmd.go:370 command.go:276 command.go:269 command.go:269 app.go:333 app.go:307 main.go:45 proc.go:283 asm_amd64.s:1700]
```