### PR TITLE
cache: don't copy when moving values from `kv.TemporalMemBatch` to `lru`

### DIFF
--- a/db/kv/kv_interface.go
+++ b/db/kv/kv_interface.go
@@ -611,9 +611,10 @@ type FlushConfig struct {
 	// tuple during Flush so a downstream cache (e.g. the BranchCache) can stay in
 	// sync. txNum is the value's write txNum, for tx-precise unwind invalidation.
 	//
-	// k and v are the batch's own storage, not scratch: they stay valid and
-	// unchanged until the batch is closed, so a callback may hold them for the
-	// rest of the flushing call. Anything that outlives the batch copies.
+	// v is the batch's own storage, not scratch: it stays valid and unchanged
+	// until the batch is closed. k is freshly allocated per call and belongs to
+	// the callback. Either may be held for the rest of the flushing call;
+	// anything that outlives the batch copies v.
 	DomainCallbacks map[Domain]func(k []byte, v []byte, step Step, txNum uint64)
 }
 

--- a/db/kv/kv_interface.go
+++ b/db/kv/kv_interface.go
@@ -611,10 +611,9 @@ type FlushConfig struct {
 	// tuple during Flush so a downstream cache (e.g. the BranchCache) can stay in
 	// sync. txNum is the value's write txNum, for tx-precise unwind invalidation.
 	//
-	// v is the batch's own storage, not scratch: it stays valid and unchanged
-	// until the batch is closed. k is freshly allocated per call and belongs to
-	// the callback. Either may be held for the rest of the flushing call;
-	// anything that outlives the batch copies v.
+	// k is freshly allocated per call and belongs to the callback. v is the
+	// batch's own storage and stays valid until the batch is closed; anything
+	// outliving the batch copies it.
 	DomainCallbacks map[Domain]func(k []byte, v []byte, step Step, txNum uint64)
 }
 

--- a/db/kv/kv_interface.go
+++ b/db/kv/kv_interface.go
@@ -610,6 +610,10 @@ type FlushConfig struct {
 	// DomainCallbacks, if set for a domain, is invoked per (key,value,step,txNum)
 	// tuple during Flush so a downstream cache (e.g. the BranchCache) can stay in
 	// sync. txNum is the value's write txNum, for tx-precise unwind invalidation.
+	//
+	// k and v are the batch's own storage, not scratch: they stay valid and
+	// unchanged until the batch is closed, so a callback may hold them for the
+	// rest of the flushing call. Anything that outlives the batch copies.
 	DomainCallbacks map[Domain]func(k []byte, v []byte, step Step, txNum uint64)
 }
 

--- a/db/kv/kv_interface.go
+++ b/db/kv/kv_interface.go
@@ -611,9 +611,8 @@ type FlushConfig struct {
 	// tuple during Flush so a downstream cache (e.g. the BranchCache) can stay in
 	// sync. txNum is the value's write txNum, for tx-precise unwind invalidation.
 	//
-	// k is freshly allocated per call and belongs to the callback. v is the
-	// batch's own storage and stays valid until the batch is closed; anything
-	// outliving the batch copies it.
+	// k belongs to the callback; v is the batch's own storage and stays valid
+	// until the batch is closed. Anything outliving the batch copies it.
 	DomainCallbacks map[Domain]func(k []byte, v []byte, step Step, txNum uint64)
 }
 

--- a/db/kv/kv_interface.go
+++ b/db/kv/kv_interface.go
@@ -611,8 +611,8 @@ type FlushConfig struct {
 	// tuple during Flush so a downstream cache (e.g. the BranchCache) can stay in
 	// sync. txNum is the value's write txNum, for tx-precise unwind invalidation.
 	//
-	// k belongs to the callback; v is the batch's own storage and stays valid
-	// until the batch is closed. Anything outliving the batch copies it.
+	// k belongs to the callback; v is the batch's own storage, which is never
+	// rewritten in place, so a consumer may retain it.
 	DomainCallbacks map[Domain]func(k []byte, v []byte, step Step, txNum uint64)
 }
 

