### PR TITLE
tests: fix flaky tip event channel tests

### DIFF
--- a/polygon/sync/event_channel_test.go
+++ b/polygon/sync/event_channel_test.go
@@ -18,10 +18,12 @@ package sync
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/erigontech/erigon-lib/synctest"
 )
 
 func TestEventChannel(t *testing.T) {
@@ -59,24 +61,26 @@ func TestEventChannel(t *testing.T) {
 	})
 
 	t.Run("ConsumeEvents", func(t *testing.T) {
-		ctx := t.Context()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context() // cancelled before t.Cleanup()
+			ch := NewEventChannel[string](2)
+			eg := errgroup.Group{}
+			eg.Go(func() error {
+				return ch.Run(ctx)
+			})
+			t.Cleanup(func() {
+				err := eg.Wait()
+				require.ErrorIs(t, err, context.Canceled)
+			})
 
-		ch := NewEventChannel[string](2)
+			ch.PushEvent("event1")
+			ch.PushEvent("event2")
+			ch.PushEvent("event3")
 
-		go func() {
-			err := ch.Run(ctx)
-			if !errors.Is(err, context.Canceled) {
-				panic("expected another error")
-			}
-		}()
-
-		ch.PushEvent("event1")
-		ch.PushEvent("event2")
-		ch.PushEvent("event3")
-
-		events := ch.Events()
-		require.Equal(t, "event2", <-events)
-		require.Equal(t, "event3", <-events)
-		require.Empty(t, events)
+			events := ch.Events()
+			require.Equal(t, "event2", <-events)
+			require.Equal(t, "event3", <-events)
+			require.Empty(t, events)
+		})
 	})
 }

--- a/polygon/sync/tip_events_test.go
+++ b/polygon/sync/tip_events_test.go
@@ -19,13 +19,13 @@ package sync
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/erigontech/erigon-lib/common"
 	"github.com/erigontech/erigon-lib/log/v3"
+	"github.com/erigontech/erigon-lib/synctest"
 	"github.com/erigontech/erigon-lib/testlog"
 	"github.com/erigontech/erigon/execution/p2p"
 )
@@ -49,35 +49,33 @@ func TestBlockEventsSpamGuard(t *testing.T) {
 
 func TestTipEventsCompositeChannel(t *testing.T) {
 	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		heimdallEvents := NewEventChannel[Event](3)
+		p2pEvents := NewEventChannel[Event](2)
+		ch := NewTipEventsCompositeChannel(heimdallEvents, p2pEvents)
+		ctx := t.Context() // cancelled before t.Cleanup()
+		eg := errgroup.Group{}
+		eg.Go(func() error {
+			return ch.Run(ctx)
+		})
+		t.Cleanup(func() {
+			err := eg.Wait()
+			require.ErrorIs(t, err, context.Canceled)
+		})
 
-	heimdallEvents := NewEventChannel[Event](3)
-	p2pEvents := NewEventChannel[Event](2)
-	ch := NewTipEventsCompositeChannel(heimdallEvents, p2pEvents)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	t.Cleanup(cancel)
+		ch.PushEvent(Event{Type: EventTypeNewMilestone})
+		ch.PushEvent(Event{Type: EventTypeNewBlockHashes}) // should be dropped due to the following 2 events
+		ch.PushEvent(Event{Type: EventTypeNewBlock})
+		ch.PushEvent(Event{Type: EventTypeNewBlockHashes})
 
-	eg, ctx := errgroup.WithContext(ctx)
-	eg.Go(func() error {
-		err := ch.Run(ctx)
-		println(err)
-		return err
+		events := make([]EventType, 3)
+		events[0] = read(ctx, t, ch.Events()).Type
+		events[1] = read(ctx, t, ch.Events()).Type
+		events[2] = read(ctx, t, ch.Events()).Type
+		require.ElementsMatch(t, events, []EventType{EventTypeNewMilestone, EventTypeNewBlock, EventTypeNewBlockHashes})
+		require.Empty(t, ch.heimdallEventsChannel.events)
+		require.Empty(t, ch.p2pEventsChannel.events)
 	})
-
-	ch.PushEvent(Event{Type: EventTypeNewMilestone})
-	ch.PushEvent(Event{Type: EventTypeNewBlockHashes}) // should be dropped due to the following 2 events
-	ch.PushEvent(Event{Type: EventTypeNewBlock})
-	ch.PushEvent(Event{Type: EventTypeNewBlockHashes})
-
-	events := make([]EventType, 3)
-	events[0] = read(ctx, t, ch.Events()).Type
-	events[1] = read(ctx, t, ch.Events()).Type
-	events[2] = read(ctx, t, ch.Events()).Type
-	require.ElementsMatch(t, events, []EventType{EventTypeNewMilestone, EventTypeNewBlock, EventTypeNewBlockHashes})
-	require.Empty(t, ch.heimdallEventsChannel.events)
-	require.Empty(t, ch.p2pEventsChannel.events)
-	cancel()
-	err := eg.Wait()
-	require.ErrorIs(t, err, context.Canceled)
 }
 
 func read(ctx context.Context, t *testing.T, ch <-chan Event) Event {


### PR DESCRIPTION
closes https://github.com/erigontech/erigon/issues/15463

recently got a flaky failure on one of my commits in main, e.g. [run](https://github.com/erigontech/erigon/actions/runs/17918145317/job/50945738531)

easy to fix using go1.24+ `synctest` pkg

```
➜ go test -count 1000 -race -run '^TestTipEventsCompositeChannel$' ./polygon/sync 
ok      github.com/erigontech/erigon/polygon/sync       33.349s

➜ go test -count 1000 -race -run '^TestEventChannel$' ./polygon/sync            
ok      github.com/erigontech/erigon/polygon/sync       31.913s
```