### PR TITLE
ci: pin the glamsterdam-devnet eels simulator to its fixtures tag

### DIFF
--- a/test-fixtures.json
+++ b/test-fixtures.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet%40v8.1.2/fixtures_glamsterdam-devnet.tar.gz",
     "sha256": "aaf9709675f625fbbed4361760c790d44696775dfad7668d0a136ab0776a0659",
     "size": 934610669,
-    "ref": "devnets/glamsterdam/8"
+    "ref": "tests-glamsterdam-devnet@v8.1.2"
   },
   "eest_stable": {
     "url": "https://github.com/ethereum/execution-specs/releases/download/tests%40v20.0.2/fixtures.tar.gz",


### PR DESCRIPTION
The merge queue has been stuck since 08-31 14:57: every run fails `hive-eest / test-hive-eest (glamsterdam-devnet, *)` with 0 passed and ~12900 errored out of 25122.

`eest_devnet` pinned its fixtures immutably (`url` + `sha256`) but its simulator by branch:

```json
"ref": "devnets/glamsterdam/8"
```

That `ref` becomes `--sim.buildarg branch=$eels_ref`, and the run uses `--docker.nocache=true`, so the eels simulator image is rebuilt from that branch's current head every time while the fixtures stay frozen.

`tests-glamsterdam-devnet@v8.1.2` was cut at `50a7f6ecaf`, which was also the branch head — simulator and fixtures were the same commit, and the shard was green. On 2026-08-31T15:58Z the branch advanced to `8ca2f4ceef` ("Merge branch 'forks/amsterdam' into devnets/glamsterdam/8", 82 files, +7389/-9179). Fixtures did not move, so every test now errors at setup.

Comparing the last green job to a failing one: same 25122 items, same hive commit `1c3ad84fba`, same fixtures cache key, same runner image, same erigon tree. The branch is the only input that moved.

Pinning to the tag matches what `eest_stable` already does (`"ref": "tests@v20.0.2"`), which is why only the devnet shard broke. After this, fixtures and simulator can only move together, in one commit.

The cache key is `hashFiles(test-fixtures.json)`, so this is an exact-key miss; `restore-keys` still prefix-matches and the tarball bytes are unchanged, so it re-verifies rather than re-downloads.

I could not run hive locally — this PR's own merge-queue run is the check.