### PR TITLE
node/ethconfig, cmd/rpcdaemon: enable FcuBackgroundCommit and 128MB state cache by default

### DIFF
--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -138,7 +138,7 @@ func RootCommand() (*cobra.Command, *httpcfg.HttpCfg) {
 	rootCmd.PersistentFlags().BoolVar(&cfg.GethCompatibility, "rpc.gethcompat", false, "Enables Geth-compatible storage iteration order for debug_storageRangeAt (sorted by keccak256 hash). Disabled by default for performance.")
 	rootCmd.PersistentFlags().StringVar(&cfg.TxPoolApiAddr, "txpool.api.addr", "", "txpool api network address, for example: 127.0.0.1:9090 (default: use value of --private.api.addr)")
 
-	rootCmd.PersistentFlags().StringVar(&stateCacheStr, "state.cache", "0MB", "Amount of data to store in the version-keyed StateCache (an equally-sized code cache is budgeted on top). Set 0 to disable entry retention while preserving snapshot-consistent reads")
+	rootCmd.PersistentFlags().StringVar(&stateCacheStr, "state.cache", "128MB", "Amount of data to store in the version-keyed StateCache (an equally-sized code cache is budgeted on top). Set 0 to disable entry retention while preserving snapshot-consistent reads")
 	rootCmd.PersistentFlags().BoolVar(&cfg.GRPCServerEnabled, "grpc", false, "Enable GRPC server")
 	rootCmd.PersistentFlags().StringVar(&cfg.GRPCListenAddress, "grpc.addr", nodecfg.DefaultGRPCHost, "GRPC server listening interface")
 	rootCmd.PersistentFlags().IntVar(&cfg.GRPCPort, "grpc.port", nodecfg.DefaultGRPCPort, "GRPC server listening port")

--- a/docs/site/docs/fundamentals/configuring-erigon.mdx
+++ b/docs/site/docs/fundamentals/configuring-erigon.mdx
@@ -417,8 +417,8 @@ Flags for configuring Fork Choice Update behavior.
   * Default: `1s`
 * `--fcu.background.prune`: Enables background pruning after FCU.
   * Default: `true`
-* `--fcu.background.commit`: Enables background flush and commit after FCU.
-  * Default: `false`
+* `--fcu.background.commit`: Returns the FCU response before MDBX flush+commit lands (commit runs in background; remote `rpcdaemon` `latest` stays consistent but can lag for the commit duration).
+  * Default: `true`
 
 ### Execution
 

--- a/docs/site/docs/fundamentals/modules/rpc-daemon.md
+++ b/docs/site/docs/fundamentals/modules/rpc-daemon.md
@@ -117,7 +117,7 @@ Flags:
       --rpc.txfeecap float                          Sets a cap on transaction fee (in ether) that can be sent via the RPC APIs (0 = no cap) (default 1)
       --socket.enabled                              Enable IPC server
       --socket.url string                           IPC server listening url. prefix supported are tcp, unix (default "unix:///var/run/erigon.sock")
-      --state.cache string                          Amount of data to store in the version-keyed StateCache (an equally-sized code cache is budgeted on top). Set 0 to disable entry retention while preserving snapshot-consistent reads (default "0MB")
+      --state.cache string                          Amount of data to store in the version-keyed StateCache (an equally-sized code cache is budgeted on top). Set 0 to disable entry retention while preserving snapshot-consistent reads (default "128MB")
       --tls.cacert string                           CA certificate for client side TLS handshake for GRPC
       --tls.cert string                             certificate for client side TLS handshake for GRPC
       --tls.key string                              key file for client side TLS handshake for GRPC

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -4121,7 +4121,7 @@ Flags:
       --rpc.txfeecap float                          Sets a cap on transaction fee (in ether) that can be sent via the RPC APIs (0 = no cap) (default 1)
       --socket.enabled                              Enable IPC server
       --socket.url string                           IPC server listening url. prefix supported are tcp, unix (default "unix:///var/run/erigon.sock")
-      --state.cache string                          Amount of data to store in the version-keyed StateCache (an equally-sized code cache is budgeted on top). Set 0 to disable entry retention while preserving snapshot-consistent reads (default "0MB")
+      --state.cache string                          Amount of data to store in the version-keyed StateCache (an equally-sized code cache is budgeted on top). Set 0 to disable entry retention while preserving snapshot-consistent reads (default "128MB")
       --tls.cacert string                           CA certificate for client side TLS handshake for GRPC
       --tls.cert string                             certificate for client side TLS handshake for GRPC
       --tls.key string                              key file for client side TLS handshake for GRPC

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -2319,8 +2319,8 @@ Flags for configuring Fork Choice Update behavior.
   * Default: `1s`
 * `--fcu.background.prune`: Enables background pruning after FCU.
   * Default: `true`
-* `--fcu.background.commit`: Enables background flush and commit after FCU.
-  * Default: `false`
+* `--fcu.background.commit`: Returns the FCU response before MDBX flush+commit lands (commit runs in background; remote `rpcdaemon` `latest` stays consistent but can lag for the commit duration).
+  * Default: `true`
 
 ### Execution
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4121,7 +4121,7 @@ Flags:
       --rpc.txfeecap float                          Sets a cap on transaction fee (in ether) that can be sent via the RPC APIs (0 = no cap) (default 1)
       --socket.enabled                              Enable IPC server
       --socket.url string                           IPC server listening url. prefix supported are tcp, unix (default "unix:///var/run/erigon.sock")
-      --state.cache string                          Amount of data to store in the version-keyed StateCache (an equally-sized code cache is budgeted on top). Set 0 to disable entry retention while preserving snapshot-consistent reads (default "0MB")
+      --state.cache string                          Amount of data to store in the version-keyed StateCache (an equally-sized code cache is budgeted on top). Set 0 to disable entry retention while preserving snapshot-consistent reads (default "128MB")
       --tls.cacert string                           CA certificate for client side TLS handshake for GRPC
       --tls.cert string                             certificate for client side TLS handshake for GRPC
       --tls.key string                              key file for client side TLS handshake for GRPC

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2319,8 +2319,8 @@ Flags for configuring Fork Choice Update behavior.
   * Default: `1s`
 * `--fcu.background.prune`: Enables background pruning after FCU.
   * Default: `true`
-* `--fcu.background.commit`: Enables background flush and commit after FCU.
-  * Default: `false`
+* `--fcu.background.commit`: Returns the FCU response before MDBX flush+commit lands (commit runs in background; remote `rpcdaemon` `latest` stays consistent but can lag for the commit duration).
+  * Default: `true`
 
 ### Execution
 

--- a/node/ethconfig/config.go
+++ b/node/ethconfig/config.go
@@ -111,9 +111,13 @@ var Defaults = Config{
 		ProduceE2:  true,
 		ProduceE3:  true,
 	},
-	FcuTimeout:          1 * time.Second,
-	FcuBackgroundPrune:  true,
-	FcuBackgroundCommit: false, // to enable, we need to 1) have rawdb API go via execctx and 2) revive Coherent cache for rpcdaemon
+	FcuTimeout:         1 * time.Second,
+	FcuBackgroundPrune: true,
+	// FcuBackgroundCommit returns the FCU response before the MDBX commit
+	// lands; the commit runs in a background goroutine and successive FCUs are
+	// serialized by the ExecModule semaphore. "Latest" state reads can lag the
+	// announced head by one block for the commit's duration.
+	FcuBackgroundCommit: true,
 	ExperimentalBAL:     false,
 	WarmupKzgCtxOnInit:  true,
 }


