### PR TITLE
db/state: persist domain file cache across rotxs and merges

### DIFF
--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -1884,12 +1884,17 @@ type aggregatorVisible struct {
 // cross-entity-consistent generation.
 func (a *Aggregator) recalcVisibleFiles(retired retiredFiles) {
 	toTxNum := a.dirtyFilesEndTxNumMinimax()
+	prev := a.visible.Load()
 	next := &aggregatorVisible{}
 	for id, d := range a.d {
 		if d == nil {
 			continue
 		}
-		next.d[id], next.dh[id], next.dhii[id] = d.calcVisibleFiles(toTxNum)
+		var prevDV *domainVisible
+		if prev != nil {
+			prevDV = prev.d[id]
+		}
+		next.d[id], next.dh[id], next.dhii[id] = d.calcVisibleFiles(toTxNum, prevDV)
 	}
 	for id, ii := range a.standaloneIIs() {
 		if ii == nil {

--- a/db/state/aggregator_align_test.go
+++ b/db/state/aggregator_align_test.go
@@ -195,7 +195,7 @@ func craftedClampedVisible(t *testing.T, agg *Aggregator) {
 	for _, dom := range []kv.Domain{kv.AccountsDomain, kv.StorageDomain, kv.CodeDomain} {
 		files := v.d[dom].files
 		require.GreaterOrEqual(t, len(files), 2)
-		crafted.d[dom] = newDomainVisible(dom, files[:len(files)-1])
+		crafted.d[dom] = newDomainVisible(dom, files[:len(files)-1], v.d[dom])
 	}
 	v.next = crafted
 	agg.visible.Store(crafted)

--- a/db/state/cache.go
+++ b/db/state/cache.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"flag"
 	"fmt"
 	"sync"
 
@@ -19,29 +20,30 @@ type u128 struct{ hi, lo uint64 }      //nolint
 type u192 struct{ hi, lo, ext uint64 } //nolint
 
 type DomainGetFromFileCache struct {
-	*freelru.LRU[uint64, domainGetFromFileCacheItem]
+	*freelru.ShardedLRU[uint64, domainGetFromFileCacheItem]
 	enabled, trace bool
 	limit          uint32
 }
 
-// nolint
+// v is a heap-owned copy and the txnum range is stored directly rather than as
+// a file index, so entries outlive the files they were read from.
 type domainGetFromFileCacheItem struct {
-	lvl uint8
-	v   []byte
+	startTxNum, endTxNum uint64
+	v                    []byte
 }
 
 var (
-	domainGetFromFileCacheLimit   = uint32(dbg.EnvInt("D_LRU", 10_000))
+	domainGetFromFileCacheLimit   = uint32(dbg.EnvInt("D_LRU", 2_500_000))
 	domainGetFromFileCacheTrace   = dbg.EnvBool("D_LRU_TRACE", false)
 	domainGetFromFileCacheEnabled = dbg.EnvBool("D_LRU_ENABLED", true)
 )
 
 func NewDomainGetFromFileCache(limit uint32) *DomainGetFromFileCache {
-	c, err := freelru.New[uint64, domainGetFromFileCacheItem](limit, u64noHash)
+	c, err := freelru.NewSharded[uint64, domainGetFromFileCacheItem](limit, u64noHash)
 	if err != nil {
 		panic(err)
 	}
-	return &DomainGetFromFileCache{LRU: c, enabled: domainGetFromFileCacheEnabled, trace: domainGetFromFileCacheTrace, limit: limit}
+	return &DomainGetFromFileCache{ShardedLRU: c, enabled: domainGetFromFileCacheEnabled, trace: domainGetFromFileCacheTrace, limit: limit}
 }
 
 func (c *DomainGetFromFileCache) SetTrace(v bool) { c.trace = v }
@@ -58,34 +60,53 @@ func (c *DomainGetFromFileCache) LogStats(dt kv.Domain) {
 	}
 }
 
-func newDomainVisible(name kv.Domain, files visibleFiles) *domainVisible {
+// newDomainCache caps capacity by the key count of the visible files: freelru
+// preallocates its full capacity upfront, so an uncapped cache costs hundreds
+// of MB per aggregator even when the files hold almost no data.
+func newDomainCache(name kv.Domain, files visibleFiles) *DomainGetFromFileCache {
+	if !domainGetFromFileCacheEnabled {
+		return nil
+	}
+	limit := domainGetFromFileCacheLimit
+	if flag.Lookup("test.v") != nil {
+		limit = 10_000
+	}
+	switch name {
+	case kv.CommitmentDomain, kv.ReceiptDomain, kv.RCacheDomain:
+		return nil
+	case kv.StorageDomain:
+		limit += limit / 2
+	case kv.CodeDomain:
+		limit /= 100 // CodeDomain has compressed values - means cache will store values (instead of pointers to mmap)
+	}
+	var fileKeys uint64
+	for _, f := range files {
+		fileKeys += uint64(f.src.decompressor.Count() / 2)
+	}
+	if fileKeys < uint64(limit) {
+		limit = uint32(fileKeys)
+	}
+	if limit == 0 {
+		return nil
+	}
+	return NewDomainGetFromFileCache(limit)
+}
+
+// newDomainVisible shares one cache across all RoTxs of a visible-files
+// generation. A merge rewrites existing data without changing lookup results,
+// so an unchanged EndTxNum lets the previous cache carry over; a changed one
+// means the file-visible data itself moved and the cache must be rebuilt.
+func newDomainVisible(name kv.Domain, files visibleFiles, prev *domainVisible) *domainVisible {
 	d := &domainVisible{
 		name:  name,
 		files: files,
 	}
-	limit := domainGetFromFileCacheLimit
-	if name == kv.CodeDomain {
-		limit /= 10 // CodeDomain has compressed values - means cache will store values (instead of pointers to mmap)
+	if prev != nil && prev.cache != nil && prev.files.EndTxNum() == files.EndTxNum() {
+		d.cache = prev.cache
+	} else {
+		d.cache = newDomainCache(name, files)
 	}
-	if limit == 0 {
-		domainGetFromFileCacheEnabled = false
-	}
-	d.caches = &sync.Pool{New: func() any { return NewDomainGetFromFileCache(limit) }}
 	return d
-}
-
-func (v *domainVisible) newGetFromFileCache() *DomainGetFromFileCache {
-	if !domainGetFromFileCacheEnabled {
-		return nil
-	}
-	return v.caches.Get().(*DomainGetFromFileCache)
-}
-func (v *domainVisible) returnGetFromFileCache(c *DomainGetFromFileCache) {
-	if c == nil {
-		return
-	}
-	c.LogStats(v.name)
-	v.caches.Put(c)
 }
 
 var (

--- a/db/state/cache_test.go
+++ b/db/state/cache_test.go
@@ -1,0 +1,52 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
+)
+
+func TestDomainCacheNilWithoutVisibleFiles(t *testing.T) {
+	t.Parallel()
+
+	dv := newDomainVisible(kv.AccountsDomain, visibleFiles{}, nil)
+	require.Nil(t, dv.cache)
+}
+
+func TestDomainCacheAcrossVisibleFileGenerations(t *testing.T) {
+	if testing.Short() {
+		t.Skip("long-running test")
+	}
+	t.Parallel()
+
+	db, d, txs := filledDomain(t, log.New())
+	err := db.UpdateNosync(t.Context(), func(tx kv.RwTx) error {
+		collateAndMerge(t, tx, d, txs)
+		return nil
+	})
+	require.NoError(t, err)
+
+	dv, _, _ := d.calcVisibleFiles(d.dirtyFilesEndTxNumMinimax(), nil)
+	require.NotEmpty(t, dv.files)
+	require.NotNil(t, dv.cache)
+
+	var keys uint32
+	for _, f := range dv.files {
+		keys += uint32(f.src.decompressor.Count() / 2)
+	}
+	require.LessOrEqual(t, dv.cache.limit, keys)
+
+	t.Run("same visible end reuses cache", func(t *testing.T) {
+		next := newDomainVisible(kv.AccountsDomain, dv.files, dv)
+		require.Same(t, dv.cache, next.cache)
+	})
+
+	t.Run("different visible end rebuilds cache", func(t *testing.T) {
+		require.Greater(t, len(dv.files), 1)
+		next := newDomainVisible(kv.AccountsDomain, dv.files[:len(dv.files)-1], dv)
+		require.NotSame(t, dv.cache, next.cache)
+	})
+}

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -26,7 +26,6 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
-	"sync"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -102,9 +101,9 @@ type Domain struct {
 }
 
 type domainVisible struct {
-	files  visibleFiles
-	name   kv.Domain
-	caches *sync.Pool
+	files visibleFiles
+	name  kv.Domain
+	cache *DomainGetFromFileCache
 }
 
 func NewDomain(cfg statecfg.DomainCfg, stepSize, stepsInFrozenFile uint64, dirs datadir.Dirs, logger log.Logger) (*Domain, error) {
@@ -391,7 +390,7 @@ func (d *Domain) retireFilesNotInList(fNames []string) retiredFiles {
 // calcVisibleFiles is pure — it does not mutate d, d.History, or d.History.InvertedIndex.
 // Aggregator.recalcVisibleFiles uses it to assemble a cross-entity consistent
 // snapshot that is published via a single atomic store.
-func (d *Domain) calcVisibleFiles(toTxNum uint64) (*domainVisible, visibleFiles, *iiVisible) {
+func (d *Domain) calcVisibleFiles(toTxNum uint64, prev *domainVisible) (*domainVisible, visibleFiles, *iiVisible) {
 	var checker func(startTxNum, endTxNum uint64) bool
 	if d.checker != nil {
 		ue := FromDomain(d.Name)
@@ -399,7 +398,7 @@ func (d *Domain) calcVisibleFiles(toTxNum uint64) (*domainVisible, visibleFiles,
 			return d.checker.CheckDependentPresent(ue, All, startTxNum, endTxNum)
 		}
 	}
-	dv := newDomainVisible(d.Name, calcVisibleFiles(d.dirtyFiles, d.Accessors, checker, false, toTxNum))
+	dv := newDomainVisible(d.Name, calcVisibleFiles(d.dirtyFiles, d.Accessors, checker, false, toTxNum), prev)
 	hv, hiv := d.History.calcVisibleFiles(toTxNum)
 	return dv, hv, hiv
 }
@@ -641,7 +640,7 @@ func (dt *DomainRoTx) getLatestFromFile(i int, filekey []byte, hi, lo uint64) (v
 // because it can observe an unsynchronized/torn view of dirtyFiles across
 // entities. Production code goes through Aggregator.BeginFilesRo.
 func (d *Domain) beginForTests() *DomainRoTx {
-	dv, hv, iv := d.calcVisibleFiles(d.dirtyFilesEndTxNumMinimax())
+	dv, hv, iv := d.calcVisibleFiles(d.dirtyFilesEndTxNumMinimax(), nil)
 	return d.beginFilesRo(dv, hv, iv)
 }
 
@@ -657,13 +656,14 @@ func (d *Domain) beginFilesRo(dv *domainVisible, hf visibleFiles, hiv *iiVisible
 func (d *Domain) initFilesRo(dt *DomainRoTx, ht *HistoryRoTx, iit *InvertedIndexRoTx, dv *domainVisible, hf visibleFiles, hiv *iiVisible) {
 	d.History.initFilesRo(ht, iit, hf, hiv)
 	*dt = DomainRoTx{
-		name:     d.Name,
-		stepSize: d.stepSize,
-		d:        d,
-		ht:       ht,
-		visible:  dv,
-		files:    dv.files,
-		salt:     d.salt.Load(),
+		name:             d.Name,
+		stepSize:         d.stepSize,
+		d:                d,
+		ht:               ht,
+		visible:          dv,
+		files:            dv.files,
+		salt:             d.salt.Load(),
+		getFromFileCache: dv.cache,
 	}
 }
 
@@ -1427,16 +1427,12 @@ func (dt *DomainRoTx) getLatestFromFiles(k []byte, maxTxNum uint64) (v []byte, f
 	hi, lo := dt.ht.iit.hashKey(k)
 
 	getFromFileCache := dt.getFromFileCache
-
-	if useCache && getFromFileCache == nil {
-		if dt.getFromFileCache == nil {
-			dt.getFromFileCache = dt.visible.newGetFromFileCache()
-		}
-		getFromFileCache = dt.getFromFileCache
+	if !useCache {
+		getFromFileCache = nil
 	}
-	if getFromFileCache != nil && useCache {
+	if getFromFileCache != nil {
 		if cv, ok := getFromFileCache.Get(hi); ok {
-			return cv.v, true, dt.files[cv.lvl].startTxNum, dt.files[cv.lvl].endTxNum, nil
+			return cv.v, true, cv.startTxNum, cv.endTxNum, nil
 		}
 	}
 
@@ -1478,8 +1474,8 @@ func (dt *DomainRoTx) getLatestFromFiles(k []byte, maxTxNum uint64) (v []byte, f
 			fmt.Printf("GetLatest(%s, %x) -> found in file %s\n", dt.name.String(), k, f.src.decompressor.FileName())
 		}
 
-		if dt.getFromFileCache != nil && useCache {
-			dt.getFromFileCache.Add(hi, domainGetFromFileCacheItem{lvl: uint8(i), v: v})
+		if getFromFileCache != nil {
+			getFromFileCache.Add(hi, domainGetFromFileCacheItem{startTxNum: f.startTxNum, endTxNum: f.endTxNum, v: bytes.Clone(v)})
 		}
 		return v, true, f.startTxNum, f.endTxNum, nil
 	}
@@ -1487,8 +1483,8 @@ func (dt *DomainRoTx) getLatestFromFiles(k []byte, maxTxNum uint64) (v []byte, f
 		fmt.Printf("GetLatest(%s, %x) -> not found in %d files\n", dt.name.String(), k, len(dt.files))
 	}
 
-	if dt.getFromFileCache != nil && useCache {
-		dt.getFromFileCache.Add(hi, domainGetFromFileCacheItem{lvl: 0, v: nil})
+	if getFromFileCache != nil {
+		getFromFileCache.Add(hi, domainGetFromFileCacheItem{})
 	}
 	return nil, false, 0, 0, nil
 }
@@ -1557,7 +1553,8 @@ func (dt *DomainRoTx) Close() {
 	dt.mapReaders = nil
 	dt.ht.Close()
 
-	dt.visible.returnGetFromFileCache(dt.getFromFileCache)
+	dt.getFromFileCache.LogStats(dt.name)
+	dt.getFromFileCache = nil
 }
 
 // reusableReader - for short read-and-forget operations. Must Reset this reader before use


### PR DESCRIPTION
Revives #18519 (closed) on top of current `main`, with the merge-survival and cache-sizing work that was done after it was closed.

Today the domain file cache is per-`DomainRoTx`: each rotx pulls a fresh (or pooled) `DomainGetFromFileCache`, so a cache built by one rotx is thrown away when that rotx closes. On the exec path that means a cache lifetime of one block.

This ties the cache to `domain.visibleFiles` instead, so all rotxs of a visible-files generation share one cache.

- `domainVisible.cache` replaces `domainVisible.caches *sync.Pool`; `DomainRoTx` just borrows the pointer, no get/put.
- A new cache is only built when `visibleFiles` change. Merges rewrite existing data without changing lookup results, so an unchanged `EndTxNum` carries the previous generation's cache over — invalidation only happens when new data becomes file-visible, i.e. roughly once per step.
- Cache entries now store the `(startTxNum, endTxNum)` range directly instead of a file index, and hold a heap-owned copy of the value. Both are needed for entries to outlive the files they were read from; the old `lvl` index was only valid against the rotx's own `files` slice.
- `freelru.LRU` → `freelru.ShardedLRU`, dropping the `sync.RWMutex` around `Add`/`Get` that a shared cache would otherwise need on every read.
- No `sync.Pool`: an existing rotx holding the cache must stay safe, and pooling can rug-pull it. New caches are created rarely enough that GC can handle the old ones.

Sizing: `freelru` preallocates its full capacity upfront, so an uncapped cache costs hundreds of MB per aggregator even on a datadir with almost no data. `newDomainCache` caps capacity by the key count of the visible files, skips `CommitmentDomain`/`ReceiptDomain`/`RCacheDomain`, and scales `StorageDomain` up / `CodeDomain` down (code values are compressed, so the cache stores values rather than mmap pointers).

Notes:

- Step returned from a cached hit can be lower than the true one after a merge carried the cache over. For non-commitment domains that step is diagnostic only ("used in Trie for memo stats and file depth access statistics"), and commitment never uses this cache.
- Default `D_LRU` raised 10_000 → 2_500_000 now that the cache is long-lived and capped by real file contents. Still tunable via `D_LRU` / `D_LRU_ENABLED`.
- There are concerns about RPC and chain-tip access patterns interfering in one shared cache. Separate caches for the two was prototyped in #19129.

Draft: needs perf numbers (hit ratio and RSS at tip, with `D_LRU_TRACE=true`) before review.
