### PR TITLE
qa-tests: avoid cancelling the running Snap Downloader test execution.

### DIFF
--- a/.github/workflows/qa-snap-download.yml
+++ b/.github/workflows/qa-snap-download.yml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   snap-download-test:


### PR DESCRIPTION
To avoid wasting resources, do not cancel the Snap-Downloader test execution.