### PR TITLE
lru: in jump-grow copy loop use `peek` instead `get`

### DIFF
--- a/execution/cache/code_cache_concurrency_test.go
+++ b/execution/cache/code_cache_concurrency_test.go
@@ -196,6 +196,64 @@ func TestCodeCache_ClearFencesStartedPut(t *testing.T) {
 	require.False(t, ok, "Clear must remove a write that started in the retiring generation")
 }
 
+// The grow copy must carry the retiring generation over in Keys() order --
+// oldest first -- because insertion order alone sets the new generation's
+// recency. Reading each entry back with Get re-links it in the generation being
+// retired, so the order the copy observes shifts as the copy walks it.
+func TestGrowLRU_GrowCopyPreservesOrder(t *testing.T) {
+	key := func(i uint64) uint64 { return i * 0x9E3779B97F4A7C15 }
+
+	g := newGrowLRU[uint64](8*datasize.MB, 16, nil)
+	defer g.Close()
+	startCap := g.curCap.Load()
+
+	const warmup = genericCacheStartCapacity / 2
+	for i := range uint64(warmup) {
+		g.Add(key(i), i)
+	}
+	for i := uint64(0); i < warmup; i += 3 { // pull recency away from insertion order
+		g.Get(key(i))
+	}
+
+	var oldKeys, oldVals []uint64
+	var trigger uint64
+	grew := false
+	for i := uint64(warmup); i < 8*genericCacheStartCapacity && !grew; i++ {
+		old := g.cur.Load()
+		if g.curCap.Load() < g.maxCap && old.Len() >= int(g.curCap.Load()) {
+			oldKeys = old.Keys() // snapshot the generation this add is about to retire
+			oldVals = make([]uint64, len(oldKeys))
+			for j, k := range oldKeys {
+				oldVals[j], _ = old.Peek(k)
+			}
+		}
+		g.Add(key(i), i)
+		if grew = g.curCap.Load() > startCap; grew {
+			trigger = i // this add landed in the new generation, after the copy
+		}
+	}
+	require.True(t, grew, "the fill must have triggered a real grow")
+
+	// Replay the snapshot into the geometry the grow chose.
+	want := g.newShards(g.curCap.Load())
+	for j, k := range oldKeys {
+		want.Add(k, oldVals[j])
+	}
+	want.Add(key(trigger), trigger)
+
+	got := g.cur.Load()
+	require.Positive(t, want.Len())
+	require.Equal(t, want.Len(), got.Len(), "the grown generation must hold every copied entry")
+	require.Equal(t, want.Keys(), got.Keys(), "the grown generation must keep the pre-grow order")
+	for _, k := range got.Keys() {
+		wantV, ok := want.Peek(k)
+		require.True(t, ok)
+		gotV, ok := got.Peek(k)
+		require.True(t, ok)
+		require.Equal(t, wantV, gotV)
+	}
+}
+
 // A growLRU generation reserves no external payload for a value freelru stores
 // inline, so the slot and per-shard charges alone have to cover it.
 func TestGrowLRU_EnvelopeCoversInlineValueGeneration(t *testing.T) {

--- a/execution/cache/grow_lru.go
+++ b/execution/cache/grow_lru.go
@@ -174,7 +174,7 @@ func (g *growLRU[V]) maybeGrow() {
 	}
 	next := g.newShards(newCap)
 	for _, k := range old.Keys() {
-		if v, ok := old.Get(k); ok {
+		if v, ok := old.Peek(k); ok {
 			next.Add(k, v)
 		}
 	}

--- a/execution/commitment/branch_cache_tail.go
+++ b/execution/commitment/branch_cache_tail.go
@@ -91,7 +91,7 @@ func (t *tailLRU) maybeGrow() {
 	}
 	next := newTailShards(newCap)
 	for _, k := range old.Keys() {
-		if v, ok := old.Get(k); ok {
+		if v, ok := old.Peek(k); ok {
 			next.Add(k, v)
 		}
 	}


### PR DESCRIPTION
to reduce `resizeMu` contention

Two copy loops: `growLRU` and `tailLRU`. The `GenericCache` path already peeks.