### PR TITLE
[r3.6] docs(site): document Erigon's JSON-RPC deviations from the standard eth API

### DIFF
--- a/docs/site/docs/fundamentals/modules/rpc-daemon.md
+++ b/docs/site/docs/fundamentals/modules/rpc-daemon.md
@@ -108,6 +108,7 @@ Flags:
       --rpc.subscription.filters.maxlogs int        Maximum number of logs to store per subscription.
       --rpc.subscription.filters.maxtopics int      Maximum number of topics per subscription to filter logs by.
       --rpc.subscription.filters.maxtxs int         Maximum number of transactions to store per subscription.
+      --rpc.subscription.filters.timeout duration   Timeout before idle filters are evicted. Defaults to 5m; set to 0 to disable eviction. (default 5m0s)
       --rpc.txfeecap float                          Sets a cap on transaction fee (in ether) that can be sent via the RPC APIs (0 = no cap) (default 1)
       --socket.enabled                              Enable IPC server
       --socket.url string                           IPC server listening url. prefix supported are tcp, unix (default "unix:///var/run/erigon.sock")

--- a/docs/site/docs/interacting-with-erigon/eth.md
+++ b/docs/site/docs/interacting-with-erigon/eth.md
@@ -149,7 +149,11 @@ deviates from it in the return shape, which keeps the `raw` field the spec dropp
 * `value` — `0` when absent
 * `gas` — from `eth_estimateGas` against `latest`
 * `chainId` — the node's chain ID; a mismatching supplied value is an error
-* fee fields — `gasPrice` before London, otherwise `maxFeePerGas` / `maxPriorityFeePerGas` from the gas oracle
+* fee fields — an explicitly supplied `gasPrice` is preserved, before or after London,
+  and cannot be combined with `maxFeePerGas` or `maxPriorityFeePerGas`. When it is absent:
+  before London `gasPrice` comes from the gas oracle; after London the dynamic fields are
+  filled independently, `maxPriorityFeePerGas` from the oracle and `maxFeePerGas` as twice
+  the base fee plus the tip. The dynamic fields are rejected before London
 * `maxFeePerBlobGas` — for blob transactions, twice the current blob gas price
 
 **Returns**

--- a/docs/site/docs/interacting-with-erigon/eth.md
+++ b/docs/site/docs/interacting-with-erigon/eth.md
@@ -39,7 +39,7 @@ This enables faster retrieval of Merkle proofs for any executed block.
 
 ### eth\_getStorageValues
 
