### PR TITLE
execution/vm: return state-gas to gas_left when a child merges

### DIFF
--- a/execution/tracing/gen_gas_change_reason_stringer.go
+++ b/execution/tracing/gen_gas_change_reason_stringer.go
@@ -24,21 +24,22 @@ func _() {
 	_ = x[GasChangeCallStorageColdAccess-13]
 	_ = x[GasChangeCallFailedExecution-14]
 	_ = x[GasChangeDelegatedDesignation-15]
+	_ = x[GasChangeCallStateGasReturned-16]
 	_ = x[GasChangeIgnored-255]
 }
 
 const (
-	_GasChangeReason_name_0 = "GasChangeUnspecifiedGasChangeTxInitialBalanceGasChangeTxIntrinsicGasGasChangeTxRefundsGasChangeTxLeftOverReturnedGasChangeCallInitialBalanceGasChangeCallLeftOverReturnedGasChangeCallLeftOverRefundedGasChangeCallContractCreationGasChangeCallContractCreation2GasChangeCallCodeStorageGasChangeCallOpCodeGasChangeCallPrecompiledContractGasChangeCallStorageColdAccessGasChangeCallFailedExecutionGasChangeDelegatedDesignation"
+	_GasChangeReason_name_0 = "GasChangeUnspecifiedGasChangeTxInitialBalanceGasChangeTxIntrinsicGasGasChangeTxRefundsGasChangeTxLeftOverReturnedGasChangeCallInitialBalanceGasChangeCallLeftOverReturnedGasChangeCallLeftOverRefundedGasChangeCallContractCreationGasChangeCallContractCreation2GasChangeCallCodeStorageGasChangeCallOpCodeGasChangeCallPrecompiledContractGasChangeCallStorageColdAccessGasChangeCallFailedExecutionGasChangeDelegatedDesignationGasChangeCallStateGasReturned"
 	_GasChangeReason_name_1 = "GasChangeIgnored"
 )
 
 var (
-	_GasChangeReason_index_0 = [...]uint16{0, 20, 45, 68, 86, 113, 140, 169, 198, 227, 257, 281, 300, 332, 362, 390, 419}
+	_GasChangeReason_index_0 = [...]uint16{0, 20, 45, 68, 86, 113, 140, 169, 198, 227, 257, 281, 300, 332, 362, 390, 419, 448}
 )
 
 func (i GasChangeReason) String() string {
 	switch {
-	case i <= 15:
+	case i <= 16:
 		return _GasChangeReason_name_0[_GasChangeReason_index_0[i]:_GasChangeReason_index_0[i+1]]
 	case i == 255:
 		return _GasChangeReason_name_1

--- a/execution/tracing/hooks.go
+++ b/execution/tracing/hooks.go
@@ -311,6 +311,10 @@ const (
 	GasChangeCallFailedExecution GasChangeReason = 14
 	// GasChangeDelegatedDesignation is the amount of gas that will be charged for resolution of delegated designation.
 	GasChangeDelegatedDesignation GasChangeReason = 15
+	// GasChangeCallStateGasReturned is EIP-8037 state gas moving out of the reservoir back into gas_left, after a
+	// child frame refilled a slot this frame had spilled gas_left to allocate. This value is always positive. It is
+	// not GasChangeCallLeftOverRefunded: no gas crosses a frame boundary, it changes dimension within one frame.
+	GasChangeCallStateGasReturned GasChangeReason = 16
 
 	// GasChangeIgnored is a special value that can be used to indicate that the gas change should be ignored as
 	// it will be "manually" tracked by a direct emit of the gas change event.

--- a/execution/vm/instructions.go
+++ b/execution/vm/instructions.go
@@ -1052,7 +1052,7 @@ func execCreate(pc uint64, evm *EVM, scope *CallContext, value uint256.Int, inpu
 		if suberr != nil && preparation.chargeNewAccount {
 			scope.refillStateGas(params.StateGasNewAccount)
 		} else if suberr == nil {
-			scope.stateGasSpill += childGasUsed.StateSpill
+			scope.mergeChildStateGas(childGasUsed.StateSpill)
 		}
 	}
 	// Push item on the stack based on the returned error. If the ruleset is
@@ -1131,7 +1131,7 @@ func opCall(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) {
 	scope.restoreChildGas(returnGas, evm.config.Tracer)
 	if evm.chainRules.IsAmsterdam {
 		if err == nil {
-			scope.stateGasSpill += childGasUsage.StateSpill
+			scope.mergeChildStateGas(childGasUsage.StateSpill)
 		} else if scope.newAccountCharged {
 			scope.refillStateGas(params.StateGasNewAccount)
 		}
@@ -1183,7 +1183,7 @@ func opCallCode(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error)
 
 	scope.restoreChildGas(returnGas, evm.config.Tracer)
 	if evm.chainRules.IsAmsterdam && err == nil {
-		scope.stateGasSpill += childGasUsage.StateSpill
+		scope.mergeChildStateGas(childGasUsage.StateSpill)
 	}
 	scope.Contract.selfBalanceCached = false
 	evm.returnData = ret
@@ -1218,7 +1218,7 @@ func opDelegateCall(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, er
 
 	scope.restoreChildGas(returnGas, evm.config.Tracer)
 	if evm.chainRules.IsAmsterdam && err == nil {
-		scope.stateGasSpill += childGasUsage.StateSpill
+		scope.mergeChildStateGas(childGasUsage.StateSpill)
 	}
 	scope.Contract.selfBalanceCached = false
 	evm.returnData = ret
@@ -1263,7 +1263,7 @@ func opStaticCall(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, erro
 
 	scope.restoreChildGas(returnGas, evm.config.Tracer)
 	if evm.chainRules.IsAmsterdam && err == nil {
-		scope.stateGasSpill += childGasUsage.StateSpill
+		scope.mergeChildStateGas(childGasUsage.StateSpill)
 	}
 	evm.returnData = ret
 	return pc, ret, nil

--- a/execution/vm/instructions.go
+++ b/execution/vm/instructions.go
@@ -1050,7 +1050,7 @@ func execCreate(pc uint64, evm *EVM, scope *CallContext, value uint256.Int, inpu
 	if forwarded {
 		scope.restoreChildGas(returnGas, evm.config.Tracer)
 		if suberr != nil && preparation.chargeNewAccount {
-			scope.refillStateGas(params.StateGasNewAccount, evm.config.Tracer, tracing.GasChangeIgnored)
+			scope.refillStateGas(params.StateGasNewAccount)
 		} else if suberr == nil {
 			scope.mergeChildStateGas(childGasUsed.StateSpill, evm.config.Tracer)
 		}
@@ -1133,7 +1133,7 @@ func opCall(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) {
 		if err == nil {
 			scope.mergeChildStateGas(childGasUsage.StateSpill, evm.config.Tracer)
 		} else if scope.newAccountCharged {
-			scope.refillStateGas(params.StateGasNewAccount, evm.config.Tracer, tracing.GasChangeIgnored)
+			scope.refillStateGas(params.StateGasNewAccount)
 		}
 	}
 	scope.Contract.selfBalanceCached = false

--- a/execution/vm/instructions.go
+++ b/execution/vm/instructions.go
@@ -1050,9 +1050,9 @@ func execCreate(pc uint64, evm *EVM, scope *CallContext, value uint256.Int, inpu
 	if forwarded {
 		scope.restoreChildGas(returnGas, evm.config.Tracer)
 		if suberr != nil && preparation.chargeNewAccount {
-			scope.refillStateGas(params.StateGasNewAccount)
+			scope.refillStateGas(params.StateGasNewAccount, evm.config.Tracer, tracing.GasChangeIgnored)
 		} else if suberr == nil {
-			scope.mergeChildStateGas(childGasUsed.StateSpill)
+			scope.mergeChildStateGas(childGasUsed.StateSpill, evm.config.Tracer)
 		}
 	}
 	// Push item on the stack based on the returned error. If the ruleset is
@@ -1131,9 +1131,9 @@ func opCall(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) {
 	scope.restoreChildGas(returnGas, evm.config.Tracer)
 	if evm.chainRules.IsAmsterdam {
 		if err == nil {
-			scope.mergeChildStateGas(childGasUsage.StateSpill)
+			scope.mergeChildStateGas(childGasUsage.StateSpill, evm.config.Tracer)
 		} else if scope.newAccountCharged {
-			scope.refillStateGas(params.StateGasNewAccount)
+			scope.refillStateGas(params.StateGasNewAccount, evm.config.Tracer, tracing.GasChangeIgnored)
 		}
 	}
 	scope.Contract.selfBalanceCached = false
@@ -1183,7 +1183,7 @@ func opCallCode(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error)
 
 	scope.restoreChildGas(returnGas, evm.config.Tracer)
 	if evm.chainRules.IsAmsterdam && err == nil {
-		scope.mergeChildStateGas(childGasUsage.StateSpill)
+		scope.mergeChildStateGas(childGasUsage.StateSpill, evm.config.Tracer)
 	}
 	scope.Contract.selfBalanceCached = false
 	evm.returnData = ret
@@ -1218,7 +1218,7 @@ func opDelegateCall(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, er
 
 	scope.restoreChildGas(returnGas, evm.config.Tracer)
 	if evm.chainRules.IsAmsterdam && err == nil {
-		scope.mergeChildStateGas(childGasUsage.StateSpill)
+		scope.mergeChildStateGas(childGasUsage.StateSpill, evm.config.Tracer)
 	}
 	scope.Contract.selfBalanceCached = false
 	evm.returnData = ret
@@ -1263,7 +1263,7 @@ func opStaticCall(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, erro
 
 	scope.restoreChildGas(returnGas, evm.config.Tracer)
 	if evm.chainRules.IsAmsterdam && err == nil {
-		scope.mergeChildStateGas(childGasUsage.StateSpill)
+		scope.mergeChildStateGas(childGasUsage.StateSpill, evm.config.Tracer)
 	}
 	evm.returnData = ret
 	return pc, ret, nil

--- a/execution/vm/interpreter.go
+++ b/execution/vm/interpreter.go
@@ -181,6 +181,15 @@ func (c *CallContext) useMdGas(gas uint64, t mdgas.MdGasType, tracer *tracing.Ho
 	return ok
 }
 
+// mergeChildStateGas takes over the child's state-gas spill, then absorbs state
+// gas the child left in the reservoir, up to the spill available in this frame.
+func (c *CallContext) mergeChildStateGas(childSpill uint64) {
+	c.stateGasSpill += childSpill
+	misplaced := min(c.stateGas, c.stateGasSpill)
+	c.stateGas -= misplaced
+	c.refillStateGas(misplaced) // LIFO: gas_left first
+}
+
 func (c *CallContext) refillStateGas(amount uint64) {
 	remaining := c.Gas()
 	used := mdgas.MdGasUsage{State: int64(amount), StateSpill: c.stateGasSpill}

--- a/execution/vm/interpreter.go
+++ b/execution/vm/interpreter.go
@@ -193,7 +193,7 @@ func (c *CallContext) mergeChildStateGas(childSpill uint64, tracer *tracing.Hook
 	before := c.gas
 	c.refillStateGas(misplaced) // LIFO: gas_left first
 	if tracer != nil && tracer.OnGasChange != nil {
-		tracer.OnGasChange(before, c.gas, tracing.GasChangeCallLeftOverRefunded)
+		tracer.OnGasChange(before, c.gas, tracing.GasChangeCallStateGasReturned)
 	}
 }
 

--- a/execution/vm/interpreter.go
+++ b/execution/vm/interpreter.go
@@ -183,20 +183,31 @@ func (c *CallContext) useMdGas(gas uint64, t mdgas.MdGasType, tracer *tracing.Ho
 
 // mergeChildStateGas takes over the child's state-gas spill, then absorbs state
 // gas the child left in the reservoir, up to the spill available in this frame.
-func (c *CallContext) mergeChildStateGas(childSpill uint64) {
+func (c *CallContext) mergeChildStateGas(childSpill uint64, tracer *tracing.Hooks) {
 	c.stateGasSpill += childSpill
 	misplaced := min(c.stateGas, c.stateGasSpill)
+	if misplaced == 0 {
+		return
+	}
 	c.stateGas -= misplaced
-	c.refillStateGas(misplaced) // LIFO: gas_left first
+	c.refillStateGas(misplaced, tracer, tracing.GasChangeCallLeftOverRefunded) // LIFO: gas_left first
 }
 
-func (c *CallContext) refillStateGas(amount uint64) {
-	remaining := c.Gas()
+func (c *CallContext) refillStateGas(amount uint64, tracer *tracing.Hooks, reason tracing.GasChangeReason) {
+	initial := c.Gas()
+	remaining := initial
 	used := mdgas.MdGasUsage{State: int64(amount), StateSpill: c.stateGasSpill}
 	mdgas.Refill(&remaining, &used, amount, mdgas.StateGas)
 	c.gas = remaining.Execution
 	c.stateGas = remaining.State
 	c.stateGasSpill = used.StateSpill
+	if tracer != nil && tracer.OnGasChange != nil && reason != tracing.GasChangeIgnored {
+		before, after := initial.Execution, remaining.Execution
+		if before == after {
+			before, after = initial.State, remaining.State
+		}
+		tracer.OnGasChange(before, after, reason)
+	}
 }
 
 func useGas(initial uint64, gas uint64, tracer *tracing.Hooks, reason tracing.GasChangeReason) (remaining uint64, ok bool) {

--- a/execution/vm/interpreter.go
+++ b/execution/vm/interpreter.go
@@ -190,24 +190,20 @@ func (c *CallContext) mergeChildStateGas(childSpill uint64, tracer *tracing.Hook
 		return
 	}
 	c.stateGas -= misplaced
-	c.refillStateGas(misplaced, tracer, tracing.GasChangeCallLeftOverRefunded) // LIFO: gas_left first
+	before := c.gas
+	c.refillStateGas(misplaced) // LIFO: gas_left first
+	if tracer != nil && tracer.OnGasChange != nil {
+		tracer.OnGasChange(before, c.gas, tracing.GasChangeCallLeftOverRefunded)
+	}
 }
 
-func (c *CallContext) refillStateGas(amount uint64, tracer *tracing.Hooks, reason tracing.GasChangeReason) {
-	initial := c.Gas()
-	remaining := initial
+func (c *CallContext) refillStateGas(amount uint64) {
+	remaining := c.Gas()
 	used := mdgas.MdGasUsage{State: int64(amount), StateSpill: c.stateGasSpill}
 	mdgas.Refill(&remaining, &used, amount, mdgas.StateGas)
 	c.gas = remaining.Execution
 	c.stateGas = remaining.State
 	c.stateGasSpill = used.StateSpill
-	if tracer != nil && tracer.OnGasChange != nil && reason != tracing.GasChangeIgnored {
-		before, after := initial.Execution, remaining.Execution
-		if before == after {
-			before, after = initial.State, remaining.State
-		}
-		tracer.OnGasChange(before, after, reason)
-	}
 }
 
 func useGas(initial uint64, gas uint64, tracer *tracing.Hooks, reason tracing.GasChangeReason) (remaining uint64, ok bool) {

--- a/execution/vm/interpreter.go
+++ b/execution/vm/interpreter.go
@@ -191,7 +191,7 @@ func (c *CallContext) mergeChildStateGas(childSpill uint64, tracer *tracing.Hook
 	}
 	c.stateGas -= misplaced
 	before := c.gas
-	c.refillStateGas(misplaced) // LIFO: gas_left first
+	c.refillStateGas(misplaced) // capped by the spill, so LIFO returns all to gas_left
 	if tracer != nil && tracer.OnGasChange != nil {
 		tracer.OnGasChange(before, c.gas, tracing.GasChangeCallStateGasReturned)
 	}

--- a/execution/vm/operations_acl.go
+++ b/execution/vm/operations_acl.go
@@ -102,7 +102,7 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 			if original.IsZero() { // reset to original inexistent slot (2.2.2.1)
 				evm.IntraBlockState().AddRefund(writeCreate)
 				if stateCreate > 0 {
-					callContext.refillStateGas(stateCreate)
+					callContext.refillStateGas(stateCreate, evm.Config().Tracer, tracing.GasChangeIgnored)
 				}
 			} else { // reset to original existing slot (2.2.2.2)
 				evm.IntraBlockState().AddRefund(writeExisting)

--- a/execution/vm/operations_acl.go
+++ b/execution/vm/operations_acl.go
@@ -102,7 +102,7 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 			if original.IsZero() { // reset to original inexistent slot (2.2.2.1)
 				evm.IntraBlockState().AddRefund(writeCreate)
 				if stateCreate > 0 {
-					callContext.refillStateGas(stateCreate, evm.Config().Tracer, tracing.GasChangeIgnored)
+					callContext.refillStateGas(stateCreate)
 				}
 			} else { // reset to original existing slot (2.2.2.2)
 				evm.IntraBlockState().AddRefund(writeExisting)

--- a/execution/vm/runtime/eip8037_cross_frame_refill_test.go
+++ b/execution/vm/runtime/eip8037_cross_frame_refill_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package runtime
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv/temporal/temporaltest"
+	"github.com/erigontech/erigon/db/state/execctx/execctxapi"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/protocol/params"
+	"github.com/erigontech/erigon/execution/state"
+	"github.com/erigontech/erigon/execution/tracing"
+	"github.com/erigontech/erigon/execution/types/accounts"
+	"github.com/erigontech/erigon/execution/vm"
+)
+
+const (
+	setterAddr  = 0x1000
+	clearerAddr = 0x1001
+	callerAddr  = 0x2000
+)
+
+// delegateCallTo emits a DELEGATECALL to target forwarding all gas, so the
+// callee writes the caller's storage. The operands are pushed in reverse: the
+// opcode pops gas, address, argsOffset, argsSize, retOffset, retSize.
+func delegateCallTo(target uint16) []byte {
+	return []byte{
+		byte(vm.PUSH1), 0x00, byte(vm.PUSH1), 0x00, // retSize, retOffset
+		byte(vm.PUSH1), 0x00, byte(vm.PUSH1), 0x00, // argsSize, argsOffset
+		byte(vm.PUSH2), byte(target >> 8), byte(target),
+		byte(vm.GAS), byte(vm.DELEGATECALL), byte(vm.POP),
+	}
+}
+
+func sstore(slot, value byte) []byte {
+	return []byte{byte(vm.PUSH1), value, byte(vm.PUSH1), slot, byte(vm.SSTORE)}
+}
+
+// TestStateGasReturnsToGasLeftAcrossFrames pins EIP-8037's promise that state
+// gas is never stranded in the reservoir. The first child allocates a slot and
+// spills from its gas_left; the second clears the same slot, but has no spill
+// of its own, so its refill lands in the reservoir. The merge must absorb it,
+// leaving the reservoir at its start-of-transaction value.
+func TestStateGasReturnsToGasLeftAcrossFrames(t *testing.T) {
+	t.Parallel()
+
+	stop := []byte{byte(vm.STOP)}
+	callSiblings := slices.Concat(delegateCallTo(setterAddr), delegateCallTo(clearerAddr), stop)
+	// Spilling for a second slot in between leaves this frame more spill than
+	// the sibling's refill can cover.
+	spillInBetween := slices.Concat(delegateCallTo(setterAddr), sstore(2, 1),
+		delegateCallTo(clearerAddr), stop)
+
+	for _, tc := range []struct {
+		name                    string
+		caller                  []byte
+		gasLimit, wantReservoir uint64
+	}{
+		{"reservoir equals spill", callSiblings, 2_000_000, 0},
+		{"spill under reservoir", callSiblings, params.MaxTxnGasLimit + 50_000, 50_000},
+		{"spill over reservoir", spillInBetween, 2_000_000, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			db := temporaltest.NewTestDB(t, datadir.New(t.TempDir()))
+			tx, domains := temporaltest.NewTestTxSD(t, db)
+			reader := state.NewReaderV3(domains.AsStateGetter(tx, execctxapi.StateGetterOptions{}))
+			statedb := state.NewWithVersionMap(reader, state.NewVersionMap(nil))
+			statedb.SetNoMaterialize(true)
+			defer statedb.Close()
+
+			deploy := func(at uint16, code []byte) accounts.Address {
+				addr := accounts.InternAddress(common.BytesToAddress([]byte{byte(at >> 8), byte(at)}))
+				require.NoError(t, statedb.SetCode(addr, code, tracing.CodeChangeUnspecified))
+				return addr
+			}
+			deploy(setterAddr, slices.Concat(sstore(1, 1), stop))
+			deploy(clearerAddr, slices.Concat(sstore(1, 0), stop))
+			caller := deploy(callerAddr, tc.caller)
+
+			_, gasRemaining, err := Call(caller, nil, &Config{
+				ChainConfig: chain.AllProtocolChanges,
+				GasLimit:    tc.gasLimit,
+				State:       statedb,
+			})
+			require.NoError(t, err)
+			require.Equal(t, tc.wantReservoir, gasRemaining.State)
+		})
+	}
+}

--- a/execution/vm/runtime/eip8037_cross_frame_refill_test.go
+++ b/execution/vm/runtime/eip8037_cross_frame_refill_test.go
@@ -35,9 +35,11 @@ import (
 )
 
 const (
-	setterAddr  = 0x1000
-	clearerAddr = 0x1001
-	callerAddr  = 0x2000
+	setterAddr   = 0x1000
+	clearerAddr  = 0x1001
+	reverterAddr = 0x1002
+	halterAddr   = 0x1003
+	callerAddr   = 0x2000
 )
 
 // delegateCallTo emits a DELEGATECALL to target forwarding all gas, so the
@@ -56,8 +58,9 @@ func sstore(slot, value byte) []byte {
 	return []byte{byte(vm.PUSH1), value, byte(vm.PUSH1), slot, byte(vm.SSTORE)}
 }
 
-// deployStateGasContracts installs the setter/clearer pair plus a caller running
-// callerCode, and returns the caller and the state it was deployed into.
+// deployStateGasContracts installs the setter/clearer pair, the two setters that
+// fail after spilling, plus a caller running callerCode, and returns the caller
+// and the state it was deployed into.
 func deployStateGasContracts(t *testing.T, callerCode []byte) (accounts.Address, *state.IntraBlockState) {
 	t.Helper()
 	db := temporaltest.NewTestDB(t, datadir.New(t.TempDir()))
@@ -75,6 +78,9 @@ func deployStateGasContracts(t *testing.T, callerCode []byte) (accounts.Address,
 	stop := []byte{byte(vm.STOP)}
 	deploy(setterAddr, slices.Concat(sstore(1, 1), stop))
 	deploy(clearerAddr, slices.Concat(sstore(1, 0), stop))
+	revert := []byte{byte(vm.PUSH1), 0x00, byte(vm.PUSH1), 0x00, byte(vm.REVERT)}
+	deploy(reverterAddr, slices.Concat(sstore(1, 1), revert))
+	deploy(halterAddr, slices.Concat(sstore(1, 1), []byte{byte(vm.INVALID)}))
 	return deploy(callerAddr, callerCode), statedb
 }
 
@@ -151,4 +157,36 @@ func TestStateGasMergeIsAnnouncedToTracer(t *testing.T) {
 		"the reservoir->gas_left move must be reported")
 	require.Len(t, gains[tracing.GasChangeCallLeftOverRefunded], 2,
 		"one leftover refund per child call, and none for the state-gas merge")
+}
+
+// A failing child hands back its entry reservoir and its spill with it, so the
+// parent must not merge that spill: doing so would credit gas_left twice for
+// state creation the child rolled back.
+func TestFailingChildStateGasIsNotMerged(t *testing.T) {
+	t.Parallel()
+
+	stop := []byte{byte(vm.STOP)}
+	for _, tc := range []struct {
+		name                       string
+		child                      uint16
+		wantReservoir, wantGasLeft uint64
+	}{
+		{"revert", reverterAddr, 50_000, 16_762_085},
+		{"exceptional halt", halterAddr, 50_000, 262_094},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			caller, statedb := deployStateGasContracts(t, slices.Concat(delegateCallTo(tc.child), stop))
+
+			_, gasRemaining, err := Call(caller, nil, &Config{
+				ChainConfig: chain.AllProtocolChanges,
+				GasLimit:    params.MaxTxnGasLimit + 50_000,
+				State:       statedb,
+			})
+			require.NoError(t, err)
+			require.Equal(t, tc.wantReservoir, gasRemaining.State)
+			require.Equal(t, tc.wantGasLeft, gasRemaining.Execution)
+		})
+	}
 }

--- a/execution/vm/runtime/eip8037_cross_frame_refill_test.go
+++ b/execution/vm/runtime/eip8037_cross_frame_refill_test.go
@@ -56,11 +56,6 @@ func sstore(slot, value byte) []byte {
 	return []byte{byte(vm.PUSH1), value, byte(vm.PUSH1), slot, byte(vm.SSTORE)}
 }
 
-// TestStateGasReturnsToGasLeftAcrossFrames pins EIP-8037's promise that state
-// gas is never stranded in the reservoir. The first child allocates a slot and
-// spills from its gas_left; the second clears the same slot, but has no spill
-// of its own, so its refill lands in the reservoir. The merge must absorb it,
-// leaving the reservoir at its start-of-transaction value.
 // deployStateGasContracts installs the setter/clearer pair plus a caller running
 // callerCode, and returns the caller and the state it was deployed into.
 func deployStateGasContracts(t *testing.T, callerCode []byte) (accounts.Address, *state.IntraBlockState) {
@@ -83,6 +78,11 @@ func deployStateGasContracts(t *testing.T, callerCode []byte) (accounts.Address,
 	return deploy(callerAddr, callerCode), statedb
 }
 
+// TestStateGasReturnsToGasLeftAcrossFrames pins EIP-8037's promise that state
+// gas is never stranded in the reservoir. The first child allocates a slot and
+// spills from its gas_left; the second clears the same slot, but has no spill
+// of its own, so its refill lands in the reservoir. The merge must absorb it,
+// leaving the reservoir at its start-of-transaction value.
 func TestStateGasReturnsToGasLeftAcrossFrames(t *testing.T) {
 	t.Parallel()
 

--- a/execution/vm/runtime/eip8037_cross_frame_refill_test.go
+++ b/execution/vm/runtime/eip8037_cross_frame_refill_test.go
@@ -61,6 +61,28 @@ func sstore(slot, value byte) []byte {
 // spills from its gas_left; the second clears the same slot, but has no spill
 // of its own, so its refill lands in the reservoir. The merge must absorb it,
 // leaving the reservoir at its start-of-transaction value.
+// deployStateGasContracts installs the setter/clearer pair plus a caller running
+// callerCode, and returns the caller and the state it was deployed into.
+func deployStateGasContracts(t *testing.T, callerCode []byte) (accounts.Address, *state.IntraBlockState) {
+	t.Helper()
+	db := temporaltest.NewTestDB(t, datadir.New(t.TempDir()))
+	tx, domains := temporaltest.NewTestTxSD(t, db)
+	reader := state.NewReaderV3(domains.AsStateGetter(tx, execctxapi.StateGetterOptions{}))
+	statedb := state.NewWithVersionMap(reader, state.NewVersionMap(nil))
+	statedb.SetNoMaterialize(true)
+	t.Cleanup(statedb.Close)
+
+	deploy := func(at uint16, code []byte) accounts.Address {
+		addr := accounts.InternAddress(common.BytesToAddress([]byte{byte(at >> 8), byte(at)}))
+		require.NoError(t, statedb.SetCode(addr, code, tracing.CodeChangeUnspecified))
+		return addr
+	}
+	stop := []byte{byte(vm.STOP)}
+	deploy(setterAddr, slices.Concat(sstore(1, 1), stop))
+	deploy(clearerAddr, slices.Concat(sstore(1, 0), stop))
+	return deploy(callerAddr, callerCode), statedb
+}
+
 func TestStateGasReturnsToGasLeftAcrossFrames(t *testing.T) {
 	t.Parallel()
 
@@ -83,21 +105,7 @@ func TestStateGasReturnsToGasLeftAcrossFrames(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			db := temporaltest.NewTestDB(t, datadir.New(t.TempDir()))
-			tx, domains := temporaltest.NewTestTxSD(t, db)
-			reader := state.NewReaderV3(domains.AsStateGetter(tx, execctxapi.StateGetterOptions{}))
-			statedb := state.NewWithVersionMap(reader, state.NewVersionMap(nil))
-			statedb.SetNoMaterialize(true)
-			defer statedb.Close()
-
-			deploy := func(at uint16, code []byte) accounts.Address {
-				addr := accounts.InternAddress(common.BytesToAddress([]byte{byte(at >> 8), byte(at)}))
-				require.NoError(t, statedb.SetCode(addr, code, tracing.CodeChangeUnspecified))
-				return addr
-			}
-			deploy(setterAddr, slices.Concat(sstore(1, 1), stop))
-			deploy(clearerAddr, slices.Concat(sstore(1, 0), stop))
-			caller := deploy(callerAddr, tc.caller)
+			caller, statedb := deployStateGasContracts(t, tc.caller)
 
 			_, gasRemaining, err := Call(caller, nil, &Config{
 				ChainConfig: chain.AllProtocolChanges,
@@ -127,22 +135,9 @@ func TestStateGasMergeIsAnnouncedToTracer(t *testing.T) {
 		},
 	}
 
-	db := temporaltest.NewTestDB(t, datadir.New(t.TempDir()))
-	tx, domains := temporaltest.NewTestTxSD(t, db)
-	reader := state.NewReaderV3(domains.AsStateGetter(tx, execctxapi.StateGetterOptions{}))
-	statedb := state.NewWithVersionMap(reader, state.NewVersionMap(nil))
-	statedb.SetNoMaterialize(true)
-	defer statedb.Close()
-
-	deploy := func(at uint16, code []byte) accounts.Address {
-		addr := accounts.InternAddress(common.BytesToAddress([]byte{byte(at >> 8), byte(at)}))
-		require.NoError(t, statedb.SetCode(addr, code, tracing.CodeChangeUnspecified))
-		return addr
-	}
 	stop := []byte{byte(vm.STOP)}
-	deploy(setterAddr, slices.Concat(sstore(1, 1), stop))
-	deploy(clearerAddr, slices.Concat(sstore(1, 0), stop))
-	caller := deploy(callerAddr, slices.Concat(delegateCallTo(setterAddr), delegateCallTo(clearerAddr), stop))
+	caller, statedb := deployStateGasContracts(t,
+		slices.Concat(delegateCallTo(setterAddr), delegateCallTo(clearerAddr), stop))
 
 	_, _, err := Call(caller, nil, &Config{
 		ChainConfig: chain.AllProtocolChanges,

--- a/execution/vm/runtime/eip8037_cross_frame_refill_test.go
+++ b/execution/vm/runtime/eip8037_cross_frame_refill_test.go
@@ -121,16 +121,17 @@ func TestStateGasReturnsToGasLeftAcrossFrames(t *testing.T) {
 	}
 }
 
-// A merge moves gas_left, so a tracer following OnGasChange must be told;
-// an unannounced increase desynchronises every gas-tracking tracer.
+// A merge moves gas_left, so a tracer following OnGasChange must be told; an
+// unannounced increase desynchronises every gas-tracking tracer. It is not a
+// leftover refund, so a tracer counting those must not see one more per call.
 func TestStateGasMergeIsAnnouncedToTracer(t *testing.T) {
 	t.Parallel()
 
-	var refunds []uint64
+	gains := map[tracing.GasChangeReason][]uint64{}
 	hooks := &tracing.Hooks{
 		OnGasChange: func(old, newGas uint64, reason tracing.GasChangeReason) {
-			if reason == tracing.GasChangeCallLeftOverRefunded && newGas > old {
-				refunds = append(refunds, newGas-old)
+			if newGas > old {
+				gains[reason] = append(gains[reason], newGas-old)
 			}
 		},
 	}
@@ -146,5 +147,8 @@ func TestStateGasMergeIsAnnouncedToTracer(t *testing.T) {
 		EVMConfig:   vm.Config{Tracer: hooks},
 	})
 	require.NoError(t, err)
-	require.Contains(t, refunds, uint64(97_920), "the reservoir->gas_left move must be reported")
+	require.Contains(t, gains[tracing.GasChangeCallStateGasReturned], uint64(97_920),
+		"the reservoir->gas_left move must be reported")
+	require.Len(t, gains[tracing.GasChangeCallLeftOverRefunded], 2,
+		"one leftover refund per child call, and none for the state-gas merge")
 }

--- a/execution/vm/runtime/eip8037_cross_frame_refill_test.go
+++ b/execution/vm/runtime/eip8037_cross_frame_refill_test.go
@@ -72,13 +72,13 @@ func TestStateGasReturnsToGasLeftAcrossFrames(t *testing.T) {
 		delegateCallTo(clearerAddr), stop)
 
 	for _, tc := range []struct {
-		name                    string
-		caller                  []byte
-		gasLimit, wantReservoir uint64
+		name                                 string
+		caller                               []byte
+		gasLimit, wantReservoir, wantGasLeft uint64
 	}{
-		{"reservoir equals spill", callSiblings, 2_000_000, 0},
-		{"spill under reservoir", callSiblings, params.MaxTxnGasLimit + 50_000, 50_000},
-		{"spill over reservoir", spillInBetween, 2_000_000, 0},
+		{"reservoir equals spill", callSiblings, 2_000_000, 0, 1_981_750},
+		{"spill under reservoir", callSiblings, params.MaxTxnGasLimit + 50_000, 50_000, 16_758_966},
+		{"spill over reservoir", spillInBetween, 2_000_000, 0, 1_871_724},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -106,6 +106,50 @@ func TestStateGasReturnsToGasLeftAcrossFrames(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.Equal(t, tc.wantReservoir, gasRemaining.State)
+			// The absorbed gas must land in gas_left: the reservoir assertion
+			// above also holds for a merge that drops it on the floor.
+			require.Equal(t, tc.wantGasLeft, gasRemaining.Execution)
 		})
 	}
+}
+
+// A merge moves gas_left, so a tracer following OnGasChange must be told;
+// an unannounced increase desynchronises every gas-tracking tracer.
+func TestStateGasMergeIsAnnouncedToTracer(t *testing.T) {
+	t.Parallel()
+
+	var refunds []uint64
+	hooks := &tracing.Hooks{
+		OnGasChange: func(old, newGas uint64, reason tracing.GasChangeReason) {
+			if reason == tracing.GasChangeCallLeftOverRefunded && newGas > old {
+				refunds = append(refunds, newGas-old)
+			}
+		},
+	}
+
+	db := temporaltest.NewTestDB(t, datadir.New(t.TempDir()))
+	tx, domains := temporaltest.NewTestTxSD(t, db)
+	reader := state.NewReaderV3(domains.AsStateGetter(tx, execctxapi.StateGetterOptions{}))
+	statedb := state.NewWithVersionMap(reader, state.NewVersionMap(nil))
+	statedb.SetNoMaterialize(true)
+	defer statedb.Close()
+
+	deploy := func(at uint16, code []byte) accounts.Address {
+		addr := accounts.InternAddress(common.BytesToAddress([]byte{byte(at >> 8), byte(at)}))
+		require.NoError(t, statedb.SetCode(addr, code, tracing.CodeChangeUnspecified))
+		return addr
+	}
+	stop := []byte{byte(vm.STOP)}
+	deploy(setterAddr, slices.Concat(sstore(1, 1), stop))
+	deploy(clearerAddr, slices.Concat(sstore(1, 0), stop))
+	caller := deploy(callerAddr, slices.Concat(delegateCallTo(setterAddr), delegateCallTo(clearerAddr), stop))
+
+	_, _, err := Call(caller, nil, &Config{
+		ChainConfig: chain.AllProtocolChanges,
+		GasLimit:    2_000_000,
+		State:       statedb,
+		EVMConfig:   vm.Config{Tracer: hooks},
+	})
+	require.NoError(t, err)
+	require.Contains(t, refunds, uint64(97_920), "the reservoir->gas_left move must be reported")
 }


### PR DESCRIPTION
A slot's original value is its value at transaction start, so a frame can refill a slot another frame allocated. Its own spill is too small to absorb the refill, which then sits in the reservoir while the gas_left that funded the spill stays reduced.

Absorb it on the merge, up to the spill available in the parent frame. No state creation is undone, so evm_state_gas_used and the transaction's gas used do not change. The step applies to successful children only, which holds because handleFrameRevert restores a failing frame's entry reservoir.

Implements https://github.com/ethereum/EIPs/pull/12265