### PR TITLE
cl, common: reuse snappy stream codecs from a pool

### DIFF
--- a/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
+++ b/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/golang/snappy"
 	"github.com/spf13/afero"
 
 	"github.com/erigontech/erigon/cl/beacon/beacon_router_configuration"
@@ -131,9 +130,7 @@ type forkGraphDisk struct {
 	envelopeExists sync.Map // common.Hash -> struct{}
 
 	// reusable buffers
-	sszBuffer       []byte
-	sszSnappyWriter *snappy.Writer
-	sszSnappyReader *snappy.Reader
+	sszBuffer []byte
 
 	rcfg       beacon_router_configuration.RouterConfiguration
 	syncedData synced_data.SyncedData

--- a/cl/phase1/forkchoice/fork_graph/fork_graph_disk_fs.go
+++ b/cl/phase1/forkchoice/fork_graph/fork_graph_disk_fs.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"os"
 
-	"github.com/golang/snappy"
 	"github.com/spf13/afero"
 
 	"github.com/erigontech/erigon/cl/clparams"
@@ -30,6 +29,7 @@ import (
 	"github.com/erigontech/erigon/cl/phase1/core/state"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/common/snappypool"
 )
 
 // maxSSZObjectSize is a generous upper bound for any single SSZ object
@@ -59,20 +59,17 @@ func (f *forkGraphDisk) readBeaconStateFromDisk(blockRoot common.Hash) (bs *stat
 	}
 	defer file.Close()
 
-	if f.sszSnappyReader == nil {
-		f.sszSnappyReader = snappy.NewReader(file)
-	} else {
-		f.sszSnappyReader.Reset(file)
-	}
+	sr := snappypool.Reader(file)
+	defer snappypool.PutReader(sr)
 	// Read the version
 	v := []byte{0}
-	if _, err := f.sszSnappyReader.Read(v); err != nil {
+	if _, err := sr.Read(v); err != nil {
 		return nil, fmt.Errorf("failed to read hard fork version: %w, root: %x", err, blockRoot)
 	}
 	// Read the length
 	lengthBytes := make([]byte, 8)
 	var n int
-	n, err = io.ReadFull(f.sszSnappyReader, lengthBytes)
+	n, err = io.ReadFull(sr, lengthBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read length: %w, root: %x", err, blockRoot)
 	}
@@ -89,7 +86,7 @@ func (f *forkGraphDisk) readBeaconStateFromDisk(blockRoot common.Hash) (bs *stat
 	} else {
 		f.sszBuffer = f.sszBuffer[:length]
 	}
-	n, err = io.ReadFull(f.sszSnappyReader, f.sszBuffer)
+	n, err = io.ReadFull(sr, f.sszBuffer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read snappy buffer: %w, root: %x", err, blockRoot)
 	}
@@ -106,7 +103,7 @@ func (f *forkGraphDisk) readBeaconStateFromDisk(blockRoot common.Hash) (bs *stat
 	// the block's state_root. Older state files won't have this field;
 	// in that case we leave previousStateRoot as zero (HashSSZ fallback).
 	var prevRoot [32]byte
-	if _, readErr := io.ReadFull(f.sszSnappyReader, prevRoot[:]); readErr == nil {
+	if _, readErr := io.ReadFull(sr, prevRoot[:]); readErr == nil {
 		bs.SetPreviousStateRoot(common.Hash(prevRoot))
 	}
 
@@ -133,26 +130,23 @@ func (f *forkGraphDisk) DumpBeaconStateOnDisk(blockRoot common.Hash, bs *state.C
 	}
 	defer dumpedFile.Close()
 
-	if f.sszSnappyWriter == nil {
-		f.sszSnappyWriter = snappy.NewBufferedWriter(dumpedFile)
-	} else {
-		f.sszSnappyWriter.Reset(dumpedFile)
-	}
+	sw := snappypool.Writer(dumpedFile)
+	defer snappypool.PutWriter(sw)
 
 	// First write the hard fork version
-	if _, err := f.sszSnappyWriter.Write([]byte{byte(version)}); err != nil {
+	if _, err := sw.Write([]byte{byte(version)}); err != nil {
 		log.Error("failed to write hard fork version", "err", err)
 		return err
 	}
 	// Second write the length
 	length := make([]byte, 8)
 	binary.BigEndian.PutUint64(length, uint64(len(f.sszBuffer)))
-	if _, err := f.sszSnappyWriter.Write(length); err != nil {
+	if _, err := sw.Write(length); err != nil {
 		log.Error("failed to write length", "err", err)
 		return err
 	}
 	// Lastly dump the state
-	if _, err := f.sszSnappyWriter.Write(f.sszBuffer); err != nil {
+	if _, err := sw.Write(f.sszBuffer); err != nil {
 		log.Error("failed to write ssz buffer", "err", err)
 		return err
 	}
@@ -168,11 +162,11 @@ func (f *forkGraphDisk) DumpBeaconStateOnDisk(blockRoot common.Hash, bs *state.C
 		// Fallback for anchor state or cases where header isn't stored yet
 		stateRootToWrite = bs.PeekPreviousStateRoot()
 	}
-	if _, err := f.sszSnappyWriter.Write(stateRootToWrite[:]); err != nil {
+	if _, err := sw.Write(stateRootToWrite[:]); err != nil {
 		log.Error("failed to write previousStateRoot", "err", err)
 		return err
 	}
-	if err = f.sszSnappyWriter.Flush(); err != nil {
+	if err = sw.Flush(); err != nil {
 		log.Error("failed to flush snappy writer", "err", err)
 		return err
 	}
@@ -215,16 +209,13 @@ func (f *forkGraphDisk) ReadEnvelopeFromDisk(blockRoot common.Hash) (envelope *c
 	}
 	defer file.Close()
 
-	if f.sszSnappyReader == nil {
-		f.sszSnappyReader = snappy.NewReader(file)
-	} else {
-		f.sszSnappyReader.Reset(file)
-	}
+	sr := snappypool.Reader(file)
+	defer snappypool.PutReader(sr)
 
 	// Read the length
 	lengthBytes := make([]byte, 8)
 	var n int
-	n, err = io.ReadFull(f.sszSnappyReader, lengthBytes)
+	n, err = io.ReadFull(sr, lengthBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read length: %w, root: %x", err, blockRoot)
 	}
@@ -241,7 +232,7 @@ func (f *forkGraphDisk) ReadEnvelopeFromDisk(blockRoot common.Hash) (envelope *c
 	} else {
 		f.sszBuffer = f.sszBuffer[:envelopeLength]
 	}
-	n, err = io.ReadFull(f.sszSnappyReader, f.sszBuffer)
+	n, err = io.ReadFull(sr, f.sszBuffer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read snappy buffer: %w, root: %x", err, blockRoot)
 	}
@@ -282,25 +273,22 @@ func (f *forkGraphDisk) DumpEnvelopeOnDisk(blockRoot common.Hash, envelope *clty
 	}
 	defer dumpedFile.Close()
 
-	if f.sszSnappyWriter == nil {
-		f.sszSnappyWriter = snappy.NewBufferedWriter(dumpedFile)
-	} else {
-		f.sszSnappyWriter.Reset(dumpedFile)
-	}
+	sw := snappypool.Writer(dumpedFile)
+	defer snappypool.PutWriter(sw)
 
 	// Write the length
 	length := make([]byte, 8)
 	binary.BigEndian.PutUint64(length, uint64(len(f.sszBuffer)))
-	if _, err := f.sszSnappyWriter.Write(length); err != nil {
+	if _, err := sw.Write(length); err != nil {
 		log.Error("failed to write length", "err", err)
 		return err
 	}
 	// Write the envelope
-	if _, err := f.sszSnappyWriter.Write(f.sszBuffer); err != nil {
+	if _, err := sw.Write(f.sszBuffer); err != nil {
 		log.Error("failed to write ssz buffer", "err", err)
 		return err
 	}
-	if err = f.sszSnappyWriter.Flush(); err != nil {
+	if err = sw.Flush(); err != nil {
 		log.Error("failed to flush snappy writer", "err", err)
 		return err
 	}

--- a/cl/rpc/rpc.go
+++ b/cl/rpc/rpc.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/c2h5oh/datasize"
-	"github.com/golang/snappy"
 	"go.uber.org/zap/buffer"
 
 	"github.com/erigontech/erigon/cl/clparams"
@@ -40,6 +39,7 @@ import (
 	"github.com/erigontech/erigon/cl/utils/eth_clock"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/common/snappypool"
 	"github.com/erigontech/erigon/node/gointerfaces"
 	"github.com/erigontech/erigon/node/gointerfaces/sentinelproto"
 )
@@ -343,8 +343,9 @@ type responseData struct {
 // parseResponseData parses the response data from a sentinel message and returns the parsed response data.
 func (b *BeaconRpcP2P) parseResponseData(message *sentinelproto.ResponseData) ([]responseData, string, error) {
 	if message.Error {
-		rd := snappy.NewReader(bytes.NewBuffer(message.Data))
+		rd := snappypool.Reader(bytes.NewReader(message.Data))
 		errBytes, _ := io.ReadAll(rd)
+		snappypool.PutReader(rd)
 		errMsg := string(errBytes)
 		log.Trace("received range req error", "err", errMsg, "raw", string(message.Data))
 		return nil, message.Peer.Pid, fmt.Errorf("peer error response: %s", errMsg)
@@ -352,6 +353,8 @@ func (b *BeaconRpcP2P) parseResponseData(message *sentinelproto.ResponseData) ([
 
 	responsePacket := []responseData{}
 	r := bytes.NewReader(message.Data)
+	sr := snappypool.Reader(r)
+	defer snappypool.PutReader(sr)
 	for {
 		forkDigest := make([]byte, 4)
 		if n, err := r.Read(forkDigest); err != nil {
@@ -375,7 +378,7 @@ func (b *BeaconRpcP2P) parseResponseData(message *sentinelproto.ResponseData) ([
 
 		// Read bytes using snappy into a new raw buffer of side encodedLn.
 		raw := make([]byte, encodedLn)
-		sr := snappy.NewReader(r)
+		sr.Reset(r)
 		bytesRead := 0
 		for bytesRead < int(encodedLn) {
 			n, err := sr.Read(raw[bytesRead:])

--- a/cl/sentinel/communication/ssz_snappy/encoding.go
+++ b/cl/sentinel/communication/ssz_snappy/encoding.go
@@ -23,26 +23,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"sync"
 
 	"github.com/c2h5oh/datasize"
-	"github.com/golang/snappy"
 
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/utils/eth_clock"
+	"github.com/erigontech/erigon/common/snappypool"
 	"github.com/erigontech/erigon/common/ssz"
 )
-
-var writerPool = sync.Pool{
-	New: func() any {
-		return snappy.NewBufferedWriter(nil)
-	},
-}
-
-func putWriter(sw *snappy.Writer) {
-	sw.Reset(nil)
-	writerPool.Put(sw)
-}
 
 func EncodeAndWrite(w io.Writer, val ssz.Marshaler, prefix ...byte) error {
 	enc := make([]byte, 0, val.EncodingSizeSSZ())
@@ -62,11 +50,10 @@ func EncodeAndWrite(w io.Writer, val ssz.Marshaler, prefix ...byte) error {
 	wr.Write(prefix)
 	wr.Write(lengthBuf[:vin])
 	// start using streamed snappy compression
-	sw, _ := writerPool.Get().(*snappy.Writer)
-	sw.Reset(wr)
+	sw := snappypool.Writer(wr)
 	defer func() {
 		sw.Flush()
-		putWriter(sw)
+		snappypool.PutWriter(sw)
 	}()
 	// Marshall and snap it
 	_, err = sw.Write(enc)
@@ -97,7 +84,8 @@ func DecodeAndReadNoForkDigest(r io.Reader, val ssz.EncodableSSZ, version clpara
 		return errors.New("payload too big")
 	}
 
-	sr := snappy.NewReader(r)
+	sr := snappypool.Reader(r)
+	defer snappypool.PutReader(sr)
 	raw := make([]byte, encodedLn)
 	if _, err := io.ReadFull(sr, raw); err != nil {
 		// fetch struct name of val
@@ -158,7 +146,8 @@ func DecodeListSSZ(data []byte, count uint64, list []ssz.EncodableSSZ, b *clpara
 		return fmt.Errorf("encoded length not equal to expected size: want %d, got %d", objSize, encodedLn)
 	}
 
-	sr := snappy.NewReader(r)
+	sr := snappypool.Reader(r)
+	defer snappypool.PutReader(sr)
 	for i := 0; i < int(count); i++ {
 		var n int
 		raw := make([]byte, encodedLn)

--- a/cl/sentinel/communication/topics_test.go
+++ b/cl/sentinel/communication/topics_test.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/golang/snappy"
 	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/snappypool"
 )
 
 func TestMaxWireResponseBytes(t *testing.T) {
@@ -44,7 +46,7 @@ func TestMaxWireResponseBytes(t *testing.T) {
 }
 
 // TestMaxWireResponseBytesBoundsStreamEncoding proves the cap never truncates: the responder writes
-// each chunk with snappy.NewBufferedWriter (stream framing: a 10-byte stream identifier plus a
+// each chunk with a snappy buffered writer (stream framing: a 10-byte stream identifier plus a
 // header+CRC per ~64 KiB frame), and snappy.MaxEncodedLen — a snappy *block* bound — must dominate
 // that stream output for every item size up to MAX_CHUNK_SIZE, so a compliant chunk is never 413'd.
 func TestMaxWireResponseBytesBoundsStreamEncoding(t *testing.T) {
@@ -64,10 +66,11 @@ func TestMaxWireResponseBytesBoundsStreamEncoding(t *testing.T) {
 		fill(payload)
 
 		var buf bytes.Buffer
-		sw := snappy.NewBufferedWriter(&buf)
+		sw := snappypool.Writer(&buf)
 		_, err := sw.Write(payload)
 		require.NoError(t, err)
 		require.NoError(t, sw.Flush())
+		snappypool.PutWriter(sw)
 		streamLen := uint64(buf.Len())
 
 		require.LessOrEqualf(t, streamLen, uint64(snappy.MaxEncodedLen(raw)),

--- a/cl/sentinel/handlers/blobs_test.go
+++ b/cl/sentinel/handlers/blobs_test.go
@@ -25,7 +25,6 @@ import (
 	"math"
 	"testing"
 
-	"github.com/golang/snappy"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
@@ -43,6 +42,7 @@ import (
 	"github.com/erigontech/erigon/cl/sentinel/peers"
 	"github.com/erigontech/erigon/cl/utils"
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/snappypool"
 	"github.com/erigontech/erigon/db/kv/dbcfg"
 	"github.com/erigontech/erigon/db/kv/mdbx/mdbxtest"
 )
@@ -138,6 +138,8 @@ func TestBlobsByRangeHandler(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, firstByte[0], byte(0))
 
+	sr := snappypool.Reader(stream)
+	defer snappypool.PutReader(sr)
 	for i := range sidecars {
 		forkDigest := make([]byte, 4)
 		_, err := stream.Read(forkDigest)
@@ -149,7 +151,7 @@ func TestBlobsByRangeHandler(t *testing.T) {
 		require.NoError(t, err)
 
 		raw := make([]byte, encodedLn)
-		sr := snappy.NewReader(stream)
+		sr.Reset(stream)
 		bytesRead := 0
 		for bytesRead < int(encodedLn) {
 			n, err := sr.Read(raw[bytesRead:])
@@ -262,6 +264,8 @@ func TestBlobsByIdentifiersHandler(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, firstByte[0], byte(0))
 
+	sr := snappypool.Reader(stream)
+	defer snappypool.PutReader(sr)
 	for i := range sidecars {
 		forkDigest := make([]byte, 4)
 		_, err := stream.Read(forkDigest)
@@ -273,7 +277,7 @@ func TestBlobsByIdentifiersHandler(t *testing.T) {
 		require.NoError(t, err)
 
 		raw := make([]byte, encodedLn)
-		sr := snappy.NewReader(stream)
+		sr.Reset(stream)
 		bytesRead := 0
 		for bytesRead < int(encodedLn) {
 			n, err := sr.Read(raw[bytesRead:])

--- a/cl/sentinel/handlers/blocks_by_head_test.go
+++ b/cl/sentinel/handlers/blocks_by_head_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/snappy"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -40,6 +39,7 @@ import (
 	"github.com/erigontech/erigon/cl/sentinel/peers"
 	"github.com/erigontech/erigon/cl/utils"
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/snappypool"
 )
 
 func TestBlocksByHeadCountCap(t *testing.T) {
@@ -202,6 +202,8 @@ func readBlocksByHeadResponses(t *testing.T, stream network.Stream, count int) [
 
 	ethClock := getEthClock(t)
 	blocks := make([]*cltypes.SignedBeaconBlock, 0, count)
+	sr := snappypool.Reader(stream)
+	defer snappypool.PutReader(sr)
 	for range count {
 		prefix := make([]byte, 1)
 		require.NoError(t, stream.SetReadDeadline(time.Now().Add(5*time.Second)))
@@ -217,7 +219,7 @@ func readBlocksByHeadResponses(t *testing.T, stream network.Stream, count int) [
 		require.NoError(t, err)
 
 		raw := make([]byte, encodedLn)
-		sr := snappy.NewReader(stream)
+		sr.Reset(stream)
 		_, err = io.ReadFull(sr, raw)
 		require.NoError(t, err)
 

--- a/cl/sentinel/handlers/blocks_by_range_test.go
+++ b/cl/sentinel/handlers/blocks_by_range_test.go
@@ -25,7 +25,6 @@ import (
 	"io"
 	"testing"
 
-	"github.com/golang/snappy"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
@@ -39,6 +38,7 @@ import (
 	"github.com/erigontech/erigon/cl/sentinel/communication/ssz_snappy"
 	"github.com/erigontech/erigon/cl/sentinel/peers"
 	"github.com/erigontech/erigon/cl/utils"
+	"github.com/erigontech/erigon/common/snappypool"
 )
 
 func TestBlocksByRootHandler(t *testing.T) {
@@ -110,6 +110,8 @@ func TestBlocksByRootHandler(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, firstByte[0], byte(0))
 
+	sr := snappypool.Reader(stream)
+	defer snappypool.PutReader(sr)
 	for i := 0; i < int(count); i++ {
 		forkDigest := make([]byte, 4)
 
@@ -126,7 +128,7 @@ func TestBlocksByRootHandler(t *testing.T) {
 		require.NoError(t, err)
 
 		raw := make([]byte, encodedLn)
-		sr := snappy.NewReader(stream)
+		sr.Reset(stream)
 		bytesRead := 0
 		for bytesRead < int(encodedLn) {
 			n, err := sr.Read(raw[bytesRead:])

--- a/cl/sentinel/handlers/blocks_by_root_test.go
+++ b/cl/sentinel/handlers/blocks_by_root_test.go
@@ -25,7 +25,6 @@ import (
 	"io"
 	"testing"
 
-	"github.com/golang/snappy"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
@@ -42,6 +41,7 @@ import (
 	"github.com/erigontech/erigon/cl/sentinel/peers"
 	"github.com/erigontech/erigon/cl/utils"
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/snappypool"
 )
 
 func TestBlocksByRangeHandler(t *testing.T) {
@@ -114,6 +114,8 @@ func TestBlocksByRangeHandler(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, firstByte[0], byte(0))
 
+	sr := snappypool.Reader(stream)
+	defer snappypool.PutReader(sr)
 	for i := 0; i < len(blockRoots); i++ {
 		forkDigest := make([]byte, 4)
 		_, err := stream.Read(forkDigest)
@@ -125,7 +127,7 @@ func TestBlocksByRangeHandler(t *testing.T) {
 		require.NoError(t, err)
 
 		raw := make([]byte, encodedLn)
-		sr := snappy.NewReader(stream)
+		sr.Reset(stream)
 		bytesRead := 0
 		for bytesRead < int(encodedLn) {
 			n, err := sr.Read(raw[bytesRead:])

--- a/cl/sentinel/handlers/execution_payload_envelopes_test.go
+++ b/cl/sentinel/handlers/execution_payload_envelopes_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"testing"
 
-	"github.com/golang/snappy"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
@@ -25,6 +24,7 @@ import (
 	"github.com/erigontech/erigon/cl/utils"
 	"github.com/erigontech/erigon/cl/utils/eth_clock"
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/snappypool"
 	chainspec "github.com/erigontech/erigon/execution/chain/spec"
 )
 
@@ -159,6 +159,8 @@ func TestExecutionPayloadEnvelopesByRangeHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	// Read response chunks
+	sr := snappypool.Reader(stream)
+	defer snappypool.PutReader(sr)
 	for i := 0; i < len(expEnvelopes); i++ {
 		// Read success byte
 		firstByte := make([]byte, 1)
@@ -185,7 +187,7 @@ func TestExecutionPayloadEnvelopesByRangeHandler(t *testing.T) {
 		require.NoError(t, err)
 
 		raw := make([]byte, encodedLn)
-		sr := snappy.NewReader(stream)
+		sr.Reset(stream)
 		bytesRead := 0
 		for bytesRead < int(encodedLn) {
 			n, err := sr.Read(raw[bytesRead:])
@@ -314,6 +316,8 @@ func TestExecutionPayloadEnvelopesByRootHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	// Read response chunks
+	sr := snappypool.Reader(stream)
+	defer snappypool.PutReader(sr)
 	for i := 0; i < len(expEnvelopes); i++ {
 		firstByte := make([]byte, 1)
 		_, err = stream.Read(firstByte)
@@ -335,7 +339,7 @@ func TestExecutionPayloadEnvelopesByRootHandler(t *testing.T) {
 		require.NoError(t, err)
 
 		raw := make([]byte, encodedLn)
-		sr := snappy.NewReader(stream)
+		sr.Reset(stream)
 		bytesRead := 0
 		for bytesRead < int(encodedLn) {
 			n, err := sr.Read(raw[bytesRead:])

--- a/cl/sentinel/handlers/light_client_test.go
+++ b/cl/sentinel/handlers/light_client_test.go
@@ -25,7 +25,6 @@ import (
 	"io"
 	"testing"
 
-	"github.com/golang/snappy"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
@@ -40,6 +39,7 @@ import (
 	"github.com/erigontech/erigon/cl/sentinel/peers"
 	"github.com/erigontech/erigon/cl/utils"
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/snappypool"
 )
 
 var altairSlot = clparams.MainnetBeaconConfig.AltairForkEpoch*clparams.MainnetBeaconConfig.SlotsPerEpoch + 1
@@ -339,6 +339,8 @@ func TestLightClientUpdates(t *testing.T) {
 	_ = got
 	expectedCount := 1
 	currentPeriod := 1
+	sr := snappypool.Reader(stream)
+	defer snappypool.PutReader(sr)
 	for range expectedCount {
 		forkDigest := make([]byte, 4)
 
@@ -355,7 +357,7 @@ func TestLightClientUpdates(t *testing.T) {
 		require.NoError(t, err)
 
 		raw := make([]byte, encodedLn)
-		sr := snappy.NewReader(stream)
+		sr.Reset(stream)
 		bytesRead := 0
 		for bytesRead < int(encodedLn) {
 			n, err := sr.Read(raw[bytesRead:])

--- a/cl/sentinel/httpreqresp/errors.go
+++ b/cl/sentinel/httpreqresp/errors.go
@@ -23,7 +23,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/golang/snappy"
+	"github.com/erigontech/erigon/common/snappypool"
 )
 
 const maxErrorMessageBytes = 256
@@ -95,7 +95,8 @@ func (r ResponseCode) ErrorMessage(resp *http.Response) (string, error) {
 	if !lengthDone {
 		return "", errMalformedErrorMessageLength
 	}
-	sr := snappy.NewReader(rawReader)
+	sr := snappypool.Reader(rawReader)
+	defer snappypool.PutReader(sr)
 	decoded, err := io.ReadAll(io.LimitReader(sr, maxErrorMessageBytes))
 	if err != nil {
 		return "", err

--- a/cl/sentinel/httpreqresp/server_test.go
+++ b/cl/sentinel/httpreqresp/server_test.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/golang/snappy"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -34,6 +33,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/cl/sentinel/communication"
+	"github.com/erigontech/erigon/common/snappypool"
 )
 
 func TestMaxResponseBodySize(t *testing.T) {
@@ -116,7 +116,8 @@ func TestResponseCodeErrorMessageRejectsOverlongLengthVarint(t *testing.T) {
 func TestResponseCodeErrorMessageCapsDecodedMessage(t *testing.T) {
 	var body bytes.Buffer
 	body.WriteByte(0x01)
-	sw := snappy.NewBufferedWriter(&body)
+	sw := snappypool.Writer(&body)
+	defer snappypool.PutWriter(sw)
 	_, err := sw.Write(bytes.Repeat([]byte{'x'}, maxErrorMessageBytes+1))
 	require.NoError(t, err)
 	require.NoError(t, sw.Close())

--- a/cl/sentinel/sentinel_requests_test.go
+++ b/cl/sentinel/sentinel_requests_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/snappy"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
@@ -48,6 +47,7 @@ import (
 	"github.com/erigontech/erigon/cl/utils/eth_clock"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/common/snappypool"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/dbcfg"
@@ -198,6 +198,8 @@ func testSentinelBlocksByRange(t *testing.T) {
 
 	responsePacket := make([]*cltypes.SignedBeaconBlock, 0)
 	r := bytes.NewReader(w.Bytes())
+	sr := snappypool.Reader(r)
+	defer snappypool.PutReader(sr)
 	for range blocks {
 		forkDigest := make([]byte, 4)
 		if _, err := r.Read(forkDigest); err != nil {
@@ -211,7 +213,7 @@ func testSentinelBlocksByRange(t *testing.T) {
 		noErr(err)
 
 		raw := make([]byte, encodedLn)
-		sr := snappy.NewReader(r)
+		sr.Reset(r)
 		bytesRead := 0
 		for bytesRead < int(encodedLn) {
 			n, err := sr.Read(raw[bytesRead:])
@@ -278,6 +280,8 @@ func testSentinelBlocksByRoots(t *testing.T) {
 
 	responsePacket := make([]*cltypes.SignedBeaconBlock, 0)
 	r := bytes.NewReader(w.Bytes())
+	sr := snappypool.Reader(r)
+	defer snappypool.PutReader(sr)
 	for range blocks {
 		forkDigest := make([]byte, 4)
 		if _, err := r.Read(forkDigest); err != nil {
@@ -291,7 +295,7 @@ func testSentinelBlocksByRoots(t *testing.T) {
 		noErr(err)
 
 		raw := make([]byte, encodedLn)
-		sr := snappy.NewReader(r)
+		sr.Reset(r)
 		bytesRead := 0
 		for bytesRead < int(encodedLn) {
 			n, err := sr.Read(raw[bytesRead:])

--- a/common/snappypool/pool.go
+++ b/common/snappypool/pool.go
@@ -1,0 +1,60 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+// Package snappypool pools the stream codecs of github.com/golang/snappy. Each
+// NewReader or NewBufferedWriter allocates ~139 KiB of scratch buffers, which is
+// worth reusing on paths that codec one message at a time.
+package snappypool
+
+import (
+	"io"
+	"sync"
+
+	"github.com/golang/snappy"
+)
+
+var (
+	readers = sync.Pool{New: func() any { return snappy.NewReader(nil) }}
+	writers = sync.Pool{New: func() any { return snappy.NewBufferedWriter(nil) }}
+)
+
+// Reader returns a pooled reader bound to r. Reset it again for every frame
+// stream, since a wire response carries a separate stream per chunk.
+func Reader(r io.Reader) *snappy.Reader {
+	sr := readers.Get().(*snappy.Reader)
+	sr.Reset(r)
+	return sr
+}
+
+// PutReader parks sr in the pool. Reset(nil) keeps it from pinning the caller's
+// reader while parked.
+func PutReader(sr *snappy.Reader) {
+	sr.Reset(nil)
+	readers.Put(sr)
+}
+
+func Writer(w io.Writer) *snappy.Writer {
+	sw := writers.Get().(*snappy.Writer)
+	sw.Reset(w)
+	return sw
+}
+
+// PutWriter parks sw in the pool. Flush first: Reset drops whatever is still
+// buffered.
+func PutWriter(sw *snappy.Writer) {
+	sw.Reset(nil)
+	writers.Put(sw)
+}


### PR DESCRIPTION
Every `snappy.NewReader` / `NewBufferedWriter` allocates ~142 KB of scratch buffers (2 allocs). `parseResponseData` built one per response chunk, so a 64-block `BeaconBlocksByRange` response burned ~8.7 MB of garbage; the sentinel handlers and the fork-graph state dump paid it per message.

New `common/snappypool` holds a reader and a writer pool, and every call site in `cl/` takes its codec from there — including the tests, so copy-paste keeps using it. `PutReader`/`PutWriter` reset to nil first, otherwise a parked codec pins the caller's stream or buffer.

The `forkGraphDisk.sszSnappyReader`/`sszSnappyWriter` fields go away with it: the pool replaces the hand-rolled per-struct cache, and a closed `afero.File` is no longer retained after a read.

Existing `cl/sentinel/...`, `cl/rpc` and `cl/phase1/forkchoice/fork_graph` suites pass, `-short` and `-race`.