### PR TITLE
execution/tracing: write traced storage values without escaping

### DIFF
--- a/execution/tracing/tracers/logger/json_stream.go
+++ b/execution/tracing/tracers/logger/json_stream.go
@@ -100,6 +100,16 @@ func (l *JsonStreamLogger) hexQuoted(v *uint256.Int) string {
 	return common.ToStringZeroCopy(append(b, '"'))
 }
 
+// hexQuotedBytes encodes b as a complete JSON string, quotes included, so the
+// caller can hand it to WriteRaw in one call. Same aliasing rule as
+// hexWithPrefix: hand it straight to the stream.
+func (l *JsonStreamLogger) hexQuotedBytes(b []byte) string {
+	l.hexEncodeBuf[0], l.hexEncodeBuf[1], l.hexEncodeBuf[2] = '"', '0', 'x'
+	n := hex.Encode(l.hexEncodeBuf[3:], b)
+	l.hexEncodeBuf[3+n] = '"'
+	return common.ToStringZeroCopy(l.hexEncodeBuf[:4+n])
+}
+
 // writeMemoryWordRaw writes a memory word as a JSON string "0x<hex>" directly
 // to the stream without any heap allocations. Pads to 32 bytes if needed.
 func (l *JsonStreamLogger) writeMemoryWordRaw(chunk []byte) {
@@ -251,15 +261,16 @@ func (l *JsonStreamLogger) OnOpcode(pc uint64, typ byte, gas, cost uint64, scope
 			l.locations = append(l.locations, loc)
 		}
 		l.locations.Sort()
-		for _, loc := range l.locations {
-			value := s[loc]
+		for i := range l.locations {
+			loc := &l.locations[i]
+			value := s[*loc]
 			if first {
 				first = false
 			} else {
 				l.stream.WriteMore()
 			}
 			l.stream.WriteObjectField(l.hexWithPrefix(loc[:]))
-			l.stream.WriteString(l.hexWithPrefix(value[:]))
+			l.stream.WriteRaw(l.hexQuotedBytes(value[:]))
 		}
 		l.stream.WriteObjectEnd()
 	}

--- a/execution/tracing/tracers/logger/json_stream.go
+++ b/execution/tracing/tracers/logger/json_stream.go
@@ -85,11 +85,12 @@ func (l *JsonStreamLogger) OnSystemCallStartV2(env *tracing.VMContext) {
 	l.env = env
 }
 
-// hexWithPrefix encodes b as a 0x-prefixed hex string using hexEncodeBuf.
-func (l *JsonStreamLogger) hexWithPrefix(b []byte) string {
+// hexWithPrefix encodes h into hexEncodeBuf as 0x-prefixed hex. It takes a hash
+// rather than a slice so the result is known to fit; the buffer is not resized.
+func (l *JsonStreamLogger) hexWithPrefix(h *common.Hash) string {
 	l.hexEncodeBuf[0] = '0'
 	l.hexEncodeBuf[1] = 'x'
-	n := hex.Encode(l.hexEncodeBuf[2:], b)
+	n := hex.Encode(l.hexEncodeBuf[2:], h[:])
 	return common.ToStringZeroCopy(l.hexEncodeBuf[:2+n])
 }
 
@@ -100,12 +101,10 @@ func (l *JsonStreamLogger) hexQuoted(v *uint256.Int) string {
 	return common.ToStringZeroCopy(append(b, '"'))
 }
 
-// hexQuotedBytes encodes b as a complete JSON string, quotes included, so the
-// caller can hand it to WriteRaw in one call. Same aliasing rule as
-// hexWithPrefix: hand it straight to the stream.
-func (l *JsonStreamLogger) hexQuotedBytes(b []byte) string {
+// hexQuotedHash is hexWithPrefix plus the quotes, ready for WriteRaw.
+func (l *JsonStreamLogger) hexQuotedHash(h *common.Hash) string {
 	l.hexEncodeBuf[0], l.hexEncodeBuf[1], l.hexEncodeBuf[2] = '"', '0', 'x'
-	n := hex.Encode(l.hexEncodeBuf[3:], b)
+	n := hex.Encode(l.hexEncodeBuf[3:], h[:])
 	l.hexEncodeBuf[3+n] = '"'
 	return common.ToStringZeroCopy(l.hexEncodeBuf[:4+n])
 }
@@ -269,8 +268,8 @@ func (l *JsonStreamLogger) OnOpcode(pc uint64, typ byte, gas, cost uint64, scope
 			} else {
 				l.stream.WriteMore()
 			}
-			l.stream.WriteObjectField(l.hexWithPrefix(loc[:]))
-			l.stream.WriteRaw(l.hexQuotedBytes(value[:]))
+			l.stream.WriteObjectField(l.hexWithPrefix(loc))
+			l.stream.WriteRaw(l.hexQuotedHash(&value))
 		}
 		l.stream.WriteObjectEnd()
 	}

--- a/execution/tracing/tracers/logger/json_stream.go
+++ b/execution/tracing/tracers/logger/json_stream.go
@@ -19,6 +19,8 @@ package logger
 import (
 	"context"
 	"encoding/hex"
+	"maps"
+	"slices"
 
 	"github.com/holiman/uint256"
 
@@ -250,24 +252,16 @@ func (l *JsonStreamLogger) OnOpcode(pc uint64, typ byte, gas, cost uint64, scope
 		l.stream.WriteMore()
 		l.stream.WriteObjectField("storage")
 		l.stream.WriteObjectStart()
-		first := true
-		// Sort storage by locations for easier comparison with geth
-		if l.locations != nil {
-			l.locations = l.locations[:0]
-		}
+		// Sorted by location for easier comparison with geth
 		s := l.storage[contractAddr]
-		for loc := range s {
-			l.locations = append(l.locations, loc)
-		}
+		l.locations = slices.AppendSeq(l.locations[:0], maps.Keys(s))
 		l.locations.Sort()
 		for i := range l.locations {
-			loc := &l.locations[i]
-			value := s[*loc]
-			if first {
-				first = false
-			} else {
+			if i > 0 {
 				l.stream.WriteMore()
 			}
+			loc := &l.locations[i]
+			value := s[*loc]
 			l.stream.WriteObjectField(l.hexWithPrefix(loc))
 			l.stream.WriteRaw(l.hexQuotedHash(&value))
 		}

--- a/execution/tracing/tracers/logger/json_stream_test.go
+++ b/execution/tracing/tracers/logger/json_stream_test.go
@@ -617,6 +617,8 @@ func BenchmarkOnOpcodeStorage(b *testing.B) {
 			for b.Loop() {
 				l.OnOpcode(uint64(i), byte(vm.SSTORE), 100, 3, scope, nil, 1, nil)
 				i++
+				// Nothing else drains this stream, and every iteration appends to it.
+				_ = l.stream.Flush()
 			}
 		})
 	}

--- a/execution/tracing/tracers/logger/json_stream_test.go
+++ b/execution/tracing/tracers/logger/json_stream_test.go
@@ -584,17 +584,17 @@ func BenchmarkStackValueWrite(b *testing.B) {
 	})
 }
 
