### PR TITLE
eth/tracers: remove dead fields from JsonStreamLogger and drop broken limit check

### DIFF
--- a/eth/tracers/logger/json_stream.go
+++ b/eth/tracers/logger/json_stream.go
@@ -45,9 +45,6 @@ type JsonStreamLogger struct {
 
 	locations common.Hashes // For sorting
 	storage   map[common.Address]Storage
-	logs      []StructLog
-	output    []byte //nolint
-	err       error  //nolint
 	env       *tracing.VMContext
 }
 
@@ -99,10 +96,6 @@ func (l *JsonStreamLogger) OnOpcode(pc uint64, typ byte, gas, cost uint64, scope
 	case <-l.ctx.Done():
 		return
 	default:
-	}
-	// check if already accumulated the specified number of logs
-	if l.cfg.Limit != 0 && l.cfg.Limit <= len(l.logs) {
-		return
 	}
 	if !l.firstCapture {
 		l.stream.WriteMore()


### PR DESCRIPTION
Delete unused fields logs, output, err from JsonStreamLogger
Remove nonfunctional limit guard that relied on len(l.logs)