### PR TITLE
execution/stagedsync: drop a step checkpoint's dirty keys once it has folded

### DIFF
--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -875,6 +875,11 @@ func targetOf(br *blockResult) commitTarget {
 	return commitTarget{blockNum: br.Block.NumberU64(), blockHash: br.Block.Hash(), lastTxNum: br.lastTxNum, stateRoot: br.Block.Root()}
 }
 
+// incrementalStepCheckpoints drops a mid-block step checkpoint's dirty flags
+// once it has folded. Off restores the previous behaviour, where every
+// checkpoint re-folds the block from its first tx.
+var incrementalStepCheckpoints = dbg.EnvBool("INCREMENTAL_STEP_CKPT", true)
+
 // computeMode selects compute's per-call behaviour; isolation is otherwise
 // decided by ownsChangeset.
 type computeMode struct {
@@ -928,6 +933,14 @@ func (cc *commitmentCalculator) compute(ctx context.Context, t commitTarget, m c
 	if !m.midBlock {
 		cc.lastComputedBlock = t.blockNum
 		cc.hasComputed = true
+	}
+
+	// A midBlock checkpoint has already folded these keys into the trie at the
+	// edge, so leaving them dirty makes every later checkpoint and the block-end
+	// fold re-emit the whole block prefix — quadratic in the number of step edges
+	// a block spans, and the reason a smaller step size costs disproportionately.
+	if m.midBlock && incrementalStepCheckpoints {
+		cc.state.ResetBlockFlags()
 	}
 
 	if !m.checkRoot {

--- a/execution/stagedsync/committer_step_boundary_test.go
+++ b/execution/stagedsync/committer_step_boundary_test.go
@@ -1035,3 +1035,65 @@ func TestShadowCrossCheck_Mismatch(t *testing.T) {
 	require.Error(t, res.err, "a divergent computed-ahead root must fail the block")
 	require.ErrorIs(t, res.err, ErrWrongTrieRoot, "shadow mismatch must surface as ErrWrongTrieRoot")
 }
+
+// A block spanning several step edges. Each checkpoint drops the dirty keys it
+// folded, so the later checkpoints see only what changed since the previous edge
+// and must still leave every branch consistent with the accounts written through
+// the last edge.
+func TestHandleMessage_StepBoundaryCheckpointsAcrossManyEdges(t *testing.T) {
+	ctx := context.Background()
+	const block1End = uint64(10)
+	const block2End = uint64(60) // interior step edges at 15, 31 and 47
+	const lastEdge = uint64(47)
+
+	db, tx, doms := setupStepTest(t)
+
+	in := make(chan applyResult, 128)
+	out := make(chan commitmentResult, 128)
+	cc, err := newCommitmentCalculator(ctx, ctx, doms, db, &chain.Config{}, "test", log.New(), false, 1<<62, in, nil, out)
+	require.NoError(t, err)
+
+	rnd := rand.New(rand.NewSource(42))
+	accountValues := make(map[string][]byte)
+	writeAccount := func(txNum uint64) {
+		addrBytes := make([]byte, length.Addr)
+		rnd.Read(addrBytes)
+		addr := accounts.InternAddress([20]byte(addrBytes))
+		bal := *uint256.NewInt(txNum * 1000)
+		acc := accounts.Account{Nonce: txNum, Balance: bal, CodeHash: accounts.EmptyCodeHash}
+		buf := accounts.SerialiseV3(&acc)
+		require.NoError(t, doms.DomainPut(kv.AccountsDomain, tx, addrBytes, buf, txNum, nil))
+		if txNum <= lastEdge {
+			accountValues[string(addrBytes)] = buf
+		}
+		blockNum := uint64(1)
+		if txNum > block1End {
+			blockNum = 2
+		}
+		cc.handleMessage(ctx, &txResult{
+			blockNum: blockNum,
+			txNum:    txNum,
+			rules:    &chain.Rules{},
+			writes:   nonceBalanceWrites(addr, txNum, bal),
+		})
+	}
+
+	for txNum := uint64(1); txNum <= block1End; txNum++ {
+		writeAccount(txNum)
+	}
+	cc.handleMessage(ctx, newTestBlockResult(1, common.Hash{0x01}, block1End, false))
+	for txNum := block1End + 1; txNum <= block2End; txNum++ {
+		writeAccount(txNum)
+	}
+	cc.handleMessage(ctx, newTestBlockResult(2, common.Hash{0x02}, block2End, false))
+	cc.Stop()
+
+	stateBlob, _, err := doms.GetLatest(kv.CommitmentDomain, tx, commitmentdb.KeyCommitmentState)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(stateBlob), 16)
+	gotTxNum, gotBlockNum := commitmentdb.DecodeTxBlockNums(stateBlob)
+	require.Equal(t, lastEdge, gotTxNum, "the latest checkpoint must be the last interior step edge")
+	require.Equal(t, uint64(2), gotBlockNum)
+
+	requireBranchesConsistentWithAccounts(t, doms, tx, accountValues)
+}


### PR DESCRIPTION
A block straddling step edges gets a commitment checkpoint per edge. Each one left its keys dirty in `cc.state`, so the next checkpoint — and the block-end fold — re-emitted the whole block prefix. Cost is quadratic in the edges a block spans: a block crossing K edges does ~K²/2 segment folds instead of K.

Measured on jochemnet (`_newPayload`, 11 fixtures, identical gas 2,199,876,000 in every arm, no root mismatches):

| step size | before | after |
|---|---|---|
| 3125 (current) | 162.98 MGas/s | **206.06** (+26%) |
| 625 | 88.42 MGas/s | **225.66** (+155%) |

Commitment work in a block's last round, step 3125: 1.15M → 183k address keys.

The old comment said the block-end fold still needed the pre-edge dirty keys. It does not: the trie is persistent, the checkpoint already folded those keys at the edge, and anything changed after the edge is dirty again. This is the same reason commitment is incremental between blocks.

Behind `INCREMENTAL_STEP_CKPT` (default on) so it can be turned off in place.

The second row is why this matters beyond the percentage: a smaller step size was ~45% slower before, and is now the faster configuration.