### PR TITLE
execution/stagedsync: don't stream account removal for nil unwind diffs

### DIFF
--- a/execution/stagedsync/stage_execute.go
+++ b/execution/stagedsync/stage_execute.go
@@ -245,11 +245,6 @@ func stateChangesStreamAtUnwind(ctx context.Context,
 
 	//TODO: why we don't call accumulator.ChangeCode???
 	handle := func(k, v []byte, table etl.CurrentTableReader, next etl.LoadNextFunc) error {
-		//TODO: This is broken - becuase it does not handle the way value changes
-		// for previous steps are represented - they will pass nil values here
-		// which will look like a delete (12/11/25 - I've not fixed this as it has
-		// been here for a while and I'm not sure what if anything receives these
-		// changes at what it does with them)
 		if len(k) == length.Addr {
 			if len(v) > 0 {
 				var account accounts.Account
@@ -311,13 +306,22 @@ func stateChangesStreamAtUnwind(ctx context.Context,
 					fmt.Printf("unwind (Block:%d,Tx:%d): del acc: %x, step: %d\n", blockUnwindTo, txUnwindTo, address, keyStep)
 				}
 			}
+			// nil = "different step" (see DomainEntryDiff.Value): the account reverts to
+			// a value at another step, not a deletion. Skip it — the collect->load below
+			// can't preserve nil vs empty, so a kept nil would DeleteAccount a live account.
+			if entry.Value == nil {
+				continue
+			}
 			if err := stateChanges.Collect(common.ToBytesZeroCopy(entry.Key)[:length.Addr], entry.Value); err != nil {
 				return err
 			}
 		}
 		storageDiffs := changeset[kv.StorageDomain]
-		for _, kv := range storageDiffs {
-			if err := stateChanges.Collect(common.ToBytesZeroCopy(kv.Key), kv.Value); err != nil {
+		for _, entry := range storageDiffs {
+			if entry.Value == nil {
+				continue // "different step", not a slot change — skip (see accounts loop)
+			}
+			if err := stateChanges.Collect(common.ToBytesZeroCopy(entry.Key), entry.Value); err != nil {
 				return err
 			}
 		}

--- a/execution/stagedsync/stage_execute_unwind_notification_test.go
+++ b/execution/stagedsync/stage_execute_unwind_notification_test.go
@@ -1,0 +1,162 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package stagedsync
+
+import (
+	"context"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/length"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/temporal/temporaltest"
+	"github.com/erigontech/erigon/execution/notifications"
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+// diffKey builds a DomainEntryDiff key: the entity key followed by the 8-byte
+// inverted step suffix that GetDiffset produces. The unwind notifier keys the
+// account collect on the leading address bytes, so the suffix content is inert.
+func diffKey(entity []byte) string {
+	k := make([]byte, len(entity)+8)
+	copy(k, entity)
+	for i := len(entity); i < len(k); i++ {
+		k[i] = 0xff // ^step for step 0
+	}
+	return string(k)
+}
+
+func changesByAddress(acc *notifications.Accumulator) map[common.Address]notifications.AccountChange {
+	streamed := acc.Changes()
+	out := make(map[common.Address]notifications.AccountChange)
+	if len(streamed) == 0 {
+		return out
+	}
+	for _, ch := range streamed[len(streamed)-1].Changes {
+		out[ch.Address] = ch
+	}
+	return out
+}
+
+// A DomainEntryDiff with a nil Value means "different step": on unwind the account
+// reverts to a value stored at another step, which is not a deletion (see the
+// DomainEntryDiff.Value semantics in db/state/domain.go unwind). The notifier must
+// not collapse it with an empty ([]byte{}) tombstone and broadcast ActionRemove,
+// or the RPC state cache is told an account was deleted when it still exists.
+func TestStateChangesStreamAtUnwind_NilAccountDiffIsNotDelete(t *testing.T) {
+	t.Parallel()
+
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	db := temporaltest.NewTestDBWithStepSize(t, dirs, 16)
+
+	ctx := context.Background()
+	tx, err := db.BeginTemporalRw(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	nilAddr := common.HexToAddress("0x00000000000000000000000000000000000000a1")
+	delAddr := common.HexToAddress("0x00000000000000000000000000000000000000a2")
+	chgAddr := common.HexToAddress("0x00000000000000000000000000000000000000a3")
+
+	chgAccount := accounts.Account{Nonce: 7, Balance: *uint256.NewInt(1_000)}
+	chgVal := accounts.SerialiseV3(&chgAccount)
+
+	var cs [kv.DomainLen][]kv.DomainEntryDiff
+	cs[kv.AccountsDomain] = []kv.DomainEntryDiff{
+		{Key: diffKey(nilAddr[:]), Value: nil},      // different step -> no change
+		{Key: diffKey(delAddr[:]), Value: []byte{}}, // absent before -> ActionRemove
+		{Key: diffKey(chgAddr[:]), Value: chgVal},   // restore value -> ActionUpsert
+	}
+
+	acc := notifications.NewAccumulator()
+	acc.StartChange(makeHeader(50, common.Hash{}), nil, true)
+
+	require.NoError(t, stateChangesStreamAtUnwind(ctx, tx, 50, 500, acc, &cs, logger))
+
+	changes := changesByAddress(acc)
+
+	_, nilEmitted := changes[nilAddr]
+	require.False(t, nilEmitted,
+		"nil diff means 'different step', not a deletion — no state change must be streamed for it")
+
+	del, ok := changes[delAddr]
+	require.True(t, ok, "empty ([]byte{}) diff is a real removal and must be streamed")
+	require.Equal(t, notifications.ActionRemove, del.Action)
+
+	chg, ok := changes[chgAddr]
+	require.True(t, ok, "non-empty diff must be streamed as an account change")
+	require.Equal(t, notifications.ActionUpsert, chg.Action)
+}
+
+// The storage branch has the same nil-vs-empty hazard: a nil ("different step")
+// storage diff must be skipped, not streamed as a ChangeStorage to an empty value
+// (which would tell the state cache the slot was zeroed when it still holds a value
+// restored at another step). A non-nil diff must still be streamed.
+func TestStateChangesStreamAtUnwind_NilStorageDiffIsSkipped(t *testing.T) {
+	t.Parallel()
+
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	db := temporaltest.NewTestDBWithStepSize(t, dirs, 16)
+
+	ctx := context.Background()
+	tx, err := db.BeginTemporalRw(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	skipAddr := common.HexToAddress("0x00000000000000000000000000000000000000b1")
+	skipLoc := common.Hash{31: 0x01}
+	keepAddr := common.HexToAddress("0x00000000000000000000000000000000000000b2")
+	keepLoc := common.Hash{31: 0x02}
+	keepVal := []byte{0xbe, 0xef}
+
+	var cs [kv.DomainLen][]kv.DomainEntryDiff
+	cs[kv.StorageDomain] = []kv.DomainEntryDiff{
+		{Key: diffKey(storageEntity(skipAddr, skipLoc)), Value: nil},
+		{Key: diffKey(storageEntity(keepAddr, keepLoc)), Value: keepVal},
+	}
+
+	acc := notifications.NewAccumulator()
+	acc.StartChange(makeHeader(50, common.Hash{}), nil, true)
+
+	require.NoError(t, stateChangesStreamAtUnwind(ctx, tx, 50, 500, acc, &cs, logger))
+
+	changes := changesByAddress(acc)
+
+	_, skipEmitted := changes[skipAddr]
+	require.False(t, skipEmitted,
+		"nil storage diff means 'different step', not a slot change — nothing must be streamed for it")
+
+	keep, ok := changes[keepAddr]
+	require.True(t, ok, "non-nil storage diff must be streamed")
+	require.Len(t, keep.StorageChanges, 1)
+	require.Equal(t, keepLoc, keep.StorageChanges[0].Location)
+	require.Equal(t, keepVal, keep.StorageChanges[0].Data)
+}
+
+func storageEntity(addr common.Address, loc common.Hash) []byte {
+	k := make([]byte, 0, length.Addr+length.Hash)
+	k = append(k, addr[:]...)
+	k = append(k, loc[:]...)
+	return k
+}


### PR DESCRIPTION
## Problem

`stateChangesStreamAtUnwind` (`execution/stagedsync/stage_execute.go`) turns the unwind changeset into state-change notifications for the RPC state cache (`kvcache.Coherent`) and the txpool's latest-batch cache. It chose `ChangeAccount` vs `DeleteAccount` using `len(v) > 0`, which collapses two distinct `DomainEntryDiff.Value` cases:

- `nil` — **"different step"**: on unwind the key reverts to a value stored at another step. This is *not* a deletion (see the `DomainEntryDiff.Value` doc in `db/kv/helpers.go` and the `db/state/domain.go` unwind).
- `[]byte{}` — an empty tombstone: a genuine removal.

Since `len(nil) == len([]byte{}) == 0`, a `nil` diff was broadcast as `ActionRemove` — i.e. the notifier told the RPC state cache and the txpool that a **still-live account was deleted** during a near-tip reorg (only when `stateStream` is on and the unwind depth is `< stateStreamLimit`).

The code carried a developer TODO documenting exactly this:

> `//TODO: This is broken - becuase it does not handle the way value changes for previous steps are represented - they will pass nil values here which will look like a delete`

## Fix

Mirror what the authoritative on-disk unwind already does (`db/state/domain.go`, `if value != nil`): skip `nil` diffs when building the notification, for **both** the account and storage domains.

The skip must happen at **collection** time (before `stateChanges.Collect`), not in the ETL load handler — the collect→load round-trip does not preserve `nil` vs empty `[]byte{}`, so by the time `handle` runs the two are indistinguishable.

## Impact / severity

Notification-layer only. The authoritative domain state is unwound by `unwindDomsToBlock` **before** the notification is sent, so execution, state root, and consensus are unaffected. The affected caches are versioned/coherent and self-heal on the next state change, and a cache miss falls through to the correctly-unwound DB. The observable effect was a transient window during a near-tip reorg where a cache-hit RPC read (`eth_getBalance` / `eth_getTransactionCount`) or the txpool could see a previous-step account as empty. No on-disk corruption, no divergence.

## Test

`stage_execute_unwind_notification_test.go` (TDD, Red → Green):

- `TestStateChangesStreamAtUnwind_NilAccountDiffIsNotDelete` — a `nil` account diff streams **no** change; `[]byte{}` → `ActionRemove`; non-empty → `ActionUpsert`.
- `TestStateChangesStreamAtUnwind_NilStorageDiffIsSkipped` — a `nil` storage diff streams nothing; a non-nil storage diff streams the slot change.

Each fails before the fix (verified by neutering each branch) and passes after. `make lint` clean; `make erigon integration` builds.

## Backports

The defect predates the current release lines (the TODO is dated 2025-11-12), so `release/3.5` and `release/3.6` are likely affected. Candidate for `[r3.5]` / `[r3.6]` backport once this lands — to be opened separately after checking each branch.
