### PR TITLE
[r3.6] execution/state: judge EIP-161 emptiness by fields, not a create marker

### DIFF
--- a/execution/state/eip161_empty_created_account_test.go
+++ b/execution/state/eip161_empty_created_account_test.go
@@ -1,0 +1,180 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/execution/tracing"
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+// emptinessScenario drives an account through a lifecycle and reports the
+// EIP-161 verdict. Each scenario runs on both the versioned and the serial
+// path, which must agree.
+type emptinessScenario struct {
+	name  string
+	steps func(t *testing.T, ibs *IntraBlockState, addr accounts.Address)
+	want  bool
+}
+
+// emptinessMode is one of the state configurations that must agree.
+type emptinessMode struct {
+	name      string
+	versioned bool
+}
+
+var emptinessModes = []emptinessMode{
+	{"serial", false},
+	{"versioned", true},
+}
+
+func runEmptiness(t *testing.T, mode emptinessMode, sc emptinessScenario, addr accounts.Address) bool {
+	t.Helper()
+
+	reader := NewNoopReader()
+	var ibs *IntraBlockState
+	if mode.versioned {
+		ibs = NewWithVersionMap(reader, NewVersionMap(nil))
+	} else {
+		ibs = New(reader)
+	}
+	defer ibs.Release(false)
+	ibs.SetTxContext(0, 0)
+	ibs.SetVersion(0)
+
+	sc.steps(t, ibs, addr)
+
+	empty, err := ibs.Empty(addr)
+	require.NoError(t, err)
+	return empty
+}
+
+// TestEmptyAccountLifecycle pins the EIP-161 emptiness predicate
+// across the account lifecycle on the versioned (parallel) path.
+//
+// EIP-161 defines empty purely by fields — no code, zero nonce, zero balance —
+// so materializing an account must not change the verdict. createObject records
+// SelfDestructPath=false for every account it materializes, and reading that
+// write as evidence of a self-destruct made every freshly created empty account
+// report non-empty for the rest of the transaction. That suppresses the
+// EIP-8037 account-creation state gas on a later value-bearing CALL to the
+// same address, so the two clients disagree on gas and diverge (issue #23670).
+//
+// The self-destruct cases are the control: they are what the gate exists for
+// under EIP-6780 and must keep reporting non-empty.
+func TestEmptyAccountLifecycle(t *testing.T) {
+	t.Parallel()
+
+	code := []byte{0x60, 0x00}
+
+	scenarios := []emptinessScenario{
+		{
+			name:  "untouched absent account is empty",
+			steps: func(*testing.T, *IntraBlockState, accounts.Address) {},
+			want:  true,
+		},
+		{
+			name: "materialized account with empty fields is empty",
+			steps: func(t *testing.T, ibs *IntraBlockState, addr accounts.Address) {
+				require.NoError(t, ibs.CreateAccount(addr, false))
+			},
+			want: true,
+		},
+		{
+			name: "materialized account holding balance is not empty",
+			steps: func(t *testing.T, ibs *IntraBlockState, addr accounts.Address) {
+				require.NoError(t, ibs.CreateAccount(addr, false))
+				require.NoError(t, ibs.SetBalance(addr, *uint256.NewInt(1), tracing.BalanceChangeUnspecified))
+			},
+			want: false,
+		},
+		{
+			name: "contract self-destructed in this tx is not empty",
+			steps: func(t *testing.T, ibs *IntraBlockState, addr accounts.Address) {
+				require.NoError(t, ibs.CreateAccount(addr, true))
+				require.NoError(t, ibs.SetCode(addr, code, tracing.CodeChangeUnspecified))
+				_, err := ibs.Selfdestruct(addr, false)
+				require.NoError(t, err)
+			},
+			want: false,
+		},
+		{
+			name: "self-destruct then recreate falls back to the recreated fields",
+			steps: func(t *testing.T, ibs *IntraBlockState, addr accounts.Address) {
+				require.NoError(t, ibs.CreateAccount(addr, true))
+				require.NoError(t, ibs.SetCode(addr, code, tracing.CodeChangeUnspecified))
+				_, err := ibs.Selfdestruct(addr, false)
+				require.NoError(t, err)
+				require.NoError(t, ibs.CreateAccount(addr, false))
+			},
+			want: true,
+		},
+		{
+			name: "recreate then self-destruct again is not empty",
+			steps: func(t *testing.T, ibs *IntraBlockState, addr accounts.Address) {
+				require.NoError(t, ibs.CreateAccount(addr, true))
+				require.NoError(t, ibs.SetCode(addr, code, tracing.CodeChangeUnspecified))
+				_, err := ibs.Selfdestruct(addr, false)
+				require.NoError(t, err)
+				require.NoError(t, ibs.CreateAccount(addr, true))
+				require.NoError(t, ibs.SetCode(addr, code, tracing.CodeChangeUnspecified))
+				_, err = ibs.Selfdestruct(addr, false)
+				require.NoError(t, err)
+			},
+			want: false,
+		},
+		{
+			name: "reverted recreate leaves the self-destruct standing",
+			steps: func(t *testing.T, ibs *IntraBlockState, addr accounts.Address) {
+				require.NoError(t, ibs.CreateAccount(addr, true))
+				require.NoError(t, ibs.SetCode(addr, code, tracing.CodeChangeUnspecified))
+				_, err := ibs.Selfdestruct(addr, false)
+				require.NoError(t, err)
+				snap := ibs.PushSnapshot()
+				require.NoError(t, ibs.CreateAccount(addr, true))
+				require.NoError(t, ibs.SetCode(addr, code, tracing.CodeChangeUnspecified))
+				ibs.RevertToSnapshot(snap, nil)
+			},
+			want: false,
+		},
+		{
+			name: "reverted self-destruct leaves the account judged by its fields",
+			steps: func(t *testing.T, ibs *IntraBlockState, addr accounts.Address) {
+				require.NoError(t, ibs.CreateAccount(addr, false))
+				snap := ibs.PushSnapshot()
+				_, err := ibs.Selfdestruct(addr, false)
+				require.NoError(t, err)
+				ibs.RevertToSnapshot(snap, nil)
+			},
+			want: true,
+		},
+	}
+
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			t.Parallel()
+			for _, mode := range emptinessModes {
+				addr := toAddr([]byte(sc.name + mode.name))
+				require.Equal(t, sc.want, runEmptiness(t, mode, sc, addr), mode.name)
+			}
+		})
+	}
+}

