### PR TITLE
db/seg: keep the page decode buffer across PagedReader.Reset

### DIFF
--- a/db/seg/seg_paged_rw.go
+++ b/db/seg/seg_paged_rw.go
@@ -99,6 +99,15 @@ func (r *Page) Reset(v []byte, compressionEnabled bool) (n int) {
 	}
 	return
 }
+
+// clear rewinds the page without dropping compressionBuf, which the next page
+// decodes into. limit=0 keeps HasNext false until a page is actually read.
+func (r *Page) clear() {
+	r.i, r.limit = 0, 0
+	r.kOffset, r.vOffset = 0, 0
+	r.kLens, r.vLens, r.data = nil, nil, nil
+}
+
 func (r *Page) HasNext() bool { return r.limit > r.i }
 func (r *Page) Next() (k, v []byte) {
 	kLen := be.Uint32(r.kLens[r.i*4:])
@@ -164,7 +173,7 @@ func (g *PagedReader) Reset(offset uint64) {
 	g.file.Reset(offset)
 	g.currentPageOffset = offset
 	g.nextPageOffset = offset
-	g.page = &Page{} // TODO: optimize
+	g.page.clear()
 	if g.file.HasNext() {
 		g.NextPage()
 	}

--- a/db/state/history_test.go
+++ b/db/state/history_test.go
@@ -2557,3 +2557,42 @@ func TestMaxHistoryValLen(t *testing.T) {
 	require.NoError(t, put(maxHistoryValLen))
 	require.Error(t, put(maxHistoryValLen+1))
 }
+
+// BenchmarkHistoryRangePaged walks merged (page-compressed) history files, which is
+// where PagedReader decodes a page per Reset. BenchmarkHistoryRange_MultiFile keeps
+// its files un-merged, so it never reaches that path.
+func BenchmarkHistoryRangePaged(b *testing.B) {
+	logger := log.New()
+	ctx := b.Context()
+
+	db, h, txs := filledHistory(b, true, logger)
+	collateAndMergeHistory(b, db, h, txs, true)
+
+	tx, err := db.BeginRo(ctx)
+	require.NoError(b, err)
+	defer tx.Rollback()
+
+	ic := h.beginForTests()
+	defer ic.Close()
+
+	paged := false
+	for _, f := range ic.files {
+		if f.src.decompressor.CompressedPageValuesCount() > 1 {
+			paged = true
+			break
+		}
+	}
+	require.True(b, paged, "bench must run against page-compressed .v files, else it does not touch PagedReader")
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		it, err := ic.HistoryRange(0, int(txs), order.Asc, -1, tx)
+		require.NoError(b, err)
+		for it.HasNext() {
+			_, _, err := it.Next()
+			require.NoError(b, err)
+		}
+		it.Close()
+	}
+}


### PR DESCRIPTION
`PagedReader.Reset` replaced the whole `Page` (`g.page = &Page{} // TODO: optimize`), dropping `compressionBuf` with it, so every seek to a new offset decoded the next page into a fresh allocation. `Page.Reset` already threads the buffer correctly — the loss was one layer up. Rewinding the page in place keeps it, and `limit = 0` still hides a stale page when the file has no next one.

This is the streaming counterpart of #23452: it hits `HistoryRange`, `RangeAsOf`, `HistoryTraceKeyFiles` and history merge.

`BenchmarkHistoryRangePaged` is new because the existing history-range benchmarks keep their files un-merged, and only merge writes paged `.v` files, so none of them reached this path. On a 16-thread EPYC 4344P, 10 interleaved rounds:

| | base | fix |
|---|---|---|
| sec/op | 131.7µ | 129.9µ (~) |
| B/op | 83.91Ki | 80.16Ki (−4.47%) |
| allocs/op | 211 | **181 (−14.2%)** |