### PR TITLE
ci: stop pectra and glamsterdam pulling images on every run

### DIFF
--- a/.github/workflows/kurtosis/pectra.io
+++ b/.github/workflows/kurtosis/pectra.io
@@ -5,7 +5,7 @@ participants_matrix:
       el_log_level: "debug"
   cl:
     - cl_type: teku
-      cl_image: consensys/teku:25.9.1
+      cl_image: consensys/teku:26.4.0
     - cl_type: lighthouse
       cl_image: sigp/lighthouse:v7.0.1
 

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -6,10 +6,10 @@ env:
   # Pinned versions of third-party containers — bump here when upgrading.
   # These are cached via actions/cache (docker save/load) to avoid re-pulling
   # on every run and to eliminate Docker Hub rate-limit exposure.
-  # LIGHTHOUSE_IMAGE, TEKU_IMAGE, LIGHTHOUSE_VC_IMAGE and the ASSERTOOR_* tags are
-  # loaded at job start from the suite .io files (single source of truth) by the
-  # "Load image versions" step, so they can't drift from what kurtosis runs. The
-  # remaining third-party tags below aren't pinned in any .io, so they stay here.
+  # Every tag a suite .io pins — CL/VC clients, assertoor, and glamsterdam's
+  # genesis generator — is loaded at job start from those files (single source of
+  # truth) by the "Load image versions" step, so the cache can't drift from what
+  # kurtosis runs. The tags below aren't pinned in any .io, so they stay here.
   # Kurtosis CLI pinned so its infra images (engine/core/files-artifacts-expander
   # are tagged with the CLI version) can be cached too. The vector and fluent-bit
   # tags are dictated by the Kurtosis release — sync them when bumping (see
@@ -209,27 +209,55 @@ jobs:
       - name: Load image versions from the .io files (single source of truth)
         run: |
           reg=.github/workflows/kurtosis/regular-assertoor.io
+          pectra_io=.github/workflows/kurtosis/pectra.io
+          glamsterdam_io=.github/workflows/kurtosis/glamsterdam.io
+          caplin_io=.github/workflows/kurtosis/caplin-minimal-assertoor.io
           assertoor=$(yq -e '.assertoor_params.image' "$reg")
-          pectra=$(yq -e '.assertoor_params.image' .github/workflows/kurtosis/pectra.io)
-          glamsterdam=$(yq -e '.assertoor_params.image' .github/workflows/kurtosis/glamsterdam.io)
+          pectra=$(yq -e '.assertoor_params.image' "$pectra_io")
+          glamsterdam=$(yq -e '.assertoor_params.image' "$glamsterdam_io")
           lighthouse=$(yq -e '.participants_matrix.cl[] | select(.cl_type == "lighthouse") | .cl_image' "$reg")
           teku=$(yq -e '.participants_matrix.cl[] | select(.cl_type == "teku") | .cl_image' "$reg")
-          lighthouse_vc=$(yq -e '.participants[] | select(.vc_type == "lighthouse") | .vc_image' .github/workflows/kurtosis/caplin-minimal-assertoor.io)
+          genesis_glamsterdam=$(yq -e '.ethereum_genesis_generator_params.image' "$glamsterdam_io")
+          lighthouse_vc=$(yq -e '.participants[] | select(.vc_type == "lighthouse") | .vc_image' "$caplin_io")
+          # pectra's clients and caplin-minimal's assertoor are warmed under the tag
+          # another suite pins; bumping one alone would silently drop it back to a
+          # Docker Hub pull, so fail here instead of caching a tag nobody runs.
+          same_tag() {
+            [ "$2" = "$3" ] \
+              || { echo "::error::$1 pins $2 but the cache warms $3; reconcile them or extend the cache key"; exit 1; }
+          }
+          same_tag "$pectra_io" \
+            "$(yq -e '.participants_matrix.cl[] | select(.cl_type == "teku") | .cl_image' "$pectra_io")" "$teku"
+          same_tag "$pectra_io" \
+            "$(yq -e '.participants_matrix.cl[] | select(.cl_type == "lighthouse") | .cl_image' "$pectra_io")" "$lighthouse_vc"
+          same_tag "$caplin_io" "$(yq -e '.assertoor_params.image' "$caplin_io")" "$assertoor"
           {
             echo "ASSERTOOR_IMAGE=$assertoor"
             echo "ASSERTOOR_PECTRA_IMAGE=$pectra"
             echo "ASSERTOOR_GLAMSTERDAM_IMAGE=$glamsterdam"
             echo "LIGHTHOUSE_IMAGE=$lighthouse"
             echo "TEKU_IMAGE=$teku"
+            echo "GLAMSTERDAM_GENESIS_GENERATOR_IMAGE=$genesis_glamsterdam"
             echo "LIGHTHOUSE_VC_IMAGE=$lighthouse_vc"
           } >> "$GITHUB_ENV"
