### PR TITLE
rpc/jsonstream, execution/tracing: fuzz that a cut-short trace still parses

### DIFF
--- a/execution/tracing/tracers/logger/json_stream_test.go
+++ b/execution/tracing/tracers/logger/json_stream_test.go
@@ -511,3 +511,113 @@ func BenchmarkJsonStreamLogger_OnOpcode(b *testing.B) {
 		i++
 	}
 }
+
+// fuzzPlan turns a fuzzer's bytes into a trace to emit. Every field is derived
+// rather than read directly so that any input produces a runnable plan.
+type fuzzPlan struct {
+	cfg      LogConfig
+	steps    int
+	stackLen int
+	memLen   int
+	rDataLen int
+	opCode   byte
+	withErr  bool
+	closeAt  int
+}
+
+func planFromSeed(seed []byte) fuzzPlan {
+	at := func(i int) int {
+		if len(seed) == 0 {
+			return 0
+		}
+		return int(seed[i%len(seed)])
+	}
+	p := fuzzPlan{
+		steps:    at(0) % 24,
+		stackLen: at(1) % 40,
+		memLen:   at(2) % 200,
+		rDataLen: at(3) % 40,
+		opCode:   byte(at(4)),
+		withErr:  at(5)&1 == 1,
+		closeAt:  at(6) % 4,
+	}
+	p.cfg = LogConfig{
+		EnableMemory:     at(7)&1 == 1,
+		DisableStack:     at(8)&1 == 1,
+		DisableStorage:   at(9)&1 == 1,
+		EnableReturnData: at(10)&1 == 1,
+		Limit:            at(11) % 8,
+	}
+	return p
+}
+
+// FuzzJsonStreamLoggerEmitsValidJSON drives the struct logger the way a trace
+// does and requires the result to parse. The interesting inputs are the ones
+// that stop early: a step limit, or a caller that closes the stream at a depth
+// it did not open, which is what happens when tracing is abandoned part way.
+func FuzzJsonStreamLoggerEmitsValidJSON(f *testing.F) {
+	for _, seed := range [][]byte{
+		{},
+		{5, 4, 64, 8, byte(vm.SSTORE), 0, 0, 0, 0, 0, 0, 0, 0},
+		{3, 2, 32, 0, byte(vm.MLOAD), 1, 1, 0, 0, 0, 1, 0, 0},
+		{9, 33, 199, 39, byte(vm.ADD), 1, 3, 1, 1, 1, 1, 1, 3},
+		{1, 0, 0, 0, byte(vm.STOP), 0, 2, 0, 0, 0, 0, 0, 1},
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, seed []byte) {
+		p := planFromSeed(seed)
+
+		var buf bytes.Buffer
+		stream := jsonstream.New(&buf)
+		l := NewJsonStreamLogger(&p.cfg, t.Context(), stream)
+		l.env = &tracing.VMContext{IntraBlockState: &mockIBS{}}
+
+		stack := make([]uint256.Int, p.stackLen)
+		for i := range stack {
+			stack[i].SetUint64(uint64(i)*0x0123456789abcdef + 1)
+		}
+		scope := &mockOpContext{memory: bytes.Repeat([]byte{0xab}, p.memLen), stack: stack}
+		rData := bytes.Repeat([]byte{0xcd}, p.rDataLen)
+
+		var opErr error
+		if p.withErr {
+			opErr = errors.New("execution reverted")
+		}
+		for i := range p.steps {
+			l.OnOpcode(uint64(i), p.opCode, 100, 3, scope, rData, 1, opErr)
+		}
+
+		// OnExit opens the envelope when nothing was captured, which is what the
+		// tracer always does before the RPC layer closes it.
+		l.OnExit(0, nil, 0, nil, false)
+
+		// Close the way the RPC layer does. Every route has to end at depth zero,
+		// but they get there differently: a finished trace closes what it opened,
+		// an abandoned one leans on ClosePending to repair it, and the error path
+		// closes back to the enclosing field first and finishes afterwards.
+		switch p.closeAt {
+		case 0:
+			stream.WriteArrayEnd()
+			stream.WriteObjectEnd()
+		case 1:
+			require.NoError(t, stream.ClosePending(0))
+		case 2:
+			require.NoError(t, stream.ClosePending(1))
+			require.NoError(t, stream.ClosePending(0))
+		default:
+			require.NoError(t, stream.ClosePending(uint(stream.Depth())))
+			require.NoError(t, stream.ClosePending(0))
+		}
+		require.NoError(t, stream.Flush())
+		require.Zero(t, stream.Depth(), "stream left open")
+
+		if buf.Len() == 0 {
+			return // nothing was emitted, nothing to parse
+		}
+		var out any
+		require.NoErrorf(t, json.Unmarshal(buf.Bytes(), &out),
+			"plan %+v produced invalid JSON: %s", p, buf.String())
+	})
+}

--- a/rpc/jsonstream/stack_stream_test.go
+++ b/rpc/jsonstream/stack_stream_test.go
@@ -17,12 +17,15 @@
 package jsonstream
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	jsoniter "github.com/json-iterator/go"
 )
@@ -1064,4 +1067,124 @@ func (w *failingWriter) Write(p []byte) (n int, err error) {
 	}
 	w.bytesWritten += len(p)
 	return len(p), nil
