### PR TITLE
.claude/rules: update branch-naming for the 3.6 release line

### DIFF
--- a/.claude/rules/branch-naming.md
+++ b/.claude/rules/branch-naming.md
@@ -3,8 +3,8 @@
 ## Release branches
 
 - `release/3.4` — Stable 3.4.x
-- `release/3.5` — Stable 3.5.x (current — v3.5.5 is the Latest release)
-- `release/3.6` — Upcoming 3.6.x (release-candidate stage: v3.6.0-rc.1 is a draft)
+- `release/3.5` — Stable 3.5.x (previous stable line)
+- `release/3.6` — Stable 3.6.x (current — v3.6.0 is the Latest release)
 - `main` — Next feature release (3.7)
 
 The "current" marker goes stale: before choosing a backport base, verify against `gh release list --repo erigontech/erigon --limit 5` (the Latest tag) and the recent `[rX.Y]`-prefixed PR stream, and update this file if it disagrees.
@@ -34,7 +34,7 @@ Non-personal prefixes that show up for cross-cutting work:
 
 ## Choosing a base branch
 
-- Bug for current stable release → base on `release/3.5`
+- Bug for current stable release → base on `release/3.6`
 - New feature → base on `main`
-- Backport / cherry-pick → branch off the target release branch, prefix the PR title with `[rX.Y]` (e.g. `[r3.5]`)
+- Backport / cherry-pick → branch off the target release branch, prefix the PR title with `[rX.Y]` (e.g. `[r3.6]`)
 - A bug present on several maintained release lines may need a backport per line — check each `release/X.Y` for the affected code before assuming one backport covers it


### PR DESCRIPTION
## What

Marks `release/3.6` as the current stable line and `release/3.5` as the previous one, and points "bug for current stable release" at `release/3.6`.

## Why

v3.6.0 was released on 2026-08-24 and is now the Latest release, so the file's `current` marker went stale — it still named `release/3.5`, and listed 3.6 as being at release-candidate stage. The file asks to be verified against `gh release list` and the recent `[rX.Y]` PR stream and updated when it disagrees; the stream agrees with the tag (of the last 60 PRs, 6 `[r3.x]` ones target `release/3.6`, 1 targets `release/3.5`).

Same refresh as #22331 did for the 3.5 line. The two-digit suffix mapping already reads `36` = release/3.6, `37` = main, so it needs no change. Doc-only; no code affected.