### PR TITLE
execution, node: test RPC state across unwind phases

### DIFF
--- a/execution/engineapi/engine_api_rpc_unwind_test.go
+++ b/execution/engineapi/engine_api_rpc_unwind_test.go
@@ -176,12 +176,31 @@ func TestEngineApiRPCStateAcrossUnwindPhases(t *testing.T) {
 		require.NotEmpty(t, awaitAsync(t, delayedCode))
 		require.NotZero(t, awaitAsync(t, delayedNonce))
 
-		// The first read may refill StateCache; the second proves that any refill
-		// remains canonical after delayed old-view reads finish.
+		cacheProbeHead, err := eat.MockCl.BuildNewPayload(ctx)
+		require.NoError(t, err)
+		status, err = eat.MockCl.InsertNewPayload(ctx, cacheProbeHead)
+		require.NoError(t, err)
+		require.Equal(t, enginetypes.ValidStatus, status.Status)
+
+		cacheProbeOverlay := transitions.hold(t, execmodule.StateTransitionOverlayPublished, 1)
+		cacheProbeCleared := transitions.hold(t, execmodule.StateTransitionOverlayCleared, 1)
+		advanceToCacheProbe := startAsync(&asyncCalls, func() (struct{}, error) {
+			return struct{}{}, eat.MockCl.UpdateForkChoice(ctx, cacheProbeHead)
+		})
+		cacheProbeOverlay.wait(t)
+
+		// This fresh overlay has no writes for these keys, so reads exercise the
+		// shared StateCache instead of the replacement overlay or database fallback.
 		for range 2 {
 			assertContractRPCStatePresentWithZeroStorage(t, readContractRPCState(ctx, t, rpcClient, storageRefillAddress, storageSlot))
 			assertContractRPCStateAbsent(t, readContractRPCState(ctx, t, rpcClient, removedAccountAddress, storageSlot))
 		}
+
+		cacheProbeOverlay.release()
+		cacheProbeCleared.wait(t)
+		cacheProbeCleared.release()
+		awaitAsync(t, advanceToCacheProbe)
+		assertCanonicalHead(ctx, t, eat, cacheProbeHead)
 	})
 }
 

