### PR TITLE
execution/stagedsync: replace the fee contribution, do not stack it

### DIFF
--- a/execution/stagedsync/exec3_fee_merge_revalidate_test.go
+++ b/execution/stagedsync/exec3_fee_merge_revalidate_test.go
@@ -1,0 +1,194 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package stagedsync
+
+import (
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/exec"
+	"github.com/erigontech/erigon/execution/state"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/execution/types/accounts"
+	"github.com/erigontech/erigon/execution/vm/evmtypes"
+)
+
+// feeMergeRevalidationFixture is a zero-tip tx (txIndex 2) that doesn't touch
+// the coinbase, with the coinbase starting EIP-161-empty. mergeFeePass drives
+// the same blockExecutor.mergeFeeWrites the apply loop's validate step calls.
+type feeMergeRevalidationFixture struct {
+	be       *blockExecutor
+	result   *execResult
+	task     *taskVersion
+	reader   *mapStateReader
+	rules    *chain.Rules
+	coinbase accounts.Address
+	version  state.Version
+}
+
+func newFeeMergeRevalidationFixture(t *testing.T) *feeMergeRevalidationFixture {
+	t.Helper()
+
+	coinbase := fAddr("coinbase")
+	header := &types.Header{Number: *uint256.NewInt(1), GasLimit: 30_000_000, GasUsed: 21000}
+	version := state.Version{BlockNum: 1, TxNum: 3, TxIndex: 2}
+	txTask := &exec.TxTask{
+		Header: header, TxNum: version.TxNum, TxIndex: version.TxIndex,
+		Config:          chain.TestChainBerlinConfig,
+		EvmBlockContext: evmtypes.BlockContext{BlockNumber: 1},
+	}
+	task := &taskVersion{execTask: &execTask{Task: txTask, shouldDelayFeeCalc: true}, version: version}
+	result := &execResult{TxResult: &exec.TxResult{
+		Task:            task,
+		ExecutionResult: evmtypes.ExecutionResult{BurntContractAddress: accounts.NilAddress},
+		Coinbase:        coinbase,
+	}}
+
+	other := fAddr("other")
+	result.TxOut = &state.WriteSet{}
+	result.TxOut.SetBalance(other, &state.VersionedWrite[uint256.Int]{
+		WriteHeader: state.WriteHeader{Address: other, Path: state.BalancePath, Version: version},
+		Val:         *uint256.NewInt(7),
+	})
+
+	be := &blockExecutor{
+		versionMap:   state.NewVersionMap(nil),
+		blockIO:      state.NewVersionedIO(8),
+		feeMergeTemp: map[int]*state.WriteSet{},
+	}
+	be.blockIO.RecordWrites(version, result.TxOut)
+
+	return &feeMergeRevalidationFixture{
+		be:       be,
+		result:   result,
+		task:     task,
+		reader:   newMapStateReader(),
+		rules:    &chain.Rules{IsSpuriousDragon: true},
+		coinbase: coinbase,
+		version:  version,
+	}
+}
+
+// fundCoinbase simulates a lower tx (txIndex 1) re-executing and crediting
+// the coinbase, committed to the version map.
+func (f *feeMergeRevalidationFixture) fundCoinbase() {
+	f.be.versionMap.WriteBalance(f.coinbase, state.Version{TxIndex: 1}, *uint256.NewInt(9_000_000), true)
+	f.be.versionMap.WriteAddress(f.coinbase, state.Version{TxIndex: 1}, &accounts.Account{Balance: *uint256.NewInt(9_000_000)}, true)
+}
+
+// mergeFeePass runs one apply-loop validation round's fee merge — the same
+// calcFees + blockExecutor.mergeFeeWrites sequence exec3_parallel.go's
+// validate loop runs — and returns calcFees' own output for the caller to
+// inspect.
+func (f *feeMergeRevalidationFixture) mergeFeePass(t *testing.T) *state.WriteSet {
+	t.Helper()
+	tipWrites, err := f.result.calcFees(f.task, f.be.versionMap, f.reader, f.rules)
+	require.NoError(t, err)
+	f.be.mergeFeeWrites(0, f.version, f.result.TxOut, tipWrites)
+	return tipWrites
+}
+
+func (f *feeMergeRevalidationFixture) normalize(t *testing.T) *state.WriteSet {
+	t.Helper()
+	rawWrites := f.be.blockIO.WriteSet(f.version.TxIndex)
+	norm, err := rawWrites.Normalize(f.be.versionMap, f.version.TxIndex, f.version.Incarnation,
+		f.reader, nil, true /*emptyRemoval*/, false /*isAura*/, false /*eip8246*/)
+	require.NoError(t, err)
+	return norm
+}
+
+// TestFeeMergeRevalidationDropsStaleDelete pins #23237: a zero-tip tx that
+// doesn't touch the coinbase first validates in a batch where an earlier tx
+// is still invalid and the coinbase is genuinely EIP-161-empty, so calcFees
+// emits a SelfDestructPath delete for it. The earlier tx is then fixed and
+// funds the coinbase without this tx re-executing, so its second calcFees
+// pass emits nothing. The recorded write set must reflect that — not keep
+// the first pass's delete merged in — once normalized for commit.
+func TestFeeMergeRevalidationDropsStaleDelete(t *testing.T) {
+	f := newFeeMergeRevalidationFixture(t)
+
+	pass1 := f.mergeFeePass(t)
+	require.False(t, pass1.IsEmpty(), "pass 1 should emit the EIP-161 delete")
+	sd1, ok := pass1.GetSelfDestruct(f.coinbase)
+	require.True(t, ok)
+	require.True(t, sd1.Val)
+
+	f.fundCoinbase()
+
+	pass2 := f.mergeFeePass(t)
+	require.True(t, pass2.IsEmpty(), "coinbase is funded now, calcFees has nothing to contribute")
+
+	norm := f.normalize(t)
+
+	_, committed := norm.GetSelfDestruct(f.coinbase)
+	require.False(t, committed, "stale EIP-161 delete from pass 1 must not survive a revalidation pass that no longer produces it")
+
+	// This tx never touches the coinbase once the stale delete is dropped —
+	// the funded balance is tx 1's own contribution, not this tx's.
+	_, hasBal := norm.GetBalance(f.coinbase)
+	require.False(t, hasBal, "this tx must stay silent about the coinbase, not fabricate a balance write either")
+}
+
+// A later round that contributes something else must replace the earlier round
+// rather than stack on it: a delete and the credit that supersedes it cannot
+// both be the tx's fee contribution.
+func TestFeeMergeRevalidationReplacesRatherThanStacks(t *testing.T) {
+	f := newFeeMergeRevalidationFixture(t)
+
+	pass1 := f.mergeFeePass(t)
+	sd, ok := pass1.GetSelfDestruct(f.coinbase)
+	require.True(t, ok)
+	require.True(t, sd.Val, "pass 1 emits the delete for an empty coinbase")
+
+	// The tip is no longer zero, so the next round credits the coinbase instead.
+	f.result.ExecutionResult.FeeTipped = *uint256.NewInt(500)
+
+	pass2 := f.mergeFeePass(t)
+	_, stillDeletes := pass2.GetSelfDestruct(f.coinbase)
+	require.False(t, stillDeletes)
+	credit, ok := pass2.GetBalance(f.coinbase)
+	require.True(t, ok, "pass 2 credits the tip")
+	require.Equal(t, uint64(500), credit.Val.Uint64())
+
+	norm := f.normalize(t)
+
+	_, committed := norm.GetSelfDestruct(f.coinbase)
+	require.False(t, committed, "the superseded delete must not ride along with the credit")
+	bal, hasBal := norm.GetBalance(f.coinbase)
+	require.True(t, hasBal)
+	require.Equal(t, uint64(500), bal.Val.Uint64())
+}
+
+// TestFeeMergeRevalidationControlNormalizeNeedsTheStaleMerge is the negative
+// control: with no first pass ever recorded, Normalize must not invent the
+// coinbase delete on its own. This isolates the delete in the other test to
+// the merge, not to Normalize's own filtering.
+func TestFeeMergeRevalidationControlNormalizeNeedsTheStaleMerge(t *testing.T) {
+	f := newFeeMergeRevalidationFixture(t)
+	f.fundCoinbase()
+
+	pass := f.mergeFeePass(t)
+	require.True(t, pass.IsEmpty())
+
+	norm := f.normalize(t)
+
+	_, committed := norm.GetSelfDestruct(f.coinbase)
+	require.False(t, committed, "Normalize must not invent the delete when no pass ever produced it")
+}

