### PR TITLE
execution/commitment, db/state: experimental deembedded commitment layout

### DIFF
--- a/cmd/valdist/main.go
+++ b/cmd/valdist/main.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/erigontech/erigon/db/seg"
+)
+
+// valdist: bounded-memory histogram of commitment domain value sizes across .kv
+// files. Sizes are counted in a fixed array (exact to 1 byte up to sizeCap); true
+// max/mean/count are exact. usage: valdist <glob-or-file> [...]
+const sizeCap = 1 << 20 // 1 MiB size ceiling for the histogram array (bytes beyond go to overflow, still counted in max)
+
+func main() {
+	var files []string
+	for _, a := range os.Args[1:] {
+		m, _ := filepath.Glob(a)
+		if len(m) == 0 {
+			files = append(files, a)
+		}
+		files = append(files, m...)
+	}
+	if len(files) == 0 {
+		fmt.Fprintln(os.Stderr, "no files")
+		os.Exit(1)
+	}
+
+	hist := make([]int64, sizeCap+1) // hist[s] = count of values with size s (s>sizeCap -> hist[sizeCap])
+	var n, total, maxv int64
+	stateKey := []byte("state")
+	for _, f := range files {
+		dec, err := seg.NewDecompressor(f)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "open %s: %v\n", f, err)
+			continue
+		}
+		r := seg.NewReader(dec.MakeGetter(), seg.CompressKeys)
+		var key, val []byte
+		for r.HasNext() {
+			key, _ = r.Next(key[:0])
+			if !r.HasNext() {
+				break
+			}
+			val, _ = r.Next(val[:0])
+			if bytes.Equal(key, stateKey) {
+				continue
+			}
+			s := len(val)
+			n++
+			total += int64(s)
+			if int64(s) > maxv {
+				maxv = int64(s)
+			}
+			if s > sizeCap {
+				s = sizeCap
+			}
+			hist[s]++
+		}
+		dec.Close()
+		fmt.Fprintf(os.Stderr, "  read %s (values so far=%d)\n", filepath.Base(f), n)
+	}
+	if n == 0 {
+		fmt.Println("no values")
+		return
+	}
+	// percentile from cumulative histogram
+	pct := func(p float64) int {
+		target := int64(float64(n) * p)
+		var c int64
+		for s := 0; s <= sizeCap; s++ {
+			c += hist[s]
+			if c >= target {
+				return s
+			}
+		}
+		return sizeCap
+	}
+	over := func(t int) int64 {
+		var c int64
+		for s := t + 1; s <= sizeCap; s++ {
+			c += hist[s]
+		}
+		return c
+	}
+	fmt.Printf("files=%d values=%d totalBytes=%d mean=%.1f\n", len(files), n, total, float64(total)/float64(n))
+	fmt.Printf("p50=%d p90=%d p99=%d p999=%d p9999=%d p99999=%d max=%d\n",
+		pct(.5), pct(.9), pct(.99), pct(.999), pct(.9999), pct(.99999), maxv)
+
+	buckets := []int{32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 65536, sizeCap}
+	labels := []string{"<=32", "33-64", "65-128", "129-256", "257-512", "513-1K", "1K-2K", "2K-4K", "4K-8K", "8K-16K", "16K-64K", ">64K"}
+	prev := -1
+	fmt.Println("size bucket : count (pct)")
+	for i, b := range buckets {
+		var c int64
+		for s := prev + 1; s <= b && s <= sizeCap; s++ {
+			c += hist[s]
+		}
+		prev = b
+		fmt.Printf("  %-8s: %12d (%6.3f%%)\n", labels[i], c, 100*float64(c)/float64(n))
+	}
+	fmt.Printf("values >2048B: %d (%.4f%%)   >4096B: %d (%.5f%%)   >8192B: %d   >65536B: %d\n",
+		over(2048), 100*float64(over(2048))/float64(n),
+		over(4096), 100*float64(over(4096))/float64(n), over(8192), over(65536))
+}

