### PR TITLE
[r3.6] execution/state: skip the create-time storage wipe when the address has no account

### DIFF
--- a/execution/state/rw_v3.go
+++ b/execution/state/rw_v3.go
@@ -211,8 +211,22 @@ func (rs *StateV3) applyVersionedWrites(roTx kv.TemporalTx, blockNum, txNum uint
 
 			// Contract creation: clear stale storage before writing new account.
 			// Matches Writer.CreateContract which calls DomainDelPrefix.
+			//
+			// An address with no committed account holds no committed storage:
+			// storage is only written for an account that exists, and deleting
+			// an account wipes its storage prefix. So probe the account first —
+			// that read is served by the per-file existence filters, while the
+			// prefix walk has to seek the .bt index of every storage .kv file.
 			if d.createContract {
-				if err := domains.DomainDelPrefix(kv.StorageDomain, roTx, address[:], txNum); err != nil {
+				prevAcc, _, err := domains.GetLatest(kv.AccountsDomain, roTx, address[:])
+				if err != nil {
+					return err
+				}
+				if len(prevAcc) == 0 {
+					if err := assertNoCommittedStorage(domains, roTx, address[:]); err != nil {
+						return err
+					}
+				} else if err := domains.DomainDelPrefix(kv.StorageDomain, roTx, address[:], txNum); err != nil {
 					return err
 				}
 			}
@@ -885,6 +899,26 @@ func (w *Writer) SetPutDel(tx kv.TemporalPutDel) { w.tx = tx }
 
 func (w *Writer) PrevAndDels() (map[string][]byte, map[string]*accounts.Account, map[string][]byte, map[string]uint64) {
 	return nil, nil, nil, nil
+}
+
+// assertNoCommittedStorage panics when addr has committed storage but no
+// committed account, so a violation of that invariant surfaces instead of
+// silently skipping a storage wipe. No-op unless asserts are enabled.
+func assertNoCommittedStorage(domains *execctx.SharedDomains, roTx kv.TemporalTx, addr []byte) error {
+	if !dbg.AssertEnabled {
+		return nil
+	}
+	found := 0
+	if err := domains.IteratePrefix(kv.StorageDomain, addr, roTx, func(k, v []byte) (bool, error) {
+		found++
+		return false, nil
+	}); err != nil {
+		return err
+	}
+	if found > 0 {
+		panic(fmt.Sprintf("createContract: %x has storage but no account", addr))
+	}
+	return nil
 }
 
 func (w *Writer) UpdateAccountData(address accounts.Address, original, account *accounts.Account) error {

--- a/execution/state/rw_v3.go
+++ b/execution/state/rw_v3.go
@@ -210,7 +210,6 @@ func (rs *StateV3) applyVersionedWrites(roTx kv.TemporalTx, blockNum, txNum uint
 			}
 
 			// Contract creation: clear stale storage before writing new account.
-			// Matches Writer.CreateContract which calls DomainDelPrefix.
 			//
 			// An address with no committed account holds no committed storage:
 			// storage is only written for an account that exists, and deleting


### PR DESCRIPTION
Cherry-pick of #23506 to release/3.6.
