### PR TITLE
db/downloader: keep local snapshot data once the initial download is complete

### DIFF
--- a/db/downloader/README.md
+++ b/db/downloader/README.md
@@ -1,5 +1,12 @@
 # Downloader Components
 
+Main Properties:
+
+```
+- if initialDownload complete: local .torrent are more important than remote. and local .torrent is more important than local .seg. If no data-file exists without .torrent - then create .torrent from data-file      
+- if initialDownload not-complete: download remote preveified.toml and align datadir according to preverified.toml (download remote .torrent and data-files)             
+```
+
 The diagram below shows the components used to manage downloads between torrents and WebSeeds.
 
 ![components](components.png)

--- a/db/downloader/README.md
+++ b/db/downloader/README.md
@@ -3,8 +3,8 @@
 Main Properties:
 
 ```
-- if initialDownload complete: local .torrent are more important than remote. and local .torrent is more important than local .seg. If no data-file exists without .torrent - then create .torrent from data-file      
-- if initialDownload not-complete: download remote preveified.toml and align datadir according to preverified.toml (download remote .torrent and data-files)             
+- if initialDownload complete: local `.torrent` are more important than remote. and local `.torrent` is more important than local `data-file`. If `data-file` exists without `.torrent` - then derivew `.torrent` from `data-file`      
+- if initialDownload not-complete: download remote `preveified.toml` and align datadir according to `preverified.toml` (download remote `.torrent` and `data-files`)             
 ```
 
 The diagram below shows the components used to manage downloads between torrents and WebSeeds.

--- a/db/downloader/README.md
+++ b/db/downloader/README.md
@@ -1,11 +1,11 @@
 # Downloader Components
 
-Main Properties:
+Main properties:
 
-```
-- if initialDownload complete: local `.torrent` are more important than remote. and local `.torrent` is more important than local `data-file`. If `data-file` exists without `.torrent` - then derivew `.torrent` from `data-file`      
-- if initialDownload not-complete: download remote `preveified.toml` and align datadir according to `preverified.toml` (download remote `.torrent` and `data-files`)             
-```
+- initial download complete (`preverified.toml` on disk): the local `data-file` outranks the remote manifest and is never moved aside. A local `.torrent` with a different infohash is dropped, and only its sizes are used to check the file: on a mismatch the data backs neither manifest, so the download goes ahead under the preverified hash and the client hash-checks and repairs the file in place. Otherwise the preverified download is skipped.
+- initial download not complete: the remote manifest wins. Download `preverified.toml` and align the datadir to it (remote `.torrent` and `data-file`s); data of the wrong size is renamed to `.part` and re-fetched.
+
+Deriving a `.torrent` from a bare `data-file` happens on the seeding path (`AddNewSeedableFile`), not on either path above.
 
 The diagram below shows the components used to manage downloads between torrents and WebSeeds.
 

--- a/db/downloader/README.md
+++ b/db/downloader/README.md
@@ -2,8 +2,8 @@
 
 Main properties:
 
-- initial download complete (`preverified.toml` on disk): the local `data-file` outranks the remote manifest and is never moved aside. A local `.torrent` with a different infohash is dropped, and only its sizes are used to check the file: on a mismatch the data backs neither manifest, so the download goes ahead under the preverified hash and the client hash-checks and repairs the file in place. Otherwise the preverified download is skipped.
-- initial download not complete: the remote manifest wins. Download `preverified.toml` and align the datadir to it (remote `.torrent` and `data-file`s); data of the wrong size is renamed to `.part` and re-fetched.
+- initial download complete (`preverified.toml` on disk): the local `data-file` outranks the remote manifest and is never moved aside. A missing `data-file` is still downloaded. A local `.torrent` with a different infohash is dropped on this path (`addPreverifiedSnapshotForDownload` retains one that is already loaded and seeds under its hash), and only its sizes are used to check the file: on a mismatch the data backs neither manifest, so the download goes ahead under the preverified hash and the client completes the file by length, re-fetching only if the length disagrees. Otherwise the preverified download is skipped.
+- initial download not complete: the remote manifest wins. Fetch the chain manifest (`chain.toml`) and align the datadir to it (remote `.torrent` and `data-file`s); data whose local `.torrent` infohash does not match the preverified one — including data with no readable `.torrent` at all — is renamed to `.part` and re-fetched. `preverified.toml` is written locally once the set is complete, never downloaded.
 
 Deriving a `.torrent` from a bare `data-file` happens on the seeding path (`AddNewSeedableFile`), not on either path above.
 