+}
+
+// jsonOp is one call a well-behaved producer could make. A plan is always a
+// structurally valid document; the fuzzer's job is to cut it short.
+type jsonOp uint8
+
+const (
+	opObjectStart jsonOp = iota
+	opObjectEnd
+	opArrayStart
+	opArrayEnd
+	opField
+	opString
+	opInt
+	opBool
+	opNil
+	opMore
+)
+
+// planDocument emits the ops for one valid JSON document, recursing until the
+// budget runs out so that a seed of any shape terminates.
+func planDocument(seed []byte, at *int, depth int, out *[]jsonOp) {
+	next := func() int {
+		if len(seed) == 0 {
+			return 0
+		}
+		v := int(seed[*at%len(seed)])
+		*at++
+		return v
+	}
+	if depth > 4 {
+		*out = append(*out, opString)
+		return
+	}
+	switch next() % 5 {
+	case 0:
+		*out = append(*out, opObjectStart)
+		for n := next() % 4; n > 0; n-- {
+			if (*out)[len(*out)-1] != opObjectStart {
+				*out = append(*out, opMore)
+			}
+			*out = append(*out, opField)
+			planDocument(seed, at, depth+1, out)
+		}
+		*out = append(*out, opObjectEnd)
+	case 1:
+		*out = append(*out, opArrayStart)
+		for n := next() % 4; n > 0; n-- {
+			if (*out)[len(*out)-1] != opArrayStart {
+				*out = append(*out, opMore)
+			}
+			planDocument(seed, at, depth+1, out)
+		}
+		*out = append(*out, opArrayEnd)
+	case 2:
+		*out = append(*out, opString)
+	case 3:
+		*out = append(*out, opInt)
+	default:
+		*out = append(*out, opBool)
+	}
+}
+
+// FuzzClosePendingAlwaysYieldsValidJSON pins the guarantee StackStream exists
+// for: a producer that stops part way through still leaves a document that
+// parses, because ClosePending fills and closes whatever was open.
+func FuzzClosePendingAlwaysYieldsValidJSON(f *testing.F) {
+	for _, seed := range [][]byte{
+		{}, {0, 2, 0, 1}, {1, 3, 2, 2, 2}, {0, 1, 0, 1, 1, 3},
+		{0, 3, 1, 2, 0, 2, 4, 4}, {4, 4, 4}, {0, 2, 1, 1, 3, 3},
+	} {
+		f.Add(seed, uint8(3))
+	}
+
+	f.Fuzz(func(t *testing.T, seed []byte, stopAfter uint8) {
+		var ops []jsonOp
+		at := 0
+		planDocument(seed, &at, 0, &ops)
+		if len(ops) == 0 {
+			return
+		}
+		cut := min(int(stopAfter), len(ops))
+
+		var buf bytes.Buffer
+		s := New(&buf).(*StackStream)
+		for _, op := range ops[:cut] {
+			switch op {
+			case opObjectStart:
+				s.WriteObjectStart()
+			case opObjectEnd:
+				s.WriteObjectEnd()
+			case opArrayStart:
+				s.WriteArrayStart()
+			case opArrayEnd:
+				s.WriteArrayEnd()
+			case opField:
+				s.WriteObjectField("k")
+			case opString:
+				s.WriteString("v")
+			case opInt:
+				s.WriteInt(7)
+			case opBool:
+				s.WriteBool(true)
+			case opNil:
+				s.WriteNil()
+			case opMore:
+				s.WriteMore()
+			}
+		}
+		require.NoError(t, s.ClosePending(0))
+		require.NoError(t, s.Flush())
+		require.Zero(t, s.Depth(), "stack left open: %s", s.StackSummary())
+
+		if buf.Len() == 0 {
+			return
+		}
+		var out any
+		require.NoErrorf(t, json.Unmarshal(buf.Bytes(), &out),
+			"ops %v cut at %d produced invalid JSON: %s", ops, cut, buf.String())
+	})
 }


### PR DESCRIPTION
A trace stops early for reasons the producer does not control: a step limit, a client that leaves, an error part way through a block. What it has already written is repaired by `ClosePending` rather than discarded, so the guarantee worth pinning is that any prefix of it still parses.

Two targets, both asserting `json.Unmarshal` succeeds and the stack is left empty.

`FuzzJsonStreamLoggerEmitsValidJSON` drives the struct logger over arbitrary configs, stack depths, memory sizes, return data and error injection, then closes by each of the routes the RPC layer takes: closing what it opened, repairing an abandoned trace with `ClosePending(0)`, and the error path that closes back to the enclosing field before finishing.

`FuzzClosePendingAlwaysYieldsValidJSON` builds a structurally valid document out of the seed, executes only the first N ops, and requires `ClosePending` to finish it. Generating a valid plan and then cutting it matters: a fuzzer emitting arbitrary calls would report failures for sequences no producer can make, since the stack repairs truncation rather than validating input.

Neither found a defect on main:

```
FuzzJsonStreamLoggerEmitsValidJSON    6,598,007 execs, 126 corpus entries
FuzzClosePendingAlwaysYieldsValidJSON 28,626,156 execs, 110 corpus entries
```

`go test` runs the seeds as ordinary cases, so the corpus is exercised on every CI run without fuzzing.
