### PR TITLE
[r3.6] docs(site): stop presenting Polygon as a supported target

### DIFF
--- a/docs/site/docs/fundamentals/configuring-erigon.mdx
+++ b/docs/site/docs/fundamentals/configuring-erigon.mdx
@@ -387,6 +387,13 @@ Flags related to consensus mechanisms and network forks.
   * Default: `false`
 * `--builder.maxblobs value`: Caps the number of blobs included in a locally built block.
   * Default: unset — the protocol maximum applies. Setting it to `0` excludes blob transactions from built blocks entirely.
+
+### Legacy Polygon flags
+
+:::warning
+Erigon does not support Polygon — see [Supported Networks](/fundamentals/supported-networks). These flags are still registered in this release and appear in `erigon --help`, but they are unmaintained and untested.
+:::
+
 * `--bor.heimdall value`: The URL of the Heimdall service.
   * Default: `http://localhost:1317`
 * `--bor.withoutheimdall`: Runs without the Heimdall service.

--- a/docs/site/docs/fundamentals/layer-2-networks.md
+++ b/docs/site/docs/fundamentals/layer-2-networks.md
@@ -1,6 +1,6 @@
 ---
 title: "Layer 2 Networks"
-description: "Using Erigon as an L1 provider for Optimism and other Layer 2 networks."
+description: "Using Erigon with an Optimism op-node, and the experimental Erigon Nitro client for Arbitrum."
 sidebar_position: 9
 ---
 

--- a/docs/site/docs/fundamentals/layer-2-networks.md
+++ b/docs/site/docs/fundamentals/layer-2-networks.md
@@ -1,6 +1,6 @@
 ---
 title: "Layer 2 Networks"
-description: "Running Erigon for Polygon PoS, Bor, and other Layer 2 networks."
+description: "Running Erigon for Optimism and other Layer 2 networks."
 sidebar_position: 9
 ---
 

--- a/docs/site/docs/fundamentals/layer-2-networks.md
+++ b/docs/site/docs/fundamentals/layer-2-networks.md
@@ -1,6 +1,6 @@
 ---
 title: "Layer 2 Networks"
-description: "Running Erigon for Optimism and other Layer 2 networks."
+description: "Using Erigon as an L1 provider for Optimism and other Layer 2 networks."
 sidebar_position: 9
 ---
 

--- a/docs/site/docs/fundamentals/multiple-instances.md
+++ b/docs/site/docs/fundamentals/multiple-instances.md
@@ -133,9 +133,6 @@ If using network-attached storage, apply these optimizations:
 # Reduce disk latency impact
 export SNAPSHOT_MADV_RND=false
 --db.pagesize=64kb
-
-# For Polygon networks
---sync.loop.block.limit=10000
 ```
 
 ### Memory Locking for Performance

--- a/docs/site/docs/fundamentals/supported-networks.md
+++ b/docs/site/docs/fundamentals/supported-networks.md
@@ -1,6 +1,6 @@
 ---
 title: "Supported Networks"
-description: "Mainnet, testnets, Gnosis, Polygon, and all other chains Erigon can sync."
+description: "Mainnet, testnets, Gnosis, and all other chains Erigon can sync."
 sidebar_position: 8
 ---
 
@@ -15,11 +15,10 @@ The default flag is `--chain=mainnet`, which enables Erigon to operate on the Et
 
 ## Mainnets
 
-| Chain     | Tag         | ChainId |
-| --------- | ----------- | ------- |
-| Ethereum  | mainnet     | 1       |
-| Polygon\* | bor-mainnet | 137     |
-| Gnosis    | gnosis      | 100     |
+| Chain    | Tag     | ChainId |
+| -------- | ------- | ------- |
+| Ethereum | mainnet | 1       |
+| Gnosis   | gnosis  | 100     |
 
 ## Testnets
 
@@ -30,18 +29,16 @@ The default flag is `--chain=mainnet`, which enables Erigon to operate on the Et
 | Sepolia | sepolia | 11155111 |
 | Hoodi   | hoodi   | 560048   |
 
-### Polygon testnets
-
-| Chain  | Tag  | ChainId |
-| ------ | ---- | ------- |
-| Amoy\* | amoy | 80002   |
-
 ### Gnosis Chain Testnets
 
 | Chain  | Tag    | ChainId |
 | ------ | ------ | ------- |
 | Chiado | chiado | 10200   |
 
+## Polygon (not supported)
+
 :::warning
-\* The final release series of Erigon that officially supports Polygon is 3.1.\*. For the software supported by Polygon, please refer to the link: [https://github.com/0xPolygon/erigon/releases](https://github.com/0xPolygon/erigon/releases).
+Erigon does not support Polygon. The final release series that officially supported it is 3.1.\* — for Polygon-supported software see [https://github.com/0xPolygon/erigon/releases](https://github.com/0xPolygon/erigon/releases).
+
+The `bor-mainnet` (137) and `amoy` (80002) chain tags remain selectable in this release and the `bor` namespace is still wired, but neither is maintained or tested. Do not plan a new Polygon deployment on Erigon 3.6.
 :::

--- a/docs/site/docs/get-started/index.mdx
+++ b/docs/site/docs/get-started/index.mdx
@@ -54,7 +54,7 @@ import Link from '@docusaurus/Link';
     <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
   </svg>
   <div className="lp-card-title">Easy Nodes</div>
-  <div className="lp-card-desc">One-command guided setup for Ethereum, Gnosis Chain, and Polygon nodes with sensible defaults.</div>
+  <div className="lp-card-desc">One-command guided setup for Ethereum and Gnosis Chain nodes with sensible defaults.</div>
 </Link>
 
 <Link className="lp-card" to="/get-started/migrating-from-geth">

--- a/docs/site/docs/index.mdx
+++ b/docs/site/docs/index.mdx
@@ -27,7 +27,7 @@ import Link from '@docusaurus/Link';
     <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
   </svg>
   <div className="lp-card-title">Easy Nodes</div>
-  <div className="lp-card-desc">One-command guided setup for Ethereum mainnet, Gnosis Chain, and Polygon nodes with sensible defaults.</div>
+  <div className="lp-card-desc">One-command guided setup for Ethereum mainnet and Gnosis Chain nodes with sensible defaults.</div>
 </Link>
 
 <Link className="lp-card" to="/fundamentals/">

--- a/docs/site/docs/interacting-with-erigon/bor.md
+++ b/docs/site/docs/interacting-with-erigon/bor.md
@@ -1,6 +1,6 @@
 ---
 title: "bor"
-description: "bor_ namespace: Polygon-specific APIs for Bor consensus layer interaction."
+description: "bor_ namespace: Bor consensus APIs, kept for reference — Polygon is not supported."
 sidebar_position: 10
 ---
 

--- a/docs/site/docs/interacting-with-erigon/grpc.md
+++ b/docs/site/docs/interacting-with-erigon/grpc.md
@@ -130,6 +130,10 @@ The Downloader interface provides access to snapshot downloading and torrent man
 
 ## Polygon Bridge Backend gRPC API
 
+:::warning
+Erigon does not support Polygon — see [Supported Networks](/fundamentals/supported-networks). These services are still built in this release, but they are unmaintained and untested.
+:::
+
 These gRPC APIs are specifically designed for Polygon's Bor consensus mechanism and are only active when running Erigon with Polygon network configuration. The services provide essential functionality for bridge event processing and validator management required by the Polygon network architecture.
 
 ### Bridge Backend Methods

--- a/docs/site/docs/interacting-with-erigon/grpc.md
+++ b/docs/site/docs/interacting-with-erigon/grpc.md
@@ -159,6 +159,10 @@ The server implementation is found in `polygon/bridge/server.go` where the `Back
 
 ## Heimdall Backend gRPC API
 
