### PR TITLE
execution/commitment: make commit_* metrics report real numbers

### DIFF
--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -2242,10 +2242,7 @@ func (hph *HexPatriciaHashed) RootHash() ([]byte, error) {
 func (hph *HexPatriciaHashed) unfoldKeyPath(hashedKey, plainKey []byte) error {
 	for unfolding := hph.needUnfolding(hashedKey); unfolding > 0; unfolding = hph.needUnfolding(hashedKey) {
 		printLater := hph.currentKeyLen == 0 && hph.mounted && hph.traceW != nil
-		var unfoldDone func()
-		if dbg.KVReadLevelledMetrics {
-			unfoldDone = hph.metrics.StartUnfolding(plainKey)
-		}
+		unfoldDone := hph.metrics.StartUnfolding(plainKey)
 		if err := hph.unfold(hashedKey, unfolding); err != nil {
 			return fmt.Errorf("unfold: %w", err)
 		}
@@ -2265,10 +2262,7 @@ func (hph *HexPatriciaHashed) followAndUpdate(hashedKey, plainKey []byte, stateU
 	//}
 	// Keep folding until the currentKey is the prefix of the key we modify
 	for hph.needFolding(hashedKey) {
-		var foldDone func()
-		if dbg.KVReadLevelledMetrics {
-			foldDone = hph.metrics.StartFolding(plainKey)
-		}
+		foldDone := hph.metrics.StartFolding(plainKey)
 		if err := hph.fold(); err != nil {
 			return fmt.Errorf("fold: %w", err)
 		}
@@ -2567,10 +2561,7 @@ func (hph *HexPatriciaHashed) Process(ctx context.Context, updates *Updates, log
 
 	// Folding everything up to the root
 	for hph.activeRows > 0 {
-		var foldDone func()
-		if dbg.KVReadLevelledMetrics {
-			foldDone = hph.metrics.StartFolding(nil)
-		}
+		foldDone := hph.metrics.StartFolding(nil)
 		if err = hph.fold(); err != nil {
 			return nil, fmt.Errorf("final fold: %w", err)
 		}

--- a/execution/commitment/metrics.go
+++ b/execution/commitment/metrics.go
@@ -41,6 +41,7 @@ type Metrics struct {
 	updateBranch             atomic.Uint64
 	loadDepths               [10]uint64
 	unfolds                  atomic.Uint64
+	folds                    atomic.Uint64
 	spentUnfolding           atomic.Int64
 	spentFolding             atomic.Int64
 	spentProcessing          atomic.Int64
@@ -68,6 +69,7 @@ type MetricValues struct {
 	UpdateBranch    uint64
 	LoadDepths      [10]uint64
 	Unfolds         uint64
+	Folds           uint64
 	SpentUnfolding  time.Duration
 	SpentFolding    time.Duration
 	SpentProcessing time.Duration
@@ -142,6 +144,7 @@ func (m *Metrics) AsValues() MetricValues {
 		UpdateBranch:    m.updateBranch.Load(),
 		LoadDepths:      m.loadDepths,
 		Unfolds:         m.unfolds.Load(),
+		Folds:           m.folds.Load(),
 		SpentUnfolding:  time.Duration(m.spentUnfolding.Load()),
 		SpentFolding:    time.Duration(m.spentFolding.Load()),
 		SpentProcessing: time.Duration(m.spentProcessing.Load()),
@@ -172,7 +175,7 @@ func (m *Metrics) logMetrics() []any {
 		"cs", common.PrettyCounter(m.cacheStorage.Load()),
 		"mb", common.PrettyCounter(m.missBranch.Load()), "ma", common.PrettyCounter(m.missAccount.Load()),
 		"ms", common.PrettyCounter(m.missStorage.Load()),
-		"fld", common.PrettyCounter(m.unfolds.Load()), "pdur", common.Round(time.Duration(m.spentProcessing.Load()), 0).String(),
+		"fld", common.PrettyCounter(m.folds.Load()), "ufld", common.PrettyCounter(m.unfolds.Load()), "pdur", common.Round(time.Duration(m.spentProcessing.Load()), 0).String(),
 		"fdur", common.Round(time.Duration(m.spentFolding.Load()), 0).String(), "ufdur", common.Round(time.Duration(m.spentUnfolding.Load()), 0),
 	}
 }
@@ -306,7 +309,14 @@ func (m *Metrics) Reset() {
 	m.missBranch.Store(0)
 	m.missAccount.Store(0)
 	m.missStorage.Store(0)
+	m.cacheBranch.Store(0)
+	m.cacheAccount.Store(0)
+	m.cacheStorage.Store(0)
 	m.unfolds.Store(0)
+	m.folds.Store(0)
+	m.spentUnfolding.Store(0)
+	m.spentFolding.Store(0)
+	m.spentProcessing.Store(0)
 
 	if !m.collectCommitmentMetrics {
 		return
@@ -314,9 +324,6 @@ func (m *Metrics) Reset() {
 
 	m.Accounts.Reset()
 	m.Branches.Reset()
-	m.spentUnfolding.Store(0)
-	m.spentFolding.Store(0)
-	m.spentProcessing.Store(0)
 }
 
 func (m *Metrics) CollectFileDepthStats(endTxNumStats map[uint64]skipStat) {
@@ -375,6 +382,10 @@ func (m *Metrics) BranchLoad(plainKey []byte) {
 	}
 }
 
+// StartUnfolding counts the unfold always — one atomic add on a worker-private
+// line — and returns a timing closure only when per-key metrics are on, since
+// that costs a time.Now() and an escaping closure per call. A nil return means
+// there is nothing to stop.
 func (m *Metrics) StartUnfolding(plainKey []byte) func() {
 	m.unfolds.Add(1)
 	if m.collectCommitmentMetrics {
@@ -387,10 +398,11 @@ func (m *Metrics) StartUnfolding(plainKey []byte) func() {
 			})
 		}
 	}
-	return func() {}
+	return nil
 }
 
 func (m *Metrics) StartFolding(plainKey []byte) func() {
+	m.folds.Add(1)
 	if m.collectCommitmentMetrics {
 		start := time.Now()
 		return func() {
@@ -401,7 +413,33 @@ func (m *Metrics) StartFolding(plainKey []byte) func() {
 			})
 		}
 	}
-	return func() {}
+	return nil
+}
+
+// Merge folds src's counters into m. The parallel trie gives every mount
+// worker its own Metrics — an atomic add on a shared line in the fold loop
+// would cost more than the counter is worth — and merges once per round.
+func (m *Metrics) Merge(src *Metrics) {
+	if src == nil || m == src {
+		return
+	}
+	m.addressKeys.Add(src.addressKeys.Load())
+	m.storageKeys.Add(src.storageKeys.Load())
+	m.loadBranch.Add(src.loadBranch.Load())
+	m.loadAccount.Add(src.loadAccount.Load())
+	m.loadStorage.Add(src.loadStorage.Load())
+	m.cacheBranch.Add(src.cacheBranch.Load())
+	m.cacheAccount.Add(src.cacheAccount.Load())
+	m.cacheStorage.Add(src.cacheStorage.Load())
+	m.missBranch.Add(src.missBranch.Load())
+	m.missAccount.Add(src.missAccount.Load())
+	m.missStorage.Add(src.missStorage.Load())
+	m.updateBranch.Add(src.updateBranch.Load())
+	m.unfolds.Add(src.unfolds.Load())
+	m.folds.Add(src.folds.Load())
+	m.spentUnfolding.Add(src.spentUnfolding.Load())
+	m.spentFolding.Add(src.spentFolding.Load())
+	m.spentProcessing.Add(src.spentProcessing.Load())
 }
 
 func (m *Metrics) TotalProcessingTimeInc(t time.Time) {

--- a/execution/commitment/parallel_metrics_test.go
+++ b/execution/commitment/parallel_metrics_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package commitment
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildNibbleSpread returns a corpus whose accounts land under distinct root
+// nibbles, so processMounted actually fans out across workers.
+func buildNibbleSpread(t *testing.T, nibbles, slots int) ([][]byte, []Update) {
+	t.Helper()
+	rnd := rand.New(rand.NewSource(9931))
+	ub := NewUpdateBuilder()
+	for n := range nibbles {
+		addNibbleAccount(ub, rnd, n, n, slots)
+	}
+	return ub.Build()
+}
+
+func TestParallelPatriciaHashedReportsProgress(t *testing.T) {
+	ms := NewMockState(t)
+	keys, upds := buildNibbleSpread(t, 16, 4)
+	require.NoError(t, ms.applyPlainUpdates(keys, upds))
+
+	tr := newParTrie(t, ms, 4)
+	defer tr.Release()
+	ut := NewUpdates(ModeParallel, t.TempDir(), KeyToHexNibbleHash)
+	defer ut.Close()
+	for _, k := range keys {
+		ut.TouchPlainKey(string(k), nil, nil)
+	}
+
+	var got []*CommitProgress
+	_, err := tr.Process(context.Background(), ut, "", func(p *CommitProgress) {
+		got = append(got, p)
+	}, WarmupConfig{})
+	require.NoError(t, err)
+
+	require.Len(t, got, 1, "parallel Process must report the round exactly once")
+	p := got[0]
+	assert.Equal(t, p.UpdateCount, p.KeyIndex, "terminal callback reports a finished round")
+
+	// The counters must describe the whole round, not one worker's slice.
+	m := p.Metrics
+	assert.Positive(t, m.AddressKeys)
+	assert.Positive(t, m.StorageKeys)
+	assert.Positive(t, m.Folds, "fold count is recorded")
+	assert.Positive(t, m.UpdateBranch, "deferred branch writes are counted")
+
+	// The parallel engine re-traverses some subtrees (mount+replay), so its key
+	// counts are traversals, not distinct keys, and legitimately exceed the
+	// sequential engine's. Guard the direction: under-counting would mean a
+	// worker's Metrics never got merged.
+	seqMS := NewMockState(t)
+	require.NoError(t, seqMS.applyPlainUpdates(keys, upds))
+	seq := newSeqTrie(t, seqMS)
+	defer seq.Release()
+	sut := WrapKeyUpdates(t, ModeDirect, KeyToHexNibbleHash, keys, upds)
+	defer sut.Close()
+	_, err = seq.Process(context.Background(), sut, "", nil, WarmupConfig{})
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, m.AddressKeys, seq.metrics.addressKeys.Load(),
+		"every worker's address keys are merged in")
+	assert.GreaterOrEqual(t, m.StorageKeys, seq.metrics.storageKeys.Load(),
+		"every worker's storage keys are merged in")
+}
+
+func TestMetricsResetClearsEveryCounter(t *testing.T) {
+	m := NewMetrics("")
+	m.cacheBranch.Add(3)
+	m.cacheAccount.Add(4)
+	m.cacheStorage.Add(5)
+	m.folds.Add(6)
+	m.unfolds.Add(7)
+	m.spentFolding.Add(8)
+
+	m.Reset()
+
+	v := m.AsValues()
+	assert.Zero(t, v.CacheBranch)
+	assert.Zero(t, v.CacheAccount)
+	assert.Zero(t, v.CacheStorage)
+	assert.Zero(t, v.Folds)
+	assert.Zero(t, v.Unfolds)
+	assert.Zero(t, v.SpentFolding)
+}

--- a/execution/commitment/parallel_mount.go
+++ b/execution/commitment/parallel_mount.go
@@ -138,6 +138,7 @@ func (p *ParallelPatriciaHashed) processMounted(ctx context.Context, updates *Up
 		ni, ch := nib, child
 		g.Go(func() error {
 			w := NewHexPatriciaHashed(p.accountKeyLen, nil, p.cfg)
+			defer p.metrics.Merge(w.metrics)
 			w.mountTo(base, ni)
 			if p.template != nil && p.template.traceW != nil {
 				w.traceW = tracePrefix(p.template.traceW, fmt.Sprintf("[mnt %x] ", ni))

--- a/execution/commitment/parallel_patricia_hashed.go
+++ b/execution/commitment/parallel_patricia_hashed.go
@@ -41,6 +41,11 @@ type ParallelPatriciaHashed struct {
 
 	leaveDeferredForCaller bool
 	deferredForCaller      []*DeferredBranchUpdate
+
+	// metrics is the round's aggregate: each mount worker counts into its own
+	// Metrics and merges here when it finishes, so the fold loop never touches
+	// a shared cache line.
+	metrics *Metrics
 }
 
 func (p *ParallelPatriciaHashed) DeepLocalFolds() uint64 { return p.deepLocalFolds.Load() }
@@ -53,6 +58,9 @@ func NewParallelPatriciaHashed(ctxFactory TrieContextFactory, accountKeyLen int1
 		numWorkers:     runtime.NumCPU(),
 		cfg:            cfg,
 	}
+	// Its own, not the template's: the template traverses the skeleton over the
+	// same keys the workers do, so aliasing them counts every key twice.
+	p.metrics = NewMetrics("")
 	return p
 }
 
@@ -250,6 +258,10 @@ func (p *ParallelPatriciaHashed) Process(
 	copy(out, rh)
 	p.rootHash.Store(&out)
 	flushTrieStateRates()
+	if onProgress != nil && p.metrics != nil {
+		n := updates.Size()
+		onProgress(&CommitProgress{KeyIndex: n, UpdateCount: n, Metrics: p.metrics.AsValues()})
+	}
 	return out, nil
 }
 
@@ -305,8 +317,14 @@ func (p *ParallelPatriciaHashed) applyDeferredUpdates(ctx context.Context, pu *p
 		return errors.New("ParallelPatriciaHashed: trieCtxFactory returned nil context for deferred apply")
 	}
 
-	if _, err := ApplyDeferredBranchUpdates(deferred, p.numWorkers, applyCtx.PutBranch); err != nil {
+	// This path calls PutBranch directly rather than through a BranchEncoder,
+	// so it is the only place the parallel engine's branch writes get counted.
+	n, err := ApplyDeferredBranchUpdates(deferred, p.numWorkers, applyCtx.PutBranch)
+	if err != nil {
 		return fmt.Errorf("apply deferred branch updates: %w", err)
+	}
+	if p.metrics != nil {
+		p.metrics.updateBranch.Add(uint64(n))
 	}
 	return nil
 }

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -9,6 +9,7 @@ import (
 	"runtime/pprof"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dbg"
@@ -106,6 +107,12 @@ type commitmentCalculator struct {
 	// roTx is a persistent read-only transaction for domain reads.
 	// Opened at start, lives for the calculator's lifetime.
 	roTx kv.TemporalTx
+
+	// commitProgress holds the most recent CommitProgress the trie reported,
+	// and firstCommitAtNs the wall time of the first round. The parallel
+	// executor reads both to log commitment stats on its own ticker.
+	commitProgress  atomic.Pointer[commitment.CommitProgress]
+	firstCommitAtNs atomic.Int64
 
 	// lastTarget tracks the most recent block boundary so that
 	// computeAndPublish knows which block to compute for.
@@ -277,6 +284,34 @@ func newCommitmentCalculator(
 		perBlockFrom:         perBlockFrom,
 		done:                 make(chan struct{}),
 	}, nil
+}
+
+// onCommitProgress is handed to ComputeCommitment so the trie's counters
+// reach the executor. Called from the calculator goroutine.
+func (cc *commitmentCalculator) onCommitProgress(p *commitment.CommitProgress) {
+	if p == nil {
+		return
+	}
+	cc.commitProgress.Store(p)
+	cc.firstCommitAtNs.CompareAndSwap(0, time.Now().UnixNano())
+}
+
+// LastCommitProgress returns the most recent round's counters, or the zero
+// value if no round has completed.
+func (cc *commitmentCalculator) LastCommitProgress() commitment.CommitProgress {
+	if p := cc.commitProgress.Load(); p != nil {
+		return *p
+	}
+	return commitment.CommitProgress{}
+}
+
+// FirstCommitAt reports when the first round ran; zero if none has.
+func (cc *commitmentCalculator) FirstCommitAt() time.Time {
+	ns := cc.firstCommitAtNs.Load()
+	if ns == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, ns)
 }
 
 func (cc *commitmentCalculator) Start(ctx context.Context) {
@@ -855,7 +890,7 @@ func (cc *commitmentCalculator) computeIsolated(ctx context.Context, t commitTar
 	defer cc.doms.UnlockChangesetAccumulator()
 	defer cc.doms.DetachChangesetAccumulatorLocked()()
 
-	rh, err := cc.doms.ComputeCommitmentLocked(ctx, cc.roTx, true, t.blockNum, t.lastTxNum, cc.logPrefix, nil)
+	rh, err := cc.doms.ComputeCommitmentLocked(ctx, cc.roTx, true, t.blockNum, t.lastTxNum, cc.logPrefix, cc.onCommitProgress)
 	if err != nil {
 		return nil, err
 	}
@@ -977,7 +1012,7 @@ func (cc *commitmentCalculator) computeWithBlockAccumulator(ctx context.Context,
 	defer cc.doms.UnlockChangesetAccumulator()
 	cs := cc.doms.GetChangesetByHash(t.blockNum, t.blockHash)
 	if cs == nil {
-		return cc.doms.ComputeCommitmentLocked(ctx, cc.roTx, true, t.blockNum, t.lastTxNum, cc.logPrefix, nil)
+		return cc.doms.ComputeCommitmentLocked(ctx, cc.roTx, true, t.blockNum, t.lastTxNum, cc.logPrefix, cc.onCommitProgress)
 	}
 	// LOAD-BEARING swap under the outer lock (already taken above). The
 	// swap below mutates the global current-accumulator pointer; the
@@ -990,7 +1025,7 @@ func (cc *commitmentCalculator) computeWithBlockAccumulator(ctx context.Context,
 	// Inside the lock we must use the *Locked variants — the public
 	// counterparts re-acquire the same Mutex and would self-deadlock.
 	defer cc.doms.SwapCommitmentDiffLocked(cs)()
-	return cc.doms.ComputeCommitmentLocked(ctx, cc.roTx, true, t.blockNum, t.lastTxNum, cc.logPrefix, nil)
+	return cc.doms.ComputeCommitmentLocked(ctx, cc.roTx, true, t.blockNum, t.lastTxNum, cc.logPrefix, cc.onCommitProgress)
 }
 
 // asOfStateReader reads account/storage/code at a specific txNum via
@@ -1059,6 +1094,3 @@ func (r *asOfStateReader) CloneForWorker(workerCtx context.Context, tx kv.Tempor
 	}
 	return &asOfStateReader{sd: r.sd, roTx: tx, getter: r.sd.AsStateGetter(tx, getterOpts), txNum: r.txNum}
 }
-
-// Keep imports used.
-var _ = commitment.CommitProgress{}

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -39,7 +39,6 @@ import (
 	"github.com/erigontech/erigon/db/rawdb/rawdbhelpers"
 	"github.com/erigontech/erigon/db/rawdb/rawtemporaldb"
 	"github.com/erigontech/erigon/db/state/execctx"
-	"github.com/erigontech/erigon/execution/commitment"
 	"github.com/erigontech/erigon/execution/exec"
 	"github.com/erigontech/erigon/execution/protocol"
 	"github.com/erigontech/erigon/execution/protocol/rules"
@@ -228,7 +227,7 @@ func execV3(ctx context.Context,
 			isApplyingBlocks:  isApplyingBlocks,
 			logger:            logger,
 			logPrefix:         logPrefix,
-			progress:          NewProgress(blockNum, inputTxNum, commitThreshold, false, logPrefix, logger),
+			progress:          NewProgress(blockNum, inputTxNum, commitThreshold, logPrefix, logger),
 			enableChaosMonkey: initialCycle,
 			hooks:             hooks,
 			blockSrc:          blockSrc,
@@ -342,7 +341,7 @@ func execV3Serial(ctx context.Context,
 			applyTx:           applyTx,
 			logger:            logger,
 			logPrefix:         execStage.LogPrefix(),
-			progress:          NewProgress(blockNum, inputTxNum, commitThreshold, false, execStage.LogPrefix(), logger),
+			progress:          NewProgress(blockNum, inputTxNum, commitThreshold, execStage.LogPrefix(), logger),
 			enableChaosMonkey: initialCycle,
 			hooks:             hooks,
 		}}
@@ -382,7 +381,7 @@ func execV3Serial(ctx context.Context,
 				stepsInDb = rawdbhelpers.IdxStepsCountV3(applyTx, doms.StepSize())
 
 				if initialCycle {
-					se.LogCommitments(committedTransactions, stepsInDb, commitment.CommitProgress{})
+					se.LogCommitments(committedTransactions, stepsInDb, se.LastCommitProgress())
 				}
 			case errors.Is(execErr, ErrWrongTrieRoot):
 				execErr = handleIncorrectRootHashError(

--- a/execution/stagedsync/exec3_metrics.go
+++ b/execution/stagedsync/exec3_metrics.go
@@ -445,7 +445,7 @@ func updateExecDomainMetrics(metrics *kvmetrics.DomainMetrics, prevMetrics *kvme
 	return prevMetrics
 }
 
-func NewProgress(initialBlockNum, initialTxNum, commitThreshold uint64, updateMetrics bool, logPrefix string, logger log.Logger) *Progress {
+func NewProgress(initialBlockNum, initialTxNum, commitThreshold uint64, logPrefix string, logger log.Logger) *Progress {
 	now := time.Now()
 	return &Progress{
 		initialTime:           now,

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -381,9 +381,6 @@ func (pe *parallelExecutor) execImpl(ctx context.Context,
 	var uncommittedGas int64
 	var hasLoggedExecution bool
 	var hasLoggedCommittments atomic.Bool
-	var commitStart time.Time
-
-	var lastProgress commitment.CommitProgress
 
 	execErr := func() (err error) {
 		defer func() {
@@ -832,6 +829,10 @@ func (pe *parallelExecutor) execImpl(ctx context.Context,
 					hasLoggedExecution = true
 					lastExecutedLog = time.Now()
 					pe.LogExecution()
+					if !calculator.FirstCommitAt().IsZero() {
+						hasLoggedCommittments.Store(true)
+						pe.LogCommitments(0, stepsInDb, calculator.LastCommitProgress())
+					}
 					agg := pe.cfg.db.(dbstate.HasAgg).Agg().(*dbstate.Aggregator)
 					if agg.HasBackgroundFilesBuild() {
 						pe.logger.Info(fmt.Sprintf("[%s] Background files build", pe.logPrefix), "progress", agg.BackgroundProgress())
@@ -859,8 +860,8 @@ func (pe *parallelExecutor) execImpl(ctx context.Context,
 	// Commitment is computed per-block by the calculator. Stage progress
 	// is updated in handleCommitResult when results are consumed.
 
-	if !hasLoggedCommittments.Load() && !commitStart.IsZero() {
-		pe.LogCommitments(0, stepsInDb, lastProgress)
+	if !hasLoggedCommittments.Load() && !calculator.FirstCommitAt().IsZero() {
+		pe.LogCommitments(0, stepsInDb, calculator.LastCommitProgress())
 	}
 
 	if execErr != nil {

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -18,6 +18,8 @@ import (
 	"github.com/erigontech/erigon/db/rawdb/rawtemporaldb"
 	"github.com/erigontech/erigon/db/state/changeset"
 	"github.com/erigontech/erigon/db/state/execctx/execctxapi"
+	"sync/atomic"
+
 	"github.com/erigontech/erigon/execution/commitment"
 	"github.com/erigontech/erigon/execution/exec"
 	"github.com/erigontech/erigon/execution/protocol"
@@ -38,6 +40,10 @@ type serialExecutor struct {
 	blockStateGasUsed uint64 // EIP-8037: accumulated state gas
 	blobGasUsed       uint64
 	worker            *exec.Worker
+
+	// commitProgress holds the most recent CommitProgress the trie reported,
+	// so the caller can log real commitment counters instead of a zero value.
+	commitProgress atomic.Pointer[commitment.CommitProgress]
 
 	// accumulator for the current block; set at StartChange and used by the
 	// block-end stateWriter so that AuRa system-call nonce changes are
@@ -186,7 +192,7 @@ func (se *serialExecutor) exec(ctx context.Context, execStage *StageState, u Unw
 				se.doms.GetCommitmentCtx().SetTraceWriter(os.Stderr)
 			}
 			// Warmup is enabled via EnableTrieWarmup at executor init
-			rh, err := se.doms.ComputeCommitment(ctx, se.applyTx, true, blockNum, inputTxNum-1, se.logPrefix, nil)
+			rh, err := se.doms.ComputeCommitment(ctx, se.applyTx, true, blockNum, inputTxNum-1, se.logPrefix, se.onCommitProgress)
 			if traceBlk {
 				se.doms.GetCommitmentCtx().SetTraceWriter(nil)
 			}
@@ -279,6 +285,22 @@ func (se *serialExecutor) exec(ctx context.Context, execStage *StageState, u Unw
 
 func (se *serialExecutor) LogExecution() {
 	se.progress.LogExecution(se.rs.StateV3, se)
+}
+
+// onCommitProgress records the trie's counters for the round just finished.
+func (se *serialExecutor) onCommitProgress(p *commitment.CommitProgress) {
+	if p != nil {
+		se.commitProgress.Store(p)
+	}
+}
+
+// LastCommitProgress returns the most recent round's counters, or the zero
+// value if no round has completed.
+func (se *serialExecutor) LastCommitProgress() commitment.CommitProgress {
+	if p := se.commitProgress.Load(); p != nil {
+		return *p
+	}
+	return commitment.CommitProgress{}
 }
 
 func (se *serialExecutor) LogCommitments(committedTransactions uint64, stepsInDb float64, lastProgress commitment.CommitProgress) {


### PR DESCRIPTION
All 13 `commit_*` gauges read zero on any node running `--experimental.parallel-commitment`; the key and read rates read zero on the serial engine too. The path from the trie's counters to Prometheus is broken at five independent points, each sufficient on its own.

## Changes
- `ParallelPatriciaHashed.Process` took an `onProgress` callback and never called it — it now reports the finished round, like `HexPatriciaHashed` does.
- The commitment calculator passed `nil` for `onProgress` at all three `ComputeCommitmentLocked` sites; it now keeps the last `CommitProgress` and the first round's time for the executor to read.
- `exec3_parallel.go` declared `hasLoggedCommittments`, `commitStart` and `lastProgress` and assigned none of them, so `!commitStart.IsZero()` was always false and `LogCommitments` was unreachable. Commitment stats now log on the existing `logEvery` ticker.
- The serial path passed a literal `CommitProgress{}`; it now passes the round's real counters.
- `StartFolding` and `StartUnfolding` sat behind a second `dbg.KVReadLevelledMetrics` gate at their call sites, so the counters stayed at zero even where the callback arrived. Counting is unconditional now — one atomic add. The per-key timing and the attribution maps stay behind the flag: they cost a `time.Now()` and an escaping closure per call.
- Added a fold counter. Only `unfolds` existed, and `logMetrics` printed it under the label `fld`.
- `Metrics.Reset` never cleared the three cache counters.
- Parallel branch writes were counted nowhere: `ApplyDeferredBranchUpdates` bypasses `BranchEncoder` and calls `PutBranch` directly. They are counted at that call now.
- Dropped `var _ = commitment.CommitProgress{}` and the unused `updateMetrics` parameter on `NewProgress`.

## Notes
Each mount worker keeps its own `Metrics` and merges into the round's aggregate when it finishes, so the fold loop never touches a shared cache line.

Parallel key counts are traversals, not distinct keys — mount+replay re-traverses subtrees, so they exceed the serial engine's for the same corpus: 40 vs 16 address keys on a 16-account fixture. `TestParallelPatriciaHashedReportsProgress` guards the direction rather than equality. Separating distinct keys from traversals is a follow-up; the two engines' numbers are not comparable until then.
