### PR TITLE
execution/commitment: fill the account fields a partial update leaves out instead of zeroing them

### DIFF
--- a/execution/commitment/commitment.go
+++ b/execution/commitment/commitment.go
@@ -1665,22 +1665,16 @@ func (t *Updates) TouchAccount(c *KeyUpdate, val []byte) {
 	if err != nil {
 		panic(err)
 	}
-	if c.update.Nonce != acc.Nonce {
-		c.update.Nonce = acc.Nonce
-		c.update.Flags |= NonceUpdate
+	c.update.Nonce = acc.Nonce
+	c.update.Balance.Set(&acc.Balance)
+	if acc.CodeHash.IsEmpty() {
+		c.update.CodeHash = empty.CodeHash
+	} else {
+		c.update.CodeHash = acc.CodeHash.Value()
 	}
-	if !c.update.Balance.Eq(&acc.Balance) {
-		c.update.Balance.Set(&acc.Balance)
-		c.update.Flags |= BalanceUpdate
-	}
-	if acc.CodeHash.Value() != c.update.CodeHash {
-		if acc.CodeHash.IsEmpty() {
-			c.update.CodeHash = empty.CodeHash
-		} else {
-			c.update.Flags |= CodeUpdate
-			c.update.CodeHash = acc.CodeHash.Value()
-		}
-	}
+	// val is the whole account record, so flag every field: a cell may skip its state
+	// read only when the update it was given covers the account completely.
+	c.update.Flags |= BalanceUpdate | NonceUpdate | CodeUpdate
 }
 
 func (t *Updates) TouchStorage(c *KeyUpdate, val []byte) {

--- a/execution/commitment/commitmentdb/commitment_context.go
+++ b/execution/commitment/commitmentdb/commitment_context.go
@@ -1083,14 +1083,13 @@ func (sdc *TrieContext) Account(plainKey []byte) (u *commitment.Update, err erro
 		return nil, err
 	}
 
-	u.Flags |= commitment.NonceUpdate
+	// encAccount is the whole account record, so flag every field: a cell may skip its
+	// state read only when the update it was given covers the account completely. A
+	// zero code hash is the empty one the initialiser already put in u.
+	u.Flags |= commitment.NonceUpdate | commitment.BalanceUpdate | commitment.CodeUpdate
 	u.Nonce = acc.Nonce
-
-	u.Flags |= commitment.BalanceUpdate
 	u.Balance = acc.Balance
-
 	if !acc.CodeHash.IsZero() {
-		u.Flags |= commitment.CodeUpdate
 		u.CodeHash = acc.CodeHash.Value()
 	}
 

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -327,8 +327,13 @@ type loadFlags uint8
 
 const (
 	cellLoadNone    = loadFlags(0)
-	cellLoadAccount = loadFlags(1)
-	cellLoadStorage = loadFlags(2)
+	cellLoadBalance = loadFlags(1)
+	cellLoadNonce   = loadFlags(2)
+	cellLoadCode    = loadFlags(4)
+	cellLoadStorage = loadFlags(8)
+	// An account leaf hashes nonce, balance and code hash together, so a cell counts as
+	// loaded only when all three are known — a partial update leaves the rest to the read.
+	cellLoadAccount = cellLoadBalance | cellLoadNonce | cellLoadCode
 )
 
 // maxCompactKeyLen bounds a compact-encoded (hex-prefix) key or branch prefix,
@@ -347,6 +352,16 @@ func (f loadFlags) String() string {
 	} else {
 		if f.account() {
 			b.WriteString("Account ")
+		} else {
+			if f&cellLoadBalance != 0 {
+				b.WriteString("Balance ")
+			}
+			if f&cellLoadNonce != 0 {
+				b.WriteString("Nonce ")
+			}
+			if f&cellLoadCode != 0 {
+				b.WriteString("Code ")
+			}
 		}
 		if f.storage() {
 			b.WriteString("Storage ")
@@ -356,7 +371,7 @@ func (f loadFlags) String() string {
 }
 
 func (f loadFlags) account() bool {
-	return f&cellLoadAccount != 0
+	return f&cellLoadAccount == cellLoadAccount
 }
 
 func (f loadFlags) storage() bool {
@@ -450,10 +465,48 @@ func (cell *cell) setFromUpdate(update *Update) {
 		cell.loaded = cell.loaded.addFlag(cellLoadStorage)
 		hadToLoad.Add(1)
 	}
-	if update.Flags&BalanceUpdate != 0 || update.Flags&NonceUpdate != 0 || update.Flags&CodeUpdate != 0 {
-		cell.loaded = cell.loaded.addFlag(cellLoadAccount)
+	if acc := accountLoadFlags(update.Flags); acc != cellLoadNone {
+		cell.loaded = cell.loaded.addFlag(acc)
 		hadToLoad.Add(1)
 	}
+}
+
+func accountLoadFlags(f UpdateFlags) loadFlags {
+	var l loadFlags
+	if f&BalanceUpdate != 0 {
+		l |= cellLoadBalance
+	}
+	if f&NonceUpdate != 0 {
+		l |= cellLoadNonce
+	}
+	if f&CodeUpdate != 0 {
+		l |= cellLoadCode
+	}
+	return l
+}
+
+// fillAccountGaps applies a state read to the account fields the cell is still missing.
+// Fields an update already merged in are the post-state the caller committed to and the
+// read can be older, so it may neither overwrite them nor turn the cell into a deletion.
+func (cell *cell) fillAccountGaps(read *Update) {
+	if cell.loaded&cellLoadAccount == cellLoadNone {
+		cell.setFromUpdate(read)
+	} else {
+		gaps := *read
+		gaps.Flags &^= DeleteUpdate
+		if cell.loaded&cellLoadBalance != 0 {
+			gaps.Flags &^= BalanceUpdate
+		}
+		if cell.loaded&cellLoadNonce != 0 {
+			gaps.Flags &^= NonceUpdate
+		}
+		if cell.loaded&cellLoadCode != 0 {
+			gaps.Flags &^= CodeUpdate
+		}
+		cell.setFromUpdate(&gaps)
+	}
+	// The read is the whole account record, whatever subset of it the context flagged.
+	cell.loaded = cell.loaded.addFlag(cellLoadAccount)
 }
 
 func (cell *cell) fillFromUpperCell(upCell *cell, depth, depthIncrement int16) {
@@ -1077,7 +1130,7 @@ func (hph *HexPatriciaHashed) witnessComputeCellHashWithStorage(cell *cell, dept
 			if err != nil {
 				return nil, storageRootHashIsSet, storageRootHash[:], err
 			}
-			cell.setFromUpdate(update)
+			cell.fillAccountGaps(update)
 		}
 
 		valLen := cell.accountForHashing(hph.accValBuf, storageRootHash)
@@ -1230,7 +1283,7 @@ func (hph *HexPatriciaHashed) computeCellHash(cell *cell, depth int16, buf []byt
 			if err != nil {
 				return nil, err
 			}
-			cell.setFromUpdate(update)
+			cell.fillAccountGaps(update)
 		}
 
 		valLen := cell.accountForHashing(hph.accValBuf, storageRootHash)
@@ -2038,9 +2091,7 @@ func (hph *HexPatriciaHashed) loadStateIfNeeded(cell *cell, counters skipStat) (
 			if err != nil {
 				return counters, err
 			}
-			cell.setFromUpdate(upd)
-			// if the update is empty, the loaded flag was not updated so do it manually
-			cell.loaded = cell.loaded.addFlag(cellLoadAccount)
+			cell.fillAccountGaps(upd)
 			counters.accLoaded++
 		}
 		if !cell.loaded.storage() && cell.storageAddrLen > 0 {
@@ -2214,7 +2265,9 @@ func (hph *HexPatriciaHashed) updateCell(plainKey, hashedKey []byte, u *Update) 
 		cell.accountAddrLen = int16(len(plainKey))
 		copy(cell.accountAddr[:], plainKey)
 
+		// The reset throws away whatever code hash the cell held, so it is no longer loaded.
 		cell.CodeHash = empty.CodeHash
+		cell.loaded &^= cellLoadCode
 	} else { // set storage key
 		cell.storageAddrLen = int16(len(plainKey))
 		copy(cell.storageAddr[:], plainKey)
@@ -3015,6 +3068,7 @@ func (hph *HexPatriciaHashed) SetState(buf []byte) error {
 			return err
 		}
 		hph.root.setFromUpdate(update)
+		hph.root.loaded = hph.root.loaded.addFlag(cellLoadAccount)
 	}
 	if hph.root.storageAddrLen > 0 {
 		if hph.ctx == nil {
@@ -3025,6 +3079,7 @@ func (hph *HexPatriciaHashed) SetState(buf []byte) error {
 			return err
 		}
 		hph.root.setFromUpdate(update)
+		hph.root.loaded = hph.root.loaded.addFlag(cellLoadStorage)
 	}
 	// A leaf root's navigation path is derivable but not reliably persisted: without it a
 	// wall probe sees an unfoldable root and the mount paths overwrite the leaf in place.

--- a/execution/commitment/hex_patricia_hashed_test.go
+++ b/execution/commitment/hex_patricia_hashed_test.go
@@ -676,6 +676,61 @@ func TestHexPatriciaHashedLoadStateIfNeededReturnsCounters(t *testing.T) {
 	})
 }
 
+func TestCellPartialAccountUpdateReadsMissingFields(t *testing.T) {
+	t.Parallel()
+
+	addrHex := "00112233445566778899aabbccddeeff00112233"
+	ms := NewMockState(t)
+	plainKeys, updates := NewUpdateBuilder().
+		Balance(addrHex, 7).
+		Nonce(addrHex, 3).
+		Build()
+	require.NoError(t, ms.applyPlainUpdates(plainKeys, updates))
+
+	hph := NewHexPatriciaHashed(length.Addr, ms, DefaultTrieConfig())
+
+	newAccountCell := func(addr []byte) cell {
+		var c cell
+		copy(c.accountAddr[:], addr)
+		c.accountAddrLen = int16(len(addr))
+		c.CodeHash = empty.CodeHash
+		return c
+	}
+
+	t.Run("state fills what the update left out", func(t *testing.T) {
+		c := newAccountCell(common.FromHex("0x" + addrHex))
+		c.setFromUpdate(&Update{Flags: BalanceUpdate, Balance: *uint256.NewInt(11)})
+		require.False(t, c.loaded.account(), "a balance-only update does not load the account")
+
+		_, err := hph.loadStateIfNeeded(&c, skipStat{})
+		require.NoError(t, err)
+		require.True(t, c.loaded.account())
+		require.Equal(t, uint64(3), c.Nonce, "nonce must come from state")
+		require.Equal(t, uint64(11), c.Balance.Uint64(), "the update's balance must outrank the state read")
+	})
+
+	t.Run("hashing a cell fills the gaps too", func(t *testing.T) {
+		c := newAccountCell(common.FromHex("0x" + addrHex))
+		c.setFromUpdate(&Update{Flags: BalanceUpdate, Balance: *uint256.NewInt(11)})
+
+		_, err := hph.computeCellHash(&c, 0, nil)
+		require.NoError(t, err)
+		require.True(t, c.loaded.account(), "one read is enough, the next hash must not repeat it")
+		require.Equal(t, uint64(11), c.Balance.Uint64())
+		require.Equal(t, uint64(3), c.Nonce)
+	})
+
+	t.Run("state without the account does not delete it", func(t *testing.T) {
+		c := newAccountCell(common.FromHex("0xff00000000000000000000000000000000000011"))
+		c.setFromUpdate(&Update{Flags: NonceUpdate, Nonce: 4})
+
+		_, err := hph.loadStateIfNeeded(&c, skipStat{})
+		require.NoError(t, err)
+		require.False(t, c.Deleted(), "an account the update is creating is not in state yet")
+		require.Equal(t, uint64(4), c.Nonce)
+	})
+}
+
 func Test_HexPatriciaHashed_RestoreAndContinue(t *testing.T) {
 	t.Parallel()
 
@@ -1378,8 +1433,6 @@ func sortUpdatesByHashIncrease(t *testing.T, hph *HexPatriciaHashed, plainKeys [
 }
 
 func Test_ModeUpdate_SiblingConsistency(t *testing.T) {
-	// TODO(#20961): untouched sibling cell hashed instead of inlined under ModeUpdate.
-	t.Skip("known parallel-calc sibling-encoding bug, see #20961")
 	t.Parallel()
 	ctx := context.Background()
 
@@ -1446,6 +1499,41 @@ func Test_ModeUpdate_SiblingConsistency(t *testing.T) {
 
 	require.Equal(t, root2Direct, root2Update,
 		"block 2 roots should match — sibling accounts must be encoded consistently")
+}
+
+// A single-account trie keeps its leaf in hph.root across Process calls, so a follow-up
+// block carrying only a balance must still hash the account's real code hash.
+func Test_ModeUpdate_RootLeafKeepsCodeHash(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	const codeHash = "5ea78a5e3cec82b66117982ea93e22a8e0018a9a8adac0ef093ca1aca0e78466"
+
+	root := func(mode Mode) []byte {
+		ms := NewMockState(t)
+		hph := NewHexPatriciaHashed(1, ms, DefaultTrieConfig())
+		defer hph.Release()
+
+		keys1, upds1 := NewUpdateBuilder().
+			Balance("00", 100).
+			Nonce("00", 7).
+			CodeHash("00", codeHash).
+			Build()
+		require.NoError(t, ms.applyPlainUpdates(keys1, upds1))
+		block1 := WrapKeyUpdates(t, mode, KeyToHexNibbleHash, keys1, upds1)
+		defer block1.Close()
+		_, err := hph.Process(ctx, block1, "", nil, WarmupConfig{})
+		require.NoError(t, err)
+
+		keys2, upds2 := NewUpdateBuilder().Balance("00", 150).Build()
+		require.NoError(t, ms.applyPlainUpdates(keys2, upds2))
+		block2 := WrapKeyUpdates(t, mode, KeyToHexNibbleHash, keys2, upds2)
+		defer block2.Close()
+		got, err := hph.Process(ctx, block2, "", nil, WarmupConfig{})
+		require.NoError(t, err)
+		return bytes.Clone(got)
+	}
+
+	require.Equal(t, root(ModeDirect), root(ModeUpdate))
 }
 
 func TestModeUpdatePreservesAccountAcrossStorageFold(t *testing.T) {

--- a/execution/commitment/parallel_patricia_hashed_test.go
+++ b/execution/commitment/parallel_patricia_hashed_test.go
@@ -1001,3 +1001,61 @@ func TestVerifyParallel_StorageIncrementalDeletes(t *testing.T) {
 		requireIncrementalEquiv(t, keys, upds, k2, u2, w)
 	}
 }
+
+// Regression marker for #20961: a follow-up block that carries only part of an
+// account (here a balance write with no nonce write) must not make the trie
+// treat the rest of the account as zero.
+func Test_ModeParallel_SiblingConsistency(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	keys1, upds1 := NewUpdateBuilder().
+		Balance("00", 100).
+		Nonce("00", 1).
+		Balance("01", 200).
+		Nonce("01", 2).
+		Balance("02", 300).
+		Nonce("02", 3).
+		Build()
+	keys2, upds2 := NewUpdateBuilder().
+		Balance("00", 150).
+		Build()
+
+	directMs := NewMockState(t)
+	directTrie := NewHexPatriciaHashed(1, directMs, DefaultTrieConfig())
+	defer directTrie.Release()
+	directRoot := func(keys [][]byte, upds []Update) []byte {
+		require.NoError(t, directMs.applyPlainUpdates(keys, upds))
+		ut := WrapKeyUpdates(t, ModeDirect, KeyToHexNibbleHash, keys, upds)
+		defer ut.Close()
+		return processRoot(t, directTrie, ut)
+	}
+	directRoot(keys1, upds1)
+	wantRoot := directRoot(keys2, upds2)
+
+	parMs := NewMockState(t)
+	parMs.SetConcurrentCommitment(true)
+	parRoot := func(keys [][]byte, upds []Update, blob []byte) ([]byte, []byte) {
+		require.NoError(t, parMs.applyPlainUpdates(keys, upds))
+		tr := NewParallelPatriciaHashed(mockTrieCtxFactory(parMs), 1, DefaultTrieConfig())
+		defer tr.Release()
+		tr.SetNumWorkers(2)
+		tr.ResetContext(parMs)
+		require.NoError(t, tr.RootTrie().SetState(blob))
+		ut := NewUpdates(ModeParallel, t.TempDir(), KeyToHexNibbleHash)
+		defer ut.Close()
+		for i, k := range keys {
+			ut.TouchPlainKeyDirect(string(k), &upds[i])
+		}
+		root, err := tr.Process(ctx, ut, "", nil, WarmupConfig{})
+		require.NoError(t, err)
+		state, err := tr.RootTrie().EncodeCurrentState(nil)
+		require.NoError(t, err)
+		return bytes.Clone(root), state
+	}
+	_, blob := parRoot(keys1, upds1, nil)
+	gotRoot, _ := parRoot(keys2, upds2, blob)
+
+	require.Equal(t, wantRoot, gotRoot,
+		"a carried balance-only update must not zero the account's untouched nonce")
+}

--- a/execution/commitment/patricia_state_mock_test.go
+++ b/execution/commitment/patricia_state_mock_test.go
@@ -116,6 +116,9 @@ func (ms *MockState) Account(plainKey []byte) (*Update, error) {
 		ms.t.Fatalf("GetAccount reading deleted account for key [%x]", plainKey)
 		return nil, nil
 	}
+	// Mirror TrieContext.Account: a domain read yields the whole account record, so it
+	// flags every field. Decode already left CodeHash at empty for a code-less account.
+	ex.Flags |= BalanceUpdate | NonceUpdate | CodeUpdate
 	return &ex, nil
 }
 

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -1889,6 +1889,8 @@ func SetAccountFieldFromAccount(out *WriteSet, addr accounts.Address, path Accou
 // TouchUpdates feeds the write set directly to a commitment.Updates buffer
 // via TouchPlainKeyDirect, one partial Update per write. The buffer merges
 // per key (ModeUpdate and ModeParallel both accumulate flags additively).
+// An address whose writes do not cover balance, nonce and code hash together
+// costs one account read at fold time, where the trie fills in the rest.
 func (s *WriteSet) TouchUpdates(updates *commitment.Updates) {
 	if s == nil {
 		return


### PR DESCRIPTION
`setFromUpdate` marked a cell fully loaded as soon as any one account flag was set, while `Merge` copies only the flagged fields. A balance-only update therefore pinned the cell with nonce 0 and an empty code hash, and the fold skipped the read that would have supplied them. #20961's diagnosis is wrong: the untouched sibling encodes fine, the touched account loses its own nonce. `ModeParallel` diverges the same way, and a root-leaf contract loses the code hash `updateCell` resets.

## Changes
- Split `loadFlags` into balance/nonce/code bits, so `loaded.account()` now requires all three.
- Add `fillAccountGaps` and call it at the three account-read sites instead of `setFromUpdate`: the read fills only the fields the cell is missing, then marks the account loaded. A merged update is the post-state the caller committed to and the read can be older, so it may neither overwrite that nor turn the cell into a deletion.
- Clear `cellLoadCode` in `updateCell`, which resets the cell's code hash.
- Set all three account flags unconditionally in `TouchAccount` and `TrieContext.Account`, and mirror that in `MockState`. Values are unchanged — `TrieContext.Account` already flagged all three for every existing account, since a code-less one carries `EmptyCodeHash` and `IsZero()` is false for it.
- Un-skip `Test_ModeUpdate_SiblingConsistency`; add a `ModeParallel` twin, the root-leaf code-hash case, and cell-level pins for the gap fill.

Perf-neutral: geomean +0.63% over six benchstat arms with nothing significant, +3 objects on 293k allocations, reads and roots identical.

Fixes #20961
