### PR TITLE
execution/tracing: stop materialising hex strings in the struct logger

### DIFF
--- a/execution/tracing/tracers/logger/json_stream.go
+++ b/execution/tracing/tracers/logger/json_stream.go
@@ -84,8 +84,9 @@ func (l *JsonStreamLogger) OnSystemCallStartV2(env *tracing.VMContext) {
 }
 
 // hexWithPrefix encodes b as a 0x-prefixed hex string using the internal buffer.
-// The result aliases that buffer, so it is only valid until the next call: hand
-// it straight to the stream, which copies it in.
+// The result aliases hexEncodeBuf, so it is invalidated by anything that writes
+// that buffer, writeMemoryWordRaw included. Hand it straight to the stream,
+// which copies it in.
 func (l *JsonStreamLogger) hexWithPrefix(b []byte) string {
 	l.hexEncodeBuf[0] = '0'
 	l.hexEncodeBuf[1] = 'x'

--- a/execution/tracing/tracers/logger/json_stream.go
+++ b/execution/tracing/tracers/logger/json_stream.go
@@ -84,11 +84,13 @@ func (l *JsonStreamLogger) OnSystemCallStartV2(env *tracing.VMContext) {
 }
 
 // hexWithPrefix encodes b as a 0x-prefixed hex string using the internal buffer.
+// The result aliases that buffer, so it is only valid until the next call: hand
+// it straight to the stream, which copies it in.
 func (l *JsonStreamLogger) hexWithPrefix(b []byte) string {
 	l.hexEncodeBuf[0] = '0'
 	l.hexEncodeBuf[1] = 'x'
 	n := hex.Encode(l.hexEncodeBuf[2:], b)
-	return string(l.hexEncodeBuf[:2+n])
+	return common.ToStringZeroCopy(l.hexEncodeBuf[:2+n])
 }
 
 // writeMemoryWordRaw writes a memory word as a JSON string "0x<hex>" directly

--- a/execution/tracing/tracers/logger/json_stream_test.go
+++ b/execution/tracing/tracers/logger/json_stream_test.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"maps"
 	"math/big"
 	"strings"
 	"testing"
@@ -418,10 +417,11 @@ func TestJsonStreamLogger_StorageEncodingManyKeys(t *testing.T) {
 		l.OnOpcode(uint64(i), byte(vm.SSTORE), 100, 3, scope, nil, 1, nil)
 		want["0x"+hex.EncodeToString(key[:])] = "0x" + hex.EncodeToString(val[:])
 	}
-	// The logger writes a step's storage on the following step, so drive one more.
-	l.OnOpcode(99, byte(vm.STOP), 100, 0, scope, nil, 1, nil)
 
-	require.NoError(t, stream.ClosePending(0))
+	// Close the way the production epilogue does: ClosePending would repair an
+	// imbalance into valid JSON and hide exactly what this pins.
+	stream.WriteArrayEnd()
+	stream.WriteObjectEnd()
 	require.NoError(t, stream.Flush())
 	require.True(t, json.Valid(buf.Bytes()), "output is not valid JSON: %s", buf.Bytes())
 
@@ -431,20 +431,51 @@ func TestJsonStreamLogger_StorageEncodingManyKeys(t *testing.T) {
 		} `json:"structLogs"`
 	}
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &out))
+	require.NotEmpty(t, out.StructLogs)
 