### PR DESCRIPTION
Flips `FcuBackgroundCommit` to `true` so the FCU response returns to the consensus client before the MDBX flush+commit lands. Stacked on #22532 (version-keyed state cache + post-commit announce, the piece this PR's `128MB` default builds on). **Merge-blocked on the rest of the #21293 split as well** — the flip activates background commit everywhere, so it also requires #22533 (overlay/committed RPC read split), #22534 (overlay safe-close invariant), and #22535 (Busy tolerance + post-FCU `WaitIdle`) to land first. GitHub retargets this to `main` when #22532 merges; do not merge before the other three.

Sets the standalone rpcdaemon `--state.cache` default to `128MB`. Standalone daemons use `Coherent` at every configured budget: positive budgets retain version-keyed entries, while `0MB` retains none, disables new-block waiting, and falls back to each caller's transaction snapshot. With the FCU response returning pre-commit, this keeps reads consistent with the committed view instead of serving pre-commit state-change data against an older head. The cache runs without cross-block root carry-over (bounded warmth; re-enabling it is tracked in #22276).

Motivated by #21008 — local profiling on mainnet at tip vs `release/3.4` showed p50 FCU latency regressed by ~+80 ms (mean ~+90 ms, p99 ~+160 ms) with wider burst tails. Background commit decouples the FCU response from the MDBX fsync so the CL gets ACK on the overlay-published head rather than the disk-flushed head.

The regression itself was caused by #19961 moving TxLookup / Senders / Finish into the synchronous FCU path via `PipelineExecutor.RunLoop`. Background commit **masks** this by hiding the fsync from the FCU response; the root-cause fix (move those stages back to a background `StageLoop`, per [#21008 comment](https://github.com/erigontech/erigon/issues/21008#issuecomment-4491763891)) is out of scope.

## Known limitation

`eth_call(latest)`, `eth_getBalance(latest)`, `eth_getStorageAt(latest)`, `eth_getCode(latest)` served by the embedded daemon: during the bg-commit window the header resolves to N (via overlay tables) but state reads evaluate against N-1, because the SD's domain mem batch is not exposed by the block overlay. Bounded staleness (~commit duration), not corruption. The SD-aware temporal view that closes this gap is tracked in #21314.

## Test plan

- [ ] Sanity-run on mainnet minimal node — confirm FCU latency drops back to `release/3.4` levels
- [ ] Standalone rpcdaemon during bg-commit window: confirm consistent (lagging) reads with default `--state.cache`, and that `eth_call(latest)` lag matches the documented limitation
- [ ] CI: full test + race + hive + kurtosis