-// TestHexQuotedBytesMatchesHexWithPrefix pins the pre-quoted form against the
+// TestHexQuotedHashMatchesHexWithPrefix pins the pre-quoted form against the
 // one WriteString produced, which the RPC output has to stay identical to.
-func TestHexQuotedBytesMatchesHexWithPrefix(t *testing.T) {
+func TestHexQuotedHashMatchesHexWithPrefix(t *testing.T) {
 	l := &JsonStreamLogger{}
-	for _, n := range []int{0, 1, 4, 20, 32} {
-		b := make([]byte, n)
-		for i := range b {
-			b[i] = byte(i*7 + 1)
+	for _, seed := range []int{0, 1, 7, 255} {
+		var h common.Hash
+		for i := range h {
+			h[i] = byte(i*seed + 1)
 		}
-		want := `"` + l.hexWithPrefix(b) + `"`
-		require.Equal(t, want, l.hexQuotedBytes(b), "len=%d", n)
+		want := `"` + l.hexWithPrefix(&h) + `"`
+		require.Equal(t, want, l.hexQuotedHash(&h), "seed=%d", seed)
 	}
 }
 

--- a/execution/tracing/tracers/logger/json_stream_test.go
+++ b/execution/tracing/tracers/logger/json_stream_test.go
@@ -583,3 +583,41 @@ func BenchmarkStackValueWrite(b *testing.B) {
 		}
 	})
 }