--- a/execution/stagedsync/exec3_fee_merge_revalidate_test.go
+++ b/execution/stagedsync/exec3_fee_merge_revalidate_test.go
@@ -94,10 +94,21 @@ func (f *feeMergeRevalidationFixture) fundCoinbase() {
 }
 
 // mergeFeePass runs one apply-loop validation round's fee merge — the same
-// calcFees + blockExecutor.mergeFeeWrites sequence exec3_parallel.go's
-// validate loop runs — and returns calcFees' own output for the caller to
-// inspect.
+// calcFees + blockExecutor.mergeFeeWrites + versionMap flush sequence
+// exec3_parallel.go's validate loop runs — and returns calcFees' own output
+// for the caller to inspect.
 func (f *feeMergeRevalidationFixture) mergeFeePass(t *testing.T) *state.WriteSet {
+	t.Helper()
+	tipWrites, err := f.result.calcFees(f.task, f.be.versionMap, f.reader, f.rules)
+	require.NoError(t, err)
+	f.be.mergeFeeWrites(0, f.version, f.result.TxOut, tipWrites)
+	f.be.versionMap.FlushVersionedWrites(f.be.blockIO.WriteSet(f.version.TxIndex), true, "")
+	return tipWrites
+}
+
+// mergeFeePassUnflushed is a round that never reaches the flush, which is what
+// the validate loop does when a read comes back too early to judge.
+func (f *feeMergeRevalidationFixture) mergeFeePassUnflushed(t *testing.T) *state.WriteSet {
 	t.Helper()
 	tipWrites, err := f.result.calcFees(f.task, f.be.versionMap, f.reader, f.rules)
 	require.NoError(t, err)
@@ -114,9 +125,9 @@ func (f *feeMergeRevalidationFixture) normalize(t *testing.T) *state.WriteSet {
 	return norm
 }
 
-// TestFeeMergeRevalidationDropsStaleDelete pins #23237: a zero-tip tx that
-// doesn't touch the coinbase first validates in a batch where an earlier tx
-// is still invalid and the coinbase is genuinely EIP-161-empty, so calcFees
+// TestFeeMergeRevalidationDropsStaleDelete covers a zero-tip tx that doesn't
+// touch the coinbase and first validates in a batch where an earlier tx is
+// still invalid and the coinbase is genuinely EIP-161-empty, so calcFees
 // emits a SelfDestructPath delete for it. The earlier tx is then fixed and
 // funds the coinbase without this tx re-executing, so its second calcFees
 // pass emits nothing. The recorded write set must reflect that — not keep
@@ -144,6 +155,45 @@ func TestFeeMergeRevalidationDropsStaleDelete(t *testing.T) {
 	// the funded balance is tx 1's own contribution, not this tx's.
 	_, hasBal := norm.GetBalance(f.coinbase)
 	require.False(t, hasBal, "this tx must stay silent about the coinbase, not fabricate a balance write either")
+}
+
+// TestFeeMergeRevalidationRetractsStaleVersionMapCell covers the version-map
+// side of the same scenario: FlushVersionedWrites is upsert-only, so pass 1's
+// fee cell stays in the version map even after pass 2's merge drops it from
+// blockIO. A downstream tx reading through that cell must not see a delete
+// this tx no longer commits.
+func TestFeeMergeRevalidationRetractsStaleVersionMapCell(t *testing.T) {
+	f := newFeeMergeRevalidationFixture(t)
+
+	pass1 := f.mergeFeePass(t)
+	require.False(t, pass1.IsEmpty(), "pass 1 should emit the EIP-161 delete")
+	_, ok := pass1.GetSelfDestruct(f.coinbase)
+	require.True(t, ok)
+
+	_, _, found := f.be.versionMap.ReadSelfDestruct(f.coinbase, f.version.TxIndex+1)
+	require.True(t, found, "pass 1's flush must land a cell in the version map")
+
+	f.fundCoinbase()
+
+	pass2 := f.mergeFeePass(t)
+	require.True(t, pass2.IsEmpty(), "coinbase is funded now, calcFees has nothing to contribute")
+
+	_, _, found = f.be.versionMap.ReadSelfDestruct(f.coinbase, f.version.TxIndex+1)
+	require.False(t, found, "pass 1's stale delete cell must be retracted from the version map once pass 2 no longer produces it")
+}
+
+// A round can record a fee contribution and never flush it, so the retraction
+// has to tolerate a header the version map never received.
+func TestFeeMergeRevalidationRetractsUnflushedHeader(t *testing.T) {
+	f := newFeeMergeRevalidationFixture(t)
+
+	pass1 := f.mergeFeePassUnflushed(t)
+	_, ok := pass1.GetSelfDestruct(f.coinbase)
+	require.True(t, ok, "pass 1 emits the delete but never reaches the flush")
+
+	f.fundCoinbase()
+
+	require.NotPanics(t, func() { f.mergeFeePassUnflushed(t) })
 }
 
 // A later round that contributes something else must replace the earlier round

--- a/execution/stagedsync/exec3_fee_merge_revalidate_test.go
+++ b/execution/stagedsync/exec3_fee_merge_revalidate_test.go
@@ -226,6 +226,44 @@ func TestFeeMergeRevalidationReplacesRatherThanStacks(t *testing.T) {
 	require.Equal(t, uint64(500), bal.Val.Uint64())
 }
 
+// A block-end or system tx never reaches the fee merge, so finalize is the
+// only thing that builds its recorded set. Re-validation re-finalizes without
+// re-executing, so a write an earlier round produced must not survive a round
+// that no longer produces it — in blockIO or in the version map.
+func TestFinalizeMergeReplacesRatherThanStacks(t *testing.T) {
+	f := newFeeMergeRevalidationFixture(t)
+
+	round1 := &state.WriteSet{}
+	round1.SetSelfDestruct(f.coinbase, &state.VersionedWrite[bool]{
+		WriteHeader: state.WriteHeader{Address: f.coinbase, Path: state.SelfDestructPath, Version: f.version},
+		Val:         true,
+	})
+	merged1 := f.be.mergeFinalizeWrites(f.version, f.result.TxOut, round1)
+	f.be.versionMap.FlushVersionedWrites(merged1, true, "")
+
+	_, recorded := f.be.blockIO.WriteSet(f.version.TxIndex).GetSelfDestruct(f.coinbase)
+	require.True(t, recorded, "round 1's finalize delete is recorded")
+	_, _, found := f.be.versionMap.ReadSelfDestruct(f.coinbase, f.version.TxIndex+1)
+	require.True(t, found, "and flushed to the version map")
+
+	beneficiary := fAddr("beneficiary")
+	round2 := &state.WriteSet{}
+	round2.SetBalance(beneficiary, &state.VersionedWrite[uint256.Int]{
+		WriteHeader: state.WriteHeader{Address: beneficiary, Path: state.BalancePath, Version: f.version},
+		Val:         *uint256.NewInt(11),
+	})
+	f.be.mergeFinalizeWrites(f.version, f.result.TxOut, round2)
+
+	_, recorded = f.be.blockIO.WriteSet(f.version.TxIndex).GetSelfDestruct(f.coinbase)
+	require.False(t, recorded, "round 1's delete must not outlive a round that no longer produces it")
+	_, _, found = f.be.versionMap.ReadSelfDestruct(f.coinbase, f.version.TxIndex+1)
+	require.False(t, found, "and its version-map cell must be retracted")
+
+	kept, ok := f.be.blockIO.WriteSet(f.version.TxIndex).GetBalance(beneficiary)
+	require.True(t, ok, "round 2's own write survives the rebuild")
+	require.Equal(t, uint64(11), kept.Val.Uint64())
+}
+
 // TestFeeMergeRevalidationControlNormalizeNeedsTheStaleMerge is the negative
 // control: with no first pass ever recorded, Normalize must not invent the
 // coinbase delete on its own. This isolates the delete in the other test to

--- a/execution/stagedsync/exec3_fee_merge_temp_test.go
+++ b/execution/stagedsync/exec3_fee_merge_temp_test.go
@@ -37,47 +37,51 @@ func feeMergeTestWrites(t *testing.T, addr accounts.Address, balance uint64) *st
 	return ws
 }
 
