### PR TITLE
rpc/gasprice: truncate blob fee arrays with the rest of the fee history

### DIFF
--- a/rpc/gasprice/feehistory.go
+++ b/rpc/gasprice/feehistory.go
@@ -473,5 +473,6 @@ func (oracle *Oracle) FeeHistory(ctx context.Context, blocks int, unresolvedLast
 		reward = nil
 	}
 	baseFee, gasUsedRatio = baseFee[:firstMissing+1], gasUsedRatio[:firstMissing]
+	blobBaseFee, blobGasUsedRatio = blobBaseFee[:firstMissing+1], blobGasUsedRatio[:firstMissing]
 	return new(big.Int).SetUint64(oldestBlock), reward, baseFee, gasUsedRatio, blobBaseFee, blobGasUsedRatio, nil
 }

--- a/rpc/gasprice/feehistory_truncate_test.go
+++ b/rpc/gasprice/feehistory_truncate_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package gasprice_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/rpc"
+	"github.com/erigontech/erigon/rpc/gasprice"
+	"github.com/erigontech/erigon/rpc/gasprice/gaspricecfg"
+)
+
+// gapBackend serves headers for every block up to head except missingBlock,
+// which returns (nil, nil) the way a reorged-away block does.
+type gapBackend struct {
+	head         uint64
+	missingBlock uint64
+	config       *chain.Config
+}
+
+func (b *gapBackend) HeaderByNumber(_ context.Context, number rpc.BlockNumber) (*types.Header, error) {
+	n := uint64(number.Int64())
+	if n == b.missingBlock || n > b.head {
+		return nil, nil
+	}
+	return &types.Header{
+		Number:   *uint256.NewInt(n),
+		GasLimit: 30_000_000,
+		GasUsed:  15_000_000,
+		BaseFee:  uint256.NewInt(1_000_000_000),
+	}, nil
+}
+
+func (b *gapBackend) BlockByNumber(context.Context, rpc.BlockNumber) (*types.Block, error) {
+	return nil, nil
+}
+
+func (b *gapBackend) ChainConfig() *chain.Config { return b.config }
+
+func (b *gapBackend) GetLatestBlockNumber() (uint64, error) { return b.head, nil }
+
+func (b *gapBackend) GetReceiptsGasUsed(context.Context, *types.Block) (types.Receipts, error) {
+	return nil, nil
+}
+
+func (b *gapBackend) PendingBlockAndReceipts() (*types.Block, types.Receipts) { return nil, nil }
+
+func (b *gapBackend) Fork(context.Context) (gasprice.OracleBackend, func(), error) {
+	return nil, nil, nil
+}
+
+// A block missing from the middle of the requested range truncates the response
+// at that block. Every returned array must be cut to the same point, otherwise
+// the blob arrays carry entries for blocks that were not returned.
+func TestFeeHistoryTruncatesBlobArrays(t *testing.T) {
+	backend := &gapBackend{
+		head:         10,
+		missingBlock: 8,
+		config:       &chain.Config{ChainID: uint256.NewInt(1), LondonBlock: new(uint64)},
+	}
+	oracle := gasprice.NewOracle(backend, gaspricecfg.Config{}, nil, gasprice.NewFeeHistoryCache(), log.New())
+
+	oldest, _, baseFee, gasUsedRatio, blobBaseFee, blobGasUsedRatio, err := oracle.FeeHistory(
+		context.Background(), 5, rpc.BlockNumber(10), nil)
+	require.NoError(t, err)
+
+	// Range is 6..10 with block 8 missing, so blocks 6 and 7 are returned.
+	require.Equal(t, uint64(6), oldest.Uint64())
+	require.Len(t, gasUsedRatio, 2)
+	require.Len(t, baseFee, len(gasUsedRatio)+1)
+	require.Len(t, blobGasUsedRatio, len(gasUsedRatio))
+	require.Len(t, blobBaseFee, len(baseFee))
+}


### PR DESCRIPTION
`FeeHistory` stops the response at the first block in the requested range that has no header (a reorg, or the range running past the head). `reward`, `baseFee` and `gasUsedRatio` are sliced to `firstMissing`, but `blobBaseFee` and `blobGasUsedRatio` were returned at the full requested length:

```go
baseFee, gasUsedRatio = baseFee[:firstMissing+1], gasUsedRatio[:firstMissing]
return new(big.Int).SetUint64(oldestBlock), reward, baseFee, gasUsedRatio, blobBaseFee, blobGasUsedRatio, nil
```

So `eth_feeHistory` returns `baseFeePerBlobGas` and `blobGasUsedRatio` entries for blocks it did not return. The extra entries are never filled, so they serialize as `null` and `0`. A caller that zips the arrays by index — the intended use, since `blobGasUsedRatio[i]` describes the same block as `gasUsedRatio[i]` — reads blob data for blocks outside the returned range.

The existing `TestFeeHistory` already asserts these lengths:

```go
if c.expCount != 0 && len(blobBaseFee) != c.expCount+1 { ... }
if len(blobBaseFeeRatio) != c.expCount { ... }
```

but none of its cases reach the truncation path: `resolveBlockRange` clamps `blocks` up front for the genesis and `maxHistory` limits, so `firstMissing == blocks` in every existing case. The new test drives `FeeHistory` through a small `OracleBackend` that returns `(nil, nil)` for one block in the middle of the range, which is the shape a reorged-away block has.

Written test-first. On `main` the new test fails on the blob assertion only, with the other three lengths already correct:

```
Error: "[0 0 0 0 0]" should have 2 item(s), but has 5
--- FAIL: TestFeeHistoryTruncatesBlobArrays
```

`go test ./rpc/gasprice/...` passes with the change, and `go tool golangci-lint run --config ./.golangci.yml ./rpc/gasprice/...` reports 0 issues.
