### PR TITLE
lru: fastpath before taking resizeMu in maybeGrow

### DIFF
--- a/common/cachebudget/budget.go
+++ b/common/cachebudget/budget.go
@@ -72,6 +72,10 @@ func (b *Budget) Reserve(n int64) bool {
 	}
 }
 
+// CanReserve reports whether Reserve would currently succeed; the answer can go
+// stale the moment it returns.
+func (b *Budget) CanReserve(n int64) bool { return n <= 0 || b.used.Load()+n <= b.limit }
+
 // Take reserves n bytes unconditionally (may push used past limit). Used for a
 // cache's initial small allocation, which must always succeed so no cache is
 // born disabled.

--- a/execution/cache/generic_cache.go
+++ b/execution/cache/generic_cache.go
@@ -231,6 +231,10 @@ func (c *GenericCache[T]) newShards(capacity, shards uint32) *lruGen[entry[T]] {
 	return g
 }
 
+func (c *GenericCache[T]) growStepBytes(curCap uint32) int64 {
+	return int64(min(curCap*genericCacheGrowFactor, c.maxCap)-curCap) * c.avgEntryBytes
+}
+
 // maybeGrow jump-resizes the LRU one step larger when it is full, the ceiling
 // hasn't been reached, and the shared envelope can fund the step. Otherwise the
 // LRU keeps its size and freelru evicts within it. Must not be called with a
@@ -252,7 +256,7 @@ func (c *GenericCache[T]) maybeGrow() {
 		return
 	}
 	newCap := min(curCap*genericCacheGrowFactor, c.maxCap)
-	delta := int64(newCap-curCap) * c.avgEntryBytes
+	delta := c.growStepBytes(curCap)
 	if !cachebudget.Global.Reserve(delta) {
 		return
 	}
@@ -440,7 +444,10 @@ func (c *GenericCache[T]) putStriped(key []byte, value T, txNum uint64, overwrit
 	// The insert lands before the grow (which must run outside the stripe), so
 	// it and any racers until the swap evict at the pre-grow cap — a transient
 	// bounded by the grow window.
-	needGrow := c.mode != ModeNoOp && curCap < c.maxCap && gen.len() >= int(curCap)
+	// A full LRU never drops back below curCap, so an unfundable step would
+	// otherwise re-enter maybeGrow on every write and serialise them on resizeMu.
+	needGrow := c.mode != ModeNoOp && curCap < c.maxCap && gen.len() >= int(curCap) &&
+		cachebudget.Global.CanReserve(c.growStepBytes(curCap))
 
 	// In ModeEvictLRU the byte budget is enforced through the entry-count cap,
 	// not a separate currentSize check: capacityEntries is derived from

--- a/execution/cache/generic_cache_concurrency_test.go
+++ b/execution/cache/generic_cache_concurrency_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/c2h5oh/datasize"
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/common/cachebudget"
 	"github.com/erigontech/erigon/common/maphash"
 )
 
@@ -522,4 +523,72 @@ func TestGenericCache_GrowCopyMatchesGetBasedCopy(t *testing.T) {
 		require.Equal(t, wantEntry.val, gotEntry.val)
 		require.Equal(t, wantEntry.txNum, gotEntry.txNum)
 	}
