### PR TITLE
[r3.5] cl: seed the ENR custody group count instead of an empty entry

### DIFF
--- a/cl/das/state/cgc_enr.go
+++ b/cl/das/state/cgc_enr.go
@@ -1,0 +1,28 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package peerdasstate
+
+import "math/big"
+
+// EncodeCgc renders a custody group count for the ENR: big endian with no leading zero
+// bytes, so zero is the empty byte string. Shared with the seed written at ENR setup so
+// both sites agree on the format.
+//
+// Spec: fulu/p2p-interface.md, "Custody group count".
+func EncodeCgc(cgc uint64) []byte {
+	return new(big.Int).SetUint64(cgc).Bytes()
+}

--- a/cl/das/state/cgc_enr_test.go
+++ b/cl/das/state/cgc_enr_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package peerdasstate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/clparams"
+)
+
+// fulu p2p-interface.md: cgc is a "Uint64 big endian integer with no leading zero
+// bytes (0 is encoded as empty byte string)".
+func TestEncodeCgcMatchesTheEnrSpec(t *testing.T) {
+	for _, tc := range []struct {
+		cgc  uint64
+		want []byte
+	}{
+		{0, []byte{}},
+		{4, []byte{0x04}},
+		{8, []byte{0x08}},
+		{255, []byte{0xff}},
+		{256, []byte{0x01, 0x00}},
+	} {
+		got := EncodeCgc(tc.cgc)
+		require.Equal(t, tc.want, got, "cgc %d", tc.cgc)
+		if len(got) > 0 {
+			require.NotZero(t, got[0], "cgc %d has a leading zero byte", tc.cgc)
+		}
+	}
+}
+
+// fulu/validator.md requires a node whose custody requirement falls to keep advertising
+// the previous (highest) count. No test can reach SetCustodyGroupCount through peerdas -
+// the only production caller is on_block.go and every test route is a gomock stub - so
+// the ratchet is pinned here directly.
+func TestSetCustodyGroupCountKeepsTheHighestAdvertised(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	s := NewPeerDasState(&cfg, &clparams.NetworkConfig{})
+
+	require.True(t, s.SetCustodyGroupCount(8), "an increase must be advertised")
+	require.False(t, s.SetCustodyGroupCount(4), "a decrease must not be advertised")
+	require.Equal(t, uint64(8), s.GetAdvertisedCgc(), "the highest count must survive a decrease")
+}

--- a/cl/das/state/state.go
+++ b/cl/das/state/state.go
@@ -1,7 +1,6 @@
 package peerdasstate
 
 import (
-	"math/big"
 	"sync"
 	"sync/atomic"
 
@@ -59,11 +58,11 @@ func (s *PeerDasState) SetCustodyGroupCount(cgc uint64) bool {
 	s.cgcMutex.Lock()
 	defer s.cgcMutex.Unlock()
 	s.realCgc = cgc
+	// A decrease is deliberately not advertised: fulu/validator.md requires a node to
+	// keep advertising the previous (highest) count and to keep serving it.
 	if cgc > s.advertisedCgc {
 		if node := s.localNode.Load(); node != nil {
-			// update cgc
-			encodedCgc := new(big.Int).SetUint64(cgc).Bytes()
-			node.Set(enr.WithEntry(s.networkConfig.CgcKey, encodedCgc))
+			node.Set(enr.WithEntry(s.networkConfig.CgcKey, EncodeCgc(cgc)))
 		}
 		s.advertisedCgc = cgc
 		s.custodyColumnsCache.Store(nil) // clear the cache

--- a/cl/p2p/p2p.go
+++ b/cl/p2p/p2p.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/erigontech/erigon/cl/clparams"
+	peerdasstate "github.com/erigontech/erigon/cl/das/state"
 	"github.com/erigontech/erigon/cl/phase1/core/state/lru"
 	"github.com/erigontech/erigon/cl/utils/eth_clock"
 	"github.com/erigontech/erigon/common"
@@ -203,7 +204,7 @@ func (p *p2pManager) setupENR() error {
 	node.Set(enr.WithEntry(p.cfg.NetworkConfig.Eth2key, forkId))
 	node.Set(enr.WithEntry(p.cfg.NetworkConfig.AttSubnetKey, initialAttnets.Bytes()))
 	node.Set(enr.WithEntry(p.cfg.NetworkConfig.SyncCommsSubnetKey, initialSyncnets.Bytes()))
-	node.Set(enr.WithEntry(p.cfg.NetworkConfig.CgcKey, []byte{}))
+	node.Set(enr.WithEntry(p.cfg.NetworkConfig.CgcKey, peerdasstate.EncodeCgc(p.cfg.BeaconConfig.CustodyRequirement)))
 	node.Set(enr.WithEntry(p.cfg.NetworkConfig.NfdKey, nfd))
 	return nil
 }

--- a/cl/p2p/p2p_enr_cgc_test.go
+++ b/cl/p2p/p2p_enr_cgc_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package p2p
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/utils/eth_clock"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/crypto"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/p2p/discover"
+	"github.com/erigontech/erigon/p2p/enr"
+)
+
+// setupENR once wrote the cgc entry as an empty byte slice, which is the canonical
+// encoding of zero, so the node advertised custody of no groups. This drives the real
+// setup path rather than the encoder, so reverting that line fails here.
+func TestSetupENRAdvertisesTheCustodyRequirement(t *testing.T) {
+	netCfg, beaconCfg, _, err := clparams.GetConfigsByNetworkName("mainnet")
+	require.NoError(t, err)
+	privKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	cfg := &P2PConfig{
+		NetworkConfig: netCfg,
+		BeaconConfig:  beaconCfg,
+		IpAddr:        "127.0.0.1",
+		Port:          0,
+		TCPPort:       4001,
+		TmpDir:        t.TempDir(),
+	}
+	listener, err := NewUDPv5Listener(context.Background(), cfg, discover.Config{PrivateKey: privKey}, log.Root())
+	require.NoError(t, err)
+	defer listener.LocalNode().Database().Close()
+	defer listener.Close()
+
+	p := &p2pManager{
+		cfg:      cfg,
+		udpv5:    listener,
+		ethClock: eth_clock.NewEthereumClock(0, common.Hash{}, beaconCfg),
+	}
+	require.NoError(t, p.setupENR())
+
+	var got []byte
+	require.NoError(t, listener.LocalNode().Node().Load(enr.WithEntry(cfg.NetworkConfig.CgcKey, &got)))
+
+	// fulu p2p-interface.md: big endian, no leading zero bytes. CUSTODY_REQUIREMENT is
+	// 4 on every network, so one byte - not a zero-padded uint64.
+	require.NotEmpty(t, got, "cgc advertised as empty, i.e. custody of no groups")
+	require.Equal(t, []byte{byte(beaconCfg.CustodyRequirement)}, got)
+}


### PR DESCRIPTION
Cherry-pick of #23560 to release/3.5.

Clean pick: the same five files, same diffstat, no branch-specific adaptations.
