### PR TITLE
rpc: answer with result:null when a streamed method writes nothing

### DIFF
--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -662,6 +662,10 @@ func (h *handler) runMethod(ctx context.Context, msg *jsonrpcMessage, callb *cal
 			stream.WriteMore()
 		}
 		HandleError(err, stream)
+	} else if !rs.Written() {
+		// A response carries exactly one of result and error, so a callback that
+		// succeeded without writing still owes a result.
+		rs.WriteNil()
 	}
 	stream.WriteObjectEnd()
 	return nil

--- a/rpc/handler_test.go
+++ b/rpc/handler_test.go
@@ -59,6 +59,12 @@ func TestHandlerDoesNotDoubleWriteNull(t *testing.T) {
 			params:   []byte("[6]"),
 			expected: `{"jsonrpc":"2.0","id":1,"result":{"structLogs":[]},"error":{"code":-32000,"message":"id 6"}}`,
 		},
+		// JSON-RPC wants exactly one of result and error, so a callback that
+		// succeeds without writing still owes a result.
+		"no_error_no_stream_write": {
+			params:   []byte("[7]"),
+			expected: `{"jsonrpc":"2.0","id":1,"result":null}`,
+		},
 	}
 
 	for name, testParams := range tests {


### PR DESCRIPTION
A streamable callback that returns nil without writing produces a response carrying neither `result` nor `error`:

```
{"jsonrpc":"2.0","id":1,}
```

That is not a JSON-RPC response, and it is not even valid JSON. `runMethod` now writes `result:null` for that case.

No method reaches it today — every early return in the seven streamable methods returns an error, and `filterV3` covers its no-match case with `WriteEmptyArray()` — but nothing held the invariant. Found while reviewing `LazyFieldStream` for #23504.
