### PR TITLE
erigon-lib/mmap: remove dead MmapRw from mmap_unix.go

### DIFF
--- a/erigon-lib/mmap/mmap_unix.go
+++ b/erigon-lib/mmap/mmap_unix.go
@@ -30,23 +30,6 @@ import (
 
 const MaxMapSize = 0xFFFFFFFFFFFF
 
-// mmap memory maps a DB's data file.
-func MmapRw(f *os.File, size int) ([]byte, *[MaxMapSize]byte, error) {
-	// Map the data file to memory.
-	mmapHandle1, err := unix.Mmap(int(f.Fd()), 0, size, syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Advise the kernel that the mmap is accessed randomly.
-	err = unix.Madvise(mmapHandle1, syscall.MADV_RANDOM)
-	if err != nil && !errors.Is(err, syscall.ENOSYS) {
-		// Ignore not implemented error in kernel because it still works.
-		return nil, nil, fmt.Errorf("madvise: %w", err)
-	}
-	mmapHandle2 := (*[MaxMapSize]byte)(unsafe.Pointer(&mmapHandle1[0]))
-	return mmapHandle1, mmapHandle2, nil
-}
 func Mmap(f *os.File, size int) ([]byte, *[MaxMapSize]byte, error) {
 	// Map the data file to memory.
 	mmapHandle1, err := unix.Mmap(int(f.Fd()), 0, size, syscall.PROT_READ, syscall.MAP_SHARED)


### PR DESCRIPTION
- MmapRw is dead code: there are zero references across the repository.
- The API is non-portable: there is no Windows implementation of MmapRw, so introducing usage would break Windows builds.
- All current call sites use read-only mapping via Mmap; no write-enabled mapping is needed.
- Removing it simplifies the API surface and avoids confusion about supported functionality.