### PR TITLE
ci: move Kurtosis install to its new apt repo, pin CLI 1.20.0

### DIFF
--- a/.github/actions/setup-kurtosis/setup.sh
+++ b/.github/actions/setup-kurtosis/setup.sh
@@ -10,7 +10,7 @@ while IFS= read -r -d '' source; do
     sudo rm -f "$source"
   fi
 done < <(sudo find "$sources_dir" -type f -print0 2>/dev/null)
-printf 'deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /\n' \
+printf 'deb [trusted=yes] https://sdk.kurtosis.com/kurtosis-cli-release-artifacts/ /\n' \
   | sudo tee "$sources_dir/kurtosis.list" >/dev/null
 
 apt_opts=(-o Acquire::Retries=3 -o Acquire::http::Timeout=15

--- a/.github/actions/setup-kurtosis/setup.test.sh
+++ b/.github/actions/setup-kurtosis/setup.test.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 here=$(cd "$(dirname -- "$0")" && pwd)
 repo=$(cd "$here/../../.." && pwd)
 script="$here/setup.sh"
+# Kurtosis CLI version the workflows pin; bump here and in KURTOSIS_VERSION together.
+version=1.20.0
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 
@@ -67,7 +69,7 @@ reset_case() {
 run_setup() {
   env PATH="$mock_bin:$PATH" \
     SETUP_KURTOSIS_CALLS="$calls" \
-    KURTOSIS_VERSION=1.15.2 \
+    KURTOSIS_VERSION="$version" \
     KURTOSIS_APT_SOURCES_DIR="$sources" \
     "$@" bash "$script"
 }
@@ -78,8 +80,12 @@ contains "update has no hard deadline" "timeout --kill-after=10s 300 apt-get upd
 contains "install has no hard deadline" "timeout --kill-after=10s 600 apt-get install" "$calls"
 contains "apt has no network bound" "Acquire::https::Timeout=15" "$calls"
 contains "apt has no lock bound" "DPkg::Lock::Timeout=60" "$calls"
-contains "version is not pinned" "kurtosis-cli=1.15.2" "$calls"
+contains "version is not pinned" "kurtosis-cli=$version" "$calls"
 contains "engine did not start" "kurtosis engine start" "$calls"
+contains "Kurtosis is not installed from the supported repository" \
+  "https://sdk.kurtosis.com/kurtosis-cli-release-artifacts/" "$sources/kurtosis.list"
+rejects "Kurtosis is installed from the retired Gemfury repository" \
+  "apt.fury.io" "$sources/kurtosis.list"
 [ ! -e "$sources/microsoft.list" ] || fail "broken third-party source remains"
 [ -e "$sources/ubuntu.list" ] || fail "Ubuntu source was removed"
 
@@ -94,6 +100,8 @@ rejects "install ran after update failure" "apt-get install" "$calls"
 for workflow in test-kurtosis-assertoor.yml test-kurtosis-gloas.yml; do
   path="$repo/.github/workflows/$workflow"
   contains "$workflow does not use shared setup" "uses: ./.github/actions/setup-kurtosis" "$path"
+  contains "$workflow pins a Kurtosis version other than $version" \
+    "KURTOSIS_VERSION: \"$version\"" "$path"
   contains "$workflow does not use the preinstalled Kurtosis action" \
     "uses: erigontech/kurtosis-assertoor-github-action@v1.1.7" "$path"
   rejects "$workflow still installs with apt directly" "sudo apt-get" "$path"

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -15,7 +15,7 @@ env:
   # tags are dictated by the Kurtosis release — sync them when bumping (see
   # logs_aggregator_functions and logs_collector_functions consts in
   # kurtosis-tech/kurtosis).
-  KURTOSIS_VERSION: "1.15.2"
+  KURTOSIS_VERSION: "1.20.0"
   KURTOSIS_VECTOR_IMAGE: "timberio/vector:0.45.0-debian"
   KURTOSIS_FLUENTBIT_IMAGE: "fluent/fluent-bit:4.0.0"
   # Engine-bootstrap helpers (logs-aggregator healthcheck, reverse proxy,
@@ -372,17 +372,15 @@ jobs:
             commitment_mode: parallel
           - suite: glamsterdam
             package_args: .github/workflows/kurtosis/glamsterdam.io
-            # Pinned to 6.1.0 rather than main: commit 835dd9b on main introduced GpuConfig,
-            # a Starlark built-in that requires Kurtosis CLI >=1.18.1, breaking Starlark eval.
-            # Unpin to main once CI is upgraded to Kurtosis 1.18.1.
+            # Pinned to 6.1.0 rather than main to keep the suite reproducible;
+            # the CLI >=1.18.1 requirement that forced the pin is now satisfied.
             ethereum_package_branch: "6.1.0"
             test_timeout_minutes: 20
             commitment_mode: serial
           - suite: glamsterdam
             package_args: .github/workflows/kurtosis/glamsterdam.io
-            # Pinned to 6.1.0 rather than main: commit 835dd9b on main introduced GpuConfig,
-            # a Starlark built-in that requires Kurtosis CLI >=1.18.1, breaking Starlark eval.
-            # Unpin to main once CI is upgraded to Kurtosis 1.18.1.
+            # Pinned to 6.1.0 rather than main to keep the suite reproducible;
+            # the CLI >=1.18.1 requirement that forced the pin is now satisfied.
             ethereum_package_branch: "6.1.0"
             test_timeout_minutes: 20
             commitment_mode: parallel

--- a/.github/workflows/test-kurtosis-gloas.yml
+++ b/.github/workflows/test-kurtosis-gloas.yml
@@ -12,7 +12,7 @@ env:
   # tags are dictated by the Kurtosis release — sync them when bumping (see
   # logs_aggregator_functions and logs_collector_functions consts in
   # kurtosis-tech/kurtosis).
-  KURTOSIS_VERSION: "1.15.2"
+  KURTOSIS_VERSION: "1.20.0"
   KURTOSIS_VECTOR_IMAGE: "timberio/vector:0.45.0-debian"
   KURTOSIS_FLUENTBIT_IMAGE: "fluent/fluent-bit:4.0.0"
   # Engine-bootstrap helpers (logs-aggregator healthcheck, reverse proxy,


### PR DESCRIPTION
Upstream retired `apt.fury.io/kurtosis-tech` in favour of a GitHub Pages repo. The old one serves neither a `Release` nor a `Translation-en` index, so `apt-get update` retries both and the "Install Kurtosis CLI and start engine" step fails. The replacement repo carries 1.16.6 and newer only, so the 1.15.2 pin has to move with it.

1.20.0 needs nothing else here: the infra image tags this workflow pins (vector, fluent-bit, traefik, alpine, curl-jq) and every CLI command the workflows and the assertoor action call are unchanged. It also fixes an upstream host-port collision that could fail parallel service starts.

Tested on a local amd64 Linux + Docker machine against a freshly built erigon image: apt install and engine start from the new repo, plus full Kurtosis + assertoor runs of all six suites (caplin-minimal, glamsterdam, gloas-caplin-mixed, gloas-three-cl-mixed, pectra, regular) — every assertoor test passed, regular 8/8 and pectra 7/7. `make test-kurtosis-setup`, actionlint and shellcheck are clean.