### PR TITLE
db/etl: store sortable-buffer bytes in chunks so filling never reallocates

### DIFF
--- a/db/etl/buffers.go
+++ b/db/etl/buffers.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"math/bits"
 	"slices"
 	"sort"
 	"strconv"
@@ -123,9 +124,49 @@ var (
 	_ Buffer = &oldestEntrySortableBuffer{}
 )
 
-// Bytes live in chunks of 1<<chunkShift rather than one slice, so filling a
-// buffer never reallocates and copies what is already stored.
-const chunkShift = 20 // 1MB
+// Bytes live in chunks rather than one slice, so filling a buffer never
+// reallocates and copies what is already stored.
+var chunkShift = chunkShiftOf(dbg.EnvDataSize("ETL_CHUNK", 1*datasize.MB))
+
+// chunkShiftOf rounds size up to a power of two, bounded to [4KB, 1GB]: outside
+// that an offset degenerates to one chunk per entry, or overflows int32.
+func chunkShiftOf(size datasize.ByteSize) uint {
+	s := max(min(int(size), 1<<30), 1<<12)
+	return uint(bits.Len(uint(s - 1)))
+}
+
+// chunkPool recycles full-size chunks across buffers.
+var chunkPool = sync.Pool{
+	New: func() any {
+		c := make([]byte, 1<<chunkShift)
+		return &c
+	},
+}
+
+// etlChunkPoolWarm chunks are seeded at startup so the first buffers to fill do
+// not pay for the allocation.
+var etlChunkPoolWarm = dbg.EnvInt("ETL_CHUNK_POOL_WARM", 64)
+
+func init() {
+	for range etlChunkPoolWarm {
+		c := make([]byte, 1<<chunkShift)
+		chunkPool.Put(&c)
+	}
+}
+
+// getChunk returns size bytes, pooled when size is the standard chunk.
+func getChunk(size int) []byte {
+	if size != 1<<chunkShift {
+		return make([]byte, size)
+	}
+	return *chunkPool.Get().(*[]byte)
+}
+
+func putChunk(c []byte) {
+	if len(c) == 1<<chunkShift {
+		chunkPool.Put(&c)
+	}
+}
 
 // entryLoc locates a key/value pair. offset is global: chunk index is
 // offset>>chunkShift, position within it offset&mask. keyLen/valLen -1 is nil.
@@ -181,7 +222,7 @@ func (b *sortableBuffer) reserve(n int) int {
 		// Start the wide chunk past every chunk already allocated, so that
 		// offset>>chunkShift addresses it rather than a narrow chunk.
 		span := (n + size - 1) / size * size
-		c := make([]byte, span)
+		c := getChunk(span)
 		off := len(b.chunks) * size
 		for range span / size {
 			b.chunks = append(b.chunks, c)
@@ -193,7 +234,7 @@ func (b *sortableBuffer) reserve(n int) int {
 		b.next += size - pos
 	}
 	for len(b.chunks)*size < b.next+max(n, 1) {
-		b.chunks = append(b.chunks, make([]byte, size))
+		b.chunks = append(b.chunks, getChunk(size))
 	}
 	off := b.next
 	b.next += n
@@ -268,13 +309,18 @@ func (b *sortableBuffer) Prealloc(predictKeysAmount, predictDataSize int) Buffer
 		b.entries = make([]entryLoc, 0, predictKeysAmount)
 	}
 	for len(b.chunks)*b.chunkSize() < predictDataSize {
-		b.chunks = append(b.chunks, make([]byte, b.chunkSize()))
+		b.chunks = append(b.chunks, getChunk(b.chunkSize()))
 	}
 	return b
 }
 
 func (b *sortableBuffer) Reset() {
 	b.entries = b.entries[:0]
+	for i, c := range b.chunks {
+		putChunk(c)
+		b.chunks[i] = nil
+	}
+	b.chunks = b.chunks[:0]
 	b.next = 0
 	b.dataLen = 0
 }

--- a/db/etl/buffers.go
+++ b/db/etl/buffers.go
@@ -44,7 +44,7 @@ const (
 	//BufIOSize - 128 pages | default is 1 page | increasing over `64 * 4096` doesn't show speedup on SSD/NVMe, but show speedup in cloud drives
 	BufIOSize = 128 * 4096
 
-	entryLocSize = 16 // sizeof(entryLoc): insertionOrder(4) + offset(4) + keyLen(4) + valLen(4)
+	entryLocSize = 20 // sizeof(entryLoc): insertionOrder(4) + chunk(4) + offset(4) + keyLen(4) + valLen(4)
 )
 
 // writeSortedEntries writes buffer entries to w in varint-length-prefixed format.
@@ -123,11 +123,17 @@ var (
 	_ Buffer = &oldestEntrySortableBuffer{}
 )
 
