### PR TITLE
node: set eth69 as default

### DIFF
--- a/node/nodecfg/defaults.go
+++ b/node/nodecfg/defaults.go
@@ -48,7 +48,7 @@ var DefaultConfig = Config{
 	WSModules:        []string{"net", "web3"},
 	P2P: p2p.Config{
 		ListenAddr:      ":30303",
-		ProtocolVersion: []uint{direct.ETH68, direct.ETH69}, // Keep eth/68 in first index for Hive tests
+		ProtocolVersion: []uint{direct.ETH69, direct.ETH68}, // Keep eth/69 in first index as default
 		MaxPeers:        32,
 		MaxPendingPeers: 1000,
 		NAT:             nat.Any(),


### PR DESCRIPTION
This PR sets `eth69` as the default networking protocol according to [EIP-7642](https://eips.ethereum.org/EIPS/eip-7642). We found this when testing the eip among clients and, because erigon set it to `eth68`, it made all clients downgrade when interacting to erigon.