### PR TITLE
added syscheck on linux

### DIFF
--- a/cmd/erigon/main.go
+++ b/cmd/erigon/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"cmp"
 	"fmt"
+	"github.com/erigontech/erigon/core/syscheck"
 	"net/http"
 	"os"
 
@@ -56,6 +57,8 @@ func runErigon(cliCtx *cli.Context) (err error) {
 	if err != nil {
 		return
 	}
+
+	syscheck.CheckKernelAllocationHints(cliCtx.Context, logger)
 
 	debugMux := cmp.Or(metricsMux, pprofMux)
 

--- a/core/syscheck/syscheck.go
+++ b/core/syscheck/syscheck.go
@@ -1,0 +1,127 @@
+package syscheck
+
+import (
+	"context"
+	"fmt"
+	"github.com/erigontech/erigon-lib/log/v3"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/shirou/gopsutil/v4/host"
+	"github.com/shirou/gopsutil/v4/mem"
+)
+
+// CheckKernelAllocationHints inspects Linux kernel /proc sysctls related to
+// virtual memory overcommit and max vma mappings, plus basic RAM/SWAP, and
+// logs precise remediation steps if something looks risky for heavy mmap/fork.
+//
+// It returns a slice of human-readable recommendations that were logged.
+func CheckKernelAllocationHints(ctx context.Context, log log.Logger) {
+	var hints []string
+
+	if runtime.GOOS != "linux" {
+		return // non-Linux: nothing to check TODO: figure out hints for other OS later
+	}
+
+	// Helpers
+	readInt := func(path string) (int64, error) {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return 0, err
+		}
+		s := strings.TrimSpace(string(b))
+		// /proc/sys values are usually small ints
+		v, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("parse %q from %s: %w", s, path, err)
+		}
+		return v, nil
+	}
+	logHint := func(msg string, kv ...any) {
+		hints = append(hints, msg)
+		log.Warn(msg, kv...)
+	}
+
+	// Kernel version (useful context in logs)
+	if kv, err := host.KernelVersionWithContext(ctx); err == nil && kv != "" {
+		log.Info("kernel detected", "version", kv)
+	}
+
+	// 1) vm.overcommit_memory
+	// 0 = heuristic (risky for fork-heavy or COW), 1 = always overcommit (recommended for Erigon-like mmap + Redis-style fork workloads), 2 = strict
+	if v, err := readInt("/proc/sys/vm/overcommit_memory"); err == nil {
+		switch v {
+		case 0:
+			logHint(
+				"vm.overcommit_memory=0 can cause fork()/allocation failures under load; set to 1",
+				"current", v,
+				"fix", `echo "vm.overcommit_memory = 1" | sudo tee /etc/sysctl.d/99-erigon.conf && sudo sysctl -p /etc/sysctl.d/99-erigon.conf`,
+			)
+		case 2:
+			logHint(
+				"vm.overcommit_memory=2 (strict) may cause allocation failures for large mmap/fork workloads; consider 1",
+				"current", v,
+				"fix", `echo "vm.overcommit_memory = 1" | sudo tee /etc/sysctl.d/99-erigon.conf && sudo sysctl -p /etc/sysctl.d/99-erigon.conf`,
+			)
+		default:
+			log.Info("vm.overcommit_memory looks OK", "current", v)
+		}
+	} else {
+		log.Debug("unable to read vm.overcommit_memory", "err", err)
+	}
+
+	// 2) vm.max_map_count (upper bound on number of VMAs / mmaps)
+	// We suggest 16777216 https://github.com/erigontech/erigon?tab=readme-ov-file#erigon-crashes-due-to-kernel-allocation-limits.
+	const wantMaxMap = int64(16777216)
+	if v, err := readInt("/proc/sys/vm/max_map_count"); err == nil {
+		if v < wantMaxMap {
+			logHint(
+				"vm.max_map_count is low for large memory-mapped databases; raise it",
+				"current", v,
+				"recommended", wantMaxMap,
+				"fix", fmt.Sprintf(`echo "vm.max_map_count = %d" | sudo tee -a /etc/sysctl.d/99-erigon.conf && sudo sysctl -p /etc/sysctl.d/99-erigon.conf`, wantMaxMap),
+			)
+		} else {
+			log.Info("vm.max_map_count looks OK", "current", v)
+		}
+	} else {
+		log.Debug("unable to read vm/max_map_count", "err", err)
+	}
+
+	// 3) RAM/SWAP sanity — fork-heavy workloads are sensitive when swap=0 and headroom is tiny.
+	if vmStat, err := mem.VirtualMemoryWithContext(ctx); err == nil {
+		swapStat, _ := mem.SwapMemoryWithContext(ctx)
+
+		// Heuristic: if free+cached < 15% of total and swap total == 0, warn.
+		headroom := float64(vmStat.Available) / float64(vmStat.Total+1)
+		if headroom < 0.15 && (swapStat == nil || swapStat.Total == 0) {
+			logHint(
+				"Low available memory headroom and no swap may cause fork()/allocation failures",
+				"mem_total", vmStat.Total,
+				"mem_available", vmStat.Available,
+				"swap_total", func() uint64 {
+					if swapStat != nil {
+						return swapStat.Total
+					}
+					return 0
+				}(),
+				"suggestion", "Consider adding a small swapfile (e.g., 4–8 GiB) to improve fork reliability.",
+				"fix", `sudo fallocate -l 8G /swapfile && sudo chmod 600 /swapfile && sudo mkswap /swapfile && echo "/swapfile none swap sw 0 0" | sudo tee -a /etc/fstab && sudo swapon -a`,
+			)
+		}
+	} else {
+		log.Debug("unable to read memory stats", "err", err)
+	}
+
+	// 4) Optional: detect containerized PID 1 (some kernels/namespaces can mask sysctl effects)
+	if b, err := os.ReadFile("/proc/1/cgroup"); err == nil && strings.Contains(string(b), "docker") {
+		log.Info("running under container cgroup; ensure sysctls are applied on the host or via --sysctl in the runtime")
+	}
+
+	if len(hints) == 0 {
+		log.Info("kernel allocation settings look sane for mmap/fork workloads")
+	}
+	return
+}


