### PR TITLE
ci: cache spamoor and rpc-snooper

### DIFF
--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -6,12 +6,12 @@ env:
   # Pinned versions of third-party containers — bump here when upgrading.
   # These are cached via actions/cache (docker save/load) to avoid re-pulling
   # on every run and to eliminate Docker Hub rate-limit exposure.
-  # The immutable tags a suite .io pins — released CL/VC clients, assertoor and
-  # glamsterdam's genesis generator — are loaded at job start from those files
+  # The tags a suite .io pins — released CL/VC clients, assertoor, glamsterdam's
+  # genesis generator and spamoor — are loaded at job start from those files
   # (single source of truth) by the "Load image versions" step, so the cache can't
-  # drift from what kurtosis runs. Mutable tags (glamsterdam's devnet lighthouse,
-  # spamoor, snooper) stay live so a run never serves a stale client. The tags
-  # below aren't pinned in any .io, so they stay here.
+  # drift from what kurtosis runs. glamsterdam's devnet lighthouse stays live: it
+  # is a client under test, so serving a stale build would quietly change what the
+  # suite covers. The tags below aren't pinned in any .io, so they stay here.
   # Kurtosis CLI pinned so its infra images (engine/core/files-artifacts-expander
   # are tagged with the CLI version) can be cached too. The vector and fluent-bit
   # tags are dictated by the Kurtosis release — sync them when bumping (see
@@ -37,6 +37,10 @@ env:
   # it publishes only :latest, so the cache serves the `latest` digest from the last
   # warm rather than tracking live `latest`.
   ETH2_VAL_TOOLS_IMAGE: "protolambda/eth2-val-tools:latest"
+  # rpc-snooper is the EL/CL traffic proxy the snooper_enabled suites launch. The
+  # ethereum-package pins no tag for it, so the cache serves the `latest` digest
+  # from the last warm rather than tracking live `latest`.
+  KURTOSIS_SNOOPER_IMAGE: "ethpandaops/rpc-snooper:latest"
   GENESIS_GENERATOR_IMAGE: "ethpandaops/ethereum-genesis-generator:4.0.4"
   CAPLIN_GENESIS_GENERATOR_IMAGE: "ethpandaops/ethereum-genesis-generator:3.3.7"
   KURTOSIS_PYTHON_IMAGE: "python:3.11-alpine"
@@ -220,6 +224,7 @@ jobs:
           lighthouse=$(yq -e '.participants_matrix.cl[] | select(.cl_type == "lighthouse") | .cl_image' "$reg")
           teku=$(yq -e '.participants_matrix.cl[] | select(.cl_type == "teku") | .cl_image' "$reg")
           genesis_glamsterdam=$(yq -e '.ethereum_genesis_generator_params.image' "$glamsterdam_io")
+          spamoor_glamsterdam=$(yq -e '.spamoor_params.image' "$glamsterdam_io")
           lighthouse_vc=$(yq -e '.participants[] | select(.vc_type == "lighthouse") | .vc_image' "$caplin_io")
           # pectra's clients and caplin-minimal's assertoor are warmed under the tag
           # another suite pins. Bumping one alone leaves it out of the cache, which
@@ -245,6 +250,7 @@ jobs:
             echo "LIGHTHOUSE_IMAGE=$lighthouse"
             echo "TEKU_IMAGE=$teku"
             echo "GLAMSTERDAM_GENESIS_GENERATOR_IMAGE=$genesis_glamsterdam"
+            echo "GLAMSTERDAM_SPAMOOR_IMAGE=$spamoor_glamsterdam"
             echo "LIGHTHOUSE_VC_IMAGE=$lighthouse_vc"
           } >> "$GITHUB_ENV"
           # Every cached tag stays spelled out in the cache key so a glance at the
@@ -254,8 +260,9 @@ jobs:
           for image in "$lighthouse" "$lighthouse_vc" "$teku" "$assertoor" \
             "kurtosis:$KURTOSIS_VERSION" "$KURTOSIS_VECTOR_IMAGE" "$KURTOSIS_FLUENTBIT_IMAGE" \
             "$KURTOSIS_CURL_JQ_IMAGE" "$KURTOSIS_TRAEFIK_IMAGE" "$KURTOSIS_ALPINE_IMAGE" \
