### PR TITLE
execution/engineapi: recover older locally built payloads

### DIFF
--- a/execution/builder/latest_block_built.go
+++ b/execution/builder/latest_block_built.go
@@ -19,27 +19,63 @@ package builder
 import (
 	"sync"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/execution/types"
 )
 
-type LatestBlockBuiltStore struct {
-	block *types.Block
+const recentBlockBuiltCapacity = 16
 
-	lock sync.Mutex
+type LatestBlockBuiltStore struct {
+	block  *types.Block
+	blocks map[common.Hash]*types.Block
+	order  []common.Hash
+
+	lock sync.RWMutex
 }
 
 func NewLatestBlockBuiltStore() *LatestBlockBuiltStore {
-	return &LatestBlockBuiltStore{}
+	return &LatestBlockBuiltStore{
+		blocks: make(map[common.Hash]*types.Block),
+	}
 }
 
 func (s *LatestBlockBuiltStore) AddBlockBuilt(block *types.Block) {
+	if block == nil {
+		return
+	}
+
+	hash := block.Hash()
+
 	s.lock.Lock()
 	defer s.lock.Unlock()
+
 	s.block = block
+
+	if s.blocks == nil {
+		s.blocks = make(map[common.Hash]*types.Block)
+	}
+
+	if _, ok := s.blocks[hash]; !ok {
+		s.order = append(s.order, hash)
+	}
+
+	s.blocks[hash] = block
+
+	for len(s.order) > recentBlockBuiltCapacity {
+		oldest := s.order[0]
+		s.order = s.order[1:]
+		delete(s.blocks, oldest)
+	}
 }
 
 func (s *LatestBlockBuiltStore) BlockBuilt() *types.Block {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	s.lock.RLock()
+	defer s.lock.RUnlock()
 	return s.block
+}
+
+func (s *LatestBlockBuiltStore) BlockBuiltByHash(hash common.Hash) *types.Block {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return s.blocks[hash]
 }

--- a/execution/builder/latest_block_built.go
+++ b/execution/builder/latest_block_built.go
@@ -55,10 +55,17 @@ func (s *LatestBlockBuiltStore) AddBlockBuilt(block *types.Block) {
 		s.blocks = make(map[common.Hash]*types.Block)
 	}
 
-	if _, ok := s.blocks[hash]; !ok {
-		s.order = append(s.order, hash)
+	if _, ok := s.blocks[hash]; ok {
+		for i, existing := range s.order {
+			if existing == hash {
+				copy(s.order[i:], s.order[i+1:])
+				s.order = s.order[:len(s.order)-1]
+				break
+			}
+		}
 	}
 
+	s.order = append(s.order, hash)
 	s.blocks[hash] = block
 
 	for len(s.order) > recentBlockBuiltCapacity {

--- a/execution/builder/latest_block_built.go
+++ b/execution/builder/latest_block_built.go
@@ -26,16 +26,18 @@ import (
 const recentBlockBuiltCapacity = 16
 
 type LatestBlockBuiltStore struct {
-	block  *types.Block
-	blocks map[common.Hash]*types.Block
-	order  []common.Hash
+	block              *types.Block
+	blocks             map[common.Hash]*types.Block
+	order              []common.Hash
+	recoveryIneligible map[common.Hash]struct{}
 
 	lock sync.RWMutex
 }
 
 func NewLatestBlockBuiltStore() *LatestBlockBuiltStore {
 	return &LatestBlockBuiltStore{
-		blocks: make(map[common.Hash]*types.Block),
+		blocks:             make(map[common.Hash]*types.Block),
+		recoveryIneligible: make(map[common.Hash]struct{}),
 	}
 }
 
@@ -53,6 +55,9 @@ func (s *LatestBlockBuiltStore) AddBlockBuilt(block *types.Block) {
 
 	if s.blocks == nil {
 		s.blocks = make(map[common.Hash]*types.Block)
+	}
+	if s.recoveryIneligible == nil {
+		s.recoveryIneligible = make(map[common.Hash]struct{})
 	}
 
 	if _, ok := s.blocks[hash]; ok {
@@ -72,6 +77,7 @@ func (s *LatestBlockBuiltStore) AddBlockBuilt(block *types.Block) {
 		oldest := s.order[0]
 		s.order = s.order[1:]
 		delete(s.blocks, oldest)
+		delete(s.recoveryIneligible, oldest)
 	}
 }
 
@@ -85,4 +91,27 @@ func (s *LatestBlockBuiltStore) BlockBuiltByHash(hash common.Hash) *types.Block 
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	return s.blocks[hash]
+}
+
+func (s *LatestBlockBuiltStore) BlockBuiltForRecovery(hash common.Hash) *types.Block {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	if _, blocked := s.recoveryIneligible[hash]; blocked {
+		return nil
+	}
+	return s.blocks[hash]
+}
+
+func (s *LatestBlockBuiltStore) MarkRecoveryIneligible(hash common.Hash) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if _, ok := s.blocks[hash]; !ok {
+		return
+	}
+	if s.recoveryIneligible == nil {
+		s.recoveryIneligible = make(map[common.Hash]struct{})
+	}
+	s.recoveryIneligible[hash] = struct{}{}
 }

--- a/execution/builder/latest_block_built_test.go
+++ b/execution/builder/latest_block_built_test.go
@@ -30,3 +30,26 @@ func TestLatestBlockBuilt(t *testing.T) {
 	s.AddBlockBuilt(b)
 	assert.Equal(t, b.Header(), s.BlockBuilt().Header())
 }
+
+func TestLatestBlockBuiltKeepsRecentBlocksByHash(t *testing.T) {
+	t.Parallel()
+
+	s := NewLatestBlockBuiltStore()
+	blocks := make([]*types.Block, recentBlockBuiltCapacity+1)
+
+	for i := range blocks {
+		blocks[i] = types.NewBlockWithHeader(
+			&types.Header{Time: uint64(i + 1)},
+			nil,
+		)
+		s.AddBlockBuilt(blocks[i])
+	}
+
+	assert.Nil(t, s.BlockBuiltByHash(blocks[0].Hash()))
+
+	for _, block := range blocks[1:] {
+		assert.Same(t, block, s.BlockBuiltByHash(block.Hash()))
+	}
+
+	assert.Same(t, blocks[len(blocks)-1], s.BlockBuilt())
+}

--- a/execution/builder/latest_block_built_test.go
+++ b/execution/builder/latest_block_built_test.go
@@ -107,3 +107,45 @@ func TestLatestBlockBuiltRefreshesRecency(t *testing.T) {
 		s.BlockBuilt(),
 	)
 }
+
+func TestLatestBlockBuiltRecoverySuppressionIsBounded(t *testing.T) {
+	t.Parallel()
+
+	s := NewLatestBlockBuiltStore()
+	block := types.NewBlockWithHeader(
+		&types.Header{Time: 1},
+		nil,
+	)
+	s.AddBlockBuilt(block)
+
+	hash := block.Hash()
+
+	// A freshly built payload is eligible for local FCU recovery.
+	assert.Same(t, block, s.BlockBuiltForRecovery(hash))
+
+	// Request-level invalidity must suppress FCU-only local recovery without
+	// discarding the underlying locally built payload.
+	s.MarkRecoveryIneligible(hash)
+
+	assert.Same(t, block, s.BlockBuiltByHash(hash))
+	assert.Nil(t, s.BlockBuiltForRecovery(hash))
+
+	// Suppression is bounded to the same lifetime as the cached payload.
+	// Once this payload is evicted, its request-level suppression state must
+	// disappear with it.
+	for i := 0; i < recentBlockBuiltCapacity; i++ {
+		other := types.NewBlockWithHeader(
+			&types.Header{Time: uint64(i + 2)},
+			nil,
+		)
+		s.AddBlockBuilt(other)
+	}
+
+	assert.Nil(t, s.BlockBuiltByHash(hash))
+	assert.Nil(t, s.BlockBuiltForRecovery(hash))
+
+	// If the same payload is later built again after eviction, it is a fresh
+	// cache entry rather than a permanently poisoned block hash.
+	s.AddBlockBuilt(block)
+	assert.Same(t, block, s.BlockBuiltForRecovery(hash))
+}

--- a/execution/builder/latest_block_built_test.go
+++ b/execution/builder/latest_block_built_test.go
@@ -53,3 +53,57 @@ func TestLatestBlockBuiltKeepsRecentBlocksByHash(t *testing.T) {
 
 	assert.Same(t, blocks[len(blocks)-1], s.BlockBuilt())
 }
+
+func TestLatestBlockBuiltRefreshesRecency(t *testing.T) {
+	t.Parallel()
+
+	s := NewLatestBlockBuiltStore()
+
+	blocks := make(
+		[]*types.Block,
+		recentBlockBuiltCapacity+1,
+	)
+
+	for i := range blocks {
+		blocks[i] = types.NewBlockWithHeader(
+			&types.Header{Time: uint64(i + 1)},
+			nil,
+		)
+	}
+
+	for _, block := range blocks[:recentBlockBuiltCapacity] {
+		s.AddBlockBuilt(block)
+	}
+
+	// Rebuilding the oldest cached payload must refresh its recency.
+	s.AddBlockBuilt(blocks[0])
+
+	// Adding one more payload must therefore evict the second-oldest
+	// payload, not the payload that was just rebuilt.
+	s.AddBlockBuilt(blocks[recentBlockBuiltCapacity])
+
+	assert.Same(
+		t,
+		blocks[0],
+		s.BlockBuiltByHash(blocks[0].Hash()),
+	)
+
+	assert.Nil(
+		t,
+		s.BlockBuiltByHash(blocks[1].Hash()),
+	)
+
+	for _, block := range blocks[2:] {
+		assert.Same(
+			t,
+			block,
+			s.BlockBuiltByHash(block.Hash()),
+		)
+	}
+
+	assert.Same(
+		t,
+		blocks[recentBlockBuiltCapacity],
+		s.BlockBuilt(),
+	)
+}

--- a/execution/builder/latest_block_built_test.go
+++ b/execution/builder/latest_block_built_test.go
@@ -133,7 +133,7 @@ func TestLatestBlockBuiltRecoverySuppressionIsBounded(t *testing.T) {
 	// Suppression is bounded to the same lifetime as the cached payload.
 	// Once this payload is evicted, its request-level suppression state must
 	// disappear with it.
-	for i := 0; i < recentBlockBuiltCapacity; i++ {
+	for i := range recentBlockBuiltCapacity {
 		other := types.NewBlockWithHeader(
 			&types.Header{Time: uint64(i + 2)},
 			nil,

--- a/execution/engineapi/engine_api_builder_test.go
+++ b/execution/engineapi/engine_api_builder_test.go
@@ -1123,3 +1123,48 @@ func lastBalanceChange(ac *types.AccountChanges) *types.BalanceChange {
 	}
 	return last
 }
+
+func TestEngineApiForkChoiceRecoversOlderLocallyBuiltPayload(t *testing.T) {
+	ctx := t.Context()
+	logger := testlog.Logger(t, log.LvlError)
+	eat, err := engineapitester.DefaultEngineApiTester(ctx, logger, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, eat.Close()) })
+
+	eat.Run(t, func(ctx context.Context, t *testing.T, eat engineapitester.EngineApiTester) {
+		baseTimestamp := eat.MockCl.State().ParentElTimestamp
+		var first *engineapitester.MockClPayload
+		var latest *engineapitester.MockClPayload
+
+		for i := uint64(1); i <= 4; i++ {
+			payload, err := eat.MockCl.BuildNewPayload(ctx, engineapitester.WithTimestamp(baseTimestamp+i))
+			require.NoError(t, err)
+			if first == nil {
+				first = payload
+			}
+			latest = payload
+		}
+
+		require.NotNil(t, first)
+		require.NotNil(t, latest)
+		require.Equal(t, first.ExecutionPayload.BlockNumber, latest.ExecutionPayload.BlockNumber)
+		require.NotEqual(t, first.ExecutionPayload.BlockHash, latest.ExecutionPayload.BlockHash)
+
+		forkChoice := enginetypes.ForkChoiceState{
+			HeadHash:           first.ExecutionPayload.BlockHash,
+			SafeBlockHash:      eat.GenesisBlock.Hash(),
+			FinalizedBlockHash: eat.GenesisBlock.Hash(),
+		}
+
+		var response *enginetypes.ForkChoiceUpdatedResponse
+		if eat.ChainConfig.AmsterdamTime != nil {
+			response, err = eat.EngineApiClient.ForkchoiceUpdatedV4(ctx, &forkChoice, nil, nil)
+		} else {
+			response, err = eat.EngineApiClient.ForkchoiceUpdatedV3(ctx, &forkChoice, nil)
+		}
+		require.NoError(t, err)
+		require.NotNil(t, response)
+		require.Equal(t, enginetypes.ValidStatus, response.PayloadStatus.Status,
+			"forkchoice must recover an older locally built payload instead of returning SYNCING")
+	})
+}

--- a/execution/engineapi/engine_api_builder_test.go
+++ b/execution/engineapi/engine_api_builder_test.go
@@ -1168,3 +1168,105 @@ func TestEngineApiForkChoiceRecoversOlderLocallyBuiltPayload(t *testing.T) {
 			"forkchoice must recover an older locally built payload instead of returning SYNCING")
 	})
 }
