### PR TITLE
diagnostics/diskutils: warn when datadir is on filesystem outside recommended set

### DIFF
--- a/db/datadir/dirs.go
+++ b/db/datadir/dirs.go
@@ -62,6 +62,35 @@ type Dirs struct {
 	Log string
 }
 
+// All returns every real directory a Dirs can point into (excluding
+// RelativeDataDir, which is an alternate form of DataDir, not its own dir).
+// A check that must see every mount point should walk this instead of
+// naming fields, so it doesn't go stale as fields are added here.
+func (d Dirs) All() []string {
+	return []string{
+		d.DataDir,
+		d.Chaindata,
+		d.Tmp,
+		d.Snap,
+		d.SnapIdx,
+		d.SnapHistory,
+		d.SnapDomain,
+		d.SnapAccessors,
+		d.SnapCaplin,
+		d.Downloader,
+		d.TxPool,
+		d.Nodes,
+		d.CaplinBlobs,
+		d.CaplinColumnData,
+		d.CaplinIndexing,
+		d.CaplinLatest,
+		d.CaplinGenesis,
+		d.CaplinHistory,
+		d.Migrations,
+		d.Log,
+	}
+}
+
 func New(datadir string) Dirs {
 	dirs := Open(datadir)
 

--- a/db/datadir/dirs.go
+++ b/db/datadir/dirs.go
@@ -65,7 +65,9 @@ type Dirs struct {
 // All returns every real directory a Dirs can point into (excluding
 // RelativeDataDir, which is an alternate form of DataDir, not its own dir).
 // A check that must see every mount point should walk this instead of
-// naming fields, so it doesn't go stale as fields are added here.
+// naming fields, so it doesn't go stale as fields are added here. Unlike
+// New()'s dir.MustExist list, not every returned path is guaranteed to
+// exist on disk; callers must tolerate a path that hasn't been created yet.
 func (d Dirs) All() []string {
 	return []string{
 		d.DataDir,

--- a/diagnostics/diskutils/filesystem.go
+++ b/diagnostics/diskutils/filesystem.go
@@ -17,6 +17,7 @@
 package diskutils
 
 import (
+	"path/filepath"
 	"slices"
 	"strings"
 
@@ -31,17 +32,66 @@ func IsRecommendedFilesystem(fsType string) bool {
 	return slices.Contains(recommendedFilesystems, strings.ToLower(fsType))
 }
 
-// WarnUnlessRecommendedFilesystem logs a warning when dirPath does not sit on
-// ext4 or XFS, the only filesystems Erigon measures performance on.
-func WarnUnlessRecommendedFilesystem(logger log.Logger, dirPath string) {
-	fsType, err := FilesystemType(dirPath)
-	if err != nil {
+// CheckFilesystem logs a warning for each filesystem behind dirPaths that is
+// neither ext4 nor XFS, the only ones Erigon measures performance on. Erigon
+// dirs can live on separate mounts, so they are reported per filesystem type.
+func CheckFilesystem(logger log.Logger, dirPaths ...string) {
+	groups, failed := unrecommendedByType(dirPaths, FilesystemType)
+	for dirPath, err := range failed {
 		logger.Debug("[diskutils] Cannot detect filesystem type", "path", dirPath, "err", err)
+	}
+	for _, group := range groups {
+		logger.Warn("[diskutils] Filesystem is neither ext4 nor XFS, performance is unverified",
+			"fstype", group.fsType, "paths", strings.Join(group.paths, ", "), "see", filesystemDocsURL)
+	}
+}
+
+type fsGroup struct {
+	fsType string
+	paths  []string
+}
+
+func unrecommendedByType(dirPaths []string, fsTypeOf func(string) (string, error)) ([]fsGroup, map[string]error) {
+	var groups []fsGroup
+	failed := map[string]error{}
+	seen := map[string]bool{"": true}
+
+	for _, dirPath := range dirPaths {
+		if seen[dirPath] {
+			continue
+		}
+		seen[dirPath] = true
+
+		fsType, err := fsTypeOf(dirPath)
+		if err != nil {
+			failed[dirPath] = err
+			continue
+		}
+		if IsRecommendedFilesystem(fsType) {
+			continue
+		}
+		if i := slices.IndexFunc(groups, func(g fsGroup) bool { return g.fsType == fsType }); i >= 0 {
+			groups[i].add(dirPath)
+			continue
+		}
+		groups = append(groups, fsGroup{fsType: fsType, paths: []string{dirPath}})
+	}
+	return groups, failed
+}
+
+// add keeps only the topmost dirs, so dirs sharing one mount are reported once.
+func (g *fsGroup) add(dirPath string) {
+	if slices.ContainsFunc(g.paths, func(p string) bool { return isAncestor(p, dirPath) }) {
 		return
 	}
-	if IsRecommendedFilesystem(fsType) {
-		return
+	g.paths = slices.DeleteFunc(g.paths, func(p string) bool { return isAncestor(dirPath, p) })
+	g.paths = append(g.paths, dirPath)
+}
+
+func isAncestor(ancestor, descendant string) bool {
+	if ancestor == descendant {
+		return true
 	}
-	logger.Warn("[diskutils] Filesystem is neither ext4 nor XFS, performance is unverified",
-		"path", dirPath, "fstype", fsType, "see", filesystemDocsURL)
+	prefix := strings.TrimSuffix(ancestor, string(filepath.Separator)) + string(filepath.Separator)
+	return strings.HasPrefix(descendant, prefix)
 }

--- a/diagnostics/diskutils/filesystem.go
+++ b/diagnostics/diskutils/filesystem.go
@@ -17,6 +17,7 @@
 package diskutils
 
 import (
+	"path/filepath"
 	"slices"
 	"strings"
 
@@ -87,19 +88,7 @@ func (g *fsGroup) add(dirPath string) {
 	g.paths = append(g.paths, dirPath)
 }
 
-// isAncestor treats both '/' and '\' as path separators regardless of GOOS,
-// since dirPaths can arrive already using either style.
 func isAncestor(ancestor, descendant string) bool {
-	if ancestor == descendant {
-		return true
-	}
-	trimmed := strings.TrimRight(ancestor, `/\`)
-	if trimmed == "" {
-		return ancestor != "" && descendant != "" && (descendant[0] == '/' || descendant[0] == '\\')
-	}
-	if !strings.HasPrefix(descendant, trimmed) || len(descendant) <= len(trimmed) {
-		return false
-	}
-	next := descendant[len(trimmed)]
-	return next == '/' || next == '\\'
+	rel, err := filepath.Rel(ancestor, descendant)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }

--- a/diagnostics/diskutils/filesystem.go
+++ b/diagnostics/diskutils/filesystem.go
@@ -17,7 +17,6 @@
 package diskutils
 
 import (
-	"path/filepath"
 	"slices"
 	"strings"
 
@@ -88,10 +87,16 @@ func (g *fsGroup) add(dirPath string) {
 	g.paths = append(g.paths, dirPath)
 }
 
+// isAncestor treats both '/' and '\' as path separators regardless of GOOS,
+// since dirPaths can arrive already using either style.
 func isAncestor(ancestor, descendant string) bool {
 	if ancestor == descendant {
 		return true
 	}
-	prefix := strings.TrimSuffix(ancestor, string(filepath.Separator)) + string(filepath.Separator)
-	return strings.HasPrefix(descendant, prefix)
+	trimmed := strings.TrimRight(ancestor, `/\`)
+	if trimmed == "" || !strings.HasPrefix(descendant, trimmed) || len(descendant) <= len(trimmed) {
+		return false
+	}
+	next := descendant[len(trimmed)]
+	return next == '/' || next == '\\'
 }

--- a/diagnostics/diskutils/filesystem.go
+++ b/diagnostics/diskutils/filesystem.go
@@ -54,10 +54,10 @@ type fsGroup struct {
 func unrecommendedByType(dirPaths []string, fsTypeOf func(string) (string, error)) ([]fsGroup, map[string]error) {
 	var groups []fsGroup
 	failed := map[string]error{}
-	seen := map[string]bool{"": true}
+	seen := map[string]bool{}
 
 	for _, dirPath := range dirPaths {
-		if seen[dirPath] {
+		if dirPath == "" || seen[dirPath] {
 			continue
 		}
 		seen[dirPath] = true
@@ -70,7 +70,7 @@ func unrecommendedByType(dirPaths []string, fsTypeOf func(string) (string, error
 		if IsRecommendedFilesystem(fsType) {
 			continue
 		}
-		if i := slices.IndexFunc(groups, func(g fsGroup) bool { return g.fsType == fsType }); i >= 0 {
+		if i := slices.IndexFunc(groups, func(g fsGroup) bool { return strings.EqualFold(g.fsType, fsType) }); i >= 0 {
 			groups[i].add(dirPath)
 			continue
 		}

--- a/diagnostics/diskutils/filesystem.go
+++ b/diagnostics/diskutils/filesystem.go
@@ -23,7 +23,7 @@ import (
 	"github.com/erigontech/erigon/common/log/v3"
 )
 
-const filesystemDocsURL = "https://docs.erigon.tech/get-started/hardware-requirements#filesystems-to-avoid"
+const filesystemDocsURL = "https://docs.erigon.tech/get-started/hardware-requirements"
 
 var recommendedFilesystems = []string{"ext4", "xfs"}
 
@@ -94,7 +94,10 @@ func isAncestor(ancestor, descendant string) bool {
 		return true
 	}
 	trimmed := strings.TrimRight(ancestor, `/\`)
-	if trimmed == "" || !strings.HasPrefix(descendant, trimmed) || len(descendant) <= len(trimmed) {
+	if trimmed == "" {
+		return ancestor != "" && descendant != "" && (descendant[0] == '/' || descendant[0] == '\\')
+	}
+	if !strings.HasPrefix(descendant, trimmed) || len(descendant) <= len(trimmed) {
 		return false
 	}
 	next := descendant[len(trimmed)]

--- a/diagnostics/diskutils/filesystem.go
+++ b/diagnostics/diskutils/filesystem.go
@@ -1,0 +1,47 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package diskutils
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/erigontech/erigon/common/log/v3"
+)
+
+const filesystemDocsURL = "https://docs.erigon.tech/get-started/hardware-requirements#filesystems-to-avoid"
+
+var recommendedFilesystems = []string{"ext4", "xfs"}
+
+func IsRecommendedFilesystem(fsType string) bool {
+	return slices.Contains(recommendedFilesystems, strings.ToLower(fsType))
+}
+
+// WarnUnlessRecommendedFilesystem logs a warning when dirPath does not sit on
+// ext4 or XFS, the only filesystems Erigon measures performance on.
+func WarnUnlessRecommendedFilesystem(logger log.Logger, dirPath string) {
+	fsType, err := FilesystemType(dirPath)
+	if err != nil {
+		logger.Debug("[diskutils] Cannot detect filesystem type", "path", dirPath, "err", err)
+		return
+	}
+	if IsRecommendedFilesystem(fsType) {
+		return
+	}
+	logger.Warn("[diskutils] Filesystem is neither ext4 nor XFS, performance is unverified",
+		"path", dirPath, "fstype", fsType, "see", filesystemDocsURL)
+}

--- a/diagnostics/diskutils/filesystem_darwin.go
+++ b/diagnostics/diskutils/filesystem_darwin.go
@@ -1,0 +1,41 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build darwin
+
+package diskutils
+
+import (
+	"fmt"
+	"syscall"
+)
+
+// FilesystemType returns the mount's filesystem type, e.g. "apfs", "hfs".
+func FilesystemType(dirPath string) (string, error) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(dirPath, &stat); err != nil {
+		return "", fmt.Errorf("statfs %s: %w", dirPath, err)
+	}
+
+	name := make([]byte, 0, len(stat.Fstypename))
+	for _, b := range &stat.Fstypename {
+		if b == 0 {
+			break
+		}
+		name = append(name, byte(b))
+	}
+	return string(name), nil
+}

--- a/diagnostics/diskutils/filesystem_darwin.go
+++ b/diagnostics/diskutils/filesystem_darwin.go
@@ -20,22 +20,15 @@ package diskutils
 
 import (
 	"fmt"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // FilesystemType returns the mount's filesystem type, e.g. "apfs", "hfs".
 func FilesystemType(dirPath string) (string, error) {
-	var stat syscall.Statfs_t
-	if err := syscall.Statfs(dirPath, &stat); err != nil {
+	var stat unix.Statfs_t
+	if err := unix.Statfs(dirPath, &stat); err != nil {
 		return "", fmt.Errorf("statfs %s: %w", dirPath, err)
 	}
-
-	name := make([]byte, 0, len(stat.Fstypename))
-	for _, b := range &stat.Fstypename {
-		if b == 0 {
-			break
-		}
-		name = append(name, byte(b))
-	}
-	return string(name), nil
+	return unix.ByteSliceToString(stat.Fstypename[:]), nil
 }

--- a/diagnostics/diskutils/filesystem_linux.go
+++ b/diagnostics/diskutils/filesystem_linux.go
@@ -1,0 +1,44 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build linux
+
+package diskutils
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// FilesystemType returns the mount's filesystem type, e.g. "ext4", "xfs", "zfs".
+func FilesystemType(dirPath string) (string, error) {
+	var stat syscall.Stat_t
+	if err := syscall.Stat(dirPath, &stat); err != nil {
+		return "", fmt.Errorf("stat %s: %w", dirPath, err)
+	}
+	devID := fmt.Sprintf("%d:%d", unix.Major(uint64(stat.Dev)), unix.Minor(uint64(stat.Dev)))
+
+	mountsFile, err := os.Open("/proc/self/mountinfo")
+	if err != nil {
+		return "", err
+	}
+	defer mountsFile.Close()
+
+	return fsTypeFromMountinfo(mountsFile, devID)
+}

--- a/diagnostics/diskutils/filesystem_other.go
+++ b/diagnostics/diskutils/filesystem_other.go
@@ -1,0 +1,25 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !darwin && !windows && !linux
+
+package diskutils
+
+import "errors"
+
+func FilesystemType(dirPath string) (string, error) {
+	return "", errors.New("filesystem type detection is not implemented for this platform")
+}

--- a/diagnostics/diskutils/filesystem_test.go
+++ b/diagnostics/diskutils/filesystem_test.go
@@ -135,9 +135,8 @@ func TestUnrecommendedByTypeAncestorReplacesDescendant(t *testing.T) {
 }
 
 func TestIsAncestorAcceptsAnySeparator(t *testing.T) {
-	// dirPaths can arrive using either separator style regardless of GOOS
-	// (e.g. Windows paths from filepath.Join use '\', test/config paths use
-	// '/'), so isAncestor must not hardcode the host's filepath.Separator.
+	// See isAncestor's doc comment for why both separator styles must work
+	// regardless of GOOS.
 	for _, tc := range []struct {
 		ancestor, descendant string
 		want                 bool
@@ -146,6 +145,8 @@ func TestIsAncestorAcceptsAnySeparator(t *testing.T) {
 		{"/data", "/data/chaindata", true},
 		{`C:\data`, `C:\data-other`, false},
 		{"/data", "/data-other", false},
+		{"/", "/data", true},
+		{`\`, `\data`, true},
 	} {
 		require.Equal(t, tc.want, isAncestor(tc.ancestor, tc.descendant), "%s -> %s", tc.ancestor, tc.descendant)
 	}
@@ -187,16 +188,25 @@ func TestFsTypeFromMountinfo(t *testing.T) {
 }
 
 func TestFsTypeFromMountinfoLongLine(t *testing.T) {
-	// An overlay2 lowerdir= superoption listing many image layers can push a
-	// single line well past bufio.Scanner's default 64KB token limit. devID
-	// "9:99" appears only on this line, so a match proves the long line itself
-	// was scanned rather than an earlier line in the sample.
+	// devID "9:99" appears only on this line, so a match proves the long
+	// line itself was scanned rather than an earlier line in the sample.
 	longSuperOptions := "lowerdir=" + strings.Repeat("/var/lib/docker/overlay2/layer:", 8000)
 	line := "64 27 9:99 / /var/lib/docker/overlay rw,relatime - overlay overlay " + longSuperOptions + "\n"
 
 	got, err := fsTypeFromMountinfo(strings.NewReader(mountinfoSample+line), "9:99")
 	require.NoError(t, err)
 	require.Equal(t, "overlay", got)
+}
+
+func TestFsTypeFromMountinfoContinuesPastVeryLongLine(t *testing.T) {
+	// A single oversized line (see fsTypeFromMountinfo's doc comment) must
+	// not stop the scan before it reaches a later, well-formed line.
+	oversized := "64 27 9:99 / /var/lib/docker/overlay rw,relatime - overlay overlay lowerdir=" +
+		strings.Repeat("/var/lib/docker/overlay2/layer:", 40000) + "\n"
+
+	got, err := fsTypeFromMountinfo(strings.NewReader(oversized+mountinfoSample), "8:2")
+	require.NoError(t, err)
+	require.Equal(t, "ext4", got)
 }
 
 func TestFsTypeFromMountinfoRejectsSeparatorBeforeSixFixedFields(t *testing.T) {

--- a/diagnostics/diskutils/filesystem_test.go
+++ b/diagnostics/diskutils/filesystem_test.go
@@ -17,6 +17,7 @@
 package diskutils
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -60,6 +61,73 @@ func TestFilesystemType(t *testing.T) {
 	fsType, err := FilesystemType(t.TempDir())
 	require.NoError(t, err)
 	require.NotEmpty(t, fsType)
+}
+
+func TestUnrecommendedByType(t *testing.T) {
+	fsTypeOf := func(dirPath string) (string, error) {
+		switch dirPath {
+		case "/data", "/data/chaindata":
+			return "zfs", nil
+		case "/snap", "/snap/domain":
+			return "btrfs", nil
+		case "/fast":
+			return "ext4", nil
+		case "/xfs":
+			return "XFS", nil
+		}
+		return "", errors.New("no such mount")
+	}
+
+	groups, failed := unrecommendedByType(
+		[]string{"/fast", "/data", "/snap", "/xfs", "/data/chaindata", "/snap/domain", "/gone"}, fsTypeOf)
+
+	require.Equal(t, []fsGroup{
+		{fsType: "zfs", paths: []string{"/data"}},
+		{fsType: "btrfs", paths: []string{"/snap"}},
+	}, groups)
+	require.Len(t, failed, 1)
+	require.Error(t, failed["/gone"])
+}
+
+func TestUnrecommendedByTypeKeepsSeparateMounts(t *testing.T) {
+	fsTypeOf := func(dirPath string) (string, error) {
+		switch dirPath {
+		case "/data":
+			return "ext4", nil
+		case "/data/chaindata", "/mnt/snap":
+			return "zfs", nil
+		}
+		return "", errors.New("no such mount")
+	}
+
+	groups, _ := unrecommendedByType([]string{"/data", "/data/chaindata", "/mnt/snap"}, fsTypeOf)
+
+	require.Equal(t, []fsGroup{{fsType: "zfs", paths: []string{"/data/chaindata", "/mnt/snap"}}}, groups)
+}
+
+func TestUnrecommendedByTypeAncestorReplacesDescendant(t *testing.T) {
+	fsTypeOf := func(string) (string, error) { return "zfs", nil }
+
+	groups, _ := unrecommendedByType([]string{"/data/chaindata", "/data-other", "/data"}, fsTypeOf)
+
+	require.Equal(t, []fsGroup{{fsType: "zfs", paths: []string{"/data-other", "/data"}}}, groups)
+}
+
+func TestUnrecommendedByTypeAllRecommended(t *testing.T) {
+	fsTypeOf := func(string) (string, error) { return "ext4", nil }
+
+	groups, failed := unrecommendedByType([]string{"/a", "/b"}, fsTypeOf)
+
+	require.Empty(t, groups)
+	require.Empty(t, failed)
+}
+
+func TestUnrecommendedByTypeSkipsDuplicatePaths(t *testing.T) {
+	fsTypeOf := func(string) (string, error) { return "zfs", nil }
+
+	groups, _ := unrecommendedByType([]string{"/data", "/data", ""}, fsTypeOf)
+
+	require.Equal(t, []fsGroup{{fsType: "zfs", paths: []string{"/data"}}}, groups)
 }
 
 func TestFsTypeFromMountinfo(t *testing.T) {

--- a/diagnostics/diskutils/filesystem_test.go
+++ b/diagnostics/diskutils/filesystem_test.go
@@ -18,6 +18,7 @@ package diskutils
 
 import (
 	"errors"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -59,6 +60,10 @@ func TestIsRecommendedFilesystem(t *testing.T) {
 
 func TestFilesystemType(t *testing.T) {
 	fsType, err := FilesystemType(t.TempDir())
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" && runtime.GOOS != "windows" {
+		require.Error(t, err) // filesystem_other.go: no detector on this platform
+		return
+	}
 	require.NoError(t, err)
 	require.NotEmpty(t, fsType)
 }
@@ -105,6 +110,22 @@ func TestUnrecommendedByTypeKeepsSeparateMounts(t *testing.T) {
 	require.Equal(t, []fsGroup{{fsType: "zfs", paths: []string{"/data/chaindata", "/mnt/snap"}}}, groups)
 }
 
+func TestUnrecommendedByTypeGroupsAcrossCase(t *testing.T) {
+	fsTypeOf := func(dirPath string) (string, error) {
+		switch dirPath {
+		case "/data":
+			return "ZFS", nil
+		case "/mnt/snap":
+			return "zfs", nil
+		}
+		return "", errors.New("no such mount")
+	}
+
+	groups, _ := unrecommendedByType([]string{"/data", "/mnt/snap"}, fsTypeOf)
+
+	require.Equal(t, []fsGroup{{fsType: "ZFS", paths: []string{"/data", "/mnt/snap"}}}, groups)
+}
+
 func TestUnrecommendedByTypeAncestorReplacesDescendant(t *testing.T) {
 	fsTypeOf := func(string) (string, error) { return "zfs", nil }
 
@@ -146,6 +167,29 @@ func TestFsTypeFromMountinfo(t *testing.T) {
 		require.NoError(t, err, tc.devID)
 		require.Equal(t, tc.want, got, tc.devID)
 	}
+}
+
+func TestFsTypeFromMountinfoLongLine(t *testing.T) {
+	// An overlay2 lowerdir= superoption listing many image layers can push a
+	// single line well past bufio.Scanner's default 64KB token limit. devID
+	// "9:99" appears only on this line, so a match proves the long line itself
+	// was scanned rather than an earlier line in the sample.
+	longSuperOptions := "lowerdir=" + strings.Repeat("/var/lib/docker/overlay2/layer:", 8000)
+	line := "64 27 9:99 / /var/lib/docker/overlay rw,relatime - overlay overlay " + longSuperOptions + "\n"
+
+	got, err := fsTypeFromMountinfo(strings.NewReader(mountinfoSample+line), "9:99")
+	require.NoError(t, err)
+	require.Equal(t, "overlay", got)
+}
+
+func TestFsTypeFromMountinfoRejectsSeparatorBeforeSixFixedFields(t *testing.T) {
+	// The six fixed fields (mountID parentID major:minor root mountPoint options)
+	// come before any optional field, so "-" can never legitimately appear
+	// before index 6; a line where it does is malformed and must not match.
+	malformed := "21 27 0:99 / - ext4 /dev/sda3 rw\n"
+
+	_, err := fsTypeFromMountinfo(strings.NewReader(malformed), "0:99")
+	require.Error(t, err)
 }
 
 func TestFsTypeFromMountinfoUnknownDevice(t *testing.T) {

--- a/diagnostics/diskutils/filesystem_test.go
+++ b/diagnostics/diskutils/filesystem_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package diskutils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Sample lines from /proc/self/mountinfo: fields 6..n are optional and only
+// present on some mounts, so the filesystem type has to be located after "-".
+const mountinfoSample = `21 27 0:20 / /proc rw,relatime shared:5 - proc proc rw
+26 27 0:24 / /run rw,nosuid,nodev shared:2 - tmpfs tmpfs rw,size=1608940k
+27 1 8:2 / / rw,relatime shared:1 - ext4 /dev/sda2 rw
+36 27 8:17 / /mnt/data rw,relatime shared:22 - xfs /dev/sdb1 rw,attr2
+48 27 0:52 / /mnt/pool rw,relatime shared:31 - zfs pool/erigon rw,xattr
+52 27 0:60 /subvol /mnt/btr rw,relatime shared:41 - btrfs /dev/sdc1 rw,ssd
+64 27 0:71 / /var/lib/docker/overlay rw,relatime - overlay overlay rw,lowerdir=/a
+70 27 253:0 / /mnt/noopt rw,relatime - ext4 /dev/dm-0 rw
+`
+
+func TestIsRecommendedFilesystem(t *testing.T) {
+	for _, tc := range []struct {
+		fsType string
+		want   bool
+	}{
+		{"ext4", true},
+		{"xfs", true},
+		{"EXT4", true},
+		{"XFS", true},
+		{"zfs", false},
+		{"btrfs", false},
+		{"apfs", false},
+		{"overlay", false},
+		{"NTFS", false},
+		{"ext3", false},
+		{"", false},
+	} {
+		require.Equal(t, tc.want, IsRecommendedFilesystem(tc.fsType), tc.fsType)
+	}
+}
+
+func TestFilesystemType(t *testing.T) {
+	fsType, err := FilesystemType(t.TempDir())
+	require.NoError(t, err)
+	require.NotEmpty(t, fsType)
+}
+
+func TestFsTypeFromMountinfo(t *testing.T) {
+	for _, tc := range []struct {
+		devID string
+		want  string
+	}{
+		{"8:2", "ext4"},
+		{"8:17", "xfs"},
+		{"0:52", "zfs"},
+		{"0:60", "btrfs"},
+		{"0:71", "overlay"},
+		{"253:0", "ext4"},
+	} {
+		got, err := fsTypeFromMountinfo(strings.NewReader(mountinfoSample), tc.devID)
+		require.NoError(t, err, tc.devID)
+		require.Equal(t, tc.want, got, tc.devID)
+	}
+}
+
+func TestFsTypeFromMountinfoUnknownDevice(t *testing.T) {
+	_, err := fsTypeFromMountinfo(strings.NewReader(mountinfoSample), "99:99")
+	require.Error(t, err)
+}
+
+func TestFilesystemTypeMissingPath(t *testing.T) {
+	_, err := FilesystemType(t.TempDir() + "/does-not-exist")
+	require.Error(t, err)
+}

--- a/diagnostics/diskutils/filesystem_test.go
+++ b/diagnostics/diskutils/filesystem_test.go
@@ -134,6 +134,23 @@ func TestUnrecommendedByTypeAncestorReplacesDescendant(t *testing.T) {
 	require.Equal(t, []fsGroup{{fsType: "zfs", paths: []string{"/data-other", "/data"}}}, groups)
 }
 
+func TestIsAncestorAcceptsAnySeparator(t *testing.T) {
+	// dirPaths can arrive using either separator style regardless of GOOS
+	// (e.g. Windows paths from filepath.Join use '\', test/config paths use
+	// '/'), so isAncestor must not hardcode the host's filepath.Separator.
+	for _, tc := range []struct {
+		ancestor, descendant string
+		want                 bool
+	}{
+		{`C:\data`, `C:\data\chaindata`, true},
+		{"/data", "/data/chaindata", true},
+		{`C:\data`, `C:\data-other`, false},
+		{"/data", "/data-other", false},
+	} {
+		require.Equal(t, tc.want, isAncestor(tc.ancestor, tc.descendant), "%s -> %s", tc.ancestor, tc.descendant)
+	}
+}
+
 func TestUnrecommendedByTypeAllRecommended(t *testing.T) {
 	fsTypeOf := func(string) (string, error) { return "ext4", nil }
 

--- a/diagnostics/diskutils/filesystem_test.go
+++ b/diagnostics/diskutils/filesystem_test.go
@@ -18,6 +18,7 @@ package diskutils
 
 import (
 	"errors"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -134,19 +135,22 @@ func TestUnrecommendedByTypeAncestorReplacesDescendant(t *testing.T) {
 	require.Equal(t, []fsGroup{{fsType: "zfs", paths: []string{"/data-other", "/data"}}}, groups)
 }
 
-func TestIsAncestorAcceptsAnySeparator(t *testing.T) {
-	// See isAncestor's doc comment for why both separator styles must work
-	// regardless of GOOS.
+func TestIsAncestor(t *testing.T) {
+	sep := string(filepath.Separator)
+	root := sep + "data"
+	child := filepath.Join(root, "chaindata")
 	for _, tc := range []struct {
 		ancestor, descendant string
 		want                 bool
 	}{
-		{`C:\data`, `C:\data\chaindata`, true},
-		{"/data", "/data/chaindata", true},
-		{`C:\data`, `C:\data-other`, false},
-		{"/data", "/data-other", false},
-		{"/", "/data", true},
-		{`\`, `\data`, true},
+		{root, child, true},
+		{root, root, true},
+		{root + sep, child, true},
+		{sep, root, true},
+		{root, root + "-other", false},
+		{child, root, false},
+		{root, filepath.Join(root, "..", "elsewhere"), false},
+		{root, filepath.Join(root, "..foo"), true},
 	} {
 		require.Equal(t, tc.want, isAncestor(tc.ancestor, tc.descendant), "%s -> %s", tc.ancestor, tc.descendant)
 	}

--- a/diagnostics/diskutils/filesystem_windows.go
+++ b/diagnostics/diskutils/filesystem_windows.go
@@ -19,7 +19,6 @@
 package diskutils
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -35,17 +34,19 @@ func FilesystemType(dirPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	volume := filepath.VolumeName(absPath)
-	if volume == "" {
-		return "", fmt.Errorf("cannot resolve volume name for %s", absPath)
-	}
-
-	root, err := windows.UTF16PtrFromString(volume + `\`)
+	absPathPtr, err := windows.UTF16PtrFromString(absPath)
 	if err != nil {
 		return "", err
 	}
+
+	// GetVolumePathName rather than filepath.VolumeName: a volume can be mounted
+	// as a folder on another drive, whose letter names a different filesystem.
+	mountPoint := make([]uint16, windows.MAX_PATH+1)
+	if err := windows.GetVolumePathName(absPathPtr, &mountPoint[0], uint32(len(mountPoint))); err != nil {
+		return "", err
+	}
 	fsName := make([]uint16, windows.MAX_PATH+1)
-	if err := windows.GetVolumeInformation(root, nil, 0, nil, nil, nil, &fsName[0], uint32(len(fsName))); err != nil {
+	if err := windows.GetVolumeInformation(&mountPoint[0], nil, 0, nil, nil, nil, &fsName[0], uint32(len(fsName))); err != nil {
 		return "", err
 	}
 	return windows.UTF16ToString(fsName), nil

--- a/diagnostics/diskutils/filesystem_windows.go
+++ b/diagnostics/diskutils/filesystem_windows.go
@@ -1,0 +1,52 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build windows
+
+package diskutils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+// FilesystemType returns the volume's filesystem type, e.g. "NTFS", "ReFS".
+func FilesystemType(dirPath string) (string, error) {
+	if _, err := os.Stat(dirPath); err != nil {
+		return "", err
+	}
+	absPath, err := filepath.Abs(dirPath)
+	if err != nil {
+		return "", err
+	}
+	volume := filepath.VolumeName(absPath)
+	if volume == "" {
+		return "", fmt.Errorf("cannot resolve volume name for %s", absPath)
+	}
+
+	root, err := windows.UTF16PtrFromString(volume + `\`)
+	if err != nil {
+		return "", err
+	}
+	fsName := make([]uint16, windows.MAX_PATH+1)
+	if err := windows.GetVolumeInformation(root, nil, 0, nil, nil, nil, &fsName[0], uint32(len(fsName))); err != nil {
+		return "", err
+	}
+	return windows.UTF16ToString(fsName), nil
+}

--- a/diagnostics/diskutils/mountinfo.go
+++ b/diagnostics/diskutils/mountinfo.go
@@ -1,0 +1,46 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package diskutils
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+)
+
+// fsTypeFromMountinfo returns the filesystem type of the mount whose major:minor
+// device ID is devID. Format: mountID parentID major:minor root mountPoint
+// options [optional fields] - fsType source superOptions
+func fsTypeFromMountinfo(mountinfo io.Reader, devID string) (string, error) {
+	scanner := bufio.NewScanner(mountinfo)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		separator := slices.Index(fields, "-")
+		if separator < 3 || separator+1 >= len(fields) {
+			continue
+		}
+		if fields[2] == devID {
+			return fields[separator+1], nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return "", fmt.Errorf("no mountinfo entry for device %s", devID)
+}

--- a/diagnostics/diskutils/mountinfo.go
+++ b/diagnostics/diskutils/mountinfo.go
@@ -24,29 +24,35 @@ import (
 	"strings"
 )
 
-// maxMountinfoLine covers the longest lines seen in practice, e.g. an
-// overlay2 mount's lowerdir= superoption listing many image layers, well
-// past bufio.Scanner's default 64KB bufio.MaxScanTokenSize.
-const maxMountinfoLine = 1 << 20
-
 // fsTypeFromMountinfo returns the filesystem type of the mount whose major:minor
 // device ID is devID. Format: mountID parentID major:minor root mountPoint
 // options [optional fields] - fsType source superOptions
+//
+// Uses bufio.Reader instead of bufio.Scanner: an overlay2 mount's lowerdir=
+// superoption can list many image layers on one line, and Scanner aborts the
+// whole scan once any single line exceeds its buffer cap.
 func fsTypeFromMountinfo(mountinfo io.Reader, devID string) (string, error) {
-	scanner := bufio.NewScanner(mountinfo)
-	scanner.Buffer(make([]byte, 0, 64*1024), maxMountinfoLine)
-	for scanner.Scan() {
-		fields := strings.Fields(scanner.Text())
-		separator := slices.Index(fields, "-")
-		if separator < 6 || separator+1 >= len(fields) {
-			continue
+	reader := bufio.NewReaderSize(mountinfo, 64*1024)
+	for {
+		line, readErr := reader.ReadString('\n')
+		if fsType, ok := fsTypeFromMountinfoLine(line, devID); ok {
+			return fsType, nil
 		}
-		if fields[2] == devID {
-			return fields[separator+1], nil
+		if readErr != nil {
+			if readErr == io.EOF {
+				break
+			}
+			return "", readErr
 		}
-	}
-	if err := scanner.Err(); err != nil {
-		return "", err
 	}
 	return "", fmt.Errorf("no mountinfo entry for device %s", devID)
+}
+
+func fsTypeFromMountinfoLine(line, devID string) (string, bool) {
+	fields := strings.Fields(line)
+	separator := slices.Index(fields, "-")
+	if separator < 6 || separator+1 >= len(fields) || fields[2] != devID {
+		return "", false
+	}
+	return fields[separator+1], true
 }

--- a/diagnostics/diskutils/mountinfo.go
+++ b/diagnostics/diskutils/mountinfo.go
@@ -24,15 +24,21 @@ import (
 	"strings"
 )
 
+// maxMountinfoLine covers the longest lines seen in practice, e.g. an
+// overlay2 mount's lowerdir= superoption listing many image layers, well
+// past bufio.Scanner's default 64KB bufio.MaxScanTokenSize.
+const maxMountinfoLine = 1 << 20
+
 // fsTypeFromMountinfo returns the filesystem type of the mount whose major:minor
 // device ID is devID. Format: mountID parentID major:minor root mountPoint
 // options [optional fields] - fsType source superOptions
 func fsTypeFromMountinfo(mountinfo io.Reader, devID string) (string, error) {
 	scanner := bufio.NewScanner(mountinfo)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxMountinfoLine)
 	for scanner.Scan() {
 		fields := strings.Fields(scanner.Text())
 		separator := slices.Index(fields, "-")
-		if separator < 3 || separator+1 >= len(fields) {
+		if separator < 6 || separator+1 >= len(fields) {
 			continue
 		}
 		if fields[2] == devID {

--- a/node/node.go
+++ b/node/node.go
@@ -253,8 +253,7 @@ func (n *Node) openDataDir(ctx context.Context) error {
 		break
 	}
 
-	dirs := n.config.Dirs
-	diskutils.CheckFilesystem(n.logger, instdir, dirs.Chaindata, dirs.Snap, dirs.SnapDomain)
+	diskutils.CheckFilesystem(n.logger, n.config.Dirs.All()...)
 	return nil
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -253,7 +253,8 @@ func (n *Node) openDataDir(ctx context.Context) error {
 		break
 	}
 
-	diskutils.WarnUnlessRecommendedFilesystem(n.logger, instdir)
+	dirs := n.config.Dirs
+	diskutils.CheckFilesystem(n.logger, instdir, dirs.Chaindata, dirs.Snap, dirs.SnapDomain)
 	return nil
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -46,6 +46,7 @@ import (
 	"github.com/erigontech/erigon/db/migrations"
 	"github.com/erigontech/erigon/db/rawdb"
 	"github.com/erigontech/erigon/db/version"
+	"github.com/erigontech/erigon/diagnostics/diskutils"
 	"github.com/erigontech/erigon/node/debug"
 	"github.com/erigontech/erigon/node/nodecfg"
 )
@@ -251,6 +252,8 @@ func (n *Node) openDataDir(ctx context.Context) error {
 		n.dirLock = l
 		break
 	}
+
+	diskutils.WarnUnlessRecommendedFilesystem(n.logger, instdir)
 	return nil
 }
 


### PR DESCRIPTION
Erigon had no way to know which filesystem its dirs sit on, so a node on ZFS or btrfs looked identical to one on ext4 in the logs. This adds the detection and a startup warning pointing at the docs.

- `FilesystemType(dirPath)` per OS:
  - Linux: `stat` for `st_dev`, then match `major:minor` against `/proc/self/mountinfo` and read the type after the `-` separator. This gives exact names (`ext4`, `zfs`, `btrfs`, `overlay`), which `statfs` magic cannot — ext2/ext3/ext4 all share `0xEF53`.
  - Darwin: `statfs` `Fstypename`.
  - Windows: `GetVolumeInformation`.
  - Other platforms return an error, so no warning fires.
- `CheckFilesystem(logger, dirPaths...)` checks the datadir, chaindata, snapshots and snapshot-domain dirs, since these often live on separate mounts. Results are grouped per filesystem type, and a dir under an already-reported dir is not listed again — so the common single-mount setup produces exactly one line naming the datadir, while a snapshots dir on its own ZFS pool gets its own line.
- A detection failure only logs at debug, so it never becomes startup noise.
- Called from `node.openDataDir` after the datadir lock is taken, so it runs once per node start.

Sample output, from a dev-chain run on macOS where all four dirs share one mount:

```
[WARN] [08-24|11:09:29.812] [diskutils] Filesystem is neither ext4 nor XFS, performance is unverified fstype=apfs paths=/tmp/fsdd4 see=https://docs.erigon.tech/get-started/hardware-requirements#filesystems-to-avoid
```

Notes for review:

- The warning also fires on macOS and Windows (APFS/NTFS). That matches what the docs say — anything outside ext4/XFS is unmeasured — but it means one extra line in dev logs. Happy to gate it to Linux if preferred.
- The mountinfo parser and the grouping are pure functions, unit-tested with an injected type resolver, so the Linux path and the multi-mount cases are covered by tests running on any OS.