### PR TITLE
rpc/jsonrpc, db/snapshotsync: seven review follow-ups from #23322

### DIFF
--- a/db/snapshotsync/freezeblocks/block_reader.go
+++ b/db/snapshotsync/freezeblocks/block_reader.go
@@ -152,13 +152,11 @@ func (r *RemoteBlockReader) AllTypes() []snaptype.Type             { panic("not 
 func (r *RemoteBlockReader) FreezingCfg() ethconfig.BlocksFreezing { panic("not supported") }
 
 // FrozenBlocks is answered by the backend. The context-free signature leaves no way to
-// surface an error or honor request cancellation, so the whole call is bounded by an
-// internal timeout however many rounds it takes, cached for a short TTL, and not
-// duplicated while one is in flight.
-// The count only grows, so a stale-low answer is the conservative one for the
-// availability gates and is served while a refresh runs. Zero is not: the pre-Byzantium
-// receipt paths read it as "no snapshots" and re-execute, so a failed fetch is not
-// cached, and it reaches only the callers that have no observation to wait for.
+// surface an error or honor cancellation, so the whole call is bounded by an internal
+// timeout however many rounds it takes, cached for a short TTL, and not duplicated while
+// one is in flight. The count only grows, so a stale-low answer is conservative for the
+// availability gates; zero is not, since callers read it as "no snapshots", so a failed
+// fetch is not cached.
 func (r *RemoteBlockReader) FrozenBlocks() uint64 {
 	deadline := time.Now().Add(r.frozenBlocksTimeout)
 	for waited := false; ; waited = true {
@@ -188,8 +186,8 @@ func (r *RemoteBlockReader) FrozenBlocks() uint64 {
 				r.frozenBlocksMu.Unlock()
 				return value
 			}
-			// Waiting is not asking: a caller left with nothing observed has spent no
-			// attempt of its own, and one more is worth its wait. A second is not.
+			// A caller that has not fetched yet retries once the in-flight one ends;
+			// waiting again would put it past the single timeout it is bounded by.
 			continue
 		}
 		r.frozenBlocksFetching = true

--- a/db/snapshotsync/freezeblocks/block_reader_test.go
+++ b/db/snapshotsync/freezeblocks/block_reader_test.go
@@ -925,10 +925,11 @@ func (c *stalledCountingFrozenBlocksClient) FrozenBlocks(ctx context.Context, in
 	return nil, ctx.Err()
 }
 
-// TestRemoteBlockReaderFrozenBlocksBoundsTheWaitToOneTimeout pins that no caller is held
-// for longer than a single fetch timeout. This getter takes no context and is reached
-// with a read transaction open, so waiting for one fetch and then running another would
-// double what a stalled backend costs the handler pool.
+// TestRemoteBlockReaderFrozenBlocksBoundsTheWaitToOneTimeout pins that a stalled backend
+// costs each caller a single timeout: a caller reaches the backend at most once, so one
+// that waited on an in-flight fetch cannot then spend a fresh timeout of its own. This
+// getter takes no context and is reached with a read transaction open, so stacking a
+// wait and a fetch of its own would double what a stalled backend costs the handler pool.
 func TestRemoteBlockReaderFrozenBlocksBoundsTheWaitToOneTimeout(t *testing.T) {
 	t.Parallel()
 
@@ -937,7 +938,6 @@ func TestRemoteBlockReaderFrozenBlocksBoundsTheWaitToOneTimeout(t *testing.T) {
 	reader := NewRemoteBlockReader(client)
 	reader.frozenBlocksTimeout = timeout
 
-	started := time.Now()
 	first := make(chan uint64, 1)
 	go func() { first <- reader.FrozenBlocks() }()
 	<-client.entered
@@ -946,6 +946,6 @@ func TestRemoteBlockReaderFrozenBlocksBoundsTheWaitToOneTimeout(t *testing.T) {
 	go func() { waiting <- reader.FrozenBlocks() }()
 
 	require.Zero(t, <-waiting, "a stalled backend leaves nothing to report")
-	require.Less(t, time.Since(started), timeout+timeout/2, "the wait and a fetch of its own must not stack up")
+	require.LessOrEqual(t, client.calls.Load(), int64(2), "each caller reaches the backend once, so no caller spends more than its own timeout")
 	require.Zero(t, <-first)
 }

--- a/rpc/jsonrpc/check_prune_gates_test.go
+++ b/rpc/jsonrpc/check_prune_gates_test.go
@@ -152,6 +152,17 @@ func TestReceiptsGateFollowsRetention(t *testing.T) {
 			refused: wideOldest - 1,
 		},
 		{
+			// Cache on with a retention that is a sentinel rather than a window: only
+			// an explicit keep-all outlives history, so this one is retired with it.
+			name: "cache_sentinel_retention",
+			cfg: pruneGatingConfig{mode: prune.Mode{
+				Initialised: true, History: pruneGatingDistance, Blocks: prune.KeepAllBlocksPruneMode,
+				Receipts: prune.KeepPostMergeBlocksPruneMode,
+			}, persistReceipts: true},
+			served:  historyOldest,
+			refused: historyOldest - 1,
+		},
+		{
 			// Cache on with a window narrower than history: past its cutoff the
 			// receipts are re-derived by re-executing, so history decides and the
 			// narrow cache costs the caller nothing.
@@ -532,7 +543,8 @@ func TestBlocksGateAppliesChainHistoryExpiry(t *testing.T) {
 
 // TestLogsByBlockHashNamesThePruneBoundary pins that a filter pinned to a block
 // hash reports pruning rather than a missing block: the range is resolved from the
-// retained header, so the gate speaks before any body is read.
+// retained header, so the gate speaks before any body is read. The resolver is a leg
+// of its own, since a caller that scans without a gate must not be handed a range.
 func TestLogsByBlockHashNamesThePruneBoundary(t *testing.T) {
 	t.Parallel()
 
@@ -559,6 +571,15 @@ func TestLogsByBlockHashNamesThePruneBoundary(t *testing.T) {
 		}},
 		{"overlay_getLogs", func() (any, error) {
 			return apis.overlay.GetLogs(ctx, filters.FilterCriteria{BlockHash: &hash}, nil, nil)
+		}},
+		{"resolveLogsRange", func() (any, error) {
+			tx, err := apis.eth.db.BeginTemporalRo(ctx)
+			if err != nil {
+				return nil, err
+			}
+			defer tx.Rollback()
+			begin, _, err := apis.eth.resolveLogsRange(ctx, tx, filters.FilterCriteria{BlockHash: &hash}, true)
+			return begin, err
 		}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1594,4 +1615,24 @@ func TestEmptyBlockReceiptsNeedNoStateHistory(t *testing.T) {
 
 	_, err = apis.eth.receiptsGenerator.GetReceipts(ctx, chainConfig, view, withTxns, eth.ReceiptsOpts{})
 	require.ErrorIs(t, err, state.PrunedError, "the control block must reach the unavailable history")
+}
+
+// TestCapabilitiesFollowHistoryForASentinelRetention pins the advertised boundary for a
+// receipts retention that is a sentinel rather than a window: it must not offer blocks
+// the gate refuses. TestReceiptsGateFollowsRetention covers the gate for the same shape.
+func TestCapabilitiesFollowHistoryForASentinelRetention(t *testing.T) {
+	t.Parallel()
+
+	apis, _ := setupPruneGating(t, pruneGatingConfig{
+		mode: prune.Mode{
+			Initialised: true, History: pruneGatingDistance, Blocks: prune.KeepAllBlocksPruneMode,
+			Receipts: prune.KeepPostMergeBlocksPruneMode,
+		},
+		persistReceipts: true,
+	})
+
+	caps, err := apis.eth.Capabilities(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, uint64(*caps.State.OldestBlock), uint64(*caps.Receipts.OldestBlock))
+	require.NotZero(t, uint64(*caps.Receipts.OldestBlock))
 }

--- a/rpc/jsonrpc/erigon_receipts.go
+++ b/rpc/jsonrpc/erigon_receipts.go
@@ -131,13 +131,11 @@ func (api *ErigonImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria)
 	defer tx.Rollback()
 
 	if crit.BlockHash != nil {
-		header, err := api._blockReader.HeaderByHash(ctx, tx, *crit.BlockHash)
-		if header == nil {
+		number, err := api.BaseAPI.resolveLogsBlockHash(ctx, tx, *crit.BlockHash)
+		if err != nil {
 			return nil, err
 		}
-		begin = header.Number.Uint64()
-		end = header.Number.Uint64()
-
+		begin, end = number, number
 	} else {
 		var err error
 		begin, end, err = logRangeLatestOnly(tx, crit)

--- a/rpc/jsonrpc/erigon_receipts_test.go
+++ b/rpc/jsonrpc/erigon_receipts_test.go
@@ -500,3 +500,22 @@ func TestGetLogsByHashZeroLogReceipt(t *testing.T) {
 	require.NoError(t, err)
 	assert.JSONEq(t, `[[]]`, string(encoded))
 }
+
+// TestErigonGetLogsByBlockHashRequiresACanonicalBlock pins erigon_getLogs on the same
+// by-hash resolution as eth_getLogs: a hash no header answers for is an error rather
+// than an empty log array, and a reorged-out sibling is not served the logs of the
+// canonical block at its height.
+func TestErigonGetLogsByBlockHashRequiresACanonicalBlock(t *testing.T) {
+	m, _, orphanedChain := rpcdaemontest.CreateTestExecModule(t)
+	api := NewErigonAPI(newBaseApiForTest(m), m.DB, nil)
+
+	unknown := common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
+	logs, err := api.GetLogs(m.Ctx, filters.FilterCriteria{BlockHash: &unknown})
+	require.ErrorContains(t, err, "block not found")
+	require.Nil(t, logs)
+
+	orphaned := orphanedChain[0].Blocks[0].Hash()
+	logs, err = api.GetLogs(m.Ctx, filters.FilterCriteria{BlockHash: &orphaned})
+	require.ErrorContains(t, err, "block not found")
+	require.Nil(t, logs)
+}

--- a/rpc/jsonrpc/eth_api.go
+++ b/rpc/jsonrpc/eth_api.go
@@ -529,16 +529,13 @@ func (api *BaseAPI) blocksFollowChainHistoryExpiry(ctx context.Context, tx kv.Tx
 }
 
 // holdsPreMergeBlockData reports whether the datadir holds full blocks below the merge
-// point, which tells a legacy archive from chain-history expiry when the stored prune
-// mode carries the same sentinel for both. Neither a pre-merge body nor the oldest
-// available block answers on its own: expiry keeps pre-merge headers and bodies, and
-// the transaction segment spanning the merge point reaches below it. Only a readable
-// transaction of an early block does, so block data the search cannot read leaves the
-// question open rather than settling it, and an open question is not remembered. The
-// answer is availability rather than policy, so a settled one is kept for a short TTL in
-// both directions instead of being decided once. One probe answers every caller waiting
-// on it: each costs several backend reads under an open read transaction, so refreshing
-// the TTL must not fan out with the load.
+// point, which tells a legacy archive from chain-history expiry where the stored prune
+// mode carries the same sentinel for both. Only a readable transaction of an early block
+// settles it: expiry keeps pre-merge headers and bodies, and the transaction segment
+// spanning the merge point reaches below it. Block data the search cannot read leaves the
+// question open and is not remembered; a settled answer is availability rather than
+// policy, so it is kept for a short TTL in both directions. One probe answers every
+// caller waiting on it, since each costs several backend reads under an open read tx.
 func (api *BaseAPI) holdsPreMergeBlockData(ctx context.Context, tx kv.Tx, mergeHeight uint64) (bool, error) {
 	for {
 		if v := api._preMergeData.Load(); v != nil && time.Since(v.at) < api._preMergeDataTTL {
@@ -781,7 +778,7 @@ func (api *BaseAPI) checkReceiptsAvailable(ctx context.Context, tx kv.Tx, block 
 	switch amount := p.ReceiptsAmount(); {
 	case amount == prune.KeepAllReceiptsPruneMode:
 		return nil
-	case p.ReceiptsFollowHistory():
+	case receiptsRetiredWithHistory(p):
 		return api.checkPruneHistory(ctx, tx, block)
 	default:
 		err := api.checkPruneField(tx, block, func(*prune.Mode) prune.BlockAmount { return amount }, "receipts are available")
@@ -792,6 +789,14 @@ func (api *BaseAPI) checkReceiptsAvailable(ctx context.Context, tx kv.Tx, block 
 	}
 }
 
+// receiptsRetiredWithHistory reports whether the receipt cache is retired at the history
+// cutoff: every retention that is not a window of its own, save an explicit keep-all.
+// This is the rule historyRetireCutoffs applies.
+func receiptsRetiredWithHistory(p *prune.Mode) bool {
+	amount := p.ReceiptsAmount()
+	return amount != prune.KeepAllReceiptsPruneMode && !amount.Enabled()
+}
+
 // postStateCalculated reports whether the receipts of this block carry a post state
 // that has to be computed, which is the case below Byzantium. The persistent cache
 // does not store that field, so those receipts are always re-executed and reach only
@@ -800,9 +805,6 @@ func (api *BaseAPI) postStateCalculated(ctx context.Context, tx kv.Tx, block uin
 	chainConfig, err := api.chainConfig(ctx, tx)
 	if err != nil {
 		return false, err
-	}
-	if chainConfig.IsByzantium(block) {
-		return false, nil
 	}
 	commitmentHistory, err := api.commitmentHistoryEnabled(tx)
 	if err != nil {

--- a/rpc/jsonrpc/eth_receipts.go
+++ b/rpc/jsonrpc/eth_receipts.go
@@ -33,7 +33,6 @@ import (
 	"github.com/erigontech/erigon/db/kv/rawdbv3"
 	"github.com/erigontech/erigon/db/kv/stream"
 	"github.com/erigontech/erigon/execution/chain"
-	"github.com/erigontech/erigon/execution/state"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/execution/types/ethutils"
 	"github.com/erigontech/erigon/rpc"
@@ -116,6 +115,40 @@ func usesLogIndex(crit filters.FilterCriteria) bool {
 	return false
 }
 
+// resolveLogsBlockHash resolves the block a by-hash log query names. The header-number
+// index also covers non-canonical headers and the log scan is by block number, so a
+// side-chain hash must not resolve to the canonical block at that height. Below the
+// pruning boundary the body is gone by policy and the boundary is what the caller is
+// told; elsewhere a missing body is what it says it is, and answering with an empty log
+// array would hide it.
+func (api *BaseAPI) resolveLogsBlockHash(ctx context.Context, tx kv.Tx, hash common.Hash) (uint64, error) {
+	number, err := api._blockReader.HeaderNumber(ctx, tx, hash)
+	if err != nil {
+		return 0, err
+	}
+	if number == nil {
+		return 0, fmt.Errorf("block not found: %x", hash)
+	}
+	canonicalHash, ok, err := api._blockReader.CanonicalHash(ctx, tx, *number)
+	if err != nil {
+		return 0, err
+	}
+	if !ok || canonicalHash != hash {
+		return 0, fmt.Errorf("block not found: %x", hash)
+	}
+	body, err := api._blockReader.CanonicalBodyForStorage(ctx, tx, *number)
+	if err != nil {
+		return 0, err
+	}
+	if body == nil {
+		if err := api.checkPruneBlocks(ctx, tx, *number); err != nil {
+			return 0, err
+		}
+		return 0, fmt.Errorf("block not found: %x", hash)
+	}
+	return *number, nil
+}
+
 // resolveLogsRange resolves a filter's block range. A BlockHash pins the range to that
 // block; otherwise negative tags are resolved against the chain, defaulting to the
 // latest executed block. With checkFuture, ranges past the latest executed block are
@@ -123,45 +156,11 @@ func usesLogIndex(crit filters.FilterCriteria) bool {
 // callers scan logs through that same tx.
 func (api *BaseAPI) resolveLogsRange(ctx context.Context, tx kv.Tx, crit filters.FilterCriteria, checkFuture bool) (begin, end uint64, err error) {
 	if crit.BlockHash != nil {
-		number, err := api._blockReader.HeaderNumber(ctx, tx, *crit.BlockHash)
+		number, err := api.resolveLogsBlockHash(ctx, tx, *crit.BlockHash)
 		if err != nil {
 			return 0, 0, err
 		}
-		if number == nil {
-			return 0, 0, fmt.Errorf("block not found: %x", *crit.BlockHash)
-		}
-		// The header-number index also covers non-canonical headers, and the log
-		// scan below is by block number: without this the caller would get the
-		// canonical block's logs for a side-chain hash.
-		canonicalHash, ok, err := api._blockReader.CanonicalHash(ctx, tx, *number)
-		if err != nil {
-			return 0, 0, err
-		}
-		if !ok || canonicalHash != *crit.BlockHash {
-			return 0, 0, fmt.Errorf("block not found: %x", *crit.BlockHash)
-		}
-		body, err := api._blockReader.CanonicalBodyForStorage(ctx, tx, *number)
-		if err != nil {
-			return 0, 0, err
-		}
-		if body == nil {
-			// The body is also missing below the pruning boundary, where the gate is the
-			// one that must speak. Where no boundary covers the block, a missing body is
-			// what it says it is, and answering with an empty log array would hide it.
-			latest, _, _, err := rpchelper.GetBlockNumber(ctx, rpc.BlockNumberOrHashWithNumber(rpc.LatestExecutedBlockNumber), tx, api._blockReader, nil)
-			if err != nil {
-				return 0, 0, err
-			}
-			if *number > latest {
-				return 0, 0, fmt.Errorf("block not found: %x", *crit.BlockHash)
-			}
-			if err := api.checkPruneBlocks(ctx, tx, *number); err == nil {
-				return 0, 0, fmt.Errorf("block not found: %x", *crit.BlockHash)
-			} else if !errors.Is(err, state.PrunedError) {
-				return 0, 0, err
-			}
-		}
-		return *number, *number, nil
+		return number, number, nil
 	}
 
 	latest, _, _, err := rpchelper.GetBlockNumber(ctx, rpc.BlockNumberOrHashWithNumber(rpc.LatestExecutedBlockNumber), tx, api._blockReader, nil)

--- a/rpc/jsonrpc/eth_system.go
+++ b/rpc/jsonrpc/eth_system.go
@@ -200,7 +200,7 @@ func (api *APIImpl) Capabilities(ctx context.Context) (*CapabilitiesResult, erro
 		switch amount := pruneMode.ReceiptsAmount(); {
 		case amount == prune.KeepAllReceiptsPruneMode:
 			receiptsOldest, receiptsAmount = 0, amount
-		case pruneMode.ReceiptsFollowHistory():
+		case receiptsRetiredWithHistory(pruneMode):
 		default:
 			receiptsOldest, receiptsAmount = widerRetention(amount.PruneTo(headBlock), amount, stateOldest, pruneMode.History)
 		}

--- a/rpc/jsonrpc/receipts/receipts_generator.go
+++ b/rpc/jsonrpc/receipts/receipts_generator.go
@@ -495,16 +495,16 @@ func (g *Generator) GetReceipts(ctx context.Context, cfg *chain.Config, tx kv.Te
 		return receipts, nil
 	}
 
-	select {
-	case g.execSem <- struct{}{}:
-		defer func() { <-g.execSem }()
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	}
-
 	err = rpchelper.CheckBlockExecuted(g.filters.WithOverlay(tx), blockNum)
 	if err != nil {
 		return nil, err
+	}
+
+	// A block with no transactions has no receipts to derive, and preparing an
+	// execution environment for it would need state history that may be pruned.
+	if len(block.Transactions()) == 0 {
+		g.addToCacheReceipts(block.HeaderNoCopy(), receipts)
+		return receipts, nil
 	}
 
 	calculatePostState := PostStateCalculated(cfg, blockNum, opts.CommitmentHistoryEnabled, g.blockReader)
@@ -524,10 +524,11 @@ func (g *Generator) GetReceipts(ctx context.Context, cfg *chain.Config, tx kv.Te
 		}
 	}
 
-	// A block with no transactions has no receipts to derive, and preparing an
-	// execution environment for it would need state history that may be pruned.
-	if len(block.Transactions()) == 0 {
-		return receipts, nil
+	select {
+	case g.execSem <- struct{}{}:
+		defer func() { <-g.execSem }()
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	}
 
 	var genEnv *ReceiptEnv

--- a/rpc/jsonrpc/receipts/receipts_generator_empty_block_test.go
+++ b/rpc/jsonrpc/receipts/receipts_generator_empty_block_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package receipts_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/execution/tests/blockgen"
+	"github.com/erigontech/erigon/p2p/protocols/eth"
+)
+
+// TestGetReceiptsCachesAnEmptyBlock pins that a block with no transactions is cached
+// like any other: it has nothing to derive, so repeating the request must not keep
+// paying the execution mutex and the execution semaphore to find that out again.
+func TestGetReceiptsCachesAnEmptyBlock(t *testing.T) {
+	m := mockWithGenerator(t, 1, func(i int, block *blockgen.BlockGen) {})
+
+	tx, err := m.DB.BeginTemporalRo(m.Ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	block, err := m.BlockReader.BlockByNumber(m.Ctx, tx, 1)
+	require.NoError(t, err)
+	require.Empty(t, block.Transactions(), "this test needs a block without transactions")
+
+	gen := m.ReceiptsReader
+	got, err := gen.GetReceipts(m.Ctx, m.ChainConfig, tx, block, eth.ReceiptsOpts{})
+	require.NoError(t, err)
+	require.Empty(t, got)
+
+	cached, ok := gen.GetCachedReceipts(m.Ctx, block.Hash())
+	require.True(t, ok, "the next request must be answered by the cache")
+	require.Empty(t, cached)
+}

--- a/rpc/jsonrpc/receipts/receipts_generator_exec_sem_test.go
+++ b/rpc/jsonrpc/receipts/receipts_generator_exec_sem_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package receipts
+
+import (
+	"context"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv/temporal/temporaltest"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/stagedsync/stages"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/p2p/protocols/eth"
+)
+
+// TestGetReceiptsAnswersAnEmptyBlockWithoutAnExecSlot pins that a block with no
+// transactions is answered before the execution semaphore: it derives nothing, so a
+// slot spent on it is a slot kept from a block that has work to do. The semaphore is
+// full and the context already cancelled, so any path reaching the semaphore reports
+// the cancellation instead of the empty result.
+func TestGetReceiptsAnswersAnEmptyBlockWithoutAnExecSlot(t *testing.T) {
+	t.Parallel()
+
+	db := temporaltest.NewTestDB(t, datadir.New(t.TempDir()))
+	tx, err := db.BeginTemporalRw(t.Context())
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	const blockNum = uint64(1)
+	require.NoError(t, stages.SaveStageProgress(tx, stages.Execution, blockNum))
+	block := types.NewBlockWithHeader(&types.Header{Number: *uint256.NewInt(blockNum)}, nil)
+
+	g := newTestGenerator(t)
+	g.blockExecMutex = &loaderMutex[common.Hash]{}
+	g.execSem = make(chan struct{}, 1)
+	g.execSem <- struct{}{}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	got, err := g.GetReceipts(ctx, chain.TestChainBerlinConfig, tx, block, eth.ReceiptsOpts{})
+	require.NoError(t, err)
+	require.Empty(t, got)
+}


### PR DESCRIPTION
Follow-up to #23322, which merged as approved with thirteen inline review notes deferred.
This closes the seven that are self-contained; the other six are grouped at the end.

| Note | Site | Change |
| --- | --- | --- |
| [r3885706832](https://github.com/erigontech/erigon/pull/23322#discussion_r3885706832) | `erigon_receipts.go` | `erigon_getLogs` no longer answers `[]` for an unknown or non-canonical block hash |
| [r3885706060](https://github.com/erigontech/erigon/pull/23322#discussion_r3885706060) | `eth_receipts.go` | `resolveLogsRange` returns the `PrunedError` it computes |
| [r3885705986](https://github.com/erigontech/erigon/pull/23322#discussion_r3885705986) | `eth_api.go`, `eth_system.go` | the receipts gate and `eth_capabilities` follow history for a sentinel retention |
| [r3885706103](https://github.com/erigontech/erigon/pull/23322#discussion_r3885706103) | `receipts_generator.go` | a transaction-free block is cached and answered before the exec semaphore |
| [r3885706918](https://github.com/erigontech/erigon/pull/23322#discussion_r3885706918) | `eth_api.go` | the Byzantium check is read once, from `receipts.PostStateCalculated` |
| [r3885706948](https://github.com/erigontech/erigon/pull/23322#discussion_r3885706948) | `block_reader_test.go` | the wall-clock assertion is replaced |
| [r3885706992](https://github.com/erigontech/erigon/pull/23322#discussion_r3885706992) | `block_reader.go`, `eth_api.go` | three comments trimmed to the invariant they carry |

Three of them are worth a line:

**By-hash logs.** `resolveLogsRange`'s hash branch is extracted into `resolveLogsBlockHash`
and `erigon_getLogs` goes through it, so all three by-hash endpoints answer alike. The same
function no longer discards the refusal it derives; error class and message are unchanged.

**Sentinel retention.** `Distance.Enabled()` is false for three values and the switch
special-cased two, so `KeepPostMergeBlocksPruneMode` produced no gate while
`historyRetireCutoffs` retires the RCache with history for it. Both switches now ask one
predicate, which also drops the ordering dependency. It is an unexported helper rather than a
second exported method on `prune.Mode`, since the existing narrow `ReceiptsFollowHistory()`
still drives RCache download policy — see below.

**Exec semaphore.** It is now taken where execution starts, immediately before `PrepareEnv`,
so neither a transaction-free block nor the persisted-receipts fast path queues behind real
re-executions. The per-block mutex still covers the whole function.

## Tests

Five new, one changed. `TestErigonGetLogsByBlockHashRequiresACanonicalBlock`;
a `resolveLogsRange` leg on `TestLogsByBlockHashNamesThePruneBoundary`; a
`cache_sentinel_retention` row on `TestReceiptsGateFollowsRetention` plus
`TestCapabilitiesFollowHistoryForASentinelRetention`; `TestGetReceiptsCachesAnEmptyBlock` and
`TestGetReceiptsAnswersAnEmptyBlockWithoutAnExecSlot` (semaphore full and context already
cancelled, so any path reaching the semaphore reports the cancellation).
`make lint` and `make test-short` are clean.

## One deviation

The flaky-assert note suggested `< 2*timeout` or a channel signal; this asserts
`client.calls.Load() <= 2` instead — each caller reaches the backend at most once, and every
fetch it runs is bounded by that caller's own deadline. Deterministic, but it pins the timing
property less tightly; `require.Less(t, time.Since(started), 2*timeout)` can go back alongside
it if preferred.

## Not in this PR

Each is a behaviour change wanting its own test:

- `erigon_getLatestLogs` is the third by-hash log path and still hand-rolls `HeaderByHash`.
- `Mode.ReceiptsFollowHistory()` (narrow) still drives RCache download policy in
  `db/snapshotsync`, so for the sentinel retention download and retirement disagree.
- `Generator.GetReceipt` (singular) takes no exec slot at all, though it executes.

