### PR TITLE
[r3.6] cmd/utils: reduce default torrent upload rate to 4mb

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -726,10 +726,8 @@ var (
 		Usage: "Bytes per second for webseeds, example: 32mb. Set Inf for no limit. If not set, rate limit is shared with torrent.download.rate",
 	}
 	TorrentUploadRateFlag = cli.StringFlag{
-		Name: "torrent.upload.rate",
-		// Still above 3.0's default, but low enough that seeding does not starve
-		// block execution for CPU and syscalls on a busy node.
-		Value: "8mb",
+		Name:  "torrent.upload.rate",
+		Value: "4mb",
 		Usage: "Bytes per second, example: 32mb. Set Inf for no limit.",
 	}
 	// Deprecated (v3.0): This flag no longer has any effect and will be removed in a future release.

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -727,8 +727,9 @@ var (
 	}
 	TorrentUploadRateFlag = cli.StringFlag{
 		Name: "torrent.upload.rate",
-		// Agreed in meeting to leave it quite a bit higher than 3.0 unless it becomes a problem.
-		Value: "16mb",
+		// Still above 3.0's default, but low enough that seeding does not starve
+		// block execution for CPU and syscalls on a busy node.
+		Value: "8mb",
 		Usage: "Bytes per second, example: 32mb. Set Inf for no limit.",
 	}
 	// Deprecated (v3.0): This flag no longer has any effect and will be removed in a future release.


### PR DESCRIPTION
seems one of https://github.com/erigontech/erigon/issues/22886