+}
+
+// A cache whose next grow step the envelope cannot fund must stop entering
+// maybeGrow: the LRU stays full at curCap, so every later insert would re-take
+// the single resizeMu and serialise all writers.
+func TestGenericCache_UnfundableGrowKeepsResizeMuOffThePutPath(t *testing.T) {
+	prevBudget := cachebudget.Global
+	cachebudget.Global = cachebudget.New(0) // Reserve always refuses, Take still succeeds
+	t.Cleanup(func() { cachebudget.Global = prevBudget })
+
+	c := closeOnCleanup(t, NewGenericCache[[]byte](64*datasize.MB, func(v []byte) int { return len(v) }, ModeEvictLRU))
+
+	key := make([]byte, 8)
+	for i := range genericCacheStartCapacity * 2 {
+		binary.BigEndian.PutUint64(key, uint64(i))
+		c.Put(key, []byte{byte(i)}, uint64(i))
+	}
+	require.Equal(t, uint32(genericCacheStartCapacity), c.curCap.Load(), "unfundable grow must leave curCap unchanged")
+
+	c.resizeMu.Lock()
+	defer c.resizeMu.Unlock()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		k := make([]byte, 8)
+		binary.BigEndian.PutUint64(k, uint64(1<<20))
+		c.Put(k, []byte{1}, 1)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("put blocked on resizeMu while the envelope could not fund a grow")
+	}
+}
+
+// Bytes another holder returns must be picked up with no explicit reset.
+func TestGenericCache_BudgetReleaseResumesGrow(t *testing.T) {
+	prevBudget := cachebudget.Global
+	t.Cleanup(func() { cachebudget.Global = prevBudget })
+
+	const capacityBytes = 64 * datasize.MB
+	sizeOf := func(v []byte) int { return len(v) }
+
+	sizer := NewGenericCache[[]byte](capacityBytes, sizeOf, ModeEvictLRU)
+	startBytes, stepBytes := sizer.reservedBytes, sizer.growStepBytes(sizer.curCap.Load())
+	sizer.Close()
+	require.Positive(t, stepBytes)
+
+	// Room for this cache plus one other holder the size of its first grow step.
+	budget := cachebudget.New(startBytes + stepBytes)
+	cachebudget.Global = budget
+	c := closeOnCleanup(t, NewGenericCache[[]byte](capacityBytes, sizeOf, ModeEvictLRU))
+	require.True(t, budget.Reserve(stepBytes), "the other holder must fit")
+	require.Equal(t, budget.Limit(), budget.Used(), "the envelope must start exactly full")
+
+	fill := func(from, to int) {
+		key := make([]byte, 8)
+		for i := from; i < to; i++ {
+			binary.BigEndian.PutUint64(key, uint64(i))
+			c.Put(key, []byte{byte(i)}, uint64(i))
+		}
+	}
+	fill(0, genericCacheStartCapacity*2)
+	require.Equal(t, uint32(genericCacheStartCapacity), c.curCap.Load(), "a full envelope must leave curCap unchanged")
+
+	budget.Release(stepBytes)
+	fill(genericCacheStartCapacity*2, genericCacheStartCapacity*3)
+	require.Greater(t, c.curCap.Load(), uint32(genericCacheStartCapacity), "freed budget must let the cache grow again")
 }

