### PR TITLE
rpc/jsonstream: flush when the buffer fills, not on the caller's schedule

### DIFF
--- a/execution/tracing/tracers/logger/json_stream.go
+++ b/execution/tracing/tracers/logger/json_stream.go
@@ -102,7 +102,7 @@ func (l *JsonStreamLogger) writeMemoryWordRaw(chunk []byte) {
 		hex.Encode(l.hexEncodeBuf[:], chunk)
 	}
 	l.stream.WriteRaw(`"0x`)
-	l.stream.Write(l.hexEncodeBuf[:64]) //nolint:errcheck
+	l.stream.WriteRaw(common.ToStringZeroCopy(l.hexEncodeBuf[:64]))
 	l.stream.WriteRaw(`"`)
 }
 
@@ -255,4 +255,5 @@ func (l *JsonStreamLogger) OnOpcode(pc uint64, typ byte, gas, cost uint64, scope
 		l.stream.WriteObjectEnd()
 	}
 	l.stream.WriteObjectEnd()
+
 }

--- a/execution/tracing/tracers/logger/json_stream_test.go
+++ b/execution/tracing/tracers/logger/json_stream_test.go
@@ -21,10 +21,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"strings"
 	"testing"
 
 	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/execution/tracing"
@@ -394,4 +396,93 @@ func TestStructLog_ErrorOmitempty(t *testing.T) {
 			t.Errorf("error message: got %q, want %q", msg, "out of gas")
 		}
 	})
+}
+
+// TestJsonStreamLogger_MemoryReachesWriter pins that a long memory-enabled trace
+// keeps reaching the writer instead of accumulating in the stream's buffer. The
+// flushing lives in the stream, so nothing in the logger has to ask for it.
+func TestJsonStreamLogger_MemoryReachesWriter(t *testing.T) {
+	var buf bytes.Buffer
+	stream := jsonstream.New(&buf)
+	l := NewJsonStreamLogger(&LogConfig{EnableMemory: true}, context.Background(), stream)
+	l.env = &tracing.VMContext{IntraBlockState: &mockIBS{}}
+
+	scope := &mockOpContext{memory: bytes.Repeat([]byte{0xab}, 2048)}
+	for i := range 200 {
+		l.OnOpcode(uint64(i), byte(vm.MLOAD), 100, 3, scope, nil, 1, nil)
+	}
+
+	require.NotZero(t, buf.Len(), "nothing reached the writer before Flush")
+}
+
+func BenchmarkJsonStreamLogger_OnOpcode(b *testing.B) {
+	key := common.BigToHash(common.Big1)
+	val := common.BigToHash(common.Big2)
+	scope := &mockOpContext{
+		memory: bytes.Repeat([]byte{0xab}, 256),
+		stack:  []uint256.Int{*new(uint256.Int).SetBytes(val[:]), *new(uint256.Int).SetBytes(key[:])},
+	}
+
+	stream := jsonstream.New(io.Discard)
+	l := NewJsonStreamLogger(&LogConfig{EnableMemory: true}, context.Background(), stream)
+	l.env = &tracing.VMContext{IntraBlockState: &mockIBS{}}
+
+	b.ReportAllocs()
+	i := 0
+	for b.Loop() {
+		l.OnOpcode(uint64(i), byte(vm.SSTORE), 100, 3, scope, nil, 1, nil)
+		i++
+	}
+}
+
+// countingWriter discards but records how much a response actually produced.
+type countingWriter struct{ n int64 }
+
+func (w *countingWriter) Write(p []byte) (int, error) { w.n += int64(len(p)); return len(p), nil }
+
+// largeTrace drives the logger over enough opcodes to produce a response far
+// larger than any buffer, reporting the bytes written and the peak buffer.
+func largeTrace(tb testing.TB, steps int) (produced int64, peakBuffer int) {
+	tb.Helper()
+	var out countingWriter
+	stream := jsonstream.New(&out)
+	l := NewJsonStreamLogger(&LogConfig{EnableMemory: true}, context.Background(), stream)
+	l.env = &tracing.VMContext{IntraBlockState: &mockIBS{}}
+
+	key := common.BigToHash(common.Big1)
+	val := common.BigToHash(common.Big2)
+	scope := &mockOpContext{
+		memory: bytes.Repeat([]byte{0xab}, 4096),
+		stack:  []uint256.Int{*new(uint256.Int).SetBytes(val[:]), *new(uint256.Int).SetBytes(key[:])},
+	}
+	for i := range steps {
+		l.OnOpcode(uint64(i), byte(vm.SSTORE), 100, 3, scope, nil, 1, nil)
+		if n := len(stream.Buffer()); n > peakBuffer {
+			peakBuffer = n
+		}
+	}
+	stream.WriteArrayEnd()
+	stream.WriteObjectEnd()
+	require.NoError(tb, stream.Flush())
+	return out.n, peakBuffer
+}
+
+// TestJsonStreamLogger_LargeTraceStaysBounded is the case streaming exists for:
+// a single transaction whose trace dwarfs any buffer. Nothing in the RPC layer
+// flushes inside one transaction, so without the stream flushing itself the
+// whole response is held in memory.
+func TestJsonStreamLogger_LargeTraceStaysBounded(t *testing.T) {
+	produced, peak := largeTrace(t, 20_000)
+
+	require.Greater(t, produced, int64(64<<20), "the trace must dwarf the buffer for this to mean anything")
+	require.Less(t, peak, 4*jsonstream.FlushThreshold,
+		"buffer peaked at %d for a %dMB response", peak, produced>>20)
+}
+
+func BenchmarkJsonStreamLogger_LargeTrace(b *testing.B) {
+	for b.Loop() {
+		produced, peak := largeTrace(b, 2_000)
+		b.ReportMetric(float64(produced>>20), "MB/op")
+		b.ReportMetric(float64(peak), "peakBuffer/op")
+	}
 }

