### PR TITLE
validate domain progress in integrity

### DIFF
--- a/eth/integrity/rcache_no_duplicates.go
+++ b/eth/integrity/rcache_no_duplicates.go
@@ -13,7 +13,6 @@ import (
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/rawdb"
-	"github.com/erigontech/erigon/execution/stagedsync/stages"
 	"github.com/erigontech/erigon/turbo/services"
 )
 
@@ -37,29 +36,11 @@ func CheckRCacheNoDups(ctx context.Context, db kv.TemporalRoDB, blockReader serv
 	fromBlock := uint64(1)
 	toBlock, _, _ := txNumsReader.FindBlockNum(tx, rcacheDomainProgress)
 
-	{
-		log.Info("[integrity] RCacheNoDups starting", "fromBlock", fromBlock, "toBlock", toBlock)
-		accProgress := tx.Debug().DomainProgress(kv.AccountsDomain)
-		diff := int(rcacheDomainProgress - accProgress)
-		if diff != 0 && diff != 1 {
-			// if no system tx -- nil is stored in rcache; so it might be atmost 1 ahead of accounts.
-			var execProgressBlock, execStartTxNum, execEndTxNum uint64
-			if execProgressBlock, err = stages.GetStageProgress(tx, stages.Execution); err != nil {
-				return err
-			}
-			if execStartTxNum, err = txNumsReader.Min(tx, execProgressBlock); err != nil {
-				return nil
-			}
-			if execEndTxNum, err = txNumsReader.Max(tx, execProgressBlock); err != nil {
-				return nil
-			}
-			err := fmt.Errorf("[integrity] RCacheDomain=%d (block=%d) not equal AccountDomain=%d, while execBlockProgress(block=%d, startTxNum=%d, endTxNum=%d)", rcacheDomainProgress, toBlock, accProgress, execProgressBlock, execStartTxNum, execEndTxNum)
-			log.Warn(err.Error())
-			return err
-		}
+	if err := ValidateDomainProgress(db, kv.RCacheDomain, txNumsReader); err != nil {
+		return err
 	}
 
-	tx.Rollback()
+	log.Info("[integrity] RCacheNoDups starting", "fromBlock", fromBlock, "toBlock", toBlock)
 
 	defer db.Debug().EnableReadAhead().DisableReadAhead()
 	return parallelChunkCheck(ctx, fromBlock, toBlock, db, blockReader, failFast, RCacheNoDupsRange)

--- a/eth/integrity/receipts_no_duplicates.go
+++ b/eth/integrity/receipts_no_duplicates.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/rawdbv3"
 	"github.com/erigontech/erigon/db/rawdb/rawtemporaldb"
 	"github.com/erigontech/erigon/turbo/services"
 )
@@ -23,6 +24,10 @@ func CheckReceiptsNoDups(ctx context.Context, db kv.TemporalRoDB, blockReader se
 
 	txNumsReader := blockReader.TxnumReader(ctx)
 
+	if err := ValidateDomainProgress(db, kv.ReceiptDomain, txNumsReader); err != nil {
+		return nil
+	}
+
 	tx, err := db.BeginTemporalRo(ctx)
 	if err != nil {
 		return err
@@ -30,19 +35,10 @@ func CheckReceiptsNoDups(ctx context.Context, db kv.TemporalRoDB, blockReader se
 	defer tx.Rollback()
 
 	receiptProgress := tx.Debug().DomainProgress(kv.ReceiptDomain)
-
 	fromBlock := uint64(1)
 	toBlock, _, _ := txNumsReader.FindBlockNum(tx, receiptProgress)
 
-	{
-		log.Info("[integrity] ReceiptsNoDups starting", "fromBlock", fromBlock, "toBlock", toBlock)
-		accProgress := tx.Debug().DomainProgress(kv.AccountsDomain)
-		if accProgress != receiptProgress {
-			err := fmt.Errorf("[integrity] ReceiptDomain=%d is behind AccountDomain=%d", receiptProgress, accProgress)
-			log.Warn(err.Error())
-		}
-	}
-	tx.Rollback()
+	log.Info("[integrity] ReceiptsNoDups starting", "fromBlock", fromBlock, "toBlock", toBlock)
 
 	return parallelChunkCheck(ctx, fromBlock, toBlock, db, blockReader, failFast, ReceiptsNoDupsRange)
 }
@@ -115,6 +111,41 @@ func ReceiptsNoDupsRange(ctx context.Context, fromBlock, toBlock uint64, tx kv.T
 			default:
 			}
 		}
+	}
+	return nil
+}
+
+func ValidateDomainProgress(db kv.TemporalRoDB, domain kv.Domain, txNumsReader rawdbv3.TxNumsReader) (err error) {
+	tx, err := db.BeginTemporalRo(context.Background())
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	receiptProgress := tx.Debug().DomainProgress(domain)
+	accProgress := tx.Debug().DomainProgress(kv.AccountsDomain)
+	if accProgress > receiptProgress {
+		e1, _, _ := txNumsReader.FindBlockNum(tx, receiptProgress)
+		e2, _, _ := txNumsReader.FindBlockNum(tx, accProgress)
+
+		// accProgress can be greater than domainProgress in some scenarios..
+		// e.g. account vs receipt
+		// like systemTx can update accounts, but no receipt is added for those tx.
+		// Similarly a series of empty blocks towards the end can cause big gaps...
+		// The message is kept because it might also happen due to problematic cases
+		// like StageCustomTrace execution not having gone through to the end leading to missing data in receipt/rcache.
+		msg := fmt.Sprintf("[integrity] %s=%d (%d) is behind AccountDomain=%d(%d); this might be okay, please check", domain.String(), receiptProgress, e1, accProgress, e2)
+		log.Warn(msg)
+		return nil
+	} else if accProgress < receiptProgress {
+		// something very wrong
+		e1, _, _ := txNumsReader.FindBlockNum(tx, receiptProgress)
+		e2, _, _ := txNumsReader.FindBlockNum(tx, accProgress)
+
+		err := fmt.Errorf("[integrity] %s=%d (%d) is ahead of AccountDomain=%d(%d)", domain.String(), receiptProgress, e1, accProgress, e2)
+		log.Error(err.Error())
+		return err
+
 	}
 	return nil
 }

