### PR TITLE
execution/cache: give growLRU the same atomic entry count

### DIFF
--- a/execution/cache/code_cache_concurrency_test.go
+++ b/execution/cache/code_cache_concurrency_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/binary"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/c2h5oh/datasize"
@@ -192,4 +193,84 @@ func TestCodeCache_ClearFencesStartedPut(t *testing.T) {
 
 	_, ok := cc.Get(addr)
 	require.False(t, ok, "Clear must remove a write that started in the retiring generation")
+}
+
+// The O(1) entry counter that replaced freelru's all-shard Len on growLRU's add
+// path must not drift from the LRU's real length on any mutation path.
+func TestGrowLRU_LenTracksLRU(t *testing.T) {
+	var evictions int
+	g := newGrowLRU[uint64](8*datasize.MB, 16, func(uint64, uint64) { evictions++ })
+	defer g.Close()
+	check := func(phase string) {
+		t.Helper()
+		require.Equal(t, g.cur.Load().lru.Len(), g.Len(), "entry counter drifted after %s", phase)
+	}
+	// growLRU hashes keys with the identity function, so spread the shard-selection
+	// bits the way its real maphash/keccak-derived keys do.
+	key := func(i uint64) uint64 { return i * 0x9E3779B97F4A7C15 }
+
+	for i := range uint64(500) {
+		g.Add(key(i), i)
+	}
+	check("adds")
+	require.Equal(t, 500, g.Len(), "500 distinct keys must fit below the 1024-slot start capacity")
+
+	for i := range uint64(100) {
+		g.Remove(key(i))
+	}
+	check("removes")
+	require.Equal(t, 100, evictions, "the caller's OnEvict must still fire for each removal")
+
+	before := g.cur.Load()
+	for i := uint64(500); i < 4000; i++ {
+		g.Add(key(i), i)
+	}
+	require.NotEqual(t, before, g.cur.Load(), "grow did not happen")
+	check("grow")
+
+	g.Purge()
+	require.Equal(t, 0, g.Len())
+	check("purge")
+}
+
+// CodeCache drives three growLRU layers through putContentLocked, which removes
+// a stale entry before re-adding it; concurrent puts of distinct code must still
+// leave each layer's counter equal to its LRU's real length.
+func TestCodeCache_GrowLRULenCounterUnderConcurrency(t *testing.T) {
+	cc := closeOnCleanup(t, NewCodeCache(8*datasize.MB, 8*datasize.MB))
+
+	const workers = 8
+	const perWorker = 3000
+	var wg sync.WaitGroup
+	for w := range workers {
+		wg.Go(func() {
+			addr := make([]byte, 20)
+			code := make([]byte, 40)
+			for i := range perWorker {
+				binary.BigEndian.PutUint64(addr[12:], uint64(w*perWorker+i))
+				binary.BigEndian.PutUint64(code, uint64(w*perWorker+i))
+				cc.Put(addr, code, uint64(i))
+			}
+		})
+	}
+	wg.Wait()
+
+	require.Equal(t, cc.hashToCode.cur.Load().lru.Len(), cc.hashToCode.Len(), "hashToCode counter drifted")
+	require.Equal(t, cc.codeHashToCode.cur.Load().lru.Len(), cc.codeHashToCode.Len(), "codeHashToCode counter drifted")
+	require.Equal(t, cc.codeSizeByCodeHash.cur.Load().lru.Len(), cc.codeSizeByCodeHash.Len(), "codeSizeByCodeHash counter drifted")
+}
+
+// Parallel adds while the LRU is still below its ceiling — the window where
+// every add runs the grow check.
+func BenchmarkGrowLRUParallelAddGrow(b *testing.B) {
+	g := newGrowLRU[uint64](256*datasize.MB, 48, nil)
+	defer g.Close()
+	var seq atomic.Uint64
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			n := seq.Add(1) * 0x9E3779B97F4A7C15
+			g.Add(n, n)
+		}
+	})
 }

--- a/execution/cache/generic_cache.go
+++ b/execution/cache/generic_cache.go
@@ -58,22 +58,22 @@ type entry[T any] struct {
 	epoch uint32 // unwind generation the entry was written in
 }
 
