### PR TITLE
rpc/jsonrpc: make the debug_traceCall block parameter optional

### DIFF
--- a/rpc/jsonrpc/debug_api.go
+++ b/rpc/jsonrpc/debug_api.go
@@ -61,7 +61,7 @@ type PrivateDebugAPI interface {
 	AccountRange(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash, start any, maxResults int, nocode, nostorage bool, incompletes *bool) (state.IteratorDump, error)
 	GetModifiedAccountsByNumber(ctx context.Context, startNum rpc.BlockNumber, endNum *rpc.BlockNumber) ([]common.Address, error)
 	GetModifiedAccountsByHash(ctx context.Context, startHash common.Hash, endHash *common.Hash) ([]common.Address, error)
-	TraceCall(ctx context.Context, args ethapi.CallArgs, blockNrOrHash rpc.BlockNumberOrHash, config *tracersConfig.TraceConfig, stream jsonstream.Stream) error
+	TraceCall(ctx context.Context, args ethapi.CallArgs, blockNrOrHash *rpc.BlockNumberOrHash, config *tracersConfig.TraceConfig, stream jsonstream.Stream) error
 	AccountAt(ctx context.Context, blockHash common.Hash, txIndex uint64, account common.Address) (*AccountResult, error)
 	GetRawHeader(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (hexutil.Bytes, error)
 	GetRawBlock(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (hexutil.Bytes, error)

--- a/rpc/jsonrpc/debug_api_test.go
+++ b/rpc/jsonrpc/debug_api_test.go
@@ -388,7 +388,8 @@ func TestTraceErrorPathsWriteNoStream(t *testing.T) {
 				cfg = &tracersConfig.TraceConfig{Tracer: &name}
 			}
 			buf, s := newStream()
-			err := api.TraceCall(m.Ctx, traceCallArgs, rpc.BlockNumberOrHashWithNumber(1), cfg, s)
+			blockNr := rpc.BlockNumberOrHashWithNumber(1)
+			err := api.TraceCall(m.Ctx, traceCallArgs, &blockNr, cfg, s)
 			require.Error(t, err)
 			require.NoError(t, s.Flush())
 			require.Empty(t, buf.Bytes(), "stream must be empty on execution error so handler omits result field")
@@ -409,7 +410,8 @@ func TestTraceErrorPathsWriteNoStream(t *testing.T) {
 
 	t.Run("TraceCall_bad_timeout", func(t *testing.T) {
 		buf, s := newStream()
-		err := api.TraceCall(m.Ctx, traceCallArgs, rpc.BlockNumberOrHashWithNumber(1), badTimeoutCfg, s)
+		blockNr := rpc.BlockNumberOrHashWithNumber(1)
+		err := api.TraceCall(m.Ctx, traceCallArgs, &blockNr, badTimeoutCfg, s)
 		require.Error(t, err)
 		require.NoError(t, s.Flush())
 		require.Empty(t, buf.Bytes(), "stream must be empty on AssembleTracer error so handler omits result field")
@@ -427,7 +429,7 @@ func callDebugTraceCall(t *testing.T, api *DebugAPIImpl, args ethapi.CallArgs, o
 
 	var buf bytes.Buffer
 	s := jsonstream.New(&buf)
-	err := api.TraceCall(context.Background(), args, rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber), &tracersConfig.TraceConfig{
+	err := api.TraceCall(context.Background(), args, nil, &tracersConfig.TraceConfig{
 		BlockOverrides: overrides,
 	}, s)
 	require.NoError(t, err)

--- a/rpc/jsonrpc/debug_trace_call_block_param_test.go
+++ b/rpc/jsonrpc/debug_trace_call_block_param_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package jsonrpc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cmd/rpcdaemon/rpcdaemontest"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/rpc"
+	"github.com/erigontech/erigon/rpc/rpccfg"
+)
+
+// debug_traceCall takes the block selector as an optional parameter defaulting
+// to latest, like the eth_ state methods.
+func TestDebugTraceCallBlockParamDefaultsToLatest(t *testing.T) {
+	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
+	debugAPI := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, &rpccfg.DebugApiConfig{})
+	server := rpc.NewServer(50, false, false, true, log.New(), 100)
+	require.NoError(t, server.RegisterName("debug", PrivateDebugAPI(debugAPI)))
+	client := rpc.DialInProc(server, log.New())
+	t.Cleanup(func() {
+		client.Close()
+		server.Stop()
+	})
+
+	callArgs := map[string]any{
+		"from":     "0x71562b71999873db5b286df957af199ec94617f7",
+		"to":       "0x0d3ab14bbad3d99f4203bd7a11acb94882050e7e",
+		"gas":      "0x5208",
+		"gasPrice": "0x0",
+		"value":    "0x1",
+	}
+
+	var atLatest json.RawMessage
+	require.NoError(t, client.CallContext(t.Context(), &atLatest, "debug_traceCall", callArgs, "latest"))
+	require.NotEmpty(t, atLatest)
+
+	for _, tc := range []struct {
+		name   string
+		params []any
+	}{
+		{name: "omitted", params: []any{callArgs}},
+		{name: "null", params: []any{callArgs, nil}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var got json.RawMessage
+			require.NoError(t, client.CallContext(t.Context(), &got, "debug_traceCall", tc.params...))
+			require.JSONEq(t, string(atLatest), string(got))
+		})
+	}
+}

--- a/rpc/jsonrpc/eth_accounts.go
+++ b/rpc/jsonrpc/eth_accounts.go
@@ -73,7 +73,7 @@ func (api *APIImpl) stateReaderAt(ctx context.Context, blockNrOrHash rpc.BlockNu
 
 // GetBalance implements eth_getBalance. Returns the balance of an account for a given address.
 func (api *APIImpl) GetBalance(ctx context.Context, address common.Address, blockNrOrHashArg *rpc.BlockNumberOrHash) (*hexutil.U256, error) {
-	blockNrOrHash := orLatest(blockNrOrHashArg)
+	blockNrOrHash := blockOrLatest(blockNrOrHashArg)
 	tx, reader, err := api.stateReaderAt(ctx, blockNrOrHash)
 	if err != nil {
 		return nil, err
@@ -94,7 +94,7 @@ func (api *APIImpl) GetBalance(ctx context.Context, address common.Address, bloc
 
 // GetTransactionCount implements eth_getTransactionCount. Returns the number of transactions sent from an address (the nonce).
 func (api *APIImpl) GetTransactionCount(ctx context.Context, address common.Address, blockNrOrHashArg *rpc.BlockNumberOrHash) (*hexutil.Uint64, error) {
-	blockNrOrHash := orLatest(blockNrOrHashArg)
+	blockNrOrHash := blockOrLatest(blockNrOrHashArg)
 	if blockNrOrHash.BlockNumber != nil && *blockNrOrHash.BlockNumber == rpc.PendingBlockNumber {
 		reply, err := api.txPool.Nonce(ctx, &txpoolproto.NonceRequest{
 			Address: gointerfaces.ConvertAddressToH160(address),
@@ -124,7 +124,7 @@ func (api *APIImpl) GetTransactionCount(ctx context.Context, address common.Addr
 
 // GetCode implements eth_getCode. Returns the byte code at a given address (if it's a smart contract).
 func (api *APIImpl) GetCode(ctx context.Context, address common.Address, blockNrOrHashArg *rpc.BlockNumberOrHash) (hexutil.Bytes, error) {
-	blockNrOrHash := orLatest(blockNrOrHashArg)
+	blockNrOrHash := blockOrLatest(blockNrOrHashArg)
 	tx, reader, err := api.stateReaderAt(ctx, blockNrOrHash)
 	if err != nil {
 		return nil, err
@@ -146,7 +146,7 @@ func (api *APIImpl) GetCode(ctx context.Context, address common.Address, blockNr
 // GetStorageValues implements eth_getStorageValues. Returns the values of multiple
 // storage slots for multiple accounts in a single request.
 func (api *APIImpl) GetStorageValues(ctx context.Context, requests map[common.Address][]common.Hash, blockNrOrHashArg *rpc.BlockNumberOrHash) (map[common.Address][]hexutil.Bytes, error) {
-	blockNrOrHash := orLatest(blockNrOrHashArg)
+	blockNrOrHash := blockOrLatest(blockNrOrHashArg)
 	var totalSlots int
 
 	for _, keys := range requests {
@@ -208,7 +208,7 @@ func (api *APIImpl) GetStorageValues(ctx context.Context, requests map[common.Ad
 
 // GetStorageAt implements eth_getStorageAt. Returns the value from a storage position at a given address.
 func (api *APIImpl) GetStorageAt(ctx context.Context, address common.Address, index string, blockNrOrHashArg *rpc.BlockNumberOrHash) (string, error) {
-	blockNrOrHash := orLatest(blockNrOrHashArg)
+	blockNrOrHash := blockOrLatest(blockNrOrHashArg)
 	var empty []byte
 	// Validation for index i.e. storage slot is non-standard: it can be interpreted as QUANTITY (stricter) or as DATA (like Hive tests do).
 	// Waiting for a spec, we choose the latter because it's more general, but we check that the length is not greater than 64 hex-digits.

--- a/rpc/jsonrpc/eth_api_test.go
+++ b/rpc/jsonrpc/eth_api_test.go
@@ -485,7 +485,7 @@ func bnhPtr(b rpc.BlockNumberOrHash) *rpc.BlockNumberOrHash { return &b }
 // TestStateMethods_OmittedBlockDefaultsToLatest verifies that an omitted (nil)
 // block selector is treated identically to an explicit "latest" selector for each
 // state method (per execution-apis: the Block parameter is optional, default
-// 'latest'). This exercises the orLatest(nil) path directly.
+// 'latest'). This exercises the blockOrLatest(nil) path directly.
 func TestStateMethods_OmittedBlockDefaultsToLatest(t *testing.T) {
 	a := assert.New(t)
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)

--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -65,10 +65,10 @@ func rejectPendingState(blockNrOrHash rpc.BlockNumberOrHash) error {
 	return nil
 }
 
-// orLatest resolves an optional block selector, defaulting to the latest block
+// blockOrLatest resolves an optional block selector, defaulting to the latest block
 // when the caller omitted the parameter (nil). Used by the state-reading methods
 // whose Block parameter is optional per execution-apis (default 'latest').
-func orLatest(blockNrOrHash *rpc.BlockNumberOrHash) rpc.BlockNumberOrHash {
+func blockOrLatest(blockNrOrHash *rpc.BlockNumberOrHash) rpc.BlockNumberOrHash {
 	if blockNrOrHash != nil {
 		return *blockNrOrHash
 	}
@@ -86,7 +86,7 @@ const (
 
 // Call implements eth_call. Executes a new message call immediately without creating a transaction on the block chain.
 func (api *APIImpl) Call(ctx context.Context, args ethapi2.CallArgs, requestedBlock *rpc.BlockNumberOrHash, stateOverrides *ethapi2.StateOverrides, blockOverrides *ethapi2.BlockOverrides) (hexutil.Bytes, error) {
-	blockNrOrHash := orLatest(requestedBlock)
+	blockNrOrHash := blockOrLatest(requestedBlock)
 	if err := rejectPendingState(blockNrOrHash); err != nil {
 		return nil, err
 	}
@@ -433,7 +433,7 @@ func (s StorageKeysInfo) EncodeKey() string {
 
 // GetProof implements eth_getProof; historical blocks are supported as far back as the commitment history allows.
 func (api *APIImpl) GetProof(ctx context.Context, address common.Address, storageKeys []hexutil.Bytes, blockNrOrHashArg *rpc.BlockNumberOrHash) (*accounts.AccProofResult, error) {
-	blockNrOrHash := orLatest(blockNrOrHashArg)
+	blockNrOrHash := blockOrLatest(blockNrOrHashArg)
 	if len(storageKeys) > maxGetProofKeys {
 		return nil, &rpc.CustomError{
 			Message: fmt.Sprintf("too many storage keys requested (max %d, got %d)", maxGetProofKeys, len(storageKeys)),

--- a/rpc/jsonrpc/eth_call_test.go
+++ b/rpc/jsonrpc/eth_call_test.go
@@ -1537,3 +1537,24 @@ func TestOptimizeWarmAddrAndAdjustGas(t *testing.T) {
 		require.Equal(t, hexutil.Uint64(100), res.GasUsed) // 100 < 2400, no underflow
 	})
 }
+
+func TestBlockOrLatest(t *testing.T) {
+	number := rpc.BlockNumberOrHashWithNumber(5)
+	hash := rpc.BlockNumberOrHashWithHash(common.Hash{0x01}, true)
+	pending := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
+
+	for _, tc := range []struct {
+		name string
+		arg  *rpc.BlockNumberOrHash
+		want rpc.BlockNumberOrHash
+	}{
+		{name: "omitted defaults to latest", arg: nil, want: rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)},
+		{name: "number is kept", arg: &number, want: number},
+		{name: "hash keeps requireCanonical", arg: &hash, want: hash},
+		{name: "pending is left to the caller to reject", arg: &pending, want: pending},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, blockOrLatest(tc.arg))
+		})
+	}
+}

--- a/rpc/jsonrpc/trace_pending_test.go
+++ b/rpc/jsonrpc/trace_pending_test.go
@@ -43,7 +43,7 @@ func TestTracingRejectsPendingTag(t *testing.T) {
 	traceAPI := newTraceApiForTest(m)
 
 	t.Run("debug_traceCall", func(t *testing.T) {
-		err := debugAPI.TraceCall(ctx, ethapi.CallArgs{}, pendingNrOrHash, nil, jsonstream.New(io.Discard))
+		err := debugAPI.TraceCall(ctx, ethapi.CallArgs{}, &pendingNrOrHash, nil, jsonstream.New(io.Discard))
 		require.ErrorIs(t, err, errPendingNotSupported)
 	})
 

--- a/rpc/jsonrpc/tracing.go
+++ b/rpc/jsonrpc/tracing.go
@@ -296,7 +296,8 @@ func (api *DebugAPIImpl) TraceTransaction(ctx context.Context, hash common.Hash,
 }
 
 // TraceCall implements debug_traceCall. Returns Geth style call traces.
-func (api *DebugAPIImpl) TraceCall(ctx context.Context, args ethapi.CallArgs, blockNrOrHash rpc.BlockNumberOrHash, config *tracersConfig.TraceConfig, stream jsonstream.Stream) error {
+func (api *DebugAPIImpl) TraceCall(ctx context.Context, args ethapi.CallArgs, requestedBlock *rpc.BlockNumberOrHash, config *tracersConfig.TraceConfig, stream jsonstream.Stream) error {
+	blockNrOrHash := blockOrLatest(requestedBlock)
 	if err := rejectPending(blockNrOrHash); err != nil {
 		return err
 	}


### PR DESCRIPTION
`debug_traceCall` took the block selector by value (`rpc.BlockNumberOrHash`), so omitting it — or passing `null` — was rejected by the positional argument parser with `missing value for required argument 1`. It was the last state-reading method still requiring the parameter: `eth_call`, `eth_estimateGas`, `eth_getBalance`, `eth_getCode`, `eth_getProof`, `eth_createAccessList`, `trace_call` and friends already take `*rpc.BlockNumberOrHash` and default to `latest`.

The parameter is now a pointer and defaults to `latest`, matching geth (`ethereum/go-ethereum#35583`) and the pending spec in `ethereum/execution-apis#855`, which marks it optional with default `latest`. `pending` is still rejected, as before.

Also renames the shared helper `orLatest` to `blockOrLatest` (mechanical, 9 call sites) and adds unit tests for it.

## Testing

- New `TestDebugTraceCallBlockParamDefaultsToLatest` drives the change through the JSON-RPC dispatch layer (where the failure was): an omitted and a `null` block selector must produce the same trace as an explicit `"latest"`. Red before the change with `missing value for required argument 1` on both cases.
- New `TestBlockOrLatest` covers the helper: nil defaults to latest, an explicit number is kept, a hash keeps `requireCanonical`, `pending` is passed through for the caller to reject.
- `go test -short ./rpc/jsonrpc/ ./rpc/` and `golangci-lint` on `rpc/jsonrpc/...` are clean.