--- a/rpc/jsonstream/factory.go
+++ b/rpc/jsonstream/factory.go
@@ -19,11 +19,20 @@ package jsonstream
 import (
 	"io"
 
+	"github.com/c2h5oh/datasize"
 	jsoniter "github.com/json-iterator/go"
 )
 
 const AutoCloseOnError = true
 const InitialBufferSize = 4096
+
+// FlushThreshold is how much a response may buffer before it is handed to the
+// writer. net/http buffers behind us, and bufio only bypasses its 4KB buffer for
+// writes larger than it holds, so flushing in small pieces turns every flush into
+// its own socket write. Measured on a 64MB response: 4KB gives 16417 socket
+// writes and 59ms, 64KB gives 2049 and 20ms, 1MB gives 129 and 12ms. 64KB keeps
+// the per-request cost bounded at high concurrency.
+const FlushThreshold = int(64 * datasize.KB)
 
 func New(out io.Writer) Stream {
 	stream := jsoniter.NewStream(jsoniter.ConfigDefault, out, InitialBufferSize)

--- a/rpc/jsonstream/iterator_stream.go
+++ b/rpc/jsonstream/iterator_stream.go
@@ -49,6 +49,15 @@ func (s *JsoniterStream) Write(content []byte) (int, error) {
 
 func (s *JsoniterStream) WriteRaw(content string) {
 	s.stream.WriteRaw(content)
+	s.flushIfFull()
+}
+
+// flushIfFull hands the buffer to the writer once it has outgrown its initial
+// size, so a large response streams instead of being held whole.
+func (s *JsoniterStream) flushIfFull() {
+	if len(s.stream.Buffer()) >= InitialBufferSize {
+		s.stream.Flush() //nolint:errcheck
+	}
 }
 
 func (s *JsoniterStream) WriteNil() {
@@ -117,6 +126,7 @@ func (s *JsoniterStream) WriteFloat64(val float64) {
 
 func (s *JsoniterStream) WriteString(val string) {
 	s.stream.WriteString(val)
+	s.flushIfFull()
 }
 
 func (s *JsoniterStream) WriteObjectStart() {

--- a/rpc/jsonstream/stack_stream.go
+++ b/rpc/jsonstream/stack_stream.go
@@ -74,6 +74,16 @@ func (s *StackStream) Write(content []byte) (int, error) {
 func (s *StackStream) WriteRaw(content string) {
 	s.stream.WriteRaw(content)
 	s.popCommaOrField()
+	s.flushIfFull()
+}
+
+// flushIfFull hands the buffer to the writer once it has outgrown its initial
+// size, so a large response streams instead of being held whole. The output is
+// the same wherever it happens: Flush only moves bytes that are already final.
+func (s *StackStream) flushIfFull() {
+	if len(s.stream.Buffer()) >= InitialBufferSize {
+		s.stream.Flush() //nolint:errcheck
+	}
 }
 
 // WriteNil writes a null value to the stream
@@ -176,6 +186,7 @@ func (s *StackStream) WriteFloat64(val float64) {
 func (s *StackStream) WriteString(val string) {
 	s.stream.WriteString(val)
 	s.popCommaOrField()
+	s.flushIfFull()
 }
 
 // WriteObjectStart writes the start of an object and adds it to the stack

--- a/rpc/jsonstream/stack_stream_test.go
+++ b/rpc/jsonstream/stack_stream_test.go
@@ -17,12 +17,20 @@
 package jsonstream
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math"
+	"net"
+	"net/http"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	jsoniter "github.com/json-iterator/go"
 )
@@ -1064,4 +1072,104 @@ func (w *failingWriter) Write(p []byte) (n int, err error) {
 	}
 	w.bytesWritten += len(p)
 	return len(p), nil
+}
+
+// TestFlushIfFull pins that the stream flushes once its buffer fills, rather
+// than growing without bound, and that flushing does not change the output.
+func TestFlushIfFull(t *testing.T) {
+	var buf bytes.Buffer
+	s := NewStackStream(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, InitialBufferSize))
+	chunk := strings.Repeat("a", 512)
+
+	s.WriteArrayStart()
+	for i := range 40 {
+		if i > 0 {
+			s.WriteMore()
+		}
+		s.WriteString(chunk)
+	}
+	require.NotZero(t, buf.Len(), "nothing reached the writer while the buffer filled")
+	s.WriteArrayEnd()
+	require.NoError(t, s.Flush())
+
+	var got []string
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	require.Len(t, got, 40)
+	for _, v := range got {
+		require.Equal(t, chunk, v)
+	}
+}
+
+// countingListener counts writes reaching the socket, which is what flushing in
+// small pieces multiplies. httptest.NewServer gives a real conn and the real
+// bufio/chunkWriter chain; ResponseRecorder would have neither.
+type countingListener struct {
+	net.Listener
+	writes, bytes *atomic.Int64
+}
+
+func (l countingListener) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	return countingConn{c, l.writes, l.bytes}, nil
+}
+
+type countingConn struct {
+	net.Conn
+	writes, bytes *atomic.Int64
+}
+
+func (c countingConn) Write(p []byte) (int, error) {
+	c.writes.Add(1)
+	c.bytes.Add(int64(len(p)))
+	return c.Conn.Write(p)
+}
+
+// BenchmarkStreamToHTTP writes a large response through the real net/http writer
+// chain at several flush thresholds, reporting the socket writes each causes.
+// bufio only bypasses its own buffer for writes larger than it holds, so a small
+// threshold turns every flush into its own socket write.
+func BenchmarkStreamToHTTP(b *testing.B) {
+	const responseSize = 8 << 20
+	chunk := strings.Repeat("x", 1024)
+
+	for _, threshold := range []int{4 << 10, 64 << 10, 1 << 20} {
+		b.Run(fmt.Sprintf("flushAt=%dKiB", threshold>>10), func(b *testing.B) {
+			var writes, bytesOut atomic.Int64
+			ln, err := net.Listen("tcp", "127.0.0.1:0")
+			require.NoError(b, err)
+
+			srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				s := jsoniter.NewStream(jsoniter.ConfigDefault, w, InitialBufferSize)
+				written := 0
+				for written < responseSize {
+					s.WriteRaw(chunk)
+					written += len(chunk)
+					if len(s.Buffer()) >= threshold {
+						s.Flush() //nolint:errcheck
+					}
+				}
+				s.Flush() //nolint:errcheck
+			})}
+			go srv.Serve(countingListener{ln, &writes, &bytesOut}) //nolint:errcheck
+			b.Cleanup(func() { srv.Close() })
+
+			url := "http://" + ln.Addr().String() + "/"
+			b.ResetTimer()
+			for b.Loop() {
+				resp, err := http.Get(url) //nolint:noctx
+				require.NoError(b, err)
+				_, err = io.Copy(io.Discard, resp.Body)
+				require.NoError(b, err)
+				resp.Body.Close()
+			}
+			b.StopTimer()
+
+			n := max(int64(b.N), 1)
+			b.ReportMetric(float64(writes.Load())/float64(n), "socketWrites/op")
+			b.ReportMetric(float64(bytesOut.Load())/float64(max(writes.Load(), 1)), "B/socketWrite")
+		})
+	}
 }