--- a/db/state/commitment_flush_metrics.go
+++ b/db/state/commitment_flush_metrics.go
@@ -1,0 +1,55 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/erigontech/erigon/common/log/v3"
+)
+
+// Commitment flush/build timing accumulators, split by the domain values vs the
+// history side. Always-on so embedded and deembedded commitment layouts can be
+// compared. Nanoseconds, summed across the whole process; logged cumulatively
+// with the "[commitment-metrics]" tag.
+var (
+	commitInExecFlushDomainNs  atomic.Int64
+	commitInExecFlushHistoryNs atomic.Int64
+	commitFileBuildDomainNs    atomic.Int64
+	commitFileBuildHistoryNs   atomic.Int64
+)
+
+func addCommitInExecFlush(domainNs, historyNs int64) {
+	commitInExecFlushDomainNs.Add(domainNs)
+	commitInExecFlushHistoryNs.Add(historyNs)
+}
+
+func addCommitFileBuild(domainNs, historyNs int64) {
+	commitFileBuildDomainNs.Add(domainNs)
+	commitFileBuildHistoryNs.Add(historyNs)
+}
+
+func logCommitMetrics(logger log.Logger, phase string) {
+	ms := func(ns int64) time.Duration { return time.Duration(ns).Truncate(time.Millisecond) }
+	logger.Info("[commitment-metrics]", "at", phase,
+		"inexec_flush_domain", ms(commitInExecFlushDomainNs.Load()),
+		"inexec_flush_history", ms(commitInExecFlushHistoryNs.Load()),
+		"filebuild_domain", ms(commitFileBuildDomainNs.Load()),
+		"filebuild_history", ms(commitFileBuildHistoryNs.Load()),
+	)
+}

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -489,13 +489,20 @@ func (w *DomainBufferedWriter) Flush(ctx context.Context, tx kv.RwTx) error {
 	if w.discard {
 		return nil
 	}
+	isCommit := w.valsTable == kv.TblCommitmentVals
+	hStart := time.Now()
 	if err := w.h.Flush(ctx, tx); err != nil {
 		return err
 	}
+	histNs := time.Since(hStart).Nanoseconds()
+	domStart := time.Now()
 
 	if w.largeVals {
 		if err := w.values.Load(tx, w.valsTable, loadFunc, etl.TransformArgs{Quit: ctx.Done(), EmptyVals: true}); err != nil {
 			return err
+		}
+		if isCommit {
+			addCommitInExecFlush(time.Since(domStart).Nanoseconds(), histNs)
 		}
 		w.Close()
 		return nil
@@ -517,6 +524,9 @@ func (w *DomainBufferedWriter) Flush(ctx context.Context, tx kv.RwTx) error {
 		return valuesCursor.PutCurrent(k, v) // DeleteCurrent+Put
 	}, etl.TransformArgs{Quit: ctx.Done(), EmptyVals: true}); err != nil {
 		return err
+	}
+	if isCommit {
+		addCommitInExecFlush(time.Since(domStart).Nanoseconds(), histNs)
 	}
 	w.Close()
 
@@ -822,10 +832,21 @@ func (d *Domain) collate(ctx context.Context, step kv.Step, txFrom, txTo uint64,
 	started := time.Now()
 	defer mxCollateTook.ObserveDuration(started)
 
+	var histCollateNs int64
+	if d.FilenameBase == kv.CommitmentDomain.String() {
+		defer func() {
+			if err == nil {
+				addCommitFileBuild(time.Since(started).Nanoseconds()-histCollateNs, histCollateNs)
+			}
+		}()
+	}
+
+	hCollateStart := time.Now()
 	coll.HistoryCollation, err = d.History.collate(ctx, step, txFrom, txTo, roTx)
 	if err != nil {
 		return Collation{}, err
 	}
+	histCollateNs = time.Since(hCollateStart).Nanoseconds()
 
 	closeCollation := true
 	defer func() {
@@ -1038,10 +1059,12 @@ func (d *Domain) buildFiles(ctx context.Context, step kv.Step, collation Collati
 		mxBuildTook.ObserveDuration(start)
 	}()
 
+	hBuildStart := time.Now()
 	hStaticFiles, err := d.History.buildFiles(ctx, step, collation.HistoryCollation, ps)
 	if err != nil {
 		return StaticFiles{}, err
 	}
+	histBuildNs := time.Since(hBuildStart).Nanoseconds()
 	valuesComp := collation.valuesComp
 
 	var (
@@ -1115,6 +1138,10 @@ func (d *Domain) buildFiles(ctx context.Context, step kv.Step, collation Collati
 		}
 	}
 	closeComp = false
+	if d.FilenameBase == kv.CommitmentDomain.String() {
+		addCommitFileBuild(time.Since(start).Nanoseconds()-histBuildNs, histBuildNs)
+		logCommitMetrics(d.logger, fmt.Sprintf("buildFiles step=%d", step))
+	}
 	return StaticFiles{
 		HistoryFiles:    hStaticFiles,
 		valuesDecomp:    valuesDecomp,

--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -183,6 +183,8 @@ func PickTrieVariant() commitment.TrieVariant {
 		return commitment.VariantStreamingHexPatricia
 	case statecfg.ExperimentalParallelCommitment:
 		return commitment.VariantParallelHexPatricia
+	case statecfg.ExperimentalDeembeddedCommitment:
+		return commitment.VariantDeembeddedHexPatricia
 	}
 	return commitment.VariantHexPatriciaTrie
 }

--- a/db/state/statecfg/state_schema.go
+++ b/db/state/statecfg/state_schema.go
@@ -207,6 +207,11 @@ var ExperimentalParallelCommitment = dbg.EnvBool("COMMITMENT_PARALLEL", false)
 // ExperimentalParallelCommitment.
 var ExperimentalStreamingCommitment = false
 
+// ExperimentalDeembeddedCommitment toggles the deembedded branch persistence
+// layout (VariantDeembeddedHexPatricia). Same root hash as the default trie;
+// the COMMITMENT_DEEMBED env var turns it on.
+var ExperimentalDeembeddedCommitment = dbg.EnvBool("COMMITMENT_DEEMBED", false)
+
 var Schema = SchemaGen{
 	AccountsDomain: DomainCfg{
 		Name: kv.AccountsDomain, ValuesTable: kv.TblAccountVals,

--- a/execution/commitment/commitment.go
+++ b/execution/commitment/commitment.go
@@ -142,6 +142,10 @@ const (
 	VariantHexPatriciaTrie      TrieVariant = "hex-patricia-hashed"
 	VariantParallelHexPatricia  TrieVariant = "hex-parallel-patricia-hashed"
 	VariantStreamingHexPatricia TrieVariant = "hex-streaming-patricia-hashed"
+	// VariantDeembeddedHexPatricia stores each branch child under its own key
+	// instead of embedding all children in the branch value. Same root hash as
+	// VariantHexPatriciaTrie; see hex_patricia_hashed_deembed.go.
+	VariantDeembeddedHexPatricia TrieVariant = "hex-deembed-patricia-hashed"
 )
 
 // InitializeTrieAndUpdates constructs the trie + updates buffer from cfg.
@@ -158,6 +162,12 @@ func InitializeTrieAndUpdates(mode Mode, tmpdir string, cfg TrieConfig) (Trie, *
 		trie.SetStreamingCommitter(sc)
 		tree := NewUpdates(ModeParallel, tmpdir, KeyToHexNibbleHash)
 		tree.SetStreamingCommitter(sc)
+		return trie, tree
+	case VariantDeembeddedHexPatricia:
+		cfg.Variant = VariantDeembeddedHexPatricia
+		log.Info("[commitment] using deembedded branch layout (VariantDeembeddedHexPatricia)")
+		trie := NewHexPatriciaHashed(length.Addr, nil, cfg)
+		tree := NewUpdates(mode, tmpdir, KeyToHexNibbleHash)
 		return trie, tree
 	case VariantHexPatriciaTrie:
 		fallthrough

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -149,6 +149,11 @@ type HexPatriciaHashed struct {
 	mountWall  int16 // depth the mounted subtree folds down to (split depth + 1); foldMounted stops here
 
 	memoizationOff bool // if true, do not rely on memoized hashes
+
+	// deembed selects the deembedded branch persistence layout: each branch's
+	// leaf children are stored under their own key rather than inlined in the
+	// branch value. Root hash is identical to the embedded layout.
+	deembed bool
 	//temp buffers
 	accValBuf rlp.RlpEncodedBytes
 
@@ -203,6 +208,14 @@ func NewHexPatriciaHashed(accountKeyLen int16, ctx PatriciaContext, cfg TrieConf
 // applyConfig stores the config and applies its fields to the trie.
 func (hph *HexPatriciaHashed) applyConfig(cfg TrieConfig) {
 	hph.cfg = cfg
+	hph.deembed = cfg.Variant == VariantDeembeddedHexPatricia
+	if hph.deembed {
+		// The deembed collect/decode path is custom and does not go through the
+		// deferred branch-encoder queue. Warmup is supported via a deembed-aware
+		// branch walk (see Warmuper.warmupKey).
+		cfg.DeferBranchUpdates = false
+		hph.cfg = cfg
+	}
 	hph.branchEncoder.setDeferUpdates(cfg.DeferBranchUpdates)
 	hph.branchEncoder.maxDeferredUpdates = DefaultMaxDeferredUpdates
 	hph.leaveDeferredForCaller = cfg.LeaveDeferredForCaller
@@ -1465,6 +1478,9 @@ func (hph *HexPatriciaHashed) unfoldBranchNode(row int, depth int16, deleted boo
 // into grid[row], records its touch/after maps, and derives hashed keys for present cells
 // at depth. The on-disk read and its flush/metrics handling stay with each caller.
 func (hph *HexPatriciaHashed) decodeBranchIntoRow(row int, depth int16, branch []byte, deleted bool) error {
+	if hph.deembed {
+		return hph.decodeDeembedBranchIntoRow(row, depth, branch, deleted)
+	}
 	maps, err := DecodeBranchInto(branch, deleted, &hph.grid[row])
 	if err != nil {
 		return err
@@ -1674,7 +1690,11 @@ func (hph *HexPatriciaHashed) foldBranch(row int, nibble, upDepth, depth int16, 
 		return err
 	}
 
-	if hph.branchEncoder.DeferUpdatesEnabled() {
+	if hph.deembed {
+		if err := hph.collectDeembedBranch(updateKey, row, hph.touchMap[row], hph.afterMap[row]); err != nil {
+			return fmt.Errorf("failed to collect deembed branch update: %w", err)
+		}
+	} else if hph.branchEncoder.DeferUpdatesEnabled() {
 		if err := hph.branchEncoder.CollectDeferredUpdate(hph.ctx, updateKey, bitmap, hph.touchMap[row], hph.afterMap[row], &cellData, !hph.branchBefore[row]); err != nil {
 			return fmt.Errorf("failed to collect deferred branch update: %w", err)
 		}
@@ -1958,6 +1978,12 @@ func (hph *HexPatriciaHashed) foldDelete(row int, nibble, upDepth int16, upCell 
 // If evictCache is true, it also evicts the branch from the cache.
 func (hph *HexPatriciaHashed) collectDeleteUpdate(updateKey []byte, row int, evictCache bool) error {
 	if hph.branchBefore[row] {
+		if hph.deembed {
+			if err := hph.deleteDeembedBranch(updateKey, hph.touchMap[row]); err != nil {
+				return fmt.Errorf("failed to encode deembed branch deletion: %w", err)
+			}
+			return nil
+		}
 		if err := hph.branchEncoder.CollectUpdate(hph.ctx, updateKey, 0, hph.touchMap[row], 0, nil, false); err != nil {
 			return fmt.Errorf("failed to encode leaf node update: %w", err)
 		}
@@ -2504,7 +2530,10 @@ func (hph *HexPatriciaHashed) Process(ctx context.Context, updates *Updates, log
 
 	defer func() { logEvery.Stop() }()
 
-	// Setup warmup if configured
+	// Setup warmup if configured. The warmuper walks the branch layout to
+	// prefetch pages along each key path; it uses a deembed-aware walk when the
+	// trie stores branch children under separate keys.
+	warmup.Deembed = hph.deembed
 	var warmuper *Warmuper
 	if warmup.Enabled {
 		warmuper = NewWarmuper(ctx, warmup)

--- a/execution/commitment/hex_patricia_hashed_deembed.go
+++ b/execution/commitment/hex_patricia_hashed_deembed.go
@@ -1,0 +1,250 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package commitment
+
+// Deembedded branch persistence.
+//
+// The default (embedded) layout stores a whole branch node — every present
+// child's hash, extension and leaf plain key — inside one value keyed by the
+// branch prefix. Branches whose children are leaves (52-byte storage plain keys
+// + hashes) therefore grow large.
+//
+// The deembedded layout splits a branch's leaf children out into their own
+// keys: the leaf child at nibble n under branch prefix P is stored at
+// compact(P||n), holding exactly the per-cell fields the embedded layout would
+// have inlined. The parent value at compact(P) then keeps only the small
+// per-child data needed to rehash and descend: sub-branch children keep their
+// {hash, extension} inline (unchanged); leaf children contribute nothing to the
+// parent body beyond a bit in leafMap.
+//
+// The in-memory fold/hash engine is untouched, so the trie root is byte-for-byte
+// identical to the embedded layout — only what is written to / read from the
+// commitment domain changes.
+//
+// Parent value layout (before the 2-byte touch-map prefix is stripped on read):
+//
+//	[touchMap:2][afterMap:2][leafMap:2]
+//	for each nibble set in afterMap, ascending:
+//	    if leaf  (leafMap bit set):  (nothing — data lives at compact(P||nibble))
+//	    if branch(leafMap bit clear): [hashLen:1][hash][extLen:1][extension]
+//
+// Leaf child value layout at compact(P||nibble):
+//
+//	[fields:1] then, per set field, uvarint(len)+bytes — identical field framing
+//	to EncodeBranch's per-cell encoding, decoded by cell.fillFromFields.
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math/bits"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/commitment/nibbles"
+)
+
+// deembedChildKey returns the commitment-domain key for the child at nibble
+// under the branch reached by prefixNibbles.
+func (hph *HexPatriciaHashed) deembedChildKey(prefixNibbles []byte, nibble int) []byte {
+	child := make([]byte, len(prefixNibbles)+1)
+	copy(child, prefixNibbles)
+	child[len(prefixNibbles)] = byte(nibble)
+	return nibbles.HexToCompact(child)
+}
+
+func appendUvarVal(buf, val []byte) []byte {
+	var tmp [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(tmp[:], uint64(len(val)))
+	buf = append(buf, tmp[:n]...)
+	return append(buf, val...)
+}
+
+// encodeDeembedLeafChild serialises a leaf cell for its standalone child key,
+// mirroring EncodeBranch's per-cell field selection so cell.fillFromFields
+// reconstructs an identical cell.
+func encodeDeembedLeafChild(cell *cell, buf []byte) []byte {
+	var fields cellFields
+	if cell.extLen > 0 && cell.storageAddrLen == 0 {
+		fields |= fieldExtension
+	}
+	if cell.accountAddrLen > 0 {
+		fields |= fieldAccountAddr
+	}
+	if cell.storageAddrLen > 0 {
+		fields |= fieldStorageAddr
+	}
+	if cell.hashLen > 0 {
+		fields |= fieldHash
+	}
+	if cell.stateHashLen == 32 && (cell.accountAddrLen > 0 || cell.storageAddrLen > 0) {
+		fields |= fieldStateHash
+	}
+	buf = append(buf, byte(fields))
+	if fields&fieldExtension != 0 {
+		buf = appendUvarVal(buf, cell.extension[:cell.extLen])
+	}
+	if fields&fieldAccountAddr != 0 {
+		buf = appendUvarVal(buf, cell.accountAddr[:cell.accountAddrLen])
+	}
+	if fields&fieldStorageAddr != 0 {
+		buf = appendUvarVal(buf, cell.storageAddr[:cell.storageAddrLen])
+	}
+	if fields&fieldHash != 0 {
+		buf = appendUvarVal(buf, cell.hash[:cell.hashLen])
+	}
+	if fields&fieldStateHash != 0 {
+		buf = appendUvarVal(buf, cell.stateHash[:cell.stateHashLen])
+	}
+	return buf
+}
+
+// collectDeembedBranch writes a branch in the deembedded layout: touched leaf
+// children go to their own keys, and the parent keeps only sub-branch children
+// inline plus the leafMap. It replaces branchEncoder.CollectUpdate for the
+// deembed trie and needs no merge-with-prev — the full present row is written.
+func (hph *HexPatriciaHashed) collectDeembedBranch(updateKey []byte, row int, touchMap, afterMap uint16) error {
+	prefix := hph.currentKey[:hph.currentKeyLen]
+
+	var leafMap uint16
+	for bitset := afterMap; bitset != 0; {
+		bit := bitset & -bitset
+		nibble := bits.TrailingZeros16(bit)
+		cell := &hph.grid[row][nibble]
+		if cell.accountAddrLen > 0 || cell.storageAddrLen > 0 {
+			leafMap |= uint16(1) << nibble
+		}
+		bitset ^= bit
+	}
+
+	var hdr [6]byte
+	binary.BigEndian.PutUint16(hdr[0:], touchMap)
+	binary.BigEndian.PutUint16(hdr[2:], afterMap)
+	binary.BigEndian.PutUint16(hdr[4:], leafMap)
+	buf := append([]byte{}, hdr[:]...)
+
+	var childBuf []byte
+	for bitset := afterMap; bitset != 0; {
+		bit := bitset & -bitset
+		nibble := bits.TrailingZeros16(bit)
+		cell := &hph.grid[row][nibble]
+
+		if leafMap&bit != 0 {
+			// Rewrite the child key only when the leaf was touched; an untouched
+			// leaf child keeps its existing (still-current) record.
+			if touchMap&bit != 0 {
+				childKey := hph.deembedChildKey(prefix, nibble)
+				childBuf = encodeDeembedLeafChild(cell, childBuf[:0])
+				if err := hph.ctx.PutBranch(childKey, common.Copy(childBuf), nil); err != nil {
+					return err
+				}
+			}
+		} else {
+			buf = append(buf, byte(cell.hashLen))
+			buf = append(buf, cell.hash[:cell.hashLen]...)
+			buf = append(buf, byte(cell.extLen))
+			buf = append(buf, cell.extension[:cell.extLen]...)
+		}
+		bitset ^= bit
+	}
+
+	return hph.ctx.PutBranch(common.Copy(updateKey), buf, nil)
+}
+
+// deleteDeembedBranch writes the empty-branch marker for a collapsed/deleted
+// branch. Leaf child keys are left as harmless orphans (never referenced by a
+// live parent); they are overwritten if the prefix is reused.
+func (hph *HexPatriciaHashed) deleteDeembedBranch(updateKey []byte, touchMap uint16) error {
+	var hdr [6]byte
+	binary.BigEndian.PutUint16(hdr[0:], touchMap)
+	// afterMap = 0, leafMap = 0
+	return hph.ctx.PutBranch(common.Copy(updateKey), common.Copy(hdr[:]), nil)
+}
+
+// decodeDeembedBranchIntoRow reverses collectDeembedBranch. branch has the
+// leading 2-byte touch map already stripped by the caller, so it starts at
+// afterMap. Leaf children are loaded eagerly from their own keys, producing an
+// in-memory row identical to the embedded decode path.
+func (hph *HexPatriciaHashed) decodeDeembedBranchIntoRow(row int, depth int16, branch []byte, deleted bool) error {
+	if len(branch) < 4 {
+		return fmt.Errorf("deembed branch too short: %d bytes", len(branch))
+	}
+	afterMap := binary.BigEndian.Uint16(branch[0:])
+	leafMap := binary.BigEndian.Uint16(branch[2:])
+	if deleted {
+		hph.touchMap[row], hph.afterMap[row] = afterMap, 0
+	} else {
+		hph.touchMap[row], hph.afterMap[row] = 0, afterMap
+	}
+
+	prefix := hph.currentKey[:hph.currentKeyLen]
+	pos := 4
+	for bitset := afterMap; bitset != 0; {
+		bit := bitset & -bitset
+		nibble := bits.TrailingZeros16(bit)
+		cell := &hph.grid[row][nibble]
+		cell.reset()
+
+		if leafMap&bit != 0 {
+			childKey := hph.deembedChildKey(prefix, nibble)
+			childVal, _, err := hph.ctx.Branch(childKey)
+			if err != nil {
+				return err
+			}
+			if len(childVal) == 0 {
+				return fmt.Errorf("missing deembed leaf child at nibble %x under prefix %x", nibble, prefix)
+			}
+			fieldBits := cellFields(childVal[0])
+			if _, err := cell.fillFromFields(childVal, 1, fieldBits); err != nil {
+				return fmt.Errorf("deembed leaf child fillFromFields nibble %x: %w", nibble, err)
+			}
+		} else {
+			if pos >= len(branch) {
+				return fmt.Errorf("deembed branch truncated before sub-branch child at nibble %x", nibble)
+			}
+			hashLen := int(branch[pos])
+			pos++
+			if pos+hashLen > len(branch) {
+				return fmt.Errorf("deembed branch truncated in hash at nibble %x", nibble)
+			}
+			if hashLen > 0 {
+				copy(cell.hash[:], branch[pos:pos+hashLen])
+				cell.hashLen = int16(hashLen)
+				pos += hashLen
+			}
+			if pos >= len(branch) {
+				return fmt.Errorf("deembed branch truncated before extension at nibble %x", nibble)
+			}
+			extLen := int(branch[pos])
+			pos++
+			if pos+extLen > len(branch) {
+				return fmt.Errorf("deembed branch truncated in extension at nibble %x", nibble)
+			}
+			if extLen > 0 {
+				copy(cell.hashedExtension[:], branch[pos:pos+extLen])
+				cell.hashedExtLen = int16(extLen)
+				copy(cell.extension[:], branch[pos:pos+extLen])
+				cell.extLen = int16(extLen)
+				pos += extLen
+			}
+		}
+
+		if err := cell.deriveHashedKeys(depth, hph.keccak, hph.accountKeyLen, hph.cellHashBuf[:]); err != nil {
+			return err
+		}
+		bitset ^= bit
+	}
+	return nil
+}

--- a/execution/commitment/hex_patricia_hashed_deembed_test.go
+++ b/execution/commitment/hex_patricia_hashed_deembed_test.go
@@ -1,0 +1,201 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package commitment
+
+import (
+	"context"
+	"encoding/hex"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/length"
+)
+
+// The deembedded layout persists branch children differently but must produce
+// the identical trie root. The tests below drive the same update stream through
+// a default (embedded) trie and a deembedded trie and assert the roots match
+// round by round. Branch-data maps (MockState.cm) are intentionally NOT compared
+// — they differ by design.
+
+func newDeembedTrie(ms *MockState) *HexPatriciaHashed {
+	cfg := DefaultTrieConfig()
+	cfg.Variant = VariantDeembeddedHexPatricia
+	return NewHexPatriciaHashed(length.Addr, ms, cfg)
+}
+
+func requireDeembedMatchesEmbedded(tb testing.TB, rounds ...*UpdateBuilder) {
+	tb.Helper()
+	ctx := context.Background()
+
+	stateEmb := NewMockState(tb)
+	stateDe := NewMockState(tb)
+	trieEmb := NewHexPatriciaHashed(length.Addr, stateEmb, DefaultTrieConfig())
+	trieDe := newDeembedTrie(stateDe)
+
+	for i, builder := range rounds {
+		plainKeys, updates := builder.Build()
+		require.NoErrorf(tb, stateEmb.applyPlainUpdates(plainKeys, updates), "round %d embedded state update", i)
+		require.NoErrorf(tb, stateDe.applyPlainUpdates(plainKeys, updates), "round %d deembed state update", i)
+
+		updsEmb := WrapKeyUpdates(tb, ModeDirect, KeyToHexNibbleHash, plainKeys, updates)
+		rootEmb, err := trieEmb.Process(ctx, updsEmb, "", nil, WarmupConfig{})
+		updsEmb.Close()
+		require.NoErrorf(tb, err, "round %d embedded process", i)
+
+		updsDe := WrapKeyUpdates(tb, ModeDirect, KeyToHexNibbleHash, plainKeys, updates)
+		rootDe, err := trieDe.Process(ctx, updsDe, "", nil, WarmupConfig{})
+		updsDe.Close()
+		require.NoErrorf(tb, err, "round %d deembed process", i)
+
+		require.Equalf(tb, rootEmb, rootDe, "round %d root mismatch\nembedded=%x\ndeembed =%x", i, rootEmb, rootDe)
+	}
+}
+
+func Test_Deembed_MatchesEmbedded_Basic(t *testing.T) {
+	t.Parallel()
+	requireDeembedMatchesEmbedded(t,
+		NewUpdateBuilder().
+			Balance("1000000000000000000000000000000000000001", 1).
+			Nonce("1000000000000000000000000000000000000002", 2).
+			Storage(
+				"1000000000000000000000000000000000000001",
+				"0100000000000000000000000000000000000000000000000000000000000000",
+				"0102",
+			),
+		NewUpdateBuilder().
+			Balance("1000000000000000000000000000000000000001", 3).
+			CodeHash(
+				"1000000000000000000000000000000000000003",
+				"0300000000000000000000000000000000000000000000000000000000000000",
+			).
+			DeleteStorage(
+				"1000000000000000000000000000000000000001",
+				"0100000000000000000000000000000000000000000000000000000000000000",
+			),
+		NewUpdateBuilder().
+			Delete("1000000000000000000000000000000000000002").
+			Storage(
+				"1000000000000000000000000000000000000004",
+				"0400000000000000000000000000000000000000000000000000000000000000",
+				"040506",
+			),
+	)
+}
+
+func Test_Deembed_MatchesEmbedded_Fixtures(t *testing.T) {
+	t.Parallel()
+	requireDeembedMatchesEmbedded(t, fixtureBaseWithCode())
+	requireDeembedMatchesEmbedded(t, fixtureBaseAccounts())
+}
+
+// Test_Deembed_MatchesEmbedded_Random drives many rounds of random inserts,
+// storage writes and deletes so the trie repeatedly grows, splits, collapses
+// and reloads branches from the persisted deembedded layout.
+func Test_Deembed_MatchesEmbedded_Random(t *testing.T) {
+	t.Parallel()
+
+	rnd := rand.New(rand.NewSource(20260719))
+	addrs := make([]string, 0, 256)
+	slots := make(map[string][]string) // addr -> storage locations (hex)
+
+	randSlot := func(ub *UpdateBuilder, a string) {
+		loc := make([]byte, length.Hash)
+		rnd.Read(loc)
+		val := make([]byte, 32)
+		rnd.Read(val)
+		locHex := hex.EncodeToString(loc)
+		ub.Storage(a, locHex, hex.EncodeToString(val))
+		slots[a] = append(slots[a], locHex)
+	}
+
+	const rounds = 25
+	builders := make([]*UpdateBuilder, 0, rounds)
+	for range rounds {
+		ub := NewUpdateBuilder()
+
+		// Insert a handful of fresh accounts, some with storage.
+		for range 8 {
+			addr := make([]byte, length.Addr)
+			rnd.Read(addr)
+			a := hex.EncodeToString(addr)
+			addrs = append(addrs, a)
+			ub.Balance(a, rnd.Uint64()+1)
+			for s := 0; s < rnd.Intn(6); s++ {
+				randSlot(ub, a)
+			}
+		}
+
+		// Mutate / add storage to some existing accounts.
+		for i := 0; i < 6 && len(addrs) > 0; i++ {
+			a := addrs[rnd.Intn(len(addrs))]
+			if rnd.Intn(2) == 0 {
+				ub.Nonce(a, rnd.Uint64())
+			}
+			randSlot(ub, a)
+		}
+
+		// Delete a few existing accounts entirely — clearing their storage too,
+		// as a real selfdestruct would.
+		if len(addrs) > 20 {
+			for range 3 {
+				idx := rnd.Intn(len(addrs))
+				a := addrs[idx]
+				for _, locHex := range slots[a] {
+					ub.DeleteStorage(a, locHex)
+				}
+				delete(slots, a)
+				ub.Delete(a)
+				addrs = append(addrs[:idx], addrs[idx+1:]...)
+			}
+		}
+
+		builders = append(builders, ub)
+	}
+
+	requireDeembedMatchesEmbedded(t, builders...)
+}
+
+// Test_Deembed_MatchesEmbedded_Whale exercises a single account carrying a large
+// storage trie (deep branch nodes — the case the deembedded layout targets).
+func Test_Deembed_MatchesEmbedded_Whale(t *testing.T) {
+	t.Parallel()
+
+	pk, upds := buildWhaleCorpus(bigAccountWhale(4000))
+
+	ctx := context.Background()
+	stateEmb := NewMockState(t)
+	stateDe := NewMockState(t)
+	require.NoError(t, stateEmb.applyPlainUpdates(pk, upds))
+	require.NoError(t, stateDe.applyPlainUpdates(pk, upds))
+
+	trieEmb := NewHexPatriciaHashed(length.Addr, stateEmb, DefaultTrieConfig())
+	trieDe := newDeembedTrie(stateDe)
+
+	updsEmb := WrapKeyUpdates(t, ModeDirect, KeyToHexNibbleHash, pk, upds)
+	rootEmb, err := trieEmb.Process(ctx, updsEmb, "", nil, WarmupConfig{})
+	updsEmb.Close()
+	require.NoError(t, err)
+
+	updsDe := WrapKeyUpdates(t, ModeDirect, KeyToHexNibbleHash, pk, upds)
+	rootDe, err := trieDe.Process(ctx, updsDe, "", nil, WarmupConfig{})
+	updsDe.Close()
+	require.NoError(t, err)
+
+	require.Equal(t, rootEmb, rootDe)
+}

--- a/execution/commitment/warmuper.go
+++ b/execution/commitment/warmuper.go
@@ -42,6 +42,7 @@ type WarmupConfig struct {
 	NumWorkers int
 	MaxDepth   int
 	LogPrefix  string
+	Deembed    bool // walk the deembedded branch layout (children under separate keys)
 }
 
 const WarmupMaxDepth = 128 // covers full key paths for both account keys (64 nibbles) and storage keys (128 nibbles)
@@ -60,6 +61,7 @@ type Warmuper struct {
 	maxDepth   int
 	numWorkers int
 	logPrefix  string
+	deembed    bool
 
 	// Work channel for incoming keys
 	work chan warmupWorkItem
@@ -97,6 +99,7 @@ func NewWarmuper(ctx context.Context, cfg WarmupConfig) *Warmuper {
 		maxDepth:   cfg.MaxDepth,
 		numWorkers: cfg.NumWorkers,
 		logPrefix:  cfg.LogPrefix,
+		deembed:    cfg.Deembed,
 	}
 	w.cond = sync.NewCond(&w.mu)
 	return w
@@ -172,9 +175,17 @@ func (w *Warmuper) warmupKey(trieCtx PatriciaContext, hashedKey []byte, startDep
 		nextNibble := int(hashedKey[depth])
 
 		branchData = branchData[2:] // skip touch map
+		childBit := uint16(1) << nextNibble
+
+		if w.deembed {
+			if advance, cont := w.warmupDeembedStep(trieCtx, branchData, hashedKey, depth, nextNibble, childBit); cont {
+				depth += advance
+				continue
+			}
+			break
+		}
 
 		bitmap := binary.BigEndian.Uint16(branchData[0:2])
-		childBit := uint16(1) << nextNibble
 
 		if bitmap&childBit == 0 {
 			break
@@ -218,6 +229,57 @@ func (w *Warmuper) warmupKey(trieCtx PatriciaContext, hashedKey []byte, startDep
 
 		depth++
 	}
+}
+
+// warmupDeembedStep advances one branch level in the deembedded layout.
+// branchData has the leading touch map stripped: [afterMap 2][leafMap 2][body].
+// The body holds, per present child ascending, sub-branch cells
+// [hashLen 1][hash][extLen 1][ext]; leaf children contribute nothing (their
+// data is at compact(prefix||nibble)). Returns (nibbles to advance, keepGoing).
+func (w *Warmuper) warmupDeembedStep(trieCtx PatriciaContext, branchData, hashedKey []byte, depth, nextNibble int, childBit uint16) (int, bool) {
+	if len(branchData) < 4 {
+		return 0, false
+	}
+	afterMap := binary.BigEndian.Uint16(branchData[0:2])
+	if afterMap&childBit == 0 {
+		return 0, false
+	}
+	leafMap := binary.BigEndian.Uint16(branchData[2:4])
+	if leafMap&childBit != 0 {
+		// Leaf child: warm its standalone record, then the path terminates.
+		childNib := make([]byte, depth+1)
+		copy(childNib, hashedKey[:depth])
+		childNib[depth] = byte(nextNibble)
+		if _, _, err := trieCtx.Branch(nibbles.HexToCompact(childNib)); err != nil {
+			log.Debug(fmt.Sprintf("[%s][warmup] deembed leaf child", w.logPrefix), "error", err)
+		}
+		return 0, false
+	}
+	// Sub-branch child: walk the body up to nextNibble to read its extension.
+	pos := 4
+	childExt := 0
+	for n := 0; n <= nextNibble; n++ {
+		bit := uint16(1) << uint(n)
+		if afterMap&bit == 0 || leafMap&bit != 0 {
+			continue // absent, or leaf (no body bytes)
+		}
+		if pos >= len(branchData) {
+			break
+		}
+		hashLen := int(branchData[pos])
+		pos++
+		pos += hashLen
+		if pos >= len(branchData) {
+			break
+		}
+		extLen := int(branchData[pos])
+		pos++
+		if n == nextNibble {
+			childExt = extLen
+		}
+		pos += extLen
+	}
+	return 1 + childExt, true
 }
 
 // WarmKey submits a hashed key for warming. Call Start() first.


### PR DESCRIPTION
Experimental commitment branch-node persistence layout, behind a flag. Root hash is byte-identical to the default (the in-memory fold/hash engine is untouched — only how branch nodes are persisted/reloaded changes).

## What

Today a branch node embeds all its children in one value; the size is dominated by **leaf children** (each ~plainkey 52B + hash 32B + stateHash 32B + ext). Deembed splits those out:

- branch record → `[touchMap][afterMap][leafMap]` + per **sub-branch** child `{hash, ext}` (unchanged refs); leaf children contribute nothing to the branch body
- each **leaf child** → its own key `compact(prefix‖nibble)` = `{ext, plainkey, hash, stateHash}`
- `leafMap` marks which children now live in their own key

Sub-branch references stay inline (tiny, and needed to navigate/rehash). Extensions unchanged. Same commitment history (the deembed `PutBranch(...,nil)` relies on `SharedDomains.domainPut` auto-filling prev via `GetLatest`).

## How to run

```
COMMITMENT_DEEMBED=true ./build/bin/integration stage_exec --datadir <dd> --chain=<chain> --block <N>
# (env var only; no CLI flag. Wired via PickTrieVariant -> VariantDeembeddedHexPatricia)
```

## How to report metrics

- **flush / file-build timing, split domain-vs-history** — always-on, grep the last cumulative line:
  `grep '\[commitment-metrics\]' <datadir>/logs/*.log | tail -1`
  → `inexec_flush_domain=.. inexec_flush_history=.. filebuild_domain=.. filebuild_history=..`
- **value-size distribution** — `go run ./cmd/valdist '<datadir>/snapshots/domain/*commitment*.kv'` (bounded memory; exact max/mean/count, histogram + percentiles)
- **domain vs history size** — sum `*commitment*.{kv,kvi}` vs `*commitment*.{v,vi,ef,efi}`

## Findings (sepolia 0→3M, serial, warmup on both)

| metric | embed | deembed |
|---|---|---|
| domain size | 2.1 GB | 2.6 GB (+24%) |
| history size | 8.4 GB | 8.8 GB (+5%) |
| # branch values | 3.59 M | 12.70 M (3.5×) |
| value mean / max | 276 B / 1290 B | 73 B / 555 B |
| throughput | 244 MGas/s | 225 MGas/s (within run-noise) |

**Value-size distribution at scale (embed layout, `.kv` files):** branch nodes never get huge on real data — max **1396 B, zero >2 KB** on sepolia_archive@11.27M (452M values) *and* mainnet@25.5M (~977M values). Whale-storage contracts produce **more** branch nodes, not bigger ones (a branch is bounded ~16 children × fixed-size cell ≈ ~2 KB regardless of contract size).

**Conclusion:** because embedded branch nodes are already small (~1.4 KB worst case), deembed's premise (eliminate huge nodes) doesn't pay off on Ethereum data — it trades ~4× smaller individual values for 3.5× more keys → net +24% domain size at ~equal throughput. Kept behind a flag as a measured experiment; the tooling (flush/build split metrics, valdist) is reusable for other commitment work.

## Testing

- `Test_Deembed_MatchesEmbedded_{Basic,Fixtures,Random,Whale}` — root byte-identical vs default (25-round random incl. deletes/collapse/reload; deep-branch whale corpus)
- real exec: mainnet genesis→46k, sepolia 0→3M twice (correct roots + commitment history), deembed-aware warmuper clean to 3M


## Value-size distribution (branch node values)

Commitment domain `.kv` values, via `cmd/valdist`. Confirms branch nodes stay small at every scale, and deembed's shrink of individual values:

| dataset (layout) | # values | mean | p50 | p90 | p99 | p999 | max | >2 KB |
|---|---|---|---|---|---|---|---|---|
| sepolia@3M (embed) | 3.59 M | 276 B | 178 | 548 | 823 | 974 | 1290 | 0 |
| sepolia@3M (deembed) | 12.70 M | 73 B | 87 | 87 | 346 | 550 | 555 | 0 |
| sepolia_archive@11.27M (embed) | 452.2 M | 282 B | 178 | 548 | 817 | 974 | 1396 | 0 |
| mainnet@25.5M (embed) | 977.5 M | 262 B | 178 | 560 | 821 | 976 | 1396 | 0 |

- Embedded branch values cap at **~1.4 KB** on all real datasets incl. mainnet whales — **zero** values exceed 2 KB (also 0 above 4 KB / 8 KB / 64 KB). A branch is bounded by ≤16 children × fixed-size cell, so whale-storage contracts produce *more* nodes, not bigger ones.
- Deembed shifts the distribution down (mean 276→73 B, max 1290→555 B) — the 555 B ceiling is the all-sub-branch parent bound (16 × `{hashLen,hash 32,extLen,ext}` + header); leaf-child records are separate and ≤~150 B.
