### PR TITLE
execution/state: skip the create-time storage wipe when the address has no account

### DIFF
--- a/execution/state/rw_v3.go
+++ b/execution/state/rw_v3.go
@@ -225,8 +225,22 @@ func (writes *WriteSet) Apply(domains *execctx.SharedDomains, roTx kv.TemporalTx
 
 			// Contract creation: clear stale storage before writing new account.
 			// Matches Writer.CreateContract which calls DomainDelPrefix.
+			//
+			// An address with no committed account holds no committed storage:
+			// storage is only written for an account that exists, and deleting
+			// an account wipes its storage prefix. So probe the account first —
+			// that read is served by the per-file existence filters, while the
+			// prefix walk has to seek the .bt index of every storage .kv file.
 			if d.createContract {
-				if err := domains.DomainDelPrefix(kv.StorageDomain, roTx, address[:], txNum); err != nil {
+				prevAcc, _, err := domains.GetLatest(kv.AccountsDomain, roTx, address[:])
+				if err != nil {
+					return err
+				}
+				if len(prevAcc) == 0 {
+					if err := assertNoCommittedStorage(domains, roTx, address[:]); err != nil {
+						return err
+					}
+				} else if err := domains.DomainDelPrefix(kv.StorageDomain, roTx, address[:], txNum); err != nil {
 					return err
 				}
 			}
@@ -817,6 +831,26 @@ func (w *Writer) SetPutDel(tx kv.TemporalPutDel) { w.tx = tx }
 
 func (w *Writer) PrevAndDels() (map[string][]byte, map[string]*accounts.Account, map[string][]byte, map[string]uint64) {
 	return nil, nil, nil, nil
+}
+
+// assertNoCommittedStorage panics when addr has committed storage but no
+// committed account, so a violation of that invariant surfaces instead of
+// silently skipping a storage wipe. No-op unless asserts are enabled.
+func assertNoCommittedStorage(domains *execctx.SharedDomains, roTx kv.TemporalTx, addr []byte) error {
+	if !dbg.AssertEnabled {
+		return nil
+	}
+	found := 0
+	if err := domains.IteratePrefix(kv.StorageDomain, addr, roTx, func(k, v []byte) (bool, error) {
+		found++
+		return false, nil
+	}); err != nil {
+		return err
+	}
+	if found > 0 {
+		panic(fmt.Sprintf("createContract: %x has storage but no account", addr))
+	}
+	return nil
 }
 
 func (w *Writer) UpdateAccountData(address accounts.Address, original, account *accounts.Account) error {

--- a/execution/state/rw_v3.go
+++ b/execution/state/rw_v3.go
@@ -224,7 +224,6 @@ func (writes *WriteSet) Apply(domains *execctx.SharedDomains, roTx kv.TemporalTx
 			}
 
 			// Contract creation: clear stale storage before writing new account.
-			// Matches Writer.CreateContract which calls DomainDelPrefix.
 			//
 			// An address with no committed account holds no committed storage:
 			// storage is only written for an account that exists, and deleting


### PR DESCRIPTION
`CREATE`/`CREATE2` wipes the target's storage prefix before writing the new account. `DomainDelPrefix` has to seek the `.bt` index of **every** storage `.kv` file (14-16 of them here) — cold random IO that costs the same whether the address has 20k slots or none. It has none for ~91% of creations.

An address with no committed account holds no committed storage: storage is only written for an account that exists, and deleting an account wipes its storage prefix. So probe the accounts domain first — that read is served by the per-file existence filters. A `dbg.AssertEnabled` check panics if the invariant is ever violated.

Measured on n5, mainnet from-0 replay at block ~11.9M (parallel exec, archive, 8-min windows):

| | per block |
|---|---|
| create-time prefix walk, before | 6784 us |
| after (account probe + remaining walks) | 43 us |

End-to-end over 6 interleaved runs with the A/B order balanced: +4% blocks/s, +6% Mgas/s. Both are inside the window-to-window drift (~8%), so treat the removed work above as the hard number.

For context, before this change 99.95% of all `IteratePrefix(StorageDomain)` calls returned zero keys and they cost 18.5 ms of a ~76 ms block. The remaining large source is the self-destruct cascade in `WriteSet.Normalize` (10.5 ms/block); it has no equivalent cheap oracle because 98.6% of self-destructed accounts do have code.
