### PR TITLE
execution/stagedsync: wait for the blocking writer after a validator-invalid

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2579,15 +2579,13 @@ type feeMerge struct {
 	version state.Version
 }
 
-// requeueInvalid re-queues a tx whose read set the validator rejected. When the
-// writer that overwrote the cell is known and can still deliver a wakeup, the tx
-// waits for it; otherwise it is deferred, since a validator-invalid may instead
-// be race-induced (a worker racing an exec-loop flush) with no blocker to name.
+// requeueInvalid waits for the writer that overwrote the tx's read set, and
+// defers when addDependency cannot register a wait: the blocker may be unknown
+// (a race with an exec-loop flush names none) or already complete.
 func (be *blockExecutor) requeueInvalid(tx int, blocker int) {
-	if blocker != state.UnknownDep && be.execTasks.addDependency(blocker, tx) {
-		return
+	if !be.execTasks.addDependency(blocker, tx) {
+		be.execTasks.pushDeferred(tx)
 	}
-	be.execTasks.pushDeferred(tx)
 }
 
 // recordWorkerWrites installs a worker result's write set and drops the fee

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2579,11 +2579,11 @@ type feeMerge struct {
 	version state.Version
 }
 
-// requeueInvalid waits for the writer that overwrote the tx's read set, and
-// defers when addDependency cannot register a wait: the blocker may be unknown
-// (a race with an exec-loop flush names none) or already complete.
-func (be *blockExecutor) requeueInvalid(tx int, blocker int) {
-	if !be.execTasks.addDependency(blocker, tx) {
+// requeueInvalid waits for the writer that overwrote the tx's read set. It
+// defers instead when addDependency cannot register a wait, which is the common
+// case: the writer is usually unknown, and a named one is often already done.
+func (be *blockExecutor) requeueInvalid(tx int, blockerTxIndex int) {
+	if !be.execTasks.addDependency(blockerTxIndex+1, tx) {
 		be.execTasks.pushDeferred(tx)
 	}
 }

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2579,6 +2579,17 @@ type feeMerge struct {
 	version state.Version
 }
 
+// requeueInvalid re-queues a tx whose read set the validator rejected. When the
+// writer that overwrote the cell is known and can still deliver a wakeup, the tx
+// waits for it; otherwise it is deferred, since a validator-invalid may instead
+// be race-induced (a worker racing an exec-loop flush) with no blocker to name.
+func (be *blockExecutor) requeueInvalid(tx int, blocker int) {
+	if blocker != state.UnknownDep && be.execTasks.addDependency(blocker, tx) {
+		return
+	}
+	be.execTasks.pushDeferred(tx)
+}
+
 // recordWorkerWrites installs a worker result's write set and drops the fee
 // credit with it: the credit belongs to the incarnation this result replaces.
 func (be *blockExecutor) recordWorkerWrites(txVersion state.Version, writes *state.WriteSet) {
@@ -2925,12 +2936,14 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 			be.recordFeeMerge(txVersion, existingWrites, tipWrites, outcome)
 		}
 
+		blocker := state.UnknownDep
 		validity := be.versionMap.ValidateVersion(txVersion.TxIndex, be.blockIO,
 			func(readVersion, writtenVersion state.Version) state.VersionValidity {
 				vv := state.VersionValid
 
 				if readVersion != writtenVersion {
 					vv = state.VersionInvalid
+					blocker = writtenVersion.TxIndex
 				} else if writtenVersion.TxIndex == state.UnknownDep && tx-1 > be.validateTasks.maxComplete() {
 					vv = state.VersionTooEarly
 				}
@@ -3110,9 +3123,7 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 			be.validateTasks.pushPendingSet(be.execTasks.getRevalidationRange(tx + 1))
 			be.validateTasks.clearInProgress(tx) // clear in progress - pending will be added again once new incarnation executes
 			be.execTasks.clearComplete(tx)
-			// Defer: validator-invalid may be race-induced (worker raced an
-			// exec-loop flush). Drain predicate in scheduleExecution waits.
-			be.execTasks.pushDeferred(tx)
+			be.requeueInvalid(tx, blocker)
 			be.preValidated[tx] = false
 			be.txIncarnations[tx]++
 			if r := be.tooManyRetries(tx, txVersion.TxIndex, "validator-invalid", nil); r != nil {

--- a/execution/stagedsync/exec3_parallel_test.go
+++ b/execution/stagedsync/exec3_parallel_test.go
@@ -2016,13 +2016,13 @@ func TestRequeueInvalid(t *testing.T) {
 		require.False(t, be.execTasks.checkPending(5), "a blocked tx must not be dispatchable")
 	})
 
-	t.Run("blocker unblocks the dependent when it completes", func(t *testing.T) {
+	t.Run("waits on the exec task of the blocking tx index, one above it", func(t *testing.T) {
 		be := newExec(8)
 
 		be.requeueInvalid(5, 2)
-		be.execTasks.setInProgress(2)
-		be.execTasks.markComplete(2)
-		be.execTasks.removeDependency(2)
+		be.execTasks.setInProgress(3)
+		be.execTasks.markComplete(3)
+		be.execTasks.removeDependency(3)
 
 		require.False(t, be.execTasks.isBlocked(5))
 		require.True(t, be.execTasks.checkPending(5), "tx must be re-dispatched once its blocker completes")

--- a/execution/stagedsync/exec3_parallel_test.go
+++ b/execution/stagedsync/exec3_parallel_test.go
@@ -1999,3 +1999,63 @@ func TestParallelBlockEndLogsCountEachSyscallOnce(t *testing.T) {
 
 	assert.Len(t, txResult.Logs, syscalls)
 }
+
+func TestRequeueInvalid(t *testing.T) {
+	newExec := func(size int) (*blockExecutor, *execStatusList) {
+		be := &blockExecutor{}
+		be.execTasks.ensureLen(size)
+		return be, &be.execTasks
+	}
+
+	t.Run("known blocker is waited on, not respeculated", func(t *testing.T) {
+		be, m := newExec(8)
+
+		be.requeueInvalid(5, 2)
+
+		require.True(t, m.isBlocked(5), "tx must wait for the writer that invalidated its read")
+		require.False(t, m.checkPending(5), "a blocked tx must not be dispatchable")
+	})
+
+	t.Run("blocker unblocks the dependent when it completes", func(t *testing.T) {
+		be, m := newExec(8)
+
+		be.requeueInvalid(5, 2)
+		m.setInProgress(2)
+		m.markComplete(2)
+		m.removeDependency(2)
+
+		require.False(t, m.isBlocked(5))
+		require.True(t, m.checkPending(5), "tx must be re-dispatched once its blocker completes")
+	})
+
+	t.Run("unknown blocker falls back to deferred", func(t *testing.T) {
+		be, m := newExec(8)
+
+		be.requeueInvalid(5, state.UnknownDep)
+
+		require.False(t, m.isBlocked(5))
+		m.drainDeferred()
+		require.True(t, m.checkPending(5))
+	})
+
+	t.Run("already-complete blocker falls back to deferred", func(t *testing.T) {
+		be, m := newExec(8)
+		m.setComplete(2)
+
+		be.requeueInvalid(5, 2)
+
+		require.False(t, m.isBlocked(5), "a completed blocker cannot deliver a wakeup")
+		m.drainDeferred()
+		require.True(t, m.checkPending(5))
+	})
+
+	t.Run("blocker at or above the dependent falls back to deferred", func(t *testing.T) {
+		be, m := newExec(8)
+
+		be.requeueInvalid(5, 5)
+
+		require.False(t, m.isBlocked(5))
+		m.drainDeferred()
+		require.True(t, m.checkPending(5))
+	})
+}

--- a/execution/stagedsync/exec3_parallel_test.go
+++ b/execution/stagedsync/exec3_parallel_test.go
@@ -2001,61 +2001,40 @@ func TestParallelBlockEndLogsCountEachSyscallOnce(t *testing.T) {
 }
 
 func TestRequeueInvalid(t *testing.T) {
-	newExec := func(size int) (*blockExecutor, *execStatusList) {
+	newExec := func(size int) *blockExecutor {
 		be := &blockExecutor{}
 		be.execTasks.ensureLen(size)
-		return be, &be.execTasks
+		return be
 	}
 
 	t.Run("known blocker is waited on, not respeculated", func(t *testing.T) {
-		be, m := newExec(8)
+		be := newExec(8)
 
 		be.requeueInvalid(5, 2)
 
-		require.True(t, m.isBlocked(5), "tx must wait for the writer that invalidated its read")
-		require.False(t, m.checkPending(5), "a blocked tx must not be dispatchable")
+		require.True(t, be.execTasks.isBlocked(5), "tx must wait for the writer that invalidated its read")
+		require.False(t, be.execTasks.checkPending(5), "a blocked tx must not be dispatchable")
 	})
 
 	t.Run("blocker unblocks the dependent when it completes", func(t *testing.T) {
-		be, m := newExec(8)
+		be := newExec(8)
 
 		be.requeueInvalid(5, 2)
-		m.setInProgress(2)
-		m.markComplete(2)
-		m.removeDependency(2)
+		be.execTasks.setInProgress(2)
+		be.execTasks.markComplete(2)
+		be.execTasks.removeDependency(2)
 
-		require.False(t, m.isBlocked(5))
-		require.True(t, m.checkPending(5), "tx must be re-dispatched once its blocker completes")
+		require.False(t, be.execTasks.isBlocked(5))
+		require.True(t, be.execTasks.checkPending(5), "tx must be re-dispatched once its blocker completes")
 	})
 
-	t.Run("unknown blocker falls back to deferred", func(t *testing.T) {
-		be, m := newExec(8)
+	t.Run("unwaitable blocker falls back to deferred", func(t *testing.T) {
+		be := newExec(8)
 
 		be.requeueInvalid(5, state.UnknownDep)
 
-		require.False(t, m.isBlocked(5))
-		m.drainDeferred()
-		require.True(t, m.checkPending(5))
-	})
-
-	t.Run("already-complete blocker falls back to deferred", func(t *testing.T) {
-		be, m := newExec(8)
-		m.setComplete(2)
-
-		be.requeueInvalid(5, 2)
-
-		require.False(t, m.isBlocked(5), "a completed blocker cannot deliver a wakeup")
-		m.drainDeferred()
-		require.True(t, m.checkPending(5))
-	})
-
-	t.Run("blocker at or above the dependent falls back to deferred", func(t *testing.T) {
-		be, m := newExec(8)
-
-		be.requeueInvalid(5, 5)
-
-		require.False(t, m.isBlocked(5))
-		m.drainDeferred()
-		require.True(t, m.checkPending(5))
+		require.False(t, be.execTasks.isBlocked(5))
+		be.execTasks.drainDeferred()
+		require.True(t, be.execTasks.checkPending(5))
 	})
 }


### PR DESCRIPTION
Mainnet blocks at :00/:30 carry ~1000-1400 txs (median 273) — exchange deposit sweeps. Block 25879019: 1035 of its 1295 txs are USDT transfers to one address, all writing one storage slot. `validateChain` p97 goes 170ms → 950-2000ms on those blocks, identically on n0 and bench-n2.

The serial dependency on that slot is real; the wasted work around it is not. A tx whose read set the validator rejects goes straight to deferred with no dependency registered, so it is re-dispatched speculatively and can lose the same race again — 2.44k executions and 1.13k validation failures for 1295 txs, against 293/64 for a normal 217-tx block.

The validator callback already receives the writing tx's version and discards it. Keep it and wait on that writer, as the abort path already does; fall back to the old deferred path when the blocker is unknown or already complete.

Draft — the end-to-end effect is not measured yet.