### PR TITLE
[r3.6] docs(site): forward-port the bor reference fix and the docs deps

### DIFF
--- a/docs/site/docs/interacting-with-erigon/bor.md
+++ b/docs/site/docs/interacting-with-erigon/bor.md
@@ -6,6 +6,10 @@ sidebar_position: 10
 
 # bor
 
+:::note
+The final Erigon release series that officially supports Polygon is 3.1.\*. The `bor` namespace is still wired and `--chain=bor-mainnet` remains selectable, so this reference is kept for those releases — but see [Supported Networks](/fundamentals/supported-networks) before planning a new Polygon deployment.
+:::
+
 The `bor` namespace provides Polygon-specific RPC methods that are only available when running Erigon on Polygon networks (Mainnet, Amoy testnet, etc.). These methods expose functionality specific to the Bor consensus engine, including validator information, snapshots, and proposer sequences.
 
 The bor namespace must be explicitly enabled using the `--http.api` flag when starting the RPC Daemon and is only functional when running on Polygon networks with the Bor consensus engine.
@@ -232,15 +236,15 @@ Returns the root hash for a range of blocks, used for checkpoint verification an
 
 **Parameters**
 
-| Parameter | Type     | Description           |
-| --------- | -------- | --------------------- |
-| start     | QUANTITY | Starting block number |
-| end       | QUANTITY | Ending block number   |
+| Parameter | Type   | Description                                      |
+| --------- | ------ | ------------------------------------------------ |
+| start     | NUMBER | Starting block number, as a plain decimal number |
+| end       | NUMBER | Ending block number, as a plain decimal number   |
 
 **Example**
 
 ```bash
-curl -s --data '{"jsonrpc":"2.0","method":"bor_getRootHash","params":["0x1", "0x100"],"id":"1"}' -H "Content-Type: application/json" -X POST http://localhost:8545
+curl -s --data '{"jsonrpc":"2.0","method":"bor_getRootHash","params":[1, 256],"id":"1"}' -H "Content-Type: application/json" -X POST http://localhost:8545
 ```
 
 
@@ -254,23 +258,30 @@ curl -s --data '{"jsonrpc":"2.0","method":"bor_getRootHash","params":["0x1", "0x
 
 ## **bor\_getVoteOnHash**
 
-Returns voting information for a specific block hash, used in the Bor consensus mechanism.
+Votes on a milestone hash: reports whether the local chain has the given hash at `endBlockNr`. All four parameters are required, and `startBlockNr` and `milestoneId` are ignored by the implementation. The implementation reads block `endBlockNr + 16`, the 16-block confirmation of `endBlockNr`, but does not require it to exist.
 
 **Parameters**
 
-| Parameter | Type           | Description                                     |
-| --------- | -------------- | ----------------------------------------------- |
-| hash      | DATA, 32 BYTES | Hash of the block to get voting information for |
+| Parameter    | Type   | Description                                                            |
+| ------------ | ------ | ---------------------------------------------------------------------- |
+| startBlockNr | NUMBER | First block of the milestone range, as a plain decimal number; ignored |
+| endBlockNr   | NUMBER | Last block of the milestone range, as a plain decimal number           |
+| hash         | STRING | Milestone hash, compared as an exact lowercase `0x`-prefixed string    |
+| milestoneId  | STRING | Heimdall milestone identifier; ignored                                 |
 
 **Example**
 
 ```bash
-curl -s --data '{"jsonrpc":"2.0","method":"bor_getVoteOnHash","params":["0x1d59ff54b1eb26b013ce3cb5fc9dab3705b415a67127a003c3e61eb445bb8df2"],"id":"1"}' -H "Content-Type: application/json" -X POST http://localhost:8545
+curl -s --data '{"jsonrpc":"2.0","method":"bor_getVoteOnHash","params":[16000000, 16000064, "0x811b9d739a17d5c42904ba97bb9e3449da74000fece0e1ec112f61a11beb7632", "0x1"],"id":"1"}' -H "Content-Type: application/json" -X POST http://localhost:8545
 ```
 
 
 **Returns**
 
