### PR TITLE
db/integrity: make CommitmentKvDeref report the keys it scanned

### DIFF
--- a/db/integrity/commitment_deref_counts_test.go
+++ b/db/integrity/commitment_deref_counts_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package integrity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/version"
+)
+
+// TestCheckCommitmentKvDerefCounts pins that a file the referencing scan clears still reports the
+// keys it walked. An all-zero tally is indistinguishable from having scanned nothing, so a run over
+// a fully plain datadir would otherwise produce a summary that proves neither outcome.
+func TestCheckCommitmentKvDerefCounts(t *testing.T) {
+	t.Run("plain file reports what it walked", func(t *testing.T) {
+		f := fakeVisibleFile{path: writeCommitmentKV(t, false), endTxNum: 20, version: version.V2_0}
+		counts, err := checkCommitmentKvDeref(t.Context(), f, 10, true /* failFast */, log.New())
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), counts.branchKeys)
+		require.Equal(t, uint64(1), counts.plainAccounts)
+		require.Zero(t, counts.referencedAccounts)
+		require.Zero(t, counts.referencedStorages)
+	})
+}

--- a/db/integrity/commitment_integrity.go
+++ b/db/integrity/commitment_integrity.go
@@ -512,32 +512,47 @@ func checkDerefBranch(
 	return dc, newBranchData, integrityErr
 }
 
-// commitmentReferencingMemo caches commitmentFileReferencing per file path. Integrity checks run
+// commitmentFileScan is what the referencing full-scan learned about one file. counts is complete
+// only when referenced is false: the scan stops at the first shortened key and leaves the tally to
+// the dereferencing pass, which walks the whole file anyway.
+type commitmentFileScan struct {
+	referenced bool
+	counts     derefCounts
+}
+
+// commitmentReferencingMemo caches scanCommitmentFile per file path. Integrity checks run
 // over an immutable file set within a process and several phases query the same file, so the full
 // content scan is done once per file.
-var commitmentReferencingMemo sync.Map // string -> bool
+var commitmentReferencingMemo sync.Map // string -> commitmentFileScan
+
+var errShortenedKeyFound = errors.New("shortened key found")
 
 // commitmentFileReferencing reports whether a commitment file carries shortened key references.
-// The integrity tool full-scans the content (not the file's version stamp) to catch a mis-stamped
-// file; any read error returns true rather than under-report as plain. Memoized per path.
 func commitmentFileReferencing(file state.VisibleFile) bool {
+	return scanCommitmentFile(file).referenced
+}
+
+// scanCommitmentFile full-scans the content (not the file's version stamp) to catch a mis-stamped
+// file; any read error reports referenced rather than under-report as plain. Memoized per path.
+func scanCommitmentFile(file state.VisibleFile) commitmentFileScan {
 	if v, ok := commitmentReferencingMemo.Load(file.Fullpath()); ok {
-		return v.(bool)
+		return v.(commitmentFileScan)
 	}
-	r := computeCommitmentFileReferencing(file)
+	r := computeCommitmentFileScan(file)
 	commitmentReferencingMemo.Store(file.Fullpath(), r)
 	return r
 }
 
