### PR TITLE
plugins/auth: enable errcheck and check PutToken error in test

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -193,7 +193,6 @@ linters:
           |p2p/rlpx\
           |p2p/sentry\
           |p2p/sentry/libsentry\
-          |plugins/auth\
           |rpc\
           |rpc/jsonrpc\
           |rpc/rpchelper\

--- a/plugins/auth/auth_test.go
+++ b/plugins/auth/auth_test.go
@@ -245,7 +245,7 @@ func TestVerifyDelegationChain(t *testing.T) {
 	}
 
 	store := NewMemoryStore()
-	store.PutToken(context.Background(), aliceToBobCID, aliceToBob)
+	require.NoError(t, store.PutToken(context.Background(), aliceToBobCID, aliceToBob))
 
 	verifier := NewVerifier(NewStoreResolver(store), store, &mockSigner{})
 


### PR DESCRIPTION
- Fixes the one errcheck violation in `plugins/auth`: the `store.PutToken` error in `auth_test.go` was discarded, now asserted with `require.NoError`.
- Removes `plugins/auth` from the errcheck baseline exclusion in `.golangci.yml`, continuing the #22538 rollout.