--- a/execution/stagedsync/stage_custom_trace.go
+++ b/execution/stagedsync/stage_custom_trace.go
@@ -33,7 +33,6 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/backup"
 	"github.com/erigontech/erigon/db/kv/kvcfg"
-	"github.com/erigontech/erigon/db/kv/rawdbv3"
 	"github.com/erigontech/erigon/db/rawdb"
 	"github.com/erigontech/erigon/db/rawdb/rawtemporaldb"
 	"github.com/erigontech/erigon/db/snapshotsync/freezeblocks"
@@ -185,12 +184,12 @@ Loop:
 
 	log.Info("SpawnCustomTrace finish")
 	if cfg.Produce.ReceiptDomain {
-		if err := AssertNotBehindAccounts(cfg.db, kv.ReceiptDomain, txNumsReader); err != nil {
+		if err := integrity.ValidateDomainProgress(cfg.db, kv.ReceiptDomain, txNumsReader); err != nil {
 			return err
 		}
 	}
 	if cfg.Produce.RCacheDomain {
-		if err := AssertNotBehindAccounts(cfg.db, kv.RCacheDomain, txNumsReader); err != nil {
+		if err := integrity.ValidateDomainProgress(cfg.db, kv.RCacheDomain, txNumsReader); err != nil {
 			return err
 		}
 	}
@@ -272,26 +271,6 @@ func customTraceBatchProduce(ctx context.Context, produce Produce, cfg *exec3.Ex
 		return err
 	}
 
-	return nil
-}
-
-func AssertNotBehindAccounts(db kv.TemporalRoDB, domain kv.Domain, txNumsReader rawdbv3.TxNumsReader) (err error) {
-	tx, err := db.BeginTemporalRo(context.Background())
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback()
-
-	receiptProgress := tx.Debug().DomainProgress(domain)
-	accProgress := tx.Debug().DomainProgress(kv.AccountsDomain)
-	if accProgress != receiptProgress {
-		e1, _, _ := txNumsReader.FindBlockNum(tx, receiptProgress)
-		e2, _, _ := txNumsReader.FindBlockNum(tx, accProgress)
-
-		err := fmt.Errorf("[integrity] %s=%d (%d) is behind AccountDomain=%d(%d)", domain.String(), receiptProgress, e1, accProgress, e2)
-		log.Warn(err.Error())
-		return nil
-	}
 	return nil
 }
 


### PR DESCRIPTION
- do not throw error, but print warning when domain progress < account progress
- rename `AssertNotBehindAccounts` -> `ValidateDomainProgress`
- use `ValidateDomainProgress` in integrity check
- some comments to indicate why the above might happen
- fix check for rcache (which would fail for consecutive empty blocks causing `diff > 1`)