### PR TITLE
common/hexutil, execution/tracing: write traced stack values without allocating or escaping

### DIFF
--- a/common/hexutil/json.go
+++ b/common/hexutil/json.go
@@ -20,6 +20,7 @@
 package hexutil
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"math/big"
@@ -149,11 +150,13 @@ func (b U256) AppendText(dst []byte) ([]byte, error) {
 	if nibbles == 0 {
 		nibbles = 1
 	}
-	dst = append(dst, '0', 'x')
-	for i := nibbles - 1; i >= 0; i-- {
-		dst = append(dst, "0123456789abcdef"[(z[i/16]>>(uint(i%16)*4))&0xf])
-	}
-	return dst, nil
+	// hex.Encode works in whole bytes, so an odd nibble count produces one
+	// leading zero digit to drop.
+	nbytes := (nibbles + 1) / 2
+	be := z.Bytes32()
+	var digits [64]byte
+	hex.Encode(digits[:2*nbytes], be[32-nbytes:])
+	return append(append(dst, '0', 'x'), digits[2*nbytes-nibbles:2*nbytes]...), nil
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/common/hexutil/json_test.go
+++ b/common/hexutil/json_test.go
@@ -295,6 +295,26 @@ func TestMarshalU256WordBoundaries(t *testing.T) {
 	}
 }
 
