### PR TITLE
docs(site): read llms page text from the built site instead of parsing MDX

### DIFF
--- a/.github/workflows/docs-site-build.yml
+++ b/.github/workflows/docs-site-build.yml
@@ -41,12 +41,6 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Verify llms.txt artifacts are up to date
-        if: steps.guard.outputs.present == 'true'
-        run: |
-          python3 docs/site/scripts/generate-llms.py --check
-          python3 -m unittest discover docs/site/scripts -v
-
       - name: Verify disk-size markers are in sync
         if: steps.guard.outputs.present == 'true'
         run: python3 docs/site/scripts/render-disk-sizes.py --check
@@ -115,3 +109,13 @@ jobs:
           # Version resolution fails the build rather than publishing a
           # placeholder, so it must not run against the anonymous rate limit.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Both read docs/site/build, so they have to follow the build rather than
+      # precede it — the built-site tests skip themselves without it.
+      - name: Run documentation script tests
+        if: steps.guard.outputs.present == 'true'
+        run: python3 -m unittest discover docs/site/scripts -v
+
+      - name: Verify llms.txt artifacts are up to date
+        if: steps.guard.outputs.present == 'true'
+        run: python3 docs/site/scripts/generate-llms.py --check

--- a/.github/workflows/docs-version-bump.yml
+++ b/.github/workflows/docs-version-bump.yml
@@ -123,15 +123,16 @@ jobs:
             jq '.[:5]' versions.json > versions.json.tmp && mv versions.json.tmp versions.json
           fi
 
-      - name: Regenerate llms.txt artifacts
-        run: python3 scripts/generate-llms.py
-
       - name: Verify build
         run: npm run build
         env:
           # Same reasoning as the snapshot step: `npm run build` loads the same
           # branch-controlled config, so it gets the read-only token too.
           GITHUB_TOKEN: ${{ steps.docs_token.outputs.token }}
+
+      # Page bodies are read from the built site, so this has to follow the build.
+      - name: Regenerate llms.txt artifacts
+        run: python3 scripts/generate-llms.py
 
       - name: Open pull request
         env:

--- a/docs/site/docs/fundamentals/mcp.mdx
+++ b/docs/site/docs/fundamentals/mcp.mdx
@@ -338,9 +338,9 @@ MCP connects a model to your **running node**. To let a model answer questions a
 | [llms.txt](https://docs.erigon.tech/llms.txt) | Index of the current documentation, with titles and descriptions | The model fetches pages on demand, or its context window is small |
 | [llms-full.txt](https://docs.erigon.tech/llms-full.txt) | The text of those same pages, as one plain-text file | You want the whole corpus in context, offline, with nothing scraped |
 
-Both are generated from the same Markdown source as this site by a script in the repository, and CI fails when a documentation change lands without regenerating them, so they cannot quietly go stale.
+Both are generated from this site's built pages by a script in the repository, and CI fails when a documentation change lands without regenerating them, so they cannot quietly go stale.
 
-Two things to know about their scope. They cover the **current** documentation and the help center only — archived versions, published under `/vX.Y/`, are not included. And the text is cleaned rather than copied verbatim: MDX components are stripped, and a section index page built as a card grid is reduced to the list of links its grids present rather than its prose. Read the corpus as the documentation's prose, not as a byte-for-byte mirror of the rendered site.
+Two things to know about their scope. They cover the **current** documentation and the help center only — archived versions, published under `/vX.Y/`, are not included. And the text is cleaned rather than copied verbatim: components are expanded and links resolved as the site renders them, and on a section index page built as a card grid each grid becomes the list of links it presents, with the page's prose kept around it in document order. Read the corpus as the documentation's prose, not as a byte-for-byte mirror of the rendered site.
 
 ```bash
 # Give a local model the whole documentation, with no network access

--- a/docs/site/scripts/generate-llms.py
+++ b/docs/site/scripts/generate-llms.py
@@ -20,6 +20,7 @@ import json
 import re
 import sys
 from collections import Counter
+from html.parser import HTMLParser
 from pathlib import Path
 
 # ── Config ────────────────────────────────────────────────────────────────────
@@ -39,6 +40,9 @@ SECTIONS = [
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
+_FM_END_RE = re.compile(r"\n---[ \t]*(?:\r?\n|\r?\Z)")
+
+
 def parse_frontmatter(text):
     """Parse a minimal YAML frontmatter subset.
 
@@ -51,9 +55,12 @@ def parse_frontmatter(text):
     meta = {}
     if not text.startswith("---"):
         return meta, text
-    end = text.find("\n---", 3)
-    if end == -1:
+    # `---` has to be the whole line: `find("\n---")` also matches `\n----` or
+    # `\n---x`, cutting the block short at a value that merely starts that way.
+    m = _FM_END_RE.search(text, 3)
+    if not m:
         return meta, text
+    end = m.start()
     block = text[3:end].strip()
     for line in block.splitlines():
         # Skip indented continuations (e.g. YAML list items, block-scalar tails).
@@ -62,278 +69,681 @@ def parse_frontmatter(text):
         if ":" in line:
             k, _, v = line.partition(":")
             meta[k.strip()] = v.strip().strip('"').strip("'")
-    return meta, text[end + 4:]
+    return meta, text[m.end():]
 
 
-# Pure-uppercase identifier: e.g. ERIGON_VERSION, IP, YOUR_ADDRESS, API_KEY.
-# Used to preserve text-substitution placeholders that look like JSX expressions
-# but are meant to be read as literal tokens by humans.
-_IDENT_BRACE_INNER = re.compile(r"^\s*[A-Z][A-Z0-9_]*\s*$")
+# ── Page text from the built site ─────────────────────────────────────────────
+#
+# Page bodies are read from the HTML Docusaurus produced, not from the MDX
+# source. The source is MDX plus arbitrary JSX, and reproducing what MDX renders
+# means reimplementing CommonMark block parsing (fences inside containers, code
+# spans versus block boundaries, HTML blocks) plus JSX. Docusaurus has already
+# done that work by build time: components are expanded, links are resolved to
+# absolute site paths, and the page body sits in one <article>.
+#
+# Requires `npm run build` in docs/site first. The generator says so rather than
+# silently emitting an empty corpus.
+
+BUILD_DIR = SITE_ROOT / "build"
+
+# Rendered inside <article> but navigation, not page content. These are the
+# stable `theme-*` class names Docusaurus documents, matched as whole class
+# tokens — the sibling hashed names (`breadcrumbsContainer_Z_bl`) change between
+# builds, and the content itself lives under `theme-doc-markdown`, so a prefix
+# match on `theme-doc-` would delete the page.
+_CHROME_CLASSES = (
+    "theme-doc-breadcrumbs",
+    "theme-doc-toc-mobile",
+    "theme-doc-toc-desktop",
+    "theme-doc-footer",
+    "theme-doc-version-banner",
+    "theme-doc-version-badge",
+    "pagination-nav",
+    # The ¶-style anchor Docusaurus injects into every heading.
+    "hash-link",
+)
+# The admonition heading holds either the type as a bare word ("warning"), which
+# `:::type` already carries, or a custom title from `:::tip Some title`. It is
+# captured rather than skipped, and kept only when it says something the marker
+# does not.
+_ADM_HEADING_PREFIX = "admonitionHeading_"
+
+_BLOCK_TAGS = {
+    "p", "div", "section", "article", "ul", "ol", "table", "thead", "tbody",
+    "blockquote", "pre", "figure", "hr", "h1", "h2", "h3", "h4", "h5", "h6",
+    "dl", "dt", "dd", "details", "summary", "figcaption",
+}
+_INLINE_WRAP = {"strong": "**", "b": "**", "em": "*", "i": "*", "summary": "**"}
+# Stands in for an inline code span's opening delimiter until its interior is
+# known, since a span holding a backtick needs a longer one.
+_CODE_MARK = "\x00CODE\x00"
+# HTMLParser reports these through handle_starttag with no matching end tag, so
+# they must not change nesting depth or open a skipped subtree.
+_VOID_TAGS = {
+    "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta",
+    "param", "source", "track", "wbr",
+}
 
 
-def _is_placeholder_brace(match):
-    """Return True if a `{...}` match wraps a pure-uppercase identifier."""
-    inner = match.group(0)[1:-1]
-    return bool(_IDENT_BRACE_INNER.match(inner))
+class _ArticleText(HTMLParser):
+    """Render a Docusaurus <article> subtree as Markdown-ish plain text.
 
-
-def _strip_jsx_expr(match):
-    """re.sub callback: drop JSX expressions, preserve placeholder identifiers.
-
-    If the expression contains a nullish-coalescing fallback (`?? 'value'` or
-    `?? "value"`), emit that fallback string so table cells stay readable in
-    the plain-text LLM artifact instead of going blank.
+    Chrome subtrees are skipped whole. A link keeps its resolved href, which is
+    what makes the corpus usable: the MDX source carries relative targets like
+    `../fundamentals/downloader`, meaningless once the page text is pooled into a
+    flat file.
     """
-    if _is_placeholder_brace(match):
-        return match.group(0)
-    inner = match.group(0)[1:-1]
-    fb = re.search(r'\?\?\s*[\'"]([^\'"]+)[\'"]', inner)
-    if fb:
-        return fb.group(1)
-    return ""
 
+    def __init__(self, page_url=""):
+        super().__init__(convert_charrefs=True)
+        # A bare `#section` target is ambiguous once page text is pooled into one
+        # flat file, so it is resolved against the page it came from.
+        self._page_url = page_url
+        self.out = []
+        self._skip_depth = 0      # >0 while inside a chrome subtree
+        self._href = None
+        self._link_segs = []
+        self._link_cur = []
+        self._in_pre = 0
+        self._pre_start = 0
+        self._at_list_marker = False
+        self._table_depth = 0
+        self._row_cells = 0
+        self._need_header_rule = False
+        self._table_body_seen = False
+        self._in_cell = False
+        self._list_stack = []
+        # Element nesting depth, kept so a container that spans other elements
+        # (admonition, blockquote) knows which end tag is its own.
+        self._depth = 0
+        self._adm_stack = []
+        self._bq_stack = []
+        # Docusaurus renders a <Tabs> group as a list of labels followed by one
+        # panel each, with no id linking them. The labels are held back and
+        # attached to their panels in order, or the tables under them read as an
+        # unlabelled run and a reader has to guess which chain is which.
+        self._adm_head = []
+        self._tablist = []
+        self._tab_labels = []
+        self._li_start = None
 
-def _sub_outside_backticks(pattern, repl, line):
-    """Apply re.sub only outside backtick-quoted inline code spans."""
-    parts = re.split(r"(`[^`]*`)", line)
-    return "".join(
-        re.sub(pattern, repl, p) if not p.startswith("`") else p
-        for p in parts
-    )
+    # -- helpers ----------------------------------------------------------
+    def _emit(self, s):
+        if self._skip_depth:
+            return
+        (self._link_cur if self._href is not None else self.out).append(s)
 
+    def _break(self, n=2):
+        if self._skip_depth:
+            return
+        if self._in_pre:
+            # Docusaurus wraps each code line in a <div class="token-line"> that
+            # already ends with <br>. That <br> supplies the newline, so a block
+            # break here would double-space every code block.
+            return
+        if self._href is not None:
+            # Checked before the cell case: a card link inside a table cell still
+            # has to segment, or its label and blurb fuse into one word.
+            seg = "".join(self._link_cur).strip()
+            if seg:
+                self._link_segs.append(seg)
+            self._link_cur = []
+            return
+        if self._in_cell:
+            # A cell is one Markdown line; a <p> or <ul> inside it must not split
+            # the row into two.
+            if self.out and not self.out[-1].endswith((" ", "|")):
+                self.out.append(" ")
+            return
+        if self._at_list_marker:
+            # The item's first block starts on the marker's line, not below it.
+            self._at_list_marker = False
+            return
+        while self.out and self.out[-1] == "\n":
+            self.out.pop()
+        self.out.append("\n" * n)
 
-def _strip_multiline_expr_blocks(text):
-    """Strip multi-line inline JSX expression blocks that open with { on their
-    own line.
-
-    Handles constructs like:
-        {[
-          {stat:'10x', label:'...'},
-        ].map(({stat, label}) => (
-          <div key={stat}>...</div>
-        ))}
-    which contain nested braces that defeat the single-line {0,120} pass.
-    Tracks brace depth; skips lines inside code fences.
-    """
-    out = []
-    in_fence = False
-    skip_depth = 0
-
-    for line in text.splitlines():
-        if line.lstrip().startswith("```"):
-            if skip_depth == 0:
-                in_fence = not in_fence
-                out.append(line)
-            # else: fence marker is inside a skipped block — discard it
-            continue
-
-        if in_fence:
-            out.append(line)
-            continue
-
-        if skip_depth > 0:
-            for ch in line:
-                if ch == '{':
-                    skip_depth += 1
-                elif ch == '}':
-                    skip_depth -= 1
-            if skip_depth < 0:
-                skip_depth = 0
-            continue  # discard this line (part of expression block)
-
-        # Detect opening of a multi-line expression block: line starts with {
-        if line.lstrip().startswith('{'):
-            depth = sum(1 if c == '{' else -1 if c == '}' else 0 for c in line)
-            if depth > 0:
-                skip_depth = depth
-                continue  # discard opening line
-
-        out.append(line)
-
-    return "\n".join(out)
-
-
-def _strip_mdx_module_syntax(text):
-    """Remove MDX import/export syntax only outside fenced code blocks."""
-    lines = text.splitlines()
-    out = []
-    in_fence = False
-    in_export_block = False
-
-    import_re = re.compile(r"^\s*import\s+.+$")
-    # Narrow: only match MDX-style exports (default / brace / const|function|class).
-    # Shell `export VAR=value` inside ```bash fences is preserved by the in_fence
-    # check above; this regex would not match those lines anyway, but the fence
-    # guard is the load-bearing protection.
-    export_single_re = re.compile(
-        r"^\s*export\s+(?:default\b.+|\{.+\}\s*;?|(?:const|function|class)\b.+;?)$"
-    )
-    export_block_start_re = re.compile(r"^\s*export\s+(?:const|function|class)\b")
-    export_block_end_re = re.compile(r"^\s*};?\s*$")
-
-    for line in lines:
-        if line.lstrip().startswith("```"):
-            in_fence = not in_fence
-            out.append(line)
-            continue
-
-        if in_fence:
-            out.append(line)
-            continue
-
-        if in_export_block:
-            if export_block_end_re.match(line):
-                in_export_block = False
-            continue
-
-        if import_re.match(line):
-            continue
-
-        if export_single_re.match(line):
-            continue
-
-        if export_block_start_re.match(line):
-            in_export_block = True
-            continue
-
-        out.append(line)
-
-    return "\n".join(out)
-
-
-def _split_fenced(text):
-    """Split text into (is_fenced, segment) pairs, preserving newlines."""
-    result = []
-    buf = []
-    in_fence = False
-    for line in text.splitlines(keepends=True):
-        if line.lstrip().startswith("```"):
-            if not in_fence:
-                result.append((False, "".join(buf)))
-                buf = [line]
-                in_fence = True
+    # -- HTMLParser hooks -------------------------------------------------
+    def handle_starttag(self, tag, attrs):
+        # HTMLParser gives None for a valueless attribute (`<div class>`), which
+        # would fail every string operation below.
+        a = {k: (v or "") for k, v in attrs}
+        void = tag in _VOID_TAGS
+        if not void:
+            self._depth += 1
+        if self._skip_depth:
+            if not void:
+                self._skip_depth += 1
+            return
+        # Whole class tokens: a substring test would skip real content whose
+        # class merely contains one of these (`my-breadcrumb-note`).
+        classes = a.get("class", "").split()
+        if any(c in classes for c in _CHROME_CLASSES):
+            if void:
+                # Nothing to skip past: dropping the element itself is enough,
+                # and entering skip mode here would swallow the text after it.
+                return
+            self._skip_depth = 1
+            return
+        adm = next((c[len("theme-admonition-"):] for c in classes
+                    if c.startswith("theme-admonition-")), None)
+        if adm and self._href is None and not self._in_cell:
+            # `:::type` carries both the kind and, with its closer, the extent —
+            # neither of which survives as plain prose.
+            self._break()
+            self._adm_stack.append([self._depth, len(self.out), adm, ""])
+            return
+        if self._adm_stack and any(c.startswith(_ADM_HEADING_PREFIX) for c in classes):
+            self._adm_head.append((self._depth, len(self.out)))
+            return
+        if tag == "blockquote" and self._href is None:
+            # A quote is a distinct block in the rendered page; without the `> `
+            # prefix it reads as the page's own prose.
+            self._break()
+            self._bq_stack.append((self._depth, len(self.out)))
+            return
+        if tag == "a" and a.get("href"):
+            self._href, self._link_segs, self._link_cur = a["href"], [], []
+            return
+        if tag == "pre":
+            if self._href is not None:
+                # Inside a link there is nowhere to put a fence; keep the text.
+                self._in_pre += 1
+                return
+            self._break()
+            self._in_pre += 1
+            self._pre_start = len(self.out)
+            # Docusaurus puts the info string on the block as `language-bash`.
+            # Dropping it costs a consumer the one hint that says whether a block
+            # is shell, JSON or YAML.
+            lang = next((c[len("language-"):] for c in classes
+                         if c.startswith("language-")), "")
+            self.out.append("\x00FENCE\x00" + lang + "\n")
+            return
+        if tag in ("h1", "h2", "h3", "h4", "h5", "h6"):
+            self._break()
+            if self._href is None:
+                self.out.append("#" * int(tag[1]) + " ")
+            return
+        if tag == "table":
+            self._table_depth += 1
+            self._need_header_rule = False
+            self._break()
+            return
+        if tag in ("thead", "tbody", "tfoot"):
+            if tag == "thead":
+                self._need_header_rule = True
+            return
+        if tag == "tr" and self._table_depth and self._href is None:
+            self._break(1)
+            self.out.append("|")
+            self._row_cells = 0
+            return
+        if tag in ("td", "th") and self._table_depth and self._href is None:
+            if tag == "th" and self._row_cells == 0 and not self._table_body_seen:
+                self._need_header_rule = True
+            self.out.append(" ")
+            self._row_cells += 1
+            self._in_cell = True
+            return
+        if tag == "ul" and (a.get("role") == "tablist" or "tabs" in classes):
+            self._tablist.append(self._depth)
+            self._tab_labels = []
+            self._break()
+            return
+        if tag == "li" and self._tablist:
+            self._li_start = len(self.out)
+            return
+        if a.get("role") == "tabpanel" and self._tab_labels:
+            self._break()
+            self.out.append(f"**{self._tab_labels.pop(0)}**")
+            self._break()
+            return
+        if tag in ("ul", "ol"):
+            start = 1
+            if tag == "ol" and a.get("start", "").isdigit():
+                start = int(a["start"])
+            self._list_stack.append([tag, start])
+            self._break()
+            return
+        if tag == "li":
+            self._break(1)
+            if self._href is not None:
+                # A list inside a card is part of its text, not page structure.
+                return
+            depth = max(0, len(self._list_stack) - 1)
+            if self._list_stack and self._list_stack[-1][0] == "ol":
+                n = self._list_stack[-1][1]
+                self._list_stack[-1][1] = n + 1
+                marker = f"{n}. "
             else:
-                buf.append(line)
-                result.append((True, "".join(buf)))
-                buf = []
-                in_fence = False
-        else:
-            buf.append(line)
-    if buf:
-        result.append((in_fence, "".join(buf)))
-    return result
+                marker = "- "
+            self.out.append("  " * depth + marker)
+            self._at_list_marker = True
+            return
+        if tag == "br":
+            # A newline inside a table cell would split the Markdown row.
+            self._emit(" " if self._table_depth else "\n")
+            return
+        if tag == "img":
+            alt = a.get("alt", "").strip()
+            if alt:
+                src = a.get("src", "")
+                if src.startswith("/"):
+                    src = BASE_URL + src
+                self._emit(f"![{alt}]({src})" if src else alt)
+            return
+        if tag == "code" and not self._in_pre:
+            # Delimiter length is only known once the interior is in hand.
+            self._emit(_CODE_MARK)
+            return
+        if tag in _INLINE_WRAP and not self._in_pre:
+            self._emit(_INLINE_WRAP[tag])
+            return
+        if tag in _BLOCK_TAGS:
+            self._break()
+
+    def handle_endtag(self, tag):
+        if tag in _VOID_TAGS:
+            # `<br/>` reaches here through handle_startendtag. It closes nothing,
+            # so letting it decrement the skip depth would end a chrome subtree
+            # early and leak the nav text after it.
+            return
+        self._depth -= 1
+        if self._skip_depth:
+            self._skip_depth -= 1
+            return
+        if self._adm_head and self._adm_head[-1][0] - 1 == self._depth:
+            _, hstart = self._adm_head.pop()
+            title = " ".join("".join(self.out[hstart:]).split())
+            del self.out[hstart:]
+            if self._adm_stack:
+                self._adm_stack[-1][3] = title
+            return
+        if self._adm_stack and self._adm_stack[-1][0] - 1 == self._depth:
+            _, start, adm, title = self._adm_stack.pop()
+            body = "".join(self.out[start:]).strip("\n")
+            del self.out[start:]
+            if body:
+                # A heading that only repeats the type says nothing the marker
+                # does not; a custom title does and has to survive.
+                head = f":::{adm} {title}" if title.lower() != adm.lower() else f":::{adm}"
+                self.out.append(f"{head}\n{body}\n:::")
+            self._break()
+            return
+        if self._bq_stack and self._bq_stack[-1][0] - 1 == self._depth:
+            _, start = self._bq_stack.pop()
+            seg = "".join(self.out[start:]).strip("\n")
+            del self.out[start:]
+            if seg:
+                # A `>` line is not blank, so the collapse pass in text() cannot
+                # reach a run of them; squeeze them here instead.
+                seg = _squeeze_blank_runs(seg)
+                self.out.append("\n".join(
+                    ("> " + ln) if ln.strip() else ">" for ln in seg.split("\n")))
+            self._break()
+            return
+        if tag == "table" and self._table_depth:
+            self._table_depth -= 1
+            self._table_body_seen = False
+            self._break()
+            return
+        if tag in ("thead", "tbody", "tfoot"):
+            return
+        if tag in ("td", "th") and self._table_depth and self._href is None:
+            self._in_cell = False
+            self.out.append(" |")
+            return
+        if tag == "tr" and self._table_depth and self._href is None:
+            # A Markdown table needs the rule under its header row to read as one.
+            if self._need_header_rule and self._row_cells:
+                self.out.append("\n|" + " --- |" * self._row_cells)
+                self._need_header_rule = False
+            self._table_body_seen = True
+            return
+        if tag == "li" and self._tablist and self._li_start is not None:
+            label = "".join(self.out[self._li_start:]).strip()
+            del self.out[self._li_start:]
+            self._li_start = None
+            if label:
+                self._tab_labels.append(label)
+            return
+        if tag == "ul" and self._tablist and self._tablist[-1] - 1 == self._depth:
+            self._tablist.pop()
+            self._break()
+            return
+        if tag in ("ul", "ol"):
+            if self._list_stack:
+                self._list_stack.pop()
+            self._break()
+            return
+        if tag == "li":
+            # Clear the marker flag so the next item gets its own line, without
+            # forcing the blank line a full block break would add.
+            self._at_list_marker = False
+            return
+        if tag == "a" and self._href is not None:
+            seg = "".join(self._link_cur).strip()
+            segs = self._link_segs + ([seg] if seg else [])
+            href, self._href = self._href, None
+            self._link_segs, self._link_cur = [], []
+            if not segs:
+                return
+            # A link wrapping several blocks is a card: the first block is its
+            # label, the rest is the blurb. A card often opens with a decorative
+            # icon, and that image is not the label.
+            texty = [x for x in segs if not _IMAGE_ONLY_RE.fullmatch(x)]
+            segs = texty or segs
+            label, rest = segs[0], " ".join(segs[1:]).strip()
+            if href.startswith("/"):
+                href = BASE_URL + href
+            elif href.startswith("#") and self._page_url:
+                href = self._page_url + href
+            link = f"[{label}]({href})" if href else label
+            if rest:
+                # A card is a block in the rendered page, so give it its own
+                # line rather than running it into the next one.
+                self._break(1)
+                self.out.append(f"- {link}: {rest}")
+                self._break(1)
+            else:
+                self.out.append(link)
+            return
+        if tag == "pre":
+            self._in_pre = max(0, self._in_pre - 1)
+            if self._href is not None:
+                return
+            while self.out and self.out[-1].endswith("\n"):
+                self.out[-1] = self.out[-1].rstrip("\n")
+                if self.out[-1] == "":
+                    self.out.pop()
+                else:
+                    break
+            # A literal backtick run inside the block needs a longer fence.
+            body = "".join(self.out[self._pre_start:])
+            longest = max((len(m) for m in re.findall(r"`+", body)), default=0)
+            fence = "`" * max(3, longest + 1)
+            for i in range(self._pre_start, len(self.out)):
+                self.out[i] = self.out[i].replace("\x00FENCE\x00", fence)
+            self.out.append("\n" + fence)
+            self._break()
+            return
+        if tag == "code" and not self._in_pre:
+            buf = self._link_cur if self._href is not None else self.out
+            try:
+                i = len(buf) - 1 - buf[::-1].index(_CODE_MARK)
+            except ValueError:
+                # The buffer was flushed mid-span; a plain span is the best that
+                # can be said about the text that survived.
+                self._emit("`")
+                return
+            inner = "".join(buf[i + 1:])
+            longest = max((len(m) for m in re.findall(r"`+", inner)), default=0)
+            delim = "`" * max(1, longest + 1)
+            # A span whose text touches a backtick needs a space inside the
+            # delimiters, which CommonMark strips back out (6.1).
+            pad = " " if inner.startswith("`") or inner.endswith("`") else ""
+            buf[i] = delim + pad
+            self._emit(pad + delim)
+            return
+        if tag in _INLINE_WRAP and not self._in_pre:
+            self._emit(_INLINE_WRAP[tag])
+            return
+        if tag in _BLOCK_TAGS:
+            self._break()
+
+    def handle_data(self, data):
+        if self._in_cell:
+            # An unescaped pipe reads as a column separator: `QUANTITY|TAG` would
+            # silently widen the row.
+            data = data.replace("|", "\\|")
+        if not self._in_pre:
+            data = re.sub(r"\s+", " ", data)
+            if not data.strip():
+                # Collapse inter-tag whitespace to a single separator. The buffer
+                # tested has to be the one being written to, or the space between
+                # two inline elements inside a link is dropped and the words fuse.
+                buf = self._link_cur if self._href is not None else self.out
+                if buf and not buf[-1].endswith((" ", "\n")):
+                    self._emit(" ")
+                return
+        self._emit(data)
+
+    def text(self):
+        s = "".join(self.out)
+        # Collapse runs of whitespace inside each line but keep the leading run,
+        # which is list indentation. Fenced blocks are left byte-for-byte: CLI
+        # help output and directory trees are column-aligned.
+        out, open_fence = [], None
+        for ln in s.split("\n"):
+            m = _LINE_FENCE_RE.match(ln)
+            if m:
+                marker = m.group(1)
+                if open_fence is None:
+                    open_fence = marker
+                    out.append(ln)
+                    continue
+                # Only a closer at least as long as its opener ends the block, so
+                # a ``` line inside a ```` block stays code and keeps its columns.
+                if marker[0] == open_fence[0] and len(marker) >= len(open_fence):
+                    open_fence = None
+                    out.append(ln)
+                    continue
+            out.append(
+                ln
+                if open_fence
+                else re.match(r"[ \t]*", ln).group(0) + re.sub(r"[ \t]+", " ", ln.strip())
+            )
+        s = "\n".join(out)
+        # Collapse blank runs outside fenced blocks only; inside one they are
+        # part of the code.
+        # Lines are marked fenced or not, then blank runs are collapsed in a
+        # single pass over the whole text. Collapsing per-chunk and re-joining
+        # the chunks would put the separator back, leaving a second blank line
+        # wherever a paragraph met a fence.
+        fenced, open_fence = [], None
+        for ln in s.split("\n"):
+            m = _LINE_FENCE_RE.match(ln)
+            inside = open_fence is not None
+            if m:
+                marker = m.group(1)
+                if open_fence is None:
+                    open_fence = marker
+                elif marker[0] == open_fence[0] and len(marker) >= len(open_fence):
+                    open_fence = None
+                    inside = True          # the closer belongs to its block
+            fenced.append(inside or open_fence is not None)
+
+        lines = s.split("\n")
+        kept = []
+        for i, ln in enumerate(lines):
+            if ln.strip() or fenced[i]:
+                kept.append(ln)
+                continue
+            # A blank line outside a fence: keep at most one in a row.
+            if kept and not kept[-1].strip() and not (fenced[i - 1] if i else False):
+                continue
+            kept.append(ln)
+        return "\n".join(kept).strip()
 
 
-def _apply_nonfenced(text, *funcs):
-    """Apply each func only to text segments outside fenced code blocks."""
-    out = []
-    for is_fenced, segment in _split_fenced(text):
-        if is_fenced:
-            out.append(segment)
-        else:
-            s = segment
-            for f in funcs:
-                s = f(s)
-            out.append(s)
-    return "".join(out)
+_ARTICLE_OPEN_RE = re.compile(r"<article\b[^>]*>", re.IGNORECASE)
+_ARTICLE_TAG_RE = re.compile(r"<article\b[^>]*>|</article\s*>", re.IGNORECASE)
+_HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
 
 
-def strip_mdx(text):
-    """Remove MDX-specific syntax, leaving clean prose markdown."""
-    # Remove MDX import/export statements only outside fenced code blocks.
-    # This preserves shell `export VAR=...` inside ```bash fences.
-    text = _strip_mdx_module_syntax(text)
-    # Remove JSX block comments and multi-line component tags (fence-aware).
-    # [^>]* in the component regexes matches newlines (char class), consuming
-    # <Link\n  prop="val"\n> in one shot without DOTALL.
-    # Uppercase-then-lowercase guard keeps ALL_CAPS placeholders like <IP>, <PID>.
-    text = _apply_nonfenced(
-        text,
-        lambda t: re.sub(r"\{/\*.*?\*/\}", "", t, flags=re.DOTALL),
-        lambda t: re.sub(r"<[A-Z][a-z][a-zA-Z]*[^>]*>", "", t),
-        lambda t: re.sub(r"</[A-Z][a-z][a-zA-Z]*>", "", t),
-    )
-    # Strip multi-line inline JSX expression blocks ({[...].map(...)} etc.) that
-    # contain nested braces and defeat the single-line {0,120} pattern below.
-    text = _strip_multiline_expr_blocks(text)
-    # Line-by-line pass: apply remaining stripping only outside fenced blocks.
-    out, in_fence = [], False
-    for line in text.splitlines():
-        if line.lstrip().startswith("```"):
-            in_fence = not in_fence
-            out.append(line)
-            continue
-        if in_fence:
-            out.append(line)
-        else:
-            line = _sub_outside_backticks(r"<[A-Za-z][^>]*/?>", "", line)
-            line = _sub_outside_backticks(r"</[A-Za-z][^>]*>", "", line)
-            # Two passes catch {{...}} (inner first, then outer). The callback
-            # preserves uppercase-identifier braces like {ERIGON_VERSION} —
-            # docs authors use these as text-substitution placeholders.
-            line = _sub_outside_backticks(r"\{[^}]{0,120}\}", _strip_jsx_expr, line)
-            line = _sub_outside_backticks(r"\{[^}]{0,120}\}", _strip_jsx_expr, line)
-            # Remove }> prefix artifact (remnant when [^>] stops at > inside =>).
-            line = re.sub(r"^\s*\}\s*>", "", line)
-            out.append(line)
-    text = "\n".join(out)
-    text = re.sub(r"\n{3,}", "\n\n", text)
-    return text.strip()
+def _article_body(html_text):
+    """Contents of the outermost <article>, or None.
 
-
-# Card-grid landing pages — the docs site uses these for top-level section
-# index pages. After MDX stripping, they collapse to a structureless pile of
-# title/desc fragments. We detect the lp-card pattern and synthesize a clean
-# bullet list instead, keeping link structure intact for LLM consumption.
-_LANDING_CARD_RE = re.compile(
-    r'<Link\s[^>]*\bto=[\'"]([^\'"]+)[\'"][^>]*>'
-    r'(?:.*?)'
-    r'<div[^>]*\blp-card-title\b[^>]*>([^<]+)</div>'
-    r'(?:.*?)'
-    r'<div[^>]*\blp-card-desc\b[^>]*>([^<]+)</div>'
-    r'(?:.*?)'
-    r'</Link>',
-    re.DOTALL,
-)
-_LANDING_HERO_RE = re.compile(
-    r'<div[^>]*\blp-hero\b[^>]*>'
-    r'(?:.*?)'
-    r'<h1>([^<]+)</h1>'
-    r'(?:.*?)'
-    r'<p>([^<]+)</p>',
-    re.DOTALL,
-)
-
-
-def synthesize_landing(raw_body):
-    """If body is a card-grid landing page, emit structured markdown.
-
-    Returns synthesized markdown, or None if no `lp-card` patterns are present.
-    Card hrefs that start with `/` are rewritten to absolute BASE_URL form so
-    bullets remain useful when the body is read out of context.
+    Depth-counted rather than matched with a lazy regex, which would stop at the
+    first nested `</article>` and silently return a partial page as a success.
     """
-    cards = list(_LANDING_CARD_RE.finditer(raw_body))
-    if not cards:
+    m = _ARTICLE_OPEN_RE.search(html_text)
+    if not m:
         return None
+    # ReactDOM emits comments, and a tag inside one is text. Counting it would
+    # end the body early and return the truncated head of the page as a success.
+    comments = [(c.start(), c.end()) for c in _HTML_COMMENT_RE.finditer(html_text)]
 
-    out = []
-    hero = _LANDING_HERO_RE.search(raw_body)
-    if hero:
-        lead = hero.group(2).strip()
-        if lead:
-            out.append(lead)
-            out.append("")
+    def commented(i):
+        return any(a <= i < b for a, b in comments)
 
-    out.append("## Sections")
-    out.append("")
-    for m in cards:
-        href = m.group(1).strip()
-        if href.startswith("/"):
-            href = BASE_URL + href.rstrip("/")
-        title = m.group(2).strip()
-        desc = m.group(3).strip()
-        out.append(f"- [{title}]({href}): {desc}")
-    return "\n".join(out)
+    depth, pos = 1, m.end()
+    for t in _ARTICLE_TAG_RE.finditer(html_text, m.end()):
+        if commented(t.start()):
+            continue
+        depth += -1 if t.group(0).startswith("</") else 1
+        if depth == 0:
+            return html_text[pos:t.start()]
+    return None  # unbalanced: refuse rather than return a truncated body
+# A segment holding nothing but an image is a decorative icon, not a label.
+_IMAGE_ONLY_RE = re.compile(r"!\[[^\]]*\]\([^)]*\)")
+
+# Docusaurus compiles a mermaid fence into a component that draws client-side, so
+# the diagram source appears nowhere in the built HTML. It is real page content —
+# a graph described in text — so it is spliced back in from the source. A fence
+# with a known info string is unambiguous on its own; no block parsing needed.
+# At most three columns of indent: four or more make an indented code block,
+# which opens no fence (CommonMark 4.5).
+_FENCE_LINE_RE = re.compile(r"^[ \t]{0,3}(`{3,}|~{3,})[ \t]*([^\s`~]*)")
+_JSX_COMMENT_RE = re.compile(r"\{/\*.*?\*/\}", re.DOTALL)
+_ATX_HEADING_RE = re.compile(r"^[ \t]{0,3}#{1,6}[ \t]+(.*?)[ \t]*#*[ \t]*$")
+_QUOTE_PREFIX_RE = re.compile(r"^[ \t]{0,3}(?:>[ \t]?)+")
+
+
+def _peel_quote(line):
+    """Strip blockquote markers so a fence inside a quote is seen as a fence."""
+    return _QUOTE_PREFIX_RE.sub("", line)
+
+
+def mermaid_blocks(source):
+    """Fenced mermaid diagrams in an MDX source, as fenced Markdown.
+
+    Returns (heading, block) pairs, where `heading` is the text of the nearest
+    ATX heading above the fence, or "" at the top of a page. The heading is what
+    lets the diagram go back where it belongs: prose around it says things like
+    "every box above", which is false if the diagram is appended to the page.
+
+    Fences are walked in order so a ```mermaid line inside a longer enclosing
+    fence is code being displayed, not a diagram, and a closer shorter than its
+    opener does not end the block (CommonMark 4.5). A fence inside a blockquote
+    is a diagram too, so container markers are peeled before the fence test.
+    """
+    # A commented-out diagram renders nothing, so it is not page content. The
+    # regions are blanked rather than removed so line structure is unchanged.
+    source = _JSX_COMMENT_RE.sub(lambda m: re.sub(r"[^\n]", " ", m.group(0)), source)
+    blocks, lines = [], source.split("\n")
+    i, n, heading = 0, len(lines), ""
+    while i < n:
+        h = _ATX_HEADING_RE.match(lines[i])
+        opener = _peel_quote(lines[i])
+        # Only a fence that was itself quoted has its body peeled: `>` is legal
+        # inside a diagram, and stripping it from a top-level fence would edit
+        # the diagram's own source.
+        see = _peel_quote if opener != lines[i] else (lambda ln: ln)
+
+        m = _FENCE_LINE_RE.match(opener)
+        if not m:
+            if h:
+                heading = h.group(1).strip()
+            i += 1
+            continue
+        marker, info = m.group(1), m.group(2).lower()
+        at, body, i = heading, [], i + 1
+        while i < n:
+            c = _FENCE_LINE_RE.match(see(lines[i]))
+            if c and c.group(1)[0] == marker[0] and len(c.group(1)) >= len(marker) \
+                    and not c.group(2):
+                break
+            body.append(see(lines[i]))
+            i += 1
+        i += 1
+        if info == "mermaid" and body:
+            text = "\n".join(body).strip("\n")
+            longest = max((len(t) for t in re.findall(r"`+", text)), default=0)
+            fence = "`" * max(3, longest + 1)
+            blocks.append((at, f"{fence}mermaid\n{text}\n{fence}"))
+    return blocks
+
+
+def splice_diagram(body, heading, block):
+    """Insert `block` under `heading` in `body`; append if the heading is gone."""
+    if not heading:
+        return body + "\n\n" + block
+
+    lines = body.split("\n")
+    # A `#` line inside a fence is code, not a heading: a bash `# Usage` comment
+    # would otherwise match the "Usage" heading and splice the diagram into the
+    # middle of the code block.
+    idx, fence = None, None
+    for i, ln in enumerate(lines):
+        m = _FENCE_LINE_RE.match(ln)
+        if m:
+            marker = m.group(1)
+            if fence is None:
+                fence = marker
+            elif marker[0] == fence[0] and len(marker) >= len(fence):
+                fence = None
+            continue
+        if fence is not None:
+            continue
+        h = _ATX_HEADING_RE.match(ln)
+        if h and h.group(1).strip() == heading:
+            idx = i
+            break
+    if idx is None:
+        return body + "\n\n" + block
+
+    # Step over diagrams already spliced under this heading, so a heading
+    # carrying several of them keeps them in source order.
+    ins, j = idx, idx + 1
+    while j < len(lines):
+        if not lines[j].strip():
+            j += 1
+            continue
+        m = _FENCE_LINE_RE.match(lines[j])
+        if not (m and m.group(2).lower() == "mermaid"):
+            break
+        marker = m.group(1)
+        j += 1
+        while j < len(lines):
+            c = _FENCE_LINE_RE.match(lines[j])
+            j += 1
+            if c and c.group(1)[0] == marker[0] and len(c.group(1)) >= len(marker) \
+                    and not c.group(2):
+                break
+        ins = j - 1
+    return "\n".join(lines[:ins + 1] + ["", block] + lines[ins + 1:])
+
+
+def built_path_for(url):
+    """Built HTML file for a deployed page URL, or None if absent."""
+    path = url[len(BASE_URL):].strip("/")
+    candidates = (
+        [BUILD_DIR / "index.html"]
+        if not path
+        else [BUILD_DIR / f"{path}.html", BUILD_DIR / path / "index.html"]
+    )
+    return next((c for c in candidates if c.is_file()), None)
+
+
+def page_text_from_build(url):
+    """Markdown-ish text of a page's <article>.
+
+    Returns None when the built page cannot be read at all, and "" when it reads
+    but renders no text — a client-drawn-only page. The caller reports those
+    differently, since "run npm run build" is the wrong advice for the second.
+    """
+    built = built_path_for(url)
+    if built is None:
+        return None
+    body = _article_body(built.read_text(encoding="utf-8"))
+    if body is None:
+        return None
+    p = _ArticleText(page_url=url)
+    p.feed(body)
+    p.close()
+    return p.text()
 
 
 def file_to_url(filepath, route_prefix):
@@ -356,15 +766,56 @@ def file_to_url(filepath, route_prefix):
     return BASE_URL + path
 
 
+# A fence keeps its meaning inside a blockquote, where the line already carries
+# `> ` markers by the time the whitespace passes run. Without peeling them those
+# passes reflow quoted code, which is column-aligned CLI output.
+_LINE_FENCE_RE = re.compile(r"[ \t]*(?:>[ \t]?)*[ \t]*(`{3,}|~{3,})")
+
+
+def _squeeze_blank_runs(text):
+    """Collapse runs of blank lines, leaving fenced blocks untouched."""
+    out, open_fence = [], None
+    for ln in text.split("\n"):
+        m = _LINE_FENCE_RE.match(ln)
+        fenced = open_fence is not None
+        if m:
+            marker = m.group(1)
+            if open_fence is None:
+                open_fence = marker
+            elif marker[0] == open_fence[0] and len(marker) >= len(open_fence):
+                open_fence = None
+                fenced = True
+        if ln.strip() or fenced or open_fence is not None or (out and out[-1].strip()):
+            out.append(ln)
+    return "\n".join(out)
+
+
+# `\s` spans newlines, so `#\s+` on a body opening with an empty H1 would reach
+# past the blank line and delete the first real prose line with it.
+_LEADING_H1_RE = re.compile(r"^#[^\S\n]+[^\n]*\n?")
+
+
+def strip_leading_h1(body):
+    """Drop a body's opening H1, which duplicates the page title."""
+    return _LEADING_H1_RE.sub("", body.lstrip("\n"), count=1).lstrip("\n")
+
+
 def first_description(body):
     """Extract first non-empty prose paragraph (not a heading, code, or table)."""
-    in_code = False
+    open_fence = None
     for line in body.splitlines():
         stripped = line.strip()
-        if stripped.startswith("```"):
-            in_code = not in_code
+        f = _FENCE_LINE_RE.match(line)
+        if f:
+            marker = f.group(1)
+            # A shorter run inside a longer fence is displayed code, not a
+            # closer, so a 4-backtick block does not desync on its interior.
+            if open_fence is None:
+                open_fence = marker
+            elif marker[0] == open_fence[0] and len(marker) >= len(open_fence):
+                open_fence = None
             continue
-        if in_code:
+        if open_fence:
             continue
         if not stripped:
             continue
@@ -394,7 +845,9 @@ def _read_category(dirpath):
         return ("", 99)
     try:
         data = json.loads(cat.read_text(encoding="utf-8"))
-    except Exception:
+    except (OSError, ValueError) as exc:
+        # Falling back silently would reorder the corpus with no way to notice.
+        print(f"generate-llms: warning: cannot read {cat}: {exc}", file=sys.stderr)
         return ("", 99)
     label = data.get("label", "")
     try:
@@ -439,15 +892,31 @@ def collect_pages(base_dir, route_prefix):
     """Walk base_dir, return list of page dicts."""
     files = sorted(set(list(base_dir.rglob("*.md")) + list(base_dir.rglob("*.mdx"))))
 
-    pages = []
+    pages, missing, empty = [], [], []
     for fpath in files:
         text = fpath.read_text(encoding="utf-8")
-        meta, body = parse_frontmatter(text)
+        meta, _ = parse_frontmatter(text)
 
-        # Card-grid landing pages: synthesize structured bullets BEFORE strip_mdx
-        # so we still have the original JSX to extract titles/hrefs from.
-        synth = synthesize_landing(body)
-        clean_body = synth if synth is not None else strip_mdx(body)
+        # Docusaurus omits a draft page from the build, so it has no page text
+        # and belongs in neither artifact.
+        if str(meta.get("draft", "")).lower() == "true":
+            continue
+
+        url = file_to_url(fpath, route_prefix)
+        # The body comes from the built page, so every MDX component and every
+        # relative link is already resolved.
+        clean_body = page_text_from_build(url)
+        if clean_body is None:
+            missing.append((fpath, url))
+            continue
+
+        for heading, diagram in mermaid_blocks(text):
+            if diagram not in clean_body:
+                clean_body = splice_diagram(clean_body, heading, diagram)
+
+        if not clean_body.strip():
+            empty.append((fpath, url))
+            continue
 
         title = meta.get("title", "")
         if not title:
@@ -455,13 +924,11 @@ def collect_pages(base_dir, route_prefix):
             title = m.group(1).strip() if m else fpath.stem.replace("-", " ").title()
 
         description = meta.get("description", "") or first_description(clean_body)
-        url = file_to_url(fpath, route_prefix)
         position = _safe_int(meta.get("sidebar_position", 50), 50)
 
         rel = fpath.relative_to(base_dir)
         section_dir = base_dir / rel.parts[0] if len(rel.parts) > 1 else base_dir
         section_label = get_category_label(section_dir) if len(rel.parts) > 1 else ""
-        section_pos = get_category_position(section_dir) if len(rel.parts) > 1 else 0
         anc_pos = ancestor_positions(fpath, base_dir)
 
         pages.append({
@@ -470,12 +937,32 @@ def collect_pages(base_dir, route_prefix):
             "url":             url,
             "position":        position,
             "section":         section_label,
-            "section_pos":     section_pos,
             "ancestor_pos":    anc_pos,
             "depth":           len(rel.parts),
             "body":            clean_body,
             "fpath":           str(fpath),
         })
+
+    if empty:
+        listed = "\n".join(f"  {f}  ->  {u}" for f, u in empty[:10])
+        raise SystemExit(
+            f"generate-llms: {len(empty)} page(s) built but render no text. A page "
+            f"whose only content draws client-side (a chart, a diagram component) "
+            f"contributes nothing to the corpus and needs handling here.\n{listed}"
+        )
+    if missing:
+        listed = "\n".join(f"  {f}  ->  {u}" for f, u in missing[:10])
+        more = f"\n  ... and {len(missing) - 10} more" if len(missing) > 10 else ""
+        hint = (
+            "docs/site/build is absent — run `npm run build` in docs/site first."
+            if not BUILD_DIR.is_dir()
+            else "these pages have no built HTML; check they are in the sidebar and that "
+                 "the build is current."
+        )
+        raise SystemExit(
+            f"generate-llms: {len(missing)} page(s) could not be read from the built "
+            f"site.\n{hint}\n{listed}{more}"
+        )
 
     return pages
 
@@ -530,8 +1017,9 @@ def build():
     lines.append(
         f"The text of every page listed below is also available as a single file: "
         f"[llms-full.txt]({BASE_URL}/llms-full.txt). Pages are cleaned for machine "
-        f"reading: MDX components are stripped, and a card-grid landing page is "
-        f"reduced to the list of links its grids contain."
+        f"reading: text comes from the built site, so components are expanded and "
+        f"links resolved, and a card-grid landing page keeps its prose with each "
+        f"grid rendered as a link list."
     )
     lines.append("")
 
@@ -573,7 +1061,10 @@ def build():
         full_parts.append("")
         # Strip a leading H1 from the body — many docs start with an H1 that
         # matches the title, which would produce a duplicate heading.
-        body = re.sub(r"^#\s+[^\n]+\n?", "", p["body"].lstrip("\n"), count=1)
+        body = strip_leading_h1(p["body"])
+        # The header already ends in a blank line; a body starting with one too
+        # would open every page with two.
+        body = body.lstrip("\n")
         full_parts.append(body)
         full_parts.append("")
         full_parts.append("---")
@@ -592,23 +1083,55 @@ def write_outputs(llms_txt, llms_full_txt):
     (REPO_ROOT / "llms-full.txt").write_text(llms_full_txt, encoding="utf-8")
 
 
+# The build resolves `{ERIGON_VERSION}` from the GitHub Releases API
+# (docusaurus.config.ts), so a page — and therefore this corpus — changes when
+# Erigon ships a release, with no commit in this repo. Comparing byte-for-byte
+# would turn `--check` red on every docs PR from that moment until someone
+# regenerates. Version tokens are therefore masked for the staleness verdict and
+# reported separately: a version-only difference is drift to fix at leisure,
+# anything else is a real regression and still fails.
+# Only the Erigon release the build resolved is masked, and it is discovered
+# from the artifact names it appears in rather than by pattern. Masking every
+# `N.N.N` would also mask a Go or library version, so a real docs edit to one of
+# those would be downgraded to warning-only drift.
+# No trailing \b: the version is followed by `_` in `erigon_v3.6.0_linux`, and
+# `0_` is not a word boundary, so an anchored pattern matches nothing there.
+_RELEASE_ANCHOR_RE = re.compile(r"erigon[:_/-]v?(\d+\.\d+\.\d+)(?!\.?\d)")
+
+
+def _mask_versions(text):
+    found = _RELEASE_ANCHOR_RE.findall(text)
+    if not found:
+        return text
+    release = Counter(found).most_common(1)[0][0]
+    return re.sub(rf"v?{re.escape(release)}(?!\.?\d)", "<release>", text)
+
+
 def check_outputs(llms_txt, llms_full_txt):
-    """Compare regenerated content to on-disk files. Return list of stale paths."""
+    """Compare regenerated content to on-disk files.
+
+    Returns (stale, version_drift): paths differing in more than version tokens,
+    and paths differing only in them.
+    """
     targets = [
         (OUT_DIR / "llms.txt",        llms_txt),
         (OUT_DIR / "llms-full.txt",   llms_full_txt),
         (REPO_ROOT / "llms.txt",      llms_txt),
         (REPO_ROOT / "llms-full.txt", llms_full_txt),
     ]
-    stale = []
+    stale, version_drift = [], []
     for path, expected in targets:
         try:
             actual = path.read_text(encoding="utf-8")
         except FileNotFoundError:
             actual = ""
-        if actual != expected:
+        if actual == expected:
+            continue
+        if _mask_versions(actual) == _mask_versions(expected):
+            version_drift.append(path)
+        else:
             stale.append(path)
-    return stale
+    return stale, version_drift
 
 
 def main():
@@ -624,13 +1147,19 @@ def main():
     llms_txt, llms_full_txt, n_pages = build()
 
     if args.check:
-        stale = check_outputs(llms_txt, llms_full_txt)
+        stale, version_drift = check_outputs(llms_txt, llms_full_txt)
         if stale:
             print("ERROR: regenerated content differs from committed files:", file=sys.stderr)
             for path in stale:
                 print(f"  {path}", file=sys.stderr)
             print("Run: python3 docs/site/scripts/generate-llms.py", file=sys.stderr)
             sys.exit(1)
+        if version_drift:
+            print(f"WARNING: {len(version_drift)} file(s) differ only in version "
+                  f"tokens — Erigon shipped a release since these were generated. "
+                  f"Regenerate when convenient; not a failure.", file=sys.stderr)
+            for path in version_drift:
+                print(f"  {path}", file=sys.stderr)
         print(f"OK: 4 llms files match regenerated content ({n_pages} pages)")
         return
 

--- a/docs/site/scripts/generate-llms.py
+++ b/docs/site/scripts/generate-llms.py
@@ -1160,7 +1160,10 @@ def main():
                   f"Regenerate when convenient; not a failure.", file=sys.stderr)
             for path in version_drift:
                 print(f"  {path}", file=sys.stderr)
-        print(f"OK: 4 llms files match regenerated content ({n_pages} pages)")
+            print(f"OK: no differences beyond the release token "
+                  f"({n_pages} pages)")
+        else:
+            print(f"OK: 4 llms files match regenerated content ({n_pages} pages)")
         return
 
     write_outputs(llms_txt, llms_full_txt)

--- a/docs/site/scripts/test_generate_llms.py
+++ b/docs/site/scripts/test_generate_llms.py
@@ -587,12 +587,13 @@ class MalformedAttributeTests(unittest.TestCase):
         )
 
 
-class ReviewRoundFixTests(unittest.TestCase):
-    """Defects found by independent review of the built-site rewrite.
+class RenderingFidelityTests(unittest.TestCase):
+    """Structure the built HTML carries and the Markdown output must keep.
 
-    Each of these produced wrong bytes in a committed artifact that `--check`
-    called green, because the check compares this code's output to this code's
-    earlier output and so cannot see a systematic error.
+    Fence languages, admonition type and title, blockquote markers, tab labels,
+    link and code-span delimiters, and the boundaries the whitespace passes must
+    not cross. `--check` compares this code's output against its own earlier
+    output, so it cannot see any of these going wrong.
     """
 
     def render(self, html, page_url=""):
@@ -654,8 +655,8 @@ class ReviewRoundFixTests(unittest.TestCase):
 
     # -- link buffer routing ------------------------------------------------
     def test_space_between_inline_elements_in_a_link_survives(self):
-        # The whitespace guard used to test the page buffer while writing to the
-        # link buffer, so the words fused.
+        # The whitespace guard has to test the buffer being written to; testing
+        # the page buffer while emitting into the link buffer fuses the words.
         self.assertEqual(
             "See [**Alpha** *beta*](https://docs.erigon.tech/x) now.",
             self.render('<p>See <a href="/x"><strong>Alpha</strong> '
@@ -704,8 +705,8 @@ class ReviewRoundFixTests(unittest.TestCase):
         self.assertLess(out.index("graph TD"), out.index("Every box above"))
 
     def test_a_hash_comment_inside_a_fence_is_not_a_heading(self):
-        # Every other scanner here is fence-aware; this one was not, so a bash
-        # `# Usage` comment matched the "Usage" heading and the diagram landed
+        # A `#` line inside a fence is code: without fence tracking a bash
+        # `# Usage` comment matches the "Usage" heading and the diagram lands
         # inside the code block.
         body = ("## Intro\n\n```bash\n# Usage\nerigon --help\n```\n\n"
                 "## Usage\n\nReal section.\n")
@@ -751,8 +752,8 @@ class ReviewRoundFixTests(unittest.TestCase):
 
     # -- blank-line collapse ------------------------------------------------
     def test_a_paragraph_meeting_a_fence_leaves_one_blank_line(self):
-        # Collapsing per-chunk and re-joining the chunks put the separator back,
-        # so every paragraph-then-code boundary carried a second blank line.
+        # Blank runs collapse in one pass over the whole text: collapsing per
+        # chunk and re-joining puts the separator back at every fence boundary.
         out = self.render('<p>Run:</p><pre class="language-sh"><code>ls</code></pre>')
         self.assertEqual("Run:\n\n```sh\nls\n```", out)
 
@@ -771,7 +772,7 @@ class ReviewRoundFixTests(unittest.TestCase):
     # -- admonition titles --------------------------------------------------
     def test_a_custom_admonition_title_survives(self):
         # `:::tip Some title` puts the title in the heading div, where the type
-        # word otherwise sits. Skipping the div wholesale dropped the title.
+        # word otherwise sits, so the div cannot simply be skipped.
         html = ('<div class="theme-admonition theme-admonition-tip">'
                 '<div class="admonitionHeading_Rf37">'
                 '<span class="admonitionIcon_a"><svg><path/></svg></span>'
@@ -795,7 +796,7 @@ class ReviewRoundFixTests(unittest.TestCase):
 
     # -- leading H1 ---------------------------------------------------------
     def test_an_empty_h1_does_not_eat_the_first_prose_line(self):
-        # `#\s+` spans newlines, so it reached past the blank line.
+        # `#\s+` would span the newline and reach the first prose line.
         self.assertEqual("First prose line.\n\nSecond.",
                          g.strip_leading_h1("# \n\nFirst prose line.\n\nSecond."))
 
@@ -804,8 +805,8 @@ class ReviewRoundFixTests(unittest.TestCase):
 
     # -- tabs ---------------------------------------------------------------
     def test_tab_labels_attach_to_their_panels(self):
-        # Docusaurus links a label to its panel by order only, so the labels
-        # used to render as a bullet list and the panels as an unlabelled run.
+        # Docusaurus links a label to its panel by order only, so the binding
+        # has to be reconstructed or the panels read as an unlabelled run.
         html = ('<ul role="tablist" class="tabs">'
                 '<li role="tab" class="tabs__item tabs__item--active">Ethereum mainnet</li>'
                 '<li role="tab" class="tabs__item">Gnosis Chain</li></ul>'

--- a/docs/site/scripts/test_generate_llms.py
+++ b/docs/site/scripts/test_generate_llms.py
@@ -6,6 +6,7 @@ Run from repo root:
 """
 
 import importlib.util
+import re
 import unittest
 from pathlib import Path
 
@@ -13,76 +14,6 @@ _HERE = Path(__file__).parent
 _spec = importlib.util.spec_from_file_location("generate_llms", _HERE / "generate-llms.py")
 g = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(g)
-
-
-class StripMdxTests(unittest.TestCase):
-    def test_preserves_inline_uppercase_placeholder(self):
-        out = g.strip_mdx("Use `erigontech/erigon:v{ERIGON_VERSION}` to pull.")
-        self.assertIn("{ERIGON_VERSION}", out)
-
-    def test_preserves_bare_uppercase_placeholder_in_prose(self):
-        out = g.strip_mdx("Download erigon_v{ERIGON_VERSION}_amd64.deb from releases.")
-        self.assertIn("{ERIGON_VERSION}", out)
-
-    def test_preserves_uppercase_placeholder_in_table_cell(self):
-        out = g.strip_mdx("| binary | erigon_v{ERIGON_VERSION}_amd64.deb |")
-        self.assertIn("{ERIGON_VERSION}", out)
-
-    def test_strips_jsx_expression(self):
-        out = g.strip_mdx("Hello {props.name} world.")
-        self.assertNotIn("{props.name}", out)
-        self.assertIn("Hello", out)
-        self.assertIn("world", out)
-
-    def test_strips_jsx_expression_with_arrow_fn(self):
-        out = g.strip_mdx("Render {items.map(i => i.name)} list.")
-        self.assertNotIn("items.map", out)
-
-    def test_preserves_export_var_in_bash_fence(self):
-        text = "```bash\nexport ERIGON_DATA=/var/erigon\n```"
-        out = g.strip_mdx(text)
-        self.assertIn("export ERIGON_DATA=/var/erigon", out)
-
-    def test_strips_mdx_export_const(self):
-        out = g.strip_mdx("export const VERSION = '1.0';\n\nHello world.")
-        self.assertNotIn("export const", out)
-        self.assertIn("Hello world", out)
-
-    def test_strips_jsx_component_tag(self):
-        out = g.strip_mdx("<Tabs>\n  Hello\n</Tabs>")
-        self.assertNotIn("<Tabs>", out)
-        self.assertNotIn("</Tabs>", out)
-        self.assertIn("Hello", out)
-
-    def test_preserves_lowercase_placeholder_in_backticks(self):
-        out = g.strip_mdx("Set `<YOUR_ADDRESS>` to your wallet.")
-        self.assertIn("<YOUR_ADDRESS>", out)
-
-    def test_preserves_fence_content_unchanged(self):
-        text = '```json\n{"jsonrpc":"2.0","method":"eth_call","params":[]}\n```'
-        out = g.strip_mdx(text)
-        self.assertIn('"jsonrpc":"2.0"', out)
-        self.assertIn('"params":[]', out)
-
-    def test_strips_multiline_jsx_expression_block(self):
-        text = "Before.\n\n{[\n  {a:1},\n  {b:2},\n].map(x => x)}\n\nAfter."
-        out = g.strip_mdx(text)
-        self.assertNotIn("{a:1}", out)
-        self.assertNotIn(".map(", out)
-        self.assertIn("Before.", out)
-        self.assertIn("After.", out)
-
-    def test_strips_mdx_imports_outside_fence(self):
-        out = g.strip_mdx("import Link from '@docusaurus/Link';\n\nReal content.")
-        self.assertNotIn("import Link", out)
-        self.assertIn("Real content", out)
-
-    def test_preserves_imports_inside_fence(self):
-        text = "```python\nimport os\nimport sys\n```"
-        out = g.strip_mdx(text)
-        self.assertIn("import os", out)
-        self.assertIn("import sys", out)
-
 
 class FrontmatterTests(unittest.TestCase):
     def test_simple_kv(self):
@@ -117,49 +48,6 @@ class SafeIntTests(unittest.TestCase):
         self.assertEqual(g._safe_int(None, 7), 7)
 
 
-class LandingSynthesisTests(unittest.TestCase):
-    def test_card_grid_synthesized(self):
-        body = """
-<div className="lp-grid">
-<Link className="lp-card" to="/get-started/">
-  <div className="lp-card-title">Get Started</div>
-  <div className="lp-card-desc">Hardware requirements and installation.</div>
-</Link>
-<Link className="lp-card" to="/staking/">
-  <div className="lp-card-title">Staking</div>
-  <div className="lp-card-desc">Run a validator.</div>
-</Link>
-</div>
-"""
-        out = g.synthesize_landing(body)
-        self.assertIsNotNone(out)
-        self.assertIn("[Get Started](https://docs.erigon.tech/get-started)", out)
-        self.assertIn("[Staking](https://docs.erigon.tech/staking)", out)
-        self.assertIn("Hardware requirements", out)
-
-    def test_hero_paragraph_emitted(self):
-        body = """
-<div className="lp-hero">
-  <h1>Get Started</h1>
-  <p>Everything you need to go from zero to a running node.</p>
-</div>
-
-<div className="lp-grid">
-<Link className="lp-card" to="/install/">
-  <div className="lp-card-title">Install</div>
-  <div className="lp-card-desc">Install instructions.</div>
-</Link>
-</div>
-"""
-        out = g.synthesize_landing(body)
-        self.assertIsNotNone(out)
-        self.assertIn("Everything you need", out)
-
-    def test_no_cards_returns_none(self):
-        out = g.synthesize_landing("# Hello\n\nProse only, no cards.")
-        self.assertIsNone(out)
-
-
 class LeadingH1StripTests(unittest.TestCase):
     """The build() body-prep step strips a leading H1 to avoid duplicate headings."""
 
@@ -175,6 +63,824 @@ class LeadingH1StripTests(unittest.TestCase):
         body = "## Subheading\n\nContent."
         out = re.sub(r"^#\s+[^\n]+\n?", "", body.lstrip("\n"), count=1)
         self.assertIn("## Subheading", out)
+
+
+class ArticleTextTests(unittest.TestCase):
+    """Rendering a built <article> subtree as Markdown-ish text."""
+
+    def render(self, html):
+        p = g._ArticleText()
+        p.feed(html)
+        p.close()
+        return p.text()
+
+    def test_bullet_list_one_item_per_line(self):
+        self.assertEqual(
+            "- A\n- B",
+            self.render('<ul><li class="">A</li>\n<li class="">B</li></ul>'),
+        )
+
+    def test_ordered_list_keeps_its_numbers(self):
+        self.assertEqual(
+            "1. First\n2. Second",
+            self.render("<ol><li>First</li><li>Second</li></ol>"),
+        )
+
+    def test_ordered_list_honours_start(self):
+        self.assertEqual(
+            "3. Third\n4. Fourth",
+            self.render('<ol start="3"><li>Third</li><li>Fourth</li></ol>'),
+        )
+
+    def test_nested_list_is_indented(self):
+        self.assertEqual(
+            "- Top\n  - Inner\n\n- Next",
+            self.render("<ul><li>Top<ul><li>Inner</li></ul></li><li>Next</li></ul>"),
+        )
+
+    def test_table_becomes_markdown_with_header_rule(self):
+        self.assertEqual(
+            "| H1 | H2 |\n| --- | --- |\n| a | b |",
+            self.render(
+                "<table><thead><tr><th>H1</th><th>H2</th></tr></thead>"
+                "<tbody><tr><td>a</td><td>b</td></tr></tbody></table>"
+            ),
+        )
+
+    def test_code_block_keeps_column_alignment(self):
+        # CLI help and directory trees are aligned; reflowing them destroys the
+        # only structure they have. This uses the markup Docusaurus actually
+        # emits — one <div class="token-line"> per line, each ending in <br> —
+        # because a synthetic <pre><code> with raw newlines cannot catch the
+        # double-spacing that shape causes, and --check compares generated output
+        # against output from the same code so it never would either.
+        out = self.render(
+            '<pre class="prism-code"><code>'
+            '<div class="token-line"><span class="token plain">'
+            "--webseed string      URLs</span><br></div>"
+            '<div class="token-line"><span class="token plain">'
+            "--datadir  string     Dir</span><br></div>"
+            "</code></pre>"
+        )
+        self.assertEqual("```\n--webseed string      URLs\n--datadir  string     Dir\n```", out)
+
+    def test_synthetic_pre_with_raw_newlines_also_works(self):
+        out = self.render("<pre><code>line1\nline2\n</code></pre>")
+        self.assertEqual("```\nline1\nline2\n```", out)
+
+    def test_inline_emphasis_and_code(self):
+        self.assertEqual(
+            "A **bold** and `tok`.",
+            self.render("<p>A <strong>bold</strong> and <code>tok</code>.</p>"),
+        )
+
+    def test_link_keeps_resolved_href(self):
+        self.assertEqual(
+            "See [that page](https://docs.erigon.tech/x/y) now.",
+            self.render('<p>See <a href="/x/y">that page</a> now.</p>'),
+        )
+
+    def test_card_link_splits_label_from_blurb(self):
+        # A landing-grid card is one <a> wrapping a title div and a description
+        # div; fusing them would produce "[TitleDescription](url)".
+        out = self.render(
+            '<a href="/get-started/"><div class="lp-card-title">Get Started</div>'
+            '<div class="lp-card-desc">Hardware and install.</div></a>'
+        )
+        self.assertEqual(
+            "- [Get Started](https://docs.erigon.tech/get-started/): Hardware and install.",
+            out,
+        )
+
+    def test_heading_anchor_is_dropped(self):
+        out = self.render(
+            '<h2 id="x">Title<a href="#x" class="hash-link">​</a></h2>'
+        )
+        self.assertEqual("## Title", out)
+
+    def test_chrome_subtree_is_skipped(self):
+        out = self.render(
+            '<div class="tocCollapsible_x theme-doc-toc-mobile">'
+            "<ul><li>On this page</li></ul></div><p>Body.</p>"
+        )
+        self.assertEqual("Body.", out)
+
+
+class MermaidSpliceTests(unittest.TestCase):
+    """Mermaid renders client-side, so its source is absent from built HTML."""
+
+    def test_fence_is_extracted_from_source(self):
+        src = 'intro\n\n```mermaid\ngraph TD\n  A --> B\n```\n\ntail\n'
+        self.assertEqual([("", "```mermaid\ngraph TD\n  A --> B\n```")],
+                         g.mermaid_blocks(src))
+
+    def test_no_mermaid_yields_nothing(self):
+        self.assertEqual([], g.mermaid_blocks("prose\n\n```bash\nls\n```\n"))
+
+
+class BuiltPathTests(unittest.TestCase):
+    def test_flat_page_and_index_forms(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            (root / "get-started").mkdir()
+            (root / "get-started" / "intro.html").write_text("x", encoding="utf-8")
+            (root / "section").mkdir()
+            (root / "section" / "index.html").write_text("x", encoding="utf-8")
+            (root / "index.html").write_text("x", encoding="utf-8")
+            orig = g.BUILD_DIR
+            g.BUILD_DIR = root
+            try:
+                b = g.BASE_URL
+                self.assertEqual(root / "get-started" / "intro.html",
+                                 g.built_path_for(b + "/get-started/intro"))
+                self.assertEqual(root / "section" / "index.html",
+                                 g.built_path_for(b + "/section"))
+                self.assertEqual(root / "index.html", g.built_path_for(b + "/"))
+                self.assertIsNone(g.built_path_for(b + "/nope"))
+            finally:
+                g.BUILD_DIR = orig
+
+
+class ArticleTextEdgeTests(unittest.TestCase):
+    """Constructs the happy-path tests miss."""
+
+    def render(self, html):
+        p = g._ArticleText()
+        p.feed(html)
+        p.close()
+        return p.text()
+
+    def test_definition_list_is_not_fused(self):
+        self.assertEqual(
+            "Term\n\nDefinition",
+            self.render("<dl><dt>Term</dt><dd>Definition</dd></dl>"),
+        )
+
+    def test_image_alt_text_is_kept(self):
+        self.assertEqual(
+            "![Meaningful diagram](https://docs.erigon.tech/x.png)",
+            self.render('<p><img alt="Meaningful diagram" src="/x.png"></p>'),
+        )
+
+    def test_table_without_thead_gets_no_header_rule(self):
+        # Promoting the first data row to a header would misattribute every cell.
+        self.assertEqual(
+            "| a | b |\n| c | d |",
+            self.render(
+                "<table><tbody><tr><td>a</td><td>b</td></tr>"
+                "<tr><td>c</td><td>d</td></tr></tbody></table>"
+            ),
+        )
+
+    def test_th_row_without_thead_is_a_header(self):
+        self.assertEqual(
+            "| H |\n| --- |\n| a |",
+            self.render("<table><tr><th>H</th></tr><tr><td>a</td></tr></table>"),
+        )
+
+    def test_code_block_containing_a_fence_gets_a_longer_fence(self):
+        self.assertEqual(
+            "````\ntext\n```\nmore\n````",
+            self.render("<pre><code>text\n```\nmore\n</code></pre>"),
+        )
+
+    def test_class_substring_is_not_treated_as_chrome(self):
+        # `theme-doc-breadcrumbs-note` is page content, not the breadcrumb nav;
+        # only whole class tokens count.
+        self.assertEqual(
+            "Real content.",
+            self.render('<div class="theme-doc-breadcrumbs-note"><p>Real content.</p></div>'),
+        )
+
+    def test_real_chrome_class_is_still_skipped(self):
+        self.assertEqual(
+            "Body.",
+            self.render(
+                '<nav class="theme-doc-breadcrumbs breadcrumbsContainer_Z_bl">'
+                "<p>nav</p></nav><p>Body.</p>"
+            ),
+        )
+
+    def test_void_element_with_chrome_class_keeps_following_text(self):
+        # A void tag has no end tag, so entering skip mode on one would swallow
+        # the rest of its parent.
+        self.assertEqual(
+            "Before after.\n\nNext.",
+            self.render(
+                '<p>Before <img class="hash-link" src="/x"> after.</p><p>Next.</p>'
+            ),
+        )
+
+
+class MermaidFenceSafetyTests(unittest.TestCase):
+    def test_inner_fence_inside_a_longer_fence_is_not_a_diagram(self):
+        # A page showing a mermaid example inside a ```` block is documentation
+        # about mermaid, not a diagram to extract.
+        self.assertEqual([], g.mermaid_blocks("````\n```mermaid\ngraph TD\n```\n````\n"))
+
+    def test_shorter_closer_does_not_end_the_block(self):
+        out = g.mermaid_blocks("````mermaid\ngraph TD\n```\n")
+        self.assertEqual(1, len(out))
+        self.assertTrue(out[0][1].startswith("````mermaid"))
+
+    def test_diagram_is_extracted(self):
+        self.assertEqual(
+            [("", "```mermaid\ngraph TD\n A-->B\n```")],
+            g.mermaid_blocks("x\n\n```mermaid\ngraph TD\n A-->B\n```\n\ny\n"),
+        )
+
+
+# Captured verbatim from a real `npm run build` of this site. The synthetic
+# fixtures above cannot catch a class-name mismatch or a wrapper shape change,
+# and `--check` compares generated output against output from the same code, so
+# it cannot either. These strings are the only guard against both.
+_REAL_BREADCRUMBS = (
+    '<nav class="theme-doc-breadcrumbs breadcrumbsContainer_Z_bl" aria-label="Breadcrumbs">'
+    '<ul class="breadcrumbs"><li class="breadcrumbs__item">'
+    '<a class="breadcrumbs__link" href="/get-started/">Get Started</a></li>'
+    '<li class="breadcrumbs__item breadcrumbs__item--active">'
+    '<span class="breadcrumbs__link">Why using Erigon?</span></li></ul></nav>'
+)
+_REAL_MOBILE_TOC = (
+    '<div class="tocCollapsible_ETCw theme-doc-toc-mobile tocMobile_ITEo">'
+    '<button type="button" class="clean-btn tocCollapsibleButton_TO0P">On this page</button></div>'
+)
+_REAL_HEADING = (
+    '<h2 class="anchor anchorTargetStickyNavbar_Vzrq" id="at-a-glance">At a glance'
+    '<a href="#at-a-glance" class="hash-link" aria-label="Direct link to At a glance"'
+    ' title="Direct link to At a glance" translate="no">\u200b</a></h2>'
+)
+_REAL_CODE_BLOCK = (
+    '<pre tabindex="0" class="prism-code language-text codeBlock_bY9V thin-scrollbar">'
+    '<code class="codeBlockLines_e6Vv">'
+    '<div class="token-line"><span class="token plain">erigon [options]</span><br></div>'
+    '<div class="token-line"><span class="token plain">  --datadir path</span><br></div>'
+    "</code></pre>"
+)
+
+
+class RealMarkupTests(unittest.TestCase):
+    """Fixtures captured from an actual build, not hand-written approximations."""
+
+    def render(self, html):
+        p = g._ArticleText()
+        p.feed(html)
+        p.close()
+        return p.text()
+
+    def test_real_breadcrumb_nav_is_stripped(self):
+        out = self.render(_REAL_BREADCRUMBS + "<p>Body.</p>")
+        self.assertEqual("Body.", out)
+
+    def test_real_mobile_toc_is_stripped(self):
+        out = self.render(_REAL_MOBILE_TOC + "<p>Body.</p>")
+        self.assertNotIn("On this page", out)
+        self.assertEqual("Body.", out)
+
+    def test_real_heading_drops_its_anchor(self):
+        self.assertEqual("## At a glance", self.render(_REAL_HEADING))
+
+    def test_real_code_block_is_not_double_spaced(self):
+        self.assertEqual(
+            "```text\nerigon [options]\n  --datadir path\n```",
+            self.render(_REAL_CODE_BLOCK),
+        )
+
+    def test_every_chrome_class_matches_a_real_token(self):
+        # A chrome entry that matches nothing is dead config and silently stops
+        # stripping what it was added for. Comparing the tuple against a literal
+        # copy of itself cannot detect that, so the tokens are looked for in the
+        # built site — which is what a Docusaurus rename actually changes.
+        if not g.BUILD_DIR.is_dir():
+            self.skipTest("docs/site/build absent; run npm run build")
+        html = "".join(p.read_text(encoding="utf-8", errors="replace")
+                       for p in list(g.BUILD_DIR.rglob("*.html"))[:40])
+        tokens = set(re.findall(r'class="([^"]*)"', html))
+        seen = {t for group in tokens for t in group.split()}
+        for entry in g._CHROME_CLASSES:
+            self.assertIn(entry, seen, f"chrome class {entry!r} matches nothing built")
+        self.assertTrue(any(t.startswith(g._ADM_HEADING_PREFIX) for t in seen),
+                        f"{g._ADM_HEADING_PREFIX!r} matches nothing built")
+
+
+class BuiltSiteIntegrationTests(unittest.TestCase):
+    """Runs against docs/site/build when it exists; skipped otherwise."""
+
+    @classmethod
+    def setUpClass(cls):
+        if not g.BUILD_DIR.is_dir():
+            raise unittest.SkipTest("docs/site/build absent; run npm run build")
+
+    def test_no_chrome_leaks_into_any_page(self):
+        leaked = []
+        for name in ("get-started/why-using-erigon", "fundamentals/architecture",
+                     "help-center/best-practices"):
+            text = g.page_text_from_build(g.BASE_URL + "/" + name)
+            if text is None:
+                continue
+            for junk in ("On this page", "Edit this page", "breadcrumbs__"):
+                if junk in text:
+                    leaked.append(f"{name}: {junk}")
+        self.assertEqual([], leaked)
+
+    def test_code_blocks_are_not_double_spaced(self):
+        text = g.page_text_from_build(g.BASE_URL + "/fundamentals/basic-usage")
+        if text is None:
+            self.skipTest("page not built")
+        fenced, blanks = False, 0
+        for line in text.split("\n"):
+            if line.lstrip().startswith("```"):
+                fenced = not fenced
+                continue
+            if fenced and not line.strip():
+                blanks += 1
+        self.assertEqual(0, blanks)
+
+
+class CardAndCellShapeTests(unittest.TestCase):
+    def render(self, html):
+        p = g._ArticleText()
+        p.feed(html)
+        p.close()
+        return p.text()
+
+    def test_icon_is_not_used_as_the_card_label(self):
+        self.assertEqual(
+            "- [Ethereum Node](https://docs.erigon.tech/x/): Run a full node.",
+            self.render(
+                '<a href="/x/"><img alt="Ethereum" src="/img/eth.svg">'
+                "<div>Ethereum Node</div><div>Run a full node.</div></a>"
+            ),
+        )
+
+    def test_image_only_link_still_keeps_the_image(self):
+        self.assertEqual(
+            "[![Only](https://docs.erigon.tech/i.svg)](https://docs.erigon.tech/x/)",
+            self.render('<a href="/x/"><img alt="Only" src="/i.svg"></a>'),
+        )
+
+    def test_br_in_a_table_cell_does_not_split_the_row(self):
+        self.assertEqual(
+            "| x y | z |",
+            self.render("<table><tbody><tr><td>x<br>y</td><td>z</td></tr></tbody></table>"),
+        )
+
+    def test_br_in_prose_still_breaks_the_line(self):
+        self.assertEqual("a\nb", self.render("<p>a<br>b</p>"))
+
+    def test_heading_inside_a_link_emits_no_stray_marker(self):
+        self.assertEqual(
+            "- [T](https://docs.erigon.tech/x): D",
+            self.render('<a href="/x"><h2>T</h2><p>D</p></a>'),
+        )
+
+    def test_pre_inside_a_link_emits_no_stray_fence(self):
+        self.assertEqual(
+            "[cmd](https://docs.erigon.tech/x)",
+            self.render('<a href="/x"><pre><code>cmd</code></pre></a>'),
+        )
+
+
+class FenceTrackingTests(unittest.TestCase):
+    """A longer fence keeps its columns even when its body holds a shorter one."""
+
+    def render(self, html):
+        p = g._ArticleText()
+        p.feed(html)
+        p.close()
+        return p.text()
+
+    def test_inner_fence_does_not_end_column_preservation(self):
+        out = self.render("<pre><code>col1    col2\n```\nA       B\n</code></pre>")
+        self.assertIn("A       B", out)
+        self.assertTrue(out.startswith("````"))
+
+    def test_pre_after_inline_text_is_separated(self):
+        out = self.render("<div>text<pre><code>x\n</code></pre></div>")
+        self.assertEqual("text\n\n```\nx\n```", out)
+
+    def test_no_placeholder_leaks(self):
+        for html in (
+            "<p>a<br><br></p><pre><code>x\n</code></pre>",
+            "<div></div><div></div><pre><code>x\n</code></pre>",
+            "<pre><code>x\n</code></pre>",
+        ):
+            self.assertNotIn("\x00", self.render(html))
+
+
+class ChromeAndStructureTests(unittest.TestCase):
+    def render(self, html):
+        p = g._ArticleText()
+        p.feed(html)
+        p.close()
+        return p.text()
+
+    def test_self_closing_void_inside_chrome_does_not_end_the_skip(self):
+        # <br/> arrives through handle_startendtag; closing nothing, it must not
+        # decrement the skip depth and leak the nav text after it.
+        self.assertEqual(
+            "Body.",
+            self.render(
+                '<nav class="theme-doc-breadcrumbs">nav<br/>more nav</nav><p>Body.</p>'
+            ),
+        )
+
+    def test_list_inside_a_link_emits_no_stray_marker(self):
+        self.assertEqual(
+            "- [one](https://docs.erigon.tech/x): D",
+            self.render('<a href="/x"><ul><li>one</li></ul><p>D</p></a>'),
+        )
+
+    def test_table_inside_a_link_emits_no_row_pipes(self):
+        self.assertEqual(
+            "- [c](https://docs.erigon.tech/x): D",
+            self.render('<a href="/x"><table><tr><td>c</td></tr></table><p>D</p></a>'),
+        )
+
+
+class ArticleBodyTests(unittest.TestCase):
+    def test_outermost_article_is_taken(self):
+        self.assertEqual(
+            "<p>a</p><article><p>b</p></article><p>c</p>",
+            g._article_body("<article><p>a</p><article><p>b</p></article><p>c</p></article>"),
+        )
+
+    def test_unbalanced_article_is_refused_not_truncated(self):
+        # Returning a partial body would look like a successful read.
+        self.assertIsNone(g._article_body("<article><p>a</p>"))
+
+    def test_no_article_returns_none(self):
+        self.assertIsNone(g._article_body("<div><p>a</p></div>"))
+
+
+class MermaidLivenessTests(unittest.TestCase):
+    def test_indented_fence_is_an_indented_code_block(self):
+        self.assertEqual([], g.mermaid_blocks("    ```mermaid\n    graph TD\n    ```\n"))
+
+    def test_commented_out_diagram_is_not_content(self):
+        self.assertEqual([], g.mermaid_blocks("{/*\n```mermaid\ngraph TD\n```\n*/}\n"))
+
+    def test_live_diagram_is_still_found(self):
+        self.assertEqual(
+            [("", "```mermaid\ngraph TD\n```")],
+            g.mermaid_blocks("```mermaid\ngraph TD\n```\n")
+        )
+
+
+class TableCellTests(unittest.TestCase):
+    """A cell is one Markdown line, and its text cannot contain a bare pipe."""
+
+    def render(self, html):
+        p = g._ArticleText()
+        p.feed(html)
+        p.close()
+        return p.text()
+
+    def test_pipe_in_cell_text_is_escaped(self):
+        self.assertEqual(
+            "| A | B |\n| --- | --- |\n| QUANTITY\\|TAG | x |",
+            self.render(
+                "<table><thead><tr><th>A</th><th>B</th></tr></thead>"
+                "<tbody><tr><td>QUANTITY|TAG</td><td>x</td></tr></tbody></table>"
+            ),
+        )
+
+    def test_block_children_do_not_split_a_row(self):
+        self.assertEqual(
+            "| one two | z |",
+            self.render(
+                "<table><tbody><tr><td><p>one</p><p>two</p></td>"
+                "<td>z</td></tr></tbody></table>"
+            ),
+        )
+
+    def test_list_in_a_cell_stays_on_one_row(self):
+        self.assertEqual(
+            "| - a - b | z |",
+            self.render(
+                "<table><tbody><tr><td><ul><li>a</li><li>b</li></ul></td>"
+                "<td>z</td></tr></tbody></table>"
+            ),
+        )
+
+
+class MalformedAttributeTests(unittest.TestCase):
+    """HTMLParser reports a valueless attribute as None."""
+
+    def render(self, html):
+        p = g._ArticleText()
+        p.feed(html)
+        p.close()
+        return p.text()
+
+    def test_valueless_class_does_not_crash(self):
+        self.assertEqual("x", self.render("<div class><p>x</p></div>"))
+
+    def test_valueless_start_does_not_crash(self):
+        self.assertEqual("1. a", self.render("<ol start><li>a</li></ol>"))
+
+    def test_blank_run_inside_a_fence_is_preserved(self):
+        self.assertEqual(
+            "```\na\n\n\n\nb\n```",
+            self.render("<pre><code>a\n\n\n\nb\n</code></pre>"),
+        )
+
+
+class ReviewRoundFixTests(unittest.TestCase):
+    """Defects found by independent review of the built-site rewrite.
+
+    Each of these produced wrong bytes in a committed artifact that `--check`
+    called green, because the check compares this code's output to this code's
+    earlier output and so cannot see a systematic error.
+    """
+
+    def render(self, html, page_url=""):
+        p = g._ArticleText(page_url=page_url)
+        p.feed(html)
+        p.close()
+        return p.text()
+
+    # -- fence info string --------------------------------------------------
+    def test_fence_keeps_its_language(self):
+        # The info string is the one hint that says whether a block is shell,
+        # JSON or YAML; the built HTML carries it as `language-*`.
+        self.assertEqual(
+            "```bash\nls -la\n```",
+            self.render('<pre class="prism-code language-bash"><code>ls -la</code></pre>'),
+        )
+
+    def test_fence_without_a_language_stays_bare(self):
+        self.assertEqual("```\nls\n```",
+                         self.render("<pre><code>ls</code></pre>"))
+
+    # -- admonitions --------------------------------------------------------
+    def test_admonition_keeps_its_type_and_extent(self):
+        html = ('<div class="theme-admonition theme-admonition-warning admonition_xJq3">'
+                '<div class="admonitionHeading_Gvgb">'
+                '<span class="admonitionIcon_a"><svg><path/></svg></span>warning</div>'
+                '<div class="admonitionContent_BuS1"><p>Do not do this.</p></div></div>')
+        self.assertEqual(":::warning\nDo not do this.\n:::", self.render(html))
+
+    def test_admonition_label_is_not_left_as_bare_prose(self):
+        html = ('<div class="theme-admonition theme-admonition-tip">'
+                '<div class="admonitionHeading_Gvgb">tip</div>'
+                '<div class="admonitionContent_BuS1"><p>Body.</p></div></div>')
+        out = self.render(html)
+        self.assertNotIn("\ntip\n", out)
+        self.assertIn(":::tip", out)
+
+    # -- blockquotes --------------------------------------------------------
+    def test_blockquote_keeps_its_marker(self):
+        self.assertEqual("> Quoted line.",
+                         self.render("<blockquote><p>Quoted line.</p></blockquote>"))
+
+    def test_a_quote_does_not_stack_empty_marker_lines(self):
+        # A `>` line is not blank, so the collapse pass in text() cannot see a
+        # run of them.
+        out = self.render("<blockquote><p>N:</p>"
+                          '<pre class="language-sh"><code>ls</code></pre></blockquote>')
+        self.assertEqual("> N:\n>\n> ```sh\n> ls\n> ```", out)
+
+    def test_nested_quotes_nest_their_markers(self):
+        self.assertEqual(
+            "> a\n>\n> > b",
+            self.render("<blockquote><p>a</p><blockquote><p>b</p>"
+                        "</blockquote></blockquote>"))
+
+    def test_blockquote_marks_every_line(self):
+        out = self.render("<blockquote><p>One.</p><p>Two.</p></blockquote>")
+        self.assertTrue(all(ln.startswith(">") for ln in out.split("\n") if ln))
+
+    # -- link buffer routing ------------------------------------------------
+    def test_space_between_inline_elements_in_a_link_survives(self):
+        # The whitespace guard used to test the page buffer while writing to the
+        # link buffer, so the words fused.
+        self.assertEqual(
+            "See [**Alpha** *beta*](https://docs.erigon.tech/x) now.",
+            self.render('<p>See <a href="/x"><strong>Alpha</strong> '
+                        '<em>beta</em></a> now.</p>'),
+        )
+
+    def test_card_link_inside_a_table_cell_segments(self):
+        out = self.render('<table><tbody><tr><td><a href="/y"><h2>T</h2>'
+                          '<p>blurb</p></a></td><td>b</td></tr></tbody></table>')
+        self.assertNotIn("Tblurb", out)
+        self.assertIn("T", out)
+        self.assertIn("blurb", out)
+
+    # -- inline code delimiters ---------------------------------------------
+    def test_inline_code_holding_a_backtick_stays_a_valid_span(self):
+        self.assertEqual("``a ` b``", self.render("<p><code>a ` b</code></p>"))
+
+    def test_inline_code_touching_a_backtick_is_padded(self):
+        # CommonMark 6.1 strips one leading and trailing space back out.
+        self.assertEqual("`` `x ``", self.render("<p><code>`x</code></p>"))
+
+    # -- same-page anchors --------------------------------------------------
+    def test_same_page_anchor_is_resolved_against_its_page(self):
+        # A bare `#frag` means nothing once every page is pooled into one file.
+        self.assertEqual(
+            "[Option 1](https://docs.erigon.tech/get-started/migrating#option-1)",
+            self.render('<p><a href="#option-1">Option 1</a></p>',
+                        page_url="https://docs.erigon.tech/get-started/migrating"),
+        )
+
+    # -- <article> boundary -------------------------------------------------
+    def test_article_end_inside_a_comment_does_not_truncate(self):
+        body = g._article_body(
+            "<article><p>real</p><!-- stray </article> --><p>more</p></article>")
+        self.assertIn("more", body)
+
+    # -- mermaid ------------------------------------------------------------
+    def test_diagram_records_the_heading_above_it(self):
+        src = "## At a glance\n\n```mermaid\ngraph TD\n```\n\nEvery box above...\n"
+        self.assertEqual([("At a glance", "```mermaid\ngraph TD\n```")],
+                         g.mermaid_blocks(src))
+
+    def test_diagram_is_spliced_under_its_heading_not_appended(self):
+        body = "## At a glance\n\nEvery box above is a Go package.\n\n## Next\n\nx"
+        out = g.splice_diagram(body, "At a glance", "```mermaid\ngraph TD\n```")
+        self.assertLess(out.index("graph TD"), out.index("Every box above"))
+
+    def test_a_hash_comment_inside_a_fence_is_not_a_heading(self):
+        # Every other scanner here is fence-aware; this one was not, so a bash
+        # `# Usage` comment matched the "Usage" heading and the diagram landed
+        # inside the code block.
+        body = ("## Intro\n\n```bash\n# Usage\nerigon --help\n```\n\n"
+                "## Usage\n\nReal section.\n")
+        out = g.splice_diagram(body, "Usage", "```mermaid\nD\n```")
+        self.assertIn("## Usage\n\n```mermaid\nD\n```", out)
+        self.assertGreater(out.index("mermaid"), out.index("erigon --help"))
+
+    def test_two_diagrams_under_one_heading_keep_source_order(self):
+        body = g.splice_diagram("## H\n\ntext\n", "H", "```mermaid\nFIRST\n```")
+        body = g.splice_diagram(body, "H", "```mermaid\nSECOND\n```")
+        self.assertLess(body.index("FIRST"), body.index("SECOND"))
+
+    def test_diagram_falls_back_to_appending_when_the_heading_is_gone(self):
+        out = g.splice_diagram("no headings here", "Missing", "```mermaid\nx\n```")
+        self.assertTrue(out.endswith("```mermaid\nx\n```"))
+
+    def test_a_top_level_diagram_keeps_its_own_angle_brackets(self):
+        # `>` is legal inside a diagram, so peeling container markers from a
+        # fence that was never quoted would edit the diagram's source.
+        out = g.mermaid_blocks("```mermaid\ngraph TD\n> a label\n```\n")
+        self.assertIn("> a label", out[0][1])
+
+    def test_diagram_inside_a_blockquote_is_still_found(self):
+        out = g.mermaid_blocks("> ```mermaid\n> graph TD\n>   A-->B\n> ```\n")
+        self.assertEqual(1, len(out))
+        self.assertIn("graph TD", out[0][1])
+
+    # -- first_description fence tracking -----------------------------------
+    def test_four_backtick_fence_does_not_desync_the_description(self):
+        # The generator itself emits a 4-backtick fence whenever a code block
+        # contains a 3-backtick run, so this is one docs edit away from live.
+        desc = ("The real description, long enough to clear the minimum length "
+                "this function requires of a paragraph.")
+        body = f"````\n```\ncode\n```\n````\n\n{desc}\n"
+        self.assertEqual(desc, g.first_description(body))
+
+    # -- frontmatter terminator ---------------------------------------------
+    def test_frontmatter_terminator_must_be_a_whole_line(self):
+        meta, rest = g.parse_frontmatter(
+            '---\ntitle: "A ---- b"\ndescription: kept\n---\nBody.\n')
+        self.assertEqual("kept", meta.get("description"))
+        self.assertEqual("Body.\n", rest)
+
+    # -- blank-line collapse ------------------------------------------------
+    def test_a_paragraph_meeting_a_fence_leaves_one_blank_line(self):
+        # Collapsing per-chunk and re-joining the chunks put the separator back,
+        # so every paragraph-then-code boundary carried a second blank line.
+        out = self.render('<p>Run:</p><pre class="language-sh"><code>ls</code></pre>')
+        self.assertEqual("Run:\n\n```sh\nls\n```", out)
+
+    def test_blank_lines_inside_a_fence_are_code(self):
+        out = self.render("<pre><code>a\n\n\nb</code></pre>")
+        self.assertEqual("```\na\n\n\nb\n```", out)
+
+    # -- table rows ---------------------------------------------------------
+    def test_an_admonition_in_a_table_cell_does_not_split_the_row(self):
+        out = self.render(
+            '<table><tbody><tr><td><div class="theme-admonition theme-admonition-note">'
+            '<div class="admonitionContent_x"><p>Careful.</p></div></div></td>'
+            '<td>b</td></tr></tbody></table>')
+        self.assertEqual("| Careful. | b |", out)
+
+    # -- admonition titles --------------------------------------------------
+    def test_a_custom_admonition_title_survives(self):
+        # `:::tip Some title` puts the title in the heading div, where the type
+        # word otherwise sits. Skipping the div wholesale dropped the title.
+        html = ('<div class="theme-admonition theme-admonition-tip">'
+                '<div class="admonitionHeading_Rf37">'
+                '<span class="admonitionIcon_a"><svg><path/></svg></span>'
+                'For validators running behind NAT</div>'
+                '<div class="admonitionContent_b"><p>Body.</p></div></div>')
+        self.assertEqual(
+            ":::tip For validators running behind NAT\nBody.\n:::", self.render(html))
+
+    # -- quoted code --------------------------------------------------------
+    def test_a_fence_inside_a_quote_keeps_its_columns(self):
+        # By the time the whitespace passes run the lines already carry `> `, so
+        # a fence scanner that does not peel the marker reflows quoted CLI output.
+        out = self.render("<blockquote><p>N:</p>"
+                          "<pre><code>col1    col2\nA       B</code></pre></blockquote>")
+        self.assertIn("> col1    col2", out)
+        self.assertIn("> A       B", out)
+
+    def test_blank_lines_inside_a_quoted_fence_are_code(self):
+        out = self.render("<blockquote><pre><code>a\n\n\nb</code></pre></blockquote>")
+        self.assertEqual("> ```\n> a\n>\n>\n> b\n> ```", out)
+
+    # -- leading H1 ---------------------------------------------------------
+    def test_an_empty_h1_does_not_eat_the_first_prose_line(self):
+        # `#\s+` spans newlines, so it reached past the blank line.
+        self.assertEqual("First prose line.\n\nSecond.",
+                         g.strip_leading_h1("# \n\nFirst prose line.\n\nSecond."))
+
+    def test_a_real_leading_h1_is_still_stripped(self):
+        self.assertEqual("Body.", g.strip_leading_h1("# Title\n\nBody."))
+
+    # -- tabs ---------------------------------------------------------------
+    def test_tab_labels_attach_to_their_panels(self):
+        # Docusaurus links a label to its panel by order only, so the labels
+        # used to render as a bullet list and the panels as an unlabelled run.
+        html = ('<ul role="tablist" class="tabs">'
+                '<li role="tab" class="tabs__item tabs__item--active">Ethereum mainnet</li>'
+                '<li role="tab" class="tabs__item">Gnosis Chain</li></ul>'
+                '<div class="margin-top--md">'
+                '<div role="tabpanel"><p>Mainnet body.</p></div>'
+                '<div role="tabpanel" hidden=""><p>Gnosis body.</p></div></div>')
+        out = self.render(html)
+        self.assertEqual(
+            "**Ethereum mainnet**\n\nMainnet body.\n\n**Gnosis Chain**\n\nGnosis body.", out)
+        self.assertNotIn("- Ethereum mainnet", out)
+
+    def test_a_hidden_tab_panel_is_still_content(self):
+        # Only the first panel is visible; the rest carry `hidden` but are real
+        # page content and the corpus needs them.
+        out = self.render('<ul role="tablist" class="tabs">'
+                          '<li role="tab">A</li><li role="tab">B</li></ul>'
+                          '<div role="tabpanel"><p>one</p></div>'
+                          '<div role="tabpanel" hidden=""><p>two</p></div>')
+        self.assertIn("two", out)
+
+    # -- details ------------------------------------------------------------
+    def test_a_summary_reads_as_a_label(self):
+        self.assertEqual(
+            "**Reset database**\n\nDeletes chain data.",
+            self.render("<details><summary>Reset database</summary>"
+                        "<p>Deletes chain data.</p></details>"))
+
+    # -- version coupling ---------------------------------------------------
+    def test_a_new_release_is_drift_not_a_failure(self):
+        # The build resolves {ERIGON_VERSION} from the GitHub Releases API, so
+        # committed bytes change with no commit in this repo.
+        a = "download erigon_v3.6.0_linux_amd64.tar.gz now"
+        b = "download erigon_v3.6.1_linux_amd64.tar.gz now"
+        self.assertIn("<release>", g._mask_versions(a))   # not vacuously equal
+        self.assertEqual(g._mask_versions(a), g._mask_versions(b))
+
+    def test_a_real_change_is_still_a_failure(self):
+        self.assertNotEqual(g._mask_versions("erigon_v3.6.0 now"),
+                            g._mask_versions("erigon_v3.6.0 later"))
+
+    def test_only_the_erigon_release_is_masked(self):
+        # Masking every N.N.N would also mask a Go or library version, so a real
+        # docs edit to one of those would be downgraded to warning-only drift.
+        a = "erigon_v3.6.0_linux needs Go 1.24.0"
+        b = "erigon_v3.6.0_linux needs Go 1.25.0"
+        self.assertIn("<release>", g._mask_versions(a))
+        self.assertIn("Go 1.24.0", g._mask_versions(a))
+        self.assertNotEqual(g._mask_versions(a), g._mask_versions(b))
+
+    def test_text_with_no_release_anchor_is_untouched(self):
+        self.assertEqual("needs Go 1.24.0", g._mask_versions("needs Go 1.24.0"))
+
+
+class BuiltCorpusShapeTests(unittest.TestCase):
+    """Assertions against the corpus this build actually produces."""
+
+    @classmethod
+    def setUpClass(cls):
+        if not g.BUILD_DIR.is_dir():
+            raise unittest.SkipTest("docs/site/build absent; run npm run build")
+        _, cls.full, _ = g.build()
+
+    def test_code_fences_carry_languages(self):
+        self.assertGreater(len(re.findall(r"^```[a-z]", self.full, re.M)), 100)
+
+    def test_admonitions_survive_as_directives(self):
+        self.assertGreater(self.full.count(":::"), 50)
+
+    def test_no_admonition_label_leaks_as_bare_prose(self):
+        for label in ("warning", "tip", "info", "danger", "note", "caution"):
+            self.assertNotIn(f"\n{label}\n", self.full,
+                             f"bare {label!r} line leaked from an admonition heading")
+
+    def test_no_link_target_is_meaningless_in_a_flat_file(self):
+        self.assertEqual([], re.findall(r"\]\((?:/|#)[^)]*\)", self.full))
 
 
 if __name__ == "__main__":

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -3,8 +3,6 @@ URL: https://docs.erigon.tech/
 
 An efficient, modular Ethereum execution layer client built for performance, low disk footprint, and flexible deployment.
 
-## Sections
-
 - [Get Started](https://docs.erigon.tech/get-started): Hardware requirements, installation options, and first-run guides to get your node online fast.
 - [Easy Nodes](https://docs.erigon.tech/get-started/easy-nodes): One-command guided setup for Ethereum mainnet and Gnosis Chain nodes with sensible defaults.
 - [Fundamentals](https://docs.erigon.tech/fundamentals): Pruning modes, configuration, Docker, JWT, logging, storage optimization, and day-to-day operations.
@@ -20,8 +18,6 @@ URL: https://docs.erigon.tech/get-started
 
 Everything you need to go from zero to a running Erigon node — requirements, installation, and guided setups.
 
-## Sections
-
 - [Why Erigon?](https://docs.erigon.tech/get-started/why-using-erigon): Performance benchmarks, disk savings, and architecture advantages over other Ethereum clients.
 - [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements): Minimum and recommended specs for mainnet, testnets, and archive mode.
 - [Installation](https://docs.erigon.tech/get-started/installation): Binary releases, building from source, Docker images, and upgrade instructions.
@@ -34,22 +30,70 @@ Everything you need to go from zero to a running Erigon node — requirements, i
 # Why using Erigon?
 URL: https://docs.erigon.tech/get-started/why-using-erigon
 
-## Sections
+Erigon is an Ethereum execution layer client focused on performance, low disk usage, and modular architecture.
 
-- [Integrated Consensus Layer (Caplin)](../fundamentals/caplin): Built-in consensus client — no need to run and manage separate software like Lighthouse. One binary handles both execution and consensus, simplifying setup for stakers and node runners.
-- [State Storage (Flat DB)](../fundamentals/optimizing-storage): Replaces the Merkle Patricia Trie with a flat key-value database. Faster reads and writes, and a smaller on-disk footprint for any node type.
-- [Immutable, Decentralised Data](../fundamentals/modules/downloader): Splits data processing into specialised stages, minimising random disk I/O and write amplification. Efficiently integrates large datasets into Erigon's flat DB.
-- [Predictable RPC Performance](../fundamentals/modules/rpc-daemon): No background compaction means no unpredictable resource spikes. RPC throughput stays stable and consistent — critical for providers and validators who cannot afford surprises.
-- [Modularity](../fundamentals/modules/): Core node, RPC Daemon, and TxPool run as independent processes with per-component resource limits. If one crashes the rest stay alive. Run multiple instances without downtime.
-- [OtterSync](../fundamentals/pruning-modes): Shifts initial sync from CPU-intensive transaction re-execution to network download — similar to BitTorrent for state data. Reduces sync time for both full and Archive nodes.
-- [Flexible Pruning](../fundamentals/optimizing-storage): Modular architecture and predictable performance handle high-volume traffic with low latency. Smaller database cuts hardware costs. Caplin reduces missed attestations and slashing risk.
-- [Home Users & Solo Stakers](../staking/): Run a full or archive node on a consumer SSD. Fast sync cuts setup from days to hours. No third-party servers — your node, your keys, your contribution to decentralisation.
+A core benefit of Erigon is its **reduced disk footprint** across all available pruning modes — achieved through efficient state storage and compression, making node operation feasible on consumer-grade hardware. It also features an **integrated Consensus Layer (Caplin)**, eliminating the need for separate CL software, and a **BitTorrent-based protocol** for decentralised historical data distribution.
+
+10×
+
+cheaper to backup & distribute node data
+
+~2 TB
+
+archive node on consumer SSD
+
+1 binary
+
+execution + consensus, no extra software
+
+40+
+
+AI query tools via built-in MCP server
+
+## Key Architectural & Performance Advantages
+
+Erigon's architecture provides measurable improvements in cost, performance, and reliability.
+
+- [Integrated Consensus Layer (Caplin)](https://docs.erigon.tech/fundamentals/caplin): Built-in consensus client — no need to run and manage separate software like Lighthouse. One binary handles both execution and consensus, simplifying setup for stakers and node runners.
+- [State Storage (Flat DB)](https://docs.erigon.tech/fundamentals/optimizing-storage): Replaces the Merkle Patricia Trie with a flat key-value database. Faster reads and writes, and a smaller on-disk footprint for any node type.
+- [Immutable, Decentralised Data](https://docs.erigon.tech/fundamentals/modules/downloader): Historical data lives in immutable files distributed via BitTorrent — up to **10× cheaper** to backup, repair, and distribute. No double-disk usage, no complex serialisation.
+- [Staged Sync](https://docs.erigon.tech/fundamentals/pruning-modes): Splits data processing into specialised stages, minimising random disk I/O and write amplification. Efficiently integrates large datasets into Erigon's flat DB.
+- [Predictable RPC Performance](https://docs.erigon.tech/fundamentals/modules/rpc-daemon): No background compaction means no unpredictable resource spikes. RPC throughput stays stable and consistent — critical for providers and validators who cannot afford surprises.
+- [Modularity](https://docs.erigon.tech/fundamentals/modules): Core node, RPC Daemon, and TxPool run as independent processes with per-component resource limits. If one crashes the rest stay alive. Run multiple instances without downtime.
+- [OtterSync](https://docs.erigon.tech/fundamentals/pruning-modes): Shifts initial sync from CPU-intensive transaction re-execution to network download — similar to BitTorrent for state data. Reduces sync time for both full and Archive nodes.
+- [Flexible Pruning](https://docs.erigon.tech/fundamentals/optimizing-storage): `--prune.mode=minimal` gives a smaller-than-full-node footprint that still satisfies all validator requirements. Right-size your storage without sacrificing functionality.
+
+## Benefits by Audience
+
+- [RPC Providers & Large Stakers](https://docs.erigon.tech/fundamentals/modules/rpc-daemon): Modular architecture and predictable performance handle high-volume traffic with low latency. Smaller database cuts hardware costs. Caplin reduces missed attestations and slashing risk.
+- [Home Users & Solo Stakers](https://docs.erigon.tech/staking): Run a full or archive node on a consumer SSD. Fast sync cuts setup from days to hours. No third-party servers — your node, your keys, your contribution to decentralisation.
+- [Developers](https://docs.erigon.tech/interacting-with-erigon): Full `trace_` namespace, historical `eth_getProof`, historical blobs, and gRPC API. Modular components let you update, extend, or replace parts without rebuilding the whole stack.
+
+## AI-Native Node Access (MCP)
+
+Erigon ships a built-in **[Model Context Protocol (MCP) server](https://docs.erigon.tech/fundamentals/mcp)**, enabled by default on `127.0.0.1:8553`. Connect any MCP-compatible AI assistant — Claude Code, Claude Desktop, or OpenAI Codex — directly to your node and query it in plain English, with zero integration overhead.
+
+💬 What is the ETH balance of vitalik.eth right now?
+
+💬 Show all ERC-20 transfers in the last 100 blocks.
+
+💬 Which tx in block 21,000,000 used the most gas?
+
+💬 My node seems stuck — check sync status and recent logs.
+
+The interface is **read-only** and localhost-bound — no risk of unintended state changes. For developers this means instant on-chain lookups during development, natural-language log triage, and a complete RPC surface accessible without writing a single line of code.
+
+```bash
+# Register with Claude Code in one command
+claude mcp add --transport sse erigon http://127.0.0.1:8553/sse
+```
+
+Where MCP lets a model query your *node*, [llms.txt and llms-full.txt](https://docs.erigon.tech/fundamentals/mcp#these-docs-as-a-single-file) let it read these *docs*: an index of the current documentation, and the same pages' text as one plain-text file for offline use.
 
 ---
 
 # Hardware Requirements
 URL: https://docs.erigon.tech/get-started/hardware-requirements
-
 
 ## Overview
 
@@ -65,7 +109,9 @@ A locally mounted **SSD** (Solid-State Drive) or **NVMe** (Non-Volatile Memory E
 
 ## Disk Size and RAM Requirements
 
-The amount of disk space recommended and RAM you need depends on the [pruning mode](../fundamentals/pruning-modes) you want to run. **Current Disk Usage** values listed below are obtained using the standard Erigon + [Caplin](../fundamentals/caplin) configuration, with the sole exception of the `--prune.mode` flag.
+The amount of disk space recommended and RAM you need depends on the [pruning mode](https://docs.erigon.tech/fundamentals/pruning-modes) you want to run. **Current Disk Usage** values listed below are obtained using the standard Erigon + [Caplin](https://docs.erigon.tech/fundamentals/caplin) configuration, with the sole exception of the `--prune.mode` flag.
+
+**Ethereum mainnet**
 
 | Pruning Mode | Current Disk Usage | Disk Size (Recommended) | RAM (Required) | RAM (Recommended) |
 | --- | --- | --- | --- | --- |
@@ -73,253 +119,225 @@ The amount of disk space recommended and RAM you need depends on the [pruning mo
 | Full (Default) | 419.04 GB | 2 TB | 16 GB | 32 GB |
 | Minimal | 478.40 GB | 1 TB | 16 GB | 64 GB |
 
-_Current Disk Usage measured as of 2026-07-19; usage grows over time as the chain grows._
+*Current Disk Usage measured as of 2026-07-19; usage grows over time as the chain grows.*
 
-| **Pruning Mode**  | **Current Disk Usage** | **Disk Size (Recommended)** | **RAM (Required)** | **RAM (Recommended)** |
-| -------------- | ---------------------- | --------------------------- | ------------------ | --------------------- |
-| Archive        | 673.59 GB | 1 TB                        | 16 GB              | 32 GB                 |
-| Full (Default) | 220.10 GB    | 1 TB                        | 8 GB               | 16 GB                 |
-| Minimal        | 304.67 GB | 500 GB                      | 8 GB               | 16 GB                 |
+**Gnosis Chain**
 
-_Current Disk Usage measured as of 2026-07-21; usage grows over time as the chain grows._
+| **Pruning Mode** | **Current Disk Usage** | **Disk Size (Recommended)** | **RAM (Required)** | **RAM (Recommended)** |
+| --- | --- | --- | --- | --- |
+| Archive | 673.59 GB | 1 TB | 16 GB | 32 GB |
+| Full (Default) | 220.10 GB | 1 TB | 8 GB | 16 GB |
+| Minimal | 304.67 GB | 500 GB | 8 GB | 16 GB |
 
-| **Pruning Mode** | **Current Disk Usage** |
-| -------------- | ---------------------- |
-| Archive        | 1.10 TB |
+*Current Disk Usage measured as of 2026-07-21; usage grows over time as the chain grows.*
 
-_Current Disk Usage measured as of 2026-07-29; usage grows over time as the chain grows. Execution layer only — full and minimal modes are not measured for this network._
+**Sepolia**
 
 | **Pruning Mode** | **Current Disk Usage** |
-| -------------- | ---------------------- |
-| Archive        | 133.73 GB |
+| --- | --- |
+| Archive | 1.10 TB |
 
-_Current Disk Usage measured as of 2026-07-29; usage grows over time as the chain grows. Execution layer only — full and minimal modes are not measured for this network._
+*Current Disk Usage measured as of 2026-07-29; usage grows over time as the chain grows. Execution layer only — full and minimal modes are not measured for this network.*
+
+**Hoodi**
 
 | **Pruning Mode** | **Current Disk Usage** |
-| -------------- | ---------------------- |
-| Archive        | 29.64 GB |
+| --- | --- |
+| Archive | 133.73 GB |
 
-_Current Disk Usage measured as of 2026-07-29; usage grows over time as the chain grows. Execution layer only — full and minimal modes are not measured for this network._
+*Current Disk Usage measured as of 2026-07-29; usage grows over time as the chain grows. Execution layer only — full and minimal modes are not measured for this network.*
+
+**Chiado**
+
+| **Pruning Mode** | **Current Disk Usage** |
+| --- | --- |
+| Archive | 29.64 GB |
+
+*Current Disk Usage measured as of 2026-07-29; usage grows over time as the chain grows. Execution layer only — full and minimal modes are not measured for this network.*
 
 :::tip
-See also how you can [optimize storage](../fundamentals/optimizing-storage).
+See also how you can [optimize storage](https://docs.erigon.tech/fundamentals/optimizing-storage).
 :::
 
 ## Bandwidth Requirements
 
 Your internet bandwidth is also an important factor, particularly for sync speed and validator performance.
 
-| Node Type      | Bandwidth (Required) | Bandwidth (Recommended) |
-| -------------- | -------------------- | ----------------------- |
-| Staking/Mining | 10 Mbps              | 50 Mbps                 |
-| Non-Staking    | 5 Mbps               | 25 Mbps                 |
+| Node Type | Bandwidth (Required) | Bandwidth (Recommended) |
+| --- | --- | --- |
+| Staking/Mining | 10 Mbps | 50 Mbps |
+| Non-Staking | 5 Mbps | 25 Mbps |
 
 ---
 
 # Migrating from Geth
 URL: https://docs.erigon.tech/get-started/migrating-from-geth
 
-
 ### Migration Paths: Choosing Your Erigon Setup
 
 When moving from another Execution Layer (EL) such as Geth, Nethermind, Reth or Besu to Erigon, node runners have a primary choice regarding their Consensus Layer (CL) setup:
 
-* **Erigon with Caplin**: The integrated setup using Erigon's embedded CL client, [Caplin](../fundamentals/caplin). Suitable for all node types — simplifies operation by removing the need for a separate consensus client.
-* **Erigon with an External Consensus Client**: This is the traditional setup, allowing to reuse an existing external CL client (like Prysm or Lighthouse).
+- **Erigon with Caplin**: The integrated setup using Erigon's embedded CL client, [Caplin](https://docs.erigon.tech/fundamentals/caplin). Suitable for all node types — simplifies operation by removing the need for a separate consensus client.
+- **Erigon with an External Consensus Client**: This is the traditional setup, allowing to reuse an existing external CL client (like Prysm or Lighthouse).
 
 The recommended approach involves running and syncing an **Erigon node alongside your existing Execution Layer (EL) client (like Geth)**. This allows for full functional verification, thorough testing, and a transition with **zero downtime**. Since Erigon requires **less disk space** than most clients, running both in parallel is practical for the duration of the migration.
 
 #### Choosing Your Migration Strategy
 
-* [Option 1](#option-1-sync-erigon-alongside-geth-and-its-cl): If you run a critical process and have enough disk space, syncing Erigon alongside Geth or any other EL is the recommended choice, and is essential for validators and RPC providers.
-  * If disk space is limited and downtime is not an option, consider syncing Erigon on a separate machine.
-* [Option 2](#option-2-remove-old-el-and-sync-erigon-downtime-accepted): If you are a home user or standard node runner (not running a validator), and the disk space is limited and downtime is acceptable, choose this option to remove your EL and the existing CL first.
+- [Option 1](https://docs.erigon.tech/get-started/migrating-from-geth#option-1-sync-erigon-alongside-geth-and-its-cl): If you run a critical process and have enough disk space, syncing Erigon alongside Geth or any other EL is the recommended choice, and is essential for validators and RPC providers.
+  - If disk space is limited and downtime is not an option, consider syncing Erigon on a separate machine.
 
-| **Node Runner Type**                                            | **Recommended Path (If Disk Space Allows)**                                                                                        | **Rationale**                                        |
-| --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| Validators                                                      | [Option 1](#option-1-sync-erigon-alongside-geth-and-its-cl): Sync Alongside Geth or any EL                   | Ensures minimal downtime and prevents slashing risk. |
-| Public RPC Providers                                            | [Option 1](#option-1-sync-erigon-alongside-geth-and-its-cl): Sync Alongside Geth or any EL                   | Guarantees zero service interruption for users.      |
-| Home Users / Standard Node Runners with no critical utilization | [Option 2](#option-2-remove-old-el-and-sync-erigon-downtime-accepted): Remove Geth or any EL and Sync Erigon | The fastest method if downtime is accepted.          |
+- [Option 2](https://docs.erigon.tech/get-started/migrating-from-geth#option-2-remove-old-el-and-sync-erigon-downtime-accepted): If you are a home user or standard node runner (not running a validator), and the disk space is limited and downtime is acceptable, choose this option to remove your EL and the existing CL first.
+
+| **Node Runner Type** | **Recommended Path (If Disk Space Allows)** | **Rationale** |
+| --- | --- | --- |
+| Validators | [Option 1](https://docs.erigon.tech/get-started/migrating-from-geth#option-1-sync-erigon-alongside-geth-and-its-cl): Sync Alongside Geth or any EL | Ensures minimal downtime and prevents slashing risk. |
+| Public RPC Providers | [Option 1](https://docs.erigon.tech/get-started/migrating-from-geth#option-1-sync-erigon-alongside-geth-and-its-cl): Sync Alongside Geth or any EL | Guarantees zero service interruption for users. |
+| Home Users / Standard Node Runners with no critical utilization | [Option 2](https://docs.erigon.tech/get-started/migrating-from-geth#option-2-remove-old-el-and-sync-erigon-downtime-accepted): Remove Geth or any EL and Sync Erigon | The fastest method if downtime is accepted. |
 
 ### Option 1: Sync Erigon Alongside Geth and its CL
 
 You can choose whether to migrate to Erigon + Caplin (the simplest setup) or continue using your existing CL.
 
+**Migrate to Erigon + Caplin (Internal CL)**
+
 This path offers the simplest validator configuration by using Erigon's embedded consensus client, Caplin. You will no longer need your external Consensus Layer (CL) client or a JWT secret for CL-EL communication.
 
 **Steps for Minimal Downtime**
 
-1. **Preparation**: [Install](installation/) Erigon.
-2. **Configuration Check** (No Conflict): Ensure Erigon's standard [ports](../fundamentals/default-ports) (JSON-RPC, P2P) are different from Geth's. The P2P listening port is configured via the `--port` command-line option. For example:
+1. **Preparation**: [Install](https://docs.erigon.tech/get-started/installation) Erigon.
 
-    ```sh
-    erigon \
-      --datadir=/data/erigon \
-      --chain=mainnet \
-      --port=30304
-    ```
-3. **Synchronization**: Start syncing Erigon. Monitor the sync status using the `eth_syncing` JSON-[RPC method](../interacting-with-erigon/) or a health check.
+2. **Configuration Check** (No Conflict): Ensure Erigon's standard [ports](https://docs.erigon.tech/fundamentals/default-ports) (JSON-RPC, P2P) are different from Geth's. The P2P listening port is configured via the `--port` command-line option. For example:
+
+```sh
+erigon \
+  --datadir=/data/erigon \
+  --chain=mainnet \
+  --port=30304
+```
+
+3. **Synchronization**: Start syncing Erigon. Monitor the sync status using the `eth_syncing` JSON-[RPC method](https://docs.erigon.tech/interacting-with-erigon) or a health check.
+
 4. **Validator Swap**: Once Erigon is fully synced, shut down Geth and the external CL client.
+
 5. **Reconfiguration and Restart**:
-   * To restart Erigon, there's no need to specify `--port`. Refer to this [guide](../fundamentals/caplin) for additional Erigon + Caplin configuration recommendations.
-   * Crucially, reconfigure your **validator keys manager** to point directly to the Erigon Beacon API, as Erigon/Caplin now handles both layers internally.
+
+  - To restart Erigon, there's no need to specify `--port`. Refer to this [guide](https://docs.erigon.tech/fundamentals/caplin) for additional Erigon + Caplin configuration recommendations.
+  - Crucially, reconfigure your **validator keys manager** to point directly to the Erigon Beacon API, as Erigon/Caplin now handles both layers internally.
+
 6. **Decommission Old Setup**: Verify Erigon/Caplin is proposing and attesting blocks correctly. If confirmed, safely remove Geth, the external CL client, and all their data, including the old JWT secret.
+
+**Migrate to Erigon + External CL**
 
 Switch to an Erigon Execution Layer (EL) while keeping your current external Consensus Layer (CL) client (e.g., Prysm, Lighthouse) and your existing JWT secret. Start by syncing Erigon with Caplin as the CL, then configure it to use the external CL.
 
 **Steps for Minimal Downtime**
 
-1. **Preparation**: [Install](installation/) Erigon.
-2. **Configuration Check**: run Erigon + Caplin simultaneously with Geth (or any other EL) for fast, parallel syncing and assign a unique port for its P2P networking via `--port` (check which ports your present
-   EL is using). For example:
+1. **Preparation**: [Install](https://docs.erigon.tech/get-started/installation) Erigon.
 
-    ```sh
-    erigon \
-      --datadir=/data/erigon \
-      --chain=mainnet \
-      --port=30304
-    ```
+2. **Configuration Check**: run Erigon + Caplin simultaneously with Geth (or any other EL) for fast, parallel syncing and assign a unique port for its P2P networking via `--port` (check which ports your present EL is using). For example:
+
+```sh
+erigon \
+  --datadir=/data/erigon \
+  --chain=mainnet \
+  --port=30304
+```
+
 3. **Synchronization**: Monitor the sync status using the `eth_syncing` JSON-RPC method or a health check.
+
 4. **Validator Swap**: Once Erigon is fully synced, **shut down** both Geth and Erigon. **Keep the external CL client running.**
-5. **Reconfiguration and Restart**: Restart Erigon, ensuring it uses the **original Engine API port and JWT secret** that your old EL client used. See [here](../staking/external-consensus-client-as-validator) for details.
+
+5. **Reconfiguration and Restart**: Restart Erigon, ensuring it uses the **original Engine API port and JWT secret** that your old EL client used. See [here](https://docs.erigon.tech/staking/external-consensus-client-as-validator) for details.
+
 6. **Decommission Old Setup**: Verify Erigon and your external CL client are proposing and attesting blocks correctly. If confirmed, safely remove Geth and its data.
 
 ### Option 2: Remove Old EL and Sync Erigon (Downtime Accepted)
 
 This is the simplest option as it requires no configuration adjustments. However, the node will be down until Erigon finishes syncing.
 
+**Erigon + Caplin (Fastest Sync)**
+
 This path is the fastest way to get Erigon running. It utilizes **Erigon's embedded consensus client, Caplin**, requiring no external CL client or JWT secret. This is ideal for home users with limited disk space and no critical uptime requirements.
 
 **Steps for Quickest Start**
 
 1. **Decommission Old Setup**: Shut down and **remove your old EL** client (Geth, etc.) and its data. If you were using an external CL client, you can shut it down as well.
-2. **Installation**: [Install](installation/) Erigon.
-3. **Configuration**: Erigon requires no special configuration; it uses default ports and settings. The [basic setup](../fundamentals/basic-usage) is sufficient for most situations.
+2. **Installation**: [Install](https://docs.erigon.tech/get-started/installation) Erigon.
+3. **Configuration**: Erigon requires no special configuration; it uses default ports and settings. The [basic setup](https://docs.erigon.tech/fundamentals/basic-usage) is sufficient for most situations.
 4. **Synchronization**: Start syncing Erigon with the default Caplin configuration (Caplin does not use the Engine API).
 5. **Final Setup**: Once Erigon is fully synced, your node is online.
 6. **Monitoring**: Monitor the sync progress using `eth_syncing` or the health check, and ensure no errors appear in Erigon's logs.
+
+**Erigon + External CL (Reuse Existing CL)**
 
 This path retains your existing **external Consensus Layer (CL)** client (e.g., Prysm, Lighthouse) but swaps the old EL client for Erigon. Since downtime is accepted, this process requires simpler port management.
 
 **Steps for Quickest Start**
 
 1. **Decommission Old Setup**: Shut down and remove your old EL client (Geth, etc.) and its data. Keep your external CL client running.
-2. **Installation**: [Install](installation/) Erigon.
-3.  **Configuration** (JWT and Ports): Ensure Erigon uses the same Engine API [port](../fundamentals/default-ports) (`--authrpc.port`) and JWT secret (`--authrpc.jwtsecret`) that the old EL client previously used. For example:\\
 
-    ```sh
-    erigon \
-      --externalcl \
-      --datadir=/data/erigon \
-      --chain=mainnet \
-      --authrpc.port=8551 \
-      --authrpc.jwtsecret=/jwt \
-      --authrpc.addr=0.0.0.0 \
-      --http \
-      --http.addr=0.0.0.0 \
-      --http.port=8545 \
-      --http.api=engine,eth,net,web3 \
-      --ws \
-      --ws.port=8546
-    ```
+2. **Installation**: [Install](https://docs.erigon.tech/get-started/installation) Erigon.
 
-    _(Otherwise, you must reconfigure your external CL client to match Erigon's default settings)_
+3. **Configuration** (JWT and Ports): Ensure Erigon uses the same Engine API [port](https://docs.erigon.tech/fundamentals/default-ports) (`--authrpc.port`) and JWT secret (`--authrpc.jwtsecret`) that the old EL client previously used. For example:\
+
+```sh
+erigon \
+  --externalcl \
+  --datadir=/data/erigon \
+  --chain=mainnet \
+  --authrpc.port=8551 \
+  --authrpc.jwtsecret=/jwt \
+  --authrpc.addr=0.0.0.0 \
+  --http \
+  --http.addr=0.0.0.0 \
+  --http.port=8545 \
+  --http.api=engine,eth,net,web3 \
+  --ws \
+  --ws.port=8546
+```
+
+*(Otherwise, you must reconfigure your external CL client to match Erigon's default settings)*
+
 4. **Synchronization**: Start syncing Erigon. Your external CL client will automatically connect to Erigon once Erigon is running and reachable on the Engine API port.
+
 5. **Monitoring and Verification**: Once Erigon is fully synced, check the logs of both Erigon and the external CL client to verify correct chain following.
 
-***
-
-See [Basic Usage](../fundamentals/basic-usage) and [Configuring Erigon](../fundamentals/configuring-erigon/) for more details on available options.
+See [Basic Usage](https://docs.erigon.tech/fundamentals/basic-usage) and [Configuring Erigon](https://docs.erigon.tech/fundamentals/configuring-erigon) for more details on available options.
 
 ---
 
 # Installation
 URL: https://docs.erigon.tech/get-started/installation
 
-'install-docker':   'all-operating-systems',
-  'install-prebuilt': 'linuxmacos',
-  'install-source':   'linuxmacos',
-  'install-native':   'windows',
-  'install-wsl':      'windows',
-  'install-arm':      'ethereum-on-arm',
-};
-
-  if (e) e.preventDefault();
-  const el = document.getElementById(id);
-  if (!el) return;
-
-  document.querySelectorAll('details[id^="install-"]').forEach(d => {
-    if (d !== el && d.open) {
-      const s = d.querySelector('summary');
-      if (s) s.click();
-      else d.open = false;
-    }
-  });
-
-  if (!el.open) {
-    const summary = el.querySelector('summary');
-    if (summary) summary.click();
-    else el.open = true;
-  }
-
-  const sectionId = sectionForMethod[id];
-  if (sectionId) {
-    history.replaceState(null, '', '#' + sectionId);
-  }
-
-  const resolveTarget = () => {
-    let t = sectionId && document.getElementById(sectionId);
-    if (!t) {
-      let cursor = el.previousElementSibling;
-      while (cursor && !/^H[1-6]$/.test(cursor.tagName)) {
-        cursor = cursor.previousElementSibling;
-      }
-      t = cursor || el;
-    }
-    return t;
-  };
-
-  let lastHeight = document.body.scrollHeight;
-  let stableFrames = 0;
-  let totalFrames = 0;
-  const waitForStableLayout = () => {
-    const h = document.body.scrollHeight;
-    if (h === lastHeight) stableFrames++;
-    else 
-    totalFrames++;
-    if (stableFrames >= 6 || totalFrames >= 90) {
-      resolveTarget().scrollIntoView();
-    } else {
-      requestAnimationFrame(waitForStableLayout);
-    }
-  };
-  requestAnimationFrame(waitForStableLayout);
-};
-
-# Installation
-
 To install Erigon, begin by choosing an installation method suited to your operating system and technical preference. Options range from the simplest to the most complex, including pre-built images, containers, or source compilation.
 
-Pre-built Binaries — Fastest way to get started. Download and run a pre-compiled binary for your architecture.
-Docker — Run Erigon in an isolated container. Recommended for most users.
-Build from Source — Full control over the build. Requires Go, C++ compiler, and CLI experience.
-Ethereum on ARM — Community image and APT repository for ARM single-board computers (Raspberry Pi, Rock 5B, Orange Pi 5).
+**Linux**
 
-Docker — Run Erigon in an isolated container. The recommended method on macOS.
-Build from Source — Compile directly on your Mac. Requires Go, Clang/GCC, and CLI experience.
+- [**Pre-built Binaries**](https://docs.erigon.tech/get-started/installation#install-prebuilt) — Fastest way to get started. Download and run a pre-compiled binary for your architecture.
+- [**Docker**](https://docs.erigon.tech/get-started/installation#install-docker) — Run Erigon in an isolated container. Recommended for most users.
+- [**Build from Source**](https://docs.erigon.tech/get-started/installation#install-source) — Full control over the build. Requires Go, C++ compiler, and CLI experience.
+- [**Ethereum on ARM**](https://docs.erigon.tech/get-started/installation#install-arm) — Community image and APT repository for ARM single-board computers (Raspberry Pi, Rock 5B, Orange Pi 5).
 
-Native Compilation — Compile and run Erigon directly on Windows using Chocolatey, MinGW, and Go.
-WSL (Windows Subsystem for Linux) — Run a full Linux environment on Windows. Recommended for best performance.
+**macOS**
+
+- [**Docker**](https://docs.erigon.tech/get-started/installation#install-docker) — Run Erigon in an isolated container. The recommended method on macOS.
+- [**Build from Source**](https://docs.erigon.tech/get-started/installation#install-source) — Compile directly on your Mac. Requires Go, Clang/GCC, and CLI experience.
+
+**Windows**
+
+- [**Native Compilation**](https://docs.erigon.tech/get-started/installation#install-native) — Compile and run Erigon directly on Windows using Chocolatey, MinGW, and Go.
+- [**WSL (Windows Subsystem for Linux)**](https://docs.erigon.tech/get-started/installation#install-wsl) — Run a full Linux environment on Windows. Recommended for best performance.
 
 ### All Operating Systems
 
-Docker
+**Docker**
 
 Docker is like a portable container for software. It packages Erigon and everything it needs to run, so you don't have to install complicated dependencies on your computer.
 
 This Docker image is fully supported on **Linux**, **macOS**, and **Windows**.
 
-_(Note: The container itself is built on multi-platform Linux architectures (linux/amd64 and linux/arm64), which is handled automatically by your Docker setup.)_
+*(Note: The container itself is built on multi-platform Linux architectures (linux/amd64 and linux/arm64), which is handled automatically by your Docker setup.)*
 
 #### **Prerequisites**
 
@@ -327,15 +345,15 @@ _(Note: The container itself is built on multi-platform Linux architectures (lin
 
 **General Info**
 
-* The Docker images feature several binaries, including: `erigon`, `downloader`, `evm`, `caplin`, `capcli`, `integration`, `rpcdaemon`, `sentry`, and `txpool`.
-* The multi-platform Docker image is available for `linux/amd64/v2` and `linux/arm64` platforms and is now based on Debian Bookworm. There's no need to pull a different image for another supported platform.
-* All build flags are now passed to the release workflow, allowing users to view previously missed build information in the released binaries and Docker images. This change is also expected to result in better build optimization.
-* Docker images now contain the label `org.opencontainers.image.revision`, which refers to the commit ID from the Erigon project used to build the artifacts.
-* With recent updates, all build configurations are now included in the release process. This provides users with more comprehensive build information for both binaries and Docker images, along with enhanced build optimizations.
-* Images are stored at [https://hub.docker.com/r/erigontech/erigon](https://hub.docker.com/r/erigontech/erigon).
+- The Docker images feature several binaries, including: `erigon`, `downloader`, `evm`, `caplin`, `capcli`, `integration`, `rpcdaemon`, `sentry`, and `txpool`.
+- The multi-platform Docker image is available for `linux/amd64/v2` and `linux/arm64` platforms and is now based on Debian Bookworm. There's no need to pull a different image for another supported platform.
+- All build flags are now passed to the release workflow, allowing users to view previously missed build information in the released binaries and Docker images. This change is also expected to result in better build optimization.
+- Docker images now contain the label `org.opencontainers.image.revision`, which refers to the commit ID from the Erigon project used to build the artifacts.
+- With recent updates, all build configurations are now included in the release process. This provides users with more comprehensive build information for both binaries and Docker images, along with enhanced build optimizations.
+- Images are stored at [https://hub.docker.com/r/erigontech/erigon](https://hub.docker.com/r/erigontech/erigon).
 
 :::warning
-**Windows**: note that Docker on Windows is affected by [WSL2 Performance and Data Storage](/get-started/installation/#install-wsl).
+**Windows**: note that Docker on Windows is affected by [WSL2 Performance and Data Storage](https://docs.erigon.tech/get-started/installation#install-wsl).
 :::
 
 #### **Download and start Erigon in Docker**
@@ -357,7 +375,7 @@ docker pull erigontech/erigon:<version_tag>
 For example:
 
 ```sh
-docker pull erigontech/erigon:v{ERIGON_VERSION}
+docker pull erigontech/erigon:v3.6.0
 ```
 
 **3. Start the Erigon container**
@@ -371,32 +389,32 @@ docker run -it erigontech/erigon:<version_tag> <flags>
 For example:
 
 ```sh
-docker run -it erigontech/erigon:v{ERIGON_VERSION} --chain=hoodi --prune.mode=minimal --datadir /erigon-data
+docker run -it erigontech/erigon:v3.6.0 --chain=hoodi --prune.mode=minimal --datadir /erigon-data
 ```
 
-* `-v` connects a folder on your computer to the container (must have authorization)
-* `-it` lets you see what's happening and interact with Erigon
-* `--chain=hoodi` specifies which [network](/fundamentals/supported-networks) to sync
-* `--prune.mode=minimal` tells Erigon to use minimal [Pruning Mode](/fundamentals/pruning-modes)
-* `--datadir` tells Erigon where to store data inside the container
+- `-v` connects a folder on your computer to the container (must have authorization)
+- `-it` lets you see what's happening and interact with Erigon
+- `--chain=hoodi` specifies which [network](https://docs.erigon.tech/fundamentals/supported-networks) to sync
+- `--prune.mode=minimal` tells Erigon to use minimal [Pruning Mode](https://docs.erigon.tech/fundamentals/pruning-modes)
+- `--datadir` tells Erigon where to store data inside the container
 
 ### Linux/macOS
 
-Pre-built Binaries (Linux Only)
+**Pre-built Binaries (Linux Only)**
 
 **1. Select Your Processor Architecture and Download**
 
-Go to the Erigon [releases page](https://github.com/erigontech/erigon/releases) on GitHub and select the latest stable version (e.g., v{ERIGON_VERSION}) or whichever version you prefer.
+Go to the Erigon [releases page](https://github.com/erigontech/erigon/releases) on GitHub and select the latest stable version (e.g., v3.6.0) or whichever version you prefer.
 
 Download the appropriate binary file for your processor architecture:
 
 | Processor Type | Binary File Type | Example File Name |
 | --- | --- | --- |
-| 64-bit Intel/AMD | Debian Package (.deb) | erigon_{ERIGON_VERSION}_amd64.deb |
-| 64-bit ARM | Debian Package (.deb) | erigon_{ERIGON_VERSION}_arm64.deb |
-| 64-bit Intel/AMD | Compressed Archive (.tar.gz) | erigon_v{ERIGON_VERSION}_linux_amd64.tar.gz |
-| 64-bit Intel/AMDv2 | Compressed Archive (.tar.gz) | erigon_v{ERIGON_VERSION}_linux_amd64v2.tar.gz |
-| 64-bit ARM | Compressed Archive (.tar.gz) | erigon_v{ERIGON_VERSION}_linux_arm64.tar.gz |
+| 64-bit Intel/AMD | Debian Package (.deb) | erigon_3.6.0_amd64.deb |
+| 64-bit ARM | Debian Package (.deb) | erigon_3.6.0_arm64.deb |
+| 64-bit Intel/AMD | Compressed Archive (.tar.gz) | erigon_v3.6.0_linux_amd64.tar.gz |
+| 64-bit Intel/AMDv2 | Compressed Archive (.tar.gz) | erigon_v3.6.0_linux_amd64v2.tar.gz |
+| 64-bit ARM | Compressed Archive (.tar.gz) | erigon_v3.6.0_linux_arm64.tar.gz |
 
 Note that the Release Page Assets table contains also the **checksum** for each file and a checksum file.
 
@@ -415,14 +433,14 @@ sha256sum <DOWNLOADED_FILE_NAME>
 Example with a `tar.gz` file:
 
 ```sh
-sha256sum erigon_v{ERIGON_VERSION}_linux_amd64.tar.gz
+sha256sum erigon_v3.6.0_linux_amd64.tar.gz
 ```
 
 This command will output a long string (the computed checksum) followed by the file name.
 
 **2.2 Compare the Checksums**
 
-Compare the checksum found in the previous step with those in the Release Notes Assets table or the erigon\_v3.x.x\_checksums.txt file in the same table.
+Compare the checksum found in the previous step with those in the Release Notes Assets table or the erigon_v3.x.x_checksums.txt file in the same table.
 
 The two checksum strings must match exactly. If they do not match, the file is corrupted, and you should delete it and download it again.
 
@@ -434,35 +452,37 @@ After downloading and verifying the checksum, follow the instructions below base
 
 This method uses your distribution's package manager (like dpkg) to install Erigon system-wide.
 
-1.  Navigate to the directory where you downloaded the pre-built binary, e.g. Downloads:
+1. Navigate to the directory where you downloaded the pre-built binary, e.g. Downloads:
 
-    ```bash
-    cd ~/Downloads
-    ```
-2.  Install the package:
+```bash
+cd ~/Downloads
+```
 
-    ```bash
-    sudo dpkg -i erigon_3.x.x_amd64.deb
-    ```
+2. Install the package:
 
-    (Replace the filename with your downloaded version)
+```bash
+sudo dpkg -i erigon_3.x.x_amd64.deb
+```
+
+(Replace the filename with your downloaded version)
 
 **b. Using Compressed Archive (`.tar.gz`)**
 
 This method gives you a standalone executable that can be run from any directory.
 
-1.  Extract the archive:
+1. Extract the archive:
 
-    ```bash
-    tar -xzf erigon_v3.x.x_linux_amd64.tar.gz
-    ```
+```bash
+tar -xzf erigon_v3.x.x_linux_amd64.tar.gz
+```
 
-    (Replace the filename with your downloaded version)
-2.  Move the resulting `erigon` executable to a directory included in your system's $PATH(e.g., $/usr/local/bin) to run it from anywhere:
+(Replace the filename with your downloaded version)
 
-    ```bash
-    sudo mv erigon /usr/local/bin/
-    ```
+2. Move the resulting `erigon` executable to a directory included in your system's $PATH(e.g., $/usr/local/bin) to run it from anywhere:
+
+```bash
+sudo mv erigon /usr/local/bin/
+```
 
 **4. Running Erigon**
 
@@ -472,7 +492,7 @@ After installation, you can run Erigon from your terminal:
 erigon [options]
 ```
 
-Build from Source
+**Build from Source**
 
 :::info
 Building from source gives you full control over the compilation process and lets you run any specific version or branch. It requires Go, a C++ compiler, and basic familiarity with the command line.
@@ -498,9 +518,7 @@ sudo apt install build-essential cmake -y
 
 **1.3 Go Programming Language**
 
-Erigon utilizes Go (also known as Golang) version 1.25 or newer for part of its development. It is recommended to have a
-fresh Go installation. If you have an older version, consider deleting the `/usr/local/go` folder (you may need to use
-`sudo`) and re-extract the new version in its place.
+Erigon utilizes Go (also known as Golang) version 1.25 or newer for part of its development. It is recommended to have a fresh Go installation. If you have an older version, consider deleting the `/usr/local/go` folder (you may need to use `sudo`) and re-extract the new version in its place.
 
 To install the latest Go version, visit the official documentation at [https://golang.org/doc/install](https://golang.org/doc/install).
 
@@ -508,8 +526,8 @@ To install the latest Go version, visit the official documentation at [https://g
 
 This turns the C++ part of Erigon's code into a program your computer can run. You can use either **Clang** or **GCC**:
 
-* For **Clang** follow the instructions at [https://clang.llvm.org/get\_started.html](https://clang.llvm.org/get_started.html);
-* For **GCC** (version 10 or newer): [https://gcc.gnu.org/install/index.html](https://gcc.gnu.org/install/index.html).
+- For **Clang** follow the instructions at [https://clang.llvm.org/get_started.html](https://clang.llvm.org/get_started.html);
+- For **GCC** (version 10 or newer): [https://gcc.gnu.org/install/index.html](https://gcc.gnu.org/install/index.html).
 
 **2. Building Erigon from Source**
 
@@ -535,7 +553,7 @@ git fetch --tags
 Check out the desired version tag by replacing `<tag_name>` with the version you want. Normally latest stable version is the best, check the official [Release Notes](https://github.com/erigontech/erigon/releases). For example:
 
 ```sh
-git checkout v{ERIGON_VERSION}
+git checkout v3.6.0
 ```
 
 **2.3 Compile the Software**
@@ -566,7 +584,7 @@ After installation, you can run Erigon from your terminal:
 
 ### Windows
 
-Native Compilation
+**Native Compilation**
 
 **1. Software Prerequisites**
 
@@ -574,7 +592,7 @@ You must install the following software and set the below environment variables 
 
 **1.1 Chocolatey**
 
-Install _Chocolatey package manager_ by following these [instructions](https://docs.chocolatey.org/en-us/choco/setup).
+Install *Chocolatey package manager* by following these [instructions](https://docs.chocolatey.org/en-us/choco/setup).
 
 Once your Windows machine has the above installed, open the **Command Prompt** by typing "**cmd**" in the search bar and check that you have correctly installed Chocolatey:
 
@@ -602,9 +620,7 @@ Git is a tool that helps download and manage the Erigon source code. To install 
 
 **1.4 Go Programming Language**
 
-Erigon utilizes Go (also known as Golang) version 1.25 or newer for part of its development. It is recommended to have a
-fresh Go installation. If you have an older version, consider deleting the `/usr/local/go` folder (you may need to use
-`sudo`) and re-extract the new version in its place.
+Erigon utilizes Go (also known as Golang) version 1.25 or newer for part of its development. It is recommended to have a fresh Go installation. If you have an older version, consider deleting the `/usr/local/go` folder (you may need to use `sudo`) and re-extract the new version in its place.
 
 To install the latest Go version, visit the official documentation at [https://golang.org/doc/install](https://golang.org/doc/install).
 
@@ -640,7 +656,7 @@ git fetch --tags
 Check out the desired version tag by replacing `<tag_name>` with the version you want. Normally latest stable version is the best, check the official [Release Notes](https://github.com/erigontech/erigon/releases). For example:
 
 ```bash
-git checkout v{ERIGON_VERSION}
+git checkout v3.6.0
 ```
 
 You might need to change the `ExecutionPolicy` to allow scripts created locally or signed by a trusted publisher to run. Open a **Powershell session as Administrator** and type:
@@ -693,36 +709,36 @@ erigon.exe [options]
 **Note**: When you first start Erigon, Windows Firewall may prompt you to allow internet access. Select "YES" to proceed.
 :::
 
-Window Subsystem for Linux (WSL)
+**Window Subsystem for Linux (WSL)**
 
 WSL enables you to run a complete GNU/Linux environment natively within Windows, offering Linux compatibility without the performance and resource overhead of traditional virtual machines.
 
 **Installation and Version**
 
-* Official Installation: Follow Microsoft's official guide to install WSL2: [https://learn.microsoft.com/en-us/windows/wsl/install](https://learn.microsoft.com/en-us/windows/wsl/install)
-* Required Version: WSL version 2 is the only version supported by Erigon.
+- Official Installation: Follow Microsoft's official guide to install WSL2: [https://learn.microsoft.com/en-us/windows/wsl/install](https://learn.microsoft.com/en-us/windows/wsl/install)
+- Required Version: WSL version 2 is the only version supported by Erigon.
 
 **Building Erigon**
 
-Once WSL2 is set up, you can build and run Erigon exactly as you would on a regular [Linux/macOS](/get-started/installation/#linuxmacos) distribution.
+Once WSL2 is set up, you can build and run Erigon exactly as you would on a regular [Linux/macOS](https://docs.erigon.tech/get-started/installation#linuxmacos) distribution.
 
 **Performance and Data Storage**
 
 The location of your Erigon data directory (`datadir`) is the most crucial factor for performance in WSL.
 
-| **Data Location**                                                         | **Performance & Configuration**                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Recommended: Native Linux Filesystem (e.g., in your Linux home directory) | Optimal Performance. Erigon runs without restrictions, and the embedded RPC Daemon works efficiently.                                                                                                                                                                                                                                                                                                                                                            |
-| Avoid: Mounted Windows Partitions (e.g., `/mnt/c/`, `/mnt/d/`)            | Performance is reduced as the native Windows drives are mounted using DrvFS (a slower network file system). This affects MDBX database access, and complicates filesystem operations that expect unix-like behaviour. Setting [`automount.options=metadata`](https://learn.microsoft.com/en-us/windows/wsl/wsl-config#automount-options) in `/etc/wsl.conf` in your distribution is recommended, but not required. Note that Docker on Windows is also affected. |
+| **Data Location** | **Performance & Configuration** |
+| --- | --- |
+| Recommended: Native Linux Filesystem (e.g., in your Linux home directory) | Optimal Performance. Erigon runs without restrictions, and the embedded RPC Daemon works efficiently. |
+| Avoid: Mounted Windows Partitions (e.g., `/mnt/c/`, `/mnt/d/`) | Performance is reduced as the native Windows drives are mounted using DrvFS (a slower network file system). This affects MDBX database access, and complicates filesystem operations that expect unix-like behaviour. Setting [`automount.options=metadata`](https://learn.microsoft.com/en-us/windows/wsl/wsl-config#automount-options) in `/etc/wsl.conf` in your distribution is recommended, but not required. Note that Docker on Windows is also affected. |
 
 **RPC Daemon Configuration**
 
 The choice of data location directly impacts how you must configure the RPC Daemon:
 
-| **Scenario**                                  | **RPC Daemon Requirement**                                                               |
-| --------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| Data on Native Linux Filesystem (Recommended) | Use the Embedded RPC Daemon. This is the highly preferred and most efficient method.     |
-| Data on Mounted Windows Partition             | The `rpcdaemon` must be configured as a remote DB even when running on the same machine. |
+| **Scenario** | **RPC Daemon Requirement** |
+| --- | --- |
+| Data on Native Linux Filesystem (Recommended) | Use the Embedded RPC Daemon. This is the highly preferred and most efficient method. |
+| Data on Mounted Windows Partition | The `rpcdaemon` must be configured as a remote DB even when running on the same machine. |
 
 :::warning
 ⚠️ Warning: The remote DB RPC Daemon is an experimental feature, is not recommended, and is extremely slow. Always aim to use the embedded RPC Daemon by keeping your data on the native Linux filesystem.
@@ -736,7 +752,7 @@ If you need to connect to Erigon from an external network (e.g., opening a port 
 
 ### Ethereum on ARM
 
-Install with APT on ARM boards
+**Install with APT on ARM boards**
 
 [Ethereum on ARM](https://ethereum-on-arm-documentation.readthedocs.io/) is a community project that provides a custom Linux image for ARM single-board computers (such as Raspberry Pi, Rock 5B, and Orange Pi 5) with an APT repository preconfigured to install and update Ethereum clients — including Erigon — as native system packages.
 
@@ -752,35 +768,34 @@ For the full image, supported boards, and setup instructions, see the [Ethereum 
 Ethereum on ARM is maintained independently by the community and is not an official Erigon distribution channel. The Erigon version available through its APT repository may lag behind the latest [GitHub release](https://github.com/erigontech/erigon/releases).
 :::
 
-Once you have Erigon installed, you can see [Basic Usage](/fundamentals/basic-usage) to configure your node and confirm it is syncing.
+Once you have Erigon installed, you can see [Basic Usage](https://docs.erigon.tech/fundamentals/basic-usage) to configure your node and confirm it is syncing.
 
 ---
 
 # Upgrading from a previous version
 URL: https://docs.erigon.tech/get-started/installation/upgrading
 
-
 Updating to the latest version of Erigon gives you access to the latest features and ensures optimal performance and stability.
 
 ## General Recommendations Before Upgrade
 
-* **Read Release Notes**: Carefully review the [Release Notes](https://github.com/erigontech/erigon/releases) for breaking changes and new features relevant to your setup.
-* **Terminate your Erigon**: End your current Erigon session by pressing `CTRL+C`.
-* **Backup**: Always back up your `datadir` before performing major upgrades.
+- **Read Release Notes**: Carefully review the [Release Notes](https://github.com/erigontech/erigon/releases) for breaking changes and new features relevant to your setup.
+- **Terminate your Erigon**: End your current Erigon session by pressing `CTRL+C`.
+- **Backup**: Always back up your `datadir` before performing major upgrades.
 
 ## Managing your Data
 
 Erigon 3.1 introduces a new snapshot format while continuing to support the old one. This means that new releases are fully compatible with your existing data. However, users who want the latest data files and data-specific fixes can perform an **optional** manual data upgrade:
 
 1. Backup your datadir.
-2. [Upgrade your Erigon installation](#upgrading-your-erigon-installation) whether from a binary, compiled source code, or Docker.
-3. Upgrade your snapshots using one of the [options below](#snapshots-upgrade-options).
+2. [Upgrade your Erigon installation](https://docs.erigon.tech/get-started/installation/upgrading#upgrading-your-erigon-installation) whether from a binary, compiled source code, or Docker.
+3. Upgrade your snapshots using one of the [options below](https://docs.erigon.tech/get-started/installation/upgrading#snapshots-upgrade-options).
 4. Run Erigon; it downloads any missing snapshots and resumes syncing.
 
 ### Snapshots Upgrade Options
 
-* `erigon snapshots update-to-new-ver-format --datadir /your/datadir`: converts your existing snapshots in place to the latest format, **keeping your data**. Quicker, but you won't get the full performance benefits of freshly built snapshots.
-* `erigon snapshots reset --datadir /your/datadir`: **destructive** — deletes `chaindata/` (and any leftover `heimdall/` and `polygon-bridge/` directories from a former Polygon datadir) and removes any snapshot files **not** in the preverified set (locally generated files, and torrents with a mismatched hash). Preverified snapshots already on disk are **kept**; on the next start Erigon downloads only **missing or incorrect** snapshots and rebuilds state.
+- `erigon snapshots update-to-new-ver-format --datadir /your/datadir`: converts your existing snapshots in place to the latest format, **keeping your data**. Quicker, but you won't get the full performance benefits of freshly built snapshots.
+- `erigon snapshots reset --datadir /your/datadir`: **destructive** — deletes `chaindata/` (and any leftover `heimdall/` and `polygon-bridge/` directories from a former Polygon datadir) and removes any snapshot files **not** in the preverified set (locally generated files, and torrents with a mismatched hash). Preverified snapshots already on disk are **kept**; on the next start Erigon downloads only **missing or incorrect** snapshots and rebuilds state.
 
 :::warning
 `erigon snapshots reset` does **not** reuse your `chaindata/` — it deletes the chaindata DB (and any leftover Polygon aux directories) and any locally generated or mismatched snapshots, then rebuilds state on the next start (downloading only missing or incorrect snapshots). Back up your `--datadir` first, and prefer `update-to-new-ver-format` if you want to keep your current data.
@@ -788,7 +803,7 @@ Erigon 3.1 introduces a new snapshot format while continuing to support the old 
 
 Choose `update-to-new-ver-format` to convert your data in place, or `reset` for a clean reset to the preverified snapshot set.
 
-Why Upgrading Erigon Doesn't Always Fix Your Data
+**Why Upgrading Erigon Doesn't Always Fix Your Data**
 
 Upgrading Erigon involves a key distinction between its core software and its data files, which are managed separately. This approach is rooted in practicality and user control.
 
@@ -819,19 +834,19 @@ If upgrading snapshots(`3.0`to `3.1`) now happens automatically, you should foll
 
 Follow the below instructions depending on your installation method:
 
-* [Pre-built binaries](#pre-built-binaries-only-linux-and-macos)
-* [Docker](#docker)
-* [Compiled source code](#compiled-from-source)
+- [Pre-built binaries](https://docs.erigon.tech/get-started/installation/upgrading#pre-built-binaries-only-linux-and-macos)
+- [Docker](https://docs.erigon.tech/get-started/installation/upgrading#docker)
+- [Compiled source code](https://docs.erigon.tech/get-started/installation/upgrading#compiled-from-source)
 
 ### Pre-built Binaries (only Linux and macOS)
 
-Download the latest binary file from [https://github.com/erigontech/erigon/releases](https://github.com/erigontech/erigon/releases), do the [checksum](./#install-prebuilt) and reinstall it, no other operation needed.
+Download the latest binary file from [https://github.com/erigontech/erigon/releases](https://github.com/erigontech/erigon/releases), do the [checksum](https://docs.erigon.tech/get-started/installation/#install-prebuilt) and reinstall it, no other operation needed.
 
 ### Docker
 
 If you're using Docker to run Erigon, the process to upgrade to a newer version of the software is straightforward and revolves around pulling the latest Docker image and then running it.
 
-Simply follow the [Docker](#docker) instructions and install and launch the new version.
+Simply follow the [Docker](https://docs.erigon.tech/get-started/installation/upgrading#docker) instructions and install and launch the new version.
 
 ### Compiled from source
 
@@ -844,8 +859,6 @@ URL: https://docs.erigon.tech/get-started/easy-nodes
 
 Guided setup for running a complete node with sensible defaults — pick your network and follow along.
 
-## Sections
-
 - [Ethereum Node](https://docs.erigon.tech/get-started/easy-nodes/how-to-run-an-ethereum-node): Run a full Ethereum mainnet node using Caplin (built-in consensus layer) or connect an external CL client.
 - [Gnosis Chain Node](https://docs.erigon.tech/get-started/easy-nodes/how-to-run-a-gnosis-chain-node): Run a full Gnosis Chain node with Erigon's embedded consensus layer or an external CL client.
 
@@ -854,13 +867,12 @@ Guided setup for running a complete node with sensible defaults — pick your ne
 # How to run an Ethereum node
 URL: https://docs.erigon.tech/get-started/easy-nodes/how-to-run-an-ethereum-node
 
-
 ## 1. Prerequisites Check
 
-1. Confirm your machine meets the necessary [Hardware Requirements](/get-started/hardware-requirements) based on your desired pruning mode.
+1. Confirm your machine meets the necessary [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements) based on your desired pruning mode.
 2. **Install Docker**:
-   * For Linux, install [Docker Engine](https://docs.docker.com/engine/install).
-   * For macOS or Windows, install [Docker Desktop](https://docs.docker.com/desktop/).
+  - For Linux, install [Docker Engine](https://docs.docker.com/engine/install).
+  - For macOS or Windows, install [Docker Desktop](https://docs.docker.com/desktop/).
 
 ## 2. Configure and Launch Erigon
 
@@ -873,7 +885,7 @@ Create a new file named `docker-compose.yml` in a directory where you want to ma
 ```yaml
 services:
   erigon:
-    image: erigontech/erigon:v{ERIGON_VERSION}
+    image: erigontech/erigon:v3.6.0
     container_name: erigon-node
     restart: always
     command:
@@ -914,16 +926,12 @@ Set `EXTERNAL_IP` before starting, either in a `.env` file next to `docker-compo
 echo "EXTERNAL_IP=$(curl -s https://api.ipify.org)" > .env
 ```
 
-or by exporting it in your shell. Forward the `30303`, `42069`, `4000` and `4001`
-ports on your router as well, otherwise peers still cannot reach you.
+or by exporting it in your shell. Forward the `30303`, `42069`, `4000` and `4001` ports on your router as well, otherwise peers still cannot reach you.
 
 :::warning
 ⚠️ **Action Required**: the volume path should be changed to suit your setup — replace `/path/to/erigon/data` with a valid, empty directory on your machine where you want Erigon to store its files.
 
-The container runs as UID/GID `1000`, so the directory must be writable by that
-user — `sudo chown -R 1000:1000 /path/to/erigon/data`. See
-[Permission denied inside Docker](/help-center/common-errors-and-solutions) if
-you hit a `permission denied` error on startup.
+The container runs as UID/GID `1000`, so the directory must be writable by that user — `sudo chown -R 1000:1000 /path/to/erigon/data`. See [Permission denied inside Docker](https://docs.erigon.tech/help-center/common-errors-and-solutions) if you hit a `permission denied` error on startup.
 :::
 
 ### **B. Launch the Node and Monitor Progress**
@@ -934,9 +942,7 @@ Open your terminal in the directory where you saved `docker-compose.yml`. To sta
 docker compose up
 ```
 
-That keeps the logs in the foreground, which is what you want the first time.
-Once you are happy with the configuration, start it detached so the node keeps
-running after you close the terminal:
+That keeps the logs in the foreground, which is what you want the first time. Once you are happy with the configuration, start it detached so the node keeps running after you close the terminal:
 
 ```bash
 docker compose up -d
@@ -946,14 +952,14 @@ and follow the logs when you need them with `docker compose logs -f`.
 
 ## Flag explanation
 
-* `--chain=mainnet` specifies to run on Ethereum mainnet
-* Add `--prune.mode=minimal` to run minimal [Pruning Mode](/fundamentals/pruning-modes) or `--prune.mode=archive` to run an archive node
-* `--datadir=/var/lib/erigon` has to name the same path as the container side of the volume mount. Without it Erigon writes to its default location inside the container instead of your mounted directory, and the data ends up in an anonymous Docker volume rather than where you pointed it
-* `--http.addr=0.0.0.0 --http.api=eth,web3,net,debug,trace,txpool` to use RPC and e.g. be able to connect your [web3 wallet](/fundamentals/web3-wallet). `0.0.0.0` is the address *inside* the container, which is what lets Docker forward to it at all; the `127.0.0.1:8545:8545` port mapping is what keeps it off your LAN. Change that mapping to `8545:8545` only if you intend to expose RPC to other machines
-* `--nat=extip:<your public IP>` and `--caplin.nat=extip:<your public IP>` advertise a reachable address so other nodes can dial you — the first for the execution layer, the second for Caplin. Without them, and without the forwarded ports, the node still syncs but only through connections it opens itself
-* `--torrent.download.rate` is deliberately not set above, because its default of `512mb` (megabytes per second) is already the maximum this recipe would ask for. During initial sync Erigon uses the full allowance, which is what you want on a dedicated machine. Add the flag only to **lower** the cap if you share the machine with other work (e.g. `--torrent.download.rate=128mb`), or set `--torrent.download.rate=Inf` to remove the limit entirely.
+- `--chain=mainnet` specifies to run on Ethereum mainnet
+- Add `--prune.mode=minimal` to run minimal [Pruning Mode](https://docs.erigon.tech/fundamentals/pruning-modes) or `--prune.mode=archive` to run an archive node
+- `--datadir=/var/lib/erigon` has to name the same path as the container side of the volume mount. Without it Erigon writes to its default location inside the container instead of your mounted directory, and the data ends up in an anonymous Docker volume rather than where you pointed it
+- `--http.addr=0.0.0.0 --http.api=eth,web3,net,debug,trace,txpool` to use RPC and e.g. be able to connect your [web3 wallet](https://docs.erigon.tech/fundamentals/web3-wallet). `0.0.0.0` is the address *inside* the container, which is what lets Docker forward to it at all; the `127.0.0.1:8545:8545` port mapping is what keeps it off your LAN. Change that mapping to `8545:8545` only if you intend to expose RPC to other machines
+- `--nat=extip:<your public IP>` and `--caplin.nat=extip:<your public IP>` advertise a reachable address so other nodes can dial you — the first for the execution layer, the second for Caplin. Without them, and without the forwarded ports, the node still syncs but only through connections it opens itself
+- `--torrent.download.rate` is deliberately not set above, because its default of `512mb` (megabytes per second) is already the maximum this recipe would ask for. During initial sync Erigon uses the full allowance, which is what you want on a dedicated machine. Add the flag only to **lower** the cap if you share the machine with other work (e.g. `--torrent.download.rate=128mb`), or set `--torrent.download.rate=Inf` to remove the limit entirely.
 
-When you get familiar with running Erigon from CLI you may also consider [staking](/staking/caplin) and/or running an Ethereum node with an [external Consensus Layer](/get-started/easy-nodes/how-to-run-an-ethereum-node/ethereum-with-an-external-cl).
+When you get familiar with running Erigon from CLI you may also consider [staking](https://docs.erigon.tech/staking/caplin) and/or running an Ethereum node with an [external Consensus Layer](https://docs.erigon.tech/get-started/easy-nodes/how-to-run-an-ethereum-node/ethereum-with-an-external-cl).
 
 :::tip
 Press `Ctrl+C` in your terminal to stop Erigon.
@@ -961,15 +967,12 @@ Press `Ctrl+C` in your terminal to stop Erigon.
 
 ## Host networking as an alternative
 
-Publishing each port individually is explicit, but Docker's NAT is also what
-makes `--nat=extip:...` necessary in the first place. Adding `network_mode:
-host` to the service instead gives the container the host's network stack
-directly, so peers see the host's own address and there is nothing to map:
+Publishing each port individually is explicit, but Docker's NAT is also what makes `--nat=extip:...` necessary in the first place. Adding `network_mode: host` to the service instead gives the container the host's network stack directly, so peers see the host's own address and there is nothing to map:
 
 ```yaml
 services:
   erigon:
-    image: erigontech/erigon:v{ERIGON_VERSION}
+    image: erigontech/erigon:v3.6.0
     network_mode: host
     command:
       - --chain=mainnet
@@ -986,98 +989,89 @@ services:
 
 Two things change with it, and both matter:
 
-* the `ports:` section is ignored — port publishing does not apply, so the
-  firewall on the host is what governs access;
-* every listener binds on the host, so anything you do not want exposed must be
-  bound explicitly to `127.0.0.1`. That is why RPC, the Engine API and the
-  internal gRPC address are pinned to loopback above. `--nat` and `--caplin.nat`
-  are no longer needed for the container, though you still need the p2p ports
-  forwarded on your router.
+- the `ports:` section is ignored — port publishing does not apply, so the firewall on the host is what governs access;
+- every listener binds on the host, so anything you do not want exposed must be bound explicitly to `127.0.0.1`. That is why RPC, the Engine API and the internal gRPC address are pinned to loopback above. `--nat` and `--caplin.nat` are no longer needed for the container, though you still need the p2p ports forwarded on your router.
 
-Host networking is Linux-only in practice; on Docker Desktop for macOS and
-Windows it does not behave the same way, so keep the published-ports form there.
+Host networking is Linux-only in practice; on Docker Desktop for macOS and Windows it does not behave the same way, so keep the published-ports form there.
 
-Additional flags can be added to [configure](/fundamentals/configuring-erigon/) Erigon with several options.
+Additional flags can be added to [configure](https://docs.erigon.tech/fundamentals/configuring-erigon) Erigon with several options.
 
 ---
 
 # Ethereum with an external CL
 URL: https://docs.erigon.tech/get-started/easy-nodes/how-to-run-an-ethereum-node/ethereum-with-an-external-cl
 
-
 You can use **Prysm**, **Lighthouse**, or any other Consensus Layer client with Erigon by including the `--externalcl` flag. This integration enables direct access to the Ethereum blockchain, allowing you to manage your keys for staking ETH and block production.
 
 :::warning
-The Engine API drives block processing, so anything that can reach it and holds
-your JWT secret controls the node. The steps below widen it past localhost only
-so a CL on another machine can connect — when you do that, protect it:
+The Engine API drives block processing, so anything that can reach it and holds your JWT secret controls the node. The steps below widen it past localhost only so a CL on another machine can connect — when you do that, protect it:
 
-* prefer the specific interface — `--authrpc.addr <this-host-LAN-IP>` — over
-  `0.0.0.0`, which listens on every interface including any public one;
-* restrict port `8551` at the firewall to the CL host's address, and never
-  expose it to the internet;
-* treat `--authrpc.vhosts` as a `Host`-header check, not a network control: it
-  is not a substitute for a firewall rule;
-* keep `jwt.hex` readable only by the accounts that need it, and copy it to the
-  CL host over a private channel.
+- prefer the specific interface — `--authrpc.addr <this-host-LAN-IP>` — over `0.0.0.0`, which listens on every interface including any public one;
+- restrict port `8551` at the firewall to the CL host's address, and never expose it to the internet;
+- treat `--authrpc.vhosts` as a `Host`-header check, not a network control: it is not a substitute for a firewall rule;
+- keep `jwt.hex` readable only by the accounts that need it, and copy it to the CL host over a private channel.
 
-If both clients run on the same machine, leave the Engine API on its default
-localhost address and skip those flags entirely.
+If both clients run on the same machine, leave the Engine API on its default localhost address and skip those flags entirely.
 :::
 
 :::tip
-Keep your consensus client current, the same way you would Erigon. Beyond fixes
-and performance work, a CL carries the fork schedule it was built with: a
-version released before an upcoming hard fork may not follow the chain through
-it, which stalls your execution layer too. Watch your client's releases
-([Prysm](https://github.com/OffchainLabs/prysm/releases),
-[Lighthouse](https://github.com/sigp/lighthouse/releases)) and upgrade before
-scheduled forks, not after.
+Keep your consensus client current, the same way you would Erigon. Beyond fixes and performance work, a CL carries the fork schedule it was built with: a version released before an upcoming hard fork may not follow the chain through it, which stalls your execution layer too. Watch your client's releases ([Prysm](https://github.com/OffchainLabs/prysm/releases), [Lighthouse](https://github.com/sigp/lighthouse/releases)) and upgrade before scheduled forks, not after.
 :::
 
 ## Erigon with Prysm as the external CL
 
-1.  Start Erigon adding the `--externalcl` flag:
+**Prysm**
 
-    ```bash
-    erigon --externalcl
-    ```
+1. Start Erigon adding the `--externalcl` flag:
 
-    If your Consensus Layer (CL) client is on a different device, add the following flags:
+```bash
+erigon --externalcl
+```
 
-    * `--authrpc.addr <this-host-LAN-IP>` — the Engine API listens on localhost by default, so it has to be widened for a remote CL. Read the warning below before reaching for `0.0.0.0`;
-    * `--authrpc.vhosts <CL_host>` where \ is the source host or the appropriate hostname that your CL client is using.
-2.  Install and run **Prysm** by following the official guide: [https://docs.prylabs.network/docs/install/install-with-script](https://docs.prylabs.network/docs/install/install-with-script).
+If your Consensus Layer (CL) client is on a different device, add the following flags:
 
-    Prysm must fully synchronize before Erigon can start syncing, since Erigon requires an existing target head to sync to. The quickest way to get Prysm synced is to use a public checkpoint synchronization endpoint from the list at [https://eth-clients.github.io/checkpoint-sync-endpoints](https://eth-clients.github.io/checkpoint-sync-endpoints).
+  - `--authrpc.addr <this-host-LAN-IP>` — the Engine API listens on localhost by default, so it has to be widened for a remote CL. Read the warning below before reaching for `0.0.0.0`;
+  - `--authrpc.vhosts <CL_host>` where <CL_host> is the source host or the appropriate hostname that your CL client is using.
+
+2. Install and run **Prysm** by following the official guide: [https://docs.prylabs.network/docs/install/install-with-script](https://docs.prylabs.network/docs/install/install-with-script).
+
+Prysm must fully synchronize before Erigon can start syncing, since Erigon requires an existing target head to sync to. The quickest way to get Prysm synced is to use a public checkpoint synchronization endpoint from the list at [https://eth-clients.github.io/checkpoint-sync-endpoints](https://eth-clients.github.io/checkpoint-sync-endpoints).
+
 3. To communicate with Erigon, the `--execution-endpoint` must be specified as `<erigon address>:8551`, where `<erigon address>` is either `http://localhost` or the IP address of the device running Erigon.
-4.  Prysm must point to the [JWT secret](../../../fundamentals/jwt) automatically created by Erigon in the `--datadir` directory.
 
-    ```bash
-    ./prysm.sh beacon-chain \
-    --execution-endpoint http://localhost:8551 \
-    --mainnet --jwt-secret=<your-datadir>/jwt.hex \
-    --checkpoint-sync-url=https://mainnet.checkpoint.sigp.io \
-    --genesis-beacon-api-url=https://mainnet.checkpoint.sigp.io
-    ```
+4. Prysm must point to the [JWT secret](https://docs.erigon.tech/fundamentals/jwt) automatically created by Erigon in the `--datadir` directory.
 
-1.  Start Erigon adding the `--externalcl` flag:
+```bash
+./prysm.sh beacon-chain \
+--execution-endpoint http://localhost:8551 \
+--mainnet --jwt-secret=<your-datadir>/jwt.hex \
+--checkpoint-sync-url=https://mainnet.checkpoint.sigp.io \
+--genesis-beacon-api-url=https://mainnet.checkpoint.sigp.io
+```
 
-    ```bash
-    erigon --externalcl
-    ```
+**Lighthouse**
+
+1. Start Erigon adding the `--externalcl` flag:
+
+```bash
+erigon --externalcl
+```
+
 2. Install and run Lighthouse by following the official guide: [https://lighthouse-book.sigmaprime.io/installation.html](https://lighthouse-book.sigmaprime.io/installation.html)
-3. Because Erigon needs a target head in order to sync, Lighthouse must be synced before Erigon can synchronize. The fastest way to synchronize Lighthouse is to use one of the many public checkpoint synchronization endpoints at [https://eth-clients.github.io/checkpoint-sync-endpoints](https://eth-clients.github.io/checkpoint-sync-endpoints).
-4. To communicate with Erigon, the `--execution-endpoint` must be specified as `<erigon address>:8551`, where `<erigon address>` is either `http://localhost` or the IP address of the device running Erigon.
-5.  Lighthouse must point to the [JWT secret](../../../fundamentals/jwt) automatically created by Erigon in the `--datadir` directory.
 
-    ```bash
-    lighthouse bn \
-    --network mainnet \
-    --execution-endpoint http://localhost:8551 \
-    --execution-jwt <your-datadir>/jwt.hex \
-    --checkpoint-sync-url https://mainnet.checkpoint.sigp.io
-    ```
+3. Because Erigon needs a target head in order to sync, Lighthouse must be synced before Erigon can synchronize. The fastest way to synchronize Lighthouse is to use one of the many public checkpoint synchronization endpoints at [https://eth-clients.github.io/checkpoint-sync-endpoints](https://eth-clients.github.io/checkpoint-sync-endpoints).
+
+4. To communicate with Erigon, the `--execution-endpoint` must be specified as `<erigon address>:8551`, where `<erigon address>` is either `http://localhost` or the IP address of the device running Erigon.
+
+5. Lighthouse must point to the [JWT secret](https://docs.erigon.tech/fundamentals/jwt) automatically created by Erigon in the `--datadir` directory.
+
+```bash
+lighthouse bn \
+--network mainnet \
+--execution-endpoint http://localhost:8551 \
+--execution-jwt <your-datadir>/jwt.hex \
+--checkpoint-sync-url https://mainnet.checkpoint.sigp.io
+```
 
 Check Erigon and your chosen CL logs to make sure that the Execution Layer (EL) and CL are communicating and that your node is syncing correctly.
 
@@ -1086,13 +1080,12 @@ Check Erigon and your chosen CL logs to make sure that the Execution Layer (EL) 
 # How to run a Gnosis Chain node
 URL: https://docs.erigon.tech/get-started/easy-nodes/how-to-run-a-gnosis-chain-node
 
-
 ## 1. Prerequisites Check
 
-1. Confirm your machine meets the necessary [Hardware Requirements](/get-started/hardware-requirements) based on your desired pruning mode.
+1. Confirm your machine meets the necessary [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements) based on your desired pruning mode.
 2. **Install Docker**:
-   * For Linux, install [Docker Engine](https://docs.docker.com/engine/install).
-   * For macOS or Windows, install [Docker Desktop](https://docs.docker.com/desktop/).
+  - For Linux, install [Docker Engine](https://docs.docker.com/engine/install).
+  - For macOS or Windows, install [Docker Desktop](https://docs.docker.com/desktop/).
 
 ## 2. Configure and Launch Erigon
 
@@ -1105,7 +1098,7 @@ Create a new file named `docker-compose.yml` in a directory where you want to ma
 ```yaml
 services:
   erigon:
-    image: erigontech/erigon:v{ERIGON_VERSION}
+    image: erigontech/erigon:v3.6.0
     container_name: erigon-node
     restart: always
     command:
@@ -1146,16 +1139,12 @@ Set `EXTERNAL_IP` before starting, either in a `.env` file next to `docker-compo
 echo "EXTERNAL_IP=$(curl -s https://api.ipify.org)" > .env
 ```
 
-or by exporting it in your shell. Forward the `30303`, `42069`, `4000` and `4001`
-ports on your router as well, otherwise peers still cannot reach you.
+or by exporting it in your shell. Forward the `30303`, `42069`, `4000` and `4001` ports on your router as well, otherwise peers still cannot reach you.
 
 :::warning
 ⚠️ **Action Required**: the volume path should be changed to suit your setup — replace `/path/to/erigon/data` with a valid, empty directory on your machine where you want Erigon to store its files.
 
-The container runs as UID/GID `1000`, so the directory must be writable by that
-user — `sudo chown -R 1000:1000 /path/to/erigon/data`. See
-[Permission denied inside Docker](/help-center/common-errors-and-solutions) if
-you hit a `permission denied` error on startup.
+The container runs as UID/GID `1000`, so the directory must be writable by that user — `sudo chown -R 1000:1000 /path/to/erigon/data`. See [Permission denied inside Docker](https://docs.erigon.tech/help-center/common-errors-and-solutions) if you hit a `permission denied` error on startup.
 :::
 
 ### **B. Launch the Node and Monitor Progress**
@@ -1166,9 +1155,7 @@ Open your terminal in the directory where you saved `docker-compose.yml`. To sta
 docker compose up
 ```
 
-That keeps the logs in the foreground, which is what you want the first time.
-Once you are happy with the configuration, start it detached so the node keeps
-running after you close the terminal:
+That keeps the logs in the foreground, which is what you want the first time. Once you are happy with the configuration, start it detached so the node keeps running after you close the terminal:
 
 ```bash
 docker compose up -d
@@ -1178,14 +1165,14 @@ and follow the logs when you need them with `docker compose logs -f`.
 
 ## Flag explanation
 
-* `--chain=gnosis` specifies to run on Gnosis Chain, use `--chain=chiado` for Chiado testnet
-* Add `--prune.mode=minimal` to run minimal [Pruning Mode](/fundamentals/pruning-modes) or `--prune.mode=archive` to run an archive node
-* `--datadir=/var/lib/erigon` has to name the same path as the container side of the volume mount. Without it Erigon writes to its default location inside the container instead of your mounted directory, and the data ends up in an anonymous Docker volume rather than where you pointed it
-* `--http.addr=0.0.0.0 --http.api=eth,web3,net,debug,trace,txpool` to use RPC and e.g. be able to connect your [web3 wallet](/fundamentals/web3-wallet). `0.0.0.0` is the address *inside* the container, which is what lets Docker forward to it at all; the `127.0.0.1:8545:8545` port mapping is what keeps it off your LAN. Change that mapping to `8545:8545` only if you intend to expose RPC to other machines
-* `--nat=extip:<your public IP>` and `--caplin.nat=extip:<your public IP>` advertise a reachable address so other nodes can dial you — the first for the execution layer, the second for Caplin. Without them, and without the forwarded ports, the node still syncs but only through connections it opens itself
-* `--torrent.download.rate` is deliberately not set above, because its default of `512mb` (megabytes per second) is already the maximum this recipe would ask for. During initial sync Erigon uses the full allowance, which is what you want on a dedicated machine. Add the flag only to **lower** the cap if you share the machine with other work (e.g. `--torrent.download.rate=128mb`), or set `--torrent.download.rate=Inf` to remove the limit entirely.
+- `--chain=gnosis` specifies to run on Gnosis Chain, use `--chain=chiado` for Chiado testnet
+- Add `--prune.mode=minimal` to run minimal [Pruning Mode](https://docs.erigon.tech/fundamentals/pruning-modes) or `--prune.mode=archive` to run an archive node
+- `--datadir=/var/lib/erigon` has to name the same path as the container side of the volume mount. Without it Erigon writes to its default location inside the container instead of your mounted directory, and the data ends up in an anonymous Docker volume rather than where you pointed it
+- `--http.addr=0.0.0.0 --http.api=eth,web3,net,debug,trace,txpool` to use RPC and e.g. be able to connect your [web3 wallet](https://docs.erigon.tech/fundamentals/web3-wallet). `0.0.0.0` is the address *inside* the container, which is what lets Docker forward to it at all; the `127.0.0.1:8545:8545` port mapping is what keeps it off your LAN. Change that mapping to `8545:8545` only if you intend to expose RPC to other machines
+- `--nat=extip:<your public IP>` and `--caplin.nat=extip:<your public IP>` advertise a reachable address so other nodes can dial you — the first for the execution layer, the second for Caplin. Without them, and without the forwarded ports, the node still syncs but only through connections it opens itself
+- `--torrent.download.rate` is deliberately not set above, because its default of `512mb` (megabytes per second) is already the maximum this recipe would ask for. During initial sync Erigon uses the full allowance, which is what you want on a dedicated machine. Add the flag only to **lower** the cap if you share the machine with other work (e.g. `--torrent.download.rate=128mb`), or set `--torrent.download.rate=Inf` to remove the limit entirely.
 
-When you get familiar with running Erigon from CLI you may also consider [staking](/staking/caplin) and/or run a Gnosis node with an [external Consensus Layer](/get-started/easy-nodes/how-to-run-a-gnosis-chain-node/gnosis-with-an-external-cl).
+When you get familiar with running Erigon from CLI you may also consider [staking](https://docs.erigon.tech/staking/caplin) and/or run a Gnosis node with an [external Consensus Layer](https://docs.erigon.tech/get-started/easy-nodes/how-to-run-a-gnosis-chain-node/gnosis-with-an-external-cl).
 
 :::tip
 Press `Ctrl+C` in your terminal to stop Erigon.
@@ -1193,15 +1180,12 @@ Press `Ctrl+C` in your terminal to stop Erigon.
 
 ## Host networking as an alternative
 
-Publishing each port individually is explicit, but Docker's NAT is also what
-makes `--nat=extip:...` necessary in the first place. Adding `network_mode:
-host` to the service instead gives the container the host's network stack
-directly, so peers see the host's own address and there is nothing to map:
+Publishing each port individually is explicit, but Docker's NAT is also what makes `--nat=extip:...` necessary in the first place. Adding `network_mode: host` to the service instead gives the container the host's network stack directly, so peers see the host's own address and there is nothing to map:
 
 ```yaml
 services:
   erigon:
-    image: erigontech/erigon:v{ERIGON_VERSION}
+    image: erigontech/erigon:v3.6.0
     network_mode: host
     command:
       - --chain=gnosis
@@ -1218,24 +1202,17 @@ services:
 
 Two things change with it, and both matter:
 
-* the `ports:` section is ignored — port publishing does not apply, so the
-  firewall on the host is what governs access;
-* every listener binds on the host, so anything you do not want exposed must be
-  bound explicitly to `127.0.0.1`. That is why RPC, the Engine API and the
-  internal gRPC address are pinned to loopback above. `--nat` and `--caplin.nat`
-  are no longer needed for the container, though you still need the p2p ports
-  forwarded on your router.
+- the `ports:` section is ignored — port publishing does not apply, so the firewall on the host is what governs access;
+- every listener binds on the host, so anything you do not want exposed must be bound explicitly to `127.0.0.1`. That is why RPC, the Engine API and the internal gRPC address are pinned to loopback above. `--nat` and `--caplin.nat` are no longer needed for the container, though you still need the p2p ports forwarded on your router.
 
-Host networking is Linux-only in practice; on Docker Desktop for macOS and
-Windows it does not behave the same way, so keep the published-ports form there.
+Host networking is Linux-only in practice; on Docker Desktop for macOS and Windows it does not behave the same way, so keep the published-ports form there.
 
-Additional flags can be added to [configure](/fundamentals/configuring-erigon/) Erigon with several options.
+Additional flags can be added to [configure](https://docs.erigon.tech/fundamentals/configuring-erigon) Erigon with several options.
 
 ---
 
 # Gnosis Chain with an external CL
 URL: https://docs.erigon.tech/get-started/easy-nodes/how-to-run-a-gnosis-chain-node/gnosis-with-an-external-cl
-
 
 Alternatively, you can also run a Gnosis Chain node as an Execution Layer (EL) and couple it with an external Consensus Layer (CL). Here is an example of configuration with **Lighthouse**.
 
@@ -1249,22 +1226,16 @@ erigon --chain=gnosis --externalcl
 
 If your CL client is on a different device, add the following flags:
 
-* `--authrpc.addr <this-host-LAN-IP>` — the Engine API listens on localhost by default, so it has to be widened for a remote CL. Read the warning below before reaching for `0.0.0.0`;
-* `--authrpc.vhosts <CL_host>` where `<CL_host>` is the source host or the appropriate hostname that your CL client is using.
+- `--authrpc.addr <this-host-LAN-IP>` — the Engine API listens on localhost by default, so it has to be widened for a remote CL. Read the warning below before reaching for `0.0.0.0`;
+- `--authrpc.vhosts <CL_host>` where `<CL_host>` is the source host or the appropriate hostname that your CL client is using.
 
 :::warning
-The Engine API drives block processing, so anything that can reach it and holds
-your JWT secret controls the node. Only widen it when the CL really is on
-another machine, and protect the endpoint when you do:
+The Engine API drives block processing, so anything that can reach it and holds your JWT secret controls the node. Only widen it when the CL really is on another machine, and protect the endpoint when you do:
 
-* prefer the specific interface — `--authrpc.addr <this-host-LAN-IP>` — over
-  `0.0.0.0`, which listens on every interface including any public one;
-* restrict port `8551` at the firewall to the CL host's address, and never
-  expose it to the internet;
-* treat `--authrpc.vhosts` as a `Host`-header check, not a network control: it
-  is not a substitute for a firewall rule;
-* keep `jwt.hex` readable only by the accounts that need it, and copy it to the
-  CL host over a private channel.
+- prefer the specific interface — `--authrpc.addr <this-host-LAN-IP>` — over `0.0.0.0`, which listens on every interface including any public one;
+- restrict port `8551` at the firewall to the CL host's address, and never expose it to the internet;
+- treat `--authrpc.vhosts` as a `Host`-header check, not a network control: it is not a substitute for a firewall rule;
+- keep `jwt.hex` readable only by the accounts that need it, and copy it to the CL host over a private channel.
 :::
 
 ### 2. Install Lighthouse
@@ -1274,12 +1245,7 @@ Install Lighthouse, following instructions at [https://lighthouse-book.sigmaprim
 The official pre-built binaries already support Gnosis Chain and Chiado, so no special build is required. You can confirm this with `lighthouse --help`, which lists `gnosis` and `chiado` among the accepted `--network` values.
 
 :::tip
-Track Lighthouse releases and keep it current, the same way you would Erigon.
-Beyond fixes and performance work, a consensus client carries the fork schedule
-it was built with: a version released before an upcoming hard fork may not
-follow the chain through it, which stalls your execution layer too. Watch the
-[Lighthouse releases](https://github.com/sigp/lighthouse/releases) page and
-upgrade before scheduled forks, not after.
+Track Lighthouse releases and keep it current, the same way you would Erigon. Beyond fixes and performance work, a consensus client carries the fork schedule it was built with: a version released before an upcoming hard fork may not follow the chain through it, which stalls your execution layer too. Watch the [Lighthouse releases](https://github.com/sigp/lighthouse/releases) page and upgrade before scheduled forks, not after.
 :::
 
 :::note
@@ -1301,29 +1267,29 @@ Because Erigon needs a target head in order to sync, Lighthouse must be synced b
 
 To communicate with Erigon, the execution endpoint must be specified as `<erigon address>:8551`, where `<erigon address>` is either `http://localhost` or the IP address of the device running Erigon.
 
-1.  Lighthouse must point to the [JWT secret](../../../fundamentals/jwt) automatically created by Erigon in the `--datadir` directory. In the following example the default data directory is used.
+1. Lighthouse must point to the [JWT secret](https://docs.erigon.tech/fundamentals/jwt) automatically created by Erigon in the `--datadir` directory. In the following example the default data directory is used.
 
-    ```bash
-    lighthouse bn \
-    --network gnosis \
-    --datadir=data \
-    --http \
-    --execution-endpoint http://localhost:8551 \
-    --execution-jwt /home/user/.local/share/erigon/jwt.hex \
-    --checkpoint-sync-url "https://checkpoint.gnosischain.com"
-    ```
+```bash
+lighthouse bn \
+--network gnosis \
+--datadir=data \
+--http \
+--execution-endpoint http://localhost:8551 \
+--execution-jwt /home/user/.local/share/erigon/jwt.hex \
+--checkpoint-sync-url "https://checkpoint.gnosischain.com"
+```
 
-    Here is an example of Lighthouse running the Chiado testnet:
+Here is an example of Lighthouse running the Chiado testnet:
 
-    ```bash
-    lighthouse bn \
-    --network chiado \
-    --datadir=data \
-    --http \
-    --execution-endpoint http://localhost:8551 \
-    --execution-jwt /home/user/.local/share/erigon/jwt.hex \
-    --checkpoint-sync-url "https://checkpoint.chiadochain.net"
-    ```
+```bash
+lighthouse bn \
+--network chiado \
+--datadir=data \
+--http \
+--execution-endpoint http://localhost:8551 \
+--execution-jwt /home/user/.local/share/erigon/jwt.hex \
+--checkpoint-sync-url "https://checkpoint.chiadochain.net"
+```
 
 Check the Erigon and Lighthouse logs to make sure that the EL and CL are communicating and that your node is syncing correctly.
 
@@ -1333,8 +1299,6 @@ Check the Erigon and Lighthouse logs to make sure that the EL and CL are communi
 URL: https://docs.erigon.tech/fundamentals
 
 Core concepts and day-to-day operations for running a healthy Erigon node.
-
-## Sections
 
 - [Basic Usage](https://docs.erigon.tech/fundamentals/basic-usage): Command-line flags, common arguments, and first steps running the Erigon binary.
 - [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes): Full, minimal, and archive sync explained — choose the right mode for your use case.
@@ -1350,8 +1314,9 @@ Core concepts and day-to-day operations for running a healthy Erigon node.
 # Basic Usage
 URL: https://docs.erigon.tech/fundamentals/basic-usage
 
-
 Erigon is mainly operated through the command line. The commands may vary based on your installation method.
+
+**Pre-Built Binaries**
 
 Open your terminal and simply start Erigon with the command:
 
@@ -1359,10 +1324,15 @@ Open your terminal and simply start Erigon with the command:
 erigon [options]
 ```
 
-* You can use Docker Compose like in this [example](/get-started/easy-nodes/how-to-run-an-ethereum-node#a-create-the-configuration-file)
-*   Alternatively you can use the Docker syntax, for example:
+**Docker**
 
-    `docker run -it erigontech/erigon:v{ERIGON_VERSION} [options]`
+- You can use Docker Compose like in this [example](https://docs.erigon.tech/get-started/easy-nodes/how-to-run-an-ethereum-node#a-create-the-configuration-file)
+
+- Alternatively you can use the Docker syntax, for example:
+
+`docker run -it erigontech/erigon:v3.6.0 [options]`
+
+**Built from Source**
 
 Open your terminal and move to the directory where you installed Erigon
 
@@ -1375,6 +1345,8 @@ You can then start Erigon with the below command:
 ```shell
 ./build/bin/erigon [options]
 ```
+
+**Windows**
 
 To run Erigon after a native compilation, enter the following command in your Command Prompt or PowerShell:
 
@@ -1398,7 +1370,7 @@ The all-in-one client is the preferred option for most users:
 
 This CLI command allows you to run an Ethereum **full node** where every process is integrated and no special configuration is needed.
 
-The default Consensus Layer utilized is [Caplin](caplin), the Erigon flagship embedded CL.
+The default Consensus Layer utilized is [Caplin](https://docs.erigon.tech/fundamentals/caplin), the Erigon flagship embedded CL.
 
 ## Example of configuration
 
@@ -1420,22 +1392,27 @@ To run Erigon with RPC Daemon, TxPool, and other components in a single process 
 
 ### Flags of Interest
 
-*   Default data directory is `/home/usr/.local/share/erigon`. If you want to store Erigon files in a non-default location, use the flag:
+- Default data directory is `/home/usr/.local/share/erigon`. If you want to store Erigon files in a non-default location, use the flag:
 
-    ```bash
-    --datadir=/desired/path/to/datadir
-    ```
-* The `--chain=mainnet` flag is set by default for Erigon to sync with the Ethereum mainnet. To explore other network options, check the [Supported Networks](supported-networks) section. For quick testing, consider selecting a testnet.
-* `--log.dir.path` dictates where [logs](logs) will be output - useful for sending reports to the Erigon team when issues occur.
-* Based on the [pruning mode](pruning-modes) you want to run you can add `--prune.mode=archive` to run an archive node, `--prune.mode=full` for a full node (default value) or `--prune.mode=minimal` for a minimal node.
-* `--http.addr=0.0.0.0 --http.api=eth,web3,net,debug,trace,txpool` to use [RPC Service](../interacting-with-erigon/) and e.g. be able to connect your [wallet](web3-wallet).
-* `--torrent.download.rate` sets the torrent download rate cap. The default is `512mb` (megabytes per second). During initial sync Erigon will use the full allowance — on a dedicated machine this is fine, but if you share the machine with other work you may want to lower it (e.g. `--torrent.download.rate=128mb`). Set `--torrent.download.rate=Inf` to remove the limit entirely.
+```bash
+--datadir=/desired/path/to/datadir
+```
+
+- The `--chain=mainnet` flag is set by default for Erigon to sync with the Ethereum mainnet. To explore other network options, check the [Supported Networks](https://docs.erigon.tech/fundamentals/supported-networks) section. For quick testing, consider selecting a testnet.
+
+- `--log.dir.path` dictates where [logs](https://docs.erigon.tech/fundamentals/logs) will be output - useful for sending reports to the Erigon team when issues occur.
+
+- Based on the [pruning mode](https://docs.erigon.tech/fundamentals/pruning-modes) you want to run you can add `--prune.mode=archive` to run an archive node, `--prune.mode=full` for a full node (default value) or `--prune.mode=minimal` for a minimal node.
+
+- `--http.addr=0.0.0.0 --http.api=eth,web3,net,debug,trace,txpool` to use [RPC Service](https://docs.erigon.tech/interacting-with-erigon) and e.g. be able to connect your [wallet](https://docs.erigon.tech/fundamentals/web3-wallet).
+
+- `--torrent.download.rate` sets the torrent download rate cap. The default is `512mb` (megabytes per second). During initial sync Erigon will use the full allowance — on a dedicated machine this is fine, but if you share the machine with other work you may want to lower it (e.g. `--torrent.download.rate=128mb`). Set `--torrent.download.rate=Inf` to remove the limit entirely.
 
 To stop the Erigon node you can use the `CTRL+C` command.
 
 Additional flags can be added to configure the node with several options.
 
-- [configuring-erigon](configuring-erigon/)
+- [configuring-erigon](https://docs.erigon.tech/fundamentals/configuring-erigon)
 
 ## How do I know it's syncing?
 
@@ -1443,7 +1420,7 @@ Once your node is running, there are two ways to confirm it is making progress a
 
 ### 1. Read the live log line
 
-Erigon's logs are organized by [staged sync](logs#staged-synchronization-architecture). Every log line emitted by the sync engine is prefixed with the current stage and its position in the pipeline. For example:
+Erigon's logs are organized by [staged sync](https://docs.erigon.tech/fundamentals/logs#staged-synchronization-architecture). Every log line emitted by the sync engine is prefixed with the current stage and its position in the pipeline. For example:
 
 ```text
 INFO[02-20|15:00:00.123] [4/8 Bodies] Downloading block bodies   block=18234567 ...
@@ -1451,7 +1428,7 @@ INFO[02-20|15:00:00.123] [4/8 Bodies] Downloading block bodies   block=18234567 
 
 The prefix `[4/8 Bodies]` means: *"stage 4 of 8, currently in the Bodies stage"*. As stages complete, the prefix advances (`[5/8 Senders]`, `[6/8 Execution]`, …) until you reach `[8/8 Finish]`, at which point the node is at the chain tip.
 
-The full ordered stage list is in [Logs → Stage Definitions](logs#stage-definitions).
+The full ordered stage list is in [Logs → Stage Definitions](https://docs.erigon.tech/fundamentals/logs#stage-definitions).
 
 ### 2. Query the JSON-RPC
 
@@ -1463,11 +1440,11 @@ curl -s -X POST -H "Content-Type: application/json" \
   http://localhost:8545
 ```
 
-* While syncing, the result is an object with `currentBlock`, `highestBlock`, and a `stages` array (one entry per stage, with `{stage_name, block_number}`). Subtract `currentBlock` from `highestBlock` to see how many blocks remain; the `stages` array gives you the same per-stage progress as the log prefix above. (`startingBlock` is also returned but is hardcoded to `"0x0"` and carries no meaningful info.)
-* Once fully synced, the result is simply `false`.
+- While syncing, the result is an object with `currentBlock`, `highestBlock`, and a `stages` array (one entry per stage, with `{stage_name, block_number}`). Subtract `currentBlock` from `highestBlock` to see how many blocks remain; the `stages` array gives you the same per-stage progress as the log prefix above. (`startingBlock` is also returned but is hardcoded to `"0x0"` and carries no meaningful info.)
+- Once fully synced, the result is simply `false`.
 
 :::tip
-For a quick reference on monitoring sync progress (including using AI assistants via MCP), see the [Frequently Asked Questions](/help-center/frequently-asked-questions-faqs).
+For a quick reference on monitoring sync progress (including using AI assistants via MCP), see the [Frequently Asked Questions](https://docs.erigon.tech/help-center/frequently-asked-questions-faqs).
 :::
 
 ## Help
@@ -1513,7 +1490,6 @@ This command will display a list of convenience commands available in the Makefi
  hive:                              run hive test suite locally using docker e.g. OUTPUT_DIR=~/results/hive SIM=ethereum/engine make hive
  automated-tests                    run automated tests (BUILD_ERIGON=0 to prevent erigon build with local image tag)
  help:                              print commands help
-
 ```
 
 For example, from your Erigon 3 installation directory, run:
@@ -1528,7 +1504,6 @@ This will execute the clean target in the Makefile, which cleans the `go cache`,
 
 # Architecture
 URL: https://docs.erigon.tech/fundamentals/architecture
-
 
 Erigon is an Ethereum execution-layer client designed around three goals: **low disk footprint**, **predictable performance**, and **operational simplicity**. This page explains how those goals shape its internal design so you know what is happening when you run the binary.
 
@@ -1563,7 +1538,7 @@ flowchart TB
     class Datadir storage
 ```
 
-Every box above is a Go package that runs **inside the `erigon` process by default**. The same binary can also be split into independent processes — see [Modular processes](#modular-processes).
+Every box above is a Go package that runs **inside the `erigon` process by default**. The same binary can also be split into independent processes — see [Modular processes](https://docs.erigon.tech/fundamentals/architecture#modular-processes).
 
 ## Staged sync
 
@@ -1581,9 +1556,7 @@ A simplified pipeline:
 6. Finalization → update the canonical chain
 ```
 
-This is the order of Erigon 3's default stage list. There is no separate
-`Commitment` stage — trie/state-root computation runs *inside* Execution (see
-below).
+This is the order of Erigon 3's default stage list. There is no separate `Commitment` stage — trie/state-root computation runs *inside* Execution (see below).
 
 Two consequences:
 
@@ -1603,14 +1576,14 @@ Use the all-in-one binary by default. Split out a service when you have a concre
 - **Replacement** — substitute Erigon's TxPool or Sentry with your own implementation.
 - **Security** — keep the p2p surface (Sentry) on a separate host from the JSON-RPC surface (RPC Daemon).
 
-See the [Modules](modules) section for per-component documentation, and the repository's [docker-compose.yml](https://github.com/erigontech/erigon/blob/main/docker-compose.yml) for a worked split-process example.
+See the [Modules](https://docs.erigon.tech/fundamentals/modules) section for per-component documentation, and the repository's [docker-compose.yml](https://github.com/erigontech/erigon/blob/main/docker-compose.yml) for a worked split-process example.
 
 ## Storage model
 
 Erigon stores everything under a single **datadir**. Two kinds of files live there:
 
 | Kind | Path | Role | Mutable? |
-|------|------|------|----------|
+| --- | --- | --- | --- |
 | Active state | `chaindata/` | Recent state and recent blocks, served from MDBX | Yes |
 | Historical data | `snapshots/` | Older blocks, history, indices — distributed as immutable `.seg` files | No |
 
@@ -1619,7 +1592,7 @@ This split is what enables Erigon's small disk footprint relative to other archi
 - **`chaindata/` is small (~22 GB on Ethereum mainnet, rarely more than 25 GB)** because it only holds latest state and recently-updated values.
 - **`snapshots/` is large but content-addressed.** Once a `.seg` file is finalised it is the *same file* on every Erigon node in the world — meaning it can be distributed via BitTorrent and verified by hash. There is no rewrite-amplification penalty for keeping history.
 
-For the exact directory layout, file sizes on mainnet, and how to split storage across fast/slow disks, see [Database](database) and [Optimizing Storage](optimizing-storage).
+For the exact directory layout, file sizes on mainnet, and how to split storage across fast/slow disks, see [Database](https://docs.erigon.tech/fundamentals/database) and [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage).
 
 ## Embedded consensus (Caplin)
 
@@ -1627,7 +1600,7 @@ Erigon ships with **Caplin**, a built-in consensus-layer client. Caplin runs emb
 
 If you prefer to run an external CL (Lighthouse, Prysm, Teku, Nimbus), pass `--externalcl` and connect via the standard Engine API. The Engine-API path is identical to what Geth, Besu, or Reth exposes.
 
-See [Caplin](caplin) for full details.
+See [Caplin](https://docs.erigon.tech/fundamentals/caplin) for full details.
 
 ## Flat key-value state
 
@@ -1643,30 +1616,29 @@ This is the single largest reason Erigon's RPC performance stays flat under load
 Erigon 3 has one sync pipeline. The user-facing choice is *what to retain after sync*, controlled by `--prune.mode`:
 
 | Mode | Retained | Use case |
-|---|---|---|
+| --- | --- | --- |
 | `archive` | Entire state history + all blocks | Indexers, block explorers, deep historical queries |
 | `full` (default) | Latest state + a rolling window of recent blocks (the default prune distance, ~262k blocks) | Most users, dApps, validators |
 | `blocks` | All blocks, but no state history | Full block/receipt history without archive-size state |
 | `minimal` | Latest state only (shortest block window) | Solo stakers, constrained hardware |
 
-See [Pruning Modes](pruning-modes) for the full comparison.
+See [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes) for the full comparison.
 
 ## Where to go next
 
-- [Database](database) — datadir layout, MDBX internals, mainnet sizing
-- [Modules](modules) — running RPC Daemon, TxPool, Sentry, Downloader as separate processes
-- [Pruning Modes](pruning-modes) — choosing what history to keep
-- [Optimizing Storage](optimizing-storage) — splitting datadir across fast and slow disks
+- [Database](https://docs.erigon.tech/fundamentals/database) — datadir layout, MDBX internals, mainnet sizing
+- [Modules](https://docs.erigon.tech/fundamentals/modules) — running RPC Daemon, TxPool, Sentry, Downloader as separate processes
+- [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes) — choosing what history to keep
+- [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage) — splitting datadir across fast and slow disks
 
 ---
 
 # Database
 URL: https://docs.erigon.tech/fundamentals/database
 
-
 Erigon stores all chain data under a single **datadir**. Understanding what lives where is useful when you size hardware, debug disk-usage issues, or split storage across fast and slow drives.
 
-This page covers the *what* and *where* of Erigon's data. For the *why* — flat KV state, immutable snapshots — see [Architecture](architecture). For operational tuning (symlinks, multi-disk layout), see [Optimizing Storage](optimizing-storage).
+This page covers the *what* and *where* of Erigon's data. For the *why* — flat KV state, immutable snapshots — see [Architecture](https://docs.erigon.tech/fundamentals/architecture). For operational tuning (symlinks, multi-disk layout), see [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage).
 
 ## The datadir at a glance
 
@@ -1707,7 +1679,7 @@ Once a snapshot file is finalised it is the same bytes on every Erigon node in t
 Snapshots are organised into several subdirectories. The main ones are:
 
 | Directory | What it holds | Access pattern |
-|---|---|---|
+| --- | --- | --- |
 | `snapshots/domain/` | Latest value per (domain, key). 6 domains: the 4 state domains (`account`, `storage`, `code`, `commitment`) plus 2 receipt domains (`receipt`, `rcache`) | Sequential + point lookup |
 | `snapshots/history/` | Every historical value per (domain, key, txn) | Point lookup keyed by transaction |
 | `snapshots/idx/` | Inverted indices over history — answers "which transactions touched key X?" | Search / filter / set intersection |
@@ -1717,10 +1689,7 @@ Snapshots are organised into several subdirectories. The main ones are:
 
 - You can replay a single historical transaction without re-executing its block.
 - If an account changes V1 → V2 → V1 within one block, `debug_getModifiedAccountsByNumber` correctly returns it.
-- Erigon stores compact per-transaction receipt *metadata* — cumulative gas used, blob gas used, log index — in a
-  **required** receipt domain. Full receipts (with logs) live in a separate cache domain that is **off by default** in
-  every prune mode (opt in with `--prune.include-receipts`). When a full receipt isn't cached, it is reconstructed on
-  demand, re-deriving logs by re-execution.
+- Erigon stores compact per-transaction receipt *metadata* — cumulative gas used, blob gas used, log index — in a **required** receipt domain. Full receipts (with logs) live in a separate cache domain that is **off by default** in every prune mode (opt in with `--prune.include-receipts`). When a full receipt isn't cached, it is reconstructed on demand, re-deriving logs by re-execution.
 
 ## What does it cost on disk?
 
@@ -1740,7 +1709,7 @@ Block segments — headers, bodies and transactions — sit directly in `snapsho
 
 Data that is off by default is excluded above. On the same mainnet node it would add 441 GB for the receipts cache (`--prune.include-receipts`), 4.4 TB for commitment history (`--prune.include-commitment-history`), and 2.5 TB for the Caplin block, blob and state archive.
 
-Each column is one node, so totals differ slightly from the headline figures on [Hardware Requirements](../get-started/hardware-requirements), which are measured on freshly synced nodes.
+Each column is one node, so totals differ slightly from the headline figures on [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements), which are measured on freshly synced nodes.
 
 ## Why `chaindata/` stays so small
 
@@ -1759,14 +1728,14 @@ Deleting `chaindata/` is **recoverable but not free**: it discards the latest mu
 - **`--batchSize`** — size of the Execution stage's in-memory buffer before it is flushed to MDBX. Default: `512M`. Raising it (for example `--batchSize 1G` or higher) can speed up execution-heavy sync at the cost of more RAM.
 - **`--db.size.limit`** — caps the MDBX file size. Useful when running multiple Erigon instances on one disk to prevent one from starving the others.
 - **`--db.read.concurrency`** — maximum number of concurrent open MDBX read transactions (the read-tx semaphore). Raise it for nodes serving heavy parallel RPC (for example a high-throughput RPC daemon against the same datadir). Lowering it does not reduce read concurrency: a value below the parallel-execution worker count would deadlock, since each worker holds a long-lived read transaction, so it is silently raised to the worker count. Lower `--exec.workers` instead.
-- **Symlinks for tiered storage.** Place `chaindata/` and `snapshots/domain/` on fast NVMe, leave `snapshots/idx/` and `snapshots/history/` on cheaper SATA. See [Optimizing Storage](optimizing-storage) for the recipe.
+- **Symlinks for tiered storage.** Place `chaindata/` and `snapshots/domain/` on fast NVMe, leave `snapshots/idx/` and `snapshots/history/` on cheaper SATA. See [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage) for the recipe.
 
 ## Safe-to-delete subdirectories
 
 If you need to reclaim space without resyncing from scratch:
 
 | Directory | Effect of deletion |
-|---|---|
+| --- | --- |
 | `txpool/` | Pending transactions lost; pool refills from peers within minutes |
 | `nodes/` | Peer cache lost; reconnects on restart |
 | `temp/` | Cleaned automatically at startup anyway |
@@ -1775,49 +1744,44 @@ If you need to reclaim space without resyncing from scratch:
 
 ## Where to go next
 
-- [Architecture](architecture) — how this storage model fits into staged sync and the flat-KV state design
-- [Optimizing Storage](optimizing-storage) — concrete recipes for splitting the datadir across multiple disks
-- [Hardware Requirements](../get-started/hardware-requirements) — disk-size numbers for each `--prune.mode`
-- [Pruning Modes](pruning-modes) — choosing what history to keep
+- [Architecture](https://docs.erigon.tech/fundamentals/architecture) — how this storage model fits into staged sync and the flat-KV state design
+- [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage) — concrete recipes for splitting the datadir across multiple disks
+- [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements) — disk-size numbers for each `--prune.mode`
+- [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes) — choosing what history to keep
 
 ---
 
 # Pruning Modes
 URL: https://docs.erigon.tech/fundamentals/pruning-modes
 
-
 Erigon 3 supports four pruning modes that control how much chain history your node retains. Choose based on your use case — most users should run a Full Node.
 
-| **Pruning Mode**                                                        | **Flag**               | **Data Retained**                                                                                   | **Primary Use Case**                                                                     |
-| --------------------------------------------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| Full Node(Default) | `--prune.mode=full`    | State and block data within the EIP-8252 window (last 262,144 blocks, ~36 days)                     | General users, DApp interaction, fastest sync.                                           |
-| [Minimal Node](#minimal-node)                         | `--prune.mode=minimal` | State and block data within the last 100,000 blocks (~14 days)                                      | Solo staking, users with constrained hardware, maximum privacy for sending transactions. |
-| [Historical Blocks](#blocks-node)                                     | `--prune.mode=blocks`  | All block/transaction history, plus state within the EIP-8252 window                                | Users needing historical block data for research or indexing.                            |
-| [Archive Node](#archive-node)                            | `--prune.mode=archive` | All historical state and all blocks                                                                 | Developers, researchers, and RPC providers requiring full historical state access.       |
+| **Pruning Mode** | **Flag** | **Data Retained** | **Primary Use Case** |
+| --- | --- | --- | --- |
+| [Full Node](https://docs.erigon.tech/fundamentals/pruning-modes#full-node) (Default) | `--prune.mode=full` | State and block data within the EIP-8252 window (last 262,144 blocks, ~36 days) | General users, DApp interaction, fastest sync. |
+| [Minimal Node](https://docs.erigon.tech/fundamentals/pruning-modes#minimal-node) | `--prune.mode=minimal` | State and block data within the last 100,000 blocks (~14 days) | Solo staking, users with constrained hardware, maximum privacy for sending transactions. |
+| [Historical Blocks](https://docs.erigon.tech/fundamentals/pruning-modes#blocks-node) | `--prune.mode=blocks` | All block/transaction history, plus state within the EIP-8252 window | Users needing historical block data for research or indexing. |
+| [Archive Node](https://docs.erigon.tech/fundamentals/pruning-modes#archive-node) | `--prune.mode=archive` | All historical state and all blocks | Developers, researchers, and RPC providers requiring full historical state access. |
 
-By **default**, Erigon run as a [full node](#full-node), to change its behavior use the flag `--prune.mode <value>`.
+By **default**, Erigon run as a [full node](https://docs.erigon.tech/fundamentals/pruning-modes#full-node), to change its behavior use the flag `--prune.mode <value>`.
 
 In order to switch type of node, you must first delete the `/chaindata` folder in the chosen `--datadir` directory and re-sync from scratch. Pruning is not reversible — data a mode has already discarded can only be recovered by re-syncing — so pick the mode that covers the history you need before you start.
 
 :::tip
 **Persisting receipts**, which are pre-calculated receipts, increase the requests-per-second (RPS) and improve the latency and throughput of all receipts and logs-related RPC calls.
 
-As of v3.6 they are disabled by default in every pruning mode (previously they were enabled by default for all modes
-except Archive); enable them with the flag `--prune.include-receipts` (the former `--persist.receipts` still works as an
-alias). Without them, receipts and logs are re-derived on demand from state history, so the related RPC calls keep
-working within the node's state-history window, just with higher latency. On a Historical Blocks node, persisted
-receipts additionally extend receipts and logs availability from the state-history window back to genesis.
+As of v3.6 they are disabled by default in every pruning mode (previously they were enabled by default for all modes except Archive); enable them with the flag `--prune.include-receipts` (the former `--persist.receipts` still works as an alias). Without them, receipts and logs are re-derived on demand from state history, so the related RPC calls keep working within the node's state-history window, just with higher latency. On a Historical Blocks node, persisted receipts additionally extend receipts and logs availability from the state-history window back to genesis.
 :::
 
 ## Archive node
 
-Ethereum's state refers to account balances, contracts, and consensus data. Archive nodes retain all historical state and require more **disk space.** However, Erigon 3 has consistently reduced the [disk space](../get-started/hardware-requirements.mdx#disk-size-and-ram-requirements) requirements for running an archive node, rendering it more affordable and accessible to a broader range of users.
+Ethereum's state refers to account balances, contracts, and consensus data. Archive nodes retain all historical state and require more **disk space.** However, Erigon 3 has consistently reduced the [disk space](https://docs.erigon.tech/get-started/hardware-requirements#disk-size-and-ram-requirements) requirements for running an archive node, rendering it more affordable and accessible to a broader range of users.
 
 Archive are ideal for extensive research on the blockchain, developers, researchers, and RPC providers requiring a complete history of the state.
 
 ## Full node
 
-The default configuration in Erigon 3 is a Full Node. This setup is designed to offer significantly **faster sync times and reduced resource consumption** for daily operations compared to other clients. It maintains state and block data within the **EIP-8252 reorg-retention window** — the last 262,144 blocks (~36.4 days), the inactivity-leak-bounded non-finality window across which an execution-layer client must be able to reconstruct state to handle any reorg without external sync. Older blocks, receipts, and state history are pruned, so a Full Node cannot serve queries against them. For block and transaction history reaching further back, run a [Blocks Node](#blocks-node); receipts need their own flags on top, as that section explains. See [EIP-8252](https://github.com/ethereum/EIPs/pull/11601) for the rationale behind the constant.
+The default configuration in Erigon 3 is a Full Node. This setup is designed to offer significantly **faster sync times and reduced resource consumption** for daily operations compared to other clients. It maintains state and block data within the **EIP-8252 reorg-retention window** — the last 262,144 blocks (~36.4 days), the inactivity-leak-bounded non-finality window across which an execution-layer client must be able to reconstruct state to handle any reorg without external sync. Older blocks, receipts, and state history are pruned, so a Full Node cannot serve queries against them. For block and transaction history reaching further back, run a [Blocks Node](https://docs.erigon.tech/fundamentals/pruning-modes#blocks-node); receipts need their own flags on top, as that section explains. See [EIP-8252](https://github.com/ethereum/EIPs/pull/11601) for the rationale behind the constant.
 
 To keep every post-merge block instead of only the window — pruning pre-merge block data alone — set `--prune.distance.blocks=keep-post-merge`. Decide before the first start: pruning is not reversible, and block data already discarded comes back only by re-syncing.
 
@@ -1829,21 +1793,12 @@ The Minimal Node configuration (`--prune.mode=minimal`) is the smallest possible
 
 ## Blocks node
 
-The Blocks Node configuration (`--prune.mode=blocks`) keeps the **full block and transaction history** — every block
-back to genesis — while pruning **state history**. It retains state only within the EIP-8252 window (the last 262,144
-blocks), the same state-retention as a Full Node, but unlike a Full Node it never prunes older blocks. This suits users
-who need complete historical **block and transaction data** — for research, indexing, or block explorers — without
-paying the disk cost of an archive node's full historical **state**. For full-range **receipts and logs**
-(`eth_getLogs` / `eth_getBlockReceipts` back to genesis), add
-`--prune.include-receipts --prune.receipts.distance=keep-all`; with `--prune.include-receipts` alone the receipt cache
-follows the state-history window (the last 262,144 blocks), and without it receipts are re-derived from state history
-within that same window.
+The Blocks Node configuration (`--prune.mode=blocks`) keeps the **full block and transaction history** — every block back to genesis — while pruning **state history**. It retains state only within the EIP-8252 window (the last 262,144 blocks), the same state-retention as a Full Node, but unlike a Full Node it never prunes older blocks. This suits users who need complete historical **block and transaction data** — for research, indexing, or block explorers — without paying the disk cost of an archive node's full historical **state**. For full-range **receipts and logs** (`eth_getLogs` / `eth_getBlockReceipts` back to genesis), add `--prune.include-receipts --prune.receipts.distance=keep-all`; with `--prune.include-receipts` alone the receipt cache follows the state-history window (the last 262,144 blocks), and without it receipts are re-derived from state history within that same window.
 
 ---
 
 # Snapshots Management
 URL: https://docs.erigon.tech/fundamentals/snapshots-management
-
 
 Erigon stores the majority of its chain data in **snapshot files** (`.seg` segments and associated index files). These immutable, compressed files cover headers, bodies, transactions, and state history. Because snapshots can occupy hundreds of gigabytes, understanding what is on disk — and how much space each category consumes — is essential for capacity planning and node maintenance.
 
@@ -1860,7 +1815,7 @@ erigon seg du [--datadir <path>] [--json] [-v | --verbose]
 ### Flags
 
 | Flag | Description |
-|------|-------------|
+| --- | --- |
 | `--datadir <path>` | Path to the Erigon data directory. Defaults to Erigon's standard data directory (`paths.DefaultDataDir()`, OS-specific) when omitted. `seg du` has no `--chain` flag, so this default is chain-agnostic. |
 | `--json` | Output results as JSON instead of human-readable text. Useful for scripting or dashboards. |
 | `-v`, `--verbose` | Show a per-domain / per-type subcategory breakdown within each category. |
@@ -1903,7 +1858,7 @@ The estimator only sums files already on disk, so the **archive** row always equ
 The category labels below are exactly what the command prints.
 
 | Category | Contents |
-|----------|----------|
+| --- | --- |
 | `domains` | Current-state domain files (latest accounts, storage, code, commitment). Never pruned, so typically the largest category on pruned (full / minimal) nodes; on an archive node, `block segments` dominate. |
 | `block segments` | Headers, bodies, and transactions (`.seg` + index files) directly under `snapshots/`. |
 | `history` | State-history snapshots for accounts, storage, code. |
@@ -1950,15 +1905,11 @@ The JSON schema matches the `duResult` struct: top-level fields `chain`, `config
 Run `seg du` while the node is **stopped**. If Erigon is running and holds the database lock, the command falls back to `unknown` for the chain name and omits the configured mode — it will still scan snapshot files and produce size figures, but mode information will be incomplete.
 :::
 
----
-
 ## Snapshot Types (Pruning Modes)
 
-The snapshot set on disk reflects the node's **pruning mode**, and `seg du` automatically detects which mode your current files correspond to. For what each mode retains and how to choose one, see [Pruning Modes](pruning-modes).
+The snapshot set on disk reflects the node's **pruning mode**, and `seg du` automatically detects which mode your current files correspond to. For what each mode retains and how to choose one, see [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes).
 
 The `seg du` estimates table shows the projected disk footprint for each mode given the files currently present, so you can evaluate a mode change before committing to a resync.
-
----
 
 ## Upgrading Snapshots in v3.5
 
@@ -1966,13 +1917,13 @@ The `seg du` estimates table shows the projected disk footprint for each mode gi
 
 v3.5 retargets the **Full** and **Blocks** pruning modes to the EIP-8252 reorg-retention window (262,144 blocks, ~36 days), up from the previous 100,000-block window. This changes **which snapshot files are present on disk** after upgrading — most notably, full nodes prune older block segments down to the window, freeing space. Existing datadirs migrate automatically on first start.
 
-Decide before that first start if you need to keep more than the window: pruning is not reversible, and block data already discarded comes back only by re-syncing. To retain every post-merge block under Full mode, pass `--prune.distance.blocks=18446744073709551615` — v3.5 takes this option as a number; the readable `keep-post-merge` alias only exists from v3.6. `--prune.mode=blocks` keeps every block back to genesis. See [Pruning Modes](pruning-modes) for what each mode keeps.
+Decide before that first start if you need to keep more than the window: pruning is not reversible, and block data already discarded comes back only by re-syncing. To retain every post-merge block under Full mode, pass `--prune.distance.blocks=18446744073709551615` — v3.5 takes this option as a number; the readable `keep-post-merge` alias only exists from v3.6. `--prune.mode=blocks` keeps every block back to genesis. See [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes) for what each mode keeps.
 
 After the first prune pass, run `seg du` to inspect the resulting on-disk breakdown.
 
 ### Manual snapshot operations
 
-To migrate snapshots to the latest format, reset them for maximum performance after a major upgrade, or downgrade to an older snapshot format, follow the step-by-step snapshot upgrade and downgrade instructions in the [Upgrading guide](../get-started/installation/upgrading). Those commands are subcommands of `erigon snapshots` (e.g. `erigon snapshots update-to-new-ver-format --datadir /your/datadir`).
+To migrate snapshots to the latest format, reset them for maximum performance after a major upgrade, or downgrade to an older snapshot format, follow the step-by-step snapshot upgrade and downgrade instructions in the [Upgrading guide](https://docs.erigon.tech/get-started/installation/upgrading). Those commands are subcommands of `erigon snapshots` (e.g. `erigon snapshots update-to-new-ver-format --datadir /your/datadir`).
 
 :::warning
 Always **back up your `--datadir`** before running snapshot reset, upgrade, or downgrade commands.
@@ -1982,7 +1933,6 @@ Always **back up your `--datadir`** before running snapshot reset, upgrade, or d
 
 # Caplin
 URL: https://docs.erigon.tech/fundamentals/caplin
-
 
 Caplin, the innovative Erigon's embedded Consensus Layer, significantly enhances the performance, efficiency, and reliability of Ethereum infrastructure. Its groundbreaking design minimizes disk usage, facilitating faster transaction processing and bolstering network security. By integrating the consensus layer directly into the EVM-node, Caplin eliminates the need for separate disk storage, thereby reducing system complexity and enhancing overall efficiency.
 
@@ -1996,13 +1946,13 @@ Caplin is enabled by default, at which point an external consensus layer is no l
 
 Caplin also has an archive mode for historical states, blocks, and blobs. These can be enabled with the following flags:
 
-* `--caplin.states-archive`: Enables the storage and retrieval of historical state data, allowing access to past states of the blockchain for debugging, analytics, or other use cases.
-* `--caplin.blocks-archive`: Enables the storage of historical block data, making it possible to query or analyze full block history.
-* `--caplin.blobs-archive`: Enables the storage of historical blobs, ensuring access to additional off-chain data that might be required for specific applications.
+- `--caplin.states-archive`: Enables the storage and retrieval of historical state data, allowing access to past states of the blockchain for debugging, analytics, or other use cases.
+- `--caplin.blocks-archive`: Enables the storage of historical block data, making it possible to query or analyze full block history.
+- `--caplin.blobs-archive`: Enables the storage of historical blobs, ensuring access to additional off-chain data that might be required for specific applications.
 
 In addition, Caplin can backfill recent blobs for an op-node or other uses with the new flag:
 
-* `--caplin.blobs-immediate-backfill`: Backfills the last 18 days' worth of blobs to quickly populate historical blob data for operational needs or analytics.
+- `--caplin.blobs-immediate-backfill`: Backfills the last 18 days' worth of blobs to quickly populate historical blob data for operational needs or analytics.
 
 With state archival enabled, Caplin's indexing database (`<datadir>/caplin/indexing`) is pruned automatically: state rows already frozen into snapshots are deleted on the antiquary cadence, so the database holds only the un-frozen tail. The `mdbx.dat` file does not shrink when rows are pruned — freed pages are reused, bounding future growth. Set `CAPLIN_STATE_PRUNE_DISABLE=true` to turn pruning off.
 
@@ -2010,16 +1960,16 @@ With state archival enabled, Caplin's indexing database (`<datadir>/caplin/index
 
 For nodes participating in PeerDAS (EIP-7594), Caplin retains data column sidecars for a configurable window:
 
-* `--caplin.columns-keep-slots` (default: `0`): Number of slots to retain PeerDAS data column sidecars. `0` uses the chain's own spec window, `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS × SLOTS_PER_EPOCH`, so the retained slot count and the wall-clock duration it covers both follow the chain (on Ethereum mainnet, 131072 slots, ~18 days). Increase this value for DA oracle or rollup nodes that require a longer column history.
+- `--caplin.columns-keep-slots` (default: `0`): Number of slots to retain PeerDAS data column sidecars. `0` uses the chain's own spec window, `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS × SLOTS_PER_EPOCH`, so the retained slot count and the wall-clock duration it covers both follow the chain (on Ethereum mainnet, 131072 slots, ~18 days). Increase this value for DA oracle or rollup nodes that require a longer column history.
 
-Caplin can also be used for [block production](../staking/caplin), aka **staking**.
+Caplin can also be used for [block production](https://docs.erigon.tech/staking/caplin), aka **staking**.
 
 ## Beacon API Configuration
 
 When Caplin is running, it exposes a Beacon API that external tools can query. The following flags control the Beacon API server:
 
 | Flag | Default | Description |
-|------|---------|-------------|
+| --- | --- | --- |
 | `--beacon.api.addr` | `localhost` | Listening address for the Beacon API |
 | `--beacon.api.port` | `5555` | Listening port for the Beacon API |
 | `--beacon.api.cors.allow-origins` | (empty) | CORS allowed origins |
@@ -2035,12 +1985,11 @@ When Caplin is running, it exposes a Beacon API that external tools can query. T
 # CLI Reference
 URL: https://docs.erigon.tech/fundamentals/configuring-erigon
 
-
 The Erigon CLI has a wide range of flags that can be used to customize its behavior. There are 3 ways to configure Erigon, listed by priority:
 
-* [Command line options](/fundamentals/configuring-erigon/#command-line-options) (flags)
-* [Configuration file](/fundamentals/configuring-erigon/#configuration-file)
-* [Environment variables](/fundamentals/configuring-erigon/#environment-variables)
+- [Command line options](https://docs.erigon.tech/fundamentals/configuring-erigon#command-line-options) (flags)
+- [Configuration file](https://docs.erigon.tech/fundamentals/configuring-erigon#configuration-file)
+- [Environment variables](https://docs.erigon.tech/fundamentals/configuring-erigon#environment-variables)
 
 :::tip
 In order to see all the available options (flags) you must run the command:
@@ -2064,453 +2013,644 @@ Flags can be combined freely, providing a high degree of customization. Here's a
 
 These flags cover the general behavior and configuration of the Erigon client.
 
-* `--datadir value`: Specifies the data directory for the databases.
-  * Default: `/home/usr/.local/share/erigon`
-* `--ethash.dagdir value`: Sets the directory to store the ethash mining DAGs.
-  * Default: `/home/usr/.local/share/erigon-ethash`
-* `--config value`: Sets Erigon flags using a YAML/TOML file.
-* `--version, -v`: Prints the version information.
-* `--help, -h`: Displays help information.
-* `--chain value`: Sets the name of the [network](/fundamentals/supported-networks) to join.
-  * Default: `mainnet`
-* `--networkid value`: Explicitly sets the network ID.
-  * Default: `1`
-* `--identity value`: Sets a custom node name.
-* `--externalcl`: Enables the external consensus layer.
-  * Default: `false`, means that Caplin is enabled.
-* `--override.osaka value`: Manually specifies the Osaka fork time.
-  * Default: `0`
-* `--override.amsterdam value`: Manually specifies the Amsterdam fork time.
-  * Default: `0`
-* `--vmdebug`: Records information for VM and contract debugging.
-  * Default: `false`
-* `--gdbme`: Restarts Erigon under gdb for debugging.
-  * Default: `false`
-* `--ethstats value`: The reporting URL for an ethstats service.
-* `--trusted-setup-file value`: Absolute path to a `trusted_setup.json` file.
-* `--prune.include-receipts, --persist.receipts, --experiment.persist.receipts.v2`: Downloads and caches historical receipts. Without it, receipts and logs are re-derived on demand from state history, so the related RPC calls still work, just with higher latency.
-  * Default: `false` (disabled) in every prune mode
-* `--keep.stored.chain.config`: Avoids overriding the chain configuration already stored in the database.
-  * Default: `false`
+- `--datadir value`: Specifies the data directory for the databases.
+  - Default: `/home/usr/.local/share/erigon`
+
+- `--ethash.dagdir value`: Sets the directory to store the ethash mining DAGs.
+  - Default: `/home/usr/.local/share/erigon-ethash`
+
+- `--config value`: Sets Erigon flags using a YAML/TOML file.
+- `--version, -v`: Prints the version information.
+- `--help, -h`: Displays help information.
+- `--chain value`: Sets the name of the [network](https://docs.erigon.tech/fundamentals/supported-networks) to join.
+  - Default: `mainnet`
+
+- `--networkid value`: Explicitly sets the network ID.
+  - Default: `1`
+
+- `--identity value`: Sets a custom node name.
+- `--externalcl`: Enables the external consensus layer.
+  - Default: `false`, means that Caplin is enabled.
+
+- `--override.osaka value`: Manually specifies the Osaka fork time.
+  - Default: `0`
+
+- `--override.amsterdam value`: Manually specifies the Amsterdam fork time.
+  - Default: `0`
+
+- `--vmdebug`: Records information for VM and contract debugging.
+  - Default: `false`
+
+- `--gdbme`: Restarts Erigon under gdb for debugging.
+  - Default: `false`
+
+- `--ethstats value`: The reporting URL for an ethstats service.
+- `--trusted-setup-file value`: Absolute path to a `trusted_setup.json` file.
+- `--prune.include-receipts, --persist.receipts, --experiment.persist.receipts.v2`: Downloads and caches historical receipts. Without it, receipts and logs are re-derived on demand from state history, so the related RPC calls still work, just with higher latency.
+  - Default: `false` (disabled) in every prune mode
+
+- `--keep.stored.chain.config`: Avoids overriding the chain configuration already stored in the database.
+  - Default: `false`
 
 ### Development, testing, and block-production helpers
 
 These flags are mainly for dev networks, testing, or specialized block-production setups.
 
-* `--allow-insecure-unlock`: Accepted for go-ethereum CLI compatibility but currently has **no effect** — the flag is registered and settable, yet nothing in the codebase reads it and Erigon exposes no account-unlocking RPC.
-  * Default: `false`
-* `--dev-validator-seed value`: Deterministic BLS key seed for the embedded dev validator. Read only in PoS dev mode, which is selected by `--chain dev`; on any other chain the flag does nothing.
-  * Default: `devnet`
-* `--dev-validator-count value`: Number of validators for PoS dev mode (`--chain dev`).
-  * Default: `64`
-* `--dev.slot-time value`: Slot duration in seconds for PoS dev mode (`--chain dev`). Values below `2` are silently raised to `2`.
-  * Default: `6`
-* `--miner.gaslimit value`: Target gas limit for mined blocks.
-  * Default: unset — the target falls back to the chain configuration's default block gas limit, or `60000000` where the chain config does not set one. An explicit `0` is ignored rather than applied as a zero limit, so the flag only takes effect when set to a positive value.
-* `--miner.extradata value`: Block extra data set by the miner. Values longer than 32 bytes are silently truncated.
-  * Default: the client version string
-* `--experimental.bal`: Generates block access lists.
-  * Default: `false`
-* `--experimental.always-generate-changesets`: Overrides changeset generation logic.
-  * Default: `false`, derived as the inverse of the `BATCH_COMMITMENTS` environment variable (itself `true` by default). Running with `BATCH_COMMITMENTS=false` therefore flips this default to `true` unless the flag is passed explicitly.
-* `--chaos.monkey`: Testing-only flag that enables spontaneous network, consensus, and other failures.
-  * Default: `false`
+- `--allow-insecure-unlock`: Accepted for go-ethereum CLI compatibility but currently has **no effect** — the flag is registered and settable, yet nothing in the codebase reads it and Erigon exposes no account-unlocking RPC.
+  - Default: `false`
+
+- `--dev-validator-seed value`: Deterministic BLS key seed for the embedded dev validator. Read only in PoS dev mode, which is selected by `--chain dev`; on any other chain the flag does nothing.
+  - Default: `devnet`
+
+- `--dev-validator-count value`: Number of validators for PoS dev mode (`--chain dev`).
+  - Default: `64`
+
+- `--dev.slot-time value`: Slot duration in seconds for PoS dev mode (`--chain dev`). Values below `2` are silently raised to `2`.
+  - Default: `6`
+
+- `--miner.gaslimit value`: Target gas limit for mined blocks.
+  - Default: unset — the target falls back to the chain configuration's default block gas limit, or `60000000` where the chain config does not set one. An explicit `0` is ignored rather than applied as a zero limit, so the flag only takes effect when set to a positive value.
+
+- `--miner.extradata value`: Block extra data set by the miner. Values longer than 32 bytes are silently truncated.
+  - Default: the client version string
+
+- `--experimental.bal`: Generates block access lists.
+  - Default: `false`
+
+- `--experimental.always-generate-changesets`: Overrides changeset generation logic.
+  - Default: `false`, derived as the inverse of the `BATCH_COMMITMENTS` environment variable (itself `true` by default). Running with `BATCH_COMMITMENTS=false` therefore flips this default to `true` unless the flag is passed explicitly.
+
+- `--chaos.monkey`: Testing-only flag that enables spontaneous network, consensus, and other failures.
+  - Default: `false`
 
 ### Database and Caching
 
-These flags control database performance and memory usage. See [Database](/fundamentals/database) for the on-disk layout.
+These flags control database performance and memory usage. See [Database](https://docs.erigon.tech/fundamentals/database) for the on-disk layout.
 
-* `--db.pagesize value`: Sets the fixed page size for the database.
-  * Default: `4KB`
-* `--db.size.limit value`: Sets a runtime limit on the chaindata database size.
-  * Default: `1TB`
-* `--db.writemap`: Enables `WRITE_MAP` for fast database writes.
-  * Default: `true`
-* `--db.read.concurrency value`: Maximum number of concurrent open database read transactions (the MDBX read-transaction semaphore); when it is full, extra readers wait for a slot by default, though some RPC paths (HTTP/WebSocket) fail fast with an overload response instead. Raise it for nodes serving heavy parallel RPC. Lowering it does not reduce read concurrency: each parallel-execution worker holds a long-lived read transaction, so a value below the worker count would deadlock and is silently raised to it. To genuinely reduce read concurrency, lower `--exec.workers` instead.
-  * Default: scales with the host as `min(max(10, GOMAXPROCS * 64), 9000)` — kept well above the CPU count because reads are I/O-bound, and capped below Go's roughly 10,000 OS-thread limit.
-* `--database.verbosity value`: Enables internal database logs.
-  * Default: `2`
-* `--batchSize value`: Sets the batch size for the execution stage.
-  * Default: `512M`
-* `--etl.bufferSize value`: Buffer size for ETL operations. Also settable through the `ETL_OPTIMAL` environment variable.
-  * Default: `256MB`
-* `--bodies.cache value`: Sets the size limit for the block bodies cache.
-  * Default: `268435456`
-* `--state.cache value`: Sets the amount of data to store in the StateCache.
-  * Default: `0MB`
-* `--sync.parallel-state-flushing`: Enables parallel state flushing.
-  * Default: `true`
-* `--erigondb.domain.steps-in-frozen-file value`: Overrides the `steps_in_frozen_file` setting from `erigondb.toml` for the domain merge cap only (history and inverted-index merges are unaffected). Pass a positive integer to set an explicit cap, or `Inf` to leave the domain merge unbounded.
-  * Default: unset (uses the value from `erigondb.toml`)
-  * Use with care — an incorrect value may affect database structure.
-* `--commitment.plainValues` *(New in v3.6)*: On the first start of a fresh datadir, write commitment values in plain form (no shortened key references). This is a one-time, per-datadir choice — it is ignored once `erigondb.toml` exists.
-  * Default: `false`
+- `--db.pagesize value`: Sets the fixed page size for the database.
+  - Default: `4KB`
+
+- `--db.size.limit value`: Sets a runtime limit on the chaindata database size.
+  - Default: `1TB`
+
+- `--db.writemap`: Enables `WRITE_MAP` for fast database writes.
+  - Default: `true`
+
+- `--db.read.concurrency value`: Maximum number of concurrent open database read transactions (the MDBX read-transaction semaphore); when it is full, extra readers wait for a slot by default, though some RPC paths (HTTP/WebSocket) fail fast with an overload response instead. Raise it for nodes serving heavy parallel RPC. Lowering it does not reduce read concurrency: each parallel-execution worker holds a long-lived read transaction, so a value below the worker count would deadlock and is silently raised to it. To genuinely reduce read concurrency, lower `--exec.workers` instead.
+  - Default: scales with the host as `min(max(10, GOMAXPROCS * 64), 9000)` — kept well above the CPU count because reads are I/O-bound, and capped below Go's roughly 10,000 OS-thread limit.
+
+- `--database.verbosity value`: Enables internal database logs.
+  - Default: `2`
+
+- `--batchSize value`: Sets the batch size for the execution stage.
+  - Default: `512M`
+
+- `--etl.bufferSize value`: Buffer size for ETL operations. Also settable through the `ETL_OPTIMAL` environment variable.
+  - Default: `256MB`
+
+- `--bodies.cache value`: Sets the size limit for the block bodies cache.
+  - Default: `268435456`
+
+- `--state.cache value`: Sets the amount of data to store in the StateCache.
+  - Default: `0MB`
+
+- `--sync.parallel-state-flushing`: Enables parallel state flushing.
+  - Default: `true`
+
+- `--erigondb.domain.steps-in-frozen-file value`: Overrides the `steps_in_frozen_file` setting from `erigondb.toml` for the domain merge cap only (history and inverted-index merges are unaffected). Pass a positive integer to set an explicit cap, or `Inf` to leave the domain merge unbounded.
+  - Default: unset (uses the value from `erigondb.toml`)
+  - Use with care — an incorrect value may affect database structure.
+
+- `--commitment.plainValues` *(New in v3.6)*: On the first start of a fresh datadir, write commitment values in plain form (no shortened key references). This is a one-time, per-datadir choice — it is ignored once `erigondb.toml` exists.
+  - Default: `false`
 
 ### Pruning and Snapshots
 
-Flags for managing how old chain data is handled and stored. See [Snapshots Management](/fundamentals/snapshots-management) for snapshot tooling and disk usage.
+Flags for managing how old chain data is handled and stored. See [Snapshots Management](https://docs.erigon.tech/fundamentals/snapshots-management) for snapshot tooling and disk usage.
 
-* `--prune.mode value`: Selects a pruning preset (`full`, `archive`, `minimal`, `blocks`). See also [Pruning Modes](/fundamentals/pruning-modes)
-  * Default: `"full"`
-* `--prune.distance value`: Keeps state history for the latest `N` blocks, or `keep-all` to keep everything.
-  * Default: unset (retention follows `--prune.mode`)
-* `--prune.distance.blocks value`: Keeps block history for the latest `N` blocks, or a named policy: `keep-post-merge` (prune pre-merge blocks only) or `keep-all` (keep every block).
-  * Default: unset (retention follows `--prune.mode`)
-* `--prune.include-commitment-history, --prune.experimental.include-commitment-history, --experimental.commitment-history`: Enables fast `eth_getProof` for executed blocks by storing commitment history. Requires +32 GB RAM. See [`eth_getProof`](/interacting-with-erigon/eth#eth_getproof).
-  * Default: `false`
-* `--prune.commitment-history.distance value`: Keeps commitment history for the latest `N` blocks, or `keep-all`. Empty or `0` (default) keeps everything. Requires `--prune.include-commitment-history`.
-  * Default: unset (empty / `0`, keeps everything)
-* `--prune.receipts.distance, --persist.receipts.distance value`: Keeps the receipt cache for the latest `N` blocks, or `keep-all`. Empty or `0` (default) follows the state-history window. Requires `--prune.include-receipts`.
-  * Default: unset (empty / `0`, follows the state-history window)
-* `--snap.skip-state-snapshot-download`: Skips state download and starts from genesis.
-  * Default: `false`
-* `--snap.keepblocks`: Workaround/debug — keeps ancient blocks in the DB instead of moving them into snapshots (useful for debugging).
-  * Default: `false`
-* `--snap.stop`: Workaround for snapshot-related bugs — stops producing new snapshot files (DB will grow as a result).
-  * Default: `false`
-* `--snap.state.stop`: Workaround for state-related bugs — stops producing new state files (DB will grow as a result).
-  * Default: `false`
-* `--snap.p2p-manifest` *(New in v3.5)* (experimental): Decentralized snapshot discovery — peers advertise their `chain.toml` manifest via ENR instead of the centralized `preverified.toml`. Opt-in; requires a compatible peer network.
-  * Default: `false`
-* `--snap.chaintoml-url value` *(New in v3.5)*: Fetch the preverified `chain.toml` directly from this URL instead of the default R2/GitHub CDN. Precedence: the `ERIGON_REMOTE_PREVERIFIED` environment variable (path to a local override file) wins over this URL and the default CDN; a local `preverified.toml` in the datadir also takes precedence — delete it to re-fetch from the URL.
-  * Default: `""` (uses the built-in CDN)
-* `--snap.download.to.block, --shadow.fork.block value`: Downloads snapshots only up to the given block number (exclusive). Intended for testing and shadow forks.
-  * Default: `0` (disabled — downloads all available snapshots)
+- `--prune.mode value`: Selects a pruning preset (`full`, `archive`, `minimal`, `blocks`). See also [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes)
+  - Default: `"full"`
+
+- `--prune.distance value`: Keeps state history for the latest `N` blocks, or `keep-all` to keep everything.
+  - Default: unset (retention follows `--prune.mode`)
+
+- `--prune.distance.blocks value`: Keeps block history for the latest `N` blocks, or a named policy: `keep-post-merge` (prune pre-merge blocks only) or `keep-all` (keep every block).
+  - Default: unset (retention follows `--prune.mode`)
+
+- `--prune.include-commitment-history, --prune.experimental.include-commitment-history, --experimental.commitment-history`: Enables fast `eth_getProof` for executed blocks by storing commitment history. Requires +32 GB RAM. See [`eth_getProof`](https://docs.erigon.tech/interacting-with-erigon/eth#eth_getproof).
+  - Default: `false`
+
+- `--prune.commitment-history.distance value`: Keeps commitment history for the latest `N` blocks, or `keep-all`. Empty or `0` (default) keeps everything. Requires `--prune.include-commitment-history`.
+  - Default: unset (empty / `0`, keeps everything)
+
+- `--prune.receipts.distance, --persist.receipts.distance value`: Keeps the receipt cache for the latest `N` blocks, or `keep-all`. Empty or `0` (default) follows the state-history window. Requires `--prune.include-receipts`.
+  - Default: unset (empty / `0`, follows the state-history window)
+
+- `--snap.skip-state-snapshot-download`: Skips state download and starts from genesis.
+  - Default: `false`
+
+- `--snap.keepblocks`: Workaround/debug — keeps ancient blocks in the DB instead of moving them into snapshots (useful for debugging).
+  - Default: `false`
+
+- `--snap.stop`: Workaround for snapshot-related bugs — stops producing new snapshot files (DB will grow as a result).
+  - Default: `false`
+
+- `--snap.state.stop`: Workaround for state-related bugs — stops producing new state files (DB will grow as a result).
+  - Default: `false`
+
+- `--snap.p2p-manifest` *(New in v3.5)* (experimental): Decentralized snapshot discovery — peers advertise their `chain.toml` manifest via ENR instead of the centralized `preverified.toml`. Opt-in; requires a compatible peer network.
+  - Default: `false`
+
+- `--snap.chaintoml-url value` *(New in v3.5)*: Fetch the preverified `chain.toml` directly from this URL instead of the default R2/GitHub CDN. Precedence: the `ERIGON_REMOTE_PREVERIFIED` environment variable (path to a local override file) wins over this URL and the default CDN; a local `preverified.toml` in the datadir also takes precedence — delete it to re-fetch from the URL.
+  - Default: `""` (uses the built-in CDN)
+
+- `--snap.download.to.block, --shadow.fork.block value`: Downloads snapshots only up to the given block number (exclusive). Intended for testing and shadow forks.
+  - Default: `0` (disabled — downloads all available snapshots)
 
 ### Transaction Pool (TxPool)
 
-Options for configuring the [transaction pool](/fundamentals/modules/txpool).
+Options for configuring the [transaction pool](https://docs.erigon.tech/fundamentals/modules/txpool).
 
-* `--txpool.api.addr value`: The TxPool API network address.
-  * Default: Uses the value of `--private.api.addr`
-* `--txpool.disable`: Disables the internal transaction pool.
-  * Default: `false`
-* `--txpool.pricelimit value`: Sets the minimum gas price for acceptance into the pool.
-  * Default: `1`
-* `--txpool.pricebump value`: Sets the price bump percentage to replace a transaction.
-  * Default: `10`
-* `--txpool.blobpricebump value`: Sets the price bump percentage for replacing a type-3 blob transaction.
-  * Default: `100`
-* `--txpool.accountslots value`: Sets the number of executable transaction slots per account.
-  * Default: `16`
-* `--txpool.blobslots value`: Sets the maximum number of blobs per account.
-  * Default: `540`
-* `--txpool.totalblobpoollimit value`: Sets the total limit on the number of all blobs in the pool.
-  * Default: `5400`
-* `--txpool.globalslots value`: Sets the maximum number of executable transaction slots for all accounts.
-  * Default: `10000`
-* `--txpool.globalbasefeeslots value`: Sets the maximum number of non-executable transactions with insufficient base fees.
-  * Default: `30000`
-* `--txpool.globalqueue value`: Sets the maximum number of non-executable transaction slots for all accounts.
-  * Default: `30000`
-* `--txpool.trace.senders value`: A comma-separated list of addresses whose transactions will be traced.
-* `--txpool.commit.every value`: Sets how often transactions are committed to storage.
-  * Default: `15s`
-* `--txpool.gossip.disable`: Disables P2P gossip of transactions.
-  * Default: `false`
-* `--txpool.queued.dormancy value`: Evicts queued transactions from senders with no on-chain state changes for at least this duration (e.g. `3h`, `2h30m`).
-  * Default: `3h0m0s`
-  * Set to `0` to disable dormancy-based eviction.
+- `--txpool.api.addr value`: The TxPool API network address.
+  - Default: Uses the value of `--private.api.addr`
+
+- `--txpool.disable`: Disables the internal transaction pool.
+  - Default: `false`
+
+- `--txpool.pricelimit value`: Sets the minimum gas price for acceptance into the pool.
+  - Default: `1`
+
+- `--txpool.pricebump value`: Sets the price bump percentage to replace a transaction.
+  - Default: `10`
+
+- `--txpool.blobpricebump value`: Sets the price bump percentage for replacing a type-3 blob transaction.
+  - Default: `100`
+
+- `--txpool.accountslots value`: Sets the number of executable transaction slots per account.
+  - Default: `16`
+
+- `--txpool.blobslots value`: Sets the maximum number of blobs per account.
+  - Default: `540`
+
+- `--txpool.totalblobpoollimit value`: Sets the total limit on the number of all blobs in the pool.
+  - Default: `5400`
+
+- `--txpool.globalslots value`: Sets the maximum number of executable transaction slots for all accounts.
+  - Default: `10000`
+
+- `--txpool.globalbasefeeslots value`: Sets the maximum number of non-executable transactions with insufficient base fees.
+  - Default: `30000`
+
+- `--txpool.globalqueue value`: Sets the maximum number of non-executable transaction slots for all accounts.
+  - Default: `30000`
+
+- `--txpool.trace.senders value`: A comma-separated list of addresses whose transactions will be traced.
+- `--txpool.commit.every value`: Sets how often transactions are committed to storage.
+  - Default: `15s`
+
+- `--txpool.gossip.disable`: Disables P2P gossip of transactions.
+  - Default: `false`
+
+- `--txpool.queued.dormancy value`: Evicts queued transactions from senders with no on-chain state changes for at least this duration (e.g. `3h`, `2h30m`).
+  - Default: `3h0m0s`
+  - Set to `0` to disable dormancy-based eviction.
 
 ### Network and Peers
 
-These flags manage network connectivity, peer discovery, and traffic control. See [Default Ports](/fundamentals/default-ports) for the full port map.
+These flags manage network connectivity, peer discovery, and traffic control. See [Default Ports](https://docs.erigon.tech/fundamentals/default-ports) for the full port map.
 
-* `--port value`: The main network listening port.
-  * Default: `30303`
-* `--p2p.protocol value`: The version of the `eth` P2P protocol.
-  * Default: `69`, `70`, `71`
-* `--nat value`: The NAT port mapping mechanism (See [here](/fundamentals/nat) for more details).
-* `--nodiscover`: Disables peer discovery.
-  * Default: `false`
-* `--discovery.v4`, `--discv4`: Enables the Node Discovery Protocol v4 (Discv4) for managed ENRs and topic discovery.
-  * Default: `false` (disabled by default since v3.4; discv5 is now the default discovery protocol)
-* `--discovery.v5`, `--discv5`, `--v5disc`: Enables the Node Discovery Protocol v5 (Discv5) for managed ENRs and topic discovery.
-  * Default: `true` (enabled by default since v3.4)
-* `--netrestrict value`: Restricts network communication to specific IP networks.
-* `--nodekey value`: The P2P node key file.
-* `--nodekeyhex value`: The P2P node key as a hexadecimal string.
-* `--discovery.dns value`: Sets DNS discovery entry points.
-* `--bootnodes value`: Comma-separated enode URLs for P2P discovery bootstrap.
-* `--staticpeers value`: Comma-separated enode URLs to connect to.
-* `--trustedpeers value`: Comma-separated enode URLs for trusted peers.
-* `--maxpeers value`: The maximum number of network peers.
-  * Default: `32`
+- `--port value`: The main network listening port.
+  - Default: `30303`
+
+- `--p2p.protocol value`: The version of the `eth` P2P protocol.
+  - Default: `69`, `70`, `71`
+
+- `--nat value`: The NAT port mapping mechanism (See [here](https://docs.erigon.tech/fundamentals/nat) for more details).
+- `--nodiscover`: Disables peer discovery.
+  - Default: `false`
+
+- `--discovery.v4`, `--discv4`: Enables the Node Discovery Protocol v4 (Discv4) for managed ENRs and topic discovery.
+  - Default: `false` (disabled by default since v3.4; discv5 is now the default discovery protocol)
+
+- `--discovery.v5`, `--discv5`, `--v5disc`: Enables the Node Discovery Protocol v5 (Discv5) for managed ENRs and topic discovery.
+  - Default: `true` (enabled by default since v3.4)
+
+- `--netrestrict value`: Restricts network communication to specific IP networks.
+- `--nodekey value`: The P2P node key file.
+- `--nodekeyhex value`: The P2P node key as a hexadecimal string.
+- `--discovery.dns value`: Sets DNS discovery entry points.
+- `--bootnodes value`: Comma-separated enode URLs for P2P discovery bootstrap.
+- `--staticpeers value`: Comma-separated enode URLs to connect to.
+- `--trustedpeers value`: Comma-separated enode URLs for trusted peers.
+- `--maxpeers value`: The maximum number of network peers.
+  - Default: `32`
 
 ### RPC & API
 
-Flags for configuring various RPC servers and their behavior. See [Interacting with Erigon](/interacting-with-erigon) for the JSON-RPC API reference.
+Flags for configuring various RPC servers and their behavior. See [Interacting with Erigon](https://docs.erigon.tech/interacting-with-erigon) for the JSON-RPC API reference.
 
-* `--private.api.addr value`: The internal gRPC API address for Erigon's components.
-  * Default: `127.0.0.1:9090`
-* `--private.api.ratelimit value`: Limits the number of simultaneous internal API requests.
-  * Default: `31872`
-* `--http`: Enables the JSON-RPC HTTP server.
-  * Default: `true`
-* `--http.enabled`: An alternative flag to enable the HTTP server.
-  * Default: `true`
-* `--graphql`: Enables the GraphQL endpoint.
-  * Default: `false`
-* `--http.addr value`: The HTTP-RPC server listening interface.
-  * Default: `localhost`
-* `--http.port value`: The HTTP-RPC server listening port.
-  * Default: `8545`
-* `--http.url value` *(New in v3.7)*: Full listen URL for the HTTP-RPC server, which overrides `--http.addr` and `--http.port`. Supported schemes are `tcp://` and `unix://` — for example `tcp://0.0.0.0:8545` or `unix:///var/run/erigon-rpc.sock`.
-  * Default: unset (the endpoint is built from `--http.addr` and `--http.port`)
-  * Only takes effect while the HTTP server is enabled.
-  * **Do not add a path to a `tcp://` URL.** The URL's host and path are concatenated into the listen address, so `tcp://0.0.0.0:8545/rpc` is not a route prefix — it produces an invalid address and the node fails to start. Only a `unix://` URL takes a path, where it *is* the socket path.
-* `--authrpc.addr value`: The HTTP-RPC server listening interface for the Engine API.
-  * Default: `localhost`
-* `--authrpc.port value`: The HTTP-RPC server listening port for the Engine API.
-  * Default: `8551`
-* `--authrpc.jwtsecret value`: The path to the [JWT secret](/fundamentals/jwt) file for the consensus layer.
-* `--http.compression`: Enables compression over HTTP-RPC.
-  * Default: `true`
-* `--http.corsdomain value`: A comma-separated list of domains for cross-origin requests.
-* `--http.vhosts value`: A comma-separated list of virtual hostnames.
-  * Default: `localhost`
-* `--authrpc.vhosts value`: A comma-separated list of virtual hostnames for the Engine API.
-  * Default: `localhost`
-* `--http.api value`: The APIs offered over the HTTP-RPC interface.
-  * Default: `eth,erigon,engine`
-* `--ws`: Enables the WS-RPC server.
-  * Default: `false`
-* `--ws.port value`: The WS-RPC server listening port.
-  * Default: `8546`
-* `--ws.compression`: Enables compression over WebSocket.
-  * Default: `true`
-* `--ws.max.connections value`: Maximum number of concurrent WebSocket connections.
-  * Default: `0` (unlimited)
+- `--private.api.addr value`: The internal gRPC API address for Erigon's components.
+  - Default: `127.0.0.1:9090`
 
-**HTTPS and IPC transports.** *(New in v3.7)* These flags are accepted by both the `erigon` binary and the standalone [RPC Daemon](/fundamentals/modules/rpc-daemon) — the embedded RPC server reads them from the same configuration. They serve the same JSON-RPC API as `--http`, over TLS or a separate socket instead.
+- `--private.api.ratelimit value`: Limits the number of simultaneous internal API requests.
+  - Default: `31872`
+
+- `--http`: Enables the JSON-RPC HTTP server.
+  - Default: `true`
+
+- `--http.enabled`: An alternative flag to enable the HTTP server.
+  - Default: `true`
+
+- `--graphql`: Enables the GraphQL endpoint.
+  - Default: `false`
+
+- `--http.addr value`: The HTTP-RPC server listening interface.
+  - Default: `localhost`
+
+- `--http.port value`: The HTTP-RPC server listening port.
+  - Default: `8545`
+
+- `--http.url value` *(New in v3.7)*: Full listen URL for the HTTP-RPC server, which overrides `--http.addr` and `--http.port`. Supported schemes are `tcp://` and `unix://` — for example `tcp://0.0.0.0:8545` or `unix:///var/run/erigon-rpc.sock`.
+  - Default: unset (the endpoint is built from `--http.addr` and `--http.port`)
+  - Only takes effect while the HTTP server is enabled.
+  - **Do not add a path to a `tcp://` URL.** The URL's host and path are concatenated into the listen address, so `tcp://0.0.0.0:8545/rpc` is not a route prefix — it produces an invalid address and the node fails to start. Only a `unix://` URL takes a path, where it *is* the socket path.
+
+- `--authrpc.addr value`: The HTTP-RPC server listening interface for the Engine API.
+  - Default: `localhost`
+
+- `--authrpc.port value`: The HTTP-RPC server listening port for the Engine API.
+  - Default: `8551`
+
+- `--authrpc.jwtsecret value`: The path to the [JWT secret](https://docs.erigon.tech/fundamentals/jwt) file for the consensus layer.
+- `--http.compression`: Enables compression over HTTP-RPC.
+  - Default: `true`
+
+- `--http.corsdomain value`: A comma-separated list of domains for cross-origin requests.
+- `--http.vhosts value`: A comma-separated list of virtual hostnames.
+  - Default: `localhost`
+
+- `--authrpc.vhosts value`: A comma-separated list of virtual hostnames for the Engine API.
+  - Default: `localhost`
+
+- `--http.api value`: The APIs offered over the HTTP-RPC interface.
+  - Default: `eth,erigon,engine`
+
+- `--ws`: Enables the WS-RPC server.
+  - Default: `false`
+
+- `--ws.port value`: The WS-RPC server listening port.
+  - Default: `8546`
+
+- `--ws.compression`: Enables compression over WebSocket.
+  - Default: `true`
+
+- `--ws.max.connections value`: Maximum number of concurrent WebSocket connections.
+  - Default: `0` (unlimited)
+
+**HTTPS and IPC transports.** *(New in v3.7)* These flags are accepted by both the `erigon` binary and the standalone [RPC Daemon](https://docs.erigon.tech/fundamentals/modules/rpc-daemon) — the embedded RPC server reads them from the same configuration. They serve the same JSON-RPC API as `--http`, over TLS or a separate socket instead.
 
 :::warning
 `--http=false` is a master switch: it disables the whole RPC stack, including the HTTPS and IPC listeners, so `--http=false --https.enabled` yields no listener at all. To serve TLS only, leave `--http` alone and turn off just the plain HTTP listener with `--http.enabled=false`.
 :::
 
-* `--https.enabled`: Enables a JSON-RPC HTTPS server on its own port, independently of the plain HTTP listener.
-  * Default: `false`
-  * `--https.cert` and `--https.key` are both required. If either is missing or unreadable the node still starts and the port still binds, but TLS serving fails and only a `Failed to serve https endpoint` warning is logged — so check the log rather than assuming success.
-* `--https.cert value`: Path to the certificate file for the HTTPS server.
-* `--https.key value`: Path to the private key file for the HTTPS server.
-* `--https.addr value`: The HTTPS-RPC server listening interface.
-  * Default: `localhost`
-* `--https.port value`: The HTTPS-RPC server listening port.
-  * Default: `0`, which means `--http.port` + 363 — so `8908` with a default `--http.port`. Set an explicit port if you need a predictable one.
-* `--https.url value`: Full listen URL for the HTTPS server, which overrides `--https.addr` and `--https.port`. Supported schemes are `tcp://` and `unix://`.
-  * Default: unset
-  * Setting this **implies `--https.enabled`**: a non-empty value turns the HTTPS server on by itself.
-* `--socket.enabled`: Enables a socket server that serves JSON-RPC on the endpoint given by `--socket.url` — a Unix socket by default, though a `tcp://` URL is also accepted.
-  * Default: `false`
-* `--socket.url value`: Listen URL for the IPC server. Supported schemes are `unix://` and `tcp://`.
-  * Default: `unix:///var/run/erigon.sock`
-  * The parent directory must exist and be writable by the Erigon user; `/var/run` normally is not, so point this at your datadir (for example `unix:///<your-datadir>/erigon.ipc`) unless you have arranged otherwise.
+- `--https.enabled`: Enables a JSON-RPC HTTPS server on its own port, independently of the plain HTTP listener.
 
-* `--rpc.batch.concurrency value`: Limits the number of goroutines for batch requests.
-  * Default: `2`
-* `--rpc.max.concurrency value`: Maximum number of concurrent HTTP RPC requests (HTTP admission control).
-  * Default: `0` (inherits value from `--db.read.concurrency`)
-  * Set to `-1` to disable admission control (unlimited)
-* `--rpc.streaming.disable`: Disables JSON streaming for heavy endpoints.
-  * Default: `false`
-* `--state.stream.disable`: Disables streaming of state changes from the core to the RPC daemon.
-  * Default: `false`
-* `--rpc.accessList value`: Specifies a granular API allowlist.
-* `--rpc.gascap value`: Sets a cap on gas usage for `eth_call`/`estimateGas`.
-  * Default: `50000000`
-* `--rpc.batch.limit value`: Sets the maximum number of requests in a batch.
-  * Default: `100`
-* `--rpc.blockrange.limit value`: Sets the maximum block range for `eth_getLogs` and similar range queries.
-  * Default: `1000`
-  * Applies to: `eth_getLogs`, `eth_getFilterLogs`, `erigon_getLogs`
-* `--rpc.logs.maxresults value`: Sets the maximum number of log results returned per query.
-  * Default: `20000`
-  * Applies to: `eth_getLogs`, `eth_getFilterLogs`, `erigon_getLogs`, `erigon_getLatestLogs`
-  * Set to `0` to remove the limit entirely (use with caution on large ranges).
-  * Works in tandem with `--rpc.blockrange.limit`: both constraints apply independently — a query can be blocked by either limit.
-* `--rpc.logs.querylimit value`: Maximum number of alternative addresses or topics allowed per search position in the `eth_getLogs` and `eth_getFilterLogs` filter criteria.
-  * Default: `1000`
-  * Applies to: `eth_getLogs`, `eth_getFilterLogs`
-  * Set to `0` or a negative value for no limit.
-* `--rpc.returndata.limit value`: Sets the maximum return data size for `eth_call`.
-  * Default: `100000`
-* `--rpc.allow-unprotected-txs`: Allows unprotected transactions via RPC.
-  * Default: `false`
-* `--rpc.gethcompat`: Enables Geth-compatible storage iteration order for `debug_storageRangeAt` (results sorted by keccak256 hash). Disabled by default for performance.
-  * Default: `false`
-* `--rpc.txfeecap value`: Sets a cap on transaction fees in ether.
-  * Default: `1`
-* `--rpc.slow value`: Logs RPC requests slower than the specified threshold.
-  * Default: `0s`
-* `--rpc.evmtimeout value`: The maximum time to wait for an EVM call.
-  * Default: `5m0s`
-* `--rpc.overlay.getlogstimeout value`: The maximum time to wait for `overlay_getLogs`.
-  * Default: `5m0s`
-* `--rpc.overlay.replayblocktimeout value`: The maximum time to wait to replay a single block.
-  * Default: `10s`
-* `--rpc.txsync.defaulttimeout value`: The default timeout for `eth_sendRawTransactionSync` when the caller does not specify one.
-  * Default: `25s`
-* `--rpc.txsync.maxtimeout value`: The maximum timeout for `eth_sendRawTransactionSync`; larger requested timeouts are clamped to this value.
-  * Default: `1m0s`
-* `--rpc.subscription.filters.maxlogs value`: Maximum logs to store per subscription.
-  * Default: `10000`
-* `--rpc.subscription.filters.maxheaders value`: Maximum block headers to store per subscription.
-  * Default: `10000`
-* `--rpc.subscription.filters.maxtxs value`: Maximum transactions to store per subscription.
-  * Default: `10000`
-* `--rpc.subscription.filters.maxaddresses value`: Maximum addresses accepted per log subscription.
-  * Default: `0`
-* `--rpc.subscription.filters.maxtopics value`: Maximum topic alternatives accepted across all positions per log subscription.
-  * Default: `0`
-* `--rpc.subscription.filters.timeout value`: Timeout before idle subscription filters are evicted.
-  * Default: `5m0s`
-  * Set to `0` to disable eviction.
-* `--http.timeouts.read value`: Maximum duration for reading a request.
-  * Default: `30s`
-* `--http.timeouts.write value`: Maximum duration before timing out a response write.
-  * Default: `30m0s`
-* `--http.timeouts.idle value`: Maximum idle time for a connection with keep-alives enabled.
-  * Default: `2m0s`
-* `--authrpc.timeouts.read value`: Maximum read duration for an Engine API request.
-  * Default: `30s`
-* `--authrpc.timeouts.write value`: Maximum write duration for an Engine API response.
-  * Default: `30m0s`
-* `--authrpc.timeouts.idle value`: Maximum idle time for an Engine API connection.
-  * Default: `2m0s`
-* `--healthcheck`: Enables gRPC health checks.
-  * Default: `false`
-* `--witness.cache.blocks value` *(New in v3.6)*: Number of recent blocks whose legacy `debug_executionWitness` result is eagerly cached in memory, keyed by block hash in an LRU. Each witness is held as serialized JSON and served verbatim on a hit, so memory use is roughly this count multiplied by the per-block witness size. Embedded RPC only, and requires `--prune.include-commitment-history` (runtime errors from `debug_executionWitness` and `eth_getWitness` name its `--prune.experimental.include-commitment-history` alias instead). This flag also gates `debug_subscribe("executionWitnesses")`, which pushes each witness over WebSocket as the cache builds it. That stream is best-effort rather than contiguous — catch-up bursts, skipped or failed builds, and slow subscribers all leave gaps — so a client that needs every height re-requests the missing ones with `debug_executionWitness`.
-  * Default: `0` (cache disabled); values above the cap of `96` are clamped
-* `--witness.cache.head-capture`: Serves recent-block `debug_executionWitness` on a minimal node without commitment-history by building each head block from a pinned parent commitment snapshot and the account/storage/code history the node keeps. Cache-only serving: out-of-window requests miss, and no history recompute is attempted. Embedded RPC only.
-  * Default: `false`
-* `--witness.cache.maxmb value`: Resident-memory cap, in MB, for the witness cache; whichever limit binds first wins between the byte budget and `--witness.cache.blocks` (still capped at `96`). `0` means count-only (no byte cap).
-  * Default: `0`
+  - Default: `false`
+  - `--https.cert` and `--https.key` are both required. If either is missing or unreadable the node still starts and the port still binds, but TLS serving fails and only a `Failed to serve https endpoint` warning is logged — so check the log rather than assuming success.
+
+- `--https.cert value`: Path to the certificate file for the HTTPS server.
+
+- `--https.key value`: Path to the private key file for the HTTPS server.
+
+- `--https.addr value`: The HTTPS-RPC server listening interface.
+
+  - Default: `localhost`
+
+- `--https.port value`: The HTTPS-RPC server listening port.
+
+  - Default: `0`, which means `--http.port` + 363 — so `8908` with a default `--http.port`. Set an explicit port if you need a predictable one.
+
+- `--https.url value`: Full listen URL for the HTTPS server, which overrides `--https.addr` and `--https.port`. Supported schemes are `tcp://` and `unix://`.
+
+  - Default: unset
+  - Setting this **implies `--https.enabled`**: a non-empty value turns the HTTPS server on by itself.
+
+- `--socket.enabled`: Enables a socket server that serves JSON-RPC on the endpoint given by `--socket.url` — a Unix socket by default, though a `tcp://` URL is also accepted.
+
+  - Default: `false`
+
+- `--socket.url value`: Listen URL for the IPC server. Supported schemes are `unix://` and `tcp://`.
+
+  - Default: `unix:///var/run/erigon.sock`
+  - The parent directory must exist and be writable by the Erigon user; `/var/run` normally is not, so point this at your datadir (for example `unix:///<your-datadir>/erigon.ipc`) unless you have arranged otherwise.
+
+- `--rpc.batch.concurrency value`: Limits the number of goroutines for batch requests.
+
+  - Default: `2`
+
+- `--rpc.max.concurrency value`: Maximum number of concurrent HTTP RPC requests (HTTP admission control).
+
+  - Default: `0` (inherits value from `--db.read.concurrency`)
+  - Set to `-1` to disable admission control (unlimited)
+
+- `--rpc.streaming.disable`: Disables JSON streaming for heavy endpoints.
+
+  - Default: `false`
+
+- `--state.stream.disable`: Disables streaming of state changes from the core to the RPC daemon.
+
+  - Default: `false`
+
+- `--rpc.accessList value`: Specifies a granular API allowlist.
+
+- `--rpc.gascap value`: Sets a cap on gas usage for `eth_call`/`estimateGas`.
+
+  - Default: `50000000`
+
+- `--rpc.batch.limit value`: Sets the maximum number of requests in a batch.
+
+  - Default: `100`
+
+- `--rpc.blockrange.limit value`: Sets the maximum block range for `eth_getLogs` and similar range queries.
+
+  - Default: `1000`
+  - Applies to: `eth_getLogs`, `eth_getFilterLogs`, `erigon_getLogs`
+
+- `--rpc.logs.maxresults value`: Sets the maximum number of log results returned per query.
+
+  - Default: `20000`
+  - Applies to: `eth_getLogs`, `eth_getFilterLogs`, `erigon_getLogs`, `erigon_getLatestLogs`
+  - Set to `0` to remove the limit entirely (use with caution on large ranges).
+  - Works in tandem with `--rpc.blockrange.limit`: both constraints apply independently — a query can be blocked by either limit.
+
+- `--rpc.logs.querylimit value`: Maximum number of alternative addresses or topics allowed per search position in the `eth_getLogs` and `eth_getFilterLogs` filter criteria.
+
+  - Default: `1000`
+  - Applies to: `eth_getLogs`, `eth_getFilterLogs`
+  - Set to `0` or a negative value for no limit.
+
+- `--rpc.returndata.limit value`: Sets the maximum return data size for `eth_call`.
+
+  - Default: `100000`
+
+- `--rpc.allow-unprotected-txs`: Allows unprotected transactions via RPC.
+
+  - Default: `false`
+
+- `--rpc.gethcompat`: Enables Geth-compatible storage iteration order for `debug_storageRangeAt` (results sorted by keccak256 hash). Disabled by default for performance.
+
+  - Default: `false`
+
+- `--rpc.txfeecap value`: Sets a cap on transaction fees in ether.
+
+  - Default: `1`
+
+- `--rpc.slow value`: Logs RPC requests slower than the specified threshold.
+
+  - Default: `0s`
+
+- `--rpc.evmtimeout value`: The maximum time to wait for an EVM call.
+
+  - Default: `5m0s`
+
+- `--rpc.overlay.getlogstimeout value`: The maximum time to wait for `overlay_getLogs`.
+
+  - Default: `5m0s`
+
+- `--rpc.overlay.replayblocktimeout value`: The maximum time to wait to replay a single block.
+
+  - Default: `10s`
+
+- `--rpc.txsync.defaulttimeout value`: The default timeout for `eth_sendRawTransactionSync` when the caller does not specify one.
+
+  - Default: `25s`
+
+- `--rpc.txsync.maxtimeout value`: The maximum timeout for `eth_sendRawTransactionSync`; larger requested timeouts are clamped to this value.
+
+  - Default: `1m0s`
+
+- `--rpc.subscription.filters.maxlogs value`: Maximum logs to store per subscription.
+
+  - Default: `10000`
+
+- `--rpc.subscription.filters.maxheaders value`: Maximum block headers to store per subscription.
+
+  - Default: `10000`
+
+- `--rpc.subscription.filters.maxtxs value`: Maximum transactions to store per subscription.
+
+  - Default: `10000`
+
+- `--rpc.subscription.filters.maxaddresses value`: Maximum addresses accepted per log subscription.
+
+  - Default: `0`
+
+- `--rpc.subscription.filters.maxtopics value`: Maximum topic alternatives accepted across all positions per log subscription.
+
+  - Default: `0`
+
+- `--rpc.subscription.filters.timeout value`: Timeout before idle subscription filters are evicted.
+
+  - Default: `5m0s`
+  - Set to `0` to disable eviction.
+
+- `--http.timeouts.read value`: Maximum duration for reading a request.
+
+  - Default: `30s`
+
+- `--http.timeouts.write value`: Maximum duration before timing out a response write.
+
+  - Default: `30m0s`
+
+- `--http.timeouts.idle value`: Maximum idle time for a connection with keep-alives enabled.
+
+  - Default: `2m0s`
+
+- `--authrpc.timeouts.read value`: Maximum read duration for an Engine API request.
+
+  - Default: `30s`
+
+- `--authrpc.timeouts.write value`: Maximum write duration for an Engine API response.
+
+  - Default: `30m0s`
+
+- `--authrpc.timeouts.idle value`: Maximum idle time for an Engine API connection.
+
+  - Default: `2m0s`
+
+- `--healthcheck`: Enables gRPC health checks.
+
+  - Default: `false`
+
+- `--witness.cache.blocks value` *(New in v3.6)*: Number of recent blocks whose legacy `debug_executionWitness` result is eagerly cached in memory, keyed by block hash in an LRU. Each witness is held as serialized JSON and served verbatim on a hit, so memory use is roughly this count multiplied by the per-block witness size. Embedded RPC only, and requires `--prune.include-commitment-history` (runtime errors from `debug_executionWitness` and `eth_getWitness` name its `--prune.experimental.include-commitment-history` alias instead). This flag also gates `debug_subscribe("executionWitnesses")`, which pushes each witness over WebSocket as the cache builds it. That stream is best-effort rather than contiguous — catch-up bursts, skipped or failed builds, and slow subscribers all leave gaps — so a client that needs every height re-requests the missing ones with `debug_executionWitness`.
+
+  - Default: `0` (cache disabled); values above the cap of `96` are clamped
+
+- `--witness.cache.head-capture`: Serves recent-block `debug_executionWitness` on a minimal node without commitment-history by building each head block from a pinned parent commitment snapshot and the account/storage/code history the node keeps. Cache-only serving: out-of-window requests miss, and no history recompute is attempted. Embedded RPC only.
+
+  - Default: `false`
+
+- `--witness.cache.maxmb value`: Resident-memory cap, in MB, for the witness cache; whichever limit binds first wins between the byte budget and `--witness.cache.blocks` (still capped at `96`). `0` means count-only (no byte cap).
+
+  - Default: `0`
 
 ### MCP Server
 
-Flags for configuring the Model Context Protocol (MCP) server. The embedded [MCP server](/fundamentals/mcp) is **enabled by default** on
-`127.0.0.1:8553`. Pass `--mcp.disable` to turn it off.
+Flags for configuring the Model Context Protocol (MCP) server. The embedded [MCP server](https://docs.erigon.tech/fundamentals/mcp) is **enabled by default** on `127.0.0.1:8553`. Pass `--mcp.disable` to turn it off.
 
-* `--mcp.disable`: Disables the embedded MCP server.
-    * Default: `false`
-* `--mcp.addr value`: The MCP server listening address.
-  * Default: `127.0.0.1`
-* `--mcp.port value`: The MCP server listening port.
-  * Default: `8553`
+- `--mcp.disable`: Disables the embedded MCP server.
+  - Default: `false`
+
+- `--mcp.addr value`: The MCP server listening address.
+  - Default: `127.0.0.1`
+
+- `--mcp.port value`: The MCP server listening port.
+  - Default: `8553`
 
 ### Logging and Profiling
 
-Flags for controlling logging and performance profiling. See [Logs](/fundamentals/logs) for log files, levels, and rotation.
+Flags for controlling logging and performance profiling. See [Logs](https://docs.erigon.tech/fundamentals/logs) for log files, levels, and rotation.
 
-* `--log.json`: Formats console logs with JSON.
-  * Default: `false`
-* `--log.console.json`: Formats console logs with JSON.
-  * Default: `false`
-* `--log.dir.json`: Formats file logs with JSON.
-  * Default: `false`
-* `--verbosity value`: Sets the log level for console logs.
-  * Default: `info`
-* `--log.console.verbosity value`: Sets the log level for console logs.
-  * Default: `info`
-* `--log.dir.disable`: Disables disk logging.
-  * Default: `false`
-* `--log.dir.path value`: The path to store user and error logs.
-* `--log.dir.prefix value`: The file name prefix for logs stored on disk.
-* `--log.dir.verbosity value`: Sets the log verbosity for disk logs.
-  * Default: `dbug`
-* `--log.delays`: Enables block delay logging.
-  * Default: `false`
-* `--pprof`: Enables the pprof HTTP server.
-  * Default: `false`
-* `--pprof.addr value`: The pprof HTTP server listening interface.
-  * Default: `127.0.0.1`
-* `--pprof.port value`: The pprof HTTP server listening port.
-  * Default: `6060`
-* `--pprof.cpuprofile value`: Writes a CPU profile to a file.
-* `--trace value`: Writes an execution trace to a file.
-* `--vmtrace value`: Sets the provider tracer.
-* `--vmtrace.jsonconfig value`: Sets the tracer's configuration.
-* `--metrics`: Enables metrics collection and reporting. See [Creating a dashboard](/fundamentals/creating-a-dashboard).
-  * Default: `false`
-* `--metrics.addr value`: The stand-alone metrics HTTP server listening interface.
-  * Default: `127.0.0.1`
-* `--metrics.port value`: The metrics HTTP server listening port.
-  * Default: `6061`
+- `--log.json`: Formats console logs with JSON.
+  - Default: `false`
+
+- `--log.console.json`: Formats console logs with JSON.
+  - Default: `false`
+
+- `--log.dir.json`: Formats file logs with JSON.
+  - Default: `false`
+
+- `--verbosity value`: Sets the log level for console logs.
+  - Default: `info`
+
+- `--log.console.verbosity value`: Sets the log level for console logs.
+  - Default: `info`
+
+- `--log.dir.disable`: Disables disk logging.
+  - Default: `false`
+
+- `--log.dir.path value`: The path to store user and error logs.
+- `--log.dir.prefix value`: The file name prefix for logs stored on disk.
+- `--log.dir.verbosity value`: Sets the log verbosity for disk logs.
+  - Default: `dbug`
+
+- `--log.delays`: Enables block delay logging.
+  - Default: `false`
+
+- `--pprof`: Enables the pprof HTTP server.
+  - Default: `false`
+
+- `--pprof.addr value`: The pprof HTTP server listening interface.
+  - Default: `127.0.0.1`
+
+- `--pprof.port value`: The pprof HTTP server listening port.
+  - Default: `6060`
+
+- `--pprof.cpuprofile value`: Writes a CPU profile to a file.
+- `--trace value`: Writes an execution trace to a file.
+- `--vmtrace value`: Sets the provider tracer.
+- `--vmtrace.jsonconfig value`: Sets the tracer's configuration.
+- `--metrics`: Enables metrics collection and reporting. See [Creating a dashboard](https://docs.erigon.tech/fundamentals/creating-a-dashboard).
+  - Default: `false`
+
+- `--metrics.addr value`: The stand-alone metrics HTTP server listening interface.
+  - Default: `127.0.0.1`
+
+- `--metrics.port value`: The metrics HTTP server listening port.
+  - Default: `6061`
 
 ### Consensus and Forks
 
 Flags related to consensus mechanisms and network forks.
 
-* `--fakepow`: Disables proof-of-work verification.
-  * Default: `false`
-* `--gpo.blocks value`: The number of recent blocks to check for gas prices.
-  * Default: `20`
-* `--gpo.percentile value`: The percentile of recent transaction gas prices to use for a suggested gas price.
-  * Default: `60`
-* `--proposer.disable`: Disables the PoS proposer.
-  * Default: `false`
-* `--builder.maxblobs value`: Caps the number of blobs included in a locally built block.
-  * Default: unset — the protocol maximum applies. Setting it to `0` excludes blob transactions from built blocks entirely.
+- `--fakepow`: Disables proof-of-work verification.
+  - Default: `false`
+
+- `--gpo.blocks value`: The number of recent blocks to check for gas prices.
+  - Default: `20`
+
+- `--gpo.percentile value`: The percentile of recent transaction gas prices to use for a suggested gas price.
+  - Default: `60`
+
+- `--proposer.disable`: Disables the PoS proposer.
+  - Default: `false`
+
+- `--builder.maxblobs value`: Caps the number of blobs included in a locally built block.
+  - Default: unset — the protocol maximum applies. Setting it to `0` excludes blob transactions from built blocks entirely.
 
 ### Sentry
 
-Flags for configuring the [Sentry](/fundamentals/modules/sentry) component.
+Flags for configuring the [Sentry](https://docs.erigon.tech/fundamentals/modules/sentry) component.
 
-* `--sentry.api.addr value`: A comma-separated list of Sentry addresses.
-* `--sentry.log-peer-info`: Logs detailed peer info when a peer connects or disconnects.
-  * Default: `false`
-* `--sentinel.addr value`: The address for the sentinel component.
-  * Default: `localhost`
-* `--sentinel.port value`: The port for the sentinel component.
-  * Default: `7777`
-* `--sentinel.bootnodes value`: Comma-separated enode URLs for P2P discovery bootstrap for the sentinel.
-* `--sentinel.staticpeers value`: Connects to comma-separated consensus static peers.
+- `--sentry.api.addr value`: A comma-separated list of Sentry addresses.
+- `--sentry.log-peer-info`: Logs detailed peer info when a peer connects or disconnects.
+  - Default: `false`
+
+- `--sentinel.addr value`: The address for the sentinel component.
+  - Default: `localhost`
+
+- `--sentinel.port value`: The port for the sentinel component.
+  - Default: `7777`
+
+- `--sentinel.bootnodes value`: Comma-separated enode URLs for P2P discovery bootstrap for the sentinel.
+- `--sentinel.staticpeers value`: Connects to comma-separated consensus static peers.
 
 ### Downloader and Synchronization
 
-These flags control the block synchronization and data downloading process, including the BitTorrent protocol settings. See [Downloader](/fundamentals/modules/downloader) for how snapshot downloading works.
+These flags control the block synchronization and data downloading process, including the BitTorrent protocol settings. See [Downloader](https://docs.erigon.tech/fundamentals/modules/downloader) for how snapshot downloading works.
 
-* `--downloader.api.addr value`: The Downloader address.
-* `--downloader.disable.ipv4`: Disables IPv4 for the Downloader.
-  * Default: `false`
-* `--downloader.disable.ipv6`: Disables IPv6 for the Downloader.
-  * Default: `false`
-* `--no-downloader`: Disables the Downloader component.
-  * Default: `false`
-* `--downloader.verify`: Verifies snapshots on startup.
-  * Default: `false`
-* `--sync.loop.throttle value`: Sets the minimum time between sync loop starts.
-* `--sync.loop.block.limit value`: Sets the maximum number of blocks to process per loop iteration.
-  * Default: `5000`
-* `--sync.loop.break.after value`: Sets the last stage of the sync loop to run.
-* `--bad.block value`: Marks a block as bad and forces a reorg.
-* `--webseed value`: Comma-separated URLs for network support infrastructure.
+- `--downloader.api.addr value`: The Downloader address.
+- `--downloader.disable.ipv4`: Disables IPv4 for the Downloader.
+  - Default: `false`
+
+- `--downloader.disable.ipv6`: Disables IPv6 for the Downloader.
+  - Default: `false`
+
+- `--no-downloader`: Disables the Downloader component.
+  - Default: `false`
+
+- `--downloader.verify`: Verifies snapshots on startup.
+  - Default: `false`
+
+- `--sync.loop.throttle value`: Sets the minimum time between sync loop starts.
+- `--sync.loop.block.limit value`: Sets the maximum number of blocks to process per loop iteration.
+  - Default: `5000`
+
+- `--sync.loop.break.after value`: Sets the last stage of the sync loop to run.
+- `--bad.block value`: Marks a block as bad and forces a reorg.
+- `--webseed value`: Comma-separated URLs for network support infrastructure.
 
 #### BitTorrent Options
 
-* `--torrent.port value`: The port to listen for the BitTorrent protocol.
-  * Default: `42069`
-* `--torrent.maxpeers value`: An unused parameter.
-  * Default: `100`
-* `--torrent.conns.perfile value`: The number of connections per file.
-  * Default: `10`
-* `--torrent.trackers.disable`: Disables conventional BitTorrent trackers.
-  * Default: `false`
-* `--torrent.upload.rate value`: The upload rate in bytes per second.
-  * Default: `16mb`
-* `--torrent.download.rate value`: Sets the torrent download rate cap. Default: `512mb`. Use a lower value on shared machines to avoid saturating the connection; use `Inf` to remove the limit.
-* `--torrent.webseed.download.rate value`: The download rate for webseeds. If not set, rate limit is shared with torrent.
-* `--torrent.verbosity value`: Sets the verbosity level for BitTorrent logs. 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail (must set `--verbosity` to equal or higher level)
-  * Default: `1`
+- `--torrent.port value`: The port to listen for the BitTorrent protocol.
+  - Default: `42069`
+
+- `--torrent.maxpeers value`: An unused parameter.
+  - Default: `100`
+
+- `--torrent.conns.perfile value`: The number of connections per file.
+  - Default: `10`
+
+- `--torrent.trackers.disable`: Disables conventional BitTorrent trackers.
+  - Default: `false`
+
+- `--torrent.upload.rate value`: The upload rate in bytes per second.
+  - Default: `16mb`
+
+- `--torrent.download.rate value`: Sets the torrent download rate cap. Default: `512mb`. Use a lower value on shared machines to avoid saturating the connection; use `Inf` to remove the limit.
+- `--torrent.webseed.download.rate value`: The download rate for webseeds. If not set, rate limit is shared with torrent.
+- `--torrent.verbosity value`: Sets the verbosity level for BitTorrent logs. 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail (must set `--verbosity` to equal or higher level)
+  - Default: `1`
 
 ### Fork Choice Update (FCU)
 
 Flags for configuring Fork Choice Update behavior.
 
-* `--fcu.timeout value`: FCU timeout before switching to async processing (use `0` to disable).
-  * Default: `1s`
-* `--fcu.background.prune`: Enables background pruning after FCU.
-  * Default: `true`
+- `--fcu.timeout value`: FCU timeout before switching to async processing (use `0` to disable).
+  - Default: `1s`
+
+- `--fcu.background.prune`: Enables background pruning after FCU.
+  - Default: `true`
 
 ### Execution
 
@@ -2518,97 +2658,129 @@ Flags for configuring the parallel block execution engine.
 
 **All `--exec.*` flags are new in v3.5** — they expose, as CLI flags, execution toggles that on earlier releases were settable only via the `EXEC3_*` / `NO_*` environment variables (which still work).
 
-* `--exec.workers value`: Number of parallel block-execution workers (equivalent to the `EXEC3_WORKERS` env var). Overridden by `--exec.serial`.
-  * Default: the number of CPU cores (inherited from the `EXEC3_WORKERS` default when the flag is not set).
-  * Note: `erigon --help` describes this flag's default as "half the number of CPU cores". That value is not actually applied — when `--exec.workers` is omitted, Erigon uses `EXEC3_WORKERS`, which defaults to the full CPU-core count. The flag-help text is a known inconsistency in the binary.
-* `--exec.serial`: Force serial execution by clamping the parallel executor to a single worker. Wins over `--exec.workers` and `EXEC3_WORKERS` — use to disable parallelism for diagnostics or like-for-like baseline comparisons.
-  * Default: `false`
-* `--exec.no-prune`: Disable all DB pruning: state-aggregator (Domain/InvertedIndex) plus stage-level pruning (Execution: ChangeSets3/BlockAccessList; TxLookup; Snapshots: PruneAncientBlocks/canonical markers/retirement). Equivalent to `NO_PRUNE=true`. Diagnostic / perf-comparison use only.
-  * Default: `false`
-* `--exec.no-merge`: Disable state-aggregator file merges for Domain / History / Inverted-Index. Equivalent to `NO_MERGE=true`. Diagnostic / perf-comparison use only.
-  * Default: `false`
-* `--exec.no-background-maintenance`: Suppress background state-aggregator and E2 block-snapshot retirement goroutines so execution is not perturbed by housekeeping work. Equivalent to `NO_BACKGROUND_E3_BUILD=true`. Diagnostic / focused-performance-testing use only — NOT an operational setting.
-  * Default: `false`
-* `--exec.batched-io`: Enable BAL-driven I/O optimisations — read-ahead pre-warming of the DB page cache (`READ_AHEAD=true`) and version-map pre-population from BAL hints (`IGNORE_BAL=false`). Disable for cold-read or non-BAL scheduling performance measurements.
-  * Default: `true`
-* `--exec.state-cache`: Enable the executor's domain-shared read cache. Equivalent to `USE_STATE_CACHE=true`. Disable for cold-read performance measurements.
-  * Default: `true`
+- `--exec.workers value`: Number of parallel block-execution workers (equivalent to the `EXEC3_WORKERS` env var). Overridden by `--exec.serial`.
+  - Default: the number of CPU cores (inherited from the `EXEC3_WORKERS` default when the flag is not set).
+  - Note: `erigon --help` describes this flag's default as "half the number of CPU cores". That value is not actually applied — when `--exec.workers` is omitted, Erigon uses `EXEC3_WORKERS`, which defaults to the full CPU-core count. The flag-help text is a known inconsistency in the binary.
+
+- `--exec.serial`: Force serial execution by clamping the parallel executor to a single worker. Wins over `--exec.workers` and `EXEC3_WORKERS` — use to disable parallelism for diagnostics or like-for-like baseline comparisons.
+  - Default: `false`
+
+- `--exec.no-prune`: Disable all DB pruning: state-aggregator (Domain/InvertedIndex) plus stage-level pruning (Execution: ChangeSets3/BlockAccessList; TxLookup; Snapshots: PruneAncientBlocks/canonical markers/retirement). Equivalent to `NO_PRUNE=true`. Diagnostic / perf-comparison use only.
+  - Default: `false`
+
+- `--exec.no-merge`: Disable state-aggregator file merges for Domain / History / Inverted-Index. Equivalent to `NO_MERGE=true`. Diagnostic / perf-comparison use only.
+  - Default: `false`
+
+- `--exec.no-background-maintenance`: Suppress background state-aggregator and E2 block-snapshot retirement goroutines so execution is not perturbed by housekeeping work. Equivalent to `NO_BACKGROUND_E3_BUILD=true`. Diagnostic / focused-performance-testing use only — NOT an operational setting.
+  - Default: `false`
+
+- `--exec.batched-io`: Enable BAL-driven I/O optimisations — read-ahead pre-warming of the DB page cache (`READ_AHEAD=true`) and version-map pre-population from BAL hints (`IGNORE_BAL=false`). Disable for cold-read or non-BAL scheduling performance measurements.
+  - Default: `true`
+
+- `--exec.state-cache`: Enable the executor's domain-shared read cache. Equivalent to `USE_STATE_CACHE=true`. Disable for cold-read performance measurements.
+  - Default: `true`
 
 **Commitment-trie construction.** The following flags change how the commitment (state-root) trie is computed during execution. Both default off and are intended for comparing root hashes against a sequential sync before enabling broadly.
 
-* `--experimental.parallel-commitment` *(New in v3.6)* (experimental): Compute the commitment trie with the fully parallel `ParallelPatriciaHashed` implementation. Equivalent to the `COMMITMENT_PARALLEL=true` environment variable.
-  * Default: `false`
-* `--experimental.streaming-commitment` *(New in v3.6)* (experimental): Compute the commitment trie with the `StreamingCommitter`, which overlaps trie folding with block execution. If set, takes precedence over `--experimental.parallel-commitment`. No environment-variable equivalent.
-  * Default: `false`
+- `--experimental.parallel-commitment` *(New in v3.6)* (experimental): Compute the commitment trie with the fully parallel `ParallelPatriciaHashed` implementation. Equivalent to the `COMMITMENT_PARALLEL=true` environment variable.
+  - Default: `false`
+
+- `--experimental.streaming-commitment` *(New in v3.6)* (experimental): Compute the commitment trie with the `StreamingCommitter`, which overlaps trie folding with block execution. If set, takes precedence over `--experimental.parallel-commitment`. No environment-variable equivalent.
+  - Default: `false`
 
 ### Caplin (Consensus Layer)
 
-Flags for configuring the [Caplin](/fundamentals/caplin) consensus layer.
+Flags for configuring the [Caplin](https://docs.erigon.tech/fundamentals/caplin) consensus layer.
 
-* `--caplin.discovery.addr value`: The address for the Caplin DISCV5 protocol.
-  * Default: `0.0.0.0`
-* `--caplin.discovery.port value`: The port for the Caplin DISCV5 protocol.
-  * Default: `4000`
-* `--caplin.discovery.tcpport value`: The TCP port for the Caplin DISCV5 protocol.
-  * Default: `4001`
-* `--caplin.checkpoint-sync-url value`: The checkpoint sync endpoint.
-* `--caplin.subscribe-all-topics`: Subscribes to all gossip topics.
-  * Default: `false`
-* `--caplin.max-peer-count value`: The maximum number of peers to connect to.
-  * Default: `128`
-* `--caplin.enable-upnp`: Enables NAT porting for Caplin.
-  * Default: `false`
-* `--caplin.local-discovery`: Also attempts to find peers over private IPs. May cause issues with some hosts (for example, Hetzner).
-  * Default: `false`
-* `--caplin.nat value`: NAT port mapping for Caplin P2P. Sets the external IP advertised in the discv5 ENR and libp2p multiaddrs while the socket binds to `--caplin.discovery.addr`. Required when running inside Docker or behind NAT. Accepted values: `""` (none), `"extip:1.2.3.4"`, `"stun"`, `"stun:<host>"`, `"upnp"`, `"pmp"`, `"pmp:192.168.0.1"`.
-  * Default: `""` (no NAT mapping)
-* `--caplin.max-inbound-traffic-per-peer value`: The maximum inbound traffic per second per peer.
-  * Default: `1MB`
-* `--caplin.max-outbound-traffic-per-peer value`: The maximum outbound traffic per second per peer.
-  * Default: `1MB`
-* `--caplin.adaptable-maximum-traffic-requirements`: Makes the node adaptable to traffic based on the number of validators.
-  * Default: `true`
-* `--caplin.blocks-archive`: Enables backfilling for blocks.
-  * Default: `false`
-* `--caplin.blobs-archive`: Enables backfilling for blobs.
-  * Default: `false`
-* `--caplin.states-archive`: Enables the archival node for historical states.
-  * Default: `false`
-* `--caplin.blobs-immediate-backfill`: Tells Caplin to immediately backfill blobs.
-  * Default: `false`
-* `--caplin.blobs-no-pruning`: Disables blob pruning.
-  * Default: `false`
-* `--caplin.columns-keep-slots value`: Number of slots to retain PeerDAS data column sidecars. Increase for DA oracle or rollup nodes that need longer column history.
-  * Default: `0` — uses the chain's spec window, `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS × SLOTS_PER_EPOCH`
-* `--caplin.checkpoint-sync.disable`: Disables checkpoint sync.
-  * Default: `false`
-* `--caplin.resume-max-staleness-epochs value`: Max epochs a locally-finalized state may be stale for Caplin to resume from it on restart instead of remote checkpoint syncing. Data-availability bound; larger values are clamped to the anchor fork's sidecar-retention window.
-  * Default: `0` (resolves to the anchor fork's sidecar-retention window)
-* `--caplin.snapgen`: Enables snapshot generation.
-  * Default: `false`
-* `--caplin.mev-relay-url value`: The MEV relay endpoint.
-* `--caplin.validator-monitor`: Enables Caplin validator monitoring metrics.
-  * Default: `false`
-* `--caplin.custom-config value`: Sets a custom config for Caplin.
-* `--caplin.custom-genesis value`: Sets a custom genesis for Caplin.
-* `--caplin.use-engine-api`: Uses the Engine API for internal Caplin.
-  * Default: `false`
-* `--beacon.api.read.timeout value`: HTTP read timeout for the Beacon API server, in seconds.
-  * Default: `5`
-* `--beacon.api.write.timeout value`: HTTP write timeout for the Beacon API server, in seconds.
-  * Default: `31536000` (~1 year)
-* `--beacon.api.idle.timeout value`: HTTP idle (keep-alive) timeout for the Beacon API server, in seconds.
-  * Default: `25`
+- `--caplin.discovery.addr value`: The address for the Caplin DISCV5 protocol.
+  - Default: `0.0.0.0`
+
+- `--caplin.discovery.port value`: The port for the Caplin DISCV5 protocol.
+  - Default: `4000`
+
+- `--caplin.discovery.tcpport value`: The TCP port for the Caplin DISCV5 protocol.
+  - Default: `4001`
+
+- `--caplin.checkpoint-sync-url value`: The checkpoint sync endpoint.
+- `--caplin.subscribe-all-topics`: Subscribes to all gossip topics.
+  - Default: `false`
+
+- `--caplin.max-peer-count value`: The maximum number of peers to connect to.
+  - Default: `128`
+
+- `--caplin.enable-upnp`: Enables NAT porting for Caplin.
+  - Default: `false`
+
+- `--caplin.local-discovery`: Also attempts to find peers over private IPs. May cause issues with some hosts (for example, Hetzner).
+  - Default: `false`
+
+- `--caplin.nat value`: NAT port mapping for Caplin P2P. Sets the external IP advertised in the discv5 ENR and libp2p multiaddrs while the socket binds to `--caplin.discovery.addr`. Required when running inside Docker or behind NAT. Accepted values: `""` (none), `"extip:1.2.3.4"`, `"stun"`, `"stun:<host>"`, `"upnp"`, `"pmp"`, `"pmp:192.168.0.1"`.
+  - Default: `""` (no NAT mapping)
+
+- `--caplin.max-inbound-traffic-per-peer value`: The maximum inbound traffic per second per peer.
+  - Default: `1MB`
+
+- `--caplin.max-outbound-traffic-per-peer value`: The maximum outbound traffic per second per peer.
+  - Default: `1MB`
+
+- `--caplin.adaptable-maximum-traffic-requirements`: Makes the node adaptable to traffic based on the number of validators.
+  - Default: `true`
+
+- `--caplin.blocks-archive`: Enables backfilling for blocks.
+  - Default: `false`
+
+- `--caplin.blobs-archive`: Enables backfilling for blobs.
+  - Default: `false`
+
+- `--caplin.states-archive`: Enables the archival node for historical states.
+  - Default: `false`
+
+- `--caplin.blobs-immediate-backfill`: Tells Caplin to immediately backfill blobs.
+  - Default: `false`
+
+- `--caplin.blobs-no-pruning`: Disables blob pruning.
+  - Default: `false`
+
+- `--caplin.columns-keep-slots value`: Number of slots to retain PeerDAS data column sidecars. Increase for DA oracle or rollup nodes that need longer column history.
+  - Default: `0` — uses the chain's spec window, `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS × SLOTS_PER_EPOCH`
+
+- `--caplin.checkpoint-sync.disable`: Disables checkpoint sync.
+  - Default: `false`
+
+- `--caplin.resume-max-staleness-epochs value`: Max epochs a locally-finalized state may be stale for Caplin to resume from it on restart instead of remote checkpoint syncing. Data-availability bound; larger values are clamped to the anchor fork's sidecar-retention window.
+  - Default: `0` (resolves to the anchor fork's sidecar-retention window)
+
+- `--caplin.snapgen`: Enables snapshot generation.
+  - Default: `false`
+
+- `--caplin.mev-relay-url value`: The MEV relay endpoint.
+- `--caplin.validator-monitor`: Enables Caplin validator monitoring metrics.
+  - Default: `false`
+
+- `--caplin.custom-config value`: Sets a custom config for Caplin.
+- `--caplin.custom-genesis value`: Sets a custom genesis for Caplin.
+- `--caplin.use-engine-api`: Uses the Engine API for internal Caplin.
+  - Default: `false`
+
+- `--beacon.api.read.timeout value`: HTTP read timeout for the Beacon API server, in seconds.
+  - Default: `5`
+
+- `--beacon.api.write.timeout value`: HTTP write timeout for the Beacon API server, in seconds.
+  - Default: `31536000` (~1 year)
+
+- `--beacon.api.idle.timeout value`: HTTP idle (keep-alive) timeout for the Beacon API server, in seconds.
+  - Default: `25`
 
 ### Shutter Network Encrypted Transactions
 
-Flags for configuring the [Shutter Network](/staking/shutter-network) encrypted transactions mempool.
+Flags for configuring the [Shutter Network](https://docs.erigon.tech/staking/shutter-network) encrypted transactions mempool.
 
-* `--shutter`: Enables the Shutter encrypted transactions mempool.
-  * Default: `false`
-* `--shutter.p2p.bootstrap.nodes value`: Overrides the default P2P bootstrap nodes.
-* `--shutter.p2p.listen.port value`: Overrides the default P2P listen port.
-  * Default: `0`
+- `--shutter`: Enables the Shutter encrypted transactions mempool.
+  - Default: `false`
+
+- `--shutter.p2p.bootstrap.nodes value`: Overrides the default P2P bootstrap nodes.
+- `--shutter.p2p.listen.port value`: Overrides the default P2P listen port.
+  - Default: `0`
 
 ## Configuration file
 
@@ -2664,46 +2836,46 @@ Erigon supports configuration through environment variables, primarily for exper
 
 **Database and Performance:**
 
-* `MDBX_LOCK_IN_RAM` - Locks MDBX database in RAM for better performance
-* `MDBX_DIRTY_SPACE_MB` - Sets dirty space limit for MDBX database
-* `SNAPSHOT_MADV_RND` - Controls snapshot memory advice randomization (default: `true`)
+- `MDBX_LOCK_IN_RAM` - Locks MDBX database in RAM for better performance
+- `MDBX_DIRTY_SPACE_MB` - Sets dirty space limit for MDBX database
+- `SNAPSHOT_MADV_RND` - Controls snapshot memory advice randomization (default: `true`)
 
 **Synchronization and Pruning:**
 
-* `NO_PRUNE` - Disables pruning when set to true (flag equivalent: `--exec.no-prune`)
-* `NO_MERGE` - Disables merging operations (flag equivalent: `--exec.no-merge`)
-* `PRUNE_TOTAL_DIFFICULTY` - Controls total difficulty pruning (default: `true`)
-* `MAX_REORG_DEPTH` - Sets maximum reorganization depth (default: `96`)
-* `CAPLIN_STATE_PRUNE_DISABLE` - Disables pruning of Caplin's state indexing DB after ranges are frozen into snapshots (default: `false`)
-* `CAPLIN_STATE_PRUNE_TIMEOUT` - Overrides the per-pass time budget for Caplin state pruning (a duration, e.g. `500ms`; default derived from the chain's slot time)
+- `NO_PRUNE` - Disables pruning when set to true (flag equivalent: `--exec.no-prune`)
+- `NO_MERGE` - Disables merging operations (flag equivalent: `--exec.no-merge`)
+- `PRUNE_TOTAL_DIFFICULTY` - Controls total difficulty pruning (default: `true`)
+- `MAX_REORG_DEPTH` - Sets maximum reorganization depth (default: `96`)
+- `CAPLIN_STATE_PRUNE_DISABLE` - Disables pruning of Caplin's state indexing DB after ranges are frozen into snapshots (default: `false`)
+- `CAPLIN_STATE_PRUNE_TIMEOUT` - Overrides the per-pass time budget for Caplin state pruning (a duration, e.g. `500ms`; default derived from the chain's slot time)
 
 **Execution and Processing:**
 
-* `EXEC3_PARALLEL` - Enables parallel block execution (Block-STM). **Default changed to `true` in v3.5** — parallel execution is now on by default. Set to `false` or use `--exec.serial` to revert to single-threaded execution.
-* `EXEC3_WORKERS` - Sets number of parallel execution workers (default: number of CPU cores)
-* `STAGES_ONLY_BLOCKS` - Limits stages to blocks only
+- `EXEC3_PARALLEL` - Enables parallel block execution (Block-STM). **Default changed to `true` in v3.5** — parallel execution is now on by default. Set to `false` or use `--exec.serial` to revert to single-threaded execution.
+- `EXEC3_WORKERS` - Sets number of parallel execution workers (default: number of CPU cores)
+- `STAGES_ONLY_BLOCKS` - Limits stages to blocks only
 
 ### Memory and Debugging Variables
 
 **Memory Management:**
 
-* `NO_MEMSTAT` - Disables memory statistics collection
-* `SAVE_HEAP_PROFILE` - Enables automatic heap profiling
-* `HEAP_PROFILE_THRESHOLD` - Memory usage percentage threshold for heap profiling (default: 35%)
+- `NO_MEMSTAT` - Disables memory statistics collection
+- `SAVE_HEAP_PROFILE` - Enables automatic heap profiling
+- `HEAP_PROFILE_THRESHOLD` - Memory usage percentage threshold for heap profiling (default: 35%)
 
 **Tracing and Debugging:**
 
-* `TRACE_ACCOUNTS` - Comma-separated list of accounts to trace
-* `TRACE_BLOCKS` - Comma-separated list of block numbers to trace
-* `TRACE_INSTRUCTIONS` - Enables instruction-level tracing
+- `TRACE_ACCOUNTS` - Comma-separated list of accounts to trace
+- `TRACE_BLOCKS` - Comma-separated list of block numbers to trace
+- `TRACE_INSTRUCTIONS` - Enables instruction-level tracing
 
 ### Docker Environment Variables
 
-When running Erigon in [Docker](/fundamentals/docker-compose), you can configure user permissions and data directories:
+When running Erigon in [Docker](https://docs.erigon.tech/fundamentals/docker-compose), you can configure user permissions and data directories:
 
-* `DOCKER_UID` - The UID of the Docker user
-* `DOCKER_GID` - The GID of the Docker user
-* `XDG_DATA_HOME` - The data directory mounted to containers
+- `DOCKER_UID` - The UID of the Docker user
+- `DOCKER_GID` - The GID of the Docker user
+- `XDG_DATA_HOME` - The data directory mounted to containers
 
 ### Usage Examples
 
@@ -2737,7 +2909,6 @@ make docker-compose
 # Supported Networks
 URL: https://docs.erigon.tech/fundamentals/supported-networks
 
-
 The default flag is `--chain=mainnet`, which enables Erigon to operate on the Ethereum mainnet. Utilize the flag `--chain=<tag>` to synchronize with one of the supported networks. For example, to synchronize Holesky, one of the Ethereum testnets, use:
 
 ```bash
@@ -2746,28 +2917,28 @@ The default flag is `--chain=mainnet`, which enables Erigon to operate on the Et
 
 ## Mainnets
 
-| Chain     | Tag         | ChainId |
-| --------- | ----------- | ------- |
-| Ethereum  | mainnet     | 1       |
-| Gnosis    | gnosis      | 100     |
+| Chain | Tag | ChainId |
+| --- | --- | --- |
+| Ethereum | mainnet | 1 |
+| Gnosis | gnosis | 100 |
 
 ## Testnets
 
 ### Ethereum testnets
 
-| Chain   | Tag     | ChainId  |
-| ------- | ------- | -------- |
+| Chain | Tag | ChainId |
+| --- | --- | --- |
 | Sepolia | sepolia | 11155111 |
-| Hoodi   | hoodi   | 560048   |
+| Hoodi | hoodi | 560048 |
 
 ### Gnosis Chain Testnets
 
-| Chain  | Tag    | ChainId |
-| ------ | ------ | ------- |
-| Chiado | chiado | 10200   |
+| Chain | Tag | ChainId |
+| --- | --- | --- |
+| Chiado | chiado | 10200 |
 
 :::warning
-Erigon no longer supports Polygon. The final release series that officially supported it is 3.1.\*. For Polygon-supported software, see [https://github.com/0xPolygon/erigon/releases](https://github.com/0xPolygon/erigon/releases).
+Erigon no longer supports Polygon. The final release series that officially supported it is 3.1.*. For Polygon-supported software, see [https://github.com/0xPolygon/erigon/releases](https://github.com/0xPolygon/erigon/releases).
 :::
 
 ---
@@ -2775,16 +2946,16 @@ Erigon no longer supports Polygon. The final release series that officially supp
 # Layer 2 Networks
 URL: https://docs.erigon.tech/fundamentals/layer-2-networks
 
-
 ### Running an Op-Node alongside Erigon
 
 To run an op-node alongside Erigon, follow these steps:
 
-1.  **Start Erigon with Caplin Enabled**: If Caplin is running as the consensus layer (CL), use the `--caplin.blobs-immediate-backfill` flag to ensure the last 18 days of blobs are backfilled, which is critical for proper synchronization with the op-node, assuming you start from a snapshot.
+1. **Start Erigon with Caplin Enabled**: If Caplin is running as the consensus layer (CL), use the `--caplin.blobs-immediate-backfill` flag to ensure the last 18 days of blobs are backfilled, which is critical for proper synchronization with the op-node, assuming you start from a snapshot.
 
-    ```bash
-    ./build/bin/erigon --caplin.blobs-immediate-backfill
-    ```
+```bash
+./build/bin/erigon --caplin.blobs-immediate-backfill
+```
+
 2. **Run the Op-Node**: Configure the op-node with the `--l1.trustrpc` flag to trust the Erigon RPC layer as the L1 node. This setup ensures smooth communication and synchronization.
 
 This configuration enables the op-node to function effectively with Erigon serving as both the L1 node and the CL.
@@ -2798,8 +2969,8 @@ mkdir /disk/datadir && \
 docker run -d -v /disk/datadir/:/home/user/erigon-data/ erigontech/nitro-erigon:main-fe4c973 --torrent.download.rate=10G --prune.mode=archive --l2rpc="http://rpcserver:port --sync.loop.block.limit 100000
 ```
 
-* **Arbitrum Sequencer**: We're currently working on adding support for the Arbitrum Sequencer. Until that work is complete, you must point Erigon to an external L2 Arbitrum RPC to get the most recent transactions and blocks. This can be either a pruned Nitro node you operate or a publicly available RPC. Any data beyond that is queried via the configured `l2rpc` during setup and synchronization, so keep this in mind when bringing a node online.
-* **RPC compatibility**: Before declaring full Arbitrum One support, we are targeting complete RPC compatibility with the Nitro node. Please note that the `timeboosted` field will remain unavailable until Sequencer integration is complete.
+- **Arbitrum Sequencer**: We're currently working on adding support for the Arbitrum Sequencer. Until that work is complete, you must point Erigon to an external L2 Arbitrum RPC to get the most recent transactions and blocks. This can be either a pruned Nitro node you operate or a publicly available RPC. Any data beyond that is queried via the configured `l2rpc` during setup and synchronization, so keep this in mind when bringing a node online.
+- **RPC compatibility**: Before declaring full Arbitrum One support, we are targeting complete RPC compatibility with the Nitro node. Please note that the `timeboosted` field will remain unavailable until Sequencer integration is complete.
 
 For more recent versions, please check [https://hub.docker.com/r/erigontech/nitro-erigon/tags](https://hub.docker.com/r/erigontech/nitro-erigon/tags).
 
@@ -2808,28 +2979,27 @@ For more recent versions, please check [https://hub.docker.com/r/erigontech/nitr
 # Default ports
 URL: https://docs.erigon.tech/fundamentals/default-ports
 
-
 Erigon use the following default port for each service:
 
-| Component | Port    | Protocol  | Purpose                     | Should Expose |
-|-----------|---------|-----------|-----------------------------|---------------|
-| engine    | `9090`  | TCP       | gRPC Server                 | Private       |
-| engine    | `42069` | TCP & UDP | Snap sync (Bittorrent)      | Public        |
-| engine    | `8551`  | TCP       | Engine API (JWT auth)       | Private       |
-| Sentry    | `30303` | TCP & UDP | eth/69, eth/70, eth/71 peering | Public     |
-| Sentry    | `9091`  | TCP       | incoming gRPC Connections   | Private       |
-| RPC Daemon | `8545`  | TCP       | HTTP & WebSockets & GraphQL | Private       |
-| RPC Daemon | `8908`  | TCP       | HTTPS (only when enabled)   | Private       |
-| mcp       | `8553`  | TCP       | MCP server (AI assistants)  | Private       |
-| shutter   | `23102` | TCP       | Peering                     | Public        |
+| Component | Port | Protocol | Purpose | Should Expose |
+| --- | --- | --- | --- | --- |
+| engine | `9090` | TCP | gRPC Server | Private |
+| engine | `42069` | TCP & UDP | Snap sync (Bittorrent) | Public |
+| engine | `8551` | TCP | Engine API (JWT auth) | Private |
+| Sentry | `30303` | TCP & UDP | eth/69, eth/70, eth/71 peering | Public |
+| Sentry | `9091` | TCP | incoming gRPC Connections | Private |
+| RPC Daemon | `8545` | TCP | HTTP & WebSockets & GraphQL | Private |
+| RPC Daemon | `8908` | TCP | HTTPS (only when enabled) | Private |
+| mcp | `8553` | TCP | MCP server (AI assistants) | Private |
+| shutter | `23102` | TCP | Peering | Public |
 
 Typically, `30303` is exposed to the internet to allow incoming peering connections: a single listener serves every supported `eth` protocol version. `9090` is exposed only internally for RPC Daemon or other connections, (e.g. RPC Daemon -> erigon). Port `8551` (JWT authenticated) is exposed only internally for Engine API JSON-RPC queries from the Consensus Layer node.
 
 To ensure proper P2P functionality for both the Execution and Consensus layers use a minimal configuration without exposing unnecessary services:
 
-* Avoid exposing other ports unless necessary for specific use cases (e.g., JSON-RPC or WebSocket);
-* Regularly audit your firewall rules to ensure they are aligned with your infrastructure needs;
-* Use monitoring tools like Prometheus or Grafana to track P2P communication metrics.
+- Avoid exposing other ports unless necessary for specific use cases (e.g., JSON-RPC or WebSocket);
+- Regularly audit your firewall rules to ensure they are aligned with your infrastructure needs;
+- Use monitoring tools like Prometheus or Grafana to track P2P communication metrics.
 
 ## Command-Line Switches for Network and Port Configuration
 
@@ -2837,40 +3007,40 @@ Here is a comprehensive list of port-related options:
 
 ### Engine
 
-* `--private.api.addr [value]`: Erigon's internal gRPC API, empty string means not to start the listener (default: `127.0.0.1:9090`)
-* `--txpool.api.addr [value]`: TxPool api network address, (default: use value of `--private.api.addr`)
-* `--torrent.port [value]`: Port to listen and serve BitTorrent protocol (default: `42069`)
-* `--authrpc.port [value]`: HTTP-RPC server listening port for the Engine API (default: `8551`)
+- `--private.api.addr [value]`: Erigon's internal gRPC API, empty string means not to start the listener (default: `127.0.0.1:9090`)
+- `--txpool.api.addr [value]`: TxPool api network address, (default: use value of `--private.api.addr`)
+- `--torrent.port [value]`: Port to listen and serve BitTorrent protocol (default: `42069`)
+- `--authrpc.port [value]`: HTTP-RPC server listening port for the Engine API (default: `8551`)
 
 ### Sentry
 
-* `--port [value]`: Network listening port (default: `30303`)
-* `--sentry.api.addr [value]`: Comma separated Sentry addresses `<host>:<port>,<host>:<port>` (default `127.0.0.1:9091`)
+- `--port [value]`: Network listening port (default: `30303`)
+- `--sentry.api.addr [value]`: Comma separated Sentry addresses `<host>:<port>,<host>:<port>` (default `127.0.0.1:9091`)
 
 ### RPC Daemon
 
-* `--ws.port [value]`: WS-RPC server listening port (default: `8546`)
-* `--http.port [value]`: HTTP-RPC server listening port (default: `8545`)
-* `--https.port [value]`: HTTPS-RPC server listening port, used only when the HTTPS server is enabled (default: `0`, meaning `--http.port` + 363 — `8908` with a default `--http.port`)
-* `--http.url [value]` / `--https.url [value]`: Full listen URL that overrides the corresponding `addr` and `port` pair (`tcp://` or `unix://`)
-* `--socket.url [value]`: IPC server listen URL, used only when the IPC server is enabled (default: `unix:///var/run/erigon.sock`)
+- `--ws.port [value]`: WS-RPC server listening port (default: `8546`)
+- `--http.port [value]`: HTTP-RPC server listening port (default: `8545`)
+- `--https.port [value]`: HTTPS-RPC server listening port, used only when the HTTPS server is enabled (default: `0`, meaning `--http.port` + 363 — `8908` with a default `--http.port`)
+- `--http.url [value]` / `--https.url [value]`: Full listen URL that overrides the corresponding `addr` and `port` pair (`tcp://` or `unix://`)
+- `--socket.url [value]`: IPC server listen URL, used only when the IPC server is enabled (default: `unix:///var/run/erigon.sock`)
 
 ### Caplin
 
-* `--caplin.discovery.port [value]`: Port for Caplin DISCV5 protocol (default: `4000`)
-* `--caplin.discovery.tcpport [value]`: TCP Port for Caplin DISCV5 protocol (default: `4001`)
+- `--caplin.discovery.port [value]`: Port for Caplin DISCV5 protocol (default: `4000`)
+- `--caplin.discovery.tcpport [value]`: TCP Port for Caplin DISCV5 protocol (default: `4001`)
 
 ### BeaconAPI
 
-* `--beacon.api.port [value]`: Sets the port to listen for beacon api requests (default: `5555`)
+- `--beacon.api.port [value]`: Sets the port to listen for beacon api requests (default: `5555`)
 
 ### MCP Server
 
 The embedded MCP server is enabled by default. To disable it, pass `--mcp.disable`.
 
-* `--mcp.disable`: Disables the embedded MCP server (default: `false`)
-* `--mcp.addr [value]`: MCP server listening address (default: `127.0.0.1`)
-* `--mcp.port [value]`: MCP server listening port (default: `8553`)
+- `--mcp.disable`: Disables the embedded MCP server (default: `false`)
+- `--mcp.addr [value]`: MCP server listening address (default: `127.0.0.1`)
+- `--mcp.port [value]`: MCP server listening port (default: `8553`)
 
 ## Shutter Network Default Ports
 
@@ -2880,15 +3050,14 @@ Bootstrap nodes are used to help new nodes discover other nodes in the network. 
 
 ### Shared ports
 
-* `--pprof.port [value]`: pprof HTTP server listening port (default: `6060`)
-* `--metrics.port [value]`: Metrics HTTP server listening port (default: `6061`)
-* `--downloader.api.addr [value]`: Downloader address `<host>:<port>`
+- `--pprof.port [value]`: pprof HTTP server listening port (default: `6060`)
+- `--metrics.port [value]`: Metrics HTTP server listening port (default: `6061`)
+- `--downloader.api.addr [value]`: Downloader address `<host>:<port>`
 
 ---
 
 # NAT
 URL: https://docs.erigon.tech/fundamentals/nat
-
 
 ### What `--nat` really controls
 
@@ -2896,34 +3065,34 @@ The `--nat` option controls how Erigon advertises its external address to other 
 
 It does not:
 
-* open firewall ports for you
-* guarantee inbound connectivity by itself
-* directly control peer count
+- open firewall ports for you
+- guarantee inbound connectivity by itself
+- directly control peer count
 
 Instead, it determines whether other nodes can initiate inbound connections to your node, which has a significant impact on:
 
-* peer diversity (inbound vs outbound)
-* transaction gossip freshness
-* block content quality for validators and block producers
+- peer diversity (inbound vs outbound)
+- transaction gossip freshness
+- block content quality for validators and block producers
 
 ### Why NAT configuration matters more than peer count
 
 Ethereum P2P is bidirectional:
 
-* your node connects outbound to peers
-* other nodes may connect inbound to you
+- your node connects outbound to peers
+- other nodes may connect inbound to you
 
 Nodes that are reachable from the internet (i.e. correctly advertised via NAT) tend to:
 
-* receive transactions earlier
-* receive a wider variety of transactions
-* maintain a healthier "pending" transaction pool
+- receive transactions earlier
+- receive a wider variety of transactions
+- maintain a healthier "pending" transaction pool
 
 For validators and block producers, this directly affects:
 
-* transaction inclusion
-* gas usage
-* likelihood of producing empty or low-gas blocks
+- transaction inclusion
+- gas usage
+- likelihood of producing empty or low-gas blocks
 
 A high peer count alone does not guarantee good transaction propagation if most peers are outbound-only.
 
@@ -2935,15 +3104,15 @@ Disables external address advertisement.
 
 Erigon will not advertise a reachable address to peers. In practice, this often results in:
 
-* mostly outbound connections
-* few or no inbound peers
-* delayed or stale transaction gossip
+- mostly outbound connections
+- few or no inbound peers
+- delayed or stale transaction gossip
 
 **Important**: `nat: none` is generally not recommended for validators or block producers, even if peer count appears high. It is primarily suitable for:
 
-* private networks
-* non-proposing archive / RPC nodes
-* restricted environments where inbound connectivity is intentionally disabled
+- private networks
+- non-proposing archive / RPC nodes
+- restricted environments where inbound connectivity is intentionally disabled
 
 ### `nat: extip:` (recommended for datacenters & VPS)
 
@@ -2951,15 +3120,15 @@ Explicitly advertises the given public IPv4 address to peers.
 
 This is the most reliable and deterministic option when:
 
-* your node has a stable public IPv4 address
-* required P2P ports are open in the firewall
+- your node has a stable public IPv4 address
+- required P2P ports are open in the firewall
 
 Benefits:
 
-* enables inbound peer connections
-* improves transaction gossip freshness
-* leads to healthier TxPool "pending" state
-* strongly recommended for validators
+- enables inbound peer connections
+- improves transaction gossip freshness
+- leads to healthier TxPool "pending" state
+- strongly recommended for validators
 
 Example:
 
@@ -2973,8 +3142,8 @@ Enables automatic NAT detection (e.g. UPnP / NAT-PMP where available).
 
 Suitable for:
 
-* home networks
-* environments where the external IP is not known in advance
+- home networks
+- environments where the external IP is not known in advance
 
 Less deterministic than extip, but generally better than none.
 
@@ -2984,9 +3153,9 @@ Uses STUN to discover the external address.
 
 Useful when:
 
-* running behind NAT
-* no UPnP is available
-* external IP cannot be configured manually
+- running behind NAT
+- no UPnP is available
+- external IP cannot be configured manually
 
 ## Caplin (consensus layer) NAT
 
@@ -2995,7 +3164,7 @@ If you are running Erigon with the embedded Caplin consensus layer, configure NA
 This flag sets the external address advertised in the **discv5 ENR** and **libp2p multiaddrs**; the socket itself still binds to `--caplin.discovery.addr`. It accepts the same values as `--nat`:
 
 | Value | Behavior |
-|-------|-----------|
+| --- | --- |
 | `""` (default) | No NAT mapping — CL peers cannot reach you inbound |
 | `extip:1.2.3.4` | Advertise a fixed public IP — recommended for VPS / datacenters |
 | `stun` | Discover external IP via STUN |
@@ -3015,7 +3184,6 @@ Set **both** `--nat` and `--caplin.nat` to the same external IP, otherwise your 
 # Optimizing Storage
 URL: https://docs.erigon.tech/fundamentals/optimizing-storage
 
-
 For optimal performance, it's recommended to store the datadir on a fast NVMe-RAID disk. However, if this is not feasible, you can store the history on a cheaper disk and still achieve good performance.
 
 ### Step 1
@@ -3024,20 +3192,21 @@ For optimal performance, it's recommended to store the datadir on a fast NVMe-RA
 
 Place the `datadir` on the slower disk. Then, create symbolic links (using `ln -s`) to the **fast disk** for the following sub-folders:
 
-* `chaindata`
-* `snapshots/domain`
+- `chaindata`
+- `snapshots/domain`
 
 This will speed up the execution of E3.
 
 On the **slow disk** place `datadir` folder with the following structure:
 
-* `chaindata` (linked to fast disk)
-* `snapshots`
-  * `domain` (linked to fast disk)
-  * `history`
-  * `idx`
-  * `accessor`
-* `temp`
+- `chaindata` (linked to fast disk)
+- `snapshots`
+  - `domain` (linked to fast disk)
+  - `history`
+  - `idx`
+  - `accessor`
+
+- `temp`
 
 ### Step 2
 
@@ -3056,18 +3225,17 @@ By following these steps, you can optimize your Erigon 3 storage setup to achiev
 # Performance Tricks
 URL: https://docs.erigon.tech/fundamentals/performance-tricks
 
-
 These instructions are designed to improve the performance of Erigon 3, particularly for synchronization and memory management, on cloud drives and other systems with specific performance characteristics.
 
 ## Increase Sync Speed
 
-* Set `--sync.loop.block.limit=10_000` and `--batchSize=2g` to speed up the synchronization process.
+- Set `--sync.loop.block.limit=10_000` and `--batchSize=2g` to speed up the synchronization process.
 
 ```bash
 --sync.loop.block.limit=10_000 --batchSize=2g
 ```
 
-* Adjust download speed with flag `--torrent.download.rate=[value]` setting your max speed (default value is `512mb`). For example:
+- Adjust download speed with flag `--torrent.download.rate=[value]` setting your max speed (default value is `512mb`). For example:
 
 ```bash
 --torrent.download.rate=1024mb
@@ -3075,7 +3243,7 @@ These instructions are designed to improve the performance of Erigon 3, particul
 
 ## Optimize for Cloud Drives
 
-* Set `SNAPSHOT_MADV_RND=false` to enable the operating system's cache prefetching for better performance on cloud drives with good throughput but bad latency.
+- Set `SNAPSHOT_MADV_RND=false` to enable the operating system's cache prefetching for better performance on cloud drives with good throughput but bad latency.
 
 ```bash
 SNAPSHOT_MADV_RND=false
@@ -3083,23 +3251,23 @@ SNAPSHOT_MADV_RND=false
 
 ## Lock Latest State in RAM
 
-* Use `vmtouch -vdlw /mnt/erigon/snapshots/domain/*bt` to lock the latest state in RAM, preventing it from being evicted due to high historical RPC traffic.
+- Use `vmtouch -vdlw /mnt/erigon/snapshots/domain/*bt` to lock the latest state in RAM, preventing it from being evicted due to high historical RPC traffic.
 
 ```bash
 vmtouch -vdlw /mnt/erigon/snapshots/domain/*bt
 ```
 
-* Run `ls /mnt/erigon/snapshots/domain/*.kv | parallel vmtouch -vdlw` to apply the same locking to all relevant files.
+- Run `ls /mnt/erigon/snapshots/domain/*.kv | parallel vmtouch -vdlw` to apply the same locking to all relevant files.
 
 ## Handle Memory Allocation Issues
 
-* If you encounter issues with memory allocation, run the following to flush any pending write operations and free up memory:
+- If you encounter issues with memory allocation, run the following to flush any pending write operations and free up memory:
 
 ```bash
 sync && sudo sysctl vm.drop_caches=3
 ```
 
-* Alternatively, set:
+- Alternatively, set:
 
 ```bash
 echo 1 > /proc/sys/vm/compact_memory
@@ -3112,20 +3280,19 @@ to help with memory allocation.
 # Multiple instances / One machine
 URL: https://docs.erigon.tech/fundamentals/multiple-instances
 
-
 Erigon supports running multiple instances on the same machine by configuring distinct ports and data directories for each instance. Multiple instances are fully supported but require careful configuration to avoid port conflicts and resource contention. The modular architecture allows for flexible deployment patterns, from fully integrated instances to distributed service architectures. The primary consideration is the performance impact from shared disk access, especially during initial synchronization phases.
 
 ## Required Configuration Flags
 
 To avoid conflicts between instances, you must define **7 essential flags** for each instance:
 
-* `--datadir` - Separate data directory for each instance
-* `--port` - P2P networking port (default: `30303`)
-* `--http.port` - HTTP JSON-RPC port (default: `8545`)
-* `--authrpc.port` - Engine API port (default: `8551`)
-* `--torrent.port` - BitTorrent protocol port (default: `42069`)
-* `--private.api.addr` - Internal gRPC API address (default: `127.0.0.1:9090`)
-* `--mcp.port` - MCP server port (default: `8553`), or `--mcp.disable` to turn it off
+- `--datadir` - Separate data directory for each instance
+- `--port` - P2P networking port (default: `30303`)
+- `--http.port` - HTTP JSON-RPC port (default: `8545`)
+- `--authrpc.port` - Engine API port (default: `8551`)
+- `--torrent.port` - BitTorrent protocol port (default: `42069`)
+- `--private.api.addr` - Internal gRPC API address (default: `127.0.0.1:9090`)
+- `--mcp.port` - MCP server port (default: `8553`), or `--mcp.disable` to turn it off
 
 ## Example Configuration
 
@@ -3165,9 +3332,9 @@ For containerized deployments, the docker-compose configuration shows how servic
 
 The compose file demonstrates the port allocation strategy:
 
-* **9090-9094**: Internal gRPC services (execution, Sentry, consensus, Downloader, TxPool)
-* **8545, 8551**: External HTTP APIs
-* **30303, 42069**: P2P networking ports
+- **9090-9094**: Internal gRPC services (execution, Sentry, consensus, Downloader, TxPool)
+- **8545, 8551**: External HTTP APIs
+- **30303, 42069**: P2P networking ports
 
 ## Best Practices
 
@@ -3175,9 +3342,9 @@ The compose file demonstrates the port allocation strategy:
 
 **Memory Considerations:** Erigon uses memory-mapped files (MDBX) where the OS manages page cache. Multiple instances will share the same page cache efficiently, but be aware that:
 
-* Each instance uses \~4GB RAM during genesis sync and \~1GB during normal operation
-* OS page cache can utilize unlimited memory and is shared between instances
-* Memory usage shown by `htop` includes OS page cache and may appear inflated
+- Each instance uses ~4GB RAM during genesis sync and ~1GB during normal operation
+- OS page cache can utilize unlimited memory and is shared between instances
+- Memory usage shown by `htop` includes OS page cache and may appear inflated
 
 :::warning
 ⚠️ **Disk Performance Warning:** Multiple instances accessing the same disk concurrently will impact performance due to increased random disk access. This is particularly problematic during the "Blocks Execution stage" which performs many random reads. **Avoid running multiple genesis syncs on the same disk.**
@@ -3196,14 +3363,14 @@ For multiple instances, consider adjusting database parameters to reduce resourc
 
 **Default Port Allocation:**
 
-| Component | Default Port | Protocol | Purpose                  |
-|-----------|--------------|----------|--------------------------|
-| Engine    | 9090         | TCP      | gRPC Server (Private)    |
-| Engine    | 42069        | TCP/UDP  | BitTorrent (Public)      |
-| Engine    | 8551         | TCP      | Engine API (Private)     |
-| Sentry    | 30303        | TCP/UDP  | P2P Peering (Public)     |
-| RPC Daemon | 8545         | TCP      | HTTP/WebSocket (Private) |
-| MCP       | 8553         | TCP      | MCP Server (Private)     |
+| Component | Default Port | Protocol | Purpose |
+| --- | --- | --- | --- |
+| Engine | 9090 | TCP | gRPC Server (Private) |
+| Engine | 42069 | TCP/UDP | BitTorrent (Public) |
+| Engine | 8551 | TCP | Engine API (Private) |
+| Sentry | 30303 | TCP/UDP | P2P Peering (Public) |
+| RPC Daemon | 8545 | TCP | HTTP/WebSocket (Private) |
+| MCP | 8553 | TCP | MCP Server (Private) |
 
 ### 4. Service Separation
 
@@ -3211,9 +3378,9 @@ Erigon supports modular deployment where components can run as separate processe
 
 For multiple instances, you can:
 
-* Run each instance with integrated services (default)
-* Separate heavy components like `downloader` or `rpcdaemon` to dedicated processes
-* Use the `--private.api.addr` flag for inter-service communication
+- Run each instance with integrated services (default)
+- Separate heavy components like `downloader` or `rpcdaemon` to dedicated processes
+- Use the `--private.api.addr` flag for inter-service communication
 
 ### 5. Monitoring and Logging
 
@@ -3269,13 +3436,14 @@ echo 1 > /proc/sys/vm/compact_memory
 
 What can be done:
 
-* reduce disk latency (not throughput, not iops)
-  * use latency-critical cloud-drives
-  * or attached-NVMe (at least for initial sync)
-* increase RAM
-* if you throw enough RAM, then can set env variable `SNAPSHOT_MADV_RND=false`
-* Use `--db.pagesize=64kb` (less fragmentation, more IO)
-* Or use Erigon 3 (it also sensitive for disk-latency - but it will download 99% of history)
+- reduce disk latency (not throughput, not iops)
+  - use latency-critical cloud-drives
+  - or attached-NVMe (at least for initial sync)
+
+- increase RAM
+- if you throw enough RAM, then can set env variable `SNAPSHOT_MADV_RND=false`
+- Use `--db.pagesize=64kb` (less fragmentation, more IO)
+- Or use Erigon 3 (it also sensitive for disk-latency - but it will download 99% of history)
 
 ```yaml
 # Ports: `9090` execution engine (private api), `9091` sentry, `9092` consensus engine, `9093` snapshot downloader, `9094` TxPool
@@ -3339,13 +3507,12 @@ Erigon itself consumes less than 2GB of RAM. Therefore, Erigon will benefit from
 # Logs
 URL: https://docs.erigon.tech/fundamentals/logs
 
-
 Erigon features a sophisticated logging framework that offers detailed visibility into the synchronization process and operational status. This system provides comprehensive, structured logs suitable for both human operators and automated monitoring, while maintaining high performance.
 
 The modular, staged approach to logging allows for granular control over verbosity, which is crucial for precise debugging and flexible deployment across various environments.
 
 :::tip
-Erigon offers a `--metrics` flag for using Prometheus/Grafana monitoring, see [Creating a Dashboard](creating-a-dashboard).
+Erigon offers a `--metrics` flag for using Prometheus/Grafana monitoring, see [Creating a Dashboard](https://docs.erigon.tech/fundamentals/creating-a-dashboard).
 :::
 
 ## Logging Framework Architecture
@@ -3358,22 +3525,22 @@ Erigon implements a custom logging framework that supports structured logging wi
 
 Erigon provides extensive logging configuration through command-line flags. Key configuration options include:
 
-* `--log.json`: Enable JSON formatting for console logs
-* `--verbosity`: Set console log level (default: `info`)
-* `--log.dir.path`: Specify directory for log files. By default Erigon writing logs to `datadir/logs` directory.
-* `--log.dir.verbosity`: Set file log level (default: `dbug`)
-* `--log.delays`: Enable block delay logging
+- `--log.json`: Enable JSON formatting for console logs
+- `--verbosity`: Set console log level (default: `info`)
+- `--log.dir.path`: Specify directory for log files. By default Erigon writing logs to `datadir/logs` directory.
+- `--log.dir.verbosity`: Set file log level (default: `dbug`)
+- `--log.delays`: Enable block delay logging
 
 **Log Levels**
 
 The logging system defines six distinct log levels in hierarchical order:
 
-* **LvlCrit (0)**: Critical errors that may cause application termination
-* **LvlError (1)**: Error conditions that require attention
-* **LvlWarn (2)**: Warning messages for potentially problematic situations
-* **LvlInfo (3)**: General informational messages
-* **LvlDebug (4)**: Detailed debugging information
-* **LvlTrace (5)**: Most verbose tracing information
+- **LvlCrit (0)**: Critical errors that may cause application termination
+- **LvlError (1)**: Error conditions that require attention
+- **LvlWarn (2)**: Warning messages for potentially problematic situations
+- **LvlInfo (3)**: General informational messages
+- **LvlDebug (4)**: Detailed debugging information
+- **LvlTrace (5)**: Most verbose tracing information
 
 The log level is set by using the `--verbosity` flag, for example:
 
@@ -3393,14 +3560,14 @@ Erigon's synchronization process is organized into sequential stages, each handl
 
 The primary synchronization stages include:
 
-* **Snapshots (OtterSync)**: Download and process blockchain snapshots
-* **Headers**: Download and validate block headers
-* **BlockHashes**: Generate block number to hash mappings
-* **Bodies**: Download and validate block bodies
-* **Senders**: Recover transaction senders from signatures
-* **Execution**: Execute transactions and update state
-* **TxLookup**: Generates transaction lookup indices. This indexing is essential for quickly finding transaction by its hash, significantly improving the performance of transaction-related RPC calls.
-* **Finish**: The finalization stage of the sync process. This is the point where the node sends out notifications to subscribers about the new blockchain head, ensuring other components and external applications are instantly aware of the latest block.
+- **Snapshots (OtterSync)**: Download and process blockchain snapshots
+- **Headers**: Download and validate block headers
+- **BlockHashes**: Generate block number to hash mappings
+- **Bodies**: Download and validate block bodies
+- **Senders**: Recover transaction senders from signatures
+- **Execution**: Execute transactions and update state
+- **TxLookup**: Generates transaction lookup indices. This indexing is essential for quickly finding transaction by its hash, significantly improving the performance of transaction-related RPC calls.
+- **Finish**: The finalization stage of the sync process. This is the point where the node sends out notifications to subscribers about the new blockchain head, ensuring other components and external applications are instantly aware of the latest block.
 
 ### Stage Progress Tracking
 
@@ -3414,10 +3581,10 @@ All log messages follow a consistent structured format with key-value pairs for 
 
 **Standard Fields:**
 
-* Timestamp (t)
-* Log level (lvl)
-* Message (msg)
-* Contextual key-value pairs
+- Timestamp (t)
+- Log level (lvl)
+- Message (msg)
+- Contextual key-value pairs
 
 ### Prefix System
 
@@ -3430,7 +3597,6 @@ The prefix format includes stage position and total count (e.g., "1/10 Headers")
 # Security
 URL: https://docs.erigon.tech/fundamentals/security
 
-
 The security practices focus heavily on the RPC Daemon since it's the primary external interface. The modular architecture allows you to run components separately, which can improve security by isolating services. For production deployments, consider using the distributed mode where services communicate via secured gRPC rather than running everything in a single process.
 
 ## Network Security
@@ -3439,39 +3605,39 @@ Securing your network ports is essential for protecting your Erigon node. Proper
 
 Based on best practices for execution clients, your local machine's firewall settings should be configured as follows:
 
-| **Port** | **Protocol** | **Purpose**                   | **Firewall Action**                                                                                                                      |
-| -------- | ------------ | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| 30303    | TCP & UDP    | Peer-to-Peer (P2P) Networking | Allow inbound and outbound traffic to enable peer discovery and connections.                                                             |
-| 8545     | TCP          | JSON-RPC (Public API)         | Block all traffic _except_ from explicitly defined trusted machines. This port should never be publicly exposed without strict controls. |
-| 9090     | TCP          | Private API Communication     | Block all traffic except for communication between your internal components (e.g., RPC Daemon and core node).                            |
+| **Port** | **Protocol** | **Purpose** | **Firewall Action** |
+| --- | --- | --- | --- |
+| 30303 | TCP & UDP | Peer-to-Peer (P2P) Networking | Allow inbound and outbound traffic to enable peer discovery and connections. |
+| 8545 | TCP | JSON-RPC (Public API) | Block all traffic *except* from explicitly defined trusted machines. This port should never be publicly exposed without strict controls. |
+| 9090 | TCP | Private API Communication | Block all traffic except for communication between your internal components (e.g., RPC Daemon and core node). |
 
 #### CORS Protection
 
 When exposing public RPC endpoints (like those on port 8545), use the following practice to mitigate cross-origin attacks:
 
-* Avoid using a wildcard `*` for Cross-Origin Resource Sharing (CORS) domains.
-* Set specific hostnames or IP addresses for CORS to ensure only authorized frontend applications can interact with your RPC service.
+- Avoid using a wildcard `*` for Cross-Origin Resource Sharing (CORS) domains.
+- Set specific hostnames or IP addresses for CORS to ensure only authorized frontend applications can interact with your RPC service.
 
 ## API Security
 
 The RPC Daemon is the primary external interface, making API security critical. To protect against abuse, denial-of-service (DoS) attacks, OOM issues and unauthorized access, implement the following controls:
 
-| **Security Measure** | **Description**                                                                                                                                                                                           | **Erigon Configuration**                                                                                                                                                             |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Method Allowlisting  | Restrict the available RPC methods to only those strictly necessary. This significantly reduces the attack surface.Can be applied to erigon or RPC Daemon process. | Use the `--rpc.accessList=rules.json` flag, pointing to a JSON file (e.g., `rules.json`) that specifies the allowed methods: `{"allow": ["net_version", "eth_getBlockByHash"]}`      |
-| Remove Admin APIs    | Never include sensitive namespaces like `admin` or `debug` in the `--http.api` list for public-facing nodes. These APIs are intended for node operators only.                                             | Omit the `admin` and `debug` namespaces from `--http.api`.                                                                                                                           |
-| Rate Limiting        | Protect against DoS attacks by limiting the processing capacity for HTTP requests and batch requests.                                                                                                               | Configure `--rpc.max.concurrency` (HTTP admission control: `0` = use `--db.read.concurrency`, `-1` = unlimited), `--rpc.batch.concurrency` and `--rpc.batch.limit`. |
-| Subscription Filters | Control WebSocket subscriptions to prevent Out-of-Memory (OOM) errors caused by a large number of filter requests.                                                                                        | Utilize the various --rpc.subscription.filters.* flags.Note: These are disabled by default because they increase the risk of OOM issues. |
+| **Security Measure** | **Description** | **Erigon Configuration** |
+| --- | --- | --- |
+| Method Allowlisting | Restrict the available RPC methods to only those strictly necessary. This significantly reduces the attack surface. Can be applied to `erigon` or `RPC Daemon` process. | Use the `--rpc.accessList=rules.json` flag, pointing to a JSON file (e.g., `rules.json`) that specifies the allowed methods: `{"allow": ["net_version", "eth_getBlockByHash"]}` |
+| Remove Admin APIs | Never include sensitive namespaces like `admin` or `debug` in the `--http.api` list for public-facing nodes. These APIs are intended for node operators only. | Omit the `admin` and `debug` namespaces from `--http.api`. |
+| Rate Limiting | Protect against DoS attacks by limiting the processing capacity for HTTP requests and batch requests. | Configure `--rpc.max.concurrency` (HTTP admission control: `0` = use `--db.read.concurrency`, `-1` = unlimited), `--rpc.batch.concurrency` and `--rpc.batch.limit`. |
+| Subscription Filters | Control WebSocket subscriptions to prevent Out-of-Memory (OOM) errors caused by a large number of filter requests. | Utilize the various `--rpc.subscription.filters.*` flags. **Note**: These are disabled by default because they increase the risk of OOM issues. |
 
 ### External Protection Layer (Recommended for Production)
 
 For production environments where RPC endpoints are exposed publicly, it is strongly recommended to place the Erigon node behind a robust proxy layer. This layer should be responsible for:
 
-* **Application-Level Filtering**: Implementing more granular logic than basic allowlists.
-* **Rate Limiting**: Providing centralized, high-performance rate limiting.
-* **TLS Termination**: Handling SSL/TLS encryption/decryption.
-* **Monitoring and Logging**: Tracking requests for security auditing.
-* **Web Application Firewalls (WAFs)**: Protecting against common web exploits.
+- **Application-Level Filtering**: Implementing more granular logic than basic allowlists.
+- **Rate Limiting**: Providing centralized, high-performance rate limiting.
+- **TLS Termination**: Handling SSL/TLS encryption/decryption.
+- **Monitoring and Logging**: Tracking requests for security auditing.
+- **Web Application Firewalls (WAFs)**: Protecting against common web exploits.
 
 ## TLS and Authentication
 
@@ -3493,7 +3659,6 @@ For production environments where RPC endpoints are exposed publicly, it is stro
 
 # JWT Secret
 URL: https://docs.erigon.tech/fundamentals/jwt
-
 
 The JWT secret is a key that allows Ethereum entities to securely validate JWTs used for authentication, authorization, and transmitting information, like a passphrase that allows Ethereum nodes/servers to verify if requests are legitimate. It should be protected and not exposed publicly.
 
@@ -3520,19 +3685,18 @@ Both Erigon and any external Consensus Layer need to point to the same JWT secre
 # TLS Authentication
 URL: https://docs.erigon.tech/fundamentals/tls-authentication
 
-
 ## Introduction
 
 TLS authentication can be enabled to ensure communication integrity and access control to the Erigon node.
 
 At a high level, the process consists of:
 
-1. [Generate the Certificate Authority (CA) key pair](#1-generating-the-key-pair-for-the-certificate-authority-ca)
-2. [Create the Certificate Authority certificate file](#2-creating-the-ca-certificate-file)
-3. [Generate a key pair](#3-generating-a-key-pair)
-4. [Create the certificate file for each public key](#4-creating-the-certificate-file-for-each-public-key)
-5. [Deploy the files to each instance](#5-deploy-the-files-on-each-instance)
-6. [Run Erigon and RPC Daemon with the correct tags](#6-run-erigon-and-rpc-daemon-with-the-correct-tags)
+1. [Generate the Certificate Authority (CA) key pair](https://docs.erigon.tech/fundamentals/tls-authentication#1-generating-the-key-pair-for-the-certificate-authority-ca)
+2. [Create the Certificate Authority certificate file](https://docs.erigon.tech/fundamentals/tls-authentication#2-creating-the-ca-certificate-file)
+3. [Generate a key pair](https://docs.erigon.tech/fundamentals/tls-authentication#3-generating-a-key-pair)
+4. [Create the certificate file for each public key](https://docs.erigon.tech/fundamentals/tls-authentication#4-creating-the-certificate-file-for-each-public-key)
+5. [Deploy the files to each instance](https://docs.erigon.tech/fundamentals/tls-authentication#5-deploy-the-files-on-each-instance)
+6. [Run Erigon and RPC Daemon with the correct tags](https://docs.erigon.tech/fundamentals/tls-authentication#6-run-erigon-and-rpc-daemon-with-the-correct-tags)
 
 The following is a detailed description of how to use the **OpenSSL** suite of tools to secure the connection between a remote Erigon node and a remote or local RPC Daemon. The same procedure applies to any Erigon component you wish to run separately; it is recommended to name the files accordingly.
 
@@ -3639,7 +3803,6 @@ While the RPC Daemon must be started with these additional options:
 # MCP Server
 URL: https://docs.erigon.tech/fundamentals/mcp
 
-
 The **Model Context Protocol (MCP)** is an open standard developed by Anthropic that allows AI assistants (such as Claude Desktop) to securely connect to external data sources and tools. MCP defines a uniform interface through which an AI model can discover, read, and invoke capabilities provided by a server — without needing any custom integration code.
 
 Erigon ships a full MCP server implementation. Once connected, an AI assistant gains structured, read-only access to Ethereum blockchain data, Erigon logs, and internal metrics — turning natural-language questions into precise on-chain lookups.
@@ -3654,8 +3817,7 @@ Erigon provides two ways to run the MCP server:
 
 ### Embedded (inside Erigon)
 
-The MCP server runs inside the main `erigon` process, with direct access to internal APIs and Prometheus metrics. It is
-**enabled by default** on `127.0.0.1:8553`:
+The MCP server runs inside the main `erigon` process, with direct access to internal APIs and Prometheus metrics. It is **enabled by default** on `127.0.0.1:8553`:
 
 ```bash
 # MCP server starts automatically on 127.0.0.1:8553
@@ -3683,23 +3845,20 @@ make mcp
 
 ### Flags (embedded mode)
 
-| Flag            | Default     | Description                                   |
-|-----------------|-------------|-----------------------------------------------|
-| `--mcp.disable` | `false`     | Disable the embedded MCP server entirely      |
-| `--mcp.addr`    | `127.0.0.1` | Listening address for the embedded MCP server |
-| `--mcp.port`    | `8553`      | Listening port for the embedded MCP server    |
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--mcp.disable` | `false` | Disable the embedded MCP server entirely |
+| `--mcp.addr` | `127.0.0.1` | Listening address for the embedded MCP server |
+| `--mcp.port` | `8553` | Listening port for the embedded MCP server |
 
 :::info
-The embedded MCP server is **enabled by default** and listens on `127.0.0.1:8553`. Because it binds to localhost only,
-it is not reachable from external networks. If you do not need AI-assistant integration, pass `--mcp.disable` to avoid
-opening the port. If you are running multiple Erigon instances on the same machine, assign distinct ports with
-`--mcp.port` to avoid conflicts.
+The embedded MCP server is **enabled by default** and listens on `127.0.0.1:8553`. Because it binds to localhost only, it is not reachable from external networks. If you do not need AI-assistant integration, pass `--mcp.disable` to avoid opening the port. If you are running multiple Erigon instances on the same machine, assign distinct ports with `--mcp.port` to avoid conflicts.
 :::
 
 ### Flags (standalone `mcp` binary)
 
 | Flag | Default | Description |
-|------|---------|-------------|
+| --- | --- | --- |
 | `--rpc.url` | `http://127.0.0.1:8545` | Erigon JSON-RPC endpoint to proxy |
 | `--port` | — | Shorthand for `--rpc.url http://127.0.0.1:<port>` |
 | `--datadir` | — | Erigon data directory (enables direct DB access mode) |
@@ -3781,6 +3940,8 @@ When something looks wrong with your node, ask the assistant to sift through log
 
 Add the following to your Claude Desktop configuration file (`~/.config/claude-desktop/config.json` on Linux/macOS, `%APPDATA%\claude-desktop\config.json` on Windows):
 
+**JSON-RPC mode**
+
 ```json
 {
   "mcpServers": {
@@ -3791,6 +3952,8 @@ Add the following to your Claude Desktop configuration file (`~/.config/claude-d
   }
 }
 ```
+
+**Datadir mode**
 
 ```json
 {
@@ -3803,6 +3966,8 @@ Add the following to your Claude Desktop configuration file (`~/.config/claude-d
 }
 ```
 
+**Embedded (HTTP)**
+
 ```json
 {
   "mcpServers": {
@@ -3814,9 +3979,7 @@ Add the following to your Claude Desktop configuration file (`~/.config/claude-d
 }
 ```
 
-The embedded MCP server starts by default on `127.0.0.1:8553` and serves streamable HTTP at `/mcp` plus SSE at `/sse`
-(use `"type": "sse"` with the `/sse` URL for clients that only support SSE). To use a different address or port, pass
-`--mcp.addr` and `--mcp.port`. To disable it, pass `--mcp.disable`.
+The embedded MCP server starts by default on `127.0.0.1:8553` and serves streamable HTTP at `/mcp` plus SSE at `/sse` (use `"type": "sse"` with the `/sse` URL for clients that only support SSE). To use a different address or port, pass `--mcp.addr` and `--mcp.port`. To disable it, pass `--mcp.disable`.
 
 After saving, restart Claude Desktop. The Erigon tools will appear in the tool panel under **erigon**.
 
@@ -3860,12 +4023,16 @@ claude mcp remove erigon
 
 [OpenAI Codex CLI](https://github.com/openai/codex) supports MCP servers via `~/.codex/config.yaml`. Add the `mcp_servers` key to your existing config file:
 
+**Embedded SSE**
+
 ```yaml
 mcp_servers:
   erigon:
     type: sse
     url: http://127.0.0.1:8553/sse
 ```
+
+**Standalone stdio**
 
 ```yaml
 mcp_servers:
@@ -3925,7 +4092,7 @@ In addition to tools, the MCP server exposes structured **resources** and **prom
 **Resources** (addressable by URI):
 
 | Resource | Description |
-|----------|-------------|
+| --- | --- |
 | `erigon://node/info` | Node version, chain, capabilities |
 | `erigon://chain/config` | Full chain configuration |
 | `erigon://blocks/recent` | Last 10 blocks summary |
@@ -3938,7 +4105,7 @@ In addition to tools, the MCP server exposes structured **resources** and **prom
 **Prompts** (pre-built analysis templates):
 
 | Prompt | Description |
-|--------|-------------|
+| --- | --- |
 | `analyze_transaction` | Deep-dive into a transaction |
 | `investigate_address` | Profile an address (balance, history, code) |
 | `analyze_block` | Summarise a block and its transactions |
@@ -3947,20 +4114,18 @@ In addition to tools, the MCP server exposes structured **resources** and **prom
 | `torrent_status` | Snapshot download health check |
 | `sync_analysis` | Node sync progress and performance |
 
----
-
 ## These Docs as a Single File
 
 MCP connects a model to your **running node**. To let a model answer questions about **Erigon itself** — flags, pruning modes, RPC namespaces, hardware sizing — point it at this documentation in machine-readable form, following the [llmstxt.org](https://llmstxt.org) convention:
 
 | File | Contents | Use it when |
-|------|----------|-------------|
+| --- | --- | --- |
 | [llms.txt](https://docs.erigon.tech/llms.txt) | Index of the current documentation, with titles and descriptions | The model fetches pages on demand, or its context window is small |
 | [llms-full.txt](https://docs.erigon.tech/llms-full.txt) | The text of those same pages, as one plain-text file | You want the whole corpus in context, offline, with nothing scraped |
 
-Both are generated from the same Markdown source as this site by a script in the repository, and CI fails when a documentation change lands without regenerating them, so they cannot quietly go stale.
+Both are generated from this site's built pages by a script in the repository, and CI fails when a documentation change lands without regenerating them, so they cannot quietly go stale.
 
-Two things to know about their scope. They cover the **current** documentation and the help center only — archived versions, published under `/vX.Y/`, are not included. And the text is cleaned rather than copied verbatim: MDX components are stripped, and a section index page built as a card grid is reduced to the list of links its grids present rather than its prose. Read the corpus as the documentation's prose, not as a byte-for-byte mirror of the rendered site.
+Two things to know about their scope. They cover the **current** documentation and the help center only — archived versions, published under `/vX.Y/`, are not included. And the text is cleaned rather than copied verbatim: components are expanded and links resolved as the site renders them, and on a section index page built as a card grid each grid becomes the list of links it presents, with the page's prose kept around it in document order. Read the corpus as the documentation's prose, not as a byte-for-byte mirror of the rendered site.
 
 ```bash
 # Give a local model the whole documentation, with no network access
@@ -3974,7 +4139,6 @@ The full file is around 430 KB. If your model's context cannot hold it, use `llm
 # Otterscan
 URL: https://docs.erigon.tech/fundamentals/otterscan
 
-
 Otterscan is an Ethereum block explorer designed to be run locally along with Erigon.
 
 Entirely based on open source code, it is fast and fully private since it works on your local machine. The user interface is intentionally very similar, but with many improvements, to the most popular Ethereum block explorer to make it easy to locate where the information is. Installation and usage instructions
@@ -3986,14 +4150,13 @@ For the installation and usage follow the official documentation at [https://doc
 # Creating a dashboard
 URL: https://docs.erigon.tech/fundamentals/creating-a-dashboard
 
-
 Erigon provides robust, built-in support for monitoring using the Prometheus and Grafana stack. This setup offers comprehensive visibility into node performance, storage usage, and network activity, including relevant metrics for the integrated Consensus Layer (Caplin).
 
 #### Prerequisites
 
-* Docker and Docker Compose installed
-* Erigon node running
-* Basic understanding of Prometheus and Grafana
+- Docker and Docker Compose installed
+- Erigon node running
+- Basic understanding of Prometheus and Grafana
 
 #### Step 1: Enable Metrics in Erigon
 
@@ -4031,7 +4194,7 @@ make prometheus
 
 Once the containers are running, access the Grafana interface at `localhost:3000`.
 
-* Default credentials: `admin/admin`
+- Default credentials: `admin/admin`
 
 #### Step 5: Utilize Pre-configured Dashboards
 
@@ -4039,12 +4202,12 @@ Erigon comes with pre-built dashboards located in `./cmd/prometheus/dashboards/`
 
 **`erigon.json`** is the recommended dashboard for most users. It contains the following sections:
 
-* **Blockchain**: Block execution speed and processing times.
-* **Block consume delay**: Latency between block production and consumption.
-* **RPC**: Request rates and response times for the JSON-RPC interface.
-* **Private api** (collapsed): Internal gRPC API metrics.
+- **Blockchain**: Block execution speed and processing times.
+- **Block consume delay**: Latency between block production and consumption.
+- **RPC**: Request rates and response times for the JSON-RPC interface.
+- **Private api** (collapsed): Internal gRPC API metrics.
 
-**`erigon_internals.json`** is a low-level dashboard used by the Erigon development team for deep internal debugging. It is exported from Erigon's own Grafana Cloud instance and requires a pre-release Grafana build — it is _not recommended_ for typical users or self-hosted setups.
+**`erigon_internals.json`** is a low-level dashboard used by the Erigon development team for deep internal debugging. It is exported from Erigon's own Grafana Cloud instance and requires a pre-release Grafana build — it is *not recommended* for typical users or self-hosted setups.
 
 #### Step 6: Memory Usage Monitoring (Important Note)
 
@@ -4056,12 +4219,12 @@ The dedicated panels in the `erigon.json` dashboard track accurate Go memory sta
 
 You can customize the setup using environment variables:
 
-| **Variable**               | **Description**                           |
-| -------------------------- | ----------------------------------------- |
-| `XDG_DATA_HOME`            | Changes default database folder location.  |
-| `ERIGON_PROMETHEUS_CONFIG` | Path to a custom `prometheus.yml` file.    |
-| `ERIGON_GRAFANA_CONFIG`    | Path to a custom `grafana.ini` file.       |
-| `ERIGON_GRAFANA_DASHBOARD` | Path to a custom dashboards directory.     |
+| **Variable** | **Description** |
+| --- | --- |
+| `XDG_DATA_HOME` | Changes default database folder location. |
+| `ERIGON_PROMETHEUS_CONFIG` | Path to a custom `prometheus.yml` file. |
+| `ERIGON_GRAFANA_CONFIG` | Path to a custom `grafana.ini` file. |
+| `ERIGON_GRAFANA_DASHBOARD` | Path to a custom dashboards directory. |
 
 Example with a Custom Prometheus Configuration:
 
@@ -4071,10 +4234,10 @@ ERIGON_PROMETHEUS_CONFIG=/path/to/custom/prometheus.yml docker compose up promet
 
 #### Troubleshooting
 
-* Ensure Erigon is running with the `--metrics` flag enabled.
-* Verify Prometheus can reach your Erigon metrics endpoint (default port: `6061`).
-* Check Docker container logs if services fail to start.
-* Confirm firewall settings allow access to monitoring ports.
+- Ensure Erigon is running with the `--metrics` flag enabled.
+- Verify Prometheus can reach your Erigon metrics endpoint (default port: `6061`).
+- Check Docker container logs if services fail to start.
+- Confirm firewall settings allow access to monitoring ports.
 
 #### For Developers
 
@@ -4084,7 +4247,6 @@ Custom metrics can be added by searching for `grpc_prometheus.Register` within t
 
 # Docker Compose
 URL: https://docs.erigon.tech/fundamentals/docker-compose
-
 
 #### Understanding File Permissions
 
@@ -4191,7 +4353,6 @@ If your Docker installation requires the Docker daemon to run as root (which is 
 # web3 Wallet
 URL: https://docs.erigon.tech/fundamentals/web3-wallet
 
-
 Whatever network you are running, it's easy to connect your Erigon node to your local web3 wallet.
 
 For Erigon to provide access to wallet functionalities it is necessary to enable RPC by adding the flags
@@ -4210,14 +4371,14 @@ For example:
 
 To configure your local Metamask wallet (browser extension):
 
-* Click on the **network selector button**. This will display a list of networks to which you're already connected
-* Click **Add network**
-* A new browser tab will open, displaying various fields to fill out. Complete the fields with the proper information, in this example for Ethereum network:
-  * **Network Name**: `Ethereum on E3` (or any name of your choice)
-  * **Chain ID**: `1` for chain ID parameter see [Supported Networks](supported-networks)
-  * **New RPC URL**: `http://127.0.0.1:8545`
-  * **Currency Symbol**: `ETH`
-  * **Block Explorer URL**: `https://www.etherscan.io` (or any explorer of your choice)
+- Click on the **network selector button**. This will display a list of networks to which you're already connected
+- Click **Add network**
+- A new browser tab will open, displaying various fields to fill out. Complete the fields with the proper information, in this example for Ethereum network:
+  - **Network Name**: `Ethereum on E3` (or any name of your choice)
+  - **Chain ID**: `1` for chain ID parameter see [Supported Networks](https://docs.erigon.tech/fundamentals/supported-networks)
+  - **New RPC URL**: `http://127.0.0.1:8545`
+  - **Currency Symbol**: `ETH`
+  - **Block Explorer URL**: `https://www.etherscan.io` (or any explorer of your choice)
 
 After performing the above steps, you will be able to see the custom network the next time you access the network selector.
 
@@ -4227,8 +4388,6 @@ After performing the above steps, you will be able to see the custom network the
 URL: https://docs.erigon.tech/fundamentals/modules
 
 Erigon's internal components can run as separate processes for scalability, security, or custom deployments. Only split them when you have a clear reason to.
-
-## Sections
 
 - [RPC Daemon](https://docs.erigon.tech/fundamentals/modules/rpc-daemon): Serve JSON-RPC requests as a separate, remoteable process — the most battle-tested external component.
 - [TxPool](https://docs.erigon.tech/fundamentals/modules/txpool): Manage the pending transaction pool as a standalone service, decoupled from the main node process.
@@ -4240,8 +4399,7 @@ Erigon's internal components can run as separate processes for scalability, secu
 # RPC Daemon
 URL: https://docs.erigon.tech/fundamentals/modules/rpc-daemon
 
-
-The RPC Daemon is a core component of Erigon that implements the [RPC Service](../../interacting-with-erigon/) by processing JSON remote procedure calls (RPCs). It can be deployed in-process (running inside Erigon) or out-of-process (as a standalone service).
+The RPC Daemon is a core component of Erigon that implements the [RPC Service](https://docs.erigon.tech/interacting-with-erigon) by processing JSON remote procedure calls (RPCs). It can be deployed in-process (running inside Erigon) or out-of-process (as a standalone service).
 
 ### RPC Deployment Modes
 
@@ -4250,17 +4408,17 @@ The Erigon RPC service offers three distinct deployment modes when it comes to t
 | Mode | Configuration | CLI Command to Run | Key Characteristics |
 | --- | --- | --- | --- |
 | Embedded | RPC server is hosted within the `erigon` process. | `./build/bin/erigon` | The simplest, all-in-one solution. No separate RPC command is needed. |
-| Local | `rpcdaemon` runs as a standalone process on the same machine as `erigon`. It directly accesses local data storage. | **Erigon:** `./build/bin/erigon --private.api.addr="<host_IP>:9090"`**rpcdaemon:** `./build/bin/rpcdaemon --datadir="<erigon_data_path>"` | Improves isolation, increases tuning options, and maintains high-performance data access. Requires two processes running on the same machine. |
-| Remote | `rpcdaemon` runs as a standalone process on a separate machine and accesses data storage remotely via the Erigon gRPC interface. | **Erigon:** `./build/bin/erigon --private.api.addr="<host_IP>:9090"`**rpcdaemon:** `./build/bin/rpcdaemon --private.api.addr="<erigon_IP>:9090"` | Scalable, leverages the same data storage for multiple service endpoints. Uses `--private.api.addr` to point the daemon to the remote Erigon instance. |
+| Local | `rpcdaemon` runs as a standalone process on the same machine as `erigon`. It directly accesses local data storage. | **Erigon:** `./build/bin/erigon --private.api.addr="<host_IP>:9090"` **rpcdaemon:** `./build/bin/rpcdaemon --datadir="<erigon_data_path>"` | Improves isolation, increases tuning options, and maintains high-performance data access. Requires two processes running on the same machine. |
+| Remote | `rpcdaemon` runs as a standalone process on a separate machine and accesses data storage remotely via the Erigon gRPC interface. | **Erigon:** `./build/bin/erigon --private.api.addr="<host_IP>:9090"` **rpcdaemon:** `./build/bin/rpcdaemon --private.api.addr="<erigon_IP>:9090"` | Scalable, leverages the same data storage for multiple service endpoints. Uses `--private.api.addr` to point the daemon to the remote Erigon instance. |
 
 For a comprehensive understanding and the latest instructions, the official documentation is essential:
 
-* **Detailed Functionality and Configuration**: The primary documentation for the `rpcdaemon` is located at [https://github.com/erigontech/erigon/blob/main/cmd/rpcdaemon/README.md](https://github.com/erigontech/erigon/blob/main/cmd/rpcdaemon/README.md).
-* **Local Access**: This documentation is also contained in your locally compiled Erigon folder at `/cmd/rpcdaemon`.
-* **Remote Running Instructions**: For detailed instructions on running RPC in Remote mode, refer to the documentation [here](https://github.com/erigontech/erigon/blob/main/cmd/rpcdaemon/README.md#running-remotely).
+- **Detailed Functionality and Configuration**: The primary documentation for the `rpcdaemon` is located at [https://github.com/erigontech/erigon/blob/main/cmd/rpcdaemon/README.md](https://github.com/erigontech/erigon/blob/main/cmd/rpcdaemon/README.md).
+- **Local Access**: This documentation is also contained in your locally compiled Erigon folder at `/cmd/rpcdaemon`.
+- **Remote Running Instructions**: For detailed instructions on running RPC in Remote mode, refer to the documentation [here](https://github.com/erigontech/erigon/blob/main/cmd/rpcdaemon/README.md#running-remotely).
 
 :::tip
-To interact with the **RPC Service** visit the dedicated page [Interacting with Erigon](../../interacting-with-erigon/).
+To interact with the **RPC Service** visit the dedicated page [Interacting with Erigon](https://docs.erigon.tech/interacting-with-erigon).
 :::
 
 ## Command Line Options
@@ -4363,7 +4521,6 @@ Flags:
 # TxPool
 URL: https://docs.erigon.tech/fundamentals/modules/txpool
 
-
 The transaction pool, also known as the mempool, is a dynamic storage area where pending transactions are held before being confirmed and added to the blockchain. Each node on the Ethereum network maintains its own local transaction pool, which is combined with others to form the global pool.
 
 In Erigon, the TxPool is a dedicated API namespace that stores pending and queued transactions in local memory. Its primary function is to manage transactions waiting to be processed by miners.
@@ -4385,7 +4542,7 @@ cd erigon
 make txpool
 ```
 
-2. Together with external TxPool also [Sentry](sentry) and [RPC Daemon](rpc-daemon) must be compiled and run separately.
+2. Together with external TxPool also [Sentry](https://docs.erigon.tech/fundamentals/modules/sentry) and [RPC Daemon](https://docs.erigon.tech/fundamentals/modules/rpc-daemon) must be compiled and run separately.
 
 ```bash
 make sentry
@@ -4417,14 +4574,14 @@ If Erigon is on a different device, add the flags `--pprof --pprof.addr 0.0.0.0`
 
 ## Flags explanation
 
-* `--txpool.disable`: This flag disables the internal transaction pool (TxPool) and block producer (default: `false`). When running the TxPool as a separate process, this flag is used to prevent the internal TxPool from interfering with the external one.
-* `--private.api.addr=localhost:9090`: This flag sets the address and port for the private API. The private API is used for internal communication between Erigon components (default: `127.0.0.1:9090`).
-* `--datadir=<your datadir>`: This flag specifies the data directory for Erigon. This is where Erigon stores its databases and other data.
-* `--http=false`: This flag disables the HTTP API server in Erigon (default: `true`). When running the TxPool as a separate process, this flag is used to prevent the internal HTTP server from interfering with the external TxPool.
-* `--sentry.api.addr=localhost:9091`: This flag sets the address and port for the Sentry API. The Sentry API is used for communication between the TxPool and the Sentry.
-* `--txpool.api.addr=localhost:9094`: This flag sets the address and port for the TxPool API (default: use value of `--private.api.addr`). The TxPool API is used for communication between the TxPool and other Erigon components.
-* `--pprof`: Enable the pprof HTTP server (default: `false`)
-* `--pprof.addr 0.0.0.0`: This flag sets the address for the pprof HTTP server (default: `127.0.0.1`). The pprof server is used for profiling and debugging Erigon. By setting this flag to `0.0.0.0`, the pprof server is made accessible from outside the local machine.
+- `--txpool.disable`: This flag disables the internal transaction pool (TxPool) and block producer (default: `false`). When running the TxPool as a separate process, this flag is used to prevent the internal TxPool from interfering with the external one.
+- `--private.api.addr=localhost:9090`: This flag sets the address and port for the private API. The private API is used for internal communication between Erigon components (default: `127.0.0.1:9090`).
+- `--datadir=<your datadir>`: This flag specifies the data directory for Erigon. This is where Erigon stores its databases and other data.
+- `--http=false`: This flag disables the HTTP API server in Erigon (default: `true`). When running the TxPool as a separate process, this flag is used to prevent the internal HTTP server from interfering with the external TxPool.
+- `--sentry.api.addr=localhost:9091`: This flag sets the address and port for the Sentry API. The Sentry API is used for communication between the TxPool and the Sentry.
+- `--txpool.api.addr=localhost:9094`: This flag sets the address and port for the TxPool API (default: use value of `--private.api.addr`). The TxPool API is used for communication between the TxPool and other Erigon components.
+- `--pprof`: Enable the pprof HTTP server (default: `false`)
+- `--pprof.addr 0.0.0.0`: This flag sets the address for the pprof HTTP server (default: `127.0.0.1`). The pprof server is used for profiling and debugging Erigon. By setting this flag to `0.0.0.0`, the pprof server is made accessible from outside the local machine.
 
 ## Command Line Options
 
@@ -4490,18 +4647,18 @@ Flags:
 # Sentry
 URL: https://docs.erigon.tech/fundamentals/modules/sentry
 
-
 Sentry connects Erigon to the Ethereum P2P network, enabling the discovery of other participants across the Internet and secure communication with them. It performs these main functions:
 
-* Peer discovery via the following:
-  * Kademlia DHT
-  * DNS lookup
-  * Configured static peers
-  * Node info saved in the database
-  * Boot nodes pre-configured in the source code
-* Peer management:
-  * handshakes
-  * holding p2p connection even if Erigon is restarted
+- Peer discovery via the following:
+  - Kademlia DHT
+  - DNS lookup
+  - Configured static peers
+  - Node info saved in the database
+  - Boot nodes pre-configured in the source code
+
+- Peer management:
+  - handshakes
+  - holding p2p connection even if Erigon is restarted
 
 The ETH core interacts with the Ethereum p2p network through the Sentry component. Sentry provides a simple interface to the core, with functions to download data, receive notifications about gossip messages, upload data on request from peers, and broadcast gossip messages either to a selected set of peers or to all peers.
 
@@ -4615,7 +4772,6 @@ Flags:
 # Downloader
 URL: https://docs.erigon.tech/fundamentals/modules/downloader
 
-
 The Downloader is a service responsible for seeding and downloading historical data using the BitTorrent protocol. Data is stored in the form of immutable `.seg` files, known as **snapshots**. The Ethereum core instructs the Downloader to download specific files, identified by their unique info hashes, which include both block headers and block bodies. The Downloader then communicates with the BitTorrent network to retrieve the necessary files, as specified by the Ethereum core.
 
 :::warning
@@ -4636,9 +4792,9 @@ For a comprehensive understanding of the Downloader's functionality, configurati
 
 Some of the key sections in the documentation include:
 
-* **How to create new snapshots**: Instructions on how to create new snapshots, including using the `seg` command and creating .torrent files.
-* **How to start the Downloader**: Instructions on how to start the Downloader, either as a separate process or as part of Erigon.
-* **How to verify .seg files**: Instructions on how to verify that .seg files have the same checksum as the current .torrent files.
+- **How to create new snapshots**: Instructions on how to create new snapshots, including using the `seg` command and creating .torrent files.
+- **How to start the Downloader**: Instructions on how to start the Downloader, either as a separate process or as part of Erigon.
+- **How to verify .seg files**: Instructions on how to verify that .seg files have the same checksum as the current .torrent files.
 
 By referring to the embedded documentation file, you can gain a deeper understanding of the Downloader's capabilities and how to effectively utilize it in your Erigon setup.
 
@@ -4731,30 +4887,29 @@ Use " [command] --help" for more information about a command.
 # Interacting with Erigon
 URL: https://docs.erigon.tech/interacting-with-erigon
 
+The Erigon RPC Service, managed by Erigon's modular [RPC Daemon](https://docs.erigon.tech/fundamentals/modules/rpc-daemon), supports various API namespaces, which can be enabled or disabled using the `--http.api` flag. The available namespaces include:
 
-The Erigon RPC Service, managed by Erigon's modular [RPC Daemon](/fundamentals/modules/rpc-daemon), supports various API namespaces, which can be enabled or disabled using the `--http.api` flag. The available namespaces include:
-
-* [`eth`](/interacting-with-erigon/eth): Standard Ethereum API.
-* [`erigon`](/interacting-with-erigon/erigon): Erigon-specific extensions.
-* [`engine`](/interacting-with-erigon/engine): The JSON-RPC Interface for Execution and Consensus Layer Communication.
-* [`web3`](/interacting-with-erigon/web3): Web3 compatibility API.
-* [`net`](/interacting-with-erigon/net): Network information API.
-* [`debug`](/interacting-with-erigon/debug): Debugging and tracing API.
-* [`trace`](/interacting-with-erigon/trace): Transaction tracing API.
-* [`txpool`](/interacting-with-erigon/txpool): Transaction pool API.
-* [`admin`](/interacting-with-erigon/admin): Node administration API
-* [`ots`](/interacting-with-erigon/ots): These methods are specifically tailored for use with Otterscan, an open-source, fast block explorer.
-* [`internal`](/interacting-with-erigon/internal): Erigon specific API for development and debugging purposes.
-* [`gRPC`](/interacting-with-erigon/grpc): API for lower-level data access.
-* [`overlay`](/interacting-with-erigon/overlay): Erigon-specific overlay API for replaying blocks with state overrides (archive nodes only).
-* [`parity`](/interacting-with-erigon/parity): Partial OpenEthereum compatibility (`parity_listStorageKeys`).
-* [`graphql`](/interacting-with-erigon/graphql): GraphQL endpoint following the ethereum/execution-apis schema.
+- [`eth`](https://docs.erigon.tech/interacting-with-erigon/eth): Standard Ethereum API.
+- [`erigon`](https://docs.erigon.tech/interacting-with-erigon/erigon): Erigon-specific extensions.
+- [`engine`](https://docs.erigon.tech/interacting-with-erigon/engine): The JSON-RPC Interface for Execution and Consensus Layer Communication.
+- [`web3`](https://docs.erigon.tech/interacting-with-erigon/web3): Web3 compatibility API.
+- [`net`](https://docs.erigon.tech/interacting-with-erigon/net): Network information API.
+- [`debug`](https://docs.erigon.tech/interacting-with-erigon/debug): Debugging and tracing API.
+- [`trace`](https://docs.erigon.tech/interacting-with-erigon/trace): Transaction tracing API.
+- [`txpool`](https://docs.erigon.tech/interacting-with-erigon/txpool): Transaction pool API.
+- [`admin`](https://docs.erigon.tech/interacting-with-erigon/admin): Node administration API
+- [`ots`](https://docs.erigon.tech/interacting-with-erigon/ots): These methods are specifically tailored for use with Otterscan, an open-source, fast block explorer.
+- [`internal`](https://docs.erigon.tech/interacting-with-erigon/internal): Erigon specific API for development and debugging purposes.
+- [`gRPC`](https://docs.erigon.tech/interacting-with-erigon/grpc): API for lower-level data access.
+- [`overlay`](https://docs.erigon.tech/interacting-with-erigon/overlay): Erigon-specific overlay API for replaying blocks with state overrides (archive nodes only).
+- [`parity`](https://docs.erigon.tech/interacting-with-erigon/parity): Partial OpenEthereum compatibility (`parity_listStorageKeys`).
+- [`graphql`](https://docs.erigon.tech/interacting-with-erigon/graphql): GraphQL endpoint following the ethereum/execution-apis schema.
 
 For a complete reference on the standard Ethereum JSON-RPC methods, especially those in the `eth`, `net`, and `web3` namespaces, it is recommended to consult the general documentation on [ethereum.org's JSON-RPC API page](https://ethereum.org/en/developers/docs/apis/json-rpc/). Additionally, for the formal specification of the `debug`, `engine`, and `eth` namespaces, including unique, detailed descriptions for methods like `eth_getProof` and `eth_simulateV1`, refer to the [Execution APIs documentation](https://ethereum.github.io/execution-apis).
 
 ## Erigon RPC Transports
 
-Erigon supports [HTTP](/interacting-with-erigon/#http), [HTTPS](/interacting-with-erigon/#https), [WebSockets](/interacting-with-erigon/#websockets), [IPC](/interacting-with-erigon/#ipc), [gRPC](/interacting-with-erigon/#grpc) and [GraphQL](/interacting-with-erigon/#graphql) through its RPC Daemon.
+Erigon supports [HTTP](https://docs.erigon.tech/interacting-with-erigon#http), [HTTPS](https://docs.erigon.tech/interacting-with-erigon#https), [WebSockets](https://docs.erigon.tech/interacting-with-erigon#websockets), [IPC](https://docs.erigon.tech/interacting-with-erigon#ipc), [gRPC](https://docs.erigon.tech/interacting-with-erigon#grpc) and [GraphQL](https://docs.erigon.tech/interacting-with-erigon#graphql) through its RPC Daemon.
 
 ### HTTP
 
@@ -4772,7 +4927,7 @@ erigon --http
 rpcdaemon --http.enabled
 ```
 
-The default port is `8545`, and the default listen address is localhost. _node/nodecfg/defaults.go:30-31_
+The default port is `8545`, and the default listen address is localhost. *node/nodecfg/defaults.go:30-31*
 
 You can configure the listen address and port using `--http.addr` and `--http.port` respectively:
 
@@ -4812,21 +4967,15 @@ Erigon supports HTTPS and HTTP/2 out of the box:
 rpcdaemon --https.enabled --https.cert /path/to/cert.pem --https.key /path/to/key.pem
 ```
 
-**New in v3.7:** the same flags work on the `erigon` binary, so the embedded RPC server can serve TLS without a separate
-daemon:
+**New in v3.7:** the same flags work on the `erigon` binary, so the embedded RPC server can serve TLS without a separate daemon:
 
 ```bash
 erigon --https.enabled --https.cert /path/to/cert.pem --https.key /path/to/key.pem
 ```
 
-The HTTPS listener is independent of the plain HTTP one and binds its own port: `--https.port`, which defaults to
-`--http.port` + 363 (`8908` with a default `--http.port`) — the derivation reads `--http.port` whether or not the plain
-HTTP listener is running. Both `--https.cert` and `--https.key` are required — if either is missing the
-port still binds but TLS serving fails with only a `Failed to serve https endpoint` warning in the log. Setting
-`--https.url` enables the HTTPS server on its own and overrides `--https.addr` and `--https.port`.
+The HTTPS listener is independent of the plain HTTP one and binds its own port: `--https.port`, which defaults to `--http.port` + 363 (`8908` with a default `--http.port`) — the derivation reads `--http.port` whether or not the plain HTTP listener is running. Both `--https.cert` and `--https.key` are required — if either is missing the port still binds but TLS serving fails with only a `Failed to serve https endpoint` warning in the log. Setting `--https.url` enables the HTTPS server on its own and overrides `--https.addr` and `--https.port`.
 
-Note that `--http=false` switches off the entire RPC stack, HTTPS included. For a TLS-only node, keep `--http` and
-disable just the plain HTTP listener with `--http.enabled=false`.
+Note that `--http=false` switches off the entire RPC stack, HTTPS included. For a TLS-only node, keep `--http` and disable just the plain HTTP listener with `--http.enabled=false`.
 
 ### WebSockets
 
@@ -4838,10 +4987,10 @@ Because WebSockets are bidirectional, nodes can push events to clients, which en
 
 The configuration of the WebSocket server follows the same pattern as the HTTP server:
 
-* Enable it using `--ws`
-* Configure the server port by passing `--ws.port` (default `8546`) _node/nodecfg/defaults.go:34_
-* Configure cross-origin requests using `--ws.origins` (though this maps to `--http.corsdomain` in Erigon)
-* WebSocket APIs inherit from the HTTP API configuration
+- Enable it using `--ws`
+- Configure the server port by passing `--ws.port` (default `8546`) *node/nodecfg/defaults.go:34*
+- Configure cross-origin requests using `--ws.origins` (though this maps to `--http.corsdomain` in Erigon)
+- WebSocket APIs inherit from the HTTP API configuration
 
 ```bash
 erigon --http --ws --http.api eth,net,debug,trace
@@ -4851,21 +5000,17 @@ erigon --http --ws --http.api eth,net,debug,trace
 
 IPC is a simpler transport protocol for use in local environments where the node and the client exist on the same machine.
 
-**New in v3.7:** the `erigon` binary accepts `--socket.enabled` and `--socket.url` directly, so IPC no longer requires a
-separate process:
+**New in v3.7:** the `erigon` binary accepts `--socket.enabled` and `--socket.url` directly, so IPC no longer requires a separate process:
 
 ```bash
 erigon --datadir=<path-to-datadir> --socket.enabled --socket.url unix:///<path-to-datadir>/erigon.ipc
 ```
 
-The default `--socket.url` is `unix:///var/run/erigon.sock`, which is usually not writable by the Erigon user — point it
-at your datadir as above. On earlier releases these flags exist only on `rpcdaemon`, and the geth-style `--ipcpath`
-endpoint remains permanently disabled in the `erigon` binary regardless of release.
+The default `--socket.url` is `unix:///var/run/erigon.sock`, which is usually not writable by the Erigon user — point it at your datadir as above. On earlier releases these flags exist only on `rpcdaemon`, and the geth-style `--ipcpath` endpoint remains permanently disabled in the `erigon` binary regardless of release.
 
 #### Enabling IPC with RPC Daemon
 
-IPC is also available from the standalone daemon, which is still the right choice when RPC serving runs on its own
-process or host.
+IPC is also available from the standalone daemon, which is still the right choice when RPC serving runs on its own process or host.
 
 First, start Erigon with the private API enabled:
 
@@ -4881,8 +5026,7 @@ rpcdaemon --private.api.addr=localhost:9090 --socket.enabled --socket.url unix:/
 
 **Important:** Make sure you have write permissions to the directory where the socket will be created.
 
-On Linux and macOS, Erigon uses UNIX sockets. On Windows, IPC is provided using named pipes (use `\\.\pipe\erigon.ipc`
-format). The socket inherits the API namespaces from the `--http.api` flag passed to `rpcdaemon`:
+On Linux and macOS, Erigon uses UNIX sockets. On Windows, IPC is provided using named pipes (use `\\.\pipe\erigon.ipc` format). The socket inherits the API namespaces from the `--http.api` flag passed to `rpcdaemon`:
 
 ```bash
 rpcdaemon --private.api.addr=localhost:9090 --socket.enabled --socket.url unix:///<path-to-datadir>/erigon.ipc --http.api eth,net,web3,debug,trace
@@ -4896,8 +5040,7 @@ You can also serve the raw JSON-RPC2 protocol over TCP instead of Unix sockets:
 rpcdaemon --private.api.addr=localhost:9090 --socket.enabled --socket.url tcp://127.0.0.1:8546
 ```
 
-**Note**: This creates a raw JSON-RPC2 socket without HTTP wrapping. Most users should use the HTTP endpoint (enabled by
-default on port 8545) instead. The TCP socket is for specialized clients that support raw JSON-RPC2 protocol.
+**Note**: This creates a raw JSON-RPC2 socket without HTTP wrapping. Most users should use the HTTP endpoint (enabled by default on port 8545) instead. The TCP socket is for specialized clients that support raw JSON-RPC2 protocol.
 
 #### Testing IPC Connection
 
@@ -4958,7 +5101,6 @@ cast rpc erigon_forks
 # eth
 URL: https://docs.erigon.tech/interacting-with-erigon/eth
 
-
 The `eth` namespace is the foundational and most commonly used API set in Ethereum's JSON-RPC interface. It provides core functionality for interacting with the Ethereum blockchain, enabling users and applications to read blockchain state and submit transactions.
 
 Key methods within this namespace allow you to check an account's balance (`eth_getBalance`), get the current block number (`eth_blockNumber`), retrieve transaction details (`eth_getTransactionByHash`), and send signed transactions to the network (`eth_sendRawTransaction`, `eth_sendRawTransactionSync`). Essentially, the `eth` namespace contains all the fundamental tools needed to observe and participate in the life of the chain.
@@ -4967,14 +5109,14 @@ Key methods within this namespace allow you to check an account's balance (`eth_
 
 For API usage refer to the below official resources:
 
-* [https://ethereum.org/en/developers/docs/apis/json-rpc/](https://ethereum.org/en/developers/docs/apis/json-rpc/)
-* [https://ethereum.github.io/execution-apis/](https://ethereum.github.io/execution-apis/)
+- [https://ethereum.org/en/developers/docs/apis/json-rpc/](https://ethereum.org/en/developers/docs/apis/json-rpc/)
+- [https://ethereum.github.io/execution-apis/](https://ethereum.github.io/execution-apis/)
 
 ### Pending state
 
 Erigon does not support the `pending` block tag for `eth_call`, `eth_createAccessList`, `eth_getProof`, `eth_getWitness`, `eth_getTxWitness`, or `eth_simulateV1`. These methods need a block header and state from the same view, and Erigon cannot currently acquire a matching pending-state view. They return `pending state is not supported` instead of executing against a different block. Other `eth` methods keep their existing pending behavior.
 
-### eth\_getProof
+### eth_getProof
 
 `eth_getProof` returns Merkle proofs for account state and storage slots, as defined in [EIP-1186](https://eips.ethereum.org/EIPS/eip-1186). It is stable and production-ready as of Erigon v3.4.
 
@@ -4990,15 +5132,15 @@ To enable historical proof support, activate commitment history storage at start
 
 This enables faster retrieval of Merkle proofs for any executed block.
 
-### eth\_getStorageValues
+### eth_getStorageValues
 
 `eth_getStorageValues` reads several storage slots for one or more accounts in a single call, reducing round-trips compared to multiple `eth_getStorageAt` calls. It is part of the [Ethereum execution APIs](https://github.com/ethereum/execution-apis/blob/main/src/eth/state.yaml) and takes two parameters.
 
 **Parameters**
 
-| Parameter   | Type             | Description                                                                                       |
-| ----------- | ---------------- | ------------------------------------------------------------------------------------------------- |
-| requests    | OBJECT           | Maps each account address to an array of 32-byte storage slot keys (hex-encoded)                   |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| requests | OBJECT | Maps each account address to an array of 32-byte storage slot keys (hex-encoded) |
 | blockNumber | STRING or NUMBER | Optional. Block number, block hash or tag (`"latest"`, `"earliest"`, etc.). Defaults to `"latest"` |
 
 **Example**
@@ -5029,15 +5171,14 @@ An object mapping each requested address to an array of 32-byte values, in the s
 
 **Limits**
 
-* A single call may request at most 1024 slots in total, counting all addresses together. Larger requests are rejected.
-* An empty `requests` object returns error code `-32602` with the message `empty request`.
-* When `blockNumber` is a block hash, the block must be canonical.
+- A single call may request at most 1024 slots in total, counting all addresses together. Larger requests are rejected.
+- An empty `requests` object returns error code `-32602` with the message `empty request`.
+- When `blockNumber` is a block hash, the block must be canonical.
 
 ---
 
 # erigon
 URL: https://docs.erigon.tech/interacting-with-erigon/erigon
-
 
 Erigon provides several RPC namespaces that extend beyond the standard Ethereum JSON-RPC API, exposing Erigon-specific functionality and data structures. The primary Erigon-specific namespace is **`erigon_`** which offer extended blockchain data access methods.
 
@@ -5045,25 +5186,23 @@ These methods must be explicitly enabled using the `--http.api` flag when starti
 
 ### Namespace Availability
 
-* The `erigon_` namespace is enabled by default in the RPC Daemon and must be explicitly included in the `--http.api` flag if customizing enabled namespaces.
+- The `erigon_` namespace is enabled by default in the RPC Daemon and must be explicitly included in the `--http.api` flag if customizing enabled namespaces.
 
 ### Performance Considerations
 
-* Erigon-specific methods are optimized for Erigon's architecture and often provide better performance than standard equivalents
-* Methods like `erigon_getHeaderByNumber` and `erigon_getHeaderByHash` can be faster as they skip transaction and uncle data
-* The `erigon_getLatestLogs` method includes advanced pagination to handle large result sets efficiently
+- Erigon-specific methods are optimized for Erigon's architecture and often provide better performance than standard equivalents
+- Methods like `erigon_getHeaderByNumber` and `erigon_getHeaderByHash` can be faster as they skip transaction and uncle data
+- The `erigon_getLatestLogs` method includes advanced pagination to handle large result sets efficiently
 
 ### Enhanced Features
 
-* `erigon_getLatestLogs` supports `ignoreTopicsOrder` for flexible topic matching
-* `erigon_getLogs` returns enhanced RPCLog objects with additional metadata like timestamps
-* `erigon_getBlockByTimestamp` uses binary search for efficient timestamp-based block lookup
+- `erigon_getLatestLogs` supports `ignoreTopicsOrder` for flexible topic matching
+- `erigon_getLogs` returns enhanced RPCLog objects with additional metadata like timestamps
+- `erigon_getBlockByTimestamp` uses binary search for efficient timestamp-based block lookup
 
 See more details [here](https://github.com/erigontech/erigon/blob/main/cmd/rpcdaemon/README.md#rpc-implementation-status) about implementation status.
 
-***
-
-## **erigon\_forks**
+## **erigon_forks**
 
 Returns the genesis block hash and a sorted list of all fork block numbers for the current chain configuration.
 
@@ -5079,23 +5218,21 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_forks","params":[],"id":"1"}' 
 
 **Returns**
 
-| Type        | Description                                                   |
-| ----------- | ------------------------------------------------------------- |
-| Object      | Contains genesis hash and fork information                    |
-| genesis     | DATA, 32 BYTES - The genesis block hash                       |
+| Type | Description |
+| --- | --- |
+| Object | Contains genesis hash and fork information |
+| genesis | DATA, 32 BYTES - The genesis block hash |
 | heightForks | ARRAY - Array of block numbers where height-based forks occur |
-| timeForks   | ARRAY - Array of timestamps where time-based forks occur      |
+| timeForks | ARRAY - Array of timestamps where time-based forks occur |
 
-***
-
-## **erigon\_blockNumber**
+## **erigon_blockNumber**
 
 Returns the latest executed block number. Unlike `eth_blockNumber`, this method can accept a specific block number parameter and returns the latest executed block rather than the fork choice head after the merge.
 
 **Parameters**
 
-| Parameter   | Type                | Description                                                             |
-| ----------- | ------------------- | ----------------------------------------------------------------------- |
+| Parameter | Type | Description |
+| --- | --- | --- |
 | blockNumber | QUANTITY (optional) | Block number to query. If omitted, returns latest executed block number |
 
 **Example**
@@ -5106,20 +5243,18 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_blockNumber","params":[],"id":
 
 **Returns**
 
-| Type     | Description                     |
-| -------- | ------------------------------- |
+| Type | Description |
+| --- | --- |
 | QUANTITY | The block number as hexadecimal |
 
-***
-
-## **erigon\_getHeaderByNumber**
+## **erigon_getHeaderByNumber**
 
 Returns a block header by block number, ignoring transaction and uncle data for potentially faster response times.
 
 **Parameters**
 
-| Parameter   | Type          | Description                                     |
-| ----------- | ------------- | ----------------------------------------------- |
+| Parameter | Type | Description |
+| --- | --- | --- |
 | blockNumber | QUANTITY\|TAG | Block number or "latest", "earliest", "pending" |
 
 **Example**
@@ -5130,20 +5265,18 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_getHeaderByNumber","params":["
 
 **Returns**
 
-| Type   | Description                                |
-| ------ | ------------------------------------------ |
+| Type | Description |
+| --- | --- |
 | Object | Block header object with all header fields |
 
-***
-
-## **erigon\_getHeaderByHash**
+## **erigon_getHeaderByHash**
 
 Returns a block header by block hash, ignoring transaction and uncle data for potentially faster response times.
 
 **Parameters**
 
-| Parameter | Type           | Description       |
-| --------- | -------------- | ----------------- |
+| Parameter | Type | Description |
+| --- | --- | --- |
 | blockHash | DATA, 32 BYTES | Hash of the block |
 
 **Example**
@@ -5154,22 +5287,20 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_getHeaderByHash","params":["0x
 
 **Returns**
 
-| Type   | Description                                |
-| ------ | ------------------------------------------ |
+| Type | Description |
+| --- | --- |
 | Object | Block header object with all header fields |
 
-***
-
-## **erigon\_getBlockByTimestamp**
+## **erigon_getBlockByTimestamp**
 
 Returns a block by timestamp using binary search to find the closest block to the specified timestamp.
 
 **Parameters**
 
-| Parameter | Type     | Description                                                                  |
-| --------- | -------- | ---------------------------------------------------------------------------- |
-| timestamp | QUANTITY | Unix timestamp                                                               |
-| fullTx    | Boolean  | If true, include full transaction objects; if false, only transaction hashes |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| timestamp | QUANTITY | Unix timestamp |
+| fullTx | Boolean | If true, include full transaction objects; if false, only transaction hashes |
 
 **Example**
 
@@ -5179,20 +5310,18 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_getBlockByTimestamp","params":
 
 **Returns**
 
-| Type   | Description                                    |
-| ------ | ---------------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Object | Block object matching closest to the timestamp |
 
-***
-
-## **erigon\_getBalanceChangesInBlock**
+## **erigon_getBalanceChangesInBlock**
 
 Returns all account balance changes that occurred within a specific block.
 
 **Parameters**
 
-| Parameter     | Type                | Description                      |
-| ------------- | ------------------- | -------------------------------- |
+| Parameter | Type | Description |
+| --- | --- | --- |
 | blockNrOrHash | QUANTITY\|TAG\|HASH | Block number, tag, or block hash |
 
 **Example**
@@ -5203,20 +5332,18 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_getBalanceChangesInBlock","par
 
 **Returns**
 
-| Type   | Description                                      |
-| ------ | ------------------------------------------------ |
+| Type | Description |
+| --- | --- |
 | Object | Mapping of addresses to their new balance values |
 
-***
-
-## **erigon\_getLogsByHash**
+## **erigon_getLogsByHash**
 
 Returns an array of arrays of logs generated by transactions in a block given by block hash.
 
 **Parameters**
 
-| Parameter | Type           | Description       |
-| --------- | -------------- | ----------------- |
+| Parameter | Type | Description |
+| --- | --- | --- |
 | blockHash | DATA, 32 BYTES | Hash of the block |
 
 **Example**
@@ -5227,21 +5354,19 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_getLogsByHash","params":["0x1d
 
 **Returns**
 
-| Type  | Description                                               |
-| ----- | --------------------------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Array | Array of arrays of log objects, one array per transaction |
 
-***
-
-## **erigon\_getLogs**
+## **erigon_getLogs**
 
 Returns an array of logs matching a given filter object with enhanced filtering capabilities.
 
 **Parameters**
 
-| Parameter | Type   | Description                                                                  |
-| --------- | ------ | ---------------------------------------------------------------------------- |
-| filter    | Object | Filter criteria including fromBlock, toBlock, address, topics, and blockHash |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| filter | Object | Filter criteria including fromBlock, toBlock, address, topics, and blockHash |
 
 **Example**
 
@@ -5251,25 +5376,23 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_getLogs","params":[{"fromBlock
 
 **Returns**
 
-| Type  | Description                                       |
-| ----- | ------------------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Array | Array of RPCLog objects with enhanced metadata |
 
 :::note
-The number of logs returned is capped by [`--rpc.logs.maxresults`](../fundamentals/configuring-erigon#rpc--api) (default `20000`). Set to `0` to remove the limit. The block range of the query is independently capped by `--rpc.blockrange.limit` (default `1000`).
+The number of logs returned is capped by [`--rpc.logs.maxresults`](https://docs.erigon.tech/fundamentals/configuring-erigon#rpc--api) (default `20000`). Set to `0` to remove the limit. The block range of the query is independently capped by `--rpc.blockrange.limit` (default `1000`).
 :::
 
-***
-
-## **erigon\_getLatestLogs**
+## **erigon_getLatestLogs**
 
 Returns the latest logs matching a filter criteria in descending order with advanced pagination and topic matching options.
 
 **Parameters**
 
-| Parameter  | Type   | Description                                                   |
-| ---------- | ------ | ------------------------------------------------------------- |
-| filter     | Object | Filter criteria object                                        |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| filter | Object | Filter criteria object |
 | logOptions | Object | Options including logCount, blockCount, and ignoreTopicsOrder |
 
 **Example**
@@ -5280,24 +5403,22 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_getLatestLogs","params":[{"add
 
 **Returns**
 
-| Type  | Description                                                  |
-| ----- | ------------------------------------------------------------ |
+| Type | Description |
+| --- | --- |
 | Array | Array of RPCLog objects in descending chronological order |
 
 :::note
-The number of logs returned is capped by [`--rpc.logs.maxresults`](../fundamentals/configuring-erigon#rpc--api) (default `20000`). Set to `0` to remove the limit.
+The number of logs returned is capped by [`--rpc.logs.maxresults`](https://docs.erigon.tech/fundamentals/configuring-erigon#rpc--api) (default `20000`). Set to `0` to remove the limit.
 :::
 
-***
-
-## **erigon\_getBlockReceiptsByBlockHash**
+## **erigon_getBlockReceiptsByBlockHash**
 
 Returns all transaction receipts for a canonical block by block hash.
 
 **Parameters**
 
-| Parameter | Type           | Description                 |
-| --------- | -------------- | --------------------------- |
+| Parameter | Type | Description |
+| --- | --- | --- |
 | blockHash | DATA, 32 BYTES | Hash of the canonical block |
 
 **Example**
@@ -5308,13 +5429,11 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_getBlockReceiptsByBlockHash","
 
 **Returns**
 
-| Type  | Description                                                |
-| ----- | ---------------------------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Array | Array of receipt objects for all transactions in the block |
 
-***
-
-## **erigon\_nodeInfo**
+## **erigon_nodeInfo**
 
 Returns a collection of metadata known about the host node and connected peers.
 
@@ -5330,17 +5449,14 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_nodeInfo","params":[],"id":"1"
 
 **Returns**
 
-| Type  | Description                                                 |
-| ----- | ----------------------------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Array | Array of NodeInfo objects containing peer and node metadata |
-
-***
 
 ---
 
 # engine
 URL: https://docs.erigon.tech/interacting-with-erigon/engine
-
 
 The Engine API is a standardized JSON-RPC interface defined by the Ethereum specification. Its purpose is to enable secure and structured communication between the Consensus Layer (CL) client and the Execution Layer (EL) client in the post-Merge Proof-of-Stake architecture.
 
@@ -5348,68 +5464,66 @@ The Engine API replaced older `eth_` methods for consensus communication. It is 
 
 For API usage refer to the below official resources:
 
-* [https://ethereum.org/en/developers/docs/apis/json-rpc/](https://ethereum.org/en/developers/docs/apis/json-rpc/)
-* [https://ethereum.github.io/execution-apis/](https://ethereum.github.io/execution-apis/)
+- [https://ethereum.org/en/developers/docs/apis/json-rpc/](https://ethereum.org/en/developers/docs/apis/json-rpc/)
+- [https://ethereum.github.io/execution-apis/](https://ethereum.github.io/execution-apis/)
 
 #### Default Erigon Behavior (Caplin)
 
 By default, Erigon runs its own embedded consensus layer client, Caplin. For optimized performance, Caplin bypasses the Engine API and uses direct internal calls to communicate with Erigon's execution layer.
 
-You can optionally force Caplin to use the Engine API interface by setting the `--caplin.use-engine-api` flag. When this flag is active, Caplin connects via the same [JWT](../fundamentals/jwt)-authenticated HTTP endpoint used by external CL clients.
+You can optionally force Caplin to use the Engine API interface by setting the `--caplin.use-engine-api` flag. When this flag is active, Caplin connects via the same [JWT](https://docs.erigon.tech/fundamentals/jwt)-authenticated HTTP endpoint used by external CL clients.
 
 #### Engine API Functionality
 
 When in use (with external CL clients), the Engine API provides essential methods for Proof-of-Stake operations:
 
-* Payload Execution: `engine_newPayloadV1/V2/V3/V4` validates and executes blocks sent by the CL.
-* Fork Choice Updates: `engine_forkchoiceUpdatedV1/V2/V3` updates the chain head and triggers block building.
-* Payload Retrieval: `engine_getPayloadV1/V2/V3/V4` retrieves built blocks for the CL to propose.
-* Payload Bodies: `engine_getPayloadBodiesByHashV1` and `engine_getPayloadBodiesByRangeV1` fetch historical data.
-* Blob Retrieval: `engine_getBlobsV1/V2/V3` retrieves blobs by versioned hash, with V3 adding support for PeerDAS data columns.
+- Payload Execution: `engine_newPayloadV1/V2/V3/V4` validates and executes blocks sent by the CL.
+- Fork Choice Updates: `engine_forkchoiceUpdatedV1/V2/V3` updates the chain head and triggers block building.
+- Payload Retrieval: `engine_getPayloadV1/V2/V3/V4` retrieves built blocks for the CL to propose.
+- Payload Bodies: `engine_getPayloadBodiesByHashV1` and `engine_getPayloadBodiesByRangeV1` fetch historical data.
+- Blob Retrieval: `engine_getBlobsV1/V2/V3` retrieves blobs by versioned hash, with V3 adding support for PeerDAS data columns.
 
 #### Configuration and Security
 
 For security, the Engine API listens on port 8551 by default and requires JWT authentication.
 
-* A JWT secret is automatically generated and saved in the file `jwt.hex` within your data directory.
-* This secret must be shared with your external consensus layer client to establish secure communication.
-* If your CL client runs on a different machine, you must expose the API using `--authrpc.addr 0.0.0.0` and configure virtual hosts appropriately with `--authrpc.vhosts`.
+- A JWT secret is automatically generated and saved in the file `jwt.hex` within your data directory.
+- This secret must be shared with your external consensus layer client to establish secure communication.
+- If your CL client runs on a different machine, you must expose the API using `--authrpc.addr 0.0.0.0` and configure virtual hosts appropriately with `--authrpc.vhosts`.
 
 ---
 
 # web3
 URL: https://docs.erigon.tech/interacting-with-erigon/web3
 
-
 The `web3` namespace provides utility methods that are part of the standard Ethereum JSON-RPC API. These methods offer basic functionality for client identification and cryptographic operations. In Erigon, the web3 namespace is implemented through the `Web3API` interface and `Web3APIImpl` struct. The web3 namespace is enabled by default in Erigon's RPC Daemon and provides essential utility functions that many Ethereum applications rely on for basic operations.
 
 For API usage refer to the below official resources:
 
-* [https://ethereum.org/en/developers/docs/apis/json-rpc/](https://ethereum.org/en/developers/docs/apis/json-rpc/)
+- [https://ethereum.org/en/developers/docs/apis/json-rpc/](https://ethereum.org/en/developers/docs/apis/json-rpc/)
 
 ### Implementation Details
 
-* The web3 namespace is implemented in `Web3APIImpl` which extends `BaseAPI` and uses the `ethBackend` for client version information
-* The `web3_sha3` method uses Erigon's crypto library implementation of Keccak-256, which is the same hashing algorithm used throughout Ethereum
-* Both methods are lightweight utility functions that don't require complex blockchain state access
+- The web3 namespace is implemented in `Web3APIImpl` which extends `BaseAPI` and uses the `ethBackend` for client version information
+- The `web3_sha3` method uses Erigon's crypto library implementation of Keccak-256, which is the same hashing algorithm used throughout Ethereum
+- Both methods are lightweight utility functions that don't require complex blockchain state access
 
 ### Usage Considerations
 
-* `web3_clientVersion` is often used by applications to identify the Ethereum client type and version for compatibility checks
-* `web3_sha3` provides the same Keccak-256 hashing that's used for Ethereum addresses, transaction hashes, and other cryptographic operations in the protocol
-* These methods are part of the core Ethereum JSON-RPC specification and are supported by all major Ethereum clients
+- `web3_clientVersion` is often used by applications to identify the Ethereum client type and version for compatibility checks
+- `web3_sha3` provides the same Keccak-256 hashing that's used for Ethereum addresses, transaction hashes, and other cryptographic operations in the protocol
+- These methods are part of the core Ethereum JSON-RPC specification and are supported by all major Ethereum clients
 
 ### Availability
 
-* The web3 namespace is enabled by default in Erigon's RPC Daemon
-* No special configuration is required to use these methods
-* They are available on both HTTP and WebSocket connections
+- The web3 namespace is enabled by default in Erigon's RPC Daemon
+- No special configuration is required to use these methods
+- They are available on both HTTP and WebSocket connections
 
 ---
 
 # net
 URL: https://docs.erigon.tech/interacting-with-erigon/net
-
 
 The `net` namespace provides network-related methods that are part of the standard Ethereum JSON-RPC API. These methods offer information about the node's network connectivity, peer count, and network version. In Erigon, the net namespace is implemented through the `NetAPI` interface and `NetAPIImpl` struct.
 
@@ -5417,42 +5531,41 @@ The `net` namespace is enabled by default in Erigon's RPC Daemon and provides es
 
 For API usage refer to the below official resources:
 
-* [https://ethereum.org/en/developers/docs/apis/json-rpc/](https://ethereum.org/en/developers/docs/apis/json-rpc/)
+- [https://ethereum.org/en/developers/docs/apis/json-rpc/](https://ethereum.org/en/developers/docs/apis/json-rpc/)
 
 ### Implementation Details
 
-* The net namespace is implemented in `NetAPIImpl` which uses the `ethBackend` to access network information.
-* `net_listening` determines connectivity by attempting to retrieve peer information from the backend.
-* `net_version` and `net_peerCount` require access to the backend and will return errors in `--datadir` mode when the backend is unavailable.
+- The net namespace is implemented in `NetAPIImpl` which uses the `ethBackend` to access network information.
+- `net_listening` determines connectivity by attempting to retrieve peer information from the backend.
+- `net_version` and `net_peerCount` require access to the backend and will return errors in `--datadir` mode when the backend is unavailable.
 
 ### Backend Dependency
 
-* Methods `net_version` and `net_peerCount` require the `ethBackend` to be available.
-* When running in `--datadir` mode or when the backend cannot be accessed, these methods will return a "not available" error.
-* The `net_listening` method gracefully handles backend unavailability by returning `false` .
+- Methods `net_version` and `net_peerCount` require the `ethBackend` to be available.
+- When running in `--datadir` mode or when the backend cannot be accessed, these methods will return a "not available" error.
+- The `net_listening` method gracefully handles backend unavailability by returning `false` .
 
 ### Network Information Usage
 
-* `net_version` is commonly used by applications to verify they're connected to the correct .Ethereum network.
-* `net_peerCount` helps monitor node connectivity and network health.
-* `net_listening` provides a basic connectivity check for the node's network interface.
+- `net_version` is commonly used by applications to verify they're connected to the correct .Ethereum network.
+- `net_peerCount` helps monitor node connectivity and network health.
+- `net_listening` provides a basic connectivity check for the node's network interface.
 
 ### Availability and Configuration
 
-* The net namespace is enabled by default in Erigon's RPC Daemon.
-* These methods are available on both HTTP and WebSocket connections.
-* For remote RPC Daemon setups, the `net` namespace must be explicitly enabled for health check functionality.
+- The net namespace is enabled by default in Erigon's RPC Daemon.
+- These methods are available on both HTTP and WebSocket connections.
+- For remote RPC Daemon setups, the `net` namespace must be explicitly enabled for health check functionality.
 
 ### Documentation References
 
-* The current implementation shows some limitations noted in the documentation, such as hardcoded return values in certain scenarios.
-* `net_peerCount` specifically counts only internal sentries, which may not reflect the total peer count in distributed setups.
+- The current implementation shows some limitations noted in the documentation, such as hardcoded return values in certain scenarios.
+- `net_peerCount` specifically counts only internal sentries, which may not reflect the total peer count in distributed setups.
 
 ---
 
 # debug
 URL: https://docs.erigon.tech/interacting-with-erigon/debug
-
 
 The `debug` namespace provides debugging and diagnostic methods for Erigon node operators and developers. These methods offer deep introspection into blockchain state, transaction execution, and node performance.
 
@@ -5464,41 +5577,39 @@ The `debug` namespace is intended for debugging and development purposes, not fo
 
 #### Security and Access Control
 
-* Debug methods are considered private and should not be exposed on public RPC endpoints;
-* These methods can consume significant resources and should be used carefully in production environments;
-* Access should be restricted to trusted operators and developers only.
+- Debug methods are considered private and should not be exposed on public RPC endpoints;
+- These methods can consume significant resources and should be used carefully in production environments;
+- Access should be restricted to trusted operators and developers only.
 
 #### Performance Considerations
 
-* Tracing methods (`debug_traceBlockByHash`, `debug_traceBlockByNumber`, `debug_traceTransaction`, `debug_traceCall`, `debug_traceCallMany`) support streaming for large results to reduce memory usage
-* The `AccountRangeMaxResults` constant limits account range queries to 8192 results, or 256 when storage is included;
-* Memory and GC control methods allow fine-tuning of node performance.
-* Some methods like `debug_accountRange` have compatibility layers for both Geth and legacy Erigon parameter formats `debug_api`
+- Tracing methods (`debug_traceBlockByHash`, `debug_traceBlockByNumber`, `debug_traceTransaction`, `debug_traceCall`, `debug_traceCallMany`) support streaming for large results to reduce memory usage
+- The `AccountRangeMaxResults` constant limits account range queries to 8192 results, or 256 when storage is included;
+- Memory and GC control methods allow fine-tuning of node performance.
+- Some methods like `debug_accountRange` have compatibility layers for both Geth and legacy Erigon parameter formats `debug_api`
 
 #### Integration with Erigon Architecture
 
-* Debug methods leverage Erigon's temporal database for historical state access;
-* The implementation uses `kv.TemporalRoDB` for efficient historical queries;
-* Tracing functionality integrates with Erigon's execution engine and EVM implementation.
+- Debug methods leverage Erigon's temporal database for historical state access;
+- The implementation uses `kv.TemporalRoDB` for efficient historical queries;
+- Tracing functionality integrates with Erigon's execution engine and EVM implementation.
 
 #### Usage in Development and Testing
 
-* These methods are essential for debugging transaction execution issues;
-* Storage range methods help analyze contract state changes;
-* Memory management methods assist in performance optimization and resource monitoring.
-
-***
+- These methods are essential for debugging transaction execution issues;
+- Storage range methods help analyze contract state changes;
+- Memory management methods assist in performance optimization and resource monitoring.
 
 ## JSON-RPC Specification
 
-### debug\_getRawReceipts
+### debug_getRawReceipts
 
 Returns an array of EIP-2718 binary-encoded receipts from a single block.
 
 #### Parameters
 
-| Parameter     | Type                    | Description                                                        |
-| ------------- | ----------------------- | ------------------------------------------------------------------ |
+| Parameter | Type | Description |
+| --- | --- | --- |
 | blockNrOrHash | QUANTITY \| TAG \| DATA | Block number, tag ("earliest", "latest", "pending"), or block hash |
 
 #### Example
@@ -5509,24 +5620,24 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_getRawReceipts","params":["0x12
 
 #### Returns
 
-| Type          | Description                                  |
-| ------------- | -------------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Array of DATA | Array of binary-encoded transaction receipts |
 
-### debug\_accountRange
+### debug_accountRange
 
 Returns a range of accounts involved in the given block range.
 
 #### Parameters
 
-| Parameter      | Type            | Description                                                 |
-| -------------- | --------------- | ----------------------------------------------------------- |
-| blockNrOrHash  | QUANTITY \| TAG | Block number or tag                                         |
-| start          | DATAARRAY       | Array of prefixes to match account addresses                |
-| maxResults     | QUANTITY        | Maximum number of accounts to retrieve                      |
-| excludeCode    | BOOLEAN         | If true, exclude byte code from results                     |
-| excludeStorage | BOOLEAN         | If true, exclude storage from results                       |
-| incompletes    | BOOLEAN         | Accepted but ignored                                        |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| blockNrOrHash | QUANTITY \| TAG | Block number or tag |
+| start | DATAARRAY | Array of prefixes to match account addresses |
+| maxResults | QUANTITY | Maximum number of accounts to retrieve |
+| excludeCode | BOOLEAN | If true, exclude byte code from results |
+| excludeStorage | BOOLEAN | If true, exclude storage from results |
+| incompletes | BOOLEAN | Accepted but ignored |
 
 #### Example
 
@@ -5536,21 +5647,21 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_accountRange","params":["0xaaaa
 
 #### Returns
 
-| Type   | Description                                        |
-| ------ | -------------------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Object | IteratorDump object containing account information |
 
-### debug\_accountAt
+### debug_accountAt
 
 Returns account information at a specific block and transaction index.
 
 #### Parameters
 
-| Parameter | Type           | Description                        |
-| --------- | -------------- | ---------------------------------- |
-| blockHash | DATA, 32 Bytes | Hash of the block                  |
-| txIndex   | QUANTITY       | Transaction index within the block |
-| address   | DATA, 20 Bytes | Account address                    |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| blockHash | DATA, 32 Bytes | Hash of the block |
+| txIndex | QUANTITY | Transaction index within the block |
+| address | DATA, 20 Bytes | Account address |
 
 #### Example
 
@@ -5560,20 +5671,20 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_accountAt","params":["0x123456.
 
 #### Returns
 
-| Type   | Description                                           |
-| ------ | ----------------------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Object | AccountResult with balance, nonce, code, and codeHash |
 
-### debug\_getModifiedAccountsByNumber
+### debug_getModifiedAccountsByNumber
 
 Returns a list of accounts modified in the given block range by number.
 
 #### Parameters
 
-| Parameter   | Type            | Description                        |
-| ----------- | --------------- | ---------------------------------- |
-| startNumber | QUANTITY \| TAG | Start block number or tag          |
-| endNumber   | QUANTITY \| TAG | End block number or tag (optional) |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| startNumber | QUANTITY \| TAG | Start block number or tag |
+| endNumber | QUANTITY \| TAG | End block number or tag (optional) |
 
 #### Example
 
@@ -5583,20 +5694,20 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_getModifiedAccountsByNumber","p
 
 #### Returns
 
-| Type                    | Description                         |
-| ----------------------- | ----------------------------------- |
+| Type | Description |
+| --- | --- |
 | Array of DATA, 20 Bytes | Array of modified account addresses |
 
-### debug\_getModifiedAccountsByHash
+### debug_getModifiedAccountsByHash
 
 Returns a list of accounts modified in the given block range by hash.
 
 #### Parameters
 
-| Parameter | Type           | Description                      |
-| --------- | -------------- | -------------------------------- |
-| startHash | DATA, 32 Bytes | Hash of the start block          |
-| endHash   | DATA, 32 Bytes | Hash of the end block (optional) |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| startHash | DATA, 32 Bytes | Hash of the start block |
+| endHash | DATA, 32 Bytes | Hash of the end block (optional) |
 
 #### Example
 
@@ -5606,23 +5717,23 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_getModifiedAccountsByHash","par
 
 #### Returns
 
-| Type                    | Description                         |
-| ----------------------- | ----------------------------------- |
+| Type | Description |
+| --- | --- |
 | Array of DATA, 20 Bytes | Array of modified account addresses |
 
-### debug\_storageRangeAt
+### debug_storageRangeAt
 
 Returns information about a range of storage locations for a contract address.
 
 #### Parameters
 
-| Parameter       | Type              | Description                             |
-| --------------- | ----------------- | --------------------------------------- |
-| blockHash       | DATA, 32 Bytes    | Hash of block at which to retrieve data |
-| txIndex         | QUANTITY, 8 Bytes | Transaction index in the block          |
-| contractAddress | DATA, 20 Bytes    | Contract address                        |
-| keyStart        | DATA, 32 Bytes    | Storage key to start from               |
-| maxResult       | QUANTITY, 8 Bytes | Maximum number of values to retrieve    |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| blockHash | DATA, 32 Bytes | Hash of block at which to retrieve data |
+| txIndex | QUANTITY, 8 Bytes | Transaction index in the block |
+| contractAddress | DATA, 20 Bytes | Contract address |
+| keyStart | DATA, 32 Bytes | Storage key to start from |
+| maxResult | QUANTITY, 8 Bytes | Maximum number of values to retrieve |
 
 #### Example
 
@@ -5632,20 +5743,20 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_storageRangeAt","params":["0xd3
 
 #### Returns
 
-| Type   | Description                                         |
-| ------ | --------------------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Object | StorageRangeResult with key/value pairs and nextKey |
 
-### debug\_traceBlockByHash
+### debug_traceBlockByHash
 
 Returns Geth style transaction traces for a block by hash.
 
 #### Parameters
 
-| Parameter | Type              | Description                 |
-| --------- | ----------------- | --------------------------- |
-| hash      | DATA, 32 Bytes    | Hash of block to trace      |
-| config    | Object (optional) | Trace configuration options |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| hash | DATA, 32 Bytes | Hash of block to trace |
+| config | Object (optional) | Trace configuration options |
 
 #### Example
 
@@ -5655,20 +5766,20 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_traceBlockByHash","params":["0x
 
 #### Returns
 
-| Type  | Description                        |
-| ----- | ---------------------------------- |
+| Type | Description |
+| --- | --- |
 | Array | Array of transaction trace objects |
 
-### debug\_traceBlockByNumber
+### debug_traceBlockByNumber
 
 Returns Geth style transaction traces for a block by number.
 
 #### Parameters
 
-| Parameter   | Type              | Description                 |
-| ----------- | ----------------- | --------------------------- |
-| blockNumber | QUANTITY \| TAG   | Block number or tag; `pending` is not supported |
-| config      | Object (optional) | Trace configuration options |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| blockNumber | QUANTITY \| TAG | Block number or tag; `pending` is not supported |
+| config | Object (optional) | Trace configuration options |
 
 #### Example
 
@@ -5678,20 +5789,20 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_traceBlockByNumber","params":["
 
 #### Returns
 
-| Type  | Description                        |
-| ----- | ---------------------------------- |
+| Type | Description |
+| --- | --- |
 | Array | Array of transaction trace objects |
 
-### debug\_traceTransaction
+### debug_traceTransaction
 
 Returns Geth style transaction trace.
 
 #### Parameters
 
-| Parameter | Type              | Description                  |
-| --------- | ----------------- | ---------------------------- |
-| hash      | DATA, 32 Bytes    | Hash of transaction to trace |
-| config    | Object (optional) | Trace configuration options  |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| hash | DATA, 32 Bytes | Hash of transaction to trace |
+| config | Object (optional) | Trace configuration options |
 
 #### Example
 
@@ -5701,21 +5812,21 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_traceTransaction","params":["0x
 
 #### Returns
 
-| Type   | Description              |
-| ------ | ------------------------ |
+| Type | Description |
+| --- | --- |
 | Object | Transaction trace object |
 
-### debug\_traceCall
+### debug_traceCall
 
 Returns Geth style call trace.
 
 #### Parameters
 
-| Parameter     | Type                    | Description                                           |
-| ------------- | ----------------------- | ----------------------------------------------------- |
-| args          | Object                  | Call arguments (to, from, gas, gasPrice, value, data) |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| args | Object | Call arguments (to, from, gas, gasPrice, value, data) |
 | blockNrOrHash | QUANTITY \| TAG \| DATA | Block number, tag, or hash; `pending` is not supported |
-| config        | Object (optional)       | Trace configuration options                           |
+| config | Object (optional) | Trace configuration options |
 
 #### Example
 
@@ -5725,21 +5836,21 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_traceCall","params":[{"to":"0x1
 
 #### Returns
 
-| Type   | Description       |
-| ------ | ----------------- |
+| Type | Description |
+| --- | --- |
 | Object | Call trace object |
 
-### debug\_traceCallMany
+### debug_traceCallMany
 
 Returns Geth style traces for multiple call bundles.
 
 #### Parameters
 
-| Parameter       | Type              | Description                                        |
-| --------------- | ----------------- | -------------------------------------------------- |
-| bundles         | Array             | Array of transaction bundles to trace              |
-| simulateContext | Object            | Simulation context; `blockNumber` does not support `pending` |
-| config          | Object (optional) | Trace configuration options                        |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| bundles | Array | Array of transaction bundles to trace |
+| simulateContext | Object | Simulation context; `blockNumber` does not support `pending` |
+| config | Object (optional) | Trace configuration options |
 
 #### Example
 
@@ -5749,19 +5860,19 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_traceCallMany","params":[[{"tra
 
 #### Returns
 
-| Type  | Description                            |
-| ----- | -------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Array | Array of trace results for each bundle |
 
-### debug\_setMemoryLimit
+### debug_setMemoryLimit
 
 Sets the GOMEMLIMIT for the process.
 
 #### Parameters
 
-| Parameter | Type     | Description           |
-| --------- | -------- | --------------------- |
-| limit     | QUANTITY | Memory limit in bytes |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| limit | QUANTITY | Memory limit in bytes |
 
 #### Example
 
@@ -5771,19 +5882,19 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_setMemoryLimit","params":[85899
 
 #### Returns
 
-| Type     | Description           |
-| -------- | --------------------- |
+| Type | Description |
+| --- | --- |
 | QUANTITY | Previous memory limit |
 
-### debug\_setGCPercent
+### debug_setGCPercent
 
 Sets the garbage collection target percentage.
 
 #### Parameters
 
-| Parameter | Type     | Description                                |
-| --------- | -------- | ------------------------------------------ |
-| v         | QUANTITY | GC percentage (negative value disables GC) |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| v | QUANTITY | GC percentage (negative value disables GC) |
 
 #### Example
 
@@ -5793,11 +5904,11 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_setGCPercent","params":[100],"i
 
 #### Returns
 
-| Type     | Description                    |
-| -------- | ------------------------------ |
+| Type | Description |
+| --- | --- |
 | QUANTITY | Previous GC percentage setting |
 
-### debug\_freeOSMemory
+### debug_freeOSMemory
 
 Forces a garbage collection to free OS memory.
 
@@ -5813,11 +5924,11 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_freeOSMemory","params":[],"id":
 
 #### Returns
 
-| Type | Description     |
-| ---- | --------------- |
+| Type | Description |
+| --- | --- |
 | null | No return value |
 
-### debug\_gcStats
+### debug_gcStats
 
 Returns garbage collection statistics.
 
@@ -5833,11 +5944,11 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_gcStats","params":[],"id":"1"}'
 
 #### Returns
 
-| Type   | Description          |
-| ------ | -------------------- |
+| Type | Description |
+| --- | --- |
 | Object | GC statistics object |
 
-### debug\_memStats
+### debug_memStats
 
 Returns detailed runtime memory statistics.
 
@@ -5853,15 +5964,14 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_memStats","params":[],"id":"1"}
 
 #### Returns
 
-| Type   | Description                      |
-| ------ | -------------------------------- |
+| Type | Description |
+| --- | --- |
 | Object | Runtime memory statistics object |
 
 ---
 
 # trace
 URL: https://docs.erigon.tech/interacting-with-erigon/trace
-
 
 The `trace` module is for getting a deeper insight into transaction processing. It includes two sets of calls the transaction trace filtering API and the ad-hoc tracing API.
 
@@ -5879,9 +5989,9 @@ The ad-hoc tracing API allows you to perform diagnostics on calls or transaction
 
 The diagnostics are requested by providing a configuration object that specifies the tracer type to be executed, allowing for deep insight into EVM execution:
 
-* `trace`: Provides a Transaction Trace, showing the sequence of all external calls, internal messages, and value transfers that occurred during execution.
-* `vmTrace`: Provides a Virtual Machine Execution Trace, delivering a full step-by-step trace of the EVM's state throughout the transaction, including all opcodes and gas usage.
-* `stateDiff`: Provides a State Difference, detailing all altered portions of the Ethereum state (e.g., storage, balances, nonces) resulting from the transaction's execution.
+- `trace`: Provides a Transaction Trace, showing the sequence of all external calls, internal messages, and value transfers that occurred during execution.
+- `vmTrace`: Provides a Virtual Machine Execution Trace, delivering a full step-by-step trace of the EVM's state throughout the transaction, including all opcodes and gas usage.
+- `stateDiff`: Provides a State Difference, detailing all altered portions of the Ethereum state (e.g., storage, balances, nonces) resulting from the transaction's execution.
 
 #### Flat Tracers
 
@@ -5901,11 +6011,11 @@ There are three primary ways to specify the transaction to be traced:
 
 ## The Transaction-Trace Filtering API
 
-These APIs allow you to get a full _externality_ trace on any transaction executed throughout the Erigon chain. Unlike the log filtering API, you are able to search and filter based only upon address information. Information returned includes the execution of all `CREATE`s, `SUICIDE`s and all variants of `CALL` together with input data, output data, gas usage, amount transferred and the success status of each individual action.
+These APIs allow you to get a full *externality* trace on any transaction executed throughout the Erigon chain. Unlike the log filtering API, you are able to search and filter based only upon address information. Information returned includes the execution of all `CREATE`s, `SUICIDE`s and all variants of `CALL` together with input data, output data, gas usage, amount transferred and the success status of each individual action.
 
 ### `traceAddress` field
 
-The `traceAddress` field of all returned traces, gives the exact location in the call trace \[index in root, index in first `CALL`, index in second `CALL`, ...].
+The `traceAddress` field of all returned traces, gives the exact location in the call trace [index in root, index in first `CALL`, index in second `CALL`, ...].
 
 i.e. if the trace is:
 
@@ -5925,18 +6035,18 @@ then it should look something like:
 
 #### Ad-hoc Tracing
 
-* [trace\_call](#trace_call)
-* [trace\_callMany](#trace_callmany)
-* [trace\_rawTransaction](#trace_rawtransaction)
-* [trace\_replayBlockTransactions](#trace_replayblocktransactions)
-* [trace\_replayTransaction](#trace_replaytransaction)
+- [trace_call](https://docs.erigon.tech/interacting-with-erigon/trace#trace_call)
+- [trace_callMany](https://docs.erigon.tech/interacting-with-erigon/trace#trace_callmany)
+- [trace_rawTransaction](https://docs.erigon.tech/interacting-with-erigon/trace#trace_rawtransaction)
+- [trace_replayBlockTransactions](https://docs.erigon.tech/interacting-with-erigon/trace#trace_replayblocktransactions)
+- [trace_replayTransaction](https://docs.erigon.tech/interacting-with-erigon/trace#trace_replaytransaction)
 
 #### Transaction-Trace Filtering
 
-* [trace\_block](#trace_block)
-* [trace\_filter](#trace_filter)
-* [trace\_get](#trace_get)
-* [trace\_transaction](#trace_transaction)
+- [trace_block](https://docs.erigon.tech/interacting-with-erigon/trace#trace_block)
+- [trace_filter](https://docs.erigon.tech/interacting-with-erigon/trace#trace_filter)
+- [trace_get](https://docs.erigon.tech/interacting-with-erigon/trace#trace_get)
+- [trace_transaction](https://docs.erigon.tech/interacting-with-erigon/trace#trace_transaction)
 
 ## Response Fields Reference
 
@@ -5947,9 +6057,9 @@ All `trace_*` methods return objects built from the same set of fields. Each met
 | Method | Top-level shape |
 | --- | --- |
 | `trace_call`, `trace_rawTransaction`, `trace_replayTransaction` | `Object` with `output`, `stateDiff`, `trace[]`, `vmTrace` |
-| `trace_callMany` | `Array` — one per input call |
-| `trace_replayBlockTransactions` | `Array` — one per transaction; each entry adds `transactionHash` |
-| `trace_block`, `trace_filter`, `trace_transaction` | `Array` (flat list across all call frames) |
+| `trace_callMany` | `Array<Object>` — one per input call |
+| `trace_replayBlockTransactions` | `Array<Object>` — one per transaction; each entry adds `transactionHash` |
+| `trace_block`, `trace_filter`, `trace_transaction` | `Array<TraceEntry>` (flat list across all call frames) |
 | `trace_get` | `TraceEntry` (single call frame at the requested `traceAddress` path) |
 
 ### Top-level (ad-hoc tracing) fields
@@ -6043,23 +6153,21 @@ The `result` object's shape depends on `type`:
 
 `result` is `null` — these actions have no return value.
 
-***
-
 ## JSON-RPC API Reference
 
-### trace\_call
+### trace_call
 
 Executes the given call and returns a number of possible traces for it.
 
 #### Parameters
 
-1. `Object` - \[Transaction object] where `from` field is optional and `nonce` field is omitted.
+1. `Object` - [Transaction object] where `from` field is optional and `nonce` field is omitted.
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
 3. `Quantity` or `Tag` - (optional) Integer of a block number, or the string `'earliest'` or `'latest'`. `'pending'` is not supported: the call is executed against committed state, so there is no pending block to execute on top of.
 
 #### Returns
 
-`Object` containing `output`, `stateDiff`, `trace[]`, `vmTrace`. Each requested trace type is populated; `stateDiff` and `vmTrace` are `null` when not requested, while `trace` is an empty array. See [Response Fields Reference](#response-fields-reference) for full field semantics.
+`Object` containing `output`, `stateDiff`, `trace[]`, `vmTrace`. Each requested trace type is populated; `stateDiff` and `vmTrace` are `null` when not requested, while `trace` is an empty array. See [Response Fields Reference](https://docs.erigon.tech/interacting-with-erigon/trace#response-fields-reference) for full field semantics.
 
 #### Example
 
@@ -6093,9 +6201,7 @@ Response
 }
 ```
 
-***
-
-### trace\_callMany
+### trace_callMany
 
 Performs multiple call traces on top of the same block. i.e. transaction `n` will be executed on top of a pending block with all `n-1` transactions applied (traced) first. Allows to trace dependent transactions.
 
@@ -6130,7 +6236,7 @@ params: [
 
 #### Returns
 
-`Array` — one entry per input call, each shaped like the `trace_call` response (`output`, `stateDiff`, `trace[]`, `vmTrace`). See [Response Fields Reference](#response-fields-reference).
+`Array<Object>` — one entry per input call, each shaped like the `trace_call` response (`output`, `stateDiff`, `trace[]`, `vmTrace`). See [Response Fields Reference](https://docs.erigon.tech/interacting-with-erigon/trace#response-fields-reference).
 
 #### Example
 
@@ -6195,9 +6301,7 @@ Response
 }
 ```
 
-***
-
-### trace\_rawTransaction
+### trace_rawTransaction
 
 Traces a call to `eth_sendRawTransaction` without making the call, returning the traces
 
@@ -6215,7 +6319,7 @@ params: [
 
 #### Returns
 
-`Object` shaped like the `trace_call` response (`output`, `stateDiff`, `trace[]`, `vmTrace`). See [Response Fields Reference](#response-fields-reference).
+`Object` shaped like the `trace_call` response (`output`, `stateDiff`, `trace[]`, `vmTrace`). See [Response Fields Reference](https://docs.erigon.tech/interacting-with-erigon/trace#response-fields-reference).
 
 #### Example
 
@@ -6249,9 +6353,7 @@ Response
 }
 ```
 
-***
-
-### trace\_replayBlockTransactions
+### trace_replayBlockTransactions
 
 Replays all transactions in a block returning the requested traces for each transaction.
 
@@ -6269,7 +6371,7 @@ params: [
 
 #### Returns
 
-`Array` — one entry per transaction in the block. Each entry is shaped like the `trace_call` response plus a `transactionHash` field identifying the transaction. See [Response Fields Reference](#response-fields-reference).
+`Array<Object>` — one entry per transaction in the block. Each entry is shaped like the `trace_call` response plus a `transactionHash` field identifying the transaction. See [Response Fields Reference](https://docs.erigon.tech/interacting-with-erigon/trace#response-fields-reference).
 
 #### Example
 
@@ -6307,9 +6409,7 @@ Response
 }
 ```
 
-***
-
-### trace\_replayTransaction
+### trace_replayTransaction
 
 Replays a transaction, returning the traces.
 
@@ -6327,7 +6427,7 @@ params: [
 
 #### Returns
 
-`Object` shaped like the `trace_call` response (`output`, `stateDiff`, `trace[]`, `vmTrace`). See [Response Fields Reference](#response-fields-reference).
+`Object` shaped like the `trace_call` response (`output`, `stateDiff`, `trace[]`, `vmTrace`). See [Response Fields Reference](https://docs.erigon.tech/interacting-with-erigon/trace#response-fields-reference).
 
 #### Example
 
@@ -6361,9 +6461,7 @@ Response
 }
 ```
 
-***
-
-### trace\_block
+### trace_block
 
 Returns traces created at given block.
 
@@ -6379,7 +6477,7 @@ params: [
 
 #### Returns
 
-`Array` — flat list of all call frames in the block, including any `"reward"` entries for block/uncle rewards. Each entry includes block-level fields (`blockHash`, `blockNumber`, `transactionHash`, `transactionPosition`). See [Response Fields Reference](#response-fields-reference).
+`Array<TraceEntry>` — flat list of all call frames in the block, including any `"reward"` entries for block/uncle rewards. Each entry includes block-level fields (`blockHash`, `blockNumber`, `transactionHash`, `transactionPosition`). See [Response Fields Reference](https://docs.erigon.tech/interacting-with-erigon/trace#response-fields-reference).
 
 #### Example
 
@@ -6422,24 +6520,23 @@ Response
 }
 ```
 
-***
-
-### trace\_filter
+### trace_filter
 
 Returns traces matching given filter
 
 #### Parameters
 
 1. `Object` - The filter object
-   * `fromBlock`: `Quantity` or `Tag` - (optional) From this block.
-   * `toBlock`: `Quantity` or `Tag` - (optional) To this block.
-   * `fromAddress`: `Array` - (optional) Sent from these addresses.
-   * `toAddress`: `Address` - (optional) Sent to these addresses.
-   * `after`: `Quantity` - (optional) The offset trace number
-   * `count`: `Quantity` - (optional) Integer number of traces to display in a batch.
-   * `mode`: `String` - (optional) Default is `"union"`, meaning traces matching either address filter are returned. Set to `"intersection"` to only return traces that satisfy both `fromAddress` and `toAddress` filters simultaneously.
 
-   The `'pending'` tag is not supported for either block bound: `trace_filter` scans committed trace history, which has no pending block.
+  - `fromBlock`: `Quantity` or `Tag` - (optional) From this block.
+  - `toBlock`: `Quantity` or `Tag` - (optional) To this block.
+  - `fromAddress`: `Array` - (optional) Sent from these addresses.
+  - `toAddress`: `Address` - (optional) Sent to these addresses.
+  - `after`: `Quantity` - (optional) The offset trace number
+  - `count`: `Quantity` - (optional) Integer number of traces to display in a batch.
+  - `mode`: `String` - (optional) Default is `"union"`, meaning traces matching either address filter are returned. Set to `"intersection"` to only return traces that satisfy both `fromAddress` and `toAddress` filters simultaneously.
+
+The `'pending'` tag is not supported for either block bound: `trace_filter` scans committed trace history, which has no pending block.
 
 ```js
 params: [{
@@ -6453,7 +6550,7 @@ params: [{
 
 #### Returns
 
-`Array` — flat list of call frames that match the filter, including any `"reward"` entries when the filter matches block coinbases or uncle authors. Each entry has block-level fields (`blockHash`, `blockNumber`, `transactionHash`, `transactionPosition`). See [Response Fields Reference](#response-fields-reference).
+`Array<TraceEntry>` — flat list of call frames that match the filter, including any `"reward"` entries when the filter matches block coinbases or uncle authors. Each entry has block-level fields (`blockHash`, `blockNumber`, `transactionHash`, `transactionPosition`). See [Response Fields Reference](https://docs.erigon.tech/interacting-with-erigon/trace#response-fields-reference).
 
 #### Example
 
@@ -6496,9 +6593,7 @@ Response
 }
 ```
 
-***
-
-### trace\_get
+### trace_get
 
 Returns the call frame at the given `traceAddress` path.
 
@@ -6516,7 +6611,7 @@ params: [
 
 #### Returns
 
-A single `TraceEntry` corresponding to the call frame at the requested `traceAddress` path, with block-level fields (`blockHash`, `blockNumber`, `transactionHash`, `transactionPosition`). See [Response Fields Reference](#response-fields-reference).
+A single `TraceEntry` corresponding to the call frame at the requested `traceAddress` path, with block-level fields (`blockHash`, `blockNumber`, `transactionHash`, `transactionPosition`). See [Response Fields Reference](https://docs.erigon.tech/interacting-with-erigon/trace#response-fields-reference).
 
 #### Example
 
@@ -6558,9 +6653,7 @@ Response
 }
 ```
 
-***
-
-### trace\_transaction
+### trace_transaction
 
 Returns all traces of given transaction
 
@@ -6574,7 +6667,7 @@ params: ["0x17104ac9d3312d8c136b7f44d4b8b47852618065ebfa534bd2d3b5ef218ca1f3"]
 
 #### Returns
 
-`Array` — flat list of all call frames in the transaction, with block-level fields (`blockHash`, `blockNumber`, `transactionHash`, `transactionPosition`) on each entry. See [Response Fields Reference](#response-fields-reference).
+`Array<TraceEntry>` — flat list of all call frames in the transaction, with block-level fields (`blockHash`, `blockNumber`, `transactionHash`, `transactionPosition`) on each entry. See [Response Fields Reference](https://docs.erigon.tech/interacting-with-erigon/trace#response-fields-reference).
 
 #### Example
 
@@ -6624,51 +6717,48 @@ Response
 # txpool
 URL: https://docs.erigon.tech/interacting-with-erigon/txpool
 
-
 The `txpool` namespace provides methods for inspecting and managing the transaction pool (mempool) in Erigon. These methods allow you to view pending and queued transactions, providing insight into the current state of unconfirmed transactions. In Erigon, the `txpool` namespace is implemented through the `TxPoolAPI` interface and `TxPoolAPIImpl` struct.
 
 The TxPool namespace must be explicitly enabled using the `--http.api` flag when starting the RPC Daemon. These methods are particularly useful for monitoring transaction pool status and debugging transaction submission issues.
 
 ### Transaction Pool Architecture
 
-* Erigon's transaction pool is organized into three sub-pools: pending (executable), baseFee (insufficient base fee), and queued (nonce gaps)
-* The `txpool_content`, `txpool_contentFrom` and `txpool_status` methods expose only the `pending` and `queued` categories, as defined by the `ethereum/execution-apis` specification. Transactions in the internal baseFee sub-pool are nonce-ready and otherwise valid, but are not executable at the current base fee: they wait for the fee condition to change. They are reported as pending, matching Geth
-* Blob transactions (type 3) are not reported by `txpool_content` and `txpool_contentFrom`, matching Geth and Nethermind. They are still counted by `txpool_status`
-* The pool can run either integrated within the main Erigon process or as a separate service for scalability
-* Transaction pool methods communicate via gRPC with the TxPool service when running in external mode
+- Erigon's transaction pool is organized into three sub-pools: pending (executable), baseFee (insufficient base fee), and queued (nonce gaps)
+- The `txpool_content`, `txpool_contentFrom` and `txpool_status` methods expose only the `pending` and `queued` categories, as defined by the `ethereum/execution-apis` specification. Transactions in the internal baseFee sub-pool are nonce-ready and otherwise valid, but are not executable at the current base fee: they wait for the fee condition to change. They are reported as pending, matching Geth
+- Blob transactions (type 3) are not reported by `txpool_content` and `txpool_contentFrom`, matching Geth and Nethermind. They are still counted by `txpool_status`
+- The pool can run either integrated within the main Erigon process or as a separate service for scalability
+- Transaction pool methods communicate via gRPC with the TxPool service when running in external mode
 
 ### Implementation Details
 
-* The `TxPoolAPIImpl` uses a `proto_txpool.TxpoolClient` to communicate with the transaction pool service
-* All transactions are decoded from RLP format and converted to `ethapi.RPCTransaction` objects for JSON-RPC responses
-* The implementation handles transaction categorization based on the `TxnType` field from the pool service
+- The `TxPoolAPIImpl` uses a `proto_txpool.TxpoolClient` to communicate with the transaction pool service
+- All transactions are decoded from RLP format and converted to `ethapi.RPCTransaction` objects for JSON-RPC responses
+- The implementation handles transaction categorization based on the `TxnType` field from the pool service
 
 ### External vs Internal Mode
 
-* **Internal Mode**: Transaction pool runs within the main Erigon process (default configuration)
-* **External Mode**: Transaction pool runs as a separate service, requiring explicit configuration with `--txpool.api.addr`. External mode requires an external Sentry service and provides better resource isolation
+- **Internal Mode**: Transaction pool runs within the main Erigon process (default configuration)
+- **External Mode**: Transaction pool runs as a separate service, requiring explicit configuration with `--txpool.api.addr`. External mode requires an external Sentry service and provides better resource isolation
 
 ### Usage in Development and Testing
 
-* These methods are commonly used for monitoring transaction submission and pool state
-* The `txpool_status` method provides quick insight into pool health and congestion
-* Transaction pool content methods help debug why transactions may not be getting mined
+- These methods are commonly used for monitoring transaction submission and pool state
+- The `txpool_status` method provides quick insight into pool health and congestion
+- Transaction pool content methods help debug why transactions may not be getting mined
 
 ### Configuration and Limits
 
-* Transaction pool limits can be configured via flags like `--txpool.globalslots`, `--txpool.globalbasefeeslots`, and `--txpool.globalqueue`
-* The pool supports various transaction types including blob transactions with separate limits
-* Pool configuration is managed through the `txpoolcfg.Config` structure
+- Transaction pool limits can be configured via flags like `--txpool.globalslots`, `--txpool.globalbasefeeslots`, and `--txpool.globalqueue`
+- The pool supports various transaction types including blob transactions with separate limits
+- Pool configuration is managed through the `txpoolcfg.Config` structure
 
 ### Availability
 
-* The `txpool` namespace is available when included in the `--http.api` flag
-* Methods are marked as "remote" in the documentation, indicating they communicate with external services
-* All `txpool` methods are available on both HTTP and WebSocket connections
+- The `txpool` namespace is available when included in the `--http.api` flag
+- Methods are marked as "remote" in the documentation, indicating they communicate with external services
+- All `txpool` methods are available on both HTTP and WebSocket connections
 
-***
-
-## **txpool\_content**
+## **txpool_content**
 
 Returns the content of the transaction pool, organized by sender address and categorized into pending and queued transactions. Blob transactions are not returned.
 
@@ -6684,23 +6774,21 @@ curl -s --data '{"jsonrpc":"2.0","method":"txpool_content","params":[],"id":"1"}
 
 **Returns**
 
-| Type    | Description                                         |
-| ------- | --------------------------------------------------- |
-| Object  | Transaction pool content organized by sub-pool type |
-| pending | Object                                              |
-| queued  | Object                                              |
+| Type | Description |
+| --- | --- |
+| Object | Transaction pool content organized by sub-pool type |
+| pending | Object |
+| queued | Object |
 
-***
-
-## **txpool\_contentFrom**
+## **txpool_contentFrom**
 
 Returns the content of the transaction pool for a specific sender address, categorized into pending and queued transactions. The same rules as `txpool_content` apply.
 
 **Parameters**
 
-| Parameter | Type           | Description                                  |
-| --------- | -------------- | -------------------------------------------- |
-| address   | DATA, 20 BYTES | The sender address to query transactions for |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| address | DATA, 20 BYTES | The sender address to query transactions for |
 
 **Example**
 
@@ -6710,15 +6798,13 @@ curl -s --data '{"jsonrpc":"2.0","method":"txpool_contentFrom","params":["0xb60e
 
 **Returns**
 
-| Type    | Description                                        |
-| ------- | -------------------------------------------------- |
-| Object  | Transaction pool content for the specified address |
-| pending | Object                                             |
-| queued  | Object                                             |
+| Type | Description |
+| --- | --- |
+| Object | Transaction pool content for the specified address |
+| pending | Object |
+| queued | Object |
 
-***
-
-## **txpool\_status**
+## **txpool_status**
 
 Returns the current status of the transaction pool, with the count of pending and queued transactions.
 
@@ -6734,17 +6820,16 @@ curl -s --data '{"jsonrpc":"2.0","method":"txpool_status","params":[],"id":"1"}'
 
 **Returns**
 
-| Type    | Description                    |
-| ------- | ------------------------------ |
-| Object  | Transaction pool status counts |
-| pending | QUANTITY                       |
-| queued  | QUANTITY                       |
+| Type | Description |
+| --- | --- |
+| Object | Transaction pool status counts |
+| pending | QUANTITY |
+| queued | QUANTITY |
 
 ---
 
 # admin
 URL: https://docs.erigon.tech/interacting-with-erigon/admin
-
 
 The `admin` namespace provides administrative methods for managing the Erigon node, including peer management and node information retrieval. These methods are designed for node operators and developers who need to monitor and control various aspects of the Erigon client's operation.
 
@@ -6752,31 +6837,29 @@ The admin namespace must be explicitly enabled using the `--http.api` flag when 
 
 ### Security Considerations
 
-* The admin namespace provides administrative functions that should not be exposed on public RPC endpoints
-* When configuring public RPC access, explicitly exclude `admin` from the `--http.api` flag to prevent unauthorized access
-* These methods can affect node connectivity and should only be used by trusted operators
+- The admin namespace provides administrative functions that should not be exposed on public RPC endpoints
+- When configuring public RPC access, explicitly exclude `admin` from the `--http.api` flag to prevent unauthorized access
+- These methods can affect node connectivity and should only be used by trusted operators
 
 ### Usage in Testing and Development
 
-* Admin methods are commonly used in automated testing environments for peer management
-* The docker-compose configuration for automated testing includes the admin namespace in the API list for testing purposes
-* These methods are essential for setting up test networks and managing peer connections programmatically
+- Admin methods are commonly used in automated testing environments for peer management
+- The docker-compose configuration for automated testing includes the admin namespace in the API list for testing purposes
+- These methods are essential for setting up test networks and managing peer connections programmatically
 
 ### Availability
 
-* Admin methods are available when the `admin` namespace is included in the `--http.api` flag
-* All admin methods are available on both HTTP and WebSocket connections
-* Some admin methods may require the node to be running with specific network configurations
+- Admin methods are available when the `admin` namespace is included in the `--http.api` flag
+- All admin methods are available on both HTTP and WebSocket connections
+- Some admin methods may require the node to be running with specific network configurations
 
 ### Integration with P2P Network
 
-* Admin methods interact directly with Erigon's P2P networking layer
-* Peer management operations may take time to complete as they involve network operations
-* The effectiveness of `admin_addPeer` depends on network connectivity and peer availability
+- Admin methods interact directly with Erigon's P2P networking layer
+- Peer management operations may take time to complete as they involve network operations
+- The effectiveness of `admin_addPeer` depends on network connectivity and peer availability
 
-***
-
-## **admin\_nodeInfo**
+## **admin_nodeInfo**
 
 Returns information about the running node, including network details, protocols, and node identification.
 
@@ -6792,13 +6875,11 @@ curl -s --data '{"jsonrpc":"2.0","method":"admin_nodeInfo","params":[],"id":"1"}
 
 **Returns**
 
-| Type   | Description                                                     |
-| ------ | --------------------------------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Object | Node information object containing network and protocol details |
 
-***
-
-## **admin\_peers**
+## **admin_peers**
 
 Returns information about connected peers, including their network addresses, protocols, and connection status.
 
@@ -6814,21 +6895,19 @@ curl -s --data '{"jsonrpc":"2.0","method":"admin_peers","params":[],"id":"1"}' -
 
 **Returns**
 
-| Type  | Description                                                          |
-| ----- | -------------------------------------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Array | Array of peer objects containing connection and protocol information |
 
-***
-
-## **admin\_addPeer**
+## **admin_addPeer**
 
 Attempts to add a new peer to the node's peer list by connecting to the specified enode URL.
 
 **Parameters**
 
-| Parameter | Type   | Description                                                       |
-| --------- | ------ | ----------------------------------------------------------------- |
-| enode     | STRING | The enode URL of the peer to add (format: enode://pubkey@ip:port) |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| enode | STRING | The enode URL of the peer to add (format: enode://pubkey@ip:port) |
 
 **Example**
 
@@ -6838,21 +6917,19 @@ curl -s --data '{"jsonrpc":"2.0","method":"admin_addPeer","params":["enode://a97
 
 **Returns**
 
-| Type    | Description                                              |
-| ------- | -------------------------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Boolean | True if the peer was successfully added, false otherwise |
 
-***
-
-## **admin\_removePeer**
+## **admin_removePeer**
 
 Removes a peer from the node's peer list by disconnecting from the specified enode URL.
 
 **Parameters**
 
-| Parameter | Type   | Description                                                          |
-| --------- | ------ | -------------------------------------------------------------------- |
-| enode     | STRING | The enode URL of the peer to remove (format: enode://pubkey@ip:port) |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| enode | STRING | The enode URL of the peer to remove (format: enode://pubkey@ip:port) |
 
 **Example**
 
@@ -6862,21 +6939,19 @@ curl -s --data '{"jsonrpc":"2.0","method":"admin_removePeer","params":["enode://
 
 **Returns**
 
-| Type    | Description                                                |
-| ------- | ---------------------------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Boolean | True if the peer was successfully removed, false otherwise |
 
-***
-
-## **admin\_addTrustedPeer**
+## **admin_addTrustedPeer**
 
 Adds a peer to the trusted peers list. Trusted peers are exempt from the maximum peer count limit and will always be connected, even when the node has reached its peer limit.
 
 **Parameters**
 
-| Parameter | Type   | Description                                                              |
-| --------- | ------ | ------------------------------------------------------------------------ |
-| enode     | STRING | The enode URL of the trusted peer to add (format: enode://pubkey@ip:port) |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| enode | STRING | The enode URL of the trusted peer to add (format: enode://pubkey@ip:port) |
 
 **Example**
 
@@ -6886,21 +6961,19 @@ curl -s --data '{"jsonrpc":"2.0","method":"admin_addTrustedPeer","params":["enod
 
 **Returns**
 
-| Type    | Description                                                       |
-| ------- | ----------------------------------------------------------------- |
-| Boolean | True if the trusted peer was successfully added, false otherwise  |
+| Type | Description |
+| --- | --- |
+| Boolean | True if the trusted peer was successfully added, false otherwise |
 
-***
-
-## **admin\_removeTrustedPeer**
+## **admin_removeTrustedPeer**
 
 Removes a peer from the trusted peers list. The peer may still remain connected if slots are available, but will no longer bypass the peer limit.
 
 **Parameters**
 
-| Parameter | Type   | Description                                                                 |
-| --------- | ------ | --------------------------------------------------------------------------- |
-| enode     | STRING | The enode URL of the trusted peer to remove (format: enode://pubkey@ip:port) |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| enode | STRING | The enode URL of the trusted peer to remove (format: enode://pubkey@ip:port) |
 
 **Example**
 
@@ -6910,17 +6983,14 @@ curl -s --data '{"jsonrpc":"2.0","method":"admin_removeTrustedPeer","params":["e
 
 **Returns**
 
-| Type    | Description                                                          |
-| ------- | -------------------------------------------------------------------- |
-| Boolean | True if the trusted peer was successfully removed, false otherwise   |
-
-***
+| Type | Description |
+| --- | --- |
+| Boolean | True if the trusted peer was successfully removed, false otherwise |
 
 ---
 
 # ots
 URL: https://docs.erigon.tech/interacting-with-erigon/ots
-
 
 In addition to the standard Geth methods, Erigon includes RPC methods prefixed with `ots_` for **Otterscan**. These are specific to the Otterscan functionality integrated with Erigon.
 
@@ -6931,18 +7001,17 @@ See more details at [https://docs.otterscan.io/api-docs/ots-api](https://docs.ot
 # internal
 URL: https://docs.erigon.tech/interacting-with-erigon/internal
 
-
 The **`internal_`** methods are for development and debugging utilities and must be explicitly included in the `--http.api` flag if customizing enabled namespaces.
 
-## **internal\_getTxNumInfo**
+## **internal_getTxNumInfo**
 
 Returns transaction number information for development and debugging purposes. This is part of Erigon's internal APIs and may change without notice.
 
 **Parameters**
 
-| Parameter | Type     | Description                 |
-| --------- | -------- | --------------------------- |
-| txNum     | QUANTITY | Internal transaction number |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| txNum | QUANTITY | Internal transaction number |
 
 **Example**
 
@@ -6952,17 +7021,16 @@ curl -s --data '{"jsonrpc":"2.0","method":"internal_getTxNumInfo","params":["0x1
 
 **Returns**
 
-| Type     | Description                    |
-| -------- | ------------------------------ |
-| Object   | Transaction number information |
-| blockNum | QUANTITY                       |
-| idx      | QUANTITY                       |
+| Type | Description |
+| --- | --- |
+| Object | Transaction number information |
+| blockNum | QUANTITY |
+| idx | QUANTITY |
 
 ---
 
 # gRPC
 URL: https://docs.erigon.tech/interacting-with-erigon/grpc
-
 
 Erigon provides gRPC APIs that allow users to access blockchain data and services directly through protocol buffer interfaces. These APIs offer high-performance, strongly-typed access to Erigon's internal services and are particularly useful for applications requiring efficient data access or integration with other gRPC-based systems.
 
@@ -6970,9 +7038,9 @@ The gRPC server can be explicitly enabled using the `--grpc` flag when running t
 
 ### Performance Considerations
 
-* gRPC APIs provide better performance than JSON-RPC for high-throughput applications
-* Direct database access via KV interface offers the fastest data retrieval
-* Shared memory access (when running locally) provides optimal performance
+- gRPC APIs provide better performance than JSON-RPC for high-throughput applications
+- Direct database access via KV interface offers the fastest data retrieval
+- Shared memory access (when running locally) provides optimal performance
 
 ### Data Format and Buckets
 
@@ -6980,9 +7048,9 @@ Database bucket names and their formats are documented in `db/kv/tables.go`. Und
 
 ### Network Access
 
-* gRPC services can be accessed over the network when properly configured
-* TLS encryption is recommended for production deployments
-* Rate limiting can be configured via `--private.api.ratelimit` flag
+- gRPC services can be accessed over the network when properly configured
+- TLS encryption is recommended for production deployments
+- Rate limiting can be configured via `--private.api.ratelimit` flag
 
 ### Integration Libraries
 
@@ -6990,13 +7058,11 @@ Erigon provides Go, Rust, and C++ implementations of the RoKV (read-only key-val
 
 ### Availability
 
-* gRPC services are available when enabled with the `--grpc` flag on the **standalone `rpcdaemon`** binary
-* Default listening address is configurable via `--grpc.addr` and `--grpc.port`
-* Services require the main Erigon node to be running and accessible
+- gRPC services are available when enabled with the `--grpc` flag on the **standalone `rpcdaemon`** binary
+- Default listening address is configurable via `--grpc.addr` and `--grpc.port`
+- Services require the main Erigon node to be running and accessible
 
 For more information, visit the [Erigon Interfaces GitHub repository](https://github.com/erigontech/interfaces).
-
-***
 
 ## **KV (Key-Value) Interface**
 
@@ -7006,10 +7072,10 @@ The KV interface provides low-level database access methods for reading blockcha
 
 The KV interface is defined in the remote protobuf specification and provides methods for:
 
-* Opening read-only transactions
-* Reading data by key ranges
-* Iterating over database buckets
-* Accessing historical state data
+- Opening read-only transactions
+- Reading data by key ranges
+- Iterating over database buckets
+- Accessing historical state data
 
 **Example Usage**
 
@@ -7020,14 +7086,12 @@ grpcurl -plaintext localhost:9090 remote.KV/Version
 
 **Available Methods**
 
-| Method       | Description                                   |
-| ------------ | --------------------------------------------- |
-| Version      | Returns the KV service API version            |
-| Tx           | Opens a read-only transaction for data access |
-| StateChanges | Streams state changes for a block range       |
-| Snapshots    | Returns information about available snapshots |
-
-***
+| Method | Description |
+| --- | --- |
+| Version | Returns the KV service API version |
+| Tx | Opens a read-only transaction for data access |
+| StateChanges | Streams state changes for a block range |
+| Snapshots | Returns information about available snapshots |
 
 ## **ETHBACKEND Interface**
 
@@ -7035,20 +7099,18 @@ The ETHBACKEND interface provides access to Ethereum-specific backend services i
 
 **Available Services**
 
-| Service         | Description                                         |
-| --------------- | --------------------------------------------------- |
-| Etherbase       | Returns the coinbase address                        |
-| NetVersion      | Returns the network ID                              |
-| NetPeerCount    | Returns the number of connected peers               |
-| ProtocolVersion | Returns the Ethereum protocol version               |
-| ClientVersion   | Returns the client version string                   |
-| Subscribe       | Subscribes to blockchain events                     |
-| NodeInfo        | Returns node information                            |
-| Peers           | Returns information about connected peers           |
-| AddPeer         | Adds a peer to the node                             |
-| PendingBlock    | Returns the pending block                           |
-
-***
+| Service | Description |
+| --- | --- |
+| Etherbase | Returns the coinbase address |
+| NetVersion | Returns the network ID |
+| NetPeerCount | Returns the number of connected peers |
+| ProtocolVersion | Returns the Ethereum protocol version |
+| ClientVersion | Returns the client version string |
+| Subscribe | Subscribes to blockchain events |
+| NodeInfo | Returns node information |
+| Peers | Returns information about connected peers |
+| AddPeer | Adds a peer to the node |
+| PendingBlock | Returns the pending block |
 
 ## **TxPool Interface**
 
@@ -7056,19 +7118,17 @@ The TxPool interface provides access to transaction pool operations and status i
 
 **Available Methods**
 
-| Method            | Description                               |
-| ----------------- | ----------------------------------------- |
-| Version           | Returns the TxPool service version        |
-| FindUnknownHashes | Finds unknown transaction hashes          |
-| GetTransactions   | Retrieves transactions from the pool      |
-| All               | Returns all transactions in the pool      |
-| PendingAdd        | Adds transactions to pending pool         |
-| PendingRemove     | Removes transactions from pending pool    |
-| OnAdd             | Subscribes to transaction addition events |
-| Mining            | Returns mining-related transaction data   |
-| NonceFromAddress  | Gets the next nonce for an address        |
-
-***
+| Method | Description |
+| --- | --- |
+| Version | Returns the TxPool service version |
+| FindUnknownHashes | Finds unknown transaction hashes |
+| GetTransactions | Retrieves transactions from the pool |
+| All | Returns all transactions in the pool |
+| PendingAdd | Adds transactions to pending pool |
+| PendingRemove | Removes transactions from pending pool |
+| OnAdd | Subscribes to transaction addition events |
+| Mining | Returns mining-related transaction data |
+| NonceFromAddress | Gets the next nonce for an address |
 
 ## **Downloader Interface**
 
@@ -7076,14 +7136,12 @@ The Downloader interface provides access to snapshot downloading and torrent man
 
 **Available Methods**
 
-| Method       | Description                        |
-| ------------ | ---------------------------------- |
-| Add          | Adds files to download queue       |
-| Delete       | Removes files from download queue  |
-| Completed    | Checks if downloads are completed  |
+| Method | Description |
+| --- | --- |
+| Add | Adds files to download queue |
+| Delete | Removes files from download queue |
+| Completed | Checks if downloads are completed |
 | SetLogPrefix | Sets logging prefix for Downloader |
-
-***
 
 ## Configuration and Security
 
@@ -7127,7 +7185,6 @@ The gRPC interface allows reading Erigon's database while the node is running, s
 # overlay
 URL: https://docs.erigon.tech/interacting-with-erigon/overlay
 
-
 The `overlay` namespace is an **Erigon-specific** extension that allows you to replay historical blocks with a modified contract bytecode, without deploying anything on-chain. It is designed for analytics use cases where you need to inject custom event emissions into an existing contract and retrieve the logs those events would have produced.
 
 :::warning
@@ -7140,10 +7197,8 @@ Enable the namespace with `--http.api=...,overlay`.
 
 Two flags control how long overlay operations can run:
 
-* `--rpc.overlay.getlogstimeout` — overall timeout for an `overlay_getLogs` call (default: `5m0s`)
-* `--rpc.overlay.replayblocktimeout` — per-block replay timeout within a `getLogs` call (default: `10s`)
-
----
+- `--rpc.overlay.getlogstimeout` — overall timeout for an `overlay_getLogs` call (default: `5m0s`)
+- `--rpc.overlay.replayblocktimeout` — per-block replay timeout within a `getLogs` call (default: `10s`)
 
 ## Methods
 
@@ -7156,7 +7211,7 @@ This is equivalent to running `eth_getLogs` on a hypothetical version of the con
 **Parameters**
 
 | # | Name | Type | Description |
-|---|------|------|-------------|
+| --- | --- | --- | --- |
 | 1 | `filter` | `FilterCriteria` | Same filter object as `eth_getLogs`: `fromBlock`, `toBlock`, `address`, `topics` |
 | 2 | `stateOverride` | `StateOverride` (optional) | Map of `address → overrides`. Each override can set `code`, `balance`, `nonce`, `state` (full state replacement), or `stateDiff` (partial state patch). Same format as the state override in `eth_call`. |
 
@@ -7190,8 +7245,6 @@ curl -X POST http://localhost:8545 \
 
 Blocks in the requested range are replayed concurrently (up to `runtime.NumCPU()` workers). Each block is independently replayed from the state at `blockNumber - 1`.
 
----
-
 ### `overlay_callConstructor`
 
 Replays the **constructor transaction** of an existing contract using a different bytecode and returns the effective creation code that would have been stored.
@@ -7201,7 +7254,7 @@ This is useful for understanding what a contract would have initialised to if it
 **Parameters**
 
 | # | Name | Type | Description |
-|---|------|------|-------------|
+| --- | --- | --- | --- |
 | 1 | `address` | `Address` | The address of the already-deployed contract |
 | 2 | `code` | `Bytes` | The replacement bytecode to use instead of the original deployment bytecode |
 
@@ -7228,6 +7281,7 @@ curl -X POST http://localhost:8545 \
 ```
 
 Internally, this method:
+
 1. Looks up the contract's creation transaction via the Otterscan API
 2. Replays all transactions in that block up to (but not including) the creation tx
 3. Executes the creation tx using the provided bytecode instead of the original
@@ -7242,7 +7296,6 @@ Internally, this method:
 # parity
 URL: https://docs.erigon.tech/interacting-with-erigon/parity
 
-
 The `parity` namespace provides a limited subset of the OpenEthereum (formerly Parity) JSON-RPC API for compatibility with tooling that targets the original Parity client.
 
 :::warning
@@ -7253,8 +7306,6 @@ Enable the namespace with `--http.api=...,parity`.
 
 For the full original OpenEthereum `parity_*` specification, see the [OpenEthereum JSON-RPC parity module documentation](https://openethereum.github.io/JSONRPC-parity-module) (archived).
 
----
-
 ## Methods
 
 ### `parity_listStorageKeys`
@@ -7264,7 +7315,7 @@ Returns all storage keys for a given contract address, paginated.
 **Parameters**
 
 | # | Name | Type | Description |
-|---|------|------|-------------|
+| --- | --- | --- | --- |
 | 1 | `address` | `Address` | The contract address to query storage for |
 | 2 | `quantity` | `integer` | Number of storage keys to return |
 | 3 | `offset` | `Bytes` (optional) | Pagination offset — the storage key to start from |
@@ -7297,7 +7348,6 @@ curl -X POST http://localhost:8545 \
 # GraphQL
 URL: https://docs.erigon.tech/interacting-with-erigon/graphql
 
-
 Erigon implements the Ethereum GraphQL interface originally introduced in [EIP-1767](https://eips.ethereum.org/EIPS/eip-1767). The schema is maintained in the [`ethereum/execution-apis`](https://github.com/ethereum/execution-apis) repository, kept in sync with client implementations such as Geth and Besu. Erigon follows that schema.
 
 ## Enabling GraphQL
@@ -7313,7 +7363,7 @@ GraphQL shares the same port as the HTTP JSON-RPC server (default `8545`). It do
 ## Endpoints
 
 | Endpoint | Purpose |
-|----------|---------|
+| --- | --- |
 | `http://localhost:8545/graphql` | GraphQL API endpoint |
 | `http://localhost:8545/graphql/ui` | GraphiQL browser UI for interactive queries |
 
@@ -7358,8 +7408,6 @@ URL: https://docs.erigon.tech/staking
 
 Run an Ethereum validator with Erigon — using the built-in Caplin consensus layer or any external CL client.
 
-## Sections
-
 - [Caplin (Built-in CL)](https://docs.erigon.tech/staking/caplin): Configure Erigon's embedded consensus layer as a full validator — no external CL dependency required.
 - [External Consensus Client](https://docs.erigon.tech/staking/external-consensus-client-as-validator): Connect Lighthouse, Prysm, Teku, or Nimbus via the Engine API for split EL/CL validator setups.
 - [Shutter Network](https://docs.erigon.tech/staking/shutter-network): Privacy-preserving mempool protection — shield validator transactions from front-running and MEV.
@@ -7368,7 +7416,6 @@ Run an Ethereum validator with Erigon — using the built-in Caplin consensus la
 
 # Using Caplin as Validator
 URL: https://docs.erigon.tech/staking/caplin
-
 
 Caplin, the Erigon embedded Consensus Layer, is also suitable for staking. However, it is required to pair it with a **validator key manager**, such as Lighthouse or Teku, since it doesn't have a native key management system.
 
@@ -7396,12 +7443,13 @@ erigon \
 
 **Flags Explanation**:
 
-* Execution Layer (Erigon):
-  * `--http.api=engine,eth,net,web3`: enables the necessary APIs for external clients and Caplin.
-  * `--ws`: enables WebSocket-based communication (optional).
-* Consensus Layer (Caplin):
-  * `--caplin.discovery.addr` and `--caplin.discovery.port`: configures Caplin's gossip and discovery layer.
-  * `--beacon.api=beacon,validator,builder,config,debug,events,node,lighthouse`: enables all possible API endpoints for the validator client.
+- Execution Layer (Erigon):
+  - `--http.api=engine,eth,net,web3`: enables the necessary APIs for external clients and Caplin.
+  - `--ws`: enables WebSocket-based communication (optional).
+
+- Consensus Layer (Caplin):
+  - `--caplin.discovery.addr` and `--caplin.discovery.port`: configures Caplin's gossip and discovery layer.
+  - `--beacon.api=beacon,validator,builder,config,debug,events,node,lighthouse`: enables all possible API endpoints for the validator client.
 
 ## 2. Set Up Lighthouse Validator Client
 
@@ -7432,9 +7480,9 @@ lighthouse vc \
 
 **Flags Explanation**:
 
-* `--network mainnet`: Specifies the Ethereum mainnet.
-* `--beacon-nodes`: Points to the Caplin beacon API at `http://127.0.0.1:5555`.
-* `--suggested-fee-recipient`: Specifies your Ethereum address for block rewards.
+- `--network mainnet`: Specifies the Ethereum mainnet.
+- `--beacon-nodes`: Points to the Caplin beacon API at `http://127.0.0.1:5555`.
+- `--suggested-fee-recipient`: Specifies your Ethereum address for block rewards.
 
 ### 2.4. Import Validator Keys
 
@@ -7449,11 +7497,10 @@ lighthouse account validator import --directory <path_to_validator_keys>
 # Using an external consensus client as validator
 URL: https://docs.erigon.tech/staking/external-consensus-client-as-validator
 
-
 To use an external Consensus Layer (CL) it is necessary to add to Erigon the flag `--externalcl`. Here are a couple of examples on how to configure Lighthouse and Prysm to run along with Erigon:
 
-* [Ethereum](../get-started/easy-nodes/how-to-run-an-ethereum-node/ethereum-with-an-external-cl)
-* [Gnosis Chain](../get-started/easy-nodes/how-to-run-a-gnosis-chain-node/gnosis-with-an-external-cl)
+- [Ethereum](https://docs.erigon.tech/get-started/easy-nodes/how-to-run-an-ethereum-node/ethereum-with-an-external-cl)
+- [Gnosis Chain](https://docs.erigon.tech/get-started/easy-nodes/how-to-run-a-gnosis-chain-node/gnosis-with-an-external-cl)
 
 Once you have Erigon and a CL client up and running, you can proceed to set up a Validator Client (VC). The VC is responsible for managing your keys and signing valid blocks.
 
@@ -7465,9 +7512,9 @@ To set up a VC, follow the instructions provided in the official documentation, 
 
 This guide will walk you through the process of setting up a VC, including:
 
-* Generating and managing your keys
-* Configuring the Validator Client
-* Signing valid blocks
+- Generating and managing your keys
+- Configuring the Validator Client
+- Signing valid blocks
 
 Make sure to follow the instructions carefully and thoroughly to ensure that your VC is set up correctly. It is always recommended to start staking with a testnet.
 
@@ -7492,13 +7539,13 @@ erigon \
 
 ## Flags explanation:
 
-* `--externalcl`: Enables the use of an external CL.
-* `--datadir=/data/erigon`: Defines the directory to be used for databases.
-* `--chain=sepolia`: Specifies the Sepolia chain.
-* `--authrpc.jwtsecret=/jwt`: Sets the location of the JWT authentication code in hex encoding. This is used by Erigon (the EL) and the CL (in this case Lighthouse) to authenticate communication.
-* `--authrpc.addr=0.0.0.0`: Allows the engine API to be accessed from any address.
-* `--http.api=engine,eth,net,web3`: Enables the necessary APIs for external clients and Caplin.
-* `--ws`: enables WebSocket-based communication, which is optional.
+- `--externalcl`: Enables the use of an external CL.
+- `--datadir=/data/erigon`: Defines the directory to be used for databases.
+- `--chain=sepolia`: Specifies the Sepolia chain.
+- `--authrpc.jwtsecret=/jwt`: Sets the location of the JWT authentication code in hex encoding. This is used by Erigon (the EL) and the CL (in this case Lighthouse) to authenticate communication.
+- `--authrpc.addr=0.0.0.0`: Allows the engine API to be accessed from any address.
+- `--http.api=engine,eth,net,web3`: Enables the necessary APIs for external clients and Caplin.
+- `--ws`: enables WebSocket-based communication, which is optional.
 
 :::info
 Note that many pre-merge flags, such as `--miner.etherbase`, are no longer useful, as block rewards and other validator-related configurations are now controlled by the Consensus Layer (CL).
@@ -7509,53 +7556,59 @@ Note that many pre-merge flags, such as `--miner.etherbase`, are no longer usefu
 # Shutter Network
 URL: https://docs.erigon.tech/staking/shutter-network
 
-
 [Shutter Network](https://www.shutter.network) is a privacy-focused protocol that provides encrypted transaction pools using threshold encryption. The main objective is to protect users from malicious MEV (Miner Extractable Value) attacks such as front-running and sandwich attacks by encrypting transactions until they are included in a block.
 
 The key advantages of Shutter Network are:
 
-* **Protection against MEV attacks:** By encrypting transactions, the network prevents malicious actors from exploiting transaction ordering.
-* **Threshold encryption:** Transactions are only decrypted when enough key holders (keypers) participate, ensuring security and decentralization.
-* **Support on Gnosis Chain:** Shutter encrypted transaction pools are currently available on [Gnosis Chain](https://docs.gnosischain.com/shutterized-gc/), with plans for Ethereum support.
+- **Protection against MEV attacks:** By encrypting transactions, the network prevents malicious actors from exploiting transaction ordering.
+- **Threshold encryption:** Transactions are only decrypted when enough key holders (keypers) participate, ensuring security and decentralization.
+- **Support on Gnosis Chain:** Shutter encrypted transaction pools are currently available on [Gnosis Chain](https://docs.gnosischain.com/shutterized-gc/), with plans for Ethereum support.
 
 ### Why Use Shutter?
 
-* **Access to Extra Transactions:** Shutterized validators can include shielded transactions not available in the public transaction pool, leading to potentially higher block rewards.
-* **User Protection:** Help protect users against MEV attacks, improving the fairness of the chain.
+- **Access to Extra Transactions:** Shutterized validators can include shielded transactions not available in the public transaction pool, leading to potentially higher block rewards.
+- **User Protection:** Help protect users against MEV attacks, improving the fairness of the chain.
 
 ## How to Run Erigon as a Shutterized Validator
 
 To participate in the Shutter encrypted transaction pool as a validator using Erigon, follow these steps:
 
-1.  **Set Up Your Validator**
+1. **Set Up Your Validator**
 
-    Deposit your stake and register your validator on Gnosis Chain reby following the [Gnosis Chain Validator Setup](https://docs.gnosischain.com/node/manual/validator/deposit).
-2.  **Register as a Shutterized Validator**
+Deposit your stake and register your validator on Gnosis Chain reby following the [Gnosis Chain Validator Setup](https://docs.gnosischain.com/node/manual/validator/deposit).
 
-    Complete the validator registration for Shutter using the tool provided in the [Shutter Validator Registration Guide](https://github.com/shutter-network/shutter-validator-registration).
-3.  **Verify Registration**
+2. **Register as a Shutterized Validator**
 
-    Use the Erigon CLI command to verify that your registration was successful:
+Complete the validator registration for Shutter using the tool provided in the [Shutter Validator Registration Guide](https://github.com/shutter-network/shutter-validator-registration).
+
+3. **Verify Registration**
+
+Use the Erigon CLI command to verify that your registration was successful:
+
 ```bash
     erigon shutter-validator-reg-check --chain <CHAIN> --el-url <EL_RPC_URL> --validator-info-file <VALIDATOR_INFO_JSON>
-    ```
-* `--chain` valid values are `gnosis` or `chiado`
-    * `--el-url`, in case you are using Erigon default ports is `http://localhost:8545`
-    * `<VALIDATOR_INFO_JSON>` is the file generated during registration.
+```
 
-    for example:
+- `--chain` valid values are `gnosis` or `chiado`
+
+  - `--el-url`, in case you are using Erigon default ports is `http://localhost:8545`
+  - `<VALIDATOR_INFO_JSON>` is the file generated during registration.
+
+for example:
+
 ```bash
     erigon shutter-validator-reg-check --chain gnosis --el-url http://localhost:8545 --validator-info-file /path/validatorInfo.json
-    ```
+```
+
 4. **Run Erigon with Shutter Support**
 
-    Start Erigon as usual, but add the `--shutter` flag to enable Shutterized Validator mode:
+Start Erigon as usual, but add the `--shutter` flag to enable Shutterized Validator mode:
 
-    ```bash
-    erigon --shutter [other options...]
-    ```
+```bash
+erigon --shutter [other options...]
+```
 
-    This works with Erigon's internal CL Caplin (enabled by default) or with an external CL client using `--externalcl`.
+This works with Erigon's internal CL Caplin (enabled by default) or with an external CL client using `--externalcl`.
 
 ## Shutter Network Default Ports
 
@@ -7565,10 +7618,10 @@ Bootstrap nodes are used to help new nodes discover other nodes in the network. 
 
 ## Reference Documentation
 
-* [Shutter Validator Registration](https://github.com/shutter-network/shutter-validator-registration)
-* [Shutter Specs](https://github.com/gnosischain/specs/tree/master/shutter)
-* [System Overview Dashboard](https://explorer.shutter.network/system-overview)
-* [Gnosis Chain Validator Setup](https://docs.gnosischain.com/node/manual/validator/deposit)
+- [Shutter Validator Registration](https://github.com/shutter-network/shutter-validator-registration)
+- [Shutter Specs](https://github.com/gnosischain/specs/tree/master/shutter)
+- [System Overview Dashboard](https://explorer.shutter.network/system-overview)
+- [Gnosis Chain Validator Setup](https://docs.gnosischain.com/node/manual/validator/deposit)
 
 ---
 
@@ -7576,8 +7629,6 @@ Bootstrap nodes are used to help new nodes discover other nodes in the network. 
 URL: https://docs.erigon.tech/about
 
 Learn about the project, how to get involved, and the license terms.
-
-## Sections
 
 - [Contributing](https://docs.erigon.tech/about/contributing): How to contribute code, report bugs, write docs, and submit pull requests to the Erigon project.
 - [Disclaimer](https://docs.erigon.tech/about/disclaimer): Important notices about software maturity, stability expectations, and intended use.
@@ -7588,7 +7639,6 @@ Learn about the project, how to get involved, and the license terms.
 # Contributing
 URL: https://docs.erigon.tech/about/contributing
 
-
 ## Erigon Client Code
 
 The Erigon node software is developed in the [erigontech/erigon](https://github.com/erigontech/erigon) repository. Code contributions follow the standard GitHub fork-and-PR workflow.
@@ -7596,18 +7646,23 @@ The Erigon node software is developed in the [erigontech/erigon](https://github.
 ### Getting started
 
 1. Fork the repository and clone your fork:
-   ```bash
-   git clone https://github.com/<your-username>/erigon.git
-   cd erigon
-   ```
+
+```bash
+git clone https://github.com/<your-username>/erigon.git
+cd erigon
+```
+
 2. Build the project (requires Go 1.25+ and a C++ compiler):
-   ```bash
-   make erigon
-   ```
+
+```bash
+make erigon
+```
+
 3. Run the test suite:
-   ```bash
-   go test ./...
-   ```
+
+```bash
+go test ./...
+```
 
 ### Reporting bugs and requesting features
 
@@ -7641,15 +7696,19 @@ Open an issue in the repository to suggest corrections, flag outdated content, o
 ### Editing locally
 
 1. Clone the repository and install dependencies:
-   ```bash
-   git clone https://github.com/erigontech/erigon.git
-   cd erigon/docs/site
-   npm install
-   ```
+
+```bash
+git clone https://github.com/erigontech/erigon.git
+cd erigon/docs/site
+npm install
+```
+
 2. Start the local dev server:
-   ```bash
-   npm run start
-   ```
+
+```bash
+npm run start
+```
+
 3. Open `http://localhost:3000` in your browser — changes to Markdown files hot-reload automatically.
 
 ### Submitting a pull request
@@ -7664,18 +7723,16 @@ Open an issue in the repository to suggest corrections, flag outdated content, o
 # License
 URL: https://docs.erigon.tech/about/license
 
-
 © 2026 Erigon Technologies AG. All rights reserved.
 
 Licensed under the [LGPL-3.0](https://github.com/erigontech/erigon/blob/release/2.60/COPYING.LESSER), [GPL-3.0](https://github.com/erigontech/erigon/blob/release/2.60/COPYING).
 
-_Permissions of this copyleft license are conditioned on making available complete source code of licensed works and modifications under the same license or the GNU GPLv3. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. However, a larger work using the licensed work through interfaces provided by the licensed work may be distributed under different terms and without source code for the larger work._
+*Permissions of this copyleft license are conditioned on making available complete source code of licensed works and modifications under the same license or the GNU GPLv3. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. However, a larger work using the licensed work through interfaces provided by the licensed work may be distributed under different terms and without source code for the larger work.*
 
 ---
 
 # Disclaimer
 URL: https://docs.erigon.tech/about/disclaimer
-
 
 The Erigon team does not take any responsibility for losses or damages occurred through the use of Erigon. While we employ a seasoned in-house security team, we have not subjected our systems to independent third-party security assessments.
 
@@ -7685,8 +7742,6 @@ The Erigon team does not take any responsibility for losses or damages occurred 
 URL: https://docs.erigon.tech/help-center
 
 Everything you need to run Erigon smoothly — from quick answers to deep diagnostics.
-
-## Sections
 
 - [FAQ](https://docs.erigon.tech/help-center/frequently-asked-questions-faqs): Answers to the most common questions about installing, syncing, and operating Erigon.
 - [Troubleshooting](https://docs.erigon.tech/help-center/troubleshooting): Step-by-step diagnostic guides for the most frequent runtime and sync issues.
@@ -7700,95 +7755,88 @@ Everything you need to run Erigon smoothly — from quick answers to deep diagno
 # Frequently Asked Questions (FAQs)
 URL: https://docs.erigon.tech/help-center/frequently-asked-questions-faqs
 
-['What is the difference between Erigon and Geth?', 'Erigon began as a fork of Geth but was rewritten to prioritise disk space and sync speed, using a flat MDBX key-value database instead of a Merkle Patricia Trie for a much smaller footprint and faster synchronisation.'],
-  ['Is Erigon a good choice for client diversity?', 'Yes. Erigon has diverged far enough from Geth to be considered a separate client, making it a strong choice for supporting Ethereum client diversity.'],
-  ['What are the minimum hardware requirements?', 'A high-end NVMe or SSD with low latency is the most critical component. 16 GB of RAM and a fast SSD are generally the minimum for a full node; exact needs vary by network and pruning mode.'],
-  ['How long does it take to sync a node?', 'It depends on hardware and bandwidth. A fast system with a high-end NVMe can sync a full node in a few hours, while slower hardware can take several days.'],
-  ['How much disk space is required?', 'It grows with the blockchain and varies by network and pruning mode — a full node needs far less than an archive node. Check the Hardware Requirements page for current figures rather than a fixed value.'],
-  ['Can I run Erigon on an HDD?', 'No. Erigon depends on high-speed disk I/O, and an HDD will almost certainly cause the node to fall behind the chain tip.'],
-  ['What is the --prune.mode flag, and which mode should I use?', 'It controls which historical data is discarded. Use full (the Erigon 3 default) for most users, minimal for validators with limited disk, and archive for a complete historical record.'],
-  ['Can I change my pruning mode after starting the node?', 'No. The pruning mode is fixed at first sync; changing it requires deleting the datadir and re-syncing from scratch.'],
-  ['Do I need a separate consensus client?', 'No. Erigon includes Caplin, an embedded consensus client that runs by default, though some validators prefer a separate consensus client for added reliability.'],
-  ['How do I upgrade my Erigon binary?', 'Gracefully shut down the node, replace the old binary with the new one, and restart. Back up your datadir before any major upgrade.'],
-  ['How do I gracefully shut down Erigon?', 'Use a process manager such as systemd or supervisor, or press Ctrl+C in the terminal, so the database closes cleanly.'],
-  ["What is Erigon's RPC daemon?", 'The RPC daemon is a separate process that serves JSON-RPC API requests and can run on a different machine from the core client for security and scalability.'],
-  ['Is it possible to recover from database corruption?', 'The most reliable fix is to delete the corrupted datadir and re-sync, though repair tools may also help. Ungraceful shutdowns are the usual cause.'],
-  ['What are the required ports?', 'P2P networking uses 30303 (TCP/UDP) and RPC uses 8545 (HTTP), 8546 (WS), and 8551 (Engine API). See Default Ports for the full list.'],
-  ['What is a snapshot sync?', 'Snapshot sync downloads pre-made snapshots of the blockchain state to greatly accelerate the initial sync instead of processing from genesis.'],
-  ["How do I monitor my node's sync progress?", 'Read the stage prefix in the live log line (e.g. [6/8 Execution]), query eth_syncing on the RPC daemon, or ask an AI assistant through the built-in MCP server.'],
-  ['Can I use Erigon with Docker?', 'Yes. Erigon provides official Docker images on Docker Hub; see the Installation guide for setup.'],
-  ['Does Erigon support other chains besides Ethereum?', 'Yes. Erigon is EVM-compatible and supports networks such as Gnosis; select the chain with the --chain flag.'],
-  ['Where can I find official support?', 'The official Erigon Discord and GitHub repository are the primary channels for support and community discussion.'],
-  ['What is Caplin?', "Caplin is Erigon's built-in beacon API server, letting Erigon act as both a consensus and execution client."],
-  ['What is OtterSync?', 'OtterSync is a syncing algorithm that shifts most computation to network bandwidth, reducing sync times and improving chain-tip performance, disk footprint, and decentralisation.'],
-  ["Why can't I query blocks before a certain height?", 'In full and minimal pruning modes Erigon discards historical state older than the pruning window. To query early blocks you must run an archive node, chosen at first sync.'],
-  ['Can I run Erigon on a Raspberry Pi or low-power ARM device?', 'It is not recommended for Mainnet, which needs a high-end NVMe SSD and at least 16 GB of RAM. A testnet like Sepolia may be feasible on higher-end ARM hardware.'],
-  ['What is the MCP server?', 'The MCP (Model Context Protocol) server is a built-in component that exposes Erigon blockchain data to AI assistants. It is enabled by default on 127.0.0.1:8553 and can be turned off with --mcp.disable.'],
-  ['How do I connect Claude Desktop to my Erigon node?', 'Build the standalone mcp binary with make mcp and add it to your Claude Desktop configuration pointing to your node JSON-RPC endpoint or datadir.'],
-  ['My node keeps falling behind the chain tip after running for a while. How do I fix it?', 'Delete only datadir/chaindata (not the whole datadir) and restart — Erigon rebuilds it from snapshots in minutes. Make sure you are on the latest release, as Erigon 3.4+ greatly reduces this problem.'],
-  ['What is the difference between deleting chaindata and deleting the whole datadir?', 'chaindata is the small mutable MDBX database that Erigon re-derives from the snapshots; the snapshots hold ~95% of the data. Deleting only chaindata is recoverable but not free — it triggers a chain-tip resync from the consensus layer, not an instant rebuild; deleting the whole datadir forces a full re-sync.'],
-  ["My node has no peers or won't sync. Which ports do I need to open?", 'Open 30303/30304 (execution P2P), 4000/4001 (Caplin), and 42069 (snapshot download), TCP and UDP where applicable; keep 8545 local. Behind NAT, set --nat and --caplin.nat to stun or upnp.'],
-  ['How do I reduce Erigon memory use or stop it from being OOM-killed?', 'Make Erigon and the Go runtime more conservative with GOMEMLIMIT, a lower GOGC, a capped GOMAXPROCS, and a smaller --batchSize.'],
-  ['Where do I report a security vulnerability?', "Report security issues through the Ethereum Foundation's Bug Bounty Program rather than public Discord or GitHub, so they can be handled responsibly."],
-  ["Where are Erigon's log files stored?", 'By default Erigon writes logs to /logs/erigon.log, in addition to standard output. Attach this file when opening a bug report.'],
-];
-
-  
-  
-
-# Frequently Asked Questions (FAQs)
-
 This list addresses the most common inquiries from the Erigon community, offering quick and direct answers to a variety of topics.
 
 1. **What is the difference between Erigon and Geth?** Erigon originated as a fork of Geth but has been entirely rewritten with a focus on disk space and sync speed. It uses a flat, key-value database (MDBX) instead of a Merkle Patricia Trie, resulting in a much smaller disk footprint and faster synchronization times.
+
 2. **Is Erigon a good choice for client diversity?** Yes. The codebases have diverged so significantly from Geth that they are now considered separate clients, making Erigon an excellent choice to support Ethereum's client diversity goals.
-3. **What are the minimum hardware requirements?** The most critical component is a high-end NVMe or SSD with very low latency. While the exact requirements vary by network, 16GB of RAM and a fast SSD are generally the minimum for a full node. See [Hardware Requirements](/get-started/hardware-requirements) for detailed specs per network and pruning mode.
+
+3. **What are the minimum hardware requirements?** The most critical component is a high-end NVMe or SSD with very low latency. While the exact requirements vary by network, 16GB of RAM and a fast SSD are generally the minimum for a full node. See [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements) for detailed specs per network and pruning mode.
+
 4. **How long does it take to sync a node?** Initial synchronization time is highly dependent on hardware and bandwidth. A fast system with a high-end NVMe can sync a full node in as little as few hours, while on slower hardware, it can take several days.
-5. **How much disk space is required?** Disk requirements grow continuously with the blockchain and vary by network and pruning mode — a full node needs far less than an archive node. Because these figures drift over time, always check the current numbers rather than relying on a fixed value. See [Hardware Requirements](/get-started/hardware-requirements) for per-network specs and [Database](/fundamentals/database) for a breakdown of what consumes disk space.
+
+5. **How much disk space is required?** Disk requirements grow continuously with the blockchain and vary by network and pruning mode — a full node needs far less than an archive node. Because these figures drift over time, always check the current numbers rather than relying on a fixed value. See [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements) for per-network specs and [Database](https://docs.erigon.tech/fundamentals/database) for a breakdown of what consumes disk space.
+
 6. **Can I run Erigon on an HDD?** It is not recommended to run Erigon on an HDD. The client's performance is critically dependent on high-speed disk I/O, and an HDD will almost certainly cause the node to fall behind the blockchain tip.
-7. **What is the `--prune.mode` flag, and which mode should I use?** This flag determines which historical data is discarded. The `full` mode (the default for Erigon 3) is suitable for most users. The `minimal` mode is for validators with limited disk space. The `archive` mode is for those who need a full historical record for all past states. See [Pruning Modes](/fundamentals/pruning-modes) for a full comparison.
+
+7. **What is the `--prune.mode` flag, and which mode should I use?** This flag determines which historical data is discarded. The `full` mode (the default for Erigon 3) is suitable for most users. The `minimal` mode is for validators with limited disk space. The `archive` mode is for those who need a full historical record for all past states. See [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes) for a full comparison.
+
 8. **Can I change my pruning mode after starting the node?** No. The pruning mode is a permanent choice made at the first sync. Changing it requires deleting the `datadir` directory and a full re-sync from scratch.
-9. **Do I need a separate consensus client?** No, you don't need a separate consensus client. In many cases, it's fine to use [Caplin](/staking/caplin), the embedded consensus client that runs by default within Erigon. However, some users, especially validators, prefer to run a [separate consensus client](/staking/external-consensus-client-as-validator) for enhanced reliability.
-10. **How do I upgrade my Erigon binary?** The process involves gracefully shutting down the node, replacing the old binary with the new one, and restarting. See the [Upgrading](/get-started/installation/upgrading) guide for step-by-step instructions. It is also recommended to back up your datadir before any major upgrade.
+
+9. **Do I need a separate consensus client?** No, you don't need a separate consensus client. In many cases, it's fine to use [Caplin](https://docs.erigon.tech/staking/caplin), the embedded consensus client that runs by default within Erigon. However, some users, especially validators, prefer to run a [separate consensus client](https://docs.erigon.tech/staking/external-consensus-client-as-validator) for enhanced reliability.
+
+10. **How do I upgrade my Erigon binary?** The process involves gracefully shutting down the node, replacing the old binary with the new one, and restarting. See the [Upgrading](https://docs.erigon.tech/get-started/installation/upgrading) guide for step-by-step instructions. It is also recommended to back up your datadir before any major upgrade.
+
 11. **How do I gracefully shut down Erigon?** The safest way to shut down is by using a process manager like `systemd` or `supervisor`. Alternatively, you can press `Ctrl+C` in the terminal to allow the database to close cleanly.
-12. **What is Erigon's RPC daemon?** The [RPC daemon](/fundamentals/modules/rpc-daemon) is a separate process that handles JSON RPC API requests. It can run on a different machine from the core Erigon client to enhance security and scalability.
+
+12. **What is Erigon's RPC daemon?** The [RPC daemon](https://docs.erigon.tech/fundamentals/modules/rpc-daemon) is a separate process that handles JSON RPC API requests. It can run on a different machine from the core Erigon client to enhance security and scalability.
+
 13. **Is it possible to recover from a database corruption?** While Erigon's database is robust, an ungraceful shutdown can cause corruption. The most reliable solution is to delete the corrupted datadir and perform a full re-sync, but it is also worth using repair tools.
-14. **What are the required ports?** Erigon requires specific ports for P2P networking (default `30303` TCP/UDP) and RPC access (`8545` HTTP, `8546` WS, `8551` Engine API). See [Default Ports](/fundamentals/default-ports) for the complete list.
-15. **What is a "snapshot sync"?** Snapshot sync is a stage of the synchronization process where the node downloads pre-made snapshots of the blockchain state. This significantly accelerates the initial sync, reducing the time required to catch up with the network. See [Pruning Modes](/fundamentals/pruning-modes) for details.
+
+14. **What are the required ports?** Erigon requires specific ports for P2P networking (default `30303` TCP/UDP) and RPC access (`8545` HTTP, `8546` WS, `8551` Engine API). See [Default Ports](https://docs.erigon.tech/fundamentals/default-ports) for the complete list.
+
+15. **What is a "snapshot sync"?** Snapshot sync is a stage of the synchronization process where the node downloads pre-made snapshots of the blockchain state. This significantly accelerates the initial sync, reducing the time required to catch up with the network. See [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes) for details.
+
 16. **How do I monitor my node's sync progress?** There are three complementary ways:
 
-    * **Read the live log line** — every sync log line is prefixed with the current stage and its position in the pipeline, e.g. `[6/8 Execution]`. The two numbers show the current stage and the total number of stages for your configuration; the prefix advances through the stages until the final `Finish` stage, at which point the node is at the chain tip. See [Logs → Stage Definitions](/fundamentals/logs#stage-definitions) for the full ordered list.
-    * **Query the JSON-RPC** — call `eth_syncing` against the RPC daemon (default port `8545`):
+  - **Read the live log line** — every sync log line is prefixed with the current stage and its position in the pipeline, e.g. `[6/8 Execution]`. The two numbers show the current stage and the total number of stages for your configuration; the prefix advances through the stages until the final `Finish` stage, at which point the node is at the chain tip. See [Logs → Stage Definitions](https://docs.erigon.tech/fundamentals/logs#stage-definitions) for the full ordered list.
 
-      ```bash
-      curl -s -X POST -H "Content-Type: application/json" \
-        --data '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}' \
-        http://localhost:8545
-      ```
+  - **Query the JSON-RPC** — call `eth_syncing` against the RPC daemon (default port `8545`):
 
-      While syncing the result is an object with `currentBlock`, `highestBlock`, and a `stages` array (per-stage progress, matching the log prefix); once fully synced it is simply `false`. (`startingBlock` is also returned but is hardcoded to `"0x0"`.)
-    * **Ask an AI assistant via MCP** — Erigon's built-in [MCP server](/fundamentals/mcp) (default `127.0.0.1:8553`) lets a connected assistant like Claude Desktop answer questions like *"Is my node synced? How many blocks behind am I?"* in plain language by querying the same data the JSON-RPC exposes. Useful when you'd rather not parse logs or `eth_syncing` output by hand.
-17. **Can I use Erigon with Docker?** Yes, Erigon provides official Docker images on Dockerhub. See the [Installation](/get-started/installation) guide for the Docker setup instructions.
-18. **Does Erigon support other chains besides Ethereum?** Yes, Erigon is an EVM-compatible client and supports other networks like Gnosis. You can specify the chain with the `--chain` flag. See [Supported Networks](/fundamentals/supported-networks) and the [Easy Nodes](/get-started/easy-nodes) guides for chain-specific setup.
+```bash
+curl -s -X POST -H "Content-Type: application/json" \
+  --data '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}' \
+  http://localhost:8545
+```
+
+While syncing the result is an object with `currentBlock`, `highestBlock`, and a `stages` array (per-stage progress, matching the log prefix); once fully synced it is simply `false`. (`startingBlock` is also returned but is hardcoded to `"0x0"`.)
+
+  - **Ask an AI assistant via MCP** — Erigon's built-in [MCP server](https://docs.erigon.tech/fundamentals/mcp) (default `127.0.0.1:8553`) lets a connected assistant like Claude Desktop answer questions like *"Is my node synced? How many blocks behind am I?"* in plain language by querying the same data the JSON-RPC exposes. Useful when you'd rather not parse logs or `eth_syncing` output by hand.
+
+17. **Can I use Erigon with Docker?** Yes, Erigon provides official Docker images on Dockerhub. See the [Installation](https://docs.erigon.tech/get-started/installation) guide for the Docker setup instructions.
+
+18. **Does Erigon support other chains besides Ethereum?** Yes, Erigon is an EVM-compatible client and supports other networks like Gnosis. You can specify the chain with the `--chain` flag. See [Supported Networks](https://docs.erigon.tech/fundamentals/supported-networks) and the [Easy Nodes](https://docs.erigon.tech/get-started/easy-nodes) guides for chain-specific setup.
+
 19. **Where can I find official support?** The primary channels for support and community discussions are the official Erigon Discord and GitHub repository.
-20. **What is Caplin?** [Caplin](/staking/caplin) is Erigon's built-in beacon API server. It allows Erigon to function as both a consensus and execution client.
+
+20. **What is Caplin?** [Caplin](https://docs.erigon.tech/staking/caplin) is Erigon's built-in beacon API server. It allows Erigon to function as both a consensus and execution client.
+
 21. **What is OtterSync?** OtterSync is a syncing algorithm that further enhances performance by shifting 98% of the computation to network bandwidth, reducing synchronization times and improving chain tip performance, disk footprint, and decentralization.
-22. **Why can't I query blocks before a certain height?** In `full` and `minimal` pruning modes, Erigon discards historical state data that is older than the pruning window. If you need to query early blocks, you must run an archive node (`--prune.mode=archive`). See [Pruning Modes](/fundamentals/pruning-modes) for more on pruning. Note that the pruning mode is set permanently at the first sync and cannot be changed without a full re-sync.
-23. **Can I run Erigon on a Raspberry Pi or low-power ARM device?** It is not recommended for Mainnet. Erigon requires a high-end NVMe SSD and sufficient RAM (16 GB minimum) for reliable operation. Low-power ARM devices typically lack the disk I/O performance and memory needed to keep up with the chain tip. See [Hardware Requirements](/get-started/hardware-requirements). A testnet like Sepolia may be feasible on higher-end ARM hardware, but expect limited performance.
+
+22. **Why can't I query blocks before a certain height?** In `full` and `minimal` pruning modes, Erigon discards historical state data that is older than the pruning window. If you need to query early blocks, you must run an archive node (`--prune.mode=archive`). See [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes) for more on pruning. Note that the pruning mode is set permanently at the first sync and cannot be changed without a full re-sync.
+
+23. **Can I run Erigon on a Raspberry Pi or low-power ARM device?** It is not recommended for Mainnet. Erigon requires a high-end NVMe SSD and sufficient RAM (16 GB minimum) for reliable operation. Low-power ARM devices typically lack the disk I/O performance and memory needed to keep up with the chain tip. See [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements). A testnet like Sepolia may be feasible on higher-end ARM hardware, but expect limited performance.
+
 24. **What is the MCP server?** The MCP (Model Context Protocol) server is a built-in component that exposes Erigon's blockchain data to AI assistants like Claude Desktop. It is enabled by default and listens on `127.0.0.1:8553`. To disable it, pass `--mcp.disable` at startup.
-25. **How do I connect Claude Desktop to my Erigon node?** Build the standalone `mcp` binary with `make mcp`, then add it to your Claude Desktop configuration at `~/.config/claude-desktop/config.json` pointing to your node's JSON-RPC endpoint or datadir. See the [MCP Server](/fundamentals/mcp) page for the full configuration example.
-26. **My node keeps falling behind the chain tip after running for a while. How do I fix it?** In most cases you can recover by deleting only the hot database — `datadir/chaindata` — and restarting. Do **not** delete the whole `datadir`, which would force a full re-sync. Erigon re-derives `chaindata` from the immutable snapshots (re-downloading them if needed) and resyncs the post-snapshot tip from the consensus layer — treat it as a chain-tip resync, not an instant rebuild, and keep a backup if fast recovery matters. Make sure you are on the latest release: Erigon 3.4+ ships a much smaller `chaindata` and an improved pruning algorithm that greatly reduces this problem. See [Common Errors and Solutions](/help-center/common-errors-and-solutions) and [Optimizing Storage](/fundamentals/optimizing-storage).
-27. **What is the difference between deleting `chaindata` and deleting the whole `datadir`?** `chaindata` is Erigon's small, mutable MDBX database (typically 15–20 GB, even on an archive node) holding recent state and sync progress. The `snapshots` directory holds the immutable historical data — roughly 95% of the total footprint. Deleting `chaindata` is recoverable but not free: Erigon re-derives state from the snapshots (re-downloading them if needed) and resyncs the post-snapshot tip from the consensus layer — a chain-tip resync, not an instant rebuild. Deleting the entire `datadir` also discards the snapshots and forces a full re-sync. When in doubt, delete only `chaindata`. See [Database](/fundamentals/database).
-28. **My node has no peers or won't sync. Which ports do I need to open?** Erigon needs several ports reachable (both TCP and UDP where applicable): `30303`/`30304` (execution-layer P2P), `4000` and `4001` (Caplin consensus peering), and `42069` (BitTorrent snapshot download). Keep the RPC port (`8545`) bound to localhost and never expose it publicly. If your node is behind NAT, set `--nat` and `--caplin.nat` to `stun` or `upnp` and forward those ports on your router. See [Default Ports](/fundamentals/default-ports) and [NAT](/fundamentals/nat).
-29. **How do I reduce Erigon's memory use or stop it from being OOM-killed?** Erigon and the Go runtime size their memory and CPU use from the resources they can see, so on a shared or memory-constrained host you can make them more conservative: set `GOMEMLIMIT` (e.g. `GOMEMLIMIT=26GiB`), lower `GOGC` (e.g. `GOGC=80`), cap `GOMAXPROCS` (e.g. to half your cores), and reduce `--batchSize` (e.g. `--batchSize=256m`). See [Common Errors and Solutions](/help-center/common-errors-and-solutions) and [Performance Tricks](/fundamentals/performance-tricks).
+
+25. **How do I connect Claude Desktop to my Erigon node?** Build the standalone `mcp` binary with `make mcp`, then add it to your Claude Desktop configuration at `~/.config/claude-desktop/config.json` pointing to your node's JSON-RPC endpoint or datadir. See the [MCP Server](https://docs.erigon.tech/fundamentals/mcp) page for the full configuration example.
+
+26. **My node keeps falling behind the chain tip after running for a while. How do I fix it?** In most cases you can recover by deleting only the hot database — `datadir/chaindata` — and restarting. Do **not** delete the whole `datadir`, which would force a full re-sync. Erigon re-derives `chaindata` from the immutable snapshots (re-downloading them if needed) and resyncs the post-snapshot tip from the consensus layer — treat it as a chain-tip resync, not an instant rebuild, and keep a backup if fast recovery matters. Make sure you are on the latest release: Erigon 3.4+ ships a much smaller `chaindata` and an improved pruning algorithm that greatly reduces this problem. See [Common Errors and Solutions](https://docs.erigon.tech/help-center/common-errors-and-solutions) and [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage).
+
+27. **What is the difference between deleting `chaindata` and deleting the whole `datadir`?** `chaindata` is Erigon's small, mutable MDBX database (typically 15–20 GB, even on an archive node) holding recent state and sync progress. The `snapshots` directory holds the immutable historical data — roughly 95% of the total footprint. Deleting `chaindata` is recoverable but not free: Erigon re-derives state from the snapshots (re-downloading them if needed) and resyncs the post-snapshot tip from the consensus layer — a chain-tip resync, not an instant rebuild. Deleting the entire `datadir` also discards the snapshots and forces a full re-sync. When in doubt, delete only `chaindata`. See [Database](https://docs.erigon.tech/fundamentals/database).
+
+28. **My node has no peers or won't sync. Which ports do I need to open?** Erigon needs several ports reachable (both TCP and UDP where applicable): `30303`/`30304` (execution-layer P2P), `4000` and `4001` (Caplin consensus peering), and `42069` (BitTorrent snapshot download). Keep the RPC port (`8545`) bound to localhost and never expose it publicly. If your node is behind NAT, set `--nat` and `--caplin.nat` to `stun` or `upnp` and forward those ports on your router. See [Default Ports](https://docs.erigon.tech/fundamentals/default-ports) and [NAT](https://docs.erigon.tech/fundamentals/nat).
+
+29. **How do I reduce Erigon's memory use or stop it from being OOM-killed?** Erigon and the Go runtime size their memory and CPU use from the resources they can see, so on a shared or memory-constrained host you can make them more conservative: set `GOMEMLIMIT` (e.g. `GOMEMLIMIT=26GiB`), lower `GOGC` (e.g. `GOGC=80`), cap `GOMAXPROCS` (e.g. to half your cores), and reduce `--batchSize` (e.g. `--batchSize=256m`). See [Common Errors and Solutions](https://docs.erigon.tech/help-center/common-errors-and-solutions) and [Performance Tricks](https://docs.erigon.tech/fundamentals/performance-tricks).
+
 30. **Where do I report a security vulnerability?** Erigon is covered by the Ethereum Foundation's [Bug Bounty Program](https://ethereum.org/bug-bounty). Report security issues there so they can be handled responsibly — not via public Discord or GitHub issues. For non-security bugs, open a GitHub issue with logs and version info.
-31. **Where are Erigon's log files stored?** By default Erigon writes logs to `<datadir>/logs/erigon.log`, in addition to standard output. Attach this file when opening a bug report. See [Logs](/fundamentals/logs) for log-level and rotation options.
+
+31. **Where are Erigon's log files stored?** By default Erigon writes logs to `<datadir>/logs/erigon.log`, in addition to standard output. Attach this file when opening a bug report. See [Logs](https://docs.erigon.tech/fundamentals/logs) for log-level and rotation options.
 
 ---
 
 # Troubleshooting
 URL: https://docs.erigon.tech/help-center/troubleshooting
-
 
 ## Resilience and Data Integrity
 
@@ -7798,22 +7846,22 @@ Erigon is highly resilient and uses a fully-transactional database. This design 
 
 When an issue arises, follow these steps to methodically diagnose and resolve the problem.
 
-1. **Check Hardware Requirements:** The most common cause of issues is insufficient disk or RAM. Ensure your system meets the recommended [Hardware Requirements](/get-started/hardware-requirements). Note that Erigon is very adaptive—adding more RAM to the server will make Erigon faster without requiring any setting changes.
-2. **Inspect Erigon Logs:** The logs are your best friend. By default Erigon writes to `<datadir>/logs/erigon.log`; use `tail -f <datadir>/logs/erigon.log` or `journalctl` to see real-time output and identify error messages or warnings. See [Logs](/fundamentals/logs) for log configuration options.
+1. **Check Hardware Requirements:** The most common cause of issues is insufficient disk or RAM. Ensure your system meets the recommended [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements). Note that Erigon is very adaptive—adding more RAM to the server will make Erigon faster without requiring any setting changes.
+2. **Inspect Erigon Logs:** The logs are your best friend. By default Erigon writes to `<datadir>/logs/erigon.log`; use `tail -f <datadir>/logs/erigon.log` or `journalctl` to see real-time output and identify error messages or warnings. See [Logs](https://docs.erigon.tech/fundamentals/logs) for log configuration options.
 3. **Verify Sync Status:** Use `curl localhost:8545 -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}'` to check if the node is actively syncing.
-4. **Monitor System Resources:** Use `htop`, `top`, or `iostat` to monitor CPU, RAM, and disk I/O. This can help you identify a performance bottleneck. For a full monitoring dashboard, see [Creating a Dashboard](/fundamentals/creating-a-dashboard).
+4. **Monitor System Resources:** Use `htop`, `top`, or `iostat` to monitor CPU, RAM, and disk I/O. This can help you identify a performance bottleneck. For a full monitoring dashboard, see [Creating a Dashboard](https://docs.erigon.tech/fundamentals/creating-a-dashboard).
 5. **Look for OOM-kill events:** After an unexpected crash, always check your system logs for an "Out of Memory" killer event. This confirms if a memory issue caused the crash.
 6. **Perform a Simple Restart**: If the node is stalled, simply restart the service using `systemctl restart erigon`. Erigon's transactional database is designed to handle interruption gracefully.
-7. **Disable RPC/CL during Initial Sync**: If you are stalling during snapshot sync, try restarting without the [RPC daemon](/fundamentals/modules/rpc-daemon) or consensus client to reduce concurrent disk access, which is a bottleneck during the slowest stage (Blocks Execution).
-8. **Check for Disk Space:** Regularly check your disk usage. A full disk will cause performance degradation and can lead to a node crash. See [Optimizing Storage](/fundamentals/optimizing-storage) for tips on reducing disk usage.
+7. **Disable RPC/CL during Initial Sync**: If you are stalling during snapshot sync, try restarting without the [RPC daemon](https://docs.erigon.tech/fundamentals/modules/rpc-daemon) or consensus client to reduce concurrent disk access, which is a bottleneck during the slowest stage (Blocks Execution).
+8. **Check for Disk Space:** Regularly check your disk usage. A full disk will cause performance degradation and can lead to a node crash. See [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage) for tips on reducing disk usage.
 9. **Verify Network Time:** Ensure your system's clock is synchronized. Incorrect time can cause issues with block propagation.
-10. **Check P2P Peer Connections:** Use `net_peerCount` or similar RPC methods to check if you have a healthy number of peers. A low count may indicate a network problem. See [Default Ports](/fundamentals/default-ports) to verify firewall rules allow P2P traffic.
-11. **Review Firewall Rules:** Confirm that your firewall is not blocking inbound or outbound traffic on the required P2P and RPC [ports](/fundamentals/default-ports).
-12. **Double-Check Configuration Flags:** Review all your command-line flags for typos or incorrect values. A single misplaced character can cause a cryptic error. See the [CLI Reference](/fundamentals/configuring-erigon) for the full flag list.
-13. **Check for Snapshot File Issues:** For version upgrades, a known issue with snapshot filenames can cause problems. Use snapshot [upgrade](/get-started/installation/upgrading) and repair options.
-14. **Correct File Ownership:** If using a dedicated user or Docker, confirm that the user has full read/write access to the datadir. See the [Docker Compose](/fundamentals/docker-compose) guide for container-specific permission tips.
-15. **Adjust RPC Timeouts:** If specific RPC requests are timing out, try increasing the timeout values to allow more time for heavy requests to complete. See the [RPC & API flags](/fundamentals/configuring-erigon#rpc--api) in the CLI Reference.
-16. **Check for `DB.read.concurrency` issues:** If you have high RPC traffic and low TPS, try reducing the `--DB.read.concurrency` flag. See [Configuring Erigon](/fundamentals/configuring-erigon) for all database-related flags.
+10. **Check P2P Peer Connections:** Use `net_peerCount` or similar RPC methods to check if you have a healthy number of peers. A low count may indicate a network problem. See [Default Ports](https://docs.erigon.tech/fundamentals/default-ports) to verify firewall rules allow P2P traffic.
+11. **Review Firewall Rules:** Confirm that your firewall is not blocking inbound or outbound traffic on the required P2P and RPC [ports](https://docs.erigon.tech/fundamentals/default-ports).
+12. **Double-Check Configuration Flags:** Review all your command-line flags for typos or incorrect values. A single misplaced character can cause a cryptic error. See the [CLI Reference](https://docs.erigon.tech/fundamentals/configuring-erigon) for the full flag list.
+13. **Check for Snapshot File Issues:** For version upgrades, a known issue with snapshot filenames can cause problems. Use snapshot [upgrade](https://docs.erigon.tech/get-started/installation/upgrading) and repair options.
+14. **Correct File Ownership:** If using a dedicated user or Docker, confirm that the user has full read/write access to the datadir. See the [Docker Compose](https://docs.erigon.tech/fundamentals/docker-compose) guide for container-specific permission tips.
+15. **Adjust RPC Timeouts:** If specific RPC requests are timing out, try increasing the timeout values to allow more time for heavy requests to complete. See the [RPC & API flags](https://docs.erigon.tech/fundamentals/configuring-erigon#rpc--api) in the CLI Reference.
+16. **Check for `DB.read.concurrency` issues:** If you have high RPC traffic and low TPS, try reducing the `--DB.read.concurrency` flag. See [Configuring Erigon](https://docs.erigon.tech/fundamentals/configuring-erigon) for all database-related flags.
 17. **Report a Bug:** If all else fails, open a detailed bug report on GitHub with logs, version info, and a clear description of the problem.
 18. **Engage with the Community:** The Erigon Discord server is an invaluable resource for seeking help from core developers and experienced users.
 
@@ -7847,10 +7895,10 @@ Attach the `.pprof` files and the goroutine dump to your GitHub issue.
 
 Hetzner applies a stateless firewall at the network edge. Ensure the following ports are open for **both TCP and UDP, inbound and outbound**:
 
-| Purpose        | Port  | Protocol |
-| -------------- | ----- | -------- |
-| P2P (Ethereum) | 30303 | TCP+UDP  |
-| P2P (Caplin)   | 9000  | TCP+UDP  |
+| Purpose | Port | Protocol |
+| --- | --- | --- |
+| P2P (Ethereum) | 30303 | TCP+UDP |
+| P2P (Caplin) | 9000 | TCP+UDP |
 
 Without these, the node may appear to have peers (via the cloud dashboard) but will suffer poor block propagation. Configure the firewall in the Hetzner Cloud Console under **Firewalls** or via `hcloud firewall`.
 
@@ -7858,7 +7906,6 @@ Without these, the node may appear to have peers (via the cloud dashboard) but w
 
 # Known Issues
 URL: https://docs.erigon.tech/help-center/known-issues
-
 
 ### Incorrect Memory Usage in `htop`
 
@@ -7870,9 +7917,9 @@ The **`RES`** (Resident) column in `htop` combines the memory used by the applic
 
 For a more accurate view of Erigon's memory usage, use one of these tools:
 
-* **`vmmap -summary PID`** _(macOS only)_: Shows a detailed breakdown with separate **`MALLOC ZONE`** and **`REGION TYPE`** sections for application memory and OS page cache.
-* **`pmap -x PID`** _(Linux)_: Prints a per-mapping breakdown of RSS and dirty pages. For the full raw detail use `cat /proc/<PID>/smaps`.
-* **Prometheus Dashboard**: This provides a graphical representation of the Go application's memory usage, excluding the OS page cache. You can run it with `make prometheus` and access it in your browser at `localhost:3000` with the credentials `admin/admin`. See [Creating a Dashboard](/fundamentals/creating-a-dashboard) for full setup instructions.
+- **`vmmap -summary PID`** *(macOS only)*: Shows a detailed breakdown with separate **`MALLOC ZONE`** and **`REGION TYPE`** sections for application memory and OS page cache.
+- **`pmap -x PID`** *(Linux)*: Prints a per-mapping breakdown of RSS and dirty pages. For the full raw detail use `cat /proc/<PID>/smaps`.
+- **Prometheus Dashboard**: This provides a graphical representation of the Go application's memory usage, excluding the OS page cache. You can run it with `make prometheus` and access it in your browser at `localhost:3000` with the credentials `admin/admin`. See [Creating a Dashboard](https://docs.erigon.tech/fundamentals/creating-a-dashboard) for full setup instructions.
 
 Erigon typically uses about **4 GB of RAM** during a genesis sync and about **1 GB** during normal operation. The OS page cache, however, can use an unlimited amount of memory.
 
@@ -7888,10 +7935,10 @@ Cloud network drives, like gp3, aren't ideal for Erigon's block execution. This 
 
 Erigon3 is designed to download most of the history, making it less sensitive to disk latency. To improve performance, focus on **reducing disk latency**, not on increasing throughput or IOPS. There are several ways to do this:
 
-* **Use latency-critical cloud drives** or attached NVMe storage, especially for the initial sync.
-* **Increase RAM**. More RAM helps buffer data and reduces the need for frequent disk access.
-* If you have sufficient RAM, you can set the environment variable **`ERIGON_SNAPSHOT_MADV_RND=false`**. This setting can improve performance by altering how Erigon handles memory.
-* Use the flag **`--db.pagesize=64kb`** to decrease database fragmentation and improve I/O efficiency.
+- **Use latency-critical cloud drives** or attached NVMe storage, especially for the initial sync.
+- **Increase RAM**. More RAM helps buffer data and reduces the need for frequent disk access.
+- If you have sufficient RAM, you can set the environment variable **`ERIGON_SNAPSHOT_MADV_RND=false`**. This setting can improve performance by altering how Erigon handles memory.
+- Use the flag **`--db.pagesize=64kb`** to decrease database fragmentation and improve I/O efficiency.
 
 #### Background File System Features Can Hurt Performance
 
@@ -7903,7 +7950,7 @@ Certain file system features, such as `autodefrag` on btrfs, can drastically inc
 
 #### The `--mount` Option and BuildKit Errors
 
-If you're encountering a BuildKit error when starting Erigon, it's likely due to an issue with the `--mount` option in your command. To fix this, you can use the following command to start Erigon with `docker-compose`. See [Docker Compose](/fundamentals/docker-compose) for the full setup guide.
+If you're encountering a BuildKit error when starting Erigon, it's likely due to an issue with the `--mount` option in your command. To fix this, you can use the following command to start Erigon with `docker-compose`. See [Docker Compose](https://docs.erigon.tech/fundamentals/docker-compose) for the full setup guide.
 
 ```bash
 XDG_DATA_HOME=/preferred/data/folder make docker-compose
@@ -7920,68 +7967,67 @@ vm.max_map_count = 16777216
 
 ### Changing `--db.pagesize` After First Sync
 
-The `--db.pagesize` flag sets the MDBX page size and **must be chosen before the first sync**. It cannot be changed on an existing database without deleting the datadir and re-syncing from scratch. See [Configuring Erigon](/fundamentals/configuring-erigon) for all database flags.
+The `--db.pagesize` flag sets the MDBX page size and **must be chosen before the first sync**. It cannot be changed on an existing database without deleting the datadir and re-syncing from scratch. See [Configuring Erigon](https://docs.erigon.tech/fundamentals/configuring-erigon) for all database flags.
 
-The default page size is `4KB`. For cloud drives or any storage with high sequential I/O latency, a larger page size (e.g. `--db.pagesize=64kb`) reduces database fragmentation and improves I/O efficiency. See [Performance Tricks](/fundamentals/performance-tricks) and [Optimizing Storage](/fundamentals/optimizing-storage) for further tuning options.
+The default page size is `4KB`. For cloud drives or any storage with high sequential I/O latency, a larger page size (e.g. `--db.pagesize=64kb`) reduces database fragmentation and improves I/O efficiency. See [Performance Tricks](https://docs.erigon.tech/fundamentals/performance-tricks) and [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage) for further tuning options.
 
 ---
 
 # Best Practices
 URL: https://docs.erigon.tech/help-center/best-practices
 
-
 These integrated practices focus on maximizing the reliability, efficiency, and security of your Erigon node setup.
 
 ## Hardware and Data Integrity
 
-| **Practice**                        | **Details**                                                                                                                                                                     | **Rationale**                                                                                                                                                                           |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Use a High-End NVMe SSD             | This is a non-negotiable prerequisite. NVMe SSDs are essential for reliable, high-performance node operation. See [Hardware Requirements](/get-started/hardware-requirements).  | Erigon is highly disk I/O intensive. Fast storage prevents bottlenecks and sync issues.                                                                                                 |
-| Integrate Hardware Reliability      | Use ECC memory and consider a disk RAID setup. Do regular backups of your chain data.                                                                                           | While Erigon's database is fully-transactional and resilient to graceful shutdowns, crashes, and power outages, it is not protected against hardware failures (disk or RAM corruption). |
-| Symlink Data Directories (Advanced) | For systems with multiple disks, consider symlinking `snapshots` and `temp` directories to a cheaper, high-capacity drive, while keeping the main `chaindata` on the fast NVMe. See [Optimizing Storage](/fundamentals/optimizing-storage). | Optimizes cost and capacity while retaining performance for critical files.                                                                          |
-| Maintain Sufficient RAM             | Ensure your system has at least the recommended RAM for your chosen network and [pruning mode](/fundamentals/pruning-modes). See [Hardware Requirements](/get-started/hardware-requirements). | Insufficient RAM, even with Erigon's memory efficiency, will lead to OOM-kill events (Out-of-Memory).                                                                                   |
+| **Practice** | **Details** | **Rationale** |
+| --- | --- | --- |
+| Use a High-End NVMe SSD | This is a non-negotiable prerequisite. NVMe SSDs are essential for reliable, high-performance node operation. See [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements). | Erigon is highly disk I/O intensive. Fast storage prevents bottlenecks and sync issues. |
+| Integrate Hardware Reliability | Use ECC memory and consider a disk RAID setup. Do regular backups of your chain data. | While Erigon's database is fully-transactional and resilient to graceful shutdowns, crashes, and power outages, it is not protected against hardware failures (disk or RAM corruption). |
+| Symlink Data Directories (Advanced) | For systems with multiple disks, consider symlinking `snapshots` and `temp` directories to a cheaper, high-capacity drive, while keeping the main `chaindata` on the fast NVMe. See [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage). | Optimizes cost and capacity while retaining performance for critical files. |
+| Maintain Sufficient RAM | Ensure your system has at least the recommended RAM for your chosen network and [pruning mode](https://docs.erigon.tech/fundamentals/pruning-modes). See [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements). | Insufficient RAM, even with Erigon's memory efficiency, will lead to OOM-kill events (Out-of-Memory). |
 
 ## Node Configuration and Startup
 
-| **Practice**                               | **Details**                                                                                                                                                                         | **Rationale**                                                                                                                                                           |
-| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Make a Mindful Pruning Mode Decision       | The `--prune.mode` flag is irreversible. Choose `full` for most cases, `minimal` for validators with limited space, and `archive` only if all historical data is absolutely needed. See [Pruning Modes](/fundamentals/pruning-modes). | An incorrect choice can lead to a necessary resync. `Full` is a balance of performance and space.                                |
-| Employ a Process Manager                   | Always run Erigon as a systemd or supervisor service. See the [Installation](/get-started/installation) guide for service setup examples.                                           | Ensures a graceful shutdown and allows for automatic restarts, contributing to stability.                                                                               |
-| Use a Dedicated User Account               | Run the Erigon service with a non-root, dedicated user account.                                                                                                                     | Follows security best practices and prevents potential permission-related errors.                                                                                       |
-| Avoid Graceful Shutdown (Unless Necessary) | While a process manager ensures a graceful shutdown, know that Erigon is safe against abrupt halts like process kills (`kill -9`) or a power outage.                                | Erigon's database is fully-transactional, meaning writes are atomic ("all-or-nothing"), preventing "partial writes" and database corruption from non-hardware failures. |
-| Tune Sync Speed with Flags                 | Use flags like `--sync.loop.block.limit` and `--batchSize` to tune the synchronization speed, especially during the initial sync. See [Configuring Erigon](/fundamentals/configuring-erigon). | Allows you to optimize the sync process based on your system's hardware capabilities.                                                   |
-| Lock the Latest State in RAM (Advanced)    | On systems with high historical RPC traffic, a tool like vmtouch can be used to lock the latest state files in RAM. See [Performance Tricks](/fundamentals/performance-tricks).     | Improves RPC response times for common queries by keeping the latest data in the fastest memory.                                                                        |
+| **Practice** | **Details** | **Rationale** |
+| --- | --- | --- |
+| Make a Mindful Pruning Mode Decision | The `--prune.mode` flag is irreversible. Choose `full` for most cases, `minimal` for validators with limited space, and `archive` only if all historical data is absolutely needed. See [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes). | An incorrect choice can lead to a necessary resync. `Full` is a balance of performance and space. |
+| Employ a Process Manager | Always run Erigon as a systemd or supervisor service. See the [Installation](https://docs.erigon.tech/get-started/installation) guide for service setup examples. | Ensures a graceful shutdown and allows for automatic restarts, contributing to stability. |
+| Use a Dedicated User Account | Run the Erigon service with a non-root, dedicated user account. | Follows security best practices and prevents potential permission-related errors. |
+| Avoid Graceful Shutdown (Unless Necessary) | While a process manager ensures a graceful shutdown, know that Erigon is safe against abrupt halts like process kills (`kill -9`) or a power outage. | Erigon's database is fully-transactional, meaning writes are atomic ("all-or-nothing"), preventing "partial writes" and database corruption from non-hardware failures. |
+| Tune Sync Speed with Flags | Use flags like `--sync.loop.block.limit` and `--batchSize` to tune the synchronization speed, especially during the initial sync. See [Configuring Erigon](https://docs.erigon.tech/fundamentals/configuring-erigon). | Allows you to optimize the sync process based on your system's hardware capabilities. |
+| Lock the Latest State in RAM (Advanced) | On systems with high historical RPC traffic, a tool like vmtouch can be used to lock the latest state files in RAM. See [Performance Tricks](https://docs.erigon.tech/fundamentals/performance-tricks). | Improves RPC response times for common queries by keeping the latest data in the fastest memory. |
 
 ## Security and Monitoring
 
-| **Practice**                | **Details**                                                                                                                                                            | **Rationale**                                                                                               |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| Configure Firewall Rules    | Configure your firewall to allow only the necessary ports for P2P and RPC communication. See [Default Ports](/fundamentals/default-ports).                             | Standard security practice to limit attack surface.                                                         |
-| Never Expose RPC Ports      | Never expose the RPC ports to the public internet without a reverse proxy. See [Security](/fundamentals/security).                                                     | RPC (Remote Procedure Call) ports grant access to node functions; public exposure is a major security risk. |
-| Monitor Your Node's Health  | Implement comprehensive monitoring using tools like Prometheus and Grafana to track key metrics like disk I/O, CPU load, and sync status in real time. See [Creating a Dashboard](/fundamentals/creating-a-dashboard). | Essential for proactively identifying performance bottlenecks and stability issues.        |
-| Enable JSON-RPC Compression | Use the `--http.compression` flag. See [Configuring Erigon](/fundamentals/configuring-erigon).                                                                         | Reduces network bandwidth usage for RPC requests.                                                           |
-| Tune RPC Batch Concurrency  | Adjust the `--rpc.batch.concurrency` flag. See [RPC & API flags](/fundamentals/configuring-erigon#rpc--api).                                                           | Limits the number of parallel database reads to prevent a single batch request from overloading the server. |
-| Harden Public RPC Endpoints | Place a reverse proxy (e.g. Nginx, Caddy) in front of Erigon. Enable rate-limiting, TLS termination, and authentication at the proxy layer. Never bind `--http.addr` to `0.0.0.0` directly on a public interface. See [TLS Authentication](/fundamentals/tls-authentication). | A direct public binding exposes the node to DoS attacks and unrestricted calls that can exhaust resources. |
+| **Practice** | **Details** | **Rationale** |
+| --- | --- | --- |
+| Configure Firewall Rules | Configure your firewall to allow only the necessary ports for P2P and RPC communication. See [Default Ports](https://docs.erigon.tech/fundamentals/default-ports). | Standard security practice to limit attack surface. |
+| Never Expose RPC Ports | Never expose the RPC ports to the public internet without a reverse proxy. See [Security](https://docs.erigon.tech/fundamentals/security). | RPC (Remote Procedure Call) ports grant access to node functions; public exposure is a major security risk. |
+| Monitor Your Node's Health | Implement comprehensive monitoring using tools like Prometheus and Grafana to track key metrics like disk I/O, CPU load, and sync status in real time. See [Creating a Dashboard](https://docs.erigon.tech/fundamentals/creating-a-dashboard). | Essential for proactively identifying performance bottlenecks and stability issues. |
+| Enable JSON-RPC Compression | Use the `--http.compression` flag. See [Configuring Erigon](https://docs.erigon.tech/fundamentals/configuring-erigon). | Reduces network bandwidth usage for RPC requests. |
+| Tune RPC Batch Concurrency | Adjust the `--rpc.batch.concurrency` flag. See [RPC & API flags](https://docs.erigon.tech/fundamentals/configuring-erigon#rpc--api). | Limits the number of parallel database reads to prevent a single batch request from overloading the server. |
+| Harden Public RPC Endpoints | Place a reverse proxy (e.g. Nginx, Caddy) in front of Erigon. Enable rate-limiting, TLS termination, and authentication at the proxy layer. Never bind `--http.addr` to `0.0.0.0` directly on a public interface. See [TLS Authentication](https://docs.erigon.tech/fundamentals/tls-authentication). | A direct public binding exposes the node to DoS attacks and unrestricted calls that can exhaust resources. |
 
 ## Maintenance and Development
 
-| **Practice**                   | **Details**                                                                                                         | **Rationale**                                                                                       |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| Keep Your Binary Updated       | Regularly update your binary. Erigon is in active development. See [Upgrading](/get-started/installation/upgrading). | New releases often contain critical bug fixes and performance improvements essential for stability. |
-| Use Official Docker Images     | If using Docker, rely on the official images provided by the Erigon team. See [Docker Compose](/fundamentals/docker-compose). | Best compatibility and stability for containerized deployment.                               |
-| Run a Test Sync on a Testnet   | Before running on Mainnet, consider performing a sync on a testnet (e.g., Sepolia). See [Supported Networks](/fundamentals/supported-networks). | Familiarizes you with the process and your system's performance characteristics.          |
-| Report Issues with Diagnostics | When a bug is encountered, provide a detailed report on GitHub with a stack trace and other diagnostic information. | Helps the development team quickly identify and fix issues.                                         |
+| **Practice** | **Details** | **Rationale** |
+| --- | --- | --- |
+| Keep Your Binary Updated | Regularly update your binary. Erigon is in active development. See [Upgrading](https://docs.erigon.tech/get-started/installation/upgrading). | New releases often contain critical bug fixes and performance improvements essential for stability. |
+| Use Official Docker Images | If using Docker, rely on the official images provided by the Erigon team. See [Docker Compose](https://docs.erigon.tech/fundamentals/docker-compose). | Best compatibility and stability for containerized deployment. |
+| Run a Test Sync on a Testnet | Before running on Mainnet, consider performing a sync on a testnet (e.g., Sepolia). See [Supported Networks](https://docs.erigon.tech/fundamentals/supported-networks). | Familiarizes you with the process and your system's performance characteristics. |
+| Report Issues with Diagnostics | When a bug is encountered, provide a detailed report on GitHub with a stack trace and other diagnostic information. | Helps the development team quickly identify and fix issues. |
 
 ## Validator-Specific Practices
 
-| **Practice**                      | **Details**                                                                                    | **Rationale**                                                           |
-| --------------------------------- | ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| Check Validator Health            | For validator nodes, a daily check of the node's logs and service status is essential. See [Caplin](/staking/caplin) and [External Consensus Client](/staking/external-consensus-client-as-validator). | Confirms that the node is signing attestations and performing its duty. |
-| Maintain a Sufficient ETH Balance | Validators must maintain an adequate ETH balance on their signer address.                      | Required to cover transaction fees for checkpoint submissions.          |
+| **Practice** | **Details** | **Rationale** |
+| --- | --- | --- |
+| Check Validator Health | For validator nodes, a daily check of the node's logs and service status is essential. See [Caplin](https://docs.erigon.tech/staking/caplin) and [External Consensus Client](https://docs.erigon.tech/staking/external-consensus-client-as-validator). | Confirms that the node is signing attestations and performing its duty. |
+| Maintain a Sufficient ETH Balance | Validators must maintain an adequate ETH balance on their signer address. | Required to cover transaction fees for checkpoint submissions. |
 
 ## Advanced Performance Tricks
 
-The following shell snippets can provide meaningful performance gains on the right hardware. See [Performance Tricks](/fundamentals/performance-tricks) for the full list.
+The following shell snippets can provide meaningful performance gains on the right hardware. See [Performance Tricks](https://docs.erigon.tech/fundamentals/performance-tricks) for the full list.
 
 **Speed up initial sync** — throttle block execution to leave I/O headroom for snapshot downloads:
 
@@ -8013,83 +8059,84 @@ export ERIGON_SNAPSHOT_MADV_RND=false
 # Common Errors and Solutions
 URL: https://docs.erigon.tech/help-center/common-errors-and-solutions
 
-
 This section details common error messages and provides clear, actionable steps to resolve them.
 
 ## Sync and Performance
 
 ### Stalling during snapshot sync (0 B/s download rate)
 
-* **Error Description:** The sync process appears to be stuck, showing a download rate of 0B/s, even with peers.
-* **Cause:** The [RPC daemon](/fundamentals/modules/rpc-daemon) or a connected consensus client may be "spamming" the Erigon node with requests, which interferes with the snapshot sync. This issue is still present in recent versions.
-* **Solution:** Temporarily disable the RPC by removing flags like `--http` and `--ws`, or stop your consensus client until the initial snapshot sync stage is complete.
+- **Error Description:** The sync process appears to be stuck, showing a download rate of 0B/s, even with peers.
+- **Cause:** The [RPC daemon](https://docs.erigon.tech/fundamentals/modules/rpc-daemon) or a connected consensus client may be "spamming" the Erigon node with requests, which interferes with the snapshot sync. This issue is still present in recent versions.
+- **Solution:** Temporarily disable the RPC by removing flags like `--http` and `--ws`, or stop your consensus client until the initial snapshot sync stage is complete.
 
 ### Sync is extremely slow or the node is constantly falling behind
 
-* **Error Description:** The node is not keeping up with the blockchain tip despite a fast internet connection.
-* **Cause:** This is almost always a disk-related problem. The read/write speed and latency of your storage device are the most significant performance bottlenecks for Erigon.
-* **Solution:** Upgrade your storage to a high-end NVMe SSD. Avoid using HDDs, network drives, or slow consumer-grade SSDs. See [Hardware Requirements](/get-started/hardware-requirements) and [Performance Tricks](/fundamentals/performance-tricks).
+- **Error Description:** The node is not keeping up with the blockchain tip despite a fast internet connection.
+- **Cause:** This is almost always a disk-related problem. The read/write speed and latency of your storage device are the most significant performance bottlenecks for Erigon.
+- **Solution:** Upgrade your storage to a high-end NVMe SSD. Avoid using HDDs, network drives, or slow consumer-grade SSDs. See [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements) and [Performance Tricks](https://docs.erigon.tech/fundamentals/performance-tricks).
 
 ### Node falls behind the tip after running for weeks
 
-* **Error Description:** A node that has been healthy for weeks gradually stops keeping up with the chain tip, sometimes after the mutable database has grown large.
-* **Cause:** Over time the mutable `chaindata` database can accumulate state that slows chain-tip processing.
-* **Solution:** Delete **only** the hot database — `datadir/chaindata` — and restart (do **not** delete the whole `datadir`, which would force a full re-sync). Erigon re-derives `chaindata` from the immutable snapshots (re-downloading them if needed) and resyncs the post-snapshot tip from the consensus layer — treat it as a chain-tip resync, not an instant rebuild, and keep a backup if fast recovery matters. Make sure you are on the latest release: Erigon 3.4+ ships a much smaller `chaindata` and an improved pruning algorithm that greatly reduces this problem. See [Optimizing Storage](/fundamentals/optimizing-storage).
+- **Error Description:** A node that has been healthy for weeks gradually stops keeping up with the chain tip, sometimes after the mutable database has grown large.
+- **Cause:** Over time the mutable `chaindata` database can accumulate state that slows chain-tip processing.
+- **Solution:** Delete **only** the hot database — `datadir/chaindata` — and restart (do **not** delete the whole `datadir`, which would force a full re-sync). Erigon re-derives `chaindata` from the immutable snapshots (re-downloading them if needed) and resyncs the post-snapshot tip from the consensus layer — treat it as a chain-tip resync, not an instant rebuild, and keep a backup if fast recovery matters. Make sure you are on the latest release: Erigon 3.4+ ships a much smaller `chaindata` and an improved pruning algorithm that greatly reduces this problem. See [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage).
 
 ### Node stuck in a "bad block" / "invalid block" forkchoice loop
 
-* **Error Description:** The node repeatedly logs `invalid block ... gas used by execution` and `bad block as forkchoice`, and stops advancing the chain head.
-* **Cause:** Corrupted state in the mutable database, typically left over from an incorrect unwind, prevents the node from validating new blocks.
-* **Solution:** Wipe `datadir/chaindata` (not the entire `datadir`) and restart on the latest patch release, which is the reliable recovery. If it recurs immediately, running with the `USE_STATE_CACHE=false` environment variable is a known temporary workaround. If you can still reproduce it on the latest release, open a GitHub issue with your full `<datadir>/logs/erigon.log` attached.
+- **Error Description:** The node repeatedly logs `invalid block ... gas used by execution` and `bad block as forkchoice`, and stops advancing the chain head.
+- **Cause:** Corrupted state in the mutable database, typically left over from an incorrect unwind, prevents the node from validating new blocks.
+- **Solution:** Wipe `datadir/chaindata` (not the entire `datadir`) and restart on the latest patch release, which is the reliable recovery. If it recurs immediately, running with the `USE_STATE_CACHE=false` environment variable is a known temporary workaround. If you can still reproduce it on the latest release, open a GitHub issue with your full `<datadir>/logs/erigon.log` attached.
 
 ## Memory and Resources
 
 ### Out of Memory (OOM) or unexpected process termination
 
-* **Error Description:** The Erigon process is abruptly terminated by the operating system, often with an OOM-kill event in the system logs (`code=killed, status=9/KILL`).
-* **Cause:** This can be a genuine memory leak or, more commonly, a symptom of a disk I/O bottleneck. When the disk can't keep up with processing, memory usage can balloon as the system tries to buffer data. Erigon and the Go runtime also size their memory and CPU use from the resources they can *see*, so on a shared or memory-constrained host they may reserve more than is safe.
-* **Solution:** Ensure your system meets the recommended RAM requirements in [Hardware Requirements](/get-started/hardware-requirements). To make Erigon more conservative on constrained hosts, set a hard memory ceiling and throttle the runtime:
+- **Error Description:** The Erigon process is abruptly terminated by the operating system, often with an OOM-kill event in the system logs (`code=killed, status=9/KILL`).
 
-  ```bash
-  # Export the runtime tunables, then pass --batchSize as an Erigon flag:
-  export GOMEMLIMIT=26GiB               # cap total Go heap (set below your physical/container limit)
-  export GOGC=80                        # collect garbage more aggressively
-  export GOMAXPROCS=$(( $(nproc) / 2 )) # show Erigon fewer cores → smaller RAM estimates
+- **Cause:** This can be a genuine memory leak or, more commonly, a symptom of a disk I/O bottleneck. When the disk can't keep up with processing, memory usage can balloon as the system tries to buffer data. Erigon and the Go runtime also size their memory and CPU use from the resources they can *see*, so on a shared or memory-constrained host they may reserve more than is safe.
 
-  erigon --batchSize=256m ...           # smaller execution batch buffer
-  ```
+- **Solution:** Ensure your system meets the recommended RAM requirements in [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements). To make Erigon more conservative on constrained hosts, set a hard memory ceiling and throttle the runtime:
 
-  A clean shutdown and restart can often resolve a transient event. If the problem persists, check your `dmesg` logs and consider upgrading your disk. See [Performance Tricks](/fundamentals/performance-tricks) for related tuning.
+```bash
+# Export the runtime tunables, then pass --batchSize as an Erigon flag:
+export GOMEMLIMIT=26GiB               # cap total Go heap (set below your physical/container limit)
+export GOGC=80                        # collect garbage more aggressively
+export GOMAXPROCS=$(( $(nproc) / 2 )) # show Erigon fewer cores → smaller RAM estimates
+
+erigon --batchSize=256m ...           # smaller execution batch buffer
+```
+
+A clean shutdown and restart can often resolve a transient event. If the problem persists, check your `dmesg` logs and consider upgrading your disk. See [Performance Tricks](https://docs.erigon.tech/fundamentals/performance-tricks) for related tuning.
 
 ## Database
 
 ### Database corruption after an unexpected shutdown
 
-* **Error Description:** The Erigon process fails to start or crashes immediately after a power outage or a forced kill.
-* **Cause:** Erigon's database can be corrupted if it is not shut down gracefully, which prevents the final writes from being committed.
-* **Solution:** The most reliable solution is to delete the corrupted datadir and re-sync from scratch. This is often faster than attempting to repair the database.
+- **Error Description:** The Erigon process fails to start or crashes immediately after a power outage or a forced kill.
+- **Cause:** Erigon's database can be corrupted if it is not shut down gracefully, which prevents the final writes from being committed.
+- **Solution:** The most reliable solution is to delete the corrupted datadir and re-sync from scratch. This is often faster than attempting to repair the database.
 
 ## Permissions and Access
 
 ### Permission denied or Access Denied errors on startup
 
-* **Error Description:** The process fails to access the datadir, logs, or other files.
-* **Cause:** The user or service account running Erigon does not have the correct file permissions for the data directory.
-* **Solution:** Use the `chown` and `chmod` commands to ensure the correct user account has ownership and full read/write access to the datadir. See [Security](/fundamentals/security) for service account best practices.
+- **Error Description:** The process fails to access the datadir, logs, or other files.
+- **Cause:** The user or service account running Erigon does not have the correct file permissions for the data directory.
+- **Solution:** Use the `chown` and `chmod` commands to ensure the correct user account has ownership and full read/write access to the datadir. See [Security](https://docs.erigon.tech/fundamentals/security) for service account best practices.
 
 ### Permission denied inside Docker (UID/GID mismatch)
 
-* **Error Description:** When running the official Docker image, Erigon fails to read or write files in the mounted datadir with a `permission denied` error.
-* **Cause:** The container runs the Erigon process as UID/GID `1000`. If the host directory is owned by a different user, the process cannot access it.
-* **Solution:** On the host, change ownership of the datadir to UID/GID 1000: `sudo chown -R 1000:1000 /your/datadir`. Alternatively, pass `--user $(id -u):$(id -g)` to `docker run` to run the container with your host user's identity. See [Docker Compose](/fundamentals/docker-compose).
+- **Error Description:** When running the official Docker image, Erigon fails to read or write files in the mounted datadir with a `permission denied` error.
+- **Cause:** The container runs the Erigon process as UID/GID `1000`. If the host directory is owned by a different user, the process cannot access it.
+- **Solution:** On the host, change ownership of the datadir to UID/GID 1000: `sudo chown -R 1000:1000 /your/datadir`. Alternatively, pass `--user $(id -u):$(id -g)` to `docker run` to run the container with your host user's identity. See [Docker Compose](https://docs.erigon.tech/fundamentals/docker-compose).
 
 ## Network and Configuration
 
 ### Connect: connection refused or dial tcp... failures
 
-* **Error Description:** The node cannot connect to an external service, such as a local or remote consensus-layer endpoint.
-* **Cause:** This is a configuration error. The dependent service is either not running, or the command-line flag is pointing to an incorrect address.
-* **Solution:** Confirm that the required services are running and that the command-line flags (e.g., `--externalcl`) are correctly set. See [Configuring Erigon](/fundamentals/configuring-erigon) for all available flags.
+- **Error Description:** The node cannot connect to an external service, such as a local or remote consensus-layer endpoint.
+- **Cause:** This is a configuration error. The dependent service is either not running, or the command-line flag is pointing to an incorrect address.
+- **Solution:** Confirm that the required services are running and that the command-line flags (e.g., `--externalcl`) are correctly set. See [Configuring Erigon](https://docs.erigon.tech/fundamentals/configuring-erigon) for all available flags.
 
 ## Chain-Specific Issues
 
@@ -8097,44 +8144,43 @@ This section details common error messages and provides clear, actionable steps 
 
 ### `libsilkworm_capi.so`: missing shared library
 
-* **Error Description:** Erigon fails to start with a dynamic linker error about a missing `libsilkworm_capi.so` shared library.
-* **Cause:** The binary was built with Silkworm support but the shared library is not present in the system's library path or alongside the binary.
-* **Solution:** Ensure the `libsilkworm_capi.so` file is located in the same directory as the `erigon` binary, or add its location to `LD_LIBRARY_PATH`. If you built from source, run `make erigon` again to confirm the library was compiled and placed correctly. See [Installation](/get-started/installation) for build-from-source instructions. Official Docker images bundle the library automatically.
+- **Error Description:** Erigon fails to start with a dynamic linker error about a missing `libsilkworm_capi.so` shared library.
+- **Cause:** The binary was built with Silkworm support but the shared library is not present in the system's library path or alongside the binary.
+- **Solution:** Ensure the `libsilkworm_capi.so` file is located in the same directory as the `erigon` binary, or add its location to `LD_LIBRARY_PATH`. If you built from source, run `make erigon` again to confirm the library was compiled and placed correctly. See [Installation](https://docs.erigon.tech/get-started/installation) for build-from-source instructions. Official Docker images bundle the library automatically.
 
 ---
 
 # Glossary of Key Terms
 URL: https://docs.erigon.tech/help-center/glossary-of-key-terms
 
-
 This glossary provides concise definitions for essential terms related to the Erigon client. Understanding this terminology is crucial for troubleshooting, configuration, and general operation.
 
-* **Account:** A unique entity on the Ethereum blockchain that can hold an ETH balance and send transactions. There are two types: externally owned accounts (EOAs) and contract accounts.
-* **Archive Node:** A node that stores the complete history of the blockchain. This includes all historical states and past transactions, allowing for deep queries into any moment in the blockchain's history. Erigon is particularly known for its highly optimized archive node. See [Pruning Modes](/fundamentals/pruning-modes).
-* **Attestation:** A validator's vote on the validity of a block or chain. A high attestation effectiveness is critical for a healthy validator and node. See [Caplin](/staking/caplin).
-* **Block:** A collection of transactions, data, and a header that is cryptographically linked to the previous block.
-* **Consensus Client (CL):** Software that runs the Proof-of-Stake (PoS) consensus protocol. It is responsible for a node's peer discovery, block propagation, and attesting to blocks. Examples include Lighthouse, Nimbus, and Prysm. Erigon includes its own built-in CL called [Caplin](/staking/caplin).
-* **datadir:** The directory where an Erigon node stores all of its blockchain data, including the database, snapshots, and temporary files. See [Optimizing Storage](/fundamentals/optimizing-storage) for tips on managing this directory.
-* **Engine API:** The communication protocol that allows the **Execution Client** (Erigon) and the **Consensus Client** to communicate and exchange data, such as new blocks and validator attestations. See the [Engine API](/interacting-with-erigon/engine) reference.
-* **Erigon:** An Ethereum **Execution Client** built for efficiency. It is designed to be highly scalable and fast, with a focus on minimizing disk space and improving synchronization speed. See [Why Erigon](/get-started/why-using-erigon).
-* **Execution Client (EL):** Software that executes and validates all transactions, and propagates new blocks across the network. It maintains a full record of the blockchain state. Erigon is an execution client.
-* **Full Node:** A node that holds a complete copy of all block data, from the genesis block to the current head. It retains recent state, all blocks post-Merge, and prunes ancient blocks and state (EIP-4444 enabled). It verifies every block and state transition. See [Pruning Modes](/fundamentals/pruning-modes).
-* **Go (Golang)**: The open-source programming language used to develop Erigon, known for its performance, concurrency, and efficiency.
-* **Gnosis Chain:** A stable, community-owned EVM-compatible chain that uses a PoS consensus mechanism. Erigon has specific optimizations and troubleshooting steps for Gnosis Chain due to its large transaction history. See the [Gnosis Chain Node](/get-started/easy-nodes/how-to-run-a-gnosis-chain-node) guide.
-* **JSON RPC**: JSON Remote Procedure Call. A lightweight protocol used by Ethereum clients to communicate with applications (like wallets or block explorers) over HTTP or WebSockets. See [Interacting with Erigon](/interacting-with-erigon) for the full API reference.
-* **head:** The most recent block in the blockchain.
-* **Minimal Node**: A node that retains the minimum amount of data necessary to function, typically by heavily pruning historical state data to significantly save disk space. See [Pruning Modes](/fundamentals/pruning-modes).
-* **MDBX:** The high-performance, key-value database that Erigon uses to store blockchain data. It is a more efficient and scalable alternative to the databases used by other clients.
-* **Merkle Patricia Trie:** A data structure used by most Ethereum clients (like Geth) to store the blockchain state. It is highly secure but can be less space-efficient than MDBX.
-* **Mempool:** A pool of unconfirmed transactions that have been submitted to the network but have not yet been included in a block.
-* **MCP Server:** The Model Context Protocol server built into Erigon that exposes blockchain data to AI assistants. See [MCP Server](/fundamentals/mcp) (v3.4+).
-* **Node:** A piece of software that runs on a computer and interacts with the blockchain network. It can be a full node, light node, or validator node.
-* **OOM-kill:** An event where the operating system's "Out of Memory" killer terminates a process (e.g., Erigon) that is consuming too much memory. See [Hardware Requirements](/get-started/hardware-requirements) for recommended RAM specs.
-* **Peer:** Another node on the network that your client is connected to. The more healthy peers you have, the more reliable your connection is. See [Default Ports](/fundamentals/default-ports) for P2P port configuration.
-* **Pruning:** The process of removing older, unnecessary data from the blockchain to save disk space. Erigon offers different pruning modes (full, minimal, archive) to suit various needs. See [Pruning Modes](/fundamentals/pruning-modes).
-* **rpcdaemon:** A separate, lightweight process in Erigon that handles JSON RPC API requests. This design allows Erigon to continue syncing efficiently even under heavy RPC load. See [RPC Daemon](/fundamentals/modules/rpc-daemon).
-* **Snapshot Sync:** A rapid synchronization method that downloads a pre-made snapshot of the blockchain state and then syncs the remaining blocks. This is much faster than syncing from the genesis block. See [Pruning Modes](/fundamentals/pruning-modes).
-* **Staged Sync:** Erigon's unique synchronization model. It processes the blockchain in a series of logical stages, such as downloading headers, verifying bodies, and building the state, to maximize speed and efficiency. See [Pruning Modes](/fundamentals/pruning-modes).
-* **Validator:** A participant in a Proof-of-Stake network who has staked the network token and is responsible for proposing and attesting to new blocks. See [Caplin](/staking/caplin) and [External Consensus Client](/staking/external-consensus-client-as-validator).
+- **Account:** A unique entity on the Ethereum blockchain that can hold an ETH balance and send transactions. There are two types: externally owned accounts (EOAs) and contract accounts.
+- **Archive Node:** A node that stores the complete history of the blockchain. This includes all historical states and past transactions, allowing for deep queries into any moment in the blockchain's history. Erigon is particularly known for its highly optimized archive node. See [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes).
+- **Attestation:** A validator's vote on the validity of a block or chain. A high attestation effectiveness is critical for a healthy validator and node. See [Caplin](https://docs.erigon.tech/staking/caplin).
+- **Block:** A collection of transactions, data, and a header that is cryptographically linked to the previous block.
+- **Consensus Client (CL):** Software that runs the Proof-of-Stake (PoS) consensus protocol. It is responsible for a node's peer discovery, block propagation, and attesting to blocks. Examples include Lighthouse, Nimbus, and Prysm. Erigon includes its own built-in CL called [Caplin](https://docs.erigon.tech/staking/caplin).
+- **datadir:** The directory where an Erigon node stores all of its blockchain data, including the database, snapshots, and temporary files. See [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage) for tips on managing this directory.
+- **Engine API:** The communication protocol that allows the **Execution Client** (Erigon) and the **Consensus Client** to communicate and exchange data, such as new blocks and validator attestations. See the [Engine API](https://docs.erigon.tech/interacting-with-erigon/engine) reference.
+- **Erigon:** An Ethereum **Execution Client** built for efficiency. It is designed to be highly scalable and fast, with a focus on minimizing disk space and improving synchronization speed. See [Why Erigon](https://docs.erigon.tech/get-started/why-using-erigon).
+- **Execution Client (EL):** Software that executes and validates all transactions, and propagates new blocks across the network. It maintains a full record of the blockchain state. Erigon is an execution client.
+- **Full Node:** A node that holds a complete copy of all block data, from the genesis block to the current head. It retains recent state, all blocks post-Merge, and prunes ancient blocks and state (EIP-4444 enabled). It verifies every block and state transition. See [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes).
+- **Go (Golang)**: The open-source programming language used to develop Erigon, known for its performance, concurrency, and efficiency.
+- **Gnosis Chain:** A stable, community-owned EVM-compatible chain that uses a PoS consensus mechanism. Erigon has specific optimizations and troubleshooting steps for Gnosis Chain due to its large transaction history. See the [Gnosis Chain Node](https://docs.erigon.tech/get-started/easy-nodes/how-to-run-a-gnosis-chain-node) guide.
+- **JSON RPC**: JSON Remote Procedure Call. A lightweight protocol used by Ethereum clients to communicate with applications (like wallets or block explorers) over HTTP or WebSockets. See [Interacting with Erigon](https://docs.erigon.tech/interacting-with-erigon) for the full API reference.
+- **head:** The most recent block in the blockchain.
+- **Minimal Node**: A node that retains the minimum amount of data necessary to function, typically by heavily pruning historical state data to significantly save disk space. See [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes).
+- **MDBX:** The high-performance, key-value database that Erigon uses to store blockchain data. It is a more efficient and scalable alternative to the databases used by other clients.
+- **Merkle Patricia Trie:** A data structure used by most Ethereum clients (like Geth) to store the blockchain state. It is highly secure but can be less space-efficient than MDBX.
+- **Mempool:** A pool of unconfirmed transactions that have been submitted to the network but have not yet been included in a block.
+- **MCP Server:** The Model Context Protocol server built into Erigon that exposes blockchain data to AI assistants. See [MCP Server](https://docs.erigon.tech/fundamentals/mcp) (v3.4+).
+- **Node:** A piece of software that runs on a computer and interacts with the blockchain network. It can be a full node, light node, or validator node.
+- **OOM-kill:** An event where the operating system's "Out of Memory" killer terminates a process (e.g., Erigon) that is consuming too much memory. See [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements) for recommended RAM specs.
+- **Peer:** Another node on the network that your client is connected to. The more healthy peers you have, the more reliable your connection is. See [Default Ports](https://docs.erigon.tech/fundamentals/default-ports) for P2P port configuration.
+- **Pruning:** The process of removing older, unnecessary data from the blockchain to save disk space. Erigon offers different pruning modes (full, minimal, archive) to suit various needs. See [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes).
+- **rpcdaemon:** A separate, lightweight process in Erigon that handles JSON RPC API requests. This design allows Erigon to continue syncing efficiently even under heavy RPC load. See [RPC Daemon](https://docs.erigon.tech/fundamentals/modules/rpc-daemon).
+- **Snapshot Sync:** A rapid synchronization method that downloads a pre-made snapshot of the blockchain state and then syncs the remaining blocks. This is much faster than syncing from the genesis block. See [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes).
+- **Staged Sync:** Erigon's unique synchronization model. It processes the blockchain in a series of logical stages, such as downloading headers, verifying bodies, and building the state, to maximize speed and efficiency. See [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes).
+- **Validator:** A participant in a Proof-of-Stake network who has staked the network token and is responsible for proposing and attesting to new blocks. See [Caplin](https://docs.erigon.tech/staking/caplin) and [External Consensus Client](https://docs.erigon.tech/staking/external-consensus-client-as-validator).
 
 ---

--- a/docs/site/static/llms.txt
+++ b/docs/site/static/llms.txt
@@ -4,7 +4,7 @@
 > modularity, and minimal disk footprint. It features an integrated consensus layer
 > (Caplin), BitTorrent-based historical data distribution, and fast node synchronization.
 
-The text of every page listed below is also available as a single file: [llms-full.txt](https://docs.erigon.tech/llms-full.txt). Pages are cleaned for machine reading: MDX components are stripped, and a card-grid landing page is reduced to the list of links its grids contain.
+The text of every page listed below is also available as a single file: [llms-full.txt](https://docs.erigon.tech/llms-full.txt). Pages are cleaned for machine reading: text comes from the built site, so components are expanded and links resolved, and a card-grid landing page keeps its prose with each grid rendered as a link list.
 
 - [Introduction](https://docs.erigon.tech/): Official documentation for Erigon — the efficient, modular Ethereum execution client. Get started, explore the JSON-RPC API, and learn how to run a full or archive node.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3,8 +3,6 @@ URL: https://docs.erigon.tech/
 
 An efficient, modular Ethereum execution layer client built for performance, low disk footprint, and flexible deployment.
 
-## Sections
-
 - [Get Started](https://docs.erigon.tech/get-started): Hardware requirements, installation options, and first-run guides to get your node online fast.
 - [Easy Nodes](https://docs.erigon.tech/get-started/easy-nodes): One-command guided setup for Ethereum mainnet and Gnosis Chain nodes with sensible defaults.
 - [Fundamentals](https://docs.erigon.tech/fundamentals): Pruning modes, configuration, Docker, JWT, logging, storage optimization, and day-to-day operations.
@@ -20,8 +18,6 @@ URL: https://docs.erigon.tech/get-started
 
 Everything you need to go from zero to a running Erigon node — requirements, installation, and guided setups.
 
-## Sections
-
 - [Why Erigon?](https://docs.erigon.tech/get-started/why-using-erigon): Performance benchmarks, disk savings, and architecture advantages over other Ethereum clients.
 - [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements): Minimum and recommended specs for mainnet, testnets, and archive mode.
 - [Installation](https://docs.erigon.tech/get-started/installation): Binary releases, building from source, Docker images, and upgrade instructions.
@@ -34,22 +30,70 @@ Everything you need to go from zero to a running Erigon node — requirements, i
 # Why using Erigon?
 URL: https://docs.erigon.tech/get-started/why-using-erigon
 
-## Sections
+Erigon is an Ethereum execution layer client focused on performance, low disk usage, and modular architecture.
 
-- [Integrated Consensus Layer (Caplin)](../fundamentals/caplin): Built-in consensus client — no need to run and manage separate software like Lighthouse. One binary handles both execution and consensus, simplifying setup for stakers and node runners.
-- [State Storage (Flat DB)](../fundamentals/optimizing-storage): Replaces the Merkle Patricia Trie with a flat key-value database. Faster reads and writes, and a smaller on-disk footprint for any node type.
-- [Immutable, Decentralised Data](../fundamentals/modules/downloader): Splits data processing into specialised stages, minimising random disk I/O and write amplification. Efficiently integrates large datasets into Erigon's flat DB.
-- [Predictable RPC Performance](../fundamentals/modules/rpc-daemon): No background compaction means no unpredictable resource spikes. RPC throughput stays stable and consistent — critical for providers and validators who cannot afford surprises.
-- [Modularity](../fundamentals/modules/): Core node, RPC Daemon, and TxPool run as independent processes with per-component resource limits. If one crashes the rest stay alive. Run multiple instances without downtime.
-- [OtterSync](../fundamentals/pruning-modes): Shifts initial sync from CPU-intensive transaction re-execution to network download — similar to BitTorrent for state data. Reduces sync time for both full and Archive nodes.
-- [Flexible Pruning](../fundamentals/optimizing-storage): Modular architecture and predictable performance handle high-volume traffic with low latency. Smaller database cuts hardware costs. Caplin reduces missed attestations and slashing risk.
-- [Home Users & Solo Stakers](../staking/): Run a full or archive node on a consumer SSD. Fast sync cuts setup from days to hours. No third-party servers — your node, your keys, your contribution to decentralisation.
+A core benefit of Erigon is its **reduced disk footprint** across all available pruning modes — achieved through efficient state storage and compression, making node operation feasible on consumer-grade hardware. It also features an **integrated Consensus Layer (Caplin)**, eliminating the need for separate CL software, and a **BitTorrent-based protocol** for decentralised historical data distribution.
+
+10×
+
+cheaper to backup & distribute node data
+
+~2 TB
+
+archive node on consumer SSD
+
+1 binary
+
+execution + consensus, no extra software
+
+40+
+
+AI query tools via built-in MCP server
+
+## Key Architectural & Performance Advantages
+
+Erigon's architecture provides measurable improvements in cost, performance, and reliability.
+
+- [Integrated Consensus Layer (Caplin)](https://docs.erigon.tech/fundamentals/caplin): Built-in consensus client — no need to run and manage separate software like Lighthouse. One binary handles both execution and consensus, simplifying setup for stakers and node runners.
+- [State Storage (Flat DB)](https://docs.erigon.tech/fundamentals/optimizing-storage): Replaces the Merkle Patricia Trie with a flat key-value database. Faster reads and writes, and a smaller on-disk footprint for any node type.
+- [Immutable, Decentralised Data](https://docs.erigon.tech/fundamentals/modules/downloader): Historical data lives in immutable files distributed via BitTorrent — up to **10× cheaper** to backup, repair, and distribute. No double-disk usage, no complex serialisation.
+- [Staged Sync](https://docs.erigon.tech/fundamentals/pruning-modes): Splits data processing into specialised stages, minimising random disk I/O and write amplification. Efficiently integrates large datasets into Erigon's flat DB.
+- [Predictable RPC Performance](https://docs.erigon.tech/fundamentals/modules/rpc-daemon): No background compaction means no unpredictable resource spikes. RPC throughput stays stable and consistent — critical for providers and validators who cannot afford surprises.
+- [Modularity](https://docs.erigon.tech/fundamentals/modules): Core node, RPC Daemon, and TxPool run as independent processes with per-component resource limits. If one crashes the rest stay alive. Run multiple instances without downtime.
+- [OtterSync](https://docs.erigon.tech/fundamentals/pruning-modes): Shifts initial sync from CPU-intensive transaction re-execution to network download — similar to BitTorrent for state data. Reduces sync time for both full and Archive nodes.
+- [Flexible Pruning](https://docs.erigon.tech/fundamentals/optimizing-storage): `--prune.mode=minimal` gives a smaller-than-full-node footprint that still satisfies all validator requirements. Right-size your storage without sacrificing functionality.
+
+## Benefits by Audience
+
+- [RPC Providers & Large Stakers](https://docs.erigon.tech/fundamentals/modules/rpc-daemon): Modular architecture and predictable performance handle high-volume traffic with low latency. Smaller database cuts hardware costs. Caplin reduces missed attestations and slashing risk.
+- [Home Users & Solo Stakers](https://docs.erigon.tech/staking): Run a full or archive node on a consumer SSD. Fast sync cuts setup from days to hours. No third-party servers — your node, your keys, your contribution to decentralisation.
+- [Developers](https://docs.erigon.tech/interacting-with-erigon): Full `trace_` namespace, historical `eth_getProof`, historical blobs, and gRPC API. Modular components let you update, extend, or replace parts without rebuilding the whole stack.
+
+## AI-Native Node Access (MCP)
+
+Erigon ships a built-in **[Model Context Protocol (MCP) server](https://docs.erigon.tech/fundamentals/mcp)**, enabled by default on `127.0.0.1:8553`. Connect any MCP-compatible AI assistant — Claude Code, Claude Desktop, or OpenAI Codex — directly to your node and query it in plain English, with zero integration overhead.
+
+💬 What is the ETH balance of vitalik.eth right now?
+
+💬 Show all ERC-20 transfers in the last 100 blocks.
+
+💬 Which tx in block 21,000,000 used the most gas?
+
+💬 My node seems stuck — check sync status and recent logs.
+
+The interface is **read-only** and localhost-bound — no risk of unintended state changes. For developers this means instant on-chain lookups during development, natural-language log triage, and a complete RPC surface accessible without writing a single line of code.
+
+```bash
+# Register with Claude Code in one command
+claude mcp add --transport sse erigon http://127.0.0.1:8553/sse
+```
+
+Where MCP lets a model query your *node*, [llms.txt and llms-full.txt](https://docs.erigon.tech/fundamentals/mcp#these-docs-as-a-single-file) let it read these *docs*: an index of the current documentation, and the same pages' text as one plain-text file for offline use.
 
 ---
 
 # Hardware Requirements
 URL: https://docs.erigon.tech/get-started/hardware-requirements
-
 
 ## Overview
 
@@ -65,7 +109,9 @@ A locally mounted **SSD** (Solid-State Drive) or **NVMe** (Non-Volatile Memory E
 
 ## Disk Size and RAM Requirements
 
-The amount of disk space recommended and RAM you need depends on the [pruning mode](../fundamentals/pruning-modes) you want to run. **Current Disk Usage** values listed below are obtained using the standard Erigon + [Caplin](../fundamentals/caplin) configuration, with the sole exception of the `--prune.mode` flag.
+The amount of disk space recommended and RAM you need depends on the [pruning mode](https://docs.erigon.tech/fundamentals/pruning-modes) you want to run. **Current Disk Usage** values listed below are obtained using the standard Erigon + [Caplin](https://docs.erigon.tech/fundamentals/caplin) configuration, with the sole exception of the `--prune.mode` flag.
+
+**Ethereum mainnet**
 
 | Pruning Mode | Current Disk Usage | Disk Size (Recommended) | RAM (Required) | RAM (Recommended) |
 | --- | --- | --- | --- | --- |
@@ -73,253 +119,225 @@ The amount of disk space recommended and RAM you need depends on the [pruning mo
 | Full (Default) | 419.04 GB | 2 TB | 16 GB | 32 GB |
 | Minimal | 478.40 GB | 1 TB | 16 GB | 64 GB |
 
-_Current Disk Usage measured as of 2026-07-19; usage grows over time as the chain grows._
+*Current Disk Usage measured as of 2026-07-19; usage grows over time as the chain grows.*
 
-| **Pruning Mode**  | **Current Disk Usage** | **Disk Size (Recommended)** | **RAM (Required)** | **RAM (Recommended)** |
-| -------------- | ---------------------- | --------------------------- | ------------------ | --------------------- |
-| Archive        | 673.59 GB | 1 TB                        | 16 GB              | 32 GB                 |
-| Full (Default) | 220.10 GB    | 1 TB                        | 8 GB               | 16 GB                 |
-| Minimal        | 304.67 GB | 500 GB                      | 8 GB               | 16 GB                 |
+**Gnosis Chain**
 
-_Current Disk Usage measured as of 2026-07-21; usage grows over time as the chain grows._
+| **Pruning Mode** | **Current Disk Usage** | **Disk Size (Recommended)** | **RAM (Required)** | **RAM (Recommended)** |
+| --- | --- | --- | --- | --- |
+| Archive | 673.59 GB | 1 TB | 16 GB | 32 GB |
+| Full (Default) | 220.10 GB | 1 TB | 8 GB | 16 GB |
+| Minimal | 304.67 GB | 500 GB | 8 GB | 16 GB |
 
-| **Pruning Mode** | **Current Disk Usage** |
-| -------------- | ---------------------- |
-| Archive        | 1.10 TB |
+*Current Disk Usage measured as of 2026-07-21; usage grows over time as the chain grows.*
 
-_Current Disk Usage measured as of 2026-07-29; usage grows over time as the chain grows. Execution layer only — full and minimal modes are not measured for this network._
+**Sepolia**
 
 | **Pruning Mode** | **Current Disk Usage** |
-| -------------- | ---------------------- |
-| Archive        | 133.73 GB |
+| --- | --- |
+| Archive | 1.10 TB |
 
-_Current Disk Usage measured as of 2026-07-29; usage grows over time as the chain grows. Execution layer only — full and minimal modes are not measured for this network._
+*Current Disk Usage measured as of 2026-07-29; usage grows over time as the chain grows. Execution layer only — full and minimal modes are not measured for this network.*
+
+**Hoodi**
 
 | **Pruning Mode** | **Current Disk Usage** |
-| -------------- | ---------------------- |
-| Archive        | 29.64 GB |
+| --- | --- |
+| Archive | 133.73 GB |
 
-_Current Disk Usage measured as of 2026-07-29; usage grows over time as the chain grows. Execution layer only — full and minimal modes are not measured for this network._
+*Current Disk Usage measured as of 2026-07-29; usage grows over time as the chain grows. Execution layer only — full and minimal modes are not measured for this network.*
+
+**Chiado**
+
+| **Pruning Mode** | **Current Disk Usage** |
+| --- | --- |
+| Archive | 29.64 GB |
+
+*Current Disk Usage measured as of 2026-07-29; usage grows over time as the chain grows. Execution layer only — full and minimal modes are not measured for this network.*
 
 :::tip
-See also how you can [optimize storage](../fundamentals/optimizing-storage).
+See also how you can [optimize storage](https://docs.erigon.tech/fundamentals/optimizing-storage).
 :::
 
 ## Bandwidth Requirements
 
 Your internet bandwidth is also an important factor, particularly for sync speed and validator performance.
 
-| Node Type      | Bandwidth (Required) | Bandwidth (Recommended) |
-| -------------- | -------------------- | ----------------------- |
-| Staking/Mining | 10 Mbps              | 50 Mbps                 |
-| Non-Staking    | 5 Mbps               | 25 Mbps                 |
+| Node Type | Bandwidth (Required) | Bandwidth (Recommended) |
+| --- | --- | --- |
+| Staking/Mining | 10 Mbps | 50 Mbps |
+| Non-Staking | 5 Mbps | 25 Mbps |
 
 ---
 
 # Migrating from Geth
 URL: https://docs.erigon.tech/get-started/migrating-from-geth
 
-
 ### Migration Paths: Choosing Your Erigon Setup
 
 When moving from another Execution Layer (EL) such as Geth, Nethermind, Reth or Besu to Erigon, node runners have a primary choice regarding their Consensus Layer (CL) setup:
 
-* **Erigon with Caplin**: The integrated setup using Erigon's embedded CL client, [Caplin](../fundamentals/caplin). Suitable for all node types — simplifies operation by removing the need for a separate consensus client.
-* **Erigon with an External Consensus Client**: This is the traditional setup, allowing to reuse an existing external CL client (like Prysm or Lighthouse).
+- **Erigon with Caplin**: The integrated setup using Erigon's embedded CL client, [Caplin](https://docs.erigon.tech/fundamentals/caplin). Suitable for all node types — simplifies operation by removing the need for a separate consensus client.
+- **Erigon with an External Consensus Client**: This is the traditional setup, allowing to reuse an existing external CL client (like Prysm or Lighthouse).
 
 The recommended approach involves running and syncing an **Erigon node alongside your existing Execution Layer (EL) client (like Geth)**. This allows for full functional verification, thorough testing, and a transition with **zero downtime**. Since Erigon requires **less disk space** than most clients, running both in parallel is practical for the duration of the migration.
 
 #### Choosing Your Migration Strategy
 
-* [Option 1](#option-1-sync-erigon-alongside-geth-and-its-cl): If you run a critical process and have enough disk space, syncing Erigon alongside Geth or any other EL is the recommended choice, and is essential for validators and RPC providers.
-  * If disk space is limited and downtime is not an option, consider syncing Erigon on a separate machine.
-* [Option 2](#option-2-remove-old-el-and-sync-erigon-downtime-accepted): If you are a home user or standard node runner (not running a validator), and the disk space is limited and downtime is acceptable, choose this option to remove your EL and the existing CL first.
+- [Option 1](https://docs.erigon.tech/get-started/migrating-from-geth#option-1-sync-erigon-alongside-geth-and-its-cl): If you run a critical process and have enough disk space, syncing Erigon alongside Geth or any other EL is the recommended choice, and is essential for validators and RPC providers.
+  - If disk space is limited and downtime is not an option, consider syncing Erigon on a separate machine.
 
-| **Node Runner Type**                                            | **Recommended Path (If Disk Space Allows)**                                                                                        | **Rationale**                                        |
-| --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| Validators                                                      | [Option 1](#option-1-sync-erigon-alongside-geth-and-its-cl): Sync Alongside Geth or any EL                   | Ensures minimal downtime and prevents slashing risk. |
-| Public RPC Providers                                            | [Option 1](#option-1-sync-erigon-alongside-geth-and-its-cl): Sync Alongside Geth or any EL                   | Guarantees zero service interruption for users.      |
-| Home Users / Standard Node Runners with no critical utilization | [Option 2](#option-2-remove-old-el-and-sync-erigon-downtime-accepted): Remove Geth or any EL and Sync Erigon | The fastest method if downtime is accepted.          |
+- [Option 2](https://docs.erigon.tech/get-started/migrating-from-geth#option-2-remove-old-el-and-sync-erigon-downtime-accepted): If you are a home user or standard node runner (not running a validator), and the disk space is limited and downtime is acceptable, choose this option to remove your EL and the existing CL first.
+
+| **Node Runner Type** | **Recommended Path (If Disk Space Allows)** | **Rationale** |
+| --- | --- | --- |
+| Validators | [Option 1](https://docs.erigon.tech/get-started/migrating-from-geth#option-1-sync-erigon-alongside-geth-and-its-cl): Sync Alongside Geth or any EL | Ensures minimal downtime and prevents slashing risk. |
+| Public RPC Providers | [Option 1](https://docs.erigon.tech/get-started/migrating-from-geth#option-1-sync-erigon-alongside-geth-and-its-cl): Sync Alongside Geth or any EL | Guarantees zero service interruption for users. |
+| Home Users / Standard Node Runners with no critical utilization | [Option 2](https://docs.erigon.tech/get-started/migrating-from-geth#option-2-remove-old-el-and-sync-erigon-downtime-accepted): Remove Geth or any EL and Sync Erigon | The fastest method if downtime is accepted. |
 
 ### Option 1: Sync Erigon Alongside Geth and its CL
 
 You can choose whether to migrate to Erigon + Caplin (the simplest setup) or continue using your existing CL.
 
+**Migrate to Erigon + Caplin (Internal CL)**
+
 This path offers the simplest validator configuration by using Erigon's embedded consensus client, Caplin. You will no longer need your external Consensus Layer (CL) client or a JWT secret for CL-EL communication.
 
 **Steps for Minimal Downtime**
 
-1. **Preparation**: [Install](installation/) Erigon.
-2. **Configuration Check** (No Conflict): Ensure Erigon's standard [ports](../fundamentals/default-ports) (JSON-RPC, P2P) are different from Geth's. The P2P listening port is configured via the `--port` command-line option. For example:
+1. **Preparation**: [Install](https://docs.erigon.tech/get-started/installation) Erigon.
 
-    ```sh
-    erigon \
-      --datadir=/data/erigon \
-      --chain=mainnet \
-      --port=30304
-    ```
-3. **Synchronization**: Start syncing Erigon. Monitor the sync status using the `eth_syncing` JSON-[RPC method](../interacting-with-erigon/) or a health check.
+2. **Configuration Check** (No Conflict): Ensure Erigon's standard [ports](https://docs.erigon.tech/fundamentals/default-ports) (JSON-RPC, P2P) are different from Geth's. The P2P listening port is configured via the `--port` command-line option. For example:
+
+```sh
+erigon \
+  --datadir=/data/erigon \
+  --chain=mainnet \
+  --port=30304
+```
+
+3. **Synchronization**: Start syncing Erigon. Monitor the sync status using the `eth_syncing` JSON-[RPC method](https://docs.erigon.tech/interacting-with-erigon) or a health check.
+
 4. **Validator Swap**: Once Erigon is fully synced, shut down Geth and the external CL client.
+
 5. **Reconfiguration and Restart**:
-   * To restart Erigon, there's no need to specify `--port`. Refer to this [guide](../fundamentals/caplin) for additional Erigon + Caplin configuration recommendations.
-   * Crucially, reconfigure your **validator keys manager** to point directly to the Erigon Beacon API, as Erigon/Caplin now handles both layers internally.
+
+  - To restart Erigon, there's no need to specify `--port`. Refer to this [guide](https://docs.erigon.tech/fundamentals/caplin) for additional Erigon + Caplin configuration recommendations.
+  - Crucially, reconfigure your **validator keys manager** to point directly to the Erigon Beacon API, as Erigon/Caplin now handles both layers internally.
+
 6. **Decommission Old Setup**: Verify Erigon/Caplin is proposing and attesting blocks correctly. If confirmed, safely remove Geth, the external CL client, and all their data, including the old JWT secret.
+
+**Migrate to Erigon + External CL**
 
 Switch to an Erigon Execution Layer (EL) while keeping your current external Consensus Layer (CL) client (e.g., Prysm, Lighthouse) and your existing JWT secret. Start by syncing Erigon with Caplin as the CL, then configure it to use the external CL.
 
 **Steps for Minimal Downtime**
 
-1. **Preparation**: [Install](installation/) Erigon.
-2. **Configuration Check**: run Erigon + Caplin simultaneously with Geth (or any other EL) for fast, parallel syncing and assign a unique port for its P2P networking via `--port` (check which ports your present
-   EL is using). For example:
+1. **Preparation**: [Install](https://docs.erigon.tech/get-started/installation) Erigon.
 
-    ```sh
-    erigon \
-      --datadir=/data/erigon \
-      --chain=mainnet \
-      --port=30304
-    ```
+2. **Configuration Check**: run Erigon + Caplin simultaneously with Geth (or any other EL) for fast, parallel syncing and assign a unique port for its P2P networking via `--port` (check which ports your present EL is using). For example:
+
+```sh
+erigon \
+  --datadir=/data/erigon \
+  --chain=mainnet \
+  --port=30304
+```
+
 3. **Synchronization**: Monitor the sync status using the `eth_syncing` JSON-RPC method or a health check.
+
 4. **Validator Swap**: Once Erigon is fully synced, **shut down** both Geth and Erigon. **Keep the external CL client running.**
-5. **Reconfiguration and Restart**: Restart Erigon, ensuring it uses the **original Engine API port and JWT secret** that your old EL client used. See [here](../staking/external-consensus-client-as-validator) for details.
+
+5. **Reconfiguration and Restart**: Restart Erigon, ensuring it uses the **original Engine API port and JWT secret** that your old EL client used. See [here](https://docs.erigon.tech/staking/external-consensus-client-as-validator) for details.
+
 6. **Decommission Old Setup**: Verify Erigon and your external CL client are proposing and attesting blocks correctly. If confirmed, safely remove Geth and its data.
 
 ### Option 2: Remove Old EL and Sync Erigon (Downtime Accepted)
 
 This is the simplest option as it requires no configuration adjustments. However, the node will be down until Erigon finishes syncing.
 
+**Erigon + Caplin (Fastest Sync)**
+
 This path is the fastest way to get Erigon running. It utilizes **Erigon's embedded consensus client, Caplin**, requiring no external CL client or JWT secret. This is ideal for home users with limited disk space and no critical uptime requirements.
 
 **Steps for Quickest Start**
 
 1. **Decommission Old Setup**: Shut down and **remove your old EL** client (Geth, etc.) and its data. If you were using an external CL client, you can shut it down as well.
-2. **Installation**: [Install](installation/) Erigon.
-3. **Configuration**: Erigon requires no special configuration; it uses default ports and settings. The [basic setup](../fundamentals/basic-usage) is sufficient for most situations.
+2. **Installation**: [Install](https://docs.erigon.tech/get-started/installation) Erigon.
+3. **Configuration**: Erigon requires no special configuration; it uses default ports and settings. The [basic setup](https://docs.erigon.tech/fundamentals/basic-usage) is sufficient for most situations.
 4. **Synchronization**: Start syncing Erigon with the default Caplin configuration (Caplin does not use the Engine API).
 5. **Final Setup**: Once Erigon is fully synced, your node is online.
 6. **Monitoring**: Monitor the sync progress using `eth_syncing` or the health check, and ensure no errors appear in Erigon's logs.
+
+**Erigon + External CL (Reuse Existing CL)**
 
 This path retains your existing **external Consensus Layer (CL)** client (e.g., Prysm, Lighthouse) but swaps the old EL client for Erigon. Since downtime is accepted, this process requires simpler port management.
 
 **Steps for Quickest Start**
 
 1. **Decommission Old Setup**: Shut down and remove your old EL client (Geth, etc.) and its data. Keep your external CL client running.
-2. **Installation**: [Install](installation/) Erigon.
-3.  **Configuration** (JWT and Ports): Ensure Erigon uses the same Engine API [port](../fundamentals/default-ports) (`--authrpc.port`) and JWT secret (`--authrpc.jwtsecret`) that the old EL client previously used. For example:\\
 
-    ```sh
-    erigon \
-      --externalcl \
-      --datadir=/data/erigon \
-      --chain=mainnet \
-      --authrpc.port=8551 \
-      --authrpc.jwtsecret=/jwt \
-      --authrpc.addr=0.0.0.0 \
-      --http \
-      --http.addr=0.0.0.0 \
-      --http.port=8545 \
-      --http.api=engine,eth,net,web3 \
-      --ws \
-      --ws.port=8546
-    ```
+2. **Installation**: [Install](https://docs.erigon.tech/get-started/installation) Erigon.
 
-    _(Otherwise, you must reconfigure your external CL client to match Erigon's default settings)_
+3. **Configuration** (JWT and Ports): Ensure Erigon uses the same Engine API [port](https://docs.erigon.tech/fundamentals/default-ports) (`--authrpc.port`) and JWT secret (`--authrpc.jwtsecret`) that the old EL client previously used. For example:\
+
+```sh
+erigon \
+  --externalcl \
+  --datadir=/data/erigon \
+  --chain=mainnet \
+  --authrpc.port=8551 \
+  --authrpc.jwtsecret=/jwt \
+  --authrpc.addr=0.0.0.0 \
+  --http \
+  --http.addr=0.0.0.0 \
+  --http.port=8545 \
+  --http.api=engine,eth,net,web3 \
+  --ws \
+  --ws.port=8546
+```
+
+*(Otherwise, you must reconfigure your external CL client to match Erigon's default settings)*
+
 4. **Synchronization**: Start syncing Erigon. Your external CL client will automatically connect to Erigon once Erigon is running and reachable on the Engine API port.
+
 5. **Monitoring and Verification**: Once Erigon is fully synced, check the logs of both Erigon and the external CL client to verify correct chain following.
 
-***
-
-See [Basic Usage](../fundamentals/basic-usage) and [Configuring Erigon](../fundamentals/configuring-erigon/) for more details on available options.
+See [Basic Usage](https://docs.erigon.tech/fundamentals/basic-usage) and [Configuring Erigon](https://docs.erigon.tech/fundamentals/configuring-erigon) for more details on available options.
 
 ---
 
 # Installation
 URL: https://docs.erigon.tech/get-started/installation
 
-'install-docker':   'all-operating-systems',
-  'install-prebuilt': 'linuxmacos',
-  'install-source':   'linuxmacos',
-  'install-native':   'windows',
-  'install-wsl':      'windows',
-  'install-arm':      'ethereum-on-arm',
-};
-
-  if (e) e.preventDefault();
-  const el = document.getElementById(id);
-  if (!el) return;
-
-  document.querySelectorAll('details[id^="install-"]').forEach(d => {
-    if (d !== el && d.open) {
-      const s = d.querySelector('summary');
-      if (s) s.click();
-      else d.open = false;
-    }
-  });
-
-  if (!el.open) {
-    const summary = el.querySelector('summary');
-    if (summary) summary.click();
-    else el.open = true;
-  }
-
-  const sectionId = sectionForMethod[id];
-  if (sectionId) {
-    history.replaceState(null, '', '#' + sectionId);
-  }
-
-  const resolveTarget = () => {
-    let t = sectionId && document.getElementById(sectionId);
-    if (!t) {
-      let cursor = el.previousElementSibling;
-      while (cursor && !/^H[1-6]$/.test(cursor.tagName)) {
-        cursor = cursor.previousElementSibling;
-      }
-      t = cursor || el;
-    }
-    return t;
-  };
-
-  let lastHeight = document.body.scrollHeight;
-  let stableFrames = 0;
-  let totalFrames = 0;
-  const waitForStableLayout = () => {
-    const h = document.body.scrollHeight;
-    if (h === lastHeight) stableFrames++;
-    else 
-    totalFrames++;
-    if (stableFrames >= 6 || totalFrames >= 90) {
-      resolveTarget().scrollIntoView();
-    } else {
-      requestAnimationFrame(waitForStableLayout);
-    }
-  };
-  requestAnimationFrame(waitForStableLayout);
-};
-
-# Installation
-
 To install Erigon, begin by choosing an installation method suited to your operating system and technical preference. Options range from the simplest to the most complex, including pre-built images, containers, or source compilation.
 
-Pre-built Binaries — Fastest way to get started. Download and run a pre-compiled binary for your architecture.
-Docker — Run Erigon in an isolated container. Recommended for most users.
-Build from Source — Full control over the build. Requires Go, C++ compiler, and CLI experience.
-Ethereum on ARM — Community image and APT repository for ARM single-board computers (Raspberry Pi, Rock 5B, Orange Pi 5).
+**Linux**
 
-Docker — Run Erigon in an isolated container. The recommended method on macOS.
-Build from Source — Compile directly on your Mac. Requires Go, Clang/GCC, and CLI experience.
+- [**Pre-built Binaries**](https://docs.erigon.tech/get-started/installation#install-prebuilt) — Fastest way to get started. Download and run a pre-compiled binary for your architecture.
+- [**Docker**](https://docs.erigon.tech/get-started/installation#install-docker) — Run Erigon in an isolated container. Recommended for most users.
+- [**Build from Source**](https://docs.erigon.tech/get-started/installation#install-source) — Full control over the build. Requires Go, C++ compiler, and CLI experience.
+- [**Ethereum on ARM**](https://docs.erigon.tech/get-started/installation#install-arm) — Community image and APT repository for ARM single-board computers (Raspberry Pi, Rock 5B, Orange Pi 5).
 
-Native Compilation — Compile and run Erigon directly on Windows using Chocolatey, MinGW, and Go.
-WSL (Windows Subsystem for Linux) — Run a full Linux environment on Windows. Recommended for best performance.
+**macOS**
+
+- [**Docker**](https://docs.erigon.tech/get-started/installation#install-docker) — Run Erigon in an isolated container. The recommended method on macOS.
+- [**Build from Source**](https://docs.erigon.tech/get-started/installation#install-source) — Compile directly on your Mac. Requires Go, Clang/GCC, and CLI experience.
+
+**Windows**
+
+- [**Native Compilation**](https://docs.erigon.tech/get-started/installation#install-native) — Compile and run Erigon directly on Windows using Chocolatey, MinGW, and Go.
+- [**WSL (Windows Subsystem for Linux)**](https://docs.erigon.tech/get-started/installation#install-wsl) — Run a full Linux environment on Windows. Recommended for best performance.
 
 ### All Operating Systems
 
-Docker
+**Docker**
 
 Docker is like a portable container for software. It packages Erigon and everything it needs to run, so you don't have to install complicated dependencies on your computer.
 
 This Docker image is fully supported on **Linux**, **macOS**, and **Windows**.
 
-_(Note: The container itself is built on multi-platform Linux architectures (linux/amd64 and linux/arm64), which is handled automatically by your Docker setup.)_
+*(Note: The container itself is built on multi-platform Linux architectures (linux/amd64 and linux/arm64), which is handled automatically by your Docker setup.)*
 
 #### **Prerequisites**
 
@@ -327,15 +345,15 @@ _(Note: The container itself is built on multi-platform Linux architectures (lin
 
 **General Info**
 
-* The Docker images feature several binaries, including: `erigon`, `downloader`, `evm`, `caplin`, `capcli`, `integration`, `rpcdaemon`, `sentry`, and `txpool`.
-* The multi-platform Docker image is available for `linux/amd64/v2` and `linux/arm64` platforms and is now based on Debian Bookworm. There's no need to pull a different image for another supported platform.
-* All build flags are now passed to the release workflow, allowing users to view previously missed build information in the released binaries and Docker images. This change is also expected to result in better build optimization.
-* Docker images now contain the label `org.opencontainers.image.revision`, which refers to the commit ID from the Erigon project used to build the artifacts.
-* With recent updates, all build configurations are now included in the release process. This provides users with more comprehensive build information for both binaries and Docker images, along with enhanced build optimizations.
-* Images are stored at [https://hub.docker.com/r/erigontech/erigon](https://hub.docker.com/r/erigontech/erigon).
+- The Docker images feature several binaries, including: `erigon`, `downloader`, `evm`, `caplin`, `capcli`, `integration`, `rpcdaemon`, `sentry`, and `txpool`.
+- The multi-platform Docker image is available for `linux/amd64/v2` and `linux/arm64` platforms and is now based on Debian Bookworm. There's no need to pull a different image for another supported platform.
+- All build flags are now passed to the release workflow, allowing users to view previously missed build information in the released binaries and Docker images. This change is also expected to result in better build optimization.
+- Docker images now contain the label `org.opencontainers.image.revision`, which refers to the commit ID from the Erigon project used to build the artifacts.
+- With recent updates, all build configurations are now included in the release process. This provides users with more comprehensive build information for both binaries and Docker images, along with enhanced build optimizations.
+- Images are stored at [https://hub.docker.com/r/erigontech/erigon](https://hub.docker.com/r/erigontech/erigon).
 
 :::warning
-**Windows**: note that Docker on Windows is affected by [WSL2 Performance and Data Storage](/get-started/installation/#install-wsl).
+**Windows**: note that Docker on Windows is affected by [WSL2 Performance and Data Storage](https://docs.erigon.tech/get-started/installation#install-wsl).
 :::
 
 #### **Download and start Erigon in Docker**
@@ -357,7 +375,7 @@ docker pull erigontech/erigon:<version_tag>
 For example:
 
 ```sh
-docker pull erigontech/erigon:v{ERIGON_VERSION}
+docker pull erigontech/erigon:v3.6.0
 ```
 
 **3. Start the Erigon container**
@@ -371,32 +389,32 @@ docker run -it erigontech/erigon:<version_tag> <flags>
 For example:
 
 ```sh
-docker run -it erigontech/erigon:v{ERIGON_VERSION} --chain=hoodi --prune.mode=minimal --datadir /erigon-data
+docker run -it erigontech/erigon:v3.6.0 --chain=hoodi --prune.mode=minimal --datadir /erigon-data
 ```
 
-* `-v` connects a folder on your computer to the container (must have authorization)
-* `-it` lets you see what's happening and interact with Erigon
-* `--chain=hoodi` specifies which [network](/fundamentals/supported-networks) to sync
-* `--prune.mode=minimal` tells Erigon to use minimal [Pruning Mode](/fundamentals/pruning-modes)
-* `--datadir` tells Erigon where to store data inside the container
+- `-v` connects a folder on your computer to the container (must have authorization)
+- `-it` lets you see what's happening and interact with Erigon
+- `--chain=hoodi` specifies which [network](https://docs.erigon.tech/fundamentals/supported-networks) to sync
+- `--prune.mode=minimal` tells Erigon to use minimal [Pruning Mode](https://docs.erigon.tech/fundamentals/pruning-modes)
+- `--datadir` tells Erigon where to store data inside the container
 
 ### Linux/macOS
 
-Pre-built Binaries (Linux Only)
+**Pre-built Binaries (Linux Only)**
 
 **1. Select Your Processor Architecture and Download**
 
-Go to the Erigon [releases page](https://github.com/erigontech/erigon/releases) on GitHub and select the latest stable version (e.g., v{ERIGON_VERSION}) or whichever version you prefer.
+Go to the Erigon [releases page](https://github.com/erigontech/erigon/releases) on GitHub and select the latest stable version (e.g., v3.6.0) or whichever version you prefer.
 
 Download the appropriate binary file for your processor architecture:
 
 | Processor Type | Binary File Type | Example File Name |
 | --- | --- | --- |
-| 64-bit Intel/AMD | Debian Package (.deb) | erigon_{ERIGON_VERSION}_amd64.deb |
-| 64-bit ARM | Debian Package (.deb) | erigon_{ERIGON_VERSION}_arm64.deb |
-| 64-bit Intel/AMD | Compressed Archive (.tar.gz) | erigon_v{ERIGON_VERSION}_linux_amd64.tar.gz |
-| 64-bit Intel/AMDv2 | Compressed Archive (.tar.gz) | erigon_v{ERIGON_VERSION}_linux_amd64v2.tar.gz |
-| 64-bit ARM | Compressed Archive (.tar.gz) | erigon_v{ERIGON_VERSION}_linux_arm64.tar.gz |
+| 64-bit Intel/AMD | Debian Package (.deb) | erigon_3.6.0_amd64.deb |
+| 64-bit ARM | Debian Package (.deb) | erigon_3.6.0_arm64.deb |
+| 64-bit Intel/AMD | Compressed Archive (.tar.gz) | erigon_v3.6.0_linux_amd64.tar.gz |
+| 64-bit Intel/AMDv2 | Compressed Archive (.tar.gz) | erigon_v3.6.0_linux_amd64v2.tar.gz |
+| 64-bit ARM | Compressed Archive (.tar.gz) | erigon_v3.6.0_linux_arm64.tar.gz |
 
 Note that the Release Page Assets table contains also the **checksum** for each file and a checksum file.
 
@@ -415,14 +433,14 @@ sha256sum <DOWNLOADED_FILE_NAME>
 Example with a `tar.gz` file:
 
 ```sh
-sha256sum erigon_v{ERIGON_VERSION}_linux_amd64.tar.gz
+sha256sum erigon_v3.6.0_linux_amd64.tar.gz
 ```
 
 This command will output a long string (the computed checksum) followed by the file name.
 
 **2.2 Compare the Checksums**
 
-Compare the checksum found in the previous step with those in the Release Notes Assets table or the erigon\_v3.x.x\_checksums.txt file in the same table.
+Compare the checksum found in the previous step with those in the Release Notes Assets table or the erigon_v3.x.x_checksums.txt file in the same table.
 
 The two checksum strings must match exactly. If they do not match, the file is corrupted, and you should delete it and download it again.
 
@@ -434,35 +452,37 @@ After downloading and verifying the checksum, follow the instructions below base
 
 This method uses your distribution's package manager (like dpkg) to install Erigon system-wide.
 
-1.  Navigate to the directory where you downloaded the pre-built binary, e.g. Downloads:
+1. Navigate to the directory where you downloaded the pre-built binary, e.g. Downloads:
 
-    ```bash
-    cd ~/Downloads
-    ```
-2.  Install the package:
+```bash
+cd ~/Downloads
+```
 
-    ```bash
-    sudo dpkg -i erigon_3.x.x_amd64.deb
-    ```
+2. Install the package:
 
-    (Replace the filename with your downloaded version)
+```bash
+sudo dpkg -i erigon_3.x.x_amd64.deb
+```
+
+(Replace the filename with your downloaded version)
 
 **b. Using Compressed Archive (`.tar.gz`)**
 
 This method gives you a standalone executable that can be run from any directory.
 
-1.  Extract the archive:
+1. Extract the archive:
 
-    ```bash
-    tar -xzf erigon_v3.x.x_linux_amd64.tar.gz
-    ```
+```bash
+tar -xzf erigon_v3.x.x_linux_amd64.tar.gz
+```
 
-    (Replace the filename with your downloaded version)
-2.  Move the resulting `erigon` executable to a directory included in your system's $PATH(e.g., $/usr/local/bin) to run it from anywhere:
+(Replace the filename with your downloaded version)
 
-    ```bash
-    sudo mv erigon /usr/local/bin/
-    ```
+2. Move the resulting `erigon` executable to a directory included in your system's $PATH(e.g., $/usr/local/bin) to run it from anywhere:
+
+```bash
+sudo mv erigon /usr/local/bin/
+```
 
 **4. Running Erigon**
 
@@ -472,7 +492,7 @@ After installation, you can run Erigon from your terminal:
 erigon [options]
 ```
 
-Build from Source
+**Build from Source**
 
 :::info
 Building from source gives you full control over the compilation process and lets you run any specific version or branch. It requires Go, a C++ compiler, and basic familiarity with the command line.
@@ -498,9 +518,7 @@ sudo apt install build-essential cmake -y
 
 **1.3 Go Programming Language**
 
-Erigon utilizes Go (also known as Golang) version 1.25 or newer for part of its development. It is recommended to have a
-fresh Go installation. If you have an older version, consider deleting the `/usr/local/go` folder (you may need to use
-`sudo`) and re-extract the new version in its place.
+Erigon utilizes Go (also known as Golang) version 1.25 or newer for part of its development. It is recommended to have a fresh Go installation. If you have an older version, consider deleting the `/usr/local/go` folder (you may need to use `sudo`) and re-extract the new version in its place.
 
 To install the latest Go version, visit the official documentation at [https://golang.org/doc/install](https://golang.org/doc/install).
 
@@ -508,8 +526,8 @@ To install the latest Go version, visit the official documentation at [https://g
 
 This turns the C++ part of Erigon's code into a program your computer can run. You can use either **Clang** or **GCC**:
 
-* For **Clang** follow the instructions at [https://clang.llvm.org/get\_started.html](https://clang.llvm.org/get_started.html);
-* For **GCC** (version 10 or newer): [https://gcc.gnu.org/install/index.html](https://gcc.gnu.org/install/index.html).
+- For **Clang** follow the instructions at [https://clang.llvm.org/get_started.html](https://clang.llvm.org/get_started.html);
+- For **GCC** (version 10 or newer): [https://gcc.gnu.org/install/index.html](https://gcc.gnu.org/install/index.html).
 
 **2. Building Erigon from Source**
 
@@ -535,7 +553,7 @@ git fetch --tags
 Check out the desired version tag by replacing `<tag_name>` with the version you want. Normally latest stable version is the best, check the official [Release Notes](https://github.com/erigontech/erigon/releases). For example:
 
 ```sh
-git checkout v{ERIGON_VERSION}
+git checkout v3.6.0
 ```
 
 **2.3 Compile the Software**
@@ -566,7 +584,7 @@ After installation, you can run Erigon from your terminal:
 
 ### Windows
 
-Native Compilation
+**Native Compilation**
 
 **1. Software Prerequisites**
 
@@ -574,7 +592,7 @@ You must install the following software and set the below environment variables 
 
 **1.1 Chocolatey**
 
-Install _Chocolatey package manager_ by following these [instructions](https://docs.chocolatey.org/en-us/choco/setup).
+Install *Chocolatey package manager* by following these [instructions](https://docs.chocolatey.org/en-us/choco/setup).
 
 Once your Windows machine has the above installed, open the **Command Prompt** by typing "**cmd**" in the search bar and check that you have correctly installed Chocolatey:
 
@@ -602,9 +620,7 @@ Git is a tool that helps download and manage the Erigon source code. To install 
 
 **1.4 Go Programming Language**
 
-Erigon utilizes Go (also known as Golang) version 1.25 or newer for part of its development. It is recommended to have a
-fresh Go installation. If you have an older version, consider deleting the `/usr/local/go` folder (you may need to use
-`sudo`) and re-extract the new version in its place.
+Erigon utilizes Go (also known as Golang) version 1.25 or newer for part of its development. It is recommended to have a fresh Go installation. If you have an older version, consider deleting the `/usr/local/go` folder (you may need to use `sudo`) and re-extract the new version in its place.
 
 To install the latest Go version, visit the official documentation at [https://golang.org/doc/install](https://golang.org/doc/install).
 
@@ -640,7 +656,7 @@ git fetch --tags
 Check out the desired version tag by replacing `<tag_name>` with the version you want. Normally latest stable version is the best, check the official [Release Notes](https://github.com/erigontech/erigon/releases). For example:
 
 ```bash
-git checkout v{ERIGON_VERSION}
+git checkout v3.6.0
 ```
 
 You might need to change the `ExecutionPolicy` to allow scripts created locally or signed by a trusted publisher to run. Open a **Powershell session as Administrator** and type:
@@ -693,36 +709,36 @@ erigon.exe [options]
 **Note**: When you first start Erigon, Windows Firewall may prompt you to allow internet access. Select "YES" to proceed.
 :::
 
-Window Subsystem for Linux (WSL)
+**Window Subsystem for Linux (WSL)**
 
 WSL enables you to run a complete GNU/Linux environment natively within Windows, offering Linux compatibility without the performance and resource overhead of traditional virtual machines.
 
 **Installation and Version**
 
-* Official Installation: Follow Microsoft's official guide to install WSL2: [https://learn.microsoft.com/en-us/windows/wsl/install](https://learn.microsoft.com/en-us/windows/wsl/install)
-* Required Version: WSL version 2 is the only version supported by Erigon.
+- Official Installation: Follow Microsoft's official guide to install WSL2: [https://learn.microsoft.com/en-us/windows/wsl/install](https://learn.microsoft.com/en-us/windows/wsl/install)
+- Required Version: WSL version 2 is the only version supported by Erigon.
 
 **Building Erigon**
 
-Once WSL2 is set up, you can build and run Erigon exactly as you would on a regular [Linux/macOS](/get-started/installation/#linuxmacos) distribution.
+Once WSL2 is set up, you can build and run Erigon exactly as you would on a regular [Linux/macOS](https://docs.erigon.tech/get-started/installation#linuxmacos) distribution.
 
 **Performance and Data Storage**
 
 The location of your Erigon data directory (`datadir`) is the most crucial factor for performance in WSL.
 
-| **Data Location**                                                         | **Performance & Configuration**                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Recommended: Native Linux Filesystem (e.g., in your Linux home directory) | Optimal Performance. Erigon runs without restrictions, and the embedded RPC Daemon works efficiently.                                                                                                                                                                                                                                                                                                                                                            |
-| Avoid: Mounted Windows Partitions (e.g., `/mnt/c/`, `/mnt/d/`)            | Performance is reduced as the native Windows drives are mounted using DrvFS (a slower network file system). This affects MDBX database access, and complicates filesystem operations that expect unix-like behaviour. Setting [`automount.options=metadata`](https://learn.microsoft.com/en-us/windows/wsl/wsl-config#automount-options) in `/etc/wsl.conf` in your distribution is recommended, but not required. Note that Docker on Windows is also affected. |
+| **Data Location** | **Performance & Configuration** |
+| --- | --- |
+| Recommended: Native Linux Filesystem (e.g., in your Linux home directory) | Optimal Performance. Erigon runs without restrictions, and the embedded RPC Daemon works efficiently. |
+| Avoid: Mounted Windows Partitions (e.g., `/mnt/c/`, `/mnt/d/`) | Performance is reduced as the native Windows drives are mounted using DrvFS (a slower network file system). This affects MDBX database access, and complicates filesystem operations that expect unix-like behaviour. Setting [`automount.options=metadata`](https://learn.microsoft.com/en-us/windows/wsl/wsl-config#automount-options) in `/etc/wsl.conf` in your distribution is recommended, but not required. Note that Docker on Windows is also affected. |
 
 **RPC Daemon Configuration**
 
 The choice of data location directly impacts how you must configure the RPC Daemon:
 
-| **Scenario**                                  | **RPC Daemon Requirement**                                                               |
-| --------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| Data on Native Linux Filesystem (Recommended) | Use the Embedded RPC Daemon. This is the highly preferred and most efficient method.     |
-| Data on Mounted Windows Partition             | The `rpcdaemon` must be configured as a remote DB even when running on the same machine. |
+| **Scenario** | **RPC Daemon Requirement** |
+| --- | --- |
+| Data on Native Linux Filesystem (Recommended) | Use the Embedded RPC Daemon. This is the highly preferred and most efficient method. |
+| Data on Mounted Windows Partition | The `rpcdaemon` must be configured as a remote DB even when running on the same machine. |
 
 :::warning
 ⚠️ Warning: The remote DB RPC Daemon is an experimental feature, is not recommended, and is extremely slow. Always aim to use the embedded RPC Daemon by keeping your data on the native Linux filesystem.
@@ -736,7 +752,7 @@ If you need to connect to Erigon from an external network (e.g., opening a port 
 
 ### Ethereum on ARM
 
-Install with APT on ARM boards
+**Install with APT on ARM boards**
 
 [Ethereum on ARM](https://ethereum-on-arm-documentation.readthedocs.io/) is a community project that provides a custom Linux image for ARM single-board computers (such as Raspberry Pi, Rock 5B, and Orange Pi 5) with an APT repository preconfigured to install and update Ethereum clients — including Erigon — as native system packages.
 
@@ -752,35 +768,34 @@ For the full image, supported boards, and setup instructions, see the [Ethereum 
 Ethereum on ARM is maintained independently by the community and is not an official Erigon distribution channel. The Erigon version available through its APT repository may lag behind the latest [GitHub release](https://github.com/erigontech/erigon/releases).
 :::
 
-Once you have Erigon installed, you can see [Basic Usage](/fundamentals/basic-usage) to configure your node and confirm it is syncing.
+Once you have Erigon installed, you can see [Basic Usage](https://docs.erigon.tech/fundamentals/basic-usage) to configure your node and confirm it is syncing.
 
 ---
 
 # Upgrading from a previous version
 URL: https://docs.erigon.tech/get-started/installation/upgrading
 
-
 Updating to the latest version of Erigon gives you access to the latest features and ensures optimal performance and stability.
 
 ## General Recommendations Before Upgrade
 
-* **Read Release Notes**: Carefully review the [Release Notes](https://github.com/erigontech/erigon/releases) for breaking changes and new features relevant to your setup.
-* **Terminate your Erigon**: End your current Erigon session by pressing `CTRL+C`.
-* **Backup**: Always back up your `datadir` before performing major upgrades.
+- **Read Release Notes**: Carefully review the [Release Notes](https://github.com/erigontech/erigon/releases) for breaking changes and new features relevant to your setup.
+- **Terminate your Erigon**: End your current Erigon session by pressing `CTRL+C`.
+- **Backup**: Always back up your `datadir` before performing major upgrades.
 
 ## Managing your Data
 
 Erigon 3.1 introduces a new snapshot format while continuing to support the old one. This means that new releases are fully compatible with your existing data. However, users who want the latest data files and data-specific fixes can perform an **optional** manual data upgrade:
 
 1. Backup your datadir.
-2. [Upgrade your Erigon installation](#upgrading-your-erigon-installation) whether from a binary, compiled source code, or Docker.
-3. Upgrade your snapshots using one of the [options below](#snapshots-upgrade-options).
+2. [Upgrade your Erigon installation](https://docs.erigon.tech/get-started/installation/upgrading#upgrading-your-erigon-installation) whether from a binary, compiled source code, or Docker.
+3. Upgrade your snapshots using one of the [options below](https://docs.erigon.tech/get-started/installation/upgrading#snapshots-upgrade-options).
 4. Run Erigon; it downloads any missing snapshots and resumes syncing.
 
 ### Snapshots Upgrade Options
 
-* `erigon snapshots update-to-new-ver-format --datadir /your/datadir`: converts your existing snapshots in place to the latest format, **keeping your data**. Quicker, but you won't get the full performance benefits of freshly built snapshots.
-* `erigon snapshots reset --datadir /your/datadir`: **destructive** — deletes `chaindata/` (and any leftover `heimdall/` and `polygon-bridge/` directories from a former Polygon datadir) and removes any snapshot files **not** in the preverified set (locally generated files, and torrents with a mismatched hash). Preverified snapshots already on disk are **kept**; on the next start Erigon downloads only **missing or incorrect** snapshots and rebuilds state.
+- `erigon snapshots update-to-new-ver-format --datadir /your/datadir`: converts your existing snapshots in place to the latest format, **keeping your data**. Quicker, but you won't get the full performance benefits of freshly built snapshots.
+- `erigon snapshots reset --datadir /your/datadir`: **destructive** — deletes `chaindata/` (and any leftover `heimdall/` and `polygon-bridge/` directories from a former Polygon datadir) and removes any snapshot files **not** in the preverified set (locally generated files, and torrents with a mismatched hash). Preverified snapshots already on disk are **kept**; on the next start Erigon downloads only **missing or incorrect** snapshots and rebuilds state.
 
 :::warning
 `erigon snapshots reset` does **not** reuse your `chaindata/` — it deletes the chaindata DB (and any leftover Polygon aux directories) and any locally generated or mismatched snapshots, then rebuilds state on the next start (downloading only missing or incorrect snapshots). Back up your `--datadir` first, and prefer `update-to-new-ver-format` if you want to keep your current data.
@@ -788,7 +803,7 @@ Erigon 3.1 introduces a new snapshot format while continuing to support the old 
 
 Choose `update-to-new-ver-format` to convert your data in place, or `reset` for a clean reset to the preverified snapshot set.
 
-Why Upgrading Erigon Doesn't Always Fix Your Data
+**Why Upgrading Erigon Doesn't Always Fix Your Data**
 
 Upgrading Erigon involves a key distinction between its core software and its data files, which are managed separately. This approach is rooted in practicality and user control.
 
@@ -819,19 +834,19 @@ If upgrading snapshots(`3.0`to `3.1`) now happens automatically, you should foll
 
 Follow the below instructions depending on your installation method:
 
-* [Pre-built binaries](#pre-built-binaries-only-linux-and-macos)
-* [Docker](#docker)
-* [Compiled source code](#compiled-from-source)
+- [Pre-built binaries](https://docs.erigon.tech/get-started/installation/upgrading#pre-built-binaries-only-linux-and-macos)
+- [Docker](https://docs.erigon.tech/get-started/installation/upgrading#docker)
+- [Compiled source code](https://docs.erigon.tech/get-started/installation/upgrading#compiled-from-source)
 
 ### Pre-built Binaries (only Linux and macOS)
 
-Download the latest binary file from [https://github.com/erigontech/erigon/releases](https://github.com/erigontech/erigon/releases), do the [checksum](./#install-prebuilt) and reinstall it, no other operation needed.
+Download the latest binary file from [https://github.com/erigontech/erigon/releases](https://github.com/erigontech/erigon/releases), do the [checksum](https://docs.erigon.tech/get-started/installation/#install-prebuilt) and reinstall it, no other operation needed.
 
 ### Docker
 
 If you're using Docker to run Erigon, the process to upgrade to a newer version of the software is straightforward and revolves around pulling the latest Docker image and then running it.
 
-Simply follow the [Docker](#docker) instructions and install and launch the new version.
+Simply follow the [Docker](https://docs.erigon.tech/get-started/installation/upgrading#docker) instructions and install and launch the new version.
 
 ### Compiled from source
 
@@ -844,8 +859,6 @@ URL: https://docs.erigon.tech/get-started/easy-nodes
 
 Guided setup for running a complete node with sensible defaults — pick your network and follow along.
 
-## Sections
-
 - [Ethereum Node](https://docs.erigon.tech/get-started/easy-nodes/how-to-run-an-ethereum-node): Run a full Ethereum mainnet node using Caplin (built-in consensus layer) or connect an external CL client.
 - [Gnosis Chain Node](https://docs.erigon.tech/get-started/easy-nodes/how-to-run-a-gnosis-chain-node): Run a full Gnosis Chain node with Erigon's embedded consensus layer or an external CL client.
 
@@ -854,13 +867,12 @@ Guided setup for running a complete node with sensible defaults — pick your ne
 # How to run an Ethereum node
 URL: https://docs.erigon.tech/get-started/easy-nodes/how-to-run-an-ethereum-node
 
-
 ## 1. Prerequisites Check
 
-1. Confirm your machine meets the necessary [Hardware Requirements](/get-started/hardware-requirements) based on your desired pruning mode.
+1. Confirm your machine meets the necessary [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements) based on your desired pruning mode.
 2. **Install Docker**:
-   * For Linux, install [Docker Engine](https://docs.docker.com/engine/install).
-   * For macOS or Windows, install [Docker Desktop](https://docs.docker.com/desktop/).
+  - For Linux, install [Docker Engine](https://docs.docker.com/engine/install).
+  - For macOS or Windows, install [Docker Desktop](https://docs.docker.com/desktop/).
 
 ## 2. Configure and Launch Erigon
 
@@ -873,7 +885,7 @@ Create a new file named `docker-compose.yml` in a directory where you want to ma
 ```yaml
 services:
   erigon:
-    image: erigontech/erigon:v{ERIGON_VERSION}
+    image: erigontech/erigon:v3.6.0
     container_name: erigon-node
     restart: always
     command:
@@ -914,16 +926,12 @@ Set `EXTERNAL_IP` before starting, either in a `.env` file next to `docker-compo
 echo "EXTERNAL_IP=$(curl -s https://api.ipify.org)" > .env
 ```
 
-or by exporting it in your shell. Forward the `30303`, `42069`, `4000` and `4001`
-ports on your router as well, otherwise peers still cannot reach you.
+or by exporting it in your shell. Forward the `30303`, `42069`, `4000` and `4001` ports on your router as well, otherwise peers still cannot reach you.
 
 :::warning
 ⚠️ **Action Required**: the volume path should be changed to suit your setup — replace `/path/to/erigon/data` with a valid, empty directory on your machine where you want Erigon to store its files.
 
-The container runs as UID/GID `1000`, so the directory must be writable by that
-user — `sudo chown -R 1000:1000 /path/to/erigon/data`. See
-[Permission denied inside Docker](/help-center/common-errors-and-solutions) if
-you hit a `permission denied` error on startup.
+The container runs as UID/GID `1000`, so the directory must be writable by that user — `sudo chown -R 1000:1000 /path/to/erigon/data`. See [Permission denied inside Docker](https://docs.erigon.tech/help-center/common-errors-and-solutions) if you hit a `permission denied` error on startup.
 :::
 
 ### **B. Launch the Node and Monitor Progress**
@@ -934,9 +942,7 @@ Open your terminal in the directory where you saved `docker-compose.yml`. To sta
 docker compose up
 ```
 
-That keeps the logs in the foreground, which is what you want the first time.
-Once you are happy with the configuration, start it detached so the node keeps
-running after you close the terminal:
+That keeps the logs in the foreground, which is what you want the first time. Once you are happy with the configuration, start it detached so the node keeps running after you close the terminal:
 
 ```bash
 docker compose up -d
@@ -946,14 +952,14 @@ and follow the logs when you need them with `docker compose logs -f`.
 
 ## Flag explanation
 
-* `--chain=mainnet` specifies to run on Ethereum mainnet
-* Add `--prune.mode=minimal` to run minimal [Pruning Mode](/fundamentals/pruning-modes) or `--prune.mode=archive` to run an archive node
-* `--datadir=/var/lib/erigon` has to name the same path as the container side of the volume mount. Without it Erigon writes to its default location inside the container instead of your mounted directory, and the data ends up in an anonymous Docker volume rather than where you pointed it
-* `--http.addr=0.0.0.0 --http.api=eth,web3,net,debug,trace,txpool` to use RPC and e.g. be able to connect your [web3 wallet](/fundamentals/web3-wallet). `0.0.0.0` is the address *inside* the container, which is what lets Docker forward to it at all; the `127.0.0.1:8545:8545` port mapping is what keeps it off your LAN. Change that mapping to `8545:8545` only if you intend to expose RPC to other machines
-* `--nat=extip:<your public IP>` and `--caplin.nat=extip:<your public IP>` advertise a reachable address so other nodes can dial you — the first for the execution layer, the second for Caplin. Without them, and without the forwarded ports, the node still syncs but only through connections it opens itself
-* `--torrent.download.rate` is deliberately not set above, because its default of `512mb` (megabytes per second) is already the maximum this recipe would ask for. During initial sync Erigon uses the full allowance, which is what you want on a dedicated machine. Add the flag only to **lower** the cap if you share the machine with other work (e.g. `--torrent.download.rate=128mb`), or set `--torrent.download.rate=Inf` to remove the limit entirely.
+- `--chain=mainnet` specifies to run on Ethereum mainnet
+- Add `--prune.mode=minimal` to run minimal [Pruning Mode](https://docs.erigon.tech/fundamentals/pruning-modes) or `--prune.mode=archive` to run an archive node
+- `--datadir=/var/lib/erigon` has to name the same path as the container side of the volume mount. Without it Erigon writes to its default location inside the container instead of your mounted directory, and the data ends up in an anonymous Docker volume rather than where you pointed it
+- `--http.addr=0.0.0.0 --http.api=eth,web3,net,debug,trace,txpool` to use RPC and e.g. be able to connect your [web3 wallet](https://docs.erigon.tech/fundamentals/web3-wallet). `0.0.0.0` is the address *inside* the container, which is what lets Docker forward to it at all; the `127.0.0.1:8545:8545` port mapping is what keeps it off your LAN. Change that mapping to `8545:8545` only if you intend to expose RPC to other machines
+- `--nat=extip:<your public IP>` and `--caplin.nat=extip:<your public IP>` advertise a reachable address so other nodes can dial you — the first for the execution layer, the second for Caplin. Without them, and without the forwarded ports, the node still syncs but only through connections it opens itself
+- `--torrent.download.rate` is deliberately not set above, because its default of `512mb` (megabytes per second) is already the maximum this recipe would ask for. During initial sync Erigon uses the full allowance, which is what you want on a dedicated machine. Add the flag only to **lower** the cap if you share the machine with other work (e.g. `--torrent.download.rate=128mb`), or set `--torrent.download.rate=Inf` to remove the limit entirely.
 
-When you get familiar with running Erigon from CLI you may also consider [staking](/staking/caplin) and/or running an Ethereum node with an [external Consensus Layer](/get-started/easy-nodes/how-to-run-an-ethereum-node/ethereum-with-an-external-cl).
+When you get familiar with running Erigon from CLI you may also consider [staking](https://docs.erigon.tech/staking/caplin) and/or running an Ethereum node with an [external Consensus Layer](https://docs.erigon.tech/get-started/easy-nodes/how-to-run-an-ethereum-node/ethereum-with-an-external-cl).
 
 :::tip
 Press `Ctrl+C` in your terminal to stop Erigon.
@@ -961,15 +967,12 @@ Press `Ctrl+C` in your terminal to stop Erigon.
 
 ## Host networking as an alternative
 
-Publishing each port individually is explicit, but Docker's NAT is also what
-makes `--nat=extip:...` necessary in the first place. Adding `network_mode:
-host` to the service instead gives the container the host's network stack
-directly, so peers see the host's own address and there is nothing to map:
+Publishing each port individually is explicit, but Docker's NAT is also what makes `--nat=extip:...` necessary in the first place. Adding `network_mode: host` to the service instead gives the container the host's network stack directly, so peers see the host's own address and there is nothing to map:
 
 ```yaml
 services:
   erigon:
-    image: erigontech/erigon:v{ERIGON_VERSION}
+    image: erigontech/erigon:v3.6.0
     network_mode: host
     command:
       - --chain=mainnet
@@ -986,98 +989,89 @@ services:
 
 Two things change with it, and both matter:
 
-* the `ports:` section is ignored — port publishing does not apply, so the
-  firewall on the host is what governs access;
-* every listener binds on the host, so anything you do not want exposed must be
-  bound explicitly to `127.0.0.1`. That is why RPC, the Engine API and the
-  internal gRPC address are pinned to loopback above. `--nat` and `--caplin.nat`
-  are no longer needed for the container, though you still need the p2p ports
-  forwarded on your router.
+- the `ports:` section is ignored — port publishing does not apply, so the firewall on the host is what governs access;
+- every listener binds on the host, so anything you do not want exposed must be bound explicitly to `127.0.0.1`. That is why RPC, the Engine API and the internal gRPC address are pinned to loopback above. `--nat` and `--caplin.nat` are no longer needed for the container, though you still need the p2p ports forwarded on your router.
 
-Host networking is Linux-only in practice; on Docker Desktop for macOS and
-Windows it does not behave the same way, so keep the published-ports form there.
+Host networking is Linux-only in practice; on Docker Desktop for macOS and Windows it does not behave the same way, so keep the published-ports form there.
 
-Additional flags can be added to [configure](/fundamentals/configuring-erigon/) Erigon with several options.
+Additional flags can be added to [configure](https://docs.erigon.tech/fundamentals/configuring-erigon) Erigon with several options.
 
 ---
 
 # Ethereum with an external CL
 URL: https://docs.erigon.tech/get-started/easy-nodes/how-to-run-an-ethereum-node/ethereum-with-an-external-cl
 
-
 You can use **Prysm**, **Lighthouse**, or any other Consensus Layer client with Erigon by including the `--externalcl` flag. This integration enables direct access to the Ethereum blockchain, allowing you to manage your keys for staking ETH and block production.
 
 :::warning
-The Engine API drives block processing, so anything that can reach it and holds
-your JWT secret controls the node. The steps below widen it past localhost only
-so a CL on another machine can connect — when you do that, protect it:
+The Engine API drives block processing, so anything that can reach it and holds your JWT secret controls the node. The steps below widen it past localhost only so a CL on another machine can connect — when you do that, protect it:
 
-* prefer the specific interface — `--authrpc.addr <this-host-LAN-IP>` — over
-  `0.0.0.0`, which listens on every interface including any public one;
-* restrict port `8551` at the firewall to the CL host's address, and never
-  expose it to the internet;
-* treat `--authrpc.vhosts` as a `Host`-header check, not a network control: it
-  is not a substitute for a firewall rule;
-* keep `jwt.hex` readable only by the accounts that need it, and copy it to the
-  CL host over a private channel.
+- prefer the specific interface — `--authrpc.addr <this-host-LAN-IP>` — over `0.0.0.0`, which listens on every interface including any public one;
+- restrict port `8551` at the firewall to the CL host's address, and never expose it to the internet;
+- treat `--authrpc.vhosts` as a `Host`-header check, not a network control: it is not a substitute for a firewall rule;
+- keep `jwt.hex` readable only by the accounts that need it, and copy it to the CL host over a private channel.
 
-If both clients run on the same machine, leave the Engine API on its default
-localhost address and skip those flags entirely.
+If both clients run on the same machine, leave the Engine API on its default localhost address and skip those flags entirely.
 :::
 
 :::tip
-Keep your consensus client current, the same way you would Erigon. Beyond fixes
-and performance work, a CL carries the fork schedule it was built with: a
-version released before an upcoming hard fork may not follow the chain through
-it, which stalls your execution layer too. Watch your client's releases
-([Prysm](https://github.com/OffchainLabs/prysm/releases),
-[Lighthouse](https://github.com/sigp/lighthouse/releases)) and upgrade before
-scheduled forks, not after.
+Keep your consensus client current, the same way you would Erigon. Beyond fixes and performance work, a CL carries the fork schedule it was built with: a version released before an upcoming hard fork may not follow the chain through it, which stalls your execution layer too. Watch your client's releases ([Prysm](https://github.com/OffchainLabs/prysm/releases), [Lighthouse](https://github.com/sigp/lighthouse/releases)) and upgrade before scheduled forks, not after.
 :::
 
 ## Erigon with Prysm as the external CL
 
-1.  Start Erigon adding the `--externalcl` flag:
+**Prysm**
 
-    ```bash
-    erigon --externalcl
-    ```
+1. Start Erigon adding the `--externalcl` flag:
 
-    If your Consensus Layer (CL) client is on a different device, add the following flags:
+```bash
+erigon --externalcl
+```
 
-    * `--authrpc.addr <this-host-LAN-IP>` — the Engine API listens on localhost by default, so it has to be widened for a remote CL. Read the warning below before reaching for `0.0.0.0`;
-    * `--authrpc.vhosts <CL_host>` where \ is the source host or the appropriate hostname that your CL client is using.
-2.  Install and run **Prysm** by following the official guide: [https://docs.prylabs.network/docs/install/install-with-script](https://docs.prylabs.network/docs/install/install-with-script).
+If your Consensus Layer (CL) client is on a different device, add the following flags:
 
-    Prysm must fully synchronize before Erigon can start syncing, since Erigon requires an existing target head to sync to. The quickest way to get Prysm synced is to use a public checkpoint synchronization endpoint from the list at [https://eth-clients.github.io/checkpoint-sync-endpoints](https://eth-clients.github.io/checkpoint-sync-endpoints).
+  - `--authrpc.addr <this-host-LAN-IP>` — the Engine API listens on localhost by default, so it has to be widened for a remote CL. Read the warning below before reaching for `0.0.0.0`;
+  - `--authrpc.vhosts <CL_host>` where <CL_host> is the source host or the appropriate hostname that your CL client is using.
+
+2. Install and run **Prysm** by following the official guide: [https://docs.prylabs.network/docs/install/install-with-script](https://docs.prylabs.network/docs/install/install-with-script).
+
+Prysm must fully synchronize before Erigon can start syncing, since Erigon requires an existing target head to sync to. The quickest way to get Prysm synced is to use a public checkpoint synchronization endpoint from the list at [https://eth-clients.github.io/checkpoint-sync-endpoints](https://eth-clients.github.io/checkpoint-sync-endpoints).
+
 3. To communicate with Erigon, the `--execution-endpoint` must be specified as `<erigon address>:8551`, where `<erigon address>` is either `http://localhost` or the IP address of the device running Erigon.
-4.  Prysm must point to the [JWT secret](../../../fundamentals/jwt) automatically created by Erigon in the `--datadir` directory.
 
-    ```bash
-    ./prysm.sh beacon-chain \
-    --execution-endpoint http://localhost:8551 \
-    --mainnet --jwt-secret=<your-datadir>/jwt.hex \
-    --checkpoint-sync-url=https://mainnet.checkpoint.sigp.io \
-    --genesis-beacon-api-url=https://mainnet.checkpoint.sigp.io
-    ```
+4. Prysm must point to the [JWT secret](https://docs.erigon.tech/fundamentals/jwt) automatically created by Erigon in the `--datadir` directory.
 
-1.  Start Erigon adding the `--externalcl` flag:
+```bash
+./prysm.sh beacon-chain \
+--execution-endpoint http://localhost:8551 \
+--mainnet --jwt-secret=<your-datadir>/jwt.hex \
+--checkpoint-sync-url=https://mainnet.checkpoint.sigp.io \
+--genesis-beacon-api-url=https://mainnet.checkpoint.sigp.io
+```
 
-    ```bash
-    erigon --externalcl
-    ```
+**Lighthouse**
+
+1. Start Erigon adding the `--externalcl` flag:
+
+```bash
+erigon --externalcl
+```
+
 2. Install and run Lighthouse by following the official guide: [https://lighthouse-book.sigmaprime.io/installation.html](https://lighthouse-book.sigmaprime.io/installation.html)
-3. Because Erigon needs a target head in order to sync, Lighthouse must be synced before Erigon can synchronize. The fastest way to synchronize Lighthouse is to use one of the many public checkpoint synchronization endpoints at [https://eth-clients.github.io/checkpoint-sync-endpoints](https://eth-clients.github.io/checkpoint-sync-endpoints).
-4. To communicate with Erigon, the `--execution-endpoint` must be specified as `<erigon address>:8551`, where `<erigon address>` is either `http://localhost` or the IP address of the device running Erigon.
-5.  Lighthouse must point to the [JWT secret](../../../fundamentals/jwt) automatically created by Erigon in the `--datadir` directory.
 
-    ```bash
-    lighthouse bn \
-    --network mainnet \
-    --execution-endpoint http://localhost:8551 \
-    --execution-jwt <your-datadir>/jwt.hex \
-    --checkpoint-sync-url https://mainnet.checkpoint.sigp.io
-    ```
+3. Because Erigon needs a target head in order to sync, Lighthouse must be synced before Erigon can synchronize. The fastest way to synchronize Lighthouse is to use one of the many public checkpoint synchronization endpoints at [https://eth-clients.github.io/checkpoint-sync-endpoints](https://eth-clients.github.io/checkpoint-sync-endpoints).
+
+4. To communicate with Erigon, the `--execution-endpoint` must be specified as `<erigon address>:8551`, where `<erigon address>` is either `http://localhost` or the IP address of the device running Erigon.
+
+5. Lighthouse must point to the [JWT secret](https://docs.erigon.tech/fundamentals/jwt) automatically created by Erigon in the `--datadir` directory.
+
+```bash
+lighthouse bn \
+--network mainnet \
+--execution-endpoint http://localhost:8551 \
+--execution-jwt <your-datadir>/jwt.hex \
+--checkpoint-sync-url https://mainnet.checkpoint.sigp.io
+```
 
 Check Erigon and your chosen CL logs to make sure that the Execution Layer (EL) and CL are communicating and that your node is syncing correctly.
 
@@ -1086,13 +1080,12 @@ Check Erigon and your chosen CL logs to make sure that the Execution Layer (EL) 
 # How to run a Gnosis Chain node
 URL: https://docs.erigon.tech/get-started/easy-nodes/how-to-run-a-gnosis-chain-node
 
-
 ## 1. Prerequisites Check
 
-1. Confirm your machine meets the necessary [Hardware Requirements](/get-started/hardware-requirements) based on your desired pruning mode.
+1. Confirm your machine meets the necessary [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements) based on your desired pruning mode.
 2. **Install Docker**:
-   * For Linux, install [Docker Engine](https://docs.docker.com/engine/install).
-   * For macOS or Windows, install [Docker Desktop](https://docs.docker.com/desktop/).
+  - For Linux, install [Docker Engine](https://docs.docker.com/engine/install).
+  - For macOS or Windows, install [Docker Desktop](https://docs.docker.com/desktop/).
 
 ## 2. Configure and Launch Erigon
 
@@ -1105,7 +1098,7 @@ Create a new file named `docker-compose.yml` in a directory where you want to ma
 ```yaml
 services:
   erigon:
-    image: erigontech/erigon:v{ERIGON_VERSION}
+    image: erigontech/erigon:v3.6.0
     container_name: erigon-node
     restart: always
     command:
@@ -1146,16 +1139,12 @@ Set `EXTERNAL_IP` before starting, either in a `.env` file next to `docker-compo
 echo "EXTERNAL_IP=$(curl -s https://api.ipify.org)" > .env
 ```
 
-or by exporting it in your shell. Forward the `30303`, `42069`, `4000` and `4001`
-ports on your router as well, otherwise peers still cannot reach you.
+or by exporting it in your shell. Forward the `30303`, `42069`, `4000` and `4001` ports on your router as well, otherwise peers still cannot reach you.
 
 :::warning
 ⚠️ **Action Required**: the volume path should be changed to suit your setup — replace `/path/to/erigon/data` with a valid, empty directory on your machine where you want Erigon to store its files.
 
-The container runs as UID/GID `1000`, so the directory must be writable by that
-user — `sudo chown -R 1000:1000 /path/to/erigon/data`. See
-[Permission denied inside Docker](/help-center/common-errors-and-solutions) if
-you hit a `permission denied` error on startup.
+The container runs as UID/GID `1000`, so the directory must be writable by that user — `sudo chown -R 1000:1000 /path/to/erigon/data`. See [Permission denied inside Docker](https://docs.erigon.tech/help-center/common-errors-and-solutions) if you hit a `permission denied` error on startup.
 :::
 
 ### **B. Launch the Node and Monitor Progress**
@@ -1166,9 +1155,7 @@ Open your terminal in the directory where you saved `docker-compose.yml`. To sta
 docker compose up
 ```
 
-That keeps the logs in the foreground, which is what you want the first time.
-Once you are happy with the configuration, start it detached so the node keeps
-running after you close the terminal:
+That keeps the logs in the foreground, which is what you want the first time. Once you are happy with the configuration, start it detached so the node keeps running after you close the terminal:
 
 ```bash
 docker compose up -d
@@ -1178,14 +1165,14 @@ and follow the logs when you need them with `docker compose logs -f`.
 
 ## Flag explanation
 
-* `--chain=gnosis` specifies to run on Gnosis Chain, use `--chain=chiado` for Chiado testnet
-* Add `--prune.mode=minimal` to run minimal [Pruning Mode](/fundamentals/pruning-modes) or `--prune.mode=archive` to run an archive node
-* `--datadir=/var/lib/erigon` has to name the same path as the container side of the volume mount. Without it Erigon writes to its default location inside the container instead of your mounted directory, and the data ends up in an anonymous Docker volume rather than where you pointed it
-* `--http.addr=0.0.0.0 --http.api=eth,web3,net,debug,trace,txpool` to use RPC and e.g. be able to connect your [web3 wallet](/fundamentals/web3-wallet). `0.0.0.0` is the address *inside* the container, which is what lets Docker forward to it at all; the `127.0.0.1:8545:8545` port mapping is what keeps it off your LAN. Change that mapping to `8545:8545` only if you intend to expose RPC to other machines
-* `--nat=extip:<your public IP>` and `--caplin.nat=extip:<your public IP>` advertise a reachable address so other nodes can dial you — the first for the execution layer, the second for Caplin. Without them, and without the forwarded ports, the node still syncs but only through connections it opens itself
-* `--torrent.download.rate` is deliberately not set above, because its default of `512mb` (megabytes per second) is already the maximum this recipe would ask for. During initial sync Erigon uses the full allowance, which is what you want on a dedicated machine. Add the flag only to **lower** the cap if you share the machine with other work (e.g. `--torrent.download.rate=128mb`), or set `--torrent.download.rate=Inf` to remove the limit entirely.
+- `--chain=gnosis` specifies to run on Gnosis Chain, use `--chain=chiado` for Chiado testnet
+- Add `--prune.mode=minimal` to run minimal [Pruning Mode](https://docs.erigon.tech/fundamentals/pruning-modes) or `--prune.mode=archive` to run an archive node
+- `--datadir=/var/lib/erigon` has to name the same path as the container side of the volume mount. Without it Erigon writes to its default location inside the container instead of your mounted directory, and the data ends up in an anonymous Docker volume rather than where you pointed it
+- `--http.addr=0.0.0.0 --http.api=eth,web3,net,debug,trace,txpool` to use RPC and e.g. be able to connect your [web3 wallet](https://docs.erigon.tech/fundamentals/web3-wallet). `0.0.0.0` is the address *inside* the container, which is what lets Docker forward to it at all; the `127.0.0.1:8545:8545` port mapping is what keeps it off your LAN. Change that mapping to `8545:8545` only if you intend to expose RPC to other machines
+- `--nat=extip:<your public IP>` and `--caplin.nat=extip:<your public IP>` advertise a reachable address so other nodes can dial you — the first for the execution layer, the second for Caplin. Without them, and without the forwarded ports, the node still syncs but only through connections it opens itself
+- `--torrent.download.rate` is deliberately not set above, because its default of `512mb` (megabytes per second) is already the maximum this recipe would ask for. During initial sync Erigon uses the full allowance, which is what you want on a dedicated machine. Add the flag only to **lower** the cap if you share the machine with other work (e.g. `--torrent.download.rate=128mb`), or set `--torrent.download.rate=Inf` to remove the limit entirely.
 
-When you get familiar with running Erigon from CLI you may also consider [staking](/staking/caplin) and/or run a Gnosis node with an [external Consensus Layer](/get-started/easy-nodes/how-to-run-a-gnosis-chain-node/gnosis-with-an-external-cl).
+When you get familiar with running Erigon from CLI you may also consider [staking](https://docs.erigon.tech/staking/caplin) and/or run a Gnosis node with an [external Consensus Layer](https://docs.erigon.tech/get-started/easy-nodes/how-to-run-a-gnosis-chain-node/gnosis-with-an-external-cl).
 
 :::tip
 Press `Ctrl+C` in your terminal to stop Erigon.
@@ -1193,15 +1180,12 @@ Press `Ctrl+C` in your terminal to stop Erigon.
 
 ## Host networking as an alternative
 
-Publishing each port individually is explicit, but Docker's NAT is also what
-makes `--nat=extip:...` necessary in the first place. Adding `network_mode:
-host` to the service instead gives the container the host's network stack
-directly, so peers see the host's own address and there is nothing to map:
+Publishing each port individually is explicit, but Docker's NAT is also what makes `--nat=extip:...` necessary in the first place. Adding `network_mode: host` to the service instead gives the container the host's network stack directly, so peers see the host's own address and there is nothing to map:
 
 ```yaml
 services:
   erigon:
-    image: erigontech/erigon:v{ERIGON_VERSION}
+    image: erigontech/erigon:v3.6.0
     network_mode: host
     command:
       - --chain=gnosis
@@ -1218,24 +1202,17 @@ services:
 
 Two things change with it, and both matter:
 
-* the `ports:` section is ignored — port publishing does not apply, so the
-  firewall on the host is what governs access;
-* every listener binds on the host, so anything you do not want exposed must be
-  bound explicitly to `127.0.0.1`. That is why RPC, the Engine API and the
-  internal gRPC address are pinned to loopback above. `--nat` and `--caplin.nat`
-  are no longer needed for the container, though you still need the p2p ports
-  forwarded on your router.
+- the `ports:` section is ignored — port publishing does not apply, so the firewall on the host is what governs access;
+- every listener binds on the host, so anything you do not want exposed must be bound explicitly to `127.0.0.1`. That is why RPC, the Engine API and the internal gRPC address are pinned to loopback above. `--nat` and `--caplin.nat` are no longer needed for the container, though you still need the p2p ports forwarded on your router.
 
-Host networking is Linux-only in practice; on Docker Desktop for macOS and
-Windows it does not behave the same way, so keep the published-ports form there.
+Host networking is Linux-only in practice; on Docker Desktop for macOS and Windows it does not behave the same way, so keep the published-ports form there.
 
-Additional flags can be added to [configure](/fundamentals/configuring-erigon/) Erigon with several options.
+Additional flags can be added to [configure](https://docs.erigon.tech/fundamentals/configuring-erigon) Erigon with several options.
 
 ---
 
 # Gnosis Chain with an external CL
 URL: https://docs.erigon.tech/get-started/easy-nodes/how-to-run-a-gnosis-chain-node/gnosis-with-an-external-cl
-
 
 Alternatively, you can also run a Gnosis Chain node as an Execution Layer (EL) and couple it with an external Consensus Layer (CL). Here is an example of configuration with **Lighthouse**.
 
@@ -1249,22 +1226,16 @@ erigon --chain=gnosis --externalcl
 
 If your CL client is on a different device, add the following flags:
 
-* `--authrpc.addr <this-host-LAN-IP>` — the Engine API listens on localhost by default, so it has to be widened for a remote CL. Read the warning below before reaching for `0.0.0.0`;
-* `--authrpc.vhosts <CL_host>` where `<CL_host>` is the source host or the appropriate hostname that your CL client is using.
+- `--authrpc.addr <this-host-LAN-IP>` — the Engine API listens on localhost by default, so it has to be widened for a remote CL. Read the warning below before reaching for `0.0.0.0`;
+- `--authrpc.vhosts <CL_host>` where `<CL_host>` is the source host or the appropriate hostname that your CL client is using.
 
 :::warning
-The Engine API drives block processing, so anything that can reach it and holds
-your JWT secret controls the node. Only widen it when the CL really is on
-another machine, and protect the endpoint when you do:
+The Engine API drives block processing, so anything that can reach it and holds your JWT secret controls the node. Only widen it when the CL really is on another machine, and protect the endpoint when you do:
 
-* prefer the specific interface — `--authrpc.addr <this-host-LAN-IP>` — over
-  `0.0.0.0`, which listens on every interface including any public one;
-* restrict port `8551` at the firewall to the CL host's address, and never
-  expose it to the internet;
-* treat `--authrpc.vhosts` as a `Host`-header check, not a network control: it
-  is not a substitute for a firewall rule;
-* keep `jwt.hex` readable only by the accounts that need it, and copy it to the
-  CL host over a private channel.
+- prefer the specific interface — `--authrpc.addr <this-host-LAN-IP>` — over `0.0.0.0`, which listens on every interface including any public one;
+- restrict port `8551` at the firewall to the CL host's address, and never expose it to the internet;
+- treat `--authrpc.vhosts` as a `Host`-header check, not a network control: it is not a substitute for a firewall rule;
+- keep `jwt.hex` readable only by the accounts that need it, and copy it to the CL host over a private channel.
 :::
 
 ### 2. Install Lighthouse
@@ -1274,12 +1245,7 @@ Install Lighthouse, following instructions at [https://lighthouse-book.sigmaprim
 The official pre-built binaries already support Gnosis Chain and Chiado, so no special build is required. You can confirm this with `lighthouse --help`, which lists `gnosis` and `chiado` among the accepted `--network` values.
 
 :::tip
-Track Lighthouse releases and keep it current, the same way you would Erigon.
-Beyond fixes and performance work, a consensus client carries the fork schedule
-it was built with: a version released before an upcoming hard fork may not
-follow the chain through it, which stalls your execution layer too. Watch the
-[Lighthouse releases](https://github.com/sigp/lighthouse/releases) page and
-upgrade before scheduled forks, not after.
+Track Lighthouse releases and keep it current, the same way you would Erigon. Beyond fixes and performance work, a consensus client carries the fork schedule it was built with: a version released before an upcoming hard fork may not follow the chain through it, which stalls your execution layer too. Watch the [Lighthouse releases](https://github.com/sigp/lighthouse/releases) page and upgrade before scheduled forks, not after.
 :::
 
 :::note
@@ -1301,29 +1267,29 @@ Because Erigon needs a target head in order to sync, Lighthouse must be synced b
 
 To communicate with Erigon, the execution endpoint must be specified as `<erigon address>:8551`, where `<erigon address>` is either `http://localhost` or the IP address of the device running Erigon.
 
-1.  Lighthouse must point to the [JWT secret](../../../fundamentals/jwt) automatically created by Erigon in the `--datadir` directory. In the following example the default data directory is used.
+1. Lighthouse must point to the [JWT secret](https://docs.erigon.tech/fundamentals/jwt) automatically created by Erigon in the `--datadir` directory. In the following example the default data directory is used.
 
-    ```bash
-    lighthouse bn \
-    --network gnosis \
-    --datadir=data \
-    --http \
-    --execution-endpoint http://localhost:8551 \
-    --execution-jwt /home/user/.local/share/erigon/jwt.hex \
-    --checkpoint-sync-url "https://checkpoint.gnosischain.com"
-    ```
+```bash
+lighthouse bn \
+--network gnosis \
+--datadir=data \
+--http \
+--execution-endpoint http://localhost:8551 \
+--execution-jwt /home/user/.local/share/erigon/jwt.hex \
+--checkpoint-sync-url "https://checkpoint.gnosischain.com"
+```
 
-    Here is an example of Lighthouse running the Chiado testnet:
+Here is an example of Lighthouse running the Chiado testnet:
 
-    ```bash
-    lighthouse bn \
-    --network chiado \
-    --datadir=data \
-    --http \
-    --execution-endpoint http://localhost:8551 \
-    --execution-jwt /home/user/.local/share/erigon/jwt.hex \
-    --checkpoint-sync-url "https://checkpoint.chiadochain.net"
-    ```
+```bash
+lighthouse bn \
+--network chiado \
+--datadir=data \
+--http \
+--execution-endpoint http://localhost:8551 \
+--execution-jwt /home/user/.local/share/erigon/jwt.hex \
+--checkpoint-sync-url "https://checkpoint.chiadochain.net"
+```
 
 Check the Erigon and Lighthouse logs to make sure that the EL and CL are communicating and that your node is syncing correctly.
 
@@ -1333,8 +1299,6 @@ Check the Erigon and Lighthouse logs to make sure that the EL and CL are communi
 URL: https://docs.erigon.tech/fundamentals
 
 Core concepts and day-to-day operations for running a healthy Erigon node.
-
-## Sections
 
 - [Basic Usage](https://docs.erigon.tech/fundamentals/basic-usage): Command-line flags, common arguments, and first steps running the Erigon binary.
 - [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes): Full, minimal, and archive sync explained — choose the right mode for your use case.
@@ -1350,8 +1314,9 @@ Core concepts and day-to-day operations for running a healthy Erigon node.
 # Basic Usage
 URL: https://docs.erigon.tech/fundamentals/basic-usage
 
-
 Erigon is mainly operated through the command line. The commands may vary based on your installation method.
+
+**Pre-Built Binaries**
 
 Open your terminal and simply start Erigon with the command:
 
@@ -1359,10 +1324,15 @@ Open your terminal and simply start Erigon with the command:
 erigon [options]
 ```
 
-* You can use Docker Compose like in this [example](/get-started/easy-nodes/how-to-run-an-ethereum-node#a-create-the-configuration-file)
-*   Alternatively you can use the Docker syntax, for example:
+**Docker**
 
-    `docker run -it erigontech/erigon:v{ERIGON_VERSION} [options]`
+- You can use Docker Compose like in this [example](https://docs.erigon.tech/get-started/easy-nodes/how-to-run-an-ethereum-node#a-create-the-configuration-file)
+
+- Alternatively you can use the Docker syntax, for example:
+
+`docker run -it erigontech/erigon:v3.6.0 [options]`
+
+**Built from Source**
 
 Open your terminal and move to the directory where you installed Erigon
 
@@ -1375,6 +1345,8 @@ You can then start Erigon with the below command:
 ```shell
 ./build/bin/erigon [options]
 ```
+
+**Windows**
 
 To run Erigon after a native compilation, enter the following command in your Command Prompt or PowerShell:
 
@@ -1398,7 +1370,7 @@ The all-in-one client is the preferred option for most users:
 
 This CLI command allows you to run an Ethereum **full node** where every process is integrated and no special configuration is needed.
 
-The default Consensus Layer utilized is [Caplin](caplin), the Erigon flagship embedded CL.
+The default Consensus Layer utilized is [Caplin](https://docs.erigon.tech/fundamentals/caplin), the Erigon flagship embedded CL.
 
 ## Example of configuration
 
@@ -1420,22 +1392,27 @@ To run Erigon with RPC Daemon, TxPool, and other components in a single process 
 
 ### Flags of Interest
 
-*   Default data directory is `/home/usr/.local/share/erigon`. If you want to store Erigon files in a non-default location, use the flag:
+- Default data directory is `/home/usr/.local/share/erigon`. If you want to store Erigon files in a non-default location, use the flag:
 
-    ```bash
-    --datadir=/desired/path/to/datadir
-    ```
-* The `--chain=mainnet` flag is set by default for Erigon to sync with the Ethereum mainnet. To explore other network options, check the [Supported Networks](supported-networks) section. For quick testing, consider selecting a testnet.
-* `--log.dir.path` dictates where [logs](logs) will be output - useful for sending reports to the Erigon team when issues occur.
-* Based on the [pruning mode](pruning-modes) you want to run you can add `--prune.mode=archive` to run an archive node, `--prune.mode=full` for a full node (default value) or `--prune.mode=minimal` for a minimal node.
-* `--http.addr=0.0.0.0 --http.api=eth,web3,net,debug,trace,txpool` to use [RPC Service](../interacting-with-erigon/) and e.g. be able to connect your [wallet](web3-wallet).
-* `--torrent.download.rate` sets the torrent download rate cap. The default is `512mb` (megabytes per second). During initial sync Erigon will use the full allowance — on a dedicated machine this is fine, but if you share the machine with other work you may want to lower it (e.g. `--torrent.download.rate=128mb`). Set `--torrent.download.rate=Inf` to remove the limit entirely.
+```bash
+--datadir=/desired/path/to/datadir
+```
+
+- The `--chain=mainnet` flag is set by default for Erigon to sync with the Ethereum mainnet. To explore other network options, check the [Supported Networks](https://docs.erigon.tech/fundamentals/supported-networks) section. For quick testing, consider selecting a testnet.
+
+- `--log.dir.path` dictates where [logs](https://docs.erigon.tech/fundamentals/logs) will be output - useful for sending reports to the Erigon team when issues occur.
+
+- Based on the [pruning mode](https://docs.erigon.tech/fundamentals/pruning-modes) you want to run you can add `--prune.mode=archive` to run an archive node, `--prune.mode=full` for a full node (default value) or `--prune.mode=minimal` for a minimal node.
+
+- `--http.addr=0.0.0.0 --http.api=eth,web3,net,debug,trace,txpool` to use [RPC Service](https://docs.erigon.tech/interacting-with-erigon) and e.g. be able to connect your [wallet](https://docs.erigon.tech/fundamentals/web3-wallet).
+
+- `--torrent.download.rate` sets the torrent download rate cap. The default is `512mb` (megabytes per second). During initial sync Erigon will use the full allowance — on a dedicated machine this is fine, but if you share the machine with other work you may want to lower it (e.g. `--torrent.download.rate=128mb`). Set `--torrent.download.rate=Inf` to remove the limit entirely.
 
 To stop the Erigon node you can use the `CTRL+C` command.
 
 Additional flags can be added to configure the node with several options.
 
-- [configuring-erigon](configuring-erigon/)
+- [configuring-erigon](https://docs.erigon.tech/fundamentals/configuring-erigon)
 
 ## How do I know it's syncing?
 
@@ -1443,7 +1420,7 @@ Once your node is running, there are two ways to confirm it is making progress a
 
 ### 1. Read the live log line
 
-Erigon's logs are organized by [staged sync](logs#staged-synchronization-architecture). Every log line emitted by the sync engine is prefixed with the current stage and its position in the pipeline. For example:
+Erigon's logs are organized by [staged sync](https://docs.erigon.tech/fundamentals/logs#staged-synchronization-architecture). Every log line emitted by the sync engine is prefixed with the current stage and its position in the pipeline. For example:
 
 ```text
 INFO[02-20|15:00:00.123] [4/8 Bodies] Downloading block bodies   block=18234567 ...
@@ -1451,7 +1428,7 @@ INFO[02-20|15:00:00.123] [4/8 Bodies] Downloading block bodies   block=18234567 
 
 The prefix `[4/8 Bodies]` means: *"stage 4 of 8, currently in the Bodies stage"*. As stages complete, the prefix advances (`[5/8 Senders]`, `[6/8 Execution]`, …) until you reach `[8/8 Finish]`, at which point the node is at the chain tip.
 
-The full ordered stage list is in [Logs → Stage Definitions](logs#stage-definitions).
+The full ordered stage list is in [Logs → Stage Definitions](https://docs.erigon.tech/fundamentals/logs#stage-definitions).
 
 ### 2. Query the JSON-RPC
 
@@ -1463,11 +1440,11 @@ curl -s -X POST -H "Content-Type: application/json" \
   http://localhost:8545
 ```
 
-* While syncing, the result is an object with `currentBlock`, `highestBlock`, and a `stages` array (one entry per stage, with `{stage_name, block_number}`). Subtract `currentBlock` from `highestBlock` to see how many blocks remain; the `stages` array gives you the same per-stage progress as the log prefix above. (`startingBlock` is also returned but is hardcoded to `"0x0"` and carries no meaningful info.)
-* Once fully synced, the result is simply `false`.
+- While syncing, the result is an object with `currentBlock`, `highestBlock`, and a `stages` array (one entry per stage, with `{stage_name, block_number}`). Subtract `currentBlock` from `highestBlock` to see how many blocks remain; the `stages` array gives you the same per-stage progress as the log prefix above. (`startingBlock` is also returned but is hardcoded to `"0x0"` and carries no meaningful info.)
+- Once fully synced, the result is simply `false`.
 
 :::tip
-For a quick reference on monitoring sync progress (including using AI assistants via MCP), see the [Frequently Asked Questions](/help-center/frequently-asked-questions-faqs).
+For a quick reference on monitoring sync progress (including using AI assistants via MCP), see the [Frequently Asked Questions](https://docs.erigon.tech/help-center/frequently-asked-questions-faqs).
 :::
 
 ## Help
@@ -1513,7 +1490,6 @@ This command will display a list of convenience commands available in the Makefi
  hive:                              run hive test suite locally using docker e.g. OUTPUT_DIR=~/results/hive SIM=ethereum/engine make hive
  automated-tests                    run automated tests (BUILD_ERIGON=0 to prevent erigon build with local image tag)
  help:                              print commands help
-
 ```
 
 For example, from your Erigon 3 installation directory, run:
@@ -1528,7 +1504,6 @@ This will execute the clean target in the Makefile, which cleans the `go cache`,
 
 # Architecture
 URL: https://docs.erigon.tech/fundamentals/architecture
-
 
 Erigon is an Ethereum execution-layer client designed around three goals: **low disk footprint**, **predictable performance**, and **operational simplicity**. This page explains how those goals shape its internal design so you know what is happening when you run the binary.
 
@@ -1563,7 +1538,7 @@ flowchart TB
     class Datadir storage
 ```
 
-Every box above is a Go package that runs **inside the `erigon` process by default**. The same binary can also be split into independent processes — see [Modular processes](#modular-processes).
+Every box above is a Go package that runs **inside the `erigon` process by default**. The same binary can also be split into independent processes — see [Modular processes](https://docs.erigon.tech/fundamentals/architecture#modular-processes).
 
 ## Staged sync
 
@@ -1581,9 +1556,7 @@ A simplified pipeline:
 6. Finalization → update the canonical chain
 ```
 
-This is the order of Erigon 3's default stage list. There is no separate
-`Commitment` stage — trie/state-root computation runs *inside* Execution (see
-below).
+This is the order of Erigon 3's default stage list. There is no separate `Commitment` stage — trie/state-root computation runs *inside* Execution (see below).
 
 Two consequences:
 
@@ -1603,14 +1576,14 @@ Use the all-in-one binary by default. Split out a service when you have a concre
 - **Replacement** — substitute Erigon's TxPool or Sentry with your own implementation.
 - **Security** — keep the p2p surface (Sentry) on a separate host from the JSON-RPC surface (RPC Daemon).
 
-See the [Modules](modules) section for per-component documentation, and the repository's [docker-compose.yml](https://github.com/erigontech/erigon/blob/main/docker-compose.yml) for a worked split-process example.
+See the [Modules](https://docs.erigon.tech/fundamentals/modules) section for per-component documentation, and the repository's [docker-compose.yml](https://github.com/erigontech/erigon/blob/main/docker-compose.yml) for a worked split-process example.
 
 ## Storage model
 
 Erigon stores everything under a single **datadir**. Two kinds of files live there:
 
 | Kind | Path | Role | Mutable? |
-|------|------|------|----------|
+| --- | --- | --- | --- |
 | Active state | `chaindata/` | Recent state and recent blocks, served from MDBX | Yes |
 | Historical data | `snapshots/` | Older blocks, history, indices — distributed as immutable `.seg` files | No |
 
@@ -1619,7 +1592,7 @@ This split is what enables Erigon's small disk footprint relative to other archi
 - **`chaindata/` is small (~22 GB on Ethereum mainnet, rarely more than 25 GB)** because it only holds latest state and recently-updated values.
 - **`snapshots/` is large but content-addressed.** Once a `.seg` file is finalised it is the *same file* on every Erigon node in the world — meaning it can be distributed via BitTorrent and verified by hash. There is no rewrite-amplification penalty for keeping history.
 
-For the exact directory layout, file sizes on mainnet, and how to split storage across fast/slow disks, see [Database](database) and [Optimizing Storage](optimizing-storage).
+For the exact directory layout, file sizes on mainnet, and how to split storage across fast/slow disks, see [Database](https://docs.erigon.tech/fundamentals/database) and [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage).
 
 ## Embedded consensus (Caplin)
 
@@ -1627,7 +1600,7 @@ Erigon ships with **Caplin**, a built-in consensus-layer client. Caplin runs emb
 
 If you prefer to run an external CL (Lighthouse, Prysm, Teku, Nimbus), pass `--externalcl` and connect via the standard Engine API. The Engine-API path is identical to what Geth, Besu, or Reth exposes.
 
-See [Caplin](caplin) for full details.
+See [Caplin](https://docs.erigon.tech/fundamentals/caplin) for full details.
 
 ## Flat key-value state
 
@@ -1643,30 +1616,29 @@ This is the single largest reason Erigon's RPC performance stays flat under load
 Erigon 3 has one sync pipeline. The user-facing choice is *what to retain after sync*, controlled by `--prune.mode`:
 
 | Mode | Retained | Use case |
-|---|---|---|
+| --- | --- | --- |
 | `archive` | Entire state history + all blocks | Indexers, block explorers, deep historical queries |
 | `full` (default) | Latest state + a rolling window of recent blocks (the default prune distance, ~262k blocks) | Most users, dApps, validators |
 | `blocks` | All blocks, but no state history | Full block/receipt history without archive-size state |
 | `minimal` | Latest state only (shortest block window) | Solo stakers, constrained hardware |
 
-See [Pruning Modes](pruning-modes) for the full comparison.
+See [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes) for the full comparison.
 
 ## Where to go next
 
-- [Database](database) — datadir layout, MDBX internals, mainnet sizing
-- [Modules](modules) — running RPC Daemon, TxPool, Sentry, Downloader as separate processes
-- [Pruning Modes](pruning-modes) — choosing what history to keep
-- [Optimizing Storage](optimizing-storage) — splitting datadir across fast and slow disks
+- [Database](https://docs.erigon.tech/fundamentals/database) — datadir layout, MDBX internals, mainnet sizing
+- [Modules](https://docs.erigon.tech/fundamentals/modules) — running RPC Daemon, TxPool, Sentry, Downloader as separate processes
+- [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes) — choosing what history to keep
+- [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage) — splitting datadir across fast and slow disks
 
 ---
 
 # Database
 URL: https://docs.erigon.tech/fundamentals/database
 
-
 Erigon stores all chain data under a single **datadir**. Understanding what lives where is useful when you size hardware, debug disk-usage issues, or split storage across fast and slow drives.
 
-This page covers the *what* and *where* of Erigon's data. For the *why* — flat KV state, immutable snapshots — see [Architecture](architecture). For operational tuning (symlinks, multi-disk layout), see [Optimizing Storage](optimizing-storage).
+This page covers the *what* and *where* of Erigon's data. For the *why* — flat KV state, immutable snapshots — see [Architecture](https://docs.erigon.tech/fundamentals/architecture). For operational tuning (symlinks, multi-disk layout), see [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage).
 
 ## The datadir at a glance
 
@@ -1707,7 +1679,7 @@ Once a snapshot file is finalised it is the same bytes on every Erigon node in t
 Snapshots are organised into several subdirectories. The main ones are:
 
 | Directory | What it holds | Access pattern |
-|---|---|---|
+| --- | --- | --- |
 | `snapshots/domain/` | Latest value per (domain, key). 6 domains: the 4 state domains (`account`, `storage`, `code`, `commitment`) plus 2 receipt domains (`receipt`, `rcache`) | Sequential + point lookup |
 | `snapshots/history/` | Every historical value per (domain, key, txn) | Point lookup keyed by transaction |
 | `snapshots/idx/` | Inverted indices over history — answers "which transactions touched key X?" | Search / filter / set intersection |
@@ -1717,10 +1689,7 @@ Snapshots are organised into several subdirectories. The main ones are:
 
 - You can replay a single historical transaction without re-executing its block.
 - If an account changes V1 → V2 → V1 within one block, `debug_getModifiedAccountsByNumber` correctly returns it.
-- Erigon stores compact per-transaction receipt *metadata* — cumulative gas used, blob gas used, log index — in a
-  **required** receipt domain. Full receipts (with logs) live in a separate cache domain that is **off by default** in
-  every prune mode (opt in with `--prune.include-receipts`). When a full receipt isn't cached, it is reconstructed on
-  demand, re-deriving logs by re-execution.
+- Erigon stores compact per-transaction receipt *metadata* — cumulative gas used, blob gas used, log index — in a **required** receipt domain. Full receipts (with logs) live in a separate cache domain that is **off by default** in every prune mode (opt in with `--prune.include-receipts`). When a full receipt isn't cached, it is reconstructed on demand, re-deriving logs by re-execution.
 
 ## What does it cost on disk?
 
@@ -1740,7 +1709,7 @@ Block segments — headers, bodies and transactions — sit directly in `snapsho
 
 Data that is off by default is excluded above. On the same mainnet node it would add 441 GB for the receipts cache (`--prune.include-receipts`), 4.4 TB for commitment history (`--prune.include-commitment-history`), and 2.5 TB for the Caplin block, blob and state archive.
 
-Each column is one node, so totals differ slightly from the headline figures on [Hardware Requirements](../get-started/hardware-requirements), which are measured on freshly synced nodes.
+Each column is one node, so totals differ slightly from the headline figures on [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements), which are measured on freshly synced nodes.
 
 ## Why `chaindata/` stays so small
 
@@ -1759,14 +1728,14 @@ Deleting `chaindata/` is **recoverable but not free**: it discards the latest mu
 - **`--batchSize`** — size of the Execution stage's in-memory buffer before it is flushed to MDBX. Default: `512M`. Raising it (for example `--batchSize 1G` or higher) can speed up execution-heavy sync at the cost of more RAM.
 - **`--db.size.limit`** — caps the MDBX file size. Useful when running multiple Erigon instances on one disk to prevent one from starving the others.
 - **`--db.read.concurrency`** — maximum number of concurrent open MDBX read transactions (the read-tx semaphore). Raise it for nodes serving heavy parallel RPC (for example a high-throughput RPC daemon against the same datadir). Lowering it does not reduce read concurrency: a value below the parallel-execution worker count would deadlock, since each worker holds a long-lived read transaction, so it is silently raised to the worker count. Lower `--exec.workers` instead.
-- **Symlinks for tiered storage.** Place `chaindata/` and `snapshots/domain/` on fast NVMe, leave `snapshots/idx/` and `snapshots/history/` on cheaper SATA. See [Optimizing Storage](optimizing-storage) for the recipe.
+- **Symlinks for tiered storage.** Place `chaindata/` and `snapshots/domain/` on fast NVMe, leave `snapshots/idx/` and `snapshots/history/` on cheaper SATA. See [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage) for the recipe.
 
 ## Safe-to-delete subdirectories
 
 If you need to reclaim space without resyncing from scratch:
 
 | Directory | Effect of deletion |
-|---|---|
+| --- | --- |
 | `txpool/` | Pending transactions lost; pool refills from peers within minutes |
 | `nodes/` | Peer cache lost; reconnects on restart |
 | `temp/` | Cleaned automatically at startup anyway |
@@ -1775,49 +1744,44 @@ If you need to reclaim space without resyncing from scratch:
 
 ## Where to go next
 
-- [Architecture](architecture) — how this storage model fits into staged sync and the flat-KV state design
-- [Optimizing Storage](optimizing-storage) — concrete recipes for splitting the datadir across multiple disks
-- [Hardware Requirements](../get-started/hardware-requirements) — disk-size numbers for each `--prune.mode`
-- [Pruning Modes](pruning-modes) — choosing what history to keep
+- [Architecture](https://docs.erigon.tech/fundamentals/architecture) — how this storage model fits into staged sync and the flat-KV state design
+- [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage) — concrete recipes for splitting the datadir across multiple disks
+- [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements) — disk-size numbers for each `--prune.mode`
+- [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes) — choosing what history to keep
 
 ---
 
 # Pruning Modes
 URL: https://docs.erigon.tech/fundamentals/pruning-modes
 
-
 Erigon 3 supports four pruning modes that control how much chain history your node retains. Choose based on your use case — most users should run a Full Node.
 
-| **Pruning Mode**                                                        | **Flag**               | **Data Retained**                                                                                   | **Primary Use Case**                                                                     |
-| --------------------------------------------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| Full Node(Default) | `--prune.mode=full`    | State and block data within the EIP-8252 window (last 262,144 blocks, ~36 days)                     | General users, DApp interaction, fastest sync.                                           |
-| [Minimal Node](#minimal-node)                         | `--prune.mode=minimal` | State and block data within the last 100,000 blocks (~14 days)                                      | Solo staking, users with constrained hardware, maximum privacy for sending transactions. |
-| [Historical Blocks](#blocks-node)                                     | `--prune.mode=blocks`  | All block/transaction history, plus state within the EIP-8252 window                                | Users needing historical block data for research or indexing.                            |
-| [Archive Node](#archive-node)                            | `--prune.mode=archive` | All historical state and all blocks                                                                 | Developers, researchers, and RPC providers requiring full historical state access.       |
+| **Pruning Mode** | **Flag** | **Data Retained** | **Primary Use Case** |
+| --- | --- | --- | --- |
+| [Full Node](https://docs.erigon.tech/fundamentals/pruning-modes#full-node) (Default) | `--prune.mode=full` | State and block data within the EIP-8252 window (last 262,144 blocks, ~36 days) | General users, DApp interaction, fastest sync. |
+| [Minimal Node](https://docs.erigon.tech/fundamentals/pruning-modes#minimal-node) | `--prune.mode=minimal` | State and block data within the last 100,000 blocks (~14 days) | Solo staking, users with constrained hardware, maximum privacy for sending transactions. |
+| [Historical Blocks](https://docs.erigon.tech/fundamentals/pruning-modes#blocks-node) | `--prune.mode=blocks` | All block/transaction history, plus state within the EIP-8252 window | Users needing historical block data for research or indexing. |
+| [Archive Node](https://docs.erigon.tech/fundamentals/pruning-modes#archive-node) | `--prune.mode=archive` | All historical state and all blocks | Developers, researchers, and RPC providers requiring full historical state access. |
 
-By **default**, Erigon run as a [full node](#full-node), to change its behavior use the flag `--prune.mode <value>`.
+By **default**, Erigon run as a [full node](https://docs.erigon.tech/fundamentals/pruning-modes#full-node), to change its behavior use the flag `--prune.mode <value>`.
 
 In order to switch type of node, you must first delete the `/chaindata` folder in the chosen `--datadir` directory and re-sync from scratch. Pruning is not reversible — data a mode has already discarded can only be recovered by re-syncing — so pick the mode that covers the history you need before you start.
 
 :::tip
 **Persisting receipts**, which are pre-calculated receipts, increase the requests-per-second (RPS) and improve the latency and throughput of all receipts and logs-related RPC calls.
 
-As of v3.6 they are disabled by default in every pruning mode (previously they were enabled by default for all modes
-except Archive); enable them with the flag `--prune.include-receipts` (the former `--persist.receipts` still works as an
-alias). Without them, receipts and logs are re-derived on demand from state history, so the related RPC calls keep
-working within the node's state-history window, just with higher latency. On a Historical Blocks node, persisted
-receipts additionally extend receipts and logs availability from the state-history window back to genesis.
+As of v3.6 they are disabled by default in every pruning mode (previously they were enabled by default for all modes except Archive); enable them with the flag `--prune.include-receipts` (the former `--persist.receipts` still works as an alias). Without them, receipts and logs are re-derived on demand from state history, so the related RPC calls keep working within the node's state-history window, just with higher latency. On a Historical Blocks node, persisted receipts additionally extend receipts and logs availability from the state-history window back to genesis.
 :::
 
 ## Archive node
 
-Ethereum's state refers to account balances, contracts, and consensus data. Archive nodes retain all historical state and require more **disk space.** However, Erigon 3 has consistently reduced the [disk space](../get-started/hardware-requirements.mdx#disk-size-and-ram-requirements) requirements for running an archive node, rendering it more affordable and accessible to a broader range of users.
+Ethereum's state refers to account balances, contracts, and consensus data. Archive nodes retain all historical state and require more **disk space.** However, Erigon 3 has consistently reduced the [disk space](https://docs.erigon.tech/get-started/hardware-requirements#disk-size-and-ram-requirements) requirements for running an archive node, rendering it more affordable and accessible to a broader range of users.
 
 Archive are ideal for extensive research on the blockchain, developers, researchers, and RPC providers requiring a complete history of the state.
 
 ## Full node
 
-The default configuration in Erigon 3 is a Full Node. This setup is designed to offer significantly **faster sync times and reduced resource consumption** for daily operations compared to other clients. It maintains state and block data within the **EIP-8252 reorg-retention window** — the last 262,144 blocks (~36.4 days), the inactivity-leak-bounded non-finality window across which an execution-layer client must be able to reconstruct state to handle any reorg without external sync. Older blocks, receipts, and state history are pruned, so a Full Node cannot serve queries against them. For block and transaction history reaching further back, run a [Blocks Node](#blocks-node); receipts need their own flags on top, as that section explains. See [EIP-8252](https://github.com/ethereum/EIPs/pull/11601) for the rationale behind the constant.
+The default configuration in Erigon 3 is a Full Node. This setup is designed to offer significantly **faster sync times and reduced resource consumption** for daily operations compared to other clients. It maintains state and block data within the **EIP-8252 reorg-retention window** — the last 262,144 blocks (~36.4 days), the inactivity-leak-bounded non-finality window across which an execution-layer client must be able to reconstruct state to handle any reorg without external sync. Older blocks, receipts, and state history are pruned, so a Full Node cannot serve queries against them. For block and transaction history reaching further back, run a [Blocks Node](https://docs.erigon.tech/fundamentals/pruning-modes#blocks-node); receipts need their own flags on top, as that section explains. See [EIP-8252](https://github.com/ethereum/EIPs/pull/11601) for the rationale behind the constant.
 
 To keep every post-merge block instead of only the window — pruning pre-merge block data alone — set `--prune.distance.blocks=keep-post-merge`. Decide before the first start: pruning is not reversible, and block data already discarded comes back only by re-syncing.
 
@@ -1829,21 +1793,12 @@ The Minimal Node configuration (`--prune.mode=minimal`) is the smallest possible
 
 ## Blocks node
 
-The Blocks Node configuration (`--prune.mode=blocks`) keeps the **full block and transaction history** — every block
-back to genesis — while pruning **state history**. It retains state only within the EIP-8252 window (the last 262,144
-blocks), the same state-retention as a Full Node, but unlike a Full Node it never prunes older blocks. This suits users
-who need complete historical **block and transaction data** — for research, indexing, or block explorers — without
-paying the disk cost of an archive node's full historical **state**. For full-range **receipts and logs**
-(`eth_getLogs` / `eth_getBlockReceipts` back to genesis), add
-`--prune.include-receipts --prune.receipts.distance=keep-all`; with `--prune.include-receipts` alone the receipt cache
-follows the state-history window (the last 262,144 blocks), and without it receipts are re-derived from state history
-within that same window.
+The Blocks Node configuration (`--prune.mode=blocks`) keeps the **full block and transaction history** — every block back to genesis — while pruning **state history**. It retains state only within the EIP-8252 window (the last 262,144 blocks), the same state-retention as a Full Node, but unlike a Full Node it never prunes older blocks. This suits users who need complete historical **block and transaction data** — for research, indexing, or block explorers — without paying the disk cost of an archive node's full historical **state**. For full-range **receipts and logs** (`eth_getLogs` / `eth_getBlockReceipts` back to genesis), add `--prune.include-receipts --prune.receipts.distance=keep-all`; with `--prune.include-receipts` alone the receipt cache follows the state-history window (the last 262,144 blocks), and without it receipts are re-derived from state history within that same window.
 
 ---
 
 # Snapshots Management
 URL: https://docs.erigon.tech/fundamentals/snapshots-management
-
 
 Erigon stores the majority of its chain data in **snapshot files** (`.seg` segments and associated index files). These immutable, compressed files cover headers, bodies, transactions, and state history. Because snapshots can occupy hundreds of gigabytes, understanding what is on disk — and how much space each category consumes — is essential for capacity planning and node maintenance.
 
@@ -1860,7 +1815,7 @@ erigon seg du [--datadir <path>] [--json] [-v | --verbose]
 ### Flags
 
 | Flag | Description |
-|------|-------------|
+| --- | --- |
 | `--datadir <path>` | Path to the Erigon data directory. Defaults to Erigon's standard data directory (`paths.DefaultDataDir()`, OS-specific) when omitted. `seg du` has no `--chain` flag, so this default is chain-agnostic. |
 | `--json` | Output results as JSON instead of human-readable text. Useful for scripting or dashboards. |
 | `-v`, `--verbose` | Show a per-domain / per-type subcategory breakdown within each category. |
@@ -1903,7 +1858,7 @@ The estimator only sums files already on disk, so the **archive** row always equ
 The category labels below are exactly what the command prints.
 
 | Category | Contents |
-|----------|----------|
+| --- | --- |
 | `domains` | Current-state domain files (latest accounts, storage, code, commitment). Never pruned, so typically the largest category on pruned (full / minimal) nodes; on an archive node, `block segments` dominate. |
 | `block segments` | Headers, bodies, and transactions (`.seg` + index files) directly under `snapshots/`. |
 | `history` | State-history snapshots for accounts, storage, code. |
@@ -1950,15 +1905,11 @@ The JSON schema matches the `duResult` struct: top-level fields `chain`, `config
 Run `seg du` while the node is **stopped**. If Erigon is running and holds the database lock, the command falls back to `unknown` for the chain name and omits the configured mode — it will still scan snapshot files and produce size figures, but mode information will be incomplete.
 :::
 
----
-
 ## Snapshot Types (Pruning Modes)
 
-The snapshot set on disk reflects the node's **pruning mode**, and `seg du` automatically detects which mode your current files correspond to. For what each mode retains and how to choose one, see [Pruning Modes](pruning-modes).
+The snapshot set on disk reflects the node's **pruning mode**, and `seg du` automatically detects which mode your current files correspond to. For what each mode retains and how to choose one, see [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes).
 
 The `seg du` estimates table shows the projected disk footprint for each mode given the files currently present, so you can evaluate a mode change before committing to a resync.
-
----
 
 ## Upgrading Snapshots in v3.5
 
@@ -1966,13 +1917,13 @@ The `seg du` estimates table shows the projected disk footprint for each mode gi
 
 v3.5 retargets the **Full** and **Blocks** pruning modes to the EIP-8252 reorg-retention window (262,144 blocks, ~36 days), up from the previous 100,000-block window. This changes **which snapshot files are present on disk** after upgrading — most notably, full nodes prune older block segments down to the window, freeing space. Existing datadirs migrate automatically on first start.
 
-Decide before that first start if you need to keep more than the window: pruning is not reversible, and block data already discarded comes back only by re-syncing. To retain every post-merge block under Full mode, pass `--prune.distance.blocks=18446744073709551615` — v3.5 takes this option as a number; the readable `keep-post-merge` alias only exists from v3.6. `--prune.mode=blocks` keeps every block back to genesis. See [Pruning Modes](pruning-modes) for what each mode keeps.
+Decide before that first start if you need to keep more than the window: pruning is not reversible, and block data already discarded comes back only by re-syncing. To retain every post-merge block under Full mode, pass `--prune.distance.blocks=18446744073709551615` — v3.5 takes this option as a number; the readable `keep-post-merge` alias only exists from v3.6. `--prune.mode=blocks` keeps every block back to genesis. See [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes) for what each mode keeps.
 
 After the first prune pass, run `seg du` to inspect the resulting on-disk breakdown.
 
 ### Manual snapshot operations
 
-To migrate snapshots to the latest format, reset them for maximum performance after a major upgrade, or downgrade to an older snapshot format, follow the step-by-step snapshot upgrade and downgrade instructions in the [Upgrading guide](../get-started/installation/upgrading). Those commands are subcommands of `erigon snapshots` (e.g. `erigon snapshots update-to-new-ver-format --datadir /your/datadir`).
+To migrate snapshots to the latest format, reset them for maximum performance after a major upgrade, or downgrade to an older snapshot format, follow the step-by-step snapshot upgrade and downgrade instructions in the [Upgrading guide](https://docs.erigon.tech/get-started/installation/upgrading). Those commands are subcommands of `erigon snapshots` (e.g. `erigon snapshots update-to-new-ver-format --datadir /your/datadir`).
 
 :::warning
 Always **back up your `--datadir`** before running snapshot reset, upgrade, or downgrade commands.
@@ -1982,7 +1933,6 @@ Always **back up your `--datadir`** before running snapshot reset, upgrade, or d
 
 # Caplin
 URL: https://docs.erigon.tech/fundamentals/caplin
-
 
 Caplin, the innovative Erigon's embedded Consensus Layer, significantly enhances the performance, efficiency, and reliability of Ethereum infrastructure. Its groundbreaking design minimizes disk usage, facilitating faster transaction processing and bolstering network security. By integrating the consensus layer directly into the EVM-node, Caplin eliminates the need for separate disk storage, thereby reducing system complexity and enhancing overall efficiency.
 
@@ -1996,13 +1946,13 @@ Caplin is enabled by default, at which point an external consensus layer is no l
 
 Caplin also has an archive mode for historical states, blocks, and blobs. These can be enabled with the following flags:
 
-* `--caplin.states-archive`: Enables the storage and retrieval of historical state data, allowing access to past states of the blockchain for debugging, analytics, or other use cases.
-* `--caplin.blocks-archive`: Enables the storage of historical block data, making it possible to query or analyze full block history.
-* `--caplin.blobs-archive`: Enables the storage of historical blobs, ensuring access to additional off-chain data that might be required for specific applications.
+- `--caplin.states-archive`: Enables the storage and retrieval of historical state data, allowing access to past states of the blockchain for debugging, analytics, or other use cases.
+- `--caplin.blocks-archive`: Enables the storage of historical block data, making it possible to query or analyze full block history.
+- `--caplin.blobs-archive`: Enables the storage of historical blobs, ensuring access to additional off-chain data that might be required for specific applications.
 
 In addition, Caplin can backfill recent blobs for an op-node or other uses with the new flag:
 
-* `--caplin.blobs-immediate-backfill`: Backfills the last 18 days' worth of blobs to quickly populate historical blob data for operational needs or analytics.
+- `--caplin.blobs-immediate-backfill`: Backfills the last 18 days' worth of blobs to quickly populate historical blob data for operational needs or analytics.
 
 With state archival enabled, Caplin's indexing database (`<datadir>/caplin/indexing`) is pruned automatically: state rows already frozen into snapshots are deleted on the antiquary cadence, so the database holds only the un-frozen tail. The `mdbx.dat` file does not shrink when rows are pruned — freed pages are reused, bounding future growth. Set `CAPLIN_STATE_PRUNE_DISABLE=true` to turn pruning off.
 
@@ -2010,16 +1960,16 @@ With state archival enabled, Caplin's indexing database (`<datadir>/caplin/index
 
 For nodes participating in PeerDAS (EIP-7594), Caplin retains data column sidecars for a configurable window:
 
-* `--caplin.columns-keep-slots` (default: `0`): Number of slots to retain PeerDAS data column sidecars. `0` uses the chain's own spec window, `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS × SLOTS_PER_EPOCH`, so the retained slot count and the wall-clock duration it covers both follow the chain (on Ethereum mainnet, 131072 slots, ~18 days). Increase this value for DA oracle or rollup nodes that require a longer column history.
+- `--caplin.columns-keep-slots` (default: `0`): Number of slots to retain PeerDAS data column sidecars. `0` uses the chain's own spec window, `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS × SLOTS_PER_EPOCH`, so the retained slot count and the wall-clock duration it covers both follow the chain (on Ethereum mainnet, 131072 slots, ~18 days). Increase this value for DA oracle or rollup nodes that require a longer column history.
 
-Caplin can also be used for [block production](../staking/caplin), aka **staking**.
+Caplin can also be used for [block production](https://docs.erigon.tech/staking/caplin), aka **staking**.
 
 ## Beacon API Configuration
 
 When Caplin is running, it exposes a Beacon API that external tools can query. The following flags control the Beacon API server:
 
 | Flag | Default | Description |
-|------|---------|-------------|
+| --- | --- | --- |
 | `--beacon.api.addr` | `localhost` | Listening address for the Beacon API |
 | `--beacon.api.port` | `5555` | Listening port for the Beacon API |
 | `--beacon.api.cors.allow-origins` | (empty) | CORS allowed origins |
@@ -2035,12 +1985,11 @@ When Caplin is running, it exposes a Beacon API that external tools can query. T
 # CLI Reference
 URL: https://docs.erigon.tech/fundamentals/configuring-erigon
 
-
 The Erigon CLI has a wide range of flags that can be used to customize its behavior. There are 3 ways to configure Erigon, listed by priority:
 
-* [Command line options](/fundamentals/configuring-erigon/#command-line-options) (flags)
-* [Configuration file](/fundamentals/configuring-erigon/#configuration-file)
-* [Environment variables](/fundamentals/configuring-erigon/#environment-variables)
+- [Command line options](https://docs.erigon.tech/fundamentals/configuring-erigon#command-line-options) (flags)
+- [Configuration file](https://docs.erigon.tech/fundamentals/configuring-erigon#configuration-file)
+- [Environment variables](https://docs.erigon.tech/fundamentals/configuring-erigon#environment-variables)
 
 :::tip
 In order to see all the available options (flags) you must run the command:
@@ -2064,453 +2013,644 @@ Flags can be combined freely, providing a high degree of customization. Here's a
 
 These flags cover the general behavior and configuration of the Erigon client.
 
-* `--datadir value`: Specifies the data directory for the databases.
-  * Default: `/home/usr/.local/share/erigon`
-* `--ethash.dagdir value`: Sets the directory to store the ethash mining DAGs.
-  * Default: `/home/usr/.local/share/erigon-ethash`
-* `--config value`: Sets Erigon flags using a YAML/TOML file.
-* `--version, -v`: Prints the version information.
-* `--help, -h`: Displays help information.
-* `--chain value`: Sets the name of the [network](/fundamentals/supported-networks) to join.
-  * Default: `mainnet`
-* `--networkid value`: Explicitly sets the network ID.
-  * Default: `1`
-* `--identity value`: Sets a custom node name.
-* `--externalcl`: Enables the external consensus layer.
-  * Default: `false`, means that Caplin is enabled.
-* `--override.osaka value`: Manually specifies the Osaka fork time.
-  * Default: `0`
-* `--override.amsterdam value`: Manually specifies the Amsterdam fork time.
-  * Default: `0`
-* `--vmdebug`: Records information for VM and contract debugging.
-  * Default: `false`
-* `--gdbme`: Restarts Erigon under gdb for debugging.
-  * Default: `false`
-* `--ethstats value`: The reporting URL for an ethstats service.
-* `--trusted-setup-file value`: Absolute path to a `trusted_setup.json` file.
-* `--prune.include-receipts, --persist.receipts, --experiment.persist.receipts.v2`: Downloads and caches historical receipts. Without it, receipts and logs are re-derived on demand from state history, so the related RPC calls still work, just with higher latency.
-  * Default: `false` (disabled) in every prune mode
-* `--keep.stored.chain.config`: Avoids overriding the chain configuration already stored in the database.
-  * Default: `false`
+- `--datadir value`: Specifies the data directory for the databases.
+  - Default: `/home/usr/.local/share/erigon`
+
+- `--ethash.dagdir value`: Sets the directory to store the ethash mining DAGs.
+  - Default: `/home/usr/.local/share/erigon-ethash`
+
+- `--config value`: Sets Erigon flags using a YAML/TOML file.
+- `--version, -v`: Prints the version information.
+- `--help, -h`: Displays help information.
+- `--chain value`: Sets the name of the [network](https://docs.erigon.tech/fundamentals/supported-networks) to join.
+  - Default: `mainnet`
+
+- `--networkid value`: Explicitly sets the network ID.
+  - Default: `1`
+
+- `--identity value`: Sets a custom node name.
+- `--externalcl`: Enables the external consensus layer.
+  - Default: `false`, means that Caplin is enabled.
+
+- `--override.osaka value`: Manually specifies the Osaka fork time.
+  - Default: `0`
+
+- `--override.amsterdam value`: Manually specifies the Amsterdam fork time.
+  - Default: `0`
+
+- `--vmdebug`: Records information for VM and contract debugging.
+  - Default: `false`
+
+- `--gdbme`: Restarts Erigon under gdb for debugging.
+  - Default: `false`
+
+- `--ethstats value`: The reporting URL for an ethstats service.
+- `--trusted-setup-file value`: Absolute path to a `trusted_setup.json` file.
+- `--prune.include-receipts, --persist.receipts, --experiment.persist.receipts.v2`: Downloads and caches historical receipts. Without it, receipts and logs are re-derived on demand from state history, so the related RPC calls still work, just with higher latency.
+  - Default: `false` (disabled) in every prune mode
+
+- `--keep.stored.chain.config`: Avoids overriding the chain configuration already stored in the database.
+  - Default: `false`
 
 ### Development, testing, and block-production helpers
 
 These flags are mainly for dev networks, testing, or specialized block-production setups.
 
-* `--allow-insecure-unlock`: Accepted for go-ethereum CLI compatibility but currently has **no effect** — the flag is registered and settable, yet nothing in the codebase reads it and Erigon exposes no account-unlocking RPC.
-  * Default: `false`
-* `--dev-validator-seed value`: Deterministic BLS key seed for the embedded dev validator. Read only in PoS dev mode, which is selected by `--chain dev`; on any other chain the flag does nothing.
-  * Default: `devnet`
-* `--dev-validator-count value`: Number of validators for PoS dev mode (`--chain dev`).
-  * Default: `64`
-* `--dev.slot-time value`: Slot duration in seconds for PoS dev mode (`--chain dev`). Values below `2` are silently raised to `2`.
-  * Default: `6`
-* `--miner.gaslimit value`: Target gas limit for mined blocks.
-  * Default: unset — the target falls back to the chain configuration's default block gas limit, or `60000000` where the chain config does not set one. An explicit `0` is ignored rather than applied as a zero limit, so the flag only takes effect when set to a positive value.
-* `--miner.extradata value`: Block extra data set by the miner. Values longer than 32 bytes are silently truncated.
-  * Default: the client version string
-* `--experimental.bal`: Generates block access lists.
-  * Default: `false`
-* `--experimental.always-generate-changesets`: Overrides changeset generation logic.
-  * Default: `false`, derived as the inverse of the `BATCH_COMMITMENTS` environment variable (itself `true` by default). Running with `BATCH_COMMITMENTS=false` therefore flips this default to `true` unless the flag is passed explicitly.
-* `--chaos.monkey`: Testing-only flag that enables spontaneous network, consensus, and other failures.
-  * Default: `false`
+- `--allow-insecure-unlock`: Accepted for go-ethereum CLI compatibility but currently has **no effect** — the flag is registered and settable, yet nothing in the codebase reads it and Erigon exposes no account-unlocking RPC.
+  - Default: `false`
+
+- `--dev-validator-seed value`: Deterministic BLS key seed for the embedded dev validator. Read only in PoS dev mode, which is selected by `--chain dev`; on any other chain the flag does nothing.
+  - Default: `devnet`
+
+- `--dev-validator-count value`: Number of validators for PoS dev mode (`--chain dev`).
+  - Default: `64`
+
+- `--dev.slot-time value`: Slot duration in seconds for PoS dev mode (`--chain dev`). Values below `2` are silently raised to `2`.
+  - Default: `6`
+
+- `--miner.gaslimit value`: Target gas limit for mined blocks.
+  - Default: unset — the target falls back to the chain configuration's default block gas limit, or `60000000` where the chain config does not set one. An explicit `0` is ignored rather than applied as a zero limit, so the flag only takes effect when set to a positive value.
+
+- `--miner.extradata value`: Block extra data set by the miner. Values longer than 32 bytes are silently truncated.
+  - Default: the client version string
+
+- `--experimental.bal`: Generates block access lists.
+  - Default: `false`
+
+- `--experimental.always-generate-changesets`: Overrides changeset generation logic.
+  - Default: `false`, derived as the inverse of the `BATCH_COMMITMENTS` environment variable (itself `true` by default). Running with `BATCH_COMMITMENTS=false` therefore flips this default to `true` unless the flag is passed explicitly.
+
+- `--chaos.monkey`: Testing-only flag that enables spontaneous network, consensus, and other failures.
+  - Default: `false`
 
 ### Database and Caching
 
-These flags control database performance and memory usage. See [Database](/fundamentals/database) for the on-disk layout.
+These flags control database performance and memory usage. See [Database](https://docs.erigon.tech/fundamentals/database) for the on-disk layout.
 
-* `--db.pagesize value`: Sets the fixed page size for the database.
-  * Default: `4KB`
-* `--db.size.limit value`: Sets a runtime limit on the chaindata database size.
-  * Default: `1TB`
-* `--db.writemap`: Enables `WRITE_MAP` for fast database writes.
-  * Default: `true`
-* `--db.read.concurrency value`: Maximum number of concurrent open database read transactions (the MDBX read-transaction semaphore); when it is full, extra readers wait for a slot by default, though some RPC paths (HTTP/WebSocket) fail fast with an overload response instead. Raise it for nodes serving heavy parallel RPC. Lowering it does not reduce read concurrency: each parallel-execution worker holds a long-lived read transaction, so a value below the worker count would deadlock and is silently raised to it. To genuinely reduce read concurrency, lower `--exec.workers` instead.
-  * Default: scales with the host as `min(max(10, GOMAXPROCS * 64), 9000)` — kept well above the CPU count because reads are I/O-bound, and capped below Go's roughly 10,000 OS-thread limit.
-* `--database.verbosity value`: Enables internal database logs.
-  * Default: `2`
-* `--batchSize value`: Sets the batch size for the execution stage.
-  * Default: `512M`
-* `--etl.bufferSize value`: Buffer size for ETL operations. Also settable through the `ETL_OPTIMAL` environment variable.
-  * Default: `256MB`
-* `--bodies.cache value`: Sets the size limit for the block bodies cache.
-  * Default: `268435456`
-* `--state.cache value`: Sets the amount of data to store in the StateCache.
-  * Default: `0MB`
-* `--sync.parallel-state-flushing`: Enables parallel state flushing.
-  * Default: `true`
-* `--erigondb.domain.steps-in-frozen-file value`: Overrides the `steps_in_frozen_file` setting from `erigondb.toml` for the domain merge cap only (history and inverted-index merges are unaffected). Pass a positive integer to set an explicit cap, or `Inf` to leave the domain merge unbounded.
-  * Default: unset (uses the value from `erigondb.toml`)
-  * Use with care — an incorrect value may affect database structure.
-* `--commitment.plainValues` *(New in v3.6)*: On the first start of a fresh datadir, write commitment values in plain form (no shortened key references). This is a one-time, per-datadir choice — it is ignored once `erigondb.toml` exists.
-  * Default: `false`
+- `--db.pagesize value`: Sets the fixed page size for the database.
+  - Default: `4KB`
+
+- `--db.size.limit value`: Sets a runtime limit on the chaindata database size.
+  - Default: `1TB`
+
+- `--db.writemap`: Enables `WRITE_MAP` for fast database writes.
+  - Default: `true`
+
+- `--db.read.concurrency value`: Maximum number of concurrent open database read transactions (the MDBX read-transaction semaphore); when it is full, extra readers wait for a slot by default, though some RPC paths (HTTP/WebSocket) fail fast with an overload response instead. Raise it for nodes serving heavy parallel RPC. Lowering it does not reduce read concurrency: each parallel-execution worker holds a long-lived read transaction, so a value below the worker count would deadlock and is silently raised to it. To genuinely reduce read concurrency, lower `--exec.workers` instead.
+  - Default: scales with the host as `min(max(10, GOMAXPROCS * 64), 9000)` — kept well above the CPU count because reads are I/O-bound, and capped below Go's roughly 10,000 OS-thread limit.
+
+- `--database.verbosity value`: Enables internal database logs.
+  - Default: `2`
+
+- `--batchSize value`: Sets the batch size for the execution stage.
+  - Default: `512M`
+
+- `--etl.bufferSize value`: Buffer size for ETL operations. Also settable through the `ETL_OPTIMAL` environment variable.
+  - Default: `256MB`
+
+- `--bodies.cache value`: Sets the size limit for the block bodies cache.
+  - Default: `268435456`
+
+- `--state.cache value`: Sets the amount of data to store in the StateCache.
+  - Default: `0MB`
+
+- `--sync.parallel-state-flushing`: Enables parallel state flushing.
+  - Default: `true`
+
+- `--erigondb.domain.steps-in-frozen-file value`: Overrides the `steps_in_frozen_file` setting from `erigondb.toml` for the domain merge cap only (history and inverted-index merges are unaffected). Pass a positive integer to set an explicit cap, or `Inf` to leave the domain merge unbounded.
+  - Default: unset (uses the value from `erigondb.toml`)
+  - Use with care — an incorrect value may affect database structure.
+
+- `--commitment.plainValues` *(New in v3.6)*: On the first start of a fresh datadir, write commitment values in plain form (no shortened key references). This is a one-time, per-datadir choice — it is ignored once `erigondb.toml` exists.
+  - Default: `false`
 
 ### Pruning and Snapshots
 
-Flags for managing how old chain data is handled and stored. See [Snapshots Management](/fundamentals/snapshots-management) for snapshot tooling and disk usage.
+Flags for managing how old chain data is handled and stored. See [Snapshots Management](https://docs.erigon.tech/fundamentals/snapshots-management) for snapshot tooling and disk usage.
 
-* `--prune.mode value`: Selects a pruning preset (`full`, `archive`, `minimal`, `blocks`). See also [Pruning Modes](/fundamentals/pruning-modes)
-  * Default: `"full"`
-* `--prune.distance value`: Keeps state history for the latest `N` blocks, or `keep-all` to keep everything.
-  * Default: unset (retention follows `--prune.mode`)
-* `--prune.distance.blocks value`: Keeps block history for the latest `N` blocks, or a named policy: `keep-post-merge` (prune pre-merge blocks only) or `keep-all` (keep every block).
-  * Default: unset (retention follows `--prune.mode`)
-* `--prune.include-commitment-history, --prune.experimental.include-commitment-history, --experimental.commitment-history`: Enables fast `eth_getProof` for executed blocks by storing commitment history. Requires +32 GB RAM. See [`eth_getProof`](/interacting-with-erigon/eth#eth_getproof).
-  * Default: `false`
-* `--prune.commitment-history.distance value`: Keeps commitment history for the latest `N` blocks, or `keep-all`. Empty or `0` (default) keeps everything. Requires `--prune.include-commitment-history`.
-  * Default: unset (empty / `0`, keeps everything)
-* `--prune.receipts.distance, --persist.receipts.distance value`: Keeps the receipt cache for the latest `N` blocks, or `keep-all`. Empty or `0` (default) follows the state-history window. Requires `--prune.include-receipts`.
-  * Default: unset (empty / `0`, follows the state-history window)
-* `--snap.skip-state-snapshot-download`: Skips state download and starts from genesis.
-  * Default: `false`
-* `--snap.keepblocks`: Workaround/debug — keeps ancient blocks in the DB instead of moving them into snapshots (useful for debugging).
-  * Default: `false`
-* `--snap.stop`: Workaround for snapshot-related bugs — stops producing new snapshot files (DB will grow as a result).
-  * Default: `false`
-* `--snap.state.stop`: Workaround for state-related bugs — stops producing new state files (DB will grow as a result).
-  * Default: `false`
-* `--snap.p2p-manifest` *(New in v3.5)* (experimental): Decentralized snapshot discovery — peers advertise their `chain.toml` manifest via ENR instead of the centralized `preverified.toml`. Opt-in; requires a compatible peer network.
-  * Default: `false`
-* `--snap.chaintoml-url value` *(New in v3.5)*: Fetch the preverified `chain.toml` directly from this URL instead of the default R2/GitHub CDN. Precedence: the `ERIGON_REMOTE_PREVERIFIED` environment variable (path to a local override file) wins over this URL and the default CDN; a local `preverified.toml` in the datadir also takes precedence — delete it to re-fetch from the URL.
-  * Default: `""` (uses the built-in CDN)
-* `--snap.download.to.block, --shadow.fork.block value`: Downloads snapshots only up to the given block number (exclusive). Intended for testing and shadow forks.
-  * Default: `0` (disabled — downloads all available snapshots)
+- `--prune.mode value`: Selects a pruning preset (`full`, `archive`, `minimal`, `blocks`). See also [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes)
+  - Default: `"full"`
+
+- `--prune.distance value`: Keeps state history for the latest `N` blocks, or `keep-all` to keep everything.
+  - Default: unset (retention follows `--prune.mode`)
+
+- `--prune.distance.blocks value`: Keeps block history for the latest `N` blocks, or a named policy: `keep-post-merge` (prune pre-merge blocks only) or `keep-all` (keep every block).
+  - Default: unset (retention follows `--prune.mode`)
+
+- `--prune.include-commitment-history, --prune.experimental.include-commitment-history, --experimental.commitment-history`: Enables fast `eth_getProof` for executed blocks by storing commitment history. Requires +32 GB RAM. See [`eth_getProof`](https://docs.erigon.tech/interacting-with-erigon/eth#eth_getproof).
+  - Default: `false`
+
+- `--prune.commitment-history.distance value`: Keeps commitment history for the latest `N` blocks, or `keep-all`. Empty or `0` (default) keeps everything. Requires `--prune.include-commitment-history`.
+  - Default: unset (empty / `0`, keeps everything)
+
+- `--prune.receipts.distance, --persist.receipts.distance value`: Keeps the receipt cache for the latest `N` blocks, or `keep-all`. Empty or `0` (default) follows the state-history window. Requires `--prune.include-receipts`.
+  - Default: unset (empty / `0`, follows the state-history window)
+
+- `--snap.skip-state-snapshot-download`: Skips state download and starts from genesis.
+  - Default: `false`
+
+- `--snap.keepblocks`: Workaround/debug — keeps ancient blocks in the DB instead of moving them into snapshots (useful for debugging).
+  - Default: `false`
+
+- `--snap.stop`: Workaround for snapshot-related bugs — stops producing new snapshot files (DB will grow as a result).
+  - Default: `false`
+
+- `--snap.state.stop`: Workaround for state-related bugs — stops producing new state files (DB will grow as a result).
+  - Default: `false`
+
+- `--snap.p2p-manifest` *(New in v3.5)* (experimental): Decentralized snapshot discovery — peers advertise their `chain.toml` manifest via ENR instead of the centralized `preverified.toml`. Opt-in; requires a compatible peer network.
+  - Default: `false`
+
+- `--snap.chaintoml-url value` *(New in v3.5)*: Fetch the preverified `chain.toml` directly from this URL instead of the default R2/GitHub CDN. Precedence: the `ERIGON_REMOTE_PREVERIFIED` environment variable (path to a local override file) wins over this URL and the default CDN; a local `preverified.toml` in the datadir also takes precedence — delete it to re-fetch from the URL.
+  - Default: `""` (uses the built-in CDN)
+
+- `--snap.download.to.block, --shadow.fork.block value`: Downloads snapshots only up to the given block number (exclusive). Intended for testing and shadow forks.
+  - Default: `0` (disabled — downloads all available snapshots)
 
 ### Transaction Pool (TxPool)
 
-Options for configuring the [transaction pool](/fundamentals/modules/txpool).
+Options for configuring the [transaction pool](https://docs.erigon.tech/fundamentals/modules/txpool).
 
-* `--txpool.api.addr value`: The TxPool API network address.
-  * Default: Uses the value of `--private.api.addr`
-* `--txpool.disable`: Disables the internal transaction pool.
-  * Default: `false`
-* `--txpool.pricelimit value`: Sets the minimum gas price for acceptance into the pool.
-  * Default: `1`
-* `--txpool.pricebump value`: Sets the price bump percentage to replace a transaction.
-  * Default: `10`
-* `--txpool.blobpricebump value`: Sets the price bump percentage for replacing a type-3 blob transaction.
-  * Default: `100`
-* `--txpool.accountslots value`: Sets the number of executable transaction slots per account.
-  * Default: `16`
-* `--txpool.blobslots value`: Sets the maximum number of blobs per account.
-  * Default: `540`
-* `--txpool.totalblobpoollimit value`: Sets the total limit on the number of all blobs in the pool.
-  * Default: `5400`
-* `--txpool.globalslots value`: Sets the maximum number of executable transaction slots for all accounts.
-  * Default: `10000`
-* `--txpool.globalbasefeeslots value`: Sets the maximum number of non-executable transactions with insufficient base fees.
-  * Default: `30000`
-* `--txpool.globalqueue value`: Sets the maximum number of non-executable transaction slots for all accounts.
-  * Default: `30000`
-* `--txpool.trace.senders value`: A comma-separated list of addresses whose transactions will be traced.
-* `--txpool.commit.every value`: Sets how often transactions are committed to storage.
-  * Default: `15s`
-* `--txpool.gossip.disable`: Disables P2P gossip of transactions.
-  * Default: `false`
-* `--txpool.queued.dormancy value`: Evicts queued transactions from senders with no on-chain state changes for at least this duration (e.g. `3h`, `2h30m`).
-  * Default: `3h0m0s`
-  * Set to `0` to disable dormancy-based eviction.
+- `--txpool.api.addr value`: The TxPool API network address.
+  - Default: Uses the value of `--private.api.addr`
+
+- `--txpool.disable`: Disables the internal transaction pool.
+  - Default: `false`
+
+- `--txpool.pricelimit value`: Sets the minimum gas price for acceptance into the pool.
+  - Default: `1`
+
+- `--txpool.pricebump value`: Sets the price bump percentage to replace a transaction.
+  - Default: `10`
+
+- `--txpool.blobpricebump value`: Sets the price bump percentage for replacing a type-3 blob transaction.
+  - Default: `100`
+
+- `--txpool.accountslots value`: Sets the number of executable transaction slots per account.
+  - Default: `16`
+
+- `--txpool.blobslots value`: Sets the maximum number of blobs per account.
+  - Default: `540`
+
+- `--txpool.totalblobpoollimit value`: Sets the total limit on the number of all blobs in the pool.
+  - Default: `5400`
+
+- `--txpool.globalslots value`: Sets the maximum number of executable transaction slots for all accounts.
+  - Default: `10000`
+
+- `--txpool.globalbasefeeslots value`: Sets the maximum number of non-executable transactions with insufficient base fees.
+  - Default: `30000`
+
+- `--txpool.globalqueue value`: Sets the maximum number of non-executable transaction slots for all accounts.
+  - Default: `30000`
+
+- `--txpool.trace.senders value`: A comma-separated list of addresses whose transactions will be traced.
+- `--txpool.commit.every value`: Sets how often transactions are committed to storage.
+  - Default: `15s`
+
+- `--txpool.gossip.disable`: Disables P2P gossip of transactions.
+  - Default: `false`
+
+- `--txpool.queued.dormancy value`: Evicts queued transactions from senders with no on-chain state changes for at least this duration (e.g. `3h`, `2h30m`).
+  - Default: `3h0m0s`
+  - Set to `0` to disable dormancy-based eviction.
 
 ### Network and Peers
 
-These flags manage network connectivity, peer discovery, and traffic control. See [Default Ports](/fundamentals/default-ports) for the full port map.
+These flags manage network connectivity, peer discovery, and traffic control. See [Default Ports](https://docs.erigon.tech/fundamentals/default-ports) for the full port map.
 
-* `--port value`: The main network listening port.
-  * Default: `30303`
-* `--p2p.protocol value`: The version of the `eth` P2P protocol.
-  * Default: `69`, `70`, `71`
-* `--nat value`: The NAT port mapping mechanism (See [here](/fundamentals/nat) for more details).
-* `--nodiscover`: Disables peer discovery.
-  * Default: `false`
-* `--discovery.v4`, `--discv4`: Enables the Node Discovery Protocol v4 (Discv4) for managed ENRs and topic discovery.
-  * Default: `false` (disabled by default since v3.4; discv5 is now the default discovery protocol)
-* `--discovery.v5`, `--discv5`, `--v5disc`: Enables the Node Discovery Protocol v5 (Discv5) for managed ENRs and topic discovery.
-  * Default: `true` (enabled by default since v3.4)
-* `--netrestrict value`: Restricts network communication to specific IP networks.
-* `--nodekey value`: The P2P node key file.
-* `--nodekeyhex value`: The P2P node key as a hexadecimal string.
-* `--discovery.dns value`: Sets DNS discovery entry points.
-* `--bootnodes value`: Comma-separated enode URLs for P2P discovery bootstrap.
-* `--staticpeers value`: Comma-separated enode URLs to connect to.
-* `--trustedpeers value`: Comma-separated enode URLs for trusted peers.
-* `--maxpeers value`: The maximum number of network peers.
-  * Default: `32`
+- `--port value`: The main network listening port.
+  - Default: `30303`
+
+- `--p2p.protocol value`: The version of the `eth` P2P protocol.
+  - Default: `69`, `70`, `71`
+
+- `--nat value`: The NAT port mapping mechanism (See [here](https://docs.erigon.tech/fundamentals/nat) for more details).
+- `--nodiscover`: Disables peer discovery.
+  - Default: `false`
+
+- `--discovery.v4`, `--discv4`: Enables the Node Discovery Protocol v4 (Discv4) for managed ENRs and topic discovery.
+  - Default: `false` (disabled by default since v3.4; discv5 is now the default discovery protocol)
+
+- `--discovery.v5`, `--discv5`, `--v5disc`: Enables the Node Discovery Protocol v5 (Discv5) for managed ENRs and topic discovery.
+  - Default: `true` (enabled by default since v3.4)
+
+- `--netrestrict value`: Restricts network communication to specific IP networks.
+- `--nodekey value`: The P2P node key file.
+- `--nodekeyhex value`: The P2P node key as a hexadecimal string.
+- `--discovery.dns value`: Sets DNS discovery entry points.
+- `--bootnodes value`: Comma-separated enode URLs for P2P discovery bootstrap.
+- `--staticpeers value`: Comma-separated enode URLs to connect to.
+- `--trustedpeers value`: Comma-separated enode URLs for trusted peers.
+- `--maxpeers value`: The maximum number of network peers.
+  - Default: `32`
 
 ### RPC & API
 
-Flags for configuring various RPC servers and their behavior. See [Interacting with Erigon](/interacting-with-erigon) for the JSON-RPC API reference.
+Flags for configuring various RPC servers and their behavior. See [Interacting with Erigon](https://docs.erigon.tech/interacting-with-erigon) for the JSON-RPC API reference.
 
-* `--private.api.addr value`: The internal gRPC API address for Erigon's components.
-  * Default: `127.0.0.1:9090`
-* `--private.api.ratelimit value`: Limits the number of simultaneous internal API requests.
-  * Default: `31872`
-* `--http`: Enables the JSON-RPC HTTP server.
-  * Default: `true`
-* `--http.enabled`: An alternative flag to enable the HTTP server.
-  * Default: `true`
-* `--graphql`: Enables the GraphQL endpoint.
-  * Default: `false`
-* `--http.addr value`: The HTTP-RPC server listening interface.
-  * Default: `localhost`
-* `--http.port value`: The HTTP-RPC server listening port.
-  * Default: `8545`
-* `--http.url value` *(New in v3.7)*: Full listen URL for the HTTP-RPC server, which overrides `--http.addr` and `--http.port`. Supported schemes are `tcp://` and `unix://` — for example `tcp://0.0.0.0:8545` or `unix:///var/run/erigon-rpc.sock`.
-  * Default: unset (the endpoint is built from `--http.addr` and `--http.port`)
-  * Only takes effect while the HTTP server is enabled.
-  * **Do not add a path to a `tcp://` URL.** The URL's host and path are concatenated into the listen address, so `tcp://0.0.0.0:8545/rpc` is not a route prefix — it produces an invalid address and the node fails to start. Only a `unix://` URL takes a path, where it *is* the socket path.
-* `--authrpc.addr value`: The HTTP-RPC server listening interface for the Engine API.
-  * Default: `localhost`
-* `--authrpc.port value`: The HTTP-RPC server listening port for the Engine API.
-  * Default: `8551`
-* `--authrpc.jwtsecret value`: The path to the [JWT secret](/fundamentals/jwt) file for the consensus layer.
-* `--http.compression`: Enables compression over HTTP-RPC.
-  * Default: `true`
-* `--http.corsdomain value`: A comma-separated list of domains for cross-origin requests.
-* `--http.vhosts value`: A comma-separated list of virtual hostnames.
-  * Default: `localhost`
-* `--authrpc.vhosts value`: A comma-separated list of virtual hostnames for the Engine API.
-  * Default: `localhost`
-* `--http.api value`: The APIs offered over the HTTP-RPC interface.
-  * Default: `eth,erigon,engine`
-* `--ws`: Enables the WS-RPC server.
-  * Default: `false`
-* `--ws.port value`: The WS-RPC server listening port.
-  * Default: `8546`
-* `--ws.compression`: Enables compression over WebSocket.
-  * Default: `true`
-* `--ws.max.connections value`: Maximum number of concurrent WebSocket connections.
-  * Default: `0` (unlimited)
+- `--private.api.addr value`: The internal gRPC API address for Erigon's components.
+  - Default: `127.0.0.1:9090`
 
-**HTTPS and IPC transports.** *(New in v3.7)* These flags are accepted by both the `erigon` binary and the standalone [RPC Daemon](/fundamentals/modules/rpc-daemon) — the embedded RPC server reads them from the same configuration. They serve the same JSON-RPC API as `--http`, over TLS or a separate socket instead.
+- `--private.api.ratelimit value`: Limits the number of simultaneous internal API requests.
+  - Default: `31872`
+
+- `--http`: Enables the JSON-RPC HTTP server.
+  - Default: `true`
+
+- `--http.enabled`: An alternative flag to enable the HTTP server.
+  - Default: `true`
+
+- `--graphql`: Enables the GraphQL endpoint.
+  - Default: `false`
+
+- `--http.addr value`: The HTTP-RPC server listening interface.
+  - Default: `localhost`
+
+- `--http.port value`: The HTTP-RPC server listening port.
+  - Default: `8545`
+
+- `--http.url value` *(New in v3.7)*: Full listen URL for the HTTP-RPC server, which overrides `--http.addr` and `--http.port`. Supported schemes are `tcp://` and `unix://` — for example `tcp://0.0.0.0:8545` or `unix:///var/run/erigon-rpc.sock`.
+  - Default: unset (the endpoint is built from `--http.addr` and `--http.port`)
+  - Only takes effect while the HTTP server is enabled.
+  - **Do not add a path to a `tcp://` URL.** The URL's host and path are concatenated into the listen address, so `tcp://0.0.0.0:8545/rpc` is not a route prefix — it produces an invalid address and the node fails to start. Only a `unix://` URL takes a path, where it *is* the socket path.
+
+- `--authrpc.addr value`: The HTTP-RPC server listening interface for the Engine API.
+  - Default: `localhost`
+
+- `--authrpc.port value`: The HTTP-RPC server listening port for the Engine API.
+  - Default: `8551`
+
+- `--authrpc.jwtsecret value`: The path to the [JWT secret](https://docs.erigon.tech/fundamentals/jwt) file for the consensus layer.
+- `--http.compression`: Enables compression over HTTP-RPC.
+  - Default: `true`
+
+- `--http.corsdomain value`: A comma-separated list of domains for cross-origin requests.
+- `--http.vhosts value`: A comma-separated list of virtual hostnames.
+  - Default: `localhost`
+
+- `--authrpc.vhosts value`: A comma-separated list of virtual hostnames for the Engine API.
+  - Default: `localhost`
+
+- `--http.api value`: The APIs offered over the HTTP-RPC interface.
+  - Default: `eth,erigon,engine`
+
+- `--ws`: Enables the WS-RPC server.
+  - Default: `false`
+
+- `--ws.port value`: The WS-RPC server listening port.
+  - Default: `8546`
+
+- `--ws.compression`: Enables compression over WebSocket.
+  - Default: `true`
+
+- `--ws.max.connections value`: Maximum number of concurrent WebSocket connections.
+  - Default: `0` (unlimited)
+
+**HTTPS and IPC transports.** *(New in v3.7)* These flags are accepted by both the `erigon` binary and the standalone [RPC Daemon](https://docs.erigon.tech/fundamentals/modules/rpc-daemon) — the embedded RPC server reads them from the same configuration. They serve the same JSON-RPC API as `--http`, over TLS or a separate socket instead.
 
 :::warning
 `--http=false` is a master switch: it disables the whole RPC stack, including the HTTPS and IPC listeners, so `--http=false --https.enabled` yields no listener at all. To serve TLS only, leave `--http` alone and turn off just the plain HTTP listener with `--http.enabled=false`.
 :::
 
-* `--https.enabled`: Enables a JSON-RPC HTTPS server on its own port, independently of the plain HTTP listener.
-  * Default: `false`
-  * `--https.cert` and `--https.key` are both required. If either is missing or unreadable the node still starts and the port still binds, but TLS serving fails and only a `Failed to serve https endpoint` warning is logged — so check the log rather than assuming success.
-* `--https.cert value`: Path to the certificate file for the HTTPS server.
-* `--https.key value`: Path to the private key file for the HTTPS server.
-* `--https.addr value`: The HTTPS-RPC server listening interface.
-  * Default: `localhost`
-* `--https.port value`: The HTTPS-RPC server listening port.
-  * Default: `0`, which means `--http.port` + 363 — so `8908` with a default `--http.port`. Set an explicit port if you need a predictable one.
-* `--https.url value`: Full listen URL for the HTTPS server, which overrides `--https.addr` and `--https.port`. Supported schemes are `tcp://` and `unix://`.
-  * Default: unset
-  * Setting this **implies `--https.enabled`**: a non-empty value turns the HTTPS server on by itself.
-* `--socket.enabled`: Enables a socket server that serves JSON-RPC on the endpoint given by `--socket.url` — a Unix socket by default, though a `tcp://` URL is also accepted.
-  * Default: `false`
-* `--socket.url value`: Listen URL for the IPC server. Supported schemes are `unix://` and `tcp://`.
-  * Default: `unix:///var/run/erigon.sock`
-  * The parent directory must exist and be writable by the Erigon user; `/var/run` normally is not, so point this at your datadir (for example `unix:///<your-datadir>/erigon.ipc`) unless you have arranged otherwise.
+- `--https.enabled`: Enables a JSON-RPC HTTPS server on its own port, independently of the plain HTTP listener.
 
-* `--rpc.batch.concurrency value`: Limits the number of goroutines for batch requests.
-  * Default: `2`
-* `--rpc.max.concurrency value`: Maximum number of concurrent HTTP RPC requests (HTTP admission control).
-  * Default: `0` (inherits value from `--db.read.concurrency`)
-  * Set to `-1` to disable admission control (unlimited)
-* `--rpc.streaming.disable`: Disables JSON streaming for heavy endpoints.
-  * Default: `false`
-* `--state.stream.disable`: Disables streaming of state changes from the core to the RPC daemon.
-  * Default: `false`
-* `--rpc.accessList value`: Specifies a granular API allowlist.
-* `--rpc.gascap value`: Sets a cap on gas usage for `eth_call`/`estimateGas`.
-  * Default: `50000000`
-* `--rpc.batch.limit value`: Sets the maximum number of requests in a batch.
-  * Default: `100`
-* `--rpc.blockrange.limit value`: Sets the maximum block range for `eth_getLogs` and similar range queries.
-  * Default: `1000`
-  * Applies to: `eth_getLogs`, `eth_getFilterLogs`, `erigon_getLogs`
-* `--rpc.logs.maxresults value`: Sets the maximum number of log results returned per query.
-  * Default: `20000`
-  * Applies to: `eth_getLogs`, `eth_getFilterLogs`, `erigon_getLogs`, `erigon_getLatestLogs`
-  * Set to `0` to remove the limit entirely (use with caution on large ranges).
-  * Works in tandem with `--rpc.blockrange.limit`: both constraints apply independently — a query can be blocked by either limit.
-* `--rpc.logs.querylimit value`: Maximum number of alternative addresses or topics allowed per search position in the `eth_getLogs` and `eth_getFilterLogs` filter criteria.
-  * Default: `1000`
-  * Applies to: `eth_getLogs`, `eth_getFilterLogs`
-  * Set to `0` or a negative value for no limit.
-* `--rpc.returndata.limit value`: Sets the maximum return data size for `eth_call`.
-  * Default: `100000`
-* `--rpc.allow-unprotected-txs`: Allows unprotected transactions via RPC.
-  * Default: `false`
-* `--rpc.gethcompat`: Enables Geth-compatible storage iteration order for `debug_storageRangeAt` (results sorted by keccak256 hash). Disabled by default for performance.
-  * Default: `false`
-* `--rpc.txfeecap value`: Sets a cap on transaction fees in ether.
-  * Default: `1`
-* `--rpc.slow value`: Logs RPC requests slower than the specified threshold.
-  * Default: `0s`
-* `--rpc.evmtimeout value`: The maximum time to wait for an EVM call.
-  * Default: `5m0s`
-* `--rpc.overlay.getlogstimeout value`: The maximum time to wait for `overlay_getLogs`.
-  * Default: `5m0s`
-* `--rpc.overlay.replayblocktimeout value`: The maximum time to wait to replay a single block.
-  * Default: `10s`
-* `--rpc.txsync.defaulttimeout value`: The default timeout for `eth_sendRawTransactionSync` when the caller does not specify one.
-  * Default: `25s`
-* `--rpc.txsync.maxtimeout value`: The maximum timeout for `eth_sendRawTransactionSync`; larger requested timeouts are clamped to this value.
-  * Default: `1m0s`
-* `--rpc.subscription.filters.maxlogs value`: Maximum logs to store per subscription.
-  * Default: `10000`
-* `--rpc.subscription.filters.maxheaders value`: Maximum block headers to store per subscription.
-  * Default: `10000`
-* `--rpc.subscription.filters.maxtxs value`: Maximum transactions to store per subscription.
-  * Default: `10000`
-* `--rpc.subscription.filters.maxaddresses value`: Maximum addresses accepted per log subscription.
-  * Default: `0`
-* `--rpc.subscription.filters.maxtopics value`: Maximum topic alternatives accepted across all positions per log subscription.
-  * Default: `0`
-* `--rpc.subscription.filters.timeout value`: Timeout before idle subscription filters are evicted.
-  * Default: `5m0s`
-  * Set to `0` to disable eviction.
-* `--http.timeouts.read value`: Maximum duration for reading a request.
-  * Default: `30s`
-* `--http.timeouts.write value`: Maximum duration before timing out a response write.
-  * Default: `30m0s`
-* `--http.timeouts.idle value`: Maximum idle time for a connection with keep-alives enabled.
-  * Default: `2m0s`
-* `--authrpc.timeouts.read value`: Maximum read duration for an Engine API request.
-  * Default: `30s`
-* `--authrpc.timeouts.write value`: Maximum write duration for an Engine API response.
-  * Default: `30m0s`
-* `--authrpc.timeouts.idle value`: Maximum idle time for an Engine API connection.
-  * Default: `2m0s`
-* `--healthcheck`: Enables gRPC health checks.
-  * Default: `false`
-* `--witness.cache.blocks value` *(New in v3.6)*: Number of recent blocks whose legacy `debug_executionWitness` result is eagerly cached in memory, keyed by block hash in an LRU. Each witness is held as serialized JSON and served verbatim on a hit, so memory use is roughly this count multiplied by the per-block witness size. Embedded RPC only, and requires `--prune.include-commitment-history` (runtime errors from `debug_executionWitness` and `eth_getWitness` name its `--prune.experimental.include-commitment-history` alias instead). This flag also gates `debug_subscribe("executionWitnesses")`, which pushes each witness over WebSocket as the cache builds it. That stream is best-effort rather than contiguous — catch-up bursts, skipped or failed builds, and slow subscribers all leave gaps — so a client that needs every height re-requests the missing ones with `debug_executionWitness`.
-  * Default: `0` (cache disabled); values above the cap of `96` are clamped
-* `--witness.cache.head-capture`: Serves recent-block `debug_executionWitness` on a minimal node without commitment-history by building each head block from a pinned parent commitment snapshot and the account/storage/code history the node keeps. Cache-only serving: out-of-window requests miss, and no history recompute is attempted. Embedded RPC only.
-  * Default: `false`
-* `--witness.cache.maxmb value`: Resident-memory cap, in MB, for the witness cache; whichever limit binds first wins between the byte budget and `--witness.cache.blocks` (still capped at `96`). `0` means count-only (no byte cap).
-  * Default: `0`
+  - Default: `false`
+  - `--https.cert` and `--https.key` are both required. If either is missing or unreadable the node still starts and the port still binds, but TLS serving fails and only a `Failed to serve https endpoint` warning is logged — so check the log rather than assuming success.
+
+- `--https.cert value`: Path to the certificate file for the HTTPS server.
+
+- `--https.key value`: Path to the private key file for the HTTPS server.
+
+- `--https.addr value`: The HTTPS-RPC server listening interface.
+
+  - Default: `localhost`
+
+- `--https.port value`: The HTTPS-RPC server listening port.
+
+  - Default: `0`, which means `--http.port` + 363 — so `8908` with a default `--http.port`. Set an explicit port if you need a predictable one.
+
+- `--https.url value`: Full listen URL for the HTTPS server, which overrides `--https.addr` and `--https.port`. Supported schemes are `tcp://` and `unix://`.
+
+  - Default: unset
+  - Setting this **implies `--https.enabled`**: a non-empty value turns the HTTPS server on by itself.
+
+- `--socket.enabled`: Enables a socket server that serves JSON-RPC on the endpoint given by `--socket.url` — a Unix socket by default, though a `tcp://` URL is also accepted.
+
+  - Default: `false`
+
+- `--socket.url value`: Listen URL for the IPC server. Supported schemes are `unix://` and `tcp://`.
+
+  - Default: `unix:///var/run/erigon.sock`
+  - The parent directory must exist and be writable by the Erigon user; `/var/run` normally is not, so point this at your datadir (for example `unix:///<your-datadir>/erigon.ipc`) unless you have arranged otherwise.
+
+- `--rpc.batch.concurrency value`: Limits the number of goroutines for batch requests.
+
+  - Default: `2`
+
+- `--rpc.max.concurrency value`: Maximum number of concurrent HTTP RPC requests (HTTP admission control).
+
+  - Default: `0` (inherits value from `--db.read.concurrency`)
+  - Set to `-1` to disable admission control (unlimited)
+
+- `--rpc.streaming.disable`: Disables JSON streaming for heavy endpoints.
+
+  - Default: `false`
+
+- `--state.stream.disable`: Disables streaming of state changes from the core to the RPC daemon.
+
+  - Default: `false`
+
+- `--rpc.accessList value`: Specifies a granular API allowlist.
+
+- `--rpc.gascap value`: Sets a cap on gas usage for `eth_call`/`estimateGas`.
+
+  - Default: `50000000`
+
+- `--rpc.batch.limit value`: Sets the maximum number of requests in a batch.
+
+  - Default: `100`
+
+- `--rpc.blockrange.limit value`: Sets the maximum block range for `eth_getLogs` and similar range queries.
+
+  - Default: `1000`
+  - Applies to: `eth_getLogs`, `eth_getFilterLogs`, `erigon_getLogs`
+
+- `--rpc.logs.maxresults value`: Sets the maximum number of log results returned per query.
+
+  - Default: `20000`
+  - Applies to: `eth_getLogs`, `eth_getFilterLogs`, `erigon_getLogs`, `erigon_getLatestLogs`
+  - Set to `0` to remove the limit entirely (use with caution on large ranges).
+  - Works in tandem with `--rpc.blockrange.limit`: both constraints apply independently — a query can be blocked by either limit.
+
+- `--rpc.logs.querylimit value`: Maximum number of alternative addresses or topics allowed per search position in the `eth_getLogs` and `eth_getFilterLogs` filter criteria.
+
+  - Default: `1000`
+  - Applies to: `eth_getLogs`, `eth_getFilterLogs`
+  - Set to `0` or a negative value for no limit.
+
+- `--rpc.returndata.limit value`: Sets the maximum return data size for `eth_call`.
+
+  - Default: `100000`
+
+- `--rpc.allow-unprotected-txs`: Allows unprotected transactions via RPC.
+
+  - Default: `false`
+
+- `--rpc.gethcompat`: Enables Geth-compatible storage iteration order for `debug_storageRangeAt` (results sorted by keccak256 hash). Disabled by default for performance.
+
+  - Default: `false`
+
+- `--rpc.txfeecap value`: Sets a cap on transaction fees in ether.
+
+  - Default: `1`
+
+- `--rpc.slow value`: Logs RPC requests slower than the specified threshold.
+
+  - Default: `0s`
+
+- `--rpc.evmtimeout value`: The maximum time to wait for an EVM call.
+
+  - Default: `5m0s`
+
+- `--rpc.overlay.getlogstimeout value`: The maximum time to wait for `overlay_getLogs`.
+
+  - Default: `5m0s`
+
+- `--rpc.overlay.replayblocktimeout value`: The maximum time to wait to replay a single block.
+
+  - Default: `10s`
+
+- `--rpc.txsync.defaulttimeout value`: The default timeout for `eth_sendRawTransactionSync` when the caller does not specify one.
+
+  - Default: `25s`
+
+- `--rpc.txsync.maxtimeout value`: The maximum timeout for `eth_sendRawTransactionSync`; larger requested timeouts are clamped to this value.
+
+  - Default: `1m0s`
+
+- `--rpc.subscription.filters.maxlogs value`: Maximum logs to store per subscription.
+
+  - Default: `10000`
+
+- `--rpc.subscription.filters.maxheaders value`: Maximum block headers to store per subscription.
+
+  - Default: `10000`
+
+- `--rpc.subscription.filters.maxtxs value`: Maximum transactions to store per subscription.
+
+  - Default: `10000`
+
+- `--rpc.subscription.filters.maxaddresses value`: Maximum addresses accepted per log subscription.
+
+  - Default: `0`
+
+- `--rpc.subscription.filters.maxtopics value`: Maximum topic alternatives accepted across all positions per log subscription.
+
+  - Default: `0`
+
+- `--rpc.subscription.filters.timeout value`: Timeout before idle subscription filters are evicted.
+
+  - Default: `5m0s`
+  - Set to `0` to disable eviction.
+
+- `--http.timeouts.read value`: Maximum duration for reading a request.
+
+  - Default: `30s`
+
+- `--http.timeouts.write value`: Maximum duration before timing out a response write.
+
+  - Default: `30m0s`
+
+- `--http.timeouts.idle value`: Maximum idle time for a connection with keep-alives enabled.
+
+  - Default: `2m0s`
+
+- `--authrpc.timeouts.read value`: Maximum read duration for an Engine API request.
+
+  - Default: `30s`
+
+- `--authrpc.timeouts.write value`: Maximum write duration for an Engine API response.
+
+  - Default: `30m0s`
+
+- `--authrpc.timeouts.idle value`: Maximum idle time for an Engine API connection.
+
+  - Default: `2m0s`
+
+- `--healthcheck`: Enables gRPC health checks.
+
+  - Default: `false`
+
+- `--witness.cache.blocks value` *(New in v3.6)*: Number of recent blocks whose legacy `debug_executionWitness` result is eagerly cached in memory, keyed by block hash in an LRU. Each witness is held as serialized JSON and served verbatim on a hit, so memory use is roughly this count multiplied by the per-block witness size. Embedded RPC only, and requires `--prune.include-commitment-history` (runtime errors from `debug_executionWitness` and `eth_getWitness` name its `--prune.experimental.include-commitment-history` alias instead). This flag also gates `debug_subscribe("executionWitnesses")`, which pushes each witness over WebSocket as the cache builds it. That stream is best-effort rather than contiguous — catch-up bursts, skipped or failed builds, and slow subscribers all leave gaps — so a client that needs every height re-requests the missing ones with `debug_executionWitness`.
+
+  - Default: `0` (cache disabled); values above the cap of `96` are clamped
+
+- `--witness.cache.head-capture`: Serves recent-block `debug_executionWitness` on a minimal node without commitment-history by building each head block from a pinned parent commitment snapshot and the account/storage/code history the node keeps. Cache-only serving: out-of-window requests miss, and no history recompute is attempted. Embedded RPC only.
+
+  - Default: `false`
+
+- `--witness.cache.maxmb value`: Resident-memory cap, in MB, for the witness cache; whichever limit binds first wins between the byte budget and `--witness.cache.blocks` (still capped at `96`). `0` means count-only (no byte cap).
+
+  - Default: `0`
 
 ### MCP Server
 
-Flags for configuring the Model Context Protocol (MCP) server. The embedded [MCP server](/fundamentals/mcp) is **enabled by default** on
-`127.0.0.1:8553`. Pass `--mcp.disable` to turn it off.
+Flags for configuring the Model Context Protocol (MCP) server. The embedded [MCP server](https://docs.erigon.tech/fundamentals/mcp) is **enabled by default** on `127.0.0.1:8553`. Pass `--mcp.disable` to turn it off.
 
-* `--mcp.disable`: Disables the embedded MCP server.
-    * Default: `false`
-* `--mcp.addr value`: The MCP server listening address.
-  * Default: `127.0.0.1`
-* `--mcp.port value`: The MCP server listening port.
-  * Default: `8553`
+- `--mcp.disable`: Disables the embedded MCP server.
+  - Default: `false`
+
+- `--mcp.addr value`: The MCP server listening address.
+  - Default: `127.0.0.1`
+
+- `--mcp.port value`: The MCP server listening port.
+  - Default: `8553`
 
 ### Logging and Profiling
 
-Flags for controlling logging and performance profiling. See [Logs](/fundamentals/logs) for log files, levels, and rotation.
+Flags for controlling logging and performance profiling. See [Logs](https://docs.erigon.tech/fundamentals/logs) for log files, levels, and rotation.
 
-* `--log.json`: Formats console logs with JSON.
-  * Default: `false`
-* `--log.console.json`: Formats console logs with JSON.
-  * Default: `false`
-* `--log.dir.json`: Formats file logs with JSON.
-  * Default: `false`
-* `--verbosity value`: Sets the log level for console logs.
-  * Default: `info`
-* `--log.console.verbosity value`: Sets the log level for console logs.
-  * Default: `info`
-* `--log.dir.disable`: Disables disk logging.
-  * Default: `false`
-* `--log.dir.path value`: The path to store user and error logs.
-* `--log.dir.prefix value`: The file name prefix for logs stored on disk.
-* `--log.dir.verbosity value`: Sets the log verbosity for disk logs.
-  * Default: `dbug`
-* `--log.delays`: Enables block delay logging.
-  * Default: `false`
-* `--pprof`: Enables the pprof HTTP server.
-  * Default: `false`
-* `--pprof.addr value`: The pprof HTTP server listening interface.
-  * Default: `127.0.0.1`
-* `--pprof.port value`: The pprof HTTP server listening port.
-  * Default: `6060`
-* `--pprof.cpuprofile value`: Writes a CPU profile to a file.
-* `--trace value`: Writes an execution trace to a file.
-* `--vmtrace value`: Sets the provider tracer.
-* `--vmtrace.jsonconfig value`: Sets the tracer's configuration.
-* `--metrics`: Enables metrics collection and reporting. See [Creating a dashboard](/fundamentals/creating-a-dashboard).
-  * Default: `false`
-* `--metrics.addr value`: The stand-alone metrics HTTP server listening interface.
-  * Default: `127.0.0.1`
-* `--metrics.port value`: The metrics HTTP server listening port.
-  * Default: `6061`
+- `--log.json`: Formats console logs with JSON.
+  - Default: `false`
+
+- `--log.console.json`: Formats console logs with JSON.
+  - Default: `false`
+
+- `--log.dir.json`: Formats file logs with JSON.
+  - Default: `false`
+
+- `--verbosity value`: Sets the log level for console logs.
+  - Default: `info`
+
+- `--log.console.verbosity value`: Sets the log level for console logs.
+  - Default: `info`
+
+- `--log.dir.disable`: Disables disk logging.
+  - Default: `false`
+
+- `--log.dir.path value`: The path to store user and error logs.
+- `--log.dir.prefix value`: The file name prefix for logs stored on disk.
+- `--log.dir.verbosity value`: Sets the log verbosity for disk logs.
+  - Default: `dbug`
+
+- `--log.delays`: Enables block delay logging.
+  - Default: `false`
+
+- `--pprof`: Enables the pprof HTTP server.
+  - Default: `false`
+
+- `--pprof.addr value`: The pprof HTTP server listening interface.
+  - Default: `127.0.0.1`
+
+- `--pprof.port value`: The pprof HTTP server listening port.
+  - Default: `6060`
+
+- `--pprof.cpuprofile value`: Writes a CPU profile to a file.
+- `--trace value`: Writes an execution trace to a file.
+- `--vmtrace value`: Sets the provider tracer.
+- `--vmtrace.jsonconfig value`: Sets the tracer's configuration.
+- `--metrics`: Enables metrics collection and reporting. See [Creating a dashboard](https://docs.erigon.tech/fundamentals/creating-a-dashboard).
+  - Default: `false`
+
+- `--metrics.addr value`: The stand-alone metrics HTTP server listening interface.
+  - Default: `127.0.0.1`
+
+- `--metrics.port value`: The metrics HTTP server listening port.
+  - Default: `6061`
 
 ### Consensus and Forks
 
 Flags related to consensus mechanisms and network forks.
 
-* `--fakepow`: Disables proof-of-work verification.
-  * Default: `false`
-* `--gpo.blocks value`: The number of recent blocks to check for gas prices.
-  * Default: `20`
-* `--gpo.percentile value`: The percentile of recent transaction gas prices to use for a suggested gas price.
-  * Default: `60`
-* `--proposer.disable`: Disables the PoS proposer.
-  * Default: `false`
-* `--builder.maxblobs value`: Caps the number of blobs included in a locally built block.
-  * Default: unset — the protocol maximum applies. Setting it to `0` excludes blob transactions from built blocks entirely.
+- `--fakepow`: Disables proof-of-work verification.
+  - Default: `false`
+
+- `--gpo.blocks value`: The number of recent blocks to check for gas prices.
+  - Default: `20`
+
+- `--gpo.percentile value`: The percentile of recent transaction gas prices to use for a suggested gas price.
+  - Default: `60`
+
+- `--proposer.disable`: Disables the PoS proposer.
+  - Default: `false`
+
+- `--builder.maxblobs value`: Caps the number of blobs included in a locally built block.
+  - Default: unset — the protocol maximum applies. Setting it to `0` excludes blob transactions from built blocks entirely.
 
 ### Sentry
 
-Flags for configuring the [Sentry](/fundamentals/modules/sentry) component.
+Flags for configuring the [Sentry](https://docs.erigon.tech/fundamentals/modules/sentry) component.
 
-* `--sentry.api.addr value`: A comma-separated list of Sentry addresses.
-* `--sentry.log-peer-info`: Logs detailed peer info when a peer connects or disconnects.
-  * Default: `false`
-* `--sentinel.addr value`: The address for the sentinel component.
-  * Default: `localhost`
-* `--sentinel.port value`: The port for the sentinel component.
-  * Default: `7777`
-* `--sentinel.bootnodes value`: Comma-separated enode URLs for P2P discovery bootstrap for the sentinel.
-* `--sentinel.staticpeers value`: Connects to comma-separated consensus static peers.
+- `--sentry.api.addr value`: A comma-separated list of Sentry addresses.
+- `--sentry.log-peer-info`: Logs detailed peer info when a peer connects or disconnects.
+  - Default: `false`
+
+- `--sentinel.addr value`: The address for the sentinel component.
+  - Default: `localhost`
+
+- `--sentinel.port value`: The port for the sentinel component.
+  - Default: `7777`
+
+- `--sentinel.bootnodes value`: Comma-separated enode URLs for P2P discovery bootstrap for the sentinel.
+- `--sentinel.staticpeers value`: Connects to comma-separated consensus static peers.
 
 ### Downloader and Synchronization
 
-These flags control the block synchronization and data downloading process, including the BitTorrent protocol settings. See [Downloader](/fundamentals/modules/downloader) for how snapshot downloading works.
+These flags control the block synchronization and data downloading process, including the BitTorrent protocol settings. See [Downloader](https://docs.erigon.tech/fundamentals/modules/downloader) for how snapshot downloading works.
 
-* `--downloader.api.addr value`: The Downloader address.
-* `--downloader.disable.ipv4`: Disables IPv4 for the Downloader.
-  * Default: `false`
-* `--downloader.disable.ipv6`: Disables IPv6 for the Downloader.
-  * Default: `false`
-* `--no-downloader`: Disables the Downloader component.
-  * Default: `false`
-* `--downloader.verify`: Verifies snapshots on startup.
-  * Default: `false`
-* `--sync.loop.throttle value`: Sets the minimum time between sync loop starts.
-* `--sync.loop.block.limit value`: Sets the maximum number of blocks to process per loop iteration.
-  * Default: `5000`
-* `--sync.loop.break.after value`: Sets the last stage of the sync loop to run.
-* `--bad.block value`: Marks a block as bad and forces a reorg.
-* `--webseed value`: Comma-separated URLs for network support infrastructure.
+- `--downloader.api.addr value`: The Downloader address.
+- `--downloader.disable.ipv4`: Disables IPv4 for the Downloader.
+  - Default: `false`
+
+- `--downloader.disable.ipv6`: Disables IPv6 for the Downloader.
+  - Default: `false`
+
+- `--no-downloader`: Disables the Downloader component.
+  - Default: `false`
+
+- `--downloader.verify`: Verifies snapshots on startup.
+  - Default: `false`
+
+- `--sync.loop.throttle value`: Sets the minimum time between sync loop starts.
+- `--sync.loop.block.limit value`: Sets the maximum number of blocks to process per loop iteration.
+  - Default: `5000`
+
+- `--sync.loop.break.after value`: Sets the last stage of the sync loop to run.
+- `--bad.block value`: Marks a block as bad and forces a reorg.
+- `--webseed value`: Comma-separated URLs for network support infrastructure.
 
 #### BitTorrent Options
 
-* `--torrent.port value`: The port to listen for the BitTorrent protocol.
-  * Default: `42069`
-* `--torrent.maxpeers value`: An unused parameter.
-  * Default: `100`
-* `--torrent.conns.perfile value`: The number of connections per file.
-  * Default: `10`
-* `--torrent.trackers.disable`: Disables conventional BitTorrent trackers.
-  * Default: `false`
-* `--torrent.upload.rate value`: The upload rate in bytes per second.
-  * Default: `16mb`
-* `--torrent.download.rate value`: Sets the torrent download rate cap. Default: `512mb`. Use a lower value on shared machines to avoid saturating the connection; use `Inf` to remove the limit.
-* `--torrent.webseed.download.rate value`: The download rate for webseeds. If not set, rate limit is shared with torrent.
-* `--torrent.verbosity value`: Sets the verbosity level for BitTorrent logs. 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail (must set `--verbosity` to equal or higher level)
-  * Default: `1`
+- `--torrent.port value`: The port to listen for the BitTorrent protocol.
+  - Default: `42069`
+
+- `--torrent.maxpeers value`: An unused parameter.
+  - Default: `100`
+
+- `--torrent.conns.perfile value`: The number of connections per file.
+  - Default: `10`
+
+- `--torrent.trackers.disable`: Disables conventional BitTorrent trackers.
+  - Default: `false`
+
+- `--torrent.upload.rate value`: The upload rate in bytes per second.
+  - Default: `16mb`
+
+- `--torrent.download.rate value`: Sets the torrent download rate cap. Default: `512mb`. Use a lower value on shared machines to avoid saturating the connection; use `Inf` to remove the limit.
+- `--torrent.webseed.download.rate value`: The download rate for webseeds. If not set, rate limit is shared with torrent.
+- `--torrent.verbosity value`: Sets the verbosity level for BitTorrent logs. 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail (must set `--verbosity` to equal or higher level)
+  - Default: `1`
 
 ### Fork Choice Update (FCU)
 
 Flags for configuring Fork Choice Update behavior.
 
-* `--fcu.timeout value`: FCU timeout before switching to async processing (use `0` to disable).
-  * Default: `1s`
-* `--fcu.background.prune`: Enables background pruning after FCU.
-  * Default: `true`
+- `--fcu.timeout value`: FCU timeout before switching to async processing (use `0` to disable).
+  - Default: `1s`
+
+- `--fcu.background.prune`: Enables background pruning after FCU.
+  - Default: `true`
 
 ### Execution
 
@@ -2518,97 +2658,129 @@ Flags for configuring the parallel block execution engine.
 
 **All `--exec.*` flags are new in v3.5** — they expose, as CLI flags, execution toggles that on earlier releases were settable only via the `EXEC3_*` / `NO_*` environment variables (which still work).
 
-* `--exec.workers value`: Number of parallel block-execution workers (equivalent to the `EXEC3_WORKERS` env var). Overridden by `--exec.serial`.
-  * Default: the number of CPU cores (inherited from the `EXEC3_WORKERS` default when the flag is not set).
-  * Note: `erigon --help` describes this flag's default as "half the number of CPU cores". That value is not actually applied — when `--exec.workers` is omitted, Erigon uses `EXEC3_WORKERS`, which defaults to the full CPU-core count. The flag-help text is a known inconsistency in the binary.
-* `--exec.serial`: Force serial execution by clamping the parallel executor to a single worker. Wins over `--exec.workers` and `EXEC3_WORKERS` — use to disable parallelism for diagnostics or like-for-like baseline comparisons.
-  * Default: `false`
-* `--exec.no-prune`: Disable all DB pruning: state-aggregator (Domain/InvertedIndex) plus stage-level pruning (Execution: ChangeSets3/BlockAccessList; TxLookup; Snapshots: PruneAncientBlocks/canonical markers/retirement). Equivalent to `NO_PRUNE=true`. Diagnostic / perf-comparison use only.
-  * Default: `false`
-* `--exec.no-merge`: Disable state-aggregator file merges for Domain / History / Inverted-Index. Equivalent to `NO_MERGE=true`. Diagnostic / perf-comparison use only.
-  * Default: `false`
-* `--exec.no-background-maintenance`: Suppress background state-aggregator and E2 block-snapshot retirement goroutines so execution is not perturbed by housekeeping work. Equivalent to `NO_BACKGROUND_E3_BUILD=true`. Diagnostic / focused-performance-testing use only — NOT an operational setting.
-  * Default: `false`
-* `--exec.batched-io`: Enable BAL-driven I/O optimisations — read-ahead pre-warming of the DB page cache (`READ_AHEAD=true`) and version-map pre-population from BAL hints (`IGNORE_BAL=false`). Disable for cold-read or non-BAL scheduling performance measurements.
-  * Default: `true`
-* `--exec.state-cache`: Enable the executor's domain-shared read cache. Equivalent to `USE_STATE_CACHE=true`. Disable for cold-read performance measurements.
-  * Default: `true`
+- `--exec.workers value`: Number of parallel block-execution workers (equivalent to the `EXEC3_WORKERS` env var). Overridden by `--exec.serial`.
+  - Default: the number of CPU cores (inherited from the `EXEC3_WORKERS` default when the flag is not set).
+  - Note: `erigon --help` describes this flag's default as "half the number of CPU cores". That value is not actually applied — when `--exec.workers` is omitted, Erigon uses `EXEC3_WORKERS`, which defaults to the full CPU-core count. The flag-help text is a known inconsistency in the binary.
+
+- `--exec.serial`: Force serial execution by clamping the parallel executor to a single worker. Wins over `--exec.workers` and `EXEC3_WORKERS` — use to disable parallelism for diagnostics or like-for-like baseline comparisons.
+  - Default: `false`
+
+- `--exec.no-prune`: Disable all DB pruning: state-aggregator (Domain/InvertedIndex) plus stage-level pruning (Execution: ChangeSets3/BlockAccessList; TxLookup; Snapshots: PruneAncientBlocks/canonical markers/retirement). Equivalent to `NO_PRUNE=true`. Diagnostic / perf-comparison use only.
+  - Default: `false`
+
+- `--exec.no-merge`: Disable state-aggregator file merges for Domain / History / Inverted-Index. Equivalent to `NO_MERGE=true`. Diagnostic / perf-comparison use only.
+  - Default: `false`
+
+- `--exec.no-background-maintenance`: Suppress background state-aggregator and E2 block-snapshot retirement goroutines so execution is not perturbed by housekeeping work. Equivalent to `NO_BACKGROUND_E3_BUILD=true`. Diagnostic / focused-performance-testing use only — NOT an operational setting.
+  - Default: `false`
+
+- `--exec.batched-io`: Enable BAL-driven I/O optimisations — read-ahead pre-warming of the DB page cache (`READ_AHEAD=true`) and version-map pre-population from BAL hints (`IGNORE_BAL=false`). Disable for cold-read or non-BAL scheduling performance measurements.
+  - Default: `true`
+
+- `--exec.state-cache`: Enable the executor's domain-shared read cache. Equivalent to `USE_STATE_CACHE=true`. Disable for cold-read performance measurements.
+  - Default: `true`
 
 **Commitment-trie construction.** The following flags change how the commitment (state-root) trie is computed during execution. Both default off and are intended for comparing root hashes against a sequential sync before enabling broadly.
 
-* `--experimental.parallel-commitment` *(New in v3.6)* (experimental): Compute the commitment trie with the fully parallel `ParallelPatriciaHashed` implementation. Equivalent to the `COMMITMENT_PARALLEL=true` environment variable.
-  * Default: `false`
-* `--experimental.streaming-commitment` *(New in v3.6)* (experimental): Compute the commitment trie with the `StreamingCommitter`, which overlaps trie folding with block execution. If set, takes precedence over `--experimental.parallel-commitment`. No environment-variable equivalent.
-  * Default: `false`
+- `--experimental.parallel-commitment` *(New in v3.6)* (experimental): Compute the commitment trie with the fully parallel `ParallelPatriciaHashed` implementation. Equivalent to the `COMMITMENT_PARALLEL=true` environment variable.
+  - Default: `false`
+
+- `--experimental.streaming-commitment` *(New in v3.6)* (experimental): Compute the commitment trie with the `StreamingCommitter`, which overlaps trie folding with block execution. If set, takes precedence over `--experimental.parallel-commitment`. No environment-variable equivalent.
+  - Default: `false`
 
 ### Caplin (Consensus Layer)
 
-Flags for configuring the [Caplin](/fundamentals/caplin) consensus layer.
+Flags for configuring the [Caplin](https://docs.erigon.tech/fundamentals/caplin) consensus layer.
 
-* `--caplin.discovery.addr value`: The address for the Caplin DISCV5 protocol.
-  * Default: `0.0.0.0`
-* `--caplin.discovery.port value`: The port for the Caplin DISCV5 protocol.
-  * Default: `4000`
-* `--caplin.discovery.tcpport value`: The TCP port for the Caplin DISCV5 protocol.
-  * Default: `4001`
-* `--caplin.checkpoint-sync-url value`: The checkpoint sync endpoint.
-* `--caplin.subscribe-all-topics`: Subscribes to all gossip topics.
-  * Default: `false`
-* `--caplin.max-peer-count value`: The maximum number of peers to connect to.
-  * Default: `128`
-* `--caplin.enable-upnp`: Enables NAT porting for Caplin.
-  * Default: `false`
-* `--caplin.local-discovery`: Also attempts to find peers over private IPs. May cause issues with some hosts (for example, Hetzner).
-  * Default: `false`
-* `--caplin.nat value`: NAT port mapping for Caplin P2P. Sets the external IP advertised in the discv5 ENR and libp2p multiaddrs while the socket binds to `--caplin.discovery.addr`. Required when running inside Docker or behind NAT. Accepted values: `""` (none), `"extip:1.2.3.4"`, `"stun"`, `"stun:<host>"`, `"upnp"`, `"pmp"`, `"pmp:192.168.0.1"`.
-  * Default: `""` (no NAT mapping)
-* `--caplin.max-inbound-traffic-per-peer value`: The maximum inbound traffic per second per peer.
-  * Default: `1MB`
-* `--caplin.max-outbound-traffic-per-peer value`: The maximum outbound traffic per second per peer.
-  * Default: `1MB`
-* `--caplin.adaptable-maximum-traffic-requirements`: Makes the node adaptable to traffic based on the number of validators.
-  * Default: `true`
-* `--caplin.blocks-archive`: Enables backfilling for blocks.
-  * Default: `false`
-* `--caplin.blobs-archive`: Enables backfilling for blobs.
-  * Default: `false`
-* `--caplin.states-archive`: Enables the archival node for historical states.
-  * Default: `false`
-* `--caplin.blobs-immediate-backfill`: Tells Caplin to immediately backfill blobs.
-  * Default: `false`
-* `--caplin.blobs-no-pruning`: Disables blob pruning.
-  * Default: `false`
-* `--caplin.columns-keep-slots value`: Number of slots to retain PeerDAS data column sidecars. Increase for DA oracle or rollup nodes that need longer column history.
-  * Default: `0` — uses the chain's spec window, `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS × SLOTS_PER_EPOCH`
-* `--caplin.checkpoint-sync.disable`: Disables checkpoint sync.
-  * Default: `false`
-* `--caplin.resume-max-staleness-epochs value`: Max epochs a locally-finalized state may be stale for Caplin to resume from it on restart instead of remote checkpoint syncing. Data-availability bound; larger values are clamped to the anchor fork's sidecar-retention window.
-  * Default: `0` (resolves to the anchor fork's sidecar-retention window)
-* `--caplin.snapgen`: Enables snapshot generation.
-  * Default: `false`
-* `--caplin.mev-relay-url value`: The MEV relay endpoint.
-* `--caplin.validator-monitor`: Enables Caplin validator monitoring metrics.
-  * Default: `false`
-* `--caplin.custom-config value`: Sets a custom config for Caplin.
-* `--caplin.custom-genesis value`: Sets a custom genesis for Caplin.
-* `--caplin.use-engine-api`: Uses the Engine API for internal Caplin.
-  * Default: `false`
-* `--beacon.api.read.timeout value`: HTTP read timeout for the Beacon API server, in seconds.
-  * Default: `5`
-* `--beacon.api.write.timeout value`: HTTP write timeout for the Beacon API server, in seconds.
-  * Default: `31536000` (~1 year)
-* `--beacon.api.idle.timeout value`: HTTP idle (keep-alive) timeout for the Beacon API server, in seconds.
-  * Default: `25`
+- `--caplin.discovery.addr value`: The address for the Caplin DISCV5 protocol.
+  - Default: `0.0.0.0`
+
+- `--caplin.discovery.port value`: The port for the Caplin DISCV5 protocol.
+  - Default: `4000`
+
+- `--caplin.discovery.tcpport value`: The TCP port for the Caplin DISCV5 protocol.
+  - Default: `4001`
+
+- `--caplin.checkpoint-sync-url value`: The checkpoint sync endpoint.
+- `--caplin.subscribe-all-topics`: Subscribes to all gossip topics.
+  - Default: `false`
+
+- `--caplin.max-peer-count value`: The maximum number of peers to connect to.
+  - Default: `128`
+
+- `--caplin.enable-upnp`: Enables NAT porting for Caplin.
+  - Default: `false`
+
+- `--caplin.local-discovery`: Also attempts to find peers over private IPs. May cause issues with some hosts (for example, Hetzner).
+  - Default: `false`
+
+- `--caplin.nat value`: NAT port mapping for Caplin P2P. Sets the external IP advertised in the discv5 ENR and libp2p multiaddrs while the socket binds to `--caplin.discovery.addr`. Required when running inside Docker or behind NAT. Accepted values: `""` (none), `"extip:1.2.3.4"`, `"stun"`, `"stun:<host>"`, `"upnp"`, `"pmp"`, `"pmp:192.168.0.1"`.
+  - Default: `""` (no NAT mapping)
+
+- `--caplin.max-inbound-traffic-per-peer value`: The maximum inbound traffic per second per peer.
+  - Default: `1MB`
+
+- `--caplin.max-outbound-traffic-per-peer value`: The maximum outbound traffic per second per peer.
+  - Default: `1MB`
+
+- `--caplin.adaptable-maximum-traffic-requirements`: Makes the node adaptable to traffic based on the number of validators.
+  - Default: `true`
+
+- `--caplin.blocks-archive`: Enables backfilling for blocks.
+  - Default: `false`
+
+- `--caplin.blobs-archive`: Enables backfilling for blobs.
+  - Default: `false`
+
+- `--caplin.states-archive`: Enables the archival node for historical states.
+  - Default: `false`
+
+- `--caplin.blobs-immediate-backfill`: Tells Caplin to immediately backfill blobs.
+  - Default: `false`
+
+- `--caplin.blobs-no-pruning`: Disables blob pruning.
+  - Default: `false`
+
+- `--caplin.columns-keep-slots value`: Number of slots to retain PeerDAS data column sidecars. Increase for DA oracle or rollup nodes that need longer column history.
+  - Default: `0` — uses the chain's spec window, `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS × SLOTS_PER_EPOCH`
+
+- `--caplin.checkpoint-sync.disable`: Disables checkpoint sync.
+  - Default: `false`
+
+- `--caplin.resume-max-staleness-epochs value`: Max epochs a locally-finalized state may be stale for Caplin to resume from it on restart instead of remote checkpoint syncing. Data-availability bound; larger values are clamped to the anchor fork's sidecar-retention window.
+  - Default: `0` (resolves to the anchor fork's sidecar-retention window)
+
+- `--caplin.snapgen`: Enables snapshot generation.
+  - Default: `false`
+
+- `--caplin.mev-relay-url value`: The MEV relay endpoint.
+- `--caplin.validator-monitor`: Enables Caplin validator monitoring metrics.
+  - Default: `false`
+
+- `--caplin.custom-config value`: Sets a custom config for Caplin.
+- `--caplin.custom-genesis value`: Sets a custom genesis for Caplin.
+- `--caplin.use-engine-api`: Uses the Engine API for internal Caplin.
+  - Default: `false`
+
+- `--beacon.api.read.timeout value`: HTTP read timeout for the Beacon API server, in seconds.
+  - Default: `5`
+
+- `--beacon.api.write.timeout value`: HTTP write timeout for the Beacon API server, in seconds.
+  - Default: `31536000` (~1 year)
+
+- `--beacon.api.idle.timeout value`: HTTP idle (keep-alive) timeout for the Beacon API server, in seconds.
+  - Default: `25`
 
 ### Shutter Network Encrypted Transactions
 
-Flags for configuring the [Shutter Network](/staking/shutter-network) encrypted transactions mempool.
+Flags for configuring the [Shutter Network](https://docs.erigon.tech/staking/shutter-network) encrypted transactions mempool.
 
-* `--shutter`: Enables the Shutter encrypted transactions mempool.
-  * Default: `false`
-* `--shutter.p2p.bootstrap.nodes value`: Overrides the default P2P bootstrap nodes.
-* `--shutter.p2p.listen.port value`: Overrides the default P2P listen port.
-  * Default: `0`
+- `--shutter`: Enables the Shutter encrypted transactions mempool.
+  - Default: `false`
+
+- `--shutter.p2p.bootstrap.nodes value`: Overrides the default P2P bootstrap nodes.
+- `--shutter.p2p.listen.port value`: Overrides the default P2P listen port.
+  - Default: `0`
 
 ## Configuration file
 
@@ -2664,46 +2836,46 @@ Erigon supports configuration through environment variables, primarily for exper
 
 **Database and Performance:**
 
-* `MDBX_LOCK_IN_RAM` - Locks MDBX database in RAM for better performance
-* `MDBX_DIRTY_SPACE_MB` - Sets dirty space limit for MDBX database
-* `SNAPSHOT_MADV_RND` - Controls snapshot memory advice randomization (default: `true`)
+- `MDBX_LOCK_IN_RAM` - Locks MDBX database in RAM for better performance
+- `MDBX_DIRTY_SPACE_MB` - Sets dirty space limit for MDBX database
+- `SNAPSHOT_MADV_RND` - Controls snapshot memory advice randomization (default: `true`)
 
 **Synchronization and Pruning:**
 
-* `NO_PRUNE` - Disables pruning when set to true (flag equivalent: `--exec.no-prune`)
-* `NO_MERGE` - Disables merging operations (flag equivalent: `--exec.no-merge`)
-* `PRUNE_TOTAL_DIFFICULTY` - Controls total difficulty pruning (default: `true`)
-* `MAX_REORG_DEPTH` - Sets maximum reorganization depth (default: `96`)
-* `CAPLIN_STATE_PRUNE_DISABLE` - Disables pruning of Caplin's state indexing DB after ranges are frozen into snapshots (default: `false`)
-* `CAPLIN_STATE_PRUNE_TIMEOUT` - Overrides the per-pass time budget for Caplin state pruning (a duration, e.g. `500ms`; default derived from the chain's slot time)
+- `NO_PRUNE` - Disables pruning when set to true (flag equivalent: `--exec.no-prune`)
+- `NO_MERGE` - Disables merging operations (flag equivalent: `--exec.no-merge`)
+- `PRUNE_TOTAL_DIFFICULTY` - Controls total difficulty pruning (default: `true`)
+- `MAX_REORG_DEPTH` - Sets maximum reorganization depth (default: `96`)
+- `CAPLIN_STATE_PRUNE_DISABLE` - Disables pruning of Caplin's state indexing DB after ranges are frozen into snapshots (default: `false`)
+- `CAPLIN_STATE_PRUNE_TIMEOUT` - Overrides the per-pass time budget for Caplin state pruning (a duration, e.g. `500ms`; default derived from the chain's slot time)
 
 **Execution and Processing:**
 
-* `EXEC3_PARALLEL` - Enables parallel block execution (Block-STM). **Default changed to `true` in v3.5** — parallel execution is now on by default. Set to `false` or use `--exec.serial` to revert to single-threaded execution.
-* `EXEC3_WORKERS` - Sets number of parallel execution workers (default: number of CPU cores)
-* `STAGES_ONLY_BLOCKS` - Limits stages to blocks only
+- `EXEC3_PARALLEL` - Enables parallel block execution (Block-STM). **Default changed to `true` in v3.5** — parallel execution is now on by default. Set to `false` or use `--exec.serial` to revert to single-threaded execution.
+- `EXEC3_WORKERS` - Sets number of parallel execution workers (default: number of CPU cores)
+- `STAGES_ONLY_BLOCKS` - Limits stages to blocks only
 
 ### Memory and Debugging Variables
 
 **Memory Management:**
 
-* `NO_MEMSTAT` - Disables memory statistics collection
-* `SAVE_HEAP_PROFILE` - Enables automatic heap profiling
-* `HEAP_PROFILE_THRESHOLD` - Memory usage percentage threshold for heap profiling (default: 35%)
+- `NO_MEMSTAT` - Disables memory statistics collection
+- `SAVE_HEAP_PROFILE` - Enables automatic heap profiling
+- `HEAP_PROFILE_THRESHOLD` - Memory usage percentage threshold for heap profiling (default: 35%)
 
 **Tracing and Debugging:**
 
-* `TRACE_ACCOUNTS` - Comma-separated list of accounts to trace
-* `TRACE_BLOCKS` - Comma-separated list of block numbers to trace
-* `TRACE_INSTRUCTIONS` - Enables instruction-level tracing
+- `TRACE_ACCOUNTS` - Comma-separated list of accounts to trace
+- `TRACE_BLOCKS` - Comma-separated list of block numbers to trace
+- `TRACE_INSTRUCTIONS` - Enables instruction-level tracing
 
 ### Docker Environment Variables
 
-When running Erigon in [Docker](/fundamentals/docker-compose), you can configure user permissions and data directories:
+When running Erigon in [Docker](https://docs.erigon.tech/fundamentals/docker-compose), you can configure user permissions and data directories:
 
-* `DOCKER_UID` - The UID of the Docker user
-* `DOCKER_GID` - The GID of the Docker user
-* `XDG_DATA_HOME` - The data directory mounted to containers
+- `DOCKER_UID` - The UID of the Docker user
+- `DOCKER_GID` - The GID of the Docker user
+- `XDG_DATA_HOME` - The data directory mounted to containers
 
 ### Usage Examples
 
@@ -2737,7 +2909,6 @@ make docker-compose
 # Supported Networks
 URL: https://docs.erigon.tech/fundamentals/supported-networks
 
-
 The default flag is `--chain=mainnet`, which enables Erigon to operate on the Ethereum mainnet. Utilize the flag `--chain=<tag>` to synchronize with one of the supported networks. For example, to synchronize Holesky, one of the Ethereum testnets, use:
 
 ```bash
@@ -2746,28 +2917,28 @@ The default flag is `--chain=mainnet`, which enables Erigon to operate on the Et
 
 ## Mainnets
 
-| Chain     | Tag         | ChainId |
-| --------- | ----------- | ------- |
-| Ethereum  | mainnet     | 1       |
-| Gnosis    | gnosis      | 100     |
+| Chain | Tag | ChainId |
+| --- | --- | --- |
+| Ethereum | mainnet | 1 |
+| Gnosis | gnosis | 100 |
 
 ## Testnets
 
 ### Ethereum testnets
 
-| Chain   | Tag     | ChainId  |
-| ------- | ------- | -------- |
+| Chain | Tag | ChainId |
+| --- | --- | --- |
 | Sepolia | sepolia | 11155111 |
-| Hoodi   | hoodi   | 560048   |
+| Hoodi | hoodi | 560048 |
 
 ### Gnosis Chain Testnets
 
-| Chain  | Tag    | ChainId |
-| ------ | ------ | ------- |
-| Chiado | chiado | 10200   |
+| Chain | Tag | ChainId |
+| --- | --- | --- |
+| Chiado | chiado | 10200 |
 
 :::warning
-Erigon no longer supports Polygon. The final release series that officially supported it is 3.1.\*. For Polygon-supported software, see [https://github.com/0xPolygon/erigon/releases](https://github.com/0xPolygon/erigon/releases).
+Erigon no longer supports Polygon. The final release series that officially supported it is 3.1.*. For Polygon-supported software, see [https://github.com/0xPolygon/erigon/releases](https://github.com/0xPolygon/erigon/releases).
 :::
 
 ---
@@ -2775,16 +2946,16 @@ Erigon no longer supports Polygon. The final release series that officially supp
 # Layer 2 Networks
 URL: https://docs.erigon.tech/fundamentals/layer-2-networks
 
-
 ### Running an Op-Node alongside Erigon
 
 To run an op-node alongside Erigon, follow these steps:
 
-1.  **Start Erigon with Caplin Enabled**: If Caplin is running as the consensus layer (CL), use the `--caplin.blobs-immediate-backfill` flag to ensure the last 18 days of blobs are backfilled, which is critical for proper synchronization with the op-node, assuming you start from a snapshot.
+1. **Start Erigon with Caplin Enabled**: If Caplin is running as the consensus layer (CL), use the `--caplin.blobs-immediate-backfill` flag to ensure the last 18 days of blobs are backfilled, which is critical for proper synchronization with the op-node, assuming you start from a snapshot.
 
-    ```bash
-    ./build/bin/erigon --caplin.blobs-immediate-backfill
-    ```
+```bash
+./build/bin/erigon --caplin.blobs-immediate-backfill
+```
+
 2. **Run the Op-Node**: Configure the op-node with the `--l1.trustrpc` flag to trust the Erigon RPC layer as the L1 node. This setup ensures smooth communication and synchronization.
 
 This configuration enables the op-node to function effectively with Erigon serving as both the L1 node and the CL.
@@ -2798,8 +2969,8 @@ mkdir /disk/datadir && \
 docker run -d -v /disk/datadir/:/home/user/erigon-data/ erigontech/nitro-erigon:main-fe4c973 --torrent.download.rate=10G --prune.mode=archive --l2rpc="http://rpcserver:port --sync.loop.block.limit 100000
 ```
 
-* **Arbitrum Sequencer**: We're currently working on adding support for the Arbitrum Sequencer. Until that work is complete, you must point Erigon to an external L2 Arbitrum RPC to get the most recent transactions and blocks. This can be either a pruned Nitro node you operate or a publicly available RPC. Any data beyond that is queried via the configured `l2rpc` during setup and synchronization, so keep this in mind when bringing a node online.
-* **RPC compatibility**: Before declaring full Arbitrum One support, we are targeting complete RPC compatibility with the Nitro node. Please note that the `timeboosted` field will remain unavailable until Sequencer integration is complete.
+- **Arbitrum Sequencer**: We're currently working on adding support for the Arbitrum Sequencer. Until that work is complete, you must point Erigon to an external L2 Arbitrum RPC to get the most recent transactions and blocks. This can be either a pruned Nitro node you operate or a publicly available RPC. Any data beyond that is queried via the configured `l2rpc` during setup and synchronization, so keep this in mind when bringing a node online.
+- **RPC compatibility**: Before declaring full Arbitrum One support, we are targeting complete RPC compatibility with the Nitro node. Please note that the `timeboosted` field will remain unavailable until Sequencer integration is complete.
 
 For more recent versions, please check [https://hub.docker.com/r/erigontech/nitro-erigon/tags](https://hub.docker.com/r/erigontech/nitro-erigon/tags).
 
@@ -2808,28 +2979,27 @@ For more recent versions, please check [https://hub.docker.com/r/erigontech/nitr
 # Default ports
 URL: https://docs.erigon.tech/fundamentals/default-ports
 
-
 Erigon use the following default port for each service:
 
-| Component | Port    | Protocol  | Purpose                     | Should Expose |
-|-----------|---------|-----------|-----------------------------|---------------|
-| engine    | `9090`  | TCP       | gRPC Server                 | Private       |
-| engine    | `42069` | TCP & UDP | Snap sync (Bittorrent)      | Public        |
-| engine    | `8551`  | TCP       | Engine API (JWT auth)       | Private       |
-| Sentry    | `30303` | TCP & UDP | eth/69, eth/70, eth/71 peering | Public     |
-| Sentry    | `9091`  | TCP       | incoming gRPC Connections   | Private       |
-| RPC Daemon | `8545`  | TCP       | HTTP & WebSockets & GraphQL | Private       |
-| RPC Daemon | `8908`  | TCP       | HTTPS (only when enabled)   | Private       |
-| mcp       | `8553`  | TCP       | MCP server (AI assistants)  | Private       |
-| shutter   | `23102` | TCP       | Peering                     | Public        |
+| Component | Port | Protocol | Purpose | Should Expose |
+| --- | --- | --- | --- | --- |
+| engine | `9090` | TCP | gRPC Server | Private |
+| engine | `42069` | TCP & UDP | Snap sync (Bittorrent) | Public |
+| engine | `8551` | TCP | Engine API (JWT auth) | Private |
+| Sentry | `30303` | TCP & UDP | eth/69, eth/70, eth/71 peering | Public |
+| Sentry | `9091` | TCP | incoming gRPC Connections | Private |
+| RPC Daemon | `8545` | TCP | HTTP & WebSockets & GraphQL | Private |
+| RPC Daemon | `8908` | TCP | HTTPS (only when enabled) | Private |
+| mcp | `8553` | TCP | MCP server (AI assistants) | Private |
+| shutter | `23102` | TCP | Peering | Public |
 
 Typically, `30303` is exposed to the internet to allow incoming peering connections: a single listener serves every supported `eth` protocol version. `9090` is exposed only internally for RPC Daemon or other connections, (e.g. RPC Daemon -> erigon). Port `8551` (JWT authenticated) is exposed only internally for Engine API JSON-RPC queries from the Consensus Layer node.
 
 To ensure proper P2P functionality for both the Execution and Consensus layers use a minimal configuration without exposing unnecessary services:
 
-* Avoid exposing other ports unless necessary for specific use cases (e.g., JSON-RPC or WebSocket);
-* Regularly audit your firewall rules to ensure they are aligned with your infrastructure needs;
-* Use monitoring tools like Prometheus or Grafana to track P2P communication metrics.
+- Avoid exposing other ports unless necessary for specific use cases (e.g., JSON-RPC or WebSocket);
+- Regularly audit your firewall rules to ensure they are aligned with your infrastructure needs;
+- Use monitoring tools like Prometheus or Grafana to track P2P communication metrics.
 
 ## Command-Line Switches for Network and Port Configuration
 
@@ -2837,40 +3007,40 @@ Here is a comprehensive list of port-related options:
 
 ### Engine
 
-* `--private.api.addr [value]`: Erigon's internal gRPC API, empty string means not to start the listener (default: `127.0.0.1:9090`)
-* `--txpool.api.addr [value]`: TxPool api network address, (default: use value of `--private.api.addr`)
-* `--torrent.port [value]`: Port to listen and serve BitTorrent protocol (default: `42069`)
-* `--authrpc.port [value]`: HTTP-RPC server listening port for the Engine API (default: `8551`)
+- `--private.api.addr [value]`: Erigon's internal gRPC API, empty string means not to start the listener (default: `127.0.0.1:9090`)
+- `--txpool.api.addr [value]`: TxPool api network address, (default: use value of `--private.api.addr`)
+- `--torrent.port [value]`: Port to listen and serve BitTorrent protocol (default: `42069`)
+- `--authrpc.port [value]`: HTTP-RPC server listening port for the Engine API (default: `8551`)
 
 ### Sentry
 
-* `--port [value]`: Network listening port (default: `30303`)
-* `--sentry.api.addr [value]`: Comma separated Sentry addresses `<host>:<port>,<host>:<port>` (default `127.0.0.1:9091`)
+- `--port [value]`: Network listening port (default: `30303`)
+- `--sentry.api.addr [value]`: Comma separated Sentry addresses `<host>:<port>,<host>:<port>` (default `127.0.0.1:9091`)
 
 ### RPC Daemon
 
-* `--ws.port [value]`: WS-RPC server listening port (default: `8546`)
-* `--http.port [value]`: HTTP-RPC server listening port (default: `8545`)
-* `--https.port [value]`: HTTPS-RPC server listening port, used only when the HTTPS server is enabled (default: `0`, meaning `--http.port` + 363 — `8908` with a default `--http.port`)
-* `--http.url [value]` / `--https.url [value]`: Full listen URL that overrides the corresponding `addr` and `port` pair (`tcp://` or `unix://`)
-* `--socket.url [value]`: IPC server listen URL, used only when the IPC server is enabled (default: `unix:///var/run/erigon.sock`)
+- `--ws.port [value]`: WS-RPC server listening port (default: `8546`)
+- `--http.port [value]`: HTTP-RPC server listening port (default: `8545`)
+- `--https.port [value]`: HTTPS-RPC server listening port, used only when the HTTPS server is enabled (default: `0`, meaning `--http.port` + 363 — `8908` with a default `--http.port`)
+- `--http.url [value]` / `--https.url [value]`: Full listen URL that overrides the corresponding `addr` and `port` pair (`tcp://` or `unix://`)
+- `--socket.url [value]`: IPC server listen URL, used only when the IPC server is enabled (default: `unix:///var/run/erigon.sock`)
 
 ### Caplin
 
-* `--caplin.discovery.port [value]`: Port for Caplin DISCV5 protocol (default: `4000`)
-* `--caplin.discovery.tcpport [value]`: TCP Port for Caplin DISCV5 protocol (default: `4001`)
+- `--caplin.discovery.port [value]`: Port for Caplin DISCV5 protocol (default: `4000`)
+- `--caplin.discovery.tcpport [value]`: TCP Port for Caplin DISCV5 protocol (default: `4001`)
 
 ### BeaconAPI
 
-* `--beacon.api.port [value]`: Sets the port to listen for beacon api requests (default: `5555`)
+- `--beacon.api.port [value]`: Sets the port to listen for beacon api requests (default: `5555`)
 
 ### MCP Server
 
 The embedded MCP server is enabled by default. To disable it, pass `--mcp.disable`.
 
-* `--mcp.disable`: Disables the embedded MCP server (default: `false`)
-* `--mcp.addr [value]`: MCP server listening address (default: `127.0.0.1`)
-* `--mcp.port [value]`: MCP server listening port (default: `8553`)
+- `--mcp.disable`: Disables the embedded MCP server (default: `false`)
+- `--mcp.addr [value]`: MCP server listening address (default: `127.0.0.1`)
+- `--mcp.port [value]`: MCP server listening port (default: `8553`)
 
 ## Shutter Network Default Ports
 
@@ -2880,15 +3050,14 @@ Bootstrap nodes are used to help new nodes discover other nodes in the network. 
 
 ### Shared ports
 
-* `--pprof.port [value]`: pprof HTTP server listening port (default: `6060`)
-* `--metrics.port [value]`: Metrics HTTP server listening port (default: `6061`)
-* `--downloader.api.addr [value]`: Downloader address `<host>:<port>`
+- `--pprof.port [value]`: pprof HTTP server listening port (default: `6060`)
+- `--metrics.port [value]`: Metrics HTTP server listening port (default: `6061`)
+- `--downloader.api.addr [value]`: Downloader address `<host>:<port>`
 
 ---
 
 # NAT
 URL: https://docs.erigon.tech/fundamentals/nat
-
 
 ### What `--nat` really controls
 
@@ -2896,34 +3065,34 @@ The `--nat` option controls how Erigon advertises its external address to other 
 
 It does not:
 
-* open firewall ports for you
-* guarantee inbound connectivity by itself
-* directly control peer count
+- open firewall ports for you
+- guarantee inbound connectivity by itself
+- directly control peer count
 
 Instead, it determines whether other nodes can initiate inbound connections to your node, which has a significant impact on:
 
-* peer diversity (inbound vs outbound)
-* transaction gossip freshness
-* block content quality for validators and block producers
+- peer diversity (inbound vs outbound)
+- transaction gossip freshness
+- block content quality for validators and block producers
 
 ### Why NAT configuration matters more than peer count
 
 Ethereum P2P is bidirectional:
 
-* your node connects outbound to peers
-* other nodes may connect inbound to you
+- your node connects outbound to peers
+- other nodes may connect inbound to you
 
 Nodes that are reachable from the internet (i.e. correctly advertised via NAT) tend to:
 
-* receive transactions earlier
-* receive a wider variety of transactions
-* maintain a healthier "pending" transaction pool
+- receive transactions earlier
+- receive a wider variety of transactions
+- maintain a healthier "pending" transaction pool
 
 For validators and block producers, this directly affects:
 
-* transaction inclusion
-* gas usage
-* likelihood of producing empty or low-gas blocks
+- transaction inclusion
+- gas usage
+- likelihood of producing empty or low-gas blocks
 
 A high peer count alone does not guarantee good transaction propagation if most peers are outbound-only.
 
@@ -2935,15 +3104,15 @@ Disables external address advertisement.
 
 Erigon will not advertise a reachable address to peers. In practice, this often results in:
 
-* mostly outbound connections
-* few or no inbound peers
-* delayed or stale transaction gossip
+- mostly outbound connections
+- few or no inbound peers
+- delayed or stale transaction gossip
 
 **Important**: `nat: none` is generally not recommended for validators or block producers, even if peer count appears high. It is primarily suitable for:
 
-* private networks
-* non-proposing archive / RPC nodes
-* restricted environments where inbound connectivity is intentionally disabled
+- private networks
+- non-proposing archive / RPC nodes
+- restricted environments where inbound connectivity is intentionally disabled
 
 ### `nat: extip:` (recommended for datacenters & VPS)
 
@@ -2951,15 +3120,15 @@ Explicitly advertises the given public IPv4 address to peers.
 
 This is the most reliable and deterministic option when:
 
-* your node has a stable public IPv4 address
-* required P2P ports are open in the firewall
+- your node has a stable public IPv4 address
+- required P2P ports are open in the firewall
 
 Benefits:
 
-* enables inbound peer connections
-* improves transaction gossip freshness
-* leads to healthier TxPool "pending" state
-* strongly recommended for validators
+- enables inbound peer connections
+- improves transaction gossip freshness
+- leads to healthier TxPool "pending" state
+- strongly recommended for validators
 
 Example:
 
@@ -2973,8 +3142,8 @@ Enables automatic NAT detection (e.g. UPnP / NAT-PMP where available).
 
 Suitable for:
 
-* home networks
-* environments where the external IP is not known in advance
+- home networks
+- environments where the external IP is not known in advance
 
 Less deterministic than extip, but generally better than none.
 
@@ -2984,9 +3153,9 @@ Uses STUN to discover the external address.
 
 Useful when:
 
-* running behind NAT
-* no UPnP is available
-* external IP cannot be configured manually
+- running behind NAT
+- no UPnP is available
+- external IP cannot be configured manually
 
 ## Caplin (consensus layer) NAT
 
@@ -2995,7 +3164,7 @@ If you are running Erigon with the embedded Caplin consensus layer, configure NA
 This flag sets the external address advertised in the **discv5 ENR** and **libp2p multiaddrs**; the socket itself still binds to `--caplin.discovery.addr`. It accepts the same values as `--nat`:
 
 | Value | Behavior |
-|-------|-----------|
+| --- | --- |
 | `""` (default) | No NAT mapping — CL peers cannot reach you inbound |
 | `extip:1.2.3.4` | Advertise a fixed public IP — recommended for VPS / datacenters |
 | `stun` | Discover external IP via STUN |
@@ -3015,7 +3184,6 @@ Set **both** `--nat` and `--caplin.nat` to the same external IP, otherwise your 
 # Optimizing Storage
 URL: https://docs.erigon.tech/fundamentals/optimizing-storage
 
-
 For optimal performance, it's recommended to store the datadir on a fast NVMe-RAID disk. However, if this is not feasible, you can store the history on a cheaper disk and still achieve good performance.
 
 ### Step 1
@@ -3024,20 +3192,21 @@ For optimal performance, it's recommended to store the datadir on a fast NVMe-RA
 
 Place the `datadir` on the slower disk. Then, create symbolic links (using `ln -s`) to the **fast disk** for the following sub-folders:
 
-* `chaindata`
-* `snapshots/domain`
+- `chaindata`
+- `snapshots/domain`
 
 This will speed up the execution of E3.
 
 On the **slow disk** place `datadir` folder with the following structure:
 
-* `chaindata` (linked to fast disk)
-* `snapshots`
-  * `domain` (linked to fast disk)
-  * `history`
-  * `idx`
-  * `accessor`
-* `temp`
+- `chaindata` (linked to fast disk)
+- `snapshots`
+  - `domain` (linked to fast disk)
+  - `history`
+  - `idx`
+  - `accessor`
+
+- `temp`
 
 ### Step 2
 
@@ -3056,18 +3225,17 @@ By following these steps, you can optimize your Erigon 3 storage setup to achiev
 # Performance Tricks
 URL: https://docs.erigon.tech/fundamentals/performance-tricks
 
-
 These instructions are designed to improve the performance of Erigon 3, particularly for synchronization and memory management, on cloud drives and other systems with specific performance characteristics.
 
 ## Increase Sync Speed
 
-* Set `--sync.loop.block.limit=10_000` and `--batchSize=2g` to speed up the synchronization process.
+- Set `--sync.loop.block.limit=10_000` and `--batchSize=2g` to speed up the synchronization process.
 
 ```bash
 --sync.loop.block.limit=10_000 --batchSize=2g
 ```
 
-* Adjust download speed with flag `--torrent.download.rate=[value]` setting your max speed (default value is `512mb`). For example:
+- Adjust download speed with flag `--torrent.download.rate=[value]` setting your max speed (default value is `512mb`). For example:
 
 ```bash
 --torrent.download.rate=1024mb
@@ -3075,7 +3243,7 @@ These instructions are designed to improve the performance of Erigon 3, particul
 
 ## Optimize for Cloud Drives
 
-* Set `SNAPSHOT_MADV_RND=false` to enable the operating system's cache prefetching for better performance on cloud drives with good throughput but bad latency.
+- Set `SNAPSHOT_MADV_RND=false` to enable the operating system's cache prefetching for better performance on cloud drives with good throughput but bad latency.
 
 ```bash
 SNAPSHOT_MADV_RND=false
@@ -3083,23 +3251,23 @@ SNAPSHOT_MADV_RND=false
 
 ## Lock Latest State in RAM
 
-* Use `vmtouch -vdlw /mnt/erigon/snapshots/domain/*bt` to lock the latest state in RAM, preventing it from being evicted due to high historical RPC traffic.
+- Use `vmtouch -vdlw /mnt/erigon/snapshots/domain/*bt` to lock the latest state in RAM, preventing it from being evicted due to high historical RPC traffic.
 
 ```bash
 vmtouch -vdlw /mnt/erigon/snapshots/domain/*bt
 ```
 
-* Run `ls /mnt/erigon/snapshots/domain/*.kv | parallel vmtouch -vdlw` to apply the same locking to all relevant files.
+- Run `ls /mnt/erigon/snapshots/domain/*.kv | parallel vmtouch -vdlw` to apply the same locking to all relevant files.
 
 ## Handle Memory Allocation Issues
 
-* If you encounter issues with memory allocation, run the following to flush any pending write operations and free up memory:
+- If you encounter issues with memory allocation, run the following to flush any pending write operations and free up memory:
 
 ```bash
 sync && sudo sysctl vm.drop_caches=3
 ```
 
-* Alternatively, set:
+- Alternatively, set:
 
 ```bash
 echo 1 > /proc/sys/vm/compact_memory
@@ -3112,20 +3280,19 @@ to help with memory allocation.
 # Multiple instances / One machine
 URL: https://docs.erigon.tech/fundamentals/multiple-instances
 
-
 Erigon supports running multiple instances on the same machine by configuring distinct ports and data directories for each instance. Multiple instances are fully supported but require careful configuration to avoid port conflicts and resource contention. The modular architecture allows for flexible deployment patterns, from fully integrated instances to distributed service architectures. The primary consideration is the performance impact from shared disk access, especially during initial synchronization phases.
 
 ## Required Configuration Flags
 
 To avoid conflicts between instances, you must define **7 essential flags** for each instance:
 
-* `--datadir` - Separate data directory for each instance
-* `--port` - P2P networking port (default: `30303`)
-* `--http.port` - HTTP JSON-RPC port (default: `8545`)
-* `--authrpc.port` - Engine API port (default: `8551`)
-* `--torrent.port` - BitTorrent protocol port (default: `42069`)
-* `--private.api.addr` - Internal gRPC API address (default: `127.0.0.1:9090`)
-* `--mcp.port` - MCP server port (default: `8553`), or `--mcp.disable` to turn it off
+- `--datadir` - Separate data directory for each instance
+- `--port` - P2P networking port (default: `30303`)
+- `--http.port` - HTTP JSON-RPC port (default: `8545`)
+- `--authrpc.port` - Engine API port (default: `8551`)
+- `--torrent.port` - BitTorrent protocol port (default: `42069`)
+- `--private.api.addr` - Internal gRPC API address (default: `127.0.0.1:9090`)
+- `--mcp.port` - MCP server port (default: `8553`), or `--mcp.disable` to turn it off
 
 ## Example Configuration
 
@@ -3165,9 +3332,9 @@ For containerized deployments, the docker-compose configuration shows how servic
 
 The compose file demonstrates the port allocation strategy:
 
-* **9090-9094**: Internal gRPC services (execution, Sentry, consensus, Downloader, TxPool)
-* **8545, 8551**: External HTTP APIs
-* **30303, 42069**: P2P networking ports
+- **9090-9094**: Internal gRPC services (execution, Sentry, consensus, Downloader, TxPool)
+- **8545, 8551**: External HTTP APIs
+- **30303, 42069**: P2P networking ports
 
 ## Best Practices
 
@@ -3175,9 +3342,9 @@ The compose file demonstrates the port allocation strategy:
 
 **Memory Considerations:** Erigon uses memory-mapped files (MDBX) where the OS manages page cache. Multiple instances will share the same page cache efficiently, but be aware that:
 
-* Each instance uses \~4GB RAM during genesis sync and \~1GB during normal operation
-* OS page cache can utilize unlimited memory and is shared between instances
-* Memory usage shown by `htop` includes OS page cache and may appear inflated
+- Each instance uses ~4GB RAM during genesis sync and ~1GB during normal operation
+- OS page cache can utilize unlimited memory and is shared between instances
+- Memory usage shown by `htop` includes OS page cache and may appear inflated
 
 :::warning
 ⚠️ **Disk Performance Warning:** Multiple instances accessing the same disk concurrently will impact performance due to increased random disk access. This is particularly problematic during the "Blocks Execution stage" which performs many random reads. **Avoid running multiple genesis syncs on the same disk.**
@@ -3196,14 +3363,14 @@ For multiple instances, consider adjusting database parameters to reduce resourc
 
 **Default Port Allocation:**
 
-| Component | Default Port | Protocol | Purpose                  |
-|-----------|--------------|----------|--------------------------|
-| Engine    | 9090         | TCP      | gRPC Server (Private)    |
-| Engine    | 42069        | TCP/UDP  | BitTorrent (Public)      |
-| Engine    | 8551         | TCP      | Engine API (Private)     |
-| Sentry    | 30303        | TCP/UDP  | P2P Peering (Public)     |
-| RPC Daemon | 8545         | TCP      | HTTP/WebSocket (Private) |
-| MCP       | 8553         | TCP      | MCP Server (Private)     |
+| Component | Default Port | Protocol | Purpose |
+| --- | --- | --- | --- |
+| Engine | 9090 | TCP | gRPC Server (Private) |
+| Engine | 42069 | TCP/UDP | BitTorrent (Public) |
+| Engine | 8551 | TCP | Engine API (Private) |
+| Sentry | 30303 | TCP/UDP | P2P Peering (Public) |
+| RPC Daemon | 8545 | TCP | HTTP/WebSocket (Private) |
+| MCP | 8553 | TCP | MCP Server (Private) |
 
 ### 4. Service Separation
 
@@ -3211,9 +3378,9 @@ Erigon supports modular deployment where components can run as separate processe
 
 For multiple instances, you can:
 
-* Run each instance with integrated services (default)
-* Separate heavy components like `downloader` or `rpcdaemon` to dedicated processes
-* Use the `--private.api.addr` flag for inter-service communication
+- Run each instance with integrated services (default)
+- Separate heavy components like `downloader` or `rpcdaemon` to dedicated processes
+- Use the `--private.api.addr` flag for inter-service communication
 
 ### 5. Monitoring and Logging
 
@@ -3269,13 +3436,14 @@ echo 1 > /proc/sys/vm/compact_memory
 
 What can be done:
 
-* reduce disk latency (not throughput, not iops)
-  * use latency-critical cloud-drives
-  * or attached-NVMe (at least for initial sync)
-* increase RAM
-* if you throw enough RAM, then can set env variable `SNAPSHOT_MADV_RND=false`
-* Use `--db.pagesize=64kb` (less fragmentation, more IO)
-* Or use Erigon 3 (it also sensitive for disk-latency - but it will download 99% of history)
+- reduce disk latency (not throughput, not iops)
+  - use latency-critical cloud-drives
+  - or attached-NVMe (at least for initial sync)
+
+- increase RAM
+- if you throw enough RAM, then can set env variable `SNAPSHOT_MADV_RND=false`
+- Use `--db.pagesize=64kb` (less fragmentation, more IO)
+- Or use Erigon 3 (it also sensitive for disk-latency - but it will download 99% of history)
 
 ```yaml
 # Ports: `9090` execution engine (private api), `9091` sentry, `9092` consensus engine, `9093` snapshot downloader, `9094` TxPool
@@ -3339,13 +3507,12 @@ Erigon itself consumes less than 2GB of RAM. Therefore, Erigon will benefit from
 # Logs
 URL: https://docs.erigon.tech/fundamentals/logs
 
-
 Erigon features a sophisticated logging framework that offers detailed visibility into the synchronization process and operational status. This system provides comprehensive, structured logs suitable for both human operators and automated monitoring, while maintaining high performance.
 
 The modular, staged approach to logging allows for granular control over verbosity, which is crucial for precise debugging and flexible deployment across various environments.
 
 :::tip
-Erigon offers a `--metrics` flag for using Prometheus/Grafana monitoring, see [Creating a Dashboard](creating-a-dashboard).
+Erigon offers a `--metrics` flag for using Prometheus/Grafana monitoring, see [Creating a Dashboard](https://docs.erigon.tech/fundamentals/creating-a-dashboard).
 :::
 
 ## Logging Framework Architecture
@@ -3358,22 +3525,22 @@ Erigon implements a custom logging framework that supports structured logging wi
 
 Erigon provides extensive logging configuration through command-line flags. Key configuration options include:
 
-* `--log.json`: Enable JSON formatting for console logs
-* `--verbosity`: Set console log level (default: `info`)
-* `--log.dir.path`: Specify directory for log files. By default Erigon writing logs to `datadir/logs` directory.
-* `--log.dir.verbosity`: Set file log level (default: `dbug`)
-* `--log.delays`: Enable block delay logging
+- `--log.json`: Enable JSON formatting for console logs
+- `--verbosity`: Set console log level (default: `info`)
+- `--log.dir.path`: Specify directory for log files. By default Erigon writing logs to `datadir/logs` directory.
+- `--log.dir.verbosity`: Set file log level (default: `dbug`)
+- `--log.delays`: Enable block delay logging
 
 **Log Levels**
 
 The logging system defines six distinct log levels in hierarchical order:
 
-* **LvlCrit (0)**: Critical errors that may cause application termination
-* **LvlError (1)**: Error conditions that require attention
-* **LvlWarn (2)**: Warning messages for potentially problematic situations
-* **LvlInfo (3)**: General informational messages
-* **LvlDebug (4)**: Detailed debugging information
-* **LvlTrace (5)**: Most verbose tracing information
+- **LvlCrit (0)**: Critical errors that may cause application termination
+- **LvlError (1)**: Error conditions that require attention
+- **LvlWarn (2)**: Warning messages for potentially problematic situations
+- **LvlInfo (3)**: General informational messages
+- **LvlDebug (4)**: Detailed debugging information
+- **LvlTrace (5)**: Most verbose tracing information
 
 The log level is set by using the `--verbosity` flag, for example:
 
@@ -3393,14 +3560,14 @@ Erigon's synchronization process is organized into sequential stages, each handl
 
 The primary synchronization stages include:
 
-* **Snapshots (OtterSync)**: Download and process blockchain snapshots
-* **Headers**: Download and validate block headers
-* **BlockHashes**: Generate block number to hash mappings
-* **Bodies**: Download and validate block bodies
-* **Senders**: Recover transaction senders from signatures
-* **Execution**: Execute transactions and update state
-* **TxLookup**: Generates transaction lookup indices. This indexing is essential for quickly finding transaction by its hash, significantly improving the performance of transaction-related RPC calls.
-* **Finish**: The finalization stage of the sync process. This is the point where the node sends out notifications to subscribers about the new blockchain head, ensuring other components and external applications are instantly aware of the latest block.
+- **Snapshots (OtterSync)**: Download and process blockchain snapshots
+- **Headers**: Download and validate block headers
+- **BlockHashes**: Generate block number to hash mappings
+- **Bodies**: Download and validate block bodies
+- **Senders**: Recover transaction senders from signatures
+- **Execution**: Execute transactions and update state
+- **TxLookup**: Generates transaction lookup indices. This indexing is essential for quickly finding transaction by its hash, significantly improving the performance of transaction-related RPC calls.
+- **Finish**: The finalization stage of the sync process. This is the point where the node sends out notifications to subscribers about the new blockchain head, ensuring other components and external applications are instantly aware of the latest block.
 
 ### Stage Progress Tracking
 
@@ -3414,10 +3581,10 @@ All log messages follow a consistent structured format with key-value pairs for 
 
 **Standard Fields:**
 
-* Timestamp (t)
-* Log level (lvl)
-* Message (msg)
-* Contextual key-value pairs
+- Timestamp (t)
+- Log level (lvl)
+- Message (msg)
+- Contextual key-value pairs
 
 ### Prefix System
 
@@ -3430,7 +3597,6 @@ The prefix format includes stage position and total count (e.g., "1/10 Headers")
 # Security
 URL: https://docs.erigon.tech/fundamentals/security
 
-
 The security practices focus heavily on the RPC Daemon since it's the primary external interface. The modular architecture allows you to run components separately, which can improve security by isolating services. For production deployments, consider using the distributed mode where services communicate via secured gRPC rather than running everything in a single process.
 
 ## Network Security
@@ -3439,39 +3605,39 @@ Securing your network ports is essential for protecting your Erigon node. Proper
 
 Based on best practices for execution clients, your local machine's firewall settings should be configured as follows:
 
-| **Port** | **Protocol** | **Purpose**                   | **Firewall Action**                                                                                                                      |
-| -------- | ------------ | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| 30303    | TCP & UDP    | Peer-to-Peer (P2P) Networking | Allow inbound and outbound traffic to enable peer discovery and connections.                                                             |
-| 8545     | TCP          | JSON-RPC (Public API)         | Block all traffic _except_ from explicitly defined trusted machines. This port should never be publicly exposed without strict controls. |
-| 9090     | TCP          | Private API Communication     | Block all traffic except for communication between your internal components (e.g., RPC Daemon and core node).                            |
+| **Port** | **Protocol** | **Purpose** | **Firewall Action** |
+| --- | --- | --- | --- |
+| 30303 | TCP & UDP | Peer-to-Peer (P2P) Networking | Allow inbound and outbound traffic to enable peer discovery and connections. |
+| 8545 | TCP | JSON-RPC (Public API) | Block all traffic *except* from explicitly defined trusted machines. This port should never be publicly exposed without strict controls. |
+| 9090 | TCP | Private API Communication | Block all traffic except for communication between your internal components (e.g., RPC Daemon and core node). |
 
 #### CORS Protection
 
 When exposing public RPC endpoints (like those on port 8545), use the following practice to mitigate cross-origin attacks:
 
-* Avoid using a wildcard `*` for Cross-Origin Resource Sharing (CORS) domains.
-* Set specific hostnames or IP addresses for CORS to ensure only authorized frontend applications can interact with your RPC service.
+- Avoid using a wildcard `*` for Cross-Origin Resource Sharing (CORS) domains.
+- Set specific hostnames or IP addresses for CORS to ensure only authorized frontend applications can interact with your RPC service.
 
 ## API Security
 
 The RPC Daemon is the primary external interface, making API security critical. To protect against abuse, denial-of-service (DoS) attacks, OOM issues and unauthorized access, implement the following controls:
 
-| **Security Measure** | **Description**                                                                                                                                                                                           | **Erigon Configuration**                                                                                                                                                             |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Method Allowlisting  | Restrict the available RPC methods to only those strictly necessary. This significantly reduces the attack surface.Can be applied to erigon or RPC Daemon process. | Use the `--rpc.accessList=rules.json` flag, pointing to a JSON file (e.g., `rules.json`) that specifies the allowed methods: `{"allow": ["net_version", "eth_getBlockByHash"]}`      |
-| Remove Admin APIs    | Never include sensitive namespaces like `admin` or `debug` in the `--http.api` list for public-facing nodes. These APIs are intended for node operators only.                                             | Omit the `admin` and `debug` namespaces from `--http.api`.                                                                                                                           |
-| Rate Limiting        | Protect against DoS attacks by limiting the processing capacity for HTTP requests and batch requests.                                                                                                               | Configure `--rpc.max.concurrency` (HTTP admission control: `0` = use `--db.read.concurrency`, `-1` = unlimited), `--rpc.batch.concurrency` and `--rpc.batch.limit`. |
-| Subscription Filters | Control WebSocket subscriptions to prevent Out-of-Memory (OOM) errors caused by a large number of filter requests.                                                                                        | Utilize the various --rpc.subscription.filters.* flags.Note: These are disabled by default because they increase the risk of OOM issues. |
+| **Security Measure** | **Description** | **Erigon Configuration** |
+| --- | --- | --- |
+| Method Allowlisting | Restrict the available RPC methods to only those strictly necessary. This significantly reduces the attack surface. Can be applied to `erigon` or `RPC Daemon` process. | Use the `--rpc.accessList=rules.json` flag, pointing to a JSON file (e.g., `rules.json`) that specifies the allowed methods: `{"allow": ["net_version", "eth_getBlockByHash"]}` |
+| Remove Admin APIs | Never include sensitive namespaces like `admin` or `debug` in the `--http.api` list for public-facing nodes. These APIs are intended for node operators only. | Omit the `admin` and `debug` namespaces from `--http.api`. |
+| Rate Limiting | Protect against DoS attacks by limiting the processing capacity for HTTP requests and batch requests. | Configure `--rpc.max.concurrency` (HTTP admission control: `0` = use `--db.read.concurrency`, `-1` = unlimited), `--rpc.batch.concurrency` and `--rpc.batch.limit`. |
+| Subscription Filters | Control WebSocket subscriptions to prevent Out-of-Memory (OOM) errors caused by a large number of filter requests. | Utilize the various `--rpc.subscription.filters.*` flags. **Note**: These are disabled by default because they increase the risk of OOM issues. |
 
 ### External Protection Layer (Recommended for Production)
 
 For production environments where RPC endpoints are exposed publicly, it is strongly recommended to place the Erigon node behind a robust proxy layer. This layer should be responsible for:
 
-* **Application-Level Filtering**: Implementing more granular logic than basic allowlists.
-* **Rate Limiting**: Providing centralized, high-performance rate limiting.
-* **TLS Termination**: Handling SSL/TLS encryption/decryption.
-* **Monitoring and Logging**: Tracking requests for security auditing.
-* **Web Application Firewalls (WAFs)**: Protecting against common web exploits.
+- **Application-Level Filtering**: Implementing more granular logic than basic allowlists.
+- **Rate Limiting**: Providing centralized, high-performance rate limiting.
+- **TLS Termination**: Handling SSL/TLS encryption/decryption.
+- **Monitoring and Logging**: Tracking requests for security auditing.
+- **Web Application Firewalls (WAFs)**: Protecting against common web exploits.
 
 ## TLS and Authentication
 
@@ -3493,7 +3659,6 @@ For production environments where RPC endpoints are exposed publicly, it is stro
 
 # JWT Secret
 URL: https://docs.erigon.tech/fundamentals/jwt
-
 
 The JWT secret is a key that allows Ethereum entities to securely validate JWTs used for authentication, authorization, and transmitting information, like a passphrase that allows Ethereum nodes/servers to verify if requests are legitimate. It should be protected and not exposed publicly.
 
@@ -3520,19 +3685,18 @@ Both Erigon and any external Consensus Layer need to point to the same JWT secre
 # TLS Authentication
 URL: https://docs.erigon.tech/fundamentals/tls-authentication
 
-
 ## Introduction
 
 TLS authentication can be enabled to ensure communication integrity and access control to the Erigon node.
 
 At a high level, the process consists of:
 
-1. [Generate the Certificate Authority (CA) key pair](#1-generating-the-key-pair-for-the-certificate-authority-ca)
-2. [Create the Certificate Authority certificate file](#2-creating-the-ca-certificate-file)
-3. [Generate a key pair](#3-generating-a-key-pair)
-4. [Create the certificate file for each public key](#4-creating-the-certificate-file-for-each-public-key)
-5. [Deploy the files to each instance](#5-deploy-the-files-on-each-instance)
-6. [Run Erigon and RPC Daemon with the correct tags](#6-run-erigon-and-rpc-daemon-with-the-correct-tags)
+1. [Generate the Certificate Authority (CA) key pair](https://docs.erigon.tech/fundamentals/tls-authentication#1-generating-the-key-pair-for-the-certificate-authority-ca)
+2. [Create the Certificate Authority certificate file](https://docs.erigon.tech/fundamentals/tls-authentication#2-creating-the-ca-certificate-file)
+3. [Generate a key pair](https://docs.erigon.tech/fundamentals/tls-authentication#3-generating-a-key-pair)
+4. [Create the certificate file for each public key](https://docs.erigon.tech/fundamentals/tls-authentication#4-creating-the-certificate-file-for-each-public-key)
+5. [Deploy the files to each instance](https://docs.erigon.tech/fundamentals/tls-authentication#5-deploy-the-files-on-each-instance)
+6. [Run Erigon and RPC Daemon with the correct tags](https://docs.erigon.tech/fundamentals/tls-authentication#6-run-erigon-and-rpc-daemon-with-the-correct-tags)
 
 The following is a detailed description of how to use the **OpenSSL** suite of tools to secure the connection between a remote Erigon node and a remote or local RPC Daemon. The same procedure applies to any Erigon component you wish to run separately; it is recommended to name the files accordingly.
 
@@ -3639,7 +3803,6 @@ While the RPC Daemon must be started with these additional options:
 # MCP Server
 URL: https://docs.erigon.tech/fundamentals/mcp
 
-
 The **Model Context Protocol (MCP)** is an open standard developed by Anthropic that allows AI assistants (such as Claude Desktop) to securely connect to external data sources and tools. MCP defines a uniform interface through which an AI model can discover, read, and invoke capabilities provided by a server — without needing any custom integration code.
 
 Erigon ships a full MCP server implementation. Once connected, an AI assistant gains structured, read-only access to Ethereum blockchain data, Erigon logs, and internal metrics — turning natural-language questions into precise on-chain lookups.
@@ -3654,8 +3817,7 @@ Erigon provides two ways to run the MCP server:
 
 ### Embedded (inside Erigon)
 
-The MCP server runs inside the main `erigon` process, with direct access to internal APIs and Prometheus metrics. It is
-**enabled by default** on `127.0.0.1:8553`:
+The MCP server runs inside the main `erigon` process, with direct access to internal APIs and Prometheus metrics. It is **enabled by default** on `127.0.0.1:8553`:
 
 ```bash
 # MCP server starts automatically on 127.0.0.1:8553
@@ -3683,23 +3845,20 @@ make mcp
 
 ### Flags (embedded mode)
 
-| Flag            | Default     | Description                                   |
-|-----------------|-------------|-----------------------------------------------|
-| `--mcp.disable` | `false`     | Disable the embedded MCP server entirely      |
-| `--mcp.addr`    | `127.0.0.1` | Listening address for the embedded MCP server |
-| `--mcp.port`    | `8553`      | Listening port for the embedded MCP server    |
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--mcp.disable` | `false` | Disable the embedded MCP server entirely |
+| `--mcp.addr` | `127.0.0.1` | Listening address for the embedded MCP server |
+| `--mcp.port` | `8553` | Listening port for the embedded MCP server |
 
 :::info
-The embedded MCP server is **enabled by default** and listens on `127.0.0.1:8553`. Because it binds to localhost only,
-it is not reachable from external networks. If you do not need AI-assistant integration, pass `--mcp.disable` to avoid
-opening the port. If you are running multiple Erigon instances on the same machine, assign distinct ports with
-`--mcp.port` to avoid conflicts.
+The embedded MCP server is **enabled by default** and listens on `127.0.0.1:8553`. Because it binds to localhost only, it is not reachable from external networks. If you do not need AI-assistant integration, pass `--mcp.disable` to avoid opening the port. If you are running multiple Erigon instances on the same machine, assign distinct ports with `--mcp.port` to avoid conflicts.
 :::
 
 ### Flags (standalone `mcp` binary)
 
 | Flag | Default | Description |
-|------|---------|-------------|
+| --- | --- | --- |
 | `--rpc.url` | `http://127.0.0.1:8545` | Erigon JSON-RPC endpoint to proxy |
 | `--port` | — | Shorthand for `--rpc.url http://127.0.0.1:<port>` |
 | `--datadir` | — | Erigon data directory (enables direct DB access mode) |
@@ -3781,6 +3940,8 @@ When something looks wrong with your node, ask the assistant to sift through log
 
 Add the following to your Claude Desktop configuration file (`~/.config/claude-desktop/config.json` on Linux/macOS, `%APPDATA%\claude-desktop\config.json` on Windows):
 
+**JSON-RPC mode**
+
 ```json
 {
   "mcpServers": {
@@ -3791,6 +3952,8 @@ Add the following to your Claude Desktop configuration file (`~/.config/claude-d
   }
 }
 ```
+
+**Datadir mode**
 
 ```json
 {
@@ -3803,6 +3966,8 @@ Add the following to your Claude Desktop configuration file (`~/.config/claude-d
 }
 ```
 
+**Embedded (HTTP)**
+
 ```json
 {
   "mcpServers": {
@@ -3814,9 +3979,7 @@ Add the following to your Claude Desktop configuration file (`~/.config/claude-d
 }
 ```
 
-The embedded MCP server starts by default on `127.0.0.1:8553` and serves streamable HTTP at `/mcp` plus SSE at `/sse`
-(use `"type": "sse"` with the `/sse` URL for clients that only support SSE). To use a different address or port, pass
-`--mcp.addr` and `--mcp.port`. To disable it, pass `--mcp.disable`.
+The embedded MCP server starts by default on `127.0.0.1:8553` and serves streamable HTTP at `/mcp` plus SSE at `/sse` (use `"type": "sse"` with the `/sse` URL for clients that only support SSE). To use a different address or port, pass `--mcp.addr` and `--mcp.port`. To disable it, pass `--mcp.disable`.
 
 After saving, restart Claude Desktop. The Erigon tools will appear in the tool panel under **erigon**.
 
@@ -3860,12 +4023,16 @@ claude mcp remove erigon
 
 [OpenAI Codex CLI](https://github.com/openai/codex) supports MCP servers via `~/.codex/config.yaml`. Add the `mcp_servers` key to your existing config file:
 
+**Embedded SSE**
+
 ```yaml
 mcp_servers:
   erigon:
     type: sse
     url: http://127.0.0.1:8553/sse
 ```
+
+**Standalone stdio**
 
 ```yaml
 mcp_servers:
@@ -3925,7 +4092,7 @@ In addition to tools, the MCP server exposes structured **resources** and **prom
 **Resources** (addressable by URI):
 
 | Resource | Description |
-|----------|-------------|
+| --- | --- |
 | `erigon://node/info` | Node version, chain, capabilities |
 | `erigon://chain/config` | Full chain configuration |
 | `erigon://blocks/recent` | Last 10 blocks summary |
@@ -3938,7 +4105,7 @@ In addition to tools, the MCP server exposes structured **resources** and **prom
 **Prompts** (pre-built analysis templates):
 
 | Prompt | Description |
-|--------|-------------|
+| --- | --- |
 | `analyze_transaction` | Deep-dive into a transaction |
 | `investigate_address` | Profile an address (balance, history, code) |
 | `analyze_block` | Summarise a block and its transactions |
@@ -3947,20 +4114,18 @@ In addition to tools, the MCP server exposes structured **resources** and **prom
 | `torrent_status` | Snapshot download health check |
 | `sync_analysis` | Node sync progress and performance |
 
----
-
 ## These Docs as a Single File
 
 MCP connects a model to your **running node**. To let a model answer questions about **Erigon itself** — flags, pruning modes, RPC namespaces, hardware sizing — point it at this documentation in machine-readable form, following the [llmstxt.org](https://llmstxt.org) convention:
 
 | File | Contents | Use it when |
-|------|----------|-------------|
+| --- | --- | --- |
 | [llms.txt](https://docs.erigon.tech/llms.txt) | Index of the current documentation, with titles and descriptions | The model fetches pages on demand, or its context window is small |
 | [llms-full.txt](https://docs.erigon.tech/llms-full.txt) | The text of those same pages, as one plain-text file | You want the whole corpus in context, offline, with nothing scraped |
 
-Both are generated from the same Markdown source as this site by a script in the repository, and CI fails when a documentation change lands without regenerating them, so they cannot quietly go stale.
+Both are generated from this site's built pages by a script in the repository, and CI fails when a documentation change lands without regenerating them, so they cannot quietly go stale.
 
-Two things to know about their scope. They cover the **current** documentation and the help center only — archived versions, published under `/vX.Y/`, are not included. And the text is cleaned rather than copied verbatim: MDX components are stripped, and a section index page built as a card grid is reduced to the list of links its grids present rather than its prose. Read the corpus as the documentation's prose, not as a byte-for-byte mirror of the rendered site.
+Two things to know about their scope. They cover the **current** documentation and the help center only — archived versions, published under `/vX.Y/`, are not included. And the text is cleaned rather than copied verbatim: components are expanded and links resolved as the site renders them, and on a section index page built as a card grid each grid becomes the list of links it presents, with the page's prose kept around it in document order. Read the corpus as the documentation's prose, not as a byte-for-byte mirror of the rendered site.
 
 ```bash
 # Give a local model the whole documentation, with no network access
@@ -3974,7 +4139,6 @@ The full file is around 430 KB. If your model's context cannot hold it, use `llm
 # Otterscan
 URL: https://docs.erigon.tech/fundamentals/otterscan
 
-
 Otterscan is an Ethereum block explorer designed to be run locally along with Erigon.
 
 Entirely based on open source code, it is fast and fully private since it works on your local machine. The user interface is intentionally very similar, but with many improvements, to the most popular Ethereum block explorer to make it easy to locate where the information is. Installation and usage instructions
@@ -3986,14 +4150,13 @@ For the installation and usage follow the official documentation at [https://doc
 # Creating a dashboard
 URL: https://docs.erigon.tech/fundamentals/creating-a-dashboard
 
-
 Erigon provides robust, built-in support for monitoring using the Prometheus and Grafana stack. This setup offers comprehensive visibility into node performance, storage usage, and network activity, including relevant metrics for the integrated Consensus Layer (Caplin).
 
 #### Prerequisites
 
-* Docker and Docker Compose installed
-* Erigon node running
-* Basic understanding of Prometheus and Grafana
+- Docker and Docker Compose installed
+- Erigon node running
+- Basic understanding of Prometheus and Grafana
 
 #### Step 1: Enable Metrics in Erigon
 
@@ -4031,7 +4194,7 @@ make prometheus
 
 Once the containers are running, access the Grafana interface at `localhost:3000`.
 
-* Default credentials: `admin/admin`
+- Default credentials: `admin/admin`
 
 #### Step 5: Utilize Pre-configured Dashboards
 
@@ -4039,12 +4202,12 @@ Erigon comes with pre-built dashboards located in `./cmd/prometheus/dashboards/`
 
 **`erigon.json`** is the recommended dashboard for most users. It contains the following sections:
 
-* **Blockchain**: Block execution speed and processing times.
-* **Block consume delay**: Latency between block production and consumption.
-* **RPC**: Request rates and response times for the JSON-RPC interface.
-* **Private api** (collapsed): Internal gRPC API metrics.
+- **Blockchain**: Block execution speed and processing times.
+- **Block consume delay**: Latency between block production and consumption.
+- **RPC**: Request rates and response times for the JSON-RPC interface.
+- **Private api** (collapsed): Internal gRPC API metrics.
 
-**`erigon_internals.json`** is a low-level dashboard used by the Erigon development team for deep internal debugging. It is exported from Erigon's own Grafana Cloud instance and requires a pre-release Grafana build — it is _not recommended_ for typical users or self-hosted setups.
+**`erigon_internals.json`** is a low-level dashboard used by the Erigon development team for deep internal debugging. It is exported from Erigon's own Grafana Cloud instance and requires a pre-release Grafana build — it is *not recommended* for typical users or self-hosted setups.
 
 #### Step 6: Memory Usage Monitoring (Important Note)
 
@@ -4056,12 +4219,12 @@ The dedicated panels in the `erigon.json` dashboard track accurate Go memory sta
 
 You can customize the setup using environment variables:
 
-| **Variable**               | **Description**                           |
-| -------------------------- | ----------------------------------------- |
-| `XDG_DATA_HOME`            | Changes default database folder location.  |
-| `ERIGON_PROMETHEUS_CONFIG` | Path to a custom `prometheus.yml` file.    |
-| `ERIGON_GRAFANA_CONFIG`    | Path to a custom `grafana.ini` file.       |
-| `ERIGON_GRAFANA_DASHBOARD` | Path to a custom dashboards directory.     |
+| **Variable** | **Description** |
+| --- | --- |
+| `XDG_DATA_HOME` | Changes default database folder location. |
+| `ERIGON_PROMETHEUS_CONFIG` | Path to a custom `prometheus.yml` file. |
+| `ERIGON_GRAFANA_CONFIG` | Path to a custom `grafana.ini` file. |
+| `ERIGON_GRAFANA_DASHBOARD` | Path to a custom dashboards directory. |
 
 Example with a Custom Prometheus Configuration:
 
@@ -4071,10 +4234,10 @@ ERIGON_PROMETHEUS_CONFIG=/path/to/custom/prometheus.yml docker compose up promet
 
 #### Troubleshooting
 
-* Ensure Erigon is running with the `--metrics` flag enabled.
-* Verify Prometheus can reach your Erigon metrics endpoint (default port: `6061`).
-* Check Docker container logs if services fail to start.
-* Confirm firewall settings allow access to monitoring ports.
+- Ensure Erigon is running with the `--metrics` flag enabled.
+- Verify Prometheus can reach your Erigon metrics endpoint (default port: `6061`).
+- Check Docker container logs if services fail to start.
+- Confirm firewall settings allow access to monitoring ports.
 
 #### For Developers
 
@@ -4084,7 +4247,6 @@ Custom metrics can be added by searching for `grpc_prometheus.Register` within t
 
 # Docker Compose
 URL: https://docs.erigon.tech/fundamentals/docker-compose
-
 
 #### Understanding File Permissions
 
@@ -4191,7 +4353,6 @@ If your Docker installation requires the Docker daemon to run as root (which is 
 # web3 Wallet
 URL: https://docs.erigon.tech/fundamentals/web3-wallet
 
-
 Whatever network you are running, it's easy to connect your Erigon node to your local web3 wallet.
 
 For Erigon to provide access to wallet functionalities it is necessary to enable RPC by adding the flags
@@ -4210,14 +4371,14 @@ For example:
 
 To configure your local Metamask wallet (browser extension):
 
-* Click on the **network selector button**. This will display a list of networks to which you're already connected
-* Click **Add network**
-* A new browser tab will open, displaying various fields to fill out. Complete the fields with the proper information, in this example for Ethereum network:
-  * **Network Name**: `Ethereum on E3` (or any name of your choice)
-  * **Chain ID**: `1` for chain ID parameter see [Supported Networks](supported-networks)
-  * **New RPC URL**: `http://127.0.0.1:8545`
-  * **Currency Symbol**: `ETH`
-  * **Block Explorer URL**: `https://www.etherscan.io` (or any explorer of your choice)
+- Click on the **network selector button**. This will display a list of networks to which you're already connected
+- Click **Add network**
+- A new browser tab will open, displaying various fields to fill out. Complete the fields with the proper information, in this example for Ethereum network:
+  - **Network Name**: `Ethereum on E3` (or any name of your choice)
+  - **Chain ID**: `1` for chain ID parameter see [Supported Networks](https://docs.erigon.tech/fundamentals/supported-networks)
+  - **New RPC URL**: `http://127.0.0.1:8545`
+  - **Currency Symbol**: `ETH`
+  - **Block Explorer URL**: `https://www.etherscan.io` (or any explorer of your choice)
 
 After performing the above steps, you will be able to see the custom network the next time you access the network selector.
 
@@ -4227,8 +4388,6 @@ After performing the above steps, you will be able to see the custom network the
 URL: https://docs.erigon.tech/fundamentals/modules
 
 Erigon's internal components can run as separate processes for scalability, security, or custom deployments. Only split them when you have a clear reason to.
-
-## Sections
 
 - [RPC Daemon](https://docs.erigon.tech/fundamentals/modules/rpc-daemon): Serve JSON-RPC requests as a separate, remoteable process — the most battle-tested external component.
 - [TxPool](https://docs.erigon.tech/fundamentals/modules/txpool): Manage the pending transaction pool as a standalone service, decoupled from the main node process.
@@ -4240,8 +4399,7 @@ Erigon's internal components can run as separate processes for scalability, secu
 # RPC Daemon
 URL: https://docs.erigon.tech/fundamentals/modules/rpc-daemon
 
-
-The RPC Daemon is a core component of Erigon that implements the [RPC Service](../../interacting-with-erigon/) by processing JSON remote procedure calls (RPCs). It can be deployed in-process (running inside Erigon) or out-of-process (as a standalone service).
+The RPC Daemon is a core component of Erigon that implements the [RPC Service](https://docs.erigon.tech/interacting-with-erigon) by processing JSON remote procedure calls (RPCs). It can be deployed in-process (running inside Erigon) or out-of-process (as a standalone service).
 
 ### RPC Deployment Modes
 
@@ -4250,17 +4408,17 @@ The Erigon RPC service offers three distinct deployment modes when it comes to t
 | Mode | Configuration | CLI Command to Run | Key Characteristics |
 | --- | --- | --- | --- |
 | Embedded | RPC server is hosted within the `erigon` process. | `./build/bin/erigon` | The simplest, all-in-one solution. No separate RPC command is needed. |
-| Local | `rpcdaemon` runs as a standalone process on the same machine as `erigon`. It directly accesses local data storage. | **Erigon:** `./build/bin/erigon --private.api.addr="<host_IP>:9090"`**rpcdaemon:** `./build/bin/rpcdaemon --datadir="<erigon_data_path>"` | Improves isolation, increases tuning options, and maintains high-performance data access. Requires two processes running on the same machine. |
-| Remote | `rpcdaemon` runs as a standalone process on a separate machine and accesses data storage remotely via the Erigon gRPC interface. | **Erigon:** `./build/bin/erigon --private.api.addr="<host_IP>:9090"`**rpcdaemon:** `./build/bin/rpcdaemon --private.api.addr="<erigon_IP>:9090"` | Scalable, leverages the same data storage for multiple service endpoints. Uses `--private.api.addr` to point the daemon to the remote Erigon instance. |
+| Local | `rpcdaemon` runs as a standalone process on the same machine as `erigon`. It directly accesses local data storage. | **Erigon:** `./build/bin/erigon --private.api.addr="<host_IP>:9090"` **rpcdaemon:** `./build/bin/rpcdaemon --datadir="<erigon_data_path>"` | Improves isolation, increases tuning options, and maintains high-performance data access. Requires two processes running on the same machine. |
+| Remote | `rpcdaemon` runs as a standalone process on a separate machine and accesses data storage remotely via the Erigon gRPC interface. | **Erigon:** `./build/bin/erigon --private.api.addr="<host_IP>:9090"` **rpcdaemon:** `./build/bin/rpcdaemon --private.api.addr="<erigon_IP>:9090"` | Scalable, leverages the same data storage for multiple service endpoints. Uses `--private.api.addr` to point the daemon to the remote Erigon instance. |
 
 For a comprehensive understanding and the latest instructions, the official documentation is essential:
 
-* **Detailed Functionality and Configuration**: The primary documentation for the `rpcdaemon` is located at [https://github.com/erigontech/erigon/blob/main/cmd/rpcdaemon/README.md](https://github.com/erigontech/erigon/blob/main/cmd/rpcdaemon/README.md).
-* **Local Access**: This documentation is also contained in your locally compiled Erigon folder at `/cmd/rpcdaemon`.
-* **Remote Running Instructions**: For detailed instructions on running RPC in Remote mode, refer to the documentation [here](https://github.com/erigontech/erigon/blob/main/cmd/rpcdaemon/README.md#running-remotely).
+- **Detailed Functionality and Configuration**: The primary documentation for the `rpcdaemon` is located at [https://github.com/erigontech/erigon/blob/main/cmd/rpcdaemon/README.md](https://github.com/erigontech/erigon/blob/main/cmd/rpcdaemon/README.md).
+- **Local Access**: This documentation is also contained in your locally compiled Erigon folder at `/cmd/rpcdaemon`.
+- **Remote Running Instructions**: For detailed instructions on running RPC in Remote mode, refer to the documentation [here](https://github.com/erigontech/erigon/blob/main/cmd/rpcdaemon/README.md#running-remotely).
 
 :::tip
-To interact with the **RPC Service** visit the dedicated page [Interacting with Erigon](../../interacting-with-erigon/).
+To interact with the **RPC Service** visit the dedicated page [Interacting with Erigon](https://docs.erigon.tech/interacting-with-erigon).
 :::
 
 ## Command Line Options
@@ -4363,7 +4521,6 @@ Flags:
 # TxPool
 URL: https://docs.erigon.tech/fundamentals/modules/txpool
 
-
 The transaction pool, also known as the mempool, is a dynamic storage area where pending transactions are held before being confirmed and added to the blockchain. Each node on the Ethereum network maintains its own local transaction pool, which is combined with others to form the global pool.
 
 In Erigon, the TxPool is a dedicated API namespace that stores pending and queued transactions in local memory. Its primary function is to manage transactions waiting to be processed by miners.
@@ -4385,7 +4542,7 @@ cd erigon
 make txpool
 ```
 
-2. Together with external TxPool also [Sentry](sentry) and [RPC Daemon](rpc-daemon) must be compiled and run separately.
+2. Together with external TxPool also [Sentry](https://docs.erigon.tech/fundamentals/modules/sentry) and [RPC Daemon](https://docs.erigon.tech/fundamentals/modules/rpc-daemon) must be compiled and run separately.
 
 ```bash
 make sentry
@@ -4417,14 +4574,14 @@ If Erigon is on a different device, add the flags `--pprof --pprof.addr 0.0.0.0`
 
 ## Flags explanation
 
-* `--txpool.disable`: This flag disables the internal transaction pool (TxPool) and block producer (default: `false`). When running the TxPool as a separate process, this flag is used to prevent the internal TxPool from interfering with the external one.
-* `--private.api.addr=localhost:9090`: This flag sets the address and port for the private API. The private API is used for internal communication between Erigon components (default: `127.0.0.1:9090`).
-* `--datadir=<your datadir>`: This flag specifies the data directory for Erigon. This is where Erigon stores its databases and other data.
-* `--http=false`: This flag disables the HTTP API server in Erigon (default: `true`). When running the TxPool as a separate process, this flag is used to prevent the internal HTTP server from interfering with the external TxPool.
-* `--sentry.api.addr=localhost:9091`: This flag sets the address and port for the Sentry API. The Sentry API is used for communication between the TxPool and the Sentry.
-* `--txpool.api.addr=localhost:9094`: This flag sets the address and port for the TxPool API (default: use value of `--private.api.addr`). The TxPool API is used for communication between the TxPool and other Erigon components.
-* `--pprof`: Enable the pprof HTTP server (default: `false`)
-* `--pprof.addr 0.0.0.0`: This flag sets the address for the pprof HTTP server (default: `127.0.0.1`). The pprof server is used for profiling and debugging Erigon. By setting this flag to `0.0.0.0`, the pprof server is made accessible from outside the local machine.
+- `--txpool.disable`: This flag disables the internal transaction pool (TxPool) and block producer (default: `false`). When running the TxPool as a separate process, this flag is used to prevent the internal TxPool from interfering with the external one.
+- `--private.api.addr=localhost:9090`: This flag sets the address and port for the private API. The private API is used for internal communication between Erigon components (default: `127.0.0.1:9090`).
+- `--datadir=<your datadir>`: This flag specifies the data directory for Erigon. This is where Erigon stores its databases and other data.
+- `--http=false`: This flag disables the HTTP API server in Erigon (default: `true`). When running the TxPool as a separate process, this flag is used to prevent the internal HTTP server from interfering with the external TxPool.
+- `--sentry.api.addr=localhost:9091`: This flag sets the address and port for the Sentry API. The Sentry API is used for communication between the TxPool and the Sentry.
+- `--txpool.api.addr=localhost:9094`: This flag sets the address and port for the TxPool API (default: use value of `--private.api.addr`). The TxPool API is used for communication between the TxPool and other Erigon components.
+- `--pprof`: Enable the pprof HTTP server (default: `false`)
+- `--pprof.addr 0.0.0.0`: This flag sets the address for the pprof HTTP server (default: `127.0.0.1`). The pprof server is used for profiling and debugging Erigon. By setting this flag to `0.0.0.0`, the pprof server is made accessible from outside the local machine.
 
 ## Command Line Options
 
@@ -4490,18 +4647,18 @@ Flags:
 # Sentry
 URL: https://docs.erigon.tech/fundamentals/modules/sentry
 
-
 Sentry connects Erigon to the Ethereum P2P network, enabling the discovery of other participants across the Internet and secure communication with them. It performs these main functions:
 
-* Peer discovery via the following:
-  * Kademlia DHT
-  * DNS lookup
-  * Configured static peers
-  * Node info saved in the database
-  * Boot nodes pre-configured in the source code
-* Peer management:
-  * handshakes
-  * holding p2p connection even if Erigon is restarted
+- Peer discovery via the following:
+  - Kademlia DHT
+  - DNS lookup
+  - Configured static peers
+  - Node info saved in the database
+  - Boot nodes pre-configured in the source code
+
+- Peer management:
+  - handshakes
+  - holding p2p connection even if Erigon is restarted
 
 The ETH core interacts with the Ethereum p2p network through the Sentry component. Sentry provides a simple interface to the core, with functions to download data, receive notifications about gossip messages, upload data on request from peers, and broadcast gossip messages either to a selected set of peers or to all peers.
 
@@ -4615,7 +4772,6 @@ Flags:
 # Downloader
 URL: https://docs.erigon.tech/fundamentals/modules/downloader
 
-
 The Downloader is a service responsible for seeding and downloading historical data using the BitTorrent protocol. Data is stored in the form of immutable `.seg` files, known as **snapshots**. The Ethereum core instructs the Downloader to download specific files, identified by their unique info hashes, which include both block headers and block bodies. The Downloader then communicates with the BitTorrent network to retrieve the necessary files, as specified by the Ethereum core.
 
 :::warning
@@ -4636,9 +4792,9 @@ For a comprehensive understanding of the Downloader's functionality, configurati
 
 Some of the key sections in the documentation include:
 
-* **How to create new snapshots**: Instructions on how to create new snapshots, including using the `seg` command and creating .torrent files.
-* **How to start the Downloader**: Instructions on how to start the Downloader, either as a separate process or as part of Erigon.
-* **How to verify .seg files**: Instructions on how to verify that .seg files have the same checksum as the current .torrent files.
+- **How to create new snapshots**: Instructions on how to create new snapshots, including using the `seg` command and creating .torrent files.
+- **How to start the Downloader**: Instructions on how to start the Downloader, either as a separate process or as part of Erigon.
+- **How to verify .seg files**: Instructions on how to verify that .seg files have the same checksum as the current .torrent files.
 
 By referring to the embedded documentation file, you can gain a deeper understanding of the Downloader's capabilities and how to effectively utilize it in your Erigon setup.
 
@@ -4731,30 +4887,29 @@ Use " [command] --help" for more information about a command.
 # Interacting with Erigon
 URL: https://docs.erigon.tech/interacting-with-erigon
 
+The Erigon RPC Service, managed by Erigon's modular [RPC Daemon](https://docs.erigon.tech/fundamentals/modules/rpc-daemon), supports various API namespaces, which can be enabled or disabled using the `--http.api` flag. The available namespaces include:
 
-The Erigon RPC Service, managed by Erigon's modular [RPC Daemon](/fundamentals/modules/rpc-daemon), supports various API namespaces, which can be enabled or disabled using the `--http.api` flag. The available namespaces include:
-
-* [`eth`](/interacting-with-erigon/eth): Standard Ethereum API.
-* [`erigon`](/interacting-with-erigon/erigon): Erigon-specific extensions.
-* [`engine`](/interacting-with-erigon/engine): The JSON-RPC Interface for Execution and Consensus Layer Communication.
-* [`web3`](/interacting-with-erigon/web3): Web3 compatibility API.
-* [`net`](/interacting-with-erigon/net): Network information API.
-* [`debug`](/interacting-with-erigon/debug): Debugging and tracing API.
-* [`trace`](/interacting-with-erigon/trace): Transaction tracing API.
-* [`txpool`](/interacting-with-erigon/txpool): Transaction pool API.
-* [`admin`](/interacting-with-erigon/admin): Node administration API
-* [`ots`](/interacting-with-erigon/ots): These methods are specifically tailored for use with Otterscan, an open-source, fast block explorer.
-* [`internal`](/interacting-with-erigon/internal): Erigon specific API for development and debugging purposes.
-* [`gRPC`](/interacting-with-erigon/grpc): API for lower-level data access.
-* [`overlay`](/interacting-with-erigon/overlay): Erigon-specific overlay API for replaying blocks with state overrides (archive nodes only).
-* [`parity`](/interacting-with-erigon/parity): Partial OpenEthereum compatibility (`parity_listStorageKeys`).
-* [`graphql`](/interacting-with-erigon/graphql): GraphQL endpoint following the ethereum/execution-apis schema.
+- [`eth`](https://docs.erigon.tech/interacting-with-erigon/eth): Standard Ethereum API.
+- [`erigon`](https://docs.erigon.tech/interacting-with-erigon/erigon): Erigon-specific extensions.
+- [`engine`](https://docs.erigon.tech/interacting-with-erigon/engine): The JSON-RPC Interface for Execution and Consensus Layer Communication.
+- [`web3`](https://docs.erigon.tech/interacting-with-erigon/web3): Web3 compatibility API.
+- [`net`](https://docs.erigon.tech/interacting-with-erigon/net): Network information API.
+- [`debug`](https://docs.erigon.tech/interacting-with-erigon/debug): Debugging and tracing API.
+- [`trace`](https://docs.erigon.tech/interacting-with-erigon/trace): Transaction tracing API.
+- [`txpool`](https://docs.erigon.tech/interacting-with-erigon/txpool): Transaction pool API.
+- [`admin`](https://docs.erigon.tech/interacting-with-erigon/admin): Node administration API
+- [`ots`](https://docs.erigon.tech/interacting-with-erigon/ots): These methods are specifically tailored for use with Otterscan, an open-source, fast block explorer.
+- [`internal`](https://docs.erigon.tech/interacting-with-erigon/internal): Erigon specific API for development and debugging purposes.
+- [`gRPC`](https://docs.erigon.tech/interacting-with-erigon/grpc): API for lower-level data access.
+- [`overlay`](https://docs.erigon.tech/interacting-with-erigon/overlay): Erigon-specific overlay API for replaying blocks with state overrides (archive nodes only).
+- [`parity`](https://docs.erigon.tech/interacting-with-erigon/parity): Partial OpenEthereum compatibility (`parity_listStorageKeys`).
+- [`graphql`](https://docs.erigon.tech/interacting-with-erigon/graphql): GraphQL endpoint following the ethereum/execution-apis schema.
 
 For a complete reference on the standard Ethereum JSON-RPC methods, especially those in the `eth`, `net`, and `web3` namespaces, it is recommended to consult the general documentation on [ethereum.org's JSON-RPC API page](https://ethereum.org/en/developers/docs/apis/json-rpc/). Additionally, for the formal specification of the `debug`, `engine`, and `eth` namespaces, including unique, detailed descriptions for methods like `eth_getProof` and `eth_simulateV1`, refer to the [Execution APIs documentation](https://ethereum.github.io/execution-apis).
 
 ## Erigon RPC Transports
 
-Erigon supports [HTTP](/interacting-with-erigon/#http), [HTTPS](/interacting-with-erigon/#https), [WebSockets](/interacting-with-erigon/#websockets), [IPC](/interacting-with-erigon/#ipc), [gRPC](/interacting-with-erigon/#grpc) and [GraphQL](/interacting-with-erigon/#graphql) through its RPC Daemon.
+Erigon supports [HTTP](https://docs.erigon.tech/interacting-with-erigon#http), [HTTPS](https://docs.erigon.tech/interacting-with-erigon#https), [WebSockets](https://docs.erigon.tech/interacting-with-erigon#websockets), [IPC](https://docs.erigon.tech/interacting-with-erigon#ipc), [gRPC](https://docs.erigon.tech/interacting-with-erigon#grpc) and [GraphQL](https://docs.erigon.tech/interacting-with-erigon#graphql) through its RPC Daemon.
 
 ### HTTP
 
@@ -4772,7 +4927,7 @@ erigon --http
 rpcdaemon --http.enabled
 ```
 
-The default port is `8545`, and the default listen address is localhost. _node/nodecfg/defaults.go:30-31_
+The default port is `8545`, and the default listen address is localhost. *node/nodecfg/defaults.go:30-31*
 
 You can configure the listen address and port using `--http.addr` and `--http.port` respectively:
 
@@ -4812,21 +4967,15 @@ Erigon supports HTTPS and HTTP/2 out of the box:
 rpcdaemon --https.enabled --https.cert /path/to/cert.pem --https.key /path/to/key.pem
 ```
 
-**New in v3.7:** the same flags work on the `erigon` binary, so the embedded RPC server can serve TLS without a separate
-daemon:
+**New in v3.7:** the same flags work on the `erigon` binary, so the embedded RPC server can serve TLS without a separate daemon:
 
 ```bash
 erigon --https.enabled --https.cert /path/to/cert.pem --https.key /path/to/key.pem
 ```
 
-The HTTPS listener is independent of the plain HTTP one and binds its own port: `--https.port`, which defaults to
-`--http.port` + 363 (`8908` with a default `--http.port`) — the derivation reads `--http.port` whether or not the plain
-HTTP listener is running. Both `--https.cert` and `--https.key` are required — if either is missing the
-port still binds but TLS serving fails with only a `Failed to serve https endpoint` warning in the log. Setting
-`--https.url` enables the HTTPS server on its own and overrides `--https.addr` and `--https.port`.
+The HTTPS listener is independent of the plain HTTP one and binds its own port: `--https.port`, which defaults to `--http.port` + 363 (`8908` with a default `--http.port`) — the derivation reads `--http.port` whether or not the plain HTTP listener is running. Both `--https.cert` and `--https.key` are required — if either is missing the port still binds but TLS serving fails with only a `Failed to serve https endpoint` warning in the log. Setting `--https.url` enables the HTTPS server on its own and overrides `--https.addr` and `--https.port`.
 
-Note that `--http=false` switches off the entire RPC stack, HTTPS included. For a TLS-only node, keep `--http` and
-disable just the plain HTTP listener with `--http.enabled=false`.
+Note that `--http=false` switches off the entire RPC stack, HTTPS included. For a TLS-only node, keep `--http` and disable just the plain HTTP listener with `--http.enabled=false`.
 
 ### WebSockets
 
@@ -4838,10 +4987,10 @@ Because WebSockets are bidirectional, nodes can push events to clients, which en
 
 The configuration of the WebSocket server follows the same pattern as the HTTP server:
 
-* Enable it using `--ws`
-* Configure the server port by passing `--ws.port` (default `8546`) _node/nodecfg/defaults.go:34_
-* Configure cross-origin requests using `--ws.origins` (though this maps to `--http.corsdomain` in Erigon)
-* WebSocket APIs inherit from the HTTP API configuration
+- Enable it using `--ws`
+- Configure the server port by passing `--ws.port` (default `8546`) *node/nodecfg/defaults.go:34*
+- Configure cross-origin requests using `--ws.origins` (though this maps to `--http.corsdomain` in Erigon)
+- WebSocket APIs inherit from the HTTP API configuration
 
 ```bash
 erigon --http --ws --http.api eth,net,debug,trace
@@ -4851,21 +5000,17 @@ erigon --http --ws --http.api eth,net,debug,trace
 
 IPC is a simpler transport protocol for use in local environments where the node and the client exist on the same machine.
 
-**New in v3.7:** the `erigon` binary accepts `--socket.enabled` and `--socket.url` directly, so IPC no longer requires a
-separate process:
+**New in v3.7:** the `erigon` binary accepts `--socket.enabled` and `--socket.url` directly, so IPC no longer requires a separate process:
 
 ```bash
 erigon --datadir=<path-to-datadir> --socket.enabled --socket.url unix:///<path-to-datadir>/erigon.ipc
 ```
 
-The default `--socket.url` is `unix:///var/run/erigon.sock`, which is usually not writable by the Erigon user — point it
-at your datadir as above. On earlier releases these flags exist only on `rpcdaemon`, and the geth-style `--ipcpath`
-endpoint remains permanently disabled in the `erigon` binary regardless of release.
+The default `--socket.url` is `unix:///var/run/erigon.sock`, which is usually not writable by the Erigon user — point it at your datadir as above. On earlier releases these flags exist only on `rpcdaemon`, and the geth-style `--ipcpath` endpoint remains permanently disabled in the `erigon` binary regardless of release.
 
 #### Enabling IPC with RPC Daemon
 
-IPC is also available from the standalone daemon, which is still the right choice when RPC serving runs on its own
-process or host.
+IPC is also available from the standalone daemon, which is still the right choice when RPC serving runs on its own process or host.
 
 First, start Erigon with the private API enabled:
 
@@ -4881,8 +5026,7 @@ rpcdaemon --private.api.addr=localhost:9090 --socket.enabled --socket.url unix:/
 
 **Important:** Make sure you have write permissions to the directory where the socket will be created.
 
-On Linux and macOS, Erigon uses UNIX sockets. On Windows, IPC is provided using named pipes (use `\\.\pipe\erigon.ipc`
-format). The socket inherits the API namespaces from the `--http.api` flag passed to `rpcdaemon`:
+On Linux and macOS, Erigon uses UNIX sockets. On Windows, IPC is provided using named pipes (use `\\.\pipe\erigon.ipc` format). The socket inherits the API namespaces from the `--http.api` flag passed to `rpcdaemon`:
 
 ```bash
 rpcdaemon --private.api.addr=localhost:9090 --socket.enabled --socket.url unix:///<path-to-datadir>/erigon.ipc --http.api eth,net,web3,debug,trace
@@ -4896,8 +5040,7 @@ You can also serve the raw JSON-RPC2 protocol over TCP instead of Unix sockets:
 rpcdaemon --private.api.addr=localhost:9090 --socket.enabled --socket.url tcp://127.0.0.1:8546
 ```
 
-**Note**: This creates a raw JSON-RPC2 socket without HTTP wrapping. Most users should use the HTTP endpoint (enabled by
-default on port 8545) instead. The TCP socket is for specialized clients that support raw JSON-RPC2 protocol.
+**Note**: This creates a raw JSON-RPC2 socket without HTTP wrapping. Most users should use the HTTP endpoint (enabled by default on port 8545) instead. The TCP socket is for specialized clients that support raw JSON-RPC2 protocol.
 
 #### Testing IPC Connection
 
@@ -4958,7 +5101,6 @@ cast rpc erigon_forks
 # eth
 URL: https://docs.erigon.tech/interacting-with-erigon/eth
 
-
 The `eth` namespace is the foundational and most commonly used API set in Ethereum's JSON-RPC interface. It provides core functionality for interacting with the Ethereum blockchain, enabling users and applications to read blockchain state and submit transactions.
 
 Key methods within this namespace allow you to check an account's balance (`eth_getBalance`), get the current block number (`eth_blockNumber`), retrieve transaction details (`eth_getTransactionByHash`), and send signed transactions to the network (`eth_sendRawTransaction`, `eth_sendRawTransactionSync`). Essentially, the `eth` namespace contains all the fundamental tools needed to observe and participate in the life of the chain.
@@ -4967,14 +5109,14 @@ Key methods within this namespace allow you to check an account's balance (`eth_
 
 For API usage refer to the below official resources:
 
-* [https://ethereum.org/en/developers/docs/apis/json-rpc/](https://ethereum.org/en/developers/docs/apis/json-rpc/)
-* [https://ethereum.github.io/execution-apis/](https://ethereum.github.io/execution-apis/)
+- [https://ethereum.org/en/developers/docs/apis/json-rpc/](https://ethereum.org/en/developers/docs/apis/json-rpc/)
+- [https://ethereum.github.io/execution-apis/](https://ethereum.github.io/execution-apis/)
 
 ### Pending state
 
 Erigon does not support the `pending` block tag for `eth_call`, `eth_createAccessList`, `eth_getProof`, `eth_getWitness`, `eth_getTxWitness`, or `eth_simulateV1`. These methods need a block header and state from the same view, and Erigon cannot currently acquire a matching pending-state view. They return `pending state is not supported` instead of executing against a different block. Other `eth` methods keep their existing pending behavior.
 
-### eth\_getProof
+### eth_getProof
 
 `eth_getProof` returns Merkle proofs for account state and storage slots, as defined in [EIP-1186](https://eips.ethereum.org/EIPS/eip-1186). It is stable and production-ready as of Erigon v3.4.
 
@@ -4990,15 +5132,15 @@ To enable historical proof support, activate commitment history storage at start
 
 This enables faster retrieval of Merkle proofs for any executed block.
 
-### eth\_getStorageValues
+### eth_getStorageValues
 
 `eth_getStorageValues` reads several storage slots for one or more accounts in a single call, reducing round-trips compared to multiple `eth_getStorageAt` calls. It is part of the [Ethereum execution APIs](https://github.com/ethereum/execution-apis/blob/main/src/eth/state.yaml) and takes two parameters.
 
 **Parameters**
 
-| Parameter   | Type             | Description                                                                                       |
-| ----------- | ---------------- | ------------------------------------------------------------------------------------------------- |
-| requests    | OBJECT           | Maps each account address to an array of 32-byte storage slot keys (hex-encoded)                   |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| requests | OBJECT | Maps each account address to an array of 32-byte storage slot keys (hex-encoded) |
 | blockNumber | STRING or NUMBER | Optional. Block number, block hash or tag (`"latest"`, `"earliest"`, etc.). Defaults to `"latest"` |
 
 **Example**
@@ -5029,15 +5171,14 @@ An object mapping each requested address to an array of 32-byte values, in the s
 
 **Limits**
 
-* A single call may request at most 1024 slots in total, counting all addresses together. Larger requests are rejected.
-* An empty `requests` object returns error code `-32602` with the message `empty request`.
-* When `blockNumber` is a block hash, the block must be canonical.
+- A single call may request at most 1024 slots in total, counting all addresses together. Larger requests are rejected.
+- An empty `requests` object returns error code `-32602` with the message `empty request`.
+- When `blockNumber` is a block hash, the block must be canonical.
 
 ---
 
 # erigon
 URL: https://docs.erigon.tech/interacting-with-erigon/erigon
-
 
 Erigon provides several RPC namespaces that extend beyond the standard Ethereum JSON-RPC API, exposing Erigon-specific functionality and data structures. The primary Erigon-specific namespace is **`erigon_`** which offer extended blockchain data access methods.
 
@@ -5045,25 +5186,23 @@ These methods must be explicitly enabled using the `--http.api` flag when starti
 
 ### Namespace Availability
 
-* The `erigon_` namespace is enabled by default in the RPC Daemon and must be explicitly included in the `--http.api` flag if customizing enabled namespaces.
+- The `erigon_` namespace is enabled by default in the RPC Daemon and must be explicitly included in the `--http.api` flag if customizing enabled namespaces.
 
 ### Performance Considerations
 
-* Erigon-specific methods are optimized for Erigon's architecture and often provide better performance than standard equivalents
-* Methods like `erigon_getHeaderByNumber` and `erigon_getHeaderByHash` can be faster as they skip transaction and uncle data
-* The `erigon_getLatestLogs` method includes advanced pagination to handle large result sets efficiently
+- Erigon-specific methods are optimized for Erigon's architecture and often provide better performance than standard equivalents
+- Methods like `erigon_getHeaderByNumber` and `erigon_getHeaderByHash` can be faster as they skip transaction and uncle data
+- The `erigon_getLatestLogs` method includes advanced pagination to handle large result sets efficiently
 
 ### Enhanced Features
 
-* `erigon_getLatestLogs` supports `ignoreTopicsOrder` for flexible topic matching
-* `erigon_getLogs` returns enhanced RPCLog objects with additional metadata like timestamps
-* `erigon_getBlockByTimestamp` uses binary search for efficient timestamp-based block lookup
+- `erigon_getLatestLogs` supports `ignoreTopicsOrder` for flexible topic matching
+- `erigon_getLogs` returns enhanced RPCLog objects with additional metadata like timestamps
+- `erigon_getBlockByTimestamp` uses binary search for efficient timestamp-based block lookup
 
 See more details [here](https://github.com/erigontech/erigon/blob/main/cmd/rpcdaemon/README.md#rpc-implementation-status) about implementation status.
 
-***
-
-## **erigon\_forks**
+## **erigon_forks**
 
 Returns the genesis block hash and a sorted list of all fork block numbers for the current chain configuration.
 
@@ -5079,23 +5218,21 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_forks","params":[],"id":"1"}' 
 
 **Returns**
 
-| Type        | Description                                                   |
-| ----------- | ------------------------------------------------------------- |
-| Object      | Contains genesis hash and fork information                    |
-| genesis     | DATA, 32 BYTES - The genesis block hash                       |
+| Type | Description |
+| --- | --- |
+| Object | Contains genesis hash and fork information |
+| genesis | DATA, 32 BYTES - The genesis block hash |
 | heightForks | ARRAY - Array of block numbers where height-based forks occur |
-| timeForks   | ARRAY - Array of timestamps where time-based forks occur      |
+| timeForks | ARRAY - Array of timestamps where time-based forks occur |
 
-***
-
-## **erigon\_blockNumber**
+## **erigon_blockNumber**
 
 Returns the latest executed block number. Unlike `eth_blockNumber`, this method can accept a specific block number parameter and returns the latest executed block rather than the fork choice head after the merge.
 
 **Parameters**
 
-| Parameter   | Type                | Description                                                             |
-| ----------- | ------------------- | ----------------------------------------------------------------------- |
+| Parameter | Type | Description |
+| --- | --- | --- |
 | blockNumber | QUANTITY (optional) | Block number to query. If omitted, returns latest executed block number |
 
 **Example**
@@ -5106,20 +5243,18 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_blockNumber","params":[],"id":
 
 **Returns**
 
-| Type     | Description                     |
-| -------- | ------------------------------- |
+| Type | Description |
+| --- | --- |
 | QUANTITY | The block number as hexadecimal |
 
-***
-
-## **erigon\_getHeaderByNumber**
+## **erigon_getHeaderByNumber**
 
 Returns a block header by block number, ignoring transaction and uncle data for potentially faster response times.
 
 **Parameters**
 
-| Parameter   | Type          | Description                                     |
-| ----------- | ------------- | ----------------------------------------------- |
+| Parameter | Type | Description |
+| --- | --- | --- |
 | blockNumber | QUANTITY\|TAG | Block number or "latest", "earliest", "pending" |
 
 **Example**
@@ -5130,20 +5265,18 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_getHeaderByNumber","params":["
 
 **Returns**
 
-| Type   | Description                                |
-| ------ | ------------------------------------------ |
+| Type | Description |
+| --- | --- |
 | Object | Block header object with all header fields |
 
-***
-
-## **erigon\_getHeaderByHash**
+## **erigon_getHeaderByHash**
 
 Returns a block header by block hash, ignoring transaction and uncle data for potentially faster response times.
 
 **Parameters**
 
-| Parameter | Type           | Description       |
-| --------- | -------------- | ----------------- |
+| Parameter | Type | Description |
+| --- | --- | --- |
 | blockHash | DATA, 32 BYTES | Hash of the block |
 
 **Example**
@@ -5154,22 +5287,20 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_getHeaderByHash","params":["0x
 
 **Returns**
 
-| Type   | Description                                |
-| ------ | ------------------------------------------ |
+| Type | Description |
+| --- | --- |
 | Object | Block header object with all header fields |
 
-***
-
-## **erigon\_getBlockByTimestamp**
+## **erigon_getBlockByTimestamp**
 
 Returns a block by timestamp using binary search to find the closest block to the specified timestamp.
 
 **Parameters**
 
-| Parameter | Type     | Description                                                                  |
-| --------- | -------- | ---------------------------------------------------------------------------- |
-| timestamp | QUANTITY | Unix timestamp                                                               |
-| fullTx    | Boolean  | If true, include full transaction objects; if false, only transaction hashes |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| timestamp | QUANTITY | Unix timestamp |
+| fullTx | Boolean | If true, include full transaction objects; if false, only transaction hashes |
 
 **Example**
 
@@ -5179,20 +5310,18 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_getBlockByTimestamp","params":
 
 **Returns**
 
-| Type   | Description                                    |
-| ------ | ---------------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Object | Block object matching closest to the timestamp |
 
-***
-
-## **erigon\_getBalanceChangesInBlock**
+## **erigon_getBalanceChangesInBlock**
 
 Returns all account balance changes that occurred within a specific block.
 
 **Parameters**
 
-| Parameter     | Type                | Description                      |
-| ------------- | ------------------- | -------------------------------- |
+| Parameter | Type | Description |
+| --- | --- | --- |
 | blockNrOrHash | QUANTITY\|TAG\|HASH | Block number, tag, or block hash |
 
 **Example**
@@ -5203,20 +5332,18 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_getBalanceChangesInBlock","par
 
 **Returns**
 
-| Type   | Description                                      |
-| ------ | ------------------------------------------------ |
+| Type | Description |
+| --- | --- |
 | Object | Mapping of addresses to their new balance values |
 
-***
-
-## **erigon\_getLogsByHash**
+## **erigon_getLogsByHash**
 
 Returns an array of arrays of logs generated by transactions in a block given by block hash.
 
 **Parameters**
 
-| Parameter | Type           | Description       |
-| --------- | -------------- | ----------------- |
+| Parameter | Type | Description |
+| --- | --- | --- |
 | blockHash | DATA, 32 BYTES | Hash of the block |
 
 **Example**
@@ -5227,21 +5354,19 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_getLogsByHash","params":["0x1d
 
 **Returns**
 
-| Type  | Description                                               |
-| ----- | --------------------------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Array | Array of arrays of log objects, one array per transaction |
 
-***
-
-## **erigon\_getLogs**
+## **erigon_getLogs**
 
 Returns an array of logs matching a given filter object with enhanced filtering capabilities.
 
 **Parameters**
 
-| Parameter | Type   | Description                                                                  |
-| --------- | ------ | ---------------------------------------------------------------------------- |
-| filter    | Object | Filter criteria including fromBlock, toBlock, address, topics, and blockHash |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| filter | Object | Filter criteria including fromBlock, toBlock, address, topics, and blockHash |
 
 **Example**
 
@@ -5251,25 +5376,23 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_getLogs","params":[{"fromBlock
 
 **Returns**
 
-| Type  | Description                                       |
-| ----- | ------------------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Array | Array of RPCLog objects with enhanced metadata |
 
 :::note
-The number of logs returned is capped by [`--rpc.logs.maxresults`](../fundamentals/configuring-erigon#rpc--api) (default `20000`). Set to `0` to remove the limit. The block range of the query is independently capped by `--rpc.blockrange.limit` (default `1000`).
+The number of logs returned is capped by [`--rpc.logs.maxresults`](https://docs.erigon.tech/fundamentals/configuring-erigon#rpc--api) (default `20000`). Set to `0` to remove the limit. The block range of the query is independently capped by `--rpc.blockrange.limit` (default `1000`).
 :::
 
-***
-
-## **erigon\_getLatestLogs**
+## **erigon_getLatestLogs**
 
 Returns the latest logs matching a filter criteria in descending order with advanced pagination and topic matching options.
 
 **Parameters**
 
-| Parameter  | Type   | Description                                                   |
-| ---------- | ------ | ------------------------------------------------------------- |
-| filter     | Object | Filter criteria object                                        |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| filter | Object | Filter criteria object |
 | logOptions | Object | Options including logCount, blockCount, and ignoreTopicsOrder |
 
 **Example**
@@ -5280,24 +5403,22 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_getLatestLogs","params":[{"add
 
 **Returns**
 
-| Type  | Description                                                  |
-| ----- | ------------------------------------------------------------ |
+| Type | Description |
+| --- | --- |
 | Array | Array of RPCLog objects in descending chronological order |
 
 :::note
-The number of logs returned is capped by [`--rpc.logs.maxresults`](../fundamentals/configuring-erigon#rpc--api) (default `20000`). Set to `0` to remove the limit.
+The number of logs returned is capped by [`--rpc.logs.maxresults`](https://docs.erigon.tech/fundamentals/configuring-erigon#rpc--api) (default `20000`). Set to `0` to remove the limit.
 :::
 
-***
-
-## **erigon\_getBlockReceiptsByBlockHash**
+## **erigon_getBlockReceiptsByBlockHash**
 
 Returns all transaction receipts for a canonical block by block hash.
 
 **Parameters**
 
-| Parameter | Type           | Description                 |
-| --------- | -------------- | --------------------------- |
+| Parameter | Type | Description |
+| --- | --- | --- |
 | blockHash | DATA, 32 BYTES | Hash of the canonical block |
 
 **Example**
@@ -5308,13 +5429,11 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_getBlockReceiptsByBlockHash","
 
 **Returns**
 
-| Type  | Description                                                |
-| ----- | ---------------------------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Array | Array of receipt objects for all transactions in the block |
 
-***
-
-## **erigon\_nodeInfo**
+## **erigon_nodeInfo**
 
 Returns a collection of metadata known about the host node and connected peers.
 
@@ -5330,17 +5449,14 @@ curl -s --data '{"jsonrpc":"2.0","method":"erigon_nodeInfo","params":[],"id":"1"
 
 **Returns**
 
-| Type  | Description                                                 |
-| ----- | ----------------------------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Array | Array of NodeInfo objects containing peer and node metadata |
-
-***
 
 ---
 
 # engine
 URL: https://docs.erigon.tech/interacting-with-erigon/engine
-
 
 The Engine API is a standardized JSON-RPC interface defined by the Ethereum specification. Its purpose is to enable secure and structured communication between the Consensus Layer (CL) client and the Execution Layer (EL) client in the post-Merge Proof-of-Stake architecture.
 
@@ -5348,68 +5464,66 @@ The Engine API replaced older `eth_` methods for consensus communication. It is 
 
 For API usage refer to the below official resources:
 
-* [https://ethereum.org/en/developers/docs/apis/json-rpc/](https://ethereum.org/en/developers/docs/apis/json-rpc/)
-* [https://ethereum.github.io/execution-apis/](https://ethereum.github.io/execution-apis/)
+- [https://ethereum.org/en/developers/docs/apis/json-rpc/](https://ethereum.org/en/developers/docs/apis/json-rpc/)
+- [https://ethereum.github.io/execution-apis/](https://ethereum.github.io/execution-apis/)
 
 #### Default Erigon Behavior (Caplin)
 
 By default, Erigon runs its own embedded consensus layer client, Caplin. For optimized performance, Caplin bypasses the Engine API and uses direct internal calls to communicate with Erigon's execution layer.
 
-You can optionally force Caplin to use the Engine API interface by setting the `--caplin.use-engine-api` flag. When this flag is active, Caplin connects via the same [JWT](../fundamentals/jwt)-authenticated HTTP endpoint used by external CL clients.
+You can optionally force Caplin to use the Engine API interface by setting the `--caplin.use-engine-api` flag. When this flag is active, Caplin connects via the same [JWT](https://docs.erigon.tech/fundamentals/jwt)-authenticated HTTP endpoint used by external CL clients.
 
 #### Engine API Functionality
 
 When in use (with external CL clients), the Engine API provides essential methods for Proof-of-Stake operations:
 
-* Payload Execution: `engine_newPayloadV1/V2/V3/V4` validates and executes blocks sent by the CL.
-* Fork Choice Updates: `engine_forkchoiceUpdatedV1/V2/V3` updates the chain head and triggers block building.
-* Payload Retrieval: `engine_getPayloadV1/V2/V3/V4` retrieves built blocks for the CL to propose.
-* Payload Bodies: `engine_getPayloadBodiesByHashV1` and `engine_getPayloadBodiesByRangeV1` fetch historical data.
-* Blob Retrieval: `engine_getBlobsV1/V2/V3` retrieves blobs by versioned hash, with V3 adding support for PeerDAS data columns.
+- Payload Execution: `engine_newPayloadV1/V2/V3/V4` validates and executes blocks sent by the CL.
+- Fork Choice Updates: `engine_forkchoiceUpdatedV1/V2/V3` updates the chain head and triggers block building.
+- Payload Retrieval: `engine_getPayloadV1/V2/V3/V4` retrieves built blocks for the CL to propose.
+- Payload Bodies: `engine_getPayloadBodiesByHashV1` and `engine_getPayloadBodiesByRangeV1` fetch historical data.
+- Blob Retrieval: `engine_getBlobsV1/V2/V3` retrieves blobs by versioned hash, with V3 adding support for PeerDAS data columns.
 
 #### Configuration and Security
 
 For security, the Engine API listens on port 8551 by default and requires JWT authentication.
 
-* A JWT secret is automatically generated and saved in the file `jwt.hex` within your data directory.
-* This secret must be shared with your external consensus layer client to establish secure communication.
-* If your CL client runs on a different machine, you must expose the API using `--authrpc.addr 0.0.0.0` and configure virtual hosts appropriately with `--authrpc.vhosts`.
+- A JWT secret is automatically generated and saved in the file `jwt.hex` within your data directory.
+- This secret must be shared with your external consensus layer client to establish secure communication.
+- If your CL client runs on a different machine, you must expose the API using `--authrpc.addr 0.0.0.0` and configure virtual hosts appropriately with `--authrpc.vhosts`.
 
 ---
 
 # web3
 URL: https://docs.erigon.tech/interacting-with-erigon/web3
 
-
 The `web3` namespace provides utility methods that are part of the standard Ethereum JSON-RPC API. These methods offer basic functionality for client identification and cryptographic operations. In Erigon, the web3 namespace is implemented through the `Web3API` interface and `Web3APIImpl` struct. The web3 namespace is enabled by default in Erigon's RPC Daemon and provides essential utility functions that many Ethereum applications rely on for basic operations.
 
 For API usage refer to the below official resources:
 
-* [https://ethereum.org/en/developers/docs/apis/json-rpc/](https://ethereum.org/en/developers/docs/apis/json-rpc/)
+- [https://ethereum.org/en/developers/docs/apis/json-rpc/](https://ethereum.org/en/developers/docs/apis/json-rpc/)
 
 ### Implementation Details
 
-* The web3 namespace is implemented in `Web3APIImpl` which extends `BaseAPI` and uses the `ethBackend` for client version information
-* The `web3_sha3` method uses Erigon's crypto library implementation of Keccak-256, which is the same hashing algorithm used throughout Ethereum
-* Both methods are lightweight utility functions that don't require complex blockchain state access
+- The web3 namespace is implemented in `Web3APIImpl` which extends `BaseAPI` and uses the `ethBackend` for client version information
+- The `web3_sha3` method uses Erigon's crypto library implementation of Keccak-256, which is the same hashing algorithm used throughout Ethereum
+- Both methods are lightweight utility functions that don't require complex blockchain state access
 
 ### Usage Considerations
 
-* `web3_clientVersion` is often used by applications to identify the Ethereum client type and version for compatibility checks
-* `web3_sha3` provides the same Keccak-256 hashing that's used for Ethereum addresses, transaction hashes, and other cryptographic operations in the protocol
-* These methods are part of the core Ethereum JSON-RPC specification and are supported by all major Ethereum clients
+- `web3_clientVersion` is often used by applications to identify the Ethereum client type and version for compatibility checks
+- `web3_sha3` provides the same Keccak-256 hashing that's used for Ethereum addresses, transaction hashes, and other cryptographic operations in the protocol
+- These methods are part of the core Ethereum JSON-RPC specification and are supported by all major Ethereum clients
 
 ### Availability
 
-* The web3 namespace is enabled by default in Erigon's RPC Daemon
-* No special configuration is required to use these methods
-* They are available on both HTTP and WebSocket connections
+- The web3 namespace is enabled by default in Erigon's RPC Daemon
+- No special configuration is required to use these methods
+- They are available on both HTTP and WebSocket connections
 
 ---
 
 # net
 URL: https://docs.erigon.tech/interacting-with-erigon/net
-
 
 The `net` namespace provides network-related methods that are part of the standard Ethereum JSON-RPC API. These methods offer information about the node's network connectivity, peer count, and network version. In Erigon, the net namespace is implemented through the `NetAPI` interface and `NetAPIImpl` struct.
 
@@ -5417,42 +5531,41 @@ The `net` namespace is enabled by default in Erigon's RPC Daemon and provides es
 
 For API usage refer to the below official resources:
 
-* [https://ethereum.org/en/developers/docs/apis/json-rpc/](https://ethereum.org/en/developers/docs/apis/json-rpc/)
+- [https://ethereum.org/en/developers/docs/apis/json-rpc/](https://ethereum.org/en/developers/docs/apis/json-rpc/)
 
 ### Implementation Details
 
-* The net namespace is implemented in `NetAPIImpl` which uses the `ethBackend` to access network information.
-* `net_listening` determines connectivity by attempting to retrieve peer information from the backend.
-* `net_version` and `net_peerCount` require access to the backend and will return errors in `--datadir` mode when the backend is unavailable.
+- The net namespace is implemented in `NetAPIImpl` which uses the `ethBackend` to access network information.
+- `net_listening` determines connectivity by attempting to retrieve peer information from the backend.
+- `net_version` and `net_peerCount` require access to the backend and will return errors in `--datadir` mode when the backend is unavailable.
 
 ### Backend Dependency
 
-* Methods `net_version` and `net_peerCount` require the `ethBackend` to be available.
-* When running in `--datadir` mode or when the backend cannot be accessed, these methods will return a "not available" error.
-* The `net_listening` method gracefully handles backend unavailability by returning `false` .
+- Methods `net_version` and `net_peerCount` require the `ethBackend` to be available.
+- When running in `--datadir` mode or when the backend cannot be accessed, these methods will return a "not available" error.
+- The `net_listening` method gracefully handles backend unavailability by returning `false` .
 
 ### Network Information Usage
 
-* `net_version` is commonly used by applications to verify they're connected to the correct .Ethereum network.
-* `net_peerCount` helps monitor node connectivity and network health.
-* `net_listening` provides a basic connectivity check for the node's network interface.
+- `net_version` is commonly used by applications to verify they're connected to the correct .Ethereum network.
+- `net_peerCount` helps monitor node connectivity and network health.
+- `net_listening` provides a basic connectivity check for the node's network interface.
 
 ### Availability and Configuration
 
-* The net namespace is enabled by default in Erigon's RPC Daemon.
-* These methods are available on both HTTP and WebSocket connections.
-* For remote RPC Daemon setups, the `net` namespace must be explicitly enabled for health check functionality.
+- The net namespace is enabled by default in Erigon's RPC Daemon.
+- These methods are available on both HTTP and WebSocket connections.
+- For remote RPC Daemon setups, the `net` namespace must be explicitly enabled for health check functionality.
 
 ### Documentation References
 
-* The current implementation shows some limitations noted in the documentation, such as hardcoded return values in certain scenarios.
-* `net_peerCount` specifically counts only internal sentries, which may not reflect the total peer count in distributed setups.
+- The current implementation shows some limitations noted in the documentation, such as hardcoded return values in certain scenarios.
+- `net_peerCount` specifically counts only internal sentries, which may not reflect the total peer count in distributed setups.
 
 ---
 
 # debug
 URL: https://docs.erigon.tech/interacting-with-erigon/debug
-
 
 The `debug` namespace provides debugging and diagnostic methods for Erigon node operators and developers. These methods offer deep introspection into blockchain state, transaction execution, and node performance.
 
@@ -5464,41 +5577,39 @@ The `debug` namespace is intended for debugging and development purposes, not fo
 
 #### Security and Access Control
 
-* Debug methods are considered private and should not be exposed on public RPC endpoints;
-* These methods can consume significant resources and should be used carefully in production environments;
-* Access should be restricted to trusted operators and developers only.
+- Debug methods are considered private and should not be exposed on public RPC endpoints;
+- These methods can consume significant resources and should be used carefully in production environments;
+- Access should be restricted to trusted operators and developers only.
 
 #### Performance Considerations
 
-* Tracing methods (`debug_traceBlockByHash`, `debug_traceBlockByNumber`, `debug_traceTransaction`, `debug_traceCall`, `debug_traceCallMany`) support streaming for large results to reduce memory usage
-* The `AccountRangeMaxResults` constant limits account range queries to 8192 results, or 256 when storage is included;
-* Memory and GC control methods allow fine-tuning of node performance.
-* Some methods like `debug_accountRange` have compatibility layers for both Geth and legacy Erigon parameter formats `debug_api`
+- Tracing methods (`debug_traceBlockByHash`, `debug_traceBlockByNumber`, `debug_traceTransaction`, `debug_traceCall`, `debug_traceCallMany`) support streaming for large results to reduce memory usage
+- The `AccountRangeMaxResults` constant limits account range queries to 8192 results, or 256 when storage is included;
+- Memory and GC control methods allow fine-tuning of node performance.
+- Some methods like `debug_accountRange` have compatibility layers for both Geth and legacy Erigon parameter formats `debug_api`
 
 #### Integration with Erigon Architecture
 
-* Debug methods leverage Erigon's temporal database for historical state access;
-* The implementation uses `kv.TemporalRoDB` for efficient historical queries;
-* Tracing functionality integrates with Erigon's execution engine and EVM implementation.
+- Debug methods leverage Erigon's temporal database for historical state access;
+- The implementation uses `kv.TemporalRoDB` for efficient historical queries;
+- Tracing functionality integrates with Erigon's execution engine and EVM implementation.
 
 #### Usage in Development and Testing
 
-* These methods are essential for debugging transaction execution issues;
-* Storage range methods help analyze contract state changes;
-* Memory management methods assist in performance optimization and resource monitoring.
-
-***
+- These methods are essential for debugging transaction execution issues;
+- Storage range methods help analyze contract state changes;
+- Memory management methods assist in performance optimization and resource monitoring.
 
 ## JSON-RPC Specification
 
-### debug\_getRawReceipts
+### debug_getRawReceipts
 
 Returns an array of EIP-2718 binary-encoded receipts from a single block.
 
 #### Parameters
 
-| Parameter     | Type                    | Description                                                        |
-| ------------- | ----------------------- | ------------------------------------------------------------------ |
+| Parameter | Type | Description |
+| --- | --- | --- |
 | blockNrOrHash | QUANTITY \| TAG \| DATA | Block number, tag ("earliest", "latest", "pending"), or block hash |
 
 #### Example
@@ -5509,24 +5620,24 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_getRawReceipts","params":["0x12
 
 #### Returns
 
-| Type          | Description                                  |
-| ------------- | -------------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Array of DATA | Array of binary-encoded transaction receipts |
 
-### debug\_accountRange
+### debug_accountRange
 
 Returns a range of accounts involved in the given block range.
 
 #### Parameters
 
-| Parameter      | Type            | Description                                                 |
-| -------------- | --------------- | ----------------------------------------------------------- |
-| blockNrOrHash  | QUANTITY \| TAG | Block number or tag                                         |
-| start          | DATAARRAY       | Array of prefixes to match account addresses                |
-| maxResults     | QUANTITY        | Maximum number of accounts to retrieve                      |
-| excludeCode    | BOOLEAN         | If true, exclude byte code from results                     |
-| excludeStorage | BOOLEAN         | If true, exclude storage from results                       |
-| incompletes    | BOOLEAN         | Accepted but ignored                                        |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| blockNrOrHash | QUANTITY \| TAG | Block number or tag |
+| start | DATAARRAY | Array of prefixes to match account addresses |
+| maxResults | QUANTITY | Maximum number of accounts to retrieve |
+| excludeCode | BOOLEAN | If true, exclude byte code from results |
+| excludeStorage | BOOLEAN | If true, exclude storage from results |
+| incompletes | BOOLEAN | Accepted but ignored |
 
 #### Example
 
@@ -5536,21 +5647,21 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_accountRange","params":["0xaaaa
 
 #### Returns
 
-| Type   | Description                                        |
-| ------ | -------------------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Object | IteratorDump object containing account information |
 
-### debug\_accountAt
+### debug_accountAt
 
 Returns account information at a specific block and transaction index.
 
 #### Parameters
 
-| Parameter | Type           | Description                        |
-| --------- | -------------- | ---------------------------------- |
-| blockHash | DATA, 32 Bytes | Hash of the block                  |
-| txIndex   | QUANTITY       | Transaction index within the block |
-| address   | DATA, 20 Bytes | Account address                    |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| blockHash | DATA, 32 Bytes | Hash of the block |
+| txIndex | QUANTITY | Transaction index within the block |
+| address | DATA, 20 Bytes | Account address |
 
 #### Example
 
@@ -5560,20 +5671,20 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_accountAt","params":["0x123456.
 
 #### Returns
 
-| Type   | Description                                           |
-| ------ | ----------------------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Object | AccountResult with balance, nonce, code, and codeHash |
 
-### debug\_getModifiedAccountsByNumber
+### debug_getModifiedAccountsByNumber
 
 Returns a list of accounts modified in the given block range by number.
 
 #### Parameters
 
-| Parameter   | Type            | Description                        |
-| ----------- | --------------- | ---------------------------------- |
-| startNumber | QUANTITY \| TAG | Start block number or tag          |
-| endNumber   | QUANTITY \| TAG | End block number or tag (optional) |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| startNumber | QUANTITY \| TAG | Start block number or tag |
+| endNumber | QUANTITY \| TAG | End block number or tag (optional) |
 
 #### Example
 
@@ -5583,20 +5694,20 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_getModifiedAccountsByNumber","p
 
 #### Returns
 
-| Type                    | Description                         |
-| ----------------------- | ----------------------------------- |
+| Type | Description |
+| --- | --- |
 | Array of DATA, 20 Bytes | Array of modified account addresses |
 
-### debug\_getModifiedAccountsByHash
+### debug_getModifiedAccountsByHash
 
 Returns a list of accounts modified in the given block range by hash.
 
 #### Parameters
 
-| Parameter | Type           | Description                      |
-| --------- | -------------- | -------------------------------- |
-| startHash | DATA, 32 Bytes | Hash of the start block          |
-| endHash   | DATA, 32 Bytes | Hash of the end block (optional) |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| startHash | DATA, 32 Bytes | Hash of the start block |
+| endHash | DATA, 32 Bytes | Hash of the end block (optional) |
 
 #### Example
 
@@ -5606,23 +5717,23 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_getModifiedAccountsByHash","par
 
 #### Returns
 
-| Type                    | Description                         |
-| ----------------------- | ----------------------------------- |
+| Type | Description |
+| --- | --- |
 | Array of DATA, 20 Bytes | Array of modified account addresses |
 
-### debug\_storageRangeAt
+### debug_storageRangeAt
 
 Returns information about a range of storage locations for a contract address.
 
 #### Parameters
 
-| Parameter       | Type              | Description                             |
-| --------------- | ----------------- | --------------------------------------- |
-| blockHash       | DATA, 32 Bytes    | Hash of block at which to retrieve data |
-| txIndex         | QUANTITY, 8 Bytes | Transaction index in the block          |
-| contractAddress | DATA, 20 Bytes    | Contract address                        |
-| keyStart        | DATA, 32 Bytes    | Storage key to start from               |
-| maxResult       | QUANTITY, 8 Bytes | Maximum number of values to retrieve    |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| blockHash | DATA, 32 Bytes | Hash of block at which to retrieve data |
+| txIndex | QUANTITY, 8 Bytes | Transaction index in the block |
+| contractAddress | DATA, 20 Bytes | Contract address |
+| keyStart | DATA, 32 Bytes | Storage key to start from |
+| maxResult | QUANTITY, 8 Bytes | Maximum number of values to retrieve |
 
 #### Example
 
@@ -5632,20 +5743,20 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_storageRangeAt","params":["0xd3
 
 #### Returns
 
-| Type   | Description                                         |
-| ------ | --------------------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Object | StorageRangeResult with key/value pairs and nextKey |
 
-### debug\_traceBlockByHash
+### debug_traceBlockByHash
 
 Returns Geth style transaction traces for a block by hash.
 
 #### Parameters
 
-| Parameter | Type              | Description                 |
-| --------- | ----------------- | --------------------------- |
-| hash      | DATA, 32 Bytes    | Hash of block to trace      |
-| config    | Object (optional) | Trace configuration options |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| hash | DATA, 32 Bytes | Hash of block to trace |
+| config | Object (optional) | Trace configuration options |
 
 #### Example
 
@@ -5655,20 +5766,20 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_traceBlockByHash","params":["0x
 
 #### Returns
 
-| Type  | Description                        |
-| ----- | ---------------------------------- |
+| Type | Description |
+| --- | --- |
 | Array | Array of transaction trace objects |
 
-### debug\_traceBlockByNumber
+### debug_traceBlockByNumber
 
 Returns Geth style transaction traces for a block by number.
 
 #### Parameters
 
-| Parameter   | Type              | Description                 |
-| ----------- | ----------------- | --------------------------- |
-| blockNumber | QUANTITY \| TAG   | Block number or tag; `pending` is not supported |
-| config      | Object (optional) | Trace configuration options |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| blockNumber | QUANTITY \| TAG | Block number or tag; `pending` is not supported |
+| config | Object (optional) | Trace configuration options |
 
 #### Example
 
@@ -5678,20 +5789,20 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_traceBlockByNumber","params":["
 
 #### Returns
 
-| Type  | Description                        |
-| ----- | ---------------------------------- |
+| Type | Description |
+| --- | --- |
 | Array | Array of transaction trace objects |
 
-### debug\_traceTransaction
+### debug_traceTransaction
 
 Returns Geth style transaction trace.
 
 #### Parameters
 
-| Parameter | Type              | Description                  |
-| --------- | ----------------- | ---------------------------- |
-| hash      | DATA, 32 Bytes    | Hash of transaction to trace |
-| config    | Object (optional) | Trace configuration options  |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| hash | DATA, 32 Bytes | Hash of transaction to trace |
+| config | Object (optional) | Trace configuration options |
 
 #### Example
 
@@ -5701,21 +5812,21 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_traceTransaction","params":["0x
 
 #### Returns
 
-| Type   | Description              |
-| ------ | ------------------------ |
+| Type | Description |
+| --- | --- |
 | Object | Transaction trace object |
 
-### debug\_traceCall
+### debug_traceCall
 
 Returns Geth style call trace.
 
 #### Parameters
 
-| Parameter     | Type                    | Description                                           |
-| ------------- | ----------------------- | ----------------------------------------------------- |
-| args          | Object                  | Call arguments (to, from, gas, gasPrice, value, data) |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| args | Object | Call arguments (to, from, gas, gasPrice, value, data) |
 | blockNrOrHash | QUANTITY \| TAG \| DATA | Block number, tag, or hash; `pending` is not supported |
-| config        | Object (optional)       | Trace configuration options                           |
+| config | Object (optional) | Trace configuration options |
 
 #### Example
 
@@ -5725,21 +5836,21 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_traceCall","params":[{"to":"0x1
 
 #### Returns
 
-| Type   | Description       |
-| ------ | ----------------- |
+| Type | Description |
+| --- | --- |
 | Object | Call trace object |
 
-### debug\_traceCallMany
+### debug_traceCallMany
 
 Returns Geth style traces for multiple call bundles.
 
 #### Parameters
 
-| Parameter       | Type              | Description                                        |
-| --------------- | ----------------- | -------------------------------------------------- |
-| bundles         | Array             | Array of transaction bundles to trace              |
-| simulateContext | Object            | Simulation context; `blockNumber` does not support `pending` |
-| config          | Object (optional) | Trace configuration options                        |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| bundles | Array | Array of transaction bundles to trace |
+| simulateContext | Object | Simulation context; `blockNumber` does not support `pending` |
+| config | Object (optional) | Trace configuration options |
 
 #### Example
 
@@ -5749,19 +5860,19 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_traceCallMany","params":[[{"tra
 
 #### Returns
 
-| Type  | Description                            |
-| ----- | -------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Array | Array of trace results for each bundle |
 
-### debug\_setMemoryLimit
+### debug_setMemoryLimit
 
 Sets the GOMEMLIMIT for the process.
 
 #### Parameters
 
-| Parameter | Type     | Description           |
-| --------- | -------- | --------------------- |
-| limit     | QUANTITY | Memory limit in bytes |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| limit | QUANTITY | Memory limit in bytes |
 
 #### Example
 
@@ -5771,19 +5882,19 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_setMemoryLimit","params":[85899
 
 #### Returns
 
-| Type     | Description           |
-| -------- | --------------------- |
+| Type | Description |
+| --- | --- |
 | QUANTITY | Previous memory limit |
 
-### debug\_setGCPercent
+### debug_setGCPercent
 
 Sets the garbage collection target percentage.
 
 #### Parameters
 
-| Parameter | Type     | Description                                |
-| --------- | -------- | ------------------------------------------ |
-| v         | QUANTITY | GC percentage (negative value disables GC) |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| v | QUANTITY | GC percentage (negative value disables GC) |
 
 #### Example
 
@@ -5793,11 +5904,11 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_setGCPercent","params":[100],"i
 
 #### Returns
 
-| Type     | Description                    |
-| -------- | ------------------------------ |
+| Type | Description |
+| --- | --- |
 | QUANTITY | Previous GC percentage setting |
 
-### debug\_freeOSMemory
+### debug_freeOSMemory
 
 Forces a garbage collection to free OS memory.
 
@@ -5813,11 +5924,11 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_freeOSMemory","params":[],"id":
 
 #### Returns
 
-| Type | Description     |
-| ---- | --------------- |
+| Type | Description |
+| --- | --- |
 | null | No return value |
 
-### debug\_gcStats
+### debug_gcStats
 
 Returns garbage collection statistics.
 
@@ -5833,11 +5944,11 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_gcStats","params":[],"id":"1"}'
 
 #### Returns
 
-| Type   | Description          |
-| ------ | -------------------- |
+| Type | Description |
+| --- | --- |
 | Object | GC statistics object |
 
-### debug\_memStats
+### debug_memStats
 
 Returns detailed runtime memory statistics.
 
@@ -5853,15 +5964,14 @@ curl -s --data '{"jsonrpc":"2.0","method":"debug_memStats","params":[],"id":"1"}
 
 #### Returns
 
-| Type   | Description                      |
-| ------ | -------------------------------- |
+| Type | Description |
+| --- | --- |
 | Object | Runtime memory statistics object |
 
 ---
 
 # trace
 URL: https://docs.erigon.tech/interacting-with-erigon/trace
-
 
 The `trace` module is for getting a deeper insight into transaction processing. It includes two sets of calls the transaction trace filtering API and the ad-hoc tracing API.
 
@@ -5879,9 +5989,9 @@ The ad-hoc tracing API allows you to perform diagnostics on calls or transaction
 
 The diagnostics are requested by providing a configuration object that specifies the tracer type to be executed, allowing for deep insight into EVM execution:
 
-* `trace`: Provides a Transaction Trace, showing the sequence of all external calls, internal messages, and value transfers that occurred during execution.
-* `vmTrace`: Provides a Virtual Machine Execution Trace, delivering a full step-by-step trace of the EVM's state throughout the transaction, including all opcodes and gas usage.
-* `stateDiff`: Provides a State Difference, detailing all altered portions of the Ethereum state (e.g., storage, balances, nonces) resulting from the transaction's execution.
+- `trace`: Provides a Transaction Trace, showing the sequence of all external calls, internal messages, and value transfers that occurred during execution.
+- `vmTrace`: Provides a Virtual Machine Execution Trace, delivering a full step-by-step trace of the EVM's state throughout the transaction, including all opcodes and gas usage.
+- `stateDiff`: Provides a State Difference, detailing all altered portions of the Ethereum state (e.g., storage, balances, nonces) resulting from the transaction's execution.
 
 #### Flat Tracers
 
@@ -5901,11 +6011,11 @@ There are three primary ways to specify the transaction to be traced:
 
 ## The Transaction-Trace Filtering API
 
-These APIs allow you to get a full _externality_ trace on any transaction executed throughout the Erigon chain. Unlike the log filtering API, you are able to search and filter based only upon address information. Information returned includes the execution of all `CREATE`s, `SUICIDE`s and all variants of `CALL` together with input data, output data, gas usage, amount transferred and the success status of each individual action.
+These APIs allow you to get a full *externality* trace on any transaction executed throughout the Erigon chain. Unlike the log filtering API, you are able to search and filter based only upon address information. Information returned includes the execution of all `CREATE`s, `SUICIDE`s and all variants of `CALL` together with input data, output data, gas usage, amount transferred and the success status of each individual action.
 
 ### `traceAddress` field
 
-The `traceAddress` field of all returned traces, gives the exact location in the call trace \[index in root, index in first `CALL`, index in second `CALL`, ...].
+The `traceAddress` field of all returned traces, gives the exact location in the call trace [index in root, index in first `CALL`, index in second `CALL`, ...].
 
 i.e. if the trace is:
 
@@ -5925,18 +6035,18 @@ then it should look something like:
 
 #### Ad-hoc Tracing
 
-* [trace\_call](#trace_call)
-* [trace\_callMany](#trace_callmany)
-* [trace\_rawTransaction](#trace_rawtransaction)
-* [trace\_replayBlockTransactions](#trace_replayblocktransactions)
-* [trace\_replayTransaction](#trace_replaytransaction)
+- [trace_call](https://docs.erigon.tech/interacting-with-erigon/trace#trace_call)
+- [trace_callMany](https://docs.erigon.tech/interacting-with-erigon/trace#trace_callmany)
+- [trace_rawTransaction](https://docs.erigon.tech/interacting-with-erigon/trace#trace_rawtransaction)
+- [trace_replayBlockTransactions](https://docs.erigon.tech/interacting-with-erigon/trace#trace_replayblocktransactions)
+- [trace_replayTransaction](https://docs.erigon.tech/interacting-with-erigon/trace#trace_replaytransaction)
 
 #### Transaction-Trace Filtering
 
-* [trace\_block](#trace_block)
-* [trace\_filter](#trace_filter)
-* [trace\_get](#trace_get)
-* [trace\_transaction](#trace_transaction)
+- [trace_block](https://docs.erigon.tech/interacting-with-erigon/trace#trace_block)
+- [trace_filter](https://docs.erigon.tech/interacting-with-erigon/trace#trace_filter)
+- [trace_get](https://docs.erigon.tech/interacting-with-erigon/trace#trace_get)
+- [trace_transaction](https://docs.erigon.tech/interacting-with-erigon/trace#trace_transaction)
 
 ## Response Fields Reference
 
@@ -5947,9 +6057,9 @@ All `trace_*` methods return objects built from the same set of fields. Each met
 | Method | Top-level shape |
 | --- | --- |
 | `trace_call`, `trace_rawTransaction`, `trace_replayTransaction` | `Object` with `output`, `stateDiff`, `trace[]`, `vmTrace` |
-| `trace_callMany` | `Array` — one per input call |
-| `trace_replayBlockTransactions` | `Array` — one per transaction; each entry adds `transactionHash` |
-| `trace_block`, `trace_filter`, `trace_transaction` | `Array` (flat list across all call frames) |
+| `trace_callMany` | `Array<Object>` — one per input call |
+| `trace_replayBlockTransactions` | `Array<Object>` — one per transaction; each entry adds `transactionHash` |
+| `trace_block`, `trace_filter`, `trace_transaction` | `Array<TraceEntry>` (flat list across all call frames) |
 | `trace_get` | `TraceEntry` (single call frame at the requested `traceAddress` path) |
 
 ### Top-level (ad-hoc tracing) fields
@@ -6043,23 +6153,21 @@ The `result` object's shape depends on `type`:
 
 `result` is `null` — these actions have no return value.
 
-***
-
 ## JSON-RPC API Reference
 
-### trace\_call
+### trace_call
 
 Executes the given call and returns a number of possible traces for it.
 
 #### Parameters
 
-1. `Object` - \[Transaction object] where `from` field is optional and `nonce` field is omitted.
+1. `Object` - [Transaction object] where `from` field is optional and `nonce` field is omitted.
 2. `Array` - Type of trace, one or more of: `"vmTrace"`, `"trace"`, `"stateDiff"`.
 3. `Quantity` or `Tag` - (optional) Integer of a block number, or the string `'earliest'` or `'latest'`. `'pending'` is not supported: the call is executed against committed state, so there is no pending block to execute on top of.
 
 #### Returns
 
-`Object` containing `output`, `stateDiff`, `trace[]`, `vmTrace`. Each requested trace type is populated; `stateDiff` and `vmTrace` are `null` when not requested, while `trace` is an empty array. See [Response Fields Reference](#response-fields-reference) for full field semantics.
+`Object` containing `output`, `stateDiff`, `trace[]`, `vmTrace`. Each requested trace type is populated; `stateDiff` and `vmTrace` are `null` when not requested, while `trace` is an empty array. See [Response Fields Reference](https://docs.erigon.tech/interacting-with-erigon/trace#response-fields-reference) for full field semantics.
 
 #### Example
 
@@ -6093,9 +6201,7 @@ Response
 }
 ```
 
-***
-
-### trace\_callMany
+### trace_callMany
 
 Performs multiple call traces on top of the same block. i.e. transaction `n` will be executed on top of a pending block with all `n-1` transactions applied (traced) first. Allows to trace dependent transactions.
 
@@ -6130,7 +6236,7 @@ params: [
 
 #### Returns
 
-`Array` — one entry per input call, each shaped like the `trace_call` response (`output`, `stateDiff`, `trace[]`, `vmTrace`). See [Response Fields Reference](#response-fields-reference).
+`Array<Object>` — one entry per input call, each shaped like the `trace_call` response (`output`, `stateDiff`, `trace[]`, `vmTrace`). See [Response Fields Reference](https://docs.erigon.tech/interacting-with-erigon/trace#response-fields-reference).
 
 #### Example
 
@@ -6195,9 +6301,7 @@ Response
 }
 ```
 
-***
-
-### trace\_rawTransaction
+### trace_rawTransaction
 
 Traces a call to `eth_sendRawTransaction` without making the call, returning the traces
 
@@ -6215,7 +6319,7 @@ params: [
 
 #### Returns
 
-`Object` shaped like the `trace_call` response (`output`, `stateDiff`, `trace[]`, `vmTrace`). See [Response Fields Reference](#response-fields-reference).
+`Object` shaped like the `trace_call` response (`output`, `stateDiff`, `trace[]`, `vmTrace`). See [Response Fields Reference](https://docs.erigon.tech/interacting-with-erigon/trace#response-fields-reference).
 
 #### Example
 
@@ -6249,9 +6353,7 @@ Response
 }
 ```
 
-***
-
-### trace\_replayBlockTransactions
+### trace_replayBlockTransactions
 
 Replays all transactions in a block returning the requested traces for each transaction.
 
@@ -6269,7 +6371,7 @@ params: [
 
 #### Returns
 
-`Array` — one entry per transaction in the block. Each entry is shaped like the `trace_call` response plus a `transactionHash` field identifying the transaction. See [Response Fields Reference](#response-fields-reference).
+`Array<Object>` — one entry per transaction in the block. Each entry is shaped like the `trace_call` response plus a `transactionHash` field identifying the transaction. See [Response Fields Reference](https://docs.erigon.tech/interacting-with-erigon/trace#response-fields-reference).
 
 #### Example
 
@@ -6307,9 +6409,7 @@ Response
 }
 ```
 
-***
-
-### trace\_replayTransaction
+### trace_replayTransaction
 
 Replays a transaction, returning the traces.
 
@@ -6327,7 +6427,7 @@ params: [
 
 #### Returns
 
-`Object` shaped like the `trace_call` response (`output`, `stateDiff`, `trace[]`, `vmTrace`). See [Response Fields Reference](#response-fields-reference).
+`Object` shaped like the `trace_call` response (`output`, `stateDiff`, `trace[]`, `vmTrace`). See [Response Fields Reference](https://docs.erigon.tech/interacting-with-erigon/trace#response-fields-reference).
 
 #### Example
 
@@ -6361,9 +6461,7 @@ Response
 }
 ```
 
-***
-
-### trace\_block
+### trace_block
 
 Returns traces created at given block.
 
@@ -6379,7 +6477,7 @@ params: [
 
 #### Returns
 
-`Array` — flat list of all call frames in the block, including any `"reward"` entries for block/uncle rewards. Each entry includes block-level fields (`blockHash`, `blockNumber`, `transactionHash`, `transactionPosition`). See [Response Fields Reference](#response-fields-reference).
+`Array<TraceEntry>` — flat list of all call frames in the block, including any `"reward"` entries for block/uncle rewards. Each entry includes block-level fields (`blockHash`, `blockNumber`, `transactionHash`, `transactionPosition`). See [Response Fields Reference](https://docs.erigon.tech/interacting-with-erigon/trace#response-fields-reference).
 
 #### Example
 
@@ -6422,24 +6520,23 @@ Response
 }
 ```
 
-***
-
-### trace\_filter
+### trace_filter
 
 Returns traces matching given filter
 
 #### Parameters
 
 1. `Object` - The filter object
-   * `fromBlock`: `Quantity` or `Tag` - (optional) From this block.
-   * `toBlock`: `Quantity` or `Tag` - (optional) To this block.
-   * `fromAddress`: `Array` - (optional) Sent from these addresses.
-   * `toAddress`: `Address` - (optional) Sent to these addresses.
-   * `after`: `Quantity` - (optional) The offset trace number
-   * `count`: `Quantity` - (optional) Integer number of traces to display in a batch.
-   * `mode`: `String` - (optional) Default is `"union"`, meaning traces matching either address filter are returned. Set to `"intersection"` to only return traces that satisfy both `fromAddress` and `toAddress` filters simultaneously.
 
-   The `'pending'` tag is not supported for either block bound: `trace_filter` scans committed trace history, which has no pending block.
+  - `fromBlock`: `Quantity` or `Tag` - (optional) From this block.
+  - `toBlock`: `Quantity` or `Tag` - (optional) To this block.
+  - `fromAddress`: `Array` - (optional) Sent from these addresses.
+  - `toAddress`: `Address` - (optional) Sent to these addresses.
+  - `after`: `Quantity` - (optional) The offset trace number
+  - `count`: `Quantity` - (optional) Integer number of traces to display in a batch.
+  - `mode`: `String` - (optional) Default is `"union"`, meaning traces matching either address filter are returned. Set to `"intersection"` to only return traces that satisfy both `fromAddress` and `toAddress` filters simultaneously.
+
+The `'pending'` tag is not supported for either block bound: `trace_filter` scans committed trace history, which has no pending block.
 
 ```js
 params: [{
@@ -6453,7 +6550,7 @@ params: [{
 
 #### Returns
 
-`Array` — flat list of call frames that match the filter, including any `"reward"` entries when the filter matches block coinbases or uncle authors. Each entry has block-level fields (`blockHash`, `blockNumber`, `transactionHash`, `transactionPosition`). See [Response Fields Reference](#response-fields-reference).
+`Array<TraceEntry>` — flat list of call frames that match the filter, including any `"reward"` entries when the filter matches block coinbases or uncle authors. Each entry has block-level fields (`blockHash`, `blockNumber`, `transactionHash`, `transactionPosition`). See [Response Fields Reference](https://docs.erigon.tech/interacting-with-erigon/trace#response-fields-reference).
 
 #### Example
 
@@ -6496,9 +6593,7 @@ Response
 }
 ```
 
-***
-
-### trace\_get
+### trace_get
 
 Returns the call frame at the given `traceAddress` path.
 
@@ -6516,7 +6611,7 @@ params: [
 
 #### Returns
 
-A single `TraceEntry` corresponding to the call frame at the requested `traceAddress` path, with block-level fields (`blockHash`, `blockNumber`, `transactionHash`, `transactionPosition`). See [Response Fields Reference](#response-fields-reference).
+A single `TraceEntry` corresponding to the call frame at the requested `traceAddress` path, with block-level fields (`blockHash`, `blockNumber`, `transactionHash`, `transactionPosition`). See [Response Fields Reference](https://docs.erigon.tech/interacting-with-erigon/trace#response-fields-reference).
 
 #### Example
 
@@ -6558,9 +6653,7 @@ Response
 }
 ```
 
-***
-
-### trace\_transaction
+### trace_transaction
 
 Returns all traces of given transaction
 
@@ -6574,7 +6667,7 @@ params: ["0x17104ac9d3312d8c136b7f44d4b8b47852618065ebfa534bd2d3b5ef218ca1f3"]
 
 #### Returns
 
-`Array` — flat list of all call frames in the transaction, with block-level fields (`blockHash`, `blockNumber`, `transactionHash`, `transactionPosition`) on each entry. See [Response Fields Reference](#response-fields-reference).
+`Array<TraceEntry>` — flat list of all call frames in the transaction, with block-level fields (`blockHash`, `blockNumber`, `transactionHash`, `transactionPosition`) on each entry. See [Response Fields Reference](https://docs.erigon.tech/interacting-with-erigon/trace#response-fields-reference).
 
 #### Example
 
@@ -6624,51 +6717,48 @@ Response
 # txpool
 URL: https://docs.erigon.tech/interacting-with-erigon/txpool
 
-
 The `txpool` namespace provides methods for inspecting and managing the transaction pool (mempool) in Erigon. These methods allow you to view pending and queued transactions, providing insight into the current state of unconfirmed transactions. In Erigon, the `txpool` namespace is implemented through the `TxPoolAPI` interface and `TxPoolAPIImpl` struct.
 
 The TxPool namespace must be explicitly enabled using the `--http.api` flag when starting the RPC Daemon. These methods are particularly useful for monitoring transaction pool status and debugging transaction submission issues.
 
 ### Transaction Pool Architecture
 
-* Erigon's transaction pool is organized into three sub-pools: pending (executable), baseFee (insufficient base fee), and queued (nonce gaps)
-* The `txpool_content`, `txpool_contentFrom` and `txpool_status` methods expose only the `pending` and `queued` categories, as defined by the `ethereum/execution-apis` specification. Transactions in the internal baseFee sub-pool are nonce-ready and otherwise valid, but are not executable at the current base fee: they wait for the fee condition to change. They are reported as pending, matching Geth
-* Blob transactions (type 3) are not reported by `txpool_content` and `txpool_contentFrom`, matching Geth and Nethermind. They are still counted by `txpool_status`
-* The pool can run either integrated within the main Erigon process or as a separate service for scalability
-* Transaction pool methods communicate via gRPC with the TxPool service when running in external mode
+- Erigon's transaction pool is organized into three sub-pools: pending (executable), baseFee (insufficient base fee), and queued (nonce gaps)
+- The `txpool_content`, `txpool_contentFrom` and `txpool_status` methods expose only the `pending` and `queued` categories, as defined by the `ethereum/execution-apis` specification. Transactions in the internal baseFee sub-pool are nonce-ready and otherwise valid, but are not executable at the current base fee: they wait for the fee condition to change. They are reported as pending, matching Geth
+- Blob transactions (type 3) are not reported by `txpool_content` and `txpool_contentFrom`, matching Geth and Nethermind. They are still counted by `txpool_status`
+- The pool can run either integrated within the main Erigon process or as a separate service for scalability
+- Transaction pool methods communicate via gRPC with the TxPool service when running in external mode
 
 ### Implementation Details
 
-* The `TxPoolAPIImpl` uses a `proto_txpool.TxpoolClient` to communicate with the transaction pool service
-* All transactions are decoded from RLP format and converted to `ethapi.RPCTransaction` objects for JSON-RPC responses
-* The implementation handles transaction categorization based on the `TxnType` field from the pool service
+- The `TxPoolAPIImpl` uses a `proto_txpool.TxpoolClient` to communicate with the transaction pool service
+- All transactions are decoded from RLP format and converted to `ethapi.RPCTransaction` objects for JSON-RPC responses
+- The implementation handles transaction categorization based on the `TxnType` field from the pool service
 
 ### External vs Internal Mode
 
-* **Internal Mode**: Transaction pool runs within the main Erigon process (default configuration)
-* **External Mode**: Transaction pool runs as a separate service, requiring explicit configuration with `--txpool.api.addr`. External mode requires an external Sentry service and provides better resource isolation
+- **Internal Mode**: Transaction pool runs within the main Erigon process (default configuration)
+- **External Mode**: Transaction pool runs as a separate service, requiring explicit configuration with `--txpool.api.addr`. External mode requires an external Sentry service and provides better resource isolation
 
 ### Usage in Development and Testing
 
-* These methods are commonly used for monitoring transaction submission and pool state
-* The `txpool_status` method provides quick insight into pool health and congestion
-* Transaction pool content methods help debug why transactions may not be getting mined
+- These methods are commonly used for monitoring transaction submission and pool state
+- The `txpool_status` method provides quick insight into pool health and congestion
+- Transaction pool content methods help debug why transactions may not be getting mined
 
 ### Configuration and Limits
 
-* Transaction pool limits can be configured via flags like `--txpool.globalslots`, `--txpool.globalbasefeeslots`, and `--txpool.globalqueue`
-* The pool supports various transaction types including blob transactions with separate limits
-* Pool configuration is managed through the `txpoolcfg.Config` structure
+- Transaction pool limits can be configured via flags like `--txpool.globalslots`, `--txpool.globalbasefeeslots`, and `--txpool.globalqueue`
+- The pool supports various transaction types including blob transactions with separate limits
+- Pool configuration is managed through the `txpoolcfg.Config` structure
 
 ### Availability
 
-* The `txpool` namespace is available when included in the `--http.api` flag
-* Methods are marked as "remote" in the documentation, indicating they communicate with external services
-* All `txpool` methods are available on both HTTP and WebSocket connections
+- The `txpool` namespace is available when included in the `--http.api` flag
+- Methods are marked as "remote" in the documentation, indicating they communicate with external services
+- All `txpool` methods are available on both HTTP and WebSocket connections
 
-***
-
-## **txpool\_content**
+## **txpool_content**
 
 Returns the content of the transaction pool, organized by sender address and categorized into pending and queued transactions. Blob transactions are not returned.
 
@@ -6684,23 +6774,21 @@ curl -s --data '{"jsonrpc":"2.0","method":"txpool_content","params":[],"id":"1"}
 
 **Returns**
 
-| Type    | Description                                         |
-| ------- | --------------------------------------------------- |
-| Object  | Transaction pool content organized by sub-pool type |
-| pending | Object                                              |
-| queued  | Object                                              |
+| Type | Description |
+| --- | --- |
+| Object | Transaction pool content organized by sub-pool type |
+| pending | Object |
+| queued | Object |
 
-***
-
-## **txpool\_contentFrom**
+## **txpool_contentFrom**
 
 Returns the content of the transaction pool for a specific sender address, categorized into pending and queued transactions. The same rules as `txpool_content` apply.
 
 **Parameters**
 
-| Parameter | Type           | Description                                  |
-| --------- | -------------- | -------------------------------------------- |
-| address   | DATA, 20 BYTES | The sender address to query transactions for |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| address | DATA, 20 BYTES | The sender address to query transactions for |
 
 **Example**
 
@@ -6710,15 +6798,13 @@ curl -s --data '{"jsonrpc":"2.0","method":"txpool_contentFrom","params":["0xb60e
 
 **Returns**
 
-| Type    | Description                                        |
-| ------- | -------------------------------------------------- |
-| Object  | Transaction pool content for the specified address |
-| pending | Object                                             |
-| queued  | Object                                             |
+| Type | Description |
+| --- | --- |
+| Object | Transaction pool content for the specified address |
+| pending | Object |
+| queued | Object |
 
-***
-
-## **txpool\_status**
+## **txpool_status**
 
 Returns the current status of the transaction pool, with the count of pending and queued transactions.
 
@@ -6734,17 +6820,16 @@ curl -s --data '{"jsonrpc":"2.0","method":"txpool_status","params":[],"id":"1"}'
 
 **Returns**
 
-| Type    | Description                    |
-| ------- | ------------------------------ |
-| Object  | Transaction pool status counts |
-| pending | QUANTITY                       |
-| queued  | QUANTITY                       |
+| Type | Description |
+| --- | --- |
+| Object | Transaction pool status counts |
+| pending | QUANTITY |
+| queued | QUANTITY |
 
 ---
 
 # admin
 URL: https://docs.erigon.tech/interacting-with-erigon/admin
-
 
 The `admin` namespace provides administrative methods for managing the Erigon node, including peer management and node information retrieval. These methods are designed for node operators and developers who need to monitor and control various aspects of the Erigon client's operation.
 
@@ -6752,31 +6837,29 @@ The admin namespace must be explicitly enabled using the `--http.api` flag when 
 
 ### Security Considerations
 
-* The admin namespace provides administrative functions that should not be exposed on public RPC endpoints
-* When configuring public RPC access, explicitly exclude `admin` from the `--http.api` flag to prevent unauthorized access
-* These methods can affect node connectivity and should only be used by trusted operators
+- The admin namespace provides administrative functions that should not be exposed on public RPC endpoints
+- When configuring public RPC access, explicitly exclude `admin` from the `--http.api` flag to prevent unauthorized access
+- These methods can affect node connectivity and should only be used by trusted operators
 
 ### Usage in Testing and Development
 
-* Admin methods are commonly used in automated testing environments for peer management
-* The docker-compose configuration for automated testing includes the admin namespace in the API list for testing purposes
-* These methods are essential for setting up test networks and managing peer connections programmatically
+- Admin methods are commonly used in automated testing environments for peer management
+- The docker-compose configuration for automated testing includes the admin namespace in the API list for testing purposes
+- These methods are essential for setting up test networks and managing peer connections programmatically
 
 ### Availability
 
-* Admin methods are available when the `admin` namespace is included in the `--http.api` flag
-* All admin methods are available on both HTTP and WebSocket connections
-* Some admin methods may require the node to be running with specific network configurations
+- Admin methods are available when the `admin` namespace is included in the `--http.api` flag
+- All admin methods are available on both HTTP and WebSocket connections
+- Some admin methods may require the node to be running with specific network configurations
 
 ### Integration with P2P Network
 
-* Admin methods interact directly with Erigon's P2P networking layer
-* Peer management operations may take time to complete as they involve network operations
-* The effectiveness of `admin_addPeer` depends on network connectivity and peer availability
+- Admin methods interact directly with Erigon's P2P networking layer
+- Peer management operations may take time to complete as they involve network operations
+- The effectiveness of `admin_addPeer` depends on network connectivity and peer availability
 
-***
-
-## **admin\_nodeInfo**
+## **admin_nodeInfo**
 
 Returns information about the running node, including network details, protocols, and node identification.
 
@@ -6792,13 +6875,11 @@ curl -s --data '{"jsonrpc":"2.0","method":"admin_nodeInfo","params":[],"id":"1"}
 
 **Returns**
 
-| Type   | Description                                                     |
-| ------ | --------------------------------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Object | Node information object containing network and protocol details |
 
-***
-
-## **admin\_peers**
+## **admin_peers**
 
 Returns information about connected peers, including their network addresses, protocols, and connection status.
 
@@ -6814,21 +6895,19 @@ curl -s --data '{"jsonrpc":"2.0","method":"admin_peers","params":[],"id":"1"}' -
 
 **Returns**
 
-| Type  | Description                                                          |
-| ----- | -------------------------------------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Array | Array of peer objects containing connection and protocol information |
 
-***
-
-## **admin\_addPeer**
+## **admin_addPeer**
 
 Attempts to add a new peer to the node's peer list by connecting to the specified enode URL.
 
 **Parameters**
 
-| Parameter | Type   | Description                                                       |
-| --------- | ------ | ----------------------------------------------------------------- |
-| enode     | STRING | The enode URL of the peer to add (format: enode://pubkey@ip:port) |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| enode | STRING | The enode URL of the peer to add (format: enode://pubkey@ip:port) |
 
 **Example**
 
@@ -6838,21 +6917,19 @@ curl -s --data '{"jsonrpc":"2.0","method":"admin_addPeer","params":["enode://a97
 
 **Returns**
 
-| Type    | Description                                              |
-| ------- | -------------------------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Boolean | True if the peer was successfully added, false otherwise |
 
-***
-
-## **admin\_removePeer**
+## **admin_removePeer**
 
 Removes a peer from the node's peer list by disconnecting from the specified enode URL.
 
 **Parameters**
 
-| Parameter | Type   | Description                                                          |
-| --------- | ------ | -------------------------------------------------------------------- |
-| enode     | STRING | The enode URL of the peer to remove (format: enode://pubkey@ip:port) |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| enode | STRING | The enode URL of the peer to remove (format: enode://pubkey@ip:port) |
 
 **Example**
 
@@ -6862,21 +6939,19 @@ curl -s --data '{"jsonrpc":"2.0","method":"admin_removePeer","params":["enode://
 
 **Returns**
 
-| Type    | Description                                                |
-| ------- | ---------------------------------------------------------- |
+| Type | Description |
+| --- | --- |
 | Boolean | True if the peer was successfully removed, false otherwise |
 
-***
-
-## **admin\_addTrustedPeer**
+## **admin_addTrustedPeer**
 
 Adds a peer to the trusted peers list. Trusted peers are exempt from the maximum peer count limit and will always be connected, even when the node has reached its peer limit.
 
 **Parameters**
 
-| Parameter | Type   | Description                                                              |
-| --------- | ------ | ------------------------------------------------------------------------ |
-| enode     | STRING | The enode URL of the trusted peer to add (format: enode://pubkey@ip:port) |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| enode | STRING | The enode URL of the trusted peer to add (format: enode://pubkey@ip:port) |
 
 **Example**
 
@@ -6886,21 +6961,19 @@ curl -s --data '{"jsonrpc":"2.0","method":"admin_addTrustedPeer","params":["enod
 
 **Returns**
 
-| Type    | Description                                                       |
-| ------- | ----------------------------------------------------------------- |
-| Boolean | True if the trusted peer was successfully added, false otherwise  |
+| Type | Description |
+| --- | --- |
+| Boolean | True if the trusted peer was successfully added, false otherwise |
 
-***
-
-## **admin\_removeTrustedPeer**
+## **admin_removeTrustedPeer**
 
 Removes a peer from the trusted peers list. The peer may still remain connected if slots are available, but will no longer bypass the peer limit.
 
 **Parameters**
 
-| Parameter | Type   | Description                                                                 |
-| --------- | ------ | --------------------------------------------------------------------------- |
-| enode     | STRING | The enode URL of the trusted peer to remove (format: enode://pubkey@ip:port) |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| enode | STRING | The enode URL of the trusted peer to remove (format: enode://pubkey@ip:port) |
 
 **Example**
 
@@ -6910,17 +6983,14 @@ curl -s --data '{"jsonrpc":"2.0","method":"admin_removeTrustedPeer","params":["e
 
 **Returns**
 
-| Type    | Description                                                          |
-| ------- | -------------------------------------------------------------------- |
-| Boolean | True if the trusted peer was successfully removed, false otherwise   |
-
-***
+| Type | Description |
+| --- | --- |
+| Boolean | True if the trusted peer was successfully removed, false otherwise |
 
 ---
 
 # ots
 URL: https://docs.erigon.tech/interacting-with-erigon/ots
-
 
 In addition to the standard Geth methods, Erigon includes RPC methods prefixed with `ots_` for **Otterscan**. These are specific to the Otterscan functionality integrated with Erigon.
 
@@ -6931,18 +7001,17 @@ See more details at [https://docs.otterscan.io/api-docs/ots-api](https://docs.ot
 # internal
 URL: https://docs.erigon.tech/interacting-with-erigon/internal
 
-
 The **`internal_`** methods are for development and debugging utilities and must be explicitly included in the `--http.api` flag if customizing enabled namespaces.
 
-## **internal\_getTxNumInfo**
+## **internal_getTxNumInfo**
 
 Returns transaction number information for development and debugging purposes. This is part of Erigon's internal APIs and may change without notice.
 
 **Parameters**
 
-| Parameter | Type     | Description                 |
-| --------- | -------- | --------------------------- |
-| txNum     | QUANTITY | Internal transaction number |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| txNum | QUANTITY | Internal transaction number |
 
 **Example**
 
@@ -6952,17 +7021,16 @@ curl -s --data '{"jsonrpc":"2.0","method":"internal_getTxNumInfo","params":["0x1
 
 **Returns**
 
-| Type     | Description                    |
-| -------- | ------------------------------ |
-| Object   | Transaction number information |
-| blockNum | QUANTITY                       |
-| idx      | QUANTITY                       |
+| Type | Description |
+| --- | --- |
+| Object | Transaction number information |
+| blockNum | QUANTITY |
+| idx | QUANTITY |
 
 ---
 
 # gRPC
 URL: https://docs.erigon.tech/interacting-with-erigon/grpc
-
 
 Erigon provides gRPC APIs that allow users to access blockchain data and services directly through protocol buffer interfaces. These APIs offer high-performance, strongly-typed access to Erigon's internal services and are particularly useful for applications requiring efficient data access or integration with other gRPC-based systems.
 
@@ -6970,9 +7038,9 @@ The gRPC server can be explicitly enabled using the `--grpc` flag when running t
 
 ### Performance Considerations
 
-* gRPC APIs provide better performance than JSON-RPC for high-throughput applications
-* Direct database access via KV interface offers the fastest data retrieval
-* Shared memory access (when running locally) provides optimal performance
+- gRPC APIs provide better performance than JSON-RPC for high-throughput applications
+- Direct database access via KV interface offers the fastest data retrieval
+- Shared memory access (when running locally) provides optimal performance
 
 ### Data Format and Buckets
 
@@ -6980,9 +7048,9 @@ Database bucket names and their formats are documented in `db/kv/tables.go`. Und
 
 ### Network Access
 
-* gRPC services can be accessed over the network when properly configured
-* TLS encryption is recommended for production deployments
-* Rate limiting can be configured via `--private.api.ratelimit` flag
+- gRPC services can be accessed over the network when properly configured
+- TLS encryption is recommended for production deployments
+- Rate limiting can be configured via `--private.api.ratelimit` flag
 
 ### Integration Libraries
 
@@ -6990,13 +7058,11 @@ Erigon provides Go, Rust, and C++ implementations of the RoKV (read-only key-val
 
 ### Availability
 
-* gRPC services are available when enabled with the `--grpc` flag on the **standalone `rpcdaemon`** binary
-* Default listening address is configurable via `--grpc.addr` and `--grpc.port`
-* Services require the main Erigon node to be running and accessible
+- gRPC services are available when enabled with the `--grpc` flag on the **standalone `rpcdaemon`** binary
+- Default listening address is configurable via `--grpc.addr` and `--grpc.port`
+- Services require the main Erigon node to be running and accessible
 
 For more information, visit the [Erigon Interfaces GitHub repository](https://github.com/erigontech/interfaces).
-
-***
 
 ## **KV (Key-Value) Interface**
 
@@ -7006,10 +7072,10 @@ The KV interface provides low-level database access methods for reading blockcha
 
 The KV interface is defined in the remote protobuf specification and provides methods for:
 
-* Opening read-only transactions
-* Reading data by key ranges
-* Iterating over database buckets
-* Accessing historical state data
+- Opening read-only transactions
+- Reading data by key ranges
+- Iterating over database buckets
+- Accessing historical state data
 
 **Example Usage**
 
@@ -7020,14 +7086,12 @@ grpcurl -plaintext localhost:9090 remote.KV/Version
 
 **Available Methods**
 
-| Method       | Description                                   |
-| ------------ | --------------------------------------------- |
-| Version      | Returns the KV service API version            |
-| Tx           | Opens a read-only transaction for data access |
-| StateChanges | Streams state changes for a block range       |
-| Snapshots    | Returns information about available snapshots |
-
-***
+| Method | Description |
+| --- | --- |
+| Version | Returns the KV service API version |
+| Tx | Opens a read-only transaction for data access |
+| StateChanges | Streams state changes for a block range |
+| Snapshots | Returns information about available snapshots |
 
 ## **ETHBACKEND Interface**
 
@@ -7035,20 +7099,18 @@ The ETHBACKEND interface provides access to Ethereum-specific backend services i
 
 **Available Services**
 
-| Service         | Description                                         |
-| --------------- | --------------------------------------------------- |
-| Etherbase       | Returns the coinbase address                        |
-| NetVersion      | Returns the network ID                              |
-| NetPeerCount    | Returns the number of connected peers               |
-| ProtocolVersion | Returns the Ethereum protocol version               |
-| ClientVersion   | Returns the client version string                   |
-| Subscribe       | Subscribes to blockchain events                     |
-| NodeInfo        | Returns node information                            |
-| Peers           | Returns information about connected peers           |
-| AddPeer         | Adds a peer to the node                             |
-| PendingBlock    | Returns the pending block                           |
-
-***
+| Service | Description |
+| --- | --- |
+| Etherbase | Returns the coinbase address |
+| NetVersion | Returns the network ID |
+| NetPeerCount | Returns the number of connected peers |
+| ProtocolVersion | Returns the Ethereum protocol version |
+| ClientVersion | Returns the client version string |
+| Subscribe | Subscribes to blockchain events |
+| NodeInfo | Returns node information |
+| Peers | Returns information about connected peers |
+| AddPeer | Adds a peer to the node |
+| PendingBlock | Returns the pending block |
 
 ## **TxPool Interface**
 
@@ -7056,19 +7118,17 @@ The TxPool interface provides access to transaction pool operations and status i
 
 **Available Methods**
 
-| Method            | Description                               |
-| ----------------- | ----------------------------------------- |
-| Version           | Returns the TxPool service version        |
-| FindUnknownHashes | Finds unknown transaction hashes          |
-| GetTransactions   | Retrieves transactions from the pool      |
-| All               | Returns all transactions in the pool      |
-| PendingAdd        | Adds transactions to pending pool         |
-| PendingRemove     | Removes transactions from pending pool    |
-| OnAdd             | Subscribes to transaction addition events |
-| Mining            | Returns mining-related transaction data   |
-| NonceFromAddress  | Gets the next nonce for an address        |
-
-***
+| Method | Description |
+| --- | --- |
+| Version | Returns the TxPool service version |
+| FindUnknownHashes | Finds unknown transaction hashes |
+| GetTransactions | Retrieves transactions from the pool |
+| All | Returns all transactions in the pool |
+| PendingAdd | Adds transactions to pending pool |
+| PendingRemove | Removes transactions from pending pool |
+| OnAdd | Subscribes to transaction addition events |
+| Mining | Returns mining-related transaction data |
+| NonceFromAddress | Gets the next nonce for an address |
 
 ## **Downloader Interface**
 
@@ -7076,14 +7136,12 @@ The Downloader interface provides access to snapshot downloading and torrent man
 
 **Available Methods**
 
-| Method       | Description                        |
-| ------------ | ---------------------------------- |
-| Add          | Adds files to download queue       |
-| Delete       | Removes files from download queue  |
-| Completed    | Checks if downloads are completed  |
+| Method | Description |
+| --- | --- |
+| Add | Adds files to download queue |
+| Delete | Removes files from download queue |
+| Completed | Checks if downloads are completed |
 | SetLogPrefix | Sets logging prefix for Downloader |
-
-***
 
 ## Configuration and Security
 
@@ -7127,7 +7185,6 @@ The gRPC interface allows reading Erigon's database while the node is running, s
 # overlay
 URL: https://docs.erigon.tech/interacting-with-erigon/overlay
 
-
 The `overlay` namespace is an **Erigon-specific** extension that allows you to replay historical blocks with a modified contract bytecode, without deploying anything on-chain. It is designed for analytics use cases where you need to inject custom event emissions into an existing contract and retrieve the logs those events would have produced.
 
 :::warning
@@ -7140,10 +7197,8 @@ Enable the namespace with `--http.api=...,overlay`.
 
 Two flags control how long overlay operations can run:
 
-* `--rpc.overlay.getlogstimeout` — overall timeout for an `overlay_getLogs` call (default: `5m0s`)
-* `--rpc.overlay.replayblocktimeout` — per-block replay timeout within a `getLogs` call (default: `10s`)
-
----
+- `--rpc.overlay.getlogstimeout` — overall timeout for an `overlay_getLogs` call (default: `5m0s`)
+- `--rpc.overlay.replayblocktimeout` — per-block replay timeout within a `getLogs` call (default: `10s`)
 
 ## Methods
 
@@ -7156,7 +7211,7 @@ This is equivalent to running `eth_getLogs` on a hypothetical version of the con
 **Parameters**
 
 | # | Name | Type | Description |
-|---|------|------|-------------|
+| --- | --- | --- | --- |
 | 1 | `filter` | `FilterCriteria` | Same filter object as `eth_getLogs`: `fromBlock`, `toBlock`, `address`, `topics` |
 | 2 | `stateOverride` | `StateOverride` (optional) | Map of `address → overrides`. Each override can set `code`, `balance`, `nonce`, `state` (full state replacement), or `stateDiff` (partial state patch). Same format as the state override in `eth_call`. |
 
@@ -7190,8 +7245,6 @@ curl -X POST http://localhost:8545 \
 
 Blocks in the requested range are replayed concurrently (up to `runtime.NumCPU()` workers). Each block is independently replayed from the state at `blockNumber - 1`.
 
----
-
 ### `overlay_callConstructor`
 
 Replays the **constructor transaction** of an existing contract using a different bytecode and returns the effective creation code that would have been stored.
@@ -7201,7 +7254,7 @@ This is useful for understanding what a contract would have initialised to if it
 **Parameters**
 
 | # | Name | Type | Description |
-|---|------|------|-------------|
+| --- | --- | --- | --- |
 | 1 | `address` | `Address` | The address of the already-deployed contract |
 | 2 | `code` | `Bytes` | The replacement bytecode to use instead of the original deployment bytecode |
 
@@ -7228,6 +7281,7 @@ curl -X POST http://localhost:8545 \
 ```
 
 Internally, this method:
+
 1. Looks up the contract's creation transaction via the Otterscan API
 2. Replays all transactions in that block up to (but not including) the creation tx
 3. Executes the creation tx using the provided bytecode instead of the original
@@ -7242,7 +7296,6 @@ Internally, this method:
 # parity
 URL: https://docs.erigon.tech/interacting-with-erigon/parity
 
-
 The `parity` namespace provides a limited subset of the OpenEthereum (formerly Parity) JSON-RPC API for compatibility with tooling that targets the original Parity client.
 
 :::warning
@@ -7253,8 +7306,6 @@ Enable the namespace with `--http.api=...,parity`.
 
 For the full original OpenEthereum `parity_*` specification, see the [OpenEthereum JSON-RPC parity module documentation](https://openethereum.github.io/JSONRPC-parity-module) (archived).
 
----
-
 ## Methods
 
 ### `parity_listStorageKeys`
@@ -7264,7 +7315,7 @@ Returns all storage keys for a given contract address, paginated.
 **Parameters**
 
 | # | Name | Type | Description |
-|---|------|------|-------------|
+| --- | --- | --- | --- |
 | 1 | `address` | `Address` | The contract address to query storage for |
 | 2 | `quantity` | `integer` | Number of storage keys to return |
 | 3 | `offset` | `Bytes` (optional) | Pagination offset — the storage key to start from |
@@ -7297,7 +7348,6 @@ curl -X POST http://localhost:8545 \
 # GraphQL
 URL: https://docs.erigon.tech/interacting-with-erigon/graphql
 
-
 Erigon implements the Ethereum GraphQL interface originally introduced in [EIP-1767](https://eips.ethereum.org/EIPS/eip-1767). The schema is maintained in the [`ethereum/execution-apis`](https://github.com/ethereum/execution-apis) repository, kept in sync with client implementations such as Geth and Besu. Erigon follows that schema.
 
 ## Enabling GraphQL
@@ -7313,7 +7363,7 @@ GraphQL shares the same port as the HTTP JSON-RPC server (default `8545`). It do
 ## Endpoints
 
 | Endpoint | Purpose |
-|----------|---------|
+| --- | --- |
 | `http://localhost:8545/graphql` | GraphQL API endpoint |
 | `http://localhost:8545/graphql/ui` | GraphiQL browser UI for interactive queries |
 
@@ -7358,8 +7408,6 @@ URL: https://docs.erigon.tech/staking
 
 Run an Ethereum validator with Erigon — using the built-in Caplin consensus layer or any external CL client.
 
-## Sections
-
 - [Caplin (Built-in CL)](https://docs.erigon.tech/staking/caplin): Configure Erigon's embedded consensus layer as a full validator — no external CL dependency required.
 - [External Consensus Client](https://docs.erigon.tech/staking/external-consensus-client-as-validator): Connect Lighthouse, Prysm, Teku, or Nimbus via the Engine API for split EL/CL validator setups.
 - [Shutter Network](https://docs.erigon.tech/staking/shutter-network): Privacy-preserving mempool protection — shield validator transactions from front-running and MEV.
@@ -7368,7 +7416,6 @@ Run an Ethereum validator with Erigon — using the built-in Caplin consensus la
 
 # Using Caplin as Validator
 URL: https://docs.erigon.tech/staking/caplin
-
 
 Caplin, the Erigon embedded Consensus Layer, is also suitable for staking. However, it is required to pair it with a **validator key manager**, such as Lighthouse or Teku, since it doesn't have a native key management system.
 
@@ -7396,12 +7443,13 @@ erigon \
 
 **Flags Explanation**:
 
-* Execution Layer (Erigon):
-  * `--http.api=engine,eth,net,web3`: enables the necessary APIs for external clients and Caplin.
-  * `--ws`: enables WebSocket-based communication (optional).
-* Consensus Layer (Caplin):
-  * `--caplin.discovery.addr` and `--caplin.discovery.port`: configures Caplin's gossip and discovery layer.
-  * `--beacon.api=beacon,validator,builder,config,debug,events,node,lighthouse`: enables all possible API endpoints for the validator client.
+- Execution Layer (Erigon):
+  - `--http.api=engine,eth,net,web3`: enables the necessary APIs for external clients and Caplin.
+  - `--ws`: enables WebSocket-based communication (optional).
+
+- Consensus Layer (Caplin):
+  - `--caplin.discovery.addr` and `--caplin.discovery.port`: configures Caplin's gossip and discovery layer.
+  - `--beacon.api=beacon,validator,builder,config,debug,events,node,lighthouse`: enables all possible API endpoints for the validator client.
 
 ## 2. Set Up Lighthouse Validator Client
 
@@ -7432,9 +7480,9 @@ lighthouse vc \
 
 **Flags Explanation**:
 
-* `--network mainnet`: Specifies the Ethereum mainnet.
-* `--beacon-nodes`: Points to the Caplin beacon API at `http://127.0.0.1:5555`.
-* `--suggested-fee-recipient`: Specifies your Ethereum address for block rewards.
+- `--network mainnet`: Specifies the Ethereum mainnet.
+- `--beacon-nodes`: Points to the Caplin beacon API at `http://127.0.0.1:5555`.
+- `--suggested-fee-recipient`: Specifies your Ethereum address for block rewards.
 
 ### 2.4. Import Validator Keys
 
@@ -7449,11 +7497,10 @@ lighthouse account validator import --directory <path_to_validator_keys>
 # Using an external consensus client as validator
 URL: https://docs.erigon.tech/staking/external-consensus-client-as-validator
 
-
 To use an external Consensus Layer (CL) it is necessary to add to Erigon the flag `--externalcl`. Here are a couple of examples on how to configure Lighthouse and Prysm to run along with Erigon:
 
-* [Ethereum](../get-started/easy-nodes/how-to-run-an-ethereum-node/ethereum-with-an-external-cl)
-* [Gnosis Chain](../get-started/easy-nodes/how-to-run-a-gnosis-chain-node/gnosis-with-an-external-cl)
+- [Ethereum](https://docs.erigon.tech/get-started/easy-nodes/how-to-run-an-ethereum-node/ethereum-with-an-external-cl)
+- [Gnosis Chain](https://docs.erigon.tech/get-started/easy-nodes/how-to-run-a-gnosis-chain-node/gnosis-with-an-external-cl)
 
 Once you have Erigon and a CL client up and running, you can proceed to set up a Validator Client (VC). The VC is responsible for managing your keys and signing valid blocks.
 
@@ -7465,9 +7512,9 @@ To set up a VC, follow the instructions provided in the official documentation, 
 
 This guide will walk you through the process of setting up a VC, including:
 
-* Generating and managing your keys
-* Configuring the Validator Client
-* Signing valid blocks
+- Generating and managing your keys
+- Configuring the Validator Client
+- Signing valid blocks
 
 Make sure to follow the instructions carefully and thoroughly to ensure that your VC is set up correctly. It is always recommended to start staking with a testnet.
 
@@ -7492,13 +7539,13 @@ erigon \
 
 ## Flags explanation:
 
-* `--externalcl`: Enables the use of an external CL.
-* `--datadir=/data/erigon`: Defines the directory to be used for databases.
-* `--chain=sepolia`: Specifies the Sepolia chain.
-* `--authrpc.jwtsecret=/jwt`: Sets the location of the JWT authentication code in hex encoding. This is used by Erigon (the EL) and the CL (in this case Lighthouse) to authenticate communication.
-* `--authrpc.addr=0.0.0.0`: Allows the engine API to be accessed from any address.
-* `--http.api=engine,eth,net,web3`: Enables the necessary APIs for external clients and Caplin.
-* `--ws`: enables WebSocket-based communication, which is optional.
+- `--externalcl`: Enables the use of an external CL.
+- `--datadir=/data/erigon`: Defines the directory to be used for databases.
+- `--chain=sepolia`: Specifies the Sepolia chain.
+- `--authrpc.jwtsecret=/jwt`: Sets the location of the JWT authentication code in hex encoding. This is used by Erigon (the EL) and the CL (in this case Lighthouse) to authenticate communication.
+- `--authrpc.addr=0.0.0.0`: Allows the engine API to be accessed from any address.
+- `--http.api=engine,eth,net,web3`: Enables the necessary APIs for external clients and Caplin.
+- `--ws`: enables WebSocket-based communication, which is optional.
 
 :::info
 Note that many pre-merge flags, such as `--miner.etherbase`, are no longer useful, as block rewards and other validator-related configurations are now controlled by the Consensus Layer (CL).
@@ -7509,53 +7556,59 @@ Note that many pre-merge flags, such as `--miner.etherbase`, are no longer usefu
 # Shutter Network
 URL: https://docs.erigon.tech/staking/shutter-network
 
-
 [Shutter Network](https://www.shutter.network) is a privacy-focused protocol that provides encrypted transaction pools using threshold encryption. The main objective is to protect users from malicious MEV (Miner Extractable Value) attacks such as front-running and sandwich attacks by encrypting transactions until they are included in a block.
 
 The key advantages of Shutter Network are:
 
-* **Protection against MEV attacks:** By encrypting transactions, the network prevents malicious actors from exploiting transaction ordering.
-* **Threshold encryption:** Transactions are only decrypted when enough key holders (keypers) participate, ensuring security and decentralization.
-* **Support on Gnosis Chain:** Shutter encrypted transaction pools are currently available on [Gnosis Chain](https://docs.gnosischain.com/shutterized-gc/), with plans for Ethereum support.
+- **Protection against MEV attacks:** By encrypting transactions, the network prevents malicious actors from exploiting transaction ordering.
+- **Threshold encryption:** Transactions are only decrypted when enough key holders (keypers) participate, ensuring security and decentralization.
+- **Support on Gnosis Chain:** Shutter encrypted transaction pools are currently available on [Gnosis Chain](https://docs.gnosischain.com/shutterized-gc/), with plans for Ethereum support.
 
 ### Why Use Shutter?
 
-* **Access to Extra Transactions:** Shutterized validators can include shielded transactions not available in the public transaction pool, leading to potentially higher block rewards.
-* **User Protection:** Help protect users against MEV attacks, improving the fairness of the chain.
+- **Access to Extra Transactions:** Shutterized validators can include shielded transactions not available in the public transaction pool, leading to potentially higher block rewards.
+- **User Protection:** Help protect users against MEV attacks, improving the fairness of the chain.
 
 ## How to Run Erigon as a Shutterized Validator
 
 To participate in the Shutter encrypted transaction pool as a validator using Erigon, follow these steps:
 
-1.  **Set Up Your Validator**
+1. **Set Up Your Validator**
 
-    Deposit your stake and register your validator on Gnosis Chain reby following the [Gnosis Chain Validator Setup](https://docs.gnosischain.com/node/manual/validator/deposit).
-2.  **Register as a Shutterized Validator**
+Deposit your stake and register your validator on Gnosis Chain reby following the [Gnosis Chain Validator Setup](https://docs.gnosischain.com/node/manual/validator/deposit).
 
-    Complete the validator registration for Shutter using the tool provided in the [Shutter Validator Registration Guide](https://github.com/shutter-network/shutter-validator-registration).
-3.  **Verify Registration**
+2. **Register as a Shutterized Validator**
 
-    Use the Erigon CLI command to verify that your registration was successful:
+Complete the validator registration for Shutter using the tool provided in the [Shutter Validator Registration Guide](https://github.com/shutter-network/shutter-validator-registration).
+
+3. **Verify Registration**
+
+Use the Erigon CLI command to verify that your registration was successful:
+
 ```bash
     erigon shutter-validator-reg-check --chain <CHAIN> --el-url <EL_RPC_URL> --validator-info-file <VALIDATOR_INFO_JSON>
-    ```
-* `--chain` valid values are `gnosis` or `chiado`
-    * `--el-url`, in case you are using Erigon default ports is `http://localhost:8545`
-    * `<VALIDATOR_INFO_JSON>` is the file generated during registration.
+```
 
-    for example:
+- `--chain` valid values are `gnosis` or `chiado`
+
+  - `--el-url`, in case you are using Erigon default ports is `http://localhost:8545`
+  - `<VALIDATOR_INFO_JSON>` is the file generated during registration.
+
+for example:
+
 ```bash
     erigon shutter-validator-reg-check --chain gnosis --el-url http://localhost:8545 --validator-info-file /path/validatorInfo.json
-    ```
+```
+
 4. **Run Erigon with Shutter Support**
 
-    Start Erigon as usual, but add the `--shutter` flag to enable Shutterized Validator mode:
+Start Erigon as usual, but add the `--shutter` flag to enable Shutterized Validator mode:
 
-    ```bash
-    erigon --shutter [other options...]
-    ```
+```bash
+erigon --shutter [other options...]
+```
 
-    This works with Erigon's internal CL Caplin (enabled by default) or with an external CL client using `--externalcl`.
+This works with Erigon's internal CL Caplin (enabled by default) or with an external CL client using `--externalcl`.
 
 ## Shutter Network Default Ports
 
@@ -7565,10 +7618,10 @@ Bootstrap nodes are used to help new nodes discover other nodes in the network. 
 
 ## Reference Documentation
 
-* [Shutter Validator Registration](https://github.com/shutter-network/shutter-validator-registration)
-* [Shutter Specs](https://github.com/gnosischain/specs/tree/master/shutter)
-* [System Overview Dashboard](https://explorer.shutter.network/system-overview)
-* [Gnosis Chain Validator Setup](https://docs.gnosischain.com/node/manual/validator/deposit)
+- [Shutter Validator Registration](https://github.com/shutter-network/shutter-validator-registration)
+- [Shutter Specs](https://github.com/gnosischain/specs/tree/master/shutter)
+- [System Overview Dashboard](https://explorer.shutter.network/system-overview)
+- [Gnosis Chain Validator Setup](https://docs.gnosischain.com/node/manual/validator/deposit)
 
 ---
 
@@ -7576,8 +7629,6 @@ Bootstrap nodes are used to help new nodes discover other nodes in the network. 
 URL: https://docs.erigon.tech/about
 
 Learn about the project, how to get involved, and the license terms.
-
-## Sections
 
 - [Contributing](https://docs.erigon.tech/about/contributing): How to contribute code, report bugs, write docs, and submit pull requests to the Erigon project.
 - [Disclaimer](https://docs.erigon.tech/about/disclaimer): Important notices about software maturity, stability expectations, and intended use.
@@ -7588,7 +7639,6 @@ Learn about the project, how to get involved, and the license terms.
 # Contributing
 URL: https://docs.erigon.tech/about/contributing
 
-
 ## Erigon Client Code
 
 The Erigon node software is developed in the [erigontech/erigon](https://github.com/erigontech/erigon) repository. Code contributions follow the standard GitHub fork-and-PR workflow.
@@ -7596,18 +7646,23 @@ The Erigon node software is developed in the [erigontech/erigon](https://github.
 ### Getting started
 
 1. Fork the repository and clone your fork:
-   ```bash
-   git clone https://github.com/<your-username>/erigon.git
-   cd erigon
-   ```
+
+```bash
+git clone https://github.com/<your-username>/erigon.git
+cd erigon
+```
+
 2. Build the project (requires Go 1.25+ and a C++ compiler):
-   ```bash
-   make erigon
-   ```
+
+```bash
+make erigon
+```
+
 3. Run the test suite:
-   ```bash
-   go test ./...
-   ```
+
+```bash
+go test ./...
+```
 
 ### Reporting bugs and requesting features
 
@@ -7641,15 +7696,19 @@ Open an issue in the repository to suggest corrections, flag outdated content, o
 ### Editing locally
 
 1. Clone the repository and install dependencies:
-   ```bash
-   git clone https://github.com/erigontech/erigon.git
-   cd erigon/docs/site
-   npm install
-   ```
+
+```bash
+git clone https://github.com/erigontech/erigon.git
+cd erigon/docs/site
+npm install
+```
+
 2. Start the local dev server:
-   ```bash
-   npm run start
-   ```
+
+```bash
+npm run start
+```
+
 3. Open `http://localhost:3000` in your browser — changes to Markdown files hot-reload automatically.
 
 ### Submitting a pull request
@@ -7664,18 +7723,16 @@ Open an issue in the repository to suggest corrections, flag outdated content, o
 # License
 URL: https://docs.erigon.tech/about/license
 
-
 © 2026 Erigon Technologies AG. All rights reserved.
 
 Licensed under the [LGPL-3.0](https://github.com/erigontech/erigon/blob/release/2.60/COPYING.LESSER), [GPL-3.0](https://github.com/erigontech/erigon/blob/release/2.60/COPYING).
 
-_Permissions of this copyleft license are conditioned on making available complete source code of licensed works and modifications under the same license or the GNU GPLv3. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. However, a larger work using the licensed work through interfaces provided by the licensed work may be distributed under different terms and without source code for the larger work._
+*Permissions of this copyleft license are conditioned on making available complete source code of licensed works and modifications under the same license or the GNU GPLv3. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. However, a larger work using the licensed work through interfaces provided by the licensed work may be distributed under different terms and without source code for the larger work.*
 
 ---
 
 # Disclaimer
 URL: https://docs.erigon.tech/about/disclaimer
-
 
 The Erigon team does not take any responsibility for losses or damages occurred through the use of Erigon. While we employ a seasoned in-house security team, we have not subjected our systems to independent third-party security assessments.
 
@@ -7685,8 +7742,6 @@ The Erigon team does not take any responsibility for losses or damages occurred 
 URL: https://docs.erigon.tech/help-center
 
 Everything you need to run Erigon smoothly — from quick answers to deep diagnostics.
-
-## Sections
 
 - [FAQ](https://docs.erigon.tech/help-center/frequently-asked-questions-faqs): Answers to the most common questions about installing, syncing, and operating Erigon.
 - [Troubleshooting](https://docs.erigon.tech/help-center/troubleshooting): Step-by-step diagnostic guides for the most frequent runtime and sync issues.
@@ -7700,95 +7755,88 @@ Everything you need to run Erigon smoothly — from quick answers to deep diagno
 # Frequently Asked Questions (FAQs)
 URL: https://docs.erigon.tech/help-center/frequently-asked-questions-faqs
 
-['What is the difference between Erigon and Geth?', 'Erigon began as a fork of Geth but was rewritten to prioritise disk space and sync speed, using a flat MDBX key-value database instead of a Merkle Patricia Trie for a much smaller footprint and faster synchronisation.'],
-  ['Is Erigon a good choice for client diversity?', 'Yes. Erigon has diverged far enough from Geth to be considered a separate client, making it a strong choice for supporting Ethereum client diversity.'],
-  ['What are the minimum hardware requirements?', 'A high-end NVMe or SSD with low latency is the most critical component. 16 GB of RAM and a fast SSD are generally the minimum for a full node; exact needs vary by network and pruning mode.'],
-  ['How long does it take to sync a node?', 'It depends on hardware and bandwidth. A fast system with a high-end NVMe can sync a full node in a few hours, while slower hardware can take several days.'],
-  ['How much disk space is required?', 'It grows with the blockchain and varies by network and pruning mode — a full node needs far less than an archive node. Check the Hardware Requirements page for current figures rather than a fixed value.'],
-  ['Can I run Erigon on an HDD?', 'No. Erigon depends on high-speed disk I/O, and an HDD will almost certainly cause the node to fall behind the chain tip.'],
-  ['What is the --prune.mode flag, and which mode should I use?', 'It controls which historical data is discarded. Use full (the Erigon 3 default) for most users, minimal for validators with limited disk, and archive for a complete historical record.'],
-  ['Can I change my pruning mode after starting the node?', 'No. The pruning mode is fixed at first sync; changing it requires deleting the datadir and re-syncing from scratch.'],
-  ['Do I need a separate consensus client?', 'No. Erigon includes Caplin, an embedded consensus client that runs by default, though some validators prefer a separate consensus client for added reliability.'],
-  ['How do I upgrade my Erigon binary?', 'Gracefully shut down the node, replace the old binary with the new one, and restart. Back up your datadir before any major upgrade.'],
-  ['How do I gracefully shut down Erigon?', 'Use a process manager such as systemd or supervisor, or press Ctrl+C in the terminal, so the database closes cleanly.'],
-  ["What is Erigon's RPC daemon?", 'The RPC daemon is a separate process that serves JSON-RPC API requests and can run on a different machine from the core client for security and scalability.'],
-  ['Is it possible to recover from database corruption?', 'The most reliable fix is to delete the corrupted datadir and re-sync, though repair tools may also help. Ungraceful shutdowns are the usual cause.'],
-  ['What are the required ports?', 'P2P networking uses 30303 (TCP/UDP) and RPC uses 8545 (HTTP), 8546 (WS), and 8551 (Engine API). See Default Ports for the full list.'],
-  ['What is a snapshot sync?', 'Snapshot sync downloads pre-made snapshots of the blockchain state to greatly accelerate the initial sync instead of processing from genesis.'],
-  ["How do I monitor my node's sync progress?", 'Read the stage prefix in the live log line (e.g. [6/8 Execution]), query eth_syncing on the RPC daemon, or ask an AI assistant through the built-in MCP server.'],
-  ['Can I use Erigon with Docker?', 'Yes. Erigon provides official Docker images on Docker Hub; see the Installation guide for setup.'],
-  ['Does Erigon support other chains besides Ethereum?', 'Yes. Erigon is EVM-compatible and supports networks such as Gnosis; select the chain with the --chain flag.'],
-  ['Where can I find official support?', 'The official Erigon Discord and GitHub repository are the primary channels for support and community discussion.'],
-  ['What is Caplin?', "Caplin is Erigon's built-in beacon API server, letting Erigon act as both a consensus and execution client."],
-  ['What is OtterSync?', 'OtterSync is a syncing algorithm that shifts most computation to network bandwidth, reducing sync times and improving chain-tip performance, disk footprint, and decentralisation.'],
-  ["Why can't I query blocks before a certain height?", 'In full and minimal pruning modes Erigon discards historical state older than the pruning window. To query early blocks you must run an archive node, chosen at first sync.'],
-  ['Can I run Erigon on a Raspberry Pi or low-power ARM device?', 'It is not recommended for Mainnet, which needs a high-end NVMe SSD and at least 16 GB of RAM. A testnet like Sepolia may be feasible on higher-end ARM hardware.'],
-  ['What is the MCP server?', 'The MCP (Model Context Protocol) server is a built-in component that exposes Erigon blockchain data to AI assistants. It is enabled by default on 127.0.0.1:8553 and can be turned off with --mcp.disable.'],
-  ['How do I connect Claude Desktop to my Erigon node?', 'Build the standalone mcp binary with make mcp and add it to your Claude Desktop configuration pointing to your node JSON-RPC endpoint or datadir.'],
-  ['My node keeps falling behind the chain tip after running for a while. How do I fix it?', 'Delete only datadir/chaindata (not the whole datadir) and restart — Erigon rebuilds it from snapshots in minutes. Make sure you are on the latest release, as Erigon 3.4+ greatly reduces this problem.'],
-  ['What is the difference between deleting chaindata and deleting the whole datadir?', 'chaindata is the small mutable MDBX database that Erigon re-derives from the snapshots; the snapshots hold ~95% of the data. Deleting only chaindata is recoverable but not free — it triggers a chain-tip resync from the consensus layer, not an instant rebuild; deleting the whole datadir forces a full re-sync.'],
-  ["My node has no peers or won't sync. Which ports do I need to open?", 'Open 30303/30304 (execution P2P), 4000/4001 (Caplin), and 42069 (snapshot download), TCP and UDP where applicable; keep 8545 local. Behind NAT, set --nat and --caplin.nat to stun or upnp.'],
-  ['How do I reduce Erigon memory use or stop it from being OOM-killed?', 'Make Erigon and the Go runtime more conservative with GOMEMLIMIT, a lower GOGC, a capped GOMAXPROCS, and a smaller --batchSize.'],
-  ['Where do I report a security vulnerability?', "Report security issues through the Ethereum Foundation's Bug Bounty Program rather than public Discord or GitHub, so they can be handled responsibly."],
-  ["Where are Erigon's log files stored?", 'By default Erigon writes logs to /logs/erigon.log, in addition to standard output. Attach this file when opening a bug report.'],
-];
-
-  
-  
-
-# Frequently Asked Questions (FAQs)
-
 This list addresses the most common inquiries from the Erigon community, offering quick and direct answers to a variety of topics.
 
 1. **What is the difference between Erigon and Geth?** Erigon originated as a fork of Geth but has been entirely rewritten with a focus on disk space and sync speed. It uses a flat, key-value database (MDBX) instead of a Merkle Patricia Trie, resulting in a much smaller disk footprint and faster synchronization times.
+
 2. **Is Erigon a good choice for client diversity?** Yes. The codebases have diverged so significantly from Geth that they are now considered separate clients, making Erigon an excellent choice to support Ethereum's client diversity goals.
-3. **What are the minimum hardware requirements?** The most critical component is a high-end NVMe or SSD with very low latency. While the exact requirements vary by network, 16GB of RAM and a fast SSD are generally the minimum for a full node. See [Hardware Requirements](/get-started/hardware-requirements) for detailed specs per network and pruning mode.
+
+3. **What are the minimum hardware requirements?** The most critical component is a high-end NVMe or SSD with very low latency. While the exact requirements vary by network, 16GB of RAM and a fast SSD are generally the minimum for a full node. See [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements) for detailed specs per network and pruning mode.
+
 4. **How long does it take to sync a node?** Initial synchronization time is highly dependent on hardware and bandwidth. A fast system with a high-end NVMe can sync a full node in as little as few hours, while on slower hardware, it can take several days.
-5. **How much disk space is required?** Disk requirements grow continuously with the blockchain and vary by network and pruning mode — a full node needs far less than an archive node. Because these figures drift over time, always check the current numbers rather than relying on a fixed value. See [Hardware Requirements](/get-started/hardware-requirements) for per-network specs and [Database](/fundamentals/database) for a breakdown of what consumes disk space.
+
+5. **How much disk space is required?** Disk requirements grow continuously with the blockchain and vary by network and pruning mode — a full node needs far less than an archive node. Because these figures drift over time, always check the current numbers rather than relying on a fixed value. See [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements) for per-network specs and [Database](https://docs.erigon.tech/fundamentals/database) for a breakdown of what consumes disk space.
+
 6. **Can I run Erigon on an HDD?** It is not recommended to run Erigon on an HDD. The client's performance is critically dependent on high-speed disk I/O, and an HDD will almost certainly cause the node to fall behind the blockchain tip.
-7. **What is the `--prune.mode` flag, and which mode should I use?** This flag determines which historical data is discarded. The `full` mode (the default for Erigon 3) is suitable for most users. The `minimal` mode is for validators with limited disk space. The `archive` mode is for those who need a full historical record for all past states. See [Pruning Modes](/fundamentals/pruning-modes) for a full comparison.
+
+7. **What is the `--prune.mode` flag, and which mode should I use?** This flag determines which historical data is discarded. The `full` mode (the default for Erigon 3) is suitable for most users. The `minimal` mode is for validators with limited disk space. The `archive` mode is for those who need a full historical record for all past states. See [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes) for a full comparison.
+
 8. **Can I change my pruning mode after starting the node?** No. The pruning mode is a permanent choice made at the first sync. Changing it requires deleting the `datadir` directory and a full re-sync from scratch.
-9. **Do I need a separate consensus client?** No, you don't need a separate consensus client. In many cases, it's fine to use [Caplin](/staking/caplin), the embedded consensus client that runs by default within Erigon. However, some users, especially validators, prefer to run a [separate consensus client](/staking/external-consensus-client-as-validator) for enhanced reliability.
-10. **How do I upgrade my Erigon binary?** The process involves gracefully shutting down the node, replacing the old binary with the new one, and restarting. See the [Upgrading](/get-started/installation/upgrading) guide for step-by-step instructions. It is also recommended to back up your datadir before any major upgrade.
+
+9. **Do I need a separate consensus client?** No, you don't need a separate consensus client. In many cases, it's fine to use [Caplin](https://docs.erigon.tech/staking/caplin), the embedded consensus client that runs by default within Erigon. However, some users, especially validators, prefer to run a [separate consensus client](https://docs.erigon.tech/staking/external-consensus-client-as-validator) for enhanced reliability.
+
+10. **How do I upgrade my Erigon binary?** The process involves gracefully shutting down the node, replacing the old binary with the new one, and restarting. See the [Upgrading](https://docs.erigon.tech/get-started/installation/upgrading) guide for step-by-step instructions. It is also recommended to back up your datadir before any major upgrade.
+
 11. **How do I gracefully shut down Erigon?** The safest way to shut down is by using a process manager like `systemd` or `supervisor`. Alternatively, you can press `Ctrl+C` in the terminal to allow the database to close cleanly.
-12. **What is Erigon's RPC daemon?** The [RPC daemon](/fundamentals/modules/rpc-daemon) is a separate process that handles JSON RPC API requests. It can run on a different machine from the core Erigon client to enhance security and scalability.
+
+12. **What is Erigon's RPC daemon?** The [RPC daemon](https://docs.erigon.tech/fundamentals/modules/rpc-daemon) is a separate process that handles JSON RPC API requests. It can run on a different machine from the core Erigon client to enhance security and scalability.
+
 13. **Is it possible to recover from a database corruption?** While Erigon's database is robust, an ungraceful shutdown can cause corruption. The most reliable solution is to delete the corrupted datadir and perform a full re-sync, but it is also worth using repair tools.
-14. **What are the required ports?** Erigon requires specific ports for P2P networking (default `30303` TCP/UDP) and RPC access (`8545` HTTP, `8546` WS, `8551` Engine API). See [Default Ports](/fundamentals/default-ports) for the complete list.
-15. **What is a "snapshot sync"?** Snapshot sync is a stage of the synchronization process where the node downloads pre-made snapshots of the blockchain state. This significantly accelerates the initial sync, reducing the time required to catch up with the network. See [Pruning Modes](/fundamentals/pruning-modes) for details.
+
+14. **What are the required ports?** Erigon requires specific ports for P2P networking (default `30303` TCP/UDP) and RPC access (`8545` HTTP, `8546` WS, `8551` Engine API). See [Default Ports](https://docs.erigon.tech/fundamentals/default-ports) for the complete list.
+
+15. **What is a "snapshot sync"?** Snapshot sync is a stage of the synchronization process where the node downloads pre-made snapshots of the blockchain state. This significantly accelerates the initial sync, reducing the time required to catch up with the network. See [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes) for details.
+
 16. **How do I monitor my node's sync progress?** There are three complementary ways:
 
-    * **Read the live log line** — every sync log line is prefixed with the current stage and its position in the pipeline, e.g. `[6/8 Execution]`. The two numbers show the current stage and the total number of stages for your configuration; the prefix advances through the stages until the final `Finish` stage, at which point the node is at the chain tip. See [Logs → Stage Definitions](/fundamentals/logs#stage-definitions) for the full ordered list.
-    * **Query the JSON-RPC** — call `eth_syncing` against the RPC daemon (default port `8545`):
+  - **Read the live log line** — every sync log line is prefixed with the current stage and its position in the pipeline, e.g. `[6/8 Execution]`. The two numbers show the current stage and the total number of stages for your configuration; the prefix advances through the stages until the final `Finish` stage, at which point the node is at the chain tip. See [Logs → Stage Definitions](https://docs.erigon.tech/fundamentals/logs#stage-definitions) for the full ordered list.
 
-      ```bash
-      curl -s -X POST -H "Content-Type: application/json" \
-        --data '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}' \
-        http://localhost:8545
-      ```
+  - **Query the JSON-RPC** — call `eth_syncing` against the RPC daemon (default port `8545`):
 
-      While syncing the result is an object with `currentBlock`, `highestBlock`, and a `stages` array (per-stage progress, matching the log prefix); once fully synced it is simply `false`. (`startingBlock` is also returned but is hardcoded to `"0x0"`.)
-    * **Ask an AI assistant via MCP** — Erigon's built-in [MCP server](/fundamentals/mcp) (default `127.0.0.1:8553`) lets a connected assistant like Claude Desktop answer questions like *"Is my node synced? How many blocks behind am I?"* in plain language by querying the same data the JSON-RPC exposes. Useful when you'd rather not parse logs or `eth_syncing` output by hand.
-17. **Can I use Erigon with Docker?** Yes, Erigon provides official Docker images on Dockerhub. See the [Installation](/get-started/installation) guide for the Docker setup instructions.
-18. **Does Erigon support other chains besides Ethereum?** Yes, Erigon is an EVM-compatible client and supports other networks like Gnosis. You can specify the chain with the `--chain` flag. See [Supported Networks](/fundamentals/supported-networks) and the [Easy Nodes](/get-started/easy-nodes) guides for chain-specific setup.
+```bash
+curl -s -X POST -H "Content-Type: application/json" \
+  --data '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}' \
+  http://localhost:8545
+```
+
+While syncing the result is an object with `currentBlock`, `highestBlock`, and a `stages` array (per-stage progress, matching the log prefix); once fully synced it is simply `false`. (`startingBlock` is also returned but is hardcoded to `"0x0"`.)
+
+  - **Ask an AI assistant via MCP** — Erigon's built-in [MCP server](https://docs.erigon.tech/fundamentals/mcp) (default `127.0.0.1:8553`) lets a connected assistant like Claude Desktop answer questions like *"Is my node synced? How many blocks behind am I?"* in plain language by querying the same data the JSON-RPC exposes. Useful when you'd rather not parse logs or `eth_syncing` output by hand.
+
+17. **Can I use Erigon with Docker?** Yes, Erigon provides official Docker images on Dockerhub. See the [Installation](https://docs.erigon.tech/get-started/installation) guide for the Docker setup instructions.
+
+18. **Does Erigon support other chains besides Ethereum?** Yes, Erigon is an EVM-compatible client and supports other networks like Gnosis. You can specify the chain with the `--chain` flag. See [Supported Networks](https://docs.erigon.tech/fundamentals/supported-networks) and the [Easy Nodes](https://docs.erigon.tech/get-started/easy-nodes) guides for chain-specific setup.
+
 19. **Where can I find official support?** The primary channels for support and community discussions are the official Erigon Discord and GitHub repository.
-20. **What is Caplin?** [Caplin](/staking/caplin) is Erigon's built-in beacon API server. It allows Erigon to function as both a consensus and execution client.
+
+20. **What is Caplin?** [Caplin](https://docs.erigon.tech/staking/caplin) is Erigon's built-in beacon API server. It allows Erigon to function as both a consensus and execution client.
+
 21. **What is OtterSync?** OtterSync is a syncing algorithm that further enhances performance by shifting 98% of the computation to network bandwidth, reducing synchronization times and improving chain tip performance, disk footprint, and decentralization.
-22. **Why can't I query blocks before a certain height?** In `full` and `minimal` pruning modes, Erigon discards historical state data that is older than the pruning window. If you need to query early blocks, you must run an archive node (`--prune.mode=archive`). See [Pruning Modes](/fundamentals/pruning-modes) for more on pruning. Note that the pruning mode is set permanently at the first sync and cannot be changed without a full re-sync.
-23. **Can I run Erigon on a Raspberry Pi or low-power ARM device?** It is not recommended for Mainnet. Erigon requires a high-end NVMe SSD and sufficient RAM (16 GB minimum) for reliable operation. Low-power ARM devices typically lack the disk I/O performance and memory needed to keep up with the chain tip. See [Hardware Requirements](/get-started/hardware-requirements). A testnet like Sepolia may be feasible on higher-end ARM hardware, but expect limited performance.
+
+22. **Why can't I query blocks before a certain height?** In `full` and `minimal` pruning modes, Erigon discards historical state data that is older than the pruning window. If you need to query early blocks, you must run an archive node (`--prune.mode=archive`). See [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes) for more on pruning. Note that the pruning mode is set permanently at the first sync and cannot be changed without a full re-sync.
+
+23. **Can I run Erigon on a Raspberry Pi or low-power ARM device?** It is not recommended for Mainnet. Erigon requires a high-end NVMe SSD and sufficient RAM (16 GB minimum) for reliable operation. Low-power ARM devices typically lack the disk I/O performance and memory needed to keep up with the chain tip. See [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements). A testnet like Sepolia may be feasible on higher-end ARM hardware, but expect limited performance.
+
 24. **What is the MCP server?** The MCP (Model Context Protocol) server is a built-in component that exposes Erigon's blockchain data to AI assistants like Claude Desktop. It is enabled by default and listens on `127.0.0.1:8553`. To disable it, pass `--mcp.disable` at startup.
-25. **How do I connect Claude Desktop to my Erigon node?** Build the standalone `mcp` binary with `make mcp`, then add it to your Claude Desktop configuration at `~/.config/claude-desktop/config.json` pointing to your node's JSON-RPC endpoint or datadir. See the [MCP Server](/fundamentals/mcp) page for the full configuration example.
-26. **My node keeps falling behind the chain tip after running for a while. How do I fix it?** In most cases you can recover by deleting only the hot database — `datadir/chaindata` — and restarting. Do **not** delete the whole `datadir`, which would force a full re-sync. Erigon re-derives `chaindata` from the immutable snapshots (re-downloading them if needed) and resyncs the post-snapshot tip from the consensus layer — treat it as a chain-tip resync, not an instant rebuild, and keep a backup if fast recovery matters. Make sure you are on the latest release: Erigon 3.4+ ships a much smaller `chaindata` and an improved pruning algorithm that greatly reduces this problem. See [Common Errors and Solutions](/help-center/common-errors-and-solutions) and [Optimizing Storage](/fundamentals/optimizing-storage).
-27. **What is the difference between deleting `chaindata` and deleting the whole `datadir`?** `chaindata` is Erigon's small, mutable MDBX database (typically 15–20 GB, even on an archive node) holding recent state and sync progress. The `snapshots` directory holds the immutable historical data — roughly 95% of the total footprint. Deleting `chaindata` is recoverable but not free: Erigon re-derives state from the snapshots (re-downloading them if needed) and resyncs the post-snapshot tip from the consensus layer — a chain-tip resync, not an instant rebuild. Deleting the entire `datadir` also discards the snapshots and forces a full re-sync. When in doubt, delete only `chaindata`. See [Database](/fundamentals/database).
-28. **My node has no peers or won't sync. Which ports do I need to open?** Erigon needs several ports reachable (both TCP and UDP where applicable): `30303`/`30304` (execution-layer P2P), `4000` and `4001` (Caplin consensus peering), and `42069` (BitTorrent snapshot download). Keep the RPC port (`8545`) bound to localhost and never expose it publicly. If your node is behind NAT, set `--nat` and `--caplin.nat` to `stun` or `upnp` and forward those ports on your router. See [Default Ports](/fundamentals/default-ports) and [NAT](/fundamentals/nat).
-29. **How do I reduce Erigon's memory use or stop it from being OOM-killed?** Erigon and the Go runtime size their memory and CPU use from the resources they can see, so on a shared or memory-constrained host you can make them more conservative: set `GOMEMLIMIT` (e.g. `GOMEMLIMIT=26GiB`), lower `GOGC` (e.g. `GOGC=80`), cap `GOMAXPROCS` (e.g. to half your cores), and reduce `--batchSize` (e.g. `--batchSize=256m`). See [Common Errors and Solutions](/help-center/common-errors-and-solutions) and [Performance Tricks](/fundamentals/performance-tricks).
+
+25. **How do I connect Claude Desktop to my Erigon node?** Build the standalone `mcp` binary with `make mcp`, then add it to your Claude Desktop configuration at `~/.config/claude-desktop/config.json` pointing to your node's JSON-RPC endpoint or datadir. See the [MCP Server](https://docs.erigon.tech/fundamentals/mcp) page for the full configuration example.
+
+26. **My node keeps falling behind the chain tip after running for a while. How do I fix it?** In most cases you can recover by deleting only the hot database — `datadir/chaindata` — and restarting. Do **not** delete the whole `datadir`, which would force a full re-sync. Erigon re-derives `chaindata` from the immutable snapshots (re-downloading them if needed) and resyncs the post-snapshot tip from the consensus layer — treat it as a chain-tip resync, not an instant rebuild, and keep a backup if fast recovery matters. Make sure you are on the latest release: Erigon 3.4+ ships a much smaller `chaindata` and an improved pruning algorithm that greatly reduces this problem. See [Common Errors and Solutions](https://docs.erigon.tech/help-center/common-errors-and-solutions) and [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage).
+
+27. **What is the difference between deleting `chaindata` and deleting the whole `datadir`?** `chaindata` is Erigon's small, mutable MDBX database (typically 15–20 GB, even on an archive node) holding recent state and sync progress. The `snapshots` directory holds the immutable historical data — roughly 95% of the total footprint. Deleting `chaindata` is recoverable but not free: Erigon re-derives state from the snapshots (re-downloading them if needed) and resyncs the post-snapshot tip from the consensus layer — a chain-tip resync, not an instant rebuild. Deleting the entire `datadir` also discards the snapshots and forces a full re-sync. When in doubt, delete only `chaindata`. See [Database](https://docs.erigon.tech/fundamentals/database).
+
+28. **My node has no peers or won't sync. Which ports do I need to open?** Erigon needs several ports reachable (both TCP and UDP where applicable): `30303`/`30304` (execution-layer P2P), `4000` and `4001` (Caplin consensus peering), and `42069` (BitTorrent snapshot download). Keep the RPC port (`8545`) bound to localhost and never expose it publicly. If your node is behind NAT, set `--nat` and `--caplin.nat` to `stun` or `upnp` and forward those ports on your router. See [Default Ports](https://docs.erigon.tech/fundamentals/default-ports) and [NAT](https://docs.erigon.tech/fundamentals/nat).
+
+29. **How do I reduce Erigon's memory use or stop it from being OOM-killed?** Erigon and the Go runtime size their memory and CPU use from the resources they can see, so on a shared or memory-constrained host you can make them more conservative: set `GOMEMLIMIT` (e.g. `GOMEMLIMIT=26GiB`), lower `GOGC` (e.g. `GOGC=80`), cap `GOMAXPROCS` (e.g. to half your cores), and reduce `--batchSize` (e.g. `--batchSize=256m`). See [Common Errors and Solutions](https://docs.erigon.tech/help-center/common-errors-and-solutions) and [Performance Tricks](https://docs.erigon.tech/fundamentals/performance-tricks).
+
 30. **Where do I report a security vulnerability?** Erigon is covered by the Ethereum Foundation's [Bug Bounty Program](https://ethereum.org/bug-bounty). Report security issues there so they can be handled responsibly — not via public Discord or GitHub issues. For non-security bugs, open a GitHub issue with logs and version info.
-31. **Where are Erigon's log files stored?** By default Erigon writes logs to `<datadir>/logs/erigon.log`, in addition to standard output. Attach this file when opening a bug report. See [Logs](/fundamentals/logs) for log-level and rotation options.
+
+31. **Where are Erigon's log files stored?** By default Erigon writes logs to `<datadir>/logs/erigon.log`, in addition to standard output. Attach this file when opening a bug report. See [Logs](https://docs.erigon.tech/fundamentals/logs) for log-level and rotation options.
 
 ---
 
 # Troubleshooting
 URL: https://docs.erigon.tech/help-center/troubleshooting
-
 
 ## Resilience and Data Integrity
 
@@ -7798,22 +7846,22 @@ Erigon is highly resilient and uses a fully-transactional database. This design 
 
 When an issue arises, follow these steps to methodically diagnose and resolve the problem.
 
-1. **Check Hardware Requirements:** The most common cause of issues is insufficient disk or RAM. Ensure your system meets the recommended [Hardware Requirements](/get-started/hardware-requirements). Note that Erigon is very adaptive—adding more RAM to the server will make Erigon faster without requiring any setting changes.
-2. **Inspect Erigon Logs:** The logs are your best friend. By default Erigon writes to `<datadir>/logs/erigon.log`; use `tail -f <datadir>/logs/erigon.log` or `journalctl` to see real-time output and identify error messages or warnings. See [Logs](/fundamentals/logs) for log configuration options.
+1. **Check Hardware Requirements:** The most common cause of issues is insufficient disk or RAM. Ensure your system meets the recommended [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements). Note that Erigon is very adaptive—adding more RAM to the server will make Erigon faster without requiring any setting changes.
+2. **Inspect Erigon Logs:** The logs are your best friend. By default Erigon writes to `<datadir>/logs/erigon.log`; use `tail -f <datadir>/logs/erigon.log` or `journalctl` to see real-time output and identify error messages or warnings. See [Logs](https://docs.erigon.tech/fundamentals/logs) for log configuration options.
 3. **Verify Sync Status:** Use `curl localhost:8545 -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}'` to check if the node is actively syncing.
-4. **Monitor System Resources:** Use `htop`, `top`, or `iostat` to monitor CPU, RAM, and disk I/O. This can help you identify a performance bottleneck. For a full monitoring dashboard, see [Creating a Dashboard](/fundamentals/creating-a-dashboard).
+4. **Monitor System Resources:** Use `htop`, `top`, or `iostat` to monitor CPU, RAM, and disk I/O. This can help you identify a performance bottleneck. For a full monitoring dashboard, see [Creating a Dashboard](https://docs.erigon.tech/fundamentals/creating-a-dashboard).
 5. **Look for OOM-kill events:** After an unexpected crash, always check your system logs for an "Out of Memory" killer event. This confirms if a memory issue caused the crash.
 6. **Perform a Simple Restart**: If the node is stalled, simply restart the service using `systemctl restart erigon`. Erigon's transactional database is designed to handle interruption gracefully.
-7. **Disable RPC/CL during Initial Sync**: If you are stalling during snapshot sync, try restarting without the [RPC daemon](/fundamentals/modules/rpc-daemon) or consensus client to reduce concurrent disk access, which is a bottleneck during the slowest stage (Blocks Execution).
-8. **Check for Disk Space:** Regularly check your disk usage. A full disk will cause performance degradation and can lead to a node crash. See [Optimizing Storage](/fundamentals/optimizing-storage) for tips on reducing disk usage.
+7. **Disable RPC/CL during Initial Sync**: If you are stalling during snapshot sync, try restarting without the [RPC daemon](https://docs.erigon.tech/fundamentals/modules/rpc-daemon) or consensus client to reduce concurrent disk access, which is a bottleneck during the slowest stage (Blocks Execution).
+8. **Check for Disk Space:** Regularly check your disk usage. A full disk will cause performance degradation and can lead to a node crash. See [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage) for tips on reducing disk usage.
 9. **Verify Network Time:** Ensure your system's clock is synchronized. Incorrect time can cause issues with block propagation.
-10. **Check P2P Peer Connections:** Use `net_peerCount` or similar RPC methods to check if you have a healthy number of peers. A low count may indicate a network problem. See [Default Ports](/fundamentals/default-ports) to verify firewall rules allow P2P traffic.
-11. **Review Firewall Rules:** Confirm that your firewall is not blocking inbound or outbound traffic on the required P2P and RPC [ports](/fundamentals/default-ports).
-12. **Double-Check Configuration Flags:** Review all your command-line flags for typos or incorrect values. A single misplaced character can cause a cryptic error. See the [CLI Reference](/fundamentals/configuring-erigon) for the full flag list.
-13. **Check for Snapshot File Issues:** For version upgrades, a known issue with snapshot filenames can cause problems. Use snapshot [upgrade](/get-started/installation/upgrading) and repair options.
-14. **Correct File Ownership:** If using a dedicated user or Docker, confirm that the user has full read/write access to the datadir. See the [Docker Compose](/fundamentals/docker-compose) guide for container-specific permission tips.
-15. **Adjust RPC Timeouts:** If specific RPC requests are timing out, try increasing the timeout values to allow more time for heavy requests to complete. See the [RPC & API flags](/fundamentals/configuring-erigon#rpc--api) in the CLI Reference.
-16. **Check for `DB.read.concurrency` issues:** If you have high RPC traffic and low TPS, try reducing the `--DB.read.concurrency` flag. See [Configuring Erigon](/fundamentals/configuring-erigon) for all database-related flags.
+10. **Check P2P Peer Connections:** Use `net_peerCount` or similar RPC methods to check if you have a healthy number of peers. A low count may indicate a network problem. See [Default Ports](https://docs.erigon.tech/fundamentals/default-ports) to verify firewall rules allow P2P traffic.
+11. **Review Firewall Rules:** Confirm that your firewall is not blocking inbound or outbound traffic on the required P2P and RPC [ports](https://docs.erigon.tech/fundamentals/default-ports).
+12. **Double-Check Configuration Flags:** Review all your command-line flags for typos or incorrect values. A single misplaced character can cause a cryptic error. See the [CLI Reference](https://docs.erigon.tech/fundamentals/configuring-erigon) for the full flag list.
+13. **Check for Snapshot File Issues:** For version upgrades, a known issue with snapshot filenames can cause problems. Use snapshot [upgrade](https://docs.erigon.tech/get-started/installation/upgrading) and repair options.
+14. **Correct File Ownership:** If using a dedicated user or Docker, confirm that the user has full read/write access to the datadir. See the [Docker Compose](https://docs.erigon.tech/fundamentals/docker-compose) guide for container-specific permission tips.
+15. **Adjust RPC Timeouts:** If specific RPC requests are timing out, try increasing the timeout values to allow more time for heavy requests to complete. See the [RPC & API flags](https://docs.erigon.tech/fundamentals/configuring-erigon#rpc--api) in the CLI Reference.
+16. **Check for `DB.read.concurrency` issues:** If you have high RPC traffic and low TPS, try reducing the `--DB.read.concurrency` flag. See [Configuring Erigon](https://docs.erigon.tech/fundamentals/configuring-erigon) for all database-related flags.
 17. **Report a Bug:** If all else fails, open a detailed bug report on GitHub with logs, version info, and a clear description of the problem.
 18. **Engage with the Community:** The Erigon Discord server is an invaluable resource for seeking help from core developers and experienced users.
 
@@ -7847,10 +7895,10 @@ Attach the `.pprof` files and the goroutine dump to your GitHub issue.
 
 Hetzner applies a stateless firewall at the network edge. Ensure the following ports are open for **both TCP and UDP, inbound and outbound**:
 
-| Purpose        | Port  | Protocol |
-| -------------- | ----- | -------- |
-| P2P (Ethereum) | 30303 | TCP+UDP  |
-| P2P (Caplin)   | 9000  | TCP+UDP  |
+| Purpose | Port | Protocol |
+| --- | --- | --- |
+| P2P (Ethereum) | 30303 | TCP+UDP |
+| P2P (Caplin) | 9000 | TCP+UDP |
 
 Without these, the node may appear to have peers (via the cloud dashboard) but will suffer poor block propagation. Configure the firewall in the Hetzner Cloud Console under **Firewalls** or via `hcloud firewall`.
 
@@ -7858,7 +7906,6 @@ Without these, the node may appear to have peers (via the cloud dashboard) but w
 
 # Known Issues
 URL: https://docs.erigon.tech/help-center/known-issues
-
 
 ### Incorrect Memory Usage in `htop`
 
@@ -7870,9 +7917,9 @@ The **`RES`** (Resident) column in `htop` combines the memory used by the applic
 
 For a more accurate view of Erigon's memory usage, use one of these tools:
 
-* **`vmmap -summary PID`** _(macOS only)_: Shows a detailed breakdown with separate **`MALLOC ZONE`** and **`REGION TYPE`** sections for application memory and OS page cache.
-* **`pmap -x PID`** _(Linux)_: Prints a per-mapping breakdown of RSS and dirty pages. For the full raw detail use `cat /proc/<PID>/smaps`.
-* **Prometheus Dashboard**: This provides a graphical representation of the Go application's memory usage, excluding the OS page cache. You can run it with `make prometheus` and access it in your browser at `localhost:3000` with the credentials `admin/admin`. See [Creating a Dashboard](/fundamentals/creating-a-dashboard) for full setup instructions.
+- **`vmmap -summary PID`** *(macOS only)*: Shows a detailed breakdown with separate **`MALLOC ZONE`** and **`REGION TYPE`** sections for application memory and OS page cache.
+- **`pmap -x PID`** *(Linux)*: Prints a per-mapping breakdown of RSS and dirty pages. For the full raw detail use `cat /proc/<PID>/smaps`.
+- **Prometheus Dashboard**: This provides a graphical representation of the Go application's memory usage, excluding the OS page cache. You can run it with `make prometheus` and access it in your browser at `localhost:3000` with the credentials `admin/admin`. See [Creating a Dashboard](https://docs.erigon.tech/fundamentals/creating-a-dashboard) for full setup instructions.
 
 Erigon typically uses about **4 GB of RAM** during a genesis sync and about **1 GB** during normal operation. The OS page cache, however, can use an unlimited amount of memory.
 
@@ -7888,10 +7935,10 @@ Cloud network drives, like gp3, aren't ideal for Erigon's block execution. This 
 
 Erigon3 is designed to download most of the history, making it less sensitive to disk latency. To improve performance, focus on **reducing disk latency**, not on increasing throughput or IOPS. There are several ways to do this:
 
-* **Use latency-critical cloud drives** or attached NVMe storage, especially for the initial sync.
-* **Increase RAM**. More RAM helps buffer data and reduces the need for frequent disk access.
-* If you have sufficient RAM, you can set the environment variable **`ERIGON_SNAPSHOT_MADV_RND=false`**. This setting can improve performance by altering how Erigon handles memory.
-* Use the flag **`--db.pagesize=64kb`** to decrease database fragmentation and improve I/O efficiency.
+- **Use latency-critical cloud drives** or attached NVMe storage, especially for the initial sync.
+- **Increase RAM**. More RAM helps buffer data and reduces the need for frequent disk access.
+- If you have sufficient RAM, you can set the environment variable **`ERIGON_SNAPSHOT_MADV_RND=false`**. This setting can improve performance by altering how Erigon handles memory.
+- Use the flag **`--db.pagesize=64kb`** to decrease database fragmentation and improve I/O efficiency.
 
 #### Background File System Features Can Hurt Performance
 
@@ -7903,7 +7950,7 @@ Certain file system features, such as `autodefrag` on btrfs, can drastically inc
 
 #### The `--mount` Option and BuildKit Errors
 
-If you're encountering a BuildKit error when starting Erigon, it's likely due to an issue with the `--mount` option in your command. To fix this, you can use the following command to start Erigon with `docker-compose`. See [Docker Compose](/fundamentals/docker-compose) for the full setup guide.
+If you're encountering a BuildKit error when starting Erigon, it's likely due to an issue with the `--mount` option in your command. To fix this, you can use the following command to start Erigon with `docker-compose`. See [Docker Compose](https://docs.erigon.tech/fundamentals/docker-compose) for the full setup guide.
 
 ```bash
 XDG_DATA_HOME=/preferred/data/folder make docker-compose
@@ -7920,68 +7967,67 @@ vm.max_map_count = 16777216
 
 ### Changing `--db.pagesize` After First Sync
 
-The `--db.pagesize` flag sets the MDBX page size and **must be chosen before the first sync**. It cannot be changed on an existing database without deleting the datadir and re-syncing from scratch. See [Configuring Erigon](/fundamentals/configuring-erigon) for all database flags.
+The `--db.pagesize` flag sets the MDBX page size and **must be chosen before the first sync**. It cannot be changed on an existing database without deleting the datadir and re-syncing from scratch. See [Configuring Erigon](https://docs.erigon.tech/fundamentals/configuring-erigon) for all database flags.
 
-The default page size is `4KB`. For cloud drives or any storage with high sequential I/O latency, a larger page size (e.g. `--db.pagesize=64kb`) reduces database fragmentation and improves I/O efficiency. See [Performance Tricks](/fundamentals/performance-tricks) and [Optimizing Storage](/fundamentals/optimizing-storage) for further tuning options.
+The default page size is `4KB`. For cloud drives or any storage with high sequential I/O latency, a larger page size (e.g. `--db.pagesize=64kb`) reduces database fragmentation and improves I/O efficiency. See [Performance Tricks](https://docs.erigon.tech/fundamentals/performance-tricks) and [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage) for further tuning options.
 
 ---
 
 # Best Practices
 URL: https://docs.erigon.tech/help-center/best-practices
 
-
 These integrated practices focus on maximizing the reliability, efficiency, and security of your Erigon node setup.
 
 ## Hardware and Data Integrity
 
-| **Practice**                        | **Details**                                                                                                                                                                     | **Rationale**                                                                                                                                                                           |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Use a High-End NVMe SSD             | This is a non-negotiable prerequisite. NVMe SSDs are essential for reliable, high-performance node operation. See [Hardware Requirements](/get-started/hardware-requirements).  | Erigon is highly disk I/O intensive. Fast storage prevents bottlenecks and sync issues.                                                                                                 |
-| Integrate Hardware Reliability      | Use ECC memory and consider a disk RAID setup. Do regular backups of your chain data.                                                                                           | While Erigon's database is fully-transactional and resilient to graceful shutdowns, crashes, and power outages, it is not protected against hardware failures (disk or RAM corruption). |
-| Symlink Data Directories (Advanced) | For systems with multiple disks, consider symlinking `snapshots` and `temp` directories to a cheaper, high-capacity drive, while keeping the main `chaindata` on the fast NVMe. See [Optimizing Storage](/fundamentals/optimizing-storage). | Optimizes cost and capacity while retaining performance for critical files.                                                                          |
-| Maintain Sufficient RAM             | Ensure your system has at least the recommended RAM for your chosen network and [pruning mode](/fundamentals/pruning-modes). See [Hardware Requirements](/get-started/hardware-requirements). | Insufficient RAM, even with Erigon's memory efficiency, will lead to OOM-kill events (Out-of-Memory).                                                                                   |
+| **Practice** | **Details** | **Rationale** |
+| --- | --- | --- |
+| Use a High-End NVMe SSD | This is a non-negotiable prerequisite. NVMe SSDs are essential for reliable, high-performance node operation. See [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements). | Erigon is highly disk I/O intensive. Fast storage prevents bottlenecks and sync issues. |
+| Integrate Hardware Reliability | Use ECC memory and consider a disk RAID setup. Do regular backups of your chain data. | While Erigon's database is fully-transactional and resilient to graceful shutdowns, crashes, and power outages, it is not protected against hardware failures (disk or RAM corruption). |
+| Symlink Data Directories (Advanced) | For systems with multiple disks, consider symlinking `snapshots` and `temp` directories to a cheaper, high-capacity drive, while keeping the main `chaindata` on the fast NVMe. See [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage). | Optimizes cost and capacity while retaining performance for critical files. |
+| Maintain Sufficient RAM | Ensure your system has at least the recommended RAM for your chosen network and [pruning mode](https://docs.erigon.tech/fundamentals/pruning-modes). See [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements). | Insufficient RAM, even with Erigon's memory efficiency, will lead to OOM-kill events (Out-of-Memory). |
 
 ## Node Configuration and Startup
 
-| **Practice**                               | **Details**                                                                                                                                                                         | **Rationale**                                                                                                                                                           |
-| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Make a Mindful Pruning Mode Decision       | The `--prune.mode` flag is irreversible. Choose `full` for most cases, `minimal` for validators with limited space, and `archive` only if all historical data is absolutely needed. See [Pruning Modes](/fundamentals/pruning-modes). | An incorrect choice can lead to a necessary resync. `Full` is a balance of performance and space.                                |
-| Employ a Process Manager                   | Always run Erigon as a systemd or supervisor service. See the [Installation](/get-started/installation) guide for service setup examples.                                           | Ensures a graceful shutdown and allows for automatic restarts, contributing to stability.                                                                               |
-| Use a Dedicated User Account               | Run the Erigon service with a non-root, dedicated user account.                                                                                                                     | Follows security best practices and prevents potential permission-related errors.                                                                                       |
-| Avoid Graceful Shutdown (Unless Necessary) | While a process manager ensures a graceful shutdown, know that Erigon is safe against abrupt halts like process kills (`kill -9`) or a power outage.                                | Erigon's database is fully-transactional, meaning writes are atomic ("all-or-nothing"), preventing "partial writes" and database corruption from non-hardware failures. |
-| Tune Sync Speed with Flags                 | Use flags like `--sync.loop.block.limit` and `--batchSize` to tune the synchronization speed, especially during the initial sync. See [Configuring Erigon](/fundamentals/configuring-erigon). | Allows you to optimize the sync process based on your system's hardware capabilities.                                                   |
-| Lock the Latest State in RAM (Advanced)    | On systems with high historical RPC traffic, a tool like vmtouch can be used to lock the latest state files in RAM. See [Performance Tricks](/fundamentals/performance-tricks).     | Improves RPC response times for common queries by keeping the latest data in the fastest memory.                                                                        |
+| **Practice** | **Details** | **Rationale** |
+| --- | --- | --- |
+| Make a Mindful Pruning Mode Decision | The `--prune.mode` flag is irreversible. Choose `full` for most cases, `minimal` for validators with limited space, and `archive` only if all historical data is absolutely needed. See [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes). | An incorrect choice can lead to a necessary resync. `Full` is a balance of performance and space. |
+| Employ a Process Manager | Always run Erigon as a systemd or supervisor service. See the [Installation](https://docs.erigon.tech/get-started/installation) guide for service setup examples. | Ensures a graceful shutdown and allows for automatic restarts, contributing to stability. |
+| Use a Dedicated User Account | Run the Erigon service with a non-root, dedicated user account. | Follows security best practices and prevents potential permission-related errors. |
+| Avoid Graceful Shutdown (Unless Necessary) | While a process manager ensures a graceful shutdown, know that Erigon is safe against abrupt halts like process kills (`kill -9`) or a power outage. | Erigon's database is fully-transactional, meaning writes are atomic ("all-or-nothing"), preventing "partial writes" and database corruption from non-hardware failures. |
+| Tune Sync Speed with Flags | Use flags like `--sync.loop.block.limit` and `--batchSize` to tune the synchronization speed, especially during the initial sync. See [Configuring Erigon](https://docs.erigon.tech/fundamentals/configuring-erigon). | Allows you to optimize the sync process based on your system's hardware capabilities. |
+| Lock the Latest State in RAM (Advanced) | On systems with high historical RPC traffic, a tool like vmtouch can be used to lock the latest state files in RAM. See [Performance Tricks](https://docs.erigon.tech/fundamentals/performance-tricks). | Improves RPC response times for common queries by keeping the latest data in the fastest memory. |
 
 ## Security and Monitoring
 
-| **Practice**                | **Details**                                                                                                                                                            | **Rationale**                                                                                               |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| Configure Firewall Rules    | Configure your firewall to allow only the necessary ports for P2P and RPC communication. See [Default Ports](/fundamentals/default-ports).                             | Standard security practice to limit attack surface.                                                         |
-| Never Expose RPC Ports      | Never expose the RPC ports to the public internet without a reverse proxy. See [Security](/fundamentals/security).                                                     | RPC (Remote Procedure Call) ports grant access to node functions; public exposure is a major security risk. |
-| Monitor Your Node's Health  | Implement comprehensive monitoring using tools like Prometheus and Grafana to track key metrics like disk I/O, CPU load, and sync status in real time. See [Creating a Dashboard](/fundamentals/creating-a-dashboard). | Essential for proactively identifying performance bottlenecks and stability issues.        |
-| Enable JSON-RPC Compression | Use the `--http.compression` flag. See [Configuring Erigon](/fundamentals/configuring-erigon).                                                                         | Reduces network bandwidth usage for RPC requests.                                                           |
-| Tune RPC Batch Concurrency  | Adjust the `--rpc.batch.concurrency` flag. See [RPC & API flags](/fundamentals/configuring-erigon#rpc--api).                                                           | Limits the number of parallel database reads to prevent a single batch request from overloading the server. |
-| Harden Public RPC Endpoints | Place a reverse proxy (e.g. Nginx, Caddy) in front of Erigon. Enable rate-limiting, TLS termination, and authentication at the proxy layer. Never bind `--http.addr` to `0.0.0.0` directly on a public interface. See [TLS Authentication](/fundamentals/tls-authentication). | A direct public binding exposes the node to DoS attacks and unrestricted calls that can exhaust resources. |
+| **Practice** | **Details** | **Rationale** |
+| --- | --- | --- |
+| Configure Firewall Rules | Configure your firewall to allow only the necessary ports for P2P and RPC communication. See [Default Ports](https://docs.erigon.tech/fundamentals/default-ports). | Standard security practice to limit attack surface. |
+| Never Expose RPC Ports | Never expose the RPC ports to the public internet without a reverse proxy. See [Security](https://docs.erigon.tech/fundamentals/security). | RPC (Remote Procedure Call) ports grant access to node functions; public exposure is a major security risk. |
+| Monitor Your Node's Health | Implement comprehensive monitoring using tools like Prometheus and Grafana to track key metrics like disk I/O, CPU load, and sync status in real time. See [Creating a Dashboard](https://docs.erigon.tech/fundamentals/creating-a-dashboard). | Essential for proactively identifying performance bottlenecks and stability issues. |
+| Enable JSON-RPC Compression | Use the `--http.compression` flag. See [Configuring Erigon](https://docs.erigon.tech/fundamentals/configuring-erigon). | Reduces network bandwidth usage for RPC requests. |
+| Tune RPC Batch Concurrency | Adjust the `--rpc.batch.concurrency` flag. See [RPC & API flags](https://docs.erigon.tech/fundamentals/configuring-erigon#rpc--api). | Limits the number of parallel database reads to prevent a single batch request from overloading the server. |
+| Harden Public RPC Endpoints | Place a reverse proxy (e.g. Nginx, Caddy) in front of Erigon. Enable rate-limiting, TLS termination, and authentication at the proxy layer. Never bind `--http.addr` to `0.0.0.0` directly on a public interface. See [TLS Authentication](https://docs.erigon.tech/fundamentals/tls-authentication). | A direct public binding exposes the node to DoS attacks and unrestricted calls that can exhaust resources. |
 
 ## Maintenance and Development
 
-| **Practice**                   | **Details**                                                                                                         | **Rationale**                                                                                       |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| Keep Your Binary Updated       | Regularly update your binary. Erigon is in active development. See [Upgrading](/get-started/installation/upgrading). | New releases often contain critical bug fixes and performance improvements essential for stability. |
-| Use Official Docker Images     | If using Docker, rely on the official images provided by the Erigon team. See [Docker Compose](/fundamentals/docker-compose). | Best compatibility and stability for containerized deployment.                               |
-| Run a Test Sync on a Testnet   | Before running on Mainnet, consider performing a sync on a testnet (e.g., Sepolia). See [Supported Networks](/fundamentals/supported-networks). | Familiarizes you with the process and your system's performance characteristics.          |
-| Report Issues with Diagnostics | When a bug is encountered, provide a detailed report on GitHub with a stack trace and other diagnostic information. | Helps the development team quickly identify and fix issues.                                         |
+| **Practice** | **Details** | **Rationale** |
+| --- | --- | --- |
+| Keep Your Binary Updated | Regularly update your binary. Erigon is in active development. See [Upgrading](https://docs.erigon.tech/get-started/installation/upgrading). | New releases often contain critical bug fixes and performance improvements essential for stability. |
+| Use Official Docker Images | If using Docker, rely on the official images provided by the Erigon team. See [Docker Compose](https://docs.erigon.tech/fundamentals/docker-compose). | Best compatibility and stability for containerized deployment. |
+| Run a Test Sync on a Testnet | Before running on Mainnet, consider performing a sync on a testnet (e.g., Sepolia). See [Supported Networks](https://docs.erigon.tech/fundamentals/supported-networks). | Familiarizes you with the process and your system's performance characteristics. |
+| Report Issues with Diagnostics | When a bug is encountered, provide a detailed report on GitHub with a stack trace and other diagnostic information. | Helps the development team quickly identify and fix issues. |
 
 ## Validator-Specific Practices
 
-| **Practice**                      | **Details**                                                                                    | **Rationale**                                                           |
-| --------------------------------- | ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| Check Validator Health            | For validator nodes, a daily check of the node's logs and service status is essential. See [Caplin](/staking/caplin) and [External Consensus Client](/staking/external-consensus-client-as-validator). | Confirms that the node is signing attestations and performing its duty. |
-| Maintain a Sufficient ETH Balance | Validators must maintain an adequate ETH balance on their signer address.                      | Required to cover transaction fees for checkpoint submissions.          |
+| **Practice** | **Details** | **Rationale** |
+| --- | --- | --- |
+| Check Validator Health | For validator nodes, a daily check of the node's logs and service status is essential. See [Caplin](https://docs.erigon.tech/staking/caplin) and [External Consensus Client](https://docs.erigon.tech/staking/external-consensus-client-as-validator). | Confirms that the node is signing attestations and performing its duty. |
+| Maintain a Sufficient ETH Balance | Validators must maintain an adequate ETH balance on their signer address. | Required to cover transaction fees for checkpoint submissions. |
 
 ## Advanced Performance Tricks
 
-The following shell snippets can provide meaningful performance gains on the right hardware. See [Performance Tricks](/fundamentals/performance-tricks) for the full list.
+The following shell snippets can provide meaningful performance gains on the right hardware. See [Performance Tricks](https://docs.erigon.tech/fundamentals/performance-tricks) for the full list.
 
 **Speed up initial sync** — throttle block execution to leave I/O headroom for snapshot downloads:
 
@@ -8013,83 +8059,84 @@ export ERIGON_SNAPSHOT_MADV_RND=false
 # Common Errors and Solutions
 URL: https://docs.erigon.tech/help-center/common-errors-and-solutions
 
-
 This section details common error messages and provides clear, actionable steps to resolve them.
 
 ## Sync and Performance
 
 ### Stalling during snapshot sync (0 B/s download rate)
 
-* **Error Description:** The sync process appears to be stuck, showing a download rate of 0B/s, even with peers.
-* **Cause:** The [RPC daemon](/fundamentals/modules/rpc-daemon) or a connected consensus client may be "spamming" the Erigon node with requests, which interferes with the snapshot sync. This issue is still present in recent versions.
-* **Solution:** Temporarily disable the RPC by removing flags like `--http` and `--ws`, or stop your consensus client until the initial snapshot sync stage is complete.
+- **Error Description:** The sync process appears to be stuck, showing a download rate of 0B/s, even with peers.
+- **Cause:** The [RPC daemon](https://docs.erigon.tech/fundamentals/modules/rpc-daemon) or a connected consensus client may be "spamming" the Erigon node with requests, which interferes with the snapshot sync. This issue is still present in recent versions.
+- **Solution:** Temporarily disable the RPC by removing flags like `--http` and `--ws`, or stop your consensus client until the initial snapshot sync stage is complete.
 
 ### Sync is extremely slow or the node is constantly falling behind
 
-* **Error Description:** The node is not keeping up with the blockchain tip despite a fast internet connection.
-* **Cause:** This is almost always a disk-related problem. The read/write speed and latency of your storage device are the most significant performance bottlenecks for Erigon.
-* **Solution:** Upgrade your storage to a high-end NVMe SSD. Avoid using HDDs, network drives, or slow consumer-grade SSDs. See [Hardware Requirements](/get-started/hardware-requirements) and [Performance Tricks](/fundamentals/performance-tricks).
+- **Error Description:** The node is not keeping up with the blockchain tip despite a fast internet connection.
+- **Cause:** This is almost always a disk-related problem. The read/write speed and latency of your storage device are the most significant performance bottlenecks for Erigon.
+- **Solution:** Upgrade your storage to a high-end NVMe SSD. Avoid using HDDs, network drives, or slow consumer-grade SSDs. See [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements) and [Performance Tricks](https://docs.erigon.tech/fundamentals/performance-tricks).
 
 ### Node falls behind the tip after running for weeks
 
-* **Error Description:** A node that has been healthy for weeks gradually stops keeping up with the chain tip, sometimes after the mutable database has grown large.
-* **Cause:** Over time the mutable `chaindata` database can accumulate state that slows chain-tip processing.
-* **Solution:** Delete **only** the hot database — `datadir/chaindata` — and restart (do **not** delete the whole `datadir`, which would force a full re-sync). Erigon re-derives `chaindata` from the immutable snapshots (re-downloading them if needed) and resyncs the post-snapshot tip from the consensus layer — treat it as a chain-tip resync, not an instant rebuild, and keep a backup if fast recovery matters. Make sure you are on the latest release: Erigon 3.4+ ships a much smaller `chaindata` and an improved pruning algorithm that greatly reduces this problem. See [Optimizing Storage](/fundamentals/optimizing-storage).
+- **Error Description:** A node that has been healthy for weeks gradually stops keeping up with the chain tip, sometimes after the mutable database has grown large.
+- **Cause:** Over time the mutable `chaindata` database can accumulate state that slows chain-tip processing.
+- **Solution:** Delete **only** the hot database — `datadir/chaindata` — and restart (do **not** delete the whole `datadir`, which would force a full re-sync). Erigon re-derives `chaindata` from the immutable snapshots (re-downloading them if needed) and resyncs the post-snapshot tip from the consensus layer — treat it as a chain-tip resync, not an instant rebuild, and keep a backup if fast recovery matters. Make sure you are on the latest release: Erigon 3.4+ ships a much smaller `chaindata` and an improved pruning algorithm that greatly reduces this problem. See [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage).
 
 ### Node stuck in a "bad block" / "invalid block" forkchoice loop
 
-* **Error Description:** The node repeatedly logs `invalid block ... gas used by execution` and `bad block as forkchoice`, and stops advancing the chain head.
-* **Cause:** Corrupted state in the mutable database, typically left over from an incorrect unwind, prevents the node from validating new blocks.
-* **Solution:** Wipe `datadir/chaindata` (not the entire `datadir`) and restart on the latest patch release, which is the reliable recovery. If it recurs immediately, running with the `USE_STATE_CACHE=false` environment variable is a known temporary workaround. If you can still reproduce it on the latest release, open a GitHub issue with your full `<datadir>/logs/erigon.log` attached.
+- **Error Description:** The node repeatedly logs `invalid block ... gas used by execution` and `bad block as forkchoice`, and stops advancing the chain head.
+- **Cause:** Corrupted state in the mutable database, typically left over from an incorrect unwind, prevents the node from validating new blocks.
+- **Solution:** Wipe `datadir/chaindata` (not the entire `datadir`) and restart on the latest patch release, which is the reliable recovery. If it recurs immediately, running with the `USE_STATE_CACHE=false` environment variable is a known temporary workaround. If you can still reproduce it on the latest release, open a GitHub issue with your full `<datadir>/logs/erigon.log` attached.
 
 ## Memory and Resources
 
 ### Out of Memory (OOM) or unexpected process termination
 
-* **Error Description:** The Erigon process is abruptly terminated by the operating system, often with an OOM-kill event in the system logs (`code=killed, status=9/KILL`).
-* **Cause:** This can be a genuine memory leak or, more commonly, a symptom of a disk I/O bottleneck. When the disk can't keep up with processing, memory usage can balloon as the system tries to buffer data. Erigon and the Go runtime also size their memory and CPU use from the resources they can *see*, so on a shared or memory-constrained host they may reserve more than is safe.
-* **Solution:** Ensure your system meets the recommended RAM requirements in [Hardware Requirements](/get-started/hardware-requirements). To make Erigon more conservative on constrained hosts, set a hard memory ceiling and throttle the runtime:
+- **Error Description:** The Erigon process is abruptly terminated by the operating system, often with an OOM-kill event in the system logs (`code=killed, status=9/KILL`).
 
-  ```bash
-  # Export the runtime tunables, then pass --batchSize as an Erigon flag:
-  export GOMEMLIMIT=26GiB               # cap total Go heap (set below your physical/container limit)
-  export GOGC=80                        # collect garbage more aggressively
-  export GOMAXPROCS=$(( $(nproc) / 2 )) # show Erigon fewer cores → smaller RAM estimates
+- **Cause:** This can be a genuine memory leak or, more commonly, a symptom of a disk I/O bottleneck. When the disk can't keep up with processing, memory usage can balloon as the system tries to buffer data. Erigon and the Go runtime also size their memory and CPU use from the resources they can *see*, so on a shared or memory-constrained host they may reserve more than is safe.
 
-  erigon --batchSize=256m ...           # smaller execution batch buffer
-  ```
+- **Solution:** Ensure your system meets the recommended RAM requirements in [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements). To make Erigon more conservative on constrained hosts, set a hard memory ceiling and throttle the runtime:
 
-  A clean shutdown and restart can often resolve a transient event. If the problem persists, check your `dmesg` logs and consider upgrading your disk. See [Performance Tricks](/fundamentals/performance-tricks) for related tuning.
+```bash
+# Export the runtime tunables, then pass --batchSize as an Erigon flag:
+export GOMEMLIMIT=26GiB               # cap total Go heap (set below your physical/container limit)
+export GOGC=80                        # collect garbage more aggressively
+export GOMAXPROCS=$(( $(nproc) / 2 )) # show Erigon fewer cores → smaller RAM estimates
+
+erigon --batchSize=256m ...           # smaller execution batch buffer
+```
+
+A clean shutdown and restart can often resolve a transient event. If the problem persists, check your `dmesg` logs and consider upgrading your disk. See [Performance Tricks](https://docs.erigon.tech/fundamentals/performance-tricks) for related tuning.
 
 ## Database
 
 ### Database corruption after an unexpected shutdown
 
-* **Error Description:** The Erigon process fails to start or crashes immediately after a power outage or a forced kill.
-* **Cause:** Erigon's database can be corrupted if it is not shut down gracefully, which prevents the final writes from being committed.
-* **Solution:** The most reliable solution is to delete the corrupted datadir and re-sync from scratch. This is often faster than attempting to repair the database.
+- **Error Description:** The Erigon process fails to start or crashes immediately after a power outage or a forced kill.
+- **Cause:** Erigon's database can be corrupted if it is not shut down gracefully, which prevents the final writes from being committed.
+- **Solution:** The most reliable solution is to delete the corrupted datadir and re-sync from scratch. This is often faster than attempting to repair the database.
 
 ## Permissions and Access
 
 ### Permission denied or Access Denied errors on startup
 
-* **Error Description:** The process fails to access the datadir, logs, or other files.
-* **Cause:** The user or service account running Erigon does not have the correct file permissions for the data directory.
-* **Solution:** Use the `chown` and `chmod` commands to ensure the correct user account has ownership and full read/write access to the datadir. See [Security](/fundamentals/security) for service account best practices.
+- **Error Description:** The process fails to access the datadir, logs, or other files.
+- **Cause:** The user or service account running Erigon does not have the correct file permissions for the data directory.
+- **Solution:** Use the `chown` and `chmod` commands to ensure the correct user account has ownership and full read/write access to the datadir. See [Security](https://docs.erigon.tech/fundamentals/security) for service account best practices.
 
 ### Permission denied inside Docker (UID/GID mismatch)
 
-* **Error Description:** When running the official Docker image, Erigon fails to read or write files in the mounted datadir with a `permission denied` error.
-* **Cause:** The container runs the Erigon process as UID/GID `1000`. If the host directory is owned by a different user, the process cannot access it.
-* **Solution:** On the host, change ownership of the datadir to UID/GID 1000: `sudo chown -R 1000:1000 /your/datadir`. Alternatively, pass `--user $(id -u):$(id -g)` to `docker run` to run the container with your host user's identity. See [Docker Compose](/fundamentals/docker-compose).
+- **Error Description:** When running the official Docker image, Erigon fails to read or write files in the mounted datadir with a `permission denied` error.
+- **Cause:** The container runs the Erigon process as UID/GID `1000`. If the host directory is owned by a different user, the process cannot access it.
+- **Solution:** On the host, change ownership of the datadir to UID/GID 1000: `sudo chown -R 1000:1000 /your/datadir`. Alternatively, pass `--user $(id -u):$(id -g)` to `docker run` to run the container with your host user's identity. See [Docker Compose](https://docs.erigon.tech/fundamentals/docker-compose).
 
 ## Network and Configuration
 
 ### Connect: connection refused or dial tcp... failures
 
-* **Error Description:** The node cannot connect to an external service, such as a local or remote consensus-layer endpoint.
-* **Cause:** This is a configuration error. The dependent service is either not running, or the command-line flag is pointing to an incorrect address.
-* **Solution:** Confirm that the required services are running and that the command-line flags (e.g., `--externalcl`) are correctly set. See [Configuring Erigon](/fundamentals/configuring-erigon) for all available flags.
+- **Error Description:** The node cannot connect to an external service, such as a local or remote consensus-layer endpoint.
+- **Cause:** This is a configuration error. The dependent service is either not running, or the command-line flag is pointing to an incorrect address.
+- **Solution:** Confirm that the required services are running and that the command-line flags (e.g., `--externalcl`) are correctly set. See [Configuring Erigon](https://docs.erigon.tech/fundamentals/configuring-erigon) for all available flags.
 
 ## Chain-Specific Issues
 
@@ -8097,44 +8144,43 @@ This section details common error messages and provides clear, actionable steps 
 
 ### `libsilkworm_capi.so`: missing shared library
 
-* **Error Description:** Erigon fails to start with a dynamic linker error about a missing `libsilkworm_capi.so` shared library.
-* **Cause:** The binary was built with Silkworm support but the shared library is not present in the system's library path or alongside the binary.
-* **Solution:** Ensure the `libsilkworm_capi.so` file is located in the same directory as the `erigon` binary, or add its location to `LD_LIBRARY_PATH`. If you built from source, run `make erigon` again to confirm the library was compiled and placed correctly. See [Installation](/get-started/installation) for build-from-source instructions. Official Docker images bundle the library automatically.
+- **Error Description:** Erigon fails to start with a dynamic linker error about a missing `libsilkworm_capi.so` shared library.
+- **Cause:** The binary was built with Silkworm support but the shared library is not present in the system's library path or alongside the binary.
+- **Solution:** Ensure the `libsilkworm_capi.so` file is located in the same directory as the `erigon` binary, or add its location to `LD_LIBRARY_PATH`. If you built from source, run `make erigon` again to confirm the library was compiled and placed correctly. See [Installation](https://docs.erigon.tech/get-started/installation) for build-from-source instructions. Official Docker images bundle the library automatically.
 
 ---
 
 # Glossary of Key Terms
 URL: https://docs.erigon.tech/help-center/glossary-of-key-terms
 
-
 This glossary provides concise definitions for essential terms related to the Erigon client. Understanding this terminology is crucial for troubleshooting, configuration, and general operation.
 
-* **Account:** A unique entity on the Ethereum blockchain that can hold an ETH balance and send transactions. There are two types: externally owned accounts (EOAs) and contract accounts.
-* **Archive Node:** A node that stores the complete history of the blockchain. This includes all historical states and past transactions, allowing for deep queries into any moment in the blockchain's history. Erigon is particularly known for its highly optimized archive node. See [Pruning Modes](/fundamentals/pruning-modes).
-* **Attestation:** A validator's vote on the validity of a block or chain. A high attestation effectiveness is critical for a healthy validator and node. See [Caplin](/staking/caplin).
-* **Block:** A collection of transactions, data, and a header that is cryptographically linked to the previous block.
-* **Consensus Client (CL):** Software that runs the Proof-of-Stake (PoS) consensus protocol. It is responsible for a node's peer discovery, block propagation, and attesting to blocks. Examples include Lighthouse, Nimbus, and Prysm. Erigon includes its own built-in CL called [Caplin](/staking/caplin).
-* **datadir:** The directory where an Erigon node stores all of its blockchain data, including the database, snapshots, and temporary files. See [Optimizing Storage](/fundamentals/optimizing-storage) for tips on managing this directory.
-* **Engine API:** The communication protocol that allows the **Execution Client** (Erigon) and the **Consensus Client** to communicate and exchange data, such as new blocks and validator attestations. See the [Engine API](/interacting-with-erigon/engine) reference.
-* **Erigon:** An Ethereum **Execution Client** built for efficiency. It is designed to be highly scalable and fast, with a focus on minimizing disk space and improving synchronization speed. See [Why Erigon](/get-started/why-using-erigon).
-* **Execution Client (EL):** Software that executes and validates all transactions, and propagates new blocks across the network. It maintains a full record of the blockchain state. Erigon is an execution client.
-* **Full Node:** A node that holds a complete copy of all block data, from the genesis block to the current head. It retains recent state, all blocks post-Merge, and prunes ancient blocks and state (EIP-4444 enabled). It verifies every block and state transition. See [Pruning Modes](/fundamentals/pruning-modes).
-* **Go (Golang)**: The open-source programming language used to develop Erigon, known for its performance, concurrency, and efficiency.
-* **Gnosis Chain:** A stable, community-owned EVM-compatible chain that uses a PoS consensus mechanism. Erigon has specific optimizations and troubleshooting steps for Gnosis Chain due to its large transaction history. See the [Gnosis Chain Node](/get-started/easy-nodes/how-to-run-a-gnosis-chain-node) guide.
-* **JSON RPC**: JSON Remote Procedure Call. A lightweight protocol used by Ethereum clients to communicate with applications (like wallets or block explorers) over HTTP or WebSockets. See [Interacting with Erigon](/interacting-with-erigon) for the full API reference.
-* **head:** The most recent block in the blockchain.
-* **Minimal Node**: A node that retains the minimum amount of data necessary to function, typically by heavily pruning historical state data to significantly save disk space. See [Pruning Modes](/fundamentals/pruning-modes).
-* **MDBX:** The high-performance, key-value database that Erigon uses to store blockchain data. It is a more efficient and scalable alternative to the databases used by other clients.
-* **Merkle Patricia Trie:** A data structure used by most Ethereum clients (like Geth) to store the blockchain state. It is highly secure but can be less space-efficient than MDBX.
-* **Mempool:** A pool of unconfirmed transactions that have been submitted to the network but have not yet been included in a block.
-* **MCP Server:** The Model Context Protocol server built into Erigon that exposes blockchain data to AI assistants. See [MCP Server](/fundamentals/mcp) (v3.4+).
-* **Node:** A piece of software that runs on a computer and interacts with the blockchain network. It can be a full node, light node, or validator node.
-* **OOM-kill:** An event where the operating system's "Out of Memory" killer terminates a process (e.g., Erigon) that is consuming too much memory. See [Hardware Requirements](/get-started/hardware-requirements) for recommended RAM specs.
-* **Peer:** Another node on the network that your client is connected to. The more healthy peers you have, the more reliable your connection is. See [Default Ports](/fundamentals/default-ports) for P2P port configuration.
-* **Pruning:** The process of removing older, unnecessary data from the blockchain to save disk space. Erigon offers different pruning modes (full, minimal, archive) to suit various needs. See [Pruning Modes](/fundamentals/pruning-modes).
-* **rpcdaemon:** A separate, lightweight process in Erigon that handles JSON RPC API requests. This design allows Erigon to continue syncing efficiently even under heavy RPC load. See [RPC Daemon](/fundamentals/modules/rpc-daemon).
-* **Snapshot Sync:** A rapid synchronization method that downloads a pre-made snapshot of the blockchain state and then syncs the remaining blocks. This is much faster than syncing from the genesis block. See [Pruning Modes](/fundamentals/pruning-modes).
-* **Staged Sync:** Erigon's unique synchronization model. It processes the blockchain in a series of logical stages, such as downloading headers, verifying bodies, and building the state, to maximize speed and efficiency. See [Pruning Modes](/fundamentals/pruning-modes).
-* **Validator:** A participant in a Proof-of-Stake network who has staked the network token and is responsible for proposing and attesting to new blocks. See [Caplin](/staking/caplin) and [External Consensus Client](/staking/external-consensus-client-as-validator).
+- **Account:** A unique entity on the Ethereum blockchain that can hold an ETH balance and send transactions. There are two types: externally owned accounts (EOAs) and contract accounts.
+- **Archive Node:** A node that stores the complete history of the blockchain. This includes all historical states and past transactions, allowing for deep queries into any moment in the blockchain's history. Erigon is particularly known for its highly optimized archive node. See [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes).
+- **Attestation:** A validator's vote on the validity of a block or chain. A high attestation effectiveness is critical for a healthy validator and node. See [Caplin](https://docs.erigon.tech/staking/caplin).
+- **Block:** A collection of transactions, data, and a header that is cryptographically linked to the previous block.
+- **Consensus Client (CL):** Software that runs the Proof-of-Stake (PoS) consensus protocol. It is responsible for a node's peer discovery, block propagation, and attesting to blocks. Examples include Lighthouse, Nimbus, and Prysm. Erigon includes its own built-in CL called [Caplin](https://docs.erigon.tech/staking/caplin).
+- **datadir:** The directory where an Erigon node stores all of its blockchain data, including the database, snapshots, and temporary files. See [Optimizing Storage](https://docs.erigon.tech/fundamentals/optimizing-storage) for tips on managing this directory.
+- **Engine API:** The communication protocol that allows the **Execution Client** (Erigon) and the **Consensus Client** to communicate and exchange data, such as new blocks and validator attestations. See the [Engine API](https://docs.erigon.tech/interacting-with-erigon/engine) reference.
+- **Erigon:** An Ethereum **Execution Client** built for efficiency. It is designed to be highly scalable and fast, with a focus on minimizing disk space and improving synchronization speed. See [Why Erigon](https://docs.erigon.tech/get-started/why-using-erigon).
+- **Execution Client (EL):** Software that executes and validates all transactions, and propagates new blocks across the network. It maintains a full record of the blockchain state. Erigon is an execution client.
+- **Full Node:** A node that holds a complete copy of all block data, from the genesis block to the current head. It retains recent state, all blocks post-Merge, and prunes ancient blocks and state (EIP-4444 enabled). It verifies every block and state transition. See [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes).
+- **Go (Golang)**: The open-source programming language used to develop Erigon, known for its performance, concurrency, and efficiency.
+- **Gnosis Chain:** A stable, community-owned EVM-compatible chain that uses a PoS consensus mechanism. Erigon has specific optimizations and troubleshooting steps for Gnosis Chain due to its large transaction history. See the [Gnosis Chain Node](https://docs.erigon.tech/get-started/easy-nodes/how-to-run-a-gnosis-chain-node) guide.
+- **JSON RPC**: JSON Remote Procedure Call. A lightweight protocol used by Ethereum clients to communicate with applications (like wallets or block explorers) over HTTP or WebSockets. See [Interacting with Erigon](https://docs.erigon.tech/interacting-with-erigon) for the full API reference.
+- **head:** The most recent block in the blockchain.
+- **Minimal Node**: A node that retains the minimum amount of data necessary to function, typically by heavily pruning historical state data to significantly save disk space. See [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes).
+- **MDBX:** The high-performance, key-value database that Erigon uses to store blockchain data. It is a more efficient and scalable alternative to the databases used by other clients.
+- **Merkle Patricia Trie:** A data structure used by most Ethereum clients (like Geth) to store the blockchain state. It is highly secure but can be less space-efficient than MDBX.
+- **Mempool:** A pool of unconfirmed transactions that have been submitted to the network but have not yet been included in a block.
+- **MCP Server:** The Model Context Protocol server built into Erigon that exposes blockchain data to AI assistants. See [MCP Server](https://docs.erigon.tech/fundamentals/mcp) (v3.4+).
+- **Node:** A piece of software that runs on a computer and interacts with the blockchain network. It can be a full node, light node, or validator node.
+- **OOM-kill:** An event where the operating system's "Out of Memory" killer terminates a process (e.g., Erigon) that is consuming too much memory. See [Hardware Requirements](https://docs.erigon.tech/get-started/hardware-requirements) for recommended RAM specs.
+- **Peer:** Another node on the network that your client is connected to. The more healthy peers you have, the more reliable your connection is. See [Default Ports](https://docs.erigon.tech/fundamentals/default-ports) for P2P port configuration.
+- **Pruning:** The process of removing older, unnecessary data from the blockchain to save disk space. Erigon offers different pruning modes (full, minimal, archive) to suit various needs. See [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes).
+- **rpcdaemon:** A separate, lightweight process in Erigon that handles JSON RPC API requests. This design allows Erigon to continue syncing efficiently even under heavy RPC load. See [RPC Daemon](https://docs.erigon.tech/fundamentals/modules/rpc-daemon).
+- **Snapshot Sync:** A rapid synchronization method that downloads a pre-made snapshot of the blockchain state and then syncs the remaining blocks. This is much faster than syncing from the genesis block. See [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes).
+- **Staged Sync:** Erigon's unique synchronization model. It processes the blockchain in a series of logical stages, such as downloading headers, verifying bodies, and building the state, to maximize speed and efficiency. See [Pruning Modes](https://docs.erigon.tech/fundamentals/pruning-modes).
+- **Validator:** A participant in a Proof-of-Stake network who has staked the network token and is responsible for proposing and attesting to new blocks. See [Caplin](https://docs.erigon.tech/staking/caplin) and [External Consensus Client](https://docs.erigon.tech/staking/external-consensus-client-as-validator).
 
 ---

--- a/llms.txt
+++ b/llms.txt
@@ -4,7 +4,7 @@
 > modularity, and minimal disk footprint. It features an integrated consensus layer
 > (Caplin), BitTorrent-based historical data distribution, and fast node synchronization.
 
-The text of every page listed below is also available as a single file: [llms-full.txt](https://docs.erigon.tech/llms-full.txt). Pages are cleaned for machine reading: MDX components are stripped, and a card-grid landing page is reduced to the list of links its grids contain.
+The text of every page listed below is also available as a single file: [llms-full.txt](https://docs.erigon.tech/llms-full.txt). Pages are cleaned for machine reading: text comes from the built site, so components are expanded and links resolved, and a card-grid landing page keeps its prose with each grid rendered as a link list.
 
 - [Introduction](https://docs.erigon.tech/): Official documentation for Erigon — the efficient, modular Ethereum execution client. Get started, explore the JSON-RPC API, and learn how to run a full or archive node.
 


### PR DESCRIPTION
Reads page text from the built site instead of parsing MDX.

The generator reproduced by hand what MDX renders, to recover the landing pages' card grids.
Docusaurus has already done that by build time — components expanded, links absolute, variables
substituted, the body in one `<article>` — so page bodies come from there. Landing-page prose now
survives: `synthesize_landing` had replaced any page holding `lp-card` with a bare list of its
links. Mermaid draws client-side, so its fence is spliced back from source.

Two costs. `--check` reads `docs/site/build`, so it runs after `npm run build` — editing a page then
checking without rebuilding reports a false pass. And it warns rather than fails when only the
Erigon release differs, since the build resolves it from the Releases API.
