### PR TITLE
tools: bound the heap on the 150M-gas EEST shards

### DIFF
--- a/tools/run-eest-spec-test.sh
+++ b/tools/run-eest-spec-test.sh
@@ -207,6 +207,11 @@ if [[ "$shard" == *-race* ]]; then
 	export GOMEMLIMIT="${GOMEMLIMIT:-4GiB}"
 fi
 
+# 150M-gas blocks peak near 18GB RSS and get OOM-killed on a 16GB runner.
+if [[ "$shard" == *-benchmark-150m-* ]]; then
+	export GOMEMLIMIT="${GOMEMLIMIT:-12GiB}"
+fi
+
 if [[ ! -x "$evm_bin" ]]; then
 	echo "$evm_bin not found or not executable; run 'make evm' first" >&2
 	exit 2


### PR DESCRIPTION
problem: `enginextests-benchmark-150m-{sequential,parallel}` peak near 18GB RSS on a 16GB runner and get OOM-killed mid-run. The log shows `make: *** Terminated` and no failing fixture, so it has been misread as a flake on at least three commits.

Solution: `GOMEMLIMIT=12GiB` on those two shards, the same guard the race shards already use.

Soft limit — below it the GC is unchanged, so there is no cost on the fast path.