+
+func TestEngineApiForkChoiceDoesNotLaunderInvalidBlobHashesViaLocalRecovery(t *testing.T) {
+	ctx := t.Context()
+	logger := testlog.Logger(t, log.LvlError)
+
+	genesis, coinbaseKey, err := engineapitester.DefaultEngineApiTesterGenesis()
+	require.NoError(t, err)
+
+	// Keep Osaka/Electra active but disable Amsterdam/Gloas. This makes
+	// NewPayloadV4 and ForkchoiceUpdatedV3 the fork-appropriate methods while
+	// retaining the modern test harness and blob validation.
+	genesis.Config.AmsterdamTime = nil
+
+	eat, err := engineapitester.InitialiseEngineApiTester(
+		ctx,
+		engineapitester.EngineApiTesterInitArgs{
+			Logger:      logger,
+			DataDir:     t.TempDir(),
+			Genesis:     genesis,
+			CoinbaseKey: coinbaseKey,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, eat.Close()) })
+
+	eat.Run(t, func(ctx context.Context, t *testing.T, eat engineapitester.EngineApiTester) {
+		require.Nil(t, eat.ChainConfig.AmsterdamTime)
+		require.NotNil(t, eat.ChainConfig.OsakaTime)
+
+		payload, err := eat.MockCl.BuildNewPayload(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, payload)
+		require.NotNil(t, payload.ExecutionPayload)
+		require.NotNil(t, payload.ParentBeaconBlockRoot)
+
+		// This payload contains no blob transactions. One otherwise correctly
+		// version-prefixed hash therefore makes the auxiliary blob-hash list
+		// inconsistent with the payload.
+		badVersionedHashes := []common.Hash{{0x01}}
+
+		executionRequests := payload.ExecutionRequests
+		if executionRequests == nil {
+			executionRequests = []hexutil.Bytes{}
+		}
+
+		status, err := eat.EngineApiClient.NewPayloadV4(
+			ctx,
+			payload.ExecutionPayload,
+			badVersionedHashes,
+			payload.ParentBeaconBlockRoot,
+			executionRequests,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, status)
+		require.Equal(t, enginetypes.InvalidStatus, status.Status)
+		require.NotNil(t, status.ValidationError)
+		require.ErrorContains(t, status.ValidationError.Error(), "mismatch blob hashes")
+
+		forkChoice := enginetypes.ForkChoiceState{
+			HeadHash:           payload.ExecutionPayload.BlockHash,
+			SafeBlockHash:      eat.GenesisBlock.Hash(),
+			FinalizedBlockHash: eat.GenesisBlock.Hash(),
+		}
+
+		response, err := eat.EngineApiClient.ForkchoiceUpdatedV3(
+			ctx,
+			&forkChoice,
+			nil,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, response)
+
+		require.NotEqual(
+			t,
+			enginetypes.ValidStatus,
+			response.PayloadStatus.Status,
+			"forkchoice must not turn an INVALID newPayload request into VALID through local-cache recovery",
+		)
+
+		status, err = eat.EngineApiClient.NewPayloadV4(
+			ctx,
+			payload.ExecutionPayload,
+			[]common.Hash{},
+			payload.ParentBeaconBlockRoot,
+			executionRequests,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, status)
+		require.Equal(t, enginetypes.ValidStatus, status.Status,
+			"a correctly formed newPayload request must remain able to validate the same execution payload")
+
+		response, err = eat.EngineApiClient.ForkchoiceUpdatedV3(
+			ctx,
+			&forkChoice,
+			nil,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, response)
+		require.Equal(t, enginetypes.ValidStatus, response.PayloadStatus.Status,
+			"correct newPayload validation must restore normal forkchoice validity")
+	})
+}

