### PR TITLE
docs(site): forward-port the minimal theme-aware footer from #23070

### DIFF
--- a/docs/site/DESIGN-SPEC.md
+++ b/docs/site/DESIGN-SPEC.md
@@ -116,7 +116,7 @@ Logo height overridden in CSS: **28px**
 ```
 "Erigon Client"
 ```
-Font: **Montserrat**, weight 800, letter-spacing 0.04em (applied via CSS)
+Font: **Quantify**, weight 700, letter-spacing 0.04em (applied via CSS)
 
 ### Left Nav Items
 | Label | Type |
@@ -149,120 +149,15 @@ Font: **Montserrat**, weight 800, letter-spacing 0.04em (applied via CSS)
 
 Completely swizzled (`src/theme/Footer/index.tsx`) — not using the Docusaurus built-in footer at all.
 
-### Container
-- Background: `#000000`
-- Font: Nunito Sans, sans-serif
-- Color: `#ffffff`
+**This site uses the minimalistic docs footer**, not the full five-column one. Canonical description lives in `erigon-documents` → `public-docs/docusaurus-design-spec.md` §6.0–§6.3; do not duplicate it here. Summary only:
 
-### Logo + Tagline (left column)
-- Logo image height: **32px**
-- Brand text: **Montserrat** font, weight 800, letter-spacing 0.04em
-- Tagline: *"Building the future on the efficient software frontier."*
-- Company address: Erigon Technologies AG, Dammstrasse 16, 6300 Zug, Switzerland
-
-### Column Headers (all 4 columns)
-- Font: **Montserrat**, weight 800
-- Size: 0.8rem
-- Letter-spacing: 0.08em
-- Text-transform: uppercase
-- Color: `rgba(255,255,255,0.4)`
-
-### Column 1 — Products
-| Label | URL |
-|---|---|
-| Erigon Client | `https://erigon.tech/products/erigon-client/` |
-| Zilkworm | `https://erigon.tech/products/zilkworm/` |
-| Cocoon | `https://erigon.tech/products/cocoon/` |
-| R&D | `https://erigon.tech/products/rnd/` |
-
-### Column 2 — Developers
-| Label | URL |
-|---|---|
-| Zilkworm Docs ↗ | `https://zilkworm.erigon.tech` |
-| Cocoon Docs ↗ | `https://cocoon.erigon.tech` |
-| Erigon Docs ↗ | `https://docs.erigon.tech` |
-| Blog | `https://erigon.tech/blog/` |
-
-### Column 3 — Company
-| Label | URL |
-|---|---|
-| About Us | `https://erigon.tech/about/` |
-| Services | `https://erigon.tech/services/` |
-| Contact | `https://erigon.tech/contact/` |
-| Privacy Policy | `https://erigon.tech/privacy/` |
-| Cookie Policy | `https://erigon.tech/cookies/` |
-
-### Column 4 — Community (icon + label)
-
-Each entry is an `<a>` with `display:flex`, `alignItems:center`, `gap:0.6rem`. Icons are inline SVG React components, `width/height:18`, `fill:currentColor` so they inherit the link color on hover.
-
-| Platform | URL |
-|---|---|
-| X / Twitter | `https://x.com/erigoneth` |
-| Discord | `https://dsc.gg/erigon` |
-| GitHub | `https://github.com/erigontech` |
-| LinkedIn | `https://www.linkedin.com/company/erigon/` |
-
-**SVG paths (all `viewBox="0 0 24 24"`, `fill="currentColor"`):**
-
-**X / Twitter** (`18×18`):
-```svg
-<path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.744l7.73-8.835L1.254 2.25H8.08l4.258 5.632L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z"/>
-```
-
-**Discord** (`18×18`):
-```svg
-<path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057c.002.022.014.043.03.058a19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>
-```
-
-**GitHub** (`18×18`):
-```svg
-<path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
-```
-
-**LinkedIn** (`18×18`):
-```svg
-<path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 23.2 0 22.222 0h.003z"/>
-```
-
-**Community column layout (React):**
-```tsx
-<div style={{display: 'flex', flexDirection: 'column', gap: '0.75rem'}}>
-  {[
-    {label: 'X / Twitter', href: 'https://x.com/erigoneth',                        Icon: IconX},
-    {label: 'Discord',     href: 'https://dsc.gg/erigon',                           Icon: IconDiscord},
-    {label: 'GitHub',      href: 'https://github.com/erigontech',                   Icon: IconGitHub},
-    {label: 'LinkedIn',    href: 'https://www.linkedin.com/company/erigon/',        Icon: IconLinkedIn},
-  ].map(({label, href, Icon}) => (
-    <a key={label} href={href} target="_blank" rel="noopener noreferrer"
-      style={{
-        display: 'flex', alignItems: 'center', gap: '0.6rem',
-        color: 'rgba(255,255,255,0.65)',
-        textDecoration: 'none', fontSize: '0.9rem', transition: 'color 0.15s',
-      }}
-      onMouseEnter={e => (e.currentTarget.style.color = '#EF7716')}
-      onMouseLeave={e => (e.currentTarget.style.color = 'rgba(255,255,255,0.65)')}>
-      <Icon />
-      {label}
-    </a>
-  ))}
-</div>
-```
-
-### Footer Link Colors
-| State | Color |
-|---|---|
-| Default | `rgba(255,255,255,0.65)` |
-| Hover | `#EF7716` |
-| Muted / address text | `rgba(255,255,255,0.35)` |
-
-### Bottom Bar
-- Copyright: `© {year} Erigon Technologies AG. All rights reserved.`
-- Inline links: Privacy Policy · Cookie Policy · Contact · hello@erigon.tech
-- Font-size: 0.8rem
-- Color: `rgba(255,255,255,0.35)`
-
----
+- Single row: brand lockup → tagline → icon-only social buttons pushed right; then a divider and a bottom bar (copyright left, Privacy / Cookie / Contact / `hello@erigon.tech` right).
+- No link columns and no postal address. Those belong to the **full** footer, which is erigon.tech's, not a docs site's. Do not "fix" this footer by porting them back.
+- Nunito Sans throughout, with the `erigon.tech` wordmark in Quantify 700.
+- Interactive elements use the contrast-safe dark orange `#A34E0B` in light mode and Erigon Orange `#EF7716` in dark mode.
+- Theme-aware surface via `--footer-*` custom properties in `src/css/custom.css`: white in light mode, black in dark. It is **not** always black — that was the previous five-column footer.
+- Both modes carry a 1px top edge. In light because a white footer on a white body has no edge of its own; in dark because `#000000` against the `#0A0A0A` page body is imperceptible.
+- Fine print is 0.55 alpha, deliberately not a mirrored 0.35: equal alpha is not equal perceived contrast across inverted surfaces, and 0.35 on white computes to 2.44:1, failing WCAG AA.
 
 ## 7. Typography
 