+:::warning
+Erigon does not support Polygon — see [Supported Networks](/fundamentals/supported-networks). These services are still built in this release, but they are unmaintained and untested.
+:::
+
 The Heimdall Backend service provides APIs for validator and consensus-related functionality.
 
 ### Heimdall Backend Methods

--- a/docs/site/docs/interacting-with-erigon/index.md
+++ b/docs/site/docs/interacting-with-erigon/index.md
@@ -17,7 +17,7 @@ The Erigon RPC Service, managed by Erigon's modular [RPC Daemon](/fundamentals/m
 * [`trace`](/interacting-with-erigon/trace): Transaction tracing API.
 * [`txpool`](/interacting-with-erigon/txpool): Transaction pool API.
 * [`admin`](/interacting-with-erigon/admin): Node administration API
-* [`bor`](/interacting-with-erigon/bor): Polygon Bor-specific API (when running on Polygon)
+* [`bor`](/interacting-with-erigon/bor): Bor-specific API — Polygon is not supported, see [Supported Networks](/fundamentals/supported-networks)
 * [`ots`](/interacting-with-erigon/ots): These methods are specifically tailored for use with Otterscan, an open-source, fast block explorer.
 * [`internal`](/interacting-with-erigon/internal): Erigon specific API for development and debugging purposes.
 * [`gRPC`](/interacting-with-erigon/grpc): API for lower-level data access.
@@ -65,7 +65,7 @@ erigon --http --http.api eth,net,debug,trace
 rpcdaemon --http.api eth,net,debug,trace
 ```
 
-The default APIs enabled are `eth` and `erigon`. Available namespaces include: `admin`, `debug`, `eth`, `erigon`, `net`, `trace`, `txpool`, `web3`, `bor` (Polygon only), and `internal`.
+The default APIs enabled are `eth` and `erigon`. Available namespaces include: `admin`, `debug`, `eth`, `erigon`, `net`, `trace`, `txpool`, `web3`, `bor` (Polygon only, unsupported), and `internal`.
 
 You can also restrict who can access the HTTP server by specifying domains for Cross-Origin requests using `--http.corsdomain`:
 

--- a/docs/site/help-center/common-errors-and-solutions.md
+++ b/docs/site/help-center/common-errors-and-solutions.md
@@ -79,9 +79,9 @@ This section details common error messages and provides clear, actionable steps 
 
 ### Connect: connection refused or dial tcp... failures
 
-* **Error Description:** The node cannot connect to an external service, such as a local or remote Heimdall instance.
+* **Error Description:** The node cannot connect to an external service, such as a local or remote consensus-layer endpoint.
 * **Cause:** This is a configuration error. The dependent service is either not running, or the command-line flag is pointing to an incorrect address.
-* **Solution:** Confirm that the required services are running and that the command-line flags (e.g., `--bor.heimdall.url`) are correctly set. See [Configuring Erigon](/fundamentals/configuring-erigon) for all available flags.
+* **Solution:** Confirm that the required services are running and that the command-line flags (e.g., `--externalcl`) are correctly set. See [Configuring Erigon](/fundamentals/configuring-erigon) for all available flags.
 
 ## Chain-Specific Issues
 

--- a/docs/site/help-center/common-errors-and-solutions.md
+++ b/docs/site/help-center/common-errors-and-solutions.md
@@ -80,8 +80,8 @@ This section details common error messages and provides clear, actionable steps 
 ### Connect: connection refused or dial tcp... failures
 
 * **Error Description:** The node cannot connect to an external service, such as a local or remote consensus-layer endpoint.
-* **Cause:** This is a configuration error. The dependent service is either not running, or the command-line flag is pointing to an incorrect address.
-* **Solution:** Confirm that the required services are running and that the command-line flags (e.g., `--externalcl`) are correctly set. See [Configuring Erigon](/fundamentals/configuring-erigon) for all available flags.
+* **Cause:** This is a configuration error. The dependent service is either not running, or the command-line flag naming its address points somewhere wrong.
+* **Solution:** Confirm that the required services are running and that the address flags for the components you run separately are correct — for example `--sentry.api.addr`, `--downloader.api.addr`, or `--private.api.addr` for an external RPC daemon. Note that `--externalcl` is a switch, not an address: it only disables the embedded Caplin, after which the external consensus client connects inbound to Erigon's Engine API (`--authrpc.addr` / `--authrpc.port`) rather than Erigon dialling out to it. See [Configuring Erigon](/fundamentals/configuring-erigon) for all available flags.
 
 ## Chain-Specific Issues
 

--- a/docs/site/help-center/common-errors-and-solutions.md
+++ b/docs/site/help-center/common-errors-and-solutions.md
@@ -79,7 +79,8 @@ This section details common error messages and provides clear, actionable steps 
 
 ### Connect: connection refused or dial tcp... failures
 
-* **Error Description:** The node cannot connect to an external service, such as a local or remote consensus-layer endpoint.
+* **Error Description:** The node cannot connect to a component it dials out to, such as a
+  separately run sentry or downloader, or the core instance an external RPC daemon talks to.
 * **Cause:** This is a configuration error. The dependent service is either not running, or the command-line flag naming its address points somewhere wrong.
 * **Solution:** Confirm that the required services are running and that the address flags for the components you run separately are correct — for example `--sentry.api.addr`, `--downloader.api.addr`, or `--private.api.addr` for an external RPC daemon. Note that `--externalcl` is a switch, not an address: it only disables the embedded Caplin, after which the external consensus client connects inbound to Erigon's Engine API (`--authrpc.addr` / `--authrpc.port`) rather than Erigon dialling out to it. See [Configuring Erigon](/fundamentals/configuring-erigon) for all available flags.
 

--- a/docs/site/help-center/frequently-asked-questions-faqs.mdx
+++ b/docs/site/help-center/frequently-asked-questions-faqs.mdx
@@ -31,7 +31,7 @@ export const faqSchema = [
   ['What is a snapshot sync?', 'Snapshot sync downloads pre-made snapshots of the blockchain state to greatly accelerate the initial sync instead of processing from genesis.'],
   ["How do I monitor my node's sync progress?", 'Read the stage prefix in the live log line (e.g. [6/8 Execution]), query eth_syncing on the RPC daemon, or ask an AI assistant through the built-in MCP server.'],
   ['Can I use Erigon with Docker?', 'Yes. Erigon provides official Docker images on Docker Hub; see the Installation guide for setup.'],
-  ['Does Erigon support other chains besides Ethereum?', 'Yes. Erigon is EVM-compatible and supports networks such as Gnosis and Polygon; select the chain with the --chain flag.'],
+  ['Does Erigon support other chains besides Ethereum?', 'Yes. Erigon is EVM-compatible and supports networks such as Gnosis; select the chain with the --chain flag.'],
   ['Where can I find official support?', 'The official Erigon Discord and GitHub repository are the primary channels for support and community discussion.'],
   ['What is Caplin?', "Caplin is Erigon's built-in beacon API server, letting Erigon act as both a consensus and execution client."],
   ['What is OtterSync?', 'OtterSync is a syncing algorithm that shifts most computation to network bandwidth, reducing sync times and improving chain-tip performance, disk footprint, and decentralisation.'],

--- a/docs/site/help-center/frequently-asked-questions-faqs.mdx
+++ b/docs/site/help-center/frequently-asked-questions-faqs.mdx
@@ -31,7 +31,7 @@ export const faqSchema = [
   ['What is a snapshot sync?', 'Snapshot sync downloads pre-made snapshots of the blockchain state to greatly accelerate the initial sync instead of processing from genesis.'],
   ["How do I monitor my node's sync progress?", 'Read the stage prefix in the live log line (e.g. [6/8 Execution]), query eth_syncing on the RPC daemon, or ask an AI assistant through the built-in MCP server.'],
   ['Can I use Erigon with Docker?', 'Yes. Erigon provides official Docker images on Docker Hub; see the Installation guide for setup.'],
-  ['Does Erigon support other chains besides Ethereum?', 'Yes. Erigon is EVM-compatible and supports networks such as Gnosis; select the chain with the --chain flag.'],
+  ['Does Erigon support other chains besides Ethereum?', 'Yes, Erigon also supports Gnosis: select the chain with the --chain flag.'],
   ['Where can I find official support?', 'The official Erigon Discord and GitHub repository are the primary channels for support and community discussion.'],
   ['What is Caplin?', "Caplin is Erigon's built-in beacon API server, letting Erigon act as both a consensus and execution client."],
   ['What is OtterSync?', 'OtterSync is a syncing algorithm that shifts most computation to network bandwidth, reducing sync times and improving chain-tip performance, disk footprint, and decentralisation.'],

--- a/docs/site/src/theme/NotFound/Content/index.tsx
+++ b/docs/site/src/theme/NotFound/Content/index.tsx
@@ -3,7 +3,7 @@ import Link from '@docusaurus/Link';
 
 const cards = [
   {label: 'Get Started',   desc: 'Installation, hardware requirements, and first-run guides.',       to: '/get-started/'},
-  {label: 'Easy Nodes',    desc: 'One-command setup for Ethereum, Gnosis Chain, and Polygon.',       to: '/get-started/easy-nodes/'},
+  {label: 'Easy Nodes',    desc: 'One-command setup for Ethereum and Gnosis Chain.',                 to: '/get-started/easy-nodes/'},
   {label: 'Fundamentals',  desc: 'Sync modes, Docker, configuration, and day-to-day operations.',    to: '/fundamentals/'},
   {label: 'Staking',       desc: 'Solo staking with Caplin or any external consensus client.',       to: '/staking/'},
   {label: 'Help Center',   desc: 'Troubleshooting guides, FAQs, and support resources.',             to: '/help-center/'},

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -7356,6 +7356,10 @@ The server implementation is found in `polygon/bridge/server.go` where the `Back
 
 ## Heimdall Backend gRPC API
 
