### PR TITLE
exec: scope the stale fee-write drop to the fee addresses

### DIFF
--- a/execution/stagedsync/exec3_fee_merge_temp_test.go
+++ b/execution/stagedsync/exec3_fee_merge_temp_test.go
@@ -60,7 +60,7 @@ func TestRecordFeeMerge_FirstMergeKeepsWorkerWrites(t *testing.T) {
 
 	txOut := feeMergeTestWrites(t, addr, 1)
 	tip := feeMergeTestWrites(t, addr, 2)
-	be.recordFeeMerge(version, txOut, tip, feeCreditNew)
+	be.recordFeeMerge(version, txOut, tip, feeCreditNew, [2]accounts.Address{addr})
 	be.superseded.release()
 
 	require.Same(t, tip, be.blockIO.WriteSet(version.TxIndex),
@@ -77,10 +77,10 @@ func TestRecordFeeMerge_RevalidationReleasesSupersededTemp(t *testing.T) {
 	version := state.Version{TxIndex: 0}
 
 	first := feeMergeTestWrites(t, addr, 2)
-	be.recordFeeMerge(version, feeMergeTestWrites(t, addr, 1), first, feeCreditNew)
+	be.recordFeeMerge(version, feeMergeTestWrites(t, addr, 1), first, feeCreditNew, [2]accounts.Address{addr})
 
 	second := feeMergeTestWrites(t, addr, 3)
-	be.recordFeeMerge(version, first, second, feeCreditNew)
+	be.recordFeeMerge(version, first, second, feeCreditNew, [2]accounts.Address{addr})
 	be.superseded.release()
 
 	require.Same(t, second, be.feeMergeTemp[0].writes)
@@ -96,11 +96,11 @@ func TestRecordFeeMerge_AfterReExecutionKeepsStaleTemp(t *testing.T) {
 	version := state.Version{TxIndex: 0}
 
 	stale := feeMergeTestWrites(t, addr, 2)
-	be.recordFeeMerge(version, feeMergeTestWrites(t, addr, 1), stale, feeCreditNew)
+	be.recordFeeMerge(version, feeMergeTestWrites(t, addr, 1), stale, feeCreditNew, [2]accounts.Address{addr})
 
 	reTxOut := feeMergeTestWrites(t, addr, 4)
 	tip := feeMergeTestWrites(t, addr, 5)
-	be.recordFeeMerge(version, reTxOut, tip, feeCreditNew)
+	be.recordFeeMerge(version, reTxOut, tip, feeCreditNew, [2]accounts.Address{addr})
 	be.superseded.release()
 
 	require.Same(t, tip, be.feeMergeTemp[0].writes)
@@ -125,7 +125,7 @@ func TestRecordFeeMerge_NoCreditKeepsWorkerWrites(t *testing.T) {
 			be := feeMergeTestExecutor(t)
 			txOut := feeMergeTestWrites(t, addr, 1)
 			be.recordWorkerWrites(version, txOut)
-			be.recordFeeMerge(version, txOut, nil, tc.outcome)
+			be.recordFeeMerge(version, txOut, nil, tc.outcome, [2]accounts.Address{addr})
 
 			require.Same(t, txOut, be.blockIO.WriteSet(version.TxIndex))
 			require.Nil(t, be.creditedWrites(version, txOut),
@@ -147,7 +147,7 @@ func TestRecordWorkerWrites_DropsCreditedTemp(t *testing.T) {
 		"the worker's own output carries no credit")
 
 	tip := feeMergeTestWrites(t, addr, 2)
-	be.recordFeeMerge(version, txOut, tip, feeCreditNew)
+	be.recordFeeMerge(version, txOut, tip, feeCreditNew, [2]accounts.Address{addr})
 	require.Same(t, tip, be.creditedWrites(version, be.blockIO.WriteSet(version.TxIndex)))
 
 	reTxOut := feeMergeTestWrites(t, addr, 3)
@@ -168,7 +168,7 @@ func TestCreditedWrites_PinsVersion(t *testing.T) {
 	version := state.Version{TxIndex: 0}
 
 	tip := feeMergeTestWrites(t, addr, 2)
-	be.recordFeeMerge(version, feeMergeTestWrites(t, addr, 1), tip, feeCreditNew)
+	be.recordFeeMerge(version, feeMergeTestWrites(t, addr, 1), tip, feeCreditNew, [2]accounts.Address{addr})
 	require.Same(t, tip, be.creditedWrites(version, tip))
 
 	reExecuted := version
@@ -193,10 +193,10 @@ func TestRecordFeeMerge_ReleaseKeepsSharedWrites(t *testing.T) {
 
 	txOut := feeMergeTestWrites(t, shared, 1)
 	temp1 := feeMergeTestWrites(t, fresh, 7)
-	be.recordFeeMerge(version, txOut, temp1, feeCreditNew)
+	be.recordFeeMerge(version, txOut, temp1, feeCreditNew, [2]accounts.Address{shared, fresh})
 
 	tipWrites := feeMergeTestWrites(t, fresh, 9)
-	be.recordFeeMerge(version, temp1, tipWrites, feeCreditNew)
+	be.recordFeeMerge(version, temp1, tipWrites, feeCreditNew, [2]accounts.Address{shared, fresh})
 	be.superseded.release()
 
 	require.True(t, temp1.Released(), "the superseded set's maps must go back to the pool")

--- a/execution/stagedsync/exec3_fee_merge_temp_test.go
+++ b/execution/stagedsync/exec3_fee_merge_temp_test.go
@@ -17,7 +17,9 @@
 package stagedsync
 
 import (
+	"encoding/binary"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/holiman/uint256"
@@ -332,4 +334,54 @@ func TestBlockResult_HandsSupersededToApplyLoop(t *testing.T) {
 		require.True(t, handed.Released())
 		require.False(t, later.Released(), "a set collected after the handoff has no reader releasing it yet")
 	})
+}
+
+func benchFeeDropSets(n int, coinbase accounts.Address) (prev, next *state.WriteSet) {
+	base := &state.WriteSet{}
+	for i := range n {
+		var a common.Address
+		binary.BigEndian.PutUint64(a[12:], uint64(i+1))
+		addr := accounts.InternAddress(a)
+		base.SetBalance(addr, &state.VersionedWrite[uint256.Int]{
+			WriteHeader: state.WriteHeader{Address: addr, Path: state.BalancePath}})
+		base.SetNonce(addr, &state.VersionedWrite[uint64]{
+			WriteHeader: state.WriteHeader{Address: addr, Path: state.NoncePath}})
+		var h common.Hash
+		binary.BigEndian.PutUint64(h[24:], uint64(i+1))
+		key := accounts.InternKey(h)
+		base.SetStorage(addr, key, &state.VersionedWrite[uint256.Int]{
+			WriteHeader: state.WriteHeader{Address: addr, Path: state.StoragePath, Key: key}})
+	}
+	for _, tip := range []**state.WriteSet{&prev, &next} {
+		ws := &state.WriteSet{}
+		ws.SetBalance(coinbase, &state.VersionedWrite[uint256.Int]{
+			WriteHeader: state.WriteHeader{Address: coinbase, Path: state.BalancePath}})
+		ws.SetAddress(coinbase, &state.VersionedWrite[*accounts.Account]{
+			WriteHeader: state.WriteHeader{Address: coinbase, Path: state.AddressPath}, Val: &accounts.Account{}})
+		*tip = base.MergeInto(ws)
+	}
+	// The half of the credit this round stopped emitting.
+	prev.SetSelfDestruct(coinbase, &state.VersionedWrite[bool]{
+		WriteHeader: state.WriteHeader{Address: coinbase, Path: state.SelfDestructPath}, Val: true})
+	return prev, next
+}
+
+// BenchmarkDropStaleVersionedWrites sizes the retraction scan against the tx's
+// own write set: the credit it retracts is the same two addresses either way.
+func BenchmarkDropStaleVersionedWrites(b *testing.B) {
+	coinbase := feeMergeTestAddr("0x7777777777777777777777777777777777777777")
+	burnt := feeMergeTestAddr("0x8888888888888888888888888888888888888888")
+	version := state.Version{TxIndex: 0}
+
+	for _, n := range []int{4, 32, 256} {
+		b.Run(fmt.Sprintf("writes=%d", n*3), func(b *testing.B) {
+			be := feeMergeTestExecutor(b)
+			prev, next := benchFeeDropSets(n, coinbase)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				be.dropStaleVersionedWrites(version, prev, next, [2]accounts.Address{coinbase, burnt})
+			}
+		})
+	}
 }

--- a/execution/stagedsync/exec3_finalize_test.go
+++ b/execution/stagedsync/exec3_finalize_test.go
@@ -1784,7 +1784,8 @@ func (r *feeCreditRound) run(t testing.TB) *state.WriteSet {
 	if outcome == feeCreditNew {
 		credit = copyWrites(tip)
 	}
-	r.be.recordFeeMerge(version, recorded, tip, outcome)
+	r.be.recordFeeMerge(version, recorded, tip, outcome,
+		[2]accounts.Address{r.result.Coinbase, r.result.ExecutionResult.BurntContractAddress})
 	r.vm.FlushVersionedWrites(r.recorded(), true, "")
 	return credit
 }

--- a/execution/stagedsync/exec3_finalize_test.go
+++ b/execution/stagedsync/exec3_finalize_test.go
@@ -1897,6 +1897,32 @@ func TestFeeEntry_RecordedInAcceptsWhatWriteToWrote(t *testing.T) {
 	}
 }
 
+// dropStaleVersionedWrites scans only feeWritePaths, so a path writeTo starts
+// emitting outside that list would leave a retracted credit in the version map
+// with nothing to report it.
+func TestFeeEntry_WriteToStaysWithinFeeWritePaths(t *testing.T) {
+	t.Parallel()
+	version := state.Version{TxIndex: 3, Incarnation: 1}
+	addr := fAddr("credited")
+
+	for _, e := range []*feeEntry{
+		{
+			addr:   addr,
+			acc:    accounts.Account{Balance: *uint256.NewInt(7), Nonce: 2, Incarnation: 1, CodeHash: accounts.EmptyCodeHash},
+			reason: tracing.BalanceIncreaseRewardTransactionFee,
+		},
+		{addr: addr, deleted: true},
+	} {
+		ws := &state.WriteSet{}
+		e.writeTo(ws, version)
+		require.NotZero(t, ws.Count(), "an entry that writes nothing proves nothing")
+		for h := range ws.AllHeaders() {
+			require.Contains(t, feeWritePaths[:], h.Path,
+				"writeTo emits %s, which the stale-credit scan does not look at", h.Path)
+		}
+	}
+}
+
 func TestFeeEntry_NilIsAbsent(t *testing.T) {
 	t.Parallel()
 	var absent *feeEntry

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2148,6 +2148,9 @@ func (e *feeEntry) shapeRecordedIn(ws *state.WriteSet, version state.Version, ad
 	return e.recordedIn(ws, version)
 }
 
+// feeWritePaths are the account paths a fee credit can occupy — see writeTo.
+var feeWritePaths = [...]state.AccountPath{state.AddressPath, state.BalancePath, state.SelfDestructPath}
+
 // hasFeeWrite reports whether ws carries a fee write for addr. The version tells
 // one apart from the worker's own write to the same address: the task version
 // carries a TxNum, a worker's own writes do not.
@@ -2606,7 +2609,7 @@ func (be *blockExecutor) creditedWrites(txVersion state.Version, ws *state.Write
 // and reclaims the merge product it supersedes. Releasing that product is safe
 // because MergeInto shares VersionedWrite pointers rather than the maps holding
 // them, so pooling those maps leaves the merged writes intact.
-func (be *blockExecutor) recordFeeMerge(txVersion state.Version, prev, tipWrites *state.WriteSet, outcome feeOutcome) {
+func (be *blockExecutor) recordFeeMerge(txVersion state.Version, prev, tipWrites *state.WriteSet, outcome feeOutcome, feeAddrs [2]accounts.Address) {
 	if outcome == feeCreditRecorded {
 		return
 	}
@@ -2631,7 +2634,7 @@ func (be *blockExecutor) recordFeeMerge(txVersion state.Version, prev, tipWrites
 	var stale *state.WriteSet
 	if superseded && merged != temp.writes {
 		stale = temp.writes
-		be.dropStaleVersionedWrites(txVersion, stale, merged)
+		be.dropStaleVersionedWrites(txVersion, stale, merged, feeAddrs)
 	}
 	// Record before releasing: until the replacement is recorded, a reader of
 	// this tx's writes still holds the superseded set the release clears.
@@ -2646,13 +2649,19 @@ func (be *blockExecutor) recordFeeMerge(txVersion state.Version, prev, tipWrites
 	}
 }
 
-// dropStaleVersionedWrites removes this tx's version-map entries for the writes
-// prev published and next no longer carries. The recorded set is flushed after
-// every round, so a dropped entry stays visible to later txs until deleted here.
-func (be *blockExecutor) dropStaleVersionedWrites(txVersion state.Version, prev, next *state.WriteSet) {
-	for h := range prev.AllHeaders() {
-		if !next.Has(h) {
-			be.versionMap.Delete(h.Address, h.Path, h.Key, txVersion.TxIndex, false)
+// dropStaleVersionedWrites deletes the fee writes prev published and next no
+// longer carries: every round flushes the recorded set, so they stay visible to
+// later txs until deleted. next holds prev's own base, so nothing else goes stale.
+func (be *blockExecutor) dropStaleVersionedWrites(txVersion state.Version, prev, next *state.WriteSet, feeAddrs [2]accounts.Address) {
+	for _, addr := range feeAddrs {
+		if addr.IsNil() {
+			continue
+		}
+		for _, path := range feeWritePaths {
+			h := state.WriteHeader{Address: addr, Path: path}
+			if prev.Has(h) && !next.Has(h) {
+				be.versionMap.Delete(addr, path, h.Key, txVersion.TxIndex, false)
+			}
 		}
 	}
 }
@@ -2922,7 +2931,8 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 			if err != nil {
 				return nil, err
 			}
-			be.recordFeeMerge(txVersion, existingWrites, tipWrites, outcome)
+			be.recordFeeMerge(txVersion, existingWrites, tipWrites, outcome,
+				[2]accounts.Address{txResult.Coinbase, txResult.ExecutionResult.BurntContractAddress})
 		}
 
 		validity := be.versionMap.ValidateVersion(txVersion.TxIndex, be.blockIO,

--- a/test-fixtures.json
+++ b/test-fixtures.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet%40v8.1.2/fixtures_glamsterdam-devnet.tar.gz",
     "sha256": "aaf9709675f625fbbed4361760c790d44696775dfad7668d0a136ab0776a0659",
     "size": 934610669,
-    "ref": "devnets/glamsterdam/8"
+    "ref": "tests-glamsterdam-devnet@v8.1.2"
   },
   "eest_stable": {
     "url": "https://github.com/ethereum/execution-specs/releases/download/tests%40v20.0.2/fixtures.tar.gz",


### PR DESCRIPTION
`dropStaleVersionedWrites` walked every header of the tx's whole write set (all account maps plus the nested storage map, one `Has` lookup each) to find what a retracted fee credit left in the version map.

`BenchmarkDropStaleVersionedWrites`:

| writes in the tx | before | after | |
|---|---|---|---|
| 12 | 345.6n ± 1% | 36.1n ± 0% | -89.6% |
| 96 | 2093.5n ± 1% | 43.6n ± 1% | -97.9% |
| 768 | 19564.5n ± 1% | 43.8n ± 0% | -99.8% |