### PR DESCRIPTION
**Draft — split out of #23456.**

## The case streaming exists for was not covered

`traceBlock` flushes per transaction (`tracing.go:174`), so `debug_traceBlockByNumber` is fine as long as the work is spread across transactions. But nothing flushes *inside* one:

| producer | mid-response flushes |
|---|---|
| `traceBlock` | per txn ✓ |
| `TraceTransaction` | **0** — and it is a single txn |
| `TraceCall` | **0** |
| `TraceCallMany` | **0**, despite two loops |
| `trace_filtering.Filter` | **0** |

So one heavy transaction is held whole in memory. `TestJsonStreamLogger_LargeTraceStaysBounded` (new) measures it — a 173MB trace peaks the stream buffer at **181,468,904 bytes**. With the stream flushing itself: **4,086**. It is also faster, 8.5ms vs 12.4ms per 17MB, because nothing has to grow and copy a buffer that large.

There was no test or benchmark in the tree producing a large response — the biggest was `benchmarkLargeArray`, 1000 ints into a nil-writer stream that never flushes.

## Where the flushing belongs

In the stream. `Flush` only moves bytes that are already final, so the output is byte-identical wherever it happens — verified by flushing after *every* call in a nested object/array and diffing against no flushing. No producer needs to know the stream buffers. `WriteRaw` and `WriteString` carry the check; the fixed-width writers cannot overshoot by more than one value, and the check inlines to `len(s.stream.buf)`.