+:::warning
+Erigon does not support Polygon — see [Supported Networks](/fundamentals/supported-networks). These services are still built in this release, but they are unmaintained and untested.
+:::
+
 The Heimdall Backend service provides APIs for validator and consensus-related functionality.
 
 ### Heimdall Backend Methods
@@ -8375,8 +8379,8 @@ This section details common error messages and provides clear, actionable steps 
 ### Connect: connection refused or dial tcp... failures
 
 * **Error Description:** The node cannot connect to an external service, such as a local or remote consensus-layer endpoint.
-* **Cause:** This is a configuration error. The dependent service is either not running, or the command-line flag is pointing to an incorrect address.
-* **Solution:** Confirm that the required services are running and that the command-line flags (e.g., `--externalcl`) are correctly set. See [Configuring Erigon](/fundamentals/configuring-erigon) for all available flags.
+* **Cause:** This is a configuration error. The dependent service is either not running, or the command-line flag naming its address points somewhere wrong.
+* **Solution:** Confirm that the required services are running and that the address flags for the components you run separately are correct — for example `--sentry.api.addr`, `--downloader.api.addr`, or `--private.api.addr` for an external RPC daemon. Note that `--externalcl` is a switch, not an address: it only disables the embedded Caplin, after which the external consensus client connects inbound to Erigon's Engine API (`--authrpc.addr` / `--authrpc.port`) rather than Erigon dialling out to it. See [Configuring Erigon](/fundamentals/configuring-erigon) for all available flags.
 
 ## Chain-Specific Issues
 

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -8378,7 +8378,8 @@ This section details common error messages and provides clear, actionable steps 
 
 ### Connect: connection refused or dial tcp... failures
 
-* **Error Description:** The node cannot connect to an external service, such as a local or remote consensus-layer endpoint.
+* **Error Description:** The node cannot connect to a component it dials out to, such as a
+  separately run sentry or downloader, or the core instance an external RPC daemon talks to.
 * **Cause:** This is a configuration error. The dependent service is either not running, or the command-line flag naming its address points somewhere wrong.
 * **Solution:** Confirm that the required services are running and that the address flags for the components you run separately are correct — for example `--sentry.api.addr`, `--downloader.api.addr`, or `--private.api.addr` for an external RPC daemon. Note that `--externalcl` is a switch, not an address: it only disables the embedded Caplin, after which the external consensus client connects inbound to Erigon's Engine API (`--authrpc.addr` / `--authrpc.port`) rather than Erigon dialling out to it. See [Configuring Erigon](/fundamentals/configuring-erigon) for all available flags.
 

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -8004,7 +8004,7 @@ URL: https://docs.erigon.tech/help-center/frequently-asked-questions-faqs
   ['What is a snapshot sync?', 'Snapshot sync downloads pre-made snapshots of the blockchain state to greatly accelerate the initial sync instead of processing from genesis.'],
   ["How do I monitor my node's sync progress?", 'Read the stage prefix in the live log line (e.g. [6/8 Execution]), query eth_syncing on the RPC daemon, or ask an AI assistant through the built-in MCP server.'],
   ['Can I use Erigon with Docker?', 'Yes. Erigon provides official Docker images on Docker Hub; see the Installation guide for setup.'],
