### PR TITLE
[r3.6] ci: close the Kurtosis image-cache gaps (#23083, #23440, #23465)

### DIFF
--- a/.github/workflows/cache-warming-kurtosis-cl-images.yml
+++ b/.github/workflows/cache-warming-kurtosis-cl-images.yml
@@ -13,9 +13,9 @@ name: Cache Warming — Kurtosis CL images
 #   - schedule (daily) -> safety net if LRU-evicted
 #   - workflow_dispatch -> manual (use once to bootstrap)
 #
-# The cache key is derived from the pinned image versions: the kurtosis-infra and
-# eth2-val-tools tags in test-kurtosis-assertoor.yml plus the CL / assertoor tags it
-# reads from the kurtosis .io files — hence the paths filter covers both.
+# The cache key is derived from the pinned third-party tags in
+# test-kurtosis-assertoor.yml plus the CL / assertoor tags it reads from the
+# kurtosis .io files — hence the paths filter covers both.
 
 on:
   push:

--- a/.github/workflows/kurtosis/pectra.io
+++ b/.github/workflows/kurtosis/pectra.io
@@ -5,7 +5,7 @@ participants_matrix:
       el_log_level: "debug"
   cl:
     - cl_type: teku
-      cl_image: consensys/teku:25.9.1
+      cl_image: consensys/teku:26.4.0
     - cl_type: lighthouse
       cl_image: sigp/lighthouse:v7.0.1
 

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -6,12 +6,12 @@ env:
   # Pinned versions of third-party containers — bump here when upgrading.
   # These are cached via actions/cache (docker save/load) to avoid re-pulling
   # on every run and to eliminate Docker Hub rate-limit exposure.
-  # The immutable tags a suite .io pins — released CL/VC clients, assertoor and
-  # glamsterdam's genesis generator — are loaded at job start from those files
+  # The tags a suite .io pins — released CL/VC clients, assertoor, glamsterdam's
+  # genesis generator and spamoor — are loaded at job start from those files
   # (single source of truth) by the "Load image versions" step, so the cache can't
-  # drift from what kurtosis runs. Mutable tags (glamsterdam's devnet lighthouse,
-  # spamoor, snooper) stay live so a run never serves a stale client. The tags
-  # below aren't pinned in any .io, so they stay here.
+  # drift from what kurtosis runs. glamsterdam's devnet lighthouse stays live: it
+  # is a client under test, so serving a stale build would quietly change what the
+  # suite covers. The tags below aren't pinned in any .io, so they stay here.
   # Kurtosis CLI pinned so its infra images (engine/core/files-artifacts-expander
   # are tagged with the CLI version) can be cached too. The vector and fluent-bit
   # tags are dictated by the Kurtosis release — sync them when bumping (see
@@ -37,6 +37,10 @@ env:
   # it publishes only :latest, so the cache serves the `latest` digest from the last
   # warm rather than tracking live `latest`.
   ETH2_VAL_TOOLS_IMAGE: "protolambda/eth2-val-tools:latest"
+  # rpc-snooper is the EL/CL traffic proxy the snooper_enabled suites launch. The
+  # ethereum-package pins no tag for it, so the cache serves the `latest` digest
+  # from the last warm rather than tracking live `latest`.
+  KURTOSIS_SNOOPER_IMAGE: "ethpandaops/rpc-snooper:latest"
   GENESIS_GENERATOR_IMAGE: "ethpandaops/ethereum-genesis-generator:4.0.4"
   CAPLIN_GENESIS_GENERATOR_IMAGE: "ethpandaops/ethereum-genesis-generator:3.3.7"
   KURTOSIS_PYTHON_IMAGE: "python:3.11-alpine"
@@ -217,6 +221,7 @@ jobs:
           lighthouse=$(yq -e '.participants_matrix.cl[] | select(.cl_type == "lighthouse") | .cl_image' "$reg")
           teku=$(yq -e '.participants_matrix.cl[] | select(.cl_type == "teku") | .cl_image' "$reg")
           genesis_glamsterdam=$(yq -e '.ethereum_genesis_generator_params.image' "$glamsterdam_io")
+          spamoor_glamsterdam=$(yq -e '.spamoor_params.image' "$glamsterdam_io")
           lighthouse_vc=$(yq -e '.participants[] | select(.vc_type == "lighthouse") | .vc_image' "$caplin_io")
           # pectra's clients and caplin-minimal's assertoor are warmed under the tag
           # another suite pins. Bumping one alone leaves it out of the cache, which
@@ -242,6 +247,7 @@ jobs:
             echo "LIGHTHOUSE_IMAGE=$lighthouse"
             echo "TEKU_IMAGE=$teku"
             echo "GLAMSTERDAM_GENESIS_GENERATOR_IMAGE=$genesis_glamsterdam"
+            echo "GLAMSTERDAM_SPAMOOR_IMAGE=$spamoor_glamsterdam"
             echo "LIGHTHOUSE_VC_IMAGE=$lighthouse_vc"
           } >> "$GITHUB_ENV"
           # Every cached tag stays spelled out in the cache key so a glance at the
