### PR TITLE
execution/commitment: use installed reader for branch child counts

### DIFF
--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -297,10 +297,7 @@ type SharedDomains struct {
 	// and DomainDel do not take it — see SwapCommitmentDiffLocked.
 	changesetMu sync.Mutex
 
-	// branchCache is the aggregator-scoped commitment branch cache consulted
-	// after local and parent memory. Its entries are not view-bound, so callers
-	// whose commitment reads can reach it while another transaction updates it
-	// must disable it. It is nil when disabled or unavailable.
+	// branchCache is nil when shared commitment caching is disabled or unavailable.
 	branchCache *commitment.BranchCache
 
 	// collector is the process-level KV-read metrics collector (aggregator

--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -297,7 +297,9 @@ type SharedDomains struct {
 	// and DomainDel do not take it — see SwapCommitmentDiffLocked.
 	changesetMu sync.Mutex
 
-	// branchCache is nil when shared commitment caching is disabled or unavailable.
+	// branchCache is the aggregator-scoped commitment cache consulted after local
+	// and parent memory. It is nil when the shared branch cache is disabled or
+	// unavailable.
 	branchCache *commitment.BranchCache
 
 	// collector is the process-level KV-read metrics collector (aggregator

--- a/execution/commitment/commitmentdb/commitment_context.go
+++ b/execution/commitment/commitmentdb/commitment_context.go
@@ -422,13 +422,12 @@ func (sdc *SharedDomainsCommitmentContext) SetCollapseTracer(tracer commitment.C
 }
 
 // BranchChildCount returns a branch's child count from the post-compute view.
-// It checks domain memory first, then uses computeReader for a branch absent
-// from memory.
-func (sdc *SharedDomainsCommitmentContext) BranchChildCount(computeReader StateReader, nibblePrefix []byte) (int, error) {
-	if computeReader == nil {
-		return 0, errors.New("BranchChildCount requires the compute state reader")
+func (sdc *SharedDomainsCommitmentContext) BranchChildCount(nibblePrefix []byte) (int, error) {
+	stateReader := sdc.stateReader
+	if stateReader == nil {
+		return 0, errors.New("BranchChildCount requires an installed state reader")
 	}
-	if computeReader.WithHistory() {
+	if stateReader.WithHistory() {
 		return 0, errors.New("BranchChildCount requires a reader that permits branch writes")
 	}
 	if sdc.pendingUpdate != nil {
@@ -444,7 +443,7 @@ func (sdc *SharedDomainsCommitmentContext) BranchChildCount(computeReader StateR
 		return 0, fmt.Errorf("BranchChildCount cannot fall through a staged unwind at step %d", maxStep)
 	}
 
-	enc, _, err := computeReader.Read(kv.CommitmentDomain, key, sdc.sharedDomains.StepSize())
+	enc, _, err := stateReader.Read(kv.CommitmentDomain, key, sdc.sharedDomains.StepSize())
 	if err != nil {
 		return 0, err
 	}

--- a/execution/commitment/commitmentdb/commitment_context.go
+++ b/execution/commitment/commitmentdb/commitment_context.go
@@ -202,10 +202,6 @@ func (sdc *SharedDomainsCommitmentContext) SetHistoryStateReader(roTx kv.Tempora
 	sdc.SetStateReader(NewHistoryStateReader(roTx, limitReadAsOfTxNum))
 }
 
-func (sdc *SharedDomainsCommitmentContext) SetCustomHistoryStateReader(stateReader StateReader) {
-	sdc.SetStateReader(stateReader)
-}
-
 func (sdc *SharedDomainsCommitmentContext) SetTraceWriter(w io.Writer) {
 	// Wrap once so the main and per-worker TrieContexts share one mutex-guarded
 	// writer: concurrent workers trace branch reads/writes without racing.

--- a/execution/commitment/commitmentdb/commitment_context.go
+++ b/execution/commitment/commitmentdb/commitment_context.go
@@ -422,6 +422,8 @@ func (sdc *SharedDomainsCommitmentContext) SetCollapseTracer(tracer commitment.C
 }
 
 // BranchChildCount returns a branch's child count from the post-compute view.
+// It reads branches written during computation from domain memory and falls
+// back to the installed state reader for unchanged branches.
 func (sdc *SharedDomainsCommitmentContext) BranchChildCount(nibblePrefix []byte) (int, error) {
 	stateReader := sdc.stateReader
 	if stateReader == nil {

--- a/execution/commitment/commitmentdb/commitment_context_test.go
+++ b/execution/commitment/commitmentdb/commitment_context_test.go
@@ -38,6 +38,7 @@ type testStateReader struct {
 	readDomain   kv.Domain
 	readKey      []byte
 	readStepSize uint64
+	readCalls    int
 	withHistory  bool
 }
 
@@ -48,6 +49,7 @@ func (r *testStateReader) WithHistory() bool { return r.withHistory }
 func (r *testStateReader) CheckDataAvailable(kv.Domain, kv.Step) error { return nil }
 
 func (r *testStateReader) Read(d kv.Domain, key []byte, stepSize uint64) ([]byte, kv.Step, error) {
+	r.readCalls++
 	r.readDomain = d
 	r.readKey = append(r.readKey[:0], key...)
 	r.readStepSize = stepSize
@@ -128,7 +130,7 @@ func TestBranchChildCountReadsPostComputeView(t *testing.T) {
 		require.Equal(t, 3, count)
 		require.Equal(t, 1, domains.calls)
 		require.Equal(t, compactKey, domains.key)
-		require.Zero(t, reader.readStepSize)
+		require.Zero(t, reader.readCalls)
 	})
 
 	t.Run("unchanged branch comes from installed reader", func(t *testing.T) {
@@ -144,6 +146,7 @@ func TestBranchChildCountReadsPostComputeView(t *testing.T) {
 		require.Equal(t, 2, count)
 		require.Equal(t, 1, domains.calls)
 		require.Equal(t, compactKey, domains.key)
+		require.Equal(t, 1, reader.readCalls)
 		require.Equal(t, kv.CommitmentDomain, reader.readDomain)
 		require.Equal(t, compactKey, reader.readKey)
 		require.Equal(t, uint64(1), reader.readStepSize)

--- a/execution/commitment/commitmentdb/commitment_context_test.go
+++ b/execution/commitment/commitmentdb/commitment_context_test.go
@@ -120,9 +120,10 @@ func TestBranchChildCountReadsPostComputeView(t *testing.T) {
 		reader := &testStateReader{branchData: []byte{0, 0, 0, 0b0000_0011}}
 		sdc := &SharedDomainsCommitmentContext{
 			sharedDomains: domains,
+			stateReader:   reader,
 		}
 
-		count, err := sdc.BranchChildCount(reader, prefix)
+		count, err := sdc.BranchChildCount(prefix)
 		require.NoError(t, err)
 		require.Equal(t, 3, count)
 		require.Equal(t, 1, domains.calls)
@@ -130,14 +131,15 @@ func TestBranchChildCountReadsPostComputeView(t *testing.T) {
 		require.Zero(t, reader.readStepSize)
 	})
 
-	t.Run("unchanged branch comes from compute reader", func(t *testing.T) {
+	t.Run("unchanged branch comes from installed reader", func(t *testing.T) {
 		domains := &branchChildCountDomains{}
 		reader := &testStateReader{branchData: []byte{0, 0, 0, 0b0000_0011}}
 		sdc := &SharedDomainsCommitmentContext{
 			sharedDomains: domains,
+			stateReader:   reader,
 		}
 
-		count, err := sdc.BranchChildCount(reader, prefix)
+		count, err := sdc.BranchChildCount(prefix)
 		require.NoError(t, err)
 		require.Equal(t, 2, count)
 		require.Equal(t, 1, domains.calls)
@@ -159,17 +161,18 @@ func TestBranchChildCountRejectsIncompleteComputedView(t *testing.T) {
 			sharedDomains: &branchChildCountDomains{},
 		}
 
-		_, err := sdc.BranchChildCount(nil, prefix)
-		require.ErrorContains(t, err, "compute state reader")
+		_, err := sdc.BranchChildCount(prefix)
+		require.ErrorContains(t, err, "installed state reader")
 	})
 
 	t.Run("history reader suppresses branch writes", func(t *testing.T) {
 		reader := &testStateReader{branchData: branch, withHistory: true}
 		sdc := &SharedDomainsCommitmentContext{
 			sharedDomains: &branchChildCountDomains{},
+			stateReader:   reader,
 		}
 
-		_, err := sdc.BranchChildCount(reader, prefix)
+		_, err := sdc.BranchChildCount(prefix)
 		require.ErrorContains(t, err, "reader that permits branch writes")
 	})
 
@@ -177,10 +180,11 @@ func TestBranchChildCountRejectsIncompleteComputedView(t *testing.T) {
 		reader := &testStateReader{branchData: branch}
 		sdc := &SharedDomainsCommitmentContext{
 			sharedDomains: &branchChildCountDomains{},
+			stateReader:   reader,
 			pendingUpdate: &commitment.PendingCommitmentUpdate{},
 		}
 
-		_, err := sdc.BranchChildCount(reader, prefix)
+		_, err := sdc.BranchChildCount(prefix)
 		require.ErrorContains(t, err, "deferred branch updates are pending")
 	})
 
@@ -188,9 +192,10 @@ func TestBranchChildCountRejectsIncompleteComputedView(t *testing.T) {
 		reader := &testStateReader{branchData: branch}
 		sdc := &SharedDomainsCommitmentContext{
 			sharedDomains: &branchChildCountDomains{bound: true, maxStep: 1},
+			stateReader:   reader,
 		}
 
-		_, err := sdc.BranchChildCount(reader, prefix)
+		_, err := sdc.BranchChildCount(prefix)
 		require.ErrorContains(t, err, "staged unwind")
 	})
 }

--- a/execution/commitment/commitmentdb/reader.go
+++ b/execution/commitment/commitmentdb/reader.go
@@ -252,7 +252,7 @@ func NewCommitmentReplayStateReader(ttx, tx kv.TemporalTx, tsd sd, plainStateAsO
 }
 
 // txLatestReader reads directly from a pinned RO transaction, bypassing
-// SharedDomains memory so commitment reads stay on the parent view.
+// SharedDomains memory so commitment reads remain on the pinned parent view.
 type txLatestReader struct {
 	tx kv.TemporalTx
 }

--- a/execution/commitment/commitmentdb/reader.go
+++ b/execution/commitment/commitmentdb/reader.go
@@ -251,11 +251,8 @@ func NewCommitmentReplayStateReader(ttx, tx kv.TemporalTx, tsd sd, plainStateAsO
 	}
 }
 
-// txLatestReader reads a domain's latest state straight from a pinned RO tx via
-// tx.GetLatest, bypassing any SharedDomains in-memory batch or aggregator-shared
-// branch cache. The head-capture build's own commitment fold mutates that shared
-// cache, so a SharedDomains-backed latest reader would observe post-state branches;
-// reading the pinned snapshot directly keeps the parent(B) commitment plane clean.
+// txLatestReader reads directly from a pinned RO transaction, bypassing
+// SharedDomains memory so commitment reads stay on the parent view.
 type txLatestReader struct {
 	tx kv.TemporalTx
 }

--- a/rpc/jsonrpc/debug_execution_witness.go
+++ b/rpc/jsonrpc/debug_execution_witness.go
@@ -1286,7 +1286,7 @@ func detectCollapseSiblings(
 	siblingPaths = make([][]byte, 0, len(candidates))
 	for _, c := range candidates {
 		if mode == witnessModeCanonical {
-			childCount, err := sdCtx.BranchChildCount(splitStateReader, c.branchPrefix)
+			childCount, err := sdCtx.BranchChildCount(c.branchPrefix)
 			if err != nil {
 				return nil, fmt.Errorf("[debug_executionWitness] read post-state branch for collapse filter: %w", err)
 			}

--- a/rpc/jsonrpc/debug_execution_witness.go
+++ b/rpc/jsonrpc/debug_execution_witness.go
@@ -1239,7 +1239,7 @@ func detectCollapseSiblings(
 	// parent snapshot (head-capture), plain state from block end. withHistory=false
 	// so branch updates are written using PutBranch().
 	splitStateReader := collapseReaderFor(hc, tx, firstTxNumInBlock, endTxNum)
-	sdCtx.SetCustomHistoryStateReader(splitStateReader)
+	sdCtx.SetStateReader(splitStateReader)
 	_, seekBlockNum, err := domains.SeekCommitment(ctx, tx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to re-seek commitment for collapse detection: %w", err)
@@ -1318,7 +1318,7 @@ func buildWitnessTrie(
 ) (encodedNodes []hexutil.Bytes, err error) {
 	encodedNodes = []hexutil.Bytes{}
 
-	sdCtx.SetCustomHistoryStateReader(trieReaderFor(hc, tx, firstTxNumInBlock))
+	sdCtx.SetStateReader(trieReaderFor(hc, tx, firstTxNumInBlock))
 	if _, _, err := domains.SeekCommitment(ctx, tx); err != nil {
 		return nil, fmt.Errorf("failed to reset commitment for regular witness: %w", err)
 	}


### PR DESCRIPTION
Follow-up to #22198.

## Summary

- remove the redundant state-reader argument from `BranchChildCount`
- use the reader installed on the commitment context for fallback branch reads
- replace the misleading witness-specific reader setter with `SetStateReader`
- assert the memory-first path with a direct fallback-reader call count
- update the head-capture reader comment to match request-scoped cache isolation
- keep the shared-cache safety requirement on the exported option instead of repeating it on a private field

## Rationale

The reader used for branch fallback is part of `SharedDomainsCommitmentContext`'s computed view. Accepting a second caller-supplied reader made it possible to validate and read a different view. Deriving the reader from the context keeps the guards and fallback read tied to the configured view. The witness paths use the general setter because history behavior is a property of each reader, not of the setter.

This is a behavior-preserving refactor, so TDD was not used. The existing `BranchChildCount` tests were updated to exercise the installed-reader path.
