### PR TITLE
rpc: seed the next access-list tracer from the previous one

### DIFF
--- a/execution/tracing/tracers/logger/access_list_tracer.go
+++ b/execution/tracing/tracers/logger/access_list_tracer.go
@@ -20,6 +20,7 @@
 package logger
 
 import (
+	"maps"
 	"slices"
 
 	"github.com/erigontech/erigon/common"
@@ -66,6 +67,18 @@ func (al accessList) addSlot(address common.Address, slot common.Hash) {
 	if _, ok := storage.slots[slot]; !ok {
 		storage.slots[slot] = len(storage.slots)
 	}
+}
+
+// clone returns an access list with the same contents, sharing no maps with al.
+func (al accessList) clone() accessList {
+	cp := make(accessList, len(al))
+	for addr, storage := range al {
+		if storage.slots != nil {
+			storage.slots = maps.Clone(storage.slots)
+		}
+		cp[addr] = storage
+	}
+	return cp
 }
 
 // equal checks if the content of the current access list is the same as the
@@ -178,6 +191,17 @@ func NewAccessListTracer(acl types.AccessList, exclude map[common.Address]struct
 		state:              state,
 		createdContracts:   make(map[common.Address]struct{}),
 		usedBeforeCreation: make(map[common.Address]struct{}),
+	}
+}
+
+// SeedNew returns a tracer that starts from a's accumulated list, for the next
+// convergence iteration. It copies the maps directly rather than round-tripping
+// through types.AccessList, and inherits a's exclusion set.
+func (a *AccessListTracer) SeedNew(state *state.IntraBlockState) *AccessListTracer {
+	return &AccessListTracer{
+		excl:  a.excl,
+		list:  a.list.clone(),
+		state: state,
 	}
 }
 

--- a/execution/tracing/tracers/logger/access_list_tracer.go
+++ b/execution/tracing/tracers/logger/access_list_tracer.go
@@ -209,12 +209,15 @@ func NewAccessListTracer(acl types.AccessList, exclude map[common.Address]struct
 
 // SeedNew returns a tracer that starts from a's accumulated list, for the next
 // convergence iteration. It copies the maps directly rather than round-tripping
-// through types.AccessList, and inherits a's exclusion set.
+// through types.AccessList, and inherits a's exclusion set. The contract sets
+// start empty: they describe one execution, not the accumulated list.
 func (a *AccessListTracer) SeedNew(state *state.IntraBlockState) *AccessListTracer {
 	return &AccessListTracer{
-		excl:  a.excl,
-		list:  a.list.cloneExcluding(a.excl),
-		state: state,
+		excl:               a.excl,
+		list:               a.list.cloneExcluding(a.excl),
+		state:              state,
+		createdContracts:   make(map[common.Address]struct{}),
+		usedBeforeCreation: make(map[common.Address]struct{}),
 	}
 }
 

--- a/execution/tracing/tracers/logger/access_list_tracer.go
+++ b/execution/tracing/tracers/logger/access_list_tracer.go
@@ -86,9 +86,7 @@ func (al accessList) cloneExcluding(excl map[common.Address]struct{}) accessList
 		}
 		storage := al[addr]
 		storage.order = len(cp)
-		if storage.slots != nil {
-			storage.slots = maps.Clone(storage.slots)
-		}
+		storage.slots = maps.Clone(storage.slots)
 		cp[addr] = storage
 	}
 	return cp
