### PR TITLE
[r3.6] builder: cover Stop when completion and cancellation race

### DIFF
--- a/execution/builder/block_builder.go
+++ b/execution/builder/block_builder.go
@@ -136,6 +136,7 @@ func (b *BlockBuilder) Stop(ctx context.Context) (*types.BlockWithReceipts, erro
 	select {
 	case <-b.done:
 	case <-ctx.Done():
+		// Completion may become ready while select chooses, so recheck before abandoning the result.
 		select {
 		case <-b.done:
 		default:

--- a/execution/builder/block_builder_test.go
+++ b/execution/builder/block_builder_test.go
@@ -234,6 +234,34 @@ func TestBlockBuilderStopPrefersCompletedOutcomeOverCanceledCaller(t *testing.T)
 	}
 }
 
+func TestBlockBuilderStopPrefersPayloadCompletedDuringSelection(t *testing.T) {
+	t.Parallel()
+
+	callerCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+	want := &types.BlockWithReceipts{}
+
+	// Stop's select evaluates channel operands in source order before choosing a ready case.
+	// Completing the builder from the context's Done method makes both cases ready together.
+	for range 100 {
+		builder := &BlockBuilder{done: make(chan struct{})}
+		stopCtx := &finishOnDoneContext{
+			Context: callerCtx,
+			finish: func() {
+				builder.mu.Lock()
+				builder.result = want
+				builder.state.Store(blockBuilderCompleted)
+				builder.mu.Unlock()
+				close(builder.done)
+			},
+		}
+
+		result, err := builder.Stop(stopCtx)
+		require.NoError(t, err)
+		require.Same(t, want, result)
+	}
+}
+
 func TestBlockBuilderStopReturnsImmediatelyAfterDiscard(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Cherry-pick of #23289 to release/3.6.

## Why now and not earlier

Until #23394 landed, this was not applicable here: `BlockBuilder.Stop()` took no context on this branch, so there was no cancellation branch to race against completion and nothing to fix. #23394 brought #22835 across, which introduces `Stop(ctx)` — and with it the window this closes.

It is worth being explicit that the sequence mattered rather than just being tidy. Attempted before #23394 this conflicted in both files; on top of it, it is a clean pick.

## What it fixes

`Stop` selects on the build finishing and on the caller's context. Both can be ready at once, and Go picks between ready cases at random — so a payload that completed while `select` was choosing could be thrown away and reported as the caller having given up. The fix is a recheck of `b.done` before abandoning the result, plus the test that pins it.

## Verification

- Straight cherry-pick, no adaptations.
- `go test -race` green across `execution/builder/...` and `execution/execmodule/...`.
- Mutation-checked on this branch: removing the recheck fails `TestBlockBuilderStopPrefersPayloadCompletedDuringSelection`, run at `-count=50` since the case it covers is a scheduler race rather than a deterministic path.
- `make lintci` clean, 0 issues.