-| Type   | Description                                            |
-| ------ | ------------------------------------------------------ |
-| Object | Voting information object for the specified block hash |
+| Type    | Description                                                               |
+| ------- | ------------------------------------------------------------------------- |
+| BOOLEAN | `true` if the local hash of `endBlockNr` equals `hash`, `false` otherwise |
+
+A hash that matches except for letter case returns `false` rather than an error.
+If the node does not have block `endBlockNr`, the call fails with
+`method handler crashed` instead of returning a boolean.

--- a/docs/site/package-lock.json
+++ b/docs/site/package-lock.json
@@ -12,18 +12,18 @@
         "@docusaurus/plugin-client-redirects": "3.10.2",
         "@docusaurus/preset-classic": "3.10.2",
         "@docusaurus/theme-mermaid": "3.10.2",
-        "@easyops-cn/docusaurus-search-local": "^0.55.2",
+        "@easyops-cn/docusaurus-search-local": "^0.55.3",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "prism-react-renderer": "^2.3.0",
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7"
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "3.10.2",
         "@docusaurus/tsconfig": "3.10.2",
         "@docusaurus/types": "3.10.2",
-        "@types/react": "^19.2.17",
+        "@types/react": "^19.2.18",
         "typescript": "6.0.3"
       },
       "engines": {
@@ -4214,9 +4214,9 @@
       }
     },
     "node_modules/@easyops-cn/docusaurus-search-local": {
-      "version": "0.55.2",
-      "resolved": "https://registry.npmjs.org/@easyops-cn/docusaurus-search-local/-/docusaurus-search-local-0.55.2.tgz",
-      "integrity": "sha512-dI/riu+MbDxkAjAHAdc0uahjXRaWKvbIPe9IAmA6AGcUfnVb9xd8s2I/6wEPTOXsAd6eFqn4Yis3WBWh3KUd3g==",
+      "version": "0.55.3",
+      "resolved": "https://registry.npmjs.org/@easyops-cn/docusaurus-search-local/-/docusaurus-search-local-0.55.3.tgz",
+      "integrity": "sha512-PlMKmxuonvZ1C+/zJS1hJaF1xaxD1TsUvOMzpP6DdQMtZqmTaYjcLGM12ePzl0m1rp3AgfTBeDbFNHQhwnH/dA==",
       "license": "MIT",
       "dependencies": {
         "@docusaurus/plugin-content-docs": "^2 || ^3",
@@ -4939,12 +4939,12 @@
       }
     },
     "node_modules/@mermaid-js/parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
