### PR TITLE
qa_tests: ensure same block for RPC tests on latest

### DIFF
--- a/.github/workflows/scripts/run_rpc_tests_ethereum_latest.sh
+++ b/.github/workflows/scripts/run_rpc_tests_ethereum_latest.sh
@@ -28,4 +28,4 @@ DISABLED_TEST_LIST=(
 DISABLED_TESTS=$(IFS=,; echo "${DISABLED_TEST_LIST[*]}")
 
 # Call the main test runner script with the required and optional parameters
-"$(dirname "$0")/run_rpc_tests.sh" mainnet v1.80.3 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR" "latest" "$REFERENCE_HOST" "do-not-compare-error-message"
+"$(dirname "$0")/run_rpc_tests.sh" mainnet v1.87.0 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR" "latest" "$REFERENCE_HOST" "do-not-compare-error-message"


### PR DESCRIPTION
Before starting the RPC Integration Tests on latest block, the test framework verifies that both Erigon and reference system are synchronised to the same block. If not, it waits until this condition is met