### PR TITLE
execution/cache: bound the code LRU by measured bytes, not an average estimate

### DIFF
--- a/execution/cache/code_cache.go
+++ b/execution/cache/code_cache.go
@@ -247,9 +247,11 @@ func NewCodeCache(codeCapacityBytes, addrCapacityBytes datasize.ByteSize) *CodeC
 	// The content-addressed layers jump-grow from a small start into the shared
 	// envelope, so a cache over few contracts (a test fixture) never pre-commits
 	// the full budget. OnEvict keeps the byte/entry counters following residency.
-	cc.hashToCode = newGrowLRU[codeEntry](codeCapacityBytes, avgCodeEntryBytes,
+	cc.hashToCode = newGrowLRUSized[codeEntry](codeCapacityBytes, avgCodeEntryBytes,
+		func(e codeEntry) int64 { return 8 + int64(len(e.code)) },
 		func(_ uint64, e codeEntry) { cc.codeSize.Add(-(8 + int64(len(e.code)))) })
-	cc.codeHashToCode = newGrowLRU[codeEntry](codeCapacityBytes, avgCodeEntryBytes,
+	cc.codeHashToCode = newGrowLRUSized[codeEntry](codeCapacityBytes, avgCodeEntryBytes,
+		func(e codeEntry) int64 { return 32 + int64(len(e.code)) },
 		func(_ uint64, e codeEntry) { cc.codeHashCodeSize.Add(-(32 + int64(len(e.code)))) })
 	cc.codeSizeByCodeHash = newGrowLRU[codeSizeEntry](
 		datasize.ByteSize(DefaultCodeSizeCacheEntries*codeSizeEntryBytes), codeSizeEntryBytes,

--- a/execution/cache/grow_lru.go
+++ b/execution/cache/grow_lru.go
@@ -46,6 +46,13 @@ type growLRU[V any] struct {
 	onEvict  func(uint64, V)
 	avgBytes int64
 
+	// avgBytes only estimates the entry ceiling, so a layer whose entries run
+	// larger than the estimate holds several x its configured budget. maxBytes
+	// bounds measured residency instead; 0 leaves a layer entry-bounded.
+	maxBytes int64
+	sizeOf   func(V) int64
+	curBytes atomic.Int64
+
 	startCap uint32
 	maxCap   uint32
 
@@ -56,6 +63,12 @@ type growLRU[V any] struct {
 }
 
 func newGrowLRU[V any](maxBytes datasize.ByteSize, avgBytes uint32, onEvict func(uint64, V)) *growLRU[V] {
+	return newGrowLRUSized(maxBytes, avgBytes, nil, onEvict)
+}
+
+// newGrowLRUSized bounds residency by what sizeOf reports rather than by the
+// avgBytes estimate. A nil sizeOf keeps the entry-only ceiling.
+func newGrowLRUSized[V any](maxBytes datasize.ByteSize, avgBytes uint32, sizeOf func(V) int64, onEvict func(uint64, V)) *growLRU[V] {
 	if avgBytes == 0 {
 		avgBytes = avgBytesPerEntry
 	}
@@ -64,6 +77,9 @@ func newGrowLRU[V any](maxBytes datasize.ByteSize, avgBytes uint32, onEvict func
 	// the ceiling — a tiny configured budget yields a tiny, still-evicting cap.
 	start := min(uint32(genericCacheStartCapacity), maxCap)
 	g := &growLRU[V]{onEvict: onEvict, avgBytes: int64(avgBytes), startCap: start, maxCap: maxCap}
+	if sizeOf != nil {
+		g.sizeOf, g.maxBytes = sizeOf, int64(maxBytes)
+	}
 	g.curCap.Store(start)
 	g.reserved = int64(start) * g.avgBytes
 	cachebudget.Global.Take(g.reserved)
@@ -76,7 +92,14 @@ func (g *growLRU[V]) newShards(capacity uint32) *freelru.ShardedLRU[uint64, V] {
 	if err != nil {
 		panic(fmt.Sprintf("growLRU: NewSharded(%d): %s", capacity, err))
 	}
-	if g.onEvict != nil {
+	if g.sizeOf != nil {
+		lru.SetOnEvict(func(k uint64, v V) {
+			g.curBytes.Add(-g.sizeOf(v))
+			if g.onEvict != nil {
+				g.onEvict(k, v)
+			}
+		})
+	} else if g.onEvict != nil {
 		lru.SetOnEvict(g.onEvict)
 	}
 	return lru
@@ -91,6 +114,11 @@ func (g *growLRU[V]) Add(key uint64, value V) {
 		lru = g.cur.Load()
 	}
 	lru.Add(key, value)
+	if g.sizeOf != nil {
+		// Callers Add only an absent key, so this never double-counts a replace.
+		// Across an unfenced grow it can, which is the drift the type documents.
+		g.curBytes.Add(g.sizeOf(value))
+	}
 }
 
 func (g *growLRU[V]) maybeGrow() {
@@ -101,7 +129,26 @@ func (g *growLRU[V]) maybeGrow() {
 	if curCap >= g.maxCap || old.Len() < int(curCap) {
 		return
 	}
+	// Refusing a bigger table at the budget is what bounds residency: entries
+	// already admitted are never evicted for size, so the bound is soft by up
+	// to one generation's worth of oversized entries.
+	if g.maxBytes > 0 && g.curBytes.Load() >= g.maxBytes {
+		return
+	}
 	newCap := min(curCap*genericCacheGrowFactor, g.maxCap)
+	if g.maxBytes > 0 {
+		// A x4 step taken while still under budget is what overshoots it, so the
+		// step is clamped to what the budget affords at the size entries are
+		// actually running — the estimate only sizes the first table.
+		if n := int64(old.Len()); n > 0 {
+			if avg := g.curBytes.Load() / n; avg > 0 {
+				newCap = min(newCap, uint32(min(g.maxBytes/avg, int64(g.maxCap))))
+			}
+		}
+		if newCap <= curCap {
+			return
+		}
+	}
 	delta := int64(newCap-curCap) * g.avgBytes
 	if !cachebudget.Global.Reserve(delta) {
 		return
@@ -128,6 +175,7 @@ func (g *growLRU[V]) Purge() {
 	cachebudget.Global.Release(g.reserved - int64(g.startCap)*g.avgBytes)
 	g.reserved = int64(g.startCap) * g.avgBytes
 	g.curCap.Store(g.startCap)
+	g.curBytes.Store(0)
 	g.cur.Store(g.newShards(g.startCap))
 }
 


### PR DESCRIPTION
`avgCodeEntryBytes` (12KB) turns the code byte budget into a freelru entry ceiling, but these contracts run ~24.6KB, so the layer holds **~2x its configured size** and under-charges `cachebudget.Global` by the same factor. `sizeOf` makes the bound track measured residency: the grow step is clamped to what the budget affords at the size entries actually are.

Measured on n5 (benchmarkoor, jochemnet glamsterdam-devnet-7 stateful @ 24402727, `test_account_access[EXTCODECOPY, EXISTING_CONTRACT_DIFF_MAX]` ladder, identical gas per arm, n=3):

| | budget | resident | MGas/s |
|---|---|---|---|
| before | 512MB | 1.077 GB (+110%) | 291.1 |
| **after** | **1GB** | **1.083 GB (+8%)** | **302.5** |
| before | 1GB | 1.44-1.56 GB (+50%) | 312.4 |

At matched residency (1.077 vs 1.083 GB) this is **+3.9%**, ranges non-overlapping — the same bytes buy more entries (47,872 vs 43,776) once the bound is truthful.

**Trade-off to decide before this leaves draft:** the numbers above use `cachebudget.Divisor` lowered 32→8. At the default envelope (32GB box → 1GB) the budget finally binds and the cache holds *less* code than today, costing ~8% on this workload. That is the point — today's speed is borrowed RAM — but it means this probably wants pairing with a larger default code budget or a size-scaled `Divisor`.

Benched on `dec25ab34b`: `main` cannot run this baseline since b8119d4895 (gd8 gas schedule vs devnet-7 fixtures).
