### PR TITLE
execution/commitment: persist zero-update commitment progress

### DIFF
--- a/db/state/execctx/domain_shared_test.go
+++ b/db/state/execctx/domain_shared_test.go
@@ -2044,3 +2044,183 @@ func TestReceiptAsOf_InFlightBlockLogIndex(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, inFlightLogIdx, got, "must serve the in-flight block's log index, not the last committed one")
 }
+
+// TestSharedDomain_ZeroUpdateCommitmentAdvancesProgress verifies that a
+// commitment computation with no state updates still advances the persisted
+// commitment position when saveState=true.
+//
+// The state root must remain unchanged, but the persisted (blockNum, txNum)
+// must move forward to the new execution position.
+func TestSharedDomain_ZeroUpdateCommitmentAdvancesProgress(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	const (
+		stepSize = uint64(100)
+		block1   = uint64(1)
+		txNum1   = uint64(10)
+		block2   = uint64(2)
+		txNum2   = uint64(20)
+	)
+
+	db := newTestDb(t, stepSize)
+	ctx := t.Context()
+
+	// -----------------------------------------------------------------
+	// Phase 1:
+	// make a real state change and persist commitment at block1/txNum1.
+	// -----------------------------------------------------------------
+
+	rwTx1, err := db.BeginTemporalRw(ctx)
+	require.NoError(t, err)
+	defer rwTx1.Rollback()
+
+	require.NoError(t, rawdbv3.TxNums.Append(rwTx1, 0, 0))
+	require.NoError(t, rawdbv3.TxNums.Append(rwTx1, block1, txNum1))
+	require.NoError(t, rawdbv3.TxNums.Append(rwTx1, block2, txNum2))
+
+	domains1, err := execctx.NewSharedDomains(ctx, rwTx1, log.New())
+	require.NoError(t, err)
+
+	addr := make([]byte, length.Addr)
+	addr[0] = 0x42
+
+	acc := accounts3.Account{
+		Nonce:       1,
+		Balance:     *uint256.NewInt(12345),
+		CodeHash:    accounts.EmptyCodeHash,
+		Incarnation: 0,
+	}
+
+	prev, _, err := domains1.GetLatest(kv.AccountsDomain, rwTx1, addr)
+	require.NoError(t, err)
+
+	require.NoError(t, domains1.DomainPut(
+		kv.AccountsDomain,
+		rwTx1,
+		addr,
+		accounts3.SerialiseV3(&acc),
+		txNum1,
+		prev,
+	))
+
+	root1, err := domains1.ComputeCommitment(
+		ctx,
+		rwTx1,
+		true,
+		block1,
+		txNum1,
+		"",
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, root1)
+
+	require.NoError(t, domains1.Flush(ctx, rwTx1))
+	domains1.Close()
+
+	require.NoError(t, rwTx1.Commit())
+
+	// -----------------------------------------------------------------
+	// Phase 2:
+	// reopen from persisted state, make ZERO state updates, then request
+	// commitment persistence at block2/txNum2.
+	// -----------------------------------------------------------------
+
+	rwTx2, err := db.BeginTemporalRw(ctx)
+	require.NoError(t, err)
+	defer rwTx2.Rollback()
+
+	state1, _, err := rwTx2.GetLatest(
+		kv.CommitmentDomain,
+		commitmentdb.KeyCommitmentState,
+		kv.GetLatestOptions{},
+	)
+	require.NoError(t, err)
+
+	if len(state1) < 16 {
+		t.Fatalf(
+			"PHASE1_BASELINE_BAD: commitment state length=%d, want >=16",
+			len(state1),
+		)
+	}
+
+	storedTx1, storedBlock1 := commitmentdb.DecodeTxBlockNums(state1)
+
+	if storedBlock1 != block1 || storedTx1 != txNum1 {
+		t.Fatalf(
+			"PHASE1_BASELINE_BAD: got block=%d txNum=%d, want block=%d txNum=%d",
+			storedBlock1,
+			storedTx1,
+			block1,
+			txNum1,
+		)
+	}
+
+	domains2, err := execctx.NewSharedDomains(ctx, rwTx2, log.New())
+	require.NoError(t, err)
+
+	// Deliberately perform NO DomainPut/DomainDel calls here.
+
+	root2, err := domains2.ComputeCommitment(
+		ctx,
+		rwTx2,
+		true,
+		block2,
+		txNum2,
+		"",
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, root2)
+
+	if !bytes.Equal(root1, root2) {
+		t.Fatalf(
+			"ROOT_CHANGED_UNEXPECTED: root1=%x root2=%x",
+			root1,
+			root2,
+		)
+	}
+
+	require.NoError(t, domains2.Flush(ctx, rwTx2))
+	domains2.Close()
+
+	require.NoError(t, rwTx2.Commit())
+
+	// -----------------------------------------------------------------
+	// Phase 3:
+	// reopen AGAIN so the assertion is against durable persisted state,
+	// not an in-memory overlay.
+	// -----------------------------------------------------------------
+
+	rwTx3, err := db.BeginTemporalRw(ctx)
+	require.NoError(t, err)
+	defer rwTx3.Rollback()
+
+	state2, _, err := rwTx3.GetLatest(
+		kv.CommitmentDomain,
+		commitmentdb.KeyCommitmentState,
+		kv.GetLatestOptions{},
+	)
+	require.NoError(t, err)
+
+	if len(state2) < 16 {
+		t.Fatalf(
+			"PHASE2_STATE_MISSING: commitment state length=%d, want >=16",
+			len(state2),
+		)
+	}
+
+	storedTx2, storedBlock2 := commitmentdb.DecodeTxBlockNums(state2)
+
+	if storedBlock2 != block2 || storedTx2 != txNum2 {
+		t.Fatalf(
+			"ZERO_UPDATE_PROGRESS_STALE: got block=%d txNum=%d; want block=%d txNum=%d; root stayed unchanged as required",
+			storedBlock2,
+			storedTx2,
+			block2,
+			txNum2,
+		)
+	}
+}

