### PR TITLE
rpcademon: eth_call update with blockOverrides

### DIFF
--- a/.github/workflows/scripts/run_rpc_tests_ethereum.sh
+++ b/.github/workflows/scripts/run_rpc_tests_ethereum.sh
@@ -44,4 +44,4 @@ DISABLED_TEST_LIST=(
 DISABLED_TESTS=$(IFS=,; echo "${DISABLED_TEST_LIST[*]}")
 
 # Call the main test runner script with the required and optional parameters
-"$(dirname "$0")/run_rpc_tests.sh" mainnet v1.90.1 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR"
+"$(dirname "$0")/run_rpc_tests.sh" mainnet v1.91.0 "$DISABLED_TESTS" "$WORKSPACE" "$RESULT_DIR"

--- a/rpc/contracts/direct_backend.go
+++ b/rpc/contracts/direct_backend.go
@@ -54,7 +54,7 @@ func (b DirectBackend) CallContract(ctx context.Context, callMsg ethereum.CallMs
 	blockNumberOrHash := BlockNumArg(blockNum)
 	var blockNumberOrHashRef *rpc.BlockNumberOrHash = &blockNumberOrHash
 
-	return b.api.Call(ctx, CallArgsFromCallMsg(callMsg), blockNumberOrHashRef, nil)
+	return b.api.Call(ctx, CallArgsFromCallMsg(callMsg), blockNumberOrHashRef, nil, nil)
 }
 
 func (b DirectBackend) PendingCodeAt(ctx context.Context, account common.Address) ([]byte, error) {

--- a/rpc/ethapi/block_overrides.go
+++ b/rpc/ethapi/block_overrides.go
@@ -36,7 +36,7 @@ type BlockOverrides struct {
 	Withdrawals   []*types.Withdrawal `json:"withdrawals"`
 }
 
-func (overrides *BlockOverrides) Override(context evmtypes.BlockContext) error {
+func (overrides *BlockOverrides) Override(context *evmtypes.BlockContext) error {
 
 	if overrides.Number != nil {
 		context.BlockNumber = overrides.Number.Uint64()

--- a/rpc/jsonrpc/eth_api.go
+++ b/rpc/jsonrpc/eth_api.go
@@ -103,7 +103,7 @@ type EthAPI interface {
 	Config(ctx context.Context, timeArg *hexutil.Uint64) (*EthConfigResp, error)
 
 	// Sending related (see ./eth_call.go)
-	Call(ctx context.Context, args ethapi.CallArgs, blockNrOrHash *rpc.BlockNumberOrHash, overrides *ethapi.StateOverrides) (hexutil.Bytes, error)
+	Call(ctx context.Context, args ethapi.CallArgs, blockNrOrHash *rpc.BlockNumberOrHash, overrides *ethapi.StateOverrides, blockOverrides *ethapi.BlockOverrides) (hexutil.Bytes, error)
 	EstimateGas(ctx context.Context, argsOrNil *ethapi.CallArgs, blockNrOrHash *rpc.BlockNumberOrHash, overrides *ethapi.StateOverrides) (hexutil.Uint64, error)
 	SendRawTransaction(ctx context.Context, encodedTx hexutil.Bytes) (common.Hash, error)
 	SendTransaction(_ context.Context, txObject interface{}) (common.Hash, error)

--- a/rpc/jsonrpc/eth_api_test.go
+++ b/rpc/jsonrpc/eth_api_test.go
@@ -221,7 +221,7 @@ func TestCall_ByBlockHash_WithRequireCanonicalDefault_NonCanonicalBlock(t *testi
 	if _, err := api.Call(context.Background(), ethapi.CallArgs{
 		From: &from,
 		To:   &to,
-	}, blockNumberOrHashRef, nil); err != nil {
+	}, blockNumberOrHashRef, nil, nil); err != nil {
 		if fmt.Sprintf("%v", err) != fmt.Sprintf("hash %s is not currently canonical", orphanedBlock.Hash().String()[2:]) {
 			/* Not sure. Here https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1898.md it is not explicitly said that
 			   eth_call should only work with canonical blocks.
@@ -246,7 +246,7 @@ func TestCall_ByBlockHash_WithRequireCanonicalTrue_NonCanonicalBlock(t *testing.
 	if _, err := api.Call(context.Background(), ethapi.CallArgs{
 		From: &from,
 		To:   &to,
-	}, blockNumberOrHashRef, nil); err != nil {
+	}, blockNumberOrHashRef, nil, nil); err != nil {
 		if fmt.Sprintf("%v", err) != fmt.Sprintf("hash %s is not currently canonical", orphanedBlock.Hash().String()[2:]) {
 			t.Errorf("wrong error: %v", err)
 		}

--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -61,7 +61,7 @@ var latestNumOrHash = rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 const estimateGasErrorRatio = 0.015
 
 // Call implements eth_call. Executes a new message call immediately without creating a transaction on the block chain.
-func (api *APIImpl) Call(ctx context.Context, args ethapi2.CallArgs, requestedBlock *rpc.BlockNumberOrHash, overrides *ethapi2.StateOverrides) (hexutil.Bytes, error) {
+func (api *APIImpl) Call(ctx context.Context, args ethapi2.CallArgs, requestedBlock *rpc.BlockNumberOrHash, overrides *ethapi2.StateOverrides, blockOverrides *ethapi2.BlockOverrides) (hexutil.Bytes, error) {
 	tx, err := api.db.BeginTemporalRo(ctx)
 	if err != nil {
 		return nil, err
@@ -89,14 +89,14 @@ func (api *APIImpl) Call(ctx context.Context, args ethapi2.CallArgs, requestedBl
 		return nil, err
 	}
 	if header == nil {
-		return nil, errors.New("header not found")
+		return nil, fmt.Errorf("header not found")
 	}
 
 	stateReader, err := rpchelper.CreateStateReader(ctx, tx, api._blockReader, blockNrOrHash, 0, api.filters, api.stateCache, api._txNumReader)
 	if err != nil {
 		return nil, err
 	}
-	result, err := transactions.DoCall(ctx, engine, args, tx, blockNrOrHash, header, overrides, api.GasCap, chainConfig, stateReader, api._blockReader, api.evmCallTimeout)
+	result, err := transactions.DoCall(ctx, engine, args, tx, blockNrOrHash, header, overrides, blockOverrides, api.GasCap, chainConfig, stateReader, api._blockReader, api.evmCallTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/jsonrpc/eth_call_test.go
+++ b/rpc/jsonrpc/eth_call_test.go
@@ -79,7 +79,7 @@ func TestEthCallNonCanonical(t *testing.T) {
 	if _, err := api.Call(context.Background(), ethapi.CallArgs{
 		From: &from,
 		To:   &to,
-	}, blockNumberOrHashRef, nil); err != nil {
+	}, blockNumberOrHashRef, nil, nil); err != nil {
 		if fmt.Sprintf("%v", err) != "hash 3fcb7c0d4569fddc89cbea54b42f163e0c789351d98810a513895ab44b47020b is not currently canonical" {
 			t.Errorf("wrong error: %v", err)
 		}
@@ -104,7 +104,7 @@ func TestEthCallToPrunedBlock(t *testing.T) {
 		From: &bankAddress,
 		To:   &contractAddress,
 		Data: &callDataBytes,
-	}, blockNumberOrHashRef, nil); err != nil {
+	}, blockNumberOrHashRef, nil, nil); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/rpc/jsonrpc/tracing.go
+++ b/rpc/jsonrpc/tracing.go
@@ -424,7 +424,7 @@ func (api *DebugAPIImpl) TraceCall(ctx context.Context, args ethapi.CallArgs, bl
 
 	blockCtx := transactions.NewEVMBlockContext(engine, header, blockNrOrHash.RequireCanonical, dbtx, api._blockReader, chainConfig)
 	if config != nil && config.BlockOverrides != nil {
-		err := config.BlockOverrides.Override(blockCtx)
+		err := config.BlockOverrides.Override(&blockCtx)
 		if err != nil {
 			return err
 		}

--- a/turbo/transactions/call.go
+++ b/turbo/transactions/call.go
@@ -112,6 +112,7 @@ func DoCall(
 	blockNrOrHash rpc.BlockNumberOrHash,
 	header *types.Header,
 	overrides *ethapi2.StateOverrides,
+	blockOverrides *ethapi2.BlockOverrides,
 	gasCap uint64,
 	chainConfig *chain.Config,
 	stateReader state.StateReader,
@@ -154,7 +155,7 @@ func DoCall(
 		var overflow bool
 		baseFee, overflow = uint256.FromBig(header.BaseFee)
 		if overflow {
-			return nil, errors.New("header.BaseFee uint256 overflow")
+			return nil, fmt.Errorf("header.BaseFee uint256 overflow")
 		}
 	}
 	msg, err := args.ToMessage(gasCap, baseFee)
@@ -162,6 +163,10 @@ func DoCall(
 		return nil, err
 	}
 	blockCtx := NewEVMBlockContext(engine, header, blockNrOrHash.RequireCanonical, tx, headerReader, chainConfig)
+	if blockOverrides != nil {
+		blockOverrides.Override(&blockCtx)
+	}
+
 	txCtx := core.NewEVMTxContext(msg)
 
 	evm := vm.NewEVM(blockCtx, txCtx, state, chainConfig, vm.Config{NoBaseFee: true})


### PR DESCRIPTION
Update eth_call with blockOverrides according specs and Geth behaviour

Included new rpc-tests TAGS with NEW  tests