### PR TITLE
cherry-pick: Improve performance of blob recovery (#17121)

### DIFF
--- a/cl/das/peer_das.go
+++ b/cl/das/peer_das.go
@@ -82,7 +82,7 @@ func NewPeerDas(
 		blobStorage:       blobStorage,
 		sentinel:          sentinel,
 		ethClock:          ethClock,
-		recoverBlobsQueue: make(chan recoverBlobsRequest, 32),
+		recoverBlobsQueue: make(chan recoverBlobsRequest, 128),
 
 		recoveringMutex: sync.Mutex{},
 		isRecovering:    make(map[common.Hash]bool),
@@ -219,7 +219,7 @@ type recoverBlobsRequest struct {
 func (d *peerdas) blobsRecoverWorker(ctx context.Context) {
 	recover := func(toRecover recoverBlobsRequest) {
 		begin := time.Now()
-		log.Trace("[blobsRecover] recovering blobs", "slot", toRecover.slot, "blockRoot", toRecover.blockRoot)
+		log.Debug("[blobsRecover] recovering blobs", "slot", toRecover.slot, "blockRoot", toRecover.blockRoot)
 		ctx := context.Background()
 		slot, blockRoot := toRecover.slot, toRecover.blockRoot
 		existingColumns, err := d.columnStorage.GetSavedColumnIndex(ctx, slot, blockRoot)
@@ -254,15 +254,19 @@ func (d *peerdas) blobsRecoverWorker(ctx context.Context) {
 				anyColumnSidecar = sidecar
 			}
 		}
+		// recover matrix
+		beginRecoverMatrix := time.Now()
 		numberOfBlobs := uint64(anyColumnSidecar.Column.Len())
 		blobMatrix, err := peerdasutils.RecoverMatrix(matrixEntries, numberOfBlobs)
 		if err != nil {
 			log.Warn("[blobsRecover] failed to recover matrix", "err", err, "slot", slot, "blockRoot", blockRoot, "numberOfBlobs", numberOfBlobs)
 			return
 		}
+		timeRecoverMatrix := time.Since(beginRecoverMatrix)
 		log.Trace("[blobsRecover] recovered matrix", "slot", slot, "blockRoot", blockRoot, "numberOfBlobs", numberOfBlobs)
 
 		// Recover blobs from the matrix
+		beginRecoverBlobs := time.Now()
 		blobSidecars := make([]*cltypes.BlobSidecar, 0, len(blobMatrix))
 		blobCommitments := solid.NewStaticListSSZ[*cltypes.KZGCommitment](int(d.beaconConfig.MaxBlobCommittmentsPerBlock), length.Bytes48)
 		for blobIndex, blobEntries := range blobMatrix {
@@ -304,6 +308,7 @@ func (d *peerdas) blobsRecoverWorker(ctx context.Context) {
 			commitment := cltypes.KZGCommitment(kzgCommitment)
 			blobCommitments.Append(&commitment)
 		}
+		timeRecoverBlobs := time.Since(beginRecoverBlobs)
 		// inclusion proof
 		for i := range len(blobSidecars) {
 			branchProof := blobCommitments.ElementProof(i)
@@ -315,7 +320,6 @@ func (d *peerdas) blobsRecoverWorker(ctx context.Context) {
 				p.Set(index+len(branchProof), anyColumnSidecar.KzgCommitmentsInclusionProof.Get(index))
 			}
 		}
-
 		// Save blobs
 		if err := d.blobStorage.WriteBlobSidecars(ctx, blockRoot, blobSidecars); err != nil {
 			log.Warn("[blobsRecover] failed to write blob sidecars", "err", err, "slot", slot, "blockRoot", blockRoot)
@@ -329,14 +333,19 @@ func (d *peerdas) blobsRecoverWorker(ctx context.Context) {
 			log.Warn("[blobsRecover] failed to get my custody columns", "err", err, "slot", slot, "blockRoot", blockRoot)
 			return
 		}
+		beginRemoveColumns := time.Now()
+		toRemove := []int64{}
 		for _, column := range existingColumns {
 			if _, ok := custodyColumns[column]; !ok {
-				if err := d.columnStorage.RemoveColumnSidecars(ctx, slot, blockRoot, int64(column)); err != nil {
-					log.Warn("[blobsRecover] failed to remove column sidecar", "err", err, "slot", slot, "blockRoot", blockRoot, "column", column)
-				}
+				toRemove = append(toRemove, int64(column))
 			}
 		}
+		if err := d.columnStorage.RemoveColumnSidecars(ctx, slot, blockRoot, toRemove...); err != nil {
+			log.Warn("[blobsRecover] failed to remove column sidecars", "err", err, "slot", slot, "blockRoot", blockRoot, "columns", toRemove)
+		}
+		timeRemoveColumns := time.Since(beginRemoveColumns)
 		// add custody data column if it doesn't exist
+		beginAddColumns := time.Now()
 		for columnIndex := range custodyColumns {
 			exist, err := d.columnStorage.ColumnSidecarExists(ctx, slot, blockRoot, int64(columnIndex))
 			if err != nil {
@@ -374,11 +383,12 @@ func (d *peerdas) blobsRecoverWorker(ctx context.Context) {
 					log.Warn("[blobsRecover] failed to write column sidecar", "err", err, "slot", slot, "blockRoot", blockRoot, "column", columnIndex)
 					continue
 				}
-				log.Debug("[blobsRecover] added a custody data column", "slot", slot, "blockRoot", blockRoot, "column", columnIndex)
+				log.Trace("[blobsRecover] added a custody data column", "slot", slot, "blockRoot", blockRoot, "column", columnIndex)
 			}
 		}
-
-		log.Debug("[blobsRecover] recovering done", "slot", slot, "blockRoot", blockRoot, "numberOfBlobs", numberOfBlobs, "elapsedTime", time.Since(begin))
+		timeAddColumns := time.Since(beginAddColumns)
+		log.Debug("[blobsRecover] recovering done", "slot", slot, "blockRoot", blockRoot, "numberOfBlobs", numberOfBlobs, "elapsedTime", time.Since(begin),
+			"timeRecoverMatrix", timeRecoverMatrix, "timeRecoverBlobs", timeRecoverBlobs, "timeRemoveColumns", timeRemoveColumns, "timeAddColumns", timeAddColumns)
 	}
 
 	// main loop
@@ -429,7 +439,6 @@ func (d *peerdas) TryScheduleRecover(slot uint64, blockRoot common.Hash) error {
 	d.recoveringMutex.Unlock()
 
 	// schedule
-	log.Debug("[blobsRecover] scheduling recover", "slot", slot, "blockRoot", blockRoot)
 	timer := time.NewTimer(3 * time.Second)
 	defer timer.Stop()
 	select {

--- a/cl/persistence/blob_storage/data_column_db.go
+++ b/cl/persistence/blob_storage/data_column_db.go
@@ -37,8 +37,11 @@ type dataColumnStorageImpl struct {
 	slotsKept         uint64
 	emitters          *beaconevents.EventEmitter
 
-	lock sync.RWMutex
+	//lock sync.RWMutex
+	rwLocks []sync.RWMutex
 }
+
+const rwLocksCount = 64
 
 func NewDataColumnStore(fs afero.Fs, slotsKept uint64, beaconChainConfig *clparams.BeaconChainConfig, ethClock eth_clock.EthereumClock, emitters *beaconevents.EventEmitter) DataColumnStorage {
 	impl := &dataColumnStorageImpl{
@@ -47,8 +50,13 @@ func NewDataColumnStore(fs afero.Fs, slotsKept uint64, beaconChainConfig *clpara
 		ethClock:          ethClock,
 		slotsKept:         slotsKept,
 		emitters:          emitters,
+		rwLocks:           make([]sync.RWMutex, rwLocksCount),
 	}
 	return impl
+}
+
+func (s *dataColumnStorageImpl) acquireLock(slot uint64) *sync.RWMutex {
+	return &s.rwLocks[slot%rwLocksCount]
 }
 
 func dataColumnFilePath(slot uint64, blockRoot common.Hash, columnIndex uint64) (dir, filepath string) {
@@ -59,8 +67,9 @@ func dataColumnFilePath(slot uint64, blockRoot common.Hash, columnIndex uint64) 
 }
 
 func (s *dataColumnStorageImpl) WriteColumnSidecars(ctx context.Context, blockRoot common.Hash, columnIndex int64, columnData *cltypes.DataColumnSidecar) error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	lock := s.acquireLock(columnData.SignedBlockHeader.Header.Slot)
+	lock.Lock()
+	defer lock.Unlock()
 	dir, filepath := dataColumnFilePath(columnData.SignedBlockHeader.Header.Slot, blockRoot, uint64(columnIndex))
 	if err := s.fs.MkdirAll(dir, 0755); err != nil {
 		return err
@@ -92,8 +101,9 @@ func (s *dataColumnStorageImpl) WriteColumnSidecars(ctx context.Context, blockRo
 }
 
 func (s *dataColumnStorageImpl) ReadColumnSidecarByColumnIndex(ctx context.Context, slot uint64, blockRoot common.Hash, columnIndex int64) (*cltypes.DataColumnSidecar, error) {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
+	lock := s.acquireLock(slot)
+	lock.RLock()
+	defer lock.RUnlock()
 	_, filepath := dataColumnFilePath(slot, blockRoot, uint64(columnIndex))
 	fh, err := s.fs.Open(filepath)
 	if err != nil {
@@ -109,8 +119,9 @@ func (s *dataColumnStorageImpl) ReadColumnSidecarByColumnIndex(ctx context.Conte
 }
 
 func (s *dataColumnStorageImpl) ColumnSidecarExists(ctx context.Context, slot uint64, blockRoot common.Hash, columnIndex int64) (bool, error) {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
+	lock := s.acquireLock(slot)
+	lock.RLock()
+	defer lock.RUnlock()
 	_, filepath := dataColumnFilePath(slot, blockRoot, uint64(columnIndex))
 	if _, err := s.fs.Stat(filepath); os.IsNotExist(err) {
 		return false, nil
@@ -121,8 +132,9 @@ func (s *dataColumnStorageImpl) ColumnSidecarExists(ctx context.Context, slot ui
 }
 
 func (s *dataColumnStorageImpl) RemoveAllColumnSidecars(ctx context.Context, slot uint64, blockRoot common.Hash) error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	lock := s.acquireLock(slot)
+	lock.Lock()
+	defer lock.Unlock()
 	for i := uint64(0); i < s.beaconChainConfig.NumberOfColumns; i++ {
 		_, filepath := dataColumnFilePath(slot, blockRoot, i)
 		s.fs.Remove(filepath)
@@ -131,8 +143,9 @@ func (s *dataColumnStorageImpl) RemoveAllColumnSidecars(ctx context.Context, slo
 }
 
 func (s *dataColumnStorageImpl) RemoveColumnSidecars(ctx context.Context, slot uint64, blockRoot common.Hash, columnIndices ...int64) error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	lock := s.acquireLock(slot)
+	lock.Lock()
+	defer lock.Unlock()
 	for _, index := range columnIndices {
 		_, filepath := dataColumnFilePath(slot, blockRoot, uint64(index))
 		if err := s.fs.Remove(filepath); err != nil {
@@ -147,8 +160,9 @@ func (s *dataColumnStorageImpl) RemoveColumnSidecars(ctx context.Context, slot u
 }
 
 func (s *dataColumnStorageImpl) WriteStream(w io.Writer, slot uint64, blockRoot common.Hash, idx uint64) error {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
+	lock := s.acquireLock(slot)
+	lock.RLock()
+	defer lock.RUnlock()
 	_, filepath := dataColumnFilePath(slot, blockRoot, idx)
 	fh, err := s.fs.Open(filepath)
 	if err != nil {
@@ -161,8 +175,9 @@ func (s *dataColumnStorageImpl) WriteStream(w io.Writer, slot uint64, blockRoot 
 
 // GetSavedColumnIndex returns the list of saved column indices for the given slot and block root.
 func (s *dataColumnStorageImpl) GetSavedColumnIndex(ctx context.Context, slot uint64, blockRoot common.Hash) ([]uint64, error) {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
+	lock := s.acquireLock(slot)
+	lock.RLock()
+	defer lock.RUnlock()
 	var savedColumns []uint64
 	for i := uint64(0); i < s.beaconChainConfig.NumberOfColumns; i++ {
 		_, filepath := dataColumnFilePath(slot, blockRoot, i)
@@ -177,8 +192,6 @@ func (s *dataColumnStorageImpl) GetSavedColumnIndex(ctx context.Context, slot ui
 }
 
 func (s *dataColumnStorageImpl) Prune(keepSlotDistance uint64) error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
 	currentSlot := s.ethClock.GetCurrentSlot()
 	currentSlot -= keepSlotDistance
 	currentSlot = (currentSlot / subdivisionSlot) * subdivisionSlot
@@ -189,7 +202,11 @@ func (s *dataColumnStorageImpl) Prune(keepSlotDistance uint64) error {
 	}
 	// delete all the folders that are older than slotsKept
 	for i := startPrune; i < currentSlot; i += subdivisionSlot {
+		log.Debug("pruning data column sidecars", "slot", i)
+		lock := s.acquireLock(i)
+		lock.Lock()
 		s.fs.RemoveAll(strconv.FormatUint(i/subdivisionSlot, 10))
+		lock.Unlock()
 	}
 	return nil
 }


### PR DESCRIPTION
It takes too much time to wait for and acquire a single lock, so try to avoid lock contention by using lock striping.