### PR TITLE
rpc: reject null for required positional arguments

### DIFF
--- a/rpc/json.go
+++ b/rpc/json.go
@@ -369,18 +369,26 @@ func parseArgumentArray(dec *json.Decoder, types []reflect.Type) ([]reflect.Valu
 		if i >= len(types) {
 			return args, fmt.Errorf("too many arguments, want at most %d", len(types))
 		}
-		argval := reflect.New(types[i])
-		if err := dec.Decode(argval.Interface()); err != nil {
+		var elem json.RawMessage
+		if err := dec.Decode(&elem); err != nil {
 			return args, fmt.Errorf("invalid argument %d: %w", i, err)
 		}
-		if argval.IsNil() && types[i].Kind() != reflect.Pointer {
+		if types[i].Kind() != reflect.Pointer && isJSONNull(elem) {
 			return args, fmt.Errorf("missing value for required argument %d", i)
+		}
+		argval := reflect.New(types[i])
+		if err := json.Unmarshal(elem, argval.Interface()); err != nil {
+			return args, fmt.Errorf("invalid argument %d: %w", i, err)
 		}
 		args = append(args, argval.Elem())
 	}
 	// Read end of args array.
 	_, err := dec.Token()
 	return args, err
+}
+
+func isJSONNull(raw json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(raw), []byte("null"))
 }
 
 // parseSubscriptionName extracts the subscription name from an encoded argument array.

--- a/rpc/json_test.go
+++ b/rpc/json_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package rpc
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePositionalArgumentsRejectsNull(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		rawArgs string
+		types   []reflect.Type
+		wantErr string
+	}{
+		{
+			name:    "null for required int",
+			rawArgs: `[null]`,
+			types:   []reflect.Type{reflect.TypeFor[int]()},
+			wantErr: "missing value for required argument 0",
+		},
+		{
+			name:    "null for required struct",
+			rawArgs: `[null]`,
+			types:   []reflect.Type{reflect.TypeFor[echoArgs]()},
+			wantErr: "missing value for required argument 0",
+		},
+		{
+			name:    "null for second required argument",
+			rawArgs: `["hi", null]`,
+			types:   []reflect.Type{reflect.TypeFor[string](), reflect.TypeFor[int]()},
+			wantErr: "missing value for required argument 1",
+		},
+		{
+			name:    "null for required slice",
+			rawArgs: `[null]`,
+			types:   []reflect.Type{reflect.TypeFor[[]int]()},
+			wantErr: "missing value for required argument 0",
+		},
+		{
+			name:    "padded null still rejected",
+			rawArgs: "[ \n null ]",
+			types:   []reflect.Type{reflect.TypeFor[int]()},
+			wantErr: "missing value for required argument 0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := parsePositionalArguments(json.RawMessage(tt.rawArgs), tt.types)
+			require.Error(t, err)
+			assert.Equal(t, tt.wantErr, err.Error())
+		})
+	}
+}
+
+func TestParsePositionalArgumentsAcceptsNullForOptional(t *testing.T) {
+	t.Parallel()
+
+	types := []reflect.Type{reflect.TypeFor[string](), reflect.TypeFor[*echoArgs]()}
+
+	args, err := parsePositionalArguments(json.RawMessage(`["hi", null]`), types)
+	require.NoError(t, err)
+	require.Len(t, args, 2)
+	assert.Equal(t, "hi", args[0].String())
+	assert.True(t, args[1].IsNil())
+}
+
+func TestParsePositionalArgumentsValues(t *testing.T) {
+	t.Parallel()
+
+	types := []reflect.Type{reflect.TypeFor[string](), reflect.TypeFor[int](), reflect.TypeFor[*echoArgs]()}
+
+	args, err := parsePositionalArguments(json.RawMessage(`["hi", 7, {"S": "there"}]`), types)
+	require.NoError(t, err)
+	require.Len(t, args, 3)
+	assert.Equal(t, "hi", args[0].String())
+	assert.EqualValues(t, 7, args[1].Int())
+	assert.Equal(t, "there", args[2].Interface().(*echoArgs).S)
+}
+
+func TestParsePositionalArgumentsInvalidArgument(t *testing.T) {
+	t.Parallel()
+
+	_, err := parsePositionalArguments(json.RawMessage(`["hi"]`), []reflect.Type{reflect.TypeFor[int]()})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid argument 0")
+}


### PR DESCRIPTION
Port of ethereum/go-ethereum#35576: Erigon has the exact same dead check.

A JSON `null` passed for a required positional argument was decoded as the zero value instead of being rejected, because the guard never fired:

```go
argval := reflect.New(types[i])   // always non-nil
if argval.IsNil() && types[i].Kind() != reflect.Pointer {   // never true
```

It affects argument types without a custom `UnmarshalJSON` (`int`, `bool`, structs, slices): e.g. `debug_storageRangeAt(..., null)` became `maxResult = 0`.

`parseArgumentArray` now decodes the element into a `json.RawMessage`, rejects a `null` when the argument type is not a pointer, then unmarshals. The handler maps the error to `-32602`, as the spec requires.

Same criterion as geth (`Kind() != reflect.Pointer`), so slices and interfaces are covered too and behaviour stays aligned on hive rpc-compat.

TDD: new `rpc/json_test.go`, the five `null` cases fail before the fix and pass after.
