### PR TITLE
execution/state: abort when a create consumes absence before the destructor's flush

### DIFF
--- a/execution/state/create_absence_fork_test.go
+++ b/execution/state/create_absence_fork_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+// TestCreateOverAbsenceConsumedBeforeDestructFlush pins the two-view fork the
+// EIP-8246 reconstruction in versionedAccountBase can otherwise smuggle past
+// validation: tx1's new-account gas probe (EIP-8037 chargeNewAccount) reads
+// the CREATE2 target as absent before tx0 — which created the account and
+// self-destructed it to itself, leaving a balance-only account — has flushed
+// its cells. When the create flow later re-reads the account, the flushed
+// destruct must NOT be silently adopted: the absence was already consumed
+// (new-account state gas was charged on it), so the tx must abort with
+// ErrDependency (or fail commit-time validation) and re-execute. Silent
+// adoption keeps the state view correct but leaves the inflated gas charge
+// standing, so the proposer and validator diverge on fees.
+//
+// The collisionCheck variant interleaves the CREATE2 collision reads between
+// the stale probe and the account load: the nonce read's destruct-wipe scan
+// records a SelfDestruct=true read, which must not be mistaken for the
+// absence having been concluded from the destruct.
+func TestCreateOverAbsenceConsumedBeforeDestructFlush(t *testing.T) {
+	t.Parallel()
+	for _, collisionCheck := range []bool{false, true} {
+		name := "createOnly"
+		if collisionCheck {
+			name = "collisionCheckFirst"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, tx, domains := NewTestRwTx(t)
+			vm := NewVersionMap(nil)
+			ibs := NewWithVersionMap(NewReaderV3(domains.AsGetter(tx)), vm)
+			defer ibs.Close()
+			ibs.SetTxContext(0, 1)
+			ibs.SetNoMaterialize(true)
+			ibs.SetVersion(0)
+			ibs.eip8246 = true
+			ibs.eip161 = true
+
+			addr := getAddress(8246)
+
+			// tx1's gas probe consumes the account's absence before tx0 flushes.
+			empty, err := ibs.Empty(addr)
+			require.NoError(t, err)
+			require.True(t, empty)
+
+			// tx0's writes flush: CREATE2 whose constructor self-destructed to
+			// itself. EIP-8246 preserves the balance; the worker flush carries no
+			// AddressPath cell, so only the destruct probe can reveal the account
+			// to tx1.
+			writeFor(vm, addr, BalancePath, accounts.NilKey, Version{TxIndex: 0, Incarnation: 0}, *uint256.NewInt(1_000_000), true)
+			writeFor(vm, addr, NoncePath, accounts.NilKey, Version{TxIndex: 0, Incarnation: 0}, uint64(1), true)
+			writeFor(vm, addr, IncarnationPath, accounts.NilKey, Version{TxIndex: 0, Incarnation: 0}, uint64(0), true)
+			writeFor(vm, addr, SelfDestructPath, accounts.NilKey, Version{TxIndex: 0, Incarnation: 0}, true, true)
+			writeFor(vm, addr, CreateContractPath, accounts.NilKey, Version{TxIndex: 0, Incarnation: 0}, true, true)
+
+			// The CREATE2 flow re-reads the account it is about to create over.
+			diverged := false
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						if r == ErrDependency {
+							diverged = true
+							return
+						}
+						panic(r)
+					}
+				}()
+				if collisionCheck {
+					codeHash, err := ibs.GetCodeHash(addr)
+					require.NoError(t, err)
+					require.True(t, codeHash.IsEmpty() || codeHash.IsZero())
+					nonce, err := ibs.GetNonce(addr)
+					require.NoError(t, err)
+					require.Zero(t, nonce)
+				}
+				require.NoError(t, ibs.CreateAccount(addr, true))
+			}()
+
+			if !diverged {
+				io := NewVersionedIO(2)
+				io.RecordReads(Version{TxIndex: 1, Incarnation: 0}, ibs.VersionedReads())
+				diverged = vm.ValidateVersion(1, io, validateEqualVersion, true, false, false, "") != VersionValid
+			}
+			require.True(t, diverged,
+				"consuming the account's absence and then adopting the flushed destruct forks the gas view from the state view")
+		})
+	}
+}