--- a/execution/engineapi/engine_server.go
+++ b/execution/engineapi/engine_server.go
@@ -68,9 +68,10 @@ var caplinEnabledLog = "Caplin is enabled, so the engine API cannot be used. for
 var errCaplinEnabled = &rpc.UnsupportedForkError{Message: "caplin is enabled"}
 
 type EngineServer struct {
-	blockDownloader *engine_block_downloader.EngineBlockDownloader
-	config          *chain.Config
-	beaconCfg       atomic.Pointer[clparams.BeaconChainConfig]
+	blockDownloader       *engine_block_downloader.EngineBlockDownloader
+	latestBlockBuiltStore *builder.LatestBlockBuiltStore
+	config                *chain.Config
+	beaconCfg             atomic.Pointer[clparams.BeaconChainConfig]
 	// Block proposing for proof-of-stake
 	proposing bool
 	// Block consuming for proof-of-stake
@@ -125,6 +126,10 @@ func NewEngineServer(
 	srv.consuming.Store(consuming)
 
 	return srv
+}
+
+func (e *EngineServer) SetLatestBlockBuiltStore(store *builder.LatestBlockBuiltStore) {
+	e.latestBlockBuiltStore = store
 }
 
 func (e *EngineServer) SetBeaconChainConfig(beaconCfg *clparams.BeaconChainConfig) {
@@ -1178,6 +1183,33 @@ func (e *EngineServer) HandleForkChoice(
 	headerNumber, err := e.chainRW.HeaderNumber(ctx, headerHash)
 	if err != nil {
 		return nil, err
+	}
+
+	// A locally built payload may be selected by the CL after a newer competing
+	// payload has been built. Recover it through the ordinary new-payload
+	// insertion/validation path before falling back to peer download.
+	if headerNumber == nil && e.latestBlockBuiltStore != nil {
+		if locallyBuilt := e.latestBlockBuiltStore.BlockBuiltByHash(headerHash); locallyBuilt != nil {
+			e.logger.Debug(fmt.Sprintf("[%s] Fork choice: recovering locally built head", logPrefix),
+				"height", locallyBuilt.NumberU64(), "hash", headerHash)
+
+			payloadStatus, recoverErr := e.HandleNewPayload(ctx, logPrefix+"LocalBuilt", locallyBuilt, nil)
+			if recoverErr != nil {
+				return nil, recoverErr
+			}
+			if payloadStatus == nil {
+				return nil, errors.New("locally built payload recovery returned nil status")
+			}
+			switch payloadStatus.Status {
+			case engine_types.InvalidStatus, engine_types.SyncingStatus:
+				return payloadStatus, nil
+			}
+
+			headerNumber, err = e.chainRW.HeaderNumber(ctx, headerHash)
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	// We do not have header, download.

--- a/execution/engineapi/engine_server.go
+++ b/execution/engineapi/engine_server.go
@@ -486,6 +486,9 @@ func (s *EngineServer) newPayload(ctx context.Context, req *engine_types.Executi
 			}, nil
 		}
 		if errors.Is(err, misc.ErrMismatchBlobHashes) || errors.Is(err, misc.ErrInvalidVersionedHash) {
+			if s.latestBlockBuiltStore != nil {
+				s.latestBlockBuiltStore.MarkRecoveryIneligible(blockHash)
+			}
 			return &engine_types.PayloadStatus{
 				Status:          engine_types.InvalidStatus,
 				ValidationError: engine_types.NewStringifiedErrorFromString(err.Error()),
@@ -645,7 +648,7 @@ func (s *EngineServer) getQuickPayloadStatusIfPossible(ctx context.Context, bloc
 	} else {
 		if shouldWait, _ := waitForResponse(50*time.Millisecond, func() (bool, error) {
 			locallyBuilt := s.latestBlockBuiltStore != nil &&
-				s.latestBlockBuiltStore.BlockBuiltByHash(blockHash) != nil
+				s.latestBlockBuiltStore.BlockBuiltForRecovery(blockHash) != nil
 			return header == nil &&
 				!locallyBuilt &&
 				s.blockDownloader.Status() == engine_block_downloader.Syncing, nil
@@ -1200,7 +1203,7 @@ func (e *EngineServer) HandleForkChoice(
 	// payload has been built. Recover it through the ordinary new-payload
 	// insertion/validation path before falling back to peer download.
 	if headerNumber == nil && e.latestBlockBuiltStore != nil {
-		if locallyBuilt := e.latestBlockBuiltStore.BlockBuiltByHash(headerHash); locallyBuilt != nil {
+		if locallyBuilt := e.latestBlockBuiltStore.BlockBuiltForRecovery(headerHash); locallyBuilt != nil {
 			e.logger.Debug(fmt.Sprintf("[%s] Fork choice: recovering locally built head", logPrefix),
 				"height", locallyBuilt.NumberU64(), "hash", headerHash)
 

--- a/execution/engineapi/engine_server.go
+++ b/execution/engineapi/engine_server.go
@@ -67,8 +67,15 @@ import (
 var caplinEnabledLog = "Caplin is enabled, so the engine API cannot be used. for external CL use --externalcl"
 var errCaplinEnabled = &rpc.UnsupportedForkError{Message: "caplin is enabled"}
 
+type engineBlockDownloader interface {
+	ReportBadHeader(common.Hash, common.Hash, string)
+	IsBadHeader(common.Hash) (bool, common.Hash, string)
+	Status() engine_block_downloader.Status
+	StartDownloading(common.Hash, *types.Block, engine_block_downloader.Trigger) bool
+}
+
 type EngineServer struct {
-	blockDownloader       *engine_block_downloader.EngineBlockDownloader
+	blockDownloader       engineBlockDownloader
 	latestBlockBuiltStore *builder.LatestBlockBuiltStore
 	config                *chain.Config
 	beaconCfg             atomic.Pointer[clparams.BeaconChainConfig]
@@ -637,7 +644,11 @@ func (s *EngineServer) getQuickPayloadStatusIfPossible(ctx context.Context, bloc
 		}
 	} else {
 		if shouldWait, _ := waitForResponse(50*time.Millisecond, func() (bool, error) {
-			return header == nil && s.blockDownloader.Status() == engine_block_downloader.Syncing, nil
+			locallyBuilt := s.latestBlockBuiltStore != nil &&
+				s.latestBlockBuiltStore.BlockBuiltByHash(blockHash) != nil
+			return header == nil &&
+				!locallyBuilt &&
+				s.blockDownloader.Status() == engine_block_downloader.Syncing, nil
 		}); shouldWait {
 			s.logger.Debug(fmt.Sprintf("[%s] Downloading some other PoS stuff", prefix), "hash", blockHash)
 			return &engine_types.PayloadStatus{Status: engine_types.SyncingStatus}, nil

--- a/execution/engineapi/testing_api_test.go
+++ b/execution/engineapi/testing_api_test.go
@@ -68,6 +68,37 @@ type stubExecutionModule struct {
 
 var _ execmodule.ExecutionModule = (*stubExecutionModule)(nil)
 
+type stubBlockDownloader struct {
+	status engine_block_downloader.Status
+}
+
+var _ engineBlockDownloader = (*stubBlockDownloader)(nil)
+
+func (*stubBlockDownloader) ReportBadHeader(
+	common.Hash,
+	common.Hash,
+	string,
+) {
+}
+
+func (*stubBlockDownloader) IsBadHeader(
+	common.Hash,
+) (bool, common.Hash, string) {
+	return false, common.Hash{}, ""
+}
+
+func (s *stubBlockDownloader) Status() engine_block_downloader.Status {
+	return s.status
+}
+
+func (*stubBlockDownloader) StartDownloading(
+	common.Hash,
+	*types.Block,
+	engine_block_downloader.Trigger,
+) bool {
+	return false
+}
+
 func (s *stubExecutionModule) GetHeader(ctx context.Context, blockHash *common.Hash, blockNumber *uint64) (*types.Header, error) {
 	if s.getHeaderFunc != nil {
 		return s.getHeaderFunc(ctx, blockHash, blockNumber)
@@ -1201,6 +1232,75 @@ func TestForkchoiceUpdatedV2PayloadAttributesWithdrawalsValidation(t *testing.T)
 		require.True(t, errors.As(err, &rpcErr))
 		require.Equal(t, -38003, rpcErr.ErrorCode())
 	})
+}
+
+func TestGetQuickPayloadStatusAllowsCachedForkchoiceDuringActiveDownload(t *testing.T) {
+	t.Parallel()
+
+	cfg := preCancunChainConfig()
+	srv := NewEngineServer(
+		log.New(),
+		cfg,
+		&stubExecutionModule{},
+		nil,
+		false,
+		false,
+		false,
+		true,
+		nil,
+		nil,
+		0,
+		0,
+	)
+
+	srv.blockDownloader = &stubBlockDownloader{
+		status: engine_block_downloader.Syncing,
+	}
+
+	store := builder.NewLatestBlockBuiltStore()
+	block := types.NewBlockWithHeader(
+		&types.Header{Time: 1},
+		nil,
+	)
+	store.AddBlockBuilt(block)
+	srv.SetLatestBlockBuiltStore(store)
+
+	forkchoiceState := &engine_types.ForkChoiceState{
+		HeadHash: block.Hash(),
+	}
+
+	status, err := srv.getQuickPayloadStatusIfPossible(
+		context.Background(),
+		block.Hash(),
+		0,
+		common.Hash{},
+		forkchoiceState,
+		false,
+	)
+	require.NoError(t, err)
+	require.Nil(
+		t,
+		status,
+		"cached local head must reach HandleForkChoice even while another download is active",
+	)
+
+	unknownHash := common.Hash{0xff}
+	unknownForkchoice := &engine_types.ForkChoiceState{
+		HeadHash: unknownHash,
+	}
+
+	status, err = srv.getQuickPayloadStatusIfPossible(
+		context.Background(),
+		unknownHash,
+		0,
+		common.Hash{},
+		unknownForkchoice,
+		false,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	require.Equal(t, engine_types.SyncingStatus, status.Status,
+		"genuinely unknown head must remain SYNCING during an active download")
 }
 
 // TestForkchoiceUpdatedV2ValidatesAttributesWhenSyncing pins the engine-api spec

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -962,6 +962,7 @@ func New(
 		config.FcuTimeout,
 		config.MaxReorgDepth,
 	)
+	engineBackendRPC.SetLatestBlockBuiltStore(latestBlockBuiltStore)
 	backend.engineBackendRPC = engineBackendRPC
 	// If we choose not to run a consensus layer, run our embedded.
 	if config.InternalCL && (clparams.EmbeddedSupported(config.NetworkID) || config.CaplinConfig.IsDevnet()) {


### PR DESCRIPTION
## Summary

Allow forkchoice to recover a recent locally built payload even when a newer competing payload has subsequently been built.

## Problem

`LatestBlockBuiltStore` retained only the most recently built block.

If several competing payloads were built and the consensus layer later selected an older locally built payload, Engine API forkchoice could no longer find that payload locally. It then fell through to downloader handling and returned `SYNCING`.

A deterministic regression reproduces this by building several competing payloads at the same height and selecting the first one afterward.

## Fix

Keep a small bounded set of recent locally built blocks indexed by hash while preserving the existing latest-block lookup.

When forkchoice references an unknown header:

- check the recent locally built block store first;
- if found, pass the block through the ordinary `HandleNewPayload` validation/insertion path;
- only fall back to peer download when the payload is not available locally.

The store is bounded to 16 recent blocks.

Current `types.Block` already retains its block access list sidecar, so no separate BAL storage or builder `finish.go` plumbing is added.

## Tests

Added:

- `TestLatestBlockBuiltKeepsRecentBlocksByHash`;
- `TestEngineApiForkChoiceRecoversOlderLocallyBuiltPayload`.

The Engine API regression returns `SYNCING` on unpatched current `main` and `VALID` with this change.

Validation included:

- deterministic RED/GREEN regression;
- full builder package tests;
- builder race tests;
- full Engine API package tests;
- focused Engine API race test;
- `node/eth` compile check;
- full Erigon build;
- `make lint`.
