### PR TITLE
execution/tracing, rpc/transactions: fix invalid structLogs JSON and reject a negative limit

### DIFF
--- a/execution/tracing/tracers/logger/json_stream.go
+++ b/execution/tracing/tracers/logger/json_stream.go
@@ -127,12 +127,20 @@ func (l *JsonStreamLogger) writeMemoryWordRaw(chunk []byte) {
 }
 
 func (l *JsonStreamLogger) OnExit(depth int, output []byte, gasUsed uint64, err error, reverted bool) {
-	// no log entry are producer
-	if l.firstCapture {
-		l.stream.WriteObjectStart()
-		l.stream.WriteObjectField("structLogs")
-		l.stream.WriteArrayStart()
+	l.writePrologueOnce()
+}
+
+// writePrologueOnce opens the response object and the structLogs array. Every
+// frame exits through OnExit, and the caller closes one object and one array, so
+// a second prologue would leave the response unbalanced.
+func (l *JsonStreamLogger) writePrologueOnce() {
+	if !l.firstCapture {
+		return
 	}
+	l.firstCapture = false
+	l.stream.WriteObjectStart()
+	l.stream.WriteObjectField("structLogs")
+	l.stream.WriteArrayStart()
 }
 
 // OnOpcode also tracks SLOAD/SSTORE ops to track storage change.
@@ -156,13 +164,8 @@ func (l *JsonStreamLogger) OnOpcode(pc uint64, typ byte, gas, cost uint64, scope
 	l.opcodeSteps++
 	if !l.firstCapture {
 		l.stream.WriteMore()
-	} else {
-		l.stream.WriteObjectStart()
-		l.stream.WriteObjectField("structLogs")
-		l.stream.WriteArrayStart()
-
-		l.firstCapture = false
 	}
+	l.writePrologueOnce()
 	var outputStorage bool
 	if !l.cfg.DisableStorage {
 		// initialise new changed values storage container for this contract

--- a/execution/tracing/tracers/logger/json_stream_test.go
+++ b/execution/tracing/tracers/logger/json_stream_test.go
@@ -207,6 +207,59 @@ func TestJsonStreamLogger_LimitDoesNotCorruptJSON(t *testing.T) {
 	}
 }
 
+// closeStreamLikeCaller writes the tail ExecuteTraceTx appends once execution is
+// over: exactly one array end and one object end, whatever the logger emitted.
+func closeStreamLikeCaller(stream jsonstream.Stream) {
+	stream.WriteArrayEnd()
+	stream.WriteMore()
+	stream.WriteObjectField("gas")
+	stream.WriteUint64(0)
+	stream.WriteMore()
+	stream.WriteObjectField("failed")
+	stream.WriteBool(false)
+	stream.WriteObjectEnd()
+}
+
+// The structLogs prologue must be written at most once. OnExit opens it too, for
+// traces that captured no step, and the caller closes exactly one object and one
+// array however many frames exited.
+func TestJsonStreamLogger_PrologueWrittenOnce(t *testing.T) {
+	dead, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tests := []struct {
+		name    string
+		cfg     *LogConfig
+		ctx     context.Context
+		opcodes int
+	}{
+		{"a negative limit suppresses every step", &LogConfig{Limit: -1}, context.Background(), 3},
+		{"a dead context suppresses every step", &LogConfig{}, dead, 3},
+		{"nothing to capture", &LogConfig{}, context.Background(), 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			stream := jsonstream.New(&buf)
+			l := NewJsonStreamLogger(tt.cfg, tt.ctx, stream)
+			l.env = &tracing.VMContext{IntraBlockState: &mockIBS{}}
+
+			scope := &mockOpContext{}
+			for i := range tt.opcodes {
+				l.OnOpcode(uint64(i), byte(vm.MLOAD), 100, 3, scope, nil, 1, nil)
+			}
+			// Two frames exit, as in any trace of a transaction that makes a call.
+			l.OnExit(1, nil, 0, nil, false)
+			l.OnExit(0, nil, 0, nil, false)
+
+			closeStreamLikeCaller(stream)
+			require.NoError(t, stream.Flush())
+			require.True(t, json.Valid(buf.Bytes()), "output is not valid JSON: %s", buf.Bytes())
+		})
+	}
+}
+
 // TestJsonStreamLogger_MemoryEncoding verifies that memory words are emitted as
 // 0x-prefixed 64-char hex strings and that a partial last word is padded to 32 bytes.
 func TestJsonStreamLogger_MemoryEncoding(t *testing.T) {

--- a/execution/tracing/tracers/logger/logger.go
+++ b/execution/tracing/tracers/logger/logger.go
@@ -57,7 +57,7 @@ type LogConfig struct {
 	DisableStorage   bool `json:"disableStorage"`   // disable storage capture
 	EnableReturnData bool `json:"enableReturnData"` // enable return data capture
 	Debug            bool `json:"debug"`            // print output during capture end
-	Limit            int  `json:"limit"`            // maximum length of output, but zero means unlimited
+	Limit            int  `json:"limit"`            // maximum number of opcode steps to capture, but zero means unlimited
 	// Chain overrides, can be used to execute a trace using future fork rules
 	Overrides *chain.Config `json:"overrides,omitempty"`
 }

--- a/rpc/transactions/tracing.go
+++ b/rpc/transactions/tracing.go
@@ -42,6 +42,7 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 	"github.com/erigontech/erigon/execution/vm"
 	"github.com/erigontech/erigon/execution/vm/evmtypes"
+	"github.com/erigontech/erigon/rpc"
 	"github.com/erigontech/erigon/rpc/jsonstream"
 	"github.com/erigontech/erigon/rpc/rpchelper"
 )
@@ -201,6 +202,9 @@ func AssembleTracer(
 		ctx, cancel := context.WithTimeout(ctx, callTimeout)
 		return logger.NewJsonStreamLogger(nil, ctx, stream).Tracer(), true, cancel, nil
 	default:
+		if config.LogConfig != nil && config.LogConfig.Limit < 0 {
+			return nil, false, func() {}, &rpc.InvalidParamsError{Message: "limit must not be negative"}
+		}
 		ctx, cancel := context.WithTimeout(ctx, callTimeout)
 		return logger.NewJsonStreamLogger(config.LogConfig, ctx, stream).Tracer(), true, cancel, nil
 	}

--- a/rpc/transactions/tracing_test.go
+++ b/rpc/transactions/tracing_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package transactions
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	tracersConfig "github.com/erigontech/erigon/execution/tracing/tracers/config"
+	"github.com/erigontech/erigon/execution/tracing/tracers/logger"
+	_ "github.com/erigontech/erigon/execution/tracing/tracers/native" // registers callTracer
+	"github.com/erigontech/erigon/rpc"
+	"github.com/erigontech/erigon/rpc/jsonstream"
+)
+
+func assembleWithLogConfig(t *testing.T, cfg *logger.LogConfig, tracerName *string) error {
+	t.Helper()
+	_, _, cancel, err := AssembleTracer(
+		t.Context(),
+		&tracersConfig.TraceConfig{LogConfig: cfg, Tracer: tracerName},
+		common.Hash{}, nil, common.Hash{}, 0,
+		jsonstream.New(io.Discard),
+		time.Second,
+	)
+	cancel()
+	return err
+}
+
+// execution-apis gives the opcode logger's limit a minimum of 0, and a negative
+// one would suppress every step, so it must be refused rather than served as an
+// empty trace.
+func TestAssembleTracerRejectsNegativeLimit(t *testing.T) {
+	err := assembleWithLogConfig(t, &logger.LogConfig{Limit: -1}, nil)
+
+	var invalidParams *rpc.InvalidParamsError
+	require.ErrorAs(t, err, &invalidParams)
+}
+
+func TestAssembleTracerAcceptsNonNegativeLimit(t *testing.T) {
+	for _, limit := range []int{0, 1, 1000} {
+		require.NoError(t, assembleWithLogConfig(t, &logger.LogConfig{Limit: limit}, nil))
+	}
+}
+
+// The limit belongs to the opcode logger, and execution-apis says a named tracer
+// ignores it, so it must not turn into an error there.
+func TestAssembleTracerIgnoresLimitForNamedTracer(t *testing.T) {
+	callTracer := "callTracer"
+	require.NoError(t, assembleWithLogConfig(t, &logger.LogConfig{Limit: -1}, &callTracer))
+}


