### PR TITLE
cmd/utils/app: address review on the hashed-order preimage export

### DIFF
--- a/cmd/utils/app/export_preimages_cmd.go
+++ b/cmd/utils/app/export_preimages_cmd.go
@@ -56,6 +56,15 @@ const (
 
 	preimagesFileName     = "framed.bin"
 	preimagesMetaFileName = "preimages.meta.json"
+
+	// Records are ordered by keccak256 of the plain key. A file written before that
+	// was pinned is shape-identical, so consumers must require this field rather than
+	// infer the order from the layout.
+	preimagesOrderKeccak256 = "keccak256"
+
+	// Scratch lives in a directory this command owns, so leftovers from a killed run
+	// can be cleared without touching anyone else's temp files.
+	preimagesScratchDirName = "export-preimages"
 )
 
 var exportPreimagesCommand = cli.Command{
@@ -74,6 +83,7 @@ var exportPreimagesCommand = cli.Command{
 type preimagesMeta struct {
 	Block     uint64 `json:"block"`
 	StateRoot string `json:"stateRoot"`
+	Order     string `json:"order"`
 	Accounts  uint64 `json:"accounts"`
 	Storage   uint64 `json:"storage"`
 }
@@ -89,7 +99,8 @@ func doExportPreimages(ctx context.Context, cliCtx *cli.Command) error {
 	if tmpDir == "" {
 		tmpDir = dirs.Tmp
 	}
-	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
+	tmpDir, err = prepareScratchDir(tmpDir)
+	if err != nil {
 		return err
 	}
 
@@ -142,7 +153,7 @@ func doExportPreimages(ctx context.Context, cliCtx *cli.Command) error {
 	}
 
 	metadata := preimagesMeta{
-		Block: blockNum, StateRoot: commitmentRoot.Hex(),
+		Block: blockNum, StateRoot: commitmentRoot.Hex(), Order: preimagesOrderKeccak256,
 		Accounts: stats.Accounts, Storage: stats.Slots,
 	}
 	metadataJSON, err := json.MarshalIndent(metadata, "", "  ")
@@ -206,7 +217,7 @@ func writePreimagesFile(
 	if err != nil {
 		return collected, err
 	}
-	stats, err = writeHashedPreimages(collector, countedWriter, ctx.Done(), reportWriting)
+	stats, err = writeHashedPreimages(ctx, collector, countedWriter, reportWriting)
 	if err != nil {
 		return stats, err
 	}
@@ -239,6 +250,20 @@ func openExportDirs(dataDir string) (datadir.Dirs, error) {
 		return dirs, fmt.Errorf("datadir is not a directory: %s", dirs.DataDir)
 	}
 	return dirs, nil
+}
+
+// prepareScratchDir gives the sort a directory of its own under tmpDir and empties it first.
+// Only collector.Close() unlinks the spill, so a SIGKILL or OOM mid-export strands it -- on
+// mainnet that is >100 GB, and the retry would then hit ENOSPC partway through.
+func prepareScratchDir(tmpDir string) (string, error) {
+	scratch := filepath.Join(tmpDir, preimagesScratchDirName)
+	if err := os.RemoveAll(scratch); err != nil {
+		return "", fmt.Errorf("clear scratch %s: %w", scratch, err)
+	}
+	if err := os.MkdirAll(scratch, 0o755); err != nil {
+		return "", err
+	}
+	return scratch, nil
 }
 
 func preparePreimagesOutput(outDir string) (framedPath, metaPath string, err error) {
@@ -285,6 +310,11 @@ func (stats exportPreimagesStats) sizeBytes() uint64 {
 // account's key is a strict prefix of its own slots' keys and of nothing else, so
 // the merge-sorted load emits each account immediately ahead of its slots, both
 // in the EIP-8347 order.
+//
+// Both domain scans are ascending by plain key and a storage key starts with its
+// address, so walking them together keeps the account for the storage run at hand:
+// that both reuses its hash across the run and rejects an orphaned slot here,
+// rather than after the whole key set has spilled to disk.
 func collectHashedPreimages(
 	ctx context.Context,
 	accounts, storage stream.KV,
@@ -297,32 +327,39 @@ func collectHashedPreimages(
 	// which takes a mutex on every call.
 	done := ctx.Done()
 
-	for accounts.HasNext() {
-		select {
-		case <-done:
-			return stats, ctx.Err()
-		default:
+	var accountAddr [preimageAddrLen]byte
+	var accountHash common.Hash
+	var hashedKey [2 * length.Hash]byte
+	haveAccount := false
+
+	nextAccount := func() error {
+		if !accounts.HasNext() {
+			haveAccount = false
+			return nil
 		}
 		accountKey, _, err := accounts.Next()
 		if err != nil {
-			return stats, err
+			return err
 		}
 		if len(accountKey) != preimageAddrLen {
-			return stats, fmt.Errorf("account: unexpected key length %d: %x", len(accountKey), accountKey)
+			return fmt.Errorf("account: unexpected key length %d: %x", len(accountKey), accountKey)
 		}
-		accountHash := crypto.Keccak256Hash(accountKey)
-		if err := collector.Collect(accountHash[:], accountKey); err != nil {
-			return stats, err
+		copy(accountAddr[:], accountKey)
+		accountHash = crypto.Keccak256Hash(accountAddr[:])
+		haveAccount = true
+		if err := collector.Collect(accountHash[:], accountAddr[:]); err != nil {
+			return err
 		}
 		stats.Accounts++
 		if onProgress != nil {
 			onProgress(stats)
 		}
+		return nil
 	}
 
-	var hashedKey [2 * length.Hash]byte
-	var lastAddress [preimageAddrLen]byte
-	haveAddress := false
+	if err := nextAccount(); err != nil {
+		return stats, err
+	}
 	for storage.HasNext() {
 		select {
 		case <-done:
@@ -337,20 +374,30 @@ func collectHashedPreimages(
 			return stats, fmt.Errorf("storage: unexpected key length %d: %x", len(storageKey), storageKey)
 		}
 		address, slotKey := storageKey[:preimageAddrLen], storageKey[preimageAddrLen:]
-		if !haveAddress || !bytes.Equal(lastAddress[:], address) {
-			copy(lastAddress[:], address)
-			accountHash := crypto.Keccak256Hash(address)
-			copy(hashedKey[:length.Hash], accountHash[:])
-			haveAddress = true
+		for haveAccount && bytes.Compare(accountAddr[:], address) < 0 {
+			if err := nextAccount(); err != nil {
+				return stats, err
+			}
+		}
+		if !haveAccount || !bytes.Equal(accountAddr[:], address) {
+			return stats, fmt.Errorf("storage slot %x under address %x has no matching account", slotKey, address)
 		}
 		slotHash := crypto.Keccak256Hash(slotKey)
+		copy(hashedKey[:length.Hash], accountHash[:])
 		copy(hashedKey[length.Hash:], slotHash[:])
 		if err := collector.Collect(hashedKey[:], slotKey); err != nil {
 			return stats, err
 		}
 		stats.Slots++
-		if onProgress != nil {
-			onProgress(stats)
+	}
+	for haveAccount {
+		select {
+		case <-done:
+			return stats, ctx.Err()
+		default:
+		}
+		if err := nextAccount(); err != nil {
+			return stats, err
 		}
 	}
 	return stats, nil
@@ -360,9 +407,9 @@ func collectHashedPreimages(
 // address[20] | slotCount[4, big-endian] | slotKey[32] * slotCount, so a record
 // is 24+32*slotCount bytes and only its fields are fixed width.
 func writeHashedPreimages(
+	ctx context.Context,
 	collector *etl.Collector,
 	writer io.Writer,
-	quit <-chan struct{},
 	onProgress func(exportPreimagesStats),
 ) (exportPreimagesStats, error) {
 	var stats exportPreimagesStats
@@ -390,6 +437,7 @@ func writeHashedPreimages(
 		}
 		stats.Accounts++
 		stats.Slots += slotCount
+		pending = false
 		if onProgress != nil {
 			onProgress(stats)
 		}
@@ -399,6 +447,9 @@ func writeHashedPreimages(
 	loadFunc := func(k, v []byte, _ etl.CurrentTableReader, _ etl.LoadNextFunc) error {
 		switch len(k) {
 		case length.Hash:
+			if len(v) != preimageAddrLen {
+				return fmt.Errorf("account hash %x: expected a %d-byte address, got %d bytes", k, preimageAddrLen, len(v))
+			}
 			if err := flushRecord(); err != nil {
 				return err
 			}
@@ -408,6 +459,9 @@ func writeHashedPreimages(
 			pending = true
 			return nil
 		case 2 * length.Hash:
+			if len(v) != preimageSlotLen {
+				return fmt.Errorf("slot under account hash %x: expected a %d-byte key, got %d bytes", k[:length.Hash], preimageSlotLen, len(v))
+			}
 			if !pending || !bytes.Equal(k[:length.Hash], accountHash[:]) {
 				return fmt.Errorf("storage slot %x under account hash %x has no matching account", v, k[:length.Hash])
 			}
@@ -418,7 +472,12 @@ func writeHashedPreimages(
 		}
 	}
 
-	if err := collector.Load(nil, "", loadFunc, etl.TransformArgs{Quit: quit}); err != nil {
+	if err := collector.Load(nil, "", loadFunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
+		// Load wraps a cancellation as "loadIntoTable : stopped", which no longer
+		// matches errors.Is(err, context.Canceled).
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return stats, ctxErr
+		}
 		return stats, err
 	}
 	// flushRecord mutates stats, so it cannot share a return statement with it.

--- a/cmd/utils/app/export_preimages_cmd_test.go
+++ b/cmd/utils/app/export_preimages_cmd_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -129,7 +130,7 @@ func exportPreimages(t *testing.T, ctx context.Context, accounts, storage stream
 	if err != nil {
 		return collected, err
 	}
-	written, err := writeHashedPreimages(collector, writer, ctx.Done(), opts.onWrite)
+	written, err := writeHashedPreimages(ctx, collector, writer, opts.onWrite)
 	if err != nil {
 		return written, err
 	}
@@ -170,10 +171,15 @@ func TestExportPreimages_OrdersByKeccakNotPlainKey(t *testing.T) {
 // multi-file merge instead of sorting one in-RAM buffer.
 func TestExportPreimages_OrderSurvivesSpillToDisk(t *testing.T) {
 	var accountPairs, storagePairs []kvPair
+	// The slot fill differs from the address fill, so a defect that shifts slot
+	// payloads onto the neighbouring record cannot pass the membership check.
+	slotFor := func(fill int) []byte { return slot(byte(255 - fill)) }
+	wantSlots := map[string][][]byte{}
 	for fill := 1; fill <= 200; fill++ {
 		address := addr(byte(fill))
 		accountPairs = append(accountPairs, kvPair{address, []byte{1}})
-		storagePairs = append(storagePairs, kvPair{storageKey(address, slot(byte(fill))), []byte{1}})
+		storagePairs = append(storagePairs, kvPair{storageKey(address, slotFor(fill)), []byte{1}})
+		wantSlots[string(address)] = [][]byte{slotFor(fill)}
 	}
 	var out bytes.Buffer
 
@@ -182,7 +188,7 @@ func TestExportPreimages_OrderSurvivesSpillToDisk(t *testing.T) {
 		exportOpts{bufferSize: 1 * datasize.KB})
 	require.NoError(t, err)
 	require.Equal(t, exportPreimagesStats{Accounts: 200, Slots: 200}, stats)
-	requireHashedOrder(t, out.Bytes())
+	requireHashedOrder(t, out.Bytes(), wantSlots)
 }
 
 func TestExportPreimages_AccountWithSlots(t *testing.T) {
@@ -274,7 +280,7 @@ func TestExportPreimages_InterleavesMultipleAccounts(t *testing.T) {
 	want = append(want, slot(0x03)...)
 	require.Equal(t, want, out.Bytes())
 	require.Equal(t, exportPreimagesStats{Accounts: 3, Slots: 3}, stats)
-	require.Equal(t, stats.sizeBytes(), uint64(out.Len()))
+	require.Equal(t, uint64(3*(20+4)+3*32), uint64(out.Len()))
 }
 
 func TestExportPreimages_SingleAccountNoStorage(t *testing.T) {
@@ -328,10 +334,13 @@ func TestWriteHashedPreimages_ReportsCompletedAccounts(t *testing.T) {
 	}, reports)
 }
 
-// requireHashedOrder re-parses the framed file and checks the EIP-8347 ordering:
-// records ascending by keccak256(address), slots ascending by keccak256(slotKey).
-func requireHashedOrder(t *testing.T, framed []byte) {
+// requireHashedOrder re-parses the framed file and checks the EIP-8347 ordering --
+// records ascending by keccak256(address), slots ascending by keccak256(slotKey) --
+// and that every record carries exactly the slots wantSlots maps to its address.
+// Order alone would pass a defect that shifts slot payloads between records.
+func requireHashedOrder(t *testing.T, framed []byte, wantSlots map[string][][]byte) {
 	t.Helper()
+	seenAccounts := 0
 	var prevAccount, prevSlot common.Hash
 	haveAccount := false
 	for len(framed) > 0 {
@@ -348,15 +357,22 @@ func requireHashedOrder(t *testing.T, framed []byte) {
 		prevAccount, haveAccount = accountHash, true
 
 		haveSlot := false
+		var gotSlots [][]byte
 		for range slotCount {
-			slotHash := crypto.Keccak256Hash(framed[:preimageSlotLen])
+			slotKey := framed[:preimageSlotLen]
+			slotHash := crypto.Keccak256Hash(slotKey)
 			framed = framed[preimageSlotLen:]
 			if haveSlot {
 				require.Negative(t, bytes.Compare(prevSlot[:], slotHash[:]), "slots out of keccak order")
 			}
 			prevSlot, haveSlot = slotHash, true
+			gotSlots = append(gotSlots, bytes.Clone(slotKey))
 		}
+		want := wantSlots[string(address)]
+		require.ElementsMatch(t, want, gotSlots, "record %x carries slots that are not its own", address)
+		seenAccounts++
 	}
+	require.Len(t, wantSlots, seenAccounts, "not every expected account reached the file")
 }
 
 // The accounts domain is walked to exhaustion before the first storage key, so on
@@ -377,7 +393,7 @@ func TestCollectHashedPreimages_CancellationWhileScanningAccounts(t *testing.T) 
 	require.ErrorIs(t, err, context.Canceled)
 }
 
-func TestCollectHashedPreimages_ReportsBothScans(t *testing.T) {
+func TestCollectHashedPreimages_ReportsPerAccountNotPerSlot(t *testing.T) {
 	accounts := &sliceKV{pairs: []kvPair{{addr(0xaa), []byte{1}}, {addr(0xbb), []byte{1}}}}
 	storage := &sliceKV{pairs: []kvPair{
 		{storageKey(addr(0xaa), slot(0x01)), []byte{1}},
@@ -390,12 +406,98 @@ func TestCollectHashedPreimages_ReportsBothScans(t *testing.T) {
 		onCollect: func(stats exportPreimagesStats) { reports = append(reports, stats) },
 	})
 	require.NoError(t, err)
-	// Every account is collected before the first slot, so the counts advance in
-	// two runs rather than interleaving.
+	// One report per account and none per slot: on mainnet the slot loop runs ~10^9
+	// times for a line that prints every 30s. Slot counts still show up, because the
+	// second account is only reached after the first account's slots are collected.
 	require.Equal(t, []exportPreimagesStats{
 		{Accounts: 1, Slots: 0},
-		{Accounts: 2, Slots: 0},
 		{Accounts: 2, Slots: 1},
-		{Accounts: 2, Slots: 2},
 	}, reports)
+}
+
+// A short value would leave the previous account's trailing bytes in the header and ship a
+// hybrid address. Neither guard downstream catches it: the record and size checks are both
+// derived from the same counts.
+func TestWriteHashedPreimages_RejectsShortValues(t *testing.T) {
+	address := addr(0xaa)
+	accountHash := crypto.Keccak256Hash(address)
+
+	t.Run("account", func(t *testing.T) {
+		collector := etl.NewCollector(t.Name(), t.TempDir(), etl.NewSortableBuffer(etl.BufferOptimalSize), log.New())
+		defer collector.Close()
+		require.NoError(t, collector.Collect(accountHash[:], address[:preimageAddrLen-1]))
+
+		_, err := writeHashedPreimages(context.Background(), collector, io.Discard, nil)
+		require.ErrorContains(t, err, "20-byte address")
+	})
+
+	t.Run("slot", func(t *testing.T) {
+		collector := etl.NewCollector(t.Name(), t.TempDir(), etl.NewSortableBuffer(etl.BufferOptimalSize), log.New())
+		defer collector.Close()
+		require.NoError(t, collector.Collect(accountHash[:], address))
+		slotHash := crypto.Keccak256Hash(slot(0x01))
+		require.NoError(t, collector.Collect(append(bytes.Clone(accountHash[:]), slotHash[:]...), slot(0x01)[:preimageSlotLen-1]))
+
+		_, err := writeHashedPreimages(context.Background(), collector, io.Discard, nil)
+		require.ErrorContains(t, err, "32-byte key")
+	})
+}
+
+// An orphaned slot must be rejected during the scan. Letting it reach the load means both
+// domains spill first - >100GB on mainnet - for a failure the first storage key already showed.
+func TestCollectHashedPreimages_RejectsOrphanBeforeDrainingStorage(t *testing.T) {
+	accounts := &sliceKV{pairs: []kvPair{{addr(0xbb), []byte{1}}}}
+	storagePairs := []kvPair{{storageKey(addr(0x11), slot(0x01)), []byte{1}}}
+	for fill := range 50 {
+		storagePairs = append(storagePairs, kvPair{storageKey(addr(0xbb), slot(byte(fill))), []byte{1}})
+	}
+	storage := &sliceKV{pairs: storagePairs}
+	var out bytes.Buffer
+
+	_, err := exportPreimages(t, context.Background(), accounts, storage, &out, exportOpts{})
+	require.ErrorContains(t, err, "no matching account")
+	require.Equal(t, 1, storage.next, "storage stream was drained past the orphan")
+	require.Zero(t, out.Len(), "nothing may be written once the scan has failed")
+}
+
+// A file written before the order was pinned is shape-identical to one written now, so the
+// metadata has to carry the order for a consumer to tell them apart.
+func TestPreimagesMetaRecordsKeccakOrder(t *testing.T) {
+	encoded, err := json.Marshal(preimagesMeta{Block: 1, StateRoot: "0x00", Order: preimagesOrderKeccak256})
+	require.NoError(t, err)
+	require.Contains(t, string(encoded), `"order":"keccak256"`)
+}
+
+func TestPrepareScratchDirClearsStaleSpill(t *testing.T) {
+	tmpDir := t.TempDir()
+	scratch, err := prepareScratchDir(tmpDir)
+	require.NoError(t, err)
+	stale := filepath.Join(scratch, "etl-tmp-from-a-killed-run")
+	require.NoError(t, os.WriteFile(stale, []byte("spill"), 0o644))
+
+	again, err := prepareScratchDir(tmpDir)
+	require.NoError(t, err)
+	require.Equal(t, scratch, again)
+	_, statErr := os.Stat(stale)
+	require.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+// Load is the longest phase, and it wraps a cancellation as "loadIntoTable : stopped".
+// Without mapping that back, Ctrl-C during it stops matching errors.Is(context.Canceled)
+// and the operator gets an error naming an empty table instead.
+func TestWriteHashedPreimages_CancellationKeepsContextErrorIdentity(t *testing.T) {
+	collector := etl.NewCollector(t.Name(), t.TempDir(), etl.NewSortableBuffer(etl.BufferOptimalSize), log.New())
+	defer collector.Close()
+	// Load only polls Quit every 1024 records, so the fixture has to outrun that.
+	var address [preimageAddrLen]byte
+	for fill := range 3000 {
+		binary.BigEndian.PutUint32(address[:4], uint32(fill))
+		accountHash := crypto.Keccak256Hash(address[:])
+		require.NoError(t, collector.Collect(accountHash[:], address[:]))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := writeHashedPreimages(ctx, collector, io.Discard, nil)
+	require.ErrorIs(t, err, context.Canceled)
 }


### PR DESCRIPTION
Addresses the review on #23473 (comment on `0732665`). Targets the PR branch, so merging this folds the fixes into #23473.

The three flagged before merge:

- **Value length unchecked in `loadFunc`** — `copy(recordHeader[:20], v)` now errors unless `len(v)` matches, for slots too. A short value left the previous account's trailing bytes in the header and shipped a hybrid address.
- **`preimagesMeta` gains `"order":"keccak256"`** — a plain-ordered file was shape-identical, so a consumer doing the sequential merge had nothing to key on.
- **Orphan rejection back before the spill** — both domain scans are ascending by plain key and a storage key starts with its address, so `collectHashedPreimages` walks them together. That restores the fail-fast and keeps the per-run account hash, instead of draining and spilling both domains first.

The smaller ones: scratch moved into a directory this command owns and empties on start; `writeHashedPreimages` takes a `ctx` and maps a cancelled `Load` back to `ctx.Err()`; `onProgress` fires per record again; the hash buffers are hoisted so the escape is once per export rather than once per account; `flushRecord` clears `pending`.

**Not done — the tmpdir space precheck.** It needs a new dependency (`gopsutil/v4/disk`; the repo only vendors `process`), and the size it would check against isn't known until the scan has run. The stale-scratch half is handled. Happy to add it if you want the dependency.

Tests: `requireHashedOrder` now checks a record carries its own slots, with a fixture whose slot fill differs from its address fill — order alone passed a defect shifting slot payloads between records. The size assertion is back to the literal layout. New coverage for the short-value guard, the fail-fast orphan, the cancelled `Load`'s error identity, the order field, and the scratch sweep. Each new guard was mutation-checked: removing it fails exactly its own test.
