### PR TITLE
exec, commitment, cl/beacon: clear pooled objects (which hold bytecode ptr)

### DIFF
--- a/cl/beacon/handler/states_test.go
+++ b/cl/beacon/handler/states_test.go
@@ -23,6 +23,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -595,4 +597,23 @@ func TestGetPendingQueuesConsensusVersionHeader(t *testing.T) {
 	}
 	require.Equal(t, versions["pending_partial_withdrawals"], versions["pending_consolidations"])
 	require.Equal(t, versions["pending_partial_withdrawals"], versions["pending_deposits"])
+}
+
+// The response can be hundreds of MB on mainnet, so it must not stay in the pool.
+func TestResponseValidatorsDoesNotParkResponseInPool(t *testing.T) {
+	seed := new(strings.Builder)
+	saved := stringsBuilderPool
+	stringsBuilderPool = &sync.Pool{New: func() any { return seed }}
+	t.Cleanup(func() { stringsBuilderPool = saved })
+
+	const count = 16
+	validators := solid.NewValidatorSetWithLength(count, count)
+	balances := solid.NewUint64ListSSZ(count)
+	for i := range count {
+		balances.Append(uint64(i))
+	}
+
+	responseValidators(httptest.NewRecorder(), nil, nil, 0, balances, validators, true, false)
+
+	require.Zero(t, seed.Len(), "pooled builder still holds the whole response")
 }

--- a/cl/beacon/handler/validators.go
+++ b/cl/beacon/handler/validators.go
@@ -42,7 +42,7 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 )
 
