### PR TITLE
[r3.6] rpc/jsonrpc, docs: report base fee sub-pool transactions as pending

### DIFF
--- a/docs/site/docs/interacting-with-erigon/txpool.md
+++ b/docs/site/docs/interacting-with-erigon/txpool.md
@@ -13,7 +13,7 @@ The TxPool namespace must be explicitly enabled using the `--http.api` flag when
 ### Transaction Pool Architecture
 
 * Erigon's transaction pool is organized into three sub-pools: pending (executable), baseFee (insufficient base fee), and queued (nonce gaps)
-* The `txpool_content`, `txpool_contentFrom` and `txpool_status` methods expose only the `pending` and `queued` categories, as defined by the `ethereum/execution-apis` specification. Transactions in the internal baseFee sub-pool are executable and only wait for a lower base fee, so they are reported as pending, matching Geth
+* The `txpool_content`, `txpool_contentFrom` and `txpool_status` methods expose only the `pending` and `queued` categories, as defined by the `ethereum/execution-apis` specification. Transactions in the internal baseFee sub-pool are nonce-ready and otherwise valid, but are not executable at the current base fee: they wait for the fee condition to change. They are reported as pending, matching Geth
 * Blob transactions (type 3) are not reported by `txpool_content` and `txpool_contentFrom`, matching Geth and Nethermind. They are still counted by `txpool_status`
 * The pool can run either integrated within the main Erigon process or as a separate service for scalability
 * Transaction pool methods communicate via gRPC with the TxPool service when running in external mode

--- a/docs/site/docs/interacting-with-erigon/txpool.md
+++ b/docs/site/docs/interacting-with-erigon/txpool.md
@@ -6,13 +6,15 @@ sidebar_position: 8
 
 # txpool
 
-The `txpool` namespace provides methods for inspecting and managing the transaction pool (mempool) in Erigon. These methods allow you to view pending, queued, and base fee transactions, providing insight into the current state of unconfirmed transactions. In Erigon, the `txpool` namespace is implemented through the `TxPoolAPI` interface and `TxPoolAPIImpl` struct.
+The `txpool` namespace provides methods for inspecting and managing the transaction pool (mempool) in Erigon. These methods allow you to view pending and queued transactions, providing insight into the current state of unconfirmed transactions. In Erigon, the `txpool` namespace is implemented through the `TxPoolAPI` interface and `TxPoolAPIImpl` struct.
 
 The TxPool namespace must be explicitly enabled using the `--http.api` flag when starting the RPC Daemon. These methods are particularly useful for monitoring transaction pool status and debugging transaction submission issues.
 
 ### Transaction Pool Architecture
 
 * Erigon's transaction pool is organized into three sub-pools: pending (executable), baseFee (insufficient base fee), and queued (nonce gaps)
+* The `txpool_content`, `txpool_contentFrom` and `txpool_status` methods expose only the `pending` and `queued` categories, as defined by the `ethereum/execution-apis` specification. Transactions in the internal baseFee sub-pool are executable and only wait for a lower base fee, so they are reported as pending, matching Geth
+* Blob transactions (type 3) are not reported by `txpool_content` and `txpool_contentFrom`, matching Geth and Nethermind. They are still counted by `txpool_status`
 * The pool can run either integrated within the main Erigon process or as a separate service for scalability
 * Transaction pool methods communicate via gRPC with the TxPool service when running in external mode
 
@@ -49,7 +51,7 @@ The TxPool namespace must be explicitly enabled using the `--http.api` flag when
 
 ## **txpool\_content**
 
-Returns the content of the transaction pool, organized by sender address and categorized into pending, queued, and baseFee sub-pools.
+Returns the content of the transaction pool, organized by sender address and categorized into pending and queued transactions. Blob transactions are not returned.
 
 **Parameters**
 
@@ -68,14 +70,13 @@ curl -s --data '{"jsonrpc":"2.0","method":"txpool_content","params":[],"id":"1"}
 | ------- | --------------------------------------------------- |
 | Object  | Transaction pool content organized by sub-pool type |
 | pending | Object                                              |
-| baseFee | Object                                              |
 | queued  | Object                                              |
 
 ***
 
 ## **txpool\_contentFrom**
 
-Returns the content of the transaction pool for a specific sender address, showing all transactions from that address across all sub-pools.
+Returns the content of the transaction pool for a specific sender address, categorized into pending and queued transactions. The same rules as `txpool_content` apply.
 
 **Parameters**
 
