### PR TITLE
[r3.6] cl/beacon: prime the execution layer before a slot this node proposes

### DIFF
--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -204,12 +204,35 @@ func attestationDue(cfg *clparams.BeaconChainConfig, stateVersion clparams.State
 	return time.Duration(cfg.AttestationDueMs(stateVersion.AfterOrEqual(clparams.GloasVersion))) * time.Millisecond
 }
 
-// computeBlockBuilderWindow returns when to first poll for the assembled payload and when to stop,
-// reserving a publication margin before the attestation deadline (see payloadPublicationDivisor).
-func computeBlockBuilderWindow(now, slotStart time.Time, cfg *clparams.BeaconChainConfig, stateVersion clparams.StateVersion) blockBuilderWindow {
+// unpreparedGrabOffset is the normal payload collection deadline measured from the slot start. It
+// reserves the final publication share of the attestation window for processing, signing, and gossip.
+func unpreparedGrabOffset(due time.Duration) time.Duration {
+	return due - due/payloadPublicationDivisor
+}
+
+// preparedGrabOffset is the earlier collection point available to a builder that was warmed before
+// the slot. The minimum-age check below preserves the build time available on the unprepared path.
+func preparedGrabOffset(due time.Duration) time.Duration {
+	return due / payloadPublicationDivisor
+}
+
+// preparedPayloadMinimumAge is how long a primed builder must already have been running before
+// production may collect from it early. It is the gap between prepared and unprepared collection
+// offsets, so both paths give the builder the same total build time.
+func preparedPayloadMinimumAge(cfg *clparams.BeaconChainConfig, stateVersion clparams.StateVersion) time.Duration {
 	due := attestationDue(cfg, stateVersion)
-	grabBy := slotStart.Add(due - due/payloadPublicationDivisor)
+	return max(unpreparedGrabOffset(due)-preparedGrabOffset(due), 0)
+}
+
+// computeBlockBuilderWindow returns when to first poll for the assembled payload and when to stop,
+// reserving a publication margin before the attestation deadline.
+func computeBlockBuilderWindow(now, slotStart time.Time, cfg *clparams.BeaconChainConfig, stateVersion clparams.StateVersion, prepared bool) blockBuilderWindow {
+	due := attestationDue(cfg, stateVersion)
+	grabBy := slotStart.Add(unpreparedGrabOffset(due))
 	firstGetAt := grabBy.Add(-minPayloadPollingWindow)
+	if prepared {
+		firstGetAt = slotStart.Add(preparedGrabOffset(due)).Add(-minPayloadPollingWindow)
+	}
 	if firstGetAt.Before(now) {
 		firstGetAt = now
 	}
@@ -547,6 +570,11 @@ func (a *ApiHandler) GetEthV3ValidatorBlock(
 	r *http.Request,
 ) (*beaconhttp.BeaconResponse, error) {
 	ctx := r.Context()
+	// Cover the whole request so preparation cannot enter the execution layer while production is
+	// still deriving or collecting the block.
+	finishProduction := a.payloadPreparationGate.beginProduction()
+	defer finishProduction()
+
 	// parse request data
 	randaoRevealString := r.URL.Query().Get("randao_reveal")
 	var randaoReveal common.Bytes96
@@ -1089,9 +1117,6 @@ func (a *ApiHandler) produceBeaconBody(
 			}
 		}
 	}
-	currEpoch := a.ethClock.GetCurrentEpoch()
-	random := baseState.GetRandaoMixes(currEpoch)
-
 	var executionPayload *cltypes.Eth1Block
 	var executionValue uint64
 	// One collector per concurrent body step. Sharing one would be a write-write race whenever
@@ -1120,15 +1145,8 @@ func (a *ApiHandler) produceBeaconBody(
 			return
 		}
 		slotNumber := hexutil.Uint64(targetSlot)
-		attrs := payloadAttributes(
-			stateVersion,
-			hexutil.Uint64(state.ComputeTimestampAtSlot(baseState, targetSlot)),
-			random,
-			feeRecipient,
-			withdrawals,
-			(*common.Hash)(&blockRoot),
-			&slotNumber,
-			targetGasLimit,
+		attrs := a.payloadBuildAttributes(
+			baseState, blockRoot, targetSlot, feeRecipient, withdrawals, &slotNumber, targetGasLimit, stateVersion,
 		)
 		builderStartedAt := time.Now()
 		idBytes, err := a.engine.ForkChoiceUpdate(
@@ -1148,7 +1166,10 @@ func (a *ApiHandler) produceBeaconBody(
 			return
 		}
 		slotStart := a.ethClock.GetSlotTime(targetSlot)
-		buildWindow := computeBlockBuilderWindow(builderStartedAt, slotStart, a.beaconChainCfg, stateVersion)
+		prepared := a.preparedPayload.matches(
+			targetSlot, idBytes, time.Now(), preparedPayloadMinimumAge(a.beaconChainCfg, stateVersion),
+		)
+		buildWindow := computeBlockBuilderWindow(builderStartedAt, slotStart, a.beaconChainCfg, stateVersion, prepared)
 		payload, bundles, requestsBundle, blockValue, pollErr := pollAssembledPayload(ctx, buildWindow, retryTime, func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
 			return a.engine.GetAssembledBlock(ctx, idBytes, stateVersion)
 		})
@@ -2149,6 +2170,9 @@ func (a *ApiHandler) storeBlockAndBlobs(
 	sidecars []*cltypes.BlobSidecar,
 	columnSidecars []*cltypes.DataColumnSidecar,
 ) error {
+	finishProduction := a.payloadPreparationGate.beginProduction()
+	defer finishProduction()
+
 	blockRoot, err := block.Block.HashSSZ()
 	if err != nil {
 		return err

--- a/cl/beacon/handler/block_production_test.go
+++ b/cl/beacon/handler/block_production_test.go
@@ -67,7 +67,7 @@ func TestBlockBuilderWindowPreGloas(t *testing.T) {
 	slotStart := time.Unix(100, 0)
 	now := slotStart
 
-	window := computeBlockBuilderWindow(now, slotStart, cfg, clparams.ElectraVersion)
+	window := computeBlockBuilderWindow(now, slotStart, cfg, clparams.ElectraVersion, false)
 
 	// Attestation deadline is 4s; polling stops a quarter of it (1s) earlier, at 3s.
 	require.Equal(t, slotStart.Add(3*time.Second).Add(-minPayloadPollingWindow), window.firstGetAt)
@@ -82,7 +82,7 @@ func TestBlockBuilderWindowGloas(t *testing.T) {
 	slotStart := time.Unix(100, 0)
 	now := slotStart
 
-	window := computeBlockBuilderWindow(now, slotStart, cfg, clparams.GloasVersion)
+	window := computeBlockBuilderWindow(now, slotStart, cfg, clparams.GloasVersion, false)
 
 	// Attestation deadline is 3s; polling stops a quarter of it (750ms) earlier, at 2.25s.
 	require.Equal(t, slotStart.Add(2250*time.Millisecond).Add(-minPayloadPollingWindow), window.firstGetAt)
@@ -335,7 +335,7 @@ func TestBlockBuilderWindowLateStartKeepsPublicationMargin(t *testing.T) {
 	slotStart := time.Unix(100, 0)
 	now := slotStart.Add(2950 * time.Millisecond)
 
-	window := computeBlockBuilderWindow(now, slotStart, cfg, clparams.ElectraVersion)
+	window := computeBlockBuilderWindow(now, slotStart, cfg, clparams.ElectraVersion, false)
 
 	// A late request clamps the first poll up to now but still stops at 3s, preserving the margin.
 	require.Equal(t, now, window.firstGetAt)
@@ -350,7 +350,7 @@ func TestBlockBuilderWindowLateRequestGrabsImmediately(t *testing.T) {
 	slotStart := time.Unix(100, 0)
 	now := slotStart.Add(5 * time.Second)
 
-	window := computeBlockBuilderWindow(now, slotStart, cfg, clparams.GloasVersion)
+	window := computeBlockBuilderWindow(now, slotStart, cfg, clparams.GloasVersion, false)
 
 	require.Equal(t, now, window.firstGetAt)
 	require.Equal(t, now, window.pollUntil)
@@ -373,7 +373,7 @@ func TestBlockBuilderWindowReservesPublicationMargin(t *testing.T) {
 		{"gloas", clparams.GloasVersion, 3 * time.Second, 2250 * time.Millisecond},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			window := computeBlockBuilderWindow(slotStart, slotStart, cfg, tc.version)
+			window := computeBlockBuilderWindow(slotStart, slotStart, cfg, tc.version, false)
 			require.Equal(t, slotStart.Add(tc.wantPollUntil), window.pollUntil)
 			require.True(t, window.pollUntil.Before(slotStart.Add(tc.deadline)),
 				"polling must stop before the attestation deadline to leave publication margin")

--- a/cl/beacon/handler/handler.go
+++ b/cl/beacon/handler/handler.go
@@ -106,6 +106,9 @@ type ApiHandler struct {
 	routerCfg *beacon_router_configuration.RouterConfiguration
 	logger    log.Logger
 
+	preparedPayload        preparedPayload
+	payloadPreparationGate payloadPreparationGate
+
 	// Validator data structures
 	validatorParams *validator_params.ValidatorParams
 	// unregisteredProposers remembers which proposers have already been warned about, so the

--- a/cl/beacon/handler/payload_preparation.go
+++ b/cl/beacon/handler/payload_preparation.go
@@ -1,0 +1,397 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package handler
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/erigontech/erigon/cl/beacon/synced_data"
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/erigontech/erigon/cl/phase1/execution_client"
+	"github.com/erigontech/erigon/cl/transition"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/execution/engineapi/engine_types"
+	"github.com/erigontech/erigon/execution/execmodule/chainreader"
+	"github.com/erigontech/erigon/execution/types"
+)
+
+var (
+	errNotOurProposal         = errors.New("next slot is not proposed by a registered validator")
+	errNoPayloadID            = errors.New("execution layer returned no payload id")
+	errHeadTooFarBack         = errors.New("head state is too far behind the slot to prepare")
+	errPreparationHeadChanged = errors.New("selected head changed while preparing payload")
+	errProposalInFlight       = errors.New("block production is in progress")
+	errPreparationTooLate     = errors.New("slot is too close to prime a payload production would use")
+)
+
+// preparedPayloadRetainSlots keeps a primed record alive past the slot it was primed for, so
+// priming the next slot cannot evict the record for a proposal that is still being produced.
+const preparedPayloadRetainSlots = 2
+
+type preparedPayloadRecord struct {
+	id       []byte
+	primedAt time.Time
+}
+
+type preparedPayload struct {
+	mu       sync.Mutex
+	payloads map[uint64]preparedPayloadRecord
+}
+
+// payloadPreparationGate keeps the short builder-start call separate from block production.
+// Preparation never holds the gate while copying state or waiting to retry.
+type payloadPreparationGate struct {
+	attempt sync.RWMutex
+}
+
+func (p *preparedPayload) set(slot uint64, payloadID []byte, primedAt time.Time) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.payloads == nil {
+		p.payloads = map[uint64]preparedPayloadRecord{}
+	}
+	// Slots this far back can no longer be produced, so dropping them bounds the map.
+	for recorded := range p.payloads {
+		if recorded+preparedPayloadRetainSlots < slot {
+			delete(p.payloads, recorded)
+		}
+	}
+	p.payloads[slot] = preparedPayloadRecord{id: bytes.Clone(payloadID), primedAt: primedAt}
+}
+
+func (p *preparedPayload) matches(slot uint64, payloadID []byte, now time.Time, minAge time.Duration) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	record, ok := p.payloads[slot]
+	return ok && len(payloadID) > 0 && bytes.Equal(record.id, payloadID) && now.Sub(record.primedAt) >= minAge
+}
+
+func (g *payloadPreparationGate) beginProduction() func() {
+	g.attempt.RLock()
+	return sync.OnceFunc(g.attempt.RUnlock)
+}
+
+func (g *payloadPreparationGate) idle() bool {
+	if !g.attempt.TryLock() {
+		return false
+	}
+	g.attempt.Unlock()
+	return true
+}
+
+func (g *payloadPreparationGate) tryBeginPreparation() (func(), bool) {
+	if !g.attempt.TryLock() {
+		return nil, false
+	}
+	return g.attempt.Unlock, true
+}
+
+// StartPayloadPreparation primes the execution layer for slots this node is due to propose.
+// The returned channel closes when the preparation loop stops.
+func (a *ApiHandler) StartPayloadPreparation(ctx context.Context) <-chan struct{} {
+	done := make(chan struct{})
+	if a.routerCfg == nil || !a.routerCfg.Validator || a.engine == nil {
+		close(done)
+		return done
+	}
+	// Direct builder startup requires the same local chain access reported by SupportInsertion.
+	if _, ok := a.engine.(execution_client.PayloadBuilder); !ok || !a.engine.SupportInsertion() {
+		close(done)
+		return done
+	}
+	go func() {
+		defer close(done)
+		a.preparePayloadLoop(ctx)
+	}()
+	return done
+}
+
+func (a *ApiHandler) preparePayloadLoop(ctx context.Context) {
+	// A quarter-slot tick lands well inside every slot without assuming when in the slot the head
+	// arrives; preparation is skipped unless the next slot is ours, so the cost is a proposer
+	// lookup on a state we already hold.
+	tick := time.Duration(a.beaconChainCfg.SecondsPerSlot) * time.Second / 4
+	// Preparation is silent on a node that rarely proposes, so say once that it is running:
+	// otherwise a loop that never started looks exactly like one with nothing to do.
+	log.Info("PayloadPreparation: watching for proposals", "every", tick)
+	ticker := time.NewTicker(tick)
+	defer ticker.Stop()
+
+	var lastSettled slotHead
+	var lastFailureLog time.Time
+	for immediate := true; ; immediate = false {
+		if immediate {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+		} else {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
+
+		targetSlot := a.ethClock.GetCurrentSlot() + 1
+		stateVersion := a.beaconChainCfg.GetCurrentStateVersion(targetSlot / a.beaconChainCfg.SlotsPerEpoch)
+		// Gloas uses builder bids instead of local payload priming. Before Capella the payload
+		// attributes needed by this path are not available.
+		if stateVersion.AfterOrEqual(clparams.GloasVersion) {
+			return
+		}
+		if stateVersion.Before(clparams.CapellaVersion) {
+			continue
+		}
+		// This early check avoids state work during production. The gate is checked again before
+		// builder startup to cover production that begins after this point.
+		if !a.payloadPreparationGate.idle() {
+			continue
+		}
+		// Nothing is registered, so nothing here can be ours. Checking first keeps a non-validating
+		// node off the state copy entirely.
+		generation := a.validatorParams.Generation()
+		if generation == 0 {
+			continue
+		}
+		// Before genesis the current slot clamps to zero, so the next slot can be arbitrarily far
+		// off; a builder primed that early hits its own cap before the slot even starts. Too late
+		// and the prime can never reach the age production demands of it.
+		slotStart := a.ethClock.GetSlotTime(targetSlot)
+		lead := time.Until(slotStart)
+		if lead > maxPreparationLead(a.beaconChainCfg) || lead < preparedPayloadMinimumAge(a.beaconChainCfg, stateVersion) {
+			continue
+		}
+		selectedRoot, _, selected := a.syncedData.SelectedHead()
+		if !selected {
+			continue
+		}
+		// Preparation requires the selected and materialized head identities to match. Otherwise
+		// its payload attributes can target stale state.
+		if selectedRoot != a.syncedData.HeadRoot() {
+			continue
+		}
+		// Memoized outcomes remain valid only for the same slot, head and validator registrations.
+		current := slotHead{slot: targetSlot, head: selectedRoot, generation: generation}
+		if current == lastSettled {
+			continue
+		}
+		prepareCtx, cancel := context.WithDeadlineCause(ctx, slotStart, errPreparationTooLate)
+		head, err := a.preparePayloadFor(prepareCtx, targetSlot)
+		cancel()
+		outcome := slotHead{slot: targetSlot, head: head, generation: generation}
+		if err != nil {
+			if errors.Is(err, errNotOurProposal) || errors.Is(err, errNoPayloadID) {
+				lastSettled = outcome
+			}
+			if !isExpectedPreparationSkip(err) && time.Since(lastFailureLog) >= time.Minute {
+				log.Warn("PayloadPreparation: failed", "slot", targetSlot, "err", err)
+				lastFailureLog = time.Now()
+			}
+			continue
+		}
+		lastSettled = outcome
+	}
+}
+
+// slotHead records work already settled for a target slot, on a given head, under a given set of
+// validator registrations. A zero value matches nothing reachable: preparation never runs before
+// the first registration arrives.
+type slotHead struct {
+	slot       uint64
+	head       common.Hash
+	generation uint64
+}
+
+// maxPreparationLead bounds how far ahead of a slot priming is worthwhile. One slot is all a live
+// chain ever offers, since preparation only ever targets the slot after the current one.
+func maxPreparationLead(cfg *clparams.BeaconChainConfig) time.Duration {
+	return time.Duration(cfg.SecondsPerSlot) * time.Second
+}
+
+// isExpectedPreparationSkip reports whether there was simply nothing to prepare, as opposed to a
+// failure worth reporting.
+func isExpectedPreparationSkip(err error) bool {
+	return errors.Is(err, errNotOurProposal) ||
+		errors.Is(err, errNoPayloadID) ||
+		errors.Is(err, errHeadTooFarBack) ||
+		errors.Is(err, errPreparationHeadChanged) ||
+		errors.Is(err, errProposalInFlight) ||
+		errors.Is(err, errPreparationTooLate) ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, synced_data.ErrNotSynced)
+}
+
+// preparePayloadFor starts the builder for targetSlot without changing execution fork choice.
+func (a *ApiHandler) preparePayloadFor(ctx context.Context, targetSlot uint64) (common.Hash, error) {
+	var (
+		baseBlockRoot      common.Hash
+		proposerIndex      uint64
+		feeRecipient       common.Address
+		baseState          *state.CachingBeaconState
+		lookupAfterAdvance bool
+	)
+	// Root, proposer and state all come from one view of the head. Reading them separately would
+	// let a head update in between pair a parent beacon block root with a different state, priming
+	// a builder that production can never match.
+	if err := a.syncedData.ViewHeadStateWithIdentity(func(headState *state.CachingBeaconState, root common.Hash, _ uint64) error {
+		baseBlockRoot = root
+		// Beyond the proposer lookahead the index has to be reshuffled from the seed, which is far
+		// too costly to repeat every tick on a large validator set.
+		slotsPerEpoch := a.beaconChainCfg.SlotsPerEpoch
+		if targetSlot/slotsPerEpoch > headState.Slot()/slotsPerEpoch+a.beaconChainCfg.MinSeedLookahead {
+			return errHeadTooFarBack
+		}
+
+		// Fulu's proposer lookahead is valid across the next epoch, so reject an unregistered
+		// proposer before copying and advancing the full state.
+		lookupAfterAdvance = targetSlot/slotsPerEpoch > headState.Slot()/slotsPerEpoch && headState.Version().Before(clparams.FuluVersion)
+		var err error
+		if !lookupAfterAdvance {
+			if proposerIndex, err = headState.GetBeaconProposerIndexForSlot(targetSlot); err != nil {
+				return err
+			}
+			var ok bool
+			if feeRecipient, ok = a.validatorParams.GetFeeRecipient(proposerIndex); !ok {
+				return errNotOurProposal
+			}
+		}
+		baseState, err = headState.Copy()
+		return err
+	}); err != nil {
+		return baseBlockRoot, err
+	}
+
+	if err := transition.DefaultMachine.ProcessSlots(baseState, targetSlot); err != nil {
+		return baseBlockRoot, err
+	}
+	if lookupAfterAdvance {
+		var err error
+		if proposerIndex, err = baseState.GetBeaconProposerIndexForSlot(targetSlot); err != nil {
+			return baseBlockRoot, err
+		}
+		var ok bool
+		if feeRecipient, ok = a.validatorParams.GetFeeRecipient(proposerIndex); !ok {
+			return baseBlockRoot, errNotOurProposal
+		}
+	}
+
+	stateVersion := a.beaconChainCfg.GetCurrentStateVersion(targetSlot / a.beaconChainCfg.SlotsPerEpoch)
+	// The lead was measured before the copy and the epoch transition, which are slow enough to have
+	// spent it. Stop rather than record a prime production would reject on age.
+	if time.Until(a.ethClock.GetSlotTime(targetSlot)) < preparedPayloadMinimumAge(a.beaconChainCfg, stateVersion) {
+		return baseBlockRoot, errPreparationTooLate
+	}
+	withdrawals, err := a.expectedWithdrawals(baseState, nil, stateVersion, targetSlot)
+	if err != nil {
+		return baseBlockRoot, err
+	}
+	head := baseState.LatestExecutionPayloadHeader().BlockHash
+	attrs := a.payloadBuildAttributes(
+		baseState, baseBlockRoot, targetSlot, feeRecipient, withdrawals, nil, nil, stateVersion,
+	)
+	payloadID, err := a.startPayloadBuildForPreparation(ctx, baseBlockRoot, head, attrs)
+	if err != nil {
+		return baseBlockRoot, err
+	}
+	if len(payloadID) == 0 {
+		return baseBlockRoot, errNoPayloadID
+	}
+	selectedRoot, _, selected := a.syncedData.SelectedHead()
+	if !selected || selectedRoot != baseBlockRoot {
+		return baseBlockRoot, errPreparationHeadChanged
+	}
+
+	a.preparedPayload.set(targetSlot, payloadID, time.Now())
+	log.Info("PayloadPreparation: primed execution layer", "slot", targetSlot, "proposer", proposerIndex, "head", baseBlockRoot)
+	return baseBlockRoot, nil
+}
+
+// startPayloadBuildForPreparation retries only when the execution head is still catching up or the
+// in-process execution module is busy. Each attempt is non-blocking and separately gated.
+func (a *ApiHandler) startPayloadBuildForPreparation(
+	ctx context.Context,
+	baseBlockRoot common.Hash,
+	head common.Hash,
+	attrs *engine_types.PayloadAttributes,
+) ([]byte, error) {
+	payloadBuilder, ok := a.engine.(execution_client.PayloadBuilder)
+	if !ok {
+		return nil, execution_client.ErrNotSupported
+	}
+	for {
+		if cause := context.Cause(ctx); cause != nil {
+			return nil, cause
+		}
+		selectedRoot, _, selected := a.syncedData.SelectedHead()
+		if !selected || selectedRoot != baseBlockRoot {
+			return nil, errPreparationHeadChanged
+		}
+		finishAttempt, ok := a.payloadPreparationGate.tryBeginPreparation()
+		if !ok {
+			return nil, errProposalInFlight
+		}
+		payloadID, err := payloadBuilder.StartPayloadBuild(ctx, head, attrs)
+		finishAttempt()
+		if err == nil {
+			return payloadID, nil
+		}
+		if !errors.Is(err, execution_client.ErrPayloadBuildHeadMismatch) &&
+			!errors.Is(err, chainreader.ErrExecutionBusy) {
+			return payloadID, err
+		}
+		if err := common.Sleep(ctx, 100*time.Millisecond); err != nil {
+			if cause := context.Cause(ctx); cause != nil {
+				return nil, cause
+			}
+			return nil, err
+		}
+	}
+}
+
+// payloadBuildAttributes is shared because production reuses a prepared builder only when every
+// attribute is identical. Fields introduced with Gloas remain nil during pre-Gloas preparation.
+func (a *ApiHandler) payloadBuildAttributes(
+	baseState *state.CachingBeaconState,
+	baseBlockRoot common.Hash,
+	targetSlot uint64,
+	feeRecipient common.Address,
+	withdrawals []*types.Withdrawal,
+	slotNumber, targetGasLimit *hexutil.Uint64,
+	stateVersion clparams.StateVersion,
+) *engine_types.PayloadAttributes {
+	targetEpoch := targetSlot / a.beaconChainCfg.SlotsPerEpoch
+	return payloadAttributes(
+		stateVersion,
+		hexutil.Uint64(state.ComputeTimestampAtSlot(baseState, targetSlot)),
+		baseState.GetRandaoMixes(targetEpoch),
+		feeRecipient,
+		withdrawals,
+		&baseBlockRoot,
+		slotNumber,
+		targetGasLimit,
+	)
+}

--- a/cl/beacon/handler/payload_preparation_test.go
+++ b/cl/beacon/handler/payload_preparation_test.go
@@ -1,0 +1,801 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package handler
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/erigontech/erigon/cl/beacon/beacon_router_configuration"
+	"github.com/erigontech/erigon/cl/beacon/synced_data"
+	sync_mock_services "github.com/erigontech/erigon/cl/beacon/synced_data/mock_services"
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/erigontech/erigon/cl/phase1/execution_client"
+	"github.com/erigontech/erigon/cl/transition"
+	"github.com/erigontech/erigon/cl/utils/eth_clock"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/execution/engineapi/engine_types"
+	"github.com/erigontech/erigon/execution/execmodule/chainreader"
+)
+
+type payloadBuildEngine struct {
+	*execution_client.MockExecutionEngine
+	t                 *testing.T
+	startPayloadBuild func(context.Context, common.Hash, *engine_types.PayloadAttributes) ([]byte, error)
+}
+
+func newPayloadBuildEngine(t *testing.T, ctrl *gomock.Controller) *payloadBuildEngine {
+	return &payloadBuildEngine{
+		MockExecutionEngine: execution_client.NewMockExecutionEngine(ctrl),
+		t:                   t,
+	}
+}
+
+func (e *payloadBuildEngine) StartPayloadBuild(
+	ctx context.Context,
+	head common.Hash,
+	attrs *engine_types.PayloadAttributes,
+) ([]byte, error) {
+	e.t.Helper()
+	require.NotNil(e.t, e.startPayloadBuild, "unexpected payload-build attempt")
+	return e.startPayloadBuild(ctx, head, attrs)
+}
+
+func TestBlockBuilderWindowTakesPreparedPayloadEarly(t *testing.T) {
+	cfg := &clparams.BeaconChainConfig{
+		SecondsPerSlot:   12,
+		IntervalsPerSlot: 3,
+	}
+	slotStart := time.Unix(100, 0)
+
+	// A primed payload is taken one quarter of the attestation deadline into the slot.
+	prepared := computeBlockBuilderWindow(slotStart, slotStart, cfg, clparams.ElectraVersion, true)
+	require.Equal(t, slotStart.Add(time.Second).Add(-minPayloadPollingWindow), prepared.firstGetAt)
+	require.Equal(t, slotStart.Add(3*time.Second), prepared.pollUntil)
+
+	// Without a primed builder nothing changes: the execution layer still needs most of the slot.
+	unprepared := computeBlockBuilderWindow(slotStart, slotStart, cfg, clparams.ElectraVersion, false)
+	require.Equal(t, slotStart.Add(3*time.Second).Add(-minPayloadPollingWindow), unprepared.firstGetAt)
+	require.Equal(t, slotStart.Add(3*time.Second), unprepared.pollUntil)
+
+	require.True(t, prepared.firstGetAt.Before(unprepared.firstGetAt))
+
+	late := computeBlockBuilderWindow(slotStart.Add(2*time.Second), slotStart, cfg, clparams.ElectraVersion, true)
+	require.Equal(t, slotStart.Add(2*time.Second), late.firstGetAt)
+	require.Equal(t, slotStart.Add(3*time.Second), late.pollUntil)
+}
+
+func TestPreparedPayloadMatchesOnlyTheSamePrime(t *testing.T) {
+	var p preparedPayload
+	id := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	now := time.Unix(100, 0)
+
+	require.False(t, p.matches(10, id, now, 0), "nothing primed yet")
+
+	p.set(10, id, now)
+	require.True(t, p.matches(10, id, now, 0))
+
+	// A different payload id means the execution layer started a fresh build — a reorg, a late
+	// block, or a changed fee recipient — so the warm builder is gone.
+	require.False(t, p.matches(10, []byte{9, 9, 9, 9, 9, 9, 9, 9}, now, 0))
+	require.False(t, p.matches(11, id, now, 0), "primed for another slot")
+	require.False(t, p.matches(10, nil, now, 0), "no id from the execution layer")
+}
+
+func TestPreparedPayloadRequiresMinimumWarmup(t *testing.T) {
+	var p preparedPayload
+	id := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	now := time.Unix(100, 0)
+	minAge := 2 * time.Second
+
+	p.set(10, id, now.Add(-minAge+time.Nanosecond))
+	require.False(t, p.matches(10, id, now, minAge))
+
+	p.set(10, id, now.Add(-minAge))
+	require.True(t, p.matches(10, id, now, minAge))
+}
+
+func TestPreparedPayloadMinimumWarmupPreservesBuildTime(t *testing.T) {
+	cfg := &clparams.BeaconChainConfig{
+		SecondsPerSlot:   12,
+		IntervalsPerSlot: 3,
+	}
+
+	require.Equal(t, 2*time.Second, preparedPayloadMinimumAge(cfg, clparams.ElectraVersion))
+}
+
+func TestStartPayloadPreparationSkipsRemoteEngine(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	engine := newPayloadBuildEngine(t, ctrl)
+	engine.EXPECT().SupportInsertion().Return(false)
+	handler := &ApiHandler{
+		engine:         engine,
+		routerCfg:      &beacon_router_configuration.RouterConfiguration{Validator: true},
+		beaconChainCfg: &clparams.BeaconChainConfig{SecondsPerSlot: 12},
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	handler.StartPayloadPreparation(ctx)
+}
+
+func TestStartPayloadPreparationSkipsWithoutValidatorAPI(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	engine := newPayloadBuildEngine(t, ctrl)
+	engine.EXPECT().SupportInsertion().Times(0)
+	handler := &ApiHandler{
+		engine:         engine,
+		routerCfg:      &beacon_router_configuration.RouterConfiguration{Validator: false},
+		beaconChainCfg: &clparams.BeaconChainConfig{SecondsPerSlot: 12},
+	}
+
+	handler.StartPayloadPreparation(t.Context())
+}
+
+func TestStartPayloadPreparationSkipsNilEngine(t *testing.T) {
+	handler := &ApiHandler{}
+	require.NotPanics(t, func() {
+		handler.StartPayloadPreparation(t.Context())
+	})
+}
+
+func TestStartPayloadPreparationStartsLocalEngine(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	engine := newPayloadBuildEngine(t, ctrl)
+	engine.EXPECT().SupportInsertion().Return(true)
+	handler := &ApiHandler{
+		engine:         engine,
+		routerCfg:      &beacon_router_configuration.RouterConfiguration{Validator: true},
+		beaconChainCfg: &clparams.BeaconChainConfig{SecondsPerSlot: 12},
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	handler.StartPayloadPreparation(ctx)
+}
+
+func TestPreparePayloadLoopRunsImmediatelyWithSlotDeadline(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	_, _, _, _, postState, handler, _, syncedData, _, validatorParams := setupTestingHandler(t, clparams.ElectraVersion, log.Root(), true)
+	targetSlot := postState.Slot() + 1
+	proposerIndex, err := postState.GetBeaconProposerIndexForSlot(targetSlot)
+	require.NoError(t, err)
+	validatorParams.SetFeeRecipient(proposerIndex, common.Address{0x11})
+	// Preparation only primes on a head fork choice has published, so the loop stands down until
+	// one is selected.
+	syncedData.(*synced_data.SyncedDataManager).OnSelectedHead(handler.syncedData.HeadRoot(), postState.Slot())
+
+	slotStart := time.Now().Add(6 * time.Second)
+	clock := eth_clock.NewMockEthereumClock(ctrl)
+	clock.EXPECT().GetCurrentSlot().Return(targetSlot - 1)
+	clock.EXPECT().GetSlotTime(targetSlot).Return(slotStart).AnyTimes()
+	handler.ethClock = clock
+
+	ctx, cancel := context.WithCancel(t.Context())
+	engine := newPayloadBuildEngine(t, ctrl)
+	engine.startPayloadBuild = func(callCtx context.Context, _ common.Hash, _ *engine_types.PayloadAttributes) ([]byte, error) {
+		deadline, ok := callCtx.Deadline()
+		require.True(t, ok)
+		require.Equal(t, slotStart, deadline)
+		cancel()
+		return []byte{1, 2, 3, 4, 5, 6, 7, 8}, nil
+	}
+	handler.engine = engine
+
+	handler.preparePayloadLoop(ctx)
+}
+
+func TestPreparePayloadLoopSkipsSlotsTooFarAhead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	_, _, _, _, postState, handler, _, _, _, validatorParams := setupTestingHandler(t, clparams.ElectraVersion, log.Root(), true)
+	targetSlot := postState.Slot() + 1
+	proposerIndex, err := postState.GetBeaconProposerIndexForSlot(targetSlot)
+	require.NoError(t, err)
+	validatorParams.SetFeeRecipient(proposerIndex, common.Address{0x11})
+
+	// Before genesis the current slot clamps to zero, so the next slot can be hours out.
+	clock := eth_clock.NewMockEthereumClock(ctrl)
+	clock.EXPECT().GetCurrentSlot().Return(targetSlot - 1).AnyTimes()
+	clock.EXPECT().GetSlotTime(targetSlot).Return(time.Now().Add(time.Hour)).AnyTimes()
+	handler.ethClock = clock
+
+	engine := newPayloadBuildEngine(t, ctrl)
+	engine.EXPECT().SupportInsertion().Return(true)
+	handler.engine = engine
+
+	ctx, cancel := context.WithTimeout(t.Context(), 250*time.Millisecond)
+	defer cancel()
+	done := handler.StartPayloadPreparation(ctx)
+	<-ctx.Done()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("payload preparation did not stop after cancellation")
+	}
+}
+
+func TestPreparePayloadLoopStandsOffWhileProducing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	_, _, _, _, postState, handler, _, _, _, validatorParams := setupTestingHandler(t, clparams.ElectraVersion, log.Root(), true)
+	targetSlot := postState.Slot() + 1
+	proposerIndex, err := postState.GetBeaconProposerIndexForSlot(targetSlot)
+	require.NoError(t, err)
+	validatorParams.SetFeeRecipient(proposerIndex, common.Address{0x11})
+
+	clock := eth_clock.NewMockEthereumClock(ctrl)
+	clock.EXPECT().GetCurrentSlot().Return(targetSlot - 1).AnyTimes()
+	clock.EXPECT().GetSlotTime(gomock.Any()).Times(0)
+	handler.ethClock = clock
+
+	// Priming would contend with the block being produced for the execution layer's single slot.
+	finishProduction := handler.payloadPreparationGate.beginProduction()
+	defer finishProduction()
+	engine := newPayloadBuildEngine(t, ctrl)
+	handler.engine = engine
+
+	ctx, cancel := context.WithTimeout(t.Context(), 250*time.Millisecond)
+	defer cancel()
+	handler.preparePayloadLoop(ctx)
+}
+
+func TestPreparePayloadLoopSkipsSlotsAboutToStart(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	_, _, _, _, postState, handler, _, _, _, validatorParams := setupTestingHandler(t, clparams.ElectraVersion, log.Root(), true)
+	targetSlot := postState.Slot() + 1
+	proposerIndex, err := postState.GetBeaconProposerIndexForSlot(targetSlot)
+	require.NoError(t, err)
+	validatorParams.SetFeeRecipient(proposerIndex, common.Address{0x11})
+
+	// Too close to the slot for the prime to ever reach the age production demands of it, so the
+	// state copy and the builder-start call would both be spent for nothing.
+	clock := eth_clock.NewMockEthereumClock(ctrl)
+	clock.EXPECT().GetCurrentSlot().Return(targetSlot - 1).AnyTimes()
+	clock.EXPECT().GetSlotTime(targetSlot).Return(time.Now().Add(200 * time.Millisecond)).AnyTimes()
+	handler.ethClock = clock
+
+	engine := newPayloadBuildEngine(t, ctrl)
+	handler.engine = engine
+
+	ctx, cancel := context.WithTimeout(t.Context(), 250*time.Millisecond)
+	defer cancel()
+	handler.preparePayloadLoop(ctx)
+}
+
+// A deterministic rejection cannot change while the slot, selected head, and validator
+// registrations stay fixed. Retrying it on every tick would repeat the expensive state work.
+func TestPreparePayloadLoopMemoizesStableFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	_, _, _, _, postState, handler, _, syncedData, _, validatorParams := setupTestingHandler(t, clparams.ElectraVersion, log.Root(), false)
+	targetSlot := postState.Slot() + 1
+	proposerIndex, err := postState.GetBeaconProposerIndexForSlot(targetSlot)
+	require.NoError(t, err)
+	// A registration for another validator starts the loop but leaves this proposal unregistered.
+	validatorParams.SetFeeRecipient(proposerIndex+1, common.Address{0x11})
+
+	config := *handler.beaconChainCfg
+	config.SecondsPerSlot = 1
+	config.IntervalsPerSlot = 3
+	handler.beaconChainCfg = &config
+	baseBlockRoot := common.Hash{0x41}
+	syncedDataMock := syncedData.(*sync_mock_services.MockSyncedData)
+	syncedDataMock.EXPECT().SelectedHead().Return(baseBlockRoot, postState.Slot(), true).AnyTimes()
+	syncedDataMock.EXPECT().HeadRoot().Return(baseBlockRoot).AnyTimes()
+	syncedDataMock.EXPECT().ViewHeadStateWithIdentity(gomock.Any()).
+		DoAndReturn(func(view synced_data.ViewHeadStateWithIdentityFn) error {
+			return view(postState, baseBlockRoot, postState.Slot())
+		}).Times(1)
+
+	engine := newPayloadBuildEngine(t, ctrl)
+	handler.engine = engine
+
+	clock := eth_clock.NewMockEthereumClock(ctrl)
+	clock.EXPECT().GetCurrentSlot().Return(targetSlot - 1).AnyTimes()
+	clock.EXPECT().GetSlotTime(targetSlot).DoAndReturn(func(uint64) time.Time {
+		return time.Now().Add(800 * time.Millisecond)
+	}).AnyTimes()
+	handler.ethClock = clock
+
+	ctx, cancel := context.WithTimeout(t.Context(), 650*time.Millisecond)
+	defer cancel()
+	handler.preparePayloadLoop(ctx)
+}
+
+func TestPreparePayloadForStartsBuildWithCompleteAttributes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	_, _, _, _, postState, handler, _, _, _, validatorParams := setupTestingHandler(t, clparams.CapellaVersion, log.Root(), true)
+	config := *handler.beaconChainCfg
+	targetEpoch := postState.Slot()/config.SlotsPerEpoch + 1
+	targetSlot := targetEpoch * config.SlotsPerEpoch
+	config.DenebForkEpoch = targetEpoch
+	config.InitializeForkSchedule()
+
+	headState := state.New(&config)
+	require.NoError(t, postState.CopyInto(headState))
+	currentEpoch := headState.Slot() / config.SlotsPerEpoch
+	headState.SetRandaoMixAt(int(currentEpoch%config.EpochsPerHistoricalVector), common.Hash{0x51})
+	headState.SetRandaoMixAt(int(targetEpoch%config.EpochsPerHistoricalVector), common.Hash{0x52})
+	baseBlockRoot := common.Hash{0x41}
+	syncedData := synced_data.NewSyncedDataManager(&config, true)
+	require.NoError(t, syncedData.OnHeadStateWithBlockRoot(headState, baseBlockRoot))
+	syncedData.OnSelectedHead(baseBlockRoot, headState.Slot())
+	handler.beaconChainCfg = &config
+	handler.syncedData = syncedData
+
+	proposerIndex, err := headState.GetBeaconProposerIndexForSlot(targetSlot)
+	require.NoError(t, err)
+
+	feeRecipient := common.Address{0x11}
+	validatorParams.SetFeeRecipient(proposerIndex, feeRecipient)
+
+	advancedState, err := headState.Copy()
+	require.NoError(t, err)
+	require.NoError(t, transition.DefaultMachine.ProcessSlots(advancedState, targetSlot))
+	require.Equal(t, clparams.CapellaVersion, headState.Version())
+	require.Equal(t, clparams.DenebVersion, advancedState.Version())
+	require.NotEqual(t, headState.GetRandaoMixes(targetEpoch), advancedState.GetRandaoMixes(targetEpoch))
+
+	require.Equal(t, clparams.DenebVersion,
+		handler.beaconChainCfg.GetCurrentStateVersion(targetSlot/handler.beaconChainCfg.SlotsPerEpoch))
+	expectedWithdrawals, err := state.GetExpectedWithdrawals(advancedState, targetSlot/handler.beaconChainCfg.SlotsPerEpoch)
+	require.NoError(t, err)
+
+	payloadID := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	engine := newPayloadBuildEngine(t, ctrl)
+	engine.startPayloadBuild = func(_ context.Context, head common.Hash, attrs *engine_types.PayloadAttributes) ([]byte, error) {
+		require.Equal(t, advancedState.LatestExecutionPayloadHeader().BlockHash, head)
+		require.Equal(t, hexutil.Uint64(state.ComputeTimestampAtSlot(advancedState, targetSlot)), attrs.Timestamp)
+		require.Equal(t, common.Hash(advancedState.GetRandaoMixes(targetSlot/handler.beaconChainCfg.SlotsPerEpoch)), attrs.PrevRandao)
+		require.Equal(t, feeRecipient, attrs.SuggestedFeeRecipient)
+		require.Equal(t, &baseBlockRoot, attrs.ParentBeaconBlockRoot)
+		require.Nil(t, attrs.SlotNumber)
+		require.Nil(t, attrs.TargetGasLimit)
+		require.NotNil(t, attrs.Withdrawals)
+		require.Len(t, attrs.Withdrawals, len(expectedWithdrawals.Withdrawals))
+		for i, withdrawal := range expectedWithdrawals.Withdrawals {
+			require.Equal(t, withdrawal.Index, attrs.Withdrawals[i].Index)
+			require.Equal(t, withdrawal.Amount, attrs.Withdrawals[i].Amount)
+			require.Equal(t, withdrawal.Validator, attrs.Withdrawals[i].Validator)
+			require.Equal(t, withdrawal.Address, attrs.Withdrawals[i].Address)
+		}
+		return payloadID, nil
+	}
+	handler.engine = engine
+
+	clock := eth_clock.NewMockEthereumClock(ctrl)
+	clock.EXPECT().GetSlotTime(gomock.Any()).Return(time.Now().Add(6 * time.Second)).AnyTimes()
+	handler.ethClock = clock
+
+	primedHead, err := handler.preparePayloadFor(t.Context(), targetSlot)
+	require.NoError(t, err)
+	require.Equal(t, baseBlockRoot, primedHead)
+	require.True(t, handler.preparedPayload.matches(targetSlot, payloadID, time.Now(), 0))
+}
+
+func TestPreparationGateRefusesActiveProduction(t *testing.T) {
+	var gate payloadPreparationGate
+	finishProduction := gate.beginProduction()
+	defer finishProduction()
+
+	_, ok := gate.tryBeginPreparation()
+
+	require.False(t, ok, "preparation must stand off a production that has announced itself")
+}
+
+func TestProductionUsesTargetSlotRandao(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	_, _, _, _, postState, handler, _, _, _, _ := setupTestingHandler(t, clparams.ElectraVersion, log.Root(), false)
+	targetSlot := postState.Slot() + 1
+	targetEpoch := targetSlot / handler.beaconChainCfg.SlotsPerEpoch
+	wallClockEpoch := targetEpoch + 1
+	targetMix := common.Hash{0x11}
+	wallClockMix := common.Hash{0x22}
+	postState.SetRandaoMixAt(int(targetEpoch%handler.beaconChainCfg.EpochsPerHistoricalVector), targetMix)
+	postState.SetRandaoMixAt(int(wallClockEpoch%handler.beaconChainCfg.EpochsPerHistoricalVector), wallClockMix)
+
+	engine := newPayloadBuildEngine(t, ctrl)
+	engine.EXPECT().ForkChoiceUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _ common.Hash, attrs *engine_types.PayloadAttributes, _ clparams.StateVersion) ([]byte, error) {
+			require.Equal(t, targetMix, common.Hash(attrs.PrevRandao))
+			return []byte{1, 2, 3, 4, 5, 6, 7, 8}, nil
+		})
+	engine.EXPECT().GetAssembledBlock(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, nil, nil, nil, errors.New("collection stops here")).AnyTimes()
+	handler.engine = engine
+
+	clock := eth_clock.NewMockEthereumClock(ctrl)
+	clock.EXPECT().GetSlotTime(targetSlot).Return(time.Now().Add(4 * time.Second)).AnyTimes()
+	clock.EXPECT().GetCurrentEpoch().Times(0)
+	handler.ethClock = clock
+
+	_, _, err := handler.produceBeaconBody(t.Context(), 1, postState.Slot(), common.Hash{0x41}, postState,
+		targetSlot, common.Bytes96{}, common.Hash{})
+
+	require.Error(t, err)
+}
+
+// Builder startup is non-blocking, so temporary execution contention is retried outside the gate.
+func TestPreparePayloadForRetriesWhileTheExecutionLayerIsBusy(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	_, _, _, _, postState, handler, _, syncedData, _, validatorParams := setupTestingHandler(t, clparams.ElectraVersion, log.Root(), false)
+	targetSlot := postState.Slot() + 1
+	proposerIndex, err := postState.GetBeaconProposerIndexForSlot(targetSlot)
+	require.NoError(t, err)
+	validatorParams.SetFeeRecipient(proposerIndex, common.Address{0x11})
+
+	baseBlockRoot := common.Hash{0x41}
+	syncedDataMock := syncedData.(*sync_mock_services.MockSyncedData)
+	syncedDataMock.EXPECT().ViewHeadStateWithIdentity(gomock.Any()).
+		DoAndReturn(func(view synced_data.ViewHeadStateWithIdentityFn) error {
+			return view(postState, baseBlockRoot, postState.Slot())
+		}).AnyTimes()
+	syncedDataMock.EXPECT().SelectedHead().Return(baseBlockRoot, postState.Slot(), true).AnyTimes()
+
+	engine := newPayloadBuildEngine(t, ctrl)
+	buildAttempts := 0
+	engine.startPayloadBuild = func(context.Context, common.Hash, *engine_types.PayloadAttributes) ([]byte, error) {
+		buildAttempts++
+		if buildAttempts == 1 {
+			return nil, chainreader.ErrExecutionBusy
+		}
+		return []byte{1, 2, 3, 4, 5, 6, 7, 8}, nil
+	}
+	handler.engine = engine
+
+	clock := eth_clock.NewMockEthereumClock(ctrl)
+	clock.EXPECT().GetSlotTime(gomock.Any()).Return(time.Now().Add(6 * time.Second)).AnyTimes()
+	handler.ethClock = clock
+
+	head, err := handler.preparePayloadFor(t.Context(), targetSlot)
+	require.NoError(t, err)
+	require.Equal(t, baseBlockRoot, head)
+	require.Equal(t, 2, buildAttempts)
+}
+
+func TestPreparePayloadForStopsRetryWhenTheHeadChanges(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	_, _, _, _, postState, handler, _, syncedData, _, validatorParams := setupTestingHandler(t, clparams.ElectraVersion, log.Root(), false)
+	targetSlot := postState.Slot() + 1
+	proposerIndex, err := postState.GetBeaconProposerIndexForSlot(targetSlot)
+	require.NoError(t, err)
+	validatorParams.SetFeeRecipient(proposerIndex, common.Address{0x11})
+
+	baseBlockRoot := common.Hash{0x41}
+	syncedDataMock := syncedData.(*sync_mock_services.MockSyncedData)
+	syncedDataMock.EXPECT().ViewHeadStateWithIdentity(gomock.Any()).
+		DoAndReturn(func(view synced_data.ViewHeadStateWithIdentityFn) error {
+			return view(postState, baseBlockRoot, postState.Slot())
+		}).AnyTimes()
+	movedBlockRoot := common.Hash{0x42}
+	gomock.InOrder(
+		syncedDataMock.EXPECT().SelectedHead().Return(baseBlockRoot, postState.Slot(), true),
+		syncedDataMock.EXPECT().SelectedHead().Return(movedBlockRoot, postState.Slot()+1, true),
+	)
+
+	engine := newPayloadBuildEngine(t, ctrl)
+	engine.startPayloadBuild = func(context.Context, common.Hash, *engine_types.PayloadAttributes) ([]byte, error) {
+		return nil, chainreader.ErrExecutionBusy
+	}
+	handler.engine = engine
+
+	clock := eth_clock.NewMockEthereumClock(ctrl)
+	clock.EXPECT().GetSlotTime(gomock.Any()).Return(time.Now().Add(6 * time.Second)).AnyTimes()
+	handler.ethClock = clock
+
+	_, err = handler.preparePayloadFor(t.Context(), targetSlot)
+	require.ErrorIs(t, err, errPreparationHeadChanged)
+}
+
+// Production waits only for a builder-start attempt that has already entered the execution layer.
+// The attempt is one non-blocking call; state copying and contention retries happen outside it.
+func TestProductionWaitsForActivePreparationAttempt(t *testing.T) {
+	var gate payloadPreparationGate
+	finishPreparation, ok := gate.tryBeginPreparation()
+	require.True(t, ok)
+
+	productionStarted := make(chan func(), 1)
+	go func() {
+		productionStarted <- gate.beginProduction()
+	}()
+
+	select {
+	case finishProduction := <-productionStarted:
+		finishProduction()
+		t.Fatal("production started during a payload-build attempt")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	finishPreparation()
+	finishProduction := <-productionStarted
+	finishProduction()
+}
+
+func TestPreparePayloadForStopsWhenProductionStartsDuringStateCopy(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	_, _, _, _, postState, handler, _, syncedData, _, validatorParams := setupTestingHandler(t, clparams.ElectraVersion, log.Root(), false)
+	targetSlot := postState.Slot() + 1
+	proposerIndex, err := postState.GetBeaconProposerIndexForSlot(targetSlot)
+	require.NoError(t, err)
+	validatorParams.SetFeeRecipient(proposerIndex, common.Address{0x11})
+
+	baseBlockRoot := common.Hash{0x41}
+	stateCopied := make(chan struct{})
+	resumePreparation := make(chan struct{})
+	syncedDataMock := syncedData.(*sync_mock_services.MockSyncedData)
+	syncedDataMock.EXPECT().ViewHeadStateWithIdentity(gomock.Any()).
+		DoAndReturn(func(view synced_data.ViewHeadStateWithIdentityFn) error {
+			err := view(postState, baseBlockRoot, postState.Slot())
+			close(stateCopied)
+			<-resumePreparation
+			return err
+		})
+	syncedDataMock.EXPECT().SelectedHead().Return(baseBlockRoot, postState.Slot(), true)
+	engine := newPayloadBuildEngine(t, ctrl)
+	handler.engine = engine
+
+	clock := eth_clock.NewMockEthereumClock(ctrl)
+	clock.EXPECT().GetSlotTime(gomock.Any()).Return(time.Now().Add(6 * time.Second)).AnyTimes()
+	handler.ethClock = clock
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := handler.preparePayloadFor(t.Context(), targetSlot)
+		result <- err
+	}()
+	<-stateCopied
+	finishProduction := handler.payloadPreparationGate.beginProduction()
+	defer finishProduction()
+	close(resumePreparation)
+
+	require.ErrorIs(t, <-result, errProposalInFlight)
+}
+
+func TestPreparePayloadForStopsWhenTheCopySpentTheLead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	_, _, _, _, postState, handler, _, syncedData, _, validatorParams := setupTestingHandler(t, clparams.ElectraVersion, log.Root(), false)
+	targetSlot := postState.Slot() + 1
+	proposerIndex, err := postState.GetBeaconProposerIndexForSlot(targetSlot)
+	require.NoError(t, err)
+	validatorParams.SetFeeRecipient(proposerIndex, common.Address{0x11})
+
+	baseBlockRoot := common.Hash{0x41}
+	syncedDataMock := syncedData.(*sync_mock_services.MockSyncedData)
+	syncedDataMock.EXPECT().ViewHeadStateWithIdentity(gomock.Any()).
+		DoAndReturn(func(view synced_data.ViewHeadStateWithIdentityFn) error {
+			return view(postState, baseBlockRoot, postState.Slot())
+		}).AnyTimes()
+	engine := newPayloadBuildEngine(t, ctrl)
+	handler.engine = engine
+
+	// Closer to the slot than the warm-up production would demand of the prime, so priming now
+	// could only occupy the module without ever being usable.
+	tooLate := preparedPayloadMinimumAge(handler.beaconChainCfg, clparams.ElectraVersion) / 2
+	clock := eth_clock.NewMockEthereumClock(ctrl)
+	clock.EXPECT().GetSlotTime(gomock.Any()).Return(time.Now().Add(tooLate)).AnyTimes()
+	handler.ethClock = clock
+
+	_, err = handler.preparePayloadFor(t.Context(), targetSlot)
+	require.ErrorIs(t, err, errPreparationTooLate)
+}
+
+func TestPreparePayloadForRejectsChangedHeadBeforeStartingBuilder(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	_, _, _, _, postState, handler, _, syncedData, _, validatorParams := setupTestingHandler(t, clparams.ElectraVersion, log.Root(), false)
+	targetSlot := postState.Slot() + 1
+	proposerIndex, err := postState.GetBeaconProposerIndexForSlot(targetSlot)
+	require.NoError(t, err)
+	validatorParams.SetFeeRecipient(proposerIndex, common.Address{0x11})
+
+	baseBlockRoot := common.Hash{0x41}
+	syncedDataMock := syncedData.(*sync_mock_services.MockSyncedData)
+	syncedDataMock.EXPECT().ViewHeadStateWithIdentity(gomock.Any()).
+		DoAndReturn(func(view synced_data.ViewHeadStateWithIdentityFn) error {
+			return view(postState, baseBlockRoot, postState.Slot())
+		})
+	syncedDataMock.EXPECT().SelectedHead().Return(common.Hash{0x42}, postState.Slot()+1, true)
+	engine := newPayloadBuildEngine(t, ctrl)
+	handler.engine = engine
+
+	clock := eth_clock.NewMockEthereumClock(ctrl)
+	clock.EXPECT().GetSlotTime(gomock.Any()).Return(time.Now().Add(6 * time.Second)).AnyTimes()
+	handler.ethClock = clock
+
+	_, err = handler.preparePayloadFor(t.Context(), targetSlot)
+	require.ErrorIs(t, err, errPreparationHeadChanged)
+	require.False(t, handler.preparedPayload.matches(targetSlot, []byte{1}, time.Now(), 0))
+}
+
+func TestPreparePayloadForUsesPostEpochProposer(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	_, _, _, _, postState, handler, _, syncedData, _, validatorParams := setupTestingHandler(t, clparams.ElectraVersion, log.Root(), false)
+	config := *handler.beaconChainCfg
+	targetEpoch := postState.Slot()/config.SlotsPerEpoch + 1
+	targetSlot := targetEpoch * config.SlotsPerEpoch
+	config.FuluForkEpoch = targetEpoch + 10
+	config.GloasForkEpoch = targetEpoch + 11
+	config.InitializeForkSchedule()
+	handler.beaconChainCfg = &config
+
+	headState := state.New(&config)
+	require.NoError(t, postState.CopyInto(headState))
+	headState.SetSlot(targetSlot - 1)
+	for i := 0; i < headState.ValidatorLength(); i += 2 {
+		headState.SetEffectiveBalanceForValidatorAtIndex(i, 0)
+		require.NoError(t, headState.SetValidatorBalance(i, config.MaxEffectiveBalanceElectra))
+	}
+
+	mixPosition := (targetEpoch + config.EpochsPerHistoricalVector - config.MinSeedLookahead - 1) % config.EpochsPerHistoricalVector
+	var oldProposer, newProposer uint64
+	found := false
+	for nonce := byte(0); ; nonce++ {
+		headState.SetRandaoMixAt(int(mixPosition), common.Hash{nonce})
+		var err error
+		oldProposer, err = headState.GetBeaconProposerIndexForSlot(targetSlot)
+		require.NoError(t, err)
+
+		advanced, err := headState.Copy()
+		require.NoError(t, err)
+		require.NoError(t, transition.DefaultMachine.ProcessSlots(advanced, targetSlot))
+		newProposer, err = advanced.GetBeaconProposerIndexForSlot(targetSlot)
+		require.NoError(t, err)
+		if oldProposer != newProposer {
+			found = true
+			break
+		}
+		if nonce == 255 {
+			break
+		}
+	}
+	require.True(t, found, "fixture must expose a proposer change across epoch processing")
+	validatorParams.SetFeeRecipient(newProposer, common.Address{0x11})
+
+	baseBlockRoot := common.Hash{0x41}
+	syncedDataMock := syncedData.(*sync_mock_services.MockSyncedData)
+	syncedDataMock.EXPECT().ViewHeadStateWithIdentity(gomock.Any()).
+		DoAndReturn(func(view synced_data.ViewHeadStateWithIdentityFn) error {
+			return view(headState, baseBlockRoot, headState.Slot())
+		})
+	syncedDataMock.EXPECT().SelectedHead().Return(baseBlockRoot, headState.Slot(), true).AnyTimes()
+	engine := newPayloadBuildEngine(t, ctrl)
+	engine.startPayloadBuild = func(_ context.Context, _ common.Hash, attrs *engine_types.PayloadAttributes) ([]byte, error) {
+		require.Equal(t, common.Address{0x11}, attrs.SuggestedFeeRecipient)
+		return []byte{1, 2, 3, 4, 5, 6, 7, 8}, nil
+	}
+	handler.engine = engine
+
+	clock := eth_clock.NewMockEthereumClock(ctrl)
+	clock.EXPECT().GetSlotTime(gomock.Any()).Return(time.Now().Add(6 * time.Second)).AnyTimes()
+	handler.ethClock = clock
+
+	_, err := handler.preparePayloadFor(t.Context(), targetSlot)
+	require.NoError(t, err)
+}
+
+func TestFuluPreparationRejectsUnregisteredProposerBeforeCopyingState(t *testing.T) {
+	_, _, _, _, postState, handler, _, syncedData, _, _ := setupTestingHandler(t, clparams.ElectraVersion, log.Root(), false)
+	currentEpoch := postState.Slot() / handler.beaconChainCfg.SlotsPerEpoch
+	handler.beaconChainCfg.FuluForkEpoch = currentEpoch
+	handler.beaconChainCfg.GloasForkEpoch = currentEpoch + 2
+	handler.beaconChainCfg.InitializeForkSchedule()
+	require.NoError(t, postState.UpgradeToFulu())
+	targetSlot := (currentEpoch + 1) * handler.beaconChainCfg.SlotsPerEpoch
+
+	baseBlockRoot := common.Hash{0x41}
+	syncedDataMock := syncedData.(*sync_mock_services.MockSyncedData)
+	syncedDataMock.EXPECT().ViewHeadStateWithIdentity(gomock.Any()).
+		DoAndReturn(func(view synced_data.ViewHeadStateWithIdentityFn) error {
+			return view(postState, baseBlockRoot, postState.Slot())
+		}).AnyTimes()
+
+	var preparationErr error
+	allocations := testing.AllocsPerRun(1, func() {
+		_, preparationErr = handler.preparePayloadFor(t.Context(), targetSlot)
+	})
+
+	require.ErrorIs(t, preparationErr, errNotOurProposal)
+	require.Less(t, allocations, 1000.0, "an unregistered Fulu proposer should not require a full state copy")
+}
+
+// Memoization must use the head paired with the state that produced the verdict, not an earlier
+// selected-head snapshot.
+func TestPreparePayloadForReturnsViewedHeadWhenProposalIsNotOurs(t *testing.T) {
+	_, _, _, _, postState, handler, _, syncedData, _, _ := setupTestingHandler(t, clparams.ElectraVersion, log.Root(), false)
+	targetSlot := postState.Slot() + 1
+	viewRoot := common.Hash{0x41}
+	syncedData.(*sync_mock_services.MockSyncedData).EXPECT().ViewHeadStateWithIdentity(gomock.Any()).
+		DoAndReturn(func(view synced_data.ViewHeadStateWithIdentityFn) error {
+			return view(postState, viewRoot, postState.Slot())
+		})
+
+	head, err := handler.preparePayloadFor(t.Context(), targetSlot)
+
+	require.ErrorIs(t, err, errNotOurProposal)
+	require.Equal(t, viewRoot, head)
+}
+
+func TestPreparePayloadForPairsRootAndStateFromOneView(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	_, _, _, _, postState, handler, _, syncedData, _, validatorParams := setupTestingHandler(t, clparams.ElectraVersion, log.Root(), false)
+	targetSlot := postState.Slot() + 1
+	proposerIndex, err := postState.GetBeaconProposerIndexForSlot(targetSlot)
+	require.NoError(t, err)
+	validatorParams.SetFeeRecipient(proposerIndex, common.Address{0x11})
+
+	// Root and state must come from one view. Separate reads could pair a new root with an old state
+	// and produce payload inputs that production can never reproduce.
+	viewRoot := common.Hash{0x41}
+	syncedDataMock := syncedData.(*sync_mock_services.MockSyncedData)
+	syncedDataMock.EXPECT().ViewHeadStateWithIdentity(gomock.Any()).
+		DoAndReturn(func(view synced_data.ViewHeadStateWithIdentityFn) error {
+			return view(postState, viewRoot, postState.Slot())
+		})
+	syncedDataMock.EXPECT().SelectedHead().Return(viewRoot, postState.Slot(), true).AnyTimes()
+
+	clock := eth_clock.NewMockEthereumClock(ctrl)
+	clock.EXPECT().GetSlotTime(gomock.Any()).Return(time.Now().Add(6 * time.Second)).AnyTimes()
+	handler.ethClock = clock
+
+	engine := newPayloadBuildEngine(t, ctrl)
+	engine.startPayloadBuild = func(_ context.Context, _ common.Hash, attrs *engine_types.PayloadAttributes) ([]byte, error) {
+		require.NotNil(t, attrs.ParentBeaconBlockRoot)
+		require.Equal(t, viewRoot, *attrs.ParentBeaconBlockRoot)
+		return []byte{1, 2, 3, 4, 5, 6, 7, 8}, nil
+	}
+	handler.engine = engine
+
+	primedHead, err := handler.preparePayloadFor(t.Context(), targetSlot)
+	require.NoError(t, err)
+	require.Equal(t, viewRoot, primedHead)
+}
+
+func TestPreparedPayloadKeepsConsecutiveSlots(t *testing.T) {
+	var p preparedPayload
+	first := []byte{1, 1, 1, 1, 1, 1, 1, 1}
+	second := []byte{2, 2, 2, 2, 2, 2, 2, 2}
+	now := time.Unix(100, 0)
+
+	// Consecutive proposals: priming slot 11 must not evict slot 10, whose block may still be
+	// in production.
+	p.set(10, first, now)
+	p.set(11, second, now)
+	require.True(t, p.matches(10, first, now, 0))
+	require.True(t, p.matches(11, second, now, 0))
+
+	// Records old enough that they can no longer be produced are dropped, so the map is bounded.
+	p.set(10+preparedPayloadRetainSlots+1, []byte{3, 3, 3, 3, 3, 3, 3, 3}, now)
+	require.False(t, p.matches(10, first, now, 0))
+}
+
+func TestPreparedPayloadCopiesTheID(t *testing.T) {
+	var p preparedPayload
+	id := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	now := time.Unix(100, 0)
+
+	p.set(10, id, now)
+	id[0] = 0xff
+
+	// The caller's buffer must not be able to invalidate, or forge, a later match.
+	require.True(t, p.matches(10, []byte{1, 2, 3, 4, 5, 6, 7, 8}, now, 0))
+	require.False(t, p.matches(10, id, now, 0))
+}