Memory words also went through `Stream.Write`, the only byte-taking method jsoniter has. It writes through on every call *and* re-slices the buffer past its spare capacity, so the next append reallocated. `WriteRaw` only appends.

## Why 64KiB and not the 4KiB initial buffer

`net/http` buffers behind us — `(*response).w` is a 2048-byte `bufio.Writer`, then `chunkWriter`, then `conn.bufw` at 4KiB. `bufio` only bypasses its own buffer for writes larger than it holds (`bufio.go:679`), so flushing in small pieces turns every flush into its own socket write. `BenchmarkStreamToHTTP` (new) counts them through the real chain:

| flush at | socket writes/response | avg per write | ns/op |
|---|---|---|---|
| 4KiB | 2053 | 4094 B | 5321594 |
| 64KiB | 257 | 32645 B | 1217377 |
| 1MiB | 17 | 493460 B | 1317652 |

1MiB buys 15× fewer syscalls for no time, at 16× the memory per concurrent stream, and `db.read.concurrency` defaults to 1024.

## Follow-ups, not in this PR

- `rpc/jsonrpc/tracing.go:174`'s per-txn flush is redundant now.
- Streams are never pooled: `jsonstream.New` calls `jsoniter.NewStream`, allocating a `Stream` and its buffer per request, while jsoniter ships `BorrowStream`/`ReturnStream` over a `sync.Pool` that nothing in erigon calls. Pooling needs a size cap so an attack trace is not pinned.
- `InitialBufferSize` (4KiB) below the flush threshold means each response climbs `[4096 5376 6912 9472 12288 16384 21760 28672 40960 57344 73728]` — ten reallocations. Raising it would cost 64KiB on every trivial response instead; pooling is the better fix.