-var stringsBuilderPool = sync.Pool{
+var stringsBuilderPool = &sync.Pool{
 	New: func() any {
 		return new(strings.Builder)
 	},
@@ -605,8 +605,10 @@ func (d directString) MarshalJSON() ([]byte, error) {
 func responseValidators(w http.ResponseWriter, filterIndicies []uint64, filterStatuses []validatorStatus, stateEpoch uint64, balances solid.Uint64ListSSZ, validators *solid.ValidatorSet, finalized bool, optimistic bool) {
 	// todo: refactor this function
 	b := stringsBuilderPool.Get().(*strings.Builder)
-	defer stringsBuilderPool.Put(b)
-	b.Reset()
+	defer func() {
+		b.Reset()
+		stringsBuilderPool.Put(b)
+	}()
 
 	var isOptimistic string = "false"
 	if optimistic {

--- a/execution/commitment/commitment.go
+++ b/execution/commitment/commitment.go
@@ -338,7 +338,8 @@ func (be *BranchEncoder) ClearDeferred() {
 	for _, upd := range be.deferred {
 		putDeferredUpdate(upd)
 	}
-	be.deferred = be.deferred[:0]
+	// Delete, not reslice: this encoder sits inside a pooled trie.
+	be.deferred = slices.Delete(be.deferred, 0, len(be.deferred))
 	if be.pendingPrefixes != nil {
 		be.pendingPrefixes.Clear()
 	}
@@ -1754,6 +1755,9 @@ func (t *Updates) hashSortDirectInMem(ctx context.Context, warmuper *Warmuper, f
 
 // fn must not retain hk or pk slices after returning: they're backed by reusable arena memory.
 func (t *Updates) HashSort(ctx context.Context, warmuper *Warmuper, fn func(hk, pk []byte, update *Update) error) error {
+	// [:cap] because the loops below reslice batchSlab many times.
+	defer func() { clear(t.batchSlab[:cap(t.batchSlab)]) }()
+
 	switch t.mode {
 	case ModeDirect:
 		cnt := len(t.keys)

--- a/execution/commitment/commitment_test.go
+++ b/execution/commitment/commitment_test.go
@@ -23,6 +23,7 @@ import (
 	"math/bits"
 	"math/rand"
 	"slices"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1120,4 +1121,62 @@ func TestApplyDeferred_CallbackSeesInputDerivedCapacity(t *testing.T) {
 			require.Equal(t, tc.updates, seen, "callback must run for every update")
 		})
 	}
+}
+
+// The encoder sits inside a HexPatriciaHashed that Release() parks in a pool,
+// so a reslice would leave a branch's buffers reachable from there.
+func TestClearDeferredDropsUpdatesItReslicesPast(t *testing.T) {
+	t.Parallel()
+
+	row, bm := generateCellRow(t, 8)
+	cells := generateCellEncodeDataRow(t, row, bm)
+
+	ctx := &recordingCtx{}
+	be := NewBranchEncoder(1024)
+	be.setDeferUpdates(true)
+	require.NoError(t, be.CollectDeferredUpdate(ctx, []byte{0xAA, 0xAA}, bm, bm, bm, &cells, true))
+	require.NoError(t, be.CollectDeferredUpdate(ctx, []byte{0xBB, 0xBB}, bm, bm, bm, &cells, true))
+	require.Len(t, be.deferred, 2)
+
+	be.ClearDeferred()
+
+	for i, upd := range be.deferred[:cap(be.deferred)] {
+		require.Nil(t, upd, "deferred[%d] still pins a DeferredBranchUpdate after ClearDeferred", i)
+	}
+}
+
+// More keys than one batch, so the mid-loop truncation runs too, not just the
+// trailing one.
+func TestHashSortLeavesNoBatchSlabEntriesBehind(t *testing.T) {
+	t.Parallel()
+
+	upd := NewUpdates(ModeUpdate, t.TempDir(), keyHasherNoop)
+	for i := range hashSortBatchSize + 1 {
+		upd.TouchPlainKey(strconv.Itoa(i), []byte("v"), upd.TouchStorage)
+	}
+
+	require.NoError(t, upd.HashSort(context.Background(), nil, func(hk, pk []byte, u *Update) error { return nil }))
+
+	require.NotZero(t, cap(upd.batchSlab), "no batch ran, so the test proves nothing")
+	for i, ku := range upd.batchSlab[:cap(upd.batchSlab)] {
+		require.Nil(t, ku.update, "batchSlab[%d] still pins an Update after HashSort", i)
+		require.Nil(t, ku.hashedKey, "batchSlab[%d] still pins a hashed key after HashSort", i)
+		require.Empty(t, ku.plainKey, "batchSlab[%d] still pins a plain key after HashSort", i)
+	}
+}
+
+// Reset recycles the updates into the pool, so it must detach the slice the way
+// every other drain of deferredCombined does.
+func TestParallelUpdateResetDetachesDeferred(t *testing.T) {
+	t.Parallel()
+
+	pu := newParallelUpdate()
+	pu.appendDeferred([]*DeferredBranchUpdate{
+		getDeferredUpdate([]byte{1}, make([]byte, 4096), nil),
+		getDeferredUpdate([]byte{2}, make([]byte, 4096), nil),
+	})
+
+	pu.Reset()
+
+	require.Nil(t, pu.deferredCombined, "Reset still pins the recycled updates")
 }

--- a/execution/commitment/parallel_patricia_hashed.go
+++ b/execution/commitment/parallel_patricia_hashed.go
@@ -238,7 +238,7 @@ func (p *ParallelPatriciaHashed) Process(
 		for _, upd := range pu.deferredCombined {
 			putDeferredUpdate(upd)
 		}
-		pu.deferredCombined = pu.deferredCombined[:0]
+		pu.deferredCombined = nil
 		pu.deferredMu.Unlock()
 		return nil, mErr
 	}

--- a/execution/commitment/parallel_update.go
+++ b/execution/commitment/parallel_update.go
@@ -76,7 +76,7 @@ func (pu *parallelUpdate) Reset() {
 	for _, upd := range pu.deferredCombined {
 		putDeferredUpdate(upd)
 	}
-	pu.deferredCombined = pu.deferredCombined[:0]
+	pu.deferredCombined = nil
 	pu.deferredMu.Unlock()
 	pu.keyArena.reset()
 }

--- a/execution/state/journal.go
+++ b/execution/state/journal.go
@@ -108,10 +108,10 @@ func newJournal() *journal {
 // release returns the journal to the pool after resetting it.
 func (j *journal) release() {
 	j.Reset()
-	clear(j.entries[:cap(j.entries)]) // [:cap] because Reset already resliced to zero
 	journalPool.Put(j)
 }
 func (j *journal) Reset() {
+	clear(j.entries[:cap(j.entries)])
 	j.entries = j.entries[:0]
 	clear(j.dirties)
 }

--- a/execution/state/journal.go
+++ b/execution/state/journal.go
@@ -111,7 +111,7 @@ func (j *journal) release() {
 	journalPool.Put(j)
 }
 func (j *journal) Reset() {
-	clear(j.entries[:cap(j.entries)])
+	clear(j.entries)
 	j.entries = j.entries[:0]
 	clear(j.dirties)
 }
@@ -134,6 +134,7 @@ func (j *journal) revert(statedb *IntraBlockState, snapshot int) {
 			}
 		}
 	}
+	clear(j.entries[snapshot:])
 	j.entries = j.entries[:snapshot]
 }
 

--- a/execution/state/journal_test.go
+++ b/execution/state/journal_test.go
@@ -143,3 +143,26 @@ func TestJournalResetDropsEntriesItReslicesPast(t *testing.T) {
 		}
 	}
 }
+
+// revert truncates to a snapshot, so the entries it drops outlive it; a Reset
+// that clears only [0:len] would leave that stretch holding its bytecode.
+func TestJournalRevertDropsTheEntriesItTruncates(t *testing.T) {
+	ibs := New(NewVersionedStateReader(0, ReadSet{}, nil, nil))
+	addr := accounts.InternAddress(common.Address{1})
+	ibs.stateObjects[addr] = newObject(ibs, addr, &accounts.Account{}, &accounts.Account{})
+
+	j := ibs.journal
+	for range 4 {
+		j.codeChange(addr, make([]byte, 4096), accounts.EmptyCodeHash, false)
+	}
+
+	j.revert(ibs, 2)
+	j.Reset()
+
+	for i, e := range j.entries[:cap(j.entries)] {
+		if e.extra != nil {
+			t.Fatalf("entry %d still pins a journalExtra after Reset (prevcode %d bytes)",
+				i, len(e.extra.prevcode))
+		}
+	}
+}

--- a/execution/state/journal_test.go
+++ b/execution/state/journal_test.go
@@ -117,3 +117,29 @@ func BenchmarkJournalStorageChange(b *testing.B) {
 		}
 	}
 }
+
+// Reset reslices entries to zero, so anything left in the backing array stays
+// reachable for as long as the journal is reused — and a kindCode entry's extra
+// holds a whole contract's bytecode. The journal outlives the transaction, so
+// that is a block's worth of dead code pinned by a pooled object.
+func TestJournalResetDropsEntriesItReslicesPast(t *testing.T) {
+	j := newJournal()
+	t.Cleanup(j.release)
+
+	addr := accounts.InternAddress(common.Address{1})
+	j.codeChange(addr, make([]byte, 4096), accounts.EmptyCodeHash, false)
+	j.codeChange(addr, make([]byte, 4096), accounts.EmptyCodeHash, false)
+	if len(j.entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(j.entries))
+	}
+
+	j.Reset()
+
+	tail := j.entries[:cap(j.entries)]
+	for i, e := range tail {
+		if e.extra != nil {
+			t.Fatalf("entry %d still pins a journalExtra after Reset (prevcode %d bytes)",
+				i, len(e.extra.prevcode))
+		}
+	}
+}