--- a/execution/cache/grow_lru.go
+++ b/execution/cache/grow_lru.go
@@ -97,7 +97,8 @@ func (g *growLRU[V]) Get(key uint64) (V, bool) { return g.cur.Load().lru.Get(key
 // have carried it into the generation this resolves.
 func (g *growLRU[V]) Add(key uint64, value V) {
 	gen := g.cur.Load()
-	if curCap := g.curCap.Load(); curCap < g.maxCap && gen.len() >= int(curCap) {
+	if curCap := g.curCap.Load(); curCap < g.maxCap && gen.len() >= int(curCap) &&
+		cachebudget.Global.CanReserve(g.growStepBytes(curCap)) {
 		g.maybeGrow()
 		gen = g.cur.Load()
 	}
@@ -116,6 +117,10 @@ func (g *growLRU[V]) Replace(key uint64, value V) {
 	gen.add(key, value)
 }
 
+func (g *growLRU[V]) growStepBytes(curCap uint32) int64 {
+	return int64(min(curCap*genericCacheGrowFactor, g.maxCap)-curCap) * g.avgBytes
+}
+
 func (g *growLRU[V]) maybeGrow() {
 	g.resizeMu.Lock()
 	defer g.resizeMu.Unlock()
@@ -125,7 +130,7 @@ func (g *growLRU[V]) maybeGrow() {
 		return
 	}
 	newCap := min(curCap*genericCacheGrowFactor, g.maxCap)
-	delta := int64(newCap-curCap) * g.avgBytes
+	delta := g.growStepBytes(curCap)
 	if !cachebudget.Global.Reserve(delta) {
 		return
 	}

--- a/execution/commitment/branch_cache_tail.go
+++ b/execution/commitment/branch_cache_tail.go
@@ -67,12 +67,17 @@ func (t *tailLRU) Get(key uint64) (*branchCacheEntry, bool) {
 
 func (t *tailLRU) Add(key uint64, entry *branchCacheEntry) {
 	lru := t.cur.Load()
-	// Avoid lru.Len() locks once fully grown.
-	if curCap := t.curCap.Load(); curCap < t.maxCap && lru.Len() >= int(curCap) {
+	// Avoid lru.Len() locks once fully grown, or once a step is unfundable.
+	if curCap := t.curCap.Load(); curCap < t.maxCap &&
+		cachebudget.Global.CanReserve(t.growStepBytes(curCap)) && lru.Len() >= int(curCap) {
 		t.maybeGrow()
 		lru = t.cur.Load()
 	}
 	lru.Add(key, entry)
+}
+
+func (t *tailLRU) growStepBytes(curCap uint32) int64 {
+	return int64(min(curCap*tailGrowFactor, t.maxCap)-curCap) * tailEntryBytes
 }
 
 func (t *tailLRU) maybeGrow() {
@@ -85,7 +90,7 @@ func (t *tailLRU) maybeGrow() {
 		return
 	}
 	newCap := min(curCap*tailGrowFactor, t.maxCap)
-	delta := int64(newCap-curCap) * tailEntryBytes
+	delta := t.growStepBytes(curCap)
 	if !cachebudget.Global.Reserve(delta) {
 		return
 	}

--- a/execution/commitment/commitmentdb/commitment_context.go
+++ b/execution/commitment/commitmentdb/commitment_context.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -416,15 +417,15 @@ func (sdc *SharedDomainsCommitmentContext) ComputeCommitment(ctx context.Context
 	}
 
 	updateCount := sdc.updates.Size()
-	//start := time.Now()
-	//defer func() {
-	//	took := time.Since(start)
-	//	var keysPerSec uint64
-	//	if took > 0 {
-	//		keysPerSec = uint64(float64(updateCount) / took.Seconds())
-	//	}
-	//	log.Debug("[commitment] processed", "block", blockNum, "txNum", txNum, "keys", common.PrettyCounter(updateCount), "keys/s", common.PrettyCounter(keysPerSec), "mode", sdc.variant, "bufmode", sdc.updates.Mode(), "spent", took, "rootHash", hex.EncodeToString(rootHash))
-	//}()
+	start := time.Now()
+	defer func() {
+		took := time.Since(start)
+		var keysPerSec uint64
+		if took > 0 {
+			keysPerSec = uint64(float64(updateCount) / took.Seconds())
+		}
+		log.Debug("[commitment] processed", "block", blockNum, "txNum", txNum, "keys", common.PrettyCounter(updateCount), "keys/s", common.PrettyCounter(keysPerSec), "mode", sdc.variant, "bufmode", sdc.updates.Mode(), "spent", took, "rootHash", hex.EncodeToString(rootHash))
+	}()
 	// Re-apply the trace writer before any trie operations (including the early-return
 	// RootHash below); GenerateWitness clears it, so it must be restored on each call.
 	sdc.patriciaTrie.SetTraceWriter(sdc.traceW)

--- a/execution/commitment/commitmentdb/commitment_context.go
+++ b/execution/commitment/commitmentdb/commitment_context.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -417,15 +416,15 @@ func (sdc *SharedDomainsCommitmentContext) ComputeCommitment(ctx context.Context
 	}
 
 	updateCount := sdc.updates.Size()
-	start := time.Now()
-	defer func() {
-		took := time.Since(start)
-		var keysPerSec uint64
-		if took > 0 {
-			keysPerSec = uint64(float64(updateCount) / took.Seconds())
-		}
-		log.Debug("[commitment] processed", "block", blockNum, "txNum", txNum, "keys", common.PrettyCounter(updateCount), "keys/s", common.PrettyCounter(keysPerSec), "mode", sdc.variant, "bufmode", sdc.updates.Mode(), "spent", took, "rootHash", hex.EncodeToString(rootHash))
-	}()
+	//start := time.Now()
+	//defer func() {
+	//	took := time.Since(start)
+	//	var keysPerSec uint64
+	//	if took > 0 {
+	//		keysPerSec = uint64(float64(updateCount) / took.Seconds())
+	//	}
+	//	log.Debug("[commitment] processed", "block", blockNum, "txNum", txNum, "keys", common.PrettyCounter(updateCount), "keys/s", common.PrettyCounter(keysPerSec), "mode", sdc.variant, "bufmode", sdc.updates.Mode(), "spent", took, "rootHash", hex.EncodeToString(rootHash))
+	//}()
 	// Re-apply the trace writer before any trie operations (including the early-return
 	// RootHash below); GenerateWitness clears it, so it must be restored on each call.
 	sdc.patriciaTrie.SetTraceWriter(sdc.traceW)


### PR DESCRIPTION
Stacked on #23545.

A full LRU never drops back below `curCap`. So once the envelope cannot fund the next grow step, the fast-path gate stays armed forever and **every** later write re-enters `maybeGrow`, takes the one global `resizeMu`, fails the same `Reserve` and returns — a process-wide serialisation point on the cache write path. `tailLRU.Add` is worse: it pays an all-shard `Len()` ahead of that call.

Gate on `Budget.CanReserve` instead: one atomic load, no per-cache state, and bytes a later `Close`/`Clear` returns are picked up on the next write with nothing to reset. `state_cache.go` already documents "that cache stops growing" — now that is what the code does.

Same gate in `GenericCache.putStriped`, `growLRU.Add`, `tailLRU.Add`.

Not what the current `stage_exec` mutex profile shows (those events are funded grows); this is the cliff behind them.