+          # actions/cache caps a key at 512 chars and spelling out every tag
+          # already needs ~500, so key on a digest of the same values. The list
+          # is echoed to keep an opaque key debuggable from the job log.
+          images=$(printf '%s\n' "$assertoor" "$pectra" "$glamsterdam" "$lighthouse" \
+            "$teku" "$genesis_glamsterdam" "$lighthouse_vc" \
+            "$KURTOSIS_VERSION" "$KURTOSIS_VECTOR_IMAGE" "$KURTOSIS_FLUENTBIT_IMAGE" \
+            "$KURTOSIS_CURL_JQ_IMAGE" "$KURTOSIS_TRAEFIK_IMAGE" "$KURTOSIS_ALPINE_IMAGE" \
+            "$ETH2_VAL_TOOLS_IMAGE" "$GENESIS_GENERATOR_IMAGE" \
+            "$CAPLIN_GENESIS_GENERATOR_IMAGE" "$KURTOSIS_PYTHON_IMAGE" | sort)
+          printf 'images behind the cache key:\n%s\n' "$images"
+          echo "DOCKER_CACHE_KEY=$(printf '%s\n' "$images" | sha256sum | cut -c1-32)" >> "$GITHUB_ENV"
 
       - name: Check whether third-party containers are already cached
         id: cache-cl-images
         uses: actions/cache/restore@v6
         with:
           path: /tmp/docker-cache
