### PR TITLE
cl: validate Fulu cell proof widths

### DIFF
--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -1205,6 +1205,12 @@ func (a *ApiHandler) produceBeaconBody(
 				executionErr = errors.New("produceBeaconBody: invalid peerdas bundle")
 				return
 			}
+			for _, proof := range bundles.Proofs {
+				if len(proof) != length.Bytes48 {
+					executionErr = errors.New("produceBeaconBody: invalid proof length")
+					return
+				}
+			}
 		}
 
 		for i := range bundles.Blobs {

--- a/cl/beacon/handler/block_production_test.go
+++ b/cl/beacon/handler/block_production_test.go
@@ -547,18 +547,27 @@ func TestSetupHeaderResponseForBlockProductionPreGloasOmitsPayloadIncluded(t *te
 }
 
 func TestProduceBeaconBodyRejectsInvalidFuluCellProofLength(t *testing.T) {
-	for _, proofLength := range []int{length.Bytes48 - 1, length.Bytes48 + 1} {
-		t.Run(fmt.Sprintf("proof length %d", proofLength), func(t *testing.T) {
-			body, err := produceFuluBodyWithProofLength(t, proofLength)
+	proofIndexes := []struct {
+		name  string
+		index int
+	}{
+		{name: "first", index: 0},
+		{name: "last", index: int(clparams.MainnetBeaconConfig.NumberOfColumns) - 1},
+	}
+	for _, proofIndex := range proofIndexes {
+		for _, proofLength := range []int{length.Bytes48 - 1, length.Bytes48 + 1} {
+			t.Run(fmt.Sprintf("%s proof length %d", proofIndex.name, proofLength), func(t *testing.T) {
+				body, err := produceFuluBodyWithProofLength(t, proofIndex.index, proofLength)
 
-			require.Nil(t, body)
-			require.ErrorContains(t, err, "invalid proof length")
-		})
+				require.Nil(t, body)
+				require.ErrorContains(t, err, "invalid proof length")
+			})
+		}
 	}
 }
 
 func TestProduceBeaconBodyAcceptsExactFuluCellProofLength(t *testing.T) {
-	body, err := produceFuluBodyWithProofLength(t, length.Bytes48)
+	body, err := produceFuluBodyWithProofLength(t, 0, length.Bytes48)
 
 	require.NoError(t, err)
 	require.NotNil(t, body)
@@ -577,13 +586,13 @@ func TestProduceBeaconBodyPreservesPreFuluValidationOrder(t *testing.T) {
 	require.ErrorContains(t, err, "invalid commitment length")
 }
 
-func produceFuluBodyWithProofLength(t *testing.T, proofLength int) (*cltypes.BeaconBody, error) {
+func produceFuluBodyWithProofLength(t *testing.T, proofIndex, proofLength int) (*cltypes.BeaconBody, error) {
 	t.Helper()
 	proofs := make([]hexutil.Bytes, clparams.MainnetBeaconConfig.NumberOfColumns)
 	for i := range proofs {
 		proofs[i] = make([]byte, length.Bytes48)
 	}
-	proofs[0] = make([]byte, proofLength)
+	proofs[proofIndex] = make([]byte, proofLength)
 	bundle := &engine_types.BlobsBundle{
 		Blobs:       []hexutil.Bytes{make([]byte, cltypes.BYTES_PER_BLOB)},
 		Commitments: []hexutil.Bytes{make([]byte, length.Bytes48)},

--- a/cl/beacon/handler/block_production_test.go
+++ b/cl/beacon/handler/block_production_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/erigontech/erigon/cl/validator/validator_params"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/common/length"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/engineapi/engine_helpers"
@@ -543,6 +544,81 @@ func TestSetupHeaderResponseForBlockProductionPreGloasOmitsPayloadIncluded(t *te
 	h.setupHeaderReponseForBlockProduction(rr, clparams.ElectraVersion, false, true, 123, 456)
 
 	require.Empty(t, rr.Header().Get("Eth-Execution-Payload-Included"))
+}
+
+func TestProduceBeaconBodyRejectsInvalidFuluCellProofLength(t *testing.T) {
+	for _, proofLength := range []int{length.Bytes48 - 1, length.Bytes48 + 1} {
+		t.Run(fmt.Sprintf("proof length %d", proofLength), func(t *testing.T) {
+			body, err := produceFuluBodyWithProofLength(t, proofLength)
+
+			require.Nil(t, body)
+			require.ErrorContains(t, err, "invalid proof length")
+		})
+	}
+}
+
+func TestProduceBeaconBodyAcceptsExactFuluCellProofLength(t *testing.T) {
+	body, err := produceFuluBodyWithProofLength(t, length.Bytes48)
+
+	require.NoError(t, err)
+	require.NotNil(t, body)
+}
+
+func TestProduceBeaconBodyPreservesPreFuluValidationOrder(t *testing.T) {
+	bundle := &engine_types.BlobsBundle{
+		Blobs:       []hexutil.Bytes{make([]byte, cltypes.BYTES_PER_BLOB)},
+		Commitments: []hexutil.Bytes{make([]byte, length.Bytes48-1)},
+		Proofs:      []hexutil.Bytes{make([]byte, length.Bytes48-1)},
+	}
+
+	body, err := produceBodyWithBundle(t, clparams.ElectraVersion, bundle)
+
+	require.Nil(t, body)
+	require.ErrorContains(t, err, "invalid commitment length")
+}
+
+func produceFuluBodyWithProofLength(t *testing.T, proofLength int) (*cltypes.BeaconBody, error) {
+	t.Helper()
+	proofs := make([]hexutil.Bytes, clparams.MainnetBeaconConfig.NumberOfColumns)
+	for i := range proofs {
+		proofs[i] = make([]byte, length.Bytes48)
+	}
+	proofs[0] = make([]byte, proofLength)
+	bundle := &engine_types.BlobsBundle{
+		Blobs:       []hexutil.Bytes{make([]byte, cltypes.BYTES_PER_BLOB)},
+		Commitments: []hexutil.Bytes{make([]byte, length.Bytes48)},
+		Proofs:      proofs,
+	}
+	return produceBodyWithBundle(t, clparams.FuluVersion, bundle)
+}
+
+func produceBodyWithBundle(t *testing.T, version clparams.StateVersion, bundle *engine_types.BlobsBundle) (*cltypes.BeaconBody, error) {
+	t.Helper()
+	_, blocks, _, _, postState, h, _, _, _, _ := setupTestingHandler(t, clparams.ElectraVersion, log.Root(), true)
+	if version.AfterOrEqual(clparams.FuluVersion) {
+		h.beaconChainCfg.FuluForkEpoch = 1
+		h.beaconChainCfg.InitializeForkSchedule()
+	}
+
+	payload := cltypes.NewEth1Block(version, h.beaconChainCfg)
+	payload.Extra = solid.NewExtraData()
+	payload.Transactions = solid.NewTransactionsSSZFromTransactions(nil)
+	payload.Withdrawals = solid.NewStaticListSSZ[*cltypes.Withdrawal](int(h.beaconChainCfg.MaxWithdrawalsPerPayload), 44)
+
+	engine := execution_client.NewMockExecutionEngine(gomock.NewController(t))
+	engine.EXPECT().ForkChoiceUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]byte{1}, nil)
+	engine.EXPECT().GetAssembledBlock(gomock.Any(), []byte{1}, version).Return(payload, bundle, nil, nil, nil)
+	h.engine = engine
+
+	baseBlock := blocks[len(blocks)-1].Block
+	baseBlockRoot, err := baseBlock.HashSSZ()
+	require.NoError(t, err)
+
+	body, _, err := h.produceBeaconBody(
+		t.Context(), 3, baseBlock.Slot, baseBlockRoot, postState, baseBlock.Slot+1,
+		common.Bytes96{0xc0}, common.Hash{},
+	)
+	return body, err
 }
 
 // TestCaplinBlockProductionWithWithdrawalRequest tests Caplin's produceBeaconBody

--- a/cl/beacon/handler/block_production_test.go
+++ b/cl/beacon/handler/block_production_test.go
@@ -552,7 +552,7 @@ func TestProduceBeaconBodyRejectsInvalidFuluCellProofLength(t *testing.T) {
 		index int
 	}{
 		{name: "first", index: 0},
-		{name: "last", index: int(clparams.MainnetBeaconConfig.NumberOfColumns) - 1},
+		{name: "last", index: 2*int(clparams.MainnetBeaconConfig.NumberOfColumns) - 1},
 	}
 	for _, proofIndex := range proofIndexes {
 		for _, proofLength := range []int{length.Bytes48 - 1, length.Bytes48 + 1} {
@@ -588,15 +588,21 @@ func TestProduceBeaconBodyPreservesPreFuluValidationOrder(t *testing.T) {
 
 func produceFuluBodyWithProofLength(t *testing.T, proofIndex, proofLength int) (*cltypes.BeaconBody, error) {
 	t.Helper()
-	proofs := make([]hexutil.Bytes, clparams.MainnetBeaconConfig.NumberOfColumns)
+	proofs := make([]hexutil.Bytes, 2*int(clparams.MainnetBeaconConfig.NumberOfColumns))
 	for i := range proofs {
 		proofs[i] = make([]byte, length.Bytes48)
 	}
 	proofs[proofIndex] = make([]byte, proofLength)
 	bundle := &engine_types.BlobsBundle{
-		Blobs:       []hexutil.Bytes{make([]byte, cltypes.BYTES_PER_BLOB)},
-		Commitments: []hexutil.Bytes{make([]byte, length.Bytes48)},
-		Proofs:      proofs,
+		Blobs: []hexutil.Bytes{
+			make([]byte, cltypes.BYTES_PER_BLOB),
+			make([]byte, cltypes.BYTES_PER_BLOB),
+		},
+		Commitments: []hexutil.Bytes{
+			make([]byte, length.Bytes48),
+			make([]byte, length.Bytes48),
+		},
+		Proofs: proofs,
 	}
 	return produceBodyWithBundle(t, clparams.FuluVersion, bundle)
 }


### PR DESCRIPTION
## Summary

- reject Fulu and later `BlobsBundleV2` responses when any cell proof is not exactly 48 bytes
- validate all proof widths before fixed-array conversion or blob cache/body mutation
- preserve the existing pre-Fulu validation order

## Why

The Osaka Engine API defines each `BlobsBundleV2.proofs` element as a 48-byte `KZGProof`. Block production previously checked only proof cardinality for Fulu and later. A short proof could therefore panic during `[]byte` to `common.Bytes48` conversion, while an overlong proof could be silently truncated.

## Tests

- TDD repro: 47-byte proof panicked before the fix; 49-byte proof escaped validation
- focused 47/48/49-byte and pre-Fulu ordering tests
- `go test ./cl/beacon/handler -count=1`
- focused `go test -race`
- `make lint` (twice, isolated cache)
- `make erigon integration`

This is the first of the follow-up hardening changes found while reviewing #23299. Broader Engine response and KZG semantic validation remain separate PRs.
