### PR TITLE
rpc: nonce check if validation requested in eth_simulateV1

### DIFF
--- a/rpc/jsonrpc/eth_simulation.go
+++ b/rpc/jsonrpc/eth_simulation.go
@@ -572,6 +572,7 @@ func (s *simulator) simulateCall(
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	msg.SetCheckNonce(s.validation)
 	intraBlockState.SetTxContext(header.Number.Uint64(), callIndex)
 	logTracer.Reset(txn.Hash(), uint(callIndex))
 


### PR DESCRIPTION
Fixes Hive test `eth_simulateV1/ethSimulate-overflow-nonce-validation`