### PR TITLE
execution/commitment, execution/stagedsync: stop allocating an arena per block

### DIFF
--- a/execution/commitment/parallel_update.go
+++ b/execution/commitment/parallel_update.go
@@ -24,14 +24,18 @@ type plainKeyArena struct {
 	buf []byte
 }
 
-const plainKeyArenaChunk = 64 * 1024
+// Grows geometrically for the same reason the prefix arena does: a fresh buffer is
+// built per block, so a block touching two keys must not pay the full chunk.
+const plainKeyArenaChunkMin = 1024
+const plainKeyArenaChunkMax = 64 * 1024
 
 func (a *plainKeyArena) intern(b []byte) []byte {
-	if len(b) > plainKeyArenaChunk {
+	if len(b) > plainKeyArenaChunkMax {
 		return append([]byte(nil), b...)
 	}
 	if cap(a.buf)-len(a.buf) < len(b) {
-		a.buf = make([]byte, 0, plainKeyArenaChunk)
+		next := max(cap(a.buf)*2, plainKeyArenaChunkMin)
+		a.buf = make([]byte, 0, min(max(next, len(b)), plainKeyArenaChunkMax))
 	}
 	off := len(a.buf)
 	a.buf = append(a.buf, b...)

--- a/execution/commitment/prefix_trie.go
+++ b/execution/commitment/prefix_trie.go
@@ -22,8 +22,17 @@ import (
 	"github.com/erigontech/erigon/execution/commitment/nibbles"
 )
 
-const prefixSlabSize = 16384
-const prefixExtChunkSize = 64 * 1024
+// Slabs and ext chunks grow geometrically: a batch touching a handful of keys must
+// not pay for a peak-sized arena, because a fresh Updates is built per block.
+const prefixSlabMin = 256
+const prefixSlabMax = 16384
+
+// Capacity resetArena keeps; anything past it is released so the arena settles at
+// its steady-state size rather than its peak.
+const prefixSlabRetain = 16384
+
+const prefixExtChunkMin = 4 * 1024
+const prefixExtChunkMax = 64 * 1024
 
 type prefixNode struct {
 	// ext is arena-backed: it stays valid only until the owning trie's Reset, which
@@ -36,34 +45,31 @@ type prefixNode struct {
 	bitmap       uint16
 }
 
-type prefixSlab struct {
-	nodes [prefixSlabSize]prefixNode
-}
-
 type prefixArena struct {
-	slabs       []*prefixSlab
+	slabs       [][]prefixNode
 	slabIdx     int
 	nextIdx     int
+	priorNodes  int // nodes held by slabs[:slabIdx], so nodeCount stays O(1)
 	extChunks   [][]byte
 	extChunkIdx int
 }
 
 func newPrefixArena() *prefixArena {
-	return &prefixArena{
-		slabs:     []*prefixSlab{new(prefixSlab)},
-		extChunks: [][]byte{make([]byte, 0, prefixExtChunkSize)},
-	}
+	return &prefixArena{slabs: [][]prefixNode{make([]prefixNode, prefixSlabMin)}}
 }
 
 func (a *prefixArena) allocNode() *prefixNode {
-	if a.nextIdx >= prefixSlabSize {
+	slab := a.slabs[a.slabIdx]
+	if a.nextIdx >= len(slab) {
+		a.priorNodes += len(slab)
 		a.slabIdx++
 		if a.slabIdx >= len(a.slabs) {
-			a.slabs = append(a.slabs, new(prefixSlab))
+			a.slabs = append(a.slabs, make([]prefixNode, min(len(slab)*2, prefixSlabMax)))
 		}
+		slab = a.slabs[a.slabIdx]
 		a.nextIdx = 0
 	}
-	n := &a.slabs[a.slabIdx].nodes[a.nextIdx]
+	n := &slab[a.nextIdx]
 	a.nextIdx++
 	*n = prefixNode{}
 	return n
@@ -74,16 +80,19 @@ func (a *prefixArena) allocExt(b []byte) []byte {
 	if len(b) == 0 {
 		return nil
 	}
-	if len(b) > prefixExtChunkSize {
+	if len(b) > prefixExtChunkMax {
 		own := make([]byte, len(b))
 		copy(own, b)
 		return own
+	}
+	if len(a.extChunks) == 0 {
+		a.extChunks = append(a.extChunks, make([]byte, 0, max(prefixExtChunkMin, len(b))))
 	}
 	chunk := a.extChunks[a.extChunkIdx]
 	if cap(chunk)-len(chunk) < len(b) {
 		a.extChunkIdx++
 		if a.extChunkIdx >= len(a.extChunks) {
-			a.extChunks = append(a.extChunks, make([]byte, 0, prefixExtChunkSize))
+			a.extChunks = append(a.extChunks, make([]byte, 0, min(max(cap(chunk)*2, len(b)), prefixExtChunkMax)))
 		}
 		chunk = a.extChunks[a.extChunkIdx]
 	}
@@ -95,17 +104,23 @@ func (a *prefixArena) allocExt(b []byte) []byte {
 
 func (a *prefixArena) resetArena() {
 	for i := 0; i <= a.slabIdx && i < len(a.slabs); i++ {
-		limit := prefixSlabSize
+		limit := len(a.slabs[i])
 		if i == a.slabIdx {
 			limit = a.nextIdx
 		}
-		clear(a.slabs[i].nodes[:limit])
+		clear(a.slabs[i][:limit])
+	}
+	keep, held := 1, len(a.slabs[0])
+	for keep < len(a.slabs) && held < prefixSlabRetain {
+		held += len(a.slabs[keep])
+		keep++
 	}
 	// nil trailing slabs first: reslicing alone keeps them GC-reachable via the backing array.
-	clear(a.slabs[1:])
-	a.slabs = a.slabs[:1]
+	clear(a.slabs[keep:])
+	a.slabs = a.slabs[:keep]
 	a.slabIdx = 0
 	a.nextIdx = 0
+	a.priorNodes = 0
 
 	for i := range a.extChunks {
 		a.extChunks[i] = a.extChunks[i][:0]
@@ -114,7 +129,7 @@ func (a *prefixArena) resetArena() {
 }
 
 func (a *prefixArena) nodeCount() int {
-	return a.slabIdx*prefixSlabSize + a.nextIdx
+	return a.priorNodes + a.nextIdx
 }
 
 func popcount(n *prefixNode) int {

--- a/execution/commitment/prefix_trie.go
+++ b/execution/commitment/prefix_trie.go
@@ -113,6 +113,13 @@ func (a *prefixArena) resetArena() {
 		held += len(a.slabs[keep])
 		keep++
 	}
+	// The ramp sums to less than one max slab, so an arena that reached a max-sized
+	// slab must keep that slab instead: keeping the ramp would re-allocate it on
+	// every reset, which is the per-batch allocation this arena exists to avoid.
+	if len(a.slabs[0]) < prefixSlabMax && keep < len(a.slabs) && len(a.slabs[keep]) == prefixSlabMax {
+		a.slabs[0] = a.slabs[keep]
+		keep = 1
+	}
 	// nil trailing slabs first: reslicing alone keeps them GC-reachable via the backing array.
 	clear(a.slabs[keep:])
 	a.slabs = a.slabs[:keep]
@@ -152,6 +159,10 @@ func newPrefixTrie() *prefixTrie {
 }
 
 func (t *prefixTrie) Reset() {
+	// Past len, visited still holds nodes from earlier inserts; a single one keeps a
+	// released slab's whole backing array reachable.
+	clear(t.visited[:cap(t.visited)])
+	t.visited = t.visited[:0]
 	t.arena.resetArena()
 	t.root = t.arena.allocNode()
 }

--- a/execution/commitment/prefix_trie.go
+++ b/execution/commitment/prefix_trie.go
@@ -27,10 +27,6 @@ import (
 const prefixSlabMin = 256
 const prefixSlabMax = 16384
 
-// Capacity resetArena keeps; anything past it is released so the arena settles at
-// its steady-state size rather than its peak.
-const prefixSlabRetain = 16384
-
 const prefixExtChunkMin = 4 * 1024
 const prefixExtChunkMax = 64 * 1024
 
@@ -110,8 +106,10 @@ func (a *prefixArena) resetArena() {
 		}
 		clear(a.slabs[i][:limit])
 	}
+	// Keep at most one max-slab's worth of capacity so the arena settles at its
+	// steady-state size; releasing the rest is what stops a peak from being pinned.
 	keep, held := 1, len(a.slabs[0])
-	for keep < len(a.slabs) && held < prefixSlabRetain {
+	for keep < len(a.slabs) && held+len(a.slabs[keep]) <= prefixSlabMax {
 		held += len(a.slabs[keep])
 		keep++
 	}

--- a/execution/commitment/prefix_trie_test.go
+++ b/execution/commitment/prefix_trie_test.go
@@ -255,7 +255,7 @@ func TestPrefixTrieExtSurvivesChunkBoundary(t *testing.T) {
 	tr := newPrefixTrie()
 
 	const keyLen = 32
-	const total = 2 * prefixExtChunkSize / keyLen
+	const total = 2 * prefixExtChunkMax / keyLen
 	want := make(map[string]bool, total)
 	for i := range total {
 		k := make([]byte, keyLen)
@@ -300,15 +300,50 @@ func TestPrefixTrieArenaReusesExtChunkBacking(t *testing.T) {
 
 func TestPrefixTrieArenaSpansMultipleSlabs(t *testing.T) {
 	tr := newPrefixTrie()
-	for range prefixSlabSize + 5 {
+	for range prefixSlabMax + 5 {
 		tr.arena.allocNode()
 	}
-	assert.Equal(t, prefixSlabSize+5+1 /*root*/, tr.arena.nodeCount())
+	assert.Equal(t, prefixSlabMax+5+1 /*root*/, tr.arena.nodeCount())
 	assert.GreaterOrEqual(t, len(tr.arena.slabs), 2)
 
 	tr.Reset()
 	assert.Equal(t, 1, tr.arena.nodeCount())
-	assert.Len(t, tr.arena.slabs, 1, "Reset must trim trailing slabs")
+	held := 0
+	for _, s := range tr.arena.slabs {
+		held += len(s)
+	}
+	assert.GreaterOrEqual(t, held, prefixSlabRetain, "Reset must keep the retained capacity")
+	assert.Less(t, held-len(tr.arena.slabs[len(tr.arena.slabs)-1]), prefixSlabRetain,
+		"Reset must drop every slab past the retention budget")
+}
+
+func TestPrefixArenaGrowsGeometrically(t *testing.T) {
+	a := newPrefixArena()
+	require.Len(t, a.slabs, 1)
+	require.Len(t, a.slabs[0], prefixSlabMin, "a fresh arena must not pay for a peak-sized slab")
+	require.Empty(t, a.extChunks, "a fresh arena must not pay for an ext chunk")
+
+	for range prefixSlabMin + 1 {
+		a.allocNode()
+	}
+	require.Len(t, a.slabs, 2)
+	require.Len(t, a.slabs[1], 2*prefixSlabMin, "each slab must double the previous one")
+	require.Equal(t, prefixSlabMin+1, a.nodeCount())
+
+	a.allocExt([]byte{1, 2, 3})
+	require.Len(t, a.extChunks, 1)
+	require.Equal(t, prefixExtChunkMin, cap(a.extChunks[0]), "the first ext chunk must start small")
+}
+
+func TestPrefixArenaSlabSizeIsCapped(t *testing.T) {
+	a := newPrefixArena()
+	for range 4 * prefixSlabMax {
+		a.allocNode()
+	}
+	for i, s := range a.slabs {
+		require.LessOrEqual(t, len(s), prefixSlabMax, "slab %d exceeds the cap", i)
+	}
+	require.Equal(t, 4*prefixSlabMax, a.nodeCount())
 }
 
 func TestPrefixTrieWalkDFSOrder(t *testing.T) {
@@ -504,17 +539,16 @@ func TestPrefixTrieInsertDuplicateMerges(t *testing.T) {
 func TestPrefixArenaAllocExt_OversizeAndReuse(t *testing.T) {
 	t.Run("extension larger than a chunk gets its own backing", func(t *testing.T) {
 		a := newPrefixArena()
-		big := bytes.Repeat([]byte{0x7}, prefixExtChunkSize+1)
+		big := bytes.Repeat([]byte{0x7}, prefixExtChunkMax+1)
 		got := a.allocExt(big)
 		require.Equal(t, big, got)
 		require.Equal(t, len(got), cap(got))
-		require.Len(t, a.extChunks, 1, "an oversize extension must not consume a chunk")
-		require.Empty(t, a.extChunks[0], "the current chunk must be untouched")
+		require.Empty(t, a.extChunks, "an oversize extension must not force a chunk into being")
 	})
 
 	t.Run("reset refills existing chunks instead of reallocating", func(t *testing.T) {
 		a := newPrefixArena()
-		block := make([]byte, prefixExtChunkSize/4)
+		block := make([]byte, prefixExtChunkMax/4)
 		for range 12 {
 			a.allocExt(block)
 		}
@@ -538,4 +572,23 @@ func TestPrefixArenaAllocExt_OversizeAndReuse(t *testing.T) {
 			require.Same(t, backing[i], &a.extChunks[i][:1][0], "chunk backing array must be reused")
 		}
 	})
+}
+
+func TestPlainKeyArenaGrowsGeometrically(t *testing.T) {
+	var a plainKeyArena
+	a.intern([]byte("addr"))
+	require.Equal(t, plainKeyArenaChunkMin, cap(a.buf), "a fresh key arena must not pay for a full chunk")
+
+	block := make([]byte, plainKeyArenaChunkMin)
+	a.intern(block)
+	require.Equal(t, 2*plainKeyArenaChunkMin, cap(a.buf), "each chunk must double the previous one")
+
+	for range 8 {
+		a.intern(block)
+	}
+	require.LessOrEqual(t, cap(a.buf), plainKeyArenaChunkMax, "chunk size must stay capped")
+
+	a.reset()
+	require.Empty(t, a.buf)
+	require.Positive(t, cap(a.buf), "reset must keep the grown capacity")
 }

--- a/execution/commitment/prefix_trie_test.go
+++ b/execution/commitment/prefix_trie_test.go
@@ -306,15 +306,16 @@ func TestPrefixTrieArenaSpansMultipleSlabs(t *testing.T) {
 	assert.Equal(t, prefixSlabMax+5+1 /*root*/, tr.arena.nodeCount())
 	assert.GreaterOrEqual(t, len(tr.arena.slabs), 2)
 
+	grown := len(tr.arena.slabs)
+
 	tr.Reset()
 	assert.Equal(t, 1, tr.arena.nodeCount())
+	assert.Less(t, len(tr.arena.slabs), grown, "Reset must drop the slabs past the budget")
 	held := 0
 	for _, s := range tr.arena.slabs {
 		held += len(s)
 	}
-	assert.GreaterOrEqual(t, held, prefixSlabRetain, "Reset must keep the retained capacity")
-	assert.Less(t, held-len(tr.arena.slabs[len(tr.arena.slabs)-1]), prefixSlabRetain,
-		"Reset must drop every slab past the retention budget")
+	assert.LessOrEqual(t, held, prefixSlabMax, "Reset must not retain more than one max slab's worth")
 }
 
 func TestPrefixArenaGrowsGeometrically(t *testing.T) {
@@ -583,10 +584,14 @@ func TestPlainKeyArenaGrowsGeometrically(t *testing.T) {
 	a.intern(block)
 	require.Equal(t, 2*plainKeyArenaChunkMin, cap(a.buf), "each chunk must double the previous one")
 
-	for range 8 {
+	for cap(a.buf) < plainKeyArenaChunkMax {
 		a.intern(block)
 	}
-	require.LessOrEqual(t, cap(a.buf), plainKeyArenaChunkMax, "chunk size must stay capped")
+	require.Equal(t, plainKeyArenaChunkMax, cap(a.buf))
+	for range 128 {
+		a.intern(block)
+	}
+	require.Equal(t, plainKeyArenaChunkMax, cap(a.buf), "chunk size must stay capped")
 
 	a.reset()
 	require.Empty(t, a.buf)

--- a/execution/commitment/prefix_trie_test.go
+++ b/execution/commitment/prefix_trie_test.go
@@ -597,3 +597,46 @@ func TestPlainKeyArenaGrowsGeometrically(t *testing.T) {
 	require.Empty(t, a.buf)
 	require.Positive(t, cap(a.buf), "reset must keep the grown capacity")
 }
+
+func TestPrefixArenaKeepsMaxSlabAcrossReset(t *testing.T) {
+	a := newPrefixArena()
+	for range prefixSlabMax + 1 {
+		a.allocNode()
+	}
+	var maxSlab *prefixNode
+	for _, s := range a.slabs {
+		if len(s) == prefixSlabMax {
+			maxSlab = &s[0]
+			break
+		}
+	}
+	require.NotNil(t, maxSlab, "test must actually reach a max-sized slab")
+
+	a.resetArena()
+	for range prefixSlabMax {
+		a.allocNode()
+	}
+	for _, s := range a.slabs {
+		if len(s) == prefixSlabMax {
+			require.Same(t, maxSlab, &s[0], "refill must reuse the max slab, not allocate a new one")
+			return
+		}
+	}
+	t.Fatal("no max-sized slab after refill")
+}
+
+func TestPrefixTrieResetClearsVisited(t *testing.T) {
+	tr := newPrefixTrie()
+	for i := range 64 {
+		k := make([]byte, 64)
+		k[0] = byte(i % 16)
+		k[1] = byte(i / 16)
+		tr.Insert(k, nil, nil)
+	}
+	require.NotZero(t, cap(tr.visited), "test must actually populate visited")
+
+	tr.Reset()
+	for i, n := range tr.visited[:cap(tr.visited)] {
+		require.Nil(t, n, "Reset left a node pointer at visited[%d], pinning a dropped slab", i)
+	}
+}

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -88,7 +88,7 @@ type commitmentCalculator struct {
 	spare *commitment.Updates
 
 	// balUpdates is the per-block BAL fold buffer, Reset and reused across blocks
-	// instead of reallocated — avoids a fresh prefix-trie arena (16k-node slab) each block.
+	// instead of reallocated — reuse keeps the arena's grown slabs and ext chunks.
 	balUpdates *commitment.Updates
 
 	// state accumulates account/storage values across TX writes.

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -82,6 +82,11 @@ type commitmentCalculator struct {
 	// execLoop or apply loop. Only this goroutine reads/writes it.
 	updates *commitment.Updates
 
+	// spare is the other half of the compute buffer ring. handOffUpdates gives
+	// updates to the commitment context and rotates this one in; the context
+	// drains its buffer synchronously, so by the next rotation it is idle.
+	spare *commitment.Updates
+
 	// balUpdates is the per-block BAL fold buffer, Reset and reused across blocks
 	// instead of reallocated — avoids a fresh prefix-trie arena (16k-node slab) each block.
 	balUpdates *commitment.Updates
@@ -213,8 +218,10 @@ func newCommitmentCalculator(
 	// trie reads leaf values from the as-of reader, so keep its ModeParallel buffer.
 	sdCtxUpdates := doms.GetCommitmentContext().GetUpdates()
 	calcUpdates := sdCtxUpdates.NewEmpty()
+	spareUpdates := sdCtxUpdates.NewEmpty()
 	if sdCtxUpdates.Mode() != commitment.ModeParallel {
 		calcUpdates.SetMode(commitment.ModeUpdate)
+		spareUpdates.SetMode(commitment.ModeUpdate)
 	}
 
 	// Open a persistent read-only TX for lazy-loading state from the domain.
@@ -244,6 +251,7 @@ func newCommitmentCalculator(
 		logPrefix:            logPrefix,
 		logger:               logger,
 		updates:              calcUpdates,
+		spare:                spareUpdates,
 		state:                newCalcState(asOfReader, logger, logPrefix),
 		asOfReader:           asOfReader,
 		roTx:                 roTx,
@@ -698,9 +706,7 @@ func (cc *commitmentCalculator) shadowCrossCheck(ctx context.Context, target com
 	}
 	cc.state.FlushToUpdates(cc.updates)
 	cc.state.ResetBlockFlags()
-	incUpdates := cc.updates
-	cc.updates = cc.updates.NewEmpty()
-	rh, err := cc.computeRootFromUpdates(ctx, target, incUpdates, cc.asOfReader)
+	rh, err := cc.computeRootFromUpdates(ctx, target, cc.handOffUpdates(), cc.asOfReader)
 	if err != nil {
 		cc.fail(ctx, target, fmt.Errorf("shadow incremental compute: %w", err))
 		return
@@ -771,6 +777,15 @@ type computeMode struct {
 	publishRoot bool   // with checkRoot, publish the successful root too (batch-boundary request), not just mismatches
 }
 
+// handOffUpdates returns the filled buffer for the caller to compute against and
+// rotates the spare into cc.updates.
+func (cc *commitmentCalculator) handOffUpdates() *commitment.Updates {
+	filled := cc.updates
+	cc.updates, cc.spare = cc.spare, filled
+	cc.updates.Reset()
+	return filled
+}
+
 // compute is the shared prologue/compute/footer for every calculator commitment
 // path; the per-call differences live in m.
 func (cc *commitmentCalculator) compute(ctx context.Context, t commitTarget, m computeMode) {
@@ -785,8 +800,7 @@ func (cc *commitmentCalculator) compute(ctx context.Context, t commitTarget, m c
 	}
 
 	sdCtx := cc.doms.GetCommitmentContext()
-	sdCtx.SetUpdates(cc.updates)
-	cc.updates = cc.updates.NewEmpty()
+	sdCtx.SetUpdates(cc.handOffUpdates())
 
 	cc.asOfReader.txNum = t.lastTxNum + 1
 	sdCtx.SetStateReader(cc.asOfReader)

--- a/execution/stagedsync/committer_test.go
+++ b/execution/stagedsync/committer_test.go
@@ -319,12 +319,14 @@ func TestHandOffUpdatesRotatesTwoBuffers(t *testing.T) {
 	touch(cc.updates, 1)
 	handed := cc.handOffUpdates()
 	require.Same(t, first, handed, "the filled buffer must be the one handed off")
+	require.NotZero(t, handed.Size(), "the handed-off buffer must keep the updates it will be folded from")
 	require.Same(t, second, cc.updates, "the spare must rotate in")
 	require.Zero(t, cc.updates.Size(), "the rotated-in buffer must be empty")
 
 	touch(cc.updates, 2)
 	handed = cc.handOffUpdates()
 	require.Same(t, second, handed)
+	require.NotZero(t, handed.Size(), "the handed-off buffer must keep the updates it will be folded from")
 	require.Same(t, first, cc.updates, "rotation must reuse the first buffer, not allocate")
 	require.Zero(t, cc.updates.Size(), "the reused buffer must be reset before refilling")
 }

--- a/execution/stagedsync/committer_test.go
+++ b/execution/stagedsync/committer_test.go
@@ -17,6 +17,7 @@
 package stagedsync
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -27,6 +28,7 @@ import (
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/db/state/execctx"
 	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/commitment"
 	"github.com/erigontech/erigon/execution/state"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/execution/types/accounts"
@@ -303,4 +305,26 @@ func TestContiguityGuard_ChainNeverRecovers(t *testing.T) {
 		assert.True(t, cc.computeAheadStopped, "the fall back to incremental must be reported at block %d", n)
 	}
 	assert.Equal(t, uint64(5), cc.lastComputedAheadBlock, "the chain must stay anchored at block 5")
+}
+
+func TestHandOffUpdatesRotatesTwoBuffers(t *testing.T) {
+	first := commitment.NewUpdates(commitment.ModeParallel, t.TempDir(), commitment.KeyToHexNibbleHash)
+	second := commitment.NewUpdates(commitment.ModeParallel, t.TempDir(), commitment.KeyToHexNibbleHash)
+	cc := &commitmentCalculator{updates: first, spare: second}
+
+	touch := func(u *commitment.Updates, addr byte) {
+		u.TouchPlainKey(string(bytes.Repeat([]byte{addr}, 20)), nil, u.TouchAccount)
+	}
+
+	touch(cc.updates, 1)
+	handed := cc.handOffUpdates()
+	require.Same(t, first, handed, "the filled buffer must be the one handed off")
+	require.Same(t, second, cc.updates, "the spare must rotate in")
+	require.Zero(t, cc.updates.Size(), "the rotated-in buffer must be empty")
+
+	touch(cc.updates, 2)
+	handed = cc.handOffUpdates()
+	require.Same(t, second, handed)
+	require.Same(t, first, cc.updates, "rotation must reuse the first buffer, not allocate")
+	require.Zero(t, cc.updates.Size(), "the reused buffer must be reset before refilling")
 }


### PR DESCRIPTION
`newPrefixArena` allocates 1,507,328 B before a single key is inserted — a full `[16384]prefixNode` slab (1.38 MiB) plus a 64 KiB ext chunk — and `newPrefixTrie` then takes one node from it, the root. `plainKeyArena.intern` allocates another 64 KiB on the first key. Both costs are per-block: `commitmentCalculator.compute` replaced its `Updates` with `NewEmpty()` on every call and the discarded buffer was never pooled. A reported exec-from-0 profile attributes 1.4 TB of `alloc_space` to that constructor.

#22801 already fixed this shape for `balUpdates`; the main path was left allocating.

## Changes

- `prefixArena` slabs grow 256 → 16384 and ext chunks 4 KiB → 64 KiB, both lazy.
- `resetArena` keeps the geometric ramp while it fits in one max slab, and switches to retaining a single max slab once the arena has reached one — so an arena past the ramp's 16,128 nodes does not re-allocate on every reset. Retention tops out at 1.38 MiB against the 1.44 MiB a fixed slab pins today.
- `prefixTrie.Reset` clears `visited` to its full capacity. Stale `*prefixNode` entries past `len` kept a released slab's whole backing array reachable.
- `plainKeyArena` grows 1 KiB → 64 KiB.
- `commitmentCalculator` rotates two `Updates` through `handOffUpdates()` rather than allocating one per compute. `Process` already ends with `consumeParallel()` — the `ModeParallel` arm of `Reset()` — so the handed-off buffer is idle by the next rotation.

Per-block allocation, same benchmark both arms, 3 runs each on darwin/arm64:

| keys/block | before | after |
|---|---|---|
| 2 | 1,573,866 B | 30,693 B |
| 200 | 1,608,810 B | 145,611 B |
| 2000 | 2,073,881 B | 971,485 B |

Only reachable with `--experimental.parallel-commitment` / `COMMITMENT_PARALLEL`, default off.
