### PR TITLE
cl/forkchoice: reuse Gloas contribution capacity

### DIFF
--- a/cl/phase1/forkchoice/gloas_weight_tree.go
+++ b/cl/phase1/forkchoice/gloas_weight_tree.go
@@ -228,6 +228,9 @@ func growGloasContributions(applied []gloasVoteContribution, size int) []gloasVo
 	if len(applied) >= size {
 		return applied
 	}
+	if cap(applied) >= size {
+		return applied[:size]
+	}
 	nextCap := max(cap(applied)*2, size)
 	next := make([]gloasVoteContribution, size, nextCap)
 	copy(next, applied)

--- a/cl/phase1/forkchoice/gloas_weight_tree.go
+++ b/cl/phase1/forkchoice/gloas_weight_tree.go
@@ -229,7 +229,10 @@ func growGloasContributions(applied []gloasVoteContribution, size int) []gloasVo
 		return applied
 	}
 	if cap(applied) >= size {
-		return applied[:size]
+		oldLen := len(applied)
+		applied = applied[:size]
+		clear(applied[oldLen:])
+		return applied
 	}
 	nextCap := max(cap(applied)*2, size)
 	next := make([]gloasVoteContribution, size, nextCap)

--- a/cl/phase1/forkchoice/gloas_weight_tree_test.go
+++ b/cl/phase1/forkchoice/gloas_weight_tree_test.go
@@ -181,14 +181,51 @@ func TestGrowGloasContributionsGrowsAmortized(t *testing.T) {
 	applied := growGloasContributions(nil, 1)
 	require.Len(t, applied, 1)
 	require.Equal(t, 1, cap(applied))
+	applied[0] = gloasVoteContribution{contribution: 42, set: true}
 
 	applied = growGloasContributions(applied, 2)
 	require.Len(t, applied, 2)
 	require.Equal(t, 2, cap(applied))
+	require.Equal(t, gloasVoteContribution{contribution: 42, set: true}, applied[0])
+	require.Equal(t, gloasVoteContribution{}, applied[1])
 
 	applied = growGloasContributions(applied, 3)
 	require.Len(t, applied, 3)
 	require.Greater(t, cap(applied), len(applied))
+	require.Equal(t, gloasVoteContribution{contribution: 42, set: true}, applied[0])
+	require.Equal(t, gloasVoteContribution{}, applied[2])
+}
+
+func TestGrowGloasContributionsReusesCapacity(t *testing.T) {
+	applied := make([]gloasVoteContribution, 1, 3)
+	applied[0] = gloasVoteContribution{contribution: 42, set: true}
+	first := &applied[0]
+
+	applied = growGloasContributions(applied, 3)
+
+	require.Len(t, applied, 3)
+	require.Equal(t, 3, cap(applied))
+	require.Same(t, first, &applied[0])
+	require.Equal(t, gloasVoteContribution{contribution: 42, set: true}, applied[0])
+	require.Equal(t, gloasVoteContribution{}, applied[1])
+	require.Equal(t, gloasVoteContribution{}, applied[2])
+}
+
+func TestGrowGloasContributionsNoGrowth(t *testing.T) {
+	require.Nil(t, growGloasContributions(nil, 0))
+
+	applied := []gloasVoteContribution{{contribution: 42, set: true}, {contribution: 64}}
+	first := &applied[0]
+
+	unchanged := growGloasContributions(applied, len(applied))
+	require.Len(t, unchanged, len(applied))
+	require.Same(t, first, &unchanged[0])
+	require.Equal(t, applied, unchanged)
+
+	notShrunk := growGloasContributions(applied, 1)
+	require.Len(t, notShrunk, len(applied))
+	require.Same(t, first, &notShrunk[0])
+	require.Equal(t, applied, notShrunk)
 }
 
 func TestGloasMarksDirtyWeightTree(t *testing.T) {

--- a/cl/phase1/forkchoice/gloas_weight_tree_test.go
+++ b/cl/phase1/forkchoice/gloas_weight_tree_test.go
@@ -211,6 +211,23 @@ func TestGrowGloasContributionsReusesCapacity(t *testing.T) {
 	require.Equal(t, gloasVoteContribution{}, applied[2])
 }
 
+func TestGrowGloasContributionsClearsReexposedCapacity(t *testing.T) {
+	backing := []gloasVoteContribution{
+		{contribution: 42, set: true},
+		{contribution: 64, set: true},
+		{contribution: 128, set: true},
+	}
+	applied := backing[:1]
+	first := &applied[0]
+
+	applied = growGloasContributions(applied, len(backing))
+
+	require.Same(t, first, &applied[0])
+	require.Equal(t, gloasVoteContribution{contribution: 42, set: true}, applied[0])
+	require.Equal(t, gloasVoteContribution{}, applied[1])
+	require.Equal(t, gloasVoteContribution{}, applied[2])
+}
+
 func TestGrowGloasContributionsNoGrowth(t *testing.T) {
 	require.Nil(t, growGloasContributions(nil, 0))
 


### PR DESCRIPTION
## Summary

- reuse the existing `gloasVoteContribution` backing array when the requested length fits its capacity
- preserve amortized growth only for genuine capacity misses
- cover capacity reuse, data preservation, zero initialization, and no-growth boundaries

## Background

On glamsterdam-devnet-8, Caplin's live heap reached approximately 48 GiB. A heap profile attributed 46.84 GiB (98.6%) to `growGloasContributions`.

The helper allocated and doubled capacity whenever `size` exceeded `len`, even when `size` still fit within `cap`. As newly introduced validator indices first voted, a one-element logical growth could repeatedly double the retained backing array.

## TDD evidence

Before the production change, `TestGrowGloasContributionsReusesCapacity` failed with:

```text
expected cap 3, actual 6
```

The minimal production change makes that test pass by reslicing within existing capacity.

## Validation

- `go test ./cl/phase1/forkchoice -count=1`
- `make lint` (clean on repeated runs, including immediately before push)
- `make erigon integration`
- `git diff --check`
- independent state/lifecycle and boundary/integration reviews converged with no actionable findings

Fixes #23728.
