### PR TITLE
execution/commitment: stabilize arena invariant test

### DIFF
--- a/execution/commitment/commitment_test.go
+++ b/execution/commitment/commitment_test.go
@@ -49,15 +49,19 @@ func noopCtxFactory(context.Context) (PatriciaContext, func()) {
 }
 
 type gatedPatriciaContext struct {
-	sleep    time.Duration
-	descend  bool
-	entered  chan struct{}
-	release  chan struct{}
-	gateDone atomic.Bool
+	sleep       time.Duration
+	descend     bool
+	entered     chan struct{}
+	release     chan struct{}
+	startOthers chan struct{}
+	gateDone    atomic.Bool
 }
 
 func (g *gatedPatriciaContext) Branch(prefix []byte) ([]byte, kv.Step, error) {
 	if (g.entered != nil || g.release != nil) && !g.gateDone.Swap(true) {
+		if g.startOthers != nil {
+			close(g.startOthers)
+		}
 		if g.entered != nil {
 			g.entered <- struct{}{}
 		}
@@ -194,9 +198,14 @@ func TestHashSort_WarmupLap(t *testing.T) {
 
 func gatedStragglerFactory(entered, release chan struct{}) TrieContextFactory {
 	var n atomic.Int32
-	return func(context.Context) (PatriciaContext, func()) {
+	startOthers := make(chan struct{})
+	return func(ctx context.Context) (PatriciaContext, func()) {
 		if n.Add(1) == 1 {
-			return &gatedPatriciaContext{entered: entered, release: release}, nil
+			return &gatedPatriciaContext{entered: entered, release: release, startOthers: startOthers}, nil
+		}
+		select {
+		case <-startOthers:
+		case <-ctx.Done():
 		}
 		return &gatedPatriciaContext{}, nil
 	}


### PR DESCRIPTION
## Summary

- make the gated warmup worker deterministically own the first generation-0 work item
- release the remaining workers only after the straggler enters `Branch`
- preserve cancellation cleanup without sleeps, skips, or weaker assertions

This is a test-only fix for the scheduler-dependent failure observed in [CI](https://github.com/erigontech/erigon/actions/runs/32981978055/job/98220648350). Production code is unchanged.

## Testing

- `go test ./execution/commitment -run '^TestHashSort_WaitBufferFreeErrorKeepsArenaInvariant$' -count=1000 -cpu=1,2,8`\n- focused race test (`-race -count=20 -cpu=1,2,8`)\n- `go test ./execution/commitment`\n- `make lint` (two clean passes with isolated caches)\n- `make erigon integration`\n- `git diff --check`