### PR TITLE
[r3.5] prune: txlookup mis-used startFrom parameter

### DIFF
--- a/db/kv/prune/prune.go
+++ b/db/kv/prune/prune.go
@@ -19,6 +19,7 @@ type Stat struct {
 	MaxTxNum         uint64
 	PruneCountTx     uint64
 	PruneCountValues uint64
+	ScanCountValues  uint64
 	DupsDeleted      uint64
 	LastPrunedValue  []byte
 	LastPrunedKey    []byte
@@ -334,6 +335,7 @@ func tableScanningPrune(
 		if ctx.Err() != nil {
 			return common.Copy(val), nil
 		}
+		stat.ScanCountValues++
 
 		// Different storage modes have different dup-iteration orders:
 		//   - StepValueStorageMode (^step||val): FirstDup = newest, LastDup = oldest
@@ -435,7 +437,7 @@ func tableScanningPrune(
 
 		select {
 		case <-logEvery.C:
-			args := []interface{}{"name", filenameBase, "pruned values", stat.PruneCountValues}
+			args := []interface{}{"name", filenameBase, "scanned values", stat.ScanCountValues, "pruned values", stat.PruneCountValues}
 			if keysCursor != nil {
 				args = append(args, "pruned tx", stat.PruneCountTx)
 			}

--- a/db/snapshotsync/freezeblocks/block_snapshots.go
+++ b/db/snapshotsync/freezeblocks/block_snapshots.go
@@ -249,11 +249,12 @@ func CanDeleteTo(curBlockNum uint64, blocksInSnapshots uint64) (blockTo uint64) 
 	}
 
 	var keep uint64 = 1024 // params.FullImmutabilityThreshold //TODO: we will increase this value after db optimizations - about on-chain-tip prune speed
-	hardLimit := (curBlockNum / 1_000) * 1_000
-	if hardLimit < keep { // the subtraction below would wrap
+	if curBlockNum+999 < keep {
+		// To prevent overflow of uint64 below
 		return blocksInSnapshots + 1
 	}
-	return min(hardLimit-keep, blocksInSnapshots+1)
+	hardLimit := (curBlockNum/1_000)*1_000 - keep
+	return min(hardLimit, blocksInSnapshots+1)
 }
 
 func (br *BlockRetire) dbHasEnoughDataForBlocksRetire(ctx context.Context) (bool, error) {

--- a/db/snapshotsync/freezeblocks/block_snapshots.go
+++ b/db/snapshotsync/freezeblocks/block_snapshots.go
@@ -249,12 +249,11 @@ func CanDeleteTo(curBlockNum uint64, blocksInSnapshots uint64) (blockTo uint64) 
 	}
 
 	var keep uint64 = 1024 // params.FullImmutabilityThreshold //TODO: we will increase this value after db optimizations - about on-chain-tip prune speed
-	if curBlockNum+999 < keep {
-		// To prevent overflow of uint64 below
+	hardLimit := (curBlockNum / 1_000) * 1_000
+	if hardLimit < keep { // the subtraction below would wrap
 		return blocksInSnapshots + 1
 	}
-	hardLimit := (curBlockNum/1_000)*1_000 - keep
-	return min(hardLimit, blocksInSnapshots+1)
+	return min(hardLimit-keep, blocksInSnapshots+1)
 }
 
 func (br *BlockRetire) dbHasEnoughDataForBlocksRetire(ctx context.Context) (bool, error) {

--- a/execution/stagedsync/no_prune_test.go
+++ b/execution/stagedsync/no_prune_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/erigontech/erigon/db/kv/memdb"
 	"github.com/erigontech/erigon/db/kv/prune"
 	"github.com/erigontech/erigon/db/snapshotsync/freezeblocks"
+	"github.com/erigontech/erigon/db/state"
 	"github.com/erigontech/erigon/execution/stagedsync/stages"
 )
 
@@ -130,7 +131,7 @@ const (
 	txlDistance = uint64(100)
 )
 
-func txLookupFixture(t *testing.T, firstHeader, pruneProgress, senders uint64) (kv.RwTx, TxLookupCfg, *PruneState) {
+func txLookupFixture(t *testing.T, firstHeader, pruneProgress, senders, staleFloor uint64) (kv.RwTx, TxLookupCfg, *PruneState) {
 	t.Helper()
 	dir := t.TempDir()
 	db := memdb.NewTestDB(t, dbcfg.ChainDB)
@@ -162,6 +163,16 @@ func txLookupFixture(t *testing.T, firstHeader, pruneProgress, senders uint64) (
 		require.NoError(t, stages.SaveStageProgress(tx, stages.Execution, senders))
 	}
 
+	if staleFloor > 0 {
+		// what the old code left behind: a rotation interrupted mid-table under a high floor
+		var mid common.Hash
+		binary.BigEndian.PutUint64(mid[:], txlBlocks/2)
+		require.NoError(t, state.SavePruneValProgress(tx, kv.TxLookup, &prune.Stat{
+			TxFrom: staleFloor, TxTo: staleFloor + 1,
+			ValueProgress: prune.InProgress, LastPrunedValue: mid[:],
+		}))
+	}
+
 	cfg := StageTxLookupCfg(prune.Mode{Initialised: true, History: prune.Distance(txlDistance)},
 		dir, freezeblocks.NewBlockReader(nil, nil))
 	s := &PruneState{ID: stages.TxLookup, ForwardProgress: txlBlocks, PruneProgress: pruneProgress,
@@ -189,8 +200,8 @@ func txLookupRow(t *testing.T, tx kv.Tx, block uint64) []byte {
 // and SpawnTxLookup sets PruneProgress to FrozenBlocks().
 func TestPruneTxLookupFloor(t *testing.T) {
 	for _, tc := range []struct {
-		name                                string
-		firstHeader, pruneProgress, senders uint64
+		name                                            string
+		firstHeader, pruneProgress, senders, staleFloor uint64
 	}{
 		{name: "headers_from_genesis", firstHeader: 1},
 		{name: "headers_pruned_to_frontier", firstHeader: txlBlocks - txlDistance},
@@ -198,9 +209,11 @@ func TestPruneTxLookupFloor(t *testing.T) {
 		{name: "forward_stage_watermark", firstHeader: 1, pruneProgress: txlBlocks - txlDistance},
 		// no non-genesis header, so the removed Senders fallback would fire
 		{name: "senders_fallback", firstHeader: txlBlocks + 1, senders: 500},
+		// upgrade: a rotation left mid-table by the old high floor must restart
+		{name: "stale_rotation", firstHeader: 1, staleFloor: txlBlocks - txlDistance},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			tx, cfg, s := txLookupFixture(t, tc.firstHeader, tc.pruneProgress, tc.senders)
+			tx, cfg, s := txLookupFixture(t, tc.firstHeader, tc.pruneProgress, tc.senders, tc.staleFloor)
 			before := txLookupCount(t, tx)
 			require.NoError(t, PruneTxLookup(s, tx, cfg, context.Background(), log.New()))
 			require.Less(t, txLookupCount(t, tx), before)

--- a/execution/stagedsync/no_prune_test.go
+++ b/execution/stagedsync/no_prune_test.go
@@ -18,15 +18,20 @@ package stagedsync
 
 import (
 	"context"
+	"encoding/binary"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/dbcfg"
+	"github.com/erigontech/erigon/db/kv/dbutils"
 	"github.com/erigontech/erigon/db/kv/memdb"
+	"github.com/erigontech/erigon/db/kv/prune"
+	"github.com/erigontech/erigon/db/snapshotsync/freezeblocks"
 	"github.com/erigontech/erigon/execution/stagedsync/stages"
 )
 
@@ -117,5 +122,93 @@ func TestNoPruneFlagBookkeeping(t *testing.T) {
 		got, err := stages.GetStagePruneProgress(tx, id)
 		require.NoError(t, err)
 		require.Equal(t, forward, got, "stage %s did not record PruneProgress under --exec.no-prune", id)
+	}
+}
+
+const (
+	txlBlocks   = uint64(2_000)
+	txlDistance = uint64(100)
+)
+
+func txLookupFixture(t *testing.T, firstHeader, pruneProgress, senders uint64) (kv.RwTx, TxLookupCfg, *PruneState) {
+	t.Helper()
+	dir := t.TempDir()
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	tx, err := db.BeginRw(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(tx.Rollback)
+
+	txNums := freezeblocks.NewBlockReader(nil, nil).TxnumReader()
+	require.NoError(t, tx.Put(kv.Headers, dbutils.HeaderKey(0, common.Hash{}), []byte{1}))
+	for b := uint64(0); b <= txlBlocks; b++ {
+		require.NoError(t, txNums.Append(tx, b, b*2+1))
+	}
+	for b := uint64(1); b <= txlBlocks; b++ {
+		var h common.Hash
+		binary.BigEndian.PutUint64(h[:], b)
+		val := make([]byte, 16)
+		binary.BigEndian.PutUint64(val[:8], b)
+		binary.BigEndian.PutUint64(val[8:], b*2)
+		require.NoError(t, tx.Put(kv.TxLookup, h[:], val))
+		if b >= firstHeader {
+			require.NoError(t, tx.Put(kv.Headers, dbutils.HeaderKey(b, h), []byte{1}))
+		}
+	}
+	if pruneProgress > 0 {
+		require.NoError(t, stages.SaveStagePruneProgress(tx, stages.TxLookup, pruneProgress))
+	}
+	if senders > 0 {
+		require.NoError(t, stages.SaveStageProgress(tx, stages.Senders, senders))
+		require.NoError(t, stages.SaveStageProgress(tx, stages.Execution, senders))
+	}
+
+	cfg := StageTxLookupCfg(prune.Mode{Initialised: true, History: prune.Distance(txlDistance)},
+		dir, freezeblocks.NewBlockReader(nil, nil))
+	s := &PruneState{ID: stages.TxLookup, ForwardProgress: txlBlocks, PruneProgress: pruneProgress,
+		CurrentSyncCycle: CurrentSyncCycleInfo{IsInitialCycle: true}}
+	return tx, cfg, s
+}
+
+func txLookupCount(t *testing.T, tx kv.Tx) int {
+	t.Helper()
+	n, err := tx.Count(kv.TxLookup)
+	require.NoError(t, err)
+	return int(n)
+}
+
+func txLookupRow(t *testing.T, tx kv.Tx, block uint64) []byte {
+	t.Helper()
+	var h common.Hash
+	binary.BigEndian.PutUint64(h[:], block)
+	v, err := tx.GetOne(kv.TxLookup, h[:])
+	require.NoError(t, err)
+	return v
+}
+
+// The floor must not track blockTo: kv.Headers is deleted to the same frontier,
+// and SpawnTxLookup sets PruneProgress to FrozenBlocks().
+func TestPruneTxLookupFloor(t *testing.T) {
+	for _, tc := range []struct {
+		name                                string
+		firstHeader, pruneProgress, senders uint64
+	}{
+		{name: "headers_from_genesis", firstHeader: 1},
+		{name: "headers_pruned_to_frontier", firstHeader: txlBlocks - txlDistance},
+		{name: "headers_pruned_past_frontier", firstHeader: txlBlocks - 1},
+		{name: "forward_stage_watermark", firstHeader: 1, pruneProgress: txlBlocks - txlDistance},
+		// no non-genesis header, so the removed Senders fallback would fire
+		{name: "senders_fallback", firstHeader: txlBlocks + 1, senders: 500},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tx, cfg, s := txLookupFixture(t, tc.firstHeader, tc.pruneProgress, tc.senders)
+			before := txLookupCount(t, tx)
+			require.NoError(t, PruneTxLookup(s, tx, cfg, context.Background(), log.New()))
+			require.Less(t, txLookupCount(t, tx), before)
+
+			blockTo := txlBlocks - txlDistance // exclusive end of the range
+			require.Nil(t, txLookupRow(t, tx, 1), "left an early row: floor above 0")
+			require.Nil(t, txLookupRow(t, tx, blockTo-1), "left a row below blockTo")
+			require.NotNil(t, txLookupRow(t, tx, blockTo), "pruned blockTo itself")
+		})
 	}
 }

--- a/execution/stagedsync/no_prune_test.go
+++ b/execution/stagedsync/no_prune_test.go
@@ -17,6 +17,7 @@
 package stagedsync
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/binary"
@@ -294,6 +295,28 @@ func TestPruneTxLookupResumesInterruptedRotation(t *testing.T) {
 	require.Equal(t, prune.Done, st.ValueProgress)
 }
 
+// A rotation that spans a bound advance resumes past rows the widened range now
+// covers, so finishing it must not record the wider bound — that would claim
+// coverage it never achieved and short-circuit the pass that would catch them.
+func TestPruneTxLookupRotationRecordsItsStartBound(t *testing.T) {
+	ctx, logger := context.Background(), log.New()
+	tx, cfg, s := txLookupFixture(t, 1, 0, 0, 0, txlBlocks/2)
+
+	// the interrupted rotation started at a lower bound than the current one
+	started, err := state.GetPruneValProgress(tx, []byte(kv.TxLookup))
+	require.NoError(t, err)
+	require.Equal(t, prune.InProgress, started.ValueProgress)
+	require.Less(t, started.TxTo, txlMinTxNum(txlBlockTo()))
+
+	require.NoError(t, PruneTxLookup(s, tx, cfg, ctx, logger))
+
+	done, err := state.GetPruneValProgress(tx, []byte(kv.TxLookup))
+	require.NoError(t, err)
+	require.Equal(t, prune.Done, done.ValueProgress)
+	require.Equal(t, started.TxTo, done.TxTo,
+		"recorded the widened bound, claiming coverage the resumed rotation skipped")
+}
+
 // A completed rotation must survive the tip advancing, or the whole table is
 // rescanned once per payload to collect a single block of rows.
 func TestPruneTxLookupSkipsRescanAfterRotation(t *testing.T) {
@@ -318,4 +341,69 @@ func TestPruneTxLookupSkipsRescanAfterRotation(t *testing.T) {
 	got, err := tx.GetOne(kv.TxLookup, planted[:])
 	require.NoError(t, err)
 	require.NotNil(t, got, "rescanned the whole table though the bound had not moved")
+}
+
+// Drives one table through the whole prune lifecycle, asserting the state machine
+// at each step rather than each step in isolation.
+func TestPruneTxLookupLifecycle(t *testing.T) {
+	ctx, logger := context.Background(), log.New()
+	tx, cfg, s := txLookupFixture(t, 1, 0, 0, 0, 0)
+	progress := func() *prune.Stat {
+		st, err := state.GetPruneValProgress(tx, []byte(kv.TxLookup))
+		require.NoError(t, err)
+		return st
+	}
+	to := txlBlockTo()
+
+	// 1. fresh node: one rotation clears everything below the bound
+	require.NoError(t, PruneTxLookup(s, tx, cfg, ctx, logger))
+	require.Equal(t, prune.Done, progress().ValueProgress)
+	require.Zero(t, txlBlockRows(t, tx, to-1), "left rows below the bound")
+	require.EqualValues(t, txlTxPerBlock, txlBlockRows(t, tx, to), "pruned the exclusive bound")
+	afterFirst := progress().TxTo
+
+	// 2. bound unchanged: short-circuits, so a row planted below it survives
+	planted := txlTxHash(txlBlocks+1, 0)
+	val := make([]byte, 16)
+	binary.BigEndian.PutUint64(val[8:], afterFirst-1)
+	require.NoError(t, tx.Put(kv.TxLookup, planted[:], val))
+	s.ForwardProgress++
+	require.NoError(t, PruneTxLookup(s, tx, cfg, ctx, logger))
+	got, err := tx.GetOne(kv.TxLookup, planted[:])
+	require.NoError(t, err)
+	require.NotNil(t, got, "rescanned though the bound had not moved")
+	require.Equal(t, afterFirst, progress().TxTo, "short-circuit moved the recorded bound")
+
+	// 3. an interrupted rotation is resumed, not restarted. The table is hash-ordered,
+	// so the probe has to sort before the saved cursor to be skipped by a resume.
+	cur := txlTxHash(txlBlocks/2, 0)
+	var before common.Hash
+	for i := uint64(0); ; i++ {
+		if h := txlTxHash(txlBlocks+2, i); bytes.Compare(h[:], cur[:]) < 0 {
+			before = h
+			break
+		}
+	}
+	require.NoError(t, tx.Put(kv.TxLookup, before[:], val))
+	require.NoError(t, state.SavePruneValProgress(tx, kv.TxLookup, &prune.Stat{
+		TxFrom: 0, TxTo: afterFirst, ValueProgress: prune.InProgress, LastPrunedValue: cur[:],
+	}))
+	require.NoError(t, PruneTxLookup(s, tx, cfg, ctx, logger))
+	require.Equal(t, prune.Done, progress().ValueProgress)
+	require.NotNil(t, mustGet(t, tx, before[:]), "restarted from First instead of resuming")
+
+	// 4. a pre-fix record bypasses the short-circuit and restarts
+	require.NoError(t, state.SavePruneValProgress(tx, kv.TxLookup, &prune.Stat{
+		TxFrom: 42, TxTo: afterFirst + 1_000_000, ValueProgress: prune.Done, LastPrunedValue: cur[:],
+	}))
+	require.NoError(t, PruneTxLookup(s, tx, cfg, ctx, logger))
+	require.Nil(t, mustGet(t, tx, before[:]), "stale record still short-circuited")
+	require.Zero(t, progress().TxFrom, "stale floor was not cleared")
+}
+
+func mustGet(t *testing.T, tx kv.Tx, k []byte) []byte {
+	t.Helper()
+	v, err := tx.GetOne(kv.TxLookup, k)
+	require.NoError(t, err)
+	return v
 }

--- a/execution/stagedsync/no_prune_test.go
+++ b/execution/stagedsync/no_prune_test.go
@@ -183,7 +183,7 @@ func txLookupFixture(t *testing.T, firstHeader, pruneProgress, senders, staleFlo
 		require.NoError(t, txNums.Append(tx, b, txlMaxTxNum(b)))
 	}
 	for b := uint64(1); b <= txlBlocks; b++ {
-		for i := uint64(0); i < txlTxPerBlock; i++ {
+		for i := range txlTxPerBlock {
 			val := make([]byte, 16)
 			binary.BigEndian.PutUint64(val[:8], b)
 			binary.BigEndian.PutUint64(val[8:], txlMinTxNum(b)+i+1)
@@ -221,7 +221,7 @@ func txLookupFixture(t *testing.T, firstHeader, pruneProgress, senders, staleFlo
 func txlBlockRows(t *testing.T, tx kv.Tx, block uint64) int {
 	t.Helper()
 	n := 0
-	for i := uint64(0); i < txlTxPerBlock; i++ {
+	for i := range txlTxPerBlock {
 		h := txlTxHash(block, i)
 		v, err := tx.GetOne(kv.TxLookup, h[:])
 		require.NoError(t, err)

--- a/execution/stagedsync/no_prune_test.go
+++ b/execution/stagedsync/no_prune_test.go
@@ -18,6 +18,7 @@ package stagedsync
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/binary"
 	"testing"
 
@@ -26,11 +27,14 @@ import (
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/config3"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/dbcfg"
 	"github.com/erigontech/erigon/db/kv/dbutils"
 	"github.com/erigontech/erigon/db/kv/memdb"
 	"github.com/erigontech/erigon/db/kv/prune"
+	"github.com/erigontech/erigon/db/kv/rawdbv3"
+	"github.com/erigontech/erigon/db/services"
 	"github.com/erigontech/erigon/db/snapshotsync/freezeblocks"
 	"github.com/erigontech/erigon/db/state"
 	"github.com/erigontech/erigon/execution/stagedsync/stages"
@@ -127,9 +131,43 @@ func TestNoPruneFlagBookkeeping(t *testing.T) {
 }
 
 const (
-	txlBlocks   = uint64(2_000)
-	txlDistance = uint64(100)
+	txlBlocks     = uint64(3_000)
+	txlTxPerBlock = uint64(3)
+	txlFrozen     = uint64(1_500) // blocks in snapshots
 )
+
+// txlBlockReader serves the two methods PruneTxLookup uses; anything else is a
+// nil-panic, which is the point.
+type txlBlockReader struct {
+	services.FullBlockReader
+	frozen uint64
+}
+
+func (r txlBlockReader) CanPruneTo(cur uint64) uint64 {
+	return freezeblocks.CanDeleteTo(cur, r.frozen)
+}
+func (r txlBlockReader) TxnumReader() rawdbv3.TxNumsReader {
+	return freezeblocks.NewBlockReader(nil, nil).TxnumReader()
+}
+
+// txlTxHash mimics production keys: unrelated to block order, so the table is
+// walked in hash order like the real one.
+func txlTxHash(block, i uint64) common.Hash {
+	var b [16]byte
+	binary.BigEndian.PutUint64(b[:8], block)
+	binary.BigEndian.PutUint64(b[8:], i)
+	return common.Hash(sha256.Sum256(b[:]))
+}
+
+// A block occupies [Min(b) system][Min(b)+1 .. Min(b)+n txns][Max(b) system],
+// and txnLookupTransform writes a row only for the txns.
+func txlMinTxNum(block uint64) uint64 {
+	if block == 0 {
+		return 0
+	}
+	return block*(txlTxPerBlock+2) - (txlTxPerBlock + 1)
+}
+func txlMaxTxNum(block uint64) uint64 { return txlMinTxNum(block) + txlTxPerBlock + 1 }
 
 func txLookupFixture(t *testing.T, firstHeader, pruneProgress, senders, staleFloor uint64) (kv.RwTx, TxLookupCfg, *PruneState) {
 	t.Helper()
@@ -142,17 +180,20 @@ func txLookupFixture(t *testing.T, firstHeader, pruneProgress, senders, staleFlo
 	txNums := freezeblocks.NewBlockReader(nil, nil).TxnumReader()
 	require.NoError(t, tx.Put(kv.Headers, dbutils.HeaderKey(0, common.Hash{}), []byte{1}))
 	for b := uint64(0); b <= txlBlocks; b++ {
-		require.NoError(t, txNums.Append(tx, b, b*2+1))
+		require.NoError(t, txNums.Append(tx, b, txlMaxTxNum(b)))
 	}
 	for b := uint64(1); b <= txlBlocks; b++ {
-		var h common.Hash
-		binary.BigEndian.PutUint64(h[:], b)
-		val := make([]byte, 16)
-		binary.BigEndian.PutUint64(val[:8], b)
-		binary.BigEndian.PutUint64(val[8:], b*2)
-		require.NoError(t, tx.Put(kv.TxLookup, h[:], val))
+		for i := uint64(0); i < txlTxPerBlock; i++ {
+			val := make([]byte, 16)
+			binary.BigEndian.PutUint64(val[:8], b)
+			binary.BigEndian.PutUint64(val[8:], txlMinTxNum(b)+i+1)
+			h := txlTxHash(b, i)
+			require.NoError(t, tx.Put(kv.TxLookup, h[:], val))
+		}
 		if b >= firstHeader {
-			require.NoError(t, tx.Put(kv.Headers, dbutils.HeaderKey(b, h), []byte{1}))
+			var hh common.Hash
+			binary.BigEndian.PutUint64(hh[:], b)
+			require.NoError(t, tx.Put(kv.Headers, dbutils.HeaderKey(b, hh), []byte{1}))
 		}
 	}
 	if pruneProgress > 0 {
@@ -162,41 +203,39 @@ func txLookupFixture(t *testing.T, firstHeader, pruneProgress, senders, staleFlo
 		require.NoError(t, stages.SaveStageProgress(tx, stages.Senders, senders))
 		require.NoError(t, stages.SaveStageProgress(tx, stages.Execution, senders))
 	}
-
 	if staleFloor > 0 {
-		// what the old code left behind: a rotation interrupted mid-table under a high floor
-		var mid common.Hash
-		binary.BigEndian.PutUint64(mid[:], txlBlocks/2)
+		h := txlTxHash(txlBlocks/2, 0)
 		require.NoError(t, state.SavePruneValProgress(tx, kv.TxLookup, &prune.Stat{
 			TxFrom: staleFloor, TxTo: staleFloor + 1,
-			ValueProgress: prune.InProgress, LastPrunedValue: mid[:],
+			ValueProgress: prune.InProgress, LastPrunedValue: h[:],
 		}))
 	}
 
-	cfg := StageTxLookupCfg(prune.Mode{Initialised: true, History: prune.Distance(txlDistance)},
-		dir, freezeblocks.NewBlockReader(nil, nil))
+	cfg := StageTxLookupCfg(prune.Mode{Initialised: true, History: prune.Distance(config3.DefaultPruneDistance)},
+		dir, txlBlockReader{frozen: txlFrozen})
 	s := &PruneState{ID: stages.TxLookup, ForwardProgress: txlBlocks, PruneProgress: pruneProgress,
 		CurrentSyncCycle: CurrentSyncCycleInfo{IsInitialCycle: true}}
 	return tx, cfg, s
 }
 
-func txLookupCount(t *testing.T, tx kv.Tx) int {
+func txlBlockRows(t *testing.T, tx kv.Tx, block uint64) int {
 	t.Helper()
-	n, err := tx.Count(kv.TxLookup)
-	require.NoError(t, err)
-	return int(n)
+	n := 0
+	for i := uint64(0); i < txlTxPerBlock; i++ {
+		h := txlTxHash(block, i)
+		v, err := tx.GetOne(kv.TxLookup, h[:])
+		require.NoError(t, err)
+		if v != nil {
+			n++
+		}
+	}
+	return n
 }
 
-func txLookupRow(t *testing.T, tx kv.Tx, block uint64) []byte {
-	t.Helper()
-	var h common.Hash
-	binary.BigEndian.PutUint64(h[:], block)
-	v, err := tx.GetOne(kv.TxLookup, h[:])
-	require.NoError(t, err)
-	return v
-}
+// The bound is the snapshot frontier: rows below it duplicate the .idx files.
+func txlBlockTo() uint64 { return freezeblocks.CanDeleteTo(txlBlocks, txlFrozen) }
 
-// The floor must not track blockTo: kv.Headers is deleted to the same frontier,
+// The floor must not track the bound: kv.Headers is deleted to the same frontier,
 // and SpawnTxLookup sets PruneProgress to FrozenBlocks().
 func TestPruneTxLookupFloor(t *testing.T) {
 	for _, tc := range []struct {
@@ -204,24 +243,43 @@ func TestPruneTxLookupFloor(t *testing.T) {
 		firstHeader, pruneProgress, senders, staleFloor uint64
 	}{
 		{name: "headers_from_genesis", firstHeader: 1},
-		{name: "headers_pruned_to_frontier", firstHeader: txlBlocks - txlDistance},
+		{name: "headers_pruned_to_frontier", firstHeader: txlBlockTo()},
 		{name: "headers_pruned_past_frontier", firstHeader: txlBlocks - 1},
-		{name: "forward_stage_watermark", firstHeader: 1, pruneProgress: txlBlocks - txlDistance},
-		// no non-genesis header, so the removed Senders fallback would fire
+		{name: "forward_stage_watermark", firstHeader: 1, pruneProgress: txlFrozen},
 		{name: "senders_fallback", firstHeader: txlBlocks + 1, senders: 500},
-		// upgrade: a rotation left mid-table by the old high floor must restart
-		{name: "stale_rotation", firstHeader: 1, staleFloor: txlBlocks - txlDistance},
+		{name: "stale_rotation", firstHeader: 1, staleFloor: txlMinTxNum(txlBlocks / 2)},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			tx, cfg, s := txLookupFixture(t, tc.firstHeader, tc.pruneProgress, tc.senders, tc.staleFloor)
-			before := txLookupCount(t, tx)
 			require.NoError(t, PruneTxLookup(s, tx, cfg, context.Background(), log.New()))
-			require.Less(t, txLookupCount(t, tx), before)
 
-			blockTo := txlBlocks - txlDistance // exclusive end of the range
-			require.Nil(t, txLookupRow(t, tx, 1), "left an early row: floor above 0")
-			require.Nil(t, txLookupRow(t, tx, blockTo-1), "left a row below blockTo")
-			require.NotNil(t, txLookupRow(t, tx, blockTo), "pruned blockTo itself")
+			to := txlBlockTo()
+			require.Positive(t, to)
+			// every txn below the bound is gone, and the bound itself is untouched
+			require.Zero(t, txlBlockRows(t, tx, 1), "left an early block: floor above 0")
+			require.Zero(t, txlBlockRows(t, tx, to-1), "left the block below the bound")
+			require.EqualValues(t, txlTxPerBlock, txlBlockRows(t, tx, to), "pruned the exclusive bound")
+			require.EqualValues(t, txlTxPerBlock, txlBlockRows(t, tx, txlBlocks), "pruned the tip")
 		})
 	}
+}
+
+// A completed rotation must survive the tip advancing, or the whole table is
+// rescanned once per payload to collect a single block of rows.
+func TestPruneTxLookupSkipsRescanAfterRotation(t *testing.T) {
+	ctx, logger := context.Background(), log.New()
+	tx, cfg, s := txLookupFixture(t, 1, 0, 0, 0)
+
+	require.NoError(t, PruneTxLookup(s, tx, cfg, ctx, logger))
+	first, err := state.GetPruneValProgress(tx, []byte(kv.TxLookup))
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	require.Equal(t, prune.Done, first.ValueProgress)
+
+	s.ForwardProgress++
+	require.NoError(t, PruneTxLookup(s, tx, cfg, ctx, logger))
+
+	second, err := state.GetPruneValProgress(tx, []byte(kv.TxLookup))
+	require.NoError(t, err)
+	require.Equal(t, first.TxTo, second.TxTo, "rescanned the whole table for one block of rows")
 }

--- a/execution/stagedsync/no_prune_test.go
+++ b/execution/stagedsync/no_prune_test.go
@@ -163,13 +163,18 @@ func txlTxHash(block, i uint64) common.Hash {
 // and txnLookupTransform writes a row only for the txns.
 func txlMinTxNum(block uint64) uint64 {
 	if block == 0 {
-		return 0
+		return 0 // genesis: [Min system][Max system], no txns
 	}
-	return block*(txlTxPerBlock+2) - (txlTxPerBlock + 1)
+	return 2 + (block-1)*(txlTxPerBlock+2)
 }
-func txlMaxTxNum(block uint64) uint64 { return txlMinTxNum(block) + txlTxPerBlock + 1 }
+func txlMaxTxNum(block uint64) uint64 {
+	if block == 0 {
+		return 1
+	}
+	return txlMinTxNum(block) + txlTxPerBlock + 1
+}
 
-func txLookupFixture(t *testing.T, firstHeader, pruneProgress, senders, staleFloor uint64) (kv.RwTx, TxLookupCfg, *PruneState) {
+func txLookupFixture(t *testing.T, firstHeader, pruneProgress, senders, staleFloor, resumeFrom uint64) (kv.RwTx, TxLookupCfg, *PruneState) {
 	t.Helper()
 	dir := t.TempDir()
 	db := memdb.NewTestDB(t, dbcfg.ChainDB)
@@ -203,11 +208,19 @@ func txLookupFixture(t *testing.T, firstHeader, pruneProgress, senders, staleFlo
 		require.NoError(t, stages.SaveStageProgress(tx, stages.Senders, senders))
 		require.NoError(t, stages.SaveStageProgress(tx, stages.Execution, senders))
 	}
+	if resumeFrom > 0 {
+		// an interrupted rotation under the current floor: must be resumed, not restarted
+		h := txlTxHash(resumeFrom, 0)
+		require.NoError(t, state.SavePruneValProgress(tx, kv.TxLookup, &prune.Stat{
+			TxFrom: 0, TxTo: 1, ValueProgress: prune.InProgress, LastPrunedValue: h[:],
+		}))
+	}
 	if staleFloor > 0 {
+		// what a pre-fix binary left: non-zero floor, TxTo from Max(blockTo), rotation Done
 		h := txlTxHash(txlBlocks/2, 0)
 		require.NoError(t, state.SavePruneValProgress(tx, kv.TxLookup, &prune.Stat{
-			TxFrom: staleFloor, TxTo: staleFloor + 1,
-			ValueProgress: prune.InProgress, LastPrunedValue: h[:],
+			TxFrom: staleFloor, TxTo: txlMaxTxNum(txlBlockTo()),
+			ValueProgress: prune.Done, LastPrunedValue: h[:],
 		}))
 	}
 
@@ -239,8 +252,8 @@ func txlBlockTo() uint64 { return freezeblocks.CanDeleteTo(txlBlocks, txlFrozen)
 // and SpawnTxLookup sets PruneProgress to FrozenBlocks().
 func TestPruneTxLookupFloor(t *testing.T) {
 	for _, tc := range []struct {
-		name                                            string
-		firstHeader, pruneProgress, senders, staleFloor uint64
+		name                                                        string
+		firstHeader, pruneProgress, senders, staleFloor, resumeFrom uint64
 	}{
 		{name: "headers_from_genesis", firstHeader: 1},
 		{name: "headers_pruned_to_frontier", firstHeader: txlBlockTo()},
@@ -250,7 +263,7 @@ func TestPruneTxLookupFloor(t *testing.T) {
 		{name: "stale_rotation", firstHeader: 1, staleFloor: txlMinTxNum(txlBlocks / 2)},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			tx, cfg, s := txLookupFixture(t, tc.firstHeader, tc.pruneProgress, tc.senders, tc.staleFloor)
+			tx, cfg, s := txLookupFixture(t, tc.firstHeader, tc.pruneProgress, tc.senders, tc.staleFloor, tc.resumeFrom)
 			require.NoError(t, PruneTxLookup(s, tx, cfg, context.Background(), log.New()))
 
 			to := txlBlockTo()
@@ -264,11 +277,28 @@ func TestPruneTxLookupFloor(t *testing.T) {
 	}
 }
 
+// An interrupted rotation under the current floor must be resumed, not restarted:
+// at the tip the budget cannot finish a pass over the whole table, so restarting
+// every cycle would mean no rotation ever completes.
+func TestPruneTxLookupResumesInterruptedRotation(t *testing.T) {
+	const resumeAt = txlBlocks / 2
+	tx, cfg, s := txLookupFixture(t, 1, 0, 0, 0, resumeAt)
+	require.NoError(t, PruneTxLookup(s, tx, cfg, context.Background(), log.New()))
+
+	// rows before the saved cursor are not visited this pass — proof it resumed
+	require.EqualValues(t, txlTxPerBlock, txlBlockRows(t, tx, 1),
+		"restarted from First instead of resuming the saved cursor")
+
+	st, err := state.GetPruneValProgress(tx, []byte(kv.TxLookup))
+	require.NoError(t, err)
+	require.Equal(t, prune.Done, st.ValueProgress)
+}
+
 // A completed rotation must survive the tip advancing, or the whole table is
 // rescanned once per payload to collect a single block of rows.
 func TestPruneTxLookupSkipsRescanAfterRotation(t *testing.T) {
 	ctx, logger := context.Background(), log.New()
-	tx, cfg, s := txLookupFixture(t, 1, 0, 0, 0)
+	tx, cfg, s := txLookupFixture(t, 1, 0, 0, 0, 0)
 
 	require.NoError(t, PruneTxLookup(s, tx, cfg, ctx, logger))
 	first, err := state.GetPruneValProgress(tx, []byte(kv.TxLookup))
@@ -276,10 +306,16 @@ func TestPruneTxLookupSkipsRescanAfterRotation(t *testing.T) {
 	require.NotNil(t, first)
 	require.Equal(t, prune.Done, first.ValueProgress)
 
+	// plant a row the bound already covers; only a rescan would remove it
+	planted := txlTxHash(txlBlocks+1, 0)
+	val := make([]byte, 16)
+	binary.BigEndian.PutUint64(val[8:], first.TxTo-1)
+	require.NoError(t, tx.Put(kv.TxLookup, planted[:], val))
+
 	s.ForwardProgress++
 	require.NoError(t, PruneTxLookup(s, tx, cfg, ctx, logger))
 
-	second, err := state.GetPruneValProgress(tx, []byte(kv.TxLookup))
+	got, err := tx.GetOne(kv.TxLookup, planted[:])
 	require.NoError(t, err)
-	require.Equal(t, first.TxTo, second.TxTo, "rescanned the whole table for one block of rows")
+	require.NotNil(t, got, "rescanned the whole table though the bound had not moved")
 }

--- a/execution/stagedsync/stage_txlookup.go
+++ b/execution/stagedsync/stage_txlookup.go
@@ -269,7 +269,9 @@ func PruneTxLookup(s *PruneState, tx kv.RwTx, cfg TxLookupCfg, ctx context.Conte
 	logEvery := time.NewTicker(logInterval)
 	defer logEvery.Stop()
 
-	pruneTimeout := 2 * time.Second
+	// Chain-tip budget: this runs on the newPayload path, next to the exec-stage
+	// prune that already takes a third of a slot.
+	pruneTimeout := 250 * time.Millisecond
 	if s.CurrentSyncCycle.IsInitialCycle {
 		pruneTimeout = time.Hour
 	}

--- a/execution/stagedsync/stage_txlookup.go
+++ b/execution/stagedsync/stage_txlookup.go
@@ -219,7 +219,8 @@ func PruneTxLookup(s *PruneState, tx kv.RwTx, cfg TxLookupCfg, ctx context.Conte
 
 	txNumReader := cfg.blockReader.TxnumReader()
 	// blockTo is exclusive, so the range ends at its first txNum: Min(blockTo) ==
-	// Max(blockTo-1)+1. Max(blockTo) would eat all of blockTo but its last txn.
+	// Max(blockTo-1)+1. A block is [Min system][Min+1..Min+len txns][Max system] and
+	// only the txns get rows, so Max(blockTo) took every lookup blockTo has.
 	txTo, err := txNumReader.Min(ctx, tx, blockTo)
 	if err != nil {
 		return fmt.Errorf("txNumReader.Min(%d): %w", blockTo, err)
@@ -242,8 +243,9 @@ func PruneTxLookup(s *PruneState, tx kv.RwTx, cfg TxLookupCfg, ctx context.Conte
 
 	// Rolling scan: preserve cursor position across txTo advances so each B-tree page
 	// is visited sequentially once per rotation instead of restarting from First() on
-	// every prune cycle. Only reset the cursor when a full rotation has completed.
-	if prevStat.ValueProgress == prune.Done {
+	// every prune cycle. Restart on a completed rotation, and on a rotation left over
+	// from a higher floor, whose cursor already passed rows this one must delete.
+	if prevStat.ValueProgress == prune.Done || prevStat.TxFrom != 0 {
 		prevStat.ValueProgress = prune.First
 		prevStat.LastPrunedValue = nil
 	}

--- a/execution/stagedsync/stage_txlookup.go
+++ b/execution/stagedsync/stage_txlookup.go
@@ -30,11 +30,9 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	mdbx2 "github.com/erigontech/erigon/db/kv/mdbx"
 	"github.com/erigontech/erigon/db/kv/prune"
-	"github.com/erigontech/erigon/db/kv/rawdbv3"
 	"github.com/erigontech/erigon/db/rawdb"
 	"github.com/erigontech/erigon/db/services"
 	"github.com/erigontech/erigon/db/state"
-	"github.com/erigontech/erigon/execution/stagedsync/stages"
 	"github.com/erigontech/erigon/execution/types"
 )
 
@@ -74,7 +72,7 @@ func SpawnTxLookup(s *StageState, tx kv.RwTx, toBlock uint64, cfg TxLookupCfg, c
 		pruneTo := cfg.prune.History.PruneTo(endBlock)
 		if startBlock < pruneTo {
 			startBlock = pruneTo
-			if err = s.UpdatePrune(tx, pruneTo); err != nil { // prune func of this stage will use this value to prevent all ancient blocks traversal
+			if err = s.UpdatePrune(tx, pruneTo); err != nil {
 				return err
 			}
 		}
@@ -83,7 +81,7 @@ func SpawnTxLookup(s *StageState, tx kv.RwTx, toBlock uint64, cfg TxLookupCfg, c
 	if cfg.blockReader.FrozenBlocks() > startBlock {
 		// Snapshot .idx files already have TxLookup index - then no reason iterate over them here
 		startBlock = cfg.blockReader.FrozenBlocks()
-		if err = s.UpdatePrune(tx, startBlock); err != nil { // prune func of this stage will use this value to prevent all ancient blocks traversal
+		if err = s.UpdatePrune(tx, startBlock); err != nil {
 			return err
 		}
 	}
@@ -206,22 +204,6 @@ func PruneTxLookup(s *PruneState, tx kv.RwTx, cfg TxLookupCfg, ctx context.Conte
 		return s.Done(tx)
 	}
 	logPrefix := s.LogPrefix()
-	blockFrom := s.PruneProgress
-	if blockFrom == 0 {
-		firstNonGenesisHeader, err := rawdbv3.SecondKey(tx, kv.Headers)
-		if err != nil {
-			return err
-		}
-		if firstNonGenesisHeader != nil {
-			blockFrom = binary.BigEndian.Uint64(firstNonGenesisHeader)
-		} else {
-			execProgress, err := stageProgress(tx, nil, stages.Senders)
-			if err != nil {
-				return err
-			}
-			blockFrom = execProgress
-		}
-	}
 	var blockTo uint64
 
 	// Forward stage doesn't write anything before PruneTo point
@@ -231,20 +213,18 @@ func PruneTxLookup(s *PruneState, tx kv.RwTx, cfg TxLookupCfg, ctx context.Conte
 		blockTo = cfg.blockReader.CanPruneTo(s.ForwardProgress)
 	}
 
-	if blockFrom >= blockTo {
+	if blockTo == 0 {
 		return nil
 	}
 
 	txNumReader := cfg.blockReader.TxnumReader()
-	txFrom, err := txNumReader.Min(ctx, tx, blockFrom)
+	// blockTo is exclusive, so the range ends at its first txNum: Min(blockTo) ==
+	// Max(blockTo-1)+1. Max(blockTo) would eat all of blockTo but its last txn.
+	txTo, err := txNumReader.Min(ctx, tx, blockTo)
 	if err != nil {
-		return fmt.Errorf("txNumReader.Min(%d): %w", blockFrom, err)
+		return fmt.Errorf("txNumReader.Min(%d): %w", blockTo, err)
 	}
-	txTo, err := txNumReader.Max(ctx, tx, blockTo)
-	if err != nil {
-		return fmt.Errorf("txNumReader.Max(%d): %w", blockTo, err)
-	}
-	if txFrom >= txTo {
+	if txTo == 0 {
 		return nil
 	}
 
@@ -268,7 +248,7 @@ func PruneTxLookup(s *PruneState, tx kv.RwTx, cfg TxLookupCfg, ctx context.Conte
 		prevStat.LastPrunedValue = nil
 	}
 	// Sync range params so TableScanningPrune won't reset the cursor mid-rotation.
-	prevStat.TxFrom = txFrom
+	prevStat.TxFrom = 0
 	prevStat.TxTo = txTo
 
 	valsRwCursor, err := tx.RwCursor(kv.TxLookup)
@@ -294,13 +274,15 @@ func PruneTxLookup(s *PruneState, tx kv.RwTx, cfg TxLookupCfg, ctx context.Conte
 	pruneCtx, pruneCancel := context.WithTimeout(ctx, pruneTimeout)
 	defer pruneCancel()
 
-	pruneStat, err := prune.TableScanningPrune(pruneCtx, logPrefix, "txlookup", txFrom, txTo, 1,
+	// txFrom stays 0: tableScanningPrune uses it only as a delete predicate, so any
+	// higher floor retains rows without saving traversal.
+	pruneStat, err := prune.TableScanningPrune(pruneCtx, logPrefix, "txlookup", 0, txTo, 1,
 		logEvery, logger, nil, valsCursor, false, prevStat, prune.ValueOffset8StorageMode)
 	if err != nil {
 		return fmt.Errorf("prune TxLookup: %w", err)
 	}
 	defer func() {
-		pruneStat.TxFrom, pruneStat.TxTo = txFrom, txTo
+		pruneStat.TxFrom, pruneStat.TxTo = 0, txTo
 		if e := state.SavePruneValProgress(tx, kv.TxLookup, pruneStat); e != nil {
 			logger.Error("[snapshots] save prune val progress", "name", "txlookup", "err", e)
 		}

--- a/execution/stagedsync/stage_txlookup.go
+++ b/execution/stagedsync/stage_txlookup.go
@@ -204,15 +204,12 @@ func PruneTxLookup(s *PruneState, tx kv.RwTx, cfg TxLookupCfg, ctx context.Conte
 		return s.Done(tx)
 	}
 	logPrefix := s.LogPrefix()
-	var blockTo uint64
-
-	// Forward stage doesn't write anything before PruneTo point
-	if cfg.prune.History.Enabled() {
-		blockTo = cfg.prune.History.PruneTo(s.ForwardProgress)
-	} else {
-		blockTo = cfg.blockReader.CanPruneTo(s.ForwardProgress)
-	}
-
+	// Rows below the snapshot frontier are duplicates of the .idx files, which is why
+	// SpawnTxLookup refuses to write them. Dropping a duplicate loses nothing, so the
+	// retention distance has no say here: prune.History.PruneTo would sit far below
+	// the frontier and leave every redundant row in place, and on a node whose
+	// snapshots lag it would sit above and delete the only copy.
+	blockTo := cfg.blockReader.CanPruneTo(s.ForwardProgress)
 	if blockTo == 0 {
 		return nil
 	}
@@ -285,6 +282,8 @@ func PruneTxLookup(s *PruneState, tx kv.RwTx, cfg TxLookupCfg, ctx context.Conte
 	if err != nil {
 		return fmt.Errorf("prune TxLookup: %w", err)
 	}
+	logger.Debug(fmt.Sprintf("[%s] prune", logPrefix), "scanned", pruneStat.ScanCountValues,
+		"pruned", pruneStat.PruneCountValues, "status", pruneStat.ValueProgress.String(), "blockTo", blockTo)
 	defer func() {
 		pruneStat.TxFrom, pruneStat.TxTo = 0, txTo
 		if e := state.SavePruneValProgress(tx, kv.TxLookup, pruneStat); e != nil {

--- a/execution/stagedsync/stage_txlookup.go
+++ b/execution/stagedsync/stage_txlookup.go
@@ -230,8 +230,13 @@ func PruneTxLookup(s *PruneState, tx kv.RwTx, cfg TxLookupCfg, ctx context.Conte
 	if err != nil {
 		return err
 	}
+	// A record left by the pre-fix floor carries a non-zero TxFrom. Its cursor already
+	// passed rows this floor must delete, and its TxTo came from Max(blockTo) so it
+	// always covers the new Min(blockTo) — it must not short-circuit below.
+	staleFloor := prevStat != nil && prevStat.TxFrom != 0
+
 	// A completed rotation that covers current txTo — nothing more to do.
-	if prevStat != nil && prevStat.TxTo >= txTo && prevStat.ValueProgress == prune.Done {
+	if !staleFloor && prevStat != nil && prevStat.TxTo >= txTo && prevStat.ValueProgress == prune.Done {
 		return nil
 	}
 	if prevStat == nil {
@@ -240,9 +245,9 @@ func PruneTxLookup(s *PruneState, tx kv.RwTx, cfg TxLookupCfg, ctx context.Conte
 
 	// Rolling scan: preserve cursor position across txTo advances so each B-tree page
 	// is visited sequentially once per rotation instead of restarting from First() on
-	// every prune cycle. Restart on a completed rotation, and on a rotation left over
-	// from a higher floor, whose cursor already passed rows this one must delete.
-	if prevStat.ValueProgress == prune.Done || prevStat.TxFrom != 0 {
+	// every prune cycle. Restart on a completed rotation, and on one left by the
+	// pre-fix floor.
+	if prevStat.ValueProgress == prune.Done || staleFloor {
 		prevStat.ValueProgress = prune.First
 		prevStat.LastPrunedValue = nil
 	}

--- a/execution/stagedsync/stage_txlookup.go
+++ b/execution/stagedsync/stage_txlookup.go
@@ -251,6 +251,14 @@ func PruneTxLookup(s *PruneState, tx kv.RwTx, cfg TxLookupCfg, ctx context.Conte
 		prevStat.ValueProgress = prune.First
 		prevStat.LastPrunedValue = nil
 	}
+	// A rotation may span a blockTo advance: it resumes from a cursor that already
+	// passed rows the widened range now covers. Record the bound the rotation started
+	// with, so completing it does not claim coverage it never achieved.
+	rotationTxTo := txTo
+	if prevStat.ValueProgress == prune.InProgress && prevStat.TxTo > 0 && prevStat.TxTo < txTo {
+		rotationTxTo = prevStat.TxTo
+	}
+
 	// Sync range params so TableScanningPrune won't reset the cursor mid-rotation.
 	prevStat.TxFrom = 0
 	prevStat.TxTo = txTo
@@ -280,8 +288,9 @@ func PruneTxLookup(s *PruneState, tx kv.RwTx, cfg TxLookupCfg, ctx context.Conte
 	pruneCtx, pruneCancel := context.WithTimeout(ctx, pruneTimeout)
 	defer pruneCancel()
 
-	// txFrom stays 0: tableScanningPrune uses it only as a delete predicate, so any
-	// higher floor retains rows without saving traversal.
+	// txFrom stays 0: this table is keyed by txn hash, so it is not sorted by txNum.
+	// The scan cannot seek to a floor nor stop at a ceiling — it walks every key and
+	// tests it — so a floor above 0 skips rows without skipping any work.
 	pruneStat, err := prune.TableScanningPrune(pruneCtx, logPrefix, "txlookup", 0, txTo, 1,
 		logEvery, logger, nil, valsCursor, false, prevStat, prune.ValueOffset8StorageMode)
 	if err != nil {
@@ -290,7 +299,7 @@ func PruneTxLookup(s *PruneState, tx kv.RwTx, cfg TxLookupCfg, ctx context.Conte
 	logger.Debug(fmt.Sprintf("[%s] prune", logPrefix), "scanned", pruneStat.ScanCountValues,
 		"pruned", pruneStat.PruneCountValues, "status", pruneStat.ValueProgress.String(), "blockTo", blockTo)
 	defer func() {
-		pruneStat.TxFrom, pruneStat.TxTo = 0, txTo
+		pruneStat.TxFrom, pruneStat.TxTo = 0, rotationTxTo
 		if e := state.SavePruneValProgress(tx, kv.TxLookup, pruneStat); e != nil {
 			logger.Error("[snapshots] save prune val progress", "name", "txlookup", "err", e)
 		}


### PR DESCRIPTION
Cherry-pick of #23390 to release/3.5. Same code, same two bugs.

## r3.5-specific adaptations
- kept `err =` (3.5 style) where main has `err :=` at the two `UpdatePrune` sites.
- test fixture uses `memdb.NewTestDB` / `BeginRw`; 3.5 has no `temporaltest`/`datadir` in this package.