### PR TITLE
[r3.6] docs(site): correct the Pruning Modes page for v3.6

### DIFF
--- a/docs/site/docs/fundamentals/pruning-modes.md
+++ b/docs/site/docs/fundamentals/pruning-modes.md
@@ -50,8 +50,10 @@ regardless of the state-history window, add `--prune.receipts.distance=keep-all`
 that fall entirely below the retention cutoff of the active `--prune.mode` are now deleted (a fresh sync already
 skipped downloading them, in v3.5 too). Before v3.6, files already on disk were retained indefinitely regardless of
 `--prune.mode`, so a long-running `full` or `minimal` node kept growing. Deletion is deferred until no reader still holds the retired
-files. The commitment-history and receipt-cache domains are retired against their own windows
-(`--prune.commitment-history.distance`, `--prune.receipts.distance`) rather than the general state-history window.
+files. The commitment-history and receipt-cache domains do not behave the same way here. Commitment history is retired
+against its own window, `--prune.commitment-history.distance`; left unset, nothing is retired. The receipt cache
+instead follows the general state-history window by default, and is only retired against an independent window when
+`--prune.receipts.distance` is set explicitly (with `keep-all` retiring nothing).
 :::
 
 ## Archive node

--- a/docs/site/docs/fundamentals/pruning-modes.md
+++ b/docs/site/docs/fundamentals/pruning-modes.md
@@ -23,17 +23,35 @@ In order to switch type of node, you must first delete the `/chaindata` folder i
 :::tip
 **Persisting receipts**, which are pre-calculated receipts, increase the requests-per-second (RPS) and improve the latency and throughput of all receipts and logs-related RPC calls.
 
