### PR TITLE
db/etl: stop the bufio read benchmarks allocating per field

### DIFF
--- a/db/etl/read_bench_test.go
+++ b/db/etl/read_bench_test.go
@@ -204,12 +204,13 @@ func benchBufioU16(b *testing.B, fname string, bufSize int) {
 	defer f.Close()
 
 	r := bufio.NewReaderSize(f, bufSize)
+	lenBuf := make([]byte, 2)
 	var buf []byte
 	for {
-		if buf, err = readFieldBufioU16(r, buf); err != nil {
+		if buf, err = readFieldBufioU16(r, lenBuf, buf); err != nil {
 			break
 		}
-		if buf, err = readFieldBufioU16(r, buf); err != nil {
+		if buf, err = readFieldBufioU16(r, lenBuf, buf); err != nil {
 			break
 		}
 	}
@@ -224,20 +225,22 @@ func benchBufioU32(b *testing.B, fname string, bufSize int) {
 	defer f.Close()
 
 	r := bufio.NewReaderSize(f, bufSize)
+	lenBuf := make([]byte, 4)
 	var buf []byte
 	for {
-		if buf, err = readFieldBufioU32(r, buf); err != nil {
+		if buf, err = readFieldBufioU32(r, lenBuf, buf); err != nil {
 			break
 		}
-		if buf, err = readFieldBufioU32(r, buf); err != nil {
+		if buf, err = readFieldBufioU32(r, lenBuf, buf); err != nil {
 			break
 		}
 	}
 }
 
-func readFieldBufioU16(r *bufio.Reader, buf []byte) ([]byte, error) {
-	var lenBuf [2]byte
-	if _, err := io.ReadFull(r, lenBuf[:]); err != nil {
+func readFieldBufioU16(r *bufio.Reader, lenBuf, buf []byte) ([]byte, error) {
+	// lenBuf comes from the caller: io.ReadFull takes an io.Reader, so a local
+	// array escapes and costs an allocation on every field read.
+	if _, err := io.ReadFull(r, lenBuf); err != nil {
 		return buf, err
 	}
 	n := int(*(*uint16)(unsafe.Pointer(&lenBuf[0])))
@@ -255,9 +258,10 @@ func readFieldBufioU16(r *bufio.Reader, buf []byte) ([]byte, error) {
 	return buf, nil
 }
 
-func readFieldBufioU32(r *bufio.Reader, buf []byte) ([]byte, error) {
-	var lenBuf [4]byte
-	if _, err := io.ReadFull(r, lenBuf[:]); err != nil {
+func readFieldBufioU32(r *bufio.Reader, lenBuf, buf []byte) ([]byte, error) {
+	// lenBuf comes from the caller: io.ReadFull takes an io.Reader, so a local
+	// array escapes and costs an allocation on every field read.
+	if _, err := io.ReadFull(r, lenBuf); err != nil {
 		return buf, err
 	}
 	n := int(*(*uint32)(unsafe.Pointer(&lenBuf[0])))


### PR DESCRIPTION
`readFieldBufioU16` and `readFieldBufioU32` read the length prefix into a local `[2]byte`/`[4]byte` and pass it to `io.ReadFull`. That takes an `io.Reader`, so the array escapes and every field read costs an allocation.

The mmap readers beside them slice the mapping directly and pay nothing, so the comparison this file exists to make was handing the bufio side a penalty that has nothing to do with buffered I/O.

The caller owns `lenBuf` now. `BenchmarkSequentialRead/val32/bufio_u16`, two alternating rounds each:

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| before | 57.3M, 59.5M | 8.42MB | 3947589 |
| after | 42.8M, 42.0M | 525KB | 7 |

Benchmark-only; no production code touched. Found while auditing allocations for #23599.