### PR TITLE
execution/state/genesiswrite: drop the inert bor section from the genesis test fixture

### DIFF
--- a/execution/state/genesiswrite/genesis_test.json
+++ b/execution/state/genesiswrite/genesis_test.json
@@ -12,28 +12,7 @@
     "istanbulBlock": 0,
     "muirGlacierBlock": 0,
     "berlinBlock": 0,
-    "londonBlock": 20,
-    "bor": {
-      "jaipurBlock": 20,
-      "delhiBlock" :20,
-      "period": {
-        "0": 2
-      },
-      "producerDelay": {
-        "0": 4
-      },
-      "sprint": {
-        "0": 8
-      },
-      "backupMultiplier": {
-        "0": 1
-      },
-      "validatorContract": "0x0000000000000000000000000000000000001000",
-      "stateReceiverContract": "0x0000000000000000000000000000000000001001",
-      "burntContract": {
-        "0": "0x000000000000000000000000000000000000dead"
-      }
-    }
+    "londonBlock": 20
   },
   "nonce": "0x0",
   "timestamp": "0x5ce28211",


### PR DESCRIPTION
`genesis_test.json` carries a full Bor consensus block in its `config` — `jaipurBlock`, `delhiBlock`, `period`, `producerDelay`, `sprint`, `backupMultiplier`, `validatorContract`, `stateReceiverContract`, `burntContract`. Its only consumer is `TestDecodeBalance0`, which unmarshals the file into a `types.Genesis` to regression-test the balance decoding from #11264. `chain.Config` has no `Bor` field any more, so the section is silently dropped on decode and asserts nothing. Found while sweeping for leftovers after the Polygon removal series (#23503).

## Changes
- remove the `bor` object from `config` in `execution/state/genesiswrite/genesis_test.json`

The `alloc` entries are untouched, including `0x0000000000000000000000000000000000001000` and `0x...1001`. Those are the Bor validator and state-receiver contract addresses, but they are also the zero-balance rows the test exists to cover, so they stay.
