### PR TITLE
rpc: fix no changes and filter not found in eth_getFilter*

### DIFF
--- a/rpc/jsonrpc/eth_filters.go
+++ b/rpc/jsonrpc/eth_filters.go
@@ -18,7 +18,6 @@ package jsonrpc
 
 import (
 	"context"
-	"errors"
 	"strings"
 
 	"github.com/erigontech/erigon-lib/common/dbg"
@@ -100,6 +99,9 @@ func (api *APIImpl) GetFilterChanges(_ context.Context, index string) ([]any, er
 	stub := make([]any, 0)
 	// remove 0x
 	cutIndex := strings.TrimPrefix(index, "0x")
+	if found := api.filters.HasSubscription(rpchelper.LogsSubID(cutIndex)); !found {
+		return nil, rpc.ErrFilterNotFound
+	}
 	if blocks, ok := api.filters.ReadPendingBlocks(rpchelper.HeadsSubID(cutIndex)); ok {
 		for _, v := range blocks {
 			stub = append(stub, v.Hash())
@@ -121,7 +123,7 @@ func (api *APIImpl) GetFilterChanges(_ context.Context, index string) ([]any, er
 		}
 		return stub, nil
 	}
-	return nil, errors.New("filter not found")
+	return []any{}, nil
 }
 
 // GetFilterLogs implements eth_getFilterLogs.
@@ -132,10 +134,13 @@ func (api *APIImpl) GetFilterLogs(_ context.Context, index string) ([]*types.Log
 		return nil, rpc.ErrNotificationsUnsupported
 	}
 	cutIndex := strings.TrimPrefix(index, "0x")
+	if found := api.filters.HasSubscription(rpchelper.LogsSubID(cutIndex)); !found {
+		return nil, rpc.ErrFilterNotFound
+	}
 	if logs, ok := api.filters.ReadLogs(rpchelper.LogsSubID(cutIndex)); ok {
 		return logs, nil
 	}
-	return nil, errors.New("filter not found")
+	return []*types.Log{}, nil
 }
 
 // NewHeads send a notification each time a new (header) block is appended to the chain.

--- a/rpc/rpchelper/filters.go
+++ b/rpc/rpchelper/filters.go
@@ -517,6 +517,10 @@ func (ff *Filters) loadLogsRequester() any {
 	return ff.logsRequestor.Load()
 }
 
+func (ff *Filters) HasSubscription(id LogsSubID) bool {
+	return ff.logsSubs.hasLogsFilter(id)
+}
+
 // UnsubscribeLogs unsubscribes from logs using the given subscription ID.
 // It returns true if the unsubscription was successful, otherwise false.
 func (ff *Filters) UnsubscribeLogs(id LogsSubID) bool {

--- a/rpc/rpchelper/logsfilter.go
+++ b/rpc/rpchelper/logsfilter.go
@@ -104,6 +104,18 @@ func (a *LogsFilterAggregator) removeLogsFilter(filterId LogsSubID) bool {
 	return true
 }
 
+// hasLogsFilter checks if a log filter identified by filterId is present in the LogsFilterAggregator.
+func (a *LogsFilterAggregator) hasLogsFilter(filterId LogsSubID) bool {
+	a.logsFilterLock.Lock()
+	defer a.logsFilterLock.Unlock()
+
+	_, ok := a.logsFilters.Get(filterId)
+	if !ok {
+		return false
+	}
+	return true
+}
+
 // createFilterRequest creates a LogsFilterRequest from the current state of the LogsFilterAggregator.
 // It generates a request that represents the union of all current log filters.
 func (a *LogsFilterAggregator) createFilterRequest() *remoteproto.LogsFilterRequest {

--- a/rpc/subscription.go
+++ b/rpc/subscription.go
@@ -37,8 +37,10 @@ import (
 var (
 	// ErrNotificationsUnsupported is returned when the connection doesn't support notifications
 	ErrNotificationsUnsupported = errors.New("notifications not supported")
-	// ErrNotificationNotFound is returned when the notification for the given id is not found
+	// ErrSubscriptionNotFound is returned when the notification for the given id is not found
 	ErrSubscriptionNotFound = errors.New("subscription not found")
+	// ErrFilterNotFound is returned when the filter for the given id is not found
+	ErrFilterNotFound = errors.New("filter not found")
 )
 
 var globalGen = randomIDGenerator()


### PR DESCRIPTION
Handle 2 different scenarios

- invalid filter ID as input: already covered by integration tests
https://github.com/erigontech/rpc-tests/blob/main/integration/mainnet/eth_getFilterChanges/test_01.json
https://github.com/erigontech/rpc-tests/blob/main/integration/mainnet/eth_getFilterLogs/test_01.json

- no change/log associated to a give filter between `eth_newFilter` and `eth_getFilter*` calls: covered by new integration utility
https://github.com/erigontech/rpc-tests/pull/469