@@ -96,14 +97,13 @@ curl -s --data '{"jsonrpc":"2.0","method":"txpool_contentFrom","params":["0xb60e
 | ------- | -------------------------------------------------- |
 | Object  | Transaction pool content for the specified address |
 | pending | Object                                             |
-| baseFee | Object                                             |
 | queued  | Object                                             |
 
 ***
 
 ## **txpool\_status**
 
-Returns the current status of the transaction pool, including the count of transactions in each sub-pool.
+Returns the current status of the transaction pool, with the count of pending and queued transactions.
 
 **Parameters**
 
@@ -122,5 +122,4 @@ curl -s --data '{"jsonrpc":"2.0","method":"txpool_status","params":[],"id":"1"}'
 | ------- | ------------------------------ |
 | Object  | Transaction pool status counts |
 | pending | QUANTITY                       |
-| baseFee | QUANTITY                       |
 | queued  | QUANTITY                       |

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -6628,7 +6628,7 @@ The TxPool namespace must be explicitly enabled using the `--http.api` flag when
 ### Transaction Pool Architecture
 
 * Erigon's transaction pool is organized into three sub-pools: pending (executable), baseFee (insufficient base fee), and queued (nonce gaps)
-* The `txpool_content`, `txpool_contentFrom` and `txpool_status` methods expose only the `pending` and `queued` categories, as defined by the `ethereum/execution-apis` specification. Transactions in the internal baseFee sub-pool are executable and only wait for a lower base fee, so they are reported as pending, matching Geth
+* The `txpool_content`, `txpool_contentFrom` and `txpool_status` methods expose only the `pending` and `queued` categories, as defined by the `ethereum/execution-apis` specification. Transactions in the internal baseFee sub-pool are nonce-ready and otherwise valid, but are not executable at the current base fee: they wait for the fee condition to change. They are reported as pending, matching Geth
 * Blob transactions (type 3) are not reported by `txpool_content` and `txpool_contentFrom`, matching Geth and Nethermind. They are still counted by `txpool_status`
 * The pool can run either integrated within the main Erigon process or as a separate service for scalability
 * Transaction pool methods communicate via gRPC with the TxPool service when running in external mode

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -6621,13 +6621,15 @@ Response
 URL: https://docs.erigon.tech/interacting-with-erigon/txpool
 
 
-The `txpool` namespace provides methods for inspecting and managing the transaction pool (mempool) in Erigon. These methods allow you to view pending, queued, and base fee transactions, providing insight into the current state of unconfirmed transactions. In Erigon, the `txpool` namespace is implemented through the `TxPoolAPI` interface and `TxPoolAPIImpl` struct.
+The `txpool` namespace provides methods for inspecting and managing the transaction pool (mempool) in Erigon. These methods allow you to view pending and queued transactions, providing insight into the current state of unconfirmed transactions. In Erigon, the `txpool` namespace is implemented through the `TxPoolAPI` interface and `TxPoolAPIImpl` struct.
 
 The TxPool namespace must be explicitly enabled using the `--http.api` flag when starting the RPC Daemon. These methods are particularly useful for monitoring transaction pool status and debugging transaction submission issues.
 
 ### Transaction Pool Architecture
 
 * Erigon's transaction pool is organized into three sub-pools: pending (executable), baseFee (insufficient base fee), and queued (nonce gaps)
+* The `txpool_content`, `txpool_contentFrom` and `txpool_status` methods expose only the `pending` and `queued` categories, as defined by the `ethereum/execution-apis` specification. Transactions in the internal baseFee sub-pool are executable and only wait for a lower base fee, so they are reported as pending, matching Geth
+* Blob transactions (type 3) are not reported by `txpool_content` and `txpool_contentFrom`, matching Geth and Nethermind. They are still counted by `txpool_status`
 * The pool can run either integrated within the main Erigon process or as a separate service for scalability
 * Transaction pool methods communicate via gRPC with the TxPool service when running in external mode
 
@@ -6664,7 +6666,7 @@ The TxPool namespace must be explicitly enabled using the `--http.api` flag when
 
 ## **txpool\_content**
 
-Returns the content of the transaction pool, organized by sender address and categorized into pending, queued, and baseFee sub-pools.
+Returns the content of the transaction pool, organized by sender address and categorized into pending and queued transactions. Blob transactions are not returned.
 
 **Parameters**
 
