### PR TITLE
[r3.6] ci: skip the QA and Kurtosis GLOAS suites on docs-only PRs

### DIFF
--- a/.github/workflows/cache-warming-kurtosis-gloas-images.yml
+++ b/.github/workflows/cache-warming-kurtosis-gloas-images.yml
@@ -38,6 +38,12 @@ permissions:
 
 jobs:
   warm:
+    # test-kurtosis-gloas.yml calls changes.yml, which reads the PR file
+    # list. A nested call can only narrow the caller's grant, so this must
+    # be granted here or the whole called workflow fails validation.
+    permissions:
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/test-kurtosis-gloas.yml
     with:
       cl-images-only: true

--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -1,0 +1,58 @@
+name: Changes
+
+# Fast path: detect whether a pull request touches anything outside the docs.
+# Callers guard expensive jobs with `needs.changes.outputs.code != 'false'` so a
+# docs-only PR skips them, and with `needs.changes.outputs.docs_site == 'true'`
+# for jobs that only matter when docs/site/** is touched.
+#
+# For every event other than pull_request (push, merge_group, schedule,
+# workflow_dispatch, and any workflow_call reached from those) both outputs are
+# true, so non-PR runs keep their full coverage.
+
+on:
+  workflow_call:
+    outputs:
+      code:
+        description: "true unless the PR touches only docs/, root-level llms*.txt and root-level *.md"
+        value: ${{ jobs.check.outputs.code }}
+      docs_site:
+        description: "true when the PR touches docs/site/**"
+        value: ${{ jobs.check.outputs.docs_site }}
+
+permissions:
+  contents: read
+  # Reads the PR file list via the REST API.
+  pull-requests: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    outputs:
+      code: ${{ steps.check.outputs.code }}
+      docs_site: ${{ steps.check.outputs.docs_site }}
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "docs_site=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --paginate --jq '.[].filename') \
+            || { echo "Failed to fetch PR files from GitHub API"; exit 1; }
+          # "code" = any file outside: docs/*, root-level llms*.txt, root-level *.md
+          # (nested *.md like execution/README.md still counts as a code change)
+          if echo "$files" | grep -qvE '^(docs/|llms[^/]*\.txt$|[^/]*\.md$)'; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+          if echo "$files" | grep -qE '^docs/site/'; then
+            echo "docs_site=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs_site=false" >> "$GITHUB_OUTPUT"
+          fi

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -35,43 +35,13 @@ permissions:
   pull-requests: write
 
 jobs:
-  # Fast path: detect whether any non-docs files changed.
-  # For merge_group and workflow_dispatch always returns code=true/docs_site=true.
-  # Jobs guarded by `needs.changes.outputs.code != 'false'` are skipped
-  # for docs-only PRs, saving 20-30 min of unnecessary Go CI.
-  # Jobs guarded by `needs.changes.outputs.docs_site == 'true'` only run when
-  # docs/site/** is touched.
+  # Docs-only detection lives in changes.yml so every workflow that needs it
+  # shares one implementation. Outputs are unchanged: code / docs_site.
   changes:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    outputs:
-      code: ${{ steps.check.outputs.code }}
-      docs_site: ${{ steps.check.outputs.docs_site }}
-    steps:
-      - id: check
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "code=true" >> "$GITHUB_OUTPUT"
-            echo "docs_site=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-            --paginate --jq '.[].filename') \
-            || { echo "Failed to fetch PR files from GitHub API"; exit 1; }
-          # "code" = any file outside: docs/*, root-level llms*.txt, root-level *.md
-          # (nested *.md like execution/README.md still counts as a code change)
-          if echo "$files" | grep -qvE '^(docs/|llms[^/]*\.txt$|[^/]*\.md$)'; then
-            echo "code=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "code=false" >> "$GITHUB_OUTPUT"
-          fi
-          if echo "$files" | grep -qE '^docs/site/'; then
-            echo "docs_site=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "docs_site=false" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/changes.yml
+    permissions:
+      contents: read
+      pull-requests: read
 
   lint:
     if: needs.changes.outputs.code != 'false'

--- a/.github/workflows/qa-rpc-integration-tests-gnosis.yml
+++ b/.github/workflows/qa-rpc-integration-tests-gnosis.yml
@@ -28,7 +28,16 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Skips the suites below on docs-only PRs; see changes.yml.
+  changes:
+    uses: ./.github/workflows/changes.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
   gnosis-rpc-integ-tests:
+    needs: [changes]
+    if: needs.changes.outputs.code != 'false'
     runs-on: [ self-hosted, qa, Gnosis, rpc-integration ]
     env:
       ERIGON_TESTBED_AREA: /opt/erigon-testbed

--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -28,7 +28,16 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Skips the suites below on docs-only PRs; see changes.yml.
+  changes:
+    uses: ./.github/workflows/changes.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
   mainnet-rpc-integ-tests:
+    needs: [changes]
+    if: needs.changes.outputs.code != 'false'
     runs-on: [ self-hosted, qa, Ethereum, rpc-integration-commitment ]
     env:
       ERIGON_TESTBED_AREA: /opt/erigon-testbed

--- a/.github/workflows/test-kurtosis-gloas.yml
+++ b/.github/workflows/test-kurtosis-gloas.yml
@@ -64,6 +64,13 @@ permissions:
   contents: read
 
 jobs:
+  # Skips the suites below on docs-only PRs; see changes.yml.
+  changes:
+    uses: ./.github/workflows/changes.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
   # Warms the docker-cl-* and docker-buildkit-* caches on the default branch
   # (where this workflow's PR runs restore them) via a dedicated workflow on a
   # paths filter + daily schedule — the caches only change when the pinned
@@ -188,7 +195,8 @@ jobs:
 
   gloas_test:
     name: gloas_${{ matrix.suite }}_test
-    if: ${{ !inputs.cl-images-only && !github.event.pull_request.draft }}
+    needs: [changes]
+    if: ${{ needs.changes.outputs.code != 'false' && !inputs.cl-images-only && !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
Companion to #23626 on `main`. `release/3.6` is the docs deploy branch, so documentation PRs land here — and here they were running the full `mainnet-rpc-integ-tests` and `gnosis-rpc-integ-tests` suites plus both `gloas_*_test` suites, none of which consult CI Gate's docs-only check. The two QA suites occupy self-hosted `qa` runners.

Same shape as #23626: detection moves into a reusable `changes.yml` that CI Gate and the three workflows all call, so the regex has one definition instead of four. The logic is copied verbatim and the output names are unchanged. Every event other than `pull_request` still returns `code=true`, so `push`, `merge_group`, `schedule` and the `workflow_call` path cache-warming uses keep their coverage.

`pull-requests: read` sits on each calling job rather than at workflow level — the QA workflows on this branch have no `permissions:` block at all, and adding one would have restricted the token for their other jobs. It is also granted on the `warm` job in `cache-warming-kurtosis-gloas-images.yml`, which calls `test-kurtosis-gloas.yml`: a nested reusable workflow can only narrow its caller's grant, so without it the called workflow fails validation.

A separate PR rather than a cherry-pick because the two QA workflows have diverged from `main` (+16/−23) around the summary-rendering step.

Verified with the gates `lint.yml` runs on this branch: `actionlint` 1.7.12 with the repo's ignore flags and `zizmor` 1.26.1 with `.github/zizmor.yml`, both clean. `ci-gate-check.sh` keys only on the name `ci-gate`, so renaming that check run to `changes / check` does not affect the gate; its test suite passes on this branch too. This PR touches `.github/`, so it is not docs-only and exercises the `code=true` path.