### PR TITLE
rpc/rpchelper: stop mutating the log shared with subscribers

### DIFF
--- a/rpc/rpchelper/filters.go
+++ b/rpc/rpchelper/filters.go
@@ -34,6 +34,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/erigontech/erigon/common/concurrent"
+	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/state/execctx"
@@ -182,6 +183,7 @@ func New(ctx context.Context, config FiltersConfig, ethBackend ApiBackend, txPoo
 	}()
 
 	go func() {
+		defer dbg.LogPanic()
 		if ethBackend == nil {
 			return
 		}

--- a/rpc/rpchelper/filters_subscribe_test.go
+++ b/rpc/rpchelper/filters_subscribe_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"math/big"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -222,4 +223,37 @@ func TestSubscribeReceiptsRemoteUpdateFailureReturnsError(t *testing.T) {
 	_, id, err := f.SubscribeReceipts(8, filters.ReceiptsFilterCriteria{})
 	require.Error(t, err)
 	require.False(t, f.receiptsSubs.removeReceiptsFilter(id))
+}
+
+// distributeLog hands the same log to every subscriber, so only the race detector
+// catches a mutation after Send: the values written back are identical.
+func TestDistributeLogsLeavesDeliveredLogsUntouched(t *testing.T) {
+	f := newTestFilters(t)
+	var delivered atomic.Int64
+	var wg sync.WaitGroup
+	ids := make([]LogsSubID, 0, 8)
+	for range 8 {
+		logs, id, err := f.SubscribeLogs(64, filters.FilterCriteria{}, ProtocolWS)
+		require.NoError(t, err)
+		t.Cleanup(func() { f.UnsubscribeLogs(id) })
+		ids = append(ids, id)
+		wg.Go(func() {
+			for lg := range logs {
+				for _, topic := range lg.Topics {
+					_ = topic
+				}
+				_ = lg.Address
+				delivered.Add(1)
+			}
+		})
+	}
+
+	for range 2000 {
+		f.OnNewLogs(createLog())
+	}
+	for _, id := range ids {
+		f.UnsubscribeLogs(id)
+	}
+	wg.Wait()
+	require.Positive(t, delivered.Load())
 }

--- a/rpc/rpchelper/filters_subscribe_test.go
+++ b/rpc/rpchelper/filters_subscribe_test.go
@@ -227,8 +227,9 @@ func TestSubscribeReceiptsRemoteUpdateFailureReturnsError(t *testing.T) {
 	require.False(t, f.receiptsSubs.removeReceiptsFilter(id))
 }
 
-// distributeLog hands the same log to every subscriber, so only the race detector
-// catches a mutation after Send: the values written back are identical.
+// distributeLog hands the same log to every subscriber, and the mutation it used to do
+// wrote identical values back, so delivery succeeds either way: without -race this test
+// asserts nothing.
 func TestDistributeLogsLeavesDeliveredLogsUntouched(t *testing.T) {
 	f := newTestFilters(t)
 	var delivered atomic.Int64
@@ -237,6 +238,8 @@ func TestDistributeLogsLeavesDeliveredLogsUntouched(t *testing.T) {
 	for range 8 {
 		logs, id, err := f.SubscribeLogs(64, filters.FilterCriteria{}, ProtocolWS)
 		require.NoError(t, err)
+		// Covers the FailNow path only, where wg.Wait() is never reached and the
+		// consumers would block on a channel nobody closes.
 		t.Cleanup(func() { f.UnsubscribeLogs(id) })
 		ids = append(ids, id)
 		wg.Go(func() {

--- a/rpc/rpchelper/logsfilter.go
+++ b/rpc/rpchelper/logsfilter.go
@@ -245,10 +245,7 @@ func (a *LogsFilterAggregator) getAggMaps() (map[common.Address]int, map[common.
 
 // distributeLog processes an event log and distributes it to all subscribed log filters.
 // It checks each filter to determine if the log should be sent based on the filter's address and topic settings.
-func (a *LogsFilterAggregator) distributeLog(eventLog *remoteproto.SubscribeLogsReply) error {
-	a.logsFilterLock.RLock()
-	defer a.logsFilterLock.RUnlock()
-
+func (a *LogsFilterAggregator) distributeLog(eventLog *remoteproto.SubscribeLogsReply) {
 	addr := gointerfaces.ConvertH160toAddress(eventLog.Address)
 	topics := make([]common.Hash, len(eventLog.Topics))
 	for i, topic := range eventLog.Topics {
@@ -271,6 +268,9 @@ func (a *LogsFilterAggregator) distributeLog(eventLog *remoteproto.SubscribeLogs
 		BlockTimestamp: hexutil.Uint64(eventLog.BlockTimestamp),
 	}
 
+	a.logsFilterLock.RLock()
+	defer a.logsFilterLock.RUnlock()
+
 	a.logsFilters.Range(func(k LogsSubID, filter *LogsFilter) error {
 		if filter.allAddrs == 0 {
 			if _, ok := filter.addrs.Get(addr); !ok {
@@ -283,7 +283,6 @@ func (a *LogsFilterAggregator) distributeLog(eventLog *remoteproto.SubscribeLogs
 		filter.sender.Send(lg)
 		return nil
 	})
-	return nil
 }
 
 // chooseTopics checks if the log topics match the filter's topics.

--- a/rpc/rpchelper/logsfilter.go
+++ b/rpc/rpchelper/logsfilter.go
@@ -249,45 +249,38 @@ func (a *LogsFilterAggregator) distributeLog(eventLog *remoteproto.SubscribeLogs
 	a.logsFilterLock.RLock()
 	defer a.logsFilterLock.RUnlock()
 
-	var lg types.RPCLog
-	var topics []common.Hash
+	addr := gointerfaces.ConvertH160toAddress(eventLog.Address)
+	topics := make([]common.Hash, len(eventLog.Topics))
+	for i, topic := range eventLog.Topics {
+		topics[i] = gointerfaces.ConvertH256ToHash(topic)
+	}
+	// The same log instance is sent to every matching subscriber, each reading it from
+	// its own goroutine, so it must not be mutated after the first Send.
+	lg := &types.RPCLog{
+		Log: types.Log{
+			Address:     addr,
+			Topics:      topics,
+			Data:        eventLog.Data,
+			BlockNumber: hexutil.Uint64(eventLog.BlockNumber),
+			TxHash:      gointerfaces.ConvertH256ToHash(eventLog.TransactionHash),
+			TxIndex:     hexutil.Uint(eventLog.TransactionIndex),
+			BlockHash:   gointerfaces.ConvertH256ToHash(eventLog.BlockHash),
+			Index:       hexutil.Uint(eventLog.LogIndex),
+			Removed:     eventLog.Removed,
+		},
+		BlockTimestamp: hexutil.Uint64(eventLog.BlockTimestamp),
+	}
 
 	a.logsFilters.Range(func(k LogsSubID, filter *LogsFilter) error {
 		if filter.allAddrs == 0 {
-			_, addrOk := filter.addrs.Get(gointerfaces.ConvertH160toAddress(eventLog.Address))
-			if !addrOk {
+			if _, ok := filter.addrs.Get(addr); !ok {
 				return nil
 			}
 		}
-
-		// Pre-allocate topics slice to the required size to avoid multiple allocations
-		topics = topics[:0]
-		if cap(topics) < len(eventLog.Topics) {
-			topics = make([]common.Hash, 0, len(eventLog.Topics))
+		if filter.allTopics == 0 && !a.chooseTopics(filter, topics) {
+			return nil
 		}
-		for _, topic := range eventLog.Topics {
-			topics = append(topics, gointerfaces.ConvertH256ToHash(topic))
-		}
-
-		if filter.allTopics == 0 {
-			if !a.chooseTopics(filter, topics) {
-				return nil
-			}
-		}
-
-		// Reuse lg object to avoid creating new instances
-		lg.Address = gointerfaces.ConvertH160toAddress(eventLog.Address)
-		lg.Topics = topics
-		lg.Data = eventLog.Data
-		lg.BlockNumber = hexutil.Uint64(eventLog.BlockNumber)
-		lg.TxHash = gointerfaces.ConvertH256ToHash(eventLog.TransactionHash)
-		lg.TxIndex = hexutil.Uint(eventLog.TransactionIndex)
-		lg.BlockHash = gointerfaces.ConvertH256ToHash(eventLog.BlockHash)
-		lg.Index = hexutil.Uint(eventLog.LogIndex)
-		lg.Removed = eventLog.Removed
-		lg.BlockTimestamp = hexutil.Uint64(eventLog.BlockTimestamp)
-
-		filter.sender.Send(&lg)
+		filter.sender.Send(lg)
 		return nil
 	})
 	return nil


### PR DESCRIPTION
`distributeLog` reused one `types.RPCLog` and one `topics` slice across loop iterations: it sent the same pointer to every subscriber, then overwrote it for the next one. Subscribers read the log from their own goroutines, so this was a data race.

Fix: build the log once before the loop, never mutate it after `Send`. The address conversion moves out of the loop too - it ran twice per matching filter.

Test fails under `-race` without the fix.

Follow-up from review: the conversions also move above `logsFilterLock.RLock()` so they no longer run inside the read critical section, `distributeLog` drops its `error` return, and the goroutine running `SubscribeLogs` gets `defer dbg.LogPanic()`.

## Output change

  For logs with no topics (anonymous `LOG0`), `topics` now serializes as `[]` instead of `null`, on `eth_subscribe("logs")` and `eth_getFilterChanges`.

  I verified `[]` is the correct form: geth always emits it (`makeLog` allocates with `make`, RLP decodes an empty list into a non-nil slice), `execution-apis` declares `topics` as `type: array` with no `null` branch, and Erigon's own
  `eth_getLogs` emits `[]` because `Logs.Copy` allocates the slice for every log leaving `IntraBlockState`.

  No QA baseline is affected: the only `eth_getFilterChanges` /  `eth_getFilterLogs` fixtures cover the "filter not found" error path.