### PR TITLE
db/integrity: report a truncated commitment file as referencing, and count cache-skipped files

### DIFF
--- a/db/integrity/commitment_deref_counts_test.go
+++ b/db/integrity/commitment_deref_counts_test.go
@@ -17,25 +17,83 @@
 package integrity
 
 import (
+	"encoding/binary"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/common/length"
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/db/version"
+	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
 )
+
+// accountStorageBranch builds a single-cell BranchData carrying an account-addr key and a
+// storage-addr key: touchMap=afterMap=1, fieldBits=fieldAccountAddr|fieldStorageAddr(6), then
+// uvarint(len)+key for each.
+func accountStorageBranch(addr, storageKey []byte) []byte {
+	b := []byte{0, 1, 0, 1, 0x06}
+	var n [binary.MaxVarintLen64]byte
+	for _, key := range [][]byte{addr, storageKey} {
+		c := binary.PutUvarint(n[:], uint64(len(key)))
+		b = append(b, n[:c]...)
+		b = append(b, key...)
+	}
+	return b
+}
+
+// writeCommitmentRecords writes a commitment .kv holding records verbatim, so an odd count leaves a
+// key with no value — the truncation the scan has to notice.
+func writeCommitmentRecords(t *testing.T, records ...[]byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "v2.1-commitment.0-2.kv")
+	comp, err := seg.NewCompressor(t.Context(), "test", path, t.TempDir(), seg.DefaultCfg, log.LvlDebug, log.New())
+	require.NoError(t, err)
+	w := seg.NewWriter(comp, statecfg.Schema.GetDomainCfg(kv.CommitmentDomain).Compression)
+	for _, r := range records {
+		_, err = w.Write(r)
+		require.NoError(t, err)
+	}
+	require.NoError(t, comp.Compress())
+	comp.Close()
+	return path
+}
 
 // TestCheckCommitmentKvDerefCounts pins that a file the referencing scan clears still reports the
 // keys it walked. An all-zero tally is indistinguishable from having scanned nothing, so a run over
 // a fully plain datadir would otherwise produce a summary that proves neither outcome.
 func TestCheckCommitmentKvDerefCounts(t *testing.T) {
 	t.Run("plain file reports what it walked", func(t *testing.T) {
-		f := fakeVisibleFile{path: writeCommitmentKV(t, false), endTxNum: 20, version: version.V2_0}
+		branch := accountStorageBranch(make([]byte, length.Addr), make([]byte, length.Addr+length.Hash))
+		f := fakeVisibleFile{path: writeCommitmentRecords(t,
+			commitmentdb.KeyCommitmentState, []byte("state-blob"),
+			[]byte("\x01"), branch,
+		), endTxNum: 20, version: version.V2_0}
+
 		counts, err := checkCommitmentKvDeref(t.Context(), f, 10, true /* failFast */, log.New())
 		require.NoError(t, err)
-		require.Equal(t, uint64(1), counts.branchKeys)
-		require.Equal(t, uint64(1), counts.plainAccounts)
-		require.Zero(t, counts.referencedAccounts)
-		require.Zero(t, counts.referencedStorages)
+		require.Equal(t, derefCounts{branchKeys: 1, plainAccounts: 1, plainStorages: 1}, counts)
+	})
+
+	t.Run("referencing file reports no tally", func(t *testing.T) {
+		f := fakeVisibleFile{path: writeCommitmentKV(t, true), endTxNum: 20, version: version.V2_1}
+		scan := scanCommitmentFile(f)
+		require.True(t, scan.referenced)
+		require.Equal(t, derefCounts{}, scan.counts)
+	})
+
+	t.Run("a key with no value is referencing, not a cleared plain scan", func(t *testing.T) {
+		f := fakeVisibleFile{path: writeCommitmentRecords(t,
+			commitmentdb.KeyCommitmentState, []byte("state-blob"),
+			[]byte("\x01"),
+		), endTxNum: 20, version: version.V2_0}
+
+		scan := scanCommitmentFile(f)
+		require.True(t, scan.referenced, "the deref pass reports the dangling key as ErrIntegrity; the scan must not skip it")
+		require.Equal(t, derefCounts{}, scan.counts)
 	})
 }

