### PR TITLE
sd: `SD.changesetMu` which must protect "field access" now get locked every DomainPut

### DIFF
--- a/common/dbg/experiments.go
+++ b/common/dbg/experiments.go
@@ -130,11 +130,7 @@ var (
 	// BALShadowCompute (requires BALDrivenCommitment) also computes each
 	// BAL-driven block incrementally and asserts both roots match before
 	// publishing; without it the BAL-driven root is published directly.
-	BALShadowCompute = EnvBool("BAL_SHADOW_COMPUTE", false)
-	// CommitmentScopedSwap narrows the calculator's changeset-accumulator swap
-	// to CommitmentDomain — the only domain it writes — so apply-side DomainPut
-	// no longer has to take changesetMu.
-	CommitmentScopedSwap          = EnvBool("COMMITMENT_SCOPED_SWAP", false)
+	BALShadowCompute              = EnvBool("BAL_SHADOW_COMPUTE", false)
 	CaplinEfficientReorg          = EnvBool("CAPLIN_EFFICIENT_REORG", true)
 	UseTxDependencies             = EnvBool("USE_TX_DEPENDENCIES", false)
 	UseStateCache                 = EnvBool("USE_STATE_CACHE", true)

--- a/common/dbg/experiments.go
+++ b/common/dbg/experiments.go
@@ -130,7 +130,11 @@ var (
 	// BALShadowCompute (requires BALDrivenCommitment) also computes each
 	// BAL-driven block incrementally and asserts both roots match before
 	// publishing; without it the BAL-driven root is published directly.
-	BALShadowCompute              = EnvBool("BAL_SHADOW_COMPUTE", false)
+	BALShadowCompute = EnvBool("BAL_SHADOW_COMPUTE", false)
+	// CommitmentScopedSwap narrows the calculator's changeset-accumulator swap
+	// to CommitmentDomain — the only domain it writes — so apply-side DomainPut
+	// no longer has to take changesetMu.
+	CommitmentScopedSwap          = EnvBool("COMMITMENT_SCOPED_SWAP", false)
 	CaplinEfficientReorg          = EnvBool("CAPLIN_EFFICIENT_REORG", true)
 	UseTxDependencies             = EnvBool("USE_TX_DEPENDENCIES", false)
 	UseStateCache                 = EnvBool("USE_STATE_CACHE", true)

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -447,6 +447,7 @@ func (w *DomainBufferedWriter) DeleteWithPrev(k []byte, txNum uint64, prev []byt
 }
 
 func (w *DomainBufferedWriter) SetDiff(diff *kv.DomainDiff) { w.diff = diff }
+func (w *DomainBufferedWriter) Diff() *kv.DomainDiff         { return w.diff }
 
 func (dt *DomainRoTx) newWriter(tmpdir string, discard bool) *DomainBufferedWriter {
 	discardHistory := discard || dt.d.HistoryDisabled

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -447,7 +447,7 @@ func (w *DomainBufferedWriter) DeleteWithPrev(k []byte, txNum uint64, prev []byt
 }
 
 func (w *DomainBufferedWriter) SetDiff(diff *kv.DomainDiff) { w.diff = diff }
-func (w *DomainBufferedWriter) Diff() *kv.DomainDiff         { return w.diff }
+func (w *DomainBufferedWriter) Diff() *kv.DomainDiff        { return w.diff }
 
 func (dt *DomainRoTx) newWriter(tmpdir string, discard bool) *DomainBufferedWriter {
 	discardHistory := discard || dt.d.HistoryDisabled

--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -506,11 +506,9 @@ func (sd *SharedDomains) ResetPendingUpdates() {
 // It sets the corresponding block's changeset as the accumulator
 // so writes go directly to the correct changeset.
 //
-// Concurrency contract: the inner swap (set cs_N → apply → restore prev)
-// mutates the commitment writer's diff, which the exec loop also rewrites
-// via SetChangesetAccumulator. Caller passes `lockHeld=true` when it
-// already holds changesetMu (calc path); `false` when FlushPendingUpdates
-// should acquire it itself (Flush / standalone callers).
+// The inner swap mutates the commitment writer's diff, which the exec loop
+// also rewrites via SetChangesetAccumulator — hence changesetMu, taken here
+// unless lockHeld says the caller already holds it.
 func (sd *SharedDomains) FlushPendingUpdates(ctx context.Context, tx kv.TemporalTx) error {
 	return sd.flushPendingUpdates(ctx, tx, false)
 }
@@ -689,11 +687,9 @@ func (sd *SharedDomains) getChangesetAccumulatorLocked() *changeset.StateChangeS
 	return nil
 }
 
-// commitmentDiffSwapper is the commitment-scoped subset of the mem batch's
-// changeset API. Every kv.TemporalMemBatch behind SharedDomains must implement
-// it: a wrapper that does not forward these would fall back to redirecting all
-// domain writers, which is only safe while DomainPut takes changesetMu — it
-// does not (see the changesetMu doc on the SharedDomains struct).
+// commitmentDiffSwapper must be implemented by every mem batch behind
+// SharedDomains: the only alternative is redirecting all domain writers,
+// which is unsafe now that DomainPut takes no lock.
 type commitmentDiffSwapper interface {
 	SetCommitmentDiff(acc *changeset.StateChangeSet)
 	SetCommitmentDiffRaw(d *kv.DomainDiff)
@@ -701,9 +697,8 @@ type commitmentDiffSwapper interface {
 }
 
 // SwapCommitmentDiffLocked points the commitment writer's diff at acc and
-// returns a func restoring the previous one. It leaves every other domain
-// writer alone, so apply-side writes are unaffected and need not be locked out.
-// Callers must hold changesetMu.
+// returns a func restoring the previous one. Every other domain writer is left
+// alone, so apply-side writes need no lock. Callers must hold changesetMu.
 func (sd *SharedDomains) SwapCommitmentDiffLocked(acc *changeset.StateChangeSet) (restore func()) {
 	h := sd.mem.(commitmentDiffSwapper)
 	prev := h.CommitmentDiff()

--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -507,15 +507,10 @@ func (sd *SharedDomains) ResetPendingUpdates() {
 // so writes go directly to the correct changeset.
 //
 // Concurrency contract: the inner swap (set cs_N → apply → restore prev)
-// mutates the global accumulator pointer and per-domain diff fields that
-// the apply goroutine's DomainPut/DomainDel writes through. Calls from
-// inside the calculator's outer LockChangesetAccumulator window must hold
-// that same Mutex; calls from end-of-stage Flush are single-threaded
-// against apply but still need the lock for race-detector happens-before
-// against any concurrent reads via DomainPut. Caller passes
-// `lockHeld=true` when it already holds changesetMu (calc path);
-// `false` when FlushPendingUpdates should acquire it itself
-// (Flush / standalone callers).
+// mutates the commitment writer's diff, which the exec loop also rewrites
+// via SetChangesetAccumulator. Caller passes `lockHeld=true` when it
+// already holds changesetMu (calc path); `false` when FlushPendingUpdates
+// should acquire it itself (Flush / standalone callers).
 func (sd *SharedDomains) FlushPendingUpdates(ctx context.Context, tx kv.TemporalTx) error {
 	return sd.flushPendingUpdates(ctx, tx, false)
 }
@@ -536,11 +531,7 @@ func (sd *SharedDomains) flushPendingUpdates(ctx context.Context, tx kv.Temporal
 	defer upd.Clear()
 
 	putBranch := func(prefix, data, prevData []byte) error {
-		// Use the unlocked variant — we either hold the lock externally
-		// (lockHeld=true) or inside this function (locked below). Using
-		// the public DomainPut would re-acquire and self-deadlock for
-		// commitment-domain writes if the lock is held externally.
-		return sd.domainPutNoLock(kv.CommitmentDomain, tx, prefix, data, upd.TxNum, prevData)
+		return sd.DomainPut(kv.CommitmentDomain, tx, prefix, data, upd.TxNum, prevData)
 	}
 
 	if !lockHeld {
@@ -585,10 +576,6 @@ func (sd *SharedDomains) flushPendingUpdates(ctx context.Context, tx kv.Temporal
 	// No past changeset found — write into whatever is current.
 	_, err := commitment.ApplyDeferredBranchUpdates(upd.Deferred, runtime.NumCPU(), putBranch)
 	return err
-}
-
-func (sd *SharedDomains) domainPutNoLock(domain kv.Domain, roTx kv.TemporalTx, k, v []byte, txNum uint64, prevVal []byte) error {
-	return sd.domainPut(domain, roTx, k, v, txNum, prevVal)
 }
 
 // AsStateGetter returns an execution-aware getter with optimized code reads.
@@ -686,7 +673,7 @@ func (sd *SharedDomains) setChangesetAccumulatorLocked(acc *changeset.StateChang
 // accumulator (the one DomainPut writes diff entries into). Returns nil if
 // none is installed. Locks changesetMu internally — must NOT be called
 // while already holding the lock (locked-window callers use
-// SwapChangesetAccumulatorLocked / DetachChangesetAccumulatorLocked).
+// SwapCommitmentDiffLocked / DetachChangesetAccumulatorLocked).
 func (sd *SharedDomains) GetChangesetAccumulator() *changeset.StateChangeSet {
 	sd.changesetMu.Lock()
 	defer sd.changesetMu.Unlock()
@@ -702,17 +689,11 @@ func (sd *SharedDomains) getChangesetAccumulatorLocked() *changeset.StateChangeS
 	return nil
 }
 
-// SwapChangesetAccumulatorLocked installs the given changeset accumulator
-// and returns a func that restores the previous one. Callers must hold
-// changesetMu.
-func (sd *SharedDomains) SwapChangesetAccumulatorLocked(acc *changeset.StateChangeSet) (restore func()) {
-	prev := sd.getChangesetAccumulatorLocked()
-	sd.setChangesetAccumulatorLocked(acc)
-	return func() { sd.setChangesetAccumulatorLocked(prev) }
-}
-
-// commitmentDiffSwapper is implemented by TemporalMemBatch for the
-// commitment-scoped swap (see SwapCommitmentDiffLocked).
+// commitmentDiffSwapper is the commitment-scoped subset of the mem batch's
+// changeset API. Every kv.TemporalMemBatch behind SharedDomains must implement
+// it: a wrapper that does not forward these would fall back to redirecting all
+// domain writers, which is only safe while DomainPut takes changesetMu — it
+// does not (see the changesetMu doc on the SharedDomains struct).
 type commitmentDiffSwapper interface {
 	SetCommitmentDiff(acc *changeset.StateChangeSet)
 	SetCommitmentDiffRaw(d *kv.DomainDiff)
@@ -720,14 +701,11 @@ type commitmentDiffSwapper interface {
 }
 
 // SwapCommitmentDiffLocked points the commitment writer's diff at acc and
-// returns a func restoring the previous one. Unlike
-// SwapChangesetAccumulatorLocked it leaves every other domain writer alone, so
-// apply-side writes are unaffected and need not be locked out.
+// returns a func restoring the previous one. It leaves every other domain
+// writer alone, so apply-side writes are unaffected and need not be locked out.
+// Callers must hold changesetMu.
 func (sd *SharedDomains) SwapCommitmentDiffLocked(acc *changeset.StateChangeSet) (restore func()) {
-	h, ok := sd.mem.(commitmentDiffSwapper)
-	if !ok {
-		return sd.SwapChangesetAccumulatorLocked(acc)
-	}
+	h := sd.mem.(commitmentDiffSwapper)
 	prev := h.CommitmentDiff()
 	h.SetCommitmentDiff(acc)
 	return func() { h.SetCommitmentDiffRaw(prev) }

--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -649,22 +649,20 @@ func (sd *SharedDomains) flushRequestMetrics() {
 	sd.reqMetrics = nil
 }
 
-// LockChangesetAccumulator and UnlockChangesetAccumulator bracket a
-// swap+use+restore sequence on the global accumulator pointer (see
-// changesetMu doc on the SharedDomains struct for the layering rationale).
-// Apply-side DomainPut/DomainDel take the same lock briefly so they
-// cannot record into a swapped accumulator that does not belong to the
-// block they are writing for.
+// LockChangesetAccumulator and UnlockChangesetAccumulator bracket the
+// calculator's swap+use+restore of the commitment writer's diff. It
+// serializes against the exec loop's per-block SetChangesetAccumulator;
+// apply-side DomainPut/DomainDel no longer take it, because the swap
+// leaves their writers alone (see SwapCommitmentDiffLocked).
 //
-// Holders MUST pair Lock with Unlock and MUST keep the critical section
-// short — currently the calculator's per-block ComputeCommitment runs
-// inside this lock, which serializes apply-side writes for the duration
-// of compute. That cost goes away once the post-hoc-from-sd-entries
-// derivation lands and this lock + the swap dance can both be deleted.
+// The calculator's per-block ComputeCommitment still runs inside this
+// lock, so the exec loop's accumulator install waits on it. That goes
+// away once the post-hoc-from-sd-entries derivation lands and this lock
+// + the swap dance can both be deleted.
 //
 // Inside the locked window callers must use the *Locked variants
-// (SwapChangesetAccumulatorLocked / DetachChangesetAccumulatorLocked) —
-// the public Set/Get acquire the same Mutex and would self-deadlock.
+// (SwapCommitmentDiffLocked / DetachChangesetAccumulatorLocked) — the
+// public Set/Get acquire the same Mutex and would self-deadlock.
 func (sd *SharedDomains) LockChangesetAccumulator()   { sd.changesetMu.Lock() }
 func (sd *SharedDomains) UnlockChangesetAccumulator() { sd.changesetMu.Unlock() }
 

--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -572,7 +572,7 @@ func (sd *SharedDomains) flushPendingUpdates(ctx context.Context, tx kv.Temporal
 		// Apply deferred branch writes under the pending update's block
 		// changeset, then save it back. All accesses under changesetMu —
 		// see concurrency contract on the wrappers above.
-		defer sd.SwapChangesetAccumulatorLocked(cs)()
+		defer sd.SwapForCommitLocked(cs)()
 
 		if _, err := commitment.ApplyDeferredBranchUpdates(upd.Deferred, runtime.NumCPU(), putBranch); err != nil {
 			return err
@@ -716,11 +716,42 @@ func (sd *SharedDomains) SwapChangesetAccumulatorLocked(acc *changeset.StateChan
 	return func() { sd.setChangesetAccumulatorLocked(prev) }
 }
 
+// commitmentDiffSwapper is implemented by TemporalMemBatch for the
+// commitment-scoped swap (see SwapCommitmentDiffLocked).
+type commitmentDiffSwapper interface {
+	SetCommitmentDiff(acc *changeset.StateChangeSet)
+	SetCommitmentDiffRaw(d *kv.DomainDiff)
+	CommitmentDiff() *kv.DomainDiff
+}
+
+// SwapCommitmentDiffLocked points the commitment writer's diff at acc and
+// returns a func restoring the previous one. Unlike
+// SwapChangesetAccumulatorLocked it leaves every other domain writer alone, so
+// apply-side writes are unaffected and need not be locked out.
+func (sd *SharedDomains) SwapCommitmentDiffLocked(acc *changeset.StateChangeSet) (restore func()) {
+	h, ok := sd.mem.(commitmentDiffSwapper)
+	if !ok {
+		return sd.SwapChangesetAccumulatorLocked(acc)
+	}
+	prev := h.CommitmentDiff()
+	h.SetCommitmentDiff(acc)
+	return func() { h.SetCommitmentDiffRaw(prev) }
+}
+
+// swapForCommitLocked routes to the commitment-scoped swap when
+// COMMITMENT_SCOPED_SWAP is set, else to the global one.
+func (sd *SharedDomains) SwapForCommitLocked(acc *changeset.StateChangeSet) func() {
+	if dbg.CommitmentScopedSwap {
+		return sd.SwapCommitmentDiffLocked(acc)
+	}
+	return sd.SwapChangesetAccumulatorLocked(acc)
+}
+
 // DetachChangesetAccumulatorLocked installs a nil changeset accumulator and
 // returns a func that restores the previous one. Callers must hold
 // changesetMu.
 func (sd *SharedDomains) DetachChangesetAccumulatorLocked() (restore func()) {
-	return sd.SwapChangesetAccumulatorLocked(nil)
+	return sd.SwapForCommitLocked(nil)
 }
 
 // GetChangesetByBlockNum returns the saved changeset for a given block
@@ -1809,7 +1840,7 @@ func (sd *SharedDomains) domainPut(domain kv.Domain, roTx kv.TemporalTx, k, v []
 	// changesetMu via LockChangesetAccumulator (re-acquiring would
 	// self-deadlock). All other domains are written by the apply goroutine
 	// and need to serialize against the swap.
-	if !lockHeld && domain != kv.CommitmentDomain {
+	if !lockHeld && domain != kv.CommitmentDomain && !dbg.CommitmentScopedSwap {
 		sd.changesetMu.Lock()
 		defer sd.changesetMu.Unlock()
 	}

--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -291,10 +291,10 @@ type SharedDomains struct {
 	// code-by-hash read with the application's authoritative codehash.
 	codeStore *cache.CodeStore
 
-	// changesetMu serializes the parallel commitment calculator's swap of the
-	// global current-changeset-accumulator pointer against DomainPut/DomainDel:
-	// without it a block N+1 write can land in block N's changeset during the
-	// swap+compute+restore window, so a later unwind reads stale prev-values.
+	// changesetMu serializes the exec loop's install of a block's changeset
+	// accumulator against the calculator's swap of the commitment writer's
+	// diff. Writers other than commitment are never redirected, so DomainPut
+	// and DomainDel do not take it — see SwapCommitmentDiffLocked.
 	changesetMu sync.Mutex
 
 	// branchCache is the aggregator-scope commitment-branch cache. It sits
@@ -572,7 +572,7 @@ func (sd *SharedDomains) flushPendingUpdates(ctx context.Context, tx kv.Temporal
 		// Apply deferred branch writes under the pending update's block
 		// changeset, then save it back. All accesses under changesetMu —
 		// see concurrency contract on the wrappers above.
-		defer sd.SwapForCommitLocked(cs)()
+		defer sd.SwapCommitmentDiffLocked(cs)()
 
 		if _, err := commitment.ApplyDeferredBranchUpdates(upd.Deferred, runtime.NumCPU(), putBranch); err != nil {
 			return err
@@ -587,11 +587,8 @@ func (sd *SharedDomains) flushPendingUpdates(ctx context.Context, tx kv.Temporal
 	return err
 }
 
-// domainPutNoLock is the lock-held variant of DomainPut for callers
-// (FlushPendingUpdates) that already hold changesetMu externally; it stays
-// correct even if the CommitmentDomain lock exemption in domainPut is removed.
 func (sd *SharedDomains) domainPutNoLock(domain kv.Domain, roTx kv.TemporalTx, k, v []byte, txNum uint64, prevVal []byte) error {
-	return sd.domainPut(domain, roTx, k, v, txNum, prevVal, true)
+	return sd.domainPut(domain, roTx, k, v, txNum, prevVal)
 }
 
 // AsStateGetter returns an execution-aware getter with optimized code reads.
@@ -738,20 +735,11 @@ func (sd *SharedDomains) SwapCommitmentDiffLocked(acc *changeset.StateChangeSet)
 	return func() { h.SetCommitmentDiffRaw(prev) }
 }
 
-// swapForCommitLocked routes to the commitment-scoped swap when
-// COMMITMENT_SCOPED_SWAP is set, else to the global one.
-func (sd *SharedDomains) SwapForCommitLocked(acc *changeset.StateChangeSet) func() {
-	if dbg.CommitmentScopedSwap {
-		return sd.SwapCommitmentDiffLocked(acc)
-	}
-	return sd.SwapChangesetAccumulatorLocked(acc)
-}
-
 // DetachChangesetAccumulatorLocked installs a nil changeset accumulator and
 // returns a func that restores the previous one. Callers must hold
 // changesetMu.
 func (sd *SharedDomains) DetachChangesetAccumulatorLocked() (restore func()) {
-	return sd.SwapForCommitLocked(nil)
+	return sd.SwapCommitmentDiffLocked(nil)
 }
 
 // GetChangesetByBlockNum returns the saved changeset for a given block
@@ -1793,14 +1781,10 @@ func (sd *SharedDomains) HistorySeek(domain kv.Domain, key []byte, ts uint64) (v
 //   - user can append k2 into k1, then underlying methods will not preform append
 //   - if `val == nil` it will call DomainDel
 func (sd *SharedDomains) DomainPut(domain kv.Domain, roTx kv.TemporalTx, k, v []byte, txNum uint64, prevVal []byte) error {
-	return sd.domainPut(domain, roTx, k, v, txNum, prevVal, false)
+	return sd.domainPut(domain, roTx, k, v, txNum, prevVal)
 }
 
-// domainPut is the shared body for DomainPut (lockHeld=false) and
-// domainPutNoLock (lockHeld=true). Factored so a new domain case or
-// pre-check is written once. See changesetMu doc on the SharedDomains
-// struct for the locking rationale.
-func (sd *SharedDomains) domainPut(domain kv.Domain, roTx kv.TemporalTx, k, v []byte, txNum uint64, prevVal []byte, lockHeld bool) error {
+func (sd *SharedDomains) domainPut(domain kv.Domain, roTx kv.TemporalTx, k, v []byte, txNum uint64, prevVal []byte) error {
 	if v == nil {
 		return fmt.Errorf("DomainPut: %s, trying to put nil value. not allowed", domain)
 	}
@@ -1832,18 +1816,6 @@ func (sd *SharedDomains) domainPut(domain kv.Domain, roTx kv.TemporalTx, k, v []
 	// sd.mem and is published to the cache only after a successful Commit;
 	// publishing it earlier could expose uncommitted, fork-specific state.
 
-	// Serialize against the calculator's accumulator-swap window — see
-	// changesetMu doc on the SharedDomains struct. Skipped when the caller
-	// already holds changesetMu (lockHeld=true, the FlushPendingUpdates
-	// path), and currently also for CommitmentDomain — those writes
-	// originate exclusively from the calculator's compute, which holds
-	// changesetMu via LockChangesetAccumulator (re-acquiring would
-	// self-deadlock). All other domains are written by the apply goroutine
-	// and need to serialize against the swap.
-	if !lockHeld && domain != kv.CommitmentDomain && !dbg.CommitmentScopedSwap {
-		sd.changesetMu.Lock()
-		defer sd.changesetMu.Unlock()
-	}
 	return sd.mem.DomainPut(domain, ks, v, txNum, prevVal)
 }
 
@@ -1888,12 +1860,7 @@ func (sd *SharedDomains) DomainDel(domain kv.Domain, tx kv.TemporalTx, k []byte,
 	}
 
 	// As in DomainPut, a deletion reaches the shared state cache only after a
-	// successful Commit. Serialize against the calculator's swap window for
-	// non-commitment domains; CommitmentDomain is skipped as described there.
-	if domain != kv.CommitmentDomain {
-		sd.changesetMu.Lock()
-		defer sd.changesetMu.Unlock()
-	}
+	// successful Commit.
 	return sd.mem.DomainDel(domain, ks, txNum, prevVal)
 }
 

--- a/db/state/temporal_mem_batch.go
+++ b/db/state/temporal_mem_batch.go
@@ -451,6 +451,25 @@ func (sd *TemporalMemBatch) SetChangesetAccumulator(acc *changeset.StateChangeSe
 		}
 	}
 }
+
+// SetCommitmentDiff redirects only the commitment writer's diff, leaving every
+// other domain writer pointed at the live accumulator.
+func (sd *TemporalMemBatch) SetCommitmentDiff(acc *changeset.StateChangeSet) {
+	if acc == nil {
+		sd.domainWriters[kv.CommitmentDomain].SetDiff(nil)
+		return
+	}
+	sd.domainWriters[kv.CommitmentDomain].SetDiff(&acc.Diffs[kv.CommitmentDomain])
+}
+
+func (sd *TemporalMemBatch) CommitmentDiff() *kv.DomainDiff {
+	return sd.domainWriters[kv.CommitmentDomain].Diff()
+}
+
+func (sd *TemporalMemBatch) SetCommitmentDiffRaw(d *kv.DomainDiff) {
+	sd.domainWriters[kv.CommitmentDomain].SetDiff(d)
+}
+
 func (sd *TemporalMemBatch) SavePastChangesetAccumulator(blockHash common.Hash, blockNumber uint64, acc *changeset.StateChangeSet) {
 	sd.pastChangesLock.Lock()
 	defer sd.pastChangesLock.Unlock()

--- a/execution/blockreplay/witnessmembatch.go
+++ b/execution/blockreplay/witnessmembatch.go
@@ -252,6 +252,9 @@ type changesetHolder interface {
 	GetChangesetAccumulator() *changeset.StateChangeSet
 	SetChangesetAccumulator(acc *changeset.StateChangeSet)
 	SavePastChangesetAccumulator(blockHash common.Hash, blockNumber uint64, acc *changeset.StateChangeSet)
+	SetCommitmentDiff(acc *changeset.StateChangeSet)
+	SetCommitmentDiffRaw(d *kv.DomainDiff)
+	CommitmentDiff() *kv.DomainDiff
 }
 
 func (w *witnessMemBatch) GetChangesetByBlockNum(blockNumber uint64) (common.Hash, *changeset.StateChangeSet) {
@@ -268,4 +271,13 @@ func (w *witnessMemBatch) SetChangesetAccumulator(acc *changeset.StateChangeSet)
 }
 func (w *witnessMemBatch) SavePastChangesetAccumulator(blockHash common.Hash, blockNumber uint64, acc *changeset.StateChangeSet) {
 	w.TemporalMemBatch.(changesetHolder).SavePastChangesetAccumulator(blockHash, blockNumber, acc)
+}
+func (w *witnessMemBatch) SetCommitmentDiff(acc *changeset.StateChangeSet) {
+	w.TemporalMemBatch.(changesetHolder).SetCommitmentDiff(acc)
+}
+func (w *witnessMemBatch) SetCommitmentDiffRaw(d *kv.DomainDiff) {
+	w.TemporalMemBatch.(changesetHolder).SetCommitmentDiffRaw(d)
+}
+func (w *witnessMemBatch) CommitmentDiff() *kv.DomainDiff {
+	return w.TemporalMemBatch.(changesetHolder).CommitmentDiff()
 }

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -216,6 +216,17 @@ func newCommitmentCalculator(
 	blockRequests chan *blockRequest,
 	out chan commitmentResult,
 ) (*commitmentCalculator, error) {
+	// The calculator folds block N while the exec loop already writes block N+1
+	// into sd.mem. Both invariants below are what keep that safe: as-of reads
+	// need every version retained, and the Updates buffer this calculator owns
+	// must not be mutated by an apply-side TouchKey.
+	if !doms.InMemHistoryReads() {
+		return nil, errors.New("commitmentCalculator: in-mem history reads must be enabled")
+	}
+	if !doms.InlineTouchKeyDisabled() {
+		return nil, errors.New("commitmentCalculator: inline TouchKey must be disabled")
+	}
+
 	// ModeUpdate carries values in its btree for the trie to read; the parallel
 	// trie reads leaf values from the as-of reader, so keep its ModeParallel buffer.
 	sdCtxUpdates := doms.GetCommitmentContext().GetUpdates()

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -980,7 +980,7 @@ func (cc *commitmentCalculator) computeWithBlockAccumulator(ctx context.Context,
 	//
 	// Inside the lock we must use the *Locked variants — the public
 	// counterparts re-acquire the same Mutex and would self-deadlock.
-	defer cc.doms.SwapChangesetAccumulatorLocked(cs)()
+	defer cc.doms.SwapForCommitLocked(cs)()
 	return cc.doms.ComputeCommitmentLocked(ctx, cc.roTx, true, t.blockNum, t.lastTxNum, cc.logPrefix, nil)
 }
 

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -216,10 +216,8 @@ func newCommitmentCalculator(
 	blockRequests chan *blockRequest,
 	out chan commitmentResult,
 ) (*commitmentCalculator, error) {
-	// The calculator folds block N while the exec loop already writes block N+1
-	// into sd.mem. Both invariants below are what keep that safe: as-of reads
-	// need every version retained, and the Updates buffer this calculator owns
-	// must not be mutated by an apply-side TouchKey.
+	// This calculator folds block N while the exec loop already writes N+1 into
+	// sd.mem; both settings below are what keep that read-safe.
 	if !doms.InMemHistoryReads() {
 		return nil, errors.New("commitmentCalculator: in-mem history reads must be enabled")
 	}

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -980,7 +980,7 @@ func (cc *commitmentCalculator) computeWithBlockAccumulator(ctx context.Context,
 	//
 	// Inside the lock we must use the *Locked variants — the public
 	// counterparts re-acquire the same Mutex and would self-deadlock.
-	defer cc.doms.SwapForCommitLocked(cs)()
+	defer cc.doms.SwapCommitmentDiffLocked(cs)()
 	return cc.doms.ComputeCommitmentLocked(ctx, cc.roTx, true, t.blockNum, t.lastTxNum, cc.logPrefix, nil)
 }
 

--- a/execution/stagedsync/committer_step_boundary_test.go
+++ b/execution/stagedsync/committer_step_boundary_test.go
@@ -573,6 +573,9 @@ func setupStepTest(t *testing.T) (kv.TemporalRwDB, kv.TemporalRwTx, *execctx.Sha
 	doms, err := execctx.NewSharedDomains(ctx, tx, logger)
 	require.NoError(t, err)
 	t.Cleanup(doms.Close)
+	// Match parallel exec: the calculator owns the Updates buffer, so writes
+	// feed it through handleMessage rather than an inline TouchKey.
+	doms.SetDisableInlineTouchKey(true)
 	return db, tx, doms
 }
 

--- a/execution/stagedsync/committer_step_boundary_test.go
+++ b/execution/stagedsync/committer_step_boundary_test.go
@@ -573,9 +573,7 @@ func setupStepTest(t *testing.T) (kv.TemporalRwDB, kv.TemporalRwTx, *execctx.Sha
 	doms, err := execctx.NewSharedDomains(ctx, tx, logger)
 	require.NoError(t, err)
 	t.Cleanup(doms.Close)
-	// Match parallel exec: the calculator owns the Updates buffer, so writes
-	// feed it through handleMessage rather than an inline TouchKey.
-	doms.SetDisableInlineTouchKey(true)
+	doms.SetDisableInlineTouchKey(true) // as parallel exec does: the calculator owns Updates
 	return db, tx, doms
 }
 


### PR DESCRIPTION
problem: the commitment calculator holds `SD.changesetMu` for a whole block's fold, and every apply-side `DomainPut` takes the same mutex. Apply just sleeps through it.

Seems we did mess 2 concerns: `sd.diffs field ptr mutation` and `updating data which living inside sd.diff object`  

```
slow domainPut took=28.7ms domain=receipt lock=28.78ms getLatest=280ns memPut=952ns
```

`changesetMu` was 67% of all mutex wait in the block profile (2556ms of 3.84s).