-	got := map[string]string{}
-	multiSlot := false
-	for _, entry := range out.StructLogs {
-		maps.Copy(got, entry.Storage)
-		multiSlot = multiSlot || len(entry.Storage) > 1
+	// Storage accumulates, so the last step carries every pair and exercises
+	// three separators.
+	require.Equal(t, want, out.StructLogs[len(out.StructLogs)-1].Storage)
+}
+
+// TestJsonStreamLogger_StorageWithMemory drives both users of hexEncodeBuf in a
+// single step, which is what the aliasing in hexWithPrefix depends on.
+func TestJsonStreamLogger_StorageWithMemory(t *testing.T) {
+	key := common.BigToHash(common.Big1)
+	val := common.BigToHash(common.Big2)
+	scope := &mockOpContext{
+		memory: bytes.Repeat([]byte{0xcd}, 64),
+		stack:  []uint256.Int{*new(uint256.Int).SetBytes(val[:]), *new(uint256.Int).SetBytes(key[:])},
 	}
-	require.True(t, multiSlot, "no step emitted more than one slot, so no separator was exercised")
-	require.Equal(t, want, got)
+
+	var buf bytes.Buffer
+	stream := jsonstream.New(&buf)
+	l := NewJsonStreamLogger(&LogConfig{EnableMemory: true}, context.Background(), stream)
+	l.env = &tracing.VMContext{IntraBlockState: &mockIBS{}}
+	l.OnOpcode(0, byte(vm.SSTORE), 100, 3, scope, nil, 1, nil)
+	stream.WriteArrayEnd()
+	stream.WriteObjectEnd()
+	require.NoError(t, stream.Flush())
+
+	var out struct {
+		StructLogs []struct {
+			Memory  []string          `json:"memory"`
+			Storage map[string]string `json:"storage"`
+		} `json:"structLogs"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &out), "output: %s", buf.Bytes())
+	require.Len(t, out.StructLogs, 1)
+
+	word := "0x" + strings.Repeat("cd", 32)
+	require.Equal(t, []string{word, word}, out.StructLogs[0].Memory)
+	require.Equal(t, map[string]string{
+		"0x" + hex.EncodeToString(key[:]): "0x" + hex.EncodeToString(val[:]),
+	}, out.StructLogs[0].Storage)
 }
 
 // TestJsonStreamLogger_ClosePendingAfterMemory pins that writing memory words keeps
-// the stream's auto-close stack balanced. Raw writes bypass the bookkeeping that
-// WriteString does, so an unbalanced stack makes ClosePending emit stray closers.
+// the stream's auto-close stack balanced: one word spans three stream calls, and
+// only the first may consume a pending comma or field.
 func TestJsonStreamLogger_ClosePendingAfterMemory(t *testing.T) {
 	var buf bytes.Buffer
 	stream := jsonstream.New(&buf)

--- a/execution/tracing/tracers/logger/json_stream_test.go
+++ b/execution/tracing/tracers/logger/json_stream_test.go
@@ -19,12 +19,17 @@ package logger
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"io"
+	"maps"
+	"math/big"
 	"strings"
 	"testing"
 
 	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/execution/tracing"
@@ -394,4 +399,84 @@ func TestStructLog_ErrorOmitempty(t *testing.T) {
 			t.Errorf("error message: got %q, want %q", msg, "out of gas")
 		}
 	})
+}
+
+// TestJsonStreamLogger_StorageEncodingManyKeys covers the separator handling when
+// more than one slot is emitted; a single-entry object never writes one.
+func TestJsonStreamLogger_StorageEncodingManyKeys(t *testing.T) {
+	var buf bytes.Buffer
+	stream := jsonstream.New(&buf)
+	l := NewJsonStreamLogger(&LogConfig{}, context.Background(), stream)
+	l.env = &tracing.VMContext{IntraBlockState: &mockIBS{}}
+
+	scope := &mockOpContext{}
+	want := map[string]string{}
+	for i := range 4 {
+		key := common.BigToHash(big.NewInt(int64(i + 1)))
+		val := common.BigToHash(big.NewInt(int64(100 + i)))
+		scope.stack = []uint256.Int{*new(uint256.Int).SetBytes(val[:]), *new(uint256.Int).SetBytes(key[:])}
+		l.OnOpcode(uint64(i), byte(vm.SSTORE), 100, 3, scope, nil, 1, nil)
+		want["0x"+hex.EncodeToString(key[:])] = "0x" + hex.EncodeToString(val[:])
+	}
+	// The logger writes a step's storage on the following step, so drive one more.
+	l.OnOpcode(99, byte(vm.STOP), 100, 0, scope, nil, 1, nil)
+
+	require.NoError(t, stream.ClosePending(0))
+	require.NoError(t, stream.Flush())
+	require.True(t, json.Valid(buf.Bytes()), "output is not valid JSON: %s", buf.Bytes())
+
+	var out struct {
+		StructLogs []struct {
+			Storage map[string]string `json:"storage"`
+		} `json:"structLogs"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &out))
+
+	got := map[string]string{}
+	multiSlot := false
+	for _, entry := range out.StructLogs {
+		maps.Copy(got, entry.Storage)
+		multiSlot = multiSlot || len(entry.Storage) > 1
+	}
+	require.True(t, multiSlot, "no step emitted more than one slot, so no separator was exercised")
+	require.Equal(t, want, got)
+}
+
+// TestJsonStreamLogger_ClosePendingAfterMemory pins that writing memory words keeps
+// the stream's auto-close stack balanced. Raw writes bypass the bookkeeping that
+// WriteString does, so an unbalanced stack makes ClosePending emit stray closers.
+func TestJsonStreamLogger_ClosePendingAfterMemory(t *testing.T) {
+	var buf bytes.Buffer
+	stream := jsonstream.New(&buf)
+	l := NewJsonStreamLogger(&LogConfig{EnableMemory: true}, context.Background(), stream)
+	l.env = &tracing.VMContext{IntraBlockState: &mockIBS{}}
+
+	scope := &mockOpContext{memory: bytes.Repeat([]byte{0xab}, 32*4)}
+	for i := range 3 {
+		l.OnOpcode(uint64(i), byte(vm.MLOAD), 100, 3, scope, nil, 1, nil)
+	}
+
+	require.NoError(t, stream.ClosePending(0))
+	require.NoError(t, stream.Flush())
+	require.True(t, json.Valid(buf.Bytes()), "output is not valid JSON: %s", buf.Bytes())
+}
+
+func BenchmarkJsonStreamLogger_OnOpcode(b *testing.B) {
+	key := common.BigToHash(common.Big1)
+	val := common.BigToHash(common.Big2)
+	scope := &mockOpContext{
+		memory: bytes.Repeat([]byte{0xab}, 256),
+		stack:  []uint256.Int{*new(uint256.Int).SetBytes(val[:]), *new(uint256.Int).SetBytes(key[:])},
+	}
+
+	stream := jsonstream.New(io.Discard)
+	l := NewJsonStreamLogger(&LogConfig{EnableMemory: true}, context.Background(), stream)
+	l.env = &tracing.VMContext{IntraBlockState: &mockIBS{}}
+
+	b.ReportAllocs()
+	i := 0
+	for b.Loop() {
+		l.OnOpcode(uint64(i), byte(vm.SSTORE), 100, 3, scope, nil, 1, nil)
+		i++
+	}
 }

--- a/rpc/jsonstream/stream.go
+++ b/rpc/jsonstream/stream.go
@@ -49,6 +49,8 @@ type Stream interface {
 	WriteUint64(val uint64)
 	WriteFloat32(val float32)
 	WriteFloat64(val float64)
+	// WriteString and WriteObjectField must consume val before returning:
+	// callers pass views over reusable buffers.
 	WriteString(val string)
 
 	// JSON structure methods


### PR DESCRIPTION
`hexWithPrefix` built its result with a `string(...)` conversion, which escapes, so it allocated per storage key *and* value per opcode — 9.8M objects on a `debug_traceBlockByNumber` profile. The buffer it encodes into is already a struct field and the stream copies the string in on the spot, so a zero-copy view of it does:

```go
-	return string(l.hexEncodeBuf[:2+n])
+	return common.ToStringZeroCopy(l.hexEncodeBuf[:2+n])
```

The `Flush()`/`Stream.Write` question that earlier revisions of this PR carried is split out into #23463.