### PR TITLE
Use MaxUint64 as return value to `HistoryStartFrom()` if no files present

### DIFF
--- a/db/kv/temporal/kv_temporal.go
+++ b/db/kv/temporal/kv_temporal.go
@@ -635,10 +635,10 @@ func (tx *tx) historyStartFrom(name kv.Domain, roTx kv.Tx) uint64 {
 	return tx.aggtx.HistoryStartFrom(name, roTx)
 }
 func (tx *Tx) HistoryStartFrom(name kv.Domain) uint64 {
-	return tx.historyStartFrom(name, tx)
+	return tx.historyStartFrom(name, tx.Tx)
 }
 func (tx *RwTx) HistoryStartFrom(name kv.Domain) uint64 {
-	return tx.historyStartFrom(name, tx)
+	return tx.historyStartFrom(name, tx.RwTx)
 }
 func (tx *Tx) DomainProgress(domain kv.Domain) uint64 {
 	return tx.aggtx.DomainProgress(domain, tx.Tx)

--- a/db/kv/temporal/kv_temporal.go
+++ b/db/kv/temporal/kv_temporal.go
@@ -631,14 +631,14 @@ func (tx *RwTx) Unwind(ctx context.Context, txNumUnwindTo uint64, changeset *[kv
 func (tx *tx) ForkableAggTx(id kv.ForkableId) any {
 	return tx.forkaggs[tx.searchForkableAggIdx(id)]
 }
-func (tx *tx) historyStartFrom(name kv.Domain) uint64 {
-	return tx.aggtx.HistoryStartFrom(name)
+func (tx *tx) historyStartFrom(name kv.Domain, roTx kv.Tx) uint64 {
+	return tx.aggtx.HistoryStartFrom(name, roTx)
 }
 func (tx *Tx) HistoryStartFrom(name kv.Domain) uint64 {
-	return tx.historyStartFrom(name)
+	return tx.historyStartFrom(name, tx)
 }
 func (tx *RwTx) HistoryStartFrom(name kv.Domain) uint64 {
-	return tx.historyStartFrom(name)
+	return tx.historyStartFrom(name, tx)
 }
 func (tx *Tx) DomainProgress(domain kv.Domain) uint64 {
 	return tx.aggtx.DomainProgress(domain, tx.Tx)

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -1920,16 +1920,6 @@ func (at *AggregatorRoTx) Close() {
 	}
 }
 
-// First txnum found in MDBX
-func firstTxNumInDB(tx kv.Tx, domain *Domain) (firstTxNum uint64, found bool) {
-	var err error
-	firstTxNum, found, err = domain.firstTxNumInDB(tx)
-	if err != nil {
-		log.Warn("[aggregator] firstTxNumInDB", "err", err)
-	}
-	return firstTxNum, found
-}
-
 // Inverted index tables only
 func lastIdInDB(db kv.RoDB, domain *Domain) (lstInDb kv.Step) {
 	if err := db.View(context.Background(), func(tx kv.Tx) error {

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -1923,7 +1923,11 @@ func (at *AggregatorRoTx) Close() {
 // First txnum found in MDBX
 func firstTxNumInDB(db kv.RoDB, domain *Domain) (firstTxNum uint64, found bool) {
 	if err := db.View(context.Background(), func(tx kv.Tx) error {
-		firstTxNum, found = domain.firstTxNumInDB(tx)
+		var err error
+		firstTxNum, found, err = domain.firstTxNumInDB(tx)
+		if err != nil {
+			return err
+		}
 		return nil
 	}); err != nil {
 		log.Warn("[aggregator] firstTxNumInDB", "err", err)

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -1638,8 +1638,8 @@ func (a *Aggregator) BuildFilesInBackground(txNum uint64) chan struct{} {
 }
 
 // Returns the first known txNum found in history files of a given domain
-func (at *AggregatorRoTx) HistoryStartFrom(name kv.Domain) uint64 {
-	return at.d[name].HistoryStartFrom(at.a.db)
+func (at *AggregatorRoTx) HistoryStartFrom(name kv.Domain, tx kv.Tx) uint64 {
+	return at.d[name].HistoryStartFrom(tx)
 }
 
 func (at *AggregatorRoTx) IndexRange(name kv.InvertedIdx, k []byte, fromTs, toTs int, asc order.By, limit int, tx kv.Tx) (timestamps stream.U64, err error) {
@@ -1921,15 +1921,10 @@ func (at *AggregatorRoTx) Close() {
 }
 
 // First txnum found in MDBX
-func firstTxNumInDB(db kv.RoDB, domain *Domain) (firstTxNum uint64, found bool) {
-	if err := db.View(context.Background(), func(tx kv.Tx) error {
-		var err error
-		firstTxNum, found, err = domain.firstTxNumInDB(tx)
-		if err != nil {
-			return err
-		}
-		return nil
-	}); err != nil {
+func firstTxNumInDB(tx kv.Tx, domain *Domain) (firstTxNum uint64, found bool) {
+	var err error
+	firstTxNum, found, err = domain.firstTxNumInDB(tx)
+	if err != nil {
 		log.Warn("[aggregator] firstTxNumInDB", "err", err)
 	}
 	return firstTxNum, found

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1460,7 +1460,7 @@ func (dt *DomainRoTx) getLatestFromFiles(k []byte, maxTxNum uint64) (v []byte, f
 // Returns the first txNum from available history
 func (dt *DomainRoTx) HistoryStartFrom() uint64 {
 	if len(dt.ht.files) == 0 {
-		return 0
+		return math.MaxUint64
 	}
 	return dt.ht.files[0].startTxNum
 }

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1460,10 +1460,7 @@ func (dt *DomainRoTx) getLatestFromFiles(k []byte, maxTxNum uint64) (v []byte, f
 // Returns the first txNum from available history
 func (dt *DomainRoTx) HistoryStartFrom(tx kv.Tx) uint64 {
 	if len(dt.ht.files) == 0 { // if no history files, check in MDBX
-		firstTxNumInMdbx, found := firstTxNumInDB(tx, dt.d)
-		if !found {
-			return math.MaxUint64 // default value of +∞
-		}
+		firstTxNumInMdbx := dt.ht.h.minTxNumInDB(tx)
 		return firstTxNumInMdbx
 	}
 	return dt.ht.files[0].startTxNum

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1458,9 +1458,9 @@ func (dt *DomainRoTx) getLatestFromFiles(k []byte, maxTxNum uint64) (v []byte, f
 }
 
 // Returns the first txNum from available history
-func (dt *DomainRoTx) HistoryStartFrom(db kv.RoDB) uint64 {
+func (dt *DomainRoTx) HistoryStartFrom(tx kv.Tx) uint64 {
 	if len(dt.ht.files) == 0 { // if no history files, check in MDBX
-		firstTxNumInMdbx, found := firstTxNumInDB(db, dt.d)
+		firstTxNumInMdbx, found := firstTxNumInDB(tx, dt.d)
 		if !found {
 			return math.MaxUint64 // default value of +∞
 		}

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1460,7 +1460,7 @@ func (dt *DomainRoTx) getLatestFromFiles(k []byte, maxTxNum uint64) (v []byte, f
 // Returns the first txNum from available history
 func (dt *DomainRoTx) HistoryStartFrom() uint64 {
 	if len(dt.ht.files) == 0 {
-		return math.MaxUint64
+		return math.MaxUint64 // default value of +∞
 	}
 	return dt.ht.files[0].startTxNum
 }

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -162,14 +162,6 @@ func (d *Domain) kvBtAccessorFilePathMask(fromStep, toStep kv.Step) string {
 	return filepath.Join(d.dirs.SnapDomain, fmt.Sprintf("*-%s.%d-%d.bt", d.FilenameBase, fromStep, toStep))
 }
 
-func (d *Domain) firstTxNumInDB(tx kv.Tx) (firstTxNum uint64, found bool) {
-	firstTxNumBytes, _ := kv.FirstKey(tx, d.History.KeysTable)
-	if len(firstTxNumBytes) == 0 {
-		return 0, false
-	}
-	return binary.BigEndian.Uint64(firstTxNumBytes), true
-}
-
 // maxStepInDB - return the latest available step in db (at-least 1 value in such step)
 func (d *Domain) maxStepInDB(tx kv.Tx) (lstInDb kv.Step) {
 	lstIdx, _ := kv.LastKey(tx, d.History.KeysTable)

--- a/db/state/history.go
+++ b/db/state/history.go
@@ -877,17 +877,6 @@ func (h *History) isEmpty(tx kv.Tx) (bool, error) {
 	return k == nil && k2 == nil, nil
 }
 
-func (h *History) firstTxNumInDB(tx kv.Tx) (firstTxNum uint64, found bool, err error) {
-	firstTxNumBytes, err := kv.FirstKey(tx, h.KeysTable)
-	if err != nil {
-		return 0, false, err
-	}
-	if len(firstTxNumBytes) == 0 {
-		return 0, false, nil
-	}
-	return binary.BigEndian.Uint64(firstTxNumBytes), true, nil
-}
-
 type HistoryRecord struct {
 	TxNum uint64
 	Value []byte

--- a/db/state/history.go
+++ b/db/state/history.go
@@ -877,6 +877,17 @@ func (h *History) isEmpty(tx kv.Tx) (bool, error) {
 	return k == nil && k2 == nil, nil
 }
 
+func (h *History) firstTxNumInDB(tx kv.Tx) (firstTxNum uint64, found bool, err error) {
+	firstTxNumBytes, err := kv.FirstKey(tx, h.KeysTable)
+	if err != nil {
+		return 0, false, err
+	}
+	if len(firstTxNumBytes) == 0 {
+		return 0, false, nil
+	}
+	return binary.BigEndian.Uint64(firstTxNumBytes), true, nil
+}
+
 type HistoryRecord struct {
 	TxNum uint64
 	Value []byte


### PR DESCRIPTION
Currently default return value of 0 leads to `PrunedError` not being thrown when commitment history is not available when `eth_getProof` is invoked. This leads to incorrect root hash error, but instead a `PrunedError` should be thrown.

A default value of +∞ is more appropriate, and fixes https://github.com/erigontech/erigon/issues/16776 as well.

UPDATE: It could happen that there are no history files, but there is history in MDBX, so the function is now updated to look into MDBX for the first txnum if there are history files in snapshots.