### PR TITLE
execution/protocol/aa: map RIP-7560 executionStatus onto the EIP-658 receipt status

### DIFF
--- a/execution/protocol/aa/aa_exec.go
+++ b/execution/protocol/aa/aa_exec.go
@@ -326,9 +326,14 @@ func ExecuteAATransaction(
 	return executionStatus, gasUsed, nil
 }
 
-func CreateAAReceipt(txnHash common.Hash, status, gasUsed, cumGasUsed, blockNum, txnIndex uint64, logs types.Logs) *types.Receipt {
+func CreateAAReceipt(txnHash common.Hash, executionStatus, gasUsed, cumGasUsed, blockNum, txnIndex uint64, logs types.Logs) *types.Receipt {
 	receipt := &types.Receipt{Type: types.AccountAbstractionTxType, CumulativeGasUsed: cumGasUsed}
-	receipt.Status = status
+	// executionStatus is RIP-7560's four-value frame outcome, not EIP-658: its
+	// zero means success, where the receipt field's zero means failure.
+	receipt.Status = types.ReceiptStatusFailed
+	if executionStatus == types.ExecutionStatusSuccess {
+		receipt.Status = types.ReceiptStatusSuccessful
+	}
 	receipt.TxHash = txnHash
 	receipt.GasUsed = gasUsed
 	// Set the receipt logs and create a bloom for filtering

--- a/execution/protocol/aa/aa_exec_test.go
+++ b/execution/protocol/aa/aa_exec_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package aa
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/types"
+)
+
+func TestCreateAAReceiptStatus(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name            string
+		executionStatus uint64
+		want            uint64
+	}{
+		{"success", types.ExecutionStatusSuccess, types.ReceiptStatusSuccessful},
+		{"execution failure", types.ExecutionStatusExecutionFailure, types.ReceiptStatusFailed},
+		{"postOp failure", types.ExecutionStatusPostOpFailure, types.ReceiptStatusFailed},
+		{"execution and postOp failure", types.ExecutionStatusExecutionAndPostOpFailure, types.ReceiptStatusFailed},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := CreateAAReceipt(common.Hash{0x11}, tc.executionStatus, 21000, 21000, 1, 0, nil)
+			require.Equal(t, tc.want, r.Status)
+		})
+	}
+}


### PR DESCRIPTION
`CreateAAReceipt` stored RIP-7560's `executionStatus` in the receipt's EIP-658 `status`. The two are numbered oppositely — `ExecutionStatusSuccess` is 0, `ReceiptStatusFailed` is 0 — so every AA receipt carried an inverted status.

| executionStatus | should be | was |
|---|---|---|
| 0 success | 1 successful | 0 failed |
| 1, 2, 3 reverted | 0 failed | 1 successful |

All three non-deprecated RIP-7560 branches of `eth-infinitism/go-ethereum` keep `receiptStatus` and `executionStatus` as separate locals and assign only the former to the receipt. Erigon's port kept one of the two.

## Changes

- `CreateAAReceipt` maps `ExecutionStatusSuccess` to `ReceiptStatusSuccessful`, every other value to `ReceiptStatusFailed`; the parameter is renamed `executionStatus`
- Test over all four execution statuses

Not visible in the receipts root until #23565, which gives type 5 an encoding.