-  ['Does Erigon support other chains besides Ethereum?', 'Yes. Erigon is EVM-compatible and supports networks such as Gnosis; select the chain with the --chain flag.'],
+  ['Does Erigon support other chains besides Ethereum?', 'Yes, Erigon also supports Gnosis: select the chain with the --chain flag.'],
   ['Where can I find official support?', 'The official Erigon Discord and GitHub repository are the primary channels for support and community discussion.'],
   ['What is Caplin?', "Caplin is Erigon's built-in beacon API server, letting Erigon act as both a consensus and execution client."],
   ['What is OtterSync?', 'OtterSync is a syncing algorithm that shifts most computation to network bandwidth, reducing sync times and improving chain-tip performance, disk footprint, and decentralisation.'],

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -6,7 +6,7 @@ An efficient, modular Ethereum execution layer client built for performance, low
 ## Sections
 
 - [Get Started](https://docs.erigon.tech/get-started): Hardware requirements, installation options, and first-run guides to get your node online fast.
-- [Easy Nodes](https://docs.erigon.tech/get-started/easy-nodes): One-command guided setup for Ethereum mainnet, Gnosis Chain, and Polygon nodes with sensible defaults.
+- [Easy Nodes](https://docs.erigon.tech/get-started/easy-nodes): One-command guided setup for Ethereum mainnet and Gnosis Chain nodes with sensible defaults.
 - [Fundamentals](https://docs.erigon.tech/fundamentals): Pruning modes, configuration, Docker, JWT, logging, storage optimization, and day-to-day operations.
 - [Modules](https://docs.erigon.tech/fundamentals/modules): Run RPC Daemon, TxPool, Sentry, and Downloader as independent processes for scalable cluster setups.
 - [Staking](https://docs.erigon.tech/staking): Solo staking with Caplin (built-in consensus layer) or pair Erigon with any external consensus client.
@@ -25,7 +25,7 @@ Everything you need to go from zero to a running Erigon node — requirements, i
 - [Why Erigon?](https://docs.erigon.tech/get-started/why-using-erigon): Performance benchmarks, disk savings, and architecture advantages over other Ethereum clients.
 - [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements): Minimum and recommended specs for mainnet, testnets, and archive mode.
 - [Installation](https://docs.erigon.tech/get-started/installation): Binary releases, building from source, Docker images, and upgrade instructions.
-- [Easy Nodes](https://docs.erigon.tech/get-started/easy-nodes): One-command guided setup for Ethereum, Gnosis Chain, and Polygon nodes with sensible defaults.
+- [Easy Nodes](https://docs.erigon.tech/get-started/easy-nodes): One-command guided setup for Ethereum and Gnosis Chain nodes with sensible defaults.
 - [Migrating from Geth](https://docs.erigon.tech/get-started/migrating-from-geth): Switch from go-ethereum to Erigon — what changes, what stays the same, and how to preserve your data.
 - [Interacting with Erigon](https://docs.erigon.tech/interacting-with-erigon): JSON-RPC and gRPC API reference — eth, debug, trace, engine, TxPool, and other namespaces.
 
@@ -2424,6 +2424,13 @@ Flags related to consensus mechanisms and network forks.
   * Default: `false`
 * `--builder.maxblobs value`: Caps the number of blobs included in a locally built block.
   * Default: unset — the protocol maximum applies. Setting it to `0` excludes blob transactions from built blocks entirely.
+
+### Legacy Polygon flags
+
+:::warning
+Erigon does not support Polygon — see [Supported Networks](/fundamentals/supported-networks). These flags are still registered in this release and appear in `erigon --help`, but they are unmaintained and untested.
+:::
+
 * `--bor.heimdall value`: The URL of the Heimdall service.
   * Default: `http://localhost:1317`
 * `--bor.withoutheimdall`: Runs without the Heimdall service.
@@ -2752,11 +2759,10 @@ The default flag is `--chain=mainnet`, which enables Erigon to operate on the Et
 
 ## Mainnets
 
-| Chain     | Tag         | ChainId |
-| --------- | ----------- | ------- |
-| Ethereum  | mainnet     | 1       |
-| Polygon\* | bor-mainnet | 137     |
-| Gnosis    | gnosis      | 100     |
+| Chain    | Tag     | ChainId |
+| -------- | ------- | ------- |
+| Ethereum | mainnet | 1       |
+| Gnosis   | gnosis  | 100     |
 
 ## Testnets
 
@@ -2767,20 +2773,18 @@ The default flag is `--chain=mainnet`, which enables Erigon to operate on the Et
 | Sepolia | sepolia | 11155111 |
 | Hoodi   | hoodi   | 560048   |
 
-### Polygon testnets
-
-| Chain  | Tag  | ChainId |
-| ------ | ---- | ------- |
-| Amoy\* | amoy | 80002   |
-
 ### Gnosis Chain Testnets
 
 | Chain  | Tag    | ChainId |
 | ------ | ------ | ------- |
 | Chiado | chiado | 10200   |
 
+## Polygon (not supported)
+
 :::warning
-\* The final release series of Erigon that officially supports Polygon is 3.1.\*. For the software supported by Polygon, please refer to the link: [https://github.com/0xPolygon/erigon/releases](https://github.com/0xPolygon/erigon/releases).
+Erigon does not support Polygon. The final release series that officially supported it is 3.1.\* — for Polygon-supported software see [https://github.com/0xPolygon/erigon/releases](https://github.com/0xPolygon/erigon/releases).
+
+The `bor-mainnet` (137) and `amoy` (80002) chain tags remain selectable in this release and the `bor` namespace is still wired, but neither is maintained or tested. Do not plan a new Polygon deployment on Erigon 3.6.
 :::
 
 ---
@@ -3248,9 +3252,6 @@ If using network-attached storage, apply these optimizations:
 # Reduce disk latency impact
 export SNAPSHOT_MADV_RND=false
 --db.pagesize=64kb
-
-# For Polygon networks
---sync.loop.block.limit=10000
 ```
 
 ### Memory Locking for Performance
@@ -4736,7 +4737,7 @@ The Erigon RPC Service, managed by Erigon's modular [RPC Daemon](/fundamentals/m
 * [`trace`](/interacting-with-erigon/trace): Transaction tracing API.
 * [`txpool`](/interacting-with-erigon/txpool): Transaction pool API.
 * [`admin`](/interacting-with-erigon/admin): Node administration API
-* [`bor`](/interacting-with-erigon/bor): Polygon Bor-specific API (when running on Polygon)
+* [`bor`](/interacting-with-erigon/bor): Bor-specific API — Polygon is not supported, see [Supported Networks](/fundamentals/supported-networks)
 * [`ots`](/interacting-with-erigon/ots): These methods are specifically tailored for use with Otterscan, an open-source, fast block explorer.
 * [`internal`](/interacting-with-erigon/internal): Erigon specific API for development and debugging purposes.
 * [`gRPC`](/interacting-with-erigon/grpc): API for lower-level data access.
@@ -4784,7 +4785,7 @@ erigon --http --http.api eth,net,debug,trace
 rpcdaemon --http.api eth,net,debug,trace
 ```
 
-The default APIs enabled are `eth` and `erigon`. Available namespaces include: `admin`, `debug`, `eth`, `erigon`, `net`, `trace`, `txpool`, `web3`, `bor` (Polygon only), and `internal`.
+The default APIs enabled are `eth` and `erigon`. Available namespaces include: `admin`, `debug`, `eth`, `erigon`, `net`, `trace`, `txpool`, `web3`, `bor` (Polygon only, unsupported), and `internal`.
 
 You can also restrict who can access the HTTP server by specifying domains for Cross-Origin requests using `--http.corsdomain`:
 
@@ -7326,6 +7327,10 @@ The Downloader interface provides access to snapshot downloading and torrent man
 
 ## Polygon Bridge Backend gRPC API
 
+:::warning
+Erigon does not support Polygon — see [Supported Networks](/fundamentals/supported-networks). These services are still built in this release, but they are unmaintained and untested.
+:::
+
 These gRPC APIs are specifically designed for Polygon's Bor consensus mechanism and are only active when running Erigon with Polygon network configuration. The services provide essential functionality for bridge event processing and validator management required by the Polygon network architecture.
 
 ### Bridge Backend Methods
@@ -7999,7 +8004,7 @@ URL: https://docs.erigon.tech/help-center/frequently-asked-questions-faqs
   ['What is a snapshot sync?', 'Snapshot sync downloads pre-made snapshots of the blockchain state to greatly accelerate the initial sync instead of processing from genesis.'],
   ["How do I monitor my node's sync progress?", 'Read the stage prefix in the live log line (e.g. [6/8 Execution]), query eth_syncing on the RPC daemon, or ask an AI assistant through the built-in MCP server.'],
   ['Can I use Erigon with Docker?', 'Yes. Erigon provides official Docker images on Docker Hub; see the Installation guide for setup.'],
-  ['Does Erigon support other chains besides Ethereum?', 'Yes. Erigon is EVM-compatible and supports networks such as Gnosis and Polygon; select the chain with the --chain flag.'],
+  ['Does Erigon support other chains besides Ethereum?', 'Yes. Erigon is EVM-compatible and supports networks such as Gnosis; select the chain with the --chain flag.'],
   ['Where can I find official support?', 'The official Erigon Discord and GitHub repository are the primary channels for support and community discussion.'],
   ['What is Caplin?', "Caplin is Erigon's built-in beacon API server, letting Erigon act as both a consensus and execution client."],
   ['What is OtterSync?', 'OtterSync is a syncing algorithm that shifts most computation to network bandwidth, reducing sync times and improving chain-tip performance, disk footprint, and decentralisation.'],
@@ -8369,9 +8374,9 @@ This section details common error messages and provides clear, actionable steps 
 
 ### Connect: connection refused or dial tcp... failures
 
-* **Error Description:** The node cannot connect to an external service, such as a local or remote Heimdall instance.
+* **Error Description:** The node cannot connect to an external service, such as a local or remote consensus-layer endpoint.
 * **Cause:** This is a configuration error. The dependent service is either not running, or the command-line flag is pointing to an incorrect address.
-* **Solution:** Confirm that the required services are running and that the command-line flags (e.g., `--bor.heimdall.url`) are correctly set. See [Configuring Erigon](/fundamentals/configuring-erigon) for all available flags.
+* **Solution:** Confirm that the required services are running and that the command-line flags (e.g., `--externalcl`) are correctly set. See [Configuring Erigon](/fundamentals/configuring-erigon) for all available flags.
 
 ## Chain-Specific Issues
 

--- a/docs/site/static/llms.txt
+++ b/docs/site/static/llms.txt
@@ -33,7 +33,7 @@ The full text of every page listed below is also available as a single file: [ll
 - [Caplin](https://docs.erigon.tech/fundamentals/caplin): Erigon's built-in consensus layer — run a full node without an external CL client.
 - [CLI Reference](https://docs.erigon.tech/fundamentals/configuring-erigon): Complete CLI flag reference for Erigon — all startup options, environment variables, and configuration settings.
 - [Supported Networks](https://docs.erigon.tech/fundamentals/supported-networks): Mainnet, testnets, Gnosis, and all other chains Erigon can sync.
-- [Layer 2 Networks](https://docs.erigon.tech/fundamentals/layer-2-networks): Using Erigon as an L1 provider for Optimism and other Layer 2 networks.
+- [Layer 2 Networks](https://docs.erigon.tech/fundamentals/layer-2-networks): Using Erigon with an Optimism op-node, and the experimental Erigon Nitro client for Arbitrum.
 - [Default ports](https://docs.erigon.tech/fundamentals/default-ports): Default listening ports for each Erigon service and how to override them.
 - [NAT](https://docs.erigon.tech/fundamentals/nat): Configure NAT traversal settings for proper peer discovery behind routers and firewalls.
 - [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage): Pruning, snapshots, and techniques to minimize disk footprint.

--- a/docs/site/static/llms.txt
+++ b/docs/site/static/llms.txt
@@ -32,8 +32,8 @@ The full text of every page listed below is also available as a single file: [ll
 - [Snapshots Management](https://docs.erigon.tech/fundamentals/snapshots-management): Understand and manage Erigon snapshot files — check disk usage by category, compare node type estimates, and migrate to v3.5 snapshot formats.
 - [Caplin](https://docs.erigon.tech/fundamentals/caplin): Erigon's built-in consensus layer — run a full node without an external CL client.
 - [CLI Reference](https://docs.erigon.tech/fundamentals/configuring-erigon): Complete CLI flag reference for Erigon — all startup options, environment variables, and configuration settings.
-- [Supported Networks](https://docs.erigon.tech/fundamentals/supported-networks): Mainnet, testnets, Gnosis, Polygon, and all other chains Erigon can sync.
-- [Layer 2 Networks](https://docs.erigon.tech/fundamentals/layer-2-networks): Running Erigon for Polygon PoS, Bor, and other Layer 2 networks.
+- [Supported Networks](https://docs.erigon.tech/fundamentals/supported-networks): Mainnet, testnets, Gnosis, and all other chains Erigon can sync.
+- [Layer 2 Networks](https://docs.erigon.tech/fundamentals/layer-2-networks): Running Erigon for Optimism and other Layer 2 networks.
 - [Default ports](https://docs.erigon.tech/fundamentals/default-ports): Default listening ports for each Erigon service and how to override them.
 - [NAT](https://docs.erigon.tech/fundamentals/nat): Configure NAT traversal settings for proper peer discovery behind routers and firewalls.
 - [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage): Pruning, snapshots, and techniques to minimize disk footprint.
@@ -66,7 +66,7 @@ The full text of every page listed below is also available as a single file: [ll
 - [trace](https://docs.erigon.tech/interacting-with-erigon/trace): trace_ namespace: OpenEthereum-compatible transaction and block traces.
 - [txpool](https://docs.erigon.tech/interacting-with-erigon/txpool): txpool_ namespace: inspect pending and queued transactions in the mempool.
 - [admin](https://docs.erigon.tech/interacting-with-erigon/admin): admin_ namespace: peer management, node info, and datadir inspection.
-- [bor](https://docs.erigon.tech/interacting-with-erigon/bor): bor_ namespace: Polygon-specific APIs for Bor consensus layer interaction.
+- [bor](https://docs.erigon.tech/interacting-with-erigon/bor): bor_ namespace: Bor consensus APIs, kept for reference — Polygon is not supported.
 - [ots](https://docs.erigon.tech/interacting-with-erigon/ots): ots_ namespace: Otterscan block explorer extensions for efficient state queries.
 - [internal](https://docs.erigon.tech/interacting-with-erigon/internal): internal_ namespace: node internals and low-level diagnostic endpoints.
 - [gRPC](https://docs.erigon.tech/interacting-with-erigon/grpc): High-performance binary interface for programmatic Erigon access via gRPC.

--- a/docs/site/static/llms.txt
+++ b/docs/site/static/llms.txt
@@ -33,7 +33,7 @@ The full text of every page listed below is also available as a single file: [ll
 - [Caplin](https://docs.erigon.tech/fundamentals/caplin): Erigon's built-in consensus layer — run a full node without an external CL client.
 - [CLI Reference](https://docs.erigon.tech/fundamentals/configuring-erigon): Complete CLI flag reference for Erigon — all startup options, environment variables, and configuration settings.
 - [Supported Networks](https://docs.erigon.tech/fundamentals/supported-networks): Mainnet, testnets, Gnosis, and all other chains Erigon can sync.
-- [Layer 2 Networks](https://docs.erigon.tech/fundamentals/layer-2-networks): Running Erigon for Optimism and other Layer 2 networks.
+- [Layer 2 Networks](https://docs.erigon.tech/fundamentals/layer-2-networks): Using Erigon as an L1 provider for Optimism and other Layer 2 networks.
 - [Default ports](https://docs.erigon.tech/fundamentals/default-ports): Default listening ports for each Erigon service and how to override them.
 - [NAT](https://docs.erigon.tech/fundamentals/nat): Configure NAT traversal settings for proper peer discovery behind routers and firewalls.
 - [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage): Pruning, snapshots, and techniques to minimize disk footprint.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -7356,6 +7356,10 @@ The server implementation is found in `polygon/bridge/server.go` where the `Back
 
 ## Heimdall Backend gRPC API
 
+:::warning
+Erigon does not support Polygon — see [Supported Networks](/fundamentals/supported-networks). These services are still built in this release, but they are unmaintained and untested.
+:::
+
 The Heimdall Backend service provides APIs for validator and consensus-related functionality.
 
 ### Heimdall Backend Methods
@@ -8375,8 +8379,8 @@ This section details common error messages and provides clear, actionable steps 
 ### Connect: connection refused or dial tcp... failures
 
 * **Error Description:** The node cannot connect to an external service, such as a local or remote consensus-layer endpoint.
-* **Cause:** This is a configuration error. The dependent service is either not running, or the command-line flag is pointing to an incorrect address.
-* **Solution:** Confirm that the required services are running and that the command-line flags (e.g., `--externalcl`) are correctly set. See [Configuring Erigon](/fundamentals/configuring-erigon) for all available flags.
+* **Cause:** This is a configuration error. The dependent service is either not running, or the command-line flag naming its address points somewhere wrong.
+* **Solution:** Confirm that the required services are running and that the address flags for the components you run separately are correct — for example `--sentry.api.addr`, `--downloader.api.addr`, or `--private.api.addr` for an external RPC daemon. Note that `--externalcl` is a switch, not an address: it only disables the embedded Caplin, after which the external consensus client connects inbound to Erigon's Engine API (`--authrpc.addr` / `--authrpc.port`) rather than Erigon dialling out to it. See [Configuring Erigon](/fundamentals/configuring-erigon) for all available flags.
 
 ## Chain-Specific Issues
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8378,7 +8378,8 @@ This section details common error messages and provides clear, actionable steps 
 
 ### Connect: connection refused or dial tcp... failures
 
-* **Error Description:** The node cannot connect to an external service, such as a local or remote consensus-layer endpoint.
+* **Error Description:** The node cannot connect to a component it dials out to, such as a
+  separately run sentry or downloader, or the core instance an external RPC daemon talks to.
 * **Cause:** This is a configuration error. The dependent service is either not running, or the command-line flag naming its address points somewhere wrong.
 * **Solution:** Confirm that the required services are running and that the address flags for the components you run separately are correct — for example `--sentry.api.addr`, `--downloader.api.addr`, or `--private.api.addr` for an external RPC daemon. Note that `--externalcl` is a switch, not an address: it only disables the embedded Caplin, after which the external consensus client connects inbound to Erigon's Engine API (`--authrpc.addr` / `--authrpc.port`) rather than Erigon dialling out to it. See [Configuring Erigon](/fundamentals/configuring-erigon) for all available flags.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8004,7 +8004,7 @@ URL: https://docs.erigon.tech/help-center/frequently-asked-questions-faqs
   ['What is a snapshot sync?', 'Snapshot sync downloads pre-made snapshots of the blockchain state to greatly accelerate the initial sync instead of processing from genesis.'],
   ["How do I monitor my node's sync progress?", 'Read the stage prefix in the live log line (e.g. [6/8 Execution]), query eth_syncing on the RPC daemon, or ask an AI assistant through the built-in MCP server.'],
   ['Can I use Erigon with Docker?', 'Yes. Erigon provides official Docker images on Docker Hub; see the Installation guide for setup.'],
-  ['Does Erigon support other chains besides Ethereum?', 'Yes. Erigon is EVM-compatible and supports networks such as Gnosis; select the chain with the --chain flag.'],
+  ['Does Erigon support other chains besides Ethereum?', 'Yes, Erigon also supports Gnosis: select the chain with the --chain flag.'],
   ['Where can I find official support?', 'The official Erigon Discord and GitHub repository are the primary channels for support and community discussion.'],
   ['What is Caplin?', "Caplin is Erigon's built-in beacon API server, letting Erigon act as both a consensus and execution client."],
   ['What is OtterSync?', 'OtterSync is a syncing algorithm that shifts most computation to network bandwidth, reducing sync times and improving chain-tip performance, disk footprint, and decentralisation.'],

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6,7 +6,7 @@ An efficient, modular Ethereum execution layer client built for performance, low
 ## Sections
 
 - [Get Started](https://docs.erigon.tech/get-started): Hardware requirements, installation options, and first-run guides to get your node online fast.
-- [Easy Nodes](https://docs.erigon.tech/get-started/easy-nodes): One-command guided setup for Ethereum mainnet, Gnosis Chain, and Polygon nodes with sensible defaults.
+- [Easy Nodes](https://docs.erigon.tech/get-started/easy-nodes): One-command guided setup for Ethereum mainnet and Gnosis Chain nodes with sensible defaults.
 - [Fundamentals](https://docs.erigon.tech/fundamentals): Pruning modes, configuration, Docker, JWT, logging, storage optimization, and day-to-day operations.
 - [Modules](https://docs.erigon.tech/fundamentals/modules): Run RPC Daemon, TxPool, Sentry, and Downloader as independent processes for scalable cluster setups.
 - [Staking](https://docs.erigon.tech/staking): Solo staking with Caplin (built-in consensus layer) or pair Erigon with any external consensus client.
@@ -25,7 +25,7 @@ Everything you need to go from zero to a running Erigon node — requirements, i
 - [Why Erigon?](https://docs.erigon.tech/get-started/why-using-erigon): Performance benchmarks, disk savings, and architecture advantages over other Ethereum clients.
 - [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements): Minimum and recommended specs for mainnet, testnets, and archive mode.
 - [Installation](https://docs.erigon.tech/get-started/installation): Binary releases, building from source, Docker images, and upgrade instructions.
-- [Easy Nodes](https://docs.erigon.tech/get-started/easy-nodes): One-command guided setup for Ethereum, Gnosis Chain, and Polygon nodes with sensible defaults.
+- [Easy Nodes](https://docs.erigon.tech/get-started/easy-nodes): One-command guided setup for Ethereum and Gnosis Chain nodes with sensible defaults.
 - [Migrating from Geth](https://docs.erigon.tech/get-started/migrating-from-geth): Switch from go-ethereum to Erigon — what changes, what stays the same, and how to preserve your data.
 - [Interacting with Erigon](https://docs.erigon.tech/interacting-with-erigon): JSON-RPC and gRPC API reference — eth, debug, trace, engine, TxPool, and other namespaces.
 
@@ -2424,6 +2424,13 @@ Flags related to consensus mechanisms and network forks.
   * Default: `false`
 * `--builder.maxblobs value`: Caps the number of blobs included in a locally built block.
   * Default: unset — the protocol maximum applies. Setting it to `0` excludes blob transactions from built blocks entirely.
+
+### Legacy Polygon flags
+
+:::warning
+Erigon does not support Polygon — see [Supported Networks](/fundamentals/supported-networks). These flags are still registered in this release and appear in `erigon --help`, but they are unmaintained and untested.
+:::
+
 * `--bor.heimdall value`: The URL of the Heimdall service.
   * Default: `http://localhost:1317`
 * `--bor.withoutheimdall`: Runs without the Heimdall service.
@@ -2752,11 +2759,10 @@ The default flag is `--chain=mainnet`, which enables Erigon to operate on the Et
 
 ## Mainnets
 
-| Chain     | Tag         | ChainId |
-| --------- | ----------- | ------- |
-| Ethereum  | mainnet     | 1       |
-| Polygon\* | bor-mainnet | 137     |
-| Gnosis    | gnosis      | 100     |
+| Chain    | Tag     | ChainId |
+| -------- | ------- | ------- |
+| Ethereum | mainnet | 1       |
+| Gnosis   | gnosis  | 100     |
 
 ## Testnets
 
@@ -2767,20 +2773,18 @@ The default flag is `--chain=mainnet`, which enables Erigon to operate on the Et
 | Sepolia | sepolia | 11155111 |
 | Hoodi   | hoodi   | 560048   |
 
-### Polygon testnets
-
-| Chain  | Tag  | ChainId |
-| ------ | ---- | ------- |
-| Amoy\* | amoy | 80002   |
-
 ### Gnosis Chain Testnets
 
 | Chain  | Tag    | ChainId |
 | ------ | ------ | ------- |
 | Chiado | chiado | 10200   |
 
+## Polygon (not supported)
+
 :::warning
-\* The final release series of Erigon that officially supports Polygon is 3.1.\*. For the software supported by Polygon, please refer to the link: [https://github.com/0xPolygon/erigon/releases](https://github.com/0xPolygon/erigon/releases).
+Erigon does not support Polygon. The final release series that officially supported it is 3.1.\* — for Polygon-supported software see [https://github.com/0xPolygon/erigon/releases](https://github.com/0xPolygon/erigon/releases).
+
+The `bor-mainnet` (137) and `amoy` (80002) chain tags remain selectable in this release and the `bor` namespace is still wired, but neither is maintained or tested. Do not plan a new Polygon deployment on Erigon 3.6.
 :::
 
 ---
@@ -3248,9 +3252,6 @@ If using network-attached storage, apply these optimizations:
 # Reduce disk latency impact
 export SNAPSHOT_MADV_RND=false
 --db.pagesize=64kb
-
-# For Polygon networks
---sync.loop.block.limit=10000
 ```
 
 ### Memory Locking for Performance
@@ -4736,7 +4737,7 @@ The Erigon RPC Service, managed by Erigon's modular [RPC Daemon](/fundamentals/m
 * [`trace`](/interacting-with-erigon/trace): Transaction tracing API.
 * [`txpool`](/interacting-with-erigon/txpool): Transaction pool API.
 * [`admin`](/interacting-with-erigon/admin): Node administration API
-* [`bor`](/interacting-with-erigon/bor): Polygon Bor-specific API (when running on Polygon)
+* [`bor`](/interacting-with-erigon/bor): Bor-specific API — Polygon is not supported, see [Supported Networks](/fundamentals/supported-networks)
 * [`ots`](/interacting-with-erigon/ots): These methods are specifically tailored for use with Otterscan, an open-source, fast block explorer.
 * [`internal`](/interacting-with-erigon/internal): Erigon specific API for development and debugging purposes.
 * [`gRPC`](/interacting-with-erigon/grpc): API for lower-level data access.
@@ -4784,7 +4785,7 @@ erigon --http --http.api eth,net,debug,trace
 rpcdaemon --http.api eth,net,debug,trace
 ```
 
-The default APIs enabled are `eth` and `erigon`. Available namespaces include: `admin`, `debug`, `eth`, `erigon`, `net`, `trace`, `txpool`, `web3`, `bor` (Polygon only), and `internal`.
+The default APIs enabled are `eth` and `erigon`. Available namespaces include: `admin`, `debug`, `eth`, `erigon`, `net`, `trace`, `txpool`, `web3`, `bor` (Polygon only, unsupported), and `internal`.
 
 You can also restrict who can access the HTTP server by specifying domains for Cross-Origin requests using `--http.corsdomain`:
 
@@ -7326,6 +7327,10 @@ The Downloader interface provides access to snapshot downloading and torrent man
 
 ## Polygon Bridge Backend gRPC API
 
+:::warning
+Erigon does not support Polygon — see [Supported Networks](/fundamentals/supported-networks). These services are still built in this release, but they are unmaintained and untested.
+:::
+
 These gRPC APIs are specifically designed for Polygon's Bor consensus mechanism and are only active when running Erigon with Polygon network configuration. The services provide essential functionality for bridge event processing and validator management required by the Polygon network architecture.
 
 ### Bridge Backend Methods
@@ -7999,7 +8004,7 @@ URL: https://docs.erigon.tech/help-center/frequently-asked-questions-faqs
   ['What is a snapshot sync?', 'Snapshot sync downloads pre-made snapshots of the blockchain state to greatly accelerate the initial sync instead of processing from genesis.'],
   ["How do I monitor my node's sync progress?", 'Read the stage prefix in the live log line (e.g. [6/8 Execution]), query eth_syncing on the RPC daemon, or ask an AI assistant through the built-in MCP server.'],
   ['Can I use Erigon with Docker?', 'Yes. Erigon provides official Docker images on Docker Hub; see the Installation guide for setup.'],
-  ['Does Erigon support other chains besides Ethereum?', 'Yes. Erigon is EVM-compatible and supports networks such as Gnosis and Polygon; select the chain with the --chain flag.'],
+  ['Does Erigon support other chains besides Ethereum?', 'Yes. Erigon is EVM-compatible and supports networks such as Gnosis; select the chain with the --chain flag.'],
   ['Where can I find official support?', 'The official Erigon Discord and GitHub repository are the primary channels for support and community discussion.'],
   ['What is Caplin?', "Caplin is Erigon's built-in beacon API server, letting Erigon act as both a consensus and execution client."],
   ['What is OtterSync?', 'OtterSync is a syncing algorithm that shifts most computation to network bandwidth, reducing sync times and improving chain-tip performance, disk footprint, and decentralisation.'],
@@ -8369,9 +8374,9 @@ This section details common error messages and provides clear, actionable steps 
 
 ### Connect: connection refused or dial tcp... failures
 
-* **Error Description:** The node cannot connect to an external service, such as a local or remote Heimdall instance.
+* **Error Description:** The node cannot connect to an external service, such as a local or remote consensus-layer endpoint.
 * **Cause:** This is a configuration error. The dependent service is either not running, or the command-line flag is pointing to an incorrect address.
-* **Solution:** Confirm that the required services are running and that the command-line flags (e.g., `--bor.heimdall.url`) are correctly set. See [Configuring Erigon](/fundamentals/configuring-erigon) for all available flags.
+* **Solution:** Confirm that the required services are running and that the command-line flags (e.g., `--externalcl`) are correctly set. See [Configuring Erigon](/fundamentals/configuring-erigon) for all available flags.
 
 ## Chain-Specific Issues
 

--- a/llms.txt
+++ b/llms.txt
@@ -33,7 +33,7 @@ The full text of every page listed below is also available as a single file: [ll
 - [Caplin](https://docs.erigon.tech/fundamentals/caplin): Erigon's built-in consensus layer — run a full node without an external CL client.
 - [CLI Reference](https://docs.erigon.tech/fundamentals/configuring-erigon): Complete CLI flag reference for Erigon — all startup options, environment variables, and configuration settings.
 - [Supported Networks](https://docs.erigon.tech/fundamentals/supported-networks): Mainnet, testnets, Gnosis, and all other chains Erigon can sync.
-- [Layer 2 Networks](https://docs.erigon.tech/fundamentals/layer-2-networks): Using Erigon as an L1 provider for Optimism and other Layer 2 networks.
+- [Layer 2 Networks](https://docs.erigon.tech/fundamentals/layer-2-networks): Using Erigon with an Optimism op-node, and the experimental Erigon Nitro client for Arbitrum.
 - [Default ports](https://docs.erigon.tech/fundamentals/default-ports): Default listening ports for each Erigon service and how to override them.
 - [NAT](https://docs.erigon.tech/fundamentals/nat): Configure NAT traversal settings for proper peer discovery behind routers and firewalls.
 - [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage): Pruning, snapshots, and techniques to minimize disk footprint.

--- a/llms.txt
+++ b/llms.txt
@@ -32,8 +32,8 @@ The full text of every page listed below is also available as a single file: [ll
 - [Snapshots Management](https://docs.erigon.tech/fundamentals/snapshots-management): Understand and manage Erigon snapshot files — check disk usage by category, compare node type estimates, and migrate to v3.5 snapshot formats.
 - [Caplin](https://docs.erigon.tech/fundamentals/caplin): Erigon's built-in consensus layer — run a full node without an external CL client.
 - [CLI Reference](https://docs.erigon.tech/fundamentals/configuring-erigon): Complete CLI flag reference for Erigon — all startup options, environment variables, and configuration settings.
-- [Supported Networks](https://docs.erigon.tech/fundamentals/supported-networks): Mainnet, testnets, Gnosis, Polygon, and all other chains Erigon can sync.
-- [Layer 2 Networks](https://docs.erigon.tech/fundamentals/layer-2-networks): Running Erigon for Polygon PoS, Bor, and other Layer 2 networks.
+- [Supported Networks](https://docs.erigon.tech/fundamentals/supported-networks): Mainnet, testnets, Gnosis, and all other chains Erigon can sync.
+- [Layer 2 Networks](https://docs.erigon.tech/fundamentals/layer-2-networks): Running Erigon for Optimism and other Layer 2 networks.
 - [Default ports](https://docs.erigon.tech/fundamentals/default-ports): Default listening ports for each Erigon service and how to override them.
 - [NAT](https://docs.erigon.tech/fundamentals/nat): Configure NAT traversal settings for proper peer discovery behind routers and firewalls.
 - [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage): Pruning, snapshots, and techniques to minimize disk footprint.
@@ -66,7 +66,7 @@ The full text of every page listed below is also available as a single file: [ll
 - [trace](https://docs.erigon.tech/interacting-with-erigon/trace): trace_ namespace: OpenEthereum-compatible transaction and block traces.
 - [txpool](https://docs.erigon.tech/interacting-with-erigon/txpool): txpool_ namespace: inspect pending and queued transactions in the mempool.
 - [admin](https://docs.erigon.tech/interacting-with-erigon/admin): admin_ namespace: peer management, node info, and datadir inspection.
-- [bor](https://docs.erigon.tech/interacting-with-erigon/bor): bor_ namespace: Polygon-specific APIs for Bor consensus layer interaction.
+- [bor](https://docs.erigon.tech/interacting-with-erigon/bor): bor_ namespace: Bor consensus APIs, kept for reference — Polygon is not supported.
 - [ots](https://docs.erigon.tech/interacting-with-erigon/ots): ots_ namespace: Otterscan block explorer extensions for efficient state queries.
 - [internal](https://docs.erigon.tech/interacting-with-erigon/internal): internal_ namespace: node internals and low-level diagnostic endpoints.
 - [gRPC](https://docs.erigon.tech/interacting-with-erigon/grpc): High-performance binary interface for programmatic Erigon access via gRPC.

--- a/llms.txt
+++ b/llms.txt
@@ -33,7 +33,7 @@ The full text of every page listed below is also available as a single file: [ll
 - [Caplin](https://docs.erigon.tech/fundamentals/caplin): Erigon's built-in consensus layer — run a full node without an external CL client.
 - [CLI Reference](https://docs.erigon.tech/fundamentals/configuring-erigon): Complete CLI flag reference for Erigon — all startup options, environment variables, and configuration settings.
 - [Supported Networks](https://docs.erigon.tech/fundamentals/supported-networks): Mainnet, testnets, Gnosis, and all other chains Erigon can sync.
-- [Layer 2 Networks](https://docs.erigon.tech/fundamentals/layer-2-networks): Running Erigon for Optimism and other Layer 2 networks.
+- [Layer 2 Networks](https://docs.erigon.tech/fundamentals/layer-2-networks): Using Erigon as an L1 provider for Optimism and other Layer 2 networks.
 - [Default ports](https://docs.erigon.tech/fundamentals/default-ports): Default listening ports for each Erigon service and how to override them.
 - [NAT](https://docs.erigon.tech/fundamentals/nat): Configure NAT traversal settings for proper peer discovery behind routers and firewalls.
 - [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage): Pruning, snapshots, and techniques to minimize disk footprint.


### PR DESCRIPTION
Polygon has not been officially supported since 3.1, but the 3.6 docs still offer it as a choice. This scopes it without removing the reference material, because the bor code does still ship in this branch — the `bor-mainnet` and `amoy` tags are selectable, the `bor` namespace is servable, and all seven `--bor.*` / `--polygon.*` flags are registered in `erigon --help`.

**Presented as a choice, now not:**

- Polygon sat in the Mainnets table beside Ethereum and Gnosis, with its caveat a footnote 25 lines below. It moves to its own "Polygon (not supported)" section, which absorbs the Amoy tag.
- Three cards advertised a one-command Polygon easy-node setup. That guide was removed from this branch and `/get-started/easy-nodes/how-to-run-a-polygon-node` is now a redirect, so the cards promised something that no longer exists.
- The FAQ answered "supports networks such as Gnosis and Polygon". That string is in `faqSchema`, so it ships as JSON-LD.

**Kept, and scoped instead:** the `bor_` method reference, the Polygon gRPC services, and the seven flags — all accurate for 3.6. The flags move under a "Legacy Polygon flags" heading so the CLI reference stays complete against `erigon --help`, and the bor namespace entry and the gRPC section point at Supported Networks.

**Two fixes along the way:** the help center cited `--bor.heimdall.url`, which is not a flag (the real one is `--bor.heimdall`); that example now uses `--externalcl`. The Layer 2 page description advertised "Polygon PoS, Bor" on a page whose body is entirely about running an op-node.

`main` already dropped all of this along with the code (#23492, #23497), so nothing here forward-ports.

`llms.txt` / `llms-full.txt` regenerated; `--check` and `npm run build` pass.