--- a/execution/vm/runtime/eip161_empty_account_gas_test.go
+++ b/execution/vm/runtime/eip161_empty_account_gas_test.go
@@ -1,0 +1,175 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package runtime
+
+import (
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/protocol/params"
+	"github.com/erigontech/erigon/execution/state"
+	"github.com/erigontech/erigon/execution/tests/testutil"
+	"github.com/erigontech/erigon/execution/tracing"
+	"github.com/erigontech/erigon/execution/types/accounts"
+	"github.com/erigontech/erigon/execution/vm"
+)
+
+// emptinessForks pairs a fork with the charge a value transfer to an
+// EIP-161-empty account owes on it: the flat 25000 before Amsterdam, the
+// EIP-8037 state-gas equivalent from Amsterdam on.
+var emptinessForks = []struct {
+	name       string
+	cfg        *chain.Config
+	newAcctGas uint64
+}{
+	{"Osaka", chain.TestChainOsakaConfig, params.CallNewAccountGas},
+	{"Amsterdam", chain.AllProtocolChanges, uint64(params.StateGasNewAccount)},
+}
+
+// callTo emits a CALL to target forwarding 10000 gas with no calldata.
+// CALL pops gas, address, value, argsOffset, argsSize, retOffset, retSize, so
+// the pushes run in reverse.
+func callTo(target byte, value byte) []byte {
+	return []byte{
+		byte(vm.PUSH1), 0x00, // retSize
+		byte(vm.PUSH1), 0x00, // retOffset
+		byte(vm.PUSH1), 0x00, // argsSize
+		byte(vm.PUSH1), 0x00, // argsOffset
+		byte(vm.PUSH1), value,
+		byte(vm.PUSH1), target,
+		byte(vm.PUSH2), 0x27, 0x10, // gas
+		byte(vm.CALL),
+		byte(vm.POP),
+	}
+}
+
+// runProgram deploys code at a funded contract on the parallel-execution path
+// and reports the gas the call consumed along with its return data.
+func runProgram(t *testing.T, code []byte, cfg *chain.Config) (uint64, []byte) {
+	t.Helper()
+
+	db := testutil.TemporalDB(t)
+	tx, domains := testutil.TemporalTxSD(t, db)
+	reader := state.NewReaderV3(domains.AsGetter(tx))
+	statedb := state.NewWithVersionMap(reader, state.NewVersionMap(nil))
+	defer statedb.Release(false)
+
+	contract := accounts.InternAddress(common.HexToAddress("0x2000"))
+	require.NoError(t, statedb.SetCode(contract, code, tracing.CodeChangeUnspecified))
+	require.NoError(t, statedb.SetBalance(contract, *uint256.NewInt(1_000), tracing.BalanceChangeUnspecified))
+
+	const gasLimit = uint64(2_000_000)
+	ret, gasRemaining, err := Call(contract, nil, &Config{
+		ChainConfig: cfg,
+		GasLimit:    gasLimit,
+		State:       statedb,
+	})
+	require.NoError(t, err)
+	return gasLimit - gasRemaining.Total(), ret
+}
+
+// TestCallChargesNewAccount pins the
+// new-account charge against the emptiness predicate that gates it.
+//
+// A zero-value CALL to a precompile materializes its account (evm.call skips
+// the EIP-161 zero-value short-circuit for precompiles), but the account stays
+// empty by EIP-161 — zero balance, zero nonce, empty code — so a later
+// value-bearing CALL to it still creates state and still owes the charge.
+// Reading createObject's SelfDestructPath=false marker as a self-destruct made
+// Empty() report false and dropped it, which is what let a preceding zero-value
+// call make the whole transaction cheaper.
+func TestCallChargesNewAccount(t *testing.T) {
+	t.Parallel()
+
+	for _, fork := range emptinessForks {
+		t.Run(fork.name, func(t *testing.T) {
+			t.Parallel()
+			for _, target := range []byte{0x01, 0x02, 0x03, 0x04, 0x42} {
+				t.Run(common.Bytes2Hex([]byte{target}), func(t *testing.T) {
+					t.Parallel()
+
+					valueCallOnly := append(callTo(target, 0x01), byte(vm.STOP))
+					zeroThenValueCall := append(append(callTo(target, 0x00), callTo(target, 0x01)...), byte(vm.STOP))
+
+					control, _ := runProgram(t, valueCallOnly, fork.cfg)
+					warmed, _ := runProgram(t, zeroThenValueCall, fork.cfg)
+
+					require.GreaterOrEqual(t, control, fork.newAcctGas,
+						"a value transfer to an absent account must be charged account creation")
+					require.GreaterOrEqual(t, warmed, fork.newAcctGas,
+						"materializing the account first must not waive the account-creation charge")
+					require.Greater(t, warmed, control,
+						"adding a zero-value call must not make the transaction cheaper")
+				})
+			}
+		})
+	}
+}
+
+// TestExtCodeHashEmptyAccount pins EIP-1052: EXTCODEHASH of an
+// empty account is 0. A materializing zero-value CALL must not change that —
+// judging the account non-empty made EXTCODEHASH fall through to the code hash
+// and return the hash of empty code instead of zero.
+func TestExtCodeHashEmptyAccount(t *testing.T) {
+	t.Parallel()
+
+	for _, fork := range emptinessForks {
+		t.Run(fork.name, func(t *testing.T) {
+			t.Parallel()
+
+			code := append(callTo(0x02, 0x00),
+				byte(vm.PUSH1), 0x02, byte(vm.EXTCODEHASH),
+				byte(vm.PUSH1), 0x00, byte(vm.MSTORE),
+				byte(vm.PUSH1), 0x20, byte(vm.PUSH1), 0x00, byte(vm.RETURN))
+
+			_, ret := runProgram(t, code, fork.cfg)
+			require.Equal(t, make([]byte, 32), ret,
+				"EXTCODEHASH of an empty account is 0, even after a call materialized it")
+		})
+	}
+}
+
+// TestSelfdestructChargesNewAccount pins the
+// SELFDESTRUCT beneficiary-creation charge against the same predicate: sending
+// a non-zero balance to an EIP-161-empty beneficiary creates state and owes the
+// charge, whether or not an earlier call materialized the account.
+func TestSelfdestructChargesNewAccount(t *testing.T) {
+	t.Parallel()
+
+	for _, fork := range emptinessForks {
+		t.Run(fork.name, func(t *testing.T) {
+			t.Parallel()
+
+			destructOnly := []byte{byte(vm.PUSH1), 0x02, byte(vm.SELFDESTRUCT)}
+			callThenDestruct := append(callTo(0x02, 0x00), byte(vm.PUSH1), 0x02, byte(vm.SELFDESTRUCT))
+
+			control, _ := runProgram(t, destructOnly, fork.cfg)
+			warmed, _ := runProgram(t, callThenDestruct, fork.cfg)
+
+			require.GreaterOrEqual(t, control, params.CreateBySelfdestructGas,
+				"SELFDESTRUCT to an empty beneficiary must be charged account creation")
+			require.GreaterOrEqual(t, warmed, params.CreateBySelfdestructGas,
+				"materializing the beneficiary first must not waive the charge")
+			require.Greater(t, warmed, control,
+				"adding a zero-value call must not make the transaction cheaper")
+		})
+	}
+}


### PR DESCRIPTION
Cherry-pick of #23672 to release/3.6.

## r3.6-specific adaptations

- Dropped the production hunk in execution/state/intra_block_state.go. This branch never added the SelfDestructPath presence gate from main, so it already judges materialized accounts by their EIP-161 fields; the imported regression tests pass without a production change.
- Adapted the tests to release/3.6 APIs: serial and versioned modes, Release(false), and SharedDomains.AsGetter.

Validation:
- go test -count=1 ./execution/state -run ^TestEmptyAccountLifecycle$
- go test -count=1 ./execution/vm/runtime -run ^(TestCallChargesNewAccount|TestExtCodeHashEmptyAccount|TestSelfdestructChargesNewAccount)$
- make lint (repeated, clean)
- make erigon integration