### PR TITLE
db/state: derive domain_prunable from the values table's prune progress, not the history keys table

### DIFF
--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1968,10 +1968,16 @@ func (dt *DomainRoTx) canScanPruneDomainTables(tx kv.Tx, untilTx uint64) (can bo
 
 	// Backlog comes from the values table's own prune progress: the history keys
 	// table tracks separate progress, and stays empty when history is disabled -
-	// as it is for commitment by default.
+	// as it is for commitment by default. prg.TxTo is the rotation's target,
+	// stored even when the scan was cut short, so only a completed rotation proves
+	// the values below it are gone; txFrom is 0, so an unfinished one bounds nothing.
+	prunedThrough := uint64(0)
+	if prg.ValueProgress == prune.Done {
+		prunedThrough = prg.TxTo
+	}
 	delta := 0.0
-	if filesEnd := dt.files.EndTxNum(); filesEnd > prg.TxTo {
-		delta = float64(filesEnd-prg.TxTo) / float64(dt.stepSize)
+	if filesEnd := dt.files.EndTxNum(); filesEnd > prunedThrough {
+		delta = float64(filesEnd-prunedThrough) / float64(dt.stepSize)
 	}
 	switch dt.name {
 	case kv.AccountsDomain:

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1965,20 +1965,24 @@ func (dt *DomainRoTx) canScanPruneDomainTables(tx kv.Tx, untilTx uint64) (can bo
 	}
 
 	done := prg.KeyProgress == prune.Done && prg.ValueProgress == prune.Done && untilTx <= prg.TxTo
-	minStep := kv.Step(dt.d.minStepInDB(tx))
-	delta := float64(max(maxStepToPrune, minStep) - min(maxStepToPrune, minStep)) // maxStep could be 0
-	switch dt.d.FilenameBase {
-	case "account":
+
+	// Backlog comes from the values table's own prune progress: the history keys
+	// table tracks separate progress, and stays empty when history is disabled -
+	// as it is for commitment by default.
+	delta := 0.0
+	if filesEnd := dt.files.EndTxNum(); filesEnd > prg.TxTo {
+		delta = float64(filesEnd-prg.TxTo) / float64(dt.stepSize)
+	}
+	switch dt.name {
+	case kv.AccountsDomain:
 		mxPrunableDAcc.Set(delta)
-	case "storage":
+	case kv.StorageDomain:
 		mxPrunableDSto.Set(delta)
-	case "code":
+	case kv.CodeDomain:
 		mxPrunableDCode.Set(delta)
-	case "commitment":
+	case kv.CommitmentDomain:
 		mxPrunableDComm.Set(delta)
 	}
-	//fmt.Printf("smallestToPrune[%s] minInDB %d inFiles %d until %d\n", dt.d.FilenameBase, minStep, maxStepToPrune, untilTx)
-	//println("in d", dt.d.FilenameBase, done, prg.TxTo)
 	return !done, maxStepToPrune
 }
 

--- a/db/state/domain_prunable_test.go
+++ b/db/state/domain_prunable_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/background"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/state/statecfg"
+	"github.com/erigontech/erigon/diagnostics/metrics"
+)
+
+// TestDomain_PrunableStepsGauge pins domain_prunable to the number of steps the
+// values table lags the snapshot files by. Commitment is the domain whose history
+// is off by default: its history keys table stays empty, so a backlog derived from
+// that table counts every step ever written.
+func TestDomain_PrunableStepsGauge(t *testing.T) {
+	// No t.Parallel: the assertions read process-global metric gauges.
+	commitment := statecfg.Schema.CommitmentDomain
+	require.True(t, commitment.Hist.HistoryDisabled, "commitment history is off by default")
+
+	withHistory := commitment
+	withHistory.Hist.HistoryDisabled = false
+	withHistory.Hist.SnapshotsDisabled = false
+
+	t.Run("commitment", func(t *testing.T) {
+		requirePrunableGauge(t, commitment, mxPrunableDComm)
+	})
+	t.Run("commitment with history", func(t *testing.T) {
+		requirePrunableGauge(t, withHistory, mxPrunableDComm)
+	})
+	t.Run("accounts", func(t *testing.T) {
+		requirePrunableGauge(t, statecfg.Schema.AccountsDomain, mxPrunableDAcc)
+	})
+}
+
+// requirePrunableGauge writes 5 steps, collates and prunes the first 3, then
+// collates the remaining 2 without pruning them, asserting the gauge after each
+// stage. The sentinel makes a gauge that is never written fail loudly.
+func requirePrunableGauge(t *testing.T, cfg statecfg.DomainCfg, gauge metrics.Gauge) {
+	t.Helper()
+
+	const aggStep = uint64(4)
+	const sentinel = float64(999)
+	const prunedSteps, totalSteps = kv.Step(3), kv.Step(5)
+
+	ctx := t.Context()
+	logEvery := time.NewTicker(time.Hour)
+	defer logEvery.Stop()
+
+	db, d := testDbAndDomainOfStep(t, cfg, aggStep, log.New())
+	tx, err := db.BeginRw(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	drt := d.beginForTests()
+	w := drt.NewWriter()
+	prev := map[string][]byte{}
+	for txNum := range uint64(totalSteps) * aggStep {
+		k := fmt.Appendf(nil, "key-%d", txNum%3)
+		v := fmt.Appendf(nil, "val-%d", txNum)
+		require.NoError(t, w.PutWithPrev(k, v, txNum, prev[string(k)]))
+		prev[string(k)] = v
+	}
+	require.NoError(t, w.Flush(ctx, tx))
+	w.Close()
+	drt.Close()
+
+	for step := range prunedSteps {
+		require.NoError(t, d.collateBuildIntegrate(ctx, step, tx, background.NewProgressSet()))
+	}
+	drt = d.beginForTests()
+	_, err = drt.Prune(ctx, tx, prunedSteps-1, 0, uint64(prunedSteps)*aggStep, math.MaxUint64, logEvery)
+	require.NoError(t, err)
+	drt.Close()
+
+	gauge.Set(sentinel)
+	drt = d.beginForTests()
+	drt.canScanPruneDomainTables(tx, uint64(prunedSteps)*aggStep)
+	drt.Close()
+	require.Equal(t, uint64(0), gauge.GetValueUint64(), "values table pruned up to the files' end")
+
+	for step := prunedSteps; step < totalSteps; step++ {
+		require.NoError(t, d.collateBuildIntegrate(ctx, step, tx, background.NewProgressSet()))
+	}
+	gauge.Set(sentinel)
+	drt = d.beginForTests()
+	defer drt.Close()
+	drt.canScanPruneDomainTables(tx, uint64(totalSteps)*aggStep)
+	require.Equal(t, uint64(totalSteps-prunedSteps), gauge.GetValueUint64(), "collated but not pruned")
+}

--- a/db/state/domain_prunable_test.go
+++ b/db/state/domain_prunable_test.go
@@ -17,6 +17,7 @@
 package state
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"testing"
@@ -27,6 +28,7 @@ import (
 	"github.com/erigontech/erigon/common/background"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/prune"
 	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/diagnostics/metrics"
 )
@@ -109,4 +111,56 @@ func requirePrunableGauge(t *testing.T, cfg statecfg.DomainCfg, gauge metrics.Ga
 	defer drt.Close()
 	drt.canScanPruneDomainTables(tx, uint64(totalSteps)*aggStep)
 	require.Equal(t, uint64(totalSteps-prunedSteps), gauge.GetValueUint64(), "collated but not pruned")
+}
+
+// TestDomain_PrunableGaugeInterruptedRotation pins the reading when a value scan
+// is cut short. prg.TxTo stores the rotation's target even then, so trusting it
+// would report a cleared backlog while the whole span is still in the table.
+func TestDomain_PrunableGaugeInterruptedRotation(t *testing.T) {
+	const aggStep = uint64(4)
+	const totalSteps = kv.Step(5)
+
+	ctx := t.Context()
+	logEvery := time.NewTicker(time.Hour)
+	defer logEvery.Stop()
+
+	db, d := testDbAndDomainOfStep(t, statecfg.Schema.CommitmentDomain, aggStep, log.New())
+	tx, err := db.BeginRw(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	drt := d.beginForTests()
+	w := drt.NewWriter()
+	prev := map[string][]byte{}
+	for txNum := range uint64(totalSteps) * aggStep {
+		k := fmt.Appendf(nil, "key-%d", txNum%3)
+		v := fmt.Appendf(nil, "val-%d", txNum)
+		require.NoError(t, w.PutWithPrev(k, v, txNum, prev[string(k)]))
+		prev[string(k)] = v
+	}
+	require.NoError(t, w.Flush(ctx, tx))
+	w.Close()
+	drt.Close()
+
+	for step := range totalSteps {
+		require.NoError(t, d.collateBuildIntegrate(ctx, step, tx, background.NewProgressSet()))
+	}
+
+	cancelled, cancel := context.WithCancel(ctx)
+	cancel()
+	drt = d.beginForTests()
+	_, err = drt.Prune(cancelled, tx, totalSteps-1, 0, uint64(totalSteps)*aggStep, math.MaxUint64, logEvery)
+	require.NoError(t, err)
+	drt.Close()
+
+	prg, err := GetPruneValProgress(tx, []byte(d.ValuesTable))
+	require.NoError(t, err)
+	require.NotEqual(t, prune.Done, prg.ValueProgress, "scan was cut short")
+	require.Equal(t, uint64(totalSteps)*aggStep, prg.TxTo, "target is stored regardless")
+
+	mxPrunableDComm.Set(999)
+	drt = d.beginForTests()
+	defer drt.Close()
+	drt.canScanPruneDomainTables(tx, uint64(totalSteps)*aggStep)
+	require.Equal(t, uint64(totalSteps), mxPrunableDComm.GetValueUint64(), "unfinished rotation bounds nothing")
 }


### PR DESCRIPTION
`domain_prunable{type="domain"}` takes its minimum step from the domain's *history keys* table. Commitment history is off by default, so that table is empty, `minStepInDB` returns 0, and the gauge reports the current step number rather than a prune backlog. `MaxPrunableStepsBacklog()` maxes across the four state domains, so commitment dominates it, and both the FCU path and the exec stage size their adaptive prune budget from it (base + 200ms per 100 steps, capped at 2/3 slot).

Mainnet archive node at step 1680:

| gauge | value | prune budget |
|---|---|---|
| commitment | 1680 | 7s (4s base, 8s cap) |
| account | 0 | |
| storage / code | 1 / 1 | |

Past step 2000 the budget pins at the cap permanently, and that time comes out of block processing. Commitment is genuinely pruned — `CommitmentVals` holds flat at ~1.6 GB — the gauge is what is wrong.

Two more defects in the same block. The switch matched `FilenameBase == "account"` but `kv.AccountsDomain.String()` is `"accounts"`, so that gauge was never written. And `prg.TxTo` is the rotation's target, stored even when the scan is cut short, so reading it as achieved progress clears the backlog while the span is still in the table.

## Changes

- Backlog is `(files.EndTxNum() - prg.TxTo) / stepSize` from the values table's own prune progress, counted only when `ValueProgress == Done`; `txFrom` is 0, so an unfinished rotation bounds nothing. Works with or without history, and fixes a smaller error for the other domains, whose history keys prune on separate progress from their values.
- Switch on `dt.name` (`kv.Domain`) instead of the filename string.

## Notes

Unit unchanged (steps); dashboard panels stay valid.