-// TestRecordFeeMergeReleasesSupersededTemp pins the three transitions the fee
-// merge goes through for one tx: the first merge has no temp to reclaim, a
-// revalidation round reclaims the temp it replaces, and a round whose input is
-// an execResult's TxOut (after a re-execution replaced the recorded slot)
-// reclaims nothing.
+// TestRecordFeeMergeReleasesSupersededTemp pins the fee-merge temp's lifecycle
+// across a tx's validation rounds: the first round has nothing to reclaim, a
+// same-baseline revalidation reclaims the temp it replaces, a round against a
+// new baseline (a re-execution's TxOut) still reclaims the stale temp since
+// MergeInto only ever reads from the baseline and never from a temp, and a
+// round with no fee contribution reverts the recorded set to the baseline
+// itself and reclaims the last temp with nothing left to track.
 func TestRecordFeeMergeReleasesSupersededTemp(t *testing.T) {
 	t.Parallel()
 
 	addr := accounts.InternAddress(common.HexToAddress("0x1111111111111111111111111111111111111111"))
 	be := &blockExecutor{feeMergeTemp: map[int]*state.WriteSet{}}
 
-	// First round: prev is the worker's TxOut, so nothing may be released.
-	txOut := feeMergeTestWrites(t, addr, 1)
-	temp1 := feeMergeTestWrites(t, addr, 2)
-	be.recordFeeMerge(0, txOut, temp1)
-	require.Same(t, temp1, be.feeMergeTemp[0])
-	require.Equal(t, 1, txOut.Count(), "TxOut must survive the fee merge")
+	txOutA := feeMergeTestWrites(t, addr, 1)
 
-	// Revalidation round: prev is the temp the first round recorded, so it is
-	// superseded and reclaimed.
-	temp2 := feeMergeTestWrites(t, addr, 3)
-	be.recordFeeMerge(0, temp1, temp2)
+	temp1 := txOutA.MergeInto(feeMergeTestWrites(t, addr, 2))
+	be.recordFeeMerge(0, txOutA, temp1)
+	require.Same(t, temp1, be.feeMergeTemp[0])
+
+	temp2 := txOutA.MergeInto(feeMergeTestWrites(t, addr, 3))
+	be.recordFeeMerge(0, txOutA, temp2)
 	be.awaitMapReleases()
 	require.Same(t, temp2, be.feeMergeTemp[0])
 	require.Equal(t, 0, temp1.Count(), "superseded fee-merge temp must be released")
-	require.Equal(t, 1, temp2.Count())
+	require.Equal(t, 1, txOutA.Count(), "txOut must survive the fee merge")
 
-	// After a re-execution the recorded slot is the new TxOut again, so the
-	// stale temp does not match prev and stays untouched.
-	txOut2 := feeMergeTestWrites(t, addr, 4)
-	temp3 := feeMergeTestWrites(t, addr, 5)
-	be.recordFeeMerge(0, txOut2, temp3)
+	txOutB := feeMergeTestWrites(t, addr, 4)
+	temp3 := txOutB.MergeInto(feeMergeTestWrites(t, addr, 5))
+	be.recordFeeMerge(0, txOutB, temp3)
 	be.awaitMapReleases()
 	require.Same(t, temp3, be.feeMergeTemp[0])
-	require.Equal(t, 1, txOut2.Count(), "TxOut must survive the fee merge")
-	require.Equal(t, 1, temp2.Count(), "a temp that is not prev must not be released")
+	require.Equal(t, 0, temp2.Count(), "stale fee-merge temp must be released across a new baseline")
+	require.Equal(t, 1, txOutB.Count(), "txOut must survive the fee merge")
+
+	be.recordFeeMerge(0, txOutB, txOutB)
+	be.awaitMapReleases()
+	require.Nil(t, be.feeMergeTemp[0])
+	require.Equal(t, 0, temp3.Count(), "superseded fee-merge temp must be released")
+	require.Equal(t, 1, txOutB.Count(), "txOut must survive the fee merge")
 }
 
