### PR TITLE
cache: remove CodeStore's cache

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -830,7 +830,7 @@ func stageExec(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) error
 	}
 	var execCodeStore *cache.CodeStore
 	if dbg.UseCodeStore {
-		execCodeStore = cache.NewCodeStore(cache.DefaultCodeStoreMemBytes, cache.DefaultCodeStoreTableBytes)
+		execCodeStore = cache.NewCodeStore(cache.DefaultCodeStoreTableBytes)
 	}
 
 	collateAndPrune := func() error {

--- a/common/dbg/experiments.go
+++ b/common/dbg/experiments.go
@@ -140,7 +140,7 @@ var (
 	CaplinEfficientReorg          = EnvBool("CAPLIN_EFFICIENT_REORG", true)
 	UseTxDependencies             = EnvBool("USE_TX_DEPENDENCIES", false)
 	UseStateCache                 = EnvBool("USE_STATE_CACHE", true)
-	UseCodeStore                  = EnvBool("USE_CODE_STORE", true)
+	UseCodeStore                  = EnvBool("USE_CODE_STORE", false)
 	DisableAdaptivePin            = EnvBool("DISABLE_ADAPTIVE_PIN", true)
 	AssertStateCache              = EnvBool("ASSERT_STATE_CACHE", false)
 	ReadAhead                     = EnvBool("READ_AHEAD", true)

--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -1641,7 +1641,7 @@ func (sd *SharedDomains) getCode(tx kv.TemporalTx, view cache.ReadView, addr []b
 			}
 			if sd.codeStore != nil {
 				if cv, ok := sd.codeStore.GetByHash(tx, codeHash); ok {
-					sd.fillCodeCacheByHash(tx, view, cv, codeHash, txNum)
+					sd.fillCodeCacheByHash(tx, view, addr, cv, codeHash, txNum)
 					return cv, true, nil
 				}
 			}
@@ -1662,8 +1662,14 @@ func (sd *SharedDomains) getCode(tx kv.TemporalTx, view cache.ReadView, addr []b
 // fillCodeCacheByHash promotes a code-store hit into the in-memory code cache,
 // the store's only memory tier. txNum is the reader's, an upper bound on the
 // code's write txNum, so an unwind drops the entry no later than the code.
-func (sd *SharedDomains) fillCodeCacheByHash(tx kv.TemporalTx, view cache.ReadView, code, codeHash []byte, txNum uint64) {
+func (sd *SharedDomains) fillCodeCacheByHash(tx kv.TemporalTx, view cache.ReadView, addr, code, codeHash []byte, txNum uint64) {
 	if sd.stateCache == nil {
+		return
+	}
+	// A bounded read observes a staged unwind rather than stable committed state:
+	// the backing still holds the dying rows inside the bound, so the bytes must
+	// not reach the shared cache. Same gate the addr-keyed fill applies.
+	if _, _, maxStep, _ := sd.latestFromMem(kv.CodeDomain, addr); maxStep != kv.NoStepBound {
 		return
 	}
 	if view.NeedsFrontier() {

--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -286,9 +286,9 @@ type SharedDomains struct {
 	// mem; both reach the transaction during flush, which resets the memo.
 	visibleEnds domainVisibleEndMemo
 
-	// codeStore is the optional two-tier (in-mem + MDBX) codehash-keyed code
-	// cache, reached via StateGetter so an addr-keyed reader can serve a
-	// code-by-hash read with the application's authoritative codehash.
+	// codeStore is the optional MDBX-backed codehash-keyed code table, reached
+	// via StateGetter so an addr-keyed reader can serve a code-by-hash read with
+	// the application's authoritative codehash.
 	codeStore *cache.CodeStore
 
 	// changesetMu serializes the exec loop's install of a block's changeset
@@ -1641,6 +1641,7 @@ func (sd *SharedDomains) getCode(tx kv.TemporalTx, view cache.ReadView, addr []b
 			}
 			if sd.codeStore != nil {
 				if cv, ok := sd.codeStore.GetByHash(tx, codeHash); ok {
+					sd.fillCodeCacheByHash(tx, view, cv, codeHash, txNum)
 					return cv, true, nil
 				}
 			}
@@ -1656,6 +1657,19 @@ func (sd *SharedDomains) getCode(tx kv.TemporalTx, view cache.ReadView, addr []b
 		return nil, false, nil
 	}
 	return v, true, nil
+}
+
+// fillCodeCacheByHash promotes a code-store hit into the in-memory code cache,
+// the store's only memory tier. txNum is the reader's, an upper bound on the
+// code's write txNum, so an unwind drops the entry no later than the code.
+func (sd *SharedDomains) fillCodeCacheByHash(tx kv.TemporalTx, view cache.ReadView, code, codeHash []byte, txNum uint64) {
+	if sd.stateCache == nil {
+		return
+	}
+	if view.NeedsFrontier() {
+		view = view.WithFrontier(sd.cacheFrontierFor(tx))
+	}
+	view.FillCodeByHash(code, codeHash, txNum)
 }
 
 // codeHashForAddr returns the Ethereum codeHash for an account, or nil if the

--- a/db/state/execctx/statecache_readfill_test.go
+++ b/db/state/execctx/statecache_readfill_test.go
@@ -825,3 +825,60 @@ func TestGetCode_CodeStoreHitFillsCodeCache(t *testing.T) {
 	require.True(t, ok, "a code-store hit must fill the in-memory code cache")
 	require.Equal(t, code, cached)
 }
+
+// A code-store hit under a staged unwind must not reach the shared cache: the
+// backing still holds the dying rows inside the bound, so the bytes are a
+// dead-fork read. Only the CodeDomain key is bounded here, so the account still
+// resolves and the store path is actually taken.
+func TestGetCode_CodeStoreHitUnderStagedUnwindDoesNotFill(t *testing.T) {
+	t.Parallel()
+
+	const stepSize = uint64(16)
+	ctx := t.Context()
+	db := newTestDb(t, stepSize)
+	codeStore := cache.NewCodeStore(1 << 20)
+
+	addr := make([]byte, 20)
+	addr[0] = 0xc7
+	code := []byte{0x60, 0x05, 0x60, 0x00, 0x55}
+	codeHash := crypto.Keccak256Hash(code)
+	account := accounts.SerialiseV3(&accounts.Account{
+		Nonce:    1,
+		CodeHash: accounts.InternCodeHash(codeHash),
+	})
+
+	seedTx, err := db.BeginTemporalRw(ctx)
+	require.NoError(t, err)
+	defer seedTx.Rollback()
+	seedDomains, err := execctx.NewSharedDomains(ctx, seedTx, log.New())
+	require.NoError(t, err)
+	defer seedDomains.Close()
+	seedDomains.SetCodeStore(codeStore)
+	seedDomains.SetTxNum(20)
+	require.NoError(t, seedDomains.DomainPut(kv.AccountsDomain, seedTx, addr, account, 20, nil))
+	require.NoError(t, seedDomains.DomainPut(kv.CodeDomain, seedTx, addr, code, 20, nil))
+	require.NoError(t, seedDomains.Commit(ctx, seedTx))
+
+	stepBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(stepBytes, ^uint64(1))
+	var diffs [kv.DomainLen][]kv.DomainEntryDiff
+	diffs[kv.CodeDomain] = []kv.DomainEntryDiff{{Key: string(addr) + string(stepBytes)}}
+
+	roTx, err := db.BeginTemporalRo(ctx)
+	require.NoError(t, err)
+	defer roTx.Rollback()
+	stateCache := newSmallStateCache()
+	t.Cleanup(stateCache.Close)
+	sd, err := execctx.NewSharedDomains(ctx, roTx, log.New())
+	require.NoError(t, err)
+	defer sd.Close()
+	sd.BindStateCache(stateCache)
+	sd.SetCodeStore(codeStore)
+	sd.Unwind(10, &diffs)
+
+	_, _, err = sd.GetCode(roTx, addr, 20)
+	require.NoError(t, err)
+
+	_, ok := stateCache.View(nil).GetCodeByHash(codeHash[:])
+	require.False(t, ok, "a bounded in-flight unwind read must not fill the code cache")
+}

--- a/db/state/execctx/statecache_readfill_test.go
+++ b/db/state/execctx/statecache_readfill_test.go
@@ -808,11 +808,18 @@ func TestGetCode_CodeStoreHitFillsCodeCache(t *testing.T) {
 
 	_, ok := stateCache.View(nil).GetCodeByHash(codeHash[:])
 	require.False(t, ok, "the code cache must start cold")
+	codeStore.Stats() // reset, so the counters below cover only the read
 
 	got, ok, err := sd.GetCode(roTx, addr, 20)
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.Equal(t, code, got)
+
+	// The CodeDomain fallback fills the same cache entry, so without this the
+	// assertion below would also hold for a store that missed.
+	hits, misses := codeStore.Stats()
+	require.Equal(t, uint64(1), hits)
+	require.Zero(t, misses)
 
 	cached, ok := stateCache.View(nil).GetCodeByHash(codeHash[:])
 	require.True(t, ok, "a code-store hit must fill the in-memory code cache")

--- a/db/state/execctx/statecache_readfill_test.go
+++ b/db/state/execctx/statecache_readfill_test.go
@@ -539,7 +539,7 @@ func TestGetCode_RejectsParentAccountAboveStagedUnwindBound(t *testing.T) {
 	})
 	require.NoError(t, parent.DomainPut(kv.AccountsDomain, rwTx, addr, deadForkAccount, 40, nil)) // step 2
 
-	codeStore := cache.NewCodeStore(1<<20, 1<<20)
+	codeStore := cache.NewCodeStore(1 << 20)
 	require.NoError(t, codeStore.PutByHash(rwTx, codeHash[:], deadForkCode))
 	child.SetCodeStore(codeStore)
 
@@ -613,7 +613,7 @@ func TestGetCode_RespectsStagedUnwindBound(t *testing.T) {
 	db := newTestDb(t, stepSize)
 	stateCache := newSmallStateCache()
 	t.Cleanup(stateCache.Close)
-	codeStore := cache.NewCodeStore(1<<20, 1<<20)
+	codeStore := cache.NewCodeStore(1 << 20)
 
 	addr := make([]byte, 20)
 	addr[0] = 0xdd
@@ -762,4 +762,59 @@ func TestGuardAggregatorForCache_ApplyOnlySkips(t *testing.T) {
 	f := &fakeForbidder{}
 	execctx.GuardAggregatorForCache(fakeHasAgg{f}, sc)
 	require.False(t, f.called)
+}
+
+// A code-store hit must promote the bytes into the in-memory code cache, which
+// is the store's only memory tier.
+func TestGetCode_CodeStoreHitFillsCodeCache(t *testing.T) {
+	t.Parallel()
+
+	const stepSize = uint64(16)
+	ctx := t.Context()
+	db := newTestDb(t, stepSize)
+	codeStore := cache.NewCodeStore(1 << 20)
+
+	addr := make([]byte, 20)
+	addr[0] = 0xf1
+	code := []byte{0x60, 0x03, 0x60, 0x00, 0x55}
+	codeHash := crypto.Keccak256Hash(code)
+	account := accounts.SerialiseV3(&accounts.Account{
+		Nonce:    1,
+		CodeHash: accounts.InternCodeHash(codeHash),
+	})
+
+	rwTx, err := db.BeginTemporalRw(ctx)
+	require.NoError(t, err)
+	defer rwTx.Rollback()
+	seedDomains, err := execctx.NewSharedDomains(ctx, rwTx, log.New())
+	require.NoError(t, err)
+	defer seedDomains.Close()
+	seedDomains.SetCodeStore(codeStore)
+	seedDomains.SetTxNum(20)
+	require.NoError(t, seedDomains.DomainPut(kv.AccountsDomain, rwTx, addr, account, 20, nil))
+	require.NoError(t, seedDomains.DomainPut(kv.CodeDomain, rwTx, addr, code, 20, nil))
+	require.NoError(t, seedDomains.Commit(ctx, rwTx))
+
+	roTx, err := db.BeginTemporalRo(ctx)
+	require.NoError(t, err)
+	defer roTx.Rollback()
+	stateCache := newSmallStateCache()
+	t.Cleanup(stateCache.Close)
+	sd, err := execctx.NewSharedDomains(ctx, roTx, log.New())
+	require.NoError(t, err)
+	defer sd.Close()
+	sd.BindStateCache(stateCache)
+	sd.SetCodeStore(codeStore)
+
+	_, ok := stateCache.View(nil).GetCodeByHash(codeHash[:])
+	require.False(t, ok, "the code cache must start cold")
+
+	got, ok, err := sd.GetCode(roTx, addr, 20)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, code, got)
+
+	cached, ok := stateCache.View(nil).GetCodeByHash(codeHash[:])
+	require.True(t, ok, "a code-store hit must fill the in-memory code cache")
+	require.Equal(t, code, cached)
 }

--- a/execution/cache/cache_test.go
+++ b/execution/cache/cache_test.go
@@ -1771,3 +1771,29 @@ func BenchmarkPublishVsViewBindLock(b *testing.B) {
 		})
 	}
 }
+
+// TestFillCodeByHash_IgnoresAccountsFrontier pins that a codeHash-only fill is
+// not gated on the accounts frontier. That gate protects the addr binding an
+// addr-keyed fill creates; a content-addressed entry has none, so requiring it
+// would drop promotions for an unrelated domain's view.
+func TestFillCodeByHash_IgnoresAccountsFrontier(t *testing.T) {
+	t.Parallel()
+
+	c := closeOnCleanup(t, NewDefaultStateCache())
+	c.Applier().Initialize(1)
+
+	code := bytes.Repeat([]byte{0x5b}, 48)
+	codeHash := crypto.Keccak256(code)
+
+	noAccountsEnd := FrontierFunc(func(d kv.Domain) (uint64, bool) {
+		if d == kv.AccountsDomain {
+			return 0, false
+		}
+		return 100, true
+	})
+	c.View(FrontierWithStateVersion(noAccountsEnd, 1)).FillCodeByHash(code, codeHash, 20)
+
+	got, ok := c.View(nil).GetCodeByHash(codeHash)
+	require.True(t, ok, "a codeHash-only fill must not need the accounts frontier")
+	require.Equal(t, code, got)
+}

--- a/execution/cache/code_cache.go
+++ b/execution/cache/code_cache.go
@@ -136,10 +136,10 @@ type CodeCache struct {
 	addrToCodeHash *lru.Cache[common.Address, addrCodeHashEntry]
 
 	// codeHashToCode: 32-byte Ethereum codeHash (keccak256) → code bytes. Populated
-	// alongside L2 when the caller provides codeHash on Put, sharing L2's code
-	// slice instead of a second copy. Independent of L1 — Get-by-codeHash
-	// bypasses addr lookup entirely. Also the memory tier of the persistent
-	// CodeStore, which promotes its hits here.
+	// when the caller provides codeHash on Put, sharing L2's slice when the same
+	// Put also binds an address and holding the only copy otherwise. Independent
+	// of L1 — Get-by-codeHash bypasses addr lookup entirely. Also the memory tier
+	// of the persistent CodeStore, which promotes its hits here.
 	codeHashToCode   *growLRU[codeEntry] // keccak(code) → code, jump-grow + LRU-evicting
 	codeHashCodeSize atomic.Int64        // resident bytes (stat; hard bound is the entry cap)
 

--- a/execution/cache/code_cache.go
+++ b/execution/cache/code_cache.go
@@ -136,10 +136,10 @@ type CodeCache struct {
 	addrToCodeHash *lru.Cache[common.Address, addrCodeHashEntry]
 
 	// codeHashToCode: 32-byte Ethereum codeHash (keccak256) → code bytes. Populated
-	// alongside L2 when the caller provides codeHash on Put. Independent
-	// of L1 — Get-by-codeHash bypasses addr lookup entirely. Memory cost:
-	// duplicates code bytes vs L2 (worst case 2x byte storage); accepted
-	// for the per-key fast-path on many-addrs-one-code workloads.
+	// alongside L2 when the caller provides codeHash on Put, sharing L2's code
+	// slice instead of a second copy. Independent of L1 — Get-by-codeHash
+	// bypasses addr lookup entirely. Also the memory tier of the persistent
+	// CodeStore, which promotes its hits here.
 	codeHashToCode   *growLRU[codeEntry] // keccak(code) → code, jump-grow + LRU-evicting
 	codeHashCodeSize atomic.Int64        // resident bytes (stat; hard bound is the entry cap)
 

--- a/execution/cache/code_store.go
+++ b/execution/cache/code_store.go
@@ -20,19 +20,17 @@ import (
 	"bytes"
 	"sync/atomic"
 
-	"github.com/maypok86/otter/v2"
-
 	"github.com/erigontech/erigon/db/kv"
 )
 
-// CodeStore is a two-tier code cache keyed by keccak(code): an in-memory otter
-// tier over a persistent MDBX TblCodeCache backing, both holding DECOMPRESSED
-// code so a hit skips the CodeDomain btree+decompress cost. Content-addressed,
-// so entries are immutable and callers must key by the authoritative account
-// codehash — a wrong codehash can only miss, never return wrong bytes.
+// CodeStore is the persistent tier of the code cache: an MDBX TblCodeCache
+// table keyed by keccak(code) holding DECOMPRESSED code, so a hit skips the
+// CodeDomain btree+decompress cost and survives a restart. The memory tier is
+// CodeCache's codehash layer — a hit here is promoted into it by the caller, so
+// the bytes are resident once. Content-addressed, so entries are immutable and
+// callers must key by the authoritative account codehash — a wrong codehash can
+// only miss, never return wrong bytes.
 type CodeStore struct {
-	mem *otter.Cache[[32]byte, []byte]
-
 	// tableSizeBytes is an in-memory approximation (not rescanned at startup);
 	// Evict prunes the MDBX tier in cursor order, safe since RoTx reads preclude
 	// LRU and entries re-derive from CodeDomain.
@@ -40,67 +38,47 @@ type CodeStore struct {
 	tableSizeBytes atomic.Int64
 	tableSeeded    atomic.Bool
 
-	memHits   atomic.Uint64
-	tableHits atomic.Uint64
-	misses    atomic.Uint64
+	hits   atomic.Uint64
+	misses atomic.Uint64
 }
 
-// Stats returns and resets the (memHits, tableHits, misses) counters.
-func (s *CodeStore) Stats() (memHits, tableHits, misses uint64) {
+// Stats returns and resets the (hits, misses) counters.
+func (s *CodeStore) Stats() (hits, misses uint64) {
 	if s == nil {
-		return 0, 0, 0
+		return 0, 0
 	}
-	return s.memHits.Swap(0), s.tableHits.Swap(0), s.misses.Swap(0)
+	return s.hits.Swap(0), s.misses.Swap(0)
 }
 
-const (
-	DefaultCodeStoreMemBytes   = 256 * 1024 * 1024
-	DefaultCodeStoreTableBytes = 1024 * 1024 * 1024
-)
+const DefaultCodeStoreTableBytes = 1024 * 1024 * 1024
 
-func NewCodeStore(memCapBytes, tableCapBytes uint64) *CodeStore {
-	mem := otter.Must(&otter.Options[[32]byte, []byte]{
-		MaximumWeight: memCapBytes,
-		Weigher:       func(_ [32]byte, code []byte) uint32 { return uint32(len(code)) },
-	})
-	return &CodeStore{mem: mem, tableCapBytes: tableCapBytes}
+func NewCodeStore(tableCapBytes uint64) *CodeStore {
+	return &CodeStore{tableCapBytes: tableCapBytes}
 }
 
-// GetByHash returns decompressed code for codehash, checking the in-memory tier
-// then the MDBX backing (populating the in-memory tier on a backing hit). A miss
-// means the caller must fall through to the authoritative CodeDomain read.
+// GetByHash returns decompressed code for codehash from the MDBX backing. A
+// miss means the caller must fall through to the authoritative CodeDomain read.
 func (s *CodeStore) GetByHash(tx kv.Getter, codeHash []byte) ([]byte, bool) {
 	if s == nil || len(codeHash) != 32 {
 		return nil, false
-	}
-	var key [32]byte
-	copy(key[:], codeHash)
-	if code, ok := s.mem.GetIfPresent(key); ok {
-		s.memHits.Add(1)
-		return code, true
 	}
 	code, err := tx.GetOne(kv.TblCodeCache, codeHash)
 	if err != nil || len(code) == 0 {
 		s.misses.Add(1)
 		return nil, false
 	}
-	// GetOne returns mmap-backed memory that must not outlive the tx; the otter
-	// tier is process-lifetime, so copy before caching/returning (kv contract).
-	code = bytes.Clone(code)
-	s.mem.Set(key, code)
-	s.tableHits.Add(1)
-	return code, true
+	s.hits.Add(1)
+	// GetOne returns mmap-backed memory that must not outlive the tx, while the
+	// code cache the caller promotes this into is process-lifetime (kv contract).
+	return bytes.Clone(code), true
 }
 
-// PutByHash records decompressed code in both tiers. The MDBX write needs an
+// PutByHash records decompressed code in the MDBX backing. The write needs an
 // RwTx, so this runs on the code write path (deploy/commit), not on reads.
 func (s *CodeStore) PutByHash(tx kv.RwTx, codeHash, code []byte) error {
 	if s == nil || len(codeHash) != 32 || len(code) == 0 {
 		return nil
 	}
-	var key [32]byte
-	copy(key[:], codeHash)
-	s.mem.Set(key, code)
 	has, err := tx.Has(kv.TblCodeCache, codeHash)
 	if err != nil {
 		return err

--- a/execution/cache/code_store.go
+++ b/execution/cache/code_store.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"sync/atomic"
 
+	"github.com/c2h5oh/datasize"
+
 	"github.com/erigontech/erigon/db/kv"
 )
 
@@ -27,7 +29,9 @@ import (
 // table keyed by keccak(code) holding DECOMPRESSED code, so a hit skips the
 // CodeDomain btree+decompress cost and survives a restart. The memory tier is
 // CodeCache's codehash layer — a hit here is promoted into it by the caller, so
-// the bytes are resident once. Content-addressed, so entries are immutable and
+// the bytes are resident once. Without a state cache (USE_STATE_CACHE=false)
+// there is no memory tier and every hit costs an MDBX read, still cheaper than
+// the CodeDomain path it replaces. Content-addressed, so entries are immutable and
 // callers must key by the authoritative account codehash — a wrong codehash can
 // only miss, never return wrong bytes.
 type CodeStore struct {
@@ -50,7 +54,7 @@ func (s *CodeStore) Stats() (hits, misses uint64) {
 	return s.hits.Swap(0), s.misses.Swap(0)
 }
 
-const DefaultCodeStoreTableBytes = 1024 * 1024 * 1024
+const DefaultCodeStoreTableBytes = uint64(1 * datasize.GB)
 
 func NewCodeStore(tableCapBytes uint64) *CodeStore {
 	return &CodeStore{tableCapBytes: tableCapBytes}

--- a/execution/cache/code_store_test.go
+++ b/execution/cache/code_store_test.go
@@ -35,21 +35,15 @@ func TestCodeStore_BackingAndEvict(t *testing.T) {
 	code := []byte{0x60, 0x80, 0x60, 0x40, 0x52}
 	hash := crypto.Keccak256(code)
 
-	// Write path populates the MDBX backing.
+	// Write path populates the MDBX backing, which every read then serves.
 	cs := NewCodeStore(1 << 20)
 	require.NoError(t, cs.PutByHash(tx, hash, code))
 	got, ok := cs.GetByHash(tx, hash)
-	require.True(t, ok)
-	require.Equal(t, code, got)
-
-	// A fresh store serves the same bytes from the backing.
-	cs2 := NewCodeStore(1 << 20)
-	got, ok = cs2.GetByHash(tx, hash)
 	require.True(t, ok, "must serve from the persistent TblCodeCache backing")
 	require.Equal(t, code, got)
 
 	// Unknown codehash misses cleanly.
-	_, ok = cs2.GetByHash(tx, crypto.Keccak256([]byte{0xff}))
+	_, ok = cs.GetByHash(tx, crypto.Keccak256([]byte{0xff}))
 	require.False(t, ok)
 
 	// Evict prunes the backing when over the table cap.

--- a/execution/cache/code_store_test.go
+++ b/execution/cache/code_store_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/erigontech/erigon/db/kv/mdbx/mdbxtest"
 )
 
-func TestCodeStore_TwoTierAndEvict(t *testing.T) {
+func TestCodeStore_BackingAndEvict(t *testing.T) {
 	db := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
 	tx, err := db.BeginRw(t.Context())
 	require.NoError(t, err)
@@ -35,15 +35,15 @@ func TestCodeStore_TwoTierAndEvict(t *testing.T) {
 	code := []byte{0x60, 0x80, 0x60, 0x40, 0x52}
 	hash := crypto.Keccak256(code)
 
-	// Write path populates both tiers.
-	cs := NewCodeStore(1<<20, 1<<20)
+	// Write path populates the MDBX backing.
+	cs := NewCodeStore(1 << 20)
 	require.NoError(t, cs.PutByHash(tx, hash, code))
 	got, ok := cs.GetByHash(tx, hash)
 	require.True(t, ok)
 	require.Equal(t, code, got)
 
-	// A fresh store (empty mem) serves from the MDBX backing tier.
-	cs2 := NewCodeStore(1<<20, 1<<20)
+	// A fresh store serves the same bytes from the backing.
+	cs2 := NewCodeStore(1 << 20)
 	got, ok = cs2.GetByHash(tx, hash)
 	require.True(t, ok, "must serve from the persistent TblCodeCache backing")
 	require.Equal(t, code, got)
@@ -53,7 +53,7 @@ func TestCodeStore_TwoTierAndEvict(t *testing.T) {
 	require.False(t, ok)
 
 	// Evict prunes the backing when over the table cap.
-	small := NewCodeStore(1<<20, 128)
+	small := NewCodeStore(128)
 	for i := range 64 {
 		c := []byte{byte(i), byte(i >> 8), 0xaa, 0xbb}
 		require.NoError(t, small.PutByHash(tx, crypto.Keccak256(c), c))
@@ -64,7 +64,7 @@ func TestCodeStore_TwoTierAndEvict(t *testing.T) {
 	// Restart scenario: a fresh store (tableSizeBytes=0) over an already-full
 	// backing must still prune — seed the size from the table, don't grow
 	// unbounded. Without the seed, Evict's under-cap early return would skip.
-	restarted := NewCodeStore(1<<20, 128)
+	restarted := NewCodeStore(128)
 	require.Zero(t, restarted.tableSizeBytes.Load())
 	require.NoError(t, restarted.Evict(tx))
 	require.LessOrEqual(t, restarted.tableSizeBytes.Load(), int64(128),

--- a/execution/cache/state_cache.go
+++ b/execution/cache/state_cache.go
@@ -304,8 +304,12 @@ func (c *StateCache) fillCodeWithHashIfFresh(key, value, codeHash []byte, readTx
 	defer c.admissionMu.RUnlock()
 	if c.publishing ||
 		viewEpoch != c.readViewEpoch.Load() ||
-		visibleEnd < c.appliedEnd[kv.CodeDomain] ||
-		accountsVisibleEnd < c.appliedEnd[kv.AccountsDomain] {
+		visibleEnd < c.appliedEnd[kv.CodeDomain] {
+		return
+	}
+	// Only an addr binding derives from an account record; a codeHash-only entry
+	// does not, so the accounts frontier must not gate it.
+	if len(key) > 0 && accountsVisibleEnd < c.appliedEnd[kv.AccountsDomain] {
 		return
 	}
 	codeCache.PutWithCodeHashIfAbsent(key, value, codeHash, readTxNum)

--- a/execution/cache/view.go
+++ b/execution/cache/view.go
@@ -283,8 +283,11 @@ func (v ReadView) FillCode(addr, code, codeHash []byte, readTxNum uint64) {
 
 // FillCodeByHash offers code resolved by codeHash alone, populating the
 // content-addressed layer without binding it to an address.
+// code must already be owned by the caller — CodeStore.GetByHash clones the
+// mmap-backed value it returns, and the cache stores that one clone rather than
+// copying every cold contract a second time.
 func (v ReadView) FillCodeByHash(code, codeHash []byte, readTxNum uint64) {
-	v.fillCodeWithHash(nil, bytes.Clone(code), codeHash, readTxNum)
+	v.fillCodeWithHash(nil, code, codeHash, readTxNum)
 }
 
 // SeedAddrCodeHash offers an addr → codeHash mapping derived from an account

--- a/execution/cache/view.go
+++ b/execution/cache/view.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"bytes"
+	"math"
 
 	"github.com/erigontech/erigon/db/kv"
 )
@@ -232,9 +233,15 @@ func (v ReadView) fillCodeWithHash(addr, code, codeHash []byte, readTxNum uint64
 	if !ok {
 		return
 	}
-	accountsEnd, ok := v.frontier.DomainVisibleEnd(kv.AccountsDomain)
-	if !ok {
-		return
+	// The accounts frontier gates the addr binding, which a codeHash-only fill
+	// does not create — requiring it there would drop the fill for an unrelated
+	// domain's view.
+	accountsEnd := uint64(math.MaxUint64)
+	if len(addr) > 0 {
+		accountsEnd, ok = v.frontier.DomainVisibleEnd(kv.AccountsDomain)
+		if !ok {
+			return
+		}
 	}
 	v.c.fillCodeWithHashIfFresh(addr, code, codeHash, readTxNum, visibleEnd, accountsEnd, v.readViewEpoch)
 }

--- a/execution/cache/view.go
+++ b/execution/cache/view.go
@@ -281,6 +281,12 @@ func (v ReadView) FillCode(addr, code, codeHash []byte, readTxNum uint64) {
 	v.fillCodeWithHash(addr, bytes.Clone(code), codeHash, readTxNum)
 }
 
+// FillCodeByHash offers code resolved by codeHash alone, populating the
+// content-addressed layer without binding it to an address.
+func (v ReadView) FillCodeByHash(code, codeHash []byte, readTxNum uint64) {
+	v.fillCodeWithHash(nil, bytes.Clone(code), codeHash, readTxNum)
+}
+
 // SeedAddrCodeHash offers an addr → codeHash mapping derived from an account
 // record read from this view, so admission checks the accounts frontier even
 // though the mapping lives in the code cache.

--- a/execution/execmodule/exec_module.go
+++ b/execution/execmodule/exec_module.go
@@ -273,7 +273,7 @@ func NewExecModule(
 	execctx.GuardAggregatorForCache(db, domainCache)
 	var codeStore *cache.CodeStore
 	if dbg.UseCodeStore {
-		codeStore = cache.NewCodeStore(cache.DefaultCodeStoreMemBytes, cache.DefaultCodeStoreTableBytes)
+		codeStore = cache.NewCodeStore(cache.DefaultCodeStoreTableBytes)
 	}
 	forkValidator := newForkValidator(ctx, currentBlockNumber, pipelineExecutor, blockReader, syncCfg.MaxReorgDepth)
 

--- a/execution/execmodule/exec_module.go
+++ b/execution/execmodule/exec_module.go
@@ -226,7 +226,8 @@ type ExecModule struct {
 
 	// stateCache is a cache for state data (accounts, storage, code)
 	stateCache *cache.StateCache
-	// codeStore is the persistent codehash-keyed code cache (in-mem + MDBX backing).
+	// codeStore is the persistent codehash-keyed code table; its memory tier is
+	// the state cache's codehash layer.
 	codeStore   *cache.CodeStore
 	readAheader *exec.BlockReadAheader
 

--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,6 @@ require (
 	github.com/mark3labs/mcp-go v0.58.0
 	github.com/mattn/go-colorable v0.1.15
 	github.com/mattn/go-isatty v0.0.24
-	github.com/maypok86/otter/v2 v2.3.0
 	github.com/miekg/dns v1.1.72
 	github.com/multiformats/go-multiaddr v0.16.1
 	github.com/nyaosorg/go-windows-shortcut v0.0.0-20220529122037-8b0c89bca4c4

--- a/go.sum
+++ b/go.sum
@@ -720,8 +720,6 @@ github.com/mattn/go-isatty v0.0.24/go.mod h1:nMCL3Zebbrt45jsMDgnfIwz6ydEQApk5oEI
 github.com/mattn/go-runewidth v0.0.24 h1:cpokDiIn0MGnhdHwuWnJBITySJ20QyNGnY2kR/ay2DU=
 github.com/mattn/go-runewidth v0.0.24/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/maypok86/otter/v2 v2.3.0 h1:8H8AVVFUSzJwIegKwv1uF5aGitTY+AIrtktg7OcLs8w=
-github.com/maypok86/otter/v2 v2.3.0/go.mod h1:XgIdlpmL6jYz882/CAx1E4C1ukfgDKSaw4mWq59+7l8=
 github.com/mdlayher/netlink v1.7.2 h1:/UtM3ofJap7Vl4QWCPDGXY8d3GIY2UGSDbK+QWmY8/g=
 github.com/mdlayher/netlink v1.7.2/go.mod h1:xraEF7uJbxLhc5fpHL4cPe221LI2bdttWlU+ZGLfQSw=
 github.com/mdlayher/socket v0.5.1 h1:VZaqt6RkGkt2OE9l3GcC6nZkqD3xKeQLyfleW/uBcos=


### PR DESCRIPTION
Removes `CodeStore.mem`, leaving `CodeCache` as the only in-memory code cache. A read served from `kv.TblCodeCache` is promoted into it.

Stacked on #23666, which disables `USE_CODE_STORE` first.