### PR TITLE
[r3.6] ChangeLog: 3.6.0 "Upstream Underbelly" release notes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,25 +1,26 @@
 # Erigon v3.6.0 — Upstream Underbelly — 2026-08-24
 
-Erigon 3.6.0 focuses on bounded disk growth and faster state access. It is an in-place upgrade from 3.5.x: existing
-datadirs need no re-sync, and old and new commitment snapshot files can coexist while normal merges convert them.
+Erigon 3.6.0 focuses on reclaiming pruned snapshot space and lowering the memory and CPU cost of state access and
+background maintenance. It is an in-place upgrade from 3.5.x: existing datadirs need no re-sync, and both referenced
+and plain commitment snapshots remain readable.
 
 ### Highlights
 
-- **Plain commitment snapshots.** Commitment branches no longer store shortened cross-file key references by default,
-  removing dereference I/O from state reads and merges at the cost of larger commitment files. Existing referenced files
-  remain readable and convert lazily; fresh syncs use the new 3.6 snapshot set (#14809, #21452, #21376) — by @awskii
+- **More reliable Caplin block production.** Caplin primes the execution layer before a proposer slot, publishes the
+  fork-choice head before copying state, and encodes the execution and consensus client versions in default block
+  graffiti (#23437, #23172, #22303) — by @lystopad
 - **Pruned nodes now reclaim old state snapshots.** State history, indexes, optional commitment history, and the receipts
   cache are retired once they fall outside their configured windows; fresh syncs also skip optional snapshots outside
   those windows. This fixes unbounded snapshot growth on long-running `minimal` and other pruned nodes (#21306, #22123,
   #21200, #22243, #22349) — by @AskAlexSharov, @JkLondon
+- **Plain commitment snapshots.** Commitment branches no longer store shortened cross-file key references by default,
+  removing dereference I/O from state reads and merges at the cost of larger commitment files. Existing per-datadir
+  settings are honored; if the setting is absent, 3.6 defaults new commitment merges to plain. Referenced files convert
+  lazily when plain writes are active, and fresh syncs use the new 3.6 snapshot set (#14809, #21452, #21376) — by @awskii
 - **Faster state access and snapshot maintenance.** Sharded LRU state, code, and commitment caches replace whole-cache
   resets; state-snapshot compression is 2–3x faster, dictionary-building merges are about 1.5x faster, and the mainnet
   `.bt` pivot cache uses roughly one quarter of its previous heap (#22154, #21625, #22050, #21875) — by @mh0lt,
   @sudeepdino008, @AskAlexSharov
-- **Glamsterdam devnet-6 support.** Adds EIP-8282 builder execution requests, EIP-2780, EIP-8038, EIP-8246, and the
-  devnet-6 revisions of EIP-7928/EIP-8037; Caplin tracks the Gloas alpha.11 request format, and BALs can be regenerated
-  throughout the weak-subjectivity period (#22091, #22093, #22053, #22060, #22122, #22136, #22161, #21764) — by
-  @domiwei, @taratorio. **Devnet/testing only — not scheduled on mainnet or any public testnet.**
 
 ### Breaking Changes
 
@@ -50,6 +51,18 @@ datadirs need no re-sync, and old and new commitment snapshot files can coexist 
 - `trace_block` and `trace_replayBlockTransactions` can include beacon-withdrawal balance changes through the optional
   `IncludeWithdrawals` trace setting (#21592) — by @lupin012
 
+#### Consensus layer and protocol
+
+- Caplin archive maintenance repairs truncated validator tables, removes frozen state rows from its indexing DB for
+  reuse, and stores compact effective balances, cutting the measured per-slot copy from about 266 MB to 18 MB (#22385,
+  #22396, #22411) — by @awskii, @AskAlexSharov
+- Caplin advertises its bound ports, skips peers without TCP endpoints, and accepts Chiado libp2p bootstrap nodes
+  (#22273, #22271, #23245) — by @MysticRyuujin, @domiwei
+- Glamsterdam devnet-6 support adds EIP-8282 builder execution requests, EIP-2780, EIP-8038, EIP-8246, and the devnet-6
+  revisions of EIP-7928/EIP-8037; Caplin tracks the Gloas alpha.11 request format, and BALs can be regenerated throughout
+  the weak-subjectivity period (#22091, #22093, #22053, #22060, #22122, #22136, #22161, #21764) — by @domiwei,
+  @taratorio. **Devnet/testing only — not scheduled on mainnet or any public testnet.**
+
 #### Operations
 
 - Pruning flags now use readable policies: `--prune.distance.blocks` accepts `keep-post-merge` and `keep-all`, while
@@ -57,9 +70,9 @@ datadirs need no re-sync, and old and new commitment snapshot files can coexist 
   remain aliases (#22119, #21200, #22349) — by @yperbasis, @JkLondon, @AskAlexSharov
 - `erigon seg index --rebuild` rebuilds every snapshot accessor and index without deleting snapshot data (#21919) — by
   @sudeepdino008
-- Caplin archive-state maintenance now removes frozen state rows from its indexing DB for reuse instead of growing the
-  DB without bound; compact effective-balance snapshots also cut the per-slot copy from about 266 MB to 18 MB on the
-  measured mainnet state (#22396, #22411) — by @awskii, @AskAlexSharov
+- The command-line layer now uses `urfave/cli/v3`. Normal flag handling remains compatible, and `--config` now applies
+  to subcommands; operators with unusual invocation patterns should smoke-test them (#22130, #22546) — by
+  @AskAlexSharov, @yperbasis, @lupin012
 
 **Full Changelog**: https://github.com/erigontech/erigon/compare/v3.5.5...v3.6.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -30,7 +30,8 @@ with leaner state access and maintenance throughout. It is an in-place upgrade f
   `--prune.include-receipts --prune.receipts.distance=keep-all` (#22296, #22349) — by @yperbasis, @AskAlexSharov
 - **Idle polling filters expire after five minutes.** Clients using `eth_newFilter`, `eth_newBlockFilter`, or
   `eth_newPendingTransactionFilter` must poll within the timeout or recreate the filter. Configure
-  `--rpc.subscription.filters.timeout`, or set it to `0` to disable eviction (#22261) — by @onelapahead
+  `--rpc.subscription.filters.timeout`, or set it to `0` to disable eviction. New `subscriptions_active` and
+  `subscriptions_*_total` metrics track the filter lifecycle (#22261) — by @onelapahead
 - **JSON-RPC compatibility changes.** Quoted decimal block numbers such as `"3"` are rejected; use `"0x3"`, a bare
   integer, or a named tag. `eth_simulateV1` now returns the specified `-38012` code when the base fee is too low instead
   of `-32602` (#21985, #21418) — by @lupin012, @Sahil-4555

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -63,6 +63,7 @@ created with Erigon 3.3 or earlier that have not already been rebased must use t
   copy from about 266 MB to 18 MB (#22385, #22396, #22411, #23408) — by @awskii, @AskAlexSharov, @lystopad
 - Caplin advertises its bound ports, skips peers without TCP endpoints, and accepts Chiado libp2p bootstrap nodes
   (#22273, #22271, #23245) — by @MysticRyuujin, @domiwei
+- A deadlock in the transaction pool that could wedge block-producing nodes during high load has been resolved (#23360) — by @lystopad
 - Glamsterdam devnet-6 support adds EIP-8282 builder execution requests, EIP-2780, EIP-8038, EIP-8246, and the devnet-6
   revisions of EIP-7928/EIP-8037; Caplin tracks the Gloas alpha.11 request format, and BALs can be regenerated throughout
   retained state history, extending beyond the weak-subjectivity period (#22091, #22093, #22053, #22060, #22122,

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,9 +1,11 @@
 # Erigon v3.6.0 — Upstream Underbelly — 2026-08-24
 
-Erigon 3.6.0 is headlined by **more reliable Caplin block production** and **pruned nodes reclaiming old snapshots**,
-with leaner state access and maintenance throughout. Most 3.5 users can upgrade without re-syncing. Datadirs created with
-Erigon 3.3 or earlier that have not already been rebased must first convert their snapshot layout with
-`erigon seg step-rebase --new-step-size=390625`.
+Erigon 3.6.0 is headlined by **more reliable Caplin block production**, **pruned nodes reclaiming old snapshots**, and
+**plain commitment snapshots**, with leaner state access and maintenance throughout. Most 3.5 users can upgrade without
+re-syncing. To benefit immediately from the new plain commitment format, existing users should install 3.6, then run
+`erigon seg reset --datadir=<path>` before starting the node; the next start will re-sync using the new snapshots. Datadirs
+created with Erigon 3.3 or earlier that have not already been rebased must use this reset path or run
+`erigon seg step-rebase --datadir=<path> --new-step-size=390625` before their first normal 3.6 start.
 
 ### Highlights
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,9 @@
 # Erigon v3.6.0 — Upstream Underbelly — 2026-08-24
 
 Erigon 3.6.0 is headlined by **more reliable Caplin block production** and **pruned nodes reclaiming old snapshots**,
-with leaner state access and maintenance throughout. It is an in-place upgrade from 3.5.x — no re-sync required.
+with leaner state access and maintenance throughout. Most 3.5 users can upgrade without re-syncing. Datadirs created with
+Erigon 3.3 or earlier that have not already been rebased must first convert their snapshot layout with
+`erigon seg step-rebase --new-step-size=390625`.
 
 ### Highlights
 
@@ -12,18 +14,18 @@ with leaner state access and maintenance throughout. It is an in-place upgrade f
   those windows. This fixes unbounded snapshot growth on long-running `minimal` and other pruned nodes (#21306, #22123,
   #21200, #22243, #22349) — by @AskAlexSharov, @JkLondon
 - **Plain commitment snapshots.** New commitment files store values directly by default, speeding state reads and merges
-  at the cost of larger files. Existing per-datadir settings are honored; referenced files remain readable and convert
-  lazily when plain writes are active (#14809, #21452, #21376) — by @awskii
+  at the cost of larger files. Existing referenced files remain readable and convert lazily during merges; the offline
+  `integration commitment convert` command provides an explicit migration path (#14809, #21452, #21376, #21933) — by
+  @awskii, @AskAlexSharov
 - **Faster state access and snapshot maintenance.** Sharded LRU state, code, and commitment caches replace whole-cache
-  resets; state-snapshot compression is 2–3x faster, dictionary-building merges are about 1.5x faster, and the mainnet
-  `.bt` pivot cache uses roughly one quarter of its previous heap (#22154, #21625, #22050, #21875) — by @mh0lt,
-  @sudeepdino008, @AskAlexSharov
+  resets; compression during state-snapshot merges is 2–3× faster, dictionary-building merges are about 1.5× faster,
+  and the mainnet `.bt` pivot cache uses roughly one quarter of its previous heap (#21386, #21982, #22154, #21625,
+  #22050, #21875) — by @mh0lt, @yperbasis, @sudeepdino008, @AskAlexSharov
 
 ### Breaking Changes
 
-- **Downgrading after new commitment files are written is unsupported.** Erigon 3.5 cannot read the new plain `v2.2`
-  commitment files. Back up the datadir before upgrading if rollback is required; upgrading itself needs no re-sync
-  (#21452, #21376).
+- **Downgrading after 3.6 writes new snapshot files is unsupported.** New 3.6 snapshot and accessor formats are
+  incompatible with Erigon 3.5. Back up the datadir before upgrading if rollback is required (#21452, #21376, #21778).
 - **Historical receipts are off by default on fresh datadirs in every prune mode.** Existing datadirs keep their stored
   enable/disable setting. Without the cache, receipt and log RPCs re-execute within the state-history window at higher
   latency. Blocks-mode operators who need receipts and logs back to genesis must use
@@ -33,8 +35,8 @@ with leaner state access and maintenance throughout. It is an in-place upgrade f
   `--rpc.subscription.filters.timeout`, or set it to `0` to disable eviction. New `subscriptions_active` and
   `subscriptions_*_total` metrics track the filter lifecycle (#22261) — by @onelapahead
 - **JSON-RPC compatibility changes.** Quoted decimal block numbers such as `"3"` are rejected; use `"0x3"`, a bare
-  integer, or a named tag. `eth_simulateV1` now returns the specified `-38012` code when the base fee is too low instead
-  of `-32602` (#21985, #21418) — by @lupin012, @Sahil-4555
+  integer, or a named tag. Streaming trace errors no longer include `result: null` alongside `error` (#21985, #21922) —
+  by @lupin012
 
 ### Added and Changed
 
@@ -51,6 +53,8 @@ with leaner state access and maintenance throughout. It is an in-place upgrade f
 
 #### Consensus layer and protocol
 
+- Validation now rejects fork-inconsistent blocks and sidecars, truncated typed transactions, invalid fee relationships,
+  and blob wrappers with trailing data (#22920, #23041, #22902, #23297) — by @yperbasis, @chfast
 - Default block graffiti now identifies both the execution and consensus clients (#22303) — by @lystopad
 - Caplin archive maintenance repairs truncated validator tables, removes frozen state rows from its indexing DB for
   reuse, and stores compact effective balances, cutting the measured per-slot copy from about 266 MB to 18 MB (#22385,
@@ -59,7 +63,8 @@ with leaner state access and maintenance throughout. It is an in-place upgrade f
   (#22273, #22271, #23245) — by @MysticRyuujin, @domiwei
 - Glamsterdam devnet-6 support adds EIP-8282 builder execution requests, EIP-2780, EIP-8038, EIP-8246, and the devnet-6
   revisions of EIP-7928/EIP-8037; Caplin tracks the Gloas alpha.11 request format, and BALs can be regenerated throughout
-  the weak-subjectivity period (#22091, #22093, #22053, #22060, #22122, #22136, #22161, #21764) — by @domiwei,
+  retained state history, extending beyond the weak-subjectivity period (#22091, #22093, #22053, #22060, #22122,
+  #22136, #22161, #21764) — by @domiwei,
   @taratorio. **Devnet/testing only — not scheduled on mainnet or any public testnet.**
 
 #### Operations
@@ -67,8 +72,8 @@ with leaner state access and maintenance throughout. It is an in-place upgrade f
 - Pruning flags now use readable policies: `--prune.distance` accepts `keep-all`, and `--prune.distance.blocks` accepts
   `keep-post-merge` and `keep-all`. Receipt and commitment-history caches have independent `--prune.*.distance` windows;
   the former receipt flag names remain aliases (#22119, #21200, #22349) — by @yperbasis, @JkLondon, @AskAlexSharov
-- `erigon seg index --rebuild` rebuilds every snapshot accessor and index without deleting snapshot data (#21919) — by
-  @sudeepdino008
+- Missing E3 accessors are rebuilt automatically on restart. `erigon seg index --rebuild` rebuilds every snapshot
+  accessor and index without deleting snapshot data (#22682, #21919) — by @AskAlexSharov, @sudeepdino008
 - The command-line layer now uses `urfave/cli/v3`. Normal flag handling remains compatible, and `--config` now applies
   to subcommands; operators with unusual invocation patterns should smoke-test them (#22130, #22546) — by
   @AskAlexSharov, @yperbasis, @lupin012

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,4 @@
-# Erigon v3.6.0 — Upstream Underbelly — TBD
+# Erigon v3.6.0 — Upstream Underbelly — 2026-08-24
 
 Erigon 3.6.0 focuses on bounded disk growth and faster state access. It is an in-place upgrade from 3.5.x: existing
 datadirs need no re-sync, and old and new commitment snapshot files can coexist while normal merges convert them.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,110 +1,67 @@
 # Erigon v3.6.0 — Upstream Underbelly — TBD
 
+Erigon 3.6.0 focuses on bounded disk growth and faster state access. It is an in-place upgrade from 3.5.x: existing
+datadirs need no re-sync, and old and new commitment snapshot files can coexist while normal merges convert them.
+
+### Highlights
+
+- **Plain commitment snapshots.** Commitment branches no longer store shortened cross-file key references by default,
+  removing dereference I/O from state reads and merges at the cost of larger commitment files. Existing referenced files
+  remain readable and convert lazily; fresh syncs use the new 3.6 snapshot set (#14809, #21452, #21376) — by @awskii
+- **Pruned nodes now reclaim old state snapshots.** State history, indexes, optional commitment history, and the receipts
+  cache are retired once they fall outside their configured windows; fresh syncs also skip optional snapshots outside
+  those windows. This fixes unbounded snapshot growth on long-running `minimal` and other pruned nodes (#21306, #22123,
+  #21200, #22243, #22349) — by @AskAlexSharov, @JkLondon
+- **Faster state access and snapshot maintenance.** Sharded LRU state, code, and commitment caches replace whole-cache
+  resets; state-snapshot compression is 2–3x faster, dictionary-building merges are about 1.5x faster, and the mainnet
+  `.bt` pivot cache uses roughly one quarter of its previous heap (#22154, #21625, #22050, #21875) — by @mh0lt,
+  @sudeepdino008, @AskAlexSharov
+- **Glamsterdam devnet-6 support.** Adds EIP-8282 builder execution requests, EIP-2780, EIP-8038, EIP-8246, and the
+  devnet-6 revisions of EIP-7928/EIP-8037; Caplin tracks the Gloas alpha.11 request format, and BALs can be regenerated
+  throughout the weak-subjectivity period (#22091, #22093, #22053, #22060, #22122, #22136, #22161, #21764) — by
+  @domiwei, @taratorio. **Devnet/testing only — not scheduled on mainnet or any public testnet.**
+
 ### Breaking Changes
 
-#### `--prune.include-receipts`: historical receipts cache now off by default in all prune modes
+- **Downgrading after new commitment files are written is unsupported.** Erigon 3.5 cannot read the new plain `v2.2`
+  commitment files. Back up the datadir before upgrading if rollback is required; upgrading itself needs no re-sync
+  (#21452, #21376).
+- **Historical receipts are off by default on fresh datadirs in every prune mode.** Existing datadirs keep their stored
+  enable/disable setting. Without the cache, receipt and log RPCs re-execute within the state-history window at higher
+  latency. Blocks-mode operators who need receipts and logs back to genesis must use
+  `--prune.include-receipts --prune.receipts.distance=keep-all` (#22296, #22349) — by @yperbasis, @AskAlexSharov
+- **Idle polling filters expire after five minutes.** Clients using `eth_newFilter`, `eth_newBlockFilter`, or
+  `eth_newPendingTransactionFilter` must poll within the timeout or recreate the filter. Configure
+  `--rpc.subscription.filters.timeout`, or set it to `0` to disable eviction (#22261) — by @onelapahead
+- **JSON-RPC validation is stricter.** Quoted decimal block numbers such as `"3"` are rejected; use `"0x3"`, a bare
+  integer, or a named tag. `eth_simulateV1` now returns the specified `-38012` code when the base fee is too low instead
+  of `-32602` (#21985, #21418) — by @lupin012, @Sahil-4555
 
-The historical ("fat") receipts cache is no longer enabled by default on non-archive nodes. Previously
-`--prune.include-receipts` (formerly `--persist.receipts`, still accepted as an alias) defaulted on for every prune mode
-except `archive`; it now defaults off everywhere. The consensus layer was the consumer that justified retaining these
-receipts on pruned nodes, and it no longer needs them ([#21617](https://github.com/erigontech/erigon/issues/21617)).
+### Added and Changed
 
-**What changed:**
+#### RPC
 
-| `--prune.mode` | Before | After |
-|---|---|---|
-| `archive` | off | off |
-| `full` | on | off |
-| `blocks` | on | off |
-| `minimal` | on | off |
+- With `--prune.include-commitment-history`, `eth_getWitness` now builds and verifies a lean witness for any block within
+  retained history (#22099) — by @awskii
+- `eth_fillTransaction` fills missing fields and returns the unsigned raw transaction plus its JSON form, compatible
+  with geth; KZG generation from raw blobs is not included (#21870) — by @lupin012
+- `eth_getBalance`, `eth_getCode`, `eth_getStorageAt`, `eth_getTransactionCount`, `eth_getProof`, and
+  `eth_getStorageValues` now default an omitted block parameter to `latest` (#21586) — by @MysticRyuujin
+- `trace_block` and `trace_replayBlockTransactions` can include beacon-withdrawal balance changes through the optional
+  `IncludeWithdrawals` trace setting (#21592) — by @lupin012
 
-Receipts and logs stay available within a node's retention window regardless: without the cache they are re-executed on
-demand from state history, so `eth_getLogs` and `eth_getBlockReceipts` keep working, at higher latency. For `full` and
-`minimal` nodes the availability window is unchanged (receipts follow the state-history window either way). For `blocks`
-nodes the cache previously made receipts and logs queryable back to genesis; without it they follow the state-history
-window (last 262,144 blocks) — pass `--prune.include-receipts` if you rely on full-range `eth_getLogs`.
+#### Operations
 
-**Migration:** existing datadirs are unaffected — the receipts-cache setting is recorded at datadir creation and the
-stored value wins, so a node already syncing with the cache keeps it. Such a node now logs a startup notice that
-`--prune.include-receipts` differs from the value stored in the datadir; pass `--prune.include-receipts` explicitly to
-silence it. Only newly-created `full`/`minimal`/`blocks` datadirs start without the cache; pass
-`--prune.include-receipts` on a fresh datadir to opt back in.
+- Pruning flags now use readable policies: `--prune.distance.blocks` accepts `keep-post-merge` and `keep-all`, while
+  receipt and commitment-history caches have independent `--prune.*.distance` windows. The former receipt flag names
+  remain aliases (#22119, #21200, #22349) — by @yperbasis, @JkLondon, @AskAlexSharov
+- `erigon seg index --rebuild` rebuilds every snapshot accessor and index without deleting snapshot data (#21919) — by
+  @sudeepdino008
+- Caplin archive-state maintenance now removes frozen state rows from its indexing DB for reuse instead of growing the
+  DB without bound; compact effective-balance snapshots also cut the per-slot copy from about 266 MB to 18 MB on the
+  measured mainnet state (#22396, #22411) — by @awskii, @AskAlexSharov
 
-(#22296) — by @yperbasis
-
----
-
-#### CLI: receipts and commitment-history pruning flags moved under `--prune.*`
-
-The receipt cache and commitment history now share the `--prune.*` naming used by the rest of the pruning flags. All
-former names keep working as aliases, and stored datadir settings are unaffected.
-
-- `--persist.receipts` → `--prune.include-receipts` (alias: `--persist.receipts`, `--experiment.persist.receipts.v2`).
-- New `--prune.receipts.distance` (alias: `--persist.receipts.distance`) bounds how far back the receipt cache is kept:
-  a block count, `keep-all`, or empty/`0` (default) to follow the state-history window. Requires
-  `--prune.include-receipts`. Snapshots older than the window are skipped at download time.
-- `--prune.commitment-history.distance` now also accepts `keep-all` (in addition to a block count); empty or `0` still
-  keeps everything.
-
-(#22349) — by @AskAlexSharov
-
----
-
-#### JSON-RPC: block-number strings must use the `0x` hex format
-
-Quoted decimal strings (e.g., `"3"`) are no longer accepted as block-number
-parameters; use the canonical hex form (e.g., `"0x3"`) instead. Bare JSON
-integers (`3`) and named tags (`"latest"`, `"earliest"`, `"pending"`,
-`"safe"`, `"finalized"`) are unchanged.
-
-**What changed:**
-
-| Input | Before | After |
-|---|---|---|
-| `"3"` (quoted decimal) | accepted | rejected with `-32602` |
-| `"0x3"` (hex string) | accepted | accepted |
-| `3` (bare integer) | accepted | accepted |
-
-**Migration:** replace any quoted decimal block number with its `0x`
-equivalent — e.g., `"3"` → `"0x3"`, `"1000000"` → `"0xf4240"`.
-
----
-
-#### `eth_simulateV1`: base fee too low error code corrected to `-38012`
-
-Aligns Erigon with the `eth_simulateV1` error code specification ([NethermindEth/nethermind#11412](https://github.com/NethermindEth/nethermind/issues/11412)).
-
-**What changed:**
-
-| Aspect | Before | After |
-|---|---|---|
-| `ErrFeeCapTooLow` error code | `-32602` (generic "Invalid params") | `-38012` (spec-mandated "baseFeePerGas is too low") |
-
-**Migration:**
-
-- If your tooling matches on error code `-32602` to detect base-fee-too-low conditions in `eth_simulateV1` responses, update it to match `-38012` instead.
-
----
-
-#### JSON-RPC: idle polling filters are evicted after 5 minutes
-
-Filters created with `eth_newFilter`, `eth_newBlockFilter`, and `eth_newPendingTransactionFilter` are now evicted when not polled for 5 minutes, matching geth's stale-filter deadline. Previously they lived — and kept buffering data — until `eth_uninstallFilter` or a restart.
-
-**What changed:**
-
-| Aspect | Before | After |
-|---|---|---|
-| Idle polling filter | kept until uninstalled or restart | evicted after 5 minutes without a poll |
-| `eth_getFilterChanges` / `eth_getFilterLogs` on an evicted id | — | `filter not found` |
-
-**Migration:** poll more often than the timeout, or recreate the filter when `filter not found` is returned (as with geth). Tune with `--rpc.subscription.filters.timeout`; set it to 0 to restore the previous keep-forever behavior. (#22261 by @onelapahead)
-
-### Added
-
-#### CLI & Operations
-
-- `--prune.distance.blocks` now accepts readable policy names — `keep-post-merge` and `keep-all` — instead of the raw `MaxUint64`-based magic numbers (`18446744073709551615` / `18446744073709551614`); `--prune.distance` likewise accepts `keep-all`. Numeric values still work (#22119) — by @yperbasis
-- `--rpc.subscription.filters.timeout` — deadline for evicting idle RPC polling filters (default 5m; 0 disables). New `subscriptions_active` gauge and `subscriptions_created_total` / `subscriptions_unsubscribed_total` / `subscriptions_reaped_total` counters track the filter lifecycle (#22261) — by @onelapahead
+**Full Changelog**: https://github.com/erigontech/erigon/compare/v3.5.5...v3.6.0
 
 ---
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -56,9 +56,9 @@ Erigon 3.3 or earlier that have not already been rebased must first convert thei
 - Validation now rejects fork-inconsistent blocks and sidecars, truncated typed transactions, invalid fee relationships,
   and blob wrappers with trailing data (#22920, #23041, #22902, #23297) — by @yperbasis, @chfast
 - Default block graffiti now identifies both the execution and consensus clients (#22303) — by @lystopad
-- Caplin archive maintenance repairs truncated validator tables, removes frozen state rows from its indexing DB for
-  reuse, and stores compact effective balances, cutting the measured per-slot copy from about 266 MB to 18 MB (#22385,
-  #22396, #22411) — by @awskii, @AskAlexSharov
+- Caplin archive maintenance repairs truncated validator tables, backs off repeatedly failing retirement work, removes
+  frozen state rows from its indexing DB for reuse, and stores compact effective balances, cutting the measured per-slot
+  copy from about 266 MB to 18 MB (#22385, #22396, #22411, #23408) — by @awskii, @AskAlexSharov, @lystopad
 - Caplin advertises its bound ports, skips peers without TCP endpoints, and accepts Chiado libp2p bootstrap nodes
   (#22273, #22271, #23245) — by @MysticRyuujin, @domiwei
 - Glamsterdam devnet-6 support adds EIP-8282 builder execution requests, EIP-2780, EIP-8038, EIP-8246, and the devnet-6
@@ -74,6 +74,7 @@ Erigon 3.3 or earlier that have not already been rebased must first convert thei
   the former receipt flag names remain aliases (#22119, #21200, #22349) — by @yperbasis, @JkLondon, @AskAlexSharov
 - Missing E3 accessors are rebuilt automatically on restart. `erigon seg index --rebuild` rebuilds every snapshot
   accessor and index without deleting snapshot data (#22682, #21919) — by @AskAlexSharov, @sudeepdino008
+- Commitment preloading no longer stalls when a step budget fills exactly (#23153) — by @lystopad
 - The command-line layer now uses `urfave/cli/v3`. Normal flag handling remains compatible, and `--config` now applies
   to subcommands; operators with unusual invocation patterns should smoke-test them (#22130, #22546) — by
   @AskAlexSharov, @yperbasis, @lupin012

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,22 +1,19 @@
 # Erigon v3.6.0 — Upstream Underbelly — 2026-08-24
 
-Erigon 3.6.0 focuses on reclaiming pruned snapshot space and lowering the memory and CPU cost of state access and
-background maintenance. It is an in-place upgrade from 3.5.x: existing datadirs need no re-sync, and both referenced
-and plain commitment snapshots remain readable.
+Erigon 3.6.0 is headlined by **more reliable Caplin block production** and **pruned nodes reclaiming old snapshots**,
+with leaner state access and maintenance throughout. It is an in-place upgrade from 3.5.x — no re-sync required.
 
 ### Highlights
 
-- **More reliable Caplin block production.** Caplin primes the execution layer before a proposer slot, publishes the
-  fork-choice head before copying state, and encodes the execution and consensus client versions in default block
-  graffiti (#23437, #23172, #22303) — by @lystopad
+- **More reliable Caplin block production.** Caplin starts payload building before proposer slots and publishes fork
+  choice earlier, giving blocks more time to reach attesters (#23437, #23172) — by @lystopad
 - **Pruned nodes now reclaim old state snapshots.** State history, indexes, optional commitment history, and the receipts
   cache are retired once they fall outside their configured windows; fresh syncs also skip optional snapshots outside
   those windows. This fixes unbounded snapshot growth on long-running `minimal` and other pruned nodes (#21306, #22123,
   #21200, #22243, #22349) — by @AskAlexSharov, @JkLondon
-- **Plain commitment snapshots.** Commitment branches no longer store shortened cross-file key references by default,
-  removing dereference I/O from state reads and merges at the cost of larger commitment files. Existing per-datadir
-  settings are honored; if the setting is absent, 3.6 defaults new commitment merges to plain. Referenced files convert
-  lazily when plain writes are active, and fresh syncs use the new 3.6 snapshot set (#14809, #21452, #21376) — by @awskii
+- **Plain commitment snapshots.** New commitment files store values directly by default, speeding state reads and merges
+  at the cost of larger files. Existing per-datadir settings are honored; referenced files remain readable and convert
+  lazily when plain writes are active (#14809, #21452, #21376) — by @awskii
 - **Faster state access and snapshot maintenance.** Sharded LRU state, code, and commitment caches replace whole-cache
   resets; state-snapshot compression is 2–3x faster, dictionary-building merges are about 1.5x faster, and the mainnet
   `.bt` pivot cache uses roughly one quarter of its previous heap (#22154, #21625, #22050, #21875) — by @mh0lt,
@@ -34,7 +31,7 @@ and plain commitment snapshots remain readable.
 - **Idle polling filters expire after five minutes.** Clients using `eth_newFilter`, `eth_newBlockFilter`, or
   `eth_newPendingTransactionFilter` must poll within the timeout or recreate the filter. Configure
   `--rpc.subscription.filters.timeout`, or set it to `0` to disable eviction (#22261) — by @onelapahead
-- **JSON-RPC validation is stricter.** Quoted decimal block numbers such as `"3"` are rejected; use `"0x3"`, a bare
+- **JSON-RPC compatibility changes.** Quoted decimal block numbers such as `"3"` are rejected; use `"0x3"`, a bare
   integer, or a named tag. `eth_simulateV1` now returns the specified `-38012` code when the base fee is too low instead
   of `-32602` (#21985, #21418) — by @lupin012, @Sahil-4555
 
@@ -53,6 +50,7 @@ and plain commitment snapshots remain readable.
 
 #### Consensus layer and protocol
 
+- Default block graffiti now identifies both the execution and consensus clients (#22303) — by @lystopad
 - Caplin archive maintenance repairs truncated validator tables, removes frozen state rows from its indexing DB for
   reuse, and stores compact effective balances, cutting the measured per-slot copy from about 266 MB to 18 MB (#22385,
   #22396, #22411) — by @awskii, @AskAlexSharov
@@ -65,9 +63,9 @@ and plain commitment snapshots remain readable.
 
 #### Operations
 
-- Pruning flags now use readable policies: `--prune.distance.blocks` accepts `keep-post-merge` and `keep-all`, while
-  receipt and commitment-history caches have independent `--prune.*.distance` windows. The former receipt flag names
-  remain aliases (#22119, #21200, #22349) — by @yperbasis, @JkLondon, @AskAlexSharov
+- Pruning flags now use readable policies: `--prune.distance` accepts `keep-all`, and `--prune.distance.blocks` accepts
+  `keep-post-merge` and `keep-all`. Receipt and commitment-history caches have independent `--prune.*.distance` windows;
+  the former receipt flag names remain aliases (#22119, #21200, #22349) — by @yperbasis, @JkLondon, @AskAlexSharov
 - `erigon seg index --rebuild` rebuilds every snapshot accessor and index without deleting snapshot data (#21919) — by
   @sudeepdino008
 - The command-line layer now uses `urfave/cli/v3`. Normal flag handling remains compatible, and `--config` now applies


### PR DESCRIPTION
Release notes for **3.6.0 "Upstream Underbelly"**, scheduled for Monday, 2026-08-24.

## Highlights

- More reliable Caplin block production, archive maintenance, and peer discovery.
- Pruned nodes now reclaim state snapshots outside their retention windows.
- Plain commitment snapshots and lower state/snapshot maintenance costs.
- Selected RPC, CLI, and operator-visible changes; Glamsterdam devnet-6 remains clearly marked test-only.

## Selection

Built from the [3.6.0 milestone](https://github.com/erigontech/erigon/milestone/71), the changes unique to `release/3.6` relative to `release/3.5`, and the 3.6 release blog post. Changes already present on `release/3.5`, refactorings, QA/CI work, dependency churn, and small fixes are omitted.

## Notes for reviewers

- `ChangeLog.md` only. This is documentation-only, so TDD does not apply.
- The release date is Monday, 2026-08-24; scope and wording can still be adjusted.
- The full changelog link compares `v3.5.5...v3.6.0`.

Validation: `make lint` (two clean passes), `make erigon integration`.
