### PR TITLE
execution/state: BAL construction is quadratic in slots per account

### DIFF
--- a/execution/bal/process_test.go
+++ b/execution/bal/process_test.go
@@ -209,7 +209,7 @@ func TestBALBlock943Direct(t *testing.T) {
 		// EIP-2935: 1 storage change at accessIndex 0 (system call txIndex=-1)
 		{
 			Address: eip2935Addr,
-			StorageChanges: []*types.SlotChanges{
+			StorageChanges: []types.SlotChanges{
 				{
 					Slot:    slot2935,
 					Changes: []*types.StorageChange{{Index: 0, Value: *val2935}},
@@ -219,7 +219,7 @@ func TestBALBlock943Direct(t *testing.T) {
 		// EIP-4788: 2 storage changes at accessIndex 0 (system call txIndex=-1)
 		{
 			Address: eip4788Addr,
-			StorageChanges: []*types.SlotChanges{
+			StorageChanges: []types.SlotChanges{
 				{
 					Slot:    slot4788Timestamp,
 					Changes: []*types.StorageChange{{Index: 0, Value: *val4788Timestamp}},

--- a/execution/bal/writes.go
+++ b/execution/bal/writes.go
@@ -41,7 +41,8 @@ func finalChangeUpTo[T indexedChange](changes []T, maxTxIndex uint32) (T, bool) 
 // ToWriteSet returns the latest BAL changes at or before maxTxIndex as state writes.
 func ToWriteSet(blockAccessList types.BlockAccessList, maxTxIndex uint32) *state.WriteSet {
 	writes := &state.WriteSet{}
-	for _, accountChanges := range blockAccessList {
+	for i := range blockAccessList {
+		accountChanges := &blockAccessList[i]
 		addr := accountChanges.Address
 		if balance, ok := finalChangeUpTo(accountChanges.BalanceChanges, maxTxIndex); ok {
 			writes.SetBalance(addr, &state.VersionedWrite[uint256.Int]{

--- a/execution/engineapi/engine_api_bal_test.go
+++ b/execution/engineapi/engine_api_bal_test.go
@@ -296,7 +296,7 @@ func TestEngineApiBALStorageWrites(t *testing.T) {
 		// Verify at least one storage slot was written at the mint tx index
 		foundStorageChange := false
 		for _, slotChange := range contractChanges.StorageChanges {
-			if findStorageChange(slotChange, balIndex) != nil {
+			if findStorageChange(&slotChange, balIndex) != nil {
 				foundStorageChange = true
 				break
 			}
@@ -476,7 +476,7 @@ func TestEngineApiBALMultiTxBlock(t *testing.T) {
 		require.NotNilf(t, contractChanges, "missing contract changes\n%s", bal.DebugString())
 		foundStorageChange := false
 		for _, slotChange := range contractChanges.StorageChanges {
-			if findStorageChange(slotChange, mintIdx) != nil {
+			if findStorageChange(&slotChange, mintIdx) != nil {
 				foundStorageChange = true
 				break
 			}
@@ -609,7 +609,7 @@ func TestEngineApiBALMixedBlock(t *testing.T) {
 		require.NotNilf(t, changerChanges, "missing changer contract\n%s", bal.DebugString())
 		foundStorageAtChange := false
 		for _, slotChange := range changerChanges.StorageChanges {
-			if findStorageChange(slotChange, changeIdx) != nil {
+			if findStorageChange(&slotChange, changeIdx) != nil {
 				foundStorageAtChange = true
 				break
 			}

--- a/execution/engineapi/engine_api_bal_test.go
+++ b/execution/engineapi/engine_api_bal_test.go
@@ -1088,9 +1088,9 @@ func decodeAndValidateBAL(t *testing.T, payload *engineapitester.MockClPayload) 
 }
 
 func findAccountChanges(bal types.BlockAccessList, addr accounts.Address) *types.AccountChanges {
-	for _, ac := range bal {
-		if ac != nil && ac.Address == addr {
-			return ac
+	for i := range bal {
+		if bal[i].Address == addr {
+			return &bal[i]
 		}
 	}
 	return nil

--- a/execution/engineapi/engine_server_getpayload_test.go
+++ b/execution/engineapi/engine_server_getpayload_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/execmodule"
 	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/execution/types/accounts"
 	"github.com/erigontech/erigon/rpc"
 )
 
@@ -268,7 +269,15 @@ func TestAssembledBlockToPayloadResponseReturnsSidecarEncodingError(t *testing.T
 		GasLimit:            30_000_000,
 		BlockAccessListHash: &balHash,
 	}
-	sidecar := types.NewBlockAccessListSidecar(types.BlockAccessList{nil})
+	// A nil nested StorageChange is the encoding failure that survives an
+	// account list of values.
+	sidecar := types.NewBlockAccessListSidecar(types.BlockAccessList{{
+		Address: accounts.InternAddress(common.Address{2}),
+		StorageChanges: []types.SlotChanges{{
+			Slot:    accounts.InternKey(common.Hash{3}),
+			Changes: []*types.StorageChange{nil},
+		}},
+	}})
 	block := types.NewBlockWithHeader(header, sidecar)
 	br := &types.BlockWithReceipts{Block: block, Requests: make(types.FlatRequests, 0)}
 

--- a/execution/exec/blocks_read_ahead.go
+++ b/execution/exec/blocks_read_ahead.go
@@ -379,7 +379,7 @@ func (bra *BlockReadAheader) warmBALState(ctx context.Context, db kv.RoDB, bal t
 					break
 				}
 				task := tasks[taskIndex]
-				account := bal[task.accountIndex]
+				account := &bal[task.accountIndex]
 				if err := warmBALStateTask(stateReader, account, task, codeMode, txCodeDestinations); err != nil {
 					log.Warn("[warmBAL] state task failed", "worker", w, "account", account.Address, "err", err)
 				}

--- a/execution/exec/blocks_read_ahead.go
+++ b/execution/exec/blocks_read_ahead.go
@@ -250,12 +250,13 @@ func balCodeWarmupModeForFlags(warmBALCode, warmTxCode bool) balCodeWarmupMode {
 
 func makeBALWarmupPlan(bal types.BlockAccessList, workers int) ([]balWarmupTask, int) {
 	taskCount := 0
-	for _, account := range bal {
-		slots := len(account.StorageChanges) + len(account.StorageReads)
+	for i := range bal {
+		slots := len(bal[i].StorageChanges) + len(bal[i].StorageReads)
 		taskCount += max(1, (slots+balWarmupStorageChunkSize-1)/balWarmupStorageChunkSize)
 	}
 	tasks := make([]balWarmupTask, 0, taskCount)
-	for accountIndex, account := range bal {
+	for accountIndex := range bal {
+		account := &bal[accountIndex]
 		slots := len(account.StorageChanges) + len(account.StorageReads)
 		if slots == 0 {
 			tasks = append(tasks, balWarmupTask{accountIndex: uint32(accountIndex)})

--- a/execution/exec/blocks_read_ahead_test.go
+++ b/execution/exec/blocks_read_ahead_test.go
@@ -181,7 +181,7 @@ func TestBlockReadAheaderIgnoresNilGetter(t *testing.T) {
 
 func TestMakeBALWarmupTasksSplitsStorageHeavyAccount(t *testing.T) {
 	bal := types.BlockAccessList{{
-		StorageChanges: make([]*types.SlotChanges, 65),
+		StorageChanges: make([]types.SlotChanges, 65),
 		StorageReads:   make([]accounts.StorageKey, 3),
 	}}
 	tasks, workers := makeBALWarmupPlan(bal, 4)
@@ -283,7 +283,7 @@ func TestWarmBALStateTaskDoesNotRepeatCodeForLaterChunks(t *testing.T) {
 
 func TestMakeBALWarmupTasksKeepsSmallAccountsTogether(t *testing.T) {
 	bal := types.BlockAccessList{
-		{StorageChanges: make([]*types.SlotChanges, 1)},
+		{StorageChanges: make([]types.SlotChanges, 1)},
 		{StorageReads: make([]accounts.StorageKey, 1)},
 	}
 	tasks, workers := makeBALWarmupPlan(bal, 4)

--- a/execution/stagedsync/bal_load_test.go
+++ b/execution/stagedsync/bal_load_test.go
@@ -64,7 +64,7 @@ func TestLoadFromBAL_MatchesApplyWrites(t *testing.T) {
 		},
 		{
 			Address: addrB,
-			StorageChanges: []*types.SlotChanges{
+			StorageChanges: []types.SlotChanges{
 				{Slot: slotS1, Changes: []*types.StorageChange{
 					{Index: 0, Value: *uint256.NewInt(1)},
 					{Index: 2, Value: *uint256.NewInt(77)}, // final

--- a/execution/stagedsync/calc_state.go
+++ b/execution/stagedsync/calc_state.go
@@ -300,7 +300,8 @@ func (cs *calcState) LoadFromBALUpTo(blockAccessList types.BlockAccessList, maxT
 	// EIP-161: a touched account whose merged block-end state is empty is
 	// removed from the trie. The BAL carries no deletion marker, so reconstruct
 	// it here, gated exactly as the incremental path (Normalize).
-	for _, ac := range blockAccessList {
+	for i := range blockAccessList {
+		ac := &blockAccessList[i]
 		acc := cs.accounts[ac.Address]
 		if acc == nil || !acc.dirty || acc.Deleted {
 			continue

--- a/execution/stagedsync/committer_step_boundary_test.go
+++ b/execution/stagedsync/committer_step_boundary_test.go
@@ -635,7 +635,7 @@ func TestComputeAhead_StepBoundaryCheckpointMidBlock(t *testing.T) {
 			accountValues[string(addrBytes)] = buf
 		}
 		idx := uint32(txNum - firstTxNum) // BAL index == txNum - firstTxNum
-		bList = append(bList, &types.AccountChanges{
+		bList = append(bList, types.AccountChanges{
 			Address:        accounts.InternAddress([20]byte(addrBytes)),
 			BalanceChanges: []*types.BalanceChange{{Index: idx, Value: balV}},
 			NonceChanges:   []*types.NonceChange{{Index: idx, Value: txNum}},

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -2886,10 +2886,19 @@ func (account *accountState) addStorageUpdate(at int, slot accounts.StorageKey, 
 		for i := range ac.StorageChanges {
 			account.slotWrites[ac.StorageChanges[i].Slot] = i
 		}
+		// StorageReads can hold the same slot twice: below the threshold reads are
+		// appended unchecked, and Normalize is what dedups them. The index needs
+		// one entry per slot, so drop the repeats while building it.
 		account.slotReads = make(map[accounts.StorageKey]int, len(ac.StorageReads))
-		for i, slot := range ac.StorageReads {
-			account.slotReads[slot] = i
+		deduped := ac.StorageReads[:0]
+		for _, slot := range ac.StorageReads {
+			if _, seen := account.slotReads[slot]; seen {
+				continue
+			}
+			account.slotReads[slot] = len(deduped)
+			deduped = append(deduped, slot)
 		}
+		ac.StorageReads = deduped
 	}
 }
 

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -2830,9 +2830,9 @@ func (account *accountState) updateReadBalance(val uint256.Int) {
 	}
 }
 
-// slotIndexMin is where scanning StorageChanges stops being cheaper than a map
-// probe. Most accounts touch a handful of slots; a storage-bloated block puts
-// thousands on one account, and every access looks the slot up.
+// slotIndexMin is where scanning the slot lists stops being cheaper than a map
+// probe. A storage-bloated block puts thousands of slots on one account and
+// looks every one of them up.
 const slotIndexMin = 16
 
 // storageWriteIndex returns the position of slot in changes.StorageChanges, or -1.
@@ -2857,8 +2857,7 @@ func (account *accountState) hasStorageWrite(slot accounts.StorageKey) bool {
 
 // addStorageUpdate records a write at slot, which storageWriteIndex already
 // located as at (-1 when the slot is new). It is the only writer of
-// changes.StorageChanges, so slotWrites cannot drift from it; Normalize
-// reorders the slice, but only after the build.
+// changes.StorageChanges, so the index cannot drift from it.
 func (account *accountState) addStorageUpdate(at int, slot accounts.StorageKey, val uint256.Int, txIndex uint32) {
 	// If we already recorded a read for this slot, drop it because a write takes precedence.
 	account.removeStorageRead(slot)

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -2864,12 +2864,12 @@ func (account *accountState) addStorageUpdate(at int, slot accounts.StorageKey, 
 
 	ac := account.changes
 	if at >= 0 {
-		changes := ac.StorageChanges[at].Changes
+		sc := &ac.StorageChanges[at]
 		// EIP-7928 no-op filter: skip if value equals the slot's last recorded write.
-		if n := len(changes); n > 0 && val.Eq(&changes[n-1].Value) {
+		if n := len(sc.Changes); n > 0 && val.Eq(&sc.Changes[n-1].Value) {
 			return
 		}
-		ac.StorageChanges[at].Changes = append(changes, &types.StorageChange{Index: txIndex, Value: val})
+		sc.Changes = append(sc.Changes, &types.StorageChange{Index: txIndex, Value: val})
 		return
 	}
 

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -2549,7 +2549,7 @@ func (io *VersionedIO) AsBlockAccessList() types.BlockAccessList {
 		}
 	}
 
-	bal := make([]*types.AccountChanges, 0, len(ac))
+	bal := make(types.BlockAccessList, 0, len(ac))
 	for _, account := range ac {
 		account.finalize()
 		account.changes.Normalize()
@@ -2564,10 +2564,10 @@ func (io *VersionedIO) AsBlockAccessList() types.BlockAccessList {
 		if account.changes.Address == params.SystemAddress && !hasAccountChanges(account.changes) && !account.nonRevertableUserAccess {
 			continue
 		}
-		bal = append(bal, account.changes)
+		bal = append(bal, *account.changes)
 	}
 
-	slices.SortFunc(bal, func(a, b *types.AccountChanges) int {
+	slices.SortFunc(bal, func(a, b types.AccountChanges) int {
 		return a.Address.Cmp(b.Address)
 	})
 
@@ -2591,6 +2591,7 @@ type accountState struct {
 	initialBalanceValue     *uint256.Int                        // tracks pre-block balance for net-zero detection
 	storageReadValues       map[accounts.StorageKey]uint256.Int // original read values for net-zero detection
 	slotWrites              map[accounts.StorageKey]int         // slot -> index into changes.StorageChanges, built past slotIndexMin
+	slotReads               map[accounts.StorageKey]int         // slot -> index into changes.StorageReads, built with slotWrites
 	nonRevertableUserAccess bool                                // true if a user tx (txIndex >= 0) has non-revertable access
 	initialCodeEmpty        bool                                // pre-block code was empty (created contract or empty-codehash read)
 }
@@ -2708,16 +2709,20 @@ func (a *accountState) setBalanceValue(v uint256.Int) {
 	*a.balanceValue = v
 }
 
-func ensureAccountState(accounts map[accounts.Address]*accountState, addr accounts.Address) *accountState {
-	if account, ok := accounts[addr]; ok {
-		return account
-	}
-	account := &accountState{
+func newAccountState(addr accounts.Address) *accountState {
+	return &accountState{
 		changes: &types.AccountChanges{Address: addr},
 		balance: newBalanceTracker(),
 		nonce:   newNonceTracker(),
 		code:    newCodeTracker(),
 	}
+}
+
+func ensureAccountState(accounts map[accounts.Address]*accountState, addr accounts.Address) *accountState {
+	if account, ok := accounts[addr]; ok {
+		return account
+	}
+	account := newAccountState(addr)
 	accounts[addr] = account
 	return account
 }
@@ -2795,6 +2800,12 @@ func (account *accountState) updateReadStorage(key accounts.StorageKey, val uint
 	if account.hasStorageWrite(key) {
 		return
 	}
+	if account.slotReads != nil {
+		if _, seen := account.slotReads[key]; seen {
+			return
+		}
+		account.slotReads[key] = len(account.changes.StorageReads)
+	}
 	account.changes.StorageReads = append(account.changes.StorageReads, key)
 }
 
@@ -2850,7 +2861,7 @@ func (account *accountState) hasStorageWrite(slot accounts.StorageKey) bool {
 // reorders the slice, but only after the build.
 func (account *accountState) addStorageUpdate(at int, slot accounts.StorageKey, val uint256.Int, txIndex uint32) {
 	// If we already recorded a read for this slot, drop it because a write takes precedence.
-	removeStorageRead(account.changes, slot)
+	account.removeStorageRead(slot)
 
 	ac := account.changes
 	if at >= 0 {
@@ -2875,24 +2886,50 @@ func (account *accountState) addStorageUpdate(at int, slot accounts.StorageKey, 
 		for i := range ac.StorageChanges {
 			account.slotWrites[ac.StorageChanges[i].Slot] = i
 		}
+		account.slotReads = make(map[accounts.StorageKey]int, len(ac.StorageReads))
+		for i, slot := range ac.StorageReads {
+			account.slotReads[slot] = i
+		}
 	}
 }
 
-func removeStorageRead(ac *types.AccountChanges, slot accounts.StorageKey) {
+// removeStorageRead drops slot from StorageReads, because a write to it takes
+// precedence. Past slotIndexMin the position is indexed and the last entry is
+// swapped in; order does not survive Normalize's sort anyway.
+func (account *accountState) removeStorageRead(slot accounts.StorageKey) {
+	ac := account.changes
 	if len(ac.StorageReads) == 0 {
 		return
 	}
-	out := ac.StorageReads[:0]
-	for _, s := range ac.StorageReads {
-		if s != slot {
-			out = append(out, s)
+	if account.slotReads == nil {
+		out := ac.StorageReads[:0]
+		for _, s := range ac.StorageReads {
+			if s != slot {
+				out = append(out, s)
+			}
 		}
+		if len(out) == 0 {
+			ac.StorageReads = nil
+		} else {
+			ac.StorageReads = out
+		}
+		return
 	}
-	if len(out) == 0 {
+	i, ok := account.slotReads[slot]
+	if !ok {
+		return
+	}
+	delete(account.slotReads, slot)
+	last := len(ac.StorageReads) - 1
+	if i != last {
+		ac.StorageReads[i] = ac.StorageReads[last]
+		account.slotReads[ac.StorageReads[i]] = i
+	}
+	if last == 0 {
 		ac.StorageReads = nil
-	} else {
-		ac.StorageReads = out
+		return
 	}
+	ac.StorageReads = ac.StorageReads[:last]
 }
 
 type versionedReadSet struct {

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -2832,8 +2832,8 @@ func (account *accountState) storageWriteIndex(slot accounts.StorageKey) int {
 		}
 		return -1
 	}
-	for i, sc := range account.changes.StorageChanges {
-		if sc != nil && sc.Slot == slot {
+	for i := range account.changes.StorageChanges {
+		if account.changes.StorageChanges[i].Slot == slot {
 			return i
 		}
 	}
@@ -2854,26 +2854,26 @@ func (account *accountState) addStorageUpdate(at int, slot accounts.StorageKey, 
 
 	ac := account.changes
 	if at >= 0 {
-		slotChange := ac.StorageChanges[at]
+		changes := ac.StorageChanges[at].Changes
 		// EIP-7928 no-op filter: skip if value equals the slot's last recorded write.
-		if n := len(slotChange.Changes); n > 0 && val.Eq(&slotChange.Changes[n-1].Value) {
+		if n := len(changes); n > 0 && val.Eq(&changes[n-1].Value) {
 			return
 		}
-		slotChange.Changes = append(slotChange.Changes, &types.StorageChange{Index: txIndex, Value: val})
+		ac.StorageChanges[at].Changes = append(changes, &types.StorageChange{Index: txIndex, Value: val})
 		return
 	}
 
 	if account.slotWrites != nil {
 		account.slotWrites[slot] = len(ac.StorageChanges)
 	}
-	ac.StorageChanges = append(ac.StorageChanges, &types.SlotChanges{
+	ac.StorageChanges = append(ac.StorageChanges, types.SlotChanges{
 		Slot:    slot,
 		Changes: []*types.StorageChange{{Index: txIndex, Value: val}},
 	})
 	if account.slotWrites == nil && len(ac.StorageChanges) >= slotIndexMin {
 		account.slotWrites = make(map[accounts.StorageKey]int, len(ac.StorageChanges))
-		for i, sc := range ac.StorageChanges {
-			account.slotWrites[sc.Slot] = i
+		for i := range ac.StorageChanges {
+			account.slotWrites[ac.StorageChanges[i].Slot] = i
 		}
 	}
 }

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -2590,6 +2590,7 @@ type accountState struct {
 	balanceValue            *uint256.Int                        // tracks latest seen balance
 	initialBalanceValue     *uint256.Int                        // tracks pre-block balance for net-zero detection
 	storageReadValues       map[accounts.StorageKey]uint256.Int // original read values for net-zero detection
+	slotWrites              map[accounts.StorageKey]int         // slot -> index into changes.StorageChanges, built past slotIndexMin
 	nonRevertableUserAccess bool                                // true if a user tx (txIndex >= 0) has non-revertable access
 	initialCodeEmpty        bool                                // pre-block code was empty (created contract or empty-codehash read)
 }
@@ -2725,12 +2726,13 @@ func (account *accountState) applyWriteStorage(key accounts.StorageKey, val uint
 	// Skip intra-tx net-zero storage writes: if this is the first write
 	// to the slot (no prior tx wrote to it) and the written value equals
 	// the original read value, it's a no-op that should remain as a read.
-	if !hasStorageWrite(account.changes, key) {
+	at := account.storageWriteIndex(key)
+	if at < 0 {
 		if origVal, wasRead := account.storageReadValues[key]; wasRead && val.Eq(&origVal) {
 			return
 		}
 	}
-	addStorageUpdate(account.changes, key, val, accessIndex)
+	account.addStorageUpdate(at, key, val, accessIndex)
 }
 
 func (account *accountState) applyWriteNonce(val uint64, accessIndex uint32) {
@@ -2790,7 +2792,7 @@ func (account *accountState) updateReadStorage(key accounts.StorageKey, val uint
 	if _, exists := account.storageReadValues[key]; !exists {
 		account.storageReadValues[key] = val
 	}
-	if hasStorageWrite(account.changes, key) {
+	if account.hasStorageWrite(key) {
 		return
 	}
 	account.changes.StorageReads = append(account.changes.StorageReads, key)
@@ -2817,41 +2819,63 @@ func (account *accountState) updateReadBalance(val uint256.Int) {
 	}
 }
 
-func addStorageUpdate(ac *types.AccountChanges, slot accounts.StorageKey, val uint256.Int, txIndex uint32) {
-	// If we already recorded a read for this slot, drop it because a write takes precedence.
-	removeStorageRead(ac, slot)
+// slotIndexMin is where scanning StorageChanges stops being cheaper than a map
+// probe. Most accounts touch a handful of slots; a storage-bloated block puts
+// thousands on one account, and every access looks the slot up.
+const slotIndexMin = 16
 
-	if ac.StorageChanges == nil {
-		ac.StorageChanges = []*types.SlotChanges{{
-			Slot:    slot,
-			Changes: []*types.StorageChange{{Index: txIndex, Value: val}},
-		}}
+// storageWriteIndex returns the position of slot in changes.StorageChanges, or -1.
+func (account *accountState) storageWriteIndex(slot accounts.StorageKey) int {
+	if account.slotWrites != nil {
+		if i, ok := account.slotWrites[slot]; ok {
+			return i
+		}
+		return -1
+	}
+	for i, sc := range account.changes.StorageChanges {
+		if sc != nil && sc.Slot == slot {
+			return i
+		}
+	}
+	return -1
+}
+
+func (account *accountState) hasStorageWrite(slot accounts.StorageKey) bool {
+	return account.storageWriteIndex(slot) >= 0
+}
+
+// addStorageUpdate records a write at slot, which storageWriteIndex already
+// located as at (-1 when the slot is new). It is the only writer of
+// changes.StorageChanges, so slotWrites cannot drift from it; Normalize
+// reorders the slice, but only after the build.
+func (account *accountState) addStorageUpdate(at int, slot accounts.StorageKey, val uint256.Int, txIndex uint32) {
+	// If we already recorded a read for this slot, drop it because a write takes precedence.
+	removeStorageRead(account.changes, slot)
+
+	ac := account.changes
+	if at >= 0 {
+		slotChange := ac.StorageChanges[at]
+		// EIP-7928 no-op filter: skip if value equals the slot's last recorded write.
+		if n := len(slotChange.Changes); n > 0 && val.Eq(&slotChange.Changes[n-1].Value) {
+			return
+		}
+		slotChange.Changes = append(slotChange.Changes, &types.StorageChange{Index: txIndex, Value: val})
 		return
 	}
 
-	for _, slotChange := range ac.StorageChanges {
-		if slotChange.Slot == slot {
-			// EIP-7928 no-op filter: skip if value equals the slot's last recorded write.
-			if n := len(slotChange.Changes); n > 0 && val.Eq(&slotChange.Changes[n-1].Value) {
-				return
-			}
-			slotChange.Changes = append(slotChange.Changes, &types.StorageChange{Index: txIndex, Value: val})
-			return
-		}
+	if account.slotWrites != nil {
+		account.slotWrites[slot] = len(ac.StorageChanges)
 	}
 	ac.StorageChanges = append(ac.StorageChanges, &types.SlotChanges{
 		Slot:    slot,
 		Changes: []*types.StorageChange{{Index: txIndex, Value: val}},
 	})
-}
-
-func hasStorageWrite(ac *types.AccountChanges, slot accounts.StorageKey) bool {
-	for _, sc := range ac.StorageChanges {
-		if sc != nil && sc.Slot == slot {
-			return true
+	if account.slotWrites == nil && len(ac.StorageChanges) >= slotIndexMin {
+		account.slotWrites = make(map[accounts.StorageKey]int, len(ac.StorageChanges))
+		for i, sc := range ac.StorageChanges {
+			account.slotWrites[sc.Slot] = i
 		}
 	}
-	return false
 }
 
 func removeStorageRead(ac *types.AccountChanges, slot accounts.StorageKey) {

--- a/execution/state/versionedio_bench_test.go
+++ b/execution/state/versionedio_bench_test.go
@@ -1,0 +1,121 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"fmt"
+	"math/big"
+	"slices"
+	"testing"
+
+	"github.com/holiman/uint256"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+// BenchmarkBALReadsThenWrites is the shape removeStorageRead is quadratic in:
+// an account accumulates reads, then writes disjoint slots, and every write
+// used to rescan the whole read list.
+func BenchmarkBALReadsThenWrites(b *testing.B) {
+	addr := accounts.InternAddress(common.HexToAddress("0xbeef"))
+	val := *uint256.NewInt(1)
+	for _, n := range []int{64, 512, 4096} {
+		reads := make([]accounts.StorageKey, n)
+		writes := make([]accounts.StorageKey, n)
+		for i := range reads {
+			reads[i] = accounts.InternKey(common.BigToHash(new(big.Int).SetInt64(int64(i))))
+			writes[i] = accounts.InternKey(common.BigToHash(new(big.Int).SetInt64(int64(i + 1<<20))))
+		}
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				account := newAccountState(addr)
+				for _, k := range reads {
+					account.updateReadStorage(k, uint256.Int{})
+				}
+				for i, k := range writes {
+					account.applyWriteStorage(k, val, uint32(i))
+				}
+			}
+			b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*n), "ns/slot")
+		})
+	}
+}
+
+// BenchmarkBALAccounts covers the other shape of a block: many accounts, few
+// slots each. It ends where asBlockAccessList does, with the encoded list
+// assembled and ordered.
+func BenchmarkBALAccounts(b *testing.B) {
+	const slotsPerAccount = 4
+	for _, nAccounts := range []int{64, 1024, 8192} {
+		addrs := make([]accounts.Address, nAccounts)
+		for i := range addrs {
+			addrs[i] = accounts.InternAddress(common.BigToAddress(new(big.Int).SetInt64(int64(i))))
+		}
+		keys := make([]accounts.StorageKey, slotsPerAccount)
+		for i := range keys {
+			keys[i] = accounts.InternKey(common.BigToHash(new(big.Int).SetInt64(int64(i))))
+		}
+		val := *uint256.NewInt(1)
+		b.Run(fmt.Sprintf("accounts=%d", nAccounts), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				bal := make(types.BlockAccessList, 0, nAccounts)
+				for _, addr := range addrs {
+					account := newAccountState(addr)
+					for i, k := range keys {
+						account.updateReadStorage(k, uint256.Int{})
+						account.applyWriteStorage(k, val, uint32(i))
+					}
+					account.finalize()
+					account.changes.Normalize()
+					bal = append(bal, *account.changes)
+				}
+				slices.SortFunc(bal, func(a, b types.AccountChanges) int { return a.Address.Cmp(b.Address) })
+			}
+			b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*nAccounts), "ns/account")
+		})
+	}
+}
+
+// BenchmarkAccountStateStorageWrites drives the EIP-7928 BAL builder the way a
+// storage-bloated block does: one account, many distinct slots, each read then
+// written once. The per-slot work must not grow with the number of slots
+// already recorded for the account.
+func BenchmarkAccountStateStorageWrites(b *testing.B) {
+	addr := accounts.InternAddress(common.HexToAddress("0xbeef"))
+	val := *uint256.NewInt(1)
+	for _, slots := range []int{4, 64, 512, 4096, 32768} {
+		keys := make([]accounts.StorageKey, slots)
+		for i := range keys {
+			keys[i] = accounts.InternKey(common.BigToHash(new(big.Int).SetInt64(int64(i))))
+		}
+		b.Run(fmt.Sprintf("slots=%d", slots), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				account := newAccountState(addr)
+				for i, k := range keys {
+					account.updateReadStorage(k, uint256.Int{})
+					account.applyWriteStorage(k, val, uint32(i))
+				}
+			}
+			b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*slots), "ns/slot")
+		})
+	}
+}

--- a/execution/state/versionedio_test.go
+++ b/execution/state/versionedio_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"math/rand"
 	"slices"
 	"sort"
 	"testing"
@@ -1751,6 +1752,106 @@ func TestAccountState_IndexCrossoverKeepsSlotsFindable(t *testing.T) {
 		require.NotContains(t, changes.StorageReads, slot, "a write supersedes the recorded read")
 	}
 	require.Len(t, changes.StorageReads, 4*slotIndexMin)
+}
+
+// TestAccountState_MatchesReferenceBuilder fuzzes read/write sequences that
+// cross slotIndexMin in both lists and compares the normalized result against a
+// straightforward builder. The indexes are pure bookkeeping, so any divergence
+// is a bug in them.
+func TestAccountState_MatchesReferenceBuilder(t *testing.T) {
+	addr := accounts.InternAddress(common.HexToAddress("0xbeef"))
+	r := rand.New(rand.NewSource(11))
+	for range 300 {
+		nSlots := 1 + r.Intn(4*slotIndexMin)
+		keys := make([]accounts.StorageKey, nSlots)
+		for i := range keys {
+			keys[i] = accounts.InternKey(common.BigToHash(new(big.Int).SetInt64(int64(i))))
+		}
+
+		account := newAccountState(addr)
+		ref := newReferenceAccount(addr)
+		for op := range 4 * nSlots {
+			k := keys[r.Intn(nSlots)]
+			v := *uint256.NewInt(uint64(r.Intn(3)))
+			if r.Intn(2) == 0 {
+				account.updateReadStorage(k, v)
+				ref.read(k, v)
+				continue
+			}
+			account.applyWriteStorage(k, v, uint32(op))
+			ref.write(k, v, uint32(op))
+		}
+
+		got, want := account.changes, ref.changes
+		got.Normalize()
+		want.Normalize()
+		require.Equal(t, want.StorageReads, got.StorageReads, "slots=%d", nSlots)
+		require.Equal(t, want.StorageChanges, got.StorageChanges, "slots=%d", nSlots)
+	}
+}
+
+// referenceAccount is the BAL storage bookkeeping written the obvious way.
+type referenceAccount struct {
+	changes  *types.AccountChanges
+	origVals map[accounts.StorageKey]uint256.Int
+}
+
+func newReferenceAccount(addr accounts.Address) *referenceAccount {
+	return &referenceAccount{
+		changes:  &types.AccountChanges{Address: addr},
+		origVals: map[accounts.StorageKey]uint256.Int{},
+	}
+}
+
+func (a *referenceAccount) written(slot accounts.StorageKey) int {
+	for i := range a.changes.StorageChanges {
+		if a.changes.StorageChanges[i].Slot == slot {
+			return i
+		}
+	}
+	return -1
+}
+
+func (a *referenceAccount) read(slot accounts.StorageKey, val uint256.Int) {
+	if _, seen := a.origVals[slot]; !seen {
+		a.origVals[slot] = val
+	}
+	if a.written(slot) >= 0 {
+		return
+	}
+	a.changes.StorageReads = append(a.changes.StorageReads, slot)
+}
+
+func (a *referenceAccount) write(slot accounts.StorageKey, val uint256.Int, idx uint32) {
+	at := a.written(slot)
+	if at < 0 {
+		if orig, seen := a.origVals[slot]; seen && val.Eq(&orig) {
+			return
+		}
+	}
+	kept := a.changes.StorageReads[:0]
+	for _, s := range a.changes.StorageReads {
+		if s != slot {
+			kept = append(kept, s)
+		}
+	}
+	if len(kept) == 0 {
+		a.changes.StorageReads = nil
+	} else {
+		a.changes.StorageReads = kept
+	}
+	if at >= 0 {
+		changes := a.changes.StorageChanges[at].Changes
+		if n := len(changes); n > 0 && val.Eq(&changes[n-1].Value) {
+			return
+		}
+		a.changes.StorageChanges[at].Changes = append(changes, &types.StorageChange{Index: idx, Value: val})
+		return
+	}
+	a.changes.StorageChanges = append(a.changes.StorageChanges, types.SlotChanges{
+		Slot:    slot,
+		Changes: []*types.StorageChange{{Index: idx, Value: val}},
+	})
 }
 
 // BenchmarkBALReadsThenWrites is the shape removeStorageRead is quadratic in:

--- a/execution/state/versionedio_test.go
+++ b/execution/state/versionedio_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand"
-	"slices"
 	"sort"
 	"testing"
 
@@ -1852,95 +1851,4 @@ func (a *referenceAccount) write(slot accounts.StorageKey, val uint256.Int, idx 
 		Slot:    slot,
 		Changes: []*types.StorageChange{{Index: idx, Value: val}},
 	})
-}
-
-// BenchmarkBALReadsThenWrites is the shape removeStorageRead is quadratic in:
-// an account accumulates reads, then writes disjoint slots, and every write
-// used to rescan the whole read list.
-func BenchmarkBALReadsThenWrites(b *testing.B) {
-	addr := accounts.InternAddress(common.HexToAddress("0xbeef"))
-	val := *uint256.NewInt(1)
-	for _, n := range []int{64, 512, 4096} {
-		reads := make([]accounts.StorageKey, n)
-		writes := make([]accounts.StorageKey, n)
-		for i := range reads {
-			reads[i] = accounts.InternKey(common.BigToHash(new(big.Int).SetInt64(int64(i))))
-			writes[i] = accounts.InternKey(common.BigToHash(new(big.Int).SetInt64(int64(i + 1<<20))))
-		}
-		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
-			b.ReportAllocs()
-			for b.Loop() {
-				account := newAccountState(addr)
-				for _, k := range reads {
-					account.updateReadStorage(k, uint256.Int{})
-				}
-				for i, k := range writes {
-					account.applyWriteStorage(k, val, uint32(i))
-				}
-			}
-			b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*n), "ns/slot")
-		})
-	}
-}
-
-// BenchmarkBALAccounts covers the other shape of a block: many accounts, few
-// slots each. It ends where asBlockAccessList does, with the encoded list
-// assembled and ordered.
-func BenchmarkBALAccounts(b *testing.B) {
-	const slotsPerAccount = 4
-	for _, nAccounts := range []int{64, 1024, 8192} {
-		addrs := make([]accounts.Address, nAccounts)
-		for i := range addrs {
-			addrs[i] = accounts.InternAddress(common.BigToAddress(new(big.Int).SetInt64(int64(i))))
-		}
-		keys := make([]accounts.StorageKey, slotsPerAccount)
-		for i := range keys {
-			keys[i] = accounts.InternKey(common.BigToHash(new(big.Int).SetInt64(int64(i))))
-		}
-		val := *uint256.NewInt(1)
-		b.Run(fmt.Sprintf("accounts=%d", nAccounts), func(b *testing.B) {
-			b.ReportAllocs()
-			for b.Loop() {
-				bal := make(types.BlockAccessList, 0, nAccounts)
-				for _, addr := range addrs {
-					account := newAccountState(addr)
-					for i, k := range keys {
-						account.updateReadStorage(k, uint256.Int{})
-						account.applyWriteStorage(k, val, uint32(i))
-					}
-					account.finalize()
-					account.changes.Normalize()
-					bal = append(bal, *account.changes)
-				}
-				slices.SortFunc(bal, func(a, b types.AccountChanges) int { return a.Address.Cmp(b.Address) })
-			}
-			b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*nAccounts), "ns/account")
-		})
-	}
-}
-
-// BenchmarkAccountStateStorageWrites drives the EIP-7928 BAL builder the way a
-// storage-bloated block does: one account, many distinct slots, each read then
-// written once. The per-slot work must not grow with the number of slots
-// already recorded for the account.
-func BenchmarkAccountStateStorageWrites(b *testing.B) {
-	addr := accounts.InternAddress(common.HexToAddress("0xbeef"))
-	val := *uint256.NewInt(1)
-	for _, slots := range []int{4, 64, 512, 4096, 32768} {
-		keys := make([]accounts.StorageKey, slots)
-		for i := range keys {
-			keys[i] = accounts.InternKey(common.BigToHash(new(big.Int).SetInt64(int64(i))))
-		}
-		b.Run(fmt.Sprintf("slots=%d", slots), func(b *testing.B) {
-			b.ReportAllocs()
-			for b.Loop() {
-				account := newAccountState(addr)
-				for i, k := range keys {
-					account.updateReadStorage(k, uint256.Int{})
-					account.applyWriteStorage(k, val, uint32(i))
-				}
-			}
-			b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*slots), "ns/slot")
-		})
-	}
 }

--- a/execution/state/versionedio_test.go
+++ b/execution/state/versionedio_test.go
@@ -19,6 +19,7 @@ package state
 import (
 	"errors"
 	"fmt"
+	"math/big"
 	"sort"
 	"testing"
 
@@ -1708,4 +1709,64 @@ func TestVersionedIO_MidBlockEmptyCodeHashReadMustNotDropRealClear(t *testing.T)
 		}
 	}
 	require.True(t, found, "authority account must appear in BAL")
+}
+
+// Slots recorded on either side of the slotIndexMin crossover must stay
+// findable: a missed index entry opens a second SlotChanges for the same slot,
+// and the BAL then carries it twice.
+func TestAddStorageUpdate_IndexCrossoverFindsSlots(t *testing.T) {
+	addr := accounts.InternAddress(common.HexToAddress("0xbeef"))
+	account := &accountState{changes: &types.AccountChanges{Address: addr}}
+	key := func(n int64) accounts.StorageKey {
+		return accounts.InternKey(common.BigToHash(new(big.Int).SetInt64(n)))
+	}
+
+	early := key(1)
+	account.applyWriteStorage(early, *uint256.NewInt(1), 0)
+	for i := range 4 * slotIndexMin {
+		account.applyWriteStorage(key(int64(i+100)), *uint256.NewInt(1), uint32(i))
+	}
+	require.NotNil(t, account.slotWrites, "the index must be built past the threshold")
+	late := key(9999)
+	account.applyWriteStorage(late, *uint256.NewInt(1), 50)
+
+	account.applyWriteStorage(early, *uint256.NewInt(2), 98)
+	account.applyWriteStorage(late, *uint256.NewInt(2), 99)
+
+	for _, slot := range []accounts.StorageKey{early, late} {
+		seen := 0
+		for _, sc := range account.changes.StorageChanges {
+			if sc.Slot == slot {
+				seen++
+				require.Len(t, sc.Changes, 2, "the second write must append to the existing slot")
+			}
+		}
+		require.Equal(t, 1, seen, "the slot must appear exactly once")
+	}
+}
+
+// BenchmarkAccountStateStorageWrites drives the EIP-7928 BAL builder the way a
+// storage-bloated block does: one account, many distinct slots, each read then
+// written once. The per-slot work must not grow with the number of slots
+// already recorded for the account.
+func BenchmarkAccountStateStorageWrites(b *testing.B) {
+	addr := accounts.InternAddress(common.HexToAddress("0xbeef"))
+	val := *uint256.NewInt(1)
+	for _, slots := range []int{4, 64, 512, 4096} {
+		keys := make([]accounts.StorageKey, slots)
+		for i := range keys {
+			keys[i] = accounts.InternKey(common.BigToHash(new(big.Int).SetInt64(int64(i))))
+		}
+		b.Run(fmt.Sprintf("slots=%d", slots), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				account := &accountState{changes: &types.AccountChanges{Address: addr}}
+				for i, k := range keys {
+					account.updateReadStorage(k, uint256.Int{})
+					account.applyWriteStorage(k, val, uint32(i))
+				}
+			}
+			b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*slots), "ns/slot")
+		})
+	}
 }

--- a/execution/state/versionedio_test.go
+++ b/execution/state/versionedio_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"slices"
 	"sort"
 	"testing"
 
@@ -1186,24 +1187,24 @@ func TestVersionedRead_EIP8246_PriorTxSelfDestructReadsAsPreserved(t *testing.T)
 }
 
 // EIP-7928 net-zero guard: a slot that is read and then written back to the
-// same value must stay a read in the BAL, not become a write. The filter
-// lives in accountState.applyWriteStorage (the helper addStorageUpdate only
-// appends). This locks the behaviour down across the typed-vio refactor.
+// same value must stay a read in the BAL, not become a write. The filter lives
+// in accountState.applyWriteStorage.
 func TestUpdateWrite_StorageReadThenWriteBackSameValue_StaysRead(t *testing.T) {
 	addr := accounts.InternAddress(common.HexToAddress("0xbeef"))
 	slot := accounts.InternKey(common.HexToHash("0x07"))
 	orig := *uint256.NewInt(42)
 
-	account := &accountState{changes: &types.AccountChanges{Address: addr}}
+	account := newAccountState(addr)
 
 	account.updateReadStorage(slot, orig)
 	require.Contains(t, account.changes.StorageReads, slot, "the read must be recorded")
 
 	account.applyWriteStorage(slot, orig, 0)
 
-	require.Empty(t, account.changes.StorageChanges,
+	changes := account.changes
+	require.Empty(t, changes.StorageChanges,
 		"write-back to the originally-read value is net-zero and must NOT be recorded as a storage write")
-	require.Contains(t, account.changes.StorageReads, slot,
+	require.Contains(t, changes.StorageReads, slot,
 		"the net-zero write-back must remain a read")
 }
 
@@ -1215,16 +1216,17 @@ func TestUpdateWrite_StorageReadThenWriteDifferentValue_BecomesWrite(t *testing.
 	orig := *uint256.NewInt(42)
 	changed := *uint256.NewInt(99)
 
-	account := &accountState{changes: &types.AccountChanges{Address: addr}}
+	account := newAccountState(addr)
 
 	account.updateReadStorage(slot, orig)
 
 	account.applyWriteStorage(slot, changed, 0)
 
-	require.Len(t, account.changes.StorageChanges, 1,
+	changes := account.changes
+	require.Len(t, changes.StorageChanges, 1,
 		"a write to a different value is a real state change and must be recorded")
-	require.Equal(t, slot, account.changes.StorageChanges[0].Slot)
-	require.NotContains(t, account.changes.StorageReads, slot,
+	require.Equal(t, slot, changes.StorageChanges[0].Slot)
+	require.NotContains(t, changes.StorageReads, slot,
 		"a real write supersedes the recorded read")
 }
 
@@ -1712,11 +1714,11 @@ func TestVersionedIO_MidBlockEmptyCodeHashReadMustNotDropRealClear(t *testing.T)
 }
 
 // Slots recorded on either side of the slotIndexMin crossover must stay
-// findable: a missed index entry opens a second SlotChanges for the same slot,
-// and the BAL then carries it twice.
-func TestAddStorageUpdate_IndexCrossoverFindsSlots(t *testing.T) {
+// findable, in both directions: a missed write index opens a second SlotChanges
+// for the same slot, and a missed read index leaves a superseded read behind.
+func TestAccountState_IndexCrossoverKeepsSlotsFindable(t *testing.T) {
 	addr := accounts.InternAddress(common.HexToAddress("0xbeef"))
-	account := &accountState{changes: &types.AccountChanges{Address: addr}}
+	account := newAccountState(addr)
 	key := func(n int64) accounts.StorageKey {
 		return accounts.InternKey(common.BigToHash(new(big.Int).SetInt64(n)))
 	}
@@ -1724,24 +1726,95 @@ func TestAddStorageUpdate_IndexCrossoverFindsSlots(t *testing.T) {
 	early := key(1)
 	account.applyWriteStorage(early, *uint256.NewInt(1), 0)
 	for i := range 4 * slotIndexMin {
+		account.updateReadStorage(key(int64(i+1000)), uint256.Int{})
 		account.applyWriteStorage(key(int64(i+100)), *uint256.NewInt(1), uint32(i))
 	}
 	require.NotNil(t, account.slotWrites, "the index must be built past the threshold")
-	late := key(9999)
-	account.applyWriteStorage(late, *uint256.NewInt(1), 50)
+	require.NotNil(t, account.slotReads)
 
+	late := key(9999)
+	account.updateReadStorage(late, uint256.Int{})
+	account.applyWriteStorage(late, *uint256.NewInt(1), 50)
 	account.applyWriteStorage(early, *uint256.NewInt(2), 98)
 	account.applyWriteStorage(late, *uint256.NewInt(2), 99)
 
+	changes := account.changes
 	for _, slot := range []accounts.StorageKey{early, late} {
 		seen := 0
-		for _, sc := range account.changes.StorageChanges {
+		for _, sc := range changes.StorageChanges {
 			if sc.Slot == slot {
 				seen++
 				require.Len(t, sc.Changes, 2, "the second write must append to the existing slot")
 			}
 		}
 		require.Equal(t, 1, seen, "the slot must appear exactly once")
+		require.NotContains(t, changes.StorageReads, slot, "a write supersedes the recorded read")
+	}
+	require.Len(t, changes.StorageReads, 4*slotIndexMin)
+}
+
+// BenchmarkBALReadsThenWrites is the shape removeStorageRead is quadratic in:
+// an account accumulates reads, then writes disjoint slots, and every write
+// used to rescan the whole read list.
+func BenchmarkBALReadsThenWrites(b *testing.B) {
+	addr := accounts.InternAddress(common.HexToAddress("0xbeef"))
+	val := *uint256.NewInt(1)
+	for _, n := range []int{64, 512, 4096} {
+		reads := make([]accounts.StorageKey, n)
+		writes := make([]accounts.StorageKey, n)
+		for i := range reads {
+			reads[i] = accounts.InternKey(common.BigToHash(new(big.Int).SetInt64(int64(i))))
+			writes[i] = accounts.InternKey(common.BigToHash(new(big.Int).SetInt64(int64(i + 1<<20))))
+		}
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				account := newAccountState(addr)
+				for _, k := range reads {
+					account.updateReadStorage(k, uint256.Int{})
+				}
+				for i, k := range writes {
+					account.applyWriteStorage(k, val, uint32(i))
+				}
+			}
+			b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*n), "ns/slot")
+		})
+	}
+}
+
+// BenchmarkBALAccounts covers the other shape of a block: many accounts, few
+// slots each. It ends where asBlockAccessList does, with the encoded list
+// assembled and ordered.
+func BenchmarkBALAccounts(b *testing.B) {
+	const slotsPerAccount = 4
+	for _, nAccounts := range []int{64, 1024, 8192} {
+		addrs := make([]accounts.Address, nAccounts)
+		for i := range addrs {
+			addrs[i] = accounts.InternAddress(common.BigToAddress(new(big.Int).SetInt64(int64(i))))
+		}
+		keys := make([]accounts.StorageKey, slotsPerAccount)
+		for i := range keys {
+			keys[i] = accounts.InternKey(common.BigToHash(new(big.Int).SetInt64(int64(i))))
+		}
+		val := *uint256.NewInt(1)
+		b.Run(fmt.Sprintf("accounts=%d", nAccounts), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				bal := make(types.BlockAccessList, 0, nAccounts)
+				for _, addr := range addrs {
+					account := newAccountState(addr)
+					for i, k := range keys {
+						account.updateReadStorage(k, uint256.Int{})
+						account.applyWriteStorage(k, val, uint32(i))
+					}
+					account.finalize()
+					account.changes.Normalize()
+					bal = append(bal, *account.changes)
+				}
+				slices.SortFunc(bal, func(a, b types.AccountChanges) int { return a.Address.Cmp(b.Address) })
+			}
+			b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*nAccounts), "ns/account")
+		})
 	}
 }
 
@@ -1760,7 +1833,7 @@ func BenchmarkAccountStateStorageWrites(b *testing.B) {
 		b.Run(fmt.Sprintf("slots=%d", slots), func(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
-				account := &accountState{changes: &types.AccountChanges{Address: addr}}
+				account := newAccountState(addr)
 				for i, k := range keys {
 					account.updateReadStorage(k, uint256.Int{})
 					account.applyWriteStorage(k, val, uint32(i))

--- a/execution/state/versionedio_test.go
+++ b/execution/state/versionedio_test.go
@@ -1752,7 +1752,7 @@ func TestAddStorageUpdate_IndexCrossoverFindsSlots(t *testing.T) {
 func BenchmarkAccountStateStorageWrites(b *testing.B) {
 	addr := accounts.InternAddress(common.HexToAddress("0xbeef"))
 	val := *uint256.NewInt(1)
-	for _, slots := range []int{4, 64, 512, 4096} {
+	for _, slots := range []int{4, 64, 512, 4096, 32768} {
 		keys := make([]accounts.StorageKey, slots)
 		for i := range keys {
 			keys[i] = accounts.InternKey(common.BigToHash(new(big.Int).SetInt64(int64(i))))

--- a/execution/state/versionedio_test.go
+++ b/execution/state/versionedio_test.go
@@ -1841,11 +1841,11 @@ func (a *referenceAccount) write(slot accounts.StorageKey, val uint256.Int, idx 
 		a.changes.StorageReads = kept
 	}
 	if at >= 0 {
-		changes := a.changes.StorageChanges[at].Changes
-		if n := len(changes); n > 0 && val.Eq(&changes[n-1].Value) {
+		sc := &a.changes.StorageChanges[at]
+		if n := len(sc.Changes); n > 0 && val.Eq(&sc.Changes[n-1].Value) {
 			return
 		}
-		a.changes.StorageChanges[at].Changes = append(changes, &types.StorageChange{Index: idx, Value: val})
+		sc.Changes = append(sc.Changes, &types.StorageChange{Index: idx, Value: val})
 		return
 	}
 	a.changes.StorageChanges = append(a.changes.StorageChanges, types.SlotChanges{

--- a/execution/state/versionmap.go
+++ b/execution/state/versionmap.go
@@ -165,7 +165,7 @@ type VersionMap struct {
 	trace bool
 }
 
-func NewVersionMap(changes []*types.AccountChanges) *VersionMap {
+func NewVersionMap(changes types.BlockAccessList) *VersionMap {
 	vm := &VersionMap{}
 	vm.WriteChanges(changes)
 	return vm
@@ -209,8 +209,9 @@ func (vm *VersionMap) StorageKeys(addr accounts.Address) []accounts.StorageKey {
 // type is enforced at compile time — a future BAL field-type change that
 // breaks the contract surfaces as a build error here rather than a runtime
 // panic on the first read of the cell.
-func (vm *VersionMap) WriteChanges(changes []*types.AccountChanges) {
-	for _, accountChanges := range changes {
+func (vm *VersionMap) WriteChanges(changes types.BlockAccessList) {
+	for i := range changes {
+		accountChanges := &changes[i]
 		if dbg.TraceBALFeed {
 			fmt.Printf(
 				"BAL-ACCT %x storage=%d balance=%d nonce=%d code=%d reads=%d\n",

--- a/execution/state/versionmap_test.go
+++ b/execution/state/versionmap_test.go
@@ -906,8 +906,8 @@ func TestGetVersionedAccount_SynthesizesCreatedFromBAL(t *testing.T) {
 // land, so the recorded read is non-nil and survives both validation and the
 // mid-execution dependency re-check once the creator flushes.
 func TestBALFedReaderDoesNotRaceCreatorFlush(t *testing.T) {
-	balFedChanges := func(addr accounts.Address) []*types.AccountChanges {
-		return []*types.AccountChanges{{
+	balFedChanges := func(addr accounts.Address) types.BlockAccessList {
+		return []types.AccountChanges{{
 			Address: addr,
 			BalanceChanges: []*types.BalanceChange{{
 				Index: 1,
@@ -915,8 +915,8 @@ func TestBALFedReaderDoesNotRaceCreatorFlush(t *testing.T) {
 			}},
 		}}
 	}
-	contractFedChanges := func(addr accounts.Address) []*types.AccountChanges {
-		return []*types.AccountChanges{{
+	contractFedChanges := func(addr accounts.Address) types.BlockAccessList {
+		return []types.AccountChanges{{
 			Address: addr,
 			NonceChanges: []*types.NonceChange{{
 				Index: 1,
@@ -974,7 +974,7 @@ func TestBALFedReaderDoesNotRaceCreatorFlush(t *testing.T) {
 	}
 	feeds := []struct {
 		name    string
-		changes func(accounts.Address) []*types.AccountChanges
+		changes func(accounts.Address) types.BlockAccessList
 		balance uint64
 		nonce   uint64
 	}{
@@ -1362,7 +1362,7 @@ func TestSynthesizedAccountRecordsNoIncarnationGuess(t *testing.T) {
 		}
 		return VersionInvalid
 	}
-	vm := NewVersionMap([]*types.AccountChanges{{
+	vm := NewVersionMap([]types.AccountChanges{{
 		Address:      addr,
 		NonceChanges: []*types.NonceChange{{Index: 227, Value: 1}},
 	}})
@@ -1399,7 +1399,7 @@ func TestDBLoadedAccountRecordsNoIncarnationDefault(t *testing.T) {
 	}
 	deployed := accounts.NewCode([]byte{0x60, 0x80, 0x60, 0x40})
 	reader := &codeReader{addr: addr, account: &accounts.Account{Balance: *uint256.NewInt(9), CodeHash: accounts.EmptyCodeHash}}
-	vm := NewVersionMap([]*types.AccountChanges{{
+	vm := NewVersionMap([]types.AccountChanges{{
 		Address:      addr,
 		NonceChanges: []*types.NonceChange{{Index: 227, Value: 1}},
 		CodeChanges:  []*types.CodeChange{{Index: 227, Bytecode: deployed.Bytes}},
@@ -1428,7 +1428,7 @@ func TestDBLoadedAccountRecordsNoIncarnationDefault(t *testing.T) {
 func TestBALPrePopulatesDerivedCodeCells(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xcd, 0x01})
 	bytecode := []byte{0x60, 0x00, 0x60, 0x00, 0xf3}
-	vm := NewVersionMap([]*types.AccountChanges{{
+	vm := NewVersionMap([]types.AccountChanges{{
 		Address:     addr,
 		CodeChanges: []*types.CodeChange{{Index: 3, Bytecode: bytecode}},
 	}})
@@ -1446,7 +1446,7 @@ func TestBALPrePopulatesDerivedCodeCells(t *testing.T) {
 
 func TestBALPrePopulatesDerivedCodeCells_ClearedCode(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xcd, 0x02})
-	vm := NewVersionMap([]*types.AccountChanges{{
+	vm := NewVersionMap([]types.AccountChanges{{
 		Address:     addr,
 		CodeChanges: []*types.CodeChange{{Index: 3, Bytecode: nil}},
 	}})
@@ -1500,7 +1500,7 @@ func TestAbsentConclusionThenCreatorFlushAborts(t *testing.T) {
 // EVM, so the load re-reads the fresh cells and reconciles the record.
 func TestBALFedReaderSurvivesCreatorFlushMidLoad(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xfd, 0x01})
-	vm := NewVersionMap([]*types.AccountChanges{{
+	vm := NewVersionMap([]types.AccountChanges{{
 		Address: addr,
 		NonceChanges: []*types.NonceChange{{
 			Index: 1,

--- a/execution/tests/testutil/block_test_util.go
+++ b/execution/tests/testutil/block_test_util.go
@@ -167,7 +167,7 @@ func (bal btBlockAccessList) toBAL() types.BlockAccessList {
 				Bytecode: cc.NewCode,
 			})
 		}
-		result[i] = entry
+		result[i] = *entry
 	}
 	return result
 }

--- a/execution/tests/testutil/block_test_util.go
+++ b/execution/tests/testutil/block_test_util.go
@@ -127,14 +127,14 @@ func (bal btBlockAccessList) toBAL() types.BlockAccessList {
 		ac := &bal[i]
 		entry := &types.AccountChanges{
 			Address:        accounts.InternAddress(ac.Address),
-			StorageChanges: make([]*types.SlotChanges, 0, len(ac.StorageChanges)),
+			StorageChanges: make([]types.SlotChanges, 0, len(ac.StorageChanges)),
 			StorageReads:   make([]accounts.StorageKey, 0, len(ac.StorageReads)),
 			BalanceChanges: make([]*types.BalanceChange, 0, len(ac.BalanceChanges)),
 			NonceChanges:   make([]*types.NonceChange, 0, len(ac.NonceChanges)),
 			CodeChanges:    make([]*types.CodeChange, 0, len(ac.CodeChanges)),
 		}
 		for _, sc := range ac.StorageChanges {
-			slotChanges := &types.SlotChanges{
+			slotChanges := types.SlotChanges{
 				Slot:    accounts.InternKey(common.BytesToHash(sc.Slot)),
 				Changes: make([]*types.StorageChange, 0, len(sc.SlotChanges)),
 			}

--- a/execution/types/block_access_list.go
+++ b/execution/types/block_access_list.go
@@ -24,7 +24,7 @@ import (
 	"github.com/erigontech/erigon/node/gointerfaces/typesproto"
 )
 
-type BlockAccessList []*AccountChanges
+type BlockAccessList []AccountChanges
 
 // BlockAccessListSidecar carries immutable decoded and encoded BAL representations.
 type BlockAccessListSidecar struct {
@@ -198,10 +198,8 @@ func (bal BlockAccessList) Copy() BlockAccessList {
 		return nil
 	}
 	cpy := make(BlockAccessList, len(bal))
-	for i, account := range bal {
-		if account == nil {
-			continue
-		}
+	for i := range bal {
+		account := &bal[i]
 		accountCopy := *account
 		accountCopy.StorageChanges = slices.Clone(account.StorageChanges)
 		for j := range account.StorageChanges {
@@ -238,7 +236,7 @@ func (bal BlockAccessList) Copy() BlockAccessList {
 				accountCopy.CodeChanges[j] = &changeCopy
 			}
 		}
-		cpy[i] = &accountCopy
+		cpy[i] = accountCopy
 	}
 	return cpy
 }
@@ -756,7 +754,13 @@ func decodeBlockAccessList(out *BlockAccessList, s *rlp.Stream) error {
 		*out = make(BlockAccessList, 0)
 		return nil
 	}
-	*out = changes
+	bal := make(BlockAccessList, len(changes))
+	for i, ac := range changes {
+		if ac != nil {
+			bal[i] = *ac
+		}
+	}
+	*out = bal
 	return nil
 }
 
@@ -781,10 +785,27 @@ func EncodeBlockAccessListBytes(bal BlockAccessList) ([]byte, error) {
 	var buf bytes.Buffer
 	encBuf := rlp.NewEncodingBuf()
 	defer encBuf.Release()
-	if err := encodeBlockAccessList(bal, &buf, encBuf[:]); err != nil {
+	if err := encodeAccountChanges(bal, &buf, encBuf[:]); err != nil {
 		return nil, err
 	}
 	return buf.Bytes(), nil
+}
+
+func encodeAccountChanges(list []AccountChanges, w io.Writer, b []byte) error {
+	var total int
+	for i := range list {
+		size := list[i].EncodingSize()
+		total += rlp.ListPrefixLen(size) + size
+	}
+	if err := rlp.EncodeListPrefix(total, w, b); err != nil {
+		return err
+	}
+	for i := range list {
+		if err := list[i].EncodeRLP(w); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 func decodeSlotChangesList(s *rlp.Stream) ([]*SlotChanges, error) {
 	var err error
@@ -986,10 +1007,8 @@ func (bal BlockAccessList) Validate() error {
 	}
 	var prev common.Address
 	var hasPrev bool
-	for i, account := range bal {
-		if account == nil {
-			return fmt.Errorf("entry %d is nil", i)
-		}
+	for i := range bal {
+		account := &bal[i]
 		address := account.Address.Value()
 		if hasPrev && bytes.Compare(prev[:], address[:]) >= 0 {
 			return fmt.Errorf("account addresses must be strictly increasing (index %d)", i)
@@ -1173,11 +1192,8 @@ func (bal BlockAccessList) DebugString() string {
 
 func (bal BlockAccessList) DebugPrint(w io.Writer) {
 	fmt.Fprintf(w, "accounts=%d", len(bal))
-	for i, account := range bal {
-		if account == nil {
-			fmt.Fprintf(w, "\n[%d] <nil>", i)
-			continue
-		}
+	for i := range bal {
+		account := &bal[i]
 		fmt.Fprintf(w, "\n[%d] addr=%s", i, account.Address.Value().Hex())
 		if len(account.StorageChanges) > 0 {
 			fmt.Fprint(w, "\n  storageChanges:")
@@ -1259,7 +1275,7 @@ func ConvertBlockAccessListFromTypesProto(protoList []*typesproto.BlockAccessLis
 	}
 	bal := make(BlockAccessList, len(protoList))
 	for i, acc := range protoList {
-		bal[i] = &AccountChanges{
+		bal[i] = AccountChanges{
 			Address: accounts.InternAddress(gointerfaces.ConvertH160toAddress(acc.Address)),
 		}
 		if acc.StorageChanges != nil {
@@ -1327,10 +1343,8 @@ func ConvertBlockAccessListToTypesProto(bal BlockAccessList) []*typesproto.Block
 		return nil
 	}
 	out := make([]*typesproto.BlockAccessListAccount, 0, len(bal))
-	for _, account := range bal {
-		if account == nil {
-			continue
-		}
+	for ai := range bal {
+		account := &bal[ai]
 		balAccount := &typesproto.BlockAccessListAccount{
 			Address: gointerfaces.ConvertAddressToH160(account.Address.Value()),
 		}
@@ -1409,10 +1423,8 @@ func ConvertBlockAccessListToExecutionProto(bal BlockAccessList) []*executionpro
 		return nil
 	}
 	out := make([]*executionproto.BlockAccessListAccount, 0, len(bal))
-	for _, account := range bal {
-		if account == nil {
-			continue
-		}
+	for ai := range bal {
+		account := &bal[ai]
 		rpcAccount := &executionproto.BlockAccessListAccount{
 			Address: gointerfaces.ConvertAddressToH160(account.Address.Value()),
 		}
@@ -1551,7 +1563,7 @@ func ConvertExecutionProtoToBlockAccessList(protoList []*executionproto.BlockAcc
 				Bytecode: data,
 			})
 		}
-		out = append(out, accountChanges)
+		out = append(out, *accountChanges)
 	}
 	if err := out.Validate(); err != nil {
 		return nil, fmt.Errorf("blockAccessList validate: %w", err)

--- a/execution/types/block_access_list.go
+++ b/execution/types/block_access_list.go
@@ -160,7 +160,7 @@ const (
 
 type AccountChanges struct {
 	Address        accounts.Address
-	StorageChanges []*SlotChanges
+	StorageChanges []SlotChanges
 	StorageReads   []accounts.StorageKey
 	BalanceChanges []*BalanceChange
 	NonceChanges   []*NonceChange
@@ -204,19 +204,16 @@ func (bal BlockAccessList) Copy() BlockAccessList {
 		}
 		accountCopy := *account
 		accountCopy.StorageChanges = slices.Clone(account.StorageChanges)
-		for j, slot := range account.StorageChanges {
-			if slot == nil {
-				continue
-			}
-			slotCopy := *slot
-			slotCopy.Changes = make([]*StorageChange, len(slot.Changes))
+		for j := range account.StorageChanges {
+			slot := &account.StorageChanges[j]
+			changes := make([]*StorageChange, len(slot.Changes))
 			for k, change := range slot.Changes {
 				if change != nil {
 					changeCopy := *change
-					slotCopy.Changes[k] = &changeCopy
+					changes[k] = &changeCopy
 				}
 			}
-			accountCopy.StorageChanges[j] = &slotCopy
+			accountCopy.StorageChanges[j].Changes = changes
 		}
 		accountCopy.StorageReads = slices.Clone(account.StorageReads)
 		accountCopy.BalanceChanges = slices.Clone(account.BalanceChanges)
@@ -258,9 +255,31 @@ func (nc *NonceChange) GetIndex() uint32   { return nc.Index }
 func (cc *CodeChange) GetIndex() uint32    { return cc.Index }
 func (sc *StorageChange) GetIndex() uint32 { return sc.Index }
 
+func encodingSizeSlotChanges(list []SlotChanges) int {
+	size := 0
+	for i := range list {
+		s := list[i].EncodingSize()
+		size += rlp.ListPrefixLen(s) + s
+	}
+	return size
+}
+
+func encodeSlotChanges(list []SlotChanges, w io.Writer, b []byte) error {
+	total := encodingSizeSlotChanges(list)
+	if err := rlp.EncodeListPrefix(total, w, b); err != nil {
+		return err
+	}
+	for i := range list {
+		if err := list[i].EncodeRLP(w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (ac *AccountChanges) EncodingSize() int {
 	size := 21 // address (1 prefix + 20 bytes)
-	storageChangesLen := encodingSizeBlockAccessList(ac.StorageChanges)
+	storageChangesLen := encodingSizeSlotChanges(ac.StorageChanges)
 	size += rlp.ListPrefixLen(storageChangesLen) + storageChangesLen
 	storageReadsLen := encodingSizeHashList(ac.StorageReads)
 	balanceChangesLen := encodingSizeBlockAccessList(ac.BalanceChanges)
@@ -291,7 +310,7 @@ func (ac *AccountChanges) EncodeRLP(w io.Writer) error {
 		return err
 	}
 
-	if err := encodeBlockAccessList(ac.StorageChanges, w, b[:]); err != nil {
+	if err := encodeSlotChanges(ac.StorageChanges, w, b[:]); err != nil {
 		return err
 	}
 	if err := encodeHashList(ac.StorageReads, w, b[:]); err != nil {
@@ -322,7 +341,14 @@ func (ac *AccountChanges) DecodeRLP(s *rlp.Stream) error {
 	if err != nil {
 		return err
 	}
-	ac.StorageChanges = list
+	if len(list) > 0 {
+		ac.StorageChanges = make([]SlotChanges, len(list))
+		for i, sc := range list {
+			if sc != nil {
+				ac.StorageChanges[i] = *sc
+			}
+		}
+	}
 
 	reads, err := decodeStorageKeys(s)
 	if err != nil {
@@ -353,15 +379,15 @@ func (ac *AccountChanges) DecodeRLP(s *rlp.Stream) error {
 
 func (ac *AccountChanges) Normalize() {
 	if len(ac.StorageChanges) > 1 {
-		slices.SortFunc(ac.StorageChanges, func(a, b *SlotChanges) int {
+		slices.SortFunc(ac.StorageChanges, func(a, b SlotChanges) int {
 			return a.Slot.Cmp(b.Slot)
 		})
 	}
 
-	for _, slotChange := range ac.StorageChanges {
-		if len(slotChange.Changes) > 1 {
-			sortByIndex(slotChange.Changes)
-			slotChange.Changes = dedupByIndex(slotChange.Changes)
+	for i := range ac.StorageChanges {
+		if len(ac.StorageChanges[i].Changes) > 1 {
+			sortByIndex(ac.StorageChanges[i].Changes)
+			ac.StorageChanges[i].Changes = dedupByIndex(ac.StorageChanges[i].Changes)
 		}
 	}
 
@@ -1009,7 +1035,7 @@ func (ac *AccountChanges) validate() error {
 	if ac == nil {
 		return errors.New("nil account changes")
 	}
-	if err := validateSlotChangeList(ac.StorageChanges); err != nil {
+	if err := validateSlotChanges(ac.StorageChanges); err != nil {
 		return fmt.Errorf("storage_changes: %w", err)
 	}
 	if err := validateStorageReads(ac.StorageReads); err != nil {
@@ -1116,18 +1142,15 @@ func validateHashOrdering(hashes []accounts.StorageKey, maxCount int, typeName s
 }
 
 // validateSlotChangeList validates a slice of SlotChanges with hash ordering and nil checks
-func validateSlotChangeList(slots []*SlotChanges) error {
+func validateSlotChanges(slots []SlotChanges) error {
 	if len(slots) == 0 {
 		return nil
 	}
 	if len(slots) > maxSlotChangesPerAccount {
 		return fmt.Errorf("too many storage slot entries (%d > %d)", len(slots), maxSlotChangesPerAccount)
 	}
-	for i, slot := range slots {
-		if slot == nil {
-			return fmt.Errorf("entry %d is nil", i)
-		}
-		if err := validateStorageChangeEntries(slot.Changes); err != nil {
+	for i := range slots {
+		if err := validateStorageChangeEntries(slots[i].Changes); err != nil {
 			return fmt.Errorf("entry %d: %w", i, err)
 		}
 	}
@@ -1240,9 +1263,9 @@ func ConvertBlockAccessListFromTypesProto(protoList []*typesproto.BlockAccessLis
 			Address: accounts.InternAddress(gointerfaces.ConvertH160toAddress(acc.Address)),
 		}
 		if acc.StorageChanges != nil {
-			bal[i].StorageChanges = make([]*SlotChanges, len(acc.StorageChanges))
+			bal[i].StorageChanges = make([]SlotChanges, len(acc.StorageChanges))
 			for j, sc := range acc.StorageChanges {
-				bal[i].StorageChanges[j] = &SlotChanges{
+				bal[i].StorageChanges[j] = SlotChanges{
 					Slot: accounts.InternKey(gointerfaces.ConvertH256ToHash(sc.Slot)),
 				}
 				if sc.Changes != nil {
@@ -1311,10 +1334,8 @@ func ConvertBlockAccessListToTypesProto(bal BlockAccessList) []*typesproto.Block
 		balAccount := &typesproto.BlockAccessListAccount{
 			Address: gointerfaces.ConvertAddressToH160(account.Address.Value()),
 		}
-		for _, storageChange := range account.StorageChanges {
-			if storageChange == nil {
-				continue
-			}
+		for si := range account.StorageChanges {
+			storageChange := &account.StorageChanges[si]
 			slotChanges := &typesproto.BlockAccessListSlotChanges{
 				Slot: gointerfaces.ConvertHashToH256(storageChange.Slot.Value()),
 			}
@@ -1395,10 +1416,8 @@ func ConvertBlockAccessListToExecutionProto(bal BlockAccessList) []*executionpro
 		rpcAccount := &executionproto.BlockAccessListAccount{
 			Address: gointerfaces.ConvertAddressToH160(account.Address.Value()),
 		}
-		for _, storageChange := range account.StorageChanges {
-			if storageChange == nil {
-				continue
-			}
+		for si := range account.StorageChanges {
+			storageChange := &account.StorageChanges[si]
 			slotChanges := &executionproto.BlockAccessListSlotChanges{
 				Slot: gointerfaces.ConvertHashToH256(storageChange.Slot.Value()),
 			}
@@ -1488,7 +1507,7 @@ func ConvertExecutionProtoToBlockAccessList(protoList []*executionproto.BlockAcc
 					Value: *val,
 				})
 			}
-			accountChanges.StorageChanges = append(accountChanges.StorageChanges, slotChanges)
+			accountChanges.StorageChanges = append(accountChanges.StorageChanges, *slotChanges)
 		}
 		for readIdx, read := range account.StorageReads {
 			if read == nil {

--- a/execution/types/block_access_list.go
+++ b/execution/types/block_access_list.go
@@ -1160,7 +1160,6 @@ func validateHashOrdering(hashes []accounts.StorageKey, maxCount int, typeName s
 	return nil
 }
 
-// validateSlotChangeList validates a slice of SlotChanges with hash ordering and nil checks
 func validateSlotChanges(slots []SlotChanges) error {
 	if len(slots) == 0 {
 		return nil

--- a/execution/types/block_access_list.go
+++ b/execution/types/block_access_list.go
@@ -1039,10 +1039,10 @@ func (bal BlockAccessList) ValidateForBlock(gasLimit uint64) error {
 func (bal BlockAccessList) ValidateMaxItems(blockGasLimit uint64) error {
 	maxItems := blockGasLimit / BalItemCost
 	var items uint64
-	for _, ac := range bal {
+	for i := range bal {
 		items++ // each address counts as 1 item
-		items += uint64(len(ac.StorageChanges))
-		items += uint64(len(ac.StorageReads))
+		items += uint64(len(bal[i].StorageChanges))
+		items += uint64(len(bal[i].StorageReads))
 	}
 	if items > maxItems {
 		return fmt.Errorf("block access list too large: %d items > %d max (gas limit %d / %d)", items, maxItems, blockGasLimit, BalItemCost)

--- a/execution/types/block_access_list.go
+++ b/execution/types/block_access_list.go
@@ -339,6 +339,7 @@ func (ac *AccountChanges) DecodeRLP(s *rlp.Stream) error {
 	if err != nil {
 		return err
 	}
+	ac.StorageChanges = nil
 	if len(list) > 0 {
 		ac.StorageChanges = make([]SlotChanges, len(list))
 		for i, sc := range list {

--- a/execution/types/block_access_list_test.go
+++ b/execution/types/block_access_list_test.go
@@ -19,7 +19,7 @@ import (
 func TestBlockAccessListCopy(t *testing.T) {
 	bal := BlockAccessList{{
 		Address: accounts.InternAddress(common.Address{1}),
-		StorageChanges: []*SlotChanges{{
+		StorageChanges: []SlotChanges{{
 			Slot:    accounts.InternKey(common.Hash{2}),
 			Changes: []*StorageChange{{Index: 1, Value: *uint256.NewInt(3)}},
 		}},
@@ -33,7 +33,7 @@ func TestBlockAccessListCopy(t *testing.T) {
 	if !reflect.DeepEqual(bal, cpy) {
 		t.Fatalf("copy differs: got %v, want %v", cpy, bal)
 	}
-	if bal[0] == cpy[0] || bal[0].StorageChanges[0] == cpy[0].StorageChanges[0] ||
+	if bal[0] == cpy[0] || &bal[0].StorageChanges[0] == &cpy[0].StorageChanges[0] ||
 		bal[0].StorageChanges[0].Changes[0] == cpy[0].StorageChanges[0].Changes[0] ||
 		bal[0].BalanceChanges[0] == cpy[0].BalanceChanges[0] ||
 		bal[0].NonceChanges[0] == cpy[0].NonceChanges[0] ||
@@ -255,7 +255,7 @@ func TestBlockAccessListCodecLeavesSemanticValidationToValidateForBlock(t *testi
 			name: "empty slot changes",
 			bal: BlockAccessList{{
 				Address: accounts.InternAddress(common.Address{1}),
-				StorageChanges: []*SlotChanges{{
+				StorageChanges: []SlotChanges{{
 					Slot: accounts.InternKey(common.Hash{1}),
 				}},
 			}},
@@ -299,17 +299,10 @@ func TestEncodeBlockAccessListRejectsNestedNil(t *testing.T) {
 		bal  BlockAccessList
 	}{
 		{
-			name: "slot changes",
-			bal: BlockAccessList{{
-				Address:        accounts.InternAddress(common.Address{1}),
-				StorageChanges: []*SlotChanges{nil},
-			}},
-		},
-		{
 			name: "storage change",
 			bal: BlockAccessList{{
 				Address: accounts.InternAddress(common.Address{1}),
-				StorageChanges: []*SlotChanges{{
+				StorageChanges: []SlotChanges{{
 					Slot:    accounts.InternKey(common.Hash{1}),
 					Changes: []*StorageChange{nil},
 				}},
@@ -350,7 +343,7 @@ func TestBlockAccessListRLPEncoding(t *testing.T) {
 	bal := BlockAccessList{
 		{
 			Address: accounts.InternAddress(common.HexToAddress("0x00000000000000000000000000000000000000aa")),
-			StorageChanges: []*SlotChanges{
+			StorageChanges: []SlotChanges{
 				{
 					Slot: accounts.InternKey(common.HexToHash("0x01")),
 					Changes: []*StorageChange{
@@ -442,7 +435,7 @@ func TestBlockAccessListSlotUniqueness(t *testing.T) {
 
 	ac := &AccountChanges{
 		Address: accounts.InternAddress(addr),
-		StorageChanges: []*SlotChanges{
+		StorageChanges: []SlotChanges{
 			{
 				Slot:    accounts.InternKey(slot),
 				Changes: []*StorageChange{{Index: 0, Value: *uint256.NewInt(1)}},
@@ -557,7 +550,7 @@ func TestBlockAccessListRejectsEmptySlotChanges(t *testing.T) {
 
 	ac := &AccountChanges{
 		Address: accounts.InternAddress(addr),
-		StorageChanges: []*SlotChanges{
+		StorageChanges: []SlotChanges{
 			{
 				Slot:    accounts.InternKey(slot),
 				Changes: []*StorageChange{}, // Intentionally empty list

--- a/execution/types/block_access_list_test.go
+++ b/execution/types/block_access_list_test.go
@@ -33,7 +33,7 @@ func TestBlockAccessListCopy(t *testing.T) {
 	if !reflect.DeepEqual(bal, cpy) {
 		t.Fatalf("copy differs: got %v, want %v", cpy, bal)
 	}
-	if bal[0] == cpy[0] || &bal[0].StorageChanges[0] == &cpy[0].StorageChanges[0] ||
+	if &bal[0] == &cpy[0] || &bal[0].StorageChanges[0] == &cpy[0].StorageChanges[0] ||
 		bal[0].StorageChanges[0].Changes[0] == cpy[0].StorageChanges[0].Changes[0] ||
 		bal[0].BalanceChanges[0] == cpy[0].BalanceChanges[0] ||
 		bal[0].NonceChanges[0] == cpy[0].NonceChanges[0] ||
@@ -287,12 +287,6 @@ func TestBlockAccessListCodecLeavesSemanticValidationToValidateForBlock(t *testi
 	}
 }
 
-func TestEncodeBlockAccessListRejectsUnrepresentableNil(t *testing.T) {
-	if _, err := EncodeBlockAccessListBytes(BlockAccessList{nil}); err == nil {
-		t.Fatal("expected nil account encoding error")
-	}
-}
-
 func TestEncodeBlockAccessListRejectsNestedNil(t *testing.T) {
 	tests := []struct {
 		name string
@@ -403,7 +397,7 @@ func TestBlockAccessListValidateMaxItems(t *testing.T) {
 				h[31] = byte(j)
 				reads[j] = accounts.InternKey(h)
 			}
-			bal[i] = &AccountChanges{
+			bal[i] = AccountChanges{
 				Address:      accounts.InternAddress(addr),
 				StorageReads: reads,
 			}
@@ -443,7 +437,7 @@ func TestBlockAccessListSlotUniqueness(t *testing.T) {
 		},
 		StorageReads: []accounts.StorageKey{accounts.InternKey(slot)},
 	}
-	bal := BlockAccessList{ac}
+	bal := BlockAccessList{*ac}
 	if err := bal.Validate(); err == nil {
 		t.Fatal("expected error for slot in both changes and reads")
 	}
@@ -558,7 +552,7 @@ func TestBlockAccessListRejectsEmptySlotChanges(t *testing.T) {
 		},
 	}
 
-	bal := BlockAccessList{ac}
+	bal := BlockAccessList{*ac}
 	err := bal.Validate()
 
 	if err == nil {

--- a/execution/types/block_access_list_test.go
+++ b/execution/types/block_access_list_test.go
@@ -581,3 +581,30 @@ func TestDecodeBlockAccessListBytesRejectsMalformedRLP(t *testing.T) {
 		}
 	}
 }
+
+// A reused AccountChanges receiver must not keep the previous decode's slots
+// when the next payload carries none: every other field is overwritten
+// unconditionally, so StorageChanges has to be too.
+func TestAccountChangesDecodeRLPClearsStorageChanges(t *testing.T) {
+	withSlots := AccountChanges{
+		Address: accounts.InternAddress(common.Address{1}),
+		StorageChanges: []SlotChanges{{
+			Slot:    accounts.InternKey(common.Hash{2}),
+			Changes: []*StorageChange{{Index: 1, Value: *uint256.NewInt(3)}},
+		}},
+	}
+	empty := AccountChanges{Address: accounts.InternAddress(common.Address{9})}
+
+	var buf bytes.Buffer
+	if err := empty.EncodeRLP(&buf); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	ac := withSlots // reuse a receiver that already holds slots
+	if err := ac.DecodeRLP(rlp.NewStream(bytes.NewReader(buf.Bytes()), 0)); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(ac.StorageChanges) != 0 {
+		t.Fatalf("decode kept %d storage changes from the previous payload", len(ac.StorageChanges))
+	}
+}

--- a/rpc/ethapi/block_access_list.go
+++ b/rpc/ethapi/block_access_list.go
@@ -62,7 +62,8 @@ type RPCAccountAccess struct {
 // MarshalBlockAccessList converts a types.BlockAccessList into the JSON-RPC response format.
 func MarshalBlockAccessList(bal types.BlockAccessList) []*RPCAccountAccess {
 	result := make([]*RPCAccountAccess, len(bal))
-	for i, ac := range bal {
+	for i := range bal {
+		ac := &bal[i]
 		entry := &RPCAccountAccess{
 			Address:        ac.Address.Value(),
 			StorageChanges: make([]*RPCSlotChanges, len(ac.StorageChanges)),

--- a/rpc/ethapi/block_access_list_test.go
+++ b/rpc/ethapi/block_access_list_test.go
@@ -16,7 +16,7 @@ func TestMarshalBlockAccessList(t *testing.T) {
 	bal := types.BlockAccessList{
 		{
 			Address: accounts.InternAddress(common.HexToAddress("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b")),
-			StorageChanges: []*types.SlotChanges{
+			StorageChanges: []types.SlotChanges{
 				{
 					Slot: accounts.InternKey(common.Hash{}),
 					Changes: []*types.StorageChange{


### PR DESCRIPTION
problem: building the EIP-7928 block access list scans unindexed lists on every
storage access, so it is quadratic in slots per account. `hasStorageWrite` was 57%
of the newPayload subtree.

Solution: index both lists by slot once an account passes 16 slots; below that a
scan beats a map probe. `StorageChanges` and `BlockAccessList` hold their elements
by value, as geth's `[]AccountAccess` does.

ns/slot, n=6 interleaved: 4096 slots 2393 → 148 (-94%), 32768 slots 18980 → 161
(-99%). Realistic 8192 accounts x 4 slots -7.7%. Cost: 64-slot accounts +20%.