--- a/db/state/execctx/domain_shared_test.go
+++ b/db/state/execctx/domain_shared_test.go
@@ -2046,14 +2046,11 @@ func TestReceiptAsOf_InFlightBlockLogIndex(t *testing.T) {
 }
 
 // TestSharedDomain_ZeroUpdateCommitmentAdvancesProgress verifies that a
-// commitment computation with no state updates still advances the persisted
-// commitment position when saveState=true.
-//
-// The state root must remain unchanged, but the persisted (blockNum, txNum)
-// must move forward to the new execution position.
+// zero-update commitment advances the persisted execution position without
+// changing the state root or serialized trie state.
 func TestSharedDomain_ZeroUpdateCommitmentAdvancesProgress(t *testing.T) {
 	if testing.Short() {
-		t.Skip()
+		t.Skip("long-running test")
 	}
 
 	const (
@@ -2066,11 +2063,6 @@ func TestSharedDomain_ZeroUpdateCommitmentAdvancesProgress(t *testing.T) {
 
 	db := newTestDb(t, stepSize)
 	ctx := t.Context()
-
-	// -----------------------------------------------------------------
-	// Phase 1:
-	// make a real state change and persist commitment at block1/txNum1.
-	// -----------------------------------------------------------------
 
 	rwTx1, err := db.BeginTemporalRw(ctx)
 	require.NoError(t, err)
@@ -2093,7 +2085,11 @@ func TestSharedDomain_ZeroUpdateCommitmentAdvancesProgress(t *testing.T) {
 		Incarnation: 0,
 	}
 
-	prev, _, err := domains1.GetLatest(kv.AccountsDomain, rwTx1, addr)
+	prev, _, err := domains1.GetLatest(
+		kv.AccountsDomain,
+		rwTx1,
+		addr,
+	)
 	require.NoError(t, err)
 
 	require.NoError(t, domains1.DomainPut(
@@ -2119,14 +2115,7 @@ func TestSharedDomain_ZeroUpdateCommitmentAdvancesProgress(t *testing.T) {
 
 	require.NoError(t, domains1.Flush(ctx, rwTx1))
 	domains1.Close()
-
 	require.NoError(t, rwTx1.Commit())
-
-	// -----------------------------------------------------------------
-	// Phase 2:
-	// reopen from persisted state, make ZERO state updates, then request
-	// commitment persistence at block2/txNum2.
-	// -----------------------------------------------------------------
 
 	rwTx2, err := db.BeginTemporalRw(ctx)
 	require.NoError(t, err)
@@ -2138,27 +2127,23 @@ func TestSharedDomain_ZeroUpdateCommitmentAdvancesProgress(t *testing.T) {
 		kv.GetLatestOptions{},
 	)
 	require.NoError(t, err)
+	require.Greater(t, len(state1), 16)
 
-	if len(state1) < 16 {
-		t.Fatalf(
-			"PHASE1_BASELINE_BAD: commitment state length=%d, want >=16",
-			len(state1),
-		)
-	}
+	storedTx1, storedBlock1 :=
+		commitmentdb.DecodeTxBlockNums(state1)
 
-	storedTx1, storedBlock1 := commitmentdb.DecodeTxBlockNums(state1)
+	require.Equal(t, block1, storedBlock1)
+	require.Equal(t, txNum1, storedTx1)
 
-	if storedBlock1 != block1 || storedTx1 != txNum1 {
-		t.Fatalf(
-			"PHASE1_BASELINE_BAD: got block=%d txNum=%d, want block=%d txNum=%d",
-			storedBlock1,
-			storedTx1,
-			block1,
-			txNum1,
-		)
-	}
+	// GetLatest may return transaction-backed memory. Preserve the serialized
+	// trie payload before committing and reopening the database transaction.
+	trieState1 := bytes.Clone(state1[16:])
 
-	domains2, err := execctx.NewSharedDomains(ctx, rwTx2, log.New())
+	domains2, err := execctx.NewSharedDomains(
+		ctx,
+		rwTx2,
+		log.New(),
+	)
 	require.NoError(t, err)
 
 	// Deliberately perform NO DomainPut/DomainDel calls here.
@@ -2174,25 +2159,11 @@ func TestSharedDomain_ZeroUpdateCommitmentAdvancesProgress(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NotEmpty(t, root2)
-
-	if !bytes.Equal(root1, root2) {
-		t.Fatalf(
-			"ROOT_CHANGED_UNEXPECTED: root1=%x root2=%x",
-			root1,
-			root2,
-		)
-	}
+	require.Equal(t, root1, root2)
 
 	require.NoError(t, domains2.Flush(ctx, rwTx2))
 	domains2.Close()
-
 	require.NoError(t, rwTx2.Commit())
-
-	// -----------------------------------------------------------------
-	// Phase 3:
-	// reopen AGAIN so the assertion is against durable persisted state,
-	// not an in-memory overlay.
-	// -----------------------------------------------------------------
 
 	rwTx3, err := db.BeginTemporalRw(ctx)
 	require.NoError(t, err)
@@ -2204,23 +2175,12 @@ func TestSharedDomain_ZeroUpdateCommitmentAdvancesProgress(t *testing.T) {
 		kv.GetLatestOptions{},
 	)
 	require.NoError(t, err)
+	require.Greater(t, len(state2), 16)
 
-	if len(state2) < 16 {
-		t.Fatalf(
-			"PHASE2_STATE_MISSING: commitment state length=%d, want >=16",
-			len(state2),
-		)
-	}
+	storedTx2, storedBlock2 :=
+		commitmentdb.DecodeTxBlockNums(state2)
 
-	storedTx2, storedBlock2 := commitmentdb.DecodeTxBlockNums(state2)
-
-	if storedBlock2 != block2 || storedTx2 != txNum2 {
-		t.Fatalf(
-			"ZERO_UPDATE_PROGRESS_STALE: got block=%d txNum=%d; want block=%d txNum=%d; root stayed unchanged as required",
-			storedBlock2,
-			storedTx2,
-			block2,
-			txNum2,
-		)
-	}
+	require.Equal(t, block2, storedBlock2)
+	require.Equal(t, txNum2, storedTx2)
+	require.Equal(t, trieState1, state2[16:])
 }

--- a/execution/commitment/commitmentdb/commitment_context.go
+++ b/execution/commitment/commitmentdb/commitment_context.go
@@ -491,13 +491,21 @@ func (sdc *SharedDomainsCommitmentContext) computeCommitment(ctx context.Context
 	// RootHash below); GenerateWitness clears it, so it must be restored on each call.
 	sdc.patriciaTrie.SetTraceWriter(sdc.traceW)
 
+	// Per-ComputeCommitment metrics accumulator for the main (root-fold) reads.
+	// The fold is single-goroutine, so this lock-free accumulator is owned
+	// exclusively here; merged into the shared metrics when commitment finishes.
+	// Warmup/concurrent-mount workers accumulate + merge independently.
+	commitMetrics := kvmetrics.NewDomainMetrics()
+	defer sdc.sharedDomains.MergeMetrics(kvmetrics.SourceCommitment, commitMetrics)
+	readCtx := kvmetrics.ContextWithMetrics(ctx, commitMetrics)
+
 	if updateCount == 0 {
 		rootHash, err = sdc.patriciaTrie.RootHash()
 		if err != nil {
 			return nil, err
 		}
 		if saveState {
-			trieContext := sdc.trieContext(tx, blockNum, txNum, ctx, putter)
+			trieContext := sdc.trieContext(tx, blockNum, txNum, readCtx, putter)
 			if err := sdc.encodeAndStoreCommitmentState(trieContext, blockNum, txNum); err != nil {
 				return nil, err
 			}
@@ -506,14 +514,6 @@ func (sdc *SharedDomainsCommitmentContext) computeCommitment(ctx context.Context
 	}
 
 	// data accessing functions should be set when domain is opened/shared context updated
-
-	// Per-ComputeCommitment metrics accumulator for the main (root-fold) reads.
-	// The fold is single-goroutine, so this lock-free accumulator is owned
-	// exclusively here; merged into the shared metrics when commitment finishes.
-	// Warmup/concurrent-mount workers accumulate + merge independently.
-	commitMetrics := kvmetrics.NewDomainMetrics()
-	defer sdc.sharedDomains.MergeMetrics(kvmetrics.SourceCommitment, commitMetrics)
-	readCtx := kvmetrics.ContextWithMetrics(ctx, commitMetrics)
 
 	trieContext := sdc.trieContext(tx, blockNum, txNum, readCtx, putter)
 

--- a/execution/commitment/commitmentdb/commitment_context.go
+++ b/execution/commitment/commitmentdb/commitment_context.go
@@ -493,7 +493,16 @@ func (sdc *SharedDomainsCommitmentContext) computeCommitment(ctx context.Context
 
 	if updateCount == 0 {
 		rootHash, err = sdc.patriciaTrie.RootHash()
-		return rootHash, err
+		if err != nil {
+			return nil, err
+		}
+		if saveState {
+			trieContext := sdc.trieContext(tx, blockNum, txNum, ctx, putter)
+			if err := sdc.encodeAndStoreCommitmentState(trieContext, blockNum, txNum); err != nil {
+				return nil, err
+			}
+		}
+		return rootHash, nil
 	}
 
 	// data accessing functions should be set when domain is opened/shared context updated


### PR DESCRIPTION
## Summary

Persist commitment progress when `ComputeCommitment` is asked to save state but there are no trie updates.

## Problem

The zero-update path returned immediately after computing the existing root hash. When `saveState` was requested, this skipped persistence of the new block/transaction progress.

As a result, the commitment root could correctly remain unchanged while the durable commitment state still reported the previous `(blockNum, txNum)` after reopening the database.

## Fix

On the zero-update path:

- compute the existing root hash as before;
- when `saveState` is enabled, build the current trie context and persist the commitment state before returning.

The trie root itself remains unchanged.

## Tests

Added `TestSharedDomain_ZeroUpdateCommitmentAdvancesProgress`.

The regression:

- persists commitment state at an initial block/transaction;
- performs a second commitment with zero state updates;
- verifies the root remains unchanged;
- reopens the database and verifies the durable block/transaction progress advanced.

Validation included:

- deterministic RED on unpatched current `main`;
- deterministic GREEN with this change;
- focused race test;
- full `db/state/execctx` tests;
- full `execution/commitment/commitmentdb` tests;
- full Erigon build;
- `make lint`.
