### PR TITLE
qa-tests: show a more specific error message inside the tip-tracking log

### DIFF
--- a/.github/workflows/qa-tip-tracking-gnosis.yml
+++ b/.github/workflows/qa-tip-tracking-gnosis.yml
@@ -266,8 +266,13 @@ jobs:
     - name: Action for Not Success
       if: ${{ always() }}
       run: |
+        if [[ "${{ steps.test_step.outputs.TEST_RESULT }}" != "success" ]]; then
+          echo "::error::Error detected during upgrade & tip-tracking test"
+        fi
+        if [[ "${{ steps.downgrade_test_step.outputs.TEST_RESULT }}" != "success" ]]; then
+          echo "::error::Error detected during downgrade & tip-tracking test"
+        fi
         if [[ "${{ steps.test_step.outputs.TEST_RESULT }}" != "success" ]] || \
            [[ "${{ steps.downgrade_test_step.outputs.TEST_RESULT }}" != "success" ]]; then
-          echo "::error::Error detected during tests"
           exit 1
         fi

--- a/.github/workflows/qa-tip-tracking.yml
+++ b/.github/workflows/qa-tip-tracking.yml
@@ -267,8 +267,14 @@ jobs:
     - name: Action for Not Success
       if: ${{ always() }}
       run: |
+        if [[ "${{ steps.test_step.outputs.TEST_RESULT }}" != "success" ]]; then
+          echo "::error::Error detected during upgrade & tip-tracking test"
+        fi
+        if [[ "${{ steps.downgrade_test_step.outputs.TEST_RESULT }}" != "success" ]]; then
+          echo "::error::Error detected during downgrade & tip-tracking test"
+        fi
         if [[ "${{ steps.test_step.outputs.TEST_RESULT }}" != "success" ]] || \
            [[ "${{ steps.downgrade_test_step.outputs.TEST_RESULT }}" != "success" ]]; then
-          echo "::error::Error detected during tests"
           exit 1
-        fi 
+        fi
+        


### PR DESCRIPTION
The error reason of the tip-tracking test is present in the test run summary, see below
<img width="575" height="419" alt="Screenshot 2025-10-03 alle 09 49 03" src="https://github.com/user-attachments/assets/84a34067-2129-4c2a-a231-510695033180" />

But in the log, it was not clear what happened:
![2025-10-03 09 49 41](https://github.com/user-attachments/assets/4738b634-6dc4-4f4d-b4ba-37bb9f3cbcf4)

Now the error reason is also present in the test run log.