--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -1252,13 +1252,12 @@ func (sd *SharedDomains) Commit(ctx context.Context, tx kv.RwTx, validate ...fun
 	var codeStoreWrites [][2][]byte
 	if sd.stateCache != nil || sd.codeStore != nil {
 		opts = append(opts, kv.WithFlushCallback(kv.CodeDomain, func(k []byte, v []byte, step kv.Step, txNum uint64) {
-			// Both consumers get the same hash; hashing a block's worth of code
-			// twice is the one duplicate they cannot avoid on their own.
+			// Only the code store needs a hash here, where every domain lock is
+			// held, and it needs one as its key. The cache reuses it when it is
+			// already in hand and otherwise hashes after the commit, off the lock.
 			var codeHash []byte
-			if len(v) > 0 {
+			if sd.codeStore != nil && len(v) > 0 {
 				codeHash = crypto.Keccak256(v)
-			}
-			if sd.codeStore != nil && codeHash != nil {
 				codeStoreWrites = append(codeStoreWrites, [2][]byte{codeHash, v})
 			}
 			if sd.stateCache != nil {

--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -1211,14 +1211,20 @@ func (sd *SharedDomains) Commit(ctx context.Context, tx kv.RwTx, validate ...fun
 	// Stash every cache-bound domain tuple during the flush and publish it only
 	// after the commit succeeds. If the commit fails, the stash is discarded, so
 	// the cache never advances ahead of durable MDBX state.
+	//
+	// The stash borrows the mem batch's buffers rather than copying them: it is
+	// consumed before Commit returns, well inside their lifetime, and each
+	// consumer copies whatever it retains. Copying here instead would hold a
+	// second image of the whole flush — hundreds of MB for a block that deploys
+	// contracts in bulk.
 	var pendingBranches []branchCacheUpdate
 	var pendingState []cache.StateUpdate
 	stash := func(domain kv.Domain) kv.FlushOption {
 		return kv.WithFlushCallback(domain, func(k []byte, v []byte, step kv.Step, txNum uint64) {
 			if domain == kv.CommitmentDomain {
 				pendingBranches = append(pendingBranches, branchCacheUpdate{
-					key:  append([]byte(nil), k...),
-					val:  append([]byte(nil), v...),
+					key:  k,
+					val:  v,
 					step: step,
 					txN:  txNum,
 				})
@@ -1226,8 +1232,8 @@ func (sd *SharedDomains) Commit(ctx context.Context, tx kv.RwTx, validate ...fun
 			}
 			pendingState = append(pendingState, cache.StateUpdate{
 				Domain: domain,
-				Key:    append([]byte(nil), k...),
-				Value:  append([]byte(nil), v...),
+				Key:    k,
+				Value:  v,
 				TxNum:  txNum,
 			})
 		})
@@ -1246,15 +1252,22 @@ func (sd *SharedDomains) Commit(ctx context.Context, tx kv.RwTx, validate ...fun
 	var codeStoreWrites [][2][]byte
 	if sd.stateCache != nil || sd.codeStore != nil {
 		opts = append(opts, kv.WithFlushCallback(kv.CodeDomain, func(k []byte, v []byte, step kv.Step, txNum uint64) {
-			if sd.codeStore != nil && len(v) > 0 {
-				codeStoreWrites = append(codeStoreWrites, [2][]byte{crypto.Keccak256(v), append([]byte(nil), v...)})
+			// Both consumers get the same hash; hashing a block's worth of code
+			// twice is the one duplicate they cannot avoid on their own.
+			var codeHash []byte
+			if len(v) > 0 {
+				codeHash = crypto.Keccak256(v)
+			}
+			if sd.codeStore != nil && codeHash != nil {
+				codeStoreWrites = append(codeStoreWrites, [2][]byte{codeHash, v})
 			}
 			if sd.stateCache != nil {
 				pendingState = append(pendingState, cache.StateUpdate{
-					Domain: kv.CodeDomain,
-					Key:    append([]byte(nil), k...),
-					Value:  append([]byte(nil), v...),
-					TxNum:  txNum,
+					Domain:   kv.CodeDomain,
+					Key:      k,
+					Value:    v,
+					CodeHash: codeHash,
+					TxNum:    txNum,
 				})
 			}
 		}))

--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -1212,11 +1212,9 @@ func (sd *SharedDomains) Commit(ctx context.Context, tx kv.RwTx, validate ...fun
 	// after the commit succeeds. If the commit fails, the stash is discarded, so
 	// the cache never advances ahead of durable MDBX state.
 	//
-	// The stash borrows the mem batch's buffers rather than copying them: it is
-	// consumed before Commit returns, well inside their lifetime, and each
-	// consumer copies whatever it retains. Copying here instead would hold a
-	// second image of the whole flush — hundreds of MB for a block that deploys
-	// contracts in bulk.
+	// The stash borrows the batch's buffers: it is consumed before Commit
+	// returns and each consumer copies what it retains, so copying here would
+	// hold a second image of the whole flush.
 	var pendingBranches []branchCacheUpdate
 	var pendingState []cache.StateUpdate
 	stash := func(domain kv.Domain) kv.FlushOption {
@@ -1252,9 +1250,8 @@ func (sd *SharedDomains) Commit(ctx context.Context, tx kv.RwTx, validate ...fun
 	var codeStoreWrites [][2][]byte
 	if sd.stateCache != nil || sd.codeStore != nil {
 		opts = append(opts, kv.WithFlushCallback(kv.CodeDomain, func(k []byte, v []byte, step kv.Step, txNum uint64) {
-			// Only the code store needs a hash here, where every domain lock is
-			// held, and it needs one as its key. The cache reuses it when it is
-			// already in hand and otherwise hashes after the commit, off the lock.
+			// Only the code store needs the hash under the domain locks, as its
+			// key; the cache reuses it if present and otherwise hashes off-lock.
 			var codeHash []byte
 			if sd.codeStore != nil && len(v) > 0 {
 				codeHash = crypto.Keccak256(v)

--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -1211,10 +1211,8 @@ func (sd *SharedDomains) Commit(ctx context.Context, tx kv.RwTx, validate ...fun
 	// Stash every cache-bound domain tuple during the flush and publish it only
 	// after the commit succeeds. If the commit fails, the stash is discarded, so
 	// the cache never advances ahead of durable MDBX state.
-	//
-	// The stash borrows the batch's buffers: it is consumed before Commit
-	// returns and each consumer copies what it retains, so copying here would
-	// hold a second image of the whole flush.
+	// It borrows the batch's buffers rather than holding a second image of the
+	// whole flush; see FlushConfig.DomainCallbacks.
 	var pendingBranches []branchCacheUpdate
 	var pendingState []cache.StateUpdate
 	stash := func(domain kv.Domain) kv.FlushOption {
@@ -1250,8 +1248,6 @@ func (sd *SharedDomains) Commit(ctx context.Context, tx kv.RwTx, validate ...fun
 	var codeStoreWrites [][2][]byte
 	if sd.stateCache != nil || sd.codeStore != nil {
 		opts = append(opts, kv.WithFlushCallback(kv.CodeDomain, func(k []byte, v []byte, step kv.Step, txNum uint64) {
-			// Only the code store needs the hash under the domain locks, as its
-			// key; the cache reuses it if present and otherwise hashes off-lock.
 			var codeHash []byte
 			if sd.codeStore != nil && len(v) > 0 {
 				codeHash = crypto.Keccak256(v)

--- a/db/state/temporal_mem_batch.go
+++ b/db/state/temporal_mem_batch.go
@@ -814,6 +814,11 @@ func (sd *TemporalMemBatch) flushLocked(ctx context.Context, tx kv.RwTx) error {
 // tuple after the MDBX write succeeds, so a downstream cache can never be left
 // ahead of MDBX. Runs under all domain locks so the callback's snapshot matches
 // flush-time state.
+//
+// The values handed to a callback are the batch's own buffers, owned since
+// putLatest cloned them and never rewritten in place — a later write to the same
+// key appends or replaces the entry rather than editing its bytes. Flush does not
+// drop them either, so they stay valid until the batch is closed.
 func (sd *TemporalMemBatch) Flush(ctx context.Context, tx kv.RwTx, opts ...kv.FlushOption) error {
 	sd.lockAllDomains()
 	defer sd.unlockAllDomains()

--- a/db/state/temporal_mem_batch.go
+++ b/db/state/temporal_mem_batch.go
@@ -814,11 +814,6 @@ func (sd *TemporalMemBatch) flushLocked(ctx context.Context, tx kv.RwTx) error {
 // tuple after the MDBX write succeeds, so a downstream cache can never be left
 // ahead of MDBX. Runs under all domain locks so the callback's snapshot matches
 // flush-time state.
-//
-// The values handed to a callback are the batch's own buffers, owned since
-// putLatest cloned them and never rewritten in place — a later write to the same
-// key appends or replaces the entry rather than editing its bytes. Flush does not
-// drop them either, so they stay valid until the batch is closed.
 func (sd *TemporalMemBatch) Flush(ctx context.Context, tx kv.RwTx, opts ...kv.FlushOption) error {
 	sd.lockAllDomains()
 	defer sd.unlockAllDomains()

--- a/db/state/temporal_mem_batch_test.go
+++ b/db/state/temporal_mem_batch_test.go
@@ -103,3 +103,37 @@ func TestTemporalMemBatchConcurrentDomainAccess(t *testing.T) {
 		}
 	}
 }
+
+// Flush hands its callbacks the batch's own value buffers, and SharedDomains.Commit
+// borrows them for the whole commit rather than copying. That is only sound while a
+// later write to the same key leaves the earlier bytes alone: an in-place rewrite
+// would corrupt the caches holding them, with nothing else to catch it.
+func TestPutLatest_NeverRewritesValuesInPlace(t *testing.T) {
+	t.Parallel()
+
+	sd := &TemporalMemBatch{
+		stepSize:          16,
+		storage:           btree2.NewMap[string, []dataWithTxNum](128),
+		metrics:           &kvmetrics.DomainMetrics{Domains: map[kv.Domain]*kvmetrics.DomainIOMetrics{}},
+		inMemHistoryReads: true,
+	}
+	for d := range sd.domains {
+		sd.domains[d] = map[string][]dataWithTxNum{}
+	}
+
+	for _, domain := range []kv.Domain{kv.AccountsDomain, kv.StorageDomain, kv.CodeDomain} {
+		key := "k-" + domain.String()
+		sd.putLatest(domain, key, []byte("first"), 1)
+		borrowed, _, ok := sd.GetLatest(domain, []byte(key))
+		require.True(t, ok)
+		require.Equal(t, []byte("first"), borrowed)
+
+		// Same txNum (replaces the entry), a later one (appends), and a longer
+		// value than the first — every shape a rewrite could take.
+		sd.putLatest(domain, key, []byte("second"), 1)
+		sd.putLatest(domain, key, []byte("third-and-longer"), 2)
+
+		require.Equal(t, []byte("first"), borrowed,
+			"%s: a borrowed value must survive later writes to its key", domain)
+	}
+}

--- a/db/state/temporal_mem_batch_test.go
+++ b/db/state/temporal_mem_batch_test.go
@@ -109,29 +109,48 @@ func TestTemporalMemBatchConcurrentDomainAccess(t *testing.T) {
 func TestPutLatest_NeverRewritesValuesInPlace(t *testing.T) {
 	t.Parallel()
 
-	sd := &TemporalMemBatch{
-		stepSize:          16,
-		storage:           btree2.NewMap[string, []dataWithTxNum](128),
-		metrics:           &kvmetrics.DomainMetrics{Domains: map[kv.Domain]*kvmetrics.DomainIOMetrics{}},
-		inMemHistoryReads: true,
-	}
-	for d := range sd.domains {
-		sd.domains[d] = map[string][]dataWithTxNum{}
-	}
+	// inMemHistoryReads picks which arm a later txNum takes: append, or overwrite
+	// the slot in place. Both must leave the earlier bytes alone.
+	for _, inMemHistoryReads := range []bool{true, false} {
+		t.Run(fmt.Sprintf("inMemHistoryReads=%v", inMemHistoryReads), func(t *testing.T) {
+			t.Parallel()
 
-	for _, domain := range []kv.Domain{kv.AccountsDomain, kv.StorageDomain, kv.CodeDomain} {
-		key := "k-" + domain.String()
-		sd.putLatest(domain, key, []byte("first"), 1)
-		borrowed, _, ok := sd.GetLatest(domain, []byte(key))
-		require.True(t, ok)
-		require.Equal(t, []byte("first"), borrowed)
+			sd := &TemporalMemBatch{
+				stepSize:          16,
+				storage:           btree2.NewMap[string, []dataWithTxNum](128),
+				metrics:           &kvmetrics.DomainMetrics{Domains: map[kv.Domain]*kvmetrics.DomainIOMetrics{}},
+				inMemHistoryReads: inMemHistoryReads,
+			}
+			for d := range sd.domains {
+				sd.domains[d] = map[string][]dataWithTxNum{}
+			}
 
-		// Same txNum (replaces the entry), a later one (appends), and a longer
-		// value than the first — every shape a rewrite could take.
-		sd.putLatest(domain, key, []byte("second"), 1)
-		sd.putLatest(domain, key, []byte("third-and-longer"), 2)
+			// Each case is the FIRST write after the borrow, so the slot still holds
+			// the borrowed buffer when the arm runs. A shorter value fits that buffer,
+			// which is what an arm recycling it would overwrite.
+			for _, next := range []struct {
+				name  string
+				val   string
+				txNum uint64
+			}{
+				{"same txNum", "second", 1},
+				{"later txNum", "third", 2},
+				{"later txNum, longer value", "third-and-longer-than-the-first-value", 2},
+			} {
+				for _, domain := range []kv.Domain{kv.AccountsDomain, kv.StorageDomain, kv.CodeDomain} {
+					key := "k-" + domain.String() + "-" + next.name
+					first := []byte("first-and-long-enough-to-be-reused")
+					sd.putLatest(domain, key, first, 1)
+					borrowed, _, ok := sd.GetLatest(domain, []byte(key))
+					require.True(t, ok)
+					require.Equal(t, first, borrowed)
 
-		require.Equal(t, []byte("first"), borrowed,
-			"%s: a borrowed value must survive later writes to its key", domain)
+					sd.putLatest(domain, key, []byte(next.val), next.txNum)
+
+					require.Equal(t, first, borrowed,
+						"%s/%s: a borrowed value must survive a later write to its key", domain, next.name)
+				}
+			}
+		})
 	}
 }

--- a/db/state/temporal_mem_batch_test.go
+++ b/db/state/temporal_mem_batch_test.go
@@ -104,10 +104,8 @@ func TestTemporalMemBatchConcurrentDomainAccess(t *testing.T) {
 	}
 }
 
-// Flush hands its callbacks the batch's own value buffers, and SharedDomains.Commit
-// borrows them for the whole commit rather than copying. That is only sound while a
-// later write to the same key leaves the earlier bytes alone: an in-place rewrite
-// would corrupt the caches holding them, with nothing else to catch it.
+// Commit borrows the batch's value buffers instead of copying, which is only
+// sound while a later write to the same key leaves the earlier bytes alone.
 func TestPutLatest_NeverRewritesValuesInPlace(t *testing.T) {
 	t.Parallel()
 

--- a/db/state/temporal_mem_batch_test.go
+++ b/db/state/temporal_mem_batch_test.go
@@ -135,7 +135,6 @@ func TestPutLatest_NeverRewritesValuesInPlace(t *testing.T) {
 			}{
 				{"same txNum", "second", 1},
 				{"later txNum", "third", 2},
-				{"later txNum, longer value", "third-and-longer-than-the-first-value", 2},
 			} {
 				for _, domain := range []kv.Domain{kv.AccountsDomain, kv.StorageDomain, kv.CodeDomain} {
 					key := "k-" + domain.String() + "-" + next.name

--- a/execution/cache/cache_test.go
+++ b/execution/cache/cache_test.go
@@ -1613,9 +1613,8 @@ func TestPublishUsesProducerCodeHash(t *testing.T) {
 	require.Equal(t, code, got)
 }
 
-// A malformed producer hash must be replaced, not used: hash32 would zero-pad it
-// into the content-addressed key, and an all-zero stamp also blanks the guard
-// that rejects a 64-bit maphash collision serving another contract's code.
+// A malformed producer hash must be re-derived, not used: it would be zero-padded
+// into the content-addressed key and would blank the collision guard.
 func TestPublishDerivesMalformedCodeHash(t *testing.T) {
 	t.Parallel()
 

--- a/execution/cache/cache_test.go
+++ b/execution/cache/cache_test.go
@@ -1580,3 +1580,39 @@ func TestApplyOnlyCacheReportsFillsDisabled(t *testing.T) {
 	t.Cleanup(c2.Close)
 	require.True(t, c2.FillsEnabled())
 }
+
+// TestPublishUsesProducerCodeHash pins that a CodeDomain update carrying a
+// CodeHash is filed under that hash rather than one the cache derives itself,
+// which is what spares it re-hashing a block's worth of code. A sentinel hash
+// makes the difference visible: re-deriving would file the entry elsewhere.
+func TestPublishUsesProducerCodeHash(t *testing.T) {
+	t.Parallel()
+
+	c := closeOnCleanup(t, NewDefaultStateCache())
+	c.Applier().Initialize(1)
+
+	addr := makeAddr(7)
+	code := bytes.Repeat([]byte{0xab}, 96)
+	var sentinel [32]byte
+	sentinel[0] = 0xc0
+	sentinel[31] = 0xde
+
+	c.Applier().Publish(1, 2, []StateUpdate{{
+		Domain:   kv.CodeDomain,
+		Key:      addr,
+		Value:    code,
+		CodeHash: sentinel[:],
+		TxNum:    20,
+	}})
+
+	got, ok := c.View(nil).GetCodeByHash(sentinel[:])
+	require.True(t, ok, "the producer's codeHash must be the one the entry is filed under")
+	require.Equal(t, code, got)
+
+	_, ok = c.View(nil).GetCodeByHash(crypto.Keccak256(code))
+	require.False(t, ok, "the cache must not re-derive a hash of its own")
+
+	got, ok = c.View(nil).Get(kv.CodeDomain, addr)
+	require.True(t, ok)
+	require.Equal(t, code, got)
+}

--- a/execution/cache/cache_test.go
+++ b/execution/cache/cache_test.go
@@ -1581,10 +1581,6 @@ func TestApplyOnlyCacheReportsFillsDisabled(t *testing.T) {
 	require.True(t, c2.FillsEnabled())
 }
 
-// TestPublishUsesProducerCodeHash pins that a CodeDomain update carrying a
-// CodeHash is filed under that hash rather than one the cache derives itself,
-// which is what spares it re-hashing a block's worth of code. A sentinel hash
-// makes the difference visible: re-deriving would file the entry elsewhere.
 func TestPublishUsesProducerCodeHash(t *testing.T) {
 	t.Parallel()
 

--- a/execution/cache/cache_test.go
+++ b/execution/cache/cache_test.go
@@ -1612,3 +1612,32 @@ func TestPublishUsesProducerCodeHash(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, code, got)
 }
+
+// A malformed producer hash must be replaced, not used: hash32 would zero-pad it
+// into the content-addressed key, and an all-zero stamp also blanks the guard
+// that rejects a 64-bit maphash collision serving another contract's code.
+func TestPublishDerivesMalformedCodeHash(t *testing.T) {
+	t.Parallel()
+
+	c := closeOnCleanup(t, NewDefaultStateCache())
+	c.Applier().Initialize(1)
+
+	addr := makeAddr(9)
+	code := bytes.Repeat([]byte{0xcd}, 64)
+	short := []byte{0x01, 0x02, 0x03}
+
+	c.Applier().Publish(1, 2, []StateUpdate{{
+		Domain:   kv.CodeDomain,
+		Key:      addr,
+		Value:    code,
+		CodeHash: short,
+		TxNum:    20,
+	}})
+
+	got, ok := c.View(nil).GetCodeByHash(crypto.Keccak256(code))
+	require.True(t, ok, "a short producer hash must be replaced by the derived one")
+	require.Equal(t, code, got)
+
+	_, ok = c.View(nil).GetCodeByHash(short)
+	require.False(t, ok, "the zero-padded short hash must not key the entry")
+}

--- a/execution/cache/cache_test.go
+++ b/execution/cache/cache_test.go
@@ -1613,8 +1613,8 @@ func TestPublishUsesProducerCodeHash(t *testing.T) {
 	require.Equal(t, code, got)
 }
 
-// A malformed producer hash must be re-derived, not used: it would be zero-padded
-// into the content-addressed key and would blank the collision guard.
+// A malformed producer hash must be re-derived, not used: it would file the entry
+// under a content address no reader queries, since lookups pass a 32-byte keccak.
 func TestPublishDerivesMalformedCodeHash(t *testing.T) {
 	t.Parallel()
 
@@ -1638,5 +1638,5 @@ func TestPublishDerivesMalformedCodeHash(t *testing.T) {
 	require.Equal(t, code, got)
 
 	_, ok = c.View(nil).GetCodeByHash(short)
-	require.False(t, ok, "the zero-padded short hash must not key the entry")
+	require.False(t, ok, "the short hash must not key the entry")
 }

--- a/execution/cache/code_store.go
+++ b/execution/cache/code_store.go
@@ -94,6 +94,7 @@ func (s *CodeStore) GetByHash(tx kv.Getter, codeHash []byte) ([]byte, bool) {
 
 // PutByHash records decompressed code in both tiers. The MDBX write needs an
 // RwTx, so this runs on the code write path (deploy/commit), not on reads.
+// The memory tier retains code without copying, so the caller must not reuse it.
 func (s *CodeStore) PutByHash(tx kv.RwTx, codeHash, code []byte) error {
 	if s == nil || len(codeHash) != 32 || len(code) == 0 {
 		return nil

--- a/execution/cache/code_store.go
+++ b/execution/cache/code_store.go
@@ -100,8 +100,7 @@ func (s *CodeStore) PutByHash(tx kv.RwTx, codeHash, code []byte) error {
 	}
 	var key [32]byte
 	copy(key[:], codeHash)
-	// The otter tier is process-lifetime, so it cannot hold the caller's buffer.
-	s.mem.Set(key, bytes.Clone(code))
+	s.mem.Set(key, code)
 	has, err := tx.Has(kv.TblCodeCache, codeHash)
 	if err != nil {
 		return err

--- a/execution/cache/code_store.go
+++ b/execution/cache/code_store.go
@@ -100,7 +100,8 @@ func (s *CodeStore) PutByHash(tx kv.RwTx, codeHash, code []byte) error {
 	}
 	var key [32]byte
 	copy(key[:], codeHash)
-	s.mem.Set(key, code)
+	// The otter tier is process-lifetime, so it cannot hold the caller's buffer.
+	s.mem.Set(key, bytes.Clone(code))
 	has, err := tx.Has(kv.TblCodeCache, codeHash)
 	if err != nil {
 		return err

--- a/execution/cache/state_cache.go
+++ b/execution/cache/state_cache.go
@@ -337,8 +337,11 @@ func prepareStateUpdate(update StateUpdate) preparedStateUpdate {
 		txNum:  update.TxNum,
 	}
 	if update.Domain == kv.CodeDomain && len(update.Value) > 0 {
+		// A short hash would be zero-padded into the content-addressed key and
+		// would also blank the collision guard that rejects a 64-bit maphash
+		// clash, so anything but a full hash is derived here instead.
 		prepared.codeHash = update.CodeHash
-		if len(prepared.codeHash) == 0 {
+		if len(prepared.codeHash) != len(common.Hash{}) {
 			prepared.codeHash = crypto.Keccak256(prepared.value)
 		}
 	}
@@ -506,16 +509,8 @@ func (c *StateCache) finishPublication(committedStateVersion uint64) {
 	c.publishing = false
 }
 
-// publishChunk bounds how many updates are prepared before they are applied.
-// Preparing the whole batch up front means holding a clone of every value in it
-// at once, which for a block that deploys hundreds of MB of contract code is a
-// second copy of the whole delta.
-const publishChunk = 256
-
 func (c *StateCache) publish(sourceStateVersion, committedStateVersion, unwindToTxNum uint64,
 	hasUnwind bool, updates []StateUpdate) {
-	prepared := make([]preparedStateUpdate, 0, min(len(updates), publishChunk))
-
 	c.applierMu.Lock()
 	defer c.applierMu.Unlock()
 	if !c.beginPublication(sourceStateVersion, committedStateVersion, unwindToTxNum, hasUnwind) {
@@ -525,15 +520,12 @@ func (c *StateCache) publish(sourceStateVersion, committedStateVersion, unwindTo
 	// Sub-caches synchronize their own reads and writes. While publishing is
 	// true, admission-gated fills cannot mutate state entries or read appliedEnd,
 	// so the serialized applier can install the batch without admissionMu.
-	for start := 0; start < len(updates); start += publishChunk {
-		chunk := updates[start:min(start+publishChunk, len(updates))]
-		prepared = prepared[:0]
-		for i := range chunk {
-			prepared = append(prepared, prepareStateUpdate(chunk[i]))
-		}
-		for i := range prepared {
-			c.applyPrepared(prepared[i])
-		}
+	//
+	// One update is prepared at a time: preparing the batch up front held a clone
+	// of every value at once — a second image of a whole block's contract code —
+	// and cost the same fill blackout, since the clones landed inside it either way.
+	for i := range updates {
+		c.applyPrepared(prepareStateUpdate(updates[i]))
 	}
 
 	c.finishPublication(committedStateVersion)

--- a/execution/cache/state_cache.go
+++ b/execution/cache/state_cache.go
@@ -337,8 +337,8 @@ func prepareStateUpdate(update StateUpdate) preparedStateUpdate {
 		txNum:  update.TxNum,
 	}
 	if update.Domain == kv.CodeDomain && len(update.Value) > 0 {
-		// A short hash files the entry under a content address no reader queries:
-		// GetCodeByHash is called with a 32-byte keccak. Re-derive anything else.
+		// GetCodeByHash is called with a 32-byte keccak; anything else would
+		// file the entry under an address no reader queries.
 		prepared.codeHash = update.CodeHash
 		if len(prepared.codeHash) != len(common.Hash{}) {
 			prepared.codeHash = crypto.Keccak256(prepared.value)
@@ -519,9 +519,7 @@ func (c *StateCache) publish(sourceStateVersion, committedStateVersion, unwindTo
 	// Sub-caches synchronize their own reads and writes. While publishing is
 	// true, admission-gated fills cannot mutate state entries or read appliedEnd,
 	// so the serialized applier can install the batch without admissionMu.
-	//
-	// One update is prepared at a time: preparing the batch up front held a
-	// clone of every value at once, a second image of the whole delta.
+	// One at a time: preparing the batch up front clones every value at once.
 	for i := range updates {
 		c.applyPrepared(prepareStateUpdate(updates[i]))
 	}

--- a/execution/cache/state_cache.go
+++ b/execution/cache/state_cache.go
@@ -337,7 +337,10 @@ func prepareStateUpdate(update StateUpdate) preparedStateUpdate {
 		txNum:  update.TxNum,
 	}
 	if update.Domain == kv.CodeDomain && len(update.Value) > 0 {
-		prepared.codeHash = crypto.Keccak256(prepared.value)
+		prepared.codeHash = update.CodeHash
+		if len(prepared.codeHash) == 0 {
+			prepared.codeHash = crypto.Keccak256(prepared.value)
+		}
 	}
 	return prepared
 }
@@ -503,12 +506,15 @@ func (c *StateCache) finishPublication(committedStateVersion uint64) {
 	c.publishing = false
 }
 
+// publishChunk bounds how many updates are prepared before they are applied.
+// Preparing the whole batch up front means holding a clone of every value in it
+// at once, which for a block that deploys hundreds of MB of contract code is a
+// second copy of the whole delta.
+const publishChunk = 256
+
 func (c *StateCache) publish(sourceStateVersion, committedStateVersion, unwindToTxNum uint64,
 	hasUnwind bool, updates []StateUpdate) {
-	prepared := make([]preparedStateUpdate, len(updates))
-	for i := range updates {
-		prepared[i] = prepareStateUpdate(updates[i])
-	}
+	prepared := make([]preparedStateUpdate, 0, min(len(updates), publishChunk))
 
 	c.applierMu.Lock()
 	defer c.applierMu.Unlock()
@@ -519,8 +525,15 @@ func (c *StateCache) publish(sourceStateVersion, committedStateVersion, unwindTo
 	// Sub-caches synchronize their own reads and writes. While publishing is
 	// true, admission-gated fills cannot mutate state entries or read appliedEnd,
 	// so the serialized applier can install the batch without admissionMu.
-	for i := range prepared {
-		c.applyPrepared(prepared[i])
+	for start := 0; start < len(updates); start += publishChunk {
+		chunk := updates[start:min(start+publishChunk, len(updates))]
+		prepared = prepared[:0]
+		for i := range chunk {
+			prepared = append(prepared, prepareStateUpdate(chunk[i]))
+		}
+		for i := range prepared {
+			c.applyPrepared(prepared[i])
+		}
 	}
 
 	c.finishPublication(committedStateVersion)

--- a/execution/cache/state_cache.go
+++ b/execution/cache/state_cache.go
@@ -338,8 +338,7 @@ func prepareStateUpdate(update StateUpdate) preparedStateUpdate {
 	}
 	if update.Domain == kv.CodeDomain && len(update.Value) > 0 {
 		// A short hash would be zero-padded into the content-addressed key and
-		// would also blank the collision guard that rejects a 64-bit maphash
-		// clash, so anything but a full hash is derived here instead.
+		// blank the collision guard, so anything but a full hash is re-derived.
 		prepared.codeHash = update.CodeHash
 		if len(prepared.codeHash) != len(common.Hash{}) {
 			prepared.codeHash = crypto.Keccak256(prepared.value)
@@ -521,9 +520,8 @@ func (c *StateCache) publish(sourceStateVersion, committedStateVersion, unwindTo
 	// true, admission-gated fills cannot mutate state entries or read appliedEnd,
 	// so the serialized applier can install the batch without admissionMu.
 	//
-	// One update is prepared at a time: preparing the batch up front held a clone
-	// of every value at once — a second image of a whole block's contract code —
-	// and cost the same fill blackout, since the clones landed inside it either way.
+	// One update is prepared at a time: preparing the batch up front held a
+	// clone of every value at once, a second image of the whole delta.
 	for i := range updates {
 		c.applyPrepared(prepareStateUpdate(updates[i]))
 	}

--- a/execution/cache/state_cache.go
+++ b/execution/cache/state_cache.go
@@ -337,8 +337,8 @@ func prepareStateUpdate(update StateUpdate) preparedStateUpdate {
 		txNum:  update.TxNum,
 	}
 	if update.Domain == kv.CodeDomain && len(update.Value) > 0 {
-		// A short hash would be zero-padded into the content-addressed key and
-		// blank the collision guard, so anything but a full hash is re-derived.
+		// A short hash files the entry under a content address no reader queries:
+		// GetCodeByHash is called with a 32-byte keccak. Re-derive anything else.
 		prepared.codeHash = update.CodeHash
 		if len(prepared.codeHash) != len(common.Hash{}) {
 			prepared.codeHash = crypto.Keccak256(prepared.value)

--- a/execution/cache/view.go
+++ b/execution/cache/view.go
@@ -321,8 +321,8 @@ type Applier struct {
 }
 
 // StateUpdate is one committed domain mutation published to StateCache.
-// CodeHash is read only for kv.CodeDomain, and only to spare the cache hashing
-// Value again when the producer already holds the hash; nil is always valid.
+// CodeHash is optional: set for kv.CodeDomain when the producer already has the
+// full hash, nil otherwise.
 type StateUpdate struct {
 	Domain   kv.Domain
 	Key      []byte

--- a/execution/cache/view.go
+++ b/execution/cache/view.go
@@ -321,11 +321,14 @@ type Applier struct {
 }
 
 // StateUpdate is one committed domain mutation published to StateCache.
+// CodeHash is read only for kv.CodeDomain, and only to spare the cache hashing
+// Value again when the producer already holds the hash; nil is always valid.
 type StateUpdate struct {
-	Domain kv.Domain
-	Key    []byte
-	Value  []byte
-	TxNum  uint64
+	Domain   kv.Domain
+	Key      []byte
+	Value    []byte
+	CodeHash []byte
+	TxNum    uint64
 }
 
 // Applier creates the writer handle.

--- a/execution/cache/view.go
+++ b/execution/cache/view.go
@@ -321,8 +321,7 @@ type Applier struct {
 }
 
 // StateUpdate is one committed domain mutation published to StateCache.
-// CodeHash is optional: set for kv.CodeDomain when the producer already has the
-// full hash, nil otherwise.
+// CodeHash is optional: set for kv.CodeDomain when the producer has it.
 type StateUpdate struct {
 	Domain   kv.Domain
 	Key      []byte


### PR DESCRIPTION
Fixes #23662. `CodeStore.mem` is process-lifetime, so `PutByHash` copies what it keeps.

`SD` does `copy` k/v before put in `sd.mem`. It means when using this k/v to populate `StateCache` don't need one more `copy`

For the 150M `unchunkified_bytecode` fixture, whose setup block has `gasLimit = 1e12` and 18,440 deploy txs of ~24.5 KB, that is ~450 MB per block.

| | peak RSS | GC max-live | wall |
|---|---|---|---|
| main | 15.9 / 15.2 / 16.8 GB | 4306 / 4389 / 4091 MB | 2:24 / 2:16 / 2:25 |
| this | 12.4 / 14.8 / 13.6 GB | 3109 / 3703 / 3658 MB | 2:01 / 2:07 / 2:03 |