+
+// TestHexQuotedBytesMatchesHexWithPrefix pins the pre-quoted form against the
+// one WriteString produced, which the RPC output has to stay identical to.
+func TestHexQuotedBytesMatchesHexWithPrefix(t *testing.T) {
+	l := &JsonStreamLogger{}
+	for _, n := range []int{0, 1, 4, 20, 32} {
+		b := make([]byte, n)
+		for i := range b {
+			b[i] = byte(i*7 + 1)
+		}
+		want := `"` + l.hexWithPrefix(b) + `"`
+		require.Equal(t, want, l.hexQuotedBytes(b), "len=%d", n)
+	}
+}
+
+// BenchmarkOnOpcodeStorage covers the shape debug_traceTransaction takes by
+// default: two hex strings per touched slot, accumulating across steps.
+func BenchmarkOnOpcodeStorage(b *testing.B) {
+	for _, slots := range []int{1, 8, 32} {
+		b.Run(fmt.Sprintf("slots=%d", slots), func(b *testing.B) {
+			l := NewJsonStreamLogger(&LogConfig{}, context.Background(), jsonstream.New(io.Discard))
+			l.env = &tracing.VMContext{IntraBlockState: &mockIBS{}}
+			scope := &mockOpContext{}
+			for i := range slots {
+				key := common.BigToHash(big.NewInt(int64(i + 1)))
+				val := common.BigToHash(big.NewInt(int64(1000 + i)))
+				scope.stack = []uint256.Int{*new(uint256.Int).SetBytes(val[:]), *new(uint256.Int).SetBytes(key[:])}
+				l.OnOpcode(uint64(i), byte(vm.SSTORE), 100, 3, scope, nil, 1, nil)
+			}
+			b.ReportAllocs()
+			i := 0
+			for b.Loop() {
+				l.OnOpcode(uint64(i), byte(vm.SSTORE), 100, 3, scope, nil, 1, nil)
+				i++
+			}
+		})
+	}
+}


### PR DESCRIPTION
Based on #23486.

A traced storage slot writes two 66-character hex strings, and `jsoniter.WriteString` copies each a byte at a time, checking every byte for escaping. The value now goes out pre-quoted through `WriteRaw`, which appends in one go.

```
goos: darwin
goarch: arm64
pkg: github.com/erigontech/erigon/execution/tracing/tracers/logger
                              │   before    │                after                │
                              │   sec/op    │   sec/op     vs base                │
OnOpcodeStorage/slots=1-16      602.9n ± 2%   458.2n ± 2%  -23.99% (p=0.000 n=8)
OnOpcodeStorage/slots=8-16      3.082µ ± 2%   2.019µ ± 6%  -34.51% (p=0.000 n=8)
OnOpcodeStorage/slots=32-16    12.035µ ± 1%   7.727µ ± 3%  -35.80% (p=0.000 n=8)
geomean                         2.817µ        1.926µ       -31.63%
```



## n5

No measurable end-to-end effect on a `debug_traceTransaction` workload: the result sits inside the run-to-run spread on that box, which is about 8%. The benchmark above is the measurement to go by.