@@ -6682,14 +6684,13 @@ curl -s --data '{"jsonrpc":"2.0","method":"txpool_content","params":[],"id":"1"}
 | ------- | --------------------------------------------------- |
 | Object  | Transaction pool content organized by sub-pool type |
 | pending | Object                                              |
-| baseFee | Object                                              |
 | queued  | Object                                              |
 
 ***
 
 ## **txpool\_contentFrom**
 
-Returns the content of the transaction pool for a specific sender address, showing all transactions from that address across all sub-pools.
+Returns the content of the transaction pool for a specific sender address, categorized into pending and queued transactions. The same rules as `txpool_content` apply.
 
 **Parameters**
 
@@ -6709,14 +6710,13 @@ curl -s --data '{"jsonrpc":"2.0","method":"txpool_contentFrom","params":["0xb60e
 | ------- | -------------------------------------------------- |
 | Object  | Transaction pool content for the specified address |
 | pending | Object                                             |
-| baseFee | Object                                             |
 | queued  | Object                                             |
 
 ***
 
 ## **txpool\_status**
 
-Returns the current status of the transaction pool, including the count of transactions in each sub-pool.
+Returns the current status of the transaction pool, with the count of pending and queued transactions.
 
 **Parameters**
 
@@ -6734,7 +6734,6 @@ curl -s --data '{"jsonrpc":"2.0","method":"txpool_status","params":[],"id":"1"}'
 | ------- | ------------------------------ |
 | Object  | Transaction pool status counts |
 | pending | QUANTITY                       |
-| baseFee | QUANTITY                       |
 | queued  | QUANTITY                       |
 
 ---

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6628,7 +6628,7 @@ The TxPool namespace must be explicitly enabled using the `--http.api` flag when
 ### Transaction Pool Architecture
 
 * Erigon's transaction pool is organized into three sub-pools: pending (executable), baseFee (insufficient base fee), and queued (nonce gaps)
-* The `txpool_content`, `txpool_contentFrom` and `txpool_status` methods expose only the `pending` and `queued` categories, as defined by the `ethereum/execution-apis` specification. Transactions in the internal baseFee sub-pool are executable and only wait for a lower base fee, so they are reported as pending, matching Geth
+* The `txpool_content`, `txpool_contentFrom` and `txpool_status` methods expose only the `pending` and `queued` categories, as defined by the `ethereum/execution-apis` specification. Transactions in the internal baseFee sub-pool are nonce-ready and otherwise valid, but are not executable at the current base fee: they wait for the fee condition to change. They are reported as pending, matching Geth
 * Blob transactions (type 3) are not reported by `txpool_content` and `txpool_contentFrom`, matching Geth and Nethermind. They are still counted by `txpool_status`
 * The pool can run either integrated within the main Erigon process or as a separate service for scalability
 * Transaction pool methods communicate via gRPC with the TxPool service when running in external mode

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6621,13 +6621,15 @@ Response
 URL: https://docs.erigon.tech/interacting-with-erigon/txpool
 
 
-The `txpool` namespace provides methods for inspecting and managing the transaction pool (mempool) in Erigon. These methods allow you to view pending, queued, and base fee transactions, providing insight into the current state of unconfirmed transactions. In Erigon, the `txpool` namespace is implemented through the `TxPoolAPI` interface and `TxPoolAPIImpl` struct.
+The `txpool` namespace provides methods for inspecting and managing the transaction pool (mempool) in Erigon. These methods allow you to view pending and queued transactions, providing insight into the current state of unconfirmed transactions. In Erigon, the `txpool` namespace is implemented through the `TxPoolAPI` interface and `TxPoolAPIImpl` struct.
 
 The TxPool namespace must be explicitly enabled using the `--http.api` flag when starting the RPC Daemon. These methods are particularly useful for monitoring transaction pool status and debugging transaction submission issues.
 
 ### Transaction Pool Architecture
 
 * Erigon's transaction pool is organized into three sub-pools: pending (executable), baseFee (insufficient base fee), and queued (nonce gaps)
