### PR TITLE
execution/types: additive transaction-type registry

### DIFF
--- a/execution/types/transaction.go
+++ b/execution/types/transaction.go
@@ -105,6 +105,25 @@ type TransactionMisc struct {
 	from accounts.Address
 }
 
+// The sender-cache trio is promoted from the embedding type when it doesn't
+// define its own; cachedSender being unexported, this is what lets a
+// transaction type outside this package satisfy the Transaction interface.
+func (t *TransactionMisc) cachedSender() (sender accounts.Address, ok bool) {
+	s := t.from
+	if s.IsNil() {
+		return sender, false
+	}
+	return s, true
+}
+
+func (t *TransactionMisc) GetSender() (accounts.Address, bool) {
+	return t.cachedSender()
+}
+
+func (t *TransactionMisc) SetSender(addr accounts.Address) {
+	t.from = addr
+}
+
 // CalcEffectiveGasTip computes the effective gas tip given a transaction's tip/fee caps and a base fee.
 // Shared logic used by all transaction types that implement GetEffectiveGasTip.
 func CalcEffectiveGasTip(baseFee *uint256.Int, getTipCap func() *uint256.Int, getFeeCap func() *uint256.Int) uint256.Int {
@@ -236,6 +255,10 @@ func UnmarshalTransactionFromBinary(data []byte, blobTxnsAreWrappedWithBlobs boo
 	case AccountAbstractionTxType:
 		t = &AccountAbstractionTransaction{}
 	default:
+		if spec, ok := registeredTxType(data[0]); ok {
+			t = spec.New()
+			break
+		}
 		if data[0] >= 0x80 {
 			// txn is type legacy which is RLP encoded
 			return DecodeTransaction(data)

--- a/execution/types/transaction_marshalling.go
+++ b/execution/types/transaction_marshalling.go
@@ -255,6 +255,9 @@ func UnmarshalTransactionFromJSON(input []byte) (Transaction, error) {
 		}
 		return tx, nil
 	default:
+		if spec, ok := registeredTxType(byte(txType)); ok {
+			return spec.UnmarshalJSON(input)
+		}
 		return nil, fmt.Errorf("unknown transaction type: %v", txType)
 	}
 }

--- a/execution/types/transaction_marshalling.go
+++ b/execution/types/transaction_marshalling.go
@@ -223,6 +223,9 @@ func UnmarshalTransactionFromJSON(input []byte) (Transaction, error) {
 			return nil, err
 		}
 	}