--- a/db/integrity/commitment_integrity.go
+++ b/db/integrity/commitment_integrity.go
@@ -570,12 +570,12 @@ func computeCommitmentFileScan(file state.VisibleFile) commitmentFileScan {
 			continue
 		}
 		counts.branchKeys++
-		accounts, storages, shortened := commitment.BranchData(v).CountPlainKeys()
-		if shortened {
+		plainAccounts, plainStorages, shortened, err := commitment.BranchData(v).CountPlainKeys()
+		if err != nil || shortened > 0 {
 			return commitmentFileScan{referenced: true}
 		}
-		counts.plainAccounts += accounts
-		counts.plainStorages += storages
+		counts.plainAccounts += plainAccounts
+		counts.plainStorages += plainStorages
 	}
 	return commitmentFileScan{counts: counts}
 }

--- a/db/integrity/commitment_integrity.go
+++ b/db/integrity/commitment_integrity.go
@@ -311,6 +311,7 @@ func CheckCommitmentKvDeref(ctx context.Context, db kv.TemporalRoDB, cache *Inte
 		fps  []fileFingerprint // nil when cache is disabled
 	}
 	var works []workItem
+	var cached int
 	for _, file := range files {
 		if !strings.HasSuffix(file.Fullpath(), ".kv") {
 			continue
@@ -332,6 +333,7 @@ func CheckCommitmentKvDeref(ctx context.Context, db kv.TemporalRoDB, cache *Inte
 			}
 			if cache.has(string(CommitmentKvDeref), fps) {
 				logger.Info("skipping (cache hit)", "kv", filepath.Base(kvPath))
+				cached++
 				continue
 			}
 		}
@@ -370,10 +372,14 @@ func CheckCommitmentKvDeref(ctx context.Context, db kv.TemporalRoDB, cache *Inte
 	for _, fps := range successFps {
 		cache.add(string(CommitmentKvDeref), fps)
 	}
+	// cachedFiles contributed no keys to the tally below: without it a warm-cache run and a run
+	// that walked nothing print the same zeros.
 	logger.Info(
 		"[integrity] CommitmentKvDeref",
 		"dur", time.Since(start),
 		"files", len(files),
+		"scannedFiles", len(works),
+		"cachedFiles", cached,
 		"branchKeys", branchKeys.Load(),
 		"referencedAccounts", referencedAccounts.Load(),
 		"plainAccounts", plainAccounts.Load(),
@@ -525,8 +531,6 @@ type commitmentFileScan struct {
 // content scan is done once per file.
 var commitmentReferencingMemo sync.Map // string -> commitmentFileScan
 
-var errShortenedKeyFound = errors.New("shortened key found")
-
 // commitmentFileReferencing reports whether a commitment file carries shortened key references.
 func commitmentFileReferencing(file state.VisibleFile) bool {
 	return scanCommitmentFile(file).referenced
@@ -546,7 +550,7 @@ func scanCommitmentFile(file state.VisibleFile) commitmentFileScan {
 func computeCommitmentFileScan(file state.VisibleFile) commitmentFileScan {
 	decomp, err := seg.NewDecompressor(file.Fullpath())
 	if err != nil {
-		log.Root().Warn("[integrity] commitmentFileReferencing: open failed, treating as referenced", "file", file.Fullpath(), "err", err)
+		log.Root().Warn("[integrity] scanCommitmentFile: open failed, treating as referenced", "file", file.Fullpath(), "err", err)
 		return commitmentFileScan{referenced: true}
 	}
 	defer decomp.Close()
@@ -557,30 +561,21 @@ func computeCommitmentFileScan(file state.VisibleFile) commitmentFileScan {
 	for g.HasNext() {
 		k, _ = g.Next(k[:0])
 		if !g.HasNext() {
-			break
+			// A dangling key is ErrIntegrity in the deref pass, which only runs on a referencing
+			// file — so report referencing and let it name the fault.
+			return commitmentFileScan{referenced: true}
 		}
 		v, _ = g.Next(v[:0])
 		if bytes.Equal(k, commitmentdb.KeyCommitmentState) {
 			continue
 		}
 		counts.branchKeys++
-		_, err := commitment.BranchData(v).ReplacePlainKeys(nil, func(key []byte, isStorage bool) ([]byte, error) {
-			if isStorage {
-				if len(key) != length.Addr+length.Hash {
-					return nil, errShortenedKeyFound
-				}
-				counts.plainStorages++
-				return nil, nil
-			}
-			if len(key) != length.Addr {
-				return nil, errShortenedKeyFound
-			}
-			counts.plainAccounts++
-			return nil, nil
-		})
-		if err != nil {
+		accounts, storages, shortened := commitment.BranchData(v).CountPlainKeys()
+		if shortened {
 			return commitmentFileScan{referenced: true}
 		}
+		counts.plainAccounts += accounts
+		counts.plainStorages += storages
 	}
 	return commitmentFileScan{counts: counts}
 }

--- a/execution/commitment/branch_plain_keys_test.go
+++ b/execution/commitment/branch_plain_keys_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package commitment
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/length"
+)
+
+// branchOfCells builds a BranchData whose touched/after maps cover len(cells) positions. Each cell
+// is a fieldBits byte followed by uvarint(len)+key for every key it carries.
+func branchOfCells(t *testing.T, cells ...[]byte) BranchData {
+	t.Helper()
+	require.LessOrEqual(t, len(cells), 16)
+	bitmap := uint16(1)<<len(cells) - 1
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint16(b[0:], bitmap)
+	binary.BigEndian.PutUint16(b[2:], bitmap)
+	for _, c := range cells {
+		b = append(b, c...)
+	}
+	return b
+}
+
+func plainAccountStorageCell() []byte {
+	return cellOf(0x06, make([]byte, length.Addr), make([]byte, length.Addr+length.Hash))
+}
+
+func shortenedAccountCell() []byte {
+	return cellOf(0x02, []byte{0x81, 0x02})
+}
+
+func cellOf(fieldBits byte, keys ...[]byte) []byte {
+	b := []byte{fieldBits}
+	var n [binary.MaxVarintLen64]byte
+	for _, k := range keys {
+		c := binary.PutUvarint(n[:], uint64(len(k)))
+		b = append(b, n[:c]...)
+		b = append(b, k...)
+	}
+	return b
+}
+
+// TestCountPlainKeysWalksPastAShortenedKey pins the whole-branch walk. Aborting at the first
+// shortened key undercounts every kind at once: the plain keys behind it go unseen and the
+// shortened ones are never tallied, so neither number can be read as a total.
+func TestCountPlainKeysWalksPastAShortenedKey(t *testing.T) {
+	t.Parallel()
+
+	t.Run("plain keys on both sides of a shortened one", func(t *testing.T) {
+		branch := branchOfCells(t, plainAccountStorageCell(), shortenedAccountCell(), plainAccountStorageCell())
+
+		plainAccounts, plainStorages, shortened, err := branch.CountPlainKeys()
+		require.NoError(t, err)
+		require.Equal(t, uint64(2), plainAccounts)
+		require.Equal(t, uint64(2), plainStorages)
+		require.Equal(t, uint64(1), shortened)
+		require.True(t, branch.HasShortenedKeys())
+	})
+
+	t.Run("a fully plain branch reports no shortened keys", func(t *testing.T) {
+		branch := branchOfCells(t, plainAccountStorageCell(), plainAccountStorageCell())
+
+		plainAccounts, plainStorages, shortened, err := branch.CountPlainKeys()
+		require.NoError(t, err)
+		require.Equal(t, uint64(2), plainAccounts)
+		require.Equal(t, uint64(2), plainStorages)
+		require.Zero(t, shortened)
+		require.False(t, branch.HasShortenedKeys())
+	})
+
+	t.Run("a truncated branch errors and still reads as referencing", func(t *testing.T) {
+		branch := branchOfCells(t, plainAccountStorageCell())
+		truncated := branch[:len(branch)-8]
+
+		_, _, _, err := truncated.CountPlainKeys()
+		require.Error(t, err)
+		require.True(t, truncated.HasShortenedKeys(), "an unparseable branch must never read as plain")
+	})
+}

--- a/execution/commitment/branch_plain_keys_test.go
+++ b/execution/commitment/branch_plain_keys_test.go
@@ -31,9 +31,10 @@ func branchOfCells(t *testing.T, cells ...[]byte) BranchData {
 	t.Helper()
 	require.LessOrEqual(t, len(cells), 16)
 	bitmap := uint16(1)<<len(cells) - 1
-	b := make([]byte, 4)
-	binary.BigEndian.PutUint16(b[0:], bitmap)
-	binary.BigEndian.PutUint16(b[2:], bitmap)
+	var header [4]byte
+	binary.BigEndian.PutUint16(header[0:], bitmap)
+	binary.BigEndian.PutUint16(header[2:], bitmap)
+	b := header[:]
 	for _, c := range cells {
 		b = append(b, c...)
 	}
@@ -85,6 +86,20 @@ func TestCountPlainKeysWalksPastAShortenedKey(t *testing.T) {
 		require.Equal(t, uint64(2), plainStorages)
 		require.Zero(t, shortened)
 		require.False(t, branch.HasShortenedKeys())
+	})
+
+	// A cell header that runs off the end was the one unchecked index in
+	// ReplacePlainKeys. It only became reachable once the count stopped returning
+	// at the first shortened key: before that, a referencing branch aborted on
+	// cell 0 and never advanced into the overrun.
+	t.Run("a branch ending on a cell boundary errors instead of panicking", func(t *testing.T) {
+		var branch BranchData = []byte{0, 3, 0, 3, 0x00} // two cells advertised, one fieldBits byte
+
+		require.NotPanics(t, func() {
+			_, _, _, err := branch.CountPlainKeys()
+			require.ErrorContains(t, err, "buffer too small for cell fields")
+		})
+		require.True(t, branch.HasShortenedKeys(), "an unparseable branch must never read as plain")
 	})
 
 	t.Run("a truncated branch errors and still reads as referencing", func(t *testing.T) {

--- a/execution/commitment/commitment.go
+++ b/execution/commitment/commitment.go
@@ -695,17 +695,28 @@ var errShortenedKeyFound = errors.New("shortened key found")
 
 // A malformed branch reports true: treat as referenced, never under-report.
 func (branchData BranchData) HasShortenedKeys() bool {
+	_, _, shortened := branchData.CountPlainKeys()
+	return shortened
+}
+
+// CountPlainKeys tallies the branch's plain account and storage keys. The tally stops at the first
+// shortened key, so it is complete only when shortened is false.
+func (branchData BranchData) CountPlainKeys() (accounts, storages uint64, shortened bool) {
 	_, err := branchData.ReplacePlainKeys(nil, func(key []byte, isStorage bool) ([]byte, error) {
 		if isStorage {
 			if len(key) != length.Addr+length.Hash {
 				return nil, errShortenedKeyFound
 			}
-		} else if len(key) != length.Addr {
+			storages++
+			return nil, nil
+		}
+		if len(key) != length.Addr {
 			return nil, errShortenedKeyFound
 		}
+		accounts++
 		return nil, nil
 	})
-	return err != nil
+	return accounts, storages, err != nil
 }
 
 // If fn returns nil, the original key is kept.

--- a/execution/commitment/commitment.go
+++ b/execution/commitment/commitment.go
@@ -691,32 +691,28 @@ func (branchData BranchData) String() string {
 	return sb.String()
 }
 
-var errShortenedKeyFound = errors.New("shortened key found")
-
 // A malformed branch reports true: treat as referenced, never under-report.
 func (branchData BranchData) HasShortenedKeys() bool {
-	_, _, shortened := branchData.CountPlainKeys()
-	return shortened
+	_, _, shortened, err := branchData.CountPlainKeys()
+	return shortened > 0 || err != nil
 }
 
-// CountPlainKeys tallies the branch's plain account and storage keys. The tally stops at the first
-// shortened key, so it is complete only when shortened is false.
-func (branchData BranchData) CountPlainKeys() (accounts, storages uint64, shortened bool) {
-	_, err := branchData.ReplacePlainKeys(nil, func(key []byte, isStorage bool) ([]byte, error) {
-		if isStorage {
-			if len(key) != length.Addr+length.Hash {
-				return nil, errShortenedKeyFound
-			}
-			storages++
-			return nil, nil
+// CountPlainKeys tallies the branch's keys by kind. It walks every cell rather than stopping at the
+// first shortened key, so a branch holding both kinds reports both truthfully. A non-nil err is a
+// parse failure, and leaves the tally partial.
+func (branchData BranchData) CountPlainKeys() (plainAccounts, plainStorages, shortened uint64, err error) {
+	_, err = branchData.ReplacePlainKeys(nil, func(key []byte, isStorage bool) ([]byte, error) {
+		switch {
+		case isStorage && len(key) == length.Addr+length.Hash:
+			plainStorages++
+		case !isStorage && len(key) == length.Addr:
+			plainAccounts++
+		default:
+			shortened++
 		}
-		if len(key) != length.Addr {
-			return nil, errShortenedKeyFound
-		}
-		accounts++
 		return nil, nil
 	})
-	return accounts, storages, err != nil
+	return plainAccounts, plainStorages, shortened, err
 }
 
 // If fn returns nil, the original key is kept.

--- a/execution/commitment/commitment.go
+++ b/execution/commitment/commitment.go
@@ -733,6 +733,9 @@ func (branchData BranchData) ReplacePlainKeys(newData []byte, fn func(key []byte
 	spanStart := 0
 	for bitset, j := touchMap&afterMap, 0; bitset != 0; j++ {
 		bit := bitset & -bitset
+		if pos >= len(branchData) {
+			return nil, errors.New("replacePlainKeys buffer too small for cell fields")
+		}
 		fields := cellFields(branchData[pos])
 		pos++
 		if fields&fieldExtension != 0 {


### PR DESCRIPTION
Follow-up to #23597. That PR made CommitmentKvDeref report the keys found by the referencing pre-scan, but three review gaps remained: a commitment .kv ending on a dangling key could be classified as a complete plain scan, warm-cache runs still printed all-zero key counts with no cache context, and plain-key length rules were duplicated between db/integrity and execution/commitment. This makes those paths explicit and shares the plain-key classifier.

## Changes

- Treat a key without a following value in computeCommitmentFileScan as referencing, so checkCommitmentKvDeref runs and reports the existing ErrIntegrity path instead of returning a partial plain tally.
- Track scannedFiles and cachedFiles in CheckCommitmentKvDeref, so zero key counters on a warm IntegrityCache run are distinguishable from a run that scanned no files.
- Add BranchData.CountPlainKeys and have HasShortenedKeys and the integrity pre-scan use it, keeping the account 20B and storage 52B rules in one package. It walks every cell instead of returning at the first shortened key, which undercounted the plain keys behind it and never tallied the shortened ones at all.
- Bounds-check the cell header in ReplacePlainKeys. It was the one unchecked index in the walk, and the whole-branch count is what reaches it: a referencing branch used to return at cell 0, so the overrun stayed unreachable from here.
- Extend TestCheckCommitmentKvDerefCounts with plain storage, referencing no-tally, and dangling-key cases.
