### PR TITLE
execution/stagedsync: split nextResult's tail segment into finalize/send/flush

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -3519,6 +3519,8 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 			}
 		}
 
+		segs.mark("finalize")
+
 		{
 			prStarted := time.Now()
 			defer func() {
@@ -3556,10 +3558,14 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 			}
 		}
 
+		segs.mark("finalizeSend")
+
 		// Flush block state cache to sd.mem — all writes (per-TX + finalize) are now visible.
 		if err := be.blockStateCache.Flush(pe.rs.Domains(), applyTx); err != nil {
 			return nil, err
 		}
+
+		segs.mark("cacheFlush")
 
 		be.result = &blockResult{
 			Block:            be.block,


### PR DESCRIPTION
## Summary
- `"[dbg] slow nextResult"`'s `tail` timing bucket silently covered everything from the `publish` mark to function return, folding `engine.Finalize`+`Normalize`+`ApplyStateWrites`, the finalize `sendResult`, and `BlockStateCache.Flush` into one number.
- Adds three marks (`finalize`, `finalizeSend`, `cacheFlush`) so a slow block-finalize call can be attributed to the right phase instead of guessing.
- Verified live on n5: a 200ms slow-nextResult instance now shows `cacheFlush=200.1ms` with the other marks in the low-µs range, pinning it to `BlockStateCache.Flush`'s `latestStateLock` contention rather than `Finalize`/`Normalize`.