### PR TITLE
rpcdaemon: trace_filter:  support block tags 

### DIFF
--- a/.github/workflows/scripts/run_rpc_tests_ethereum.sh
+++ b/.github/workflows/scripts/run_rpc_tests_ethereum.sh
@@ -44,4 +44,4 @@ DISABLED_TEST_LIST=(
 DISABLED_TESTS=$(IFS=,; echo "${DISABLED_TEST_LIST[*]}")
 
 # Call the main test runner script with the required and optional parameters
-"$(dirname "$0")/run_rpc_tests.sh" mainnet v1.89.0 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR"
+"$(dirname "$0")/run_rpc_tests.sh" mainnet v1.90.0 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR"

--- a/.github/workflows/scripts/run_rpc_tests_ethereum.sh
+++ b/.github/workflows/scripts/run_rpc_tests_ethereum.sh
@@ -44,4 +44,4 @@ DISABLED_TEST_LIST=(
 DISABLED_TESTS=$(IFS=,; echo "${DISABLED_TEST_LIST[*]}")
 
 # Call the main test runner script with the required and optional parameters
-"$(dirname "$0")/run_rpc_tests.sh" mainnet v1.90.0 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR"
+"$(dirname "$0")/run_rpc_tests.sh" mainnet v1.90.1 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR"

--- a/.github/workflows/scripts/run_rpc_tests_ethereum_latest.sh
+++ b/.github/workflows/scripts/run_rpc_tests_ethereum_latest.sh
@@ -38,4 +38,4 @@ DISABLED_TEST_LIST=(
 DISABLED_TESTS=$(IFS=,; echo "${DISABLED_TEST_LIST[*]}")
 
 # Call the main test runner script with the required and optional parameters
-"$(dirname "$0")/run_rpc_tests.sh" mainnet v1.90.0 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR" "latest" "$REFERENCE_HOST" "do-not-compare-error-message"
+"$(dirname "$0")/run_rpc_tests.sh" mainnet v1.90.1 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR" "latest" "$REFERENCE_HOST" "do-not-compare-error-message"

--- a/.github/workflows/scripts/run_rpc_tests_ethereum_latest.sh
+++ b/.github/workflows/scripts/run_rpc_tests_ethereum_latest.sh
@@ -38,4 +38,4 @@ DISABLED_TEST_LIST=(
 DISABLED_TESTS=$(IFS=,; echo "${DISABLED_TEST_LIST[*]}")
 
 # Call the main test runner script with the required and optional parameters
-"$(dirname "$0")/run_rpc_tests.sh" mainnet v1.89.0 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR" "latest" "$REFERENCE_HOST" "do-not-compare-error-message"
+"$(dirname "$0")/run_rpc_tests.sh" mainnet v1.90.0 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR" "latest" "$REFERENCE_HOST" "do-not-compare-error-message"

--- a/.github/workflows/scripts/run_rpc_tests_gnosis.sh
+++ b/.github/workflows/scripts/run_rpc_tests_gnosis.sh
@@ -22,5 +22,5 @@ DISABLED_TEST_LIST=(
 DISABLED_TESTS=$(IFS=,; echo "${DISABLED_TEST_LIST[*]}")
 
 # Call the main test runner script with the required and optional parameters
-"$(dirname "$0")/run_rpc_tests.sh" gnosis v1.90.0 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR"
+"$(dirname "$0")/run_rpc_tests.sh" gnosis v1.90.1 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR"
 

--- a/.github/workflows/scripts/run_rpc_tests_gnosis.sh
+++ b/.github/workflows/scripts/run_rpc_tests_gnosis.sh
@@ -22,5 +22,5 @@ DISABLED_TEST_LIST=(
 DISABLED_TESTS=$(IFS=,; echo "${DISABLED_TEST_LIST[*]}")
 
 # Call the main test runner script with the required and optional parameters
-"$(dirname "$0")/run_rpc_tests.sh" gnosis v1.88.1 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR"
+"$(dirname "$0")/run_rpc_tests.sh" gnosis v1.90.0 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR"
 

--- a/rpc/jsonrpc/call_traces_test.go
+++ b/rpc/jsonrpc/call_traces_test.go
@@ -28,11 +28,11 @@ import (
 	"github.com/valyala/fastjson"
 
 	"github.com/erigontech/erigon-lib/common"
-	"github.com/erigontech/erigon-lib/common/hexutil"
 	"github.com/erigontech/erigon/cmd/rpcdaemon/cli/httpcfg"
 	"github.com/erigontech/erigon/core"
 	"github.com/erigontech/erigon/execution/stages/mock"
 	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/rpc"
 	"github.com/erigontech/erigon/rpc/jsonstream"
 )
 
@@ -76,13 +76,12 @@ func TestCallTraceOneByOne(t *testing.T) {
 	s := jsoniter.ConfigDefault.BorrowStream(nil)
 	defer jsoniter.ConfigDefault.ReturnStream(s)
 	stream := jsonstream.Wrap(s)
-	var fromBlock, toBlock uint64
-	fromBlock = 1
-	toBlock = 10
+	fromBlock := rpc.BlockNumber(1)
+	toBlock := rpc.BlockNumber(10)
 	toAddress1 := common.Address{1}
 	traceReq1 := TraceFilterRequest{
-		FromBlock: (*hexutil.Uint64)(&fromBlock),
-		ToBlock:   (*hexutil.Uint64)(&toBlock),
+		FromBlock: &rpc.BlockNumberOrHash{BlockNumber: &fromBlock},
+		ToBlock:   &rpc.BlockNumberOrHash{BlockNumber: &toBlock},
 		ToAddress: []*common.Address{&toAddress1},
 	}
 	if err = api.Filter(context.Background(), traceReq1, new(bool), nil, stream); err != nil {
@@ -120,13 +119,12 @@ func TestCallTraceUnwind(t *testing.T) {
 	s := jsoniter.ConfigDefault.BorrowStream(nil)
 	defer jsoniter.ConfigDefault.ReturnStream(s)
 	stream := jsonstream.Wrap(s)
-	var fromBlock, toBlock uint64
-	fromBlock = 1
-	toBlock = 10
+	fromBlock := rpc.BlockNumber(1)
+	toBlock := rpc.BlockNumber(10)
 	toAddress1 := common.Address{1}
 	traceReq1 := TraceFilterRequest{
-		FromBlock: (*hexutil.Uint64)(&fromBlock),
-		ToBlock:   (*hexutil.Uint64)(&toBlock),
+		FromBlock: &rpc.BlockNumberOrHash{BlockNumber: &fromBlock},
+		ToBlock:   &rpc.BlockNumberOrHash{BlockNumber: &toBlock},
 		ToAddress: []*common.Address{&toAddress1},
 	}
 	if err = api.Filter(context.Background(), traceReq1, new(bool), nil, stream); err != nil {
@@ -140,8 +138,8 @@ func TestCallTraceUnwind(t *testing.T) {
 	stream.Reset(nil)
 	toBlock = 12
 	traceReq2 := TraceFilterRequest{
-		FromBlock: (*hexutil.Uint64)(&fromBlock),
-		ToBlock:   (*hexutil.Uint64)(&toBlock),
+		FromBlock: &rpc.BlockNumberOrHash{BlockNumber: &fromBlock},
+		ToBlock:   &rpc.BlockNumberOrHash{BlockNumber: &toBlock},
 		ToAddress: []*common.Address{&toAddress1},
 	}
 	if err = api.Filter(context.Background(), traceReq2, new(bool), nil, stream); err != nil {
@@ -156,8 +154,8 @@ func TestCallTraceUnwind(t *testing.T) {
 	fromBlock = 12
 	toBlock = 20
 	traceReq3 := TraceFilterRequest{
-		FromBlock: (*hexutil.Uint64)(&fromBlock),
-		ToBlock:   (*hexutil.Uint64)(&toBlock),
+		FromBlock: &rpc.BlockNumberOrHash{BlockNumber: &fromBlock},
+		ToBlock:   &rpc.BlockNumberOrHash{BlockNumber: &toBlock},
 		ToAddress: []*common.Address{&toAddress1},
 	}
 	if err = api.Filter(context.Background(), traceReq3, new(bool), nil, stream); err != nil {
@@ -184,12 +182,11 @@ func TestFilterNoAddresses(t *testing.T) {
 	s := jsoniter.ConfigDefault.BorrowStream(nil)
 	defer jsoniter.ConfigDefault.ReturnStream(s)
 	stream := jsonstream.Wrap(s)
-	var fromBlock, toBlock uint64
-	fromBlock = 1
-	toBlock = 10
+	fromBlock := rpc.BlockNumber(1)
+	toBlock := rpc.BlockNumber(10)
 	traceReq1 := TraceFilterRequest{
-		FromBlock: (*hexutil.Uint64)(&fromBlock),
-		ToBlock:   (*hexutil.Uint64)(&toBlock),
+		FromBlock: &rpc.BlockNumberOrHash{BlockNumber: &fromBlock},
+		ToBlock:   &rpc.BlockNumberOrHash{BlockNumber: &toBlock},
 	}
 	if err = api.Filter(context.Background(), traceReq1, new(bool), nil, stream); err != nil {
 		t.Fatalf("trace_filter failed: %v", err)
@@ -228,15 +225,16 @@ func TestFilterAddressIntersection(t *testing.T) {
 	err = m.InsertChain(chain)
 	require.NoError(t, err, "inserting chain")
 
-	fromBlock, toBlock := uint64(1), uint64(15)
+	fromBlock := rpc.BlockNumber(1)
+	toBlock := rpc.BlockNumber(15)
 	t.Run("second", func(t *testing.T) {
 		s := jsoniter.ConfigDefault.BorrowStream(nil)
 		defer jsoniter.ConfigDefault.ReturnStream(s)
 		stream := jsonstream.Wrap(s)
 
 		traceReq1 := TraceFilterRequest{
-			FromBlock:   (*hexutil.Uint64)(&fromBlock),
-			ToBlock:     (*hexutil.Uint64)(&toBlock),
+			FromBlock:   &rpc.BlockNumberOrHash{BlockNumber: &fromBlock},
+			ToBlock:     &rpc.BlockNumberOrHash{BlockNumber: &toBlock},
 			FromAddress: []*common.Address{&m.Address, &other},
 			ToAddress:   []*common.Address{&m.Address, &toAddress2},
 			Mode:        TraceFilterModeIntersection,
@@ -252,8 +250,8 @@ func TestFilterAddressIntersection(t *testing.T) {
 		stream := jsonstream.Wrap(s)
 
 		traceReq1 := TraceFilterRequest{
-			FromBlock:   (*hexutil.Uint64)(&fromBlock),
-			ToBlock:     (*hexutil.Uint64)(&toBlock),
+			FromBlock:   &rpc.BlockNumberOrHash{BlockNumber: &fromBlock},
+			ToBlock:     &rpc.BlockNumberOrHash{BlockNumber: &toBlock},
 			FromAddress: []*common.Address{&m.Address, &other},
 			ToAddress:   []*common.Address{&toAddress1, &m.Address},
 			Mode:        TraceFilterModeIntersection,
@@ -269,8 +267,8 @@ func TestFilterAddressIntersection(t *testing.T) {
 		stream := jsonstream.Wrap(s)
 
 		traceReq1 := TraceFilterRequest{
-			FromBlock:   (*hexutil.Uint64)(&fromBlock),
-			ToBlock:     (*hexutil.Uint64)(&toBlock),
+			FromBlock:   &rpc.BlockNumberOrHash{BlockNumber: &fromBlock},
+			ToBlock:     &rpc.BlockNumberOrHash{BlockNumber: &toBlock},
 			ToAddress:   []*common.Address{&other},
 			FromAddress: []*common.Address{&toAddress2, &toAddress1, &other},
 			Mode:        TraceFilterModeIntersection,

--- a/rpc/jsonrpc/trace_filtering.go
+++ b/rpc/jsonrpc/trace_filtering.go
@@ -305,10 +305,14 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, gas
 
 	var fromBlock uint64
 	var toBlock uint64
+	var err error
 	if req.FromBlock == nil {
 		fromBlock = 0
 	} else {
-		fromBlock = uint64(*req.FromBlock)
+		fromBlock, _, _, err = rpchelper.GetBlockNumber(ctx, *req.FromBlock, dbtx, api._blockReader, api.filters)
+		if err != nil {
+			return err
+		}
 	}
 
 	if req.ToBlock == nil {
@@ -318,7 +322,10 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, gas
 		}
 		toBlock = *headNumber
 	} else {
-		toBlock = uint64(*req.ToBlock)
+		toBlock, _, _, err = rpchelper.GetBlockNumber(ctx, *req.ToBlock, dbtx, api._blockReader, api.filters)
+		if err != nil {
+			return err
+		}
 	}
 	if fromBlock > toBlock {
 		return errors.New("invalid parameters: fromBlock cannot be greater than toBlock")
@@ -921,13 +928,13 @@ func (api *TraceAPIImpl) callTransaction(
 
 // TraceFilterRequest represents the arguments for trace_filter
 type TraceFilterRequest struct {
-	FromBlock   *hexutil.Uint64   `json:"fromBlock"`
-	ToBlock     *hexutil.Uint64   `json:"toBlock"`
-	FromAddress []*common.Address `json:"fromAddress"`
-	ToAddress   []*common.Address `json:"toAddress"`
-	Mode        TraceFilterMode   `json:"mode"`
-	After       *uint64           `json:"after"`
-	Count       *uint64           `json:"count"`
+	FromBlock   *rpc.BlockNumberOrHash `json:"fromBlock"`
+	ToBlock     *rpc.BlockNumberOrHash `json:"toBlock"`
+	FromAddress []*common.Address      `json:"fromAddress"`
+	ToAddress   []*common.Address      `json:"toAddress"`
+	Mode        TraceFilterMode        `json:"mode"`
+	After       *uint64                `json:"after"`
+	Count       *uint64                `json:"count"`
 }
 
 type TraceFilterMode string


### PR DESCRIPTION
The RPC specification for trace_filter includes support for block tags (e.g., 'latest', 'earliest'). 
Nethermind also supports this feature.