### PR TITLE
[r3.6] execution/stagedsync: cover the create-time storage wipe

### DIFF
--- a/execution/stagedsync/exec3_2cache_test.go
+++ b/execution/stagedsync/exec3_2cache_test.go
@@ -221,3 +221,44 @@ func TestNotifyAccumulatorFromVersionedWrites(t *testing.T) {
 	require.Equal(t, storageVal.Bytes(), changes[0].Changes[0].StorageChanges[0].Data,
 		"ChangeStorage must populate StorageChange.Data")
 }
+
+// A CREATE landing on an address that already holds committed storage must wipe
+// that storage before the new account is written, or the recreated contract
+// inherits slots from its predecessor. Pins the apply-side wipe itself: the
+// suite previously passed with `if d.createContract` disabled outright, so
+// nothing guarded the account-present branch of that clear.
+func TestApplyStateWritesCreateContractWipesCommittedStorage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires mdbx")
+	}
+
+	tx, domains := setup2CacheTest(t)
+	rs := state.NewStateV3Buffered(state.NewStateV3(domains, false, log.New()))
+
+	addr := accounts.InternAddress(common.HexToAddress("0xc0ffee"))
+	addrVal := addr.Value()
+	seed := accounts.Account{Nonce: 1, Balance: *uint256.NewInt(7)}
+	require.NoError(t, domains.DomainPut(kv.AccountsDomain, tx, addrVal[:], accounts.SerialiseV3(&seed), 0, nil))
+
+	slotVal := common.HexToHash("0x01")
+	composite := append(append([]byte{}, addrVal[:]...), slotVal[:]...)
+	require.NoError(t, domains.DomainPut(kv.StorageDomain, tx, composite, []byte{0xaa}, 0, nil))
+
+	countSlots := func() int {
+		n := 0
+		require.NoError(t, domains.IteratePrefix(kv.StorageDomain, addrVal[:], tx, func(k, v []byte) (bool, error) {
+			n++
+			return true, nil
+		}))
+		return n
+	}
+	require.Equal(t, 1, countSlots(), "seeded storage must be visible before the create")
+
+	writes := newWS().
+		createContract(addr, state.Version{}, true).
+		nonce(addr, state.Version{}, 1).
+		build()
+	require.NoError(t, rs.ApplyStateWrites(context.Background(), tx, 1, 100, writes, nil, &chain.Rules{}, nil))
+
+	require.Zero(t, countSlots(), "CREATE over an existing account must clear its committed storage")
+}


### PR DESCRIPTION
Cherry-pick of #23513 to release/3.6.

## r3.6-specific adaptations

`exec3_apply_writes_test.go` does not exist on this branch, so the test lands in `exec3_2cache_test.go`, next to `setup2CacheTest`.
