### PR TITLE
rawdbreset: correct error message when saving Headers progress

### DIFF
--- a/eth/rawdbreset/reset_stages.go
+++ b/eth/rawdbreset/reset_stages.go
@@ -70,7 +70,7 @@ func ResetBlocks(tx kv.RwTx, db kv.RoDB, br services.FullBlockReader, bw *blocki
 		return fmt.Errorf("saving Bodies progress failed: %w", err)
 	}
 	if err := stages.SaveStageProgress(tx, stages.Headers, 1); err != nil {
-		return fmt.Errorf("saving Bodies progress failed: %w", err)
+		return fmt.Errorf("saving Headers progress failed: %w", err)
 	}
 	if err := stages.SaveStageProgress(tx, stages.Snapshots, 0); err != nil {
 		return fmt.Errorf("saving Snapshots progress failed: %w", err)


### PR DESCRIPTION
The error string for the Headers progress save incorrectly referenced “Bodies,” likely due to copy/paste. This change aligns the error message with the actual stage being saved, improving log accuracy and debuggability.