-// TestRecordFeeMergeReleaseKeepsSharedWrites pins what makes the release safe:
-// MergeInto shares VersionedWrite pointers rather than the maps holding them,
-// so pooling the superseded temp's maps leaves the surviving set readable.
+// TestRecordFeeMergeReleaseKeepsSharedWrites pins what makes the release
+// safe: MergeInto shares VersionedWrite pointers with txOut rather than
+// cloning them, so pooling a superseded temp's maps must leave both the
+// surviving merged set and txOut itself readable.
 func TestRecordFeeMergeReleaseKeepsSharedWrites(t *testing.T) {
 	t.Parallel()
 
@@ -85,17 +89,23 @@ func TestRecordFeeMergeReleaseKeepsSharedWrites(t *testing.T) {
 	fresh := accounts.InternAddress(common.HexToAddress("0x3333333333333333333333333333333333333333"))
 	be := &blockExecutor{feeMergeTemp: map[int]*state.WriteSet{}}
 
-	temp1 := feeMergeTestWrites(t, shared, 7)
-	be.recordFeeMerge(0, feeMergeTestWrites(t, shared, 1), temp1)
+	txOut := feeMergeTestWrites(t, shared, 7)
 
-	tipWrites := feeMergeTestWrites(t, fresh, 9)
-	merged := temp1.MergeInto(tipWrites)
-	require.Same(t, tipWrites, merged)
-	be.recordFeeMerge(0, temp1, merged)
+	temp1 := txOut.MergeInto(feeMergeTestWrites(t, fresh, 1))
+	be.recordFeeMerge(0, txOut, temp1)
+
+	merged := txOut.MergeInto(feeMergeTestWrites(t, fresh, 2))
+	require.NotSame(t, temp1, merged)
+	be.recordFeeMerge(0, txOut, merged)
 	be.awaitMapReleases()
 
-	require.Equal(t, 0, temp1.Count())
+	require.Equal(t, 0, temp1.Count(), "superseded fee-merge temp must be released")
+
 	vw, ok := merged.GetBalance(shared)
-	require.True(t, ok, "entry shared from the released temp must still be reachable")
+	require.True(t, ok, "entry shared with txOut must still be reachable after releasing a temp that also shared it")
 	require.Equal(t, uint64(7), vw.Val.Uint64())
+
+	txOutVW, ok := txOut.GetBalance(shared)
+	require.True(t, ok, "txOut itself must survive the release")
+	require.Equal(t, uint64(7), txOutVW.Val.Uint64())
 }

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2463,13 +2463,21 @@ func (be *blockExecutor) invalidBlockResult(err error) *blockResult {
 // read through it doesn't see a fee cell this tx no longer writes.
 func (be *blockExecutor) mergeFeeWrites(tx int, txVersion state.Version, txOut, tipWrites *state.WriteSet) {
 	merged := txOut.MergeInto(tipWrites)
-	for h := range be.feeMergeTemp[tx].AllHeaders() {
+	be.retractDropped(txVersion, be.feeMergeTemp[tx], merged)
+	be.blockIO.RecordWrites(txVersion, merged)
+	be.recordFeeMerge(tx, txOut, merged)
+}
+
+// retractDropped removes from the version map every header prev held that
+// merged no longer does. Unlike the re-execution path's identical removal, it
+// pushes no revalidation range: finalize and publish accumulate gas with no
+// idempotence guard, so re-opening a completed tx double-counts it.
+func (be *blockExecutor) retractDropped(txVersion state.Version, prev, merged *state.WriteSet) {
+	for h := range prev.AllHeaders() {
 		if !merged.Has(h) {
 			be.versionMap.Delete(h.Address, h.Path, h.Key, txVersion.TxIndex, false)
 		}
 	}
-	be.blockIO.RecordWrites(txVersion, merged)
-	be.recordFeeMerge(tx, txOut, merged)
 }
 
 // mergeFinalizeWrites rebuilds tx's recorded set from baseline plus what
@@ -2480,11 +2488,7 @@ func (be *blockExecutor) mergeFeeWrites(tx int, txVersion state.Version, txOut, 
 func (be *blockExecutor) mergeFinalizeWrites(txVersion state.Version, baseline, finalizeWrites *state.WriteSet) *state.WriteSet {
 	prevWrites := be.blockIO.WriteSet(txVersion.TxIndex)
 	merged := baseline.MergeInto(finalizeWrites)
-	for h := range prevWrites.AllHeaders() {
-		if !merged.Has(h) {
-			be.versionMap.Delete(h.Address, h.Path, h.Key, txVersion.TxIndex, false)
-		}
-	}
+	be.retractDropped(txVersion, prevWrites, merged)
 	be.blockIO.RecordWrites(txVersion, merged)
 	return merged
 }

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2472,10 +2472,27 @@ func (be *blockExecutor) mergeFeeWrites(tx int, txVersion state.Version, txOut, 
 	be.recordFeeMerge(tx, txOut, merged)
 }
 
-// recordFeeMerge tracks the write set a fee-merge round produced for tx and
-// reclaims the one it superseded. txOut is the merge's immutable baseline and
-// is never released. When tipWrites is empty, MergeInto returns txOut itself
-// as merged, so there is no new temp to track.
+// mergeFinalizeWrites rebuilds tx's recorded set from baseline plus what
+// finalize produced this round, rather than layering onto the previous
+// round's result — a re-validated tx re-finalizes, and a write an earlier
+// round produced must not outlive a round that no longer produces it. What
+// the rebuild drops is retracted from the version map at tx's own index.
+func (be *blockExecutor) mergeFinalizeWrites(txVersion state.Version, baseline, finalizeWrites *state.WriteSet) *state.WriteSet {
+	prevWrites := be.blockIO.WriteSet(txVersion.TxIndex)
+	merged := baseline.MergeInto(finalizeWrites)
+	for h := range prevWrites.AllHeaders() {
+		if !merged.Has(h) {
+			be.versionMap.Delete(h.Address, h.Path, h.Key, txVersion.TxIndex, false)
+		}
+	}
+	be.blockIO.RecordWrites(txVersion, merged)
+	return merged
+}
+
+// recordFeeMerge tracks the write set a merge round produced for tx and
+// reclaims the one it superseded. txOut is the baseline and is never released.
+// The caller must already have recorded merged: the superseded set is only
+// safe to pool once nothing can still reach it through blockIO.
 func (be *blockExecutor) recordFeeMerge(tx int, txOut, merged *state.WriteSet) {
 	if temp := be.feeMergeTemp[tx]; temp != nil && temp != txOut && temp != merged {
 		be.queueMapRelease(temp)
@@ -2685,12 +2702,14 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 
 			// Remove entries that were previously written but are no longer
 			// written — res.TxOut.Has answers membership directly, no cmp map.
+			// The header need not have a cell: a round that recorded a fee or
+			// finalize merge and then skipped the flush leaves one behind.
 			deletedWrites := 0
 			for h := range prevWrites.AllHeaders() {
 				if !res.TxOut.Has(h) {
 					hasWriteChange = true
 					deletedWrites++
-					be.versionMap.Delete(h.Address, h.Path, h.Key, txVersion.TxIndex, true)
+					be.versionMap.Delete(h.Address, h.Path, h.Key, txVersion.TxIndex, false)
 				}
 			}
 			if dbg.TraceReexec {
@@ -2752,6 +2771,7 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 
 		var trace bool
 		var tracePrefix string
+		feeMerged := false
 
 		if trace = dbg.TraceTransactionIO && dbg.TraceTx(be.number(), txVersion.TxIndex); trace {
 			tracePrefix = fmt.Sprintf("%d (%d.%d)", be.number(), txVersion.TxIndex, txVersion.Incarnation)
@@ -2784,6 +2804,7 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 				return nil, err
 			}
 			be.mergeFeeWrites(tx, txVersion, txResult.TxOut, tipWrites)
+			feeMerged = true
 		}
 
 		validity := be.versionMap.ValidateVersion(txVersion.TxIndex, be.blockIO,
@@ -2908,10 +2929,17 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 					be.blockIO.RecordReads(txVersion, existing)
 				}
 				if !addWrites.IsEmpty() {
-					// Merge finalization writes with existing execution writes.
-					existingWrites := be.blockIO.WriteSet(txVersion.TxIndex)
-					merged := existingWrites.MergeInto(addWrites)
-					be.blockIO.RecordWrites(txVersion, merged)
+					// The fee merge already reset the recorded set to TxOut
+					// this round; a block-end or system tx never reaches it,
+					// so its baseline is TxOut itself.
+					baseline := be.blockIO.WriteSet(txVersion.TxIndex)
+					if !feeMerged {
+						baseline = txResult.TxOut
+					}
+					merged := be.mergeFinalizeWrites(txVersion, baseline, addWrites)
+					if !feeMerged {
+						be.recordFeeMerge(tx, txResult.TxOut, merged)
+					}
 
 					// Flush the merged writes (including fee calc changes)
 					// to the version map so that subsequent per-tx

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2454,14 +2454,27 @@ func (be *blockExecutor) invalidBlockResult(err error) *blockResult {
 	}
 }
 
-// recordFeeMerge takes ownership of the set the fee merge just recorded for tx
-// and reclaims the one it superseded. Only a set an earlier fee merge created
-// may be released: prev is otherwise some execResult's TxOut, which stays live.
-// MergeInto shares VersionedWrite pointers rather than the maps holding them,
-// so pooling prev's maps leaves the writes merged now holds intact.
-func (be *blockExecutor) recordFeeMerge(tx int, prev, merged *state.WriteSet) {
-	if temp := be.feeMergeTemp[tx]; temp != nil && temp == prev && merged != temp {
+// mergeFeeWrites records tipWrites as tx's fee contribution, rebuilt from
+// txOut (the worker's raw output) on every call rather than layered onto a
+// prior round's result — an empty tipWrites on a later round must drop an
+// earlier round's contribution, not leave it stacked on top of the new one.
+func (be *blockExecutor) mergeFeeWrites(tx int, txVersion state.Version, txOut, tipWrites *state.WriteSet) {
+	merged := txOut.MergeInto(tipWrites)
+	be.blockIO.RecordWrites(txVersion, merged)
+	be.recordFeeMerge(tx, txOut, merged)
+}
+
+// recordFeeMerge tracks the write set a fee-merge round produced for tx and
+// reclaims the one it superseded. txOut is the merge's immutable baseline and
+// is never released. When tipWrites is empty, MergeInto returns txOut itself
+// as merged, so there is no new temp to track.
+func (be *blockExecutor) recordFeeMerge(tx int, txOut, merged *state.WriteSet) {
+	if temp := be.feeMergeTemp[tx]; temp != nil && temp != txOut && temp != merged {
 		be.queueMapRelease(temp)
+	}
+	if merged == txOut {
+		delete(be.feeMergeTemp, tx)
+		return
 	}
 	be.feeMergeTemp[tx] = merged
 }
@@ -2762,12 +2775,7 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 			if err != nil {
 				return nil, err
 			}
-			if !tipWrites.IsEmpty() {
-				existingWrites := be.blockIO.WriteSet(txVersion.TxIndex)
-				merged := existingWrites.MergeInto(tipWrites)
-				be.blockIO.RecordWrites(txVersion, merged)
-				be.recordFeeMerge(tx, existingWrites, merged)
-			}
+			be.mergeFeeWrites(tx, txVersion, txResult.TxOut, tipWrites)
 		}
 
 		validity := be.versionMap.ValidateVersion(txVersion.TxIndex, be.blockIO,

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2458,8 +2458,16 @@ func (be *blockExecutor) invalidBlockResult(err error) *blockResult {
 // txOut (the worker's raw output) on every call rather than layered onto a
 // prior round's result — an empty tipWrites on a later round must drop an
 // earlier round's contribution, not leave it stacked on top of the new one.
+// A header the prior round's temp had that merged no longer has is also
+// retracted from the version map at this tx's own index, so a downstream
+// read through it doesn't see a fee cell this tx no longer writes.
 func (be *blockExecutor) mergeFeeWrites(tx int, txVersion state.Version, txOut, tipWrites *state.WriteSet) {
 	merged := txOut.MergeInto(tipWrites)
+	for h := range be.feeMergeTemp[tx].AllHeaders() {
+		if !merged.Has(h) {
+			be.versionMap.Delete(h.Address, h.Path, h.Key, txVersion.TxIndex, false)
+		}
+	}
 	be.blockIO.RecordWrites(txVersion, merged)
 	be.recordFeeMerge(tx, txOut, merged)
 }


### PR DESCRIPTION
`calcFees` runs before every validation round of a tx, but its result was merged onto whatever the previous round left recorded, and an empty result was not merged at all. A write one round produced therefore outlived the round that would not produce it. Fixes #23237.

```mermaid
sequenceDiagram
    participant M as tx M (lower)
    participant N as tx N (zero tip)
    participant IO as blockIO.WriteSet(N)
    Note over M: invalid this batch
    N->>IO: round 1 — coinbase is EIP-161-empty,<br/>merge SelfDestructPath=true
    M->>M: re-executes, funds the coinbase
    Note over N: re-validated, not re-executed,<br/>so RecordWrites never replaces the set
    N-->>IO: round 2 — calcFees emits nothing,<br/>merge skipped, delete stays
    IO->>IO: commits — a funded account is deleted
```

`Normalize` does not catch it: it filters `SelfDestructPath` on incarnation alone, and a re-validation does not change the incarnation.

## Changes

- Rebuild the recorded set from the worker's `TxOut` on every round instead of layering onto the previous one. `MergeInto` short-circuits on an empty side, so a round with no fee contribution reverts the set to the raw worker output.
- Retract from the version map what the rebuild drops. The recorded set is flushed every round but cells are deleted only when a tx re-executes, by diffing against what was recorded — so a shrinking set would otherwise orphan a flushed fee cell where that delete loop can never see it.
- `recordFeeMerge` compared the tracked temp against the previously recorded set, which is now always `TxOut`, so it would never have reclaimed anything. It releases the superseded temp instead, and never the baseline or the set in use.

## Notes

`TxOut` is safe as the baseline: its only mutator, `StripBalanceWrite`, runs for system and block-end txs, which the fee merge's own guard excludes. Finalize writes are dropped from the recorded set by the rebuild and regenerated on whichever round commits, since finalize runs only under `valid && cntInvalid == 0`. The retraction can only reach a synthetic fee header — `merged` always contains everything `TxOut` has — and `Delete` is scoped to one `txIdx`, so no other tx's cell is reachable. It passes `checkExists=false` because a round can record a merge it never flushes, when `VersionTooEarly` continues past the flush.

Reproduced before fixing: the normalized write set carried the delete while the coinbase held 9,000,000 wei, and a control with no first round committed no delete, placing the defect in the merge rather than in `Normalize`.