@@ -184,19 +182,24 @@ type AccessListTracer struct {
 // An optional set of addresses to be excluded from the resulting accesslist can
 // also be specified.
 func NewAccessListTracer(acl types.AccessList, exclude map[common.Address]struct{}, state *state.IntraBlockState) *AccessListTracer {
-	excl := make(map[common.Address]struct{})
-	if exclude != nil {
-		excl = exclude
-	}
-	list := newAccessList()
+	t := newAccessListTracer(exclude, newAccessList(), state)
 	for _, al := range acl {
-		if _, ok := excl[al.Address]; ok {
+		if _, ok := t.excl[al.Address]; ok {
 			continue
 		}
-		list.addAddress(al.Address)
+		t.list.addAddress(al.Address)
 		for _, slot := range al.StorageKeys {
-			list.addSlot(al.Address, slot)
+			t.list.addSlot(al.Address, slot)
 		}
+	}
+	return t
+}
+
+// newAccessListTracer holds the construction both entry points share, so they
+// cannot drift.
+func newAccessListTracer(excl map[common.Address]struct{}, list accessList, state *state.IntraBlockState) *AccessListTracer {
+	if excl == nil {
+		excl = make(map[common.Address]struct{})
 	}
 	return &AccessListTracer{
 		excl:               excl,
@@ -208,17 +211,10 @@ func NewAccessListTracer(acl types.AccessList, exclude map[common.Address]struct
 }
 
 // SeedNew returns a tracer that starts from a's accumulated list, for the next
-// convergence iteration. It copies the maps directly rather than round-tripping
-// through types.AccessList, and inherits a's exclusion set. The contract sets
-// start empty: they describe one execution, not the accumulated list.
+// convergence iteration, copying the maps directly rather than round-tripping
+// through types.AccessList.
 func (a *AccessListTracer) SeedNew(state *state.IntraBlockState) *AccessListTracer {
-	return &AccessListTracer{
-		excl:               a.excl,
-		list:               a.list.cloneExcluding(a.excl),
-		state:              state,
-		createdContracts:   make(map[common.Address]struct{}),
-		usedBeforeCreation: make(map[common.Address]struct{}),
-	}
+	return newAccessListTracer(a.excl, a.list.cloneExcluding(a.excl), state)
 }
 
 func (a *AccessListTracer) Hooks() *tracing.Hooks {

--- a/execution/tracing/tracers/logger/access_list_tracer.go
+++ b/execution/tracing/tracers/logger/access_list_tracer.go
@@ -69,10 +69,23 @@ func (al accessList) addSlot(address common.Address, slot common.Hash) {
 	}
 }
 
-// clone returns an access list with the same contents, sharing no maps with al.
-func (al accessList) clone() accessList {
-	cp := make(accessList, len(al))
+// cloneExcluding copies al without the excluded addresses, sharing no maps with
+// it and renumbering order so it stays dense. The exclusion is not redundant:
+// the SLOAD/SSTORE path of OnOpcode adds the executing address without
+// consulting excl, so an excluded address can be in al.
+func (al accessList) cloneExcluding(excl map[common.Address]struct{}) accessList {
+	byOrder := make([]common.Address, len(al))
 	for addr, storage := range al {
+		byOrder[storage.order] = addr
+	}
+
+	cp := make(accessList, len(al))
+	for _, addr := range byOrder {
+		if _, ok := excl[addr]; ok {
+			continue
+		}
+		storage := al[addr]
+		storage.order = len(cp)
 		if storage.slots != nil {
 			storage.slots = maps.Clone(storage.slots)
 		}
@@ -200,7 +213,7 @@ func NewAccessListTracer(acl types.AccessList, exclude map[common.Address]struct
 func (a *AccessListTracer) SeedNew(state *state.IntraBlockState) *AccessListTracer {
 	return &AccessListTracer{
 		excl:  a.excl,
-		list:  a.list.clone(),
+		list:  a.list.cloneExcluding(a.excl),
 		state: state,
 	}
 }

--- a/execution/tracing/tracers/logger/access_list_tracer_test.go
+++ b/execution/tracing/tracers/logger/access_list_tracer_test.go
@@ -93,7 +93,6 @@ func TestAccessListTracerSeedNew(t *testing.T) {
 
 	require.Equal(t, roundTripped.AccessList(), seeded.AccessList())
 	require.True(t, seeded.Equal(prev))
-	require.True(t, seeded.Equal(roundTripped))
 
 	seeded.list.addSlot(addr, slot3)
 	seeded.list.addAddress(excluded)
@@ -101,9 +100,8 @@ func TestAccessListTracerSeedNew(t *testing.T) {
 	require.Equal(t, roundTripped.AccessList(), prev.AccessList())
 }
 
-// TestAccessListTracerSeedNewDropsExcluded pins that seeding filters the exclusion
-// set. OnOpcode's SLOAD/SSTORE path adds the executing address without checking
-// excl, so an excluded address reaches the list and must not survive re-seeding.
+// TestAccessListTracerSeedNewDropsExcluded pins the filtering cloneExcluding
+// documents: an excluded address can reach the list, and must not survive.
 func TestAccessListTracerSeedNewDropsExcluded(t *testing.T) {
 	excluded := common.BytesToAddress([]byte{0x77})
 	excl := map[common.Address]struct{}{excluded: {}}
@@ -138,7 +136,7 @@ func TestAccessListTracerSeedNewTracesOpcodes(t *testing.T) {
 
 func BenchmarkAccessListTracerSeed(b *testing.B) {
 	// Real eth_createAccessList lists are small: a handful of addresses with a
-	// few slots each. The wide shapes are here to show where the crossover is.
+	// few slots each. The wide shapes are here for scale.
 	for _, shape := range []struct{ nAddrs, nSlots int }{
 		{1, 1}, {1, 5}, {1, 17}, {3, 5}, {5, 20}, {30, 20},
 	} {

--- a/execution/tracing/tracers/logger/access_list_tracer_test.go
+++ b/execution/tracing/tracers/logger/access_list_tracer_test.go
@@ -70,3 +70,56 @@ func TestNewAccessListTracerExcludedAddress(t *testing.T) {
 		t.Fatalf("excluded prelude address must not contribute tuples, got %+v", got)
 	}
 }
+
+// TestAccessListTracerSeedNew pins that seeding directly from the accumulated maps
+// is observationally the same as the types.AccessList round-trip it replaces, and
+// that the two tracers share nothing.
+func TestAccessListTracerSeedNew(t *testing.T) {
+	excluded := common.BytesToAddress([]byte{0x09})
+	excl := map[common.Address]struct{}{excluded: {}}
+
+	prev := NewAccessListTracer(nil, excl, nil)
+	prev.list.addSlot(addr, slot1)
+	prev.list.addSlot(addr, slot2)
+	prev.list.addAddress(common.BytesToAddress([]byte{0x02, 0x72}))
+
+	seeded := prev.SeedNew(nil)
+	roundTripped := NewAccessListTracer(prev.AccessList(), excl, nil)
+
+	require.Equal(t, roundTripped.AccessList(), seeded.AccessList())
+	require.True(t, seeded.Equal(prev))
+	require.True(t, seeded.Equal(roundTripped))
+
+	seeded.list.addSlot(addr, slot3)
+	seeded.list.addAddress(excluded)
+	require.False(t, seeded.Equal(prev), "the seeded tracer must not write through to its source")
+	require.Equal(t, roundTripped.AccessList(), prev.AccessList())
+}
+
+func BenchmarkAccessListTracerSeed(b *testing.B) {
+	const nAddrs, nSlots = 30, 20
+
+	prev := NewAccessListTracer(nil, nil, nil)
+	for a := range nAddrs {
+		address := common.BytesToAddress([]byte{byte(a + 1)})
+		for s := range nSlots {
+			prev.list.addSlot(address, common.BytesToHash([]byte{byte(s + 1)}))
+		}
+	}
+
+	// AccessList() is built either way (the message needs it), so only the seeding
+	// half differs between the two.
+	acl := prev.AccessList()
+	b.Run("roundTrip", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			_ = NewAccessListTracer(acl, nil, nil)
+		}
+	})
+	b.Run("seedNew", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			_ = prev.SeedNew(nil)
+		}
+	})
+}

--- a/execution/tracing/tracers/logger/access_list_tracer_test.go
+++ b/execution/tracing/tracers/logger/access_list_tracer_test.go
@@ -17,6 +17,7 @@
 package logger
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -136,29 +137,33 @@ func TestAccessListTracerSeedNewTracesOpcodes(t *testing.T) {
 }
 
 func BenchmarkAccessListTracerSeed(b *testing.B) {
-	const nAddrs, nSlots = 30, 20
-
-	prev := NewAccessListTracer(nil, nil, nil)
-	for a := range nAddrs {
-		address := common.BytesToAddress([]byte{byte(a + 1)})
-		for s := range nSlots {
-			prev.list.addSlot(address, common.BytesToHash([]byte{byte(s + 1)}))
+	// Real eth_createAccessList lists are small: a handful of addresses with a
+	// few slots each. The wide shapes are here to show where the crossover is.
+	for _, shape := range []struct{ nAddrs, nSlots int }{
+		{1, 1}, {1, 5}, {1, 17}, {3, 5}, {5, 20}, {30, 20},
+	} {
+		prev := NewAccessListTracer(nil, nil, nil)
+		for a := range shape.nAddrs {
+			address := common.BytesToAddress([]byte{byte(a + 1)})
+			for s := range shape.nSlots {
+				prev.list.addSlot(address, common.BytesToHash([]byte{byte(s + 1)}))
+			}
 		}
+		// AccessList() is built either way, so only the seeding half differs.
+		acl := prev.AccessList()
+		name := fmt.Sprintf("%dx%d", shape.nAddrs, shape.nSlots)
+
+		b.Run(name+"/roundTrip", func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				_ = NewAccessListTracer(acl, nil, nil)
+			}
+		})
+		b.Run(name+"/seedNew", func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				_ = prev.SeedNew(nil)
+			}
+		})
 	}
-
-	// AccessList() is built either way (the message needs it), so only the seeding
-	// half differs between the two.
-	acl := prev.AccessList()
-	b.Run("roundTrip", func(b *testing.B) {
-		b.ReportAllocs()
-		for b.Loop() {
-			_ = NewAccessListTracer(acl, nil, nil)
-		}
-	})
-	b.Run("seedNew", func(b *testing.B) {
-		b.ReportAllocs()
-		for b.Loop() {
-			_ = prev.SeedNew(nil)
-		}
-	})
 }

--- a/execution/tracing/tracers/logger/access_list_tracer_test.go
+++ b/execution/tracing/tracers/logger/access_list_tracer_test.go
@@ -96,6 +96,22 @@ func TestAccessListTracerSeedNew(t *testing.T) {
 	require.Equal(t, roundTripped.AccessList(), prev.AccessList())
 }
 
+// TestAccessListTracerSeedNewDropsExcluded pins that seeding filters the exclusion
+// set. OnOpcode's SLOAD/SSTORE path adds the executing address without checking
+// excl, so an excluded address reaches the list and must not survive re-seeding.
+func TestAccessListTracerSeedNewDropsExcluded(t *testing.T) {
+	excluded := common.BytesToAddress([]byte{0x77})
+	excl := map[common.Address]struct{}{excluded: {}}
+
+	prev := NewAccessListTracer(nil, excl, nil)
+	prev.list.addSlot(excluded, slot1)
+	prev.list.addSlot(addr, slot2)
+
+	seeded := prev.SeedNew(nil)
+	require.Equal(t, NewAccessListTracer(prev.AccessList(), excl, nil).AccessList(), seeded.AccessList())
+	require.Equal(t, types.AccessList{{Address: addr, StorageKeys: []common.Hash{slot2}}}, seeded.AccessList())
+}
+
 func BenchmarkAccessListTracerSeed(b *testing.B) {
 	const nAddrs, nSlots = 30, 20
 

--- a/execution/tracing/tracers/logger/access_list_tracer_test.go
+++ b/execution/tracing/tracers/logger/access_list_tracer_test.go
@@ -21,8 +21,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/holiman/uint256"
+
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/execution/types/accounts"
+	"github.com/erigontech/erigon/execution/vm"
 )
 
 var (
@@ -110,6 +114,25 @@ func TestAccessListTracerSeedNewDropsExcluded(t *testing.T) {
 	seeded := prev.SeedNew(nil)
 	require.Equal(t, NewAccessListTracer(prev.AccessList(), excl, nil).AccessList(), seeded.AccessList())
 	require.Equal(t, types.AccessList{{Address: addr, StorageKeys: []common.Hash{slot2}}}, seeded.AccessList())
+}
+
+// TestAccessListTracerSeedNewTracesOpcodes drives a seeded tracer through the
+// opcodes that write its contract sets, which the AccessList-only assertions
+// above never reach.
+func TestAccessListTracerSeedNewTracesOpcodes(t *testing.T) {
+	prev := NewAccessListTracer(nil, nil, nil)
+	prev.list.addSlot(addr, slot1)
+
+	seeded := prev.SeedNew(nil)
+	scope := &mockOpContext{
+		address: accounts.InternAddress(addr),
+		stack:   []uint256.Int{*new(uint256.Int).SetBytes(slot2[:])},
+	}
+	seeded.OnOpcode(0, byte(vm.SLOAD), 100, 3, scope, nil, 1, nil)
+
+	require.Equal(t, types.AccessList{{Address: addr, StorageKeys: []common.Hash{slot1, slot2}}}, seeded.AccessList())
+	require.True(t, seeded.UsedBeforeCreation(addr))
+	require.Empty(t, seeded.CreatedContracts())
 }
 
 func BenchmarkAccessListTracerSeed(b *testing.B) {

--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -1043,7 +1043,7 @@ func (api *APIImpl) CreateAccessList(ctx context.Context, args ethapi2.CallArgs,
 			}
 		}
 
-		// Retrieve the current access list to expand
+		// The message needs the list; the next tracer is seeded from the maps.
 		accessList := prevTracer.AccessList()
 		log.Trace("Creating access list", "input", accessList)
 

--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -1062,7 +1062,7 @@ func (api *APIImpl) CreateAccessList(ctx context.Context, args ethapi2.CallArgs,
 		}
 
 		// Apply the transaction with the access list tracer
-		tracer := logger.NewAccessListTracer(accessList, excl, ibs)
+		tracer := prevTracer.SeedNew(ibs)
 		defer tracer.Close()
 		config := vm.Config{Tracer: tracer.Hooks(), NoBaseFee: true}
 		txCtx := protocol.NewEVMTxContext(msg)

--- a/rpc/jsonrpc/eth_call_test.go
+++ b/rpc/jsonrpc/eth_call_test.go
@@ -241,6 +241,29 @@ func TestCreateAccessListContractCreationWithoutFromDoesNotPanic(t *testing.T) {
 	require.NotNil(t, res)
 }
 
+// TestCreateAccessListTracesStorage covers a target that touches storage, which is
+// the path where the tracer writes its contract sets. A plain value transfer never
+// reaches it.
+func TestCreateAccessListTracesStorage(t *testing.T) {
+	m, bankAddress, contractAddress, _ := chainWithDeployedContractAndConfig(t, chain.AllProtocolChanges)
+	api := newEthApiForTest(newBaseApiForTest(m), m.DB, stubTxPoolClient{}, nil)
+	data := hexutil.Bytes(contractInvocationData(42))
+
+	for _, from := range []*common.Address{&bankAddress, nil} {
+		res, err := api.CreateAccessList(context.Background(), ethapi.CallArgs{
+			From: from,
+			To:   &contractAddress,
+			Data: &data,
+		}, nil, nil, nil)
+		require.NoError(t, err)
+		require.Empty(t, res.Error)
+		require.Len(t, *res.Accesslist, 1)
+		require.Equal(t, contractAddress, (*res.Accesslist)[0].Address)
+		// store() writes slots 0x00..0x10.
+		require.Len(t, (*res.Accesslist)[0].StorageKeys, 17)
+	}
+}
+
 func TestEthCallNonCanonical(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
 	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)


### PR DESCRIPTION
Each `CreateAccessList` convergence iteration built a `types.AccessList` from the previous tracer's maps and immediately parsed it back into maps for the next tracer. The list is built either way (the message needs it), so only the parse is avoidable: `SeedNew` copies the maps directly and applies the exclusion set, which the round-trip was doing implicitly.

Two bugs found by hive's rpc-compat suite and fixed here:

- `OnOpcode`'s SLOAD/SSTORE path adds the executing address without consulting `excl`, so an excluded address reaches the list. The round-trip filtered it out every iteration; a plain clone let it through into the RPC result.
- The tracer's contract sets have to start empty per execution — leaving them nil panicked on the first `SLOAD`.

`BenchmarkAccessListTracerSeed` (new), M4 Max. Real access lists are small, so it is parameterised by shape rather than measuring one wide list:

| shape | roundTrip | seedNew |
|---|---|---|
| 1×1 | 8 allocs, 237ns | 7 allocs, 217ns |
| 1×5 | 8 allocs, 316ns | 7 allocs, 237ns |
| 1×17 | 13 allocs, 1517ns | 9 allocs, 478ns |
| 3×5 | 12 allocs, 919ns | 12 allocs, 550ns |
| 5×20 | 41 allocs, 7708ns | 26 allocs, 1432ns |
| 30×20 | 223 allocs, 41.6µs | 128 allocs, 7.9µs |

Never worse, and the gap widens with list size.