### PR TITLE
rawdbreset: propagate ClearTables errors in ResetSenders and ResetExec

### DIFF
--- a/eth/rawdbreset/reset_stages.go
+++ b/eth/rawdbreset/reset_stages.go
@@ -112,7 +112,7 @@ func ResetBlocks(tx kv.RwTx, db kv.RoDB, br services.FullBlockReader, bw *blocki
 
 func ResetSenders(ctx context.Context, tx kv.RwTx) error {
 	if err := backup.ClearTables(ctx, tx, kv.Senders); err != nil {
-		return nil
+		return fmt.Errorf("clearing senders table: %w", err)
 	}
 	return clearStageProgress(tx, stages.Senders)
 }
@@ -130,7 +130,7 @@ func ResetExec(ctx context.Context, db kv.TemporalRwDB) (err error) {
 		}
 
 		if err := backup.ClearTables(ctx, tx, cleanupList...); err != nil {
-			return nil
+			return fmt.Errorf("clearing exec state tables: %w", err)
 		}
 		// corner case: state files may be ahead of block files - so, can't use SharedDomains here. juts leave progress as 0.
 		return nil


### PR DESCRIPTION
ClearTables errors were swallowed (returning nil) in ResetSenders and ResetExec, which made resets appear successful even when table clears failed. This contradicts project-wide handling (other stages and CLI paths return the error) and can mask data inconsistency. This change returns the wrapped error with context, ensuring callers (CLI/tests) can detect and react to failures, improving reliability and observability of reset operations.