### PR TITLE
rpc/rpchelper, engineapitester: unblock receipts reconnect, check hash before receipt

### DIFF
--- a/execution/engineapi/engineapitester/txn_inclusion_verifier.go
+++ b/execution/engineapi/engineapitester/txn_inclusion_verifier.go
@@ -111,6 +111,11 @@ func (v TxnInclusionVerifier) VerifyTxnsOrderedInclusion(
 			return err
 		}
 
+		if txn.Hash() != inclusion.TxnHash {
+			markMissing(inclusion)
+			continue
+		}
+
 		// fcu persistance is now asynchronous so this can get called
 		// in the test loop before the tx data is coommited in which
 		// case it will fail and needs to retry
@@ -126,10 +131,6 @@ func (v TxnInclusionVerifier) VerifyTxnsOrderedInclusion(
 
 		if r.Status != types.ReceiptStatusSuccessful {
 			return fmt.Errorf("txn %d in block %d not successful", inclusion.TxnIndex, r.BlockNumber)
-		}
-
-		if txn.Hash() != inclusion.TxnHash {
-			markMissing(inclusion)
 		}
 	}
 

--- a/execution/engineapi/engineapitester/txn_inclusion_verifier_test.go
+++ b/execution/engineapi/engineapitester/txn_inclusion_verifier_test.go
@@ -17,12 +17,16 @@
 package engineapitester
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/hexutil"
 	enginetypes "github.com/erigontech/erigon/execution/engineapi/engine_types"
+	"github.com/erigontech/erigon/execution/types"
 )
 
 // An expected inclusion at an index beyond the payload's txn list must be reported
@@ -30,6 +34,22 @@ import (
 func TestVerifyTxnsOrderedInclusionReportsMissingTxnIndexes(t *testing.T) {
 	verifier := NewTxnInclusionVerifier(nil)
 	payload := &enginetypes.ExecutionPayload{}
+	err := verifier.VerifyTxnsOrderedInclusion(t.Context(), payload, OrderedInclusion{
+		TxnIndex: 0,
+		TxnHash:  common.HexToHash("0x01"),
+	})
+	require.ErrorContains(t, err, "txns missing")
+}
+
+// A hash mismatch at an expected index is a missing inclusion, so the receipt of the
+// unrelated txn occupying that index must not be fetched.
+func TestVerifyTxnsOrderedInclusionDoesNotFetchReceiptOnHashMismatch(t *testing.T) {
+	txn := types.NewTransaction(0, common.HexToAddress("0x02"), uint256.NewInt(1), 21_000, uint256.NewInt(1), nil)
+	var buf bytes.Buffer
+	require.NoError(t, txn.MarshalBinary(&buf))
+
+	verifier := NewTxnInclusionVerifier(nil) // a receipt lookup would panic on the nil client
+	payload := &enginetypes.ExecutionPayload{Transactions: []hexutil.Bytes{buf.Bytes()}}
 	err := verifier.VerifyTxnsOrderedInclusion(t.Context(), payload, OrderedInclusion{
 		TxnIndex: 0,
 		TxnHash:  common.HexToHash("0x01"),

--- a/rpc/rpchelper/filters.go
+++ b/rpc/rpchelper/filters.go
@@ -221,16 +221,7 @@ func New(ctx context.Context, config FiltersConfig, ethBackend ApiBackend, txPoo
 				return
 			default:
 			}
-			if err := ethBackend.SubscribeReceipts(ctx, ff.OnReceipts, func(send func(*remoteproto.ReceiptsFilterRequest) error) {
-				ff.mu.Lock()
-				ff.receiptsRequestor.Store(send)
-				ff.mu.Unlock()
-				if ff.pendingReceiptsUpdate.CompareAndSwap(true, false) {
-					if err := ff.sendReceiptsFilterUpdate(); err != nil {
-						logger.Warn("rpc filters: error sending pending receipts filter update", "err", err)
-					}
-				}
-			}); err != nil {
+			if err := ethBackend.SubscribeReceipts(ctx, ff.OnReceipts, ff.onReceiptsRequestorReady); err != nil {
 				select {
 				case <-ctx.Done():
 					activeSubscriptionsLogsClientGauge.With(prometheus.Labels{clientLabelName: "ethBackend_Receipts"}).Dec()
@@ -738,6 +729,24 @@ func (ff *Filters) UnsubscribeReceipts(id ReceiptsSubID) bool {
 		ff.logger.Warn("Could not update remote receipts filter after unsubscribe", "err", err)
 	}
 	return true
+}
+
+// onReceiptsRequestorReady installs the requestor of a freshly connected receipts
+// stream and flushes an update that was deferred while no requestor existed.
+func (ff *Filters) onReceiptsRequestorReady(send func(*remoteproto.ReceiptsFilterRequest) error) {
+	ff.mu.Lock()
+	ff.receiptsRequestor.Store(send)
+	ff.mu.Unlock()
+	if !ff.pendingReceiptsUpdate.CompareAndSwap(true, false) {
+		return
+	}
+	// off the stream goroutine: sendReceiptsFilterUpdate waits on receiptsRequestMu,
+	// which a stalled send can hold, and the caller must reach its Recv loop.
+	go func() {
+		if err := ff.sendReceiptsFilterUpdate(); err != nil {
+			ff.logger.Warn("rpc filters: error sending pending receipts filter update", "err", err)
+		}
+	}()
 }
 
 // sendReceiptsFilterUpdate sends the current receipts filter state to the server.

--- a/rpc/rpchelper/filters_subscribe_test.go
+++ b/rpc/rpchelper/filters_subscribe_test.go
@@ -199,3 +199,27 @@ func TestSubscribeReceiptsConcurrentSubscribersDoNotSendStaleRequest(t *testing.
 	require.True(t, finalHashes[hash1], "last delivered request lost hash1: %v", finalHashes)
 	require.True(t, finalHashes[hash2], "last delivered request lost hash2: %v", finalHashes)
 }
+
+// A reconnecting receipts stream must be able to start receiving even while another
+// subscriber is stuck in an upstream send: the requestor is installed and the deferred
+// update is flushed without blocking the stream's Recv loop.
+func TestOnReceiptsRequestorReadyDoesNotBlockOnAStalledSend(t *testing.T) {
+	f := newTestFilters(t)
+	f.pendingReceiptsUpdate.Store(true)
+
+	// stand in for a subscriber blocked inside a send on the previous stream
+	f.receiptsRequestMu.Lock()
+	defer f.receiptsRequestMu.Unlock()
+
+	returned := make(chan struct{})
+	go func() {
+		defer close(returned)
+		f.onReceiptsRequestorReady(func(*remoteproto.ReceiptsFilterRequest) error { return nil })
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("onReceiptsRequestorReady blocked behind the stalled send")
+	}
+}


### PR DESCRIPTION
- receipts `onReady` runs before the stream's `Recv` loop, so flush the deferred filter update off that goroutine
- check the txn hash before fetching its receipt, so a mismatch reports "txns missing"