+	if txType > 0xff {
+		return nil, fmt.Errorf("unknown transaction type: %v", txType)
+	}
 	switch byte(txType) {
 	case LegacyTxType:
 		tx := &LegacyTx{}

--- a/execution/types/transaction_marshalling.go
+++ b/execution/types/transaction_marshalling.go
@@ -255,7 +255,7 @@ func UnmarshalTransactionFromJSON(input []byte) (Transaction, error) {
 		}
 		return tx, nil
 	default:
-		if spec, ok := registeredTxType(byte(txType)); ok {
+		if spec, ok := registeredTxType(byte(txType)); ok && spec.UnmarshalJSON != nil {
 			return spec.UnmarshalJSON(input)
 		}
 		return nil, fmt.Errorf("unknown transaction type: %v", txType)

--- a/execution/types/transaction_marshalling.go
+++ b/execution/types/transaction_marshalling.go
@@ -255,7 +255,7 @@ func UnmarshalTransactionFromJSON(input []byte) (Transaction, error) {
 		}
 		return tx, nil
 	default:
-		if spec, ok := registeredTxType(byte(txType)); ok && spec.UnmarshalJSON != nil {
+		if spec, ok := registeredTxType(byte(txType)); ok && uint64(txType) < 0x80 && spec.UnmarshalJSON != nil {
 			return spec.UnmarshalJSON(input)
 		}
 		return nil, fmt.Errorf("unknown transaction type: %v", txType)

--- a/execution/types/transaction_signing.go
+++ b/execution/types/transaction_signing.go
@@ -290,8 +290,8 @@ func (sg Signer) SenderWithContext(context *secp256k1.Context, txn Transaction) 
 	case *AccountAbstractionTransaction:
 		return txn.Sender(Signer{})
 	default:
-		if _, ok := registeredTxType(txn.Type()); ok {
-			return txn.Sender(Signer{})
+		if spec, ok := registeredTxType(txn.Type()); ok && spec.Sender != nil {
+			return spec.Sender(txn, sg)
 		}
 		return accounts.NilAddress, ErrTxTypeNotSupported
 	}
@@ -326,8 +326,15 @@ func (sg Signer) SignatureValues(txn Transaction, sig []byte) (R, S, V *uint256.
 		}
 	default:
 		if _, ok := registeredTxType(txn.Type()); ok {
-			v, r, s := txn.RawSignatureValues()
-			return r, s, v, nil
+			chainId := txn.GetChainID()
+			if chainId != nil && !chainId.IsZero() && !chainId.Eq(&sg.chainID) {
+				return nil, nil, nil, ErrInvalidChainId
+			}
+			R, S, V, err = decodeSignature(sig)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			return R, S, V, nil
 		}
 		return nil, nil, nil, ErrTxTypeNotSupported
 	}

--- a/execution/types/transaction_signing.go
+++ b/execution/types/transaction_signing.go
@@ -290,6 +290,9 @@ func (sg Signer) SenderWithContext(context *secp256k1.Context, txn Transaction) 
 	case *AccountAbstractionTransaction:
 		return txn.Sender(Signer{})
 	default:
+		if _, ok := registeredTxType(txn.Type()); ok {
+			return txn.Sender(Signer{})
+		}
 		return accounts.NilAddress, ErrTxTypeNotSupported
 	}
 	return recoverPlain(context, txn.SigningHash(signChainID), R, S, &V, !sg.malleable)
@@ -322,6 +325,10 @@ func (sg Signer) SignatureValues(txn Transaction, sig []byte) (R, S, V *uint256.
 			return nil, nil, nil, err
 		}
 	default:
+		if _, ok := registeredTxType(txn.Type()); ok {
+			v, r, s := txn.RawSignatureValues()
+			return r, s, v, nil
+		}
 		return nil, nil, nil, ErrTxTypeNotSupported
 	}
 	return R, S, V, nil

--- a/execution/types/tx_registry.go
+++ b/execution/types/tx_registry.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Erigon Authors
+// Copyright 2026 The Erigon Authors
 // This file is part of Erigon.
 //
 // Erigon is free software: you can redistribute it and/or modify

--- a/execution/types/tx_registry.go
+++ b/execution/types/tx_registry.go
@@ -1,0 +1,59 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"fmt"
+)
+
+// TxTypeSpec describes an externally registered transaction type's decode
+// facets. It is consulted only from the default arm of the built-in type
+// switches, so an unregistered id keeps today's behavior unchanged.
+type TxTypeSpec struct {
+	New           func() Transaction
+	UnmarshalJSON func([]byte) (Transaction, error)
+}
+
+var txTypeRegistry = map[byte]TxTypeSpec{}
+
+// RegisterTxType registers spec for id. It panics if id collides with a
+// built-in transaction type, lies outside the EIP-2718 typed-envelope range,
+// or was already registered, and if spec.New is nil — all programming errors
+// caught at init time.
+func RegisterTxType(id byte, spec TxTypeSpec) {
+	switch id {
+	case LegacyTxType, AccessListTxType, DynamicFeeTxType, BlobTxType, SetCodeTxType, AccountAbstractionTxType:
+		panic(fmt.Sprintf("types: RegisterTxType: %d collides with a built-in transaction type", id))
+	}
+	if id >= 0x80 {
+		// EIP-2718 reserves type bytes below 0x80; above it is the first byte
+		// of a legacy RLP-encoded transaction.
+		panic(fmt.Sprintf("types: RegisterTxType: %d outside the EIP-2718 type range", id))
+	}
+	if spec.New == nil {
+		panic("types: RegisterTxType: spec.New is nil")
+	}
+	if _, ok := txTypeRegistry[id]; ok {
+		panic(fmt.Sprintf("types: RegisterTxType: %d already registered", id))
+	}
+	txTypeRegistry[id] = spec
+}
+
+func registeredTxType(id byte) (TxTypeSpec, bool) {
+	spec, ok := txTypeRegistry[id]
+	return spec, ok
+}