### PR DESCRIPTION
Two fixes:

1. **A negative `limit` is refused** with `-32602`. execution-apis gives `limit` a minimum of 0. The check is in `AssembleTracer`, only in the branch that builds the opcode logger, because a named tracer ignores `limit`.

2. **The `structLogs` prologue is written once.** `OnExit` opened `{"structLogs":[` without clearing `firstCapture`, so with no step captured every frame exit opened it again, while the caller closes one object and one array. On two frames `debug_traceTransaction` answered:

   ```
   {"structLogs":[{"structLogs":[],"gas":0,"failed":false}
   ```

The negative limit is the reported way into item 2. The rare one is a low `--rpc.evmtimeout` expiring before the first recorded opcode, on a trace where at least two frames exit: `OnOpcode` returns early on `ctx.Done()`, while execution still runs to the end since nothing calls `tracer.Stop` on this path. Item 1 closes the reported entry, item 2 closes the shape, so the next early `return` added to `OnOpcode` cannot reopen it.

## Tests

`execution/tracing/tracers/logger`, `TestJsonStreamLogger_PrologueWrittenOnce` — one case per way of capturing no step, each asserting the response parses:

- a negative limit suppresses every step
- a dead context suppresses every step
- nothing to capture

All three fail on `main` with the output above.

`rpc/transactions`, new `tracing_test.go`:

- `TestAssembleTracerRejectsNegativeLimit` — `-32602` for `limit: -1`
- `TestAssembleTracerAcceptsNonNegativeLimit` — 0, 1 and 1000 still build a tracer
- `TestAssembleTracerIgnoresLimitForNamedTracer` — `callTracer` with `limit: -1` is not an error

Closes #23478
