### PR TITLE
docs(site): refresh disk sizes from 2026-08-23 sync

### DIFF
--- a/docs/site/docs/get-started/hardware-requirements.mdx
+++ b/docs/site/docs/get-started/hardware-requirements.mdx
@@ -32,9 +32,9 @@ The amount of disk space recommended and RAM you need depends on the [pruning mo
 | --- | --- | --- | --- | --- |
 | Archive | {/* ds:mainnet:archive */}2.03 TB{/* ds:end */} | 4 TB | 32 GB | 64 GB |
 | Full (Default) | {/* ds:mainnet:full */}419.04 GB{/* ds:end */} | 2 TB | 16 GB | 32 GB |
-| Minimal | {/* ds:mainnet:minimal */}378.97 GB{/* ds:end */} | 1 TB | 16 GB | 64 GB |
+| Minimal | {/* ds:mainnet:minimal */}478.40 GB{/* ds:end */} | 1 TB | 16 GB | 64 GB |
 
-_Current Disk Usage measured as of {/* ds-date:mainnet */}2026-07-19{/* ds:end */}; usage grows over time as the chain grows._
+_Current Disk Usage measured as of {/* ds-date:mainnet */}2026-08-24{/* ds:end */}; usage grows over time as the chain grows._
 
 </TabItem>
 <TabItem value="gnosis-chain" label="Gnosis Chain">
@@ -42,9 +42,9 @@ _Current Disk Usage measured as of {/* ds-date:mainnet */}2026-07-19{/* ds:end *
 | -------------- | ---------------------- | --------------------------- | ------------------ | --------------------- |
 | Archive        | {/* ds:gnosis:archive */}673.59 GB{/* ds:end */} | 1 TB                        | 16 GB              | 32 GB                 |
 | Full (Default) | {/* ds:gnosis:full */}220.10 GB{/* ds:end */}    | 1 TB                        | 8 GB               | 16 GB                 |
-| Minimal        | {/* ds:gnosis:minimal */}204.45 GB{/* ds:end */} | 500 GB                      | 8 GB               | 16 GB                 |
+| Minimal        | {/* ds:gnosis:minimal */}304.67 GB{/* ds:end */} | 500 GB                      | 8 GB               | 16 GB                 |
 
-_Current Disk Usage measured as of {/* ds-date:gnosis */}2026-07-21{/* ds:end */}; usage grows over time as the chain grows._
+_Current Disk Usage measured as of {/* ds-date:gnosis */}2026-08-24{/* ds:end */}; usage grows over time as the chain grows._
 </TabItem>
 <TabItem value="sepolia" label="Sepolia">
 | **Pruning Mode** | **Current Disk Usage** |

--- a/docs/site/docs/get-started/hardware-requirements.mdx
+++ b/docs/site/docs/get-started/hardware-requirements.mdx
@@ -34,7 +34,7 @@ The amount of disk space recommended and RAM you need depends on the [pruning mo
 | Full (Default) | {/* ds:mainnet:full */}419.04 GB{/* ds:end */} | 2 TB | 16 GB | 32 GB |
 | Minimal | {/* ds:mainnet:minimal */}478.40 GB{/* ds:end */} | 1 TB | 16 GB | 64 GB |
 
-_Current Disk Usage measured as of {/* ds-date:mainnet */}2026-08-24{/* ds:end */}; usage grows over time as the chain grows._
+_Current Disk Usage measured as of {/* ds-date:mainnet */}2026-07-19{/* ds:end */}; usage grows over time as the chain grows._
 
 </TabItem>
 <TabItem value="gnosis-chain" label="Gnosis Chain">
@@ -44,7 +44,7 @@ _Current Disk Usage measured as of {/* ds-date:mainnet */}2026-08-24{/* ds:end *
 | Full (Default) | {/* ds:gnosis:full */}220.10 GB{/* ds:end */}    | 1 TB                        | 8 GB               | 16 GB                 |
 | Minimal        | {/* ds:gnosis:minimal */}304.67 GB{/* ds:end */} | 500 GB                      | 8 GB               | 16 GB                 |
 
-_Current Disk Usage measured as of {/* ds-date:gnosis */}2026-08-24{/* ds:end */}; usage grows over time as the chain grows._
+_Current Disk Usage measured as of {/* ds-date:gnosis */}2026-07-21{/* ds:end */}; usage grows over time as the chain grows._
 </TabItem>
 <TabItem value="sepolia" label="Sepolia">
 | **Pruning Mode** | **Current Disk Usage** |

--- a/docs/site/src/data/disk-sizes.json
+++ b/docs/site/src/data/disk-sizes.json
@@ -1,5 +1,5 @@
 {
-  "ci_last_updated": "2026-07-29",
+  "ci_last_updated": "2026-08-24",
   "networks": {
     "mainnet": {
       "archive": {
@@ -15,10 +15,10 @@
         "source": "manual"
       },
       "minimal": {
-        "bytes": 378972109206,
-        "display": "378.97 GB",
-        "measured_at": "2026-07-19",
-        "source": "manual"
+        "bytes": 478402613248,
+        "display": "478.40 GB",
+        "measured_at": "2026-08-24",
+        "source": "ci"
       }
     },
     "gnosis": {
@@ -35,10 +35,10 @@
         "source": "manual"
       },
       "minimal": {
-        "bytes": 204449318751,
-        "display": "204.45 GB",
-        "measured_at": "2026-07-21",
-        "source": "manual"
+        "bytes": 304668426240,
+        "display": "304.67 GB",
+        "measured_at": "2026-08-24",
+        "source": "ci"
       }
     },
     "sepolia": {

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -73,7 +73,7 @@ The amount of disk space recommended and RAM you need depends on the [pruning mo
 | Full (Default) | 419.04 GB | 2 TB | 16 GB | 32 GB |
 | Minimal | 478.40 GB | 1 TB | 16 GB | 64 GB |
 
-_Current Disk Usage measured as of 2026-08-24; usage grows over time as the chain grows._
+_Current Disk Usage measured as of 2026-07-19; usage grows over time as the chain grows._
 
 | **Pruning Mode**  | **Current Disk Usage** | **Disk Size (Recommended)** | **RAM (Required)** | **RAM (Recommended)** |
 | -------------- | ---------------------- | --------------------------- | ------------------ | --------------------- |
@@ -81,7 +81,7 @@ _Current Disk Usage measured as of 2026-08-24; usage grows over time as the chai
 | Full (Default) | 220.10 GB    | 1 TB                        | 8 GB               | 16 GB                 |
 | Minimal        | 304.67 GB | 500 GB                      | 8 GB               | 16 GB                 |
 
-_Current Disk Usage measured as of 2026-08-24; usage grows over time as the chain grows._
+_Current Disk Usage measured as of 2026-07-21; usage grows over time as the chain grows._
 
 | **Pruning Mode** | **Current Disk Usage** |
 | -------------- | ---------------------- |

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -71,17 +71,17 @@ The amount of disk space recommended and RAM you need depends on the [pruning mo
 | --- | --- | --- | --- | --- |
 | Archive | 2.03 TB | 4 TB | 32 GB | 64 GB |
 | Full (Default) | 419.04 GB | 2 TB | 16 GB | 32 GB |
-| Minimal | 378.97 GB | 1 TB | 16 GB | 64 GB |
+| Minimal | 478.40 GB | 1 TB | 16 GB | 64 GB |
 
-_Current Disk Usage measured as of 2026-07-19; usage grows over time as the chain grows._
+_Current Disk Usage measured as of 2026-08-24; usage grows over time as the chain grows._
 
 | **Pruning Mode**  | **Current Disk Usage** | **Disk Size (Recommended)** | **RAM (Required)** | **RAM (Recommended)** |
 | -------------- | ---------------------- | --------------------------- | ------------------ | --------------------- |
 | Archive        | 673.59 GB | 1 TB                        | 16 GB              | 32 GB                 |
 | Full (Default) | 220.10 GB    | 1 TB                        | 8 GB               | 16 GB                 |
-| Minimal        | 204.45 GB | 500 GB                      | 8 GB               | 16 GB                 |
+| Minimal        | 304.67 GB | 500 GB                      | 8 GB               | 16 GB                 |
 
-_Current Disk Usage measured as of 2026-07-21; usage grows over time as the chain grows._
+_Current Disk Usage measured as of 2026-08-24; usage grows over time as the chain grows._
 
 | **Pruning Mode** | **Current Disk Usage** |
 | -------------- | ---------------------- |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -73,7 +73,7 @@ The amount of disk space recommended and RAM you need depends on the [pruning mo
 | Full (Default) | 419.04 GB | 2 TB | 16 GB | 32 GB |
 | Minimal | 478.40 GB | 1 TB | 16 GB | 64 GB |
 
-_Current Disk Usage measured as of 2026-08-24; usage grows over time as the chain grows._
+_Current Disk Usage measured as of 2026-07-19; usage grows over time as the chain grows._
 
 | **Pruning Mode**  | **Current Disk Usage** | **Disk Size (Recommended)** | **RAM (Required)** | **RAM (Recommended)** |
 | -------------- | ---------------------- | --------------------------- | ------------------ | --------------------- |
@@ -81,7 +81,7 @@ _Current Disk Usage measured as of 2026-08-24; usage grows over time as the chai
 | Full (Default) | 220.10 GB    | 1 TB                        | 8 GB               | 16 GB                 |
 | Minimal        | 304.67 GB | 500 GB                      | 8 GB               | 16 GB                 |
 
-_Current Disk Usage measured as of 2026-08-24; usage grows over time as the chain grows._
+_Current Disk Usage measured as of 2026-07-21; usage grows over time as the chain grows._
 
 | **Pruning Mode** | **Current Disk Usage** |
 | -------------- | ---------------------- |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -71,17 +71,17 @@ The amount of disk space recommended and RAM you need depends on the [pruning mo
 | --- | --- | --- | --- | --- |
 | Archive | 2.03 TB | 4 TB | 32 GB | 64 GB |
 | Full (Default) | 419.04 GB | 2 TB | 16 GB | 32 GB |
-| Minimal | 378.97 GB | 1 TB | 16 GB | 64 GB |
+| Minimal | 478.40 GB | 1 TB | 16 GB | 64 GB |
 
-_Current Disk Usage measured as of 2026-07-19; usage grows over time as the chain grows._
+_Current Disk Usage measured as of 2026-08-24; usage grows over time as the chain grows._
 
 | **Pruning Mode**  | **Current Disk Usage** | **Disk Size (Recommended)** | **RAM (Required)** | **RAM (Recommended)** |
 | -------------- | ---------------------- | --------------------------- | ------------------ | --------------------- |
 | Archive        | 673.59 GB | 1 TB                        | 16 GB              | 32 GB                 |
 | Full (Default) | 220.10 GB    | 1 TB                        | 8 GB               | 16 GB                 |
-| Minimal        | 204.45 GB | 500 GB                      | 8 GB               | 16 GB                 |
+| Minimal        | 304.67 GB | 500 GB                      | 8 GB               | 16 GB                 |
 
-_Current Disk Usage measured as of 2026-07-21; usage grows over time as the chain grows._
+_Current Disk Usage measured as of 2026-08-24; usage grows over time as the chain grows._
 
 | **Pruning Mode** | **Current Disk Usage** |
 | -------------- | ---------------------- |


### PR DESCRIPTION
## Summary
- Refresh `docs/site/src/data/disk-sizes.json` from the latest successful minimal QA sync run on 2026-08-23.
- Re-render `docs/site/docs/get-started/hardware-requirements.mdx` so the static markers match the JSON.
- Regenerate the llms artifacts after the docs page change.

## Verification
- `python3 docs/site/scripts/update-disk-sizes.py ... minimal`
- `python3 docs/site/scripts/render-disk-sizes.py --check`
- `python3 docs/site/scripts/generate-llms.py --check`
- `npm run build`

## Notes
- Updated mainnet minimal and Gnosis minimal disk-usage figures only.
- No other docs pages changed.