--- a/cl/phase1/execution_client/execution_client_direct.go
+++ b/cl/phase1/execution_client/execution_client_direct.go
@@ -149,6 +149,16 @@ func (cc *ExecutionClientDirect) ForkChoiceUpdate(ctx context.Context, finalized
 	return idBytes, nil
 }
 
+func (cc *ExecutionClientDirect) StartPayloadBuild(ctx context.Context, head common.Hash, attributes *engine_types.PayloadAttributes) ([]byte, error) {
+	id, err := startPayloadBuild(ctx, cc.chainRW, head, attributes)
+	if err != nil {
+		return nil, err
+	}
+	idBytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(idBytes, id)
+	return idBytes, nil
+}
+
 func retryAssembleBlock(ctx context.Context, attempts int, delay time.Duration, assemble func(context.Context) (uint64, error)) (uint64, error) {
 	if attempts <= 0 {
 		return 0, errors.New("assemble block requires at least one attempt")

--- a/cl/phase1/execution_client/payload_build.go
+++ b/cl/phase1/execution_client/payload_build.go
@@ -1,0 +1,53 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package execution_client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/engineapi/engine_types"
+	"github.com/erigontech/erigon/execution/execmodule/chainreader"
+)
+
+// ErrPayloadBuildHeadMismatch reports that the execution layer has not adopted the parent on which
+// preparation wants to build. A later canonical forkchoice update may make the request valid.
+var ErrPayloadBuildHeadMismatch = errors.New("execution head does not match payload parent")
+
+// PayloadBuilder starts a build through the local execution module without changing fork choice.
+// An implementation backed only by a remote Engine API returns ErrNotSupported.
+type PayloadBuilder interface {
+	StartPayloadBuild(ctx context.Context, head common.Hash, attributes *engine_types.PayloadAttributes) ([]byte, error)
+}
+
+func startPayloadBuild(
+	ctx context.Context,
+	chainRW chainreader.ChainReaderWriterEth1,
+	head common.Hash,
+	attributes *engine_types.PayloadAttributes,
+) (uint64, error) {
+	executionHead, _, _, err := chainRW.GetForkChoice(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if executionHead != head {
+		return 0, fmt.Errorf("%w: have %x, want %x", ErrPayloadBuildHeadMismatch, executionHead, head)
+	}
+	return chainRW.AssembleBlock(ctx, head, attributes)
+}

--- a/cl/phase1/execution_client/payload_build_test.go
+++ b/cl/phase1/execution_client/payload_build_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package execution_client
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/builder"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/engineapi/engine_types"
+	"github.com/erigontech/erigon/execution/execmodule"
+	"github.com/erigontech/erigon/execution/execmodule/chainreader"
+)
+
+type payloadBuildModuleStub struct {
+	execmodule.ExecutionModule
+	forkChoice      execmodule.ForkChoiceState
+	assembled       execmodule.AssembleBlockResult
+	assembleCalls   int
+	forkChoiceCalls int
+}
+
+func (s *payloadBuildModuleStub) GetForkChoice(context.Context) (execmodule.ForkChoiceState, error) {
+	return s.forkChoice, nil
+}
+
+func (s *payloadBuildModuleStub) UpdateForkChoice(context.Context, common.Hash, common.Hash, common.Hash) (execmodule.ForkChoiceResult, error) {
+	s.forkChoiceCalls++
+	return execmodule.ForkChoiceResult{Status: execmodule.ExecutionStatusSuccess}, nil
+}
+
+func (s *payloadBuildModuleStub) AssembleBlock(context.Context, *builder.Parameters) (execmodule.AssembleBlockResult, error) {
+	s.assembleCalls++
+	return s.assembled, nil
+}
+
+func TestDirectStartPayloadBuildDoesNotUpdateForkChoice(t *testing.T) {
+	head := common.Hash{0x41}
+	module := &payloadBuildModuleStub{
+		forkChoice: execmodule.ForkChoiceState{HeadHash: head},
+		assembled:  execmodule.AssembleBlockResult{PayloadID: 42},
+	}
+	client, err := NewExecutionClientDirect(
+		chainreader.NewChainReaderEth1(chain.AllProtocolChanges, module, time.Second), nil,
+	)
+	require.NoError(t, err)
+
+	id, err := client.StartPayloadBuild(t.Context(), head, &engine_types.PayloadAttributes{})
+
+	require.NoError(t, err)
+	want := make([]byte, 8)
+	binary.LittleEndian.PutUint64(want, 42)
+	require.Equal(t, want, id)
+	require.Equal(t, 1, module.assembleCalls)
+	require.Zero(t, module.forkChoiceCalls)
+}
+
+func TestStartPayloadBuildRequiresMatchingExecutionHead(t *testing.T) {
+	module := &payloadBuildModuleStub{
+		forkChoice: execmodule.ForkChoiceState{HeadHash: common.Hash{0x41}},
+		assembled:  execmodule.AssembleBlockResult{PayloadID: 42},
+	}
+	client, err := NewExecutionClientDirect(
+		chainreader.NewChainReaderEth1(chain.AllProtocolChanges, module, time.Second), nil,
+	)
+	require.NoError(t, err)
+
+	_, err = client.StartPayloadBuild(t.Context(), common.Hash{0x42}, &engine_types.PayloadAttributes{})
+
+	require.ErrorIs(t, err, ErrPayloadBuildHeadMismatch)
+	require.Zero(t, module.assembleCalls)
+}
+
+func TestEngineClientDoesNotExposeDirectPayloadBuild(t *testing.T) {
+	_, ok := any(&ExecutionClientEngine{}).(PayloadBuilder)
+	require.False(t, ok)
+}

--- a/cl/validator/validator_params/validator_params.go
+++ b/cl/validator/validator_params/validator_params.go
@@ -18,12 +18,14 @@ package validator_params
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/erigontech/erigon/common"
 )
 
 type ValidatorParams struct {
 	feeRecipients sync.Map
+	generation    atomic.Uint64
 }
 
 func NewValidatorParams() *ValidatorParams {
@@ -31,7 +33,18 @@ func NewValidatorParams() *ValidatorParams {
 }
 
 func (vp *ValidatorParams) SetFeeRecipient(validatorIndex uint64, feeRecipient common.Address) {
-	vp.feeRecipients.Store(validatorIndex, feeRecipient)
+	// Validator clients re-register unchanged on a schedule, so only a real change counts: a
+	// generation that moved on every call would be useless to anyone caching a lookup.
+	if previous, loaded := vp.feeRecipients.Swap(validatorIndex, feeRecipient); !loaded || previous.(common.Address) != feeRecipient {
+		vp.generation.Add(1)
+	}
+}
+
+// Generation changes whenever a registration is added or its fee recipient changes, and is zero
+// until the first one arrives. A consumer caching a lookup can compare it to find out whether a
+// later registration could have changed the answer.
+func (vp *ValidatorParams) Generation() uint64 {
+	return vp.generation.Load()
 }
 
 func (vp *ValidatorParams) GetFeeRecipient(validatorIndex uint64) (common.Address, bool) {

--- a/cmd/caplin/caplin1/run.go
+++ b/cmd/caplin/caplin1/run.go
@@ -630,6 +630,7 @@ func RunCaplinService(ctx context.Context, engine execution_client.ExecutionEngi
 			payloadAttestationService,
 			proposerPreferencesService,
 		)
+		apiHandler.StartPayloadPreparation(ctx)
 		go beacon.ListenAndServe(&beacon.LayeredBeaconHandler{
 			ArchiveApi: apiHandler,
 		}, config.BeaconAPIRouter)


### PR DESCRIPTION
Cherry-pick of #23399 to release/3.6. Last piece of the #23105 split — everything else it was built on is already here (#23103, #23172, #23320, #23321, #23339, #23360, #23380, #23394, #23408, #23409, #23420).

Block production starts the payload inside the slot it is for, so the builder packs against the clock and a busy execution layer eats the margin the block needs to reach attesters. Preparation issues the forkchoice update with attributes a slot early, and production collects from that builder instead of starting one, taking the payload earlier by exactly the warm-up it already has.

Scope is narrow: the loop stops at the proposer lookup unless a fee recipient is registered for that index, so a node that never proposes never reaches the state copy. It does not start outside validator API mode or against a remote engine. Gloas is left alone, where builders gossip bids instead.

## r3.6 adaptations

Two conflicts, neither in preparation itself:

- `cmd/caplin/caplin1/run.go`: took the `StartPayloadPreparation(ctx)` call and kept this branch's `beacon.ListenAndServe` form, which does not take a context or return an error here.
- `db/seg/decompress.go`: the incoming hunk adds a `//nolint:unused` to `residencyOnce`. That field is part of the page-residency work, which is not on this branch at all — `git grep residency` finds nothing in `db/seg` here — so the annotation would have suppressed a warning for a field that does not exist. Kept this branch's version. Consistent with `make lintci` being clean on this branch and reporting that field only on main-based ones.

Nothing else needed adapting; the preparation files, the gate, the generation counter and the direct-client changes all applied unchanged.

## Verification

- `go test -race` green across `cl/beacon/handler`, `cl/phase1/execution_client/...` and `cl/validator/...`; all 28 preparation tests came across.
- Both guards that answer the review findings on #23105 were mutation-checked on this branch, not just assumed to have travelled:
  - removing the too-late guard fails `TestPreparePayloadForStopsWhenTheCopySpentTheLead`;
  - making the per-attempt head re-check always pass fails `TestPreparePayloadForStopsRetryWhenTheHeadChanges` and `TestPreparePayloadForRejectsChangedHeadBeforeStartingBuilder`.
- `make lintci` clean, 0 issues.