-          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.LIGHTHOUSE_VC_IMAGE }}-${{ env.TEKU_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}-${{ env.ETH2_VAL_TOOLS_IMAGE }}-${{ env.ASSERTOOR_PECTRA_IMAGE }}-${{ env.ASSERTOOR_GLAMSTERDAM_IMAGE }}-${{ env.GENESIS_GENERATOR_IMAGE }}-${{ env.CAPLIN_GENESIS_GENERATOR_IMAGE }}-${{ env.KURTOSIS_PYTHON_IMAGE }}
+          key: docker-cl-${{ env.DOCKER_CACHE_KEY }}
           lookup-only: true
 
       - name: Pull third-party containers
@@ -261,6 +289,7 @@ jobs:
           pull "${ETH2_VAL_TOOLS_IMAGE}"
           pull "${GENESIS_GENERATOR_IMAGE}"
           pull "${CAPLIN_GENESIS_GENERATOR_IMAGE}"
+          pull "${GLAMSTERDAM_GENESIS_GENERATOR_IMAGE}"
           pull "${KURTOSIS_PYTHON_IMAGE}"
           docker save "${LIGHTHOUSE_IMAGE}" -o /tmp/docker-cache/lighthouse.tar
           docker save "${LIGHTHOUSE_VC_IMAGE}" -o /tmp/docker-cache/lighthouse-vc.tar
@@ -279,6 +308,7 @@ jobs:
           docker save "${ETH2_VAL_TOOLS_IMAGE}" -o /tmp/docker-cache/eth2-val-tools.tar
           docker save "${GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/genesis-generator.tar
           docker save "${CAPLIN_GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/caplin-genesis-generator.tar
+          docker save "${GLAMSTERDAM_GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/glamsterdam-genesis-generator.tar
           docker save "${KURTOSIS_PYTHON_IMAGE}" -o /tmp/docker-cache/python.tar
 
       - name: Save third-party containers to cache
@@ -286,7 +316,7 @@ jobs:
         uses: actions/cache/save@v6
         with:
           path: /tmp/docker-cache
-          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.LIGHTHOUSE_VC_IMAGE }}-${{ env.TEKU_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}-${{ env.ETH2_VAL_TOOLS_IMAGE }}-${{ env.ASSERTOOR_PECTRA_IMAGE }}-${{ env.ASSERTOOR_GLAMSTERDAM_IMAGE }}-${{ env.GENESIS_GENERATOR_IMAGE }}-${{ env.CAPLIN_GENESIS_GENERATOR_IMAGE }}-${{ env.KURTOSIS_PYTHON_IMAGE }}
+          key: docker-cl-${{ env.DOCKER_CACHE_KEY }}
 
       - name: Check whether buildkit image is already cached
         id: cache-buildkit-image
@@ -420,27 +450,55 @@ jobs:
       - name: Load image versions from the .io files (single source of truth)
         run: |
           reg=.github/workflows/kurtosis/regular-assertoor.io
+          pectra_io=.github/workflows/kurtosis/pectra.io
+          glamsterdam_io=.github/workflows/kurtosis/glamsterdam.io
+          caplin_io=.github/workflows/kurtosis/caplin-minimal-assertoor.io
           assertoor=$(yq -e '.assertoor_params.image' "$reg")
-          pectra=$(yq -e '.assertoor_params.image' .github/workflows/kurtosis/pectra.io)
-          glamsterdam=$(yq -e '.assertoor_params.image' .github/workflows/kurtosis/glamsterdam.io)
+          pectra=$(yq -e '.assertoor_params.image' "$pectra_io")
+          glamsterdam=$(yq -e '.assertoor_params.image' "$glamsterdam_io")
           lighthouse=$(yq -e '.participants_matrix.cl[] | select(.cl_type == "lighthouse") | .cl_image' "$reg")
           teku=$(yq -e '.participants_matrix.cl[] | select(.cl_type == "teku") | .cl_image' "$reg")
-          lighthouse_vc=$(yq -e '.participants[] | select(.vc_type == "lighthouse") | .vc_image' .github/workflows/kurtosis/caplin-minimal-assertoor.io)
+          genesis_glamsterdam=$(yq -e '.ethereum_genesis_generator_params.image' "$glamsterdam_io")
+          lighthouse_vc=$(yq -e '.participants[] | select(.vc_type == "lighthouse") | .vc_image' "$caplin_io")
+          # pectra's clients and caplin-minimal's assertoor are warmed under the tag
+          # another suite pins; bumping one alone would silently drop it back to a
+          # Docker Hub pull, so fail here instead of caching a tag nobody runs.
+          same_tag() {
+            [ "$2" = "$3" ] \
+              || { echo "::error::$1 pins $2 but the cache warms $3; reconcile them or extend the cache key"; exit 1; }
+          }
+          same_tag "$pectra_io" \
+            "$(yq -e '.participants_matrix.cl[] | select(.cl_type == "teku") | .cl_image' "$pectra_io")" "$teku"
+          same_tag "$pectra_io" \
+            "$(yq -e '.participants_matrix.cl[] | select(.cl_type == "lighthouse") | .cl_image' "$pectra_io")" "$lighthouse_vc"
+          same_tag "$caplin_io" "$(yq -e '.assertoor_params.image' "$caplin_io")" "$assertoor"
           {
             echo "ASSERTOOR_IMAGE=$assertoor"
             echo "ASSERTOOR_PECTRA_IMAGE=$pectra"
             echo "ASSERTOOR_GLAMSTERDAM_IMAGE=$glamsterdam"
             echo "LIGHTHOUSE_IMAGE=$lighthouse"
             echo "TEKU_IMAGE=$teku"
+            echo "GLAMSTERDAM_GENESIS_GENERATOR_IMAGE=$genesis_glamsterdam"
             echo "LIGHTHOUSE_VC_IMAGE=$lighthouse_vc"
           } >> "$GITHUB_ENV"
+          # actions/cache caps a key at 512 chars and spelling out every tag
+          # already needs ~500, so key on a digest of the same values. The list
+          # is echoed to keep an opaque key debuggable from the job log.
+          images=$(printf '%s\n' "$assertoor" "$pectra" "$glamsterdam" "$lighthouse" \
+            "$teku" "$genesis_glamsterdam" "$lighthouse_vc" \
+            "$KURTOSIS_VERSION" "$KURTOSIS_VECTOR_IMAGE" "$KURTOSIS_FLUENTBIT_IMAGE" \
+            "$KURTOSIS_CURL_JQ_IMAGE" "$KURTOSIS_TRAEFIK_IMAGE" "$KURTOSIS_ALPINE_IMAGE" \
+            "$ETH2_VAL_TOOLS_IMAGE" "$GENESIS_GENERATOR_IMAGE" \
+            "$CAPLIN_GENESIS_GENERATOR_IMAGE" "$KURTOSIS_PYTHON_IMAGE" | sort)
+          printf 'images behind the cache key:\n%s\n' "$images"
+          echo "DOCKER_CACHE_KEY=$(printf '%s\n' "$images" | sha256sum | cut -c1-32)" >> "$GITHUB_ENV"
 
       - name: Restore cached third-party containers
         id: cache-cl-images
         uses: actions/cache@v6
         with:
           path: /tmp/docker-cache
-          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.LIGHTHOUSE_VC_IMAGE }}-${{ env.TEKU_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}-${{ env.ETH2_VAL_TOOLS_IMAGE }}-${{ env.ASSERTOOR_PECTRA_IMAGE }}-${{ env.ASSERTOOR_GLAMSTERDAM_IMAGE }}-${{ env.GENESIS_GENERATOR_IMAGE }}-${{ env.CAPLIN_GENESIS_GENERATOR_IMAGE }}-${{ env.KURTOSIS_PYTHON_IMAGE }}
+          key: docker-cl-${{ env.DOCKER_CACHE_KEY }}
 
       - name: Load cached containers into daemon
         if: steps.cache-cl-images.outputs.cache-hit == 'true'
@@ -462,6 +520,7 @@ jobs:
           docker load -i /tmp/docker-cache/eth2-val-tools.tar
           docker load -i /tmp/docker-cache/genesis-generator.tar
           docker load -i /tmp/docker-cache/caplin-genesis-generator.tar
+          docker load -i /tmp/docker-cache/glamsterdam-genesis-generator.tar
           docker load -i /tmp/docker-cache/python.tar
 
       - name: Pull third-party containers and save to cache
@@ -493,6 +552,7 @@ jobs:
           pull "${ETH2_VAL_TOOLS_IMAGE}"
           pull "${GENESIS_GENERATOR_IMAGE}"
           pull "${CAPLIN_GENESIS_GENERATOR_IMAGE}"
+          pull "${GLAMSTERDAM_GENESIS_GENERATOR_IMAGE}"
           pull "${KURTOSIS_PYTHON_IMAGE}"
           docker save "${LIGHTHOUSE_IMAGE}" -o /tmp/docker-cache/lighthouse.tar
           docker save "${LIGHTHOUSE_VC_IMAGE}" -o /tmp/docker-cache/lighthouse-vc.tar
@@ -511,6 +571,7 @@ jobs:
           docker save "${ETH2_VAL_TOOLS_IMAGE}" -o /tmp/docker-cache/eth2-val-tools.tar
           docker save "${GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/genesis-generator.tar
           docker save "${CAPLIN_GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/caplin-genesis-generator.tar
+          docker save "${GLAMSTERDAM_GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/glamsterdam-genesis-generator.tar
           docker save "${KURTOSIS_PYTHON_IMAGE}" -o /tmp/docker-cache/python.tar
 
       - name: Install Kurtosis CLI and start engine

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -247,24 +247,27 @@ jobs:
             echo "GLAMSTERDAM_GENESIS_GENERATOR_IMAGE=$genesis_glamsterdam"
             echo "LIGHTHOUSE_VC_IMAGE=$lighthouse_vc"
           } >> "$GITHUB_ENV"
