### PR TITLE
refactor: use b.Loop() to simplify the code and improve performance

### DIFF
--- a/common/crypto/bn254/cloudflare/bn254_test.go
+++ b/common/crypto/bn254/cloudflare/bn254_test.go
@@ -94,23 +94,21 @@ func TestTripartiteDiffieHellman(t *testing.T) {
 
 func BenchmarkG1(b *testing.B) {
 	x, _ := rand.Int(rand.Reader, Order)
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		new(G1).ScalarBaseMult(x)
 	}
 }
 
 func BenchmarkG2(b *testing.B) {
 	x, _ := rand.Int(rand.Reader, Order)
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		new(G2).ScalarBaseMult(x)
 	}
 }
 func BenchmarkPairing(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		Pair(&G1{curveGen}, &G2{twistGen})
 	}
 }

--- a/common/crypto/bn254/google/bn254_test.go
+++ b/common/crypto/bn254/google/bn254_test.go
@@ -305,7 +305,7 @@ func TestTripartiteDiffieHellman(t *testing.T) {
 }
 
 func BenchmarkPairing(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		Pair(&G1{curveGen}, &G2{twistGen})
 	}
 }

--- a/common/crypto/crypto_test.go
+++ b/common/crypto/crypto_test.go
@@ -95,7 +95,7 @@ func TestToECDSAErrors(t *testing.T) {
 
 func BenchmarkSha3(b *testing.B) {
 	a := []byte("hello world")
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		Keccak256(a)
 	}
 }

--- a/common/crypto/ecies/ecies_test.go
+++ b/common/crypto/ecies/ecies_test.go
@@ -176,7 +176,7 @@ func TestTooBigSharedKey(t *testing.T) {
 
 // Benchmark the generation of P256 keys.
 func BenchmarkGenerateKeyP256(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if _, err := GenerateKey(rand.Reader, elliptic.P256(), nil); err != nil {
 			b.Fatal(err)
 		}
@@ -189,8 +189,8 @@ func BenchmarkGenSharedKeyP256(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		_, err := prv.GenerateShared(&prv.PublicKey, 16, 16)
 		if err != nil {
 			b.Fatal(err)
@@ -204,8 +204,8 @@ func BenchmarkGenSharedKeyS256(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		_, err := prv.GenerateShared(&prv.PublicKey, 16, 16)
 		if err != nil {
 			b.Fatal(err)

--- a/common/crypto/signature_test.go
+++ b/common/crypto/signature_test.go
@@ -138,7 +138,7 @@ func TestPubkeyRandom(t *testing.T) {
 }
 
 func BenchmarkEcrecoverSignature(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if _, err := Ecrecover(testmsg, testsig); err != nil {
 			b.Fatal("ecrecover error", err)
 		}
@@ -147,7 +147,7 @@ func BenchmarkEcrecoverSignature(b *testing.B) {
 
 func BenchmarkVerifySignature(b *testing.B) {
 	sig := testsig[:len(testsig)-1] // remove recovery id
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if !VerifySignature(testpubkey, testmsg, sig) {
 			b.Fatal("verify error")
 		}
@@ -155,7 +155,7 @@ func BenchmarkVerifySignature(b *testing.B) {
 }
 
 func BenchmarkDecompressPubkey(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if _, err := DecompressPubkey(testpubkeyc); err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
These changes use b.Loop() to simplify the code and improve performance

Supported by Go Team, more info: https://go.dev/blog/testing-b-loop

More info can see https://go.dev/issue/73137.

Before:

```shell
go test -run=^$ -bench=. ./common/crypto -timeout=1h     
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/common/crypto
cpu: Apple M4
BenchmarkSha3-10                  	 4661552	       240.0 ns/op
BenchmarkEcrecoverSignature-10    	   74696	     16256 ns/op
BenchmarkVerifySignature-10       	   94023	     13391 ns/op
BenchmarkDecompressPubkey-10      	  526609	      2280 ns/op
PASS
ok  	github.com/erigontech/erigon/common/crypto	5.807s

```

After:

```shell
go test -run=^$ -bench=. ./common/crypto -timeout=1h  
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/common/crypto
cpu: Apple M4
BenchmarkSha3-10                  	 4623690	       253.0 ns/op
BenchmarkEcrecoverSignature-10    	   77833	     15569 ns/op
BenchmarkVerifySignature-10       	   91219	     13073 ns/op
BenchmarkDecompressPubkey-10      	  526153	      2268 ns/op
PASS
ok  	github.com/erigontech/erigon/common/crypto	5.181s
```