### PR TITLE
ci: update hive to latest commit on ethereum/hive repo

### DIFF
--- a/.github/workflows/hive-versions.json
+++ b/.github/workflows/hive-versions.json
@@ -1,5 +1,5 @@
 {
-  "hive_repository": "taratorio/hive",
-  "hive_ref": "fix/withdrawals-clmock-config",
+  "hive_repository": "ethereum/hive",
+  "hive_ref": "43ea47bef5761351e3da7b726050ea80ab362c52",
   "execution_apis_ref": "f74de4b86e3b011384808c294c3d71f2854729a2"
 }


### PR DESCRIPTION
after https://github.com/ethereum/hive/pull/1604 got upstreamed into ethereum/hive we can switch back to it