-          # actions/cache caps a key at 512 chars and spelling out every tag
-          # already needs ~500, so key on a digest of the same values. The list
-          # is echoed to keep an opaque key debuggable from the job log.
-          images=$(printf '%s\n' "$assertoor" "$pectra" "$glamsterdam" "$lighthouse" \
-            "$teku" "$genesis_glamsterdam" "$lighthouse_vc" \
-            "$KURTOSIS_VERSION" "$KURTOSIS_VECTOR_IMAGE" "$KURTOSIS_FLUENTBIT_IMAGE" \
+          # Every cached tag stays spelled out in the cache key so a glance at the
+          # Actions cache list shows what a key holds. Only the registry/org prefix
+          # is dropped, which keeps the key clear of actions/cache's 512-char cap.
+          key=docker-cl
+          for image in "$lighthouse" "$lighthouse_vc" "$teku" "$assertoor" \
+            "kurtosis:$KURTOSIS_VERSION" "$KURTOSIS_VECTOR_IMAGE" "$KURTOSIS_FLUENTBIT_IMAGE" \
             "$KURTOSIS_CURL_JQ_IMAGE" "$KURTOSIS_TRAEFIK_IMAGE" "$KURTOSIS_ALPINE_IMAGE" \
-            "$ETH2_VAL_TOOLS_IMAGE" "$GENESIS_GENERATOR_IMAGE" \
-            "$CAPLIN_GENESIS_GENERATOR_IMAGE" "$KURTOSIS_PYTHON_IMAGE" | sort)
-          printf 'images behind the cache key:\n%s\n' "$images"
-          echo "DOCKER_CACHE_KEY=$(printf '%s\n' "$images" | sha256sum | cut -c1-32)" >> "$GITHUB_ENV"
+            "$ETH2_VAL_TOOLS_IMAGE" "$pectra" "$glamsterdam" "$GENESIS_GENERATOR_IMAGE" \
+            "$CAPLIN_GENESIS_GENERATOR_IMAGE" "$genesis_glamsterdam" "$KURTOSIS_PYTHON_IMAGE"; do
+            key="$key-${image##*/}"
+          done
+          [ ${#key} -le 512 ] \
+            || echo "::warning::cache key is ${#key} chars, over the 512 actions/cache allows"
+          echo "DOCKER_CACHE_KEY=$key" >> "$GITHUB_ENV"
 
       - name: Check whether third-party containers are already cached
         id: cache-cl-images
         uses: actions/cache/restore@v6
         with:
           path: /tmp/docker-cache
-          key: docker-cl-${{ env.DOCKER_CACHE_KEY }}
+          key: ${{ env.DOCKER_CACHE_KEY }}
           lookup-only: true
 
       - name: Pull third-party containers
@@ -323,7 +326,7 @@ jobs:
         uses: actions/cache/save@v6
         with:
           path: /tmp/docker-cache
-          key: docker-cl-${{ env.DOCKER_CACHE_KEY }}
+          key: ${{ env.DOCKER_CACHE_KEY }}
 
       - name: Check whether buildkit image is already cached
         id: cache-buildkit-image
@@ -493,24 +496,27 @@ jobs:
             echo "GLAMSTERDAM_GENESIS_GENERATOR_IMAGE=$genesis_glamsterdam"
             echo "LIGHTHOUSE_VC_IMAGE=$lighthouse_vc"
           } >> "$GITHUB_ENV"
-          # actions/cache caps a key at 512 chars and spelling out every tag
-          # already needs ~500, so key on a digest of the same values. The list
-          # is echoed to keep an opaque key debuggable from the job log.
-          images=$(printf '%s\n' "$assertoor" "$pectra" "$glamsterdam" "$lighthouse" \
-            "$teku" "$genesis_glamsterdam" "$lighthouse_vc" \
-            "$KURTOSIS_VERSION" "$KURTOSIS_VECTOR_IMAGE" "$KURTOSIS_FLUENTBIT_IMAGE" \
+          # Every cached tag stays spelled out in the cache key so a glance at the
+          # Actions cache list shows what a key holds. Only the registry/org prefix
+          # is dropped, which keeps the key clear of actions/cache's 512-char cap.
+          key=docker-cl
+          for image in "$lighthouse" "$lighthouse_vc" "$teku" "$assertoor" \
+            "kurtosis:$KURTOSIS_VERSION" "$KURTOSIS_VECTOR_IMAGE" "$KURTOSIS_FLUENTBIT_IMAGE" \
             "$KURTOSIS_CURL_JQ_IMAGE" "$KURTOSIS_TRAEFIK_IMAGE" "$KURTOSIS_ALPINE_IMAGE" \
-            "$ETH2_VAL_TOOLS_IMAGE" "$GENESIS_GENERATOR_IMAGE" \
-            "$CAPLIN_GENESIS_GENERATOR_IMAGE" "$KURTOSIS_PYTHON_IMAGE" | sort)
-          printf 'images behind the cache key:\n%s\n' "$images"
-          echo "DOCKER_CACHE_KEY=$(printf '%s\n' "$images" | sha256sum | cut -c1-32)" >> "$GITHUB_ENV"
+            "$ETH2_VAL_TOOLS_IMAGE" "$pectra" "$glamsterdam" "$GENESIS_GENERATOR_IMAGE" \
+            "$CAPLIN_GENESIS_GENERATOR_IMAGE" "$genesis_glamsterdam" "$KURTOSIS_PYTHON_IMAGE"; do
+            key="$key-${image##*/}"
+          done
+          [ ${#key} -le 512 ] \
+            || echo "::warning::cache key is ${#key} chars, over the 512 actions/cache allows"
+          echo "DOCKER_CACHE_KEY=$key" >> "$GITHUB_ENV"
 
       - name: Restore cached third-party containers
         id: cache-cl-images
         uses: actions/cache@v6
         with:
           path: /tmp/docker-cache
-          key: docker-cl-${{ env.DOCKER_CACHE_KEY }}
+          key: ${{ env.DOCKER_CACHE_KEY }}
 
       - name: Load cached containers into daemon
         if: steps.cache-cl-images.outputs.cache-hit == 'true'

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -222,17 +222,22 @@ jobs:
           genesis_glamsterdam=$(yq -e '.ethereum_genesis_generator_params.image' "$glamsterdam_io")
           lighthouse_vc=$(yq -e '.participants[] | select(.vc_type == "lighthouse") | .vc_image' "$caplin_io")
           # pectra's clients and caplin-minimal's assertoor are warmed under the tag
-          # another suite pins; bumping one alone would silently drop it back to a
-          # Docker Hub pull, so fail here instead of caching a tag nobody runs.
-          same_tag() {
-            [ "$2" = "$3" ] \
-              || { echo "::error::$1 pins $2 but the cache warms $3; reconcile them or extend the cache key"; exit 1; }
+          # another suite pins. Bumping one alone leaves it out of the cache, which
+          # is a slow path rather than a failure: warn, and hand the tag to the
+          # pre-pull step so it is fetched with retries.
+          uncached=
+          check_warmed() { # .io file, tag it pins, tag the cache warms
+            if [ "$2" != "$3" ]; then
+              echo "::warning::$1 pins $2 but the cache warms $3; extend the cache key to warm it"
+              uncached="$uncached $2"
+            fi
           }
-          same_tag "$pectra_io" \
+          check_warmed "$pectra_io" \
             "$(yq -e '.participants_matrix.cl[] | select(.cl_type == "teku") | .cl_image' "$pectra_io")" "$teku"
-          same_tag "$pectra_io" \
+          check_warmed "$pectra_io" \
             "$(yq -e '.participants_matrix.cl[] | select(.cl_type == "lighthouse") | .cl_image' "$pectra_io")" "$lighthouse_vc"
-          same_tag "$caplin_io" "$(yq -e '.assertoor_params.image' "$caplin_io")" "$assertoor"
+          check_warmed "$caplin_io" "$(yq -e '.assertoor_params.image' "$caplin_io")" "$assertoor"
+          echo "UNCACHED_IMAGES=${uncached# }" >> "$GITHUB_ENV"
           {
             echo "ASSERTOOR_IMAGE=$assertoor"
             echo "ASSERTOOR_PECTRA_IMAGE=$pectra"
@@ -463,17 +468,22 @@ jobs:
           genesis_glamsterdam=$(yq -e '.ethereum_genesis_generator_params.image' "$glamsterdam_io")
           lighthouse_vc=$(yq -e '.participants[] | select(.vc_type == "lighthouse") | .vc_image' "$caplin_io")
           # pectra's clients and caplin-minimal's assertoor are warmed under the tag
-          # another suite pins; bumping one alone would silently drop it back to a
-          # Docker Hub pull, so fail here instead of caching a tag nobody runs.
-          same_tag() {
-            [ "$2" = "$3" ] \
-              || { echo "::error::$1 pins $2 but the cache warms $3; reconcile them or extend the cache key"; exit 1; }
+          # another suite pins. Bumping one alone leaves it out of the cache, which
+          # is a slow path rather than a failure: warn, and hand the tag to the
+          # pre-pull step so it is fetched with retries.
+          uncached=
+          check_warmed() { # .io file, tag it pins, tag the cache warms
+            if [ "$2" != "$3" ]; then
+              echo "::warning::$1 pins $2 but the cache warms $3; extend the cache key to warm it"
+              uncached="$uncached $2"
+            fi
           }
-          same_tag "$pectra_io" \
+          check_warmed "$pectra_io" \
             "$(yq -e '.participants_matrix.cl[] | select(.cl_type == "teku") | .cl_image' "$pectra_io")" "$teku"
-          same_tag "$pectra_io" \
+          check_warmed "$pectra_io" \
             "$(yq -e '.participants_matrix.cl[] | select(.cl_type == "lighthouse") | .cl_image' "$pectra_io")" "$lighthouse_vc"
-          same_tag "$caplin_io" "$(yq -e '.assertoor_params.image' "$caplin_io")" "$assertoor"
+          check_warmed "$caplin_io" "$(yq -e '.assertoor_params.image' "$caplin_io")" "$assertoor"
+          echo "UNCACHED_IMAGES=${uncached# }" >> "$GITHUB_ENV"
           {
             echo "ASSERTOOR_IMAGE=$assertoor"
             echo "ASSERTOOR_PECTRA_IMAGE=$pectra"
@@ -575,6 +585,21 @@ jobs:
           docker save "${CAPLIN_GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/caplin-genesis-generator.tar
           docker save "${GLAMSTERDAM_GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/glamsterdam-genesis-generator.tar
           docker save "${KURTOSIS_PYTHON_IMAGE}" -o /tmp/docker-cache/python.tar
+
+      # An uncovered tag would otherwise be pulled inside `kurtosis run`, where a
+      # registry blip fails the whole test step. Fetch it here instead, with the
+      # same retries the cached images get; kurtosis still pulls it if this fails.
+      - name: Pre-pull suite images the cache does not cover
+        if: env.UNCACHED_IMAGES != ''
+        run: |
+          for image in ${UNCACHED_IMAGES}; do
+            for n in 1 2 3; do
+              if docker pull "$image"; then continue 2; fi
+              echo "docker pull $image failed (attempt $n of 3)"
+              sleep $((10 * n))
+            done
+            echo "::warning::could not pre-pull $image; kurtosis retries it at run time"
+          done
 
       - name: Install Kurtosis CLI and start engine
         uses: ./.github/actions/setup-kurtosis

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -6,10 +6,12 @@ env:
   # Pinned versions of third-party containers — bump here when upgrading.
   # These are cached via actions/cache (docker save/load) to avoid re-pulling
   # on every run and to eliminate Docker Hub rate-limit exposure.
-  # Every tag a suite .io pins — CL/VC clients, assertoor, and glamsterdam's
-  # genesis generator — is loaded at job start from those files (single source of
-  # truth) by the "Load image versions" step, so the cache can't drift from what
-  # kurtosis runs. The tags below aren't pinned in any .io, so they stay here.
+  # The immutable tags a suite .io pins — released CL/VC clients, assertoor and
+  # glamsterdam's genesis generator — are loaded at job start from those files
+  # (single source of truth) by the "Load image versions" step, so the cache can't
+  # drift from what kurtosis runs. Mutable tags (glamsterdam's devnet lighthouse,
+  # spamoor, snooper) stay live so a run never serves a stale client. The tags
+  # below aren't pinned in any .io, so they stay here.
   # Kurtosis CLI pinned so its infra images (engine/core/files-artifacts-expander
   # are tagged with the CLI version) can be cached too. The vector and fluent-bit
   # tags are dictated by the Kurtosis release — sync them when bumping (see


### PR DESCRIPTION
The "Load image versions" step read teku only from `regular-assertoor.io`, and the genesis generator only from the env block. So `pectra.io`'s teku and `glamsterdam.io`'s `ethereum-genesis-generator:6.1.4` never entered the `docker-cl-*` cache, and both suites fetched them from Docker Hub on every run — visible as `remotely downloaded` in any pectra/glamsterdam job log, and by their absence from the cache key itself.

glamsterdam's generator is now read from its `.io` and warmed with the rest. pectra pinned `teku:25.9.1` next to regular's `26.4.0`; the suite passes on 26.4.0 (7 of 7 assertoor tests, same wall-clock time), so it moves to the tag that is already cached instead of warming a second teku that is 3 GB on disk against 26.4.0's 824 MB.

pectra's clients and caplin-minimal's assertoor are only warmed because they currently equal the tag another suite pins. Bumping one alone leaves it uncached, which is a slow path rather than a failure: the load step warns and hands the tag to a pre-pull step that fetches it with the same retries the cached images get. That also keeps the fetch out of `kurtosis run`, where a registry blip fails the whole test step.

Spelling out full image references needs ~476 of the 512 characters `actions/cache` allows, leaving no room for the image this adds. The key now drops the registry/org prefix and keeps every `app:tag`, so the Actions cache list still shows what an entry holds, at 345 chars:

```
docker-cl-lighthouse:v8.1.3-lighthouse:v7.0.1-teku:26.4.0-assertoor:v0.1.2-kurtosis:1.20.0-vector:0.45.0-debian-fluent-bit:4.0.0-curl-jq:latest-traefik:2.10.6-alpine:3.17-eth2-val-tools:latest-assertoor:v0.0.17-assertoor:v0.1.3-ethereum-genesis-generator:4.0.4-ethereum-genesis-generator:3.3.7-ethereum-genesis-generator:6.1.4-python:3.11-alpine
```