### PR TITLE
cl/beacon: preserve actionable production failures

### DIFF
--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -290,6 +290,9 @@ func (a *ApiHandler) expectedWithdrawals(
 	return cltypes.ConvertConsensusWithdrawalsToExecutionWithdrawals(consensusWithdrawals), nil
 }
 
+// feeRecipientForProposal returns the registered fee recipient. Falling back to the zero address
+// gives the proposal's fees away, so missing registrations are warned. The bounded cache suppresses
+// duplicate warnings only while a proposer remains recent.
 func (a *ApiHandler) feeRecipientForProposal(proposerIndex, targetSlot uint64) common.Address {
 	feeRecipient, registered := a.validatorParams.GetFeeRecipient(proposerIndex)
 	if registered {
@@ -297,6 +300,7 @@ func (a *ApiHandler) feeRecipientForProposal(proposerIndex, targetSlot uint64) c
 	}
 	shouldWarn := true
 	if a.warnedUnregisteredProposers != nil {
+		// Claim the warning atomically so concurrent requests for the same proposer emit one record.
 		alreadyWarned, _ := a.warnedUnregisteredProposers.ContainsOrAdd(proposerIndex, struct{}{})
 		shouldWarn = !alreadyWarned
 	}
@@ -307,6 +311,7 @@ func (a *ApiHandler) feeRecipientForProposal(proposerIndex, targetSlot uint64) c
 	return common.Address{}
 }
 
+// productionErrorSeverity defines the shared priority order for error selection and logging.
 type productionErrorSeverity uint8
 
 const (
@@ -329,6 +334,7 @@ func classifyProductionError(err error) productionErrorSeverity {
 	}
 }
 
