### PR TITLE
execution/types: wire the tx-type registry into the three receipt dispatch sites

### DIFF
--- a/execution/types/receipt.go
+++ b/execution/types/receipt.go
@@ -209,18 +209,15 @@ func (r *Receipt) decodeTyped(b []byte) error {
 	if len(b) <= 1 {
 		return errShortTypedReceipt
 	}
-	switch b[0] {
-	case DynamicFeeTxType, AccessListTxType, BlobTxType, SetCodeTxType:
-		var data receiptRLP
-		err := rlp.DecodeBytes(b[1:], &data)
-		if err != nil {
-			return err
-		}
-		r.Type = b[0]
-		return r.setFromRLP(data)
-	default:
+	if !knownTypedTxType(b[0]) {
 		return ErrTxTypeNotSupported
 	}
+	var data receiptRLP
+	if err := rlp.DecodeBytes(b[1:], &data); err != nil {
+		return err
+	}
+	r.Type = b[0]
+	return r.setFromRLP(data)
 }
 
 func (r *Receipt) decodePayload(s *rlp.Stream) error {
@@ -303,14 +300,12 @@ func (r *Receipt) DecodeRLP(s *rlp.Stream) error {
 			return fmt.Errorf("read typed receipt: %w", err)
 		}
 		r.Type = b[0]
-		switch r.Type {
-		case AccessListTxType, DynamicFeeTxType, BlobTxType, SetCodeTxType:
-			inner := rlp.NewStream(bytes.NewReader(b[1:]), uint64(len(b)-1))
-			if err := r.decodePayload(inner); err != nil {
-				return err
-			}
-		default:
+		if !knownTypedTxType(r.Type) {
 			return ErrTxTypeNotSupported
+		}
+		inner := rlp.NewStream(bytes.NewReader(b[1:]), uint64(len(b)-1))
+		if err := r.decodePayload(inner); err != nil {
+			return err
 		}
 	default:
 		return rlp.ErrExpectedList
@@ -527,36 +522,19 @@ func (rs Receipts) Copy() Receipts {
 func (rs Receipts) EncodeIndex(i int, w *bytes.Buffer) {
 	r := rs[i]
 	data := &receiptRLP{r.statusEncoding(), r.CumulativeGasUsed, r.Bloom, r.Logs}
-	switch r.Type {
-	case LegacyTxType:
+	if r.Type == LegacyTxType {
 		if err := rlp.Encode(w, data); err != nil {
 			panic(err)
 		}
-	case AccessListTxType:
-		//nolint:errcheck
-		w.WriteByte(AccessListTxType)
-		if err := rlp.Encode(w, data); err != nil {
-			panic(err)
-		}
-	case DynamicFeeTxType:
-		w.WriteByte(DynamicFeeTxType)
-		if err := rlp.Encode(w, data); err != nil {
-			panic(err)
-		}
-	case BlobTxType:
-		w.WriteByte(BlobTxType)
-		if err := rlp.Encode(w, data); err != nil {
-			panic(err)
-		}
-	case SetCodeTxType:
-		w.WriteByte(SetCodeTxType)
-		if err := rlp.Encode(w, data); err != nil {
-			panic(err)
-		}
-	default:
-		// For unsupported types, write nothing. Since this is for
-		// DeriveSha, the error will be caught matching the derived hash
-		// to the block.
+		return
+	}
+	if !knownTypedTxType(r.Type) {
+		// Fail where the type is visible; the alternative surfaces as a
+		// receipts-root mismatch that names nothing.
+		panic(fmt.Sprintf("types: Receipts.EncodeIndex: unknown transaction type %d", r.Type))
+	}
+	if err := r.encodeTyped(data, w); err != nil {
+		panic(err)
 	}
 }
 

--- a/execution/types/receipt.go
+++ b/execution/types/receipt.go
@@ -209,7 +209,7 @@ func (r *Receipt) decodeTyped(b []byte) error {
 	if len(b) <= 1 {
 		return errShortTypedReceipt
 	}
-	if !knownTypedTxType(b[0]) {
+	if !hasStandardReceiptPayload(b[0]) {
 		return ErrTxTypeNotSupported
 	}
 	var data receiptRLP
@@ -300,7 +300,7 @@ func (r *Receipt) DecodeRLP(s *rlp.Stream) error {
 			return fmt.Errorf("read typed receipt: %w", err)
 		}
 		r.Type = b[0]
-		if !knownTypedTxType(r.Type) {
+		if !hasStandardReceiptPayload(r.Type) {
 			return ErrTxTypeNotSupported
 		}
 		inner := rlp.NewStream(bytes.NewReader(b[1:]), uint64(len(b)-1))
@@ -452,7 +452,7 @@ func (r *ReceiptForStorage) DecodeRLP(s *rlp.Stream) error {
 	if dec.Type, err = s.Uint8(); err != nil {
 		return fmt.Errorf("read Type: %w", err)
 	}
-	if dec.Type != LegacyTxType && !knownTypedTxType(dec.Type) {
+	if dec.Type != LegacyTxType && !hasStandardReceiptPayload(dec.Type) {
 		return fmt.Errorf("invalid receipt type %d", dec.Type)
 	}
 	kind, size, err := s.Kind()
@@ -531,10 +531,10 @@ func (rs Receipts) EncodeIndex(i int, w *bytes.Buffer) {
 		}
 		return
 	}
-	if !knownTypedTxType(r.Type) {
+	if !hasStandardReceiptPayload(r.Type) {
 		// Fail where the type is visible; the alternative surfaces as a
 		// receipts-root mismatch that names nothing.
-		panic(fmt.Sprintf("types: Receipts.EncodeIndex: unknown transaction type %d", r.Type))
+		panic(fmt.Sprintf("types: Receipts.EncodeIndex: transaction type %d has no standard receipt payload", r.Type))
 	}
 	if err := r.encodeTyped(data, w); err != nil {
 		panic(err)

--- a/execution/types/receipt.go
+++ b/execution/types/receipt.go
@@ -147,6 +147,9 @@ func (r Receipt) EncodeRLP(w io.Writer) error {
 	if r.Type == LegacyTxType {
 		return rlp.Encode(w, data)
 	}
+	if !hasStandardReceiptPayload(r.Type) {
+		return ErrTxTypeNotSupported
+	}
 	buf := pool.GetBuffer()
 	defer pool.PutBuffer(buf)
 	if err := r.encodeTyped(data, buf); err != nil {
@@ -161,6 +164,9 @@ func (r Receipt) EncodeRLP(w io.Writer) error {
 //
 //	receiptₙ = [tx-type, post-state-or-status, cumulative-gas, logs]
 func (r Receipt) EncodeRLP69(w io.Writer) error {
+	if r.Type != LegacyTxType && !hasStandardReceiptPayload(r.Type) {
+		return ErrTxTypeNotSupported
+	}
 	data := &receiptRLP69{r.Type, r.statusEncoding(), r.CumulativeGasUsed, r.Logs}
 	return rlp.Encode(w, data)
 }
@@ -175,6 +181,9 @@ func (r *Receipt) encodeTyped(data *receiptRLP, w *bytes.Buffer) error {
 func (r *Receipt) MarshalBinary() ([]byte, error) {
 	if r.Type == LegacyTxType {
 		return rlp.EncodeToBytes(r)
+	}
+	if !hasStandardReceiptPayload(r.Type) {
+		return nil, ErrTxTypeNotSupported
 	}
 	data := &receiptRLP{r.statusEncoding(), r.CumulativeGasUsed, r.Bloom, r.Logs}
 	var buf bytes.Buffer
@@ -229,7 +238,9 @@ func (r *Receipt) decodePayload(s *rlp.Stream) error {
 	if b, err = s.Bytes(); err != nil {
 		return fmt.Errorf("read PostStateOrStatus: %w", err)
 	}
-	r.setStatus(b)
+	if err = r.setStatus(b); err != nil {
+		return err
+	}
 	if r.CumulativeGasUsed, err = s.Uint64(); err != nil {
 		return fmt.Errorf("read CumulativeGasUsed: %w", err)
 	}
@@ -289,20 +300,21 @@ func (r *Receipt) DecodeRLP(s *rlp.Stream) error {
 	case rlp.String:
 		// EIP-2718 typed txn receipt. Read the envelope as raw bytes,
 		// then decode from them using a fresh stream.
-		if size == 0 {
-			// Empty string is not a valid typed receipt. Return a real error
-			// rather than rlp.EOL: as a slice element EOL would be read as
-			// end-of-list and silently drop the receipt.
+		if size <= 1 {
+			// A type byte with no payload is not a valid typed receipt, and
+			// neither is the empty string. Return a real error rather than
+			// rlp.EOL: as a slice element EOL would be read as end-of-list
+			// and silently drop the receipt.
 			return errShortTypedReceipt
 		}
 		b := make([]byte, size)
 		if err = s.ReadBytes(b); err != nil {
 			return fmt.Errorf("read typed receipt: %w", err)
 		}
-		r.Type = b[0]
-		if !hasStandardReceiptPayload(r.Type) {
+		if !hasStandardReceiptPayload(b[0]) {
 			return ErrTxTypeNotSupported
 		}
+		r.Type = b[0]
 		inner := rlp.NewStream(bytes.NewReader(b[1:]), uint64(len(b)-1))
 		if err := r.decodePayload(inner); err != nil {
 			return err
@@ -369,6 +381,9 @@ type ReceiptForStorage Receipt
 // EncodeRLP implements rlp.Encoder, and flattens all content fields of a receipt
 // into an RLP stream.
 func (r *ReceiptForStorage) EncodeRLP(w io.Writer) error {
+	if r.Type != LegacyTxType && !hasStandardReceiptPayload(r.Type) {
+		return fmt.Errorf("invalid receipt type %d", r.Type)
+	}
 	if r.FirstLogIndexWithinBlock == 0 && len(r.Logs) > 0 {
 		r.FirstLogIndexWithinBlock = uint32(r.Logs[0].Index)
 	}
@@ -532,9 +547,11 @@ func (rs Receipts) EncodeIndex(i int, w *bytes.Buffer) {
 		return
 	}
 	if !hasStandardReceiptPayload(r.Type) {
-		// Fail where the type is visible; the alternative surfaces as a
-		// receipts-root mismatch that names nothing.
-		panic(fmt.Sprintf("types: Receipts.EncodeIndex: transaction type %d has no standard receipt payload", r.Type))
+		// Write nothing, as before. This runs under DeriveSha on the block
+		// path, so a type with no encoding here has to surface as a receipts
+		// root mismatch that rejects the block, not as a panic a peer can
+		// reach by sending one.
+		return
 	}
 	if err := r.encodeTyped(data, w); err != nil {
 		panic(err)

--- a/execution/types/receipt.go
+++ b/execution/types/receipt.go
@@ -238,7 +238,7 @@ func (r *Receipt) decodePayload(s *rlp.Stream) error {
 	if b, err = s.Bytes(); err != nil {
 		return fmt.Errorf("read PostStateOrStatus: %w", err)
 	}
-	if err = r.setStatus(b); err != nil {
+	if err := r.setStatus(b); err != nil {
 		return err
 	}
 	if r.CumulativeGasUsed, err = s.Uint64(); err != nil {
@@ -381,7 +381,7 @@ type ReceiptForStorage Receipt
 // EncodeRLP implements rlp.Encoder, and flattens all content fields of a receipt
 // into an RLP stream.
 func (r *ReceiptForStorage) EncodeRLP(w io.Writer) error {
-	if r.Type != LegacyTxType && !hasStandardReceiptPayload(r.Type) {
+	if !storableReceiptType(r.Type) {
 		return fmt.Errorf("invalid receipt type %d", r.Type)
 	}
 	if r.FirstLogIndexWithinBlock == 0 && len(r.Logs) > 0 {
@@ -467,7 +467,7 @@ func (r *ReceiptForStorage) DecodeRLP(s *rlp.Stream) error {
 	if dec.Type, err = s.Uint8(); err != nil {
 		return fmt.Errorf("read Type: %w", err)
 	}
-	if dec.Type != LegacyTxType && !hasStandardReceiptPayload(dec.Type) {
+	if !storableReceiptType(dec.Type) {
 		return fmt.Errorf("invalid receipt type %d", dec.Type)
 	}
 	kind, size, err := s.Kind()

--- a/execution/types/receipt.go
+++ b/execution/types/receipt.go
@@ -452,6 +452,9 @@ func (r *ReceiptForStorage) DecodeRLP(s *rlp.Stream) error {
 	if dec.Type, err = s.Uint8(); err != nil {
 		return fmt.Errorf("read Type: %w", err)
 	}
+	if dec.Type != LegacyTxType && !knownTypedTxType(dec.Type) {
+		return fmt.Errorf("invalid receipt type %d", dec.Type)
+	}
 	kind, size, err := s.Kind()
 	if err != nil {
 		return fmt.Errorf("read PostStateOrStatus: %w", err)

--- a/execution/types/receipt_test.go
+++ b/execution/types/receipt_test.go
@@ -546,51 +546,42 @@ func TestReceiptEncode(t *testing.T) {
 	})
 }
 
-// TestAccountAbstractionReceiptEncoding pins type 5 to the standard typed
-// encoding. Both status values are covered because they encode to different
-// payloads (0x01 against the empty string).
-//
-// The EncodeIndex leaf is the consensus-visible part: before the registry was
-// wired in, type 5 fell to the default arm and contributed zero bytes, so the
-// receipts root of a block carrying an AA transaction changes here.
-func TestAccountAbstractionReceiptEncoding(t *testing.T) {
+// TestAccountAbstractionReceiptStaysUnencoded pins type 5 out of the consensus
+// receipt paths: giving it an encoding it never had moves the receipts root of
+// an RIP-7560 block. Storage is the exception, and already round-trips type 5.
+func TestAccountAbstractionReceiptStaysUnencoded(t *testing.T) {
 	t.Parallel()
 
-	roots := []common.Hash{
-		common.HexToHash("0x1b9e70ed972e759c9b3da0c6393e8c7737bc9a1139481bb8a2876218be238784"),
-		common.HexToHash("0x9d13aed92c9bd29c7d8fcb09dd05d836d7cc0dc8802e6cb30449b6ea3e81f5f7"),
+	r := &Receipt{
+		Type:              AccountAbstractionTxType,
+		Status:            ReceiptStatusSuccessful,
+		CumulativeGasUsed: 21000,
+		Logs: []*Log{{
+			Address: common.BytesToAddress([]byte{0x11}),
+			Topics:  []common.Hash{common.HexToHash("dead")},
+			Data:    []byte{0xff},
+		}},
 	}
-	for i, status := range []uint64{ReceiptStatusSuccessful, ReceiptStatusFailed} {
-		r := &Receipt{
-			Type:              AccountAbstractionTxType,
-			Status:            status,
-			CumulativeGasUsed: 21000,
-			Logs: []*Log{{
-				Address: common.BytesToAddress([]byte{0x11}),
-				Topics:  []common.Hash{common.HexToHash("dead")},
-				Data:    []byte{0xff},
-			}},
-		}
-		r.Bloom = CreateBloom(Receipts{r})
+	r.Bloom = CreateBloom(Receipts{r})
 
-		binary, err := r.MarshalBinary()
-		require.NoError(t, err)
-		require.Equal(t, byte(AccountAbstractionTxType), binary[0])
+	_, err := r.MarshalBinary()
+	require.ErrorIs(t, err, ErrTxTypeNotSupported)
+	require.ErrorIs(t, r.EncodeRLP(new(bytes.Buffer)), ErrTxTypeNotSupported)
+	require.ErrorIs(t, r.EncodeRLP69(new(bytes.Buffer)), ErrTxTypeNotSupported)
 
-		payload, err := rlp.EncodeToBytes(&receiptRLP{r.statusEncoding(), r.CumulativeGasUsed, r.Bloom, r.Logs})
-		require.NoError(t, err)
-		var buf bytes.Buffer
-		Receipts{r}.EncodeIndex(0, &buf)
-		require.Equal(t, append([]byte{AccountAbstractionTxType}, payload...), buf.Bytes())
-		require.Equal(t, roots[i], DeriveSha(Receipts{r}))
+	var buf bytes.Buffer
+	Receipts{r}.EncodeIndex(0, &buf)
+	require.Empty(t, buf.Bytes())
 
-		got := new(Receipt)
-		require.NoError(t, got.UnmarshalBinary(binary))
-		require.Equal(t, r.Type, got.Type)
-		require.Equal(t, r.Status, got.Status)
-		require.Equal(t, r.CumulativeGasUsed, got.CumulativeGasUsed)
-		require.Equal(t, r.Logs, got.Logs)
-	}
+	// The empty-leaf root main derives for the same receipt.
+	require.Equal(t, common.HexToHash("0x01d05430bbe453102aa0430967e6389b1083ce3e3c04b5653034be32d99e00b6"), DeriveSha(Receipts{r}))
+
+	stored, err := rlp.EncodeToBytes((*ReceiptForStorage)(r))
+	require.NoError(t, err)
+	unstored := new(ReceiptForStorage)
+	require.NoError(t, rlp.DecodeBytes(stored, unstored))
+	require.Equal(t, r.Type, unstored.Type)
+	require.Equal(t, r.CumulativeGasUsed, unstored.CumulativeGasUsed)
 }
 
 // TestTypedReceiptDecodersAgree pins UnmarshalBinary and DecodeRLP to the same

--- a/execution/types/receipt_test.go
+++ b/execution/types/receipt_test.go
@@ -546,34 +546,38 @@ func TestReceiptEncode(t *testing.T) {
 	})
 }
 
-// TestAccountAbstractionReceiptEncoding pins the built-in RIP-7560 receipt,
-// produced by aa.CreateAAReceipt, to the standard typed encoding.
+// TestAccountAbstractionReceiptEncoding pins type 5 to the standard typed
+// encoding. Both status values are covered because they encode to different
+// payloads (0x01 against the empty string).
 func TestAccountAbstractionReceiptEncoding(t *testing.T) {
 	t.Parallel()
 
-	r := &Receipt{
-		Type:              AccountAbstractionTxType,
-		Status:            ReceiptStatusSuccessful,
-		CumulativeGasUsed: 21000,
-		Logs: []*Log{{
-			Address: common.BytesToAddress([]byte{0x11}),
-			Topics:  []common.Hash{common.HexToHash("dead")},
-			Data:    []byte{0xff},
-		}},
+	for _, status := range []uint64{ReceiptStatusSuccessful, ReceiptStatusFailed} {
+		r := &Receipt{
+			Type:              AccountAbstractionTxType,
+			Status:            status,
+			CumulativeGasUsed: 21000,
+			Logs: []*Log{{
+				Address: common.BytesToAddress([]byte{0x11}),
+				Topics:  []common.Hash{common.HexToHash("dead")},
+				Data:    []byte{0xff},
+			}},
+		}
+		r.Bloom = CreateBloom(Receipts{r})
+
+		binary, err := r.MarshalBinary()
+		require.NoError(t, err)
+		require.Equal(t, byte(AccountAbstractionTxType), binary[0])
+
+		var buf bytes.Buffer
+		Receipts{r}.EncodeIndex(0, &buf)
+		require.Equal(t, binary, buf.Bytes())
+
+		got := new(Receipt)
+		require.NoError(t, got.UnmarshalBinary(binary))
+		require.Equal(t, r.Type, got.Type)
+		require.Equal(t, r.Status, got.Status)
+		require.Equal(t, r.CumulativeGasUsed, got.CumulativeGasUsed)
+		require.Equal(t, r.Logs, got.Logs)
 	}
-	r.Bloom = CreateBloom(Receipts{r})
-
-	binary, err := r.MarshalBinary()
-	require.NoError(t, err)
-	require.Equal(t, byte(AccountAbstractionTxType), binary[0])
-
-	var buf bytes.Buffer
-	Receipts{r}.EncodeIndex(0, &buf)
-	require.Equal(t, binary, buf.Bytes())
-
-	got := new(Receipt)
-	require.NoError(t, got.UnmarshalBinary(binary))
-	require.Equal(t, r.Type, got.Type)
-	require.Equal(t, r.CumulativeGasUsed, got.CumulativeGasUsed)
-	require.Equal(t, r.Logs, got.Logs)
 }

--- a/execution/types/receipt_test.go
+++ b/execution/types/receipt_test.go
@@ -549,10 +549,18 @@ func TestReceiptEncode(t *testing.T) {
 // TestAccountAbstractionReceiptEncoding pins type 5 to the standard typed
 // encoding. Both status values are covered because they encode to different
 // payloads (0x01 against the empty string).
+//
+// The EncodeIndex leaf is the consensus-visible part: before the registry was
+// wired in, type 5 fell to the default arm and contributed zero bytes, so the
+// receipts root of a block carrying an AA transaction changes here.
 func TestAccountAbstractionReceiptEncoding(t *testing.T) {
 	t.Parallel()
 
-	for _, status := range []uint64{ReceiptStatusSuccessful, ReceiptStatusFailed} {
+	roots := []common.Hash{
+		common.HexToHash("0x1b9e70ed972e759c9b3da0c6393e8c7737bc9a1139481bb8a2876218be238784"),
+		common.HexToHash("0x9d13aed92c9bd29c7d8fcb09dd05d836d7cc0dc8802e6cb30449b6ea3e81f5f7"),
+	}
+	for i, status := range []uint64{ReceiptStatusSuccessful, ReceiptStatusFailed} {
 		r := &Receipt{
 			Type:              AccountAbstractionTxType,
 			Status:            status,
@@ -569,9 +577,12 @@ func TestAccountAbstractionReceiptEncoding(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, byte(AccountAbstractionTxType), binary[0])
 
+		payload, err := rlp.EncodeToBytes(&receiptRLP{r.statusEncoding(), r.CumulativeGasUsed, r.Bloom, r.Logs})
+		require.NoError(t, err)
 		var buf bytes.Buffer
 		Receipts{r}.EncodeIndex(0, &buf)
-		require.Equal(t, binary, buf.Bytes())
+		require.Equal(t, append([]byte{AccountAbstractionTxType}, payload...), buf.Bytes())
+		require.Equal(t, roots[i], DeriveSha(Receipts{r}))
 
 		got := new(Receipt)
 		require.NoError(t, got.UnmarshalBinary(binary))
@@ -580,4 +591,53 @@ func TestAccountAbstractionReceiptEncoding(t *testing.T) {
 		require.Equal(t, r.CumulativeGasUsed, got.CumulativeGasUsed)
 		require.Equal(t, r.Logs, got.Logs)
 	}
+}
+
+// TestTypedReceiptDecodersAgree pins UnmarshalBinary and DecodeRLP to the same
+// verdict on a typed envelope. They are separate implementations over the same
+// bytes, so a guard added to one and not the other is a decoder split: the same
+// receipt is accepted on one path and rejected on the other.
+func TestTypedReceiptDecodersAgree(t *testing.T) {
+	t.Parallel()
+
+	envelope := func(t *testing.T, b []byte) []byte {
+		t.Helper()
+		enveloped, err := rlp.EncodeToBytes(b)
+		require.NoError(t, err)
+		return enveloped
+	}
+
+	t.Run("a bare type byte is too short on both", func(t *testing.T) {
+		b := []byte{DynamicFeeTxType}
+		require.ErrorIs(t, new(Receipt).UnmarshalBinary(b), errShortTypedReceipt)
+		// Hand-built: EncodeToBytes collapses a single sub-0x80 byte to itself,
+		// which the stream reads as rlp.Byte and never offers to DecodeRLP.
+		require.ErrorIs(t, rlp.DecodeBytes([]byte{0x81, DynamicFeeTxType}, new(Receipt)), errShortTypedReceipt)
+	})
+
+	t.Run("an out-of-range status is rejected on both", func(t *testing.T) {
+		payload, err := rlp.EncodeToBytes(&receiptRLP{[]byte{1, 2, 3, 4, 5}, 21000, Bloom{}, nil})
+		require.NoError(t, err)
+		b := append([]byte{DynamicFeeTxType}, payload...)
+
+		require.ErrorContains(t, new(Receipt).UnmarshalBinary(b), "invalid receipt status")
+		require.ErrorContains(t, rlp.DecodeBytes(envelope(t, b), new(Receipt)), "invalid receipt status")
+	})
+
+	t.Run("a rejected type leaves the receipt untouched on both", func(t *testing.T) {
+		const unsupported = 0x7f
+		payload, err := rlp.EncodeToBytes(&receiptRLP{[]byte{1}, 21000, Bloom{}, nil})
+		require.NoError(t, err)
+		b := append([]byte{unsupported}, payload...)
+
+		for _, decode := range []func(*Receipt) error{
+			func(r *Receipt) error { return r.UnmarshalBinary(b) },
+			func(r *Receipt) error { return rlp.DecodeBytes(envelope(t, b), r) },
+		} {
+			r := &Receipt{Type: BlobTxType, CumulativeGasUsed: 7}
+			require.ErrorIs(t, decode(r), ErrTxTypeNotSupported)
+			require.Equal(t, byte(BlobTxType), r.Type, "a rejected decode must not half-overwrite the target")
+			require.Equal(t, uint64(7), r.CumulativeGasUsed)
+		}
+	})
 }

--- a/execution/types/receipt_test.go
+++ b/execution/types/receipt_test.go
@@ -545,3 +545,35 @@ func TestReceiptEncode(t *testing.T) {
 		require.Equal(t, len(r1.Logs[0].Topics), len(r2.Logs[0].Topics))
 	})
 }
+
+// TestAccountAbstractionReceiptEncoding pins the built-in RIP-7560 receipt,
+// produced by aa.CreateAAReceipt, to the standard typed encoding.
+func TestAccountAbstractionReceiptEncoding(t *testing.T) {
+	t.Parallel()
+
+	r := &Receipt{
+		Type:              AccountAbstractionTxType,
+		Status:            ReceiptStatusSuccessful,
+		CumulativeGasUsed: 21000,
+		Logs: []*Log{{
+			Address: common.BytesToAddress([]byte{0x11}),
+			Topics:  []common.Hash{common.HexToHash("dead")},
+			Data:    []byte{0xff},
+		}},
+	}
+	r.Bloom = CreateBloom(Receipts{r})
+
+	binary, err := r.MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, byte(AccountAbstractionTxType), binary[0])
+
+	var buf bytes.Buffer
+	Receipts{r}.EncodeIndex(0, &buf)
+	require.Equal(t, binary, buf.Bytes())
+
+	got := new(Receipt)
+	require.NoError(t, got.UnmarshalBinary(binary))
+	require.Equal(t, r.Type, got.Type)
+	require.Equal(t, r.CumulativeGasUsed, got.CumulativeGasUsed)
+	require.Equal(t, r.Logs, got.Logs)
+}

--- a/execution/types/tx_registry.go
+++ b/execution/types/tx_registry.go
@@ -24,8 +24,8 @@ import (
 )
 
 // TxTypeSpec describes an externally registered transaction type. Registering
-// an id also admits it to the receipt encode and decode paths, so it decides
-// what bytes reach the receipts trie; an unregistered id is rejected there.
+// an id admits it to the transaction decode and sender paths only; the receipt
+// paths are separate and opt-in through StandardReceiptPayload.
 type TxTypeSpec struct {
 	New func() Transaction
 	// UnmarshalJSON may be nil for types not submittable over JSON-RPC;
@@ -38,8 +38,9 @@ type TxTypeSpec struct {
 	// StandardReceiptPayload declares that this type's receipts carry the
 	// same payload as the built-in typed receipts. EIP-2718 leaves
 	// ReceiptPayload opaque and type-specific, so a type that adds consensus
-	// fields to it — as OP's deposit receipts do — must leave this false and
-	// gets no receipt encoding rather than a silently wrong one.
+	// fields to it — as OP's deposit receipts do — must leave this false. Such
+	// a type is then absent from the receipts root this package derives, and
+	// the chain has to supply its own DerivableList.
 	StandardReceiptPayload bool
 }
 
@@ -79,6 +80,8 @@ func registeredTxType(id byte) (TxTypeSpec, bool) {
 	return spec, ok
 }
 
+// builtinTxType is the registration-collision list: the ids this package defines
+// itself, which an external type may not claim.
 func builtinTxType(id byte) bool {
 	switch id {
 	case LegacyTxType, AccessListTxType, DynamicFeeTxType, BlobTxType, SetCodeTxType, AccountAbstractionTxType:
@@ -87,14 +90,14 @@ func builtinTxType(id byte) bool {
 	return false
 }
 
-// hasStandardReceiptPayload reports whether id's receipts are the typed
-// receipt with the built-in payload. Legacy is excluded — it carries no type
-// byte — and a registered type has to opt in.
+// hasStandardReceiptPayload reports whether id's receipts are the typed receipt
+// with the built-in payload. Deliberately its own list rather than builtinTxType:
+// EIP-2718 leaves ReceiptPayload type-specific, so a future built-in that adds a
+// consensus receipt field must stay off this one. Legacy is absent because it
+// carries no type byte; a registered type has to opt in.
 func hasStandardReceiptPayload(id byte) bool {
-	if id == LegacyTxType {
-		return false
-	}
-	if builtinTxType(id) {
+	switch id {
+	case AccessListTxType, DynamicFeeTxType, BlobTxType, SetCodeTxType, AccountAbstractionTxType:
 		return true
 	}
 	spec, ok := registeredTxType(id)

--- a/execution/types/tx_registry.go
+++ b/execution/types/tx_registry.go
@@ -47,8 +47,7 @@ var (
 // or was already registered, and if spec.New is nil — all programming errors
 // caught at init time.
 func RegisterTxType(id byte, spec TxTypeSpec) {
-	switch id {
-	case LegacyTxType, AccessListTxType, DynamicFeeTxType, BlobTxType, SetCodeTxType, AccountAbstractionTxType:
+	if builtinTxType(id) {
 		panic(fmt.Sprintf("types: RegisterTxType: %d collides with a built-in transaction type", id))
 	}
 	if id >= 0x80 {
@@ -72,4 +71,26 @@ func registeredTxType(id byte) (TxTypeSpec, bool) {
 	defer txTypeRegistryMu.RUnlock()
 	spec, ok := txTypeRegistry[id]
 	return spec, ok
+}
+
+func builtinTxType(id byte) bool {
+	switch id {
+	case LegacyTxType, AccessListTxType, DynamicFeeTxType, BlobTxType, SetCodeTxType, AccountAbstractionTxType:
+		return true
+	}
+	return false
+}
+
+// knownTypedTxType reports whether id is an EIP-2718 typed transaction type
+// this build knows: built-in or externally registered. Legacy is excluded — it
+// carries no type byte.
+func knownTypedTxType(id byte) bool {
+	if id == LegacyTxType {
+		return false
+	}
+	if builtinTxType(id) {
+		return true
+	}
+	_, ok := registeredTxType(id)
+	return ok
 }

--- a/execution/types/tx_registry.go
+++ b/execution/types/tx_registry.go
@@ -35,6 +35,12 @@ type TxTypeSpec struct {
 	// must be self-contained and never call back into the signer's own
 	// dispatch. Nil means sender recovery rejects the type.
 	Sender func(txn Transaction, sg Signer) (accounts.Address, error)
+	// StandardReceiptPayload declares that this type's receipts carry the
+	// same payload as the built-in typed receipts. EIP-2718 leaves
+	// ReceiptPayload opaque and type-specific, so a type that adds consensus
+	// fields to it — as OP's deposit receipts do — must leave this false and
+	// gets no receipt encoding rather than a silently wrong one.
+	StandardReceiptPayload bool
 }
 
 var (
@@ -81,16 +87,16 @@ func builtinTxType(id byte) bool {
 	return false
 }
 
-// knownTypedTxType reports whether id is an EIP-2718 typed transaction type
-// this build knows: built-in or externally registered. Legacy is excluded — it
-// carries no type byte.
-func knownTypedTxType(id byte) bool {
+// hasStandardReceiptPayload reports whether id's receipts are the typed
+// receipt with the built-in payload. Legacy is excluded — it carries no type
+// byte — and a registered type has to opt in.
+func hasStandardReceiptPayload(id byte) bool {
 	if id == LegacyTxType {
 		return false
 	}
 	if builtinTxType(id) {
 		return true
 	}
-	_, ok := registeredTxType(id)
-	return ok
+	spec, ok := registeredTxType(id)
+	return ok && spec.StandardReceiptPayload
 }

--- a/execution/types/tx_registry.go
+++ b/execution/types/tx_registry.go
@@ -91,15 +91,27 @@ func builtinTxType(id byte) bool {
 }
 
 // hasStandardReceiptPayload reports whether id's receipts are the typed receipt
-// with the built-in payload. Deliberately its own list rather than builtinTxType:
-// EIP-2718 leaves ReceiptPayload type-specific, so a future built-in that adds a
-// consensus receipt field must stay off this one. Legacy is absent because it
-// carries no type byte; a registered type has to opt in.
+// with the built-in payload. Its own list rather than builtinTxType: EIP-2718
+// leaves ReceiptPayload type-specific, so a built-in that adds a consensus
+// receipt field stays off this one. Legacy carries no type byte; a registered
+// type has to opt in.
+//
+// AccountAbstractionTxType is off it deliberately — it has never had a receipt
+// encoding, so giving it one moves the receipts root of an RIP-7560 block (#23569).
 func hasStandardReceiptPayload(id byte) bool {
 	switch id {
-	case AccessListTxType, DynamicFeeTxType, BlobTxType, SetCodeTxType, AccountAbstractionTxType:
+	case AccessListTxType, DynamicFeeTxType, BlobTxType, SetCodeTxType:
 		return true
 	}
 	spec, ok := registeredTxType(id)
 	return ok && spec.StandardReceiptPayload
+}
+
+// storableReceiptType reports whether ReceiptForStorage can hold id's receipts
+// without dropping a field. Wider than hasStandardReceiptPayload: the storage
+// format keeps Type as a plain field, so every built-in round-trips whatever its
+// consensus encoding. A registered type must still claim the standard payload —
+// the format has no room for the extra fields the opt-out exists for.
+func storableReceiptType(id byte) bool {
+	return builtinTxType(id) || hasStandardReceiptPayload(id)
 }

--- a/execution/types/tx_registry.go
+++ b/execution/types/tx_registry.go
@@ -23,9 +23,9 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// TxTypeSpec describes an externally registered transaction type's decode
-// facets. It is consulted only from the default arm of the built-in type
-// switches, so an unregistered id keeps today's behavior unchanged.
+// TxTypeSpec describes an externally registered transaction type. Registering
+// an id also admits it to the receipt encode and decode paths, so it decides
+// what bytes reach the receipts trie; an unregistered id is rejected there.
 type TxTypeSpec struct {
 	New func() Transaction
 	// UnmarshalJSON may be nil for types not submittable over JSON-RPC;

--- a/execution/types/tx_registry_embed_test.go
+++ b/execution/types/tx_registry_embed_test.go
@@ -121,7 +121,8 @@ func (tx *externalTx) Sender(types.Signer) (accounts.Address, error) {
 func TestExternalPackageTxTypeEndToEnd(t *testing.T) {
 	want := accounts.InternAddress(common.HexToAddress("0xabcd"))
 	types.RegisterTxType(externalTxType, types.TxTypeSpec{
-		New: func() types.Transaction { return &externalTx{} },
+		New:                    func() types.Transaction { return &externalTx{} },
+		StandardReceiptPayload: true,
 		Sender: func(txn types.Transaction, _ types.Signer) (accounts.Address, error) {
 			return txn.(*externalTx).Sender(types.Signer{})
 		},

--- a/execution/types/tx_registry_embed_test.go
+++ b/execution/types/tx_registry_embed_test.go
@@ -139,4 +139,30 @@ func TestExternalPackageTxTypeEndToEnd(t *testing.T) {
 	got, err := types.Signer{}.SenderWithContext(nil, decoded)
 	require.NoError(t, err)
 	require.Equal(t, want, got)
+
+	receipt := &types.Receipt{
+		Type:              externalTxType,
+		Status:            types.ReceiptStatusSuccessful,
+		CumulativeGasUsed: 21000,
+		Logs: []*types.Log{{
+			Address: common.BytesToAddress([]byte{0x11}),
+			Topics:  []common.Hash{common.HexToHash("dead")},
+			Data:    []byte{0xff},
+		}},
+	}
+	receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
+
+	binary, err := receipt.MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, byte(externalTxType), binary[0])
+
+	var indexed bytes.Buffer
+	types.Receipts{receipt}.EncodeIndex(0, &indexed)
+	require.Equal(t, binary, indexed.Bytes())
+
+	gotReceipt := new(types.Receipt)
+	require.NoError(t, gotReceipt.UnmarshalBinary(binary))
+	require.Equal(t, receipt.Type, gotReceipt.Type)
+	require.Equal(t, receipt.CumulativeGasUsed, gotReceipt.CumulativeGasUsed)
+	require.Equal(t, receipt.Logs, gotReceipt.Logs)
 }

--- a/execution/types/tx_registry_test.go
+++ b/execution/types/tx_registry_test.go
@@ -322,3 +322,83 @@ func TestRegisteredTxTypeNilJSONDecoder(t *testing.T) {
 	_, err := UnmarshalTransactionFromJSON([]byte(`{"type":"0x7d"}`))
 	require.Error(t, err)
 }
+
+// rawReceiptList is a DerivableList of pre-encoded leaves, used to pin the
+// receipts root a registered type must derive to.
+type rawReceiptList [][]byte
+
+func (l rawReceiptList) Len() int { return len(l) }
+
+func (l rawReceiptList) EncodeIndex(i int, w *bytes.Buffer) { w.Write(l[i]) }
+
+func fakeRegisteredReceipt() *Receipt {
+	r := &Receipt{
+		Type:              fakeRegisteredTxType,
+		Status:            ReceiptStatusSuccessful,
+		CumulativeGasUsed: 42,
+		Logs: []*Log{{
+			Address: common.BytesToAddress([]byte{0x11}),
+			Topics:  []common.Hash{common.HexToHash("dead")},
+			Data:    []byte{0x01, 0x00, 0xff},
+		}},
+	}
+	r.Bloom = CreateBloom(Receipts{r})
+	return r
+}
+
+func TestRegisteredTxTypeReceiptRoundTrip(t *testing.T) {
+	registerFakeTxType(t)
+
+	want := fakeRegisteredReceipt()
+	binary, err := want.MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, byte(fakeRegisteredTxType), binary[0])
+
+	got := new(Receipt)
+	require.NoError(t, got.UnmarshalBinary(binary))
+	require.Equal(t, want.Type, got.Type)
+	require.Equal(t, want.Status, got.Status)
+	require.Equal(t, want.CumulativeGasUsed, got.CumulativeGasUsed)
+	require.Equal(t, want.Bloom, got.Bloom)
+	require.Equal(t, want.Logs, got.Logs)
+
+	var buf bytes.Buffer
+	require.NoError(t, want.EncodeRLP(&buf))
+	streamed := new(Receipt)
+	require.NoError(t, rlp.DecodeBytes(buf.Bytes(), streamed))
+	require.Equal(t, want.Type, streamed.Type)
+	require.Equal(t, want.CumulativeGasUsed, streamed.CumulativeGasUsed)
+	require.Equal(t, want.Logs, streamed.Logs)
+}
+
+func TestRegisteredTxTypeReceiptRoot(t *testing.T) {
+	registerFakeTxType(t)
+
+	r := fakeRegisteredReceipt()
+	binary, err := r.MarshalBinary()
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	Receipts{r}.EncodeIndex(0, &buf)
+	require.Equal(t, binary, buf.Bytes(), "EncodeIndex must agree with MarshalBinary")
+
+	require.Equal(t, DeriveSha(rawReceiptList{binary}), DeriveSha(Receipts{r}))
+}
+
+func TestUnregisteredReceiptTypeRejected(t *testing.T) {
+	const unknownType = 0x7f
+
+	payload, err := rlp.EncodeToBytes(&receiptRLP{[]byte{1}, 42, Bloom{}, nil})
+	require.NoError(t, err)
+	binary := append([]byte{unknownType}, payload...)
+
+	require.ErrorIs(t, new(Receipt).UnmarshalBinary(binary), ErrTxTypeNotSupported)
+
+	enveloped, err := rlp.EncodeToBytes(binary)
+	require.NoError(t, err)
+	require.ErrorIs(t, rlp.DecodeBytes(enveloped, new(Receipt)), ErrTxTypeNotSupported)
+
+	require.Panics(t, func() {
+		Receipts{{Type: unknownType}}.EncodeIndex(0, new(bytes.Buffer))
+	}, "encoding an unclaimed type must fail loudly, not derive a wrong root")
+}

--- a/execution/types/tx_registry_test.go
+++ b/execution/types/tx_registry_test.go
@@ -323,14 +323,6 @@ func TestRegisteredTxTypeNilJSONDecoder(t *testing.T) {
 	require.Error(t, err)
 }
 
-// rawReceiptList is a DerivableList of pre-encoded leaves, used to pin the
-// receipts root a registered type must derive to.
-type rawReceiptList [][]byte
-
-func (l rawReceiptList) Len() int { return len(l) }
-
-func (l rawReceiptList) EncodeIndex(i int, w *bytes.Buffer) { w.Write(l[i]) }
-
 func fakeRegisteredReceipt() *Receipt {
 	r := &Receipt{
 		Type:              fakeRegisteredTxType,
@@ -369,6 +361,13 @@ func TestRegisteredTxTypeReceiptRoundTrip(t *testing.T) {
 	require.Equal(t, want.Type, streamed.Type)
 	require.Equal(t, want.CumulativeGasUsed, streamed.CumulativeGasUsed)
 	require.Equal(t, want.Logs, streamed.Logs)
+
+	stored, err := rlp.EncodeToBytes((*ReceiptForStorage)(want))
+	require.NoError(t, err)
+	unstored := new(ReceiptForStorage)
+	require.NoError(t, rlp.DecodeBytes(stored, unstored))
+	require.Equal(t, want.Type, unstored.Type)
+	require.Equal(t, want.CumulativeGasUsed, unstored.CumulativeGasUsed)
 }
 
 func TestRegisteredTxTypeReceiptRoot(t *testing.T) {
@@ -382,7 +381,9 @@ func TestRegisteredTxTypeReceiptRoot(t *testing.T) {
 	Receipts{r}.EncodeIndex(0, &buf)
 	require.Equal(t, binary, buf.Bytes(), "EncodeIndex must agree with MarshalBinary")
 
-	require.Equal(t, DeriveSha(rawReceiptList{binary}), DeriveSha(Receipts{r}))
+	// Golden root over the single 0x7e-prefixed leaf.
+	want := common.HexToHash("0x10d0be5b17612ce56aca9e438311c8c76484f24346b5c911857a522aacec5d20")
+	require.Equal(t, want, DeriveSha(Receipts{r}))
 }
 
 func TestUnregisteredReceiptTypeRejected(t *testing.T) {
@@ -401,4 +402,10 @@ func TestUnregisteredReceiptTypeRejected(t *testing.T) {
 	require.Panics(t, func() {
 		Receipts{{Type: unknownType}}.EncodeIndex(0, new(bytes.Buffer))
 	}, "encoding an unclaimed type must fail loudly, not derive a wrong root")
+
+	// The panic above is only a programming-error guard because a stored
+	// receipt cannot carry an unclaimed type into it.
+	stored, err := rlp.EncodeToBytes(&ReceiptForStorage{Type: unknownType, Status: ReceiptStatusSuccessful})
+	require.NoError(t, err)
+	require.ErrorContains(t, rlp.DecodeBytes(stored, new(ReceiptForStorage)), "invalid receipt type")
 }

--- a/execution/types/tx_registry_test.go
+++ b/execution/types/tx_registry_test.go
@@ -176,8 +176,9 @@ func registerFakeTxType(t *testing.T) {
 		return
 	}
 	RegisterTxType(fakeRegisteredTxType, TxTypeSpec{
-		New:           func() Transaction { return &fakeRegisteredTx{} },
-		UnmarshalJSON: unmarshalFakeRegisteredTxJSON,
+		New:                    func() Transaction { return &fakeRegisteredTx{} },
+		StandardReceiptPayload: true,
+		UnmarshalJSON:          unmarshalFakeRegisteredTxJSON,
 		Sender: func(txn Transaction, _ Signer) (accounts.Address, error) {
 			return txn.(*fakeRegisteredTx).sender, nil
 		},
@@ -406,6 +407,28 @@ func TestUnregisteredReceiptTypeRejected(t *testing.T) {
 	// The panic above is only a programming-error guard because a stored
 	// receipt cannot carry an unclaimed type into it.
 	stored, err := rlp.EncodeToBytes(&ReceiptForStorage{Type: unknownType, Status: ReceiptStatusSuccessful})
+	require.NoError(t, err)
+	require.ErrorContains(t, rlp.DecodeBytes(stored, new(ReceiptForStorage)), "invalid receipt type")
+}
+
+// A type whose ReceiptPayload is not the built-in one — OP's deposit receipts
+// add two consensus fields — must be refused rather than encoded as standard.
+func TestRegisteredTxTypeWithoutStandardReceiptPayload(t *testing.T) {
+	const customReceiptType = 0x7a
+
+	RegisterTxType(customReceiptType, TxTypeSpec{New: func() Transaction { return &fakeRegisteredTx{} }})
+	t.Cleanup(func() { unregisterTxType(customReceiptType) })
+
+	r := &Receipt{Type: customReceiptType, Status: ReceiptStatusSuccessful, CumulativeGasUsed: 1}
+	binary, err := r.MarshalBinary()
+	require.NoError(t, err)
+	require.ErrorIs(t, new(Receipt).UnmarshalBinary(binary), ErrTxTypeNotSupported)
+
+	require.Panics(t, func() {
+		Receipts{r}.EncodeIndex(0, new(bytes.Buffer))
+	}, "a type that never claimed the standard payload must not get one")
+
+	stored, err := rlp.EncodeToBytes((*ReceiptForStorage)(r))
 	require.NoError(t, err)
 	require.ErrorContains(t, rlp.DecodeBytes(stored, new(ReceiptForStorage)), "invalid receipt type")
 }

--- a/execution/types/tx_registry_test.go
+++ b/execution/types/tx_registry_test.go
@@ -400,13 +400,20 @@ func TestUnregisteredReceiptTypeRejected(t *testing.T) {
 	require.NoError(t, err)
 	require.ErrorIs(t, rlp.DecodeBytes(enveloped, new(Receipt)), ErrTxTypeNotSupported)
 
-	require.Panics(t, func() {
-		Receipts{{Type: unknownType}}.EncodeIndex(0, new(bytes.Buffer))
-	}, "encoding an unclaimed type must fail loudly, not derive a wrong root")
+	_, err = (&Receipt{Type: unknownType}).MarshalBinary()
+	require.ErrorIs(t, err, ErrTxTypeNotSupported)
 
-	// The panic above is only a programming-error guard because a stored
-	// receipt cannot carry an unclaimed type into it.
-	stored, err := rlp.EncodeToBytes(&ReceiptForStorage{Type: unknownType, Status: ReceiptStatusSuccessful})
+	// EncodeIndex runs under DeriveSha on the block path, so it contributes no
+	// leaf rather than panicking; the block is rejected on the root mismatch.
+	var derived bytes.Buffer
+	Receipts{{Type: unknownType}}.EncodeIndex(0, &derived)
+	require.Empty(t, derived.Bytes())
+
+	_, err = rlp.EncodeToBytes(&ReceiptForStorage{Type: unknownType, Status: ReceiptStatusSuccessful})
+	require.ErrorContains(t, err, "invalid receipt type")
+
+	// Bypass the encoder to stand in for bytes an older binary already wrote.
+	stored, err := rlp.EncodeToBytes(&storedReceiptRLP{Type: unknownType, PostStateOrStatus: []byte{1}})
 	require.NoError(t, err)
 	require.ErrorContains(t, rlp.DecodeBytes(stored, new(ReceiptForStorage)), "invalid receipt type")
 }
@@ -420,15 +427,22 @@ func TestRegisteredTxTypeWithoutStandardReceiptPayload(t *testing.T) {
 	t.Cleanup(func() { unregisterTxType(customReceiptType) })
 
 	r := &Receipt{Type: customReceiptType, Status: ReceiptStatusSuccessful, CumulativeGasUsed: 1}
-	binary, err := r.MarshalBinary()
-	require.NoError(t, err)
-	require.ErrorIs(t, new(Receipt).UnmarshalBinary(binary), ErrTxTypeNotSupported)
 
-	require.Panics(t, func() {
-		Receipts{r}.EncodeIndex(0, new(bytes.Buffer))
-	}, "a type that never claimed the standard payload must not get one")
+	// Both directions, or the encode side emits bytes this package's own
+	// decoder rejects.
+	_, err := r.MarshalBinary()
+	require.ErrorIs(t, err, ErrTxTypeNotSupported)
+	require.ErrorIs(t, r.EncodeRLP(new(bytes.Buffer)), ErrTxTypeNotSupported)
+	require.ErrorIs(t, r.EncodeRLP69(new(bytes.Buffer)), ErrTxTypeNotSupported)
 
-	stored, err := rlp.EncodeToBytes((*ReceiptForStorage)(r))
+	payload, err := rlp.EncodeToBytes(&receiptRLP{r.statusEncoding(), r.CumulativeGasUsed, r.Bloom, r.Logs})
 	require.NoError(t, err)
-	require.ErrorContains(t, rlp.DecodeBytes(stored, new(ReceiptForStorage)), "invalid receipt type")
+	require.ErrorIs(t, new(Receipt).UnmarshalBinary(append([]byte{customReceiptType}, payload...)), ErrTxTypeNotSupported)
+
+	var derived bytes.Buffer
+	Receipts{r}.EncodeIndex(0, &derived)
+	require.Empty(t, derived.Bytes(), "a type that never claimed the standard payload must not get one")
+
+	_, err = rlp.EncodeToBytes((*ReceiptForStorage)(r))
+	require.ErrorContains(t, err, "invalid receipt type")
 }


### PR DESCRIPTION
`RegisterTxType` (#22201) wired four dispatch sites and left three, all in `execution/types/receipt.go`. A registered type's receipts do not round-trip, and `Receipts.EncodeIndex` wrote zero bytes for an unclaimed id — a silently wrong receipts root. `AccountAbstractionTxType` hits the same gap.

The built-in typed receipts share one payload, which `encodeTyped` already writes, so the three switches become one predicate. EIP-2718 leaves `ReceiptPayload` type-specific, so a registered type opts in to that payload rather than inheriting it.

**Consensus-visible.** Type 5 (AA) now contributes a `0x05 || receiptRLP` leaf where it contributed none, so the receipts root of a block carrying an AA transaction changes. It is devnet-only behind `chain.Config.AllowAA`, and the previous root committed to nothing about those receipts.

## Changes

- `hasStandardReceiptPayload` in `tx_registry.go` — its own list, not `builtinTxType`, so a future built-in with type-specific receipt fields stays off it
- `TxTypeSpec.StandardReceiptPayload` gates registered types. Without it every receipt path refuses the id, so a type carrying extra consensus fields — OP's deposit receipts — cannot be given an encoding it never claimed
- Both directions: `MarshalBinary`, `EncodeRLP`, `EncodeRLP69` and both `ReceiptForStorage` halves, not only the decoders
- `EncodeIndex` writes nothing for such a type, as before. It runs under `DeriveSha` on the block path, so the failure has to be a root mismatch that rejects the block, not a panic a peer can reach
- Three places the two typed decoders disagreed: `decodePayload` dropped `setStatus`'s error, `DecodeRLP` accepted a bare type byte, and it set `Type` before the gate
- Round-trip, pinned-root, decoder-parity and rejection tests

Follow-up to #22201, part of #22193.
