### PR TITLE
execution/vm: grow EVM memory in pages, then double

### DIFF
--- a/execution/vm/memory.go
+++ b/execution/vm/memory.go
@@ -116,20 +116,13 @@ func (m *Memory) Resize(size uint64) {
 		return
 	}
 
-	newCap := uint64(cap(m.store)) * 2
-	if newCap < size {
-		newCap = alignUpToPage(size)
-	}
-	store := make([]byte, size, newCap)
+	store := make([]byte, size, max(uint64(cap(m.store))*2, alignUpToPage(size)))
 	copy(store, m.store)
 	m.store = store
 }
 
 func alignUpToPage(n uint64) uint64 {
-	if aligned := (n + memoryPageSize - 1) &^ uint64(memoryPageSize-1); aligned >= n {
-		return aligned
-	}
-	return n
+	return (n + memoryPageSize - 1) &^ uint64(memoryPageSize-1)
 }
 
 func (m *Memory) reset() {

--- a/execution/vm/memory.go
+++ b/execution/vm/memory.go
@@ -96,12 +96,13 @@ func (m *Memory) Set32(offset uint64, val *uint256.Int) {
 	val.PutUint256(m.store[offset:])
 }
 
-// memoryPageSize - Resize rounds capacity up to whole pages and then doubles it,
-// like evmone and revm. Plain append walks a ~1.25x ladder instead, so a frame
-// growing word by word from cold pays ~10 reallocations to reach 4 KiB.
+// memoryPageSize is a growth quantum, not an OS page: 4 KiB is where evmone and
+// revm start a frame.
 const memoryPageSize = 4 * 1024
 
-// Resize resizes the memory to size
+// Resize resizes the memory to size. Capacity doubles, falling back to a whole
+// memoryPageSize multiple when doubling is not enough; plain append walks a
+// ~1.25x ladder instead and pays an allocation per step.
 func (m *Memory) Resize(size uint64) {
 	currLen := uint64(len(m.store))
 	if size <= currLen {
@@ -125,7 +126,10 @@ func (m *Memory) Resize(size uint64) {
 }
 
 func alignUpToPage(n uint64) uint64 {
-	return (n + memoryPageSize - 1) &^ uint64(memoryPageSize-1)
+	if aligned := (n + memoryPageSize - 1) &^ uint64(memoryPageSize-1); aligned >= n {
+		return aligned
+	}
+	return n
 }
 
 func (m *Memory) reset() {

--- a/execution/vm/memory.go
+++ b/execution/vm/memory.go
@@ -96,8 +96,10 @@ func (m *Memory) Set32(offset uint64, val *uint256.Int) {
 	val.PutUint256(m.store[offset:])
 }
 
-// zeroes - pre-allocated zeroes for Resize()
-var zeroes = make([]byte, 4*4096)
+// memoryPageSize - Resize rounds capacity up to whole pages and then doubles it,
+// like evmone and revm. Plain append walks a ~1.25x ladder instead, so a frame
+// growing word by word from cold pays ~10 reallocations to reach 4 KiB.
+const memoryPageSize = 4 * 1024
 
 // Resize resizes the memory to size
 func (m *Memory) Resize(size uint64) {
@@ -113,13 +115,13 @@ func (m *Memory) Resize(size uint64) {
 		return
 	}
 
-	grow := size - currLen
-	if grow <= uint64(len(zeroes)) {
-		m.store = append(m.store, zeroes[:grow]...)
-		return
+	newCap := uint64(cap(m.store)) * 2
+	if newCap < size {
+		newCap = (size + memoryPageSize - 1) &^ uint64(memoryPageSize-1)
 	}
-
-	m.store = append(m.store, make([]byte, grow)...)
+	store := make([]byte, size, newCap)
+	copy(store, m.store)
+	m.store = store
 }
 
 func (m *Memory) reset() {

--- a/execution/vm/memory.go
+++ b/execution/vm/memory.go
@@ -117,11 +117,15 @@ func (m *Memory) Resize(size uint64) {
 
 	newCap := uint64(cap(m.store)) * 2
 	if newCap < size {
-		newCap = (size + memoryPageSize - 1) &^ uint64(memoryPageSize-1)
+		newCap = alignUpToPage(size)
 	}
 	store := make([]byte, size, newCap)
 	copy(store, m.store)
 	m.store = store
+}
+
+func alignUpToPage(n uint64) uint64 {
+	return (n + memoryPageSize - 1) &^ uint64(memoryPageSize-1)
 }
 
 func (m *Memory) reset() {

--- a/execution/vm/memory_test.go
+++ b/execution/vm/memory_test.go
@@ -86,6 +86,37 @@ func TestMemoryCopy(t *testing.T) {
 	}
 }
 
+// TestMemoryResizeZeroesReusedBuffer pins the fast path Resize takes once a
+// pooled buffer is warm: a frame must not see the previous frame's bytes.
+func TestMemoryResizeZeroesReusedBuffer(t *testing.T) {
+	t.Parallel()
+	m := NewMemory()
+	m.Resize(64)
+	for i := range m.store {
+		m.store[i] = 0xFF
+	}
+	m.reset()
+
+	m.Resize(64)
+	if want := make([]byte, 64); !bytes.Equal(m.store, want) {
+		t.Fatalf("reused buffer not zeroed: %#x", m.store)
+	}
+}
+
+func TestMemoryResizeCapacity(t *testing.T) {
+	t.Parallel()
+	m := NewMemory()
+	m.Resize(32)
+	if got := cap(m.store); got != memoryPageSize {
+		t.Fatalf("cold resize to 32: cap %d, want %d", got, memoryPageSize)
+	}
+
+	m.Resize(memoryPageSize + 32)
+	if got := cap(m.store); got != 2*memoryPageSize {
+		t.Fatalf("grow past one page: cap %d, want %d", got, 2*memoryPageSize)
+	}
+}
+
 func BenchmarkResize(b *testing.B) {
 	memory := NewMemory()
 	var i uint64

--- a/execution/vm/memory_test.go
+++ b/execution/vm/memory_test.go
@@ -86,11 +86,11 @@ func TestMemoryCopy(t *testing.T) {
 	}
 }
 
-// TestMemoryResizeZeroesReusedBuffer pins the fast path Resize takes once a
-// pooled buffer is warm: a frame must not see the previous frame's bytes.
+// TestMemoryResizeZeroesReusedBuffer pins the fast path Resize takes once the
+// buffer is warm: a frame must not see the previous frame's bytes.
 func TestMemoryResizeZeroesReusedBuffer(t *testing.T) {
 	t.Parallel()
-	m := NewMemory()
+	var m Memory
 	m.Resize(64)
 	for i := range m.store {
 		m.store[i] = 0xFF
@@ -105,7 +105,7 @@ func TestMemoryResizeZeroesReusedBuffer(t *testing.T) {
 
 func TestMemoryResizeCapacity(t *testing.T) {
 	t.Parallel()
-	m := NewMemory()
+	var m Memory
 	m.Resize(32)
 	if got := cap(m.store); got != memoryPageSize {
 		t.Fatalf("cold resize to 32: cap %d, want %d", got, memoryPageSize)
@@ -114,6 +114,12 @@ func TestMemoryResizeCapacity(t *testing.T) {
 	m.Resize(memoryPageSize + 32)
 	if got := cap(m.store); got != 2*memoryPageSize {
 		t.Fatalf("grow past one page: cap %d, want %d", got, 2*memoryPageSize)
+	}
+
+	// Doubling wins over page alignment here: align-only would give 3 pages.
+	m.Resize(2*memoryPageSize + 32)
+	if got := cap(m.store); got != 4*memoryPageSize {
+		t.Fatalf("grow past two pages: cap %d, want %d", got, 4*memoryPageSize)
 	}
 }
 

--- a/execution/vm/memory_test.go
+++ b/execution/vm/memory_test.go
@@ -18,6 +18,7 @@ package vm
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -91,5 +92,21 @@ func BenchmarkResize(b *testing.B) {
 	for b.Loop() {
 		memory.Resize(i)
 		i++
+	}
+}
+
+// BenchmarkResizeCold grows a fresh memory word-by-word, the pattern a call
+// frame sees when it gets a CallContext whose buffer the pool has not warmed.
+func BenchmarkResizeCold(b *testing.B) {
+	for _, target := range []uint64{4 * 1024, 64 * 1024, 1024 * 1024} {
+		b.Run(fmt.Sprintf("%dKiB", target/1024), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				var m Memory
+				for size := uint64(32); size <= target; size += 32 {
+					m.Resize(size)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
`Memory.Resize` appended, so Go's growslice walked its ~1.25x ladder: a cold frame growing word by word paid 10 reallocations to reach 4 KiB and 31 to reach 1 MiB. Now capacity rounds up to a 4 KiB page and doubles from there — the policy evmone and revm use.

n0 (EPYC 4344P, 10 interleaved rounds vs `main`):

```
ResizeCold/4KiB      1463n -> 494n     -66%   10 -> 1 allocs
ResizeCold/64KiB    21.98µ -> 10.85µ   -51%   20 -> 5 allocs
ResizeCold/1024KiB    504µ -> 203µ     -60%   31 -> 9 allocs
```

End-to-end EVM benchmarks are flat (`execution/vm/benchmark` geomean -0.23% sec/op, `execution/vm/runtime` +0.49%, allocs/op unchanged everywhere): each `b.Loop` iteration reuses a pooled `CallContext` whose buffer is already grown, so only the first is cold. `contextPool` is a `sync.Pool` though, so every GC drops the warm buffers and cold recurs in production.

Cost: capacity can reach 2x the bytes used, against ~1.1x before, and a cold frame now allocates a whole 4 KiB even to touch one word. EIP-7825 caps a transaction at 2^24 gas and memory gas is quadratic, so one frame tops out at 2.81 MiB (5.6 MiB of capacity) and a whole call stack at 16.2 MiB, at depth ~84 — past that the 63/64 rule starves deep frames faster than extra frames add memory. In exchange copy volume drops (~2N vs ~5N), and a one-shot large resize rounds to exact pages instead of doubling. The `zeroes` global is gone: `make` returns zeroed memory.

