### PR TITLE
tools: bound the 150M-gas EEST shards' heap so they stop OOMing the runner

### DIFF
--- a/tools/eest-spec-shards.yml
+++ b/tools/eest-spec-shards.yml
@@ -408,11 +408,16 @@
   max-allowed-failures: 0
   commitment-parallel: false
   no-ramdisk: true
+  # 150M-gas blocks peak near 18GB RSS unbounded, over a 16GB runner. About half
+  # of that is Go heap; the rest is reclaimable MDBX mapping, so capping the heap
+  # is what keeps the process out of the OOM killer.
+  gomemlimit: 4GiB
 - shard: enginextests-benchmark-150m-parallel
   workers: 1
   max-allowed-failures: 0
   commitment-parallel: true
   no-ramdisk: true
+  gomemlimit: 4GiB
 - shard: zkevm-witness
   workers: 8
   max-allowed-failures: 0

--- a/tools/run-eest-spec-test.sh
+++ b/tools/run-eest-spec-test.sh
@@ -125,13 +125,16 @@ shard_row=$(yq -o=json '.' "$manifest" | jq -r --arg s "$shard" '
 	.[] | select(.shard == $s)
 	| if (."commitment-parallel" | type) != "boolean"
 		then error("shard \($s) must define boolean commitment-parallel")
-		else "\(.workers)\t\(."max-allowed-failures")\t\(."commitment-parallel")\t\(."no-ramdisk" // false)\t\(."expected-tests" // 0)\t\(.run // "")"
+		# gomemlimit emits "-" rather than "" because tab is IFS whitespace: `read`
+		# collapses a run of tabs, so an empty interior field would shift `run`
+		# into its slot.
+		else "\(.workers)\t\(."max-allowed-failures")\t\(."commitment-parallel")\t\(."no-ramdisk" // false)\t\(."expected-tests" // 0)\t\(."gomemlimit" // "-")\t\(.run // "")"
 	end')
 if [[ -z "$shard_row" ]]; then
 	echo "shard $shard not found in $manifest" >&2
 	exit 2
 fi
-IFS=$'\t' read -r default_workers default_max commitment_parallel shard_no_ramdisk expected_tests run_regex <<<"$shard_row"
+IFS=$'\t' read -r default_workers default_max commitment_parallel shard_no_ramdisk expected_tests shard_gomemlimit run_regex <<<"$shard_row"
 # Always set ERIGON_COMMITMENT_PARALLEL explicitly (true or false) so the shard's
 # commitment mode is pinned to the manifest, independent of whatever
 # statecfg.ExperimentalParallelCommitment defaults to at runtime. Execution is
@@ -200,12 +203,16 @@ workers="${EEST_SPEC_WORKERS:-$default_workers}"
 max="${EEST_SPEC_MAX_FAILURES:-$default_max}"
 evm_bin="${EVM_BIN:-build/bin/evm}"
 
-# Race-instrumented shards multiply RSS several-fold over the Go heap (TSAN
-# shadow + history). Bound the heap so allocation bursts trigger GC early
-# instead of growing the process into the CI runner's OOM range.
-if [[ "$shard" == *-race* ]]; then
+# Bound the heap so allocation bursts trigger GC early instead of growing the
+# process into the CI runner's OOM range. Race-instrumented shards need it
+# because TSAN shadow + history multiply RSS several-fold over the Go heap; the
+# manifest sets it per shard for the ones whose own heap is the problem.
+if [[ "$shard_gomemlimit" != "-" ]]; then
+	export GOMEMLIMIT="${GOMEMLIMIT:-$shard_gomemlimit}"
+elif [[ "$shard" == *-race* ]]; then
 	export GOMEMLIMIT="${GOMEMLIMIT:-4GiB}"
 fi
+echo "GOMEMLIMIT: ${GOMEMLIMIT:-unset}"
 
 if [[ ! -x "$evm_bin" ]]; then
 	echo "$evm_bin not found or not executable; run 'make evm' first" >&2


### PR DESCRIPTION
`enginextests-benchmark-150m-{sequential,parallel}` peak near 18GB RSS on a 16GB `ubuntu-24.04` runner and get killed mid-run. The log shows `make: *** Terminated` then "The runner has received a shutdown signal" with no failing fixture, so it reads as a flake — it has been misattributed as one on at least three separate commits.

Measured by running the exact CI command on a 62GB box, where it cannot OOM:

| | peak RSS | wall |
|---|---|---|
| unbounded | 17.46 GiB | 6:46 |
| `GOMEMLIMIT=4GiB` | 13.27 GiB | 9:24 |

At the peak, RSS is 14.5GB of which 9.1GB is anonymous and the rest reclaimable MDBX mapping, and the GC heap goal tops out at 7.8GB. So the heap is the half that can OOM, and capping it is the lever that works. 4GiB rather than 8GiB because the unbounded heap already peaks at 7.8GB — an 8GiB cap would barely bind.

Evidence it is memory and not something else: 145G volume with 109G free after cleanup, so not disk; the job timeout is 60min and these die at 11-16min; 74 sibling jobs kept running and passed after one died, so not concurrency cancellation; several race shards run 23-35min and pass, so not duration; and 1m/5m/10m/30m/60m/100m all pass in both variants while only 150m fails, either variant, intermittently.

`gomemlimit` is a per-shard manifest key, so the existing `-race` hardcode becomes its fallback rather than a second mechanism.

One incidental fix: the jq row emits `-` rather than `""` for an unset limit. Tab is IFS whitespace, so `read` collapses a run of tabs — an empty interior field shifted the `run` regex into the limit's slot, which made every race shard parse its fork filter as a memory limit.