### PR TITLE
Enable eth/69, drop eth/67

### DIFF
--- a/node/nodecfg/defaults.go
+++ b/node/nodecfg/defaults.go
@@ -48,7 +48,7 @@ var DefaultConfig = Config{
 	WSModules:        []string{"net", "web3"},
 	P2P: p2p.Config{
 		ListenAddr:      ":30303",
-		ProtocolVersion: []uint{direct.ETH68, direct.ETH67},
+		ProtocolVersion: []uint{direct.ETH68, direct.ETH69, direct.ETH67}, // Keep eth/68 in first index for Hive tests
 		MaxPeers:        32,
 		MaxPendingPeers: 1000,
 		NAT:             nat.Any(),

--- a/node/nodecfg/defaults.go
+++ b/node/nodecfg/defaults.go
@@ -48,7 +48,7 @@ var DefaultConfig = Config{
 	WSModules:        []string{"net", "web3"},
 	P2P: p2p.Config{
 		ListenAddr:      ":30303",
-		ProtocolVersion: []uint{direct.ETH68, direct.ETH69, direct.ETH67}, // Keep eth/68 in first index for Hive tests
+		ProtocolVersion: []uint{direct.ETH68, direct.ETH69}, // Keep eth/68 in first index for Hive tests
 		MaxPeers:        32,
 		MaxPendingPeers: 1000,
 		NAT:             nat.Any(),

--- a/txnprovider/txpool/tests/helper/p2p_client.go
+++ b/txnprovider/txpool/tests/helper/p2p_client.go
@@ -53,7 +53,7 @@ func (p *p2pClient) Connect() (<-chan TxMessage, <-chan error, error) {
 	cfg := &p2p.Config{
 		ListenAddr:      ":30307",
 		AllowedPorts:    []uint{30303, 30304, 30305, 30306, 30307},
-		ProtocolVersion: []uint{direct.ETH69, direct.ETH68, direct.ETH67},
+		ProtocolVersion: []uint{direct.ETH69, direct.ETH68},
 		MaxPeers:        32,
 		MaxPendingPeers: 1000,
 		NAT:             nat.Any(),


### PR DESCRIPTION
Keep eth/68 on port 30303 to keep Hive tests passing for now.

Hive test run: https://github.com/erigontech/erigon/actions/runs/17908526341/job/50914448868