-`eth_getStorageValues` reads several storage slots for one or more accounts in a single call, reducing round-trips compared to multiple `eth_getStorageAt` calls. It is part of the [Ethereum execution APIs](https://github.com/ethereum/execution-apis/blob/main/src/eth/state.yaml) and takes two parameters.
+`eth_getStorageValues` reads several storage slots for one or more accounts in a single call, reducing round-trips compared to multiple `eth_getStorageAt` calls. It originated as an Erigon extension and has since been adopted into the [Ethereum execution APIs](https://github.com/ethereum/execution-apis/blob/main/src/eth/state.yaml) (April 2026). It takes two parameters.
 
 **Parameters**
 
@@ -120,9 +120,10 @@ requested block is older than the retained commitment history, it fails with
 
 ### eth\_fillTransaction
 
-`eth_fillTransaction` is not in the standard set (it matches the geth method of the
-same name). It takes a partially specified transaction, fills in what is missing, and
-returns it unsigned — it neither signs nor submits anything.
+`eth_fillTransaction` takes a partially specified transaction, fills in what is
+missing, and returns it unsigned — it neither signs nor submits anything. The method
+was added to the execution-apis specification in July 2026; Erigon (matching geth)
+deviates from it in the return shape, which keeps the `raw` field the spec dropped.
 
 **Parameters**
 
@@ -140,7 +141,8 @@ returns it unsigned — it neither signs nor submits anything.
 **Returns**
 
 An object with `raw`, the RLP-encoded unsigned transaction, and `tx`, the same
-transaction in JSON form.
+transaction in JSON form. The standardized result carries only `tx`; the extra `raw`
+field is the geth-compatible shape.
 
 :::info
 KZG commitment and proof generation from raw blobs is not implemented. Blob
@@ -157,7 +159,9 @@ Accepted everywhere a block is selected:
 * a `0x`-prefixed hex string without leading zeros — `"0x3"`, `"0x2ed119"`
 * a bare, unquoted JSON integer — `3`
 * the named tags `"earliest"`, `"latest"`, `"safe"`, `"finalized"`, `"pending"`
-* `null`, which means `latest`
+* `null`, which means `latest` — except in the few methods whose block-or-hash
+  parameter is required (`eth_getBlockReceipts`, `eth_getBlockAccessList`,
+  `eth_simulateV1`, `eth_getWitness`, `eth_getTxWitness`), which reject it
 
 Rejected everywhere:
 

--- a/docs/site/docs/interacting-with-erigon/eth.md
+++ b/docs/site/docs/interacting-with-erigon/eth.md
@@ -155,7 +155,10 @@ deviates from it in the return shape, which keeps the `raw` field the spec dropp
   while `v` is zero. A pre-London fill, or a post-London fill supplying `gasPrice` with
   no access list, therefore returns `tx` without `chainId`
 * fee fields — an explicitly supplied `gasPrice` is preserved, before or after London,
-  and cannot be combined with `maxFeePerGas` or `maxPriorityFeePerGas`. When it is absent:
+  though after London it must be non-zero (`gasPrice must be non-zero after london fork`);
+  before London a zero is accepted. It cannot be combined with `maxFeePerGas` or
+  `maxPriorityFeePerGas`, and a supplied pair must satisfy `maxFeePerGas` non-zero and
+  `>= maxPriorityFeePerGas`. When `gasPrice` is absent:
   before London `gasPrice` comes from the gas oracle; after London the dynamic fields are
   filled independently, `maxPriorityFeePerGas` from the oracle and `maxFeePerGas` as twice
   the base fee plus the tip. The dynamic fields are rejected before London
@@ -163,13 +166,21 @@ deviates from it in the return shape, which keeps the `raw` field the spec dropp
 
 **Returns**
 
-An object with `raw`, the RLP-encoded unsigned transaction, and `tx`, the same
-transaction in JSON form. The standardized result carries only `tx`; the extra `raw`
-field is the geth-compatible shape.
+An object with `raw`, the unsigned transaction in its canonical binary encoding, and
+`tx`, the same transaction in JSON form. `raw` comes from `MarshalBinary`, so it is bare
+RLP only for a legacy transaction; a typed one is the EIP-2718 type byte followed by the
+encoded payload, and feeding that straight to an RLP decoder will fail. The standardized
+result carries only `tx`; the extra `raw` field is the geth-compatible shape.
 
 :::info
 KZG commitment and proof generation from raw blobs is not implemented. Blob
 transactions must already carry their `blobVersionedHashes`.
+
+The sidecar fields the specification defines — `blobs`, `commitments` and `proofs` — are
+not supported: `CallArgs` has no field for them, so they are dropped from the request
+without an error even when a complete precomputed sidecar is supplied, and they are
+absent from the returned `tx` and `raw`. Callers that need the sidecar must keep it
+themselves and reattach it before submitting.
 :::
 
 ### Block number parameter format

--- a/docs/site/docs/interacting-with-erigon/eth.md
+++ b/docs/site/docs/interacting-with-erigon/eth.md
@@ -99,7 +99,9 @@ without a full state database.
 :::info
 `eth_getTxWitness` currently only bounds-checks `txIndex` — an index past the end of the
 block is an error, but the witness it returns is the same whole-block witness
-`eth_getWitness` produces.
+`eth_getWitness` produces. At the genesis block not even that check runs: both methods
+share one implementation that returns the empty witness as soon as the block number
+resolves to `0`, so any `txIndex` is accepted there.
 :::
 
 **Returns**
@@ -110,14 +112,17 @@ self-verified. The genesis block returns an empty witness.
 
 **Requirements**
 
-Both methods need commitment history, so start the node with:
+Both methods need commitment history for any block above genesis, so start the node with:
 
 ```text
 --prune.include-commitment-history
 ```
 
-Without it the call fails with an error starting with `eth_getWitness requires
-commitment history`; the message continues with a restart hint that names the
+The genesis block is the one exception: the empty witness is returned before the
+commitment-history check, so `eth_getWitness` and `eth_getTxWitness` succeed at block `0`
+on a node without commitment history. For every other block, without it the call fails
+with an error starting with `eth_getWitness requires commitment history`; the message
+continues with a restart hint that names the
 `--prune.experimental.include-commitment-history` alias rather than the canonical flag
 above. If the requested block is older than the retained commitment history, the call
 fails with an error starting with `commitment history pruned`, followed by the retained
@@ -164,9 +169,16 @@ Accepted everywhere a block is selected:
 * a `0x`-prefixed hex string without leading zeros — `"0x3"`, `"0x2ed119"`
 * a bare, unquoted JSON integer — `3`
 * the named tags `"earliest"`, `"latest"`, `"safe"`, `"finalized"`, `"pending"`
-* `null`, which means `latest` — except in the few methods whose block-or-hash
-  parameter is required (`eth_getBlockReceipts`, `eth_getBlockAccessList`,
-  `eth_simulateV1`, `eth_getWitness`, `eth_getTxWitness`), which reject it
+* `null`, but only where the selector is optional: it leaves the parameter unset, and
+  the method's own default applies — `latest` for most, though the default is
+  per-method. A **required** block-or-hash parameter rejects top-level `null`:
+  `BlockNumberOrHash.UnmarshalJSON` decodes `null` into an empty struct and then fails
+  with `at least one of BlockNumber or BlockHash is needed if a dictionary is provided`
+  (`rpc/types.go`). That is a property of the type, not a list of special-cased methods
+  — it holds for every method whose selector is a required `BlockNumberOrHash`,
+  including `eth_getBlockReceipts`, `eth_getBlockAccessList`, `eth_simulateV1`,
+  `eth_getWitness`, `eth_getTxWitness`, `eth_getBlockByHash` and
+  `trace_replayBlockTransactions`
 
 Rejected everywhere:
 
@@ -181,11 +193,24 @@ and are now rejected with `hex string without 0x prefix`, returned as an
 integer `3`, or a named tag.
 :::
 
-Two further forms are accepted only by methods whose parameter is a plain block number,
-such as `eth_getBlockByNumber`, `eth_getBlockTransactionCountByNumber` and `trace_block`:
-the Erigon-specific tag `"latestExecuted"`, and the string `"null"`, which means `latest`.
+Two further forms exist: the Erigon-specific tag `"latestExecuted"`, and the string
+`"null"`, which means `latest`. Both are parsed by `BlockNumber.UnmarshalJSON`, so they are
+accepted unconditionally by methods whose parameter is a plain block number — such as
+`eth_getBlockByNumber`, `eth_getBlockTransactionCountByNumber` and `trace_block`.
+
 Methods taking a block-number-or-hash selector — `eth_call`, `eth_getBalance`,
-`eth_getProof` and the rest — reject both.
+`eth_getProof` and the rest — reject both **as top-level strings** only.
+`BlockNumberOrHash.UnmarshalJSON` tries the object form first, and that path decodes the
+`blockNumber` field through `BlockNumber`, which does accept them. So on those
+block-number-or-hash methods the object-wrapped forms work:
+
+```json
+{"blockNumber": "latestExecuted"}
+{"blockNumber": "null"}
+```
+
+while the bare strings `"latestExecuted"` and `"null"` fail on those same methods, because
+the top-level string switch does not list them.
 
 ### Filter lifetime
 

--- a/docs/site/docs/interacting-with-erigon/eth.md
+++ b/docs/site/docs/interacting-with-erigon/eth.md
@@ -19,7 +19,9 @@ For API usage refer to the below official resources:
 * [https://ethereum.github.io/execution-apis/](https://ethereum.github.io/execution-apis/)
 
 The sections below cover only the places where Erigon adds a method that is not in that
-standard set, or where its behaviour differs from it. Everything else follows the spec.
+standard set, or where its behaviour differs from it. They are not an exhaustive
+compliance statement: anything not listed here is expected to follow the spec, but a
+deviation that has not yet been documented may still exist.
 
 ### eth\_getProof
 
@@ -114,9 +116,12 @@ Both methods need commitment history, so start the node with:
 --prune.include-commitment-history
 ```
 
-Without it the call fails with `eth_getWitness requires commitment history`. If the
-requested block is older than the retained commitment history, it fails with
-`commitment history pruned`.
+Without it the call fails with an error starting with `eth_getWitness requires
+commitment history`; the message continues with a restart hint that names the
+`--prune.experimental.include-commitment-history` alias rather than the canonical flag
+above. If the requested block is older than the retained commitment history, the call
+fails with an error starting with `commitment history pruned`, followed by the retained
+range.
 
 ### eth\_fillTransaction
 

--- a/docs/site/docs/interacting-with-erigon/eth.md
+++ b/docs/site/docs/interacting-with-erigon/eth.md
@@ -148,7 +148,12 @@ deviates from it in the return shape, which keeps the `raw` field the spec dropp
 * `nonce` — from the pending nonce of `from`, or `0` when `from` is absent
 * `value` — `0` when absent
 * `gas` — from `eth_estimateGas` against `latest`
-* `chainId` — the node's chain ID; a mismatching supplied value is an error
+* `chainId` — the node's chain ID; a mismatching supplied value is an error. It is used
+  for validation and carried by typed transactions, but it does not appear in the
+  returned `tx` for an unsigned legacy transaction: `CallArgs.ToTransaction` builds a
+  `LegacyTx` with no chain-ID field, and the response encoder skips chain-ID derivation
+  while `v` is zero. A pre-London fill, or a post-London fill supplying `gasPrice` with
+  no access list, therefore returns `tx` without `chainId`
 * fee fields — an explicitly supplied `gasPrice` is preserved, before or after London,
   and cannot be combined with `maxFeePerGas` or `maxPriorityFeePerGas`. When it is absent:
   before London `gasPrice` comes from the gas oracle; after London the dynamic fields are
@@ -193,6 +198,9 @@ Accepted everywhere a block is selected:
 Rejected everywhere:
 
 * a quoted decimal string — `"3"`, `"100"`
+* a block number above `2^63-1`, in either parameter type — `BlockNumber.UnmarshalJSON`
+  and `BlockNumberOrHash.UnmarshalJSON` both fail with `blocknumber too high`, so
+  `"0x8000000000000000"` and the equivalent bare integer are out of range
 * hex with leading zeros — `"0x01"`
 * hex without the prefix — `"ff"`
 

--- a/docs/site/docs/interacting-with-erigon/eth.md
+++ b/docs/site/docs/interacting-with-erigon/eth.md
@@ -198,9 +198,11 @@ Accepted everywhere a block is selected:
 Rejected everywhere:
 
 * a quoted decimal string — `"3"`, `"100"`
-* a block number above `2^63-1`, in either parameter type — `BlockNumber.UnmarshalJSON`
-  and `BlockNumberOrHash.UnmarshalJSON` both fail with `blocknumber too high`, so
-  `"0x8000000000000000"` and the equivalent bare integer are out of range
+* a block number above `2^63-1` — out of range in both parameter types, though the error
+  differs: a plain **block-number** parameter fails with `block number larger than
+  int64`, while a top-level numeric or hex **block-or-hash** value fails with
+  `blocknumber too high` (`rpc/types.go`). `"0x8000000000000000"` and the equivalent
+  bare integer are rejected either way
 * hex with leading zeros — `"0x01"`
 * hex without the prefix — `"ff"`
 

--- a/docs/site/docs/interacting-with-erigon/eth.md
+++ b/docs/site/docs/interacting-with-erigon/eth.md
@@ -18,6 +18,9 @@ For API usage refer to the below official resources:
 * [https://ethereum.org/en/developers/docs/apis/json-rpc/](https://ethereum.org/en/developers/docs/apis/json-rpc/)
 * [https://ethereum.github.io/execution-apis/](https://ethereum.github.io/execution-apis/)
 
+The sections below cover only the places where Erigon adds a method that is not in that
+standard set, or where its behaviour differs from it. Everything else follows the spec.
+
 ### eth\_getProof
 
 `eth_getProof` returns Merkle proofs for account state and storage slots, as defined in [EIP-1186](https://eips.ethereum.org/EIPS/eip-1186). It is stable and production-ready as of Erigon v3.4.
@@ -76,3 +79,120 @@ An object mapping each requested address to an array of 32-byte values, in the s
 * A single call may request at most 1024 slots in total, counting all addresses together. Larger requests are rejected.
 * An empty `requests` object returns error code `-32602` with the message `empty request`.
 * When `blockNumber` is a block hash, the block must be canonical.
+
+### eth\_getWitness and eth\_getTxWitness
+
+Neither method exists in the standard set. They return a state witness for the
+*pre-state* of a block: the serialized trie node stream needed to re-execute it
+without a full state database.
+
+**Parameters**
+
+| Method | Parameter | Type | Description |
+| ------ | --------- | ---- | ----------- |
+| `eth_getWitness` | blockNumberOrHash | STRING, NUMBER or OBJECT | Block to build the witness for |
+| `eth_getTxWitness` | blockNumberOrHash | STRING, NUMBER or OBJECT | Block containing the transaction |
+| `eth_getTxWitness` | txIndex | QUANTITY | Index of a transaction within that block |
+
+:::info
+`eth_getTxWitness` currently only bounds-checks `txIndex` — an index past the end of the
+block is an error, but the witness it returns is the same whole-block witness
+`eth_getWitness` produces.
+:::
+
+**Returns**
+
+`DATA` — the serialized witness. Erigon decodes the bytes it is about to return and
+checks that they rebuild the parent state root, so a witness that comes back is
+self-verified. The genesis block returns an empty witness.
+
+**Requirements**
+
+Both methods need commitment history, so start the node with:
+
+```text
+--prune.include-commitment-history
+```
+
+Without it the call fails with `eth_getWitness requires commitment history`. If the
+requested block is older than the retained commitment history, it fails with
+`commitment history pruned`.
+
+### eth\_fillTransaction
+
+`eth_fillTransaction` is not in the standard set (it matches the geth method of the
+same name). It takes a partially specified transaction, fills in what is missing, and
+returns it unsigned — it neither signs nor submits anything.
+
+**Parameters**
+
+1. `Object` — a transaction object in the same shape `eth_call` accepts.
+
+**Fills in**
+
+* `nonce` — from the pending nonce of `from`, or `0` when `from` is absent
+* `value` — `0` when absent
+* `gas` — from `eth_estimateGas` against `latest`
+* `chainId` — the node's chain ID; a mismatching supplied value is an error
+* fee fields — `gasPrice` before London, otherwise `maxFeePerGas` / `maxPriorityFeePerGas` from the gas oracle
+* `maxFeePerBlobGas` — for blob transactions, twice the current blob gas price
+
+**Returns**
+
+An object with `raw`, the RLP-encoded unsigned transaction, and `tx`, the same
+transaction in JSON form.
+
+:::info
+KZG commitment and proof generation from raw blobs is not implemented. Blob
+transactions must already carry their `blobVersionedHashes`.
+:::
+
+### Block number parameter format
+
+Erigon accepts more block-number forms than the standard schema, which allows only a
+`0x`-prefixed hex quantity string or a named tag.
+
+Accepted everywhere a block is selected:
+
+* a `0x`-prefixed hex string without leading zeros — `"0x3"`, `"0x2ed119"`
+* a bare, unquoted JSON integer — `3`
+* the named tags `"earliest"`, `"latest"`, `"safe"`, `"finalized"`, `"pending"`
+* `null`, which means `latest`
+
+Rejected everywhere:
+
+* a quoted decimal string — `"3"`, `"100"`
+* hex with leading zeros — `"0x01"`
+* hex without the prefix — `"ff"`
+
+:::warning
+**Breaking change in v3.6.** Quoted decimal strings such as `"3"` used to be accepted
+and are now rejected with `hex string without 0x prefix`, returned as an
+`invalid params` error. Callers relying on that form must switch to `"0x3"`, the bare
+integer `3`, or a named tag.
+:::
+
+Two further forms are accepted only by methods whose parameter is a plain block number,
+such as `eth_getBlockByNumber`, `eth_getBlockTransactionCountByNumber` and `trace_block`:
+the Erigon-specific tag `"latestExecuted"`, and the string `"null"`, which means `latest`.
+Methods taking a block-number-or-hash selector — `eth_call`, `eth_getBalance`,
+`eth_getProof` and the rest — reject both.
+
+### Filter lifetime
+
+The standard spec does not say how long a filter lives. In Erigon, a filter created by
+`eth_newFilter`, `eth_newBlockFilter`, or `eth_newPendingTransactionFilter` is evicted
+once it has gone **5 minutes** without being polled. `eth_getFilterChanges` and
+`eth_getFilterLogs` both count as a poll and reset the clock, so a filter stays alive on
+a quiet chain as long as the client keeps asking. A call against an evicted filter
+returns `filter not found`.
+
+Change the window, or turn eviction off entirely, with:
+
+```text
+--rpc.subscription.filters.timeout 15m   # longer window
+--rpc.subscription.filters.timeout 0     # keep filters indefinitely
+```
+
+Eviction applies only to these polling filters. WebSocket subscriptions live as long as
+their connection does.

--- a/docs/site/docs/interacting-with-erigon/eth.md
+++ b/docs/site/docs/interacting-with-erigon/eth.md
@@ -23,6 +23,15 @@ standard set, or where its behaviour differs from it. They are not an exhaustive
 compliance statement: anything not listed here is expected to follow the spec, but a
 deviation that has not yet been documented may still exist.
 
+:::info
+`execution-apis` is a living specification rather than a frozen standard — methods are
+still being added, and some long-standing `eth` behaviour was never specified at all — so
+parts of what follows are differences from a moving target rather than defects. Erigon
+runs the specification's own conformance vectors in CI (Hive's `rpc-compat` suite against
+a pinned `execution-apis` revision) and works with the other client teams on closing
+these gaps, so this page will change as the two converge.
+:::
+
 ### eth\_getProof
 
 `eth_getProof` returns Merkle proofs for account state and storage slots, as defined in [EIP-1186](https://eips.ethereum.org/EIPS/eip-1186). It is stable and production-ready as of Erigon v3.4.

--- a/docs/site/docs/interacting-with-erigon/eth.md
+++ b/docs/site/docs/interacting-with-erigon/eth.md
@@ -143,6 +143,11 @@ deviates from it in the return shape, which keeps the `raw` field the spec dropp
 
 1. `Object` — a transaction object in the same shape `eth_call` accepts.
 
+The standard `type` field is ignored. `CallArgs` has no field for it and unknown JSON
+properties are accepted silently, so the envelope is inferred from whichever fee,
+access-list and blob fields are present. On a post-London head, `{"type": "0x0"}` with no
+`gasPrice` comes back as a type `0x2` transaction rather than the legacy type requested.
+
 **Fills in**
 
 * `nonce` — from the pending nonce of `from`, or `0` when `from` is absent
@@ -171,6 +176,13 @@ An object with `raw`, the unsigned transaction in its canonical binary encoding,
 RLP only for a legacy transaction; a typed one is the EIP-2718 type byte followed by the
 encoded payload, and feeding that straight to an RLP decoder will fail. The standardized
 result carries only `tx`; the extra `raw` field is the geth-compatible shape.
+
+A typed result also carries `gasPrice: null`. `FillTransaction` passes no base fee to the
+response encoder, so `computeGasPrice` returns nothing and the missing key is filled with
+`null` — deliberate geth parity, pinned by `rpc/ethapi/api_test.go`. The standardized
+type-2 unsigned schema requires `gasPrice` to be a hex quantity, so a schema-validating
+client will reject the result; read `maxFeePerGas` and `maxPriorityFeePerGas` instead.
+Legacy results carry a real `gasPrice`.
 
 :::info
 KZG commitment and proof generation from raw blobs is not implemented. Blob

--- a/docs/site/docs/interacting-with-erigon/eth.md
+++ b/docs/site/docs/interacting-with-erigon/eth.md
@@ -99,16 +99,20 @@ without a full state database.
 :::info
 `eth_getTxWitness` currently only bounds-checks `txIndex` — an index past the end of the
 block is an error, but the witness it returns is the same whole-block witness
-`eth_getWitness` produces. At the genesis block not even that check runs: both methods
-share one implementation that returns the empty witness as soon as the block number
-resolves to `0`, so any `txIndex` is accepted there.
+`eth_getWitness` produces. Two cases are not rejected: the check narrows the index with
+`int(txIndex)`, so on a 64-bit build a value from `0x8000000000000000` upward wraps
+negative and passes; and at the genesis block the check never runs at all, because both
+methods share one implementation that returns the empty witness as soon as the block
+number resolves to `0`.
 :::
 
 **Returns**
 
-`DATA` — the serialized witness. Erigon decodes the bytes it is about to return and
-checks that they rebuild the parent state root, so a witness that comes back is
-self-verified. The genesis block returns an empty witness.
+`DATA` — the serialized witness. On the normal path Erigon decodes the bytes it is about
+to return and checks that they rebuild the parent state root, so the witness is
+self-verified. Two early returns skip that check because they produce no witness to
+verify: the genesis block, and any block whose access set turns out to be empty. Both
+return the empty witness.
 
 **Requirements**
 
@@ -169,16 +173,18 @@ Accepted everywhere a block is selected:
 * a `0x`-prefixed hex string without leading zeros — `"0x3"`, `"0x2ed119"`
 * a bare, unquoted JSON integer — `3`
 * the named tags `"earliest"`, `"latest"`, `"safe"`, `"finalized"`, `"pending"`
-* `null`, but only where the selector is optional: it leaves the parameter unset, and
-  the method's own default applies — `latest` for most, though the default is
-  per-method. A **required** block-or-hash parameter rejects top-level `null`:
-  `BlockNumberOrHash.UnmarshalJSON` decodes `null` into an empty struct and then fails
-  with `at least one of BlockNumber or BlockHash is needed if a dictionary is provided`
-  (`rpc/types.go`). That is a property of the type, not a list of special-cased methods
-  — it holds for every method whose selector is a required `BlockNumberOrHash`,
-  including `eth_getBlockReceipts`, `eth_getBlockAccessList`, `eth_simulateV1`,
-  `eth_getWitness`, `eth_getTxWitness`, `eth_getBlockByHash` and
-  `trace_replayBlockTransactions`
+* `null`, whose handling depends on the parameter's type, not on the method:
+  * a plain **block-number** parameter accepts it — `BlockNumber.UnmarshalJSON` maps
+    top-level `null` to `latest`, so `eth_getBlockByNumber`, `trace_block` and the rest
+    of that family take it even though the parameter is required;
+  * an **optional** block-or-hash parameter accepts it too: the selector is left unset
+    and the method's own default applies, `latest` for most;
+  * a **required** block-or-hash parameter rejects it —
+    `BlockNumberOrHash.UnmarshalJSON` decodes `null` into an empty struct and then fails
+    with `at least one of BlockNumber or BlockHash is needed if a dictionary is
+    provided` (`rpc/types.go`). This holds for every such method, including
+    `eth_getBlockReceipts`, `eth_getBlockAccessList`, `eth_simulateV1`, `eth_getWitness`,
+    `eth_getTxWitness`, `eth_getBlockByHash` and `trace_replayBlockTransactions`
 
 Rejected everywhere:
 

--- a/docs/site/docs/interacting-with-erigon/eth.md
+++ b/docs/site/docs/interacting-with-erigon/eth.md
@@ -145,8 +145,21 @@ deviates from it in the return shape, which keeps the `raw` field the spec dropp
 
 The standard `type` field is ignored. `CallArgs` has no field for it and unknown JSON
 properties are accepted silently, so the envelope is inferred from whichever fee,
-access-list and blob fields are present. On a post-London head, `{"type": "0x0"}` with no
-`gasPrice` comes back as a type `0x2` transaction rather than the legacy type requested.
+access-list and blob fields are present. On a post-London head, a request such as
+
+```json
+{
+  "from": "0x71562b71999873db5b286df957af199ec94617f7",
+  "to": "0x0d3ab14bbad3d99f4203bd7a11acb94882050e7e",
+  "gas": "0x5208",
+  "type": "0x0"
+}
+```
+
+comes back as a type `0x2` transaction rather than the legacy type requested, because no
+`gasPrice` was supplied. The `to` field is not decoration: a fill with neither `to` nor
+contract-creation data fails with `contract creation without any data provided` before a
+transaction is built at all.
 
 **Fills in**
 
@@ -177,12 +190,18 @@ RLP only for a legacy transaction; a typed one is the EIP-2718 type byte followe
 encoded payload, and feeding that straight to an RLP decoder will fail. The standardized
 result carries only `tx`; the extra `raw` field is the geth-compatible shape.
 
-A typed result also carries `gasPrice: null`. `FillTransaction` passes no base fee to the
-response encoder, so `computeGasPrice` returns nothing and the missing key is filled with
-`null` — deliberate geth parity, pinned by `rpc/ethapi/api_test.go`. The standardized
-type-2 unsigned schema requires `gasPrice` to be a hex quantity, so a schema-validating
-client will reject the result; read `maxFeePerGas` and `maxPriorityFeePerGas` instead.
-Legacy results carry a real `gasPrice`.
+A dynamic-fee result — types `0x2`, `0x3` and `0x4` — also carries `gasPrice: null`.
+`FillTransaction` passes no base fee to the response encoder, so `computeGasPrice`
+returns nothing and the missing key is filled with `null` — deliberate geth parity,
+pinned by `rpc/ethapi/api_test.go`. The standardized type-2 unsigned schema requires
+`gasPrice` to be a hex quantity, so a schema-validating client will reject the result;
+read `maxFeePerGas` and `maxPriorityFeePerGas` instead.
+
+Legacy (`0x0`) and access-list (`0x1`) results are not affected: `NewRPCTransaction`
+takes their `gasPrice` from the tip cap, so it is a real hex quantity. Those two carry
+`maxFeePerGas: null` and `maxPriorityFeePerGas: null` instead, filled in by the same
+rule. A type `0x1` fill is reached by supplying `gasPrice` together with an
+`accessList` — Erigon keeps the list where geth drops it to a legacy transaction.
 
 :::info
 KZG commitment and proof generation from raw blobs is not implemented. Blob
@@ -200,7 +219,16 @@ themselves and reattach it before submitting.
 Erigon accepts more block-number forms than the standard schema, which allows only a
 `0x`-prefixed hex quantity string or a named tag.
 
-Accepted everywhere a block is selected:
+The rules below govern parameters decoded as `BlockNumber` or `BlockNumberOrHash` — the
+selector of `eth_getBlockByNumber`, `eth_getBalance`, `eth_call`, `trace_block` and the
+rest of that family. They do not apply to methods that select a block through a fixed
+`common.Hash` parameter: `eth_getBlockTransactionCountByHash`,
+`eth_getTransactionByBlockHashAndIndex`, `eth_getRawTransactionByBlockHashAndIndex`,
+`eth_getUncleByBlockHashAndIndex` and `eth_getUncleCountByBlockHash` take a 32-byte hash
+and nothing else. `eth_getBlockByHash` is not one of them — despite the name its
+parameter is a `BlockNumberOrHash`, so it follows the rules here.
+
+Accepted:
 
 * a `0x`-prefixed hex string without leading zeros — `"0x3"`, `"0x2ed119"`
 * a bare, unquoted JSON integer — `3`
@@ -218,7 +246,7 @@ Accepted everywhere a block is selected:
     `eth_getBlockReceipts`, `eth_getBlockAccessList`, `eth_simulateV1`, `eth_getWitness`,
     `eth_getTxWitness`, `eth_getBlockByHash` and `trace_replayBlockTransactions`
 
-Rejected everywhere:
+Rejected by both parameter types:
 
 * a quoted decimal string — `"3"`, `"100"`
 * a block number above `2^63-1` — out of range in both parameter types, though the error

--- a/docs/site/docs/interacting-with-erigon/eth.md
+++ b/docs/site/docs/interacting-with-erigon/eth.md
@@ -176,11 +176,13 @@ transaction is built at all.
 * `value` — `0` when absent
 * `gas` — from `eth_estimateGas` against `latest`
 * `chainId` — the node's chain ID; a mismatching supplied value is an error. It is used
-  for validation and carried by typed transactions, but it does not appear in the
-  returned `tx` for an unsigned legacy transaction: `CallArgs.ToTransaction` builds a
+  for validation and carried by every typed transaction, but it does not appear in the
+  returned `tx` when the fill infers legacy type `0x0`: `CallArgs.ToTransaction` builds a
   `LegacyTx` with no chain-ID field, and the response encoder skips chain-ID derivation
-  while `v` is zero. A pre-London fill, or a post-London fill supplying `gasPrice` with
-  no access list, therefore returns `tx` without `chainId`
+  while `v` is zero. That is the `default` arm of the type switch — reached only when
+  none of `authorizationList`, `blobVersionedHashes`, `maxFeePerGas` or `accessList` is
+  present. An `accessList` fill before London and a blob or authorization-list fill after
+  it are typed and carry `chainId`, even when `gasPrice` is supplied
 * fee fields — an explicitly supplied `gasPrice` is preserved, before or after London,
   though after London it must be non-zero (`gasPrice must be non-zero after london fork`);
   before London a zero is accepted. It cannot be combined with `maxFeePerGas` or
@@ -198,6 +200,17 @@ An object with `raw`, the unsigned transaction in its canonical binary encoding,
 RLP only for a legacy transaction; a typed one is the EIP-2718 type byte followed by the
 encoded payload, and feeding that straight to an RLP decoder will fail. The standardized
 result carries only `tx`; the extra `raw` field is the geth-compatible shape.
+
+`tx` also carries four fields the standardized unsigned schemas do not define. `v`, `r`
+and `s` are placeholders — `SignTransactionResult.MarshalJSON` writes `"0x0"` for each —
+and a typed result adds `yParity`, likewise `0x0`. Nothing is signed here, so none of
+them is a signature.
+
+:::warning
+The `hash` field is computed before signing and **changes once the transaction is
+signed**. It is not the hash the transaction will have when submitted, so it must not be
+used to track it. Take the hash from `eth_sendRawTransaction` instead.
+:::
 
 A dynamic-fee result — types `0x2`, `0x3` and `0x4` — also carries `gasPrice: null`.
 `FillTransaction` passes no base fee to the response encoder, so `computeGasPrice`

--- a/docs/site/docs/interacting-with-erigon/trace.md
+++ b/docs/site/docs/interacting-with-erigon/trace.md
@@ -151,7 +151,7 @@ A `TraceEntry` represents a single call frame (root call, internal call, contrac
 | `error` | String | (Optional) Present when the call frame errored. `"Reverted"` (title-cased) is the only special-cased value; all other errors are the verbatim Go error string, e.g. `"out of gas"`, `"invalid opcode: ..."`. For `"Reverted"`, `result` is still populated with `gasUsed` and `output` (or `code`/`address` for a `create` frame); for other errors, `result` is `null`. |
 | `subtraces` | QUANTITY | Number of direct child call frames produced by this frame. Used together with `traceAddress` to reconstruct the call tree from a flat list. |
 | `traceAddress` | Array of QUANTITY | Path to this frame inside the call tree. Empty array `[]` for the root call; `[0]` is the first child of the root; `[1, 0]` is the first child of the second child of the root, etc. |
-| `type` | String | One of `"call"`, `"create"`, `"suicide"` (self-destruct), `"reward"` (block or uncle reward — appears in `trace_block` and in `trace_filter` results when the filter matches block coinbases or uncle authors; `trace_block` alone also emits beacon-chain-withdrawal rewards, on request). |
+| `type` | String | One of `"call"`, `"create"`, `"suicide"` (self-destruct), `"reward"` (a consensus payout rather than a call — appears in `trace_block` and in `trace_filter` results when the filter matches block coinbases or uncle authors; `trace_block` alone also emits Aura block-reward-contract payouts and, on request, beacon-chain withdrawals. See `rewardType` for the full set). |
 | `blockHash` | DATA, 32 BYTES | (Only in block-level methods: `trace_block`, `trace_filter`, `trace_transaction`, `trace_get`) Hash of the block containing the transaction. |
 | `blockNumber` | QUANTITY | (Block-level methods only) Number of the block containing the transaction. |
 | `transactionHash` | DATA, 32 BYTES | (Block-level methods only) Hash of the transaction containing this call frame. Absent for `"reward"` entries. |
@@ -190,13 +190,13 @@ The `action` object's shape depends on `type`:
 | `refundAddress` | DATA, 20 BYTES | Address that received the contract's remaining balance. |
 | `balance` | QUANTITY | Wei amount transferred to `refundAddress`. |
 
-**`type: "reward"`** (block or uncle reward in `trace_block` and `trace_filter`; withdrawal reward in `trace_block` only)
+**`type: "reward"`** (block and uncle rewards in `trace_block` and `trace_filter`; Aura block-reward-contract and withdrawal rewards in `trace_block` only)
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `author` | DATA, 20 BYTES | Address receiving the reward — the miner, the uncle author, or the withdrawal recipient when `rewardType` is `"withdrawal"`. |
+| `author` | DATA, 20 BYTES | Address receiving the reward: the block author, the uncle author, the beneficiary named by the block-reward contract for `"external"` and `"emptyStep"`, or the withdrawal recipient for `"withdrawal"`. |
 | `value` | QUANTITY | Wei amount of the reward. |
-| `rewardType` | String | `"block"` or `"uncle"`. `trace_block` also emits `"withdrawal"` when `IncludeWithdrawals` is set; `trace_filter` never does — see [Beacon-chain withdrawals](#beacon-chain-withdrawals). |
+| `rewardType` | String | `trace_filter` emits only `"block"` and `"uncle"`. `trace_block` maps the consensus reward kind through `rewardKindToString`, so it can also return `"emptyStep"` and `"external"` on Aura chains such as Gnosis (a block-reward-contract payout), or `"unknown"` for an unrecognised kind; it additionally emits `"withdrawal"` when `IncludeWithdrawals` is set — see [Beacon-chain withdrawals](#beacon-chain-withdrawals). |
 
 ### Result variants
 

--- a/docs/site/docs/interacting-with-erigon/trace.md
+++ b/docs/site/docs/interacting-with-erigon/trace.md
@@ -441,8 +441,17 @@ Replays all transactions in a block returning the requested traces for each tran
 
 1. `Quantity`, `Tag`, `Data` or `Object` - A block-number-or-hash selector: an integer block number, a named tag such as `'earliest'`, `'latest'` or `'pending'`, a block hash, or the object form `{"blockNumber": ...}` / `{"blockHash": ...}`. Required — `null` is rejected. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
-3. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still replayed instead of failing the call.
+3. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still replayed instead of failing the call. It does more than bypass that check — see the warning below.
 4. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to have beacon-chain withdrawals reflected in the `stateDiff` output. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
+
+:::warning
+`gasBailOut` alters replayed state for **every** transaction, not only underfunded ones.
+`TxnExecutor.buyGas` skips the sender's gas and blob-fee deductions whenever it is set,
+the gas-refund path is skipped along with them, and the block producer's tip is still
+credited. The resulting `stateDiff`, and the state each later transaction in the block
+sees, therefore differ from a normal replay — do not use the output to reconstruct
+balances.
+:::
 
 ```js
 params: [
@@ -567,8 +576,17 @@ Returns traces created at given block.
 #### Parameters
 
 1. `Quantity`, `Tag` or `null` - A plain block number: an integer (hex string or bare JSON integer), a named tag (`'earliest'`, `'latest'`, `'pending'`, `'safe'`, `'finalized'`, or the Erigon-specific `'latestExecuted'`), or `null` / `"null"`, both of which mean `latest`. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
-2. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still traced instead of failing the replay — the OpenEthereum/Parity behaviour.
+2. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still traced instead of failing the replay — the OpenEthereum/Parity behaviour. It does more than bypass that check — see the warning below.
 3. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to append a `"reward"` entry per beacon-chain withdrawal. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
+
+:::warning
+`gasBailOut` alters replayed state for **every** transaction, not only underfunded ones.
+`TxnExecutor.buyGas` skips the sender's gas and blob-fee deductions whenever it is set,
+the gas-refund path is skipped along with them, and the block producer's tip is still
+credited. The resulting `stateDiff`, and the state each later transaction in the block
+sees, therefore differ from a normal replay — do not use the output to reconstruct
+balances.
+:::
 
 ```js
 params: [

--- a/docs/site/docs/interacting-with-erigon/trace.md
+++ b/docs/site/docs/interacting-with-erigon/trace.md
@@ -121,6 +121,11 @@ balances:
   non-zero `value`, the EVM-level bailout engages and `Transfer` skips the sender debit
   while still crediting the recipient. Value appears from nowhere, so a trace can show
   what looks like balance creation.
+* **On Gnosis and Chiado, the burn contract is credited too.** Where the chain
+  configures a `burntContract` — Gnosis and Chiado do, most chains do not — a London
+  transaction credits it `gasUsed * baseFee`, plus the blob fee on Aura from Prague. The
+  sender was never debited, so this is a second source of apparent balance creation in
+  `stateDiff` on those chains. Chains that simply burn the base fee are unaffected.
 :::
 
 Whether one transaction's altered state is visible to the next depends on the execution

--- a/docs/site/docs/interacting-with-erigon/trace.md
+++ b/docs/site/docs/interacting-with-erigon/trace.md
@@ -194,9 +194,9 @@ The `action` object's shape depends on `type`:
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `author` | DATA, 20 BYTES | Address receiving the reward: the block author, the uncle author, the beneficiary named by the block-reward contract for `"external"` and `"emptyStep"`, or the withdrawal recipient for `"withdrawal"`. |
+| `author` | DATA, 20 BYTES | Address receiving the reward: the block author, the uncle author, the beneficiary attributed by the block-reward contract for `"external"`, or the withdrawal recipient for `"withdrawal"`. |
 | `value` | QUANTITY | Wei amount of the reward. |
-| `rewardType` | String | `trace_filter` emits only `"block"` and `"uncle"`. `trace_block` maps the consensus reward kind through `rewardKindToString`, so it can also return `"emptyStep"` and `"external"` on Aura chains such as Gnosis (a block-reward-contract payout), or `"unknown"` for an unrecognised kind; it additionally emits `"withdrawal"` when `IncludeWithdrawals` is set — see [Beacon-chain withdrawals](#beacon-chain-withdrawals). |
+| `rewardType` | String | `trace_filter` emits only `"block"` and `"uncle"`. `trace_block` maps the consensus reward kind through `rewardKindToString`, so it also returns `"external"` for a block-reward-contract payout on Aura chains such as Gnosis, and emits `"withdrawal"` when `IncludeWithdrawals` is set — see [Beacon-chain withdrawals](#beacon-chain-withdrawals). That mapping additionally defines `"emptyStep"` (an AuthorityRound empty-step author) and `"unknown"`, but no current code path produces either. |
 
 ### Result variants
 

--- a/docs/site/docs/interacting-with-erigon/trace.md
+++ b/docs/site/docs/interacting-with-erigon/trace.md
@@ -93,8 +93,11 @@ reported. How they appear depends on the method:
 * **`trace_replayBlockTransactions`** has no block-level slot in its per-transaction
   result shape, so withdrawals surface only through `stateDiff`. You must request
   `"stateDiff"` in the trace types; when you do, one extra entry is appended to the
-  result array, containing only the withdrawal balance changes. Multiple withdrawals to
-  the same address are merged into a single balance change.
+  result array, carrying the withdrawal state changes. Its shape depends on whether the
+  recipient already existed: an existing account gets a `"*"` balance change with `code`
+  and `nonce` marked `"="`, while an account created by the withdrawal itself gets `"+"`
+  entries for `balance`, `code` (`"0x"`) and `nonce` (`"0x0"`). Storage is empty either
+  way. Multiple withdrawals to the same address are merged into a single balance change.
 
 ## JSON-RPC methods
 
@@ -148,7 +151,7 @@ A `TraceEntry` represents a single call frame (root call, internal call, contrac
 | `error` | String | (Optional) Present when the call frame errored. `"Reverted"` (title-cased) is the only special-cased value; all other errors are the verbatim Go error string, e.g. `"out of gas"`, `"invalid opcode: ..."`. For `"Reverted"`, `result` is still populated with `gasUsed` and `output` (or `code`/`address` for a `create` frame); for other errors, `result` is `null`. |
 | `subtraces` | QUANTITY | Number of direct child call frames produced by this frame. Used together with `traceAddress` to reconstruct the call tree from a flat list. |
 | `traceAddress` | Array of QUANTITY | Path to this frame inside the call tree. Empty array `[]` for the root call; `[0]` is the first child of the root; `[1, 0]` is the first child of the second child of the root, etc. |
-| `type` | String | One of `"call"`, `"create"`, `"suicide"` (self-destruct), `"reward"` (block/uncle reward — appears in `trace_block` and in `trace_filter` results when the filter matches block coinbases or uncle authors). |
+| `type` | String | One of `"call"`, `"create"`, `"suicide"` (self-destruct), `"reward"` (block, uncle or beacon-chain-withdrawal reward — appears in `trace_block` and in `trace_filter` results when the filter matches block coinbases, uncle authors or withdrawal recipients). |
 | `blockHash` | DATA, 32 BYTES | (Only in block-level methods: `trace_block`, `trace_filter`, `trace_transaction`, `trace_get`) Hash of the block containing the transaction. |
 | `blockNumber` | QUANTITY | (Block-level methods only) Number of the block containing the transaction. |
 | `transactionHash` | DATA, 32 BYTES | (Block-level methods only) Hash of the transaction containing this call frame. Absent for `"reward"` entries. |
@@ -187,11 +190,11 @@ The `action` object's shape depends on `type`:
 | `refundAddress` | DATA, 20 BYTES | Address that received the contract's remaining balance. |
 | `balance` | QUANTITY | Wei amount transferred to `refundAddress`. |
 
-**`type: "reward"`** (block/uncle reward, in `trace_block` and `trace_filter`)
+**`type: "reward"`** (block, uncle or withdrawal reward, in `trace_block` and `trace_filter`)
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `author` | DATA, 20 BYTES | Address receiving the reward (miner / uncle author). |
+| `author` | DATA, 20 BYTES | Address receiving the reward — the miner, the uncle author, or the withdrawal recipient when `rewardType` is `"withdrawal"`. |
 | `value` | QUANTITY | Wei amount of the reward. |
 | `rewardType` | String | `"block"` or `"uncle"`, and `"withdrawal"` when `IncludeWithdrawals` is set — see [Beacon-chain withdrawals](#beacon-chain-withdrawals). |
 
@@ -572,7 +575,7 @@ params: [
 
 #### Returns
 
-`Array<TraceEntry>` — flat list of all call frames in the block, including any `"reward"` entries for block/uncle rewards. Each entry includes block-level fields (`blockHash`, `blockNumber`, `transactionHash`, `transactionPosition`). See [Response Fields Reference](#response-fields-reference).
+`Array<TraceEntry>` — flat list of all call frames in the block, including any `"reward"` entries for block, uncle and (when requested) withdrawal rewards. Every entry carries `blockHash` and `blockNumber`; `transactionHash` and `transactionPosition` are present on transaction call frames but omitted from `"reward"` entries, which no transaction caused. See [Response Fields Reference](#response-fields-reference).
 
 #### Example
 

--- a/docs/site/docs/interacting-with-erigon/trace.md
+++ b/docs/site/docs/interacting-with-erigon/trace.md
@@ -115,7 +115,9 @@ balances:
 * **Gas and blob fees are never deducted.** `TxnExecutor.buyGas` skips both `SubBalance`
   calls whenever the flag is set, for *every* replayed transaction — funded senders
   included, not only underfunded ones.
-* **Refunds are skipped.** The gas-refund path is gated on `refunds && !gasBailout`.
+* **Refunds are skipped.** The gas-refund path is gated on `refunds && !gasBailout` — that
+  is the internal Go parameter, spelled with a lowercase `o`, not the JSON-RPC
+  `gasBailOut` this section documents.
 * **The producer is still paid.** The block producer's tip is credited as usual.
 * **An unaffordable value transfer is credited anyway.** When the sender cannot cover a
   non-zero `value`, the EVM-level bailout engages and `Transfer` skips the sender debit
@@ -481,7 +483,7 @@ Replays all transactions in a block returning the requested traces for each tran
 
 #### Parameters
 
-1. `Quantity`, `Tag`, `Data` or `Object` - A block-number-or-hash selector: an integer block number, a named tag such as `'earliest'`, `'latest'` or `'pending'`, a block hash, or the object form `{"blockNumber": ...}` / `{"blockHash": ...}`. Required — `null` is rejected. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
+1. `Quantity`, `Number`, `Tag`, `Data` or `Object` - A block-number-or-hash selector: a hex block number, a bare JSON integer (an Erigon extension — not a standard `QUANTITY`), a named tag such as `'earliest'`, `'latest'` or `'pending'`, a block hash, or the object form `{"blockNumber": ...}` / `{"blockHash": ...}`. Required — `null` is rejected. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
 3. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still replayed instead of failing the call. It does more than bypass that check — see [The gasBailOut option](#the-gasbailout-option).
 4. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to have beacon-chain withdrawals reflected in the `stateDiff` output. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
@@ -609,7 +611,7 @@ Returns traces created at given block.
 
 #### Parameters
 
-1. `Quantity`, `Tag` or `null` - A plain block number: an integer (hex string or bare JSON integer), a named tag (`'earliest'`, `'latest'`, `'pending'`, `'safe'`, `'finalized'`, or the Erigon-specific `'latestExecuted'`), or `null` / `"null"`, both of which mean `latest`. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
+1. `Quantity`, `Number`, `Tag` or `null` - A plain block number: a hex string, or a bare JSON integer as an Erigon extension (not a standard `QUANTITY`), a named tag (`'earliest'`, `'latest'`, `'pending'`, `'safe'`, `'finalized'`, or the Erigon-specific `'latestExecuted'`), or `null` / `"null"`, both of which mean `latest`. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
 2. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still traced instead of failing the replay — the OpenEthereum/Parity behaviour. It does more than bypass that check — see [The gasBailOut option](#the-gasbailout-option).
 3. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to append a `"reward"` entry per beacon-chain withdrawal. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
 

--- a/docs/site/docs/interacting-with-erigon/trace.md
+++ b/docs/site/docs/interacting-with-erigon/trace.md
@@ -123,7 +123,7 @@ All `trace_*` methods return objects built from the same set of fields. Each met
 | --- | --- |
 | `trace_call`, `trace_rawTransaction`, `trace_replayTransaction` | `Object` with `output`, `stateDiff`, `trace[]`, `vmTrace` |
 | `trace_callMany` | `Array<Object>` — one per input call |
-| `trace_replayBlockTransactions` | `Array<Object>` — one per transaction; each entry adds `transactionHash` |
+| `trace_replayBlockTransactions` | `Array<Object>` — one per transaction; each entry adds `transactionHash`. One extra trailing entry when withdrawals are requested — see [trace_replayBlockTransactions](#trace_replayblocktransactions) |
 | `trace_block`, `trace_filter`, `trace_transaction` | `Array<TraceEntry>` (flat list across all call frames) |
 | `trace_get` | `TraceEntry` (single call frame at the requested position) |
 
@@ -436,7 +436,7 @@ Replays all transactions in a block returning the requested traces for each tran
 
 #### Parameters
 
-1. `Quantity` or `Tag` - Integer of a block number, or the string `'earliest'`, `'latest'` or `'pending'`.
+1. `Quantity`, `Tag`, `Data` or `Object` - A block-number-or-hash selector: an integer block number, a named tag such as `'earliest'`, `'latest'` or `'pending'`, a block hash, or the object form `{"blockNumber": ...}` / `{"blockHash": ...}`. Required — `null` is rejected. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
 3. `Boolean` - Optional. `gasBailOut`.
 4. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to have beacon-chain withdrawals reflected in the `stateDiff` output. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
@@ -450,7 +450,15 @@ params: [
 
 #### Returns
 
-`Array<Object>` — one entry per transaction in the block. Each entry is shaped like the `trace_call` response plus a `transactionHash` field identifying the transaction. See [Response Fields Reference](#response-fields-reference).
+`Array<Object>` — by default one entry per transaction in the block (see below for the one exception). Each entry is shaped like the `trace_call` response plus a `transactionHash` field identifying the transaction. See [Response Fields Reference](#response-fields-reference).
+
+The one-entry-per-transaction mapping does not hold when withdrawals are requested.
+With `"stateDiff"` in the trace types and `"IncludeWithdrawals": true` in the trace
+settings, a block that has withdrawals gets **one extra entry appended** after the
+last transaction — an empty `trace` and a `stateDiff` carrying only the withdrawal
+balance changes, with no `transactionHash`. Consumers that index results positionally
+against the block's transaction list must skip that trailing entry. See [Beacon-chain
+withdrawals](#beacon-chain-withdrawals).
 
 #### Example
 

--- a/docs/site/docs/interacting-with-erigon/trace.md
+++ b/docs/site/docs/interacting-with-erigon/trace.md
@@ -69,10 +69,16 @@ then it should look something like:
 
 Beacon-chain withdrawals credit balances outside of any transaction, so by default no
 trace mentions them. `trace_block` and `trace_replayBlockTransactions` can be asked to
-include them by passing a trace-settings object as the last positional parameter:
+include them by passing a trace-settings object as the last positional parameter. It is
+positional, so the parameters before it have to be supplied even when they are not
+otherwise needed:
 
 ```js
-{ "IncludeWithdrawals": true }
+// trace_block(blockNumber, gasBailOut, traceSettings)
+["0x1194bf0", false, { "IncludeWithdrawals": true }]
+
+// trace_replayBlockTransactions(blockNumber, traceTypes, gasBailOut, traceSettings)
+["0x1194bf0", ["stateDiff"], false, { "IncludeWithdrawals": true }]
 ```
 
 The default is off — omit the object, or leave the field out, and withdrawals are not

--- a/docs/site/docs/interacting-with-erigon/trace.md
+++ b/docs/site/docs/interacting-with-erigon/trace.md
@@ -275,6 +275,7 @@ Executes the given call and returns a number of possible traces for it.
 1. `Object` - \[Transaction object] where `from` field is optional and `nonce` field is omitted.
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
 3. `Quantity` or `Tag` - (optional) Integer of a block number, or the string `'earliest'`, `'latest'` or `'pending'`.
+4. `Object` - Optional trace settings (`TraceConfig`), the same object the other `trace` methods accept.
 
 This method takes no `gasBailOut` parameter — it always replays with the bailout enabled. See [The gasBailOut option](#the-gasbailout-option).
 
@@ -325,6 +326,7 @@ Performs multiple call traces on top of the same block. i.e. transaction `n` wil
 
 1. `Array` - List of trace calls with the type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
 2. `Quantity` or `Tag` - (optional) integer block number, or the string `'latest'`, `'earliest'` or `'pending'` (default block parameter).
+3. `Object` - Optional trace settings (`TraceConfig`), the same object the other `trace` methods accept.
 
 This method takes no `gasBailOut` parameter — it always replays with the bailout enabled. See [The gasBailOut option](#the-gasbailout-option).
 

--- a/docs/site/docs/interacting-with-erigon/trace.md
+++ b/docs/site/docs/interacting-with-erigon/trace.md
@@ -65,6 +65,31 @@ then it should look something like:
 
 `[ {A: []}, {B: [0]}, {G: [0, 0]}, {C: [1]}, {G: [1, 0]} ]`
 
+## Beacon-chain withdrawals
+
+Beacon-chain withdrawals credit balances outside of any transaction, so by default no
+trace mentions them. `trace_block` and `trace_replayBlockTransactions` can be asked to
+include them by passing a trace-settings object as the last positional parameter:
+
+```js
+{ "IncludeWithdrawals": true }
+```
+
+The default is off — omit the object, or leave the field out, and withdrawals are not
+reported. How they appear depends on the method:
+
+* **`trace_block`** appends one entry per withdrawal to the flat trace list. Each is a
+  `"reward"` entry whose `action.rewardType` is `"withdrawal"`, with `action.author` set
+  to the withdrawal address and `action.value` to the amount **in wei** (the beacon chain
+  denominates withdrawals in Gwei). These entries carry no `transactionHash` or
+  `transactionPosition`, since no transaction caused them.
+
+* **`trace_replayBlockTransactions`** has no block-level slot in its per-transaction
+  result shape, so withdrawals surface only through `stateDiff`. You must request
+  `"stateDiff"` in the trace types; when you do, one extra entry is appended to the
+  result array, containing only the withdrawal balance changes. Multiple withdrawals to
+  the same address are merged into a single balance change.
+
 ## JSON-RPC methods
 
 #### Ad-hoc Tracing
@@ -407,6 +432,8 @@ Replays all transactions in a block returning the requested traces for each tran
 
 1. `Quantity` or `Tag` - Integer of a block number, or the string `'earliest'`, `'latest'` or `'pending'`.
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
+3. `Boolean` - Optional. `gasBailOut`.
+4. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to have beacon-chain withdrawals reflected in the `stateDiff` output. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
 
 ```js
 params: [
@@ -520,6 +547,8 @@ Returns traces created at given block.
 #### Parameters
 
 1. `Quantity` or `Tag` - Integer of a block number, or the string `'earliest'`, `'latest'` or `'pending'`.
+2. `Boolean` - Optional. `gasBailOut`.
+3. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to append a `"reward"` entry per beacon-chain withdrawal. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
 
 ```js
 params: [

--- a/docs/site/docs/interacting-with-erigon/trace.md
+++ b/docs/site/docs/interacting-with-erigon/trace.md
@@ -151,7 +151,7 @@ A `TraceEntry` represents a single call frame (root call, internal call, contrac
 | `error` | String | (Optional) Present when the call frame errored. `"Reverted"` (title-cased) is the only special-cased value; all other errors are the verbatim Go error string, e.g. `"out of gas"`, `"invalid opcode: ..."`. For `"Reverted"`, `result` is still populated with `gasUsed` and `output` (or `code`/`address` for a `create` frame); for other errors, `result` is `null`. |
 | `subtraces` | QUANTITY | Number of direct child call frames produced by this frame. Used together with `traceAddress` to reconstruct the call tree from a flat list. |
 | `traceAddress` | Array of QUANTITY | Path to this frame inside the call tree. Empty array `[]` for the root call; `[0]` is the first child of the root; `[1, 0]` is the first child of the second child of the root, etc. |
-| `type` | String | One of `"call"`, `"create"`, `"suicide"` (self-destruct), `"reward"` (block, uncle or beacon-chain-withdrawal reward — appears in `trace_block` and in `trace_filter` results when the filter matches block coinbases, uncle authors or withdrawal recipients). |
+| `type` | String | One of `"call"`, `"create"`, `"suicide"` (self-destruct), `"reward"` (block or uncle reward — appears in `trace_block` and in `trace_filter` results when the filter matches block coinbases or uncle authors; `trace_block` alone also emits beacon-chain-withdrawal rewards, on request). |
 | `blockHash` | DATA, 32 BYTES | (Only in block-level methods: `trace_block`, `trace_filter`, `trace_transaction`, `trace_get`) Hash of the block containing the transaction. |
 | `blockNumber` | QUANTITY | (Block-level methods only) Number of the block containing the transaction. |
 | `transactionHash` | DATA, 32 BYTES | (Block-level methods only) Hash of the transaction containing this call frame. Absent for `"reward"` entries. |
@@ -190,13 +190,13 @@ The `action` object's shape depends on `type`:
 | `refundAddress` | DATA, 20 BYTES | Address that received the contract's remaining balance. |
 | `balance` | QUANTITY | Wei amount transferred to `refundAddress`. |
 
-**`type: "reward"`** (block, uncle or withdrawal reward, in `trace_block` and `trace_filter`)
+**`type: "reward"`** (block or uncle reward in `trace_block` and `trace_filter`; withdrawal reward in `trace_block` only)
 
 | Field | Type | Description |
 | --- | --- | --- |
 | `author` | DATA, 20 BYTES | Address receiving the reward — the miner, the uncle author, or the withdrawal recipient when `rewardType` is `"withdrawal"`. |
 | `value` | QUANTITY | Wei amount of the reward. |
-| `rewardType` | String | `"block"` or `"uncle"`, and `"withdrawal"` when `IncludeWithdrawals` is set — see [Beacon-chain withdrawals](#beacon-chain-withdrawals). |
+| `rewardType` | String | `"block"` or `"uncle"`. `trace_block` also emits `"withdrawal"` when `IncludeWithdrawals` is set; `trace_filter` never does — see [Beacon-chain withdrawals](#beacon-chain-withdrawals). |
 
 ### Result variants
 
@@ -458,8 +458,11 @@ params: [
 The one-entry-per-transaction mapping does not hold when withdrawals are requested.
 With `"stateDiff"` in the trace types and `"IncludeWithdrawals": true` in the trace
 settings, a block that has withdrawals gets **one extra entry appended** after the
-last transaction — an empty `trace` and a `stateDiff` carrying only the withdrawal
-balance changes, with no `transactionHash`. Consumers that index results positionally
+last transaction — an empty `trace` and a `stateDiff` carrying only the withdrawal state
+changes, with no `transactionHash`. That diff is a balance change alone only when the
+recipient already existed; a recipient created by the withdrawal also gets `code` and
+`nonce` entries, as described under [Beacon-chain withdrawals](#beacon-chain-withdrawals).
+Consumers that index results positionally
 against the block's transaction list must skip that trailing entry. See [Beacon-chain
 withdrawals](#beacon-chain-withdrawals).
 

--- a/docs/site/docs/interacting-with-erigon/trace.md
+++ b/docs/site/docs/interacting-with-erigon/trace.md
@@ -99,6 +99,37 @@ reported. How they appear depends on the method:
   entries for `balance`, `code` (`"0x"`) and `nonce` (`"0x0"`). Storage is empty either
   way. Multiple withdrawals to the same address are merged into a single balance change.
 
+## The gasBailOut option
+
+`gasBailOut` relaxes the balance rules during replay. It is exposed as a parameter by
+`trace_replayBlockTransactions`, `trace_replayTransaction`, `trace_block`,
+`trace_transaction`, `trace_get` and `trace_filter`, defaulting to `false` in each.
+`trace_call`, `trace_callMany` and `trace_rawTransaction` take no such parameter and
+always enable it internally, so everything below applies to them unconditionally.
+
+:::warning
+`gasBailOut` is not only a bypass for senders who cannot afford the gas charge. It
+changes replayed state in ways that make the output unsuitable for reconstructing
+balances:
+
+* **Gas and blob fees are never deducted.** `TxnExecutor.buyGas` skips both `SubBalance`
+  calls whenever the flag is set, for *every* replayed transaction — funded senders
+  included, not only underfunded ones.
+* **Refunds are skipped.** The gas-refund path is gated on `refunds && !gasBailout`.
+* **The producer is still paid.** The block producer's tip is credited as usual.
+* **An unaffordable value transfer is credited anyway.** When the sender cannot cover a
+  non-zero `value`, the EVM-level bailout engages and `Transfer` skips the sender debit
+  while still crediting the recipient. Value appears from nowhere, so a trace can show
+  what looks like balance creation.
+:::
+
+Whether one transaction's altered state is visible to the next depends on the execution
+path. Replaying a historical block for traces alone runs each transaction in parallel
+against its own canonical pre-state, so nothing propagates. The sequential path — taken
+when `stateDiff` or `vmTrace` is requested, for Bor state-sync transactions, and for
+single-transaction blocks — carries the altered state forward to every later transaction
+in the block.
+
 ## JSON-RPC methods
 
 #### Ad-hoc Tracing
@@ -235,6 +266,8 @@ Executes the given call and returns a number of possible traces for it.
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
 3. `Quantity` or `Tag` - (optional) Integer of a block number, or the string `'earliest'`, `'latest'` or `'pending'`.
 
+This method takes no `gasBailOut` parameter — it always replays with the bailout enabled. See [The gasBailOut option](#the-gasbailout-option).
+
 #### Returns
 
 `Object` containing `output`, `stateDiff`, `trace[]`, `vmTrace`. Each requested trace type is populated; the others are `null`. See [Response Fields Reference](#response-fields-reference) for full field semantics.
@@ -282,6 +315,8 @@ Performs multiple call traces on top of the same block. i.e. transaction `n` wil
 
 1. `Array` - List of trace calls with the type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
 2. `Quantity` or `Tag` - (optional) integer block number, or the string `'latest'`, `'earliest'` or `'pending'` (default block parameter).
+
+This method takes no `gasBailOut` parameter — it always replays with the bailout enabled. See [The gasBailOut option](#the-gasbailout-option).
 
 ```js
 params: [
@@ -386,6 +421,8 @@ Traces a call to `eth_sendRawTransaction` without making the call, returning the
 1. `Data` - Raw transaction data.
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
 
+This method takes no `gasBailOut` parameter — it always replays with the bailout enabled. See [The gasBailOut option](#the-gasbailout-option).
+
 ```js
 params: [
   "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675",
@@ -441,17 +478,8 @@ Replays all transactions in a block returning the requested traces for each tran
 
 1. `Quantity`, `Tag`, `Data` or `Object` - A block-number-or-hash selector: an integer block number, a named tag such as `'earliest'`, `'latest'` or `'pending'`, a block hash, or the object form `{"blockNumber": ...}` / `{"blockHash": ...}`. Required — `null` is rejected. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
-3. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still replayed instead of failing the call. It does more than bypass that check — see the warning below.
+3. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still replayed instead of failing the call. It does more than bypass that check — see [The gasBailOut option](#the-gasbailout-option).
 4. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to have beacon-chain withdrawals reflected in the `stateDiff` output. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
-
-:::warning
-`gasBailOut` alters replayed state for **every** transaction, not only underfunded ones.
-`TxnExecutor.buyGas` skips the sender's gas and blob-fee deductions whenever it is set,
-the gas-refund path is skipped along with them, and the block producer's tip is still
-credited. The resulting `stateDiff`, and the state each later transaction in the block
-sees, therefore differ from a normal replay — do not use the output to reconstruct
-balances.
-:::
 
 ```js
 params: [
@@ -522,6 +550,7 @@ Replays a transaction, returning the traces.
 
 1. `Hash` - Transaction hash.
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
+3. `Boolean` - Optional, default `false`. `gasBailOut`. See [The gasBailOut option](#the-gasbailout-option).
 
 ```js
 params: [
@@ -576,17 +605,8 @@ Returns traces created at given block.
 #### Parameters
 
 1. `Quantity`, `Tag` or `null` - A plain block number: an integer (hex string or bare JSON integer), a named tag (`'earliest'`, `'latest'`, `'pending'`, `'safe'`, `'finalized'`, or the Erigon-specific `'latestExecuted'`), or `null` / `"null"`, both of which mean `latest`. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
-2. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still traced instead of failing the replay — the OpenEthereum/Parity behaviour. It does more than bypass that check — see the warning below.
+2. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still traced instead of failing the replay — the OpenEthereum/Parity behaviour. It does more than bypass that check — see [The gasBailOut option](#the-gasbailout-option).
 3. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to append a `"reward"` entry per beacon-chain withdrawal. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
-
-:::warning
-`gasBailOut` alters replayed state for **every** transaction, not only underfunded ones.
-`TxnExecutor.buyGas` skips the sender's gas and blob-fee deductions whenever it is set,
-the gas-refund path is skipped along with them, and the block producer's tip is still
-credited. The resulting `stateDiff`, and the state each later transaction in the block
-sees, therefore differ from a normal replay — do not use the output to reconstruct
-balances.
-:::
 
 ```js
 params: [
@@ -656,6 +676,7 @@ Returns traces matching given filter
    * `after`: `Quantity` - (optional) The offset trace number
    * `count`: `Quantity` - (optional) Integer number of traces to display in a batch.
    * `mode`: `String` - (optional) Default is `"union"`, meaning traces matching either address filter are returned. Set to `"intersection"` to only return traces that satisfy both `fromAddress` and `toAddress` filters simultaneously.
+2. `Boolean` - Optional, default `false`. `gasBailOut`. See [The gasBailOut option](#the-gasbailout-option).
 
 
 ```js
@@ -670,7 +691,7 @@ params: [{
 
 #### Returns
 
-`Array<TraceEntry>` — flat list of call frames that match the filter, including any `"reward"` entries when the filter matches block coinbases or uncle authors. Each entry has block-level fields (`blockHash`, `blockNumber`, `transactionHash`, `transactionPosition`). See [Response Fields Reference](#response-fields-reference).
+`Array<TraceEntry>` — flat list of call frames that match the filter, including any `"reward"` entries when the filter matches block coinbases or uncle authors. Call frames carry `blockHash`, `blockNumber`, `transactionHash` and `transactionPosition`; `"reward"` entries are block-level and carry only `blockHash` and `blockNumber` — `newRewardTrace` sets no transaction fields at all. See [Response Fields Reference](#response-fields-reference).
 
 #### Example
 
@@ -724,6 +745,7 @@ Returns trace at given position.
 
 1. `Hash` - Transaction hash.
 2. `Array` - Index positions of the traces.
+3. `Boolean` - Optional, default `false`. `gasBailOut`. See [The gasBailOut option](#the-gasbailout-option).
 
 ```js
 params: [
@@ -786,6 +808,7 @@ Returns all traces of given transaction
 #### Parameters
 
 1. `Hash` - Transaction hash
+2. `Boolean` - Optional, default `false`. `gasBailOut`. See [The gasBailOut option](#the-gasbailout-option).
 
 ```js
 params: ["0x17104ac9d3312d8c136b7f44d4b8b47852618065ebfa534bd2d3b5ef218ca1f3"]

--- a/docs/site/docs/interacting-with-erigon/trace.md
+++ b/docs/site/docs/interacting-with-erigon/trace.md
@@ -123,14 +123,15 @@ balances:
   non-zero `value`, the EVM-level bailout engages and `Transfer` skips the sender debit
   while still crediting the recipient. Value appears from nowhere, so a trace can show
   what looks like balance creation.
-* **On Gnosis and Chiado, the burn contract is credited too.** Where the chain
-  configures a `burntContract` — Gnosis and Chiado do, most chains do not — a **non-free**
-  London transaction credits it `gasUsed * baseFee`, plus the blob fee on Aura from
-  Prague. The sender was never debited, so this is a second source of apparent balance
-  creation in `stateDiff` on those chains. Aura marks zero-fee certified service
-  transactions as free, and the credit is guarded by `!msg.IsFree()`, so those are
-  excluded. Chains that simply burn the base fee never receive this extra credit — every
-  other effect above still applies to them.
+* **Where the chain configures a burn contract, that contract is credited too.** A
+  **non-free** London transaction credits the configured `burntContract` with
+  `gasUsed * baseFee`; on Aura from Prague the blob fee is added on top. Gnosis and
+  Chiado configure one, and so do Polygon's Bor chains — mainnet, Amoy, Mumbai and the
+  devnet. The sender was never debited, so this is a second source of apparent balance
+  creation in `stateDiff`. Aura marks zero-fee certified service transactions as free
+  and the credit is guarded by `!msg.IsFree()`, so those are excluded. Chains with no
+  configured contract never receive this extra credit — every other effect above still
+  applies to them.
 :::
 
 Whether one transaction's altered state is visible to the next depends on the execution

--- a/docs/site/docs/interacting-with-erigon/trace.md
+++ b/docs/site/docs/interacting-with-erigon/trace.md
@@ -124,10 +124,13 @@ balances:
   while still crediting the recipient. Value appears from nowhere, so a trace can show
   what looks like balance creation.
 * **On Gnosis and Chiado, the burn contract is credited too.** Where the chain
-  configures a `burntContract` — Gnosis and Chiado do, most chains do not — a London
-  transaction credits it `gasUsed * baseFee`, plus the blob fee on Aura from Prague. The
-  sender was never debited, so this is a second source of apparent balance creation in
-  `stateDiff` on those chains. Chains that simply burn the base fee are unaffected.
+  configures a `burntContract` — Gnosis and Chiado do, most chains do not — a **non-free**
+  London transaction credits it `gasUsed * baseFee`, plus the blob fee on Aura from
+  Prague. The sender was never debited, so this is a second source of apparent balance
+  creation in `stateDiff` on those chains. Aura marks zero-fee certified service
+  transactions as free, and the credit is guarded by `!msg.IsFree()`, so those are
+  excluded. Chains that simply burn the base fee never receive this extra credit — every
+  other effect above still applies to them.
 :::
 
 Whether one transaction's altered state is visible to the next depends on the execution
@@ -558,6 +561,7 @@ Replays a transaction, returning the traces.
 1. `Hash` - Transaction hash.
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
 3. `Boolean` - Optional, default `false`. `gasBailOut`. See [The gasBailOut option](#the-gasbailout-option).
+4. `Object` - Optional trace settings (`TraceConfig`), the same object the other `trace` methods accept.
 
 ```js
 params: [
@@ -684,6 +688,7 @@ Returns traces matching given filter
    * `count`: `Quantity` - (optional) Integer number of traces to display in a batch.
    * `mode`: `String` - (optional) Default is `"union"`, meaning traces matching either address filter are returned. Set to `"intersection"` to only return traces that satisfy both `fromAddress` and `toAddress` filters simultaneously.
 2. `Boolean` - Optional, default `false`. `gasBailOut`. See [The gasBailOut option](#the-gasbailout-option).
+3. `Object` - Optional trace settings (`TraceConfig`), the same object the other `trace` methods accept.
 
 
 ```js
@@ -753,6 +758,7 @@ Returns trace at given position.
 1. `Hash` - Transaction hash.
 2. `Array` - Index positions of the traces.
 3. `Boolean` - Optional, default `false`. `gasBailOut`. See [The gasBailOut option](#the-gasbailout-option).
+4. `Object` - Optional trace settings (`TraceConfig`), the same object the other `trace` methods accept.
 
 ```js
 params: [
@@ -816,6 +822,7 @@ Returns all traces of given transaction
 
 1. `Hash` - Transaction hash
 2. `Boolean` - Optional, default `false`. `gasBailOut`. See [The gasBailOut option](#the-gasbailout-option).
+3. `Object` - Optional trace settings (`TraceConfig`), the same object the other `trace` methods accept.
 
 ```js
 params: ["0x17104ac9d3312d8c136b7f44d4b8b47852618065ebfa534bd2d3b5ef218ca1f3"]

--- a/docs/site/docs/interacting-with-erigon/trace.md
+++ b/docs/site/docs/interacting-with-erigon/trace.md
@@ -123,7 +123,7 @@ All `trace_*` methods return objects built from the same set of fields. Each met
 | --- | --- |
 | `trace_call`, `trace_rawTransaction`, `trace_replayTransaction` | `Object` with `output`, `stateDiff`, `trace[]`, `vmTrace` |
 | `trace_callMany` | `Array<Object>` — one per input call |
-| `trace_replayBlockTransactions` | `Array<Object>` — one per transaction; each entry adds `transactionHash`. One extra trailing entry when withdrawals are requested — see [trace_replayBlockTransactions](#trace_replayblocktransactions) |
+| `trace_replayBlockTransactions` | `Array<Object>` — one per transaction; each entry adds `transactionHash`. One extra trailing entry when `stateDiff` is requested with `"IncludeWithdrawals": true` and the block has withdrawals — see [trace_replayBlockTransactions](#trace_replayblocktransactions) |
 | `trace_block`, `trace_filter`, `trace_transaction` | `Array<TraceEntry>` (flat list across all call frames) |
 | `trace_get` | `TraceEntry` (single call frame at the requested position) |
 

--- a/docs/site/docs/interacting-with-erigon/trace.md
+++ b/docs/site/docs/interacting-with-erigon/trace.md
@@ -193,7 +193,7 @@ The `action` object's shape depends on `type`:
 | --- | --- | --- |
 | `author` | DATA, 20 BYTES | Address receiving the reward (miner / uncle author). |
 | `value` | QUANTITY | Wei amount of the reward. |
-| `rewardType` | String | `"block"` or `"uncle"`. |
+| `rewardType` | String | `"block"` or `"uncle"`, and `"withdrawal"` when `IncludeWithdrawals` is set — see [Beacon-chain withdrawals](#beacon-chain-withdrawals). |
 
 ### Result variants
 
@@ -438,7 +438,7 @@ Replays all transactions in a block returning the requested traces for each tran
 
 1. `Quantity`, `Tag`, `Data` or `Object` - A block-number-or-hash selector: an integer block number, a named tag such as `'earliest'`, `'latest'` or `'pending'`, a block hash, or the object form `{"blockNumber": ...}` / `{"blockHash": ...}`. Required — `null` is rejected. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
-3. `Boolean` - Optional. `gasBailOut`.
+3. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still replayed instead of failing the call.
 4. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to have beacon-chain withdrawals reflected in the `stateDiff` output. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
 
 ```js
@@ -560,8 +560,8 @@ Returns traces created at given block.
 
 #### Parameters
 
-1. `Quantity` or `Tag` - Integer of a block number, or the string `'earliest'`, `'latest'` or `'pending'`.
-2. `Boolean` - Optional. `gasBailOut`.
+1. `Quantity`, `Tag` or `null` - A plain block number: an integer (hex string or bare JSON integer), a named tag (`'earliest'`, `'latest'`, `'pending'`, `'safe'`, `'finalized'`, or the Erigon-specific `'latestExecuted'`), or `null` / `"null"`, both of which mean `latest`. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
+2. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still traced instead of failing the replay — the OpenEthereum/Parity behaviour.
 3. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to append a `"reward"` entry per beacon-chain withdrawal. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
 
 ```js

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -5075,7 +5075,10 @@ deviates from it in the return shape, which keeps the `raw` field the spec dropp
   while `v` is zero. A pre-London fill, or a post-London fill supplying `gasPrice` with
   no access list, therefore returns `tx` without `chainId`
 * fee fields — an explicitly supplied `gasPrice` is preserved, before or after London,
-  and cannot be combined with `maxFeePerGas` or `maxPriorityFeePerGas`. When it is absent:
+  though after London it must be non-zero (`gasPrice must be non-zero after london fork`);
+  before London a zero is accepted. It cannot be combined with `maxFeePerGas` or
+  `maxPriorityFeePerGas`, and a supplied pair must satisfy `maxFeePerGas` non-zero and
+  `>= maxPriorityFeePerGas`. When `gasPrice` is absent:
   before London `gasPrice` comes from the gas oracle; after London the dynamic fields are
   filled independently, `maxPriorityFeePerGas` from the oracle and `maxFeePerGas` as twice
   the base fee plus the tip. The dynamic fields are rejected before London
@@ -5083,13 +5086,21 @@ deviates from it in the return shape, which keeps the `raw` field the spec dropp
 
 **Returns**
 
-An object with `raw`, the RLP-encoded unsigned transaction, and `tx`, the same
-transaction in JSON form. The standardized result carries only `tx`; the extra `raw`
-field is the geth-compatible shape.
+An object with `raw`, the unsigned transaction in its canonical binary encoding, and
+`tx`, the same transaction in JSON form. `raw` comes from `MarshalBinary`, so it is bare
+RLP only for a legacy transaction; a typed one is the EIP-2718 type byte followed by the
+encoded payload, and feeding that straight to an RLP decoder will fail. The standardized
+result carries only `tx`; the extra `raw` field is the geth-compatible shape.
 
 :::info
 KZG commitment and proof generation from raw blobs is not implemented. Blob
 transactions must already carry their `blobVersionedHashes`.
+
+The sidecar fields the specification defines — `blobs`, `commitments` and `proofs` — are
+not supported: `CallArgs` has no field for them, so they are dropped from the request
+without an error even when a complete precomputed sidecar is supplied, and they are
+absent from the returned `tx` and `raw`. Callers that need the sidecar must keep it
+themselves and reattach it before submitting.
 :::
 
 ### Block number parameter format
@@ -6145,7 +6156,7 @@ A `TraceEntry` represents a single call frame (root call, internal call, contrac
 | `error` | String | (Optional) Present when the call frame errored. `"Reverted"` (title-cased) is the only special-cased value; all other errors are the verbatim Go error string, e.g. `"out of gas"`, `"invalid opcode: ..."`. For `"Reverted"`, `result` is still populated with `gasUsed` and `output` (or `code`/`address` for a `create` frame); for other errors, `result` is `null`. |
 | `subtraces` | QUANTITY | Number of direct child call frames produced by this frame. Used together with `traceAddress` to reconstruct the call tree from a flat list. |
 | `traceAddress` | Array of QUANTITY | Path to this frame inside the call tree. Empty array `[]` for the root call; `[0]` is the first child of the root; `[1, 0]` is the first child of the second child of the root, etc. |
-| `type` | String | One of `"call"`, `"create"`, `"suicide"` (self-destruct), `"reward"` (block or uncle reward — appears in `trace_block` and in `trace_filter` results when the filter matches block coinbases or uncle authors; `trace_block` alone also emits beacon-chain-withdrawal rewards, on request). |
+| `type` | String | One of `"call"`, `"create"`, `"suicide"` (self-destruct), `"reward"` (a consensus payout rather than a call — appears in `trace_block` and in `trace_filter` results when the filter matches block coinbases or uncle authors; `trace_block` alone also emits Aura block-reward-contract payouts and, on request, beacon-chain withdrawals. See `rewardType` for the full set). |
 | `blockHash` | DATA, 32 BYTES | (Only in block-level methods: `trace_block`, `trace_filter`, `trace_transaction`, `trace_get`) Hash of the block containing the transaction. |
 | `blockNumber` | QUANTITY | (Block-level methods only) Number of the block containing the transaction. |
 | `transactionHash` | DATA, 32 BYTES | (Block-level methods only) Hash of the transaction containing this call frame. Absent for `"reward"` entries. |
@@ -6184,13 +6195,13 @@ The `action` object's shape depends on `type`:
 | `refundAddress` | DATA, 20 BYTES | Address that received the contract's remaining balance. |
 | `balance` | QUANTITY | Wei amount transferred to `refundAddress`. |
 
-**`type: "reward"`** (block or uncle reward in `trace_block` and `trace_filter`; withdrawal reward in `trace_block` only)
+**`type: "reward"`** (block and uncle rewards in `trace_block` and `trace_filter`; Aura block-reward-contract and withdrawal rewards in `trace_block` only)
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `author` | DATA, 20 BYTES | Address receiving the reward — the miner, the uncle author, or the withdrawal recipient when `rewardType` is `"withdrawal"`. |
+| `author` | DATA, 20 BYTES | Address receiving the reward: the block author, the uncle author, the beneficiary named by the block-reward contract for `"external"` and `"emptyStep"`, or the withdrawal recipient for `"withdrawal"`. |
 | `value` | QUANTITY | Wei amount of the reward. |
-| `rewardType` | String | `"block"` or `"uncle"`. `trace_block` also emits `"withdrawal"` when `IncludeWithdrawals` is set; `trace_filter` never does — see [Beacon-chain withdrawals](#beacon-chain-withdrawals). |
+| `rewardType` | String | `trace_filter` emits only `"block"` and `"uncle"`. `trace_block` maps the consensus reward kind through `rewardKindToString`, so it can also return `"emptyStep"` and `"external"` on Aura chains such as Gnosis (a block-reward-contract payout), or `"unknown"` for an unrecognised kind; it additionally emits `"withdrawal"` when `IncludeWithdrawals` is set — see [Beacon-chain withdrawals](#beacon-chain-withdrawals). |
 
 ### Result variants
 

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -6166,6 +6166,37 @@ reported. How they appear depends on the method:
   entries for `balance`, `code` (`"0x"`) and `nonce` (`"0x0"`). Storage is empty either
   way. Multiple withdrawals to the same address are merged into a single balance change.
 
+## The gasBailOut option
+
+`gasBailOut` relaxes the balance rules during replay. It is exposed as a parameter by
+`trace_replayBlockTransactions`, `trace_replayTransaction`, `trace_block`,
+`trace_transaction`, `trace_get` and `trace_filter`, defaulting to `false` in each.
+`trace_call`, `trace_callMany` and `trace_rawTransaction` take no such parameter and
+always enable it internally, so everything below applies to them unconditionally.
+
+:::warning
+`gasBailOut` is not only a bypass for senders who cannot afford the gas charge. It
+changes replayed state in ways that make the output unsuitable for reconstructing
+balances:
+
+* **Gas and blob fees are never deducted.** `TxnExecutor.buyGas` skips both `SubBalance`
+  calls whenever the flag is set, for *every* replayed transaction — funded senders
+  included, not only underfunded ones.
+* **Refunds are skipped.** The gas-refund path is gated on `refunds && !gasBailout`.
+* **The producer is still paid.** The block producer's tip is credited as usual.
+* **An unaffordable value transfer is credited anyway.** When the sender cannot cover a
+  non-zero `value`, the EVM-level bailout engages and `Transfer` skips the sender debit
+  while still crediting the recipient. Value appears from nowhere, so a trace can show
+  what looks like balance creation.
+:::
+
+Whether one transaction's altered state is visible to the next depends on the execution
+path. Replaying a historical block for traces alone runs each transaction in parallel
+against its own canonical pre-state, so nothing propagates. The sequential path — taken
+when `stateDiff` or `vmTrace` is requested, for Bor state-sync transactions, and for
+single-transaction blocks — carries the altered state forward to every later transaction
+in the block.
+
 ## JSON-RPC methods
 
 #### Ad-hoc Tracing
@@ -6302,6 +6333,8 @@ Executes the given call and returns a number of possible traces for it.
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
 3. `Quantity` or `Tag` - (optional) Integer of a block number, or the string `'earliest'`, `'latest'` or `'pending'`.
 
+This method takes no `gasBailOut` parameter — it always replays with the bailout enabled. See [The gasBailOut option](#the-gasbailout-option).
+
 #### Returns
 
 `Object` containing `output`, `stateDiff`, `trace[]`, `vmTrace`. Each requested trace type is populated; the others are `null`. See [Response Fields Reference](#response-fields-reference) for full field semantics.
@@ -6348,6 +6381,8 @@ Performs multiple call traces on top of the same block. i.e. transaction `n` wil
 
 1. `Array` - List of trace calls with the type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
 2. `Quantity` or `Tag` - (optional) integer block number, or the string `'latest'`, `'earliest'` or `'pending'` (default block parameter).
+
+This method takes no `gasBailOut` parameter — it always replays with the bailout enabled. See [The gasBailOut option](#the-gasbailout-option).
 
 ```js
 params: [
@@ -6451,6 +6486,8 @@ Traces a call to `eth_sendRawTransaction` without making the call, returning the
 1. `Data` - Raw transaction data.
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
 
+This method takes no `gasBailOut` parameter — it always replays with the bailout enabled. See [The gasBailOut option](#the-gasbailout-option).
+
 ```js
 params: [
   "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675",
@@ -6504,17 +6541,8 @@ Replays all transactions in a block returning the requested traces for each tran
 
 1. `Quantity`, `Tag`, `Data` or `Object` - A block-number-or-hash selector: an integer block number, a named tag such as `'earliest'`, `'latest'` or `'pending'`, a block hash, or the object form `{"blockNumber": ...}` / `{"blockHash": ...}`. Required — `null` is rejected. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
-3. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still replayed instead of failing the call. It does more than bypass that check — see the warning below.
+3. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still replayed instead of failing the call. It does more than bypass that check — see [The gasBailOut option](#the-gasbailout-option).
 4. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to have beacon-chain withdrawals reflected in the `stateDiff` output. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
-
-:::warning
-`gasBailOut` alters replayed state for **every** transaction, not only underfunded ones.
-`TxnExecutor.buyGas` skips the sender's gas and blob-fee deductions whenever it is set,
-the gas-refund path is skipped along with them, and the block producer's tip is still
-credited. The resulting `stateDiff`, and the state each later transaction in the block
-sees, therefore differ from a normal replay — do not use the output to reconstruct
-balances.
-:::
 
 ```js
 params: [
@@ -6584,6 +6612,7 @@ Replays a transaction, returning the traces.
 
 1. `Hash` - Transaction hash.
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
+3. `Boolean` - Optional, default `false`. `gasBailOut`. See [The gasBailOut option](#the-gasbailout-option).
 
 ```js
 params: [
@@ -6637,17 +6666,8 @@ Returns traces created at given block.
 #### Parameters
 
 1. `Quantity`, `Tag` or `null` - A plain block number: an integer (hex string or bare JSON integer), a named tag (`'earliest'`, `'latest'`, `'pending'`, `'safe'`, `'finalized'`, or the Erigon-specific `'latestExecuted'`), or `null` / `"null"`, both of which mean `latest`. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
-2. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still traced instead of failing the replay — the OpenEthereum/Parity behaviour. It does more than bypass that check — see the warning below.
+2. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still traced instead of failing the replay — the OpenEthereum/Parity behaviour. It does more than bypass that check — see [The gasBailOut option](#the-gasbailout-option).
 3. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to append a `"reward"` entry per beacon-chain withdrawal. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
-
-:::warning
-`gasBailOut` alters replayed state for **every** transaction, not only underfunded ones.
-`TxnExecutor.buyGas` skips the sender's gas and blob-fee deductions whenever it is set,
-the gas-refund path is skipped along with them, and the block producer's tip is still
-credited. The resulting `stateDiff`, and the state each later transaction in the block
-sees, therefore differ from a normal replay — do not use the output to reconstruct
-balances.
-:::
 
 ```js
 params: [
@@ -6716,6 +6736,7 @@ Returns traces matching given filter
    * `after`: `Quantity` - (optional) The offset trace number
    * `count`: `Quantity` - (optional) Integer number of traces to display in a batch.
    * `mode`: `String` - (optional) Default is `"union"`, meaning traces matching either address filter are returned. Set to `"intersection"` to only return traces that satisfy both `fromAddress` and `toAddress` filters simultaneously.
+2. `Boolean` - Optional, default `false`. `gasBailOut`. See [The gasBailOut option](#the-gasbailout-option).
 
 ```js
 params: [{
@@ -6729,7 +6750,7 @@ params: [{
 
 #### Returns
 
-`Array` — flat list of call frames that match the filter, including any `"reward"` entries when the filter matches block coinbases or uncle authors. Each entry has block-level fields (`blockHash`, `blockNumber`, `transactionHash`, `transactionPosition`). See [Response Fields Reference](#response-fields-reference).
+`Array` — flat list of call frames that match the filter, including any `"reward"` entries when the filter matches block coinbases or uncle authors. Call frames carry `blockHash`, `blockNumber`, `transactionHash` and `transactionPosition`; `"reward"` entries are block-level and carry only `blockHash` and `blockNumber` — `newRewardTrace` sets no transaction fields at all. See [Response Fields Reference](#response-fields-reference).
 
 #### Example
 
@@ -6782,6 +6803,7 @@ Returns trace at given position.
 
 1. `Hash` - Transaction hash.
 2. `Array` - Index positions of the traces.
+3. `Boolean` - Optional, default `false`. `gasBailOut`. See [The gasBailOut option](#the-gasbailout-option).
 
 ```js
 params: [
@@ -6843,6 +6865,7 @@ Returns all traces of given transaction
 #### Parameters
 
 1. `Hash` - Transaction hash
+2. `Boolean` - Optional, default `false`. `gasBailOut`. See [The gasBailOut option](#the-gasbailout-option).
 
 ```js
 params: ["0x17104ac9d3312d8c136b7f44d4b8b47852618065ebfa534bd2d3b5ef218ca1f3"]

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -4939,7 +4939,9 @@ For API usage refer to the below official resources:
 * [https://ethereum.github.io/execution-apis/](https://ethereum.github.io/execution-apis/)
 
 The sections below cover only the places where Erigon adds a method that is not in that
-standard set, or where its behaviour differs from it. Everything else follows the spec.
+standard set, or where its behaviour differs from it. They are not an exhaustive
+compliance statement: anything not listed here is expected to follow the spec, but a
+deviation that has not yet been documented may still exist.
 
 ### eth\_getProof
 
@@ -5034,9 +5036,12 @@ Both methods need commitment history, so start the node with:
 --prune.include-commitment-history
 ```
 
-Without it the call fails with `eth_getWitness requires commitment history`. If the
-requested block is older than the retained commitment history, it fails with
-`commitment history pruned`.
+Without it the call fails with an error starting with `eth_getWitness requires
+commitment history`; the message continues with a restart hint that names the
+`--prune.experimental.include-commitment-history` alias rather than the canonical flag
+above. If the requested block is older than the retained commitment history, the call
+fails with an error starting with `commitment history pruned`, followed by the retained
+range.
 
 ### eth\_fillTransaction
 
@@ -6013,10 +6018,16 @@ then it should look something like:
 
 Beacon-chain withdrawals credit balances outside of any transaction, so by default no
 trace mentions them. `trace_block` and `trace_replayBlockTransactions` can be asked to
-include them by passing a trace-settings object as the last positional parameter:
+include them by passing a trace-settings object as the last positional parameter. It is
+positional, so the parameters before it have to be supplied even when they are not
+otherwise needed:
 
 ```js
-{ "IncludeWithdrawals": true }
+// trace_block(blockNumber, gasBailOut, traceSettings)
+["0x1194bf0", false, { "IncludeWithdrawals": true }]
+
+// trace_replayBlockTransactions(blockNumber, traceTypes, gasBailOut, traceSettings)
+["0x1194bf0", ["stateDiff"], false, { "IncludeWithdrawals": true }]
 ```
 
 The default is off — omit the object, or leave the field out, and withdrawals are not

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -4943,6 +4943,15 @@ standard set, or where its behaviour differs from it. They are not an exhaustive
 compliance statement: anything not listed here is expected to follow the spec, but a
 deviation that has not yet been documented may still exist.
 
+:::info
+`execution-apis` is a living specification rather than a frozen standard — methods are
+still being added, and some long-standing `eth` behaviour was never specified at all — so
+parts of what follows are differences from a moving target rather than defects. Erigon
+runs the specification's own conformance vectors in CI (Hive's `rpc-compat` suite against
+a pinned `execution-apis` revision) and works with the other client teams on closing
+these gaps, so this page will change as the two converge.
+:::
+
 ### eth\_getProof
 
 `eth_getProof` returns Merkle proofs for account state and storage slots, as defined in [EIP-1186](https://eips.ethereum.org/EIPS/eip-1186). It is stable and production-ready as of Erigon v3.4.

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -5019,7 +5019,9 @@ without a full state database.
 :::info
 `eth_getTxWitness` currently only bounds-checks `txIndex` — an index past the end of the
 block is an error, but the witness it returns is the same whole-block witness
-`eth_getWitness` produces.
+`eth_getWitness` produces. At the genesis block not even that check runs: both methods
+share one implementation that returns the empty witness as soon as the block number
+resolves to `0`, so any `txIndex` is accepted there.
 :::
 
 **Returns**
@@ -5030,14 +5032,17 @@ self-verified. The genesis block returns an empty witness.
 
 **Requirements**
 
-Both methods need commitment history, so start the node with:
+Both methods need commitment history for any block above genesis, so start the node with:
 
 ```text
 --prune.include-commitment-history
 ```
 
-Without it the call fails with an error starting with `eth_getWitness requires
-commitment history`; the message continues with a restart hint that names the
+The genesis block is the one exception: the empty witness is returned before the
+commitment-history check, so `eth_getWitness` and `eth_getTxWitness` succeed at block `0`
+on a node without commitment history. For every other block, without it the call fails
+with an error starting with `eth_getWitness requires commitment history`; the message
+continues with a restart hint that names the
 `--prune.experimental.include-commitment-history` alias rather than the canonical flag
 above. If the requested block is older than the retained commitment history, the call
 fails with an error starting with `commitment history pruned`, followed by the retained
@@ -5084,9 +5089,16 @@ Accepted everywhere a block is selected:
 * a `0x`-prefixed hex string without leading zeros — `"0x3"`, `"0x2ed119"`
 * a bare, unquoted JSON integer — `3`
 * the named tags `"earliest"`, `"latest"`, `"safe"`, `"finalized"`, `"pending"`
-* `null`, which means `latest` — except in the few methods whose block-or-hash
-  parameter is required (`eth_getBlockReceipts`, `eth_getBlockAccessList`,
-  `eth_simulateV1`, `eth_getWitness`, `eth_getTxWitness`), which reject it
+* `null`, but only where the selector is optional: it leaves the parameter unset, and
+  the method's own default applies — `latest` for most, though the default is
+  per-method. A **required** block-or-hash parameter rejects top-level `null`:
+  `BlockNumberOrHash.UnmarshalJSON` decodes `null` into an empty struct and then fails
+  with `at least one of BlockNumber or BlockHash is needed if a dictionary is provided`
+  (`rpc/types.go`). That is a property of the type, not a list of special-cased methods
+  — it holds for every method whose selector is a required `BlockNumberOrHash`,
+  including `eth_getBlockReceipts`, `eth_getBlockAccessList`, `eth_simulateV1`,
+  `eth_getWitness`, `eth_getTxWitness`, `eth_getBlockByHash` and
+  `trace_replayBlockTransactions`
 
 Rejected everywhere:
 
@@ -5101,11 +5113,24 @@ and are now rejected with `hex string without 0x prefix`, returned as an
 integer `3`, or a named tag.
 :::
 
-Two further forms are accepted only by methods whose parameter is a plain block number,
-such as `eth_getBlockByNumber`, `eth_getBlockTransactionCountByNumber` and `trace_block`:
-the Erigon-specific tag `"latestExecuted"`, and the string `"null"`, which means `latest`.
+Two further forms exist: the Erigon-specific tag `"latestExecuted"`, and the string
+`"null"`, which means `latest`. Both are parsed by `BlockNumber.UnmarshalJSON`, so they are
+accepted unconditionally by methods whose parameter is a plain block number — such as
+`eth_getBlockByNumber`, `eth_getBlockTransactionCountByNumber` and `trace_block`.
+
 Methods taking a block-number-or-hash selector — `eth_call`, `eth_getBalance`,
-`eth_getProof` and the rest — reject both.
+`eth_getProof` and the rest — reject both **as top-level strings** only.
+`BlockNumberOrHash.UnmarshalJSON` tries the object form first, and that path decodes the
+`blockNumber` field through `BlockNumber`, which does accept them. So on those
+block-number-or-hash methods the object-wrapped forms work:
+
+```json
+{"blockNumber": "latestExecuted"}
+{"blockNumber": "null"}
+```
+
+while the bare strings `"latestExecuted"` and `"null"` fail on those same methods, because
+the top-level string switch does not list them.
 
 ### Filter lifetime
 
@@ -6072,7 +6097,7 @@ All `trace_*` methods return objects built from the same set of fields. Each met
 | --- | --- |
 | `trace_call`, `trace_rawTransaction`, `trace_replayTransaction` | `Object` with `output`, `stateDiff`, `trace[]`, `vmTrace` |
 | `trace_callMany` | `Array` — one per input call |
-| `trace_replayBlockTransactions` | `Array` — one per transaction; each entry adds `transactionHash` |
+| `trace_replayBlockTransactions` | `Array` — one per transaction; each entry adds `transactionHash`. One extra trailing entry when withdrawals are requested — see [trace_replayBlockTransactions](#trace_replayblocktransactions) |
 | `trace_block`, `trace_filter`, `trace_transaction` | `Array` (flat list across all call frames) |
 | `trace_get` | `TraceEntry` (single call frame at the requested position) |
 
@@ -6381,7 +6406,7 @@ Replays all transactions in a block returning the requested traces for each tran
 
 #### Parameters
 
-1. `Quantity` or `Tag` - Integer of a block number, or the string `'earliest'`, `'latest'` or `'pending'`.
+1. `Quantity`, `Tag`, `Data` or `Object` - A block-number-or-hash selector: an integer block number, a named tag such as `'earliest'`, `'latest'` or `'pending'`, a block hash, or the object form `{"blockNumber": ...}` / `{"blockHash": ...}`. Required — `null` is rejected. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
 3. `Boolean` - Optional. `gasBailOut`.
 4. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to have beacon-chain withdrawals reflected in the `stateDiff` output. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
@@ -6395,7 +6420,15 @@ params: [
 
 #### Returns
 
-`Array` — one entry per transaction in the block. Each entry is shaped like the `trace_call` response plus a `transactionHash` field identifying the transaction. See [Response Fields Reference](#response-fields-reference).
+`Array` — by default one entry per transaction in the block (see below for the one exception). Each entry is shaped like the `trace_call` response plus a `transactionHash` field identifying the transaction. See [Response Fields Reference](#response-fields-reference).
+
+The one-entry-per-transaction mapping does not hold when withdrawals are requested.
+With `"stateDiff"` in the trace types and `"IncludeWithdrawals": true` in the trace
+settings, a block that has withdrawals gets **one extra entry appended** after the
+last transaction — an empty `trace` and a `stateDiff` carrying only the withdrawal
+balance changes, with no `transactionHash`. Consumers that index results positionally
+against the block's transaction list must skip that trailing entry. See [Beacon-chain
+withdrawals](#beacon-chain-withdrawals).
 
 #### Example
 

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -6342,6 +6342,7 @@ Executes the given call and returns a number of possible traces for it.
 1. `Object` - \[Transaction object] where `from` field is optional and `nonce` field is omitted.
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
 3. `Quantity` or `Tag` - (optional) Integer of a block number, or the string `'earliest'`, `'latest'` or `'pending'`.
+4. `Object` - Optional trace settings (`TraceConfig`), the same object the other `trace` methods accept.
 
 This method takes no `gasBailOut` parameter — it always replays with the bailout enabled. See [The gasBailOut option](#the-gasbailout-option).
 
@@ -6391,6 +6392,7 @@ Performs multiple call traces on top of the same block. i.e. transaction `n` wil
 
 1. `Array` - List of trace calls with the type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
 2. `Quantity` or `Tag` - (optional) integer block number, or the string `'latest'`, `'earliest'` or `'pending'` (default block parameter).
+3. `Object` - Optional trace settings (`TraceConfig`), the same object the other `trace` methods accept.
 
 This method takes no `gasBailOut` parameter — it always replays with the bailout enabled. See [The gasBailOut option](#the-gasbailout-option).
 

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -5065,8 +5065,21 @@ deviates from it in the return shape, which keeps the `raw` field the spec dropp
 
 The standard `type` field is ignored. `CallArgs` has no field for it and unknown JSON
 properties are accepted silently, so the envelope is inferred from whichever fee,
-access-list and blob fields are present. On a post-London head, `{"type": "0x0"}` with no
-`gasPrice` comes back as a type `0x2` transaction rather than the legacy type requested.
+access-list and blob fields are present. On a post-London head, a request such as
+
+```json
+{
+  "from": "0x71562b71999873db5b286df957af199ec94617f7",
+  "to": "0x0d3ab14bbad3d99f4203bd7a11acb94882050e7e",
+  "gas": "0x5208",
+  "type": "0x0"
+}
+```
+
+comes back as a type `0x2` transaction rather than the legacy type requested, because no
+`gasPrice` was supplied. The `to` field is not decoration: a fill with neither `to` nor
+contract-creation data fails with `contract creation without any data provided` before a
+transaction is built at all.
 
 **Fills in**
 
@@ -5097,12 +5110,18 @@ RLP only for a legacy transaction; a typed one is the EIP-2718 type byte followe
 encoded payload, and feeding that straight to an RLP decoder will fail. The standardized
 result carries only `tx`; the extra `raw` field is the geth-compatible shape.
 
-A typed result also carries `gasPrice: null`. `FillTransaction` passes no base fee to the
-response encoder, so `computeGasPrice` returns nothing and the missing key is filled with
-`null` — deliberate geth parity, pinned by `rpc/ethapi/api_test.go`. The standardized
-type-2 unsigned schema requires `gasPrice` to be a hex quantity, so a schema-validating
-client will reject the result; read `maxFeePerGas` and `maxPriorityFeePerGas` instead.
-Legacy results carry a real `gasPrice`.
+A dynamic-fee result — types `0x2`, `0x3` and `0x4` — also carries `gasPrice: null`.
+`FillTransaction` passes no base fee to the response encoder, so `computeGasPrice`
+returns nothing and the missing key is filled with `null` — deliberate geth parity,
+pinned by `rpc/ethapi/api_test.go`. The standardized type-2 unsigned schema requires
+`gasPrice` to be a hex quantity, so a schema-validating client will reject the result;
+read `maxFeePerGas` and `maxPriorityFeePerGas` instead.
+
+Legacy (`0x0`) and access-list (`0x1`) results are not affected: `NewRPCTransaction`
+takes their `gasPrice` from the tip cap, so it is a real hex quantity. Those two carry
+`maxFeePerGas: null` and `maxPriorityFeePerGas: null` instead, filled in by the same
+rule. A type `0x1` fill is reached by supplying `gasPrice` together with an
+`accessList` — Erigon keeps the list where geth drops it to a legacy transaction.
 
 :::info
 KZG commitment and proof generation from raw blobs is not implemented. Blob
@@ -5120,7 +5139,16 @@ themselves and reattach it before submitting.
 Erigon accepts more block-number forms than the standard schema, which allows only a
 `0x`-prefixed hex quantity string or a named tag.
 
-Accepted everywhere a block is selected:
+The rules below govern parameters decoded as `BlockNumber` or `BlockNumberOrHash` — the
+selector of `eth_getBlockByNumber`, `eth_getBalance`, `eth_call`, `trace_block` and the
+rest of that family. They do not apply to methods that select a block through a fixed
+`common.Hash` parameter: `eth_getBlockTransactionCountByHash`,
+`eth_getTransactionByBlockHashAndIndex`, `eth_getRawTransactionByBlockHashAndIndex`,
+`eth_getUncleByBlockHashAndIndex` and `eth_getUncleCountByBlockHash` take a 32-byte hash
+and nothing else. `eth_getBlockByHash` is not one of them — despite the name its
+parameter is a `BlockNumberOrHash`, so it follows the rules here.
+
+Accepted:
 
 * a `0x`-prefixed hex string without leading zeros — `"0x3"`, `"0x2ed119"`
 * a bare, unquoted JSON integer — `3`
@@ -5138,7 +5166,7 @@ Accepted everywhere a block is selected:
     `eth_getBlockReceipts`, `eth_getBlockAccessList`, `eth_simulateV1`, `eth_getWitness`,
     `eth_getTxWitness`, `eth_getBlockByHash` and `trace_replayBlockTransactions`
 
-Rejected everywhere:
+Rejected by both parameter types:
 
 * a quoted decimal string — `"3"`, `"100"`
 * a block number above `2^63-1` — out of range in both parameter types, though the error

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -6190,14 +6190,15 @@ balances:
   non-zero `value`, the EVM-level bailout engages and `Transfer` skips the sender debit
   while still crediting the recipient. Value appears from nowhere, so a trace can show
   what looks like balance creation.
-* **On Gnosis and Chiado, the burn contract is credited too.** Where the chain
-  configures a `burntContract` — Gnosis and Chiado do, most chains do not — a **non-free**
-  London transaction credits it `gasUsed * baseFee`, plus the blob fee on Aura from
-  Prague. The sender was never debited, so this is a second source of apparent balance
-  creation in `stateDiff` on those chains. Aura marks zero-fee certified service
-  transactions as free, and the credit is guarded by `!msg.IsFree()`, so those are
-  excluded. Chains that simply burn the base fee never receive this extra credit — every
-  other effect above still applies to them.
+* **Where the chain configures a burn contract, that contract is credited too.** A
+  **non-free** London transaction credits the configured `burntContract` with
+  `gasUsed * baseFee`; on Aura from Prague the blob fee is added on top. Gnosis and
+  Chiado configure one, and so do Polygon's Bor chains — mainnet, Amoy, Mumbai and the
+  devnet. The sender was never debited, so this is a second source of apparent balance
+  creation in `stateDiff`. Aura marks zero-fee certified service transactions as free
+  and the credit is guarded by `!msg.IsFree()`, so those are excluded. Chains with no
+  configured contract never receive this extra credit — every other effect above still
+  applies to them.
 :::
 
 Whether one transaction's altered state is visible to the next depends on the execution

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -6191,10 +6191,13 @@ balances:
   while still crediting the recipient. Value appears from nowhere, so a trace can show
   what looks like balance creation.
 * **On Gnosis and Chiado, the burn contract is credited too.** Where the chain
-  configures a `burntContract` — Gnosis and Chiado do, most chains do not — a London
-  transaction credits it `gasUsed * baseFee`, plus the blob fee on Aura from Prague. The
-  sender was never debited, so this is a second source of apparent balance creation in
-  `stateDiff` on those chains. Chains that simply burn the base fee are unaffected.
+  configures a `burntContract` — Gnosis and Chiado do, most chains do not — a **non-free**
+  London transaction credits it `gasUsed * baseFee`, plus the blob fee on Aura from
+  Prague. The sender was never debited, so this is a second source of apparent balance
+  creation in `stateDiff` on those chains. Aura marks zero-fee certified service
+  transactions as free, and the credit is guarded by `!msg.IsFree()`, so those are
+  excluded. Chains that simply burn the base fee never receive this extra credit — every
+  other effect above still applies to them.
 :::
 
 Whether one transaction's altered state is visible to the next depends on the execution
@@ -6620,6 +6623,7 @@ Replays a transaction, returning the traces.
 1. `Hash` - Transaction hash.
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
 3. `Boolean` - Optional, default `false`. `gasBailOut`. See [The gasBailOut option](#the-gasbailout-option).
+4. `Object` - Optional trace settings (`TraceConfig`), the same object the other `trace` methods accept.
 
 ```js
 params: [
@@ -6744,6 +6748,7 @@ Returns traces matching given filter
    * `count`: `Quantity` - (optional) Integer number of traces to display in a batch.
    * `mode`: `String` - (optional) Default is `"union"`, meaning traces matching either address filter are returned. Set to `"intersection"` to only return traces that satisfy both `fromAddress` and `toAddress` filters simultaneously.
 2. `Boolean` - Optional, default `false`. `gasBailOut`. See [The gasBailOut option](#the-gasbailout-option).
+3. `Object` - Optional trace settings (`TraceConfig`), the same object the other `trace` methods accept.
 
 ```js
 params: [{
@@ -6811,6 +6816,7 @@ Returns trace at given position.
 1. `Hash` - Transaction hash.
 2. `Array` - Index positions of the traces.
 3. `Boolean` - Optional, default `false`. `gasBailOut`. See [The gasBailOut option](#the-gasbailout-option).
+4. `Object` - Optional trace settings (`TraceConfig`), the same object the other `trace` methods accept.
 
 ```js
 params: [
@@ -6873,6 +6879,7 @@ Returns all traces of given transaction
 
 1. `Hash` - Transaction hash
 2. `Boolean` - Optional, default `false`. `gasBailOut`. See [The gasBailOut option](#the-gasbailout-option).
+3. `Object` - Optional trace settings (`TraceConfig`), the same object the other `trace` methods accept.
 
 ```js
 params: ["0x17104ac9d3312d8c136b7f44d4b8b47852618065ebfa534bd2d3b5ef218ca1f3"]

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -5118,9 +5118,11 @@ Accepted everywhere a block is selected:
 Rejected everywhere:
 
 * a quoted decimal string — `"3"`, `"100"`
-* a block number above `2^63-1`, in either parameter type — `BlockNumber.UnmarshalJSON`
-  and `BlockNumberOrHash.UnmarshalJSON` both fail with `blocknumber too high`, so
-  `"0x8000000000000000"` and the equivalent bare integer are out of range
+* a block number above `2^63-1` — out of range in both parameter types, though the error
+  differs: a plain **block-number** parameter fails with `block number larger than
+  int64`, while a top-level numeric or hex **block-or-hash** value fails with
+  `blocknumber too high` (`rpc/types.go`). `"0x8000000000000000"` and the equivalent
+  bare integer are rejected either way
 * hex with leading zeros — `"0x01"`
 * hex without the prefix — `"ff"`
 
@@ -6143,7 +6145,7 @@ A `TraceEntry` represents a single call frame (root call, internal call, contrac
 | `error` | String | (Optional) Present when the call frame errored. `"Reverted"` (title-cased) is the only special-cased value; all other errors are the verbatim Go error string, e.g. `"out of gas"`, `"invalid opcode: ..."`. For `"Reverted"`, `result` is still populated with `gasUsed` and `output` (or `code`/`address` for a `create` frame); for other errors, `result` is `null`. |
 | `subtraces` | QUANTITY | Number of direct child call frames produced by this frame. Used together with `traceAddress` to reconstruct the call tree from a flat list. |
 | `traceAddress` | Array of QUANTITY | Path to this frame inside the call tree. Empty array `[]` for the root call; `[0]` is the first child of the root; `[1, 0]` is the first child of the second child of the root, etc. |
-| `type` | String | One of `"call"`, `"create"`, `"suicide"` (self-destruct), `"reward"` (block, uncle or beacon-chain-withdrawal reward — appears in `trace_block` and in `trace_filter` results when the filter matches block coinbases, uncle authors or withdrawal recipients). |
+| `type` | String | One of `"call"`, `"create"`, `"suicide"` (self-destruct), `"reward"` (block or uncle reward — appears in `trace_block` and in `trace_filter` results when the filter matches block coinbases or uncle authors; `trace_block` alone also emits beacon-chain-withdrawal rewards, on request). |
 | `blockHash` | DATA, 32 BYTES | (Only in block-level methods: `trace_block`, `trace_filter`, `trace_transaction`, `trace_get`) Hash of the block containing the transaction. |
 | `blockNumber` | QUANTITY | (Block-level methods only) Number of the block containing the transaction. |
 | `transactionHash` | DATA, 32 BYTES | (Block-level methods only) Hash of the transaction containing this call frame. Absent for `"reward"` entries. |
@@ -6182,13 +6184,13 @@ The `action` object's shape depends on `type`:
 | `refundAddress` | DATA, 20 BYTES | Address that received the contract's remaining balance. |
 | `balance` | QUANTITY | Wei amount transferred to `refundAddress`. |
 
-**`type: "reward"`** (block, uncle or withdrawal reward, in `trace_block` and `trace_filter`)
+**`type: "reward"`** (block or uncle reward in `trace_block` and `trace_filter`; withdrawal reward in `trace_block` only)
 
 | Field | Type | Description |
 | --- | --- | --- |
 | `author` | DATA, 20 BYTES | Address receiving the reward — the miner, the uncle author, or the withdrawal recipient when `rewardType` is `"withdrawal"`. |
 | `value` | QUANTITY | Wei amount of the reward. |
-| `rewardType` | String | `"block"` or `"uncle"`, and `"withdrawal"` when `IncludeWithdrawals` is set — see [Beacon-chain withdrawals](#beacon-chain-withdrawals). |
+| `rewardType` | String | `"block"` or `"uncle"`. `trace_block` also emits `"withdrawal"` when `IncludeWithdrawals` is set; `trace_filter` never does — see [Beacon-chain withdrawals](#beacon-chain-withdrawals). |
 
 ### Result variants
 
@@ -6446,8 +6448,11 @@ params: [
 The one-entry-per-transaction mapping does not hold when withdrawals are requested.
 With `"stateDiff"` in the trace types and `"IncludeWithdrawals": true` in the trace
 settings, a block that has withdrawals gets **one extra entry appended** after the
-last transaction — an empty `trace` and a `stateDiff` carrying only the withdrawal
-balance changes, with no `transactionHash`. Consumers that index results positionally
+last transaction — an empty `trace` and a `stateDiff` carrying only the withdrawal state
+changes, with no `transactionHash`. That diff is a balance change alone only when the
+recipient already existed; a recipient created by the withdrawal also gets `code` and
+`nonce` entries, as described under [Beacon-chain withdrawals](#beacon-chain-withdrawals).
+Consumers that index results positionally
 against the block's transaction list must skip that trailing entry. See [Beacon-chain
 withdrawals](#beacon-chain-withdrawals).
 

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -5069,7 +5069,11 @@ deviates from it in the return shape, which keeps the `raw` field the spec dropp
 * `value` — `0` when absent
 * `gas` — from `eth_estimateGas` against `latest`
 * `chainId` — the node's chain ID; a mismatching supplied value is an error
-* fee fields — `gasPrice` before London, otherwise `maxFeePerGas` / `maxPriorityFeePerGas` from the gas oracle
+* fee fields — an explicitly supplied `gasPrice` is preserved, before or after London,
+  and cannot be combined with `maxFeePerGas` or `maxPriorityFeePerGas`. When it is absent:
+  before London `gasPrice` comes from the gas oracle; after London the dynamic fields are
+  filled independently, `maxPriorityFeePerGas` from the oracle and `maxFeePerGas` as twice
+  the base fee plus the tip. The dynamic fields are rejected before London
 * `maxFeePerBlobGas` — for blob transactions, twice the current blob gas price
 
 **Returns**
@@ -6103,7 +6107,7 @@ All `trace_*` methods return objects built from the same set of fields. Each met
 | --- | --- |
 | `trace_call`, `trace_rawTransaction`, `trace_replayTransaction` | `Object` with `output`, `stateDiff`, `trace[]`, `vmTrace` |
 | `trace_callMany` | `Array` — one per input call |
-| `trace_replayBlockTransactions` | `Array` — one per transaction; each entry adds `transactionHash`. One extra trailing entry when withdrawals are requested — see [trace_replayBlockTransactions](#trace_replayblocktransactions) |
+| `trace_replayBlockTransactions` | `Array` — one per transaction; each entry adds `transactionHash`. One extra trailing entry when `stateDiff` is requested with `"IncludeWithdrawals": true` and the block has withdrawals — see [trace_replayBlockTransactions](#trace_replayblocktransactions) |
 | `trace_block`, `trace_filter`, `trace_transaction` | `Array` (flat list across all call frames) |
 | `trace_get` | `TraceEntry` (single call frame at the requested position) |
 

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -5063,6 +5063,11 @@ deviates from it in the return shape, which keeps the `raw` field the spec dropp
 
 1. `Object` — a transaction object in the same shape `eth_call` accepts.
 
+The standard `type` field is ignored. `CallArgs` has no field for it and unknown JSON
+properties are accepted silently, so the envelope is inferred from whichever fee,
+access-list and blob fields are present. On a post-London head, `{"type": "0x0"}` with no
+`gasPrice` comes back as a type `0x2` transaction rather than the legacy type requested.
+
 **Fills in**
 
 * `nonce` — from the pending nonce of `from`, or `0` when `from` is absent
@@ -5091,6 +5096,13 @@ An object with `raw`, the unsigned transaction in its canonical binary encoding,
 RLP only for a legacy transaction; a typed one is the EIP-2718 type byte followed by the
 encoded payload, and feeding that straight to an RLP decoder will fail. The standardized
 result carries only `tx`; the extra `raw` field is the geth-compatible shape.
+
+A typed result also carries `gasPrice: null`. `FillTransaction` passes no base fee to the
+response encoder, so `computeGasPrice` returns nothing and the missing key is filled with
+`null` — deliberate geth parity, pinned by `rpc/ethapi/api_test.go`. The standardized
+type-2 unsigned schema requires `gasPrice` to be a hex quantity, so a schema-validating
+client will reject the result; read `maxFeePerGas` and `maxPriorityFeePerGas` instead.
+Legacy results carry a real `gasPrice`.
 
 :::info
 KZG commitment and proof generation from raw blobs is not implemented. Blob
@@ -6199,9 +6211,9 @@ The `action` object's shape depends on `type`:
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `author` | DATA, 20 BYTES | Address receiving the reward: the block author, the uncle author, the beneficiary named by the block-reward contract for `"external"` and `"emptyStep"`, or the withdrawal recipient for `"withdrawal"`. |
+| `author` | DATA, 20 BYTES | Address receiving the reward: the block author, the uncle author, the beneficiary attributed by the block-reward contract for `"external"`, or the withdrawal recipient for `"withdrawal"`. |
 | `value` | QUANTITY | Wei amount of the reward. |
-| `rewardType` | String | `trace_filter` emits only `"block"` and `"uncle"`. `trace_block` maps the consensus reward kind through `rewardKindToString`, so it can also return `"emptyStep"` and `"external"` on Aura chains such as Gnosis (a block-reward-contract payout), or `"unknown"` for an unrecognised kind; it additionally emits `"withdrawal"` when `IncludeWithdrawals` is set — see [Beacon-chain withdrawals](#beacon-chain-withdrawals). |
+| `rewardType` | String | `trace_filter` emits only `"block"` and `"uncle"`. `trace_block` maps the consensus reward kind through `rewardKindToString`, so it also returns `"external"` for a block-reward-contract payout on Aura chains such as Gnosis, and emits `"withdrawal"` when `IncludeWithdrawals` is set — see [Beacon-chain withdrawals](#beacon-chain-withdrawals). That mapping additionally defines `"emptyStep"` (an AuthorityRound empty-step author) and `"unknown"`, but no current code path produces either. |
 
 ### Result variants
 

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -6182,7 +6182,9 @@ balances:
 * **Gas and blob fees are never deducted.** `TxnExecutor.buyGas` skips both `SubBalance`
   calls whenever the flag is set, for *every* replayed transaction — funded senders
   included, not only underfunded ones.
-* **Refunds are skipped.** The gas-refund path is gated on `refunds && !gasBailout`.
+* **Refunds are skipped.** The gas-refund path is gated on `refunds && !gasBailout` — that
+  is the internal Go parameter, spelled with a lowercase `o`, not the JSON-RPC
+  `gasBailOut` this section documents.
 * **The producer is still paid.** The block producer's tip is credited as usual.
 * **An unaffordable value transfer is credited anyway.** When the sender cannot cover a
   non-zero `value`, the EVM-level bailout engages and `Transfer` skips the sender debit
@@ -6544,7 +6546,7 @@ Replays all transactions in a block returning the requested traces for each tran
 
 #### Parameters
 
-1. `Quantity`, `Tag`, `Data` or `Object` - A block-number-or-hash selector: an integer block number, a named tag such as `'earliest'`, `'latest'` or `'pending'`, a block hash, or the object form `{"blockNumber": ...}` / `{"blockHash": ...}`. Required — `null` is rejected. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
+1. `Quantity`, `Number`, `Tag`, `Data` or `Object` - A block-number-or-hash selector: a hex block number, a bare JSON integer (an Erigon extension — not a standard `QUANTITY`), a named tag such as `'earliest'`, `'latest'` or `'pending'`, a block hash, or the object form `{"blockNumber": ...}` / `{"blockHash": ...}`. Required — `null` is rejected. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
 3. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still replayed instead of failing the call. It does more than bypass that check — see [The gasBailOut option](#the-gasbailout-option).
 4. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to have beacon-chain withdrawals reflected in the `stateDiff` output. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
@@ -6670,7 +6672,7 @@ Returns traces created at given block.
 
 #### Parameters
 
-1. `Quantity`, `Tag` or `null` - A plain block number: an integer (hex string or bare JSON integer), a named tag (`'earliest'`, `'latest'`, `'pending'`, `'safe'`, `'finalized'`, or the Erigon-specific `'latestExecuted'`), or `null` / `"null"`, both of which mean `latest`. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
+1. `Quantity`, `Number`, `Tag` or `null` - A plain block number: a hex string, or a bare JSON integer as an Erigon extension (not a standard `QUANTITY`), a named tag (`'earliest'`, `'latest'`, `'pending'`, `'safe'`, `'finalized'`, or the Erigon-specific `'latestExecuted'`), or `null` / `"null"`, both of which mean `latest`. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
 2. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still traced instead of failing the replay — the OpenEthereum/Parity behaviour. It does more than bypass that check — see [The gasBailOut option](#the-gasbailout-option).
 3. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to append a `"reward"` entry per beacon-chain withdrawal. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
 

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -5096,11 +5096,13 @@ transaction is built at all.
 * `value` — `0` when absent
 * `gas` — from `eth_estimateGas` against `latest`
 * `chainId` — the node's chain ID; a mismatching supplied value is an error. It is used
-  for validation and carried by typed transactions, but it does not appear in the
-  returned `tx` for an unsigned legacy transaction: `CallArgs.ToTransaction` builds a
+  for validation and carried by every typed transaction, but it does not appear in the
+  returned `tx` when the fill infers legacy type `0x0`: `CallArgs.ToTransaction` builds a
   `LegacyTx` with no chain-ID field, and the response encoder skips chain-ID derivation
-  while `v` is zero. A pre-London fill, or a post-London fill supplying `gasPrice` with
-  no access list, therefore returns `tx` without `chainId`
+  while `v` is zero. That is the `default` arm of the type switch — reached only when
+  none of `authorizationList`, `blobVersionedHashes`, `maxFeePerGas` or `accessList` is
+  present. An `accessList` fill before London and a blob or authorization-list fill after
+  it are typed and carry `chainId`, even when `gasPrice` is supplied
 * fee fields — an explicitly supplied `gasPrice` is preserved, before or after London,
   though after London it must be non-zero (`gasPrice must be non-zero after london fork`);
   before London a zero is accepted. It cannot be combined with `maxFeePerGas` or
@@ -5118,6 +5120,17 @@ An object with `raw`, the unsigned transaction in its canonical binary encoding,
 RLP only for a legacy transaction; a typed one is the EIP-2718 type byte followed by the
 encoded payload, and feeding that straight to an RLP decoder will fail. The standardized
 result carries only `tx`; the extra `raw` field is the geth-compatible shape.
+
+`tx` also carries four fields the standardized unsigned schemas do not define. `v`, `r`
+and `s` are placeholders — `SignTransactionResult.MarshalJSON` writes `"0x0"` for each —
+and a typed result adds `yParity`, likewise `0x0`. Nothing is signed here, so none of
+them is a signature.
+
+:::warning
+The `hash` field is computed before signing and **changes once the transaction is
+signed**. It is not the hash the transaction will have when submitted, so it must not be
+used to track it. Take the hash from `eth_sendRawTransaction` instead.
+:::
 
 A dynamic-fee result — types `0x2`, `0x3` and `0x4` — also carries `gasPrice: null`.
 `FillTransaction` passes no base fee to the response encoder, so `computeGasPrice`
@@ -6491,8 +6504,17 @@ Replays all transactions in a block returning the requested traces for each tran
 
 1. `Quantity`, `Tag`, `Data` or `Object` - A block-number-or-hash selector: an integer block number, a named tag such as `'earliest'`, `'latest'` or `'pending'`, a block hash, or the object form `{"blockNumber": ...}` / `{"blockHash": ...}`. Required — `null` is rejected. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
-3. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still replayed instead of failing the call.
+3. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still replayed instead of failing the call. It does more than bypass that check — see the warning below.
 4. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to have beacon-chain withdrawals reflected in the `stateDiff` output. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
+
+:::warning
+`gasBailOut` alters replayed state for **every** transaction, not only underfunded ones.
+`TxnExecutor.buyGas` skips the sender's gas and blob-fee deductions whenever it is set,
+the gas-refund path is skipped along with them, and the block producer's tip is still
+credited. The resulting `stateDiff`, and the state each later transaction in the block
+sees, therefore differ from a normal replay — do not use the output to reconstruct
+balances.
+:::
 
 ```js
 params: [
@@ -6615,8 +6637,17 @@ Returns traces created at given block.
 #### Parameters
 
 1. `Quantity`, `Tag` or `null` - A plain block number: an integer (hex string or bare JSON integer), a named tag (`'earliest'`, `'latest'`, `'pending'`, `'safe'`, `'finalized'`, or the Erigon-specific `'latestExecuted'`), or `null` / `"null"`, both of which mean `latest`. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
-2. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still traced instead of failing the replay — the OpenEthereum/Parity behaviour.
+2. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still traced instead of failing the replay — the OpenEthereum/Parity behaviour. It does more than bypass that check — see the warning below.
 3. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to append a `"reward"` entry per beacon-chain withdrawal. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
+
+:::warning
+`gasBailOut` alters replayed state for **every** transaction, not only underfunded ones.
+`TxnExecutor.buyGas` skips the sender's gas and blob-fee deductions whenever it is set,
+the gas-refund path is skipped along with them, and the block producer's tip is still
+credited. The resulting `stateDiff`, and the state each later transaction in the block
+sees, therefore differ from a normal replay — do not use the output to reconstruct
+balances.
+:::
 
 ```js
 params: [

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -6188,6 +6188,11 @@ balances:
   non-zero `value`, the EVM-level bailout engages and `Transfer` skips the sender debit
   while still crediting the recipient. Value appears from nowhere, so a trace can show
   what looks like balance creation.
+* **On Gnosis and Chiado, the burn contract is credited too.** Where the chain
+  configures a `burntContract` — Gnosis and Chiado do, most chains do not — a London
+  transaction credits it `gasUsed * baseFee`, plus the blob fee on Aura from Prague. The
+  sender was never debited, so this is a second source of apparent balance creation in
+  `stateDiff` on those chains. Chains that simply burn the base fee are unaffected.
 :::
 
 Whether one transaction's altered state is visible to the next depends on the execution

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -4334,6 +4334,7 @@ Flags:
       --rpc.subscription.filters.maxlogs int        Maximum number of logs to store per subscription.
       --rpc.subscription.filters.maxtopics int      Maximum number of topics per subscription to filter logs by.
       --rpc.subscription.filters.maxtxs int         Maximum number of transactions to store per subscription.
+      --rpc.subscription.filters.timeout duration   Timeout before idle filters are evicted. Defaults to 5m; set to 0 to disable eviction. (default 5m0s)
       --rpc.txfeecap float                          Sets a cap on transaction fee (in ether) that can be sent via the RPC APIs (0 = no cap) (default 1)
       --socket.enabled                              Enable IPC server
       --socket.url string                           IPC server listening url. prefix supported are tcp, unix (default "unix:///var/run/erigon.sock")
@@ -4937,6 +4938,9 @@ For API usage refer to the below official resources:
 * [https://ethereum.org/en/developers/docs/apis/json-rpc/](https://ethereum.org/en/developers/docs/apis/json-rpc/)
 * [https://ethereum.github.io/execution-apis/](https://ethereum.github.io/execution-apis/)
 
+The sections below cover only the places where Erigon adds a method that is not in that
+standard set, or where its behaviour differs from it. Everything else follows the spec.
+
 ### eth\_getProof
 
 `eth_getProof` returns Merkle proofs for account state and storage slots, as defined in [EIP-1186](https://eips.ethereum.org/EIPS/eip-1186). It is stable and production-ready as of Erigon v3.4.
@@ -4955,7 +4959,7 @@ This enables faster retrieval of Merkle proofs for any executed block.
 
 ### eth\_getStorageValues
 
-`eth_getStorageValues` reads several storage slots for one or more accounts in a single call, reducing round-trips compared to multiple `eth_getStorageAt` calls. It is part of the [Ethereum execution APIs](https://github.com/ethereum/execution-apis/blob/main/src/eth/state.yaml) and takes two parameters.
+`eth_getStorageValues` reads several storage slots for one or more accounts in a single call, reducing round-trips compared to multiple `eth_getStorageAt` calls. It originated as an Erigon extension and has since been adopted into the [Ethereum execution APIs](https://github.com/ethereum/execution-apis/blob/main/src/eth/state.yaml) (April 2026). It takes two parameters.
 
 **Parameters**
 
@@ -4995,6 +4999,127 @@ An object mapping each requested address to an array of 32-byte values, in the s
 * A single call may request at most 1024 slots in total, counting all addresses together. Larger requests are rejected.
 * An empty `requests` object returns error code `-32602` with the message `empty request`.
 * When `blockNumber` is a block hash, the block must be canonical.
+
+### eth\_getWitness and eth\_getTxWitness
+
+Neither method exists in the standard set. They return a state witness for the
+*pre-state* of a block: the serialized trie node stream needed to re-execute it
+without a full state database.
+
+**Parameters**
+
+| Method | Parameter | Type | Description |
+| ------ | --------- | ---- | ----------- |
+| `eth_getWitness` | blockNumberOrHash | STRING, NUMBER or OBJECT | Block to build the witness for |
+| `eth_getTxWitness` | blockNumberOrHash | STRING, NUMBER or OBJECT | Block containing the transaction |
+| `eth_getTxWitness` | txIndex | QUANTITY | Index of a transaction within that block |
+
+:::info
+`eth_getTxWitness` currently only bounds-checks `txIndex` — an index past the end of the
+block is an error, but the witness it returns is the same whole-block witness
+`eth_getWitness` produces.
+:::
+
+**Returns**
+
+`DATA` — the serialized witness. Erigon decodes the bytes it is about to return and
+checks that they rebuild the parent state root, so a witness that comes back is
+self-verified. The genesis block returns an empty witness.
+
+**Requirements**
+
+Both methods need commitment history, so start the node with:
+
+```text
+--prune.include-commitment-history
+```
+
+Without it the call fails with `eth_getWitness requires commitment history`. If the
+requested block is older than the retained commitment history, it fails with
+`commitment history pruned`.
+
+### eth\_fillTransaction
+
+`eth_fillTransaction` takes a partially specified transaction, fills in what is
+missing, and returns it unsigned — it neither signs nor submits anything. The method
+was added to the execution-apis specification in July 2026; Erigon (matching geth)
+deviates from it in the return shape, which keeps the `raw` field the spec dropped.
+
+**Parameters**
+
+1. `Object` — a transaction object in the same shape `eth_call` accepts.
+
+**Fills in**
+
+* `nonce` — from the pending nonce of `from`, or `0` when `from` is absent
+* `value` — `0` when absent
+* `gas` — from `eth_estimateGas` against `latest`
+* `chainId` — the node's chain ID; a mismatching supplied value is an error
+* fee fields — `gasPrice` before London, otherwise `maxFeePerGas` / `maxPriorityFeePerGas` from the gas oracle
+* `maxFeePerBlobGas` — for blob transactions, twice the current blob gas price
+
+**Returns**
+
+An object with `raw`, the RLP-encoded unsigned transaction, and `tx`, the same
+transaction in JSON form. The standardized result carries only `tx`; the extra `raw`
+field is the geth-compatible shape.
+
+:::info
+KZG commitment and proof generation from raw blobs is not implemented. Blob
+transactions must already carry their `blobVersionedHashes`.
+:::
+
+### Block number parameter format
+
+Erigon accepts more block-number forms than the standard schema, which allows only a
+`0x`-prefixed hex quantity string or a named tag.
+
+Accepted everywhere a block is selected:
+
+* a `0x`-prefixed hex string without leading zeros — `"0x3"`, `"0x2ed119"`
+* a bare, unquoted JSON integer — `3`
+* the named tags `"earliest"`, `"latest"`, `"safe"`, `"finalized"`, `"pending"`
+* `null`, which means `latest` — except in the few methods whose block-or-hash
+  parameter is required (`eth_getBlockReceipts`, `eth_getBlockAccessList`,
+  `eth_simulateV1`, `eth_getWitness`, `eth_getTxWitness`), which reject it
+
+Rejected everywhere:
+
+* a quoted decimal string — `"3"`, `"100"`
+* hex with leading zeros — `"0x01"`
+* hex without the prefix — `"ff"`
+
+:::warning
+**Breaking change in v3.6.** Quoted decimal strings such as `"3"` used to be accepted
+and are now rejected with `hex string without 0x prefix`, returned as an
+`invalid params` error. Callers relying on that form must switch to `"0x3"`, the bare
+integer `3`, or a named tag.
+:::
+
+Two further forms are accepted only by methods whose parameter is a plain block number,
+such as `eth_getBlockByNumber`, `eth_getBlockTransactionCountByNumber` and `trace_block`:
+the Erigon-specific tag `"latestExecuted"`, and the string `"null"`, which means `latest`.
+Methods taking a block-number-or-hash selector — `eth_call`, `eth_getBalance`,
+`eth_getProof` and the rest — reject both.
+
+### Filter lifetime
+
+The standard spec does not say how long a filter lives. In Erigon, a filter created by
+`eth_newFilter`, `eth_newBlockFilter`, or `eth_newPendingTransactionFilter` is evicted
+once it has gone **5 minutes** without being polled. `eth_getFilterChanges` and
+`eth_getFilterLogs` both count as a poll and reset the clock, so a filter stays alive on
+a quiet chain as long as the client keeps asking. A call against an evicted filter
+returns `filter not found`.
+
+Change the window, or turn eviction off entirely, with:
+
+```text
+--rpc.subscription.filters.timeout 15m   # longer window
+--rpc.subscription.filters.timeout 0     # keep filters indefinitely
+```
+
+Eviction applies only to these polling filters. WebSocket subscriptions live as long as
+their connection does.
 
 ---
 
@@ -5884,6 +6009,31 @@ then it should look something like:
 
 `[ {A: []}, {B: [0]}, {G: [0, 0]}, {C: [1]}, {G: [1, 0]} ]`
 
+## Beacon-chain withdrawals
+
+Beacon-chain withdrawals credit balances outside of any transaction, so by default no
+trace mentions them. `trace_block` and `trace_replayBlockTransactions` can be asked to
+include them by passing a trace-settings object as the last positional parameter:
+
+```js
+{ "IncludeWithdrawals": true }
+```
+
+The default is off — omit the object, or leave the field out, and withdrawals are not
+reported. How they appear depends on the method:
+
+* **`trace_block`** appends one entry per withdrawal to the flat trace list. Each is a
+  `"reward"` entry whose `action.rewardType` is `"withdrawal"`, with `action.author` set
+  to the withdrawal address and `action.value` to the amount **in wei** (the beacon chain
+  denominates withdrawals in Gwei). These entries carry no `transactionHash` or
+  `transactionPosition`, since no transaction caused them.
+
+* **`trace_replayBlockTransactions`** has no block-level slot in its per-transaction
+  result shape, so withdrawals surface only through `stateDiff`. You must request
+  `"stateDiff"` in the trace types; when you do, one extra entry is appended to the
+  result array, containing only the withdrawal balance changes. Multiple withdrawals to
+  the same address are merged into a single balance change.
+
 ## JSON-RPC methods
 
 #### Ad-hoc Tracing
@@ -6222,6 +6372,8 @@ Replays all transactions in a block returning the requested traces for each tran
 
 1. `Quantity` or `Tag` - Integer of a block number, or the string `'earliest'`, `'latest'` or `'pending'`.
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
+3. `Boolean` - Optional. `gasBailOut`.
+4. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to have beacon-chain withdrawals reflected in the `stateDiff` output. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
 
 ```js
 params: [
@@ -6333,6 +6485,8 @@ Returns traces created at given block.
 #### Parameters
 
 1. `Quantity` or `Tag` - Integer of a block number, or the string `'earliest'`, `'latest'` or `'pending'`.
+2. `Boolean` - Optional. `gasBailOut`.
+3. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to append a `"reward"` entry per beacon-chain withdrawal. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
 
 ```js
 params: [

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -5019,16 +5019,20 @@ without a full state database.
 :::info
 `eth_getTxWitness` currently only bounds-checks `txIndex` — an index past the end of the
 block is an error, but the witness it returns is the same whole-block witness
-`eth_getWitness` produces. At the genesis block not even that check runs: both methods
-share one implementation that returns the empty witness as soon as the block number
-resolves to `0`, so any `txIndex` is accepted there.
+`eth_getWitness` produces. Two cases are not rejected: the check narrows the index with
+`int(txIndex)`, so on a 64-bit build a value from `0x8000000000000000` upward wraps
+negative and passes; and at the genesis block the check never runs at all, because both
+methods share one implementation that returns the empty witness as soon as the block
+number resolves to `0`.
 :::
 
 **Returns**
 
-`DATA` — the serialized witness. Erigon decodes the bytes it is about to return and
-checks that they rebuild the parent state root, so a witness that comes back is
-self-verified. The genesis block returns an empty witness.
+`DATA` — the serialized witness. On the normal path Erigon decodes the bytes it is about
+to return and checks that they rebuild the parent state root, so the witness is
+self-verified. Two early returns skip that check because they produce no witness to
+verify: the genesis block, and any block whose access set turns out to be empty. Both
+return the empty witness.
 
 **Requirements**
 
@@ -5089,16 +5093,18 @@ Accepted everywhere a block is selected:
 * a `0x`-prefixed hex string without leading zeros — `"0x3"`, `"0x2ed119"`
 * a bare, unquoted JSON integer — `3`
 * the named tags `"earliest"`, `"latest"`, `"safe"`, `"finalized"`, `"pending"`
-* `null`, but only where the selector is optional: it leaves the parameter unset, and
-  the method's own default applies — `latest` for most, though the default is
-  per-method. A **required** block-or-hash parameter rejects top-level `null`:
-  `BlockNumberOrHash.UnmarshalJSON` decodes `null` into an empty struct and then fails
-  with `at least one of BlockNumber or BlockHash is needed if a dictionary is provided`
-  (`rpc/types.go`). That is a property of the type, not a list of special-cased methods
-  — it holds for every method whose selector is a required `BlockNumberOrHash`,
-  including `eth_getBlockReceipts`, `eth_getBlockAccessList`, `eth_simulateV1`,
-  `eth_getWitness`, `eth_getTxWitness`, `eth_getBlockByHash` and
-  `trace_replayBlockTransactions`
+* `null`, whose handling depends on the parameter's type, not on the method:
+  * a plain **block-number** parameter accepts it — `BlockNumber.UnmarshalJSON` maps
+    top-level `null` to `latest`, so `eth_getBlockByNumber`, `trace_block` and the rest
+    of that family take it even though the parameter is required;
+  * an **optional** block-or-hash parameter accepts it too: the selector is left unset
+    and the method's own default applies, `latest` for most;
+  * a **required** block-or-hash parameter rejects it —
+    `BlockNumberOrHash.UnmarshalJSON` decodes `null` into an empty struct and then fails
+    with `at least one of BlockNumber or BlockHash is needed if a dictionary is
+    provided` (`rpc/types.go`). This holds for every such method, including
+    `eth_getBlockReceipts`, `eth_getBlockAccessList`, `eth_simulateV1`, `eth_getWitness`,
+    `eth_getTxWitness`, `eth_getBlockByHash` and `trace_replayBlockTransactions`
 
 Rejected everywhere:
 
@@ -6167,7 +6173,7 @@ The `action` object's shape depends on `type`:
 | --- | --- | --- |
 | `author` | DATA, 20 BYTES | Address receiving the reward (miner / uncle author). |
 | `value` | QUANTITY | Wei amount of the reward. |
-| `rewardType` | String | `"block"` or `"uncle"`. |
+| `rewardType` | String | `"block"` or `"uncle"`, and `"withdrawal"` when `IncludeWithdrawals` is set — see [Beacon-chain withdrawals](#beacon-chain-withdrawals). |
 
 ### Result variants
 
@@ -6408,7 +6414,7 @@ Replays all transactions in a block returning the requested traces for each tran
 
 1. `Quantity`, `Tag`, `Data` or `Object` - A block-number-or-hash selector: an integer block number, a named tag such as `'earliest'`, `'latest'` or `'pending'`, a block hash, or the object form `{"blockNumber": ...}` / `{"blockHash": ...}`. Required — `null` is rejected. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
-3. `Boolean` - Optional. `gasBailOut`.
+3. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still replayed instead of failing the call.
 4. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to have beacon-chain withdrawals reflected in the `stateDiff` output. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
 
 ```js
@@ -6528,8 +6534,8 @@ Returns traces created at given block.
 
 #### Parameters
 
-1. `Quantity` or `Tag` - Integer of a block number, or the string `'earliest'`, `'latest'` or `'pending'`.
-2. `Boolean` - Optional. `gasBailOut`.
+1. `Quantity`, `Tag` or `null` - A plain block number: an integer (hex string or bare JSON integer), a named tag (`'earliest'`, `'latest'`, `'pending'`, `'safe'`, `'finalized'`, or the Erigon-specific `'latestExecuted'`), or `null` / `"null"`, both of which mean `latest`. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
+2. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still traced instead of failing the replay — the OpenEthereum/Parity behaviour.
 3. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to append a `"reward"` entry per beacon-chain withdrawal. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
 
 ```js

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -5068,7 +5068,12 @@ deviates from it in the return shape, which keeps the `raw` field the spec dropp
 * `nonce` — from the pending nonce of `from`, or `0` when `from` is absent
 * `value` — `0` when absent
 * `gas` — from `eth_estimateGas` against `latest`
-* `chainId` — the node's chain ID; a mismatching supplied value is an error
+* `chainId` — the node's chain ID; a mismatching supplied value is an error. It is used
+  for validation and carried by typed transactions, but it does not appear in the
+  returned `tx` for an unsigned legacy transaction: `CallArgs.ToTransaction` builds a
+  `LegacyTx` with no chain-ID field, and the response encoder skips chain-ID derivation
+  while `v` is zero. A pre-London fill, or a post-London fill supplying `gasPrice` with
+  no access list, therefore returns `tx` without `chainId`
 * fee fields — an explicitly supplied `gasPrice` is preserved, before or after London,
   and cannot be combined with `maxFeePerGas` or `maxPriorityFeePerGas`. When it is absent:
   before London `gasPrice` comes from the gas oracle; after London the dynamic fields are
@@ -5113,6 +5118,9 @@ Accepted everywhere a block is selected:
 Rejected everywhere:
 
 * a quoted decimal string — `"3"`, `"100"`
+* a block number above `2^63-1`, in either parameter type — `BlockNumber.UnmarshalJSON`
+  and `BlockNumberOrHash.UnmarshalJSON` both fail with `blocknumber too high`, so
+  `"0x8000000000000000"` and the equivalent bare integer are out of range
 * hex with leading zeros — `"0x01"`
 * hex without the prefix — `"ff"`
 
@@ -6077,8 +6085,11 @@ reported. How they appear depends on the method:
 * **`trace_replayBlockTransactions`** has no block-level slot in its per-transaction
   result shape, so withdrawals surface only through `stateDiff`. You must request
   `"stateDiff"` in the trace types; when you do, one extra entry is appended to the
-  result array, containing only the withdrawal balance changes. Multiple withdrawals to
-  the same address are merged into a single balance change.
+  result array, carrying the withdrawal state changes. Its shape depends on whether the
+  recipient already existed: an existing account gets a `"*"` balance change with `code`
+  and `nonce` marked `"="`, while an account created by the withdrawal itself gets `"+"`
+  entries for `balance`, `code` (`"0x"`) and `nonce` (`"0x0"`). Storage is empty either
+  way. Multiple withdrawals to the same address are merged into a single balance change.
 
 ## JSON-RPC methods
 
@@ -6132,7 +6143,7 @@ A `TraceEntry` represents a single call frame (root call, internal call, contrac
 | `error` | String | (Optional) Present when the call frame errored. `"Reverted"` (title-cased) is the only special-cased value; all other errors are the verbatim Go error string, e.g. `"out of gas"`, `"invalid opcode: ..."`. For `"Reverted"`, `result` is still populated with `gasUsed` and `output` (or `code`/`address` for a `create` frame); for other errors, `result` is `null`. |
 | `subtraces` | QUANTITY | Number of direct child call frames produced by this frame. Used together with `traceAddress` to reconstruct the call tree from a flat list. |
 | `traceAddress` | Array of QUANTITY | Path to this frame inside the call tree. Empty array `[]` for the root call; `[0]` is the first child of the root; `[1, 0]` is the first child of the second child of the root, etc. |
-| `type` | String | One of `"call"`, `"create"`, `"suicide"` (self-destruct), `"reward"` (block/uncle reward — appears in `trace_block` and in `trace_filter` results when the filter matches block coinbases or uncle authors). |
+| `type` | String | One of `"call"`, `"create"`, `"suicide"` (self-destruct), `"reward"` (block, uncle or beacon-chain-withdrawal reward — appears in `trace_block` and in `trace_filter` results when the filter matches block coinbases, uncle authors or withdrawal recipients). |
 | `blockHash` | DATA, 32 BYTES | (Only in block-level methods: `trace_block`, `trace_filter`, `trace_transaction`, `trace_get`) Hash of the block containing the transaction. |
 | `blockNumber` | QUANTITY | (Block-level methods only) Number of the block containing the transaction. |
 | `transactionHash` | DATA, 32 BYTES | (Block-level methods only) Hash of the transaction containing this call frame. Absent for `"reward"` entries. |
@@ -6171,11 +6182,11 @@ The `action` object's shape depends on `type`:
 | `refundAddress` | DATA, 20 BYTES | Address that received the contract's remaining balance. |
 | `balance` | QUANTITY | Wei amount transferred to `refundAddress`. |
 
-**`type: "reward"`** (block/uncle reward, in `trace_block` and `trace_filter`)
+**`type: "reward"`** (block, uncle or withdrawal reward, in `trace_block` and `trace_filter`)
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `author` | DATA, 20 BYTES | Address receiving the reward (miner / uncle author). |
+| `author` | DATA, 20 BYTES | Address receiving the reward — the miner, the uncle author, or the withdrawal recipient when `rewardType` is `"withdrawal"`. |
 | `value` | QUANTITY | Wei amount of the reward. |
 | `rewardType` | String | `"block"` or `"uncle"`, and `"withdrawal"` when `IncludeWithdrawals` is set — see [Beacon-chain withdrawals](#beacon-chain-withdrawals). |
 
@@ -6550,7 +6561,7 @@ params: [
 
 #### Returns
 
-`Array` — flat list of all call frames in the block, including any `"reward"` entries for block/uncle rewards. Each entry includes block-level fields (`blockHash`, `blockNumber`, `transactionHash`, `transactionPosition`). See [Response Fields Reference](#response-fields-reference).
+`Array` — flat list of all call frames in the block, including any `"reward"` entries for block, uncle and (when requested) withdrawal rewards. Every entry carries `blockHash` and `blockNumber`; `transactionHash` and `transactionPosition` are present on transaction call frames but omitted from `"reward"` entries, which no transaction caused. See [Response Fields Reference](#response-fields-reference).
 
 #### Example
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5075,7 +5075,10 @@ deviates from it in the return shape, which keeps the `raw` field the spec dropp
   while `v` is zero. A pre-London fill, or a post-London fill supplying `gasPrice` with
   no access list, therefore returns `tx` without `chainId`
 * fee fields — an explicitly supplied `gasPrice` is preserved, before or after London,
-  and cannot be combined with `maxFeePerGas` or `maxPriorityFeePerGas`. When it is absent:
+  though after London it must be non-zero (`gasPrice must be non-zero after london fork`);
+  before London a zero is accepted. It cannot be combined with `maxFeePerGas` or
+  `maxPriorityFeePerGas`, and a supplied pair must satisfy `maxFeePerGas` non-zero and
+  `>= maxPriorityFeePerGas`. When `gasPrice` is absent:
   before London `gasPrice` comes from the gas oracle; after London the dynamic fields are
   filled independently, `maxPriorityFeePerGas` from the oracle and `maxFeePerGas` as twice
   the base fee plus the tip. The dynamic fields are rejected before London
@@ -5083,13 +5086,21 @@ deviates from it in the return shape, which keeps the `raw` field the spec dropp
 
 **Returns**
 
-An object with `raw`, the RLP-encoded unsigned transaction, and `tx`, the same
-transaction in JSON form. The standardized result carries only `tx`; the extra `raw`
-field is the geth-compatible shape.
+An object with `raw`, the unsigned transaction in its canonical binary encoding, and
+`tx`, the same transaction in JSON form. `raw` comes from `MarshalBinary`, so it is bare
+RLP only for a legacy transaction; a typed one is the EIP-2718 type byte followed by the
+encoded payload, and feeding that straight to an RLP decoder will fail. The standardized
+result carries only `tx`; the extra `raw` field is the geth-compatible shape.
 
 :::info
 KZG commitment and proof generation from raw blobs is not implemented. Blob
 transactions must already carry their `blobVersionedHashes`.
+
+The sidecar fields the specification defines — `blobs`, `commitments` and `proofs` — are
+not supported: `CallArgs` has no field for them, so they are dropped from the request
+without an error even when a complete precomputed sidecar is supplied, and they are
+absent from the returned `tx` and `raw`. Callers that need the sidecar must keep it
+themselves and reattach it before submitting.
 :::
 
 ### Block number parameter format
@@ -6145,7 +6156,7 @@ A `TraceEntry` represents a single call frame (root call, internal call, contrac
 | `error` | String | (Optional) Present when the call frame errored. `"Reverted"` (title-cased) is the only special-cased value; all other errors are the verbatim Go error string, e.g. `"out of gas"`, `"invalid opcode: ..."`. For `"Reverted"`, `result` is still populated with `gasUsed` and `output` (or `code`/`address` for a `create` frame); for other errors, `result` is `null`. |
 | `subtraces` | QUANTITY | Number of direct child call frames produced by this frame. Used together with `traceAddress` to reconstruct the call tree from a flat list. |
 | `traceAddress` | Array of QUANTITY | Path to this frame inside the call tree. Empty array `[]` for the root call; `[0]` is the first child of the root; `[1, 0]` is the first child of the second child of the root, etc. |
-| `type` | String | One of `"call"`, `"create"`, `"suicide"` (self-destruct), `"reward"` (block or uncle reward — appears in `trace_block` and in `trace_filter` results when the filter matches block coinbases or uncle authors; `trace_block` alone also emits beacon-chain-withdrawal rewards, on request). |
+| `type` | String | One of `"call"`, `"create"`, `"suicide"` (self-destruct), `"reward"` (a consensus payout rather than a call — appears in `trace_block` and in `trace_filter` results when the filter matches block coinbases or uncle authors; `trace_block` alone also emits Aura block-reward-contract payouts and, on request, beacon-chain withdrawals. See `rewardType` for the full set). |
 | `blockHash` | DATA, 32 BYTES | (Only in block-level methods: `trace_block`, `trace_filter`, `trace_transaction`, `trace_get`) Hash of the block containing the transaction. |
 | `blockNumber` | QUANTITY | (Block-level methods only) Number of the block containing the transaction. |
 | `transactionHash` | DATA, 32 BYTES | (Block-level methods only) Hash of the transaction containing this call frame. Absent for `"reward"` entries. |
@@ -6184,13 +6195,13 @@ The `action` object's shape depends on `type`:
 | `refundAddress` | DATA, 20 BYTES | Address that received the contract's remaining balance. |
 | `balance` | QUANTITY | Wei amount transferred to `refundAddress`. |
 
-**`type: "reward"`** (block or uncle reward in `trace_block` and `trace_filter`; withdrawal reward in `trace_block` only)
+**`type: "reward"`** (block and uncle rewards in `trace_block` and `trace_filter`; Aura block-reward-contract and withdrawal rewards in `trace_block` only)
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `author` | DATA, 20 BYTES | Address receiving the reward — the miner, the uncle author, or the withdrawal recipient when `rewardType` is `"withdrawal"`. |
+| `author` | DATA, 20 BYTES | Address receiving the reward: the block author, the uncle author, the beneficiary named by the block-reward contract for `"external"` and `"emptyStep"`, or the withdrawal recipient for `"withdrawal"`. |
 | `value` | QUANTITY | Wei amount of the reward. |
-| `rewardType` | String | `"block"` or `"uncle"`. `trace_block` also emits `"withdrawal"` when `IncludeWithdrawals` is set; `trace_filter` never does — see [Beacon-chain withdrawals](#beacon-chain-withdrawals). |
+| `rewardType` | String | `trace_filter` emits only `"block"` and `"uncle"`. `trace_block` maps the consensus reward kind through `rewardKindToString`, so it can also return `"emptyStep"` and `"external"` on Aura chains such as Gnosis (a block-reward-contract payout), or `"unknown"` for an unrecognised kind; it additionally emits `"withdrawal"` when `IncludeWithdrawals` is set — see [Beacon-chain withdrawals](#beacon-chain-withdrawals). |
 
 ### Result variants
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6166,6 +6166,37 @@ reported. How they appear depends on the method:
   entries for `balance`, `code` (`"0x"`) and `nonce` (`"0x0"`). Storage is empty either
   way. Multiple withdrawals to the same address are merged into a single balance change.
 
+## The gasBailOut option
+
+`gasBailOut` relaxes the balance rules during replay. It is exposed as a parameter by
+`trace_replayBlockTransactions`, `trace_replayTransaction`, `trace_block`,
+`trace_transaction`, `trace_get` and `trace_filter`, defaulting to `false` in each.
+`trace_call`, `trace_callMany` and `trace_rawTransaction` take no such parameter and
+always enable it internally, so everything below applies to them unconditionally.
+
+:::warning
+`gasBailOut` is not only a bypass for senders who cannot afford the gas charge. It
+changes replayed state in ways that make the output unsuitable for reconstructing
+balances:
+
+* **Gas and blob fees are never deducted.** `TxnExecutor.buyGas` skips both `SubBalance`
+  calls whenever the flag is set, for *every* replayed transaction — funded senders
+  included, not only underfunded ones.
+* **Refunds are skipped.** The gas-refund path is gated on `refunds && !gasBailout`.
+* **The producer is still paid.** The block producer's tip is credited as usual.
+* **An unaffordable value transfer is credited anyway.** When the sender cannot cover a
+  non-zero `value`, the EVM-level bailout engages and `Transfer` skips the sender debit
+  while still crediting the recipient. Value appears from nowhere, so a trace can show
+  what looks like balance creation.
+:::
+
+Whether one transaction's altered state is visible to the next depends on the execution
+path. Replaying a historical block for traces alone runs each transaction in parallel
+against its own canonical pre-state, so nothing propagates. The sequential path — taken
+when `stateDiff` or `vmTrace` is requested, for Bor state-sync transactions, and for
+single-transaction blocks — carries the altered state forward to every later transaction
+in the block.
+
 ## JSON-RPC methods
 
 #### Ad-hoc Tracing
@@ -6302,6 +6333,8 @@ Executes the given call and returns a number of possible traces for it.
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
 3. `Quantity` or `Tag` - (optional) Integer of a block number, or the string `'earliest'`, `'latest'` or `'pending'`.
 
+This method takes no `gasBailOut` parameter — it always replays with the bailout enabled. See [The gasBailOut option](#the-gasbailout-option).
+
 #### Returns
 
 `Object` containing `output`, `stateDiff`, `trace[]`, `vmTrace`. Each requested trace type is populated; the others are `null`. See [Response Fields Reference](#response-fields-reference) for full field semantics.
@@ -6348,6 +6381,8 @@ Performs multiple call traces on top of the same block. i.e. transaction `n` wil
 
 1. `Array` - List of trace calls with the type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
 2. `Quantity` or `Tag` - (optional) integer block number, or the string `'latest'`, `'earliest'` or `'pending'` (default block parameter).
+
+This method takes no `gasBailOut` parameter — it always replays with the bailout enabled. See [The gasBailOut option](#the-gasbailout-option).
 
 ```js
 params: [
@@ -6451,6 +6486,8 @@ Traces a call to `eth_sendRawTransaction` without making the call, returning the
 1. `Data` - Raw transaction data.
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
 
+This method takes no `gasBailOut` parameter — it always replays with the bailout enabled. See [The gasBailOut option](#the-gasbailout-option).
+
 ```js
 params: [
   "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675",
@@ -6504,17 +6541,8 @@ Replays all transactions in a block returning the requested traces for each tran
 
 1. `Quantity`, `Tag`, `Data` or `Object` - A block-number-or-hash selector: an integer block number, a named tag such as `'earliest'`, `'latest'` or `'pending'`, a block hash, or the object form `{"blockNumber": ...}` / `{"blockHash": ...}`. Required — `null` is rejected. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
-3. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still replayed instead of failing the call. It does more than bypass that check — see the warning below.
+3. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still replayed instead of failing the call. It does more than bypass that check — see [The gasBailOut option](#the-gasbailout-option).
 4. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to have beacon-chain withdrawals reflected in the `stateDiff` output. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
-
-:::warning
-`gasBailOut` alters replayed state for **every** transaction, not only underfunded ones.
-`TxnExecutor.buyGas` skips the sender's gas and blob-fee deductions whenever it is set,
-the gas-refund path is skipped along with them, and the block producer's tip is still
-credited. The resulting `stateDiff`, and the state each later transaction in the block
-sees, therefore differ from a normal replay — do not use the output to reconstruct
-balances.
-:::
 
 ```js
 params: [
@@ -6584,6 +6612,7 @@ Replays a transaction, returning the traces.
 
 1. `Hash` - Transaction hash.
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
+3. `Boolean` - Optional, default `false`. `gasBailOut`. See [The gasBailOut option](#the-gasbailout-option).
 
 ```js
 params: [
@@ -6637,17 +6666,8 @@ Returns traces created at given block.
 #### Parameters
 
 1. `Quantity`, `Tag` or `null` - A plain block number: an integer (hex string or bare JSON integer), a named tag (`'earliest'`, `'latest'`, `'pending'`, `'safe'`, `'finalized'`, or the Erigon-specific `'latestExecuted'`), or `null` / `"null"`, both of which mean `latest`. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
-2. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still traced instead of failing the replay — the OpenEthereum/Parity behaviour. It does more than bypass that check — see the warning below.
+2. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still traced instead of failing the replay — the OpenEthereum/Parity behaviour. It does more than bypass that check — see [The gasBailOut option](#the-gasbailout-option).
 3. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to append a `"reward"` entry per beacon-chain withdrawal. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
-
-:::warning
-`gasBailOut` alters replayed state for **every** transaction, not only underfunded ones.
-`TxnExecutor.buyGas` skips the sender's gas and blob-fee deductions whenever it is set,
-the gas-refund path is skipped along with them, and the block producer's tip is still
-credited. The resulting `stateDiff`, and the state each later transaction in the block
-sees, therefore differ from a normal replay — do not use the output to reconstruct
-balances.
-:::
 
 ```js
 params: [
@@ -6716,6 +6736,7 @@ Returns traces matching given filter
    * `after`: `Quantity` - (optional) The offset trace number
    * `count`: `Quantity` - (optional) Integer number of traces to display in a batch.
    * `mode`: `String` - (optional) Default is `"union"`, meaning traces matching either address filter are returned. Set to `"intersection"` to only return traces that satisfy both `fromAddress` and `toAddress` filters simultaneously.
+2. `Boolean` - Optional, default `false`. `gasBailOut`. See [The gasBailOut option](#the-gasbailout-option).
 
 ```js
 params: [{
@@ -6729,7 +6750,7 @@ params: [{
 
 #### Returns
 
-`Array` — flat list of call frames that match the filter, including any `"reward"` entries when the filter matches block coinbases or uncle authors. Each entry has block-level fields (`blockHash`, `blockNumber`, `transactionHash`, `transactionPosition`). See [Response Fields Reference](#response-fields-reference).
+`Array` — flat list of call frames that match the filter, including any `"reward"` entries when the filter matches block coinbases or uncle authors. Call frames carry `blockHash`, `blockNumber`, `transactionHash` and `transactionPosition`; `"reward"` entries are block-level and carry only `blockHash` and `blockNumber` — `newRewardTrace` sets no transaction fields at all. See [Response Fields Reference](#response-fields-reference).
 
 #### Example
 
@@ -6782,6 +6803,7 @@ Returns trace at given position.
 
 1. `Hash` - Transaction hash.
 2. `Array` - Index positions of the traces.
+3. `Boolean` - Optional, default `false`. `gasBailOut`. See [The gasBailOut option](#the-gasbailout-option).
 
 ```js
 params: [
@@ -6843,6 +6865,7 @@ Returns all traces of given transaction
 #### Parameters
 
 1. `Hash` - Transaction hash
+2. `Boolean` - Optional, default `false`. `gasBailOut`. See [The gasBailOut option](#the-gasbailout-option).
 
 ```js
 params: ["0x17104ac9d3312d8c136b7f44d4b8b47852618065ebfa534bd2d3b5ef218ca1f3"]

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4939,7 +4939,9 @@ For API usage refer to the below official resources:
 * [https://ethereum.github.io/execution-apis/](https://ethereum.github.io/execution-apis/)
 
 The sections below cover only the places where Erigon adds a method that is not in that
-standard set, or where its behaviour differs from it. Everything else follows the spec.
+standard set, or where its behaviour differs from it. They are not an exhaustive
+compliance statement: anything not listed here is expected to follow the spec, but a
+deviation that has not yet been documented may still exist.
 
 ### eth\_getProof
 
@@ -5034,9 +5036,12 @@ Both methods need commitment history, so start the node with:
 --prune.include-commitment-history
 ```
 
-Without it the call fails with `eth_getWitness requires commitment history`. If the
-requested block is older than the retained commitment history, it fails with
-`commitment history pruned`.
+Without it the call fails with an error starting with `eth_getWitness requires
+commitment history`; the message continues with a restart hint that names the
+`--prune.experimental.include-commitment-history` alias rather than the canonical flag
+above. If the requested block is older than the retained commitment history, the call
+fails with an error starting with `commitment history pruned`, followed by the retained
+range.
 
 ### eth\_fillTransaction
 
@@ -6013,10 +6018,16 @@ then it should look something like:
 
 Beacon-chain withdrawals credit balances outside of any transaction, so by default no
 trace mentions them. `trace_block` and `trace_replayBlockTransactions` can be asked to
-include them by passing a trace-settings object as the last positional parameter:
+include them by passing a trace-settings object as the last positional parameter. It is
+positional, so the parameters before it have to be supplied even when they are not
+otherwise needed:
 
 ```js
-{ "IncludeWithdrawals": true }
+// trace_block(blockNumber, gasBailOut, traceSettings)
+["0x1194bf0", false, { "IncludeWithdrawals": true }]
+
+// trace_replayBlockTransactions(blockNumber, traceTypes, gasBailOut, traceSettings)
+["0x1194bf0", ["stateDiff"], false, { "IncludeWithdrawals": true }]
 ```
 
 The default is off — omit the object, or leave the field out, and withdrawals are not

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4943,6 +4943,15 @@ standard set, or where its behaviour differs from it. They are not an exhaustive
 compliance statement: anything not listed here is expected to follow the spec, but a
 deviation that has not yet been documented may still exist.
 
+:::info
+`execution-apis` is a living specification rather than a frozen standard — methods are
+still being added, and some long-standing `eth` behaviour was never specified at all — so
+parts of what follows are differences from a moving target rather than defects. Erigon
+runs the specification's own conformance vectors in CI (Hive's `rpc-compat` suite against
+a pinned `execution-apis` revision) and works with the other client teams on closing
+these gaps, so this page will change as the two converge.
+:::
+
 ### eth\_getProof
 
 `eth_getProof` returns Merkle proofs for account state and storage slots, as defined in [EIP-1186](https://eips.ethereum.org/EIPS/eip-1186). It is stable and production-ready as of Erigon v3.4.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5019,7 +5019,9 @@ without a full state database.
 :::info
 `eth_getTxWitness` currently only bounds-checks `txIndex` — an index past the end of the
 block is an error, but the witness it returns is the same whole-block witness
-`eth_getWitness` produces.
+`eth_getWitness` produces. At the genesis block not even that check runs: both methods
+share one implementation that returns the empty witness as soon as the block number
+resolves to `0`, so any `txIndex` is accepted there.
 :::
 
 **Returns**
@@ -5030,14 +5032,17 @@ self-verified. The genesis block returns an empty witness.
 
 **Requirements**
 
-Both methods need commitment history, so start the node with:
+Both methods need commitment history for any block above genesis, so start the node with:
 
 ```text
 --prune.include-commitment-history
 ```
 
-Without it the call fails with an error starting with `eth_getWitness requires
-commitment history`; the message continues with a restart hint that names the
+The genesis block is the one exception: the empty witness is returned before the
+commitment-history check, so `eth_getWitness` and `eth_getTxWitness` succeed at block `0`
+on a node without commitment history. For every other block, without it the call fails
+with an error starting with `eth_getWitness requires commitment history`; the message
+continues with a restart hint that names the
 `--prune.experimental.include-commitment-history` alias rather than the canonical flag
 above. If the requested block is older than the retained commitment history, the call
 fails with an error starting with `commitment history pruned`, followed by the retained
@@ -5084,9 +5089,16 @@ Accepted everywhere a block is selected:
 * a `0x`-prefixed hex string without leading zeros — `"0x3"`, `"0x2ed119"`
 * a bare, unquoted JSON integer — `3`
 * the named tags `"earliest"`, `"latest"`, `"safe"`, `"finalized"`, `"pending"`
-* `null`, which means `latest` — except in the few methods whose block-or-hash
-  parameter is required (`eth_getBlockReceipts`, `eth_getBlockAccessList`,
-  `eth_simulateV1`, `eth_getWitness`, `eth_getTxWitness`), which reject it
+* `null`, but only where the selector is optional: it leaves the parameter unset, and
+  the method's own default applies — `latest` for most, though the default is
+  per-method. A **required** block-or-hash parameter rejects top-level `null`:
+  `BlockNumberOrHash.UnmarshalJSON` decodes `null` into an empty struct and then fails
+  with `at least one of BlockNumber or BlockHash is needed if a dictionary is provided`
+  (`rpc/types.go`). That is a property of the type, not a list of special-cased methods
+  — it holds for every method whose selector is a required `BlockNumberOrHash`,
+  including `eth_getBlockReceipts`, `eth_getBlockAccessList`, `eth_simulateV1`,
+  `eth_getWitness`, `eth_getTxWitness`, `eth_getBlockByHash` and
+  `trace_replayBlockTransactions`
 
 Rejected everywhere:
 
@@ -5101,11 +5113,24 @@ and are now rejected with `hex string without 0x prefix`, returned as an
 integer `3`, or a named tag.
 :::
 
-Two further forms are accepted only by methods whose parameter is a plain block number,
-such as `eth_getBlockByNumber`, `eth_getBlockTransactionCountByNumber` and `trace_block`:
-the Erigon-specific tag `"latestExecuted"`, and the string `"null"`, which means `latest`.
+Two further forms exist: the Erigon-specific tag `"latestExecuted"`, and the string
+`"null"`, which means `latest`. Both are parsed by `BlockNumber.UnmarshalJSON`, so they are
+accepted unconditionally by methods whose parameter is a plain block number — such as
+`eth_getBlockByNumber`, `eth_getBlockTransactionCountByNumber` and `trace_block`.
+
 Methods taking a block-number-or-hash selector — `eth_call`, `eth_getBalance`,
-`eth_getProof` and the rest — reject both.
+`eth_getProof` and the rest — reject both **as top-level strings** only.
+`BlockNumberOrHash.UnmarshalJSON` tries the object form first, and that path decodes the
+`blockNumber` field through `BlockNumber`, which does accept them. So on those
+block-number-or-hash methods the object-wrapped forms work:
+
+```json
+{"blockNumber": "latestExecuted"}
+{"blockNumber": "null"}
+```
+
+while the bare strings `"latestExecuted"` and `"null"` fail on those same methods, because
+the top-level string switch does not list them.
 
 ### Filter lifetime
 
@@ -6072,7 +6097,7 @@ All `trace_*` methods return objects built from the same set of fields. Each met
 | --- | --- |
 | `trace_call`, `trace_rawTransaction`, `trace_replayTransaction` | `Object` with `output`, `stateDiff`, `trace[]`, `vmTrace` |
 | `trace_callMany` | `Array` — one per input call |
-| `trace_replayBlockTransactions` | `Array` — one per transaction; each entry adds `transactionHash` |
+| `trace_replayBlockTransactions` | `Array` — one per transaction; each entry adds `transactionHash`. One extra trailing entry when withdrawals are requested — see [trace_replayBlockTransactions](#trace_replayblocktransactions) |
 | `trace_block`, `trace_filter`, `trace_transaction` | `Array` (flat list across all call frames) |
 | `trace_get` | `TraceEntry` (single call frame at the requested position) |
 
@@ -6381,7 +6406,7 @@ Replays all transactions in a block returning the requested traces for each tran
 
 #### Parameters
 
-1. `Quantity` or `Tag` - Integer of a block number, or the string `'earliest'`, `'latest'` or `'pending'`.
+1. `Quantity`, `Tag`, `Data` or `Object` - A block-number-or-hash selector: an integer block number, a named tag such as `'earliest'`, `'latest'` or `'pending'`, a block hash, or the object form `{"blockNumber": ...}` / `{"blockHash": ...}`. Required — `null` is rejected. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
 3. `Boolean` - Optional. `gasBailOut`.
 4. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to have beacon-chain withdrawals reflected in the `stateDiff` output. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
@@ -6395,7 +6420,15 @@ params: [
 
 #### Returns
 
-`Array` — one entry per transaction in the block. Each entry is shaped like the `trace_call` response plus a `transactionHash` field identifying the transaction. See [Response Fields Reference](#response-fields-reference).
+`Array` — by default one entry per transaction in the block (see below for the one exception). Each entry is shaped like the `trace_call` response plus a `transactionHash` field identifying the transaction. See [Response Fields Reference](#response-fields-reference).
+
+The one-entry-per-transaction mapping does not hold when withdrawals are requested.
+With `"stateDiff"` in the trace types and `"IncludeWithdrawals": true` in the trace
+settings, a block that has withdrawals gets **one extra entry appended** after the
+last transaction — an empty `trace` and a `stateDiff` carrying only the withdrawal
+balance changes, with no `transactionHash`. Consumers that index results positionally
+against the block's transaction list must skip that trailing entry. See [Beacon-chain
+withdrawals](#beacon-chain-withdrawals).
 
 #### Example
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6342,6 +6342,7 @@ Executes the given call and returns a number of possible traces for it.
 1. `Object` - \[Transaction object] where `from` field is optional and `nonce` field is omitted.
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
 3. `Quantity` or `Tag` - (optional) Integer of a block number, or the string `'earliest'`, `'latest'` or `'pending'`.
+4. `Object` - Optional trace settings (`TraceConfig`), the same object the other `trace` methods accept.
 
 This method takes no `gasBailOut` parameter — it always replays with the bailout enabled. See [The gasBailOut option](#the-gasbailout-option).
 
@@ -6391,6 +6392,7 @@ Performs multiple call traces on top of the same block. i.e. transaction `n` wil
 
 1. `Array` - List of trace calls with the type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
 2. `Quantity` or `Tag` - (optional) integer block number, or the string `'latest'`, `'earliest'` or `'pending'` (default block parameter).
+3. `Object` - Optional trace settings (`TraceConfig`), the same object the other `trace` methods accept.
 
 This method takes no `gasBailOut` parameter — it always replays with the bailout enabled. See [The gasBailOut option](#the-gasbailout-option).
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5065,8 +5065,21 @@ deviates from it in the return shape, which keeps the `raw` field the spec dropp
 
 The standard `type` field is ignored. `CallArgs` has no field for it and unknown JSON
 properties are accepted silently, so the envelope is inferred from whichever fee,
-access-list and blob fields are present. On a post-London head, `{"type": "0x0"}` with no
-`gasPrice` comes back as a type `0x2` transaction rather than the legacy type requested.
+access-list and blob fields are present. On a post-London head, a request such as
+
+```json
+{
+  "from": "0x71562b71999873db5b286df957af199ec94617f7",
+  "to": "0x0d3ab14bbad3d99f4203bd7a11acb94882050e7e",
+  "gas": "0x5208",
+  "type": "0x0"
+}
+```
+
+comes back as a type `0x2` transaction rather than the legacy type requested, because no
+`gasPrice` was supplied. The `to` field is not decoration: a fill with neither `to` nor
+contract-creation data fails with `contract creation without any data provided` before a
+transaction is built at all.
 
 **Fills in**
 
@@ -5097,12 +5110,18 @@ RLP only for a legacy transaction; a typed one is the EIP-2718 type byte followe
 encoded payload, and feeding that straight to an RLP decoder will fail. The standardized
 result carries only `tx`; the extra `raw` field is the geth-compatible shape.
 
-A typed result also carries `gasPrice: null`. `FillTransaction` passes no base fee to the
-response encoder, so `computeGasPrice` returns nothing and the missing key is filled with
-`null` — deliberate geth parity, pinned by `rpc/ethapi/api_test.go`. The standardized
-type-2 unsigned schema requires `gasPrice` to be a hex quantity, so a schema-validating
-client will reject the result; read `maxFeePerGas` and `maxPriorityFeePerGas` instead.
-Legacy results carry a real `gasPrice`.
+A dynamic-fee result — types `0x2`, `0x3` and `0x4` — also carries `gasPrice: null`.
+`FillTransaction` passes no base fee to the response encoder, so `computeGasPrice`
+returns nothing and the missing key is filled with `null` — deliberate geth parity,
+pinned by `rpc/ethapi/api_test.go`. The standardized type-2 unsigned schema requires
+`gasPrice` to be a hex quantity, so a schema-validating client will reject the result;
+read `maxFeePerGas` and `maxPriorityFeePerGas` instead.
+
+Legacy (`0x0`) and access-list (`0x1`) results are not affected: `NewRPCTransaction`
+takes their `gasPrice` from the tip cap, so it is a real hex quantity. Those two carry
+`maxFeePerGas: null` and `maxPriorityFeePerGas: null` instead, filled in by the same
+rule. A type `0x1` fill is reached by supplying `gasPrice` together with an
+`accessList` — Erigon keeps the list where geth drops it to a legacy transaction.
 
 :::info
 KZG commitment and proof generation from raw blobs is not implemented. Blob
@@ -5120,7 +5139,16 @@ themselves and reattach it before submitting.
 Erigon accepts more block-number forms than the standard schema, which allows only a
 `0x`-prefixed hex quantity string or a named tag.
 
-Accepted everywhere a block is selected:
+The rules below govern parameters decoded as `BlockNumber` or `BlockNumberOrHash` — the
+selector of `eth_getBlockByNumber`, `eth_getBalance`, `eth_call`, `trace_block` and the
+rest of that family. They do not apply to methods that select a block through a fixed
+`common.Hash` parameter: `eth_getBlockTransactionCountByHash`,
+`eth_getTransactionByBlockHashAndIndex`, `eth_getRawTransactionByBlockHashAndIndex`,
+`eth_getUncleByBlockHashAndIndex` and `eth_getUncleCountByBlockHash` take a 32-byte hash
+and nothing else. `eth_getBlockByHash` is not one of them — despite the name its
+parameter is a `BlockNumberOrHash`, so it follows the rules here.
+
+Accepted:
 
 * a `0x`-prefixed hex string without leading zeros — `"0x3"`, `"0x2ed119"`
 * a bare, unquoted JSON integer — `3`
@@ -5138,7 +5166,7 @@ Accepted everywhere a block is selected:
     `eth_getBlockReceipts`, `eth_getBlockAccessList`, `eth_simulateV1`, `eth_getWitness`,
     `eth_getTxWitness`, `eth_getBlockByHash` and `trace_replayBlockTransactions`
 
-Rejected everywhere:
+Rejected by both parameter types:
 
 * a quoted decimal string — `"3"`, `"100"`
 * a block number above `2^63-1` — out of range in both parameter types, though the error

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6190,14 +6190,15 @@ balances:
   non-zero `value`, the EVM-level bailout engages and `Transfer` skips the sender debit
   while still crediting the recipient. Value appears from nowhere, so a trace can show
   what looks like balance creation.
-* **On Gnosis and Chiado, the burn contract is credited too.** Where the chain
-  configures a `burntContract` — Gnosis and Chiado do, most chains do not — a **non-free**
-  London transaction credits it `gasUsed * baseFee`, plus the blob fee on Aura from
-  Prague. The sender was never debited, so this is a second source of apparent balance
-  creation in `stateDiff` on those chains. Aura marks zero-fee certified service
-  transactions as free, and the credit is guarded by `!msg.IsFree()`, so those are
-  excluded. Chains that simply burn the base fee never receive this extra credit — every
-  other effect above still applies to them.
+* **Where the chain configures a burn contract, that contract is credited too.** A
+  **non-free** London transaction credits the configured `burntContract` with
+  `gasUsed * baseFee`; on Aura from Prague the blob fee is added on top. Gnosis and
+  Chiado configure one, and so do Polygon's Bor chains — mainnet, Amoy, Mumbai and the
+  devnet. The sender was never debited, so this is a second source of apparent balance
+  creation in `stateDiff`. Aura marks zero-fee certified service transactions as free
+  and the credit is guarded by `!msg.IsFree()`, so those are excluded. Chains with no
+  configured contract never receive this extra credit — every other effect above still
+  applies to them.
 :::
 
 Whether one transaction's altered state is visible to the next depends on the execution

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6191,10 +6191,13 @@ balances:
   while still crediting the recipient. Value appears from nowhere, so a trace can show
   what looks like balance creation.
 * **On Gnosis and Chiado, the burn contract is credited too.** Where the chain
-  configures a `burntContract` — Gnosis and Chiado do, most chains do not — a London
-  transaction credits it `gasUsed * baseFee`, plus the blob fee on Aura from Prague. The
-  sender was never debited, so this is a second source of apparent balance creation in
-  `stateDiff` on those chains. Chains that simply burn the base fee are unaffected.
+  configures a `burntContract` — Gnosis and Chiado do, most chains do not — a **non-free**
+  London transaction credits it `gasUsed * baseFee`, plus the blob fee on Aura from
+  Prague. The sender was never debited, so this is a second source of apparent balance
+  creation in `stateDiff` on those chains. Aura marks zero-fee certified service
+  transactions as free, and the credit is guarded by `!msg.IsFree()`, so those are
+  excluded. Chains that simply burn the base fee never receive this extra credit — every
+  other effect above still applies to them.
 :::
 
 Whether one transaction's altered state is visible to the next depends on the execution
@@ -6620,6 +6623,7 @@ Replays a transaction, returning the traces.
 1. `Hash` - Transaction hash.
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
 3. `Boolean` - Optional, default `false`. `gasBailOut`. See [The gasBailOut option](#the-gasbailout-option).
+4. `Object` - Optional trace settings (`TraceConfig`), the same object the other `trace` methods accept.
 
 ```js
 params: [
@@ -6744,6 +6748,7 @@ Returns traces matching given filter
    * `count`: `Quantity` - (optional) Integer number of traces to display in a batch.
    * `mode`: `String` - (optional) Default is `"union"`, meaning traces matching either address filter are returned. Set to `"intersection"` to only return traces that satisfy both `fromAddress` and `toAddress` filters simultaneously.
 2. `Boolean` - Optional, default `false`. `gasBailOut`. See [The gasBailOut option](#the-gasbailout-option).
+3. `Object` - Optional trace settings (`TraceConfig`), the same object the other `trace` methods accept.
 
 ```js
 params: [{
@@ -6811,6 +6816,7 @@ Returns trace at given position.
 1. `Hash` - Transaction hash.
 2. `Array` - Index positions of the traces.
 3. `Boolean` - Optional, default `false`. `gasBailOut`. See [The gasBailOut option](#the-gasbailout-option).
+4. `Object` - Optional trace settings (`TraceConfig`), the same object the other `trace` methods accept.
 
 ```js
 params: [
@@ -6873,6 +6879,7 @@ Returns all traces of given transaction
 
 1. `Hash` - Transaction hash
 2. `Boolean` - Optional, default `false`. `gasBailOut`. See [The gasBailOut option](#the-gasbailout-option).
+3. `Object` - Optional trace settings (`TraceConfig`), the same object the other `trace` methods accept.
 
 ```js
 params: ["0x17104ac9d3312d8c136b7f44d4b8b47852618065ebfa534bd2d3b5ef218ca1f3"]

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5118,9 +5118,11 @@ Accepted everywhere a block is selected:
 Rejected everywhere:
 
 * a quoted decimal string — `"3"`, `"100"`
-* a block number above `2^63-1`, in either parameter type — `BlockNumber.UnmarshalJSON`
-  and `BlockNumberOrHash.UnmarshalJSON` both fail with `blocknumber too high`, so
-  `"0x8000000000000000"` and the equivalent bare integer are out of range
+* a block number above `2^63-1` — out of range in both parameter types, though the error
+  differs: a plain **block-number** parameter fails with `block number larger than
+  int64`, while a top-level numeric or hex **block-or-hash** value fails with
+  `blocknumber too high` (`rpc/types.go`). `"0x8000000000000000"` and the equivalent
+  bare integer are rejected either way
 * hex with leading zeros — `"0x01"`
 * hex without the prefix — `"ff"`
 
@@ -6143,7 +6145,7 @@ A `TraceEntry` represents a single call frame (root call, internal call, contrac
 | `error` | String | (Optional) Present when the call frame errored. `"Reverted"` (title-cased) is the only special-cased value; all other errors are the verbatim Go error string, e.g. `"out of gas"`, `"invalid opcode: ..."`. For `"Reverted"`, `result` is still populated with `gasUsed` and `output` (or `code`/`address` for a `create` frame); for other errors, `result` is `null`. |
 | `subtraces` | QUANTITY | Number of direct child call frames produced by this frame. Used together with `traceAddress` to reconstruct the call tree from a flat list. |
 | `traceAddress` | Array of QUANTITY | Path to this frame inside the call tree. Empty array `[]` for the root call; `[0]` is the first child of the root; `[1, 0]` is the first child of the second child of the root, etc. |
-| `type` | String | One of `"call"`, `"create"`, `"suicide"` (self-destruct), `"reward"` (block, uncle or beacon-chain-withdrawal reward — appears in `trace_block` and in `trace_filter` results when the filter matches block coinbases, uncle authors or withdrawal recipients). |
+| `type` | String | One of `"call"`, `"create"`, `"suicide"` (self-destruct), `"reward"` (block or uncle reward — appears in `trace_block` and in `trace_filter` results when the filter matches block coinbases or uncle authors; `trace_block` alone also emits beacon-chain-withdrawal rewards, on request). |
 | `blockHash` | DATA, 32 BYTES | (Only in block-level methods: `trace_block`, `trace_filter`, `trace_transaction`, `trace_get`) Hash of the block containing the transaction. |
 | `blockNumber` | QUANTITY | (Block-level methods only) Number of the block containing the transaction. |
 | `transactionHash` | DATA, 32 BYTES | (Block-level methods only) Hash of the transaction containing this call frame. Absent for `"reward"` entries. |
@@ -6182,13 +6184,13 @@ The `action` object's shape depends on `type`:
 | `refundAddress` | DATA, 20 BYTES | Address that received the contract's remaining balance. |
 | `balance` | QUANTITY | Wei amount transferred to `refundAddress`. |
 
-**`type: "reward"`** (block, uncle or withdrawal reward, in `trace_block` and `trace_filter`)
+**`type: "reward"`** (block or uncle reward in `trace_block` and `trace_filter`; withdrawal reward in `trace_block` only)
 
 | Field | Type | Description |
 | --- | --- | --- |
 | `author` | DATA, 20 BYTES | Address receiving the reward — the miner, the uncle author, or the withdrawal recipient when `rewardType` is `"withdrawal"`. |
 | `value` | QUANTITY | Wei amount of the reward. |
-| `rewardType` | String | `"block"` or `"uncle"`, and `"withdrawal"` when `IncludeWithdrawals` is set — see [Beacon-chain withdrawals](#beacon-chain-withdrawals). |
+| `rewardType` | String | `"block"` or `"uncle"`. `trace_block` also emits `"withdrawal"` when `IncludeWithdrawals` is set; `trace_filter` never does — see [Beacon-chain withdrawals](#beacon-chain-withdrawals). |
 
 ### Result variants
 
@@ -6446,8 +6448,11 @@ params: [
 The one-entry-per-transaction mapping does not hold when withdrawals are requested.
 With `"stateDiff"` in the trace types and `"IncludeWithdrawals": true` in the trace
 settings, a block that has withdrawals gets **one extra entry appended** after the
-last transaction — an empty `trace` and a `stateDiff` carrying only the withdrawal
-balance changes, with no `transactionHash`. Consumers that index results positionally
+last transaction — an empty `trace` and a `stateDiff` carrying only the withdrawal state
+changes, with no `transactionHash`. That diff is a balance change alone only when the
+recipient already existed; a recipient created by the withdrawal also gets `code` and
+`nonce` entries, as described under [Beacon-chain withdrawals](#beacon-chain-withdrawals).
+Consumers that index results positionally
 against the block's transaction list must skip that trailing entry. See [Beacon-chain
 withdrawals](#beacon-chain-withdrawals).
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5069,7 +5069,11 @@ deviates from it in the return shape, which keeps the `raw` field the spec dropp
 * `value` — `0` when absent
 * `gas` — from `eth_estimateGas` against `latest`
 * `chainId` — the node's chain ID; a mismatching supplied value is an error
-* fee fields — `gasPrice` before London, otherwise `maxFeePerGas` / `maxPriorityFeePerGas` from the gas oracle
+* fee fields — an explicitly supplied `gasPrice` is preserved, before or after London,
+  and cannot be combined with `maxFeePerGas` or `maxPriorityFeePerGas`. When it is absent:
+  before London `gasPrice` comes from the gas oracle; after London the dynamic fields are
+  filled independently, `maxPriorityFeePerGas` from the oracle and `maxFeePerGas` as twice
+  the base fee plus the tip. The dynamic fields are rejected before London
 * `maxFeePerBlobGas` — for blob transactions, twice the current blob gas price
 
 **Returns**
@@ -6103,7 +6107,7 @@ All `trace_*` methods return objects built from the same set of fields. Each met
 | --- | --- |
 | `trace_call`, `trace_rawTransaction`, `trace_replayTransaction` | `Object` with `output`, `stateDiff`, `trace[]`, `vmTrace` |
 | `trace_callMany` | `Array` — one per input call |
-| `trace_replayBlockTransactions` | `Array` — one per transaction; each entry adds `transactionHash`. One extra trailing entry when withdrawals are requested — see [trace_replayBlockTransactions](#trace_replayblocktransactions) |
+| `trace_replayBlockTransactions` | `Array` — one per transaction; each entry adds `transactionHash`. One extra trailing entry when `stateDiff` is requested with `"IncludeWithdrawals": true` and the block has withdrawals — see [trace_replayBlockTransactions](#trace_replayblocktransactions) |
 | `trace_block`, `trace_filter`, `trace_transaction` | `Array` (flat list across all call frames) |
 | `trace_get` | `TraceEntry` (single call frame at the requested position) |
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5063,6 +5063,11 @@ deviates from it in the return shape, which keeps the `raw` field the spec dropp
 
 1. `Object` — a transaction object in the same shape `eth_call` accepts.
 
+The standard `type` field is ignored. `CallArgs` has no field for it and unknown JSON
+properties are accepted silently, so the envelope is inferred from whichever fee,
+access-list and blob fields are present. On a post-London head, `{"type": "0x0"}` with no
+`gasPrice` comes back as a type `0x2` transaction rather than the legacy type requested.
+
 **Fills in**
 
 * `nonce` — from the pending nonce of `from`, or `0` when `from` is absent
@@ -5091,6 +5096,13 @@ An object with `raw`, the unsigned transaction in its canonical binary encoding,
 RLP only for a legacy transaction; a typed one is the EIP-2718 type byte followed by the
 encoded payload, and feeding that straight to an RLP decoder will fail. The standardized
 result carries only `tx`; the extra `raw` field is the geth-compatible shape.
+
+A typed result also carries `gasPrice: null`. `FillTransaction` passes no base fee to the
+response encoder, so `computeGasPrice` returns nothing and the missing key is filled with
+`null` — deliberate geth parity, pinned by `rpc/ethapi/api_test.go`. The standardized
+type-2 unsigned schema requires `gasPrice` to be a hex quantity, so a schema-validating
+client will reject the result; read `maxFeePerGas` and `maxPriorityFeePerGas` instead.
+Legacy results carry a real `gasPrice`.
 
 :::info
 KZG commitment and proof generation from raw blobs is not implemented. Blob
@@ -6199,9 +6211,9 @@ The `action` object's shape depends on `type`:
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `author` | DATA, 20 BYTES | Address receiving the reward: the block author, the uncle author, the beneficiary named by the block-reward contract for `"external"` and `"emptyStep"`, or the withdrawal recipient for `"withdrawal"`. |
+| `author` | DATA, 20 BYTES | Address receiving the reward: the block author, the uncle author, the beneficiary attributed by the block-reward contract for `"external"`, or the withdrawal recipient for `"withdrawal"`. |
 | `value` | QUANTITY | Wei amount of the reward. |
-| `rewardType` | String | `trace_filter` emits only `"block"` and `"uncle"`. `trace_block` maps the consensus reward kind through `rewardKindToString`, so it can also return `"emptyStep"` and `"external"` on Aura chains such as Gnosis (a block-reward-contract payout), or `"unknown"` for an unrecognised kind; it additionally emits `"withdrawal"` when `IncludeWithdrawals` is set — see [Beacon-chain withdrawals](#beacon-chain-withdrawals). |
+| `rewardType` | String | `trace_filter` emits only `"block"` and `"uncle"`. `trace_block` maps the consensus reward kind through `rewardKindToString`, so it also returns `"external"` for a block-reward-contract payout on Aura chains such as Gnosis, and emits `"withdrawal"` when `IncludeWithdrawals` is set — see [Beacon-chain withdrawals](#beacon-chain-withdrawals). That mapping additionally defines `"emptyStep"` (an AuthorityRound empty-step author) and `"unknown"`, but no current code path produces either. |
 
 ### Result variants
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6182,7 +6182,9 @@ balances:
 * **Gas and blob fees are never deducted.** `TxnExecutor.buyGas` skips both `SubBalance`
   calls whenever the flag is set, for *every* replayed transaction — funded senders
   included, not only underfunded ones.
-* **Refunds are skipped.** The gas-refund path is gated on `refunds && !gasBailout`.
+* **Refunds are skipped.** The gas-refund path is gated on `refunds && !gasBailout` — that
+  is the internal Go parameter, spelled with a lowercase `o`, not the JSON-RPC
+  `gasBailOut` this section documents.
 * **The producer is still paid.** The block producer's tip is credited as usual.
 * **An unaffordable value transfer is credited anyway.** When the sender cannot cover a
   non-zero `value`, the EVM-level bailout engages and `Transfer` skips the sender debit
@@ -6544,7 +6546,7 @@ Replays all transactions in a block returning the requested traces for each tran
 
 #### Parameters
 
-1. `Quantity`, `Tag`, `Data` or `Object` - A block-number-or-hash selector: an integer block number, a named tag such as `'earliest'`, `'latest'` or `'pending'`, a block hash, or the object form `{"blockNumber": ...}` / `{"blockHash": ...}`. Required — `null` is rejected. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
+1. `Quantity`, `Number`, `Tag`, `Data` or `Object` - A block-number-or-hash selector: a hex block number, a bare JSON integer (an Erigon extension — not a standard `QUANTITY`), a named tag such as `'earliest'`, `'latest'` or `'pending'`, a block hash, or the object form `{"blockNumber": ...}` / `{"blockHash": ...}`. Required — `null` is rejected. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
 3. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still replayed instead of failing the call. It does more than bypass that check — see [The gasBailOut option](#the-gasbailout-option).
 4. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to have beacon-chain withdrawals reflected in the `stateDiff` output. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
@@ -6670,7 +6672,7 @@ Returns traces created at given block.
 
 #### Parameters
 
-1. `Quantity`, `Tag` or `null` - A plain block number: an integer (hex string or bare JSON integer), a named tag (`'earliest'`, `'latest'`, `'pending'`, `'safe'`, `'finalized'`, or the Erigon-specific `'latestExecuted'`), or `null` / `"null"`, both of which mean `latest`. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
+1. `Quantity`, `Number`, `Tag` or `null` - A plain block number: a hex string, or a bare JSON integer as an Erigon extension (not a standard `QUANTITY`), a named tag (`'earliest'`, `'latest'`, `'pending'`, `'safe'`, `'finalized'`, or the Erigon-specific `'latestExecuted'`), or `null` / `"null"`, both of which mean `latest`. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
 2. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still traced instead of failing the replay — the OpenEthereum/Parity behaviour. It does more than bypass that check — see [The gasBailOut option](#the-gasbailout-option).
 3. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to append a `"reward"` entry per beacon-chain withdrawal. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5096,11 +5096,13 @@ transaction is built at all.
 * `value` — `0` when absent
 * `gas` — from `eth_estimateGas` against `latest`
 * `chainId` — the node's chain ID; a mismatching supplied value is an error. It is used
-  for validation and carried by typed transactions, but it does not appear in the
-  returned `tx` for an unsigned legacy transaction: `CallArgs.ToTransaction` builds a
+  for validation and carried by every typed transaction, but it does not appear in the
+  returned `tx` when the fill infers legacy type `0x0`: `CallArgs.ToTransaction` builds a
   `LegacyTx` with no chain-ID field, and the response encoder skips chain-ID derivation
-  while `v` is zero. A pre-London fill, or a post-London fill supplying `gasPrice` with
-  no access list, therefore returns `tx` without `chainId`
+  while `v` is zero. That is the `default` arm of the type switch — reached only when
+  none of `authorizationList`, `blobVersionedHashes`, `maxFeePerGas` or `accessList` is
+  present. An `accessList` fill before London and a blob or authorization-list fill after
+  it are typed and carry `chainId`, even when `gasPrice` is supplied
 * fee fields — an explicitly supplied `gasPrice` is preserved, before or after London,
   though after London it must be non-zero (`gasPrice must be non-zero after london fork`);
   before London a zero is accepted. It cannot be combined with `maxFeePerGas` or
@@ -5118,6 +5120,17 @@ An object with `raw`, the unsigned transaction in its canonical binary encoding,
 RLP only for a legacy transaction; a typed one is the EIP-2718 type byte followed by the
 encoded payload, and feeding that straight to an RLP decoder will fail. The standardized
 result carries only `tx`; the extra `raw` field is the geth-compatible shape.
+
+`tx` also carries four fields the standardized unsigned schemas do not define. `v`, `r`
+and `s` are placeholders — `SignTransactionResult.MarshalJSON` writes `"0x0"` for each —
+and a typed result adds `yParity`, likewise `0x0`. Nothing is signed here, so none of
+them is a signature.
+
+:::warning
+The `hash` field is computed before signing and **changes once the transaction is
+signed**. It is not the hash the transaction will have when submitted, so it must not be
+used to track it. Take the hash from `eth_sendRawTransaction` instead.
+:::
 
 A dynamic-fee result — types `0x2`, `0x3` and `0x4` — also carries `gasPrice: null`.
 `FillTransaction` passes no base fee to the response encoder, so `computeGasPrice`
@@ -6491,8 +6504,17 @@ Replays all transactions in a block returning the requested traces for each tran
 
 1. `Quantity`, `Tag`, `Data` or `Object` - A block-number-or-hash selector: an integer block number, a named tag such as `'earliest'`, `'latest'` or `'pending'`, a block hash, or the object form `{"blockNumber": ...}` / `{"blockHash": ...}`. Required — `null` is rejected. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
-3. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still replayed instead of failing the call.
+3. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still replayed instead of failing the call. It does more than bypass that check — see the warning below.
 4. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to have beacon-chain withdrawals reflected in the `stateDiff` output. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
+
+:::warning
+`gasBailOut` alters replayed state for **every** transaction, not only underfunded ones.
+`TxnExecutor.buyGas` skips the sender's gas and blob-fee deductions whenever it is set,
+the gas-refund path is skipped along with them, and the block producer's tip is still
+credited. The resulting `stateDiff`, and the state each later transaction in the block
+sees, therefore differ from a normal replay — do not use the output to reconstruct
+balances.
+:::
 
 ```js
 params: [
@@ -6615,8 +6637,17 @@ Returns traces created at given block.
 #### Parameters
 
 1. `Quantity`, `Tag` or `null` - A plain block number: an integer (hex string or bare JSON integer), a named tag (`'earliest'`, `'latest'`, `'pending'`, `'safe'`, `'finalized'`, or the Erigon-specific `'latestExecuted'`), or `null` / `"null"`, both of which mean `latest`. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
-2. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still traced instead of failing the replay — the OpenEthereum/Parity behaviour.
+2. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still traced instead of failing the replay — the OpenEthereum/Parity behaviour. It does more than bypass that check — see the warning below.
 3. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to append a `"reward"` entry per beacon-chain withdrawal. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
+
+:::warning
+`gasBailOut` alters replayed state for **every** transaction, not only underfunded ones.
+`TxnExecutor.buyGas` skips the sender's gas and blob-fee deductions whenever it is set,
+the gas-refund path is skipped along with them, and the block producer's tip is still
+credited. The resulting `stateDiff`, and the state each later transaction in the block
+sees, therefore differ from a normal replay — do not use the output to reconstruct
+balances.
+:::
 
 ```js
 params: [

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6188,6 +6188,11 @@ balances:
   non-zero `value`, the EVM-level bailout engages and `Transfer` skips the sender debit
   while still crediting the recipient. Value appears from nowhere, so a trace can show
   what looks like balance creation.
+* **On Gnosis and Chiado, the burn contract is credited too.** Where the chain
+  configures a `burntContract` — Gnosis and Chiado do, most chains do not — a London
+  transaction credits it `gasUsed * baseFee`, plus the blob fee on Aura from Prague. The
+  sender was never debited, so this is a second source of apparent balance creation in
+  `stateDiff` on those chains. Chains that simply burn the base fee are unaffected.
 :::
 
 Whether one transaction's altered state is visible to the next depends on the execution

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4334,6 +4334,7 @@ Flags:
       --rpc.subscription.filters.maxlogs int        Maximum number of logs to store per subscription.
       --rpc.subscription.filters.maxtopics int      Maximum number of topics per subscription to filter logs by.
       --rpc.subscription.filters.maxtxs int         Maximum number of transactions to store per subscription.
+      --rpc.subscription.filters.timeout duration   Timeout before idle filters are evicted. Defaults to 5m; set to 0 to disable eviction. (default 5m0s)
       --rpc.txfeecap float                          Sets a cap on transaction fee (in ether) that can be sent via the RPC APIs (0 = no cap) (default 1)
       --socket.enabled                              Enable IPC server
       --socket.url string                           IPC server listening url. prefix supported are tcp, unix (default "unix:///var/run/erigon.sock")
@@ -4937,6 +4938,9 @@ For API usage refer to the below official resources:
 * [https://ethereum.org/en/developers/docs/apis/json-rpc/](https://ethereum.org/en/developers/docs/apis/json-rpc/)
 * [https://ethereum.github.io/execution-apis/](https://ethereum.github.io/execution-apis/)
 
+The sections below cover only the places where Erigon adds a method that is not in that
+standard set, or where its behaviour differs from it. Everything else follows the spec.
+
 ### eth\_getProof
 
 `eth_getProof` returns Merkle proofs for account state and storage slots, as defined in [EIP-1186](https://eips.ethereum.org/EIPS/eip-1186). It is stable and production-ready as of Erigon v3.4.
@@ -4955,7 +4959,7 @@ This enables faster retrieval of Merkle proofs for any executed block.
 
 ### eth\_getStorageValues
 
-`eth_getStorageValues` reads several storage slots for one or more accounts in a single call, reducing round-trips compared to multiple `eth_getStorageAt` calls. It is part of the [Ethereum execution APIs](https://github.com/ethereum/execution-apis/blob/main/src/eth/state.yaml) and takes two parameters.
+`eth_getStorageValues` reads several storage slots for one or more accounts in a single call, reducing round-trips compared to multiple `eth_getStorageAt` calls. It originated as an Erigon extension and has since been adopted into the [Ethereum execution APIs](https://github.com/ethereum/execution-apis/blob/main/src/eth/state.yaml) (April 2026). It takes two parameters.
 
 **Parameters**
 
@@ -4995,6 +4999,127 @@ An object mapping each requested address to an array of 32-byte values, in the s
 * A single call may request at most 1024 slots in total, counting all addresses together. Larger requests are rejected.
 * An empty `requests` object returns error code `-32602` with the message `empty request`.
 * When `blockNumber` is a block hash, the block must be canonical.
+
+### eth\_getWitness and eth\_getTxWitness
+
+Neither method exists in the standard set. They return a state witness for the
+*pre-state* of a block: the serialized trie node stream needed to re-execute it
+without a full state database.
+
+**Parameters**
+
+| Method | Parameter | Type | Description |
+| ------ | --------- | ---- | ----------- |
+| `eth_getWitness` | blockNumberOrHash | STRING, NUMBER or OBJECT | Block to build the witness for |
+| `eth_getTxWitness` | blockNumberOrHash | STRING, NUMBER or OBJECT | Block containing the transaction |
+| `eth_getTxWitness` | txIndex | QUANTITY | Index of a transaction within that block |
+
+:::info
+`eth_getTxWitness` currently only bounds-checks `txIndex` — an index past the end of the
+block is an error, but the witness it returns is the same whole-block witness
+`eth_getWitness` produces.
+:::
+
+**Returns**
+
+`DATA` — the serialized witness. Erigon decodes the bytes it is about to return and
+checks that they rebuild the parent state root, so a witness that comes back is
+self-verified. The genesis block returns an empty witness.
+
+**Requirements**
+
+Both methods need commitment history, so start the node with:
+
+```text
+--prune.include-commitment-history
+```
+
+Without it the call fails with `eth_getWitness requires commitment history`. If the
+requested block is older than the retained commitment history, it fails with
+`commitment history pruned`.
+
+### eth\_fillTransaction
+
+`eth_fillTransaction` takes a partially specified transaction, fills in what is
+missing, and returns it unsigned — it neither signs nor submits anything. The method
+was added to the execution-apis specification in July 2026; Erigon (matching geth)
+deviates from it in the return shape, which keeps the `raw` field the spec dropped.
+
+**Parameters**
+
+1. `Object` — a transaction object in the same shape `eth_call` accepts.
+
+**Fills in**
+
+* `nonce` — from the pending nonce of `from`, or `0` when `from` is absent
+* `value` — `0` when absent
+* `gas` — from `eth_estimateGas` against `latest`
+* `chainId` — the node's chain ID; a mismatching supplied value is an error
+* fee fields — `gasPrice` before London, otherwise `maxFeePerGas` / `maxPriorityFeePerGas` from the gas oracle
+* `maxFeePerBlobGas` — for blob transactions, twice the current blob gas price
+
+**Returns**
+
+An object with `raw`, the RLP-encoded unsigned transaction, and `tx`, the same
+transaction in JSON form. The standardized result carries only `tx`; the extra `raw`
+field is the geth-compatible shape.
+
+:::info
+KZG commitment and proof generation from raw blobs is not implemented. Blob
+transactions must already carry their `blobVersionedHashes`.
+:::
+
+### Block number parameter format
+
+Erigon accepts more block-number forms than the standard schema, which allows only a
+`0x`-prefixed hex quantity string or a named tag.
+
+Accepted everywhere a block is selected:
+
+* a `0x`-prefixed hex string without leading zeros — `"0x3"`, `"0x2ed119"`
+* a bare, unquoted JSON integer — `3`
+* the named tags `"earliest"`, `"latest"`, `"safe"`, `"finalized"`, `"pending"`
+* `null`, which means `latest` — except in the few methods whose block-or-hash
+  parameter is required (`eth_getBlockReceipts`, `eth_getBlockAccessList`,
+  `eth_simulateV1`, `eth_getWitness`, `eth_getTxWitness`), which reject it
+
+Rejected everywhere:
+
+* a quoted decimal string — `"3"`, `"100"`
+* hex with leading zeros — `"0x01"`
+* hex without the prefix — `"ff"`
+
+:::warning
+**Breaking change in v3.6.** Quoted decimal strings such as `"3"` used to be accepted
+and are now rejected with `hex string without 0x prefix`, returned as an
+`invalid params` error. Callers relying on that form must switch to `"0x3"`, the bare
+integer `3`, or a named tag.
+:::
+
+Two further forms are accepted only by methods whose parameter is a plain block number,
+such as `eth_getBlockByNumber`, `eth_getBlockTransactionCountByNumber` and `trace_block`:
+the Erigon-specific tag `"latestExecuted"`, and the string `"null"`, which means `latest`.
+Methods taking a block-number-or-hash selector — `eth_call`, `eth_getBalance`,
+`eth_getProof` and the rest — reject both.
+
+### Filter lifetime
+
+The standard spec does not say how long a filter lives. In Erigon, a filter created by
+`eth_newFilter`, `eth_newBlockFilter`, or `eth_newPendingTransactionFilter` is evicted
+once it has gone **5 minutes** without being polled. `eth_getFilterChanges` and
+`eth_getFilterLogs` both count as a poll and reset the clock, so a filter stays alive on
+a quiet chain as long as the client keeps asking. A call against an evicted filter
+returns `filter not found`.
+
+Change the window, or turn eviction off entirely, with:
+
+```text
+--rpc.subscription.filters.timeout 15m   # longer window
+--rpc.subscription.filters.timeout 0     # keep filters indefinitely
+```
+
+Eviction applies only to these polling filters. WebSocket subscriptions live as long as
+their connection does.
 
 ---
 
@@ -5884,6 +6009,31 @@ then it should look something like:
 
 `[ {A: []}, {B: [0]}, {G: [0, 0]}, {C: [1]}, {G: [1, 0]} ]`
 
+## Beacon-chain withdrawals
+
+Beacon-chain withdrawals credit balances outside of any transaction, so by default no
+trace mentions them. `trace_block` and `trace_replayBlockTransactions` can be asked to
+include them by passing a trace-settings object as the last positional parameter:
+
+```js
+{ "IncludeWithdrawals": true }
+```
+
+The default is off — omit the object, or leave the field out, and withdrawals are not
+reported. How they appear depends on the method:
+
+* **`trace_block`** appends one entry per withdrawal to the flat trace list. Each is a
+  `"reward"` entry whose `action.rewardType` is `"withdrawal"`, with `action.author` set
+  to the withdrawal address and `action.value` to the amount **in wei** (the beacon chain
+  denominates withdrawals in Gwei). These entries carry no `transactionHash` or
+  `transactionPosition`, since no transaction caused them.
+
+* **`trace_replayBlockTransactions`** has no block-level slot in its per-transaction
+  result shape, so withdrawals surface only through `stateDiff`. You must request
+  `"stateDiff"` in the trace types; when you do, one extra entry is appended to the
+  result array, containing only the withdrawal balance changes. Multiple withdrawals to
+  the same address are merged into a single balance change.
+
 ## JSON-RPC methods
 
 #### Ad-hoc Tracing
@@ -6222,6 +6372,8 @@ Replays all transactions in a block returning the requested traces for each tran
 
 1. `Quantity` or `Tag` - Integer of a block number, or the string `'earliest'`, `'latest'` or `'pending'`.
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
+3. `Boolean` - Optional. `gasBailOut`.
+4. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to have beacon-chain withdrawals reflected in the `stateDiff` output. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
 
 ```js
 params: [
@@ -6333,6 +6485,8 @@ Returns traces created at given block.
 #### Parameters
 
 1. `Quantity` or `Tag` - Integer of a block number, or the string `'earliest'`, `'latest'` or `'pending'`.
+2. `Boolean` - Optional. `gasBailOut`.
+3. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to append a `"reward"` entry per beacon-chain withdrawal. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
 
 ```js
 params: [

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5019,16 +5019,20 @@ without a full state database.
 :::info
 `eth_getTxWitness` currently only bounds-checks `txIndex` — an index past the end of the
 block is an error, but the witness it returns is the same whole-block witness
-`eth_getWitness` produces. At the genesis block not even that check runs: both methods
-share one implementation that returns the empty witness as soon as the block number
-resolves to `0`, so any `txIndex` is accepted there.
+`eth_getWitness` produces. Two cases are not rejected: the check narrows the index with
+`int(txIndex)`, so on a 64-bit build a value from `0x8000000000000000` upward wraps
+negative and passes; and at the genesis block the check never runs at all, because both
+methods share one implementation that returns the empty witness as soon as the block
+number resolves to `0`.
 :::
 
 **Returns**
 
-`DATA` — the serialized witness. Erigon decodes the bytes it is about to return and
-checks that they rebuild the parent state root, so a witness that comes back is
-self-verified. The genesis block returns an empty witness.
+`DATA` — the serialized witness. On the normal path Erigon decodes the bytes it is about
+to return and checks that they rebuild the parent state root, so the witness is
+self-verified. Two early returns skip that check because they produce no witness to
+verify: the genesis block, and any block whose access set turns out to be empty. Both
+return the empty witness.
 
 **Requirements**
 
@@ -5089,16 +5093,18 @@ Accepted everywhere a block is selected:
 * a `0x`-prefixed hex string without leading zeros — `"0x3"`, `"0x2ed119"`
 * a bare, unquoted JSON integer — `3`
 * the named tags `"earliest"`, `"latest"`, `"safe"`, `"finalized"`, `"pending"`
-* `null`, but only where the selector is optional: it leaves the parameter unset, and
-  the method's own default applies — `latest` for most, though the default is
-  per-method. A **required** block-or-hash parameter rejects top-level `null`:
-  `BlockNumberOrHash.UnmarshalJSON` decodes `null` into an empty struct and then fails
-  with `at least one of BlockNumber or BlockHash is needed if a dictionary is provided`
-  (`rpc/types.go`). That is a property of the type, not a list of special-cased methods
-  — it holds for every method whose selector is a required `BlockNumberOrHash`,
-  including `eth_getBlockReceipts`, `eth_getBlockAccessList`, `eth_simulateV1`,
-  `eth_getWitness`, `eth_getTxWitness`, `eth_getBlockByHash` and
-  `trace_replayBlockTransactions`
+* `null`, whose handling depends on the parameter's type, not on the method:
+  * a plain **block-number** parameter accepts it — `BlockNumber.UnmarshalJSON` maps
+    top-level `null` to `latest`, so `eth_getBlockByNumber`, `trace_block` and the rest
+    of that family take it even though the parameter is required;
+  * an **optional** block-or-hash parameter accepts it too: the selector is left unset
+    and the method's own default applies, `latest` for most;
+  * a **required** block-or-hash parameter rejects it —
+    `BlockNumberOrHash.UnmarshalJSON` decodes `null` into an empty struct and then fails
+    with `at least one of BlockNumber or BlockHash is needed if a dictionary is
+    provided` (`rpc/types.go`). This holds for every such method, including
+    `eth_getBlockReceipts`, `eth_getBlockAccessList`, `eth_simulateV1`, `eth_getWitness`,
+    `eth_getTxWitness`, `eth_getBlockByHash` and `trace_replayBlockTransactions`
 
 Rejected everywhere:
 
@@ -6167,7 +6173,7 @@ The `action` object's shape depends on `type`:
 | --- | --- | --- |
 | `author` | DATA, 20 BYTES | Address receiving the reward (miner / uncle author). |
 | `value` | QUANTITY | Wei amount of the reward. |
-| `rewardType` | String | `"block"` or `"uncle"`. |
+| `rewardType` | String | `"block"` or `"uncle"`, and `"withdrawal"` when `IncludeWithdrawals` is set — see [Beacon-chain withdrawals](#beacon-chain-withdrawals). |
 
 ### Result variants
 
@@ -6408,7 +6414,7 @@ Replays all transactions in a block returning the requested traces for each tran
 
 1. `Quantity`, `Tag`, `Data` or `Object` - A block-number-or-hash selector: an integer block number, a named tag such as `'earliest'`, `'latest'` or `'pending'`, a block hash, or the object form `{"blockNumber": ...}` / `{"blockHash": ...}`. Required — `null` is rejected. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
-3. `Boolean` - Optional. `gasBailOut`.
+3. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still replayed instead of failing the call.
 4. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to have beacon-chain withdrawals reflected in the `stateDiff` output. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
 
 ```js
@@ -6528,8 +6534,8 @@ Returns traces created at given block.
 
 #### Parameters
 
-1. `Quantity` or `Tag` - Integer of a block number, or the string `'earliest'`, `'latest'` or `'pending'`.
-2. `Boolean` - Optional. `gasBailOut`.
+1. `Quantity`, `Tag` or `null` - A plain block number: an integer (hex string or bare JSON integer), a named tag (`'earliest'`, `'latest'`, `'pending'`, `'safe'`, `'finalized'`, or the Erigon-specific `'latestExecuted'`), or `null` / `"null"`, both of which mean `latest`. See [Block number parameter format](/interacting-with-erigon/eth#block-number-parameter-format).
+2. `Boolean` - Optional, default `false`. `gasBailOut`. When `true`, a transaction whose sender cannot afford the gas charge is still traced instead of failing the replay — the OpenEthereum/Parity behaviour.
 3. `Object` - Optional trace settings. Set `"IncludeWithdrawals": true` to append a `"reward"` entry per beacon-chain withdrawal. See [Beacon-chain withdrawals](#beacon-chain-withdrawals).
 
 ```js

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5068,7 +5068,12 @@ deviates from it in the return shape, which keeps the `raw` field the spec dropp
 * `nonce` — from the pending nonce of `from`, or `0` when `from` is absent
 * `value` — `0` when absent
 * `gas` — from `eth_estimateGas` against `latest`
-* `chainId` — the node's chain ID; a mismatching supplied value is an error
+* `chainId` — the node's chain ID; a mismatching supplied value is an error. It is used
+  for validation and carried by typed transactions, but it does not appear in the
+  returned `tx` for an unsigned legacy transaction: `CallArgs.ToTransaction` builds a
+  `LegacyTx` with no chain-ID field, and the response encoder skips chain-ID derivation
+  while `v` is zero. A pre-London fill, or a post-London fill supplying `gasPrice` with
+  no access list, therefore returns `tx` without `chainId`
 * fee fields — an explicitly supplied `gasPrice` is preserved, before or after London,
   and cannot be combined with `maxFeePerGas` or `maxPriorityFeePerGas`. When it is absent:
   before London `gasPrice` comes from the gas oracle; after London the dynamic fields are
@@ -5113,6 +5118,9 @@ Accepted everywhere a block is selected:
 Rejected everywhere:
 
 * a quoted decimal string — `"3"`, `"100"`
+* a block number above `2^63-1`, in either parameter type — `BlockNumber.UnmarshalJSON`
+  and `BlockNumberOrHash.UnmarshalJSON` both fail with `blocknumber too high`, so
+  `"0x8000000000000000"` and the equivalent bare integer are out of range
 * hex with leading zeros — `"0x01"`
 * hex without the prefix — `"ff"`
 
@@ -6077,8 +6085,11 @@ reported. How they appear depends on the method:
 * **`trace_replayBlockTransactions`** has no block-level slot in its per-transaction
   result shape, so withdrawals surface only through `stateDiff`. You must request
   `"stateDiff"` in the trace types; when you do, one extra entry is appended to the
-  result array, containing only the withdrawal balance changes. Multiple withdrawals to
-  the same address are merged into a single balance change.
+  result array, carrying the withdrawal state changes. Its shape depends on whether the
+  recipient already existed: an existing account gets a `"*"` balance change with `code`
+  and `nonce` marked `"="`, while an account created by the withdrawal itself gets `"+"`
+  entries for `balance`, `code` (`"0x"`) and `nonce` (`"0x0"`). Storage is empty either
+  way. Multiple withdrawals to the same address are merged into a single balance change.
 
 ## JSON-RPC methods
 
@@ -6132,7 +6143,7 @@ A `TraceEntry` represents a single call frame (root call, internal call, contrac
 | `error` | String | (Optional) Present when the call frame errored. `"Reverted"` (title-cased) is the only special-cased value; all other errors are the verbatim Go error string, e.g. `"out of gas"`, `"invalid opcode: ..."`. For `"Reverted"`, `result` is still populated with `gasUsed` and `output` (or `code`/`address` for a `create` frame); for other errors, `result` is `null`. |
 | `subtraces` | QUANTITY | Number of direct child call frames produced by this frame. Used together with `traceAddress` to reconstruct the call tree from a flat list. |
 | `traceAddress` | Array of QUANTITY | Path to this frame inside the call tree. Empty array `[]` for the root call; `[0]` is the first child of the root; `[1, 0]` is the first child of the second child of the root, etc. |
-| `type` | String | One of `"call"`, `"create"`, `"suicide"` (self-destruct), `"reward"` (block/uncle reward — appears in `trace_block` and in `trace_filter` results when the filter matches block coinbases or uncle authors). |
+| `type` | String | One of `"call"`, `"create"`, `"suicide"` (self-destruct), `"reward"` (block, uncle or beacon-chain-withdrawal reward — appears in `trace_block` and in `trace_filter` results when the filter matches block coinbases, uncle authors or withdrawal recipients). |
 | `blockHash` | DATA, 32 BYTES | (Only in block-level methods: `trace_block`, `trace_filter`, `trace_transaction`, `trace_get`) Hash of the block containing the transaction. |
 | `blockNumber` | QUANTITY | (Block-level methods only) Number of the block containing the transaction. |
 | `transactionHash` | DATA, 32 BYTES | (Block-level methods only) Hash of the transaction containing this call frame. Absent for `"reward"` entries. |
@@ -6171,11 +6182,11 @@ The `action` object's shape depends on `type`:
 | `refundAddress` | DATA, 20 BYTES | Address that received the contract's remaining balance. |
 | `balance` | QUANTITY | Wei amount transferred to `refundAddress`. |
 
-**`type: "reward"`** (block/uncle reward, in `trace_block` and `trace_filter`)
+**`type: "reward"`** (block, uncle or withdrawal reward, in `trace_block` and `trace_filter`)
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `author` | DATA, 20 BYTES | Address receiving the reward (miner / uncle author). |
+| `author` | DATA, 20 BYTES | Address receiving the reward — the miner, the uncle author, or the withdrawal recipient when `rewardType` is `"withdrawal"`. |
 | `value` | QUANTITY | Wei amount of the reward. |
 | `rewardType` | String | `"block"` or `"uncle"`, and `"withdrawal"` when `IncludeWithdrawals` is set — see [Beacon-chain withdrawals](#beacon-chain-withdrawals). |
 
@@ -6550,7 +6561,7 @@ params: [
 
 #### Returns
 
-`Array` — flat list of all call frames in the block, including any `"reward"` entries for block/uncle rewards. Each entry includes block-level fields (`blockHash`, `blockNumber`, `transactionHash`, `transactionPosition`). See [Response Fields Reference](#response-fields-reference).
+`Array` — flat list of all call frames in the block, including any `"reward"` entries for block, uncle and (when requested) withdrawal rewards. Every entry carries `blockHash` and `blockNumber`; `transactionHash` and `transactionPosition` are present on transaction call frames but omitted from `"reward"` entries, which no transaction caused. See [Response Fields Reference](#response-fields-reference).
 
 #### Example
 


### PR DESCRIPTION
Documents where Erigon's `eth` and `trace` APIs deviate from the standard spec, so callers meet these differences in the docs rather than in production. Rebased onto `release/3.6` after #23582, whose `eth_getStorageValues` corrections are preserved.

**`eth`** — the two non-standard witness methods and the commitment history they need; `eth_fillTransaction`'s geth-shaped result, its ignored `type` field, which types carry `gasPrice: null` or omit `chainId`, the unsigned `hash` that changes once signed, and the unsupported blob sidecar; which block-number forms Erigon accepts and which it now rejects, quoted decimals being a v3.6 breaking change; and the five-minute filter timeout.

**`trace`** — how `IncludeWithdrawals` surfaces beacon-chain withdrawals, including the extra trailing entry `trace_replayBlockTransactions` appends that positional consumers must skip. A new shared section covers `gasBailOut` for all nine methods that enable it: it never deducts gas or blob fees, skips refunds, still pays the producer, and credits an unaffordable value transfer without debiting its sender, and on any chain with a configured burn contract credits that contract on a non-free transaction. Also completes the positional signatures with the trailing `TraceConfig`, and corrects the block selector and the `trace_filter` reward entries, which carry no transaction metadata.

**Flags** — adds `--rpc.subscription.filters.timeout` to the RPC daemon page.

An info card at the top of the `eth` page notes that `execution-apis` is still a moving specification, so part of what is listed is convergence rather than defects.





