### PR TITLE
cl: report when the blob store takes fewer sidecars than requested

### DIFF
--- a/cl/persistence/blob_storage/blob_db.go
+++ b/cl/persistence/blob_storage/blob_db.go
@@ -203,7 +203,12 @@ type sidecarsPayload struct {
 
 type verifyHeaderSignatureFn func(header *cltypes.SignedBeaconBlockHeader) error
 
-// VerifyAgainstIdentifiersAndInsertIntoTheBlobStore does all due verification for blobs before database insertion. it also returns the latest correctly return blob.
+// VerifyAgainstIdentifiersAndInsertIntoTheBlobStore does all due verification for blobs before database insertion.
+// Returns the slot of the last sidecar it processed and how many it stored.
+//
+// It stops at the first identifier a response does not match and returns a nil error, so a
+// nil error does not mean every sidecar landed — callers must compare the stored count
+// against what they asked for.
 func VerifyAgainstIdentifiersAndInsertIntoTheBlobStore(ctx context.Context, storage BlobStorage, identifiers *solid.ListSSZ[*cltypes.BlobIdentifier], sidecars []*cltypes.BlobSidecar, verifySignatureFn verifyHeaderSignatureFn) (uint64, uint64, error) {
 	kzgCtx := kzg.Ctx()
 	inserted := atomic.Uint64{}

--- a/cl/phase1/network/blob_downloader.go
+++ b/cl/phase1/network/blob_downloader.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
 	"github.com/erigontech/erigon/cl/das"
 	"github.com/erigontech/erigon/cl/persistence/blob_storage"
 	"github.com/erigontech/erigon/cl/rpc"
@@ -381,7 +382,15 @@ func (b *BlobHistoryDownloader) recoverDenebBlobs(blocks []*cltypes.SignedBeacon
 		b.logger.Debug("[BlobHistoryDownloader] Error requesting blobs", "err", err)
 		return
 	}
-	_, _, err = blob_storage.VerifyAgainstIdentifiersAndInsertIntoTheBlobStore(b.ctx, b.blobStorage, req, blobs.Responses, func(header *cltypes.SignedBeaconBlockHeader) error {
+	b.storeDenebBlobs(blocks, req, blobs.Responses)
+}
+
+// storeDenebBlobs verifies a response against the requested identifiers and stores what
+// matches. A nil error does not mean every sidecar landed: the insert stops at the first
+// identifier the response does not match, so the count is the only way to tell a full
+// insert from an empty one.
+func (b *BlobHistoryDownloader) storeDenebBlobs(blocks []*cltypes.SignedBeaconBlock, req *solid.ListSSZ[*cltypes.BlobIdentifier], sidecars []*cltypes.BlobSidecar) {
+	_, inserted, err := blob_storage.VerifyAgainstIdentifiersAndInsertIntoTheBlobStore(b.ctx, b.blobStorage, req, sidecars, func(header *cltypes.SignedBeaconBlockHeader) error {
 		// The block is preverified so just check that the signature is correct against the block
 		for _, block := range blocks {
 			if block.Block.Slot != header.Header.Slot {
@@ -398,6 +407,11 @@ func (b *BlobHistoryDownloader) recoverDenebBlobs(blocks []*cltypes.SignedBeacon
 		// Best-effort backfill: log and move on rather than banning a peer from the
 		// shared live-sync pool for a historical-blob verification miss.
 		b.logger.Warn("[BlobHistoryDownloader] Error verifying blobs", "err", err)
+		return
+	}
+	if inserted < uint64(req.Len()) {
+		b.logger.Warn("[BlobHistoryDownloader] Store took fewer blobs than requested",
+			"requested", req.Len(), "stored", inserted, "responses", len(sidecars))
 	}
 }
 

--- a/cl/phase1/network/blob_insert_test.go
+++ b/cl/phase1/network/blob_insert_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package network
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	blob_mock_services "github.com/erigontech/erigon/cl/persistence/blob_storage/mock_services"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/log/v3"
+)
+
+type recordingHandler struct{ records []*log.Record }
+
+func (h *recordingHandler) Log(r *log.Record) error {
+	h.records = append(h.records, r)
+	return nil
+}
+
+func (h *recordingHandler) Enabled(_ context.Context, _ log.Lvl) bool { return true }
+
+func (h *recordingHandler) find(msg string) *log.Record {
+	for _, r := range h.records {
+		if r.Msg == msg {
+			return r
+		}
+	}
+	return nil
+}
+
+// VerifyAgainstIdentifiersAndInsertIntoTheBlobStore stops at the first identifier a
+// response does not match and returns a nil error reporting how many it stored, so a
+// caller that checks only the error cannot tell a full insert from an empty one. A
+// backfill that treats a zero insert as success leaves the slot permanently short with
+// nothing in the log to say so.
+func TestStoreDenebBlobsReportsWhenTheStoreTookFewerThanRequested(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	handler := &recordingHandler{}
+	logger := log.New()
+	logger.SetHandler(handler)
+
+	b := &BlobHistoryDownloader{
+		ctx:         context.Background(),
+		beaconCfg:   &clparams.MainnetBeaconConfig,
+		blobStorage: blob_mock_services.NewMockBlobStorage(ctrl),
+		logger:      logger,
+	}
+
+	req := solid.NewStaticListSSZ[*cltypes.BlobIdentifier](8, 40)
+	req.Append(&cltypes.BlobIdentifier{BlockRoot: common.HexToHash("0xaa"), Index: 0})
+
+	// A sidecar whose header hashes to some other root: the insert loop breaks on the
+	// first identifier mismatch, stores nothing, and reports no error.
+	sidecar := &cltypes.BlobSidecar{
+		SignedBlockHeader: &cltypes.SignedBeaconBlockHeader{
+			Header: &cltypes.BeaconBlockHeader{Slot: 1},
+		},
+	}
+
+	b.storeDenebBlobs(nil, req, []*cltypes.BlobSidecar{sidecar})
+
+	rec := handler.find("[BlobHistoryDownloader] Store took fewer blobs than requested")
+	require.NotNil(t, rec, "a zero insert must not pass silently")
+	require.Contains(t, rec.Ctx, 1, "the log must name how many were requested")
+	require.Contains(t, rec.Ctx, uint64(0), "the log must name how many were stored")
+}

--- a/cl/phase1/network/blob_insert_test.go
+++ b/cl/phase1/network/blob_insert_test.go
@@ -49,6 +49,19 @@ func (h *recordingHandler) find(msg string) *log.Record {
 	return nil
 }
 
+// ctxValue returns a named field from a log record's context, so an assertion cannot be
+// satisfied by an unrelated field that happens to hold the same value.
+func ctxValue(t *testing.T, rec *log.Record, key string) any {
+	t.Helper()
+	for i := 0; i+1 < len(rec.Ctx); i += 2 {
+		if k, ok := rec.Ctx[i].(string); ok && k == key {
+			return rec.Ctx[i+1]
+		}
+	}
+	t.Fatalf("log record has no %q field: %v", key, rec.Ctx)
+	return nil
+}
+
 // VerifyAgainstIdentifiersAndInsertIntoTheBlobStore stops at the first identifier a
 // response does not match and returns a nil error reporting how many it stored, so a
 // caller that checks only the error cannot tell a full insert from an empty one. A
@@ -82,6 +95,8 @@ func TestStoreDenebBlobsReportsWhenTheStoreTookFewerThanRequested(t *testing.T) 
 
 	rec := handler.find("[BlobHistoryDownloader] Store took fewer blobs than requested")
 	require.NotNil(t, rec, "a zero insert must not pass silently")
-	require.Contains(t, rec.Ctx, 1, "the log must name how many were requested")
-	require.Contains(t, rec.Ctx, uint64(0), "the log must name how many were stored")
+	require.Equal(t, log.LvlWarn, rec.Lvl, "a silent data loss must be a warning, not a debug line")
+	require.Equal(t, 1, ctxValue(t, rec, "requested"))
+	require.Equal(t, uint64(0), ctxValue(t, rec, "stored"))
+	require.Equal(t, 1, ctxValue(t, rec, "responses"))
 }


### PR DESCRIPTION
The historical blob backfill could store nothing and report success.

`VerifyAgainstIdentifiersAndInsertIntoTheBlobStore` stops at the first identifier a response does not match, then returns a **nil error** alongside the number of sidecars it actually stored (`blob_db.go:230-236`). `recoverDenebBlobs` discarded both counts and checked only the error, so an insert that stored zero looked exactly like a complete one — no log line, and the blocks were left behind as done.

Measured on a gnosis archive node: **218 slots fetched a sidecar and stored none**, with no error and nothing in the log. That node has 1,569 blob gaps of unexplained origin; this is a plausible mechanism for how gaps like them form silently, though I have not proven it is the one that produced these.

### Changes

- Split the store step out of `recoverDenebBlobs` into `storeDenebBlobs` so it is reachable from a test without an RPC.
- Compare the stored count against the request and warn on a shortfall.
- Document the contract on the storage function: a nil error does not mean every sidecar landed.

Nothing about what gets stored, or the verification itself, changes.

### Note for reviewers

I deliberately did **not** change the `break` behaviour or the error contract. The early exit may well be intentional for a paired stream, and `cl/phase1/stages/forward_sync.go` already returns on that error — making the function newly error out could change forward-sync behaviour. The defect addressed here is purely that a caller could not tell the two outcomes apart. If you would rather the function itself signalled a zero insert, say so and I will do it that way instead.

### Test

`TestStoreDenebBlobsReportsWhenTheStoreTookFewerThanRequested` feeds one identifier and a sidecar whose header hashes to a different root, which is exactly the path that returns `(_, 0, nil)`. It fails without the fix, and I verified it pins the comparison by flipping `<` to `>` — the test goes red.