+// mostActionableProductionError returns the higher-severity error and preserves the first on ties.
 func mostActionableProductionError(first, second error) error {
 	if classifyProductionError(second) > classifyProductionError(first) {
 		return second
@@ -384,6 +390,7 @@ func pollAssembledPayload(
 		firstErr error
 	)
 	for {
+		// A collection attempt stops the builder; do not start one after the caller has gone.
 		if ctx.Err() != nil {
 			return nil, nil, nil, nil, terminalCause(ctx, attempts, failures, firstErr)
 		}
@@ -664,6 +671,7 @@ func (a *ApiHandler) GetEthV3ValidatorBlock(
 	log.Info("[Beacon API] Found BeaconState object for block production", "slot", targetSlot, "duration", time.Since(start))
 	block, err := a.produceBlock(ctx, builderBoostFactor, baseBlockSlot, baseBlockRoot, baseState, targetSlot, randaoReveal, graffiti)
 	if err != nil {
+		// produceBlock logs production failures at its error boundary.
 		return nil, err
 	}
 

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -401,7 +401,8 @@ func pollAssembledPayload(
 				}
 			}
 			if execution_client.IsUnknownPayloadError(err) {
-				return nil, nil, nil, nil, terminalCause(ctx, attempts, failures, firstErr)
+				cause := mostActionableProductionError(firstErr, err)
+				return nil, nil, nil, nil, terminalCause(ctx, attempts, failures, cause)
 			}
 		} else if payload != nil {
 			return payload, bundles, requestsBundle, blockValue, nil

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -290,38 +290,63 @@ func (a *ApiHandler) expectedWithdrawals(
 	return cltypes.ConvertConsensusWithdrawalsToExecutionWithdrawals(consensusWithdrawals), nil
 }
 
-// feeRecipientForProposal resolves the fee recipient, warning once per proposer when there is none:
-// building with the zero address gives that block's fees away.
 func (a *ApiHandler) feeRecipientForProposal(proposerIndex, targetSlot uint64) common.Address {
 	feeRecipient, registered := a.validatorParams.GetFeeRecipient(proposerIndex)
 	if registered {
 		return feeRecipient
 	}
-	// Claimed in one step, so requests for the same slot arriving together do not each decide they
-	// are the first. Without somewhere to remember them, reporting every time beats reporting never.
-	firstTime := true
-	if a.unregisteredProposers != nil {
-		alreadyWarned, _ := a.unregisteredProposers.ContainsOrAdd(proposerIndex, struct{}{})
-		firstTime = !alreadyWarned
+	shouldWarn := true
+	if a.warnedUnregisteredProposers != nil {
+		alreadyWarned, _ := a.warnedUnregisteredProposers.ContainsOrAdd(proposerIndex, struct{}{})
+		shouldWarn = !alreadyWarned
 	}
-	if firstTime {
+	if shouldWarn {
 		log.Warn("BlockProduction: no fee recipient from prepare_beacon_proposer, using zero address",
 			"proposerIndex", proposerIndex, "slot", targetSlot)
 	}
 	return common.Address{}
 }
 
+type productionErrorSeverity uint8
+
+const (
+	productionErrorNone productionErrorSeverity = iota
+	productionErrorCanceled
+	productionErrorUnknownPayload
+	productionErrorActionable
+)
+
+func classifyProductionError(err error) productionErrorSeverity {
+	switch {
+	case err == nil:
+		return productionErrorNone
+	case errors.Is(err, context.Canceled):
+		return productionErrorCanceled
+	case execution_client.IsUnknownPayloadError(err):
+		return productionErrorUnknownPayload
+	default:
+		return productionErrorActionable
+	}
+}
+
+func mostActionableProductionError(first, second error) error {
+	if classifyProductionError(second) > classifyProductionError(first) {
+		return second
+	}
+	return first
+}
+
 // reportProductionFailure is the one place a failed production is recorded, so every exit through
 // produceBlock is covered exactly once. A caller that has already gone is not something anyone can
 // act on; an execution layer that stopped answering still is, and that arrives as a deadline.
 func reportProductionFailure(err error, targetSlot uint64) {
-	switch {
-	case err == nil:
-	case errors.Is(err, context.Canceled):
+	switch classifyProductionError(err) {
+	case productionErrorNone:
+	case productionErrorCanceled:
 		log.Debug("BlockProduction: abandoned by its caller", "err", err, "slot", targetSlot)
-	case execution_client.IsUnknownPayloadError(err):
+	case productionErrorUnknownPayload:
 		log.Warn("BlockProduction: execution payload is unknown", "err", err, "slot", targetSlot)
-	default:
+	case productionErrorActionable:
 		log.Error("BlockProduction: failed to produce block", "err", err, "slot", targetSlot)
 	}
 }
@@ -359,18 +384,12 @@ func pollAssembledPayload(
 		firstErr error
 	)
 	for {
-		// Nothing is waiting for this payload any more, and starting another collection would stop
-		// the builder and could fail for reasons of its own - contention, most likely - which would
-		// then be reported against a slot nobody is waiting for.
 		if ctx.Err() != nil {
 			return nil, nil, nil, nil, terminalCause(ctx, attempts, failures, firstErr)
 		}
 		// Grab at least once, even past the deadline, so a late produce request still gets a payload.
 		payload, bundles, requestsBundle, blockValue, err := get()
 		attempts++
-		if execution_client.IsUnknownPayloadError(err) {
-			return nil, nil, nil, nil, err
-		}
 		if err != nil {
 			// The caller's own cancellation comes back through get. That is the slot ending, not
 			// the execution layer failing, and it is not worth reporting on a healthy node. A
@@ -380,6 +399,9 @@ func pollAssembledPayload(
 				if firstErr == nil {
 					firstErr = err
 				}
+			}
+			if execution_client.IsUnknownPayloadError(err) {
+				return nil, nil, nil, nil, terminalCause(ctx, attempts, failures, firstErr)
 			}
 		} else if payload != nil {
 			return payload, bundles, requestsBundle, blockValue, nil
@@ -641,7 +663,6 @@ func (a *ApiHandler) GetEthV3ValidatorBlock(
 	log.Info("[Beacon API] Found BeaconState object for block production", "slot", targetSlot, "duration", time.Since(start))
 	block, err := a.produceBlock(ctx, builderBoostFactor, baseBlockSlot, baseBlockRoot, baseState, targetSlot, randaoReveal, graffiti)
 	if err != nil {
-		// produceBlock owns this record; repeating it here made one failure two.
 		return nil, err
 	}
 
@@ -1353,11 +1374,8 @@ func (a *ApiHandler) produceBeaconBody(
 		})
 	}
 	wg.Wait()
-	if executionErr != nil {
-		return nil, 0, executionErr
-	}
-	if syncAggregateErr != nil {
-		return nil, 0, syncAggregateErr
+	if err := mostActionableProductionError(executionErr, syncAggregateErr); err != nil {
+		return nil, 0, err
 	}
 	if executionPayload == nil {
 		return nil, 0, errors.New("failed to produce execution payload")

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -292,7 +292,7 @@ func (a *ApiHandler) expectedWithdrawals(
 
 // feeRecipientForProposal returns the registered fee recipient. Falling back to the zero address
 // gives the proposal's fees away, so missing registrations are warned. The bounded cache suppresses
-// duplicate warnings only while a proposer remains recent.
+// duplicate warnings until their entries are evicted.
 func (a *ApiHandler) feeRecipientForProposal(proposerIndex, targetSlot uint64) common.Address {
 	feeRecipient, registered := a.validatorParams.GetFeeRecipient(proposerIndex)
 	if registered {
@@ -300,7 +300,7 @@ func (a *ApiHandler) feeRecipientForProposal(proposerIndex, targetSlot uint64) c
 	}
 	shouldWarn := true
 	if a.warnedUnregisteredProposers != nil {
-		// Claim the warning atomically so concurrent requests for the same proposer emit one record.
+		// Check and add atomically so matching requests cannot both claim the same absent entry.
 		alreadyWarned, _ := a.warnedUnregisteredProposers.ContainsOrAdd(proposerIndex, struct{}{})
 		shouldWarn = !alreadyWarned
 	}
@@ -311,20 +311,38 @@ func (a *ApiHandler) feeRecipientForProposal(proposerIndex, targetSlot uint64) c
 	return common.Address{}
 }
 
-// productionErrorSeverity defines the shared priority order for error selection and logging.
+// productionErrorSeverity orders failures by diagnostic value and determines their log level.
 type productionErrorSeverity uint8
 
 const (
 	productionErrorNone productionErrorSeverity = iota
 	productionErrorCanceled
 	productionErrorUnknownPayload
+	productionErrorUnexpectedCancellation
 	productionErrorActionable
 )
 
+// productionOperationCanceledError distinguishes an internal cancellation from the request ending.
+type productionOperationCanceledError struct {
+	operation string
+	cause     error
+}
+
+func (e *productionOperationCanceledError) Error() string {
+	return e.operation + " canceled while request remained active: " + e.cause.Error()
+}
+
+func (e *productionOperationCanceledError) Unwrap() error {
+	return e.cause
+}
+
 func classifyProductionError(err error) productionErrorSeverity {
+	var operationCanceled *productionOperationCanceledError
 	switch {
 	case err == nil:
 		return productionErrorNone
+	case errors.As(err, &operationCanceled):
+		return productionErrorUnexpectedCancellation
 	case errors.Is(err, context.Canceled):
 		return productionErrorCanceled
 	case execution_client.IsUnknownPayloadError(err):
@@ -342,9 +360,8 @@ func mostActionableProductionError(first, second error) error {
 	return first
 }
 
-// reportProductionFailure is the one place a failed production is recorded, so every exit through
-// produceBlock is covered exactly once. A caller that has already gone is not something anyone can
-// act on; an execution layer that stopped answering still is, and that arrives as a deadline.
+// reportProductionFailure emits one handler-level record for each failed produceBlock call. Caller
+// cancellation is routine; failures observed while the request is active remain actionable.
 func reportProductionFailure(err error, targetSlot uint64) {
 	switch classifyProductionError(err) {
 	case productionErrorNone:
@@ -352,9 +369,18 @@ func reportProductionFailure(err error, targetSlot uint64) {
 		log.Debug("BlockProduction: abandoned by its caller", "err", err, "slot", targetSlot)
 	case productionErrorUnknownPayload:
 		log.Warn("BlockProduction: execution payload is unknown", "err", err, "slot", targetSlot)
-	case productionErrorActionable:
+	case productionErrorUnexpectedCancellation, productionErrorActionable:
 		log.Error("BlockProduction: failed to produce block", "err", err, "slot", targetSlot)
 	}
+}
+
+// preserveProductionCancellation records whether the request was active when cancellation was
+// observed.
+func preserveProductionCancellation(requestErr error, operation string, err error) error {
+	if requestErr == nil && errors.Is(err, context.Canceled) {
+		return &productionOperationCanceledError{operation: operation, cause: err}
+	}
+	return err
 }
 
 func shouldRetryGetPayload(now, deadline time.Time) bool {
@@ -398,18 +424,14 @@ func pollAssembledPayload(
 		payload, bundles, requestsBundle, blockValue, err := get()
 		attempts++
 		if err != nil {
-			// The caller's own cancellation comes back through get. That is the slot ending, not
-			// the execution layer failing, and it is not worth reporting on a healthy node. A
-			// failure that happened before it still is.
-			if ctx.Err() == nil || !errors.Is(err, ctx.Err()) {
+			requestErr := ctx.Err()
+			if requestErr == nil || !errors.Is(err, requestErr) {
 				failures++
-				if firstErr == nil {
-					firstErr = err
-				}
+				failure := preserveProductionCancellation(requestErr, "payload collection", err)
+				firstErr = mostActionableProductionError(firstErr, failure)
 			}
 			if execution_client.IsUnknownPayloadError(err) {
-				cause := mostActionableProductionError(firstErr, err)
-				return nil, nil, nil, nil, terminalCause(ctx, attempts, failures, cause)
+				return nil, nil, nil, nil, terminalCause(ctx, attempts, failures, firstErr)
 			}
 		} else if payload != nil {
 			return payload, bundles, requestsBundle, blockValue, nil
@@ -1179,7 +1201,8 @@ func (a *ApiHandler) produceBeaconBody(
 			stateVersion,
 		)
 		if err != nil {
-			executionErr = fmt.Errorf("produceBeaconBody: forkchoice update: %w", err)
+			executionErr = fmt.Errorf("produceBeaconBody: %w",
+				preserveProductionCancellation(ctx.Err(), "forkchoice update", err))
 			return
 		}
 		if len(idBytes) == 0 {

--- a/cl/beacon/handler/block_production_test.go
+++ b/cl/beacon/handler/block_production_test.go
@@ -489,6 +489,25 @@ func TestPollAssembledPayloadKeepsFailureBeforeUnknownPayload(t *testing.T) {
 	require.Equal(t, 2, calls)
 }
 
+func TestPollAssembledPayloadDoesNotTreatBuilderCancellationAsCallerCancellation(t *testing.T) {
+	now := time.Now()
+	window := blockBuilderWindow{firstGetAt: now, pollUntil: now.Add(time.Second)}
+	calls := 0
+
+	_, _, _, _, err := pollAssembledPayload(t.Context(), window, time.Millisecond,
+		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+			calls++
+			if calls == 1 {
+				return nil, nil, nil, nil, context.Canceled
+			}
+			return nil, nil, nil, nil, &engine_helpers.UnknownPayloadErr
+		})
+
+	require.True(t, execution_client.IsUnknownPayloadError(err))
+	require.NotErrorIs(t, err, context.Canceled)
+	require.Equal(t, 2, calls)
+}
+
 func TestProductionReportsUnknownPayloadOnce(t *testing.T) {
 	logs := captureProductionLogs(t)
 

--- a/cl/beacon/handler/block_production_test.go
+++ b/cl/beacon/handler/block_production_test.go
@@ -467,10 +467,32 @@ func TestPollAssembledPayloadStopsOnUnknownPayload(t *testing.T) {
 	}
 }
 
+func TestPollAssembledPayloadKeepsFailureBeforeUnknownPayload(t *testing.T) {
+	firstErr := errors.New("EL busy")
+	now := time.Now()
+	window := blockBuilderWindow{firstGetAt: now, pollUntil: now.Add(time.Second)}
+	calls := 0
+
+	payload, _, _, _, err := pollAssembledPayload(t.Context(), window, time.Millisecond,
+		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+			calls++
+			if calls == 1 {
+				return nil, nil, nil, nil, firstErr
+			}
+			return nil, nil, nil, nil, &engine_helpers.UnknownPayloadErr
+		})
+
+	require.ErrorIs(t, err, firstErr)
+	require.False(t, execution_client.IsUnknownPayloadError(err))
+	require.ErrorContains(t, err, "2 attempts, 2 failed")
+	require.Nil(t, payload)
+	require.Equal(t, 2, calls)
+}
+
 func TestProductionReportsUnknownPayloadOnce(t *testing.T) {
 	logs := captureProductionLogs(t)
 
-	err := produceBlockWithFailingCollection(t, t.Context(), &engine_helpers.UnknownPayloadErr)
+	err := produceBlockWithFailingCollection(t, t.Context(), &engine_helpers.UnknownPayloadErr, nil)
 	require.Error(t, err)
 
 	captured := logs()
@@ -998,20 +1020,19 @@ func TestPollAssembledPayloadStillReportsFailuresThatPrecededTheCancellation(t *
 	require.Contains(t, err.Error(), "boom")
 }
 
-func TestFeeRecipientWarnsOncePerProposer(t *testing.T) {
+func TestFeeRecipientDeduplicatesRecentWarnings(t *testing.T) {
 	logs := captureProductionLogs(t)
-	warned, err := lru.New[uint64, struct{}]("unregisteredProposers", 8)
+	warned, err := lru.New[uint64, struct{}]("warnedUnregisteredProposers", 8)
 	require.NoError(t, err)
 	params := validator_params.NewValidatorParams()
-	a := &ApiHandler{validatorParams: params, unregisteredProposers: warned}
+	a := &ApiHandler{validatorParams: params, warnedUnregisteredProposers: warned}
 
 	registered := common.Address{0x11}
 	params.SetFeeRecipient(7, registered)
 	require.Equal(t, registered, a.feeRecipientForProposal(7, 1))
 	require.NotContains(t, logs(), "lvl=warn", "a registered proposer must stay quiet")
 
-	// Giving the fees away is worth saying, but only once: a chain whose validator never registers
-	// one would otherwise warn on every proposal.
+	// Repeated requests for a proposer share one warning while its entry remains cached.
 	require.Equal(t, common.Address{}, a.feeRecipientForProposal(9, 2))
 	require.Equal(t, common.Address{}, a.feeRecipientForProposal(9, 3))
 	require.Equal(t, 1, strings.Count(logs(), "lvl=warn"))
@@ -1019,16 +1040,15 @@ func TestFeeRecipientWarnsOncePerProposer(t *testing.T) {
 	require.Equal(t, common.Address{}, a.feeRecipientForProposal(10, 4))
 	require.Equal(t, 2, strings.Count(logs(), "lvl=warn"), "a different proposer is worth saying again")
 
-	// Alternating proposers must not each reset the other: 9 has already been reported.
 	require.Equal(t, common.Address{}, a.feeRecipientForProposal(9, 5))
 	require.Equal(t, 2, strings.Count(logs(), "lvl=warn"))
 }
 
-func TestFeeRecipientWarnsOncePerProposerUnderConcurrentRequests(t *testing.T) {
+func TestFeeRecipientDeduplicatesConcurrentWarnings(t *testing.T) {
 	logs := captureProductionLogs(t)
-	warned, err := lru.New[uint64, struct{}]("unregisteredProposers", 8)
+	warned, err := lru.New[uint64, struct{}]("warnedUnregisteredProposers", 8)
 	require.NoError(t, err)
-	a := &ApiHandler{validatorParams: validator_params.NewValidatorParams(), unregisteredProposers: warned}
+	a := &ApiHandler{validatorParams: validator_params.NewValidatorParams(), warnedUnregisteredProposers: warned}
 
 	// Several block template requests for the same slot arrive together, and each would otherwise
 	// find the proposer absent and report it.
@@ -1052,8 +1072,6 @@ func TestPollAssembledPayloadDoesNotCollectAfterTheCallerHasGone(t *testing.T) {
 	_, _, _, _, err := pollAssembledPayload(ctx, window, time.Microsecond,
 		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
 			calls++
-			// The execution module takes its semaphore before it looks at a context, so a request
-			// made after the caller has gone comes back as contention rather than cancellation.
 			return nil, nil, nil, nil, errors.New("execution module is busy")
 		})
 
@@ -1062,10 +1080,7 @@ func TestPollAssembledPayloadDoesNotCollectAfterTheCallerHasGone(t *testing.T) {
 	require.NotContains(t, logs(), "lvl=eror")
 }
 
-// produceBlockWithFailingCollection drives a real production through to the payload collection and
-// makes that collection fail the given way, so the records the whole request emits are observable
-// rather than only those of the polling loop.
-func produceBlockWithFailingCollection(t *testing.T, ctx context.Context, collect error) error {
+func produceBlockWithFailingCollection(t *testing.T, ctx context.Context, collect, syncFailure error) error {
 	t.Helper()
 	ctrl := gomock.NewController(t)
 	_, _, _, _, postState, handler, _, _, _, _ := setupTestingHandler(t, clparams.ElectraVersion, log.Root(), false)
@@ -1077,6 +1092,12 @@ func produceBlockWithFailingCollection(t *testing.T, ctx context.Context, collec
 		Return(nil, nil, nil, nil, collect).AnyTimes()
 	engine.EXPECT().SupportInsertion().Return(true).AnyTimes()
 	handler.engine = engine
+	if syncFailure != nil {
+		syncPool := sync_pool_mock.NewMockSyncContributionPool(ctrl)
+		syncPool.EXPECT().GetSyncAggregate(gomock.Any(), gomock.Any()).
+			Return(nil, syncFailure).AnyTimes()
+		handler.syncMessagePool = syncPool
+	}
 
 	_, err := handler.produceBlock(ctx, 1, postState.Slot(), common.Hash{0x41}, postState,
 		postState.Slot()+1, common.Bytes96{}, common.Hash{})
@@ -1087,7 +1108,7 @@ func TestProductionReportsAFailedCollectionExactlyOnce(t *testing.T) {
 	ctx := t.Context()
 	logs := captureProductionLogs(t)
 
-	err := produceBlockWithFailingCollection(t, ctx, errors.New("boom"))
+	err := produceBlockWithFailingCollection(t, ctx, errors.New("boom"), nil)
 	require.Error(t, err)
 
 	// One record for the whole request, and it carries the cause: the generic failure the caller
@@ -1124,27 +1145,30 @@ func TestProductionReportsMissingPayloadIDExactlyOnce(t *testing.T) {
 	require.NotContains(t, captured, "failed to produce execution payload")
 }
 
-func TestProductionCollectsTwoFailingBodyStepsWithoutRacing(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	_, _, _, _, postState, handler, _, _, _, _ := setupTestingHandler(t, clparams.ElectraVersion, log.Root(), false)
+func TestProductionPrefersFirstOfConcurrentActionableFailures(t *testing.T) {
+	boom := errors.New("boom")
+	err := produceBlockWithFailingCollection(t, t.Context(), boom, errors.New("no aggregate"))
+	require.ErrorIs(t, err, boom)
+}
 
-	engine := execution_client.NewMockExecutionEngine(ctrl)
-	engine.EXPECT().ForkChoiceUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return([]byte{1, 2, 3, 4, 5, 6, 7, 8}, nil).AnyTimes()
-	engine.EXPECT().GetAssembledBlock(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(nil, nil, nil, nil, errors.New("boom")).AnyTimes()
-	engine.EXPECT().SupportInsertion().Return(true).AnyTimes()
-	handler.engine = engine
+func TestProductionReportsActionableConcurrentFailure(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		collectionErr error
+	}{
+		{name: "canceled payload collection", collectionErr: context.Canceled},
+		{name: "unknown execution payload", collectionErr: &engine_helpers.UnknownPayloadErr},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			logs := captureProductionLogs(t)
+			err := produceBlockWithFailingCollection(t, t.Context(), tc.collectionErr, errors.New("no aggregate"))
+			require.ErrorContains(t, err, "no aggregate")
 
-	// The body steps run concurrently, so each needs somewhere of its own to put its failure.
-	syncPool := sync_pool_mock.NewMockSyncContributionPool(ctrl)
-	syncPool.EXPECT().GetSyncAggregate(gomock.Any(), gomock.Any()).
-		Return(nil, errors.New("no aggregate")).AnyTimes()
-	handler.syncMessagePool = syncPool
-
-	_, err := handler.produceBlock(t.Context(), 1, postState.Slot(), common.Hash{0x41}, postState,
-		postState.Slot()+1, common.Bytes96{}, common.Hash{})
-	require.Error(t, err)
+			captured := logs()
+			require.Equal(t, 1, strings.Count(captured, "lvl=eror"), "records:\n"+captured)
+			require.Contains(t, captured, "no aggregate")
+		})
+	}
 }
 
 func TestProductionSaysNothingWhenTheRequestWasAbandoned(t *testing.T) {
@@ -1152,7 +1176,7 @@ func TestProductionSaysNothingWhenTheRequestWasAbandoned(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	err := produceBlockWithFailingCollection(t, ctx, context.Canceled)
+	err := produceBlockWithFailingCollection(t, ctx, context.Canceled, nil)
 	require.Error(t, err)
 
 	// A validator client that disconnects, or a node shutting down, is routine. Nothing about it is

--- a/cl/beacon/handler/block_production_test.go
+++ b/cl/beacon/handler/block_production_test.go
@@ -494,6 +494,7 @@ func TestPollAssembledPayloadDoesNotTreatBuilderCancellationAsCallerCancellation
 	window := blockBuilderWindow{firstGetAt: now, pollUntil: now.Add(time.Second)}
 	calls := 0
 
+	// The request remains live while the builder's own operation is canceled.
 	_, _, _, _, err := pollAssembledPayload(t.Context(), window, time.Millisecond,
 		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
 			calls++
@@ -1059,6 +1060,7 @@ func TestFeeRecipientDeduplicatesRecentWarnings(t *testing.T) {
 	require.Equal(t, common.Address{}, a.feeRecipientForProposal(10, 4))
 	require.Equal(t, 2, strings.Count(logs(), "lvl=warn"), "a different proposer is worth saying again")
 
+	// Another proposer must not reset a cached warning while capacity remains.
 	require.Equal(t, common.Address{}, a.feeRecipientForProposal(9, 5))
 	require.Equal(t, 2, strings.Count(logs(), "lvl=warn"))
 }
@@ -1099,6 +1101,8 @@ func TestPollAssembledPayloadDoesNotCollectAfterTheCallerHasGone(t *testing.T) {
 	require.NotContains(t, logs(), "lvl=eror")
 }
 
+// produceBlockWithFailingCollection exercises the production error boundary with controlled
+// execution-payload and sync-aggregate failures.
 func produceBlockWithFailingCollection(t *testing.T, ctx context.Context, collect, syncFailure error) error {
 	t.Helper()
 	ctrl := gomock.NewController(t)

--- a/cl/beacon/handler/block_production_test.go
+++ b/cl/beacon/handler/block_production_test.go
@@ -489,7 +489,7 @@ func TestPollAssembledPayloadKeepsFailureBeforeUnknownPayload(t *testing.T) {
 	require.Equal(t, 2, calls)
 }
 
-func TestPollAssembledPayloadDoesNotTreatBuilderCancellationAsCallerCancellation(t *testing.T) {
+func TestPollAssembledPayloadPreservesBuilderCancellationWhileRequestRemainsActive(t *testing.T) {
 	now := time.Now()
 	window := blockBuilderWindow{firstGetAt: now, pollUntil: now.Add(time.Second)}
 	calls := 0
@@ -504,9 +504,31 @@ func TestPollAssembledPayloadDoesNotTreatBuilderCancellationAsCallerCancellation
 			return nil, nil, nil, nil, &engine_helpers.UnknownPayloadErr
 		})
 
-	require.True(t, execution_client.IsUnknownPayloadError(err))
-	require.NotErrorIs(t, err, context.Canceled)
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, execution_client.IsUnknownPayloadError(err))
+	require.ErrorContains(t, err, "payload collection canceled while request remained active")
 	require.Equal(t, 2, calls)
+}
+
+func TestProductionReportsBuilderCancellationAfterPollDeadline(t *testing.T) {
+	logs := captureProductionLogs(t)
+	past := time.Now().Add(-time.Second)
+	window := blockBuilderWindow{firstGetAt: past, pollUntil: past}
+	calls := 0
+
+	_, _, _, _, err := pollAssembledPayload(t.Context(), window, time.Millisecond,
+		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+			calls++
+			return nil, nil, nil, nil, context.Canceled
+		})
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 1, calls)
+	reportProductionFailure(err, 123)
+
+	captured := logs()
+	require.Contains(t, captured, "lvl=eror")
+	require.Contains(t, captured, "payload collection canceled while request remained active")
 }
 
 func TestProductionReportsUnknownPayloadOnce(t *testing.T) {
@@ -1040,9 +1062,9 @@ func TestPollAssembledPayloadStillReportsFailuresThatPrecededTheCancellation(t *
 	require.Contains(t, err.Error(), "boom")
 }
 
-func TestFeeRecipientDeduplicatesRecentWarnings(t *testing.T) {
+func TestFeeRecipientDeduplicatesWarningsWhileCached(t *testing.T) {
 	logs := captureProductionLogs(t)
-	warned, err := lru.New[uint64, struct{}]("warnedUnregisteredProposers", 8)
+	warned, err := lru.New[uint64, struct{}]("unregisteredProposers", 2)
 	require.NoError(t, err)
 	params := validator_params.NewValidatorParams()
 	a := &ApiHandler{validatorParams: params, warnedUnregisteredProposers: warned}
@@ -1063,11 +1085,16 @@ func TestFeeRecipientDeduplicatesRecentWarnings(t *testing.T) {
 	// Another proposer must not reset a cached warning while capacity remains.
 	require.Equal(t, common.Address{}, a.feeRecipientForProposal(9, 5))
 	require.Equal(t, 2, strings.Count(logs(), "lvl=warn"))
+
+	// Once capacity evicts an entry, that proposer can produce another useful warning.
+	require.Equal(t, common.Address{}, a.feeRecipientForProposal(11, 6))
+	require.Equal(t, common.Address{}, a.feeRecipientForProposal(9, 7))
+	require.Equal(t, 4, strings.Count(logs(), "lvl=warn"))
 }
 
 func TestFeeRecipientDeduplicatesConcurrentWarnings(t *testing.T) {
 	logs := captureProductionLogs(t)
-	warned, err := lru.New[uint64, struct{}]("warnedUnregisteredProposers", 8)
+	warned, err := lru.New[uint64, struct{}]("unregisteredProposers", 8)
 	require.NoError(t, err)
 	a := &ApiHandler{validatorParams: validator_params.NewValidatorParams(), warnedUnregisteredProposers: warned}
 
@@ -1141,9 +1168,8 @@ func TestProductionReportsAFailedCollectionExactlyOnce(t *testing.T) {
 	require.Contains(t, captured, "boom")
 }
 
-func TestProductionReportsMissingPayloadIDExactlyOnce(t *testing.T) {
-	ctx := t.Context()
-	logs := captureProductionLogs(t)
+func produceBlockWithForkChoiceResult(t *testing.T, ctx context.Context, payloadID []byte, forkChoiceErr error) error {
+	t.Helper()
 	ctrl := gomock.NewController(t)
 	_, _, _, _, postState, handler, _, _, _, validatorParams := setupTestingHandler(t, clparams.ElectraVersion, log.Root(), false)
 	targetSlot := postState.Slot() + 1
@@ -1153,12 +1179,28 @@ func TestProductionReportsMissingPayloadIDExactlyOnce(t *testing.T) {
 
 	engine := execution_client.NewMockExecutionEngine(ctrl)
 	engine.EXPECT().ForkChoiceUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(nil, nil).AnyTimes()
+		Return(payloadID, forkChoiceErr).AnyTimes()
 	engine.EXPECT().SupportInsertion().Return(true).AnyTimes()
 	handler.engine = engine
 
 	_, err = handler.produceBlock(ctx, 1, postState.Slot(), common.Hash{0x41}, postState,
 		targetSlot, common.Bytes96{}, common.Hash{})
+	return err
+}
+
+func TestProductionReportsForkChoiceCancellationWhileRequestRemainsActive(t *testing.T) {
+	logs := captureProductionLogs(t)
+	err := produceBlockWithForkChoiceResult(t, t.Context(), nil, context.Canceled)
+	require.ErrorIs(t, err, context.Canceled)
+
+	captured := logs()
+	require.Equal(t, 1, strings.Count(captured, "lvl=eror"), "records:\n"+captured)
+	require.Contains(t, captured, "forkchoice update canceled while request remained active")
+}
+
+func TestProductionReportsMissingPayloadIDExactlyOnce(t *testing.T) {
+	logs := captureProductionLogs(t)
+	err := produceBlockWithForkChoiceResult(t, t.Context(), nil, nil)
 	require.ErrorContains(t, err, "forkchoice update returned no payload ID")
 
 	captured := logs()

--- a/cl/beacon/handler/handler.go
+++ b/cl/beacon/handler/handler.go
@@ -107,7 +107,8 @@ type ApiHandler struct {
 	logger    log.Logger
 
 	// Validator data structures
-	validatorParams                    *validator_params.ValidatorParams
+	validatorParams *validator_params.ValidatorParams
+	// warnedUnregisteredProposers bounds the set of recent proposers whose warnings are deduplicated.
 	warnedUnregisteredProposers        *lru.Cache[uint64, struct{}]
 	blobBundles                        *lru.Cache[common.Bytes48, BlobBundle] // Keep recent bundled blobs from the execution layer.
 	engine                             execution_client.ExecutionEngine

--- a/cl/beacon/handler/handler.go
+++ b/cl/beacon/handler/handler.go
@@ -108,7 +108,7 @@ type ApiHandler struct {
 
 	// Validator data structures
 	validatorParams *validator_params.ValidatorParams
-	// warnedUnregisteredProposers bounds the set of recent proposers whose warnings are deduplicated.
+	// Bounded cache for fee-recipient warnings; eviction permits a later warning for a proposer.
 	warnedUnregisteredProposers        *lru.Cache[uint64, struct{}]
 	blobBundles                        *lru.Cache[common.Bytes48, BlobBundle] // Keep recent bundled blobs from the execution layer.
 	engine                             execution_client.ExecutionEngine
@@ -201,7 +201,8 @@ func NewApiHandler(
 		blobSnapshots = caplinSnapshots
 	}
 
-	warnedUnregisteredProposers, err := lru.New[uint64, struct{}]("warnedUnregisteredProposers", 1024)
+	// Keep the metric label stable because dashboards can depend on it.
+	warnedUnregisteredProposers, err := lru.New[uint64, struct{}]("unregisteredProposers", 1024)
 	if err != nil {
 		panic(err)
 	}

--- a/cl/beacon/handler/handler.go
+++ b/cl/beacon/handler/handler.go
@@ -107,10 +107,8 @@ type ApiHandler struct {
 	logger    log.Logger
 
 	// Validator data structures
-	validatorParams *validator_params.ValidatorParams
-	// unregisteredProposers remembers which proposers have already been warned about, so the
-	// warning is once per proposer rather than once per proposal.
-	unregisteredProposers              *lru.Cache[uint64, struct{}]
+	validatorParams                    *validator_params.ValidatorParams
+	warnedUnregisteredProposers        *lru.Cache[uint64, struct{}]
 	blobBundles                        *lru.Cache[common.Bytes48, BlobBundle] // Keep recent bundled blobs from the execution layer.
 	engine                             execution_client.ExecutionEngine
 	elClientVersion                    atomic.Pointer[engine_types.ClientVersionV1] // Cached execution client version for default graffiti.
@@ -202,7 +200,7 @@ func NewApiHandler(
 		blobSnapshots = caplinSnapshots
 	}
 
-	unregisteredProposers, err := lru.New[uint64, struct{}]("unregisteredProposers", 1024)
+	warnedUnregisteredProposers, err := lru.New[uint64, struct{}]("warnedUnregisteredProposers", 1024)
 	if err != nil {
 		panic(err)
 	}
@@ -234,7 +232,7 @@ func NewApiHandler(
 		caplinStateSnapshots:               caplinStateSnapshots,
 		peerDas:                            peerDas,
 		slotWaitedForAttestationProduction: slotWaitedForAttestationProduction,
-		unregisteredProposers:              unregisteredProposers,
+		warnedUnregisteredProposers:        warnedUnregisteredProposers,
 		randaoMixesPool: sync.Pool{New: func() any {
 			return solid.NewHashVector(int(beaconChainConfig.EpochsPerHistoricalVector))
 		}},


### PR DESCRIPTION
## Summary

- preserve the most diagnostic failure across payload polling and concurrent block-body production
- distinguish caller cancellation from fork-choice or payload-collection cancellation while the request remains active
- use one diagnostic priority for error selection and logging: caller cancellation is debug, unknown payload is a warning, and unexpected internal cancellation or a concrete failure is an error
- describe the bounded fee-recipient warning cache accurately without changing its metric label

Follow-up to #23274.

## TDD

Regression tests were added before their fixes and cover:

- an actionable polling failure followed by unknown payload
- internal payload-collection cancellation followed by unknown payload or the poll deadline while the request remains active
- fork-choice cancellation while the request remains active
- a lower-priority execution failure concurrent with an actionable sync-aggregate failure
- first-error preservation when concurrent failures have equal priority

