### PR TITLE
execution/types, rpc/jsonrpc: drop ErigonLog in favour of RPCLog

### DIFF
--- a/docs/site/docs/interacting-with-erigon/erigon.md
+++ b/docs/site/docs/interacting-with-erigon/erigon.md
@@ -23,7 +23,7 @@ These methods must be explicitly enabled using the `--http.api` flag when starti
 ### Enhanced Features
 
 * `erigon_getLatestLogs` supports `ignoreTopicsOrder` for flexible topic matching
-* `erigon_getLogs` returns enhanced ErigonLog objects with additional metadata like timestamps
+* `erigon_getLogs` returns enhanced RPCLog objects with additional metadata like timestamps
 * `erigon_getBlockByTimestamp` uses binary search for efficient timestamp-based block lookup
 
 See more details [here](https://github.com/erigontech/erigon/blob/main/cmd/rpcdaemon/README.md#rpc-implementation-status) about implementation status.
@@ -228,7 +228,7 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_getLogs","params":[{"fromBlock
 
 | Type  | Description                                       |
 | ----- | ------------------------------------------------- |
-| Array | Array of ErigonLog objects with enhanced metadata |
+| Array | Array of RPCLog objects with enhanced metadata |
 
 :::note
 The number of logs returned is capped by [`--rpc.logs.maxresults`](../fundamentals/configuring-erigon#rpc--api) (default `20000`). Set to `0` to remove the limit. The block range of the query is independently capped by `--rpc.blockrange.limit` (default `1000`).
@@ -258,7 +258,7 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_getLatestLogs","params":[{"add
 
 | Type  | Description                                                  |
 | ----- | ------------------------------------------------------------ |
-| Array | Array of ErigonLog objects in descending chronological order |
+| Array | Array of RPCLog objects in descending chronological order |
 
 :::note
 The number of logs returned is capped by [`--rpc.logs.maxresults`](../fundamentals/configuring-erigon#rpc--api) (default `20000`). Set to `0` to remove the limit.

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -5034,7 +5034,7 @@ These methods must be explicitly enabled using the `--http.api` flag when starti
 ### Enhanced Features
 
 * `erigon_getLatestLogs` supports `ignoreTopicsOrder` for flexible topic matching
-* `erigon_getLogs` returns enhanced ErigonLog objects with additional metadata like timestamps
+* `erigon_getLogs` returns enhanced RPCLog objects with additional metadata like timestamps
 * `erigon_getBlockByTimestamp` uses binary search for efficient timestamp-based block lookup
 
 See more details [here](https://github.com/erigontech/erigon/blob/main/cmd/rpcdaemon/README.md#rpc-implementation-status) about implementation status.
@@ -5231,7 +5231,7 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_getLogs","params":[{"fromBlock
 
 | Type  | Description                                       |
 | ----- | ------------------------------------------------- |
-| Array | Array of ErigonLog objects with enhanced metadata |
+| Array | Array of RPCLog objects with enhanced metadata |
 
 :::note
 The number of logs returned is capped by [`--rpc.logs.maxresults`](../fundamentals/configuring-erigon#rpc--api) (default `20000`). Set to `0` to remove the limit. The block range of the query is independently capped by `--rpc.blockrange.limit` (default `1000`).
@@ -5260,7 +5260,7 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_getLatestLogs","params":[{"add
 
 | Type  | Description                                                  |
 | ----- | ------------------------------------------------------------ |
-| Array | Array of ErigonLog objects in descending chronological order |
+| Array | Array of RPCLog objects in descending chronological order |
 
 :::note
 The number of logs returned is capped by [`--rpc.logs.maxresults`](../fundamentals/configuring-erigon#rpc--api) (default `20000`). Set to `0` to remove the limit.

--- a/execution/types/encdec_test.go
+++ b/execution/types/encdec_test.go
@@ -1098,17 +1098,6 @@ func BenchmarkLogJSON(b *testing.B) {
 			benchJSONSink, _ = json.Marshal(rpcLog)
 		}
 	})
-
-	erigonLog := &ErigonLog{
-		Log:            *log,
-		BlockTimestamp: hexutil.Uint64(1700000000),
-	}
-	b.Run("ErigonLog/Single", func(b *testing.B) {
-		b.ReportAllocs()
-		for b.Loop() {
-			benchJSONSink, _ = json.Marshal(erigonLog)
-		}
-	})
 }
 
 var benchLogSink Log
@@ -1145,17 +1134,6 @@ func BenchmarkLogJSONUnmarshal(b *testing.B) {
 		b.ReportAllocs()
 		for b.Loop() {
 			_ = json.Unmarshal(rpcEncoded, &rpcSink)
-		}
-	})
-
-	erigonLog := &ErigonLog{Log: *log, BlockTimestamp: hexutil.Uint64(1700000000)}
-	erigonEncoded, err := json.Marshal(erigonLog)
-	require.NoError(b, err)
-	var erigonSink ErigonLog
-	b.Run("ErigonLog/Single", func(b *testing.B) {
-		b.ReportAllocs()
-		for b.Loop() {
-			_ = json.Unmarshal(erigonEncoded, &erigonSink)
 		}
 	})
 }

--- a/execution/types/ethutils/receipt.go
+++ b/execution/types/ethutils/receipt.go
@@ -70,7 +70,7 @@ func MarshalReceipt(
 		if receipt.Logs != nil {
 			rpcLogs := make([]*types.RPCLog, 0, len(receipt.Logs))
 			for _, l := range receipt.Logs {
-				rpcLogs = append(rpcLogs, types.ToRPCTransactionLog(l, header, txnHash, uint64(receipt.TransactionIndex)))
+				rpcLogs = append(rpcLogs, types.ToRPCTransactionLog(l, header))
 			}
 			logsToMarshal = rpcLogs
 		} else {

--- a/execution/types/log.go
+++ b/execution/types/log.go
@@ -134,52 +134,14 @@ func (logs Logs) ToRPCLogs(timestamp uint64) RPCLogs {
 
 // UnmarshalJSON parses both the embedded Log fields and the RPC-specific blockTimestamp field.
 func (l *RPCLog) UnmarshalJSON(input []byte) error {
-	type flat struct {
-		Address        *common.Address `json:"address"`
-		Topics         *[]common.Hash  `json:"topics"`
-		Data           *hexutil.Bytes  `json:"data"`
-		BlockNumber    *hexutil.Uint64 `json:"blockNumber"`
-		TxHash         *common.Hash    `json:"transactionHash"`
-		TxIndex        *hexutil.Uint   `json:"transactionIndex"`
-		BlockHash      *common.Hash    `json:"blockHash"`
-		Index          *hexutil.Uint   `json:"logIndex"`
-		Removed        *bool           `json:"removed"`
-		BlockTimestamp *hexutil.Uint64 `json:"blockTimestamp"`
-	}
-	var dec flat
-	if err := json.Unmarshal(input, &dec); err != nil {
+	if err := l.Log.UnmarshalJSON(input); err != nil {
 		return err
 	}
-	if dec.Address == nil {
-		return errors.New("missing required field 'address' for Log")
+	var dec struct {
+		BlockTimestamp *hexutil.Uint64 `json:"blockTimestamp"`
 	}
-	l.Address = *dec.Address
-	if dec.Topics == nil {
-		return errors.New("missing required field 'topics' for Log")
-	}
-	l.Topics = *dec.Topics
-	if dec.Data == nil {
-		return errors.New("missing required field 'data' for Log")
-	}
-	l.Data = *dec.Data
-	if dec.TxHash == nil {
-		return errors.New("missing required field 'transactionHash' for Log")
-	}
-	l.TxHash = *dec.TxHash
-	if dec.BlockNumber != nil {
-		l.BlockNumber = *dec.BlockNumber
-	}
-	if dec.TxIndex != nil {
-		l.TxIndex = *dec.TxIndex
-	}
-	if dec.BlockHash != nil {
-		l.BlockHash = *dec.BlockHash
-	}
-	if dec.Index != nil {
-		l.Index = *dec.Index
-	}
-	if dec.Removed != nil {
-		l.Removed = *dec.Removed
+	if err := json.Unmarshal(input, &dec); err != nil {
+		return err
 	}
 	if dec.BlockTimestamp != nil {
 		l.BlockTimestamp = *dec.BlockTimestamp
@@ -223,7 +185,7 @@ func (logs Logs) Copy() Logs {
 }
 
 // ToRPCTransactionLog converts types.Log in a RPCLog.
-func ToRPCTransactionLog(log *Log, header *Header, txHash common.Hash, txIndex uint64) *RPCLog {
+func ToRPCTransactionLog(log *Log, header *Header) *RPCLog {
 	return &RPCLog{
 		Log:            *log,
 		BlockTimestamp: hexutil.Uint64(header.Time),

--- a/execution/types/log.go
+++ b/execution/types/log.go
@@ -112,86 +112,24 @@ func (l *Log) UnmarshalJSON(input []byte) error {
 	return nil
 }
 
-// UnmarshalJSON validates required fields and parses the BlockTimestamp field.
-func (l *ErigonLog) UnmarshalJSON(input []byte) error {
-	type flat struct {
-		Address        *common.Address `json:"address"`
-		Topics         *[]common.Hash  `json:"topics"`
-		Data           *hexutil.Bytes  `json:"data"`
-		BlockNumber    *hexutil.Uint64 `json:"blockNumber"`
-		TxHash         *common.Hash    `json:"transactionHash"`
-		TxIndex        *hexutil.Uint   `json:"transactionIndex"`
-		BlockHash      *common.Hash    `json:"blockHash"`
-		Index          *hexutil.Uint   `json:"logIndex"`
-		Removed        *bool           `json:"removed"`
-		BlockTimestamp *hexutil.Uint64 `json:"blockTimestamp"`
-	}
-	var dec flat
-	if err := json.Unmarshal(input, &dec); err != nil {
-		return err
-	}
-	if dec.Address == nil {
-		return errors.New("missing required field 'address' for Log")
-	}
-	l.Address = *dec.Address
-	if dec.Topics == nil {
-		return errors.New("missing required field 'topics' for Log")
-	}
-	l.Topics = *dec.Topics
-	if dec.Data == nil {
-		return errors.New("missing required field 'data' for Log")
-	}
-	l.Data = *dec.Data
-	if dec.TxHash == nil {
-		return errors.New("missing required field 'transactionHash' for Log")
-	}
-	l.TxHash = *dec.TxHash
-	if dec.BlockNumber != nil {
-		l.BlockNumber = *dec.BlockNumber
-	}
-	if dec.TxIndex != nil {
-		l.TxIndex = *dec.TxIndex
-	}
-	if dec.BlockHash != nil {
-		l.BlockHash = *dec.BlockHash
-	}
-	if dec.Index != nil {
-		l.Index = *dec.Index
-	}
-	if dec.Removed != nil {
-		l.Removed = *dec.Removed
-	}
-	if dec.BlockTimestamp != nil {
-		l.BlockTimestamp = *dec.BlockTimestamp
-	}
-	return nil
-}
-
 type Logs []*Log
-
-type ErigonLog struct {
-	Log
-	BlockTimestamp hexutil.Uint64 `json:"blockTimestamp" codec:"-"`
-}
-
-type ErigonLogs []*ErigonLog
-
-// ToErigonLogs converts Logs to ErigonLogs, adding a timestamp to each entry.
-func (logs Logs) ToErigonLogs(timestamp uint64) ErigonLogs {
-	result := make(ErigonLogs, len(logs))
-	for i, l := range logs {
-		result[i] = &ErigonLog{
-			Log:            *l,
-			BlockTimestamp: hexutil.Uint64(timestamp),
-		}
-	}
-	return result
-}
 
 // RPCLog Extends `types.Log` and add BlockTimestamp field
 type RPCLog struct {
 	Log
 	BlockTimestamp hexutil.Uint64 `json:"blockTimestamp" codec:"-"`
+}
+
+// ToRPCLogs converts Logs to RPCLogs, adding a timestamp to each entry.
+func (logs Logs) ToRPCLogs(timestamp uint64) RPCLogs {
+	result := make(RPCLogs, len(logs))
+	for i, l := range logs {
+		result[i] = &RPCLog{
+			Log:            *l,
+			BlockTimestamp: hexutil.Uint64(timestamp),
+		}
+	}
+	return result
 }
 
 // UnmarshalJSON parses both the embedded Log fields and the RPC-specific blockTimestamp field.

--- a/execution/types/log_test.go
+++ b/execution/types/log_test.go
@@ -400,15 +400,26 @@ func TestToRPCLogs(t *testing.T) {
 
 	logs := Logs{
 		{
-			Address: common.HexToAddress("0x5555555555555555555555555555555555555555"),
-			Topics:  []common.Hash{common.HexToHash("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")},
-			Data:    hexutil.Bytes{0xaa},
-			Index:   1,
+			Address:     common.HexToAddress("0x5555555555555555555555555555555555555555"),
+			Topics:      []common.Hash{common.HexToHash("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")},
+			Data:        hexutil.Bytes{0xaa},
+			BlockNumber: 0x1234,
+			TxHash:      common.HexToHash("0x1111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff"),
+			TxIndex:     7,
+			BlockHash:   common.HexToHash("0x99990000aaaabbbbccccddddeeeeffff11112222333344445555666677778888"),
+			Index:       1,
+			Removed:     false,
 		},
 		{
-			Address: common.HexToAddress("0x6666666666666666666666666666666666666666"),
-			Data:    hexutil.Bytes{0xbb},
-			Index:   2,
+			Address:     common.HexToAddress("0x6666666666666666666666666666666666666666"),
+			Topics:      []common.Hash{common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")},
+			Data:        hexutil.Bytes{0xbb},
+			BlockNumber: 0x1234,
+			TxHash:      common.HexToHash("0x2222333344445555666677778888999900001111aaaabbbbccccddddeeeeffff"),
+			TxIndex:     8,
+			BlockHash:   common.HexToHash("0x99990000aaaabbbbccccddddeeeeffff11112222333344445555666677778888"),
+			Index:       2,
+			Removed:     true,
 		},
 	}
 
@@ -417,16 +428,17 @@ func TestToRPCLogs(t *testing.T) {
 	require.Len(t, rpcLogs, len(logs))
 	for i, rpcLog := range rpcLogs {
 		require.Equal(t, hexutil.Uint64(1900000000), rpcLog.BlockTimestamp)
-		require.Equal(t, logs[i].Address, rpcLog.Address)
-		require.Equal(t, logs[i].Topics, rpcLog.Topics)
-		require.Equal(t, logs[i].Data, rpcLog.Data)
-		require.Equal(t, logs[i].Index, rpcLog.Index)
+		require.Equal(t, *logs[i], rpcLog.Log)
 	}
 }
 
 func TestToRPCLogsEmpty(t *testing.T) {
 	t.Parallel()
 
-	require.Empty(t, Logs{}.ToRPCLogs(1))
-	require.Empty(t, Logs(nil).ToRPCLogs(1))
+	// Non-nil empty, so eth_getLogs/erigon_getLogs serialise `[]` and not `null`.
+	for _, logs := range []Logs{{}, nil} {
+		rpcLogs := logs.ToRPCLogs(1)
+		require.NotNil(t, rpcLogs)
+		require.Len(t, rpcLogs, 0)
+	}
 }

--- a/execution/types/log_test.go
+++ b/execution/types/log_test.go
@@ -346,10 +346,10 @@ func TestFilterWithTopicMapEquivalence(t *testing.T) {
 	}
 }
 
-func TestErigonLogJSONBlockTimestamp(t *testing.T) {
+func TestRPCLogJSONBlockTimestamp(t *testing.T) {
 	t.Parallel()
 
-	el := &ErigonLog{
+	el := &RPCLog{
 		Log: Log{
 			Address: common.HexToAddress("0x1111111111111111111111111111111111111111"),
 			Topics:  []common.Hash{common.HexToHash("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")},
@@ -366,56 +366,67 @@ func TestErigonLogJSONBlockTimestamp(t *testing.T) {
 	require.Contains(t, s, `"blockTimestamp":"0x6553f100"`)
 	require.NotContains(t, s, `"timestamp"`)
 
-	var decoded ErigonLog
+	var decoded RPCLog
 	require.NoError(t, json.Unmarshal(b, &decoded))
 	require.Equal(t, el.BlockTimestamp, decoded.BlockTimestamp)
 	require.Equal(t, el.Address, decoded.Address)
 	require.Equal(t, el.TxHash, decoded.TxHash)
 }
 
-func TestErigonLogUnmarshalJSONBlockTimestamp(t *testing.T) {
+func TestRPCLogUnmarshalJSONBlockTimestamp(t *testing.T) {
 	t.Parallel()
 
 	input := `{"address":"0x2222222222222222222222222222222222222222","blockHash":"0x222233334444555566667777888899990000aaaabbbbccccddddeeeeffff1111","blockNumber":"0x200000","blockTimestamp":"0x60000000","data":"0x4455","logIndex":"0x5","topics":["0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"],"transactionHash":"0x33334444555566667777888899990000aaaabbbbccccddddeeeeffff11112222","transactionIndex":"0x6"}`
 
-	var log ErigonLog
+	var log RPCLog
 	require.NoError(t, json.Unmarshal([]byte(input), &log))
 	require.Equal(t, hexutil.Uint64(0x60000000), log.BlockTimestamp)
 	require.Equal(t, common.HexToAddress("0x2222222222222222222222222222222222222222"), log.Address)
 }
 
-func TestErigonLogUnmarshalJSONLegacyTimestampIgnored(t *testing.T) {
+func TestRPCLogUnmarshalJSONLegacyTimestampIgnored(t *testing.T) {
 	t.Parallel()
 
 	input := `{"address":"0x3333333333333333333333333333333333333333","blockHash":"0x4444555566667777888899990000aaaabbbbccccddddeeeeffff111122223333","blockNumber":"0x300000","timestamp":"0x70000000","data":"0x6677","logIndex":"0x8","topics":["0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],"transactionHash":"0x555566667777888899990000aaaabbbbccccddddeeeeffff1111222233334444","transactionIndex":"0x9"}`
 
-	var log ErigonLog
+	var log RPCLog
 	require.NoError(t, json.Unmarshal([]byte(input), &log))
 	require.Equal(t, hexutil.Uint64(0), log.BlockTimestamp)
 	require.Equal(t, common.HexToAddress("0x3333333333333333333333333333333333333333"), log.Address)
 }
 
-func TestErigonAndRPCLogTimestampConsistency(t *testing.T) {
+func TestToRPCLogs(t *testing.T) {
 	t.Parallel()
 
-	log := Log{
-		Address: common.HexToAddress("0x4444444444444444444444444444444444444444"),
-		Topics:  []common.Hash{common.HexToHash("0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")},
-		Data:    hexutil.Bytes{0x88, 0x99},
-		TxHash:  common.HexToHash("0x7777888899990000aaaabbbbccccddddeeeeffff111122223333444455556666"),
+	logs := Logs{
+		{
+			Address: common.HexToAddress("0x5555555555555555555555555555555555555555"),
+			Topics:  []common.Hash{common.HexToHash("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")},
+			Data:    hexutil.Bytes{0xaa},
+			Index:   1,
+		},
+		{
+			Address: common.HexToAddress("0x6666666666666666666666666666666666666666"),
+			Data:    hexutil.Bytes{0xbb},
+			Index:   2,
+		},
 	}
-	ts := hexutil.Uint64(1800000000)
 
-	erigonB, err := json.Marshal(&ErigonLog{Log: log, BlockTimestamp: ts})
-	require.NoError(t, err)
-	rpcB, err := json.Marshal(&RPCLog{Log: log, BlockTimestamp: ts})
-	require.NoError(t, err)
+	rpcLogs := logs.ToRPCLogs(1900000000)
 
-	var erigonMap, rpcMap map[string]any
-	require.NoError(t, json.Unmarshal(erigonB, &erigonMap))
-	require.NoError(t, json.Unmarshal(rpcB, &rpcMap))
+	require.Len(t, rpcLogs, len(logs))
+	for i, rpcLog := range rpcLogs {
+		require.Equal(t, hexutil.Uint64(1900000000), rpcLog.BlockTimestamp)
+		require.Equal(t, logs[i].Address, rpcLog.Address)
+		require.Equal(t, logs[i].Topics, rpcLog.Topics)
+		require.Equal(t, logs[i].Data, rpcLog.Data)
+		require.Equal(t, logs[i].Index, rpcLog.Index)
+	}
+}
 
-	require.Equal(t, rpcMap["blockTimestamp"], erigonMap["blockTimestamp"])
-	require.Nil(t, erigonMap["timestamp"])
-	require.Nil(t, rpcMap["timestamp"])
+func TestToRPCLogsEmpty(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, Logs{}.ToRPCLogs(1))
+	require.Empty(t, Logs(nil).ToRPCLogs(1))
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5034,7 +5034,7 @@ These methods must be explicitly enabled using the `--http.api` flag when starti
 ### Enhanced Features
 
 * `erigon_getLatestLogs` supports `ignoreTopicsOrder` for flexible topic matching
-* `erigon_getLogs` returns enhanced ErigonLog objects with additional metadata like timestamps
+* `erigon_getLogs` returns enhanced RPCLog objects with additional metadata like timestamps
 * `erigon_getBlockByTimestamp` uses binary search for efficient timestamp-based block lookup
 
 See more details [here](https://github.com/erigontech/erigon/blob/main/cmd/rpcdaemon/README.md#rpc-implementation-status) about implementation status.
@@ -5231,7 +5231,7 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_getLogs","params":[{"fromBlock
 
 | Type  | Description                                       |
 | ----- | ------------------------------------------------- |
-| Array | Array of ErigonLog objects with enhanced metadata |
+| Array | Array of RPCLog objects with enhanced metadata |
 
 :::note
 The number of logs returned is capped by [`--rpc.logs.maxresults`](../fundamentals/configuring-erigon#rpc--api) (default `20000`). Set to `0` to remove the limit. The block range of the query is independently capped by `--rpc.blockrange.limit` (default `1000`).
@@ -5260,7 +5260,7 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_getLatestLogs","params":[{"add
 
 | Type  | Description                                                  |
 | ----- | ------------------------------------------------------------ |
-| Array | Array of ErigonLog objects in descending chronological order |
+| Array | Array of RPCLog objects in descending chronological order |
 
 :::note
 The number of logs returned is capped by [`--rpc.logs.maxresults`](../fundamentals/configuring-erigon#rpc--api) (default `20000`). Set to `0` to remove the limit.

--- a/rpc/contracts/direct_backend.go
+++ b/rpc/contracts/direct_backend.go
@@ -130,17 +130,7 @@ func (b DirectBackend) FilterLogs(ctx context.Context, query bind.FilterQuery) (
 	res := make([]types.Log, len(rpcLogs))
 
 	for i, log := range rpcLogs {
-		res[i] = types.Log{
-			Address:     log.Address,
-			Topics:      log.Topics,
-			Data:        log.Data,
-			BlockNumber: log.BlockNumber,
-			TxHash:      log.TxHash,
-			TxIndex:     log.TxIndex,
-			BlockHash:   log.BlockHash,
-			Index:       log.Index,
-			Removed:     log.Removed,
-		}
+		res[i] = log.Log
 	}
 
 	return res, nil

--- a/rpc/jsonrpc/erigon_api.go
+++ b/rpc/jsonrpc/erigon_api.go
@@ -44,8 +44,8 @@ type ErigonAPI interface {
 	// Receipt related (see ./erigon_receipts.go)
 	GetLogsByHash(ctx context.Context, hash common.Hash) ([][]*types.Log, error)
 	//GetLogsByNumber(ctx context.Context, number rpc.BlockNumber) ([][]*types.Log, error)
-	GetLogs(ctx context.Context, crit filters.FilterCriteria) (types.ErigonLogs, error)
-	GetLatestLogs(ctx context.Context, crit filters.FilterCriteria, logOptions filters.LogFilterOptions) (types.ErigonLogs, error)
+	GetLogs(ctx context.Context, crit filters.FilterCriteria) (types.RPCLogs, error)
+	GetLatestLogs(ctx context.Context, crit filters.FilterCriteria, logOptions filters.LogFilterOptions) (types.RPCLogs, error)
 	// Gets cannonical block receipt through hash. If the block is not cannonical returns error
 	GetBlockReceiptsByBlockHash(ctx context.Context, cannonicalBlockHash common.Hash) ([]map[string]any, error)
 

--- a/rpc/jsonrpc/erigon_receipts.go
+++ b/rpc/jsonrpc/erigon_receipts.go
@@ -115,17 +115,17 @@ func resolveLogBound(bound *big.Int, def uint64, name string) (uint64, error) {
 }
 
 // GetLogs implements erigon_getLogs. Returns an array of logs matching a given filter object.
-func (api *ErigonImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria) (types.ErigonLogs, error) {
+func (api *ErigonImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria) (types.RPCLogs, error) {
 	if err := crit.ValidateTopicPositions(); err != nil {
 		return nil, err
 	}
 
 	var begin, end uint64
-	erigonLogs := types.ErigonLogs{}
+	rpcLogs := types.RPCLogs{}
 
 	tx, beginErr := api.db.BeginTemporalRo(ctx)
 	if beginErr != nil {
-		return erigonLogs, beginErr
+		return rpcLogs, beginErr
 	}
 	defer tx.Rollback()
 
@@ -174,7 +174,7 @@ func (api *ErigonImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria)
 // Examples:
 // {} or nil          matches any topics list
 // {{A}}              matches topic A in any positions. Logs with {{B}, {A}} will be matched
-func (api *ErigonImpl) GetLatestLogs(ctx context.Context, crit filters.FilterCriteria, logOptions filters.LogFilterOptions) (types.ErigonLogs, error) {
+func (api *ErigonImpl) GetLatestLogs(ctx context.Context, crit filters.FilterCriteria, logOptions filters.LogFilterOptions) (types.RPCLogs, error) {
 	if logOptions.LogCount != 0 && logOptions.BlockCount != 0 {
 		return nil, errors.New("logs count & block count are ambigious")
 	}
@@ -192,10 +192,10 @@ func (api *ErigonImpl) GetLatestLogs(ctx context.Context, crit filters.FilterCri
 		return nil, &rpc.CustomError{Message: fmt.Sprintf("%s: requested %d, maximum %d", errRequestedBlockCountExceedsLimit, logOptions.BlockCount, api.blockRangeLimit), Code: rpc.ErrCodeInvalidParams}
 	}
 
-	erigonLogs := types.ErigonLogs{}
+	rpcLogs := types.RPCLogs{}
 	tx, beginErr := api.db.BeginTemporalRo(ctx)
 	if beginErr != nil {
-		return erigonLogs, beginErr
+		return rpcLogs, beginErr
 	}
 	defer tx.Rollback()
 
@@ -241,7 +241,7 @@ func (api *ErigonImpl) GetLatestLogs(ctx context.Context, crit filters.FilterCri
 	// The Logs should retrieve from latest to oldest order=Descend
 	txNumbers, err := applyFiltersV3(api._txNumReader, tx, begin, end, crit, order.Desc)
 	if err != nil {
-		return erigonLogs, err
+		return rpcLogs, err
 	}
 
 	addrMap := make(map[common.Address]struct{}, len(crit.Addresses))
@@ -296,7 +296,7 @@ func (api *ErigonImpl) GetLatestLogs(ctx context.Context, crit filters.FilterCri
 		var blockLogs types.Logs
 
 		if logOptions.BlockCount != 0 && logOptions.BlockCount < blockCount {
-			return erigonLogs, nil
+			return rpcLogs, nil
 		}
 
 		txn, ok, err := api._txnReader.TxnByIdxInBlock(ctx, tx, blockNum, txIndex)
@@ -349,32 +349,32 @@ func (api *ErigonImpl) GetLatestLogs(ctx context.Context, crit filters.FilterCri
 			return nil, fmt.Errorf("block not found %d", blockNum)
 		}
 		for _, log := range filtered {
-			if api.getLogsMaxResults != 0 && len(erigonLogs) >= api.getLogsMaxResults {
+			if api.getLogsMaxResults != 0 && len(rpcLogs) >= api.getLogsMaxResults {
 				return nil, &rpc.CustomError{Message: fmt.Sprintf("%s: %d", errExceedLogResults, api.getLogsMaxResults), Code: rpc.ErrCodeInvalidParams}
 			}
-			erigonLog := &types.ErigonLog{}
-			erigonLog.BlockNumber = hexutil.Uint64(blockNum)
-			erigonLog.BlockHash = blockHash
+			rpcLog := &types.RPCLog{}
+			rpcLog.BlockNumber = hexutil.Uint64(blockNum)
+			rpcLog.BlockHash = blockHash
 			txi := int(log.TxIndex)
 			if txi >= len(body.Transactions) {
 				return nil, fmt.Errorf("log txIndex %d out of range in block %d with %d txns", txi, blockNum, len(body.Transactions))
 			}
-			erigonLog.TxHash = body.Transactions[txi].Hash()
-			erigonLog.BlockTimestamp = hexutil.Uint64(timestamp)
-			erigonLog.Address = log.Address
-			erigonLog.Topics = log.Topics
-			erigonLog.Data = log.Data
-			erigonLog.Index = log.Index
-			erigonLog.TxIndex = log.TxIndex
-			erigonLog.Removed = log.Removed
-			erigonLogs = append(erigonLogs, erigonLog)
+			rpcLog.TxHash = body.Transactions[txi].Hash()
+			rpcLog.BlockTimestamp = hexutil.Uint64(timestamp)
+			rpcLog.Address = log.Address
+			rpcLog.Topics = log.Topics
+			rpcLog.Data = log.Data
+			rpcLog.Index = log.Index
+			rpcLog.TxIndex = log.TxIndex
+			rpcLog.Removed = log.Removed
+			rpcLogs = append(rpcLogs, rpcLog)
 		}
 
 		if logOptions.LogCount != 0 && logOptions.LogCount <= logCount {
-			return erigonLogs, nil
+			return rpcLogs, nil
 		}
 	}
-	return erigonLogs, nil
+	return rpcLogs, nil
 }
 
 func (api *ErigonImpl) GetBlockReceiptsByBlockHash(ctx context.Context, cannonicalBlockHash common.Hash) ([]map[string]any, error) {

--- a/rpc/jsonrpc/erigon_receipts.go
+++ b/rpc/jsonrpc/erigon_receipts.go
@@ -121,11 +121,10 @@ func (api *ErigonImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria)
 	}
 
 	var begin, end uint64
-	rpcLogs := types.RPCLogs{}
 
 	tx, beginErr := api.db.BeginTemporalRo(ctx)
 	if beginErr != nil {
-		return rpcLogs, beginErr
+		return nil, beginErr
 	}
 	defer tx.Rollback()
 
@@ -192,12 +191,13 @@ func (api *ErigonImpl) GetLatestLogs(ctx context.Context, crit filters.FilterCri
 		return nil, &rpc.CustomError{Message: fmt.Sprintf("%s: requested %d, maximum %d", errRequestedBlockCountExceedsLimit, logOptions.BlockCount, api.blockRangeLimit), Code: rpc.ErrCodeInvalidParams}
 	}
 
-	rpcLogs := types.RPCLogs{}
 	tx, beginErr := api.db.BeginTemporalRo(ctx)
 	if beginErr != nil {
-		return rpcLogs, beginErr
+		return nil, beginErr
 	}
 	defer tx.Rollback()
+
+	rpcLogs := types.RPCLogs{}
 
 	var err error
 	var begin, end uint64 // Filter range: begin-end(from-to). Two limits are included in the filter
@@ -241,7 +241,7 @@ func (api *ErigonImpl) GetLatestLogs(ctx context.Context, crit filters.FilterCri
 	// The Logs should retrieve from latest to oldest order=Descend
 	txNumbers, err := applyFiltersV3(api._txNumReader, tx, begin, end, crit, order.Desc)
 	if err != nil {
-		return rpcLogs, err
+		return nil, err
 	}
 
 	addrMap := make(map[common.Address]struct{}, len(crit.Addresses))
@@ -352,21 +352,14 @@ func (api *ErigonImpl) GetLatestLogs(ctx context.Context, crit filters.FilterCri
 			if api.getLogsMaxResults != 0 && len(rpcLogs) >= api.getLogsMaxResults {
 				return nil, &rpc.CustomError{Message: fmt.Sprintf("%s: %d", errExceedLogResults, api.getLogsMaxResults), Code: rpc.ErrCodeInvalidParams}
 			}
-			rpcLog := &types.RPCLog{}
-			rpcLog.BlockNumber = hexutil.Uint64(blockNum)
-			rpcLog.BlockHash = blockHash
 			txi := int(log.TxIndex)
 			if txi >= len(body.Transactions) {
 				return nil, fmt.Errorf("log txIndex %d out of range in block %d with %d txns", txi, blockNum, len(body.Transactions))
 			}
+			rpcLog := &types.RPCLog{Log: *log, BlockTimestamp: hexutil.Uint64(timestamp)}
+			rpcLog.BlockNumber = hexutil.Uint64(blockNum)
+			rpcLog.BlockHash = blockHash
 			rpcLog.TxHash = body.Transactions[txi].Hash()
-			rpcLog.BlockTimestamp = hexutil.Uint64(timestamp)
-			rpcLog.Address = log.Address
-			rpcLog.Topics = log.Topics
-			rpcLog.Data = log.Data
-			rpcLog.Index = log.Index
-			rpcLog.TxIndex = log.TxIndex
-			rpcLog.Removed = log.Removed
 			rpcLogs = append(rpcLogs, rpcLog)
 		}
 

--- a/rpc/jsonrpc/erigon_receipts_test.go
+++ b/rpc/jsonrpc/erigon_receipts_test.go
@@ -83,12 +83,9 @@ func TestErigonGetLatestLogs(t *testing.T) {
 	api := NewErigonAPI(newBaseApiForTest(m), db, nil)
 	expectedLogs, _ := api.GetLogs(m.Ctx, filters.FilterCriteria{FromBlock: big.NewInt(0), ToBlock: big.NewInt(rpc.LatestBlockNumber.Int64())})
 
-	expectedRPCLogs := make(types.RPCLogs, 0)
+	expectedRPCLogs := make(types.RPCLogs, 0, len(expectedLogs))
 	for _, expectedLog := range slices.Backward(expectedLogs) {
-		expectedRPCLogs = append(expectedRPCLogs, &types.RPCLog{
-			Log:            expectedLog.Log,
-			BlockTimestamp: expectedLog.BlockTimestamp,
-		})
+		expectedRPCLogs = append(expectedRPCLogs, expectedLog)
 	}
 	actual, err := api.GetLatestLogs(m.Ctx, filters.FilterCriteria{FromBlock: big.NewInt(0), ToBlock: big.NewInt(rpc.LatestBlockNumber.Int64())}, filters.LogFilterOptions{
 		LogCount: uint64(len(expectedLogs)),
@@ -123,12 +120,9 @@ func TestErigonGetLatestLogsIgnoreTopics(t *testing.T) {
 	api := NewErigonAPI(newBaseApiForTest(m), db, nil)
 	expectedLogs, _ := api.GetLogs(m.Ctx, filters.FilterCriteria{FromBlock: big.NewInt(0), ToBlock: big.NewInt(rpc.LatestBlockNumber.Int64())})
 
-	expectedRPCLogs := make([]*types.RPCLog, 0)
+	expectedRPCLogs := make(types.RPCLogs, 0, len(expectedLogs))
 	for _, expectedLog := range slices.Backward(expectedLogs) {
-		expectedRPCLogs = append(expectedRPCLogs, &types.RPCLog{
-			Log:            expectedLog.Log,
-			BlockTimestamp: expectedLog.BlockTimestamp,
-		})
+		expectedRPCLogs = append(expectedRPCLogs, expectedLog)
 	}
 
 	var lastBlock uint64

--- a/rpc/jsonrpc/erigon_receipts_test.go
+++ b/rpc/jsonrpc/erigon_receipts_test.go
@@ -83,9 +83,9 @@ func TestErigonGetLatestLogs(t *testing.T) {
 	api := NewErigonAPI(newBaseApiForTest(m), db, nil)
 	expectedLogs, _ := api.GetLogs(m.Ctx, filters.FilterCriteria{FromBlock: big.NewInt(0), ToBlock: big.NewInt(rpc.LatestBlockNumber.Int64())})
 
-	expectedErigonLogs := make(types.ErigonLogs, 0)
+	expectedRPCLogs := make(types.RPCLogs, 0)
 	for _, expectedLog := range slices.Backward(expectedLogs) {
-		expectedErigonLogs = append(expectedErigonLogs, &types.ErigonLog{
+		expectedRPCLogs = append(expectedRPCLogs, &types.RPCLog{
 			Log:            expectedLog.Log,
 			BlockTimestamp: expectedLog.BlockTimestamp,
 		})
@@ -97,9 +97,9 @@ func TestErigonGetLatestLogs(t *testing.T) {
 		t.Errorf("calling erigon_getLatestLogs: %v", err)
 	}
 	require.NotNil(t, actual)
-	assert.Equal(expectedErigonLogs, actual)
+	assert.Equal(expectedRPCLogs, actual)
 
-	expectedLog := &types.ErigonLog{
+	expectedLog := &types.RPCLog{
 		Log: types.Log{
 			Address:     common.HexToAddress("0x3CB5b6E26e0f37F2514D45641F15Bd6fEC2E0c4c"),
 			Topics:      []common.Hash{common.HexToHash("0x68f6a0f063c25c6678c443b9a484086f15ba8f91f60218695d32a5251f2050eb")},
@@ -123,9 +123,9 @@ func TestErigonGetLatestLogsIgnoreTopics(t *testing.T) {
 	api := NewErigonAPI(newBaseApiForTest(m), db, nil)
 	expectedLogs, _ := api.GetLogs(m.Ctx, filters.FilterCriteria{FromBlock: big.NewInt(0), ToBlock: big.NewInt(rpc.LatestBlockNumber.Int64())})
 
-	expectedErigonLogs := make([]*types.ErigonLog, 0)
+	expectedRPCLogs := make([]*types.RPCLog, 0)
 	for _, expectedLog := range slices.Backward(expectedLogs) {
-		expectedErigonLogs = append(expectedErigonLogs, &types.ErigonLog{
+		expectedRPCLogs = append(expectedRPCLogs, &types.RPCLog{
 			Log:            expectedLog.Log,
 			BlockTimestamp: expectedLog.BlockTimestamp,
 		})
@@ -150,7 +150,7 @@ func TestErigonGetLatestLogsIgnoreTopics(t *testing.T) {
 		t.Errorf("calling erigon_getLatestLogs: %v", err)
 	}
 	require.NotNil(t, actual)
-	assert.EqualValues(expectedErigonLogs, actual)
+	assert.EqualValues(expectedRPCLogs, actual)
 }
 
 var (

--- a/rpc/jsonrpc/eth_receipts.go
+++ b/rpc/jsonrpc/eth_receipts.go
@@ -234,30 +234,7 @@ func (api *APIImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria) (t
 		return nil, err
 	}
 
-	erigonLogs, err := api.getLogsV3(ctx, tx, begin, end, crit, api.BaseAPI.blockRangeLimit, api.BaseAPI.getLogsMaxResults)
-	if err != nil {
-		return nil, err
-	}
-
-	rpcLogs := make(types.RPCLogs, len(erigonLogs))
-	for i, log := range erigonLogs {
-		rpcLogs[i] = &types.RPCLog{
-			Log: types.Log{
-				Address:     log.Address,
-				Topics:      log.Topics,
-				Data:        log.Data,
-				BlockNumber: log.BlockNumber,
-				TxHash:      log.TxHash,
-				TxIndex:     log.TxIndex,
-				BlockHash:   log.BlockHash,
-				Index:       log.Index,
-				Removed:     log.Removed,
-			},
-			BlockTimestamp: log.BlockTimestamp,
-		}
-	}
-
-	return rpcLogs, nil
+	return api.getLogsV3(ctx, tx, begin, end, crit, api.BaseAPI.blockRangeLimit, api.BaseAPI.getLogsMaxResults)
 }
 
 func applyFiltersV3(txNumsReader rawdbv3.TxNumsReader, tx kv.TemporalTx, begin, end uint64, crit filters.FilterCriteria, asc order.By) (out stream.U64, err error) {
@@ -326,8 +303,8 @@ func applyFiltersV3(txNumsReader rawdbv3.TxNumsReader, tx kv.TemporalTx, begin, 
 	return out, nil
 }
 
-func (api *BaseAPI) getLogsV3(ctx context.Context, tx kv.TemporalTx, begin, end uint64, crit filters.FilterCriteria, rangeLimit int, maxResults int) ([]*types.ErigonLog, error) {
-	logs := []*types.ErigonLog{} //nolint
+func (api *BaseAPI) getLogsV3(ctx context.Context, tx kv.TemporalTx, begin, end uint64, crit filters.FilterCriteria, rangeLimit int, maxResults int) (types.RPCLogs, error) {
+	logs := types.RPCLogs{} //nolint
 
 	// Treat range-limit violations as invalid filter input to match eth_getLogs parameter validation.
 	if rangeLimit != 0 && (end-begin) > uint64(rangeLimit) {
@@ -382,7 +359,7 @@ func (api *BaseAPI) getLogsV3(ctx context.Context, tx kv.TemporalTx, begin, end 
 		}
 
 		if r, ok := api.receiptsGenerator.TryGetCachedReceipt(header.Hash(), txNum, txIndex); ok {
-			logs, err = appendErigonLogs(logs, r.Logs.FilterWithTopicMap(addrMap, topicMap, 0), header.Time, maxResults)
+			logs, err = appendRPCLogs(logs, r.Logs.FilterWithTopicMap(addrMap, topicMap, 0), header.Time, maxResults)
 			if err != nil {
 				return nil, err
 			}
@@ -405,7 +382,7 @@ func (api *BaseAPI) getLogsV3(ctx context.Context, tx kv.TemporalTx, begin, end 
 			return nil, err
 		}
 
-		logs, err = appendErigonLogs(logs, r.Logs.FilterWithTopicMap(addrMap, topicMap, 0), header.Time, maxResults)
+		logs, err = appendRPCLogs(logs, r.Logs.FilterWithTopicMap(addrMap, topicMap, 0), header.Time, maxResults)
 		if err != nil {
 			return nil, err
 		}
@@ -414,13 +391,13 @@ func (api *BaseAPI) getLogsV3(ctx context.Context, tx kv.TemporalTx, begin, end 
 	return logs, nil
 }
 
-func appendErigonLogs(logs []*types.ErigonLog, filtered types.Logs, blockTime uint64, maxResults int) ([]*types.ErigonLog, error) {
+func appendRPCLogs(logs types.RPCLogs, filtered types.Logs, blockTime uint64, maxResults int) (types.RPCLogs, error) {
 	if maxResults != 0 && len(logs)+len(filtered) > maxResults {
 		return nil, &rpc.InvalidParamsError{
 			Message: fmt.Sprintf("%s: %d", errExceedLogResults, maxResults),
 		}
 	}
-	return append(logs, filtered.ToErigonLogs(blockTime)...), nil
+	return append(logs, filtered.ToRPCLogs(blockTime)...), nil
 }
 
 // The Topic list restricts matches to particular event topics. Each event has a list

--- a/rpc/jsonrpc/eth_receipts.go
+++ b/rpc/jsonrpc/eth_receipts.go
@@ -182,11 +182,9 @@ func (api *APIImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria) (t
 		return nil, err
 	}
 
-	logs := types.RPCLogs{}
-
 	tx, beginErr := api.db.BeginTemporalRo(ctx)
 	if beginErr != nil {
-		return logs, beginErr
+		return nil, beginErr
 	}
 	defer tx.Rollback()
 
@@ -304,7 +302,7 @@ func applyFiltersV3(txNumsReader rawdbv3.TxNumsReader, tx kv.TemporalTx, begin, 
 }
 
 func (api *BaseAPI) getLogsV3(ctx context.Context, tx kv.TemporalTx, begin, end uint64, crit filters.FilterCriteria, rangeLimit int, maxResults int) (types.RPCLogs, error) {
-	logs := types.RPCLogs{} //nolint
+	logs := types.RPCLogs{}
 
 	// Treat range-limit violations as invalid filter input to match eth_getLogs parameter validation.
 	if rangeLimit != 0 && (end-begin) > uint64(rangeLimit) {
@@ -328,7 +326,7 @@ func (api *BaseAPI) getLogsV3(ctx context.Context, tx kv.TemporalTx, begin, end 
 
 	txNumbers, err := applyFiltersV3(api._txNumReader, tx, begin, end, crit, order.Asc)
 	if err != nil {
-		return logs, err
+		return nil, err
 	}
 
 	it := rawdbv3.TxNums2BlockNums(ctx, tx, api._txNumReader, txNumbers, order.Asc)

--- a/rpc/jsonrpc/eth_receipts_test.go
+++ b/rpc/jsonrpc/eth_receipts_test.go
@@ -36,8 +36,8 @@ func logsWithIndexes(n int) types.Logs {
 	return logs
 }
 
-func rpcLogsWithIndexes(n int) []*types.RPCLog {
-	logs := make([]*types.RPCLog, n)
+func rpcLogsWithIndexes(n int) types.RPCLogs {
+	logs := make(types.RPCLogs, n)
 	for i, l := range logsWithIndexes(n) {
 		logs[i] = &types.RPCLog{Log: *l}
 	}
@@ -49,7 +49,7 @@ func TestAppendRPCLogs(t *testing.T) {
 
 	cases := []struct {
 		name       string
-		logs       []*types.RPCLog
+		logs       types.RPCLogs
 		filtered   types.Logs
 		maxResults int
 		wantLen    int

--- a/rpc/jsonrpc/eth_receipts_test.go
+++ b/rpc/jsonrpc/eth_receipts_test.go
@@ -36,20 +36,20 @@ func logsWithIndexes(n int) types.Logs {
 	return logs
 }
 
-func erigonLogsWithIndexes(n int) []*types.ErigonLog {
-	logs := make([]*types.ErigonLog, n)
+func rpcLogsWithIndexes(n int) []*types.RPCLog {
+	logs := make([]*types.RPCLog, n)
 	for i, l := range logsWithIndexes(n) {
-		logs[i] = &types.ErigonLog{Log: *l}
+		logs[i] = &types.RPCLog{Log: *l}
 	}
 	return logs
 }
 
-func TestAppendErigonLogs(t *testing.T) {
+func TestAppendRPCLogs(t *testing.T) {
 	const blockTime = 42
 
 	cases := []struct {
 		name       string
-		logs       []*types.ErigonLog
+		logs       []*types.RPCLog
 		filtered   types.Logs
 		maxResults int
 		wantLen    int
@@ -59,13 +59,13 @@ func TestAppendErigonLogs(t *testing.T) {
 		{name: "below limit", filtered: logsWithIndexes(3), maxResults: 5, wantLen: 3},
 		{name: "at limit", filtered: logsWithIndexes(3), maxResults: 3, wantLen: 3},
 		{name: "above limit", filtered: logsWithIndexes(4), maxResults: 3, wantErr: true},
-		{name: "limit counts logs appended earlier", logs: erigonLogsWithIndexes(2), filtered: logsWithIndexes(2), maxResults: 3, wantErr: true},
-		{name: "nothing to append at limit", logs: erigonLogsWithIndexes(2), maxResults: 2, wantLen: 2},
+		{name: "limit counts logs appended earlier", logs: rpcLogsWithIndexes(2), filtered: logsWithIndexes(2), maxResults: 3, wantErr: true},
+		{name: "nothing to append at limit", logs: rpcLogsWithIndexes(2), maxResults: 2, wantLen: 2},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := appendErigonLogs(tc.logs, tc.filtered, blockTime, tc.maxResults)
+			got, err := appendRPCLogs(tc.logs, tc.filtered, blockTime, tc.maxResults)
 			if tc.wantErr {
 				require.Nil(t, got)
 				var rpcErr rpc.Error


### PR DESCRIPTION
`ErigonLog` and `RPCLog` were identical: the same embedded `Log`, the same `BlockTimestamp` field and tags, and a duplicated `UnmarshalJSON` (54 lines, byte for byte). `eth_getLogs` paid for the split - `getLogsV3` returned `[]*ErigonLog` and `GetLogs` then copied every field into an `RPCLog`. Keep `RPCLog`, delete `ErigonLog`, and let `getLogsV3` return `RPCLogs` directly, so the conversion loop goes away. `ToErigonLogs` becomes `ToRPCLogs`.

**No response change.** Neither type ever had a custom `MarshalJSON` - the JSON comes from the struct tags, which were the same on both. `eth_getLogs`, `erigon_getLogs` and `erigon_getLatestLogs` answer exactly as before, and the rpc-tests need no update.

**Breaking change.** This removes `ErigonLog`, `ErigonLogs` and `Logs.ToErigonLogs` from `execution/types` and changes two `ErigonAPI` signatures to `types.RPCLogs`. Out-of-tree importers break on upgrade; the fix is a rename. No compatibility aliases on purpose: `type ErigonLog = RPCLog` would keep alive the duplication this PR removes.

Tests: the `blockTimestamp` coverage now targets `RPCLog`. `TestErigonAndRPCLogTimestampConsistency` is dropped - with one type it would compare `RPCLog` to itself. Added `TestToRPCLogs` and `TestToRPCLogsEmpty`, which pins that empty responses stay `[]` and not `null`.

**Review follow-ups.** `erigon_getLatestLogs` and `DirectBackend.FilterLogs` copy the whole struct instead of listing nine fields; `RPCLog.UnmarshalJSON` delegates to `Log.UnmarshalJSON`; error paths return `nil` instead of an empty slice; `ToRPCTransactionLog` drops two parameters it ignored; docs and `llms-full.txt` no longer name the removed type.