### PR TITLE
db/snaptype, db/snapshotsync: epoch-aligned block segments via "ep" filename marker

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -1201,6 +1201,24 @@ func allSnapshots(ctx context.Context, db kv.RoDB, logger log.Logger) (*blocksna
 
 		_aggSingleton.SetProduceMod(snapCfg.ProduceE3)
 
+		if rwDB, ok := db.(kv.RwDB); ok {
+			var needsMigration bool
+			if needsMigration, err = freezeblocks.HasDecimalBlockSegments(dirs, chainConfig); err != nil {
+				return
+			}
+			if needsMigration {
+				var unlock func()
+				if unlock, err = dirs.TryFlock(); err != nil {
+					return
+				}
+				err = freezeblocks.MigrateDecimalToEpoch(ctx, dirs, rwDB, chainConfig, estimate.CompressSnapshot.Workers(), logger)
+				unlock()
+				if err != nil {
+					return
+				}
+			}
+		}
+
 		g := &errgroup.Group{}
 		g.Go(func() error {
 			_allSnapshotsSingleton.OptimisticalyOpenFolder()

--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -1207,6 +1207,9 @@ func allSnapshots(ctx context.Context, db kv.RoDB, logger log.Logger) (*blocksna
 				return
 			}
 			if needsMigration {
+				if err = freezeblocks.CheckLegacyDownloadFinished(rwDB, dirs, chainConfig); err != nil {
+					return
+				}
 				var unlock func()
 				if unlock, err = dirs.TryFlock(); err != nil {
 					return

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -465,6 +465,15 @@ func RemoteServices(ctx context.Context, cfg *httpcfg.HttpCfg, logger log.Logger
 			return nil, nil, nil, nil, nil, nil, nil, nil, err
 		}
 		if allSegmentsDownloadComplete {
+			needsMigration, err := freezeblocks.HasDecimalBlockSegments(cfg.Dirs, cc)
+			if err != nil {
+				return nil, nil, nil, nil, nil, nil, nil, nil, err
+			}
+			if needsMigration {
+				return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf(
+					"datadir %s still has legacy decimal block segments: start erigon once (or run `erigon seg retire --datadir=%s`) to convert them, then start rpcdaemon",
+					cfg.Dirs.DataDir, cfg.Dirs.DataDir)
+			}
 			allSnapshots.OptimisticalyOpenFolder()
 
 			allSnapshots.LogStat("remote")

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -3330,6 +3330,9 @@ func doUnmerge(ctx context.Context, cliCtx *cli.Command, dirs datadir.Dirs) erro
 	if info.Epoch {
 		step = snaptype.EpochMinSegmentSize
 	}
+	if segLen := info.To - info.From; step > segLen {
+		step = segLen
+	}
 	var compressor *seg.Compressor
 	compresCfg := seg.DefaultCfg
 	workers := estimate.CompressSnapshot.Workers()

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -3074,6 +3074,11 @@ func openSnaps(ctx context.Context, cfg ethconfig.BlocksFreezing, dirs datadir.D
 
 	chainConfig := fromdb.ChainConfig(chainDB)
 
+	// Convert legacy decimal block segments to the epoch layout before opening them.
+	if err = freezeblocks.MigrateDecimalToEpoch(ctx, dirs, chainDB, chainConfig, estimate.CompressSnapshot.Workers(), logger); err != nil {
+		return
+	}
+
 	res.BlockSnaps = blocksnapshots.NewRoSnapshots(cfg, dirs.Snap, logger)
 	if err = res.BlockSnaps.OpenFolder(); err != nil {
 		return
@@ -3320,6 +3325,11 @@ func doUnmerge(ctx context.Context, cliCtx *cli.Command, dirs datadir.Dirs) erro
 	logger.Info("number of elements", "source", sourcefile, "count", decomp.Count())
 
 	blockFrom, blockTo := info.From, info.To
+
+	step := uint64(snaptype.Erigon2MinSegmentSize)
+	if info.Epoch {
+		step = snaptype.EpochMinSegmentSize
+	}
 	var compressor *seg.Compressor
 	compresCfg := seg.DefaultCfg
 	workers := estimate.CompressSnapshot.Workers()
@@ -3329,7 +3339,7 @@ func doUnmerge(ctx context.Context, cliCtx *cli.Command, dirs datadir.Dirs) erro
 	switch {
 	case info.Type.Enum() == snaptype2.Enums.Headers || info.Type.Enum() == snaptype2.Enums.Bodies:
 		for g.HasNext() {
-			if blockFrom%1000 == 0 {
+			if blockFrom%step == 0 {
 				if compressor != nil {
 					if err := compressor.Compress(); err != nil {
 						return err
@@ -3337,7 +3347,7 @@ func doUnmerge(ctx context.Context, cliCtx *cli.Command, dirs datadir.Dirs) erro
 					compressor.Close()
 				}
 
-				unmerged_fileinfo := info.Type.FileInfo(dirs.Snap, blockFrom, blockFrom+1000)
+				unmerged_fileinfo := info.Type.FileInfo(dirs.Snap, info.Epoch, blockFrom, blockFrom+step)
 				compressor, err = seg.NewCompressor(ctx, "unmerge", unmerged_fileinfo.Path, dirs.Tmp, compresCfg, log.LvlTrace, logger)
 				if err != nil {
 					return err
@@ -3361,8 +3371,8 @@ func doUnmerge(ctx context.Context, cliCtx *cli.Command, dirs datadir.Dirs) erro
 		return fmt.Errorf("unsupported type %s", info.Type.Enum().String())
 	default:
 		// tx unmerge
-		for ; blockFrom < blockTo; blockFrom += 1000 {
-			um_fileinfo := snaptype2.Enums.Bodies.Type().FileInfo(dirs.Snap, blockFrom, blockFrom+1000)
+		for ; blockFrom < blockTo; blockFrom += step {
+			um_fileinfo := snaptype2.Enums.Bodies.Type().FileInfo(dirs.Snap, info.Epoch, blockFrom, blockFrom+step)
 			bodiesSegment, err := seg.NewDecompressor(um_fileinfo.Path)
 			if err != nil {
 				return err

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -3075,6 +3075,9 @@ func openSnaps(ctx context.Context, cfg ethconfig.BlocksFreezing, dirs datadir.D
 	chainConfig := fromdb.ChainConfig(chainDB)
 
 	// Convert legacy decimal block segments to the epoch layout before opening them.
+	if err = freezeblocks.CheckLegacyDownloadFinished(chainDB, dirs, chainConfig); err != nil {
+		return
+	}
 	if err = freezeblocks.MigrateDecimalToEpoch(ctx, dirs, chainDB, chainConfig, estimate.CompressSnapshot.Workers(), logger); err != nil {
 		return
 	}

--- a/db/downloader/seedable_epoch_test.go
+++ b/db/downloader/seedable_epoch_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package downloader
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/db/snaptype2"
+)
+
+// An epoch block segment at the merge limit must be seedable like its decimal counterpart. Its name
+// carries the "-ep" marker as an extra dash-separated part, which the pre-filter in
+// seedableSegmentFiles must tolerate — otherwise no epoch segment ever gets a .torrent and the chain
+// cannot be published at all.
+func TestSeedableSegmentFilesAcceptsEpoch(t *testing.T) {
+	dir := t.TempDir()
+	full := snaptype2.Headers.FileInfo(dir, true, 0, 524_288)  // at EpochMergeLimit -> seedable
+	partial := snaptype2.Headers.FileInfo(dir, true, 0, 8_192) // below it -> not seedable
+	for _, f := range []string{full.Name(), partial.Name()} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, f), []byte{}, 0o644))
+	}
+
+	got, err := seedableSegmentFiles(dir, "mainnet", false)
+	require.NoError(t, err)
+	require.Equal(t, []string{full.Name()}, got)
+}

--- a/db/integrity/caplin_state_integrity_test.go
+++ b/db/integrity/caplin_state_integrity_test.go
@@ -35,7 +35,7 @@ import (
 
 func writeRootSeg(t *testing.T, dirs datadir.Dirs, table string, from, to uint64, words [][]byte) {
 	t.Helper()
-	name := snaptype.BeaconBlocks.FileName(version.ZeroVersion, from, to)
+	name := snaptype.BeaconBlocks.FileName(version.ZeroVersion, false, from, to)
 	name = strings.ReplaceAll(name, "beaconblocks", table)
 	c, err := seg.NewCompressor(context.Background(), "test", filepath.Join(dirs.SnapCaplin, name), dirs.Tmp, seg.DefaultCfg, log.LvlCrit, log.New())
 	require.NoError(t, err)

--- a/db/snapcfg/mergelimit_epoch_test.go
+++ b/db/snapcfg/mergelimit_epoch_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package snapcfg_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/db/snapcfg"
+	"github.com/erigontech/erigon/db/snaptype"
+	"github.com/erigontech/erigon/db/snaptype2"
+)
+
+// With epoch=true the block merge limit is the epoch frozen size and the merge steps are the epoch
+// ladder. Caplin keeps its own regime.
+func TestMergeLimitEpochRounding(t *testing.T) {
+	cfg := &snapcfg.Cfg{}
+
+	require.Equal(t, uint64(snaptype.EpochMergeLimit), snapcfg.MergeLimitFromCfg(cfg, snaptype.Unknown, true, 21_000_000))
+	require.Equal(t, []uint64{524_288, 65_536, 8_192}, snapcfg.MergeStepsFromCfg(cfg, snaptype.Unknown, true, 21_000_000))
+
+	// Caplin shards by slot and keeps its own limit, even when asked in the epoch regime.
+	require.Equal(t, uint64(snaptype.CaplinMergeLimit), cfg.MergeLimit(snaptype.CaplinEnums.BeaconBlocks, false, 21_000_000))
+	require.Equal(t, uint64(snaptype.CaplinMergeLimit), cfg.MergeLimit(snaptype.CaplinEnums.BeaconBlocks, true, 21_000_000))
+	require.Equal(t, uint64(snaptype.CaplinMergeLimit), cfg.MergeLimit(snaptype.CaplinEnums.BlobSidecars, true, 21_000_000))
+}
+
+// The decimal merge limit/steps are what a non-epoch chain (Aura) gets; the regime comes from the
+// explicit epoch argument, not from the type.
+func TestMergeLimitDecimal(t *testing.T) {
+	cfg := &snapcfg.Cfg{}
+	require.Equal(t, uint64(snaptype.Erigon2MergeLimit), cfg.MergeLimit(snaptype.Unknown, false, 21_000_000))
+	require.Equal(t, []uint64{100_000, 10_000}, snapcfg.MergeStepsFromCfg(cfg, snaptype.Unknown, false, 21_000_000))
+}
+
+// A full-size (524288) epoch segment is frozen and seedable; a smaller tier is neither. The ranges
+// are 1024- (not 1000-) aligned, so the FileInfo is built directly to keep the exact block bounds.
+func TestSeedableFrozenEpoch(t *testing.T) {
+	cfg := &snapcfg.Cfg{}
+
+	frozen := snaptype.FileInfo{Epoch: true, From: 0, To: snaptype.EpochMergeLimit, Type: snaptype2.Headers} // 524288
+	require.True(t, cfg.IsFrozen(frozen))
+	require.True(t, cfg.Seedable(frozen))
+
+	small := snaptype.FileInfo{Epoch: true, From: 0, To: 8_192, Type: snaptype2.Headers} // one era1 tier
+	require.False(t, cfg.IsFrozen(small))
+	require.False(t, cfg.Seedable(small))
+}

--- a/db/snapcfg/mergelimit_epoch_test.go
+++ b/db/snapcfg/mergelimit_epoch_test.go
@@ -61,3 +61,29 @@ func TestSeedableFrozenEpoch(t *testing.T) {
 	require.False(t, cfg.IsFrozen(small))
 	require.False(t, cfg.Seedable(small))
 }
+
+// The preverified type filter derives a file's type from the last dash-separated token before the
+// extension, which for an epoch segment is the "ep" marker rather than the type. Dropping those
+// entries as unreadable means a published epoch manifest can never turn into a download request.
+func TestTypedKeepsEpochEntries(t *testing.T) {
+	types := snaptype2.BlockSnapshotTypes
+	p := snapcfg.Preverified{Items: []snapcfg.PreverifiedItem{
+		{Name: "v1.1-000000-000512-headers-ep.seg", Hash: "aa"},
+		{Name: "v1.1-000000-000512-bodies-ep.seg", Hash: "bb"},
+		{Name: "v1.1-000000-000512-transactions-ep.seg", Hash: "cc"},
+		{Name: "v2.0-000000-000512-transactions-to-block-ep.idx", Hash: "dd"},
+		{Name: "v1.1-000000-000500-headers.seg", Hash: "ee"}, // decimal still kept
+	}}
+
+	var kept []string
+	for _, it := range p.Typed(types).Items {
+		kept = append(kept, it.Name)
+	}
+	require.ElementsMatch(t, []string{
+		"v1.1-000000-000512-headers-ep.seg",
+		"v1.1-000000-000512-bodies-ep.seg",
+		"v1.1-000000-000512-transactions-ep.seg",
+		"v2.0-000000-000512-transactions-to-block-ep.idx",
+		"v1.1-000000-000500-headers.seg",
+	}, kept)
+}

--- a/db/snapcfg/util.go
+++ b/db/snapcfg/util.go
@@ -242,6 +242,13 @@ func (p Preverified) Typed(types []snaptype.Type) Preverified {
 
 		//typeName, _ := strings.CutSuffix(parts[2], filepath.Ext(parts[2]))
 		typeName := name[lastSep+1 : dot]
+		// An epoch segment carries the "ep" marker as a suffix on the type, so the last dash-separated
+		// token is the marker; the type is the one before it.
+		if typeName == snaptype.EpochMarker {
+			if prevSep := strings.LastIndex(name[:lastSep], "-"); prevSep >= 0 {
+				typeName = name[prevSep+1 : lastSep]
+			}
+		}
 		include := false
 		idxIndex := 0
 		if strings.Contains(name, "transactions-to-block") { // transactions-to-block should just be "transactions" type

--- a/db/snapcfg/util.go
+++ b/db/snapcfg/util.go
@@ -433,21 +433,25 @@ type Cfg struct {
 
 // Seedable - can seed it over Bittorrent network to other nodes
 func (c Cfg) Seedable(info snaptype.FileInfo) bool {
-	mergeLimit := c.MergeLimit(info.Type.Enum(), info.From)
+	mergeLimit := c.MergeLimit(info.Type.Enum(), info.Epoch, info.From)
 	return info.To-info.From == mergeLimit
 }
 
 // IsFrozen - can't be merged to bigger files
 func (c Cfg) IsFrozen(info snaptype.FileInfo) bool {
-	mergeLimit := c.MergeLimit(info.Type.Enum(), info.From)
+	mergeLimit := c.MergeLimit(info.Type.Enum(), info.Epoch, info.From)
 	return info.To-info.From >= mergeLimit
 }
 
-func (c Cfg) MergeLimit(t snaptype.Enum, fromBlock uint64) uint64 {
+func (c Cfg) MergeLimit(t snaptype.Enum, epoch bool, fromBlock uint64) uint64 {
 	// Caplin entries are skipped below and no core entry can match a caplin enum, so the
-	// scan is a no-op for these types — and IsFrozen calls this per segment opened.
+	// scan is a no-op for these types — and IsFrozen calls this per segment opened. It shards by
+	// slot rather than by block, so it keeps its own limit even on an epoch chain.
 	if snaptype.IsCaplinType(t) {
 		return snaptype.CaplinMergeLimit
+	}
+	if epoch {
+		return snaptype.EpochMergeLimit
 	}
 
 	hasType := t == snaptype.MinCoreEnum
@@ -485,7 +489,7 @@ func (c Cfg) MergeLimit(t snaptype.Enum, fromBlock uint64) uint64 {
 		return snaptype.Erigon2MergeLimit
 	}
 
-	return c.MergeLimit(snaptype.MinCoreEnum, fromBlock)
+	return c.MergeLimit(snaptype.MinCoreEnum, epoch, fromBlock)
 }
 
 func RegisterKnownTypes(networkName string, types []snaptype.Type) {
@@ -494,17 +498,20 @@ func RegisterKnownTypes(networkName string, types []snaptype.Type) {
 
 var knownTypes = map[string][]snaptype.Type{}
 
-func MergeLimitFromCfg(cfg *Cfg, snapType snaptype.Enum, fromBlock uint64) uint64 {
-	return cfg.MergeLimit(snapType, fromBlock)
+func MergeLimitFromCfg(cfg *Cfg, snapType snaptype.Enum, epoch bool, fromBlock uint64) uint64 {
+	return cfg.MergeLimit(snapType, epoch, fromBlock)
 }
 
 var oldMergeSteps = append([]uint64{snaptype.Erigon2OldMergeLimit}, snaptype.MergeSteps...)
 
-func MergeStepsFromCfg(cfg *Cfg, snapType snaptype.Enum, fromBlock uint64) []uint64 {
-	mergeLimit := MergeLimitFromCfg(cfg, snapType, fromBlock)
+func MergeStepsFromCfg(cfg *Cfg, snapType snaptype.Enum, epoch bool, fromBlock uint64) []uint64 {
+	mergeLimit := MergeLimitFromCfg(cfg, snapType, epoch, fromBlock)
 
-	if mergeLimit == snaptype.Erigon2OldMergeLimit {
+	switch mergeLimit {
+	case snaptype.Erigon2OldMergeLimit:
 		return oldMergeSteps
+	case snaptype.EpochMergeLimit:
+		return snaptype.EpochMergeSteps
 	}
 
 	return snaptype.MergeSteps

--- a/db/snapcfg/util_test.go
+++ b/db/snapcfg/util_test.go
@@ -224,10 +224,10 @@ func TestMergeLimitCaplinTypesSkipPreverifiedScan(t *testing.T) {
 	for _, typ := range append(snaptype.CaplinSnapshotTypes, snaptype.CaplinStateSnapshotTypes...) {
 		e := typ.Enum()
 		require.True(t, snaptype.IsCaplinType(e), typ.Name())
-		require.Equal(t, uint64(snaptype.CaplinMergeLimit), cfg.MergeLimit(e, 0), typ.Name())
-		require.Equal(t, uint64(snaptype.CaplinMergeLimit), cfg.MergeLimit(e, 1_000_000), typ.Name())
+		require.Equal(t, uint64(snaptype.CaplinMergeLimit), cfg.MergeLimit(e, false, 0), typ.Name())
+		require.Equal(t, uint64(snaptype.CaplinMergeLimit), cfg.MergeLimit(e, false, 1_000_000), typ.Name())
 	}
 
-	require.Equal(t, uint64(snaptype.Erigon2MergeLimit), cfg.MergeLimit(snaptype.MinCoreEnum, 0),
+	require.Equal(t, uint64(snaptype.Erigon2MergeLimit), cfg.MergeLimit(snaptype.MinCoreEnum, false, 0),
 		"core types must still resolve through the preverified scan")
 }

--- a/db/snapshotsync/base_unknown_type_test.go
+++ b/db/snapshotsync/base_unknown_type_test.go
@@ -55,8 +55,8 @@ func TestFindOverlapsSkipsUnknownCaplinType(t *testing.T) {
 	dirs := datadir.New(t.TempDir())
 	unknownName := "v1.1-000000-000050-BlockProposers.seg"
 	validNames := []string{
-		snaptype.PendingDepositsDump.FileName(version.V1_1, 0, 50_000),
-		snaptype.PendingDepositsDump.FileName(version.V1_1, 50_000, 100_000),
+		snaptype.PendingDepositsDump.FileName(version.V1_1, false, 0, 50_000),
+		snaptype.PendingDepositsDump.FileName(version.V1_1, false, 50_000, 100_000),
 	}
 	require.NoError(t, os.WriteFile(filepath.Join(dirs.SnapCaplin, unknownName), []byte("unknown"), 0o644))
 	for _, name := range validNames {

--- a/db/snapshotsync/caplin_state_overlap_test.go
+++ b/db/snapshotsync/caplin_state_overlap_test.go
@@ -45,7 +45,7 @@ func writeCaplinStateFixture(t *testing.T, dir, table string, from, to uint64, l
 
 func writeCaplinStateFixtureVersion(t *testing.T, dir, table string, from, to uint64, v version.Version, logger log.Logger) (segPath, idxPath string) {
 	t.Helper()
-	segName := strings.ReplaceAll(snaptype.BeaconBlocks.FileName(v, from, to), "beaconblocks", table)
+	segName := strings.ReplaceAll(snaptype.BeaconBlocks.FileName(v, false, from, to), "beaconblocks", table)
 	segPath = filepath.Join(dir, segName)
 
 	compressCfg := seg.DefaultCfg

--- a/db/snapshotsync/caplin_state_snapshots.go
+++ b/db/snapshotsync/caplin_state_snapshots.go
@@ -488,7 +488,7 @@ func caplinStateFileName(snapName string, fromSlot, toSlot uint64) (string, erro
 	if typ == nil {
 		return "", fmt.Errorf("unknown caplin state snapshot type %q", snapName)
 	}
-	return typ.FileName(version.ZeroVersion, fromSlot, toSlot), nil
+	return typ.FileName(version.ZeroVersion, false, fromSlot, toSlot), nil
 }
 
 type caplinStateDumpJob struct {
@@ -589,7 +589,7 @@ func (s *CaplinStateSnapshots) BuildMissingIndices(ctx context.Context, logger l
 				return fmt.Errorf("invalid caplin state snapshot filename %q", df.FileName())
 			}
 
-			indexFile := filepath.Join(sn.Dir(), snaptype.IdxFileName(sn.Version, sn.From, sn.To, sn.CaplinTypeString))
+			indexFile := filepath.Join(sn.Dir(), snaptype.IdxFileName(sn.Version, false, sn.From, sn.To, sn.CaplinTypeString))
 			if _, err := os.Stat(indexFile); err == nil {
 				logger.Info("index file already exists, yet dirtyFile didn't have it opened", "seg", sn.Name())
 				continue

--- a/db/snapshotsync/caplinsnapschema/caplin_snap_schema_test.go
+++ b/db/snapshotsync/caplinsnapschema/caplin_snap_schema_test.go
@@ -41,11 +41,11 @@ func TestNewCaplinSchemaUsesRegisteredStateTypes(t *testing.T) {
 
 			dataFile, err := schema.DataFile(statecfg.Version{}, 0, 50_000)
 			require.NoError(t, err)
-			require.Equal(t, filepath.Join(dirs.SnapCaplin, typ.FileName(version.ZeroVersion, 0, 50_000)), dataFile)
+			require.Equal(t, filepath.Join(dirs.SnapCaplin, typ.FileName(version.ZeroVersion, false, 0, 50_000)), dataFile)
 
 			indexFile, err := schema.AccessorIdxFile(statecfg.Version{}, 0, 50_000, 0)
 			require.NoError(t, err)
-			require.Equal(t, filepath.Join(dirs.SnapCaplin, typ.IdxFileName(typ.Indexes()[0].Version.Current, 0, 50_000)), indexFile)
+			require.Equal(t, filepath.Join(dirs.SnapCaplin, typ.IdxFileName(typ.Indexes()[0].Version.Current, false, 0, 50_000)), indexFile)
 		})
 	}
 }

--- a/db/snapshotsync/find_overlaps_test.go
+++ b/db/snapshotsync/find_overlaps_test.go
@@ -30,7 +30,7 @@ import (
 
 func writeEmptySeg(t *testing.T, dir string, typ snaptype.Type, from, to uint64) string {
 	t.Helper()
-	name := typ.FileName(version.ZeroVersion, from, to)
+	name := typ.FileName(version.ZeroVersion, false, from, to)
 	path := filepath.Join(dir, name)
 	require.NoError(t, os.WriteFile(path, []byte{0}, 0o644))
 	return name

--- a/db/snapshotsync/freezeblocks/block_reader_test.go
+++ b/db/snapshotsync/freezeblocks/block_reader_test.go
@@ -55,7 +55,7 @@ import (
 func createTestSegmentFile(t *testing.T, from, to uint64, name snaptype.Enum, dir string, ver snaptype.Version, logger log.Logger) {
 	compressCfg := seg.DefaultCfg
 	compressCfg.MinPatternScore = 100
-	c, err := seg.NewCompressor(t.Context(), "test", filepath.Join(dir, snaptype.SegmentFileName(ver, from, to, name)), dir, compressCfg, log.LvlDebug, logger)
+	c, err := seg.NewCompressor(t.Context(), "test", filepath.Join(dir, snaptype.SegmentFileName(ver, false, from, to, name)), dir, compressCfg, log.LvlDebug, logger)
 	require.NoError(t, err)
 	defer c.Close()
 	c.DisableFsync()
@@ -67,7 +67,7 @@ func createTestSegmentFile(t *testing.T, from, to uint64, name snaptype.Enum, di
 		KeyCount:   1,
 		BucketSize: 10,
 		TmpDir:     dir,
-		IndexFile:  filepath.Join(dir, snaptype.IdxFileName(ver, from, to, name.String())),
+		IndexFile:  filepath.Join(dir, snaptype.IdxFileName(ver, false, from, to, name.String())),
 		LeafSize:   8,
 	}, logger)
 	require.NoError(t, err)
@@ -82,7 +82,7 @@ func createTestSegmentFile(t *testing.T, from, to uint64, name snaptype.Enum, di
 			KeyCount:   1,
 			BucketSize: 10,
 			TmpDir:     dir,
-			IndexFile:  filepath.Join(dir, snaptype.IdxFileName(ver, from, to, snaptype2.Indexes.TxnHash2BlockNum.Name)),
+			IndexFile:  filepath.Join(dir, snaptype.IdxFileName(ver, false, from, to, snaptype2.Indexes.TxnHash2BlockNum.Name)),
 			LeafSize:   8,
 		}, logger)
 		require.NoError(t, err)
@@ -97,7 +97,7 @@ func createTestSegmentFile(t *testing.T, from, to uint64, name snaptype.Enum, di
 func createTestSegmentOnlyFile(t *testing.T, from, to uint64, name snaptype.Enum, dir string, ver snaptype.Version, logger log.Logger) {
 	compressCfg := seg.DefaultCfg
 	compressCfg.MinPatternScore = 100
-	c, err := seg.NewCompressor(t.Context(), "test", filepath.Join(dir, snaptype.SegmentFileName(ver, from, to, name)), dir, compressCfg, log.LvlDebug, logger)
+	c, err := seg.NewCompressor(t.Context(), "test", filepath.Join(dir, snaptype.SegmentFileName(ver, false, from, to, name)), dir, compressCfg, log.LvlDebug, logger)
 	require.NoError(t, err)
 	defer c.Close()
 	c.DisableFsync()
@@ -108,7 +108,7 @@ func createTestSegmentOnlyFile(t *testing.T, from, to uint64, name snaptype.Enum
 func requireSegmentFilesExist(t *testing.T, dir string, ver snaptype.Version, from, to uint64, names ...snaptype.Enum) {
 	t.Helper()
 	for _, name := range names {
-		_, err := os.Stat(filepath.Join(dir, snaptype.SegmentFileName(ver, from, to, name)))
+		_, err := os.Stat(filepath.Join(dir, snaptype.SegmentFileName(ver, false, from, to, name)))
 		require.NoError(t, err)
 	}
 }
@@ -262,7 +262,7 @@ func TestBlockRetireFallback(t *testing.T) {
 	reopenedSnapshots.Close()
 
 	// Removing the unindexed overlap leaves the same indexed subsegments visible.
-	unindexedOverlap := filepath.Join(dirs.Snap, snaptype.SegmentFileName(ver, 1, 2000, snaptype2.Enums.Transactions))
+	unindexedOverlap := filepath.Join(dirs.Snap, snaptype.SegmentFileName(ver, false, 1, 2000, snaptype2.Enums.Transactions))
 	require.NoError(t, dir.RemoveFile(unindexedOverlap))
 
 	restoredSnapshots := blocksnapshots.NewRoSnapshots(snapshots.Cfg(), dirs.Snap, logger)
@@ -512,7 +512,7 @@ func TestCanonicalHashCache_SnapshotPath(t *testing.T) {
 	word := append([]byte{0}, rlpBytes...)
 
 	// Write the headers segment with a single valid entry.
-	segPath := filepath.Join(dirs.Snap, snaptype.SegmentFileName(ver, from, to, snaptype2.Enums.Headers))
+	segPath := filepath.Join(dirs.Snap, snaptype.SegmentFileName(ver, false, from, to, snaptype2.Enums.Headers))
 	compressCfg := seg.DefaultCfg
 	compressCfg.MinPatternScore = 100
 	c, err := seg.NewCompressor(t.Context(), "test", segPath, dirs.Snap, compressCfg, log.LvlDebug, logger)
@@ -523,7 +523,7 @@ func TestCanonicalHashCache_SnapshotPath(t *testing.T) {
 	c.Close()
 
 	// Build index with BaseDataID=from so OrdinalLookup(blockNum-from)=OrdinalLookup(0).
-	idxPath := filepath.Join(dirs.Snap, snaptype.IdxFileName(ver, from, to, snaptype2.Enums.Headers.String()))
+	idxPath := filepath.Join(dirs.Snap, snaptype.IdxFileName(ver, false, from, to, snaptype2.Enums.Headers.String()))
 	idx, err := recsplit.NewRecSplit(recsplit.RecSplitArgs{
 		KeyCount:   1,
 		BucketSize: 10,

--- a/db/snapshotsync/freezeblocks/block_snapshots.go
+++ b/db/snapshotsync/freezeblocks/block_snapshots.go
@@ -74,17 +74,30 @@ import (
 // transaction_hash  -> transactions_segment_offset
 // transaction_hash  -> block_number
 
-func chooseSegmentEnd(from, to uint64, snapType snaptype.Enum, snCfg *snapcfg.Cfg) uint64 {
-	blocksPerFile := snapcfg.MergeLimitFromCfg(snCfg, snapType, from)
+func chooseSegmentEnd(epoch bool, from, to uint64, snapType snaptype.Enum, snCfg *snapcfg.Cfg) uint64 {
+	blocksPerFile := snapcfg.MergeLimitFromCfg(snCfg, snapType, epoch, from)
+
+	minSize := uint64(snaptype.Erigon2MinSegmentSize)
+	if epoch {
+		minSize = snaptype.EpochMinSegmentSize
+	}
 
 	next := (from/blocksPerFile + 1) * blocksPerFile
 	to = min(next, to)
 
-	if to < snaptype.Erigon2MinSegmentSize {
+	if to < minSize {
 		return to
 	}
 
-	return to - (to % snaptype.Erigon2MinSegmentSize) // round down to the nearest 1k
+	return to - (to % minSize) // round down to the nearest minSize
+}
+
+func segmentNoCompress(epoch bool, size uint64) bool {
+	mergeLimit := uint64(snaptype.Erigon2MergeLimit)
+	if epoch {
+		mergeLimit = snaptype.EpochMergeLimit
+	}
+	return size < mergeLimit-1
 }
 
 type BlockRetire struct {
@@ -182,8 +195,7 @@ func (br *BlockRetire) snapshots() *blocksnapshots.RoSnapshots {
 func (br *BlockRetire) canRetire(blocksInSnapshots uint64, finalityCtx dbfinality.Context, snapType snaptype.Enum) (blockFrom, blockTo uint64, can bool) {
 	blockTo = finalityCtx.RetireToBlockNum()
 	blockFrom = blocksInSnapshots + 1
-	blockFrom, blockTo, can = snapshotsync.CanRetire(blockFrom, blockTo, snapType, br.snCfg, br.config.Snapshot.E2RetireStep)
-	return blockFrom, blockTo, can
+	return snapshotsync.CanRetire(snaptype2.RegimeFor(br.chainConfig), blockFrom, blockTo, snapType, br.snCfg, br.config.Snapshot.E2RetireStep)
 }
 
 func CanDeleteTo(curBlockNum uint64, blocksInSnapshots uint64) (blockTo uint64) {
@@ -495,8 +507,9 @@ func DumpBlocks(ctx context.Context, blockFrom, blockTo uint64, chainConfig *cha
 		return err
 	}
 
-	for i := blockFrom; i < blockTo; i = chooseSegmentEnd(i, blockTo, snaptype2.Enums.Headers, snCfg) {
-		lastTxNum, err := dumpBlocksRange(ctx, i, chooseSegmentEnd(i, blockTo, snaptype2.Enums.Headers, snCfg), tmpDir, snapDir, firstTxNum, chainDB, chainConfig, workers, lvl, logger, inProgress)
+	epoch := snaptype2.RegimeFor(chainConfig)
+	for i := blockFrom; i < blockTo; i = chooseSegmentEnd(epoch, i, blockTo, snaptype2.Enums.Headers, snCfg) {
+		lastTxNum, err := dumpBlocksRange(ctx, i, chooseSegmentEnd(epoch, i, blockTo, snaptype2.Enums.Headers, snCfg), tmpDir, snapDir, firstTxNum, chainDB, chainConfig, workers, lvl, logger, inProgress)
 		if err != nil {
 			return err
 		}
@@ -506,6 +519,7 @@ func DumpBlocks(ctx context.Context, blockFrom, blockTo uint64, chainConfig *cha
 }
 
 func dumpBlocksRange(ctx context.Context, blockFrom, blockTo uint64, tmpDir, snapDir string, firstTxNum uint64, chainDB kv.RoDB, chainConfig *chain.Config, workers int, lvl log.Lvl, logger log.Logger, inProgress *snapshotsync.BaseRoSnapshots) (lastTxNum uint64, err error) {
+	epoch := snaptype2.RegimeFor(chainConfig)
 	logEvery := time.NewTicker(20 * time.Second)
 	defer logEvery.Stop()
 
@@ -514,17 +528,16 @@ func dumpBlocksRange(ctx context.Context, blockFrom, blockTo uint64, tmpDir, sna
 		logger.Error("DumpBodies", "err", err)
 		return lastTxNum, err
 	}
-
-	if _, err = dumpRange(ctx, snaptype2.Headers.FileInfo(snapDir, blockFrom, blockTo),
+	if _, err = dumpRange(ctx, snaptype2.Headers.FileInfo(snapDir, epoch, blockFrom, blockTo),
 		DumpHeaders, nil, chainDB, chainConfig, tmpDir, workers, lvl, logger, inProgress); err != nil {
 		return 0, err
 	}
 
-	if lastTxNum, err = dumpRange(ctx, snaptype2.Bodies.FileInfo(snapDir, blockFrom, blockTo),
+	if lastTxNum, err = dumpRange(ctx, snaptype2.Bodies.FileInfo(snapDir, epoch, blockFrom, blockTo),
 		DumpBodies, func(context.Context) uint64 { return firstTxNum }, chainDB, chainConfig, tmpDir, workers, lvl, logger, inProgress); err != nil {
 		return lastTxNum, err
 	}
-	if _, err = dumpRange(ctx, snaptype2.Transactions.FileInfo(snapDir, blockFrom, blockTo),
+	if _, err = dumpRange(ctx, snaptype2.Transactions.FileInfo(snapDir, epoch, blockFrom, blockTo),
 		DumpTxs, func(context.Context) uint64 { return firstTxNum }, chainDB, chainConfig, tmpDir, workers, lvl, logger, inProgress); err != nil {
 		return lastTxNum, err
 	}
@@ -569,7 +582,7 @@ func dumpRange(ctx context.Context, f snaptype.FileInfo, dumper dumpFunc, firstK
 	// Means:
 	//  - build must be fast
 	//  - merge can be slow and expensive
-	noCompress := (f.To - f.From) < (snaptype.Erigon2MergeLimit - 1)
+	noCompress := segmentNoCompress(f.Epoch, f.To-f.From)
 
 	lastKeyValue, err = dumper(ctx, chainDB, chainConfig, f.From, f.To, firstKey, func(v []byte) error {
 		if noCompress {

--- a/db/snapshotsync/freezeblocks/block_snapshots_epoch_test.go
+++ b/db/snapshotsync/freezeblocks/block_snapshots_epoch_test.go
@@ -1,0 +1,81 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package freezeblocks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/db/snapcfg"
+	"github.com/erigontech/erigon/db/snapshotsync"
+	"github.com/erigontech/erigon/db/snaptype"
+)
+
+// retireSegments drives the real produce path: the retire loop calls CanRetire to pick one
+// tier at a time, and DumpBlocks carves that range with chooseSegmentEnd. It returns the
+// [from,to) of every segment file that would be produced for [0, available). The regime is
+// selected by snapType (a block type is epoch, a Bor type is decimal), not by any switch.
+func retireSegments(available uint64, snapType snaptype.Enum, epoch bool, cfg *snapcfg.Cfg) [][2]uint64 {
+	var segs [][2]uint64
+	for from := uint64(0); ; {
+		bf, bt, can := snapshotsync.CanRetire(epoch, from, available, snapType, cfg, 0)
+		if !can {
+			return segs
+		}
+		for i := bf; i < bt; {
+			end := chooseSegmentEnd(epoch, i, bt, snapType, cfg)
+			segs = append(segs, [2]uint64{i, end})
+			i = end
+		}
+		from = bt
+	}
+}
+
+// The epoch produce path (block stream) decomposes a range into clean 1024/8192/65536/524288
+// tiers, and chooseSegmentEnd preserves each tier boundary (the 1024 round-down never corrupts it).
+func TestEpochRetirePipeline(t *testing.T) {
+	require.Equal(t, [][2]uint64{
+		{0, 524_288},       // 64 era1 (top tier)
+		{524_288, 589_824}, // 8 era1
+		{589_824, 598_016}, // 1 era1
+		{598_016, 599_040}, // min tier (1024)
+	}, retireSegments(600_000, snaptype.Unknown, true, &snapcfg.Cfg{}))
+	// tail [599_040, 600_000) is < 1024 and stays in the DB.
+}
+
+// The decimal tier decomposition (1000/10000/100000) is what a non-epoch chain gets; the regime
+// comes from the explicit epoch argument, not from the type.
+func TestDecimalRetirePipeline(t *testing.T) {
+	require.Equal(t, [][2]uint64{
+		{0, 100_000},
+		{100_000, 110_000},
+		{110_000, 120_000},
+	}, retireSegments(120_000, snaptype.Unknown, false, &snapcfg.Cfg{}))
+}
+
+// A freshly-dumped segment is compressed only at the frozen (merge-limit) size; smaller
+// tiers are left uncompressed for merge to compress later. The threshold follows the
+// region's merge limit (524288 for the epoch block stream, 100000 for a decimal one).
+func TestSegmentNoCompress(t *testing.T) {
+	require.False(t, segmentNoCompress(false, snaptype.Erigon2MergeLimit)) // decimal frozen -> compress
+	require.True(t, segmentNoCompress(false, 10_000))                      // small tier -> uncompressed
+
+	require.False(t, segmentNoCompress(true, snaptype.EpochMergeLimit)) // 524288 frozen -> compress
+	require.True(t, segmentNoCompress(true, 65_536))                    // intermediate tier -> uncompressed
+	require.True(t, segmentNoCompress(true, 1_024))
+}

--- a/db/snapshotsync/freezeblocks/block_snapshots_test.go
+++ b/db/snapshotsync/freezeblocks/block_snapshots_test.go
@@ -72,7 +72,7 @@ func TestBlockRetireUsesFinalityContext(t *testing.T) {
 		nil,
 		nil,
 		db,
-		&chain.Config{},
+		&chain.Config{Aura: &chain.AuRaConfig{}},
 		&cfg,
 		nil,
 		nil,

--- a/db/snapshotsync/freezeblocks/block_snapshots_test.go
+++ b/db/snapshotsync/freezeblocks/block_snapshots_test.go
@@ -264,9 +264,9 @@ func TestRetireMergedTransactionFilesBelow(t *testing.T) {
 
 	// The seeder is told about the [0, mergeLimit) tx segment: its .seg + both indexes.
 	require.ElementsMatch(t, []string{
-		snaptype.SegmentFileName(ver, 0, testMergeLimit, snaptype2.Transactions.Enum()),
-		snaptype.IdxFileName(ver, 0, testMergeLimit, snaptype2.Transactions.Enum().String()),
-		snaptype.IdxFileName(ver, 0, testMergeLimit, snaptype2.Indexes.TxnHash2BlockNum.Name),
+		snaptype.SegmentFileName(ver, false, 0, testMergeLimit, snaptype2.Transactions.Enum()),
+		snaptype.IdxFileName(ver, false, 0, testMergeLimit, snaptype2.Transactions.Enum().String()),
+		snaptype.IdxFileName(ver, false, 0, testMergeLimit, snaptype2.Indexes.TxnHash2BlockNum.Name),
 	}, deleted)
 
 	// Gone from the live set...
@@ -293,7 +293,7 @@ func TestDumpRangeErrorsWhenRangeAlreadyClaimed(t *testing.T) {
 	snapshots := blocksnapshots.NewRoSnapshots(cfg, dir, logger)
 	defer snapshots.Close()
 
-	f := snaptype2.Headers.FileInfo(dir, 0, 1000)
+	f := snaptype2.Headers.FileInfo(dir, false, 0, 1000)
 	require.True(t, snapshots.TryAcquireRange(f.Type.Enum(), f.From, f.To))
 
 	dumperCalled := false

--- a/db/snapshotsync/freezeblocks/caplin_snapshots.go
+++ b/db/snapshotsync/freezeblocks/caplin_snapshots.go
@@ -205,7 +205,7 @@ func (v *CaplinView) BeaconBlocksSegment(slot uint64) (*snapshotsync.VisibleSegm
 func dumpBeaconBlocksRange(ctx context.Context, db kv.RoDB, fromSlot uint64, toSlot uint64, salt uint32, dirs datadir.Dirs, workers int, lvl log.Lvl, logger log.Logger) error {
 	tmpDir, snapDir := dirs.Tmp, dirs.Snap
 
-	segName := snaptype.BeaconBlocks.FileName(version.ZeroVersion, fromSlot, toSlot)
+	segName := snaptype.BeaconBlocks.FileName(version.ZeroVersion, false, fromSlot, toSlot)
 	f, _, _ := snaptype.ParseFileName(snapDir, segName)
 
 	compressCfg := seg.DefaultCfg
@@ -276,7 +276,7 @@ func dumpBeaconBlocksRange(ctx context.Context, db kv.RoDB, fromSlot uint64, toS
 func DumpBlobSidecarsRange(ctx context.Context, db kv.RoDB, storage blob_storage.BlobStorage, fromSlot uint64, toSlot uint64, salt uint32, dirs datadir.Dirs, workers int, blobCountFn BlobCountBySlotFn, lvl log.Lvl, logger log.Logger) error {
 	tmpDir, snapDir := dirs.Tmp, dirs.Snap
 
-	segName := snaptype.BlobSidecars.FileName(version.ZeroVersion, fromSlot, toSlot)
+	segName := snaptype.BlobSidecars.FileName(version.ZeroVersion, false, fromSlot, toSlot)
 	f, _, _ := snaptype.ParseFileName(snapDir, segName)
 
 	compressCfg := seg.DefaultCfg
@@ -362,13 +362,13 @@ func DumpBlobSidecarsRange(ctx context.Context, db kv.RoDB, storage blob_storage
 
 func DumpBeaconBlocks(ctx context.Context, db kv.RoDB, fromSlot, toSlot uint64, salt uint32, dirs datadir.Dirs, workers int, lvl log.Lvl, logger log.Logger) error {
 	cfg := snapcfg.KnownCfgOrDevnet("")
-	for i := fromSlot; i < toSlot; i = chooseSegmentEnd(i, toSlot, snaptype.CaplinEnums.BeaconBlocks, cfg) {
-		blocksPerFile := snapcfg.MergeLimitFromCfg(cfg, snaptype.CaplinEnums.BeaconBlocks, i)
+	for i := fromSlot; i < toSlot; i = chooseSegmentEnd(false, i, toSlot, snaptype.CaplinEnums.BeaconBlocks, cfg) {
+		blocksPerFile := snapcfg.MergeLimitFromCfg(cfg, snaptype.CaplinEnums.BeaconBlocks, false, i)
 
 		if toSlot-i < blocksPerFile {
 			break
 		}
-		to := chooseSegmentEnd(i, toSlot, snaptype.CaplinEnums.BeaconBlocks, cfg)
+		to := chooseSegmentEnd(false, i, toSlot, snaptype.CaplinEnums.BeaconBlocks, cfg)
 		logger.Log(lvl, "Dumping beacon blocks", "from", i, "to", to)
 		if err := dumpBeaconBlocksRange(ctx, db, i, to, salt, dirs, workers, lvl, logger); err != nil {
 			return err
@@ -381,13 +381,13 @@ type BlobCountBySlotFn func(slot uint64) (uint64, error)
 
 func DumpBlobsSidecar(ctx context.Context, blobStorage blob_storage.BlobStorage, db kv.RoDB, fromSlot, toSlot uint64, salt uint32, dirs datadir.Dirs, compressWorkers int, blobCountFn BlobCountBySlotFn, lvl log.Lvl, logger log.Logger) error {
 	cfg := snapcfg.KnownCfgOrDevnet("")
-	for i := fromSlot; i < toSlot; i = chooseSegmentEnd(i, toSlot, snaptype.CaplinEnums.BlobSidecars, cfg) {
-		blocksPerFile := snapcfg.MergeLimitFromCfg(cfg, snaptype.CaplinEnums.BlobSidecars, i)
+	for i := fromSlot; i < toSlot; i = chooseSegmentEnd(false, i, toSlot, snaptype.CaplinEnums.BlobSidecars, cfg) {
+		blocksPerFile := snapcfg.MergeLimitFromCfg(cfg, snaptype.CaplinEnums.BlobSidecars, false, i)
 
 		if toSlot-i < blocksPerFile {
 			break
 		}
-		to := chooseSegmentEnd(i, toSlot, snaptype.CaplinEnums.BlobSidecars, cfg)
+		to := chooseSegmentEnd(false, i, toSlot, snaptype.CaplinEnums.BlobSidecars, cfg)
 		logger.Log(lvl, "Dumping blobs sidecars", "from", i, "to", to)
 		if err := DumpBlobSidecarsRange(ctx, db, blobStorage, i, to, salt, dirs, compressWorkers, blobCountFn, lvl, logger); err != nil {
 			return err

--- a/db/snapshotsync/freezeblocks/caplin_snapshots_test.go
+++ b/db/snapshotsync/freezeblocks/caplin_snapshots_test.go
@@ -98,7 +98,7 @@ func TestDumpBeaconBlocksRangeBuildsSegAndIdx(t *testing.T) {
 
 	require.NoError(t, dumpBeaconBlocksRange(ctx, db, 0, snaptype.CaplinMergeLimit, 1, dirs, 1, log.LvlDebug, log.New()))
 
-	segName := snaptype.BeaconBlocks.FileName(version.ZeroVersion, 0, snaptype.CaplinMergeLimit)
+	segName := snaptype.BeaconBlocks.FileName(version.ZeroVersion, false, 0, snaptype.CaplinMergeLimit)
 	f, _, ok := snaptype.ParseFileName(dirs.Snap, segName)
 	require.True(t, ok)
 
@@ -217,7 +217,7 @@ func slotWord(slot uint64) []byte {
 
 func writeCaplinSegment(t *testing.T, dirs datadir.Dirs, sType snaptype.Type, from, to uint64, withIndex bool, word func(slot uint64) []byte) {
 	t.Helper()
-	segName := sType.FileName(version.ZeroVersion, from, to)
+	segName := sType.FileName(version.ZeroVersion, false, from, to)
 	f, _, ok := snaptype.ParseFileName(dirs.Snap, segName)
 	require.True(t, ok)
 

--- a/db/snapshotsync/freezeblocks/dump_test.go
+++ b/db/snapshotsync/freezeblocks/dump_test.go
@@ -31,8 +31,11 @@ import (
 	"github.com/erigontech/erigon/db/kv/prune"
 	"github.com/erigontech/erigon/db/snapcfg"
 	"github.com/erigontech/erigon/db/snapshotsync/freezeblocks"
+	"github.com/erigontech/erigon/db/snaptype"
+	"github.com/erigontech/erigon/db/snaptype2"
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/chain/networkname"
+	chainspec "github.com/erigontech/erigon/execution/chain/spec"
 	"github.com/erigontech/erigon/execution/execmodule/execmoduletester"
 	"github.com/erigontech/erigon/execution/rlp"
 	"github.com/erigontech/erigon/execution/tests/blockgen"
@@ -74,6 +77,11 @@ func TestDump(t *testing.T) {
 		},
 		{
 			chainSize:   50,
+			chainConfig: chain.AllProtocolChanges,
+		},
+		{
+			// eth chain -> epoch: block dump carves 1024-aligned segments
+			chainSize:   1024,
 			chainConfig: chain.AllProtocolChanges,
 		},
 	}
@@ -209,10 +217,6 @@ func TestDump(t *testing.T) {
 			require.Equal(lastTxNum, firstTxNum+uint64(i*3))
 		})
 		t.Run("blocks", func(t *testing.T) {
-			if test.chainSize < 1000 || test.chainSize%1000 != 0 {
-				t.Skip("Block dump requires chain size to be a multiple of 1000")
-			}
-
 			require := require.New(t)
 
 			logger := log.New()
@@ -221,7 +225,15 @@ func TestDump(t *testing.T) {
 			snConfig, _ := snapcfg.KnownCfg(networkname.Mainnet)
 			snConfig.ExpectBlocks = math.MaxUint64
 
-			err := freezeblocks.DumpBlocks(m.Ctx, 0, uint64(test.chainSize), m.ChainConfig, tmpDir, snapDir, m.DB, 1, log.LvlInfo, logger, m.BlockReader, snConfig, nil)
+			// production only ever retires whole segments; feed DumpBlocks the segmentable prefix
+			// (a chain shorter than one segment yields none), matching the chain's regime.
+			minSeg := uint64(snaptype.Erigon2MinSegmentSize)
+			if snaptype2.RegimeFor(test.chainConfig) {
+				minSeg = snaptype.EpochMinSegmentSize
+			}
+			blockTo := uint64(test.chainSize) / minSeg * minSeg
+
+			err := freezeblocks.DumpBlocks(m.Ctx, 0, blockTo, m.ChainConfig, tmpDir, snapDir, m.DB, 1, log.LvlInfo, logger, m.BlockReader, snConfig, nil)
 			require.NoError(err)
 		})
 	}
@@ -263,4 +275,11 @@ func createDumpTestKV(t *testing.T, chainConfig *chain.Config, chainSize int) *e
 	}
 
 	return m
+}
+
+// The block-segment regime is scoped to Ethereum-family chains: RegimeFor is epoch for eth and
+// decimal for Aura (Gnosis).
+func TestRegimeForByChain(t *testing.T) {
+	require.True(t, snaptype2.RegimeFor(chain.AllProtocolChanges))
+	require.False(t, snaptype2.RegimeFor(chainspec.Gnosis.Config))
 }

--- a/db/snapshotsync/freezeblocks/epoch_migration.go
+++ b/db/snapshotsync/freezeblocks/epoch_migration.go
@@ -31,6 +31,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sort"
+	"strings"
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/background"
@@ -99,41 +100,64 @@ func classifyByType(all []snaptype.FileInfo, t snaptype.Enum) (epoch, decimal []
 	return sortedNoOverlaps(epoch), sortedNoOverlaps(decimal)
 }
 
-// coverage walks type t as one run from block 0 and returns:
-//   - epochStart: end of the epoch segments we already made; a re-run picks up here.
-//   - coveredTo: how far the run goes once the decimal segments continue past the epoch part.
-//     frozenMax is the smallest coveredTo of the three types (a block is done only when all three
-//     have it — same min RoSnapshots uses).
+// coverage walks one type as a single run and returns:
+//   - start: where conversion resumes. Either the end of the epoch segments already written, or, for a
+//     type with none, its own data frontier — which a pruned node leaves far above block 0. The caller
+//     snaps it to the shared tiling.
+//   - coveredTo: how far the run reaches. frozenMax is the smallest coveredTo across types.
 //   - runLen: how many decimal segments from the front have no gaps — the ones a repack reads.
-//     After earlier deletions the first one may not start at block 0.
 //
-// The decimal segment sitting across the epoch frontier is caught by From <= coveredTo < To; a gap
-// stops both the run and coveredTo. Inputs must be sorted and overlap-free.
-func coverage(epoch, decimal []snaptype.FileInfo) (epochStart, coveredTo uint64, runLen int) {
-	for i := range epoch { // contiguous epoch prefix from block 0
-		f := &epoch[i]
-		if f.From != epochStart {
-			break
+// A gap stops both the run and coveredTo. Inputs must be sorted and overlap-free.
+func coverage(epoch, decimal []snaptype.FileInfo) (start, coveredTo uint64, runLen int) {
+	var epochEnd uint64
+	haveEpoch := len(epoch) > 0
+	if haveEpoch {
+		epochEnd = epoch[0].From
+		for i := range epoch {
+			if epoch[i].From != epochEnd {
+				break
+			}
+			epochEnd = epoch[i].To
 		}
-		epochStart = f.To
 	}
-	coveredTo = epochStart
-	end := uint64(0)
+	var decimalStart, decimalEnd uint64
 	if len(decimal) > 0 {
-		end = decimal[0].From
-	}
-	for i := range decimal {
-		f := &decimal[i]
-		if f.From != end {
-			break // gap: the contiguous decimal run ends here
-		}
-		runLen++
-		end = f.To
-		if f.From <= coveredTo && coveredTo < f.To {
-			coveredTo = f.To
+		decimalStart = decimal[0].From
+		decimalEnd = decimalStart
+		for i := range decimal {
+			if decimal[i].From != decimalEnd {
+				break // gap: the contiguous decimal run ends here
+			}
+			runLen++
+			decimalEnd = decimal[i].To
 		}
 	}
-	return epochStart, coveredTo, runLen
+
+	switch {
+	case runLen == 0:
+		return epochEnd, epochEnd, 0
+	case !haveEpoch:
+		return decimalStart, decimalEnd, runLen
+	case decimalStart > epochEnd:
+		return 0, 0, 0 // epoch run and decimal run do not meet: leave this type alone
+	default:
+		return epochEnd, max(epochEnd, decimalEnd), runLen
+	}
+}
+
+// startOnPlan returns the first boundary of plan at or above frontier. Every block type converts on
+// one shared tiling, because the transactions index is built by walking a bodies segment of the
+// identical range; a pruned type therefore resumes on a boundary, dropping the blocks below it.
+func startOnPlan(plan [][2]uint64, frontier uint64) uint64 {
+	for _, r := range plan {
+		if r[0] >= frontier {
+			return r[0]
+		}
+	}
+	if len(plan) == 0 {
+		return frontier
+	}
+	return plan[len(plan)-1][1]
 }
 
 // removeDecimalSegFiles deletes each decimal segment and everything with its range and type: the .seg,
@@ -203,6 +227,7 @@ func (s *seqWords) Close() {
 }
 
 type epochMigrator struct {
+	uncovered   []string // types with no usable segments; the refusal names them
 	dirs        datadir.Dirs
 	snCfg       *snapcfg.Cfg
 	db          kv.RwDB
@@ -571,9 +596,20 @@ func (m *epochMigrator) run(ctx context.Context) error {
 		return nil
 	}
 	if frozenMax == 0 {
-		return fmt.Errorf("epoch-migration: decimal segments present but none reach a contiguous frontier from block 0; refusing to delete anything")
+		// Every block type must be present and reachable: the visible-file calculation drops every
+		// type when one of them has none, so converting such a datadir would only move the breakage.
+		return fmt.Errorf("epoch-migration: no usable segments for %s; refusing to convert a datadir that is already unopenable",
+			strings.Join(m.uncovered, ", "))
 	}
 	m.logger.Info("[epoch-migration] converting decimal block segments to epoch", "upto", frozenMax)
+
+	// One tiling for every type: a pruned type resumes on a boundary of it, never between two.
+	plan, _ := planEpochSegments(0, frozenMax, m.snCfg)
+	for _, t := range snaptype2.BlockSnapshotTypes {
+		if s := start[t.Enum()]; s > 0 {
+			start[t.Enum()] = startOnPlan(plan, s)
+		}
+	}
 
 	tailFrom := frozenMax - frozenMax%snaptype.EpochMinSegmentSize
 	tailHeaders := make(map[uint64][]byte)
@@ -637,11 +673,14 @@ func (m *epochMigrator) loadSegs() (start map[snaptype.Enum]uint64, frozenMax ui
 	frozenMax = ^uint64(0)
 	for _, t := range snaptype2.BlockSnapshotTypes {
 		epoch, decimal := classifyByType(all, t.Enum())
-		epochStart, coveredTo, contiguousLen := coverage(epoch, decimal)
+		typeStart, coveredTo, contiguousLen := coverage(epoch, decimal)
 		m.decimalSegs[t.Enum()] = decimal
 		m.contiguousLen[t.Enum()] = contiguousLen
-		start[t.Enum()] = epochStart
+		start[t.Enum()] = typeStart
 		frozenMax = min(frozenMax, coveredTo)
+		if coveredTo == 0 {
+			m.uncovered = append(m.uncovered, t.Name())
+		}
 		if len(decimal) > 0 {
 			hasDecimal = true
 		}
@@ -662,7 +701,6 @@ func hasEpochIndexes(info snaptype.FileInfo, names []string) bool {
 // (the transactions index needs the epoch bodies), and skips any segment whose index already exists so
 // a re-run doesn't rebuild everything.
 func (m *epochMigrator) buildEpochIndexes(ctx context.Context, frozenMax uint64) error {
-	plan, _ := planEpochSegments(0, frozenMax, m.snCfg)
 	des, err := os.ReadDir(m.dirs.Snap)
 	if err != nil {
 		return err
@@ -671,9 +709,14 @@ func (m *epochMigrator) buildEpochIndexes(ctx context.Context, frozenMax uint64)
 	for _, de := range des {
 		names = append(names, de.Name())
 	}
+	plan, _ := planEpochSegments(0, frozenMax, m.snCfg)
 	for _, t := range snaptype2.BlockSnapshotTypes {
 		for _, r := range plan {
 			info := t.FileInfo(m.dirs.Snap, true, r[0], r[1])
+			// A pruned type has no segment below its frontier; there is nothing to index there.
+			if !slices.Contains(names, filepath.Base(info.Path)) {
+				continue
+			}
 			if hasEpochIndexes(info, names) {
 				continue
 			}

--- a/db/snapshotsync/freezeblocks/epoch_migration.go
+++ b/db/snapshotsync/freezeblocks/epoch_migration.go
@@ -164,6 +164,10 @@ func startOnPlan(plan [][2]uint64, frontier uint64) uint64 {
 // its .torrent and its indexes (an index may have a different version, so we match range+type with the
 // version left wild). The trailing wildcard that picks up those extensions also picks up the epoch file
 // printing the same digits, so each match is decoded and only the decimal ones are deleted.
+//
+// A removal that fails is ignored, as elsewhere in the snapshot code. On Windows it fails while
+// anything still holds the file, and by this point its blocks are in an epoch segment, so the
+// leftover is redundant: the next run sweeps it.
 func removeDecimalSegFiles(segs []snaptype.FileInfo) error {
 	for i := range segs {
 		f := &segs[i]
@@ -176,9 +180,7 @@ func removeDecimalSegFiles(segs []snaptype.FileInfo) error {
 			if fi, _, ok := snaptype.ParseFileName("", filepath.Base(m)); ok && fi.Epoch {
 				continue
 			}
-			if err := dir.RemoveFile(m); err != nil {
-				return err
-			}
+			_ = dir.RemoveFile(m)
 		}
 	}
 	return nil

--- a/db/snapshotsync/freezeblocks/epoch_migration.go
+++ b/db/snapshotsync/freezeblocks/epoch_migration.go
@@ -1,0 +1,704 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package freezeblocks
+
+// Turns old decimal block segments (named by block/1000) into epoch ones ("ep"-marked, block/1024),
+// at startup before anything opens a segment.
+//
+// Crash-safe: we drop a decimal segment only after every block in it is safe elsewhere — in an epoch
+// segment, or (for the sub-1024 tail) in the DB. Segments and indexes are written to a temp file then
+// renamed, so anything on disk is complete and a re-run after a crash just carries on.
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/background"
+	"github.com/erigontech/erigon/common/dir"
+	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/common/length"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/dbutils"
+	"github.com/erigontech/erigon/db/rawdb"
+	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/snapcfg"
+	"github.com/erigontech/erigon/db/snapshotsync"
+	"github.com/erigontech/erigon/db/snaptype"
+	"github.com/erigontech/erigon/db/snaptype2"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/rlp"
+	"github.com/erigontech/erigon/execution/types"
+)
+
+// planEpochSegments cuts [from, frozenMax) into epoch segment ranges. tailFrom is where the leftover
+// too small for a segment starts — those blocks go to the DB.
+func planEpochSegments(from, frozenMax uint64, snCfg *snapcfg.Cfg) (segs [][2]uint64, tailFrom uint64) {
+	for {
+		bf, bt, can := snapshotsync.CanRetire(true, from, frozenMax, snaptype.Unknown, snCfg, 0)
+		if !can {
+			return segs, from
+		}
+		segs = append(segs, [2]uint64{bf, bt})
+		from = bt
+	}
+}
+
+func sortedNoOverlaps(segs []snaptype.FileInfo) []snaptype.FileInfo {
+	sort.Slice(segs, func(i, j int) bool {
+		if segs[i].From != segs[j].From {
+			return segs[i].From < segs[j].From
+		}
+		return segs[i].To < segs[j].To
+	})
+	return snapshotsync.NoOverlaps(segs)
+}
+
+// classifyByType splits one dir scan into type t's epoch ("ep"-marked) and decimal segments, sorted
+// and overlap-free. We scan the dir once and reuse this everywhere.
+func classifyByType(all []snaptype.FileInfo, t snaptype.Enum) (epoch, decimal []snaptype.FileInfo) {
+	for i := range all {
+		f := &all[i]
+		switch {
+		case f.Type == nil || f.Type.Enum() != t:
+		case f.Epoch:
+			epoch = append(epoch, *f)
+		default:
+			decimal = append(decimal, *f)
+		}
+	}
+	return sortedNoOverlaps(epoch), sortedNoOverlaps(decimal)
+}
+
+// coverage walks type t as one run from block 0 and returns:
+//   - epochStart: end of the epoch segments we already made; a re-run picks up here.
+//   - coveredTo: how far the run goes once the decimal segments continue past the epoch part.
+//     frozenMax is the smallest coveredTo of the three types (a block is done only when all three
+//     have it — same min RoSnapshots uses).
+//   - runLen: how many decimal segments from the front have no gaps — the ones a repack reads.
+//     After earlier deletions the first one may not start at block 0.
+//
+// The decimal segment sitting across the epoch frontier is caught by From <= coveredTo < To; a gap
+// stops both the run and coveredTo. Inputs must be sorted and overlap-free.
+func coverage(epoch, decimal []snaptype.FileInfo) (epochStart, coveredTo uint64, runLen int) {
+	for i := range epoch { // contiguous epoch prefix from block 0
+		f := &epoch[i]
+		if f.From != epochStart {
+			break
+		}
+		epochStart = f.To
+	}
+	coveredTo = epochStart
+	end := uint64(0)
+	if len(decimal) > 0 {
+		end = decimal[0].From
+	}
+	for i := range decimal {
+		f := &decimal[i]
+		if f.From != end {
+			break // gap: the contiguous decimal run ends here
+		}
+		runLen++
+		end = f.To
+		if f.From <= coveredTo && coveredTo < f.To {
+			coveredTo = f.To
+		}
+	}
+	return epochStart, coveredTo, runLen
+}
+
+// removeDecimalSegFiles deletes each decimal segment and everything with its range and type: the .seg,
+// its .torrent and its indexes (an index may have a different version, so we match range+type with the
+// version left wild). The trailing wildcard that picks up those extensions also picks up the epoch file
+// printing the same digits, so each match is decoded and only the decimal ones are deleted.
+func removeDecimalSegFiles(segs []snaptype.FileInfo) error {
+	for i := range segs {
+		f := &segs[i]
+		mask := filepath.Join(filepath.Dir(f.Path), snaptype.FileMask(false, f.From, f.To, f.TypeString)+"*")
+		matches, err := filepath.Glob(mask)
+		if err != nil {
+			return err
+		}
+		for _, m := range matches {
+			if fi, _, ok := snaptype.ParseFileName("", filepath.Base(m)); ok && fi.Epoch {
+				continue
+			}
+			if err := dir.RemoveFile(m); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// seqWords reads a run of segments word by word in block order, opening one segment at a time and
+// closing it before the next.
+type seqWords struct {
+	segs []snaptype.FileInfo
+	i    int
+	cur  *seg.Decompressor
+	g    *seg.Getter
+}
+
+func newSeqWords(segs []snaptype.FileInfo) *seqWords { return &seqWords{segs: segs, i: -1} }
+
+// next returns the next word, moving across segments and closing each one as it's finished. ok is
+// false once all segments are read.
+func (s *seqWords) next() (word []byte, ok bool, err error) {
+	for {
+		if s.g != nil && s.g.HasNext() {
+			word, _ = s.g.Next(nil)
+			return word, true, nil
+		}
+		if s.cur != nil {
+			s.cur.Close()
+			s.cur, s.g = nil, nil
+		}
+		s.i++
+		if s.i >= len(s.segs) {
+			return nil, false, nil
+		}
+		d, err := seg.NewDecompressor(s.segs[s.i].Path)
+		if err != nil {
+			return nil, false, err
+		}
+		s.cur, s.g = d, d.MakeGetter()
+	}
+}
+
+func (s *seqWords) Close() {
+	if s.cur != nil {
+		s.cur.Close()
+		s.cur = nil
+	}
+}
+
+type epochMigrator struct {
+	dirs        datadir.Dirs
+	snCfg       *snapcfg.Cfg
+	db          kv.RwDB
+	chainConfig *chain.Config
+	workers     int
+	lvl         log.Lvl
+	logger      log.Logger
+
+	// decimalSegs holds each type's decimal segments (sorted, overlap-free) from the one startup scan.
+	// contiguousLen is how many from the front have no gaps — the run we convert; anything past a gap
+	// is left for the final cleanup. Repacks trim decimalSegs as they delete. loadSegs fills both.
+	decimalSegs   map[snaptype.Enum][]snaptype.FileInfo
+	contiguousLen map[snaptype.Enum]int
+}
+
+func (m *epochMigrator) segsToMigrate(t snaptype.Enum) []snaptype.FileInfo {
+	return m.decimalSegs[t][:m.contiguousLen[t]]
+}
+
+// repackWordPerBlock re-segments a one-word-per-block type (headers, bodies). It reads the decimal
+// run one file at a time, skips blocks already in epoch segments ([firstFrom, startBlock)), and writes
+// the epoch segments planned for [startBlock, frozenMax), copying each block's word as-is. As soon as
+// an epoch segment is on disk, the decimal segments it fully covers get deleted, to keep peak disk low.
+// The sub-1024 tail goes to onTail for the DB.
+// startBlock is the type's epoch frontier, so a crash just resumes from there; frozenMax is the
+// cross-type frontier.
+func (m *epochMigrator) repackWordPerBlock(ctx context.Context, t snaptype.Type, startBlock, frozenMax uint64, onTail func(blockNum uint64, word []byte) error) error {
+	if startBlock >= frozenMax {
+		return nil
+	}
+	segs := m.segsToMigrate(t.Enum())
+	plan, _ := planEpochSegments(startBlock, frozenMax, m.snCfg)
+	sw := newSeqWords(segs)
+	defer sw.Close()
+
+	blockNum := segs[0].From
+
+	// skip blocks already in an epoch segment.
+	for ; blockNum < startBlock; blockNum++ {
+		if _, ok, err := sw.next(); err != nil {
+			return err
+		} else if !ok {
+			return fmt.Errorf("epoch-migrate %s: ran out of words skipping to %d", t.Name(), startBlock)
+		}
+	}
+
+	// decimal segments already covered by written epoch segments.
+	delIdx := 0
+
+	writeSeg := func(a, b uint64) error {
+		compressCfg := BlockCompressCfg
+		compressCfg.Workers = m.workers
+		path := t.FileInfo(m.dirs.Snap, true, a, b).Path
+		c, err := seg.NewCompressor(ctx, "epoch-migrate "+t.Name(), path, m.dirs.Tmp, compressCfg, m.lvl, m.logger)
+		if err != nil {
+			return err
+		}
+		defer c.Close()
+		noCompress := segmentNoCompress(true, b-a)
+		for ; blockNum < b; blockNum++ {
+			w, ok, err := sw.next()
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return fmt.Errorf("epoch-migrate %s: ran out of words at block %d (segment [%d,%d))", t.Name(), blockNum, a, b)
+			}
+			if noCompress {
+				if err := c.AddUncompressedWord(w); err != nil {
+					return err
+				}
+			} else if err := c.AddWord(w); err != nil {
+				return err
+			}
+		}
+		return c.Compress()
+	}
+
+	for _, r := range plan {
+		if err := writeSeg(r[0], r[1]); err != nil {
+			return err
+		}
+		start := delIdx
+		for delIdx < len(segs) && segs[delIdx].To <= r[1] {
+			delIdx++
+		}
+		if err := removeDecimalSegFiles(segs[start:delIdx]); err != nil {
+			return err
+		}
+	}
+
+	for ; blockNum < frozenMax; blockNum++ {
+		w, ok, err := sw.next()
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("epoch-migrate %s: ran out of tail words at block %d", t.Name(), blockNum)
+		}
+		if err := onTail(blockNum, w); err != nil {
+			return err
+		}
+	}
+
+	m.decimalSegs[t.Enum()] = m.decimalSegs[t.Enum()][delIdx:]
+	return nil
+}
+
+func writeTailBlock(rwTx kv.RwTx, headerWord, bodyWord []byte, txWords [][]byte) error {
+	var h types.Header
+	if err := rlp.DecodeBytes(headerWord[1:], &h); err != nil {
+		return fmt.Errorf("epoch-migrate tail: decode header: %w", err)
+	}
+	num := h.Number.Uint64()
+	hash := h.Hash()
+	if err := rawdb.WriteHeaderRaw(rwTx, num, hash, headerWord[1:], false); err != nil {
+		return err
+	}
+	if err := rawdb.WriteCanonicalHash(rwTx, hash, num); err != nil {
+		return err
+	}
+	if err := rwTx.Put(kv.BlockBody, dbutils.BlockBodyKey(num, hash), bodyWord); err != nil {
+		return err
+	}
+
+	var b types.BodyForStorage
+	if err := rlp.DecodeBytes(bodyWord, &b); err != nil {
+		return fmt.Errorf("epoch-migrate tail: decode body %d: %w", num, err)
+	}
+	base := b.BaseTxnID.U64()
+	senders := make([]common.Address, 0, len(txWords))
+	lookup := make([]byte, 16)
+	for i, w := range txWords {
+		if i == 0 || i == len(txWords)-1 {
+			continue
+		}
+
+		// segment word is firstByte(1) + sender(20) + txRLP; EthTx stores just the txRLP, keyed by the
+		// global txn id (base + i, since begin-system is index 0).
+		txnRlp := w[1+length.Addr:]
+		if err := rwTx.Put(kv.EthTx, hexutil.EncodeTs(base+uint64(i)), txnRlp); err != nil {
+			return err
+		}
+		senders = append(senders, common.BytesToAddress(w[1:1+length.Addr]))
+
+		// while the block was frozen, hash->block lookups came from the tx-to-block index and
+		// stage_txlookup pruned kv.TxLookup for this range. The block is out of the epoch index now, so
+		// without this entry the txn can't be found by hash — and the stage won't rebuild it, it only
+		// runs forward from the tip.
+		txn, err := types.DecodeTransaction(txnRlp)
+		if err != nil {
+			return fmt.Errorf("epoch-migrate tail: decode txn %d of block %d: %w", i, num, err)
+		}
+		txnHash := txn.Hash()
+		binary.BigEndian.PutUint64(lookup[:8], num)
+		binary.BigEndian.PutUint64(lookup[8:], base+uint64(i))
+		if err := rwTx.Put(kv.TxLookup, txnHash[:], lookup); err != nil {
+			return err
+		}
+	}
+	return rawdb.WriteSenders(rwTx, hash, num, senders)
+}
+
+// repackTransactions re-segments the transactions type. It's txn-granular, not block-granular: a block
+// has exactly BodyForStorage.TxCount words (1 begin-system + TxCount-2 real + 1 end-system, or none if
+// TxCount==0). So it reads bodies (for each block's TxCount and BaseTxnID) and transactions together,
+// taking TxCount tx words per block and splitting on epoch boundaries. Tail blocks go to onTail with
+// their BaseTxnID, needed to put them back in the EthTx table.
+func (m *epochMigrator) repackTransactions(ctx context.Context, startBlock, frozenMax uint64, onTail func(blockNum, baseTxnID uint64, txnWords [][]byte) error) error {
+	if startBlock >= frozenMax {
+		return nil
+	}
+	bodySegs := m.segsToMigrate(snaptype2.Bodies.Enum())
+	txSegs := m.segsToMigrate(snaptype2.Transactions.Enum())
+	bodyFirstFrom := bodySegs[0].From
+	txFirstFrom := txSegs[0].From
+	plan, _ := planEpochSegments(startBlock, frozenMax, m.snCfg)
+
+	bodies := newSeqWords(bodySegs)
+	defer bodies.Close()
+	txs := newSeqWords(txSegs)
+	defer txs.Close()
+
+	// nextBlock reads one body word and returns that block's txn count and base txn id.
+	nextBlock := func(blockNum uint64) (txCount, baseTxnID uint64, err error) {
+		w, ok, err := bodies.next()
+		if err != nil {
+			return 0, 0, err
+		}
+		if !ok {
+			return 0, 0, fmt.Errorf("epoch-migrate transactions: ran out of bodies at block %d", blockNum)
+		}
+		var b types.BodyForStorage
+		if err := rlp.DecodeBytes(w, &b); err != nil {
+			return 0, 0, fmt.Errorf("epoch-migrate transactions: decode body %d: %w", blockNum, err)
+		}
+		return uint64(b.TxCount), b.BaseTxnID.U64(), nil
+	}
+
+	// advance bodies without decoding (we don't need TxCount here)
+	advanceBody := func(blockNum uint64) error {
+		if _, ok, err := bodies.next(); err != nil {
+			return err
+		} else if !ok {
+			return fmt.Errorf("epoch-migrate transactions: ran out of bodies at block %d", blockNum)
+		}
+		return nil
+	}
+	skipTx := func(n uint64) error {
+		for range n {
+			if _, ok, err := txs.next(); err != nil {
+				return err
+			} else if !ok {
+				return fmt.Errorf("epoch-migrate transactions: ran out of tx words during skip")
+			}
+		}
+		return nil
+	}
+
+	// Line both streams up to startBlock. Bodies is repacked last, so its decimal is still complete here
+	// and runs from block 0; transactions may start higher, its lower segments already converted and
+	// deleted. Below txFirstFrom a block has no tx words, so we just move bodies along and don't bother
+	// decoding it.
+	for b := bodyFirstFrom; b < startBlock; b++ {
+		if b < txFirstFrom {
+			if err := advanceBody(b); err != nil {
+				return err
+			}
+			continue
+		}
+		txCount, _, err := nextBlock(b)
+		if err != nil {
+			return err
+		}
+		if err := skipTx(txCount); err != nil {
+			return err
+		}
+	}
+
+	tt := snaptype2.Transactions
+	blockNum := startBlock
+	writeSeg := func(a, b uint64) error {
+		compressCfg := BlockCompressCfg
+		compressCfg.Workers = m.workers
+		path := tt.FileInfo(m.dirs.Snap, true, a, b).Path
+		c, err := seg.NewCompressor(ctx, "epoch-migrate transactions", path, m.dirs.Tmp, compressCfg, m.lvl, m.logger)
+		if err != nil {
+			return err
+		}
+		defer c.Close()
+		noCompress := segmentNoCompress(true, b-a)
+		for ; blockNum < b; blockNum++ {
+			txCount, _, err := nextBlock(blockNum)
+			if err != nil {
+				return err
+			}
+			for range txCount {
+				w, ok, err := txs.next()
+				if err != nil {
+					return err
+				}
+				if !ok {
+					return fmt.Errorf("epoch-migrate transactions: ran out of tx words at block %d", blockNum)
+				}
+				if noCompress {
+					if err := c.AddUncompressedWord(w); err != nil {
+						return err
+					}
+				} else if err := c.AddWord(w); err != nil {
+					return err
+				}
+			}
+		}
+		return c.Compress()
+	}
+
+	delIdx := 0
+	for _, r := range plan {
+		if err := writeSeg(r[0], r[1]); err != nil {
+			return err
+		}
+		start := delIdx
+		for delIdx < len(txSegs) && txSegs[delIdx].To <= r[1] {
+			delIdx++
+		}
+		if err := removeDecimalSegFiles(txSegs[start:delIdx]); err != nil {
+			return err
+		}
+	}
+	for ; blockNum < frozenMax; blockNum++ {
+		txCount, baseTxnID, err := nextBlock(blockNum)
+		if err != nil {
+			return err
+		}
+		words := make([][]byte, 0, txCount)
+		for range txCount {
+			w, ok, err := txs.next()
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return fmt.Errorf("epoch-migrate transactions: ran out of tail tx words at block %d", blockNum)
+			}
+			words = append(words, append([]byte(nil), w...))
+		}
+		if err := onTail(blockNum, baseTxnID, words); err != nil {
+			return err
+		}
+	}
+	m.decimalSegs[snaptype2.Transactions.Enum()] = m.decimalSegs[snaptype2.Transactions.Enum()][delIdx:]
+	return nil
+}
+
+// HasDecimalBlockSegments reports whether the datadir still holds legacy decimal block segments that
+// MigrateDecimalToEpoch would convert. Read-only consumers use it to refuse such a datadir rather than
+// convert one they do not own. Always false on a decimal chain, where decimal is the regime, not
+// pending work.
+func HasDecimalBlockSegments(dirs datadir.Dirs, chainConfig *chain.Config) (bool, error) {
+	if !snaptype2.RegimeFor(chainConfig) {
+		return false, nil
+	}
+	all, err := snaptype.Segments(dirs.Snap)
+	if err != nil {
+		return false, err
+	}
+	for _, t := range snaptype2.BlockSnapshotTypes {
+		if _, decimal := classifyByType(all, t.Enum()); len(decimal) > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// MigrateDecimalToEpoch turns any decimal block segments in dirs.Snap into epoch ones and writes the
+// sub-1024 tail back to the DB. Run it at startup, before the block snapshots are opened. It's a no-op
+// when there's no decimal, and safe to re-run after a crash (it resumes from the epoch segments already
+// on disk).
+func MigrateDecimalToEpoch(ctx context.Context, dirs datadir.Dirs, db kv.RwDB, chainConfig *chain.Config, workers int, logger log.Logger) error {
+	if !snaptype2.RegimeFor(chainConfig) {
+		return nil // decimal chain (Bor/Gnosis): nothing to convert
+	}
+	snCfg := snapcfg.KnownCfgOrDevnet(chainConfig.ChainName)
+	m := &epochMigrator{
+		dirs:        dirs,
+		snCfg:       snCfg,
+		db:          db,
+		chainConfig: chainConfig,
+		workers:     workers,
+		lvl:         log.LvlInfo,
+		logger:      logger,
+	}
+	return m.run(ctx)
+}
+
+// run keeps no marker file: every step is idempotent and a crash resumes from the epoch segments on
+// disk. Types go in dependency order — headers, transactions, bodies — because the transactions repack
+// reads the decimal bodies, so those go last. Each repack deletes its own decimal segments as their
+// blocks become safe in epoch segments; the segment straddling tailFrom is kept until the DB tail is
+// committed, then removed.
+func (m *epochMigrator) run(ctx context.Context) error {
+	start, frozenMax, hasDecimal, err := m.loadSegs()
+	if err != nil {
+		return err
+	}
+	if !hasDecimal {
+		return nil
+	}
+	if frozenMax == 0 {
+		return fmt.Errorf("epoch-migration: decimal segments present but none reach a contiguous frontier from block 0; refusing to delete anything")
+	}
+	m.logger.Info("[epoch-migration] converting decimal block segments to epoch", "upto", frozenMax)
+
+	tailFrom := frozenMax - frozenMax%snaptype.EpochMinSegmentSize
+	tailHeaders := make(map[uint64][]byte)
+	tailBodies := make(map[uint64][]byte)
+	tailTxs := make(map[uint64][][]byte)
+
+	if err := m.repackWordPerBlock(ctx, snaptype2.Headers, start[snaptype2.Headers.Enum()], frozenMax, func(bn uint64, w []byte) error {
+		tailHeaders[bn] = append([]byte(nil), w...)
+		return nil
+	}); err != nil {
+		return err
+	}
+	if err := m.repackTransactions(ctx, start[snaptype2.Transactions.Enum()], frozenMax, func(bn, _ uint64, ws [][]byte) error {
+		tailTxs[bn] = ws
+		return nil
+	}); err != nil {
+		return err
+	}
+	if err := m.repackWordPerBlock(ctx, snaptype2.Bodies, start[snaptype2.Bodies.Enum()], frozenMax, func(bn uint64, w []byte) error {
+		tailBodies[bn] = append([]byte(nil), w...)
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if err := m.db.Update(ctx, func(tx kv.RwTx) error {
+		for bn := tailFrom; bn < frozenMax; bn++ {
+			if err := writeTailBlock(tx, tailHeaders[bn], tailBodies[bn], tailTxs[bn]); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	tailHeaders, tailBodies, tailTxs = nil, nil, nil
+
+	if err := m.buildEpochIndexes(ctx, frozenMax); err != nil {
+		return err
+	}
+
+	// tail is in the DB now, so the straddle segments (and any leftovers) can go.
+	if err := m.deleteDecimalSegs(frozenMax); err != nil {
+		return err
+	}
+	m.logger.Info("[epoch-migration] done", "upto", frozenMax, "tailToDB", [2]uint64{tailFrom, frozenMax})
+	return nil
+}
+
+// loadSegs does the single startup dir scan: it caches each type's decimal segments and returns, per
+// type, the start block (epoch prefix end), the overall frozenMax (min coverage across types) and
+// whether there's any decimal segment at all.
+func (m *epochMigrator) loadSegs() (start map[snaptype.Enum]uint64, frozenMax uint64, hasDecimal bool, err error) {
+	all, err := snaptype.Segments(m.dirs.Snap)
+	if err != nil {
+		return nil, 0, false, err
+	}
+	m.decimalSegs = make(map[snaptype.Enum][]snaptype.FileInfo)
+	m.contiguousLen = make(map[snaptype.Enum]int)
+	start = make(map[snaptype.Enum]uint64)
+	frozenMax = ^uint64(0)
+	for _, t := range snaptype2.BlockSnapshotTypes {
+		epoch, decimal := classifyByType(all, t.Enum())
+		epochStart, coveredTo, contiguousLen := coverage(epoch, decimal)
+		m.decimalSegs[t.Enum()] = decimal
+		m.contiguousLen[t.Enum()] = contiguousLen
+		start[t.Enum()] = epochStart
+		frozenMax = min(frozenMax, coveredTo)
+		if len(decimal) > 0 {
+			hasDecimal = true
+		}
+	}
+	return start, frozenMax, hasDecimal, nil
+}
+
+func hasEpochIndexes(info snaptype.FileInfo, names []string) bool {
+	for _, n := range info.Type.IdxFileNames(info.Epoch, info.From, info.To) {
+		if !slices.Contains(names, n) {
+			return false
+		}
+	}
+	return true
+}
+
+// buildEpochIndexes builds the epoch indexes that are missing. It runs after every segment is on disk
+// (the transactions index needs the epoch bodies), and skips any segment whose index already exists so
+// a re-run doesn't rebuild everything.
+func (m *epochMigrator) buildEpochIndexes(ctx context.Context, frozenMax uint64) error {
+	plan, _ := planEpochSegments(0, frozenMax, m.snCfg)
+	des, err := os.ReadDir(m.dirs.Snap)
+	if err != nil {
+		return err
+	}
+	names := make([]string, 0, len(des))
+	for _, de := range des {
+		names = append(names, de.Name())
+	}
+	for _, t := range snaptype2.BlockSnapshotTypes {
+		for _, r := range plan {
+			info := t.FileInfo(m.dirs.Snap, true, r[0], r[1])
+			if hasEpochIndexes(info, names) {
+				continue
+			}
+			p := &background.Progress{}
+			if err := t.BuildIndexes(ctx, info, nil, m.chainConfig, m.dirs.Tmp, p, m.lvl, m.logger); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// deleteDecimalSegs removes the decimal segments still cached after the repacks — the one straddling
+// tailFrom per type (kept until the DB tail was committed) and anything after a gap. The repacks
+// already deleted everything below the frontier, so there's no dir re-scan here.
+//
+// Segments above frozenMax are dropped, not converted: they're past the contiguous frontier (a gap, or
+// a type that reaches further than the others), so nothing can read them anyway. That still throws away
+// blocks the node has to fetch again, so each one is logged.
+func (m *epochMigrator) deleteDecimalSegs(frozenMax uint64) error {
+	for _, t := range snaptype2.BlockSnapshotTypes {
+		segs := m.decimalSegs[t.Enum()]
+		for i := range segs {
+			f := &segs[i]
+			if f.From >= frozenMax {
+				m.logger.Warn("[epoch-migration] dropping decimal segment above the migrated frontier; its blocks were not converted and will need re-downloading",
+					"file", f.Name(), "from", f.From, "to", f.To, "frozenMax", frozenMax)
+			}
+		}
+		if err := removeDecimalSegFiles(m.decimalSegs[t.Enum()]); err != nil {
+			return err
+		}
+		m.decimalSegs[t.Enum()] = nil
+	}
+	return nil
+}

--- a/db/snapshotsync/freezeblocks/epoch_migration.go
+++ b/db/snapshotsync/freezeblocks/epoch_migration.go
@@ -70,9 +70,17 @@ func sortedNoOverlaps(segs []snaptype.FileInfo) []snaptype.FileInfo {
 		if segs[i].From != segs[j].From {
 			return segs[i].From < segs[j].From
 		}
-		return segs[i].To < segs[j].To
+		return segs[i].To > segs[j].To
 	})
-	return snapshotsync.NoOverlaps(segs)
+	out := segs[:0:0]
+	var maxTo uint64
+	for i := range segs {
+		if len(out) == 0 || segs[i].To > maxTo {
+			out = append(out, segs[i])
+			maxTo = segs[i].To
+		}
+	}
+	return out
 }
 
 // classifyByType splits one dir scan into type t's epoch ("ep"-marked) and decimal segments, sorted

--- a/db/snapshotsync/freezeblocks/epoch_migration.go
+++ b/db/snapshotsync/freezeblocks/epoch_migration.go
@@ -26,6 +26,7 @@ package freezeblocks
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -147,17 +148,15 @@ func coverage(epoch, decimal []snaptype.FileInfo) (start, coveredTo uint64, runL
 
 // startOnPlan returns the first boundary of plan at or above frontier. Every block type converts on
 // one shared tiling, because the transactions index is built by walking a bodies segment of the
-// identical range; a pruned type therefore resumes on a boundary, dropping the blocks below it.
+// identical range; a pruned type therefore resumes on a boundary, dropping the blocks below it. A
+// type starting inside the sub-1024 tail has no boundary above it and keeps its own frontier.
 func startOnPlan(plan [][2]uint64, frontier uint64) uint64 {
 	for _, r := range plan {
 		if r[0] >= frontier {
 			return r[0]
 		}
 	}
-	if len(plan) == 0 {
-		return frontier
-	}
-	return plan[len(plan)-1][1]
+	return frontier // no boundary at or above it: tail-only range, nothing to convert
 }
 
 // removeDecimalSegFiles deletes each decimal segment and everything with its range and type: the .seg,
@@ -540,6 +539,33 @@ func (m *epochMigrator) repackTransactions(ctx context.Context, startBlock, froz
 		}
 	}
 	m.decimalSegs[snaptype2.Transactions.Enum()] = m.decimalSegs[snaptype2.Transactions.Enum()][delIdx:]
+	return nil
+}
+
+// ErrUnfinishedLegacyDownload names a datadir that cannot go either way: converting it would build on
+// a segment set with holes, and leaving it alone does not help either, because this build asks the
+// manifest for epoch files only, so the decimal download it was in the middle of cannot resume.
+var ErrUnfinishedLegacyDownload = errors.New("this datadir holds an unfinished pre-epoch snapshot download: " +
+	"finish it with the previous release, or remove the snapshots directory and sync again")
+
+// CheckLegacyDownloadFinished guards every entry point that would convert a datadir. It reports
+// ErrUnfinishedLegacyDownload when decimal segments are present from a download that never finished,
+// so the operator is told what the datadir actually is rather than that some type is missing.
+func CheckLegacyDownloadFinished(db kv.RoDB, dirs datadir.Dirs, chainConfig *chain.Config) error {
+	complete, err := rawdb.AllSegmentsDownloadCompleteFromDB(db)
+	if err != nil {
+		return err
+	}
+	if complete {
+		return nil
+	}
+	hasDecimal, err := HasDecimalBlockSegments(dirs, chainConfig)
+	if err != nil {
+		return err
+	}
+	if hasDecimal {
+		return ErrUnfinishedLegacyDownload
+	}
 	return nil
 }
 

--- a/db/snapshotsync/freezeblocks/epoch_migration_idem_test.go
+++ b/db/snapshotsync/freezeblocks/epoch_migration_idem_test.go
@@ -1,0 +1,159 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package freezeblocks
+
+import (
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/dbcfg"
+	"github.com/erigontech/erigon/db/kv/dbutils"
+	"github.com/erigontech/erigon/db/kv/mdbx/mdbxtest"
+	"github.com/erigontech/erigon/db/rawdb"
+	"github.com/erigontech/erigon/execution/rlp"
+	"github.com/erigontech/erigon/execution/types"
+)
+
+// A crash between tail commits is repaired by re-writing the tail on the next run, so writing the
+// same tail block twice must leave the DB byte-identical — no duplicated rows, no shifted EthTx ids.
+// Every table the tail touches is a plain (non-DupSort) table written with Put, and the EthTx
+// sequence is deliberately not advanced; this pins that.
+func TestWriteTailBlockIsIdempotent(t *testing.T) {
+	db := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
+
+	h := &types.Header{Number: *uint256.NewInt(7)}
+	hRLP, err := rlp.EncodeToBytes(h)
+	require.NoError(t, err)
+	headerWord := append([]byte{0xaa}, hRLP...)
+	hash := h.Hash()
+
+	body := types.BodyForStorage{BaseTxnID: types.BaseTxnID(200), TxCount: 4}
+	bodyWord, err := rlp.EncodeToBytes(&body)
+	require.NoError(t, err)
+
+	w1, raw1, _ := tailTxWord(t, 0, 1)
+	w2, raw2, _ := tailTxWord(t, 1, 2)
+	txWords := [][]byte{{0}, w1, w2, {0}}
+
+	counts := func() map[string]int {
+		out := map[string]int{}
+		require.NoError(t, db.View(t.Context(), func(tx kv.Tx) error {
+			for _, tbl := range []string{kv.Headers, kv.HeaderCanonical, kv.HeaderNumber, kv.BlockBody, kv.EthTx, kv.Senders, kv.TxLookup} {
+				n, err := tx.Count(tbl)
+				if err != nil {
+					return err
+				}
+				out[tbl] = int(n)
+			}
+			return nil
+		}))
+		return out
+	}
+	seq := func() uint64 {
+		var s uint64
+		require.NoError(t, db.View(t.Context(), func(tx kv.Tx) error {
+			var err error
+			s, err = tx.ReadSequence(kv.EthTx)
+			return err
+		}))
+		return s
+	}
+
+	commit := func() {
+		require.NoError(t, db.Update(t.Context(), func(tx kv.RwTx) error {
+			return writeTailBlock(tx, headerWord, bodyWord, txWords)
+		}))
+	}
+
+	commit()
+	after1, seq1 := counts(), seq()
+	commit() // the re-run after a crash between per-type tail commits
+	after2, seq2 := counts(), seq()
+
+	require.Equal(t, after1, after2, "second write changed row counts: %v -> %v", after1, after2)
+	require.Equal(t, seq1, seq2, "second write moved the EthTx sequence")
+
+	// and the content still reads back correctly
+	require.NoError(t, db.View(t.Context(), func(tx kv.Tx) error {
+		got := rawdb.ReadHeaderByNumber(tx, 7)
+		require.NotNil(t, got)
+		require.Equal(t, uint64(7), got.Number.Uint64())
+
+		ch, err := rawdb.ReadCanonicalHash(tx, 7)
+		require.NoError(t, err)
+		require.Equal(t, hash, ch)
+
+		bfs, err := rawdb.ReadBodyForStorageByKey(tx, dbutils.BlockBodyKey(7, hash))
+		require.NoError(t, err)
+		require.Equal(t, uint32(4), bfs.TxCount)
+		require.Equal(t, uint64(200), bfs.BaseTxnID.U64())
+
+		for id, want := range map[uint64][]byte{201: raw1, 202: raw2} {
+			v, err := tx.GetOne(kv.EthTx, hexutil.EncodeTs(id))
+			require.NoError(t, err)
+			require.Equal(t, want, v, "EthTx %d", id)
+		}
+
+		senders, err := rawdb.ReadSenders(tx, hash, 7)
+		require.NoError(t, err)
+		require.Len(t, senders, 2, "senders duplicated on re-write")
+		return nil
+	}))
+}
+
+// A tail block leaves the frozen range, so the transactions-to-block index no longer covers it and
+// stage_txlookup will not rebuild kv.TxLookup for it (it resumes from its own progress at the tip).
+// writeTailBlock therefore has to write the lookup entry itself, with the same blockNum||txNum shape
+// the stage uses, or eth_getTransactionByHash returns nothing for the whole tail.
+func TestWriteTailBlockWritesTxLookup(t *testing.T) {
+	db := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
+
+	h := &types.Header{Number: *uint256.NewInt(11)}
+	hRLP, err := rlp.EncodeToBytes(h)
+	require.NoError(t, err)
+	headerWord := append([]byte{0xaa}, hRLP...)
+
+	const base = uint64(500)
+	body := types.BodyForStorage{BaseTxnID: types.BaseTxnID(base), TxCount: 4} // 2 real + 2 system
+	bodyWord, err := rlp.EncodeToBytes(&body)
+	require.NoError(t, err)
+
+	w1, _, hash1 := tailTxWord(t, 0, 1)
+	w2, _, hash2 := tailTxWord(t, 1, 2)
+	txWords := [][]byte{{0}, w1, w2, {0}}
+
+	require.NoError(t, db.Update(t.Context(), func(tx kv.RwTx) error {
+		return writeTailBlock(tx, headerWord, bodyWord, txWords)
+	}))
+
+	require.NoError(t, db.View(t.Context(), func(tx kv.Tx) error {
+		// txWords index 1 and 2 -> txn ids base+1, base+2, matching the EthTx keys
+		for want, hash := range map[uint64]common.Hash{base + 1: hash1, base + 2: hash2} {
+			blockNum, txNum, err := rawdb.ReadTxLookupEntry(tx, hash)
+			require.NoError(t, err)
+			require.NotNil(t, blockNum, "no TxLookup entry for %x", hash)
+			require.Equal(t, uint64(11), *blockNum)
+			require.Equal(t, want, *txNum)
+		}
+		return nil
+	}))
+}

--- a/db/snapshotsync/freezeblocks/epoch_migration_idx_test.go
+++ b/db/snapshotsync/freezeblocks/epoch_migration_idx_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package freezeblocks
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/db/snaptype"
+	"github.com/erigontech/erigon/db/snaptype2"
+	"github.com/erigontech/erigon/db/version"
+)
+
+// removeDecimalSegFiles must take the decimal indexes with the segment. They carry their own file
+// version, so a mask derived from the .seg name cannot reach them — and a decimal index left
+// behind is not merely garbage: its name encodes the same block pair as the epoch segment that
+// replaces it, so it can be mistaken for that segment's index.
+func TestRemoveSegFilesDeletesDecimalIndexes(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name string) string {
+		p := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(p, []byte("x"), 0o644))
+		return p
+	}
+
+	segPath := write(snaptype.SegmentFileName(version.V1_1, false, 0, 1000, snaptype2.Headers.Enum()))
+	decIdx := write(snaptype.IdxFileName(version.V2_0, false, 0, 1000, snaptype2.Headers.Name()))
+	torrent := write(snaptype.SegmentFileName(version.V1_1, false, 0, 1000, snaptype2.Headers.Enum()) + ".torrent")
+	// the epoch segment's own index encodes to the same 000000-000001 pair and must survive
+	epochInfo := snaptype2.Headers.FileInfo(dir, true, 0, 1024)
+	epochSeg := write(epochInfo.Name())
+	var epochIdxs []string
+	for _, n := range epochInfo.Type.IdxFileNames(epochInfo.Epoch, epochInfo.From, epochInfo.To) {
+		epochIdxs = append(epochIdxs, write(n))
+	}
+
+	info, _, ok := snaptype.ParseFileName(dir, filepath.Base(segPath))
+	require.True(t, ok)
+	require.NoError(t, removeDecimalSegFiles([]snaptype.FileInfo{info}))
+
+	require.NoFileExists(t, segPath)
+	require.NoFileExists(t, decIdx)
+	require.NoFileExists(t, torrent)
+	require.FileExists(t, epochSeg)
+	for _, p := range epochIdxs {
+		require.FileExists(t, p, p)
+	}
+}
+
+// The transactions type owns two indexes, one of which (transactions-to-block) is only a prefix
+// match away from the other, so removing a decimal transactions segment must take both.
+func TestRemoveSegFilesDeletesAllIndexesOfType(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name string) string {
+		p := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(p, []byte("x"), 0o644))
+		return p
+	}
+
+	segPath := write(snaptype.SegmentFileName(version.V1_1, false, 1000, 2000, snaptype2.Transactions.Enum()))
+	var decIdx []string
+	for _, idx := range snaptype2.Transactions.Indexes() {
+		decIdx = append(decIdx, write(snaptype.IdxFileName(version.V2_0, false, 1000, 2000, idx.Name)))
+	}
+	require.Len(t, decIdx, 2)
+	// epoch [1024,2048) prints the same 000001-000002 digits as decimal [1000,2000)
+	epochInfo := snaptype2.Transactions.FileInfo(dir, true, 1024, 2048)
+	epochKeep := []string{write(epochInfo.Name())}
+	for _, n := range epochInfo.Type.IdxFileNames(epochInfo.Epoch, epochInfo.From, epochInfo.To) {
+		epochKeep = append(epochKeep, write(n))
+	}
+
+	info, _, ok := snaptype.ParseFileName(dir, filepath.Base(segPath))
+	require.True(t, ok)
+	require.NoError(t, removeDecimalSegFiles([]snaptype.FileInfo{info}))
+
+	require.NoFileExists(t, segPath)
+	for _, p := range decIdx {
+		require.NoFileExists(t, p, p)
+	}
+	for _, p := range epochKeep {
+		require.FileExists(t, p, p)
+	}
+}
+
+// hasEpochIndexes decides whether buildEpochIndexes may skip a segment, so it must answer only
+// about the epoch-named index. snaptype.HasIndexFiles cannot: its lookup wildcards the version and
+// encodes the range as block/1000, and decimal [1000k,1000(k+1)) collides with epoch
+// [1024k,1024(k+1)) for every k below ~42 — accepting the decimal index there makes the migration
+// skip building the real one and then delete the decimal segments.
+func TestHasEpochIndexesIgnoresDecimalIndex(t *testing.T) {
+	const from, to = uint64(0), uint64(1024)
+	epochInfo := snaptype2.Headers.FileInfo("", true, from, to)
+	epochSeg := epochInfo.Name()
+	decIdx := snaptype.IdxFileName(version.V2_0, false, 0, 1000, snaptype2.Headers.Name())
+	epochIdxs := epochInfo.Type.IdxFileNames(epochInfo.Epoch, epochInfo.From, epochInfo.To)
+
+	// The "ep" marker is what keeps an epoch index distinct from a decimal one that would otherwise
+	// wildcard-match the same range+type: the epoch index carries the "-ep" marker, the decimal one does not.
+	require.NotContains(t, decIdx, "-ep.")
+	require.Len(t, epochIdxs, 1)
+	require.Contains(t, epochIdxs[0], "-ep.")
+
+	require.False(t, hasEpochIndexes(epochInfo, []string{epochSeg, decIdx}),
+		"a leftover decimal index must not count as the epoch segment's index")
+	require.True(t, hasEpochIndexes(epochInfo, append([]string{epochSeg}, epochIdxs...)))
+}

--- a/db/snapshotsync/freezeblocks/epoch_migration_integration_test.go
+++ b/db/snapshotsync/freezeblocks/epoch_migration_integration_test.go
@@ -95,9 +95,13 @@ func dumpAllDecimal(t *testing.T, m *execmoduletester.ExecModuleTester, logger l
 	}
 }
 
-// migrate runs MigrateDecimalToEpoch against the tester's datadir and DB.
+// migrate runs MigrateDecimalToEpoch against the tester's datadir and DB. It closes the tester's
+// snapshots first: in production the migration runs before anything opens a segment, and it deletes
+// each decimal segment once its blocks are durable elsewhere. Holding those files open makes that
+// delete fail on Windows, where an open mapping blocks removal.
 func migrate(t *testing.T, m *execmoduletester.ExecModuleTester, logger log.Logger) error {
 	t.Helper()
+	m.BlockSnapshots.Close()
 	return freezeblocks.MigrateDecimalToEpoch(m.Ctx, m.Dirs, m.DB, m.ChainConfig, 1, logger)
 }
 

--- a/db/snapshotsync/freezeblocks/epoch_migration_integration_test.go
+++ b/db/snapshotsync/freezeblocks/epoch_migration_integration_test.go
@@ -1,0 +1,300 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package freezeblocks_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/dir"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/dbutils"
+	"github.com/erigontech/erigon/db/rawdb"
+	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/snapshotsync/freezeblocks"
+	"github.com/erigontech/erigon/db/snaptype"
+	"github.com/erigontech/erigon/db/snaptype2"
+	"github.com/erigontech/erigon/db/version"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/execmodule/execmoduletester"
+	"github.com/erigontech/erigon/execution/rlp"
+	"github.com/erigontech/erigon/execution/types"
+)
+
+const (
+	migrationChainSize = 3000 // split into decimal segments [0,1000),[1000,2000),[2000,3000)
+	migrationTailFrom  = 2048 // floor(3000, 1024); epoch tiles [0,1024),[1024,2048), tail [2048,3000)
+	migrationTailBlock = 2500 // a block inside the tail [2048,3000), used to prove tail writes
+)
+
+// decimalBounds are the 1000-aligned block boundaries the fixture splits the decimal data at, so the
+// migration reads across several segments and its per-segment deletion advances over more than one.
+// The segment holding migrationTailFrom ([2000,3000)) is the straddle; the two below it get deleted
+// during the produce phase, and [2000,3000) survives to the final cleanup.
+var decimalBounds = []uint64{0, 1000, 2000, migrationChainSize}
+
+// dumpDecimalSeg dumps the real block data for [from,to) into a v1 (decimal-named) segment of typ,
+// giving the migration authentic decimal input to convert. firstTxNum seeds the BaseTxnID for a
+// bodies segment (ignored by the other types); it returns the last txn id used so a caller can chain
+// firstTxNum across consecutive bodies segments.
+func dumpDecimalSeg(t *testing.T, m *execmoduletester.ExecModuleTester, from, to uint64, typ snaptype.Type, firstTxNum uint64, logger log.Logger) (lastTxNum uint64) {
+	t.Helper()
+	cfg := freezeblocks.BlockCompressCfg
+	cfg.Workers = 1
+	path := filepath.Join(m.Dirs.Snap, snaptype.SegmentFileName(version.V1_0, false, from, to, typ.Enum()))
+	c, err := seg.NewCompressor(m.Ctx, "test-decimal", path, m.Dirs.Tmp, cfg, log.LvlDebug, logger)
+	require.NoError(t, err)
+	defer c.Close()
+	c.DisableFsync()
+	collect := func(v []byte) error { return c.AddWord(v) }
+	switch typ.Enum() {
+	case snaptype2.Headers.Enum():
+		_, err = freezeblocks.DumpHeadersRaw(m.Ctx, m.DB, m.ChainConfig, from, to, nil, collect, 1, log.LvlDebug, logger, true)
+	case snaptype2.Bodies.Enum():
+		lastTxNum, err = freezeblocks.DumpBodies(m.Ctx, m.DB, m.ChainConfig, from, to, func(context.Context) uint64 { return firstTxNum }, collect, 1, log.LvlDebug, logger)
+	case snaptype2.Transactions.Enum():
+		_, err = freezeblocks.DumpTxs(m.Ctx, m.DB, m.ChainConfig, from, to, nil, collect, 1, log.LvlDebug, logger)
+	}
+	require.NoError(t, err)
+	require.NoError(t, c.Compress())
+	return lastTxNum
+}
+
+// dumpAllDecimal writes the decimal segments for [0,migrationChainSize), split at decimalBounds, for
+// all three block types. Bodies chain firstTxNum across segments so BaseTxnID stays cumulative.
+func dumpAllDecimal(t *testing.T, m *execmoduletester.ExecModuleTester, logger log.Logger) {
+	t.Helper()
+	for i := 0; i+1 < len(decimalBounds); i++ {
+		dumpDecimalSeg(t, m, decimalBounds[i], decimalBounds[i+1], snaptype2.Headers, 0, logger)
+		dumpDecimalSeg(t, m, decimalBounds[i], decimalBounds[i+1], snaptype2.Transactions, 0, logger)
+	}
+	// DumpBodies returns the next block's BaseTxnID (it advances past the trailing system tx), so the
+	// next segment continues from exactly that value — no extra +1.
+	var firstTxNum uint64
+	for i := 0; i+1 < len(decimalBounds); i++ {
+		firstTxNum = dumpDecimalSeg(t, m, decimalBounds[i], decimalBounds[i+1], snaptype2.Bodies, firstTxNum, logger)
+	}
+}
+
+// migrate runs MigrateDecimalToEpoch against the tester's datadir and DB.
+func migrate(t *testing.T, m *execmoduletester.ExecModuleTester, logger log.Logger) error {
+	t.Helper()
+	return freezeblocks.MigrateDecimalToEpoch(m.Ctx, m.Dirs, m.DB, m.ChainConfig, 1, logger)
+}
+
+// headerInDB reports whether block n's header is present in the DB.
+func headerInDB(t *testing.T, m *execmoduletester.ExecModuleTester, n uint64) bool {
+	t.Helper()
+	var present bool
+	require.NoError(t, m.DB.View(m.Ctx, func(tx kv.Tx) error {
+		present = rawdb.ReadHeaderByNumber(tx, n) != nil
+		return nil
+	}))
+	return present
+}
+
+// dropHeader deletes block n's header from the DB, simulating a tail block whose write-back has not
+// been committed yet.
+func dropHeader(t *testing.T, m *execmoduletester.ExecModuleTester, n uint64) {
+	t.Helper()
+	require.NoError(t, m.DB.Update(m.Ctx, func(tx kv.RwTx) error {
+		h := rawdb.ReadHeaderByNumber(tx, n)
+		require.NotNil(t, h)
+		return tx.Delete(kv.Headers, dbutils.HeaderKey(n, h.Hash()))
+	}))
+}
+
+// requireEpochOnly asserts a single epoch-only regime: the first epoch tier [0,1024) is present for
+// every block type, and none of the decimal segments remain on disk.
+func requireEpochOnly(t *testing.T, m *execmoduletester.ExecModuleTester) {
+	t.Helper()
+	for _, typ := range snaptype2.BlockSnapshotTypes {
+		require.FileExists(t, filepath.Join(m.Dirs.Snap, typ.FileInfo(m.Dirs.Snap, true, 0, 1024).Name()), typ.Name())
+		for i := 0; i+1 < len(decimalBounds); i++ {
+			require.NoFileExists(t, filepath.Join(m.Dirs.Snap, snaptype.SegmentFileName(version.V1_0, false, decimalBounds[i], decimalBounds[i+1], typ.Enum())), typ.Name())
+		}
+	}
+}
+
+// setupMigrated builds a chain, dumps it as decimal, and runs one full migration, leaving the datadir
+// in the completed state: epoch [0,1024),[1024,2048) + indexes, decimal deleted, tail [2048,3000) in DB.
+func setupMigrated(t *testing.T, logger log.Logger) *execmoduletester.ExecModuleTester {
+	t.Helper()
+	m := createDumpTestKV(t, chain.AllProtocolChanges, migrationChainSize)
+	dumpAllDecimal(t, m, logger)
+	require.NoError(t, migrate(t, m, logger))
+	return m
+}
+
+// TestMigrateDecimalToEpoch is the happy path: a fresh datadir of decimal segments is converted to
+// epoch [0,1024),[1024,2048) with indexes, the sub-1024 tail [2048,3000) is written back to the DB,
+// the decimal segments are deleted, and a second run is a no-op.
+func TestMigrateDecimalToEpoch(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	logger := log.New()
+	m := createDumpTestKV(t, chain.AllProtocolChanges, migrationChainSize)
+	dumpAllDecimal(t, m, logger)
+
+	// Drop a tail block first so we can prove the migration actually writes the tail back.
+	dropHeader(t, m, migrationTailBlock)
+	require.False(t, headerInDB(t, m, migrationTailBlock))
+
+	require.NoError(t, migrate(t, m, logger))
+
+	// The first epoch tier [0,1024) exists with indexes for all three block types; decimal ones gone.
+	requireEpochOnly(t, m)
+	for _, typ := range snaptype2.BlockSnapshotTypes {
+		for _, idxName := range typ.IdxFileNames(true, 0, 1024) {
+			require.FileExists(t, filepath.Join(m.Dirs.Snap, idxName), idxName)
+		}
+	}
+
+	// Epoch header segment content is correct: word K decodes to header number K.
+	d, err := seg.NewDecompressor(filepath.Join(m.Dirs.Snap, snaptype2.Headers.FileInfo(m.Dirs.Snap, true, 0, 1024).Name()))
+	require.NoError(t, err)
+	defer d.Close()
+	require.Equal(t, 1024, d.Count())
+	g := d.MakeGetter()
+	for k := uint64(0); g.HasNext(); k++ {
+		w, _ := g.Next(nil)
+		var h types.Header
+		require.NoError(t, rlp.DecodeBytes(w[1:], &h))
+		require.Equal(t, k, h.Number.Uint64())
+	}
+
+	// The tail block was written back to the DB.
+	require.True(t, headerInDB(t, m, migrationTailBlock))
+
+	// Idempotent: a second run finds no decimal and is a no-op.
+	require.NoError(t, migrate(t, m, logger))
+	requireEpochOnly(t, m)
+}
+
+// TestEpochMigration_ResumeBeforeTailCommit covers a crash after the epoch segments were produced but
+// before the DB tail was committed: the straddling decimal segment (the tail's data source) is still
+// on disk. On restart the straddle keeps coverage past tailFrom, so frozenMax(3000) > startBlock
+// (2048) and the repack guard does NOT fire — the repack re-collects the tail from the straddle and
+// re-commits it. Proven by dropping a tail block before the resume and checking it is restored.
+func TestEpochMigration_ResumeBeforeTailCommit(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	logger := log.New()
+	m := setupMigrated(t, logger)
+
+	// "convert done, tail not yet committed": straddle present again, tail block missing from the DB.
+	dumpAllDecimal(t, m, logger)
+	dropHeader(t, m, migrationTailBlock)
+	require.False(t, headerInDB(t, m, migrationTailBlock))
+
+	require.NoError(t, migrate(t, m, logger))
+
+	// The tail was re-collected from the straddle and written back; the datadir is epoch-only again.
+	require.True(t, headerInDB(t, m, migrationTailBlock))
+	requireEpochOnly(t, m)
+}
+
+// TestEpochMigration_ResumeAfterTailCommit covers a crash after the tail was committed but before the
+// straddling decimal segments were deleted: both the DB tail and the straddle are present. The
+// straddle still keeps frozenMax > tailFrom, so the repack runs and idempotently re-writes the
+// identical tail, then the cleanup removes the straddle. The datadir converges and the tail survives.
+func TestEpochMigration_ResumeAfterTailCommit(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	logger := log.New()
+	m := setupMigrated(t, logger)
+	require.True(t, headerInDB(t, m, migrationTailBlock)) // tail already committed by setupMigrated
+
+	// "tail committed, straddle not yet deleted": straddle present again, DB tail left in place.
+	dumpAllDecimal(t, m, logger)
+
+	require.NoError(t, migrate(t, m, logger))
+
+	require.True(t, headerInDB(t, m, migrationTailBlock))
+	requireEpochOnly(t, m)
+}
+
+// TestEpochMigration_ResumeDuringCleanup covers a crash midway through deleting the straddles: the
+// tail is already committed, some types' straddles are gone, and at least one type's straddle
+// survives. That collapses frozenMax to tailFrom, so the repack guard (startBlock >= frozenMax) skips
+// producing/collecting for every type — including the transactions repack, which therefore never
+// reads the (now-absent) decimal bodies. This must neither error nor drop the already-committed tail.
+// Reproduced by recreating only the transactions straddle.
+func TestEpochMigration_ResumeDuringCleanup(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	logger := log.New()
+	m := setupMigrated(t, logger)
+	require.True(t, headerInDB(t, m, migrationTailBlock))
+
+	// Only the transactions straddle ([2000,3000)) survives → frozenMax collapses to tailFrom and the
+	// guard fires (headers/bodies have no decimal at all, so their coverage is just the epoch prefix).
+	straddleFrom, straddleTo := decimalBounds[len(decimalBounds)-2], decimalBounds[len(decimalBounds)-1]
+	dumpDecimalSeg(t, m, straddleFrom, straddleTo, snaptype2.Transactions, 0, logger)
+
+	require.NoError(t, migrate(t, m, logger)) // guard skips the repacks; no "ran out of bodies" error
+
+	require.True(t, headerInDB(t, m, migrationTailBlock)) // the committed tail is untouched
+	requireEpochOnly(t, m)                                // the leftover transactions straddle is removed
+}
+
+// TestEpochMigration_TailDurableBeforeIndexes pins the write order: the DB tail is committed before
+// the epoch indexes are built, so a crash during index building (the longest, most memory-hungry
+// phase) leaves the tail already durable instead of forcing it to be re-collected. Index building is
+// made to fail by pointing the migration at an unusable tmp dir, which nothing before it needs on a
+// resume — the epoch segments already exist, so no compressor runs.
+func TestEpochMigration_TailDurableBeforeIndexes(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	logger := log.New()
+	m := setupMigrated(t, logger)
+
+	dumpAllDecimal(t, m, logger)
+	dropHeader(t, m, migrationTailBlock)
+	require.False(t, headerInDB(t, m, migrationTailBlock))
+
+	// force the index step to run (and then fail): drop the headers index, and make tmp unusable.
+	headersIdx := snaptype2.Headers.IdxFileNames(true, 0, 1024)[0]
+	require.NoError(t, dir.RemoveFile(filepath.Join(m.Dirs.Snap, headersIdx)))
+	brokenTmp := filepath.Join(t.TempDir(), "not-a-dir")
+	require.NoError(t, os.WriteFile(brokenTmp, nil, 0o644))
+	dirs := m.Dirs
+	dirs.Tmp = brokenTmp
+
+	require.Error(t, freezeblocks.MigrateDecimalToEpoch(m.Ctx, dirs, m.DB, m.ChainConfig, 1, logger))
+
+	require.True(t, headerInDB(t, m, migrationTailBlock),
+		"tail must be committed before the indexes are built")
+	require.NoFileExists(t, filepath.Join(m.Dirs.Snap, headersIdx))
+
+	// That failure leaves a state this ordering newly makes possible — tail committed, an index
+	// missing, straddles still on disk. A resume has to converge from it.
+	require.NoError(t, migrate(t, m, logger))
+	require.FileExists(t, filepath.Join(m.Dirs.Snap, headersIdx))
+	require.True(t, headerInDB(t, m, migrationTailBlock))
+	requireEpochOnly(t, m)
+}

--- a/db/snapshotsync/freezeblocks/epoch_migration_test.go
+++ b/db/snapshotsync/freezeblocks/epoch_migration_test.go
@@ -1,0 +1,494 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package freezeblocks
+
+import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/snapcfg"
+	"github.com/erigontech/erigon/db/snaptype"
+	"github.com/erigontech/erigon/db/snaptype2"
+	"github.com/erigontech/erigon/db/version"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/chain/networkname"
+	chainspec "github.com/erigontech/erigon/execution/chain/spec"
+	"github.com/erigontech/erigon/execution/rlp"
+	"github.com/erigontech/erigon/execution/types"
+
+	"github.com/holiman/uint256"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/crypto"
+	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/common/length"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/dbutils"
+	"github.com/erigontech/erigon/db/kv/mdbx/mdbxtest"
+	"github.com/erigontech/erigon/db/rawdb"
+)
+
+// writeTailBlock re-inserts a block from its segment words into the DB at the ORIGINAL BaseTxnID
+// (real txns only in EthTx; system-tx slots skipped) and it round-trips back through the reader.
+func TestWriteTailBlock(t *testing.T) {
+	_, tx := mdbxtest.NewTestTx(t)
+
+	h := &types.Header{Number: *uint256.NewInt(5)}
+	hRLP, err := rlp.EncodeToBytes(h)
+	require.NoError(t, err)
+	headerWord := append([]byte{0xaa}, hRLP...) // firstByte-of-hash + header rlp
+	hash := h.Hash()
+
+	body := types.BodyForStorage{BaseTxnID: types.BaseTxnID(100), TxCount: 4} // 2 real + 2 system
+	bodyWord, err := rlp.EncodeToBytes(&body)
+	require.NoError(t, err)
+
+	w1, raw1, _ := tailTxWord(t, 0, 1)
+	w2, raw2, _ := tailTxWord(t, 1, 2)
+	txWords := [][]byte{{0}, w1, w2, {0}} // begin, real0, real1, end
+
+	require.NoError(t, writeTailBlock(tx, headerWord, bodyWord, txWords))
+
+	got := rawdb.ReadHeaderByNumber(tx, 5)
+	require.NotNil(t, got)
+	require.Equal(t, uint64(5), got.Number.Uint64())
+	ch, err := rawdb.ReadCanonicalHash(tx, 5)
+	require.NoError(t, err)
+	require.Equal(t, hash, ch)
+
+	bfs, err := rawdb.ReadBodyForStorageByKey(tx, dbutils.BlockBodyKey(5, hash))
+	require.NoError(t, err)
+	require.Equal(t, uint32(4), bfs.TxCount)
+	require.Equal(t, uint64(100), bfs.BaseTxnID.U64())
+
+	// real txns at base+1=101, base+2=102 (system slots 100 and 103 hold nothing)
+	v1, err := tx.GetOne(kv.EthTx, hexutil.EncodeTs(101))
+	require.NoError(t, err)
+	require.Equal(t, raw1, v1)
+	v2, err := tx.GetOne(kv.EthTx, hexutil.EncodeTs(102))
+	require.NoError(t, err)
+	require.Equal(t, raw2, v2)
+	sys, err := tx.GetOne(kv.EthTx, hexutil.EncodeTs(100))
+	require.NoError(t, err)
+	require.Nil(t, sys)
+
+	senders, err := rawdb.ReadSenders(tx, hash, 5)
+	require.NoError(t, err)
+	require.Len(t, senders, 2)
+	require.Equal(t, byte(1), senders[0][0])
+	require.Equal(t, byte(2), senders[1][0])
+}
+
+// The tail is written into the (pruned) key range below the DB's existing data. writeTailBlock must
+// place it there with Put — filling the low keys without disturbing the higher, already-present data
+// and without touching the EthTx sequence counter (which tracks the tip). This mirrors the real
+// state: blocks [F,tip) and their high txn ids are in the DB, [1,F) were pruned, and the migration
+// back-fills a tail block below F.
+func TestWriteTailBlockBelowExistingData(t *testing.T) {
+	_, tx := mdbxtest.NewTestTx(t)
+
+	// Pre-existing high-range data: a header at a high block and an EthTx entry at a high txn id, with
+	// the EthTx sequence advanced to the tip (as IncrementSequence would leave it during normal sync).
+	const existingBlock, existingTxnID = uint64(900_000), uint64(5_000_000)
+	existing := &types.Header{Number: *uint256.NewInt(existingBlock)}
+	existingHash := existing.Hash()
+	existingRLP, err := rlp.EncodeToBytes(existing)
+	require.NoError(t, err)
+	require.NoError(t, rawdb.WriteHeaderRaw(tx, existingBlock, existingHash, existingRLP, false))
+	require.NoError(t, rawdb.WriteCanonicalHash(tx, existingHash, existingBlock))
+	require.NoError(t, tx.Put(kv.EthTx, hexutil.EncodeTs(existingTxnID), []byte("existing-tx")))
+	_, err = tx.IncrementSequence(kv.EthTx, existingTxnID+1) // sequence now sits at the tip
+	require.NoError(t, err)
+	seqBefore, err := tx.ReadSequence(kv.EthTx)
+	require.NoError(t, err)
+
+	// A tail block far below the existing data: block 5, BaseTxnID 100, TxCount 4 (2 real + 2 system).
+	h := &types.Header{Number: *uint256.NewInt(5)}
+	hRLP, err := rlp.EncodeToBytes(h)
+	require.NoError(t, err)
+	headerWord := append([]byte{0xaa}, hRLP...)
+	body := types.BodyForStorage{BaseTxnID: types.BaseTxnID(100), TxCount: 4}
+	bodyWord, err := rlp.EncodeToBytes(&body)
+	require.NoError(t, err)
+	w1, raw1, _ := tailTxWord(t, 0, 1)
+	w2, _, _ := tailTxWord(t, 1, 2)
+	txWords := [][]byte{{0}, w1, w2, {0}}
+
+	require.NoError(t, writeTailBlock(tx, headerWord, bodyWord, txWords))
+
+	// The tail block landed at the low keys.
+	require.NotNil(t, rawdb.ReadHeaderByNumber(tx, 5))
+	v, err := tx.GetOne(kv.EthTx, hexutil.EncodeTs(101)) // first real txn at base+1
+	require.NoError(t, err)
+	require.Equal(t, raw1, v)
+
+	// The pre-existing high-range data is untouched.
+	require.NotNil(t, rawdb.ReadHeaderByNumber(tx, existingBlock))
+	ev, err := tx.GetOne(kv.EthTx, hexutil.EncodeTs(existingTxnID))
+	require.NoError(t, err)
+	require.Equal(t, []byte("existing-tx"), ev)
+
+	// The EthTx sequence counter (the tip's next id) is unchanged — the tail used Put, not the sequence.
+	seqAfter, err := tx.ReadSequence(kv.EthTx)
+	require.NoError(t, err)
+	require.Equal(t, seqBefore, seqAfter)
+
+	// EthTx stays sorted: the back-filled low ids come first, the pre-existing high id stays last.
+	c, err := tx.Cursor(kv.EthTx)
+	require.NoError(t, err)
+	defer c.Close()
+	first, _, err := c.First()
+	require.NoError(t, err)
+	require.Equal(t, hexutil.EncodeTs(101), first)
+	last, _, err := c.Last()
+	require.NoError(t, err)
+	require.Equal(t, hexutil.EncodeTs(existingTxnID), last)
+}
+
+// createSeqSeg writes a decimal .seg for [from,to) whose word for block K is big-endian K, so a
+// repack can be verified block-by-block. No index is written (the migration reads segments
+// sequentially via the raw Decompressor).
+func createSeqSeg(t *testing.T, dir string, from, to uint64, name snaptype.Type, ver snaptype.Version, epoch bool, logger log.Logger) {
+	cfg := seg.DefaultCfg
+	cfg.MinPatternScore = 100
+	c, err := seg.NewCompressor(t.Context(), "test", filepath.Join(dir, snaptype.SegmentFileName(ver, epoch, from, to, name.Enum())), dir, cfg, log.LvlDebug, logger)
+	require.NoError(t, err)
+	defer c.Close()
+	c.DisableFsync()
+	buf := make([]byte, 8)
+	for k := from; k < to; k++ {
+		binary.BigEndian.PutUint64(buf, k)
+		require.NoError(t, c.AddWord(buf))
+	}
+	require.NoError(t, c.Compress())
+}
+
+// repackWordPerBlock re-segments two decimal headers segments covering [0,2000) into the planned
+// epoch segment [0,1024), copying words verbatim, and hands the sub-1024 tail (1024..1999) to the
+// DB callback.
+func TestRepackWordPerBlock(t *testing.T) {
+	dir := t.TempDir()
+	logger := log.New()
+	createSeqSeg(t, dir, 0, 1000, snaptype2.Headers, version.V1_0, false, logger)
+	createSeqSeg(t, dir, 1000, 2000, snaptype2.Headers, version.V1_0, false, logger)
+
+	m := &epochMigrator{
+		dirs:    datadir.Dirs{Snap: dir, Tmp: dir},
+		snCfg:   snapcfg.KnownCfgOrDevnet(networkname.Mainnet),
+		workers: 1,
+		lvl:     log.LvlDebug,
+		logger:  logger,
+	}
+	_, _, hasDecimal, err := m.loadSegs()
+	require.NoError(t, err)
+	require.True(t, hasDecimal)
+	const frozenMax = 2000 // isolating headers; the real orchestrator takes the min over all block types
+
+	var tail []uint64
+	require.NoError(t, m.repackWordPerBlock(t.Context(), snaptype2.Headers, 0, frozenMax,
+		func(bn uint64, w []byte) error { tail = append(tail, binary.BigEndian.Uint64(w)); return nil }))
+
+	// epoch segment [0,1024) has exactly blocks 0..1023 in order
+	d, err := seg.NewDecompressor(snaptype2.Headers.FileInfo(dir, true, 0, 1024).Path)
+	require.NoError(t, err)
+	defer d.Close()
+	require.Equal(t, 1024, d.Count())
+	g := d.MakeGetter()
+	for k := range uint64(1024) {
+		w, _ := g.Next(nil)
+		require.Equal(t, k, binary.BigEndian.Uint64(w))
+	}
+	// tail = blocks 1024..1999 (976 blocks) handed to the DB callback in order
+	require.Len(t, tail, 976)
+	require.Equal(t, uint64(1024), tail[0])
+	require.Equal(t, uint64(1999), tail[975])
+
+	// per-segment deletion: [0,1000) is fully covered by epoch [0,1024) and removed; the segment
+	// straddling tailFrom ([1000,2000)) is kept for the tail and survives this step.
+	require.NoFileExists(t, filepath.Join(dir, snaptype.SegmentFileName(version.V1_0, false, 0, 1000, snaptype2.Headers.Enum())))
+	require.FileExists(t, filepath.Join(dir, snaptype.SegmentFileName(version.V1_0, false, 1000, 2000, snaptype2.Headers.Enum())))
+}
+
+// On resume, the type's decimal below the epoch frontier is already gone, so the run starts from
+// the straddling segment: repack skips [firstFrom, startBlock) and, when the frontier is already at
+// tailFrom, produces no epoch segment and just hands the tail to the DB callback.
+func TestRepackWordPerBlockResume(t *testing.T) {
+	dir := t.TempDir()
+	logger := log.New()
+	// [0,1000) was already migrated and deleted; only the straddling [1000,2000) remains.
+	createSeqSeg(t, dir, 1000, 2000, snaptype2.Headers, version.V1_0, false, logger)
+
+	m := &epochMigrator{
+		dirs:    datadir.Dirs{Snap: dir, Tmp: dir},
+		snCfg:   snapcfg.KnownCfgOrDevnet(networkname.Mainnet),
+		workers: 1,
+		lvl:     log.LvlDebug,
+		logger:  logger,
+	}
+	_, _, _, err := m.loadSegs()
+	require.NoError(t, err)
+	var tail []uint64
+	require.NoError(t, m.repackWordPerBlock(t.Context(), snaptype2.Headers, 1024, 2000,
+		func(bn uint64, w []byte) error { tail = append(tail, binary.BigEndian.Uint64(w)); return nil }))
+
+	// startBlock == tailFrom == 1024 → no epoch segment produced, tail = 1024..1999 from the straddle
+	require.NoFileExists(t, snaptype2.Headers.FileInfo(dir, true, 0, 1024).Path)
+	require.Len(t, tail, 976)
+	require.Equal(t, uint64(1024), tail[0])
+	require.Equal(t, uint64(1999), tail[975])
+}
+
+// When a type is already fully migrated (startBlock == frozenMax), the repack is a no-op even if
+// its decimal is gone and, for transactions, the bodies decimal is gone too. This guards the
+// resume where the final straddle deletion crashed partway: frozenMax collapses to tailFrom, and a
+// type whose decimal already vanished must not try to read an empty stream.
+func TestRepackNoopWhenAlreadyMigrated(t *testing.T) {
+	dir := t.TempDir()
+	logger := log.New()
+	m := &epochMigrator{
+		dirs:    datadir.Dirs{Snap: dir, Tmp: dir},
+		snCfg:   snapcfg.KnownCfgOrDevnet(networkname.Mainnet),
+		workers: 1,
+		lvl:     log.LvlDebug,
+		logger:  logger,
+	}
+	called := false
+	require.NoError(t, m.repackWordPerBlock(t.Context(), snaptype2.Headers, 1024, 1024,
+		func(uint64, []byte) error { called = true; return nil }))
+	require.NoError(t, m.repackTransactions(t.Context(), 1024, 1024,
+		func(uint64, uint64, [][]byte) error { called = true; return nil }))
+	require.False(t, called)
+}
+
+// classifyByType splits one directory scan per type, and coverage folds each type's epoch prefix and
+// the decimal run continuing it into (epochStart, coveredTo, runLen) in a single pass — the resume
+// start, the frozenMax input, and the gap-free run a repack reads.
+func TestClassifyByTypeAndCoverage(t *testing.T) {
+	dir := t.TempDir()
+	logger := log.New()
+	// headers already migrated to epoch [0,1024); decimal straddle [1000,2000) still present.
+	createSeqSeg(t, dir, 0, 1024, snaptype2.Headers, version.V1_1, true, logger)
+	createSeqSeg(t, dir, 1000, 2000, snaptype2.Headers, version.V1_0, false, logger)
+	// bodies: fully-decimal from 0, then a gap, then a post-gap orphan.
+	createSeqSeg(t, dir, 0, 1000, snaptype2.Bodies, version.V1_0, false, logger)
+	createSeqSeg(t, dir, 1000, 2000, snaptype2.Bodies, version.V1_0, false, logger)
+	createSeqSeg(t, dir, 3000, 4000, snaptype2.Bodies, version.V1_0, false, logger) // gap at [2000,3000)
+
+	all, err := snaptype.Segments(dir)
+	require.NoError(t, err)
+
+	epoch, decimal := classifyByType(all, snaptype2.Headers.Enum())
+	require.Len(t, epoch, 1)
+	require.Len(t, decimal, 1)
+	epochStart, coveredTo, runLen := coverage(epoch, decimal)
+	require.Equal(t, uint64(1024), epochStart) // resume producing from the epoch frontier
+	require.Equal(t, uint64(2000), coveredTo)  // straddle decimal extends coverage to 2000
+	require.Equal(t, 1, runLen)
+
+	epoch, decimal = classifyByType(all, snaptype2.Bodies.Enum())
+	require.Empty(t, epoch)
+	require.Len(t, decimal, 3)
+	epochStart, coveredTo, runLen = coverage(epoch, decimal)
+	require.Equal(t, uint64(0), epochStart)
+	require.Equal(t, uint64(2000), coveredTo) // gap at 2000 truncates coverage
+	require.Equal(t, 2, runLen)               // post-gap [3000,4000) dropped from the run
+
+	// transactions type: nothing on disk → no coverage, no decimal.
+	epoch, decimal = classifyByType(all, snaptype2.Transactions.Enum())
+	require.Empty(t, epoch)
+	require.Empty(t, decimal)
+	epochStart, coveredTo, runLen = coverage(epoch, decimal)
+	require.Zero(t, epochStart)
+	require.Zero(t, coveredTo)
+	require.Zero(t, runLen)
+}
+
+// createBodyAndTxSegs writes a matching pair of decimal segments for [from,to): a bodies segment
+// whose word for block K is rlp(BodyForStorage{BaseTxnID: K*txPerBlock, TxCount: txPerBlock}), and
+// a transactions segment with txPerBlock words per block, each encoding (blockNum, txIndex).
+func createBodyAndTxSegs(t *testing.T, dir string, from, to, txPerBlock uint64, ver snaptype.Version, logger log.Logger) {
+	cfg := seg.DefaultCfg
+	cfg.MinPatternScore = 100
+	bc, err := seg.NewCompressor(t.Context(), "test", filepath.Join(dir, snaptype.SegmentFileName(ver, false, from, to, snaptype2.Bodies.Enum())), dir, cfg, log.LvlDebug, logger)
+	require.NoError(t, err)
+	defer bc.Close()
+	bc.DisableFsync()
+	tc, err := seg.NewCompressor(t.Context(), "test", filepath.Join(dir, snaptype.SegmentFileName(ver, false, from, to, snaptype2.Transactions.Enum())), dir, cfg, log.LvlDebug, logger)
+	require.NoError(t, err)
+	defer tc.Close()
+	tc.DisableFsync()
+
+	for k := from; k < to; k++ {
+		body := types.BodyForStorage{BaseTxnID: types.BaseTxnID(k * txPerBlock), TxCount: uint32(txPerBlock)}
+		w, err := rlp.EncodeToBytes(&body)
+		require.NoError(t, err)
+		require.NoError(t, bc.AddWord(w))
+		for j := range txPerBlock {
+			buf := make([]byte, 16)
+			binary.BigEndian.PutUint64(buf[:8], k)
+			binary.BigEndian.PutUint64(buf[8:], j)
+			require.NoError(t, tc.AddWord(buf))
+		}
+	}
+	require.NoError(t, bc.Compress())
+	require.NoError(t, tc.Compress())
+}
+
+// repackTransactions splits the txn-granular transactions segment at block boundaries using the
+// bodies' TxCount: [0,2000) at 2 txns/block → epoch [0,1024) with 2048 words, tail 976 blocks.
+func TestRepackTransactions(t *testing.T) {
+	dir := t.TempDir()
+	logger := log.New()
+	createBodyAndTxSegs(t, dir, 0, 1000, 2, version.V1_0, logger)
+	createBodyAndTxSegs(t, dir, 1000, 2000, 2, version.V1_0, logger)
+
+	m := &epochMigrator{
+		dirs:    datadir.Dirs{Snap: dir, Tmp: dir},
+		snCfg:   snapcfg.KnownCfgOrDevnet(networkname.Mainnet),
+		workers: 1,
+		lvl:     log.LvlDebug,
+		logger:  logger,
+	}
+	_, _, _, err := m.loadSegs()
+	require.NoError(t, err)
+	type tailBlk struct {
+		base uint64
+		n    int
+	}
+	var tail []tailBlk
+	require.NoError(t, m.repackTransactions(t.Context(), 0, 2000, func(bn, base uint64, words [][]byte) error {
+		tail = append(tail, tailBlk{base, len(words)})
+		return nil
+	}))
+
+	// epoch transactions segment [0,1024) holds 2*1024 words in (block, txIndex) order
+	d, err := seg.NewDecompressor(snaptype2.Transactions.FileInfo(dir, true, 0, 1024).Path)
+	require.NoError(t, err)
+	defer d.Close()
+	require.Equal(t, 2048, d.Count())
+	g := d.MakeGetter()
+	for k := range uint64(1024) {
+		for j := range uint64(2) {
+			w, _ := g.Next(nil)
+			require.Equal(t, k, binary.BigEndian.Uint64(w[:8]))
+			require.Equal(t, j, binary.BigEndian.Uint64(w[8:]))
+		}
+	}
+	// tail: blocks 1024..1999, each with BaseTxnID = block*2 and 2 words
+	require.Len(t, tail, 976)
+	require.Equal(t, uint64(1024*2), tail[0].base)
+	require.Equal(t, 2, tail[0].n)
+	require.Equal(t, uint64(1999*2), tail[975].base)
+}
+
+// The plan tiles [0, floor(frozenMax,1024)) with epoch tiers (524288/65536/8192/1024) and leaves
+// the sub-1024 remainder as the DB tail. For frozenMax=600000 the floor is 599040.
+func TestPlanEpochSegments(t *testing.T) {
+	snCfg := snapcfg.KnownCfgOrDevnet(networkname.Mainnet)
+
+	segs, tailFrom := planEpochSegments(0, 600_000, snCfg)
+	require.Equal(t, [][2]uint64{
+		{0, 524_288},
+		{524_288, 589_824},
+		{589_824, 598_016},
+		{598_016, 599_040},
+	}, segs)
+	require.Equal(t, uint64(599_040), tailFrom) // 600000 - 600000%1024
+
+	// A frozenMax already below one tier has no epoch segments; everything is tail.
+	segs, tailFrom = planEpochSegments(0, 500, snCfg)
+	require.Empty(t, segs)
+	require.Equal(t, uint64(0), tailFrom)
+
+	// An exact tier boundary leaves no tail.
+	segs, tailFrom = planEpochSegments(0, 524_288, snCfg)
+	require.Equal(t, [][2]uint64{{0, 524_288}}, segs)
+	require.Equal(t, uint64(524_288), tailFrom)
+}
+
+// tailTxWord builds a transactions-segment word — firstByte-of-hash + sender(20) + txn binary — for a
+// real signed txn. writeTailBlock decodes each txn to get its hash for the kv.TxLookup entry, so the
+// payload has to be a decodable transaction, not filler.
+func tailTxWord(t *testing.T, nonce uint64, sender byte) (word, raw []byte, hash common.Hash) {
+	t.Helper()
+	key, err := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	require.NoError(t, err)
+	txn, err := types.SignNewTx(key, *types.LatestSignerForChainID(uint256.NewInt(1337)), &types.LegacyTx{
+		CommonTx: types.CommonTx{Nonce: nonce, GasLimit: 21000, Value: *uint256.NewInt(1)},
+		GasPrice: *uint256.NewInt(1),
+	})
+	require.NoError(t, err)
+	var buf bytes.Buffer
+	require.NoError(t, txn.MarshalBinary(&buf))
+	raw = buf.Bytes()
+	word = append([]byte{0xaa, sender}, make([]byte, length.Addr-1)...)
+	word = append(word, raw...)
+	return word, raw, txn.Hash()
+}
+
+// HasDecimalBlockSegments is what read-only consumers (rpcdaemon) use to refuse a datadir that still
+// needs converting, instead of converting it themselves. It must not fire on a decimal chain, where
+// decimal is the correct regime rather than pending work.
+func TestHasDecimalBlockSegments(t *testing.T) {
+	write := func(t *testing.T, dir string, epoch bool, from, to uint64) {
+		t.Helper()
+		for _, typ := range snaptype2.BlockSnapshotTypes {
+			name := typ.FileInfo(dir, epoch, from, to).Name()
+			// non-empty: ParseDir skips zero-length files
+			require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte{0}, 0o644))
+		}
+	}
+
+	t.Run("decimal segments on an eth chain need converting", func(t *testing.T) {
+		dirs := datadir.New(t.TempDir())
+		write(t, dirs.Snap, false, 0, 1_000)
+		got, err := HasDecimalBlockSegments(dirs, chain.AllProtocolChanges)
+		require.NoError(t, err)
+		require.True(t, got)
+	})
+
+	t.Run("epoch segments do not", func(t *testing.T) {
+		dirs := datadir.New(t.TempDir())
+		write(t, dirs.Snap, true, 0, 1_024)
+		got, err := HasDecimalBlockSegments(dirs, chain.AllProtocolChanges)
+		require.NoError(t, err)
+		require.False(t, got)
+	})
+
+	t.Run("empty datadir does not", func(t *testing.T) {
+		dirs := datadir.New(t.TempDir())
+		got, err := HasDecimalBlockSegments(dirs, chain.AllProtocolChanges)
+		require.NoError(t, err)
+		require.False(t, got)
+	})
+
+	t.Run("a decimal chain never does", func(t *testing.T) {
+		dirs := datadir.New(t.TempDir())
+		write(t, dirs.Snap, false, 0, 1_000)
+		got, err := HasDecimalBlockSegments(dirs, chainspec.Gnosis.Config)
+		require.NoError(t, err)
+		require.False(t, got)
+	})
+}

--- a/db/snapshotsync/freezeblocks/epoch_migration_test.go
+++ b/db/snapshotsync/freezeblocks/epoch_migration_test.go
@@ -492,3 +492,28 @@ func TestHasDecimalBlockSegments(t *testing.T) {
 		require.False(t, got)
 	})
 }
+
+// A crash between a merge output landing and RemoveOverlaps can leave a merged segment on disk
+// alongside the old subsegments it subsumes. sortedNoOverlaps must drop the contained subsegments so
+// coverage sees a clean From-ascending run and does not mistake the first contained file for a gap —
+// which previously truncated the run and deleted valid decimal segments beyond it.
+func TestSortedNoOverlapsDropsContained(t *testing.T) {
+	fi := func(from, to uint64) snaptype.FileInfo { return snaptype.FileInfo{From: from, To: to} }
+	rng := func(s []snaptype.FileInfo) [][2]uint64 {
+		out := make([][2]uint64, len(s))
+		for i, f := range s {
+			out[i] = [2]uint64{f.From, f.To}
+		}
+		return out
+	}
+
+	// merged [0,8192) coexists with its old subsegments; only the container survives, then the tail.
+	in := []snaptype.FileInfo{fi(1024, 2048), fi(0, 8192), fi(0, 1024), fi(2048, 3072), fi(8192, 16384)}
+	require.Equal(t, [][2]uint64{{0, 8192}, {8192, 16384}}, rng(sortedNoOverlaps(in)))
+
+	// with the contained files gone, coverage counts the full contiguous run rather than stopping at
+	// a false gap at the first subsegment.
+	_, coveredTo, runLen := coverage(nil, sortedNoOverlaps(in))
+	require.Equal(t, uint64(16384), coveredTo)
+	require.Equal(t, 2, runLen)
+}

--- a/db/snapshotsync/freezeblocks/epoch_migration_test.go
+++ b/db/snapshotsync/freezeblocks/epoch_migration_test.go
@@ -517,3 +517,83 @@ func TestSortedNoOverlapsDropsContained(t *testing.T) {
 	require.Equal(t, uint64(16384), coveredTo)
 	require.Equal(t, 2, runLen)
 }
+
+// Pruning deletes whole segments, so a type whose old history is gone starts well above block 0.
+// coverage must report that block, not give up because the run does not reach block 0.
+func TestCoveragePrunedType(t *testing.T) {
+	dir := t.TempDir()
+	logger := log.New()
+	createSeqSeg(t, dir, 3000, 4000, snaptype2.Transactions, version.V1_0, false, logger)
+	createSeqSeg(t, dir, 4000, 5000, snaptype2.Transactions, version.V1_0, false, logger)
+
+	all, err := snaptype.Segments(dir)
+	require.NoError(t, err)
+	epoch, decimal := classifyByType(all, snaptype2.Transactions.Enum())
+	require.Empty(t, epoch)
+	require.Len(t, decimal, 2)
+
+	start, coveredTo, runLen := coverage(epoch, decimal)
+	require.Equal(t, uint64(3000), start, "the type's own frontier; the caller aligns it to the shared tiling")
+	require.Equal(t, uint64(5000), coveredTo)
+	require.Equal(t, 2, runLen)
+}
+
+// On a pruned node headers and bodies still reach block 0 while transactions start higher up. Every
+// type ends at the same block, so only the starts differ, and loadSegs has to report them per type.
+func TestLoadSegsPrunedTransactions(t *testing.T) {
+	dir := t.TempDir()
+	logger := log.New()
+	for _, tp := range []snaptype.Type{snaptype2.Headers, snaptype2.Bodies} {
+		createSeqSeg(t, dir, 0, 1000, tp, version.V1_0, false, logger)
+		createSeqSeg(t, dir, 1000, 2000, tp, version.V1_0, false, logger)
+		createSeqSeg(t, dir, 2000, 3000, tp, version.V1_0, false, logger)
+	}
+	createSeqSeg(t, dir, 2000, 3000, snaptype2.Transactions, version.V1_0, false, logger)
+
+	m := &epochMigrator{
+		dirs:    datadir.Dirs{Snap: dir, Tmp: dir},
+		snCfg:   snapcfg.KnownCfgOrDevnet(networkname.Mainnet),
+		workers: 1,
+		lvl:     log.LvlDebug,
+		logger:  logger,
+	}
+	start, frozenMax, hasDecimal, err := m.loadSegs()
+	require.NoError(t, err)
+	require.True(t, hasDecimal)
+	require.Equal(t, uint64(3000), frozenMax, "every type ends at 3000; pruning only moves starts")
+	require.Equal(t, uint64(0), start[snaptype2.Headers.Enum()])
+	require.Equal(t, uint64(0), start[snaptype2.Bodies.Enum()])
+	require.Equal(t, uint64(2000), start[snaptype2.Transactions.Enum()],
+		"raw frontier; run() aligns it to the shared tiling")
+}
+
+// A datadir missing one block type cannot open any block segment at all, so it is already broken.
+// Converting it would move the breakage rather than fix it: refuse, and say which type is missing.
+func TestMigrateRefusesTypeWithNoSegments(t *testing.T) {
+	dir := t.TempDir()
+	logger := log.New()
+	for _, tp := range []snaptype.Type{snaptype2.Headers, snaptype2.Bodies} {
+		createSeqSeg(t, dir, 0, 1000, tp, version.V1_0, false, logger)
+		createSeqSeg(t, dir, 1000, 2000, tp, version.V1_0, false, logger)
+	}
+
+	err := MigrateDecimalToEpoch(t.Context(), datadir.Dirs{Snap: dir, Tmp: dir}, nil,
+		chainspec.Mainnet.Config, 1, logger)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "transactions", "the error must name the missing type")
+}
+
+// Every transactions segment needs a bodies segment with the same from and to, because that is how
+// its index gets built. So a pruned type resumes at the next cut in the shared plan, which is not
+// the same as the next multiple of 1024.
+func TestStartOnPlan(t *testing.T) {
+	plan, tailFrom := planEpochSegments(0, 20_000, snapcfg.KnownCfgOrDevnet(networkname.Mainnet))
+	require.Equal(t, [][2]uint64{{0, 8192}, {8192, 16384}, {16384, 17408}, {17408, 18432}, {18432, 19456}}, plan)
+	require.Equal(t, uint64(19_456), tailFrom)
+
+	require.Equal(t, uint64(0), startOnPlan(plan, 0))
+	require.Equal(t, uint64(8192), startOnPlan(plan, 1), "1 is on no boundary; the next one is 8192")
+	require.Equal(t, uint64(16384), startOnPlan(plan, 9_000), "9216 would be 1024-aligned but is not a boundary")
+	require.Equal(t, uint64(16384), startOnPlan(plan, 16_384))
+	require.Equal(t, uint64(18432), startOnPlan(plan, 17_409))
+}

--- a/db/snapshotsync/freezeblocks/epoch_migration_test.go
+++ b/db/snapshotsync/freezeblocks/epoch_migration_test.go
@@ -597,3 +597,16 @@ func TestStartOnPlan(t *testing.T) {
 	require.Equal(t, uint64(16384), startOnPlan(plan, 16_384))
 	require.Equal(t, uint64(18432), startOnPlan(plan, 17_409))
 }
+
+// A pruned type can start inside the sub-1024 tail, where the plan has no later boundary. Returning
+// the last boundary there puts the resume point below the type's own data, so its words would be
+// paired with earlier blocks. Keeping the frontier leaves the range tail-only, with no segment.
+func TestStartOnPlanKeepsFrontierPastLastBoundary(t *testing.T) {
+	plan, tailFrom := planEpochSegments(0, 86_000, snapcfg.KnownCfgOrDevnet(networkname.Mainnet))
+	require.Equal(t, uint64(84_992), tailFrom)
+
+	require.Equal(t, uint64(85_000), startOnPlan(plan, 85_000),
+		"no boundary at or above the frontier: keep it, do not fall back below it")
+	require.Equal(t, uint64(84_992), startOnPlan(plan, 84_992), "an exact boundary is kept")
+	require.Equal(t, uint64(0), startOnPlan(nil, 0))
+}

--- a/db/snapshotsync/merger.go
+++ b/db/snapshotsync/merger.go
@@ -40,13 +40,14 @@ func (m *Merger) DisableFsync() { m.noFsync = true }
 
 func (m *Merger) FindMergeRanges(currentRanges []Range, maxBlockNum uint64) (toMerge []Range) {
 	cfg := m.snCfg
+	epoch := snaptype2.RegimeFor(m.chainConfig)
 	for i := len(currentRanges) - 1; i > 0; i-- {
 		r := currentRanges[i]
-		mergeLimit := cfg.MergeLimit(snaptype.Unknown, r.From())
+		mergeLimit := cfg.MergeLimit(snaptype.Unknown, epoch, r.From())
 		if r.To()-r.From() >= mergeLimit {
 			continue
 		}
-		for _, span := range snapcfg.MergeStepsFromCfg(cfg, snaptype.Unknown, r.From()) {
+		for _, span := range snapcfg.MergeStepsFromCfg(cfg, snaptype.Unknown, epoch, r.From()) {
 			if r.To()%span != 0 {
 				continue
 			}
@@ -219,11 +220,12 @@ func (m *Merger) Merge(
 			out[snapType] = append(out[snapType], t...)
 		}
 
+		epoch := snaptype2.RegimeFor(m.chainConfig)
 		for _, t := range snapTypes {
 			newDirtySegment, err := m.mergeSubSegment(
 				ctx,
 				v,
-				t.FileInfo(snapDir, r.From(), r.To()),
+				t.FileInfo(snapDir, epoch, r.From(), r.To()),
 				toMerge[t.Enum()],
 				snapDir,
 				doIndex,
@@ -389,6 +391,7 @@ func (m *Merger) merge(ctx context.Context, v *View, toMerge []*DirtySegment, ta
 	sn := &DirtySegment{
 		segType: targetFile.Type,
 		version: targetFile.Version,
+		epoch:   targetFile.Epoch,
 		Range:   Range{targetFile.From, targetFile.To},
 		frozen:  m.snCfg.IsFrozen(targetFile),
 	}

--- a/db/snapshotsync/merger.go
+++ b/db/snapshotsync/merger.go
@@ -55,6 +55,9 @@ func (m *Merger) FindMergeRanges(currentRanges []Range, maxBlockNum uint64) (toM
 				break
 			}
 			aggFrom := r.To() - span
+			if !rangesCover(currentRanges, aggFrom, r.To()) {
+				break // reaches below our lowest segment; pruning deleted those blocks
+			}
 			toMerge = append(toMerge, NewRange(aggFrom, r.To()))
 			for i >= 0 && currentRanges[i].From() > aggFrom {
 				i--
@@ -64,6 +67,29 @@ func (m *Merger) FindMergeRanges(currentRanges []Range, maxBlockNum uint64) (toM
 	}
 	slices.SortFunc(toMerge, func(i, j Range) int { return cmp.Compare(i.From(), j.From()) })
 	return toMerge
+}
+
+// rangesCover says whether ranges (sorted, non-overlapping) cover all of [from,to) with no hole.
+//
+// The ladder picks what to merge by subtracting a tier size from the top of an existing range, so it
+// can ask for a range starting below the lowest segment we still have. That happens on a pruned node,
+// where the oldest transactions were deleted. Merging it anyway would write a file whose name claims
+// blocks it does not contain, and nothing downstream would notice.
+func rangesCover(ranges []Range, from, to uint64) bool {
+	at := from
+	for _, r := range ranges {
+		if r.To() <= at {
+			continue
+		}
+		if r.From() > at {
+			return false
+		}
+		at = r.To()
+		if at >= to {
+			return true
+		}
+	}
+	return at >= to
 }
 
 func (m *Merger) filesByRange(v *View, from, to uint64) (map[snaptype.Enum][]*DirtySegment, error) {

--- a/db/snapshotsync/snapshots.go
+++ b/db/snapshotsync/snapshots.go
@@ -147,9 +147,13 @@ func findOverlaps[T SortedRange](in []T) (res []T, overlapped []T) {
 	return res, overlapped
 }
 
-func CanRetire(from, to uint64, snapType snaptype.Enum, snCfg *snapcfg.Cfg, retireStep uint64) (blockFrom, blockTo uint64, can bool) {
+func CanRetire(epoch bool, from, to uint64, snapType snaptype.Enum, snCfg *snapcfg.Cfg, retireStep uint64) (blockFrom, blockTo uint64, can bool) {
 	if to <= from {
 		return
+	}
+	// The epoch ladder is 1024 -> 8192 -> 65536 -> 524288; retireStep can lower only its smallest tier.
+	if epoch {
+		return canRetireEpoch(from, to, epochMinSegmentSize(retireStep))
 	}
 	if retireStep == 0 {
 		retireStep = 1_000
@@ -157,7 +161,7 @@ func CanRetire(from, to uint64, snapType snaptype.Enum, snCfg *snapcfg.Cfg, reti
 	blockFrom = (from / retireStep) * retireStep
 	roundedToRetireStep := (to / retireStep) * retireStep
 	maxJump := retireStep
-	mergeLimit := snapcfg.MergeLimitFromCfg(snCfg, snapType, blockFrom)
+	mergeLimit := snapcfg.MergeLimitFromCfg(snCfg, snapType, epoch, blockFrom)
 	switch {
 	case blockFrom%mergeLimit == 0:
 		maxJump = mergeLimit
@@ -180,6 +184,49 @@ func CanRetire(from, to uint64, snapType snaptype.Enum, snCfg *snapcfg.Cfg, reti
 		blockTo = blockFrom
 	}
 	return blockFrom, blockTo, blockTo-blockFrom >= retireStep
+}
+
+// canRetireEpoch is CanRetire's epoch-rounded variant: the ladder is 1024 -> 8192 -> 65536
+// -> 524288 (era1-derived) instead of the decimal 1k/10k/100k/mergeLimit.
+// epochMinSegmentSize resolves the smallest epoch tier to produce. retireStep may lower it below the
+// 1024 default, but only to a power of two that still divides the 8192 era1 tier — a step that never
+// lines up with a merge span would strand its segments below the ladder forever.
+func epochMinSegmentSize(retireStep uint64) uint64 {
+	if retireStep == 0 || retireStep > snaptype.EpochMinSegmentSize || 8_192%retireStep != 0 ||
+		retireStep&(retireStep-1) != 0 {
+		return snaptype.EpochMinSegmentSize
+	}
+	return retireStep
+}
+
+func canRetireEpoch(from, to, minSize uint64) (blockFrom, blockTo uint64, can bool) {
+	blockFrom = (from / minSize) * minSize
+	roundedTo := (to / minSize) * minSize
+
+	var maxJump uint64 = minSize
+	switch {
+	case blockFrom%snaptype.EpochMergeLimit == 0:
+		maxJump = snaptype.EpochMergeLimit
+	case blockFrom%65_536 == 0:
+		maxJump = 65_536
+	case blockFrom%8_192 == 0:
+		maxJump = 8_192
+	}
+
+	jump := min(maxJump, roundedTo-blockFrom)
+	switch { // only next segment sizes are allowed
+	case jump >= snaptype.EpochMergeLimit:
+		blockTo = blockFrom + snaptype.EpochMergeLimit
+	case jump >= 65_536:
+		blockTo = blockFrom + 65_536
+	case jump >= 8_192:
+		blockTo = blockFrom + 8_192
+	case jump >= minSize:
+		blockTo = blockFrom + minSize
+	default:
+		blockTo = blockFrom
+	}
+	return blockFrom, blockTo, blockTo-blockFrom >= minSize
 }
 
 type Range struct {
@@ -205,16 +252,18 @@ type DirtySegment struct {
 	indexes []*recsplit.Index
 	segType snaptype.Type
 	version snaptype.Version
+	epoch   bool // era1-aligned ("ep"-marked, block/1024) vs decimal (block/1000)
 
 	frozen bool
 
 	canDelete atomic.Bool
 }
 
-func NewDirtySegment(segType snaptype.Type, version snaptype.Version, from uint64, to uint64, frozen bool) *DirtySegment {
+func NewDirtySegment(segType snaptype.Type, version snaptype.Version, epoch bool, from uint64, to uint64, frozen bool) *DirtySegment {
 	return &DirtySegment{
 		segType: segType,
 		version: version,
+		epoch:   epoch,
 		Range:   Range{from, to},
 		frozen:  frozen,
 	}
@@ -303,7 +352,7 @@ func (s *DirtySegment) FileName() string {
 	if s.Decompressor != nil {
 		return s.Decompressor.FileName()
 	}
-	return s.Type().FileName(s.version, s.from, s.to)
+	return s.Type().FileName(s.version, s.epoch, s.from, s.to)
 }
 
 func (s *DirtySegment) FilePaths(basePath string) (relativePaths []string) {
@@ -327,7 +376,7 @@ func (s *DirtySegment) FilePaths(basePath string) (relativePaths []string) {
 }
 
 func (s *DirtySegment) FileInfo(dir string) snaptype.FileInfo {
-	return s.Type().FileInfoByMask(dir, s.from, s.to)
+	return s.Type().FileInfoByMask(dir, s.epoch, s.from, s.to)
 }
 
 func (s *DirtySegment) GetRange() (from, to uint64) { return s.from, s.to }
@@ -391,7 +440,7 @@ func (s *DirtySegment) closeAndRemoveFiles() {
 }
 
 func (s *DirtySegment) OpenIdxIfNeed(dir string, optimistic bool, dirEntries []string) (err error) {
-	if len(s.Type().IdxFileNames(s.from, s.to)) == 0 {
+	if len(s.Type().IdxFileNames(s.epoch, s.from, s.to)) == 0 {
 		return nil
 	}
 
@@ -420,7 +469,7 @@ func (s *DirtySegment) openIdx(dir string, dirEntries []string) (err error) {
 		s.indexes = append(s.indexes, nil)
 	}
 
-	for i, fileName := range s.Type().IdxFileNames(s.from, s.to) {
+	for i, fileName := range s.Type().IdxFileNames(s.epoch, s.from, s.to) {
 		if s.indexes[i] != nil {
 			continue
 		}
@@ -1222,7 +1271,7 @@ func (s *BaseRoSnapshots) openSegments(fileNames []string, open bool, optimistic
 
 		sn, exists := FindOpenSegment(segtype, fName)
 		if !exists {
-			sn = &DirtySegment{segType: f.Type, version: f.Version, Range: Range{f.From, f.To}, frozen: s.snCfg.IsFrozen(f)}
+			sn = &DirtySegment{segType: f.Type, version: f.Version, epoch: f.Epoch, Range: Range{f.From, f.To}, frozen: s.snCfg.IsFrozen(f)}
 		}
 
 		if open {
@@ -1546,7 +1595,7 @@ func isIndexedOnDisk(dirPath string, f snaptype.FileInfo) bool {
 	if f.Type == nil {
 		return false
 	}
-	for _, name := range f.Type.IdxFileNames(f.From, f.To) {
+	for _, name := range f.Type.IdxFileNames(f.Epoch, f.From, f.To) {
 		ok, err := dir.FileExist(filepath.Join(dirPath, name))
 		if err != nil || !ok {
 			return false

--- a/db/snapshotsync/snapshots_race_test.go
+++ b/db/snapshotsync/snapshots_race_test.go
@@ -64,7 +64,7 @@ func TestRemoveOverlapsDefersUnlinkWhileViewOpen(t *testing.T) {
 	defer s.Close()
 	require.NoError(s.OpenFolder())
 
-	subPath := filepath.Join(dir, snaptype.SegmentFileName(version.V1_0, 0, 1_000, snaptype2.Headers.Enum()))
+	subPath := filepath.Join(dir, snaptype.SegmentFileName(version.V1_0, false, 0, 1_000, snaptype2.Headers.Enum()))
 	_, err := os.Stat(subPath)
 	require.NoError(err, "sub-segment must exist before RemoveOverlaps")
 
@@ -121,13 +121,13 @@ func TestOpenFolderReclaimKeepsRecreatedFile(t *testing.T) {
 	// An external actor removes the [0,1000) files; OpenFolder retires them close-only
 	// (they are already gone from disk), then the same files are recreated before v drains.
 	for _, snT := range snaptype2.BlockSnapshotTypes {
-		require.NoError(dir.RemoveFile(filepath.Join(tmpDir, snaptype.SegmentFileName(version.V1_0, 0, 1_000, snT.Enum()))))
+		require.NoError(dir.RemoveFile(filepath.Join(tmpDir, snaptype.SegmentFileName(version.V1_0, false, 0, 1_000, snT.Enum()))))
 	}
 	require.NoError(s.OpenFolder())
 	for _, snT := range snaptype2.BlockSnapshotTypes {
 		createTestSegmentFile(t, 0, 1_000, snT.Enum(), tmpDir, version.V1_0, logger)
 	}
-	headersPath := filepath.Join(tmpDir, snaptype.SegmentFileName(version.V1_0, 0, 1_000, snaptype2.Headers.Enum()))
+	headersPath := filepath.Join(tmpDir, snaptype.SegmentFileName(version.V1_0, false, 0, 1_000, snaptype2.Headers.Enum()))
 
 	v.Close() // drains the pinning generation -> reclaims the retired segments (close-only)
 	vClosed = true
@@ -186,7 +186,7 @@ func TestRemoveOverlapsProtectsPendingRetired(t *testing.T) {
 	s.recalcVisibleFiles(s.alignMin, subs) // retire subs to the current generation
 	s.dirtyLock.Unlock()
 
-	subPath := filepath.Join(dir, snaptype.SegmentFileName(version.V1_0, 0, 1_000, snaptype2.Headers.Enum()))
+	subPath := filepath.Join(dir, snaptype.SegmentFileName(version.V1_0, false, 0, 1_000, snaptype2.Headers.Enum()))
 	_, err := os.Stat(subPath)
 	require.NoError(err, "retired sub must still be on disk while a reader pins it")
 
@@ -225,7 +225,7 @@ func TestReadersRaceRetire(t *testing.T) {
 	for from := uint64(0); from < 10_000; from += 1_000 {
 		for i, snT := range snaptype2.BlockSnapshotTypes {
 			createTestSegmentFile(t, from, from+1_000, snT.Enum(), dir, verOf(i), logger)
-			subNames = append(subNames, snaptype.SegmentFileName(verOf(i), from, from+1_000, snT.Enum()))
+			subNames = append(subNames, snaptype.SegmentFileName(verOf(i), false, from, from+1_000, snT.Enum()))
 		}
 	}
 	for i, snT := range snaptype2.BlockSnapshotTypes {

--- a/db/snapshotsync/snapshots_test.go
+++ b/db/snapshotsync/snapshots_test.go
@@ -50,7 +50,7 @@ import (
 func createTestSegmentFile(t *testing.T, from, to uint64, name snaptype.Enum, dir string, ver snaptype.Version, logger log.Logger) {
 	compressCfg := seg.DefaultCfg
 	compressCfg.MinPatternScore = 100
-	c, err := seg.NewCompressor(t.Context(), "test", filepath.Join(dir, snaptype.SegmentFileName(ver, from, to, name)), dir, compressCfg, log.LvlDebug, logger)
+	c, err := seg.NewCompressor(t.Context(), "test", filepath.Join(dir, snaptype.SegmentFileName(ver, false, from, to, name)), dir, compressCfg, log.LvlDebug, logger)
 	require.NoError(t, err)
 	defer c.Close()
 	c.DisableFsync()
@@ -62,7 +62,7 @@ func createTestSegmentFile(t *testing.T, from, to uint64, name snaptype.Enum, di
 		KeyCount:   1,
 		BucketSize: 10,
 		TmpDir:     dir,
-		IndexFile:  filepath.Join(dir, snaptype.IdxFileName(ver, from, to, name.String())),
+		IndexFile:  filepath.Join(dir, snaptype.IdxFileName(ver, false, from, to, name.String())),
 		LeafSize:   8,
 	}, logger)
 	require.NoError(t, err)
@@ -77,7 +77,7 @@ func createTestSegmentFile(t *testing.T, from, to uint64, name snaptype.Enum, di
 			KeyCount:   1,
 			BucketSize: 10,
 			TmpDir:     dir,
-			IndexFile:  filepath.Join(dir, snaptype.IdxFileName(ver, from, to, snaptype2.Indexes.TxnHash2BlockNum.Name)),
+			IndexFile:  filepath.Join(dir, snaptype.IdxFileName(ver, false, from, to, snaptype2.Indexes.TxnHash2BlockNum.Name)),
 			LeafSize:   8,
 		}, logger)
 		require.NoError(t, err)
@@ -92,7 +92,7 @@ func createTestSegmentFile(t *testing.T, from, to uint64, name snaptype.Enum, di
 func createTestSegmentOnlyFile(t *testing.T, from, to uint64, name snaptype.Enum, dir string, ver snaptype.Version, logger log.Logger) {
 	compressCfg := seg.DefaultCfg
 	compressCfg.MinPatternScore = 100
-	c, err := seg.NewCompressor(t.Context(), "test", filepath.Join(dir, snaptype.SegmentFileName(ver, from, to, name)), dir, compressCfg, log.LvlDebug, logger)
+	c, err := seg.NewCompressor(t.Context(), "test", filepath.Join(dir, snaptype.SegmentFileName(ver, false, from, to, name)), dir, compressCfg, log.LvlDebug, logger)
 	require.NoError(t, err)
 	defer c.Close()
 	c.DisableFsync()
@@ -101,7 +101,8 @@ func createTestSegmentOnlyFile(t *testing.T, from, to uint64, name snaptype.Enum
 }
 
 func TestFindMergeRange(t *testing.T) {
-	merger := NewMerger("x", 1, log.LvlInfo, nil, chainspec.Mainnet.Config, nil)
+	merger := NewMerger("x", 1, log.LvlInfo, nil, chainspec.Gnosis.Config, nil)
+	merger.snCfg = snapcfg.KnownCfgOrDevnet(networkname.Mainnet)
 	merger.DisableFsync()
 	t.Run("big", func(t *testing.T) {
 		var RangesOld []Range
@@ -186,7 +187,8 @@ func TestMergeSnapshots(t *testing.T) {
 	defer s.Close()
 	require.NoError(s.OpenFolder())
 	{
-		merger := NewMerger(dir, 1, log.LvlInfo, nil, chainspec.Mainnet.Config, logger)
+		merger := NewMerger(dir, 1, log.LvlInfo, nil, chainspec.Gnosis.Config, logger)
+		merger.snCfg = snapcfg.KnownCfgOrDevnet(networkname.Mainnet) // decimal chain, mainnet's 500k ladder
 		merger.DisableFsync()
 		require.NoError(s.OpenSegments(snaptype2.BlockSnapshotTypes, true))
 		Ranges := merger.FindMergeRanges(s.Ranges(false), s.SegmentsMax())
@@ -200,7 +202,7 @@ func TestMergeSnapshots(t *testing.T) {
 		require.NoError(err)
 	}
 
-	expectedFileName := snaptype.SegmentFileName(snaptype2.Transactions.Versions().Current, 0, 500_000, snaptype2.Transactions.Enum())
+	expectedFileName := snaptype.SegmentFileName(snaptype2.Transactions.Versions().Current, false, 0, 500_000, snaptype2.Transactions.Enum())
 	d, err := seg.NewDecompressor(filepath.Join(dir, expectedFileName))
 	require.NoError(err)
 	defer d.Close()
@@ -208,7 +210,8 @@ func TestMergeSnapshots(t *testing.T) {
 	require.Equal(50, a)
 
 	{
-		merger := NewMerger(dir, 1, log.LvlInfo, nil, chainspec.Mainnet.Config, logger)
+		merger := NewMerger(dir, 1, log.LvlInfo, nil, chainspec.Gnosis.Config, logger)
+		merger.snCfg = snapcfg.KnownCfgOrDevnet(networkname.Mainnet) // decimal chain, mainnet's 500k ladder
 		merger.DisableFsync()
 		s.OpenFolder()
 		Ranges := merger.FindMergeRanges(s.Ranges(false), s.SegmentsMax())
@@ -220,7 +223,7 @@ func TestMergeSnapshots(t *testing.T) {
 
 	// [0; N] merges are not supported anymore
 
-	// expectedFileName = snaptype.SegmentFileName(snaptype2.Transactions.Versions().Current, 600_000, 700_000, snaptype2.Transactions.Enum())
+	// expectedFileName = snaptype.SegmentFileName(snaptype2.Transactions.Versions().Current, false, 600_000, 700_000, snaptype2.Transactions.Enum())
 	// d, err = seg.NewDecompressor(filepath.Join(dir, expectedFileName))
 	// require.NoError(err)
 	// defer d.Close()
@@ -245,7 +248,7 @@ func TestMergeSnapshots(t *testing.T) {
 	// 	require.NoError(err)
 	// }
 
-	// expectedFileName = snaptype.SegmentFileName(snaptype2.Transactions.Versions().Current, start+100_000, start+200_000, snaptype2.Transactions.Enum())
+	// expectedFileName = snaptype.SegmentFileName(snaptype2.Transactions.Versions().Current, false, start+100_000, start+200_000, snaptype2.Transactions.Enum())
 	// d, err = seg.NewDecompressor(filepath.Join(dir, expectedFileName))
 	// require.NoError(err)
 	// defer d.Close()
@@ -262,7 +265,7 @@ func TestMergeSnapshots(t *testing.T) {
 	// 	require.NoError(err)
 	// }
 
-	// expectedFileName = snaptype.SegmentFileName(snaptype2.Transactions.Versions().Current, start+600_000, start+700_000, snaptype2.Transactions.Enum())
+	// expectedFileName = snaptype.SegmentFileName(snaptype2.Transactions.Versions().Current, false, start+600_000, start+700_000, snaptype2.Transactions.Enum())
 	// d, err = seg.NewDecompressor(filepath.Join(dir, expectedFileName))
 	// require.NoError(err)
 	// defer d.Close()
@@ -287,11 +290,12 @@ func TestMergeSkipsPreClaimedRange(t *testing.T) {
 	claimed, free := NewRange(0, 20_000), NewRange(20_000, 40_000)
 	require.True(s.TryAcquireRange(snaptype2.Transactions.Enum(), claimed.From(), claimed.To()))
 
-	merger := NewMerger(dir, 1, log.LvlInfo, nil, chainspec.Mainnet.Config, logger)
+	merger := NewMerger(dir, 1, log.LvlInfo, nil, chainspec.Gnosis.Config, logger)
+	merger.snCfg = snapcfg.KnownCfgOrDevnet(networkname.Mainnet) // decimal chain, mainnet's 500k ladder
 	merger.DisableFsync()
 	require.NoError(merger.Merge(t.Context(), s, snaptype2.BlockSnapshotTypes, []Range{claimed, free}, s.Dir(), false, nil, nil))
 
-	skippedFile := filepath.Join(dir, snaptype.SegmentFileName(snaptype2.Transactions.Versions().Current, claimed.From(), claimed.To(), snaptype2.Transactions.Enum()))
+	skippedFile := filepath.Join(dir, snaptype.SegmentFileName(snaptype2.Transactions.Versions().Current, false, claimed.From(), claimed.To(), snaptype2.Transactions.Enum()))
 	exists, err := dir2.FileExist(skippedFile)
 	require.NoError(err)
 	require.False(exists)
@@ -300,7 +304,7 @@ func TestMergeSkipsPreClaimedRange(t *testing.T) {
 	s.ReleaseRange(snaptype2.Headers.Enum(), claimed.From(), claimed.To())
 
 	for _, snT := range snaptype2.BlockSnapshotTypes {
-		mergedFile := filepath.Join(dir, snaptype.SegmentFileName(snT.Versions().Current, free.From(), free.To(), snT.Enum()))
+		mergedFile := filepath.Join(dir, snaptype.SegmentFileName(snT.Versions().Current, false, free.From(), free.To(), snT.Enum()))
 		exists, err := dir2.FileExist(mergedFile)
 		require.NoError(err)
 		require.True(exists)
@@ -354,7 +358,7 @@ func TestRetireFilesIsIdempotent(t *testing.T) {
 	defer s.Close()
 	require.NoError(s.OpenFolder())
 
-	fileName := snaptype.SegmentFileName(version.V1_0, 0, 10_000, snaptype2.Bodies.Enum())
+	fileName := snaptype.SegmentFileName(version.V1_0, false, 0, 10_000, snaptype2.Bodies.Enum())
 
 	require.NoError(s.retireFiles(mvcc.RetireReasonAged, fileName))
 	require.False(slices.Contains(s.Files(), fileName))
@@ -395,7 +399,7 @@ func TestRetireFilesDetachesFromDirty(t *testing.T) {
 	require.Equal(2, s.dirty[txEnum].Len())
 	require.True(visibleHas(s, txEnum, 0, 10_000))
 
-	require.NoError(s.retireFiles(mvcc.RetireReasonAged, snaptype.SegmentFileName(version.V1_0, 0, 10_000, txEnum)))
+	require.NoError(s.retireFiles(mvcc.RetireReasonAged, snaptype.SegmentFileName(version.V1_0, false, 0, 10_000, txEnum)))
 
 	// Detached from dirty, not just hidden...
 	require.Equal(1, s.dirty[txEnum].Len())
@@ -529,9 +533,9 @@ func TestRetireFilesAbove(t *testing.T) {
 	require.False(visibleHas(s, txEnum, 10_000, 20_000))
 	require.False(visibleHas(s, txEnum, 20_000, 30_000))
 
-	require.Contains(deleted, snaptype.SegmentFileName(version.V1_0, 10_000, 20_000, txEnum), "seeder told about removed files")
-	require.Contains(deleted, snaptype.SegmentFileName(version.V1_0, 20_000, 30_000, txEnum))
-	require.NotContains(deleted, snaptype.SegmentFileName(version.V1_0, 0, 10_000, txEnum))
+	require.Contains(deleted, snaptype.SegmentFileName(version.V1_0, false, 10_000, 20_000, txEnum), "seeder told about removed files")
+	require.Contains(deleted, snaptype.SegmentFileName(version.V1_0, false, 20_000, 30_000, txEnum))
+	require.NotContains(deleted, snaptype.SegmentFileName(version.V1_0, false, 0, 10_000, txEnum))
 }
 
 func TestRemoveOverlaps(t *testing.T) {
@@ -678,10 +682,10 @@ func TestCanRetire(t *testing.T) {
 	}
 	snCfg := snapcfg.KnownCfgOrDevnet(networkname.Mainnet)
 	for i, tc := range cases {
-		from, to, can := CanRetire(tc.inFrom, tc.inTo, snaptype.Unknown, snCfg, tc.retireStep)
+		from, to, can := CanRetire(false, tc.inFrom, tc.inTo, snaptype.Unknown, snCfg, tc.retireStep)
 		require.Equal(t, tc.outFrom, from, i)
 		require.Equal(t, tc.outTo, to, i)
-		require.Equal(t, tc.can, can, "CanRetire(%d, %d) case %d", tc.inFrom, tc.inTo, i)
+		require.Equal(t, tc.can, can, "CanRetire(false, %d, %d) case %d", tc.inFrom, tc.inTo, i)
 	}
 }
 
@@ -1036,7 +1040,7 @@ func TestCalculateVisibleSegmentsWhenGapsInIdx(t *testing.T) {
 		createFile(i*500_000, (i+1)*500_000, snaptype2.Transactions)
 	}
 
-	missingIdxFile := filepath.Join(dir, snaptype.IdxFileName(version.V1_0, 500_000, 1_000_000, snaptype2.Headers.Name()))
+	missingIdxFile := filepath.Join(dir, snaptype.IdxFileName(version.V1_0, false, 500_000, 1_000_000, snaptype2.Headers.Name()))
 	err := dir2.RemoveFile(missingIdxFile)
 	require.NoError(err)
 
@@ -1078,7 +1082,7 @@ func TestSegmentsMaxDerivedFromVisible(t *testing.T) {
 	// segmentsMax because it was set from dirty files in openSegments.
 	// Now it must not, because it never becomes visible.
 	createFile(1_500_000, 2_000_000, snaptype2.Headers)
-	missingIdx := filepath.Join(dir, snaptype.IdxFileName(version.V1_0, 1_500_000, 2_000_000, snaptype2.Headers.Name()))
+	missingIdx := filepath.Join(dir, snaptype.IdxFileName(version.V1_0, false, 1_500_000, 2_000_000, snaptype2.Headers.Name()))
 	require.NoError(dir2.RemoveFile(missingIdx))
 
 	require.NoError(s.OpenFolder())
@@ -1165,7 +1169,7 @@ func TestRetireVsLiveViewDoesNotCrash(t *testing.T) {
 	var subNames []string
 	for from := uint64(0); from < 10_000; from += 1_000 {
 		for i, snT := range snaptype2.BlockSnapshotTypes {
-			subNames = append(subNames, snaptype.SegmentFileName(verOf(i), from, from+1_000, snT.Enum()))
+			subNames = append(subNames, snaptype.SegmentFileName(verOf(i), false, from, from+1_000, snT.Enum()))
 		}
 	}
 	require.NoError(s.retireFiles(mvcc.RetireReasonAged, subNames...))
@@ -1184,7 +1188,7 @@ func createTestIdxFile(t *testing.T, from, to uint64, name snaptype.Enum, dir st
 		KeyCount:   1,
 		BucketSize: 10,
 		TmpDir:     dir,
-		IndexFile:  filepath.Join(dir, snaptype.IdxFileName(ver, from, to, name.String())),
+		IndexFile:  filepath.Join(dir, snaptype.IdxFileName(ver, false, from, to, name.String())),
 		LeafSize:   8,
 	}, logger)
 	require.NoError(t, err)
@@ -1199,7 +1203,7 @@ func createTestIdxFile(t *testing.T, from, to uint64, name snaptype.Enum, dir st
 			KeyCount:   1,
 			BucketSize: 10,
 			TmpDir:     dir,
-			IndexFile:  filepath.Join(dir, snaptype.IdxFileName(ver, from, to, snaptype2.Indexes.TxnHash2BlockNum.Name)),
+			IndexFile:  filepath.Join(dir, snaptype.IdxFileName(ver, false, from, to, snaptype2.Indexes.TxnHash2BlockNum.Name)),
 			LeafSize:   8,
 		}, logger)
 		require.NoError(t, err)
@@ -1393,7 +1397,7 @@ func TestDirtySegmentsMaxCountsUnindexedTail(t *testing.T) {
 	for i := range uint64(3) {
 		createTestSegmentFile(t, i*10_000, (i+1)*10_000, snaptype2.Enums.Headers, dir, version.V1_0, logger)
 	}
-	missingIdx := filepath.Join(dir, snaptype.IdxFileName(version.V1_0, 20_000, 30_000, snaptype2.Headers.Name()))
+	missingIdx := filepath.Join(dir, snaptype.IdxFileName(version.V1_0, false, 20_000, 30_000, snaptype2.Headers.Name()))
 	require.NoError(dir2.RemoveFile(missingIdx))
 	require.NoError(s.OpenFolder())
 
@@ -1417,7 +1421,7 @@ func TestDirtySegmentsMaxFollowsRetire(t *testing.T) {
 	require.NoError(s.OpenFolder())
 	require.Equal(uint64(30_000-1), s.DirtySegmentsMax(snaptype2.Enums.Headers))
 
-	tail := snaptype.SegmentFileName(version.V1_0, 20_000, 30_000, snaptype2.Enums.Headers)
+	tail := snaptype.SegmentFileName(version.V1_0, false, 20_000, 30_000, snaptype2.Enums.Headers)
 	require.NoError(s.retireFiles(mvcc.RetireReasonMerged, tail))
 	require.Equal(uint64(20_000-1), s.DirtySegmentsMax(snaptype2.Enums.Headers))
 }
@@ -1435,7 +1439,7 @@ func TestWalkDirtySegments(t *testing.T) {
 	for i := range uint64(3) {
 		createTestSegmentFile(t, i*10_000, (i+1)*10_000, snaptype2.Enums.Headers, dir, version.V1_0, logger)
 	}
-	missingIdx := filepath.Join(dir, snaptype.IdxFileName(version.V1_0, 20_000, 30_000, snaptype2.Headers.Name()))
+	missingIdx := filepath.Join(dir, snaptype.IdxFileName(version.V1_0, false, 20_000, 30_000, snaptype2.Headers.Name()))
 	require.NoError(dir2.RemoveFile(missingIdx))
 	require.NoError(s.OpenFolder())
 
@@ -1470,7 +1474,7 @@ func TestOpenListOpensOnlyNamedFiles(t *testing.T) {
 		createTestSegmentFile(t, i*10_000, (i+1)*10_000, snaptype2.Enums.Headers, dir, version.V1_0, logger)
 	}
 	name := func(i uint64) string {
-		return snaptype.SegmentFileName(version.V1_0, i*10_000, (i+1)*10_000, snaptype2.Enums.Headers)
+		return snaptype.SegmentFileName(version.V1_0, false, i*10_000, (i+1)*10_000, snaptype2.Enums.Headers)
 	}
 
 	cfg := ethconfig.BlocksFreezing{ChainName: networkname.Mainnet}
@@ -1550,7 +1554,7 @@ func TestOpenListToleratesDuplicateNames(t *testing.T) {
 	logger := log.New()
 	dir, require := t.TempDir(), require.New(t)
 	createTestSegmentFile(t, 0, 10_000, snaptype2.Enums.Headers, dir, version.V1_0, logger)
-	name := snaptype.SegmentFileName(version.V1_0, 0, 10_000, snaptype2.Enums.Headers)
+	name := snaptype.SegmentFileName(version.V1_0, false, 0, 10_000, snaptype2.Enums.Headers)
 
 	cfg := ethconfig.BlocksFreezing{ChainName: networkname.Mainnet}
 	s := NewBaseRoSnapshots(cfg, dir, []snaptype.Type{snaptype2.Headers}, snaptype2.Headers, false, logger)
@@ -1581,4 +1585,99 @@ func TestViewSegmentsOfUnmanagedType(t *testing.T) {
 		_, ok := v.Segment(snaptype.BeaconBlocks, 0)
 		require.False(ok)
 	})
+}
+
+// The epoch ladder is 1024 -> 8192 -> 65536 -> 524288, and CanRetire only ever yields one of those
+// aligned tiers, never a partial one.
+func TestCanRetireEpoch(t *testing.T) {
+	require := require.New(t)
+
+	cases := []struct {
+		inFrom, inTo, outFrom, outTo uint64
+		can                          bool
+	}{
+		{0, 524_288, 0, 524_288, true},       // full top-tier segment
+		{0, 100_000, 0, 65_536, true},        // largest aligned tier that fits
+		{0, 10_000, 0, 8_192, true},          // one era1 file
+		{8_192, 20_000, 8_192, 16_384, true}, // from aligned to 8192 only
+		{0, 500, 0, 0, false},                // below the 1024 min tier
+	}
+	snCfg := snapcfg.KnownCfgOrDevnet(networkname.Mainnet)
+	for i, tc := range cases {
+		from, to, can := CanRetire(true, tc.inFrom, tc.inTo, snaptype.Unknown, snCfg, 0)
+		require.Equal(int(tc.outFrom), int(from), i)
+		require.Equal(int(tc.outTo), int(to), i)
+		require.Equal(tc.can, can, i)
+	}
+}
+
+// Each epoch tier merges into the next one up, and a run of full top-tier segments is frozen.
+func TestFindMergeRangeEpoch(t *testing.T) {
+	merger := NewMerger("x", 1, log.LvlInfo, nil, chainspec.Mainnet.Config, nil)
+	merger.DisableFsync()
+
+	tiers := []struct{ size, next uint64 }{
+		{1_024, 8_192},
+		{8_192, 65_536},
+		{65_536, 524_288},
+	}
+	for _, tr := range tiers {
+		var r Ranges
+		for i := uint64(0); i < tr.next/tr.size; i++ {
+			r = append(r, NewRange(i*tr.size, (i+1)*tr.size))
+		}
+		found := merger.FindMergeRanges(r, tr.next)
+		require.Equal(t, Ranges{NewRange(0, tr.next)}.String(), Ranges(found).String(), "size %d -> %d", tr.size, tr.next)
+	}
+
+	var r Ranges
+	for i := range uint64(8) {
+		r = append(r, NewRange(i*524_288, (i+1)*524_288))
+	}
+	require.Empty(t, merger.FindMergeRanges(r, 8*524_288))
+}
+
+// The regime is a property of the chain, so the same ranges merge on the decimal ladder for a
+// Gnosis merger and on the epoch ladder for a mainnet one.
+func TestFindMergeRangeBorNotEpoch(t *testing.T) {
+	decimalMerger := NewMerger("x", 1, log.LvlInfo, nil, chainspec.Gnosis.Config, nil)
+	decimalMerger.DisableFsync()
+	epochMerger := NewMerger("x", 1, log.LvlInfo, nil, chainspec.Mainnet.Config, nil)
+	epochMerger.DisableFsync()
+
+	var decimal Ranges
+	for i := range uint64(10) {
+		decimal = append(decimal, NewRange(i*10_000, (i+1)*10_000))
+	}
+	require.Equal(t, Ranges{NewRange(0, 100_000)}.String(),
+		Ranges(decimalMerger.FindMergeRanges(decimal, 100_000)).String())
+	// same input on the epoch chain does NOT merge (100k not 2^k-aligned)
+	require.Empty(t, epochMerger.FindMergeRanges(decimal, 100_000))
+
+	var epoch Ranges
+	for i := range uint64(8) {
+		epoch = append(epoch, NewRange(i*8_192, (i+1)*8_192))
+	}
+	require.Equal(t, Ranges{NewRange(0, 65_536)}.String(),
+		Ranges(epochMerger.FindMergeRanges(epoch, 65_536)).String())
+}
+
+func TestCanRetireEpochStep(t *testing.T) {
+	snCfg := snapcfg.KnownCfgOrDevnet(networkname.Mainnet)
+
+	from, to, can := CanRetire(true, 1, 9, snaptype.Unknown, snCfg, 8)
+	require.True(t, can)
+	require.Equal(t, uint64(0), from)
+	require.Equal(t, uint64(8), to)
+
+	_, _, can = CanRetire(true, 1, 9, snaptype.Unknown, snCfg, 10)
+	require.False(t, can, "a step that does not divide 8192 must fall back to the 1024 floor")
+
+	_, _, can = CanRetire(true, 1, 9, snaptype.Unknown, snCfg, 0)
+	require.False(t, can, "no step means the 1024 floor")
+
+	from, to, can = CanRetire(true, 1, 20_000, snaptype.Unknown, snCfg, 8)
+	require.True(t, can)
+	require.Equal(t, uint64(0), from)
+	require.Equal(t, uint64(8_192), to)
 }

--- a/db/snapshotsync/snapshots_test.go
+++ b/db/snapshotsync/snapshots_test.go
@@ -1747,3 +1747,20 @@ func TestFindMergeRangeSkipsUncoveredLowerHalf(t *testing.T) {
 	require.Empty(t, merger.FindMergeRanges(r, 3_203_072),
 		"the 8192 tier below 3_203_072 reaches under the pruned frontier")
 }
+
+// The other side of that condition. When the pruned type resumes on a 524288 boundary, every merge
+// the ladder can ask for starts at or above it, so the coverage check must not get in the way.
+func TestFindMergeRangeAllowsAlignedPrunedStart(t *testing.T) {
+	merger := NewMerger("x", 1, log.LvlInfo, nil, chainspec.Mainnet.Config, nil)
+	merger.DisableFsync()
+
+	const start = 6 * 524_288 // 3_145_728
+	var r Ranges
+	for from := uint64(start); from < 7*524_288; from += 65_536 {
+		r = append(r, NewRange(from, from+65_536))
+	}
+
+	require.Equal(t, Ranges{NewRange(start, 7*524_288)}.String(),
+		Ranges(merger.FindMergeRanges(r, 7*524_288)).String(),
+		"nothing is missing below the start, so the tier merges")
+}

--- a/db/snapshotsync/snapshots_test.go
+++ b/db/snapshotsync/snapshots_test.go
@@ -1681,3 +1681,69 @@ func TestCanRetireEpochStep(t *testing.T) {
 	require.Equal(t, uint64(0), from)
 	require.Equal(t, uint64(8_192), to)
 }
+
+// A node that downloaded its lower segments starts producing again at the end of the last one. How
+// big a segment it may cut there depends on what that block is aligned to.
+func TestCanRetireEpochSeam(t *testing.T) {
+	require := require.New(t)
+	snCfg := snapcfg.KnownCfgOrDevnet(networkname.Mainnet)
+
+	cases := []struct {
+		name                         string
+		inFrom, inTo, outFrom, outTo uint64
+	}{
+		{"8192-aligned boundary jumps one era1 file", 598_016, 610_000, 598_016, 606_208},
+		{"65536-aligned boundary jumps a whole tier", 589_824, 700_000, 589_824, 655_360},
+		{"only the 1024 floor fits", 598_016, 600_000, 598_016, 599_040},
+	}
+	for _, tc := range cases {
+		from, to, can := CanRetire(true, tc.inFrom, tc.inTo, snaptype.Unknown, snCfg, 0)
+		require.True(can, tc.name)
+		require.Equal(int(tc.outFrom), int(from), tc.name)
+		require.Equal(int(tc.outTo), int(to), tc.name)
+	}
+}
+
+// After a download the file list is one large segment followed by small ones just produced. Those
+// small ones merge among themselves; the large neighbour is already full and must be left alone.
+func TestFindMergeRangeEpochSeam(t *testing.T) {
+	merger := NewMerger("x", 1, log.LvlInfo, nil, chainspec.Mainnet.Config, nil)
+	merger.DisableFsync()
+
+	seam := func(produced uint64) Ranges {
+		r := Ranges{
+			NewRange(0, 524_288),
+			NewRange(524_288, 589_824),
+			NewRange(589_824, 598_016),
+		}
+		for i := range produced {
+			r = append(r, NewRange(598_016+i*1_024, 598_016+(i+1)*1_024))
+		}
+		return r
+	}
+
+	full := seam(8)
+	require.Equal(t, Ranges{NewRange(598_016, 606_208)}.String(),
+		Ranges(merger.FindMergeRanges(full, 606_208)).String())
+
+	require.Empty(t, merger.FindMergeRanges(seam(7), 605_184),
+		"an incomplete era1 file must not drag the downloaded neighbour into a merge")
+}
+
+// A pruned type starts above block 0 and between two cuts, so sooner or later the ladder asks for a
+// merge reaching below its first file. Doing it would write a file short of the range in its name.
+func TestFindMergeRangeSkipsUncoveredLowerHalf(t *testing.T) {
+	merger := NewMerger("x", 1, log.LvlInfo, nil, chainspec.Mainnet.Config, nil)
+	merger.DisableFsync()
+
+	// transactions pruned to 3_200_000; the first 8192-aligned boundary above it is 3_203_072, whose
+	// merge range would start at 3_194_880 — below anything on disk.
+	var r Ranges
+	for from := uint64(3_200_000); from < 3_203_072; from += 1_024 {
+		r = append(r, NewRange(from, from+1_024))
+	}
+	r = append(r, NewRange(3_202_048, 3_203_072))
+
+	require.Empty(t, merger.FindMergeRanges(r, 3_203_072),
+		"the 8192 tier below 3_203_072 reaches under the pruned frontier")
+}

--- a/db/snapshotsync/snapshotsync.go
+++ b/db/snapshotsync/snapshotsync.go
@@ -553,6 +553,10 @@ func SyncSnapshots(
 				continue
 			}
 
+			if snaptype.EpochRegimeMismatch(p.Name, snaptype2.RegimeFor(cc)) {
+				continue
+			}
+
 			downloadRequest = append(downloadRequest, dbservices.DownloadRequest{
 				Path:        p.Name,
 				TorrentHash: p.Hash,

--- a/db/snaptype/files.go
+++ b/db/snaptype/files.go
@@ -36,38 +36,77 @@ import (
 	"github.com/erigontech/erigon/db/version"
 )
 
-func FileName(version Version, from, to uint64, fileType string) string {
-	if to < from {
-		panic(fmt.Errorf("snap file name to < from: %d < %d", to, from))
+// EpochMarker flags an epoch (era1-aligned) block segment in its file name, as a suffix on the type:
+// v1.0-000000-000008-headers-ep.seg. The marker makes the regime self-describing and independent of
+// the (content) version; decimal files carry no marker. It goes last, not next to the version, so that
+// a lookup mask — whose version is a wildcard, since an index's version may differ from its segment's
+// — cannot match across regimes: the two regimes print the same digits for the same tier index
+// (decimal [1000,2000) and epoch [1024,2048) are both "000001-000002"), and a wildcard sitting where
+// the marker is would swallow it.
+const EpochMarker = "ep"
+
+// fileNameBase is the divisor a file name encodes block numbers with: epoch block segments print
+// block/1024, decimal ones (Bor/Gnosis block segments, and every non-block type) block/1000.
+func fileNameBase(epoch bool) uint64 {
+	if epoch {
+		return 1_024
 	}
-	if to-from < 1000 {
+	return 1_000
+}
+
+func markedType(fileType string, epoch bool) string {
+	if epoch {
+		return fileType + "-" + EpochMarker
+	}
+	return fileType
+}
+
+func fileName(version Version, epoch bool, from, to uint64, fileType string) string {
+	base, spellOut := nameEncoding(epoch, from, to)
+	fileType = markedType(fileType, epoch)
+	if spellOut {
 		return fmt.Sprintf("%s-%09d-%09d-%s", version.String(), from, to, fileType)
 	}
-	return fmt.Sprintf("%s-%06d-%06d-%s", version.String(), from/1_000, to/1_000, fileType)
+	return fmt.Sprintf("%s-%06d-%06d-%s", version.String(), from/base, to/base, fileType)
 }
 
-func FileMask(from, to uint64, fileType string) string {
+func fileMask(epoch bool, from, to uint64, fileType string) string {
+	base, spellOut := nameEncoding(epoch, from, to)
+	fileType = markedType(fileType, epoch)
+	if spellOut {
+		return fmt.Sprintf("*-%09d-%09d-%s", from, to, fileType)
+	}
+	return fmt.Sprintf("*-%06d-%06d-%s", from/base, to/base, fileType)
+}
+
+func nameEncoding(epoch bool, from, to uint64) (base uint64, spellOut bool) {
 	if to < from {
 		panic(fmt.Errorf("snap file name to < from: %d < %d", to, from))
 	}
-	if to-from < 1000 {
-		return fmt.Sprintf("*-%09d-%09d-%s", from, to, fileType)
-	}
-	return fmt.Sprintf("*-%06d-%06d-%s", from/1_000, to/1_000, fileType)
+	base = fileNameBase(epoch)
+	return base, to-from < base
 }
 
-func SegmentFileName(version Version, from, to uint64, t Enum) string {
-	return FileName(version, from, to, t.String()) + ".seg"
-}
-func IdxFileName(version Version, from, to uint64, fType string) string {
-	return FileName(version, from, to, fType) + ".idx"
+func FileName(version Version, epoch bool, from, to uint64, fileType string) string {
+	return fileName(version, epoch, from, to, fileType)
 }
 
-func SegmentFileMask(from, to uint64, t Enum) string {
-	return FileMask(from, to, t.String()) + ".seg"
+func FileMask(epoch bool, from, to uint64, fileType string) string {
+	return fileMask(epoch, from, to, fileType)
 }
-func IdxFileMask(from, to uint64, fType string) string {
-	return FileMask(from, to, fType) + ".idx"
+
+func SegmentFileName(version Version, epoch bool, from, to uint64, t Enum) string {
+	return fileName(version, epoch, from, to, t.String()) + ".seg"
+}
+func IdxFileName(version Version, epoch bool, from, to uint64, fType string) string {
+	return fileName(version, epoch, from, to, fType) + ".idx"
+}
+
+func SegmentFileMask(epoch bool, from, to uint64, t Enum) string {
+	return fileMask(epoch, from, to, t.String()) + ".seg"
+}
+func IdxFileMask(epoch bool, from, to uint64, fType string) string {
+	return fileMask(epoch, from, to, fType) + ".idx"
 }
 
 func FilterExt(in []FileInfo, expectExt string) (out []FileInfo) {
@@ -117,7 +156,7 @@ func FilesWithExt(dir string, expectExt string) ([]FileInfo, error) {
 
 func IsCorrectFileName(name string) bool {
 	parts := strings.Split(name, "-")
-	return len(parts) == 4
+	return len(parts) == 4 || len(parts) == 5
 }
 
 // check that filename w/o ext matches pattern: "<any>.<num>-<num>"
@@ -196,7 +235,13 @@ func ParseFileName(dir, fileName string) (res FileInfo, isE3Seedable bool, ok bo
 		if ok {
 			res.CaplinTypeString = res.Type.Name()
 		}
-	} else { // 1-2-bodies
+	} else { // 1-2-bodies  (or  1-2-bodies-ep for epoch)
+		// epoch (era1-aligned) block segments carry the "ep" marker as a type suffix; it makes the
+		// regime self-describing, independent of the version.
+		if trimmed, found := strings.CutSuffix(croppedFileName, "-"+EpochMarker); found {
+			res.Epoch = true
+			croppedFileName = trimmed
+		}
 		fromStr, rest, ok := strings.Cut(croppedFileName, "-")
 		if !ok || fromStr == "" {
 			return res, false, false
@@ -215,11 +260,11 @@ func ParseFileName(dir, fileName string) (res FileInfo, isE3Seedable bool, ok bo
 			return res, false, false
 		}
 		var multiplier uint64
-		switch len(fromStr) {
-		case 9: // smallest number in file name is < 1_000, so we represent it as it is
+		switch {
+		case len(fromStr) == 9: // range shorter than the regime's divisor, spelled out as it is
 			multiplier = 1
-		default: // smallest number in file name is > 1_000, so we represent it as /1000
-			multiplier = 1_000
+		default:
+			multiplier = fileNameBase(res.Epoch)
 		}
 		res.From, res.To, res.TypeString, res.CaplinTypeString = uint64(from)*multiplier, uint64(to)*multiplier, typeString, typeString
 		res.Type, ok = ParseFileType(typeString)
@@ -309,10 +354,50 @@ func IsSeedableExtension(name string) bool {
 //     less files - means small files will be removed after merge (no peers for this files).
 const Erigon2OldMergeLimit = 500_000
 const Erigon2MergeLimit = 100_000
+
+// EpochMergeLimit is the frozen (top-tier) size of epoch-rounded block segments: 64 era1
+// files of 8192 blocks each.
+const EpochMergeLimit = 524_288
 const CaplinMergeLimit = 10_000
 const Erigon2MinSegmentSize = 1_000
 
+// EpochMinSegmentSize is the produce/round-down granularity of epoch-rounded segments
+// (the smallest tier, 2^10), analogous to Erigon2MinSegmentSize for the decimal scheme.
+const EpochMinSegmentSize = 1_024
+
 var MergeSteps = []uint64{100_000, 10_000}
+
+// EpochMergeSteps are the merge targets (largest first) for epoch-rounded segments: the
+// 1024-block produce tier merges up through 8192 (one era1 file), 65536, to 524288.
+var EpochMergeSteps = []uint64{524_288, 65_536, 8_192}
+
+// epochTypes is the set of segment types eligible for the epoch (era1-aligned) layout — the core eth
+// block segments. Whether a given file/production actually uses epoch is decided per chain (see
+// snaptype2.RegimeFor); this set only gates which types can ever be epoch. Written only at init.
+var epochTypes = map[Enum]bool{Unknown: true}
+
+// RegisterEpochType marks a segment type as epoch-eligible.
+func RegisterEpochType(t Enum) { epochTypes[t] = true }
+
+// EpochType reports whether type t is epoch-eligible (a core block segment). The actual regime for a
+// file is carried by FileInfo.Epoch (reads) or chosen by the chain at production (writes).
+func EpochType(t Enum) bool { return epochTypes[t] }
+
+// EpochRegimeMismatch reports whether snapshot file `name` belongs to the block-segment regime
+// opposite to epochOn, so a chain in that regime must skip it: an epoch chain skips decimal
+// (no "ep" marker) block files and a decimal chain skips epoch ("ep"-marked) block files. Files
+// that are not core block segments (state, Caplin, Bor, salt) never mismatch.
+func EpochRegimeMismatch(name string, epochOn bool) bool {
+	fi, stateFile, ok := ParseFileName("", name)
+	if !ok || stateFile || fi.Type == nil {
+		return false
+	}
+	enum := fi.Type.Enum()
+	if enum == Unknown || !epochTypes[enum] {
+		return false
+	}
+	return fi.Epoch != epochOn
+}
 
 // FileInfo - parsed file metadata
 type FileInfo struct {
@@ -320,6 +405,7 @@ type FileInfo struct {
 	From, To        uint64
 	name, Path, Ext string
 	Type            Type
+	Epoch           bool // epoch (era1-aligned, "ep"-marked, block/1024) vs decimal (block/1000)
 
 	CaplinTypeString string // part of file-name - without version, range, ext
 	TypeString       string
@@ -351,18 +437,14 @@ func (f FileInfo) CompareTo(o FileInfo) int {
 	return strings.Compare(f.name, o.name)
 }
 
+// As returns the same block range and version as f, for a different type. The name must come from
+// FileName: an epoch block segment encodes block/1024, and a hand-rolled /1000 here would address a
+// different range for every segment whose two encodings disagree (any tier from 8192 up).
 func (f FileInfo) As(t Type) FileInfo {
-	if f.To < f.From {
-		panic(fmt.Errorf("file info To < From: %d < %d", f.To, f.From))
-	}
-	var name string
-	if f.To-f.From < 1_000 {
-		name = fmt.Sprintf("%s-%09d-%09d-%s%s", f.Version.String(), f.From, f.To, t, f.Ext)
-	} else {
-		name = fmt.Sprintf("%s-%06d-%06d-%s%s", f.Version.String(), f.From/1_000, f.To/1_000, t, f.Ext)
-	}
+	name := fileName(f.Version, f.Epoch, f.From, f.To, t.Name()) + f.Ext
 	return FileInfo{
 		Version: f.Version,
+		Epoch:   f.Epoch,
 		From:    f.From,
 		To:      f.To,
 		Ext:     f.Ext,

--- a/db/snaptype/files_epoch_test.go
+++ b/db/snaptype/files_epoch_test.go
@@ -1,0 +1,195 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package snaptype_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/db/snaptype"
+	snaptype2 "github.com/erigontech/erigon/db/snaptype2"
+	"github.com/erigontech/erigon/db/version"
+)
+
+// The regime is a filename marker ("ep"), independent of the content version: decimal names encode
+// block/1000 with no marker, epoch names encode block/1024 with the marker. The public FileName is
+// always decimal; epoch names are built through FileInfo.
+func TestEpochNameRoundTrip(t *testing.T) {
+	// decimal round-trips (public FileName, no marker)
+	name := snaptype.FileName(version.V1_0, false, 21_000_000, 21_100_000, "headers")
+	require.Equal(t, "v1.0-021000-021100-headers", name)
+	res, _, ok := snaptype.ParseFileName("", name+".seg")
+	require.True(t, ok)
+	require.False(t, res.Epoch)
+	require.Equal(t, uint64(21_000_000), res.From)
+	require.Equal(t, uint64(21_100_000), res.To)
+
+	// epoch round-trips: marker + block/1024, at a range that is not 1000-aligned (top tier)
+	epoch := snaptype2.Headers.FileInfo("", true, 20_971_520, 21_495_808)
+	require.Equal(t, "ep", epochMarkerOf(t, epoch.Name()))
+	res, _, ok = snaptype.ParseFileName("", epoch.Name())
+	require.True(t, ok)
+	require.True(t, res.Epoch)
+	require.Equal(t, uint64(20_971_520), res.From)
+	require.Equal(t, uint64(21_495_808), res.To)
+}
+
+func epochMarkerOf(t *testing.T, name string) string {
+	t.Helper()
+	fi, _, ok := snaptype.ParseFileName("", name)
+	require.True(t, ok)
+	if fi.Epoch {
+		return "ep"
+	}
+	return ""
+}
+
+// A segment's idx mask must encode the same range the segment name does, or it addresses the wrong
+// file. For epoch (block/1024) segments this bites from block 43008 up, where from/1000 != from/1024
+// and consecutive segments are one printed digit apart — a /1000 mask would land on the neighbour.
+func TestEpochIdxMaskMatchesName(t *testing.T) {
+	seg := snaptype2.Headers.FileInfo("", true, 43_008, 44_032)
+	idxName := seg.Type.IdxFileNames(seg.Epoch, seg.From, seg.To)[0]
+	mask := snaptype.IdxFileMask(seg.Epoch, seg.From, seg.To, snaptype2.Indexes.HeaderHash.Name)
+
+	ok, err := filepath.Match(mask, idxName)
+	require.NoError(t, err)
+	require.True(t, ok, "mask %q does not match its own idx name %q", mask, idxName)
+
+	neighbour := snaptype2.Headers.IdxFileNames(true, 44_032, 45_056)[0]
+	ok, err = filepath.Match(mask, neighbour)
+	require.NoError(t, err)
+	require.False(t, ok, "mask %q wrongly matches the next segment %q", mask, neighbour)
+}
+
+// FileInfo must carry the exact block/1024 range: building the name decimally and re-parsing would
+// truncate (1024 -> 1000, 524288 -> 524000), which corrupts From/To and, downstream, the segment
+// length the transactions index is built against.
+func TestFileInfoNoTruncation(t *testing.T) {
+	for _, tc := range []struct{ from, to uint64 }{
+		{0, 1024},
+		{0, 524_288},
+		{524_288, 589_824},
+		{43_008, 44_032},
+	} {
+		f := snaptype2.Headers.FileInfo("", true, tc.from, tc.to)
+		require.True(t, f.Epoch)
+		require.Equal(t, tc.from, f.From, "[%d,%d)", tc.from, tc.to)
+		require.Equal(t, tc.to, f.To, "[%d,%d)", tc.from, tc.to)
+
+		res, _, ok := snaptype.ParseFileName("", f.Name())
+		require.True(t, ok)
+		require.Equal(t, tc.from, res.From)
+		require.Equal(t, tc.to, res.To)
+	}
+}
+
+// The download filter uses EpochRegimeMismatch to keep an epoch chain from pulling decimal block
+// files (and vice versa), keyed on the marker. It also covers block indexes — including the
+// transactions-to-block index, which resolves to the transactions type. Non-block files never match.
+func TestEpochRegimeMismatch(t *testing.T) {
+	decHeaders := snaptype.FileName(version.V1_0, false, 0, 500_000, "headers") + ".seg"
+	epochHeaders := snaptype2.Headers.FileInfo("", true, 0, 524_288).Name()
+	epochBodies := snaptype2.Bodies.FileInfo("", true, 0, 524_288).Name()
+
+	// epoch chain: keep epoch block files, skip decimal ones
+	require.False(t, snaptype.EpochRegimeMismatch(epochHeaders, true))
+	require.False(t, snaptype.EpochRegimeMismatch(epochBodies, true))
+	require.True(t, snaptype.EpochRegimeMismatch(decHeaders, true))
+
+	// decimal chain: keep decimal block files, skip epoch ones
+	require.False(t, snaptype.EpochRegimeMismatch(decHeaders, false))
+	require.True(t, snaptype.EpochRegimeMismatch(epochHeaders, false))
+
+	// indexes are classified by their own marker, same as segments
+	require.True(t, snaptype.EpochRegimeMismatch("v2.0-000000-000500-headers.idx", true))
+	require.True(t, snaptype.EpochRegimeMismatch("v2.0-000000-000500-transactions-to-block.idx", true))
+	require.False(t, snaptype.EpochRegimeMismatch("v2.0-000000-000512-headers-ep.idx", true))
+	require.True(t, snaptype.EpochRegimeMismatch("v2.0-000000-000512-transactions-to-block-ep.idx", false))
+	require.False(t, snaptype.EpochRegimeMismatch("v2.0-000000-000500-headers.idx", false))
+
+	// non-block files are never a mismatch, regardless of regime
+	for _, epochOn := range []bool{true, false} {
+		require.False(t, snaptype.EpochRegimeMismatch("v1.0-accounts.0-2048.kv", epochOn))
+		require.False(t, snaptype.EpochRegimeMismatch("salt-blocks.txt", epochOn))
+		require.False(t, snaptype.EpochRegimeMismatch("not-a-snapshot", epochOn))
+	}
+}
+
+// FileInfo.As must keep the source regime and range: the transactions index builder resolves the
+// bodies segment through As, and an epoch segment resolved with a decimal /1000 range would look for
+// the wrong file (at the 524288 tier, -000524- instead of -000512-).
+func TestFileInfoAsKeepsEpoch(t *testing.T) {
+	for _, tc := range []struct{ from, to uint64 }{
+		{0, 1024},
+		{0, 524_288},
+		{524_288, 589_824},
+		{43_008, 44_032},
+	} {
+		txInfo := snaptype2.Transactions.FileInfo("/snap", true, tc.from, tc.to)
+		got := txInfo.As(snaptype2.Bodies)
+		want := snaptype2.Bodies.FileInfo("/snap", true, tc.from, tc.to).Name()
+		require.Equal(t, want, got.Name(), "As() name for [%d,%d)", tc.from, tc.to)
+		require.True(t, got.Epoch)
+		require.Equal(t, tc.from, got.From)
+		require.Equal(t, tc.to, got.To)
+	}
+}
+
+// A decimal mask's leading version wildcard also matches an "ep"-marked name that prints the same
+// digits: decimal [1000,2000) and epoch [1024,2048) are both "000001-000002". The two address
+// different block ranges, so a lookup in one regime must never settle for the other's file.
+func TestLookupDoesNotCrossRegime(t *testing.T) {
+	dir := t.TempDir()
+	decimal := snaptype2.Headers.FileInfo(dir, false, 1_000, 2_000)
+	epoch := snaptype2.Headers.FileInfo(dir, true, 1_024, 2_048)
+	for _, f := range []snaptype.FileInfo{decimal, epoch} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, f.Name()), []byte{}, 0o644))
+	}
+
+	// the marker has to stay clear of the mask's version wildcard: a mask is version-wildcarded because
+	// an index's version may differ from its segment's, and `*` spans dashes.
+	decMask := snaptype.SegmentFileMask(false, 1_000, 2_000, snaptype2.Enums.Headers)
+	crosses, err := filepath.Match(decMask, epoch.Name())
+	require.NoError(t, err)
+	require.False(t, crosses, "decimal mask %q matches the epoch name %q", decMask, epoch.Name())
+
+	found := snaptype2.Headers.FileInfoByMask(dir, false, 1_000, 2_000)
+	require.False(t, found.Epoch)
+	require.Equal(t, [2]uint64{1_000, 2_000}, [2]uint64{found.From, found.To})
+
+	found = snaptype2.Headers.FileInfoByMask(dir, true, 1_024, 2_048)
+	require.True(t, found.Epoch)
+	require.Equal(t, [2]uint64{1_024, 2_048}, [2]uint64{found.From, found.To})
+}
+
+func TestEpochSubTierNameSpellsOutBlocks(t *testing.T) {
+	small := snaptype2.Headers.FileInfo("", true, 8, 16)
+	require.Equal(t, "v1.1-000000008-000000016-headers-ep.seg", small.Name())
+
+	res, _, ok := snaptype.ParseFileName("", small.Name())
+	require.True(t, ok)
+	require.True(t, res.Epoch)
+	require.Equal(t, [2]uint64{8, 16}, [2]uint64{res.From, res.To})
+
+	// a full tier is unaffected
+	full := snaptype2.Headers.FileInfo("", true, 0, 1024)
+	require.Equal(t, "v1.1-000000-000001-headers-ep.seg", full.Name())
+}

--- a/db/snaptype/type.go
+++ b/db/snaptype/type.go
@@ -172,7 +172,7 @@ func (i Index) HasFile(info FileInfo, dirEntries []string, logger log.Logger) bo
 		return false
 	}
 
-	fNameMask := IdxFileMask(info.From, info.To, i.Name)
+	fNameMask := IdxFileMask(info.Epoch, info.From, info.To, i.Name)
 	fPath, fileVer, ok, err := version.MatchVersionedFile(fNameMask, dirEntries, dir)
 	if err != nil {
 		logger.Debug("[ind] HasFile: files by pattern didn't found", "f", fNameMask, "dir", dir, "err", err)
@@ -209,11 +209,11 @@ type Type interface {
 	Enum() Enum
 	Versions() Versions
 	Name() string
-	FileName(version Version, from uint64, to uint64) string
-	FileInfo(dir string, from uint64, to uint64) FileInfo
-	FileInfoByMask(dir string, from uint64, to uint64) FileInfo
-	IdxFileName(version Version, from uint64, to uint64, index ...Index) string
-	IdxFileNames(from uint64, to uint64) []string
+	FileName(version Version, epoch bool, from uint64, to uint64) string
+	FileInfo(dir string, epoch bool, from, to uint64) FileInfo
+	FileInfoByMask(dir string, epoch bool, from uint64, to uint64) FileInfo
+	IdxFileName(version Version, epoch bool, from uint64, to uint64, index ...Index) string
+	IdxFileNames(epoch bool, from uint64, to uint64) []string
 	Indexes() []Index
 	HasIndexFiles(info FileInfo, dirEntries []string, logger log.Logger) bool
 	BuildIndexes(ctx context.Context, info FileInfo, indexBuilder IndexBuilder, chainConfig *chain.Config, tmpDir string, p *background.Progress, lvl log.Lvl, logger log.Logger) error
@@ -300,27 +300,27 @@ func (s SnapType) RangeExtractor() RangeExtractor {
 	return s.rangeExtractor
 }
 
-func (s SnapType) FileName(version Version, from uint64, to uint64) string {
+func (s SnapType) FileName(version Version, epoch bool, from uint64, to uint64) string {
 	if version.Major == 0 && version.Minor == 0 {
 		version = s.versions.Current
 	}
 
-	return SegmentFileName(version, from, to, s.enum)
+	return SegmentFileName(version, epoch, from, to, s.enum)
 }
 
-func (s SnapType) FileMask(from uint64, to uint64) string {
-	return SegmentFileMask(from, to, s.enum)
+func (s SnapType) FileMask(epoch bool, from uint64, to uint64) string {
+	return SegmentFileMask(epoch, from, to, s.enum)
 }
 
-func (s SnapType) FileInfo(dir string, from uint64, to uint64) FileInfo {
-	f, _, _ := ParseFileName(dir, s.FileName(s.versions.Current, from, to))
+func (s SnapType) FileInfo(dir string, epoch bool, from, to uint64) FileInfo {
+	f, _, _ := ParseFileName(dir, s.FileName(s.versions.Current, epoch, from, to))
 	return f
 }
 
-func (s SnapType) FileInfoByMask(dir string, from uint64, to uint64) FileInfo {
-	fName, _, ok, err := version.FindFilesWithVersionsByPattern(filepath.Join(dir, s.FileMask(from, to)))
+func (s SnapType) FileInfoByMask(dir string, epoch bool, from uint64, to uint64) FileInfo {
+	fName, _, ok, err := version.FindFilesWithVersionsByPattern(filepath.Join(dir, s.FileMask(epoch, from, to)))
 	if err != nil {
-		log.Debug("[snaptype] file mask error", "err", err, "fName", s.FileName(s.versions.Current, from, to))
+		log.Debug("[snaptype] file mask error", "err", err, "fName", s.FileName(s.versions.Current, epoch, from, to))
 		return FileInfo{}
 	}
 	if !ok {
@@ -366,16 +366,16 @@ func (s SnapType) HasIndexFiles(info FileInfo, dirEntries []string, logger log.L
 	return true
 }
 
-func (s SnapType) IdxFileNames(from uint64, to uint64) []string {
+func (s SnapType) IdxFileNames(epoch bool, from uint64, to uint64) []string {
 	fileNames := make([]string, len(s.indexes))
 	for i, index := range s.indexes {
-		fileNames[i] = IdxFileName(index.Version.Current, from, to, index.Name)
+		fileNames[i] = IdxFileName(index.Version.Current, epoch, from, to, index.Name)
 	}
 
 	return fileNames
 }
 
-func (s SnapType) IdxFileName(ver version.Version, from uint64, to uint64, index ...Index) string {
+func (s SnapType) IdxFileName(ver version.Version, epoch bool, from uint64, to uint64, index ...Index) string {
 	if len(index) == 0 {
 		if len(s.indexes) == 0 {
 			return ""
@@ -391,7 +391,7 @@ func (s SnapType) IdxFileName(ver version.Version, from uint64, to uint64, index
 		}
 	}
 
-	return IdxFileName(ver, from, to, index[0].Name)
+	return IdxFileName(ver, epoch, from, to, index[0].Name)
 }
 
 func ParseFileType(s string) (Type, bool) {
@@ -444,13 +444,12 @@ func (ft Enum) Type() Type {
 	return registeredTypes[ft]
 }
 
-func (e Enum) FileName(from uint64, to uint64) string {
-	return SegmentFileName(e.Type().Versions().Current, from, to, e)
+func (e Enum) FileName(epoch bool, from uint64, to uint64) string {
+	return SegmentFileName(e.Type().Versions().Current, epoch, from, to, e)
 }
 
-func (e Enum) FileInfo(dir string, from uint64, to uint64) FileInfo {
-	f, _, _ := ParseFileName(dir, e.FileName(from, to))
-	return f
+func (e Enum) FileInfo(dir string, epoch bool, from, to uint64) FileInfo {
+	return e.Type().FileInfo(dir, epoch, from, to)
 }
 
 func (e Enum) HasIndexFiles(info FileInfo, dirEntries []string, logger log.Logger) bool {
@@ -501,7 +500,7 @@ func BuildIndex(ctx context.Context, info FileInfo, indexVersion version.Version
 
 	cfg.KeyCount = d.Count()
 	idxVer := indexVersion.Current
-	cfg.IndexFile = filepath.Join(info.Dir(), info.Type.IdxFileName(idxVer, info.From, info.To))
+	cfg.IndexFile = filepath.Join(info.Dir(), info.Type.IdxFileName(idxVer, info.Epoch, info.From, info.To))
 	versionOfRs := version.DataStructureVersion(0)
 	if !idxVer.Eq(version.V1_0) { // inner version=1 incompatible with .efi v1.0
 		versionOfRs = recsplit.ExistenceFilterVersion
@@ -564,7 +563,7 @@ func BuildIndexWithSnapName(ctx context.Context, info FileInfo, cfg recsplit.Rec
 	defer d.Close()
 
 	cfg.KeyCount = d.Count()
-	cfg.IndexFile = filepath.Join(info.Dir(), IdxFileName(info.Version, info.From, info.To, info.CaplinTypeString))
+	cfg.IndexFile = filepath.Join(info.Dir(), IdxFileName(info.Version, info.Epoch, info.From, info.To, info.CaplinTypeString))
 	rs, err := recsplit.NewRecSplit(cfg, logger)
 	if err != nil {
 		return err

--- a/db/snaptype2/block_types.go
+++ b/db/snaptype2/block_types.go
@@ -41,6 +41,11 @@ import (
 )
 
 func init() {
+	// the core block segments (headers/bodies/transactions) are the ones eligible for the epoch
+	// (era1-aligned) layout; register their enums so snaptype gates epoch strictly to them.
+	for _, t := range BlockSnapshotTypes {
+		snaptype.RegisterEpochType(t.Enum())
+	}
 	ethereumTypes := make([]snaptype.Type, 0, len(BlockSnapshotTypes)+len(snaptype.CaplinSnapshotTypes))
 	ethereumTypes = append(ethereumTypes, BlockSnapshotTypes...)
 	ethereumTypes = append(ethereumTypes, snaptype.CaplinSnapshotTypes...)
@@ -51,6 +56,14 @@ func init() {
 	snapcfg.RegisterKnownTypes(networkname.Chiado, ethereumTypes)
 	snapcfg.RegisterKnownTypes(networkname.Hoodi, ethereumTypes)
 	snapcfg.RegisterKnownTypes(networkname.Bloatnet, ethereumTypes)
+}
+
+// RegimeFor reports whether block segments on this chain use the epoch (era1-aligned, block/1024)
+// layout. Only Ethereum-family chains do; Aura (Gnosis) keeps the decimal layout. This is the single
+// chain->regime decision; everything else reads FileInfo.Epoch or is threaded this value from a
+// production entry point.
+func RegimeFor(chainConfig *chain.Config) bool {
+	return chainConfig != nil && chainConfig.Aura == nil
 }
 
 var Enums = struct {
@@ -236,7 +249,8 @@ var (
 					BucketSize: recsplit.DefaultBucketSize,
 					LeafSize:   recsplit.DefaultLeafSize,
 					TmpDir:     tmpDir,
-					IndexFile:  filepath.Join(sn.Dir(), sn.Type.IdxFileName(Indexes.TxnHash.Version.Current, sn.From, sn.To)),
+					IndexFile: filepath.Join(sn.Dir(), sn.Type.IdxFileName(Indexes.TxnHash.Version.Current, sn.Epoch,
+						sn.From, sn.To)),
 					BaseDataID: baseTxnID.U64(),
 				}, logger)
 				if err != nil {
@@ -251,7 +265,7 @@ var (
 					LeafSize:   recsplit.DefaultLeafSize,
 					TmpDir:     tmpDir,
 					IndexFile: filepath.Join(sn.Dir(),
-						sn.Type.IdxFileName(Indexes.TxnHash2BlockNum.Version.Current,
+						sn.Type.IdxFileName(Indexes.TxnHash2BlockNum.Version.Current, sn.Epoch,
 							sn.From, sn.To, Indexes.TxnHash2BlockNum)),
 					BaseDataID: firstBlockNum,
 				}, logger)

--- a/execution/execmodule/exec_module_devp2p_test.go
+++ b/execution/execmodule/exec_module_devp2p_test.go
@@ -54,11 +54,10 @@ import (
 // receipt list per requested block in request order — an empty list for empty
 // blocks — and end at the first block that cannot be served.
 func TestGetBlockReceiptsFrozenBlocks(t *testing.T) {
-	t.Parallel()
 	const (
-		// The chain is one minimal block segment (file names encode block/1000, so
-		// segments cannot be smaller) plus a small tail that stays unfrozen in the DB.
-		frozenChainLength   = snaptype.Erigon2MinSegmentSize + 10
+		// The chain is one minimal block segment (epoch segments are 1024-aligned, so a segment
+		// cannot be smaller) plus a small tail that stays unfrozen in the DB.
+		frozenChainLength   = snaptype.EpochMinSegmentSize + 10
 		frozenEmptyBlockNum = 500
 	)
 	devp2pTestKey, err := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
@@ -87,14 +86,14 @@ func TestGetBlockReceiptsFrozenBlocks(t *testing.T) {
 	// Freeze the first segment's blocks into a snapshot file and prune them from
 	// the DB, exactly as block retirement does.
 	snCfg, _ := snapcfg.KnownCfg(networkname.Mainnet)
-	require.NoError(t, freezeblocks.DumpBlocks(m.Ctx, 0, snaptype.Erigon2MinSegmentSize, m.ChainConfig, m.Dirs.Tmp, m.Dirs.Snap, m.DB, 1, log.LvlInfo, log.New(), m.BlockReader, snCfg, nil))
+	require.NoError(t, freezeblocks.DumpBlocks(m.Ctx, 0, snaptype.EpochMinSegmentSize, m.ChainConfig, m.Dirs.Tmp, m.Dirs.Snap, m.DB, 1, log.LvlInfo, log.New(), m.BlockReader, snCfg, nil))
 	require.NoError(t, m.BlockSnapshots.OpenFolder())
 	rwTx, err := m.DB.BeginRw(m.Ctx)
 	require.NoError(t, err)
 	defer rwTx.Rollback()
-	deleted, err := rawdb.PruneBlocks(rwTx, snaptype.Erigon2MinSegmentSize, snaptype.Erigon2MinSegmentSize)
+	deleted, err := rawdb.PruneBlocks(rwTx, snaptype.EpochMinSegmentSize, snaptype.EpochMinSegmentSize)
 	require.NoError(t, err)
-	require.Equal(t, snaptype.Erigon2MinSegmentSize-1, deleted)
+	require.Equal(t, snaptype.EpochMinSegmentSize-1, deleted)
 	require.NoError(t, rwTx.Commit())
 	tx, err := m.DB.BeginTemporalRo(m.Ctx)
 	require.NoError(t, err)
@@ -108,7 +107,7 @@ func TestGetBlockReceiptsFrozenBlocks(t *testing.T) {
 	emptyBlockHash := blockHash(frozenEmptyBlockNum)
 	// Precondition making the scenario real: the empty block is readable via the
 	// snapshot-aware block reader but its header is gone from the DB tables.
-	require.GreaterOrEqual(t, m.BlockReader.FrozenBlocks(), uint64(snaptype.Erigon2MinSegmentSize-1))
+	require.GreaterOrEqual(t, m.BlockReader.FrozenBlocks(), uint64(snaptype.EpochMinSegmentSize-1))
 	prunedHeader, err := rawdb.ReadHeaderByHash(tx, emptyBlockHash)
 	require.NoError(t, err)
 	require.Nil(t, prunedHeader)

--- a/execution/execmodule/exec_module_non_finality_test.go
+++ b/execution/execmodule/exec_module_non_finality_test.go
@@ -43,7 +43,9 @@ func TestExecModule_GivenReorgPastFinalised_WhenFinality_ThenInvalidFCU(t *testi
 	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
 	defer cancel()
 	const (
-		e2RetireStepSize  = 10
+		// A power of two that divides 8192: the epoch ladder has no tier for step 10, so it would
+		// fall back to 1024 and retire nothing at this chain length.
+		e2RetireStepSize  = 8
 		e3RetireStepSize  = 3 // 3 txns per block (1 + 2 system txns)
 		maxReorgDepth     = 2
 		chainLen          = e2RetireStepSize + maxReorgDepth + 1
@@ -137,11 +139,11 @@ func TestExecModule_GivenReorgPastFinalised_WhenFinality_ThenInvalidFCU(t *testi
 	// also check that we didnt create any snapshot files for non-finalised blocks
 	err = emt.BlockSnapshots.OpenFolder()
 	require.NoError(t, err)
-	require.Equal(t, uint64(9), emt.BlockSnapshots.BlocksAvailable())
+	require.Equal(t, uint64(e2RetireStepSize-1), emt.BlockSnapshots.BlocksAvailable())
 	tx, err := emt.DB.BeginTemporalRo(ctx)
 	require.NoError(t, err)
 	defer tx.Rollback()
-	require.Equal(t, uint64(33), tx.Debug().TxNumsInFiles(kv.CommitmentDomain))
+	require.Equal(t, uint64(finalisedBlockNum*e3RetireStepSize), tx.Debug().TxNumsInFiles(kv.CommitmentDomain))
 }
 
 func TestExecModule_GivenReorgAtFinalisedBlock_WhenFinality_ThenInvalidFCU(t *testing.T) {
@@ -196,7 +198,9 @@ func TestExecModule_GivenReorgPastMaxReorgDepth_WhenNonFinality_ThenReorg(t *tes
 	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
 	defer cancel()
 	const (
-		e2RetireStepSize  = 10
+		// A power of two that divides 8192: the epoch ladder has no tier for step 10, so it would
+		// fall back to 1024 and retire nothing at this chain length.
+		e2RetireStepSize  = 8
 		e3RetireStepSize  = 3 // 3 txns per block (1 + 2 system txns)
 		maxReorgDepth     = 2
 		chainLen          = e2RetireStepSize + maxReorgDepth + 1
@@ -297,5 +301,5 @@ func TestExecModule_GivenReorgPastMaxReorgDepth_WhenNonFinality_ThenReorg(t *tes
 	tx, err := emt.DB.BeginTemporalRo(ctx)
 	require.NoError(t, err)
 	defer tx.Rollback()
-	require.Equal(t, uint64(21), tx.Debug().TxNumsInFiles(kv.CommitmentDomain))
+	require.Equal(t, uint64(finalisedBlockNum*e3RetireStepSize), tx.Debug().TxNumsInFiles(kv.CommitmentDomain))
 }

--- a/execution/execmodule/exec_module_snapshots_test.go
+++ b/execution/execmodule/exec_module_snapshots_test.go
@@ -36,7 +36,9 @@ import (
 func TestExecModuleProducesE2Snapshots(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
 	defer cancel()
-	retireStep := uint64(10)
+	// An eth-family chain gets epoch-aligned block segments; E2RetireStep lowers the ladder's smallest
+	// tier from 1024 so this needs a handful of blocks rather than a thousand.
+	retireStep := uint64(8)
 	chainLen := int(retireStep) + 2
 	emt := execmoduletester.New(
 		t,
@@ -72,8 +74,6 @@ func TestExecModuleProducesE2Snapshots(t *testing.T) {
 	result, err = emt.UpdateForkChoice(ctx, cp.TopBlock.Header())
 	require.NoError(t, err)
 	require.Equal(t, execmodule.ExecutionStatusSuccess, result.Status)
-	require.NoError(t, emt.WaitForBlockRetirement(ctx))
-	err = emt.BlockSnapshots.OpenFolder()
-	require.NoError(t, err)
-	require.Equal(t, uint64(9), emt.BlockSnapshots.BlocksAvailable())
+	require.NoError(t, emt.WaitForBlocksAvailable(ctx, retireStep-1))
+	require.Equal(t, retireStep-1, emt.BlockSnapshots.BlocksAvailable())
 }

--- a/execution/execmodule/execmoduletester/exec_module_tester.go
+++ b/execution/execmodule/execmoduletester/exec_module_tester.go
@@ -896,6 +896,27 @@ func (emt *ExecModuleTester) UpdateForkChoice(ctx context.Context, header *types
 	})
 }
 
+// WaitForBlocksAvailable waits until the block snapshots expose at least n blocks. Retirement runs in
+// the background and its start/done events do not pair one-to-one with fork-choice updates — a cycle
+// that finds nothing to freeze signals both just the same — so a caller that needs the files on disk
+// polls here instead of counting events.
+func (emt *ExecModuleTester) WaitForBlocksAvailable(ctx context.Context, n uint64) error {
+	for {
+		if err := emt.BlockSnapshots.OpenFolder(); err != nil {
+			return err
+		}
+		available := emt.BlockSnapshots.BlocksAvailable()
+		if available >= n {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("waiting for %d blocks in snapshots (have %d): %w", n, available, ctx.Err())
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+}
+
 func (emt *ExecModuleTester) WaitForBlockRetirement(ctx context.Context) error {
 	select {
 	case started := <-emt.retirementStart:

--- a/execution/state/genesiswrite/head_timestamp_test.go
+++ b/execution/state/genesiswrite/head_timestamp_test.go
@@ -111,7 +111,7 @@ func writeHeaderSegment(t *testing.T, dirs datadir.Dirs, headers []*types.Header
 	ctx := context.Background()
 	logger := log.New()
 	from, to := headers[0].Number.Uint64(), headers[len(headers)-1].Number.Uint64()+1
-	name := snaptype.SegmentFileName(version.V1_0, from, to, snaptype2.Enums.Headers)
+	name := snaptype.SegmentFileName(version.V1_0, false, from, to, snaptype2.Enums.Headers)
 
 	c, err := seg.NewCompressor(ctx, "test", filepath.Join(dirs.Snap, name), dirs.Tmp, seg.DefaultCfg, log.LvlDebug, logger)
 	require.NoError(t, err)

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -49,6 +49,7 @@ import (
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/disk"
+	"github.com/erigontech/erigon/common/estimate"
 	"github.com/erigontech/erigon/common/event"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/config3"
@@ -1256,6 +1257,13 @@ func SetUpBlockReader(ctx context.Context, db kv.RwDB, dirs datadir.Dirs, snConf
 	_, knownSnapCfg := snapcfg.KnownCfg(chainConfig.ChainName)
 	createNewSaltFileIfNeeded := snConfig.Snapshot.NoDownloader || snConfig.Snapshot.DisableDownloadE3 || !knownSnapCfg
 	if _, err := snaptype.LoadSalt(dirs.Snap, createNewSaltFileIfNeeded, logger); err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	// Convert legacy decimal block segments to the epoch layout before anything opens the segment
+	// directory: the two size ladders never align, so an epoch producer cannot extend a decimal
+	// frontier without overlapping it, and that overlap breaks the frozen tx-num sequence.
+	if err := freezeblocks.MigrateDecimalToEpoch(ctx, dirs, db, chainConfig, estimate.CompressSnapshot.Workers(), logger); err != nil {
 		return nil, nil, nil, nil, err
 	}
 

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -1260,19 +1260,27 @@ func SetUpBlockReader(ctx context.Context, db kv.RwDB, dirs datadir.Dirs, snConf
 		return nil, nil, nil, nil, err
 	}
 
+	allSegmentsDownloadComplete, err := rawdb.AllSegmentsDownloadCompleteFromDB(db)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
 	// Convert legacy decimal block segments to the epoch layout before anything opens the segment
 	// directory: the two size ladders never align, so an epoch producer cannot extend a decimal
 	// frontier without overlapping it, and that overlap breaks the frozen tx-num sequence.
+	//
+	// A datadir whose pre-epoch download never finished cannot go either way: converting it would
+	// build on a set with holes, and leaving it alone does not help because this build asks the
+	// manifest only for epoch files, so the decimal download can never resume. Say so instead of
+	// failing later with a message about a missing type.
+	if err := freezeblocks.CheckLegacyDownloadFinished(db, dirs, chainConfig); err != nil {
+		return nil, nil, nil, nil, err
+	}
 	if err := freezeblocks.MigrateDecimalToEpoch(ctx, dirs, db, chainConfig, estimate.CompressSnapshot.Workers(), logger); err != nil {
 		return nil, nil, nil, nil, err
 	}
 
 	tdb, dbIsTemporal := db.(*temporal.DB)
-
-	allSegmentsDownloadComplete, err := rawdb.AllSegmentsDownloadCompleteFromDB(db)
-	if err != nil {
-		return nil, nil, nil, nil, err
-	}
 	if allSegmentsDownloadComplete {
 		allSnapshots.OptimisticalyOpenFolder()
 	} else {


### PR DESCRIPTION
## What

Block segments are sized 1000 / 10k / 100k / 500k. era1 files are 8192 blocks. The two grids do not
line up, so neither can be turned into the other without loss.

This puts eth-family chains on an 8192-based grid: produce 1024, merge 8192 → 65536 → 524288.
Existing datadirs are converted in place the first time the new binary starts. Bor and Gnosis keep
the old grid. Which grid a chain uses is decided once, in `snaptype2.RegimeFor(chainConfig)`, and
passed down as a plain `epoch bool`.

## The filename says which grid, and the marker goes last

An epoch segment is `v1.1-000000-000512-headers-ep.seg`: same content version, plus an `ep` marker.
The bytes inside are unchanged, only the sizing, so putting this in the schema version would have
made a global number mean something chain-specific.

The marker has to come after the type:

```
v1.1-000000-000512-headers-ep.seg
└ver ┘└── range ──┘└─type─┘└mark┘

A segment finds its index with a mask that wildcards the version, because an index's version
can differ from its segment's:

    *-000001-000002-headers.idx        decimal segment looking for its index
    *-000001-000002-headers-ep.idx     epoch segment looking for its index

decimal [1000,2000) and epoch [1024,2048) both print as 000001-000002. Put the marker next
to the version and it falls inside the wildcard, so a decimal segment matches an epoch index
and reads at the wrong offsets.
```

## Migration

An existing decimal datadir converts once, at startup, in `MigrateDecimalToEpoch`:

```
decimal on disk   [0 ................................ frozenMax)

                  |<------ repack to epoch ------>|<-- tail -->|
                  0                          tailFrom      frozenMax
                                                  ^ floor(frozenMax, 1024)

1. repack [0, tailFrom) into epoch segments; each decimal file is deleted once its
   blocks are safe in an epoch file
2. write [tailFrom, frozenMax) back to the DB, so the frozen range and the DB stay
   contiguous
3. build the indexes, then drop the decimal files straddling the boundary
```

There is no marker file. What has already been done is read back from the epoch segments on disk, so
a `kill -9` at any point is resumed by simply running again. The tail is committed before indexes are
built, so a crash does not force the longest phase to run twice.

The node migrates under the datadir lock it already holds. Read-only consumers such as rpcdaemon
refuse an unconverted datadir instead of converting it themselves.

## Pruned nodes are the hard case

Pruning deletes transactions only, and deletes whole files, so a normal node looks like this:

```
block 0                        3,200,000              3,522,000
  |                                 |                      |
headers       ###################################################
bodies        ###################################################
transactions                        ########################
                                    ^ everything below was pruned away
```

Two things follow, and they are the same problem: transactions no longer start where the others do.

**Every type is cut at the same blocks.** A transactions index is built by walking the bodies
segment with the identical range, so each transactions segment needs a bodies segment with the same
`from` and `to`. The conversion plan is computed once from block 0; each type converts the part of
it that it has data for.

**Transactions resume at a cut, not at their first block.** 3,200,000 is not on the new grid, so
they start at 3,211,264 and the blocks below are dropped. Those are already under the retention
cutoff the node set for itself, since pruning rounds down to a whole file. Keeping the straddling
decimal file instead does not work: it would overlap the epoch segments above it, and overlapping
ranges are resolved by dropping the smaller one, which would throw away what we just wrote.

## Merging has to check it has the whole range

The ladder picks what to merge by subtracting a tier size from the top of an existing range. That
can reach below the lowest file on disk:

```
transactions on disk       [3,211,264 ---------------------- 3,670,016)
ladder asks for a 524288    [3,145,728 --------------------- 3,670,016)
                             ^^^^^^^^ nothing here
```

Nothing checked this, so the merge wrote a file whose name claimed blocks it did not contain, and no
error appeared anywhere. The old grid never reached this: its pruning step and its merge limit are
both 100k, so those files were already at full size and were never merged again.

Whether a node pays for the check depends on where the chain head was when it converted:

```
plan cuts, computed once from block 0:

  |<---------- 524288 tiers ---------->|<- 65536 -><- 8192 -><-1024->|
  0                                    T                          head
                                       ^ last 524288 boundary

frontier below T  ->  resume point is a multiple of 524288  ->  no merge can reach
                                                                below it, check never fires

frontier above T  ->  resume point is a 65536 or 8192 cut   ->  the blocks between it and
                                                                the next 524288 boundary
                                                                stay as 65536 files
```

Roughly half of chain heights land on each side. When there is such a band, headers and bodies are
held back with it even though they have the data, because the merge list is built from transactions.
Letting them merge alone would put the types back on different grids, which is what the shared plan
prevents. The band is temporary: once pruning has eaten it, the resume point is back on a top-tier
boundary. Until then the alternative is a silently short file.

The migration could avoid the band by downloading the few decimal transactions files needed to reach
a top-tier boundary. It does not: that would put a network dependency on the startup path and
re-fetch history the operator chose to delete.

## A datadir missing a block type is refused

If any type has no segments, the node cannot open block segments at all. Converting would move the
breakage rather than fix it, so the migration stops and says which type is missing.

## Rollout

Epoch files must be published before new binaries can bootstrap from snapshots. Given today's
manifest a new binary requests no block segments at all, because the grid filter drops every decimal
entry. Old binaries reading a manifest that contains epoch entries drop them through the existing
type filter and sync from the decimal set as usual, so one manifest can serve both.

## Testing

**Upgrading a real pruned node (hoodi).**

```
old binary   download 53.8GB (blocks + state), catch up to the tip with Caplin
             => ordinary pruned node: headers/bodies from 0, transactions from 3,200,000

new binary   migrate on start
             => 39 decimal segments converted, transactions resume at 3,211,264,
                every transactions range has a bodies range identical to it,
                no decimal segments left

             keep following the chain
             => new segments appear above the migration boundary, then eight of them
                merge across it into one 8192 segment, indexes and torrent included
```

**Localnet.**

- Two nodes, BitTorrent only. The publisher seeds; a second node with an empty datadir, no
  `.torrent` files and no webseed pulls 1.2GB from it, gets the metadata from the peer, rebuilds its
  indexes, serves identical block data, and then seeds it onward.
- The same publish step over an HTTP webseed: a fresh node downloads, rebuilds indexes, and every
  file matches the publisher byte for byte.
- A 6213-entry manifest mixing the published decimal set with epoch entries: the new binary requests
  only the epoch ones and downloads all four tiers.
- That same manifest given to the current release binary: it drops the 24 epoch entries and starts
  normally.

## Known open items

- **Mainnet scale.** Migration duration, peak memory, temp space and crash recovery are untested at
  mainnet size.
- **Long runs.** Continuous freezing, merging and pruning over days has not been exercised.
- **Aura chains.** Gnosis and Chiado are meant to be untouched by all of this, and the tests say so,
  but neither has been run for real.
- **Rollback.** The migration is one-way and older binaries cannot read `-ep` files. This needs
  either a down-migration tool or a clear note in the release.

## Known limitations

- The sub-1024 tail is held in memory until one commit. At current mainnet block sizes that is
  around 210 MB.
- Decimal segments above `frozenMax`, or above a gap, are dropped rather than converted. Each one is
  logged.