+func BenchmarkU256AppendText(b *testing.B) {
+	buf := make([]byte, 0, 66)
+	for _, tc := range []struct {
+		name string
+		v    *uint256.Int
+	}{
+		{"small", uint256.NewInt(42)},
+		{"u64", uint256.NewInt(0x1234567890abcdef)},
+		{"full", new(uint256.Int).SetAllOne()},
+	} {
+		v := U256(*tc.v)
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				buf, _ = v.AppendText(buf[:0])
+			}
+		})
+	}
+}
+
 var unmarshalUint16Tests = []unmarshalTest{
 	// invalid encoding
 	{input: "", wantErr: errJSONEOF},

--- a/execution/tracing/tracers/logger/json_stream.go
+++ b/execution/tracing/tracers/logger/json_stream.go
@@ -94,6 +94,14 @@ func (l *JsonStreamLogger) hexWithPrefix(b []byte) string {
 	return common.ToStringZeroCopy(l.hexEncodeBuf[:2+n])
 }
 
+// hexQuoted encodes v as a complete JSON string, quotes included, so the caller
+// can hand it to WriteRaw in one call.
+func (l *JsonStreamLogger) hexQuoted(v *uint256.Int) string {
+	l.hexEncodeBuf[0] = '"'
+	b, _ := hexutil.U256(*v).AppendText(l.hexEncodeBuf[:1])
+	return common.ToStringZeroCopy(append(b, '"'))
+}
+
 // writeMemoryWordRaw writes a memory word as a JSON string "0x<hex>" directly
 // to the stream without any heap allocations. Pads to 32 bytes if needed.
 func (l *JsonStreamLogger) writeMemoryWordRaw(chunk []byte) {
@@ -205,11 +213,11 @@ func (l *JsonStreamLogger) OnOpcode(pc uint64, typ byte, gas, cost uint64, scope
 		l.stream.WriteMore()
 		l.stream.WriteObjectField("stack")
 		l.stream.WriteArrayStart()
-		for i, stackValue := range stack {
+		for i := range stack {
 			if i > 0 {
 				l.stream.WriteMore()
 			}
-			l.stream.WriteString(stackValue.Hex())
+			l.stream.WriteRaw(l.hexQuoted(&stack[i]))
 		}
 		l.stream.WriteArrayEnd()
 	}

--- a/execution/tracing/tracers/logger/json_stream.go
+++ b/execution/tracing/tracers/logger/json_stream.go
@@ -38,9 +38,11 @@ import (
 // a track record of modified storage which is used in reporting snapshots of the
 // contract their storage.
 type JsonStreamLogger struct {
-	ctx          context.Context
-	cfg          LogConfig
-	stream       jsonstream.Stream
+	ctx    context.Context
+	cfg    LogConfig
+	stream jsonstream.Stream
+	// Scratch for the hex helpers below. Every result aliases it, so only one is
+	// live at a time: hand it to the stream, which copies, before encoding the next.
 	hexEncodeBuf [128]byte
 	firstCapture bool
 	opcodeSteps  int // steps captured so far; executed-but-suppressed ones don't count
@@ -83,10 +85,7 @@ func (l *JsonStreamLogger) OnSystemCallStartV2(env *tracing.VMContext) {
 	l.env = env
 }
 
-// hexWithPrefix encodes b as a 0x-prefixed hex string using the internal buffer.
-// The result aliases hexEncodeBuf, so it is invalidated by anything that writes
-// that buffer, writeMemoryWordRaw included. Hand it straight to the stream,
-// which copies it in.
+// hexWithPrefix encodes b as a 0x-prefixed hex string using hexEncodeBuf.
 func (l *JsonStreamLogger) hexWithPrefix(b []byte) string {
 	l.hexEncodeBuf[0] = '0'
 	l.hexEncodeBuf[1] = 'x'
@@ -94,8 +93,7 @@ func (l *JsonStreamLogger) hexWithPrefix(b []byte) string {
 	return common.ToStringZeroCopy(l.hexEncodeBuf[:2+n])
 }
 
-// hexQuoted encodes v as a complete JSON string, quotes included, so the caller
-// can hand it to WriteRaw in one call.
+// hexQuoted encodes v as a complete JSON string, quotes included, for WriteRaw.
 func (l *JsonStreamLogger) hexQuoted(v *uint256.Int) string {
 	l.hexEncodeBuf[0] = '"'
 	b, _ := hexutil.U256(*v).AppendText(l.hexEncodeBuf[:1])

--- a/execution/tracing/tracers/logger/json_stream_test.go
+++ b/execution/tracing/tracers/logger/json_stream_test.go
@@ -549,6 +549,8 @@ func BenchmarkOnOpcodeStackDepth(b *testing.B) {
 			for b.Loop() {
 				l.OnOpcode(uint64(i), byte(vm.ADD), 100, 3, scope, nil, 1, nil)
 				i++
+				// Nothing else drains this stream, and every iteration appends to it.
+				_ = l.stream.Flush()
 			}
 		})
 	}
@@ -567,6 +569,7 @@ func BenchmarkStackValueWrite(b *testing.B) {
 			for i := range vals {
 				s.WriteString(vals[i].Hex())
 			}
+			_ = s.Flush()
 		}
 	})
 	b.Run("WriteRaw_hexQuoted", func(b *testing.B) {
@@ -576,6 +579,7 @@ func BenchmarkStackValueWrite(b *testing.B) {
 			for i := range vals {
 				l.stream.WriteRaw(l.hexQuoted(&vals[i]))
 			}
+			_ = l.stream.Flush()
 		}
 	})
 }

--- a/execution/tracing/tracers/logger/json_stream_test.go
+++ b/execution/tracing/tracers/logger/json_stream_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"math/big"
 	"strings"
@@ -510,4 +511,71 @@ func BenchmarkJsonStreamLogger_OnOpcode(b *testing.B) {
 		l.OnOpcode(uint64(i), byte(vm.SSTORE), 100, 3, scope, nil, 1, nil)
 		i++
 	}
+}
+
+// TestHexQuotedMatchesUint256Hex pins the stack encoding against uint256.Hex,
+// which the RPC output has to stay byte-identical to. The interesting cases are
+// the nibble boundaries: Hex counts nibbles, not bytes, so 0xf is one digit and
+// 0x10 is two.
+func TestHexQuotedMatchesUint256Hex(t *testing.T) {
+	l := &JsonStreamLogger{}
+	for _, str := range []string{
+		"0", "1", "f", "10", "ff", "100",
+		"1234567890abcdef",
+		"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+		"0000000000000000000000000000000000000000000000000000000000000001",
+		"8000000000000000000000000000000000000000000000000000000000000000",
+	} {
+		v := new(uint256.Int).SetBytes(common.FromHex("0x" + str))
+		require.Equal(t, `"`+v.Hex()+`"`, l.hexQuoted(v), "value 0x%s", str)
+	}
+}
+
+// BenchmarkOnOpcodeStackDepth shows the scaling: the saved allocation is per
+// stack slot per step, and a real trace is not two slots deep.
+func BenchmarkOnOpcodeStackDepth(b *testing.B) {
+	for _, depth := range []int{2, 8, 16, 32} {
+		b.Run(fmt.Sprintf("depth=%d", depth), func(b *testing.B) {
+			stack := make([]uint256.Int, depth)
+			for i := range stack {
+				stack[i].SetUint64(uint64(i)*0x0123456789abcdef + 1)
+			}
+			scope := &mockOpContext{memory: bytes.Repeat([]byte{0xab}, 256), stack: stack}
+			l := NewJsonStreamLogger(&LogConfig{}, context.Background(), jsonstream.New(io.Discard))
+			l.env = &tracing.VMContext{IntraBlockState: &mockIBS{}}
+
+			b.ReportAllocs()
+			i := 0
+			for b.Loop() {
+				l.OnOpcode(uint64(i), byte(vm.ADD), 100, 3, scope, nil, 1, nil)
+				i++
+			}
+		})
+	}
+}
+
+func BenchmarkStackValueWrite(b *testing.B) {
+	vals := make([]uint256.Int, 16)
+	for i := range vals {
+		vals[i].SetUint64(uint64(i)*0x0123456789abcdef + 1)
+	}
+
+	b.Run("WriteString_Hex", func(b *testing.B) {
+		s := jsonstream.New(io.Discard)
+		b.ReportAllocs()
+		for b.Loop() {
+			for i := range vals {
+				s.WriteString(vals[i].Hex())
+			}
+		}
+	})
+	b.Run("WriteRaw_hexQuoted", func(b *testing.B) {
+		l := &JsonStreamLogger{stream: jsonstream.New(io.Discard)}
+		b.ReportAllocs()
+		for b.Loop() {
+			for i := range vals {
+				l.stream.WriteRaw(l.hexQuoted(&vals[i]))
+			}
+		}
+	})
 }


### PR DESCRIPTION
`uint256.Int.Hex` allocates a 66-byte buffer and a string on every call, and `jsoniter.WriteString` then copies that a byte at a time, checking each one for escaping. A struct trace does both once per stack slot per step.

`hexQuoted` builds the whole JSON string, quotes included, in the logger's existing `hexEncodeBuf`, so `WriteRaw` appends it in one go — the shape `writeMemoryWordRaw` already uses for memory words.

```go
l.stream.WriteRaw(l.hexQuoted(&stack[i]))
```

`hexutil.U256.AppendText` encoded a nibble at a time, which at full width was slower than the allocating `Hex` it is meant to replace. It now uses `hex.Encode` at every size. Short values pay 1.7ns for that; a fast path below 8 nibbles recovers it but is not worth a second code path. Every `hexutil.U256` marshal gets this, not only the tracer.

```
go1.27.0 darwin/arm64
                        │   before     │                after                │
                        │   sec/op     │   sec/op     vs base                │
U256AppendText/small-16    3.727n ± 16%   5.415n ± 1%  +45.29% (p=0.002 n=6)
U256AppendText/u64-16     11.525n ±  1%   8.954n ± 1%  -22.31% (p=0.002 n=6)
U256AppendText/full-16     37.89n ± 15%   22.25n ± 1%  -41.27% (p=0.002 n=6)
geomean                    11.76n         10.26n       -12.80%
```

`BenchmarkOnOpcodeStackDepth`, with the benchmark flushing each iteration so the
numbers are not buffer growth:

```
go1.27.0 darwin/arm64
                               │   before     │                after                 │
                               │   sec/op     │   sec/op     vs base                 │
OnOpcodeStackDepth/depth=2-16     304.1n ± 0%   234.7n ± 14%  -22.83% (p=0.002 n=6)
OnOpcodeStackDepth/depth=8-16     781.1n ± 1%   459.5n ± 17%  -41.17% (p=0.002 n=6)
OnOpcodeStackDepth/depth=16-16   1443.0n ± 1%   572.8n ±  7%  -60.30% (p=0.002 n=6)
OnOpcodeStackDepth/depth=32-16   2819.5n ± 4%   919.5n ±  2%  -67.39% (p=0.002 n=6)
geomean                           991.5n        488.2n        -50.76%

                               │  allocs/op   │  allocs/op     vs base               │
OnOpcodeStackDepth/depth=2-16      2.000 ± 0%    0.000 ± 0%  -100.00% (p=0.002 n=6)
OnOpcodeStackDepth/depth=32-16     32.00 ± 0%     0.00 ± 0%  -100.00% (p=0.002 n=6)
```

Both halves matter independently: dropping the allocation alone is worth 8.5%, and appending in bulk instead of through `WriteString`'s per-byte loop is the rest.

## n5, real rpcdaemon on `mainnet36_full`

8 concurrent `debug_traceTransaction` against a transaction whose response is 29MB, 60s, with a 45s CPU profile:

| | main | this PR |
|---|---|---|
| `uint256.(*Int).Hex` | 31.23% cum | — |
| `hexQuoted`, incl. `AppendText` | — | 33.00% cum |
| `jsoniter.WriteString` | 28.60% cum | 5.31% cum |
| gc + malloc, flat | 5.59% | 0.02% |
| `debug_traceTransaction`/sec | 59.5 | 75.2 |

Two costs collapse into one: the hex encoding stops allocating a string per stack value, and the value no longer goes through `WriteString`'s per-byte escape loop. Together that is 59.83% of profiled CPU against 38.31%, and the garbage those strings produced disappears.

