### PR TITLE
Replace time.Tick with time.NewTicker in trackRemovedFiles to prevent timer leak

### DIFF
--- a/erigon-lib/common/dir/rw_dir.go
+++ b/erigon-lib/common/dir/rw_dir.go
@@ -42,6 +42,9 @@ func init() {
 }
 
 func trackRemovedFiles() {
+	// Use a single ticker to avoid leaking timers created by time.Tick
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
 	for {
 		select {
 		case path := <-removedFilesChan:
@@ -49,7 +52,7 @@ func trackRemovedFiles() {
 				removedFiles = make([]string, 0)
 			}
 			removedFiles = append(removedFiles, path)
-		case <-time.Tick(30 * time.Second):
+		case <-ticker.C:
 			for _, path := range removedFiles {
 				if exists, _ := FileExist(path); exists {
 					panic("Removed file unexpectedly exists: " + path)


### PR DESCRIPTION

Description
### Summary
Replace `time.Tick` with a single `time.NewTicker` in `trackRemovedFiles` and stop it via `defer ticker.Stop()` to avoid leaking timers.

### Rationale
`time.Tick` creates a ticker that cannot be stopped; using it directly inside a looped `select` leads to accumulating timers and unnecessary wakeups over time.

### Changes
- Create one `time.NewTicker(30 * time.Second)` outside the loop and use `ticker.C`.