-// lruGen is one generation of the sharded LRU plus an O(1) live-entry count.
+// lruGen is one generation of a sharded LRU plus an O(1) live-entry count.
 // freelru's own Len RLocks every shard, so the grow check — which every insert
 // runs while the cache is below its ceiling — cannot use it without serialising
 // writers that would otherwise touch disjoint shards.
-type lruGen[T any] struct {
-	lru *freelru.ShardedLRU[uint64, entry[T]]
+type lruGen[V any] struct {
+	lru *freelru.ShardedLRU[uint64, V]
 	n   atomic.Int64
 }
 
-func (g *lruGen[T]) len() int { return int(g.n.Load()) }
+func (g *lruGen[V]) len() int { return int(g.n.Load()) }
 
 // add inserts a key the LRU does not already hold — every call site removes an
 // existing one first — so the count rises by one; a capacity eviction inside
 // freelru fires OnEvict, which takes it back down.
-func (g *lruGen[T]) add(h uint64, e entry[T]) (evicted bool) {
-	evicted = g.lru.Add(h, e)
+func (g *lruGen[V]) add(h uint64, v V) (evicted bool) {
+	evicted = g.lru.Add(h, v)
 	g.n.Add(1)
 	return evicted
 }
@@ -85,7 +85,7 @@ type GenericCache[T any] struct {
 	// held — on a jump-grow (fully copied generation) and on Clear (fresh
 	// empty one) — so no write lands in a retired generation and no reader
 	// sees a partial copy (see maybeGrow, Clear).
-	data      atomic.Pointer[lruGen[T]]
+	data      atomic.Pointer[lruGen[entry[T]]]
 	capacityB datasize.ByteSize
 	mode      Mode
 
@@ -218,12 +218,12 @@ func newGenericCacheEntries[T any](capacityBytes datasize.ByteSize, capacityEntr
 // entry. The callback must not feed the evictions metric — it also fires for
 // intentional Removes — so capacity evictions are counted from Add's evicted
 // return at the call sites.
-func (c *GenericCache[T]) newShards(capacity, shards uint32) *lruGen[T] {
+func (c *GenericCache[T]) newShards(capacity, shards uint32) *lruGen[entry[T]] {
 	lru, err := freelru.NewShardedWithSize[uint64, entry[T]](shards, capacity, capacity+capacity/4, u64identity)
 	if err != nil {
 		panic(err)
 	}
-	g := &lruGen[T]{lru: lru}
+	g := &lruGen[entry[T]]{lru: lru}
 	lru.SetOnEvict(func(_ uint64, e entry[T]) {
 		c.currentSize.Add(-int64(e.size))
 		g.n.Add(-1)

--- a/execution/cache/grow_lru.go
+++ b/execution/cache/grow_lru.go
@@ -38,11 +38,12 @@ import (
 // write lost in a retired generation is a benign miss, and an entry whose
 // removal a racing copy undid serves correct bytes until its stale stamp
 // drops it on the next read. Do not reuse for mutable-per-key values — those
-// need GenericCache's fenced swap. The onEvict-maintained counters are
-// approximate across grow windows (a lost write is counted but never
-// evicted; a raced removal can subtract twice).
+// need GenericCache's fenced swap. The onEvict-maintained counters — this
+// type's per-generation entry count and the caller's byte counters — are
+// approximate across grow windows (a lost write is counted but never evicted;
+// a raced removal can subtract twice).
 type growLRU[V any] struct {
-	cur      atomic.Pointer[freelru.ShardedLRU[uint64, V]]
+	cur      atomic.Pointer[lruGen[V]]
 	onEvict  func(uint64, V)
 	avgBytes int64
 
@@ -71,26 +72,30 @@ func newGrowLRU[V any](maxBytes datasize.ByteSize, avgBytes uint32, onEvict func
 	return g
 }
 
-func (g *growLRU[V]) newShards(capacity uint32) *freelru.ShardedLRU[uint64, V] {
+func (g *growLRU[V]) newShards(capacity uint32) *lruGen[V] {
 	lru, err := freelru.NewSharded[uint64, V](capacity, u64identity)
 	if err != nil {
 		panic(fmt.Sprintf("growLRU: NewSharded(%d): %s", capacity, err))
 	}
-	if g.onEvict != nil {
-		lru.SetOnEvict(g.onEvict)
-	}
-	return lru
+	gen := &lruGen[V]{lru: lru}
+	lru.SetOnEvict(func(k uint64, v V) {
+		gen.n.Add(-1)
+		if g.onEvict != nil {
+			g.onEvict(k, v)
+		}
+	})
+	return gen
 }
 
-func (g *growLRU[V]) Get(key uint64) (V, bool) { return g.cur.Load().Get(key) }
+func (g *growLRU[V]) Get(key uint64) (V, bool) { return g.cur.Load().lru.Get(key) }
 
 func (g *growLRU[V]) Add(key uint64, value V) {
-	lru := g.cur.Load()
-	if curCap := g.curCap.Load(); curCap < g.maxCap && lru.Len() >= int(curCap) {
+	gen := g.cur.Load()
+	if curCap := g.curCap.Load(); curCap < g.maxCap && gen.len() >= int(curCap) {
 		g.maybeGrow()
-		lru = g.cur.Load()
+		gen = g.cur.Load()
 	}
-	lru.Add(key, value)
+	gen.add(key, value)
 }
 
 func (g *growLRU[V]) maybeGrow() {
@@ -98,7 +103,7 @@ func (g *growLRU[V]) maybeGrow() {
 	defer g.resizeMu.Unlock()
 	old := g.cur.Load()
 	curCap := g.curCap.Load()
-	if curCap >= g.maxCap || old.Len() < int(curCap) {
+	if curCap >= g.maxCap || old.len() < int(curCap) {
 		return
 	}
 	newCap := min(curCap*genericCacheGrowFactor, g.maxCap)
@@ -107,9 +112,9 @@ func (g *growLRU[V]) maybeGrow() {
 		return
 	}
 	next := g.newShards(newCap)
-	for _, k := range old.Keys() {
-		if v, ok := old.Get(k); ok {
-			next.Add(k, v)
+	for _, k := range old.lru.Keys() {
+		if v, ok := old.lru.Get(k); ok {
+			next.add(k, v)
 		}
 	}
 	g.cur.Store(next)
@@ -117,8 +122,8 @@ func (g *growLRU[V]) maybeGrow() {
 	g.reserved += delta
 }
 
-func (g *growLRU[V]) Remove(key uint64) { g.cur.Load().Remove(key) }
-func (g *growLRU[V]) Len() int          { return g.cur.Load().Len() }
+func (g *growLRU[V]) Remove(key uint64) { g.cur.Load().lru.Remove(key) }
+func (g *growLRU[V]) Len() int          { return g.cur.Load().len() }
 
 // Purge empties the LRU and shrinks it back to the start size, returning the
 // grown budget to the envelope (it regrows on demand).


### PR DESCRIPTION
Stacked on #23522 — review that first; this PR's own diff is the second commit.

`growLRU.Add` ran its grow check through `freelru.ShardedLRU.Len`, which RLocks every shard in turn, on **every add** while the LRU was below its ceiling; `maybeGrow` scanned again inside `resizeMu`. `CodeCache` drives three of these layers (`hashToCode`, `codeHashToCode`, `codeSizeByCodeHash`) straight off the EVM code path.

Same fix as #23522: reuse `lruGen`, generalised over the value type, so the count comes from an atomic maintained by `add` and the `OnEvict` callback. `Len()` becomes O(1) too. `putContentLocked` already removes an existing entry before re-adding, so every `Add` reaching freelru is for an absent key — the invariant the counter needs.

`BenchmarkGrowLRUParallelAddGrow` (added), M4 Max, `-cpu 10`:

```
                       │ growLRU_Len  │           growLRU_counter           │
                       │    sec/op    │    sec/op     vs base               │
GrowLRUParallelAddGrow   756.90n ± 8%   96.58n ± 13%  -87.24% (p=0.002 n=6)
```

`CodeCache.Put` end-to-end does **not** move (500.2n → 497.1n, p=0.394): `addrToHash` / `addrToCodeHash` are `hashicorp/golang-lru` caches behind a single global mutex, and that dominates the put path. This PR removes real CPU time from the content layers; unlocking it end-to-end needs that addr LRU sharded, which is separate work.

Two tests pin counter == the LRU's real length: `growLRU` directly across add / remove / eviction / grow / `Purge`, and all three `CodeCache` layers under concurrent puts. Both verified to fail against a mutated counter.

No TDD cycle: performance refactor with no intended behaviour change.

https://claude.ai/code/session_01WFkAYPPhqPe1NXg41Nph78