-      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
       "license": "MIT",
       "dependencies": {
-        "@chevrotain/types": "~11.1.1"
+        "@chevrotain/types": "~11.1.2"
       }
     },
     "node_modules/@noble/hashes": {
@@ -6275,9 +6275,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -7170,9 +7170,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -9339,9 +9339,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -10010,9 +10010,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -11682,9 +11682,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -12537,26 +12537,26 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.15.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
-      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+      "version": "11.16.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.1.tgz",
+      "integrity": "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==",
       "license": "MIT",
       "dependencies": {
-        "@braintree/sanitize-url": "^7.1.1",
+        "@braintree/sanitize-url": "^7.1.2",
         "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.1.1",
+        "@mermaid-js/parser": "^1.2.0",
         "@types/d3": "^7.4.3",
         "@upsetjs/venn.js": "^2.0.0",
-        "cytoscape": "^3.33.1",
+        "cytoscape": "^3.33.3",
         "cytoscape-cose-bilkent": "^4.1.0",
         "cytoscape-fcose": "^2.2.0",
         "d3": "^7.9.0",
         "d3-sankey": "^0.12.3",
         "dagre-d3-es": "7.0.14",
-        "dayjs": "^1.11.19",
-        "dompurify": "^3.3.1",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
         "es-toolkit": "^1.45.1",
-        "katex": "^0.16.25",
+        "katex": "^0.16.45",
         "khroma": "^2.1.0",
         "marked": "^16.3.0",
         "roughjs": "^4.6.6",
@@ -14514,9 +14514,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -16934,24 +16934,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-fast-compare": {
@@ -18914,9 +18914,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -21,18 +21,18 @@
     "@docusaurus/plugin-client-redirects": "3.10.2",
     "@docusaurus/preset-classic": "3.10.2",
     "@docusaurus/theme-mermaid": "3.10.2",
-    "@easyops-cn/docusaurus-search-local": "^0.55.2",
+    "@easyops-cn/docusaurus-search-local": "^0.55.3",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
-    "react": "^19.2.7",
-    "react-dom": "^19.2.7"
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.10.2",
     "@docusaurus/tsconfig": "3.10.2",
     "@docusaurus/types": "3.10.2",
-    "@types/react": "^19.2.17",
+    "@types/react": "^19.2.18",
     "typescript": "6.0.3"
   },
   "browserslist": {
@@ -54,10 +54,11 @@
     "webpack": "5.105.0",
     "@babel/plugin-transform-modules-systemjs": "^7.29.4",
     "@babel/core": "^7.29.6",
-    "fast-uri": "^3.1.4",
+    "fast-uri": "^3.1.5",
     "http-proxy-middleware": "^2.0.10",
     "joi": "^17.13.4",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.0",
+    "brace-expansion": "^1.1.17",
     "gray-matter": {
       "js-yaml": "3.14.2"
     },

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -6863,6 +6863,10 @@ curl -s --data '{"jsonrpc":"2.0","method":"admin_removeTrustedPeer","params":["e
 URL: https://docs.erigon.tech/interacting-with-erigon/bor
 
 
+:::note
+The final Erigon release series that officially supports Polygon is 3.1.\*. The `bor` namespace is still wired and `--chain=bor-mainnet` remains selectable, so this reference is kept for those releases — but see [Supported Networks](/fundamentals/supported-networks) before planning a new Polygon deployment.
+:::
+
 The `bor` namespace provides Polygon-specific RPC methods that are only available when running Erigon on Polygon networks (Mainnet, Amoy testnet, etc.). These methods expose functionality specific to the Bor consensus engine, including validator information, snapshots, and proposer sequences.
 
 The bor namespace must be explicitly enabled using the `--http.api` flag when starting the RPC Daemon and is only functional when running on Polygon networks with the Bor consensus engine.
@@ -7081,15 +7085,15 @@ Returns the root hash for a range of blocks, used for checkpoint verification an
 
 **Parameters**
 
-| Parameter | Type     | Description           |
-| --------- | -------- | --------------------- |
-| start     | QUANTITY | Starting block number |
-| end       | QUANTITY | Ending block number   |
+| Parameter | Type   | Description                                      |
+| --------- | ------ | ------------------------------------------------ |
+| start     | NUMBER | Starting block number, as a plain decimal number |
+| end       | NUMBER | Ending block number, as a plain decimal number   |
 
 **Example**
 
 ```bash
-curl -s --data '{"jsonrpc":"2.0","method":"bor_getRootHash","params":["0x1", "0x100"],"id":"1"}' -H "Content-Type: application/json" -X POST http://localhost:8545
+curl -s --data '{"jsonrpc":"2.0","method":"bor_getRootHash","params":[1, 256],"id":"1"}' -H "Content-Type: application/json" -X POST http://localhost:8545
 ```
 
 **Returns**
@@ -7102,25 +7106,32 @@ curl -s --data '{"jsonrpc":"2.0","method":"bor_getRootHash","params":["0x1", "0x
 
 ## **bor\_getVoteOnHash**
 
-Returns voting information for a specific block hash, used in the Bor consensus mechanism.
+Votes on a milestone hash: reports whether the local chain has the given hash at `endBlockNr`. All four parameters are required, and `startBlockNr` and `milestoneId` are ignored by the implementation. The implementation reads block `endBlockNr + 16`, the 16-block confirmation of `endBlockNr`, but does not require it to exist.
 
 **Parameters**
 
-| Parameter | Type           | Description                                     |
-| --------- | -------------- | ----------------------------------------------- |
-| hash      | DATA, 32 BYTES | Hash of the block to get voting information for |
+| Parameter    | Type   | Description                                                            |
+| ------------ | ------ | ---------------------------------------------------------------------- |
+| startBlockNr | NUMBER | First block of the milestone range, as a plain decimal number; ignored |
+| endBlockNr   | NUMBER | Last block of the milestone range, as a plain decimal number           |
+| hash         | STRING | Milestone hash, compared as an exact lowercase `0x`-prefixed string    |
+| milestoneId  | STRING | Heimdall milestone identifier; ignored                                 |
 
 **Example**
 
 ```bash
-curl -s --data '{"jsonrpc":"2.0","method":"bor_getVoteOnHash","params":["0x1d59ff54b1eb26b013ce3cb5fc9dab3705b415a67127a003c3e61eb445bb8df2"],"id":"1"}' -H "Content-Type: application/json" -X POST http://localhost:8545
+curl -s --data '{"jsonrpc":"2.0","method":"bor_getVoteOnHash","params":[16000000, 16000064, "0x811b9d739a17d5c42904ba97bb9e3449da74000fece0e1ec112f61a11beb7632", "0x1"],"id":"1"}' -H "Content-Type: application/json" -X POST http://localhost:8545
 ```
 
 **Returns**
 
-| Type   | Description                                            |
-| ------ | ------------------------------------------------------ |
-| Object | Voting information object for the specified block hash |
+| Type    | Description                                                               |
+| ------- | ------------------------------------------------------------------------- |
+| BOOLEAN | `true` if the local hash of `endBlockNr` equals `hash`, `false` otherwise |
+
+A hash that matches except for letter case returns `false` rather than an error.
+If the node does not have block `endBlockNr`, the call fails with
+`method handler crashed` instead of returning a boolean.
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6863,6 +6863,10 @@ curl -s --data '{"jsonrpc":"2.0","method":"admin_removeTrustedPeer","params":["e
 URL: https://docs.erigon.tech/interacting-with-erigon/bor
 
 
+:::note
+The final Erigon release series that officially supports Polygon is 3.1.\*. The `bor` namespace is still wired and `--chain=bor-mainnet` remains selectable, so this reference is kept for those releases — but see [Supported Networks](/fundamentals/supported-networks) before planning a new Polygon deployment.
+:::
+
 The `bor` namespace provides Polygon-specific RPC methods that are only available when running Erigon on Polygon networks (Mainnet, Amoy testnet, etc.). These methods expose functionality specific to the Bor consensus engine, including validator information, snapshots, and proposer sequences.
 
 The bor namespace must be explicitly enabled using the `--http.api` flag when starting the RPC Daemon and is only functional when running on Polygon networks with the Bor consensus engine.
@@ -7081,15 +7085,15 @@ Returns the root hash for a range of blocks, used for checkpoint verification an
 
 **Parameters**
 
-| Parameter | Type     | Description           |
-| --------- | -------- | --------------------- |
-| start     | QUANTITY | Starting block number |
-| end       | QUANTITY | Ending block number   |
+| Parameter | Type   | Description                                      |
+| --------- | ------ | ------------------------------------------------ |
+| start     | NUMBER | Starting block number, as a plain decimal number |
+| end       | NUMBER | Ending block number, as a plain decimal number   |
 
 **Example**
 
 ```bash
-curl -s --data '{"jsonrpc":"2.0","method":"bor_getRootHash","params":["0x1", "0x100"],"id":"1"}' -H "Content-Type: application/json" -X POST http://localhost:8545
+curl -s --data '{"jsonrpc":"2.0","method":"bor_getRootHash","params":[1, 256],"id":"1"}' -H "Content-Type: application/json" -X POST http://localhost:8545
 ```
 
 **Returns**
@@ -7102,25 +7106,32 @@ curl -s --data '{"jsonrpc":"2.0","method":"bor_getRootHash","params":["0x1", "0x
 
 ## **bor\_getVoteOnHash**
 
-Returns voting information for a specific block hash, used in the Bor consensus mechanism.
+Votes on a milestone hash: reports whether the local chain has the given hash at `endBlockNr`. All four parameters are required, and `startBlockNr` and `milestoneId` are ignored by the implementation. The implementation reads block `endBlockNr + 16`, the 16-block confirmation of `endBlockNr`, but does not require it to exist.
 
 **Parameters**
 
-| Parameter | Type           | Description                                     |
-| --------- | -------------- | ----------------------------------------------- |
-| hash      | DATA, 32 BYTES | Hash of the block to get voting information for |
+| Parameter    | Type   | Description                                                            |
+| ------------ | ------ | ---------------------------------------------------------------------- |
+| startBlockNr | NUMBER | First block of the milestone range, as a plain decimal number; ignored |
+| endBlockNr   | NUMBER | Last block of the milestone range, as a plain decimal number           |
+| hash         | STRING | Milestone hash, compared as an exact lowercase `0x`-prefixed string    |
+| milestoneId  | STRING | Heimdall milestone identifier; ignored                                 |
 
 **Example**
 
 ```bash
-curl -s --data '{"jsonrpc":"2.0","method":"bor_getVoteOnHash","params":["0x1d59ff54b1eb26b013ce3cb5fc9dab3705b415a67127a003c3e61eb445bb8df2"],"id":"1"}' -H "Content-Type: application/json" -X POST http://localhost:8545
+curl -s --data '{"jsonrpc":"2.0","method":"bor_getVoteOnHash","params":[16000000, 16000064, "0x811b9d739a17d5c42904ba97bb9e3449da74000fece0e1ec112f61a11beb7632", "0x1"],"id":"1"}' -H "Content-Type: application/json" -X POST http://localhost:8545
 ```
 
 **Returns**
 
-| Type   | Description                                            |
-| ------ | ------------------------------------------------------ |
-| Object | Voting information object for the specified block hash |
+| Type    | Description                                                               |
+| ------- | ------------------------------------------------------------------------- |
+| BOOLEAN | `true` if the local hash of `endBlockNr` equals `hash`, `false` otherwise |
+
+A hash that matches except for letter case returns `false` rather than an error.
+If the node does not have block `endBlockNr`, the call fails with
+`method handler crashed` instead of returning a boolean.
 
 ---
 


### PR DESCRIPTION
Two fixes reached `main` — and the bor one also `release/3.5` — but never got forward-ported here. This branch now publishes docs.erigon.tech, so the bor reference is live and wrong.

## bor reference

`bor_getRootHash` and `bor_getVoteOnHash` take plain `uint64`, not `rpc.BlockNumber`, so their block arguments are decimal numbers rather than hex QUANTITY — the example was calling them with `"0x1"`. Everything in the fix was re-checked against `rpc/jsonrpc/bor_api_impl.go` on this branch rather than taken from main's copy:

- `startBlockNr` and `milestoneId` are read by neither implementation.
- The `endBlockNr + 16` confirmation block is looked up but not required to exist, because `BlockByNumber` returns `nil, nil` for an absent block.
- That same `nil, nil` is why a missing `endBlockNr` panics into `method handler crashed` instead of returning a boolean.
- The four remaining `QUANTITY|TAG` parameters are correct and untouched — `getSnapshot`, `getSigners`, `getAuthor` and `getSnapshotProposer` really do take `rpc.BlockNumber`/`BlockNumberOrHash`.

The Polygon support-window note matches what `supported-networks` already says on this branch.

## docs/site dependencies

`react`/`react-dom` 19.2.7 → 19.2.8, `@easyops-cn/docusaurus-search-local` 0.55.2 → 0.55.3, `@types/react`, `fast-uri` 3.1.4 → 3.1.5, `js-yaml` 4.2.0 → 4.3.0, plus the `brace-expansion` override this branch was missing. Pure version bumps.

## Not carried over, deliberately

Polygon stays documented here: this branch still ships the `polygon/` tree, so the removal on main is 3.7 work. Same for the v3.7 HTTPS/IPC transports, the GraphQL pending-call note (`pending state is not supported` doesn't exist on this branch) and the wit0 removal. The tsconfig `baseUrl` fix, the drift-guard comment and the portable test script are already here under different cherry-pick SHAs — they only looked missing in a commit-level diff.

The help center's `16KB` page size is also correct here and stays: this branch sets `DefaultChainDBPageSize = 16 * datasize.KB` and uses it as the `--db.pagesize` default. main reads `4KB` because it changed that constant. Worth a separate look: this branch's `--db.pagesize` usage string still claims the default equals the OS page size, which it doesn't.

## Verified

`npm test` 8/8, `generate-llms.py --check` OK at 73 pages, full `docusaurus build` SUCCESS, and the built pages carry the corrected bor tables.