+* The `txpool_content`, `txpool_contentFrom` and `txpool_status` methods expose only the `pending` and `queued` categories, as defined by the `ethereum/execution-apis` specification. Transactions in the internal baseFee sub-pool are executable and only wait for a lower base fee, so they are reported as pending, matching Geth
+* Blob transactions (type 3) are not reported by `txpool_content` and `txpool_contentFrom`, matching Geth and Nethermind. They are still counted by `txpool_status`
 * The pool can run either integrated within the main Erigon process or as a separate service for scalability
 * Transaction pool methods communicate via gRPC with the TxPool service when running in external mode
 
@@ -6664,7 +6666,7 @@ The TxPool namespace must be explicitly enabled using the `--http.api` flag when
 
 ## **txpool\_content**
 
-Returns the content of the transaction pool, organized by sender address and categorized into pending, queued, and baseFee sub-pools.
+Returns the content of the transaction pool, organized by sender address and categorized into pending and queued transactions. Blob transactions are not returned.
 
 **Parameters**
 
@@ -6682,14 +6684,13 @@ curl -s --data '{"jsonrpc":"2.0","method":"txpool_content","params":[],"id":"1"}
 | ------- | --------------------------------------------------- |
 | Object  | Transaction pool content organized by sub-pool type |
 | pending | Object                                              |
-| baseFee | Object                                              |
 | queued  | Object                                              |
 
 ***
 
 ## **txpool\_contentFrom**
 
-Returns the content of the transaction pool for a specific sender address, showing all transactions from that address across all sub-pools.
+Returns the content of the transaction pool for a specific sender address, categorized into pending and queued transactions. The same rules as `txpool_content` apply.
 
 **Parameters**
 
@@ -6709,14 +6710,13 @@ curl -s --data '{"jsonrpc":"2.0","method":"txpool_contentFrom","params":["0xb60e
 | ------- | -------------------------------------------------- |
 | Object  | Transaction pool content for the specified address |
 | pending | Object                                             |
-| baseFee | Object                                             |
 | queued  | Object                                             |
 
 ***
 
 ## **txpool\_status**
 
-Returns the current status of the transaction pool, including the count of transactions in each sub-pool.
+Returns the current status of the transaction pool, with the count of pending and queued transactions.
 
 **Parameters**
 
@@ -6734,7 +6734,6 @@ curl -s --data '{"jsonrpc":"2.0","method":"txpool_status","params":[],"id":"1"}'
 | ------- | ------------------------------ |
 | Object  | Transaction pool status counts |
 | pending | QUANTITY                       |
-| baseFee | QUANTITY                       |
 | queued  | QUANTITY                       |
 
 ---

--- a/rpc/jsonrpc/txpool_api.go
+++ b/rpc/jsonrpc/txpool_api.go
@@ -87,7 +87,9 @@ func (api *TxPoolAPIImpl) Content(ctx context.Context) (map[string]map[string]ma
 		}
 		addr := gointerfaces.ConvertH160toAddress(reply.Txs[i].Sender)
 		switch reply.Txs[i].TxnType {
-		case txpoolproto.AllReply_PENDING:
+		// Base fee sub-pool transactions are executable and only wait for a lower base fee,
+		// which is what Geth keeps in its pending list, so they belong to the pending bucket.
+		case txpoolproto.AllReply_PENDING, txpoolproto.AllReply_BASE_FEE:
 			if _, ok := pending[addr]; !ok {
 				pending[addr] = make([]types.Transaction, 0, 4)
 			}
@@ -152,7 +154,7 @@ func (api *TxPoolAPIImpl) ContentFrom(ctx context.Context, addr common.Address) 
 		}
 
 		switch reply.Txs[i].TxnType {
-		case txpoolproto.AllReply_PENDING:
+		case txpoolproto.AllReply_PENDING, txpoolproto.AllReply_BASE_FEE:
 			pending = append(pending, txn)
 		case txpoolproto.AllReply_QUEUED:
 			queued = append(queued, txn)
@@ -185,7 +187,7 @@ func (api *TxPoolAPIImpl) Status(ctx context.Context) (map[string]hexutil.Uint, 
 		return nil, err
 	}
 	return map[string]hexutil.Uint{
-		"pending": hexutil.Uint(reply.PendingCount),
+		"pending": hexutil.Uint(reply.PendingCount + reply.BaseFeeCount),
 		"queued":  hexutil.Uint(reply.QueuedCount),
 	}, nil
 }