-// entryLoc stores the location of a key/value pair within sortableBuffer.data.
-// Key occupies data[offset : offset+keyLen], value follows at data[offset+max(0,keyLen) : ...+valLen].
-// keyLen/valLen of -1 indicates nil.
+// etlChunkSize is the granularity sortableBuffer grows by. A buffer holds its
+// bytes in chunks of this size instead of one slice, so filling it never
+// reallocates and copies what is already stored.
+var etlChunkSize = int(dbg.EnvDataSize("ETL_CHUNK", 1*datasize.MB))
+
+// entryLoc stores the location of a key/value pair within one sortableBuffer chunk.
+// Key occupies chunk[offset : offset+keyLen], value follows at chunk[offset+max(0,keyLen) : ...+valLen].
+// keyLen/valLen of -1 indicates nil. An entry never spans two chunks.
 type entryLoc struct {
 	insertionOrder int32 // enables stable sort via unstable SortFunc
+	chunk          int32
 	offset         int32
 	keyLen         int32
 	valLen         int32
@@ -139,20 +145,47 @@ func NewSortableBuffer(bufferOptimalSize datasize.ByteSize) *sortableBuffer {
 	}
 	return &sortableBuffer{
 		optimalSize: int(bufferOptimalSize.Bytes()),
+		chunkSize:   etlChunkSize,
 	}
 }
 
 type sortableBuffer struct {
 	entries     []entryLoc
-	data        []byte
+	chunks      [][]byte
+	cur         int // index in chunks currently being filled
+	dataLen     int
 	optimalSize int
+	chunkSize   int
+}
+
+// reserve returns the index of a chunk with room for n more bytes, allocating
+// or advancing as needed. A partly-filled chunk is abandoned rather than split,
+// so an entry is always contiguous.
+func (b *sortableBuffer) reserve(n int) int {
+	if b.chunkSize <= 0 {
+		b.chunkSize = etlChunkSize
+	}
+	for b.cur < len(b.chunks) {
+		c := b.chunks[b.cur]
+		if cap(c)-len(c) >= n {
+			return b.cur
+		}
+		b.cur++
+	}
+	size := max(b.chunkSize, n)
+	b.chunks = append(b.chunks, make([]byte, 0, size))
+	b.cur = len(b.chunks) - 1
+	return b.cur
 }
 
 // Put adds key and value to the buffer. These slices will not be accessed later,
 // so no copying is necessary
 func (b *sortableBuffer) Put(k, v []byte) {
+	ci := b.reserve(len(k) + len(v))
+	c := b.chunks[ci]
 	e := entryLoc{
-		offset:         int32(len(b.data)),    //nolint:gosec
+		chunk:          int32(ci),             //nolint:gosec
+		offset:         int32(len(c)),         //nolint:gosec
 		keyLen:         int32(len(k)),         //nolint:gosec
 		valLen:         int32(len(v)),         //nolint:gosec
 		insertionOrder: int32(len(b.entries)), //nolint:gosec
@@ -164,10 +197,11 @@ func (b *sortableBuffer) Put(k, v []byte) {
 		e.valLen = -1
 	}
 	b.entries = append(b.entries, e)
-	b.data = append(append(b.data, k...), v...)
+	b.chunks[ci] = append(append(c, k...), v...)
+	b.dataLen += len(k) + len(v)
 }
 
-func (b *sortableBuffer) Size() int { return len(b.data) + len(b.entries)*entryLocSize }
+func (b *sortableBuffer) Size() int { return b.dataLen + len(b.entries)*entryLocSize }
 
 func (b *sortableBuffer) Len() int {
 	return len(b.entries)
@@ -183,12 +217,12 @@ func (b *sortableBuffer) Get(i int) ([]byte, []byte) {
 	}
 	var key, val []byte
 	if kLen > 0 {
-		key = b.data[keyOffset : keyOffset+kLen]
+		key = b.chunks[e.chunk][keyOffset : keyOffset+kLen]
 	} else if kLen == 0 {
 		key = []byte{}
 	}
 	if vLen > 0 {
-		val = b.data[valOffset : valOffset+vLen]
+		val = b.chunks[e.chunk][valOffset : valOffset+vLen]
 	} else if vLen == 0 {
 		val = []byte{}
 	}
@@ -199,26 +233,38 @@ func (b *sortableBuffer) Prealloc(predictKeysAmount, predictDataSize int) Buffer
 	if cap(b.entries) < predictKeysAmount {
 		b.entries = make([]entryLoc, 0, predictKeysAmount)
 	}
-	if cap(b.data) < predictDataSize {
-		b.data = make([]byte, 0, predictDataSize)
+	if b.chunkSize <= 0 {
+		b.chunkSize = etlChunkSize
+	}
+	var have int
+	for _, c := range b.chunks {
+		have += cap(c)
+	}
+	for have < predictDataSize {
+		b.chunks = append(b.chunks, make([]byte, 0, b.chunkSize))
+		have += b.chunkSize
 	}
 	return b
 }
 
 func (b *sortableBuffer) Reset() {
 	b.entries = b.entries[:0]
-	b.data = b.data[:0]
+	for i := range b.chunks {
+		b.chunks[i] = b.chunks[i][:0]
+	}
+	b.cur = 0
+	b.dataLen = 0
 }
 func (b *sortableBuffer) SizeLimit() int { return b.optimalSize }
 func (b *sortableBuffer) Sort() {
-	data := b.data
-	cmp := func(a, b entryLoc) int {
-		aKey := data[a.offset : a.offset+max(a.keyLen, 0)]
-		bKey := data[b.offset : b.offset+max(b.keyLen, 0)]
+	chunks := b.chunks
+	cmp := func(x, y entryLoc) int {
+		aKey := chunks[x.chunk][x.offset : x.offset+max(x.keyLen, 0)]
+		bKey := chunks[y.chunk][y.offset : y.offset+max(y.keyLen, 0)]
 		if c := bytes.Compare(aKey, bKey); c != 0 {
 			return c
 		}
-		return int(a.insertionOrder - b.insertionOrder) // StableSort: preserve insertion order for duplicate keys
+		return int(x.insertionOrder - y.insertionOrder) // StableSort: preserve insertion order for duplicate keys
 	}
 	if slices.IsSortedFunc(b.entries, cmp) {
 		return
@@ -246,7 +292,7 @@ func (b *sortableBuffer) Write(w io.Writer) error {
 			return err
 		}
 		if kLen > 0 {
-			if _, err := w.Write(b.data[keyOffset : keyOffset+kLen]); err != nil {
+			if _, err := w.Write(b.chunks[e.chunk][keyOffset : keyOffset+kLen]); err != nil {
 				return err
 			}
 		}
@@ -256,7 +302,7 @@ func (b *sortableBuffer) Write(w io.Writer) error {
 			return err
 		}
 		if vLen > 0 {
-			if _, err := w.Write(b.data[valOffset : valOffset+vLen]); err != nil {
+			if _, err := w.Write(b.chunks[e.chunk][valOffset : valOffset+vLen]); err != nil {
 				return err
 			}
 		}

--- a/db/etl/buffers.go
+++ b/db/etl/buffers.go
@@ -123,15 +123,9 @@ var (
 	_ Buffer = &oldestEntrySortableBuffer{}
 )
 
-// Bytes live in chunks rather than one slice, so filling a buffer never
-// reallocates and copies what is already stored.
-var etlChunkShift = clampChunkShift(dbg.EnvInt("ETL_CHUNK_SHIFT", 20)) // 1MB
-
-// clampChunkShift bounds the chunk to [4KB, 1GB] — outside that an offset
-// either degenerates to one chunk per entry or overflows int32.
-func clampChunkShift(v int) uint {
-	return uint(min(max(v, 12), 30))
-}
+// Bytes live in chunks of 1<<chunkShift rather than one slice, so filling a
+// buffer never reallocates and copies what is already stored.
+const chunkShift = 20 // 1MB
 
 // entryLoc locates a key/value pair. offset is global: chunk index is
 // offset>>chunkShift, position within it offset&mask. keyLen/valLen -1 is nil.
@@ -157,8 +151,8 @@ func NewSortableBuffer(bufferOptimalSize datasize.ByteSize) *sortableBuffer {
 	}
 	return &sortableBuffer{
 		optimalSize: int(bufferOptimalSize.Bytes()),
-		chunkShift:  etlChunkShift,
-		chunkMask:   1<<etlChunkShift - 1,
+		chunkShift:  chunkShift,
+		chunkMask:   1<<chunkShift - 1,
 	}
 }
 

--- a/db/etl/buffers.go
+++ b/db/etl/buffers.go
@@ -166,6 +166,9 @@ type entryLoc struct {
 // keyPrefixOf packs the first 8 key bytes big-endian, zero-padded, so comparing
 // prefixes as uint64 orders them the same as comparing the bytes.
 func keyPrefixOf(k []byte) uint64 {
+	if len(k) >= 8 {
+		return binary.BigEndian.Uint64(k)
+	}
 	var buf [8]byte
 	copy(buf[:], k)
 	return binary.BigEndian.Uint64(buf[:])

--- a/db/etl/buffers.go
+++ b/db/etl/buffers.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"math/bits"
 	"slices"
 	"sort"
 	"strconv"
@@ -126,19 +125,12 @@ var (
 
 // Bytes live in chunks rather than one slice, so filling a buffer never
 // reallocates and copies what is already stored.
-var chunkShift = chunkShiftOf(dbg.EnvDataSize("ETL_CHUNK", 1*datasize.MB))
-
-// chunkShiftOf rounds size up to a power of two, bounded to [4KB, 1GB]: outside
-// that an offset degenerates to one chunk per entry, or overflows int32.
-func chunkShiftOf(size datasize.ByteSize) uint {
-	s := max(min(int(size), 1<<30), 1<<12)
-	return uint(bits.Len(uint(s - 1)))
-}
+const chunkSize = 1 << 20 // 1MB
 
 // chunkPool recycles full-size chunks across buffers.
 var chunkPool = sync.Pool{
 	New: func() any {
-		c := make([]byte, 1<<chunkShift)
+		c := make([]byte, chunkSize)
 		return &c
 	},
 }
@@ -149,27 +141,27 @@ var etlChunkPoolWarm = dbg.EnvInt("ETL_CHUNK_POOL_WARM", 64)
 
 func init() {
 	for range etlChunkPoolWarm {
-		c := make([]byte, 1<<chunkShift)
+		c := make([]byte, chunkSize)
 		chunkPool.Put(&c)
 	}
 }
 
 // getChunk returns size bytes, pooled when size is the standard chunk.
 func getChunk(size int) []byte {
-	if size != 1<<chunkShift {
+	if size != chunkSize {
 		return make([]byte, size)
 	}
 	return *chunkPool.Get().(*[]byte)
 }
 
 func putChunk(c []byte) {
-	if len(c) == 1<<chunkShift {
+	if len(c) == chunkSize {
 		chunkPool.Put(&c)
 	}
 }
 
 // entryLoc locates a key/value pair. offset is global: chunk index is
-// offset>>chunkShift, position within it offset&mask. keyLen/valLen -1 is nil.
+// offset/chunkSize, position within it offset%chunkSize. keyLen/valLen -1 is nil.
 type entryLoc struct {
 	insertionOrder int32 // enables stable sort via unstable SortFunc
 	offset         int32
@@ -192,8 +184,6 @@ func NewSortableBuffer(bufferOptimalSize datasize.ByteSize) *sortableBuffer {
 	}
 	return &sortableBuffer{
 		optimalSize: int(bufferOptimalSize.Bytes()),
-		chunkShift:  chunkShift,
-		chunkMask:   1<<chunkShift - 1,
 	}
 }
 
@@ -203,38 +193,28 @@ type sortableBuffer struct {
 	next        int // global offset of the next free byte
 	dataLen     int
 	optimalSize int
-	chunkShift  uint
-	chunkMask   int
-}
-
-func (b *sortableBuffer) chunkSize() int { return 1 << b.chunkShift }
-
-// setChunkShift keeps chunkMask in step with chunkShift.
-func (b *sortableBuffer) setChunkShift(shift uint) {
-	b.chunkShift, b.chunkMask = shift, 1<<shift-1
 }
 
 // reserve returns the offset of n contiguous free bytes. An entry never spans
 // chunks; one wider than a chunk gets its own, filling the slots it covers.
 func (b *sortableBuffer) reserve(n int) int {
-	size := b.chunkSize()
-	if n > size {
+	if n > chunkSize {
 		// Start the wide chunk past every chunk already allocated, so that
-		// offset>>chunkShift addresses it rather than a narrow chunk.
-		span := (n + size - 1) / size * size
+		// offset/chunkSize addresses it rather than a narrow chunk.
+		span := (n + chunkSize - 1) / chunkSize * chunkSize
 		c := getChunk(span)
-		off := len(b.chunks) * size
-		for range span / size {
+		off := len(b.chunks) * chunkSize
+		for range span / chunkSize {
 			b.chunks = append(b.chunks, c)
 		}
 		b.next = off + span
 		return off
 	}
-	if pos := b.next & (size - 1); pos+n > size {
-		b.next += size - pos
+	if pos := b.next % chunkSize; pos+n > chunkSize {
+		b.next += chunkSize - pos
 	}
-	for len(b.chunks)*size < b.next+max(n, 1) {
-		b.chunks = append(b.chunks, getChunk(size))
+	for len(b.chunks)*chunkSize < b.next+max(n, 1) {
+		b.chunks = append(b.chunks, getChunk(chunkSize))
 	}
 	off := b.next
 	b.next += n
@@ -249,7 +229,7 @@ func (b *sortableBuffer) at(offset, length int) []byte {
 // locate resolves an offset to its chunk and the position within it. A key and
 // its value share a chunk, so callers resolve once and slice both.
 func (b *sortableBuffer) locate(offset int) ([]byte, int) {
-	return b.chunks[offset>>b.chunkShift], offset & b.chunkMask
+	return b.chunks[offset/chunkSize], offset % chunkSize
 }
 
 // Put adds key and value to the buffer. These slices will not be accessed later,
@@ -308,8 +288,8 @@ func (b *sortableBuffer) Prealloc(predictKeysAmount, predictDataSize int) Buffer
 	if cap(b.entries) < predictKeysAmount {
 		b.entries = make([]entryLoc, 0, predictKeysAmount)
 	}
-	for len(b.chunks)*b.chunkSize() < predictDataSize {
-		b.chunks = append(b.chunks, getChunk(b.chunkSize()))
+	for len(b.chunks)*chunkSize < predictDataSize {
+		b.chunks = append(b.chunks, getChunk(chunkSize))
 	}
 	return b
 }

--- a/db/etl/buffers.go
+++ b/db/etl/buffers.go
@@ -123,11 +123,8 @@ var (
 	_ Buffer = &oldestEntrySortableBuffer{}
 )
 
-// Bytes live in chunks rather than one slice, so filling a buffer never
-// reallocates and copies what is already stored.
-const chunkSize = 1 << 20 // 1MB
+var chunkSize = int(dbg.EnvDataSize("ETL_CHUNK", 1*datasize.MB))
 
-// chunkPool recycles full-size chunks across buffers.
 var chunkPool = sync.Pool{
 	New: func() any {
 		c := make([]byte, chunkSize)
@@ -135,18 +132,15 @@ var chunkPool = sync.Pool{
 	},
 }
 
-// etlChunkPoolWarm chunks are seeded at startup so the first buffers to fill do
-// not pay for the allocation.
-var etlChunkPoolWarm = dbg.EnvInt("ETL_CHUNK_POOL_WARM", 64)
+var chunkPoolWarm = dbg.EnvInt("ETL_CHUNK_POOL_WARM", 64)
 
 func init() {
-	for range etlChunkPoolWarm {
+	for range chunkPoolWarm {
 		c := make([]byte, chunkSize)
 		chunkPool.Put(&c)
 	}
 }
 
-// getChunk returns size bytes, pooled when size is the standard chunk.
 func getChunk(size int) []byte {
 	if size != chunkSize {
 		return make([]byte, size)
@@ -160,8 +154,7 @@ func putChunk(c []byte) {
 	}
 }
 
-// entryLoc locates a key/value pair. offset is global: chunk index is
-// offset/chunkSize, position within it offset%chunkSize. keyLen/valLen -1 is nil.
+// entryLoc locates a key/value pair. keyLen/valLen of -1 means a nil slice.
 type entryLoc struct {
 	insertionOrder int32 // enables stable sort via unstable SortFunc
 	offset         int32
@@ -196,11 +189,11 @@ type sortableBuffer struct {
 }
 
 // reserve returns the offset of n contiguous free bytes. An entry never spans
-// chunks; one wider than a chunk gets its own, filling the slots it covers.
+// chunks, so the tail of a chunk that cannot hold it is skipped.
 func (b *sortableBuffer) reserve(n int) int {
 	if n > chunkSize {
-		// Start the wide chunk past every chunk already allocated, so that
-		// offset/chunkSize addresses it rather than a narrow chunk.
+		// Past every allocated chunk, so offset/chunkSize finds this wide one
+		// and not a narrow chunk that cannot hold n.
 		span := (n + chunkSize - 1) / chunkSize * chunkSize
 		c := getChunk(span)
 		off := len(b.chunks) * chunkSize
@@ -226,8 +219,7 @@ func (b *sortableBuffer) at(offset, length int) []byte {
 	return c[pos : pos+length]
 }
 
-// locate resolves an offset to its chunk and the position within it. A key and
-// its value share a chunk, so callers resolve once and slice both.
+// A key and its value always share a chunk, so callers locate once and slice both.
 func (b *sortableBuffer) locate(offset int) ([]byte, int) {
 	return b.chunks[offset/chunkSize], offset % chunkSize
 }

--- a/db/etl/buffers.go
+++ b/db/etl/buffers.go
@@ -44,7 +44,7 @@ const (
 	//BufIOSize - 128 pages | default is 1 page | increasing over `64 * 4096` doesn't show speedup on SSD/NVMe, but show speedup in cloud drives
 	BufIOSize = 128 * 4096
 
-	entryLocSize = 20 // sizeof(entryLoc): insertionOrder(4) + chunk(4) + offset(4) + keyLen(4) + valLen(4)
+	entryLocSize = 24 // sizeof(entryLoc): insertionOrder(4) + offset(4) + keyLen(4) + valLen(4) + keyPrefix(8)
 )
 
 // writeSortedEntries writes buffer entries to w in varint-length-prefixed format.
@@ -123,20 +123,32 @@ var (
 	_ Buffer = &oldestEntrySortableBuffer{}
 )
 
-// etlChunkSize is the granularity sortableBuffer grows by. A buffer holds its
-// bytes in chunks of this size instead of one slice, so filling it never
+// Bytes live in chunks rather than one slice, so filling a buffer never
 // reallocates and copies what is already stored.
-var etlChunkSize = int(dbg.EnvDataSize("ETL_CHUNK", 1*datasize.MB))
+var etlChunkShift = clampChunkShift(dbg.EnvInt("ETL_CHUNK_SHIFT", 20)) // 1MB
 
-// entryLoc stores the location of a key/value pair within one sortableBuffer chunk.
-// Key occupies chunk[offset : offset+keyLen], value follows at chunk[offset+max(0,keyLen) : ...+valLen].
-// keyLen/valLen of -1 indicates nil. An entry never spans two chunks.
+// clampChunkShift bounds the chunk to [4KB, 1GB] — outside that an offset
+// either degenerates to one chunk per entry or overflows int32.
+func clampChunkShift(v int) uint {
+	return uint(min(max(v, 12), 30))
+}
+
+// entryLoc locates a key/value pair. offset is global: chunk index is
+// offset>>chunkShift, position within it offset&mask. keyLen/valLen -1 is nil.
 type entryLoc struct {
 	insertionOrder int32 // enables stable sort via unstable SortFunc
-	chunk          int32
 	offset         int32
 	keyLen         int32
 	valLen         int32
+	keyPrefix      uint64 // see keyPrefixOf
+}
+
+// keyPrefixOf packs the first 8 key bytes big-endian, zero-padded, so comparing
+// prefixes as uint64 orders them the same as comparing the bytes.
+func keyPrefixOf(k []byte) uint64 {
+	var buf [8]byte
+	copy(buf[:], k)
+	return binary.BigEndian.Uint64(buf[:])
 }
 
 func NewSortableBuffer(bufferOptimalSize datasize.ByteSize) *sortableBuffer {
@@ -145,50 +157,60 @@ func NewSortableBuffer(bufferOptimalSize datasize.ByteSize) *sortableBuffer {
 	}
 	return &sortableBuffer{
 		optimalSize: int(bufferOptimalSize.Bytes()),
-		chunkSize:   etlChunkSize,
+		chunkShift:  etlChunkShift,
 	}
 }
 
 type sortableBuffer struct {
 	entries     []entryLoc
 	chunks      [][]byte
-	cur         int // index in chunks currently being filled
+	next        int // global offset of the next free byte
 	dataLen     int
 	optimalSize int
-	chunkSize   int
+	chunkShift  uint
 }
 
-// reserve returns the index of a chunk with room for n more bytes, allocating
-// or advancing as needed. A partly-filled chunk is abandoned rather than split,
-// so an entry is always contiguous.
+func (b *sortableBuffer) chunkSize() int { return 1 << b.chunkShift }
+
+// reserve returns the offset of n contiguous free bytes. An entry never spans
+// chunks; one wider than a chunk gets its own, filling the slots it covers.
 func (b *sortableBuffer) reserve(n int) int {
-	if b.chunkSize <= 0 {
-		b.chunkSize = etlChunkSize
+	size := b.chunkSize()
+	if pos := b.next & (size - 1); pos != 0 && pos+n > size {
+		b.next += size - pos
 	}
-	for b.cur < len(b.chunks) {
-		c := b.chunks[b.cur]
-		if cap(c)-len(c) >= n {
-			return b.cur
+	span := (max(n, 1) + size - 1) / size * size
+	for len(b.chunks)*size < b.next+max(n, 1) {
+		c := make([]byte, span)
+		for range span / size {
+			b.chunks = append(b.chunks, c)
 		}
-		b.cur++
 	}
-	size := max(b.chunkSize, n)
-	b.chunks = append(b.chunks, make([]byte, 0, size))
-	b.cur = len(b.chunks) - 1
-	return b.cur
+	off := b.next
+	if n > size {
+		b.next = off + span
+	} else {
+		b.next = off + n
+	}
+	return off
+}
+
+func (b *sortableBuffer) at(offset, length int) []byte {
+	c := b.chunks[offset>>b.chunkShift]
+	pos := offset & (b.chunkSize() - 1)
+	return c[pos : pos+length]
 }
 
 // Put adds key and value to the buffer. These slices will not be accessed later,
 // so no copying is necessary
 func (b *sortableBuffer) Put(k, v []byte) {
-	ci := b.reserve(len(k) + len(v))
-	c := b.chunks[ci]
+	off := b.reserve(len(k) + len(v))
 	e := entryLoc{
-		chunk:          int32(ci),             //nolint:gosec
-		offset:         int32(len(c)),         //nolint:gosec
+		offset:         int32(off),            //nolint:gosec
 		keyLen:         int32(len(k)),         //nolint:gosec
 		valLen:         int32(len(v)),         //nolint:gosec
 		insertionOrder: int32(len(b.entries)), //nolint:gosec
+		keyPrefix:      keyPrefixOf(k),
 	}
 	if k == nil {
 		e.keyLen = -1
@@ -197,7 +219,8 @@ func (b *sortableBuffer) Put(k, v []byte) {
 		e.valLen = -1
 	}
 	b.entries = append(b.entries, e)
-	b.chunks[ci] = append(append(c, k...), v...)
+	copy(b.at(off, len(k)), k)
+	copy(b.at(off+len(k), len(v)), v)
 	b.dataLen += len(k) + len(v)
 }
 
@@ -217,12 +240,12 @@ func (b *sortableBuffer) Get(i int) ([]byte, []byte) {
 	}
 	var key, val []byte
 	if kLen > 0 {
-		key = b.chunks[e.chunk][keyOffset : keyOffset+kLen]
+		key = b.at(keyOffset, kLen)
 	} else if kLen == 0 {
 		key = []byte{}
 	}
 	if vLen > 0 {
-		val = b.chunks[e.chunk][valOffset : valOffset+vLen]
+		val = b.at(valOffset, vLen)
 	} else if vLen == 0 {
 		val = []byte{}
 	}
@@ -233,35 +256,29 @@ func (b *sortableBuffer) Prealloc(predictKeysAmount, predictDataSize int) Buffer
 	if cap(b.entries) < predictKeysAmount {
 		b.entries = make([]entryLoc, 0, predictKeysAmount)
 	}
-	if b.chunkSize <= 0 {
-		b.chunkSize = etlChunkSize
-	}
-	var have int
-	for _, c := range b.chunks {
-		have += cap(c)
-	}
-	for have < predictDataSize {
-		b.chunks = append(b.chunks, make([]byte, 0, b.chunkSize))
-		have += b.chunkSize
+	for len(b.chunks)*b.chunkSize() < predictDataSize {
+		b.chunks = append(b.chunks, make([]byte, b.chunkSize()))
 	}
 	return b
 }
 
 func (b *sortableBuffer) Reset() {
 	b.entries = b.entries[:0]
-	for i := range b.chunks {
-		b.chunks[i] = b.chunks[i][:0]
-	}
-	b.cur = 0
+	b.next = 0
 	b.dataLen = 0
 }
 func (b *sortableBuffer) SizeLimit() int { return b.optimalSize }
 func (b *sortableBuffer) Sort() {
-	chunks := b.chunks
 	cmp := func(x, y entryLoc) int {
-		aKey := chunks[x.chunk][x.offset : x.offset+max(x.keyLen, 0)]
-		bKey := chunks[y.chunk][y.offset : y.offset+max(y.keyLen, 0)]
-		if c := bytes.Compare(aKey, bKey); c != 0 {
+		if x.keyPrefix != y.keyPrefix {
+			if x.keyPrefix < y.keyPrefix {
+				return -1
+			}
+			return 1
+		}
+		xKey := b.at(int(x.offset), int(max(x.keyLen, 0)))
+		yKey := b.at(int(y.offset), int(max(y.keyLen, 0)))
+		if c := bytes.Compare(xKey, yKey); c != 0 {
 			return c
 		}
 		return int(x.insertionOrder - y.insertionOrder) // StableSort: preserve insertion order for duplicate keys
@@ -292,7 +309,7 @@ func (b *sortableBuffer) Write(w io.Writer) error {
 			return err
 		}
 		if kLen > 0 {
-			if _, err := w.Write(b.chunks[e.chunk][keyOffset : keyOffset+kLen]); err != nil {
+			if _, err := w.Write(b.at(keyOffset, kLen)); err != nil {
 				return err
 			}
 		}
@@ -302,7 +319,7 @@ func (b *sortableBuffer) Write(w io.Writer) error {
 			return err
 		}
 		if vLen > 0 {
-			if _, err := w.Write(b.chunks[e.chunk][valOffset : valOffset+vLen]); err != nil {
+			if _, err := w.Write(b.at(valOffset, vLen)); err != nil {
 				return err
 			}
 		}

--- a/db/etl/buffers.go
+++ b/db/etl/buffers.go
@@ -158,6 +158,7 @@ func NewSortableBuffer(bufferOptimalSize datasize.ByteSize) *sortableBuffer {
 	return &sortableBuffer{
 		optimalSize: int(bufferOptimalSize.Bytes()),
 		chunkShift:  etlChunkShift,
+		chunkMask:   1<<etlChunkShift - 1,
 	}
 }
 
@@ -168,9 +169,15 @@ type sortableBuffer struct {
 	dataLen     int
 	optimalSize int
 	chunkShift  uint
+	chunkMask   int
 }
 
 func (b *sortableBuffer) chunkSize() int { return 1 << b.chunkShift }
+
+// setChunkShift keeps chunkMask in step with chunkShift.
+func (b *sortableBuffer) setChunkShift(shift uint) {
+	b.chunkShift, b.chunkMask = shift, 1<<shift-1
+}
 
 // reserve returns the offset of n contiguous free bytes. An entry never spans
 // chunks; one wider than a chunk gets its own, filling the slots it covers.
@@ -200,9 +207,14 @@ func (b *sortableBuffer) reserve(n int) int {
 }
 
 func (b *sortableBuffer) at(offset, length int) []byte {
-	c := b.chunks[offset>>b.chunkShift]
-	pos := offset & (b.chunkSize() - 1)
+	c, pos := b.locate(offset)
 	return c[pos : pos+length]
+}
+
+// locate resolves an offset to its chunk and the position within it. A key and
+// its value share a chunk, so callers resolve once and slice both.
+func (b *sortableBuffer) locate(offset int) ([]byte, int) {
+	return b.chunks[offset>>b.chunkShift], offset & b.chunkMask
 }
 
 // Put adds key and value to the buffer. These slices will not be accessed later,
@@ -223,8 +235,9 @@ func (b *sortableBuffer) Put(k, v []byte) {
 		e.valLen = -1
 	}
 	b.entries = append(b.entries, e)
-	copy(b.at(off, len(k)), k)
-	copy(b.at(off+len(k), len(v)), v)
+	c, pos := b.locate(off)
+	copy(c[pos:], k)
+	copy(c[pos+len(k):], v)
 	b.dataLen += len(k) + len(v)
 }
 
@@ -237,19 +250,19 @@ func (b *sortableBuffer) Len() int {
 func (b *sortableBuffer) Get(i int) ([]byte, []byte) {
 	e := &b.entries[i]
 	kLen, vLen := int(e.keyLen), int(e.valLen)
-	keyOffset := int(e.offset)
-	valOffset := keyOffset
+	c, pos := b.locate(int(e.offset))
+	valPos := pos
 	if kLen > 0 {
-		valOffset += kLen
+		valPos += kLen
 	}
 	var key, val []byte
 	if kLen > 0 {
-		key = b.at(keyOffset, kLen)
+		key = c[pos : pos+kLen]
 	} else if kLen == 0 {
 		key = []byte{}
 	}
 	if vLen > 0 {
-		val = b.at(valOffset, vLen)
+		val = c[valPos : valPos+vLen]
 	} else if vLen == 0 {
 		val = []byte{}
 	}
@@ -280,8 +293,10 @@ func (b *sortableBuffer) Sort() {
 			}
 			return 1
 		}
-		xKey := b.at(int(x.offset), int(max(x.keyLen, 0)))
-		yKey := b.at(int(y.offset), int(max(y.keyLen, 0)))
+		xc, xp := b.locate(int(x.offset))
+		yc, yp := b.locate(int(y.offset))
+		xKey := xc[xp : xp+int(max(x.keyLen, 0))]
+		yKey := yc[yp : yp+int(max(y.keyLen, 0))]
 		if c := bytes.Compare(xKey, yKey); c != 0 {
 			return c
 		}

--- a/db/etl/buffers.go
+++ b/db/etl/buffers.go
@@ -176,22 +176,26 @@ func (b *sortableBuffer) chunkSize() int { return 1 << b.chunkShift }
 // chunks; one wider than a chunk gets its own, filling the slots it covers.
 func (b *sortableBuffer) reserve(n int) int {
 	size := b.chunkSize()
-	if pos := b.next & (size - 1); pos != 0 && pos+n > size {
-		b.next += size - pos
-	}
-	span := (max(n, 1) + size - 1) / size * size
-	for len(b.chunks)*size < b.next+max(n, 1) {
+	if n > size {
+		// Start the wide chunk past every chunk already allocated, so that
+		// offset>>chunkShift addresses it rather than a narrow chunk.
+		span := (n + size - 1) / size * size
 		c := make([]byte, span)
+		off := len(b.chunks) * size
 		for range span / size {
 			b.chunks = append(b.chunks, c)
 		}
+		b.next = off + span
+		return off
+	}
+	if pos := b.next & (size - 1); pos+n > size {
+		b.next += size - pos
+	}
+	for len(b.chunks)*size < b.next+max(n, 1) {
+		b.chunks = append(b.chunks, make([]byte, size))
 	}
 	off := b.next
-	if n > size {
-		b.next = off + span
-	} else {
-		b.next = off + n
-	}
+	b.next += n
 	return off
 }
 

--- a/db/etl/buffers.go
+++ b/db/etl/buffers.go
@@ -214,11 +214,6 @@ func (b *sortableBuffer) reserve(n int) int {
 	return off
 }
 
-func (b *sortableBuffer) at(offset, length int) []byte {
-	c, pos := b.locate(offset)
-	return c[pos : pos+length]
-}
-
 // A key and its value always share a chunk, so callers locate once and slice both.
 func (b *sortableBuffer) locate(offset int) ([]byte, int) {
 	return b.chunks[offset/chunkSize], offset % chunkSize
@@ -329,10 +324,10 @@ func (b *sortableBuffer) Write(w io.Writer) error {
 	for i := range b.entries {
 		e := &b.entries[i]
 		kLen, vLen := int(e.keyLen), int(e.valLen)
-		keyOffset := int(e.offset)
-		valOffset := keyOffset
+		c, pos := b.locate(int(e.offset))
+		valPos := pos
 		if kLen > 0 {
-			valOffset += kLen
+			valPos += kLen
 		}
 		// write key
 		n := binary.PutVarint(numBuf[:], int64(e.keyLen))
@@ -340,7 +335,7 @@ func (b *sortableBuffer) Write(w io.Writer) error {
 			return err
 		}
 		if kLen > 0 {
-			if _, err := w.Write(b.at(keyOffset, kLen)); err != nil {
+			if _, err := w.Write(c[pos : pos+kLen]); err != nil {
 				return err
 			}
 		}
@@ -350,7 +345,7 @@ func (b *sortableBuffer) Write(w io.Writer) error {
 			return err
 		}
 		if vLen > 0 {
-			if _, err := w.Write(b.at(valOffset, vLen)); err != nil {
+			if _, err := w.Write(c[valPos : valPos+vLen]); err != nil {
 				return err
 			}
 		}

--- a/db/etl/etl_test.go
+++ b/db/etl/etl_test.go
@@ -496,9 +496,10 @@ func TestReuseCollectorAfterLoad(t *testing.T) {
 	c.Close()
 
 	// buffers are not lost
-	require.Empty(t, buf.data)
+	require.Zero(t, buf.dataLen)
 	require.Empty(t, buf.entries)
-	require.NotZero(t, cap(buf.data))
+	require.NotEmpty(t, buf.chunks)
+	require.NotZero(t, cap(buf.chunks[0]))
 	require.NotZero(t, cap(buf.entries))
 
 	// teset that no data visible

--- a/db/etl/etl_test.go
+++ b/db/etl/etl_test.go
@@ -498,7 +498,7 @@ func TestReuseCollectorAfterLoad(t *testing.T) {
 	// buffers are not lost
 	require.Zero(t, buf.dataLen)
 	require.Empty(t, buf.entries)
-	require.NotEmpty(t, buf.chunks)
+	require.Empty(t, buf.chunks)
 	require.NotZero(t, cap(buf.entries))
 
 	// teset that no data visible

--- a/db/etl/etl_test.go
+++ b/db/etl/etl_test.go
@@ -1578,8 +1578,6 @@ func TestCollectorWithAllocatorDrawsBufferLazily(t *testing.T) {
 // TestSortableBufferChunkBoundaries pins the chunked layout: entries that cross
 // a chunk, an entry wider than a chunk, and the same after Reset.
 func TestSortableBufferChunkBoundaries(t *testing.T) {
-	const shift = 12 // 4KB chunks
-	chunkSize := 1 << shift
 
 	type kv struct{ k, v []byte }
 	mk := func(seed byte, n int) []byte {
@@ -1597,7 +1595,6 @@ func TestSortableBufferChunkBoundaries(t *testing.T) {
 	}
 
 	buf := NewSortableBuffer(64 * datasize.MB)
-	buf.setChunkShift(shift)
 	// Prealloc first: an oversize entry must not be placed into a narrow chunk.
 	buf.Prealloc(4, chunkSize*4)
 

--- a/db/etl/etl_test.go
+++ b/db/etl/etl_test.go
@@ -499,7 +499,6 @@ func TestReuseCollectorAfterLoad(t *testing.T) {
 	require.Zero(t, buf.dataLen)
 	require.Empty(t, buf.entries)
 	require.NotEmpty(t, buf.chunks)
-	require.NotZero(t, cap(buf.chunks[0]))
 	require.NotZero(t, cap(buf.entries))
 
 	// teset that no data visible
@@ -1574,4 +1573,59 @@ func TestCollectorWithAllocatorDrawsBufferLazily(t *testing.T) {
 	v, err := tx.GetOne(table, []byte{1})
 	require.NoError(err)
 	require.Equal([]byte{1}, v)
+}
+
+// TestSortableBufferChunkBoundaries pins the chunked layout: entries that cross
+// a chunk, an entry wider than a chunk, and the same after Reset.
+func TestSortableBufferChunkBoundaries(t *testing.T) {
+	const shift = 12 // 4KB chunks
+	chunkSize := 1 << shift
+
+	type kv struct{ k, v []byte }
+	mk := func(seed byte, n int) []byte {
+		b := make([]byte, n)
+		for i := range b {
+			b[i] = seed + byte(i%7)
+		}
+		return b
+	}
+	want := []kv{
+		{mk(1, 8), mk(2, chunkSize/2)}, // fits
+		{mk(3, 8), mk(4, chunkSize/2)}, // forces a boundary skip
+		{mk(5, 8), mk(6, chunkSize*3)}, // wider than a chunk
+		{mk(7, 8), mk(8, 16)},          // lands after the oversize chunk
+	}
+
+	buf := NewSortableBuffer(64 * datasize.MB)
+	buf.chunkShift = shift
+
+	for round := range 2 { // second round exercises reuse after Reset
+		for _, e := range want {
+			buf.Put(e.k, e.v)
+		}
+		require.Equal(t, len(want), buf.Len(), "round %d", round)
+
+		for i, e := range want {
+			k, v := buf.Get(i)
+			require.Equal(t, e.k, k, "round %d key %d", round, i)
+			require.Equal(t, e.v, v, "round %d val %d", round, i)
+		}
+
+		buf.Sort()
+		var prev []byte
+		for i := range buf.Len() {
+			k, _ := buf.Get(i)
+			if prev != nil {
+				require.LessOrEqual(t, bytes.Compare(prev, k), 0, "round %d not sorted at %d", round, i)
+			}
+			prev = append(prev[:0], k...)
+		}
+
+		var out bytes.Buffer
+		require.NoError(t, buf.Write(&out))
+		require.NotZero(t, out.Len())
+
+		buf.Reset()
+		require.Zero(t, buf.Len())
+	}
 }

--- a/db/etl/etl_test.go
+++ b/db/etl/etl_test.go
@@ -1598,6 +1598,8 @@ func TestSortableBufferChunkBoundaries(t *testing.T) {
 
 	buf := NewSortableBuffer(64 * datasize.MB)
 	buf.chunkShift = shift
+	// Prealloc first: an oversize entry must not be placed into a narrow chunk.
+	buf.Prealloc(4, chunkSize*4)
 
 	for round := range 2 { // second round exercises reuse after Reset
 		for _, e := range want {

--- a/db/etl/etl_test.go
+++ b/db/etl/etl_test.go
@@ -1597,7 +1597,7 @@ func TestSortableBufferChunkBoundaries(t *testing.T) {
 	}
 
 	buf := NewSortableBuffer(64 * datasize.MB)
-	buf.chunkShift = shift
+	buf.setChunkShift(shift)
 	// Prealloc first: an oversize entry must not be placed into a narrow chunk.
 	buf.Prealloc(4, chunkSize*4)
 


### PR DESCRIPTION
problem: `etl.Collect` does expensive re-alloc inside. It's critical because now it happening inside `SD.mu` critical section. 

```
slow etl bufPut took=14.4ms collector=commitmentdomain.flush len=62655 sizeLimit=33554432
```

Solution: chunk-chunk sortable buf (`ETL_CHUNK`, default 1MB), chunks pooled and pre-warmed. Plus an 8-byte key prefix in `entryLoc`, so `Sort` compares in registers instead of reading keys.

integration stage_exec, mainnet 12630794->12630900, 3 runs each:
- `SD.mu` hold 2775ms -> 2429ms, apply-side wait 2660ms -> 2302ms, re-alloc stalls 16 -> 0
- max RSS 12328MB -> 11445MB, alloc_space 3.84GB -> 3.02GB (`sortableBuffer.Put` was 439MB, now absent)

`go test -bench` vs main, geomean +1.26%:
- `Collect/10k_largebuf` -85%, `Collect/100k_largebuf` -65%
- `Sort/sorted_500k` -70%, `Sort/random_500k` -23%
- `PutOnly` +48%, `InmemLoadOnly` +31% — a 24-byte `entryLoc` (was 16) and a `reserve` per Put

The chunk pool measured worse than leaving chunks on the buffer (alloc 4.18GB vs 3.02GB, RSS 11948 vs 11445MB, no change in lock wait): without it `Reset` keeps the chunks, so a recycled buffer refills with zero allocation. It is its own commit if we want to drop it.
