### PR TITLE
rpc/jsonstream: recycle streams through a sync.Pool

### DIFF
--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -221,7 +221,8 @@ func (h *handler) handleBatch(msgs []*jsonrpcMessage) {
 				// streamed response: res == nil, already written to the stream.
 				// notification: no response, leaving buf empty (only non-empty buffers reply).
 				buf := bytes.NewBuffer(nil)
-				stream := jsonstream.New(buf)
+				stream := jsonstream.Get(buf)
+				defer jsonstream.Put(stream)
 				if res := h.handleCallMsg(cp, calls[i], stream); res != nil {
 					res.writeTo(stream)
 				}
@@ -233,7 +234,8 @@ func (h *handler) handleBatch(msgs []*jsonrpcMessage) {
 		}
 		wg.Wait()
 		h.addSubscriptions(cp.notifiers)
-		out := jsonstream.New(nil)
+		out := jsonstream.Get(nil)
+		defer jsonstream.Put(out)
 		out.WriteArrayStart()
 		wrote := false
 		for _, answer := range answersWithNils {
@@ -279,7 +281,8 @@ func (h *handler) handleMsg(msg *jsonrpcMessage, stream jsonstream.Stream) {
 	h.startCallProc(func(cp *callProc) {
 		needWriteStream := false
 		if stream == nil {
-			stream = jsonstream.New(nil)
+			stream = jsonstream.Get(nil)
+			defer jsonstream.Put(stream)
 			needWriteStream = true
 		}
 		answer := h.handleCallMsg(cp, msg, stream)

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -235,7 +235,6 @@ func (h *handler) handleBatch(msgs []*jsonrpcMessage) {
 		wg.Wait()
 		h.addSubscriptions(cp.notifiers)
 		out := jsonstream.Get(nil)
-		defer jsonstream.Put(out)
 		out.WriteArrayStart()
 		wrote := false
 		for _, answer := range answersWithNils {
@@ -252,6 +251,7 @@ func (h *handler) handleBatch(msgs []*jsonrpcMessage) {
 		if wrote {
 			h.conn.WriteJSON(cp.ctx, rawResponse(out.Buffer()))
 		}
+		jsonstream.Put(out)
 		for _, n := range cp.notifiers {
 			n.activate()
 		}
@@ -282,7 +282,6 @@ func (h *handler) handleMsg(msg *jsonrpcMessage, stream jsonstream.Stream) {
 		needWriteStream := false
 		if stream == nil {
 			stream = jsonstream.Get(nil)
-			defer jsonstream.Put(stream)
 			needWriteStream = true
 		}
 		answer := h.handleCallMsg(cp, msg, stream)
@@ -292,6 +291,7 @@ func (h *handler) handleMsg(msg *jsonrpcMessage, stream jsonstream.Stream) {
 		}
 		if needWriteStream {
 			h.conn.WriteJSON(cp.ctx, rawResponse(stream.Buffer()))
+			jsonstream.Put(stream)
 		} else {
 			stream.WriteRaw("\n")
 		}

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -234,28 +234,56 @@ func (h *handler) handleBatch(msgs []*jsonrpcMessage) {
 		}
 		wg.Wait()
 		h.addSubscriptions(cp.notifiers)
-		out := jsonstream.Get(nil)
-		out.WriteArrayStart()
-		wrote := false
-		for _, answer := range answersWithNils {
-			if answer == nil {
-				continue
-			}
-			if wrote {
-				out.WriteMore()
-			}
-			wrote = true
-			out.WriteRawBytes(answer)
-		}
-		out.WriteArrayEnd()
-		if wrote {
-			h.conn.WriteJSON(cp.ctx, rawResponse(out.Buffer()))
-		}
-		jsonstream.Put(out)
+		h.sendBatchAnswers(cp.ctx, answersWithNils)
 		for _, n := range cp.notifiers {
 			n.activate()
 		}
 	})
+}
+
+// sendBatchAnswers joins the per-item answers into one JSON array and sends it.
+// It owns the stream for the whole call, so the pool gets it back on any exit.
+func (h *handler) sendBatchAnswers(ctx context.Context, answers [][]byte) {
+	out := jsonstream.Get(nil)
+	defer jsonstream.Put(out)
+
+	out.WriteArrayStart()
+	wrote := false
+	for _, answer := range answers {
+		if answer == nil {
+			continue
+		}
+		if wrote {
+			out.WriteMore()
+		}
+		wrote = true
+		out.WriteRawBytes(answer)
+	}
+	out.WriteArrayEnd()
+	if wrote {
+		h.conn.WriteJSON(ctx, rawResponse(out.Buffer()))
+	}
+}
+
+// answerBuffered serves a call for a transport that has no stream to write
+// through: the whole response is built in a pooled stream and sent in one piece.
+// It owns the stream, so the pool gets it back on any exit.
+func (h *handler) answerBuffered(cp *callProc, msg *jsonrpcMessage) {
+	stream := jsonstream.Get(nil)
+	defer jsonstream.Put(stream)
+
+	h.answerInto(cp, msg, stream)
+	h.conn.WriteJSON(cp.ctx, rawResponse(stream.Buffer()))
+}
+
+// answerInto runs the call and leaves its response in stream. A streamed method
+// writes its own; anything else is encoded here.
+func (h *handler) answerInto(cp *callProc, msg *jsonrpcMessage, stream jsonstream.Stream) {
+	answer := h.handleCallMsg(cp, msg, stream)
+	h.addSubscriptions(cp.notifiers)
+	if answer != nil {
+		answer.writeTo(stream)
+	}
 }
 
 func (h *handler) respondWithBatchTooLarge(cp *callProc, batch []*jsonrpcMessage) {
@@ -279,20 +307,10 @@ func (h *handler) handleMsg(msg *jsonrpcMessage, stream jsonstream.Stream) {
 		return
 	}
 	h.startCallProc(func(cp *callProc) {
-		needWriteStream := false
 		if stream == nil {
-			stream = jsonstream.Get(nil)
-			needWriteStream = true
-		}
-		answer := h.handleCallMsg(cp, msg, stream)
-		h.addSubscriptions(cp.notifiers)
-		if answer != nil {
-			answer.writeTo(stream)
-		}
-		if needWriteStream {
-			h.conn.WriteJSON(cp.ctx, rawResponse(stream.Buffer()))
-			jsonstream.Put(stream)
+			h.answerBuffered(cp, msg)
 		} else {
+			h.answerInto(cp, msg, stream)
 			stream.WriteRaw("\n")
 		}
 		for _, n := range cp.notifiers {

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -316,7 +316,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer codec.Close()
 	var stream jsonstream.Stream
 	if !s.disableStreaming {
-		stream = jsonstream.New(w)
+		stream = jsonstream.Get(w)
+		defer jsonstream.Put(stream)
 	}
 
 	errorMsg := s.serveSingleRequest(ctx, codec, stream)

--- a/rpc/jsonstream/factory.go
+++ b/rpc/jsonstream/factory.go
@@ -46,6 +46,7 @@ func flushIfFull(stream *jsoniter.Stream) {
 	}
 }
 
+// New builds an unpooled stream. Request paths use Get.
 func New(out io.Writer) Stream {
 	return NewSized(out, InitialBufferSize)
 }
@@ -57,15 +58,13 @@ func NewSized(out io.Writer, bufSize int) Stream {
 
 var streamPool = sync.Pool{New: func() any { return newStackStream(nil, InitialBufferSize) }}
 
-// maxPooledBufferSize bounds what a stream may carry back into the pool. A
-// non-streaming response is appended whole, so the buffer ends up the size of
-// the response; the bound keeps ordinary ones and drops the outliers, which the
-// pool would otherwise pin one per running goroutine.
-const maxPooledBufferSize = 4 * int(datasize.MB)
+// maxPooledBufferSize bounds what a stream carries back into the pool. A
+// non-streaming response is appended whole, so its buffer ends up as large as
+// the response, and the pool holds one per running goroutine.
+const maxPooledBufferSize = 16 * FlushThreshold
 
-// Get is New over a pool, so a response reuses the previous one's buffer instead
-// of growing a fresh 4KB one up to the flush threshold. Hand the stream back with
-// Put once the bytes have left it; not doing so only costs the recycling.
+// Get is New over a pool. Put the stream back once its bytes have left it;
+// skipping Put only costs the recycling.
 func Get(out io.Writer) Stream {
 	s := streamPool.Get().(*StackStream)
 	s.Reset(out)
@@ -79,6 +78,6 @@ func Put(s Stream) {
 	if !ok || cap(ss.stream.Buffer()) > maxPooledBufferSize {
 		return
 	}
-	ss.Reset(nil)
+	ss.Reset(nil) // the writer goes too, so an idle stream pins no connection
 	streamPool.Put(ss)
 }

--- a/rpc/jsonstream/factory.go
+++ b/rpc/jsonstream/factory.go
@@ -57,10 +57,11 @@ func NewSized(out io.Writer, bufSize int) Stream {
 
 var streamPool = sync.Pool{New: func() any { return newStackStream(nil, InitialBufferSize) }}
 
-// maxPooledBufferSize bounds what a stream may carry back into the pool. A value
-// larger than the flush threshold grows the buffer past it in one write, and
-// keeping that would pin one request's peak for the life of the process.
-const maxPooledBufferSize = 4 * FlushThreshold
+// maxPooledBufferSize bounds what a stream may carry back into the pool. A
+// non-streaming response is appended whole, so the buffer ends up the size of
+// the response; the bound keeps ordinary ones and drops the outliers, which the
+// pool would otherwise pin one per running goroutine.
+const maxPooledBufferSize = 4 * int(datasize.MB)
 
 // Get is New over a pool, so a response reuses the previous one's buffer instead
 // of growing a fresh 4KB one up to the flush threshold. Hand the stream back with

--- a/rpc/jsonstream/factory.go
+++ b/rpc/jsonstream/factory.go
@@ -18,6 +18,7 @@ package jsonstream
 
 import (
 	"io"
+	"sync"
 
 	"github.com/c2h5oh/datasize"
 
@@ -52,4 +53,31 @@ func New(out io.Writer) Stream {
 // NewSized is New with an explicit initial buffer size.
 func NewSized(out io.Writer, bufSize int) Stream {
 	return newStackStream(out, bufSize)
+}
+
+var streamPool = sync.Pool{New: func() any { return newStackStream(nil, InitialBufferSize) }}
+
+// maxPooledBufferSize bounds what a stream may carry back into the pool. A value
+// larger than the flush threshold grows the buffer past it in one write, and
+// keeping that would pin one request's peak for the life of the process.
+const maxPooledBufferSize = 4 * FlushThreshold
+
+// Get is New over a pool, so a response reuses the previous one's buffer instead
+// of growing a fresh 4KB one up to the flush threshold. Hand the stream back with
+// Put once the bytes have left it; not doing so only costs the recycling.
+func Get(out io.Writer) Stream {
+	s := streamPool.Get().(*StackStream)
+	s.Reset(out)
+	return s
+}
+
+// Put returns a stream to the pool. The caller must hold no view of Buffer()
+// afterwards, and must not write to the stream again.
+func Put(s Stream) {
+	ss, ok := s.(*StackStream)
+	if !ok || cap(ss.stream.Buffer()) > maxPooledBufferSize {
+		return
+	}
+	ss.Reset(nil)
+	streamPool.Put(ss)
 }

--- a/rpc/jsonstream/stack_stream_test.go
+++ b/rpc/jsonstream/stack_stream_test.go
@@ -1182,40 +1182,29 @@ func TestLazyFieldStreamPassesValuelessWrites(t *testing.T) {
 	}
 }
 
-// TestPoolHandsBackAcleanStream pins what Put must clear: a reused stream that
-// kept the previous response's bytes would prepend them to the next one, and one
-// that kept the latched error would fail every Flush without draining.
-func TestPoolHandsBackACleanStream(t *testing.T) {
-	s := Get(goneWriter{}).(*StackStream)
-	s.WriteObjectStart()
-	s.WriteObjectField("a")
-	s.WriteString(strings.Repeat("x", 2*FlushThreshold))
-	require.Error(t, s.Flush())
+// Put clears the writer as well as the bytes. A pooled stream that kept one
+// would pin the connection it came from until the next Get.
+func TestPutReleasesWriterAndBytes(t *testing.T) {
+	var out bytes.Buffer
+	s := Get(&out).(*StackStream)
+	s.WriteString("pending")
 	Put(s)
 
-	var out bytes.Buffer
-	reused := Get(&out)
-	require.Empty(t, reused.Buffer())
-	require.Equal(t, 0, reused.Depth())
-	reused.WriteString("ok")
-	require.NoError(t, reused.Flush())
-	require.Equal(t, `"ok"`, out.String())
-	Put(reused)
+	require.Empty(t, s.Buffer())
+	require.NoError(t, s.Flush())
+	require.Empty(t, out.String())
 }
 
-// A response that grew far past the flush threshold is dropped rather than
-// pooled, so one outsized value cannot pin its peak for the life of the process.
-func TestPoolDropsOversizedBuffers(t *testing.T) {
+// A response above the bound is dropped rather than pooled, so one outsized
+// value cannot pin its peak per goroutine.
+func TestPutDropsOversizedBuffer(t *testing.T) {
 	s := Get(nil).(*StackStream)
-	s.WriteString(strings.Repeat("x", 2*maxPooledBufferSize))
+	s.WriteString(strings.Repeat("x", maxPooledBufferSize))
 	require.Greater(t, cap(s.Buffer()), maxPooledBufferSize)
-	Put(s)
 
-	for range 8 {
-		got := Get(nil).(*StackStream)
-		require.LessOrEqual(t, cap(got.Buffer()), maxPooledBufferSize)
-		Put(got)
-	}
+	Put(s)
+	require.NotEmpty(t, s.Buffer(), "an oversized stream is dropped, not reset and pooled")
+	require.NotSame(t, s, Get(nil).(*StackStream))
 }
 
 func BenchmarkStreamAcquire(b *testing.B) {

--- a/rpc/jsonstream/stack_stream_test.go
+++ b/rpc/jsonstream/stack_stream_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"strings"
 	"testing"
@@ -1179,4 +1180,70 @@ func TestLazyFieldStreamPassesValuelessWrites(t *testing.T) {
 			require.NotContains(t, string(inner.Buffer()), `"result":`)
 		})
 	}
+}
+
+// TestPoolHandsBackAcleanStream pins what Put must clear: a reused stream that
+// kept the previous response's bytes would prepend them to the next one, and one
+// that kept the latched error would fail every Flush without draining.
+func TestPoolHandsBackACleanStream(t *testing.T) {
+	s := Get(goneWriter{}).(*StackStream)
+	s.WriteObjectStart()
+	s.WriteObjectField("a")
+	s.WriteString(strings.Repeat("x", 2*FlushThreshold))
+	require.Error(t, s.Flush())
+	Put(s)
+
+	var out bytes.Buffer
+	reused := Get(&out)
+	require.Empty(t, reused.Buffer())
+	require.Equal(t, 0, reused.Depth())
+	reused.WriteString("ok")
+	require.NoError(t, reused.Flush())
+	require.Equal(t, `"ok"`, out.String())
+	Put(reused)
+}
+
+// A response that grew far past the flush threshold is dropped rather than
+// pooled, so one outsized value cannot pin its peak for the life of the process.
+func TestPoolDropsOversizedBuffers(t *testing.T) {
+	s := Get(nil).(*StackStream)
+	s.WriteString(strings.Repeat("x", 8*FlushThreshold))
+	require.Greater(t, cap(s.Buffer()), maxPooledBufferSize)
+	Put(s)
+
+	for range 8 {
+		got := Get(nil).(*StackStream)
+		require.LessOrEqual(t, cap(got.Buffer()), maxPooledBufferSize)
+		Put(got)
+	}
+}
+
+func BenchmarkStreamAcquire(b *testing.B) {
+	result := strings.Repeat("0xabcdef", 512)
+	write := func(s Stream) {
+		s.WriteObjectStart()
+		s.WriteObjectField("jsonrpc")
+		s.WriteString("2.0")
+		s.WriteMore()
+		s.WriteObjectField("result")
+		s.WriteString(result)
+		s.WriteObjectEnd()
+	}
+	b.Run("impl=new", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			s := New(io.Discard)
+			write(s)
+			_ = s.Flush()
+		}
+	})
+	b.Run("impl=pool", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			s := Get(io.Discard)
+			write(s)
+			_ = s.Flush()
+			Put(s)
+		}
+	})
 }

--- a/rpc/jsonstream/stack_stream_test.go
+++ b/rpc/jsonstream/stack_stream_test.go
@@ -1207,7 +1207,7 @@ func TestPoolHandsBackACleanStream(t *testing.T) {
 // pooled, so one outsized value cannot pin its peak for the life of the process.
 func TestPoolDropsOversizedBuffers(t *testing.T) {
 	s := Get(nil).(*StackStream)
-	s.WriteString(strings.Repeat("x", 8*FlushThreshold))
+	s.WriteString(strings.Repeat("x", 2*maxPooledBufferSize))
 	require.Greater(t, cap(s.Buffer()), maxPooledBufferSize)
 	Put(s)
 


### PR DESCRIPTION
Stacked on #23493.

problem: every JSON-RPC response builds a fresh `StackStream` — wrapper, stack and a 4KB jsoniter buffer — and drops it. A non-streaming response is appended whole, so that 4KB is regrown to the size of the response on every request.

Solution: `Get`/`Put` over a `sync.Pool` on the four request-scoped call sites. A buffer above `16*FlushThreshold` (1MB) is dropped instead of pooled, so the pool holds at most one response-sized buffer per running goroutine.

n0, rpcdaemon on `/erigon-data/mainnet36_archive`. One method: `eth_getBlockByNumber` with tx bodies, 2000 distinct blocks (25.600M–25.602M) generated by `cmd/rpctest benchEthGetBlockByNumber2` and replayed with vegeta — 555KB mean response. Medians of 4 interleaved rounds:

| | base | pool |
| --- | ---: | ---: |
| alloc/req @600 rps | 2.569 MB | **2.227 MB** (−13.3%) |
| `eth_getBlockByNumber` req/s, saturated | 1331.7 | 1336.4 |
| p50 / p99 @600 rps | 4.70 / 15.37 ms | 4.74 / 15.48 ms |

`alloc_space` attributes it: `StackStream.WriteRawBytes` flat 27.60 GB → 11.33 GB over the same run, process total 128.7 GB → 111.4 GB. Throughput and latency do not move — this workload is marshal- and IO-bound, not allocator-bound.

`BenchmarkStreamAcquire`, one 4KB result field per response (M4 Max, go1.27): 1220 → 546 ns/op, 9616 → 0 B/op, 5 → 0 allocs/op.