--- a/db/downloader/download-batch.go
+++ b/db/downloader/download-batch.go
@@ -39,10 +39,14 @@ func (me *downloadBatch) taskWaiter() {
 }
 
 func (me *downloadBatch) addDownload(item preverifiedSnapshot) error {
-	t, first, localMetainfo, err := me.d.addPreverifiedSnapshotForDownload(item.InfoHash, item.Name)
+	snapshotTorrent, first, localMetainfo, err := me.d.addPreverifiedSnapshotForDownload(item.InfoHash, item.Name)
 	if err != nil {
 		return err
 	}
+	if !snapshotTorrent.Ok {
+		return nil
+	}
+	t := snapshotTorrent.Value
 	me.torrents = append(me.torrents, t)
 	if !first {
 		return nil

--- a/db/downloader/download-batch.go
+++ b/db/downloader/download-batch.go
@@ -39,7 +39,7 @@ func (me *downloadBatch) taskWaiter() {
 }
 
 func (me *downloadBatch) addDownload(item preverifiedSnapshot) error {
-	t, first, miOpt, err := me.d.addPreverifiedSnapshotForDownload(item.InfoHash, item.Name)
+	t, first, localMetainfo, err := me.d.addPreverifiedSnapshotForDownload(item.InfoHash, item.Name)
 	if err != nil {
 		return err
 	}
@@ -49,7 +49,7 @@ func (me *downloadBatch) addDownload(item preverifiedSnapshot) error {
 	}
 	me.metainfoTasks.Go(func() {
 		me.doMetainfoTask(func() func() {
-			return me.d.addedFirstDownloader(me.d.ctx, t, miOpt, item.Name, item.InfoHash)
+			return me.d.addedFirstDownloader(me.d.ctx, t, localMetainfo, item.Name, item.InfoHash)
 		})
 	})
 	return nil

--- a/db/downloader/download-batch.go
+++ b/db/downloader/download-batch.go
@@ -39,9 +39,12 @@ func (me *downloadBatch) taskWaiter() {
 }
 
 func (me *downloadBatch) addDownload(item preverifiedSnapshot) error {
-	snapshotTorrent, first, localMetainfo, err := me.d.addPreverifiedSnapshotForDownload(item.InfoHash, item.Name)
+	snapshotTorrent, first, localMetainfo, keptLocal, err := me.d.addPreverifiedSnapshotForDownload(item.InfoHash, item.Name)
 	if err != nil {
 		return err
+	}
+	if keptLocal {
+		me.all.Go(func() { me.d.seedKeptSnapshot(me.d.ctx, item.Name) })
 	}
 	if !snapshotTorrent.Ok {
 		return nil

--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -57,6 +57,7 @@ import (
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dbg"
+	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/downloader/downloadercfg"
@@ -493,18 +494,15 @@ func (d *Downloader) StartTorrentPeerManager(ctx context.Context) {
 	})
 }
 
-// Reports whether the data on disk is what info describes, by rebuilding the piece hashes from it.
-// Sizes alone can't say: a stale metainfo can describe different content of the same length.
-func (d *Downloader) snapshotDataMatchesMetainfo(name string, info *metainfo.Info) bool {
-	if !d.snapshotDataSizesMatch(info) {
-		return false
+// preverified.toml is written once the initial snapshot set completes, pinning the local hash set.
+// Read on every call: the snapshot stage writes the file mid-run, and from that moment local data
+// must be kept.
+func (d *Downloader) initialDownloadComplete() (bool, error) {
+	complete, err := dir.FileExist(d.cfg.Dirs.PreverifiedPath())
+	if err != nil {
+		return false, fmt.Errorf("checking %v: %w", d.cfg.Dirs.PreverifiedPath(), err)
 	}
-	rebuilt := metainfo.Info{PieceLength: info.PieceLength, Name: info.Name}
-	if err := rebuilt.BuildFromFilePath(d.filePathForName(name)); err != nil {
-		d.log(log.LvlWarn, "error hashing local snapshot", "err", err, "name", name)
-		return false
-	}
-	return rebuilt.Length == info.Length && bytes.Equal(rebuilt.Pieces, info.Pieces)
+	return complete, nil
 }
 
 func (d *Downloader) snapshotDataSizesMatch(info *metainfo.Info) bool {
@@ -1013,7 +1011,17 @@ func (d *Downloader) testStartSingleDownloadNoWait(
 	return err
 }
 
+// Moves data aside so a download can't reuse it. Only legal while the initial download is
+// incomplete: after that the local files are what this node built or restored, and nothing may
+// remove them.
 func (d *Downloader) invalidateData(name snapshotName, preverifiedInfoHash metainfo.Hash) (err error) {
+	complete, err := d.initialDownloadComplete()
+	if err != nil {
+		return err
+	}
+	if complete {
+		return fmt.Errorf("refusing to invalidate %q: initial download is complete", name)
+	}
 	_, ok := d.torrentClient.Torrent(preverifiedInfoHash)
 	// Torrent in use, bad idea to proceed. This shouldn't happen since we should have found
 	// the existing name earlier.
@@ -1041,7 +1049,8 @@ func (d *Downloader) addPreverifiedSnapshotForDownload(
 	preverifiedInfoHash metainfo.Hash,
 	name string,
 ) (
-	t *torrent.Torrent,
+	// None when local data wins.
+	snapshotTorrent g.Option[*torrent.Torrent],
 	firstDownloader bool, // First add of this Torrent that asked to download. The caller is responsible for adding download tasks.
 	localMetainfo g.Option[*metainfo.MetaInfo],
 	err error,
@@ -1066,7 +1075,7 @@ func (d *Downloader) addPreverifiedSnapshotForDownload(
 				"name", name,
 				"existing_infohash", existingT.InfoHash().HexString(),
 				"preverified_infohash", preverifiedInfoHash.HexString())
-			t = existingT
+			snapshotTorrent.Set(existingT)
 			err = nil
 			return
 		}
@@ -1075,14 +1084,17 @@ func (d *Downloader) addPreverifiedSnapshotForDownload(
 	// We can invalidate data if a torrent isn't yet loaded.
 	if !ok {
 		var isNew bool
-		t, isNew, localMetainfo, err = d.addTorrentForPreverifiedSnapshot(preverifiedInfoHash, name)
-		if err != nil {
+		var addedTorrent g.Option[*torrent.Torrent]
+		addedTorrent, isNew, localMetainfo, err = d.addTorrentForPreverifiedSnapshot(preverifiedInfoHash, name)
+		if err != nil || !addedTorrent.Ok {
 			return
 		}
 		panicif.False(isNew)
+		t = addedTorrent.Value
 	}
 	g.MakeMapIfNil(&d.downloads)
 	firstDownloader = !g.MapInsert(d.downloads, t, struct{}{}).Ok
+	snapshotTorrent.Set(t)
 	return
 }
 
@@ -1090,51 +1102,45 @@ func (d *Downloader) addTorrentForPreverifiedSnapshot(
 	preverifiedInfoHash metainfo.Hash,
 	name string,
 ) (
-	t *torrent.Torrent,
+	// None when local data wins.
+	addedTorrent g.Option[*torrent.Torrent],
 	isNew bool,
 	localMetainfo g.Option[*metainfo.MetaInfo],
 	err error,
 ) {
-	var addInfoHash metainfo.Hash
-	localMetainfo, addInfoHash, err = d.chooseAddInfoHash(preverifiedInfoHash, name)
+	var download bool
+	localMetainfo, download, err = d.prepareLocalDataForDownload(preverifiedInfoHash, name)
+	if err != nil || !download {
+		return
+	}
+	t, isNew, err := d.addTorrent(name, preverifiedInfoHash)
 	if err != nil {
 		return
 	}
-	t, isNew, err = d.addTorrent(name, addInfoHash)
+	addedTorrent.Set(t)
 	return
 }
 
-// Returns the info hash to add the torrent under: the preverified one, or the local one when the
-// data on disk backs its own metainfo. Data backing no metainfo is invalidated so the download
-// can't reuse it.
-func (d *Downloader) chooseAddInfoHash(
+// Reports whether the preverified download should go ahead. Data that backs no matching metainfo is
+// invalidated, but only while the manifest is still authoritative.
+func (d *Downloader) prepareLocalDataForDownload(
 	preverifiedInfoHash metainfo.Hash,
 	name string,
 ) (
 	localMetainfo g.Option[*metainfo.MetaInfo],
-	addInfoHash metainfo.Hash,
+	download bool,
 	err error,
 ) {
-	addInfoHash = preverifiedInfoHash
-	localMetainfo, err = d.maybeLoadMetainfoFromDisk(name)
-	if err != nil {
-		d.log(log.LvlWarn, "error loading metainfo from disk", "err", err, "name", name)
-		err = nil
+	// An unreadable metainfo is logged and then treated as missing: it says nothing about the data.
+	localMetainfo, loadErr := d.maybeLoadMetainfoFromDisk(name)
+	if loadErr != nil {
+		d.log(log.LvlWarn, "error loading metainfo from disk", "err", loadErr, "name", name)
 	}
 	if localMetainfo.Ok {
 		localInfoHash := localMetainfo.Value.HashInfoBytes()
 		if localInfoHash == preverifiedInfoHash {
-			return
+			return localMetainfo, true, nil
 		}
-		if info, infoErr := localMetainfo.Value.UnmarshalInfo(); infoErr == nil && d.snapshotDataMatchesMetainfo(name, &info) {
-			d.log(log.LvlWarn, "keeping local snapshot, preverified hash differs",
-				"preverified", preverifiedInfoHash,
-				"local", localInfoHash,
-				"name", name)
-			addInfoHash = localInfoHash
-			return
-		}
-		// This is fine if we're doing initial sync. If we're not we shouldn't be here.
 		d.log(log.LvlWarn, "preverified snapshot hash has changed",
 			"preverified", preverifiedInfoHash,
 			"local", localInfoHash,
@@ -1144,12 +1150,36 @@ func (d *Downloader) chooseAddInfoHash(
 	} else {
 		d.log(log.LvlDebug, "snapshot metainfo missing", "name", name)
 	}
-	err = d.invalidateData(name, preverifiedInfoHash)
+
+	complete, err := d.initialDownloadComplete()
 	if err != nil {
-		err = fmt.Errorf("invalidating old snapshot data: %w", err)
-		return
+		return localMetainfo, false, err
 	}
-	return
+	if complete {
+		// Local data outranks the manifest from here on: keep whatever we have, download the rest.
+		exists, err := d.snapshotDataExists(name)
+		if err != nil {
+			return localMetainfo, false, err
+		}
+		if exists {
+			// TODO(@AskAlexSharov, #21522): build the metainfo here when missing, so the kept file can be seeded.
+			d.log(log.LvlWarn, "keeping local snapshot, skipping preverified download", "name", name)
+		}
+		return localMetainfo, !exists, nil
+	}
+
+	if err := d.invalidateData(name, preverifiedInfoHash); err != nil {
+		return localMetainfo, false, fmt.Errorf("invalidating old snapshot data: %w", err)
+	}
+	return localMetainfo, true, nil
+}
+
+func (d *Downloader) snapshotDataExists(name string) (bool, error) {
+	exists, err := dir.FileExist(d.filePathForName(name))
+	if err != nil {
+		return false, fmt.Errorf("checking snapshot data for %q: %w", name, err)
+	}
+	return exists, nil
 }
 
 func (d *Downloader) addedFirstDownloader(

--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -494,7 +494,7 @@ func (d *Downloader) StartTorrentPeerManager(ctx context.Context) {
 }
 
 // Check snapshot data looks right.
-func (d *Downloader) snapshotDataLooksComplete(info *metainfo.Info) bool {
+func (d *Downloader) snapshotDataSizesMatch(info *metainfo.Info) bool {
 	for f := range info.UpvertedFilesIter() {
 		pathParts := append([]string{info.BestName()}, f.BestPath()...)
 		slashPath := path.Join(pathParts...)
@@ -774,7 +774,7 @@ func (d *Downloader) loadMetainfoFromDisk(name string) (mi *metainfo.MetaInfo, e
 
 // Loads metainfo from disk, removing it if it's invalid. Returns Some metainfo if it's valid. Logs
 // errors.
-func (d *Downloader) maybeLoadMetainfoFromDisk(name string) (miOpt g.Option[*metainfo.MetaInfo], err error) {
+func (d *Downloader) maybeLoadMetainfoFromDisk(name string) (localMetainfo g.Option[*metainfo.MetaInfo], err error) {
 	miPath := d.metainfoFilePathForName(name)
 	mi, err := metainfo.LoadFromFile(miPath)
 	if err != nil {
@@ -783,7 +783,7 @@ func (d *Downloader) maybeLoadMetainfoFromDisk(name string) (miOpt g.Option[*met
 		}
 		return
 	}
-	miOpt.Set(mi)
+	localMetainfo.Set(mi)
 	return
 }
 
@@ -1000,39 +1000,46 @@ func (d *Downloader) testStartSingleDownloadNoWait(
 	return err
 }
 
-func (d *Downloader) invalidateData(name snapshotName, infoHash metainfo.Hash) (err error) {
-	_, ok := d.torrentClient.Torrent(infoHash)
+func (d *Downloader) invalidateData(name snapshotName, preverifiedInfoHash metainfo.Hash) (err error) {
+	_, ok := d.torrentClient.Torrent(preverifiedInfoHash)
 	// Torrent in use, bad idea to proceed. This shouldn't happen since we should have found
 	// the existing name earlier.
 	panicif.True(ok)
 	// Ensure the data isn't reused. We're presuming the storage in use, but we can't afford
 	// to wait until another torrent is fetched, and then we mistake a non-partial file with
 	// the correct size as being complete.
-	err = os.Rename(d.filePathForName(name), d.filePathForName(name+".part"))
-	if err != nil && errors.Is(err, os.ErrNotExist) {
-		err = nil
+	from := d.filePathForName(name)
+	to := d.filePathForName(name + ".part")
+	err = os.Rename(from, to)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			err = nil
+		}
+		return
 	}
+	d.log(log.LvlWarn, "invalidated local snapshot data, will re-download",
+		"name", name, "renamed_to", to, "preverified", preverifiedInfoHash)
 	return
 }
 
 // Download a preverified file. That means it has a published manifest (metainfo), and a known info
 // hash. Caller is responsible for flushing missing metainfos to disk when complete.
 func (d *Downloader) addPreverifiedSnapshotForDownload(
-	infoHash metainfo.Hash,
+	preverifiedInfoHash metainfo.Hash,
 	name string,
 ) (
 	t *torrent.Torrent,
 	// First add of this Torrent that asked to download. The caller is responsible for adding
 	// download tasks.
 	firstDownloader bool,
-	miOpt g.Option[*metainfo.MetaInfo],
+	localMetainfo g.Option[*metainfo.MetaInfo],
 	err error,
 ) {
 	// Prevent anyone else from trying to add a torrent in the meanwhile, so we can do data
 	// invalidation, and identify the first downloader.
 	d.lock.Lock()
 	defer d.lock.Unlock()
-	t, ok, err := d.getExistingSnapshotTorrent(name, infoHash)
+	t, ok, err := d.getExistingSnapshotTorrent(name, preverifiedInfoHash)
 	if err != nil {
 		// If a torrent for this name is already loaded with a different infohash, keep the
 		// existing local torrent and skip the preverified download. This handles the case where
@@ -1043,11 +1050,11 @@ func (d *Downloader) addPreverifiedSnapshotForDownload(
 		// by AddTorrentsFromDisk before initial sync runs) is tracked separately. The proper fix
 		// is to run initial sync before AddTorrentsFromDisk so the preverified TOML hashes can
 		// always take precedence. See: https://github.com/erigontech/erigon/issues/19435
-		if existingT, nameOk := d.torrentsByName[name]; nameOk && existingT.InfoHash() != infoHash {
+		if existingT, nameOk := d.torrentsByName[name]; nameOk && existingT.InfoHash() != preverifiedInfoHash {
 			d.log(log.LvlWarn, "snapshot already loaded with different infohash, keeping existing local torrent (preverified skipped)",
 				"name", name,
 				"existing_infohash", existingT.InfoHash().HexString(),
-				"preverified_infohash", infoHash.HexString())
+				"preverified_infohash", preverifiedInfoHash.HexString())
 			t = existingT
 			err = nil
 			return
@@ -1056,50 +1063,77 @@ func (d *Downloader) addPreverifiedSnapshotForDownload(
 	}
 	// We can invalidate data if a torrent isn't yet loaded.
 	if !ok {
-		miOpt, err = d.loadMatchingMetainfoOrInvalidateData(infoHash, name)
+		var isNew bool
+		t, isNew, localMetainfo, err = d.addTorrentForPreverifiedSnapshot(preverifiedInfoHash, name)
 		if err != nil {
 			return
 		}
-		var new bool
-		t, new, err = d.addTorrent(name, infoHash)
-		if err != nil {
-			return
-		}
-		panicif.False(new)
+		panicif.False(isNew)
 	}
 	g.MakeMapIfNil(&d.downloads)
 	firstDownloader = !g.MapInsert(d.downloads, t, struct{}{}).Ok
 	return
 }
 
-func (d *Downloader) loadMatchingMetainfoOrInvalidateData(
-	infoHash metainfo.Hash,
+func (d *Downloader) addTorrentForPreverifiedSnapshot(
+	preverifiedInfoHash metainfo.Hash,
 	name string,
 ) (
-	miOpt g.Option[*metainfo.MetaInfo],
+	t *torrent.Torrent,
+	isNew bool,
+	localMetainfo g.Option[*metainfo.MetaInfo],
 	err error,
 ) {
-	miOpt, err = d.maybeLoadMetainfoFromDisk(name)
+	var addInfoHash metainfo.Hash
+	localMetainfo, addInfoHash, err = d.chooseAddInfoHash(preverifiedInfoHash, name)
+	if err != nil {
+		return
+	}
+	t, isNew, err = d.addTorrent(name, addInfoHash)
+	return
+}
+
+// Returns the info hash to add the torrent under: the preverified one, or the local one when the
+// data on disk backs its own metainfo. Data backing no metainfo is invalidated so the download
+// can't reuse it.
+func (d *Downloader) chooseAddInfoHash(
+	preverifiedInfoHash metainfo.Hash,
+	name string,
+) (
+	localMetainfo g.Option[*metainfo.MetaInfo],
+	addInfoHash metainfo.Hash,
+	err error,
+) {
+	addInfoHash = preverifiedInfoHash
+	localMetainfo, err = d.maybeLoadMetainfoFromDisk(name)
 	if err != nil {
 		d.log(log.LvlError, "error loading metainfo from disk", "err", err, "name", name)
 		err = nil
 	}
-	if miOpt.Ok {
-		loadedIh := miOpt.Value.HashInfoBytes()
-		if loadedIh == infoHash {
+	if localMetainfo.Ok {
+		localInfoHash := localMetainfo.Value.HashInfoBytes()
+		if localInfoHash == preverifiedInfoHash {
+			return
+		}
+		if info, infoErr := localMetainfo.Value.UnmarshalInfo(); infoErr == nil && d.snapshotDataSizesMatch(&info) {
+			d.log(log.LvlWarn, "keeping local snapshot, preverified hash differs",
+				"preverified", preverifiedInfoHash,
+				"local", localInfoHash,
+				"name", name)
+			addInfoHash = localInfoHash
 			return
 		}
 		// This is fine if we're doing initial sync. If we're not we shouldn't be here.
 		d.log(log.LvlWarn, "preverified snapshot hash has changed",
-			"expected", infoHash,
-			"actual", loadedIh,
+			"preverified", preverifiedInfoHash,
+			"local", localInfoHash,
 			"name", name)
 		// Forget the metainfo we loaded, it's wrong (probably changed hash but not name...)
-		miOpt.SetNone()
+		localMetainfo.SetNone()
 	} else {
 		d.log(log.LvlDebug, "snapshot metainfo missing", "name", name)
 	}
-	err = d.invalidateData(name, infoHash)
+	err = d.invalidateData(name, preverifiedInfoHash)
 	if err != nil {
 		err = fmt.Errorf("invalidating old snapshot data: %w", err)
 		return
@@ -1110,12 +1144,12 @@ func (d *Downloader) loadMatchingMetainfoOrInvalidateData(
 func (d *Downloader) addedFirstDownloader(
 	ctx context.Context,
 	t *torrent.Torrent,
-	miOpt g.Option[*metainfo.MetaInfo],
+	localMetainfo g.Option[*metainfo.MetaInfo],
 	name string,
 	infoHash metainfo.Hash,
 ) (afterAdd func()) {
 	// Try again, we would have invalidated data for changed infohashes now.
-	if !miOpt.Ok {
+	if !localMetainfo.Ok {
 		// Yes I mean for this error to be scoped here.
 		err := d.fetchMetainfoFromWebseeds(ctx, name, infoHash)
 		if err == nil {
@@ -1123,7 +1157,7 @@ func (d *Downloader) addedFirstDownloader(
 			// through the same path that is used on a good run. No data invalidation here, at this
 			// point we've added the torrent, and already invalidated if the metainfo was missing
 			// the first time.
-			miOpt, err = d.maybeLoadMetainfoFromDisk(name)
+			localMetainfo, err = d.maybeLoadMetainfoFromDisk(name)
 			if err != nil {
 				// Should this error be returned instead?
 				d.log(log.LvlError, "error loading metainfo from disk", "err", err, "name", name)
@@ -1133,10 +1167,10 @@ func (d *Downloader) addedFirstDownloader(
 		}
 	}
 
-	if miOpt.Ok {
+	if localMetainfo.Ok {
 		// Good case: We have a metainfo with the right infohash, either just fetched from a
 		// webseed, or it was cached on disk.
-		err := d.applyMetainfo(miOpt.Value, t)
+		err := d.applyMetainfo(localMetainfo.Value, t)
 		if err != nil {
 			d.log(log.LvlError, "error applying metainfo", "err", err, "name", name)
 		}
@@ -1285,7 +1319,7 @@ func (d *Downloader) addTorrentIfComplete(
 		err = fmt.Errorf("unmarshalling info from metainfo: %w", err)
 		return
 	}
-	if !d.snapshotDataLooksComplete(&info) {
+	if !d.snapshotDataSizesMatch(&info) {
 		err = nil
 		return
 	}

--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -1136,6 +1136,7 @@ func (d *Downloader) prepareLocalDataForDownload(
 	if loadErr != nil {
 		d.log(log.LvlWarn, "error loading metainfo from disk", "err", loadErr, "name", name)
 	}
+	localMetainfoUnbacked := false
 	if localMetainfo.Ok {
 		localInfoHash := localMetainfo.Value.HashInfoBytes()
 		if localInfoHash == preverifiedInfoHash {
@@ -1145,6 +1146,8 @@ func (d *Downloader) prepareLocalDataForDownload(
 			"preverified", preverifiedInfoHash,
 			"local", localInfoHash,
 			"name", name)
+		info, infoErr := localMetainfo.Value.UnmarshalInfo()
+		localMetainfoUnbacked = infoErr == nil && !d.snapshotDataSizesMatch(&info)
 		// Forget the metainfo we loaded, it's wrong (probably changed hash but not name...)
 		localMetainfo.SetNone()
 	} else {
@@ -1161,11 +1164,20 @@ func (d *Downloader) prepareLocalDataForDownload(
 		if err != nil {
 			return localMetainfo, false, err
 		}
-		if exists {
-			// TODO(@AskAlexSharov, #21522): build the metainfo here when missing, so the kept file can be seeded.
-			d.log(log.LvlWarn, "keeping local snapshot, skipping preverified download", "name", name)
+		if !exists {
+			return localMetainfo, true, nil
 		}
-		return localMetainfo, !exists, nil
+		if localMetainfoUnbacked {
+			// The data backs neither manifest, and nothing else here would ever repair it.
+			// Downloading hands it to the client, which hash-checks and repairs in place.
+			d.log(log.LvlWarn, "local snapshot does not match its own metainfo, downloading",
+				"name", name)
+			return localMetainfo, true, nil
+		}
+		// TODO(@AskAlexSharov, #21522): build and add the metainfo when it is missing
+		// (BuildTorrentIfNeed + addCompleteTorrent), or the kept file is never seeded.
+		d.log(log.LvlWarn, "keeping local snapshot, skipping preverified download", "name", name)
+		return localMetainfo, false, nil
 	}
 
 	if err := d.invalidateData(name, preverifiedInfoHash); err != nil {

--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -1201,15 +1201,15 @@ func (d *Downloader) addedFirstDownloader(
 	name string,
 	infoHash metainfo.Hash,
 ) (afterAdd func()) {
-	// Try again, we would have invalidated data for changed infohashes now.
+	// Try the webseeds for the metainfo that wasn't on disk. Nothing here relies on the data having
+	// been moved aside: after the initial download it never is, and the client hash-checks and
+	// repairs the file in place.
 	if !localMetainfo.Ok {
 		// Yes I mean for this error to be scoped here.
 		err := d.fetchMetainfoFromWebseeds(ctx, name, infoHash)
 		if err == nil {
 			// Always reuse code paths to ensure no surprises later. I.e. load the metainfo again
-			// through the same path that is used on a good run. No data invalidation here, at this
-			// point we've added the torrent, and already invalidated if the metainfo was missing
-			// the first time.
+			// through the same path that is used on a good run.
 			localMetainfo, err = d.maybeLoadMetainfoFromDisk(name)
 			if err != nil {
 				// Should this error be returned instead?

--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -493,7 +493,20 @@ func (d *Downloader) StartTorrentPeerManager(ctx context.Context) {
 	})
 }
 
-// Check snapshot data looks right.
+// Reports whether the data on disk is what info describes, by rebuilding the piece hashes from it.
+// Sizes alone can't say: a stale metainfo can describe different content of the same length.
+func (d *Downloader) snapshotDataMatchesMetainfo(name string, info *metainfo.Info) bool {
+	if !d.snapshotDataSizesMatch(info) {
+		return false
+	}
+	rebuilt := metainfo.Info{PieceLength: info.PieceLength, Name: info.Name}
+	if err := rebuilt.BuildFromFilePath(d.filePathForName(name)); err != nil {
+		d.log(log.LvlWarn, "error hashing local snapshot", "err", err, "name", name)
+		return false
+	}
+	return rebuilt.Length == info.Length && bytes.Equal(rebuilt.Pieces, info.Pieces)
+}
+
 func (d *Downloader) snapshotDataSizesMatch(info *metainfo.Info) bool {
 	for f := range info.UpvertedFilesIter() {
 		pathParts := append([]string{info.BestName()}, f.BestPath()...)
@@ -1029,9 +1042,7 @@ func (d *Downloader) addPreverifiedSnapshotForDownload(
 	name string,
 ) (
 	t *torrent.Torrent,
-	// First add of this Torrent that asked to download. The caller is responsible for adding
-	// download tasks.
-	firstDownloader bool,
+	firstDownloader bool, // First add of this Torrent that asked to download. The caller is responsible for adding download tasks.
 	localMetainfo g.Option[*metainfo.MetaInfo],
 	err error,
 ) {
@@ -1107,7 +1118,7 @@ func (d *Downloader) chooseAddInfoHash(
 	addInfoHash = preverifiedInfoHash
 	localMetainfo, err = d.maybeLoadMetainfoFromDisk(name)
 	if err != nil {
-		d.log(log.LvlError, "error loading metainfo from disk", "err", err, "name", name)
+		d.log(log.LvlWarn, "error loading metainfo from disk", "err", err, "name", name)
 		err = nil
 	}
 	if localMetainfo.Ok {
@@ -1115,7 +1126,7 @@ func (d *Downloader) chooseAddInfoHash(
 		if localInfoHash == preverifiedInfoHash {
 			return
 		}
-		if info, infoErr := localMetainfo.Value.UnmarshalInfo(); infoErr == nil && d.snapshotDataSizesMatch(&info) {
+		if info, infoErr := localMetainfo.Value.UnmarshalInfo(); infoErr == nil && d.snapshotDataMatchesMetainfo(name, &info) {
 			d.log(log.LvlWarn, "keeping local snapshot, preverified hash differs",
 				"preverified", preverifiedInfoHash,
 				"local", localInfoHash,

--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -1053,6 +1053,9 @@ func (d *Downloader) addPreverifiedSnapshotForDownload(
 	snapshotTorrent g.Option[*torrent.Torrent],
 	firstDownloader bool, // First add of this Torrent that asked to download. The caller is responsible for adding download tasks.
 	localMetainfo g.Option[*metainfo.MetaInfo],
+	// Local data was kept and no torrent is registered for it. The caller seeds it, off d.lock:
+	// deriving a metainfo hashes the whole file.
+	keptLocal bool,
 	err error,
 ) {
 	// Prevent anyone else from trying to add a torrent in the meanwhile, so we can do data
@@ -1085,7 +1088,7 @@ func (d *Downloader) addPreverifiedSnapshotForDownload(
 	if !ok {
 		var isNew bool
 		var addedTorrent g.Option[*torrent.Torrent]
-		addedTorrent, isNew, localMetainfo, err = d.addTorrentForPreverifiedSnapshot(preverifiedInfoHash, name)
+		addedTorrent, isNew, localMetainfo, keptLocal, err = d.addTorrentForPreverifiedSnapshot(preverifiedInfoHash, name)
 		if err != nil || !addedTorrent.Ok {
 			return
 		}
@@ -1106,11 +1109,13 @@ func (d *Downloader) addTorrentForPreverifiedSnapshot(
 	addedTorrent g.Option[*torrent.Torrent],
 	isNew bool,
 	localMetainfo g.Option[*metainfo.MetaInfo],
+	keptLocal bool,
 	err error,
 ) {
 	var download bool
 	localMetainfo, download, err = d.prepareLocalDataForDownload(preverifiedInfoHash, name)
 	if err != nil || !download {
+		keptLocal = err == nil
 		return
 	}
 	t, isNew, err := d.addTorrent(name, preverifiedInfoHash)
@@ -1178,8 +1183,6 @@ func (d *Downloader) prepareLocalDataForDownload(
 				"name", name)
 			return localMetainfo, true, nil
 		}
-		// TODO(@AskAlexSharov, #21522): build and add the metainfo when it is missing
-		// (BuildTorrentIfNeed + addCompleteTorrent), or the kept file is never seeded.
 		d.log(log.LvlWarn, "keeping local snapshot, skipping preverified download", "name", name)
 		return localMetainfo, false, nil
 	}
@@ -1188,6 +1191,14 @@ func (d *Downloader) prepareLocalDataForDownload(
 		return localMetainfo, false, fmt.Errorf("invalidating old snapshot data: %w", err)
 	}
 	return localMetainfo, true, nil
+}
+
+// seedKeptSnapshot registers a kept local snapshot so it is seeded, deriving the metainfo when
+// none is on disk. Must run without d.lock: deriving it hashes the whole file.
+func (d *Downloader) seedKeptSnapshot(ctx context.Context, name string) {
+	if err := d.AddNewSeedableFile(ctx, name); err != nil && ctx.Err() == nil {
+		d.log(log.LvlWarn, "cannot seed kept local snapshot", "err", err, "name", name)
+	}
 }
 
 func (d *Downloader) snapshotDataExists(name string) (bool, error) {

--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -1147,6 +1147,9 @@ func (d *Downloader) prepareLocalDataForDownload(
 			"local", localInfoHash,
 			"name", name)
 		info, infoErr := localMetainfo.Value.UnmarshalInfo()
+		if infoErr != nil {
+			d.log(log.LvlWarn, "error unmarshalling local metainfo", "err", infoErr, "name", name)
+		}
 		localMetainfoUnbacked = infoErr == nil && !d.snapshotDataSizesMatch(&info)
 		// Forget the metainfo we loaded, it's wrong (probably changed hash but not name...)
 		localMetainfo.SetNone()
@@ -1168,8 +1171,9 @@ func (d *Downloader) prepareLocalDataForDownload(
 			return localMetainfo, true, nil
 		}
 		if localMetainfoUnbacked {
-			// The data backs neither manifest, and nothing else here would ever repair it.
-			// Downloading hands it to the client, which hash-checks and repairs in place.
+			// The data backs neither manifest. Downloading hands it to the client, which
+			// completes the file by length, so a wrong length is re-fetched while
+			// same-length-different-bytes is not.
 			d.log(log.LvlWarn, "local snapshot does not match its own metainfo, downloading",
 				"name", name)
 			return localMetainfo, true, nil
@@ -1202,8 +1206,8 @@ func (d *Downloader) addedFirstDownloader(
 	infoHash metainfo.Hash,
 ) (afterAdd func()) {
 	// Try the webseeds for the metainfo that wasn't on disk. Nothing here relies on the data having
-	// been moved aside: after the initial download it never is, and the client hash-checks and
-	// repairs the file in place.
+	// been moved aside: after the initial download it never is, and the client completes the file
+	// by length.
 	if !localMetainfo.Ok {
 		// Yes I mean for this error to be scoped here.
 		err := d.fetchMetainfoFromWebseeds(ctx, name, infoHash)

--- a/db/downloader/downloader_test.go
+++ b/db/downloader/downloader_test.go
@@ -17,6 +17,7 @@
 package downloader
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io/fs"
@@ -345,4 +346,69 @@ func newDownloaderTest(t *testing.T) *downloaderTest {
 		cfg:        cfg,
 		downloader: d,
 	}
+}
+
+// logBuffer is a log sink readable while the Downloader's goroutines write to it.
+type logBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *logBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *logBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func newLocalSnapshotTest(t *testing.T) (d *Downloader, logs *logBuffer, name, path string) {
+	d = newDownloaderTest(t).downloader
+	logs = &logBuffer{}
+	d.logger.SetHandler(log.LvlFilterHandler(log.LvlWarn, log.StreamHandler(logs, log.LogfmtFormat())))
+
+	name = "domain/v2.0-accounts.0-1024.kv"
+	path = d.filePathForName(name)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("locally rebuilt"), 0o644))
+	return
+}
+
+// Issue #21522: data that backs no metainfo is renamed to .part, leaving a hole in the snapshot
+// tier. That must be visible at warn level or louder.
+func TestInvalidateDataRenamesLocalFile(t *testing.T) {
+	require := require.New(t)
+	d, logs, name, path := newLocalSnapshotTest(t)
+	differentPreverifiedInfoHash := snaptype.Hex2InfoHash("aa")
+
+	_, addInfoHash, err := d.chooseAddInfoHash(differentPreverifiedInfoHash, name)
+	require.NoError(err)
+	require.Equal(differentPreverifiedInfoHash, addInfoHash)
+
+	require.NoFileExists(path)
+	require.FileExists(path + ".part")
+	require.Contains(logs.String(), name, "rename must be logged at warn or louder")
+}
+
+// Data that backs its own metainfo was built or kept deliberately, so a preverified hash that
+// disagrees must not evict it.
+func TestKeepsCompleteLocalSnapshot(t *testing.T) {
+	require := require.New(t)
+	d, logs, name, path := newLocalSnapshotTest(t)
+	_, err := BuildTorrentIfNeed(t.Context(), name, d.snapDir(), d.torrentFS)
+	require.NoError(err)
+
+	differentPreverifiedInfoHash := snaptype.Hex2InfoHash("aa")
+	localMetainfo, addInfoHash, err := d.chooseAddInfoHash(differentPreverifiedInfoHash, name)
+	require.NoError(err)
+	require.True(localMetainfo.Ok)
+	require.Equal(localMetainfo.Value.HashInfoBytes(), addInfoHash)
+
+	require.FileExists(path)
+	require.NoFileExists(path + ".part")
+	require.Contains(logs.String(), name)
 }

--- a/db/downloader/downloader_test.go
+++ b/db/downloader/downloader_test.go
@@ -609,8 +609,8 @@ func allLocalSnapshotStates() (all []localSnapshotState) {
 	return
 }
 
-// Invariant: once preverified.toml exists, no state of the datadir may cost a data file, and a file
-// we have is never re-downloaded.
+// Invariant: once preverified.toml exists, no state of the datadir may cost a data file. The
+// download flag below is only the decision to add the torrent, not a decision to fetch bytes.
 func TestNeverEvictsAfterInitialDownload(t *testing.T) {
 	require := require.New(t)
 	d := newDownloaderTest(t).downloader

--- a/db/downloader/downloader_test.go
+++ b/db/downloader/downloader_test.go
@@ -26,6 +26,7 @@ import (
 	"runtime"
 	"sync"
 	"testing"
+	"time"
 
 	g "github.com/anacrolix/generics"
 	"github.com/anacrolix/torrent/metainfo"
@@ -38,6 +39,8 @@ import (
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/downloader/downloadercfg"
 	"github.com/erigontech/erigon/db/snaptype"
+	"github.com/erigontech/erigon/node/gointerfaces"
+	"github.com/erigontech/erigon/node/gointerfaces/downloaderproto"
 )
 
 func TestConcurrentDownload(t *testing.T) {
@@ -628,6 +631,30 @@ func TestNeverEvictsAfterInitialDownload(t *testing.T) {
 		wantDownload := !st.data || st.metainfo == "matching"
 		require.Equal(wantDownload, download, "%+v", st)
 	}
+}
+
+// The guard has to hold at the entry point that reaches it in production: cmd/downloader --seedbox
+// issues a Download per preverified item whatever cfg.Local says, while erigon's own sync path is
+// gated earlier. The bounded context is so a regression fails instead of waiting on a peer.
+func TestGrpcDownloadKeepsLocalDataAfterInitialDownload(t *testing.T) {
+	require := require.New(t)
+	d, _, name, path := newLocalSnapshotTest(t)
+	markInitialDownloadComplete(t, d)
+	svr, err := NewGrpcServer(d)
+	require.NoError(err)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	_, err = svr.Download(ctx, &downloaderproto.DownloadRequest{
+		Items: []*downloaderproto.DownloadItem{{
+			Path:        name,
+			TorrentHash: gointerfaces.ConvertAddressToH160(snaptype.Hex2InfoHash("aa")),
+		}},
+	})
+	require.NoError(err)
+
+	require.FileExists(path)
+	require.NoFileExists(path + ".part")
 }
 
 // The snapshot stage writes preverified.toml mid-run, so the rule must be re-read, not cached from

--- a/db/downloader/downloader_test.go
+++ b/db/downloader/downloader_test.go
@@ -378,8 +378,8 @@ func newLocalSnapshotTest(t *testing.T) (d *Downloader, logs *logBuffer, name, p
 	return
 }
 
-// Issue #21522: data that backs no metainfo is renamed to .part, leaving a hole in the snapshot
-// tier. That must be visible at warn level or louder.
+// Data that backs no metainfo is renamed to .part, leaving a hole in the snapshot tier. That must
+// be visible at warn level or louder.
 func TestInvalidateDataRenamesLocalFile(t *testing.T) {
 	require := require.New(t)
 	d, logs, name, path := newLocalSnapshotTest(t)
@@ -394,7 +394,7 @@ func TestInvalidateDataRenamesLocalFile(t *testing.T) {
 	require.Contains(logs.String(), name, "rename must be logged at warn or louder")
 }
 
-// Data that backs its own metainfo was built or kept deliberately, so a preverified hash that
+// Data that hashes to its own metainfo was built or kept deliberately, so a preverified hash that
 // disagrees must not evict it.
 func TestKeepsCompleteLocalSnapshot(t *testing.T) {
 	require := require.New(t)
@@ -411,4 +411,25 @@ func TestKeepsCompleteLocalSnapshot(t *testing.T) {
 	require.FileExists(path)
 	require.NoFileExists(path + ".part")
 	require.Contains(logs.String(), name)
+}
+
+// Same length as its metainfo but different content: the metainfo is stale, so the local hash must
+// not be adopted.
+func TestInvalidatesLocalSnapshotNotMatchingItsMetainfo(t *testing.T) {
+	require := require.New(t)
+	d, _, name, path := newLocalSnapshotTest(t)
+	_, err := BuildTorrentIfNeed(t.Context(), name, d.snapDir(), d.torrentFS)
+	require.NoError(err)
+
+	before, err := os.ReadFile(path)
+	require.NoError(err)
+	require.NoError(os.WriteFile(path, bytes.Repeat([]byte("x"), len(before)), 0o644))
+
+	differentPreverifiedInfoHash := snaptype.Hex2InfoHash("aa")
+	_, addInfoHash, err := d.chooseAddInfoHash(differentPreverifiedInfoHash, name)
+	require.NoError(err)
+	require.Equal(differentPreverifiedInfoHash, addInfoHash)
+
+	require.NoFileExists(path)
+	require.FileExists(path + ".part")
 }

--- a/db/downloader/downloader_test.go
+++ b/db/downloader/downloader_test.go
@@ -27,10 +27,13 @@ import (
 	"sync"
 	"testing"
 
+	g "github.com/anacrolix/generics"
+	"github.com/anacrolix/torrent/metainfo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/downloader/downloadercfg"
@@ -378,58 +381,275 @@ func newLocalSnapshotTest(t *testing.T) (d *Downloader, logs *logBuffer, name, p
 	return
 }
 
-// Data that backs no metainfo is renamed to .part, leaving a hole in the snapshot tier. That must
-// be visible at warn level or louder.
+// Renaming data to .part leaves a hole in the snapshot tier, so it must be logged at warn or louder.
 func TestInvalidateDataRenamesLocalFile(t *testing.T) {
 	require := require.New(t)
 	d, logs, name, path := newLocalSnapshotTest(t)
 	differentPreverifiedInfoHash := snaptype.Hex2InfoHash("aa")
 
-	_, addInfoHash, err := d.chooseAddInfoHash(differentPreverifiedInfoHash, name)
-	require.NoError(err)
-	require.Equal(differentPreverifiedInfoHash, addInfoHash)
+	_, download := prepareLocalDataForDownload(t, d, differentPreverifiedInfoHash, name)
+	require.True(download)
 
 	require.NoFileExists(path)
 	require.FileExists(path + ".part")
-	require.Contains(logs.String(), name, "rename must be logged at warn or louder")
-}
-
-// Data that hashes to its own metainfo was built or kept deliberately, so a preverified hash that
-// disagrees must not evict it.
-func TestKeepsCompleteLocalSnapshot(t *testing.T) {
-	require := require.New(t)
-	d, logs, name, path := newLocalSnapshotTest(t)
-	_, err := BuildTorrentIfNeed(t.Context(), name, d.snapDir(), d.torrentFS)
-	require.NoError(err)
-
-	differentPreverifiedInfoHash := snaptype.Hex2InfoHash("aa")
-	localMetainfo, addInfoHash, err := d.chooseAddInfoHash(differentPreverifiedInfoHash, name)
-	require.NoError(err)
-	require.True(localMetainfo.Ok)
-	require.Equal(localMetainfo.Value.HashInfoBytes(), addInfoHash)
-
-	require.FileExists(path)
-	require.NoFileExists(path + ".part")
+	require.Contains(logs.String(), "invalidated local snapshot data", "rename must be logged at warn or louder")
 	require.Contains(logs.String(), name)
 }
 
-// Same length as its metainfo but different content: the metainfo is stale, so the local hash must
-// not be adopted.
-func TestInvalidatesLocalSnapshotNotMatchingItsMetainfo(t *testing.T) {
+// A stale metainfo doesn't rescue the data while the initial download is incomplete.
+func TestInvalidateDataWithStaleMetainfo(t *testing.T) {
 	require := require.New(t)
 	d, _, name, path := newLocalSnapshotTest(t)
 	_, err := BuildTorrentIfNeed(t.Context(), name, d.snapDir(), d.torrentFS)
 	require.NoError(err)
 
-	before, err := os.ReadFile(path)
-	require.NoError(err)
-	require.NoError(os.WriteFile(path, bytes.Repeat([]byte("x"), len(before)), 0o644))
-
-	differentPreverifiedInfoHash := snaptype.Hex2InfoHash("aa")
-	_, addInfoHash, err := d.chooseAddInfoHash(differentPreverifiedInfoHash, name)
-	require.NoError(err)
-	require.Equal(differentPreverifiedInfoHash, addInfoHash)
+	_, download := prepareLocalDataForDownload(t, d, snaptype.Hex2InfoHash("aa"), name)
+	require.True(download)
 
 	require.NoFileExists(path)
 	require.FileExists(path + ".part")
+}
+
+// Once preverified.toml exists, local data is kept whatever the manifest says.
+func TestKeepsLocalSnapshotAfterInitialDownload(t *testing.T) {
+	for _, withMetainfo := range []bool{false, true} {
+		t.Run(fmt.Sprint("withMetainfo=", withMetainfo), func(t *testing.T) {
+			require := require.New(t)
+			d, logs, name, path := newLocalSnapshotTest(t)
+			if withMetainfo {
+				_, err := BuildTorrentIfNeed(t.Context(), name, d.snapDir(), d.torrentFS)
+				require.NoError(err)
+			}
+			markInitialDownloadComplete(t, d)
+
+			_, download := prepareLocalDataForDownload(t, d, snaptype.Hex2InfoHash("aa"), name)
+			require.False(download, "preverified download must be skipped")
+
+			require.FileExists(path)
+			require.NoFileExists(path + ".part")
+			require.Contains(logs.String(), "keeping local snapshot")
+			require.Contains(logs.String(), name)
+		})
+	}
+}
+
+// Nothing local to protect: the preverified file is still downloaded.
+func TestDownloadsMissingSnapshotAfterInitialDownload(t *testing.T) {
+	require := require.New(t)
+	d, _, name, path := newLocalSnapshotTest(t)
+	require.NoError(dir.RemoveFile(path))
+	markInitialDownloadComplete(t, d)
+
+	preverifiedInfoHash := snaptype.Hex2InfoHash("aa")
+	_, download := prepareLocalDataForDownload(t, d, preverifiedInfoHash, name)
+	require.True(download)
+}
+
+// Under d.lock, as production callers hold it.
+func prepareLocalDataForDownload(t *testing.T, d *Downloader, preverifiedInfoHash metainfo.Hash, name string) (
+	localMetainfo g.Option[*metainfo.MetaInfo],
+	download bool,
+) {
+	t.Helper()
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	localMetainfo, download, err := d.prepareLocalDataForDownload(preverifiedInfoHash, name)
+	require.NoError(t, err)
+	return localMetainfo, download
+}
+
+func markInitialDownloadComplete(t *testing.T, d *Downloader) {
+	require.NoError(t, os.WriteFile(d.cfg.Dirs.PreverifiedPath(), nil, 0o644))
+}
+
+// The metainfo on disk is the preverified one: the file is used as-is.
+func TestKeepsSnapshotMatchingPreverifiedHash(t *testing.T) {
+	for _, initialDownloadComplete := range []bool{false, true} {
+		t.Run(fmt.Sprint("initialDownloadComplete=", initialDownloadComplete), func(t *testing.T) {
+			require := require.New(t)
+			d, _, name, path := newLocalSnapshotTest(t)
+			_, err := BuildTorrentIfNeed(t.Context(), name, d.snapDir(), d.torrentFS)
+			require.NoError(err)
+			if initialDownloadComplete {
+				markInitialDownloadComplete(t, d)
+			}
+			localInfoHash := loadLocalInfoHash(t, d, name)
+
+			localMetainfo, download := prepareLocalDataForDownload(t, d, localInfoHash, name)
+			require.True(localMetainfo.Ok)
+			require.True(download)
+
+			require.FileExists(path)
+			require.NoFileExists(path + ".part")
+		})
+	}
+}
+
+// A from-scratch sync has no data to invalidate, so it must stay quiet.
+func TestInvalidateDataQuietWithoutLocalData(t *testing.T) {
+	require := require.New(t)
+	d, logs, name, path := newLocalSnapshotTest(t)
+	require.NoError(dir.RemoveFile(path))
+
+	_, download := prepareLocalDataForDownload(t, d, snaptype.Hex2InfoHash("aa"), name)
+	require.True(download)
+
+	require.NoFileExists(path + ".part")
+	require.Empty(logs.String())
+}
+
+// An unreadable metainfo costs the file only while the manifest is still authoritative.
+func TestUnreadableMetainfoEvictsOnlyDuringInitialDownload(t *testing.T) {
+	for _, initialDownloadComplete := range []bool{false, true} {
+		t.Run(fmt.Sprint("initialDownloadComplete=", initialDownloadComplete), func(t *testing.T) {
+			require := require.New(t)
+			d, _, name, path := newLocalSnapshotTest(t)
+			require.NoError(os.WriteFile(d.metainfoFilePathForName(name), []byte("not bencode"), 0o644))
+			if initialDownloadComplete {
+				markInitialDownloadComplete(t, d)
+			}
+
+			_, download := prepareLocalDataForDownload(t, d, snaptype.Hex2InfoHash("aa"), name)
+			if initialDownloadComplete {
+				require.False(download)
+				require.FileExists(path)
+			} else {
+				require.True(download)
+				require.NoFileExists(path)
+			}
+		})
+	}
+}
+
+// The skip reaches the caller as None, so the batch has nothing to wait for.
+func TestAddPreverifiedSnapshotSkipsAfterInitialDownload(t *testing.T) {
+	require := require.New(t)
+	d, _, name, path := newLocalSnapshotTest(t)
+	markInitialDownloadComplete(t, d)
+
+	snapshotTorrent, firstDownloader, _, err := d.addPreverifiedSnapshotForDownload(snaptype.Hex2InfoHash("aa"), name)
+	require.NoError(err)
+	require.False(snapshotTorrent.Ok)
+	require.False(firstDownloader)
+	require.FileExists(path)
+}
+
+func loadLocalInfoHash(t *testing.T, d *Downloader, name string) metainfo.Hash {
+	t.Helper()
+	mi, err := metainfo.LoadFromFile(d.metainfoFilePathForName(name))
+	require.NoError(t, err)
+	return mi.HashInfoBytes()
+}
+
+type localSnapshotState struct {
+	data     bool
+	metainfo string // "none", "matching", "stale", "corrupt"
+}
+
+func (st localSnapshotState) name() string {
+	return fmt.Sprintf("domain/v2.0-accounts.%d-%d.kv", boolToInt(st.data), len(st.metainfo))
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// Writes one snapshot in the requested state and returns its name and the hash a caller should pass
+// as the preverified one.
+func writeLocalSnapshot(t *testing.T, d *Downloader, name string, st localSnapshotState) metainfo.Hash {
+	t.Helper()
+	path := d.filePathForName(name)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("locally rebuilt "+name), 0o644))
+	preverified := snaptype.Hex2InfoHash("aa")
+	switch st.metainfo {
+	case "matching":
+		_, err := BuildTorrentIfNeed(t.Context(), name, d.snapDir(), d.torrentFS)
+		require.NoError(t, err)
+		preverified = loadLocalInfoHash(t, d, name)
+	case "stale":
+		_, err := BuildTorrentIfNeed(t.Context(), name, d.snapDir(), d.torrentFS)
+		require.NoError(t, err)
+	case "corrupt":
+		require.NoError(t, os.WriteFile(d.metainfoFilePathForName(name), []byte("not bencode"), 0o644))
+	}
+	if !st.data {
+		require.NoError(t, dir.RemoveFile(path))
+	}
+	return preverified
+}
+
+func allLocalSnapshotStates() (all []localSnapshotState) {
+	for _, data := range []bool{false, true} {
+		for _, mi := range []string{"none", "matching", "stale", "corrupt"} {
+			all = append(all, localSnapshotState{data: data, metainfo: mi})
+		}
+	}
+	return
+}
+
+// Invariant: once preverified.toml exists, no state of the datadir may cost a data file, and a file
+// we have is never re-downloaded.
+func TestNeverEvictsAfterInitialDownload(t *testing.T) {
+	require := require.New(t)
+	d := newDownloaderTest(t).downloader
+	markInitialDownloadComplete(t, d)
+
+	for _, st := range allLocalSnapshotStates() {
+		name := st.name()
+		preverified := writeLocalSnapshot(t, d, name, st)
+
+		_, download := prepareLocalDataForDownload(t, d, preverified, name)
+
+		require.NoFileExists(d.filePathForName(name)+".part", "%+v", st)
+		require.Equal(st.data, fileExists(d.filePathForName(name)), "%+v", st)
+		// The preverified file is the local file: adding it is free, the client sees it complete.
+		wantDownload := !st.data || st.metainfo == "matching"
+		require.Equal(wantDownload, download, "%+v", st)
+	}
+}
+
+// The snapshot stage writes preverified.toml mid-run, so the rule must be re-read, not cached from
+// an earlier call.
+func TestInitialDownloadCompletingMidRunKeepsLocalData(t *testing.T) {
+	require := require.New(t)
+	d := newDownloaderTest(t).downloader
+
+	beforeName := "domain/v2.0-accounts.0-1024.kv"
+	writeLocalSnapshot(t, d, beforeName, localSnapshotState{data: true, metainfo: "none"})
+	_, download := prepareLocalDataForDownload(t, d, snaptype.Hex2InfoHash("aa"), beforeName)
+	require.True(download)
+	require.FileExists(d.filePathForName(beforeName) + ".part")
+
+	markInitialDownloadComplete(t, d)
+
+	afterName := "domain/v2.0-accounts.1024-2048.kv"
+	writeLocalSnapshot(t, d, afterName, localSnapshotState{data: true, metainfo: "none"})
+	_, download = prepareLocalDataForDownload(t, d, snaptype.Hex2InfoHash("aa"), afterName)
+	require.False(download)
+	require.FileExists(d.filePathForName(afterName))
+	require.NoFileExists(d.filePathForName(afterName) + ".part")
+}
+
+// The rename itself refuses to run after the initial download, whatever the caller decided.
+func TestInvalidateDataRefusesAfterInitialDownload(t *testing.T) {
+	require := require.New(t)
+	d, _, name, path := newLocalSnapshotTest(t)
+	markInitialDownloadComplete(t, d)
+
+	d.lock.Lock()
+	err := d.invalidateData(name, snaptype.Hex2InfoHash("aa"))
+	d.lock.Unlock()
+
+	require.Error(err)
+	require.FileExists(path)
+	require.NoFileExists(path + ".part")
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }

--- a/db/downloader/downloader_test.go
+++ b/db/downloader/downloader_test.go
@@ -433,6 +433,24 @@ func TestKeepsLocalSnapshotAfterInitialDownload(t *testing.T) {
 	}
 }
 
+// Data that no longer matches its own metainfo backs neither manifest. Keeping it unverified
+// leaves a hole in the snapshot tier, so it goes to the client, which hash-checks and repairs it.
+func TestDownloadsLocalSnapshotNotMatchingItsMetainfo(t *testing.T) {
+	require := require.New(t)
+	d, logs, name, path := newLocalSnapshotTest(t)
+	_, err := BuildTorrentIfNeed(t.Context(), name, d.snapDir(), d.torrentFS)
+	require.NoError(err)
+	require.NoError(os.WriteFile(path, []byte("truncated"), 0o644))
+	markInitialDownloadComplete(t, d)
+
+	_, download := prepareLocalDataForDownload(t, d, snaptype.Hex2InfoHash("aa"), name)
+	require.True(download, "a file that backs no metainfo must be re-fetched, not kept")
+
+	require.FileExists(path, "the client repairs in place, so the data must stay where it is")
+	require.NoFileExists(path+".part", "invalidation stays forbidden after the initial download")
+	require.Contains(logs.String(), name)
+}
+
 // Nothing local to protect: the preverified file is still downloaded.
 func TestDownloadsMissingSnapshotAfterInitialDownload(t *testing.T) {
 	require := require.New(t)

--- a/db/downloader/downloader_test.go
+++ b/db/downloader/downloader_test.go
@@ -549,7 +549,7 @@ func TestAddPreverifiedSnapshotSkipsAfterInitialDownload(t *testing.T) {
 	d, _, name, path := newLocalSnapshotTest(t)
 	markInitialDownloadComplete(t, d)
 
-	snapshotTorrent, firstDownloader, _, err := d.addPreverifiedSnapshotForDownload(snaptype.Hex2InfoHash("aa"), name)
+	snapshotTorrent, firstDownloader, _, _, err := d.addPreverifiedSnapshotForDownload(snaptype.Hex2InfoHash("aa"), name)
 	require.NoError(err)
 	require.False(snapshotTorrent.Ok)
 	require.False(firstDownloader)
@@ -656,6 +656,26 @@ func TestGrpcDownloadKeepsLocalDataAfterInitialDownload(t *testing.T) {
 
 	require.FileExists(path)
 	require.NoFileExists(path + ".part")
+}
+
+// A kept snapshot still has to be seeded. With no torrent registered the name is absent from
+// torrentsByName, so allActiveSnapshots and PublishLocalChainToml never see it, and a seedbox
+// silently stops serving a file it holds.
+func TestKeptLocalSnapshotIsSeeded(t *testing.T) {
+	require := require.New(t)
+	d, _, name, path := newLocalSnapshotTest(t)
+	markInitialDownloadComplete(t, d)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	require.NoError(d.testStartSingleDownloadNoWait(ctx, snaptype.Hex2InfoHash("aa"), name))
+
+	require.FileExists(path)
+	require.NoFileExists(path + ".part")
+	d.lock.RLock()
+	_, registered := d.torrentsByName[name]
+	d.lock.RUnlock()
+	require.True(registered, "a kept snapshot must be registered, or it is never seeded")
 }
 
 // The snapshot stage writes preverified.toml mid-run, so the rule must be re-read, not cached from

--- a/db/downloader/downloader_test.go
+++ b/db/downloader/downloader_test.go
@@ -437,7 +437,7 @@ func TestKeepsLocalSnapshotAfterInitialDownload(t *testing.T) {
 }
 
 // Data that no longer matches its own metainfo backs neither manifest. Keeping it unverified
-// leaves a hole in the snapshot tier, so it goes to the client, which hash-checks and repairs it.
+// leaves a hole in the snapshot tier, so it goes to the client, which completes it by length.
 func TestDownloadsLocalSnapshotNotMatchingItsMetainfo(t *testing.T) {
 	require := require.New(t)
 	d, logs, name, path := newLocalSnapshotTest(t)
@@ -449,8 +449,9 @@ func TestDownloadsLocalSnapshotNotMatchingItsMetainfo(t *testing.T) {
 	_, download := prepareLocalDataForDownload(t, d, snaptype.Hex2InfoHash("aa"), name)
 	require.True(download, "a file that backs no metainfo must be re-fetched, not kept")
 
-	require.FileExists(path, "the client repairs in place, so the data must stay where it is")
+	require.FileExists(path, "the client completes in place, so the data must stay where it is")
 	require.NoFileExists(path+".part", "invalidation stays forbidden after the initial download")
+	require.Contains(logs.String(), "local snapshot does not match its own metainfo")
 	require.Contains(logs.String(), name)
 }
 

--- a/db/downloader/downloadercfg/downloadercfg.go
+++ b/db/downloader/downloadercfg/downloadercfg.go
@@ -317,11 +317,11 @@ func LoadSnapshotsHashes(ctx context.Context, dirs datadir.Dirs, chainName strin
 	}
 
 	preverifiedPath := dirs.PreverifiedPath()
-	exists, err := dir.FileExist(preverifiedPath)
+	initialDownloadComplete, err := dir.FileExist(preverifiedPath)
 	if err != nil {
 		return err
 	}
-	if exists {
+	if initialDownloadComplete {
 		// Load hashes from local preverified.toml
 		haveToml, err := os.ReadFile(preverifiedPath)
 		if err != nil {
@@ -336,7 +336,7 @@ func LoadSnapshotsHashes(ctx context.Context, dirs datadir.Dirs, chainName strin
 			return fmt.Errorf("failed to fetch remote snapshot hashes for chain %s", chainName)
 		}
 	}
-	cfg.Local = exists
+	cfg.Local = initialDownloadComplete
 	return nil
 }
 


### PR DESCRIPTION
A preverified infohash that didn't match the local file made the downloader rename that file to `.part`, with no log above debug. The snapshot tier then had a hole — reads in that step range fell through to the DB and returned zero values, surfacing much later as `nonce too high` or a wrong trie root, with nothing pointing back at the rename.

`preverified.toml` is written once the initial snapshot set completes, and from then on the local hash set is pinned: `SyncSnapshots` already stops sending download requests (`snapshotsync.go:411`). The downloader now follows the same rule instead of assuming the manifest always wins.

- **Initial download complete** (`preverified.toml` present): local data is kept and the preverified download is skipped. A missing file is still downloaded.
- **Data that disagrees with its own `.torrent`** is not kept: it backs neither manifest, so the download goes ahead and the client completes the file by length. `invalidateData` stays refused once the initial download is complete, so nothing is renamed away.
- **A kept file is registered for seeding** via `AddNewSeedableFile`, off `d.lock` since deriving a metainfo hashes the whole file. Without it the name was absent from `torrentsByName`, `allActiveSnapshots` and `PublishLocalChainToml`, so a seedbox silently stopped serving a file it holds.
- **Initial download incomplete**: unchanged — the manifest is authoritative, so data whose `.torrent` infohash doesn't match the preverified one is renamed to `.part`, now logged at warn with the file name, the `.part` path and the preverified hash.
- `dir.FileExist` errors are propagated instead of guessed, so a broken snapshots dir fails the request rather than silently skipping every download.
- `snapshotDataLooksComplete` -> `snapshotDataSizesMatch`: it only compares `os.Stat` sizes, never piece hashes.

Known gap: with `UsePartFiles` on and `IgnoreUnverifiedPieceCompletion` off, the client completes a piece on length alone (`storage/file-torrent.go:49`), so same-length-different-bytes is kept and seeded. `--downloader.verify` is what hashes.

Refs #21522