-As of v3.6 they are disabled by default in every pruning mode (previously they were enabled by default for all modes
-except Archive); enable them with the flag `--prune.include-receipts` (the former `--persist.receipts` still works as an
-alias). Without them, receipts and logs are re-derived on demand from state history, so the related RPC calls keep
-working within the node's state-history window, just with higher latency. On a Historical Blocks node, persisted
-receipts additionally extend receipts and logs availability from the state-history window back to genesis.
+As of v3.6 they are disabled by default in every pruning mode on **fresh datadirs** (previously they were enabled by
+default for all modes except Archive); enable them with the flag `--prune.include-receipts` (the former
+`--persist.receipts` still works as an alias). An **existing datadir keeps the setting it was created with**: if the
+flag disagrees with the stored value, Erigon logs a warning and uses the stored value — changing it requires a fresh
+datadir. Without the cache, receipts and logs are re-derived on demand from state history, so the related RPC calls keep
+working within the node's state-history window, just with higher latency.
+
+`--prune.include-receipts` on its own does **not** extend receipts and logs back to genesis: the receipt cache follows
+the node's state-history window. On an [Archive node](#archive-node) that window is unbounded, so the cache covers the
+whole chain. On a [Full](#full-node), [Minimal](#minimal-node) or [Historical Blocks](#blocks-node) node it is the
+mode's state-history window (262,144 blocks for full and blocks, 100,000 for minimal). To keep the cache in full
+regardless of the state-history window, add `--prune.receipts.distance=keep-all`; a finite
+`--prune.receipts.distance=N` keeps it for the latest `N` blocks instead. Either form requires
+`--prune.include-receipts`.
 :::
 
 :::note[Breaking change in v3.5]
 **`--prune.mode=full` now follows the EIP-8252 reorg-retention window.** In v3.4, full mode pruned only pre-merge block data (EIP-4444 history-expiry) and **kept all post-merge block bodies, transactions, and receipts**, with a 100,000-block state-history window. In v3.5 it retains just the last **262,144 blocks (~36.4 days)** for *both* state and block data, matching [EIP-8252](https://github.com/ethereum/EIPs/pull/11601)'s `REORG_RETENTION_WINDOW`. The state-history window therefore grows (100,000 → 262,144), but **block bodies and receipts older than 262,144 blocks are now pruned** — a full node will no longer serve them.
 
 `--prune.mode=blocks` is unaffected for block data (it still keeps every block back to genesis); only its `History` window bumps from 100,000 to 262,144. `--prune.mode=minimal` is unchanged — both `Blocks` and `History` retain the 100,000-block window. **Existing datadirs upgrade automatically** on first start — Erigon rewrites the persisted mode and logs the transition, no operator action required. But **already-pruned block data cannot be recovered**, so choose *before* upgrading: set `--prune.distance.blocks=keep-post-merge` to retain the old full-mode behavior (keep post-merge blocks, prune only pre-merge), or use `--prune.mode=blocks` to keep every block back to genesis. See [#21342](https://github.com/erigontech/erigon/pull/21342) for details.
+:::
+
+:::note[New in v3.6]
+**Pruned nodes now reclaim disk from old snapshot files.** Frozen state-history (`.v`) and inverted-index (`.ef`) files
+that fall entirely below the retention cutoff of the active `--prune.mode` are now deleted, and a fresh sync skips
+downloading them in the first place. Before v3.6 these files were retained indefinitely regardless of `--prune.mode`,
+so a long-running `full` or `minimal` node kept growing. Deletion is deferred until no reader still holds the retired
+files. The commitment-history and receipt-cache domains are retired against their own windows
+(`--prune.commitment-history.distance`, `--prune.receipts.distance`) rather than the general state-history window.
 :::
 
 ## Archive node
@@ -50,7 +68,7 @@ We strongly recommend running a Full Node whenever possible, as its reduced disk
 
 ## Minimal node
 
-The Minimal Node configuration (`--prune.mode=minimal`) is the smallest possible setup. It keeps only recent blocks and the **latest state** — it does not retain state history, so historical state queries are not supported. This makes it perfectly suited for **solo staking** and users seeking maximum **privacy** when interacting with the EVM, such as sending transactions directly through their node. This mode is the most suitable for users with severely constrained hardware.
+The Minimal Node configuration (`--prune.mode=minimal`) is the smallest possible setup. It keeps blocks and state history only for the last **100,000 blocks** (~14 days) — a deliberately sub-EIP-8252 window — so historical state queries outside that window are not supported. This makes it perfectly suited for **solo staking** and users seeking maximum **privacy** when interacting with the EVM, such as sending transactions directly through their node. This mode is the most suitable for users with severely constrained hardware.
 
 ## Blocks node
 

--- a/docs/site/docs/fundamentals/pruning-modes.md
+++ b/docs/site/docs/fundamentals/pruning-modes.md
@@ -36,7 +36,9 @@ whole chain. On a [Full](#full-node), [Minimal](#minimal-node) or [Historical Bl
 mode's state-history window (262,144 blocks for full and blocks, 100,000 for minimal). To keep the cache in full
 regardless of the state-history window, add `--prune.receipts.distance=keep-all`; a finite
 `--prune.receipts.distance=N` keeps it for the latest `N` blocks instead. Either form requires
-`--prune.include-receipts`.
+`--prune.include-receipts`. Note that this retains the receipt *cache* only — it does not keep the
+log address and topic indexes a filtered `eth_getLogs` needs. See
+[Historical Blocks Node](#blocks-node).
 :::
 
 :::note[Breaking change in v3.5]
@@ -78,8 +80,18 @@ The Blocks Node configuration (`--prune.mode=blocks`) keeps the **full block and
 back to genesis — while pruning **state history**. It retains state only within the EIP-8252 window (the last 262,144
 blocks), the same state-retention as a Full Node, but unlike a Full Node it never prunes older blocks. This suits users
 who need complete historical **block and transaction data** — for research, indexing, or block explorers — without
-paying the disk cost of an archive node's full historical **state**. For full-range **receipts and logs**
-(`eth_getLogs` / `eth_getBlockReceipts` back to genesis), add
+paying the disk cost of an archive node's full historical **state**. For full-range **receipts** by block
+(`eth_getBlockReceipts` back to genesis), add
 `--prune.include-receipts --prune.receipts.distance=keep-all`; with `--prune.include-receipts` alone the receipt cache
 follows the state-history window (the last 262,144 blocks), and without it receipts are re-derived from state history
 within that same window.
+
+`keep-all` does **not** extend filtered `eth_getLogs` back to genesis. It retains the receipt-cache domain only; the
+log address and topic indexes that a filtered query needs are standalone inverted indexes, retired against the general
+state-history cutoff (`AggregatorRoTx.Retire` applies `RetireCutoffs.Default` to them, and only `RCacheDomain` carries
+the `keep-all` override). An address- or topic-filtered `eth_getLogs` can therefore miss matches older than 262,144
+blocks even with the cache retained. Note that dropping the filters does not merely widen the query — it changes the
+read path: with neither `address` nor `topics` set, `applyFiltersV3` consults no bitmap and falls back to a plain
+`stream.Range` over the retained cache, so an unfiltered range query is unaffected. For those older ranges, either query
+by block with `eth_getBlockReceipts` and filter client-side, or use an [Archive node](#archive-node), whose unbounded
+state-history window keeps the log indexes too.

--- a/docs/site/docs/fundamentals/pruning-modes.md
+++ b/docs/site/docs/fundamentals/pruning-modes.md
@@ -42,14 +42,14 @@ regardless of the state-history window, add `--prune.receipts.distance=keep-all`
 :::note[Breaking change in v3.5]
 **`--prune.mode=full` now follows the EIP-8252 reorg-retention window.** In v3.4, full mode pruned only pre-merge block data (EIP-4444 history-expiry) and **kept all post-merge block bodies, transactions, and receipts**, with a 100,000-block state-history window. In v3.5 it retains just the last **262,144 blocks (~36.4 days)** for *both* state and block data, matching [EIP-8252](https://github.com/ethereum/EIPs/pull/11601)'s `REORG_RETENTION_WINDOW`. The state-history window therefore grows (100,000 → 262,144), but **block bodies and receipts older than 262,144 blocks are now pruned** — a full node will no longer serve them.
 
-`--prune.mode=blocks` is unaffected for block data (it still keeps every block back to genesis); only its `History` window bumps from 100,000 to 262,144. `--prune.mode=minimal` is unchanged — both `Blocks` and `History` retain the 100,000-block window. **Existing datadirs upgrade automatically** on first start — Erigon rewrites the persisted mode and logs the transition, no operator action required. But **already-pruned block data cannot be recovered**, so choose *before* upgrading: set `--prune.distance.blocks=keep-post-merge` to retain the old full-mode behavior (keep post-merge blocks, prune only pre-merge), or use `--prune.mode=blocks` to keep every block back to genesis. See [#21342](https://github.com/erigontech/erigon/pull/21342) for details.
+`--prune.mode=blocks` is unaffected for block data (it still keeps every block back to genesis); only its `History` window bumps from 100,000 to 262,144. `--prune.mode=minimal` is unchanged — both `Blocks` and `History` retain the 100,000-block window. **Existing datadirs upgrade automatically** on first start — Erigon rewrites the persisted mode and logs the transition, no operator action required. But **already-pruned block data cannot be recovered**, so choose *before* upgrading: set `--prune.distance.blocks=keep-post-merge` to retain the old full-mode behavior (keep post-merge blocks, prune only pre-merge) — the named `keep-post-merge` alias parses only on v3.6 and later; on a v3.5 binary pass the equivalent numeric sentinel `--prune.distance.blocks=18446744073709551615` — or use `--prune.mode=blocks` to keep every block back to genesis. See [#21342](https://github.com/erigontech/erigon/pull/21342) for details.
 :::
 
 :::note[New in v3.6]
 **Pruned nodes now reclaim disk from old snapshot files.** Frozen state-history (`.v`) and inverted-index (`.ef`) files
-that fall entirely below the retention cutoff of the active `--prune.mode` are now deleted, and a fresh sync skips
-downloading them in the first place. Before v3.6 these files were retained indefinitely regardless of `--prune.mode`,
-so a long-running `full` or `minimal` node kept growing. Deletion is deferred until no reader still holds the retired
+that fall entirely below the retention cutoff of the active `--prune.mode` are now deleted (a fresh sync already
+skipped downloading them, in v3.5 too). Before v3.6, files already on disk were retained indefinitely regardless of
+`--prune.mode`, so a long-running `full` or `minimal` node kept growing. Deletion is deferred until no reader still holds the retired
 files. The commitment-history and receipt-cache domains are retired against their own windows
 (`--prune.commitment-history.distance`, `--prune.receipts.distance`) rather than the general state-history window.
 :::

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -1806,17 +1806,35 @@ In order to switch type of node, you must first delete the `/chaindata` folder i
 :::tip
 **Persisting receipts**, which are pre-calculated receipts, increase the requests-per-second (RPS) and improve the latency and throughput of all receipts and logs-related RPC calls.
 
-As of v3.6 they are disabled by default in every pruning mode (previously they were enabled by default for all modes
-except Archive); enable them with the flag `--prune.include-receipts` (the former `--persist.receipts` still works as an
-alias). Without them, receipts and logs are re-derived on demand from state history, so the related RPC calls keep
-working within the node's state-history window, just with higher latency. On a Historical Blocks node, persisted
-receipts additionally extend receipts and logs availability from the state-history window back to genesis.
+As of v3.6 they are disabled by default in every pruning mode on **fresh datadirs** (previously they were enabled by
+default for all modes except Archive); enable them with the flag `--prune.include-receipts` (the former
+`--persist.receipts` still works as an alias). An **existing datadir keeps the setting it was created with**: if the
+flag disagrees with the stored value, Erigon logs a warning and uses the stored value — changing it requires a fresh
+datadir. Without the cache, receipts and logs are re-derived on demand from state history, so the related RPC calls keep
+working within the node's state-history window, just with higher latency.
+
+`--prune.include-receipts` on its own does **not** extend receipts and logs back to genesis: the receipt cache follows
+the node's state-history window. On an [Archive node](#archive-node) that window is unbounded, so the cache covers the
+whole chain. On a [Full](#full-node), [Minimal](#minimal-node) or [Historical Blocks](#blocks-node) node it is the
+mode's state-history window (262,144 blocks for full and blocks, 100,000 for minimal). To keep the cache in full
+regardless of the state-history window, add `--prune.receipts.distance=keep-all`; a finite
+`--prune.receipts.distance=N` keeps it for the latest `N` blocks instead. Either form requires
+`--prune.include-receipts`.
 :::
 
 :::note[Breaking change in v3.5]
 **`--prune.mode=full` now follows the EIP-8252 reorg-retention window.** In v3.4, full mode pruned only pre-merge block data (EIP-4444 history-expiry) and **kept all post-merge block bodies, transactions, and receipts**, with a 100,000-block state-history window. In v3.5 it retains just the last **262,144 blocks (~36.4 days)** for *both* state and block data, matching [EIP-8252](https://github.com/ethereum/EIPs/pull/11601)'s `REORG_RETENTION_WINDOW`. The state-history window therefore grows (100,000 → 262,144), but **block bodies and receipts older than 262,144 blocks are now pruned** — a full node will no longer serve them.
 
-`--prune.mode=blocks` is unaffected for block data (it still keeps every block back to genesis); only its `History` window bumps from 100,000 to 262,144. `--prune.mode=minimal` is unchanged — both `Blocks` and `History` retain the 100,000-block window. **Existing datadirs upgrade automatically** on first start — Erigon rewrites the persisted mode and logs the transition, no operator action required. But **already-pruned block data cannot be recovered**, so choose *before* upgrading: set `--prune.distance.blocks=keep-post-merge` to retain the old full-mode behavior (keep post-merge blocks, prune only pre-merge), or use `--prune.mode=blocks` to keep every block back to genesis. See [#21342](https://github.com/erigontech/erigon/pull/21342) for details.
+`--prune.mode=blocks` is unaffected for block data (it still keeps every block back to genesis); only its `History` window bumps from 100,000 to 262,144. `--prune.mode=minimal` is unchanged — both `Blocks` and `History` retain the 100,000-block window. **Existing datadirs upgrade automatically** on first start — Erigon rewrites the persisted mode and logs the transition, no operator action required. But **already-pruned block data cannot be recovered**, so choose *before* upgrading: set `--prune.distance.blocks=keep-post-merge` to retain the old full-mode behavior (keep post-merge blocks, prune only pre-merge) — the named `keep-post-merge` alias parses only on v3.6 and later; on a v3.5 binary pass the equivalent numeric sentinel `--prune.distance.blocks=18446744073709551615` — or use `--prune.mode=blocks` to keep every block back to genesis. See [#21342](https://github.com/erigontech/erigon/pull/21342) for details.
+:::
+
+:::note[New in v3.6]
+**Pruned nodes now reclaim disk from old snapshot files.** Frozen state-history (`.v`) and inverted-index (`.ef`) files
+that fall entirely below the retention cutoff of the active `--prune.mode` are now deleted (a fresh sync already
+skipped downloading them, in v3.5 too). Before v3.6, files already on disk were retained indefinitely regardless of
+`--prune.mode`, so a long-running `full` or `minimal` node kept growing. Deletion is deferred until no reader still holds the retired
+files. The commitment-history and receipt-cache domains are retired against their own windows
+(`--prune.commitment-history.distance`, `--prune.receipts.distance`) rather than the general state-history window.
 :::
 
 ## Archive node
@@ -1833,7 +1851,7 @@ We strongly recommend running a Full Node whenever possible, as its reduced disk
 
 ## Minimal node
 
-The Minimal Node configuration (`--prune.mode=minimal`) is the smallest possible setup. It keeps only recent blocks and the **latest state** — it does not retain state history, so historical state queries are not supported. This makes it perfectly suited for **solo staking** and users seeking maximum **privacy** when interacting with the EVM, such as sending transactions directly through their node. This mode is the most suitable for users with severely constrained hardware.
+The Minimal Node configuration (`--prune.mode=minimal`) is the smallest possible setup. It keeps blocks and state history only for the last **100,000 blocks** (~14 days) — a deliberately sub-EIP-8252 window — so historical state queries outside that window are not supported. This makes it perfectly suited for **solo staking** and users seeking maximum **privacy** when interacting with the EVM, such as sending transactions directly through their node. This mode is the most suitable for users with severely constrained hardware.
 
 ## Blocks node
 

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -1833,8 +1833,10 @@ regardless of the state-history window, add `--prune.receipts.distance=keep-all`
 that fall entirely below the retention cutoff of the active `--prune.mode` are now deleted (a fresh sync already
 skipped downloading them, in v3.5 too). Before v3.6, files already on disk were retained indefinitely regardless of
 `--prune.mode`, so a long-running `full` or `minimal` node kept growing. Deletion is deferred until no reader still holds the retired
-files. The commitment-history and receipt-cache domains are retired against their own windows
-(`--prune.commitment-history.distance`, `--prune.receipts.distance`) rather than the general state-history window.
+files. The commitment-history and receipt-cache domains do not behave the same way here. Commitment history is retired
+against its own window, `--prune.commitment-history.distance`; left unset, nothing is retired. The receipt cache
+instead follows the general state-history window by default, and is only retired against an independent window when
+`--prune.receipts.distance` is set explicitly (with `keep-all` retiring nothing).
 :::
 
 ## Archive node

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -1819,7 +1819,9 @@ whole chain. On a [Full](#full-node), [Minimal](#minimal-node) or [Historical Bl
 mode's state-history window (262,144 blocks for full and blocks, 100,000 for minimal). To keep the cache in full
 regardless of the state-history window, add `--prune.receipts.distance=keep-all`; a finite
 `--prune.receipts.distance=N` keeps it for the latest `N` blocks instead. Either form requires
-`--prune.include-receipts`.
+`--prune.include-receipts`. Note that this retains the receipt *cache* only — it does not keep the
+log address and topic indexes a filtered `eth_getLogs` needs. See
+[Historical Blocks Node](#blocks-node).
 :::
 
 :::note[Breaking change in v3.5]
@@ -1861,11 +1863,21 @@ The Blocks Node configuration (`--prune.mode=blocks`) keeps the **full block and
 back to genesis — while pruning **state history**. It retains state only within the EIP-8252 window (the last 262,144
 blocks), the same state-retention as a Full Node, but unlike a Full Node it never prunes older blocks. This suits users
 who need complete historical **block and transaction data** — for research, indexing, or block explorers — without
-paying the disk cost of an archive node's full historical **state**. For full-range **receipts and logs**
-(`eth_getLogs` / `eth_getBlockReceipts` back to genesis), add
+paying the disk cost of an archive node's full historical **state**. For full-range **receipts** by block
+(`eth_getBlockReceipts` back to genesis), add
 `--prune.include-receipts --prune.receipts.distance=keep-all`; with `--prune.include-receipts` alone the receipt cache
 follows the state-history window (the last 262,144 blocks), and without it receipts are re-derived from state history
 within that same window.
+
+`keep-all` does **not** extend filtered `eth_getLogs` back to genesis. It retains the receipt-cache domain only; the
+log address and topic indexes that a filtered query needs are standalone inverted indexes, retired against the general
+state-history cutoff (`AggregatorRoTx.Retire` applies `RetireCutoffs.Default` to them, and only `RCacheDomain` carries
+the `keep-all` override). An address- or topic-filtered `eth_getLogs` can therefore miss matches older than 262,144
+blocks even with the cache retained. Note that dropping the filters does not merely widen the query — it changes the
+read path: with neither `address` nor `topics` set, `applyFiltersV3` consults no bitmap and falls back to a plain
+`stream.Range` over the retained cache, so an unfiltered range query is unaffected. For those older ranges, either query
+by block with `eth_getBlockReceipts` and filter client-side, or use an [Archive node](#archive-node), whose unbounded
+state-history window keeps the log indexes too.
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1806,17 +1806,35 @@ In order to switch type of node, you must first delete the `/chaindata` folder i
 :::tip
 **Persisting receipts**, which are pre-calculated receipts, increase the requests-per-second (RPS) and improve the latency and throughput of all receipts and logs-related RPC calls.
 
-As of v3.6 they are disabled by default in every pruning mode (previously they were enabled by default for all modes
-except Archive); enable them with the flag `--prune.include-receipts` (the former `--persist.receipts` still works as an
-alias). Without them, receipts and logs are re-derived on demand from state history, so the related RPC calls keep
-working within the node's state-history window, just with higher latency. On a Historical Blocks node, persisted
-receipts additionally extend receipts and logs availability from the state-history window back to genesis.
+As of v3.6 they are disabled by default in every pruning mode on **fresh datadirs** (previously they were enabled by
+default for all modes except Archive); enable them with the flag `--prune.include-receipts` (the former
+`--persist.receipts` still works as an alias). An **existing datadir keeps the setting it was created with**: if the
+flag disagrees with the stored value, Erigon logs a warning and uses the stored value — changing it requires a fresh
+datadir. Without the cache, receipts and logs are re-derived on demand from state history, so the related RPC calls keep
+working within the node's state-history window, just with higher latency.
+
+`--prune.include-receipts` on its own does **not** extend receipts and logs back to genesis: the receipt cache follows
+the node's state-history window. On an [Archive node](#archive-node) that window is unbounded, so the cache covers the
+whole chain. On a [Full](#full-node), [Minimal](#minimal-node) or [Historical Blocks](#blocks-node) node it is the
+mode's state-history window (262,144 blocks for full and blocks, 100,000 for minimal). To keep the cache in full
+regardless of the state-history window, add `--prune.receipts.distance=keep-all`; a finite
+`--prune.receipts.distance=N` keeps it for the latest `N` blocks instead. Either form requires
+`--prune.include-receipts`.
 :::
 
 :::note[Breaking change in v3.5]
 **`--prune.mode=full` now follows the EIP-8252 reorg-retention window.** In v3.4, full mode pruned only pre-merge block data (EIP-4444 history-expiry) and **kept all post-merge block bodies, transactions, and receipts**, with a 100,000-block state-history window. In v3.5 it retains just the last **262,144 blocks (~36.4 days)** for *both* state and block data, matching [EIP-8252](https://github.com/ethereum/EIPs/pull/11601)'s `REORG_RETENTION_WINDOW`. The state-history window therefore grows (100,000 → 262,144), but **block bodies and receipts older than 262,144 blocks are now pruned** — a full node will no longer serve them.
 
-`--prune.mode=blocks` is unaffected for block data (it still keeps every block back to genesis); only its `History` window bumps from 100,000 to 262,144. `--prune.mode=minimal` is unchanged — both `Blocks` and `History` retain the 100,000-block window. **Existing datadirs upgrade automatically** on first start — Erigon rewrites the persisted mode and logs the transition, no operator action required. But **already-pruned block data cannot be recovered**, so choose *before* upgrading: set `--prune.distance.blocks=keep-post-merge` to retain the old full-mode behavior (keep post-merge blocks, prune only pre-merge), or use `--prune.mode=blocks` to keep every block back to genesis. See [#21342](https://github.com/erigontech/erigon/pull/21342) for details.
+`--prune.mode=blocks` is unaffected for block data (it still keeps every block back to genesis); only its `History` window bumps from 100,000 to 262,144. `--prune.mode=minimal` is unchanged — both `Blocks` and `History` retain the 100,000-block window. **Existing datadirs upgrade automatically** on first start — Erigon rewrites the persisted mode and logs the transition, no operator action required. But **already-pruned block data cannot be recovered**, so choose *before* upgrading: set `--prune.distance.blocks=keep-post-merge` to retain the old full-mode behavior (keep post-merge blocks, prune only pre-merge) — the named `keep-post-merge` alias parses only on v3.6 and later; on a v3.5 binary pass the equivalent numeric sentinel `--prune.distance.blocks=18446744073709551615` — or use `--prune.mode=blocks` to keep every block back to genesis. See [#21342](https://github.com/erigontech/erigon/pull/21342) for details.
+:::
+
+:::note[New in v3.6]
+**Pruned nodes now reclaim disk from old snapshot files.** Frozen state-history (`.v`) and inverted-index (`.ef`) files
+that fall entirely below the retention cutoff of the active `--prune.mode` are now deleted (a fresh sync already
+skipped downloading them, in v3.5 too). Before v3.6, files already on disk were retained indefinitely regardless of
+`--prune.mode`, so a long-running `full` or `minimal` node kept growing. Deletion is deferred until no reader still holds the retired
+files. The commitment-history and receipt-cache domains are retired against their own windows
+(`--prune.commitment-history.distance`, `--prune.receipts.distance`) rather than the general state-history window.
 :::
 
 ## Archive node
@@ -1833,7 +1851,7 @@ We strongly recommend running a Full Node whenever possible, as its reduced disk
 
 ## Minimal node
 
-The Minimal Node configuration (`--prune.mode=minimal`) is the smallest possible setup. It keeps only recent blocks and the **latest state** — it does not retain state history, so historical state queries are not supported. This makes it perfectly suited for **solo staking** and users seeking maximum **privacy** when interacting with the EVM, such as sending transactions directly through their node. This mode is the most suitable for users with severely constrained hardware.
+The Minimal Node configuration (`--prune.mode=minimal`) is the smallest possible setup. It keeps blocks and state history only for the last **100,000 blocks** (~14 days) — a deliberately sub-EIP-8252 window — so historical state queries outside that window are not supported. This makes it perfectly suited for **solo staking** and users seeking maximum **privacy** when interacting with the EVM, such as sending transactions directly through their node. This mode is the most suitable for users with severely constrained hardware.
 
 ## Blocks node
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1833,8 +1833,10 @@ regardless of the state-history window, add `--prune.receipts.distance=keep-all`
 that fall entirely below the retention cutoff of the active `--prune.mode` are now deleted (a fresh sync already
 skipped downloading them, in v3.5 too). Before v3.6, files already on disk were retained indefinitely regardless of
 `--prune.mode`, so a long-running `full` or `minimal` node kept growing. Deletion is deferred until no reader still holds the retired
-files. The commitment-history and receipt-cache domains are retired against their own windows
-(`--prune.commitment-history.distance`, `--prune.receipts.distance`) rather than the general state-history window.
+files. The commitment-history and receipt-cache domains do not behave the same way here. Commitment history is retired
+against its own window, `--prune.commitment-history.distance`; left unset, nothing is retired. The receipt cache
+instead follows the general state-history window by default, and is only retired against an independent window when
+`--prune.receipts.distance` is set explicitly (with `keep-all` retiring nothing).
 :::
 
 ## Archive node

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1819,7 +1819,9 @@ whole chain. On a [Full](#full-node), [Minimal](#minimal-node) or [Historical Bl
 mode's state-history window (262,144 blocks for full and blocks, 100,000 for minimal). To keep the cache in full
 regardless of the state-history window, add `--prune.receipts.distance=keep-all`; a finite
 `--prune.receipts.distance=N` keeps it for the latest `N` blocks instead. Either form requires
-`--prune.include-receipts`.
+`--prune.include-receipts`. Note that this retains the receipt *cache* only — it does not keep the
+log address and topic indexes a filtered `eth_getLogs` needs. See
+[Historical Blocks Node](#blocks-node).
 :::
 
 :::note[Breaking change in v3.5]
@@ -1861,11 +1863,21 @@ The Blocks Node configuration (`--prune.mode=blocks`) keeps the **full block and
 back to genesis — while pruning **state history**. It retains state only within the EIP-8252 window (the last 262,144
 blocks), the same state-retention as a Full Node, but unlike a Full Node it never prunes older blocks. This suits users
 who need complete historical **block and transaction data** — for research, indexing, or block explorers — without
-paying the disk cost of an archive node's full historical **state**. For full-range **receipts and logs**
-(`eth_getLogs` / `eth_getBlockReceipts` back to genesis), add
+paying the disk cost of an archive node's full historical **state**. For full-range **receipts** by block
+(`eth_getBlockReceipts` back to genesis), add
 `--prune.include-receipts --prune.receipts.distance=keep-all`; with `--prune.include-receipts` alone the receipt cache
 follows the state-history window (the last 262,144 blocks), and without it receipts are re-derived from state history
 within that same window.
+
+`keep-all` does **not** extend filtered `eth_getLogs` back to genesis. It retains the receipt-cache domain only; the
+log address and topic indexes that a filtered query needs are standalone inverted indexes, retired against the general
+state-history cutoff (`AggregatorRoTx.Retire` applies `RetireCutoffs.Default` to them, and only `RCacheDomain` carries
+the `keep-all` override). An address- or topic-filtered `eth_getLogs` can therefore miss matches older than 262,144
+blocks even with the cache retained. Note that dropping the filters does not merely widen the query — it changes the
+read path: with neither `address` nor `topics` set, `applyFiltersV3` consults no bitmap and falls back to a plain
+`stream.Range` over the retained cache, so an unfiltered range query is unaffected. For those older ranges, either query
+by block with `eth_getBlockReceipts` and filter client-side, or use an [Archive node](#archive-node), whose unbounded
+state-history window keeps the log indexes too.
 
 ---
 


### PR DESCRIPTION
Corrects the Pruning Modes page for v3.6. Every default and sentinel is traced to `db/kv/prune`, `db/config3`, and the two flag-parse paths in `cmd/utils` and `node/cli`.

- The receipts cache is off by default in every prune mode, and an unset `--prune.receipts.distance` follows the state-history window rather than keeping everything. Existing datadirs keep whatever they were created with; there is no supported migration.
- `--persist.receipts` is documented as an alias of the current name, `--prune.include-receipts`.
- `--prune.receipts.distance=keep-all` is scoped to what it actually retains. It overrides the retire cutoff for the receipt-cache domain only. `LogAddrIdx` and `LogTopicIdx` are standalone inverted indexes and `AggregatorRoTx.Retire` applies the general history cutoff to them, so an address- or topic-filtered `eth_getLogs` can still miss matches older than the state-history window. Full-range reads are `eth_getBlockReceipts`; an unfiltered range query is unaffected, because with no address or topic set `applyFiltersV3` consults no bitmap and scans the retained cache instead.
- The upgrade advice in the v3.5 breaking-change card now works on v3.5. It previously told operators to set `--prune.distance.blocks=keep-post-merge` before upgrading, but that alias only parses on v3.6; the numeric equivalent is given.
- Frozen history and inverted-index files below the cutoff are now deleted. The note is scoped to files already on disk, since a fresh sync already skipped them in v3.5.
- Minimal mode's retention is stated as 100,000 blocks rather than "no state history".
