### PR TITLE
[r3.6] PORTING OF PR #22919

### DIFF
--- a/docs/site/docs/fundamentals/caplin.md
+++ b/docs/site/docs/fundamentals/caplin.md
@@ -53,3 +53,9 @@ When Caplin is running, it exposes a Beacon API that external tools can query. T
 | `--beacon.api.read.timeout` | `5` | HTTP server read timeout, in seconds |
 | `--beacon.api.write.timeout` | `31536000` | HTTP server write timeout, in seconds (~1 year) |
 | `--beacon.api.idle.timeout` | `25` | HTTP server idle timeout, in seconds |
+
+The API is not served until you enable it with `--beacon.api=<namespaces>`; see [Caplin for staking](../staking/caplin) for the full namespace list.
+
+:::note
+Enabling the Beacon API increases RAM usage by roughly **6 GB**. Account for it when sizing your host — see [Hardware Requirements](../get-started/hardware-requirements).
+:::

--- a/docs/site/docs/fundamentals/configuring-erigon.mdx
+++ b/docs/site/docs/fundamentals/configuring-erigon.mdx
@@ -618,7 +618,7 @@ http = true
 Erigon supports configuration through environment variables, primarily for experimental features and advanced settings.
 
 :::tip
-Erigon's own variables — everything below except the [Docker](#docker-environment-variables) ones, which do not take the `ERIGON_` prefix — can be set with or without it. `ERIGON_SNAPSHOT_MADV_RND` and `SNAPSHOT_MADV_RND` both work. Prefer the prefixed form: Erigon logs a warning when it reads the bare name, and the prefix keeps these from colliding with unrelated variables in your environment. The examples below use it.
+Erigon's own variables — everything below except the [Docker](#docker-environment-variables) ones, which do not take the `ERIGON_` prefix — can be set with or without it. `ERIGON_SNAPSHOT_MADV_RND` and `SNAPSHOT_MADV_RND` both work. Prefer the prefixed form. Erigon logs every variable it reads at warn level either way, but the bare name draws an extra `use ERIGON_ prefix for env` warning on top, and the prefix keeps these from colliding with unrelated variables in your environment. The examples below use it.
 :::
 
 ### Core Environment Variables

