### PR TITLE
cmd/utils/app: export preimages in EIP-8347 keccak256 hashed-key order

### DIFF
--- a/cmd/utils/app/export_preimages_cmd.go
+++ b/cmd/utils/app/export_preimages_cmd.go
@@ -257,7 +257,7 @@ func openExportDirs(dataDir string) (datadir.Dirs, error) {
 // mainnet that is >100 GB, and the retry would then hit ENOSPC partway through.
 func prepareScratchDir(tmpDir string) (string, error) {
 	scratch := filepath.Join(tmpDir, preimagesScratchDirName)
-	if err := os.RemoveAll(scratch); err != nil {
+	if err := dir.RemoveAll(scratch); err != nil {
 		return "", fmt.Errorf("clear scratch %s: %w", scratch, err)
 	}
 	if err := os.MkdirAll(scratch, 0o755); err != nil {

--- a/cmd/utils/app/export_preimages_cmd.go
+++ b/cmd/utils/app/export_preimages_cmd.go
@@ -43,6 +43,7 @@ import (
 	"github.com/erigontech/erigon/db/kv/dbcfg"
 	"github.com/erigontech/erigon/db/kv/stream"
 	"github.com/erigontech/erigon/db/rawdb"
+	"github.com/erigontech/erigon/db/state"
 	"github.com/erigontech/erigon/execution/commitment"
 	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
 	"github.com/erigontech/erigon/execution/types"
@@ -133,19 +134,53 @@ func doExportPreimages(ctx context.Context, cliCtx *cli.Command) error {
 		return err
 	}
 	defer outputFile.Close()
-	bufferedWriter := bufio.NewWriterSize(outputFile, 4<<20)
-	countedWriter := &countingWriter{writer: bufferedWriter}
+
+	start := time.Now()
+	stats, err := writePreimagesFile(ctx, outputFile, tmpDir, aggTx, tx, logger)
+	if err != nil {
+		return fmt.Errorf("export aborted (partial file %s): %w", framedPath, err)
+	}
+
+	metadata := preimagesMeta{
+		Block: blockNum, StateRoot: commitmentRoot.Hex(),
+		Accounts: stats.Accounts, Storage: stats.Slots,
+	}
+	metadataJSON, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(metaPath, append(metadataJSON, '\n'), 0o644); err != nil {
+		return err
+	}
+	logger.Info("[export-preimages] done", "accounts", stats.Accounts, "slots", stats.Slots, "file", framedPath, "bytes", stats.sizeBytes(), "took", time.Since(start).Round(time.Second))
+	return nil
+}
+
+// writePreimagesFile hashes both domain scans through an ETL sort and writes the
+// framed file. Every error it returns leaves outputFile partially written.
+func writePreimagesFile(
+	ctx context.Context,
+	outputFile *os.File,
+	tmpDir string,
+	aggTx *state.AggregatorRoTx,
+	tx kv.Tx,
+	logger log.Logger,
+) (exportPreimagesStats, error) {
+	var stats exportPreimagesStats
 
 	accounts, err := aggTx.DebugRangeLatest(tx, kv.AccountsDomain, nil, nil, kv.Unlim)
 	if err != nil {
-		return err
+		return stats, err
 	}
 	defer accounts.Close()
 	storage, err := aggTx.DebugRangeLatest(tx, kv.StorageDomain, nil, nil, kv.Unlim)
 	if err != nil {
-		return err
+		return stats, err
 	}
 	defer storage.Close()
+
+	bufferedWriter := bufio.NewWriterSize(outputFile, 4<<20)
+	countedWriter := &countingWriter{writer: bufferedWriter}
 
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
@@ -164,47 +199,31 @@ func doExportPreimages(ctx context.Context, cliCtx *cli.Command) error {
 		}
 	}
 
-	collector := etl.NewCollector("export-preimages", tmpDir, etl.NewSortableBuffer(etl.BufferOptimalSize), logger).
-		SortAndFlushInBackground(true)
+	collector := etl.NewCollector("export-preimages", tmpDir, etl.NewSortableBuffer(etl.BufferOptimalSize), logger)
 	defer collector.Close()
 
-	start := time.Now()
 	collected, err := collectHashedPreimages(ctx, accounts, storage, collector, reportHashing)
 	if err != nil {
-		return err
+		return collected, err
 	}
-	stats, err := writeHashedPreimages(collector, countedWriter, ctx.Done(), reportWriting)
+	stats, err = writeHashedPreimages(collector, countedWriter, ctx.Done(), reportWriting)
 	if err != nil {
-		return fmt.Errorf("export aborted (partial file %s): %w", framedPath, err)
+		return stats, err
 	}
 	if stats != collected {
-		return fmt.Errorf("sort lost keys: collected %d accounts / %d slots, wrote %d / %d",
+		return stats, fmt.Errorf("sort lost keys: collected %d accounts / %d slots, wrote %d / %d",
 			collected.Accounts, collected.Slots, stats.Accounts, stats.Slots)
 	}
 	if err := bufferedWriter.Flush(); err != nil {
-		return err
+		return stats, err
 	}
 	if err := outputFile.Sync(); err != nil {
-		return err
+		return stats, err
 	}
-	sizeBytes := stats.sizeBytes()
-	if countedWriter.written != sizeBytes {
-		return fmt.Errorf("size mismatch: wrote %d bytes, formula says %d", countedWriter.written, sizeBytes)
+	if sizeBytes := stats.sizeBytes(); countedWriter.written != sizeBytes {
+		return stats, fmt.Errorf("size mismatch: wrote %d bytes, formula says %d", countedWriter.written, sizeBytes)
 	}
-
-	metadata := preimagesMeta{
-		Block: blockNum, StateRoot: commitmentRoot.Hex(),
-		Accounts: stats.Accounts, Storage: stats.Slots,
-	}
-	metadataJSON, err := json.MarshalIndent(metadata, "", "  ")
-	if err != nil {
-		return err
-	}
-	if err := os.WriteFile(metaPath, append(metadataJSON, '\n'), 0o644); err != nil {
-		return err
-	}
-	logger.Info("[export-preimages] done", "accounts", stats.Accounts, "slots", stats.Slots, "file", framedPath, "bytes", sizeBytes, "took", time.Since(start).Round(time.Second))
-	return nil
+	return stats, nil
 }
 
 func openExportDirs(dataDir string) (datadir.Dirs, error) {
@@ -337,8 +356,9 @@ func collectHashedPreimages(
 	return stats, nil
 }
 
-// writeHashedPreimages drains the collector into fixed-width records:
-// address[20] | slotCount[4, big-endian] | slotKey[32] * slotCount.
+// writeHashedPreimages drains the collector into records of
+// address[20] | slotCount[4, big-endian] | slotKey[32] * slotCount, so a record
+// is 24+32*slotCount bytes and only its fields are fixed width.
 func writeHashedPreimages(
 	collector *etl.Collector,
 	writer io.Writer,
@@ -401,5 +421,7 @@ func writeHashedPreimages(
 	if err := collector.Load(nil, "", loadFunc, etl.TransformArgs{Quit: quit}); err != nil {
 		return stats, err
 	}
-	return stats, flushRecord()
+	// flushRecord mutates stats, so it cannot share a return statement with it.
+	err := flushRecord()
+	return stats, err
 }

--- a/cmd/utils/app/export_preimages_cmd.go
+++ b/cmd/utils/app/export_preimages_cmd.go
@@ -33,9 +33,12 @@ import (
 
 	"github.com/erigontech/erigon/cmd/utils"
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/common/dir"
+	"github.com/erigontech/erigon/common/length"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/etl"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/dbcfg"
 	"github.com/erigontech/erigon/db/kv/stream"
@@ -57,12 +60,13 @@ const (
 var exportPreimagesCommand = cli.Command{
 	Name:        "export-preimages",
 	Usage:       "Export plain-key state preimages (account addresses + storage slot keys) to a framed binary file",
-	Description: "Writes framed.bin plus a preimages.meta.json sidecar with the block/stateRoot pin to --out. The state root is verified against the canonical header; a mismatch aborts the export.",
+	Description: "Writes framed.bin plus a preimages.meta.json sidecar with the block/stateRoot pin to --out. Records are ordered by keccak256 of the plain key, per EIP-8347. The state root is verified against the canonical header; a mismatch aborts the export.",
 	Hidden:      true,
 	Action:      doExportPreimages,
 	Flags: joinFlags([]cli.Flag{
 		&utils.DataDirFlag,
 		&cli.StringFlag{Name: "out", Value: ".", Usage: "output directory for the framed file and preimages.meta.json"},
+		&cli.StringFlag{Name: "tmpdir", Usage: "scratch directory for the external sort, sized for the whole key set (default: <datadir>/temp)"},
 	}),
 }
 
@@ -80,6 +84,13 @@ func doExportPreimages(ctx context.Context, cliCtx *cli.Command) error {
 		return err
 	}
 	outDir := cliCtx.String("out")
+	tmpDir := cliCtx.String("tmpdir")
+	if tmpDir == "" {
+		tmpDir = dirs.Tmp
+	}
+	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
+		return err
+	}
 
 	chainDB := dbCfg(dbcfg.ChainDB, dirs.Chaindata).MustOpen()
 	defer chainDB.Close()
@@ -138,18 +149,37 @@ func doExportPreimages(ctx context.Context, cliCtx *cli.Command) error {
 
 	logEvery := time.NewTicker(30 * time.Second)
 	defer logEvery.Stop()
-	reportProgress := func(stats exportPreimagesStats) {
+	reportHashing := func(stats exportPreimagesStats) {
 		select {
 		case <-logEvery.C:
-			logger.Info("[export-preimages] progress", "accounts", stats.Accounts, "slots", stats.Slots, "bytes", countedWriter.written)
+			logger.Info("[export-preimages] hashing", "accounts", stats.Accounts, "slots", stats.Slots)
+		default:
+		}
+	}
+	reportWriting := func(stats exportPreimagesStats) {
+		select {
+		case <-logEvery.C:
+			logger.Info("[export-preimages] writing", "accounts", stats.Accounts, "slots", stats.Slots, "bytes", countedWriter.written)
 		default:
 		}
 	}
 
+	collector := etl.NewCollector("export-preimages", tmpDir, etl.NewSortableBuffer(etl.BufferOptimalSize), logger).
+		SortAndFlushInBackground(true)
+	defer collector.Close()
+
 	start := time.Now()
-	stats, err := writeFramedPreimages(ctx, accounts, storage, countedWriter, reportProgress)
+	collected, err := collectHashedPreimages(ctx, accounts, storage, collector, reportHashing)
+	if err != nil {
+		return err
+	}
+	stats, err := writeHashedPreimages(collector, countedWriter, ctx.Done(), reportWriting)
 	if err != nil {
 		return fmt.Errorf("export aborted (partial file %s): %w", framedPath, err)
+	}
+	if stats != collected {
+		return fmt.Errorf("sort lost keys: collected %d accounts / %d slots, wrote %d / %d",
+			collected.Accounts, collected.Slots, stats.Accounts, stats.Slots)
 	}
 	if err := bufferedWriter.Flush(); err != nil {
 		return err
@@ -231,43 +261,23 @@ func (stats exportPreimagesStats) sizeBytes() uint64 {
 	return stats.Accounts*(preimageAddrLen+preimageCountLen) + stats.Slots*preimageSlotLen
 }
 
-// writeFramedPreimages writes plain-key ordered records as:
-// address[20] | slotCount[4, big-endian] | slotKey[32] * slotCount.
-func writeFramedPreimages(
+// collectHashedPreimages keys every plain key by its MPT path: keccak256(address)
+// for an account, keccak256(address)||keccak256(slotKey) for a storage slot. An
+// account's key is a strict prefix of its own slots' keys and of nothing else, so
+// the merge-sorted load emits each account immediately ahead of its slots, both
+// in the EIP-8347 order.
+func collectHashedPreimages(
 	ctx context.Context,
 	accounts, storage stream.KV,
-	writer io.Writer,
+	collector *etl.Collector,
 	onProgress func(exportPreimagesStats),
 ) (exportPreimagesStats, error) {
 	var stats exportPreimagesStats
-	slotKeys := make([]byte, 0, 1<<20)
 
 	// A non-blocking Done check is lock-free on the hot path, unlike ctx.Err,
 	// which takes a mutex on every call.
 	done := ctx.Done()
 
-	var storageKey []byte
-	hasStorage := false
-	advanceStorage := func() error {
-		select {
-		case <-done:
-			return ctx.Err()
-		default:
-		}
-		hasStorage = storage.HasNext()
-		if !hasStorage {
-			return nil
-		}
-		var err error
-		storageKey, _, err = storage.Next()
-		return err
-	}
-	if err := advanceStorage(); err != nil {
-		return stats, err
-	}
-
-	var recordHeader [preimageAddrLen + preimageCountLen]byte
-	address := recordHeader[:preimageAddrLen]
 	for accounts.HasNext() {
 		select {
 		case <-done:
@@ -281,48 +291,115 @@ func writeFramedPreimages(
 		if len(accountKey) != preimageAddrLen {
 			return stats, fmt.Errorf("account: unexpected key length %d: %x", len(accountKey), accountKey)
 		}
-		// Stream keys are only valid for two Next calls; copy to hold the
-		// address across storage iterator advances.
-		copy(address, accountKey)
-
-		slotKeys = slotKeys[:0]
-		var slotCount uint64
-		for hasStorage {
-			if len(storageKey) != preimageAddrLen+preimageSlotLen {
-				return stats, fmt.Errorf("storage: unexpected key length %d: %x", len(storageKey), storageKey)
-			}
-			addressOrder := bytes.Compare(storageKey[:preimageAddrLen], address)
-			if addressOrder > 0 {
-				break
-			}
-			if addressOrder < 0 {
-				return stats, fmt.Errorf("storage key %x has no matching account", storageKey)
-			}
-			slotKeys = append(slotKeys, storageKey[preimageAddrLen:]...)
-			slotCount++
-			if err := advanceStorage(); err != nil {
-				return stats, err
-			}
+		accountHash := crypto.Keccak256Hash(accountKey)
+		if err := collector.Collect(accountHash[:], accountKey); err != nil {
+			return stats, err
 		}
+		stats.Accounts++
+		if onProgress != nil {
+			onProgress(stats)
+		}
+	}
 
+	var hashedKey [2 * length.Hash]byte
+	var lastAddress [preimageAddrLen]byte
+	haveAddress := false
+	for storage.HasNext() {
+		select {
+		case <-done:
+			return stats, ctx.Err()
+		default:
+		}
+		storageKey, _, err := storage.Next()
+		if err != nil {
+			return stats, err
+		}
+		if len(storageKey) != preimageAddrLen+preimageSlotLen {
+			return stats, fmt.Errorf("storage: unexpected key length %d: %x", len(storageKey), storageKey)
+		}
+		address, slotKey := storageKey[:preimageAddrLen], storageKey[preimageAddrLen:]
+		if !haveAddress || !bytes.Equal(lastAddress[:], address) {
+			copy(lastAddress[:], address)
+			accountHash := crypto.Keccak256Hash(address)
+			copy(hashedKey[:length.Hash], accountHash[:])
+			haveAddress = true
+		}
+		slotHash := crypto.Keccak256Hash(slotKey)
+		copy(hashedKey[length.Hash:], slotHash[:])
+		if err := collector.Collect(hashedKey[:], slotKey); err != nil {
+			return stats, err
+		}
+		stats.Slots++
+		if onProgress != nil {
+			onProgress(stats)
+		}
+	}
+	return stats, nil
+}
+
+// writeHashedPreimages drains the collector into fixed-width records:
+// address[20] | slotCount[4, big-endian] | slotKey[32] * slotCount.
+func writeHashedPreimages(
+	collector *etl.Collector,
+	writer io.Writer,
+	quit <-chan struct{},
+	onProgress func(exportPreimagesStats),
+) (exportPreimagesStats, error) {
+	var stats exportPreimagesStats
+	var recordHeader [preimageAddrLen + preimageCountLen]byte
+	var accountHash common.Hash
+	slotKeys := make([]byte, 0, 1<<20)
+	pending := false
+
+	// slotCount precedes the slots, so a record can only be written once its last
+	// slot has arrived.
+	flushRecord := func() error {
+		if !pending {
+			return nil
+		}
+		slotCount := uint64(len(slotKeys) / preimageSlotLen)
 		if slotCount > math.MaxUint32 {
-			return stats, fmt.Errorf("account %x has %d slots (> uint32)", address, slotCount)
+			return fmt.Errorf("account %x has %d slots (> uint32)", recordHeader[:preimageAddrLen], slotCount)
 		}
 		binary.BigEndian.PutUint32(recordHeader[preimageAddrLen:], uint32(slotCount))
 		if _, err := writer.Write(recordHeader[:]); err != nil {
-			return stats, err
+			return err
 		}
 		if _, err := writer.Write(slotKeys); err != nil {
-			return stats, err
+			return err
 		}
 		stats.Accounts++
 		stats.Slots += slotCount
 		if onProgress != nil {
 			onProgress(stats)
 		}
+		return nil
 	}
-	if hasStorage {
-		return stats, fmt.Errorf("storage key %x has no matching account", storageKey)
+
+	loadFunc := func(k, v []byte, _ etl.CurrentTableReader, _ etl.LoadNextFunc) error {
+		switch len(k) {
+		case length.Hash:
+			if err := flushRecord(); err != nil {
+				return err
+			}
+			copy(recordHeader[:preimageAddrLen], v)
+			accountHash = common.BytesToHash(k)
+			slotKeys = slotKeys[:0]
+			pending = true
+			return nil
+		case 2 * length.Hash:
+			if !pending || !bytes.Equal(k[:length.Hash], accountHash[:]) {
+				return fmt.Errorf("storage slot %x under account hash %x has no matching account", v, k[:length.Hash])
+			}
+			slotKeys = append(slotKeys, v...)
+			return nil
+		default:
+			return fmt.Errorf("collector: unexpected key length %d: %x", len(k), k)
+		}
 	}
-	return stats, nil
+
+	if err := collector.Load(nil, "", loadFunc, etl.TransformArgs{Quit: quit}); err != nil {
+		return stats, err
+	}
+	return stats, flushRecord()
 }

--- a/cmd/utils/app/export_preimages_cmd.go
+++ b/cmd/utils/app/export_preimages_cmd.go
@@ -56,6 +56,15 @@ const (
 
 	preimagesFileName     = "framed.bin"
 	preimagesMetaFileName = "preimages.meta.json"
+
+	// Records are ordered by keccak256 of the plain key. A file written before that
+	// was pinned is shape-identical, so consumers must require this field rather than
+	// infer the order from the layout.
+	preimagesOrderKeccak256 = "keccak256"
+
+	// Scratch lives in a directory this command owns, so leftovers from a killed run
+	// can be cleared without touching anyone else's temp files.
+	preimagesScratchDirName = "export-preimages"
 )
 
 var exportPreimagesCommand = cli.Command{
@@ -74,6 +83,7 @@ var exportPreimagesCommand = cli.Command{
 type preimagesMeta struct {
 	Block     uint64 `json:"block"`
 	StateRoot string `json:"stateRoot"`
+	Order     string `json:"order"`
 	Accounts  uint64 `json:"accounts"`
 	Storage   uint64 `json:"storage"`
 }
@@ -89,7 +99,8 @@ func doExportPreimages(ctx context.Context, cliCtx *cli.Command) error {
 	if tmpDir == "" {
 		tmpDir = dirs.Tmp
 	}
-	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
+	tmpDir, err = prepareScratchDir(tmpDir)
+	if err != nil {
 		return err
 	}
 
@@ -142,7 +153,7 @@ func doExportPreimages(ctx context.Context, cliCtx *cli.Command) error {
 	}
 
 	metadata := preimagesMeta{
-		Block: blockNum, StateRoot: commitmentRoot.Hex(),
+		Block: blockNum, StateRoot: commitmentRoot.Hex(), Order: preimagesOrderKeccak256,
 		Accounts: stats.Accounts, Storage: stats.Slots,
 	}
 	metadataJSON, err := json.MarshalIndent(metadata, "", "  ")
@@ -206,7 +217,7 @@ func writePreimagesFile(
 	if err != nil {
 		return collected, err
 	}
-	stats, err = writeHashedPreimages(collector, countedWriter, ctx.Done(), reportWriting)
+	stats, err = writeHashedPreimages(ctx, collector, countedWriter, reportWriting)
 	if err != nil {
 		return stats, err
 	}
@@ -239,6 +250,20 @@ func openExportDirs(dataDir string) (datadir.Dirs, error) {
 		return dirs, fmt.Errorf("datadir is not a directory: %s", dirs.DataDir)
 	}
 	return dirs, nil
+}
+
+// prepareScratchDir gives the sort a directory of its own under tmpDir and empties it first.
+// Only collector.Close() unlinks the spill, so a SIGKILL or OOM mid-export strands it -- on
+// mainnet that is >100 GB, and the retry would then hit ENOSPC partway through.
+func prepareScratchDir(tmpDir string) (string, error) {
+	scratch := filepath.Join(tmpDir, preimagesScratchDirName)
+	if err := os.RemoveAll(scratch); err != nil {
+		return "", fmt.Errorf("clear scratch %s: %w", scratch, err)
+	}
+	if err := os.MkdirAll(scratch, 0o755); err != nil {
+		return "", err
+	}
+	return scratch, nil
 }
 
 func preparePreimagesOutput(outDir string) (framedPath, metaPath string, err error) {
@@ -285,6 +310,11 @@ func (stats exportPreimagesStats) sizeBytes() uint64 {
 // account's key is a strict prefix of its own slots' keys and of nothing else, so
 // the merge-sorted load emits each account immediately ahead of its slots, both
 // in the EIP-8347 order.
+//
+// Both domain scans are ascending by plain key and a storage key starts with its
+// address, so walking them together keeps the account for the storage run at hand:
+// that both reuses its hash across the run and rejects an orphaned slot here,
+// rather than after the whole key set has spilled to disk.
 func collectHashedPreimages(
 	ctx context.Context,
 	accounts, storage stream.KV,
@@ -297,32 +327,39 @@ func collectHashedPreimages(
 	// which takes a mutex on every call.
 	done := ctx.Done()
 
-	for accounts.HasNext() {
-		select {
-		case <-done:
-			return stats, ctx.Err()
-		default:
+	var accountAddr [preimageAddrLen]byte
+	var accountHash common.Hash
+	var hashedKey [2 * length.Hash]byte
+	haveAccount := false
+
+	nextAccount := func() error {
+		if !accounts.HasNext() {
+			haveAccount = false
+			return nil
 		}
 		accountKey, _, err := accounts.Next()
 		if err != nil {
-			return stats, err
+			return err
 		}
 		if len(accountKey) != preimageAddrLen {
-			return stats, fmt.Errorf("account: unexpected key length %d: %x", len(accountKey), accountKey)
+			return fmt.Errorf("account: unexpected key length %d: %x", len(accountKey), accountKey)
 		}
-		accountHash := crypto.Keccak256Hash(accountKey)
-		if err := collector.Collect(accountHash[:], accountKey); err != nil {
-			return stats, err
+		copy(accountAddr[:], accountKey)
+		accountHash = crypto.Keccak256Hash(accountAddr[:])
+		haveAccount = true
+		if err := collector.Collect(accountHash[:], accountAddr[:]); err != nil {
+			return err
 		}
 		stats.Accounts++
 		if onProgress != nil {
 			onProgress(stats)
 		}
+		return nil
 	}
 
-	var hashedKey [2 * length.Hash]byte
-	var lastAddress [preimageAddrLen]byte
-	haveAddress := false
+	if err := nextAccount(); err != nil {
+		return stats, err
+	}
 	for storage.HasNext() {
 		select {
 		case <-done:
@@ -337,20 +374,30 @@ func collectHashedPreimages(
 			return stats, fmt.Errorf("storage: unexpected key length %d: %x", len(storageKey), storageKey)
 		}
 		address, slotKey := storageKey[:preimageAddrLen], storageKey[preimageAddrLen:]
-		if !haveAddress || !bytes.Equal(lastAddress[:], address) {
-			copy(lastAddress[:], address)
-			accountHash := crypto.Keccak256Hash(address)
-			copy(hashedKey[:length.Hash], accountHash[:])
-			haveAddress = true
+		for haveAccount && bytes.Compare(accountAddr[:], address) < 0 {
+			if err := nextAccount(); err != nil {
+				return stats, err
+			}
+		}
+		if !haveAccount || !bytes.Equal(accountAddr[:], address) {
+			return stats, fmt.Errorf("storage slot %x under address %x has no matching account", slotKey, address)
 		}
 		slotHash := crypto.Keccak256Hash(slotKey)
+		copy(hashedKey[:length.Hash], accountHash[:])
 		copy(hashedKey[length.Hash:], slotHash[:])
 		if err := collector.Collect(hashedKey[:], slotKey); err != nil {
 			return stats, err
 		}
 		stats.Slots++
-		if onProgress != nil {
-			onProgress(stats)
+	}
+	for haveAccount {
+		select {
+		case <-done:
+			return stats, ctx.Err()
+		default:
+		}
+		if err := nextAccount(); err != nil {
+			return stats, err
 		}
 	}
 	return stats, nil
@@ -360,9 +407,9 @@ func collectHashedPreimages(
 // address[20] | slotCount[4, big-endian] | slotKey[32] * slotCount, so a record
 // is 24+32*slotCount bytes and only its fields are fixed width.
 func writeHashedPreimages(
+	ctx context.Context,
 	collector *etl.Collector,
 	writer io.Writer,
-	quit <-chan struct{},
 	onProgress func(exportPreimagesStats),
 ) (exportPreimagesStats, error) {
 	var stats exportPreimagesStats
@@ -390,6 +437,7 @@ func writeHashedPreimages(
 		}
 		stats.Accounts++
 		stats.Slots += slotCount
+		pending = false
 		if onProgress != nil {
 			onProgress(stats)
 		}
@@ -399,6 +447,9 @@ func writeHashedPreimages(
 	loadFunc := func(k, v []byte, _ etl.CurrentTableReader, _ etl.LoadNextFunc) error {
 		switch len(k) {
 		case length.Hash:
+			if len(v) != preimageAddrLen {
+				return fmt.Errorf("account hash %x: expected a %d-byte address, got %d bytes", k, preimageAddrLen, len(v))
+			}
 			if err := flushRecord(); err != nil {
 				return err
 			}
@@ -408,6 +459,9 @@ func writeHashedPreimages(
 			pending = true
 			return nil
 		case 2 * length.Hash:
+			if len(v) != preimageSlotLen {
+				return fmt.Errorf("slot under account hash %x: expected a %d-byte key, got %d bytes", k[:length.Hash], preimageSlotLen, len(v))
+			}
 			if !pending || !bytes.Equal(k[:length.Hash], accountHash[:]) {
 				return fmt.Errorf("storage slot %x under account hash %x has no matching account", v, k[:length.Hash])
 			}
@@ -418,7 +472,12 @@ func writeHashedPreimages(
 		}
 	}
 
-	if err := collector.Load(nil, "", loadFunc, etl.TransformArgs{Quit: quit}); err != nil {
+	if err := collector.Load(nil, "", loadFunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
+		// Load wraps a cancellation as "loadIntoTable : stopped", which no longer
+		// matches errors.Is(err, context.Canceled).
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return stats, ctxErr
+		}
 		return stats, err
 	}
 	// flushRecord mutates stats, so it cannot share a return statement with it.

--- a/cmd/utils/app/export_preimages_cmd.go
+++ b/cmd/utils/app/export_preimages_cmd.go
@@ -333,6 +333,11 @@ func collectHashedPreimages(
 	haveAccount := false
 
 	nextAccount := func() error {
+		select {
+		case <-done:
+			return ctx.Err()
+		default:
+		}
 		if !accounts.HasNext() {
 			haveAccount = false
 			return nil
@@ -391,11 +396,6 @@ func collectHashedPreimages(
 		stats.Slots++
 	}
 	for haveAccount {
-		select {
-		case <-done:
-			return stats, ctx.Err()
-		default:
-		}
 		if err := nextAccount(); err != nil {
 			return stats, err
 		}

--- a/cmd/utils/app/export_preimages_cmd_test.go
+++ b/cmd/utils/app/export_preimages_cmd_test.go
@@ -348,7 +348,7 @@ func requireHashedOrder(t *testing.T, framed []byte) {
 		prevAccount, haveAccount = accountHash, true
 
 		haveSlot := false
-		for i := 0; i < slotCount; i++ {
+		for range slotCount {
 			slotHash := crypto.Keccak256Hash(framed[:preimageSlotLen])
 			framed = framed[preimageSlotLen:]
 			if haveSlot {

--- a/cmd/utils/app/export_preimages_cmd_test.go
+++ b/cmd/utils/app/export_preimages_cmd_test.go
@@ -358,3 +358,44 @@ func requireHashedOrder(t *testing.T, framed []byte) {
 		}
 	}
 }
+
+// The accounts domain is walked to exhaustion before the first storage key, so on
+// mainnet this guard is the only thing that answers a Ctrl-C for hours.
+func TestCollectHashedPreimages_CancellationWhileScanningAccounts(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	accounts := &cancelOnNthNextKV{
+		sliceKV: &sliceKV{pairs: []kvPair{
+			{addr(0xaa), []byte{1}},
+			{addr(0xbb), []byte{1}},
+		}},
+		cancel:    cancel,
+		remaining: 1,
+	}
+	var out bytes.Buffer
+
+	_, err := exportPreimages(t, ctx, accounts, &sliceKV{}, &out, exportOpts{})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestCollectHashedPreimages_ReportsBothScans(t *testing.T) {
+	accounts := &sliceKV{pairs: []kvPair{{addr(0xaa), []byte{1}}, {addr(0xbb), []byte{1}}}}
+	storage := &sliceKV{pairs: []kvPair{
+		{storageKey(addr(0xaa), slot(0x01)), []byte{1}},
+		{storageKey(addr(0xbb), slot(0x02)), []byte{1}},
+	}}
+	var out bytes.Buffer
+	var reports []exportPreimagesStats
+
+	_, err := exportPreimages(t, context.Background(), accounts, storage, &out, exportOpts{
+		onCollect: func(stats exportPreimagesStats) { reports = append(reports, stats) },
+	})
+	require.NoError(t, err)
+	// Every account is collected before the first slot, so the counts advance in
+	// two runs rather than interleaving.
+	require.Equal(t, []exportPreimagesStats{
+		{Accounts: 1, Slots: 0},
+		{Accounts: 2, Slots: 0},
+		{Accounts: 2, Slots: 1},
+		{Accounts: 2, Slots: 2},
+	}, reports)
+}

--- a/cmd/utils/app/export_preimages_cmd_test.go
+++ b/cmd/utils/app/export_preimages_cmd_test.go
@@ -19,13 +19,20 @@ package app
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/c2h5oh/datasize"
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/crypto"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/etl"
+	"github.com/erigontech/erigon/db/kv/stream"
 	"github.com/erigontech/erigon/execution/types"
 )
 
@@ -104,7 +111,81 @@ func storageKey(address, slotKey []byte) []byte {
 	return append(append([]byte{}, address...), slotKey...)
 }
 
-func TestWriteFramedPreimages_AccountWithSlots(t *testing.T) {
+type exportOpts struct {
+	bufferSize datasize.ByteSize
+	onCollect  func(exportPreimagesStats)
+	onWrite    func(exportPreimagesStats)
+}
+
+func exportPreimages(t *testing.T, ctx context.Context, accounts, storage stream.KV, writer io.Writer, opts exportOpts) (exportPreimagesStats, error) {
+	t.Helper()
+	if opts.bufferSize == 0 {
+		opts.bufferSize = etl.BufferOptimalSize
+	}
+	collector := etl.NewCollector(t.Name(), t.TempDir(), etl.NewSortableBuffer(opts.bufferSize), log.New())
+	defer collector.Close()
+
+	collected, err := collectHashedPreimages(ctx, accounts, storage, collector, opts.onCollect)
+	if err != nil {
+		return collected, err
+	}
+	written, err := writeHashedPreimages(collector, writer, ctx.Done(), opts.onWrite)
+	if err != nil {
+		return written, err
+	}
+	require.Equal(t, collected, written, "sort must neither drop nor invent keys")
+	return written, nil
+}
+
+// keccak256 order of the 20-byte repeated addresses is 0xaa < 0x11, the reverse
+// of their plain-key order; of the 32-byte repeated slot keys it is 0x03 < 0x01 <
+// 0x02. Both fixtures are fed in plain order so a plain-key sort cannot pass.
+func TestExportPreimages_OrdersByKeccakNotPlainKey(t *testing.T) {
+	accounts := &sliceKV{pairs: []kvPair{
+		{addr(0x11), []byte{1}},
+		{addr(0xaa), []byte{1}},
+	}}
+	storage := &sliceKV{pairs: []kvPair{
+		{storageKey(addr(0xaa), slot(0x01)), []byte{1}},
+		{storageKey(addr(0xaa), slot(0x02)), []byte{1}},
+		{storageKey(addr(0xaa), slot(0x03)), []byte{1}},
+	}}
+	var out bytes.Buffer
+
+	stats, err := exportPreimages(t, context.Background(), accounts, storage, &out, exportOpts{})
+	require.NoError(t, err)
+
+	want := append([]byte{}, addr(0xaa)...)
+	want = append(want, 0, 0, 0, 3)
+	want = append(want, slot(0x03)...)
+	want = append(want, slot(0x01)...)
+	want = append(want, slot(0x02)...)
+	want = append(want, addr(0x11)...)
+	want = append(want, 0, 0, 0, 0)
+	require.Equal(t, want, out.Bytes())
+	require.Equal(t, exportPreimagesStats{Accounts: 2, Slots: 3}, stats)
+}
+
+// A buffer this small flushes every few entries, so the load runs as a real
+// multi-file merge instead of sorting one in-RAM buffer.
+func TestExportPreimages_OrderSurvivesSpillToDisk(t *testing.T) {
+	var accountPairs, storagePairs []kvPair
+	for fill := 1; fill <= 200; fill++ {
+		address := addr(byte(fill))
+		accountPairs = append(accountPairs, kvPair{address, []byte{1}})
+		storagePairs = append(storagePairs, kvPair{storageKey(address, slot(byte(fill))), []byte{1}})
+	}
+	var out bytes.Buffer
+
+	stats, err := exportPreimages(t, context.Background(),
+		&sliceKV{pairs: accountPairs}, &sliceKV{pairs: storagePairs}, &out,
+		exportOpts{bufferSize: 1 * datasize.KB})
+	require.NoError(t, err)
+	require.Equal(t, exportPreimagesStats{Accounts: 200, Slots: 200}, stats)
+	requireHashedOrder(t, out.Bytes())
+}
+
+func TestExportPreimages_AccountWithSlots(t *testing.T) {
 	address := addr(0xaa)
 	accounts := &sliceKV{pairs: []kvPair{{address, []byte{1}}}}
 	storage := &sliceKV{pairs: []kvPair{
@@ -113,7 +194,7 @@ func TestWriteFramedPreimages_AccountWithSlots(t *testing.T) {
 	}}
 	var out bytes.Buffer
 
-	stats, err := writeFramedPreimages(context.Background(), accounts, storage, &out, nil)
+	stats, err := exportPreimages(t, context.Background(), accounts, storage, &out, exportOpts{})
 	require.NoError(t, err)
 
 	want := append([]byte{}, address...)
@@ -121,47 +202,51 @@ func TestWriteFramedPreimages_AccountWithSlots(t *testing.T) {
 	want = append(want, slot(0x01)...)
 	want = append(want, slot(0x02)...)
 	require.Equal(t, want, out.Bytes())
-	require.Equal(t, uint64(1), stats.Accounts)
-	require.Equal(t, uint64(2), stats.Slots)
+	require.Equal(t, exportPreimagesStats{Accounts: 1, Slots: 2}, stats)
 }
 
-func TestWriteFramedPreimages_RejectsOrphanedStorage(t *testing.T) {
-	accounts := &sliceKV{pairs: []kvPair{{addr(0xbb), []byte{1}}}}
-	storage := &sliceKV{pairs: []kvPair{
-		{storageKey(addr(0x11), slot(0x01)), []byte{1}},
-		{storageKey(addr(0xbb), slot(0x02)), []byte{1}},
-		{storageKey(addr(0xcc), slot(0x03)), []byte{1}},
-	}}
-	var out bytes.Buffer
+func TestExportPreimages_RejectsOrphanedStorage(t *testing.T) {
+	// keccak256: addr(0x11) sorts before addr(0xbb), addr(0xcc) after it, so this
+	// covers an orphan hitting the load with and without a record already open.
+	for name, orphan := range map[string][]byte{"before": addr(0x11), "after": addr(0xcc)} {
+		t.Run(name, func(t *testing.T) {
+			accounts := &sliceKV{pairs: []kvPair{{addr(0xbb), []byte{1}}}}
+			storage := &sliceKV{pairs: []kvPair{
+				{storageKey(orphan, slot(0x01)), []byte{1}},
+				{storageKey(addr(0xbb), slot(0x02)), []byte{1}},
+			}}
+			var out bytes.Buffer
 
-	_, err := writeFramedPreimages(context.Background(), accounts, storage, &out, nil)
-	require.ErrorContains(t, err, "no matching account")
+			_, err := exportPreimages(t, context.Background(), accounts, storage, &out, exportOpts{})
+			require.ErrorContains(t, err, "no matching account")
+		})
+	}
 }
 
-func TestWriteFramedPreimages_MalformedAccountKey(t *testing.T) {
+func TestCollectHashedPreimages_MalformedAccountKey(t *testing.T) {
 	accounts := &sliceKV{pairs: []kvPair{{[]byte{0xaa, 0xbb}, []byte{1}}}}
 	var out bytes.Buffer
 
-	_, err := writeFramedPreimages(context.Background(), accounts, &sliceKV{}, &out, nil)
+	_, err := exportPreimages(t, context.Background(), accounts, &sliceKV{}, &out, exportOpts{})
 	require.ErrorContains(t, err, "key length")
 }
 
-func TestWriteFramedPreimages_MalformedStorageKey(t *testing.T) {
+func TestCollectHashedPreimages_MalformedStorageKey(t *testing.T) {
 	address := addr(0xaa)
-	accounts := &sliceKV{pairs: []kvPair{{address, []byte{1}}}}
-	tooShort := &sliceKV{pairs: []kvPair{{[]byte{0xaa}, []byte{1}}}}
+	accountsOf := func() *sliceKV { return &sliceKV{pairs: []kvPair{{address, []byte{1}}}} }
 	var out bytes.Buffer
 
-	_, err := writeFramedPreimages(context.Background(), accounts, tooShort, &out, nil)
+	tooShort := &sliceKV{pairs: []kvPair{{[]byte{0xaa}, []byte{1}}}}
+	_, err := exportPreimages(t, context.Background(), accountsOf(), tooShort, &out, exportOpts{})
 	require.ErrorContains(t, err, "key length")
 
 	wrongTotal := &sliceKV{pairs: []kvPair{{storageKey(address, []byte{0x01}), []byte{1}}}}
 	out.Reset()
-	_, err = writeFramedPreimages(context.Background(), &sliceKV{pairs: []kvPair{{address, []byte{1}}}}, wrongTotal, &out, nil)
+	_, err = exportPreimages(t, context.Background(), accountsOf(), wrongTotal, &out, exportOpts{})
 	require.ErrorContains(t, err, "key length")
 }
 
-func TestWriteFramedPreimages_InterleavesMultipleAccounts(t *testing.T) {
+func TestExportPreimages_InterleavesMultipleAccounts(t *testing.T) {
 	accounts := &sliceKV{pairs: []kvPair{
 		{addr(0xaa), []byte{1}},
 		{addr(0xbb), []byte{1}},
@@ -174,9 +259,10 @@ func TestWriteFramedPreimages_InterleavesMultipleAccounts(t *testing.T) {
 	}}
 	var out bytes.Buffer
 
-	stats, err := writeFramedPreimages(context.Background(), accounts, storage, &out, nil)
+	stats, err := exportPreimages(t, context.Background(), accounts, storage, &out, exportOpts{})
 	require.NoError(t, err)
 
+	// keccak256 leaves 0xaa < 0xbb < 0xcc, so record order matches plain order here.
 	want := append([]byte{}, addr(0xaa)...)
 	want = append(want, 0, 0, 0, 2)
 	want = append(want, slot(0x01)...)
@@ -187,28 +273,22 @@ func TestWriteFramedPreimages_InterleavesMultipleAccounts(t *testing.T) {
 	want = append(want, 0, 0, 0, 1)
 	want = append(want, slot(0x03)...)
 	require.Equal(t, want, out.Bytes())
-	require.Equal(t, uint64(3), stats.Accounts)
-	require.Equal(t, uint64(3), stats.Slots)
-
-	wantSize := stats.Accounts*(20+4) + stats.Slots*32
-	require.Equal(t, wantSize, uint64(out.Len()))
+	require.Equal(t, exportPreimagesStats{Accounts: 3, Slots: 3}, stats)
+	require.Equal(t, stats.sizeBytes(), uint64(out.Len()))
 }
 
-func TestWriteFramedPreimages_SingleAccountNoStorage(t *testing.T) {
+func TestExportPreimages_SingleAccountNoStorage(t *testing.T) {
 	accounts := &sliceKV{pairs: []kvPair{{addr(0xaa), []byte{1}}}}
-	storage := &sliceKV{}
 	var out bytes.Buffer
 
-	stats, err := writeFramedPreimages(context.Background(), accounts, storage, &out, nil)
+	stats, err := exportPreimages(t, context.Background(), accounts, &sliceKV{}, &out, exportOpts{})
 	require.NoError(t, err)
 
-	want := append(addr(0xaa), 0, 0, 0, 0)
-	require.Equal(t, want, out.Bytes())
-	require.Equal(t, uint64(1), stats.Accounts)
-	require.Equal(t, uint64(0), stats.Slots)
+	require.Equal(t, append(addr(0xaa), 0, 0, 0, 0), out.Bytes())
+	require.Equal(t, exportPreimagesStats{Accounts: 1, Slots: 0}, stats)
 }
 
-func TestWriteFramedPreimages_CancellationWhileScanningStorage(t *testing.T) {
+func TestCollectHashedPreimages_CancellationWhileScanningStorage(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	address := addr(0xaa)
 	accounts := &sliceKV{pairs: []kvPair{{address, []byte{1}}}}
@@ -218,15 +298,15 @@ func TestWriteFramedPreimages_CancellationWhileScanningStorage(t *testing.T) {
 			{storageKey(address, slot(0x02)), []byte{1}},
 		}},
 		cancel:    cancel,
-		remaining: 2,
+		remaining: 1,
 	}
 	var out bytes.Buffer
 
-	_, err := writeFramedPreimages(ctx, accounts, storage, &out, nil)
+	_, err := exportPreimages(t, ctx, accounts, storage, &out, exportOpts{})
 	require.ErrorIs(t, err, context.Canceled)
 }
 
-func TestWriteFramedPreimages_ReportsCompletedAccounts(t *testing.T) {
+func TestWriteHashedPreimages_ReportsCompletedAccounts(t *testing.T) {
 	addressA := addr(0xaa)
 	addressB := addr(0xbb)
 	accounts := &sliceKV{pairs: []kvPair{{addressA, []byte{1}}, {addressB, []byte{1}}}}
@@ -238,12 +318,43 @@ func TestWriteFramedPreimages_ReportsCompletedAccounts(t *testing.T) {
 	var out bytes.Buffer
 	var reports []exportPreimagesStats
 
-	_, err := writeFramedPreimages(context.Background(), accounts, storage, &out, func(stats exportPreimagesStats) {
-		reports = append(reports, stats)
+	_, err := exportPreimages(t, context.Background(), accounts, storage, &out, exportOpts{
+		onWrite: func(stats exportPreimagesStats) { reports = append(reports, stats) },
 	})
 	require.NoError(t, err)
 	require.Equal(t, []exportPreimagesStats{
 		{Accounts: 1, Slots: 2},
 		{Accounts: 2, Slots: 3},
 	}, reports)
+}
+
+// requireHashedOrder re-parses the framed file and checks the EIP-8347 ordering:
+// records ascending by keccak256(address), slots ascending by keccak256(slotKey).
+func requireHashedOrder(t *testing.T, framed []byte) {
+	t.Helper()
+	var prevAccount, prevSlot common.Hash
+	haveAccount := false
+	for len(framed) > 0 {
+		require.GreaterOrEqual(t, len(framed), preimageAddrLen+preimageCountLen)
+		address := framed[:preimageAddrLen]
+		slotCount := int(binary.BigEndian.Uint32(framed[preimageAddrLen:]))
+		framed = framed[preimageAddrLen+preimageCountLen:]
+		require.GreaterOrEqual(t, len(framed), slotCount*preimageSlotLen)
+
+		accountHash := crypto.Keccak256Hash(address)
+		if haveAccount {
+			require.Negative(t, bytes.Compare(prevAccount[:], accountHash[:]), "accounts out of keccak order")
+		}
+		prevAccount, haveAccount = accountHash, true
+
+		haveSlot := false
+		for i := 0; i < slotCount; i++ {
+			slotHash := crypto.Keccak256Hash(framed[:preimageSlotLen])
+			framed = framed[preimageSlotLen:]
+			if haveSlot {
+				require.Negative(t, bytes.Compare(prevSlot[:], slotHash[:]), "slots out of keccak order")
+			}
+			prevSlot, haveSlot = slotHash, true
+		}
+	}
 }

--- a/cmd/utils/app/export_preimages_cmd_test.go
+++ b/cmd/utils/app/export_preimages_cmd_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -129,7 +130,7 @@ func exportPreimages(t *testing.T, ctx context.Context, accounts, storage stream
 	if err != nil {
 		return collected, err
 	}
-	written, err := writeHashedPreimages(collector, writer, ctx.Done(), opts.onWrite)
+	written, err := writeHashedPreimages(ctx, collector, writer, opts.onWrite)
 	if err != nil {
 		return written, err
 	}
@@ -170,10 +171,15 @@ func TestExportPreimages_OrdersByKeccakNotPlainKey(t *testing.T) {
 // multi-file merge instead of sorting one in-RAM buffer.
 func TestExportPreimages_OrderSurvivesSpillToDisk(t *testing.T) {
 	var accountPairs, storagePairs []kvPair
+	// The slot fill differs from the address fill, so a defect that shifts slot
+	// payloads onto the neighbouring record cannot pass the membership check.
+	slotFor := func(fill int) []byte { return slot(byte(255 - fill)) }
+	wantSlots := map[string][][]byte{}
 	for fill := 1; fill <= 200; fill++ {
 		address := addr(byte(fill))
 		accountPairs = append(accountPairs, kvPair{address, []byte{1}})
-		storagePairs = append(storagePairs, kvPair{storageKey(address, slot(byte(fill))), []byte{1}})
+		storagePairs = append(storagePairs, kvPair{storageKey(address, slotFor(fill)), []byte{1}})
+		wantSlots[string(address)] = [][]byte{slotFor(fill)}
 	}
 	var out bytes.Buffer
 
@@ -182,7 +188,7 @@ func TestExportPreimages_OrderSurvivesSpillToDisk(t *testing.T) {
 		exportOpts{bufferSize: 1 * datasize.KB})
 	require.NoError(t, err)
 	require.Equal(t, exportPreimagesStats{Accounts: 200, Slots: 200}, stats)
-	requireHashedOrder(t, out.Bytes())
+	requireHashedOrder(t, out.Bytes(), wantSlots)
 }
 
 func TestExportPreimages_AccountWithSlots(t *testing.T) {
@@ -274,7 +280,7 @@ func TestExportPreimages_InterleavesMultipleAccounts(t *testing.T) {
 	want = append(want, slot(0x03)...)
 	require.Equal(t, want, out.Bytes())
 	require.Equal(t, exportPreimagesStats{Accounts: 3, Slots: 3}, stats)
-	require.Equal(t, stats.sizeBytes(), uint64(out.Len()))
+	require.Equal(t, uint64(3*(20+4)+3*32), uint64(out.Len()))
 }
 
 func TestExportPreimages_SingleAccountNoStorage(t *testing.T) {
@@ -328,10 +334,13 @@ func TestWriteHashedPreimages_ReportsCompletedAccounts(t *testing.T) {
 	}, reports)
 }
 
-// requireHashedOrder re-parses the framed file and checks the EIP-8347 ordering:
-// records ascending by keccak256(address), slots ascending by keccak256(slotKey).
-func requireHashedOrder(t *testing.T, framed []byte) {
+// requireHashedOrder re-parses the framed file and checks the EIP-8347 ordering --
+// records ascending by keccak256(address), slots ascending by keccak256(slotKey) --
+// and that every record carries exactly the slots wantSlots maps to its address.
+// Order alone would pass a defect that shifts slot payloads between records.
+func requireHashedOrder(t *testing.T, framed []byte, wantSlots map[string][][]byte) {
 	t.Helper()
+	seenAccounts := 0
 	var prevAccount, prevSlot common.Hash
 	haveAccount := false
 	for len(framed) > 0 {
@@ -348,15 +357,22 @@ func requireHashedOrder(t *testing.T, framed []byte) {
 		prevAccount, haveAccount = accountHash, true
 
 		haveSlot := false
+		var gotSlots [][]byte
 		for range slotCount {
-			slotHash := crypto.Keccak256Hash(framed[:preimageSlotLen])
+			slotKey := framed[:preimageSlotLen]
+			slotHash := crypto.Keccak256Hash(slotKey)
 			framed = framed[preimageSlotLen:]
 			if haveSlot {
 				require.Negative(t, bytes.Compare(prevSlot[:], slotHash[:]), "slots out of keccak order")
 			}
 			prevSlot, haveSlot = slotHash, true
+			gotSlots = append(gotSlots, bytes.Clone(slotKey))
 		}
+		want := wantSlots[string(address)]
+		require.ElementsMatch(t, want, gotSlots, "record %x carries slots that are not its own", address)
+		seenAccounts++
 	}
+	require.Len(t, wantSlots, seenAccounts, "not every expected account reached the file")
 }
 
 // The accounts domain is walked to exhaustion before the first storage key, so on
@@ -377,7 +393,7 @@ func TestCollectHashedPreimages_CancellationWhileScanningAccounts(t *testing.T) 
 	require.ErrorIs(t, err, context.Canceled)
 }
 
-func TestCollectHashedPreimages_ReportsBothScans(t *testing.T) {
+func TestCollectHashedPreimages_ReportsPerAccountNotPerSlot(t *testing.T) {
 	accounts := &sliceKV{pairs: []kvPair{{addr(0xaa), []byte{1}}, {addr(0xbb), []byte{1}}}}
 	storage := &sliceKV{pairs: []kvPair{
 		{storageKey(addr(0xaa), slot(0x01)), []byte{1}},
@@ -390,12 +406,98 @@ func TestCollectHashedPreimages_ReportsBothScans(t *testing.T) {
 		onCollect: func(stats exportPreimagesStats) { reports = append(reports, stats) },
 	})
 	require.NoError(t, err)
-	// Every account is collected before the first slot, so the counts advance in
-	// two runs rather than interleaving.
+	// One report per account and none per slot: on mainnet the slot loop runs ~10^9
+	// times for a line that prints every 30s. Slot counts still show up, because the
+	// second account is only reached after the first account's slots are collected.
 	require.Equal(t, []exportPreimagesStats{
 		{Accounts: 1, Slots: 0},
-		{Accounts: 2, Slots: 0},
 		{Accounts: 2, Slots: 1},
-		{Accounts: 2, Slots: 2},
 	}, reports)
+}
+
+// A short value would leave the previous account's trailing bytes in the header and ship a
+// hybrid address. Neither guard downstream catches it: the record and size checks are both
+// derived from the same counts.
+func TestWriteHashedPreimages_RejectsShortValues(t *testing.T) {
+	address := addr(0xaa)
+	accountHash := crypto.Keccak256Hash(address)
+
+	t.Run("account", func(t *testing.T) {
+		collector := etl.NewCollector(t.Name(), t.TempDir(), etl.NewSortableBuffer(etl.BufferOptimalSize), log.New())
+		defer collector.Close()
+		require.NoError(t, collector.Collect(accountHash[:], address[:preimageAddrLen-1]))
+
+		_, err := writeHashedPreimages(context.Background(), collector, io.Discard, nil)
+		require.ErrorContains(t, err, "20-byte address")
+	})
+
+	t.Run("slot", func(t *testing.T) {
+		collector := etl.NewCollector(t.Name(), t.TempDir(), etl.NewSortableBuffer(etl.BufferOptimalSize), log.New())
+		defer collector.Close()
+		require.NoError(t, collector.Collect(accountHash[:], address))
+		slotHash := crypto.Keccak256Hash(slot(0x01))
+		require.NoError(t, collector.Collect(append(bytes.Clone(accountHash[:]), slotHash[:]...), slot(0x01)[:preimageSlotLen-1]))
+
+		_, err := writeHashedPreimages(context.Background(), collector, io.Discard, nil)
+		require.ErrorContains(t, err, "32-byte key")
+	})
+}
+
+// An orphaned slot must be rejected during the scan. Letting it reach the load means both
+// domains spill first - >100GB on mainnet - for a failure the first storage key already showed.
+func TestCollectHashedPreimages_RejectsOrphanBeforeDrainingStorage(t *testing.T) {
+	accounts := &sliceKV{pairs: []kvPair{{addr(0xbb), []byte{1}}}}
+	storagePairs := []kvPair{{storageKey(addr(0x11), slot(0x01)), []byte{1}}}
+	for fill := range 50 {
+		storagePairs = append(storagePairs, kvPair{storageKey(addr(0xbb), slot(byte(fill))), []byte{1}})
+	}
+	storage := &sliceKV{pairs: storagePairs}
+	var out bytes.Buffer
+
+	_, err := exportPreimages(t, context.Background(), accounts, storage, &out, exportOpts{})
+	require.ErrorContains(t, err, "no matching account")
+	require.Equal(t, 1, storage.next, "storage stream was drained past the orphan")
+	require.Zero(t, out.Len(), "nothing may be written once the scan has failed")
+}
+
+// A file written before the order was pinned is shape-identical to one written now, so the
+// metadata has to carry the order for a consumer to tell them apart.
+func TestPreimagesMetaRecordsKeccakOrder(t *testing.T) {
+	encoded, err := json.Marshal(preimagesMeta{Block: 1, StateRoot: "0x00", Order: preimagesOrderKeccak256})
+	require.NoError(t, err)
+	require.Contains(t, string(encoded), `"order":"keccak256"`)
+}
+
+func TestPrepareScratchDirClearsStaleSpill(t *testing.T) {
+	tmpDir := t.TempDir()
+	scratch, err := prepareScratchDir(tmpDir)
+	require.NoError(t, err)
+	stale := filepath.Join(scratch, "etl-tmp-from-a-killed-run")
+	require.NoError(t, os.WriteFile(stale, []byte("spill"), 0o644))
+
+	again, err := prepareScratchDir(tmpDir)
+	require.NoError(t, err)
+	require.Equal(t, scratch, again)
+	_, statErr := os.Stat(stale)
+	require.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+// Load is the longest phase, and it wraps a cancellation as "loadIntoTable : stopped".
+// Without mapping that back, Ctrl-C during it stops matching errors.Is(context.Canceled)
+// and the operator gets an error naming an empty table instead.
+func TestWriteHashedPreimages_CancellationKeepsContextErrorIdentity(t *testing.T) {
+	collector := etl.NewCollector(t.Name(), t.TempDir(), etl.NewSortableBuffer(etl.BufferOptimalSize), log.New())
+	defer collector.Close()
+	// Load only polls Quit every 1024 records, so the fixture has to outrun that.
+	var address [preimageAddrLen]byte
+	for fill := range 3000 {
+		binary.BigEndian.PutUint32(address[:4], uint32(fill))
+		accountHash := crypto.Keccak256Hash(address[:])
+		require.NoError(t, collector.Collect(accountHash[:], address[:]))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := writeHashedPreimages(ctx, collector, io.Discard, nil)
+	require.ErrorIs(t, err, context.Canceled)
 }

--- a/cmd/utils/app/export_preimages_cmd_test.go
+++ b/cmd/utils/app/export_preimages_cmd_test.go
@@ -501,3 +501,50 @@ func TestWriteHashedPreimages_CancellationKeepsContextErrorIdentity(t *testing.T
 	_, err := writeHashedPreimages(ctx, collector, io.Discard, nil)
 	require.ErrorIs(t, err, context.Canceled)
 }
+
+// Accounts past the last storage-bearing one are reached only by the drain loop after
+// the storage scan ends. Dropping them loses state silently: both count guards are
+// derived from this same scan, so neither can contradict it.
+func TestExportPreimages_AccountsAfterLastStorageKey(t *testing.T) {
+	accounts := &sliceKV{pairs: []kvPair{
+		{addr(0xaa), []byte{1}},
+		{addr(0xbb), []byte{1}},
+		{addr(0xcc), []byte{1}},
+	}}
+	storage := &sliceKV{pairs: []kvPair{{storageKey(addr(0xaa), slot(0x01)), []byte{1}}}}
+	var out bytes.Buffer
+
+	stats, err := exportPreimages(t, context.Background(), accounts, storage, &out, exportOpts{})
+	require.NoError(t, err)
+
+	want := append([]byte{}, addr(0xaa)...)
+	want = append(want, 0, 0, 0, 1)
+	want = append(want, slot(0x01)...)
+	want = append(want, addr(0xbb)...)
+	want = append(want, 0, 0, 0, 0)
+	want = append(want, addr(0xcc)...)
+	want = append(want, 0, 0, 0, 0)
+	require.Equal(t, want, out.Bytes())
+	require.Equal(t, exportPreimagesStats{Accounts: 3, Slots: 1}, stats)
+}
+
+// Advancing to the account that owns a storage run walks an unbounded stretch of
+// storage-less accounts. Checking only in the storage loop leaves that stretch
+// uninterruptible, which on mainnet is most of the domain.
+func TestCollectHashedPreimages_CancellationWhileAdvancingToStorageOwner(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	accounts := &cancelOnNthNextKV{
+		sliceKV: &sliceKV{pairs: []kvPair{
+			{addr(0xaa), []byte{1}},
+			{addr(0xbb), []byte{1}},
+			{addr(0xcc), []byte{1}},
+		}},
+		cancel:    cancel,
+		remaining: 2,
+	}
+	storage := &sliceKV{pairs: []kvPair{{storageKey(addr(0xcc), slot(0x01)), []byte{1}}}}
+	var out bytes.Buffer
+
+	_, err := exportPreimages(t, ctx, accounts, storage, &out, exportOpts{})
+	require.ErrorIs(t, err, context.Canceled)
+}


### PR DESCRIPTION
Follow-up to #22645. EIP-8347 now pins the preimage file to hashed-key order (ethereum/EIPs#12215): records ascending by `keccak256(address)`, slots within a record by `keccak256(slotKey)`. #22645 wrote plain-key order, straight off the domain scan. Those sort keys are the MPT paths, so both consumers — the consensus-anchoring re-hash and a hash-keyed self-converter — read the file as a sequential merge against their own trie walk.

Erigon 3 stores plain keys, so one ETL collector produces the order: an account under `keccak256(address)`, a slot under `keccak256(address) || keccak256(slotKey)`. An account's key is a strict prefix of its own slots' keys and of nothing else, so one merge-sorted load emits each account immediately ahead of its slots.

Record layout is unchanged. Scratch is the ETL spill, at `sortableBuffer.Write` framing: 54 B/account and 99 B/slot — the slot key's zigzagged length reaches 128, so it costs 2 varint bytes rather than 1. It lives in a directory this command owns and empties on start, since only `collector.Close()` unlinks a spill and a killed run would strand >100 GB. `--tmpdir` moves that off `<datadir>/temp`.

## Changes

- `collectHashedPreimages` walks both domain scans together, so the account owning a storage run is at hand: its hash is reused across the run, and an orphaned slot fails there rather than after both domains have spilled.
- `writeHashedPreimages` drains the collector, buffering a record's slots until `slotCount` is known, and rejects a key or value whose length is not the one its zone implies.
- `doExportPreimages` cross-checks collected against written counts. A mismatch fails the run and withholds `preimages.meta.json`, so a truncated `framed.bin` cannot pass as a pinned export.
- `preimages.meta.json` carries `"order":"keccak256"`. A plain-ordered file is shape-identical, so a consumer has nothing else to key on.
- Everything that can leave a partial `framed.bin` sits behind one error wrap naming the file, and a cancelled `Load` keeps its `context.Canceled` identity.
- Tests: fixtures whose keccak order inverts their plain order, a 1 KB-buffer case forcing a real multi-file merge, and per-record slot membership so an order-preserving payload shift cannot pass.