--- a/execution/types/tx_registry.go
+++ b/execution/types/tx_registry.go
@@ -19,6 +19,8 @@ package types
 import (
 	"fmt"
 	"sync"
+
+	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
 // TxTypeSpec describes an externally registered transaction type's decode
@@ -29,6 +31,10 @@ type TxTypeSpec struct {
 	// UnmarshalJSON may be nil for types not submittable over JSON-RPC;
 	// JSON decoding then rejects the type id as unknown.
 	UnmarshalJSON func([]byte) (Transaction, error)
+	// Sender resolves the transaction's sender with the caller's signer; it
+	// must be self-contained and never call back into the signer's own
+	// dispatch. Nil means sender recovery rejects the type.
+	Sender func(txn Transaction, sg Signer) (accounts.Address, error)
 }
 
 var (

--- a/execution/types/tx_registry.go
+++ b/execution/types/tx_registry.go
@@ -18,17 +18,23 @@ package types
 
 import (
 	"fmt"
+	"sync"
 )
 
 // TxTypeSpec describes an externally registered transaction type's decode
 // facets. It is consulted only from the default arm of the built-in type
 // switches, so an unregistered id keeps today's behavior unchanged.
 type TxTypeSpec struct {
-	New           func() Transaction
+	New func() Transaction
+	// UnmarshalJSON may be nil for types not submittable over JSON-RPC;
+	// JSON decoding then rejects the type id as unknown.
 	UnmarshalJSON func([]byte) (Transaction, error)
 }
 
-var txTypeRegistry = map[byte]TxTypeSpec{}
+var (
+	txTypeRegistryMu sync.RWMutex
+	txTypeRegistry   = map[byte]TxTypeSpec{}
+)
 
 // RegisterTxType registers spec for id. It panics if id collides with a
 // built-in transaction type, lies outside the EIP-2718 typed-envelope range,
@@ -47,13 +53,23 @@ func RegisterTxType(id byte, spec TxTypeSpec) {
 	if spec.New == nil {
 		panic("types: RegisterTxType: spec.New is nil")
 	}
+	txTypeRegistryMu.Lock()
+	defer txTypeRegistryMu.Unlock()
 	if _, ok := txTypeRegistry[id]; ok {
 		panic(fmt.Sprintf("types: RegisterTxType: %d already registered", id))
 	}
 	txTypeRegistry[id] = spec
 }
 
+func unregisterTxType(id byte) {
+	txTypeRegistryMu.Lock()
+	defer txTypeRegistryMu.Unlock()
+	delete(txTypeRegistry, id)
+}
+
 func registeredTxType(id byte) (TxTypeSpec, bool) {
+	txTypeRegistryMu.RLock()
+	defer txTypeRegistryMu.RUnlock()
 	spec, ok := txTypeRegistry[id]
 	return spec, ok
 }

--- a/execution/types/tx_registry.go
+++ b/execution/types/tx_registry.go
@@ -67,12 +67,6 @@ func RegisterTxType(id byte, spec TxTypeSpec) {
 	txTypeRegistry[id] = spec
 }
 
-func unregisterTxType(id byte) {
-	txTypeRegistryMu.Lock()
-	defer txTypeRegistryMu.Unlock()
-	delete(txTypeRegistry, id)
-}
-
 func registeredTxType(id byte) (TxTypeSpec, bool) {
 	txTypeRegistryMu.RLock()
 	defer txTypeRegistryMu.RUnlock()

--- a/execution/types/tx_registry_embed_test.go
+++ b/execution/types/tx_registry_embed_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+// Package types_test pins from outside the package that embedding
+// TransactionMisc is sufficient for an external transaction type to satisfy
+// the Transaction interface (cachedSender is unexported) and ride the
+// registry end to end.
+package types_test
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/rlp"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+const externalTxType = 0x7b
+
+type externalTx struct {
+	types.TransactionMisc
+
+	Nonce uint64
+	from  accounts.Address
+}
+
+var _ types.Transaction = (*externalTx)(nil)
+
+func (tx *externalTx) Type() byte                               { return externalTxType }
+func (tx *externalTx) GetChainID() *uint256.Int                 { return uint256.NewInt(0) }
+func (tx *externalTx) GetNonce() uint64                         { return tx.Nonce }
+func (tx *externalTx) GetTipCap() *uint256.Int                  { return uint256.NewInt(0) }
+func (tx *externalTx) GetFeeCap() *uint256.Int                  { return uint256.NewInt(0) }
+func (tx *externalTx) GetBlobHashes() []common.Hash             { return nil }
+func (tx *externalTx) GetGasLimit() uint64                      { return 21000 }
+func (tx *externalTx) GetBlobGas() uint64                       { return 0 }
+func (tx *externalTx) GetValue() *uint256.Int                   { return uint256.NewInt(0) }
+func (tx *externalTx) GetTo() *common.Address                   { return nil }
+func (tx *externalTx) GetData() []byte                          { return nil }
+func (tx *externalTx) GetAccessList() types.AccessList          { return nil }
+func (tx *externalTx) GetAuthorizations() []types.Authorization { return nil }
+func (tx *externalTx) Protected() bool                          { return true }
+func (tx *externalTx) IsContractDeploy() bool                   { return false }
+func (tx *externalTx) Unwrap() types.Transaction                { return tx }
+
+func (tx *externalTx) GetEffectiveGasTip(*uint256.Int) uint256.Int { return uint256.Int{} }
+
+func (tx *externalTx) AsMessage(types.Signer, *uint256.Int, *chain.Rules) (*types.Message, error) {
+	return nil, nil
+}
+
+func (tx *externalTx) WithSignature(types.Signer, []byte) (types.Transaction, error) {
+	return tx, nil
+}
+
+func (tx *externalTx) Hash() common.Hash                    { return types.RlpHash([]any{tx.Nonce}) }
+func (tx *externalTx) SigningHash(*uint256.Int) common.Hash { return tx.Hash() }
+
+func (tx *externalTx) RawSignatureValues() (*uint256.Int, *uint256.Int, *uint256.Int) {
+	z := uint256.NewInt(0)
+	return z, z, z
+}
+
+func (tx *externalTx) EncodingSize() int { return rlp.U64Len(tx.Nonce) }
+
+func (tx *externalTx) EncodeRLP(w io.Writer) error {
+	b := rlp.NewEncodingBuf()
+	defer b.Release()
+	if err := rlp.EncodeListPrefix(rlp.U64Len(tx.Nonce), w, b[:]); err != nil {
+		return err
+	}
+	return rlp.EncodeU64(tx.Nonce, w, b[:])
+}
+
+func (tx *externalTx) DecodeRLP(s *rlp.Stream) error {
+	if _, err := s.List(); err != nil {
+		return err
+	}
+	var err error
+	if tx.Nonce, err = s.Uint64(); err != nil {
+		return err
+	}
+	return s.ListEnd()
+}
+
+func (tx *externalTx) MarshalBinary(w io.Writer) error {
+	if _, err := w.Write([]byte{externalTxType}); err != nil {
+		return err
+	}
+	return tx.EncodeRLP(w)
+}
+
+func (tx *externalTx) Sender(types.Signer) (accounts.Address, error) {
+	if from, ok := tx.GetSender(); ok {
+		return from, nil
+	}
+	tx.SetSender(tx.from)
+	return tx.from, nil
+}
+
+func TestExternalPackageTxTypeEndToEnd(t *testing.T) {
+	want := accounts.InternAddress(common.HexToAddress("0xabcd"))
+	types.RegisterTxType(externalTxType, types.TxTypeSpec{
+		New: func() types.Transaction { return &externalTx{} },
+		Sender: func(txn types.Transaction, _ types.Signer) (accounts.Address, error) {
+			return txn.(*externalTx).Sender(types.Signer{})
+		},
+	})
+	t.Cleanup(func() { types.UnregisterTxTypeForTesting(externalTxType) })
+
+	var buf bytes.Buffer
+	require.NoError(t, (&externalTx{Nonce: 7, from: want}).MarshalBinary(&buf))
+
+	decoded, err := types.UnmarshalTransactionFromBinary(buf.Bytes(), false)
+	require.NoError(t, err)
+	require.Equal(t, uint64(7), decoded.GetNonce())
+
+	decoded.SetSender(want)
+	got, err := types.Signer{}.SenderWithContext(nil, decoded)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}

--- a/execution/types/tx_registry_export_test.go
+++ b/execution/types/tx_registry_export_test.go
@@ -1,0 +1,19 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+var UnregisterTxTypeForTesting = unregisterTxType

--- a/execution/types/tx_registry_test.go
+++ b/execution/types/tx_registry_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Erigon Authors
+// Copyright 2026 The Erigon Authors
 // This file is part of Erigon.
 //
 // Erigon is free software: you can redistribute it and/or modify

--- a/execution/types/tx_registry_test.go
+++ b/execution/types/tx_registry_test.go
@@ -265,6 +265,13 @@ func TestRegisteredTxTypeJSONTypeAliasing(t *testing.T) {
 	require.Error(t, err, "an out-of-range type value must not alias onto a registered byte id")
 }
 
+func TestJSONBuiltinTypeAliasing(t *testing.T) {
+	// byte(0x100) == 0x00 would alias an out-of-range type onto LegacyTxType;
+	// it must be rejected as unknown rather than silently decoded as legacy.
+	_, err := UnmarshalTransactionFromJSON([]byte(`{"type":"0x100","nonce":"0x1"}`))
+	require.ErrorContains(t, err, "unknown transaction type")
+}
+
 func TestRegisterTxTypeCollisions(t *testing.T) {
 	builtinSpec := TxTypeSpec{New: func() Transaction { return &LegacyTx{} }}
 

--- a/execution/types/tx_registry_test.go
+++ b/execution/types/tx_registry_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"sync"
 	"testing"
 
 	"github.com/holiman/uint256"
@@ -165,8 +164,6 @@ func unmarshalFakeRegisteredTxJSON(input []byte) (Transaction, error) {
 	return &fakeRegisteredTx{Nonce: uint64(dec.Nonce), Data: dec.Data}, nil
 }
 
-var registerFakeTxTypeOnce sync.Once
-
 func unregisterTxType(id byte) {
 	txTypeRegistryMu.Lock()
 	defer txTypeRegistryMu.Unlock()
@@ -175,15 +172,17 @@ func unregisterTxType(id byte) {
 
 func registerFakeTxType(t *testing.T) {
 	t.Helper()
-	registerFakeTxTypeOnce.Do(func() {
-		RegisterTxType(fakeRegisteredTxType, TxTypeSpec{
-			New:           func() Transaction { return &fakeRegisteredTx{} },
-			UnmarshalJSON: unmarshalFakeRegisteredTxJSON,
-			Sender: func(txn Transaction, _ Signer) (accounts.Address, error) {
-				return txn.(*fakeRegisteredTx).sender, nil
-			},
-		})
+	if _, ok := registeredTxType(fakeRegisteredTxType); ok {
+		return
+	}
+	RegisterTxType(fakeRegisteredTxType, TxTypeSpec{
+		New:           func() Transaction { return &fakeRegisteredTx{} },
+		UnmarshalJSON: unmarshalFakeRegisteredTxJSON,
+		Sender: func(txn Transaction, _ Signer) (accounts.Address, error) {
+			return txn.(*fakeRegisteredTx).sender, nil
+		},
 	})
+	t.Cleanup(func() { unregisterTxType(fakeRegisteredTxType) })
 }
 
 func TestRegisteredTxTypeBinaryRoundTrip(t *testing.T) {

--- a/execution/types/tx_registry_test.go
+++ b/execution/types/tx_registry_test.go
@@ -1,0 +1,251 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/rlp"
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+const fakeRegisteredTxType = 0x7e
+
+// fakeRegisteredTx is a minimal Transaction implementation used to prove the
+// registry dispatch works for a type this package knows nothing about. It
+// embeds TransactionMisc to exercise the sender-cache trio an out-of-package type
+// would otherwise be unable to implement.
+type fakeRegisteredTx struct {
+	TransactionMisc
+
+	Nonce  uint64
+	Data   []byte
+	sender accounts.Address
+}
+
+func (tx *fakeRegisteredTx) Type() byte                         { return fakeRegisteredTxType }
+func (tx *fakeRegisteredTx) GetChainID() *uint256.Int           { return uint256.NewInt(0) }
+func (tx *fakeRegisteredTx) GetNonce() uint64                   { return tx.Nonce }
+func (tx *fakeRegisteredTx) GetTipCap() *uint256.Int            { return uint256.NewInt(0) }
+func (tx *fakeRegisteredTx) GetFeeCap() *uint256.Int            { return uint256.NewInt(0) }
+func (tx *fakeRegisteredTx) GetBlobHashes() []common.Hash       { return nil }
+func (tx *fakeRegisteredTx) GetGasLimit() uint64                { return 21000 }
+func (tx *fakeRegisteredTx) GetBlobGas() uint64                 { return 0 }
+func (tx *fakeRegisteredTx) GetValue() *uint256.Int             { return uint256.NewInt(0) }
+func (tx *fakeRegisteredTx) GetTo() *common.Address             { return nil }
+func (tx *fakeRegisteredTx) GetData() []byte                    { return tx.Data }
+func (tx *fakeRegisteredTx) GetAccessList() AccessList          { return nil }
+func (tx *fakeRegisteredTx) GetAuthorizations() []Authorization { return nil }
+func (tx *fakeRegisteredTx) Protected() bool                    { return true }
+func (tx *fakeRegisteredTx) IsContractDeploy() bool             { return false }
+func (tx *fakeRegisteredTx) Unwrap() Transaction                { return tx }
+
+func (tx *fakeRegisteredTx) GetEffectiveGasTip(baseFee *uint256.Int) uint256.Int {
+	return uint256.Int{}
+}
+
+func (tx *fakeRegisteredTx) AsMessage(Signer, *uint256.Int, *chain.Rules) (*Message, error) {
+	return nil, nil
+}
+
+func (tx *fakeRegisteredTx) WithSignature(Signer, []byte) (Transaction, error) {
+	return tx, nil
+}
+
+func (tx *fakeRegisteredTx) Hash() common.Hash {
+	return RlpHash([]any{tx.Nonce, tx.Data})
+}
+
+func (tx *fakeRegisteredTx) SigningHash(*uint256.Int) common.Hash {
+	return tx.Hash()
+}
+
+func (tx *fakeRegisteredTx) RawSignatureValues() (*uint256.Int, *uint256.Int, *uint256.Int) {
+	z := uint256.NewInt(0)
+	return z, z, z
+}
+
+func (tx *fakeRegisteredTx) EncodingSize() int {
+	return rlp.U64Len(tx.Nonce) + rlp.StringLen(tx.Data)
+}
+
+func (tx *fakeRegisteredTx) encodePayload(w io.Writer) error {
+	payloadSize := rlp.U64Len(tx.Nonce) + rlp.StringLen(tx.Data)
+	b := rlp.NewEncodingBuf()
+	defer b.Release()
+	if err := rlp.EncodeListPrefix(payloadSize, w, b[:]); err != nil {
+		return err
+	}
+	if err := rlp.EncodeU64(tx.Nonce, w, b[:]); err != nil {
+		return err
+	}
+	return rlp.EncodeString(tx.Data, w, b[:])
+}
+
+func (tx *fakeRegisteredTx) EncodeRLP(w io.Writer) error {
+	return tx.encodePayload(w)
+}
+
+func (tx *fakeRegisteredTx) DecodeRLP(s *rlp.Stream) error {
+	if _, err := s.List(); err != nil {
+		return err
+	}
+	var err error
+	if tx.Nonce, err = s.Uint64(); err != nil {
+		return err
+	}
+	if tx.Data, err = s.Bytes(); err != nil {
+		return err
+	}
+	return s.ListEnd()
+}
+
+func (tx *fakeRegisteredTx) MarshalBinary(w io.Writer) error {
+	b := rlp.NewEncodingBuf()
+	defer b.Release()
+	b[0] = fakeRegisteredTxType
+	if _, err := w.Write(b[:1]); err != nil {
+		return err
+	}
+	return tx.encodePayload(w)
+}
+
+func (tx *fakeRegisteredTx) Sender(Signer) (accounts.Address, error) {
+	if from, ok := tx.GetSender(); ok {
+		return from, nil
+	}
+	tx.SetSender(tx.sender)
+	return tx.sender, nil
+}
+
+type fakeRegisteredTxJSON struct {
+	Type  hexutil.Uint64 `json:"type"`
+	Nonce hexutil.Uint64 `json:"nonce"`
+	Data  hexutil.Bytes  `json:"input"`
+}
+
+func (tx *fakeRegisteredTx) MarshalJSON() ([]byte, error) {
+	return json.Marshal(fakeRegisteredTxJSON{
+		Type:  hexutil.Uint64(fakeRegisteredTxType),
+		Nonce: hexutil.Uint64(tx.Nonce),
+		Data:  tx.Data,
+	})
+}
+
+func unmarshalFakeRegisteredTxJSON(input []byte) (Transaction, error) {
+	var dec fakeRegisteredTxJSON
+	if err := json.Unmarshal(input, &dec); err != nil {
+		return nil, err
+	}
+	return &fakeRegisteredTx{Nonce: uint64(dec.Nonce), Data: dec.Data}, nil
+}
+
+var registerFakeTxTypeOnce sync.Once
+
+func registerFakeTxType(t *testing.T) {
+	t.Helper()
+	registerFakeTxTypeOnce.Do(func() {
+		RegisterTxType(fakeRegisteredTxType, TxTypeSpec{
+			New:           func() Transaction { return &fakeRegisteredTx{} },
+			UnmarshalJSON: unmarshalFakeRegisteredTxJSON,
+		})
+	})
+}
+
+func TestRegisteredTxTypeBinaryRoundTrip(t *testing.T) {
+	registerFakeTxType(t)
+
+	want := &fakeRegisteredTx{Nonce: 7, Data: []byte{0xde, 0xad, 0xbe, 0xef}}
+	var buf bytes.Buffer
+	require.NoError(t, want.MarshalBinary(&buf))
+
+	got, err := UnmarshalTransactionFromBinary(buf.Bytes(), false)
+	require.NoError(t, err)
+	gotFake, ok := got.(*fakeRegisteredTx)
+	require.True(t, ok)
+	require.Equal(t, want.Nonce, gotFake.Nonce)
+	require.Equal(t, want.Data, gotFake.Data)
+}
+
+func TestRegisteredTxTypeJSONRoundTrip(t *testing.T) {
+	registerFakeTxType(t)
+
+	want := &fakeRegisteredTx{Nonce: 9, Data: []byte{0x01, 0x02}}
+	encoded, err := json.Marshal(want)
+	require.NoError(t, err)
+
+	got, err := UnmarshalTransactionFromJSON(encoded)
+	require.NoError(t, err)
+	gotFake, ok := got.(*fakeRegisteredTx)
+	require.True(t, ok)
+	require.Equal(t, want.Nonce, gotFake.Nonce)
+	require.Equal(t, want.Data, gotFake.Data)
+}
+
+func TestRegisteredTxTypeSenderResolution(t *testing.T) {
+	registerFakeTxType(t)
+
+	want := accounts.InternAddress(common.HexToAddress("0x00000000000000000000000000000000001234"))
+	tx := &fakeRegisteredTx{Nonce: 1, sender: want}
+
+	signer := Signer{}
+	got, err := signer.SenderWithContext(nil, tx)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestRegisterTxTypeCollisions(t *testing.T) {
+	builtinSpec := TxTypeSpec{New: func() Transaction { return &LegacyTx{} }}
+
+	require.Panics(t, func() {
+		RegisterTxType(LegacyTxType, builtinSpec)
+	})
+	require.Panics(t, func() {
+		RegisterTxType(AccountAbstractionTxType, builtinSpec)
+	})
+
+	registerFakeTxType(t)
+	require.Panics(t, func() {
+		RegisterTxType(fakeRegisteredTxType, builtinSpec)
+	})
+
+	require.Panics(t, func() {
+		RegisterTxType(0x80, builtinSpec)
+	})
+}
+
+func TestUnregisteredTxTypeStillUnsupported(t *testing.T) {
+	const unknownType = 0x7f
+
+	_, err := UnmarshalTransactionFromBinary([]byte{unknownType, 0x01}, false)
+	require.True(t, errors.Is(err, ErrTxTypeNotSupported))
+
+	_, err = UnmarshalTransactionFromJSON([]byte(`{"type":"0x7f"}`))
+	require.Error(t, err)
+	require.False(t, errors.Is(err, ErrTxTypeNotSupported))
+}

--- a/execution/types/tx_registry_test.go
+++ b/execution/types/tx_registry_test.go
@@ -173,6 +173,9 @@ func registerFakeTxType(t *testing.T) {
 		RegisterTxType(fakeRegisteredTxType, TxTypeSpec{
 			New:           func() Transaction { return &fakeRegisteredTx{} },
 			UnmarshalJSON: unmarshalFakeRegisteredTxJSON,
+			Sender: func(txn Transaction, _ Signer) (accounts.Address, error) {
+				return txn.(*fakeRegisteredTx).sender, nil
+			},
 		})
 	})
 }
@@ -217,6 +220,43 @@ func TestRegisteredTxTypeSenderResolution(t *testing.T) {
 	got, err := signer.SenderWithContext(nil, tx)
 	require.NoError(t, err)
 	require.Equal(t, want, got)
+}
+
+type fakeSenderlessTx struct{ fakeRegisteredTx }
+
+func (f *fakeSenderlessTx) Type() byte { return 0x7c }
+
+func TestRegisteredTxTypeWithoutSenderFacetUnsupported(t *testing.T) {
+	RegisterTxType(0x7c, TxTypeSpec{New: func() Transaction { return &fakeSenderlessTx{} }})
+	t.Cleanup(func() { unregisterTxType(0x7c) })
+
+	tx := &fakeSenderlessTx{}
+	_, err := Signer{}.SenderWithContext(nil, tx)
+	require.ErrorIs(t, err, ErrTxTypeNotSupported)
+}
+
+func TestRegisteredTxTypeSignatureValuesDecodeSig(t *testing.T) {
+	registerFakeTxType(t)
+
+	sig := make([]byte, 65)
+	for i := range 64 {
+		sig[i] = byte(i + 1)
+	}
+	sig[64] = 1
+
+	sg := *LatestSignerForChainID(uint256.NewInt(1))
+	r, s, v, err := sg.SignatureValues(&fakeRegisteredTx{}, sig)
+	require.NoError(t, err)
+	require.Equal(t, new(uint256.Int).SetBytes(sig[:32]), r)
+	require.Equal(t, new(uint256.Int).SetBytes(sig[32:64]), s)
+	require.Equal(t, uint256.NewInt(1), v)
+}
+
+func TestRegisteredTxTypeJSONTypeAliasing(t *testing.T) {
+	registerFakeTxType(t)
+
+	_, err := UnmarshalTransactionFromJSON([]byte(`{"type":"0x17e","nonce":"0x1"}`))
+	require.Error(t, err, "an out-of-range type value must not alias onto a registered byte id")
 }
 
 func TestRegisterTxTypeCollisions(t *testing.T) {

--- a/execution/types/tx_registry_test.go
+++ b/execution/types/tx_registry_test.go
@@ -249,3 +249,11 @@ func TestUnregisteredTxTypeStillUnsupported(t *testing.T) {
 	require.Error(t, err)
 	require.False(t, errors.Is(err, ErrTxTypeNotSupported))
 }
+
+func TestRegisteredTxTypeNilJSONDecoder(t *testing.T) {
+	RegisterTxType(0x7d, TxTypeSpec{New: func() Transaction { return &fakeRegisteredTx{} }})
+	t.Cleanup(func() { unregisterTxType(0x7d) })
+
+	_, err := UnmarshalTransactionFromJSON([]byte(`{"type":"0x7d"}`))
+	require.Error(t, err)
+}

--- a/execution/types/tx_registry_test.go
+++ b/execution/types/tx_registry_test.go
@@ -167,6 +167,12 @@ func unmarshalFakeRegisteredTxJSON(input []byte) (Transaction, error) {
 
 var registerFakeTxTypeOnce sync.Once
 
+func unregisterTxType(id byte) {
+	txTypeRegistryMu.Lock()
+	defer txTypeRegistryMu.Unlock()
+	delete(txTypeRegistry, id)
+}
+
 func registerFakeTxType(t *testing.T) {
 	t.Helper()
 	registerFakeTxTypeOnce.Do(func() {


### PR DESCRIPTION
Every transaction-type dispatch in `execution/types` is a hardcoded switch over the six built-in ids, so an L2 adding envelope types must edit core switches. The nitro-erigon fork ended up with four independently maintained dispatch tables that drifted apart (including a decode-then-drop bug in the JSON arm).

## Changes
- `RegisterTxType(id, TxTypeSpec{New, UnmarshalJSON})` — additive only: panics on collision with a built-in id, on ids outside the EIP-2718 typed-envelope range (they would shadow legacy RLP decoding), and on double registration.
- Consulted exclusively from the `default` arms of the existing switches: binary decode, JSON decode, and `SenderWithContext`/`SignatureValues` — registered types resolve their own senders, following the `AccountAbstractionTransaction` precedent.
- `TransactionMisc` gains the sender-cache trio (`cachedSender`/`GetSender`/`SetSender`), so a transaction type outside the package satisfies the `Transaction` interface by embedding what in-package types already embed; in-package types shadow it with their own identical methods, unchanged.

Part of #22193.