### PR DESCRIPTION
```
erigon@dev-bm-e3-ethmainnet-n1:~/erigon$ make erigon && ./build/bin/erigon --datadir=/erigon-data/ethmainnet31 --chain=mainnet --log.console.verbosity=4 --prune.mode=archive
Building /home/erigon/erigon/build/bin/erigon
cd ./cmd/erigon && GOARCH=amd64 GOAMD64=v2  CGO_CFLAGS="-O2 -g  -DMDBX_FORCE_ASSERTIONS=0  -DMDBX_DISABLE_VALIDATION=0  -DMDBX_ENV_CHECKPID=0  -D__BLST_PORTABLE__ -Wno-unknown-warning-option -Wno-enum-int-mismatch -Wno-strict-prototypes -Wno-unused-but-set-variable -O3" CGO_LDFLAGS="-O2 -g -O3 -g" GOPRIVATE="github.com/erigontech/silkworm-go" go  build -trimpath -buildvcs=false -ldflags "-X github.com/erigontech/erigon/db/version.GitCommit=8d983e9d54645f01ef75c1d030fe09fb0d867c47 -X github.com/erigontech/erigon/db/version.GitBranch=jklondon/syscheck -X github.com/erigontech/erigon/db/version.GitTag=v3.0.0-beta1-1702-g8d983e9-dirty"  -tags , -o /home/erigon/erigon/build/bin/erigon
# github.com/go-llsqlite/crawshaw/c
In function ‘sqlite3Strlen30’,
    inlined from ‘sqlite3ColumnSetColl’ at sqlite3.c:123675:10:
sqlite3.c:35602:28: warning: ‘strlen’ reading 1 or more bytes from a region of size 0 [-Wstringop-overread]
35602 |   return 0x3fffffff & (int)strlen(z);
      |                            ^~~~~~~~~
In function ‘sqlite3ColumnSetColl’:
cc1: note: source object is likely at address zero
At top level:
cc1: note: unrecognized command-line option ‘-Wno-unknown-warning-option’ may have been intended to silence earlier diagnostics
Run "/home/erigon/erigon/build/bin/erigon" to launch erigon.
INFO[09-29|18:22:22.702] logging to file system                   log dir=/erigon-data/ethmainnet31/logs file prefix=erigon log level=info json=false
INFO[09-29|18:22:22.702] kernel detected                          version=6.8.0-71-generic
WARN[09-29|18:22:22.702] vm.overcommit_memory=0 can cause fork()/allocation failures under load; set to 1 current=0 fix="echo \"vm.overcommit_memory = 1\" | sudo tee /etc/sysctl.d/99-erigon.conf && sudo sysctl -p /etc/sysctl.d/99-erigon.conf"
WARN[09-29|18:22:22.702] vm.max_map_count is low for large memory-mapped databases; raise it current=1048576 recommended=16777216 fix="echo \"vm.max_map_count = 16777216\" | sudo tee -a /etc/sysctl.d/99-erigon.conf && sudo sysctl -p /etc/sysctl.d/99-erigon.conf"
```
This how it looks like

closes #16470 