### PR TITLE
[r3.6] execution/stagedsync: COMMITMENT_AFTER_EXEC flag to serialize commitment behind execution

### DIFF
--- a/common/dbg/experiments.go
+++ b/common/dbg/experiments.go
@@ -124,7 +124,12 @@ var (
 	// BALShadowCompute (requires BALDrivenCommitment) also computes each
 	// BAL-driven block incrementally and asserts both roots match before
 	// publishing; without it the BAL-driven root is published directly.
-	BALShadowCompute     = EnvBool("BAL_SHADOW_COMPUTE", false)
+	BALShadowCompute = EnvBool("BAL_SHADOW_COMPUTE", false)
+	// CommitmentAfterExec makes the exec loop wait for the commitment
+	// calculator to finish block N before starting N+1, so the two never
+	// contend for SharedDomains.changesetMu. Diagnostic: it trades the
+	// exec/commitment overlap for the absence of that contention.
+	CommitmentAfterExec  = EnvBool("COMMITMENT_AFTER_EXEC", false)
 	CaplinEfficientReorg = EnvBool("CAPLIN_EFFICIENT_REORG", true)
 	UseTxDependencies    = EnvBool("USE_TX_DEPENDENCIES", false)
 	UseStateCache        = EnvBool("USE_STATE_CACHE", true)

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -210,6 +210,11 @@ func (cc *commitmentCalculator) markProcessed(blockNum uint64) {
 // calculator stops, or ctx is cancelled. It is the COMMITMENT_AFTER_EXEC
 // barrier: with it the exec loop never runs a block alongside a commitment.
 func (cc *commitmentCalculator) WaitProcessed(ctx context.Context, blockNum uint64) error {
+	if cc.in == nil {
+		// No commit stream: loop() never runs, so nothing ever marks a block
+		// processed and every escape below is unreachable.
+		return nil
+	}
 	for {
 		cc.processedMu.Lock()
 		reached := cc.processedThrough >= blockNum

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -185,6 +185,47 @@ type commitmentCalculator struct {
 
 	wg   sync.WaitGroup
 	done chan struct{}
+
+	// processedThrough is the highest block whose blockResult the calculator
+	// has fully handled (computed or merely accumulated). processedWake is
+	// closed and replaced on every advance so waiters can select on it.
+	processedMu      sync.Mutex
+	processedThrough uint64
+	processedWake    chan struct{}
+}
+
+// markProcessed publishes that blockNum's blockResult is fully handled.
+func (cc *commitmentCalculator) markProcessed(blockNum uint64) {
+	cc.processedMu.Lock()
+	defer cc.processedMu.Unlock()
+	if blockNum <= cc.processedThrough {
+		return
+	}
+	cc.processedThrough = blockNum
+	close(cc.processedWake)
+	cc.processedWake = make(chan struct{})
+}
+
+// WaitProcessed blocks until the calculator has handled blockNum, the
+// calculator stops, or ctx is cancelled. It is the COMMITMENT_AFTER_EXEC
+// barrier: with it the exec loop never runs a block alongside a commitment.
+func (cc *commitmentCalculator) WaitProcessed(ctx context.Context, blockNum uint64) error {
+	for {
+		cc.processedMu.Lock()
+		reached := cc.processedThrough >= blockNum
+		wake := cc.processedWake
+		cc.processedMu.Unlock()
+		if reached {
+			return nil
+		}
+		select {
+		case <-wake:
+		case <-cc.done:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 }
 
 func newCommitmentCalculator(
@@ -249,6 +290,7 @@ func newCommitmentCalculator(
 		forcePerBlockCompute: forcePerBlockCompute,
 		perBlockFrom:         perBlockFrom,
 		done:                 make(chan struct{}),
+		processedWake:        make(chan struct{}),
 	}, nil
 }
 
@@ -430,6 +472,7 @@ func (cc *commitmentCalculator) handleMessage(ctx context.Context, msg applyResu
 		delete(cc.foldedAhead, r.BlockNum)
 		delete(cc.balRoots, r.BlockNum)
 		cc.maybeFoldAhead(ctx, r.BlockNum+1)
+		cc.markProcessed(r.BlockNum)
 
 	case *commitComputeRequest:
 		// Explicit compute signal from the apply loop at batch boundary.

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1238,7 +1238,7 @@ func (pe *parallelExecutor) execLoop(ctx context.Context) (err error) {
 				}
 
 				if dbg.CommitmentAfterExec && pe.calculator != nil {
-					if err := pe.calculator.WaitProcessed(ctx, blockResult.BlockNum); err != nil {
+					if err := pe.calculator.WaitProcessed(commitmentBarrierCtx(ctx, terminal), blockResult.BlockNum); err != nil {
 						return err
 					}
 				}
@@ -1372,6 +1372,18 @@ func (pe *parallelExecutor) processRequest(ctx context.Context, execRequest *exe
 	}
 
 	return nil
+}
+
+// commitmentBarrierCtx returns the context the COMMITMENT_AFTER_EXEC barrier
+// waits on. On a terminal block the stopCause is already published, so ctx is
+// cancelled: waiting on it would return before triggerBatchCommitment and drop
+// the batch-end commitment. The blockResult was sent with mustDeliver, so the
+// calculator always reaches markProcessed and the wait still ends.
+func commitmentBarrierCtx(ctx context.Context, terminal bool) context.Context {
+	if terminal {
+		return context.WithoutCancel(ctx)
+	}
+	return ctx
 }
 
 // applyLoopMissingBlocks returns the blockNums in txResultBlocks that

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -108,7 +108,9 @@ type parallelExecutor struct {
 	// calculator to drain.
 	applyResultsCh  chan applyResult
 	commitResultsCh chan applyResult
-	maxBlockNum     uint64 // set before execLoop; exec loop exits when reached
+	// calculator is read-only for the exec loop: the COMMITMENT_AFTER_EXEC barrier.
+	calculator  *commitmentCalculator
+	maxBlockNum uint64 // set before execLoop; exec loop exits when reached
 	// accumulator for txpool state-diff notifications; set before execLoop
 	// starts so that AuRa system-call nonce changes are emitted per block.
 	accumulator *shards.Accumulator
@@ -346,6 +348,7 @@ func (pe *parallelExecutor) execImpl(ctx context.Context, execStage *StageState,
 	if err != nil {
 		return nil, nil, err
 	}
+	pe.calculator = calculator
 	calculator.Start(ctx)
 	defer calculator.Stop()
 
@@ -1232,6 +1235,12 @@ func (pe *parallelExecutor) execLoop(ctx context.Context) (err error) {
 				// and cancelling would join context.Canceled onto the reported error.
 				if blockResult.Err != nil {
 					return nil
+				}
+
+				if dbg.CommitmentAfterExec && pe.calculator != nil {
+					if err := pe.calculator.WaitProcessed(ctx, blockResult.BlockNum); err != nil {
+						return err
+					}
 				}
 
 				pe.Lock()

--- a/execution/stagedsync/exec3_parallel_robustness_test.go
+++ b/execution/stagedsync/exec3_parallel_robustness_test.go
@@ -1196,3 +1196,44 @@ func TestWrapAsExecAbort_PreservesOriginError(t *testing.T) {
 		})
 	}
 }
+
+// TestCommitmentBarrierCtxSurvivesTerminalCancel pins the barrier's context
+// choice. The terminal stop publishes the stopCause — cancelling the exec-loop
+// ctx — before the exec loop reaches the COMMITMENT_AFTER_EXEC barrier, so a
+// barrier that waits on that ctx returns immediately and the loop errors out
+// before triggerBatchCommitment. That silently drops the batch-end commitment:
+// state flushes for the whole range while the commitment domain stays at the
+// previous boundary.
+func TestCommitmentBarrierCtxSurvivesTerminalCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.Error(t, commitmentBarrierCtx(ctx, false).Err(),
+		"non-terminal blocks must still abort the barrier on cancellation")
+	require.NoError(t, commitmentBarrierCtx(ctx, true).Err(),
+		"terminal blocks must wait past the stopCause so triggerBatchCommitment still runs")
+}
+
+// TestWaitProcessedWithoutCommitStreamReturns covers a nil commit stream: the
+// calculator is assigned but has no input, so its loop never
+// runs and nothing ever calls markProcessed. Every escape in WaitProcessed is
+// then unreachable — processedWake is never closed, done needs Stop() (deferred
+// behind the parked exec loop) and ctx needs the terminal stop — so the barrier
+// must not wait at all.
+func TestWaitProcessedWithoutCommitStreamReturns(t *testing.T) {
+	cc := &commitmentCalculator{
+		in:            nil,
+		done:          make(chan struct{}),
+		processedWake: make(chan struct{}),
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cc.WaitProcessed(context.Background(), 1) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitProcessed parked with no commit stream: nothing can ever mark a block processed")
+	}
+}


### PR DESCRIPTION
Cherry-pick of #23515 to release/3.6.

## r3.6-specific adaptations

- `exec3_parallel.go` has no `completeBlock` on 3.6; the barrier goes inline in the exec loop at the same point (after `sendResult` + the `blockResult.Err` early return).
- `committer.go` names differ: `maybeFoldAhead` / `r.BlockNum` instead of `maybeComputeAhead` / `blockNum`.