### PR TITLE
execution/vm: disable the value transfer in syscall

### DIFF
--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -955,22 +955,7 @@ func (sdb *IntraBlockState) AddBalance(addr accounts.Address, amount uint256.Int
 	// EIP161: We must check emptiness for the objects such that the account
 	// clearing (0,0,0 objects) can take effect.
 	if amount.IsZero() {
-		stateObject, err := sdb.GetOrNewStateObject(addr)
-		if err != nil {
-			return err
-		}
-
-		if stateObject.data.Empty() {
-			versionWritten(sdb, addr, BalancePath, accounts.NilKey, uint256.Int{})
-			if _, ok := sdb.journal.dirties[addr]; !ok {
-				if dbg.TraceTransactionIO && (sdb.trace || dbg.TraceAccount(addr.Handle())) {
-					fmt.Printf("%d (%d.%d) Touch %x\n", sdb.blockNum, sdb.txIndex, sdb.version, addr)
-				}
-				sdb.touchAccount(addr)
-			}
-		}
-
-		return nil
+		return sdb.TouchAccount(addr)
 	}
 
 	prev, wasCommited, _ := sdb.getBalance(addr)
@@ -1008,6 +993,27 @@ func (sdb *IntraBlockState) touchAccount(addr accounts.Address) {
 		// flattened journals.
 		sdb.journal.dirty(addr)
 	}
+}
+
+// TouchAccount materializes an empty account and records the zero-balance touch
+// needed for state clearing and trie consistency.
+func (sdb *IntraBlockState) TouchAccount(addr accounts.Address) error {
+	stateObject, err := sdb.GetOrNewStateObject(addr)
+	if err != nil {
+		return err
+	}
+
+	if stateObject.data.Empty() {
+		versionWritten(sdb, addr, BalancePath, accounts.NilKey, uint256.Int{})
+		if _, ok := sdb.journal.dirties[addr]; !ok {
+			if dbg.TraceTransactionIO && (sdb.trace || dbg.TraceAccount(addr.Handle())) {
+				fmt.Printf("%d (%d.%d) Touch %x\n", sdb.blockNum, sdb.txIndex, sdb.version, addr)
+			}
+			sdb.touchAccount(addr)
+		}
+	}
+
+	return nil
 }
 
 func (sdb *IntraBlockState) getVersionedAccount(addr accounts.Address, readStorage bool) (*accounts.Account, ReadSource, Version, error) {
@@ -1140,10 +1146,11 @@ func (sdb *IntraBlockState) refreshVersionedAccount(addr accounts.Address, readA
 // SubBalance subtracts amount from the account associated with addr.
 // DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) SubBalance(addr accounts.Address, amount uint256.Int, reason tracing.BalanceChangeReason) error {
-	if amount.IsZero() && addr != params.SystemAddress {
-		// We skip this early exit if the sender is the system address
-		// because Gnosis has a special logic to create an empty system account
-		// even after Spurious Dragon (see PR 5645 and Issue 18276).
+	if amount.IsZero() {
+		if addr == params.SystemAddress {
+			// Gnosis keeps an empty system account even after Spurious Dragon.
+			return sdb.TouchAccount(addr)
+		}
 		return nil
 	}
 

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -1148,7 +1148,13 @@ func (sdb *IntraBlockState) refreshVersionedAccount(addr accounts.Address, readA
 func (sdb *IntraBlockState) SubBalance(addr accounts.Address, amount uint256.Int, reason tracing.BalanceChangeReason) error {
 	if amount.IsZero() {
 		if addr == params.SystemAddress {
-			// Gnosis keeps an empty system account even after Spurious Dragon.
+			// Gnosis/AuRa keeps an empty system account even after
+			// Spurious Dragon (see PR 5645 and Issue 18276).
+			//
+			// The primary syscall path in evm.call() handles this via
+			// TouchAccount directly; this branch is retained as
+			// defense-in-depth for other callers (AuRa engine,
+			// consensus callbacks).
 			return sdb.TouchAccount(addr)
 		}
 		return nil

--- a/execution/vm/evm.go
+++ b/execution/vm/evm.go
@@ -307,10 +307,11 @@ func (evm *EVM) call(typ OpCode, caller accounts.Address, callerAddress accounts
 
 	if typ == CALL || typ == CALLCODE {
 		// Fail if we're trying to transfer more than the available balance.
-		// CanTransfer is only relevant for calls that may execute Transfer.
-		// Zero-value calls short-circuit the balance check, and system calls
-		// are excluded because they intentionally bypass Transfer semantics.
-		if !syscall && !value.IsZero() {
+		// Only check when value is non-zero — matching geth's short-circuit
+		// behavior. Calling CanTransfer for zero-value calls (e.g. system
+		// calls) creates spurious balance reads on the caller that pollute
+		// the Block Access List (EIP-7928).
+		if !value.IsZero() {
 			canTransfer, err := evm.Context.CanTransfer(evm.intraBlockState, caller, value)
 			if err != nil {
 				return nil, mdgas.MdGas{}, err

--- a/execution/vm/evm.go
+++ b/execution/vm/evm.go
@@ -325,7 +325,7 @@ func (evm *EVM) call(typ OpCode, caller accounts.Address, callerAddress accounts
 			return nil, mdgas.MdGas{}, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
 		}
 		if !exist {
-			if !isPrecompile && evm.chainRules.IsSpuriousDragon && value.IsZero() {
+			if !isPrecompile && evm.chainRules.IsSpuriousDragon && value.IsZero() && !isSystemCall(caller) {
 				return nil, gas, nil
 			}
 			evm.intraBlockState.CreateAccount(addr, false)

--- a/execution/vm/evm.go
+++ b/execution/vm/evm.go
@@ -307,11 +307,9 @@ func (evm *EVM) call(typ OpCode, caller accounts.Address, callerAddress accounts
 
 	if typ == CALL || typ == CALLCODE {
 		// Fail if we're trying to transfer more than the available balance.
-		// Only check for non-system calls with non-zero value. Skipping
-		// CanTransfer for zero-value calls matches geth's short-circuit
-		// behavior, while skipping system calls avoids spurious balance
-		// reads on the caller that pollute the Block Access List
-		// (EIP-7928).
+		// CanTransfer is only relevant for calls that may execute Transfer.
+		// Zero-value calls short-circuit the balance check, and system calls
+		// are excluded because they intentionally bypass Transfer semantics.
 		if !syscall && !value.IsZero() {
 			canTransfer, err := evm.Context.CanTransfer(evm.intraBlockState, caller, value)
 			if err != nil {

--- a/execution/vm/evm.go
+++ b/execution/vm/evm.go
@@ -344,8 +344,9 @@ func (evm *EVM) call(typ OpCode, caller accounts.Address, callerAddress accounts
 				return nil, mdgas.MdGas{}, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
 			}
 		} else {
-			// Calling Transfer is required even for zero-value transfers to
-			// ensure the usual touch/state-clearing behavior is applied.
+			// Normal (non-syscall) calls always go through Transfer —
+			// this handles both value movement and the zero-balance touch
+			// required for state clearing.
 			if err := evm.Context.Transfer(evm.intraBlockState, caller, addr, value, bailout, evm.chainRules); err != nil {
 				return nil, mdgas.MdGas{}, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
 			}

--- a/execution/vm/evm.go
+++ b/execution/vm/evm.go
@@ -252,6 +252,10 @@ func (evm *EVM) SetCallGasTemp(gas uint64) {
 	evm.callGasTemp = gas
 }
 
+func isSystemCall(caller accounts.Address) bool {
+	return caller == params.SystemAddress
+}
+
 // SetPrecompiles sets the precompiles for the EVM
 func (evm *EVM) SetPrecompiles(precompiles PrecompiledContracts) {
 	evm.precompiles = precompiles
@@ -299,13 +303,15 @@ func (evm *EVM) call(typ OpCode, caller accounts.Address, callerAddress accounts
 	if depth > int(params.CallCreateDepth) {
 		return nil, gas, ErrDepth
 	}
+	syscall := isSystemCall(caller)
+
 	if typ == CALL || typ == CALLCODE {
 		// Fail if we're trying to transfer more than the available balance.
 		// Only check when value is non-zero — matching geth's short-circuit
 		// behavior. Calling CanTransfer for zero-value calls (e.g. system
 		// calls) creates spurious balance reads on the caller that pollute
 		// the Block Access List (EIP-7928).
-		if !value.IsZero() {
+		if !syscall && !value.IsZero() {
 			canTransfer, err := evm.Context.CanTransfer(evm.intraBlockState, caller, value)
 			if err != nil {
 				return nil, mdgas.MdGas{}, err
@@ -330,7 +336,18 @@ func (evm *EVM) call(typ OpCode, caller accounts.Address, callerAddress accounts
 			}
 			evm.intraBlockState.CreateAccount(addr, false)
 		}
-		evm.Context.Transfer(evm.intraBlockState, caller, addr, value, bailout, evm.chainRules)
+		// System calls still need the sender-side zero-balance touch so AuRa
+		// keeps the empty system account in the PMT, but they must not execute
+		// the full transfer semantics.
+		if syscall && value.IsZero() {
+			if err := evm.intraBlockState.TouchAccount(caller); err != nil {
+				return nil, mdgas.MdGas{}, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
+			}
+		} else {
+			// Calling Transfer is required even for zero-value transfers to
+			// ensure the usual touch/state-clearing behavior is applied.
+			evm.Context.Transfer(evm.intraBlockState, caller, addr, value, bailout, evm.chainRules)
+		}
 	} else if typ == STATICCALL {
 		// We do an AddBalance of zero here, just in order to trigger a touch.
 		// This doesn't matter on Mainnet, where all empties are gone at the time of Byzantium,

--- a/execution/vm/evm.go
+++ b/execution/vm/evm.go
@@ -307,10 +307,7 @@ func (evm *EVM) call(typ OpCode, caller accounts.Address, callerAddress accounts
 
 	if typ == CALL || typ == CALLCODE {
 		// Fail if we're trying to transfer more than the available balance.
-		// Only check when value is non-zero — matching geth's short-circuit
-		// behavior. Calling CanTransfer for zero-value calls (e.g. system
-		// calls) creates spurious balance reads on the caller that pollute
-		// the Block Access List (EIP-7928).
+		// Skip the check for zero-value calls, matching geth's short-circuit.
 		if !value.IsZero() {
 			canTransfer, err := evm.Context.CanTransfer(evm.intraBlockState, caller, value)
 			if err != nil {
@@ -336,9 +333,10 @@ func (evm *EVM) call(typ OpCode, caller accounts.Address, callerAddress accounts
 			}
 			evm.intraBlockState.CreateAccount(addr, false)
 		}
-		// System calls still need the sender-side zero-balance touch so AuRa
-		// keeps the empty system account in the PMT, but they must not execute
-		// the full transfer semantics.
+		// System calls use TouchAccount instead of Transfer to avoid
+		// spurious balance reads on the caller that would pollute the
+		// Block Access List (EIP-7928). The touch is still needed so
+		// AuRa/Gnosis keeps the empty system account in the PMT.
 		if syscall && value.IsZero() {
 			if err := evm.intraBlockState.TouchAccount(caller); err != nil {
 				return nil, mdgas.MdGas{}, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)

--- a/execution/vm/evm.go
+++ b/execution/vm/evm.go
@@ -307,10 +307,11 @@ func (evm *EVM) call(typ OpCode, caller accounts.Address, callerAddress accounts
 
 	if typ == CALL || typ == CALLCODE {
 		// Fail if we're trying to transfer more than the available balance.
-		// Only check when value is non-zero — matching geth's short-circuit
-		// behavior. Calling CanTransfer for zero-value calls (e.g. system
-		// calls) creates spurious balance reads on the caller that pollute
-		// the Block Access List (EIP-7928).
+		// Only check for non-system calls with non-zero value. Skipping
+		// CanTransfer for zero-value calls matches geth's short-circuit
+		// behavior, while skipping system calls avoids spurious balance
+		// reads on the caller that pollute the Block Access List
+		// (EIP-7928).
 		if !syscall && !value.IsZero() {
 			canTransfer, err := evm.Context.CanTransfer(evm.intraBlockState, caller, value)
 			if err != nil {
@@ -346,7 +347,9 @@ func (evm *EVM) call(typ OpCode, caller accounts.Address, callerAddress accounts
 		} else {
 			// Calling Transfer is required even for zero-value transfers to
 			// ensure the usual touch/state-clearing behavior is applied.
-			evm.Context.Transfer(evm.intraBlockState, caller, addr, value, bailout, evm.chainRules)
+			if err := evm.Context.Transfer(evm.intraBlockState, caller, addr, value, bailout, evm.chainRules); err != nil {
+				return nil, mdgas.MdGas{}, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
+			}
 		}
 	} else if typ == STATICCALL {
 		// We do an AddBalance of zero here, just in order to trigger a touch.
@@ -573,7 +576,9 @@ func (evm *EVM) create(caller accounts.Address, codeAndHash *codeAndHash, gasRem
 	if evm.chainRules.IsSpuriousDragon {
 		evm.intraBlockState.SetNonce(address, 1)
 	}
-	evm.Context.Transfer(evm.intraBlockState, caller, address, value, bailout, evm.chainRules)
+	if err := evm.Context.Transfer(evm.intraBlockState, caller, address, value, bailout, evm.chainRules); err != nil {
+		return nil, accounts.NilAddress, mdgas.MdGas{}, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
+	}
 
 	// Initialise a new contract and set the code that is to be used by the EVM.
 	// The contract is a scoped environment for this execution context only.

--- a/execution/vm/evm.go
+++ b/execution/vm/evm.go
@@ -325,7 +325,7 @@ func (evm *EVM) call(typ OpCode, caller accounts.Address, callerAddress accounts
 			return nil, mdgas.MdGas{}, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
 		}
 		if !exist {
-			if !isPrecompile && evm.chainRules.IsSpuriousDragon && value.IsZero() && !isSystemCall(caller) {
+			if !isPrecompile && evm.chainRules.IsSpuriousDragon && value.IsZero() && !syscall {
 				return nil, gas, nil
 			}
 			evm.intraBlockState.CreateAccount(addr, false)

--- a/execution/vm/gas_table_test.go
+++ b/execution/vm/gas_table_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/erigontech/erigon/db/state/execctx"
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/protocol/mdgas"
+	"github.com/erigontech/erigon/execution/protocol/params"
 	"github.com/erigontech/erigon/execution/state"
 	"github.com/erigontech/erigon/execution/tests/testutil"
 	"github.com/erigontech/erigon/execution/types/accounts"
@@ -219,4 +220,42 @@ func TestCreateGas(t *testing.T) {
 		domains.Close()
 	}
 	tx.Rollback()
+}
+
+// TestSystemCallZeroValueSkipsTransferChecks verifies that zero-value system
+// calls do not invoke CanTransfer or Transfer.
+func TestSystemCallZeroValueSkipsTransferChecks(t *testing.T) {
+	t.Parallel()
+
+	tx, sd := testTemporalTxSD(t)
+	txNum, _, err := sd.SeekCommitment(t.Context(), tx)
+	require.NoError(t, err)
+
+	r, w := state.NewReaderV3(sd.AsGetter(tx)), state.NewWriter(sd.AsPutDel(tx), nil, txNum)
+	s := state.New(r)
+
+	address := accounts.InternAddress(common.BytesToAddress([]byte("callee")))
+
+	canTransferCalled := false
+	transferCalled := false
+	canTransferErr := errors.New("can transfer should not be called")
+	transferErr := errors.New("transfer should not be called")
+
+	vmctx := evmtypes.BlockContext{
+		CanTransfer: func(evmtypes.IntraBlockState, accounts.Address, uint256.Int) (bool, error) {
+			canTransferCalled = true
+			return false, canTransferErr
+		},
+		Transfer: func(evmtypes.IntraBlockState, accounts.Address, accounts.Address, uint256.Int, bool, *chain.Rules) error {
+			transferCalled = true
+			return transferErr
+		},
+	}
+	_ = s.CommitBlock(vmctx.Rules(chain.TestChainConfig), w)
+
+	vmenv := vm.NewEVM(vmctx, evmtypes.TxContext{}, s, chain.TestChainConfig, vm.Config{})
+	_, _, err = vmenv.Call(params.SystemAddress, address, nil, mdgas.MdGas{Regular: math.MaxUint64}, uint256.Int{}, false /* bailout */)
+	require.NoError(t, err)
+	require.False(t, canTransferCalled, "CanTransfer should be skipped for zero-value system calls")
+	require.False(t, transferCalled, "Transfer should be skipped for zero-value system calls")
 }

--- a/execution/vm/gas_table_test.go
+++ b/execution/vm/gas_table_test.go
@@ -251,9 +251,9 @@ func TestSystemCallZeroValueSkipsTransferChecks(t *testing.T) {
 			return transferErr
 		},
 	}
-	_ = s.CommitBlock(vmctx.Rules(chain.TestChainConfig), w)
+	_ = s.CommitBlock(vmctx.Rules(chain.TestChainBerlinConfig), w)
 
-	vmenv := vm.NewEVM(vmctx, evmtypes.TxContext{}, s, chain.TestChainConfig, vm.Config{})
+	vmenv := vm.NewEVM(vmctx, evmtypes.TxContext{}, s, chain.TestChainBerlinConfig, vm.Config{})
 	_, _, err = vmenv.Call(params.SystemAddress, address, nil, mdgas.MdGas{Regular: math.MaxUint64}, uint256.Int{}, false /* bailout */)
 	require.NoError(t, err)
 	require.False(t, canTransferCalled, "CanTransfer should be skipped for zero-value system calls")

--- a/execution/vm/runtime/runtime_test.go
+++ b/execution/vm/runtime/runtime_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/protocol"
 	"github.com/erigontech/erigon/execution/protocol/mdgas"
+	"github.com/erigontech/erigon/execution/protocol/params"
 	"github.com/erigontech/erigon/execution/protocol/rules"
 	"github.com/erigontech/erigon/execution/state"
 	"github.com/erigontech/erigon/execution/tests/testutil"
@@ -889,4 +890,100 @@ func TestGasTracingNoUnderflowOnStateGas(t *testing.T) {
 		}
 	}
 	require.True(t, found, "expected at least one GasChangeCallOpCode event from SSTORE")
+}
+
+// TestSystemCallZeroValueSkipsTransferChecks verifies that a system call
+// (caller = SystemAddress, value = 0) executes successfully without triggering
+// CanTransfer or Transfer balance-change hooks on the caller. It also asserts:
+//   - SYSTEM_ADDRESS was touched and exists after the call (positive check on the
+//     caller-side empty-account creation for Gnosis/AuRa; see PR 5645, Issue 18276).
+//   - SYSTEM_ADDRESS remains an empty account after the call.
+//   - SYSTEM_ADDRESS is absent from the BAL produced by the call's TxIO.
+//   - No balance-change tracer events fire for SYSTEM_ADDRESS as a result of
+//     the zero-value transfer path.
+func TestSystemCallZeroValueSkipsTransferChecks(t *testing.T) {
+	t.Parallel()
+
+	db := testutil.TemporalDB(t)
+	tx, domains := testutil.TemporalTxSD(t, db)
+	statedb := state.New(state.NewReaderV3(domains.AsGetter(tx)))
+
+	systemAddr := params.SystemAddress
+	target := accounts.InternAddress(common.HexToAddress("0xbeef"))
+
+	// Deploy a trivial contract at the target that returns 0x42.
+	statedb.CreateAccount(target, true)
+	statedb.SetCode(target, []byte{
+		byte(vm.PUSH1), 0x42,
+		byte(vm.PUSH1), 0,
+		byte(vm.MSTORE),
+		byte(vm.PUSH1), 32,
+		byte(vm.PUSH1), 0,
+		byte(vm.RETURN),
+	})
+
+	// Track balance-change events on SYSTEM_ADDRESS.
+	type balChange struct {
+		addr   accounts.Address
+		oldBal uint256.Int
+		newBal uint256.Int
+		reason tracing.BalanceChangeReason
+	}
+	var balChanges []balChange
+
+	hooks := &tracing.Hooks{
+		OnBalanceChange: func(addr accounts.Address, prev, newBal uint256.Int, reason tracing.BalanceChangeReason) {
+			if addr == systemAddr {
+				balChanges = append(balChanges, balChange{addr, prev, newBal, reason})
+			}
+		},
+	}
+
+	cfg := &Config{
+		State:     statedb,
+		Origin:    systemAddr,
+		EVMConfig: vm.Config{Tracer: hooks},
+		GasLimit:  10_000_000,
+	}
+	setDefaults(cfg)
+
+	vmenv := NewEnv(cfg)
+	rules := vmenv.ChainRules()
+	statedb.Prepare(rules, systemAddr, cfg.Coinbase, target, vm.ActivePrecompiles(rules), nil, nil)
+
+	ret, _, err := vmenv.Call(
+		systemAddr,
+		target,
+		nil,
+		mdgas.SplitTxnGasLimit(cfg.GasLimit, mdgas.MdGas{}, rules),
+		uint256.Int{}, // value = 0
+		false,
+	)
+	require.NoError(t, err)
+
+	// The contract should have returned 0x42.
+	require.Equal(t, 32, len(ret))
+	require.Equal(t, byte(0x42), ret[31])
+
+	// Positive check: SYSTEM_ADDRESS must exist (Gnosis/AuRa invariant).
+	exists, err := statedb.Exist(systemAddr)
+	require.NoError(t, err)
+	require.True(t, exists, "SYSTEM_ADDRESS should exist after a zero-value syscall")
+
+	// SYSTEM_ADDRESS must remain empty after the touch.
+	empty, err := statedb.Empty(systemAddr)
+	require.NoError(t, err)
+	require.True(t, empty, "SYSTEM_ADDRESS should remain empty after a zero-value syscall")
+
+	// The call-level BAL must not include SYSTEM_ADDRESS when the syscall only
+	// performs the sender-side touch and no actual account access.
+	bal := statedb.TxIO().AsBlockAccessList()
+	for _, accountChanges := range bal {
+		require.NotEqual(t, systemAddr, accountChanges.Address,
+			"SYSTEM_ADDRESS should be absent from the BAL after a zero-value syscall")
+	}
+
+	// No balance-change events should have fired for SYSTEM_ADDRESS
+	// from the zero-value call path.
+	require.Empty(t, balChanges, "no balance-change events expected for SYSTEM_ADDRESS on zero-value syscall, got %v", balChanges)
 }


### PR DESCRIPTION
In [src/ethereum/forks/amsterdam/vm/interpreter.py (lines 299–304)](https://github.com/ethereum/execution-specs/blob/d22139bf438649d9dbc139ab685b9f9075980253/src/ethereum/forks/amsterdam/vm/interpreter.py#L299), the caller’s address is currently added to the block-level access list only when there is an actual ETH value transfer. This check depends on `should_transfer_value` being true and value being `non-zero`. For system transactions, both of these are set to false and zero respectively, so this condition never passes. As a result, the caller address (SYSTEM_ADDRESS) is not tracked in the access list during system calls. This PR implements the same syscall behavior in Erigon, aligning it with [Geth](https://github.com/ethereum/go-ethereum/pull/33741) and the EIP-7928 specification.