### PR TITLE
db/state, execution/stagedsync: env-gated commitment-timing + trie-warmup diagnostics

### DIFF
--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -1738,7 +1738,15 @@ func (sd *SharedDomains) computeCommitment(ctx context.Context, tx kv.TemporalTx
 	if err != nil {
 		return nil, err
 	}
-	return sd.sdCtx.ComputeCommitment(ctx, tx, saveStateAfter, blockNum, txNum, logPrefix, onProgress)
+	if !dbg.EnvBool("COMMIT_TIMING", false) {
+		return sd.sdCtx.ComputeCommitment(ctx, tx, saveStateAfter, blockNum, txNum, logPrefix, onProgress)
+	}
+	ccStart := time.Now()
+	rootHash, err = sd.sdCtx.ComputeCommitment(ctx, tx, saveStateAfter, blockNum, txNum, logPrefix, onProgress)
+	if sd.logger != nil {
+		sd.logger.Info("[commit-timing]", "blk", blockNum, "computeCommitment", time.Since(ccStart))
+	}
+	return rootHash, err
 }
 
 // EnableTrieWarmup enables parallel warmup of MDBX page cache during commitment.

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -197,7 +197,7 @@ func ExecV3(ctx context.Context,
 	var lastCommittedBlockNum uint64
 
 	doms.EnableParaTrieDB(cfg.db)
-	doms.EnableTrieWarmup(true)
+	doms.EnableTrieWarmup(!dbg.EnvBool("DISABLE_TRIE_WARMUP", false))
 	doms.SetDeferCommitmentUpdates(false)
 	// Enable deferred commitment updates for fork validation and parallel initial sync.
 	// Deferred updates batch commitment calculations to block boundaries rather than


### PR DESCRIPTION
## What

Two opt-in, default-off diagnostics for measuring commitment (state-root) cost at chain tip:

- **`COMMIT_TIMING=true`** — logs per-block `ComputeCommitment` duration. Placed at the single funnel `SharedDomains.computeCommitment`, so it captures every commitment path (serial exec, the parallel committer goroutine, and fork validation) with one hook instead of scattering logs across call sites.
- **`DISABLE_TRIE_WARMUP=true`** — disables the commitment trie warmuper (previously hardcoded on) so its effect on throughput can be A/B tested.

## Why

Investigating where per-block processing time goes at chain tip, and the cost of placing cold commitment `.kv` files on slower (HDD) storage. Measured with these hooks: when the deep commitment files sit on HDD, `ComputeCommitment` is ~60% of per-block processing time (median ~290 ms/block, p90 ~1.6 s), dragging chain-tip throughput from ~119 mgas/s (EVM-only) down to ~45. These toggles isolate and quantify that.

## Notes

Draft — instrumentation for a perf investigation, not intended to merge as-is. Both flags are off by default, so there is no behaviour or performance change unless explicitly set.
