### PR TITLE
cl/services: harden deferred Gloas data-column sidecars

### DIFF
--- a/cl/phase1/network/services/data_column_sidecar_service.go
+++ b/cl/phase1/network/services/data_column_sidecar_service.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/erigontech/erigon/cl/beacon/beaconevents"
@@ -52,16 +50,13 @@ type dataColumnSidecarService struct {
 	columnSidecarStorage blob_storage.DataColumnStorage
 	emitters             *beaconevents.EventEmitter
 
-	// [New in Gloas:EIP7732] Pending sidecars waiting for block to arrive
-	pendingGloasSidecars     sync.Map // map[seenGloasSidecarKey]*pendingGloasSidecarJob
-	pendingGloasSidecarCount atomic.Int32
+	// [New in Gloas:EIP7732] Pending sidecars waiting for their blocks.
+	pendingGloasSidecars *pendingJobQueue[pendingGloasSidecarKey, pendingGloasSidecar]
 }
 
-// pendingGloasSidecarJob holds a sidecar that is waiting for its block to arrive
-type pendingGloasSidecarJob struct {
-	sidecar      *cltypes.DataColumnSidecar
-	subnet       *uint64
-	creationTime time.Time
+type pendingGloasSidecar struct {
+	sidecar *cltypes.DataColumnSidecar
+	subnet  *uint64
 }
 
 // seenSidecarKey is used for Fulu (pre-GLOAS) seen tracking
@@ -76,6 +71,17 @@ type seenSidecarKey struct {
 type seenGloasSidecarKey struct {
 	beaconBlockRoot common.Hash
 	index           uint64
+}
+
+// pendingGloasSidecarKey includes the full message root because candidates enter
+// the pending queue before validation. This prevents an invalid candidate from
+// suppressing another for the same block and column. Slot is retained for expiry
+// diagnostics.
+type pendingGloasSidecarKey struct {
+	beaconBlockRoot common.Hash
+	index           uint64
+	slot            uint64
+	messageRoot     common.Hash
 }
 
 func NewDataColumnSidecarService(
@@ -106,8 +112,24 @@ func NewDataColumnSidecarService(
 		columnSidecarStorage: columnSidecarStorage,
 		emitters:             emitters,
 	}
-	go s.loopPendingGloasSidecars(ctx)
+	s.pendingGloasSidecars = s.newPendingGloasSidecarQueue(ctx)
 	return s
+}
+
+func (s *dataColumnSidecarService) newPendingGloasSidecarQueue(ctx context.Context) *pendingJobQueue[pendingGloasSidecarKey, pendingGloasSidecar] {
+	return newPendingJobQueue(ctx, pendingJobQueueOptions{
+		name:          "gloas_data_column_sidecar",
+		capacity:      maxPendingGloasSidecars,
+		expiry:        pendingGloasSidecarExpiry,
+		checkInterval: pendingGloasSidecarTick,
+	},
+		s.tryProcessPendingGloasSidecar,
+		nil,
+		func(key pendingGloasSidecarKey, _ pendingGloasSidecar) {
+			log.Debug("[dataColumnSidecarService] expired pending GLOAS sidecar",
+				"slot", key.slot, "blockRoot", key.beaconBlockRoot.String(), "index", key.index)
+		},
+		nil)
 }
 
 func (s *dataColumnSidecarService) Names() []string {
@@ -187,14 +209,14 @@ func (s *dataColumnSidecarService) processFuluMessage(ctx context.Context, subne
 		return errors.New("invalid column sidecar length")
 	}
 
-	// [REJECT] The sidecar is valid as verified by verify_data_column_sidecar(sidecar).
-	if !verifyDataColumnSidecar(msg) {
-		return errors.New("invalid data column sidecar")
-	}
-
 	// [REJECT] The sidecar is for the correct subnet
 	if subnet != nil && *subnet != computeSubnetForDataColumnSidecar(msg.Index) {
 		return fmt.Errorf("incorrect subnet %d for data column sidecar index %d", *subnet, msg.Index)
+	}
+
+	// [REJECT] The sidecar is valid as verified by verify_data_column_sidecar(sidecar).
+	if !verifyDataColumnSidecar(msg) {
+		return errors.New("invalid data column sidecar")
 	}
 
 	// [IGNORE] The sidecar is not from a future slot
@@ -270,6 +292,12 @@ func (s *dataColumnSidecarService) processGloasMessage(ctx context.Context, subn
 		return ErrIgnore
 	}
 
+	// [REJECT] The sidecar is for the correct subnet. This must precede
+	// content-based IGNORE checks so source metadata cannot alter their verdict.
+	if subnet != nil && *subnet != computeSubnetForDataColumnSidecar(msg.Index) {
+		return fmt.Errorf("incorrect subnet %d for data column sidecar index %d", *subnet, msg.Index)
+	}
+
 	// [IGNORE] The sidecar is not from a future slot (with some tolerance for clock disparity)
 	if slot > s.ethClock.GetCurrentSlot() && !s.ethClock.IsSlotCurrentSlotWithMaximumClockDisparity(slot) {
 		return ErrIgnore
@@ -328,11 +356,6 @@ func (s *dataColumnSidecarService) processGloasMessage(ctx context.Context, subn
 		return errors.New("invalid data column sidecar")
 	}
 
-	// [REJECT] The sidecar is for the correct subnet
-	if subnet != nil && *subnet != computeSubnetForDataColumnSidecar(msg.Index) {
-		return fmt.Errorf("incorrect subnet %d for data column sidecar index %d", *subnet, msg.Index)
-	}
-
 	// [REJECT] The sidecar's column data is valid as verified by verify_data_column_sidecar_kzg_proofs(sidecar, bid.blob_kzg_commitments)
 	if !verifyDataColumnSidecarKZGProofsWithCommitments(msg, kzgCommitments) {
 		return errors.New("invalid kzg proofs for data column sidecar")
@@ -383,91 +406,59 @@ func (s *dataColumnSidecarService) verifyProposerSignature(proposerIndex uint64,
 	return valid, nil
 }
 
-// scheduleSidecarForLaterProcessing queues a GLOAS sidecar for later processing when its block arrives
+// scheduleSidecarForLaterProcessing queues a GLOAS sidecar until its block arrives.
 func (s *dataColumnSidecarService) scheduleSidecarForLaterProcessing(sidecar *cltypes.DataColumnSidecar, subnet *uint64) {
-	if s.pendingGloasSidecarCount.Load() >= maxPendingGloasSidecars {
-		log.Trace("[dataColumnSidecarService] pending GLOAS sidecars at capacity, dropping",
-			"slot", sidecar.Slot, "blockRoot", sidecar.BeaconBlockRoot.String(), "index", sidecar.Index)
-		return
+	_, err := s.pendingGloasSidecars.enqueueLazy(pendingGloasSidecar{
+		sidecar: sidecar,
+		subnet:  subnet,
+	}, func() (pendingGloasSidecarKey, error) { return pendingGloasSidecarKeyFor(sidecar) })
+	if err != nil {
+		log.Warn("[dataColumnSidecarService] failed to hash pending GLOAS sidecar",
+			"slot", sidecar.Slot, "blockRoot", sidecar.BeaconBlockRoot.String(), "index", sidecar.Index, "err", err)
 	}
-
-	key := seenGloasSidecarKey{
-		beaconBlockRoot: sidecar.BeaconBlockRoot,
-		index:           sidecar.Index,
-	}
-
-	// Don't schedule if already pending
-	if _, loaded := s.pendingGloasSidecars.LoadOrStore(key, &pendingGloasSidecarJob{
-		sidecar:      sidecar,
-		subnet:       subnet,
-		creationTime: time.Now(),
-	}); loaded {
-		return
-	}
-	s.pendingGloasSidecarCount.Add(1)
-
-	log.Debug("[dataColumnSidecarService] scheduled GLOAS sidecar for later processing",
-		"slot", sidecar.Slot, "blockRoot", sidecar.BeaconBlockRoot.String(), "index", sidecar.Index)
 }
 
-// loopPendingGloasSidecars periodically retries processing pending sidecars
-func (s *dataColumnSidecarService) loopPendingGloasSidecars(ctx context.Context) {
-	ticker := time.NewTicker(pendingGloasSidecarTick)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-		}
-
-		s.pendingGloasSidecars.Range(func(key, value any) bool {
-			job := value.(*pendingGloasSidecarJob)
-			sidecarKey := key.(seenGloasSidecarKey)
-
-			// Check if expired
-			if time.Since(job.creationTime) > pendingGloasSidecarExpiry {
-				s.pendingGloasSidecars.Delete(sidecarKey)
-				s.pendingGloasSidecarCount.Add(-1)
-				log.Debug("[dataColumnSidecarService] expired pending GLOAS sidecar",
-					"slot", job.sidecar.Slot, "blockRoot", job.sidecar.BeaconBlockRoot.String(), "index", job.sidecar.Index)
-				return true
-			}
-
-			// Check if slot has become finalized while waiting
-			if job.sidecar.Slot <= s.forkChoice.FinalizedSlot() {
-				s.pendingGloasSidecars.Delete(sidecarKey)
-				s.pendingGloasSidecarCount.Add(-1)
-				log.Debug("[dataColumnSidecarService] pending GLOAS sidecar slot is now finalized",
-					"slot", job.sidecar.Slot, "blockRoot", job.sidecar.BeaconBlockRoot.String(), "index", job.sidecar.Index)
-				return true
-			}
-
-			// Only retry if block is now available in forkChoice (recent blocks only)
-			if _, ok := s.forkChoice.GetBlock(job.sidecar.BeaconBlockRoot); !ok {
-				// Block still not available, keep waiting
-				return true
-			}
-
-			// Block is available, try to process
-			if err := s.processGloasMessage(ctx, job.subnet, job.sidecar); err != nil {
-				// Processing failed for another reason (not block delay), remove from pending
-				s.pendingGloasSidecars.Delete(sidecarKey)
-				s.pendingGloasSidecarCount.Add(-1)
-				if !errors.Is(err, ErrIgnore) {
-					log.Trace("[dataColumnSidecarService] failed to process pending GLOAS sidecar",
-						"slot", job.sidecar.Slot, "blockRoot", job.sidecar.BeaconBlockRoot.String(), "index", job.sidecar.Index, "err", err)
-				}
-				return true
-			}
-
-			// Successfully processed, remove from pending
-			s.pendingGloasSidecars.Delete(sidecarKey)
-			s.pendingGloasSidecarCount.Add(-1)
-			log.Debug("[dataColumnSidecarService] successfully processed pending GLOAS sidecar",
-				"slot", job.sidecar.Slot, "blockRoot", job.sidecar.BeaconBlockRoot.String(), "index", job.sidecar.Index)
-			return true
-		})
+func pendingGloasSidecarKeyFor(sidecar *cltypes.DataColumnSidecar) (pendingGloasSidecarKey, error) {
+	root, err := sidecar.HashSSZ()
+	if err != nil {
+		return pendingGloasSidecarKey{}, err
 	}
+	return pendingGloasSidecarKey{
+		beaconBlockRoot: sidecar.BeaconBlockRoot,
+		index:           sidecar.Index,
+		slot:            sidecar.Slot,
+		messageRoot:     common.Hash(root),
+	}, nil
+}
+
+func (s *dataColumnSidecarService) tryProcessPendingGloasSidecar(
+	ctx context.Context,
+	_ pendingGloasSidecarKey,
+	pending pendingGloasSidecar,
+) pendingJobDecision {
+	sidecar := pending.sidecar
+	if sidecar.Slot <= s.forkChoice.FinalizedSlot() {
+		log.Debug("[dataColumnSidecarService] pending GLOAS sidecar slot is now finalized",
+			"slot", sidecar.Slot, "blockRoot", sidecar.BeaconBlockRoot.String(), "index", sidecar.Index)
+		return pendingJobRemove
+	}
+	if _, ok := s.forkChoice.GetBlock(sidecar.BeaconBlockRoot); !ok {
+		return pendingJobKeep
+	}
+	// Keep the entry while processing. If the referenced block disappears, any
+	// re-enqueue must deduplicate against this job and preserve its expiry window.
+	if err := s.processGloasMessage(ctx, pending.subnet, sidecar); err != nil {
+		if errors.Is(err, ErrIgnore) {
+			if _, ok := s.forkChoice.GetBlock(sidecar.BeaconBlockRoot); !ok {
+				return pendingJobKeep
+			}
+		} else {
+			log.Trace("[dataColumnSidecarService] failed to process pending GLOAS sidecar",
+				"slot", sidecar.Slot, "blockRoot", sidecar.BeaconBlockRoot.String(), "index", sidecar.Index, "err", err)
+		}
+		return pendingJobRemove
+	}
+	log.Debug("[dataColumnSidecarService] successfully processed pending GLOAS sidecar",
+		"slot", sidecar.Slot, "blockRoot", sidecar.BeaconBlockRoot.String(), "index", sidecar.Index)
+	return pendingJobRemove
 }

--- a/cl/phase1/network/services/data_column_sidecar_service_test.go
+++ b/cl/phase1/network/services/data_column_sidecar_service_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
@@ -19,6 +20,7 @@ import (
 	das_mock "github.com/erigontech/erigon/cl/das/mock_services"
 	das_state_mock "github.com/erigontech/erigon/cl/das/state/mock_services"
 	blob_storage_mock "github.com/erigontech/erigon/cl/persistence/blob_storage/mock_services"
+	"github.com/erigontech/erigon/cl/phase1/forkchoice"
 	forkchoice_mock "github.com/erigontech/erigon/cl/phase1/forkchoice/mock_services"
 	"github.com/erigontech/erigon/cl/utils/bls"
 	"github.com/erigontech/erigon/cl/utils/eth_clock"
@@ -64,6 +66,21 @@ type dataColumnSidecarTestSuite struct {
 	mockFuncs                *mockFuncs
 }
 
+type blockAvailableOnceStore struct {
+	forkchoice.ForkChoiceStorage
+	blockRoot common.Hash
+	block     *cltypes.SignedBeaconBlock
+	getCalls  int
+}
+
+func (s *blockAvailableOnceStore) GetBlock(blockRoot common.Hash) (*cltypes.SignedBeaconBlock, bool) {
+	s.getCalls++
+	if s.getCalls == 1 && blockRoot == s.blockRoot {
+		return s.block, true
+	}
+	return nil, false
+}
+
 func (t *dataColumnSidecarTestSuite) SetupTest() {
 	t.gomockCtrl = gomock.NewController(t.T())
 	t.mockForkChoice = forkchoice_mock.NewForkChoiceStorageMock(t.T())
@@ -89,7 +106,7 @@ func (t *dataColumnSidecarTestSuite) SetupTest() {
 	}
 
 	t.dataColumnSidecarService = NewDataColumnSidecarService(
-		context.Background(),
+		canceledPendingQueueContext(t.T()),
 		t.beaconConfig,
 		t.mockEthClock,
 		t.mockForkChoice,
@@ -227,40 +244,16 @@ func (t *dataColumnSidecarTestSuite) TestProcessMessage_WhenInvalidDataColumnSid
 	t.Contains(err.Error(), "invalid data column sidecar")
 }
 
-// TestProcessMessage_WhenIncorrectSubnet_ReturnsError tests subnet validation
-func (t *dataColumnSidecarTestSuite) TestProcessMessage_WhenIncorrectSubnet_ReturnsError() {
-	// Setup mock functions
+func (t *dataColumnSidecarTestSuite) TestProcessMessage_WhenIncorrectSubnet_RejectsBeforeSidecarVerification() {
 	incorrectSubnet := uint64(987654321)
-	computeSubnetForDataColumnSidecar = func(index uint64) uint64 { return 1234 } // Return different subnet
+	computeSubnetForDataColumnSidecar = func(index uint64) uint64 { return 1234 }
 	verifyDataColumnSidecar = t.mockFuncs.VerifyDataColumnSidecar
-	blsVerify = t.mockFuncs.BlsVerify
 
-	// Setup
 	t.mockSyncedData.EXPECT().Syncing().Return(false)
-	t.mockEthClock.EXPECT().GetCurrentSlot().Return(testSlot).AnyTimes()
-	t.mockFuncs.ctrl.RecordCall(t.mockFuncs, "VerifyDataColumnSidecar", gomock.Any()).Return(true).AnyTimes()
-	t.mockFuncs.ctrl.RecordCall(t.mockFuncs, "BlsVerify", gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 
-	// Mock fork choice methods to avoid panic
-	t.mockForkChoice.Headers[testParentRoot] = &cltypes.BeaconBlockHeader{
-		// Slot: testSlot - 1,
-	}
-	t.mockForkChoice.FinalizedCheckpointVal = solid.Checkpoint{
-		// Epoch: (testSlot - 100) / 32,
-		// Root:  [32]byte{1},
-	}
-	//t.mockForkChoice.Ancestors[(testSlot-100)/32*32] = [32]byte{1}
-
-	// Mock ViewHeadState to avoid panic
-	t.mockSyncedData.EXPECT().ViewHeadState(gomock.Any()).DoAndReturn(func(fn synced_data.ViewHeadStateFn) error {
-		return nil
-	}).Return(nil).AnyTimes()
-
-	// Execute
 	sidecar := createMockDataColumnSidecar(testSlot, 0)
 	err := t.dataColumnSidecarService.ProcessMessage(context.Background(), &incorrectSubnet, sidecar)
 
-	// Assert
 	t.Error(err)
 	t.Contains(err.Error(), "incorrect subnet")
 }
@@ -557,6 +550,21 @@ func (t *dataColumnSidecarTestSuite) TestGloasProcessMessage_WhenFutureSlot_Retu
 	t.Equal(ErrIgnore, err)
 }
 
+func (t *dataColumnSidecarTestSuite) TestGloasProcessMessage_WhenIncorrectSubnetAndFutureSlot_ReturnsError() {
+	computeSubnetForDataColumnSidecar = func(index uint64) uint64 { return 1234 }
+	incorrectSubnet := uint64(9999)
+
+	t.mockSyncedData.EXPECT().Syncing().Return(false)
+	t.mockEthClock.EXPECT().GetCurrentSlot().Return(testSlot).AnyTimes()
+	t.mockEthClock.EXPECT().IsSlotCurrentSlotWithMaximumClockDisparity(testSlot + 100).Return(false).AnyTimes()
+
+	sidecar := createMockGloasDataColumnSidecar(testSlot+100, 0, testBlockRoot)
+	err := t.dataColumnSidecarService.ProcessMessage(context.Background(), &incorrectSubnet, sidecar)
+
+	t.Error(err)
+	t.Contains(err.Error(), "incorrect subnet")
+}
+
 // TestGloasProcessMessage_WhenSlotFinalized_ReturnsErrIgnore tests GLOAS finalized slot handling
 func (t *dataColumnSidecarTestSuite) TestGloasProcessMessage_WhenSlotFinalized_ReturnsErrIgnore() {
 	t.mockSyncedData.EXPECT().Syncing().Return(false)
@@ -579,6 +587,132 @@ func (t *dataColumnSidecarTestSuite) TestGloasProcessMessage_WhenBlockNotFound_S
 	err := t.dataColumnSidecarService.ProcessMessage(context.Background(), nil, sidecar)
 
 	t.Equal(ErrIgnore, err)
+	service := t.dataColumnSidecarService.(*dataColumnSidecarService)
+	t.Equal(int32(1), service.pendingGloasSidecars.count.Load())
+	key, keyErr := pendingGloasSidecarKeyFor(sidecar)
+	t.NoError(keyErr)
+	_, exists := service.pendingGloasSidecars.jobs.Load(key)
+	t.True(exists)
+}
+
+func (t *dataColumnSidecarTestSuite) TestGloasPendingQueueCap() {
+	service := t.dataColumnSidecarService.(*dataColumnSidecarService)
+	t.Equal(int32(maxPendingGloasSidecars), service.pendingGloasSidecars.capacity)
+	service.pendingGloasSidecars.count.Store(maxPendingGloasSidecars)
+
+	sidecar := createMockGloasDataColumnSidecar(testSlot, 0, testBlockRoot)
+	service.scheduleSidecarForLaterProcessing(sidecar, nil)
+
+	t.Equal(int32(maxPendingGloasSidecars), service.pendingGloasSidecars.count.Load())
+	key, err := pendingGloasSidecarKeyFor(sidecar)
+	t.NoError(err)
+	_, exists := service.pendingGloasSidecars.jobs.Load(key)
+	t.False(exists)
+}
+
+func (t *dataColumnSidecarTestSuite) TestGloasPendingQueueDeduplicates() {
+	service := t.dataColumnSidecarService.(*dataColumnSidecarService)
+	sidecar := createMockGloasDataColumnSidecar(testSlot, 0, testBlockRoot)
+
+	service.scheduleSidecarForLaterProcessing(sidecar, nil)
+	service.scheduleSidecarForLaterProcessing(sidecar, nil)
+
+	t.Equal(int32(1), service.pendingGloasSidecars.count.Load())
+}
+
+func (t *dataColumnSidecarTestSuite) TestGloasPendingQueueKeepsDistinctContentForSameColumn() {
+	service := t.dataColumnSidecarService.(*dataColumnSidecarService)
+	first := createMockGloasDataColumnSidecar(testSlot, 0, testBlockRoot)
+	second := createMockGloasDataColumnSidecar(testSlot, 0, testBlockRoot)
+	differentProof := &cltypes.KZGProof{}
+	differentProof[0] = 0xff
+	second.KzgProofs.Append(differentProof)
+
+	service.scheduleSidecarForLaterProcessing(first, nil)
+	service.scheduleSidecarForLaterProcessing(second, nil)
+
+	t.Equal(int32(2), service.pendingGloasSidecars.count.Load())
+}
+
+func (t *dataColumnSidecarTestSuite) TestGloasPendingQueueKeepsOriginalAgeWhenBlockDisappears() {
+	service := t.dataColumnSidecarService.(*dataColumnSidecarService)
+	sidecar := createMockGloasDataColumnSidecar(testSlot, 0, testBlockRoot)
+	service.scheduleSidecarForLaterProcessing(sidecar, nil)
+
+	var original *pendingJob[pendingGloasSidecar]
+	service.pendingGloasSidecars.jobs.Range(func(_, value any) bool {
+		original = value.(*pendingJob[pendingGloasSidecar])
+		return false
+	})
+	t.NotNil(original)
+	original.creationTime = time.Now().Add(-pendingGloasSidecarExpiry / 2)
+
+	t.mockEthClock.EXPECT().GetCurrentSlot().Return(testSlot).AnyTimes()
+	service.forkChoice = &blockAvailableOnceStore{
+		ForkChoiceStorage: t.mockForkChoice,
+		blockRoot:         testBlockRoot,
+		block:             createMockGloasBlock(testSlot, testBlockRoot),
+	}
+	service.pendingGloasSidecars.processPending(t.T().Context())
+
+	var stored *pendingJob[pendingGloasSidecar]
+	service.pendingGloasSidecars.jobs.Range(func(_, value any) bool {
+		stored = value.(*pendingJob[pendingGloasSidecar])
+		return false
+	})
+	t.Same(original, stored)
+	t.Equal(int32(1), service.pendingGloasSidecars.count.Load())
+}
+
+func (t *dataColumnSidecarTestSuite) TestGloasPendingQueueDropsFinalizedSidecar() {
+	service := t.dataColumnSidecarService.(*dataColumnSidecarService)
+	t.mockForkChoice.FinalizedSlotVal = testSlot
+	sidecar := createMockGloasDataColumnSidecar(testSlot, 0, testBlockRoot)
+	service.scheduleSidecarForLaterProcessing(sidecar, nil)
+	t.Equal(int32(1), service.pendingGloasSidecars.count.Load())
+
+	service.pendingGloasSidecars.processPending(t.T().Context())
+
+	t.Zero(service.pendingGloasSidecars.count.Load())
+}
+
+func (t *dataColumnSidecarTestSuite) TestGloasPendingQueueExpiryLogsSlot() {
+	service := t.dataColumnSidecarService.(*dataColumnSidecarService)
+	sidecar := createMockGloasDataColumnSidecar(testSlot, 0, testBlockRoot)
+	service.scheduleSidecarForLaterProcessing(sidecar, nil)
+	service.pendingGloasSidecars.jobs.Range(func(_, value any) bool {
+		value.(*pendingJob[pendingGloasSidecar]).creationTime = time.Now().Add(-(pendingGloasSidecarExpiry + time.Second))
+		return false
+	})
+	output := captureServiceLogs(t.T())
+
+	service.pendingGloasSidecars.processPending(t.T().Context())
+
+	t.Zero(service.pendingGloasSidecars.count.Load())
+	t.Contains(output.String(), "slot=321")
+}
+
+func (t *dataColumnSidecarTestSuite) TestGloasPendingQueueProcessesAvailableBlock() {
+	verifyDataColumnSidecarWithCommitments = t.mockFuncs.VerifyDataColumnSidecarWithCommitments
+	verifyDataColumnSidecarKZGProofsWithCommitments = t.mockFuncs.VerifyDataColumnSidecarKZGProofsWithCommitments
+	t.mockEthClock.EXPECT().GetCurrentSlot().Return(testSlot).AnyTimes()
+	t.mockFuncs.ctrl.RecordCall(t.mockFuncs, "VerifyDataColumnSidecarWithCommitments", gomock.Any(), gomock.Any()).Return(true)
+	t.mockFuncs.ctrl.RecordCall(t.mockFuncs, "VerifyDataColumnSidecarKZGProofsWithCommitments", gomock.Any(), gomock.Any()).Return(true)
+	t.mockForkChoice.Blocks[testBlockRoot] = createMockGloasBlock(testSlot, testBlockRoot)
+	t.mockColumnSidecarStorage.EXPECT().WriteColumnSidecars(gomock.Any(), testBlockRoot, int64(0), gomock.Any()).Return(nil)
+	t.mockPeerDas.EXPECT().TryScheduleRecover(testSlot, testBlockRoot).Return(nil)
+
+	service := t.dataColumnSidecarService.(*dataColumnSidecarService)
+	sidecar := createMockGloasDataColumnSidecar(testSlot, 0, testBlockRoot)
+	service.scheduleSidecarForLaterProcessing(sidecar, nil)
+	service.pendingGloasSidecars.processPending(t.T().Context())
+
+	t.Zero(service.pendingGloasSidecars.count.Load())
+	_, seen := service.seenGloasSidecar.Get(seenGloasSidecarKey{
+		beaconBlockRoot: testBlockRoot,
+		index:           sidecar.Index,
+	})
+	t.True(seen)
 }
 
 // TestGloasProcessMessage_WhenSlotMismatch_ReturnsError tests slot mismatch validation
@@ -615,25 +749,21 @@ func (t *dataColumnSidecarTestSuite) TestGloasProcessMessage_WhenInvalidSidecar_
 	t.Contains(err.Error(), "invalid data column sidecar")
 }
 
-// TestGloasProcessMessage_WhenIncorrectSubnet_ReturnsError tests GLOAS subnet validation
-func (t *dataColumnSidecarTestSuite) TestGloasProcessMessage_WhenIncorrectSubnet_ReturnsError() {
-	verifyDataColumnSidecarWithCommitments = t.mockFuncs.VerifyDataColumnSidecarWithCommitments
+func (t *dataColumnSidecarTestSuite) TestGloasProcessMessage_WhenIncorrectSubnet_RejectsBeforeQueueing() {
 	computeSubnetForDataColumnSidecar = func(index uint64) uint64 { return 1234 }
 
 	incorrectSubnet := uint64(9999)
 
 	t.mockSyncedData.EXPECT().Syncing().Return(false)
 	t.mockEthClock.EXPECT().GetCurrentSlot().Return(testSlot).AnyTimes()
-	t.mockFuncs.ctrl.RecordCall(t.mockFuncs, "VerifyDataColumnSidecarWithCommitments", gomock.Any(), gomock.Any()).Return(true).AnyTimes()
-
-	block := createMockGloasBlock(testSlot, testBlockRoot)
-	t.mockForkChoice.Blocks[testBlockRoot] = block
 
 	sidecar := createMockGloasDataColumnSidecar(testSlot, 0, testBlockRoot)
 	err := t.dataColumnSidecarService.ProcessMessage(context.Background(), &incorrectSubnet, sidecar)
 
 	t.Error(err)
 	t.Contains(err.Error(), "incorrect subnet")
+	service := t.dataColumnSidecarService.(*dataColumnSidecarService)
+	t.Zero(service.pendingGloasSidecars.count.Load())
 }
 
 // TestGloasProcessMessage_WhenInvalidKZGProofs_ReturnsError tests GLOAS KZG proof validation

--- a/cl/phase1/network/services/execution_payload_bid_service.go
+++ b/cl/phase1/network/services/execution_payload_bid_service.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/erigontech/erigon/cl/beacon/beaconevents"
@@ -47,17 +46,10 @@ type seenBidKey struct {
 	slot         uint64
 }
 
-// pendingBidKey tracks bids waiting for proposer preferences.
 type pendingBidKey struct {
 	builderIndex uint64
 	slot         uint64
 	messageRoot  common.Hash
-}
-
-// pendingBidJob represents a pending bid waiting for proposer preferences to arrive.
-type pendingBidJob struct {
-	msg          *cltypes.SignedExecutionPayloadBid
-	creationTime time.Time
 }
 
 type bidValidationStateKey struct {
@@ -97,11 +89,8 @@ type executionPayloadBidService struct {
 	validationStateMu    sync.Mutex
 	validationStateCache *lru.CacheWithTTL[bidValidationStateKey, *bidValidationStateEntry]
 
-	// Pending bids waiting for proposer preferences
-	pendingBids  sync.Map // pendingBidKey -> *pendingBidJob
-	pendingMu    sync.Mutex
-	pendingCount atomic.Int32
-	pendingCond  *sync.Cond
+	// pending retains bids until their validation dependencies are available.
+	pending *pendingJobQueue[pendingBidKey, *cltypes.SignedExecutionPayloadBid]
 }
 
 // NewExecutionPayloadBidService creates a new execution payload bid gossip service.
@@ -133,10 +122,25 @@ func NewExecutionPayloadBidService(
 		emitters:             emitters,
 		seenCache:            seenCache,
 		validationStateCache: validationStateCache,
-		pendingCond:          sync.NewCond(&sync.Mutex{}),
 	}
-	go s.loop(ctx)
+	s.pending = s.newPendingQueue(ctx)
 	return s
+}
+
+func (s *executionPayloadBidService) newPendingQueue(ctx context.Context) *pendingJobQueue[pendingBidKey, *cltypes.SignedExecutionPayloadBid] {
+	return newPendingJobQueue(ctx, pendingJobQueueOptions{
+		name:          "execution_payload_bid",
+		capacity:      maxPendingBids,
+		expiry:        pendingBidExpiry,
+		checkInterval: pendingBidCheckInterval,
+	},
+		s.tryProcessPendingBid,
+		nil,
+		func(key pendingBidKey, _ *cltypes.SignedExecutionPayloadBid) {
+			log.Trace("Pending execution payload bid expired",
+				"slot", key.slot, "builderIndex", key.builderIndex)
+		},
+		nil)
 }
 
 func (s *executionPayloadBidService) Names() []string {
@@ -477,156 +481,60 @@ func (s *executionPayloadBidService) validateBuilderAvailability(
 	return builder, nil
 }
 
-// queuePendingBid adds a bid to the pending queue for later processing when preferences arrive.
+// queuePendingBid defers a bid until its validation dependencies are available.
 func (s *executionPayloadBidService) queuePendingBid(msg *cltypes.SignedExecutionPayloadBid) {
-	key := pendingBidKeyFor(msg)
-	job := &pendingBidJob{
-		msg:          msg,
-		creationTime: time.Now(),
+	_, err := s.pending.enqueueLazy(msg, func() (pendingBidKey, error) { return pendingBidKeyFor(msg) })
+	if err != nil {
+		log.Warn("Failed to hash execution payload bid for pending queue",
+			"slot", msg.Message.Slot, "builderIndex", msg.Message.BuilderIndex, "err", err)
 	}
-
-	s.pendingMu.Lock()
-	if _, loaded := s.pendingBids.Load(key); loaded {
-		s.pendingMu.Unlock()
-		return
-	}
-	if s.pendingCount.Load() >= maxPendingBids {
-		s.pendingMu.Unlock()
-		return
-	}
-	s.pendingBids.Store(key, job)
-	s.pendingCount.Add(1)
-	s.pendingMu.Unlock()
-
-	s.signalPendingBids()
 }
 
-func (s *executionPayloadBidService) deletePendingBid(key pendingBidKey, job *pendingBidJob) bool {
-	s.pendingMu.Lock()
-	defer s.pendingMu.Unlock()
-	current, ok := s.pendingBids.Load(key)
-	if !ok || current != job {
-		return false
+func pendingBidKeyFor(msg *cltypes.SignedExecutionPayloadBid) (pendingBidKey, error) {
+	root, err := msg.HashSSZ()
+	if err != nil {
+		return pendingBidKey{}, err
 	}
-	s.pendingBids.Delete(key)
-	s.pendingCount.Add(-1)
-	return true
-}
-
-func (s *executionPayloadBidService) signalPendingBids() {
-	s.pendingCond.L.Lock()
-	s.pendingCond.Signal()
-	s.pendingCond.L.Unlock()
-}
-
-func pendingBidKeyFor(msg *cltypes.SignedExecutionPayloadBid) pendingBidKey {
-	root, _ := msg.HashSSZ()
 	return pendingBidKey{
 		builderIndex: msg.Message.BuilderIndex,
 		slot:         msg.Message.Slot,
 		messageRoot:  common.Hash(root),
-	}
+	}, nil
 }
 
-// loop is the background goroutine that processes pending bids.
-func (s *executionPayloadBidService) loop(ctx context.Context) {
-	// Wake any blocked Wait() on context cancellation to prevent deadlock.
-	go func() {
-		<-ctx.Done()
-		s.pendingCond.L.Lock()
-		s.pendingCond.Broadcast()
-		s.pendingCond.L.Unlock()
-	}()
-
-	for {
-		// Wait until there are pending bids
-		s.pendingCond.L.Lock()
-		for s.pendingCount.Load() == 0 {
-			select {
-			case <-ctx.Done():
-				s.pendingCond.L.Unlock()
-				return
-			default:
-			}
-			s.pendingCond.Wait()
-		}
-		s.pendingCond.L.Unlock()
-
-		// Poll until all pending bids are processed
-		ticker := time.NewTicker(pendingBidCheckInterval)
-		for s.pendingCount.Load() > 0 {
-			select {
-			case <-ctx.Done():
-				ticker.Stop()
-				return
-			case <-ticker.C:
-				s.processPendingBids()
-			}
-		}
-		ticker.Stop()
+// tryProcessPendingBid retains bids with unavailable dependencies and removes
+// stale, invalid, or successfully stored bids.
+func (s *executionPayloadBidService) tryProcessPendingBid(_ context.Context, key pendingBidKey, msg *cltypes.SignedExecutionPayloadBid) pendingJobDecision {
+	currentSlot := s.ethClock.GetCurrentSlot()
+	if key.slot != currentSlot && key.slot != currentSlot+1 {
+		log.Trace("Pending execution payload bid slot expired",
+			"slot", key.slot, "builderIndex", key.builderIndex)
+		return pendingJobRemove
 	}
-}
 
-// processPendingBids checks pending bids whose proposer preferences may have arrived.
-func (s *executionPayloadBidService) processPendingBids() {
-	s.pendingBids.Range(func(key, value any) bool {
-		pendingKey := key.(pendingBidKey)
-		job := value.(*pendingBidJob)
+	if s.seenCache.Contains(seenBidKey{builderIndex: key.builderIndex, slot: key.slot}) {
+		return pendingJobRemove
+	}
 
-		// Check expiry
-		if time.Since(job.creationTime) > pendingBidExpiry {
-			if s.deletePendingBid(pendingKey, job) {
-				log.Trace("Pending execution payload bid expired",
-					"slot", pendingKey.slot, "builderIndex", pendingKey.builderIndex)
-			}
-			return true
+	preferences, ok, err := s.matchingProposerPreferences(msg)
+	if err != nil {
+		if errors.Is(err, errBidDependencyUnavailable) {
+			return pendingJobKeep
 		}
+		log.Trace("Failed to match pending execution payload bid",
+			"slot", key.slot, "builderIndex", key.builderIndex, "err", err)
+		return pendingJobRemove
+	}
+	if !ok {
+		return pendingJobKeep
+	}
 
-		// Check if bid slot is still valid
-		currentSlot := s.ethClock.GetCurrentSlot()
-		if pendingKey.slot != currentSlot && pendingKey.slot != currentSlot+1 {
-			if s.deletePendingBid(pendingKey, job) {
-				log.Trace("Pending execution payload bid slot expired",
-					"slot", pendingKey.slot, "builderIndex", pendingKey.builderIndex)
-			}
-			return true
+	if err := s.validateAndStoreBid(msg, preferences); err != nil {
+		if errors.Is(err, errBidDependencyUnavailable) {
+			return pendingJobKeep
 		}
-
-		if s.seenCache.Contains(seenBidKey{builderIndex: pendingKey.builderIndex, slot: pendingKey.slot}) {
-			s.deletePendingBid(pendingKey, job)
-			return true
-		}
-
-		preferences, ok, err := s.matchingProposerPreferences(job.msg)
-		if err != nil {
-			if errors.Is(err, errBidDependencyUnavailable) {
-				return true
-			}
-			if s.deletePendingBid(pendingKey, job) {
-				log.Trace("Failed to match pending execution payload bid",
-					"slot", pendingKey.slot,
-					"builderIndex", pendingKey.builderIndex,
-					"err", err)
-			}
-			return true
-		}
-		if !ok {
-			return true // Preferences still not here, keep waiting
-		}
-
-		if err := s.validateAndStoreBid(job.msg, preferences); err != nil {
-			if errors.Is(err, errBidDependencyUnavailable) {
-				return true
-			}
-			if s.deletePendingBid(pendingKey, job) {
-				log.Trace("Failed to process pending execution payload bid",
-					"slot", pendingKey.slot,
-					"builderIndex", pendingKey.builderIndex,
-					"err", err)
-			}
-			return true
-		}
-		s.deletePendingBid(pendingKey, job)
-		return true
-	})
+		log.Trace("Failed to process pending execution payload bid",
+			"slot", key.slot, "builderIndex", key.builderIndex, "err", err)
+	}
+	return pendingJobRemove
 }

--- a/cl/phase1/network/services/execution_payload_bid_service_test.go
+++ b/cl/phase1/network/services/execution_payload_bid_service_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -63,8 +64,9 @@ func setupExecutionPayloadBidService(t *testing.T, ctrl *gomock.Controller) (
 		emitters:             beaconevents.NewEventEmitter(),
 		seenCache:            seenCache,
 		validationStateCache: validationStateCache,
-		pendingCond:          sync.NewCond(&sync.Mutex{}),
 	}
+	service.pending = service.newPendingQueue(canceledPendingQueueContext(t))
+	service.pending.stopAndWait()
 
 	return service, mockSyncedData, ethClockMock, fcMock, epbsPool
 }
@@ -84,6 +86,13 @@ func newTestSignedExecutionPayloadBid(slot uint64, builderIndex uint64, value ui
 		},
 		Signature: common.Bytes96{},
 	}
+}
+
+func mustPendingBidKey(t *testing.T, msg *cltypes.SignedExecutionPayloadBid) pendingBidKey {
+	t.Helper()
+	key, err := pendingBidKeyFor(msg)
+	require.NoError(t, err)
+	return key
 }
 
 // addPreferencesToPool adds a SignedProposerPreferences to the pool for the given slot.
@@ -278,7 +287,7 @@ func TestExecutionPayloadBidServiceRejectsNonZeroExecutionPaymentBeforeQueue(t *
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "execution_payment must be 0")
-	require.Equal(t, int32(0), service.pendingCount.Load())
+	require.Equal(t, int32(0), service.pending.count.Load())
 }
 
 func TestExecutionPayloadBidServiceRejectsTooManyBlobCommitmentsBeforeQueue(t *testing.T) {
@@ -298,7 +307,7 @@ func TestExecutionPayloadBidServiceRejectsTooManyBlobCommitmentsBeforeQueue(t *t
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "too many blob_kzg_commitments")
-	require.Equal(t, int32(0), service.pendingCount.Load())
+	require.Equal(t, int32(0), service.pending.count.Load())
 }
 
 func TestExecutionPayloadBidServiceWaitsForMatchingDependentRootPreference(t *testing.T) {
@@ -320,15 +329,15 @@ func TestExecutionPayloadBidServiceWaitsForMatchingDependentRootPreference(t *te
 
 	ethClockMock.EXPECT().GetCurrentSlot().Return(uint64(100))
 	require.True(t, errors.Is(service.ProcessMessage(context.Background(), nil, msg), ErrIgnore))
-	require.Equal(t, int32(1), service.pendingCount.Load())
+	require.Equal(t, int32(1), service.pending.count.Load())
 
 	addPreferencesToPool(epbsPool, 100)
 	fcMock.ExecutionPayloadStatusMap[msg.Message.ParentBlockHash] = execution_client.PayloadStatusValidated
 	fcMock.Headers[msg.Message.ParentBlockRoot] = &cltypes.BeaconBlockHeader{}
 	ethClockMock.EXPECT().GetCurrentSlot().Return(uint64(100))
 
-	service.processPendingBids()
-	require.Equal(t, int32(0), service.pendingCount.Load())
+	service.pending.processPending(context.Background())
+	require.Equal(t, int32(0), service.pending.count.Load())
 	_, found := epbsPool.HighestBids.Get(pool.HighestBidKey{Slot: 100, ParentBlockHash: msg.Message.ParentBlockHash, ParentBlockRoot: msg.Message.ParentBlockRoot})
 	require.True(t, found)
 }
@@ -345,19 +354,19 @@ func TestExecutionPayloadBidServiceWaitsForParentState(t *testing.T) {
 
 	ethClockMock.EXPECT().GetCurrentSlot().Return(uint64(100))
 	require.True(t, errors.Is(service.ProcessMessage(context.Background(), nil, msg), ErrIgnore))
-	require.Equal(t, int32(1), service.pendingCount.Load())
+	require.Equal(t, int32(1), service.pending.count.Load())
 
 	ethClockMock.EXPECT().GetCurrentSlot().Return(uint64(100))
-	service.processPendingBids()
-	require.Equal(t, int32(1), service.pendingCount.Load())
+	service.pending.processPending(context.Background())
+	require.Equal(t, int32(1), service.pending.count.Load())
 
 	fcMock.StateAtBlockRootVal[msg.Message.ParentBlockRoot] = newBidParentState(service.beaconCfg, testDependentRoot)
 	fcMock.ExecutionPayloadStatusMap[msg.Message.ParentBlockHash] = execution_client.PayloadStatusValidated
 	fcMock.Headers[msg.Message.ParentBlockRoot] = &cltypes.BeaconBlockHeader{}
 	ethClockMock.EXPECT().GetCurrentSlot().Return(uint64(100))
 
-	service.processPendingBids()
-	require.Equal(t, int32(0), service.pendingCount.Load())
+	service.pending.processPending(context.Background())
+	require.Equal(t, int32(0), service.pending.count.Load())
 	_, found := epbsPool.HighestBids.Get(pool.HighestBidKey{Slot: 100, ParentBlockHash: msg.Message.ParentBlockHash, ParentBlockRoot: msg.Message.ParentBlockRoot})
 	require.True(t, found)
 }
@@ -608,7 +617,7 @@ func TestExecutionPayloadBidServiceRejectsLowerBidBeforeStateFetch(t *testing.T)
 	require.True(t, errors.Is(err, ErrIgnore))
 	require.Contains(t, err.Error(), "not higher than existing")
 	require.Zero(t, service.validationStateCache.Len())
-	require.Equal(t, int32(0), service.pendingCount.Load())
+	require.Equal(t, int32(0), service.pending.count.Load())
 }
 
 func TestExecutionPayloadBidServiceDifferentParentHashes(t *testing.T) {
@@ -682,26 +691,6 @@ func TestExecutionPayloadBidServiceSuccess(t *testing.T) {
 	require.Equal(t, msg, stored)
 }
 
-func TestExecutionPayloadBidServicePendingQueueCap(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	service, _, _, _, _ := setupExecutionPayloadBidService(t, ctrl)
-
-	// Fill the queue to the cap
-	service.pendingCount.Store(maxPendingBids)
-
-	msg := newTestSignedExecutionPayloadBid(100, 999, 1000)
-
-	service.queuePendingBid(msg)
-
-	// Should still be at cap — new item was rejected
-	require.Equal(t, int32(maxPendingBids), service.pendingCount.Load())
-	key := pendingBidKeyFor(msg)
-	_, exists := service.pendingBids.Load(key)
-	require.False(t, exists)
-}
-
 func TestExecutionPayloadBidServicePendingQueueKeepsDistinctSameBuilderSlot(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -715,16 +704,16 @@ func TestExecutionPayloadBidServicePendingQueueKeepsDistinctSameBuilderSlot(t *t
 	service.queuePendingBid(first)
 	service.queuePendingBid(second)
 
-	require.Equal(t, int32(2), service.pendingCount.Load())
-	stored, firstExists := service.pendingBids.Load(pendingBidKeyFor(first))
+	require.Equal(t, int32(2), service.pending.count.Load())
+	stored, firstExists := service.pending.jobs.Load(mustPendingBidKey(t, first))
 	require.True(t, firstExists)
-	require.Same(t, first, stored.(*pendingBidJob).msg)
-	stored, secondExists := service.pendingBids.Load(pendingBidKeyFor(second))
+	require.Same(t, first, stored.(*pendingJob[*cltypes.SignedExecutionPayloadBid]).msg)
+	stored, secondExists := service.pending.jobs.Load(mustPendingBidKey(t, second))
 	require.True(t, secondExists)
-	require.Same(t, second, stored.(*pendingBidJob).msg)
+	require.Same(t, second, stored.(*pendingJob[*cltypes.SignedExecutionPayloadBid]).msg)
 }
 
-func TestExecutionPayloadBidServiceDeletePendingBidDoesNotRemoveOtherSameBuilderSlot(t *testing.T) {
+func TestExecutionPayloadBidServiceRemovePendingBidDoesNotRemoveOtherSameBuilderSlot(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -733,17 +722,17 @@ func TestExecutionPayloadBidServiceDeletePendingBidDoesNotRemoveOtherSameBuilder
 	second := newTestSignedExecutionPayloadBid(100, 1, 2000)
 
 	service.queuePendingBid(first)
-	firstKey := pendingBidKeyFor(first)
-	firstJob, exists := service.pendingBids.Load(firstKey)
+	firstKey := mustPendingBidKey(t, first)
+	firstJob, exists := service.pending.jobs.Load(firstKey)
 	require.True(t, exists)
 
 	service.queuePendingBid(second)
-	require.True(t, service.deletePendingBid(firstKey, firstJob.(*pendingBidJob)))
-	require.Equal(t, int32(1), service.pendingCount.Load())
+	require.True(t, service.pending.remove(firstKey, firstJob.(*pendingJob[*cltypes.SignedExecutionPayloadBid])))
+	require.Equal(t, int32(1), service.pending.count.Load())
 
-	current, exists := service.pendingBids.Load(pendingBidKeyFor(second))
+	current, exists := service.pending.jobs.Load(mustPendingBidKey(t, second))
 	require.True(t, exists)
-	require.Same(t, second, current.(*pendingBidJob).msg)
+	require.Same(t, second, current.(*pendingJob[*cltypes.SignedExecutionPayloadBid]).msg)
 }
 
 func TestExecutionPayloadBidServicePendingQueueCapConcurrent(t *testing.T) {
@@ -752,7 +741,7 @@ func TestExecutionPayloadBidServicePendingQueueCapConcurrent(t *testing.T) {
 
 	service, _, _, _, _ := setupExecutionPayloadBidService(t, ctrl)
 
-	service.pendingCount.Store(maxPendingBids - 5)
+	service.pending.count.Store(maxPendingBids - 5)
 
 	var wg sync.WaitGroup
 	for i := range 100 {
@@ -763,13 +752,103 @@ func TestExecutionPayloadBidServicePendingQueueCapConcurrent(t *testing.T) {
 	}
 	wg.Wait()
 
-	require.Equal(t, int32(maxPendingBids), service.pendingCount.Load())
+	require.Equal(t, int32(maxPendingBids), service.pending.count.Load())
 	stored := 0
-	service.pendingBids.Range(func(_, _ any) bool {
+	service.pending.jobs.Range(func(_, _ any) bool {
 		stored++
 		return true
 	})
 	require.Equal(t, 5, stored)
+}
+
+func TestExecutionPayloadBidServicePendingExpiry(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	service, _, _, _, _ := setupExecutionPayloadBidService(t, ctrl)
+
+	msg := newTestSignedExecutionPayloadBid(100, 1, 1000)
+	key := mustPendingBidKey(t, msg)
+	storePendingJob(t, service.pending, key, msg, time.Now().Add(-(pendingBidExpiry + time.Second)))
+
+	// Expiry is checked before the slot check, so no ethClock call is expected.
+	service.pending.processPending(context.Background())
+
+	require.Equal(t, int32(0), service.pending.count.Load())
+	_, exists := service.pending.jobs.Load(key)
+	require.False(t, exists)
+}
+
+func TestExecutionPayloadBidServicePendingStaleSlotDropped(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	service, _, ethClockMock, _, _ := setupExecutionPayloadBidService(t, ctrl)
+
+	msg := newTestSignedExecutionPayloadBid(100, 1, 1000)
+	key := mustPendingBidKey(t, msg)
+	storePendingJob(t, service.pending, key, msg, time.Now())
+
+	// A stale slot removes the job before any dependency retry.
+	ethClockMock.EXPECT().GetCurrentSlot().Return(uint64(200))
+	output := captureServiceLogs(t)
+
+	service.pending.processPending(context.Background())
+
+	require.Equal(t, int32(0), service.pending.count.Load())
+	_, exists := service.pending.jobs.Load(key)
+	require.False(t, exists)
+	require.Contains(t, output.String(), "Pending execution payload bid slot expired")
+}
+
+func TestExecutionPayloadBidServicePendingValidationFailureLogged(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	service, _, ethClockMock, fcMock, epbsPool := setupExecutionPayloadBidService(t, ctrl)
+	msg := newTestSignedExecutionPayloadBid(100, 1, 1000)
+	msg.Message.FeeRecipient = common.HexToAddress("0xdead")
+	fcMock.Headers[msg.Message.ParentBlockRoot] = &cltypes.BeaconBlockHeader{Slot: 99}
+	addPreferencesToPool(epbsPool, msg.Message.Slot)
+	ethClockMock.EXPECT().GetCurrentSlot().Return(msg.Message.Slot)
+	output := captureServiceLogs(t)
+
+	decision := service.tryProcessPendingBid(t.Context(), mustPendingBidKey(t, msg), msg)
+
+	require.Equal(t, pendingJobRemove, decision)
+	require.Contains(t, output.String(), "Failed to process pending execution payload bid")
+	require.Contains(t, output.String(), "fee_recipient")
+}
+
+// TestExecutionPayloadBidServiceLoopProcessesQueuedBid exercises the real
+// polling loop, including its wake-up and retry after the
+// missing dependency becomes available.
+func TestExecutionPayloadBidServiceLoopProcessesQueuedBid(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	service, _, ethClockMock, fcMock, epbsPool := setupExecutionPayloadBidService(t, ctrl)
+
+	msg := newTestSignedExecutionPayloadBid(100, 1, 1000)
+	fcMock.ExecutionPayloadStatusMap[msg.Message.ParentBlockHash] = execution_client.PayloadStatusValidated
+	fcMock.Headers[msg.Message.ParentBlockRoot] = &cltypes.BeaconBlockHeader{}
+
+	ethClockMock.EXPECT().GetCurrentSlot().Return(uint64(100)).AnyTimes()
+
+	pending := service.newPendingQueue(t.Context())
+	service.pending = pending
+	defer pending.stopAndWait()
+
+	require.ErrorIs(t, service.ProcessMessage(context.Background(), nil, msg), ErrIgnore)
+	require.Equal(t, int32(1), service.pending.count.Load())
+
+	addPreferencesToPool(epbsPool, 100)
+
+	bidKey := pool.HighestBidKey{Slot: 100, ParentBlockHash: msg.Message.ParentBlockHash, ParentBlockRoot: msg.Message.ParentBlockRoot}
+	require.Eventually(t, func() bool {
+		_, found := epbsPool.HighestBids.Get(bidKey)
+		return found && service.pending.count.Load() == 0
+	}, 5*time.Second, 10*time.Millisecond)
 }
 
 func TestExecutionPayloadBidServiceDecodeGossipMessage(t *testing.T) {

--- a/cl/phase1/network/services/execution_payload_service.go
+++ b/cl/phase1/network/services/execution_payload_service.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/erigontech/erigon/cl/beacon/beaconevents"
@@ -52,12 +50,6 @@ type pendingEnvelopeKey struct {
 	envelopeHash common.Hash
 }
 
-// envelopeJob represents a pending envelope waiting for its block to arrive
-type envelopeJob struct {
-	envelope     *cltypes.SignedExecutionPayloadEnvelope
-	creationTime time.Time
-}
-
 const (
 	seenEnvelopeCacheSize        = 1000
 	pendingEnvelopeExpiry        = 30 * time.Second
@@ -74,9 +66,7 @@ type executionPayloadService struct {
 	seenEnvelopesCache *lru.Cache[seenEnvelopeKey, struct{}]
 
 	// Pending envelopes waiting for block to arrive
-	pendingEnvelopes sync.Map // pendingEnvelopeKey -> *envelopeJob
-	pendingCount     atomic.Int32
-	pendingCond      *sync.Cond
+	pending *pendingJobQueue[pendingEnvelopeKey, *cltypes.SignedExecutionPayloadEnvelope]
 }
 
 // NewExecutionPayloadService creates a new execution payload service
@@ -95,10 +85,18 @@ func NewExecutionPayloadService(
 		beaconCfg:          beaconCfg,
 		emitters:           emitters,
 		seenEnvelopesCache: seenEnvelopesCache,
-		pendingCond:        sync.NewCond(&sync.Mutex{}),
 	}
-	go s.loop(ctx)
+	s.pending = s.newPendingQueue()
+	go s.pending.loop(ctx)
 	return s
+}
+
+func (s *executionPayloadService) newPendingQueue() *pendingJobQueue[pendingEnvelopeKey, *cltypes.SignedExecutionPayloadEnvelope] {
+	return newPendingJobQueue(maxPendingEnvelopes, pendingEnvelopeExpiry, pendingEnvelopeCheckInterval,
+		s.tryProcessPendingEnvelope,
+		func(key pendingEnvelopeKey) {
+			log.Trace("Pending envelope expired", "blockRoot", key.blockRoot)
+		})
 }
 
 func (s *executionPayloadService) Names() []string {
@@ -204,104 +202,31 @@ func (s *executionPayloadService) ProcessMessage(ctx context.Context, _ *uint64,
 
 // queuePendingEnvelope adds an envelope to the pending queue for later processing
 func (s *executionPayloadService) queuePendingEnvelope(blockRoot common.Hash, envelope *cltypes.SignedExecutionPayloadEnvelope) {
-	if s.pendingCount.Add(1) > maxPendingEnvelopes {
-		s.pendingCount.Add(-1)
-		return
-	}
-
-	// Compute envelope hash to allow multiple candidates per block
-	envelopeHash, err := envelope.HashSSZ()
-	if err != nil {
-		s.pendingCount.Add(-1)
-		log.Warn("Failed to hash envelope for pending queue", "blockRoot", blockRoot, "err", err)
-		return
-	}
-
-	key := pendingEnvelopeKey{
-		blockRoot:    blockRoot,
-		envelopeHash: envelopeHash,
-	}
-
-	if _, loaded := s.pendingEnvelopes.LoadOrStore(key, &envelopeJob{
-		envelope:     envelope,
-		creationTime: time.Now(),
-	}); loaded {
-		s.pendingCount.Add(-1)
-	} else {
-		s.pendingCond.L.Lock()
-		s.pendingCond.Signal()
-		s.pendingCond.L.Unlock()
-	}
-}
-
-// loop is the background goroutine that processes pending envelopes
-func (s *executionPayloadService) loop(ctx context.Context) {
-	// Wake any blocked Wait() on context cancellation to prevent deadlock.
-	go func() {
-		<-ctx.Done()
-		s.pendingCond.L.Lock()
-		s.pendingCond.Broadcast()
-		s.pendingCond.L.Unlock()
-	}()
-
-	for {
-		// Wait until there are pending envelopes
-		s.pendingCond.L.Lock()
-		for s.pendingCount.Load() == 0 {
-			// Check if context is cancelled
-			select {
-			case <-ctx.Done():
-				s.pendingCond.L.Unlock()
-				return
-			default:
-			}
-			s.pendingCond.Wait()
+	err := s.pending.enqueueLazy(envelope, func() (pendingEnvelopeKey, error) {
+		envelopeHash, err := envelope.HashSSZ()
+		if err != nil {
+			return pendingEnvelopeKey{}, err
 		}
-		s.pendingCond.L.Unlock()
-
-		// Poll until all pending envelopes are processed
-		ticker := time.NewTicker(pendingEnvelopeCheckInterval)
-		for s.pendingCount.Load() > 0 {
-			select {
-			case <-ctx.Done():
-				ticker.Stop()
-				return
-			case <-ticker.C:
-				s.processPendingEnvelopes(ctx)
-			}
-		}
-		ticker.Stop()
-	}
-}
-
-// processPendingEnvelopes checks and processes any pending envelopes whose blocks have arrived
-func (s *executionPayloadService) processPendingEnvelopes(ctx context.Context) {
-	s.pendingEnvelopes.Range(func(key, value any) bool {
-		pendingKey := key.(pendingEnvelopeKey)
-		job := value.(*envelopeJob)
-
-		// Check expiry
-		if time.Since(job.creationTime) > pendingEnvelopeExpiry {
-			s.pendingEnvelopes.Delete(pendingKey)
-			s.pendingCount.Add(-1)
-			log.Trace("Pending envelope expired", "blockRoot", pendingKey.blockRoot)
-			return true
-		}
-
-		// Check if block has arrived
-		block, ok := s.forkchoiceStore.GetBlock(pendingKey.blockRoot)
-		if !ok || block == nil {
-			return true // Block still not here, keep waiting
-		}
-
-		// Block arrived, remove from pending and process
-		s.pendingEnvelopes.Delete(pendingKey)
-		s.pendingCount.Add(-1)
-
-		// Re-run full validation via ProcessMessage
-		if err := s.ProcessMessage(ctx, nil, job.envelope); err != nil {
-			log.Trace("Failed to process pending envelope", "blockRoot", pendingKey.blockRoot, "err", err)
-		}
-		return true
+		return pendingEnvelopeKey{
+			blockRoot:    blockRoot,
+			envelopeHash: envelopeHash,
+		}, nil
 	})
+	if err != nil {
+		log.Warn("Failed to hash envelope for pending queue", "blockRoot", blockRoot, "err", err)
+	}
+}
+
+// tryProcessPendingEnvelope re-runs full validation via ProcessMessage once the block has arrived.
+func (s *executionPayloadService) tryProcessPendingEnvelope(ctx context.Context, key pendingEnvelopeKey, envelope *cltypes.SignedExecutionPayloadEnvelope) (func(), bool) {
+	block, ok := s.forkchoiceStore.GetBlock(key.blockRoot)
+	if !ok || block == nil {
+		return nil, false // Block still not here, keep waiting
+	}
+
+	return func() {
+		if err := s.ProcessMessage(ctx, nil, envelope); err != nil {
+			log.Trace("Failed to process pending envelope", "blockRoot", key.blockRoot, "err", err)
+		}
+	}, true
 }

--- a/cl/phase1/network/services/execution_payload_service.go
+++ b/cl/phase1/network/services/execution_payload_service.go
@@ -39,12 +39,9 @@ type seenEnvelopeKey struct {
 	builderIndex    uint64
 }
 
-// pendingEnvelopeKey tracks envelopes waiting for their block to arrive.
-// We use (blockRoot, envelopeHash) as key instead of just blockRoot because:
-//   - Multiple envelopes (including forged ones) may arrive before the block
-//   - Using only blockRoot would cause later arrivals to overwrite earlier ones
-//   - If a forged envelope overwrites the valid one, we lose the valid envelope
-//   - With envelopeHash, all candidates are kept and validated when block arrives
+// pendingEnvelopeKey identifies one envelope candidate for a block. Including
+// envelopeHash keeps competing candidates separate until validation, so an
+// invalid candidate cannot prevent a valid candidate from being queued.
 type pendingEnvelopeKey struct {
 	blockRoot    common.Hash
 	envelopeHash common.Hash
@@ -86,17 +83,23 @@ func NewExecutionPayloadService(
 		emitters:           emitters,
 		seenEnvelopesCache: seenEnvelopesCache,
 	}
-	s.pending = s.newPendingQueue()
-	go s.pending.loop(ctx)
+	s.pending = s.newPendingQueue(ctx)
 	return s
 }
 
-func (s *executionPayloadService) newPendingQueue() *pendingJobQueue[pendingEnvelopeKey, *cltypes.SignedExecutionPayloadEnvelope] {
-	return newPendingJobQueue(maxPendingEnvelopes, pendingEnvelopeExpiry, pendingEnvelopeCheckInterval,
+func (s *executionPayloadService) newPendingQueue(ctx context.Context) *pendingJobQueue[pendingEnvelopeKey, *cltypes.SignedExecutionPayloadEnvelope] {
+	return newPendingJobQueue(ctx, pendingJobQueueOptions{
+		name:          "execution_payload_envelope",
+		capacity:      maxPendingEnvelopes,
+		expiry:        pendingEnvelopeExpiry,
+		checkInterval: pendingEnvelopeCheckInterval,
+	},
 		s.tryProcessPendingEnvelope,
-		func(key pendingEnvelopeKey) {
+		s.processPendingEnvelope,
+		func(key pendingEnvelopeKey, _ *cltypes.SignedExecutionPayloadEnvelope) {
 			log.Trace("Pending envelope expired", "blockRoot", key.blockRoot)
-		})
+		},
+		nil)
 }
 
 func (s *executionPayloadService) Names() []string {
@@ -200,9 +203,9 @@ func (s *executionPayloadService) ProcessMessage(ctx context.Context, _ *uint64,
 	return nil
 }
 
-// queuePendingEnvelope adds an envelope to the pending queue for later processing
+// queuePendingEnvelope defers an envelope until its referenced block is available.
 func (s *executionPayloadService) queuePendingEnvelope(blockRoot common.Hash, envelope *cltypes.SignedExecutionPayloadEnvelope) {
-	err := s.pending.enqueueLazy(envelope, func() (pendingEnvelopeKey, error) {
+	_, err := s.pending.enqueueLazy(envelope, func() (pendingEnvelopeKey, error) {
 		envelopeHash, err := envelope.HashSSZ()
 		if err != nil {
 			return pendingEnvelopeKey{}, err
@@ -217,16 +220,16 @@ func (s *executionPayloadService) queuePendingEnvelope(blockRoot common.Hash, en
 	}
 }
 
-// tryProcessPendingEnvelope re-runs full validation via ProcessMessage once the block has arrived.
-func (s *executionPayloadService) tryProcessPendingEnvelope(ctx context.Context, key pendingEnvelopeKey, envelope *cltypes.SignedExecutionPayloadEnvelope) (func(), bool) {
+func (s *executionPayloadService) tryProcessPendingEnvelope(_ context.Context, key pendingEnvelopeKey, _ *cltypes.SignedExecutionPayloadEnvelope) pendingJobDecision {
 	block, ok := s.forkchoiceStore.GetBlock(key.blockRoot)
 	if !ok || block == nil {
-		return nil, false // Block still not here, keep waiting
+		return pendingJobKeep
 	}
+	return pendingJobRemoveThenProcess
+}
 
-	return func() {
-		if err := s.ProcessMessage(ctx, nil, envelope); err != nil {
-			log.Trace("Failed to process pending envelope", "blockRoot", key.blockRoot, "err", err)
-		}
-	}, true
+func (s *executionPayloadService) processPendingEnvelope(ctx context.Context, key pendingEnvelopeKey, envelope *cltypes.SignedExecutionPayloadEnvelope) {
+	if err := s.ProcessMessage(ctx, nil, envelope); err != nil {
+		log.Trace("Failed to process pending envelope", "blockRoot", key.blockRoot, "err", err)
+	}
 }

--- a/cl/phase1/network/services/execution_payload_service_test.go
+++ b/cl/phase1/network/services/execution_payload_service_test.go
@@ -82,7 +82,7 @@ func TestExecutionPayloadServiceBlockNotFound(t *testing.T) {
 
 	// Verify envelope was queued (check internal state)
 	impl := service.(*executionPayloadService)
-	require.Equal(t, int32(1), impl.pendingCount.Load())
+	require.Equal(t, int32(1), impl.pending.count.Load())
 
 	// Now add block to forkchoice
 	fcu.Blocks[blockRoot] = &cltypes.SignedBeaconBlock{
@@ -218,13 +218,13 @@ func TestExecutionPayloadServicePendingEnvelopeExpiry(t *testing.T) {
 	forkchoiceMock := mock_services.NewForkChoiceStorageMock(t)
 	ctx := t.Context()
 
-	// Create service directly to access internals
+	// Create service directly to access internals; the background loop is not started
 	impl := &executionPayloadService{
 		forkchoiceStore: forkchoiceMock,
 		beaconCfg:       cfg,
 		emitters:        beaconevents.NewEventEmitter(),
-		pendingCond:     nil, // Don't start background loop
 	}
+	impl.pending = impl.newPendingQueue()
 	seenCache, err := lru.New[seenEnvelopeKey, struct{}]("seen_envelopes", seenEnvelopeCacheSize)
 	require.NoError(t, err)
 	impl.seenEnvelopesCache = seenCache
@@ -239,17 +239,17 @@ func TestExecutionPayloadServicePendingEnvelopeExpiry(t *testing.T) {
 		blockRoot:    blockRoot,
 		envelopeHash: envelopeHash,
 	}
-	impl.pendingEnvelopes.Store(key, &envelopeJob{
-		envelope:     envelope,
+	impl.pending.jobs.Store(key, &pendingJob[*cltypes.SignedExecutionPayloadEnvelope]{
+		msg:          envelope,
 		creationTime: time.Now().Add(-pendingEnvelopeExpiry - time.Second), // expired
 	})
-	impl.pendingCount.Store(1)
+	impl.pending.count.Store(1)
 
 	// Process pending - should remove expired
-	impl.processPendingEnvelopes(ctx)
+	impl.pending.processPending(ctx)
 
-	require.Equal(t, int32(0), impl.pendingCount.Load())
-	_, exists := impl.pendingEnvelopes.Load(key)
+	require.Equal(t, int32(0), impl.pending.count.Load())
+	_, exists := impl.pending.jobs.Load(key)
 	require.False(t, exists)
 }
 
@@ -258,13 +258,13 @@ func TestExecutionPayloadServicePendingEnvelopeProcessing(t *testing.T) {
 	forkchoiceMock := mock_services.NewForkChoiceStorageMock(t)
 	ctx := t.Context()
 
-	// Create service directly to access internals
+	// Create service directly to access internals; the background loop is not started
 	impl := &executionPayloadService{
 		forkchoiceStore: forkchoiceMock,
 		beaconCfg:       cfg,
 		emitters:        beaconevents.NewEventEmitter(),
-		pendingCond:     nil,
 	}
+	impl.pending = impl.newPendingQueue()
 	seenCache, err := lru.New[seenEnvelopeKey, struct{}]("seen_envelopes", seenEnvelopeCacheSize)
 	require.NoError(t, err)
 	impl.seenEnvelopesCache = seenCache
@@ -279,15 +279,15 @@ func TestExecutionPayloadServicePendingEnvelopeProcessing(t *testing.T) {
 		blockRoot:    blockRoot,
 		envelopeHash: envelopeHash,
 	}
-	impl.pendingEnvelopes.Store(key, &envelopeJob{
-		envelope:     envelope,
+	impl.pending.jobs.Store(key, &pendingJob[*cltypes.SignedExecutionPayloadEnvelope]{
+		msg:          envelope,
 		creationTime: time.Now(),
 	})
-	impl.pendingCount.Store(1)
+	impl.pending.count.Store(1)
 
 	// Block not yet available - should keep pending
-	impl.processPendingEnvelopes(ctx)
-	require.Equal(t, int32(1), impl.pendingCount.Load())
+	impl.pending.processPending(ctx)
+	require.Equal(t, int32(1), impl.pending.count.Load())
 
 	// Now add block
 	forkchoiceMock.Blocks[blockRoot] = &cltypes.SignedBeaconBlock{
@@ -297,9 +297,9 @@ func TestExecutionPayloadServicePendingEnvelopeProcessing(t *testing.T) {
 	}
 
 	// Process again - should process and remove
-	impl.processPendingEnvelopes(ctx)
-	require.Equal(t, int32(0), impl.pendingCount.Load())
-	_, exists := impl.pendingEnvelopes.Load(key)
+	impl.pending.processPending(ctx)
+	require.Equal(t, int32(0), impl.pending.count.Load())
+	_, exists := impl.pending.jobs.Load(key)
 	require.False(t, exists)
 
 	// Envelope should be marked as seen
@@ -315,8 +315,8 @@ func TestExecutionPayloadServiceMultiplePendingForSameBlock(t *testing.T) {
 		forkchoiceStore: forkchoiceMock,
 		beaconCfg:       cfg,
 		emitters:        beaconevents.NewEventEmitter(),
-		pendingCond:     nil,
 	}
+	impl.pending = impl.newPendingQueue()
 	seenCache, err := lru.New[seenEnvelopeKey, struct{}]("seen_envelopes", seenEnvelopeCacheSize)
 	require.NoError(t, err)
 	impl.seenEnvelopesCache = seenCache
@@ -331,15 +331,15 @@ func TestExecutionPayloadServiceMultiplePendingForSameBlock(t *testing.T) {
 	hash2, _ := envelope2.HashSSZ()
 
 	// Add both as pending
-	impl.pendingEnvelopes.Store(pendingEnvelopeKey{blockRoot, hash1}, &envelopeJob{
-		envelope:     envelope1,
+	impl.pending.jobs.Store(pendingEnvelopeKey{blockRoot, hash1}, &pendingJob[*cltypes.SignedExecutionPayloadEnvelope]{
+		msg:          envelope1,
 		creationTime: time.Now(),
 	})
-	impl.pendingEnvelopes.Store(pendingEnvelopeKey{blockRoot, hash2}, &envelopeJob{
-		envelope:     envelope2,
+	impl.pending.jobs.Store(pendingEnvelopeKey{blockRoot, hash2}, &pendingJob[*cltypes.SignedExecutionPayloadEnvelope]{
+		msg:          envelope2,
 		creationTime: time.Now(),
 	})
-	impl.pendingCount.Store(2)
+	impl.pending.count.Store(2)
 
 	// Add block
 	forkchoiceMock.Blocks[blockRoot] = &cltypes.SignedBeaconBlock{
@@ -349,9 +349,9 @@ func TestExecutionPayloadServiceMultiplePendingForSameBlock(t *testing.T) {
 	}
 
 	// Process - both should be processed
-	impl.processPendingEnvelopes(ctx)
+	impl.pending.processPending(ctx)
 
-	require.Equal(t, int32(0), impl.pendingCount.Load())
+	require.Equal(t, int32(0), impl.pending.count.Load())
 	require.True(t, impl.seenEnvelopesCache.Contains(seenEnvelopeKey{blockRoot, 1}))
 	require.True(t, impl.seenEnvelopesCache.Contains(seenEnvelopeKey{blockRoot, 2}))
 }
@@ -367,20 +367,20 @@ func TestExecutionPayloadServicePendingQueueCap(t *testing.T) {
 		beaconCfg:          cfg,
 		emitters:           beaconevents.NewEventEmitter(),
 		seenEnvelopesCache: seenCache,
-		pendingCond:        sync.NewCond(&sync.Mutex{}),
 	}
+	impl.pending = impl.newPendingQueue()
 
-	impl.pendingCount.Store(maxPendingEnvelopes)
+	impl.pending.count.Store(maxPendingEnvelopes)
 
 	blockRoot := common.HexToHash("0xffff")
 	envelope := newTestSignedEnvelope(100, blockRoot, 999)
 
 	impl.queuePendingEnvelope(blockRoot, envelope)
 
-	require.Equal(t, int32(maxPendingEnvelopes), impl.pendingCount.Load())
+	require.Equal(t, int32(maxPendingEnvelopes), impl.pending.count.Load())
 	envelopeHash, err := envelope.HashSSZ()
 	require.NoError(t, err)
-	_, exists := impl.pendingEnvelopes.Load(pendingEnvelopeKey{blockRoot, envelopeHash})
+	_, exists := impl.pending.jobs.Load(pendingEnvelopeKey{blockRoot, envelopeHash})
 	require.False(t, exists)
 }
 
@@ -395,10 +395,10 @@ func TestExecutionPayloadServicePendingQueueCapConcurrent(t *testing.T) {
 		beaconCfg:          cfg,
 		emitters:           beaconevents.NewEventEmitter(),
 		seenEnvelopesCache: seenCache,
-		pendingCond:        sync.NewCond(&sync.Mutex{}),
 	}
+	impl.pending = impl.newPendingQueue()
 
-	impl.pendingCount.Store(maxPendingEnvelopes - 5)
+	impl.pending.count.Store(maxPendingEnvelopes - 5)
 
 	var wg sync.WaitGroup
 	for i := range 100 {
@@ -410,9 +410,9 @@ func TestExecutionPayloadServicePendingQueueCapConcurrent(t *testing.T) {
 	}
 	wg.Wait()
 
-	require.Equal(t, int32(maxPendingEnvelopes), impl.pendingCount.Load())
+	require.Equal(t, int32(maxPendingEnvelopes), impl.pending.count.Load())
 	stored := 0
-	impl.pendingEnvelopes.Range(func(_, _ any) bool {
+	impl.pending.jobs.Range(func(_, _ any) bool {
 		stored++
 		return true
 	})

--- a/cl/phase1/network/services/execution_payload_service_test.go
+++ b/cl/phase1/network/services/execution_payload_service_test.go
@@ -37,7 +37,8 @@ import (
 func setupExecutionPayloadService(t *testing.T) (ExecutionPayloadService, *mock_services.ForkChoiceStorageMock) {
 	cfg := &clparams.MainnetBeaconConfig
 	forkchoiceMock := mock_services.NewForkChoiceStorageMock(t)
-	service := NewExecutionPayloadService(t.Context(), forkchoiceMock, cfg, beaconevents.NewEventEmitter())
+	service := NewExecutionPayloadService(canceledPendingQueueContext(t), forkchoiceMock, cfg, beaconevents.NewEventEmitter())
+	service.(*executionPayloadService).pending.stopAndWait()
 	return service, forkchoiceMock
 }
 
@@ -218,13 +219,13 @@ func TestExecutionPayloadServicePendingEnvelopeExpiry(t *testing.T) {
 	forkchoiceMock := mock_services.NewForkChoiceStorageMock(t)
 	ctx := t.Context()
 
-	// Create service directly to access internals; the background loop is not started
+	// Use a stopped queue so expiry is processed explicitly.
 	impl := &executionPayloadService{
 		forkchoiceStore: forkchoiceMock,
 		beaconCfg:       cfg,
 		emitters:        beaconevents.NewEventEmitter(),
 	}
-	impl.pending = impl.newPendingQueue()
+	impl.pending = impl.newPendingQueue(canceledPendingQueueContext(t))
 	seenCache, err := lru.New[seenEnvelopeKey, struct{}]("seen_envelopes", seenEnvelopeCacheSize)
 	require.NoError(t, err)
 	impl.seenEnvelopesCache = seenCache
@@ -239,11 +240,7 @@ func TestExecutionPayloadServicePendingEnvelopeExpiry(t *testing.T) {
 		blockRoot:    blockRoot,
 		envelopeHash: envelopeHash,
 	}
-	impl.pending.jobs.Store(key, &pendingJob[*cltypes.SignedExecutionPayloadEnvelope]{
-		msg:          envelope,
-		creationTime: time.Now().Add(-pendingEnvelopeExpiry - time.Second), // expired
-	})
-	impl.pending.count.Store(1)
+	storePendingJob(t, impl.pending, key, envelope, time.Now().Add(-(pendingEnvelopeExpiry + time.Second)))
 
 	// Process pending - should remove expired
 	impl.pending.processPending(ctx)
@@ -258,13 +255,13 @@ func TestExecutionPayloadServicePendingEnvelopeProcessing(t *testing.T) {
 	forkchoiceMock := mock_services.NewForkChoiceStorageMock(t)
 	ctx := t.Context()
 
-	// Create service directly to access internals; the background loop is not started
+	// Use a stopped queue so pending jobs are processed explicitly.
 	impl := &executionPayloadService{
 		forkchoiceStore: forkchoiceMock,
 		beaconCfg:       cfg,
 		emitters:        beaconevents.NewEventEmitter(),
 	}
-	impl.pending = impl.newPendingQueue()
+	impl.pending = impl.newPendingQueue(canceledPendingQueueContext(t))
 	seenCache, err := lru.New[seenEnvelopeKey, struct{}]("seen_envelopes", seenEnvelopeCacheSize)
 	require.NoError(t, err)
 	impl.seenEnvelopesCache = seenCache
@@ -279,11 +276,7 @@ func TestExecutionPayloadServicePendingEnvelopeProcessing(t *testing.T) {
 		blockRoot:    blockRoot,
 		envelopeHash: envelopeHash,
 	}
-	impl.pending.jobs.Store(key, &pendingJob[*cltypes.SignedExecutionPayloadEnvelope]{
-		msg:          envelope,
-		creationTime: time.Now(),
-	})
-	impl.pending.count.Store(1)
+	storePendingJob(t, impl.pending, key, envelope, time.Now())
 
 	// Block not yet available - should keep pending
 	impl.pending.processPending(ctx)
@@ -316,7 +309,7 @@ func TestExecutionPayloadServiceMultiplePendingForSameBlock(t *testing.T) {
 		beaconCfg:       cfg,
 		emitters:        beaconevents.NewEventEmitter(),
 	}
-	impl.pending = impl.newPendingQueue()
+	impl.pending = impl.newPendingQueue(canceledPendingQueueContext(t))
 	seenCache, err := lru.New[seenEnvelopeKey, struct{}]("seen_envelopes", seenEnvelopeCacheSize)
 	require.NoError(t, err)
 	impl.seenEnvelopesCache = seenCache
@@ -331,15 +324,8 @@ func TestExecutionPayloadServiceMultiplePendingForSameBlock(t *testing.T) {
 	hash2, _ := envelope2.HashSSZ()
 
 	// Add both as pending
-	impl.pending.jobs.Store(pendingEnvelopeKey{blockRoot, hash1}, &pendingJob[*cltypes.SignedExecutionPayloadEnvelope]{
-		msg:          envelope1,
-		creationTime: time.Now(),
-	})
-	impl.pending.jobs.Store(pendingEnvelopeKey{blockRoot, hash2}, &pendingJob[*cltypes.SignedExecutionPayloadEnvelope]{
-		msg:          envelope2,
-		creationTime: time.Now(),
-	})
-	impl.pending.count.Store(2)
+	storePendingJob(t, impl.pending, pendingEnvelopeKey{blockRoot, hash1}, envelope1, time.Now())
+	storePendingJob(t, impl.pending, pendingEnvelopeKey{blockRoot, hash2}, envelope2, time.Now())
 
 	// Add block
 	forkchoiceMock.Blocks[blockRoot] = &cltypes.SignedBeaconBlock{
@@ -368,8 +354,7 @@ func TestExecutionPayloadServicePendingQueueCap(t *testing.T) {
 		emitters:           beaconevents.NewEventEmitter(),
 		seenEnvelopesCache: seenCache,
 	}
-	impl.pending = impl.newPendingQueue()
-
+	impl.pending = impl.newPendingQueue(canceledPendingQueueContext(t))
 	impl.pending.count.Store(maxPendingEnvelopes)
 
 	blockRoot := common.HexToHash("0xffff")
@@ -396,7 +381,7 @@ func TestExecutionPayloadServicePendingQueueCapConcurrent(t *testing.T) {
 		emitters:           beaconevents.NewEventEmitter(),
 		seenEnvelopesCache: seenCache,
 	}
-	impl.pending = impl.newPendingQueue()
+	impl.pending = impl.newPendingQueue(canceledPendingQueueContext(t))
 
 	impl.pending.count.Store(maxPendingEnvelopes - 5)
 

--- a/cl/phase1/network/services/payload_attestation_service.go
+++ b/cl/phase1/network/services/payload_attestation_service.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -51,12 +49,6 @@ type pendingPayloadAttestationKey struct {
 	messageRoot    common.Hash
 }
 
-// pendingPayloadAttestationJob represents a pending attestation waiting for its block.
-type pendingPayloadAttestationJob struct {
-	msg          *cltypes.PayloadAttestationMessage
-	creationTime time.Time
-}
-
 const (
 	// seenPayloadAttestationCacheSize: PTC has 512 validators per slot.
 	// With clock disparity, we may see attestations for ~2 slots.
@@ -77,10 +69,8 @@ type payloadAttestationService struct {
 	// Cache to track seen attestations: (slot, validatorIndex) -> struct{}
 	seenAttestationsCache *lru.Cache[seenPayloadAttestationKey, struct{}]
 
-	// Pending attestations waiting for block to arrive
-	pendingAttestations sync.Map // pendingPayloadAttestationKey -> *pendingPayloadAttestationJob
-	pendingCount        atomic.Int32
-	pendingCond         *sync.Cond
+	// Pending attestations waiting for block to arrive.
+	pending             *pendingJobQueue[pendingPayloadAttestationKey, *cltypes.PayloadAttestationMessage]
 	validationAdmission chan struct{}
 }
 
@@ -103,11 +93,19 @@ func NewPayloadAttestationService(
 		netCfg:                netCfg,
 		emitters:              emitters,
 		seenAttestationsCache: seenCache,
-		pendingCond:           sync.NewCond(&sync.Mutex{}),
 		validationAdmission:   make(chan struct{}, maxConcurrentPayloadAttestationValidations),
 	}
-	go s.loop(ctx)
+	s.pending = s.newPendingQueue()
+	go s.pending.loop(ctx)
 	return s
+}
+
+func (s *payloadAttestationService) newPendingQueue() *pendingJobQueue[pendingPayloadAttestationKey, *cltypes.PayloadAttestationMessage] {
+	return newPendingJobQueue(maxPendingAttestations, pendingPayloadAttestationExpiry, pendingPayloadAttestationCheckInterval,
+		s.tryProcessPendingAttestation,
+		func(key pendingPayloadAttestationKey) {
+			log.Trace("Pending payload attestation expired", "blockRoot", key.blockRoot)
+		})
 }
 
 func (s *payloadAttestationService) Names() []string {
@@ -207,23 +205,9 @@ func (s *payloadAttestationService) ProcessMessage(ctx context.Context, _ *uint6
 
 // queuePendingAttestation adds an attestation to the pending queue for later processing.
 func (s *payloadAttestationService) queuePendingAttestation(blockRoot common.Hash, msg *cltypes.PayloadAttestationMessage) {
-	if s.pendingCount.Add(1) > maxPendingAttestations {
-		s.pendingCount.Add(-1)
-		return
-	}
-
-	key := pendingPayloadAttestationKeyFor(blockRoot, msg)
-
-	if _, loaded := s.pendingAttestations.LoadOrStore(key, &pendingPayloadAttestationJob{
-		msg:          msg,
-		creationTime: time.Now(),
-	}); loaded {
-		s.pendingCount.Add(-1)
-	} else {
-		s.pendingCond.L.Lock()
-		s.pendingCond.Signal()
-		s.pendingCond.L.Unlock()
-	}
+	_ = s.pending.enqueueLazy(msg, func() (pendingPayloadAttestationKey, error) {
+		return pendingPayloadAttestationKeyFor(blockRoot, msg), nil
+	})
 }
 
 func pendingPayloadAttestationKeyFor(blockRoot common.Hash, msg *cltypes.PayloadAttestationMessage) pendingPayloadAttestationKey {
@@ -235,80 +219,21 @@ func pendingPayloadAttestationKeyFor(blockRoot common.Hash, msg *cltypes.Payload
 	}
 }
 
-// loop is the background goroutine that processes pending attestations.
-func (s *payloadAttestationService) loop(ctx context.Context) {
-	// Wake any blocked Wait() on context cancellation to prevent deadlock.
-	go func() {
-		<-ctx.Done()
-		s.pendingCond.L.Lock()
-		s.pendingCond.Broadcast()
-		s.pendingCond.L.Unlock()
-	}()
-
-	for {
-		// Wait until there are pending attestations
-		s.pendingCond.L.Lock()
-		for s.pendingCount.Load() == 0 {
-			select {
-			case <-ctx.Done():
-				s.pendingCond.L.Unlock()
-				return
-			default:
-			}
-			s.pendingCond.Wait()
-		}
-		s.pendingCond.L.Unlock()
-
-		// Poll until all pending attestations are processed
-		ticker := time.NewTicker(pendingPayloadAttestationCheckInterval)
-		for s.pendingCount.Load() > 0 {
-			select {
-			case <-ctx.Done():
-				ticker.Stop()
-				return
-			case <-ticker.C:
-				s.processPendingAttestations(ctx)
-			}
-		}
-		ticker.Stop()
+// tryProcessPendingAttestation re-runs validation via ProcessMessage once the block has arrived,
+// dropping attestations that are no longer for the current slot.
+func (s *payloadAttestationService) tryProcessPendingAttestation(ctx context.Context, key pendingPayloadAttestationKey, msg *cltypes.PayloadAttestationMessage) (func(), bool) {
+	if !s.ethClock.IsSlotCurrentSlotWithMaximumClockDisparity(msg.Data.Slot) {
+		log.Trace("Pending payload attestation slot mismatch", "blockRoot", key.blockRoot)
+		return nil, true
 	}
-}
 
-// processPendingAttestations checks and processes any pending attestations whose blocks have arrived.
-func (s *payloadAttestationService) processPendingAttestations(ctx context.Context) {
-	s.pendingAttestations.Range(func(key, value any) bool {
-		pendingKey := key.(pendingPayloadAttestationKey)
-		job := value.(*pendingPayloadAttestationJob)
+	if _, ok := s.forkchoiceStore.GetHeader(key.blockRoot); !ok {
+		return nil, false
+	}
 
-		// Check expiry
-		if time.Since(job.creationTime) > pendingPayloadAttestationExpiry {
-			s.pendingAttestations.Delete(pendingKey)
-			s.pendingCount.Add(-1)
-			log.Trace("Pending payload attestation expired", "blockRoot", pendingKey.blockRoot)
-			return true
+	return func() {
+		if err := s.ProcessMessage(ctx, nil, msg); err != nil {
+			log.Trace("Failed to process pending payload attestation", "blockRoot", key.blockRoot, "err", err)
 		}
-
-		// Check if attestation is still for current slot (with clock disparity allowance)
-		if !s.ethClock.IsSlotCurrentSlotWithMaximumClockDisparity(job.msg.Data.Slot) {
-			s.pendingAttestations.Delete(pendingKey)
-			s.pendingCount.Add(-1)
-			log.Trace("Pending payload attestation slot mismatch", "blockRoot", pendingKey.blockRoot)
-			return true
-		}
-
-		// Check if block has arrived
-		if _, ok := s.forkchoiceStore.GetHeader(pendingKey.blockRoot); !ok {
-			return true // Block still not here, keep waiting
-		}
-
-		// Block arrived, remove from pending and process
-		s.pendingAttestations.Delete(pendingKey)
-		s.pendingCount.Add(-1)
-
-		// Re-run validation via ProcessMessage
-		if err := s.ProcessMessage(ctx, nil, job.msg); err != nil {
-			log.Trace("Failed to process pending payload attestation", "blockRoot", pendingKey.blockRoot, "err", err)
-		}
-		return true
-	})
+	}, true
 }

--- a/cl/phase1/network/services/payload_attestation_service.go
+++ b/cl/phase1/network/services/payload_attestation_service.go
@@ -41,8 +41,8 @@ type seenPayloadAttestationKey struct {
 	validatorIndex uint64
 }
 
-// pendingPayloadAttestationKey tracks attestations waiting for their block to arrive.
-// Key is (blockRoot, validatorIndex) since each validator can only submit one attestation per block.
+// pendingPayloadAttestationKey identifies a queued attestation. messageRoot keeps
+// messages with the same block and validator distinct until validation.
 type pendingPayloadAttestationKey struct {
 	blockRoot      common.Hash
 	validatorIndex uint64
@@ -69,7 +69,7 @@ type payloadAttestationService struct {
 	// Cache to track seen attestations: (slot, validatorIndex) -> struct{}
 	seenAttestationsCache *lru.Cache[seenPayloadAttestationKey, struct{}]
 
-	// Pending attestations waiting for block to arrive.
+	// pending retains attestations until their referenced blocks are available.
 	pending             *pendingJobQueue[pendingPayloadAttestationKey, *cltypes.PayloadAttestationMessage]
 	validationAdmission chan struct{}
 }
@@ -95,17 +95,23 @@ func NewPayloadAttestationService(
 		seenAttestationsCache: seenCache,
 		validationAdmission:   make(chan struct{}, maxConcurrentPayloadAttestationValidations),
 	}
-	s.pending = s.newPendingQueue()
-	go s.pending.loop(ctx)
+	s.pending = s.newPendingQueue(ctx)
 	return s
 }
 
-func (s *payloadAttestationService) newPendingQueue() *pendingJobQueue[pendingPayloadAttestationKey, *cltypes.PayloadAttestationMessage] {
-	return newPendingJobQueue(maxPendingAttestations, pendingPayloadAttestationExpiry, pendingPayloadAttestationCheckInterval,
+func (s *payloadAttestationService) newPendingQueue(ctx context.Context) *pendingJobQueue[pendingPayloadAttestationKey, *cltypes.PayloadAttestationMessage] {
+	return newPendingJobQueue(ctx, pendingJobQueueOptions{
+		name:          "payload_attestation",
+		capacity:      maxPendingAttestations,
+		expiry:        pendingPayloadAttestationExpiry,
+		checkInterval: pendingPayloadAttestationCheckInterval,
+	},
 		s.tryProcessPendingAttestation,
-		func(key pendingPayloadAttestationKey) {
+		s.processPendingAttestation,
+		func(key pendingPayloadAttestationKey, _ *cltypes.PayloadAttestationMessage) {
 			log.Trace("Pending payload attestation expired", "blockRoot", key.blockRoot)
-		})
+		},
+		nil)
 }
 
 func (s *payloadAttestationService) Names() []string {
@@ -203,37 +209,45 @@ func (s *payloadAttestationService) ProcessMessage(ctx context.Context, _ *uint6
 	return nil
 }
 
-// queuePendingAttestation adds an attestation to the pending queue for later processing.
+// queuePendingAttestation defers an attestation until its referenced block is available.
 func (s *payloadAttestationService) queuePendingAttestation(blockRoot common.Hash, msg *cltypes.PayloadAttestationMessage) {
-	_ = s.pending.enqueueLazy(msg, func() (pendingPayloadAttestationKey, error) {
-		return pendingPayloadAttestationKeyFor(blockRoot, msg), nil
+	_, err := s.pending.enqueueLazy(msg, func() (pendingPayloadAttestationKey, error) {
+		return pendingPayloadAttestationKeyFor(blockRoot, msg)
 	})
+	if err != nil {
+		log.Warn("Failed to hash payload attestation for pending queue",
+			"blockRoot", blockRoot, "validatorIndex", msg.ValidatorIndex, "err", err)
+	}
 }
 
-func pendingPayloadAttestationKeyFor(blockRoot common.Hash, msg *cltypes.PayloadAttestationMessage) pendingPayloadAttestationKey {
-	root, _ := msg.HashSSZ()
+func pendingPayloadAttestationKeyFor(blockRoot common.Hash, msg *cltypes.PayloadAttestationMessage) (pendingPayloadAttestationKey, error) {
+	root, err := msg.HashSSZ()
+	if err != nil {
+		return pendingPayloadAttestationKey{}, err
+	}
 	return pendingPayloadAttestationKey{
 		blockRoot:      blockRoot,
 		validatorIndex: msg.ValidatorIndex,
 		messageRoot:    common.Hash(root),
-	}
+	}, nil
 }
 
-// tryProcessPendingAttestation re-runs validation via ProcessMessage once the block has arrived,
-// dropping attestations that are no longer for the current slot.
-func (s *payloadAttestationService) tryProcessPendingAttestation(ctx context.Context, key pendingPayloadAttestationKey, msg *cltypes.PayloadAttestationMessage) (func(), bool) {
+// tryProcessPendingAttestation drops stale messages and revalidates the rest
+// once their referenced block arrives.
+func (s *payloadAttestationService) tryProcessPendingAttestation(_ context.Context, key pendingPayloadAttestationKey, msg *cltypes.PayloadAttestationMessage) pendingJobDecision {
 	if !s.ethClock.IsSlotCurrentSlotWithMaximumClockDisparity(msg.Data.Slot) {
 		log.Trace("Pending payload attestation slot mismatch", "blockRoot", key.blockRoot)
-		return nil, true
+		return pendingJobRemove
 	}
 
 	if _, ok := s.forkchoiceStore.GetHeader(key.blockRoot); !ok {
-		return nil, false
+		return pendingJobKeep
 	}
+	return pendingJobRemoveThenProcess
+}
 
-	return func() {
-		if err := s.ProcessMessage(ctx, nil, msg); err != nil {
-			log.Trace("Failed to process pending payload attestation", "blockRoot", key.blockRoot, "err", err)
-		}
-	}, true
+func (s *payloadAttestationService) processPendingAttestation(ctx context.Context, key pendingPayloadAttestationKey, msg *cltypes.PayloadAttestationMessage) {
+	if err := s.ProcessMessage(ctx, nil, msg); err != nil {
+		log.Trace("Failed to process pending payload attestation", "blockRoot", key.blockRoot, "err", err)
+	}
 }

--- a/cl/phase1/network/services/payload_attestation_service_test.go
+++ b/cl/phase1/network/services/payload_attestation_service_test.go
@@ -108,9 +108,9 @@ func setupPayloadAttestationService(t *testing.T, ctrl *gomock.Controller) (*pay
 		netCfg:                nil, // Not used in current implementation
 		seenAttestationsCache: seenCache,
 		emitters:              beaconevents.NewEventEmitter(),
-		pendingCond:           sync.NewCond(&sync.Mutex{}), // Needed for queuePendingAttestation
 		validationAdmission:   make(chan struct{}, maxConcurrentPayloadAttestationValidations),
 	}
+	service.pending = service.newPendingQueue()
 
 	return service, forkchoiceMock, ethClockMock
 }
@@ -477,11 +477,11 @@ func TestPayloadAttestationServiceBlockNotFound(t *testing.T) {
 	require.True(t, errors.Is(err, ErrAttestationQueued))
 
 	// Verify attestation was queued
-	require.Equal(t, int32(1), service.pendingCount.Load())
+	require.Equal(t, int32(1), service.pending.count.Load())
 
 	// Verify the pending key
 	key := pendingPayloadAttestationKeyFor(blockRoot, msg)
-	_, exists := service.pendingAttestations.Load(key)
+	_, exists := service.pending.jobs.Load(key)
 	require.True(t, exists)
 }
 
@@ -500,10 +500,10 @@ func TestPayloadAttestationServicePendingQueueKeepsDistinctSameValidatorBlock(t 
 	service.queuePendingAttestation(blockRoot, first)
 	service.queuePendingAttestation(blockRoot, second)
 
-	require.Equal(t, int32(2), service.pendingCount.Load())
-	_, firstExists := service.pendingAttestations.Load(pendingPayloadAttestationKeyFor(blockRoot, first))
+	require.Equal(t, int32(2), service.pending.count.Load())
+	_, firstExists := service.pending.jobs.Load(pendingPayloadAttestationKeyFor(blockRoot, first))
 	require.True(t, firstExists)
-	_, secondExists := service.pendingAttestations.Load(pendingPayloadAttestationKeyFor(blockRoot, second))
+	_, secondExists := service.pending.jobs.Load(pendingPayloadAttestationKeyFor(blockRoot, second))
 	require.True(t, secondExists)
 }
 
@@ -598,17 +598,17 @@ func TestPayloadAttestationServicePendingExpiry(t *testing.T) {
 
 	// Add expired job directly
 	key := pendingPayloadAttestationKeyFor(blockRoot, msg)
-	service.pendingAttestations.Store(key, &pendingPayloadAttestationJob{
+	service.pending.jobs.Store(key, &pendingJob[*cltypes.PayloadAttestationMessage]{
 		msg:          msg,
 		creationTime: time.Now().Add(-pendingPayloadAttestationExpiry - time.Second), // expired
 	})
-	service.pendingCount.Store(1)
+	service.pending.count.Store(1)
 
 	// Process pending - should remove expired
-	service.processPendingAttestations(context.Background())
+	service.pending.processPending(context.Background())
 
-	require.Equal(t, int32(0), service.pendingCount.Load())
-	_, exists := service.pendingAttestations.Load(key)
+	require.Equal(t, int32(0), service.pending.count.Load())
+	_, exists := service.pending.jobs.Load(key)
 	require.False(t, exists)
 }
 
@@ -623,20 +623,20 @@ func TestPayloadAttestationServicePendingSlotMismatch(t *testing.T) {
 
 	// Add pending job
 	key := pendingPayloadAttestationKeyFor(blockRoot, msg)
-	service.pendingAttestations.Store(key, &pendingPayloadAttestationJob{
+	service.pending.jobs.Store(key, &pendingJob[*cltypes.PayloadAttestationMessage]{
 		msg:          msg,
 		creationTime: time.Now(),
 	})
-	service.pendingCount.Store(1)
+	service.pending.count.Store(1)
 
 	// Mock: slot 100 is no longer current
 	ethClockMock.EXPECT().IsSlotCurrentSlotWithMaximumClockDisparity(uint64(100)).Return(false)
 
 	// Process pending - should remove due to slot mismatch
-	service.processPendingAttestations(context.Background())
+	service.pending.processPending(context.Background())
 
-	require.Equal(t, int32(0), service.pendingCount.Load())
-	_, exists := service.pendingAttestations.Load(key)
+	require.Equal(t, int32(0), service.pending.count.Load())
+	_, exists := service.pending.jobs.Load(key)
 	require.False(t, exists)
 }
 
@@ -651,16 +651,16 @@ func TestPayloadAttestationServicePendingProcessing(t *testing.T) {
 
 	// Add pending job
 	key := pendingPayloadAttestationKeyFor(blockRoot, msg)
-	service.pendingAttestations.Store(key, &pendingPayloadAttestationJob{
+	service.pending.jobs.Store(key, &pendingJob[*cltypes.PayloadAttestationMessage]{
 		msg:          msg,
 		creationTime: time.Now(),
 	})
-	service.pendingCount.Store(1)
+	service.pending.count.Store(1)
 
 	// First process: slot ok, but block not available
 	ethClockMock.EXPECT().IsSlotCurrentSlotWithMaximumClockDisparity(uint64(100)).Return(true)
-	service.processPendingAttestations(context.Background())
-	require.Equal(t, int32(1), service.pendingCount.Load()) // Still pending
+	service.pending.processPending(context.Background())
+	require.Equal(t, int32(1), service.pending.count.Load()) // Still pending
 
 	// Now add block header
 	fcu.Headers[blockRoot] = &cltypes.BeaconBlockHeader{
@@ -670,10 +670,10 @@ func TestPayloadAttestationServicePendingProcessing(t *testing.T) {
 	// Second process: slot ok, block available -> should process
 	// ProcessMessage will be called, which calls IsSlotCurrentSlotWithMaximumClockDisparity again
 	ethClockMock.EXPECT().IsSlotCurrentSlotWithMaximumClockDisparity(uint64(100)).Return(true).Times(2)
-	service.processPendingAttestations(context.Background())
+	service.pending.processPending(context.Background())
 
-	require.Equal(t, int32(0), service.pendingCount.Load())
-	_, exists := service.pendingAttestations.Load(key)
+	require.Equal(t, int32(0), service.pending.count.Load())
+	_, exists := service.pending.jobs.Load(key)
 	require.False(t, exists)
 
 	// Attestation should be marked as seen
@@ -693,15 +693,15 @@ func TestPayloadAttestationServiceMultiplePendingForSameBlock(t *testing.T) {
 	msg2 := newTestPayloadAttestationMessage(100, 2, blockRoot)
 
 	// Add both as pending
-	service.pendingAttestations.Store(pendingPayloadAttestationKeyFor(blockRoot, msg1), &pendingPayloadAttestationJob{
+	service.pending.jobs.Store(pendingPayloadAttestationKeyFor(blockRoot, msg1), &pendingJob[*cltypes.PayloadAttestationMessage]{
 		msg:          msg1,
 		creationTime: time.Now(),
 	})
-	service.pendingAttestations.Store(pendingPayloadAttestationKeyFor(blockRoot, msg2), &pendingPayloadAttestationJob{
+	service.pending.jobs.Store(pendingPayloadAttestationKeyFor(blockRoot, msg2), &pendingJob[*cltypes.PayloadAttestationMessage]{
 		msg:          msg2,
 		creationTime: time.Now(),
 	})
-	service.pendingCount.Store(2)
+	service.pending.count.Store(2)
 
 	// Add block header
 	fcu.Headers[blockRoot] = &cltypes.BeaconBlockHeader{
@@ -712,9 +712,9 @@ func TestPayloadAttestationServiceMultiplePendingForSameBlock(t *testing.T) {
 	ethClockMock.EXPECT().IsSlotCurrentSlotWithMaximumClockDisparity(uint64(100)).Return(true).Times(4)
 
 	// Process - both should be processed
-	service.processPendingAttestations(context.Background())
+	service.pending.processPending(context.Background())
 
-	require.Equal(t, int32(0), service.pendingCount.Load())
+	require.Equal(t, int32(0), service.pending.count.Load())
 	require.True(t, service.seenAttestationsCache.Contains(seenPayloadAttestationKey{100, 1}))
 	require.True(t, service.seenAttestationsCache.Contains(seenPayloadAttestationKey{100, 2}))
 }
@@ -726,7 +726,7 @@ func TestPayloadAttestationServicePendingQueueCap(t *testing.T) {
 	service, _, _ := setupPayloadAttestationService(t, ctrl)
 
 	// Fill the queue to the cap
-	service.pendingCount.Store(maxPendingAttestations)
+	service.pending.count.Store(maxPendingAttestations)
 
 	blockRoot := common.HexToHash("0xffff")
 	msg := newTestPayloadAttestationMessage(100, 999, blockRoot)
@@ -734,9 +734,9 @@ func TestPayloadAttestationServicePendingQueueCap(t *testing.T) {
 	service.queuePendingAttestation(blockRoot, msg)
 
 	// Should still be at cap — new item was rejected
-	require.Equal(t, int32(maxPendingAttestations), service.pendingCount.Load())
+	require.Equal(t, int32(maxPendingAttestations), service.pending.count.Load())
 	key := pendingPayloadAttestationKeyFor(blockRoot, msg)
-	_, exists := service.pendingAttestations.Load(key)
+	_, exists := service.pending.jobs.Load(key)
 	require.False(t, exists)
 }
 
@@ -747,7 +747,7 @@ func TestPayloadAttestationServicePendingQueueCapConcurrent(t *testing.T) {
 	service, _, _ := setupPayloadAttestationService(t, ctrl)
 
 	// Start near cap so only a few slots remain
-	service.pendingCount.Store(maxPendingAttestations - 5)
+	service.pending.count.Store(maxPendingAttestations - 5)
 
 	var wg sync.WaitGroup
 	for i := range 100 {
@@ -759,9 +759,9 @@ func TestPayloadAttestationServicePendingQueueCapConcurrent(t *testing.T) {
 	}
 	wg.Wait()
 
-	require.Equal(t, int32(maxPendingAttestations), service.pendingCount.Load())
+	require.Equal(t, int32(maxPendingAttestations), service.pending.count.Load())
 	stored := 0
-	service.pendingAttestations.Range(func(_, _ any) bool {
+	service.pending.jobs.Range(func(_, _ any) bool {
 		stored++
 		return true
 	})

--- a/cl/phase1/network/services/payload_attestation_service_test.go
+++ b/cl/phase1/network/services/payload_attestation_service_test.go
@@ -110,7 +110,7 @@ func setupPayloadAttestationService(t *testing.T, ctrl *gomock.Controller) (*pay
 		emitters:              beaconevents.NewEventEmitter(),
 		validationAdmission:   make(chan struct{}, maxConcurrentPayloadAttestationValidations),
 	}
-	service.pending = service.newPendingQueue()
+	service.pending = service.newPendingQueue(canceledPendingQueueContext(t))
 
 	return service, forkchoiceMock, ethClockMock
 }
@@ -392,6 +392,17 @@ func newTestPayloadAttestationMessage(slot uint64, validatorIndex uint64, blockR
 	}
 }
 
+func mustPendingPayloadAttestationKey(
+	t *testing.T,
+	blockRoot common.Hash,
+	msg *cltypes.PayloadAttestationMessage,
+) pendingPayloadAttestationKey {
+	t.Helper()
+	key, err := pendingPayloadAttestationKeyFor(blockRoot, msg)
+	require.NoError(t, err)
+	return key
+}
+
 func TestPayloadAttestationServiceNilMessage(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -480,7 +491,7 @@ func TestPayloadAttestationServiceBlockNotFound(t *testing.T) {
 	require.Equal(t, int32(1), service.pending.count.Load())
 
 	// Verify the pending key
-	key := pendingPayloadAttestationKeyFor(blockRoot, msg)
+	key := mustPendingPayloadAttestationKey(t, blockRoot, msg)
 	_, exists := service.pending.jobs.Load(key)
 	require.True(t, exists)
 }
@@ -501,9 +512,9 @@ func TestPayloadAttestationServicePendingQueueKeepsDistinctSameValidatorBlock(t 
 	service.queuePendingAttestation(blockRoot, second)
 
 	require.Equal(t, int32(2), service.pending.count.Load())
-	_, firstExists := service.pending.jobs.Load(pendingPayloadAttestationKeyFor(blockRoot, first))
+	_, firstExists := service.pending.jobs.Load(mustPendingPayloadAttestationKey(t, blockRoot, first))
 	require.True(t, firstExists)
-	_, secondExists := service.pending.jobs.Load(pendingPayloadAttestationKeyFor(blockRoot, second))
+	_, secondExists := service.pending.jobs.Load(mustPendingPayloadAttestationKey(t, blockRoot, second))
 	require.True(t, secondExists)
 }
 
@@ -597,12 +608,8 @@ func TestPayloadAttestationServicePendingExpiry(t *testing.T) {
 	msg := newTestPayloadAttestationMessage(100, 1, blockRoot)
 
 	// Add expired job directly
-	key := pendingPayloadAttestationKeyFor(blockRoot, msg)
-	service.pending.jobs.Store(key, &pendingJob[*cltypes.PayloadAttestationMessage]{
-		msg:          msg,
-		creationTime: time.Now().Add(-pendingPayloadAttestationExpiry - time.Second), // expired
-	})
-	service.pending.count.Store(1)
+	key := mustPendingPayloadAttestationKey(t, blockRoot, msg)
+	storePendingJob(t, service.pending, key, msg, time.Now().Add(-(pendingPayloadAttestationExpiry + time.Second)))
 
 	// Process pending - should remove expired
 	service.pending.processPending(context.Background())
@@ -622,15 +629,12 @@ func TestPayloadAttestationServicePendingSlotMismatch(t *testing.T) {
 	msg := newTestPayloadAttestationMessage(100, 1, blockRoot)
 
 	// Add pending job
-	key := pendingPayloadAttestationKeyFor(blockRoot, msg)
-	service.pending.jobs.Store(key, &pendingJob[*cltypes.PayloadAttestationMessage]{
-		msg:          msg,
-		creationTime: time.Now(),
-	})
-	service.pending.count.Store(1)
+	key := mustPendingPayloadAttestationKey(t, blockRoot, msg)
+	storePendingJob(t, service.pending, key, msg, time.Now())
 
 	// Mock: slot 100 is no longer current
 	ethClockMock.EXPECT().IsSlotCurrentSlotWithMaximumClockDisparity(uint64(100)).Return(false)
+	output := captureServiceLogs(t)
 
 	// Process pending - should remove due to slot mismatch
 	service.pending.processPending(context.Background())
@@ -638,6 +642,7 @@ func TestPayloadAttestationServicePendingSlotMismatch(t *testing.T) {
 	require.Equal(t, int32(0), service.pending.count.Load())
 	_, exists := service.pending.jobs.Load(key)
 	require.False(t, exists)
+	require.Contains(t, output.String(), "Pending payload attestation slot mismatch")
 }
 
 func TestPayloadAttestationServicePendingProcessing(t *testing.T) {
@@ -650,12 +655,8 @@ func TestPayloadAttestationServicePendingProcessing(t *testing.T) {
 	msg := newTestPayloadAttestationMessage(100, 42, blockRoot)
 
 	// Add pending job
-	key := pendingPayloadAttestationKeyFor(blockRoot, msg)
-	service.pending.jobs.Store(key, &pendingJob[*cltypes.PayloadAttestationMessage]{
-		msg:          msg,
-		creationTime: time.Now(),
-	})
-	service.pending.count.Store(1)
+	key := mustPendingPayloadAttestationKey(t, blockRoot, msg)
+	storePendingJob(t, service.pending, key, msg, time.Now())
 
 	// First process: slot ok, but block not available
 	ethClockMock.EXPECT().IsSlotCurrentSlotWithMaximumClockDisparity(uint64(100)).Return(true)
@@ -693,15 +694,8 @@ func TestPayloadAttestationServiceMultiplePendingForSameBlock(t *testing.T) {
 	msg2 := newTestPayloadAttestationMessage(100, 2, blockRoot)
 
 	// Add both as pending
-	service.pending.jobs.Store(pendingPayloadAttestationKeyFor(blockRoot, msg1), &pendingJob[*cltypes.PayloadAttestationMessage]{
-		msg:          msg1,
-		creationTime: time.Now(),
-	})
-	service.pending.jobs.Store(pendingPayloadAttestationKeyFor(blockRoot, msg2), &pendingJob[*cltypes.PayloadAttestationMessage]{
-		msg:          msg2,
-		creationTime: time.Now(),
-	})
-	service.pending.count.Store(2)
+	storePendingJob(t, service.pending, mustPendingPayloadAttestationKey(t, blockRoot, msg1), msg1, time.Now())
+	storePendingJob(t, service.pending, mustPendingPayloadAttestationKey(t, blockRoot, msg2), msg2, time.Now())
 
 	// Add block header
 	fcu.Headers[blockRoot] = &cltypes.BeaconBlockHeader{
@@ -717,27 +711,6 @@ func TestPayloadAttestationServiceMultiplePendingForSameBlock(t *testing.T) {
 	require.Equal(t, int32(0), service.pending.count.Load())
 	require.True(t, service.seenAttestationsCache.Contains(seenPayloadAttestationKey{100, 1}))
 	require.True(t, service.seenAttestationsCache.Contains(seenPayloadAttestationKey{100, 2}))
-}
-
-func TestPayloadAttestationServicePendingQueueCap(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	service, _, _ := setupPayloadAttestationService(t, ctrl)
-
-	// Fill the queue to the cap
-	service.pending.count.Store(maxPendingAttestations)
-
-	blockRoot := common.HexToHash("0xffff")
-	msg := newTestPayloadAttestationMessage(100, 999, blockRoot)
-
-	service.queuePendingAttestation(blockRoot, msg)
-
-	// Should still be at cap — new item was rejected
-	require.Equal(t, int32(maxPendingAttestations), service.pending.count.Load())
-	key := pendingPayloadAttestationKeyFor(blockRoot, msg)
-	_, exists := service.pending.jobs.Load(key)
-	require.False(t, exists)
 }
 
 func TestPayloadAttestationServicePendingQueueCapConcurrent(t *testing.T) {

--- a/cl/phase1/network/services/pending_job_queue.go
+++ b/cl/phase1/network/services/pending_job_queue.go
@@ -1,0 +1,165 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package services
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type pendingJob[M any] struct {
+	msg          M
+	creationTime time.Time
+}
+
+// pendingJobQueue holds gossip messages whose processing dependencies have not
+// arrived yet and retries them periodically until processed or expired.
+type pendingJobQueue[K comparable, M any] struct {
+	capacity int32
+	expiry   time.Duration
+	tick     time.Duration
+	// tryProcess decides a job's fate: done=false keeps it queued for the next
+	// tick; done=true removes it. A non-nil process func runs after the removal,
+	// so that a concurrent re-enqueue under the same key is not lost.
+	tryProcess func(ctx context.Context, key K, msg M) (process func(), done bool)
+	onExpired  func(key K)
+
+	jobs  sync.Map // K -> *pendingJob[M]
+	count atomic.Int32
+	cond  *sync.Cond
+}
+
+func newPendingJobQueue[K comparable, M any](
+	capacity int32,
+	expiry time.Duration,
+	tick time.Duration,
+	tryProcess func(ctx context.Context, key K, msg M) (func(), bool),
+	onExpired func(key K),
+) *pendingJobQueue[K, M] {
+	return &pendingJobQueue[K, M]{
+		capacity:   capacity,
+		expiry:     expiry,
+		tick:       tick,
+		tryProcess: tryProcess,
+		onExpired:  onExpired,
+		cond:       sync.NewCond(&sync.Mutex{}),
+	}
+}
+
+func (q *pendingJobQueue[K, M]) enqueueLazy(msg M, buildKey func() (K, error)) error {
+	if !q.reserve() {
+		return nil
+	}
+
+	key, err := buildKey()
+	if err != nil {
+		q.count.Add(-1)
+		return err
+	}
+	q.storeReserved(key, msg)
+	return nil
+}
+
+func (q *pendingJobQueue[K, M]) reserve() bool {
+	if q.count.Add(1) > q.capacity {
+		q.count.Add(-1)
+		return false
+	}
+	return true
+}
+
+func (q *pendingJobQueue[K, M]) storeReserved(key K, msg M) {
+	if _, loaded := q.jobs.LoadOrStore(key, &pendingJob[M]{
+		msg:          msg,
+		creationTime: time.Now(),
+	}); loaded {
+		q.count.Add(-1)
+	} else {
+		q.cond.L.Lock()
+		q.cond.Signal()
+		q.cond.L.Unlock()
+	}
+}
+
+func (q *pendingJobQueue[K, M]) remove(key K) {
+	q.jobs.Delete(key)
+	q.count.Add(-1)
+}
+
+// loop is the background goroutine that retries pending jobs.
+func (q *pendingJobQueue[K, M]) loop(ctx context.Context) {
+	// Wake any blocked Wait() on context cancellation to prevent deadlock.
+	go func() {
+		<-ctx.Done()
+		q.cond.L.Lock()
+		q.cond.Broadcast()
+		q.cond.L.Unlock()
+	}()
+
+	for {
+		// Wait until there are pending jobs
+		q.cond.L.Lock()
+		for q.count.Load() == 0 {
+			select {
+			case <-ctx.Done():
+				q.cond.L.Unlock()
+				return
+			default:
+			}
+			q.cond.Wait()
+		}
+		q.cond.L.Unlock()
+
+		// Poll until all pending jobs are processed
+		ticker := time.NewTicker(q.tick)
+		for q.count.Load() > 0 {
+			select {
+			case <-ctx.Done():
+				ticker.Stop()
+				return
+			case <-ticker.C:
+				q.processPending(ctx)
+			}
+		}
+		ticker.Stop()
+	}
+}
+
+func (q *pendingJobQueue[K, M]) processPending(ctx context.Context) {
+	q.jobs.Range(func(key, value any) bool {
+		k := key.(K)
+		job := value.(*pendingJob[M])
+
+		if time.Since(job.creationTime) > q.expiry {
+			q.remove(k)
+			q.onExpired(k)
+			return true
+		}
+
+		process, done := q.tryProcess(ctx, k, job.msg)
+		if !done {
+			return true
+		}
+		q.remove(k)
+		if process != nil {
+			process()
+		}
+		return true
+	})
+}

--- a/cl/phase1/network/services/pending_job_queue.go
+++ b/cl/phase1/network/services/pending_job_queue.go
@@ -21,119 +21,235 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/erigontech/erigon/diagnostics/metrics"
 )
 
 type pendingJob[M any] struct {
+	mu           sync.Mutex
 	msg          M
 	creationTime time.Time
 }
 
-// pendingJobQueue holds gossip messages whose processing dependencies have not
-// arrived yet and retries them periodically until processed or expired.
-type pendingJobQueue[K comparable, M any] struct {
-	capacity int32
-	expiry   time.Duration
-	tick     time.Duration
-	// tryProcess decides a job's fate: done=false keeps it queued for the next
-	// tick; done=true removes it. A non-nil process func runs after the removal,
-	// so that a concurrent re-enqueue under the same key is not lost.
-	tryProcess func(ctx context.Context, key K, msg M) (process func(), done bool)
-	onExpired  func(key K)
+type pendingJobQueueOptions struct {
+	name          string
+	capacity      int32
+	expiry        time.Duration
+	checkInterval time.Duration
+}
 
-	jobs  sync.Map // K -> *pendingJob[M]
-	count atomic.Int32
-	cond  *sync.Cond
+type pendingJobEnqueueResult uint8
+
+const (
+	pendingJobEnqueueError pendingJobEnqueueResult = iota
+	pendingJobEnqueued
+	pendingJobDuplicate
+	pendingJobQueueFull
+)
+
+type pendingJobDecision uint8
+
+const (
+	pendingJobKeep pendingJobDecision = iota
+	pendingJobRemove
+	pendingJobRemoveThenProcess
+)
+
+var pendingJobQueueRejectedCounter = metrics.GetOrCreateCounterVec(
+	"caplin_pending_job_queue_rejected_total",
+	[]string{"queue"},
+	"Total pending queue admission attempts rejected at capacity",
+)
+
+// pendingJobQueue retries dependency-blocked jobs on the single processing loop
+// started by newPendingJobQueue. Jobs remain until the service callback requests
+// removal or they expire.
+type pendingJobQueue[K comparable, M any] struct {
+	pendingJobQueueOptions
+	// tryProcess callbacks run sequentially without holding the entry lock.
+	// mergeDuplicate and onExpired hold it and must not enqueue the same key;
+	// onExpired runs immediately before removal. processAfterRemove runs only
+	// after successful removal, so it may re-enqueue.
+	tryProcess         func(ctx context.Context, key K, msg M) pendingJobDecision
+	processAfterRemove func(ctx context.Context, key K, msg M)
+	onExpired          func(key K, msg M)
+	mergeDuplicate     func(existing, incoming M)
+
+	jobs sync.Map // K -> *pendingJob[M]
+	// count includes stored jobs and reservations held by in-flight enqueues. It
+	// can exceed the number of visible jobs, but it never exceeds capacity.
+	count    atomic.Int32
+	wakeLoop chan struct{}
+
+	cancelLoop context.CancelFunc
+	loopWG     sync.WaitGroup
+
+	fullCounter metrics.Counter
 }
 
 func newPendingJobQueue[K comparable, M any](
-	capacity int32,
-	expiry time.Duration,
-	tick time.Duration,
-	tryProcess func(ctx context.Context, key K, msg M) (func(), bool),
-	onExpired func(key K),
+	ctx context.Context,
+	options pendingJobQueueOptions,
+	tryProcess func(ctx context.Context, key K, msg M) pendingJobDecision,
+	processAfterRemove func(ctx context.Context, key K, msg M),
+	onExpired func(key K, msg M),
+	mergeDuplicate func(existing, incoming M),
 ) *pendingJobQueue[K, M] {
-	return &pendingJobQueue[K, M]{
-		capacity:   capacity,
-		expiry:     expiry,
-		tick:       tick,
-		tryProcess: tryProcess,
-		onExpired:  onExpired,
-		cond:       sync.NewCond(&sync.Mutex{}),
+	if options.capacity <= 0 {
+		panic("pending job queue capacity must be positive")
 	}
+	if options.expiry <= 0 {
+		panic("pending job queue expiry must be positive")
+	}
+	if options.checkInterval <= 0 {
+		panic("pending job queue check interval must be positive")
+	}
+	if options.name == "" {
+		panic("pending job queue name must not be empty")
+	}
+	if tryProcess == nil {
+		panic("pending job queue requires tryProcess")
+	}
+	if onExpired == nil {
+		panic("pending job queue requires onExpired")
+	}
+	loopCtx, cancelLoop := context.WithCancel(ctx)
+	q := &pendingJobQueue[K, M]{
+		pendingJobQueueOptions: options,
+		tryProcess:             tryProcess,
+		processAfterRemove:     processAfterRemove,
+		onExpired:              onExpired,
+		mergeDuplicate:         mergeDuplicate,
+		wakeLoop:               make(chan struct{}, 1),
+		cancelLoop:             cancelLoop,
+		fullCounter:            pendingJobQueueRejectedCounter.WithLabelValues(options.name),
+	}
+	q.loopWG.Go(func() {
+		q.loop(loopCtx)
+	})
+	return q
 }
 
-func (q *pendingJobQueue[K, M]) enqueueLazy(msg M, buildKey func() (K, error)) error {
+func (q *pendingJobQueue[K, M]) stopAndWait() {
+	q.cancelLoop()
+	q.loopWG.Wait()
+}
+
+// enqueueLazy reserves capacity before building the key so a full queue skips
+// potentially expensive work. A duplicate arriving at capacity is therefore
+// reported as full because detecting it would require building the key. Storage
+// keeps or releases the reservation; deferred cleanup handles key-construction
+// errors and panics.
+func (q *pendingJobQueue[K, M]) enqueueLazy(msg M, buildKey func() (K, error)) (pendingJobEnqueueResult, error) {
 	if !q.reserve() {
-		return nil
+		return pendingJobQueueFull, nil
 	}
+
+	reservationOwned := true
+	defer func() {
+		if reservationOwned {
+			q.count.Add(-1)
+		}
+	}()
 
 	key, err := buildKey()
 	if err != nil {
-		q.count.Add(-1)
-		return err
+		return pendingJobEnqueueError, err
 	}
-	q.storeReserved(key, msg)
-	return nil
+	result := q.storeReserved(key, msg)
+	reservationOwned = false
+	return result, nil
 }
 
 func (q *pendingJobQueue[K, M]) reserve() bool {
-	if q.count.Add(1) > q.capacity {
+	for {
+		count := q.count.Load()
+		if count >= q.capacity {
+			q.fullCounter.Inc()
+			return false
+		}
+		if q.count.CompareAndSwap(count, count+1) {
+			return true
+		}
+	}
+}
+
+// storeReserved transfers the caller's reservation to a new job, or releases
+// it if the key is already present.
+func (q *pendingJobQueue[K, M]) storeReserved(key K, msg M) pendingJobEnqueueResult {
+	candidate := &pendingJob[M]{
+		msg:          msg,
+		creationTime: time.Now(),
+	}
+	for {
+		value, loaded := q.jobs.LoadOrStore(key, candidate)
+		if !loaded {
+			break
+		}
+		if !q.mergeStoredDuplicate(key, value.(*pendingJob[M]), msg) {
+			continue
+		}
 		q.count.Add(-1)
+		return pendingJobDuplicate
+	}
+	// Wake notifications may coalesce; count determines whether work remains.
+	select {
+	case q.wakeLoop <- struct{}{}:
+	default:
+	}
+	return pendingJobEnqueued
+}
+
+// mergeStoredDuplicate confirms that existing is still current while merging
+// its state, serializing the merge with expiry and removal.
+func (q *pendingJobQueue[K, M]) mergeStoredDuplicate(key K, existing *pendingJob[M], incoming M) bool {
+	existing.mu.Lock()
+	defer existing.mu.Unlock()
+	current, ok := q.jobs.Load(key)
+	if !ok || current != existing {
 		return false
+	}
+	if q.mergeDuplicate != nil {
+		q.mergeDuplicate(existing.msg, incoming)
 	}
 	return true
 }
 
-func (q *pendingJobQueue[K, M]) storeReserved(key K, msg M) {
-	if _, loaded := q.jobs.LoadOrStore(key, &pendingJob[M]{
-		msg:          msg,
-		creationTime: time.Now(),
-	}); loaded {
-		q.count.Add(-1)
-	} else {
-		q.cond.L.Lock()
-		q.cond.Signal()
-		q.cond.L.Unlock()
+func (q *pendingJobQueue[K, M]) remove(key K, job *pendingJob[M]) bool {
+	if !q.jobs.CompareAndDelete(key, job) {
+		return false
 	}
-}
-
-func (q *pendingJobQueue[K, M]) remove(key K) {
-	q.jobs.Delete(key)
 	q.count.Add(-1)
+	return true
 }
 
 // loop is the background goroutine that retries pending jobs.
 func (q *pendingJobQueue[K, M]) loop(ctx context.Context) {
-	// Wake any blocked Wait() on context cancellation to prevent deadlock.
-	go func() {
-		<-ctx.Done()
-		q.cond.L.Lock()
-		q.cond.Broadcast()
-		q.cond.L.Unlock()
-	}()
-
 	for {
-		// Wait until there are pending jobs
-		q.cond.L.Lock()
+		if ctx.Err() != nil {
+			return
+		}
 		for q.count.Load() == 0 {
 			select {
 			case <-ctx.Done():
-				q.cond.L.Unlock()
 				return
-			default:
+			case <-q.wakeLoop:
 			}
-			q.cond.Wait()
 		}
-		q.cond.L.Unlock()
 
-		// Poll until all pending jobs are processed
-		ticker := time.NewTicker(q.tick)
+		ticker := time.NewTicker(q.checkInterval)
 		for q.count.Load() > 0 {
 			select {
 			case <-ctx.Done():
 				ticker.Stop()
 				return
 			case <-ticker.C:
+				// A tick can win the select after cancellation is ready. Recheck
+				// before invoking service code on an already-canceled queue.
+				if ctx.Err() != nil {
+					ticker.Stop()
+					return
+				}
 				q.processPending(ctx)
 			}
 		}
@@ -141,24 +257,45 @@ func (q *pendingJobQueue[K, M]) loop(ctx context.Context) {
 	}
 }
 
+// processPending runs callbacks sequentially. Once it observes cancellation, it
+// stops before the next job; an already-started callback may finish. It must not
+// be called concurrently.
 func (q *pendingJobQueue[K, M]) processPending(ctx context.Context) {
 	q.jobs.Range(func(key, value any) bool {
+		if ctx.Err() != nil {
+			return false
+		}
 		k := key.(K)
 		job := value.(*pendingJob[M])
-
 		if time.Since(job.creationTime) > q.expiry {
-			q.remove(k)
-			q.onExpired(k)
+			job.mu.Lock()
+			current, stored := q.jobs.Load(k)
+			if stored && current == job {
+				q.onExpired(k, job.msg)
+				q.remove(k, job)
+			}
+			job.mu.Unlock()
 			return true
 		}
 
-		process, done := q.tryProcess(ctx, k, job.msg)
-		if !done {
+		decision := q.tryProcess(ctx, k, job.msg)
+		switch decision {
+		case pendingJobKeep:
 			return true
+		case pendingJobRemove:
+		case pendingJobRemoveThenProcess:
+			if q.processAfterRemove == nil {
+				panic("pending job queue requires processAfterRemove")
+			}
+		default:
+			panic("invalid pending job decision")
 		}
-		q.remove(k)
-		if process != nil {
-			process()
+
+		job.mu.Lock()
+		removed := q.remove(k, job)
+		job.mu.Unlock()
+		if removed && decision == pendingJobRemoveThenProcess {
+			q.processAfterRemove(ctx, k, job.msg)
 		}
 		return true
 	})

--- a/cl/phase1/network/services/pending_job_queue_test.go
+++ b/cl/phase1/network/services/pending_job_queue_test.go
@@ -1,0 +1,570 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package services
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+)
+
+type serviceLogCapture struct {
+	mu     sync.Mutex
+	buffer bytes.Buffer
+}
+
+func (c *serviceLogCapture) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.buffer.Write(p)
+}
+
+func (c *serviceLogCapture) String() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.buffer.String()
+}
+
+func (c *serviceLogCapture) Bytes() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return bytes.Clone(c.buffer.Bytes())
+}
+
+func captureServiceLogs(t *testing.T) *serviceLogCapture {
+	t.Helper()
+	var output serviceLogCapture
+	logger := log.Root()
+	previousHandler := logger.GetHandler()
+	logger.SetHandler(log.StreamHandler(&output, log.LogfmtFormat()))
+	t.Cleanup(func() { logger.SetHandler(previousHandler) })
+	return &output
+}
+
+func canceledPendingQueueContext(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	return ctx
+}
+
+func storePendingJob[K comparable, M any](
+	t *testing.T,
+	queue *pendingJobQueue[K, M],
+	key K,
+	msg M,
+	creationTime time.Time,
+) *pendingJob[M] {
+	t.Helper()
+	job := &pendingJob[M]{
+		msg:          msg,
+		creationTime: creationTime,
+	}
+	_, loaded := queue.jobs.LoadOrStore(key, job)
+	require.False(t, loaded)
+	queue.count.Add(1)
+	return job
+}
+
+func enqueueTestPendingJob[K comparable, M any](queue *pendingJobQueue[K, M], key K, msg M) pendingJobEnqueueResult {
+	result, err := queue.enqueueLazy(msg, func() (K, error) { return key, nil })
+	if err != nil {
+		panic(err)
+	}
+	return result
+}
+
+func newTestPendingJobQueueWithOptions(ctx context.Context, options pendingJobQueueOptions) *pendingJobQueue[int, string] {
+	return newPendingJobQueue(ctx, options,
+		func(context.Context, int, string) pendingJobDecision {
+			return pendingJobKeep
+		},
+		nil,
+		func(int, string) {},
+		nil,
+	)
+}
+
+func newTestPendingJobQueue(t *testing.T) *pendingJobQueue[int, string] {
+	return newTestPendingJobQueueWithOptions(canceledPendingQueueContext(t), pendingJobQueueOptions{
+		name:          t.Name(),
+		capacity:      1,
+		expiry:        time.Minute,
+		checkInterval: time.Millisecond,
+	})
+}
+
+func TestNewPendingJobQueueRejectsNilTryProcess(t *testing.T) {
+	require.Panics(t, func() {
+		newPendingJobQueue[int, string](
+			t.Context(),
+			pendingJobQueueOptions{
+				name:          t.Name(),
+				capacity:      1,
+				expiry:        time.Minute,
+				checkInterval: time.Millisecond,
+			},
+			nil,
+			nil,
+			func(int, string) {},
+			nil,
+		)
+	})
+}
+
+func TestNewPendingJobQueueRejectsNilOnExpired(t *testing.T) {
+	require.Panics(t, func() {
+		newPendingJobQueue[int, string](
+			t.Context(),
+			pendingJobQueueOptions{
+				name:          t.Name(),
+				capacity:      1,
+				expiry:        time.Minute,
+				checkInterval: time.Millisecond,
+			},
+			func(context.Context, int, string) pendingJobDecision {
+				return pendingJobKeep
+			},
+			nil,
+			nil,
+			nil,
+		)
+	})
+}
+
+func TestNewPendingJobQueueRejectsEmptyName(t *testing.T) {
+	require.PanicsWithValue(t, "pending job queue name must not be empty", func() {
+		newTestPendingJobQueueWithOptions(t.Context(), pendingJobQueueOptions{
+			capacity:      1,
+			expiry:        time.Minute,
+			checkInterval: time.Millisecond,
+		})
+	})
+}
+
+func TestNewPendingJobQueueRejectsNonPositiveCapacity(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		capacity int32
+	}{
+		{name: "zero", capacity: 0},
+		{name: "negative", capacity: -1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.PanicsWithValue(t, "pending job queue capacity must be positive", func() {
+				newTestPendingJobQueueWithOptions(t.Context(), pendingJobQueueOptions{
+					capacity:      test.capacity,
+					expiry:        time.Minute,
+					checkInterval: time.Millisecond,
+				})
+			})
+		})
+	}
+}
+
+func TestNewPendingJobQueueRejectsNonPositiveExpiry(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		expiry time.Duration
+	}{
+		{name: "zero", expiry: 0},
+		{name: "negative", expiry: -time.Millisecond},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.PanicsWithValue(t, "pending job queue expiry must be positive", func() {
+				newTestPendingJobQueueWithOptions(t.Context(), pendingJobQueueOptions{
+					name:          t.Name(),
+					capacity:      1,
+					expiry:        test.expiry,
+					checkInterval: time.Millisecond,
+				})
+			})
+		})
+	}
+}
+
+func TestNewPendingJobQueueRejectsNonPositiveCheckInterval(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		checkInterval time.Duration
+	}{
+		{name: "zero", checkInterval: 0},
+		{name: "negative", checkInterval: -time.Millisecond},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.PanicsWithValue(t, "pending job queue check interval must be positive", func() {
+				newTestPendingJobQueueWithOptions(t.Context(), pendingJobQueueOptions{
+					capacity:      1,
+					expiry:        time.Minute,
+					checkInterval: test.checkInterval,
+				})
+			})
+		})
+	}
+}
+
+func TestNewPendingJobQueueStartsProcessingLoop(t *testing.T) {
+	processed := make(chan string, 1)
+	queue := newPendingJobQueue(
+		t.Context(),
+		pendingJobQueueOptions{
+			name:          t.Name(),
+			capacity:      1,
+			expiry:        time.Minute,
+			checkInterval: time.Millisecond,
+		},
+		func(_ context.Context, _ int, msg string) pendingJobDecision {
+			processed <- msg
+			return pendingJobRemove
+		},
+		nil,
+		func(int, string) {},
+		nil,
+	)
+
+	result, err := queue.enqueueLazy("message", func() (int, error) {
+		return 1, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, pendingJobEnqueued, result)
+
+	select {
+	case msg := <-processed:
+		require.Equal(t, "message", msg)
+	case <-time.After(time.Second):
+		t.Fatal("pending job queue did not process the job")
+	}
+	require.Eventually(t, func() bool {
+		return queue.count.Load() == 0
+	}, time.Second, time.Millisecond)
+}
+
+func TestPendingJobQueueDoesNotProcessAfterContextCancellation(t *testing.T) {
+	processed := 0
+	for range 1_000 {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		queue := &pendingJobQueue[int, string]{
+			pendingJobQueueOptions: pendingJobQueueOptions{
+				capacity:      1,
+				expiry:        time.Minute,
+				checkInterval: time.Nanosecond,
+			},
+			tryProcess: func(context.Context, int, string) pendingJobDecision {
+				processed++
+				return pendingJobRemove
+			},
+			onExpired: func(int, string) {},
+			wakeLoop:  make(chan struct{}, 1),
+		}
+		storePendingJob(t, queue, 1, "message", time.Now())
+
+		queue.loop(ctx)
+	}
+
+	require.Zero(t, processed)
+}
+
+func TestPendingJobQueueCancellationStopsCurrentScan(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	processed := 0
+	queue := &pendingJobQueue[int, string]{
+		pendingJobQueueOptions: pendingJobQueueOptions{
+			capacity: 2,
+			expiry:   time.Minute,
+		},
+		tryProcess: func(context.Context, int, string) pendingJobDecision {
+			processed++
+			cancel()
+			return pendingJobKeep
+		},
+		onExpired: func(int, string) {},
+	}
+	storePendingJob(t, queue, 1, "first", time.Now())
+	storePendingJob(t, queue, 2, "second", time.Now())
+
+	queue.processPending(ctx)
+
+	require.Equal(t, 1, processed)
+}
+
+func TestPendingJobQueueStopWaitsForInFlightProcessing(t *testing.T) {
+	processing := make(chan context.Context, 1)
+	processingReleased := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseProcessing := func() {
+		releaseOnce.Do(func() { close(processingReleased) })
+	}
+
+	queue := newPendingJobQueue(
+		t.Context(),
+		pendingJobQueueOptions{
+			name:          t.Name(),
+			capacity:      1,
+			expiry:        time.Minute,
+			checkInterval: time.Millisecond,
+		},
+		func(ctx context.Context, _ int, _ string) pendingJobDecision {
+			processing <- ctx
+			<-processingReleased
+			return pendingJobRemove
+		},
+		nil,
+		func(int, string) {},
+		nil,
+	)
+	defer func() {
+		releaseProcessing()
+		queue.stopAndWait()
+	}()
+	require.Equal(t, pendingJobEnqueued, enqueueTestPendingJob(queue, 1, "message"))
+
+	var processingCtx context.Context
+	select {
+	case processingCtx = <-processing:
+	case <-time.After(time.Second):
+		t.Fatal("pending job queue did not start processing")
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		queue.stopAndWait()
+		close(stopped)
+	}()
+	select {
+	case <-processingCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("pending job queue was not cancelled")
+	}
+	select {
+	case <-stopped:
+		t.Fatal("pending job queue reported completion while processing was still active")
+	default:
+	}
+
+	releaseProcessing()
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("pending job queue did not stop")
+	}
+}
+
+func TestPendingJobQueueEnqueueDeduplicates(t *testing.T) {
+	queue := newTestPendingJobQueueWithOptions(canceledPendingQueueContext(t), pendingJobQueueOptions{
+		name:          t.Name(),
+		capacity:      2,
+		expiry:        time.Minute,
+		checkInterval: time.Millisecond,
+	})
+
+	firstResult := enqueueTestPendingJob(queue, 1, "original")
+	duplicateResult := enqueueTestPendingJob(queue, 1, "duplicate")
+
+	require.Equal(t, pendingJobEnqueued, firstResult)
+	require.Equal(t, pendingJobDuplicate, duplicateResult)
+	require.Equal(t, int32(1), queue.count.Load())
+	stored, exists := queue.jobs.Load(1)
+	require.True(t, exists)
+	require.Equal(t, "original", stored.(*pendingJob[string]).msg)
+}
+
+func TestPendingJobQueueEnqueueSkipsKeyBuildAtCapacity(t *testing.T) {
+	queue := newTestPendingJobQueue(t)
+	queue.count.Store(queue.capacity)
+
+	keyBuilt := false
+	result, err := queue.enqueueLazy("message", func() (int, error) {
+		keyBuilt = true
+		return 1, nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, pendingJobQueueFull, result)
+	require.False(t, keyBuilt)
+	require.Equal(t, queue.capacity, queue.count.Load())
+}
+
+func TestPendingJobQueueEnqueueReleasesReservationOnKeyBuildPanic(t *testing.T) {
+	queue := newTestPendingJobQueue(t)
+
+	require.Panics(t, func() {
+		_, _ = queue.enqueueLazy("message", func() (int, error) {
+			panic("key build failed")
+		})
+	})
+	require.Zero(t, queue.count.Load())
+}
+
+func TestPendingJobQueueEnqueueReleasesReservationOnKeyBuildError(t *testing.T) {
+	queue := newTestPendingJobQueue(t)
+	wantErr := errors.New("key build failed")
+
+	result, err := queue.enqueueLazy("message", func() (int, error) {
+		return 0, wantErr
+	})
+
+	require.ErrorIs(t, err, wantErr)
+	require.Equal(t, pendingJobEnqueueError, result)
+	require.Zero(t, queue.count.Load())
+}
+
+func TestPendingJobQueueCountsFullRejection(t *testing.T) {
+	queue := newTestPendingJobQueue(t)
+	queue.count.Store(queue.capacity)
+	before := queue.fullCounter.GetValueUint64()
+
+	result := enqueueTestPendingJob(queue, 1, "message")
+
+	require.Equal(t, pendingJobQueueFull, result)
+	require.Equal(t, before+1, queue.fullCounter.GetValueUint64())
+}
+
+func TestPendingJobQueueConcurrentEnqueueResults(t *testing.T) {
+	const capacity = int32(5)
+	queue := newTestPendingJobQueueWithOptions(canceledPendingQueueContext(t), pendingJobQueueOptions{
+		name:          t.Name(),
+		capacity:      capacity,
+		expiry:        time.Minute,
+		checkInterval: time.Millisecond,
+	})
+	var enqueued atomic.Int32
+	var full atomic.Int32
+	var unexpected atomic.Int32
+	var wg sync.WaitGroup
+
+	for key := range 100 {
+		wg.Go(func() {
+			switch enqueueTestPendingJob(queue, key, "message") {
+			case pendingJobEnqueued:
+				enqueued.Add(1)
+			case pendingJobQueueFull:
+				full.Add(1)
+			default:
+				unexpected.Add(1)
+			}
+		})
+	}
+	wg.Wait()
+
+	require.Equal(t, capacity, enqueued.Load())
+	require.Equal(t, int32(100)-capacity, full.Load())
+	require.Zero(t, unexpected.Load())
+	require.Equal(t, capacity, queue.count.Load())
+}
+
+func TestPendingJobQueueConcurrentEnqueueRemoveKeepsCountBounded(t *testing.T) {
+	const (
+		workers  = 32
+		attempts = 10_000
+	)
+	queue := newTestPendingJobQueue(t)
+	held := storePendingJob(t, queue, 0, "held", time.Now())
+
+	start := make(chan struct{})
+	continueAfterRemove := make(chan struct{})
+	var overCapacity atomic.Bool
+
+	var firstAttempts sync.WaitGroup
+	firstAttempts.Add(workers)
+	var successfulEnqueues atomic.Int32
+	var unexpectedResults atomic.Int32
+	var workersWG sync.WaitGroup
+	for worker := range workers {
+		workersWG.Go(func() {
+			<-start
+			if enqueueTestPendingJob(queue, worker+1, "message") != pendingJobQueueFull {
+				unexpectedResults.Add(1)
+			}
+			firstAttempts.Done()
+			<-continueAfterRemove
+
+			for attempt := range attempts {
+				key := workers + 1 + worker*attempts + attempt
+				switch enqueueTestPendingJob(queue, key, "message") {
+				case pendingJobQueueFull:
+				case pendingJobEnqueued:
+					successfulEnqueues.Add(1)
+					runtime.Gosched()
+					if queue.count.Load() > queue.capacity {
+						overCapacity.Store(true)
+					}
+					job, loaded := queue.jobs.Load(key)
+					if !loaded || !queue.remove(key, job.(*pendingJob[string])) {
+						unexpectedResults.Add(1)
+					}
+				default:
+					unexpectedResults.Add(1)
+				}
+			}
+		})
+	}
+	close(start)
+	firstAttempts.Wait()
+	removed := queue.remove(0, held)
+	close(continueAfterRemove)
+	workersWG.Wait()
+
+	require.True(t, removed)
+	require.False(t, overCapacity.Load())
+	require.NotZero(t, successfulEnqueues.Load())
+	require.Zero(t, unexpectedResults.Load())
+	require.Zero(t, queue.count.Load())
+}
+
+func TestPendingJobQueueAfterRemoveCanEnqueueSameKey(t *testing.T) {
+	var queue *pendingJobQueue[int, string]
+	afterRemoveCalled := false
+
+	queue = newPendingJobQueue(canceledPendingQueueContext(t), pendingJobQueueOptions{
+		name:          t.Name(),
+		capacity:      1,
+		expiry:        time.Minute,
+		checkInterval: time.Millisecond,
+	},
+		func(context.Context, int, string) pendingJobDecision {
+			return pendingJobRemoveThenProcess
+		},
+		func(_ context.Context, key int, _ string) {
+			afterRemoveCalled = true
+			_, exists := queue.jobs.Load(key)
+			require.False(t, exists)
+			_ = enqueueTestPendingJob(queue, key, "replacement")
+		},
+		func(int, string) {},
+		nil,
+	)
+
+	_ = enqueueTestPendingJob(queue, 1, "original")
+
+	queue.processPending(t.Context())
+
+	require.True(t, afterRemoveCalled)
+	require.Equal(t, int32(1), queue.count.Load())
+	stored, exists := queue.jobs.Load(1)
+	require.True(t, exists)
+	require.Equal(t, "replacement", stored.(*pendingJob[string]).msg)
+}


### PR DESCRIPTION
Service-specific layer in the split of #22177. Stacked on #23644 and independent of the beacon-block sibling PR #23646.

The Gloas data-column sidecar scheduler uses the bounded shared queue. Pending identity includes the block root, column index, slot, and full sidecar root, so invalid content cannot suppress another candidate for the same block and column.

Subnet validation runs before content-based `IGNORE` checks and before queue admission. Deferred processing keeps the current entry while dependencies are unavailable, preserving the original expiry, and removes finalized or permanently invalid sidecars.

## Validation

- `go test ./cl/phase1/network/services`
- `go test -race ./cl/phase1/network/services`
- `make lint`
- `make erigon integration`