### PR TITLE
cmd/integration: let the exec commands select the parallel commitment trie

### DIFF
--- a/cmd/integration/commands/dump_state_test.go
+++ b/cmd/integration/commands/dump_state_test.go
@@ -33,8 +33,10 @@ import (
 
 	"github.com/holiman/uint256"
 	"github.com/klauspost/compress/zstd"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/cmd/utils"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
@@ -43,6 +45,7 @@ import (
 	"github.com/erigontech/erigon/db/kv/temporal/temporaltest"
 	"github.com/erigontech/erigon/db/state/execctx"
 	"github.com/erigontech/erigon/db/state/execctx/execctxapi"
+	"github.com/erigontech/erigon/db/state/statecfg"
 	chainpkg "github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/stagedsync/stages"
 	"github.com/erigontech/erigon/execution/state"
@@ -620,4 +623,40 @@ func TestDumpStateToTSV_MinBalanceFilter(t *testing.T) {
 	require.Contains(t, buf.String(), "0x0000000000000000000000000000000000000001")
 	require.NotContains(t, buf.String(), "0x0000000000000000000000000000000000000002")
 	require.NotContains(t, buf.String(), "0x0000000000000000000000000000000000000003")
+}
+
+// TestExecCommandsExposeParallelCommitment pins the flag on every integration
+// command that computes commitment. Without it the flag is unknown on stage_exec,
+// so integration can only ever run the sequential trie.
+func TestExecCommandsExposeParallelCommitment(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cmd  *cobra.Command
+	}{
+		{name: "stage_exec", cmd: cmdStageExec},
+		{name: "state_stages", cmd: stateStages},
+		{name: "loop_exec", cmd: loopExecCmd},
+		{name: "commitment_rebuild", cmd: cmdCommitmentRebuild},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NotNil(t, tc.cmd.Flags().Lookup(utils.ExperimentalParallelCommitmentFlag.Name),
+				"command cannot select the parallel trie")
+		})
+	}
+}
+
+// TestWithExperimentalCommitmentFollowsErigonDefault pins integration's default to
+// erigon's own flag default, so flipping it in one place cannot leave the two
+// binaries computing commitment with different tries.
+func TestWithExperimentalCommitmentFollowsErigonDefault(t *testing.T) {
+	defer func(v bool) { utils.ExperimentalParallelCommitmentFlag.Value = v }(utils.ExperimentalParallelCommitmentFlag.Value)
+	defer func(v bool) { statecfg.ExperimentalParallelCommitment = v }(statecfg.ExperimentalParallelCommitment)
+
+	utils.ExperimentalParallelCommitmentFlag.Value = true
+	statecfg.ExperimentalParallelCommitment = false
+
+	withExperimentalCommitment(&cobra.Command{Use: "probe"})
+
+	require.True(t, statecfg.ExperimentalParallelCommitment,
+		"integration ignored erigon's default and would run the sequential trie")
 }

--- a/cmd/integration/commands/flags.go
+++ b/cmd/integration/commands/flags.go
@@ -168,8 +168,13 @@ func withDataDir(cmd *cobra.Command) {
 	must(cmd.MarkFlagDirname("chaindata"))
 }
 
+// withExperimentalCommitment binds the flag erigon uses to pick the commitment
+// trie. The default ORs erigon's own flag default with the env-derived value so
+// that flipping the default in one binary cannot leave the other on a different
+// trie.
 func withExperimentalCommitment(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&statecfg.ExperimentalParallelCommitment, utils.ExperimentalParallelCommitmentFlag.Name, statecfg.ExperimentalParallelCommitment, utils.ExperimentalParallelCommitmentFlag.Usage)
+	def := statecfg.ExperimentalParallelCommitment || utils.ExperimentalParallelCommitmentFlag.Value
+	cmd.Flags().BoolVar(&statecfg.ExperimentalParallelCommitment, utils.ExperimentalParallelCommitmentFlag.Name, def, utils.ExperimentalParallelCommitmentFlag.Usage)
 }
 
 func withBatchSize(cmd *cobra.Command) {

--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -316,6 +316,7 @@ func init() {
 	withTraceFlags(cmdStageExec)
 	withChainTipMode(cmdStageExec)
 	withErigondbDomainStepsInFrozenFile(cmdStageExec)
+	withExperimentalCommitment(cmdStageExec)
 	rootCmd.AddCommand(cmdStageExec)
 
 	withStageBase(cmdStageExecReplay)

--- a/cmd/integration/commands/state_stages.go
+++ b/cmd/integration/commands/state_stages.go
@@ -131,6 +131,7 @@ func init() {
 	withChain(stateStages)
 	withWorkers(stateStages)
 	withChaosMonkey(stateStages)
+	withExperimentalCommitment(stateStages)
 	rootCmd.AddCommand(stateStages)
 
 	withConfig(loopExecCmd)
@@ -140,6 +141,7 @@ func init() {
 	withChain(loopExecCmd)
 	withWorkers(loopExecCmd)
 	withChaosMonkey(loopExecCmd)
+	withExperimentalCommitment(loopExecCmd)
 	rootCmd.AddCommand(loopExecCmd)
 }
 


### PR DESCRIPTION
`stage_exec`, `state_stages` and `loop_exec` all compute commitment but never registered `--experimental.parallel-commitment`, so the flag was unknown there and only `ERIGON_COMMITMENT_PARALLEL` could reach `statecfg`. Only `commitment_rebuild` had it.

A `stage_exec --limit=10000` profile on n5 shows the cost: the sequential trie saturates one core for the whole exec window (`commitmentCalculator.loop` 123.3s wall, 120.0s computing) while the executor's workers sit 96% parked in `popWait` — 2.7 of 16 cores busy.

The flag default now ORs erigon's own flag default with the env-derived value, so flipping the default in one binary cannot leave the other on a different trie.