### PR TITLE
db/state: split TemporalMemBatch latestStateLock into per-domain mutexes

### DIFF
--- a/db/state/temporal_mem_batch.go
+++ b/db/state/temporal_mem_batch.go
@@ -44,10 +44,13 @@ type dataWithTxNum struct {
 	txNum uint64
 }
 
-// Sized to a cache-line multiple so neighboring per-domain locks don't false-share.
+// Prevents false sharing between neighboring per-domain locks on widespread
+// platforms with 128 mod (cache line size) = 0 — the sync.Pool poolLocal pad
+// pattern. The 128-byte stride keeps lock bodies off a shared 64-byte line
+// for any base alignment of the array.
 type paddedRWMutex struct {
 	sync.RWMutex
-	_ [64 - unsafe.Sizeof(sync.RWMutex{})%64]byte
+	_ [128 - unsafe.Sizeof(sync.RWMutex{})%128]byte
 }
 
 // TemporalMemBatch - temporal read-write interface - which storing updates in RAM. Don't forget to call `.Flush()`

--- a/db/state/temporal_mem_batch.go
+++ b/db/state/temporal_mem_batch.go
@@ -43,6 +43,12 @@ type dataWithTxNum struct {
 	txNum uint64
 }
 
+// Padded to a cache line so per-domain locks don't false-share.
+type paddedRWMutex struct {
+	sync.RWMutex
+	_ [40]byte
+}
+
 // TemporalMemBatch - temporal read-write interface - which storing updates in RAM. Don't forget to call `.Flush()`
 type TemporalMemBatch struct {
 	stepSize uint64
@@ -53,9 +59,9 @@ type TemporalMemBatch struct {
 	// Disable for offline commands (stage_exec etc.) — history reads come from disk anyway.
 	inMemHistoryReads bool
 
-	latestStateLock sync.RWMutex
-	domains         [kv.DomainLen]map[string][]dataWithTxNum
-	storage         *btree2.Map[string, []dataWithTxNum] // TODO: replace hardcoded domain name to per-config configuration of available Guarantees/AccessMethods (range vs get)
+	latestStateLocks [kv.DomainLen]paddedRWMutex
+	domains          [kv.DomainLen]map[string][]dataWithTxNum
+	storage          *btree2.Map[string, []dataWithTxNum] // TODO: replace hardcoded domain name to per-config configuration of available Guarantees/AccessMethods (range vs get)
 
 	domainWriters [kv.DomainLen]*DomainBufferedWriter
 	iiWriters     []*InvertedIndexBufferedWriter
@@ -116,6 +122,18 @@ func NewTemporalMemBatch(tx kv.TemporalTx, ioMetrics any) *TemporalMemBatch {
 func (sd *TemporalMemBatch) SetInMemHistoryReads(v bool) { sd.inMemHistoryReads = v }
 func (sd *TemporalMemBatch) InMemHistoryReads() bool     { return sd.inMemHistoryReads }
 
+func (sd *TemporalMemBatch) lockAllDomains() {
+	for i := range sd.latestStateLocks {
+		sd.latestStateLocks[i].Lock()
+	}
+}
+
+func (sd *TemporalMemBatch) unlockAllDomains() {
+	for i := range sd.latestStateLocks {
+		sd.latestStateLocks[i].Unlock()
+	}
+}
+
 func (sd *TemporalMemBatch) DomainPut(domain kv.Domain, k string, v []byte, txNum uint64, preval []byte) error {
 	sameTxNumUpdate := sd.putLatest(domain, k, v, txNum)
 	return sd.putHistory(domain, common.ToBytesZeroCopy(k), v, txNum, preval, sameTxNumUpdate)
@@ -142,8 +160,8 @@ func (sd *TemporalMemBatch) putHistory(domain kv.Domain, k, v []byte, txNum uint
 // putLatest reports whether this write is a same-txNum update of the key,
 // replacing the key's last entry in place instead of appending a version.
 func (sd *TemporalMemBatch) putLatest(domain kv.Domain, key string, val []byte, txNum uint64) (sameTxNumUpdate bool) {
-	sd.latestStateLock.Lock()
-	defer sd.latestStateLock.Unlock()
+	sd.latestStateLocks[domain].Lock()
+	defer sd.latestStateLocks[domain].Unlock()
 
 	var updateMetrics = func(domain kv.Domain, putKeySize int, putValueSize int) {
 		sd.metrics.Lock()
@@ -224,13 +242,13 @@ func (sd *TemporalMemBatch) putLatest(domain kv.Domain, key string, val []byte, 
 }
 
 func (sd *TemporalMemBatch) GetLatest(domain kv.Domain, key []byte) (v []byte, step kv.Step, ok bool) {
-	sd.latestStateLock.RLock()
-	defer sd.latestStateLock.RUnlock()
+	sd.latestStateLocks[domain].RLock()
+	defer sd.latestStateLocks[domain].RUnlock()
 	return sd.getLatest(domain, key)
 }
 
 // getLatest is the lock-free implementation of GetLatest.
-// The caller must already hold latestStateLock (either RLock or Lock),
+// The caller must already hold the domain's lock (either RLock or Lock),
 // e.g. from within an IteratePrefix callback.
 func (sd *TemporalMemBatch) getLatest(domain kv.Domain, key []byte) (v []byte, step kv.Step, ok bool) {
 	var unwoundLatest = func(domain kv.Domain, key string) (v []byte, step kv.Step, ok bool) {
@@ -280,8 +298,8 @@ func (sd *TemporalMemBatch) GetAsOf(domain kv.Domain, key []byte, ts uint64) (v 
 	if !sd.inMemHistoryReads && domain != kv.ReceiptDomain {
 		return nil, false, errors.New("GetAsOf called on TemporalMemBatch with inMemHistoryReads disabled")
 	}
-	sd.latestStateLock.RLock()
-	defer sd.latestStateLock.RUnlock()
+	sd.latestStateLocks[domain].RLock()
+	defer sd.latestStateLocks[domain].RUnlock()
 
 	// unwoundLatest returns the pre-unwound-block value for a key that was
 	// modified by the unwound block. Only fires when ts is at-or-after the
@@ -346,15 +364,15 @@ func (sd *TemporalMemBatch) SizeEstimate() uint64 {
 	// CachePutSize is guarded by the metrics lock — the put path, Merge and the
 	// reset all mutate it under sd.metrics.Lock(), and MergeMetrics folds in a
 	// boundary worker's accumulator from another goroutine. Read under the same
-	// lock (not latestStateLock, which guards the domains map, not this counter).
+	// lock (not the domain locks, which guard the domains maps, not this counter).
 	sd.metrics.RLock()
 	defer sd.metrics.RUnlock()
 	return uint64(sd.metrics.CachePutSize)
 }
 
 func (sd *TemporalMemBatch) IteratePrefix(domain kv.Domain, prefix []byte, roTx kv.Tx, it func(k []byte, v []byte) (cont bool, err error)) error {
-	sd.latestStateLock.RLock()
-	defer sd.latestStateLock.RUnlock()
+	sd.latestStateLocks[domain].RLock()
+	defer sd.latestStateLocks[domain].RUnlock()
 	var ramIter btree2.MapIter[string, []dataWithTxNum]
 	if domain == kv.StorageDomain {
 		ramIter = sd.storage.Iter()
@@ -410,8 +428,8 @@ func (sd *TemporalMemBatch) HasPrefix(domain kv.Domain, prefix []byte, roTx kv.T
 // for the given domain whose key starts with prefix.  It never touches disk or
 // segment files — only the in-memory btree (StorageDomain) or the domain map.
 func (sd *TemporalMemBatch) HasPrefixInRAM(domain kv.Domain, prefix []byte) bool {
-	sd.latestStateLock.RLock()
-	defer sd.latestStateLock.RUnlock()
+	sd.latestStateLocks[domain].RLock()
+	defer sd.latestStateLocks[domain].RUnlock()
 
 	if domain == kv.StorageDomain {
 		prefixStr := common.ToStringZeroCopy(prefix)
@@ -535,8 +553,8 @@ func (sd *TemporalMemBatch) GetDiffset(tx kv.RwTx, blockHash common.Hash, blockN
 
 // Unwind drops [unwindToTxNum, ∞)
 func (sd *TemporalMemBatch) Unwind(unwindToTxNum uint64, changeset *[kv.DomainLen][]kv.DomainEntryDiff) {
-	sd.latestStateLock.Lock()
-	defer sd.latestStateLock.Unlock()
+	sd.lockAllDomains()
+	defer sd.unlockAllDomains()
 
 	sd.unwindToTxNum = unwindToTxNum
 
@@ -745,7 +763,7 @@ func (sd *TemporalMemBatch) Merge(o kv.TemporalMemBatch) error {
 }
 
 // flushLocked is the body of Flush, factored so the callback path can run it
-// inside latestStateLock without re-acquiring. PlainStateVersion advances here
+// holding all domain locks without re-acquiring. PlainStateVersion advances here
 // with the domain writes; metadata overlays must not advance it independently.
 func (sd *TemporalMemBatch) flushLocked(ctx context.Context, tx kv.RwTx) error {
 	if sd.unwindChangesetRaw != nil {
@@ -773,11 +791,11 @@ func (sd *TemporalMemBatch) flushLocked(ctx context.Context, tx kv.RwTx) error {
 // Flush writes the mem-batch to tx. With kv.WithFlushCallback options, the
 // registered per-domain callback is invoked for every (key, value, step, txNum)
 // tuple after the MDBX write succeeds, so a downstream cache can never be left
-// ahead of MDBX. Runs under latestStateLock so the callback's snapshot matches
+// ahead of MDBX. Runs under all domain locks so the callback's snapshot matches
 // flush-time state.
 func (sd *TemporalMemBatch) Flush(ctx context.Context, tx kv.RwTx, opts ...kv.FlushOption) error {
-	sd.latestStateLock.Lock()
-	defer sd.latestStateLock.Unlock()
+	sd.lockAllDomains()
+	defer sd.unlockAllDomains()
 
 	if err := sd.flushLocked(ctx, tx); err != nil {
 		return err
@@ -819,8 +837,8 @@ func (sd *TemporalMemBatch) Flush(ctx context.Context, tx kv.RwTx, opts ...kv.Fl
 // FlushWithCommitmentCallback flushes the batch then invokes cb per
 // commitment-domain tuple under the lock.
 func (sd *TemporalMemBatch) FlushWithCommitmentCallback(ctx context.Context, tx kv.RwTx, cb execctx.CommitmentFlushCallback) error {
-	sd.latestStateLock.Lock()
-	defer sd.latestStateLock.Unlock()
+	sd.lockAllDomains()
+	defer sd.unlockAllDomains()
 
 	if err := sd.flushLocked(ctx, tx); err != nil {
 		return err

--- a/db/state/temporal_mem_batch.go
+++ b/db/state/temporal_mem_batch.go
@@ -27,6 +27,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"unsafe"
 
 	btree2 "github.com/tidwall/btree"
 
@@ -43,10 +44,10 @@ type dataWithTxNum struct {
 	txNum uint64
 }
 
-// Padded to a cache line so per-domain locks don't false-share.
+// Sized to a cache-line multiple so neighboring per-domain locks don't false-share.
 type paddedRWMutex struct {
 	sync.RWMutex
-	_ [40]byte
+	_ [64 - unsafe.Sizeof(sync.RWMutex{})%64]byte
 }
 
 // TemporalMemBatch - temporal read-write interface - which storing updates in RAM. Don't forget to call `.Flush()`

--- a/db/state/temporal_mem_batch_test.go
+++ b/db/state/temporal_mem_batch_test.go
@@ -17,13 +17,18 @@
 package state
 
 import (
+	"fmt"
+	"sync"
 	"testing"
+
+	btree2 "github.com/tidwall/btree"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/state/changeset"
+	"github.com/erigontech/erigon/db/state/kvmetrics"
 )
 
 // A reorg unwind restores domain values from the diffset, so a domain missing
@@ -43,5 +48,63 @@ func TestGetDiffsetCoversAllDomains(t *testing.T) {
 	require.True(t, ok)
 	for d := range kv.DomainLen {
 		require.NotEmpty(t, diffs[d], "domain %s missing from GetDiffset", d)
+	}
+}
+
+// Pins the locking contract of the per-domain latestStateLocks: readers and
+// writers of different domains run concurrently while Unwind takes every
+// lock. Meaningful under -race; also checks unwind correctness afterwards.
+func TestTemporalMemBatchConcurrentDomainAccess(t *testing.T) {
+	t.Parallel()
+	sd := &TemporalMemBatch{
+		stepSize: 16,
+		storage:  btree2.NewMap[string, []dataWithTxNum](128),
+		metrics:  &kvmetrics.DomainMetrics{Domains: map[kv.Domain]*kvmetrics.DomainIOMetrics{}},
+	}
+	for d := range sd.domains {
+		sd.domains[d] = map[string][]dataWithTxNum{}
+	}
+
+	const keysPerDomain = 200
+	const cutoff = uint64(keysPerDomain / 2)
+	var wg sync.WaitGroup
+	for d := range kv.DomainLen {
+		domain := kv.Domain(d)
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for i := range keysPerDomain {
+				key := fmt.Sprintf("%s-%03d", domain, i)
+				sd.putLatest(domain, key, []byte(key), uint64(i))
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for i := range keysPerDomain {
+				key := fmt.Sprintf("%s-%03d", domain, i)
+				if v, _, ok := sd.GetLatest(domain, []byte(key)); ok && string(v) != key {
+					t.Errorf("domain %s key %s: got %q", domain, key, v)
+				}
+				sd.HasPrefixInRAM(domain, []byte(key))
+			}
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range 50 {
+			sd.Unwind(cutoff, nil)
+		}
+	}()
+	wg.Wait()
+
+	sd.Unwind(cutoff, nil)
+	for d := range kv.DomainLen {
+		domain := kv.Domain(d)
+		for i := range keysPerDomain {
+			key := fmt.Sprintf("%s-%03d", domain, i)
+			_, _, ok := sd.GetLatest(domain, []byte(key))
+			require.Equal(t, uint64(i) < cutoff, ok, "domain %s key %s", domain, key)
+		}
 	}
 }

--- a/db/state/temporal_mem_batch_test.go
+++ b/db/state/temporal_mem_batch_test.go
@@ -70,16 +70,13 @@ func TestTemporalMemBatchConcurrentDomainAccess(t *testing.T) {
 	var wg sync.WaitGroup
 	for d := range kv.DomainLen {
 		domain := kv.Domain(d)
-		wg.Add(2)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for i := range keysPerDomain {
 				key := fmt.Sprintf("%s-%03d", domain, i)
 				sd.putLatest(domain, key, []byte(key), uint64(i))
 			}
-		}()
-		go func() {
-			defer wg.Done()
+		})
+		wg.Go(func() {
 			for i := range keysPerDomain {
 				key := fmt.Sprintf("%s-%03d", domain, i)
 				if v, _, ok := sd.GetLatest(domain, []byte(key)); ok && string(v) != key {
@@ -87,15 +84,13 @@ func TestTemporalMemBatchConcurrentDomainAccess(t *testing.T) {
 				}
 				sd.HasPrefixInRAM(domain, []byte(key))
 			}
-		}()
+		})
 	}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for range 50 {
 			sd.Unwind(cutoff, nil)
 		}
-	}()
+	})
 	wg.Wait()
 
 	sd.Unwind(cutoff, nil)


### PR DESCRIPTION
Split `TemporalMemBatch.latestStateLock` into per-domain mutexes