-func computeCommitmentFileReferencing(file state.VisibleFile) bool {
+func computeCommitmentFileScan(file state.VisibleFile) commitmentFileScan {
 	decomp, err := seg.NewDecompressor(file.Fullpath())
 	if err != nil {
 		log.Root().Warn("[integrity] commitmentFileReferencing: open failed, treating as referenced", "file", file.Fullpath(), "err", err)
-		return true
+		return commitmentFileScan{referenced: true}
 	}
 	defer decomp.Close()
 
 	g := seg.NewReader(decomp.MakeGetter(), statecfg.Schema.GetDomainCfg(kv.CommitmentDomain).Compression)
+	var counts derefCounts
 	var k, v []byte
 	for g.HasNext() {
 		k, _ = g.Next(k[:0])
@@ -548,11 +563,26 @@ func computeCommitmentFileReferencing(file state.VisibleFile) bool {
 		if bytes.Equal(k, commitmentdb.KeyCommitmentState) {
 			continue
 		}
-		if commitment.BranchData(v).HasShortenedKeys() {
-			return true
+		counts.branchKeys++
+		_, err := commitment.BranchData(v).ReplacePlainKeys(nil, func(key []byte, isStorage bool) ([]byte, error) {
+			if isStorage {
+				if len(key) != length.Addr+length.Hash {
+					return nil, errShortenedKeyFound
+				}
+				counts.plainStorages++
+				return nil, nil
+			}
+			if len(key) != length.Addr {
+				return nil, errShortenedKeyFound
+			}
+			counts.plainAccounts++
+			return nil, nil
+		})
+		if err != nil {
+			return commitmentFileScan{referenced: true}
 		}
 	}
-	return false
+	return commitmentFileScan{counts: counts}
 }
 
 func checkCommitmentKvDeref(ctx context.Context, file state.VisibleFile, stepSize uint64, failFast bool, logger log.Logger) (derefCounts, error) {
@@ -560,15 +590,18 @@ func checkCommitmentKvDeref(ctx context.Context, file state.VisibleFile, stepSiz
 	fileName := filepath.Base(file.Fullpath())
 	startTxNum := file.StartRootNum()
 	endTxNum := file.EndRootNum()
-	if !commitmentFileReferencing(file) {
+	if scan := scanCommitmentFile(file); !scan.referenced {
 		logger.Info(
 			"[integrity] CommitmentKvDeref skipped, no shortened keys found (full scan)",
 			"file", fileName,
 			"startTxNum", startTxNum,
 			"endTxNum", endTxNum,
 			"steps", (endTxNum-startTxNum)/stepSize,
+			"branchKeys", scan.counts.branchKeys,
+			"plainAccounts", scan.counts.plainAccounts,
+			"plainStorages", scan.counts.plainStorages,
 		)
-		return derefCounts{}, nil
+		return scan.counts, nil
 	}
 	trace := logger.Enabled(ctx, log.LvlTrace)
 	workers := max(dbg.EnvInt("CHECK_COMMITMENT_KVS_DEREF_WORKERS", 4), 1)


### PR DESCRIPTION
`CommitmentKvDeref` returns before its counting loop when the referencing full-scan finds no shortened keys, so a datadir that carries no references reports `branchKeys=0 plainAccounts=0 plainStorages=0` — byte-identical to a run that opened nothing. The scan already visits every branch of every file; this counts what it walked and returns that instead of an empty struct.

## Changes
- `scanCommitmentFile` replaces the bool-returning memo behind `commitmentFileReferencing`, carrying a `derefCounts` next to the referenced verdict. `commitmentFileReferencing` stays as a one-line wrapper, so the `StateVerify` and hash-verification call sites are untouched.
- The scan tallies plain account and storage keys inline instead of calling `BranchData.HasShortenedKeys()`. It still returns at the first shortened key with an empty tally — a referencing file is counted once, by the dereferencing pass, not twice.
- The skip branch logs `branchKeys` / `plainAccounts` / `plainStorages` per file and returns them, so the run summary aggregates real numbers.

## Notes
Run over a mainnet archive datadir — 6 commitment `.kv`, 270 GiB, steps 0-9553, all `v2.2`:

| | before | after |
|---|---|---|
| `branchKeys` | 0 | 1,034,055,242 |
| `plainAccounts` | 0 | 694,814,954 |
| `plainStorages` | 0 | 2,133,269,197 |
| `referencedAccounts` / `referencedStorages` | 0 | 0 |

Per-file counts match an independent scanner over the same files exactly. Same traversal as before, now tallying as it goes; the wall-clock difference between the two runs (35m56s, then 24m07s) is page-cache warmth.
