### PR TITLE
db/downloader: close the file VerifyFileFailFast opens

### DIFF
--- a/db/downloader/downloader_test.go
+++ b/db/downloader/downloader_test.go
@@ -1255,3 +1255,28 @@ func TestKeptLocalSeedingReportsCancelDuringJoin(t *testing.T) {
 		t.Fatal("wait did not return after the caller cancelled")
 	}
 }
+
+func openFdCount(t *testing.T) int {
+	t.Helper()
+	ents, err := os.ReadDir("/dev/fd")
+	require.NoError(t, err)
+	return len(ents)
+}
+
+func TestVerifyDataFailFastClosesFiles(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no /dev/fd on windows")
+	}
+	require := require.New(t)
+	test := newDownloaderTest(t)
+	require.NoError(os.WriteFile(filepath.Join(test.dirs.Snap, "a"), bytes.Repeat([]byte{1}, 4096), 0o644))
+	require.NoError(test.downloader.AddNewSeedableFile(t.Context(), "a"))
+
+	const runs = 20
+	require.NoError(test.downloader.VerifyData(test.downloader.ctx, nil, true))
+	before := openFdCount(t)
+	for range runs {
+		require.NoError(test.downloader.VerifyData(test.downloader.ctx, nil, true))
+	}
+	require.Less(openFdCount(t)-before, runs/2, "VerifyFileFailFast leaks a file descriptor per verified file")
+}

--- a/db/downloader/util.go
+++ b/db/downloader/util.go
@@ -378,11 +378,7 @@ func VerifyFileFailFast(ctx context.Context, t *torrent.Torrent, root string, co
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if err != nil {
-			f.Close()
-		}
-	}()
+	defer f.Close()
 
 	hasher := sha1.New()
 	for i := 0; i < info.NumPieces(); i++ {


### PR DESCRIPTION
`VerifyFileFailFast` never closed the file it opened — on success or on failure. Its deferred close is guarded by an `err` the function cannot set: the result is unnamed, so `return err` assigns nothing, and every `err` after the open check is shadowed by an inner `:=`.

`VerifyData(..., failFast: true)` runs it in an errgroup over every file in the datadir, so a verify leaked one fd per snapshot file.

Fix is `defer f.Close()`. The test counts fds across repeated verifies; before the fix it leaked exactly one per run.
