### PR TITLE
rpc: count responses the client never received

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -333,7 +333,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Retry-After", "1")
 			w.WriteHeader(http.StatusServiceUnavailable)
 		}
-		stream.Flush()
+		if err := stream.Flush(); err != nil {
+			// The status is already sent, so this is the only place a truncated
+			// reply can show up.
+			undeliveredGauge.Inc()
+			if common.FastContextErr(ctx) != nil {
+				s.logger.Trace("rpc: client stopped reading", "url", r.URL.String())
+			} else {
+				s.logger.Warn("rpc: response not delivered", "url", r.URL.String(), "err", err)
+			}
+		}
 	}
 }
 

--- a/rpc/http_test.go
+++ b/rpc/http_test.go
@@ -22,6 +22,7 @@ package rpc
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -302,4 +303,36 @@ func TestOverloadedRequestGets503(t *testing.T) {
 			require.Contains(t, rec.Body.String(), ErrMsgServerOverloaded)
 		})
 	}
+}
+
+// hangUpWriter accepts headers, then fails every body write, standing in for a
+// client that goes away mid-response.
+type hangUpWriter struct {
+	header http.Header
+	status int
+}
+
+func (w *hangUpWriter) Header() http.Header { return w.header }
+func (w *hangUpWriter) WriteHeader(s int)   { w.status = s }
+func (w *hangUpWriter) Write([]byte) (int, error) {
+	return 0, errors.New("connection reset by peer")
+}
+
+// TestUndeliveredResponseIsCounted pins that a reply the client never received
+// is recorded. The status is already sent by then, so the counter is the only
+// place a truncated reply can show up.
+func TestUndeliveredResponseIsCounted(t *testing.T) {
+	srv := NewServer(50, false, false, false /* disableStreaming */, log.Root(), 100)
+	defer srv.Stop()
+	require.NoError(t, srv.RegisterName("test", new(testService)))
+
+	before := undeliveredGauge.GetValueUint64()
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"test_echo","params":["x",1]}`
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	srv.ServeHTTP(&hangUpWriter{header: make(http.Header)}, req)
+
+	require.Greater(t, undeliveredGauge.GetValueUint64(), before,
+		"a response the client never received was not recorded")
 }

--- a/rpc/metrics.go
+++ b/rpc/metrics.go
@@ -31,6 +31,9 @@ var (
 	rpcMetricsLabels   = map[bool]map[string]string{}
 	rpcRequestGauge    = metrics.GetOrCreateCounter("rpc_total")
 	failedReqeustGauge = metrics.GetOrCreateCounter("rpc_failure")
+	// A streamed response the client did not receive in full. Batch and
+	// non-streaming replies never touch the stream, so they are not counted.
+	undeliveredGauge = metrics.GetOrCreateCounter("rpc_undelivered_total")
 )
 
 // PreAllocateRPCMetricLabels pre-allocates labels for all rpc methods inside API List


### PR DESCRIPTION
Based on #23496.

A streamed reply that the client stopped reading was going entirely unrecorded: the status is already on the wire when the final `Flush` runs, so it cannot change, and the error was dropped.

The counter is unconditional. The log level is a hint rather than a determination: a client walking away is routine, a write failing while the request context is still live is not. Both branches were checked against a real disconnect, where `net/http` cancels the request context before the write error surfaces.

Known gap: batch and non-streaming replies go out through `conn.WriteJSON` and never touch the stream, so they are not counted.

