### PR TITLE
common, cl: enable errcheck across common/* and resolve #23577 review follow-ups

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -90,13 +90,7 @@ linters:
       - linters:
           - errcheck
         path: "^(\
-          common\
-          |common/crypto\
-          |common/crypto/blake2b\
-          |common/iouring\
-          |common/log/v3\
-          |common/mmap\
-          |db/datadir\
+          db/datadir\
           |db/datadir/reset\
           |db/datastruct/btindex\
           |db/datastruct/fusefilter\

--- a/cl/persistence/blob_storage/bucket_store.go
+++ b/cl/persistence/blob_storage/bucket_store.go
@@ -150,14 +150,8 @@ func (b *bucketStore) encodeTo(path string, v ssz.Marshaler) error {
 		return err
 	}
 	defer fh.Close()
-	// EncodeAndWrite flushes in a defer and discards that error, so a short write is
-	// only observable on the writer it was handed.
-	w := &errWriter{w: fh}
-	if err := ssz_snappy.EncodeAndWrite(w, v); err != nil {
+	if err := ssz_snappy.EncodeAndWrite(fh, v); err != nil {
 		return err
-	}
-	if w.err != nil {
-		return w.err
 	}
 	if err := fh.Sync(); err != nil {
 		return err
@@ -214,22 +208,6 @@ func (b *bucketStore) stream(w io.Writer, slot uint64, root common.Hash, idx uin
 	defer fh.Close()
 	_, err = io.Copy(w, fh)
 	return err
-}
-
-type errWriter struct {
-	w   io.Writer
-	err error
-}
-
-func (e *errWriter) Write(p []byte) (int, error) {
-	n, err := e.w.Write(p)
-	if err == nil && n < len(p) {
-		err = io.ErrShortWrite
-	}
-	if err != nil && e.err == nil {
-		e.err = err
-	}
-	return n, err
 }
 
 // pruneBelow removes every bucket that ends before slot. It attempts all of them and

--- a/cl/sentinel/communication/ssz_snappy/encoding.go
+++ b/cl/sentinel/communication/ssz_snappy/encoding.go
@@ -64,7 +64,9 @@ func EncodeAndWrite(w io.Writer, val ssz.Marshaler, prefix ...byte) error {
 	lengthBuf := make([]byte, 10)
 	vin := binary.PutUvarint(lengthBuf, uint64(len(enc)))
 
-	// Create writer size
+	// Sized to hold the whole frame: with a smaller buffer bufio writes chunks
+	// straight to w, and there it loops forever on a writer that keeps returning
+	// (0, nil) instead of reporting a short write.
 	wr := bufio.NewWriterSize(w, 10+len(enc))
 	// Write length of packet
 	if _, err := wr.Write(prefix); err != nil {

--- a/cl/sentinel/discovery.go
+++ b/cl/sentinel/discovery.go
@@ -302,13 +302,13 @@ func (s *Sentinel) getSubnetCoverageWithPeers() (coverage [attestationSubnetCoun
 	return coverage, subnetToPeers
 }
 
-// pruneExcessPeers disconnects excess peers while ensuring no subnet becomes empty
 func (s *Sentinel) closePeer(pid peer.ID) {
 	if err := s.p2p.Host().Network().ClosePeer(pid); err != nil {
 		log.Trace("[Sentinel] failed to close peer", "peer", pid, "err", err)
 	}
 }
 
+// pruneExcessPeers disconnects excess peers while ensuring no subnet becomes empty
 func (s *Sentinel) pruneExcessPeers() {
 	peerCount := len(s.p2p.Host().Network().Peers())
 	targetPeerCount := int(s.cfg.MaxPeerCount)

--- a/cl/transition/impl/eth2/statechange/process_pending_consolidations_test.go
+++ b/cl/transition/impl/eth2/statechange/process_pending_consolidations_test.go
@@ -1,0 +1,80 @@
+package statechange_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/erigontech/erigon/cl/abstract/mock_services"
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/transition/impl/eth2/statechange"
+)
+
+const (
+	consolidationSourceIndex = 1
+	consolidationTargetIndex = 2
+	sourceBalance            = 40_000_000_000
+	sourceEffectiveBalance   = 32_000_000_000
+)
+
+// consolidationState wires up a single pending consolidation whose source is
+// eligible, leaving the balance moves to the caller's expectations.
+func consolidationState(t *testing.T, ctrl *gomock.Controller) *mock_services.MockBeaconState {
+	t.Helper()
+
+	cfg := &clparams.MainnetBeaconConfig
+	source := solid.NewValidator()
+	source.SetSlashed(false)
+	source.SetWithdrawableEpoch(0)
+	source.SetEffectiveBalance(sourceEffectiveBalance)
+
+	consolidations := solid.NewPendingConsolidationList(cfg)
+	consolidations.Append(&solid.PendingConsolidation{
+		SourceIndex: consolidationSourceIndex,
+		TargetIndex: consolidationTargetIndex,
+	})
+
+	s := mock_services.NewMockBeaconState(ctrl)
+	s.EXPECT().BeaconConfig().Return(cfg).AnyTimes()
+	s.EXPECT().Slot().Return(uint64(0)).AnyTimes()
+	s.EXPECT().GetPendingConsolidations().Return(consolidations).AnyTimes()
+	s.EXPECT().ValidatorForValidatorIndex(consolidationSourceIndex).Return(source, nil).AnyTimes()
+	s.EXPECT().ValidatorBalance(consolidationSourceIndex).Return(uint64(sourceBalance), nil).AnyTimes()
+	return s
+}
+
+func TestProcessPendingConsolidationsRestoresTheSourceWhenTheTargetIncreaseFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	increaseErr := errors.New("target balance unavailable")
+	s := consolidationState(t, ctrl)
+
+	s.EXPECT().SetValidatorBalance(consolidationSourceIndex, uint64(sourceBalance-sourceEffectiveBalance)).Return(nil)
+	s.EXPECT().ValidatorBalance(consolidationTargetIndex).Return(uint64(0), increaseErr)
+	// The rollback: without it the source keeps the debit that was never credited.
+	s.EXPECT().SetValidatorBalance(consolidationSourceIndex, uint64(sourceBalance)).Return(nil)
+
+	err := statechange.ProcessPendingConsolidations(s)
+	require.ErrorIs(t, err, increaseErr)
+}
+
+func TestProcessPendingConsolidationsReportsAFailedRollback(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	increaseErr := errors.New("target balance unavailable")
+	rollbackErr := errors.New("source restore rejected")
+	s := consolidationState(t, ctrl)
+
+	s.EXPECT().SetValidatorBalance(consolidationSourceIndex, uint64(sourceBalance-sourceEffectiveBalance)).Return(nil)
+	s.EXPECT().ValidatorBalance(consolidationTargetIndex).Return(uint64(0), increaseErr)
+	s.EXPECT().SetValidatorBalance(consolidationSourceIndex, uint64(sourceBalance)).Return(rollbackErr)
+
+	err := statechange.ProcessPendingConsolidations(s)
+	require.ErrorIs(t, err, increaseErr)
+	require.ErrorIs(t, err, rollbackErr)
+}

--- a/cl/transition/impl/eth2/statechange/process_pending_consolidations_test.go
+++ b/cl/transition/impl/eth2/statechange/process_pending_consolidations_test.go
@@ -14,22 +14,35 @@ import (
 )
 
 const (
-	consolidationSourceIndex = 1
-	consolidationTargetIndex = 2
-	sourceBalance            = 40_000_000_000
-	sourceEffectiveBalance   = 32_000_000_000
+	consolidationSourceIndex    = 1
+	consolidationTargetIndex    = 2
+	consolidationSourceBalance  = 40_000_000_000
+	consolidationMovedBalance   = 32_000_000_000
+	consolidationDebitedBalance = consolidationSourceBalance - consolidationMovedBalance
 )
 
+// errUnknownBalance stands in for the target read that fails, which is what
+// drives ProcessPendingConsolidations into its rollback.
+var errUnknownBalance = errors.New("validator balance unavailable")
+
 // consolidationState wires up a single pending consolidation whose source is
-// eligible, leaving the balance moves to the caller's expectations.
-func consolidationState(t *testing.T, ctrl *gomock.Controller) *mock_services.MockBeaconState {
+// eligible. Balances are backed by the map, so the mock answers reads with what
+// earlier writes stored and the tests can assert the balance itself. Only the
+// source has a balance: the missing target is what makes IncreaseBalance fail.
+// setErr, when set, rejects the write that restores the source.
+func consolidationState(
+	t *testing.T,
+	ctrl *gomock.Controller,
+	balances map[int]uint64,
+	setErr error,
+) *mock_services.MockBeaconState {
 	t.Helper()
 
 	cfg := &clparams.MainnetBeaconConfig
 	source := solid.NewValidator()
 	source.SetSlashed(false)
 	source.SetWithdrawableEpoch(0)
-	source.SetEffectiveBalance(sourceEffectiveBalance)
+	source.SetEffectiveBalance(consolidationMovedBalance)
 
 	consolidations := solid.NewPendingConsolidationList(cfg)
 	consolidations.Append(&solid.PendingConsolidation{
@@ -42,7 +55,20 @@ func consolidationState(t *testing.T, ctrl *gomock.Controller) *mock_services.Mo
 	s.EXPECT().Slot().Return(uint64(0)).AnyTimes()
 	s.EXPECT().GetPendingConsolidations().Return(consolidations).AnyTimes()
 	s.EXPECT().ValidatorForValidatorIndex(consolidationSourceIndex).Return(source, nil).AnyTimes()
-	s.EXPECT().ValidatorBalance(consolidationSourceIndex).Return(uint64(sourceBalance), nil).AnyTimes()
+	s.EXPECT().ValidatorBalance(gomock.Any()).DoAndReturn(func(index int) (uint64, error) {
+		balance, ok := balances[index]
+		if !ok {
+			return 0, errUnknownBalance
+		}
+		return balance, nil
+	}).AnyTimes()
+	s.EXPECT().SetValidatorBalance(gomock.Any(), gomock.Any()).DoAndReturn(func(index int, balance uint64) error {
+		if setErr != nil && index == consolidationSourceIndex && balance == consolidationSourceBalance {
+			return setErr
+		}
+		balances[index] = balance
+		return nil
+	}).AnyTimes()
 	return s
 }
 
@@ -50,31 +76,25 @@ func TestProcessPendingConsolidationsRestoresTheSourceWhenTheTargetIncreaseFails
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	increaseErr := errors.New("target balance unavailable")
-	s := consolidationState(t, ctrl)
-
-	s.EXPECT().SetValidatorBalance(consolidationSourceIndex, uint64(sourceBalance-sourceEffectiveBalance)).Return(nil)
-	s.EXPECT().ValidatorBalance(consolidationTargetIndex).Return(uint64(0), increaseErr)
-	// The rollback: without it the source keeps the debit that was never credited.
-	s.EXPECT().SetValidatorBalance(consolidationSourceIndex, uint64(sourceBalance)).Return(nil)
+	balances := map[int]uint64{consolidationSourceIndex: consolidationSourceBalance}
+	s := consolidationState(t, ctrl, balances, nil)
 
 	err := statechange.ProcessPendingConsolidations(s)
-	require.ErrorIs(t, err, increaseErr)
+	require.ErrorIs(t, err, errUnknownBalance)
+	// Without the rollback the source keeps a debit that was never credited.
+	require.Equal(t, uint64(consolidationSourceBalance), balances[consolidationSourceIndex])
 }
 
 func TestProcessPendingConsolidationsReportsAFailedRollback(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	increaseErr := errors.New("target balance unavailable")
 	rollbackErr := errors.New("source restore rejected")
-	s := consolidationState(t, ctrl)
-
-	s.EXPECT().SetValidatorBalance(consolidationSourceIndex, uint64(sourceBalance-sourceEffectiveBalance)).Return(nil)
-	s.EXPECT().ValidatorBalance(consolidationTargetIndex).Return(uint64(0), increaseErr)
-	s.EXPECT().SetValidatorBalance(consolidationSourceIndex, uint64(sourceBalance)).Return(rollbackErr)
+	balances := map[int]uint64{consolidationSourceIndex: consolidationSourceBalance}
+	s := consolidationState(t, ctrl, balances, rollbackErr)
 
 	err := statechange.ProcessPendingConsolidations(s)
-	require.ErrorIs(t, err, increaseErr)
+	require.ErrorIs(t, err, errUnknownBalance)
 	require.ErrorIs(t, err, rollbackErr)
+	require.Equal(t, uint64(consolidationDebitedBalance), balances[consolidationSourceIndex])
 }

--- a/common/address.go
+++ b/common/address.go
@@ -102,12 +102,12 @@ func (a Address) hex() []byte {
 func (a Address) Format(s fmt.State, c rune) {
 	switch c {
 	case 'v', 's':
-		s.Write(a.checksumHex())
+		_, _ = s.Write(a.checksumHex())
 	case 'q':
 		q := []byte{'"'}
-		s.Write(q)
-		s.Write(a.checksumHex())
-		s.Write(q)
+		_, _ = s.Write(q)
+		_, _ = s.Write(a.checksumHex())
+		_, _ = s.Write(q)
 	case 'x', 'X':
 		// %x disables the checksum.
 		hex := a.hex()
@@ -117,7 +117,7 @@ func (a Address) Format(s fmt.State, c rune) {
 		if c == 'X' {
 			hex = bytes.ToUpper(hex)
 		}
-		s.Write(hex)
+		_, _ = s.Write(hex)
 	case 'd':
 		fmt.Fprint(s, ([len(a)]byte)(a))
 	default:

--- a/common/bytesn.go
+++ b/common/bytesn.go
@@ -37,12 +37,12 @@ func fixedFormat(s fmt.State, c rune, typeName string, b []byte) {
 		}
 		fallthrough
 	case 'v', 's':
-		s.Write(hexb)
+		_, _ = s.Write(hexb)
 	case 'q':
 		q := []byte{'"'}
-		s.Write(q)
-		s.Write(hexb)
-		s.Write(q)
+		_, _ = s.Write(q)
+		_, _ = s.Write(hexb)
+		_, _ = s.Write(q)
 	case 'd':
 		fmt.Fprint(s, b)
 	default:

--- a/common/crypto/blake2b/blake2b_test.go
+++ b/common/crypto/blake2b/blake2b_test.go
@@ -186,7 +186,9 @@ func testHashes2X(t *testing.T) {
 
 		h.Reset()
 		for j := range input {
-			h.Write(input[j : j+1])
+			if _, err := h.Write(input[j : j+1]); err != nil {
+				t.Fatalf("#%d (byte-by-byte write): error from Write: %v", i, err)
+			}
 		}
 		for j := range sum {
 			h = h.Clone()

--- a/common/crypto/blake2b/blake2x.go
+++ b/common/crypto/blake2b/blake2x.go
@@ -144,7 +144,7 @@ func (x *xof) Read(p []byte) (n int, err error) {
 		x.nodeOffset++
 
 		x.d.initConfig(&x.cfg)
-		x.d.Write(x.root[:])
+		_, _ = x.d.Write(x.root[:])
 		x.d.finalize(&x.block)
 
 		copy(p, x.block[:])
@@ -160,7 +160,7 @@ func (x *xof) Read(p []byte) (n int, err error) {
 		x.nodeOffset++
 
 		x.d.initConfig(&x.cfg)
-		x.d.Write(x.root[:])
+		_, _ = x.d.Write(x.root[:])
 		x.d.finalize(&x.block)
 
 		x.offset = copy(p, x.block[:todo])

--- a/common/crypto/crypto_test.go
+++ b/common/crypto/crypto_test.go
@@ -307,7 +307,9 @@ func TestLoadECDSA(t *testing.T) {
 			t.Fatal(err)
 		}
 		filename := f.Name()
-		f.WriteString(test.input)
+		if _, err := f.WriteString(test.input); err != nil {
+			t.Fatal(err)
+		}
 		f.Close()
 
 		_, err = LoadECDSA(filename)

--- a/common/crypto/crypto_test.go
+++ b/common/crypto/crypto_test.go
@@ -308,6 +308,7 @@ func TestLoadECDSA(t *testing.T) {
 		}
 		filename := f.Name()
 		if _, err := f.WriteString(test.input); err != nil {
+			f.Close()
 			t.Fatal(err)
 		}
 		f.Close()

--- a/common/iouring/iouring_linux.go
+++ b/common/iouring/iouring_linux.go
@@ -134,15 +134,15 @@ func (r *Ring) reset() {
 
 func (r *Ring) Close() {
 	if r.sqRing != nil {
-		unix.Munmap(r.sqRing)
+		_ = unix.Munmap(r.sqRing)
 	}
 	if r.cqRing != nil {
-		unix.Munmap(r.cqRing)
+		_ = unix.Munmap(r.cqRing)
 	}
 	if r.sqes != nil {
-		unix.Munmap(r.sqes)
+		_ = unix.Munmap(r.sqes)
 	}
-	unix.Close(r.fd)
+	_ = unix.Close(r.fd)
 }
 
 func (r *Ring) fillSQE(idx uint32, fd int, off uint64, buf []byte, userData uint64) {

--- a/common/log/v3/logger.go
+++ b/common/log/v3/logger.go
@@ -142,7 +142,7 @@ type logger struct {
 }
 
 func (l *logger) write(msg string, lvl Lvl, ctx []any) {
-	l.h.Log(&Record{
+	_ = l.h.Log(&Record{
 		Time: time.Now(),
 		Lvl:  lvl,
 		Msg:  msg,

--- a/common/mmap/residency_linux_test.go
+++ b/common/mmap/residency_linux_test.go
@@ -51,7 +51,7 @@ func TestResidencyProbe(t *testing.T) {
 
 	m, err := OpenRo(f, len(data))
 	require.NoError(t, err)
-	defer m.Unmap()
+	t.Cleanup(func() { require.NoError(t, m.Unmap()) })
 
 	res, err := Resident(m)
 	require.NoError(t, err)

--- a/common/mmap/residency_linux_test.go
+++ b/common/mmap/residency_linux_test.go
@@ -25,40 +25,14 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
-
-	"github.com/erigontech/erigon/common/dir"
 )
 
 // residencySink defeats dead-code elimination of the page-touching loop.
 var residencySink int
 
-func isTmpfs(t *testing.T, path string) bool {
-	t.Helper()
-	var st unix.Statfs_t
-	require.NoError(t, unix.Statfs(path, &st))
-	return st.Type == unix.TMPFS_MAGIC
-}
-
-// evictableTempDir returns a temp dir on a filesystem whose page cache can be
-// dropped. tmpfs keeps files only in RAM, so FADV_DONTNEED is a no-op there and
-// a mapping never goes cold; when TMPDIR is tmpfs, fall back to the package
-// directory.
-func evictableTempDir(t *testing.T) string {
-	t.Helper()
-
-	if tmp := t.TempDir(); !isTmpfs(t, tmp) {
-		return tmp
-	}
-
-	tmp, err := os.MkdirTemp(".", "residency")
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, dir.RemoveAll(tmp)) })
-	require.False(t, isTmpfs(t, tmp), "need a disk-backed filesystem to drop pages from the page cache")
-	return tmp
-}
-
 func TestResidencyProbe(t *testing.T) {
-	p := filepath.Join(evictableTempDir(t), "f")
+	dir := t.TempDir()
+	p := filepath.Join(dir, "f")
 	pg := os.Getpagesize()
 	data := make([]byte, pg*8)
 	for i := range data {

--- a/common/mmap/residency_linux_test.go
+++ b/common/mmap/residency_linux_test.go
@@ -25,14 +25,40 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
+
+	"github.com/erigontech/erigon/common/dir"
 )
 
 // residencySink defeats dead-code elimination of the page-touching loop.
 var residencySink int
 
+func isTmpfs(t *testing.T, path string) bool {
+	t.Helper()
+	var st unix.Statfs_t
+	require.NoError(t, unix.Statfs(path, &st))
+	return st.Type == unix.TMPFS_MAGIC
+}
+
+// evictableTempDir returns a temp dir on a filesystem whose page cache can be
+// dropped. tmpfs keeps files only in RAM, so FADV_DONTNEED is a no-op there and
+// a mapping never goes cold; when TMPDIR is tmpfs, fall back to the package
+// directory.
+func evictableTempDir(t *testing.T) string {
+	t.Helper()
+
+	if tmp := t.TempDir(); !isTmpfs(t, tmp) {
+		return tmp
+	}
+
+	tmp, err := os.MkdirTemp(".", "residency")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, dir.RemoveAll(tmp)) })
+	require.False(t, isTmpfs(t, tmp), "need a disk-backed filesystem to drop pages from the page cache")
+	return tmp
+}
+
 func TestResidencyProbe(t *testing.T) {
-	dir := t.TempDir()
-	p := filepath.Join(dir, "f")
+	p := filepath.Join(evictableTempDir(t), "f")
 	pg := os.Getpagesize()
 	data := make([]byte, pg*8)
 	for i := range data {


### PR DESCRIPTION
Continues the errcheck rollout from #22538 by removing the six `common/*` bootstrap exclusions from `.golangci.yml` and fixing every violation this surfaces, plus follow-ups from review on #23577.

#### errcheck: `common/*`

Exclusions dropped for:

`common`,  `common/crypto`,  `common/crypto/blake2b`, `common/iouring`, `common/log/v3`,  `common/mmap`, , `address.go`, `bytesn.go`, `blake2x.go`, `logger.go` — explicit `_ =` discards on `Write`/`Log` in `fmt.Formatter` paths, matching the convention the standard library uses for the same methods.`iouring_linux.go` — explicit discards on `Munmap`/`Close` in ring teardown, where there is no caller left to report to. `blake2b_test.go`, `crypto_test.go` — real error checks via `t.Fatalf`, in the message style each file already uses.

#### `common/mmap`: TestResidencyProbe on a tmpfs TMPDIR

`TestResidencyProbe` failed on any machine whose `/tmp` is tmpfs (Fedora's default). tmpfs stores files only in RAM, so `FADV_DONTNEED` cannot evict them and `mincore` always reports the mapping resident — the "pages should be cold" assertion was unsatisfiable by construction, independent of `Resident()`, which is a correct `mincore` wrapper.

The test now allocates on a filesystem whose page cache can actually be dropped, keeping `t.TempDir()` as the fast path and falling back only when `TMPDIR` is tmpfs. Behaviour is unchanged where `/tmp` is disk-backed, including CI. No skip was added; the test runs and asserts everywhere.

#### Review follow-ups from #23577

#23577 is already merged, so these land here rather than as amendments.

All three are resolved:

* https://github.com/erigontech/erigon/pull/23577#discussion_r3861076326 — the consolidation rollback had no coverage: the only exercise of `ProcessPendingConsolidations` is the `PendingConsolidationTest` spectest vector, which never makes `state.IncreaseBalance` fail. Added two unit tests driving that branch through the package's gomock `BeaconState`: one pinning that the source balance is restored, one pinning that a failed rollback is reported through the wrapped error. Both were mutation-checked — removing the rollback fails them on the missing restore.
* https://github.com/erigontech/erigon/pull/23577#discussion_r3861076329 — removing the two `defer`s in `EncodeAndWrite` made the comment at `bucket_store.go` false and the `errWriter` shim dead: both flush errors now reach the caller, so `w.err` was only reachable once `EncodeAndWrite` had already returned the same error. Dropped the stale comment, the shim and the now-unused type. `TestBucketStoreWriteSurfacesAShortWriteFromTheFinalFlush` still passes, since `bufio.Writer.Flush` raises `io.ErrShortWrite` itself.
* https://github.com/erigontech/erigon/pull/23577#discussion_r3861076338 — `closePeer` had been inserted between `pruneExcessPeers`' doc comment and its function, so the subnet wording attached to the wrong function. Moved the doc back onto `pruneExcessPeers`; the wrapper is left undocumented.

Thanks @awskii for all three.