--- a/execution/engineapi/engine_api_rpc_unwind_test.go
+++ b/execution/engineapi/engine_api_rpc_unwind_test.go
@@ -43,8 +43,9 @@ import (
 )
 
 const (
-	rpcTransitionTimeout = time.Minute
-	rpcClientTimeout     = 5 * time.Minute
+	rpcTransitionTimeout       = time.Minute
+	rpcClientTimeout           = 10 * rpcTransitionTimeout
+	stateChurnSeed       int64 = 0
 )
 
 func TestEngineApiRPCStateAcrossUnwindPhases(t *testing.T) {
@@ -67,14 +68,14 @@ func TestEngineApiRPCStateAcrossUnwindPhases(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	asyncCalls := newAsyncClientCallGroup()
+	var asyncCalls sync.WaitGroup
 	t.Cleanup(func() {
-		asyncCalls.wait()
+		asyncCalls.Wait()
 		require.NoError(t, eat.Close())
 	})
 
 	eat.Run(t, func(ctx context.Context, t *testing.T, eat engineapitester.EngineApiTester) {
-		seed := firstNonZeroStateChurnSeed()
+		seed := stateChurnSeed
 		// Each boundary gets its own contract because an RPC assertion may fill
 		// StateCache; sharing a key could let one phase mask the next.
 		_, storageRefillAddress, storageRefill, _ := buildChurnChain(ctx, t, eat, 0, nil)
@@ -91,7 +92,7 @@ func TestEngineApiRPCStateAcrossUnwindPhases(t *testing.T) {
 			applyStateChurnPoke(ctx, t, eat, churn, transactOpts, seed)
 		}
 		// This post-target deployment makes account and code removal part of the
-		// unwind, while the earlier contracts exercise restored storage.
+		// unwind, while retained contracts lose their post-target storage writes.
 		_, removedAccountAddress, _, _ := buildChurnChain(ctx, t, eat, 0, nil)
 		storageSlot := stateChurnStorageSlot(0)
 		expectedStorage := common.BigToHash(new(big.Int).SetUint64(stateChurnPokeValue(uint64(seed), 0)))
@@ -118,7 +119,10 @@ func TestEngineApiRPCStateAcrossUnwindPhases(t *testing.T) {
 		require.Equal(t, enginetypes.ValidStatus, status.Status)
 
 		oldHeadOverlay := transitions.hold(t, execmodule.StateTransitionOverlayPublished, 1)
-		advanceToOldHead := startAsync(asyncCalls, func() (struct{}, error) {
+		// An FCU response does not imply teardown completion. Consume this
+		// lifecycle's clear event before reusing the transition point.
+		oldHeadCleared := transitions.hold(t, execmodule.StateTransitionOverlayCleared, 1)
+		advanceToOldHead := startAsync(&asyncCalls, func() (struct{}, error) {
 			return struct{}{}, eat.MockCl.UpdateForkChoice(ctx, oldHead)
 		})
 		oldHeadOverlay.wait(t)
@@ -126,17 +130,19 @@ func TestEngineApiRPCStateAcrossUnwindPhases(t *testing.T) {
 		// These requests stay bound to the old head across the reorg. Their MVCC
 		// reads may finish later, but they must not refill canonical cache entries.
 		preUnwindViews := transitions.hold(t, execmodule.StateTransitionRPCViewBound, 3)
-		delayedStorage := startAsync(asyncCalls, func() (common.Hash, error) {
+		delayedStorage := startAsync(&asyncCalls, func() (common.Hash, error) {
 			return readRPCStorage(ctx, rpcClient, storageRefillAddress, storageSlot)
 		})
-		delayedCode := startAsync(asyncCalls, func() (hexutil.Bytes, error) {
+		delayedCode := startAsync(&asyncCalls, func() (hexutil.Bytes, error) {
 			return readRPCCode(ctx, rpcClient, removedAccountAddress)
 		})
-		delayedNonce := startAsync(asyncCalls, func() (hexutil.Uint64, error) {
+		delayedNonce := startAsync(&asyncCalls, func() (hexutil.Uint64, error) {
 			return readRPCNonce(ctx, rpcClient, removedAccountAddress)
 		})
 		preUnwindViews.wait(t)
 		oldHeadOverlay.release()
+		oldHeadCleared.wait(t)
+		oldHeadCleared.release()
 		awaitAsync(t, advanceToOldHead)
 		assertCanonicalHead(ctx, t, eat, oldHead)
 
@@ -144,7 +150,7 @@ func TestEngineApiRPCStateAcrossUnwindPhases(t *testing.T) {
 		replacementOverlay := transitions.hold(t, execmodule.StateTransitionOverlayPublished, 1)
 		replacementCommitted := transitions.hold(t, execmodule.StateTransitionCommitComplete, 1)
 		replacementCleared := transitions.hold(t, execmodule.StateTransitionOverlayCleared, 1)
-		reorgToTarget := startAsync(asyncCalls, func() (struct{}, error) {
+		reorgToTarget := startAsync(&asyncCalls, func() (struct{}, error) {
 			return struct{}{}, eat.MockCl.UpdateForkChoice(ctx, reorgTarget)
 		})
 
@@ -258,55 +264,14 @@ func stateChurnPokeValue(seed, cursor uint64) uint64 {
 	return new(big.Int).Mod(new(big.Int).SetBytes(hash[:]), big.NewInt(3)).Uint64()
 }
 
-func firstNonZeroStateChurnSeed() int64 {
-	for seed := uint64(0); ; seed++ {
-		if stateChurnPokeValue(seed, 0) != 0 {
-			return int64(seed)
-		}
-	}
-}
-
 type asyncResult[T any] struct {
 	value T
 	err   error
 }
 
-func TestAsyncClientCallGroupDrainsBeforeResourceCleanup(t *testing.T) {
-	finished := make(chan struct{})
-	asyncCalls := newAsyncClientCallGroup()
-	t.Cleanup(func() {
-		asyncCalls.wait()
-		select {
-		case <-finished:
-		default:
-			t.Error("resource cleanup ran before the asynchronous call finished")
-		}
-	})
-
-	startAsync(asyncCalls, func() (struct{}, error) {
-		<-t.Context().Done()
-		close(finished)
-		return struct{}{}, nil
-	})
-}
-
-// asyncClientCallGroup drains test-owned client goroutines before the tester
-// waits for detached server-side forkchoice work.
-type asyncClientCallGroup struct {
-	wg sync.WaitGroup
-}
-
-func newAsyncClientCallGroup() *asyncClientCallGroup {
-	return &asyncClientCallGroup{}
-}
-
-func (g *asyncClientCallGroup) wait() {
-	g.wg.Wait()
-}
-
-func startAsync[T any](group *asyncClientCallGroup, call func() (T, error)) <-chan asyncResult[T] {
+func startAsync[T any](group *sync.WaitGroup, call func() (T, error)) <-chan asyncResult[T] {
 	result := make(chan asyncResult[T], 1)
-	group.wg.Go(func() {
+	group.Go(func() {
 		value, err := call()
 		result <- asyncResult[T]{value: value, err: err}
 	})

--- a/execution/engineapi/engine_api_rpc_unwind_test.go
+++ b/execution/engineapi/engine_api_rpc_unwind_test.go
@@ -64,6 +64,7 @@ func TestEngineApiRPCStateAcrossUnwindPhases(t *testing.T) {
 		CoinbaseKey:             coinbaseKey,
 		EngineApiClientTimeout:  &engineAPIClientTimeout,
 		StateTransitionObserver: transitions.observe,
+		EnableTestingAPI:        true,
 		EthConfigTweaker: func(config *ethconfig.Config) {
 			config.MaxReorgDepth = stateChurnReorgDepthBudget
 		},
@@ -187,8 +188,9 @@ func TestEngineApiRPCStateAcrossUnwindPhases(t *testing.T) {
 		require.NotEmpty(t, awaitAsync(t, delayedCode))
 		require.NotZero(t, awaitAsync(t, delayedNonce))
 
-		cacheProbeHead, err := eat.MockCl.BuildNewPayload(ctx)
+		cacheProbeHead, err := eat.MockCl.BuildEmptyPayload(ctx, rpcClient.CallContext)
 		require.NoError(t, err)
+		require.Empty(t, cacheProbeHead.ExecutionPayload.Transactions)
 		status, err = eat.MockCl.InsertNewPayload(ctx, cacheProbeHead)
 		require.NoError(t, err)
 		require.Equal(t, enginetypes.ValidStatus, status.Status)

--- a/execution/engineapi/engine_api_rpc_unwind_test.go
+++ b/execution/engineapi/engine_api_rpc_unwind_test.go
@@ -73,89 +73,105 @@ func TestEngineApiRPCStateAcrossUnwindPhases(t *testing.T) {
 
 	eat.Run(t, func(ctx context.Context, t *testing.T, eat engineapitester.EngineApiTester) {
 		seed := firstNonZeroStateChurnSeed()
-		_, staleStorageAddress, staleStorage, _ := buildChurnChain(ctx, t, eat, 0, nil)
-		_, overlayReadAddress, overlayRead, _ := buildChurnChain(ctx, t, eat, 0, nil)
-		_, committedReadAddress, committedRead, _ := buildChurnChain(ctx, t, eat, 0, nil)
-		_, clearedReadAddress, clearedRead, _ := buildChurnChain(ctx, t, eat, 0, nil)
-		base, err := eat.MockCl.BuildCanonicalBlock(ctx)
+		// Each boundary gets its own contract because an RPC assertion may fill
+		// StateCache; sharing a key could let one phase mask the next.
+		_, storageRefillAddress, storageRefill, _ := buildChurnChain(ctx, t, eat, 0, nil)
+		_, overlayPhaseAddress, overlayPhase, _ := buildChurnChain(ctx, t, eat, 0, nil)
+		_, commitPhaseAddress, commitPhase, _ := buildChurnChain(ctx, t, eat, 0, nil)
+		_, databasePhaseAddress, databasePhase, _ := buildChurnChain(ctx, t, eat, 0, nil)
+		reorgTarget, err := eat.MockCl.BuildCanonicalBlock(ctx)
 		require.NoError(t, err)
 
-		for _, churn := range []*contracts.StateChurn{staleStorage, overlayRead, committedRead, clearedRead} {
-			applyStateChurnPoke(ctx, t, eat, churn, seed)
+		transactOpts, err := bind.NewKeyedTransactorWithChainID(eat.CoinbaseKey, eat.ChainId())
+		require.NoError(t, err)
+		transactOpts.GasLimit = params.MaxTxnGasLimit
+		for _, churn := range []*contracts.StateChurn{storageRefill, overlayPhase, commitPhase, databasePhase} {
+			applyStateChurnPoke(ctx, t, eat, churn, transactOpts, seed)
 		}
-		_, staleAccountAddress, _, _ := buildChurnChain(ctx, t, eat, 0, nil)
+		// This post-target deployment makes account and code removal part of the
+		// unwind, while the earlier contracts exercise restored storage.
+		_, removedAccountAddress, _, _ := buildChurnChain(ctx, t, eat, 0, nil)
 		storageSlot := stateChurnStorageSlot(0)
 		expectedStorage := common.BigToHash(new(big.Int).SetUint64(stateChurnPokeValue(uint64(seed), 0)))
 
-		rpcClient, err := rpc.DialHTTPWithClient(eat.JsonRpcUrl, &http.Client{Timeout: rpcClientTimeout}, logger)
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		t.Cleanup(transport.CloseIdleConnections)
+		rpcClient, err := rpc.DialHTTPWithClient(
+			eat.JsonRpcUrl,
+			&http.Client{Transport: transport, Timeout: rpcClientTimeout},
+			logger,
+		)
 		require.NoError(t, err)
-		defer rpcClient.Close()
 
-		assertContractRPCStatePresent(t, readContractRPCState(ctx, t, rpcClient, staleStorageAddress, storageSlot), expectedStorage)
-		assertContractRPCStatePresent(t, readContractRPCState(ctx, t, rpcClient, overlayReadAddress, storageSlot), expectedStorage)
-		assertContractRPCStatePresent(t, readContractRPCState(ctx, t, rpcClient, committedReadAddress, storageSlot), expectedStorage)
-		assertContractRPCStatePresent(t, readContractRPCState(ctx, t, rpcClient, clearedReadAddress, storageSlot), expectedStorage)
-		assertContractRPCStateWithoutStorage(t, readContractRPCState(ctx, t, rpcClient, staleAccountAddress, storageSlot))
+		assertContractRPCStatePresentWithStorage(t, readContractRPCState(ctx, t, rpcClient, storageRefillAddress, storageSlot), expectedStorage)
+		assertContractRPCStatePresentWithStorage(t, readContractRPCState(ctx, t, rpcClient, overlayPhaseAddress, storageSlot), expectedStorage)
+		assertContractRPCStatePresentWithStorage(t, readContractRPCState(ctx, t, rpcClient, commitPhaseAddress, storageSlot), expectedStorage)
+		assertContractRPCStatePresentWithStorage(t, readContractRPCState(ctx, t, rpcClient, databasePhaseAddress, storageSlot), expectedStorage)
+		assertContractRPCStatePresentWithZeroStorage(t, readContractRPCState(ctx, t, rpcClient, removedAccountAddress, storageSlot))
 
-		next, err := eat.MockCl.BuildNewPayload(ctx)
+		oldHead, err := eat.MockCl.BuildNewPayload(ctx)
 		require.NoError(t, err)
-		status, err := eat.MockCl.InsertNewPayload(ctx, next)
+		status, err := eat.MockCl.InsertNewPayload(ctx, oldHead)
 		require.NoError(t, err)
 		require.Equal(t, enginetypes.ValidStatus, status.Status)
 
-		overlayA := transitions.hold(t, execmodule.StateTransitionOverlayPublished, 1)
-		advance := startAsync(func() (struct{}, error) {
-			return struct{}{}, eat.MockCl.UpdateForkChoice(ctx, next)
+		oldHeadOverlay := transitions.hold(t, execmodule.StateTransitionOverlayPublished, 1)
+		advanceToOldHead := startAsync(func() (struct{}, error) {
+			return struct{}{}, eat.MockCl.UpdateForkChoice(ctx, oldHead)
 		})
-		overlayA.wait(t)
+		oldHeadOverlay.wait(t)
 
-		oldViews := transitions.hold(t, execmodule.StateTransitionRPCViewBound, 3)
-		oldStorage := startAsync(func() (common.Hash, error) {
-			return readRPCStorage(ctx, rpcClient, staleStorageAddress, storageSlot)
+		// These requests stay bound to the old head across the reorg. Their MVCC
+		// reads may finish later, but they must not refill canonical cache entries.
+		preUnwindViews := transitions.hold(t, execmodule.StateTransitionRPCViewBound, 3)
+		delayedStorage := startAsync(func() (common.Hash, error) {
+			return readRPCStorage(ctx, rpcClient, storageRefillAddress, storageSlot)
 		})
-		oldCode := startAsync(func() (hexutil.Bytes, error) {
-			return readRPCCode(ctx, rpcClient, staleAccountAddress)
+		delayedCode := startAsync(func() (hexutil.Bytes, error) {
+			return readRPCCode(ctx, rpcClient, removedAccountAddress)
 		})
-		oldNonce := startAsync(func() (hexutil.Uint64, error) {
-			return readRPCNonce(ctx, rpcClient, staleAccountAddress)
+		delayedNonce := startAsync(func() (hexutil.Uint64, error) {
+			return readRPCNonce(ctx, rpcClient, removedAccountAddress)
 		})
-		oldViews.wait(t)
-		overlayA.release()
-		awaitAsync(t, advance)
-		assertCanonicalHead(ctx, t, eat, next)
+		preUnwindViews.wait(t)
+		oldHeadOverlay.release()
+		awaitAsync(t, advanceToOldHead)
+		assertCanonicalHead(ctx, t, eat, oldHead)
 
-		unwind := transitions.hold(t, execmodule.StateTransitionUnwindComplete, 1)
-		overlayB := transitions.hold(t, execmodule.StateTransitionOverlayPublished, 1)
-		committedB := transitions.hold(t, execmodule.StateTransitionCommitComplete, 1)
-		clearedB := transitions.hold(t, execmodule.StateTransitionOverlayCleared, 1)
-		reorg := startAsync(func() (struct{}, error) {
-			return struct{}{}, eat.MockCl.UpdateForkChoice(ctx, base)
+		unwindComplete := transitions.hold(t, execmodule.StateTransitionUnwindComplete, 1)
+		replacementOverlay := transitions.hold(t, execmodule.StateTransitionOverlayPublished, 1)
+		replacementCommitted := transitions.hold(t, execmodule.StateTransitionCommitComplete, 1)
+		replacementCleared := transitions.hold(t, execmodule.StateTransitionOverlayCleared, 1)
+		reorgToTarget := startAsync(func() (struct{}, error) {
+			return struct{}{}, eat.MockCl.UpdateForkChoice(ctx, reorgTarget)
 		})
 
-		unwind.wait(t)
-		unwind.release()
-		overlayB.wait(t)
-		assertContractRPCStateWithoutStorage(t, readContractRPCState(ctx, t, rpcClient, overlayReadAddress, storageSlot))
-		overlayB.release()
+		unwindComplete.wait(t)
+		unwindComplete.release()
+		replacementOverlay.wait(t)
+		assertContractRPCStatePresentWithZeroStorage(t, readContractRPCState(ctx, t, rpcClient, overlayPhaseAddress, storageSlot))
+		replacementOverlay.release()
 
-		committedB.wait(t)
-		assertContractRPCStateWithoutStorage(t, readContractRPCState(ctx, t, rpcClient, committedReadAddress, storageSlot))
-		committedB.release()
+		replacementCommitted.wait(t)
+		assertContractRPCStatePresentWithZeroStorage(t, readContractRPCState(ctx, t, rpcClient, commitPhaseAddress, storageSlot))
+		replacementCommitted.release()
 
-		clearedB.wait(t)
-		assertContractRPCStateWithoutStorage(t, readContractRPCState(ctx, t, rpcClient, clearedReadAddress, storageSlot))
-		clearedB.release()
-		awaitAsync(t, reorg)
-		assertCanonicalHead(ctx, t, eat, base)
+		replacementCleared.wait(t)
+		assertContractRPCStatePresentWithZeroStorage(t, readContractRPCState(ctx, t, rpcClient, databasePhaseAddress, storageSlot))
+		replacementCleared.release()
+		awaitAsync(t, reorgToTarget)
+		assertCanonicalHead(ctx, t, eat, reorgTarget)
 
-		oldViews.release()
-		require.Equal(t, expectedStorage, awaitAsync(t, oldStorage))
-		require.NotEmpty(t, awaitAsync(t, oldCode))
-		require.NotZero(t, awaitAsync(t, oldNonce))
+		preUnwindViews.release()
+		require.Equal(t, expectedStorage, awaitAsync(t, delayedStorage))
+		require.NotEmpty(t, awaitAsync(t, delayedCode))
+		require.NotZero(t, awaitAsync(t, delayedNonce))
 
+		// The first read may refill StateCache; the second proves that any refill
+		// remains canonical after delayed old-view reads finish.
 		for range 2 {
-			assertContractRPCStateWithoutStorage(t, readContractRPCState(ctx, t, rpcClient, staleStorageAddress, storageSlot))
-			assertContractRPCStateAbsent(t, readContractRPCState(ctx, t, rpcClient, staleAccountAddress, storageSlot))
+			assertContractRPCStatePresentWithZeroStorage(t, readContractRPCState(ctx, t, rpcClient, storageRefillAddress, storageSlot))
+			assertContractRPCStateAbsent(t, readContractRPCState(ctx, t, rpcClient, removedAccountAddress, storageSlot))
 		}
 	})
 }
@@ -183,6 +199,8 @@ func readContractRPCState(
 	return contractRPCState{storage: storage, code: code, nonce: nonce}
 }
 
+// These reads keep the caller's context because the test deliberately holds
+// requests in flight across a forkchoice update.
 func readRPCStorage(ctx context.Context, client *rpc.Client, address common.Address, storageSlot common.Hash) (common.Hash, error) {
 	var result common.Hash
 	err := client.CallContext(ctx, &result, "eth_getStorageAt", address, storageSlot, "latest")
@@ -201,14 +219,14 @@ func readRPCNonce(ctx context.Context, client *rpc.Client, address common.Addres
 	return result, err
 }
 
-func assertContractRPCStatePresent(t *testing.T, got contractRPCState, expectedStorage common.Hash) {
+func assertContractRPCStatePresentWithStorage(t *testing.T, got contractRPCState, expectedStorage common.Hash) {
 	t.Helper()
 	require.Equal(t, expectedStorage, got.storage)
 	require.NotEmpty(t, got.code)
 	require.NotZero(t, got.nonce)
 }
 
-func assertContractRPCStateWithoutStorage(t *testing.T, got contractRPCState) {
+func assertContractRPCStatePresentWithZeroStorage(t *testing.T, got contractRPCState) {
 	t.Helper()
 	require.Zero(t, got.storage)
 	require.NotEmpty(t, got.code)
@@ -220,24 +238,6 @@ func assertContractRPCStateAbsent(t *testing.T, got contractRPCState) {
 	require.Zero(t, got.storage)
 	require.Empty(t, got.code)
 	require.Zero(t, got.nonce)
-}
-
-func applyStateChurnPoke(
-	ctx context.Context,
-	t *testing.T,
-	eat engineapitester.EngineApiTester,
-	churn *contracts.StateChurn,
-	seed int64,
-) {
-	t.Helper()
-	transactOpts, err := bind.NewKeyedTransactorWithChainID(eat.CoinbaseKey, eat.ChainId())
-	require.NoError(t, err)
-	transactOpts.GasLimit = params.MaxTxnGasLimit
-	txn, err := churn.Poke(transactOpts, big.NewInt(seed))
-	require.NoError(t, err)
-	block, err := eat.MockCl.BuildCanonicalBlock(ctx)
-	require.NoError(t, err)
-	require.NoError(t, eat.TxnInclusionVerifier.VerifyTxnsInclusion(ctx, block.ExecutionPayload, txn.Hash()))
 }
 
 func uint256Word(value uint64) []byte {
@@ -293,6 +293,8 @@ func awaitAsync[T any](t *testing.T, result <-chan asyncResult[T]) T {
 	}
 }
 
+// stateTransitionController turns inline lifecycle callbacks into
+// deterministic barriers.
 type stateTransitionController struct {
 	mu    sync.Mutex
 	holds map[execmodule.StateTransitionPoint]*stateTransitionHold

--- a/execution/engineapi/engine_api_rpc_unwind_test.go
+++ b/execution/engineapi/engine_api_rpc_unwind_test.go
@@ -1,0 +1,372 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package engineapi_test
+
+import (
+	"context"
+	"encoding/binary"
+	"math/big"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/crypto"
+	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/common/testlog"
+	"github.com/erigontech/erigon/execution/abi/bind"
+	enginetypes "github.com/erigontech/erigon/execution/engineapi/engine_types"
+	"github.com/erigontech/erigon/execution/engineapi/engineapitester"
+	"github.com/erigontech/erigon/execution/execmodule"
+	"github.com/erigontech/erigon/execution/protocol/params"
+	"github.com/erigontech/erigon/execution/state/contracts"
+	"github.com/erigontech/erigon/node/ethconfig"
+	"github.com/erigontech/erigon/rpc"
+)
+
+const (
+	rpcTransitionTimeout = time.Minute
+	rpcClientTimeout     = 5 * time.Minute
+)
+
+func TestEngineApiRPCStateAcrossUnwindPhases(t *testing.T) {
+	ctx := t.Context()
+	logger := testlog.Logger(t, log.LvlDebug)
+	genesis, coinbaseKey, err := engineapitester.DefaultEngineApiTesterGenesis()
+	require.NoError(t, err)
+
+	transitions := newStateTransitionController()
+	engineAPIClientTimeout := rpcClientTimeout
+	eat, err := engineapitester.InitialiseEngineApiTester(ctx, engineapitester.EngineApiTesterInitArgs{
+		Logger:                  logger,
+		DataDir:                 t.TempDir(),
+		Genesis:                 genesis,
+		CoinbaseKey:             coinbaseKey,
+		EngineApiClientTimeout:  &engineAPIClientTimeout,
+		StateTransitionObserver: transitions.observe,
+		EthConfigTweaker: func(config *ethconfig.Config) {
+			config.MaxReorgDepth = stateChurnReorgDepthBudget
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, eat.Close())
+	})
+
+	eat.Run(t, func(ctx context.Context, t *testing.T, eat engineapitester.EngineApiTester) {
+		seed := firstNonZeroStateChurnSeed()
+		_, staleStorageAddress, staleStorage, _ := buildChurnChain(ctx, t, eat, 0, nil)
+		_, overlayReadAddress, overlayRead, _ := buildChurnChain(ctx, t, eat, 0, nil)
+		_, committedReadAddress, committedRead, _ := buildChurnChain(ctx, t, eat, 0, nil)
+		_, clearedReadAddress, clearedRead, _ := buildChurnChain(ctx, t, eat, 0, nil)
+		base, err := eat.MockCl.BuildCanonicalBlock(ctx)
+		require.NoError(t, err)
+
+		for _, churn := range []*contracts.StateChurn{staleStorage, overlayRead, committedRead, clearedRead} {
+			applyStateChurnPoke(ctx, t, eat, churn, seed)
+		}
+		_, staleAccountAddress, _, _ := buildChurnChain(ctx, t, eat, 0, nil)
+		storageSlot := stateChurnStorageSlot(0)
+		expectedStorage := common.BigToHash(new(big.Int).SetUint64(stateChurnPokeValue(uint64(seed), 0)))
+
+		rpcClient, err := rpc.DialHTTPWithClient(eat.JsonRpcUrl, &http.Client{Timeout: rpcClientTimeout}, logger)
+		require.NoError(t, err)
+		defer rpcClient.Close()
+
+		assertContractRPCStatePresent(t, readContractRPCState(ctx, t, rpcClient, staleStorageAddress, storageSlot), expectedStorage)
+		assertContractRPCStatePresent(t, readContractRPCState(ctx, t, rpcClient, overlayReadAddress, storageSlot), expectedStorage)
+		assertContractRPCStatePresent(t, readContractRPCState(ctx, t, rpcClient, committedReadAddress, storageSlot), expectedStorage)
+		assertContractRPCStatePresent(t, readContractRPCState(ctx, t, rpcClient, clearedReadAddress, storageSlot), expectedStorage)
+		assertContractRPCStateWithoutStorage(t, readContractRPCState(ctx, t, rpcClient, staleAccountAddress, storageSlot))
+
+		next, err := eat.MockCl.BuildNewPayload(ctx)
+		require.NoError(t, err)
+		status, err := eat.MockCl.InsertNewPayload(ctx, next)
+		require.NoError(t, err)
+		require.Equal(t, enginetypes.ValidStatus, status.Status)
+
+		overlayA := transitions.hold(t, execmodule.StateTransitionOverlayPublished, 1)
+		advance := startAsync(func() (struct{}, error) {
+			return struct{}{}, eat.MockCl.UpdateForkChoice(ctx, next)
+		})
+		overlayA.wait(t)
+
+		oldViews := transitions.hold(t, execmodule.StateTransitionRPCViewBound, 3)
+		oldStorage := startAsync(func() (common.Hash, error) {
+			return readRPCStorage(ctx, rpcClient, staleStorageAddress, storageSlot)
+		})
+		oldCode := startAsync(func() (hexutil.Bytes, error) {
+			return readRPCCode(ctx, rpcClient, staleAccountAddress)
+		})
+		oldNonce := startAsync(func() (hexutil.Uint64, error) {
+			return readRPCNonce(ctx, rpcClient, staleAccountAddress)
+		})
+		oldViews.wait(t)
+		overlayA.release()
+		awaitAsync(t, advance)
+		assertCanonicalHead(ctx, t, eat, next)
+
+		unwind := transitions.hold(t, execmodule.StateTransitionUnwindComplete, 1)
+		overlayB := transitions.hold(t, execmodule.StateTransitionOverlayPublished, 1)
+		committedB := transitions.hold(t, execmodule.StateTransitionCommitComplete, 1)
+		clearedB := transitions.hold(t, execmodule.StateTransitionOverlayCleared, 1)
+		reorg := startAsync(func() (struct{}, error) {
+			return struct{}{}, eat.MockCl.UpdateForkChoice(ctx, base)
+		})
+
+		unwind.wait(t)
+		unwind.release()
+		overlayB.wait(t)
+		assertContractRPCStateWithoutStorage(t, readContractRPCState(ctx, t, rpcClient, overlayReadAddress, storageSlot))
+		overlayB.release()
+
+		committedB.wait(t)
+		assertContractRPCStateWithoutStorage(t, readContractRPCState(ctx, t, rpcClient, committedReadAddress, storageSlot))
+		committedB.release()
+
+		clearedB.wait(t)
+		assertContractRPCStateWithoutStorage(t, readContractRPCState(ctx, t, rpcClient, clearedReadAddress, storageSlot))
+		clearedB.release()
+		awaitAsync(t, reorg)
+		assertCanonicalHead(ctx, t, eat, base)
+
+		oldViews.release()
+		require.Equal(t, expectedStorage, awaitAsync(t, oldStorage))
+		require.NotEmpty(t, awaitAsync(t, oldCode))
+		require.NotZero(t, awaitAsync(t, oldNonce))
+
+		for range 2 {
+			assertContractRPCStateWithoutStorage(t, readContractRPCState(ctx, t, rpcClient, staleStorageAddress, storageSlot))
+			assertContractRPCStateAbsent(t, readContractRPCState(ctx, t, rpcClient, staleAccountAddress, storageSlot))
+		}
+	})
+}
+
+type contractRPCState struct {
+	storage common.Hash
+	code    hexutil.Bytes
+	nonce   hexutil.Uint64
+}
+
+func readContractRPCState(
+	ctx context.Context,
+	t *testing.T,
+	client *rpc.Client,
+	address common.Address,
+	storageSlot common.Hash,
+) contractRPCState {
+	t.Helper()
+	storage, err := readRPCStorage(ctx, client, address, storageSlot)
+	require.NoError(t, err)
+	code, err := readRPCCode(ctx, client, address)
+	require.NoError(t, err)
+	nonce, err := readRPCNonce(ctx, client, address)
+	require.NoError(t, err)
+	return contractRPCState{storage: storage, code: code, nonce: nonce}
+}
+
+func readRPCStorage(ctx context.Context, client *rpc.Client, address common.Address, storageSlot common.Hash) (common.Hash, error) {
+	var result common.Hash
+	err := client.CallContext(ctx, &result, "eth_getStorageAt", address, storageSlot, "latest")
+	return result, err
+}
+
+func readRPCCode(ctx context.Context, client *rpc.Client, address common.Address) (hexutil.Bytes, error) {
+	var result hexutil.Bytes
+	err := client.CallContext(ctx, &result, "eth_getCode", address, "latest")
+	return result, err
+}
+
+func readRPCNonce(ctx context.Context, client *rpc.Client, address common.Address) (hexutil.Uint64, error) {
+	var result hexutil.Uint64
+	err := client.CallContext(ctx, &result, "eth_getTransactionCount", address, "latest")
+	return result, err
+}
+
+func assertContractRPCStatePresent(t *testing.T, got contractRPCState, expectedStorage common.Hash) {
+	t.Helper()
+	require.Equal(t, expectedStorage, got.storage)
+	require.NotEmpty(t, got.code)
+	require.NotZero(t, got.nonce)
+}
+
+func assertContractRPCStateWithoutStorage(t *testing.T, got contractRPCState) {
+	t.Helper()
+	require.Zero(t, got.storage)
+	require.NotEmpty(t, got.code)
+	require.NotZero(t, got.nonce)
+}
+
+func assertContractRPCStateAbsent(t *testing.T, got contractRPCState) {
+	t.Helper()
+	require.Zero(t, got.storage)
+	require.Empty(t, got.code)
+	require.Zero(t, got.nonce)
+}
+
+func applyStateChurnPoke(
+	ctx context.Context,
+	t *testing.T,
+	eat engineapitester.EngineApiTester,
+	churn *contracts.StateChurn,
+	seed int64,
+) {
+	t.Helper()
+	transactOpts, err := bind.NewKeyedTransactorWithChainID(eat.CoinbaseKey, eat.ChainId())
+	require.NoError(t, err)
+	transactOpts.GasLimit = params.MaxTxnGasLimit
+	txn, err := churn.Poke(transactOpts, big.NewInt(seed))
+	require.NoError(t, err)
+	block, err := eat.MockCl.BuildCanonicalBlock(ctx)
+	require.NoError(t, err)
+	require.NoError(t, eat.TxnInclusionVerifier.VerifyTxnsInclusion(ctx, block.ExecutionPayload, txn.Hash()))
+}
+
+func uint256Word(value uint64) []byte {
+	word := make([]byte, 32)
+	binary.BigEndian.PutUint64(word[24:], value)
+	return word
+}
+
+func stateChurnStorageSlot(index uint64) common.Hash {
+	ringKey := common.BytesToHash(crypto.Keccak256([]byte("statechurn"), uint256Word(index)))
+	return common.BytesToHash(crypto.Keccak256(ringKey[:], make([]byte, 32)))
+}
+
+func stateChurnPokeValue(seed, cursor uint64) uint64 {
+	hash := common.BytesToHash(crypto.Keccak256(uint256Word(seed), uint256Word(cursor)))
+	return new(big.Int).Mod(new(big.Int).SetBytes(hash[:]), big.NewInt(3)).Uint64()
+}
+
+func firstNonZeroStateChurnSeed() int64 {
+	for seed := uint64(0); ; seed++ {
+		if stateChurnPokeValue(seed, 0) != 0 {
+			return int64(seed)
+		}
+	}
+}
+
+type asyncResult[T any] struct {
+	value T
+	err   error
+}
+
+func startAsync[T any](call func() (T, error)) <-chan asyncResult[T] {
+	result := make(chan asyncResult[T], 1)
+	go func() {
+		value, err := call()
+		result <- asyncResult[T]{value: value, err: err}
+	}()
+	return result
+}
+
+func awaitAsync[T any](t *testing.T, result <-chan asyncResult[T]) T {
+	t.Helper()
+	timer := time.NewTimer(rpcTransitionTimeout)
+	defer timer.Stop()
+	select {
+	case result := <-result:
+		require.NoError(t, result.err)
+		return result.value
+	case <-timer.C:
+		t.Fatal("asynchronous operation did not complete")
+		var zero T
+		return zero
+	}
+}
+
+type stateTransitionController struct {
+	mu    sync.Mutex
+	holds map[execmodule.StateTransitionPoint]*stateTransitionHold
+}
+
+func newStateTransitionController() *stateTransitionController {
+	return &stateTransitionController{holds: make(map[execmodule.StateTransitionPoint]*stateTransitionHold)}
+}
+
+func (c *stateTransitionController) hold(
+	t *testing.T,
+	point execmodule.StateTransitionPoint,
+	count int,
+) *stateTransitionHold {
+	t.Helper()
+	if count < 1 {
+		t.Fatal("transition hold count must be positive")
+	}
+	hold := &stateTransitionHold{
+		point:     point,
+		remaining: count,
+		reached:   make(chan struct{}),
+		proceed:   make(chan struct{}),
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, exists := c.holds[point]; exists {
+		t.Fatalf("transition %d already has a hold", point)
+	}
+	c.holds[point] = hold
+	t.Cleanup(hold.release)
+	return hold
+}
+
+func (c *stateTransitionController) observe(ctx context.Context, point execmodule.StateTransitionPoint) {
+	c.mu.Lock()
+	hold := c.holds[point]
+	if hold == nil {
+		c.mu.Unlock()
+		return
+	}
+	hold.remaining--
+	if hold.remaining == 0 {
+		delete(c.holds, point)
+		close(hold.reached)
+	}
+	proceed := hold.proceed
+	c.mu.Unlock()
+
+	select {
+	case <-proceed:
+	case <-ctx.Done():
+	}
+}
+
+type stateTransitionHold struct {
+	point     execmodule.StateTransitionPoint
+	remaining int
+	reached   chan struct{}
+	proceed   chan struct{}
+	once      sync.Once
+}
+
+func (h *stateTransitionHold) wait(t *testing.T) {
+	t.Helper()
+	timer := time.NewTimer(rpcTransitionTimeout)
+	defer timer.Stop()
+	select {
+	case <-h.reached:
+	case <-timer.C:
+		t.Fatalf("state transition %d was not reached", h.point)
+	}
+}
+
+func (h *stateTransitionHold) release() {
+	h.once.Do(func() { close(h.proceed) })
+}

--- a/execution/engineapi/engine_api_rpc_unwind_test.go
+++ b/execution/engineapi/engine_api_rpc_unwind_test.go
@@ -67,7 +67,9 @@ func TestEngineApiRPCStateAcrossUnwindPhases(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+	asyncCalls := newAsyncClientCallGroup()
 	t.Cleanup(func() {
+		asyncCalls.wait()
 		require.NoError(t, eat.Close())
 	})
 
@@ -116,7 +118,7 @@ func TestEngineApiRPCStateAcrossUnwindPhases(t *testing.T) {
 		require.Equal(t, enginetypes.ValidStatus, status.Status)
 
 		oldHeadOverlay := transitions.hold(t, execmodule.StateTransitionOverlayPublished, 1)
-		advanceToOldHead := startAsync(func() (struct{}, error) {
+		advanceToOldHead := startAsync(asyncCalls, func() (struct{}, error) {
 			return struct{}{}, eat.MockCl.UpdateForkChoice(ctx, oldHead)
 		})
 		oldHeadOverlay.wait(t)
@@ -124,13 +126,13 @@ func TestEngineApiRPCStateAcrossUnwindPhases(t *testing.T) {
 		// These requests stay bound to the old head across the reorg. Their MVCC
 		// reads may finish later, but they must not refill canonical cache entries.
 		preUnwindViews := transitions.hold(t, execmodule.StateTransitionRPCViewBound, 3)
-		delayedStorage := startAsync(func() (common.Hash, error) {
+		delayedStorage := startAsync(asyncCalls, func() (common.Hash, error) {
 			return readRPCStorage(ctx, rpcClient, storageRefillAddress, storageSlot)
 		})
-		delayedCode := startAsync(func() (hexutil.Bytes, error) {
+		delayedCode := startAsync(asyncCalls, func() (hexutil.Bytes, error) {
 			return readRPCCode(ctx, rpcClient, removedAccountAddress)
 		})
-		delayedNonce := startAsync(func() (hexutil.Uint64, error) {
+		delayedNonce := startAsync(asyncCalls, func() (hexutil.Uint64, error) {
 			return readRPCNonce(ctx, rpcClient, removedAccountAddress)
 		})
 		preUnwindViews.wait(t)
@@ -142,7 +144,7 @@ func TestEngineApiRPCStateAcrossUnwindPhases(t *testing.T) {
 		replacementOverlay := transitions.hold(t, execmodule.StateTransitionOverlayPublished, 1)
 		replacementCommitted := transitions.hold(t, execmodule.StateTransitionCommitComplete, 1)
 		replacementCleared := transitions.hold(t, execmodule.StateTransitionOverlayCleared, 1)
-		reorgToTarget := startAsync(func() (struct{}, error) {
+		reorgToTarget := startAsync(asyncCalls, func() (struct{}, error) {
 			return struct{}{}, eat.MockCl.UpdateForkChoice(ctx, reorgTarget)
 		})
 
@@ -269,12 +271,45 @@ type asyncResult[T any] struct {
 	err   error
 }
 
-func startAsync[T any](call func() (T, error)) <-chan asyncResult[T] {
+func TestAsyncClientCallGroupDrainsBeforeResourceCleanup(t *testing.T) {
+	finished := make(chan struct{})
+	asyncCalls := newAsyncClientCallGroup()
+	t.Cleanup(func() {
+		asyncCalls.wait()
+		select {
+		case <-finished:
+		default:
+			t.Error("resource cleanup ran before the asynchronous call finished")
+		}
+	})
+
+	startAsync(asyncCalls, func() (struct{}, error) {
+		<-t.Context().Done()
+		close(finished)
+		return struct{}{}, nil
+	})
+}
+
+// asyncClientCallGroup drains test-owned client goroutines before the tester
+// waits for detached server-side forkchoice work.
+type asyncClientCallGroup struct {
+	wg sync.WaitGroup
+}
+
+func newAsyncClientCallGroup() *asyncClientCallGroup {
+	return &asyncClientCallGroup{}
+}
+
+func (g *asyncClientCallGroup) wait() {
+	g.wg.Wait()
+}
+
+func startAsync[T any](group *asyncClientCallGroup, call func() (T, error)) <-chan asyncResult[T] {
 	result := make(chan asyncResult[T], 1)
-	go func() {
+	group.wg.Go(func() {
 		value, err := call()
 		result <- asyncResult[T]{value: value, err: err}
-	}()
+	})
 	return result
 }
 

--- a/execution/engineapi/engine_api_rpc_unwind_test.go
+++ b/execution/engineapi/engine_api_rpc_unwind_test.go
@@ -46,6 +46,7 @@ const (
 	rpcTransitionTimeout       = time.Minute
 	rpcClientTimeout           = 10 * rpcTransitionTimeout
 	stateChurnSeed       int64 = 0
+	delayedRPCUserAgent        = "erigon-rpc-unwind-delayed"
 )
 
 func TestEngineApiRPCStateAcrossUnwindPhases(t *testing.T) {
@@ -96,15 +97,23 @@ func TestEngineApiRPCStateAcrossUnwindPhases(t *testing.T) {
 		_, removedAccountAddress, _, _ := buildChurnChain(ctx, t, eat, 0, nil)
 		storageSlot := stateChurnStorageSlot(0)
 		expectedStorage := common.BigToHash(new(big.Int).SetUint64(stateChurnPokeValue(uint64(seed), 0)))
+		require.NotZero(t, expectedStorage)
 
-		transport := http.DefaultTransport.(*http.Transport).Clone()
-		t.Cleanup(transport.CloseIdleConnections)
+		transport := http.DefaultTransport
+		if defaultTransport, ok := transport.(*http.Transport); ok {
+			transport = defaultTransport.Clone()
+		}
+		httpClient := &http.Client{Transport: transport, Timeout: rpcClientTimeout}
+		t.Cleanup(httpClient.CloseIdleConnections)
 		rpcClient, err := rpc.DialHTTPWithClient(
 			eat.JsonRpcUrl,
-			&http.Client{Transport: transport, Timeout: rpcClientTimeout},
+			httpClient,
 			logger,
 		)
 		require.NoError(t, err)
+		delayedRPCClient, err := rpc.DialHTTPWithClient(eat.JsonRpcUrl, httpClient, logger)
+		require.NoError(t, err)
+		delayedRPCClient.SetHeader("User-Agent", delayedRPCUserAgent)
 
 		assertContractRPCStatePresentWithStorage(t, readContractRPCState(ctx, t, rpcClient, storageRefillAddress, storageSlot), expectedStorage)
 		assertContractRPCStatePresentWithStorage(t, readContractRPCState(ctx, t, rpcClient, publicationBoundaryAddress, storageSlot), expectedStorage)
@@ -129,15 +138,17 @@ func TestEngineApiRPCStateAcrossUnwindPhases(t *testing.T) {
 
 		// These requests stay bound to the old head across the reorg. Their MVCC
 		// reads may finish later, but they must not refill canonical cache entries.
-		preUnwindViews := transitions.hold(t, execmodule.StateTransitionRPCViewBound, 3)
+		preUnwindViews := transitions.holdMatching(t, execmodule.StateTransitionRPCViewBound, 3, func(ctx context.Context) bool {
+			return rpc.PeerInfoFromContext(ctx).HTTP.UserAgent == delayedRPCUserAgent
+		})
 		delayedStorage := startAsync(&asyncCalls, func() (common.Hash, error) {
-			return readRPCStorage(ctx, rpcClient, storageRefillAddress, storageSlot)
+			return readRPCStorage(ctx, delayedRPCClient, storageRefillAddress, storageSlot)
 		})
 		delayedCode := startAsync(&asyncCalls, func() (hexutil.Bytes, error) {
-			return readRPCCode(ctx, rpcClient, removedAccountAddress)
+			return readRPCCode(ctx, delayedRPCClient, removedAccountAddress)
 		})
 		delayedNonce := startAsync(&asyncCalls, func() (hexutil.Uint64, error) {
-			return readRPCNonce(ctx, rpcClient, removedAccountAddress)
+			return readRPCNonce(ctx, delayedRPCClient, removedAccountAddress)
 		})
 		preUnwindViews.wait(t)
 		oldHeadOverlay.release()
@@ -313,6 +324,32 @@ func awaitAsync[T any](t *testing.T, result <-chan asyncResult[T]) T {
 	}
 }
 
+func TestStateTransitionControllerFiltersObservations(t *testing.T) {
+	type matchKey struct{}
+
+	transitions := newStateTransitionController()
+	hold := transitions.holdMatching(t, execmodule.StateTransitionRPCViewBound, 1, func(ctx context.Context) bool {
+		matched, _ := ctx.Value(matchKey{}).(bool)
+		return matched
+	})
+
+	transitions.observe(t.Context(), execmodule.StateTransitionRPCViewBound)
+	select {
+	case <-hold.reached:
+		t.Fatal("unmatched observation reached the hold")
+	default:
+	}
+
+	matchedCtx, cancel := context.WithCancel(context.WithValue(t.Context(), matchKey{}, true))
+	cancel()
+	transitions.observe(matchedCtx, execmodule.StateTransitionRPCViewBound)
+	select {
+	case <-hold.reached:
+	default:
+		t.Fatal("matched observation did not reach the hold")
+	}
+}
+
 // stateTransitionController turns inline lifecycle callbacks into
 // deterministic barriers.
 type stateTransitionController struct {
@@ -330,6 +367,16 @@ func (c *stateTransitionController) hold(
 	count int,
 ) *stateTransitionHold {
 	t.Helper()
+	return c.holdMatching(t, point, count, nil)
+}
+
+func (c *stateTransitionController) holdMatching(
+	t *testing.T,
+	point execmodule.StateTransitionPoint,
+	count int,
+	matches func(context.Context) bool,
+) *stateTransitionHold {
+	t.Helper()
 	if count < 1 {
 		t.Fatal("transition hold count must be positive")
 	}
@@ -338,6 +385,7 @@ func (c *stateTransitionController) hold(
 		remaining: count,
 		reached:   make(chan struct{}),
 		proceed:   make(chan struct{}),
+		matches:   matches,
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -352,7 +400,7 @@ func (c *stateTransitionController) hold(
 func (c *stateTransitionController) observe(ctx context.Context, point execmodule.StateTransitionPoint) {
 	c.mu.Lock()
 	hold := c.holds[point]
-	if hold == nil {
+	if hold == nil || hold.matches != nil && !hold.matches(ctx) {
 		c.mu.Unlock()
 		return
 	}
@@ -375,6 +423,7 @@ type stateTransitionHold struct {
 	remaining int
 	reached   chan struct{}
 	proceed   chan struct{}
+	matches   func(context.Context) bool
 	once      sync.Once
 }
 

--- a/execution/engineapi/engine_api_rpc_unwind_test.go
+++ b/execution/engineapi/engine_api_rpc_unwind_test.go
@@ -79,7 +79,7 @@ func TestEngineApiRPCStateAcrossUnwindPhases(t *testing.T) {
 		// Each boundary gets its own contract because an RPC assertion may fill
 		// StateCache; sharing a key could let one phase mask the next.
 		_, storageRefillAddress, storageRefill, _ := buildChurnChain(ctx, t, eat, 0, nil)
-		_, overlayPhaseAddress, overlayPhase, _ := buildChurnChain(ctx, t, eat, 0, nil)
+		_, publicationBoundaryAddress, publicationBoundary, _ := buildChurnChain(ctx, t, eat, 0, nil)
 		_, commitPhaseAddress, commitPhase, _ := buildChurnChain(ctx, t, eat, 0, nil)
 		_, databasePhaseAddress, databasePhase, _ := buildChurnChain(ctx, t, eat, 0, nil)
 		reorgTarget, err := eat.MockCl.BuildCanonicalBlock(ctx)
@@ -88,7 +88,7 @@ func TestEngineApiRPCStateAcrossUnwindPhases(t *testing.T) {
 		transactOpts, err := bind.NewKeyedTransactorWithChainID(eat.CoinbaseKey, eat.ChainId())
 		require.NoError(t, err)
 		transactOpts.GasLimit = params.MaxTxnGasLimit
-		for _, churn := range []*contracts.StateChurn{storageRefill, overlayPhase, commitPhase, databasePhase} {
+		for _, churn := range []*contracts.StateChurn{storageRefill, publicationBoundary, commitPhase, databasePhase} {
 			applyStateChurnPoke(ctx, t, eat, churn, transactOpts, seed)
 		}
 		// This post-target deployment makes account and code removal part of the
@@ -107,7 +107,7 @@ func TestEngineApiRPCStateAcrossUnwindPhases(t *testing.T) {
 		require.NoError(t, err)
 
 		assertContractRPCStatePresentWithStorage(t, readContractRPCState(ctx, t, rpcClient, storageRefillAddress, storageSlot), expectedStorage)
-		assertContractRPCStatePresentWithStorage(t, readContractRPCState(ctx, t, rpcClient, overlayPhaseAddress, storageSlot), expectedStorage)
+		assertContractRPCStatePresentWithStorage(t, readContractRPCState(ctx, t, rpcClient, publicationBoundaryAddress, storageSlot), expectedStorage)
 		assertContractRPCStatePresentWithStorage(t, readContractRPCState(ctx, t, rpcClient, commitPhaseAddress, storageSlot), expectedStorage)
 		assertContractRPCStatePresentWithStorage(t, readContractRPCState(ctx, t, rpcClient, databasePhaseAddress, storageSlot), expectedStorage)
 		assertContractRPCStatePresentWithZeroStorage(t, readContractRPCState(ctx, t, rpcClient, removedAccountAddress, storageSlot))
@@ -155,9 +155,10 @@ func TestEngineApiRPCStateAcrossUnwindPhases(t *testing.T) {
 		})
 
 		unwindComplete.wait(t)
+		assertContractRPCStatePresentWithStorage(t, readContractRPCState(ctx, t, rpcClient, publicationBoundaryAddress, storageSlot), expectedStorage)
 		unwindComplete.release()
 		replacementOverlay.wait(t)
-		assertContractRPCStatePresentWithZeroStorage(t, readContractRPCState(ctx, t, rpcClient, overlayPhaseAddress, storageSlot))
+		assertContractRPCStatePresentWithZeroStorage(t, readContractRPCState(ctx, t, rpcClient, publicationBoundaryAddress, storageSlot))
 		replacementOverlay.release()
 
 		replacementCommitted.wait(t)

--- a/execution/engineapi/engine_api_state_churn_reorg_test.go
+++ b/execution/engineapi/engine_api_state_churn_reorg_test.go
@@ -225,11 +225,11 @@ func TestEngineApiForkBounceStateChurn(t *testing.T) {
 	})
 }
 
-// buildChurnChain deploys StateChurn at block 2 on the given tester and then
-// applies one poke per block, using seed(k) for the k-th poke. payloads[0] is
-// the deploy block (height 2) and payloads[k+1] is the block applying poke k
-// (height 3+k). sums[i] is the on-chain trackedSum observed at payloads[i] and
-// is the ground truth a later unwind/reorg must reproduce.
+// buildChurnChain deploys StateChurn in the next block and then applies one
+// poke per block, using seed(k) for the k-th poke. payloads[0] is the deploy
+// block and payloads[k+1] applies poke k. sums[i] is the on-chain trackedSum
+// observed at payloads[i] and is the ground truth a later unwind/reorg must
+// reproduce.
 func buildChurnChain(
 	ctx context.Context,
 	t *testing.T,

--- a/execution/engineapi/engine_api_state_churn_reorg_test.go
+++ b/execution/engineapi/engine_api_state_churn_reorg_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common"
-	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/common/testlog"
 	"github.com/erigontech/erigon/execution/abi/bind"
@@ -294,15 +293,7 @@ func churnAndAssert(
 	transactOpts, err := bind.NewKeyedTransactorWithChainID(eat.CoinbaseKey, eat.ChainId())
 	require.NoError(t, err)
 	transactOpts.GasLimit = params.MaxTxnGasLimit
-	coinbaseAddr := crypto.PubkeyToAddress(eat.CoinbaseKey.PublicKey)
 	for k := range pokes {
-		// Pin the nonce to the head state: the txpool's own pending-nonce view
-		// can be stale right after a reorg/restart (re-injected dead-fork txns,
-		// https://github.com/erigontech/erigon/issues/22299), and submission is
-		// retried while the pool digests the head change.
-		nonce, err := eat.RpcApiClient.GetTransactionCount(coinbaseAddr, rpc.LatestBlock)
-		require.NoError(t, err)
-		transactOpts.Nonce = nonce
 		var txn types.Transaction
 		require.Eventually(t, func() bool {
 			var err error

--- a/execution/engineapi/engine_api_state_churn_reorg_test.go
+++ b/execution/engineapi/engine_api_state_churn_reorg_test.go
@@ -254,15 +254,28 @@ func buildChurnChain(
 	sums = append(sums, recordChurnSum(ctx, t, churn))
 
 	for k := range pokes {
-		txn, err := churn.Poke(transactOpts, big.NewInt(seed(k)))
-		require.NoError(t, err)
-		block, err := eat.MockCl.BuildCanonicalBlock(ctx)
-		require.NoError(t, err)
-		require.NoError(t, eat.TxnInclusionVerifier.VerifyTxnsInclusion(ctx, block.ExecutionPayload, txn.Hash()))
+		block := applyStateChurnPoke(ctx, t, eat, churn, transactOpts, seed(k))
 		payloads = append(payloads, block)
 		sums = append(sums, recordChurnSum(ctx, t, churn))
 	}
 	return payloads, addr, churn, sums
+}
+
+func applyStateChurnPoke(
+	ctx context.Context,
+	t *testing.T,
+	eat engineapitester.EngineApiTester,
+	churn *contracts.StateChurn,
+	transactOpts *bind.TransactOpts,
+	seed int64,
+) *engineapitester.MockClPayload {
+	t.Helper()
+	txn, err := churn.Poke(transactOpts, big.NewInt(seed))
+	require.NoError(t, err)
+	block, err := eat.MockCl.BuildCanonicalBlock(ctx)
+	require.NoError(t, err)
+	require.NoError(t, eat.TxnInclusionVerifier.VerifyTxnsInclusion(ctx, block.ExecutionPayload, txn.Hash()))
+	return block
 }
 
 // churnAndAssert applies pokes one block at a time on the tester's current

--- a/execution/engineapi/engineapitester/engine_api_tester.go
+++ b/execution/engineapi/engineapitester/engine_api_tester.go
@@ -268,10 +268,6 @@ func InitialiseEngineApiTester(ctx context.Context, args EngineApiTesterInitArgs
 		RpcTxSyncDefaultTimeout:  rpccfg.DefaultRpcTxSyncDefaultTimeout,
 		RpcTxSyncMaxTimeout:      rpccfg.DefaultRpcTxSyncMaxTimeout,
 	}
-	if args.StateTransitionObserver != nil {
-		httpConfig.StateCache.LocalCache = execmodule.NewCache(args.StateTransitionObserver)
-	}
-
 	nodeKeyConfig := p2p.NodeKeyConfig{}
 	nodeKey, err := nodeKeyConfig.LoadOrGenerateAndSave(nodeKeyConfig.DefaultPath(args.DataDir))
 	if err != nil {
@@ -353,7 +349,14 @@ func InitialiseEngineApiTester(ctx context.Context, args EngineApiTesterInitArgs
 	if err != nil {
 		return EngineApiTester{}, fmt.Errorf("obtain jwt secret: %w", err)
 	}
-	ethBackend, err := eth.New(ctx, ethNode, &ethConfig, logger, nil)
+	ethBackend, err := eth.New(
+		ctx,
+		ethNode,
+		&ethConfig,
+		logger,
+		nil,
+		eth.WithStateTransitionObserver(args.StateTransitionObserver),
+	)
 	if err != nil {
 		return EngineApiTester{}, fmt.Errorf("eth.New: %w", err)
 	}

--- a/execution/engineapi/engineapitester/engine_api_tester.go
+++ b/execution/engineapi/engineapitester/engine_api_tester.go
@@ -41,6 +41,7 @@ import (
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv/dbcfg"
+	"github.com/erigontech/erigon/db/kv/kvcache"
 	"github.com/erigontech/erigon/db/state"
 	"github.com/erigontech/erigon/execution/builder/buildercfg"
 	"github.com/erigontech/erigon/execution/chain"
@@ -356,6 +357,9 @@ func InitialiseEngineApiTester(ctx context.Context, args EngineApiTesterInitArgs
 		logger,
 		nil,
 		eth.WithStateTransitionObserver(args.StateTransitionObserver),
+		eth.WithRPCStateCacheDecorator(func(cache kvcache.Cache) kvcache.Cache {
+			return withRPCViewObserver(cache, args.StateTransitionObserver)
+		}),
 	)
 	if err != nil {
 		return EngineApiTester{}, fmt.Errorf("eth.New: %w", err)

--- a/execution/engineapi/engineapitester/engine_api_tester.go
+++ b/execution/engineapi/engineapitester/engine_api_tester.go
@@ -46,6 +46,7 @@ import (
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/chain/networkname"
 	"github.com/erigontech/erigon/execution/engineapi"
+	"github.com/erigontech/erigon/execution/execmodule"
 	"github.com/erigontech/erigon/execution/protocol/misc"
 	"github.com/erigontech/erigon/execution/protocol/params"
 	"github.com/erigontech/erigon/execution/protocol/rules/merge"
@@ -267,6 +268,9 @@ func InitialiseEngineApiTester(ctx context.Context, args EngineApiTesterInitArgs
 		RpcTxSyncDefaultTimeout:  rpccfg.DefaultRpcTxSyncDefaultTimeout,
 		RpcTxSyncMaxTimeout:      rpccfg.DefaultRpcTxSyncMaxTimeout,
 	}
+	if args.StateTransitionObserver != nil {
+		httpConfig.StateCache.LocalCache = execmodule.NewCache(args.StateTransitionObserver)
+	}
 
 	nodeKeyConfig := p2p.NodeKeyConfig{}
 	nodeKey, err := nodeKeyConfig.LoadOrGenerateAndSave(nodeKeyConfig.DefaultPath(args.DataDir))
@@ -433,17 +437,18 @@ func InitialiseEngineApiTester(ctx context.Context, args EngineApiTesterInitArgs
 }
 
 type EngineApiTesterInitArgs struct {
-	Logger                 log.Logger
-	DataDir                string
-	Genesis                *types.Genesis
-	CoinbaseKey            *ecdsa.PrivateKey
-	EthConfigTweaker       func(*ethconfig.Config)
-	MockClState            *MockClState
-	NoEmptyBlock1          bool
-	EngineApiClientTimeout *time.Duration
-	DisableTxPool          bool
-	DisableSentry          bool
-	MdbxDBSizeLimit        datasize.ByteSize
+	Logger                  log.Logger
+	DataDir                 string
+	Genesis                 *types.Genesis
+	CoinbaseKey             *ecdsa.PrivateKey
+	EthConfigTweaker        func(*ethconfig.Config)
+	MockClState             *MockClState
+	NoEmptyBlock1           bool
+	EngineApiClientTimeout  *time.Duration
+	DisableTxPool           bool
+	DisableSentry           bool
+	MdbxDBSizeLimit         datasize.ByteSize
+	StateTransitionObserver execmodule.StateTransitionObserver
 }
 
 type EngineApiTester struct {

--- a/execution/engineapi/engineapitester/engine_api_tester.go
+++ b/execution/engineapi/engineapitester/engine_api_tester.go
@@ -249,6 +249,10 @@ func InitialiseEngineApiTester(ctx context.Context, args EngineApiTesterInitArgs
 	engineApiPort := engineApiListener.Addr().(*net.TCPAddr).Port
 	logger.Debug("[engine-api-tester] selected ports", "engineApi", engineApiPort, "jsonRpc", jsonRpcPort)
 
+	httpAPIs := []string{"eth"}
+	if args.EnableTestingAPI {
+		httpAPIs = append(httpAPIs, "testing")
+	}
 	httpConfig := httpcfg.HttpCfg{
 		Enabled:                  true,
 		HttpServerEnabled:        true,
@@ -257,7 +261,7 @@ func InitialiseEngineApiTester(ctx context.Context, args EngineApiTesterInitArgs
 		HttpListenAddress:        "127.0.0.1",
 		HttpPort:                 jsonRpcPort,
 		HttpListener:             jsonRpcListener,
-		API:                      []string{"eth"},
+		API:                      httpAPIs,
 		AuthRpcHTTPListenAddress: "127.0.0.1",
 		AuthRpcPort:              engineApiPort,
 		AuthRpcListener:          engineApiListener,
@@ -456,6 +460,7 @@ type EngineApiTesterInitArgs struct {
 	DisableSentry           bool
 	MdbxDBSizeLimit         datasize.ByteSize
 	StateTransitionObserver execmodule.StateTransitionObserver
+	EnableTestingAPI        bool
 }
 
 type EngineApiTester struct {

--- a/execution/engineapi/engineapitester/mock_cl.go
+++ b/execution/engineapi/engineapitester/mock_cl.go
@@ -18,6 +18,7 @@ package engineapitester
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -101,46 +102,10 @@ func (cl *MockCl) BuildCanonicalBlock(ctx context.Context, opts ...BlockBuilding
 // parent can be overridden via an option) and returns the resulting payload id and the payload
 // attributes used. It is the first half of BuildNewPayload.
 func (cl *MockCl) StartBuilding(ctx context.Context, opts ...BlockBuildingOption) (hexutil.Bytes, enginetypes.PayloadAttributes, error) {
-	options := cl.applyBlockBuildingOptions(opts...)
-	forkChoiceState := enginetypes.ForkChoiceState{
-		HeadHash:           cl.state.ParentElBlock,
-		SafeBlockHash:      cl.genesis,
-		FinalizedBlockHash: cl.genesis,
+	forkChoiceState, payloadAttributes, err := cl.nextPayloadBuildInputs(ctx, opts...)
+	if err != nil {
+		return nil, enginetypes.PayloadAttributes{}, fmt.Errorf("start building: %w", err)
 	}
-	var timestamp uint64
-	if options.timestamp != nil {
-		timestamp = *options.timestamp
-	} else {
-		timestamp = cl.state.ParentElTimestamp + 1
-	}
-	if options.waitUntilTimestamp {
-		waitDuration := time.Until(time.Unix(int64(timestamp), 0)) + 100*time.Millisecond
-		cl.logger.Debug("[mock-cl] waiting until", "time", timestamp, "duration", waitDuration)
-		err := common.Sleep(ctx, waitDuration)
-		if err != nil {
-			return nil, enginetypes.PayloadAttributes{}, fmt.Errorf("start building: wait error: %w", err)
-		}
-	}
-	parentBeaconBlockRoot := common.U256ToHash(cl.state.ParentClBlockRoot)
-	slotNumber := cl.state.NextSlotNumber()
-	withdrawals := make([]*types.Withdrawal, 0)
-	if options.withdrawals != nil {
-		withdrawals = options.withdrawals
-	}
-	payloadAttributes := enginetypes.PayloadAttributes{
-		Timestamp:             hexutil.Uint64(timestamp),
-		PrevRandao:            common.U256ToHash(cl.state.ParentRandao),
-		SuggestedFeeRecipient: cl.suggestedFeeRecipient,
-		Withdrawals:           withdrawals,
-		ParentBeaconBlockRoot: &parentBeaconBlockRoot,
-	}
-	if cl.chainConfig.AmsterdamTime != nil {
-		payloadAttributes.SlotNumber = (*hexutil.Uint64)(&slotNumber)
-		targetGasLimit := hexutil.Uint64(cl.genesisGasLimit)
-		payloadAttributes.TargetGasLimit = &targetGasLimit
-	}
-	cl.logger.Debug("[mock-cl] building block", "timestamp", timestamp)
-	// start the block building process
 	fcuRes, err := RetryEngine(ctx, []enginetypes.EngineStatus{enginetypes.SyncingStatus}, nil,
 		func() (*enginetypes.ForkChoiceUpdatedResponse, enginetypes.EngineStatus, error) {
 			var r *enginetypes.ForkChoiceUpdatedResponse
@@ -165,6 +130,84 @@ func (cl *MockCl) StartBuilding(ctx context.Context, opts ...BlockBuildingOption
 		return nil, enginetypes.PayloadAttributes{}, fmt.Errorf("forkchoiceUpdated for block building returned no payload id")
 	}
 	return *fcuRes.PayloadId, payloadAttributes, nil
+}
+
+func (cl *MockCl) nextPayloadBuildInputs(ctx context.Context, opts ...BlockBuildingOption) (enginetypes.ForkChoiceState, enginetypes.PayloadAttributes, error) {
+	options := cl.applyBlockBuildingOptions(opts...)
+	forkChoiceState := enginetypes.ForkChoiceState{
+		HeadHash:           cl.state.ParentElBlock,
+		SafeBlockHash:      cl.genesis,
+		FinalizedBlockHash: cl.genesis,
+	}
+	var timestamp uint64
+	if options.timestamp != nil {
+		timestamp = *options.timestamp
+	} else {
+		timestamp = cl.state.ParentElTimestamp + 1
+	}
+	if options.waitUntilTimestamp {
+		waitDuration := time.Until(time.Unix(int64(timestamp), 0)) + 100*time.Millisecond
+		cl.logger.Debug("[mock-cl] waiting until", "time", timestamp, "duration", waitDuration)
+		err := common.Sleep(ctx, waitDuration)
+		if err != nil {
+			return enginetypes.ForkChoiceState{}, enginetypes.PayloadAttributes{}, fmt.Errorf("wait error: %w", err)
+		}
+	}
+	parentBeaconBlockRoot := common.U256ToHash(cl.state.ParentClBlockRoot)
+	slotNumber := cl.state.NextSlotNumber()
+	withdrawals := make([]*types.Withdrawal, 0)
+	if options.withdrawals != nil {
+		withdrawals = options.withdrawals
+	}
+	payloadAttributes := enginetypes.PayloadAttributes{
+		Timestamp:             hexutil.Uint64(timestamp),
+		PrevRandao:            common.U256ToHash(cl.state.ParentRandao),
+		SuggestedFeeRecipient: cl.suggestedFeeRecipient,
+		Withdrawals:           withdrawals,
+		ParentBeaconBlockRoot: &parentBeaconBlockRoot,
+	}
+	if cl.chainConfig.AmsterdamTime != nil {
+		payloadAttributes.SlotNumber = (*hexutil.Uint64)(&slotNumber)
+		targetGasLimit := hexutil.Uint64(cl.genesisGasLimit)
+		payloadAttributes.TargetGasLimit = &targetGasLimit
+	}
+	cl.logger.Debug("[mock-cl] building block", "timestamp", timestamp)
+	return forkChoiceState, payloadAttributes, nil
+}
+
+// BuildEmptyPayload builds a payload with an explicit empty transaction list.
+func (cl *MockCl) BuildEmptyPayload(
+	ctx context.Context,
+	call func(context.Context, any, string, ...any) error,
+	opts ...BlockBuildingOption,
+) (*MockClPayload, error) {
+	forkChoiceState, payloadAttributes, err := cl.nextPayloadBuildInputs(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("build empty payload: %w", err)
+	}
+	emptyTransactions := []hexutil.Bytes{}
+	var response enginetypes.GetPayloadResponse
+	if err := call(
+		ctx,
+		&response,
+		"testing_buildBlockV1",
+		forkChoiceState.HeadHash,
+		&payloadAttributes,
+		&emptyTransactions,
+		nil,
+	); err != nil {
+		return nil, fmt.Errorf("build empty payload: %w", err)
+	}
+	if response.ExecutionPayload == nil {
+		return nil, errors.New("build empty payload: response has no execution payload")
+	}
+	if len(response.ExecutionPayload.Transactions) != 0 {
+		return nil, fmt.Errorf("build empty payload: response has %d transactions", len(response.ExecutionPayload.Transactions))
+	}
+	return &MockClPayload{
+		GetPayloadResponse:    &response,
+		ParentBeaconBlockRoot: payloadAttributes.ParentBeaconBlockRoot,
+	}, nil
 }
 
 // GetBuiltPayload fetches the payload being built under the given id using the fork-appropriate

--- a/execution/engineapi/engineapitester/mock_cl_test.go
+++ b/execution/engineapi/engineapitester/mock_cl_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package engineapitester
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/execution/chain"
+	enginetypes "github.com/erigontech/erigon/execution/engineapi/engine_types"
+)
+
+func TestBuildEmptyPayloadSuppliesExplicitEmptyTransactions(t *testing.T) {
+	parentHash := common.HexToHash("0x01")
+	cl := &MockCl{
+		logger:          log.New(),
+		genesis:         common.HexToHash("0x02"),
+		genesisGasLimit: 30_000_000,
+		state: &MockClState{
+			ParentElBlock:     parentHash,
+			ParentElTimestamp: 1,
+		},
+		chainConfig: &chain.Config{},
+	}
+
+	ctx := t.Context()
+	payload, err := cl.BuildEmptyPayload(ctx, func(
+		gotCtx context.Context,
+		result any,
+		method string,
+		args ...any,
+	) error {
+		require.Equal(t, ctx, gotCtx)
+		require.Equal(t, "testing_buildBlockV1", method)
+		require.Len(t, args, 4)
+		require.Equal(t, parentHash, args[0])
+		attributes, ok := args[1].(*enginetypes.PayloadAttributes)
+		require.True(t, ok)
+		require.NotNil(t, attributes.ParentBeaconBlockRoot)
+		transactions, ok := args[2].(*[]hexutil.Bytes)
+		require.True(t, ok)
+		require.NotNil(t, transactions)
+		require.Empty(t, *transactions)
+		require.Nil(t, args[3])
+
+		response, ok := result.(*enginetypes.GetPayloadResponse)
+		require.True(t, ok)
+		response.ExecutionPayload = &enginetypes.ExecutionPayload{Transactions: []hexutil.Bytes{}}
+		return nil
+	})
+	require.NoError(t, err)
+	require.Empty(t, payload.ExecutionPayload.Transactions)
+	require.NotNil(t, payload.ParentBeaconBlockRoot)
+}

--- a/execution/engineapi/engineapitester/state_cache.go
+++ b/execution/engineapi/engineapitester/state_cache.go
@@ -1,0 +1,46 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package engineapitester
+
+import (
+	"context"
+
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/kvcache"
+	"github.com/erigontech/erigon/execution/execmodule"
+)
+
+type rpcViewObserverCache struct {
+	kvcache.Cache
+	observer execmodule.StateTransitionObserver
+}
+
+func withRPCViewObserver(cache kvcache.Cache, observer execmodule.StateTransitionObserver) kvcache.Cache {
+	if observer == nil {
+		return cache
+	}
+	return &rpcViewObserverCache{Cache: cache, observer: observer}
+}
+
+func (c *rpcViewObserverCache) View(ctx context.Context, tx kv.TemporalTx) (kvcache.CacheView, error) {
+	view, err := c.Cache.View(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	c.observer(ctx, execmodule.StateTransitionRPCViewBound)
+	return view, nil
+}

--- a/execution/engineapi/engineapitester/state_cache_test.go
+++ b/execution/engineapi/engineapitester/state_cache_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package engineapitester
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/kvcache"
+	"github.com/erigontech/erigon/execution/execmodule"
+)
+
+type viewOnlyCache struct {
+	kvcache.Cache
+	view kvcache.CacheView
+}
+
+func (c viewOnlyCache) View(context.Context, kv.TemporalTx) (kvcache.CacheView, error) {
+	return c.view, nil
+}
+
+type stubCacheView struct{}
+
+func (*stubCacheView) Get([]byte) ([]byte, error)              { return nil, nil }
+func (*stubCacheView) GetCode([]byte) ([]byte, error)          { return nil, nil }
+func (*stubCacheView) HasStorage(common.Address) (bool, error) { return false, nil }
+
+func TestRPCViewObserverRunsSynchronouslyAfterBinding(t *testing.T) {
+	type observation struct {
+		ctx   context.Context
+		point execmodule.StateTransitionPoint
+	}
+	type viewResult struct {
+		view kvcache.CacheView
+		err  error
+	}
+
+	observed := make(chan observation, 1)
+	release := make(chan struct{})
+	releaseObserver := sync.OnceFunc(func() { close(release) })
+	t.Cleanup(releaseObserver)
+	ctx := t.Context()
+	expectedView := &stubCacheView{}
+	cache := withRPCViewObserver(viewOnlyCache{view: expectedView}, func(ctx context.Context, point execmodule.StateTransitionPoint) {
+		observed <- observation{ctx: ctx, point: point}
+		<-release
+	})
+	result := make(chan viewResult, 1)
+	go func() {
+		view, err := cache.View(ctx, nil)
+		result <- viewResult{view: view, err: err}
+	}()
+
+	select {
+	case got := <-observed:
+		require.Equal(t, ctx, got.ctx)
+		require.Equal(t, execmodule.StateTransitionRPCViewBound, got.point)
+	case <-time.After(time.Second):
+		t.Fatal("RPC view observer was not called")
+	}
+	select {
+	case <-result:
+		t.Fatal("cache view returned before the observer was released")
+	default:
+	}
+	releaseObserver()
+	select {
+	case got := <-result:
+		require.NoError(t, got.err)
+		require.Same(t, expectedView, got.view)
+	case <-time.After(time.Second):
+		t.Fatal("cache view did not return after the observer was released")
+	}
+}

--- a/execution/execmodule/exec_module.go
+++ b/execution/execmodule/exec_module.go
@@ -314,13 +314,20 @@ func NewExecModule(
 	return em
 }
 
-// WaitIdle blocks until any in-flight updateForkChoice goroutine finishes.
-// Call before closing the database to avoid waitTxsAllDoneOnClose hangs.
+// WaitIdle blocks until any in-flight updateForkChoice goroutine finishes or
+// ctx ends.
 func (e *ExecModule) WaitIdle(ctx context.Context) {
 	if err := e.semaphore.Acquire(ctx, 1); err != nil {
 		return // context cancelled — best effort
 	}
 	e.semaphore.Release(1)
+}
+
+// Drain waits without a local timeout for serialized execution work to finish.
+// Callers must stop producers first because backing resources are unsafe to
+// close while execution still holds a transaction.
+func (e *ExecModule) Drain() {
+	e.WaitIdle(context.Background())
 }
 
 // newDomainStateCache is the module's one construction site of the domain

--- a/execution/execmodule/exec_module.go
+++ b/execution/execmodule/exec_module.go
@@ -104,8 +104,14 @@ func GetBlockHashFromMissingSegmentError(err error) (common.Hash, bool) {
 // the SD is the authoritative source, so the coherent cache's state-tracking
 // machinery is unnecessary.
 type Cache struct {
-	execModule  *ExecModule
-	publishedSD func() *execctx.SharedDomains // returns the latest published SD from Events
+	execModule              *ExecModule
+	publishedSD             func() *execctx.SharedDomains // returns the latest published SD from Events
+	stateTransitionObserver StateTransitionObserver
+}
+
+// NewCache creates the RPC state cache bridge with an optional lifecycle observer.
+func NewCache(observer StateTransitionObserver) *Cache {
+	return &Cache{stateTransitionObserver: observer}
 }
 
 // SetPublishedSD wires the Cache to fall back to the published SD from Events
@@ -117,25 +123,26 @@ func (c *Cache) SetPublishedSD(provider func() *execctx.SharedDomains) {
 var _ kvcache.Cache = (*Cache)(nil)         // compile-time interface check
 var _ kvcache.CacheView = (*CacheView)(nil) // compile-time interface check
 
-func (c *Cache) View(_ context.Context, tx kv.TemporalTx) (kvcache.CacheView, error) {
-	var context *execctx.SharedDomains
+func (c *Cache) View(ctx context.Context, tx kv.TemporalTx) (kvcache.CacheView, error) {
+	var sd *execctx.SharedDomains
 	if c.execModule != nil {
 		c.execModule.lock.RLock()
-		context = c.execModule.currentContext
+		sd = c.execModule.currentContext
 		c.execModule.lock.RUnlock()
 	}
 	// Fall back to the published SD from Events while an FCU commits
 	// (currentContext is nil but the SD is still valid in memory).
-	if context == nil && c.publishedSD != nil {
-		context = c.publishedSD()
+	if sd == nil && c.publishedSD != nil {
+		sd = c.publishedSD()
 	}
 
 	var view *CacheView
-	if context != nil {
-		view = &CacheView{context: context, getter: context.AsStateGetter(tx, execctxapi.StateGetterOptions{})}
+	if sd != nil {
+		view = &CacheView{context: sd, getter: sd.AsStateGetter(tx, execctxapi.StateGetterOptions{})}
 	} else {
 		view = &CacheView{getter: execctx.NewTemporalTxStateGetter(tx)}
 	}
+	c.observeStateTransition(ctx, StateTransitionRPCViewBound)
 	return view, nil
 }
 func (c *Cache) OnNewBlock(sc *remoteproto.StateChangeBatch) {}
@@ -230,6 +237,8 @@ type ExecModule struct {
 	codeStore   *cache.CodeStore
 	readAheader *exec.BlockReadAheader
 
+	stateTransitionObserver StateTransitionObserver
+
 	stopNode func() error
 }
 
@@ -297,6 +306,7 @@ func NewExecModule(
 
 	if stateCache != nil {
 		stateCache.execModule = em
+		em.stateTransitionObserver = stateCache.stateTransitionObserver
 	}
 	return em
 }

--- a/execution/execmodule/exec_module.go
+++ b/execution/execmodule/exec_module.go
@@ -109,7 +109,8 @@ type Cache struct {
 	stateTransitionObserver StateTransitionObserver
 }
 
-// NewCache creates the RPC state cache bridge with an optional lifecycle observer.
+// NewCache creates the RPC state bridge. A nil observer disables test
+// instrumentation.
 func NewCache(observer StateTransitionObserver) *Cache {
 	return &Cache{stateTransitionObserver: observer}
 }
@@ -142,6 +143,8 @@ func (c *Cache) View(ctx context.Context, tx kv.TemporalTx) (kvcache.CacheView, 
 	} else {
 		view = &CacheView{getter: execctx.NewTemporalTxStateGetter(tx)}
 	}
+	// Notify after selecting the getter so a paused request stays bound to this
+	// exact state view while forkchoice advances.
 	c.observeStateTransition(ctx, StateTransitionRPCViewBound)
 	return view, nil
 }

--- a/execution/execmodule/exec_module.go
+++ b/execution/execmodule/exec_module.go
@@ -104,15 +104,13 @@ func GetBlockHashFromMissingSegmentError(err error) (common.Hash, bool) {
 // the SD is the authoritative source, so the coherent cache's state-tracking
 // machinery is unnecessary.
 type Cache struct {
-	execModule              *ExecModule
-	publishedSD             func() *execctx.SharedDomains // returns the latest published SD from Events
-	stateTransitionObserver StateTransitionObserver
+	execModule  *ExecModule
+	publishedSD func() *execctx.SharedDomains // returns the latest published SD from Events
 }
 
-// NewCache creates the RPC state bridge. A nil observer disables test
-// instrumentation.
-func NewCache(observer StateTransitionObserver) *Cache {
-	return &Cache{stateTransitionObserver: observer}
+// NewCache creates the RPC state bridge.
+func NewCache() *Cache {
+	return &Cache{}
 }
 
 // SetPublishedSD wires the Cache to fall back to the published SD from Events
@@ -143,9 +141,6 @@ func (c *Cache) View(ctx context.Context, tx kv.TemporalTx) (kvcache.CacheView, 
 	} else {
 		view = &CacheView{getter: execctx.NewTemporalTxStateGetter(tx)}
 	}
-	// Notify after selecting the getter so a paused request stays bound to this
-	// exact state view while forkchoice advances.
-	c.observeStateTransition(ctx, StateTransitionRPCViewBound)
 	return view, nil
 }
 func (c *Cache) OnNewBlock(sc *remoteproto.StateChangeBatch) {}
@@ -247,6 +242,17 @@ type ExecModule struct {
 
 var _ ExecutionModule = (*ExecModule)(nil) // compile-time interface check
 
+// ExecModuleOption configures execution-module construction.
+type ExecModuleOption func(*ExecModule)
+
+// WithStateTransitionObserver enables deterministic execution lifecycle hooks
+// for integration tests.
+func WithStateTransitionObserver(observer StateTransitionObserver) ExecModuleOption {
+	return func(module *ExecModule) {
+		module.stateTransitionObserver = observer
+	}
+}
+
 func NewExecModule(
 	ctx context.Context,
 	blockReader dbservices.FullBlockReader,
@@ -266,6 +272,7 @@ func NewExecModule(
 	onlySnapDownloadOnStart bool,
 	readAheader *exec.BlockReadAheader,
 	stopNode func() error,
+	opts ...ExecModuleOption,
 ) *ExecModule {
 	domainCache := newDomainStateCache(stateCacheBudget)
 	execctx.GuardAggregatorForCache(db, domainCache)
@@ -299,6 +306,9 @@ func NewExecModule(
 		readAheader:             readAheader,
 		stopNode:                stopNode,
 	}
+	for _, opt := range opts {
+		opt(em)
+	}
 
 	// Wire the process-global state cache into the read-ahead so its
 	// prefetches populate the same hashmap that SharedDomains.GetLatest
@@ -309,7 +319,6 @@ func NewExecModule(
 
 	if stateCache != nil {
 		stateCache.execModule = em
-		em.stateTransitionObserver = stateCache.stateTransitionObserver
 	}
 	return em
 }

--- a/execution/execmodule/exec_module.go
+++ b/execution/execmodule/exec_module.go
@@ -108,11 +108,6 @@ type Cache struct {
 	publishedSD func() *execctx.SharedDomains // returns the latest published SD from Events
 }
 
-// NewCache creates the RPC state bridge.
-func NewCache() *Cache {
-	return &Cache{}
-}
-
 // SetPublishedSD wires the Cache to fall back to the published SD from Events
 // when the exec module's currentContext is nil (e.g. while an FCU commits).
 func (c *Cache) SetPublishedSD(provider func() *execctx.SharedDomains) {

--- a/execution/execmodule/exec_module_internal_test.go
+++ b/execution/execmodule/exec_module_internal_test.go
@@ -19,7 +19,9 @@ package execmodule
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/c2h5oh/datasize"
 	"github.com/holiman/uint256"
@@ -30,6 +32,7 @@ import (
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/dbservices"
 	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/kvcache"
 	"github.com/erigontech/erigon/execution/types"
 )
 
@@ -73,6 +76,54 @@ func (r sideForkReader) BodyWithTransactions(_ context.Context, _ kv.Getter, has
 		return r.forkBody, nil
 	}
 	return nil, nil
+}
+
+func TestCacheViewObserverRunsSynchronouslyAfterBinding(t *testing.T) {
+	type observation struct {
+		ctx   context.Context
+		point StateTransitionPoint
+	}
+	type viewResult struct {
+		view kvcache.CacheView
+		err  error
+	}
+
+	observed := make(chan observation, 1)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseObserver := func() { releaseOnce.Do(func() { close(release) }) }
+	t.Cleanup(releaseObserver)
+	ctx := t.Context()
+	cache := NewCache(func(ctx context.Context, point StateTransitionPoint) {
+		observed <- observation{ctx: ctx, point: point}
+		<-release
+	})
+	result := make(chan viewResult, 1)
+	go func() {
+		view, err := cache.View(ctx, nil)
+		result <- viewResult{view: view, err: err}
+	}()
+
+	select {
+	case got := <-observed:
+		require.Equal(t, ctx, got.ctx)
+		require.Equal(t, StateTransitionRPCViewBound, got.point)
+	case <-time.After(time.Second):
+		t.Fatal("cache view observer was not called")
+	}
+	select {
+	case <-result:
+		t.Fatal("cache view returned before the observer was released")
+	default:
+	}
+	releaseObserver()
+	select {
+	case got := <-result:
+		require.NoError(t, got.err)
+		require.NotNil(t, got.view)
+	case <-time.After(time.Second):
+		t.Fatal("cache view did not return after the observer was released")
+	}
 }
 
 // The module is the one owner of the domain state cache: callers pass a byte

--- a/execution/execmodule/exec_module_internal_test.go
+++ b/execution/execmodule/exec_module_internal_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/dbservices"
 	"github.com/erigontech/erigon/db/kv"
-	"github.com/erigontech/erigon/db/kv/kvcache"
 	"github.com/erigontech/erigon/execution/types"
 )
 
@@ -106,54 +105,6 @@ func (r sideForkReader) BodyWithTransactions(_ context.Context, _ kv.Getter, has
 		return r.forkBody, nil
 	}
 	return nil, nil
-}
-
-func TestCacheViewObserverRunsSynchronouslyAfterBinding(t *testing.T) {
-	type observation struct {
-		ctx   context.Context
-		point StateTransitionPoint
-	}
-	type viewResult struct {
-		view kvcache.CacheView
-		err  error
-	}
-
-	observed := make(chan observation, 1)
-	release := make(chan struct{})
-	var releaseOnce sync.Once
-	releaseObserver := func() { releaseOnce.Do(func() { close(release) }) }
-	t.Cleanup(releaseObserver)
-	ctx := t.Context()
-	cache := NewCache(func(ctx context.Context, point StateTransitionPoint) {
-		observed <- observation{ctx: ctx, point: point}
-		<-release
-	})
-	result := make(chan viewResult, 1)
-	go func() {
-		view, err := cache.View(ctx, nil)
-		result <- viewResult{view: view, err: err}
-	}()
-
-	select {
-	case got := <-observed:
-		require.Equal(t, ctx, got.ctx)
-		require.Equal(t, StateTransitionRPCViewBound, got.point)
-	case <-time.After(time.Second):
-		t.Fatal("cache view observer was not called")
-	}
-	select {
-	case <-result:
-		t.Fatal("cache view returned before the observer was released")
-	default:
-	}
-	releaseObserver()
-	select {
-	case got := <-result:
-		require.NoError(t, got.err)
-		require.NotNil(t, got.view)
-	case <-time.After(time.Second):
-		t.Fatal("cache view did not return after the observer was released")
-	}
 }
 
 // The module is the one owner of the domain state cache: callers pass a byte

--- a/execution/execmodule/exec_module_internal_test.go
+++ b/execution/execmodule/exec_module_internal_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/c2h5oh/datasize"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dbg"
@@ -58,6 +59,35 @@ type sideForkReader struct {
 	canonicalHash common.Hash
 	forkHeader    *types.Header
 	forkBody      *types.Body
+}
+
+func TestDrainWaitsForInFlightExecution(t *testing.T) {
+	module := &ExecModule{semaphore: semaphore.NewWeighted(1)}
+	require.NoError(t, module.semaphore.Acquire(t.Context(), 1))
+	release := sync.OnceFunc(func() { module.semaphore.Release(1) })
+	t.Cleanup(release)
+
+	started := make(chan struct{})
+	drained := make(chan struct{})
+	go func() {
+		close(started)
+		module.Drain()
+		close(drained)
+	}()
+	<-started
+
+	select {
+	case <-drained:
+		t.Fatal("drain returned while execution was still active")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	release()
+	select {
+	case <-drained:
+	case <-time.After(time.Second):
+		t.Fatal("drain did not return after execution became idle")
+	}
 }
 
 func (r sideForkReader) IsCanonical(_ context.Context, _ kv.Getter, hash common.Hash, _ uint64) (bool, error) {

--- a/execution/execmodule/execmoduletester/exec_module_tester.go
+++ b/execution/execmodule/execmoduletester/exec_module_tester.go
@@ -763,7 +763,7 @@ func New(tb testing.TB, opts ...Option) *ExecModuleTester {
 
 	hook := stageloop.NewHook(mock.Ctx, mock.Notifications, mock.posStagedSync, mock.ChainConfig, logger, dispatcher, nil, nil, nil, mock.BlockReader)
 
-	mock.StateCache = &execmodule.Cache{}
+	mock.StateCache = execmodule.NewCache(nil)
 
 	accum := &execmodule.Accumulation{
 		Accumulator:    mock.Notifications.Accumulator,

--- a/execution/execmodule/execmoduletester/exec_module_tester.go
+++ b/execution/execmodule/execmoduletester/exec_module_tester.go
@@ -771,7 +771,7 @@ func New(tb testing.TB, opts ...Option) *ExecModuleTester {
 
 	hook := stageloop.NewHook(mock.Ctx, mock.Notifications, mock.posStagedSync, mock.ChainConfig, logger, dispatcher, nil, nil, nil, mock.BlockReader)
 
-	mock.StateCache = execmodule.NewCache(opt.stateTransitionObserver)
+	mock.StateCache = execmodule.NewCache()
 
 	accum := &execmodule.Accumulation{
 		Accumulator:    mock.Notifications.Accumulator,
@@ -796,6 +796,7 @@ func New(tb testing.TB, opts ...Option) *ExecModuleTester {
 		false, /* onlySnapDownloadOnStart */
 		readAheader,
 		func() error { return nil },
+		execmodule.WithStateTransitionObserver(opt.stateTransitionObserver),
 	)
 	mock.ForkValidator = mock.ExecModule.ForkValidator()
 

--- a/execution/execmodule/execmoduletester/exec_module_tester.go
+++ b/execution/execmodule/execmoduletester/exec_module_tester.go
@@ -383,6 +383,13 @@ func WithSentryProtocol(protocol uint) Option {
 	}
 }
 
+// WithStateTransitionObserver exposes execution lifecycle boundaries to tests.
+func WithStateTransitionObserver(observer execmodule.StateTransitionObserver) Option {
+	return func(opts *options) {
+		opts.stateTransitionObserver = observer
+	}
+}
+
 type options struct {
 	stepSize                      *uint64
 	e2RetireStep                  *uint64
@@ -398,6 +405,7 @@ type options struct {
 	alwaysGenerateChangesets      *bool
 	maxReorgDepth                 *uint64
 	sentryProtocol                uint
+	stateTransitionObserver       execmodule.StateTransitionObserver
 	skipAmsterdamBuilderContracts bool
 }
 
@@ -763,7 +771,7 @@ func New(tb testing.TB, opts ...Option) *ExecModuleTester {
 
 	hook := stageloop.NewHook(mock.Ctx, mock.Notifications, mock.posStagedSync, mock.ChainConfig, logger, dispatcher, nil, nil, nil, mock.BlockReader)
 
-	mock.StateCache = execmodule.NewCache(nil)
+	mock.StateCache = execmodule.NewCache(opt.stateTransitionObserver)
 
 	accum := &execmodule.Accumulation{
 		Accumulator:    mock.Notifications.Accumulator,

--- a/execution/execmodule/execmoduletester/exec_module_tester.go
+++ b/execution/execmodule/execmoduletester/exec_module_tester.go
@@ -771,7 +771,7 @@ func New(tb testing.TB, opts ...Option) *ExecModuleTester {
 
 	hook := stageloop.NewHook(mock.Ctx, mock.Notifications, mock.posStagedSync, mock.ChainConfig, logger, dispatcher, nil, nil, nil, mock.BlockReader)
 
-	mock.StateCache = execmodule.NewCache()
+	mock.StateCache = &execmodule.Cache{}
 
 	accum := &execmodule.Accumulation{
 		Accumulator:    mock.Notifications.Accumulator,

--- a/execution/execmodule/execmoduletester/exec_module_tester_test.go
+++ b/execution/execmodule/execmoduletester/exec_module_tester_test.go
@@ -51,11 +51,11 @@ func TestInsertChain(t *testing.T) {
 
 func TestStateTransitionObserver(t *testing.T) {
 	t.Parallel()
-	observed := make(map[execmodule.StateTransitionPoint]bool)
+	observed := make(map[execmodule.StateTransitionPoint]int)
 	var mu sync.Mutex
 	m := execmoduletester.New(t, execmoduletester.WithStateTransitionObserver(func(_ context.Context, point execmodule.StateTransitionPoint) {
 		mu.Lock()
-		observed[point] = true
+		observed[point]++
 		mu.Unlock()
 	}))
 	chain, err := m.GenerateChain(1, func(_ int, b *blockgen.BlockGen) {
@@ -72,8 +72,11 @@ func TestStateTransitionObserver(t *testing.T) {
 		execmodule.StateTransitionCommitComplete,
 		execmodule.StateTransitionOverlayCleared,
 	} {
-		require.Truef(t, observed[point], "state transition %d was not observed", point)
+		require.Positivef(t, observed[point], "state transition %d was not observed", point)
 	}
+	published := observed[execmodule.StateTransitionOverlayPublished]
+	require.Equal(t, published, observed[execmodule.StateTransitionCommitComplete], "each published FCU result must become durable")
+	require.Equal(t, published, observed[execmodule.StateTransitionOverlayCleared], "only a published overlay may emit a clear event")
 }
 
 func TestReorgsWithInsertChain(t *testing.T) {

--- a/execution/execmodule/execmoduletester/exec_module_tester_test.go
+++ b/execution/execmodule/execmoduletester/exec_module_tester_test.go
@@ -17,11 +17,14 @@
 package execmoduletester_test
 
 import (
+	"context"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/execmodule"
 	"github.com/erigontech/erigon/execution/execmodule/execmoduletester"
 	"github.com/erigontech/erigon/execution/tests/blockgen"
 )
@@ -44,6 +47,33 @@ func TestInsertChain(t *testing.T) {
 	require.NoError(t, err)
 	err = m.InsertChain(chain)
 	require.NoError(t, err)
+}
+
+func TestStateTransitionObserver(t *testing.T) {
+	t.Parallel()
+	observed := make(map[execmodule.StateTransitionPoint]bool)
+	var mu sync.Mutex
+	m := execmoduletester.New(t, execmoduletester.WithStateTransitionObserver(func(_ context.Context, point execmodule.StateTransitionPoint) {
+		mu.Lock()
+		observed[point] = true
+		mu.Unlock()
+	}))
+	chain, err := m.GenerateChain(1, func(_ int, b *blockgen.BlockGen) {
+		b.SetCoinbase(common.Address{1})
+	})
+	require.NoError(t, err)
+	require.NoError(t, m.InsertValidateAndUfc1By1(t.Context(), chain.Blocks))
+	m.ExecModule.WaitIdle(t.Context())
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, point := range []execmodule.StateTransitionPoint{
+		execmodule.StateTransitionOverlayPublished,
+		execmodule.StateTransitionCommitComplete,
+		execmodule.StateTransitionOverlayCleared,
+	} {
+		require.Truef(t, observed[point], "state transition %d was not observed", point)
+	}
 }
 
 func TestReorgsWithInsertChain(t *testing.T) {

--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -695,7 +695,7 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 		// released and flush/commit/prune can proceed without blocking the
 		// next FCU.
 		e.logger.Debug("[updateForkChoice] dispatching notifications", "head", blockHash)
-		if err := e.dispatchNotificationsFromOverlay(currentContext, finishProgressBefore); err != nil {
+		if err := e.dispatchNotificationsFromOverlay(ctx, currentContext, finishProgressBefore); err != nil {
 			return sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, fmt.Errorf("fcu: dispatch notifications: %w", err), stateFlushingInParallel)
 		}
 
@@ -775,7 +775,7 @@ func (e *ExecModule) logTimings(msg string, timings []any) {
 // domain flush, not the metadata overlay, owns its durable sequence advance.
 // Dispatch must finish before the execution semaphore is released so the next
 // FCU cannot overtake these notifications.
-func (e *ExecModule) dispatchNotificationsFromOverlay(sd *execctx.SharedDomains, finishProgressBefore uint64) error {
+func (e *ExecModule) dispatchNotificationsFromOverlay(ctx context.Context, sd *execctx.SharedDomains, finishProgressBefore uint64) error {
 	dispatcher := e.pipelineExecutor.Dispatcher()
 	if dispatcher == nil || e.accum == nil {
 		e.logger.Debug("[dispatchNotifications] skipped: dispatcher or accum nil", "dispatcherNil", dispatcher == nil, "accumNil", e.accum == nil)
@@ -799,7 +799,9 @@ func (e *ExecModule) dispatchNotificationsFromOverlay(sd *execctx.SharedDomains,
 	// before any StateChangeBatch arrives, so it can buffer events properly.
 	e.logger.Debug("[dispatchNotifications] publishing SD")
 	dispatcher.PublishOverlay(sd)
-	e.observeStateTransition(e.backgroundCtx, StateTransitionOverlayPublished)
+	// Overlay publication is drop-tolerant; the observer supplies the blocking
+	// boundary required by deterministic integration tests.
+	e.observeStateTransition(ctx, StateTransitionOverlayPublished)
 
 	e.logger.Debug("[dispatchNotifications] dispatching", "finishBefore", finishProgressBefore, "finishAfter", finishProgressAfter)
 	if err := dispatcher.Dispatch(

--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -290,6 +290,7 @@ func (e *ExecModule) unwindIfNeeded(
 			err = fmt.Errorf("updateForkChoice: %w", err)
 			return nil, err
 		}
+		e.observeStateTransition(ctx, StateTransitionUnwindComplete)
 	}
 	// SD.Unwind (inside RunUnwind) tx-aware-invalidates the BranchCache by
 	// the unwound txNum, so no whole-cache clear is needed here.
@@ -419,6 +420,7 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 		}
 		if dispatcher := e.pipelineExecutor.Dispatcher(); dispatcher != nil {
 			dispatcher.PublishOverlay(nil)
+			e.observeStateTransition(ctx, StateTransitionOverlayCleared)
 		}
 		currentContext.Close()
 		currentContext = nil
@@ -716,6 +718,7 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 		if err != nil {
 			return sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, err, stateFlushingInParallel)
 		}
+		e.observeStateTransition(ctx, StateTransitionCommitComplete)
 
 		// Prune: background by default (fcuBackgroundPrune=true). RunPrune
 		// shares the pipeline Sync with the next FCU's RunLoop, so the
@@ -796,6 +799,7 @@ func (e *ExecModule) dispatchNotificationsFromOverlay(sd *execctx.SharedDomains,
 	// before any StateChangeBatch arrives, so it can buffer events properly.
 	e.logger.Debug("[dispatchNotifications] publishing SD")
 	dispatcher.PublishOverlay(sd)
+	e.observeStateTransition(e.backgroundCtx, StateTransitionOverlayPublished)
 
 	e.logger.Debug("[dispatchNotifications] dispatching", "finishBefore", finishProgressBefore, "finishAfter", finishProgressAfter)
 	if err := dispatcher.Dispatch(

--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -414,13 +414,17 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 	// Clear the published overlay before closing the SD, so concurrent
 	// readers (e.g. a second FCU calling GetHeaderByHash) don't access
 	// a closed SharedDomains via Events.LatestSD().
+	overlayPublished := false
 	teardownOverlay := func() {
 		if currentContext == nil {
 			return
 		}
 		if dispatcher := e.pipelineExecutor.Dispatcher(); dispatcher != nil {
 			dispatcher.PublishOverlay(nil)
-			e.observeStateTransition(ctx, StateTransitionOverlayCleared)
+			if overlayPublished {
+				overlayPublished = false
+				e.observeStateTransition(ctx, StateTransitionOverlayCleared)
+			}
 		}
 		currentContext.Close()
 		currentContext = nil
@@ -695,8 +699,10 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 		// released and flush/commit/prune can proceed without blocking the
 		// next FCU.
 		e.logger.Debug("[updateForkChoice] dispatching notifications", "head", blockHash)
-		if err := e.dispatchNotificationsFromOverlay(ctx, currentContext, finishProgressBefore); err != nil {
-			return sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, fmt.Errorf("fcu: dispatch notifications: %w", err), stateFlushingInParallel)
+		published, dispatchErr := e.dispatchNotificationsFromOverlay(ctx, currentContext, finishProgressBefore)
+		overlayPublished = published
+		if dispatchErr != nil {
+			return sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, fmt.Errorf("fcu: dispatch notifications: %w", dispatchErr), stateFlushingInParallel)
 		}
 
 		// Hand the semaphore to a background goroutine: FCU cleanup runs first,
@@ -774,25 +780,26 @@ func (e *ExecModule) logTimings(msg string, timings []any) {
 // SD's block overlay. The state version is supplied separately because the
 // domain flush, not the metadata overlay, owns its durable sequence advance.
 // Dispatch must finish before the execution semaphore is released so the next
-// FCU cannot overtake these notifications.
-func (e *ExecModule) dispatchNotificationsFromOverlay(ctx context.Context, sd *execctx.SharedDomains, finishProgressBefore uint64) error {
+// FCU cannot overtake these notifications. The result reports whether
+// publication happened, including when the later notification dispatch fails.
+func (e *ExecModule) dispatchNotificationsFromOverlay(ctx context.Context, sd *execctx.SharedDomains, finishProgressBefore uint64) (bool, error) {
 	dispatcher := e.pipelineExecutor.Dispatcher()
 	if dispatcher == nil || e.accum == nil {
 		e.logger.Debug("[dispatchNotifications] skipped: dispatcher or accum nil", "dispatcherNil", dispatcher == nil, "accumNil", e.accum == nil)
-		return nil
+		return false, nil
 	}
 	overlay := sd.BlockOverlay()
 	if overlay == nil {
 		e.logger.Debug("[dispatchNotifications] skipped: overlay nil")
-		return nil
+		return false, nil
 	}
 	finishProgressAfter, err := stages.GetStageProgress(overlay, stages.Finish)
 	if err != nil {
-		return err
+		return false, err
 	}
 	stateVersion, err := sd.ProjectedStateVersion()
 	if err != nil {
-		return fmt.Errorf("project notification state version: %w", err)
+		return false, fmt.Errorf("project notification state version: %w", err)
 	}
 	// Publish the overlay BEFORE dispatching notifications. This ensures
 	// the BlockListener (overlay-aware shutter) sees the overlay as active
@@ -814,10 +821,10 @@ func (e *ExecModule) dispatchNotificationsFromOverlay(ctx context.Context, sd *e
 		finishProgressAfter,
 		e.pipelineExecutor.Sync().PrevUnwindPoint(),
 	); err != nil {
-		return err
+		return true, err
 	}
 
-	return nil
+	return true, nil
 }
 
 // runForkchoiceFlushCommit opens a brief RwTx, flushes the SharedDomains

--- a/execution/execmodule/state_transition.go
+++ b/execution/execmodule/state_transition.go
@@ -44,12 +44,6 @@ const (
 // lifecycle boundary. A blocking observer must return when its context ends.
 type StateTransitionObserver func(context.Context, StateTransitionPoint)
 
-func (c *Cache) observeStateTransition(ctx context.Context, point StateTransitionPoint) {
-	if c.stateTransitionObserver != nil {
-		c.stateTransitionObserver(ctx, point)
-	}
-}
-
 func (e *ExecModule) observeStateTransition(ctx context.Context, point StateTransitionPoint) {
 	if e.stateTransitionObserver != nil {
 		e.stateTransitionObserver(ctx, point)

--- a/execution/execmodule/state_transition.go
+++ b/execution/execmodule/state_transition.go
@@ -1,0 +1,45 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package execmodule
+
+import "context"
+
+// StateTransitionPoint identifies an RPC or forkchoice lifecycle boundary.
+type StateTransitionPoint uint8
+
+const (
+	StateTransitionRPCViewBound StateTransitionPoint = iota
+	StateTransitionUnwindComplete
+	StateTransitionOverlayPublished
+	StateTransitionCommitComplete
+	StateTransitionOverlayCleared
+)
+
+// StateTransitionObserver runs synchronously at each lifecycle boundary.
+type StateTransitionObserver func(context.Context, StateTransitionPoint)
+
+func (c *Cache) observeStateTransition(ctx context.Context, point StateTransitionPoint) {
+	if c.stateTransitionObserver != nil {
+		c.stateTransitionObserver(ctx, point)
+	}
+}
+
+func (e *ExecModule) observeStateTransition(ctx context.Context, point StateTransitionPoint) {
+	if e.stateTransitionObserver != nil {
+		e.stateTransitionObserver(ctx, point)
+	}
+}

--- a/execution/execmodule/state_transition.go
+++ b/execution/execmodule/state_transition.go
@@ -18,18 +18,30 @@ package execmodule
 
 import "context"
 
-// StateTransitionPoint identifies an RPC or forkchoice lifecycle boundary.
+// StateTransitionPoint identifies where an integration test may pause RPC view
+// binding or forkchoice processing.
 type StateTransitionPoint uint8
 
 const (
+	// StateTransitionRPCViewBound means the RPC getter has selected its
+	// SharedDomains or database view, but no state has been read yet.
 	StateTransitionRPCViewBound StateTransitionPoint = iota
+	// StateTransitionUnwindComplete means staged unwind replay has finished,
+	// before replacement canonical state is published.
 	StateTransitionUnwindComplete
+	// StateTransitionOverlayPublished means new RPC views can read the FCU result
+	// from SharedDomains before it is durable.
 	StateTransitionOverlayPublished
+	// StateTransitionCommitComplete means the FCU result is durable while the
+	// published SharedDomains remains available to RPC views.
 	StateTransitionCommitComplete
+	// StateTransitionOverlayCleared means new RPC views fall back to the
+	// committed database after SharedDomains is unpublished.
 	StateTransitionOverlayCleared
 )
 
-// StateTransitionObserver runs synchronously at each lifecycle boundary.
+// StateTransitionObserver is an integration-test hook that runs inline at each
+// lifecycle boundary. A blocking observer must return when its context ends.
 type StateTransitionObserver func(context.Context, StateTransitionPoint)
 
 func (c *Cache) observeStateTransition(ctx context.Context, point StateTransitionPoint) {

--- a/execution/execmodule/state_transition.go
+++ b/execution/execmodule/state_transition.go
@@ -26,7 +26,7 @@ const (
 	// StateTransitionRPCViewBound means the RPC getter has selected its
 	// SharedDomains or database view, but no state has been read yet.
 	StateTransitionRPCViewBound StateTransitionPoint = iota
-	// StateTransitionUnwindComplete means staged unwind replay has finished,
+	// StateTransitionUnwindComplete means forkchoice unwind replay has finished,
 	// before replacement canonical state is published.
 	StateTransitionUnwindComplete
 	// StateTransitionOverlayPublished means new RPC views can read the FCU result
@@ -36,7 +36,7 @@ const (
 	// published SharedDomains remains available to RPC views.
 	StateTransitionCommitComplete
 	// StateTransitionOverlayCleared means new RPC views fall back to the
-	// committed database after SharedDomains is unpublished.
+	// committed database after the FCU-published SharedDomains is unpublished.
 	StateTransitionOverlayCleared
 )
 

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -671,7 +671,10 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		blobGetter = backend.txPool
 	}
 
-	execmoduleCache := &execmodule.Cache{}
+	execmoduleCache, ok := stack.Config().Http.StateCache.LocalCache.(*execmodule.Cache)
+	if !ok || execmoduleCache == nil {
+		execmoduleCache = execmodule.NewCache(nil)
+	}
 	execmoduleCache.SetPublishedSD(backend.notifications.Events.LatestSD)
 	httpRpcCfg := stack.Config().Http
 	httpRpcCfg.StateCache.LocalCache = execmoduleCache

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -706,7 +706,7 @@ func New(
 		blobGetter = backend.txPool
 	}
 
-	execmoduleCache := execmodule.NewCache()
+	execmoduleCache := &execmodule.Cache{}
 	execmoduleCache.SetPublishedSD(backend.notifications.Events.LatestSD)
 	var rpcStateCache kvcache.Cache = execmoduleCache
 	if options.rpcStateCacheDecorator != nil {

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -244,6 +244,7 @@ func checkAndSetCommitmentHistoryFlag(tx kv.RwTx, logger log.Logger, dirs datadi
 
 type newOptions struct {
 	stateTransitionObserver execmodule.StateTransitionObserver
+	rpcStateCacheDecorator  func(kvcache.Cache) kvcache.Cache
 }
 
 // NewOption configures Ethereum construction without adding runtime settings.
@@ -254,6 +255,13 @@ type NewOption func(*newOptions)
 func WithStateTransitionObserver(observer execmodule.StateTransitionObserver) NewOption {
 	return func(options *newOptions) {
 		options.stateTransitionObserver = observer
+	}
+}
+
+// WithRPCStateCacheDecorator wraps the embedded RPC state cache during construction.
+func WithRPCStateCacheDecorator(decorator func(kvcache.Cache) kvcache.Cache) NewOption {
+	return func(options *newOptions) {
+		options.rpcStateCacheDecorator = decorator
 	}
 }
 
@@ -698,10 +706,14 @@ func New(
 		blobGetter = backend.txPool
 	}
 
-	execmoduleCache := execmodule.NewCache(options.stateTransitionObserver)
+	execmoduleCache := execmodule.NewCache()
 	execmoduleCache.SetPublishedSD(backend.notifications.Events.LatestSD)
+	var rpcStateCache kvcache.Cache = execmoduleCache
+	if options.rpcStateCacheDecorator != nil {
+		rpcStateCache = options.rpcStateCacheDecorator(rpcStateCache)
+	}
 	httpRpcCfg := stack.Config().Http
-	httpRpcCfg.StateCache.LocalCache = execmoduleCache
+	httpRpcCfg.StateCache.LocalCache = rpcStateCache
 	ethRpcClient, txPoolRpcClient, miningRpcClient, rpcDaemonStateCache, rpcFilters := rpcdaemoncli.EmbeddedServices(
 		ctx,
 		backend.chainDB,
@@ -914,6 +926,7 @@ func New(
 		false, /* onlySnapDownloadOnStart */
 		backend.readAheader,
 		backend.stopNode,
+		execmodule.WithStateTransitionObserver(options.stateTransitionObserver),
 	)
 	backend.execModule.SetPublishedSD(backend.notifications.Events.LatestSD)
 

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -1455,13 +1455,10 @@ func (s *Ethereum) Stop() error {
 		s.logger.Error("background component error", "err", err)
 	}
 
-	// Wait for any in-flight updateForkChoice goroutine to finish. These are
-	// fire-and-forget goroutines that hold DB read transactions; without this
-	// wait, chainDB.Close() can hang in waitTxsAllDoneOnClose.
+	// Detached forkchoice work can hold a database transaction. Shutdown must
+	// drain it completely before chainDB.Close rather than continue on a timer.
 	if s.execModule != nil {
-		waitCtx, waitCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		s.execModule.WaitIdle(waitCtx)
-		waitCancel()
+		s.execModule.Drain()
 	}
 
 	// Wait for any in-flight read-ahead warmup goroutines that hold DB read

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -242,9 +242,36 @@ func checkAndSetCommitmentHistoryFlag(tx kv.RwTx, logger log.Logger, dirs datadi
 	return nil
 }
 
+type newOptions struct {
+	stateTransitionObserver execmodule.StateTransitionObserver
+}
+
+// NewOption configures Ethereum construction without adding runtime settings.
+type NewOption func(*newOptions)
+
+// WithStateTransitionObserver enables deterministic execution lifecycle hooks
+// for integration tests.
+func WithStateTransitionObserver(observer execmodule.StateTransitionObserver) NewOption {
+	return func(options *newOptions) {
+		options.stateTransitionObserver = observer
+	}
+}
+
 // New creates a new Ethereum object (including the
 // initialisation of the common Ethereum object)
-func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger log.Logger, tracer *tracers.Tracer) (*Ethereum, error) {
+func New(
+	ctx context.Context,
+	stack *node.Node,
+	config *ethconfig.Config,
+	logger log.Logger,
+	tracer *tracers.Tracer,
+	opts ...NewOption,
+) (*Ethereum, error) {
+	options := newOptions{}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
 	var kzgWarmupDone chan struct{}
 	if config.WarmupKzgCtxOnInit {
 		kzgWarmupDone = make(chan struct{})
@@ -671,10 +698,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		blobGetter = backend.txPool
 	}
 
-	execmoduleCache, ok := stack.Config().Http.StateCache.LocalCache.(*execmodule.Cache)
-	if !ok || execmoduleCache == nil {
-		execmoduleCache = execmodule.NewCache(nil)
-	}
+	execmoduleCache := execmodule.NewCache(options.stateTransitionObserver)
 	execmoduleCache.SetPublishedSD(backend.notifications.Events.LatestSD)
 	httpRpcCfg := stack.Config().Http
 	httpRpcCfg.StateCache.LocalCache = execmoduleCache


### PR DESCRIPTION
Part of #21860. Complements the lower-level cache tests in #23005 with running-node coverage for the RPC/unwind failure class in #22463.

## Why

The missing safety net was the complete interaction between HTTP RPC requests and an Engine API reorg:

- three tagged requests bind to old head **A**;
- forkchoice unwinds to ancestor **B**;
- newly bound `latest` requests observe **B** through overlay publication, durable commit, and database fallback;
- the delayed **A** requests may finish from their valid MVCC views, but must not refill `StateCache` with dead-fork data.

Timing sleeps cannot define these windows reliably, so the test pauses execution at synchronous lifecycle boundaries.

## Scenario

```mermaid
sequenceDiagram
    participant CL as Mock CL
    participant FCU as ExecModule FCU
    participant OldRPC as RPC views bound to A
    participant Overlay as SharedDomains overlay
    participant DB as MDBX
    participant NewRPC as newly bound RPC

    CL->>FCU: forkchoiceUpdated(A)
    FCU->>Overlay: publish A
    OldRPC->>OldRPC: bind tagged views and pause before reading
    FCU->>DB: commit A
    FCU->>Overlay: clear A

    CL->>FCU: forkchoiceUpdated(B)
    FCU->>FCU: unwind to B
    Note over FCU,DB: committed A remains visible until B is published
    FCU->>Overlay: publish B
    NewRPC->>Overlay: assert B before commit
    FCU->>DB: commit B
    NewRPC->>Overlay: assert B after commit
    FCU->>Overlay: clear B
    NewRPC->>DB: assert durable B

    OldRPC-->>OldRPC: finish from the old A views

    CL->>FCU: forkchoiceUpdated(C)
    FCU->>Overlay: publish transaction-free C
    NewRPC->>Overlay: repeat canonical reads through C
    Note over NewRPC,Overlay: untouched keys probe StateCache for stale A refill
    FCU->>Overlay: clear C
```

The **B** overlay publication is the visibility switch. Before it, newly bound requests see committed **A**; from publication onward, they must consistently see **B**. The final **C** step is an explicitly transaction-free child of **B**, built through `testing_buildBlockV1` with a non-nil empty transaction list. This bypasses the txpool, so unwound transactions cannot enter **C** and its fresh overlay cannot answer the probed keys from its own writes. Repeated reads therefore exercise the shared `StateCache` and expose any stale **A** refill.

## Assertions

| Boundary | What the test proves |
| --- | --- |
| Tagged A RPC views bound | Exactly the delayed storage, code, and nonce requests are pinned before their first read |
| B unwind complete | Replacement state is still private; committed A remains visible |
| B overlay published | Dead-fork storage is absent while retained account, code, and nonce remain |
| B committed and overlay cleared | The same result survives commit and MDBX fallback |
| Delayed A views released | Old values may return, but cannot repopulate canonical cache entries |
| C transaction-free overlay cache probes | Repeated reads return B-equivalent state, proving the shared cache was not poisoned by A |

Each lifecycle assertion uses a separate persistent `StateChurn` contract, so an earlier RPC cache fill cannot mask a later path. Their selected slot is absent at **B** and written only on **A**, exercising removal of dead-fork storage while preserving the account. A fifth contract exists only on **A**, exercising complete account and code removal. The generated **A** storage value is required to be non-zero, so the distinction cannot silently collapse. Non-zero value restoration remains covered by the broader StateChurn suite and #23005.

## Design and production impact

- `StateTransitionObserver` exposes five inline boundaries: RPC view bound, unwind complete, overlay published, commit complete, and overlay cleared.
- The delayed calls use a dedicated tagged RPC client. The RPC-view barrier accepts only matching server-side peer contexts, so unrelated cache views cannot consume its slots.
- Publication, commit, and clear observations are paired with the FCU that actually published the overlay. An FCU response is not treated as proof that deferred teardown has finished.
- The observer is optional and nil in production. RPC view observation is added by an `engineapitester` cache decorator, leaving the production `Cache.View` path unchanged.
- The real overlay event bus remains drop-tolerant; it is not reused as a blocking test barrier.
- Node shutdown drains detached forkchoice work before closing the database, preventing an in-flight transaction from blocking DB shutdown.
- The test uses real HTTP `eth_getStorageAt`, `eth_getCode`, and `eth_getTransactionCount` calls and real Engine API forkchoice updates. Channels establish ordering; timeouts only bound failures.
- The `testing` RPC namespace is enabled only for this `engineapitester` fixture so **C** can bypass the txpool; production RPC configuration is unchanged.
- The obsolete #22299 `latest`-nonce workaround is removed; #22326 now supplies the normal pending-nonce behavior.

## Relationship and scope

#23005 tests cache admission and commit/publication interleavings directly. This PR tests the surrounding HTTP RPC, Engine API, overlay, commit, and fallback wiring. It intentionally does not duplicate every internal midpoint.

Coverage is a deterministic in-process full node. Crash windows, randomized reorg schedules, real-CL/Kurtosis runs, and the exact DB-commit/cache-publication midpoint remain separate #21860 layers.

## Review order

1. `execution/execmodule/state_transition.go` and `forkchoice.go`: boundary semantics and placement.
2. `node/eth/backend.go` and `execution/engineapi/engineapitester`: full-node wiring, test-only RPC/cache hooks, empty-payload construction, and shutdown draining.
3. `execution/engineapi/engine_api_rpc_unwind_test.go`: reorg scenario and cache-refill assertions.
4. `engine_api_state_churn_reorg_test.go`: shared churn helper and pending-nonce path.