@@ -251,8 +257,9 @@ jobs:
           for image in "$lighthouse" "$lighthouse_vc" "$teku" "$assertoor" \
             "kurtosis:$KURTOSIS_VERSION" "$KURTOSIS_VECTOR_IMAGE" "$KURTOSIS_FLUENTBIT_IMAGE" \
             "$KURTOSIS_CURL_JQ_IMAGE" "$KURTOSIS_TRAEFIK_IMAGE" "$KURTOSIS_ALPINE_IMAGE" \
-            "$ETH2_VAL_TOOLS_IMAGE" "$pectra" "$glamsterdam" "$GENESIS_GENERATOR_IMAGE" \
-            "$CAPLIN_GENESIS_GENERATOR_IMAGE" "$genesis_glamsterdam" "$KURTOSIS_PYTHON_IMAGE"; do
+            "$ETH2_VAL_TOOLS_IMAGE" "$KURTOSIS_SNOOPER_IMAGE" "$pectra" "$glamsterdam" \
+            "$GENESIS_GENERATOR_IMAGE" "$CAPLIN_GENESIS_GENERATOR_IMAGE" \
+            "$genesis_glamsterdam" "$spamoor_glamsterdam" "$KURTOSIS_PYTHON_IMAGE"; do
             key="$key-${image##*/}"
           done
           [ ${#key} -le 512 ] \
@@ -297,6 +304,8 @@ jobs:
           pull "${GENESIS_GENERATOR_IMAGE}"
           pull "${CAPLIN_GENESIS_GENERATOR_IMAGE}"
           pull "${GLAMSTERDAM_GENESIS_GENERATOR_IMAGE}"
+          pull "${GLAMSTERDAM_SPAMOOR_IMAGE}"
+          pull "${KURTOSIS_SNOOPER_IMAGE}"
           pull "${KURTOSIS_PYTHON_IMAGE}"
           docker save "${LIGHTHOUSE_IMAGE}" -o /tmp/docker-cache/lighthouse.tar
           docker save "${LIGHTHOUSE_VC_IMAGE}" -o /tmp/docker-cache/lighthouse-vc.tar
@@ -316,6 +325,8 @@ jobs:
           docker save "${GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/genesis-generator.tar
           docker save "${CAPLIN_GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/caplin-genesis-generator.tar
           docker save "${GLAMSTERDAM_GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/glamsterdam-genesis-generator.tar
+          docker save "${GLAMSTERDAM_SPAMOOR_IMAGE}" -o /tmp/docker-cache/spamoor.tar
+          docker save "${KURTOSIS_SNOOPER_IMAGE}" -o /tmp/docker-cache/rpc-snooper.tar
           docker save "${KURTOSIS_PYTHON_IMAGE}" -o /tmp/docker-cache/python.tar
 
       - name: Save third-party containers to cache
@@ -455,6 +466,7 @@ jobs:
           lighthouse=$(yq -e '.participants_matrix.cl[] | select(.cl_type == "lighthouse") | .cl_image' "$reg")
           teku=$(yq -e '.participants_matrix.cl[] | select(.cl_type == "teku") | .cl_image' "$reg")
           genesis_glamsterdam=$(yq -e '.ethereum_genesis_generator_params.image' "$glamsterdam_io")
+          spamoor_glamsterdam=$(yq -e '.spamoor_params.image' "$glamsterdam_io")
           lighthouse_vc=$(yq -e '.participants[] | select(.vc_type == "lighthouse") | .vc_image' "$caplin_io")
           # pectra's clients and caplin-minimal's assertoor are warmed under the tag
           # another suite pins. Bumping one alone leaves it out of the cache, which
@@ -480,6 +492,7 @@ jobs:
             echo "LIGHTHOUSE_IMAGE=$lighthouse"
             echo "TEKU_IMAGE=$teku"
             echo "GLAMSTERDAM_GENESIS_GENERATOR_IMAGE=$genesis_glamsterdam"
+            echo "GLAMSTERDAM_SPAMOOR_IMAGE=$spamoor_glamsterdam"
             echo "LIGHTHOUSE_VC_IMAGE=$lighthouse_vc"
           } >> "$GITHUB_ENV"
           # Every cached tag stays spelled out in the cache key so a glance at the
@@ -489,8 +502,9 @@ jobs:
           for image in "$lighthouse" "$lighthouse_vc" "$teku" "$assertoor" \
             "kurtosis:$KURTOSIS_VERSION" "$KURTOSIS_VECTOR_IMAGE" "$KURTOSIS_FLUENTBIT_IMAGE" \
             "$KURTOSIS_CURL_JQ_IMAGE" "$KURTOSIS_TRAEFIK_IMAGE" "$KURTOSIS_ALPINE_IMAGE" \
-            "$ETH2_VAL_TOOLS_IMAGE" "$pectra" "$glamsterdam" "$GENESIS_GENERATOR_IMAGE" \
-            "$CAPLIN_GENESIS_GENERATOR_IMAGE" "$genesis_glamsterdam" "$KURTOSIS_PYTHON_IMAGE"; do
+            "$ETH2_VAL_TOOLS_IMAGE" "$KURTOSIS_SNOOPER_IMAGE" "$pectra" "$glamsterdam" \
+            "$GENESIS_GENERATOR_IMAGE" "$CAPLIN_GENESIS_GENERATOR_IMAGE" \
+            "$genesis_glamsterdam" "$spamoor_glamsterdam" "$KURTOSIS_PYTHON_IMAGE"; do
             key="$key-${image##*/}"
           done
           [ ${#key} -le 512 ] \
@@ -525,6 +539,8 @@ jobs:
           docker load -i /tmp/docker-cache/genesis-generator.tar
           docker load -i /tmp/docker-cache/caplin-genesis-generator.tar
           docker load -i /tmp/docker-cache/glamsterdam-genesis-generator.tar
+          docker load -i /tmp/docker-cache/spamoor.tar
+          docker load -i /tmp/docker-cache/rpc-snooper.tar
           docker load -i /tmp/docker-cache/python.tar
 
       - name: Pull third-party containers and save to cache
@@ -557,6 +573,8 @@ jobs:
           pull "${GENESIS_GENERATOR_IMAGE}"
           pull "${CAPLIN_GENESIS_GENERATOR_IMAGE}"
           pull "${GLAMSTERDAM_GENESIS_GENERATOR_IMAGE}"
+          pull "${GLAMSTERDAM_SPAMOOR_IMAGE}"
+          pull "${KURTOSIS_SNOOPER_IMAGE}"
           pull "${KURTOSIS_PYTHON_IMAGE}"
           docker save "${LIGHTHOUSE_IMAGE}" -o /tmp/docker-cache/lighthouse.tar
           docker save "${LIGHTHOUSE_VC_IMAGE}" -o /tmp/docker-cache/lighthouse-vc.tar
@@ -576,6 +594,8 @@ jobs:
           docker save "${GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/genesis-generator.tar
           docker save "${CAPLIN_GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/caplin-genesis-generator.tar
           docker save "${GLAMSTERDAM_GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/glamsterdam-genesis-generator.tar
+          docker save "${GLAMSTERDAM_SPAMOOR_IMAGE}" -o /tmp/docker-cache/spamoor.tar
+          docker save "${KURTOSIS_SNOOPER_IMAGE}" -o /tmp/docker-cache/rpc-snooper.tar
           docker save "${KURTOSIS_PYTHON_IMAGE}" -o /tmp/docker-cache/python.tar
 
       # An uncovered tag would otherwise be pulled inside `kurtosis run`, where a

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -33,10 +33,11 @@ env:
   BUILDKIT_IMAGE: "moby/buildkit:v0.30.0"
   # eth2-val-tools is the validator-keystore generator pulled during `kurtosis run`;
   # it publishes only :latest, so the cache serves the `latest` digest from the last
-  # warm rather than tracking live `latest`. (genesis-generator is pulled live: its
-  # version is the ethereum-package default, which varies per ethereum_package_branch,
-  # so it isn't cached here.)
+  # warm rather than tracking live `latest`.
   ETH2_VAL_TOOLS_IMAGE: "protolambda/eth2-val-tools:latest"
+  GENESIS_GENERATOR_IMAGE: "ethpandaops/ethereum-genesis-generator:4.0.4"
+  CAPLIN_GENESIS_GENERATOR_IMAGE: "ethpandaops/ethereum-genesis-generator:3.3.7"
+  KURTOSIS_PYTHON_IMAGE: "python:3.11-alpine"
 
 on:
   workflow_dispatch:
@@ -225,7 +226,7 @@ jobs:
         uses: actions/cache/restore@v6
         with:
           path: /tmp/docker-cache
-          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.LIGHTHOUSE_VC_IMAGE }}-${{ env.TEKU_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}-${{ env.ETH2_VAL_TOOLS_IMAGE }}-${{ env.ASSERTOOR_PECTRA_IMAGE }}-${{ env.ASSERTOOR_GLAMSTERDAM_IMAGE }}
+          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.LIGHTHOUSE_VC_IMAGE }}-${{ env.TEKU_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}-${{ env.ETH2_VAL_TOOLS_IMAGE }}-${{ env.ASSERTOOR_PECTRA_IMAGE }}-${{ env.ASSERTOOR_GLAMSTERDAM_IMAGE }}-${{ env.GENESIS_GENERATOR_IMAGE }}-${{ env.CAPLIN_GENESIS_GENERATOR_IMAGE }}-${{ env.KURTOSIS_PYTHON_IMAGE }}
           lookup-only: true
 
       - name: Pull third-party containers
@@ -255,6 +256,9 @@ jobs:
           pull "${KURTOSIS_TRAEFIK_IMAGE}"
           pull "${KURTOSIS_ALPINE_IMAGE}"
           pull "${ETH2_VAL_TOOLS_IMAGE}"
+          pull "${GENESIS_GENERATOR_IMAGE}"
+          pull "${CAPLIN_GENESIS_GENERATOR_IMAGE}"
+          pull "${KURTOSIS_PYTHON_IMAGE}"
           docker save "${LIGHTHOUSE_IMAGE}" -o /tmp/docker-cache/lighthouse.tar
           docker save "${LIGHTHOUSE_VC_IMAGE}" -o /tmp/docker-cache/lighthouse-vc.tar
           docker save "${TEKU_IMAGE}" -o /tmp/docker-cache/teku.tar
@@ -270,13 +274,16 @@ jobs:
           docker save "${KURTOSIS_TRAEFIK_IMAGE}" -o /tmp/docker-cache/traefik.tar
           docker save "${KURTOSIS_ALPINE_IMAGE}" -o /tmp/docker-cache/alpine.tar
           docker save "${ETH2_VAL_TOOLS_IMAGE}" -o /tmp/docker-cache/eth2-val-tools.tar
+          docker save "${GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/genesis-generator.tar
+          docker save "${CAPLIN_GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/caplin-genesis-generator.tar
+          docker save "${KURTOSIS_PYTHON_IMAGE}" -o /tmp/docker-cache/python.tar
 
       - name: Save third-party containers to cache
         if: steps.cache-cl-images.outputs.cache-hit != 'true'
         uses: actions/cache/save@v6
         with:
           path: /tmp/docker-cache
-          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.LIGHTHOUSE_VC_IMAGE }}-${{ env.TEKU_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}-${{ env.ETH2_VAL_TOOLS_IMAGE }}-${{ env.ASSERTOOR_PECTRA_IMAGE }}-${{ env.ASSERTOOR_GLAMSTERDAM_IMAGE }}
+          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.LIGHTHOUSE_VC_IMAGE }}-${{ env.TEKU_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}-${{ env.ETH2_VAL_TOOLS_IMAGE }}-${{ env.ASSERTOOR_PECTRA_IMAGE }}-${{ env.ASSERTOOR_GLAMSTERDAM_IMAGE }}-${{ env.GENESIS_GENERATOR_IMAGE }}-${{ env.CAPLIN_GENESIS_GENERATOR_IMAGE }}-${{ env.KURTOSIS_PYTHON_IMAGE }}
 
       - name: Check whether buildkit image is already cached
         id: cache-buildkit-image
@@ -419,7 +426,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: /tmp/docker-cache
-          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.LIGHTHOUSE_VC_IMAGE }}-${{ env.TEKU_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}-${{ env.ETH2_VAL_TOOLS_IMAGE }}-${{ env.ASSERTOOR_PECTRA_IMAGE }}-${{ env.ASSERTOOR_GLAMSTERDAM_IMAGE }}
+          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.LIGHTHOUSE_VC_IMAGE }}-${{ env.TEKU_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}-${{ env.ETH2_VAL_TOOLS_IMAGE }}-${{ env.ASSERTOOR_PECTRA_IMAGE }}-${{ env.ASSERTOOR_GLAMSTERDAM_IMAGE }}-${{ env.GENESIS_GENERATOR_IMAGE }}-${{ env.CAPLIN_GENESIS_GENERATOR_IMAGE }}-${{ env.KURTOSIS_PYTHON_IMAGE }}
 
       - name: Load cached containers into daemon
         if: steps.cache-cl-images.outputs.cache-hit == 'true'
@@ -439,6 +446,9 @@ jobs:
           docker load -i /tmp/docker-cache/traefik.tar
           docker load -i /tmp/docker-cache/alpine.tar
           docker load -i /tmp/docker-cache/eth2-val-tools.tar
+          docker load -i /tmp/docker-cache/genesis-generator.tar
+          docker load -i /tmp/docker-cache/caplin-genesis-generator.tar
+          docker load -i /tmp/docker-cache/python.tar
 
       - name: Pull third-party containers and save to cache
         if: steps.cache-cl-images.outputs.cache-hit != 'true'
@@ -467,6 +477,9 @@ jobs:
           pull "${KURTOSIS_TRAEFIK_IMAGE}"
           pull "${KURTOSIS_ALPINE_IMAGE}"
           pull "${ETH2_VAL_TOOLS_IMAGE}"
+          pull "${GENESIS_GENERATOR_IMAGE}"
+          pull "${CAPLIN_GENESIS_GENERATOR_IMAGE}"
+          pull "${KURTOSIS_PYTHON_IMAGE}"
           docker save "${LIGHTHOUSE_IMAGE}" -o /tmp/docker-cache/lighthouse.tar
           docker save "${LIGHTHOUSE_VC_IMAGE}" -o /tmp/docker-cache/lighthouse-vc.tar
           docker save "${TEKU_IMAGE}" -o /tmp/docker-cache/teku.tar
@@ -482,6 +495,9 @@ jobs:
           docker save "${KURTOSIS_TRAEFIK_IMAGE}" -o /tmp/docker-cache/traefik.tar
           docker save "${KURTOSIS_ALPINE_IMAGE}" -o /tmp/docker-cache/alpine.tar
           docker save "${ETH2_VAL_TOOLS_IMAGE}" -o /tmp/docker-cache/eth2-val-tools.tar
+          docker save "${GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/genesis-generator.tar
+          docker save "${CAPLIN_GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/caplin-genesis-generator.tar
+          docker save "${KURTOSIS_PYTHON_IMAGE}" -o /tmp/docker-cache/python.tar
 
       - name: Install Kurtosis CLI and start engine
         uses: ./.github/actions/setup-kurtosis

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -6,10 +6,12 @@ env:
   # Pinned versions of third-party containers — bump here when upgrading.
   # These are cached via actions/cache (docker save/load) to avoid re-pulling
   # on every run and to eliminate Docker Hub rate-limit exposure.
-  # LIGHTHOUSE_IMAGE, TEKU_IMAGE, LIGHTHOUSE_VC_IMAGE and the ASSERTOOR_* tags are
-  # loaded at job start from the suite .io files (single source of truth) by the
-  # "Load image versions" step, so they can't drift from what kurtosis runs. The
-  # remaining third-party tags below aren't pinned in any .io, so they stay here.
+  # The immutable tags a suite .io pins — released CL/VC clients, assertoor and
+  # glamsterdam's genesis generator — are loaded at job start from those files
+  # (single source of truth) by the "Load image versions" step, so the cache can't
+  # drift from what kurtosis runs. Mutable tags (glamsterdam's devnet lighthouse,
+  # spamoor, snooper) stay live so a run never serves a stale client. The tags
+  # below aren't pinned in any .io, so they stay here.
   # Kurtosis CLI pinned so its infra images (engine/core/files-artifacts-expander
   # are tagged with the CLI version) can be cached too. The vector and fluent-bit
   # tags are dictated by the Kurtosis release — sync them when bumping (see
@@ -206,27 +208,63 @@ jobs:
       - name: Load image versions from the .io files (single source of truth)
         run: |
           reg=.github/workflows/kurtosis/regular-assertoor.io
+          pectra_io=.github/workflows/kurtosis/pectra.io
+          glamsterdam_io=.github/workflows/kurtosis/glamsterdam.io
+          caplin_io=.github/workflows/kurtosis/caplin-minimal-assertoor.io
           assertoor=$(yq -e '.assertoor_params.image' "$reg")
-          pectra=$(yq -e '.assertoor_params.image' .github/workflows/kurtosis/pectra.io)
-          glamsterdam=$(yq -e '.assertoor_params.image' .github/workflows/kurtosis/glamsterdam.io)
+          pectra=$(yq -e '.assertoor_params.image' "$pectra_io")
+          glamsterdam=$(yq -e '.assertoor_params.image' "$glamsterdam_io")
           lighthouse=$(yq -e '.participants_matrix.cl[] | select(.cl_type == "lighthouse") | .cl_image' "$reg")
           teku=$(yq -e '.participants_matrix.cl[] | select(.cl_type == "teku") | .cl_image' "$reg")
-          lighthouse_vc=$(yq -e '.participants[] | select(.vc_type == "lighthouse") | .vc_image' .github/workflows/kurtosis/caplin-minimal-assertoor.io)
+          genesis_glamsterdam=$(yq -e '.ethereum_genesis_generator_params.image' "$glamsterdam_io")
+          lighthouse_vc=$(yq -e '.participants[] | select(.vc_type == "lighthouse") | .vc_image' "$caplin_io")
+          # pectra's clients and caplin-minimal's assertoor are warmed under the tag
+          # another suite pins. Bumping one alone leaves it out of the cache, which
+          # is a slow path rather than a failure: warn, and hand the tag to the
+          # pre-pull step so it is fetched with retries.
+          uncached=
+          check_warmed() { # .io file, tag it pins, tag the cache warms
+            if [ "$2" != "$3" ]; then
+              echo "::warning::$1 pins $2 but the cache warms $3; extend the cache key to warm it"
+              uncached="$uncached $2"
+            fi
+          }
+          check_warmed "$pectra_io" \
+            "$(yq -e '.participants_matrix.cl[] | select(.cl_type == "teku") | .cl_image' "$pectra_io")" "$teku"
+          check_warmed "$pectra_io" \
+            "$(yq -e '.participants_matrix.cl[] | select(.cl_type == "lighthouse") | .cl_image' "$pectra_io")" "$lighthouse_vc"
+          check_warmed "$caplin_io" "$(yq -e '.assertoor_params.image' "$caplin_io")" "$assertoor"
+          echo "UNCACHED_IMAGES=${uncached# }" >> "$GITHUB_ENV"
           {
             echo "ASSERTOOR_IMAGE=$assertoor"
             echo "ASSERTOOR_PECTRA_IMAGE=$pectra"
             echo "ASSERTOOR_GLAMSTERDAM_IMAGE=$glamsterdam"
             echo "LIGHTHOUSE_IMAGE=$lighthouse"
             echo "TEKU_IMAGE=$teku"
+            echo "GLAMSTERDAM_GENESIS_GENERATOR_IMAGE=$genesis_glamsterdam"
             echo "LIGHTHOUSE_VC_IMAGE=$lighthouse_vc"
           } >> "$GITHUB_ENV"
+          # Every cached tag stays spelled out in the cache key so a glance at the
+          # Actions cache list shows what a key holds. Only the registry/org prefix
+          # is dropped, which keeps the key clear of actions/cache's 512-char cap.
+          key=docker-cl
+          for image in "$lighthouse" "$lighthouse_vc" "$teku" "$assertoor" \
+            "kurtosis:$KURTOSIS_VERSION" "$KURTOSIS_VECTOR_IMAGE" "$KURTOSIS_FLUENTBIT_IMAGE" \
+            "$KURTOSIS_CURL_JQ_IMAGE" "$KURTOSIS_TRAEFIK_IMAGE" "$KURTOSIS_ALPINE_IMAGE" \
+            "$ETH2_VAL_TOOLS_IMAGE" "$pectra" "$glamsterdam" "$GENESIS_GENERATOR_IMAGE" \
+            "$CAPLIN_GENESIS_GENERATOR_IMAGE" "$genesis_glamsterdam" "$KURTOSIS_PYTHON_IMAGE"; do
+            key="$key-${image##*/}"
+          done
+          [ ${#key} -le 512 ] \
+            || echo "::warning::cache key is ${#key} chars, over the 512 actions/cache allows"
+          echo "DOCKER_CACHE_KEY=$key" >> "$GITHUB_ENV"
 
       - name: Check whether third-party containers are already cached
         id: cache-cl-images
         uses: actions/cache/restore@v6
         with:
           path: /tmp/docker-cache
-          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.LIGHTHOUSE_VC_IMAGE }}-${{ env.TEKU_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}-${{ env.ETH2_VAL_TOOLS_IMAGE }}-${{ env.ASSERTOOR_PECTRA_IMAGE }}-${{ env.ASSERTOOR_GLAMSTERDAM_IMAGE }}-${{ env.GENESIS_GENERATOR_IMAGE }}-${{ env.CAPLIN_GENESIS_GENERATOR_IMAGE }}-${{ env.KURTOSIS_PYTHON_IMAGE }}
+          key: ${{ env.DOCKER_CACHE_KEY }}
           lookup-only: true
 
       - name: Pull third-party containers
@@ -258,6 +296,7 @@ jobs:
           pull "${ETH2_VAL_TOOLS_IMAGE}"
           pull "${GENESIS_GENERATOR_IMAGE}"
           pull "${CAPLIN_GENESIS_GENERATOR_IMAGE}"
+          pull "${GLAMSTERDAM_GENESIS_GENERATOR_IMAGE}"
           pull "${KURTOSIS_PYTHON_IMAGE}"
           docker save "${LIGHTHOUSE_IMAGE}" -o /tmp/docker-cache/lighthouse.tar
           docker save "${LIGHTHOUSE_VC_IMAGE}" -o /tmp/docker-cache/lighthouse-vc.tar
@@ -276,6 +315,7 @@ jobs:
           docker save "${ETH2_VAL_TOOLS_IMAGE}" -o /tmp/docker-cache/eth2-val-tools.tar
           docker save "${GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/genesis-generator.tar
           docker save "${CAPLIN_GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/caplin-genesis-generator.tar
+          docker save "${GLAMSTERDAM_GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/glamsterdam-genesis-generator.tar
           docker save "${KURTOSIS_PYTHON_IMAGE}" -o /tmp/docker-cache/python.tar
 
       - name: Save third-party containers to cache
@@ -283,7 +323,7 @@ jobs:
         uses: actions/cache/save@v6
         with:
           path: /tmp/docker-cache
-          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.LIGHTHOUSE_VC_IMAGE }}-${{ env.TEKU_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}-${{ env.ETH2_VAL_TOOLS_IMAGE }}-${{ env.ASSERTOOR_PECTRA_IMAGE }}-${{ env.ASSERTOOR_GLAMSTERDAM_IMAGE }}-${{ env.GENESIS_GENERATOR_IMAGE }}-${{ env.CAPLIN_GENESIS_GENERATOR_IMAGE }}-${{ env.KURTOSIS_PYTHON_IMAGE }}
+          key: ${{ env.DOCKER_CACHE_KEY }}
 
       - name: Check whether buildkit image is already cached
         id: cache-buildkit-image
@@ -406,27 +446,63 @@ jobs:
       - name: Load image versions from the .io files (single source of truth)
         run: |
           reg=.github/workflows/kurtosis/regular-assertoor.io
+          pectra_io=.github/workflows/kurtosis/pectra.io
+          glamsterdam_io=.github/workflows/kurtosis/glamsterdam.io
+          caplin_io=.github/workflows/kurtosis/caplin-minimal-assertoor.io
           assertoor=$(yq -e '.assertoor_params.image' "$reg")
-          pectra=$(yq -e '.assertoor_params.image' .github/workflows/kurtosis/pectra.io)
-          glamsterdam=$(yq -e '.assertoor_params.image' .github/workflows/kurtosis/glamsterdam.io)
+          pectra=$(yq -e '.assertoor_params.image' "$pectra_io")
+          glamsterdam=$(yq -e '.assertoor_params.image' "$glamsterdam_io")
           lighthouse=$(yq -e '.participants_matrix.cl[] | select(.cl_type == "lighthouse") | .cl_image' "$reg")
           teku=$(yq -e '.participants_matrix.cl[] | select(.cl_type == "teku") | .cl_image' "$reg")
-          lighthouse_vc=$(yq -e '.participants[] | select(.vc_type == "lighthouse") | .vc_image' .github/workflows/kurtosis/caplin-minimal-assertoor.io)
+          genesis_glamsterdam=$(yq -e '.ethereum_genesis_generator_params.image' "$glamsterdam_io")
+          lighthouse_vc=$(yq -e '.participants[] | select(.vc_type == "lighthouse") | .vc_image' "$caplin_io")
+          # pectra's clients and caplin-minimal's assertoor are warmed under the tag
+          # another suite pins. Bumping one alone leaves it out of the cache, which
+          # is a slow path rather than a failure: warn, and hand the tag to the
+          # pre-pull step so it is fetched with retries.
+          uncached=
+          check_warmed() { # .io file, tag it pins, tag the cache warms
+            if [ "$2" != "$3" ]; then
+              echo "::warning::$1 pins $2 but the cache warms $3; extend the cache key to warm it"
+              uncached="$uncached $2"
+            fi
+          }
+          check_warmed "$pectra_io" \
+            "$(yq -e '.participants_matrix.cl[] | select(.cl_type == "teku") | .cl_image' "$pectra_io")" "$teku"
+          check_warmed "$pectra_io" \
+            "$(yq -e '.participants_matrix.cl[] | select(.cl_type == "lighthouse") | .cl_image' "$pectra_io")" "$lighthouse_vc"
+          check_warmed "$caplin_io" "$(yq -e '.assertoor_params.image' "$caplin_io")" "$assertoor"
+          echo "UNCACHED_IMAGES=${uncached# }" >> "$GITHUB_ENV"
           {
             echo "ASSERTOOR_IMAGE=$assertoor"
             echo "ASSERTOOR_PECTRA_IMAGE=$pectra"
             echo "ASSERTOOR_GLAMSTERDAM_IMAGE=$glamsterdam"
             echo "LIGHTHOUSE_IMAGE=$lighthouse"
             echo "TEKU_IMAGE=$teku"
+            echo "GLAMSTERDAM_GENESIS_GENERATOR_IMAGE=$genesis_glamsterdam"
             echo "LIGHTHOUSE_VC_IMAGE=$lighthouse_vc"
           } >> "$GITHUB_ENV"
+          # Every cached tag stays spelled out in the cache key so a glance at the
+          # Actions cache list shows what a key holds. Only the registry/org prefix
+          # is dropped, which keeps the key clear of actions/cache's 512-char cap.
+          key=docker-cl
+          for image in "$lighthouse" "$lighthouse_vc" "$teku" "$assertoor" \
+            "kurtosis:$KURTOSIS_VERSION" "$KURTOSIS_VECTOR_IMAGE" "$KURTOSIS_FLUENTBIT_IMAGE" \
+            "$KURTOSIS_CURL_JQ_IMAGE" "$KURTOSIS_TRAEFIK_IMAGE" "$KURTOSIS_ALPINE_IMAGE" \
+            "$ETH2_VAL_TOOLS_IMAGE" "$pectra" "$glamsterdam" "$GENESIS_GENERATOR_IMAGE" \
+            "$CAPLIN_GENESIS_GENERATOR_IMAGE" "$genesis_glamsterdam" "$KURTOSIS_PYTHON_IMAGE"; do
+            key="$key-${image##*/}"
+          done
+          [ ${#key} -le 512 ] \
+            || echo "::warning::cache key is ${#key} chars, over the 512 actions/cache allows"
+          echo "DOCKER_CACHE_KEY=$key" >> "$GITHUB_ENV"
 
       - name: Restore cached third-party containers
         id: cache-cl-images
         uses: actions/cache@v6
         with:
           path: /tmp/docker-cache
-          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.LIGHTHOUSE_VC_IMAGE }}-${{ env.TEKU_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}-${{ env.ETH2_VAL_TOOLS_IMAGE }}-${{ env.ASSERTOOR_PECTRA_IMAGE }}-${{ env.ASSERTOOR_GLAMSTERDAM_IMAGE }}-${{ env.GENESIS_GENERATOR_IMAGE }}-${{ env.CAPLIN_GENESIS_GENERATOR_IMAGE }}-${{ env.KURTOSIS_PYTHON_IMAGE }}
+          key: ${{ env.DOCKER_CACHE_KEY }}
 
       - name: Load cached containers into daemon
         if: steps.cache-cl-images.outputs.cache-hit == 'true'
@@ -448,6 +524,7 @@ jobs:
           docker load -i /tmp/docker-cache/eth2-val-tools.tar
           docker load -i /tmp/docker-cache/genesis-generator.tar
           docker load -i /tmp/docker-cache/caplin-genesis-generator.tar
+          docker load -i /tmp/docker-cache/glamsterdam-genesis-generator.tar
           docker load -i /tmp/docker-cache/python.tar
 
       - name: Pull third-party containers and save to cache
@@ -479,6 +556,7 @@ jobs:
           pull "${ETH2_VAL_TOOLS_IMAGE}"
           pull "${GENESIS_GENERATOR_IMAGE}"
           pull "${CAPLIN_GENESIS_GENERATOR_IMAGE}"
+          pull "${GLAMSTERDAM_GENESIS_GENERATOR_IMAGE}"
           pull "${KURTOSIS_PYTHON_IMAGE}"
           docker save "${LIGHTHOUSE_IMAGE}" -o /tmp/docker-cache/lighthouse.tar
           docker save "${LIGHTHOUSE_VC_IMAGE}" -o /tmp/docker-cache/lighthouse-vc.tar
@@ -497,7 +575,23 @@ jobs:
           docker save "${ETH2_VAL_TOOLS_IMAGE}" -o /tmp/docker-cache/eth2-val-tools.tar
           docker save "${GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/genesis-generator.tar
           docker save "${CAPLIN_GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/caplin-genesis-generator.tar
+          docker save "${GLAMSTERDAM_GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/glamsterdam-genesis-generator.tar
           docker save "${KURTOSIS_PYTHON_IMAGE}" -o /tmp/docker-cache/python.tar
+
+      # An uncovered tag would otherwise be pulled inside `kurtosis run`, where a
+      # registry blip fails the whole test step. Fetch it here instead, with the
+      # same retries the cached images get; kurtosis still pulls it if this fails.
+      - name: Pre-pull suite images the cache does not cover
+        if: env.UNCACHED_IMAGES != ''
+        run: |
+          for image in ${UNCACHED_IMAGES}; do
+            for n in 1 2 3; do
+              if docker pull "$image"; then continue 2; fi
+              echo "docker pull $image failed (attempt $n of 3)"
+              sleep $((10 * n))
+            done
+            echo "::warning::could not pre-pull $image; kurtosis retries it at run time"
+          done
 
       - name: Install Kurtosis CLI and start engine
         uses: ./.github/actions/setup-kurtosis


### PR DESCRIPTION
Cherry-picks of #23440 and #23465 (with #23083 as a prerequisite) so release/3.6 caches the same set of third-party images as main and stops pulling them from Docker Hub inside `kurtosis run`.

## What

- #23083 — cache the regular/pectra genesis generator, the Caplin genesis generator and the Kurtosis python helper.
- #23440 — read glamsterdam's genesis generator from its `.io`, align pectra's teku with the warmed tag, replace the inline cache key with a generated one, and warn + pre-pull (with retries) for any suite tag the cache does not cover instead of failing the job.
- #23465 — cache spamoor and rpc-snooper.

## Why

release/3.6 had only the first Kurtosis change of this series (#23441), so its cache still omitted the genesis generators, python, spamoor and rpc-snooper, and pectra pulled its own teku tag every run. Each of those is a live Docker Hub fetch during `kurtosis run`, where a registry blip fails the whole test step — and merging this also lets the cache-warming workflow populate the release/3.6 entry under the new key, so branch PRs restore instead of re-pulling.

## r3.6-specific adaptations

- #23083 also patched the old inline apt installer; release/3.6 already uses the `setup-kurtosis` composite action (#23441), so that hunk was dropped and the action call kept.
- No value adaptations were needed: every suite tag is read from the `.io` files at run time, so release/3.6 keeps its own pins (glamsterdam genesis generator 6.1.2, devnet-6 lighthouse) automatically. The generated key differs from main's by exactly that genesis-generator tag, which is intended — the two lines track different devnets.

## Validation

- Emulated the "Load image versions" step against this branch's `.io` files: every `yq -e` query resolves, all three coverage checks report warmed (pectra teku 26.4.0 = regular teku, pectra lighthouse v7.0.1 = caplin-minimal VC lighthouse, caplin-minimal assertoor v0.1.2 = regular assertoor), so no pre-pull is triggered; the generated key is 379/512 chars.
- `make test-kurtosis-setup` passes; both workflows and `pectra.io` parse.
- The same series has been running on main since 2026-08-21/22: the daily warm is green, and the assertoor matrix now makes a single run-time Docker Hub fetch (glamsterdam's devnet lighthouse, deliberately left live), down from six.