### PR TITLE
Remove unnecessary docker login for kurtosis CI tests

### DIFF
--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -23,12 +23,6 @@ jobs:
       - name: Fast checkout git repository
         uses: actions/checkout@v5
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME }}
-          password: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_TOKEN }}
-
       - name: Docker build current branch
         run: |
           docker build -t test/erigon:current .
@@ -48,12 +42,6 @@ jobs:
     steps:
       - name: Fast checkout git repository
         uses: actions/checkout@v5
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  ## v3.3.0
-        with:
-          username: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_USERNAME }}
-          password: ${{ secrets.ORG_DOCKERHUB_ERIGONTECH_TOKEN }}
 
       - name: Docker build current branch
         run: |


### PR DESCRIPTION
There's a docker login that prevents tests from running for PRs from repos (and thus external contributors) from passing, such as in https://github.com/erigontech/erigon/pull/17072. Looks like it's not necessary.