### PR TITLE
cl/services: share pending queue for payload gossip

### DIFF
--- a/cl/phase1/network/services/execution_payload_service.go
+++ b/cl/phase1/network/services/execution_payload_service.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/erigontech/erigon/cl/beacon/beaconevents"
@@ -52,12 +50,6 @@ type pendingEnvelopeKey struct {
 	envelopeHash common.Hash
 }
 
-// envelopeJob represents a pending envelope waiting for its block to arrive
-type envelopeJob struct {
-	envelope     *cltypes.SignedExecutionPayloadEnvelope
-	creationTime time.Time
-}
-
 const (
 	seenEnvelopeCacheSize        = 1000
 	pendingEnvelopeExpiry        = 30 * time.Second
@@ -74,9 +66,7 @@ type executionPayloadService struct {
 	seenEnvelopesCache *lru.Cache[seenEnvelopeKey, struct{}]
 
 	// Pending envelopes waiting for block to arrive
-	pendingEnvelopes sync.Map // pendingEnvelopeKey -> *envelopeJob
-	pendingCount     atomic.Int32
-	pendingCond      *sync.Cond
+	pending *pendingJobQueue[pendingEnvelopeKey, *cltypes.SignedExecutionPayloadEnvelope]
 }
 
 // NewExecutionPayloadService creates a new execution payload service
@@ -95,10 +85,18 @@ func NewExecutionPayloadService(
 		beaconCfg:          beaconCfg,
 		emitters:           emitters,
 		seenEnvelopesCache: seenEnvelopesCache,
-		pendingCond:        sync.NewCond(&sync.Mutex{}),
 	}
-	go s.loop(ctx)
+	s.pending = s.newPendingQueue()
+	go s.pending.loop(ctx)
 	return s
+}
+
+func (s *executionPayloadService) newPendingQueue() *pendingJobQueue[pendingEnvelopeKey, *cltypes.SignedExecutionPayloadEnvelope] {
+	return newPendingJobQueue(maxPendingEnvelopes, pendingEnvelopeExpiry, pendingEnvelopeCheckInterval,
+		s.tryProcessPendingEnvelope,
+		func(key pendingEnvelopeKey) {
+			log.Trace("Pending envelope expired", "blockRoot", key.blockRoot)
+		})
 }
 
 func (s *executionPayloadService) Names() []string {
@@ -204,104 +202,31 @@ func (s *executionPayloadService) ProcessMessage(ctx context.Context, _ *uint64,
 
 // queuePendingEnvelope adds an envelope to the pending queue for later processing
 func (s *executionPayloadService) queuePendingEnvelope(blockRoot common.Hash, envelope *cltypes.SignedExecutionPayloadEnvelope) {
-	if s.pendingCount.Add(1) > maxPendingEnvelopes {
-		s.pendingCount.Add(-1)
-		return
-	}
-
-	// Compute envelope hash to allow multiple candidates per block
-	envelopeHash, err := envelope.HashSSZ()
-	if err != nil {
-		s.pendingCount.Add(-1)
-		log.Warn("Failed to hash envelope for pending queue", "blockRoot", blockRoot, "err", err)
-		return
-	}
-
-	key := pendingEnvelopeKey{
-		blockRoot:    blockRoot,
-		envelopeHash: envelopeHash,
-	}
-
-	if _, loaded := s.pendingEnvelopes.LoadOrStore(key, &envelopeJob{
-		envelope:     envelope,
-		creationTime: time.Now(),
-	}); loaded {
-		s.pendingCount.Add(-1)
-	} else {
-		s.pendingCond.L.Lock()
-		s.pendingCond.Signal()
-		s.pendingCond.L.Unlock()
-	}
-}
-
-// loop is the background goroutine that processes pending envelopes
-func (s *executionPayloadService) loop(ctx context.Context) {
-	// Wake any blocked Wait() on context cancellation to prevent deadlock.
-	go func() {
-		<-ctx.Done()
-		s.pendingCond.L.Lock()
-		s.pendingCond.Broadcast()
-		s.pendingCond.L.Unlock()
-	}()
-
-	for {
-		// Wait until there are pending envelopes
-		s.pendingCond.L.Lock()
-		for s.pendingCount.Load() == 0 {
-			// Check if context is cancelled
-			select {
-			case <-ctx.Done():
-				s.pendingCond.L.Unlock()
-				return
-			default:
-			}
-			s.pendingCond.Wait()
+	err := s.pending.enqueueLazy(envelope, func() (pendingEnvelopeKey, error) {
+		envelopeHash, err := envelope.HashSSZ()
+		if err != nil {
+			return pendingEnvelopeKey{}, err
 		}
-		s.pendingCond.L.Unlock()
-
-		// Poll until all pending envelopes are processed
-		ticker := time.NewTicker(pendingEnvelopeCheckInterval)
-		for s.pendingCount.Load() > 0 {
-			select {
-			case <-ctx.Done():
-				ticker.Stop()
-				return
-			case <-ticker.C:
-				s.processPendingEnvelopes(ctx)
-			}
-		}
-		ticker.Stop()
-	}
-}
-
-// processPendingEnvelopes checks and processes any pending envelopes whose blocks have arrived
-func (s *executionPayloadService) processPendingEnvelopes(ctx context.Context) {
-	s.pendingEnvelopes.Range(func(key, value any) bool {
-		pendingKey := key.(pendingEnvelopeKey)
-		job := value.(*envelopeJob)
-
-		// Check expiry
-		if time.Since(job.creationTime) > pendingEnvelopeExpiry {
-			s.pendingEnvelopes.Delete(pendingKey)
-			s.pendingCount.Add(-1)
-			log.Trace("Pending envelope expired", "blockRoot", pendingKey.blockRoot)
-			return true
-		}
-
-		// Check if block has arrived
-		block, ok := s.forkchoiceStore.GetBlock(pendingKey.blockRoot)
-		if !ok || block == nil {
-			return true // Block still not here, keep waiting
-		}
-
-		// Block arrived, remove from pending and process
-		s.pendingEnvelopes.Delete(pendingKey)
-		s.pendingCount.Add(-1)
-
-		// Re-run full validation via ProcessMessage
-		if err := s.ProcessMessage(ctx, nil, job.envelope); err != nil {
-			log.Trace("Failed to process pending envelope", "blockRoot", pendingKey.blockRoot, "err", err)
-		}
-		return true
+		return pendingEnvelopeKey{
+			blockRoot:    blockRoot,
+			envelopeHash: envelopeHash,
+		}, nil
 	})
+	if err != nil {
+		log.Warn("Failed to hash envelope for pending queue", "blockRoot", blockRoot, "err", err)
+	}
+}
+
+// tryProcessPendingEnvelope re-runs full validation via ProcessMessage once the block has arrived.
+func (s *executionPayloadService) tryProcessPendingEnvelope(ctx context.Context, key pendingEnvelopeKey, envelope *cltypes.SignedExecutionPayloadEnvelope) (func(), bool) {
+	block, ok := s.forkchoiceStore.GetBlock(key.blockRoot)
+	if !ok || block == nil {
+		return nil, false // Block still not here, keep waiting
+	}
+
+	return func() {
+		if err := s.ProcessMessage(ctx, nil, envelope); err != nil {
+			log.Trace("Failed to process pending envelope", "blockRoot", key.blockRoot, "err", err)
+		}
+	}, true
 }

--- a/cl/phase1/network/services/execution_payload_service_test.go
+++ b/cl/phase1/network/services/execution_payload_service_test.go
@@ -82,7 +82,7 @@ func TestExecutionPayloadServiceBlockNotFound(t *testing.T) {
 
 	// Verify envelope was queued (check internal state)
 	impl := service.(*executionPayloadService)
-	require.Equal(t, int32(1), impl.pendingCount.Load())
+	require.Equal(t, int32(1), impl.pending.count.Load())
 
 	// Now add block to forkchoice
 	fcu.Blocks[blockRoot] = &cltypes.SignedBeaconBlock{
@@ -218,13 +218,13 @@ func TestExecutionPayloadServicePendingEnvelopeExpiry(t *testing.T) {
 	forkchoiceMock := mock_services.NewForkChoiceStorageMock(t)
 	ctx := t.Context()
 
-	// Create service directly to access internals
+	// Create service directly to access internals; the background loop is not started
 	impl := &executionPayloadService{
 		forkchoiceStore: forkchoiceMock,
 		beaconCfg:       cfg,
 		emitters:        beaconevents.NewEventEmitter(),
-		pendingCond:     nil, // Don't start background loop
 	}
+	impl.pending = impl.newPendingQueue()
 	seenCache, err := lru.New[seenEnvelopeKey, struct{}]("seen_envelopes", seenEnvelopeCacheSize)
 	require.NoError(t, err)
 	impl.seenEnvelopesCache = seenCache
@@ -239,17 +239,17 @@ func TestExecutionPayloadServicePendingEnvelopeExpiry(t *testing.T) {
 		blockRoot:    blockRoot,
 		envelopeHash: envelopeHash,
 	}
-	impl.pendingEnvelopes.Store(key, &envelopeJob{
-		envelope:     envelope,
+	impl.pending.jobs.Store(key, &pendingJob[*cltypes.SignedExecutionPayloadEnvelope]{
+		msg:          envelope,
 		creationTime: time.Now().Add(-pendingEnvelopeExpiry - time.Second), // expired
 	})
-	impl.pendingCount.Store(1)
+	impl.pending.count.Store(1)
 
 	// Process pending - should remove expired
-	impl.processPendingEnvelopes(ctx)
+	impl.pending.processPending(ctx)
 
-	require.Equal(t, int32(0), impl.pendingCount.Load())
-	_, exists := impl.pendingEnvelopes.Load(key)
+	require.Equal(t, int32(0), impl.pending.count.Load())
+	_, exists := impl.pending.jobs.Load(key)
 	require.False(t, exists)
 }
 
@@ -258,13 +258,13 @@ func TestExecutionPayloadServicePendingEnvelopeProcessing(t *testing.T) {
 	forkchoiceMock := mock_services.NewForkChoiceStorageMock(t)
 	ctx := t.Context()
 
-	// Create service directly to access internals
+	// Create service directly to access internals; the background loop is not started
 	impl := &executionPayloadService{
 		forkchoiceStore: forkchoiceMock,
 		beaconCfg:       cfg,
 		emitters:        beaconevents.NewEventEmitter(),
-		pendingCond:     nil,
 	}
+	impl.pending = impl.newPendingQueue()
 	seenCache, err := lru.New[seenEnvelopeKey, struct{}]("seen_envelopes", seenEnvelopeCacheSize)
 	require.NoError(t, err)
 	impl.seenEnvelopesCache = seenCache
@@ -279,15 +279,15 @@ func TestExecutionPayloadServicePendingEnvelopeProcessing(t *testing.T) {
 		blockRoot:    blockRoot,
 		envelopeHash: envelopeHash,
 	}
-	impl.pendingEnvelopes.Store(key, &envelopeJob{
-		envelope:     envelope,
+	impl.pending.jobs.Store(key, &pendingJob[*cltypes.SignedExecutionPayloadEnvelope]{
+		msg:          envelope,
 		creationTime: time.Now(),
 	})
-	impl.pendingCount.Store(1)
+	impl.pending.count.Store(1)
 
 	// Block not yet available - should keep pending
-	impl.processPendingEnvelopes(ctx)
-	require.Equal(t, int32(1), impl.pendingCount.Load())
+	impl.pending.processPending(ctx)
+	require.Equal(t, int32(1), impl.pending.count.Load())
 
 	// Now add block
 	forkchoiceMock.Blocks[blockRoot] = &cltypes.SignedBeaconBlock{
@@ -297,9 +297,9 @@ func TestExecutionPayloadServicePendingEnvelopeProcessing(t *testing.T) {
 	}
 
 	// Process again - should process and remove
-	impl.processPendingEnvelopes(ctx)
-	require.Equal(t, int32(0), impl.pendingCount.Load())
-	_, exists := impl.pendingEnvelopes.Load(key)
+	impl.pending.processPending(ctx)
+	require.Equal(t, int32(0), impl.pending.count.Load())
+	_, exists := impl.pending.jobs.Load(key)
 	require.False(t, exists)
 
 	// Envelope should be marked as seen
@@ -315,8 +315,8 @@ func TestExecutionPayloadServiceMultiplePendingForSameBlock(t *testing.T) {
 		forkchoiceStore: forkchoiceMock,
 		beaconCfg:       cfg,
 		emitters:        beaconevents.NewEventEmitter(),
-		pendingCond:     nil,
 	}
+	impl.pending = impl.newPendingQueue()
 	seenCache, err := lru.New[seenEnvelopeKey, struct{}]("seen_envelopes", seenEnvelopeCacheSize)
 	require.NoError(t, err)
 	impl.seenEnvelopesCache = seenCache
@@ -331,15 +331,15 @@ func TestExecutionPayloadServiceMultiplePendingForSameBlock(t *testing.T) {
 	hash2, _ := envelope2.HashSSZ()
 
 	// Add both as pending
-	impl.pendingEnvelopes.Store(pendingEnvelopeKey{blockRoot, hash1}, &envelopeJob{
-		envelope:     envelope1,
+	impl.pending.jobs.Store(pendingEnvelopeKey{blockRoot, hash1}, &pendingJob[*cltypes.SignedExecutionPayloadEnvelope]{
+		msg:          envelope1,
 		creationTime: time.Now(),
 	})
-	impl.pendingEnvelopes.Store(pendingEnvelopeKey{blockRoot, hash2}, &envelopeJob{
-		envelope:     envelope2,
+	impl.pending.jobs.Store(pendingEnvelopeKey{blockRoot, hash2}, &pendingJob[*cltypes.SignedExecutionPayloadEnvelope]{
+		msg:          envelope2,
 		creationTime: time.Now(),
 	})
-	impl.pendingCount.Store(2)
+	impl.pending.count.Store(2)
 
 	// Add block
 	forkchoiceMock.Blocks[blockRoot] = &cltypes.SignedBeaconBlock{
@@ -349,9 +349,9 @@ func TestExecutionPayloadServiceMultiplePendingForSameBlock(t *testing.T) {
 	}
 
 	// Process - both should be processed
-	impl.processPendingEnvelopes(ctx)
+	impl.pending.processPending(ctx)
 
-	require.Equal(t, int32(0), impl.pendingCount.Load())
+	require.Equal(t, int32(0), impl.pending.count.Load())
 	require.True(t, impl.seenEnvelopesCache.Contains(seenEnvelopeKey{blockRoot, 1}))
 	require.True(t, impl.seenEnvelopesCache.Contains(seenEnvelopeKey{blockRoot, 2}))
 }
@@ -367,20 +367,20 @@ func TestExecutionPayloadServicePendingQueueCap(t *testing.T) {
 		beaconCfg:          cfg,
 		emitters:           beaconevents.NewEventEmitter(),
 		seenEnvelopesCache: seenCache,
-		pendingCond:        sync.NewCond(&sync.Mutex{}),
 	}
+	impl.pending = impl.newPendingQueue()
 
-	impl.pendingCount.Store(maxPendingEnvelopes)
+	impl.pending.count.Store(maxPendingEnvelopes)
 
 	blockRoot := common.HexToHash("0xffff")
 	envelope := newTestSignedEnvelope(100, blockRoot, 999)
 
 	impl.queuePendingEnvelope(blockRoot, envelope)
 
-	require.Equal(t, int32(maxPendingEnvelopes), impl.pendingCount.Load())
+	require.Equal(t, int32(maxPendingEnvelopes), impl.pending.count.Load())
 	envelopeHash, err := envelope.HashSSZ()
 	require.NoError(t, err)
-	_, exists := impl.pendingEnvelopes.Load(pendingEnvelopeKey{blockRoot, envelopeHash})
+	_, exists := impl.pending.jobs.Load(pendingEnvelopeKey{blockRoot, envelopeHash})
 	require.False(t, exists)
 }
 
@@ -395,10 +395,10 @@ func TestExecutionPayloadServicePendingQueueCapConcurrent(t *testing.T) {
 		beaconCfg:          cfg,
 		emitters:           beaconevents.NewEventEmitter(),
 		seenEnvelopesCache: seenCache,
-		pendingCond:        sync.NewCond(&sync.Mutex{}),
 	}
+	impl.pending = impl.newPendingQueue()
 
-	impl.pendingCount.Store(maxPendingEnvelopes - 5)
+	impl.pending.count.Store(maxPendingEnvelopes - 5)
 
 	var wg sync.WaitGroup
 	for i := range 100 {
@@ -410,9 +410,9 @@ func TestExecutionPayloadServicePendingQueueCapConcurrent(t *testing.T) {
 	}
 	wg.Wait()
 
-	require.Equal(t, int32(maxPendingEnvelopes), impl.pendingCount.Load())
+	require.Equal(t, int32(maxPendingEnvelopes), impl.pending.count.Load())
 	stored := 0
-	impl.pendingEnvelopes.Range(func(_, _ any) bool {
+	impl.pending.jobs.Range(func(_, _ any) bool {
 		stored++
 		return true
 	})

--- a/cl/phase1/network/services/payload_attestation_service.go
+++ b/cl/phase1/network/services/payload_attestation_service.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -51,12 +49,6 @@ type pendingPayloadAttestationKey struct {
 	messageRoot    common.Hash
 }
 
-// pendingPayloadAttestationJob represents a pending attestation waiting for its block.
-type pendingPayloadAttestationJob struct {
-	msg          *cltypes.PayloadAttestationMessage
-	creationTime time.Time
-}
-
 const (
 	// seenPayloadAttestationCacheSize: PTC has 512 validators per slot.
 	// With clock disparity, we may see attestations for ~2 slots.
@@ -77,10 +69,8 @@ type payloadAttestationService struct {
 	// Cache to track seen attestations: (slot, validatorIndex) -> struct{}
 	seenAttestationsCache *lru.Cache[seenPayloadAttestationKey, struct{}]
 
-	// Pending attestations waiting for block to arrive
-	pendingAttestations sync.Map // pendingPayloadAttestationKey -> *pendingPayloadAttestationJob
-	pendingCount        atomic.Int32
-	pendingCond         *sync.Cond
+	// Pending attestations waiting for block to arrive.
+	pending             *pendingJobQueue[pendingPayloadAttestationKey, *cltypes.PayloadAttestationMessage]
 	validationAdmission chan struct{}
 }
 
@@ -103,11 +93,19 @@ func NewPayloadAttestationService(
 		netCfg:                netCfg,
 		emitters:              emitters,
 		seenAttestationsCache: seenCache,
-		pendingCond:           sync.NewCond(&sync.Mutex{}),
 		validationAdmission:   make(chan struct{}, maxConcurrentPayloadAttestationValidations),
 	}
-	go s.loop(ctx)
+	s.pending = s.newPendingQueue()
+	go s.pending.loop(ctx)
 	return s
+}
+
+func (s *payloadAttestationService) newPendingQueue() *pendingJobQueue[pendingPayloadAttestationKey, *cltypes.PayloadAttestationMessage] {
+	return newPendingJobQueue(maxPendingAttestations, pendingPayloadAttestationExpiry, pendingPayloadAttestationCheckInterval,
+		s.tryProcessPendingAttestation,
+		func(key pendingPayloadAttestationKey) {
+			log.Trace("Pending payload attestation expired", "blockRoot", key.blockRoot)
+		})
 }
 
 func (s *payloadAttestationService) Names() []string {
@@ -207,23 +205,9 @@ func (s *payloadAttestationService) ProcessMessage(ctx context.Context, _ *uint6
 
 // queuePendingAttestation adds an attestation to the pending queue for later processing.
 func (s *payloadAttestationService) queuePendingAttestation(blockRoot common.Hash, msg *cltypes.PayloadAttestationMessage) {
-	if s.pendingCount.Add(1) > maxPendingAttestations {
-		s.pendingCount.Add(-1)
-		return
-	}
-
-	key := pendingPayloadAttestationKeyFor(blockRoot, msg)
-
-	if _, loaded := s.pendingAttestations.LoadOrStore(key, &pendingPayloadAttestationJob{
-		msg:          msg,
-		creationTime: time.Now(),
-	}); loaded {
-		s.pendingCount.Add(-1)
-	} else {
-		s.pendingCond.L.Lock()
-		s.pendingCond.Signal()
-		s.pendingCond.L.Unlock()
-	}
+	_ = s.pending.enqueueLazy(msg, func() (pendingPayloadAttestationKey, error) {
+		return pendingPayloadAttestationKeyFor(blockRoot, msg), nil
+	})
 }
 
 func pendingPayloadAttestationKeyFor(blockRoot common.Hash, msg *cltypes.PayloadAttestationMessage) pendingPayloadAttestationKey {
@@ -235,80 +219,21 @@ func pendingPayloadAttestationKeyFor(blockRoot common.Hash, msg *cltypes.Payload
 	}
 }
 
-// loop is the background goroutine that processes pending attestations.
-func (s *payloadAttestationService) loop(ctx context.Context) {
-	// Wake any blocked Wait() on context cancellation to prevent deadlock.
-	go func() {
-		<-ctx.Done()
-		s.pendingCond.L.Lock()
-		s.pendingCond.Broadcast()
-		s.pendingCond.L.Unlock()
-	}()
-
-	for {
-		// Wait until there are pending attestations
-		s.pendingCond.L.Lock()
-		for s.pendingCount.Load() == 0 {
-			select {
-			case <-ctx.Done():
-				s.pendingCond.L.Unlock()
-				return
-			default:
-			}
-			s.pendingCond.Wait()
-		}
-		s.pendingCond.L.Unlock()
-
-		// Poll until all pending attestations are processed
-		ticker := time.NewTicker(pendingPayloadAttestationCheckInterval)
-		for s.pendingCount.Load() > 0 {
-			select {
-			case <-ctx.Done():
-				ticker.Stop()
-				return
-			case <-ticker.C:
-				s.processPendingAttestations(ctx)
-			}
-		}
-		ticker.Stop()
+// tryProcessPendingAttestation re-runs validation via ProcessMessage once the block has arrived,
+// dropping attestations that are no longer for the current slot.
+func (s *payloadAttestationService) tryProcessPendingAttestation(ctx context.Context, key pendingPayloadAttestationKey, msg *cltypes.PayloadAttestationMessage) (func(), bool) {
+	if !s.ethClock.IsSlotCurrentSlotWithMaximumClockDisparity(msg.Data.Slot) {
+		log.Trace("Pending payload attestation slot mismatch", "blockRoot", key.blockRoot)
+		return nil, true
 	}
-}
 
-// processPendingAttestations checks and processes any pending attestations whose blocks have arrived.
-func (s *payloadAttestationService) processPendingAttestations(ctx context.Context) {
-	s.pendingAttestations.Range(func(key, value any) bool {
-		pendingKey := key.(pendingPayloadAttestationKey)
-		job := value.(*pendingPayloadAttestationJob)
+	if _, ok := s.forkchoiceStore.GetHeader(key.blockRoot); !ok {
+		return nil, false
+	}
 
-		// Check expiry
-		if time.Since(job.creationTime) > pendingPayloadAttestationExpiry {
-			s.pendingAttestations.Delete(pendingKey)
-			s.pendingCount.Add(-1)
-			log.Trace("Pending payload attestation expired", "blockRoot", pendingKey.blockRoot)
-			return true
+	return func() {
+		if err := s.ProcessMessage(ctx, nil, msg); err != nil {
+			log.Trace("Failed to process pending payload attestation", "blockRoot", key.blockRoot, "err", err)
 		}
-
-		// Check if attestation is still for current slot (with clock disparity allowance)
-		if !s.ethClock.IsSlotCurrentSlotWithMaximumClockDisparity(job.msg.Data.Slot) {
-			s.pendingAttestations.Delete(pendingKey)
-			s.pendingCount.Add(-1)
-			log.Trace("Pending payload attestation slot mismatch", "blockRoot", pendingKey.blockRoot)
-			return true
-		}
-
-		// Check if block has arrived
-		if _, ok := s.forkchoiceStore.GetHeader(pendingKey.blockRoot); !ok {
-			return true // Block still not here, keep waiting
-		}
-
-		// Block arrived, remove from pending and process
-		s.pendingAttestations.Delete(pendingKey)
-		s.pendingCount.Add(-1)
-
-		// Re-run validation via ProcessMessage
-		if err := s.ProcessMessage(ctx, nil, job.msg); err != nil {
-			log.Trace("Failed to process pending payload attestation", "blockRoot", pendingKey.blockRoot, "err", err)
-		}
-		return true
-	})
+	}, true
 }

--- a/cl/phase1/network/services/payload_attestation_service_test.go
+++ b/cl/phase1/network/services/payload_attestation_service_test.go
@@ -108,9 +108,9 @@ func setupPayloadAttestationService(t *testing.T, ctrl *gomock.Controller) (*pay
 		netCfg:                nil, // Not used in current implementation
 		seenAttestationsCache: seenCache,
 		emitters:              beaconevents.NewEventEmitter(),
-		pendingCond:           sync.NewCond(&sync.Mutex{}), // Needed for queuePendingAttestation
 		validationAdmission:   make(chan struct{}, maxConcurrentPayloadAttestationValidations),
 	}
+	service.pending = service.newPendingQueue()
 
 	return service, forkchoiceMock, ethClockMock
 }
@@ -477,11 +477,11 @@ func TestPayloadAttestationServiceBlockNotFound(t *testing.T) {
 	require.True(t, errors.Is(err, ErrAttestationQueued))
 
 	// Verify attestation was queued
-	require.Equal(t, int32(1), service.pendingCount.Load())
+	require.Equal(t, int32(1), service.pending.count.Load())
 
 	// Verify the pending key
 	key := pendingPayloadAttestationKeyFor(blockRoot, msg)
-	_, exists := service.pendingAttestations.Load(key)
+	_, exists := service.pending.jobs.Load(key)
 	require.True(t, exists)
 }
 
@@ -500,10 +500,10 @@ func TestPayloadAttestationServicePendingQueueKeepsDistinctSameValidatorBlock(t 
 	service.queuePendingAttestation(blockRoot, first)
 	service.queuePendingAttestation(blockRoot, second)
 
-	require.Equal(t, int32(2), service.pendingCount.Load())
-	_, firstExists := service.pendingAttestations.Load(pendingPayloadAttestationKeyFor(blockRoot, first))
+	require.Equal(t, int32(2), service.pending.count.Load())
+	_, firstExists := service.pending.jobs.Load(pendingPayloadAttestationKeyFor(blockRoot, first))
 	require.True(t, firstExists)
-	_, secondExists := service.pendingAttestations.Load(pendingPayloadAttestationKeyFor(blockRoot, second))
+	_, secondExists := service.pending.jobs.Load(pendingPayloadAttestationKeyFor(blockRoot, second))
 	require.True(t, secondExists)
 }
 
@@ -598,17 +598,17 @@ func TestPayloadAttestationServicePendingExpiry(t *testing.T) {
 
 	// Add expired job directly
 	key := pendingPayloadAttestationKeyFor(blockRoot, msg)
-	service.pendingAttestations.Store(key, &pendingPayloadAttestationJob{
+	service.pending.jobs.Store(key, &pendingJob[*cltypes.PayloadAttestationMessage]{
 		msg:          msg,
 		creationTime: time.Now().Add(-pendingPayloadAttestationExpiry - time.Second), // expired
 	})
-	service.pendingCount.Store(1)
+	service.pending.count.Store(1)
 
 	// Process pending - should remove expired
-	service.processPendingAttestations(context.Background())
+	service.pending.processPending(context.Background())
 
-	require.Equal(t, int32(0), service.pendingCount.Load())
-	_, exists := service.pendingAttestations.Load(key)
+	require.Equal(t, int32(0), service.pending.count.Load())
+	_, exists := service.pending.jobs.Load(key)
 	require.False(t, exists)
 }
 
@@ -623,20 +623,20 @@ func TestPayloadAttestationServicePendingSlotMismatch(t *testing.T) {
 
 	// Add pending job
 	key := pendingPayloadAttestationKeyFor(blockRoot, msg)
-	service.pendingAttestations.Store(key, &pendingPayloadAttestationJob{
+	service.pending.jobs.Store(key, &pendingJob[*cltypes.PayloadAttestationMessage]{
 		msg:          msg,
 		creationTime: time.Now(),
 	})
-	service.pendingCount.Store(1)
+	service.pending.count.Store(1)
 
 	// Mock: slot 100 is no longer current
 	ethClockMock.EXPECT().IsSlotCurrentSlotWithMaximumClockDisparity(uint64(100)).Return(false)
 
 	// Process pending - should remove due to slot mismatch
-	service.processPendingAttestations(context.Background())
+	service.pending.processPending(context.Background())
 
-	require.Equal(t, int32(0), service.pendingCount.Load())
-	_, exists := service.pendingAttestations.Load(key)
+	require.Equal(t, int32(0), service.pending.count.Load())
+	_, exists := service.pending.jobs.Load(key)
 	require.False(t, exists)
 }
 
@@ -651,16 +651,16 @@ func TestPayloadAttestationServicePendingProcessing(t *testing.T) {
 
 	// Add pending job
 	key := pendingPayloadAttestationKeyFor(blockRoot, msg)
-	service.pendingAttestations.Store(key, &pendingPayloadAttestationJob{
+	service.pending.jobs.Store(key, &pendingJob[*cltypes.PayloadAttestationMessage]{
 		msg:          msg,
 		creationTime: time.Now(),
 	})
-	service.pendingCount.Store(1)
+	service.pending.count.Store(1)
 
 	// First process: slot ok, but block not available
 	ethClockMock.EXPECT().IsSlotCurrentSlotWithMaximumClockDisparity(uint64(100)).Return(true)
-	service.processPendingAttestations(context.Background())
-	require.Equal(t, int32(1), service.pendingCount.Load()) // Still pending
+	service.pending.processPending(context.Background())
+	require.Equal(t, int32(1), service.pending.count.Load()) // Still pending
 
 	// Now add block header
 	fcu.Headers[blockRoot] = &cltypes.BeaconBlockHeader{
@@ -670,10 +670,10 @@ func TestPayloadAttestationServicePendingProcessing(t *testing.T) {
 	// Second process: slot ok, block available -> should process
 	// ProcessMessage will be called, which calls IsSlotCurrentSlotWithMaximumClockDisparity again
 	ethClockMock.EXPECT().IsSlotCurrentSlotWithMaximumClockDisparity(uint64(100)).Return(true).Times(2)
-	service.processPendingAttestations(context.Background())
+	service.pending.processPending(context.Background())
 
-	require.Equal(t, int32(0), service.pendingCount.Load())
-	_, exists := service.pendingAttestations.Load(key)
+	require.Equal(t, int32(0), service.pending.count.Load())
+	_, exists := service.pending.jobs.Load(key)
 	require.False(t, exists)
 
 	// Attestation should be marked as seen
@@ -693,15 +693,15 @@ func TestPayloadAttestationServiceMultiplePendingForSameBlock(t *testing.T) {
 	msg2 := newTestPayloadAttestationMessage(100, 2, blockRoot)
 
 	// Add both as pending
-	service.pendingAttestations.Store(pendingPayloadAttestationKeyFor(blockRoot, msg1), &pendingPayloadAttestationJob{
+	service.pending.jobs.Store(pendingPayloadAttestationKeyFor(blockRoot, msg1), &pendingJob[*cltypes.PayloadAttestationMessage]{
 		msg:          msg1,
 		creationTime: time.Now(),
 	})
-	service.pendingAttestations.Store(pendingPayloadAttestationKeyFor(blockRoot, msg2), &pendingPayloadAttestationJob{
+	service.pending.jobs.Store(pendingPayloadAttestationKeyFor(blockRoot, msg2), &pendingJob[*cltypes.PayloadAttestationMessage]{
 		msg:          msg2,
 		creationTime: time.Now(),
 	})
-	service.pendingCount.Store(2)
+	service.pending.count.Store(2)
 
 	// Add block header
 	fcu.Headers[blockRoot] = &cltypes.BeaconBlockHeader{
@@ -712,9 +712,9 @@ func TestPayloadAttestationServiceMultiplePendingForSameBlock(t *testing.T) {
 	ethClockMock.EXPECT().IsSlotCurrentSlotWithMaximumClockDisparity(uint64(100)).Return(true).Times(4)
 
 	// Process - both should be processed
-	service.processPendingAttestations(context.Background())
+	service.pending.processPending(context.Background())
 
-	require.Equal(t, int32(0), service.pendingCount.Load())
+	require.Equal(t, int32(0), service.pending.count.Load())
 	require.True(t, service.seenAttestationsCache.Contains(seenPayloadAttestationKey{100, 1}))
 	require.True(t, service.seenAttestationsCache.Contains(seenPayloadAttestationKey{100, 2}))
 }
@@ -726,7 +726,7 @@ func TestPayloadAttestationServicePendingQueueCap(t *testing.T) {
 	service, _, _ := setupPayloadAttestationService(t, ctrl)
 
 	// Fill the queue to the cap
-	service.pendingCount.Store(maxPendingAttestations)
+	service.pending.count.Store(maxPendingAttestations)
 
 	blockRoot := common.HexToHash("0xffff")
 	msg := newTestPayloadAttestationMessage(100, 999, blockRoot)
@@ -734,9 +734,9 @@ func TestPayloadAttestationServicePendingQueueCap(t *testing.T) {
 	service.queuePendingAttestation(blockRoot, msg)
 
 	// Should still be at cap — new item was rejected
-	require.Equal(t, int32(maxPendingAttestations), service.pendingCount.Load())
+	require.Equal(t, int32(maxPendingAttestations), service.pending.count.Load())
 	key := pendingPayloadAttestationKeyFor(blockRoot, msg)
-	_, exists := service.pendingAttestations.Load(key)
+	_, exists := service.pending.jobs.Load(key)
 	require.False(t, exists)
 }
 
@@ -747,7 +747,7 @@ func TestPayloadAttestationServicePendingQueueCapConcurrent(t *testing.T) {
 	service, _, _ := setupPayloadAttestationService(t, ctrl)
 
 	// Start near cap so only a few slots remain
-	service.pendingCount.Store(maxPendingAttestations - 5)
+	service.pending.count.Store(maxPendingAttestations - 5)
 
 	var wg sync.WaitGroup
 	for i := range 100 {
@@ -759,9 +759,9 @@ func TestPayloadAttestationServicePendingQueueCapConcurrent(t *testing.T) {
 	}
 	wg.Wait()
 
-	require.Equal(t, int32(maxPendingAttestations), service.pendingCount.Load())
+	require.Equal(t, int32(maxPendingAttestations), service.pending.count.Load())
 	stored := 0
-	service.pendingAttestations.Range(func(_, _ any) bool {
+	service.pending.jobs.Range(func(_, _ any) bool {
 		stored++
 		return true
 	})

--- a/cl/phase1/network/services/pending_job_queue.go
+++ b/cl/phase1/network/services/pending_job_queue.go
@@ -1,0 +1,165 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package services
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type pendingJob[M any] struct {
+	msg          M
+	creationTime time.Time
+}
+
+// pendingJobQueue holds gossip messages whose processing dependencies have not
+// arrived yet and retries them periodically until processed or expired.
+type pendingJobQueue[K comparable, M any] struct {
+	capacity int32
+	expiry   time.Duration
+	tick     time.Duration
+	// tryProcess decides a job's fate: done=false keeps it queued for the next
+	// tick; done=true removes it. A non-nil process func runs after the removal,
+	// so that a concurrent re-enqueue under the same key is not lost.
+	tryProcess func(ctx context.Context, key K, msg M) (process func(), done bool)
+	onExpired  func(key K)
+
+	jobs  sync.Map // K -> *pendingJob[M]
+	count atomic.Int32
+	cond  *sync.Cond
+}
+
+func newPendingJobQueue[K comparable, M any](
+	capacity int32,
+	expiry time.Duration,
+	tick time.Duration,
+	tryProcess func(ctx context.Context, key K, msg M) (func(), bool),
+	onExpired func(key K),
+) *pendingJobQueue[K, M] {
+	return &pendingJobQueue[K, M]{
+		capacity:   capacity,
+		expiry:     expiry,
+		tick:       tick,
+		tryProcess: tryProcess,
+		onExpired:  onExpired,
+		cond:       sync.NewCond(&sync.Mutex{}),
+	}
+}
+
+func (q *pendingJobQueue[K, M]) enqueueLazy(msg M, buildKey func() (K, error)) error {
+	if !q.reserve() {
+		return nil
+	}
+
+	key, err := buildKey()
+	if err != nil {
+		q.count.Add(-1)
+		return err
+	}
+	q.storeReserved(key, msg)
+	return nil
+}
+
+func (q *pendingJobQueue[K, M]) reserve() bool {
+	if q.count.Add(1) > q.capacity {
+		q.count.Add(-1)
+		return false
+	}
+	return true
+}
+
+func (q *pendingJobQueue[K, M]) storeReserved(key K, msg M) {
+	if _, loaded := q.jobs.LoadOrStore(key, &pendingJob[M]{
+		msg:          msg,
+		creationTime: time.Now(),
+	}); loaded {
+		q.count.Add(-1)
+	} else {
+		q.cond.L.Lock()
+		q.cond.Signal()
+		q.cond.L.Unlock()
+	}
+}
+
+func (q *pendingJobQueue[K, M]) remove(key K) {
+	q.jobs.Delete(key)
+	q.count.Add(-1)
+}
+
+// loop is the background goroutine that retries pending jobs.
+func (q *pendingJobQueue[K, M]) loop(ctx context.Context) {
+	// Wake any blocked Wait() on context cancellation to prevent deadlock.
+	go func() {
+		<-ctx.Done()
+		q.cond.L.Lock()
+		q.cond.Broadcast()
+		q.cond.L.Unlock()
+	}()
+
+	for {
+		// Wait until there are pending jobs
+		q.cond.L.Lock()
+		for q.count.Load() == 0 {
+			select {
+			case <-ctx.Done():
+				q.cond.L.Unlock()
+				return
+			default:
+			}
+			q.cond.Wait()
+		}
+		q.cond.L.Unlock()
+
+		// Poll until all pending jobs are processed
+		ticker := time.NewTicker(q.tick)
+		for q.count.Load() > 0 {
+			select {
+			case <-ctx.Done():
+				ticker.Stop()
+				return
+			case <-ticker.C:
+				q.processPending(ctx)
+			}
+		}
+		ticker.Stop()
+	}
+}
+
+func (q *pendingJobQueue[K, M]) processPending(ctx context.Context) {
+	q.jobs.Range(func(key, value any) bool {
+		k := key.(K)
+		job := value.(*pendingJob[M])
+
+		if time.Since(job.creationTime) > q.expiry {
+			q.remove(k)
+			q.onExpired(k)
+			return true
+		}
+
+		process, done := q.tryProcess(ctx, k, job.msg)
+		if !done {
+			return true
+		}
+		q.remove(k)
+		if process != nil {
+			process()
+		}
+		return true
+	})
+}


### PR DESCRIPTION
First PR in the split of #22177.

This PR extracts the duplicated pending scheduler used by execution-payload envelopes and payload attestations into an unexported `pendingJobQueue[K, M]`.

There are no intended behavior changes. Each service keeps its existing key, capacity, 100 ms polling interval, 30-second expiry, duplicate handling, full-queue fast path, removal-before-processing order, cancellation behavior, and logs. The existing service tests are mechanically adapted to the shared representation.

TDD was not used because this is a pure refactor; the existing service tests are the safety net.

## Stack

- #23643 — shared-queue refactor (this PR)
- #23644 — queue hardening and bid migration
- #23645 — deferred Gloas data-column sidecars
- #23646 — deferred beacon blocks

The last two PRs are sibling branches and can be reviewed independently after #23644.
