### PR TITLE
qa-tests: bump lighthouse version in sync-with-externalcl test

### DIFF
--- a/.github/workflows/qa-sync-with-externalcl.yml
+++ b/.github/workflows/qa-sync-with-externalcl.yml
@@ -45,9 +45,9 @@ jobs:
         run: |
           mkdir -p $CL_DATA_DIR
           if [ "${{ matrix.client }}" == "lighthouse" ]; then
-            curl -LO https://github.com/sigp/lighthouse/releases/download/v7.1.0/lighthouse-v7.1.0-x86_64-unknown-linux-gnu.tar.gz
-            tar -xvf lighthouse-v7.1.0-x86_64-unknown-linux-gnu.tar.gz -C $CL_DATA_DIR
-            rm lighthouse-v7.1.0-x86_64-unknown-linux-gnu.tar.gz
+            curl -LO https://github.com/sigp/lighthouse/releases/download/v8.0.0-rc.0/lighthouse-v8.0.0-rc.0-x86_64-unknown-linux-gnu.tar.gz                     
+            tar -xvf lighthouse-v8.0.0-rc.0-x86_64-unknown-linux-gnu.tar.gz -C $CL_DATA_DIR
+            rm lighthouse-v8.0.0-rc.0-x86_64-unknown-linux-gnu.tar.gz
           elif [ "${{ matrix.client }}" == "prysm" ]; then
             curl -L https://raw.githubusercontent.com/prysmaticlabs/prysm/master/prysm.sh -o $CL_DATA_DIR/prysm.sh
             chmod +x $CL_DATA_DIR/prysm.sh


### PR DESCRIPTION
In an attempt to resolve the random checkpoint sync errors we are experiencing with Lighthouse, we are trying out a newer version of the client, even though it is still in beta.