### PR TITLE
`--prune.distance`: to print user-friendly advise in corner-cases

### DIFF
--- a/cmd/integration/Readme.md
+++ b/cmd/integration/Readme.md
@@ -24,9 +24,6 @@ integration stage_exec --reset
 # Unwind single stage N blocks backward
 integration stage_exec --unwind=N
 
-# Run stage prune to block N
-integration stage_exec --prune.to=N
-
 # To remove all blocks (together with bodies/txs) from db 
 integration stage_headers --reset --datadir=<my_datadir> --chain=<my_chain>
 

--- a/cmd/integration/commands/commitment.go
+++ b/cmd/integration/commands/commitment.go
@@ -112,7 +112,6 @@ func init() {
 	withBlock(cmdCommitmentRebuild)
 	withExperimentalCommitment(cmdCommitmentRebuild)
 	withUnwind(cmdCommitmentRebuild)
-	withPruneTo(cmdCommitmentRebuild)
 	withIntegrityChecks(cmdCommitmentRebuild)
 	withHeimdall(cmdCommitmentRebuild)
 	withChaosMonkey(cmdCommitmentRebuild)

--- a/cmd/integration/commands/flags.go
+++ b/cmd/integration/commands/flags.go
@@ -114,7 +114,7 @@ func withUnwind(cmd *cobra.Command) {
 	cmd.Flags().Uint64Var(&unwind, "unwind", 0, "how much blocks unwind on each iteration")
 }
 func withPruneTo(cmd *cobra.Command) {
-	cmd.Flags().Uint64Var(&pruneTo, "prune.to", 0, "how much blocks unwind on each iteration")
+	cmd.Flags().Uint64Var(&pruneTo, "prune.to", 0, "prune up to this block number (must not be above the stage progress)")
 }
 
 func withUnwindEvery(cmd *cobra.Command) {

--- a/cmd/integration/commands/flags.go
+++ b/cmd/integration/commands/flags.go
@@ -40,7 +40,7 @@ var (
 	chaindata                    string
 	databaseVerbosity            int
 	referenceChaindata           string
-	block, pruneTo, unwind       uint64
+	block, unwind                uint64
 	unwindEvery                  uint64
 	batchSizeStr                 string
 	domain                       string
@@ -113,10 +113,6 @@ func withBlock(cmd *cobra.Command) {
 func withUnwind(cmd *cobra.Command) {
 	cmd.Flags().Uint64Var(&unwind, "unwind", 0, "how much blocks unwind on each iteration")
 }
-func withPruneTo(cmd *cobra.Command) {
-	cmd.Flags().Uint64Var(&pruneTo, "prune.to", 0, "prune up to this block number (must not be above the stage progress)")
-}
-
 func withUnwindEvery(cmd *cobra.Command) {
 	cmd.Flags().Uint64Var(&unwindEvery, "unwind.every", 0, "each iteration test will move forward `--unwind.every` blocks, then unwind `--unwind` blocks")
 }

--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -328,7 +328,6 @@ func init() {
 	withStageBase(cmdStageExec)
 	withReset(cmdStageExec)
 	withBlock(cmdStageExec)
-	withPruneTo(cmdStageExec)
 	withTraceFlags(cmdStageExec)
 	withChainTipMode(cmdStageExec)
 	withErigondbDomainStepsInFrozenFile(cmdStageExec)
@@ -341,7 +340,6 @@ func init() {
 	withStageBase(cmdStageCustomTrace)
 	withReset(cmdStageCustomTrace)
 	withBlock(cmdStageCustomTrace)
-	withPruneTo(cmdStageCustomTrace)
 	withTraceFlags(cmdStageCustomTrace)
 	withDomain(cmdStageCustomTrace)
 	withErigondbDomainStepsInFrozenFile(cmdStageCustomTrace)
@@ -350,7 +348,6 @@ func init() {
 	withStageBase(cmdStageTxLookup)
 	withReset(cmdStageTxLookup)
 	withBlock(cmdStageTxLookup)
-	withPruneTo(cmdStageTxLookup)
 	rootCmd.AddCommand(cmdStageTxLookup)
 
 	withConfig(cmdPrintMigrations)
@@ -625,9 +622,6 @@ func stageSenders(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) er
 		if err := stagedsync.UnwindSendersStage(u, tx, cfg, ctx); err != nil {
 			return err
 		}
-	case pruneTo > 0:
-		//noop
-		return nil
 	default:
 		if err := stagedsync.SpawnRecoverSendersStage(cfg, s, sync, tx, block, ctx, logger); err != nil {
 			return err
@@ -673,13 +667,6 @@ func stageExec(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) error
 
 	logger.Info("Stage", "name", s.ID, "progress", s.BlockNumber)
 	chainConfig, pm := fromdb.ChainConfig(db), fromdb.PruneMode(db)
-	if pruneTo > 0 {
-		d, err := prune.DistanceFrom(s.BlockNumber, pruneTo)
-		if err != nil {
-			return err
-		}
-		pm.History = d
-	}
 
 	genesis := readGenesis(chain)
 	br, _ := blocksIO(db, logger)
@@ -700,10 +687,6 @@ func stageExec(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) error
 			return nil
 		}); err != nil {
 			return err
-		}
-
-		if unwind < pruneTo {
-			return fmt.Errorf("can't prune beyond unwind: unwind=%d, prune=%d", unwind, pruneTo)
 		}
 	}
 
@@ -734,18 +717,6 @@ func stageExec(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) error
 		err = tx.Commit()
 		tx = nil
 		return err
-	}
-
-	if pruneTo > 0 {
-		p, err := sync.PruneStageState(stages.Execution, s.BlockNumber, tx, true)
-		if err != nil {
-			return err
-		}
-		err = stagedsync.PruneExecutionStage(ctx, p, tx, cfg, 0, logger)
-		if err != nil {
-			return err
-		}
-		return tx.Commit()
 	}
 
 	var sendersProgress, execProgress uint64
@@ -1062,13 +1033,6 @@ func stageTxLookup(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) e
 	defer tx.Rollback()
 
 	s := stage(sync, tx, stages.TxLookup)
-	if pruneTo > 0 {
-		d, err := prune.DistanceFrom(s.BlockNumber, pruneTo)
-		if err != nil {
-			return err
-		}
-		pm.History = d
-	}
 	logger.Info("Stage", "name", s.ID, "progress", s.BlockNumber)
 
 	br, _ := blocksIO(db, logger)
@@ -1081,15 +1045,6 @@ func stageTxLookup(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) e
 
 		u := sync.NewUnwindState(stages.TxLookup, s.BlockNumber-unwind, s.BlockNumber, true, false)
 		err = stagedsync.UnwindTxLookup(u, s, tx, cfg, ctx, logger)
-		if err != nil {
-			return err
-		}
-	case pruneTo > 0:
-		p, err := sync.PruneStageState(stages.TxLookup, s.BlockNumber, tx, true)
-		if err != nil {
-			return err
-		}
-		err = stagedsync.PruneTxLookup(p, tx, cfg, ctx, logger)
 		if err != nil {
 			return err
 		}

--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -674,7 +674,11 @@ func stageExec(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) error
 	logger.Info("Stage", "name", s.ID, "progress", s.BlockNumber)
 	chainConfig, pm := fromdb.ChainConfig(db), fromdb.PruneMode(db)
 	if pruneTo > 0 {
-		pm.History = prune.Distance(s.BlockNumber - pruneTo)
+		d, err := prune.DistanceFrom(s.BlockNumber, pruneTo)
+		if err != nil {
+			return err
+		}
+		pm.History = d
 	}
 
 	genesis := readGenesis(chain)
@@ -1059,7 +1063,11 @@ func stageTxLookup(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) e
 
 	s := stage(sync, tx, stages.TxLookup)
 	if pruneTo > 0 {
-		pm.History = prune.Distance(s.BlockNumber - pruneTo)
+		d, err := prune.DistanceFrom(s.BlockNumber, pruneTo)
+		if err != nil {
+			return err
+		}
+		pm.History = d
 	}
 	logger.Info("Stage", "name", s.ID, "progress", s.BlockNumber)
 

--- a/db/kv/prune/distance.go
+++ b/db/kv/prune/distance.go
@@ -90,10 +90,9 @@ func parseDistanceNumber(s, flag, aliasHint string) (uint64, error) {
 }
 
 // stateHistoryDistanceCLIValue renders a state-history-style distance as its
-// operator-facing argument. keepAll is the flag's own "keep-all" sentinel, the
-// same one parseStateHistoryDistance takes: each flag maps the alias to a
-// different value, so only that one may render as the alias. Other sentinels
-// render as their number, which the parser still accepts unchanged.
+// operator-facing argument. Each flag maps "keep-all" to its own sentinel, so
+// only keepAll — the same sentinel parseStateHistoryDistance takes — may render
+// as the alias; any other sentinel stays a number the parser still accepts.
 func stateHistoryDistanceCLIValue(v uint64, keepAll Distance) string {
 	if Distance(v) == keepAll {
 		return "keep-all"

--- a/db/kv/prune/distance.go
+++ b/db/kv/prune/distance.go
@@ -89,16 +89,6 @@ func parseDistanceNumber(s, flag, aliasHint string) (uint64, error) {
 	return n, nil
 }
 
-// DistanceFrom returns the retention distance from stageHead back to target.
-// Subtracting the two directly underflows when target is above stageHead, and
-// lands on a policy sentinel rather than a large distance.
-func DistanceFrom(stageHead, target uint64) (Distance, error) {
-	if target > stageHead {
-		return 0, fmt.Errorf("prune target %d is above stage progress %d", target, stageHead)
-	}
-	return Distance(stageHead - target), nil
-}
-
 // stateHistoryDistanceCLIValue renders a state-history-style distance as its
 // operator-facing argument. Every sentinel disables pruning for these fields, so
 // all of them render as the alias the parser accepts rather than as a raw magic

--- a/db/kv/prune/distance.go
+++ b/db/kv/prune/distance.go
@@ -90,11 +90,12 @@ func parseDistanceNumber(s, flag, aliasHint string) (uint64, error) {
 }
 
 // stateHistoryDistanceCLIValue renders a state-history-style distance as its
-// operator-facing argument. Every sentinel disables pruning for these fields, so
-// all of them render as the alias the parser accepts rather than as a raw magic
-// number the operator cannot re-pass.
-func stateHistoryDistanceCLIValue(v uint64) string {
-	if !Distance(v).Enabled() {
+// operator-facing argument. keepAll is the flag's own "keep-all" sentinel, the
+// same one parseStateHistoryDistance takes: each flag maps the alias to a
+// different value, so only that one may render as the alias. Other sentinels
+// render as their number, which the parser still accepts unchanged.
+func stateHistoryDistanceCLIValue(v uint64, keepAll Distance) string {
+	if Distance(v) == keepAll {
 		return "keep-all"
 	}
 	return strconv.FormatUint(v, 10)

--- a/db/kv/prune/distance.go
+++ b/db/kv/prune/distance.go
@@ -89,6 +89,27 @@ func parseDistanceNumber(s, flag, aliasHint string) (uint64, error) {
 	return n, nil
 }
 
+// DistanceFrom returns the retention distance from stageHead back to target.
+// Subtracting the two directly underflows when target is above stageHead, and
+// lands on a policy sentinel rather than a large distance.
+func DistanceFrom(stageHead, target uint64) (Distance, error) {
+	if target > stageHead {
+		return 0, fmt.Errorf("prune target %d is above stage progress %d", target, stageHead)
+	}
+	return Distance(stageHead - target), nil
+}
+
+// stateHistoryDistanceCLIValue renders a state-history-style distance as its
+// operator-facing argument. Every sentinel disables pruning for these fields, so
+// all of them render as the alias the parser accepts rather than as a raw magic
+// number the operator cannot re-pass.
+func stateHistoryDistanceCLIValue(v uint64) string {
+	if !Distance(v).Enabled() {
+		return "keep-all"
+	}
+	return strconv.FormatUint(v, 10)
+}
+
 // blocksDistanceCLIValue renders a Blocks retention value as the operator-facing
 // --prune.distance.blocks argument, preferring the named alias for sentinels.
 func blocksDistanceCLIValue(v uint64) string {

--- a/db/kv/prune/distance_test.go
+++ b/db/kv/prune/distance_test.go
@@ -190,32 +190,6 @@ func TestModeString_ReceiptsKeepAll(t *testing.T) {
 	assert.NotContains(t, def.String(), "prune.receipts.distance")
 }
 
-// A Distance built by bare subtraction underflows when the target is above the
-// stage head, and lands exactly on the policy sentinels: off-by-one becomes
-// KeepPostMergeBlocksPruneMode, off-by-two becomes KeepAllBlocksPruneMode. Both
-// report Enabled()==false, so pruning silently turns into a different policy.
-func TestDistanceFrom(t *testing.T) {
-	const head = uint64(1000)
-
-	got, err := DistanceFrom(head, 900)
-	require.NoError(t, err)
-	assert.Equal(t, Distance(100), got)
-	assert.Equal(t, uint64(900), got.PruneTo(head))
-
-	got, err = DistanceFrom(head, head)
-	require.NoError(t, err)
-	assert.Equal(t, Distance(0), got)
-
-	for _, target := range []uint64{head + 1, head + 2, head + 3} {
-		_, err := DistanceFrom(head, target)
-		require.Error(t, err, "target %d is above head %d", target, head)
-	}
-
-	overshot := head + 1
-	assert.Equal(t, KeepPostMergeBlocksPruneMode, Distance(head-overshot))
-	assert.False(t, Distance(head-overshot).Enabled())
-}
-
 // Sentinels must render as their CLI alias, never as the raw magic number --
 // the rendered string is what EnsureNotChanged tells the operator to re-pass.
 func TestModeString_HistorySentinelRendersByName(t *testing.T) {

--- a/db/kv/prune/distance_test.go
+++ b/db/kv/prune/distance_test.go
@@ -99,6 +99,37 @@ func TestParseHistoryDistance(t *testing.T) {
 	}
 }
 
+// Every state-history flag maps "keep-all" to its own sentinel, so rendering the
+// alias for a sentinel that is not the flag's own would re-parse to a different
+// value — and for Receipts, to a different meaning.
+func TestStateHistoryDistanceCLIValueRoundTrips(t *testing.T) {
+	flags := []struct {
+		name    string
+		keepAll Distance
+		parse   func(string, string) (uint64, error)
+	}{
+		{"prune.distance", KeepPostMergeBlocksPruneMode, ParseHistoryDistance},
+		{"prune.commitment-history.distance", KeepAllBlocksPruneMode, ParseCommitmentHistoryDistance},
+		{"prune.receipts.distance", KeepAllReceiptsPruneMode, ParseReceiptsDistance},
+	}
+	values := []Distance{
+		KeepPostMergeBlocksPruneMode,
+		KeepAllBlocksPruneMode,
+		KeepAllReceiptsPruneMode,
+		100_000,
+	}
+	for _, f := range flags {
+		t.Run(f.name, func(t *testing.T) {
+			for _, v := range values {
+				rendered := stateHistoryDistanceCLIValue(uint64(v), f.keepAll)
+				got, err := f.parse(rendered, f.name)
+				require.NoError(t, err)
+				assert.Equal(t, uint64(v), got, "--%s=%s must re-parse to the value it was rendered from", f.name, rendered)
+			}
+		})
+	}
+}
+
 func TestBlocksDistanceCLIValue(t *testing.T) {
 	assert.Equal(t, "keep-post-merge", blocksDistanceCLIValue(uint64(KeepPostMergeBlocksPruneMode)))
 	assert.Equal(t, "keep-all", blocksDistanceCLIValue(uint64(KeepAllBlocksPruneMode)))
@@ -190,14 +221,15 @@ func TestModeString_ReceiptsKeepAll(t *testing.T) {
 	assert.NotContains(t, def.String(), "prune.receipts.distance")
 }
 
-// Sentinels must render as their CLI alias, never as the raw magic number --
-// the rendered string is what EnsureNotChanged tells the operator to re-pass.
-func TestModeString_HistorySentinelRendersByName(t *testing.T) {
+// A legacy datadir can hold a sentinel that is not this flag's own keep-all.
+// Rendering it as the alias would re-parse to a different value, so it stays a
+// number -- which the parser still accepts unchanged.
+func TestModeString_ForeignSentinelRendersAsNumber(t *testing.T) {
 	m := ArchiveMode
 	m.History = KeepAllBlocksPruneMode
-	assert.NotContains(t, m.String(), "18446744073709551614")
+	assert.Contains(t, m.String(), "--prune.distance=18446744073709551614")
 
 	m = ArchiveMode
 	m.CommitmentHistory = KeepPostMergeBlocksPruneMode
-	assert.NotContains(t, m.String(), "18446744073709551615")
+	assert.Contains(t, m.String(), "--prune.commitment-history.distance=18446744073709551615")
 }

--- a/db/kv/prune/distance_test.go
+++ b/db/kv/prune/distance_test.go
@@ -189,3 +189,41 @@ func TestModeString_ReceiptsKeepAll(t *testing.T) {
 	assert.True(t, def.ReceiptsFollowHistory(), "unset receipts follows history")
 	assert.NotContains(t, def.String(), "prune.receipts.distance")
 }
+
+// A Distance built by bare subtraction underflows when the target is above the
+// stage head, and lands exactly on the policy sentinels: off-by-one becomes
+// KeepPostMergeBlocksPruneMode, off-by-two becomes KeepAllBlocksPruneMode. Both
+// report Enabled()==false, so pruning silently turns into a different policy.
+func TestDistanceFrom(t *testing.T) {
+	const head = uint64(1000)
+
+	got, err := DistanceFrom(head, 900)
+	require.NoError(t, err)
+	assert.Equal(t, Distance(100), got)
+	assert.Equal(t, uint64(900), got.PruneTo(head))
+
+	got, err = DistanceFrom(head, head)
+	require.NoError(t, err)
+	assert.Equal(t, Distance(0), got)
+
+	for _, target := range []uint64{head + 1, head + 2, head + 3} {
+		_, err := DistanceFrom(head, target)
+		require.Error(t, err, "target %d is above head %d", target, head)
+	}
+
+	overshot := head + 1
+	assert.Equal(t, KeepPostMergeBlocksPruneMode, Distance(head-overshot))
+	assert.False(t, Distance(head-overshot).Enabled())
+}
+
+// Sentinels must render as their CLI alias, never as the raw magic number --
+// the rendered string is what EnsureNotChanged tells the operator to re-pass.
+func TestModeString_HistorySentinelRendersByName(t *testing.T) {
+	m := ArchiveMode
+	m.History = KeepAllBlocksPruneMode
+	assert.NotContains(t, m.String(), "18446744073709551614")
+
+	m = ArchiveMode
+	m.CommitmentHistory = KeepPostMergeBlocksPruneMode
+	assert.NotContains(t, m.String(), "18446744073709551615")
+}

--- a/db/kv/prune/storage_mode.go
+++ b/db/kv/prune/storage_mode.go
@@ -124,7 +124,7 @@ func (m Mode) String() string {
 		var sb strings.Builder
 		sb.WriteString(fullModeStr + "(legacy)")
 		if m.History.toValue() != FullMode.History.toValue() {
-			fmt.Fprintf(&sb, " --prune.distance=%d", m.History.toValue())
+			fmt.Fprintf(&sb, " --prune.distance=%s", stateHistoryDistanceCLIValue(m.History.toValue()))
 		}
 		appendCommitmentHistory(&sb, m)
 		appendReceipts(&sb, m)
@@ -136,7 +136,7 @@ func (m Mode) String() string {
 		var sb strings.Builder
 		sb.WriteString(blockModeStr)
 		if m.History.toValue() != BlocksMode.History.toValue() {
-			fmt.Fprintf(&sb, " --prune.distance=%d", m.History.toValue())
+			fmt.Fprintf(&sb, " --prune.distance=%s", stateHistoryDistanceCLIValue(m.History.toValue()))
 		}
 		appendCommitmentHistory(&sb, m)
 		appendReceipts(&sb, m)
@@ -150,7 +150,7 @@ func (m Mode) String() string {
 	var sb strings.Builder
 	sb.WriteString(archiveModeStr)
 	if m.History.toValue() != DefaultMode.History.toValue() {
-		fmt.Fprintf(&sb, " --prune.distance=%d", m.History.toValue())
+		fmt.Fprintf(&sb, " --prune.distance=%s", stateHistoryDistanceCLIValue(m.History.toValue()))
 	}
 	if m.Blocks.toValue() != DefaultMode.Blocks.toValue() {
 		fmt.Fprintf(&sb, " --prune.distance.blocks=%s", blocksDistanceCLIValue(m.Blocks.toValue()))
@@ -169,7 +169,7 @@ func modeEquals(a, b Mode) bool {
 
 func appendCommitmentHistory(sb *strings.Builder, m Mode) {
 	if m.CommitmentHistory != nil && m.CommitmentHistory.toValue() != KeepAllBlocksPruneMode.toValue() {
-		fmt.Fprintf(sb, " --prune.commitment-history.distance=%d", m.CommitmentHistory.toValue())
+		fmt.Fprintf(sb, " --prune.commitment-history.distance=%s", stateHistoryDistanceCLIValue(m.CommitmentHistory.toValue()))
 	}
 }
 
@@ -182,7 +182,7 @@ func appendReceipts(sb *strings.Builder, m Mode) {
 	case KeepAllReceiptsPruneMode.toValue():
 		sb.WriteString(" --prune.receipts.distance=keep-all")
 	default:
-		fmt.Fprintf(sb, " --prune.receipts.distance=%d", m.Receipts.toValue())
+		fmt.Fprintf(sb, " --prune.receipts.distance=%s", stateHistoryDistanceCLIValue(m.Receipts.toValue()))
 	}
 }
 

--- a/db/kv/prune/storage_mode.go
+++ b/db/kv/prune/storage_mode.go
@@ -174,16 +174,12 @@ func appendCommitmentHistory(sb *strings.Builder, m Mode) {
 }
 
 func appendReceipts(sb *strings.Builder, m Mode) {
-	if m.Receipts == nil {
+	// An unset or KeepAllBlocksPruneMode value is the follow-history default —
+	// nothing for the operator to re-pass.
+	if m.Receipts == nil || m.Receipts.toValue() == KeepAllBlocksPruneMode.toValue() {
 		return
 	}
-	switch m.Receipts.toValue() {
-	case KeepAllBlocksPruneMode.toValue(): // follow-history default — nothing to render
-	case KeepAllReceiptsPruneMode.toValue():
-		sb.WriteString(" --prune.receipts.distance=keep-all")
-	default:
-		fmt.Fprintf(sb, " --prune.receipts.distance=%s", stateHistoryDistanceCLIValue(m.Receipts.toValue(), KeepAllReceiptsPruneMode))
-	}
+	fmt.Fprintf(sb, " --prune.receipts.distance=%s", stateHistoryDistanceCLIValue(m.Receipts.toValue(), KeepAllReceiptsPruneMode))
 }
 
 func FromCli(pruneMode string, distanceHistory, distanceBlocks, commitmentHistoryOlder, receiptsDistance uint64) (Mode, error) {

--- a/db/kv/prune/storage_mode.go
+++ b/db/kv/prune/storage_mode.go
@@ -124,7 +124,7 @@ func (m Mode) String() string {
 		var sb strings.Builder
 		sb.WriteString(fullModeStr + "(legacy)")
 		if m.History.toValue() != FullMode.History.toValue() {
-			fmt.Fprintf(&sb, " --prune.distance=%s", stateHistoryDistanceCLIValue(m.History.toValue()))
+			fmt.Fprintf(&sb, " --prune.distance=%s", stateHistoryDistanceCLIValue(m.History.toValue(), KeepPostMergeBlocksPruneMode))
 		}
 		appendCommitmentHistory(&sb, m)
 		appendReceipts(&sb, m)
@@ -136,7 +136,7 @@ func (m Mode) String() string {
 		var sb strings.Builder
 		sb.WriteString(blockModeStr)
 		if m.History.toValue() != BlocksMode.History.toValue() {
-			fmt.Fprintf(&sb, " --prune.distance=%s", stateHistoryDistanceCLIValue(m.History.toValue()))
+			fmt.Fprintf(&sb, " --prune.distance=%s", stateHistoryDistanceCLIValue(m.History.toValue(), KeepPostMergeBlocksPruneMode))
 		}
 		appendCommitmentHistory(&sb, m)
 		appendReceipts(&sb, m)
@@ -150,7 +150,7 @@ func (m Mode) String() string {
 	var sb strings.Builder
 	sb.WriteString(archiveModeStr)
 	if m.History.toValue() != DefaultMode.History.toValue() {
-		fmt.Fprintf(&sb, " --prune.distance=%s", stateHistoryDistanceCLIValue(m.History.toValue()))
+		fmt.Fprintf(&sb, " --prune.distance=%s", stateHistoryDistanceCLIValue(m.History.toValue(), KeepPostMergeBlocksPruneMode))
 	}
 	if m.Blocks.toValue() != DefaultMode.Blocks.toValue() {
 		fmt.Fprintf(&sb, " --prune.distance.blocks=%s", blocksDistanceCLIValue(m.Blocks.toValue()))
@@ -169,7 +169,7 @@ func modeEquals(a, b Mode) bool {
 
 func appendCommitmentHistory(sb *strings.Builder, m Mode) {
 	if m.CommitmentHistory != nil && m.CommitmentHistory.toValue() != KeepAllBlocksPruneMode.toValue() {
-		fmt.Fprintf(sb, " --prune.commitment-history.distance=%s", stateHistoryDistanceCLIValue(m.CommitmentHistory.toValue()))
+		fmt.Fprintf(sb, " --prune.commitment-history.distance=%s", stateHistoryDistanceCLIValue(m.CommitmentHistory.toValue(), KeepAllBlocksPruneMode))
 	}
 }
 
@@ -182,7 +182,7 @@ func appendReceipts(sb *strings.Builder, m Mode) {
 	case KeepAllReceiptsPruneMode.toValue():
 		sb.WriteString(" --prune.receipts.distance=keep-all")
 	default:
-		fmt.Fprintf(sb, " --prune.receipts.distance=%s", stateHistoryDistanceCLIValue(m.Receipts.toValue()))
+		fmt.Fprintf(sb, " --prune.receipts.distance=%s", stateHistoryDistanceCLIValue(m.Receipts.toValue(), KeepAllReceiptsPruneMode))
 	}
 }
 


### PR DESCRIPTION
integration opens the chaindb in accede mode — `root.go:64`: `Accede(true) // integration tool: must not create db` — so the prune mode is always already persisted and readable via `fromdb.PruneMode(db)`. It does not need a prune flag of its own. `--prune.to` was the only one it had, and `grep` finds no reference to it anywhere outside `cmd/integration`; erigon itself has no absolute-target prune flag to mirror, since every `--prune.*` it exposes is relative.

The flag could not express its own value safely either. Both call sites built a `Distance` by bare subtraction, so a target above the stage head underflowed onto the policy sentinels. At head 1000:

| flag | Distance | `Enabled` | `Mode.String()` — what the operator is told to re-pass |
|---|---|---|---|
| `--prune.to=1000` | 0 | true | `blocks --prune.distance=0` |
| `--prune.to=1001` | MaxUint64 | **false** | `archive` |
| `--prune.to=1002` | MaxUint64-1 | **false** | `archive --prune.distance=18446744073709551614` |
| `--prune.to=1003` | MaxUint64-2 | false | `archive --prune.distance=18446744073709551613` |

`PruneTo` clamps, so an underflowed distance prunes *nothing* — it fails safe, but silently, and a one-block typo reads back as a mode change.

## What the flag was actually doing

Of its four registrations, two never read the value — `stage_custom_trace` and `commitment_rebuild` registered it and ignored it. `stage_senders` had `case pruneTo > 0: //noop; return nil`. The `stage_exec` guard compared `unwind < pruneTo`, a relative count against an absolute block.

Only `stage_exec` and `stage_tx_lookup` did real work with it, and the prune *amount* there already came from the persisted mode through `cfg` — `PruneStageState` takes `s.BlockNumber` and `PruneExecutionStage` reads `cfg`. The synthesized `pm.History` was the flag's only contribution, so removing it loses no configuration.

## Also here

`Mode.String()` rendered state-history sentinels as the raw uint64, while `Blocks` already mapped them to their CLI alias. This is the recommendation path: `EnsureNotChanged` returns `changing --prune.* flags is prohibited, last time you used: ...`, so whatever it prints has to re-parse to the value it came from. Reachable from a legacy datadir independently of the flag.

The three sentinels are not interchangeable — each flag parses `keep-all` to its own (`--prune.distance` → `KeepPostMergeBlocksPruneMode`, `--prune.commitment-history.distance` → `KeepAllBlocksPruneMode`, `--prune.receipts.distance` → `KeepAllReceiptsPruneMode`). So `stateHistoryDistanceCLIValue` takes the flag's own sentinel, mirroring the `keepAll` argument `parseStateHistoryDistance` already took, and renders `keep-all` only for that one; anything else stays a number the parser still accepts. Rendering every disabled sentinel as the alias would have re-parsed to a different `Mode`, and on `Receipts` would have turned follow-history into forced keep-all.

For `History` and `CommitmentHistory` the flag's own sentinel is the value the named mode already carries, so `Mode.String()` folds it into the mode name and never prints the flag; `Receipts` is the one place the alias is actually reachable.

`DistanceFrom` from the first revision goes with its only callers — every remaining `Distance` in the tree is built through the `prune.Parse*Distance` functions, none by subtraction.
