### PR TITLE
execution/tests: add retry to engine api tests for no connection on win

### DIFF
--- a/execution/tests/engine_api_tester.go
+++ b/execution/tests/engine_api_tester.go
@@ -213,7 +213,11 @@ func InitialiseEngineApiTester(t *testing.T, args EngineApiTesterInitArgs) Engin
 		// requests should not take more than 5 secs in a test env, yet we can spam frequently
 		engineapi.WithJsonRpcClientRetryBackOff(50*time.Millisecond),
 		engineapi.WithJsonRpcClientMaxRetries(100),
-		engineapi.WithRetryableErrCheckers(engineapi.ErrContainsRetryableErrChecker("connection refused")),
+		engineapi.WithRetryableErrCheckers(
+			engineapi.ErrContainsRetryableErrChecker("connection refused"),
+			// below happened on win CI
+			engineapi.ErrContainsRetryableErrChecker("No connection could be made because the target machine actively refused it"),
+		),
 	)
 	require.NoError(t, err)
 	var mockCl *MockCl


### PR DESCRIPTION
after https://github.com/erigontech/erigon/pull/17164 we got a flake in this [run](https://github.com/erigontech/erigon/actions/runs/17908063097/job/50913085203) with:
```
engine_api_tester.go:223: 
Error Trace:	github.com/erigontech/erigon/execution/tests/engine_api_tester.go:223
			     github.com/erigontech/erigon/execution/tests/engine_api_tester.go:63
		             github.com/erigontech/erigon/execution/tests/engine_api_reorg_test.go:34
Error:      	Received unexpected error:
            	Post "http://127.0.0.1:58525/": dial tcp 127.0.0.1:58525: connectex: No connection could be made because the target machine actively refused it.
Test:       	TestEngineApiInvalidPayloadThenValidCanonicalFcuWithPayloadShouldSucceed
```

adding the corresponding err to the retry-able errors for the engine api tester (it is an initialisation timing err)