### PR TITLE
cl/das: self-heal PeerDAS custody column subscription via per-slot reconcile

### DIFF
--- a/cl/das/peer_das.go
+++ b/cl/das/peer_das.go
@@ -128,7 +128,11 @@ func NewPeerDas(
 		indiciesDB:     indiciesDB,
 		gloasDataCache: gloasDataCache,
 	}
-	p.resubscribeGossip()
+	if !p.resubscribeGossip() {
+		// Initial subscribe raced fork-digest topic registration; keep
+		// reconciling per slot until the custody-column subscriptions take.
+		go p.resubscribeGossipLoop(ctx)
+	}
 	for range numOfBlobRecoveryWorkers {
 		go p.blobsRecoverWorker(ctx)
 	}
@@ -286,35 +290,71 @@ func (d *peerdas) isMyColumnDataAvailable(slot uint64, blockRoot common.Hash) (b
 	return len(nowCustodies) == len(expectedCustodies), nil
 }
 
-func (d *peerdas) resubscribeGossip() {
+// resubscribeGossip subscribes to the node's custody data-column gossip subnets
+// and reports whether every subscription is now established. It is idempotent
+// (SubscribeWithExpiry no-ops on an already-subscribed topic), so it is safe to
+// re-run on a reconcile tick until it succeeds — see resubscribeGossipLoop.
+func (d *peerdas) resubscribeGossip() bool {
 	if d.IsArchivedMode() {
+		allSubscribed := true
 		// subscribe to all subnets
 		for subnet := range d.beaconConfig.DataColumnSidecarSubnetCount {
 			topicName := gossip.TopicNameDataColumnSidecar(subnet)
 			expiry := time.Unix(0, math.MaxInt64)
 			if err := d.gossipManager.SubscribeWithExpiry(topicName, expiry); err != nil {
+				allSubscribed = false
 				log.Warn("[peerdas] failed to subscribe to column sidecar subnet", "err", err, "subnet", subnet)
 			} else {
 				log.Debug("[peerdas] subscribed to column sidecar subnet", "subnet", subnet)
 			}
 		}
-		return
+		return allSubscribed
 	}
 
 	// subscribe to the columns in our custody group
 	custodyColumns, err := d.state.GetMyCustodyColumns()
 	if err != nil {
 		log.Warn("failed to get my custody columns", "err", err)
-		return
+		return false
 	}
+	allSubscribed := true
 	for column := range custodyColumns {
 		subnet := ComputeSubnetForDataColumnSidecar(column)
 		topicName := gossip.TopicNameDataColumnSidecar(subnet)
 		expiry := time.Unix(0, math.MaxInt64)
 		if err := d.gossipManager.SubscribeWithExpiry(topicName, expiry); err != nil {
+			allSubscribed = false
 			log.Warn("[peerdas] failed to subscribe to column sidecar", "err", err, "column", column, "subnet", subnet)
 		} else {
 			log.Debug("[peerdas] subscribed to column sidecar", "column", column, "subnet", subnet)
+		}
+	}
+	return allSubscribed
+}
+
+// resubscribeGossipLoop retries resubscribeGossip on a slot cadence until every
+// custody data-column subnet is subscribed, then stops. The initial subscribe
+// in NewPeerDas can fail with "topic not found" when the current fork digest's
+// gossip topics are not yet registered; those requests are parked but never
+// replayed, so without this reconcile the node never subscribes to its custody
+// columns, never receives them, and PeerDAS data availability never succeeds.
+// Re-running is idempotent, mirroring the per-slot subnet reconciliation other
+// consensus clients use to self-heal a missed subscription.
+func (d *peerdas) resubscribeGossipLoop(ctx context.Context) {
+	interval := time.Duration(d.beaconConfig.SecondsPerSlot) * time.Second
+	if interval <= 0 {
+		interval = 12 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if d.resubscribeGossip() {
+				return
+			}
 		}
 	}
 }


### PR DESCRIPTION
## What

Make Caplin's PeerDAS custody data-column gossip subscription **self-heal** by re-running `resubscribeGossip()` on a per-slot reconcile until every custody subnet is subscribed, instead of the current one-shot-at-init.

## Why — the bug

On a node syncing a PeerDAS + Gloas/ePBS network (reproduced on `glamsterdam-devnet-6`), the node permanently stalls a few blocks short of chain tip. Chain-tip GLOAS payloads fail with `EIP-7594 column data is not available`, and the execution block-collector then loops forever on the downstream symptom `parent's total difficulty not found`.

Root cause, traced in `cl/das/peer_das.go`:

- `resubscribeGossip()` (subscribes the node's custody data-column subnets) is called **exactly once**, at `NewPeerDas` init, and again only if custody-group-count *increases* (`UpdateValidatorsCustody`) — never on a slot/epoch/fork tick.
- `gossipManager.SubscribeWithExpiry` composes the topic with the **current fork digest at call time**. At that single init call the digest's data-column gossip topics aren't registered yet (the data-column service is gated `withBeginVersion(FuluVersion)` and registration races init), so every `SubscribeWithExpiry` returns `"topic not found"` and the request is parked in `TopicSubscriptions.toSubscribes`.
- `toSubscribes` is only ever drained by `TopicSubscriptions.Add` (topic registered *while* a defer is pending) and by the fork-transition handler, which only migrates *already-registered* topics — neither replays these parked, digest-stamped entries.

Net: the node subscribes to **zero** data-column subnets (observed live: 8 subscribe attempts at startup, 0 successes, no retries), never receives its custody columns, so `forkchoice.IsDataAvailable` fails for every GLOAS block → payloads can't apply → the EL never advances past the stall.

## Fix

`resubscribeGossip()` now returns whether all custody subnets are subscribed. `NewPeerDas` starts `resubscribeGossipLoop(ctx)` when the initial attempt doesn't fully succeed; the loop re-runs `resubscribeGossip` every `SecondsPerSlot` and stops once all subscriptions take. `SubscribeWithExpiry` is idempotent on an already-subscribed topic (it skips re-subscribe and only bumps expiry), so re-running is cheap and safe.

This mirrors the industry-standard model: Prysm reconciles data-column subnet subscriptions against the current fork digest every slot (`beacon-chain/sync/fork_watcher.go` → `trySubscribeSubnets`), so a missed subscription self-heals on the next tick; Lighthouse reaches the same safety by gating its one-shot subscribe behind a settled/synced digest plus an explicit pre-fork re-subscribe. Caplin had neither guarantee — this adds the per-slot self-heal.

## Scope / correctness

- Networking-only change (gossip subscription retry); no state-transition or consensus-rule behavior is altered.
- Idempotent and bounded: the loop exits once all custody subnets are subscribed; custody *increases* remain handled by the existing `UpdateValidatorsCustody` path.
- `cl/das` builds, vets, and its tests pass.

## Notes

Draft — validated by unit tests + code trace and matched against Prysm/Lighthouse behavior; full confirmation is a devnet resync past the stall block on `glamsterdam-devnet-6`, which I'll run before un-drafting.
