### PR TITLE
execution/vm: build the trace Version inside the trace guard

### DIFF
--- a/execution/vm/evm.go
+++ b/execution/vm/evm.go
@@ -336,8 +336,8 @@ func (evm *EVM) call(typ OpCode, caller accounts.Address, callerAddress accounts
 		gasUsed.Execution = deriveFrameExecutionGasUsed(inputTotal, gasRemaining.Total(), gasUsed.State)
 	}()
 
-	version := evm.intraBlockState.Version()
 	if (dbg.TraceTransactionIO && !dbg.TraceInstructions) && (evm.intraBlockState.Trace() || dbg.TraceAccount(caller.Handle())) {
+		version := evm.intraBlockState.Version()
 		fmt.Printf("%d (%d.%d) %s: %x %x\n", evm.intraBlockState.BlockNumber(), version.TxIndex, version.Incarnation, typ, addr, input)
 		defer func() {
 			fmt.Printf("%d (%d.%d) RETURN (%s): %x: %x, %d, %v\n", evm.intraBlockState.BlockNumber(), version.TxIndex, version.Incarnation, typ, addr, ret, gasRemaining, err)


### PR DESCRIPTION
`evm.call` built a `Version` on **every** call frame, but the only readers are the two `dbg.TraceTransactionIO` prints right below it — dead work whenever tracing is off, which is always in production.

`Version()` inlines into three field loads plus a 32-byte struct build, so this is small, but it also spends `evm.call`'s inline budget on a debug path.

Found while auditing `EVM.Run` for allocations. No allocation involved — the `fmt.Printf` sites themselves are all correctly guarded, and `BenchmarkSimpleLoop/loop-100M` already reports 0 allocs/op with `dbg.Trace*` off.
