### PR TITLE
execution: give the Amsterdam genesis header a slotNumber

### DIFF
--- a/execution/state/genesiswrite/genesis_test.go
+++ b/execution/state/genesiswrite/genesis_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/holiman/uint256"
+	"github.com/jinzhu/copier"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -248,13 +249,16 @@ func TestGenesisStorageBearingEmptyAccountIsPresent(t *testing.T) {
 func TestAmsterdamGenesisCarriesSlotNumber(t *testing.T) {
 	t.Parallel()
 
+	// Deep copy: chain.Config carries a sync.Once and a memoized map, and its own doc
+	// forbids copying it by value.
+	var cfg chain.Config
+	require.NoError(t, copier.CopyWithOption(&cfg, chain.AllProtocolChanges, copier.Option{DeepCopy: true}))
 	zero := uint64(0)
-	cfg := *chain.AllProtocolChanges
 	cfg.AmsterdamTime = &zero
 	head, _ := genesiswrite.GenesisWithoutStateToBlock(&types.Genesis{Config: &cfg})
 
 	// merge.VerifyHeader rejects an Amsterdam header without one (ErrMissingSlotNumber),
-	// and geth and besu both put zero here, so the genesis hash depends on it.
+	// and the genesis hash depends on it.
 	require.NotNil(t, head.SlotNumber, "Amsterdam genesis header must carry slotNumber")
 	require.Zero(t, *head.SlotNumber)
 

--- a/execution/state/genesiswrite/genesis_test.go
+++ b/execution/state/genesiswrite/genesis_test.go
@@ -245,6 +245,24 @@ func TestGenesisStorageBearingEmptyAccountIsPresent(t *testing.T) {
 	assert.Equal(u256.U64(0x2a), got, "storage slot must be readable")
 }
 
+func TestAmsterdamGenesisCarriesSlotNumber(t *testing.T) {
+	t.Parallel()
+
+	zero := uint64(0)
+	cfg := *chain.AllProtocolChanges
+	cfg.AmsterdamTime = &zero
+	head, _ := genesiswrite.GenesisWithoutStateToBlock(&types.Genesis{Config: &cfg})
+
+	// merge.VerifyHeader rejects an Amsterdam header without one (ErrMissingSlotNumber),
+	// and geth and besu both put zero here, so the genesis hash depends on it.
+	require.NotNil(t, head.SlotNumber, "Amsterdam genesis header must carry slotNumber")
+	require.Zero(t, *head.SlotNumber)
+
+	cfg.AmsterdamTime = nil
+	head, _ = genesiswrite.GenesisWithoutStateToBlock(&types.Genesis{Config: &cfg})
+	require.Nil(t, head.SlotNumber, "pre-Amsterdam genesis header must not carry slotNumber")
+}
+
 // See https://github.com/erigontech/erigon/pull/11264
 func TestDecodeBalance0(t *testing.T) {
 	genesisData, err := os.ReadFile("./genesis_test.json")

--- a/execution/state/genesiswrite/genesis_write.go
+++ b/execution/state/genesiswrite/genesis_write.go
@@ -554,6 +554,8 @@ func GenesisWithoutStateToBlock(g *types.Genesis) (head *types.Header, withdrawa
 		}
 		if g.SlotNumber != nil {
 			head.SlotNumber = g.SlotNumber
+		} else {
+			head.SlotNumber = new(uint64)
 		}
 	}
 


### PR DESCRIPTION
`GenesisWithoutStateToBlock` defaults every other Amsterdam-and-later header field at genesis —
`blobGasUsed`, `excessBlobGas`, `parentBeaconBlockRoot`, `requestsHash`, `blockAccessListHash` — but
leaves `slotNumber` nil unless the genesis JSON names it, and nothing emits it. The field is then
absent from the header RLP and block 0 gets a different hash.

Erigon's own rule rejects that header: `VerifyHeader` in `execution/protocol/rules/merge` returns
`ErrMissingSlotNumber` for an Amsterdam header without a `slotNumber`, so the two halves of erigon
disagree about a block erigon itself produced. EIP-7843 carves out no exception for block 0.

Found while bringing erigon up on an Amsterdam-at-genesis devnet, where go-ethereum produced a
genesis block hash erigon could not reproduce. Every other header field was identical, state root
included; go-ethereum carried `"slotNumber": "0x0"` and erigon carried nothing. With the default,
the two agree.

## Changes

- default `head.SlotNumber` to zero under Amsterdam, as the neighbouring Amsterdam fields already are
- a test that the field is present at genesis under Amsterdam and absent before it