--- a/docs/site/docs/fundamentals/configuring-erigon.mdx
+++ b/docs/site/docs/fundamentals/configuring-erigon.mdx
@@ -300,9 +300,9 @@ Flags for configuring various RPC servers and their behavior. See [Interacting w
   * Default: `10000`
 * `--rpc.subscription.filters.maxtxs value`: Maximum transactions to store per subscription.
   * Default: `10000`
-* `--rpc.subscription.filters.maxaddresses value`: Maximum addresses per subscription to filter logs by.
+* `--rpc.subscription.filters.maxaddresses value`: Maximum addresses accepted per log subscription.
   * Default: `0`
-* `--rpc.subscription.filters.maxtopics value`: Maximum topics per subscription to filter logs by.
+* `--rpc.subscription.filters.maxtopics value`: Maximum topic alternatives accepted across all positions per log subscription.
   * Default: `0`
 * `--rpc.subscription.filters.timeout value`: Timeout before idle subscription filters are evicted.
   * Default: `5m0s`
@@ -617,6 +617,10 @@ http = true
 
 Erigon supports configuration through environment variables, primarily for experimental features and advanced settings.
 
+:::tip
+Erigon's own variables — everything below except the [Docker](#docker-environment-variables) ones, which do not take the `ERIGON_` prefix — can be set with or without it. `ERIGON_SNAPSHOT_MADV_RND` and `SNAPSHOT_MADV_RND` both work. Prefer the prefixed form: Erigon logs a warning when it reads the bare name, and the prefix keeps these from colliding with unrelated variables in your environment. The examples below use it.
+:::
+
 ### Core Environment Variables
 
 **Database and Performance:**
@@ -686,16 +690,16 @@ When running Erigon in [Docker](/fundamentals/docker-compose), you can configure
 **Basic Performance Tuning:**
 
 ```bash
-export MDBX_LOCK_IN_RAM=true
-export SNAPSHOT_MADV_RND=false
+export ERIGON_MDBX_LOCK_IN_RAM=true
+export ERIGON_SNAPSHOT_MADV_RND=false
 ./build/bin/erigon --datadir=/path/to/data
 ```
 
 **Memory Debugging:**
 
 ```bash
-export SAVE_HEAP_PROFILE=true
-export HEAP_PROFILE_THRESHOLD=45
+export ERIGON_SAVE_HEAP_PROFILE=true
+export ERIGON_HEAP_PROFILE_THRESHOLD=45
 ./build/bin/erigon --datadir=/path/to/data
 ```
 

--- a/docs/site/docs/fundamentals/database.md
+++ b/docs/site/docs/fundamentals/database.md
@@ -98,7 +98,7 @@ Deleting `chaindata/` is **recoverable but not free**: it discards the latest mu
 
 ## Tuning knobs
 
-- **`--batchSize`** — size of the Execution stage's in-memory buffer before it is flushed to MDBX. Default: `512M`. Raising it (for example `--batchSize 1G` or higher) can speed up execution-heavy sync at the cost of more RAM.
+- **`--batchSize`** — size of the Execution stage's in-memory buffer before it is flushed to MDBX. Default: `512M`. Raising it (for example `--batchSize 1G` or higher) can speed up execution-heavy sync at the cost of more RAM. It is the Execution stage's commit threshold, so a larger value means larger single MDBX write transactions, which raise the file's high-water mark in bigger steps. Keeping it at or below `1G` is a useful heuristic if you want MDBX to grow more gradually.
 - **`--db.size.limit`** — caps the MDBX file size. Useful when running multiple Erigon instances on one disk to prevent one from starving the others.
 - **`--db.read.concurrency`** — maximum number of concurrent open MDBX read transactions (the read-tx semaphore). Raise it for nodes serving heavy parallel RPC (for example a high-throughput RPC daemon against the same datadir); low values are fine for low-read-concurrency nodes such as validators.
 - **Symlinks for tiered storage.** Place `chaindata/` and `snapshots/domain/` on fast NVMe, leave `snapshots/idx/` and `snapshots/history/` on cheaper SATA. See [Optimizing Storage](optimizing-storage) for the recipe.

--- a/docs/site/docs/fundamentals/logs.md
+++ b/docs/site/docs/fundamentals/logs.md
@@ -31,6 +31,10 @@ Erigon provides extensive logging configuration through command-line flags. Key 
 * `--log.dir.verbosity`: Set file log level (default: `dbug`)
 * `--log.delays`: Enable block delay logging
 
+**Downloader (torrent) logs**
+
+The torrent client inside the Downloader keeps its own JSON-formatted file, `logs/torrent.log`. It is written at whichever is **more verbose** of `--torrent.verbosity` and `WARN`, so warnings and errors always reach it even at the default verbosity. Messages at `--torrent.verbosity` or above are additionally forwarded to Erigon's own file and console loggers, which emit them only if `--log.dir.verbosity` and `--verbosity` are themselves set to a verbose enough level.
+
 **Log Levels**
 
 The logging system defines six distinct log levels in hierarchical order:

--- a/docs/site/docs/fundamentals/logs.md
+++ b/docs/site/docs/fundamentals/logs.md
@@ -33,7 +33,7 @@ Erigon provides extensive logging configuration through command-line flags. Key 
 
 **Downloader (torrent) logs**
 
-The torrent client inside the Downloader keeps its own JSON-formatted file, `logs/torrent.log`. It is written at whichever is **more verbose** of `--torrent.verbosity` and `WARN`, so warnings and errors always reach it even at the default verbosity. Messages at `--torrent.verbosity` or above are additionally forwarded to Erigon's own file and console loggers, which emit them only if `--log.dir.verbosity` and `--verbosity` are themselves set to a verbose enough level.
+The torrent client inside the Downloader keeps its own JSON-formatted file at `<datadir>/logs/torrent.log`. The path is built from the datadir and does **not** follow `--log.dir.path`, so it stays there even when Erigon's own logs are redirected elsewhere. It is written at whichever is **more verbose** of `--torrent.verbosity` and `WARN`, so warnings and errors always reach it even at the default verbosity. Messages at `--torrent.verbosity` or above are additionally forwarded to Erigon's own file and console loggers, which emit them only if `--log.dir.verbosity` and `--verbosity` are themselves set to a verbose enough level.
 
 **Log Levels**
 

--- a/docs/site/docs/fundamentals/multiple-instances.md
+++ b/docs/site/docs/fundamentals/multiple-instances.md
@@ -129,10 +129,17 @@ For Prometheus monitoring, each instance should expose metrics on different port
 
 If using network-attached storage, apply these optimizations:
 
+Set the environment variable before starting Erigon:
+
 ```bash
-# Reduce disk latency impact
-export SNAPSHOT_MADV_RND=false
---db.pagesize=64kb
+export ERIGON_SNAPSHOT_MADV_RND=false   # let the OS prefetch; needs spare RAM
+```
+
+And pass these flags:
+
+```bash
+--db.pagesize=64kb              # less fragmentation; must be set before the first sync
+--sync.loop.block.limit=10000   # blocks per loop iteration (default 5000)
 ```
 
 ### Memory Locking for Performance
@@ -167,7 +174,7 @@ What can be done:
   * use latency-critical cloud-drives
   * or attached-NVMe (at least for initial sync)
 * increase RAM
-* if you throw enough RAM, then can set env variable `SNAPSHOT_MADV_RND=false`
+* if you throw enough RAM, then can set env variable `ERIGON_SNAPSHOT_MADV_RND=false`
 * Use `--db.pagesize=64kb` (less fragmentation, more IO)
 * Or use Erigon 3 (it also sensitive for disk-latency - but it will download 99% of history)
 

--- a/docs/site/docs/fundamentals/optimizing-storage.md
+++ b/docs/site/docs/fundamentals/optimizing-storage.md
@@ -6,7 +6,7 @@ sidebar_position: 12
 
 # Optimizing Storage
 
-For optimal performance, it's recommended to store the datadir on a fast NVMe-RAID disk. However, if this is not feasible, you can store the history on a cheaper disk and still achieve good performance.
+For optimal performance, store the datadir on a single fast NVMe device formatted with ext4 or XFS — see [Filesystem](../get-started/hardware-requirements#filesystem). If that is not feasible, you can keep the history on a cheaper disk and still achieve good performance.
 
 ### Step 1
 

--- a/docs/site/docs/fundamentals/performance-tricks.md
+++ b/docs/site/docs/fundamentals/performance-tricks.md
@@ -24,10 +24,10 @@ These instructions are designed to improve the performance of Erigon 3, particul
 
 ## Optimize for Cloud Drives
 
-* Set `SNAPSHOT_MADV_RND=false` to enable the operating system's cache prefetching for better performance on cloud drives with good throughput but bad latency.
+* Set `ERIGON_SNAPSHOT_MADV_RND=false` to enable the operating system's cache prefetching for better performance on cloud drives with good throughput but bad latency.
 
 ```bash
-SNAPSHOT_MADV_RND=false
+export ERIGON_SNAPSHOT_MADV_RND=false
 ```
 
 ## Lock Latest State in RAM

--- a/docs/site/docs/fundamentals/security.md
+++ b/docs/site/docs/fundamentals/security.md
@@ -20,6 +20,10 @@ Based on best practices for execution clients, your local machine's firewall set
 | 8545     | TCP          | JSON-RPC (Public API)         | Block all traffic _except_ from explicitly defined trusted machines. This port should never be publicly exposed without strict controls. |
 | 9090     | TCP          | Private API Communication     | Block all traffic except for communication between your internal components (e.g., RPC Daemon and core node).                            |
 
+:::note
+Some hosting providers add firewall requirements and operational pitfalls on top of these. If you run on Hetzner Cloud or a Hetzner dedicated server, see the [Hetzner firewall note](/help-center/troubleshooting#hetzner-cloud--dedicated-server-firewall-note) for the ports their edge firewall must allow, and for the reserved IPv4 ranges worth blocking yourself so outbound dials do not trip their abuse detection.
+:::
+
 #### CORS Protection
 
 When exposing public RPC endpoints (like those on port 8545), use the following practice to mitigate cross-origin attacks:

--- a/docs/site/docs/get-started/hardware-requirements.mdx
+++ b/docs/site/docs/get-started/hardware-requirements.mdx
@@ -15,12 +15,53 @@ A locally mounted **SSD** (Solid-State Drive) or **NVMe** (Non-Volatile Memory E
 
 | Component | Recommendation | Notes |
 | --- | --- | --- |
-| Disk Type | Use high-end NVMe SSDs. | Avoid HDDs.SSD performance may degrade when nearing full capacity. |
-| Disk Configuration | RAID 0 for multiple disks (Speed) | High-Speed Option: RAID 0 provides maximum speed but no redundancy (data loss risk).ZFS filesystems may be considered for Archive nodes for their data integrity features, but complex RAID-Z setups are generally not recommended. |
+| Disk Type | Use high-end NVMe SSDs. | Avoid HDDs. SSD performance may degrade when nearing full capacity. |
+| Disk Configuration | A single NVMe device is enough for any pruning mode. | An archive node fits on one 4 TB drive, so RAID 0 striping is not needed. For failure protection, use a mirrored array, not RAID 0. See [Filesystem](#filesystem). |
+| Filesystem | ext4 or XFS | See [Filesystem](#filesystem) below. |
 | RAM | Adequate memory is crucial | Reduces bottlenecks during sync and improves performance under load. |
-| CPU | 4–8 cores for Full nodes8–16 cores for Archive nodes | More cores are generally better for intense sync and query operations. |
+| CPU | 4–8 cores for Full nodes, 8–16 cores for Archive nodes | More cores are generally better for intense sync and query operations. |
 | Linux | Kernel version > v4 | A modern Linux distribution is required. |
 
+
+## Filesystem
+
+Use **ext4** or **XFS** on a single NVMe device. The disk figures below are measured on ext4, and that is the configuration Erigon's own measurements come from. XFS is a reasonable choice on the same reasoning, but we have not measured it.
+
+Mount with `noatime` so reads do not generate metadata writes:
+
+```
+UUID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx  /data  ext4  defaults,noatime  0 2
+```
+
+Use the filesystem UUID (`blkid` prints it) rather than a `/dev/nvme…` name, which can move between boots. The final `2` is the `fsck` pass for a non-root filesystem.
+
+### Why the filesystem matters
+
+Erigon's bottleneck is disk **latency**, not throughput or IOPS — see [Improving Performance](/help-center/known-issues#improving-performance). Erigon does pre-warm what it can, but two properties of the workload mean its reads cannot be fully predicted, so part of every block's reads lands cold:
+
+* **EVM execution reads arbitrary state.** Nothing tells you in advance which accounts or storage slots a block will touch. Once the working set no longer fits in RAM, some of those reads land on cold data no cache had reason to hold.
+* **Merkle trie updates pull in neighbours.** Updating one key requires reading the nodes next to it in the trie. Those may be accounts the EVM never touches — they are involved only because of where they sit in the trie.
+
+Every layer the filesystem adds is added on top of each of those reads. That is what favours a thin filesystem here: ext4 and XFS store a file and leave caching to the OS page cache, which is what Erigon's memory-mapped database is built to use.
+
+### Filesystems to avoid
+
+Prefer a plain journaling filesystem over a copy-on-write or database-like one:
+
+* **ZFS** behaves more like a database than a filesystem. It keeps its own write-ahead log and its own cache (**ARC**), and that cache competes with the OS page cache for the same RAM. Optional features such as encryption and dedup add work to the read path this workload is bound by, and tuning ZFS for it is not a solved problem.
+* **Btrfs** is a copy-on-write B-tree of pages, and Erigon's MDBX database is itself a B-tree of pages, so you end up running a database inside a database. Its `autodefrag` feature is the sharpest edge: it can multiply write I/O by as much as 100x. See [Background File System Features Can Hurt Performance](/help-center/known-issues#background-file-system-features-can-hurt-performance).
+
+Filesystems other than ext4 and XFS are not part of what we measure, so treat their performance as unverified rather than assumed.
+
+A few more points that follow from Erigon's storage model — see [Database](../fundamentals/database) for the layout:
+
+* **One device is enough.** An archive node fits on a single 4 TB drive, so RAID 0 gains you no capacity you need while doubling the chance of losing the datadir. Stripe only if no single drive you have is large enough.
+* **For failure protection, use redundancy — not RAID 0.** A mirrored array and ECC memory guard against a failing disk or bad RAM, which is what [Best Practices](/help-center/best-practices) recommends. RAID 0 does the opposite.
+* **Most of the datadir is re-downloadable.** Snapshot files are content-addressed and refetched from peers, so `chaindata/` is the part worth backing up.
+* **Erigon memory-maps its database.** Leave RAM free for the page cache rather than handing it to a filesystem or volume manager to cache on its own.
+* **Network and cloud block storage are slow for block execution.** See [known issues](/help-center/known-issues#cloud-network-drives).
+
+If you must split the datadir across a fast and a slow device, see [Optimizing Storage](../fundamentals/optimizing-storage).
 
 ## Disk Size and RAM Requirements
 
@@ -81,3 +122,16 @@ Your internet bandwidth is also an important factor, particularly for sync speed
 | -------------- | -------------------- | ----------------------- |
 | Staking/Mining | 10 Mbps              | 50 Mbps                 |
 | Non-Staking    | 5 Mbps               | 25 Mbps                 |
+
+## Sync Times
+
+Approximate times to sync from scratch to the tip of the chain.
+
+| Chain    | Archive | Full (Default) | Minimal |
+| -------- | ------- | -------------- | ------- |
+| Ethereum | ~8 h    | ~4–6 h         | ~2 h    |
+| Gnosis   | ~2 h    | ~1–2 h         | ~30 m   |
+
+:::info
+These figures are indicative and are **not measured by CI** — read them as an order of magnitude, not a target. Most of the elapsed time is snapshot download rather than block execution, so your available [bandwidth](#bandwidth-requirements) influences the result more than CPU does: expect proportionally faster syncs on a well-connected host and slower ones on a constrained link.
+:::

--- a/docs/site/docs/get-started/hardware-requirements.mdx
+++ b/docs/site/docs/get-started/hardware-requirements.mdx
@@ -65,7 +65,7 @@ If you must split the datadir across a fast and a slow device, see [Optimizing S
 
 ## Disk Size and RAM Requirements
 
-The amount of disk space recommended and RAM you need depends on the [pruning mode](../fundamentals/pruning-modes) you want to run. **Current Disk Usage** values listed below are obtained using the standard Erigon + [Caplin](../fundamentals/caplin) configuration, with the sole exception of the `--prune.mode` flag.
+The amount of disk space recommended and RAM you need depends on the [pruning mode](../fundamentals/pruning-modes) you want to run. **Current Disk Usage** values listed below are obtained using the standard Erigon + [Caplin](../fundamentals/caplin) configuration, varying only the `--prune.mode` flag unless a tab notes otherwise.
 
 <Tabs>
 <TabItem value="ethereum-mainnet" label="Ethereum mainnet">

--- a/docs/site/docs/get-started/installation/index.mdx
+++ b/docs/site/docs/get-started/installation/index.mdx
@@ -357,13 +357,27 @@ make -j<n> erigon
 
 The resulting executable binary will be created in the `./build/bin/erigon` path.
 
+**2.4 Installing Outside the Build Tree (Optional)**
+
+Running Erigon as a [dedicated system user](/fundamentals/security) — for example under `systemd` — is easiest when the binaries live outside your source checkout, where that user can reach them. Pass a destination to `make install`:
+
+```sh
+make DIST=/opt/erigon install
+```
+
+`make install` creates the destination directory, so a path under `/opt` needs either `sudo make DIST=/opt/erigon install` or a directory you already own (`sudo install -d -o $USER /opt/erigon`). A path under `$HOME/erigon` avoids that entirely. `make install` copies whatever is currently in `build/bin`, so build every component you intend to deploy before running it.
+
+Once installed this way, run the installed copy — `/opt/erigon/erigon` — rather than the one in the build tree.
+
 **3. Running Erigon**
 
-After installation, you can run Erigon from your terminal:
+From the build tree, run Erigon from your terminal:
 
 ```sh
 ./build/bin/erigon [options]
 ```
+
+If you completed step 2.4, run the binary at your chosen `DIST` path instead.
 
 </details>
 

--- a/docs/site/help-center/troubleshooting.md
+++ b/docs/site/help-center/troubleshooting.md
@@ -44,7 +44,7 @@ kill -SIGUSR1 $(pidof erigon)
 # Stack traces are printed to the erigon log / stdout
 ```
 
-If the node is wedged and you are ready to lose it, `kill -SIGABRT <pid>` dumps the stacks and terminates that process in one step. Pass an explicit PID rather than `$(pidof erigon)`: `SIGABRT` is destructive, and on a host running more than one instance `pidof` would abort all of them.
+If the node is wedged and you are ready to lose it, `kill -SIGQUIT <pid>` dumps every goroutine stack and terminates that process in one step. Erigon wires a handler only for `SIGUSR1`, so `SIGQUIT` falls through to the Go runtime's own behaviour — the same one this repository's CI watchdog relies on. Pass an explicit PID rather than `$(pidof erigon)`: `SIGQUIT` is destructive, and on a host running more than one instance `pidof` would kill all of them.
 
 **Capture a CPU or heap profile via pprof** (requires `--pprof` flag at startup — default address `localhost:6060`; override with `--pprof.addr` and `--pprof.port`):
 
@@ -83,7 +83,7 @@ The Caplin ports are its defaults (`--caplin.discovery.port` and `--caplin.disco
 
 Without these, the node may appear to have peers (via the cloud dashboard) but will suffer poor block propagation. Configure Cloud firewalls in the Hetzner Cloud Console under **Firewalls** or via `hcloud firewall`; for dedicated servers the equivalent lives in the Robot panel under **Server → Firewall**.
 
-A public-facing Erigon node should also not attempt to peer with IPv4 ranges that are reserved for special use. Blocking them is worth doing explicitly on Hetzner, whose abuse and netscan detection flags outbound dials to reserved ranges — that is what prompted this note, rather than their firewall filtering the traffic. Do not apply this to a node using `--caplin.local-discovery`, which deliberately peers over private IPs. The authoritative list is the [IANA IPv4 Special-Purpose Address Registry](https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml) ([RFC 6890](https://datatracker.ietf.org/doc/html/rfc6890)); the ranges below are the ones commonly blocked for an Ethereum node (`100.64.0.0/10` comes from [RFC 6598](https://datatracker.ietf.org/doc/html/rfc6598), and `192.88.99.0/24` has since been deprecated by [RFC 7526](https://datatracker.ietf.org/doc/html/rfc7526) — blocking it remains correct):
+A public-facing Erigon node should also not attempt to peer with IPv4 ranges that are reserved for special use. Blocking them is worth doing explicitly on Hetzner, whose abuse and netscan detection flags outbound dials to reserved ranges — that is what prompted this note, rather than their firewall filtering the traffic. Do not apply this to a node using `--caplin.local-discovery`, which deliberately peers over private IPs. The authoritative list is the [IANA IPv4 Special-Purpose Address Registry](https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml) ([RFC 6890](https://datatracker.ietf.org/doc/html/rfc6890)); the ranges below are that registry's entries most often blocked for an Ethereum node — it is a reference list, not a ruleset to paste verbatim: `127.0.0.0/8` and `255.255.255.255/32` are included for completeness but must **not** go into an outbound drop rule, for the reason given after the list (`100.64.0.0/10` comes from [RFC 6598](https://datatracker.ietf.org/doc/html/rfc6598), and `192.88.99.0/24` has since been deprecated by [RFC 7526](https://datatracker.ietf.org/doc/html/rfc7526) — blocking it remains correct):
 
 ```text
 0.0.0.0/8             "This" Network                                RFC 1122, Section 3.2.1.3
@@ -94,7 +94,7 @@ A public-facing Erigon node should also not attempt to peer with IPv4 ranges tha
 172.16.0.0/12         Private-Use Networks                          RFC 1918
 192.0.0.0/24          IETF Protocol Assignments                     RFC 5736
 192.0.2.0/24          TEST-NET-1                                    RFC 5737
-192.88.99.0/24        6to4 Relay Anycast                            RFC 3068
+192.88.99.0/24        6to4 Relay Anycast (deprecated)               RFC 3068, RFC 7526
 192.168.0.0/16        Private-Use Networks                          RFC 1918
 198.18.0.0/15         Network Interconnect Device Benchmark Testing RFC 2544
 198.51.100.0/24       TEST-NET-2                                    RFC 5737

--- a/docs/site/help-center/troubleshooting.md
+++ b/docs/site/help-center/troubleshooting.md
@@ -66,7 +66,7 @@ Attach the `.pprof` files and the goroutine dump to your GitHub issue.
 Hetzner filters traffic at the network edge, and the two product lines need different rules:
 
 * **Cloud** — the firewall is stateful, so return traffic is handled for you. Outbound is allow-all, but only for as long as no outbound rule exists: per Hetzner's FAQ, *"If you define one or more outbound rules, the outbound direction also changes to implicit 'deny'"*. Adding outbound rules for the ports below would therefore cut off DNS, NTP and HTTPS — including the snapshot webseeds — and break the initial download. Define **inbound rules only** and leave the outbound list empty.
-* **Dedicated servers (Robot)** — the firewall is stateless, so return traffic needs an explicit rule of its own. Here you do need rules in both directions.
+* **Dedicated servers (Robot)** — the firewall is stateless, so nothing is inferred from an outgoing connection. The listening ports in the table below are not enough on their own: replies to Erigon's own outbound connections — DNS, HTTPS to the snapshot webseeds, and outgoing peer dials — arrive on ephemeral local ports and need inbound rules of their own (TCP with `ack` set, plus the UDP ranges you use), and any outbound filtering needs matching reply rules. Follow [Hetzner's notes on stateless-firewall configuration](https://docs.hetzner.com/robot/dedicated-server/firewall/#notes-about-stateless-firewall-configuration) rather than porting a Cloud ruleset across.
 
 The ports to allow inbound:
 
@@ -75,11 +75,11 @@ The ports to allow inbound:
 | P2P (execution layer)            | 30303 | TCP+UDP  |
 | Snapshot downloader (BitTorrent) | 42069 | TCP+UDP  |
 | Caplin DISCV5 discovery          | 4000  | UDP      |
-| Caplin DISCV5                    | 4001  | TCP      |
+| Caplin libp2p peering            | 4001  | TCP      |
 
 This table is not exhaustive — it lists what a default node needs. See [Default ports](/fundamentals/default-ports) for every port Erigon can open, including the opt-in Shutter port.
 
-The Caplin ports are its defaults (`--caplin.discovery.port` and `--caplin.discovery.tcpport`); change the rules to match if you override them. If you run an **external** consensus client instead of Caplin, open the ports that client uses rather than the Caplin ones. Lighthouse, Teku and Nimbus default to `9000` TCP+UDP, and Lighthouse additionally uses `9001` UDP for QUIC; Prysm defaults to `13000` TCP and `12000` UDP. Check your client's own documentation rather than assuming `9000`.
+The Caplin ports are its defaults (`--caplin.discovery.port` and `--caplin.discovery.tcpport`); change the rules to match if you override them. Note the second flag's help text calls it a DISCV5 port, which is a misnomer: DISCV5 is UDP-only and runs on `4000`, while `4001` is the libp2p TCP listen address Caplin advertises for peering. If you run an **external** consensus client instead of Caplin, open the ports that client uses rather than the Caplin ones. Lighthouse, Teku and Nimbus default to `9000` TCP+UDP, and Lighthouse additionally uses `9001` UDP for QUIC; Prysm defaults to `13000` TCP and `12000` UDP. Check your client's own documentation rather than assuming `9000`.
 
 Without these, the node may appear to have peers (via the cloud dashboard) but will suffer poor block propagation. Configure Cloud firewalls in the Hetzner Cloud Console under **Firewalls** or via `hcloud firewall`; for dedicated servers the equivalent lives in the Robot panel under **Server → Firewall**.
 
@@ -104,4 +104,8 @@ A public-facing Erigon node should also not attempt to peer with IPv4 ranges tha
 255.255.255.255/32    Limited Broadcast                             RFC 919 and RFC 922, Section 7
 ```
 
-A near-identical list expressed in [iptables syntax](https://ethereum.stackexchange.com/questions/6386/how-to-prevent-being-blacklisted-for-running-an-ethereum-client/13068#13068) is available on Stack Exchange. It covers 14 of the 16 ranges above, deliberately leaving out `127.0.0.0/8` and `255.255.255.255/32`: an `OUTPUT` drop on loopback would break Erigon's own inter-component traffic, such as the RPC Daemon reaching the core node on `127.0.0.1:9090`.
+A near-identical list expressed in [iptables syntax](https://ethereum.stackexchange.com/questions/6386/how-to-prevent-being-blacklisted-for-running-an-ethereum-client/13068#13068) is available on Stack Exchange, but do not paste it in as a blanket `OUTPUT` policy:
+
+* It omits `127.0.0.0/8`, which is correct — an `OUTPUT` drop on loopback would break Erigon's own inter-component traffic, such as the RPC Daemon reaching the core node on `127.0.0.1:9090`.
+* It has no separate `255.255.255.255/32` rule, but that address is **not** left reachable: `240.0.0.0/4` spans `240.0.0.0`–`255.255.255.255` and already covers it.
+* On **Hetzner Cloud** it drops the metadata endpoint at `169.254.169.254`, which sits inside `169.254.0.0/16`, along with legitimate private-network and multicast traffic. Exempt what your instance needs, or scope the rules to Erigon's peer dialing instead of the whole `OUTPUT` chain.

--- a/docs/site/help-center/troubleshooting.md
+++ b/docs/site/help-center/troubleshooting.md
@@ -44,7 +44,7 @@ kill -SIGUSR1 $(pidof erigon)
 # Stack traces are printed to the erigon log / stdout
 ```
 
-If the node is wedged and you are ready to lose it, `kill -SIGQUIT <pid>` dumps every goroutine stack and terminates that process in one step. Erigon wires a handler only for `SIGUSR1`, so `SIGQUIT` falls through to the Go runtime's own behaviour — the same one this repository's CI watchdog relies on. Pass an explicit PID rather than `$(pidof erigon)`: `SIGQUIT` is destructive, and on a host running more than one instance `pidof` would kill all of them.
+If the node is wedged and you are ready to lose it, `kill -SIGQUIT <pid>` dumps every goroutine stack and terminates that process in one step. Erigon installs a stack-dump handler for `SIGUSR1` and shutdown handlers for `SIGINT` and `SIGTERM`, but none for `SIGQUIT` — so `SIGQUIT` falls through to the Go runtime's own behaviour, the same one this repository's CI watchdog relies on. Pass an explicit PID rather than `$(pidof erigon)`: `SIGQUIT` is destructive, and on a host running more than one instance `pidof` would kill all of them.
 
 **Capture a CPU or heap profile via pprof** (requires `--pprof` flag at startup — default address `localhost:6060`; override with `--pprof.addr` and `--pprof.port`):
 

--- a/docs/site/help-center/troubleshooting.md
+++ b/docs/site/help-center/troubleshooting.md
@@ -44,6 +44,8 @@ kill -SIGUSR1 $(pidof erigon)
 # Stack traces are printed to the erigon log / stdout
 ```
 
+If the node is wedged and you are ready to lose it, `kill -SIGABRT <pid>` dumps the stacks and terminates that process in one step. Pass an explicit PID rather than `$(pidof erigon)`: `SIGABRT` is destructive, and on a host running more than one instance `pidof` would abort all of them.
+
 **Capture a CPU or heap profile via pprof** (requires `--pprof` flag at startup — default address `localhost:6060`; override with `--pprof.addr` and `--pprof.port`):
 
 ```bash
@@ -61,12 +63,45 @@ Attach the `.pprof` files and the goroutine dump to your GitHub issue.
 
 ## Hetzner Cloud / Dedicated Server Firewall Note
 
-Hetzner applies a stateless firewall at the network edge. Ensure the following ports are open for **both TCP and UDP, inbound and outbound**:
+Hetzner filters traffic at the network edge, and the two product lines need different rules:
 
-| Purpose        | Port  | Protocol |
-| -------------- | ----- | -------- |
-| P2P (Ethereum) | 30303 | TCP+UDP  |
-| P2P (Caplin)   | 9000  | TCP+UDP  |
+* **Cloud** — the firewall is stateful, so return traffic is handled for you. Outbound is allow-all, but only for as long as no outbound rule exists: per Hetzner's FAQ, *"If you define one or more outbound rules, the outbound direction also changes to implicit 'deny'"*. Adding outbound rules for the ports below would therefore cut off DNS, NTP and HTTPS — including the snapshot webseeds — and break the initial download. Define **inbound rules only** and leave the outbound list empty.
+* **Dedicated servers (Robot)** — the firewall is stateless, so return traffic needs an explicit rule of its own. Here you do need rules in both directions.
 
-Without these, the node may appear to have peers (via the cloud dashboard) but will suffer poor block propagation. Configure the firewall in the Hetzner Cloud Console under **Firewalls** or via `hcloud firewall`.
+The ports to allow inbound:
 
+| Purpose                          | Port  | Protocol |
+| -------------------------------- | ----- | -------- |
+| P2P (execution layer)            | 30303 | TCP+UDP  |
+| Snapshot downloader (BitTorrent) | 42069 | TCP+UDP  |
+| Caplin DISCV5 discovery          | 4000  | UDP      |
+| Caplin DISCV5                    | 4001  | TCP      |
+
+This table is not exhaustive — it lists what a default node needs. See [Default ports](/fundamentals/default-ports) for every port Erigon can open, including the opt-in Shutter port.
+
+The Caplin ports are its defaults (`--caplin.discovery.port` and `--caplin.discovery.tcpport`); change the rules to match if you override them. If you run an **external** consensus client instead of Caplin, open the ports that client uses rather than the Caplin ones. Lighthouse, Teku and Nimbus default to `9000` TCP+UDP, and Lighthouse additionally uses `9001` UDP for QUIC; Prysm defaults to `13000` TCP and `12000` UDP. Check your client's own documentation rather than assuming `9000`.
+
+Without these, the node may appear to have peers (via the cloud dashboard) but will suffer poor block propagation. Configure Cloud firewalls in the Hetzner Cloud Console under **Firewalls** or via `hcloud firewall`; for dedicated servers the equivalent lives in the Robot panel under **Server → Firewall**.
+
+A public-facing Erigon node should also not attempt to peer with IPv4 ranges that are reserved for special use. Blocking them is worth doing explicitly on Hetzner, whose abuse and netscan detection flags outbound dials to reserved ranges — that is what prompted this note, rather than their firewall filtering the traffic. Do not apply this to a node using `--caplin.local-discovery`, which deliberately peers over private IPs. The authoritative list is the [IANA IPv4 Special-Purpose Address Registry](https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml) ([RFC 6890](https://datatracker.ietf.org/doc/html/rfc6890)); the ranges below are the ones commonly blocked for an Ethereum node (`100.64.0.0/10` comes from [RFC 6598](https://datatracker.ietf.org/doc/html/rfc6598), and `192.88.99.0/24` has since been deprecated by [RFC 7526](https://datatracker.ietf.org/doc/html/rfc7526) — blocking it remains correct):
+
+```text
+0.0.0.0/8             "This" Network                                RFC 1122, Section 3.2.1.3
+10.0.0.0/8            Private-Use Networks                          RFC 1918
+100.64.0.0/10         Carrier-Grade NAT (CGN)                       RFC 6598, Section 7
+127.0.0.0/8           Loopback                                      RFC 1122, Section 3.2.1.3
+169.254.0.0/16        Link Local                                    RFC 3927
+172.16.0.0/12         Private-Use Networks                          RFC 1918
+192.0.0.0/24          IETF Protocol Assignments                     RFC 5736
+192.0.2.0/24          TEST-NET-1                                    RFC 5737
+192.88.99.0/24        6to4 Relay Anycast                            RFC 3068
+192.168.0.0/16        Private-Use Networks                          RFC 1918
+198.18.0.0/15         Network Interconnect Device Benchmark Testing RFC 2544
+198.51.100.0/24       TEST-NET-2                                    RFC 5737
+203.0.113.0/24        TEST-NET-3                                    RFC 5737
+224.0.0.0/4           Multicast                                     RFC 3171
+240.0.0.0/4           Reserved for Future Use                       RFC 1112, Section 4
+255.255.255.255/32    Limited Broadcast                             RFC 919 and RFC 922, Section 7
+```
+
+A near-identical list expressed in [iptables syntax](https://ethereum.stackexchange.com/questions/6386/how-to-prevent-being-blacklisted-for-running-an-ethereum-client/13068#13068) is available on Stack Exchange. It covers 14 of the 16 ranges above, deliberately leaving out `127.0.0.0/8` and `255.255.255.255/32`: an `OUTPUT` drop on loopback would break Erigon's own inter-component traffic, such as the RPC Daemon reaching the core node on `127.0.0.1:9090`.

--- a/docs/site/scripts/generate-llms.py
+++ b/docs/site/scripts/generate-llms.py
@@ -77,6 +77,160 @@ def _is_placeholder_brace(match):
     return bool(_IDENT_BRACE_INNER.match(inner))
 
 
+
+
+DEFAULT_TAB_HEADING_DEPTH = 3
+MAX_HEADING_DEPTH = 6
+
+_TABITEM_TAG = re.compile(r"<TabItem\b[^>]*>")
+_TABITEM_OPEN = re.compile(r"<TabItem\b")
+_TABS_OPEN = re.compile(r"<Tabs\b")
+_TABS_CLOSE = re.compile(r"</Tabs\s*>")
+_ATX_HEADING = re.compile(r"\s*(#{1,6})\s")
+# label="X" / label='X' / label={'X'} — Docusaurus accepts all three.
+_TAB_LABEL = re.compile(
+    r"""\blabel\s*=\s*(?:"([^"]*)"|'([^']*)'|\{\s*['"]([^'"]*)['"]\s*\})"""
+)
+# Docusaurus falls back to rendering `value` when `label` is absent, so we do too.
+_TAB_VALUE = re.compile(
+    r"""\bvalue\s*=\s*(?:"([^"]*)"|'([^']*)'|\{\s*['"]([^'"]*)['"]\s*\})"""
+)
+
+
+def _label_of(tag):
+    """A TabItem's visible text: its `label`, else its `value`, else ''."""
+    for pattern in (_TAB_LABEL, _TAB_VALUE):
+        m = pattern.search(tag)
+        if m:
+            return next(g for g in m.groups() if g is not None).strip()
+    return ""
+
+
+def _scan_tab_structure(text):
+    """Fence-aware scan returning (lines, headings, tabs, blocks).
+
+    headings maps line index → heading level; tabs maps line index → visible
+    text; blocks is a list of (open, close) line indices for each <Tabs> set.
+    """
+    lines = text.splitlines()
+    headings, tabs, blocks, open_at, in_fence = {}, {}, [], None, False
+    skip_to = -1
+    for i, line in enumerate(lines):
+        if i <= skip_to:  # continuation lines of a multiline <TabItem …> tag
+            continue
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        heading = _ATX_HEADING.match(line)
+        if heading:
+            headings[i] = len(heading.group(1))
+            continue
+        if _TABS_OPEN.search(line) and open_at is None:
+            open_at = i
+        if _TABS_CLOSE.search(line) and open_at is not None:
+            blocks.append((open_at, i))
+            open_at = None
+        tag = _tabitem_tag_at(lines, i)
+        if tag:
+            text_, end, col_start, col_end = tag
+            skip_to = end
+            rest = (line[:col_start] + lines[end][col_end:]).strip()
+            tabs[i] = (_label_of(text_), end, rest)
+    if open_at is not None:  # unclosed <Tabs>: treat the rest of the doc as its body
+        blocks.append((open_at, len(lines)))
+    return lines, headings, tabs, blocks
+
+
+def _tabitem_tag_at(lines, i):
+    """Assemble a `<TabItem …>` opening tag that starts on line `i`.
+
+    Returns `(tag_text, end_line, start_col, end_col)`, or None if no tag starts
+    there. MDX lets the attributes span several lines, and matching only within
+    one line would find no `label` — the heading would be dropped and the later
+    multi-line component strip would delete the label text with the tag. Quotes
+    are tracked so a `>` inside an attribute value does not end the tag early.
+    """
+    m = _TABITEM_OPEN.search(lines[i])
+    if not m:
+        return None
+    quote, buf = None, []
+    for j in range(i, len(lines)):
+        line = lines[j]
+        start = m.start() if j == i else 0
+        for col in range(start, len(line)):
+            ch = line[col]
+            if quote:
+                if ch == quote:
+                    quote = None
+            elif ch in "\"'":
+                quote = ch
+            elif ch == ">":
+                buf.append(line[start : col + 1])
+                return "\n".join(buf), j, m.start(), col + 1
+        buf.append(line[start:])
+    return None  # unterminated tag: leave it to the generic component strip
+
+
+def _tab_heading_depth(start, end, headings):
+    """Pick a heading level for one tab set that nests correctly both ways.
+
+    One level below the enclosing section, so a tab never outranks the section
+    containing it — but never shallower than the first heading *after* the set,
+    so that heading stays a sibling of the tab set instead of being swallowed
+    as a subsection of the last tab.
+    """
+    before = [lvl for i, lvl in headings.items() if i < start]
+    after = [lvl for i, lvl in sorted(headings.items()) if i > end]
+    depth = (before[-1] if before else DEFAULT_TAB_HEADING_DEPTH - 1) + 1
+    if after:
+        depth = max(depth, after[0])
+    return min(depth, MAX_HEADING_DEPTH)
+
+
+def _tabitem_labels_to_headings(text):
+    """Turn each `<TabItem label="X">` into a heading carrying X.
+
+    Tabs are a browser affordance, but the label is often the only thing saying
+    *which* variant the block below describes — which network, OS, or install
+    method. The generic component strip in strip_mdx() drops the tag wholesale,
+    which used to leave sibling tables and code blocks indistinguishable in the
+    text output (five unlabelled disk-size tables in a row, for instance).
+    """
+    lines, headings, tabs, blocks = _scan_tab_structure(text)
+    if not tabs:
+        return text
+
+    # A tab set is delimited by <Tabs>…</Tabs>, not by "no heading in between":
+    # a heading inside one tab's body must not split the set and demote the
+    # tabs that follow it. Tabs outside any <Tabs> block are handled per-tab.
+    depth_at = {}
+    for start, end in blocks:
+        depth = _tab_heading_depth(start, end, headings)
+        for i in tabs:
+            if start < i < end:
+                depth_at[i] = depth
+    for i in tabs:
+        if i not in depth_at:
+            depth_at[i] = _tab_heading_depth(i, i, headings)
+
+    out, skip_to = [], -1
+    for i, line in enumerate(lines):
+        if i <= skip_to:  # attribute lines of a multiline tag, already consumed
+            continue
+        if i not in tabs:
+            out.append(line)
+            continue
+        label, end, rest = tabs[i]
+        skip_to = end
+        if label:
+            out.extend(["", "#" * depth_at[i] + f" {label}", ""])
+        if rest:
+            out.append(rest)
+    return "\n".join(out)
+
+
 def _strip_jsx_expr(match):
     """re.sub callback: drop JSX expressions, preserve placeholder identifiers.
 
@@ -243,6 +397,9 @@ def strip_mdx(text):
     # Remove MDX import/export statements only outside fenced code blocks.
     # This preserves shell `export VAR=...` inside ```bash fences.
     text = _strip_mdx_module_syntax(text)
+    # Promote TabItem labels to headings before the generic component strip
+    # below erases them along with the tag.
+    text = _tabitem_labels_to_headings(text)
     # Remove JSX block comments and multi-line component tags (fence-aware).
     # [^>]* in the component regexes matches newlines (char class), consuming
     # <Link\n  prop="val"\n> in one shot without DOTALL.

--- a/docs/site/scripts/test_generate_llms.py
+++ b/docs/site/scripts/test_generate_llms.py
@@ -296,5 +296,168 @@ class LeadingH1StripTests(unittest.TestCase):
         self.assertIn("## Subheading", out)
 
 
+
+class TabItemLabelTests(unittest.TestCase):
+    """Tab labels must survive as headings — without them, sibling tables and
+    code blocks are indistinguishable in the text output.
+    """
+
+    def test_label_becomes_heading_below_enclosing_section(self):
+        text = (
+            "## Disk Size\n\n"
+            "<Tabs>\n"
+            '<TabItem value="ethereum-mainnet" label="Ethereum mainnet">\n'
+            "| Mode | Usage |\n"
+            "</TabItem>\n"
+            "</Tabs>"
+        )
+        out = g.strip_mdx(text)
+        self.assertIn("### Ethereum mainnet", out)
+        self.assertNotIn("TabItem", out)
+
+    def test_multiline_opening_tag_still_yields_heading(self):
+        """MDX allows the attributes to be spread over several lines. Matching
+        within one line found no label, so the heading was dropped and the
+        multi-line component strip then swallowed the label text as well.
+        """
+        text = (
+            "## Disk Size\n\n"
+            "<Tabs>\n"
+            "<TabItem\n"
+            '  value="ethereum-mainnet"\n'
+            '  label="Ethereum mainnet">\n'
+            "| Mode | Usage |\n"
+            "</TabItem>\n"
+            "</Tabs>"
+        )
+        out = g.strip_mdx(text)
+        self.assertIn("### Ethereum mainnet", out)
+        self.assertNotIn("TabItem", out)
+        self.assertNotIn("value=", out)
+
+    def test_angle_bracket_inside_label_does_not_end_the_tag(self):
+        text = (
+            "## Ports\n\n"
+            "<Tabs>\n"
+            '<TabItem value="gt" label="Version > 3.1">\n'
+            "body\n"
+            "</TabItem>\n"
+            "</Tabs>"
+        )
+        out = g.strip_mdx(text)
+        self.assertIn("### Version > 3.1", out)
+        self.assertNotIn("TabItem", out)
+
+    def test_sibling_tabs_are_each_labelled(self):
+        text = (
+            "## Disk Size\n\n"
+            "<Tabs>\n"
+            '<TabItem value="sepolia" label="Sepolia">\n'
+            "| Archive | 1.10 TB |\n"
+            "</TabItem>\n"
+            '<TabItem value="hoodi" label="Hoodi">\n'
+            "| Archive | 133.73 GB |\n"
+            "</TabItem>\n"
+            "</Tabs>"
+        )
+        out = g.strip_mdx(text)
+        self.assertIn("### Sepolia", out)
+        self.assertIn("### Hoodi", out)
+        self.assertLess(out.index("### Sepolia"), out.index("1.10 TB"))
+        self.assertLess(out.index("1.10 TB"), out.index("### Hoodi"))
+
+    def test_depth_follows_nearest_preceding_heading(self):
+        text = "### Install\n\n<TabItem value=\"linux\" label=\"Linux\">\napt install\n"
+        out = g.strip_mdx(text)
+        self.assertIn("#### Linux", out)
+
+    def test_following_heading_stays_a_sibling(self):
+        """A heading after the tab set must not become a subsection of the last
+        tab — the installation page has exactly this shape (h1, OS tabs, then
+        '### All Operating Systems').
+        """
+        text = (
+            "# Installation\n\n"
+            "<Tabs>\n"
+            '<TabItem value="linux" label="Linux">\n'
+            "apt install\n"
+            "</TabItem>\n"
+            '<TabItem value="windows" label="Windows">\n'
+            "choco install\n"
+            "</TabItem>\n"
+            "</Tabs>\n\n"
+            "### All Operating Systems\n\nShared steps.\n"
+        )
+        out = g.strip_mdx(text)
+        self.assertIn("### Linux", out)
+        self.assertIn("### Windows", out)
+        self.assertNotIn("## Linux", out.replace("### Linux", ""))
+        # Same level as the heading that follows, so it is not nested under it.
+        self.assertIn("### All Operating Systems", out)
+
+    def test_depth_defaults_when_no_preceding_heading(self):
+        out = g.strip_mdx('<TabItem value="linux" label="Linux">\napt install\n')
+        self.assertIn("### Linux", out)
+
+    def test_depth_capped_at_h6(self):
+        text = "###### Deep\n\n<TabItem value=\"linux\" label=\"Linux\">\napt install\n"
+        out = g.strip_mdx(text)
+        self.assertIn("###### Linux", out)
+        self.assertNotIn("#######", out)
+
+    def test_single_quoted_and_braced_labels(self):
+        out = g.strip_mdx("## S\n\n<TabItem value='a' label='macOS'>\nbrew\n")
+        self.assertIn("### macOS", out)
+        out = g.strip_mdx("## S\n\n<TabItem value=\"a\" label={'Windows'}>\nchoco\n")
+        self.assertIn("### Windows", out)
+
+    def test_tabitem_inside_fence_untouched(self):
+        text = '```mdx\n<TabItem value="a" label="Linux">\n```'
+        out = g.strip_mdx(text)
+        self.assertIn('<TabItem value="a" label="Linux">', out)
+
+    def test_unlabelled_tabitem_falls_back_to_value(self):
+        """Docusaurus renders `value` when `label` is absent, so a tab without a
+        label must still get a heading — otherwise it silently reintroduces the
+        unlabelled-tables problem.
+        """
+        out = g.strip_mdx('## S\n\n<TabItem value="linux">\nbody\n')
+        self.assertIn("### linux", out)
+        self.assertNotIn("TabItem", out)
+        self.assertIn("body", out)
+
+    def test_label_wins_over_value(self):
+        out = g.strip_mdx('## S\n\n<TabItem value="macos" label="macOS">\nbrew\n')
+        self.assertIn("### macOS", out)
+        self.assertNotIn("### macos", out)
+
+    def test_attributeless_tabitem_emits_no_heading(self):
+        out = g.strip_mdx("## S\n\n<TabItem>\nbody\n")
+        self.assertNotIn("TabItem", out)
+        self.assertIn("body", out)
+        self.assertEqual(out.count("###"), 0)
+
+    def test_heading_inside_tab_body_does_not_split_the_set(self):
+        """A heading inside the first tab's body must not demote the tabs after
+        it: the set is delimited by <Tabs>…</Tabs>, not by heading positions.
+        """
+        text = (
+            "## Setup\n\n"
+            "<Tabs>\n"
+            '<TabItem value="linux" label="Linux">\n'
+            "#### Extra step\n"
+            "apt install\n"
+            "</TabItem>\n"
+            '<TabItem value="windows" label="Windows">\n'
+            "choco install\n"
+            "</TabItem>\n"
+            "</Tabs>\n"
+        )
+        out = g.strip_mdx(text)
+        self.assertIn("### Linux", out)
+        self.assertIn("### Windows", out)
+        # Both tabs sit at the same level despite the h4 inside the first body.
+        self.assertNotIn("##### Windows", out)
+
 if __name__ == "__main__":
     unittest.main()

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -109,7 +109,9 @@ If you must split the datadir across a fast and a slow device, see [Optimizing S
 
 ## Disk Size and RAM Requirements
 
-The amount of disk space recommended and RAM you need depends on the [pruning mode](../fundamentals/pruning-modes) you want to run. **Current Disk Usage** values listed below are obtained using the standard Erigon + [Caplin](../fundamentals/caplin) configuration, with the sole exception of the `--prune.mode` flag.
+The amount of disk space recommended and RAM you need depends on the [pruning mode](../fundamentals/pruning-modes) you want to run. **Current Disk Usage** values listed below are obtained using the standard Erigon + [Caplin](../fundamentals/caplin) configuration, varying only the `--prune.mode` flag unless a tab notes otherwise.
+
+### Ethereum mainnet
 
 | Pruning Mode | Current Disk Usage | Disk Size (Recommended) | RAM (Required) | RAM (Recommended) |
 | --- | --- | --- | --- | --- |
@@ -119,6 +121,8 @@ The amount of disk space recommended and RAM you need depends on the [pruning mo
 
 _Current Disk Usage measured as of 2026-07-19; usage grows over time as the chain grows._
 
+### Gnosis Chain
+
 | **Pruning Mode**  | **Current Disk Usage** | **Disk Size (Recommended)** | **RAM (Required)** | **RAM (Recommended)** |
 | -------------- | ---------------------- | --------------------------- | ------------------ | --------------------- |
 | Archive        | 673.59 GB | 1 TB                        | 16 GB              | 32 GB                 |
@@ -127,17 +131,23 @@ _Current Disk Usage measured as of 2026-07-19; usage grows over time as the chai
 
 _Current Disk Usage measured as of 2026-07-21; usage grows over time as the chain grows._
 
+### Sepolia
+
 | **Pruning Mode** | **Current Disk Usage** |
 | -------------- | ---------------------- |
 | Archive        | 1.10 TB |
 
 _Current Disk Usage measured as of 2026-07-29; usage grows over time as the chain grows. Execution layer only — full and minimal modes are not measured for this network._
 
+### Hoodi
+
 | **Pruning Mode** | **Current Disk Usage** |
 | -------------- | ---------------------- |
 | Archive        | 133.73 GB |
 
 _Current Disk Usage measured as of 2026-07-29; usage grows over time as the chain grows. Execution layer only — full and minimal modes are not measured for this network._
+
+### Chiado
 
 | **Pruning Mode** | **Current Disk Usage** |
 | -------------- | ---------------------- |
@@ -202,6 +212,8 @@ The recommended approach involves running and syncing an **Erigon node alongside
 
 You can choose whether to migrate to Erigon + Caplin (the simplest setup) or continue using your existing CL.
 
+#### Migrate to Erigon + Caplin (Internal CL)
+
 This path offers the simplest validator configuration by using Erigon's embedded consensus client, Caplin. You will no longer need your external Consensus Layer (CL) client or a JWT secret for CL-EL communication.
 
 **Steps for Minimal Downtime**
@@ -221,6 +233,8 @@ This path offers the simplest validator configuration by using Erigon's embedded
    * To restart Erigon, there's no need to specify `--port`. Refer to this [guide](../fundamentals/caplin) for additional Erigon + Caplin configuration recommendations.
    * Crucially, reconfigure your **validator keys manager** to point directly to the Erigon Beacon API, as Erigon/Caplin now handles both layers internally.
 6. **Decommission Old Setup**: Verify Erigon/Caplin is proposing and attesting blocks correctly. If confirmed, safely remove Geth, the external CL client, and all their data, including the old JWT secret.
+
+#### Migrate to Erigon + External CL
 
 Switch to an Erigon Execution Layer (EL) while keeping your current external Consensus Layer (CL) client (e.g., Prysm, Lighthouse) and your existing JWT secret. Start by syncing Erigon with Caplin as the CL, then configure it to use the external CL.
 
@@ -245,6 +259,8 @@ Switch to an Erigon Execution Layer (EL) while keeping your current external Con
 
 This is the simplest option as it requires no configuration adjustments. However, the node will be down until Erigon finishes syncing.
 
+#### Erigon + Caplin (Fastest Sync)
+
 This path is the fastest way to get Erigon running. It utilizes **Erigon's embedded consensus client, Caplin**, requiring no external CL client or JWT secret. This is ideal for home users with limited disk space and no critical uptime requirements.
 
 **Steps for Quickest Start**
@@ -255,6 +271,8 @@ This path is the fastest way to get Erigon running. It utilizes **Erigon's embed
 4. **Synchronization**: Start syncing Erigon with the default Caplin configuration (Caplin does not use the Engine API).
 5. **Final Setup**: Once Erigon is fully synced, your node is online.
 6. **Monitoring**: Monitor the sync progress using `eth_syncing` or the health check, and ensure no errors appear in Erigon's logs.
+
+#### Erigon + External CL (Reuse Existing CL)
 
 This path retains your existing **external Consensus Layer (CL)** client (e.g., Prysm, Lighthouse) but swaps the old EL client for Erigon. Since downtime is accepted, this process requires simpler port management.
 
@@ -357,13 +375,19 @@ URL: https://docs.erigon.tech/get-started/installation
 
 To install Erigon, begin by choosing an installation method suited to your operating system and technical preference. Options range from the simplest to the most complex, including pre-built images, containers, or source compilation.
 
+### Linux
+
 Pre-built Binaries — Fastest way to get started. Download and run a pre-compiled binary for your architecture.
 Docker — Run Erigon in an isolated container. Recommended for most users.
 Build from Source — Full control over the build. Requires Go, C++ compiler, and CLI experience.
 Ethereum on ARM — Community image and APT repository for ARM single-board computers (Raspberry Pi, Rock 5B, Orange Pi 5).
 
+### macOS
+
 Docker — Run Erigon in an isolated container. The recommended method on macOS.
 Build from Source — Compile directly on your Mac. Requires Go, Clang/GCC, and CLI experience.
+
+### Windows
 
 Native Compilation — Compile and run Erigon directly on Windows using Chocolatey, MinGW, and Go.
 WSL (Windows Subsystem for Linux) — Run a full Linux environment on Windows. Recommended for best performance.
@@ -1108,6 +1132,8 @@ scheduled forks, not after.
 
 ## Erigon with Prysm as the external CL
 
+### Prysm
+
 1.  Start Erigon adding the `--externalcl` flag:
 
     ```bash
@@ -1131,6 +1157,8 @@ scheduled forks, not after.
     --checkpoint-sync-url=https://mainnet.checkpoint.sigp.io \
     --genesis-beacon-api-url=https://mainnet.checkpoint.sigp.io
     ```
+
+### Lighthouse
 
 1.  Start Erigon adding the `--externalcl` flag:
 
@@ -1424,16 +1452,22 @@ URL: https://docs.erigon.tech/fundamentals/basic-usage
 
 Erigon is mainly operated through the command line. The commands may vary based on your installation method.
 
+## Pre-Built Binaries
+
 Open your terminal and simply start Erigon with the command:
 
 ```text
 erigon [options]
 ```
 
+## Docker
+
 * You can use Docker Compose like in this [example](/get-started/easy-nodes/how-to-run-an-ethereum-node#a-create-the-configuration-file)
 *   Alternatively you can use the Docker syntax, for example:
 
     `docker run -it erigontech/erigon:v{ERIGON_VERSION} [options]`
+
+## Built from Source
 
 Open your terminal and move to the directory where you installed Erigon
 
@@ -1446,6 +1480,8 @@ You can then start Erigon with the below command:
 ```shell
 ./build/bin/erigon [options]
 ```
+
+## Windows
 
 To run Erigon after a native compilation, enter the following command in your Command Prompt or PowerShell:
 
@@ -3921,6 +3957,8 @@ When something looks wrong with your node, ask the assistant to sift through log
 
 Add the following to your Claude Desktop configuration file (`~/.config/claude-desktop/config.json` on Linux/macOS, `%APPDATA%\claude-desktop\config.json` on Windows):
 
+### JSON-RPC mode
+
 ```json
 {
   "mcpServers": {
@@ -3932,6 +3970,8 @@ Add the following to your Claude Desktop configuration file (`~/.config/claude-d
 }
 ```
 
+### Datadir mode
+
 ```json
 {
   "mcpServers": {
@@ -3942,6 +3982,8 @@ Add the following to your Claude Desktop configuration file (`~/.config/claude-d
   }
 }
 ```
+
+### Embedded (SSE)
 
 ```json
 {
@@ -3993,12 +4035,16 @@ claude mcp remove erigon
 
 [OpenAI Codex CLI](https://github.com/openai/codex) supports MCP servers via `~/.codex/config.yaml`. Add the `mcp_servers` key to your existing config file:
 
+### Embedded SSE
+
 ```yaml
 mcp_servers:
   erigon:
     type: sse
     url: http://127.0.0.1:8553/sse
 ```
+
+### Standalone stdio
 
 ```yaml
 mcp_servers:

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -60,11 +60,52 @@ A locally mounted **SSD** (Solid-State Drive) or **NVMe** (Non-Volatile Memory E
 
 | Component | Recommendation | Notes |
 | --- | --- | --- |
-| Disk Type | Use high-end NVMe SSDs. | Avoid HDDs.SSD performance may degrade when nearing full capacity. |
-| Disk Configuration | RAID 0 for multiple disks (Speed) | High-Speed Option: RAID 0 provides maximum speed but no redundancy (data loss risk).ZFS filesystems may be considered for Archive nodes for their data integrity features, but complex RAID-Z setups are generally not recommended. |
+| Disk Type | Use high-end NVMe SSDs. | Avoid HDDs. SSD performance may degrade when nearing full capacity. |
+| Disk Configuration | A single NVMe device is enough for any pruning mode. | An archive node fits on one 4 TB drive, so RAID 0 striping is not needed. For failure protection, use a mirrored array, not RAID 0. See [Filesystem](#filesystem). |
+| Filesystem | ext4 or XFS | See [Filesystem](#filesystem) below. |
 | RAM | Adequate memory is crucial | Reduces bottlenecks during sync and improves performance under load. |
-| CPU | 4–8 cores for Full nodes8–16 cores for Archive nodes | More cores are generally better for intense sync and query operations. |
+| CPU | 4–8 cores for Full nodes, 8–16 cores for Archive nodes | More cores are generally better for intense sync and query operations. |
 | Linux | Kernel version > v4 | A modern Linux distribution is required. |
+
+## Filesystem
+
+Use **ext4** or **XFS** on a single NVMe device. The disk figures below are measured on ext4, and that is the configuration Erigon's own measurements come from. XFS is a reasonable choice on the same reasoning, but we have not measured it.
+
+Mount with `noatime` so reads do not generate metadata writes:
+
+```
+UUID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx  /data  ext4  defaults,noatime  0 2
+```
+
+Use the filesystem UUID (`blkid` prints it) rather than a `/dev/nvme…` name, which can move between boots. The final `2` is the `fsck` pass for a non-root filesystem.
+
+### Why the filesystem matters
+
+Erigon's bottleneck is disk **latency**, not throughput or IOPS — see [Improving Performance](/help-center/known-issues#improving-performance). Erigon does pre-warm what it can, but two properties of the workload mean its reads cannot be fully predicted, so part of every block's reads lands cold:
+
+* **EVM execution reads arbitrary state.** Nothing tells you in advance which accounts or storage slots a block will touch. Once the working set no longer fits in RAM, some of those reads land on cold data no cache had reason to hold.
+* **Merkle trie updates pull in neighbours.** Updating one key requires reading the nodes next to it in the trie. Those may be accounts the EVM never touches — they are involved only because of where they sit in the trie.
+
+Every layer the filesystem adds is added on top of each of those reads. That is what favours a thin filesystem here: ext4 and XFS store a file and leave caching to the OS page cache, which is what Erigon's memory-mapped database is built to use.
+
+### Filesystems to avoid
+
+Prefer a plain journaling filesystem over a copy-on-write or database-like one:
+
+* **ZFS** behaves more like a database than a filesystem. It keeps its own write-ahead log and its own cache (**ARC**), and that cache competes with the OS page cache for the same RAM. Optional features such as encryption and dedup add work to the read path this workload is bound by, and tuning ZFS for it is not a solved problem.
+* **Btrfs** is a copy-on-write B-tree of pages, and Erigon's MDBX database is itself a B-tree of pages, so you end up running a database inside a database. Its `autodefrag` feature is the sharpest edge: it can multiply write I/O by as much as 100x. See [Background File System Features Can Hurt Performance](/help-center/known-issues#background-file-system-features-can-hurt-performance).
+
+Filesystems other than ext4 and XFS are not part of what we measure, so treat their performance as unverified rather than assumed.
+
+A few more points that follow from Erigon's storage model — see [Database](../fundamentals/database) for the layout:
+
+* **One device is enough.** An archive node fits on a single 4 TB drive, so RAID 0 gains you no capacity you need while doubling the chance of losing the datadir. Stripe only if no single drive you have is large enough.
+* **For failure protection, use redundancy — not RAID 0.** A mirrored array and ECC memory guard against a failing disk or bad RAM, which is what [Best Practices](/help-center/best-practices) recommends. RAID 0 does the opposite.
+* **Most of the datadir is re-downloadable.** Snapshot files are content-addressed and refetched from peers, so `chaindata/` is the part worth backing up.
+* **Erigon memory-maps its database.** Leave RAM free for the page cache rather than handing it to a filesystem or volume manager to cache on its own.
+* **Network and cloud block storage are slow for block execution.** See [known issues](/help-center/known-issues#cloud-network-drives).
+
+If you must split the datadir across a fast and a slow device, see [Optimizing Storage](../fundamentals/optimizing-storage).
 
 ## Disk Size and RAM Requirements
 
@@ -116,6 +157,19 @@ Your internet bandwidth is also an important factor, particularly for sync speed
 | -------------- | -------------------- | ----------------------- |
 | Staking/Mining | 10 Mbps              | 50 Mbps                 |
 | Non-Staking    | 5 Mbps               | 25 Mbps                 |
+
+## Sync Times
+
+Approximate times to sync from scratch to the tip of the chain.
+
+| Chain    | Archive | Full (Default) | Minimal |
+| -------- | ------- | -------------- | ------- |
+| Ethereum | ~8 h    | ~4–6 h         | ~2 h    |
+| Gnosis   | ~2 h    | ~1–2 h         | ~30 m   |
+
+:::info
+These figures are indicative and are **not measured by CI** — read them as an order of magnitude, not a target. Most of the elapsed time is snapshot download rather than block execution, so your available [bandwidth](#bandwidth-requirements) influences the result more than CPU does: expect proportionally faster syncs on a well-connected host and slower ones on a constrained link.
+:::
 
 ---
 
@@ -559,13 +613,27 @@ make -j<n> erigon
 
 The resulting executable binary will be created in the `./build/bin/erigon` path.
 
+**2.4 Installing Outside the Build Tree (Optional)**
+
+Running Erigon as a [dedicated system user](/fundamentals/security) — for example under `systemd` — is easiest when the binaries live outside your source checkout, where that user can reach them. Pass a destination to `make install`:
+
+```sh
+make DIST=/opt/erigon install
+```
+
+`make install` creates the destination directory, so a path under `/opt` needs either `sudo make DIST=/opt/erigon install` or a directory you already own (`sudo install -d -o $USER /opt/erigon`). A path under `$HOME/erigon` avoids that entirely. `make install` copies whatever is currently in `build/bin`, so build every component you intend to deploy before running it.
+
+Once installed this way, run the installed copy — `/opt/erigon/erigon` — rather than the one in the build tree.
+
 **3. Running Erigon**
 
-After installation, you can run Erigon from your terminal:
+From the build tree, run Erigon from your terminal:
 
 ```sh
 ./build/bin/erigon [options]
 ```
+
+If you completed step 2.4, run the binary at your chosen `DIST` path instead.
 
 ### Windows
 
@@ -1760,7 +1828,7 @@ Deleting `chaindata/` is **recoverable but not free**: it discards the latest mu
 
 ## Tuning knobs
 
-- **`--batchSize`** — size of the Execution stage's in-memory buffer before it is flushed to MDBX. Default: `512M`. Raising it (for example `--batchSize 1G` or higher) can speed up execution-heavy sync at the cost of more RAM.
+- **`--batchSize`** — size of the Execution stage's in-memory buffer before it is flushed to MDBX. Default: `512M`. Raising it (for example `--batchSize 1G` or higher) can speed up execution-heavy sync at the cost of more RAM. It is the Execution stage's commit threshold, so a larger value means larger single MDBX write transactions, which raise the file's high-water mark in bigger steps. Keeping it at or below `1G` is a useful heuristic if you want MDBX to grow more gradually.
 - **`--db.size.limit`** — caps the MDBX file size. Useful when running multiple Erigon instances on one disk to prevent one from starving the others.
 - **`--db.read.concurrency`** — maximum number of concurrent open MDBX read transactions (the read-tx semaphore). Raise it for nodes serving heavy parallel RPC (for example a high-throughput RPC daemon against the same datadir); low values are fine for low-read-concurrency nodes such as validators.
 - **Symlinks for tiered storage.** Place `chaindata/` and `snapshots/domain/` on fast NVMe, leave `snapshots/idx/` and `snapshots/history/` on cheaper SATA. See [Optimizing Storage](optimizing-storage) for the recipe.
@@ -2072,6 +2140,12 @@ When Caplin is running, it exposes a Beacon API that external tools can query. T
 | `--beacon.api.write.timeout` | `31536000` | HTTP server write timeout, in seconds (~1 year) |
 | `--beacon.api.idle.timeout` | `25` | HTTP server idle timeout, in seconds |
 
+The API is not served until you enable it with `--beacon.api=<namespaces>`; see [Caplin for staking](../staking/caplin) for the full namespace list.
+
+:::note
+Enabling the Beacon API increases RAM usage by roughly **6 GB**. Account for it when sizing your host — see [Hardware Requirements](../get-started/hardware-requirements).
+:::
+
 ---
 
 # CLI Reference
@@ -2371,9 +2445,9 @@ Flags for configuring various RPC servers and their behavior. See [Interacting w
   * Default: `10000`
 * `--rpc.subscription.filters.maxtxs value`: Maximum transactions to store per subscription.
   * Default: `10000`
-* `--rpc.subscription.filters.maxaddresses value`: Maximum addresses per subscription to filter logs by.
+* `--rpc.subscription.filters.maxaddresses value`: Maximum addresses accepted per log subscription.
   * Default: `0`
-* `--rpc.subscription.filters.maxtopics value`: Maximum topics per subscription to filter logs by.
+* `--rpc.subscription.filters.maxtopics value`: Maximum topic alternatives accepted across all positions per log subscription.
   * Default: `0`
 * `--rpc.subscription.filters.timeout value`: Timeout before idle subscription filters are evicted.
   * Default: `5m0s`
@@ -2688,6 +2762,10 @@ http = true
 
 Erigon supports configuration through environment variables, primarily for experimental features and advanced settings.
 
+:::tip
+Erigon's own variables — everything below except the [Docker](#docker-environment-variables) ones, which do not take the `ERIGON_` prefix — can be set with or without it. `ERIGON_SNAPSHOT_MADV_RND` and `SNAPSHOT_MADV_RND` both work. Prefer the prefixed form: Erigon logs a warning when it reads the bare name, and the prefix keeps these from colliding with unrelated variables in your environment. The examples below use it.
+:::
+
 ### Core Environment Variables
 
 **Database and Performance:**
@@ -2757,16 +2835,16 @@ When running Erigon in [Docker](/fundamentals/docker-compose), you can configure
 **Basic Performance Tuning:**
 
 ```bash
-export MDBX_LOCK_IN_RAM=true
-export SNAPSHOT_MADV_RND=false
+export ERIGON_MDBX_LOCK_IN_RAM=true
+export ERIGON_SNAPSHOT_MADV_RND=false
 ./build/bin/erigon --datadir=/path/to/data
 ```
 
 **Memory Debugging:**
 
 ```bash
-export SAVE_HEAP_PROFILE=true
-export HEAP_PROFILE_THRESHOLD=45
+export ERIGON_SAVE_HEAP_PROFILE=true
+export ERIGON_HEAP_PROFILE_THRESHOLD=45
 ./build/bin/erigon --datadir=/path/to/data
 ```
 
@@ -3063,7 +3141,7 @@ Set **both** `--nat` and `--caplin.nat` to the same external IP, otherwise your 
 URL: https://docs.erigon.tech/fundamentals/optimizing-storage
 
 
-For optimal performance, it's recommended to store the datadir on a fast NVMe-RAID disk. However, if this is not feasible, you can store the history on a cheaper disk and still achieve good performance.
+For optimal performance, store the datadir on a single fast NVMe device formatted with ext4 or XFS — see [Filesystem](../get-started/hardware-requirements#filesystem). If that is not feasible, you can keep the history on a cheaper disk and still achieve good performance.
 
 ### Step 1
 
@@ -3122,10 +3200,10 @@ These instructions are designed to improve the performance of Erigon 3, particul
 
 ## Optimize for Cloud Drives
 
-* Set `SNAPSHOT_MADV_RND=false` to enable the operating system's cache prefetching for better performance on cloud drives with good throughput but bad latency.
+* Set `ERIGON_SNAPSHOT_MADV_RND=false` to enable the operating system's cache prefetching for better performance on cloud drives with good throughput but bad latency.
 
 ```bash
-SNAPSHOT_MADV_RND=false
+export ERIGON_SNAPSHOT_MADV_RND=false
 ```
 
 ## Lock Latest State in RAM
@@ -3282,10 +3360,17 @@ For Prometheus monitoring, each instance should expose metrics on different port
 
 If using network-attached storage, apply these optimizations:
 
+Set the environment variable before starting Erigon:
+
 ```bash
-# Reduce disk latency impact
-export SNAPSHOT_MADV_RND=false
---db.pagesize=64kb
+export ERIGON_SNAPSHOT_MADV_RND=false   # let the OS prefetch; needs spare RAM
+```
+
+And pass these flags:
+
+```bash
+--db.pagesize=64kb              # less fragmentation; must be set before the first sync
+--sync.loop.block.limit=10000   # blocks per loop iteration (default 5000)
 ```
 
 ### Memory Locking for Performance
@@ -3320,7 +3405,7 @@ What can be done:
   * use latency-critical cloud-drives
   * or attached-NVMe (at least for initial sync)
 * increase RAM
-* if you throw enough RAM, then can set env variable `SNAPSHOT_MADV_RND=false`
+* if you throw enough RAM, then can set env variable `ERIGON_SNAPSHOT_MADV_RND=false`
 * Use `--db.pagesize=64kb` (less fragmentation, more IO)
 * Or use Erigon 3 (it also sensitive for disk-latency - but it will download 99% of history)
 
@@ -3411,6 +3496,10 @@ Erigon provides extensive logging configuration through command-line flags. Key 
 * `--log.dir.verbosity`: Set file log level (default: `dbug`)
 * `--log.delays`: Enable block delay logging
 
+**Downloader (torrent) logs**
+
+The torrent client inside the Downloader keeps its own JSON-formatted file, `logs/torrent.log`. It is written at whichever is **more verbose** of `--torrent.verbosity` and `WARN`, so warnings and errors always reach it even at the default verbosity. Messages at `--torrent.verbosity` or above are additionally forwarded to Erigon's own file and console loggers, which emit them only if `--log.dir.verbosity` and `--verbosity` are themselves set to a verbose enough level.
+
 **Log Levels**
 
 The logging system defines six distinct log levels in hierarchical order:
@@ -3491,6 +3580,10 @@ Based on best practices for execution clients, your local machine's firewall set
 | 30303    | TCP & UDP    | Peer-to-Peer (P2P) Networking | Allow inbound and outbound traffic to enable peer discovery and connections.                                                             |
 | 8545     | TCP          | JSON-RPC (Public API)         | Block all traffic _except_ from explicitly defined trusted machines. This port should never be publicly exposed without strict controls. |
 | 9090     | TCP          | Private API Communication     | Block all traffic except for communication between your internal components (e.g., RPC Daemon and core node).                            |
+
+:::note
+Some hosting providers add firewall requirements and operational pitfalls on top of these. If you run on Hetzner Cloud or a Hetzner dedicated server, see the [Hetzner firewall note](/help-center/troubleshooting#hetzner-cloud--dedicated-server-firewall-note) for the ports their edge firewall must allow, and for the reserved IPv4 ranges worth blocking yourself so outbound dials do not trip their abuse detection.
+:::
 
 #### CORS Protection
 
@@ -8536,6 +8629,8 @@ kill -SIGUSR1 $(pidof erigon)
 # Stack traces are printed to the erigon log / stdout
 ```
 
+If the node is wedged and you are ready to lose it, `kill -SIGABRT <pid>` dumps the stacks and terminates that process in one step. Pass an explicit PID rather than `$(pidof erigon)`: `SIGABRT` is destructive, and on a host running more than one instance `pidof` would abort all of them.
+
 **Capture a CPU or heap profile via pprof** (requires `--pprof` flag at startup — default address `localhost:6060`; override with `--pprof.addr` and `--pprof.port`):
 
 ```bash
@@ -8553,14 +8648,48 @@ Attach the `.pprof` files and the goroutine dump to your GitHub issue.
 
 ## Hetzner Cloud / Dedicated Server Firewall Note
 
-Hetzner applies a stateless firewall at the network edge. Ensure the following ports are open for **both TCP and UDP, inbound and outbound**:
+Hetzner filters traffic at the network edge, and the two product lines need different rules:
 
-| Purpose        | Port  | Protocol |
-| -------------- | ----- | -------- |
-| P2P (Ethereum) | 30303 | TCP+UDP  |
-| P2P (Caplin)   | 9000  | TCP+UDP  |
+* **Cloud** — the firewall is stateful, so return traffic is handled for you. Outbound is allow-all, but only for as long as no outbound rule exists: per Hetzner's FAQ, *"If you define one or more outbound rules, the outbound direction also changes to implicit 'deny'"*. Adding outbound rules for the ports below would therefore cut off DNS, NTP and HTTPS — including the snapshot webseeds — and break the initial download. Define **inbound rules only** and leave the outbound list empty.
+* **Dedicated servers (Robot)** — the firewall is stateless, so return traffic needs an explicit rule of its own. Here you do need rules in both directions.
 
-Without these, the node may appear to have peers (via the cloud dashboard) but will suffer poor block propagation. Configure the firewall in the Hetzner Cloud Console under **Firewalls** or via `hcloud firewall`.
+The ports to allow inbound:
+
+| Purpose                          | Port  | Protocol |
+| -------------------------------- | ----- | -------- |
+| P2P (execution layer)            | 30303 | TCP+UDP  |
+| Snapshot downloader (BitTorrent) | 42069 | TCP+UDP  |
+| Caplin DISCV5 discovery          | 4000  | UDP      |
+| Caplin DISCV5                    | 4001  | TCP      |
+
+This table is not exhaustive — it lists what a default node needs. See [Default ports](/fundamentals/default-ports) for every port Erigon can open, including the opt-in Shutter port.
+
+The Caplin ports are its defaults (`--caplin.discovery.port` and `--caplin.discovery.tcpport`); change the rules to match if you override them. If you run an **external** consensus client instead of Caplin, open the ports that client uses rather than the Caplin ones. Lighthouse, Teku and Nimbus default to `9000` TCP+UDP, and Lighthouse additionally uses `9001` UDP for QUIC; Prysm defaults to `13000` TCP and `12000` UDP. Check your client's own documentation rather than assuming `9000`.
+
+Without these, the node may appear to have peers (via the cloud dashboard) but will suffer poor block propagation. Configure Cloud firewalls in the Hetzner Cloud Console under **Firewalls** or via `hcloud firewall`; for dedicated servers the equivalent lives in the Robot panel under **Server → Firewall**.
+
+A public-facing Erigon node should also not attempt to peer with IPv4 ranges that are reserved for special use. Blocking them is worth doing explicitly on Hetzner, whose abuse and netscan detection flags outbound dials to reserved ranges — that is what prompted this note, rather than their firewall filtering the traffic. Do not apply this to a node using `--caplin.local-discovery`, which deliberately peers over private IPs. The authoritative list is the [IANA IPv4 Special-Purpose Address Registry](https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml) ([RFC 6890](https://datatracker.ietf.org/doc/html/rfc6890)); the ranges below are the ones commonly blocked for an Ethereum node (`100.64.0.0/10` comes from [RFC 6598](https://datatracker.ietf.org/doc/html/rfc6598), and `192.88.99.0/24` has since been deprecated by [RFC 7526](https://datatracker.ietf.org/doc/html/rfc7526) — blocking it remains correct):
+
+```text
+0.0.0.0/8             "This" Network                                RFC 1122, Section 3.2.1.3
+10.0.0.0/8            Private-Use Networks                          RFC 1918
+100.64.0.0/10         Carrier-Grade NAT (CGN)                       RFC 6598, Section 7
+127.0.0.0/8           Loopback                                      RFC 1122, Section 3.2.1.3
+169.254.0.0/16        Link Local                                    RFC 3927
+172.16.0.0/12         Private-Use Networks                          RFC 1918
+192.0.0.0/24          IETF Protocol Assignments                     RFC 5736
+192.0.2.0/24          TEST-NET-1                                    RFC 5737
+192.88.99.0/24        6to4 Relay Anycast                            RFC 3068
+192.168.0.0/16        Private-Use Networks                          RFC 1918
+198.18.0.0/15         Network Interconnect Device Benchmark Testing RFC 2544
+198.51.100.0/24       TEST-NET-2                                    RFC 5737
+203.0.113.0/24        TEST-NET-3                                    RFC 5737
+224.0.0.0/4           Multicast                                     RFC 3171
+240.0.0.0/4           Reserved for Future Use                       RFC 1112, Section 4
+255.255.255.255/32    Limited Broadcast                             RFC 919 and RFC 922, Section 7
+```
+
+A near-identical list expressed in [iptables syntax](https://ethereum.stackexchange.com/questions/6386/how-to-prevent-being-blacklisted-for-running-an-ethereum-client/13068#13068) is available on Stack Exchange. It covers 14 of the 16 ranges above, deliberately leaving out `127.0.0.0/8` and `255.255.255.255/32`: an `OUTPUT` drop on loopback would break Erigon's own inter-component traffic, such as the RPC Daemon reaching the core node on `127.0.0.1:9090`.
 
 ---
 

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -3498,7 +3498,7 @@ Erigon provides extensive logging configuration through command-line flags. Key 
 
 **Downloader (torrent) logs**
 
-The torrent client inside the Downloader keeps its own JSON-formatted file, `logs/torrent.log`. It is written at whichever is **more verbose** of `--torrent.verbosity` and `WARN`, so warnings and errors always reach it even at the default verbosity. Messages at `--torrent.verbosity` or above are additionally forwarded to Erigon's own file and console loggers, which emit them only if `--log.dir.verbosity` and `--verbosity` are themselves set to a verbose enough level.
+The torrent client inside the Downloader keeps its own JSON-formatted file at `<datadir>/logs/torrent.log`. The path is built from the datadir and does **not** follow `--log.dir.path`, so it stays there even when Erigon's own logs are redirected elsewhere. It is written at whichever is **more verbose** of `--torrent.verbosity` and `WARN`, so warnings and errors always reach it even at the default verbosity. Messages at `--torrent.verbosity` or above are additionally forwarded to Erigon's own file and console loggers, which emit them only if `--log.dir.verbosity` and `--verbosity` are themselves set to a verbose enough level.
 
 **Log Levels**
 
@@ -8651,7 +8651,7 @@ Attach the `.pprof` files and the goroutine dump to your GitHub issue.
 Hetzner filters traffic at the network edge, and the two product lines need different rules:
 
 * **Cloud** — the firewall is stateful, so return traffic is handled for you. Outbound is allow-all, but only for as long as no outbound rule exists: per Hetzner's FAQ, *"If you define one or more outbound rules, the outbound direction also changes to implicit 'deny'"*. Adding outbound rules for the ports below would therefore cut off DNS, NTP and HTTPS — including the snapshot webseeds — and break the initial download. Define **inbound rules only** and leave the outbound list empty.
-* **Dedicated servers (Robot)** — the firewall is stateless, so return traffic needs an explicit rule of its own. Here you do need rules in both directions.
+* **Dedicated servers (Robot)** — the firewall is stateless, so nothing is inferred from an outgoing connection. The listening ports in the table below are not enough on their own: replies to Erigon's own outbound connections — DNS, HTTPS to the snapshot webseeds, and outgoing peer dials — arrive on ephemeral local ports and need inbound rules of their own (TCP with `ack` set, plus the UDP ranges you use), and any outbound filtering needs matching reply rules. Follow [Hetzner's notes on stateless-firewall configuration](https://docs.hetzner.com/robot/dedicated-server/firewall/#notes-about-stateless-firewall-configuration) rather than porting a Cloud ruleset across.
 
 The ports to allow inbound:
 
@@ -8660,11 +8660,11 @@ The ports to allow inbound:
 | P2P (execution layer)            | 30303 | TCP+UDP  |
 | Snapshot downloader (BitTorrent) | 42069 | TCP+UDP  |
 | Caplin DISCV5 discovery          | 4000  | UDP      |
-| Caplin DISCV5                    | 4001  | TCP      |
+| Caplin libp2p peering            | 4001  | TCP      |
 
 This table is not exhaustive — it lists what a default node needs. See [Default ports](/fundamentals/default-ports) for every port Erigon can open, including the opt-in Shutter port.
 
-The Caplin ports are its defaults (`--caplin.discovery.port` and `--caplin.discovery.tcpport`); change the rules to match if you override them. If you run an **external** consensus client instead of Caplin, open the ports that client uses rather than the Caplin ones. Lighthouse, Teku and Nimbus default to `9000` TCP+UDP, and Lighthouse additionally uses `9001` UDP for QUIC; Prysm defaults to `13000` TCP and `12000` UDP. Check your client's own documentation rather than assuming `9000`.
+The Caplin ports are its defaults (`--caplin.discovery.port` and `--caplin.discovery.tcpport`); change the rules to match if you override them. Note the second flag's help text calls it a DISCV5 port, which is a misnomer: DISCV5 is UDP-only and runs on `4000`, while `4001` is the libp2p TCP listen address Caplin advertises for peering. If you run an **external** consensus client instead of Caplin, open the ports that client uses rather than the Caplin ones. Lighthouse, Teku and Nimbus default to `9000` TCP+UDP, and Lighthouse additionally uses `9001` UDP for QUIC; Prysm defaults to `13000` TCP and `12000` UDP. Check your client's own documentation rather than assuming `9000`.
 
 Without these, the node may appear to have peers (via the cloud dashboard) but will suffer poor block propagation. Configure Cloud firewalls in the Hetzner Cloud Console under **Firewalls** or via `hcloud firewall`; for dedicated servers the equivalent lives in the Robot panel under **Server → Firewall**.
 
@@ -8689,7 +8689,11 @@ A public-facing Erigon node should also not attempt to peer with IPv4 ranges tha
 255.255.255.255/32    Limited Broadcast                             RFC 919 and RFC 922, Section 7
 ```
 
-A near-identical list expressed in [iptables syntax](https://ethereum.stackexchange.com/questions/6386/how-to-prevent-being-blacklisted-for-running-an-ethereum-client/13068#13068) is available on Stack Exchange. It covers 14 of the 16 ranges above, deliberately leaving out `127.0.0.0/8` and `255.255.255.255/32`: an `OUTPUT` drop on loopback would break Erigon's own inter-component traffic, such as the RPC Daemon reaching the core node on `127.0.0.1:9090`.
+A near-identical list expressed in [iptables syntax](https://ethereum.stackexchange.com/questions/6386/how-to-prevent-being-blacklisted-for-running-an-ethereum-client/13068#13068) is available on Stack Exchange, but do not paste it in as a blanket `OUTPUT` policy:
+
+* It omits `127.0.0.0/8`, which is correct — an `OUTPUT` drop on loopback would break Erigon's own inter-component traffic, such as the RPC Daemon reaching the core node on `127.0.0.1:9090`.
+* It has no separate `255.255.255.255/32` rule, but that address is **not** left reachable: `240.0.0.0/4` spans `240.0.0.0`–`255.255.255.255` and already covers it.
+* On **Hetzner Cloud** it drops the metadata endpoint at `169.254.169.254`, which sits inside `169.254.0.0/16`, along with legitimate private-network and multicast traffic. Exempt what your instance needs, or scope the rules to Erigon's peer dialing instead of the whole `OUTPUT` chain.
 
 ---
 

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -8629,7 +8629,7 @@ kill -SIGUSR1 $(pidof erigon)
 # Stack traces are printed to the erigon log / stdout
 ```
 
-If the node is wedged and you are ready to lose it, `kill -SIGQUIT <pid>` dumps every goroutine stack and terminates that process in one step. Erigon wires a handler only for `SIGUSR1`, so `SIGQUIT` falls through to the Go runtime's own behaviour — the same one this repository's CI watchdog relies on. Pass an explicit PID rather than `$(pidof erigon)`: `SIGQUIT` is destructive, and on a host running more than one instance `pidof` would kill all of them.
+If the node is wedged and you are ready to lose it, `kill -SIGQUIT <pid>` dumps every goroutine stack and terminates that process in one step. Erigon installs a stack-dump handler for `SIGUSR1` and shutdown handlers for `SIGINT` and `SIGTERM`, but none for `SIGQUIT` — so `SIGQUIT` falls through to the Go runtime's own behaviour, the same one this repository's CI watchdog relies on. Pass an explicit PID rather than `$(pidof erigon)`: `SIGQUIT` is destructive, and on a host running more than one instance `pidof` would kill all of them.
 
 **Capture a CPU or heap profile via pprof** (requires `--pprof` flag at startup — default address `localhost:6060`; override with `--pprof.addr` and `--pprof.port`):
 

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -2763,7 +2763,7 @@ http = true
 Erigon supports configuration through environment variables, primarily for experimental features and advanced settings.
 
 :::tip
-Erigon's own variables — everything below except the [Docker](#docker-environment-variables) ones, which do not take the `ERIGON_` prefix — can be set with or without it. `ERIGON_SNAPSHOT_MADV_RND` and `SNAPSHOT_MADV_RND` both work. Prefer the prefixed form: Erigon logs a warning when it reads the bare name, and the prefix keeps these from colliding with unrelated variables in your environment. The examples below use it.
+Erigon's own variables — everything below except the [Docker](#docker-environment-variables) ones, which do not take the `ERIGON_` prefix — can be set with or without it. `ERIGON_SNAPSHOT_MADV_RND` and `SNAPSHOT_MADV_RND` both work. Prefer the prefixed form. Erigon logs every variable it reads at warn level either way, but the bare name draws an extra `use ERIGON_ prefix for env` warning on top, and the prefix keeps these from colliding with unrelated variables in your environment. The examples below use it.
 :::
 
 ### Core Environment Variables
@@ -8629,7 +8629,7 @@ kill -SIGUSR1 $(pidof erigon)
 # Stack traces are printed to the erigon log / stdout
 ```
 
-If the node is wedged and you are ready to lose it, `kill -SIGABRT <pid>` dumps the stacks and terminates that process in one step. Pass an explicit PID rather than `$(pidof erigon)`: `SIGABRT` is destructive, and on a host running more than one instance `pidof` would abort all of them.
+If the node is wedged and you are ready to lose it, `kill -SIGQUIT <pid>` dumps every goroutine stack and terminates that process in one step. Erigon wires a handler only for `SIGUSR1`, so `SIGQUIT` falls through to the Go runtime's own behaviour — the same one this repository's CI watchdog relies on. Pass an explicit PID rather than `$(pidof erigon)`: `SIGQUIT` is destructive, and on a host running more than one instance `pidof` would kill all of them.
 
 **Capture a CPU or heap profile via pprof** (requires `--pprof` flag at startup — default address `localhost:6060`; override with `--pprof.addr` and `--pprof.port`):
 
@@ -8668,7 +8668,7 @@ The Caplin ports are its defaults (`--caplin.discovery.port` and `--caplin.disco
 
 Without these, the node may appear to have peers (via the cloud dashboard) but will suffer poor block propagation. Configure Cloud firewalls in the Hetzner Cloud Console under **Firewalls** or via `hcloud firewall`; for dedicated servers the equivalent lives in the Robot panel under **Server → Firewall**.
 
-A public-facing Erigon node should also not attempt to peer with IPv4 ranges that are reserved for special use. Blocking them is worth doing explicitly on Hetzner, whose abuse and netscan detection flags outbound dials to reserved ranges — that is what prompted this note, rather than their firewall filtering the traffic. Do not apply this to a node using `--caplin.local-discovery`, which deliberately peers over private IPs. The authoritative list is the [IANA IPv4 Special-Purpose Address Registry](https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml) ([RFC 6890](https://datatracker.ietf.org/doc/html/rfc6890)); the ranges below are the ones commonly blocked for an Ethereum node (`100.64.0.0/10` comes from [RFC 6598](https://datatracker.ietf.org/doc/html/rfc6598), and `192.88.99.0/24` has since been deprecated by [RFC 7526](https://datatracker.ietf.org/doc/html/rfc7526) — blocking it remains correct):
+A public-facing Erigon node should also not attempt to peer with IPv4 ranges that are reserved for special use. Blocking them is worth doing explicitly on Hetzner, whose abuse and netscan detection flags outbound dials to reserved ranges — that is what prompted this note, rather than their firewall filtering the traffic. Do not apply this to a node using `--caplin.local-discovery`, which deliberately peers over private IPs. The authoritative list is the [IANA IPv4 Special-Purpose Address Registry](https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml) ([RFC 6890](https://datatracker.ietf.org/doc/html/rfc6890)); the ranges below are that registry's entries most often blocked for an Ethereum node — it is a reference list, not a ruleset to paste verbatim: `127.0.0.0/8` and `255.255.255.255/32` are included for completeness but must **not** go into an outbound drop rule, for the reason given after the list (`100.64.0.0/10` comes from [RFC 6598](https://datatracker.ietf.org/doc/html/rfc6598), and `192.88.99.0/24` has since been deprecated by [RFC 7526](https://datatracker.ietf.org/doc/html/rfc7526) — blocking it remains correct):
 
 ```text
 0.0.0.0/8             "This" Network                                RFC 1122, Section 3.2.1.3
@@ -8679,7 +8679,7 @@ A public-facing Erigon node should also not attempt to peer with IPv4 ranges tha
 172.16.0.0/12         Private-Use Networks                          RFC 1918
 192.0.0.0/24          IETF Protocol Assignments                     RFC 5736
 192.0.2.0/24          TEST-NET-1                                    RFC 5737
-192.88.99.0/24        6to4 Relay Anycast                            RFC 3068
+192.88.99.0/24        6to4 Relay Anycast (deprecated)               RFC 3068, RFC 7526
 192.168.0.0/16        Private-Use Networks                          RFC 1918
 198.18.0.0/15         Network Interconnect Device Benchmark Testing RFC 2544
 198.51.100.0/24       TEST-NET-2                                    RFC 5737

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -109,7 +109,9 @@ If you must split the datadir across a fast and a slow device, see [Optimizing S
 
 ## Disk Size and RAM Requirements
 
-The amount of disk space recommended and RAM you need depends on the [pruning mode](../fundamentals/pruning-modes) you want to run. **Current Disk Usage** values listed below are obtained using the standard Erigon + [Caplin](../fundamentals/caplin) configuration, with the sole exception of the `--prune.mode` flag.
+The amount of disk space recommended and RAM you need depends on the [pruning mode](../fundamentals/pruning-modes) you want to run. **Current Disk Usage** values listed below are obtained using the standard Erigon + [Caplin](../fundamentals/caplin) configuration, varying only the `--prune.mode` flag unless a tab notes otherwise.
+
+### Ethereum mainnet
 
 | Pruning Mode | Current Disk Usage | Disk Size (Recommended) | RAM (Required) | RAM (Recommended) |
 | --- | --- | --- | --- | --- |
@@ -119,6 +121,8 @@ The amount of disk space recommended and RAM you need depends on the [pruning mo
 
 _Current Disk Usage measured as of 2026-07-19; usage grows over time as the chain grows._
 
+### Gnosis Chain
+
 | **Pruning Mode**  | **Current Disk Usage** | **Disk Size (Recommended)** | **RAM (Required)** | **RAM (Recommended)** |
 | -------------- | ---------------------- | --------------------------- | ------------------ | --------------------- |
 | Archive        | 673.59 GB | 1 TB                        | 16 GB              | 32 GB                 |
@@ -127,17 +131,23 @@ _Current Disk Usage measured as of 2026-07-19; usage grows over time as the chai
 
 _Current Disk Usage measured as of 2026-07-21; usage grows over time as the chain grows._
 
+### Sepolia
+
 | **Pruning Mode** | **Current Disk Usage** |
 | -------------- | ---------------------- |
 | Archive        | 1.10 TB |
 
 _Current Disk Usage measured as of 2026-07-29; usage grows over time as the chain grows. Execution layer only — full and minimal modes are not measured for this network._
 
+### Hoodi
+
 | **Pruning Mode** | **Current Disk Usage** |
 | -------------- | ---------------------- |
 | Archive        | 133.73 GB |
 
 _Current Disk Usage measured as of 2026-07-29; usage grows over time as the chain grows. Execution layer only — full and minimal modes are not measured for this network._
+
+### Chiado
 
 | **Pruning Mode** | **Current Disk Usage** |
 | -------------- | ---------------------- |
@@ -202,6 +212,8 @@ The recommended approach involves running and syncing an **Erigon node alongside
 
 You can choose whether to migrate to Erigon + Caplin (the simplest setup) or continue using your existing CL.
 
+#### Migrate to Erigon + Caplin (Internal CL)
+
 This path offers the simplest validator configuration by using Erigon's embedded consensus client, Caplin. You will no longer need your external Consensus Layer (CL) client or a JWT secret for CL-EL communication.
 
 **Steps for Minimal Downtime**
@@ -221,6 +233,8 @@ This path offers the simplest validator configuration by using Erigon's embedded
    * To restart Erigon, there's no need to specify `--port`. Refer to this [guide](../fundamentals/caplin) for additional Erigon + Caplin configuration recommendations.
    * Crucially, reconfigure your **validator keys manager** to point directly to the Erigon Beacon API, as Erigon/Caplin now handles both layers internally.
 6. **Decommission Old Setup**: Verify Erigon/Caplin is proposing and attesting blocks correctly. If confirmed, safely remove Geth, the external CL client, and all their data, including the old JWT secret.
+
+#### Migrate to Erigon + External CL
 
 Switch to an Erigon Execution Layer (EL) while keeping your current external Consensus Layer (CL) client (e.g., Prysm, Lighthouse) and your existing JWT secret. Start by syncing Erigon with Caplin as the CL, then configure it to use the external CL.
 
@@ -245,6 +259,8 @@ Switch to an Erigon Execution Layer (EL) while keeping your current external Con
 
 This is the simplest option as it requires no configuration adjustments. However, the node will be down until Erigon finishes syncing.
 
+#### Erigon + Caplin (Fastest Sync)
+
 This path is the fastest way to get Erigon running. It utilizes **Erigon's embedded consensus client, Caplin**, requiring no external CL client or JWT secret. This is ideal for home users with limited disk space and no critical uptime requirements.
 
 **Steps for Quickest Start**
@@ -255,6 +271,8 @@ This path is the fastest way to get Erigon running. It utilizes **Erigon's embed
 4. **Synchronization**: Start syncing Erigon with the default Caplin configuration (Caplin does not use the Engine API).
 5. **Final Setup**: Once Erigon is fully synced, your node is online.
 6. **Monitoring**: Monitor the sync progress using `eth_syncing` or the health check, and ensure no errors appear in Erigon's logs.
+
+#### Erigon + External CL (Reuse Existing CL)
 
 This path retains your existing **external Consensus Layer (CL)** client (e.g., Prysm, Lighthouse) but swaps the old EL client for Erigon. Since downtime is accepted, this process requires simpler port management.
 
@@ -357,13 +375,19 @@ URL: https://docs.erigon.tech/get-started/installation
 
 To install Erigon, begin by choosing an installation method suited to your operating system and technical preference. Options range from the simplest to the most complex, including pre-built images, containers, or source compilation.
 
+### Linux
+
 Pre-built Binaries — Fastest way to get started. Download and run a pre-compiled binary for your architecture.
 Docker — Run Erigon in an isolated container. Recommended for most users.
 Build from Source — Full control over the build. Requires Go, C++ compiler, and CLI experience.
 Ethereum on ARM — Community image and APT repository for ARM single-board computers (Raspberry Pi, Rock 5B, Orange Pi 5).
 
+### macOS
+
 Docker — Run Erigon in an isolated container. The recommended method on macOS.
 Build from Source — Compile directly on your Mac. Requires Go, Clang/GCC, and CLI experience.
+
+### Windows
 
 Native Compilation — Compile and run Erigon directly on Windows using Chocolatey, MinGW, and Go.
 WSL (Windows Subsystem for Linux) — Run a full Linux environment on Windows. Recommended for best performance.
@@ -1108,6 +1132,8 @@ scheduled forks, not after.
 
 ## Erigon with Prysm as the external CL
 
+### Prysm
+
 1.  Start Erigon adding the `--externalcl` flag:
 
     ```bash
@@ -1131,6 +1157,8 @@ scheduled forks, not after.
     --checkpoint-sync-url=https://mainnet.checkpoint.sigp.io \
     --genesis-beacon-api-url=https://mainnet.checkpoint.sigp.io
     ```
+
+### Lighthouse
 
 1.  Start Erigon adding the `--externalcl` flag:
 
@@ -1424,16 +1452,22 @@ URL: https://docs.erigon.tech/fundamentals/basic-usage
 
 Erigon is mainly operated through the command line. The commands may vary based on your installation method.
 
+## Pre-Built Binaries
+
 Open your terminal and simply start Erigon with the command:
 
 ```text
 erigon [options]
 ```
 
+## Docker
+
 * You can use Docker Compose like in this [example](/get-started/easy-nodes/how-to-run-an-ethereum-node#a-create-the-configuration-file)
 *   Alternatively you can use the Docker syntax, for example:
 
     `docker run -it erigontech/erigon:v{ERIGON_VERSION} [options]`
+
+## Built from Source
 
 Open your terminal and move to the directory where you installed Erigon
 
@@ -1446,6 +1480,8 @@ You can then start Erigon with the below command:
 ```shell
 ./build/bin/erigon [options]
 ```
+
+## Windows
 
 To run Erigon after a native compilation, enter the following command in your Command Prompt or PowerShell:
 
@@ -3921,6 +3957,8 @@ When something looks wrong with your node, ask the assistant to sift through log
 
 Add the following to your Claude Desktop configuration file (`~/.config/claude-desktop/config.json` on Linux/macOS, `%APPDATA%\claude-desktop\config.json` on Windows):
 
+### JSON-RPC mode
+
 ```json
 {
   "mcpServers": {
@@ -3932,6 +3970,8 @@ Add the following to your Claude Desktop configuration file (`~/.config/claude-d
 }
 ```
 
+### Datadir mode
+
 ```json
 {
   "mcpServers": {
@@ -3942,6 +3982,8 @@ Add the following to your Claude Desktop configuration file (`~/.config/claude-d
   }
 }
 ```
+
+### Embedded (SSE)
 
 ```json
 {
@@ -3993,12 +4035,16 @@ claude mcp remove erigon
 
 [OpenAI Codex CLI](https://github.com/openai/codex) supports MCP servers via `~/.codex/config.yaml`. Add the `mcp_servers` key to your existing config file:
 
+### Embedded SSE
+
 ```yaml
 mcp_servers:
   erigon:
     type: sse
     url: http://127.0.0.1:8553/sse
 ```
+
+### Standalone stdio
 
 ```yaml
 mcp_servers:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -60,11 +60,52 @@ A locally mounted **SSD** (Solid-State Drive) or **NVMe** (Non-Volatile Memory E
 
 | Component | Recommendation | Notes |
 | --- | --- | --- |
-| Disk Type | Use high-end NVMe SSDs. | Avoid HDDs.SSD performance may degrade when nearing full capacity. |
-| Disk Configuration | RAID 0 for multiple disks (Speed) | High-Speed Option: RAID 0 provides maximum speed but no redundancy (data loss risk).ZFS filesystems may be considered for Archive nodes for their data integrity features, but complex RAID-Z setups are generally not recommended. |
+| Disk Type | Use high-end NVMe SSDs. | Avoid HDDs. SSD performance may degrade when nearing full capacity. |
+| Disk Configuration | A single NVMe device is enough for any pruning mode. | An archive node fits on one 4 TB drive, so RAID 0 striping is not needed. For failure protection, use a mirrored array, not RAID 0. See [Filesystem](#filesystem). |
+| Filesystem | ext4 or XFS | See [Filesystem](#filesystem) below. |
 | RAM | Adequate memory is crucial | Reduces bottlenecks during sync and improves performance under load. |
-| CPU | 4–8 cores for Full nodes8–16 cores for Archive nodes | More cores are generally better for intense sync and query operations. |
+| CPU | 4–8 cores for Full nodes, 8–16 cores for Archive nodes | More cores are generally better for intense sync and query operations. |
 | Linux | Kernel version > v4 | A modern Linux distribution is required. |
+
+## Filesystem
+
+Use **ext4** or **XFS** on a single NVMe device. The disk figures below are measured on ext4, and that is the configuration Erigon's own measurements come from. XFS is a reasonable choice on the same reasoning, but we have not measured it.
+
+Mount with `noatime` so reads do not generate metadata writes:
+
+```
+UUID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx  /data  ext4  defaults,noatime  0 2
+```
+
+Use the filesystem UUID (`blkid` prints it) rather than a `/dev/nvme…` name, which can move between boots. The final `2` is the `fsck` pass for a non-root filesystem.
+
+### Why the filesystem matters
+
+Erigon's bottleneck is disk **latency**, not throughput or IOPS — see [Improving Performance](/help-center/known-issues#improving-performance). Erigon does pre-warm what it can, but two properties of the workload mean its reads cannot be fully predicted, so part of every block's reads lands cold:
+
+* **EVM execution reads arbitrary state.** Nothing tells you in advance which accounts or storage slots a block will touch. Once the working set no longer fits in RAM, some of those reads land on cold data no cache had reason to hold.
+* **Merkle trie updates pull in neighbours.** Updating one key requires reading the nodes next to it in the trie. Those may be accounts the EVM never touches — they are involved only because of where they sit in the trie.
+
+Every layer the filesystem adds is added on top of each of those reads. That is what favours a thin filesystem here: ext4 and XFS store a file and leave caching to the OS page cache, which is what Erigon's memory-mapped database is built to use.
+
+### Filesystems to avoid
+
+Prefer a plain journaling filesystem over a copy-on-write or database-like one:
+
+* **ZFS** behaves more like a database than a filesystem. It keeps its own write-ahead log and its own cache (**ARC**), and that cache competes with the OS page cache for the same RAM. Optional features such as encryption and dedup add work to the read path this workload is bound by, and tuning ZFS for it is not a solved problem.
+* **Btrfs** is a copy-on-write B-tree of pages, and Erigon's MDBX database is itself a B-tree of pages, so you end up running a database inside a database. Its `autodefrag` feature is the sharpest edge: it can multiply write I/O by as much as 100x. See [Background File System Features Can Hurt Performance](/help-center/known-issues#background-file-system-features-can-hurt-performance).
+
+Filesystems other than ext4 and XFS are not part of what we measure, so treat their performance as unverified rather than assumed.
+
+A few more points that follow from Erigon's storage model — see [Database](../fundamentals/database) for the layout:
+
+* **One device is enough.** An archive node fits on a single 4 TB drive, so RAID 0 gains you no capacity you need while doubling the chance of losing the datadir. Stripe only if no single drive you have is large enough.
+* **For failure protection, use redundancy — not RAID 0.** A mirrored array and ECC memory guard against a failing disk or bad RAM, which is what [Best Practices](/help-center/best-practices) recommends. RAID 0 does the opposite.
+* **Most of the datadir is re-downloadable.** Snapshot files are content-addressed and refetched from peers, so `chaindata/` is the part worth backing up.
+* **Erigon memory-maps its database.** Leave RAM free for the page cache rather than handing it to a filesystem or volume manager to cache on its own.
+* **Network and cloud block storage are slow for block execution.** See [known issues](/help-center/known-issues#cloud-network-drives).
+
+If you must split the datadir across a fast and a slow device, see [Optimizing Storage](../fundamentals/optimizing-storage).
 
 ## Disk Size and RAM Requirements
 
@@ -116,6 +157,19 @@ Your internet bandwidth is also an important factor, particularly for sync speed
 | -------------- | -------------------- | ----------------------- |
 | Staking/Mining | 10 Mbps              | 50 Mbps                 |
 | Non-Staking    | 5 Mbps               | 25 Mbps                 |
+
+## Sync Times
+
+Approximate times to sync from scratch to the tip of the chain.
+
+| Chain    | Archive | Full (Default) | Minimal |
+| -------- | ------- | -------------- | ------- |
+| Ethereum | ~8 h    | ~4–6 h         | ~2 h    |
+| Gnosis   | ~2 h    | ~1–2 h         | ~30 m   |
+
+:::info
+These figures are indicative and are **not measured by CI** — read them as an order of magnitude, not a target. Most of the elapsed time is snapshot download rather than block execution, so your available [bandwidth](#bandwidth-requirements) influences the result more than CPU does: expect proportionally faster syncs on a well-connected host and slower ones on a constrained link.
+:::
 
 ---
 
@@ -559,13 +613,27 @@ make -j<n> erigon
 
 The resulting executable binary will be created in the `./build/bin/erigon` path.
 
+**2.4 Installing Outside the Build Tree (Optional)**
+
+Running Erigon as a [dedicated system user](/fundamentals/security) — for example under `systemd` — is easiest when the binaries live outside your source checkout, where that user can reach them. Pass a destination to `make install`:
+
+```sh
+make DIST=/opt/erigon install
+```
+
+`make install` creates the destination directory, so a path under `/opt` needs either `sudo make DIST=/opt/erigon install` or a directory you already own (`sudo install -d -o $USER /opt/erigon`). A path under `$HOME/erigon` avoids that entirely. `make install` copies whatever is currently in `build/bin`, so build every component you intend to deploy before running it.
+
+Once installed this way, run the installed copy — `/opt/erigon/erigon` — rather than the one in the build tree.
+
 **3. Running Erigon**
 
-After installation, you can run Erigon from your terminal:
+From the build tree, run Erigon from your terminal:
 
 ```sh
 ./build/bin/erigon [options]
 ```
+
+If you completed step 2.4, run the binary at your chosen `DIST` path instead.
 
 ### Windows
 
@@ -1760,7 +1828,7 @@ Deleting `chaindata/` is **recoverable but not free**: it discards the latest mu
 
 ## Tuning knobs
 
-- **`--batchSize`** — size of the Execution stage's in-memory buffer before it is flushed to MDBX. Default: `512M`. Raising it (for example `--batchSize 1G` or higher) can speed up execution-heavy sync at the cost of more RAM.
+- **`--batchSize`** — size of the Execution stage's in-memory buffer before it is flushed to MDBX. Default: `512M`. Raising it (for example `--batchSize 1G` or higher) can speed up execution-heavy sync at the cost of more RAM. It is the Execution stage's commit threshold, so a larger value means larger single MDBX write transactions, which raise the file's high-water mark in bigger steps. Keeping it at or below `1G` is a useful heuristic if you want MDBX to grow more gradually.
 - **`--db.size.limit`** — caps the MDBX file size. Useful when running multiple Erigon instances on one disk to prevent one from starving the others.
 - **`--db.read.concurrency`** — maximum number of concurrent open MDBX read transactions (the read-tx semaphore). Raise it for nodes serving heavy parallel RPC (for example a high-throughput RPC daemon against the same datadir); low values are fine for low-read-concurrency nodes such as validators.
 - **Symlinks for tiered storage.** Place `chaindata/` and `snapshots/domain/` on fast NVMe, leave `snapshots/idx/` and `snapshots/history/` on cheaper SATA. See [Optimizing Storage](optimizing-storage) for the recipe.
@@ -2072,6 +2140,12 @@ When Caplin is running, it exposes a Beacon API that external tools can query. T
 | `--beacon.api.write.timeout` | `31536000` | HTTP server write timeout, in seconds (~1 year) |
 | `--beacon.api.idle.timeout` | `25` | HTTP server idle timeout, in seconds |
 
+The API is not served until you enable it with `--beacon.api=<namespaces>`; see [Caplin for staking](../staking/caplin) for the full namespace list.
+
+:::note
+Enabling the Beacon API increases RAM usage by roughly **6 GB**. Account for it when sizing your host — see [Hardware Requirements](../get-started/hardware-requirements).
+:::
+
 ---
 
 # CLI Reference
@@ -2371,9 +2445,9 @@ Flags for configuring various RPC servers and their behavior. See [Interacting w
   * Default: `10000`
 * `--rpc.subscription.filters.maxtxs value`: Maximum transactions to store per subscription.
   * Default: `10000`
-* `--rpc.subscription.filters.maxaddresses value`: Maximum addresses per subscription to filter logs by.
+* `--rpc.subscription.filters.maxaddresses value`: Maximum addresses accepted per log subscription.
   * Default: `0`
-* `--rpc.subscription.filters.maxtopics value`: Maximum topics per subscription to filter logs by.
+* `--rpc.subscription.filters.maxtopics value`: Maximum topic alternatives accepted across all positions per log subscription.
   * Default: `0`
 * `--rpc.subscription.filters.timeout value`: Timeout before idle subscription filters are evicted.
   * Default: `5m0s`
@@ -2688,6 +2762,10 @@ http = true
 
 Erigon supports configuration through environment variables, primarily for experimental features and advanced settings.
 
+:::tip
+Erigon's own variables — everything below except the [Docker](#docker-environment-variables) ones, which do not take the `ERIGON_` prefix — can be set with or without it. `ERIGON_SNAPSHOT_MADV_RND` and `SNAPSHOT_MADV_RND` both work. Prefer the prefixed form: Erigon logs a warning when it reads the bare name, and the prefix keeps these from colliding with unrelated variables in your environment. The examples below use it.
+:::
+
 ### Core Environment Variables
 
 **Database and Performance:**
@@ -2757,16 +2835,16 @@ When running Erigon in [Docker](/fundamentals/docker-compose), you can configure
 **Basic Performance Tuning:**
 
 ```bash
-export MDBX_LOCK_IN_RAM=true
-export SNAPSHOT_MADV_RND=false
+export ERIGON_MDBX_LOCK_IN_RAM=true
+export ERIGON_SNAPSHOT_MADV_RND=false
 ./build/bin/erigon --datadir=/path/to/data
 ```
 
 **Memory Debugging:**
 
 ```bash
-export SAVE_HEAP_PROFILE=true
-export HEAP_PROFILE_THRESHOLD=45
+export ERIGON_SAVE_HEAP_PROFILE=true
+export ERIGON_HEAP_PROFILE_THRESHOLD=45
 ./build/bin/erigon --datadir=/path/to/data
 ```
 
@@ -3063,7 +3141,7 @@ Set **both** `--nat` and `--caplin.nat` to the same external IP, otherwise your 
 URL: https://docs.erigon.tech/fundamentals/optimizing-storage
 
 
-For optimal performance, it's recommended to store the datadir on a fast NVMe-RAID disk. However, if this is not feasible, you can store the history on a cheaper disk and still achieve good performance.
+For optimal performance, store the datadir on a single fast NVMe device formatted with ext4 or XFS — see [Filesystem](../get-started/hardware-requirements#filesystem). If that is not feasible, you can keep the history on a cheaper disk and still achieve good performance.
 
 ### Step 1
 
@@ -3122,10 +3200,10 @@ These instructions are designed to improve the performance of Erigon 3, particul
 
 ## Optimize for Cloud Drives
 
-* Set `SNAPSHOT_MADV_RND=false` to enable the operating system's cache prefetching for better performance on cloud drives with good throughput but bad latency.
+* Set `ERIGON_SNAPSHOT_MADV_RND=false` to enable the operating system's cache prefetching for better performance on cloud drives with good throughput but bad latency.
 
 ```bash
-SNAPSHOT_MADV_RND=false
+export ERIGON_SNAPSHOT_MADV_RND=false
 ```
 
 ## Lock Latest State in RAM
@@ -3282,10 +3360,17 @@ For Prometheus monitoring, each instance should expose metrics on different port
 
 If using network-attached storage, apply these optimizations:
 
+Set the environment variable before starting Erigon:
+
 ```bash
-# Reduce disk latency impact
-export SNAPSHOT_MADV_RND=false
---db.pagesize=64kb
+export ERIGON_SNAPSHOT_MADV_RND=false   # let the OS prefetch; needs spare RAM
+```
+
+And pass these flags:
+
+```bash
+--db.pagesize=64kb              # less fragmentation; must be set before the first sync
+--sync.loop.block.limit=10000   # blocks per loop iteration (default 5000)
 ```
 
 ### Memory Locking for Performance
@@ -3320,7 +3405,7 @@ What can be done:
   * use latency-critical cloud-drives
   * or attached-NVMe (at least for initial sync)
 * increase RAM
-* if you throw enough RAM, then can set env variable `SNAPSHOT_MADV_RND=false`
+* if you throw enough RAM, then can set env variable `ERIGON_SNAPSHOT_MADV_RND=false`
 * Use `--db.pagesize=64kb` (less fragmentation, more IO)
 * Or use Erigon 3 (it also sensitive for disk-latency - but it will download 99% of history)
 
@@ -3411,6 +3496,10 @@ Erigon provides extensive logging configuration through command-line flags. Key 
 * `--log.dir.verbosity`: Set file log level (default: `dbug`)
 * `--log.delays`: Enable block delay logging
 
+**Downloader (torrent) logs**
+
+The torrent client inside the Downloader keeps its own JSON-formatted file, `logs/torrent.log`. It is written at whichever is **more verbose** of `--torrent.verbosity` and `WARN`, so warnings and errors always reach it even at the default verbosity. Messages at `--torrent.verbosity` or above are additionally forwarded to Erigon's own file and console loggers, which emit them only if `--log.dir.verbosity` and `--verbosity` are themselves set to a verbose enough level.
+
 **Log Levels**
 
 The logging system defines six distinct log levels in hierarchical order:
@@ -3491,6 +3580,10 @@ Based on best practices for execution clients, your local machine's firewall set
 | 30303    | TCP & UDP    | Peer-to-Peer (P2P) Networking | Allow inbound and outbound traffic to enable peer discovery and connections.                                                             |
 | 8545     | TCP          | JSON-RPC (Public API)         | Block all traffic _except_ from explicitly defined trusted machines. This port should never be publicly exposed without strict controls. |
 | 9090     | TCP          | Private API Communication     | Block all traffic except for communication between your internal components (e.g., RPC Daemon and core node).                            |
+
+:::note
+Some hosting providers add firewall requirements and operational pitfalls on top of these. If you run on Hetzner Cloud or a Hetzner dedicated server, see the [Hetzner firewall note](/help-center/troubleshooting#hetzner-cloud--dedicated-server-firewall-note) for the ports their edge firewall must allow, and for the reserved IPv4 ranges worth blocking yourself so outbound dials do not trip their abuse detection.
+:::
 
 #### CORS Protection
 
@@ -8536,6 +8629,8 @@ kill -SIGUSR1 $(pidof erigon)
 # Stack traces are printed to the erigon log / stdout
 ```
 
+If the node is wedged and you are ready to lose it, `kill -SIGABRT <pid>` dumps the stacks and terminates that process in one step. Pass an explicit PID rather than `$(pidof erigon)`: `SIGABRT` is destructive, and on a host running more than one instance `pidof` would abort all of them.
+
 **Capture a CPU or heap profile via pprof** (requires `--pprof` flag at startup — default address `localhost:6060`; override with `--pprof.addr` and `--pprof.port`):
 
 ```bash
@@ -8553,14 +8648,48 @@ Attach the `.pprof` files and the goroutine dump to your GitHub issue.
 
 ## Hetzner Cloud / Dedicated Server Firewall Note
 
-Hetzner applies a stateless firewall at the network edge. Ensure the following ports are open for **both TCP and UDP, inbound and outbound**:
+Hetzner filters traffic at the network edge, and the two product lines need different rules:
 
-| Purpose        | Port  | Protocol |
-| -------------- | ----- | -------- |
-| P2P (Ethereum) | 30303 | TCP+UDP  |
-| P2P (Caplin)   | 9000  | TCP+UDP  |
+* **Cloud** — the firewall is stateful, so return traffic is handled for you. Outbound is allow-all, but only for as long as no outbound rule exists: per Hetzner's FAQ, *"If you define one or more outbound rules, the outbound direction also changes to implicit 'deny'"*. Adding outbound rules for the ports below would therefore cut off DNS, NTP and HTTPS — including the snapshot webseeds — and break the initial download. Define **inbound rules only** and leave the outbound list empty.
+* **Dedicated servers (Robot)** — the firewall is stateless, so return traffic needs an explicit rule of its own. Here you do need rules in both directions.
 
-Without these, the node may appear to have peers (via the cloud dashboard) but will suffer poor block propagation. Configure the firewall in the Hetzner Cloud Console under **Firewalls** or via `hcloud firewall`.
+The ports to allow inbound:
+
+| Purpose                          | Port  | Protocol |
+| -------------------------------- | ----- | -------- |
+| P2P (execution layer)            | 30303 | TCP+UDP  |
+| Snapshot downloader (BitTorrent) | 42069 | TCP+UDP  |
+| Caplin DISCV5 discovery          | 4000  | UDP      |
+| Caplin DISCV5                    | 4001  | TCP      |
+
+This table is not exhaustive — it lists what a default node needs. See [Default ports](/fundamentals/default-ports) for every port Erigon can open, including the opt-in Shutter port.
+
+The Caplin ports are its defaults (`--caplin.discovery.port` and `--caplin.discovery.tcpport`); change the rules to match if you override them. If you run an **external** consensus client instead of Caplin, open the ports that client uses rather than the Caplin ones. Lighthouse, Teku and Nimbus default to `9000` TCP+UDP, and Lighthouse additionally uses `9001` UDP for QUIC; Prysm defaults to `13000` TCP and `12000` UDP. Check your client's own documentation rather than assuming `9000`.
+
+Without these, the node may appear to have peers (via the cloud dashboard) but will suffer poor block propagation. Configure Cloud firewalls in the Hetzner Cloud Console under **Firewalls** or via `hcloud firewall`; for dedicated servers the equivalent lives in the Robot panel under **Server → Firewall**.
+
+A public-facing Erigon node should also not attempt to peer with IPv4 ranges that are reserved for special use. Blocking them is worth doing explicitly on Hetzner, whose abuse and netscan detection flags outbound dials to reserved ranges — that is what prompted this note, rather than their firewall filtering the traffic. Do not apply this to a node using `--caplin.local-discovery`, which deliberately peers over private IPs. The authoritative list is the [IANA IPv4 Special-Purpose Address Registry](https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml) ([RFC 6890](https://datatracker.ietf.org/doc/html/rfc6890)); the ranges below are the ones commonly blocked for an Ethereum node (`100.64.0.0/10` comes from [RFC 6598](https://datatracker.ietf.org/doc/html/rfc6598), and `192.88.99.0/24` has since been deprecated by [RFC 7526](https://datatracker.ietf.org/doc/html/rfc7526) — blocking it remains correct):
+
+```text
+0.0.0.0/8             "This" Network                                RFC 1122, Section 3.2.1.3
+10.0.0.0/8            Private-Use Networks                          RFC 1918
+100.64.0.0/10         Carrier-Grade NAT (CGN)                       RFC 6598, Section 7
+127.0.0.0/8           Loopback                                      RFC 1122, Section 3.2.1.3
+169.254.0.0/16        Link Local                                    RFC 3927
+172.16.0.0/12         Private-Use Networks                          RFC 1918
+192.0.0.0/24          IETF Protocol Assignments                     RFC 5736
+192.0.2.0/24          TEST-NET-1                                    RFC 5737
+192.88.99.0/24        6to4 Relay Anycast                            RFC 3068
+192.168.0.0/16        Private-Use Networks                          RFC 1918
+198.18.0.0/15         Network Interconnect Device Benchmark Testing RFC 2544
+198.51.100.0/24       TEST-NET-2                                    RFC 5737
+203.0.113.0/24        TEST-NET-3                                    RFC 5737
+224.0.0.0/4           Multicast                                     RFC 3171
+240.0.0.0/4           Reserved for Future Use                       RFC 1112, Section 4
+255.255.255.255/32    Limited Broadcast                             RFC 919 and RFC 922, Section 7
+```
+
+A near-identical list expressed in [iptables syntax](https://ethereum.stackexchange.com/questions/6386/how-to-prevent-being-blacklisted-for-running-an-ethereum-client/13068#13068) is available on Stack Exchange. It covers 14 of the 16 ranges above, deliberately leaving out `127.0.0.0/8` and `255.255.255.255/32`: an `OUTPUT` drop on loopback would break Erigon's own inter-component traffic, such as the RPC Daemon reaching the core node on `127.0.0.1:9090`.
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3498,7 +3498,7 @@ Erigon provides extensive logging configuration through command-line flags. Key 
 
 **Downloader (torrent) logs**
 
-The torrent client inside the Downloader keeps its own JSON-formatted file, `logs/torrent.log`. It is written at whichever is **more verbose** of `--torrent.verbosity` and `WARN`, so warnings and errors always reach it even at the default verbosity. Messages at `--torrent.verbosity` or above are additionally forwarded to Erigon's own file and console loggers, which emit them only if `--log.dir.verbosity` and `--verbosity` are themselves set to a verbose enough level.
+The torrent client inside the Downloader keeps its own JSON-formatted file at `<datadir>/logs/torrent.log`. The path is built from the datadir and does **not** follow `--log.dir.path`, so it stays there even when Erigon's own logs are redirected elsewhere. It is written at whichever is **more verbose** of `--torrent.verbosity` and `WARN`, so warnings and errors always reach it even at the default verbosity. Messages at `--torrent.verbosity` or above are additionally forwarded to Erigon's own file and console loggers, which emit them only if `--log.dir.verbosity` and `--verbosity` are themselves set to a verbose enough level.
 
 **Log Levels**
 
@@ -8651,7 +8651,7 @@ Attach the `.pprof` files and the goroutine dump to your GitHub issue.
 Hetzner filters traffic at the network edge, and the two product lines need different rules:
 
 * **Cloud** — the firewall is stateful, so return traffic is handled for you. Outbound is allow-all, but only for as long as no outbound rule exists: per Hetzner's FAQ, *"If you define one or more outbound rules, the outbound direction also changes to implicit 'deny'"*. Adding outbound rules for the ports below would therefore cut off DNS, NTP and HTTPS — including the snapshot webseeds — and break the initial download. Define **inbound rules only** and leave the outbound list empty.
-* **Dedicated servers (Robot)** — the firewall is stateless, so return traffic needs an explicit rule of its own. Here you do need rules in both directions.
+* **Dedicated servers (Robot)** — the firewall is stateless, so nothing is inferred from an outgoing connection. The listening ports in the table below are not enough on their own: replies to Erigon's own outbound connections — DNS, HTTPS to the snapshot webseeds, and outgoing peer dials — arrive on ephemeral local ports and need inbound rules of their own (TCP with `ack` set, plus the UDP ranges you use), and any outbound filtering needs matching reply rules. Follow [Hetzner's notes on stateless-firewall configuration](https://docs.hetzner.com/robot/dedicated-server/firewall/#notes-about-stateless-firewall-configuration) rather than porting a Cloud ruleset across.
 
 The ports to allow inbound:
 
@@ -8660,11 +8660,11 @@ The ports to allow inbound:
 | P2P (execution layer)            | 30303 | TCP+UDP  |
 | Snapshot downloader (BitTorrent) | 42069 | TCP+UDP  |
 | Caplin DISCV5 discovery          | 4000  | UDP      |
-| Caplin DISCV5                    | 4001  | TCP      |
+| Caplin libp2p peering            | 4001  | TCP      |
 
 This table is not exhaustive — it lists what a default node needs. See [Default ports](/fundamentals/default-ports) for every port Erigon can open, including the opt-in Shutter port.
 
-The Caplin ports are its defaults (`--caplin.discovery.port` and `--caplin.discovery.tcpport`); change the rules to match if you override them. If you run an **external** consensus client instead of Caplin, open the ports that client uses rather than the Caplin ones. Lighthouse, Teku and Nimbus default to `9000` TCP+UDP, and Lighthouse additionally uses `9001` UDP for QUIC; Prysm defaults to `13000` TCP and `12000` UDP. Check your client's own documentation rather than assuming `9000`.
+The Caplin ports are its defaults (`--caplin.discovery.port` and `--caplin.discovery.tcpport`); change the rules to match if you override them. Note the second flag's help text calls it a DISCV5 port, which is a misnomer: DISCV5 is UDP-only and runs on `4000`, while `4001` is the libp2p TCP listen address Caplin advertises for peering. If you run an **external** consensus client instead of Caplin, open the ports that client uses rather than the Caplin ones. Lighthouse, Teku and Nimbus default to `9000` TCP+UDP, and Lighthouse additionally uses `9001` UDP for QUIC; Prysm defaults to `13000` TCP and `12000` UDP. Check your client's own documentation rather than assuming `9000`.
 
 Without these, the node may appear to have peers (via the cloud dashboard) but will suffer poor block propagation. Configure Cloud firewalls in the Hetzner Cloud Console under **Firewalls** or via `hcloud firewall`; for dedicated servers the equivalent lives in the Robot panel under **Server → Firewall**.
 
@@ -8689,7 +8689,11 @@ A public-facing Erigon node should also not attempt to peer with IPv4 ranges tha
 255.255.255.255/32    Limited Broadcast                             RFC 919 and RFC 922, Section 7
 ```
 
-A near-identical list expressed in [iptables syntax](https://ethereum.stackexchange.com/questions/6386/how-to-prevent-being-blacklisted-for-running-an-ethereum-client/13068#13068) is available on Stack Exchange. It covers 14 of the 16 ranges above, deliberately leaving out `127.0.0.0/8` and `255.255.255.255/32`: an `OUTPUT` drop on loopback would break Erigon's own inter-component traffic, such as the RPC Daemon reaching the core node on `127.0.0.1:9090`.
+A near-identical list expressed in [iptables syntax](https://ethereum.stackexchange.com/questions/6386/how-to-prevent-being-blacklisted-for-running-an-ethereum-client/13068#13068) is available on Stack Exchange, but do not paste it in as a blanket `OUTPUT` policy:
+
+* It omits `127.0.0.0/8`, which is correct — an `OUTPUT` drop on loopback would break Erigon's own inter-component traffic, such as the RPC Daemon reaching the core node on `127.0.0.1:9090`.
+* It has no separate `255.255.255.255/32` rule, but that address is **not** left reachable: `240.0.0.0/4` spans `240.0.0.0`–`255.255.255.255` and already covers it.
+* On **Hetzner Cloud** it drops the metadata endpoint at `169.254.169.254`, which sits inside `169.254.0.0/16`, along with legitimate private-network and multicast traffic. Exempt what your instance needs, or scope the rules to Erigon's peer dialing instead of the whole `OUTPUT` chain.
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8629,7 +8629,7 @@ kill -SIGUSR1 $(pidof erigon)
 # Stack traces are printed to the erigon log / stdout
 ```
 
-If the node is wedged and you are ready to lose it, `kill -SIGQUIT <pid>` dumps every goroutine stack and terminates that process in one step. Erigon wires a handler only for `SIGUSR1`, so `SIGQUIT` falls through to the Go runtime's own behaviour — the same one this repository's CI watchdog relies on. Pass an explicit PID rather than `$(pidof erigon)`: `SIGQUIT` is destructive, and on a host running more than one instance `pidof` would kill all of them.
+If the node is wedged and you are ready to lose it, `kill -SIGQUIT <pid>` dumps every goroutine stack and terminates that process in one step. Erigon installs a stack-dump handler for `SIGUSR1` and shutdown handlers for `SIGINT` and `SIGTERM`, but none for `SIGQUIT` — so `SIGQUIT` falls through to the Go runtime's own behaviour, the same one this repository's CI watchdog relies on. Pass an explicit PID rather than `$(pidof erigon)`: `SIGQUIT` is destructive, and on a host running more than one instance `pidof` would kill all of them.
 
 **Capture a CPU or heap profile via pprof** (requires `--pprof` flag at startup — default address `localhost:6060`; override with `--pprof.addr` and `--pprof.port`):
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2763,7 +2763,7 @@ http = true
 Erigon supports configuration through environment variables, primarily for experimental features and advanced settings.
 
 :::tip
-Erigon's own variables — everything below except the [Docker](#docker-environment-variables) ones, which do not take the `ERIGON_` prefix — can be set with or without it. `ERIGON_SNAPSHOT_MADV_RND` and `SNAPSHOT_MADV_RND` both work. Prefer the prefixed form: Erigon logs a warning when it reads the bare name, and the prefix keeps these from colliding with unrelated variables in your environment. The examples below use it.
+Erigon's own variables — everything below except the [Docker](#docker-environment-variables) ones, which do not take the `ERIGON_` prefix — can be set with or without it. `ERIGON_SNAPSHOT_MADV_RND` and `SNAPSHOT_MADV_RND` both work. Prefer the prefixed form. Erigon logs every variable it reads at warn level either way, but the bare name draws an extra `use ERIGON_ prefix for env` warning on top, and the prefix keeps these from colliding with unrelated variables in your environment. The examples below use it.
 :::
 
 ### Core Environment Variables
@@ -8629,7 +8629,7 @@ kill -SIGUSR1 $(pidof erigon)
 # Stack traces are printed to the erigon log / stdout
 ```
 
-If the node is wedged and you are ready to lose it, `kill -SIGABRT <pid>` dumps the stacks and terminates that process in one step. Pass an explicit PID rather than `$(pidof erigon)`: `SIGABRT` is destructive, and on a host running more than one instance `pidof` would abort all of them.
+If the node is wedged and you are ready to lose it, `kill -SIGQUIT <pid>` dumps every goroutine stack and terminates that process in one step. Erigon wires a handler only for `SIGUSR1`, so `SIGQUIT` falls through to the Go runtime's own behaviour — the same one this repository's CI watchdog relies on. Pass an explicit PID rather than `$(pidof erigon)`: `SIGQUIT` is destructive, and on a host running more than one instance `pidof` would kill all of them.
 
 **Capture a CPU or heap profile via pprof** (requires `--pprof` flag at startup — default address `localhost:6060`; override with `--pprof.addr` and `--pprof.port`):
 
@@ -8668,7 +8668,7 @@ The Caplin ports are its defaults (`--caplin.discovery.port` and `--caplin.disco
 
 Without these, the node may appear to have peers (via the cloud dashboard) but will suffer poor block propagation. Configure Cloud firewalls in the Hetzner Cloud Console under **Firewalls** or via `hcloud firewall`; for dedicated servers the equivalent lives in the Robot panel under **Server → Firewall**.
 
-A public-facing Erigon node should also not attempt to peer with IPv4 ranges that are reserved for special use. Blocking them is worth doing explicitly on Hetzner, whose abuse and netscan detection flags outbound dials to reserved ranges — that is what prompted this note, rather than their firewall filtering the traffic. Do not apply this to a node using `--caplin.local-discovery`, which deliberately peers over private IPs. The authoritative list is the [IANA IPv4 Special-Purpose Address Registry](https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml) ([RFC 6890](https://datatracker.ietf.org/doc/html/rfc6890)); the ranges below are the ones commonly blocked for an Ethereum node (`100.64.0.0/10` comes from [RFC 6598](https://datatracker.ietf.org/doc/html/rfc6598), and `192.88.99.0/24` has since been deprecated by [RFC 7526](https://datatracker.ietf.org/doc/html/rfc7526) — blocking it remains correct):
+A public-facing Erigon node should also not attempt to peer with IPv4 ranges that are reserved for special use. Blocking them is worth doing explicitly on Hetzner, whose abuse and netscan detection flags outbound dials to reserved ranges — that is what prompted this note, rather than their firewall filtering the traffic. Do not apply this to a node using `--caplin.local-discovery`, which deliberately peers over private IPs. The authoritative list is the [IANA IPv4 Special-Purpose Address Registry](https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml) ([RFC 6890](https://datatracker.ietf.org/doc/html/rfc6890)); the ranges below are that registry's entries most often blocked for an Ethereum node — it is a reference list, not a ruleset to paste verbatim: `127.0.0.0/8` and `255.255.255.255/32` are included for completeness but must **not** go into an outbound drop rule, for the reason given after the list (`100.64.0.0/10` comes from [RFC 6598](https://datatracker.ietf.org/doc/html/rfc6598), and `192.88.99.0/24` has since been deprecated by [RFC 7526](https://datatracker.ietf.org/doc/html/rfc7526) — blocking it remains correct):
 
 ```text
 0.0.0.0/8             "This" Network                                RFC 1122, Section 3.2.1.3
@@ -8679,7 +8679,7 @@ A public-facing Erigon node should also not attempt to peer with IPv4 ranges tha
 172.16.0.0/12         Private-Use Networks                          RFC 1918
 192.0.0.0/24          IETF Protocol Assignments                     RFC 5736
 192.0.2.0/24          TEST-NET-1                                    RFC 5737
-192.88.99.0/24        6to4 Relay Anycast                            RFC 3068
+192.88.99.0/24        6to4 Relay Anycast (deprecated)               RFC 3068, RFC 7526
 192.168.0.0/16        Private-Use Networks                          RFC 1918
 198.18.0.0/15         Network Interconnect Device Benchmark Testing RFC 2544
 198.51.100.0/24       TEST-NET-2                                    RFC 5737


### PR DESCRIPTION
#22919 landed on `release/3.5` and was never forward-ported. When `docs-deploy` switched to `release/3.6` on 2026-08-25, the published site silently lost all of it. This brings it onto `release/3.6`, re-derived against this branch's source rather than copied from 3.5.

Three things the site currently gets wrong:

- The Overview table recommends **RAID 0** and floats **ZFS** for archive nodes, which the restored Filesystem section directly contradicts. Its Disk Type and CPU rows are also missing two line breaks (`Avoid HDDs.SSD performance`, `Full nodes8–16 cores`).
- The Hetzner note calls the firewall **stateless for both product lines**. Cloud is stateful, and adding outbound rules there flips outbound to implicit deny — which breaks the snapshot download.
- That note's port table lists **9000 for Caplin**. That is Lighthouse's default; Caplin's own are `4000` UDP and `4001` TCP (`caplin.discovery.port`, `caplin.discovery.tcpport`). The downloader's `42069` was missing entirely.

Hardware Requirements regains the Filesystem section (ext4/XFS, `noatime`, why latency is the bottleneck, why ZFS and Btrfs are the wrong shape here) and Sync Times. Troubleshooting regains the reserved-IPv4 list worth blocking so outbound dials do not trip Hetzner's abuse detection, and `SIGQUIT` for a wedged node (Erigon installs no `SIGQUIT` handler, so it falls through to the Go runtime's all-goroutine dump).

Also: the `ERIGON_` env-var prefix rule (Erigon accepts both spellings, warns on the bare one, and the Docker variables do not take it), the `torrent.log` verbosity rule, the Beacon API's ~6 GB RAM cost, `make DIST=… install`, and what `--batchSize` does to MDBX growth.

Separately, `--rpc.subscription.filters.maxtopics` counts alternatives **across all positions**, not per position — `topicCount` is a single counter spanning the outer loop in `rpc/rpchelper/filters.go` on this branch. The flag's `Usage` string here does not say so; `main`'s prose does, so this takes that wording. The `rpcdaemon --help` paste is left alone: it must keep matching this branch's actual output.

Dual-commit pair with #23675 (`main`).

Gate: `npm ci && npm run build` green, `generate-llms.py --check` OK (73 pages), `render-disk-sizes.py --check` OK, editorial scan and `sidebar_position` lint clean.

