### PR TITLE
[r32] Bump eth mainnet default block gas limit to 60M

### DIFF
--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -51,7 +51,7 @@ import (
 var BorDefaultMinerGasPrice = big.NewInt(25 * common.GWei)
 
 // Fail-back block gas limit. Better specify one in the chain config.
-const DefaultBlockGasLimit uint64 = 45_000_000
+const DefaultBlockGasLimit uint64 = 60_000_000
 
 func DefaultBlockGasLimitByChain(config *Config) uint64 {
 	if config.Genesis == nil || config.Genesis.Config == nil || config.Genesis.Config.DefaultBlockGasLimit == nil {

--- a/execution/chain/spec/chainspecs/mainnet.json
+++ b/execution/chain/spec/chainspecs/mainnet.json
@@ -35,5 +35,5 @@
   },
   "depositContractAddress": "0x00000000219ab540356cBB839Cbe05303d7705Fa",
   "ethash": {},
-  "defaultBlockGasLimit": 45000000
+  "defaultBlockGasLimit": 60000000
 }


### PR DESCRIPTION
Cherry pick #16949 into `release/3.2`