@@ -273,6 +168,7 @@ All fonts are self-hosted via `@font-face` (no CDN). Woff2 files live in `static
 @font-face { font-family: 'Nunito Sans';  src: url('/fonts/NunitoSans-Regular.woff2')    format('woff2'); font-weight: 400; }
 @font-face { font-family: 'Nunito Sans';  src: url('/fonts/NunitoSans-Bold.woff2')        format('woff2'); font-weight: 700; }
 @font-face { font-family: 'Nunito Sans';  src: url('/fonts/NunitoSans-ExtraBold.woff2')  format('woff2'); font-weight: 800; }
+@font-face { font-family: 'Quantify';     src: url('/fonts/Quantify.woff2')               format('woff2'); font-weight: 700; }
 ```
 
 ### Font Roles
@@ -280,7 +176,7 @@ All fonts are self-hosted via `@font-face` (no CDN). Woff2 files live in `static
 |---|---|---|
 | Body text | Nunito Sans, sans-serif | 400 |
 | Headings (h1–h6) | Montserrat, sans-serif | 800 |
-| Navbar title, footer brand | Montserrat | 800 |
+| Navbar title, footer brand (logo wordmark) | Quantify | 700 |
 | Navbar left items | Montserrat | 800 |
 | Code | system monospace | — |
 

--- a/docs/site/docusaurus.config.ts
+++ b/docs/site/docusaurus.config.ts
@@ -208,16 +208,6 @@ export default async function createConfig(): Promise<Config> {
           },
         ],
       },
-      footer: {
-        style: 'dark',
-        links: [
-          {title: 'Community', items: [
-            {label: 'GitHub', href: 'https://github.com/erigontech/erigon'},
-            {label: 'Discord', href: 'https://discord.gg/erigon'},
-          ]},
-        ],
-        copyright: `Copyright © ${new Date().getFullYear()} Erigon. Built with Docusaurus.`,
-      },
       metadata: [
         {name: 'description', content: 'Official documentation for Erigon — the efficient, modular Ethereum execution client built for performance and low disk footprint.'},
         {name: 'theme-color', content: '#EF7716'},

--- a/docs/site/src/css/custom.css
+++ b/docs/site/src/css/custom.css
@@ -4,8 +4,13 @@
  * Light bg: #FFFFFF, Dark bg: #0A0A0A
  * Fonts: Montserrat ExtraBold (headings), Nunito Sans (body),
  *        Quantify 700 (brand wordmark — navbar title + footer brand, see
- *        docusaurus-design-spec.md §7 Font Roles)
+ *        DESIGN-SPEC.md §7 Font Roles)
  */
+
+/* Self-hosted fonts — no Google Fonts or CDN. See DESIGN-SPEC.md §7.
+   Quantify is non-free and licensed to Erigon: keep self-hosting this woff2, and
+   do not swap it for the CDN copy at fonts.cdnfonts.com/css/quantify. Licence
+   scope is recorded in the design spec, not here. */
 
 @font-face {
   font-family: 'Montserrat';
@@ -454,40 +459,139 @@ details.alert.alert--info summary {
   color: var(--ifm-font-color-base) !important;
 }
 
-/* Footer background matches dark brand */
-.footer {
-  background-color: #000000;
+/* ─── Footer palette ─────────────────────────────────────────────────────── */
+/* Invariants:
+   - Surface follows the colour mode: white in light, black in dark.
+   - Text uses a fixed alpha ramp, not Infima's emphasis vars — those invert with
+     the theme and would render dark-on-black.
+   - Both modes carry a 1px top edge. A white footer on a white page body has no
+     edge of its own, and #000000 on the #0A0A0A page body is imperceptible.
+   - Fine print is 0.55, not 0.35: alpha is not perceptually symmetric across
+     inverted surfaces, and 0.35 on white is 2.44:1, below WCAG AA's 4.5:1.
+   - --footer-accent stays separate from --brand-accent, which is site-wide.
+   - The accent is per-mode for the same reason the alpha ramp is. Brand #EF7716
+     is 7.32:1 on the black footer but only 2.87:1 on the white one, below AA;
+     #A34E0B is 5.75:1 there. --footer-accent-tint carries the pre-color-mix
+     fallback for each mode so the tint cannot drift from the text it sits under. */
+:root {
+  --footer-accent: #A34E0B;
+  --footer-accent-tint: rgba(163, 78, 11, 0.12);
+  --footer-bg: #FFFFFF;
+  --footer-fg: #000000;
+  --footer-tagline: rgba(0, 0, 0, 0.55);
+  --footer-icon: rgba(0, 0, 0, 0.65);
+  --footer-fine: rgba(0, 0, 0, 0.55);
+  --footer-box-border: rgba(0, 0, 0, 0.25);
+  --footer-divider: rgba(0, 0, 0, 0.08);
+  --footer-top-edge: rgba(0, 0, 0, 0.08);
+}
+[data-theme='dark'] {
+  --footer-accent: #EF7716;
+  --footer-accent-tint: rgba(239, 119, 22, 0.12);
+  --footer-bg: #000000;
+  --footer-fg: #FFFFFF;
+  --footer-tagline: rgba(255, 255, 255, 0.55);
+  --footer-icon: rgba(255, 255, 255, 0.65);
+  --footer-fine: rgba(255, 255, 255, 0.55);
+  --footer-box-border: rgba(255, 255, 255, 0.15);
+  --footer-divider: rgba(255, 255, 255, 0.08);
+  --footer-top-edge: rgba(255, 255, 255, 0.08);
 }
 
-/* ─── Footer social pill buttons ─────────────────────────────────────────── */
+/* ─── Footer interactive states ──────────────────────────────────────────── */
+/* These live in CSS, not in React onMouseEnter/onMouseLeave handlers. Those
+   handlers only fire for a mouse: keyboard users tabbing through the footer got
+   no accent state at all, and mutating inline styles fights any later theming.
+   :hover and :focus-visible are declared together so mouse, keyboard and touch
+   all get the same affordance. */
 
-.footer-social-btn {
+.footer-brand {
   display: flex;
   align-items: center;
-  gap: 0.65rem;
-  padding: 0.55rem 0.85rem;
-  border-radius: 8px;
-  border: 1px solid rgba(255,255,255,0.15);
-  color: rgba(255,255,255,0.65) !important;
-  text-decoration: none !important;
-  font-size: 0.875rem;
-  font-weight: 500;
-  transition: color 0.2s ease, border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  gap: 0.6rem;
+  color: inherit;
+  text-decoration: none;
+  transition: color 0.15s;
 }
-.footer-social-btn:hover {
-  color: #EF7716 !important;
-  border-color: #EF7716 !important;
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(239,119,22,0.15);
+.footer-brand:hover,
+.footer-brand:focus-visible {
+  color: var(--footer-accent);
+  /* Infima's `a:hover` sets text-decoration: underline and outranks the base
+     class on specificity, so it has to be cleared on the state too. */
+  text-decoration: none;
+}
+
+.footer-socials {
+  display: flex;
+  flex-direction: row;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  margin-left: auto;
+}
+
+.footer-social {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border: 1px solid var(--footer-box-border);
+  border-radius: 8px;
+  color: var(--footer-icon);
+  text-decoration: none;
+  background: transparent;
+  transition: color 0.15s, border-color 0.15s, background-color 0.15s;
+}
+.footer-social:hover,
+.footer-social:focus-visible {
+  color: var(--footer-accent);
+  border-color: var(--footer-accent);
+  /* Fallback first: color-mix() is Chrome/Edge 111+, Firefox 113+, Safari 16.2+,
+     and the default production browserslist still resolves down to Chrome 109.
+     Older engines keep the flat tint; newer ones take the color-mix line. The
+     fallback is a per-mode var rather than a literal because --footer-accent
+     differs between modes: a hardcoded orange would tint the light footer with
+     the dark-mode accent on any engine without color-mix. */
+  background-color: var(--footer-accent-tint);
+  background-color: color-mix(in srgb, var(--footer-accent) 12%, transparent);
+}
+
+.footer-legal {
+  font-size: 0.8rem;
+  color: var(--footer-fine);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+.footer-legal:hover,
+.footer-legal:focus-visible {
+  color: var(--footer-accent);
+  text-decoration: none;
+}
+
+/* The icon buttons had no visible keyboard focus indicator at all. */
+.footer-brand:focus-visible,
+.footer-social:focus-visible,
+.footer-legal:focus-visible {
+  outline: 2px solid var(--footer-accent);
+  outline-offset: 2px;
 }
 
 /* ─── Footer responsive (mobile) ────────────────────────────────────────── */
 
 @media (max-width: 768px) {
+  /* The footer top row is flex, not a grid — stack it, don't set columns. */
   .footer-top-grid {
-    grid-template-columns: 1fr !important;
-    padding: 2.5rem 1.5rem 2rem !important;
-    gap: 2.5rem !important;
+    flex-direction: column !important;
+    align-items: flex-start !important;
+    padding: 1.5rem 1.5rem 1rem !important;
+    gap: 1rem !important;
+  }
+
+  /* Socials are pushed right by margin-left:auto on desktop; drop that so they
+     align with the brand and tagline once stacked. Targets the dedicated class,
+     not > div:last-child, which broke if another div were appended. */
+  .footer-socials {
+    margin-left: 0;
   }
 
   .footer-bottom-bar {

--- a/docs/site/src/theme/Footer/index.tsx
+++ b/docs/site/src/theme/Footer/index.tsx
@@ -25,167 +25,114 @@ const IconLinkedIn = () => (
   </svg>
 );
 
+/* Brand stack per DESIGN-SPEC.md §7: Nunito Sans for body/UI text,
+   Quantify 700 for the wordmark only. Colours live in custom.css as --footer-*
+   vars so the surface can invert between light and dark mode.
+   Interactive states (hover, focus-visible, the accent tint) are CSS classes —
+   .footer-brand / .footer-social / .footer-legal — not handlers here. See
+   "Footer interactive states" in custom.css for why. */
+const BODY = 'var(--ifm-font-family-base)';
+const SURFACE = 'var(--footer-bg)';
+const FOREGROUND = 'var(--footer-fg)';
+const TAGLINE = 'var(--footer-tagline)';
+const FINE_BASE = 'var(--footer-fine)';
+const DIVIDER = 'var(--footer-divider)';
+const TOP_EDGE = 'var(--footer-top-edge)';
+
+const SOCIALS = [
+  {label: 'X / Twitter', href: 'https://x.com/erigoneth', Icon: IconX},
+  {label: 'Discord', href: 'https://dsc.gg/erigon', Icon: IconDiscord},
+  {label: 'GitHub', href: 'https://github.com/erigontech', Icon: IconGitHub},
+  {label: 'LinkedIn', href: 'https://www.linkedin.com/company/erigon/', Icon: IconLinkedIn},
+];
+
+const LEGAL = [
+  {label: 'Privacy Policy', href: 'https://erigon.tech/privacy/'},
+  {label: 'Cookie Policy', href: 'https://erigon.tech/cookies/'},
+  {label: 'Contact', href: 'https://erigon.tech/contact/'},
+  {label: 'hello@erigon.tech', href: 'mailto:hello@erigon.tech'},
+];
+
 export default function Footer(): React.ReactElement {
   const logoUrl = useBaseUrl('/img/logo-icon-orange.png');
 
   return (
-    <footer style={{background: '#000000', color: '#ffffff', fontFamily: "'Nunito Sans', sans-serif"}}>
-      {/* Top section */}
+    <footer style={{
+      background: SURFACE,
+      color: FOREGROUND,
+      borderTop: `1px solid ${TOP_EDGE}`,
+      fontFamily: BODY,
+    }}>
+      {/* Top section — single horizontal row */}
       <div className="footer-top-grid" style={{
         maxWidth: '1280px',
         margin: '0 auto',
-        padding: '3.5rem 2rem 2.5rem',
-        display: 'grid',
-        gridTemplateColumns: '2fr 1fr 1fr 1fr 1fr',
-        gap: '2rem',
+        padding: '1.25rem 2rem 0.75rem',
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: '1.25rem',
+        flexWrap: 'wrap',
       }}>
 
-        {/* Brand column */}
-        <div style={{display: 'flex', flexDirection: 'column', gap: '1rem'}}>
-          <div style={{display: 'flex', alignItems: 'center', gap: '0.6rem'}}>
-            <img src={logoUrl} alt="Erigon" style={{height: '32px', width: 'auto'}} />
-            <span style={{fontFamily: "'Quantify', sans-serif", fontWeight: 700, fontSize: '1rem', letterSpacing: '0.04em'}}>erigon.tech</span>
-          </div>
-          <p style={{
-            fontSize: '0.875rem',
-            color: 'rgba(255,255,255,0.55)',
-            lineHeight: 1.6,
-            margin: 0,
-            maxWidth: '240px',
-          }}>
-            Building the future on the efficient software frontier.
-          </p>
-          <p style={{
-            fontSize: '0.8rem',
-            color: 'rgba(255,255,255,0.35)',
-            lineHeight: 1.6,
-            margin: 0,
-          }}>
-            Erigon Technologies AG<br />
-            Dammstrasse 16<br />
-            6300 Zug, Switzerland
-          </p>
-        </div>
+        {/* Brand lockup — one anchor around logo + wordmark, so it is a single
+            hit target. The aria-label opens with the visible wordmark text:
+            an aria-label replaces the whole accessible name, so a label that
+            omitted "erigon.tech" would leave the name not containing the
+            visible one, failing WCAG 2.5.3 Label in Name (A). */}
+        <a href="https://erigon.tech" target="_blank" rel="noopener noreferrer"
+          aria-label="erigon.tech home page" className="footer-brand">
+          <img src={logoUrl} alt="Erigon" style={{height: '32px', width: 'auto'}} />
+          <span style={{fontFamily: "'Quantify', sans-serif", fontWeight: 700, fontSize: '1rem', letterSpacing: '0.04em'}}>erigon.tech</span>
+        </a>
 
-        {/* Products column */}
-        <div>
-          <p style={{fontFamily: "'Montserrat', sans-serif", fontWeight: 800, fontSize: '0.8rem', letterSpacing: '0.08em', textTransform: 'uppercase', color: '#f0f0f0', margin: '0 0 1rem'}}>Products</p>
-          <ul style={{listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '0.6rem'}}>
-            {[
-              {label: 'Erigon Client', href: 'https://erigon.tech/products/erigon-client/'},
-              {label: 'Zilkworm', href: 'https://erigon.tech/products/zilkworm/'},
-              {label: 'Cocoon', href: 'https://erigon.tech/products/cocoon/'},
-              {label: 'R&D', href: 'https://erigon.tech/products/rnd/'},
-            ].map(({label, href}) => (
-              <li key={label}>
-                <a href={href} target="_blank" rel="noopener noreferrer" style={{color: 'rgba(255,255,255,0.65)', textDecoration: 'none', fontSize: '0.9rem', transition: 'color 0.15s'}}
-                  onMouseEnter={e => (e.currentTarget.style.color = '#EF7716')}
-                  onMouseLeave={e => (e.currentTarget.style.color = 'rgba(255,255,255,0.65)')}>
-                  {label}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </div>
+        {/* Tagline */}
+        <p style={{
+          fontSize: '0.875rem',
+          color: TAGLINE,
+          lineHeight: 1.6,
+          margin: 0,
+          maxWidth: '360px',
+        }}>
+          Building the future on the efficient software frontier.
+        </p>
 
-        {/* Developers column */}
-        <div>
-          <p style={{fontFamily: "'Montserrat', sans-serif", fontWeight: 800, fontSize: '0.8rem', letterSpacing: '0.08em', textTransform: 'uppercase', color: '#f0f0f0', margin: '0 0 1rem'}}>Developers</p>
-          <ul style={{listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '0.6rem'}}>
-            {[
-              {label: 'Zilkworm Docs ↗', href: 'https://zilkworm.erigon.tech'},
-              {label: 'Cocoon Docs ↗', href: 'https://cocoon.erigon.tech'},
-              {label: 'Erigon Docs ↗', href: 'https://docs.erigon.tech'},
-              {label: 'Blog', href: 'https://erigon.tech/blog/'},
-            ].map(({label, href}) => (
-              <li key={label}>
-                <a href={href} target="_blank" rel="noopener noreferrer" style={{color: 'rgba(255,255,255,0.65)', textDecoration: 'none', fontSize: '0.9rem', transition: 'color 0.15s'}}
-                  onMouseEnter={e => (e.currentTarget.style.color = '#EF7716')}
-                  onMouseLeave={e => (e.currentTarget.style.color = 'rgba(255,255,255,0.65)')}>
-                  {label}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </div>
-
-        {/* Company column */}
-        <div>
-          <p style={{fontFamily: "'Montserrat', sans-serif", fontWeight: 800, fontSize: '0.8rem', letterSpacing: '0.08em', textTransform: 'uppercase', color: '#f0f0f0', margin: '0 0 1rem'}}>Company</p>
-          <ul style={{listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '0.6rem'}}>
-            {[
-              {label: 'About Us', href: 'https://erigon.tech/about/'},
-              {label: 'Services', href: 'https://erigon.tech/services/'},
-              {label: 'Contact', href: 'https://erigon.tech/contact/'},
-              {label: 'Privacy Policy', href: 'https://erigon.tech/privacy/'},
-              {label: 'Cookie Policy', href: 'https://erigon.tech/cookies/'},
-            ].map(({label, href}) => (
-              <li key={label}>
-                <a href={href} target="_blank" rel="noopener noreferrer" style={{color: 'rgba(255,255,255,0.65)', textDecoration: 'none', fontSize: '0.9rem', transition: 'color 0.15s'}}
-                  onMouseEnter={e => (e.currentTarget.style.color = '#EF7716')}
-                  onMouseLeave={e => (e.currentTarget.style.color = 'rgba(255,255,255,0.65)')}>
-                  {label}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </div>
-
-        {/* Community column */}
-        <div>
-          <p style={{fontFamily: "'Montserrat', sans-serif", fontWeight: 800, fontSize: '0.8rem', letterSpacing: '0.08em', textTransform: 'uppercase', color: '#f0f0f0', margin: '0 0 1rem'}}>Community</p>
-          <div style={{display: 'flex', flexDirection: 'column', gap: '0.5rem'}}>
-            {[
-              {label: 'X / Twitter', href: 'https://x.com/erigoneth', Icon: IconX},
-              {label: 'Discord', href: 'https://dsc.gg/erigon', Icon: IconDiscord},
-              {label: 'GitHub', href: 'https://github.com/erigontech', Icon: IconGitHub},
-              {label: 'LinkedIn', href: 'https://www.linkedin.com/company/erigon/', Icon: IconLinkedIn},
-            ].map(({label, href, Icon}) => (
-              <a key={label} href={href} target="_blank" rel="noopener noreferrer" className="footer-social-btn">
-                <Icon />
-                {label}
-              </a>
-            ))}
-          </div>
+        {/* Social icons — right aligned */}
+        <div className="footer-socials">
+          {SOCIALS.map(({label, href, Icon}) => (
+            <a key={label} href={href} target="_blank" rel="noopener noreferrer" aria-label={label} title={label}
+              className="footer-social">
+              <Icon />
+            </a>
+          ))}
         </div>
       </div>
 
       {/* Divider */}
-      <div style={{borderTop: '1px solid rgba(255,255,255,0.08)', margin: '0 2rem'}} />
+      <div style={{borderTop: `1px solid ${DIVIDER}`, margin: '0.25rem 2rem'}} />
 
       {/* Bottom bar */}
       <div className="footer-bottom-bar" style={{
         maxWidth: '1280px',
         margin: '0 auto',
-        padding: '1.25rem 2rem',
+        padding: '0.7rem 2rem',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'space-between',
         flexWrap: 'wrap',
         gap: '0.75rem',
       }}>
-        <span style={{fontSize: '0.8rem', color: 'rgba(255,255,255,0.35)'}}>
+        <span style={{fontSize: '0.8rem', color: FINE_BASE}}>
           © {new Date().getFullYear()} Erigon Technologies AG. All rights reserved.
         </span>
         <div style={{display: 'flex', alignItems: 'center', gap: '1.5rem', flexWrap: 'wrap'}}>
-          {[
-            {label: 'Privacy Policy', href: 'https://erigon.tech/privacy/'},
-            {label: 'Cookie Policy', href: 'https://erigon.tech/cookies/'},
-            {label: 'Contact', href: 'https://erigon.tech/contact/'},
-          ].map(({label, href}) => (
-            <a key={label} href={href} target="_blank" rel="noopener noreferrer"
-              style={{fontSize: '0.8rem', color: 'rgba(255,255,255,0.35)', textDecoration: 'none', transition: 'color 0.15s'}}
-              onMouseEnter={e => (e.currentTarget.style.color = '#EF7716')}
-              onMouseLeave={e => (e.currentTarget.style.color = 'rgba(255,255,255,0.35)')}>
+          {LEGAL.map(({label, href}) => (
+            <a key={label} href={href}
+              {...(href.startsWith('mailto:') ? {} : {target: '_blank', rel: 'noopener noreferrer'})}
+              className="footer-legal">
               {label}
             </a>
           ))}
-          <a href="mailto:hello@erigon.tech"
-            style={{fontSize: '0.8rem', color: 'rgba(255,255,255,0.35)', textDecoration: 'none', transition: 'color 0.15s'}}
-            onMouseEnter={e => (e.currentTarget.style.color = '#EF7716')}
-            onMouseLeave={e => (e.currentTarget.style.color = 'rgba(255,255,255,0.35)')}>
-            hello@erigon.tech
-          </a>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
Forward-ports the footer half of #23070 to `main`, matching the `release/3.6` port in #23601.

#23070 merged to `release/3.5` only. Its font half reached `main` independently through #22981, so the wordmark is already here — the footer half never followed. `main` still serves the five-column black footer, the dead `.footer-social-btn` rules, the inline `onMouseEnter` handlers, and an unused `themeConfig.footer` block whose Discord link contradicts the real one.

The three non-config files are **byte-identical** to #23601, so `main` and `release/3.6` end up with the same footer. That parity is the reason this exists as its own PR: `main` is where future release branches are cut from, so a fix landing only on `release/3.6` would be lost at the next cut and both defects below would reappear.

This overlaps @yperbasis's #23475, which targets the same branch with the same source change. It differs in three ways, and the author's call on how to reconcile them is welcome:

- **`--footer-accent-tint` per mode.** #23475 moved the light accent to `#A34E0B` as a contrast fix, but left the pre-`color-mix` fallback hardcoded to `rgba(239, 119, 22, 0.12)`. Any engine below the `color-mix` baseline — Chrome 109 is still in the default browserslist — then tints the light footer with the dark-mode orange underneath `#A34E0B` text. The fallback now tracks the mode.
- **`aria-label` satisfies Label in Name.** The brand anchor's label was `"Erigon home page"` while its visible label is the `erigon.tech` wordmark. An `aria-label` replaces the whole accessible name, so the name did not contain the visible text — WCAG 2.5.3 Label in Name (Level A). It now opens with the wordmark: `"erigon.tech home page"`. This is pre-existing in #23070 as merged to `release/3.5`, not something #23475 introduced.
- **Palette comments kept.** The comments recording the palette invariants — including why the fine print is 0.55 alpha rather than a mirrored 0.35, which computes to 2.44:1 and fails AA — and why the interactive states are CSS rather than handlers, are retained from the merged `release/3.5` version. Stale `docusaurus-design-spec.md` paths are corrected to `DESIGN-SPEC.md`.

The light accent stays `#A34E0B` from #23475, which is a real fix worth keeping: brand `#EF7716` measures 7.32:1 on the black footer but 2.87:1 on the white one, below AA, where `#A34E0B` is 5.75:1. Dark mode keeps `#EF7716`.

Verified with `npm ci && npm run build`: footer classes render, both accent and tint values appear per mode, the minifier guards `color-mix` behind `@supports`, the old footer is gone, and `generate-llms.py --check` matches.