-            "$ETH2_VAL_TOOLS_IMAGE" "$pectra" "$glamsterdam" "$GENESIS_GENERATOR_IMAGE" \
-            "$CAPLIN_GENESIS_GENERATOR_IMAGE" "$genesis_glamsterdam" "$KURTOSIS_PYTHON_IMAGE"; do
+            "$ETH2_VAL_TOOLS_IMAGE" "$KURTOSIS_SNOOPER_IMAGE" "$pectra" "$glamsterdam" \
+            "$GENESIS_GENERATOR_IMAGE" "$CAPLIN_GENESIS_GENERATOR_IMAGE" \
+            "$genesis_glamsterdam" "$spamoor_glamsterdam" "$KURTOSIS_PYTHON_IMAGE"; do
             key="$key-${image##*/}"
           done
           [ ${#key} -le 512 ] \
@@ -300,6 +307,8 @@ jobs:
           pull "${GENESIS_GENERATOR_IMAGE}"
           pull "${CAPLIN_GENESIS_GENERATOR_IMAGE}"
           pull "${GLAMSTERDAM_GENESIS_GENERATOR_IMAGE}"
+          pull "${GLAMSTERDAM_SPAMOOR_IMAGE}"
+          pull "${KURTOSIS_SNOOPER_IMAGE}"
           pull "${KURTOSIS_PYTHON_IMAGE}"
           docker save "${LIGHTHOUSE_IMAGE}" -o /tmp/docker-cache/lighthouse.tar
           docker save "${LIGHTHOUSE_VC_IMAGE}" -o /tmp/docker-cache/lighthouse-vc.tar
@@ -319,6 +328,8 @@ jobs:
           docker save "${GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/genesis-generator.tar
           docker save "${CAPLIN_GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/caplin-genesis-generator.tar
           docker save "${GLAMSTERDAM_GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/glamsterdam-genesis-generator.tar
+          docker save "${GLAMSTERDAM_SPAMOOR_IMAGE}" -o /tmp/docker-cache/spamoor.tar
+          docker save "${KURTOSIS_SNOOPER_IMAGE}" -o /tmp/docker-cache/rpc-snooper.tar
           docker save "${KURTOSIS_PYTHON_IMAGE}" -o /tmp/docker-cache/python.tar
 
       - name: Save third-party containers to cache
@@ -469,6 +480,7 @@ jobs:
           lighthouse=$(yq -e '.participants_matrix.cl[] | select(.cl_type == "lighthouse") | .cl_image' "$reg")
           teku=$(yq -e '.participants_matrix.cl[] | select(.cl_type == "teku") | .cl_image' "$reg")
           genesis_glamsterdam=$(yq -e '.ethereum_genesis_generator_params.image' "$glamsterdam_io")
+          spamoor_glamsterdam=$(yq -e '.spamoor_params.image' "$glamsterdam_io")
           lighthouse_vc=$(yq -e '.participants[] | select(.vc_type == "lighthouse") | .vc_image' "$caplin_io")
           # pectra's clients and caplin-minimal's assertoor are warmed under the tag
           # another suite pins. Bumping one alone leaves it out of the cache, which
@@ -494,6 +506,7 @@ jobs:
             echo "LIGHTHOUSE_IMAGE=$lighthouse"
             echo "TEKU_IMAGE=$teku"
             echo "GLAMSTERDAM_GENESIS_GENERATOR_IMAGE=$genesis_glamsterdam"
+            echo "GLAMSTERDAM_SPAMOOR_IMAGE=$spamoor_glamsterdam"
             echo "LIGHTHOUSE_VC_IMAGE=$lighthouse_vc"
           } >> "$GITHUB_ENV"
           # Every cached tag stays spelled out in the cache key so a glance at the
@@ -503,8 +516,9 @@ jobs:
           for image in "$lighthouse" "$lighthouse_vc" "$teku" "$assertoor" \
             "kurtosis:$KURTOSIS_VERSION" "$KURTOSIS_VECTOR_IMAGE" "$KURTOSIS_FLUENTBIT_IMAGE" \
             "$KURTOSIS_CURL_JQ_IMAGE" "$KURTOSIS_TRAEFIK_IMAGE" "$KURTOSIS_ALPINE_IMAGE" \
-            "$ETH2_VAL_TOOLS_IMAGE" "$pectra" "$glamsterdam" "$GENESIS_GENERATOR_IMAGE" \
-            "$CAPLIN_GENESIS_GENERATOR_IMAGE" "$genesis_glamsterdam" "$KURTOSIS_PYTHON_IMAGE"; do
+            "$ETH2_VAL_TOOLS_IMAGE" "$KURTOSIS_SNOOPER_IMAGE" "$pectra" "$glamsterdam" \
+            "$GENESIS_GENERATOR_IMAGE" "$CAPLIN_GENESIS_GENERATOR_IMAGE" \
+            "$genesis_glamsterdam" "$spamoor_glamsterdam" "$KURTOSIS_PYTHON_IMAGE"; do
             key="$key-${image##*/}"
           done
           [ ${#key} -le 512 ] \
@@ -539,6 +553,8 @@ jobs:
           docker load -i /tmp/docker-cache/genesis-generator.tar
           docker load -i /tmp/docker-cache/caplin-genesis-generator.tar
           docker load -i /tmp/docker-cache/glamsterdam-genesis-generator.tar
+          docker load -i /tmp/docker-cache/spamoor.tar
+          docker load -i /tmp/docker-cache/rpc-snooper.tar
           docker load -i /tmp/docker-cache/python.tar
 
       - name: Pull third-party containers and save to cache
@@ -571,6 +587,8 @@ jobs:
           pull "${GENESIS_GENERATOR_IMAGE}"
           pull "${CAPLIN_GENESIS_GENERATOR_IMAGE}"
           pull "${GLAMSTERDAM_GENESIS_GENERATOR_IMAGE}"
+          pull "${GLAMSTERDAM_SPAMOOR_IMAGE}"
+          pull "${KURTOSIS_SNOOPER_IMAGE}"
           pull "${KURTOSIS_PYTHON_IMAGE}"
           docker save "${LIGHTHOUSE_IMAGE}" -o /tmp/docker-cache/lighthouse.tar
           docker save "${LIGHTHOUSE_VC_IMAGE}" -o /tmp/docker-cache/lighthouse-vc.tar
@@ -590,6 +608,8 @@ jobs:
           docker save "${GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/genesis-generator.tar
           docker save "${CAPLIN_GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/caplin-genesis-generator.tar
           docker save "${GLAMSTERDAM_GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/glamsterdam-genesis-generator.tar
+          docker save "${GLAMSTERDAM_SPAMOOR_IMAGE}" -o /tmp/docker-cache/spamoor.tar
+          docker save "${KURTOSIS_SNOOPER_IMAGE}" -o /tmp/docker-cache/rpc-snooper.tar
           docker save "${KURTOSIS_PYTHON_IMAGE}" -o /tmp/docker-cache/python.tar
 
       # An uncovered tag would otherwise be pulled inside `kurtosis run`, where a


### PR DESCRIPTION
Both images are fetched from Docker Hub on every glamsterdam job — `remotely downloaded` in the job log — so a registry outage or maintenance window fails the suite even though every other image it needs is already local. That is the exposure this caching block exists to remove, and it applies regardless of the performance win.

`spamoor:master` is pinned in `glamsterdam.io`, so it is read from there like the genesis generator. `rpc-snooper:latest` is an ethereum-package default that no `.io` pins, so it is pinned in the env block like `eth2-val-tools:latest`. Both are mutable tags, so the cache serves the digest from the last warm rather than tracking the live tag — the same trade-off already documented for `curl-jq:latest` and `eth2-val-tools:latest`. The key stays readable at 379 of 512 chars:

```
docker-cl-lighthouse:v8.1.3-…-eth2-val-tools:latest-rpc-snooper:latest-…-ethereum-genesis-generator:6.1.4-spamoor:master-python:3.11-alpine
```

glamsterdam's `lighthouse:glamsterdam-devnet-7` deliberately stays live. It is a consensus client under test, so serving a stale build would quietly change what the suite covers, which is the rationale `test-kurtosis-gloas.yml` already records for devnet client images.

One consequence worth knowing: the cache-warming job uses `lookup-only`, so an existing entry is never refreshed — a mutable tag's digest is frozen until some other key component changes. That is today's behaviour for the two `:latest` images already cached; if periodic refresh is wanted, the warm job would need to delete the entry instead.