### PR TITLE
Change Debian package workflow to local reference

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,7 +291,7 @@ jobs:
     name: Debian packages
     needs: [ build-release, test-release ]
     if: always() && contains(needs.build-release.result, 'success') && !contains(needs.test-release.result, 'failure')
-    uses: erigontech/erigon/.github/workflows/reusable-release-build-debian-pkg.yml@main
+    uses: ./.github/workflows/reusable-release-build-debian-pkg.yml
     with:
       application: ${{ needs.build-release.outputs.application }}
       version: ${{ needs.build-release.outputs.parsed-version }}


### PR DESCRIPTION
Better way to implement https://github.com/erigontech/erigon/pull/16228

In this case same reusable workflow would be checked out from the same tag/branch as caller workflow.