### PR TITLE
Return original abort error string if exsists

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -75,7 +75,7 @@ func (e ErrExecAbortError) Error() string {
 		return fmt.Sprintf("execution aborted due to dependency %d", e.DependencyTxIndex)
 	} else {
 		if e.OriginError != nil {
-			return fmt.Sprintf("execution aborted: %s", e.OriginError)
+			return e.OriginError.Error()
 		}
 		return "execution aborted"
 	}


### PR DESCRIPTION
This fixes 11 eest/consume-engine tests due the additional error reason for GAS_LIMIT_EXCEEDS_MAXIMUM breaking the hive message parser.

This should also fix any other parsing of execution abort messages. 