--- a/execution/state/create_absence_fork_test.go
+++ b/execution/state/create_absence_fork_test.go
@@ -25,22 +25,15 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// TestCreateOverAbsenceConsumedBeforeDestructFlush pins the two-view fork the
-// EIP-8246 reconstruction in versionedAccountBase can otherwise smuggle past
-// validation: tx1's new-account gas probe (EIP-8037 chargeNewAccount) reads
-// the CREATE2 target as absent before tx0 — which created the account and
-// self-destructed it to itself, leaving a balance-only account — has flushed
-// its cells. When the create flow later re-reads the account, the flushed
-// destruct must NOT be silently adopted: the absence was already consumed
-// (new-account state gas was charged on it), so the tx must abort with
-// ErrDependency (or fail commit-time validation) and re-execute. Silent
-// adoption keeps the state view correct but leaves the inflated gas charge
-// standing, so the proposer and validator diverge on fees.
-//
-// The collisionCheck variant interleaves the CREATE2 collision reads between
-// the stale probe and the account load: the nonce read's destruct-wipe scan
-// records a SelfDestruct=true read, which must not be mistaken for the
-// absence having been concluded from the destruct.
+// TestCreateOverAbsenceConsumedBeforeDestructFlush pins the OCC invariant
+// that an execution which consumed an account's absence (e.g. for the
+// EIP-8037 new-account gas charge) must not silently adopt a destruct flushed
+// since: the attempt has to abort with ErrDependency or fail commit-time
+// validation, else its gas view forks from its state view. The
+// collisionCheckFirst variant interleaves the CREATE2 collision reads between
+// the probe and the account load — their destruct-wipe scan records a
+// SelfDestruct=true read that must not count as the absence having been
+// concluded from the destruct.
 func TestCreateOverAbsenceConsumedBeforeDestructFlush(t *testing.T) {
 	t.Parallel()
 	for _, collisionCheck := range []bool{false, true} {

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -1169,7 +1169,7 @@ func (sdb *IntraBlockState) synthesizeCreatedAccountBase(addr accounts.Address) 
 	// the address mid-execution and reconcile the fork out of validation's
 	// sight. Only a provisional (mid-load) probe may adopt fresh cells — the
 	// stale conclusion re-executes via commit-time validation instead.
-	if tr, ok := sdb.versionedReads.GetAddress(addr); ok && tr.Source != ProvisionalRead && (tr.Val == nil || tr.Val.Account() == nil) {
+	if sdb.consumedAddressAbsence(addr) {
 		return nil, false
 	}
 	if destructed, sdRes, ok := sdb.versionMap.ReadSelfDestruct(addr, sdb.txIndex); ok && sdRes.Status() == MVReadResultDone && destructed {
@@ -1223,6 +1223,14 @@ func (sdb *IntraBlockState) synthesizeCreatedAccountBase(addr accounts.Address) 
 	}
 	acc.Root.SetBytes(trie.EmptyRoot[:])
 	return acc, true
+}
+
+// consumedAddressAbsence reports whether this tx holds a definitive
+// (non-provisional) nil AddressPath read — it already concluded the account is
+// absent, so later loads must not adopt cells flushed since.
+func (sdb *IntraBlockState) consumedAddressAbsence(addr accounts.Address) bool {
+	tr, ok := sdb.versionedReads.GetAddress(addr)
+	return ok && tr.Source != ProvisionalRead && (tr.Val == nil || tr.Val.Account() == nil)
 }
 
 // finalizeProvisionalAddressRead demotes a load's in-flight nil record probe
@@ -1315,6 +1323,20 @@ func (sdb *IntraBlockState) versionedAccountBase(addr accounts.Address, readStor
 	// re-created it, in which case fall through to the normal read.
 	if sdb.eip8246 && readAccount == nil {
 		if destructed, sdRes, ok := sdb.versionMap.ReadSelfDestruct(addr, sdb.txIndex); ok && sdRes.Status() == MVReadResultDone && destructed {
+			// A definitive nil AddressPath read means this tx already consumed the
+			// account's absence (e.g. the EIP-8037 new-account gas charge), so
+			// cells flushed since would fork its view mid-execution: reconstructing
+			// from them reconciles the fork out of validation's sight. Abort and
+			// re-execute instead. Only an absence concluded from this destruct
+			// itself — recorded as a MapRead at the destructor's index — makes
+			// reconstruction consistent rather than a fork.
+			if tr, ok := sdb.versionedReads.GetAddress(addr); ok && tr.Source != ProvisionalRead && (tr.Val == nil || tr.Val.Account() == nil) &&
+				!(tr.Source == MapRead && tr.Version.TxIndex == sdRes.DepIdx()) {
+				if sdRes.DepIdx() > sdb.dep {
+					sdb.dep = sdRes.DepIdx()
+				}
+				panic(ErrDependency)
+			}
 			destructTxIndex := sdRes.DepIdx()
 			// Only a genuine re-creation (a later CreateAccount, which writes
 			// AddressPath) skips reconstruction. Later Balance/Nonce/CodeHash

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -1324,14 +1324,12 @@ func (sdb *IntraBlockState) versionedAccountBase(addr accounts.Address, readStor
 	if sdb.eip8246 && readAccount == nil {
 		if destructed, sdRes, ok := sdb.versionMap.ReadSelfDestruct(addr, sdb.txIndex); ok && sdRes.Status() == MVReadResultDone && destructed {
 			// A definitive nil AddressPath read means this tx already consumed the
-			// account's absence (e.g. the EIP-8037 new-account gas charge), so
-			// cells flushed since would fork its view mid-execution: reconstructing
-			// from them reconciles the fork out of validation's sight. Abort and
-			// re-execute instead. Only an absence concluded from this destruct
-			// itself — recorded as a MapRead at the destructor's index — makes
-			// reconstruction consistent rather than a fork.
+			// account's absence, so reconstructing from cells flushed since would
+			// fork its view out of validation's sight — abort and re-execute.
+			// Exempt only an absence concluded from this destruct itself,
+			// recorded as a MapRead at the destruct cell's exact version.
 			if tr, ok := sdb.versionedReads.GetAddress(addr); ok && tr.Source != ProvisionalRead && (tr.Val == nil || tr.Val.Account() == nil) &&
-				!(tr.Source == MapRead && tr.Version.TxIndex == sdRes.DepIdx()) {
+				!(tr.Source == MapRead && tr.Version.TxIndex == sdRes.DepIdx() && tr.Version.Incarnation == sdRes.Incarnation()) {
 				if sdRes.DepIdx() > sdb.dep {
 					sdb.dep = sdRes.DepIdx()
 				}


### PR DESCRIPTION
Fixes the `TestEngineApiEIP8246PreservedBalanceSurvivesCreate2Recreate` race-shard flake, hit on two unrelated branches within hours ([run 31437721312](https://github.com/erigontech/erigon/actions/runs/31437721312/job/93616802197), [run 31452022879](https://github.com/erigontech/erigon/actions/runs/31452022879/job/93658183863)): the block with the CREATE2 self-destruct-to-self and the same-salt recreate assembles fine, then newPayload rejects it with a BAL mismatch, a wrong trie root, and `gas used mismatch: header=183600 execution=367200`.

## Root cause

Workers publish writes to the version map per address and read per path, so a prior tx's cells can appear midway through an execution. Here, tx2's EIP-8037 new-account gas probe (`chargeNewAccount = Empty(target)` in `prepareCreate`) read the CREATE2 target as absent just before tx1 (create + self-destruct-to-itself, EIP-8246 preserved balance) flushed. The probe recorded a definitive nil AddressPath read and charged full new-account state gas. When the create flow re-read the target, the EIP-8246 reconstruction in `versionedAccountBase` saw the now-flushed destruct, rebuilt the preserved account — and `accountRead` overwrote the recorded nil read, erasing the observation the gas charge was built on. The bug was introduced by #22190, whose provisional account reads and recorded-read reconciliation let that overwrite reach a definitive read from an earlier load. Validation then saw a consistent read set and published the fork: correct state, but fresh-create fees and doubled block state gas. In the instrumented repro, the recreate's gas profile is byte-identical to the fresh create's:

```
[EXECDBG] blk=3 done tx=0 inc=0 rcptGas=221219 execGas=37619 stateGas=183600 tipped=21370671467879
[EXECDBG] blk=3 done tx=1 inc=0 rcptGas=221219 execGas=37619 stateGas=183600 tipped=21370671467879
```

221219/37619 = 5.8805 is exactly the sender-charge and coinbase-tip inflation in the BAL diff, and 2×183600 is the gas-used mismatch.

`synthesizeCreatedAccountBase` already refuses to adopt flushed cells over a definitive nil read; the EIP-8246 branch was missing the equivalent protection. Merely declining reconstruction is not enough there: execution would continue on `previous == nil` and record a version-stamped synthetic balance read with a stale value — a wrong-state fork that also validates cleanly.

## Fix

Mirror `versionedReadCore`'s fork handling: with a definitive nil AddressPath read on record, a newly visible destruct aborts the attempt with `ErrDependency`, and the scheduler re-executes it against the destructor. The only exemption is an absence concluded from this destruct itself (a MapRead at the destruct cell's exact version). Re-execution converges: a fresh attempt that sees the destruct from the start takes the destruct-erased AddressPath outcome, which records no definitive nil.

An earlier version of the guard instead exempted "a `SelfDestruct=true` read is recorded" and failed under stress at ~1/2,300: the CREATE2 collision check's nonce read records exactly such a read via its destruct-wipe scan after the absence was already consumed. The deterministic test pins both interleavings.

The shared "definitive nil read" predicate is extracted as `consumedAddressAbsence`, also used by `synthesizeCreatedAccountBase`.

## Testing

- `TestCreateOverAbsenceConsumedBeforeDestructFlush` drives the production read path through the fork in two variants (with and without the collision-check reads in between) and requires abort-or-invalid-validation. Red on main, green with the fix.
- Stress (macOS, `-race`, `ERIGON_COMMITMENT_PARALLEL=false`, GOMAXPROCS 2–6, parallel lanes): main fails ~1/1,200 with the exact CI signature; the fix passed 4,500+ consecutive runs.
- Green: `execution/state`, `execution/vm`, `execution/bal`, `execution/stagedsync`, `execution/execmodule`, `execution/engineapi`, `execution/tests`, `make lint`.
