### PR TITLE
[r3.5] ci: install Kurtosis from its new apt repo, pin CLI 1.20.0

### DIFF
--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -14,7 +14,7 @@ env:
   # tags are dictated by the Kurtosis release — sync them when bumping (see
   # logs_aggregator_functions and logs_collector_functions consts in
   # kurtosis-tech/kurtosis).
-  KURTOSIS_VERSION: "1.15.2"
+  KURTOSIS_VERSION: "1.20.0"
   KURTOSIS_VECTOR_IMAGE: "timberio/vector:0.45.0-debian"
   KURTOSIS_FLUENTBIT_IMAGE: "fluent/fluent-bit:4.0.0"
 
@@ -221,7 +221,7 @@ jobs:
         # where a registry blip fails the whole test step. Start it here from
         # the pre-loaded images, with cheap retries.
         run: |
-          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+          echo "deb [trusted=yes] https://sdk.kurtosis.com/kurtosis-cli-release-artifacts/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
           sudo apt-get update
           sudo apt-get install -y kurtosis-cli=${KURTOSIS_VERSION}
           kurtosis analytics disable

--- a/.github/workflows/test-kurtosis-gloas.yml
+++ b/.github/workflows/test-kurtosis-gloas.yml
@@ -10,7 +10,7 @@ env:
   # tags are dictated by the Kurtosis release — sync them when bumping (see
   # logs_aggregator_functions and logs_collector_functions consts in
   # kurtosis-tech/kurtosis).
-  KURTOSIS_VERSION: "1.15.2"
+  KURTOSIS_VERSION: "1.20.0"
   KURTOSIS_VECTOR_IMAGE: "timberio/vector:0.45.0-debian"
   KURTOSIS_FLUENTBIT_IMAGE: "fluent/fluent-bit:4.0.0"
 
@@ -131,7 +131,7 @@ jobs:
         # where a registry blip fails the whole test step. Start it here from
         # the pre-loaded images, with cheap retries.
         run: |
-          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+          echo "deb [trusted=yes] https://sdk.kurtosis.com/kurtosis-cli-release-artifacts/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
           sudo apt-get update
           sudo apt-get install -y kurtosis-cli=${KURTOSIS_VERSION}
           kurtosis analytics disable


### PR DESCRIPTION
Adapted backport of #23439 to release/3.5, which installs Kurtosis from the retired `apt.fury.io/kurtosis-tech` repo and pins 1.15.2 — a version the replacement repo does not carry — so its Kurtosis jobs cannot pass as-is.

## r3.5-specific adaptations

This branch predates the shared `setup-kurtosis` action (#23400), so the install lives inline in both workflows and the cherry-pick does not apply. Only the repository URL and the pinned version are changed, in place; the surrounding inline script, the engine-start retries and the matrix are untouched.

Verified on amd64 Linux: this branch's install step, run verbatim against the new repo, installs 1.20.0 and starts the engine.