### PR TITLE
gitignore: ignore *.pprof dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,7 @@ mdbx.lck
 .my
 
 *.prof
+*.pprof
 
 .claude/projects/
 */**/*.local.json


### PR DESCRIPTION
`stage_exec` writes `stage_exec_{cpu,heap,mutex,fgprof}.pprof` into the working directory (`startExecProfiling`, `cmd/integration/commands/stages.go`), and `debug.Handler` writes the same extension elsewhere. `.gitignore` covers `*.prof` but not `*.pprof`, so those land as untracked noise in `git status` and are easy to sweep into a commit by accident.