--- a/execution/state/rw_v3.go
+++ b/execution/state/rw_v3.go
@@ -1784,10 +1784,11 @@ func returnReadList(v ReadLists) {
 	if v == nil {
 		return
 	}
-	//for _, tbl := range v {
-	//	clear(tbl.Keys)
-	//	clear(tbl.Vals)
-	//	tbl.Keys, tbl.Vals = tbl.Keys[:0], tbl.Vals[:0]
-	//}
+	// Not optional: Vals pins what the txn read until the list is reused.
+	for _, tbl := range v {
+		clear(tbl.Keys)
+		clear(tbl.Vals)
+		tbl.Keys, tbl.Vals = tbl.Keys[:0], tbl.Vals[:0]
+	}
 	readListPool.Put(v)
 }

--- a/execution/state/rw_v3_allocs_test.go
+++ b/execution/state/rw_v3_allocs_test.go
@@ -196,3 +196,24 @@ func BenchmarkCachedReaderAccountRead(b *testing.B) {
 		}
 	})
 }
+
+// returnReadList pools the list, so leaving Vals populated keeps every value the
+// transaction read — bytecode included — alive for as long as the pool holds it.
+// Not parallel: it inspects an object it has just handed back to the pool.
+func TestReturnReadListUnpinsWhatTheTxnRead(t *testing.T) {
+	lists := readListPool.Get().(ReadLists)
+	tbl := lists[kv.AccountsDomain.String()]
+	tbl.Push("k1", make([]byte, 4096))
+	tbl.Push("k2", make([]byte, 4096))
+	require.Equal(t, 2, tbl.Len())
+
+	returnReadList(lists)
+
+	require.Zero(t, tbl.Len())
+	for i, v := range tbl.Vals[:cap(tbl.Vals)] {
+		require.Nil(t, v, "Vals[%d] still pins %d bytes the txn read", i, len(v))
+	}
+	for i, k := range tbl.Keys[:cap(tbl.Keys)] {
+		require.Empty(t, k, "Keys[%d] still pins a key", i)
+	}
+}


### PR DESCRIPTION
seems it's root cause of OOM in tests: https://github.com/erigontech/erigon/pull/23640

not all pointers was cleared before returning objects to `sync.Pool`

Same class, found by sweeping every `sync.Pool` in the repo:

- `BranchEncoder.ClearDeferred` — up to 50k `*DeferredBranchUpdate` stayed in the backing array, and that encoder lives inside a `HexPatriciaHashed` that `Release()` pools.
- `Updates.batchSlab` — truncated between hash-sort batches; one `clear` on the way out of `HashSort`.
- `responseValidators` — reset its pooled `strings.Builder` on checkout instead of on return, parking a whole validators response in the pool.

The `returnReadList` clearing was commented out in `bd654e06d` (`save`, 2023-10-17); no rationale was recorded.

`journal.Reset` now clears by `len` rather than `[:cap]`, so a transaction no longer pays the block's high-water mark; `revert` clears the stretch it truncates, which is what makes that correct.
