### PR TITLE
execution/exec: stop retries from consuming the fresh-task dispatch budget

### DIFF
--- a/execution/exec/txtask.go
+++ b/execution/exec/txtask.go
@@ -852,12 +852,13 @@ func (q *QueueWithRetry) ReTry(t Task) {
 		return
 	}
 	heap.Push(&q.retires, t)
-	wake := q.wake
-	q.lock.Unlock()
+	// Send under the lock: a consumer that pops this task before its token exists
+	// leaves the token behind, and a token without a task wakes a worker for nothing.
 	select {
-	case wake <- struct{}{}:
+	case q.wake <- struct{}{}:
 	default:
 	}
+	q.lock.Unlock()
 }
 
 // Next - blocks until new task available

--- a/execution/exec/txtask.go
+++ b/execution/exec/txtask.go
@@ -889,8 +889,13 @@ func (q *QueueWithRetry) popWait(ctx context.Context) (task Task, ok bool) {
 
 		select {
 		case <-wake:
-			if retry, has := q.popNoWait(); has {
-				return retry, true
+			q.lock.Lock()
+			if q.retires.Len() > 0 {
+				task = heap.Pop(&q.retires).(Task)
+			}
+			q.lock.Unlock()
+			if task != nil {
+				return task, true
 			}
 		case inTask, ok := <-newTasks:
 			if !ok {
@@ -920,9 +925,16 @@ func (q *QueueWithRetry) popNoWait() (task Task, ok bool) {
 		task = heap.Pop(&q.retires).(Task)
 	}
 	newTasks := q.newTasks
+	wake := q.wake
 	q.lock.Unlock()
 
 	if has {
+		// Balance the token ReTry pushed for this task: a token that outlives
+		// its task parks and unparks a worker that has nothing to do.
+		select {
+		case <-wake:
+		default:
+		}
 		return task, task != nil
 	}
 

--- a/execution/exec/txtask.go
+++ b/execution/exec/txtask.go
@@ -753,6 +753,7 @@ type QueueWithRetry struct {
 	closed   bool
 	newTasks chan Task
 	parked   chan Task
+	wake     chan struct{}
 	retires  Queue[Task]
 	lock     sync.Mutex
 	capacity int
@@ -761,13 +762,17 @@ type QueueWithRetry struct {
 var queuePool sync.Pool
 
 func NewQueueWithRetry(capacity int) *QueueWithRetry {
-	return &QueueWithRetry{newTasks: make(chan Task, capacity), capacity: capacity}
+	return &QueueWithRetry{
+		newTasks: make(chan Task, capacity),
+		wake:     make(chan struct{}, capacity),
+		capacity: capacity,
+	}
 }
 
 func GetQueueWithRetryFromPool(capacity int) *QueueWithRetry {
 	if v := queuePool.Get(); v != nil {
 		q := v.(*QueueWithRetry)
-		if q.capacity == capacity && q.parked != nil {
+		if q.capacity == capacity && q.parked != nil && q.wake != nil {
 			q.closed = false
 			q.newTasks = q.parked
 			q.parked = nil
@@ -779,8 +784,9 @@ func GetQueueWithRetryFromPool(capacity int) *QueueWithRetry {
 
 func (q *QueueWithRetry) NewTasksLen() int {
 	q.lock.Lock()
-	defer q.lock.Unlock()
-	return len(q.newTasks)
+	newTasks := q.newTasks
+	q.lock.Unlock()
+	return len(newTasks)
 }
 func (q *QueueWithRetry) Capacity() int { return q.capacity }
 func (q *QueueWithRetry) RetriesLen() (l int) {
@@ -846,10 +852,10 @@ func (q *QueueWithRetry) ReTry(t Task) {
 		return
 	}
 	heap.Push(&q.retires, t)
-	newTasks := q.newTasks
+	wake := q.wake
 	q.lock.Unlock()
 	select {
-	case newTasks <- nil:
+	case wake <- struct{}{}:
 	default:
 	}
 }
@@ -875,12 +881,17 @@ func (q *QueueWithRetry) popWait(ctx context.Context) (task Task, ok bool) {
 	for {
 		q.lock.Lock()
 		newTasks := q.newTasks
+		wake := q.wake
 		q.lock.Unlock()
 		if newTasks == nil {
 			return q.popNoWait()
 		}
 
 		select {
+		case <-wake:
+			if retry, has := q.popNoWait(); has {
+				return retry, true
+			}
 		case inTask, ok := <-newTasks:
 			if !ok {
 				return q.popNoWait()
@@ -955,6 +966,9 @@ func (q *QueueWithRetry) Release() {
 	// Drain channel.
 	for len(q.newTasks) > 0 {
 		<-q.newTasks
+	}
+	for len(q.wake) > 0 {
+		<-q.wake
 	}
 	// Clear retry heap, keep backing array.
 	clear(q.retires)

--- a/execution/exec/txtask_test.go
+++ b/execution/exec/txtask_test.go
@@ -19,6 +19,9 @@ package exec
 import (
 	"context"
 	"fmt"
+	"runtime"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -277,7 +280,8 @@ func TestHistoricalBlockEndLogs(t *testing.T) {
 
 type queueStubTask struct {
 	Task
-	txNum uint64
+	txNum     uint64
+	remaining int
 }
 
 func (s *queueStubTask) Version() state.Version { return state.Version{TxNum: s.txNum} }
@@ -327,4 +331,109 @@ func TestQueueWithRetryServesRetriesFirst(t *testing.T) {
 	}
 	require.Equal(t, []uint64{3, 7, 100}, got)
 	require.Equal(t, 0, q.Len())
+}
+
+// Measures the fresh-task capacity the retry path takes away from the
+// dispatcher. The budget expression mirrors blockExecutor.scheduleExecution.
+func TestQueueWithRetryBudgetUnderRetryLoad(t *testing.T) {
+	const capacity = 64
+
+	for _, retries := range []int{1, 8, 32, capacity} {
+		t.Run(fmt.Sprintf("retries=%d", retries), func(t *testing.T) {
+			q := NewQueueWithRetry(capacity)
+			defer q.Close()
+
+			for i := range retries {
+				q.ReTry(&queueStubTask{txNum: uint64(i)})
+			}
+			for range retries {
+				task, ok := q.Next(context.Background())
+				require.True(t, ok)
+				require.NotNil(t, task)
+			}
+			require.Equal(t, 0, q.RetriesLen())
+
+			budget := q.Capacity() - q.NewTasksLen()
+			t.Logf("served %d retries: budget %d/%d, lost %d slots", retries, budget, capacity, capacity-budget)
+			require.Equal(t, capacity, budget)
+		})
+	}
+}
+
+func BenchmarkQueueWithRetryDispatch(b *testing.B) {
+	const (
+		capacity = 2_048
+		workers  = 4
+	)
+
+	type dim struct {
+		retriesPerTask int
+		workPerTask    int
+	}
+	for _, d := range []dim{{0, 0}, {1, 0}, {4, 0}, {1, 2_000}, {4, 2_000}} {
+		retriesPerTask, workPerTask := d.retriesPerTask, d.workPerTask
+		b.Run(fmt.Sprintf("retriesPerTask=%d/work=%d", retriesPerTask, workPerTask), func(b *testing.B) {
+			q := NewQueueWithRetry(capacity)
+			var done atomic.Int64
+			var wg sync.WaitGroup
+
+			for range workers {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					for {
+						task, ok := q.Next(context.Background())
+						if !ok {
+							return
+						}
+						stub := task.(*queueStubTask)
+						queueBenchSink += busyWork(workPerTask)
+						if stub.remaining > 0 {
+							stub.remaining--
+							q.ReTry(stub)
+							continue
+						}
+						done.Add(1)
+					}
+				}()
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; {
+				budget := q.Capacity() - q.NewTasksLen()
+				if budget <= 0 {
+					runtime.Gosched()
+					continue
+				}
+				for range budget {
+					if i == b.N {
+						break
+					}
+					if !q.TryAdd(&queueStubTask{txNum: uint64(i), remaining: retriesPerTask}) {
+						break
+					}
+					i++
+				}
+			}
+			for done.Load() < int64(b.N) {
+				runtime.Gosched()
+			}
+			b.StopTimer()
+
+			q.Close()
+			wg.Wait()
+		})
+	}
+}
+
+var queueBenchSink uint64
+
+// busyWork stands in for the EVM execution a real task carries, so the
+// benchmark does not report queue overhead as if it were the whole cost.
+func busyWork(iterations int) uint64 {
+	var x uint64 = 1
+	for range iterations {
+		x = x*6364136223846793005 + 1442695040888963407
+	}
+	return x
 }

--- a/execution/exec/txtask_test.go
+++ b/execution/exec/txtask_test.go
@@ -378,9 +378,7 @@ func BenchmarkQueueWithRetryDispatch(b *testing.B) {
 			var wg sync.WaitGroup
 
 			for range workers {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+				wg.Go(func() {
 					for {
 						task, ok := q.Next(context.Background())
 						if !ok {
@@ -395,7 +393,7 @@ func BenchmarkQueueWithRetryDispatch(b *testing.B) {
 						}
 						done.Add(1)
 					}
-				}()
+				})
 			}
 
 			b.ResetTimer()

--- a/execution/exec/txtask_test.go
+++ b/execution/exec/txtask_test.go
@@ -274,3 +274,57 @@ func TestHistoricalBlockEndLogs(t *testing.T) {
 		})
 	}
 }
+
+type queueStubTask struct {
+	Task
+	txNum uint64
+}
+
+func (s *queueStubTask) Version() state.Version { return state.Version{TxNum: s.txNum} }
+func (s *queueStubTask) isNil() bool            { return s == nil }
+func (s *queueStubTask) compare(other Task) int {
+	switch {
+	case s.txNum > other.Version().TxNum:
+		return 1
+	case s.txNum < other.Version().TxNum:
+		return -1
+	default:
+		return 0
+	}
+}
+
+// Retries live in the unbounded heap, so they must leave the whole input
+// capacity free for fresh tasks - the dispatch budget is derived from it.
+func TestQueueWithRetryRetriesDontConsumeNewTaskCapacity(t *testing.T) {
+	const capacity = 8
+	q := NewQueueWithRetry(capacity)
+	defer q.Close()
+
+	for i := range capacity {
+		q.ReTry(&queueStubTask{txNum: uint64(i)})
+	}
+
+	require.Equal(t, capacity, q.RetriesLen())
+	require.Equal(t, 0, q.NewTasksLen())
+	require.True(t, q.TryAdd(&queueStubTask{txNum: 100}))
+}
+
+func TestQueueWithRetryServesRetriesFirst(t *testing.T) {
+	q := NewQueueWithRetry(8)
+	defer q.Close()
+
+	require.True(t, q.TryAdd(&queueStubTask{txNum: 100}))
+	q.ReTry(&queueStubTask{txNum: 7})
+	q.ReTry(&queueStubTask{txNum: 3})
+
+	ctx := context.Background()
+	var got []uint64
+	for range 3 {
+		task, ok := q.Next(ctx)
+		require.True(t, ok)
+		require.NotNil(t, task)
+		got = append(got, task.Version().TxNum)
+	}
+	require.Equal(t, []uint64{3, 7, 100}, got)
+	require.Equal(t, 0, q.Len())
+}

--- a/execution/exec/txtask_test.go
+++ b/execution/exec/txtask_test.go
@@ -379,13 +379,15 @@ func BenchmarkQueueWithRetryDispatch(b *testing.B) {
 
 			for range workers {
 				wg.Go(func() {
+					var sink uint64
+					defer func() { queueBenchSink.Add(sink) }()
 					for {
 						task, ok := q.Next(context.Background())
 						if !ok {
 							return
 						}
 						stub := task.(*queueStubTask)
-						queueBenchSink += busyWork(workPerTask)
+						sink += busyWork(workPerTask)
 						if stub.remaining > 0 {
 							stub.remaining--
 							q.ReTry(stub)
@@ -424,7 +426,7 @@ func BenchmarkQueueWithRetryDispatch(b *testing.B) {
 	}
 }
 
-var queueBenchSink uint64
+var queueBenchSink atomic.Uint64
 
 // busyWork stands in for the EVM execution a real task carries, so the
 // benchmark does not report queue overhead as if it were the whole cost.


### PR DESCRIPTION
`QueueWithRetry.ReTry` woke waiters by pushing a `nil` task into `newTasks`. That slot stays occupied until the retry heap drains, so `NewTasksLen()` stays inflated, and `scheduleExecution` derives `budget := Capacity() - NewTasksLen()` from it — each served retry permanently costs one of 2048 fresh incarnation-0 slots, up to a full stall once retries reach capacity. The invariant its own comment states did not hold.

Retries now wake through a dedicated `wake chan struct{}`; the pop path drops the token together with the task, so a token never outlives its task.

Correctness only, not a speed-up: on n0 (mainnet 7,892,971 → 7,894,971, 4 interleaved rounds per arm) the arms are indistinguishable — 88.26s ± 4.10 vs 86.43s ± 1.66, Welch t=0.83 — with identical repeat% and dispatch count. In practice the heap empties often enough that sentinel occupancy never nears capacity. `BenchmarkQueueWithRetryDispatch` shows the extra channel costs ~100-300ns/task with no task work, and is flat once a task does ~1us of work.

`TestQueueWithRetryBudgetUnderRetryLoad` pins the loss at one input slot per served retry.
