### PR TITLE
execution: drop BlockStateCache from tx execution workers (P1)

### DIFF
--- a/execution/exec/state.go
+++ b/execution/exec/state.go
@@ -245,10 +245,9 @@ func (rw *Worker) ResetState(rs *state.StateV3Buffered, chainTx kv.TemporalTx, s
 		if chainTx != nil {
 			getter = rs.Domains().AsGetterMetered(chainTx, rw.readMetrics)
 		}
-		// Use CachedReaderV3 for parallel workers — caches account data
-		// on first read per block, providing a stable pre-block committed
-		// view for GetCommittedState. The blockStateCache is set per block
-		// via SetBlockStateCache before workers start.
+		// Parallel workers read the pre-block base directly (sd.mem → StateCache
+		// → files). The version map on top of this reader gives intra-block
+		// isolation, so no per-block committed cache is needed here.
 		rw.SetReader(state.NewCachedReaderV3(getter, nil))
 	}
 
@@ -496,14 +495,6 @@ func (rw *Worker) SetReader(reader state.StateReader) {
 	}
 }
 
-// SetBlockStateCache updates the block-level account cache on the worker's
-// CachedReaderV3. Called before each block's workers start execution.
-func (rw *Worker) SetBlockStateCache(cache *state.BlockStateCache) {
-	if cr, ok := rw.stateReader.(*state.CachedReaderV3); ok {
-		cr.SetBlockStateCache(cache)
-	}
-}
-
 func (rw *Worker) RunTxTaskNoLock(txTask Task) *TxResult {
 	if txTask.IsHistoric() && !rw.historyMode {
 		// in case if we cancelled execution and commitment happened in the middle of the block, we have to process block
@@ -515,11 +506,6 @@ func (rw *Worker) RunTxTaskNoLock(txTask Task) *TxResult {
 		rw.SetReader(state.NewHistoryReaderV3WithSharedDomains(rw.chainTx, rw.rs.Domains(), txTask.Version().TxNum))
 	} else if !txTask.IsHistoric() && (rw.stateReader == nil || rw.historyMode) {
 		rw.SetReader(state.NewCachedReaderV3(rw.rs.Domains().AsGetterMetered(rw.chainTx, rw.readMetrics), nil))
-	}
-
-	// Set the per-block committed state cache from the task.
-	if cache := txTask.GetBlockStateCache(); cache != nil {
-		rw.SetBlockStateCache(cache)
 	}
 
 	if rw.background && rw.chainTx == nil {

--- a/execution/exec/txtask.go
+++ b/execution/exec/txtask.go
@@ -58,7 +58,6 @@ type Task interface {
 
 	Version() state.Version
 	VersionMap() *state.VersionMap
-	GetBlockStateCache() *state.BlockStateCache
 	VersionedReads(ibs *state.IntraBlockState) state.ReadSet
 	VersionedWrites(ibs *state.IntraBlockState) *state.WriteSet
 	Reset(evm *vm.EVM, ibs *state.IntraBlockState, callTracer *calltracer.CallTracer) error
@@ -231,10 +230,6 @@ type TxTask struct {
 	signer       *types.Signer
 	dependencies []int
 	rules        *chain.Rules
-
-	// BlockStateCache holds pre-block account state for stable committed reads.
-	// Shared across all tasks in the same block. Set by the parallel executor.
-	BlockStateCache *state.BlockStateCache
 }
 
 func (t *TxTask) compare(other Task) int {
@@ -436,10 +431,6 @@ func (t *TxTask) Dependencies() []int {
 
 func (t *TxTask) VersionMap() *state.VersionMap {
 	return nil
-}
-
-func (t *TxTask) GetBlockStateCache() *state.BlockStateCache {
-	return t.BlockStateCache
 }
 
 func (t *TxTask) VersionedReads(ibs *state.IntraBlockState) state.ReadSet {

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -718,8 +718,6 @@ func (te *txExecutor) executeBlocks(ctx context.Context, startBlockNum uint64, m
 			}), te.cfg.engine, te.cfg.author, te.cfg.chainConfig)
 
 			var txTasks []exec.Task
-			// Per-block committed state cache for parallel workers' GetCommittedState.
-			blockStateCache := state.NewBlockStateCache()
 
 			blockStartTxNum := inputTxNum
 			for txIndex := -1; txIndex <= len(txs); txIndex++ {
@@ -744,7 +742,6 @@ func (te *txExecutor) executeBlocks(ctx context.Context, startBlockNum uint64, m
 					Trace:            dbg.TraceTx(blockNum, txIndex),
 					Hooks:            te.hooks,
 					Logger:           te.logger,
-					BlockStateCache:  blockStateCache,
 				}
 
 				txTasks = append(txTasks, txTask)


### PR DESCRIPTION
Part 1 of removing/reducing dependence on `BlockStateCache` (#23140). 
## Summary 

BlockStateCache is used in two places:
- in tx exec workers reader: `versionedMap` (outside of reader) -> BlockCache -> sd.mem -> sd.parent.mem -> StateCache -> temporalDb
- write buffer: tx results are recorded here at apply/finzalize tx time. 

BlockStateCache has two parts:
- "current" data: accumulated writes during block execution
- "committed" data: state AsOf start of block execution, loaded as needed.

---

- BlockStateCache is redundant and probably be removed. Exploring that in more PRs. Even if don't manage to remove it completely; reducing its scope is useful.
- This PR removes the first usage -- versionedMap already provides block-accumulated changes (and `readCurrent=false` so `BlockStateCache.current`  is anyway skipped.); StateCache provides the "committed" data. So tx execution workers are already covered.
- the `StateCache` is already an in-mem cache. `BlockStateCache`'s "committed state" is acting as a duplicate layer on top, interfering with `StateCache` retention/LRU policies etc. (so it justifies removal of "commitment state" of BlockCache - will be done in separate PR)
