### PR TITLE
refactor: using reflect.TypeFor

### DIFF
--- a/p2p/event/feed_test.go
+++ b/p2p/event/feed_test.go
@@ -32,7 +32,7 @@ func TestFeedPanics(t *testing.T) {
 	{
 		var f Feed
 		f.Send(2)
-		want := feedTypeError{op: "Send", got: reflect.TypeOf(uint64(0)), want: reflect.TypeOf(0)}
+		want := feedTypeError{op: "Send", got: reflect.TypeFor[uint64](), want: reflect.TypeFor[int]()}
 		if err := checkPanic(want, func() { f.Send(uint64(2)) }); err != nil {
 			t.Error(err)
 		}
@@ -41,7 +41,7 @@ func TestFeedPanics(t *testing.T) {
 		var f Feed
 		ch := make(chan int)
 		f.Subscribe(ch)
-		want := feedTypeError{op: "Send", got: reflect.TypeOf(uint64(0)), want: reflect.TypeOf(0)}
+		want := feedTypeError{op: "Send", got: reflect.TypeFor[uint64](), want: reflect.TypeFor[int]()}
 		if err := checkPanic(want, func() { f.Send(uint64(2)) }); err != nil {
 			t.Error(err)
 		}

--- a/p2p/forkid/forkid.go
+++ b/p2p/forkid/forkid.go
@@ -216,7 +216,7 @@ func ChecksumToBytes(hash uint32) [4]byte {
 // GatherForks gathers all the known forks and creates a sorted list out of them.
 func GatherForks(config *chain.Config, genesisTime uint64) (heightForks []uint64, timeForks []uint64) {
 	// Gather all the fork block numbers via reflection
-	kind := reflect.TypeOf(chain.Config{})
+	kind := reflect.TypeFor[chain.Config]()
 	conf := reflect.ValueOf(config).Elem()
 
 	for i := 0; i < kind.NumField(); i++ {

--- a/p2p/transport_test.go
+++ b/p2p/transport_test.go
@@ -134,7 +134,7 @@ func TestProtocolHandshakeErrors(t *testing.T) {
 		{
 			code: handshakeMsg,
 			msg:  []byte{1, 2, 3},
-			err:  NewPeerError(PeerErrorInvalidMessage, DiscProtocolError, rlp.WrapStreamError(rlp.ErrExpectedList, reflect.TypeOf(protoHandshake{})), "(code 0) (size 4)"),
+			err:  NewPeerError(PeerErrorInvalidMessage, DiscProtocolError, rlp.WrapStreamError(rlp.ErrExpectedList, reflect.TypeFor[protoHandshake]()), "(code 0) (size 4)"),
 		},
 		{
 			code: handshakeMsg,


### PR DESCRIPTION
Try to use better api reflect.TypeFor instead of reflect.TypeOf when we have known the type.
More info https://github.com/golang/go/issues/60088