--- a/rpc/jsonrpc/txpool_api.go
+++ b/rpc/jsonrpc/txpool_api.go
@@ -87,8 +87,8 @@ func (api *TxPoolAPIImpl) Content(ctx context.Context) (map[string]map[string]ma
 		}
 		addr := gointerfaces.ConvertH160toAddress(reply.Txs[i].Sender)
 		switch reply.Txs[i].TxnType {
-		// Base fee sub-pool transactions are executable and only wait for a lower base fee,
-		// which is what Geth keeps in its pending list, so they belong to the pending bucket.
+		// Base fee sub-pool transactions are nonce-ready and otherwise valid, waiting only for the
+		// base fee to drop, which is what Geth keeps in its pending list, so they are pending here too.
 		case txpoolproto.AllReply_PENDING, txpoolproto.AllReply_BASE_FEE:
 			if _, ok := pending[addr]; !ok {
 				pending[addr] = make([]types.Transaction, 0, 4)
@@ -187,7 +187,7 @@ func (api *TxPoolAPIImpl) Status(ctx context.Context) (map[string]hexutil.Uint, 
 		return nil, err
 	}
 	return map[string]hexutil.Uint{
-		"pending": hexutil.Uint(reply.PendingCount + reply.BaseFeeCount),
+		"pending": hexutil.Uint(uint64(reply.PendingCount) + uint64(reply.BaseFeeCount)),
 		"queued":  hexutil.Uint(reply.QueuedCount),
 	}, nil
 }

--- a/rpc/jsonrpc/txpool_api_test.go
+++ b/rpc/jsonrpc/txpool_api_test.go
@@ -19,6 +19,7 @@ package jsonrpc
 import (
 	"bytes"
 	"context"
+	"math"
 	"testing"
 
 	"github.com/holiman/uint256"
@@ -96,8 +97,8 @@ func (s *stubPoolContentClient) Status(context.Context, *txpoolproto.StatusReque
 	return s.status, nil
 }
 
-// Transactions the pool keeps in its base fee sub-pool are executable but pay less than the
-// current base fee, which is what Geth reports as pending, so they belong to the pending bucket.
+// Transactions the pool keeps in its base fee sub-pool are nonce-ready and otherwise valid, but pay
+// less than the current base fee, which is what Geth reports as pending, so they are pending here too.
 func TestTxPoolContentBaseFeeSubPool(t *testing.T) {
 	m := execmoduletester.New(t, execmoduletester.WithTxPool())
 	require := require.New(t)
@@ -154,4 +155,16 @@ func TestTxPoolContentBaseFeeSubPool(t *testing.T) {
 	require.Len(status, 2)
 	require.Equal(hexutil.Uint(3), status["pending"])
 	require.Equal(hexutil.Uint(1), status["queued"])
+}
+
+func TestTxPoolStatusSumsCountsWithoutWrapping(t *testing.T) {
+	require := require.New(t)
+	pool := &stubPoolContentClient{
+		status: &txpoolproto.StatusReply{PendingCount: math.MaxUint32, BaseFeeCount: 1, QueuedCount: 0},
+	}
+	api := NewTxPoolAPI(nil, nil, pool)
+
+	status, err := api.Status(context.Background())
+	require.NoError(err)
+	require.Equal(hexutil.Uint(math.MaxUint32)+1, status["pending"])
 }

--- a/rpc/jsonrpc/txpool_api_test.go
+++ b/rpc/jsonrpc/txpool_api_test.go
@@ -18,10 +18,12 @@ package jsonrpc
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 
 	"github.com/erigontech/erigon/cmd/rpcdaemon/rpcdaemontest"
 	"github.com/erigontech/erigon/common"
@@ -31,6 +33,7 @@ import (
 	"github.com/erigontech/erigon/execution/protocol/params"
 	"github.com/erigontech/erigon/execution/tests/blockgen"
 	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/node/gointerfaces"
 	"github.com/erigontech/erigon/node/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon/rpc/rpccfg"
 	"github.com/erigontech/erigon/rpc/rpchelper"
@@ -77,4 +80,78 @@ func TestTxPoolContent(t *testing.T) {
 	require.Len(status, 2)
 	require.Equal(status["pending"], hexutil.Uint(1))
 	require.Equal(status["queued"], hexutil.Uint(0))
+}
+
+type stubPoolContentClient struct {
+	txpoolproto.TxpoolClient
+	all    *txpoolproto.AllReply
+	status *txpoolproto.StatusReply
+}
+
+func (s *stubPoolContentClient) All(context.Context, *txpoolproto.AllRequest, ...grpc.CallOption) (*txpoolproto.AllReply, error) {
+	return s.all, nil
+}
+
+func (s *stubPoolContentClient) Status(context.Context, *txpoolproto.StatusRequest, ...grpc.CallOption) (*txpoolproto.StatusReply, error) {
+	return s.status, nil
+}
+
+// Transactions the pool keeps in its base fee sub-pool are executable but pay less than the
+// current base fee, which is what Geth reports as pending, so they belong to the pending bucket.
+func TestTxPoolContentBaseFeeSubPool(t *testing.T) {
+	m := execmoduletester.New(t, execmoduletester.WithTxPool())
+	require := require.New(t)
+	chain, err := blockgen.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 1, func(i int, b *blockgen.BlockGen) {
+		b.SetCoinbase(common.Address{1})
+	})
+	require.NoError(err)
+	require.NoError(m.InsertChain(chain))
+
+	ctx, conn := rpcdaemontest.CreateTestGrpcConn(t, m)
+	ff := rpchelper.New(ctx, rpchelper.DefaultFiltersConfig, nil, txpoolproto.NewTxpoolClient(conn), txpoolproto.NewMiningClient(conn), func() {}, m.Log, nil)
+
+	signer := *types.LatestSignerForChainID(m.ChainConfig.ChainID)
+	rlpOf := func(nonce uint64) []byte {
+		txn, err := types.SignTx(types.NewTransaction(nonce, common.Address{1}, uint256.NewInt(1234), params.TxGas, uint256.NewInt(10*common.GWei), nil), signer, m.Key)
+		require.NoError(err)
+		buf := bytes.NewBuffer(nil)
+		require.NoError(txn.MarshalBinary(buf))
+		return buf.Bytes()
+	}
+
+	sender := gointerfaces.ConvertAddressToH160(m.Address)
+	pool := &stubPoolContentClient{
+		all: &txpoolproto.AllReply{Txs: []*txpoolproto.AllReply_Tx{
+			{TxnType: txpoolproto.AllReply_PENDING, Sender: sender, RlpTx: rlpOf(0)},
+			{TxnType: txpoolproto.AllReply_PENDING, Sender: sender, RlpTx: rlpOf(1)},
+			{TxnType: txpoolproto.AllReply_BASE_FEE, Sender: sender, RlpTx: rlpOf(2)},
+			{TxnType: txpoolproto.AllReply_QUEUED, Sender: sender, RlpTx: rlpOf(4)},
+		}},
+		status: &txpoolproto.StatusReply{PendingCount: 2, BaseFeeCount: 1, QueuedCount: 1},
+	}
+	api := NewTxPoolAPI(NewBaseApi(ff, kvcache.New(kvcache.DefaultCoherentConfig), m.BlockReader, m.Engine, nil, &rpccfg.BaseApiConfig{Dirs: m.Dirs}), m.DB, pool)
+
+	addr := m.Address.String()
+
+	content, err := api.Content(ctx)
+	require.NoError(err)
+	require.Len(content, 2)
+	require.Len(content["pending"][addr], 3)
+	require.Contains(content["pending"][addr], "2")
+	require.Len(content["queued"][addr], 1)
+	require.Contains(content["queued"][addr], "4")
+
+	contentFrom, err := api.ContentFrom(ctx, m.Address)
+	require.NoError(err)
+	require.Len(contentFrom, 2)
+	require.Len(contentFrom["pending"], 3)
+	require.Contains(contentFrom["pending"], "2")
+	require.Len(contentFrom["queued"], 1)
+	require.Contains(contentFrom["queued"], "4")
+
+	status, err := api.Status(ctx)
+	require.NoError(err)
+	require.Len(status, 2)
+	require.Equal(hexutil.Uint(3), status["pending"])
+	require.Equal(hexutil.Uint(1), status["queued"])
 }


### PR DESCRIPTION
Cherry-pick of #23624 to `release/3.6`.

## r3.6-specific adaptations

- `rpc/jsonrpc/txpool_api_test.go`: the new test builds the chain with `blockgen.GenerateChain(...)` instead of `m.GenerateChain(...)`, which does not exist on this branch, and passes the extra `bridgeReader` argument (`nil`) that `NewBaseApi` still takes here.

The code and documentation changes are identical to the ones on `main`.
