### PR TITLE
[r3.6] txnprovider/txpool: load pool from db under p.lock

### DIFF
--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -2650,6 +2650,11 @@ func (p *TxPool) flushLocked(tx kv.RwTx) (err error) {
 }
 
 func (p *TxPool) fromDB(ctx context.Context, tx kv.Tx, coreTx kv.TemporalTx) error {
+	// The state-changes stream is already live when the pool loads, so OnNewBlock can
+	// write the same senders maps and sub-pools while this runs.
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
 	if p.lastSeenBlock.Load() == 0 {
 		lastSeenBlock, err := LastSeenBlock(tx)
 		if err != nil {

--- a/txnprovider/txpool/pool_test.go
+++ b/txnprovider/txpool/pool_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math"
 	"testing"
+	"time"
 
 	goethkzg "github.com/crate-crypto/go-eth-kzg"
 	"github.com/holiman/uint256"
@@ -2487,30 +2488,85 @@ func (p probeFeeCalculator) CurrentFees(*chain.Config, kv.Getter) (uint64, uint6
 	return 0, 0, 0, 0, nil
 }
 
-// The state-changes stream is consumed as soon as Run starts, so OnNewBlock can land
-// while start() is still loading. Both write p.senders, so the load must hold p.lock.
+// Run starts the state-changes goroutine before start(), so OnNewBlock can land while
+// the pool is still loading. Both write p.senders, so the load must hold p.lock.
 func TestFromDBLoadsUnderPoolLock(t *testing.T) {
 	req := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
+	logger := log.New()
 	coreDB := temporaltest.NewTestDB(t, datadir.New(t.TempDir()))
 	poolDB := memdb.NewTestPoolDB(t)
 
+	const senderCount = 2_000
+	testAddr := func(i int) (addr common.Address) {
+		addr[0], addr[1] = byte(i), byte(i>>8)
+		return addr
+	}
+	acc := accounts3.Account{Nonce: 1, Balance: *uint256.NewInt(1 * common.Ether), CodeHash: accounts.EmptyCodeHash}
+	accData := accounts3.SerialiseV3(&acc)
+	changes := make([]*remoteproto.AccountChange, senderCount)
+	for i := range changes {
+		changes[i] = &remoteproto.AccountChange{
+			Action:  remoteproto.Action_UPSERT,
+			Address: gointerfaces.ConvertAddressToH160(testAddr(i)),
+			Data:    accData,
+		}
+	}
+	block := &remoteproto.StateChangeBatch{
+		PendingBlockBaseFee: 1_000_000,
+		BlockGasLimit:       1_000_000,
+		ChangeBatch: []*remoteproto.StateChange{{
+			BlockHeight: 0,
+			BlockHash:   gointerfaces.ConvertHashToH256([32]byte{}),
+			Changes:     changes,
+		}},
+	}
+
 	var pool *TxPool
 	var lockHeld bool
+	var onNewBlockErr error
+	onNewBlockDone := make(chan struct{})
+
 	probe := probeFeeCalculator{fn: func() {
+		// fromDB is half way through the load here.
 		if pool.lock.TryLock() {
 			pool.lock.Unlock()
-			return
+		} else {
+			lockHeld = true
 		}
-		lockHeld = true
+
+		go func() {
+			defer close(onNewBlockDone)
+			onNewBlockErr = pool.OnNewBlock(ctx, block, TxnSlots{}, TxnSlots{}, TxnSlots{})
+		}()
+
+		// Write the senders maps from the loading goroutine, spread out so the writes
+		// overlap the ones OnNewBlock makes. Unlocked that is an unsynchronised map
+		// write pair, which -race reports and the Go runtime aborts on. Locked,
+		// OnNewBlock cannot start yet, so the window closes on the deadline instead.
+		deadline := time.After(200 * time.Millisecond)
+		for i := 0; i < senderCount; i++ {
+			pool.senders.getOrCreateID(testAddr(i), logger)
+			select {
+			case <-onNewBlockDone:
+				return
+			case <-deadline:
+				return
+			default:
+			}
+			time.Sleep(20 * time.Microsecond)
+		}
 	}}
 
 	pool, err := New(ctx, make(chan Announcements, 100), poolDB, coreDB, txpoolcfg.DefaultConfig,
 		kvcache.New(kvcache.DefaultCoherentConfig), chain.AllProtocolChanges, nil, nil, func() {}, nil, nil,
-		log.New(), WithFeeCalculator(probe))
+		logger, WithFeeCalculator(probe))
 	req.NoError(err)
 	req.NoError(pool.start(ctx))
+
+	<-onNewBlockDone
+	req.NoError(onNewBlockErr)
 	req.True(lockHeld, "fromDB must hold p.lock while it populates the pool")
 }

--- a/txnprovider/txpool/pool_test.go
+++ b/txnprovider/txpool/pool_test.go
@@ -2478,3 +2478,39 @@ func TestQueuedTxnPromotedAfterStaleAddLocal(t *testing.T) {
 	asrt.Equal(1, pending, "queued tx must be promoted after re-evaluation")
 	asrt.Equal(0, queued, "queued must be empty after promotion")
 }
+
+// probeFeeCalculator runs fn from the middle of fromDB, where CurrentFees is called.
+type probeFeeCalculator struct{ fn func() }
+
+func (p probeFeeCalculator) CurrentFees(*chain.Config, kv.Getter) (uint64, uint64, uint64, uint64, error) {
+	p.fn()
+	return 0, 0, 0, 0, nil
+}
+
+// The state-changes stream is consumed as soon as Run starts, so OnNewBlock can land
+// while start() is still loading. Both write p.senders, so the load must hold p.lock.
+func TestFromDBLoadsUnderPoolLock(t *testing.T) {
+	req := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	coreDB := temporaltest.NewTestDB(t, datadir.New(t.TempDir()))
+	poolDB := memdb.NewTestPoolDB(t)
+
+	var pool *TxPool
+	var lockHeld bool
+	probe := probeFeeCalculator{fn: func() {
+		if pool.lock.TryLock() {
+			pool.lock.Unlock()
+			return
+		}
+		lockHeld = true
+	}}
+
+	pool, err := New(ctx, make(chan Announcements, 100), poolDB, coreDB, txpoolcfg.DefaultConfig,
+		kvcache.New(kvcache.DefaultCoherentConfig), chain.AllProtocolChanges, nil, nil, func() {}, nil, nil,
+		log.New(), WithFeeCalculator(probe))
+	req.NoError(err)
+	req.NoError(pool.start(ctx))
+	req.True(lockHeld, "fromDB must hold p.lock while it populates the pool")
+}

--- a/txnprovider/txpool/pool_test.go
+++ b/txnprovider/txpool/pool_test.go
@@ -2547,7 +2547,7 @@ func TestFromDBLoadsUnderPoolLock(t *testing.T) {
 		// write pair, which -race reports and the Go runtime aborts on. Locked,
 		// OnNewBlock cannot start yet, so the window closes on the deadline instead.
 		deadline := time.After(200 * time.Millisecond)
-		for i := 0; i < senderCount; i++ {
+		for i := range senderCount {
 			pool.senders.getOrCreateID(testAddr(i), logger)
 			select {
 			case <-onNewBlockDone:


### PR DESCRIPTION
Fixes `fatal error: concurrent map read and map write` in `sendersBatch.getOrCreateID` (#23509) by loading the pool under `p.lock`.

`TxPool.Run` starts the state-changes goroutine (`p2pFetcher.ConnectCore()`) before `p.start(ctx)`, but `fromDB` mutated `p.senders.senderIDs` / `senderID2Addr`, the sub-pools and `senderLastActivity` without taking `p.lock`. A block arriving during startup runs `OnNewBlock` -> `senders.onNewBlock` -> `getOrCreateID`, which reads and writes the same maps under the lock.

Lock order is unchanged: `start()` already holds the `poolDB` RoTx before `p.lock`, which is the order `best()` documents.

Closes #23509

Test: `TestFromDBLoadsUnderPoolLock` drives `OnNewBlock` from inside the load window, so without the lock `-race` reports the exact stack from #23509. Ported from #23511.
