### PR TITLE
Fix eth_getProof : Missing `storageRootHashIsSet` to true 

### DIFF
--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -826,6 +826,7 @@ func (hph *HexPatriciaHashed) witnessComputeCellHashWithStorage(cell *cell, dept
 				}
 				cell.stateHashLen = 0
 				hadToReset.Add(1)
+				storageRootHashIsSet = true
 			} else if cell.hashLen > 0 {
 				storageRootHash = cell.hash
 				storageRootHashIsSet = true


### PR DESCRIPTION
This fixes the `eth_getProof` for the first example in :
https://github.com/erigontech/erigon/issues/16752

```
> curl -X POST -H "Content-Type: application/json" \
  -d '{
    "jsonrpc": "2.0",
    "method": "eth_getProof",
    "params": [
      "0x12ddA8BFfdbEBF79502B175fA1413a4765e69b2F",
      [],
      "0x15f68ef"
    ],
    "id": 1
  }' \
  http://localhost:8545

 error code -32000: hash sort failed: loadIntoTable : subTrieRoot(96ebf0aad9006a003b893e63fd222d7ecf84f689019ce06f45e33e3d6d845860) != cellHash(03b4d41a46af2a2918ff5a398e6f4645c73021d3dceb8a3f1342d2b194e1afe8)\
 ```
 
 The `storageRootHashIsSet` was not set to true, so empty storage root hash was being used.