### PR TITLE
cl/persistence, db: pool zstd decoders, lower what zstd encoders hold

### DIFF
--- a/cl/persistence/base_encoding/rabbit.go
+++ b/cl/persistence/base_encoding/rabbit.go
@@ -28,7 +28,7 @@ import (
 
 func WriteRabbits(in []uint64, w io.Writer) error {
 	// Retrieve compressor first.
-	compressor := compressorPool.Get().(*zstd.Encoder)
+	compressor := zstdWriterPool.Get().(*zstd.Encoder)
 	defer putComp(compressor)
 	compressor.Reset(w)
 

--- a/cl/persistence/base_encoding/rabbit.go
+++ b/cl/persistence/base_encoding/rabbit.go
@@ -22,15 +22,12 @@ import (
 	"fmt"
 	"io"
 	"math"
-
-	"github.com/klauspost/compress/zstd"
 )
 
 func WriteRabbits(in []uint64, w io.Writer) error {
 	// Retrieve compressor first.
-	compressor := zstdWriterPool.Get().(*zstd.Encoder)
-	defer putComp(compressor)
-	compressor.Reset(w)
+	compressor := getZstdWriter(w)
+	defer putZstdWriter(compressor)
 
 	var buf [8]byte
 	writeNum := func(v uint64) error {

--- a/cl/persistence/base_encoding/rabbit.go
+++ b/cl/persistence/base_encoding/rabbit.go
@@ -77,11 +77,11 @@ func WriteRabbits(in []uint64, w io.Writer) error {
 
 func ReadRabbits(out []uint64, r io.Reader) ([]uint64, error) {
 	// Retrieve compressor first
-	decompressor, err := zstd.NewReader(r)
+	decompressor, err := GetZstdReader(r)
 	if err != nil {
 		return nil, err
 	}
-	defer decompressor.Close()
+	defer PutZstdReader(decompressor)
 
 	var buf [8]byte
 	readNum := func() (uint64, error) {

--- a/cl/persistence/base_encoding/rabbit_test.go
+++ b/cl/persistence/base_encoding/rabbit_test.go
@@ -161,7 +161,7 @@ func leScalars(vs ...uint64) []byte {
 
 func zstdCompress(t *testing.T, payload []byte) io.Reader {
 	t.Helper()
-	compressor := compressorPool.Get().(*zstd.Encoder)
+	compressor := zstdWriterPool.Get().(*zstd.Encoder)
 	defer putComp(compressor)
 	var b bytes.Buffer
 	compressor.Reset(&b)

--- a/cl/persistence/base_encoding/rabbit_test.go
+++ b/cl/persistence/base_encoding/rabbit_test.go
@@ -161,10 +161,9 @@ func leScalars(vs ...uint64) []byte {
 
 func zstdCompress(t *testing.T, payload []byte) io.Reader {
 	t.Helper()
-	compressor := zstdWriterPool.Get().(*zstd.Encoder)
-	defer putComp(compressor)
 	var b bytes.Buffer
-	compressor.Reset(&b)
+	compressor := getZstdWriter(&b)
+	defer putZstdWriter(compressor)
 	_, err := compressor.Write(payload)
 	require.NoError(t, err)
 	require.NoError(t, compressor.Close())

--- a/cl/persistence/base_encoding/uint64_diff.go
+++ b/cl/persistence/base_encoding/uint64_diff.go
@@ -72,7 +72,10 @@ func GetZstdReader(r io.Reader) (*zstd.Decoder, error) {
 }
 
 func PutZstdReader(v *zstd.Decoder) {
-	_ = v.Reset(nil)
+	// Reset fails only on a closed decoder, which can never be revived.
+	if err := v.Reset(nil); err != nil {
+		return
+	}
 	zstdReaderPool.Put(v)
 }
 

--- a/cl/persistence/base_encoding/uint64_diff.go
+++ b/cl/persistence/base_encoding/uint64_diff.go
@@ -44,6 +44,32 @@ func putComp(v *zstd.Encoder) {
 	compressorPool.Put(v)
 }
 
+var decompressorPool = sync.Pool{
+	New: func() any {
+		decompressor, err := zstd.NewReader(nil)
+		if err != nil {
+			panic(err)
+		}
+		return decompressor
+	},
+}
+
+// GetZstdReader returns a pooled decoder reading r. Release with PutZstdReader, not
+// Close: Close is permanent.
+func GetZstdReader(r io.Reader) (*zstd.Decoder, error) {
+	decompressor := decompressorPool.Get().(*zstd.Decoder)
+	if err := decompressor.Reset(r); err != nil {
+		PutZstdReader(decompressor)
+		return nil, err
+	}
+	return decompressor, nil
+}
+
+func PutZstdReader(v *zstd.Decoder) {
+	_ = v.Reset(nil)
+	decompressorPool.Put(v)
+}
+
 var repeatedPatternBufferPool = sync.Pool{
 	New: func() any {
 		b := make([]repeatedPatternEntry, 1028)
@@ -138,11 +164,11 @@ func ApplyCompressedSerializedUint64ListDiff(in, out []byte, diff []byte, revers
 	}
 	var entry repeatedPatternEntry
 
-	decompressor, err := zstd.NewReader(reader)
+	decompressor, err := GetZstdReader(reader)
 	if err != nil {
 		return nil, err
 	}
-	defer decompressor.Close()
+	defer PutZstdReader(decompressor)
 
 	temp := make([]byte, 8)
 	currIndex := 0

--- a/cl/persistence/base_encoding/uint64_diff.go
+++ b/cl/persistence/base_encoding/uint64_diff.go
@@ -29,7 +29,7 @@ import (
 )
 
 // make a sync.pool of compressors (zstd)
-var compressorPool = sync.Pool{
+var zstdWriterPool = sync.Pool{
 	New: func() any {
 		compressor, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedFastest))
 		if err != nil {
@@ -41,10 +41,10 @@ var compressorPool = sync.Pool{
 
 func putComp(v *zstd.Encoder) {
 	v.Reset(nil)
-	compressorPool.Put(v)
+	zstdWriterPool.Put(v)
 }
 
-var decompressorPool = sync.Pool{
+var zstdReaderPool = sync.Pool{
 	New: func() any {
 		decompressor, err := zstd.NewReader(nil)
 		if err != nil {
@@ -57,7 +57,7 @@ var decompressorPool = sync.Pool{
 // GetZstdReader returns a pooled decoder reading r. Release with PutZstdReader, not
 // Close: Close is permanent.
 func GetZstdReader(r io.Reader) (*zstd.Decoder, error) {
-	decompressor := decompressorPool.Get().(*zstd.Decoder)
+	decompressor := zstdReaderPool.Get().(*zstd.Decoder)
 	if err := decompressor.Reset(r); err != nil {
 		PutZstdReader(decompressor)
 		return nil, err
@@ -67,7 +67,7 @@ func GetZstdReader(r io.Reader) (*zstd.Decoder, error) {
 
 func PutZstdReader(v *zstd.Decoder) {
 	_ = v.Reset(nil)
-	decompressorPool.Put(v)
+	zstdReaderPool.Put(v)
 }
 
 var repeatedPatternBufferPool = sync.Pool{
@@ -87,7 +87,7 @@ func ComputeCompressedSerializedUint64ListDiff(w io.Writer, oldVal, newVal []byt
 		return errors.New("old list is longer than new list")
 	}
 
-	compressor := compressorPool.Get().(*zstd.Encoder)
+	compressor := zstdWriterPool.Get().(*zstd.Encoder)
 	defer putComp(compressor)
 	compressor.Reset(w)
 

--- a/cl/persistence/base_encoding/uint64_diff.go
+++ b/cl/persistence/base_encoding/uint64_diff.go
@@ -28,7 +28,6 @@ import (
 	"github.com/klauspost/compress/zstd"
 )
 
-// make a sync.pool of compressors (zstd)
 var zstdWriterPool = sync.Pool{
 	New: func() any {
 		compressor, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedFastest))
@@ -39,7 +38,14 @@ var zstdWriterPool = sync.Pool{
 	},
 }
 
-func putComp(v *zstd.Encoder) {
+// getZstdWriter returns a pooled encoder writing to w. Release with putZstdWriter.
+func getZstdWriter(w io.Writer) *zstd.Encoder {
+	compressor := zstdWriterPool.Get().(*zstd.Encoder)
+	compressor.Reset(w)
+	return compressor
+}
+
+func putZstdWriter(v *zstd.Encoder) {
 	v.Reset(nil)
 	zstdWriterPool.Put(v)
 }
@@ -87,9 +93,8 @@ func ComputeCompressedSerializedUint64ListDiff(w io.Writer, oldVal, newVal []byt
 		return errors.New("old list is longer than new list")
 	}
 
-	compressor := zstdWriterPool.Get().(*zstd.Encoder)
-	defer putComp(compressor)
-	compressor.Reset(w)
+	compressor := getZstdWriter(w)
+	defer putZstdWriter(compressor)
 
 	// Get one repeated pattern buffer from the pool
 	repeatedPatternPtr := repeatedPatternBufferPool.Get().(*[]repeatedPatternEntry)

--- a/cl/persistence/beacon_indicies/indicies.go
+++ b/cl/persistence/beacon_indicies/indicies.go
@@ -34,10 +34,14 @@ import (
 	"github.com/erigontech/erigon/db/kv/dbutils"
 )
 
-// make a zstd writer pool
+// Encoder options must not change the output: these bytes are copied verbatim into
+// the caplin .seg files. These two do not, and halve what an encoder holds.
 var zstdWriterPool = &sync.Pool{
 	New: func() any {
-		encoder, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedBetterCompression))
+		encoder, err := zstd.NewWriter(nil,
+			zstd.WithEncoderLevel(zstd.SpeedBetterCompression),
+			zstd.WithEncoderConcurrency(1),
+			zstd.WithLowerEncoderMem(true))
 		if err != nil {
 			panic(err)
 		}

--- a/cl/persistence/beacon_indicies/indicies.go
+++ b/cl/persistence/beacon_indicies/indicies.go
@@ -36,8 +36,7 @@ import (
 )
 
 // Encoder options must not change the output: these bytes are copied verbatim into
-// the caplin .seg files. Lower encoder memory does not, and cuts what an encoder
-// holds by ~40%.
+// the caplin .seg files.
 var zstdWriterPool = &sync.Pool{
 	New: func() any {
 		encoder, err := zstd.NewWriter(nil,

--- a/cl/persistence/beacon_indicies/indicies.go
+++ b/cl/persistence/beacon_indicies/indicies.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"sync"
 
 	"github.com/klauspost/compress/zstd"
@@ -35,12 +36,12 @@ import (
 )
 
 // Encoder options must not change the output: these bytes are copied verbatim into
-// the caplin .seg files. These two do not, and halve what an encoder holds.
+// the caplin .seg files. Lower encoder memory does not, and cuts what an encoder
+// holds by ~40%.
 var zstdWriterPool = &sync.Pool{
 	New: func() any {
 		encoder, err := zstd.NewWriter(nil,
 			zstd.WithEncoderLevel(zstd.SpeedBetterCompression),
-			zstd.WithEncoderConcurrency(1),
 			zstd.WithLowerEncoderMem(true))
 		if err != nil {
 			panic(err)
@@ -49,7 +50,14 @@ var zstdWriterPool = &sync.Pool{
 	},
 }
 
-func putWriter(v *zstd.Encoder) {
+// getZstdWriter returns a pooled encoder writing to w. Release with putZstdWriter.
+func getZstdWriter(w io.Writer) *zstd.Encoder {
+	encoder := zstdWriterPool.Get().(*zstd.Encoder)
+	encoder.Reset(w)
+	return encoder
+}
+
+func putZstdWriter(v *zstd.Encoder) {
 	v.Reset(nil)
 	zstdWriterPool.Put(v)
 }
@@ -350,9 +358,8 @@ func WriteBeaconBlock(ctx context.Context, tx kv.RwTx, block *cltypes.SignedBeac
 	// take a buffer and encoder
 	buf := pool.GetBuffer()
 	defer pool.PutBuffer(buf)
-	encoder := zstdWriterPool.Get().(*zstd.Encoder)
-	defer putWriter(encoder)
-	encoder.Reset(buf)
+	encoder := getZstdWriter(buf)
+	defer putZstdWriter(encoder)
 	_, err = snapshot_format.WriteBlockForSnapshot(encoder, block, nil)
 	if err != nil {
 		return err

--- a/cl/persistence/beacon_indicies/indicies_test.go
+++ b/cl/persistence/beacon_indicies/indicies_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"math/rand"
 	"testing"
 
 	"github.com/klauspost/compress/zstd"
@@ -383,9 +384,8 @@ func TestHasMorePrunableBeaconBlocksReturnsCursorError(t *testing.T) {
 	require.ErrorIs(t, err, wantErr)
 }
 
-// The encoder options must not change the output: these bytes are copied verbatim
-// into the caplin .seg files.
-func TestWriteBeaconBlockMatchesDefaultEncoderOptions(t *testing.T) {
+// See zstdWriterPool for why the output has to stay byte-identical.
+func TestWriteBeaconBlockMatchesReferenceEncoderOptions(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
 	tx, err := db.BeginRw(context.Background())
@@ -410,4 +410,36 @@ func TestWriteBeaconBlockMatchesDefaultEncoderOptions(t *testing.T) {
 	require.NoError(t, enc.Close())
 
 	require.Equal(t, want.Bytes(), stored)
+}
+
+// Window and history options only start to change the output once a payload crosses
+// the 128KiB block size, which a single beacon block stays well below.
+func TestZstdWriterPoolMatchesReferenceEncoderOptionsOnLargePayload(t *testing.T) {
+	payload := make([]byte, 4<<20)
+	r := rand.New(rand.NewSource(1))
+	for i := range payload {
+		if i%23 == 0 {
+			payload[i] = byte(r.Intn(256))
+		} else {
+			payload[i] = byte(i % 251)
+		}
+	}
+
+	var want bytes.Buffer
+	ref, err := zstd.NewWriter(&want, zstd.WithEncoderLevel(zstd.SpeedBetterCompression))
+	require.NoError(t, err)
+	_, err = ref.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, ref.Close())
+
+	// Twice, so a pooled encoder also has to match after reuse.
+	for range 2 {
+		var got bytes.Buffer
+		enc := getZstdWriter(&got)
+		_, err = enc.Write(payload)
+		require.NoError(t, err)
+		require.NoError(t, enc.Close())
+		putZstdWriter(enc)
+		require.Equal(t, want.Bytes(), got.Bytes())
+	}
 }

--- a/cl/persistence/beacon_indicies/indicies_test.go
+++ b/cl/persistence/beacon_indicies/indicies_test.go
@@ -17,6 +17,7 @@
 package beacon_indicies
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"testing"
@@ -26,6 +27,7 @@ import (
 
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/persistence/format/snapshot_format"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/dbcfg"
@@ -379,4 +381,33 @@ func TestHasMorePrunableBeaconBlocksReturnsCursorError(t *testing.T) {
 
 	require.False(t, hasMore)
 	require.ErrorIs(t, err, wantErr)
+}
+
+// The encoder options must not change the output: these bytes are copied verbatim
+// into the caplin .seg files.
+func TestWriteBeaconBlockMatchesDefaultEncoderOptions(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	tx, err := db.BeginRw(context.Background())
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.Phase0Version)
+	block.Block.Slot = 42
+	block.EncodingSizeSSZ()
+	blockRoot, err := block.Block.HashSSZ()
+	require.NoError(t, err)
+
+	require.NoError(t, WriteBeaconBlock(context.Background(), tx, block))
+	stored, err := tx.GetOne(kv.BeaconBlocks, dbutils.BlockBodyKey(block.Block.Slot, blockRoot))
+	require.NoError(t, err)
+
+	var want bytes.Buffer
+	enc, err := zstd.NewWriter(&want, zstd.WithEncoderLevel(zstd.SpeedBetterCompression))
+	require.NoError(t, err)
+	_, err = snapshot_format.WriteBlockForSnapshot(enc, block, nil)
+	require.NoError(t, err)
+	require.NoError(t, enc.Close())
+
+	require.Equal(t, want.Bytes(), stored)
 }

--- a/cl/persistence/state/historical_states_reader/historical_states_reader.go
+++ b/cl/persistence/state/historical_states_reader/historical_states_reader.go
@@ -24,8 +24,6 @@ import (
 	"io"
 	"time"
 
-	"github.com/klauspost/compress/zstd"
-
 	"github.com/erigontech/erigon/cl/beacon/synced_data"
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
@@ -581,11 +579,11 @@ func (r *HistoricalStatesReader) reconstructDiffedUint64List(tx kv.Tx, kvGetter 
 	}
 
 	// Read the diff file
-	zstdReader, err := zstd.NewReader(bytes.NewReader(compressed))
+	zstdReader, err := base_encoding.GetZstdReader(bytes.NewReader(compressed))
 	if err != nil {
 		return nil, err
 	}
-	defer zstdReader.Close()
+	defer base_encoding.PutZstdReader(zstdReader)
 
 	currentList := make([]byte, validatorSetLength*8)
 	if _, err = io.ReadFull(zstdReader, currentList); err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
@@ -666,11 +664,11 @@ func (r *HistoricalStatesReader) reconstructBalances(tx kv.Tx, kvGetter state_ac
 	if len(compressed) == 0 {
 		return nil, fmt.Errorf("dump not found for slot %d", freshDumpSlot)
 	}
-	zstdReader, err := zstd.NewReader(bytes.NewReader(compressed))
+	zstdReader, err := base_encoding.GetZstdReader(bytes.NewReader(compressed))
 	if err != nil {
 		return nil, err
 	}
-	defer zstdReader.Close()
+	defer base_encoding.PutZstdReader(zstdReader)
 	currentList := make([]byte, validatorSetLength*8)
 	if _, err = io.ReadFull(zstdReader, currentList); err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
 		return nil, err
@@ -751,11 +749,11 @@ func (r *HistoricalStatesReader) ReconstructUint64ListDump(kvGetter state_access
 		return err
 	}
 	// Read the diff file
-	zstdReader, err := zstd.NewReader(&b)
+	zstdReader, err := base_encoding.GetZstdReader(&b)
 	if err != nil {
 		return err
 	}
-	defer zstdReader.Close()
+	defer base_encoding.PutZstdReader(zstdReader)
 	currentList := make([]byte, size*8)
 
 	if _, err = io.ReadFull(zstdReader, currentList); err != nil && !errors.Is(err, io.EOF) {
@@ -1036,11 +1034,11 @@ func ReadQueueSSZ[T solid.EncodableHashableSSZ](kvGetter state_accessors.GetValF
 	}
 
 	if len(compressed) != 0 {
-		zstdReader, err := zstd.NewReader(bytes.NewReader(compressed))
+		zstdReader, err := base_encoding.GetZstdReader(bytes.NewReader(compressed))
 		if err != nil {
 			return err
 		}
-		defer zstdReader.Close()
+		defer base_encoding.PutZstdReader(zstdReader)
 
 		sszEnc, err := io.ReadAll(zstdReader)
 		if err != nil {
@@ -1087,11 +1085,11 @@ func ReadRequiredQueueSSZ[T solid.EncodableHashableSSZ](kvGetter state_accessors
 	}
 
 	// Decompress and decode the dump.
-	zstdReader, err := zstd.NewReader(bytes.NewReader(compressed))
+	zstdReader, err := base_encoding.GetZstdReader(bytes.NewReader(compressed))
 	if err != nil {
 		return err
 	}
-	defer zstdReader.Close()
+	defer base_encoding.PutZstdReader(zstdReader)
 	sszEnc, err := io.ReadAll(zstdReader)
 	if err != nil {
 		return err
@@ -1148,11 +1146,11 @@ func readCompressedSSZ[T interface {
 		return fmt.Errorf("%w: table %s, slot %d", ErrMissingGloasData, table, slot)
 	}
 
-	zstdReader, err := zstd.NewReader(bytes.NewReader(compressed))
+	zstdReader, err := base_encoding.GetZstdReader(bytes.NewReader(compressed))
 	if err != nil {
 		return err
 	}
-	defer zstdReader.Close()
+	defer base_encoding.PutZstdReader(zstdReader)
 
 	sszEnc, err := io.ReadAll(zstdReader)
 	if err != nil {

--- a/cl/persistence/state/historical_states_reader/historical_states_reader.go
+++ b/cl/persistence/state/historical_states_reader/historical_states_reader.go
@@ -583,10 +583,10 @@ func (r *HistoricalStatesReader) reconstructDiffedUint64List(tx kv.Tx, kvGetter 
 	if err != nil {
 		return nil, err
 	}
-	defer base_encoding.PutZstdReader(zstdReader)
-
 	currentList := make([]byte, validatorSetLength*8)
-	if _, err = io.ReadFull(zstdReader, currentList); err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
+	_, err = io.ReadFull(zstdReader, currentList)
+	base_encoding.PutZstdReader(zstdReader)
+	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
 		return nil, err
 	}
 
@@ -668,9 +668,10 @@ func (r *HistoricalStatesReader) reconstructBalances(tx kv.Tx, kvGetter state_ac
 	if err != nil {
 		return nil, err
 	}
-	defer base_encoding.PutZstdReader(zstdReader)
 	currentList := make([]byte, validatorSetLength*8)
-	if _, err = io.ReadFull(zstdReader, currentList); err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
+	_, err = io.ReadFull(zstdReader, currentList)
+	base_encoding.PutZstdReader(zstdReader)
+	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
 		return nil, err
 	}
 
@@ -753,10 +754,10 @@ func (r *HistoricalStatesReader) ReconstructUint64ListDump(kvGetter state_access
 	if err != nil {
 		return err
 	}
-	defer base_encoding.PutZstdReader(zstdReader)
 	currentList := make([]byte, size*8)
-
-	if _, err = io.ReadFull(zstdReader, currentList); err != nil && !errors.Is(err, io.EOF) {
+	_, err = io.ReadFull(zstdReader, currentList)
+	base_encoding.PutZstdReader(zstdReader)
+	if err != nil && !errors.Is(err, io.EOF) {
 		return fmt.Errorf("failed to read dump: %w, len: %d", err, len(v))
 	}
 
@@ -1038,9 +1039,8 @@ func ReadQueueSSZ[T solid.EncodableHashableSSZ](kvGetter state_accessors.GetValF
 		if err != nil {
 			return err
 		}
-		defer base_encoding.PutZstdReader(zstdReader)
-
 		sszEnc, err := io.ReadAll(zstdReader)
+		base_encoding.PutZstdReader(zstdReader)
 		if err != nil {
 			return err
 		}
@@ -1089,8 +1089,8 @@ func ReadRequiredQueueSSZ[T solid.EncodableHashableSSZ](kvGetter state_accessors
 	if err != nil {
 		return err
 	}
-	defer base_encoding.PutZstdReader(zstdReader)
 	sszEnc, err := io.ReadAll(zstdReader)
+	base_encoding.PutZstdReader(zstdReader)
 	if err != nil {
 		return err
 	}
@@ -1150,9 +1150,8 @@ func readCompressedSSZ[T interface {
 	if err != nil {
 		return err
 	}
-	defer base_encoding.PutZstdReader(zstdReader)
-
 	sszEnc, err := io.ReadAll(zstdReader)
+	base_encoding.PutZstdReader(zstdReader)
 	if err != nil {
 		return err
 	}

--- a/db/compress/compress.go
+++ b/db/compress/compress.go
@@ -11,7 +11,7 @@ import (
 var (
 	// Decoder side: saw 2x higher throughput (parallel RPC with much decoding if use `zstdDecPool` (sync.Pool) vs single `zstd.NewReader`. So, keep pool for decoders.
 	// Encoder side: saw high mem use when using pool of encoders. And probably we don't need high-throughput on writes (they are usually in background). So, keep 1 encoder - it inside using GOMAXPROCS concurrency limit (see zstd.WithDecoderConcurrency).
-	zstdEnc, _  = zstd.NewWriter(nil, zstd.WithEncoderCRC(false), zstd.WithZeroFrames(true))
+	zstdEnc, _  = zstd.NewWriter(nil, zstd.WithEncoderCRC(false), zstd.WithZeroFrames(true), zstd.WithLowerEncoderMem(true))
 	zstdDecPool = sync.Pool{
 		New: func() any {
 			dec, _ := zstd.NewReader(nil, zstd.IgnoreChecksum(true))

--- a/db/compress/compress.go
+++ b/db/compress/compress.go
@@ -21,7 +21,10 @@ var (
 )
 
 func putDec(dec *zstd.Decoder) {
-	_ = dec.Reset(nil)
+	// Reset fails only on a closed decoder, which can never be revived.
+	if err := dec.Reset(nil); err != nil {
+		return
+	}
 	zstdDecPool.Put(dec)
 }
 

--- a/db/snapshotsync/freezeblocks/beacon_block_reader.go
+++ b/db/snapshotsync/freezeblocks/beacon_block_reader.go
@@ -56,7 +56,10 @@ func getZstdReader(r io.Reader) (*zstd.Decoder, error) {
 }
 
 func putZstdReader(reader *zstd.Decoder) {
-	_ = reader.Reset(nil)
+	// Reset fails only on a closed decoder, which can never be revived.
+	if err := reader.Reset(nil); err != nil {
+		return
+	}
 	zstdReaderPool.Put(reader)
 }
 
@@ -231,13 +234,6 @@ func (r *beaconSnapshotReader) ReadBlockByRoot(ctx context.Context, tx kv.Tx, ro
 	var buf []byte
 	// When no snapshots are available (BlocksAvailable==0) or slot exceeds snapshot range, read from DB.
 	if r.sn.BlocksAvailable() == 0 || *slot > r.sn.BlocksAvailable() {
-		slot, err := beacon_indicies.ReadBlockSlotByBlockRoot(tx, root)
-		if err != nil {
-			return nil, err
-		}
-		if slot == nil {
-			return nil, nil
-		}
 		buf, err = tx.GetOne(kv.BeaconBlocks, dbutils.BlockBodyKey(*slot, root))
 		if err != nil {
 			return nil, err

--- a/db/snapshotsync/freezeblocks/beacon_block_reader.go
+++ b/db/snapshotsync/freezeblocks/beacon_block_reader.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"sync"
 
 	"github.com/klauspost/compress/zstd"
@@ -34,7 +35,7 @@ import (
 	"github.com/erigontech/erigon/execution/types"
 )
 
-var decompressorPool = sync.Pool{
+var zstdReaderPool = sync.Pool{
 	New: func() any {
 		r, err := zstd.NewReader(nil)
 		if err != nil {
@@ -44,9 +45,19 @@ var decompressorPool = sync.Pool{
 	},
 }
 
-func putDecoder(reader *zstd.Decoder) {
+// getZstdReader returns a pooled decoder reading r. Release with putZstdReader.
+func getZstdReader(r io.Reader) (*zstd.Decoder, error) {
+	reader := zstdReaderPool.Get().(*zstd.Decoder)
+	if err := reader.Reset(r); err != nil {
+		putZstdReader(reader)
+		return nil, err
+	}
+	return reader, nil
+}
+
+func putZstdReader(reader *zstd.Decoder) {
 	_ = reader.Reset(nil)
-	decompressorPool.Put(reader)
+	zstdReaderPool.Put(reader)
 }
 
 type BeaconSnapshotReader interface {
@@ -136,9 +147,11 @@ func (r *beaconSnapshotReader) ReadBlockBySlot(ctx context.Context, tx kv.Tx, sl
 	}
 
 	// Decompress this thing
-	reader := decompressorPool.Get().(*zstd.Decoder)
-	defer putDecoder(reader)
-	reader.Reset(bytes.NewReader(buf))
+	reader, err := getZstdReader(bytes.NewReader(buf))
+	if err != nil {
+		return nil, err
+	}
+	defer putZstdReader(reader)
 
 	// Use pooled readers to avoid allocations.
 	return snapshot_format.ReadBlockFromSnapshot(reader, r.eth1Getter, r.cfg)
@@ -193,9 +206,11 @@ func (r *beaconSnapshotReader) ReadBeaconBlockBodyBySlot(ctx context.Context, tx
 	}
 
 	// Decompress this thing
-	reader := decompressorPool.Get().(*zstd.Decoder)
-	defer putDecoder(reader)
-	reader.Reset(bytes.NewReader(buf))
+	reader, err := getZstdReader(bytes.NewReader(buf))
+	if err != nil {
+		return nil, err
+	}
+	defer putZstdReader(reader)
 
 	// Use pooled readers to avoid allocations.
 	return snapshot_format.ReadBeaconBlockBodyFromSnapshot(reader, r.cfg)
@@ -266,9 +281,11 @@ func (r *beaconSnapshotReader) ReadBlockByRoot(ctx context.Context, tx kv.Tx, ro
 		return nil, nil
 	}
 	// Decompress this thing
-	reader := decompressorPool.Get().(*zstd.Decoder)
-	defer putDecoder(reader)
-	reader.Reset(bytes.NewReader(buf))
+	reader, err := getZstdReader(bytes.NewReader(buf))
+	if err != nil {
+		return nil, err
+	}
+	defer putZstdReader(reader)
 
 	// Use pooled readers to avoid allocations.
 	return snapshot_format.ReadBlockFromSnapshot(reader, r.eth1Getter, r.cfg)

--- a/db/snapshotsync/freezeblocks/caplin_snapshots.go
+++ b/db/snapshotsync/freezeblocks/caplin_snapshots.go
@@ -24,8 +24,6 @@ import (
 	"math"
 	"path/filepath"
 
-	"github.com/klauspost/compress/zstd"
-
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/persistence/beacon_indicies"
@@ -474,9 +472,11 @@ func (s *CaplinSnapshots) ReadHeader(slot uint64, tx kv.Tx) (*cltypes.SignedBeac
 		return nil, 0, common.Hash{}, nil
 	}
 	// Decompress this thing
-	reader := decompressorPool.Get().(*zstd.Decoder)
-	defer putDecoder(reader)
-	reader.Reset(bytes.NewReader(buf))
+	reader, err := getZstdReader(bytes.NewReader(buf))
+	if err != nil {
+		return nil, 0, common.Hash{}, err
+	}
+	defer putZstdReader(reader)
 
 	// Use pooled readers to avoid allocations.
 	header, elBlockNumber, elBlockHash, err := snapshot_format.ReadBlockHeaderFromSnapshotWithExecutionData(reader, s.beaconCfg)


### PR DESCRIPTION
Eight caplin decode sites built a zstd decoder per call and released it with `Close`, which is permanent — so nothing was ever reused. `base_encoding` now owns a `zstdReaderPool` next to its writer pool, and the six sites in `historical_states_reader.go` plus `uint64_diff.go` and `rabbit.go` take from it.

`WithLowerEncoderMem(true)` flips the encoder history buffer from two windows to one window plus a block (`enc_base.go` `ensureHist`), and `Reset` keeps that buffer for the encoder's life — so it is what a pooled or long-lived encoder holds, not a per-call cost. Applied to the `beacon_indicies` pool and the `db/compress` encoder.

Output is byte-identical, which these paths need: `WriteBeaconBlock`'s bytes are copied verbatim into the caplin `.seg` files, and `db/compress` feeds `db/seg`. `TestZstdWriterPoolMatchesReferenceEncoderOptionsOnLargePayload` pins that at 4MiB — above zstd's 128KiB block size, where window options start to change output.

`WithEncoderConcurrency` is deliberately not set: in `db/compress` it is what serves concurrent `EncodeAll` callers.

Behaviour changes:

- The four `freezeblocks` reader sites propagate the `Decoder.Reset` error they used to drop.
- All three release helpers drop a decoder whose `Reset(nil)` fails instead of pooling it. `Reset` returns only `ErrDecoderClosed`, and a closed decoder cannot be revived, so pooling it poisoned the pool for the life of the process.
- `historical_states_reader` returns each decoder right after the read rather than at function exit, so a large-frame decoder is not pinned across the per-slot diff loop that borrows from the same pool.

Not addressed here: pooled decoders retain their frame-history buffer, so a multi-MB dump decoder can be reused for small diffs; both decoder pools use the default `GOMAXPROCS` concurrency, which suits large payloads and not small ones, so the fix is probably a second pool rather than one setting. `cl/antiquary/beacon_states_collector.go` holds a long-lived encoder that did not get `WithLowerEncoderMem`.
