### PR TITLE
[r3.6] cl/network: fix blob history backfill boundary and sparse-peer startup

### DIFF
--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -451,8 +451,8 @@ func (a *Antiquary) NotifyBackfilled() {
 	a.backfilled.Store(true) // this is the lowest slot not in snapshots
 }
 
-func (a *Antiquary) NotifyBlobBackfilled() {
-	a.blobBackfilled.Store(true)
+func (a *Antiquary) NotifyBlobBackfilled(completed bool) {
+	a.blobBackfilled.Store(completed)
 }
 
 func (a *Antiquary) antiquateBlobs() error {

--- a/cl/antiquary/antiquary_test.go
+++ b/cl/antiquary/antiquary_test.go
@@ -424,8 +424,10 @@ func TestNotifyBlobBackfilled(t *testing.T) {
 	a := NewAntiquary(ctx, nil, nil, nil, &clparams.MainnetBeaconConfig, datadir.Dirs{}, nil, nil, nil, nil, nil, nil, log.New(), true, true, true, false, nil)
 
 	require.False(t, a.blobBackfilled.Load())
-	a.NotifyBlobBackfilled()
+	a.NotifyBlobBackfilled(true)
 	require.True(t, a.blobBackfilled.Load())
+	a.NotifyBlobBackfilled(false)
+	require.False(t, a.blobBackfilled.Load())
 }
 
 func TestBeaconStatesCollector_CollectStateRoot(t *testing.T) {

--- a/cl/antiquary/retirement_loop_test.go
+++ b/cl/antiquary/retirement_loop_test.go
@@ -197,6 +197,16 @@ func TestRetirementTickWaitsForBackfill(t *testing.T) {
 	require.Zero(t, h.blobsRuns)
 }
 
+func TestRetirementTickStopsBlobsWhenCompletionIsRevoked(t *testing.T) {
+	h := newTickHarness(t)
+	h.a.NotifyBlobBackfilled(false)
+
+	h.tick(3)
+
+	require.Equal(t, 3, h.blocksRuns)
+	require.Zero(t, h.blobsRuns)
+}
+
 // A failure during shutdown is not the step's fault, so it must not be counted.
 func TestRetirementTickDoesNotBackOffOnShutdown(t *testing.T) {
 	h := newTickHarness(t)

--- a/cl/beacon/handler/utils_test.go
+++ b/cl/beacon/handler/utils_test.go
@@ -18,7 +18,6 @@ package handler
 
 import (
 	"context"
-	"math"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -103,7 +102,7 @@ func setupTestingHandler(t *testing.T, v clparams.StateVersion, logger log.Logge
 	genesis, err := initial_state.GetGenesisState(chainspec.MainnetChainID)
 	require.NoError(t, err)
 	ethClock := eth_clock.NewEthereumClock(genesis.GenesisTime(), genesis.GenesisValidatorsRoot(), &bcfg)
-	blobStorage := blob_storage.NewBlobStore(blobDb, afero.NewMemMapFs(), math.MaxUint64, &bcfg, ethClock)
+	blobStorage := blob_storage.NewBlobStore(blobDb, afero.NewMemMapFs())
 	columnStorage := blob_storage_mock.NewMockDataColumnStorage(ctrl)
 	blobStorage.WriteBlobSidecars(ctx, firstBlockRoot, []*cltypes.BlobSidecar{
 		{

--- a/cl/das/mock_services/peer_das_mock.go
+++ b/cl/das/mock_services/peer_das_mock.go
@@ -273,40 +273,40 @@ func (c *MockPeerDasIsDataAvailableCall) DoAndReturn(f func(uint64, common.Hash)
 	return c
 }
 
-// Prune mocks base method.
-func (m *MockPeerDas) Prune(keepSlotDistance uint64) error {
+// PruneBelow mocks base method.
+func (m *MockPeerDas) PruneBelow(slot uint64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Prune", keepSlotDistance)
+	ret := m.ctrl.Call(m, "PruneBelow", slot)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Prune indicates an expected call of Prune.
-func (mr *MockPeerDasMockRecorder) Prune(keepSlotDistance any) *MockPeerDasPruneCall {
+// PruneBelow indicates an expected call of PruneBelow.
+func (mr *MockPeerDasMockRecorder) PruneBelow(slot any) *MockPeerDasPruneBelowCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prune", reflect.TypeOf((*MockPeerDas)(nil).Prune), keepSlotDistance)
-	return &MockPeerDasPruneCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PruneBelow", reflect.TypeOf((*MockPeerDas)(nil).PruneBelow), slot)
+	return &MockPeerDasPruneBelowCall{Call: call}
 }
 
-// MockPeerDasPruneCall wrap *gomock.Call
-type MockPeerDasPruneCall struct {
+// MockPeerDasPruneBelowCall wrap *gomock.Call
+type MockPeerDasPruneBelowCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockPeerDasPruneCall) Return(arg0 error) *MockPeerDasPruneCall {
+func (c *MockPeerDasPruneBelowCall) Return(arg0 error) *MockPeerDasPruneBelowCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockPeerDasPruneCall) Do(f func(uint64) error) *MockPeerDasPruneCall {
+func (c *MockPeerDasPruneBelowCall) Do(f func(uint64) error) *MockPeerDasPruneBelowCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockPeerDasPruneCall) DoAndReturn(f func(uint64) error) *MockPeerDasPruneCall {
+func (c *MockPeerDasPruneBelowCall) DoAndReturn(f func(uint64) error) *MockPeerDasPruneBelowCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -343,6 +343,42 @@ func (c *MockPeerDasSetForkChoiceCall) Do(f func(das.BlockGetter)) *MockPeerDasS
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockPeerDasSetForkChoiceCall) DoAndReturn(f func(das.BlockGetter)) *MockPeerDasSetForkChoiceCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// Start mocks base method.
+func (m *MockPeerDas) Start(ctx context.Context) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Start", ctx)
+}
+
+// Start indicates an expected call of Start.
+func (mr *MockPeerDasMockRecorder) Start(ctx any) *MockPeerDasStartCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockPeerDas)(nil).Start), ctx)
+	return &MockPeerDasStartCall{Call: call}
+}
+
+// MockPeerDasStartCall wrap *gomock.Call
+type MockPeerDasStartCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockPeerDasStartCall) Return() *MockPeerDasStartCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockPeerDasStartCall) Do(f func(context.Context)) *MockPeerDasStartCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockPeerDasStartCall) DoAndReturn(f func(context.Context)) *MockPeerDasStartCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/cl/das/peer_das.go
+++ b/cl/das/peer_das.go
@@ -1,9 +1,11 @@
 package das
 
 import (
+	"container/heap"
 	"context"
 	"errors"
 	"math"
+	"os"
 	"sync"
 	"time"
 
@@ -48,12 +50,13 @@ type gloasBlockData struct {
 
 //go:generate mockgen -typed=true -destination=mock_services/peer_das_mock.go -package=mock_services . PeerDas
 type PeerDas interface {
+	Start(ctx context.Context)
 	// [Modified in Gloas:EIP7732] Changed from []*SignedBlindedBeaconBlock to []ColumnSyncableSignedBlock
 	// to support both pre-GLOAS (blinded) and GLOAS (non-blinded) blocks
 	DownloadColumnsAndRecoverBlobs(ctx context.Context, blocks []cltypes.ColumnSyncableSignedBlock) error
 	DownloadOnlyCustodyColumns(ctx context.Context, blocks []cltypes.ColumnSyncableSignedBlock) error
 	IsDataAvailable(slot uint64, blockRoot common.Hash) (bool, error)
-	Prune(keepSlotDistance uint64) error
+	PruneBelow(slot uint64) error
 	UpdateValidatorsCustody(cgc uint64)
 	TryScheduleRecover(slot uint64, blockRoot common.Hash) error
 	IsBlobAlreadyRecovered(blockRoot common.Hash) bool
@@ -64,8 +67,11 @@ type PeerDas interface {
 	SetForkChoice(forkChoice BlockGetter) // [New in Gloas:EIP7732]
 }
 
-var (
-	numOfBlobRecoveryWorkers = 8
+var numOfBlobRecoveryWorkers = 8
+
+const (
+	blobRecoveryValidationRetryInterval = 500 * time.Millisecond
+	maxBlobRecoveryResultBytes          = 16 << 20
 )
 
 type peerdas struct {
@@ -81,19 +87,34 @@ type peerdas struct {
 	gossipManager     gossipmgr.Gossip
 	recoverBlobsQueue chan recoverBlobsRequest
 
-	recoveringMutex   sync.Mutex
-	isRecovering      map[common.Hash]bool
-	blocksToCheckSync sync.Map // blockRoot -> ColumnSyncableSignedBlock (SignedBeaconBlock or SignedBlindedBeaconBlock)
+	recoveringMutex     sync.Mutex
+	isRecovering        map[common.Hash]bool
+	recoveryRequests    map[common.Hash]recoverBlobsRequest
+	recoveryGenerations map[common.Hash]uint64
+	recoveryResults     map[common.Hash]*blobRecoveryResult
+	recoveryResultOrder []common.Hash
+	recoveryResultBytes int
+	recoveryRetryOnce   sync.Once
+	recoveryRetryMutex  sync.Mutex
+	recoveryRetries     map[common.Hash]*delayedRecoverBlobsRequest
+	recoveryRetryQueue  blobRecoveryRetryHeap
+	recoveryRetryAfter  time.Time
+	recoveryRetryWake   chan struct{}
+	recoveryPreferRetry bool
+	recoverySlots       map[uint64]*blobRecoverySlot
+	recoverySlotQueue   blobRecoverySlotHeap
+	recoveryPruneFloor  uint64
+	blocksToCheckSync   sync.Map // blockRoot -> ColumnSyncableSignedBlock (SignedBeaconBlock or SignedBlindedBeaconBlock)
 
 	// [New in Gloas:EIP7732] For fetching blocks to get kzg_commitments
 	forkChoice     BlockGetter
 	blockReader    freezeblocks.BeaconSnapshotReader
 	indiciesDB     kv.RoDB
 	gloasDataCache *lru.Cache[common.Hash, *gloasBlockData] // cache for GLOAS block data (~1KB per entry)
+	startOnce      sync.Once
 }
 
 func NewPeerDas(
-	ctx context.Context,
 	rpc *rpc.BeaconRpcP2P,
 	beaconConfig *clparams.BeaconChainConfig,
 	caplinConfig *clparams.CaplinConfig,
@@ -122,20 +143,30 @@ func NewPeerDas(
 		gossipManager:     gossipManager,
 		recoverBlobsQueue: make(chan recoverBlobsRequest, 128),
 
-		recoveringMutex:   sync.Mutex{},
-		isRecovering:      make(map[common.Hash]bool),
-		blocksToCheckSync: sync.Map{},
+		recoveringMutex:     sync.Mutex{},
+		isRecovering:        make(map[common.Hash]bool),
+		recoveryRequests:    make(map[common.Hash]recoverBlobsRequest),
+		recoveryGenerations: make(map[common.Hash]uint64),
+		recoveryResults:     make(map[common.Hash]*blobRecoveryResult),
+		recoveryRetries:     make(map[common.Hash]*delayedRecoverBlobsRequest),
+		recoveryRetryWake:   make(chan struct{}, numOfBlobRecoveryWorkers),
+		blocksToCheckSync:   sync.Map{},
 
 		blockReader:    blockReader,
 		indiciesDB:     indiciesDB,
 		gloasDataCache: gloasDataCache,
 	}
-	p.resubscribeGossip()
-	for range numOfBlobRecoveryWorkers {
-		go p.blobsRecoverWorker(ctx)
-	}
-	go p.syncColumnDataWorker(ctx)
 	return p
+}
+
+func (d *peerdas) Start(ctx context.Context) {
+	d.startOnce.Do(func() {
+		d.resubscribeGossip()
+		for range numOfBlobRecoveryWorkers {
+			go d.blobsRecoverWorker(ctx)
+		}
+		go d.syncColumnDataWorker(ctx)
+	})
 }
 
 func (d *peerdas) StateReader() peerdasstate.PeerDasStateReader {
@@ -246,6 +277,95 @@ func (d *peerdas) IsBlobAlreadyRecovered(blockRoot common.Hash) bool {
 	return count > 0
 }
 
+type blobRecoveryMetadata struct {
+	slot         uint64
+	blockRoot    common.Hash
+	version      clparams.StateVersion
+	signature    common.Bytes96
+	hasSignature bool
+	commitments  []common.Bytes48
+}
+
+func newBlobRecoveryMetadata(block cltypes.ColumnSyncableSignedBlock, blockRoot common.Hash) (*blobRecoveryMetadata, error) {
+	commitments := block.GetBlobKzgCommitments()
+	if commitments == nil {
+		return nil, errors.New("missing blob commitments")
+	}
+	metadata := &blobRecoveryMetadata{
+		slot:        block.GetSlot(),
+		blockRoot:   blockRoot,
+		version:     block.Version(),
+		commitments: make([]common.Bytes48, commitments.Len()),
+	}
+	switch block := block.(type) {
+	case *cltypes.SignedBeaconBlock:
+		metadata.signature = block.Signature
+		metadata.hasSignature = true
+	case *cltypes.SignedBlindedBeaconBlock:
+		metadata.signature = block.Signature
+		metadata.hasSignature = true
+	}
+	for i := range commitments.Len() {
+		commitment := commitments.Get(i)
+		if commitment == nil {
+			return nil, errors.New("nil blob commitment")
+		}
+		metadata.commitments[i] = common.Bytes48(*commitment)
+	}
+	return metadata, nil
+}
+
+type blobRecoveryValidation uint8
+
+const (
+	blobRecoveryUnavailable blobRecoveryValidation = iota
+	blobRecoveryInvalid
+	blobRecoveryComplete
+)
+
+func (d *peerdas) validateStoredBlobRecoveryMetadata(ctx context.Context, metadata *blobRecoveryMetadata, count uint32) blobRecoveryValidation {
+	if metadata == nil || len(metadata.commitments) == 0 || int(count) != len(metadata.commitments) {
+		if metadata != nil && len(metadata.commitments) == 0 {
+			return blobRecoveryComplete
+		}
+		return blobRecoveryInvalid
+	}
+	sidecars, found, err := d.blobStorage.ReadBlobSidecars(ctx, metadata.slot, metadata.blockRoot)
+	if err != nil {
+		return blobRecoveryUnavailable
+	}
+	if !found || len(sidecars) != len(metadata.commitments) {
+		return blobRecoveryInvalid
+	}
+	seen := make([]bool, len(metadata.commitments))
+	for _, sidecar := range sidecars {
+		if sidecar == nil || sidecar.SignedBlockHeader == nil || sidecar.SignedBlockHeader.Header == nil || sidecar.Index >= uint64(len(metadata.commitments)) || seen[sidecar.Index] {
+			return blobRecoveryInvalid
+		}
+		root, err := sidecar.SignedBlockHeader.Header.HashSSZ()
+		if err != nil || root != metadata.blockRoot || sidecar.SignedBlockHeader.Header.Slot != metadata.slot || metadata.hasSignature && sidecar.SignedBlockHeader.Signature != metadata.signature || sidecar.KzgCommitment != metadata.commitments[sidecar.Index] {
+			return blobRecoveryInvalid
+		}
+		seen[sidecar.Index] = true
+	}
+	if blob_storage.VerifyBlobSidecars(sidecars, metadata.version, nil) != nil {
+		return blobRecoveryInvalid
+	}
+	return blobRecoveryComplete
+}
+
+func (d *peerdas) storedBlobRecoveryValidation(ctx context.Context, metadata *blobRecoveryMetadata) (blobRecoveryValidation, uint32) {
+	if metadata == nil {
+		return blobRecoveryInvalid, 0
+	}
+	count, err := d.blobStorage.KzgCommitmentsCount(ctx, metadata.blockRoot)
+	if err != nil {
+		log.Warn("failed to get kzg commitments count", "err", err, "blockRoot", metadata.blockRoot)
+		return blobRecoveryUnavailable, 0
+	}
+	return d.validateStoredBlobRecoveryMetadata(ctx, metadata, count), count
+}
+
 func (d *peerdas) IsColumnOverHalf(slot uint64, blockRoot common.Hash) bool {
 	existingColumns, err := d.columnStorage.GetSavedColumnIndex(context.Background(), slot, blockRoot)
 	if err != nil {
@@ -331,174 +451,734 @@ func (d *peerdas) UpdateValidatorsCustody(cgc uint64) {
 	}
 }
 
-func (d *peerdas) Prune(keepSlotDistance uint64) error {
-	if err := d.columnStorage.Prune(keepSlotDistance); err != nil {
+func (d *peerdas) PruneBelow(slot uint64) error {
+	err := d.columnStorage.PruneBelow(slot)
+	if errors.Is(err, blob_storage.ErrPruneNotStarted) {
 		return err
 	}
-
-	curSlot := d.ethClock.GetCurrentSlot()
-	if curSlot < keepSlotDistance {
+	d.pruneBlobRecoveriesBelow(slot)
+	// A partial failure still advances the floor: pruneBelow attempts every bucket, so it
+	// leaves stragglers rather than an untouched store, and the floor only understates them.
+	if slot == 0 {
 		d.state.SetEarliestAvailableSlot(0)
-	} else {
-		earliestSlot := curSlot - keepSlotDistance
-		if earliestSlot > d.state.GetEarliestAvailableSlot() {
-			d.state.SetEarliestAvailableSlot(earliestSlot)
+	} else if slot > d.state.GetEarliestAvailableSlot() {
+		d.state.SetEarliestAvailableSlot(slot)
+	}
+	return err
+}
+
+func (d *peerdas) pruneBlobRecoveriesBelow(slot uint64) {
+	d.initBlobRecoveryRetries()
+	d.recoveryRetryMutex.Lock()
+	d.recoveringMutex.Lock()
+	d.initBlobRecoveryOwnershipLocked()
+	if slot > d.recoveryPruneFloor {
+		d.recoveryPruneFloor = slot
+	}
+	for d.recoverySlotQueue.Len() > 0 && d.recoverySlotQueue[0].slot < d.recoveryPruneFloor {
+		ownedSlot := heap.Pop(&d.recoverySlotQueue).(*blobRecoverySlot)
+		delete(d.recoverySlots, ownedSlot.slot)
+		for root := range ownedSlot.roots {
+			d.removeBlobRecoveryResultLocked(root)
+			if d.isRecovering[root] {
+				continue
+			}
+			d.removeDelayedBlobRecoveryLocked(root)
+			delete(d.isRecovering, root)
+			delete(d.recoveryRequests, root)
+			delete(d.recoveryGenerations, root)
 		}
 	}
-	return nil
+	d.recoveringMutex.Unlock()
+	d.recoveryRetryMutex.Unlock()
+	select {
+	case d.recoveryRetryWake <- struct{}{}:
+	default:
+	}
 }
 
 type recoverBlobsRequest struct {
 	slot      uint64
 	blockRoot common.Hash
+	metadata  *blobRecoveryMetadata
+}
+
+type delayedRecoverBlobsRequest struct {
+	request   recoverBlobsRequest
+	notBefore time.Time
+	heapIndex int
+}
+
+type blobRecoveryRetryHeap []*delayedRecoverBlobsRequest
+
+func (h blobRecoveryRetryHeap) Len() int { return len(h) }
+
+func (h blobRecoveryRetryHeap) Less(i, j int) bool {
+	return h[i].notBefore.Before(h[j].notBefore)
+}
+
+func (h blobRecoveryRetryHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].heapIndex = i
+	h[j].heapIndex = j
+}
+
+func (h *blobRecoveryRetryHeap) Push(value any) {
+	delayed := value.(*delayedRecoverBlobsRequest)
+	delayed.heapIndex = len(*h)
+	*h = append(*h, delayed)
+}
+
+func (h *blobRecoveryRetryHeap) Pop() any {
+	old := *h
+	last := len(old) - 1
+	delayed := old[last]
+	old[last] = nil
+	delayed.heapIndex = -1
+	*h = old[:last]
+	return delayed
+}
+
+type blobRecoverySlot struct {
+	slot      uint64
+	roots     map[common.Hash]struct{}
+	heapIndex int
+}
+
+type blobRecoverySlotHeap []*blobRecoverySlot
+
+func (h blobRecoverySlotHeap) Len() int { return len(h) }
+
+func (h blobRecoverySlotHeap) Less(i, j int) bool { return h[i].slot < h[j].slot }
+
+func (h blobRecoverySlotHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].heapIndex = i
+	h[j].heapIndex = j
+}
+
+func (h *blobRecoverySlotHeap) Push(value any) {
+	slot := value.(*blobRecoverySlot)
+	slot.heapIndex = len(*h)
+	*h = append(*h, slot)
+}
+
+func (h *blobRecoverySlotHeap) Pop() any {
+	old := *h
+	last := len(old) - 1
+	slot := old[last]
+	old[last] = nil
+	slot.heapIndex = -1
+	*h = old[:last]
+	return slot
+}
+
+type blobRecoveryResult struct {
+	existingColumns         []uint64
+	isGloas                 bool
+	kzgCommitmentsFromBlock *solid.ListSSZ[*cltypes.KZGCommitment]
+	anyColumnSidecar        *cltypes.DataColumnSidecar
+	blobMatrix              [][]cltypes.MatrixEntry
+	blobSidecars            []*cltypes.BlobSidecar
+	numberOfBlobs           uint64
+	timeRecoverMatrix       time.Duration
+	timeRecoverBlobs        time.Duration
+	encodedBytes            int
+}
+
+func newBlobRecoveryResult(
+	existingColumns []uint64,
+	isGloas bool,
+	kzgCommitmentsFromBlock *solid.ListSSZ[*cltypes.KZGCommitment],
+	anyColumnSidecar *cltypes.DataColumnSidecar,
+	blobMatrix [][]cltypes.MatrixEntry,
+	blobSidecars []*cltypes.BlobSidecar,
+	numberOfBlobs uint64,
+	timeRecoverMatrix time.Duration,
+	timeRecoverBlobs time.Duration,
+) *blobRecoveryResult {
+	encodedBytes := len(existingColumns) * 8
+	if anyColumnSidecar != nil {
+		encodedBytes += anyColumnSidecar.EncodingSizeSSZ()
+	}
+	if kzgCommitmentsFromBlock != nil {
+		encodedBytes += kzgCommitmentsFromBlock.EncodingSizeSSZ()
+	}
+	for _, entries := range blobMatrix {
+		for i := range entries {
+			encodedBytes += entries[i].EncodingSizeSSZ()
+		}
+	}
+	for _, sidecar := range blobSidecars {
+		encodedBytes += sidecar.EncodingSizeSSZ()
+	}
+	return &blobRecoveryResult{
+		existingColumns:         existingColumns,
+		isGloas:                 isGloas,
+		kzgCommitmentsFromBlock: kzgCommitmentsFromBlock,
+		anyColumnSidecar:        anyColumnSidecar,
+		blobMatrix:              blobMatrix,
+		blobSidecars:            blobSidecars,
+		numberOfBlobs:           numberOfBlobs,
+		timeRecoverMatrix:       timeRecoverMatrix,
+		timeRecoverBlobs:        timeRecoverBlobs,
+		encodedBytes:            encodedBytes,
+	}
+}
+
+func (d *peerdas) initBlobRecoveryRetries() {
+	d.recoveryRetryOnce.Do(func() {
+		if d.recoveryRetries == nil {
+			d.recoveryRetries = make(map[common.Hash]*delayedRecoverBlobsRequest)
+		}
+		if d.recoveryRetryWake == nil {
+			d.recoveryRetryWake = make(chan struct{}, numOfBlobRecoveryWorkers)
+		}
+	})
+}
+
+func (d *peerdas) initBlobRecoveryOwnershipLocked() {
+	if d.isRecovering == nil {
+		d.isRecovering = make(map[common.Hash]bool)
+	}
+	if d.recoveryRequests == nil {
+		d.recoveryRequests = make(map[common.Hash]recoverBlobsRequest)
+	}
+	if d.recoveryGenerations == nil {
+		d.recoveryGenerations = make(map[common.Hash]uint64)
+	}
+	if d.recoveryResults == nil {
+		d.recoveryResults = make(map[common.Hash]*blobRecoveryResult)
+	}
+	if d.recoverySlots == nil {
+		d.recoverySlots = make(map[uint64]*blobRecoverySlot)
+	}
+}
+
+func blobRecoveryRetryServiceInterval() time.Duration {
+	workers := max(numOfBlobRecoveryWorkers, 1)
+	return blobRecoveryValidationRetryInterval / time.Duration(workers)
+}
+
+func (d *peerdas) trackBlobRecoverySlotLocked(request recoverBlobsRequest) {
+	slot := d.recoverySlots[request.slot]
+	if slot == nil {
+		slot = &blobRecoverySlot{slot: request.slot, roots: make(map[common.Hash]struct{})}
+		d.recoverySlots[request.slot] = slot
+		heap.Push(&d.recoverySlotQueue, slot)
+	}
+	slot.roots[request.blockRoot] = struct{}{}
+}
+
+func (d *peerdas) removeBlobRecoverySlotLocked(request recoverBlobsRequest) {
+	slot := d.recoverySlots[request.slot]
+	if slot == nil {
+		return
+	}
+	delete(slot.roots, request.blockRoot)
+	if len(slot.roots) == 0 {
+		heap.Remove(&d.recoverySlotQueue, slot.heapIndex)
+		delete(d.recoverySlots, request.slot)
+	}
+}
+
+func (d *peerdas) removeBlobRecoveryOwnershipLocked(blockRoot common.Hash) {
+	request, exists := d.recoveryRequests[blockRoot]
+	delete(d.isRecovering, blockRoot)
+	delete(d.recoveryRequests, blockRoot)
+	delete(d.recoveryGenerations, blockRoot)
+	d.removeBlobRecoveryResultLocked(blockRoot)
+	if exists {
+		d.removeBlobRecoverySlotLocked(request)
+	}
+}
+
+func (d *peerdas) removeDelayedBlobRecoveryLocked(blockRoot common.Hash) {
+	delayed := d.recoveryRetries[blockRoot]
+	if delayed == nil {
+		return
+	}
+	heap.Remove(&d.recoveryRetryQueue, delayed.heapIndex)
+	delete(d.recoveryRetries, blockRoot)
+}
+
+func (d *peerdas) blobRecoveryResult(blockRoot common.Hash) *blobRecoveryResult {
+	d.recoveringMutex.Lock()
+	defer d.recoveringMutex.Unlock()
+	return d.recoveryResults[blockRoot]
+}
+
+func (d *peerdas) authoritativeBlobRecoveryRequest(request recoverBlobsRequest) recoverBlobsRequest {
+	d.recoveringMutex.Lock()
+	defer d.recoveringMutex.Unlock()
+	if owned, exists := d.recoveryRequests[request.blockRoot]; exists {
+		return owned
+	}
+	return request
+}
+
+func (d *peerdas) cacheBlobRecoveryResult(blockRoot common.Hash, result *blobRecoveryResult) bool {
+	if result == nil || result.encodedBytes > maxBlobRecoveryResultBytes {
+		return false
+	}
+	d.recoveringMutex.Lock()
+	defer d.recoveringMutex.Unlock()
+	d.initBlobRecoveryOwnershipLocked()
+	if request, exists := d.recoveryRequests[blockRoot]; exists && request.slot < d.recoveryPruneFloor {
+		return false
+	}
+	d.removeBlobRecoveryResultLocked(blockRoot)
+	for d.recoveryResultBytes+result.encodedBytes > maxBlobRecoveryResultBytes && len(d.recoveryResultOrder) > 0 {
+		evictedRoot := d.recoveryResultOrder[0]
+		d.removeBlobRecoveryResultLocked(evictedRoot)
+	}
+	d.recoveryResultOrder = append(d.recoveryResultOrder, blockRoot)
+	d.recoveryResults[blockRoot] = result
+	d.recoveryResultBytes += result.encodedBytes
+	return true
+}
+
+func (d *peerdas) removeBlobRecoveryResultLocked(blockRoot common.Hash) {
+	result := d.recoveryResults[blockRoot]
+	if result == nil {
+		return
+	}
+	d.recoveryResultBytes -= result.encodedBytes
+	delete(d.recoveryResults, blockRoot)
+	for i, root := range d.recoveryResultOrder {
+		if root == blockRoot {
+			copy(d.recoveryResultOrder[i:], d.recoveryResultOrder[i+1:])
+			d.recoveryResultOrder = d.recoveryResultOrder[:len(d.recoveryResultOrder)-1]
+			break
+		}
+	}
+}
+
+func (d *peerdas) removeBlobRecoveryResult(blockRoot common.Hash) {
+	d.recoveringMutex.Lock()
+	d.removeBlobRecoveryResultLocked(blockRoot)
+	d.recoveringMutex.Unlock()
+}
+
+func (d *peerdas) delayBlobRecovery(request recoverBlobsRequest) bool {
+	d.initBlobRecoveryRetries()
+	d.recoveryRetryMutex.Lock()
+	d.recoveringMutex.Lock()
+	d.initBlobRecoveryOwnershipLocked()
+	if owned, exists := d.recoveryRequests[request.blockRoot]; exists {
+		request = owned
+	} else {
+		d.recoveryRequests[request.blockRoot] = request
+		d.recoveryGenerations[request.blockRoot] = 1
+		d.trackBlobRecoverySlotLocked(request)
+	}
+	if request.slot < d.recoveryPruneFloor {
+		d.removeDelayedBlobRecoveryLocked(request.blockRoot)
+		d.removeBlobRecoveryOwnershipLocked(request.blockRoot)
+		d.recoveringMutex.Unlock()
+		d.recoveryRetryMutex.Unlock()
+		return false
+	}
+	d.isRecovering[request.blockRoot] = false
+	d.recoveringMutex.Unlock()
+
+	notBefore := time.Now().Add(blobRecoveryValidationRetryInterval)
+	if existing := d.recoveryRetries[request.blockRoot]; existing != nil {
+		existing.request = request
+		existing.notBefore = notBefore
+		heap.Fix(&d.recoveryRetryQueue, existing.heapIndex)
+	} else {
+		delayed := &delayedRecoverBlobsRequest{request: request, notBefore: notBefore, heapIndex: -1}
+		d.recoveryRetries[request.blockRoot] = delayed
+		heap.Push(&d.recoveryRetryQueue, delayed)
+	}
+	d.recoveryRetryMutex.Unlock()
+	select {
+	case d.recoveryRetryWake <- struct{}{}:
+	default:
+	}
+	return true
+}
+
+func (d *peerdas) nextBlobRecoveryRequest(ctx context.Context) (recoverBlobsRequest, bool) {
+	d.initBlobRecoveryRetries()
+	for {
+		now := time.Now()
+		var next time.Time
+		d.recoveryRetryMutex.Lock()
+		if d.recoveryRetryQueue.Len() > 0 {
+			next = d.recoveryRetryQueue[0].notBefore
+			if d.recoveryRetryAfter.After(next) {
+				next = d.recoveryRetryAfter
+			}
+		}
+		if !next.IsZero() && !next.After(now) {
+			if !d.recoveryPreferRetry {
+				select {
+				case request := <-d.recoverBlobsQueue:
+					d.recoveryPreferRetry = true
+					d.recoveryRetryMutex.Unlock()
+					return request, true
+				default:
+				}
+			}
+			delayed := heap.Pop(&d.recoveryRetryQueue).(*delayedRecoverBlobsRequest)
+			delete(d.recoveryRetries, delayed.request.blockRoot)
+			d.recoveryRetryAfter = now.Add(blobRecoveryRetryServiceInterval())
+			d.recoveryPreferRetry = false
+			d.recoveryRetryMutex.Unlock()
+			return delayed.request, true
+		}
+		d.recoveryRetryMutex.Unlock()
+
+		if next.IsZero() {
+			select {
+			case <-ctx.Done():
+				return recoverBlobsRequest{}, false
+			case request := <-d.recoverBlobsQueue:
+				return request, true
+			case <-d.recoveryRetryWake:
+			}
+			continue
+		}
+
+		timer := time.NewTimer(time.Until(next))
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return recoverBlobsRequest{}, false
+		case request := <-d.recoverBlobsQueue:
+			timer.Stop()
+			return request, true
+		case <-d.recoveryRetryWake:
+			timer.Stop()
+		case <-timer.C:
+		}
+	}
+}
+
+func (d *peerdas) claimBlobRecovery(request recoverBlobsRequest) (recoverBlobsRequest, uint64, bool) {
+	d.recoveringMutex.Lock()
+	defer d.recoveringMutex.Unlock()
+	d.initBlobRecoveryOwnershipLocked()
+	if request.slot < d.recoveryPruneFloor {
+		d.removeBlobRecoveryOwnershipLocked(request.blockRoot)
+		return recoverBlobsRequest{}, 0, false
+	}
+	active, exists := d.isRecovering[request.blockRoot]
+	if active {
+		return recoverBlobsRequest{}, 0, false
+	}
+	if !exists {
+		d.isRecovering[request.blockRoot] = false
+		d.recoveryRequests[request.blockRoot] = request
+		d.recoveryGenerations[request.blockRoot] = 1
+		d.trackBlobRecoverySlotLocked(request)
+	}
+	owned, exists := d.recoveryRequests[request.blockRoot]
+	if !exists {
+		owned = request
+		d.recoveryRequests[request.blockRoot] = request
+		d.recoveryGenerations[request.blockRoot] = 1
+		d.trackBlobRecoverySlotLocked(request)
+	}
+	d.isRecovering[request.blockRoot] = true
+	return owned, d.recoveryGenerations[request.blockRoot], true
+}
+
+func (d *peerdas) releaseBlobRecovery(blockRoot common.Hash, generation uint64) {
+	d.recoveringMutex.Lock()
+	request, exists := d.recoveryRequests[blockRoot]
+	if !exists {
+		d.recoveringMutex.Unlock()
+		return
+	}
+	if request.slot < d.recoveryPruneFloor {
+		d.removeBlobRecoveryOwnershipLocked(blockRoot)
+		d.recoveringMutex.Unlock()
+		return
+	}
+	if current := d.recoveryGenerations[blockRoot]; current != generation {
+		d.isRecovering[blockRoot] = false
+		d.recoveringMutex.Unlock()
+		d.delayBlobRecovery(request)
+		return
+	}
+	d.removeBlobRecoveryOwnershipLocked(blockRoot)
+	d.recoveringMutex.Unlock()
+}
+
+func (d *peerdas) clearDelayedBlobRecoveries() {
+	d.initBlobRecoveryRetries()
+	d.recoveryRetryMutex.Lock()
+	d.recoveringMutex.Lock()
+	d.recoveryRetries = make(map[common.Hash]*delayedRecoverBlobsRequest)
+	d.recoveryRetryQueue = nil
+	d.recoveryRetryAfter = time.Time{}
+	d.recoveryPreferRetry = false
+	for root, active := range d.isRecovering {
+		if !active {
+			d.removeBlobRecoveryOwnershipLocked(root)
+		}
+	}
+	d.recoveryResults = make(map[common.Hash]*blobRecoveryResult)
+	d.recoveryResultOrder = nil
+	d.recoveryResultBytes = 0
+	d.recoveringMutex.Unlock()
+	d.recoveryRetryMutex.Unlock()
+}
+
+func (d *peerdas) enqueueBlobRecovery(request recoverBlobsRequest) error {
+	d.recoveringMutex.Lock()
+	d.initBlobRecoveryOwnershipLocked()
+	if request.slot < d.recoveryPruneFloor {
+		d.recoveringMutex.Unlock()
+		return nil
+	}
+	if _, ok := d.isRecovering[request.blockRoot]; ok {
+		owned := d.recoveryRequests[request.blockRoot]
+		if owned.metadata == nil && request.metadata != nil {
+			d.recoveryRequests[request.blockRoot] = request
+			d.recoveryGenerations[request.blockRoot]++
+		}
+		d.recoveringMutex.Unlock()
+		return nil
+	}
+	d.isRecovering[request.blockRoot] = false
+	d.recoveryRequests[request.blockRoot] = request
+	d.recoveryGenerations[request.blockRoot] = 1
+	d.trackBlobRecoverySlotLocked(request)
+	select {
+	case d.recoverBlobsQueue <- request:
+		d.recoveringMutex.Unlock()
+		return nil
+	default:
+		d.recoveringMutex.Unlock()
+		d.delayBlobRecovery(request)
+		return nil
+	}
 }
 
 func (d *peerdas) blobsRecoverWorker(ctx context.Context) {
-	recover := func(toRecover recoverBlobsRequest) {
+	defer d.clearDelayedBlobRecoveries()
+	recover := func(toRecover recoverBlobsRequest) (retryScheduled bool) {
+		if ctx.Err() != nil {
+			return
+		}
 		begin := time.Now()
 		log.Debug("[blobsRecover] recovering blobs", "slot", toRecover.slot, "blockRoot", toRecover.blockRoot)
-		ctx := context.Background()
 		slot, blockRoot := toRecover.slot, toRecover.blockRoot
-		existingColumns, err := d.columnStorage.GetSavedColumnIndex(ctx, slot, blockRoot)
-		if err != nil {
-			log.Warn("[blobsRecover] failed to get saved column index", "err", err)
-			return
-		}
-		if len(existingColumns) < int(d.beaconConfig.NumberOfColumns+1)/2 {
-			log.Debug("[blobsRecover] not enough columns to recover", "slot", slot, "blockRoot", blockRoot, "existingColumns", len(existingColumns))
-			return
-		}
-
-		// [Modified in Gloas:EIP7732] For GLOAS, kzg_commitments and SignedBlockHeader come from block
-		epoch := slot / d.beaconConfig.SlotsPerEpoch
-		isGloas := d.beaconConfig.GetCurrentStateVersion(epoch) >= clparams.GloasVersion
-		var kzgCommitmentsFromBlock *solid.ListSSZ[*cltypes.KZGCommitment]
-		var signedBlockHeaderFromBlock *cltypes.SignedBeaconBlockHeader
-		if isGloas {
-			kzgCommitmentsFromBlock, err = d.getKzgCommitmentsForGloas(slot, blockRoot)
-			if err != nil {
-				log.Warn("[blobsRecover] failed to get kzg commitments for GLOAS", "err", err, "slot", slot, "blockRoot", blockRoot)
-				return
-			}
-			signedBlockHeaderFromBlock, err = d.getSignedBlockHeaderForGloas(blockRoot)
-			if err != nil {
-				log.Warn("[blobsRecover] failed to get signed block header for GLOAS", "err", err, "slot", slot, "blockRoot", blockRoot)
-				return
-			}
-		}
-
-		// Recover the matrix from the column sidecars
-		matrixEntries := []cltypes.MatrixEntry{}
-		var anyColumnSidecar *cltypes.DataColumnSidecar
-		for _, columnIndex := range existingColumns {
-			sidecar, err := d.columnStorage.ReadColumnSidecarByColumnIndex(ctx, slot, blockRoot, int64(columnIndex))
-			if err != nil {
-				log.Debug("[blobsRecover] failed to read column sidecar", "err", err)
-				d.columnStorage.RemoveColumnSidecars(ctx, slot, blockRoot, int64(columnIndex))
-				return
-			}
-			if sidecar.Column.Len() > int(d.beaconConfig.MaxBlobCommittmentsPerBlock) {
-				log.Warn("[blobsRecover] invalid column sidecar", "slot", slot, "blockRoot", blockRoot, "columnIndex", columnIndex, "columnLen", sidecar.Column.Len())
-				return
-			}
-			for i := 0; i < sidecar.Column.Len(); i++ {
-				matrixEntries = append(matrixEntries, cltypes.MatrixEntry{
-					Cell:        *sidecar.Column.Get(i),
-					KzgProof:    *sidecar.KzgProofs.Get(i),
-					RowIndex:    uint64(i),
-					ColumnIndex: columnIndex,
-				})
-			}
-			if anyColumnSidecar == nil {
-				anyColumnSidecar = sidecar
-			}
-		}
-		// recover matrix
-		beginRecoverMatrix := time.Now()
-		numberOfBlobs := uint64(anyColumnSidecar.Column.Len())
-		blobMatrix, err := peerdasutils.RecoverMatrix(matrixEntries, numberOfBlobs)
-		if err != nil {
-			log.Warn("[blobsRecover] failed to recover matrix", "err", err, "slot", slot, "blockRoot", blockRoot, "numberOfBlobs", numberOfBlobs)
-			return
-		}
-		timeRecoverMatrix := time.Since(beginRecoverMatrix)
-		log.Trace("[blobsRecover] recovered matrix", "slot", slot, "blockRoot", blockRoot, "numberOfBlobs", numberOfBlobs)
-
-		// Recover blobs from the matrix
-		beginRecoverBlobs := time.Now()
-		blobSidecars := make([]*cltypes.BlobSidecar, 0, len(blobMatrix))
-		blobCommitments := solid.NewStaticListSSZ[*cltypes.KZGCommitment](int(d.beaconConfig.MaxBlobCommittmentsPerBlock), length.Bytes48)
-		for blobIndex, blobEntries := range blobMatrix {
-			var (
-				blob           cltypes.Blob
-				kzgCommitment  common.Bytes48
-				kzgProof       common.Bytes48
-				inclusionProof solid.HashVectorSSZ = solid.NewHashVector(cltypes.CommitmentBranchSize)
-			)
-			// blob
-			if len(blobEntries) != int(d.beaconConfig.NumberOfColumns) {
-				log.Warn("[blobsRecover] invalid blob entries", "blobIndex", blobIndex, "slot", slot, "blockRoot", blockRoot, "blobEntries", len(blobEntries))
-				return
-			}
-			for i := range len(blobEntries) / 2 {
-				if copied := copy(blob[i*cltypes.BytesPerCell:], blobEntries[i].Cell[:]); copied != cltypes.BytesPerCell {
-					log.Warn("[blobsRecover] failed to copy cell", "blobIndex", blobIndex, "slot", slot, "blockRoot", blockRoot)
+		result := d.blobRecoveryResult(blockRoot)
+		if result == nil {
+			result = func() (result *blobRecoveryResult) {
+				existingColumns, err := d.columnStorage.GetSavedColumnIndex(ctx, slot, blockRoot)
+				if err != nil {
+					log.Warn("[blobsRecover] failed to get saved column index", "err", err)
+					if ctx.Err() == nil {
+						retryScheduled = d.delayBlobRecovery(toRecover)
+					}
 					return
 				}
-			}
-			// kzg commitment
-			// [Modified in Gloas:EIP7732] Use kzg_commitments from block for GLOAS
-			if isGloas {
-				copy(kzgCommitment[:], kzgCommitmentsFromBlock.Get(blobIndex)[:])
-			} else {
-				copy(kzgCommitment[:], anyColumnSidecar.KzgCommitments.Get(blobIndex)[:])
-			}
-			// kzg proof
-			ckzgBlob := goethkzg.Blob(blob)
-			proof, err := kzg.Ctx().ComputeBlobKZGProof(&ckzgBlob, goethkzg.KZGCommitment(kzgCommitment), 0 /* numGoRoutines */)
-			if err != nil {
-				log.Warn("[blobsRecover] failed to compute blob kzg proof", "blobIndex", blobIndex, "slot", slot, "blockRoot", blockRoot)
+				if ctx.Err() != nil {
+					return
+				}
+				if len(existingColumns) < int(d.beaconConfig.NumberOfColumns+1)/2 {
+					log.Debug("[blobsRecover] not enough columns to recover", "slot", slot, "blockRoot", blockRoot, "existingColumns", len(existingColumns))
+					return
+				}
+
+				// [Modified in Gloas:EIP7732] For GLOAS, kzg_commitments and SignedBlockHeader come from block
+				epoch := slot / d.beaconConfig.SlotsPerEpoch
+				isGloas := d.beaconConfig.GetCurrentStateVersion(epoch) >= clparams.GloasVersion
+				var kzgCommitmentsFromBlock *solid.ListSSZ[*cltypes.KZGCommitment]
+				var signedBlockHeaderFromBlock *cltypes.SignedBeaconBlockHeader
+				if isGloas {
+					kzgCommitmentsFromBlock, err = d.getKzgCommitmentsForGloas(slot, blockRoot)
+					if err != nil {
+						log.Warn("[blobsRecover] failed to get kzg commitments for GLOAS", "err", err, "slot", slot, "blockRoot", blockRoot)
+						return
+					}
+					signedBlockHeaderFromBlock, err = d.getSignedBlockHeaderForGloas(blockRoot)
+					if err != nil {
+						log.Warn("[blobsRecover] failed to get signed block header for GLOAS", "err", err, "slot", slot, "blockRoot", blockRoot)
+						return
+					}
+				}
+
+				// Recover the matrix from the column sidecars
+				matrixEntries := []cltypes.MatrixEntry{}
+				var anyColumnSidecar *cltypes.DataColumnSidecar
+				for _, columnIndex := range existingColumns {
+					if ctx.Err() != nil {
+						return
+					}
+					sidecar, err := d.columnStorage.ReadColumnSidecarByColumnIndex(ctx, slot, blockRoot, int64(columnIndex))
+					if err != nil {
+						log.Debug("[blobsRecover] failed to read column sidecar", "err", err)
+						if ctx.Err() != nil {
+							return
+						}
+						if errors.Is(err, os.ErrNotExist) {
+							if removeErr := d.columnStorage.RemoveColumnSidecars(ctx, slot, blockRoot, int64(columnIndex)); removeErr != nil {
+								log.Debug("[blobsRecover] failed to remove column sidecar", "err", removeErr)
+							}
+						} else {
+							retryScheduled = d.delayBlobRecovery(toRecover)
+						}
+						return
+					}
+					if sidecar.Column.Len() > int(d.beaconConfig.MaxBlobCommittmentsPerBlock) {
+						log.Warn("[blobsRecover] invalid column sidecar", "slot", slot, "blockRoot", blockRoot, "columnIndex", columnIndex, "columnLen", sidecar.Column.Len())
+						return
+					}
+					for i := 0; i < sidecar.Column.Len(); i++ {
+						matrixEntries = append(matrixEntries, cltypes.MatrixEntry{
+							Cell:        *sidecar.Column.Get(i),
+							KzgProof:    *sidecar.KzgProofs.Get(i),
+							RowIndex:    uint64(i),
+							ColumnIndex: columnIndex,
+						})
+					}
+					if anyColumnSidecar == nil {
+						anyColumnSidecar = sidecar
+					}
+				}
+				// recover matrix
+				beginRecoverMatrix := time.Now()
+				numberOfBlobs := uint64(anyColumnSidecar.Column.Len())
+				if ctx.Err() != nil {
+					return
+				}
+				blobMatrix, err := peerdasutils.RecoverMatrix(matrixEntries, numberOfBlobs)
+				if err != nil {
+					log.Warn("[blobsRecover] failed to recover matrix", "err", err, "slot", slot, "blockRoot", blockRoot, "numberOfBlobs", numberOfBlobs)
+					return
+				}
+				timeRecoverMatrix := time.Since(beginRecoverMatrix)
+				if ctx.Err() != nil {
+					return
+				}
+				log.Trace("[blobsRecover] recovered matrix", "slot", slot, "blockRoot", blockRoot, "numberOfBlobs", numberOfBlobs)
+
+				// Recover blobs from the matrix
+				beginRecoverBlobs := time.Now()
+				blobSidecars := make([]*cltypes.BlobSidecar, 0, len(blobMatrix))
+				blobCommitments := solid.NewStaticListSSZ[*cltypes.KZGCommitment](int(d.beaconConfig.MaxBlobCommittmentsPerBlock), length.Bytes48)
+				for blobIndex, blobEntries := range blobMatrix {
+					var (
+						blob           cltypes.Blob
+						kzgCommitment  common.Bytes48
+						kzgProof       common.Bytes48
+						inclusionProof solid.HashVectorSSZ = solid.NewHashVector(cltypes.CommitmentBranchSize)
+					)
+					// blob
+					if len(blobEntries) != int(d.beaconConfig.NumberOfColumns) {
+						log.Warn("[blobsRecover] invalid blob entries", "blobIndex", blobIndex, "slot", slot, "blockRoot", blockRoot, "blobEntries", len(blobEntries))
+						return
+					}
+					for i := range len(blobEntries) / 2 {
+						if copied := copy(blob[i*cltypes.BytesPerCell:], blobEntries[i].Cell[:]); copied != cltypes.BytesPerCell {
+							log.Warn("[blobsRecover] failed to copy cell", "blobIndex", blobIndex, "slot", slot, "blockRoot", blockRoot)
+							return
+						}
+					}
+					// kzg commitment
+					// [Modified in Gloas:EIP7732] Use kzg_commitments from block for GLOAS
+					if isGloas {
+						copy(kzgCommitment[:], kzgCommitmentsFromBlock.Get(blobIndex)[:])
+					} else {
+						copy(kzgCommitment[:], anyColumnSidecar.KzgCommitments.Get(blobIndex)[:])
+					}
+					// kzg proof
+					ckzgBlob := goethkzg.Blob(blob)
+					proof, err := kzg.Ctx().ComputeBlobKZGProof(&ckzgBlob, goethkzg.KZGCommitment(kzgCommitment), 0 /* numGoRoutines */)
+					if err != nil {
+						log.Warn("[blobsRecover] failed to compute blob kzg proof", "blobIndex", blobIndex, "slot", slot, "blockRoot", blockRoot)
+						return
+					}
+					copy(kzgProof[:], proof[:])
+					// [Modified in Gloas:EIP7732] Use SignedBlockHeader from block for GLOAS
+					var signedBlockHeader *cltypes.SignedBeaconBlockHeader
+					if isGloas {
+						signedBlockHeader = signedBlockHeaderFromBlock
+					} else {
+						signedBlockHeader = anyColumnSidecar.SignedBlockHeader
+					}
+					blobSidecar := cltypes.NewBlobSidecar(
+						uint64(blobIndex),
+						&blob,
+						kzgCommitment,
+						kzgProof,
+						signedBlockHeader,
+						inclusionProof,
+					)
+					blobSidecars = append(blobSidecars, blobSidecar)
+					commitment := cltypes.KZGCommitment(kzgCommitment)
+					blobCommitments.Append(&commitment)
+				}
+				timeRecoverBlobs := time.Since(beginRecoverBlobs)
+				// inclusion proof
+				// [Modified in Gloas:EIP7732] GLOAS sidecars don't have KzgCommitmentsInclusionProof
+				if !isGloas {
+					for i := range len(blobSidecars) {
+						branchProof := blobCommitments.ElementProof(i)
+						p := blobSidecars[i].CommitmentInclusionProof
+						for index := range branchProof {
+							p.Set(index, branchProof[index])
+						}
+						for index := range anyColumnSidecar.KzgCommitmentsInclusionProof.Length() {
+							p.Set(index+len(branchProof), anyColumnSidecar.KzgCommitmentsInclusionProof.Get(index))
+						}
+					}
+				}
+				return newBlobRecoveryResult(existingColumns, isGloas, kzgCommitmentsFromBlock, anyColumnSidecar, blobMatrix, blobSidecars, numberOfBlobs, timeRecoverMatrix, timeRecoverBlobs)
+			}()
+			if result == nil {
 				return
 			}
-			copy(kzgProof[:], proof[:])
-			// [Modified in Gloas:EIP7732] Use SignedBlockHeader from block for GLOAS
-			var signedBlockHeader *cltypes.SignedBeaconBlockHeader
-			if isGloas {
-				signedBlockHeader = signedBlockHeaderFromBlock
-			} else {
-				signedBlockHeader = anyColumnSidecar.SignedBlockHeader
-			}
-			blobSidecar := cltypes.NewBlobSidecar(
-				uint64(blobIndex),
-				&blob,
-				kzgCommitment,
-				kzgProof,
-				signedBlockHeader,
-				inclusionProof)
-			blobSidecars = append(blobSidecars, blobSidecar)
-			commitment := cltypes.KZGCommitment(kzgCommitment)
-			blobCommitments.Append(&commitment)
 		}
-		timeRecoverBlobs := time.Since(beginRecoverBlobs)
-		// inclusion proof
-		// [Modified in Gloas:EIP7732] GLOAS sidecars don't have KzgCommitmentsInclusionProof
-		if !isGloas {
-			for i := range len(blobSidecars) {
-				branchProof := blobCommitments.ElementProof(i)
-				p := blobSidecars[i].CommitmentInclusionProof
-				for index := range branchProof {
-					p.Set(index, branchProof[index])
-				}
-				for index := range anyColumnSidecar.KzgCommitmentsInclusionProof.Length() {
-					p.Set(index+len(branchProof), anyColumnSidecar.KzgCommitmentsInclusionProof.Get(index))
-				}
-			}
-		}
+		existingColumns := result.existingColumns
+		isGloas := result.isGloas
+		kzgCommitmentsFromBlock := result.kzgCommitmentsFromBlock
+		anyColumnSidecar := result.anyColumnSidecar
+		blobMatrix := result.blobMatrix
+		blobSidecars := result.blobSidecars
+		numberOfBlobs := result.numberOfBlobs
+		timeRecoverMatrix := result.timeRecoverMatrix
+		timeRecoverBlobs := result.timeRecoverBlobs
 		// Save blobs
-		if err := d.blobStorage.WriteBlobSidecars(ctx, blockRoot, blobSidecars); err != nil {
-			log.Warn("[blobsRecover] failed to write blob sidecars", "err", err, "slot", slot, "blockRoot", blockRoot)
+		toRecover = d.authoritativeBlobRecoveryRequest(toRecover)
+		if toRecover.metadata != nil {
+			validation, _ := d.storedBlobRecoveryValidation(ctx, toRecover.metadata)
+			if validation == blobRecoveryUnavailable && ctx.Err() == nil {
+				d.cacheBlobRecoveryResult(blockRoot, result)
+				return d.delayBlobRecovery(toRecover)
+			}
+			if validation != blobRecoveryInvalid {
+				return
+			}
+		} else {
+			count, err := d.blobStorage.KzgCommitmentsCount(ctx, blockRoot)
+			if err != nil && ctx.Err() == nil {
+				d.cacheBlobRecoveryResult(blockRoot, result)
+				return d.delayBlobRecovery(toRecover)
+			}
+			if err != nil || count > 0 {
+				return
+			}
+		}
+		if ctx.Err() != nil {
 			return
 		}
+		if err := d.blobStorage.WriteBlobSidecars(ctx, blockRoot, blobSidecars); err != nil {
+			log.Warn("[blobsRecover] failed to write blob sidecars", "err", err, "slot", slot, "blockRoot", blockRoot)
+			if ctx.Err() == nil {
+				d.cacheBlobRecoveryResult(blockRoot, result)
+				return d.delayBlobRecovery(toRecover)
+			}
+			return
+		}
+		d.removeBlobRecoveryResult(blockRoot)
 		log.Trace("[blobsRecover] saved blobs", "slot", slot, "blockRoot", blockRoot, "numberOfBlobs", numberOfBlobs)
 
 		// remove column sidecars that are not in our custody group
@@ -528,11 +1208,15 @@ func (d *peerdas) blobsRecoverWorker(ctx context.Context) {
 			}
 			if !exist {
 				blobSize := anyColumnSidecar.Column.Len()
-				sidecar := cltypes.NewDataColumnSidecar()
+				version := d.beaconConfig.GetCurrentStateVersion(slot / d.beaconConfig.SlotsPerEpoch)
+				sidecar := cltypes.NewDataColumnSidecarWithVersion(version)
 				sidecar.Index = columnIndex
-				sidecar.SignedBlockHeader = anyColumnSidecar.SignedBlockHeader
 				// [Modified in Gloas:EIP7732] GLOAS sidecars don't have KzgCommitmentsInclusionProof and KzgCommitments
-				if !isGloas {
+				if isGloas {
+					sidecar.Slot = slot
+					sidecar.BeaconBlockRoot = blockRoot
+				} else {
+					sidecar.SignedBlockHeader = anyColumnSidecar.SignedBlockHeader
 					sidecar.KzgCommitmentsInclusionProof = anyColumnSidecar.KzgCommitmentsInclusionProof
 					sidecar.KzgCommitments = anyColumnSidecar.KzgCommitments
 				}
@@ -578,77 +1262,77 @@ func (d *peerdas) blobsRecoverWorker(ctx context.Context) {
 		timeAddColumns := time.Since(beginAddColumns)
 		log.Debug("[blobsRecover] recovering done", "slot", slot, "blockRoot", blockRoot, "numberOfBlobs", numberOfBlobs, "elapsedTime", time.Since(begin),
 			"timeRecoverMatrix", timeRecoverMatrix, "timeRecoverBlobs", timeRecoverBlobs, "timeRemoveColumns", timeRemoveColumns, "timeAddColumns", timeAddColumns)
+		return false
 	}
 
 	// main loop
 	for {
-		select {
-		case <-ctx.Done():
+		toRecover, ok := d.nextBlobRecoveryRequest(ctx)
+		if !ok {
 			return
-		case toRecover := <-d.recoverBlobsQueue:
-			d.recoveringMutex.Lock()
-			if _, ok := d.isRecovering[toRecover.blockRoot]; ok {
-				// recovering, skip
-				d.recoveringMutex.Unlock()
-				continue
-			}
-			d.isRecovering[toRecover.blockRoot] = true
-			d.recoveringMutex.Unlock()
+		}
+		var generation uint64
+		toRecover, generation, ok = d.claimBlobRecovery(toRecover)
+		if !ok {
+			continue
+		}
 
-			// check if the blobs are already recovered
-			if !d.IsBlobAlreadyRecovered(toRecover.blockRoot) {
-				// recover the blobs
-				recover(toRecover)
+		var retryScheduled bool
+		if toRecover.metadata != nil {
+			validation, _ := d.storedBlobRecoveryValidation(ctx, toRecover.metadata)
+			switch validation {
+			case blobRecoveryUnavailable:
+				if ctx.Err() == nil {
+					retryScheduled = d.delayBlobRecovery(toRecover)
+				}
+			case blobRecoveryInvalid:
+				retryScheduled = recover(toRecover)
 			}
-			// remove the block from the recovering map
-			d.recoveringMutex.Lock()
-			delete(d.isRecovering, toRecover.blockRoot)
-			d.recoveringMutex.Unlock()
+		} else {
+			count, err := d.blobStorage.KzgCommitmentsCount(ctx, toRecover.blockRoot)
+			if err != nil {
+				if ctx.Err() == nil {
+					retryScheduled = d.delayBlobRecovery(toRecover)
+				}
+			} else if count == 0 && ctx.Err() == nil {
+				retryScheduled = recover(toRecover)
+			}
+		}
+		if !retryScheduled {
+			d.releaseBlobRecovery(toRecover.blockRoot, generation)
 		}
 	}
 }
 
 func (d *peerdas) TryScheduleRecover(slot uint64, blockRoot common.Hash) error {
+	return d.tryScheduleRecover(slot, blockRoot, nil)
+}
+
+func (d *peerdas) tryScheduleRecover(slot uint64, blockRoot common.Hash, metadata *blobRecoveryMetadata) error {
 	if !d.IsArchivedMode() && !d.StateReader().IsSupernode() {
 		return nil
 	}
 
-	if !d.IsColumnOverHalf(slot, blockRoot) || d.IsBlobAlreadyRecovered(blockRoot) {
+	if !d.IsColumnOverHalf(slot, blockRoot) || metadata == nil && d.IsBlobAlreadyRecovered(blockRoot) {
 		// no need to recover if column data is not over 50% or the blobs are already recovered
 		return nil
 	}
 
-	// early check if the blobs are recovering
-	d.recoveringMutex.Lock()
-	if _, ok := d.isRecovering[blockRoot]; ok {
-		d.recoveringMutex.Unlock()
-		return nil
-	}
-	d.recoveringMutex.Unlock()
-
-	// schedule
-	timer := time.NewTimer(3 * time.Second)
-	defer timer.Stop()
-	select {
-	case d.recoverBlobsQueue <- recoverBlobsRequest{
+	request := recoverBlobsRequest{
 		slot:      slot,
 		blockRoot: blockRoot,
-	}:
-	case <-timer.C:
-		return errors.New("failed to schedule recover: timeout")
+		metadata:  metadata,
 	}
-	return nil
+	return d.enqueueBlobRecovery(request)
 }
 
-var (
-	allColumns = func() map[cltypes.CustodyIndex]bool {
-		columns := map[cltypes.CustodyIndex]bool{}
-		for i := range 128 {
-			columns[cltypes.CustodyIndex(i)] = true
-		}
-		return columns
-	}()
-)
+var allColumns = func() map[cltypes.CustodyIndex]bool {
+	columns := map[cltypes.CustodyIndex]bool{}
+	for i := range 128 {
+		columns[cltypes.CustodyIndex(i)] = true
+	}
+	return columns
+}()
 
 // DownloadMissingColumns downloads the missing columns for the given blocks but not recover the blobs
 func (d *peerdas) DownloadOnlyCustodyColumns(ctx context.Context, blocks []cltypes.ColumnSyncableSignedBlock) error {
@@ -676,7 +1360,8 @@ func (d *peerdas) DownloadOnlyCustodyColumns(ctx context.Context, blocks []cltyp
 
 func (d *peerdas) DownloadColumnsAndRecoverBlobs(ctx context.Context, blocks []cltypes.ColumnSyncableSignedBlock) error {
 	// filter out blocks that don't need to be processed
-	blocksToProcess := []cltypes.ColumnSyncableSignedBlock{}
+	recoveryDetails := []*blobRecoveryMetadata{}
+	validatedBlobCounts := make(map[common.Hash]uint32)
 	for _, block := range blocks {
 		kzgCommitments := block.GetBlobKzgCommitments()
 		if block.Version() < clparams.FuluVersion ||
@@ -690,16 +1375,28 @@ func (d *peerdas) DownloadColumnsAndRecoverBlobs(ctx context.Context, blocks []c
 			continue
 		}
 
-		if d.IsColumnOverHalf(block.GetSlot(), root) || d.IsBlobAlreadyRecovered(root) {
-			if err := d.TryScheduleRecover(block.GetSlot(), root); err != nil {
-				log.Debug("failed to schedule recover", "err", err)
+		metadata, err := newBlobRecoveryMetadata(block, root)
+		if err != nil {
+			log.Warn("failed to build blob recovery metadata", "err", err, "blockRoot", root)
+			continue
+		}
+		validation, count := d.storedBlobRecoveryValidation(ctx, metadata)
+		if validation != blobRecoveryUnavailable {
+			validatedBlobCounts[root] = count
+		}
+		complete := validation == blobRecoveryComplete
+		if d.IsColumnOverHalf(block.GetSlot(), root) || complete {
+			if !complete {
+				if err := d.tryScheduleRecover(block.GetSlot(), root, metadata); err != nil {
+					log.Debug("failed to schedule recover", "err", err)
+				}
 			}
 			continue
 		}
-		blocksToProcess = append(blocksToProcess, block)
+		recoveryDetails = append(recoveryDetails, metadata)
 	}
 
-	if len(blocksToProcess) == 0 {
+	if len(recoveryDetails) == 0 {
 		return nil
 	}
 
@@ -709,16 +1406,16 @@ func (d *peerdas) DownloadColumnsAndRecoverBlobs(ctx context.Context, blocks []c
 		for _, block := range blocks {
 			slots = append(slots, block.GetSlot())
 		}
-		log.Debug("DownloadColumnsAndRecoverBlobs", "elapsed time", time.Since(begin), "slots", slots)
+		log.Debug("DownloadColumnsAndRecoverBlobs", "elapsed", time.Since(begin), "slots", slots)
 	}()
 
 	// initialize the download request
 	batchBlcokSize := 4
 	wg := sync.WaitGroup{}
-	for i := 0; i < len(blocksToProcess); i += batchBlcokSize {
-		blocks := blocksToProcess[i:min(i+batchBlcokSize, len(blocksToProcess))]
+	for i := 0; i < len(recoveryDetails); i += batchBlcokSize {
+		details := recoveryDetails[i:min(i+batchBlcokSize, len(recoveryDetails))]
 		wg.Go(func() {
-			req, err := initializeDownloadRequest(blocks, d.beaconConfig, d.columnStorage, allColumns)
+			req, err := initializeDownloadRequestFromRecoveryDetails(details, validatedBlobCounts, d.beaconConfig, d.columnStorage, allColumns)
 			if err != nil {
 				log.Warn("failed to initialize download request", "err", err)
 				return
@@ -730,15 +1427,20 @@ func (d *peerdas) DownloadColumnsAndRecoverBlobs(ctx context.Context, blocks []c
 	return nil
 }
 
-func (d *peerdas) runDownload(ctx context.Context, req *downloadRequest, needToRecoverBlobs bool) error {
+func (d *peerdas) runDownload(ctx context.Context, req *downloadRequest, needToRecoverBlobs bool) {
+	type resolvedColumn struct {
+		slot      uint64
+		blockRoot common.Hash
+	}
 	type resultData struct {
 		sidecars  []*cltypes.DataColumnSidecar
 		pid       string
 		reqLength int
+		requested map[requestedDataColumn]struct{}
 		err       error
 	}
 	if req.remainingEntriesCount() == 0 {
-		return nil
+		return
 	}
 
 	stopChan := make(chan struct{})
@@ -759,21 +1461,19 @@ func (d *peerdas) runDownload(ctx context.Context, req *downloadRequest, needToR
 				wg.Go(func() {
 					cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 					defer cancel()
-					ids := req.requestData()
+					ids, requested := req.requestData()
 					if ids.Len() == 0 {
 						return
 					}
-					reqLength := 0
-					ids.Range(func(_ int, id *cltypes.DataColumnsByRootIdentifier, length int) bool {
-						reqLength += id.Columns.Length()
-						return true
-					})
-					s, pid, err := d.rpc.SendColumnSidecarsByRootIdentifierReq(cctx, ids)
+					s, pid, filtered, err := d.rpc.SendColumnSidecarsByRootIdentifierReqWithSnapshot(cctx, ids)
+					requested = requestedDataColumnsForPayload(requested, filtered)
+					reqLength := len(requested)
 					select {
 					case resultChan <- resultData{
 						sidecars:  s,
 						pid:       pid,
 						reqLength: reqLength,
+						requested: requested,
 						err:       err,
 					}:
 					default:
@@ -797,9 +1497,23 @@ mainloop:
 		case <-halfCheckTicker.C:
 			for _, entry := range req.remainingEntries() {
 				if needToRecoverBlobs {
-					if d.IsColumnOverHalf(entry.slot, entry.blockRoot) || d.IsBlobAlreadyRecovered(entry.blockRoot) {
-						// no need to schedule recovery for this block because someone else will do it
+					metadata := req.recovery(entry.blockRoot)
+					if d.IsColumnOverHalf(entry.slot, entry.blockRoot) {
 						req.removeBlock(entry.slot, entry.blockRoot)
+						if err := d.tryScheduleRecover(entry.slot, entry.blockRoot, metadata); err != nil {
+							log.Debug("failed to schedule recover", "err", err)
+						}
+					} else if metadata != nil {
+						count, err := d.blobStorage.KzgCommitmentsCount(ctx, entry.blockRoot)
+						if err == nil && req.blobCountNeedsValidation(entry.blockRoot, count) {
+							validation := d.validateStoredBlobRecoveryMetadata(ctx, metadata, count)
+							if validation != blobRecoveryUnavailable {
+								req.updateValidatedBlobCount(entry.blockRoot, count)
+							}
+							if validation == blobRecoveryComplete {
+								req.removeBlock(entry.slot, entry.blockRoot)
+							}
+						}
 					}
 				} else {
 					available, err := d.isMyColumnDataAvailable(entry.slot, entry.blockRoot)
@@ -829,22 +1543,58 @@ mainloop:
 				continue
 			}
 			log.Debug("received column sidecars", "pid", result.pid, "reqLength", result.reqLength, "count", len(result.sidecars))
+			if len(result.sidecars) > result.reqLength {
+				log.Debug("rejecting over-cardinality column response", "pid", result.pid, "reqLength", result.reqLength, "count", len(result.sidecars))
+				d.rpc.BanPeer(result.pid)
+				continue
+			}
+			resolved := make([]resolvedColumn, len(result.sidecars))
+			seen := make(map[requestedDataColumn]struct{}, len(result.sidecars))
+			validResponse := true
+			for i, sidecar := range result.sidecars {
+				if sidecar == nil {
+					validResponse = false
+					break
+				}
+				slot, blockRoot, ok := d.resolveColumnSidecarSlotAndRoot(sidecar)
+				if !ok {
+					validResponse = false
+					break
+				}
+				key := requestedDataColumn{slot: slot, blockRoot: blockRoot, index: sidecar.Index}
+				if _, ok := result.requested[key]; !ok {
+					validResponse = false
+					break
+				}
+				metadata := req.recovery(blockRoot)
+				if sidecar.Version() < clparams.GloasVersion && metadata != nil && metadata.hasSignature && sidecar.SignedBlockHeader.Signature != metadata.signature {
+					validResponse = false
+					break
+				}
+				if _, duplicate := seen[key]; duplicate {
+					validResponse = false
+					break
+				}
+				seen[key] = struct{}{}
+				resolved[i] = resolvedColumn{slot: slot, blockRoot: blockRoot}
+			}
+			if !validResponse {
+				log.Debug("rejecting malformed, schema-inconsistent, or unrequested column response", "pid", result.pid)
+				d.rpc.BanPeer(result.pid)
+				continue
+			}
 			var wg sync.WaitGroup
-			for _, sidecar := range result.sidecars {
+			for i, sidecar := range result.sidecars {
 				wg.Go(func() {
-					slot, blockRoot, ok := d.resolveColumnSidecarSlotAndRoot(sidecar)
-					if !ok {
-						log.Debug("rejecting malformed or schema-inconsistent column sidecar", "pid", result.pid)
-						d.rpc.BanPeer(result.pid)
-						return
-					}
+					slot, blockRoot := resolved[i].slot, resolved[i].blockRoot
 					isGloasSidecar := sidecar.Version() >= clparams.GloasVersion
 					defer func() {
 						// check if need to schedule recover whenever we download a column sidecar
-						if needToRecoverBlobs &&
-							(d.IsColumnOverHalf(slot, blockRoot) || d.IsBlobAlreadyRecovered(blockRoot)) {
+						if needToRecoverBlobs && d.IsColumnOverHalf(slot, blockRoot) {
 							req.removeBlock(slot, blockRoot)
-							d.TryScheduleRecover(slot, blockRoot)
+							if err := d.tryScheduleRecover(slot, blockRoot, req.recovery(blockRoot)); err != nil {
+								log.Debug("failed to schedule recover", "err", err)
+							}
 						}
 					}()
 
@@ -919,17 +1669,12 @@ mainloop:
 			}
 		}
 	}
-
-	return nil
 }
 
-// resolveColumnSidecarSlotAndRoot reads a received column sidecar's slot and
-// block root from the fields populated by the schema it was decoded with. ok is
-// false for a malformed sidecar, or one whose slot disagrees with that schema —
-// see BeaconChainConfig.ForkSchemaMatchesSlot.
+// resolveColumnSidecarSlotAndRoot rejects malformed sidecars and response fork versions that are not active at the claimed slot.
 func (d *peerdas) resolveColumnSidecarSlotAndRoot(sidecar *cltypes.DataColumnSidecar) (slot uint64, blockRoot common.Hash, ok bool) {
 	if sidecar.Version() >= clparams.GloasVersion {
-		if !d.beaconConfig.ForkSchemaMatchesSlot(sidecar.Slot, sidecar.Version()) {
+		if d.beaconConfig.GetCurrentStateVersion(sidecar.Slot/d.beaconConfig.SlotsPerEpoch) != sidecar.Version() {
 			return 0, common.Hash{}, false
 		}
 		return sidecar.Slot, sidecar.BeaconBlockRoot, true
@@ -938,7 +1683,7 @@ func (d *peerdas) resolveColumnSidecarSlotAndRoot(sidecar *cltypes.DataColumnSid
 	if header == nil || header.Header == nil {
 		return 0, common.Hash{}, false
 	}
-	if !d.beaconConfig.ForkSchemaMatchesSlot(header.Header.Slot, sidecar.Version()) {
+	if d.beaconConfig.GetCurrentStateVersion(header.Header.Slot/d.beaconConfig.SlotsPerEpoch) != sidecar.Version() {
 		return 0, common.Hash{}, false
 	}
 	root, err := header.Header.HashSSZ()
@@ -964,11 +1709,43 @@ type downloadTableEntry struct {
 	slot      uint64
 }
 
+type requestedDataColumn struct {
+	slot      uint64
+	blockRoot common.Hash
+	index     uint64
+}
+
+func requestedDataColumnsForPayload(requested map[requestedDataColumn]struct{}, payload *solid.ListSSZ[*cltypes.DataColumnsByRootIdentifier]) map[requestedDataColumn]struct{} {
+	type identity struct {
+		blockRoot common.Hash
+		index     uint64
+	}
+	selected := make(map[identity]struct{})
+	if payload != nil {
+		payload.Range(func(_ int, id *cltypes.DataColumnsByRootIdentifier, _ int) bool {
+			id.Columns.Range(func(_ int, column uint64, _ int) bool {
+				selected[identity{blockRoot: id.BlockRoot, index: column}] = struct{}{}
+				return true
+			})
+			return true
+		})
+	}
+	filtered := make(map[requestedDataColumn]struct{}, len(selected))
+	for column := range requested {
+		if _, ok := selected[identity{blockRoot: column.blockRoot, index: column.index}]; ok {
+			filtered[column] = struct{}{}
+		}
+	}
+	return filtered
+}
+
 // downloadRequest is used to track the download progress of the column sidecars
 type downloadRequest struct {
-	beaconConfig  *clparams.BeaconChainConfig
-	tableMutex    sync.RWMutex
-	downloadTable map[downloadTableEntry]map[uint64]bool
+	beaconConfig       *clparams.BeaconChainConfig
+	tableMutex         sync.RWMutex
+	downloadTable      map[downloadTableEntry]map[uint64]bool
+	recoveryDetails    map[common.Hash]*blobRecoveryMetadata
+	validatedBlobCount map[common.Hash]uint32
 }
 
 // [Modified in Gloas:EIP7732] Changed from []*SignedBlindedBeaconBlock to []ColumnSyncableSignedBlock
@@ -978,8 +1755,7 @@ func initializeDownloadRequest(
 	columnStorage blob_storage.DataColumnStorage,
 	expectedColumns map[cltypes.CustodyIndex]bool,
 ) (*downloadRequest, error) {
-	downloadTable := make(map[downloadTableEntry]map[uint64]bool)
-	blockRootToBeaconBlock := make(map[common.Hash]cltypes.ColumnSyncableSignedBlock)
+	details := make([]*blobRecoveryMetadata, 0, len(blocks))
 	for _, block := range blocks {
 		if block.Version() < clparams.FuluVersion {
 			continue
@@ -993,10 +1769,34 @@ func initializeDownloadRequest(
 		if err != nil {
 			return nil, err
 		}
-		blockRootToBeaconBlock[blockRoot] = block
+		metadata, err := newBlobRecoveryMetadata(block, blockRoot)
+		if err != nil {
+			return nil, err
+		}
+		details = append(details, metadata)
+	}
+	return initializeDownloadRequestFromRecoveryDetails(details, nil, beaconConfig, columnStorage, expectedColumns)
+}
+
+func initializeDownloadRequestFromRecoveryDetails(
+	details []*blobRecoveryMetadata,
+	validatedBlobCounts map[common.Hash]uint32,
+	beaconConfig *clparams.BeaconChainConfig,
+	columnStorage blob_storage.DataColumnStorage,
+	expectedColumns map[cltypes.CustodyIndex]bool,
+) (*downloadRequest, error) {
+	downloadTable := make(map[downloadTableEntry]map[uint64]bool)
+	recoveryDetails := make(map[common.Hash]*blobRecoveryMetadata, len(details))
+	requestValidatedCounts := make(map[common.Hash]uint32, len(details))
+	for _, metadata := range details {
+		if metadata == nil {
+			continue
+		}
+		recoveryDetails[metadata.blockRoot] = metadata
+		requestValidatedCounts[metadata.blockRoot] = validatedBlobCounts[metadata.blockRoot]
 
 		// get the existing columns from the column storage
-		existingColumns, err := columnStorage.GetSavedColumnIndex(context.Background(), block.GetSlot(), blockRoot)
+		existingColumns, err := columnStorage.GetSavedColumnIndex(context.Background(), metadata.slot, metadata.blockRoot)
 		if err != nil {
 			return nil, err
 		}
@@ -1006,8 +1806,8 @@ func initializeDownloadRequest(
 		}
 
 		if _, ok := downloadTable[downloadTableEntry{
-			blockRoot: blockRoot,
-			slot:      block.GetSlot(),
+			blockRoot: metadata.blockRoot,
+			slot:      metadata.slot,
 		}]; !ok {
 			table := make(map[uint64]bool)
 			for column := range expectedColumns {
@@ -1017,16 +1817,34 @@ func initializeDownloadRequest(
 			}
 			if len(table) > 0 {
 				downloadTable[downloadTableEntry{
-					blockRoot: blockRoot,
-					slot:      block.GetSlot(),
+					blockRoot: metadata.blockRoot,
+					slot:      metadata.slot,
 				}] = table
 			}
 		}
 	}
 	return &downloadRequest{
-		beaconConfig:  beaconConfig,
-		downloadTable: downloadTable,
+		beaconConfig:       beaconConfig,
+		downloadTable:      downloadTable,
+		recoveryDetails:    recoveryDetails,
+		validatedBlobCount: requestValidatedCounts,
 	}, nil
+}
+
+func (d *downloadRequest) recovery(blockRoot common.Hash) *blobRecoveryMetadata {
+	return d.recoveryDetails[blockRoot]
+}
+
+func (d *downloadRequest) blobCountNeedsValidation(blockRoot common.Hash, count uint32) bool {
+	d.tableMutex.RLock()
+	defer d.tableMutex.RUnlock()
+	return d.validatedBlobCount[blockRoot] != count
+}
+
+func (d *downloadRequest) updateValidatedBlobCount(blockRoot common.Hash, count uint32) {
+	d.tableMutex.Lock()
+	defer d.tableMutex.Unlock()
+	d.validatedBlobCount[blockRoot] = count
 }
 
 func (d *downloadRequest) remainingEntries() []downloadTableEntry {
@@ -1067,8 +1885,9 @@ func (d *downloadRequest) removeBlock(slot uint64, blockRoot common.Hash) {
 	})
 }
 
-func (d *downloadRequest) requestData() *solid.ListSSZ[*cltypes.DataColumnsByRootIdentifier] {
+func (d *downloadRequest) requestData() (*solid.ListSSZ[*cltypes.DataColumnsByRootIdentifier], map[requestedDataColumn]struct{}) {
 	payload := solid.NewDynamicListSSZ[*cltypes.DataColumnsByRootIdentifier](int(d.beaconConfig.MaxRequestBlocksDeneb))
+	requested := make(map[requestedDataColumn]struct{})
 
 	d.tableMutex.RLock()
 	defer d.tableMutex.RUnlock()
@@ -1079,12 +1898,13 @@ func (d *downloadRequest) requestData() *solid.ListSSZ[*cltypes.DataColumnsByRoo
 		}
 		for column := range columns {
 			id.Columns.Append(column)
+			requested[requestedDataColumn{slot: entry.slot, blockRoot: entry.blockRoot, index: column}] = struct{}{}
 		}
 		if id.Columns.Length() > 0 {
 			payload.Append(id)
 		}
 	}
-	return payload
+	return payload, requested
 }
 
 func (d *peerdas) SyncColumnDataLater(block *cltypes.SignedBeaconBlock) error {
@@ -1138,12 +1958,13 @@ func (d *peerdas) syncColumnDataWorker(ctx context.Context) {
 					return true
 				}
 				available, err := d.IsDataAvailable(block.GetSlot(), root)
-				if err != nil {
+				switch {
+				case err != nil:
 					log.Warn("failed to check if data is available", "err", err)
-				} else if available {
+				case available:
 					log.Trace("[syncColumnDataWorker] column data is already available, removing from sync queue", "slot", block.GetSlot(), "blockRoot", root)
 					d.blocksToCheckSync.Delete(root)
-				} else {
+				default:
 					blocks = append(blocks, block)
 					roots = append(roots, root)
 				}

--- a/cl/das/peer_das_download_test.go
+++ b/cl/das/peer_das_download_test.go
@@ -19,26 +19,33 @@ package das
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
+	"errors"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc"
 
 	"github.com/erigontech/erigon/cl/beacon/beaconevents"
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
 	peerdasstate "github.com/erigontech/erigon/cl/das/state"
+	peerdasutils "github.com/erigontech/erigon/cl/das/utils"
 	"github.com/erigontech/erigon/cl/persistence/blob_storage"
+	blob_storage_mock_services "github.com/erigontech/erigon/cl/persistence/blob_storage/mock_services"
 	"github.com/erigontech/erigon/cl/phase1/core/state/lru"
 	"github.com/erigontech/erigon/cl/rpc"
 	"github.com/erigontech/erigon/cl/sentinel/communication/ssz_snappy"
 	"github.com/erigontech/erigon/cl/utils/eth_clock"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/node/gointerfaces/sentinelproto"
+	"github.com/erigontech/erigon/p2p/enode"
 )
 
 // maliciousColumnSentinel stands in for a selected custody peer. It answers
@@ -48,15 +55,21 @@ type maliciousColumnSentinel struct {
 	sentinelproto.SentinelClient
 	metadataResponse []byte
 	columnResponse   []byte
+	columnResponses  [][]byte
+	peerEnodeID      string
 
-	metadataOnce  sync.Once
-	metadataReady chan struct{}
-	banOnce       sync.Once
-	banned        chan struct{}
+	metadataOnce    sync.Once
+	metadataReady   chan struct{}
+	columnOnce      sync.Once
+	columnRequested chan struct{}
+	releaseColumn   chan struct{}
+	columnCalls     atomic.Int32
+	banOnce         sync.Once
+	banned          chan struct{}
 }
 
 func (s *maliciousColumnSentinel) PeersInfo(context.Context, *sentinelproto.PeersInfoRequest, ...grpc.CallOption) (*sentinelproto.PeersInfoResponse, error) {
-	return &sentinelproto.PeersInfoResponse{Peers: []*sentinelproto.Peer{{Pid: "malicious-peer"}}}, nil
+	return &sentinelproto.PeersInfoResponse{Peers: []*sentinelproto.Peer{{Pid: "malicious-peer", EnodeId: s.peerEnodeID}}}, nil
 }
 
 func (s *maliciousColumnSentinel) BanPeer(context.Context, *sentinelproto.Peer, ...grpc.CallOption) (*sentinelproto.EmptyMessage, error) {
@@ -64,13 +77,1046 @@ func (s *maliciousColumnSentinel) BanPeer(context.Context, *sentinelproto.Peer, 
 	return &sentinelproto.EmptyMessage{}, nil
 }
 
-func (s *maliciousColumnSentinel) SendPeerRequest(_ context.Context, req *sentinelproto.RequestDataWithPeer, _ ...grpc.CallOption) (*sentinelproto.ResponseData, error) {
+func (s *maliciousColumnSentinel) SendPeerRequest(ctx context.Context, req *sentinelproto.RequestDataWithPeer, _ ...grpc.CallOption) (*sentinelproto.ResponseData, error) {
 	peer := &sentinelproto.Peer{Pid: "malicious-peer"}
 	if strings.Contains(req.Topic, "metadata") {
 		s.metadataOnce.Do(func() { close(s.metadataReady) })
 		return &sentinelproto.ResponseData{Data: s.metadataResponse, Peer: peer}, nil
 	}
-	return &sentinelproto.ResponseData{Data: s.columnResponse, Peer: peer}, nil
+	if s.columnRequested != nil {
+		s.columnOnce.Do(func() { close(s.columnRequested) })
+	}
+	if s.releaseColumn != nil {
+		select {
+		case <-s.releaseColumn:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	response := s.columnResponse
+	if len(s.columnResponses) > 0 {
+		index := min(int(s.columnCalls.Add(1))-1, len(s.columnResponses)-1)
+		response = s.columnResponses[index]
+	}
+	return &sentinelproto.ResponseData{Data: response, Peer: peer}, nil
+}
+
+type writeObservingColumnStorage struct {
+	blob_storage.DataColumnStorage
+	lookups chan struct{}
+	writes  chan *cltypes.DataColumnSidecar
+}
+
+func (s *writeObservingColumnStorage) ColumnSidecarExists(ctx context.Context, slot uint64, blockRoot common.Hash, columnIndex int64) (bool, error) {
+	select {
+	case s.lookups <- struct{}{}:
+	default:
+	}
+	return s.DataColumnStorage.ColumnSidecarExists(ctx, slot, blockRoot, columnIndex)
+}
+
+func (s *writeObservingColumnStorage) WriteColumnSidecars(ctx context.Context, blockRoot common.Hash, columnIndex int64, sidecar *cltypes.DataColumnSidecar) error {
+	if err := s.DataColumnStorage.WriteColumnSidecars(ctx, blockRoot, columnIndex, sidecar); err != nil {
+		return err
+	}
+	select {
+	case s.writes <- sidecar:
+	default:
+	}
+	return nil
+}
+
+func newColumnResponseRPC(t *testing.T, cfg *clparams.BeaconChainConfig, currentSlot uint64, responses ...[]*cltypes.DataColumnSidecar) (*rpc.BeaconRpcP2P, *maliciousColumnSentinel) {
+	return newColumnResponseRPCWithPeer(t, cfg, currentSlot, "", cfg.NumberOfColumns, responses...)
+}
+
+func newColumnResponseRPCWithPeer(t *testing.T, cfg *clparams.BeaconChainConfig, currentSlot uint64, peerEnodeID string, custodyGroupCount uint64, responses ...[]*cltypes.DataColumnSidecar) (*rpc.BeaconRpcP2P, *maliciousColumnSentinel) {
+	return newColumnResponseRPCWithPeerAndForkEpoch(t, cfg, currentSlot, peerEnodeID, custodyGroupCount, cfg.FuluForkEpoch, responses...)
+}
+
+func newColumnResponseRPCWithPeerAndForkEpoch(t *testing.T, cfg *clparams.BeaconChainConfig, currentSlot uint64, peerEnodeID string, custodyGroupCount, responseForkEpoch uint64, responses ...[]*cltypes.DataColumnSidecar) (*rpc.BeaconRpcP2P, *maliciousColumnSentinel) {
+	t.Helper()
+	genesisTime := uint64(time.Now().Unix()) - currentSlot*cfg.SecondsPerSlot
+	clock := eth_clock.NewEthereumClock(genesisTime, common.Hash{}, cfg)
+	require.GreaterOrEqual(t, clock.StateVersionByEpoch(clock.GetCurrentEpoch()), clparams.FuluVersion)
+	digest, err := clock.ComputeForkDigest(responseForkEpoch)
+	require.NoError(t, err)
+	encoded := make([][]byte, len(responses))
+	for i, sidecars := range responses {
+		var wire bytes.Buffer
+		for j, sidecar := range sidecars {
+			if j > 0 {
+				require.NoError(t, wire.WriteByte(0))
+			}
+			require.NoError(t, ssz_snappy.EncodeAndWrite(&wire, sidecar, digest[:]...))
+		}
+		encoded[i] = wire.Bytes()
+	}
+
+	syncnets := [1]byte{}
+	metadata := &cltypes.Metadata{Syncnets: &syncnets, CustodyGroupCount: &custodyGroupCount}
+	var metadataWire bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&metadataWire, metadata))
+	sentinel := &maliciousColumnSentinel{
+		metadataResponse: metadataWire.Bytes(),
+		columnResponses:  encoded,
+		peerEnodeID:      peerEnodeID,
+		metadataReady:    make(chan struct{}),
+		banned:           make(chan struct{}),
+	}
+	rpcClient := rpc.NewBeaconRpcP2P(t.Context(), sentinel, cfg, clock, nil)
+	select {
+	case <-sentinel.metadataReady:
+	case <-time.After(30 * time.Second):
+		t.Fatal("column response peer was not added to the custody-peer queue")
+	}
+	return rpcClient, sentinel
+}
+
+func TestRunDownloadRejectsResponseForkDigestMismatchBeforeStorage(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	currentSlot := (cfg.FuluForkEpoch + 1) * cfg.SlotsPerEpoch
+	block, root, _, columns := recoverableFuluDataAtSlot(t, &cfg, currentSlot)
+	rpcClient, sentinel := newColumnResponseRPCWithPeerAndForkEpoch(
+		t,
+		&cfg,
+		currentSlot,
+		"",
+		cfg.NumberOfColumns,
+		cfg.DenebForkEpoch,
+		[]*cltypes.DataColumnSidecar{columns[0]},
+	)
+
+	storage := &writeObservingColumnStorage{
+		DataColumnStorage: blob_storage.NewDataColumnStore(afero.NewMemMapFs(), &cfg, beaconevents.NewEventEmitter()),
+		lookups:           make(chan struct{}, 1),
+		writes:            make(chan *cltypes.DataColumnSidecar, 1),
+	}
+	d := &peerdas{
+		rpc:           rpcClient,
+		beaconConfig:  &cfg,
+		state:         peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{}),
+		columnStorage: storage,
+	}
+	req := &downloadRequest{
+		beaconConfig: &cfg,
+		downloadTable: map[downloadTableEntry]map[uint64]bool{
+			{blockRoot: root, slot: block.GetSlot()}: {0: true},
+		},
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() { defer close(done); d.runDownload(ctx, req, false) }()
+
+	select {
+	case <-sentinel.banned:
+	case <-storage.lookups:
+		cancel()
+		<-done
+		t.Fatal("fork-digest mismatch reached storage lookup")
+	case <-time.After(30 * time.Second):
+		cancel()
+		<-done
+		t.Fatal("fork-digest mismatch was neither rejected nor processed")
+	}
+	cancel()
+	<-done
+	require.Equal(t, 1, req.remainingEntriesCount())
+}
+
+func TestRunDownloadRejectsStaleBPOForkDigestBeforeStorage(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	require.GreaterOrEqual(t, len(cfg.BlobSchedule), 2)
+	earlierEpoch := cfg.BlobSchedule[0].Epoch
+	laterEpoch := cfg.BlobSchedule[1].Epoch
+	currentSlot := laterEpoch * cfg.SlotsPerEpoch
+
+	clock := eth_clock.NewEthereumClock(uint64(time.Now().Unix())-currentSlot*cfg.SecondsPerSlot, common.Hash{}, &cfg)
+	earlierDigest, err := clock.ComputeForkDigest(earlierEpoch)
+	require.NoError(t, err)
+	laterDigest, err := clock.ComputeForkDigest(laterEpoch)
+	require.NoError(t, err)
+	require.NotEqual(t, earlierDigest, laterDigest)
+	earlierVersion, err := clock.StateVersionByForkDigest(earlierDigest)
+	require.NoError(t, err)
+	laterVersion, err := clock.StateVersionByForkDigest(laterDigest)
+	require.NoError(t, err)
+	require.Equal(t, clparams.FuluVersion, earlierVersion)
+	require.Equal(t, clparams.FuluVersion, laterVersion)
+
+	block, root, _, columns := recoverableFuluDataAtSlot(t, &cfg, currentSlot)
+	rpcClient, sentinel := newColumnResponseRPCWithPeerAndForkEpoch(
+		t,
+		&cfg,
+		currentSlot,
+		"",
+		cfg.NumberOfColumns,
+		earlierEpoch,
+		[]*cltypes.DataColumnSidecar{columns[0]},
+	)
+
+	storage := &writeObservingColumnStorage{
+		DataColumnStorage: blob_storage.NewDataColumnStore(afero.NewMemMapFs(), &cfg, beaconevents.NewEventEmitter()),
+		lookups:           make(chan struct{}, 1),
+		writes:            make(chan *cltypes.DataColumnSidecar, 1),
+	}
+	d := &peerdas{
+		rpc:           rpcClient,
+		beaconConfig:  &cfg,
+		state:         peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{}),
+		columnStorage: storage,
+	}
+	req := &downloadRequest{
+		beaconConfig: &cfg,
+		downloadTable: map[downloadTableEntry]map[uint64]bool{
+			{blockRoot: root, slot: block.GetSlot()}: {0: true},
+		},
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() { defer close(done); d.runDownload(ctx, req, false) }()
+
+	select {
+	case <-sentinel.banned:
+	case <-storage.lookups:
+		cancel()
+		<-done
+		t.Fatal("stale BPO fork digest reached storage lookup")
+	case <-time.After(30 * time.Second):
+		cancel()
+		<-done
+		t.Fatal("stale BPO fork digest was neither rejected nor processed")
+	}
+	cancel()
+	<-done
+	require.Equal(t, 1, req.remainingEntriesCount())
+}
+
+func TestRunDownloadAcceptsExactBPOForkDigest(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	require.GreaterOrEqual(t, len(cfg.BlobSchedule), 2)
+
+	for _, test := range []struct {
+		name    string
+		epoch   uint64
+		blinded bool
+	}{
+		{name: "first BPO epoch with full block metadata", epoch: cfg.BlobSchedule[0].Epoch},
+		{name: "second BPO epoch with blinded block metadata", epoch: cfg.BlobSchedule[1].Epoch, blinded: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			currentSlot := test.epoch * cfg.SlotsPerEpoch
+			executionBlockHash := common.Hash{}
+			if test.blinded {
+				executionBlockHash = common.HexToHash("0x01")
+			}
+			block, root, _, columns := recoverableFuluDataAtSlotWithExecutionBlockHash(t, &cfg, currentSlot, executionBlockHash)
+			var recoveryBlock cltypes.ColumnSyncableSignedBlock = block
+			if test.blinded {
+				blinded, err := block.Blinded()
+				require.NoError(t, err)
+				recoveryBlock = blinded
+			}
+			recoveryRoot, err := recoveryBlock.BlockHashSSZ()
+			require.NoError(t, err)
+			require.Equal(t, root, common.Hash(recoveryRoot))
+			metadata, err := newBlobRecoveryMetadata(recoveryBlock, root)
+			require.NoError(t, err)
+			rpcClient, sentinel := newColumnResponseRPCWithPeerAndForkEpoch(
+				t,
+				&cfg,
+				currentSlot,
+				"",
+				cfg.NumberOfColumns,
+				test.epoch,
+				[]*cltypes.DataColumnSidecar{columns[0]},
+			)
+
+			storage := &writeObservingColumnStorage{
+				DataColumnStorage: blob_storage.NewDataColumnStore(afero.NewMemMapFs(), &cfg, beaconevents.NewEventEmitter()),
+				lookups:           make(chan struct{}, 1),
+				writes:            make(chan *cltypes.DataColumnSidecar, 1),
+			}
+			d := &peerdas{
+				rpc:           rpcClient,
+				beaconConfig:  &cfg,
+				state:         peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{}),
+				columnStorage: storage,
+			}
+			req := &downloadRequest{
+				beaconConfig: &cfg,
+				downloadTable: map[downloadTableEntry]map[uint64]bool{
+					{blockRoot: root, slot: block.GetSlot()}: {0: true},
+				},
+				recoveryDetails:    map[common.Hash]*blobRecoveryMetadata{root: metadata},
+				validatedBlobCount: map[common.Hash]uint32{root: 0},
+			}
+			ctx, cancel := context.WithCancel(t.Context())
+			done := make(chan struct{})
+			go func() { defer close(done); d.runDownload(ctx, req, true) }()
+
+			select {
+			case sidecar := <-storage.writes:
+				require.Equal(t, uint64(0), sidecar.Index)
+			case <-sentinel.banned:
+				cancel()
+				<-done
+				t.Fatal("exact BPO fork digest was banned")
+			case <-time.After(30 * time.Second):
+				cancel()
+				<-done
+				t.Fatal("exact BPO fork digest did not reach storage")
+			}
+			cancel()
+			<-done
+			require.Equal(t, 0, req.remainingEntriesCount())
+		})
+	}
+}
+
+func TestRunDownloadRejectsFuluSignatureMismatchBeforeStorage(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.AltairForkEpoch = 0
+	cfg.BellatrixForkEpoch = 0
+	cfg.CapellaForkEpoch = 0
+	cfg.DenebForkEpoch = 0
+	cfg.ElectraForkEpoch = 0
+	cfg.FuluForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	block, root, _, columns := recoverableFuluDataAtSlot(t, &cfg, 100)
+	metadata, err := newBlobRecoveryMetadata(block, root)
+	require.NoError(t, err)
+	mismatchedHeader := *columns[1].SignedBlockHeader
+	mismatchedHeader.Signature[0] ^= 1
+	columns[1].SignedBlockHeader = &mismatchedHeader
+	require.True(t, VerifyDataColumnSidecar(columns[1]))
+	require.True(t, VerifyDataColumnSidecarInclusionProof(columns[1]))
+	require.True(t, VerifyDataColumnSidecarKZGProofs(columns[1]))
+
+	rpcClient, sentinel := newColumnResponseRPC(t, &cfg, block.GetSlot(), []*cltypes.DataColumnSidecar{columns[0], columns[1]})
+	baseStorage := blob_storage.NewDataColumnStore(afero.NewMemMapFs(), &cfg, beaconevents.NewEventEmitter())
+	storage := &writeObservingColumnStorage{
+		DataColumnStorage: baseStorage,
+		lookups:           make(chan struct{}, 1),
+		writes:            make(chan *cltypes.DataColumnSidecar, 1),
+	}
+	d := &peerdas{
+		rpc:           rpcClient,
+		beaconConfig:  &cfg,
+		state:         peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{}),
+		columnStorage: storage,
+	}
+	req := &downloadRequest{
+		beaconConfig: &cfg,
+		downloadTable: map[downloadTableEntry]map[uint64]bool{
+			{blockRoot: root, slot: block.GetSlot()}: {0: true, 1: true},
+		},
+		recoveryDetails:    map[common.Hash]*blobRecoveryMetadata{root: metadata},
+		validatedBlobCount: map[common.Hash]uint32{root: 0},
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() { defer close(done); d.runDownload(ctx, req, true) }()
+
+	select {
+	case <-sentinel.banned:
+	case <-storage.lookups:
+		select {
+		case <-storage.writes:
+			cancel()
+			<-done
+			t.Fatal("signature-mismatched Fulu column was persisted")
+		case <-sentinel.banned:
+			cancel()
+			<-done
+			t.Fatal("signature mismatch reached storage lookup before rejection")
+		case <-time.After(30 * time.Second):
+			cancel()
+			<-done
+			t.Fatal("signature mismatch reached storage lookup without a terminal result")
+		}
+	case <-time.After(30 * time.Second):
+		cancel()
+		<-done
+		t.Fatal("signature mismatch was neither rejected nor processed")
+	}
+	cancel()
+	<-done
+	require.Equal(t, 1, req.remainingEntriesCount())
+	_, remaining := req.requestData()
+	require.Len(t, remaining, 2)
+	saved, err := baseStorage.GetSavedColumnIndex(t.Context(), block.GetSlot(), root)
+	require.NoError(t, err)
+	require.Empty(t, saved)
+}
+
+func TestRunDownloadAcceptsGloasSidecarWithRecoveryMetadata(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.AltairForkEpoch = 0
+	cfg.BellatrixForkEpoch = 0
+	cfg.CapellaForkEpoch = 0
+	cfg.DenebForkEpoch = 0
+	cfg.ElectraForkEpoch = 0
+	cfg.FuluForkEpoch = 1
+	cfg.GloasForkEpoch = 2
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	currentSlot := cfg.GloasForkEpoch * cfg.SlotsPerEpoch
+	block, root, columns := recoverableGloasColumns(t, &cfg, currentSlot)
+	metadata, err := newBlobRecoveryMetadata(block, root)
+	require.NoError(t, err)
+	require.True(t, metadata.hasSignature)
+	rpcClient, sentinel := newColumnResponseRPCWithPeerAndForkEpoch(
+		t,
+		&cfg,
+		currentSlot,
+		"",
+		cfg.NumberOfColumns,
+		cfg.GloasForkEpoch,
+		[]*cltypes.DataColumnSidecar{columns[0]},
+	)
+
+	storage := &writeObservingColumnStorage{
+		DataColumnStorage: blob_storage.NewDataColumnStore(afero.NewMemMapFs(), &cfg, beaconevents.NewEventEmitter()),
+		lookups:           make(chan struct{}, 1),
+		writes:            make(chan *cltypes.DataColumnSidecar, 1),
+	}
+	gloasDataCache, err := lru.New[common.Hash, *gloasBlockData]("gloasSignaturePreflight", 1)
+	require.NoError(t, err)
+	gloasDataCache.Add(root, &gloasBlockData{
+		BlobKzgCommitments:      block.GetBlobKzgCommitments(),
+		SignedBeaconBlockHeader: block.SignedBeaconBlockHeader(),
+	})
+	d := &peerdas{
+		rpc:            rpcClient,
+		beaconConfig:   &cfg,
+		state:          peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{}),
+		columnStorage:  storage,
+		gloasDataCache: gloasDataCache,
+	}
+	req := &downloadRequest{
+		beaconConfig: &cfg,
+		downloadTable: map[downloadTableEntry]map[uint64]bool{
+			{blockRoot: root, slot: block.GetSlot()}: {0: true},
+		},
+		recoveryDetails:    map[common.Hash]*blobRecoveryMetadata{root: metadata},
+		validatedBlobCount: map[common.Hash]uint32{root: 0},
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() { defer close(done); d.runDownload(ctx, req, true) }()
+
+	select {
+	case sidecar := <-storage.writes:
+		require.Equal(t, uint64(0), sidecar.Index)
+	case <-sentinel.banned:
+		cancel()
+		<-done
+		t.Fatal("valid Gloas sidecar was rejected by Fulu signature preflight")
+	case <-time.After(30 * time.Second):
+		cancel()
+		<-done
+		t.Fatal("valid Gloas sidecar did not reach storage")
+	}
+	cancel()
+	<-done
+	require.Equal(t, 0, req.remainingEntriesCount())
+}
+
+func TestRunDownloadRejectsColumnFilteredOutOfWireRequest(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.AltairForkEpoch = 0
+	cfg.BellatrixForkEpoch = 0
+	cfg.CapellaForkEpoch = 0
+	cfg.DenebForkEpoch = 0
+	cfg.ElectraForkEpoch = 0
+	cfg.FuluForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	block, root, _, columns := recoverableFuluDataAtSlot(t, &cfg, 100)
+
+	var nodeID enode.ID
+	foundPeer := false
+	for candidate := range uint64(10_000) {
+		binary.LittleEndian.PutUint64(nodeID[:8], candidate)
+		mask, err := peerdasutils.GetCustodyColumns(nodeID, 1)
+		require.NoError(t, err)
+		if mask[0] && !mask[1] {
+			foundPeer = true
+			break
+		}
+	}
+	require.True(t, foundPeer)
+	rpcClient, sentinel := newColumnResponseRPCWithPeer(t, &cfg, block.GetSlot(), nodeID.String(), 1, []*cltypes.DataColumnSidecar{columns[1]})
+
+	baseStorage := blob_storage.NewDataColumnStore(afero.NewMemMapFs(), &cfg, beaconevents.NewEventEmitter())
+	storage := &writeObservingColumnStorage{
+		DataColumnStorage: baseStorage,
+		lookups:           make(chan struct{}, 1),
+		writes:            make(chan *cltypes.DataColumnSidecar, 1),
+	}
+	d := &peerdas{
+		rpc:           rpcClient,
+		beaconConfig:  &cfg,
+		state:         peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{}),
+		columnStorage: storage,
+	}
+	req := &downloadRequest{
+		beaconConfig: &cfg,
+		downloadTable: map[downloadTableEntry]map[uint64]bool{
+			{blockRoot: root, slot: block.GetSlot()}: {0: true, 1: true},
+		},
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() { defer close(done); d.runDownload(ctx, req, false) }()
+
+	select {
+	case <-sentinel.banned:
+	case <-storage.lookups:
+		cancel()
+		<-done
+		t.Fatal("column excluded from the wire request reached storage lookup")
+	case <-time.After(30 * time.Second):
+		cancel()
+		<-done
+		t.Fatal("column excluded from the wire request was neither rejected nor stored")
+	}
+	cancel()
+	<-done
+	require.Equal(t, 1, req.remainingEntriesCount())
+}
+
+func TestRunDownloadRejectsValidUnrequestedFuluIdentityBeforeStorage(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.AltairForkEpoch = 0
+	cfg.BellatrixForkEpoch = 0
+	cfg.CapellaForkEpoch = 0
+	cfg.DenebForkEpoch = 0
+	cfg.ElectraForkEpoch = 0
+	cfg.FuluForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	blockA, rootA, _, _ := recoverableFuluDataAtSlot(t, &cfg, 100)
+	_, rootB, _, columnsB := recoverableFuluDataAtSlot(t, &cfg, 101)
+	rpcClient, sentinel := newColumnResponseRPC(t, &cfg, blockA.GetSlot(), []*cltypes.DataColumnSidecar{columnsB[1]})
+
+	baseStorage := blob_storage.NewDataColumnStore(afero.NewMemMapFs(), &cfg, beaconevents.NewEventEmitter())
+	storage := &writeObservingColumnStorage{
+		DataColumnStorage: baseStorage,
+		lookups:           make(chan struct{}, 1),
+		writes:            make(chan *cltypes.DataColumnSidecar, 1),
+	}
+	d := &peerdas{
+		rpc:           rpcClient,
+		beaconConfig:  &cfg,
+		state:         peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{}),
+		columnStorage: storage,
+	}
+	req := &downloadRequest{
+		beaconConfig: &cfg,
+		downloadTable: map[downloadTableEntry]map[uint64]bool{
+			{blockRoot: rootA, slot: blockA.GetSlot()}: {0: true},
+		},
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() { defer close(done); d.runDownload(ctx, req, false) }()
+
+	select {
+	case <-sentinel.banned:
+	case <-storage.lookups:
+		cancel()
+		<-done
+		t.Fatalf("unrequested root %x reached storage lookup", rootB)
+	case <-time.After(30 * time.Second):
+		cancel()
+		<-done
+		t.Fatal("unrequested sidecar was neither rejected nor stored")
+	}
+	cancel()
+	<-done
+	require.Equal(t, 1, req.remainingEntriesCount(), "intended root was removed by an unrelated response")
+}
+
+func TestRunDownloadRejectsOverCardinalityBeforeStorage(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.AltairForkEpoch = 0
+	cfg.BellatrixForkEpoch = 0
+	cfg.CapellaForkEpoch = 0
+	cfg.DenebForkEpoch = 0
+	cfg.ElectraForkEpoch = 0
+	cfg.FuluForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	block, root, _, columns := recoverableFuluDataAtSlot(t, &cfg, 100)
+	rpcClient, sentinel := newColumnResponseRPC(t, &cfg, block.GetSlot(), []*cltypes.DataColumnSidecar{columns[0], columns[0]})
+
+	baseStorage := blob_storage.NewDataColumnStore(afero.NewMemMapFs(), &cfg, beaconevents.NewEventEmitter())
+	storage := &writeObservingColumnStorage{
+		DataColumnStorage: baseStorage,
+		lookups:           make(chan struct{}, 1),
+		writes:            make(chan *cltypes.DataColumnSidecar, 1),
+	}
+	d := &peerdas{
+		rpc:           rpcClient,
+		beaconConfig:  &cfg,
+		state:         peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{}),
+		columnStorage: storage,
+	}
+	req := &downloadRequest{
+		beaconConfig: &cfg,
+		downloadTable: map[downloadTableEntry]map[uint64]bool{
+			{blockRoot: root, slot: block.GetSlot()}: {0: true},
+		},
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() { defer close(done); d.runDownload(ctx, req, false) }()
+
+	select {
+	case <-sentinel.banned:
+	case <-storage.lookups:
+		cancel()
+		<-done
+		t.Fatal("over-cardinality response reached storage lookup")
+	case <-time.After(30 * time.Second):
+		cancel()
+		<-done
+		t.Fatal("over-cardinality response was neither rejected nor stored")
+	}
+	cancel()
+	<-done
+	require.Equal(t, 1, req.remainingEntriesCount())
+}
+
+func TestRunDownloadRejectsDuplicateRequestedTupleBeforeStorage(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.AltairForkEpoch = 0
+	cfg.BellatrixForkEpoch = 0
+	cfg.CapellaForkEpoch = 0
+	cfg.DenebForkEpoch = 0
+	cfg.ElectraForkEpoch = 0
+	cfg.FuluForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	block, root, _, columns := recoverableFuluDataAtSlot(t, &cfg, 100)
+	rpcClient, sentinel := newColumnResponseRPC(t, &cfg, block.GetSlot(), []*cltypes.DataColumnSidecar{columns[0], columns[0]})
+
+	baseStorage := blob_storage.NewDataColumnStore(afero.NewMemMapFs(), &cfg, beaconevents.NewEventEmitter())
+	storage := &writeObservingColumnStorage{
+		DataColumnStorage: baseStorage,
+		lookups:           make(chan struct{}, 1),
+		writes:            make(chan *cltypes.DataColumnSidecar, 1),
+	}
+	d := &peerdas{
+		rpc:           rpcClient,
+		beaconConfig:  &cfg,
+		state:         peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{}),
+		columnStorage: storage,
+	}
+	req := &downloadRequest{
+		beaconConfig: &cfg,
+		downloadTable: map[downloadTableEntry]map[uint64]bool{
+			{blockRoot: root, slot: block.GetSlot()}: {0: true, 1: true},
+		},
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() { defer close(done); d.runDownload(ctx, req, false) }()
+
+	select {
+	case <-sentinel.banned:
+	case <-storage.lookups:
+		cancel()
+		<-done
+		t.Fatal("duplicate requested tuple reached storage lookup")
+	case <-time.After(30 * time.Second):
+		cancel()
+		<-done
+		t.Fatal("duplicate response tuple was neither rejected nor processed")
+	}
+	cancel()
+	<-done
+	require.Equal(t, 1, req.remainingEntriesCount())
+}
+
+func TestRunDownloadAcceptsPartialReorderedRequestedSubset(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.AltairForkEpoch = 0
+	cfg.BellatrixForkEpoch = 0
+	cfg.CapellaForkEpoch = 0
+	cfg.DenebForkEpoch = 0
+	cfg.ElectraForkEpoch = 0
+	cfg.FuluForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	block, root, _, columns := recoverableFuluDataAtSlot(t, &cfg, 100)
+	metadata, err := newBlobRecoveryMetadata(&blockHashCountingBlock{ColumnSyncableSignedBlock: block}, root)
+	require.NoError(t, err)
+	require.False(t, metadata.hasSignature)
+	rpcClient, sentinel := newColumnResponseRPC(t, &cfg, block.GetSlot(), []*cltypes.DataColumnSidecar{columns[2], columns[0]}, nil)
+
+	baseStorage := blob_storage.NewDataColumnStore(afero.NewMemMapFs(), &cfg, beaconevents.NewEventEmitter())
+	storage := &writeObservingColumnStorage{
+		DataColumnStorage: baseStorage,
+		lookups:           make(chan struct{}, 8),
+		writes:            make(chan *cltypes.DataColumnSidecar, 2),
+	}
+	d := &peerdas{
+		rpc:           rpcClient,
+		beaconConfig:  &cfg,
+		state:         peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{}),
+		columnStorage: storage,
+	}
+	req := &downloadRequest{
+		beaconConfig: &cfg,
+		downloadTable: map[downloadTableEntry]map[uint64]bool{
+			{blockRoot: root, slot: block.GetSlot()}: {0: true, 1: true, 2: true},
+		},
+		recoveryDetails: map[common.Hash]*blobRecoveryMetadata{root: metadata},
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() { defer close(done); d.runDownload(ctx, req, false) }()
+
+	written := map[uint64]bool{}
+	for len(written) < 2 {
+		select {
+		case sidecar := <-storage.writes:
+			written[sidecar.Index] = true
+		case <-sentinel.banned:
+			cancel()
+			<-done
+			t.Fatal("legal partial reordered response was banned")
+		case <-time.After(30 * time.Second):
+			cancel()
+			<-done
+			t.Fatal("legal partial reordered response did not reach storage")
+		}
+	}
+	cancel()
+	<-done
+	require.Equal(t, map[uint64]bool{0: true, 2: true}, written)
+	_, remaining := req.requestData()
+	require.Equal(t, map[requestedDataColumn]struct{}{
+		{slot: block.GetSlot(), blockRoot: root, index: 1}: {},
+	}, remaining)
+}
+
+func TestRunDownloadAcceptsLateSnapshotMemberAfterConcurrentCompletion(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.AltairForkEpoch = 0
+	cfg.BellatrixForkEpoch = 0
+	cfg.CapellaForkEpoch = 0
+	cfg.DenebForkEpoch = 0
+	cfg.ElectraForkEpoch = 0
+	cfg.FuluForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	block, root, _, columns := recoverableFuluDataAtSlot(t, &cfg, 100)
+	rpcClient, sentinel := newColumnResponseRPC(t, &cfg, block.GetSlot(), []*cltypes.DataColumnSidecar{columns[0]})
+	sentinel.columnRequested = make(chan struct{})
+	sentinel.releaseColumn = make(chan struct{})
+
+	baseStorage := blob_storage.NewDataColumnStore(afero.NewMemMapFs(), &cfg, beaconevents.NewEventEmitter())
+	storage := &writeObservingColumnStorage{
+		DataColumnStorage: baseStorage,
+		lookups:           make(chan struct{}, 1),
+		writes:            make(chan *cltypes.DataColumnSidecar, 1),
+	}
+	d := &peerdas{
+		rpc:           rpcClient,
+		beaconConfig:  &cfg,
+		state:         peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{}),
+		columnStorage: storage,
+	}
+	req := &downloadRequest{
+		beaconConfig: &cfg,
+		downloadTable: map[downloadTableEntry]map[uint64]bool{
+			{blockRoot: root, slot: block.GetSlot()}: {0: true},
+		},
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { defer close(done); d.runDownload(ctx, req, false) }()
+
+	select {
+	case <-sentinel.columnRequested:
+	case <-time.After(30 * time.Second):
+		t.Fatal("column request did not reach the selected peer")
+	}
+	require.NoError(t, baseStorage.WriteColumnSidecars(t.Context(), root, 0, columns[0]))
+	req.removeColumn(block.GetSlot(), root, 0)
+	close(sentinel.releaseColumn)
+
+	select {
+	case <-storage.lookups:
+	case <-sentinel.banned:
+		t.Fatal("late response member was checked against mutable current membership")
+	case <-time.After(30 * time.Second):
+		t.Fatal("late response was not processed")
+	}
+	select {
+	case <-done:
+	case <-sentinel.banned:
+		t.Fatal("late response member was falsely banned")
+	case <-time.After(30 * time.Second):
+		t.Fatal("runDownload did not finish after concurrent completion")
+	}
+}
+
+func TestRunDownloadDoesNotRevalidateBlobStorageWhileWaitingForColumns(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.FuluForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	block := cltypes.NewSignedBeaconBlock(&cfg, clparams.FuluVersion)
+	block.Block.Slot = 100
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	root, err := block.Block.HashSSZ()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	ctrl := gomock.NewController(t)
+	columnStorage := blob_storage_mock_services.NewMockDataColumnStorage(ctrl)
+	var halfChecks atomic.Int32
+	columnStorage.EXPECT().GetSavedColumnIndex(gomock.Any(), block.Block.Slot, root).DoAndReturn(
+		func(context.Context, uint64, common.Hash) ([]uint64, error) {
+			if halfChecks.Add(1) == 2 {
+				cancel()
+			}
+			return nil, nil
+		},
+	).AnyTimes()
+	blobStorage := blob_storage_mock_services.NewMockBlobStorage(ctrl)
+	var durableReads atomic.Int32
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), root).Return(uint32(1), nil).AnyTimes()
+	blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), block.Block.Slot, root).DoAndReturn(
+		func(context.Context, uint64, common.Hash) ([]*cltypes.BlobSidecar, bool, error) {
+			durableReads.Add(1)
+			return nil, false, nil
+		},
+	).AnyTimes()
+
+	d := &peerdas{
+		beaconConfig:  &cfg,
+		columnStorage: columnStorage,
+		blobStorage:   blobStorage,
+	}
+	metadata, err := newBlobRecoveryMetadata(block, root)
+	require.NoError(t, err)
+	req := &downloadRequest{
+		beaconConfig: &cfg,
+		downloadTable: map[downloadTableEntry]map[uint64]bool{
+			{blockRoot: root, slot: block.Block.Slot}: {},
+		},
+		recoveryDetails:    map[common.Hash]*blobRecoveryMetadata{root: metadata},
+		validatedBlobCount: map[common.Hash]uint32{root: 1},
+	}
+
+	done := make(chan struct{})
+	go func() { defer close(done); d.runDownload(ctx, req, true) }()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("download did not stop after its context was canceled")
+	}
+	require.Zero(t, durableReads.Load(), "storage validation must be event-driven, not ticker-driven")
+}
+
+func TestRunDownloadValidatesBlobStorageAfterCountChanges(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.FuluForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	block, root, sidecars, _ := recoverableFuluData(t, &cfg)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	ctrl := gomock.NewController(t)
+	columnStorage := blob_storage_mock_services.NewMockDataColumnStorage(ctrl)
+	var halfChecks atomic.Int32
+	columnStorage.EXPECT().GetSavedColumnIndex(gomock.Any(), block.Block.Slot, root).DoAndReturn(
+		func(context.Context, uint64, common.Hash) ([]uint64, error) {
+			if halfChecks.Add(1) == 2 {
+				cancel()
+			}
+			return nil, nil
+		},
+	).AnyTimes()
+	blobStorage := blob_storage_mock_services.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), root).Return(uint32(len(sidecars)), nil).AnyTimes()
+	var durableReads atomic.Int32
+	blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), block.Block.Slot, root).DoAndReturn(
+		func(context.Context, uint64, common.Hash) ([]*cltypes.BlobSidecar, bool, error) {
+			durableReads.Add(1)
+			return sidecars, true, nil
+		},
+	).AnyTimes()
+	metadata, err := newBlobRecoveryMetadata(block, root)
+	require.NoError(t, err)
+	d := &peerdas{beaconConfig: &cfg, columnStorage: columnStorage, blobStorage: blobStorage}
+	req := &downloadRequest{
+		beaconConfig: &cfg,
+		downloadTable: map[downloadTableEntry]map[uint64]bool{
+			{blockRoot: root, slot: block.Block.Slot}: {},
+		},
+		recoveryDetails:    map[common.Hash]*blobRecoveryMetadata{root: metadata},
+		validatedBlobCount: map[common.Hash]uint32{root: 1},
+	}
+
+	d.runDownload(ctx, req, true)
+	require.Equal(t, int32(1), durableReads.Load(), "a changed durable count must trigger one validation event")
+}
+
+func TestRunDownloadRetriesTransientBlobReadAtUnchangedCount(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.FuluForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	block, root, sidecars, _ := recoverableFuluData(t, &cfg)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	ctrl := gomock.NewController(t)
+	columnStorage := blob_storage_mock_services.NewMockDataColumnStorage(ctrl)
+	var halfChecks atomic.Int32
+	columnStorage.EXPECT().GetSavedColumnIndex(gomock.Any(), block.Block.Slot, root).DoAndReturn(
+		func(context.Context, uint64, common.Hash) ([]uint64, error) {
+			if halfChecks.Add(1) == 3 {
+				cancel()
+			}
+			return nil, nil
+		},
+	).AnyTimes()
+	blobStorage := blob_storage_mock_services.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), root).Return(uint32(len(sidecars)), nil).AnyTimes()
+	var durableReads atomic.Int32
+	blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), block.Block.Slot, root).DoAndReturn(
+		func(context.Context, uint64, common.Hash) ([]*cltypes.BlobSidecar, bool, error) {
+			if durableReads.Add(1) == 1 {
+				return nil, false, errors.New("transient read failure")
+			}
+			return sidecars, true, nil
+		},
+	).AnyTimes()
+	metadata, err := newBlobRecoveryMetadata(block, root)
+	require.NoError(t, err)
+	d := &peerdas{beaconConfig: &cfg, columnStorage: columnStorage, blobStorage: blobStorage}
+	req := &downloadRequest{
+		beaconConfig: &cfg,
+		downloadTable: map[downloadTableEntry]map[uint64]bool{
+			{blockRoot: root, slot: block.Block.Slot}: {},
+		},
+		recoveryDetails:    map[common.Hash]*blobRecoveryMetadata{root: metadata},
+		validatedBlobCount: map[common.Hash]uint32{root: 1},
+	}
+
+	d.runDownload(ctx, req, true)
+	require.Equal(t, int32(2), durableReads.Load(), "transient validation failure must retry without a count mutation")
+	require.NoError(t, ctx.Err(), "valid storage must finish the request before lifecycle cancellation")
+}
+
+func TestRunDownloadPacesPermanentBlobReadErrorsUntilCancellation(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.FuluForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	block := cltypes.NewSignedBeaconBlock(&cfg, clparams.FuluVersion)
+	block.Block.Slot = 100
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	root, err := block.Block.HashSSZ()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	ctrl := gomock.NewController(t)
+	columnStorage := blob_storage_mock_services.NewMockDataColumnStorage(ctrl)
+	columnStorage.EXPECT().GetSavedColumnIndex(gomock.Any(), block.Block.Slot, root).Return(nil, nil).AnyTimes()
+	blobStorage := blob_storage_mock_services.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), root).Return(uint32(1), nil).AnyTimes()
+	var durableReads atomic.Int32
+	blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), block.Block.Slot, root).DoAndReturn(
+		func(context.Context, uint64, common.Hash) ([]*cltypes.BlobSidecar, bool, error) {
+			if durableReads.Add(1) == 2 {
+				cancel()
+			}
+			return nil, false, errors.New("permanent read failure")
+		},
+	).AnyTimes()
+	metadata, err := newBlobRecoveryMetadata(block, root)
+	require.NoError(t, err)
+	d := &peerdas{beaconConfig: &cfg, columnStorage: columnStorage, blobStorage: blobStorage}
+	req := &downloadRequest{
+		beaconConfig: &cfg,
+		downloadTable: map[downloadTableEntry]map[uint64]bool{
+			{blockRoot: root, slot: block.Block.Slot}: {},
+		},
+		recoveryDetails:    map[common.Hash]*blobRecoveryMetadata{root: metadata},
+		validatedBlobCount: map[common.Hash]uint32{root: 0},
+	}
+
+	done := make(chan struct{})
+	go func() { defer close(done); d.runDownload(ctx, req, true) }()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("permanent read errors were not paced by the download lifecycle")
+	}
+	require.Equal(t, int32(2), durableReads.Load())
+	require.ErrorIs(t, ctx.Err(), context.Canceled)
+}
+
+func TestRunDownloadDoesNotRepeatConclusiveInvalidBlobValidation(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.FuluForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	block := cltypes.NewSignedBeaconBlock(&cfg, clparams.FuluVersion)
+	block.Block.Slot = 100
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	root, err := block.Block.HashSSZ()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	ctrl := gomock.NewController(t)
+	columnStorage := blob_storage_mock_services.NewMockDataColumnStorage(ctrl)
+	var halfChecks atomic.Int32
+	columnStorage.EXPECT().GetSavedColumnIndex(gomock.Any(), block.Block.Slot, root).DoAndReturn(
+		func(context.Context, uint64, common.Hash) ([]uint64, error) {
+			if halfChecks.Add(1) == 2 {
+				cancel()
+			}
+			return nil, nil
+		},
+	).AnyTimes()
+	blobStorage := blob_storage_mock_services.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), root).Return(uint32(1), nil).AnyTimes()
+	var durableReads atomic.Int32
+	blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), block.Block.Slot, root).DoAndReturn(
+		func(context.Context, uint64, common.Hash) ([]*cltypes.BlobSidecar, bool, error) {
+			durableReads.Add(1)
+			return []*cltypes.BlobSidecar{nil}, true, nil
+		},
+	).AnyTimes()
+	metadata, err := newBlobRecoveryMetadata(block, root)
+	require.NoError(t, err)
+	d := &peerdas{beaconConfig: &cfg, columnStorage: columnStorage, blobStorage: blobStorage}
+	req := &downloadRequest{
+		beaconConfig: &cfg,
+		downloadTable: map[downloadTableEntry]map[uint64]bool{
+			{blockRoot: root, slot: block.Block.Slot}: {},
+		},
+		recoveryDetails:    map[common.Hash]*blobRecoveryMetadata{root: metadata},
+		validatedBlobCount: map[common.Hash]uint32{root: 0},
+	}
+
+	d.runDownload(ctx, req, true)
+	require.Equal(t, int32(1), durableReads.Load(), "conclusively invalid storage must stay cached until its count changes")
 }
 
 // A peer selects the response fork digest, so it can serve a Gloas-schema
@@ -136,7 +1182,7 @@ func TestRunDownloadRejectsGloasSidecarWithPreGloasSlot(t *testing.T) {
 		rpc:            rpcClient,
 		beaconConfig:   &cfg,
 		state:          peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{}),
-		columnStorage:  blob_storage.NewDataColumnStore(afero.NewMemMapFs(), 0, &cfg, clock, beaconevents.NewEventEmitter()),
+		columnStorage:  blob_storage.NewDataColumnStore(afero.NewMemMapFs(), &cfg, beaconevents.NewEventEmitter()),
 		gloasDataCache: gloasDataCache,
 	}
 	req := &downloadRequest{
@@ -146,8 +1192,11 @@ func TestRunDownloadRejectsGloasSidecarWithPreGloasSlot(t *testing.T) {
 		},
 	}
 
-	done := make(chan error, 1)
-	go func() { done <- d.runDownload(ctx, req, false) }()
+	done := make(chan struct{})
+	go func() {
+		d.runDownload(ctx, req, false)
+		close(done)
+	}()
 
 	select {
 	case <-sentinel.banned:

--- a/cl/das/peer_das_start_test.go
+++ b/cl/das/peer_das_start_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package das
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	peerdasstate "github.com/erigontech/erigon/cl/das/state"
+	gossipmock "github.com/erigontech/erigon/cl/phase1/network/gossip/mock_services"
+)
+
+func TestPeerDasSubscribesOnlyAfterStart(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	gossipManager := gossipmock.NewMockGossip(ctrl)
+	beaconConfig := clparams.MainnetBeaconConfig
+	beaconConfig.DataColumnSidecarSubnetCount = 2
+	caplinConfig := clparams.CaplinConfig{ArchiveBlobs: true}
+	peerDasState := peerdasstate.NewPeerDasState(&beaconConfig, &clparams.NetworkConfig{})
+
+	peerDas := NewPeerDas(nil, &beaconConfig, &caplinConfig, nil, nil, nil, [32]byte{}, nil, peerDasState, gossipManager, nil, nil)
+
+	gossipManager.EXPECT().SubscribeWithExpiry(gomock.Any(), gomock.Any()).Times(2)
+	ctx, cancel := context.WithCancel(context.Background())
+	peerDas.Start(ctx)
+	peerDas.Start(ctx)
+	cancel()
+}

--- a/cl/das/peer_das_test.go
+++ b/cl/das/peer_das_test.go
@@ -17,16 +17,38 @@
 package das
 
 import (
+	"container/heap"
+	"context"
 	"errors"
 	"fmt"
+	"os"
+	"reflect"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	goethkzg "github.com/crate-crypto/go-eth-kzg"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
+	"github.com/erigontech/erigon/cl/beacon/beaconevents"
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	peerdasstate "github.com/erigontech/erigon/cl/das/state"
+	peerdasutils "github.com/erigontech/erigon/cl/das/utils"
+	"github.com/erigontech/erigon/cl/persistence/blob_storage"
+	blob_storage_mock_services "github.com/erigontech/erigon/cl/persistence/blob_storage/mock_services"
+	"github.com/erigontech/erigon/cl/phase1/core/state/lru"
 	"github.com/erigontech/erigon/cl/sentinel/httpreqresp"
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/crypto"
+	"github.com/erigontech/erigon/common/crypto/kzg"
+	"github.com/erigontech/erigon/db/kv/dbcfg"
+	mdbxtest "github.com/erigontech/erigon/db/kv/memdb"
+	"github.com/erigontech/erigon/p2p/enode"
 )
 
 // initTestBeaconConfig installs cfg as the global config if no test has done so
@@ -37,6 +59,1971 @@ func initTestBeaconConfig(cfg *clparams.BeaconChainConfig) {
 	if clparams.GetBeaconConfig() == nil {
 		clparams.InitGlobalStaticConfig(cfg, &clparams.CaplinConfig{})
 	}
+}
+
+type writeNotifyingBlobStorage struct {
+	blob_storage.BlobStorage
+	written chan struct{}
+	once    sync.Once
+}
+
+type transientBlobWriteStorage struct {
+	blob_storage.BlobStorage
+	calls     atomic.Int32
+	succeeded chan struct{}
+	once      sync.Once
+}
+
+func (s *transientBlobWriteStorage) WriteBlobSidecars(ctx context.Context, root common.Hash, sidecars []*cltypes.BlobSidecar) error {
+	if s.calls.Add(1) == 1 {
+		return errors.New("transient blob write failure")
+	}
+	if err := s.BlobStorage.WriteBlobSidecars(ctx, root, sidecars); err != nil {
+		return err
+	}
+	s.once.Do(func() { close(s.succeeded) })
+	return nil
+}
+
+type unavailableRootsBlobStorage struct {
+	blob_storage.BlobStorage
+	roots    map[common.Hash]struct{}
+	attempts atomic.Int32
+	started  chan struct{}
+	once     sync.Once
+}
+
+func (s *unavailableRootsBlobStorage) KzgCommitmentsCount(ctx context.Context, blockRoot common.Hash) (uint32, error) {
+	if _, unavailable := s.roots[blockRoot]; unavailable {
+		s.attempts.Add(1)
+		s.once.Do(func() { close(s.started) })
+		return 0, errors.New("blob storage unavailable")
+	}
+	return s.BlobStorage.KzgCommitmentsCount(ctx, blockRoot)
+}
+
+type savedColumnReadCountingStorage struct {
+	blob_storage.DataColumnStorage
+	reads atomic.Int32
+}
+
+type transientSavedColumnIndexStorage struct {
+	blob_storage.DataColumnStorage
+	calls  atomic.Int32
+	failAt int32
+	failed chan struct{}
+	onFail func()
+	once   sync.Once
+}
+
+type transientColumnSidecarReadStorage struct {
+	blob_storage.DataColumnStorage
+	columnIndex   int64
+	readErr       error
+	targetReads   atomic.Int32
+	targetRemoves atomic.Int32
+	onFail        func()
+	failed        chan struct{}
+	once          sync.Once
+}
+
+type blockingBlobWriteStorage struct {
+	blob_storage.BlobStorage
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (s *blockingBlobWriteStorage) WriteBlobSidecars(ctx context.Context, blockRoot common.Hash, sidecars []*cltypes.BlobSidecar) error {
+	s.once.Do(func() { close(s.entered) })
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-s.release:
+		return s.BlobStorage.WriteBlobSidecars(ctx, blockRoot, sidecars)
+	}
+}
+
+type postPruneColumnWriteStorage struct {
+	blob_storage.DataColumnStorage
+	pruned atomic.Bool
+	writes atomic.Int32
+	want   int32
+	done   chan struct{}
+	once   sync.Once
+}
+
+func (s *postPruneColumnWriteStorage) WriteColumnSidecars(ctx context.Context, blockRoot common.Hash, columnIndex int64, sidecar *cltypes.DataColumnSidecar) error {
+	err := s.DataColumnStorage.WriteColumnSidecars(ctx, blockRoot, columnIndex, sidecar)
+	if s.pruned.Load() && s.writes.Add(1) == s.want {
+		s.once.Do(func() { close(s.done) })
+	}
+	return err
+}
+
+func (s *savedColumnReadCountingStorage) GetSavedColumnIndex(ctx context.Context, slot uint64, blockRoot common.Hash) ([]uint64, error) {
+	s.reads.Add(1)
+	return s.DataColumnStorage.GetSavedColumnIndex(ctx, slot, blockRoot)
+}
+
+func (s *transientSavedColumnIndexStorage) GetSavedColumnIndex(ctx context.Context, slot uint64, blockRoot common.Hash) ([]uint64, error) {
+	if s.calls.Add(1) == s.failAt {
+		if s.onFail != nil {
+			s.onFail()
+		}
+		s.once.Do(func() { close(s.failed) })
+		return nil, errors.New("transient saved-column read failure")
+	}
+	return s.DataColumnStorage.GetSavedColumnIndex(ctx, slot, blockRoot)
+}
+
+func (s *transientColumnSidecarReadStorage) ReadColumnSidecarByColumnIndex(ctx context.Context, slot uint64, blockRoot common.Hash, columnIndex int64) (*cltypes.DataColumnSidecar, error) {
+	if columnIndex == s.columnIndex && s.targetReads.Add(1) == 1 {
+		if s.onFail != nil {
+			s.onFail()
+		}
+		s.once.Do(func() { close(s.failed) })
+		return nil, s.readErr
+	}
+	return s.DataColumnStorage.ReadColumnSidecarByColumnIndex(ctx, slot, blockRoot, columnIndex)
+}
+
+func (s *transientColumnSidecarReadStorage) RemoveColumnSidecars(ctx context.Context, slot uint64, blockRoot common.Hash, columnIndices ...int64) error {
+	for _, columnIndex := range columnIndices {
+		if columnIndex == s.columnIndex {
+			s.targetRemoves.Add(1)
+		}
+	}
+	return s.DataColumnStorage.RemoveColumnSidecars(ctx, slot, blockRoot, columnIndices...)
+}
+
+type blockHashCountingBlock struct {
+	cltypes.ColumnSyncableSignedBlock
+	calls atomic.Int32
+}
+
+func (b *blockHashCountingBlock) BlockHashSSZ() ([32]byte, error) {
+	b.calls.Add(1)
+	return b.ColumnSyncableSignedBlock.BlockHashSSZ()
+}
+
+func (s *writeNotifyingBlobStorage) WriteBlobSidecars(ctx context.Context, blockRoot common.Hash, sidecars []*cltypes.BlobSidecar) error {
+	if err := s.BlobStorage.WriteBlobSidecars(ctx, blockRoot, sidecars); err != nil {
+		return err
+	}
+	s.once.Do(func() { close(s.written) })
+	return nil
+}
+
+func recoverableFuluData(t *testing.T, cfg *clparams.BeaconChainConfig) (*cltypes.SignedBeaconBlock, common.Hash, []*cltypes.BlobSidecar, []*cltypes.DataColumnSidecar) {
+	return recoverableFuluDataAtSlot(t, cfg, 100)
+}
+
+func recoverableFuluDataAtSlot(t *testing.T, cfg *clparams.BeaconChainConfig, slot uint64) (*cltypes.SignedBeaconBlock, common.Hash, []*cltypes.BlobSidecar, []*cltypes.DataColumnSidecar) {
+	return recoverableFuluDataAtSlotWithExecutionBlockHash(t, cfg, slot, common.Hash{})
+}
+
+func recoverableFuluDataAtSlotWithExecutionBlockHash(t *testing.T, cfg *clparams.BeaconChainConfig, slot uint64, executionBlockHash common.Hash) (*cltypes.SignedBeaconBlock, common.Hash, []*cltypes.BlobSidecar, []*cltypes.DataColumnSidecar) {
+	t.Helper()
+	block := cltypes.NewSignedBeaconBlock(cfg, clparams.FuluVersion)
+	block.Block.Slot = slot
+	block.Block.Body.ExecutionPayload.BlockHash = executionBlockHash
+	blobs := []goethkzg.Blob{{1}, {2}}
+	commitments := make([]goethkzg.KZGCommitment, len(blobs))
+	cellsAndProofs := make([]peerdasutils.CellsAndKZGProofs, len(blobs))
+	for i := range blobs {
+		commitment, err := kzg.Ctx().BlobToKZGCommitment(&blobs[i], 0)
+		require.NoError(t, err)
+		commitments[i] = commitment
+		block.GetBlobKzgCommitments().Append((*cltypes.KZGCommitment)(&commitment))
+		cells, proofs, err := peerdasutils.ComputeCellsAndKZGProofs(blobs[i][:])
+		require.NoError(t, err)
+		cellsAndProofs[i] = peerdasutils.CellsAndKZGProofs{Blobs: cells, Proofs: proofs}
+	}
+	root, err := block.Block.HashSSZ()
+	require.NoError(t, err)
+	proofRaw, err := block.Block.Body.KzgCommitmentsInclusionProof()
+	require.NoError(t, err)
+	columnProof := solid.NewHashVector(cltypes.CommitmentBranchSize)
+	for i := range proofRaw {
+		columnProof.Set(i, proofRaw[i])
+	}
+	columns, err := peerdasutils.GetDataColumnSidecars(block.SignedBeaconBlockHeader(), block.GetBlobKzgCommitments(), columnProof, cellsAndProofs)
+	require.NoError(t, err)
+
+	sidecars := make([]*cltypes.BlobSidecar, len(blobs))
+	for i := range blobs {
+		proof, err := kzg.Ctx().ComputeBlobKZGProof(&blobs[i], commitments[i], 0)
+		require.NoError(t, err)
+		branch, err := block.Block.Body.KzgCommitmentMerkleProof(i)
+		require.NoError(t, err)
+		inclusionProof := solid.NewHashVector(cltypes.CommitmentBranchSize)
+		for j := range branch {
+			inclusionProof.Set(j, common.Hash(branch[j]))
+		}
+		sidecars[i] = cltypes.NewBlobSidecar(uint64(i), (*cltypes.Blob)(&blobs[i]), common.Bytes48(commitments[i]), common.Bytes48(proof), block.SignedBeaconBlockHeader(), inclusionProof)
+	}
+	return block, root, sidecars, columns
+}
+
+func recoverableGloasColumns(t *testing.T, cfg *clparams.BeaconChainConfig, slot uint64) (*cltypes.SignedBeaconBlock, common.Hash, []*cltypes.DataColumnSidecar) {
+	t.Helper()
+	block := cltypes.NewSignedBeaconBlock(cfg, clparams.GloasVersion)
+	block.Block.Slot = slot
+	blobs := []goethkzg.Blob{{1}, {2}}
+	cellsAndProofs := make([]peerdasutils.CellsAndKZGProofs, len(blobs))
+	for i := range blobs {
+		commitment, err := kzg.Ctx().BlobToKZGCommitment(&blobs[i], 0)
+		require.NoError(t, err)
+		block.GetBlobKzgCommitments().Append((*cltypes.KZGCommitment)(&commitment))
+		cells, proofs, err := peerdasutils.ComputeCellsAndKZGProofs(blobs[i][:])
+		require.NoError(t, err)
+		cellsAndProofs[i] = peerdasutils.CellsAndKZGProofs{Blobs: cells, Proofs: proofs}
+	}
+	root, err := block.Block.HashSSZ()
+	require.NoError(t, err)
+	columns, err := peerdasutils.GetDataColumnSidecarsGloas(slot, root, cellsAndProofs)
+	require.NoError(t, err)
+	return block, root, columns
+}
+
+func TestPeerDasPruneBelowUpdatesEarliestAvailableSlot(t *testing.T) {
+	tests := []struct {
+		name           string
+		initial, floor uint64
+		pruneErr       error
+		want           uint64
+	}{
+		{name: "advances", initial: 0, floor: 100, want: 100},
+		{name: "does not move backwards", initial: 100, floor: 50, want: 100},
+		{name: "zero floor resets", initial: 100, floor: 0, want: 0},
+		{name: "advances after prune error", initial: 100, floor: 200, pruneErr: errors.New("prune failed"), want: 200},
+		{name: "does not advance when prune did not start", initial: 100, floor: 200, pruneErr: fmt.Errorf("readdir: %w", blob_storage.ErrPruneNotStarted), want: 100},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			columnStorage := blob_storage_mock_services.NewMockDataColumnStorage(ctrl)
+			columnStorage.EXPECT().PruneBelow(test.floor).Return(test.pruneErr)
+			cfg := clparams.MainnetBeaconConfig
+			state := peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{})
+			state.SetEarliestAvailableSlot(test.initial)
+			d := &peerdas{state: state, columnStorage: columnStorage}
+
+			err := d.PruneBelow(test.floor)
+			require.ErrorIs(t, err, test.pruneErr)
+			require.Equal(t, test.want, state.GetEarliestAvailableSlot())
+		})
+	}
+}
+
+func TestPeerDasPruneBelowUpdatesRecoveryOwnership(t *testing.T) {
+	pruneErr := errors.New("partial prune")
+	for _, test := range []struct {
+		name      string
+		err       error
+		wantPrune bool
+	}{
+		{name: "success", wantPrune: true},
+		{name: "partial", err: pruneErr, wantPrune: true},
+		{name: "not started", err: blob_storage.ErrPruneNotStarted},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			columnStorage := blob_storage_mock_services.NewMockDataColumnStorage(ctrl)
+			columnStorage.EXPECT().PruneBelow(uint64(10)).Return(test.err)
+			cfg := clparams.MainnetBeaconConfig
+			state := peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{})
+			d := &peerdas{state: state, columnStorage: columnStorage, recoverBlobsQueue: make(chan recoverBlobsRequest, 8)}
+			below := recoverBlobsRequest{slot: 9, blockRoot: common.Hash{9}}
+			at := recoverBlobsRequest{slot: 10, blockRoot: common.Hash{10}}
+			above := recoverBlobsRequest{slot: 11, blockRoot: common.Hash{11}}
+			require.True(t, d.delayBlobRecovery(below))
+			require.True(t, d.delayBlobRecovery(at))
+			require.True(t, d.delayBlobRecovery(above))
+			require.True(t, d.cacheBlobRecoveryResult(below.blockRoot, &blobRecoveryResult{encodedBytes: 1}))
+
+			err := d.PruneBelow(10)
+			require.ErrorIs(t, err, test.err)
+			if !test.wantPrune {
+				require.Contains(t, d.recoveryRetries, below.blockRoot)
+				require.Contains(t, d.recoveryResults, below.blockRoot)
+				require.Contains(t, d.recoverySlots, below.slot)
+				require.Equal(t, 1, d.recoveryResultBytes)
+				require.Zero(t, d.recoveryPruneFloor)
+				return
+			}
+			require.NotContains(t, d.recoveryRetries, below.blockRoot)
+			require.NotContains(t, d.isRecovering, below.blockRoot)
+			require.NotContains(t, d.recoveryResults, below.blockRoot)
+			require.NotContains(t, d.recoverySlots, below.slot)
+			require.Zero(t, d.recoveryResultBytes)
+			require.Contains(t, d.recoveryRetries, at.blockRoot)
+			require.Contains(t, d.recoveryRetries, above.blockRoot)
+			require.Len(t, d.recoveryRetryQueue, 2)
+			require.Equal(t, uint64(10), d.recoveryPruneFloor)
+			require.False(t, d.delayBlobRecovery(below))
+			require.NotContains(t, d.isRecovering, below.blockRoot)
+		})
+	}
+}
+
+func TestPeerDasPruneBelowHandlesQueuedAndActiveRecovery(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	columnStorage := blob_storage_mock_services.NewMockDataColumnStorage(ctrl)
+	columnStorage.EXPECT().PruneBelow(uint64(10)).Return(nil)
+	cfg := clparams.MainnetBeaconConfig
+	state := peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{})
+	d := &peerdas{state: state, columnStorage: columnStorage, recoverBlobsQueue: make(chan recoverBlobsRequest, 2)}
+	active := recoverBlobsRequest{slot: 8, blockRoot: common.Hash{8}}
+	queued := recoverBlobsRequest{slot: 9, blockRoot: common.Hash{9}}
+	require.NoError(t, d.enqueueBlobRecovery(active))
+	require.NoError(t, d.enqueueBlobRecovery(queued))
+	activeToken := <-d.recoverBlobsQueue
+	activeToken, generation, ok := d.claimBlobRecovery(activeToken)
+	require.True(t, ok)
+
+	require.NoError(t, d.PruneBelow(10))
+	require.True(t, d.isRecovering[active.blockRoot])
+	require.False(t, d.delayBlobRecovery(activeToken))
+	d.releaseBlobRecovery(active.blockRoot, generation)
+	require.NotContains(t, d.isRecovering, active.blockRoot)
+
+	queuedToken := <-d.recoverBlobsQueue
+	_, _, ok = d.claimBlobRecovery(queuedToken)
+	require.False(t, ok)
+	require.NotContains(t, d.isRecovering, queued.blockRoot)
+}
+
+func TestPeerDasPruneBelowPreventsActiveRecoveryFromRecreatingColumns(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.FuluForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	const slot = uint64(9_999)
+	block, root, _, columns := recoverableFuluDataAtSlot(t, &cfg, slot)
+
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	nodeDB, err := enode.OpenDB("")
+	require.NoError(t, err)
+	t.Cleanup(func() { nodeDB.Close() })
+	state := peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{})
+	state.SetLocalNodeID(enode.NewLocalNode(nodeDB, key))
+	custodyColumns, err := state.GetMyCustodyColumns()
+	require.NoError(t, err)
+	require.NotEmpty(t, custodyColumns)
+
+	columnFS := afero.NewMemMapFs()
+	baseColumnStorage := blob_storage.NewDataColumnStore(columnFS, &cfg, beaconevents.NewEventEmitter())
+	seeded := 0
+	for index, sidecar := range columns {
+		if custodyColumns[uint64(index)] {
+			continue
+		}
+		require.NoError(t, baseColumnStorage.WriteColumnSidecars(t.Context(), root, int64(index), sidecar))
+		seeded++
+		if seeded == int((cfg.NumberOfColumns+1)/2) {
+			break
+		}
+	}
+	require.Equal(t, int((cfg.NumberOfColumns+1)/2), seeded)
+	columnStorage := &postPruneColumnWriteStorage{
+		DataColumnStorage: baseColumnStorage,
+		want:              int32(len(custodyColumns)),
+		done:              make(chan struct{}),
+	}
+
+	db := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
+	blobFS := afero.NewMemMapFs()
+	baseBlobStorage := blob_storage.NewBlobStore(db, blobFS)
+	blobStorage := &blockingBlobWriteStorage{
+		BlobStorage: baseBlobStorage,
+		entered:     make(chan struct{}),
+		release:     make(chan struct{}),
+	}
+	metadata, err := newBlobRecoveryMetadata(block, root)
+	require.NoError(t, err)
+	d := &peerdas{
+		beaconConfig:      &cfg,
+		state:             state,
+		columnStorage:     columnStorage,
+		blobStorage:       blobStorage,
+		recoverBlobsQueue: make(chan recoverBlobsRequest, 1),
+		isRecovering:      make(map[common.Hash]bool),
+	}
+	require.NoError(t, d.enqueueBlobRecovery(recoverBlobsRequest{slot: slot, blockRoot: root, metadata: metadata}))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	workerDone := make(chan struct{})
+	go func() {
+		d.blobsRecoverWorker(ctx)
+		close(workerDone)
+	}()
+	t.Cleanup(func() {
+		select {
+		case <-blobStorage.release:
+		default:
+			close(blobStorage.release)
+		}
+		cancel()
+		<-workerDone
+	})
+	select {
+	case <-blobStorage.entered:
+	case <-time.After(30 * time.Second):
+		t.Fatal("blob recovery did not reach persistence")
+	}
+
+	require.NoError(t, d.PruneBelow(slot+1))
+	columnStorage.pruned.Store(true)
+	close(blobStorage.release)
+	select {
+	case <-columnStorage.done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("blob recovery did not finish its column persistence suffix")
+	}
+
+	freshColumns := blob_storage.NewDataColumnStore(columnFS, &cfg, beaconevents.NewEventEmitter())
+	storedColumns, err := freshColumns.GetSavedColumnIndex(t.Context(), slot, root)
+	require.NoError(t, err)
+	require.Empty(t, storedColumns)
+	blobs, found, err := baseBlobStorage.ReadBlobSidecars(t.Context(), slot, root)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Len(t, blobs, 2)
+}
+
+func TestGloasRecoveryPersistsGeneratedCustodyColumnAtOriginalIdentity(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.AltairForkEpoch = 0
+	cfg.BellatrixForkEpoch = 0
+	cfg.CapellaForkEpoch = 0
+	cfg.DenebForkEpoch = 0
+	cfg.ElectraForkEpoch = 0
+	cfg.FuluForkEpoch = 1
+	cfg.GloasForkEpoch = 2
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	slot := 2 * cfg.SlotsPerEpoch
+	block, root, columns := recoverableGloasColumns(t, &cfg, slot)
+
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	nodeDB, err := enode.OpenDB("")
+	require.NoError(t, err)
+	t.Cleanup(func() { nodeDB.Close() })
+	state := peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{})
+	state.SetLocalNodeID(enode.NewLocalNode(nodeDB, key))
+	custodyColumns, err := state.GetMyCustodyColumns()
+	require.NoError(t, err)
+	require.NotEmpty(t, custodyColumns)
+
+	columnFS := afero.NewMemMapFs()
+	columnStorage := blob_storage.NewDataColumnStore(columnFS, &cfg, beaconevents.NewEventEmitter())
+	seeded := 0
+	for index, sidecar := range columns {
+		if custodyColumns[uint64(index)] {
+			continue
+		}
+		require.NoError(t, columnStorage.WriteColumnSidecars(t.Context(), root, int64(index), sidecar))
+		seeded++
+		if seeded == int((cfg.NumberOfColumns+1)/2) {
+			break
+		}
+	}
+	require.Equal(t, int((cfg.NumberOfColumns+1)/2), seeded)
+
+	db := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
+	blobStorage := blob_storage.NewBlobStore(db, afero.NewMemMapFs())
+	metadata, err := newBlobRecoveryMetadata(block, root)
+	require.NoError(t, err)
+	gloasDataCache, err := lru.New[common.Hash, *gloasBlockData]("testGloasData", 1)
+	require.NoError(t, err)
+	gloasDataCache.Add(root, &gloasBlockData{
+		BlobKzgCommitments:      block.GetBlobKzgCommitments(),
+		SignedBeaconBlockHeader: block.SignedBeaconBlockHeader(),
+	})
+	d := &peerdas{
+		beaconConfig:      &cfg,
+		state:             state,
+		columnStorage:     columnStorage,
+		blobStorage:       blobStorage,
+		recoverBlobsQueue: make(chan recoverBlobsRequest, 1),
+		isRecovering:      make(map[common.Hash]bool),
+		gloasDataCache:    gloasDataCache,
+	}
+	require.NoError(t, d.enqueueBlobRecovery(recoverBlobsRequest{slot: slot, blockRoot: root, metadata: metadata}))
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		d.blobsRecoverWorker(ctx)
+		close(done)
+	}()
+	t.Cleanup(func() { cancel(); <-done })
+
+	var stored *cltypes.DataColumnSidecar
+	for index := range custodyColumns {
+		require.Eventually(t, func() bool {
+			fresh := blob_storage.NewDataColumnStore(columnFS, &cfg, beaconevents.NewEventEmitter())
+			var readErr error
+			stored, readErr = fresh.ReadColumnSidecarByColumnIndex(t.Context(), slot, root, int64(index))
+			return readErr == nil
+		}, 10*time.Second, 10*time.Millisecond)
+		break
+	}
+	require.Equal(t, clparams.GloasVersion, stored.Version())
+	require.Equal(t, slot, stored.Slot)
+	require.Equal(t, root, stored.BeaconBlockRoot)
+}
+
+func TestDownloadColumnsAndRecoverBlobsAdmitsPartialBlobCount(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	cfg := clparams.MainnetBeaconConfig
+	block := cltypes.NewSignedBeaconBlock(&cfg, clparams.FuluVersion)
+	block.Block.Slot = 100
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	root, err := block.Block.HashSSZ()
+	require.NoError(t, err)
+
+	columnStorage := blob_storage_mock_services.NewMockDataColumnStorage(ctrl)
+	columnStorage.EXPECT().GetSavedColumnIndex(gomock.Any(), block.Block.Slot, root).Return(nil, nil).Times(2)
+	blobStorage := blob_storage_mock_services.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), root).Return(uint32(1), nil)
+	d := &peerdas{beaconConfig: &cfg, columnStorage: columnStorage, blobStorage: blobStorage}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	require.NoError(t, d.DownloadColumnsAndRecoverBlobs(ctx, []cltypes.ColumnSyncableSignedBlock{block}))
+}
+
+func assertDownloadColumnsOverwritesBlobStorage(t *testing.T, initialSidecars func([]*cltypes.BlobSidecar) []*cltypes.BlobSidecar) {
+	t.Helper()
+	cfg := clparams.MainnetBeaconConfig
+	cfg.FuluForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	block, root, sidecars, columns := recoverableFuluData(t, &cfg)
+
+	db := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
+	fs := afero.NewMemMapFs()
+	storage := blob_storage.NewBlobStore(db, fs)
+	require.NoError(t, storage.WriteBlobSidecars(t.Context(), root, initialSidecars(sidecars)))
+	notifying := &writeNotifyingBlobStorage{BlobStorage: storage, written: make(chan struct{})}
+	columnStorage := blob_storage.NewDataColumnStore(afero.NewMemMapFs(), &cfg, beaconevents.NewEventEmitter())
+	for i := range (cfg.NumberOfColumns + 1) / 2 {
+		require.NoError(t, columnStorage.WriteColumnSidecars(t.Context(), root, int64(i), columns[i]))
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	d := &peerdas{
+		beaconConfig:      &cfg,
+		caplinConfig:      &clparams.CaplinConfig{ArchiveBlobs: true},
+		state:             peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{}),
+		columnStorage:     columnStorage,
+		blobStorage:       notifying,
+		recoverBlobsQueue: make(chan recoverBlobsRequest, 1),
+		isRecovering:      make(map[common.Hash]bool),
+	}
+	go d.blobsRecoverWorker(ctx)
+
+	require.NoError(t, d.DownloadColumnsAndRecoverBlobs(ctx, []cltypes.ColumnSyncableSignedBlock{block}))
+	select {
+	case <-notifying.written:
+	case <-time.After(30 * time.Second):
+		t.Fatal("incomplete or invalid blob storage was not overwritten by PeerDAS recovery")
+	}
+
+	fresh := blob_storage.NewBlobStore(db, fs)
+	stored, found, err := fresh.ReadBlobSidecars(t.Context(), block.Block.Slot, root)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Len(t, stored, len(sidecars))
+	require.NoError(t, blob_storage.VerifyBlobSidecars(stored, clparams.FuluVersion, nil))
+	for i := range stored {
+		require.Equal(t, uint64(i), stored[i].Index)
+		require.Equal(t, sidecars[i].KzgCommitment, stored[i].KzgCommitment)
+	}
+}
+
+func TestDownloadColumnsAndRecoverBlobsOverwritesPartialBlobStorage(t *testing.T) {
+	assertDownloadColumnsOverwritesBlobStorage(t, func(sidecars []*cltypes.BlobSidecar) []*cltypes.BlobSidecar {
+		return sidecars[:1]
+	})
+}
+
+func TestDownloadColumnsAndRecoverBlobsOverwritesInvalidBlobStorageWithExpectedCount(t *testing.T) {
+	assertDownloadColumnsOverwritesBlobStorage(t, func(sidecars []*cltypes.BlobSidecar) []*cltypes.BlobSidecar {
+		return []*cltypes.BlobSidecar{sidecars[0], sidecars[0]}
+	})
+}
+
+func TestDownloadColumnsAndRecoverBlobsRetriesTransientInitialRecoveryRead(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.FuluForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	block, root, sidecars, columns := recoverableFuluData(t, &cfg)
+
+	baseColumnStorage := blob_storage.NewDataColumnStore(afero.NewMemMapFs(), &cfg, beaconevents.NewEventEmitter())
+	for i := range (cfg.NumberOfColumns + 1) / 2 {
+		require.NoError(t, baseColumnStorage.WriteColumnSidecars(t.Context(), root, int64(i), columns[i]))
+	}
+	columnStorage := &transientSavedColumnIndexStorage{
+		DataColumnStorage: baseColumnStorage,
+		failAt:            3,
+		failed:            make(chan struct{}),
+	}
+	db := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
+	blobFS := afero.NewMemMapFs()
+	baseBlobStorage := blob_storage.NewBlobStore(db, blobFS)
+	blobStorage := &writeNotifyingBlobStorage{BlobStorage: baseBlobStorage, written: make(chan struct{})}
+	d := &peerdas{
+		beaconConfig:      &cfg,
+		caplinConfig:      &clparams.CaplinConfig{ArchiveBlobs: true},
+		state:             peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{}),
+		columnStorage:     columnStorage,
+		blobStorage:       blobStorage,
+		recoverBlobsQueue: make(chan recoverBlobsRequest, 1),
+		isRecovering:      make(map[common.Hash]bool),
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	workerDone := make(chan struct{})
+	go func() {
+		d.blobsRecoverWorker(ctx)
+		close(workerDone)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-workerDone
+	})
+
+	require.NoError(t, d.DownloadColumnsAndRecoverBlobs(ctx, []cltypes.ColumnSyncableSignedBlock{block}))
+	select {
+	case <-columnStorage.failed:
+	case <-time.After(30 * time.Second):
+		t.Fatal("worker did not reach the transient saved-column read failure")
+	}
+	d.recoveringMutex.Lock()
+	_, ownerRetained := d.recoveryRequests[root]
+	d.recoveringMutex.Unlock()
+	require.True(t, ownerRetained, "transient recovery read must retain exact ownership")
+
+	select {
+	case <-blobStorage.written:
+	case <-time.After(30 * time.Second):
+		t.Fatal("transient saved-column read lost the sole recovery owner")
+	}
+	require.Eventually(t, func() bool {
+		d.recoveringMutex.Lock()
+		defer d.recoveringMutex.Unlock()
+		_, owned := d.recoveryRequests[root]
+		return !owned
+	}, 30*time.Second, 10*time.Millisecond)
+	fresh := blob_storage.NewBlobStore(db, blobFS)
+	stored, found, err := fresh.ReadBlobSidecars(t.Context(), block.Block.Slot, root)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Len(t, stored, len(sidecars))
+}
+
+func TestDownloadColumnsAndRecoverBlobsDoesNotRetryCanceledInitialRecoveryRead(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.FuluForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	block, root, _, columns := recoverableFuluData(t, &cfg)
+
+	baseColumnStorage := blob_storage.NewDataColumnStore(afero.NewMemMapFs(), &cfg, beaconevents.NewEventEmitter())
+	for i := range (cfg.NumberOfColumns + 1) / 2 {
+		require.NoError(t, baseColumnStorage.WriteColumnSidecars(t.Context(), root, int64(i), columns[i]))
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	columnStorage := &transientSavedColumnIndexStorage{
+		DataColumnStorage: baseColumnStorage,
+		failAt:            3,
+		failed:            make(chan struct{}),
+		onFail:            cancel,
+	}
+	db := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
+	blobStorage := blob_storage.NewBlobStore(db, afero.NewMemMapFs())
+	d := &peerdas{
+		beaconConfig:      &cfg,
+		caplinConfig:      &clparams.CaplinConfig{ArchiveBlobs: true},
+		state:             peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{}),
+		columnStorage:     columnStorage,
+		blobStorage:       blobStorage,
+		recoverBlobsQueue: make(chan recoverBlobsRequest, 1),
+		isRecovering:      make(map[common.Hash]bool),
+	}
+	workerDone := make(chan struct{})
+	go func() {
+		d.blobsRecoverWorker(ctx)
+		close(workerDone)
+	}()
+
+	require.NoError(t, d.DownloadColumnsAndRecoverBlobs(ctx, []cltypes.ColumnSyncableSignedBlock{block}))
+	select {
+	case <-columnStorage.failed:
+	case <-time.After(30 * time.Second):
+		t.Fatal("worker did not reach the canceled saved-column read")
+	}
+	select {
+	case <-workerDone:
+	case <-time.After(30 * time.Second):
+		t.Fatal("canceled recovery worker did not stop")
+	}
+	require.Equal(t, int32(3), columnStorage.calls.Load())
+	d.recoveringMutex.Lock()
+	_, owned := d.recoveryRequests[root]
+	d.recoveringMutex.Unlock()
+	require.False(t, owned)
+	stored, found, err := blobStorage.ReadBlobSidecars(t.Context(), block.Block.Slot, root)
+	require.NoError(t, err)
+	require.False(t, found)
+	require.Empty(t, stored)
+}
+
+func TestDownloadColumnsAndRecoverBlobsRetriesTransientColumnReadWithoutRemoving(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.FuluForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	block, root, sidecars, columns := recoverableFuluData(t, &cfg)
+
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	nodeDB, err := enode.OpenDB("")
+	require.NoError(t, err)
+	t.Cleanup(func() { nodeDB.Close() })
+	state := peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{})
+	state.SetLocalNodeID(enode.NewLocalNode(nodeDB, key))
+	custodyColumns, err := state.GetMyCustodyColumns()
+	require.NoError(t, err)
+	require.NotEmpty(t, custodyColumns)
+	var targetColumn uint64
+	for column := range custodyColumns {
+		targetColumn = column
+		break
+	}
+
+	columnFS := afero.NewMemMapFs()
+	baseColumnStorage := blob_storage.NewDataColumnStore(columnFS, &cfg, beaconevents.NewEventEmitter())
+	require.NoError(t, baseColumnStorage.WriteColumnSidecars(t.Context(), root, int64(targetColumn), columns[targetColumn]))
+	seeded := 1
+	for column, sidecar := range columns {
+		if uint64(column) == targetColumn {
+			continue
+		}
+		require.NoError(t, baseColumnStorage.WriteColumnSidecars(t.Context(), root, int64(column), sidecar))
+		seeded++
+		if seeded == int((cfg.NumberOfColumns+1)/2) {
+			break
+		}
+	}
+	require.Equal(t, int((cfg.NumberOfColumns+1)/2), seeded)
+	columnStorage := &transientColumnSidecarReadStorage{
+		DataColumnStorage: baseColumnStorage,
+		columnIndex:       int64(targetColumn),
+		readErr:           errors.New("transient column-sidecar read failure"),
+		failed:            make(chan struct{}),
+	}
+	db := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
+	blobFS := afero.NewMemMapFs()
+	baseBlobStorage := blob_storage.NewBlobStore(db, blobFS)
+	blobStorage := &writeNotifyingBlobStorage{BlobStorage: baseBlobStorage, written: make(chan struct{})}
+	d := &peerdas{
+		beaconConfig:      &cfg,
+		caplinConfig:      &clparams.CaplinConfig{ArchiveBlobs: true},
+		state:             state,
+		columnStorage:     columnStorage,
+		blobStorage:       blobStorage,
+		recoverBlobsQueue: make(chan recoverBlobsRequest, 1),
+		isRecovering:      make(map[common.Hash]bool),
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	workerDone := make(chan struct{})
+	go func() {
+		d.blobsRecoverWorker(ctx)
+		close(workerDone)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-workerDone
+	})
+
+	require.NoError(t, d.DownloadColumnsAndRecoverBlobs(ctx, []cltypes.ColumnSyncableSignedBlock{block}))
+	select {
+	case <-columnStorage.failed:
+	case <-time.After(30 * time.Second):
+		t.Fatal("worker did not reach the transient column-sidecar read failure")
+	}
+	select {
+	case <-blobStorage.written:
+	case <-time.After(30 * time.Second):
+		t.Fatal("transient column-sidecar read lost the sole recovery owner")
+	}
+	require.Eventually(t, func() bool {
+		d.recoveringMutex.Lock()
+		defer d.recoveringMutex.Unlock()
+		_, owned := d.recoveryRequests[root]
+		return !owned
+	}, 30*time.Second, 10*time.Millisecond)
+	require.Equal(t, int32(2), columnStorage.targetReads.Load())
+	require.Zero(t, columnStorage.targetRemoves.Load())
+	_, err = baseColumnStorage.ReadColumnSidecarByColumnIndex(t.Context(), block.Block.Slot, root, int64(targetColumn))
+	require.NoError(t, err)
+	fresh := blob_storage.NewBlobStore(db, blobFS)
+	stored, found, err := fresh.ReadBlobSidecars(t.Context(), block.Block.Slot, root)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Len(t, stored, len(sidecars))
+}
+
+func TestDownloadColumnsAndRecoverBlobsRemovesMissingColumnAndReleasesOwner(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.FuluForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	block, root, _, columns := recoverableFuluData(t, &cfg)
+
+	baseColumnStorage := blob_storage.NewDataColumnStore(afero.NewMemMapFs(), &cfg, beaconevents.NewEventEmitter())
+	for column := range (cfg.NumberOfColumns + 1) / 2 {
+		require.NoError(t, baseColumnStorage.WriteColumnSidecars(t.Context(), root, int64(column), columns[column]))
+	}
+	columnStorage := &transientColumnSidecarReadStorage{
+		DataColumnStorage: baseColumnStorage,
+		columnIndex:       0,
+		readErr:           os.ErrNotExist,
+		failed:            make(chan struct{}),
+	}
+	db := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
+	blobStorage := blob_storage.NewBlobStore(db, afero.NewMemMapFs())
+	d := &peerdas{
+		beaconConfig:      &cfg,
+		caplinConfig:      &clparams.CaplinConfig{ArchiveBlobs: true},
+		state:             peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{}),
+		columnStorage:     columnStorage,
+		blobStorage:       blobStorage,
+		recoverBlobsQueue: make(chan recoverBlobsRequest, 1),
+		isRecovering:      make(map[common.Hash]bool),
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	workerDone := make(chan struct{})
+	go func() {
+		d.blobsRecoverWorker(ctx)
+		close(workerDone)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-workerDone
+	})
+
+	require.NoError(t, d.DownloadColumnsAndRecoverBlobs(ctx, []cltypes.ColumnSyncableSignedBlock{block}))
+	select {
+	case <-columnStorage.failed:
+	case <-time.After(30 * time.Second):
+		t.Fatal("worker did not reach the missing column-sidecar read")
+	}
+	require.Eventually(t, func() bool {
+		d.recoveringMutex.Lock()
+		_, owned := d.recoveryRequests[root]
+		d.recoveringMutex.Unlock()
+		return !owned && columnStorage.targetRemoves.Load() == 1
+	}, 30*time.Second, 10*time.Millisecond)
+	require.Equal(t, int32(1), columnStorage.targetReads.Load())
+	_, err := baseColumnStorage.ReadColumnSidecarByColumnIndex(t.Context(), block.Block.Slot, root, 0)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	saved, err := baseColumnStorage.GetSavedColumnIndex(t.Context(), block.Block.Slot, root)
+	require.NoError(t, err)
+	require.Len(t, saved, int((cfg.NumberOfColumns+1)/2)-1)
+	stored, found, err := blobStorage.ReadBlobSidecars(t.Context(), block.Block.Slot, root)
+	require.NoError(t, err)
+	require.False(t, found)
+	require.Empty(t, stored)
+}
+
+func TestDownloadColumnsAndRecoverBlobsDoesNotRetryCanceledColumnRead(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.FuluForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	block, root, _, columns := recoverableFuluData(t, &cfg)
+
+	baseColumnStorage := blob_storage.NewDataColumnStore(afero.NewMemMapFs(), &cfg, beaconevents.NewEventEmitter())
+	for column := range (cfg.NumberOfColumns + 1) / 2 {
+		require.NoError(t, baseColumnStorage.WriteColumnSidecars(t.Context(), root, int64(column), columns[column]))
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	columnStorage := &transientColumnSidecarReadStorage{
+		DataColumnStorage: baseColumnStorage,
+		columnIndex:       0,
+		readErr:           errors.New("transient column-sidecar read failure"),
+		onFail:            cancel,
+		failed:            make(chan struct{}),
+	}
+	db := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
+	blobStorage := blob_storage.NewBlobStore(db, afero.NewMemMapFs())
+	d := &peerdas{
+		beaconConfig:      &cfg,
+		caplinConfig:      &clparams.CaplinConfig{ArchiveBlobs: true},
+		state:             peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{}),
+		columnStorage:     columnStorage,
+		blobStorage:       blobStorage,
+		recoverBlobsQueue: make(chan recoverBlobsRequest, 1),
+		isRecovering:      make(map[common.Hash]bool),
+	}
+	workerDone := make(chan struct{})
+	go func() {
+		d.blobsRecoverWorker(ctx)
+		close(workerDone)
+	}()
+
+	require.NoError(t, d.DownloadColumnsAndRecoverBlobs(ctx, []cltypes.ColumnSyncableSignedBlock{block}))
+	select {
+	case <-columnStorage.failed:
+	case <-time.After(30 * time.Second):
+		t.Fatal("worker did not reach the canceled column-sidecar read")
+	}
+	select {
+	case <-workerDone:
+	case <-time.After(30 * time.Second):
+		t.Fatal("worker did not stop after cancellation")
+	}
+	require.Equal(t, int32(1), columnStorage.targetReads.Load())
+	require.Zero(t, columnStorage.targetRemoves.Load())
+	d.recoveringMutex.Lock()
+	_, owned := d.recoveryRequests[root]
+	d.recoveringMutex.Unlock()
+	require.False(t, owned)
+	d.recoveryRetryMutex.Lock()
+	_, delayed := d.recoveryRetries[root]
+	d.recoveryRetryMutex.Unlock()
+	require.False(t, delayed)
+	_, err := baseColumnStorage.ReadColumnSidecarByColumnIndex(t.Context(), block.Block.Slot, root, 0)
+	require.NoError(t, err)
+	stored, found, err := blobStorage.ReadBlobSidecars(t.Context(), block.Block.Slot, root)
+	require.NoError(t, err)
+	require.False(t, found)
+	require.Empty(t, stored)
+}
+
+func TestBlobRecoveryRetriesTransientFinalWrite(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.FuluForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	block, root, sidecars, columns := recoverableFuluData(t, &cfg)
+
+	db := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
+	baseBlobStorage := blob_storage.NewBlobStore(db, afero.NewMemMapFs())
+	blobStorage := &transientBlobWriteStorage{BlobStorage: baseBlobStorage, succeeded: make(chan struct{})}
+	baseColumnStorage := blob_storage.NewDataColumnStore(afero.NewMemMapFs(), &cfg, beaconevents.NewEventEmitter())
+	columnStorage := &savedColumnReadCountingStorage{DataColumnStorage: baseColumnStorage}
+	for i := range (cfg.NumberOfColumns + 1) / 2 {
+		require.NoError(t, columnStorage.WriteColumnSidecars(t.Context(), root, int64(i), columns[i]))
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	d := &peerdas{
+		beaconConfig:      &cfg,
+		caplinConfig:      &clparams.CaplinConfig{ArchiveBlobs: true},
+		state:             peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{}),
+		columnStorage:     columnStorage,
+		blobStorage:       blobStorage,
+		recoverBlobsQueue: make(chan recoverBlobsRequest, 1),
+		isRecovering:      make(map[common.Hash]bool),
+	}
+	done := make(chan struct{})
+	go func() { d.blobsRecoverWorker(ctx); close(done) }()
+	t.Cleanup(func() { cancel(); <-done })
+
+	require.NoError(t, d.DownloadColumnsAndRecoverBlobs(ctx, []cltypes.ColumnSyncableSignedBlock{block}))
+	select {
+	case <-blobStorage.succeeded:
+	case <-time.After(10 * time.Second):
+		t.Fatal("transient final write dropped the recovery owner")
+	}
+	require.Equal(t, int32(2), blobStorage.calls.Load())
+	require.Equal(t, int32(3), columnStorage.reads.Load(), "final-write retry must reuse reconstruction")
+	stored, found, err := baseBlobStorage.ReadBlobSidecars(t.Context(), block.Block.Slot, root)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Len(t, stored, len(sidecars))
+}
+
+func TestDownloadColumnsAndRecoverBlobsRetainsAllDelayedRootsAndAdmitsHealthyRoot(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.FuluForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	block, root, _, columns := recoverableFuluData(t, &cfg)
+
+	db := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
+	storage := blob_storage.NewBlobStore(db, afero.NewMemMapFs())
+	notifying := &writeNotifyingBlobStorage{BlobStorage: storage, written: make(chan struct{})}
+	unavailable := &unavailableRootsBlobStorage{
+		BlobStorage: notifying,
+		roots:       make(map[common.Hash]struct{}),
+		started:     make(chan struct{}),
+	}
+	columnStorage := blob_storage.NewDataColumnStore(afero.NewMemMapFs(), &cfg, beaconevents.NewEventEmitter())
+	for i := range (cfg.NumberOfColumns + 1) / 2 {
+		require.NoError(t, columnStorage.WriteColumnSidecars(t.Context(), root, int64(i), columns[i]))
+	}
+
+	d := &peerdas{
+		beaconConfig:      &cfg,
+		caplinConfig:      &clparams.CaplinConfig{ArchiveBlobs: true},
+		state:             peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{}),
+		columnStorage:     columnStorage,
+		blobStorage:       unavailable,
+		recoverBlobsQueue: make(chan recoverBlobsRequest, 128),
+		isRecovering:      make(map[common.Hash]bool),
+	}
+	poisonedCount := cap(d.recoverBlobsQueue) + 1
+	for i := range poisonedCount {
+		poisonedRoot := common.Hash{byte(i + 1), 0xff}
+		unavailable.roots[poisonedRoot] = struct{}{}
+		d.delayBlobRecovery(recoverBlobsRequest{slot: block.Block.Slot, blockRoot: poisonedRoot})
+	}
+	require.Len(t, d.recoveryRetries, poisonedCount)
+	require.Len(t, d.isRecovering, poisonedCount)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	var workers sync.WaitGroup
+	for range numOfBlobRecoveryWorkers {
+		workers.Go(func() { d.blobsRecoverWorker(ctx) })
+	}
+	select {
+	case <-unavailable.started:
+	case <-time.After(3 * time.Second):
+		cancel()
+		workers.Wait()
+		t.Fatal("delayed poison roots were not retried")
+	}
+	require.NoError(t, d.DownloadColumnsAndRecoverBlobs(t.Context(), []cltypes.ColumnSyncableSignedBlock{block}))
+	select {
+	case <-notifying.written:
+	case <-time.After(10 * time.Second):
+		cancel()
+		workers.Wait()
+		t.Fatal("delayed retries blocked a fresh healthy recovery root")
+	}
+	require.Positive(t, unavailable.attempts.Load())
+	d.recoveringMutex.Lock()
+	for poisonedRoot := range unavailable.roots {
+		require.Contains(t, d.isRecovering, poisonedRoot)
+	}
+	d.recoveringMutex.Unlock()
+	cancel()
+	workers.Wait()
+}
+
+func TestBlobsRecoverWorkerStopsWhenDurableCheckIsCanceled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	cfg := clparams.MainnetBeaconConfig
+	block := cltypes.NewSignedBeaconBlock(&cfg, clparams.FuluVersion)
+	block.Block.Slot = 100
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	root, err := block.Block.HashSSZ()
+	require.NoError(t, err)
+
+	readStarted := make(chan struct{})
+	postCancelRecovery := make(chan struct{})
+	blobStorage := blob_storage_mock_services.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), root).Return(uint32(1), nil)
+	blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), block.Block.Slot, root).DoAndReturn(
+		func(ctx context.Context, _ uint64, _ common.Hash) ([]*cltypes.BlobSidecar, bool, error) {
+			close(readStarted)
+			<-ctx.Done()
+			return nil, false, ctx.Err()
+		},
+	)
+	columnStorage := blob_storage_mock_services.NewMockDataColumnStorage(ctrl)
+	columnStorage.EXPECT().GetSavedColumnIndex(gomock.Any(), block.Block.Slot, root).DoAndReturn(
+		func(context.Context, uint64, common.Hash) ([]uint64, error) {
+			close(postCancelRecovery)
+			return nil, errors.New("unexpected recovery after cancellation")
+		},
+	).AnyTimes()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	d := &peerdas{
+		beaconConfig:      &cfg,
+		columnStorage:     columnStorage,
+		blobStorage:       blobStorage,
+		recoverBlobsQueue: make(chan recoverBlobsRequest, 1),
+		isRecovering:      make(map[common.Hash]bool),
+	}
+	metadata, err := newBlobRecoveryMetadata(block, root)
+	require.NoError(t, err)
+	d.recoverBlobsQueue <- recoverBlobsRequest{slot: block.Block.Slot, blockRoot: root, metadata: metadata}
+	workerDone := make(chan struct{})
+	go func() {
+		d.blobsRecoverWorker(ctx)
+		close(workerDone)
+	}()
+
+	<-readStarted
+	cancel()
+	<-workerDone
+	select {
+	case <-postCancelRecovery:
+		t.Fatal("worker started recovery after its durable check was canceled")
+	default:
+	}
+}
+
+func TestBlobsRecoverWorkerStopsWhenRecoveryContextIsCanceled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	cfg := clparams.MainnetBeaconConfig
+	root := common.HexToHash("0xcafe")
+	ctx, cancel := context.WithCancel(t.Context())
+	postCancelColumnRead := make(chan struct{})
+
+	blobStorage := blob_storage_mock_services.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), root).Return(uint32(0), nil)
+	columnStorage := blob_storage_mock_services.NewMockDataColumnStorage(ctrl)
+	columnStorage.EXPECT().GetSavedColumnIndex(gomock.Any(), uint64(100), root).DoAndReturn(
+		func(context.Context, uint64, common.Hash) ([]uint64, error) {
+			cancel()
+			return make([]uint64, (cfg.NumberOfColumns+1)/2), nil
+		},
+	)
+	columnStorage.EXPECT().ReadColumnSidecarByColumnIndex(gomock.Any(), uint64(100), root, gomock.Any()).DoAndReturn(
+		func(context.Context, uint64, common.Hash, int64) (*cltypes.DataColumnSidecar, error) {
+			close(postCancelColumnRead)
+			return nil, errors.New("unexpected column read after cancellation")
+		},
+	).AnyTimes()
+	columnStorage.EXPECT().RemoveColumnSidecars(gomock.Any(), uint64(100), root, gomock.Any()).Return(nil).AnyTimes()
+
+	d := &peerdas{
+		beaconConfig:      &cfg,
+		columnStorage:     columnStorage,
+		blobStorage:       blobStorage,
+		recoverBlobsQueue: make(chan recoverBlobsRequest, 1),
+		isRecovering:      make(map[common.Hash]bool),
+	}
+	d.recoverBlobsQueue <- recoverBlobsRequest{slot: 100, blockRoot: root}
+	workerDone := make(chan struct{})
+	go func() {
+		d.blobsRecoverWorker(ctx)
+		close(workerDone)
+	}()
+
+	<-workerDone
+	select {
+	case <-postCancelColumnRead:
+		t.Fatal("worker read recovery columns after its context was canceled")
+	default:
+	}
+}
+
+func TestBlobsRecoverWorkerRechecksDurableCompletionBeforeWrite(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.FuluForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	block, root, sidecars, columns := recoverableFuluData(t, &cfg)
+	columnStorage := blob_storage.NewDataColumnStore(afero.NewMemMapFs(), &cfg, beaconevents.NewEventEmitter())
+	for i := range (cfg.NumberOfColumns + 1) / 2 {
+		require.NoError(t, columnStorage.WriteColumnSidecars(t.Context(), root, int64(i), columns[i]))
+	}
+
+	ctrl := gomock.NewController(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	var countReads atomic.Int32
+	blobStorage := blob_storage_mock_services.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), root).DoAndReturn(
+		func(context.Context, common.Hash) (uint32, error) {
+			if countReads.Add(1) == 1 {
+				return 0, nil
+			}
+			return uint32(len(sidecars)), nil
+		},
+	).AnyTimes()
+	blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), block.Block.Slot, root).DoAndReturn(
+		func(context.Context, uint64, common.Hash) ([]*cltypes.BlobSidecar, bool, error) {
+			cancel()
+			return sidecars, true, nil
+		},
+	).AnyTimes()
+	overwriteAttempted := make(chan struct{})
+	var overwriteOnce sync.Once
+	blobStorage.EXPECT().WriteBlobSidecars(gomock.Any(), root, gomock.Any()).DoAndReturn(
+		func(context.Context, common.Hash, []*cltypes.BlobSidecar) error {
+			overwriteOnce.Do(func() { close(overwriteAttempted) })
+			cancel()
+			return errors.New("unexpected overwrite of concurrent completion")
+		},
+	).AnyTimes()
+
+	metadata, err := newBlobRecoveryMetadata(block, root)
+	require.NoError(t, err)
+	d := &peerdas{
+		beaconConfig:      &cfg,
+		columnStorage:     columnStorage,
+		blobStorage:       blobStorage,
+		recoverBlobsQueue: make(chan recoverBlobsRequest, 1),
+		isRecovering:      make(map[common.Hash]bool),
+	}
+	d.recoverBlobsQueue <- recoverBlobsRequest{slot: block.Block.Slot, blockRoot: root, metadata: metadata}
+	workerDone := make(chan struct{})
+	go func() {
+		d.blobsRecoverWorker(ctx)
+		close(workerDone)
+	}()
+	select {
+	case <-workerDone:
+	case <-time.After(30 * time.Second):
+		t.Fatal("blob recovery worker did not finish")
+	}
+	select {
+	case <-overwriteAttempted:
+		t.Fatal("worker overwrote blob storage that completed during recovery")
+	default:
+	}
+	require.GreaterOrEqual(t, countReads.Load(), int32(2), "worker must revalidate immediately before writing")
+}
+
+func TestMetadataFreeBlobRecoveryRechecksConcurrentCompletionBeforeWrite(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.FuluForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	block, root, _, columns := recoverableFuluData(t, &cfg)
+	columnStorage := blob_storage.NewDataColumnStore(afero.NewMemMapFs(), &cfg, beaconevents.NewEventEmitter())
+	for i := range (cfg.NumberOfColumns + 1) / 2 {
+		require.NoError(t, columnStorage.WriteColumnSidecars(t.Context(), root, int64(i), columns[i]))
+	}
+
+	ctrl := gomock.NewController(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	var countReads atomic.Int32
+	blobStorage := blob_storage_mock_services.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), root).DoAndReturn(
+		func(context.Context, common.Hash) (uint32, error) {
+			if countReads.Add(1) == 1 {
+				return 0, nil
+			}
+			cancel()
+			return 1, nil
+		},
+	).AnyTimes()
+	overwriteAttempted := make(chan struct{})
+	var overwriteOnce sync.Once
+	blobStorage.EXPECT().WriteBlobSidecars(gomock.Any(), root, gomock.Any()).DoAndReturn(
+		func(context.Context, common.Hash, []*cltypes.BlobSidecar) error {
+			overwriteOnce.Do(func() { close(overwriteAttempted) })
+			return errors.New("unexpected metadata-free overwrite")
+		},
+	).AnyTimes()
+	d := &peerdas{
+		beaconConfig:      &cfg,
+		columnStorage:     columnStorage,
+		blobStorage:       blobStorage,
+		recoverBlobsQueue: make(chan recoverBlobsRequest, 1),
+		isRecovering:      make(map[common.Hash]bool),
+	}
+	require.NoError(t, d.enqueueBlobRecovery(recoverBlobsRequest{slot: block.Block.Slot, blockRoot: root}))
+	d.blobsRecoverWorker(ctx)
+
+	select {
+	case <-overwriteAttempted:
+		t.Fatal("metadata-free recovery overwrote concurrent durable data")
+	default:
+	}
+	require.GreaterOrEqual(t, countReads.Load(), int32(2))
+}
+
+func TestBlobsRecoverWorkerContinuesAfterTransientAdmissionValidation(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.FuluForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	block, root, sidecars, columns := recoverableFuluData(t, &cfg)
+	columnStorage := blob_storage.NewDataColumnStore(afero.NewMemMapFs(), &cfg, beaconevents.NewEventEmitter())
+	for i := range (cfg.NumberOfColumns + 1) / 2 {
+		require.NoError(t, columnStorage.WriteColumnSidecars(t.Context(), root, int64(i), columns[i]))
+	}
+
+	ctrl := gomock.NewController(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	blobStorage := blob_storage_mock_services.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), root).DoAndReturn(
+		func(context.Context, common.Hash) (uint32, error) {
+			return uint32(len(sidecars)), nil
+		},
+	).AnyTimes()
+	var durableReads atomic.Int32
+	blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), block.Block.Slot, root).DoAndReturn(
+		func(context.Context, uint64, common.Hash) ([]*cltypes.BlobSidecar, bool, error) {
+			if durableReads.Add(1) == 1 {
+				return nil, false, errors.New("transient admission read failure")
+			}
+			return nil, false, nil
+		},
+	).AnyTimes()
+	writeAttempted := make(chan struct{})
+	var writeOnce sync.Once
+	blobStorage.EXPECT().WriteBlobSidecars(gomock.Any(), root, gomock.Any()).DoAndReturn(
+		func(context.Context, common.Hash, []*cltypes.BlobSidecar) error {
+			writeOnce.Do(func() { close(writeAttempted) })
+			cancel()
+			return errors.New("stop after observing recovery write")
+		},
+	).AnyTimes()
+
+	metadata, err := newBlobRecoveryMetadata(block, root)
+	require.NoError(t, err)
+	d := &peerdas{
+		beaconConfig:      &cfg,
+		columnStorage:     columnStorage,
+		blobStorage:       blobStorage,
+		recoverBlobsQueue: make(chan recoverBlobsRequest, 2),
+		isRecovering:      make(map[common.Hash]bool),
+	}
+	d.recoverBlobsQueue <- recoverBlobsRequest{slot: block.Block.Slot, blockRoot: root, metadata: metadata}
+	workerDone := make(chan struct{})
+	go func() {
+		d.blobsRecoverWorker(ctx)
+		close(workerDone)
+	}()
+	select {
+	case <-workerDone:
+	case <-time.After(30 * time.Second):
+		t.Fatal("blob recovery worker did not release capacity")
+	}
+	select {
+	case <-writeAttempted:
+	default:
+		t.Fatal("transient admission validation dropped the only recovery owner")
+	}
+	require.Equal(t, int32(3), durableReads.Load(), "worker must revalidate after the delay and at the write boundary")
+}
+
+func TestBlobsRecoverWorkerRetriesTransientPrewriteValidation(t *testing.T) {
+	assertBlobsRecoverWorkerPrewriteUnavailable(t, false)
+}
+
+func TestBlobsRecoverWorkerPacesPersistentPrewriteUnavailableUntilCancellation(t *testing.T) {
+	assertBlobsRecoverWorkerPrewriteUnavailable(t, true)
+}
+
+func TestBlobsRecoverWorkersDoNotStarveHealthyRootBehindPersistentUnavailable(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.FuluForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	block, _, sidecars, columns := recoverableFuluData(t, &cfg)
+	existingColumns := make([]uint64, (cfg.NumberOfColumns+1)/2)
+	encodedColumns := make([][]byte, len(existingColumns))
+	for i := range existingColumns {
+		existingColumns[i] = uint64(i)
+		encoded, err := columns[i].EncodeSSZ(nil)
+		require.NoError(t, err)
+		encodedColumns[i] = encoded
+	}
+
+	ctrl := gomock.NewController(t)
+	columnStorage := blob_storage_mock_services.NewMockDataColumnStorage(ctrl)
+	columnStorage.EXPECT().GetSavedColumnIndex(gomock.Any(), block.Block.Slot, gomock.Any()).Return(existingColumns, nil).AnyTimes()
+	columnStorage.EXPECT().ReadColumnSidecarByColumnIndex(gomock.Any(), block.Block.Slot, gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ uint64, _ common.Hash, columnIndex int64) (*cltypes.DataColumnSidecar, error) {
+			column := cltypes.NewDataColumnSidecarWithVersion(clparams.FuluVersion)
+			if err := column.DecodeSSZ(encodedColumns[columnIndex], int(clparams.FuluVersion)); err != nil {
+				return nil, err
+			}
+			return column, nil
+		},
+	).AnyTimes()
+
+	poisonedRoots := make(map[common.Hash]bool, numOfBlobRecoveryWorkers)
+	requests := make([]recoverBlobsRequest, 0, numOfBlobRecoveryWorkers+1)
+	baseMetadata, err := newBlobRecoveryMetadata(block, common.Hash{})
+	require.NoError(t, err)
+	for i := range numOfBlobRecoveryWorkers {
+		root := common.Hash{byte(i + 1)}
+		poisonedRoots[root] = true
+		metadata := *baseMetadata
+		metadata.blockRoot = root
+		requests = append(requests, recoverBlobsRequest{slot: block.Block.Slot, blockRoot: root, metadata: &metadata})
+	}
+	healthyRoot := common.Hash{0xff}
+	healthyMetadata := *baseMetadata
+	healthyMetadata.blockRoot = healthyRoot
+	healthyRequest := recoverBlobsRequest{slot: block.Block.Slot, blockRoot: healthyRoot, metadata: &healthyMetadata}
+
+	blobStorage := blob_storage_mock_services.NewMockBlobStorage(ctrl)
+	var storageMutex sync.Mutex
+	countReads := make(map[common.Hash]int)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, root common.Hash) (uint32, error) {
+			storageMutex.Lock()
+			defer storageMutex.Unlock()
+			countReads[root]++
+			if countReads[root] == 1 {
+				return 0, nil
+			}
+			return uint32(len(sidecars)), nil
+		},
+	).AnyTimes()
+	allPoisonedObserved := make(chan struct{})
+	poisonedSeen := make(map[common.Hash]bool, numOfBlobRecoveryWorkers)
+	blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), block.Block.Slot, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ uint64, root common.Hash) ([]*cltypes.BlobSidecar, bool, error) {
+			if poisonedRoots[root] {
+				storageMutex.Lock()
+				if !poisonedSeen[root] {
+					poisonedSeen[root] = true
+					if len(poisonedSeen) == numOfBlobRecoveryWorkers {
+						close(allPoisonedObserved)
+					}
+				}
+				storageMutex.Unlock()
+				return nil, false, errors.New("persistent storage outage")
+			}
+			return nil, false, nil
+		},
+	).AnyTimes()
+	healthyWritten := make(chan struct{})
+	poisonedWrite := make(chan struct{})
+	var healthyWriteOnce sync.Once
+	var poisonedWriteOnce sync.Once
+	blobStorage.EXPECT().WriteBlobSidecars(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, root common.Hash, _ []*cltypes.BlobSidecar) error {
+			if poisonedRoots[root] {
+				poisonedWriteOnce.Do(func() { close(poisonedWrite) })
+			} else if root == healthyRoot {
+				healthyWriteOnce.Do(func() { close(healthyWritten) })
+			}
+			return errors.New("stop after observing recovery write")
+		},
+	).AnyTimes()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	d := &peerdas{
+		beaconConfig:      &cfg,
+		columnStorage:     columnStorage,
+		blobStorage:       blobStorage,
+		recoverBlobsQueue: make(chan recoverBlobsRequest, 16),
+		isRecovering:      make(map[common.Hash]bool),
+	}
+	for _, request := range requests {
+		d.recoverBlobsQueue <- request
+	}
+	workersDone := make(chan struct{})
+	var workers sync.WaitGroup
+	for range numOfBlobRecoveryWorkers {
+		workers.Go(func() { d.blobsRecoverWorker(ctx) })
+	}
+	go func() {
+		workers.Wait()
+		close(workersDone)
+	}()
+	select {
+	case <-allPoisonedObserved:
+	case <-time.After(30 * time.Second):
+		cancel()
+		<-workersDone
+		t.Fatal("not every recovery worker reached persistent unavailable storage")
+	}
+	d.recoverBlobsQueue <- healthyRequest
+	select {
+	case <-healthyWritten:
+	case <-time.After(10 * time.Second):
+		cancel()
+		<-workersDone
+		t.Fatal("persistent unavailable roots starved a healthy recovery root")
+	}
+	select {
+	case <-poisonedWrite:
+		t.Fatal("persistent unavailable storage was overwritten")
+	default:
+	}
+	cancel()
+	select {
+	case <-workersDone:
+	case <-time.After(30 * time.Second):
+		t.Fatal("recovery workers did not drain after cancellation")
+	}
+	d.recoveringMutex.Lock()
+	require.Empty(t, d.isRecovering)
+	d.recoveringMutex.Unlock()
+	d.recoveryRetryMutex.Lock()
+	require.Empty(t, d.recoveryRetries)
+	d.recoveryRetryMutex.Unlock()
+	d.recoveringMutex.Lock()
+	require.Empty(t, d.recoveryResults)
+	require.Zero(t, d.recoveryResultBytes)
+	d.recoveringMutex.Unlock()
+}
+
+func TestEnqueueBlobRecoveryDeduplicatesOwnedRoot(t *testing.T) {
+	d := &peerdas{
+		recoverBlobsQueue: make(chan recoverBlobsRequest, 2),
+		isRecovering:      make(map[common.Hash]bool),
+	}
+	request := recoverBlobsRequest{blockRoot: common.Hash{1}}
+	require.NoError(t, d.enqueueBlobRecovery(request))
+	require.NoError(t, d.enqueueBlobRecovery(request))
+	require.Len(t, d.recoverBlobsQueue, 1)
+	require.Len(t, d.isRecovering, 1)
+
+	queued := <-d.recoverBlobsQueue
+	_, generation, ok := d.claimBlobRecovery(queued)
+	require.True(t, ok)
+	_, _, ok = d.claimBlobRecovery(queued)
+	require.False(t, ok)
+	d.releaseBlobRecovery(queued.blockRoot, generation)
+	require.Empty(t, d.isRecovering)
+}
+
+func TestEnqueueBlobRecoveryPreservesOwnershipAtCapacity(t *testing.T) {
+	d := &peerdas{
+		recoverBlobsQueue: make(chan recoverBlobsRequest, 2),
+		isRecovering:      make(map[common.Hash]bool),
+	}
+	first := recoverBlobsRequest{blockRoot: common.Hash{1}}
+	second := recoverBlobsRequest{blockRoot: common.Hash{2}}
+	third := recoverBlobsRequest{blockRoot: common.Hash{3}}
+	require.NoError(t, d.enqueueBlobRecovery(first))
+	require.NoError(t, d.enqueueBlobRecovery(second))
+	require.NoError(t, d.enqueueBlobRecovery(third))
+	require.Len(t, d.recoverBlobsQueue, 2)
+	require.Len(t, d.isRecovering, 3)
+	require.Contains(t, d.recoveryRetries, third.blockRoot)
+
+	queued := <-d.recoverBlobsQueue
+	_, generation, ok := d.claimBlobRecovery(queued)
+	require.True(t, ok)
+	d.releaseBlobRecovery(queued.blockRoot, generation)
+	d.recoveryRetries[third.blockRoot].notBefore = time.Now()
+	d.recoveryPreferRetry = true
+	retry, ok := d.nextBlobRecoveryRequest(t.Context())
+	require.True(t, ok)
+	require.Equal(t, third.blockRoot, retry.blockRoot)
+	require.Len(t, d.recoverBlobsQueue, 1)
+	require.Len(t, d.isRecovering, 2)
+}
+
+func TestNextBlobRecoveryRequestAlternatesReadyQueueAndRetry(t *testing.T) {
+	d := &peerdas{
+		recoverBlobsQueue: make(chan recoverBlobsRequest, 1),
+		isRecovering:      make(map[common.Hash]bool),
+	}
+	queued := recoverBlobsRequest{blockRoot: common.Hash{1}}
+	delayed := recoverBlobsRequest{blockRoot: common.Hash{2}}
+	d.recoverBlobsQueue <- queued
+	require.True(t, d.delayBlobRecovery(delayed))
+	d.recoveryRetryMutex.Lock()
+	d.recoveryRetries[delayed.blockRoot].notBefore = time.Now().Add(-time.Second)
+	heap.Fix(&d.recoveryRetryQueue, d.recoveryRetries[delayed.blockRoot].heapIndex)
+	d.recoveryRetryMutex.Unlock()
+
+	first, ok := d.nextBlobRecoveryRequest(t.Context())
+	require.True(t, ok)
+	require.Equal(t, queued.blockRoot, first.blockRoot)
+	second, ok := d.nextBlobRecoveryRequest(t.Context())
+	require.True(t, ok)
+	require.Equal(t, delayed.blockRoot, second.blockRoot)
+}
+
+func TestNextBlobRecoveryRequestGloballyPacesDelayedRetries(t *testing.T) {
+	d := &peerdas{recoverBlobsQueue: make(chan recoverBlobsRequest, 1)}
+	const retries = 9
+	for i := range retries {
+		request := recoverBlobsRequest{slot: uint64(i + 1), blockRoot: common.Hash{byte(i + 1)}}
+		require.True(t, d.delayBlobRecovery(request))
+	}
+	d.recoveryRetryMutex.Lock()
+	for _, delayed := range d.recoveryRetries {
+		delayed.notBefore = time.Now().Add(-time.Second)
+	}
+	heap.Init(&d.recoveryRetryQueue)
+	d.recoveryRetryMutex.Unlock()
+
+	started := time.Now()
+	for range retries {
+		_, ok := d.nextBlobRecoveryRequest(t.Context())
+		require.True(t, ok)
+	}
+	require.GreaterOrEqual(t, time.Since(started), blobRecoveryValidationRetryInterval-10*time.Millisecond)
+	require.Len(t, d.isRecovering, retries)
+	require.Empty(t, d.recoveryRetries)
+
+	typeOfPeerDas := reflect.TypeFor[peerdas]()
+	heapField, hasHeap := typeOfPeerDas.FieldByName("recoveryRetryQueue")
+	_, hasLinearOrder := typeOfPeerDas.FieldByName("recoveryRetryOrder")
+	require.True(t, hasHeap)
+	require.True(t, reflect.PointerTo(heapField.Type).Implements(reflect.TypeFor[heap.Interface]()))
+	require.False(t, hasLinearOrder)
+}
+
+func TestBlobRecoveryMetadataUpgradeRepairsInvalidEqualCountStorage(t *testing.T) {
+	for _, lifecycle := range []string{"queued", "active", "delayed"} {
+		t.Run(lifecycle, func(t *testing.T) {
+			cfg := clparams.MainnetBeaconConfig
+			cfg.FuluForkEpoch = 0
+			cfg.InitializeForkSchedule()
+			initTestBeaconConfig(&cfg)
+			block, root, sidecars, columns := recoverableFuluData(t, &cfg)
+			columnStorage := blob_storage.NewDataColumnStore(afero.NewMemMapFs(), &cfg, beaconevents.NewEventEmitter())
+			for i := range (cfg.NumberOfColumns + 1) / 2 {
+				require.NoError(t, columnStorage.WriteColumnSidecars(t.Context(), root, int64(i), columns[i]))
+			}
+
+			ctrl := gomock.NewController(t)
+			firstCountStarted := make(chan struct{})
+			releaseFirstCount := make(chan struct{})
+			var countCalls atomic.Int32
+			blobStorage := blob_storage_mock_services.NewMockBlobStorage(ctrl)
+			blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), root).DoAndReturn(
+				func(context.Context, common.Hash) (uint32, error) {
+					if lifecycle == "active" && countCalls.Add(1) == 1 {
+						close(firstCountStarted)
+						<-releaseFirstCount
+					}
+					return uint32(len(sidecars)), nil
+				},
+			).AnyTimes()
+			blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), block.Block.Slot, root).Return(nil, false, nil).AnyTimes()
+			written := make(chan struct{})
+			var writeOnce sync.Once
+			ctx, cancel := context.WithCancel(t.Context())
+			blobStorage.EXPECT().WriteBlobSidecars(gomock.Any(), root, gomock.Any()).DoAndReturn(
+				func(context.Context, common.Hash, []*cltypes.BlobSidecar) error {
+					writeOnce.Do(func() { close(written) })
+					cancel()
+					return errors.New("stop after metadata repair")
+				},
+			).AnyTimes()
+			metadata, err := newBlobRecoveryMetadata(block, root)
+			require.NoError(t, err)
+			d := &peerdas{
+				beaconConfig:      &cfg,
+				state:             peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{}),
+				columnStorage:     columnStorage,
+				blobStorage:       blobStorage,
+				recoverBlobsQueue: make(chan recoverBlobsRequest, 2),
+				isRecovering:      make(map[common.Hash]bool),
+			}
+			nilRequest := recoverBlobsRequest{slot: block.Block.Slot, blockRoot: root}
+			strongRequest := recoverBlobsRequest{slot: block.Block.Slot, blockRoot: root, metadata: metadata}
+			switch lifecycle {
+			case "queued":
+				require.NoError(t, d.enqueueBlobRecovery(nilRequest))
+				require.NoError(t, d.enqueueBlobRecovery(strongRequest))
+			case "delayed":
+				d.delayBlobRecovery(nilRequest)
+				require.NoError(t, d.enqueueBlobRecovery(strongRequest))
+			case "active":
+				require.NoError(t, d.enqueueBlobRecovery(nilRequest))
+			}
+
+			workerDone := make(chan struct{})
+			go func() {
+				d.blobsRecoverWorker(ctx)
+				close(workerDone)
+			}()
+			if lifecycle == "active" {
+				select {
+				case <-firstCountStarted:
+				case <-time.After(10 * time.Second):
+					cancel()
+					<-workerDone
+					t.Fatal("metadata-free recovery did not become active")
+				}
+				require.NoError(t, d.enqueueBlobRecovery(strongRequest))
+				close(releaseFirstCount)
+			}
+			select {
+			case <-written:
+			case <-time.After(30 * time.Second):
+				cancel()
+				<-workerDone
+				t.Fatal("stronger metadata did not retain recovery ownership")
+			}
+			cancel()
+			<-workerDone
+		})
+	}
+}
+
+func TestBlobRecoveryResultCacheEnforcesByteCapacity(t *testing.T) {
+	d := &peerdas{}
+	firstRoot := common.Hash{1}
+	secondRoot := common.Hash{2}
+	require.True(t, d.cacheBlobRecoveryResult(firstRoot, &blobRecoveryResult{encodedBytes: maxBlobRecoveryResultBytes - 1}))
+	require.True(t, d.cacheBlobRecoveryResult(secondRoot, &blobRecoveryResult{encodedBytes: 2}))
+	require.NotContains(t, d.recoveryResults, firstRoot)
+	require.Contains(t, d.recoveryResults, secondRoot)
+	require.Equal(t, 2, d.recoveryResultBytes)
+	require.False(t, d.cacheBlobRecoveryResult(common.Hash{3}, &blobRecoveryResult{encodedBytes: maxBlobRecoveryResultBytes + 1}))
+}
+
+func TestBlobRecoveryResultCacheUsesEncodedProtocolBoundary(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.BlobSchedule = []clparams.BlobParameters{{Epoch: 1, MaxBlobsPerBlock: 48}}
+	require.EqualValues(t, 48, cfg.MaxBlobsPerBlockUpperBound())
+
+	resultForBlobs := func(count int) *blobRecoveryResult {
+		matrix := make([][]cltypes.MatrixEntry, count)
+		sidecars := make([]*cltypes.BlobSidecar, count)
+		for i := range count {
+			matrix[i] = make([]cltypes.MatrixEntry, 128)
+			sidecars[i] = &cltypes.BlobSidecar{}
+		}
+		return newBlobRecoveryResult(nil, false, nil, nil, matrix, sidecars, uint64(count), 0, 0)
+	}
+
+	d := &peerdas{recoverBlobsQueue: make(chan recoverBlobsRequest, 1)}
+	fortyOne := resultForBlobs(41)
+	fortyTwo := resultForBlobs(42)
+	require.LessOrEqual(t, fortyOne.encodedBytes, maxBlobRecoveryResultBytes)
+	require.Greater(t, fortyTwo.encodedBytes, maxBlobRecoveryResultBytes)
+	require.True(t, d.cacheBlobRecoveryResult(common.Hash{41}, fortyOne))
+	require.False(t, d.cacheBlobRecoveryResult(common.Hash{42}, fortyTwo))
+}
+
+func TestBlobRecoveryResultCacheEvictionPreservesExactRetryOwnership(t *testing.T) {
+	resultForBlobs := func(count int) *blobRecoveryResult {
+		matrix := make([][]cltypes.MatrixEntry, count)
+		sidecars := make([]*cltypes.BlobSidecar, count)
+		for i := range count {
+			matrix[i] = make([]cltypes.MatrixEntry, 128)
+			sidecars[i] = &cltypes.BlobSidecar{}
+		}
+		return newBlobRecoveryResult(nil, false, nil, nil, matrix, sidecars, uint64(count), 0, 0)
+	}
+
+	d := &peerdas{recoverBlobsQueue: make(chan recoverBlobsRequest, 1)}
+	first := recoverBlobsRequest{slot: 1, blockRoot: common.Hash{1}}
+	second := recoverBlobsRequest{slot: 2, blockRoot: common.Hash{2}}
+	firstResult := resultForBlobs(21)
+	secondResult := resultForBlobs(21)
+	require.Less(t, firstResult.encodedBytes, maxBlobRecoveryResultBytes)
+	require.Less(t, secondResult.encodedBytes, maxBlobRecoveryResultBytes)
+	require.Greater(t, firstResult.encodedBytes+secondResult.encodedBytes, maxBlobRecoveryResultBytes)
+	require.True(t, d.delayBlobRecovery(first))
+	require.True(t, d.delayBlobRecovery(second))
+	require.True(t, d.cacheBlobRecoveryResult(first.blockRoot, firstResult))
+	require.True(t, d.cacheBlobRecoveryResult(second.blockRoot, secondResult))
+	require.NotContains(t, d.recoveryResults, first.blockRoot)
+	require.Contains(t, d.recoveryResults, second.blockRoot)
+	require.Contains(t, d.recoveryRetries, first.blockRoot)
+	require.Contains(t, d.recoveryRetries, second.blockRoot)
+	require.Contains(t, d.isRecovering, first.blockRoot)
+	require.Contains(t, d.isRecovering, second.blockRoot)
+	require.LessOrEqual(t, d.recoveryResultBytes, maxBlobRecoveryResultBytes)
+}
+
+func TestBlobsRecoverWorkerClearsQueuedOwnershipOnShutdown(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	blobStorage := blob_storage_mock_services.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(1), nil).AnyTimes()
+	d := &peerdas{
+		blobStorage:       blobStorage,
+		recoverBlobsQueue: make(chan recoverBlobsRequest, 2),
+		isRecovering:      make(map[common.Hash]bool),
+	}
+	require.NoError(t, d.enqueueBlobRecovery(recoverBlobsRequest{blockRoot: common.Hash{1}}))
+	require.NoError(t, d.enqueueBlobRecovery(recoverBlobsRequest{blockRoot: common.Hash{2}}))
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	d.blobsRecoverWorker(ctx)
+
+	require.Empty(t, d.isRecovering)
+	require.Empty(t, d.recoveryRequests)
+	require.Empty(t, d.recoveryGenerations)
+	require.Empty(t, d.recoveryRetries)
+	require.Empty(t, d.recoveryRetryQueue)
+	require.Empty(t, d.recoverySlots)
+	require.Empty(t, d.recoverySlotQueue)
+}
+
+func assertBlobsRecoverWorkerPrewriteUnavailable(t *testing.T, persistent bool) {
+	t.Helper()
+	cfg := clparams.MainnetBeaconConfig
+	cfg.FuluForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	block, root, sidecars, columns := recoverableFuluData(t, &cfg)
+	baseColumnStorage := blob_storage.NewDataColumnStore(afero.NewMemMapFs(), &cfg, beaconevents.NewEventEmitter())
+	columnStorage := &savedColumnReadCountingStorage{DataColumnStorage: baseColumnStorage}
+	for i := range (cfg.NumberOfColumns + 1) / 2 {
+		require.NoError(t, columnStorage.WriteColumnSidecars(t.Context(), root, int64(i), columns[i]))
+	}
+
+	ctrl := gomock.NewController(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	blobStorage := blob_storage_mock_services.NewMockBlobStorage(ctrl)
+	var countReads atomic.Int32
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), root).DoAndReturn(
+		func(context.Context, common.Hash) (uint32, error) {
+			if countReads.Add(1) == 1 {
+				return 0, nil
+			}
+			return uint32(len(sidecars)), nil
+		},
+	).AnyTimes()
+	var durableReads atomic.Int32
+	blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), block.Block.Slot, root).DoAndReturn(
+		func(context.Context, uint64, common.Hash) ([]*cltypes.BlobSidecar, bool, error) {
+			read := durableReads.Add(1)
+			if persistent || read == 1 {
+				if persistent && read == 2 {
+					cancel()
+				}
+				return nil, false, errors.New("prewrite storage unavailable")
+			}
+			return nil, false, nil
+		},
+	).AnyTimes()
+	writeAttempted := make(chan struct{})
+	var writeOnce sync.Once
+	blobStorage.EXPECT().WriteBlobSidecars(gomock.Any(), root, gomock.Any()).DoAndReturn(
+		func(context.Context, common.Hash, []*cltypes.BlobSidecar) error {
+			writeOnce.Do(func() { close(writeAttempted) })
+			cancel()
+			return errors.New("stop after observing recovery write")
+		},
+	).AnyTimes()
+
+	metadata, err := newBlobRecoveryMetadata(block, root)
+	require.NoError(t, err)
+	d := &peerdas{
+		beaconConfig:      &cfg,
+		columnStorage:     columnStorage,
+		blobStorage:       blobStorage,
+		recoverBlobsQueue: make(chan recoverBlobsRequest, 2),
+		isRecovering:      make(map[common.Hash]bool),
+	}
+	d.recoverBlobsQueue <- recoverBlobsRequest{slot: block.Block.Slot, blockRoot: root, metadata: metadata}
+	workerDone := make(chan struct{})
+	go func() {
+		d.blobsRecoverWorker(ctx)
+		close(workerDone)
+	}()
+	select {
+	case <-workerDone:
+	case <-time.After(30 * time.Second):
+		t.Fatal("blob recovery worker did not stop")
+	}
+	expectedReads := int32(3)
+	if persistent {
+		expectedReads = 2
+	}
+	require.Equal(t, expectedReads, durableReads.Load(), "prewrite validation must be paced and retain ownership")
+	require.Equal(t, int32(1), columnStorage.reads.Load(), "prewrite retry must reuse the completed reconstruction")
+	select {
+	case <-writeAttempted:
+		require.False(t, persistent, "persistent unavailable storage must not be overwritten")
+	default:
+		require.True(t, persistent, "finite transient outage dropped the recovery owner")
+	}
+}
+
+func TestRecoverBlobsRequestDoesNotRetainFullBlock(t *testing.T) {
+	blockType := reflect.TypeFor[cltypes.ColumnSyncableSignedBlock]()
+	requestType := reflect.TypeFor[recoverBlobsRequest]()
+	for i := range requestType.NumField() {
+		require.NotEqual(t, blockType, requestType.Field(i).Type, "recovery queue must not retain a full block")
+	}
+}
+
+func TestDownloadRequestDoesNotRetainFullBlock(t *testing.T) {
+	blockType := reflect.TypeFor[cltypes.ColumnSyncableSignedBlock]()
+	requestType := reflect.TypeFor[downloadRequest]()
+	for i := range requestType.NumField() {
+		fieldType := requestType.Field(i).Type
+		if fieldType.Kind() == reflect.Map {
+			require.NotEqual(t, blockType, fieldType.Elem(), "column download lifecycle must not retain full blocks")
+		}
+	}
+}
+
+func TestDownloadColumnsHashesBlockOncePerLifecycle(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	cfg := clparams.MainnetBeaconConfig
+	block := cltypes.NewSignedBeaconBlock(&cfg, clparams.FuluVersion)
+	block.Block.Slot = 100
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	root, err := block.Block.HashSSZ()
+	require.NoError(t, err)
+	counted := &blockHashCountingBlock{ColumnSyncableSignedBlock: block}
+
+	columnStorage := blob_storage_mock_services.NewMockDataColumnStorage(ctrl)
+	columnStorage.EXPECT().GetSavedColumnIndex(gomock.Any(), block.Block.Slot, root).Return(nil, nil).Times(2)
+	blobStorage := blob_storage_mock_services.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), root).Return(uint32(0), nil)
+	d := &peerdas{beaconConfig: &cfg, columnStorage: columnStorage, blobStorage: blobStorage}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	require.NoError(t, d.DownloadColumnsAndRecoverBlobs(ctx, []cltypes.ColumnSyncableSignedBlock{counted}))
+	require.Equal(t, int32(1), counted.calls.Load(), "block root must be reused across the download lifecycle")
+}
+
+func TestBlobRecoveryMetadataIsCompactImmutableAcrossBlockSchemas(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	tests := []struct {
+		name    string
+		version clparams.StateVersion
+		block   func() cltypes.ColumnSyncableSignedBlock
+	}{
+		{name: "fulu block", version: clparams.FuluVersion, block: func() cltypes.ColumnSyncableSignedBlock {
+			return cltypes.NewSignedBeaconBlock(&cfg, clparams.FuluVersion)
+		}},
+		{name: "fulu blinded block", version: clparams.FuluVersion, block: func() cltypes.ColumnSyncableSignedBlock {
+			return cltypes.NewSignedBlindedBeaconBlock(&cfg, clparams.FuluVersion)
+		}},
+		{name: "gloas block", version: clparams.GloasVersion, block: func() cltypes.ColumnSyncableSignedBlock {
+			return cltypes.NewSignedBeaconBlock(&cfg, clparams.GloasVersion)
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			block := test.block()
+			commitment := cltypes.KZGCommitment{1}
+			block.GetBlobKzgCommitments().Append(&commitment)
+			root, err := block.BlockHashSSZ()
+			require.NoError(t, err)
+
+			metadata, err := newBlobRecoveryMetadata(block, root)
+			require.NoError(t, err)
+			commitment[0] = 2
+
+			require.Equal(t, common.Hash(root), metadata.blockRoot)
+			require.Equal(t, block.GetSlot(), metadata.slot)
+			require.Equal(t, test.version, metadata.version)
+			require.Equal(t, byte(1), metadata.commitments[0][0], "metadata must own its copied commitment")
+		})
+	}
+}
+
+func TestBlobRecoveryMetadataRejectsWrongBlockSignature(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.FuluForkEpoch = 0
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	block, root, sidecars, _ := recoverableFuluData(t, &cfg)
+	sidecars[0].SignedBlockHeader.Signature[0] = 1
+	metadata, err := newBlobRecoveryMetadata(block, root)
+	require.NoError(t, err)
+
+	ctrl := gomock.NewController(t)
+	blobStorage := blob_storage_mock_services.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), block.Block.Slot, root).Return(sidecars, true, nil)
+	d := &peerdas{blobStorage: blobStorage}
+
+	require.Equal(t, blobRecoveryInvalid, d.validateStoredBlobRecoveryMetadata(t.Context(), metadata, uint32(len(sidecars))))
 }
 
 func TestIsExpectedColumnDownloadMiss(t *testing.T) {

--- a/cl/persistence/blob_storage/blob_db.go
+++ b/cl/persistence/blob_storage/blob_db.go
@@ -20,11 +20,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"io"
-	"math"
-	"os"
-	"strconv"
 	"sync"
 	"sync/atomic"
 
@@ -34,15 +30,9 @@ import (
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
-	"github.com/erigontech/erigon/cl/sentinel/communication/ssz_snappy"
-	"github.com/erigontech/erigon/cl/utils/eth_clock"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/crypto/kzg"
 	"github.com/erigontech/erigon/db/kv"
-)
-
-const (
-	subdivisionSlot = 10_000
 )
 
 //go:generate mockgen -typed=true -destination=./mock_services/blob_storage_mock.go -package=mock_services . BlobStorage
@@ -53,26 +43,20 @@ type BlobStorage interface {
 	BlobSidecarExists(ctx context.Context, slot uint64, blockRoot common.Hash, idx uint64) (bool, error)
 	WriteStream(w io.Writer, slot uint64, blockRoot common.Hash, idx uint64) error // Used for P2P networking
 	KzgCommitmentsCount(ctx context.Context, blockRoot common.Hash) (uint32, error)
-	Prune() error
+	PruneBelow(slot uint64) error
 }
 
 type BlobStore struct {
-	db                kv.RwDB
-	fs                afero.Fs
-	beaconChainConfig *clparams.BeaconChainConfig
-	ethClock          eth_clock.EthereumClock
-	slotsKept         uint64
+	bucketStore
+	slotLocks
+	db kv.RwDB
 }
 
-func NewBlobStore(db kv.RwDB, fs afero.Fs, slotsKept uint64, beaconChainConfig *clparams.BeaconChainConfig, ethClock eth_clock.EthereumClock) BlobStorage {
-	return &BlobStore{fs: fs, db: db, slotsKept: slotsKept, beaconChainConfig: beaconChainConfig, ethClock: ethClock}
-}
-
-func blobSidecarFilePath(slot, index uint64, blockRoot common.Hash) (folderpath, filepath string) {
-	subdir := slot / subdivisionSlot
-	folderpath = strconv.FormatUint(subdir, 10)
-	filepath = fmt.Sprintf("%s/%s_%d", folderpath, blockRoot.String(), index)
-	return
+func NewBlobStore(db kv.RwDB, fs afero.Fs) BlobStorage {
+	bs := &BlobStore{db: db}
+	bs.bucketStore.init(fs)
+	bs.slotLocks.initLocks()
+	return bs
 }
 
 /*
@@ -83,24 +67,39 @@ indicies:
 
 // WriteBlobSidecars writes the sidecars on the database. it assumes that all blobSidecars are for the same blockRoot and we have all of them.
 func (bs *BlobStore) WriteBlobSidecars(ctx context.Context, blockRoot common.Hash, blobSidecars []*cltypes.BlobSidecar) error {
-
-	for _, blobSidecar := range blobSidecars {
-		folderPath, filePath := blobSidecarFilePath(
-			blobSidecar.SignedBlockHeader.Header.Slot,
-			blobSidecar.Index, blockRoot)
-		// mkdir the whole folder and subfolders
-		bs.fs.MkdirAll(folderPath, 0755)
-		// create the file
-		file, err := bs.fs.Create(filePath)
+	// An empty batch writes no file, so it has no slot to lock on; it still records a
+	// zero count row, which is what tells "this block has no blobs" from "unknown".
+	if len(blobSidecars) > 0 {
+		var slot uint64
+		for index, sidecar := range blobSidecars {
+			if sidecar == nil || sidecar.SignedBlockHeader == nil || sidecar.SignedBlockHeader.Header == nil {
+				return errors.New("blob sidecar is missing its signed block header")
+			}
+			if index == 0 {
+				slot = sidecar.SignedBlockHeader.Header.Slot
+				continue
+			}
+			if sidecar.SignedBlockHeader.Header.Slot != slot {
+				return errors.New("blob sidecars span multiple slots")
+			}
+		}
+		lock := bs.forSlot(slot)
+		lock.Lock()
+		if !bs.startWrite(slot) {
+			lock.Unlock()
+			return nil
+		}
+		defer bs.finishWrite()
+		err := func() error {
+			defer lock.Unlock()
+			for _, blobSidecar := range blobSidecars {
+				if _, err := bs.writeAdmitted(blobSidecar.SignedBlockHeader.Header.Slot, blockRoot, blobSidecar.Index, blobSidecar); err != nil {
+					return err
+				}
+			}
+			return nil
+		}()
 		if err != nil {
-			return err
-		}
-		defer file.Close()
-
-		if err := ssz_snappy.EncodeAndWrite(file, blobSidecar); err != nil {
-			return err
-		}
-		if err := file.Sync(); err != nil {
 			return err
 		}
 	}
@@ -135,69 +134,39 @@ func (bs *BlobStore) ReadBlobSidecars(ctx context.Context, slot uint64, blockRoo
 	}
 	kzgCommitmentsLength := binary.LittleEndian.Uint32(val)
 
+	lock := bs.forSlot(slot)
+	lock.RLock()
+	defer lock.RUnlock()
+
 	var blobSidecars []*cltypes.BlobSidecar
 	for i := range kzgCommitmentsLength {
-		_, filePath := blobSidecarFilePath(slot, uint64(i), blockRoot)
-		file, err := bs.fs.Open(filePath)
+		blobSidecar := &cltypes.BlobSidecar{}
+		found, err := bs.read(slot, blockRoot, uint64(i), blobSidecar, clparams.DenebVersion)
 		if err != nil {
-			if errors.Is(err, afero.ErrFileNotFound) {
-				return nil, false, nil
-			}
 			return nil, false, err
 		}
-		defer file.Close()
-
-		blobSidecar := &cltypes.BlobSidecar{}
-		if err := ssz_snappy.DecodeAndReadNoForkDigest(file, blobSidecar, clparams.DenebVersion); err != nil {
-			return nil, false, err
+		if !found {
+			return nil, false, nil
 		}
 		blobSidecars = append(blobSidecars, blobSidecar)
 	}
 	return blobSidecars, true, nil
 }
 
-// Do a bit of pruning
-func (bs *BlobStore) Prune() error {
-	if bs.slotsKept == math.MaxUint64 {
-		return nil
-	}
-
-	currentSlot := bs.ethClock.GetCurrentSlot()
-	if currentSlot <= bs.slotsKept {
-		return nil
-	}
-	currentSlot -= bs.slotsKept
-	currentSlot = (currentSlot / subdivisionSlot) * subdivisionSlot
-	// delete all the folders that are older than slotsKept
-	for i := uint64(0); i < currentSlot; i += subdivisionSlot {
-		bs.fs.RemoveAll(strconv.FormatUint(i/subdivisionSlot, 10))
-	}
-	return nil
+func (bs *BlobStore) PruneBelow(slot uint64) error {
+	return bs.pruneBelow(slot)
 }
 
 func (bs *BlobStore) BlobSidecarExists(ctx context.Context, slot uint64, blockRoot common.Hash, idx uint64) (bool, error) {
-	_, filePath := blobSidecarFilePath(slot, idx, blockRoot)
-	_, err := bs.fs.Stat(filePath)
-	if os.IsNotExist(err) {
-		return false, nil
-	} else if err != nil {
-		return false, err
-	}
-	return true, nil
+	return bs.exists(slot, blockRoot, idx)
 }
+
 func (bs *BlobStore) WriteStream(w io.Writer, slot uint64, blockRoot common.Hash, idx uint64) error {
-	_, filePath := blobSidecarFilePath(slot, idx, blockRoot)
-	file, err := bs.fs.Open(filePath)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-	_, err = io.Copy(w, file)
-	return err
+	return bs.stream(w, slot, blockRoot, idx)
 }
 
 func (bs *BlobStore) KzgCommitmentsCount(ctx context.Context, blockRoot common.Hash) (uint32, error) {
-	tx, err := bs.db.BeginRo(context.Background())
+	tx, err := bs.db.BeginRo(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -213,6 +182,10 @@ func (bs *BlobStore) KzgCommitmentsCount(ctx context.Context, blockRoot common.H
 }
 
 func (bs *BlobStore) RemoveBlobSidecars(ctx context.Context, slot uint64, blockRoot common.Hash) error {
+	lock := bs.forSlot(slot)
+	lock.Lock()
+	defer lock.Unlock()
+
 	tx, err := bs.db.BeginRw(ctx)
 	if err != nil {
 		return err
@@ -226,14 +199,24 @@ func (bs *BlobStore) RemoveBlobSidecars(ctx context.Context, slot uint64, blockR
 		return nil
 	}
 	kzgCommitmentsLength := binary.LittleEndian.Uint32(val)
+	var firstErr error
 	for i := range kzgCommitmentsLength {
-		_, filePath := blobSidecarFilePath(slot, uint64(i), blockRoot)
-		if err := bs.fs.Remove(filePath); err != nil {
-			return err
+		if err := bs.remove(slot, blockRoot, uint64(i)); err != nil && firstErr == nil {
+			firstErr = err
 		}
 	}
-	tx.Delete(kv.BlockRootToKzgCommitments, blockRoot[:])
-	return tx.Commit()
+	// Drop the row even after a partial failure: a file missing under a surviving row reads as
+	// unavailable forever, but a dropped row reads as unknown and lets the block be re-fetched.
+	if err := tx.Delete(kv.BlockRootToKzgCommitments, blockRoot[:]); err != nil {
+		if firstErr == nil {
+			firstErr = err
+		}
+		return firstErr
+	}
+	if err := tx.Commit(); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
 }
 
 type sidecarsPayload struct {
@@ -242,6 +225,36 @@ type sidecarsPayload struct {
 }
 
 type verifyHeaderSignatureFn func(header *cltypes.SignedBeaconBlockHeader) error
+
+// VerifyBlobSidecars validates sidecar proofs and optionally their signed headers.
+func VerifyBlobSidecars(sidecars []*cltypes.BlobSidecar, version clparams.StateVersion, verifySignatureFn func(*cltypes.SignedBeaconBlockHeader) error) error {
+	if len(sidecars) == 0 {
+		return nil
+	}
+	blobs := make([]*goethkzg.Blob, len(sidecars))
+	commitments := make([]goethkzg.KZGCommitment, len(sidecars))
+	proofs := make([]goethkzg.KZGProof, len(sidecars))
+	for i, sidecar := range sidecars {
+		if sidecar == nil || sidecar.SignedBlockHeader == nil || sidecar.SignedBlockHeader.Header == nil {
+			return errors.New("blob response contains incomplete sidecar")
+		}
+		if version < clparams.GloasVersion && !cltypes.VerifyCommitmentInclusionProof(sidecar.KzgCommitment, sidecar.CommitmentInclusionProof, sidecar.Index, clparams.DenebVersion, sidecar.SignedBlockHeader.Header.BodyRoot) {
+			return errors.New("could not verify blob's inclusion proof")
+		}
+		if verifySignatureFn != nil {
+			if err := verifySignatureFn(sidecar.SignedBlockHeader); err != nil {
+				return err
+			}
+		}
+		blobs[i] = (*goethkzg.Blob)(&sidecar.Blob)
+		commitments[i] = goethkzg.KZGCommitment(sidecar.KzgCommitment)
+		proofs[i] = goethkzg.KZGProof(sidecar.KzgProof)
+	}
+	if err := kzg.Ctx().VerifyBlobKZGProofBatch(blobs, commitments, proofs); err != nil {
+		return errors.New("sidecar is wrong")
+	}
+	return nil
+}
 
 // VerifyAgainstIdentifiersAndInsertIntoTheBlobStore does all due verification for blobs before database insertion. it also returns the latest correctly return blob.
 func VerifyAgainstIdentifiersAndInsertIntoTheBlobStore(ctx context.Context, storage BlobStorage, identifiers *solid.ListSSZ[*cltypes.BlobIdentifier], sidecars []*cltypes.BlobSidecar, verifySignatureFn verifyHeaderSignatureFn) (uint64, uint64, error) {

--- a/cl/persistence/blob_storage/blob_db_test.go
+++ b/cl/persistence/blob_storage/blob_db_test.go
@@ -18,8 +18,14 @@ package blob_storage
 
 import (
 	"context"
+	"runtime"
+	"slices"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
+	goethkzg "github.com/crate-crypto/go-eth-kzg"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 
@@ -27,10 +33,30 @@ import (
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/crypto/kzg"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/dbcfg"
 	"github.com/erigontech/erigon/db/kv/memdb"
 )
+
+func TestVerifyBlobSidecarsGloasDoesNotRequireInclusionProof(t *testing.T) {
+	blob := goethkzg.Blob{}
+	commitment, err := kzg.Ctx().BlobToKZGCommitment(&blob, 0)
+	require.NoError(t, err)
+	proof, err := kzg.Ctx().ComputeBlobKZGProof(&blob, commitment, 0)
+	require.NoError(t, err)
+	sidecar := cltypes.NewBlobSidecar(
+		0,
+		(*cltypes.Blob)(&blob),
+		common.Bytes48(commitment),
+		common.Bytes48(proof),
+		&cltypes.SignedBeaconBlockHeader{Header: &cltypes.BeaconBlockHeader{}},
+		solid.NewHashVector(cltypes.CommitmentBranchSize),
+	)
+
+	require.NoError(t, VerifyBlobSidecars([]*cltypes.BlobSidecar{sidecar}, clparams.GloasVersion, nil))
+	require.Error(t, VerifyBlobSidecars([]*cltypes.BlobSidecar{sidecar}, clparams.FuluVersion, nil))
+}
 
 func setupTestDB(t *testing.T) kv.RwDB {
 	db := memdb.NewTestDB(t, dbcfg.ChainDB)
@@ -45,7 +71,7 @@ func TestBlobDB(t *testing.T) {
 	s2 := cltypes.NewBlobSidecar(1, &cltypes.Blob{3}, common.Bytes48{5}, common.Bytes48{9}, &cltypes.SignedBeaconBlockHeader{Header: &cltypes.BeaconBlockHeader{Slot: 1}}, solid.NewHashVector(cltypes.CommitmentBranchSize))
 
 	//
-	bs := NewBlobStore(db, afero.NewMemMapFs(), 12, &clparams.MainnetBeaconConfig, nil)
+	bs := NewBlobStore(db, afero.NewMemMapFs())
 	blockRoot := common.Hash{1}
 	err := bs.WriteBlobSidecars(context.Background(), blockRoot, []*cltypes.BlobSidecar{s1, s2})
 	require.NoError(t, err)
@@ -67,4 +93,349 @@ func TestBlobDB(t *testing.T) {
 	require.Equal(t, s2.KzgProof, sidecars[1].KzgProof)
 	require.Equal(t, s1.SignedBlockHeader, sidecars[0].SignedBlockHeader)
 	require.Equal(t, s2.SignedBlockHeader, sidecars[1].SignedBlockHeader)
+}
+
+func TestBlobStorePruneFloorRejectsLateWritesAndAllowsCleanup(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	bs := NewBlobStore(db, afero.NewMemMapFs())
+	existingRoot := common.Hash{1}
+	require.NoError(t, bs.WriteBlobSidecars(t.Context(), existingRoot, []*cltypes.BlobSidecar{testSidecar(100, 0, 1)}))
+
+	require.NoError(t, bs.PruneBelow(500))
+	require.NoError(t, bs.RemoveBlobSidecars(t.Context(), 100, existingRoot))
+	_, found, err := bs.ReadBlobSidecars(t.Context(), 100, existingRoot)
+	require.NoError(t, err)
+	require.False(t, found, "cleanup removes must still clear the stale commitment row below the write floor")
+
+	lateRoot := common.Hash{2}
+	require.NoError(t, bs.WriteBlobSidecars(t.Context(), lateRoot, []*cltypes.BlobSidecar{testSidecar(499, 0, 2)}))
+	count, err := bs.KzgCommitmentsCount(t.Context(), lateRoot)
+	require.NoError(t, err)
+	require.Zero(t, count, "a rejected write must not publish a count without files")
+	_, found, err = bs.ReadBlobSidecars(t.Context(), 499, lateRoot)
+	require.NoError(t, err)
+	require.False(t, found)
+
+	boundaryRoot := common.Hash{3}
+	require.NoError(t, bs.WriteBlobSidecars(t.Context(), boundaryRoot, []*cltypes.BlobSidecar{testSidecar(500, 0, 3)}))
+	_, found, err = bs.ReadBlobSidecars(t.Context(), 500, boundaryRoot)
+	require.NoError(t, err)
+	require.True(t, found, "the floor itself remains writable")
+}
+
+type blockingBlobRemoveFs struct {
+	afero.Fs
+	path    string
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (f *blockingBlobRemoveFs) Remove(path string) error {
+	if path == f.path {
+		f.once.Do(func() { close(f.entered) })
+		<-f.release
+	}
+	return f.Fs.Remove(path)
+}
+
+func TestBlobStoreWriterWaitingForSlotDoesNotBlockPrune(t *testing.T) {
+	previousProcs := runtime.GOMAXPROCS(1)
+	defer runtime.GOMAXPROCS(previousProcs)
+
+	db := setupTestDB(t)
+	defer db.Close()
+	fs := &blockingBlobRemoveFs{
+		Fs:      afero.NewMemMapFs(),
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	storage := NewBlobStore(db, fs)
+	bs := storage.(*BlobStore)
+	const slot = 2*subdivisionSlot + 1
+	oldRoot, lateRoot := common.Hash{1}, common.Hash{2}
+	releaseRemove := sync.OnceFunc(func() { close(fs.release) })
+	defer releaseRemove()
+
+	require.NoError(t, storage.WriteBlobSidecars(t.Context(), oldRoot, []*cltypes.BlobSidecar{testSidecar(slot, 0, 1)}))
+	require.NoError(t, fs.MkdirAll("0", 0o755))
+	_, fs.path = bs.path(slot, oldRoot, 0)
+
+	removeDone := make(chan error, 1)
+	go func() { removeDone <- storage.RemoveBlobSidecars(context.Background(), slot, oldRoot) }()
+	<-fs.entered
+
+	writerCtx, cancelWriter := context.WithCancel(t.Context())
+	t.Cleanup(cancelWriter)
+	writerStarted := make(chan struct{})
+	writerDone := make(chan error, 1)
+	go func() {
+		close(writerStarted)
+		writerDone <- storage.WriteBlobSidecars(writerCtx, lateRoot, []*cltypes.BlobSidecar{testSidecar(slot, 0, 2)})
+	}()
+	<-writerStarted
+	runtime.Gosched()
+	select {
+	case err := <-writerDone:
+		t.Fatalf("writer completed instead of waiting for the remove-held slot lock: %v", err)
+	default:
+	}
+	cancelWriter()
+
+	pruneDone := make(chan error, 1)
+	go func() { pruneDone <- storage.PruneBelow(slot + 1) }()
+	select {
+	case err := <-pruneDone:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("a writer waiting for a slot lock blocked prune-floor advancement")
+	}
+	select {
+	case err := <-removeDone:
+		t.Fatalf("remove completed before its filesystem gate was released: %v", err)
+	default:
+	}
+
+	releaseRemove()
+	require.NoError(t, <-removeDone)
+	require.NoError(t, <-writerDone)
+	count, err := storage.KzgCommitmentsCount(t.Context(), lateRoot)
+	require.NoError(t, err)
+	require.Zero(t, count)
+	exists, err := storage.BlobSidecarExists(t.Context(), slot, lateRoot, 0)
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
+func TestBlobStoreRejectsMixedSlotBatchAcrossPruneFloor(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	bs := NewBlobStore(db, afero.NewMemMapFs())
+	require.NoError(t, bs.PruneBelow(500))
+	root := common.Hash{1}
+
+	err := bs.WriteBlobSidecars(t.Context(), root, []*cltypes.BlobSidecar{
+		testSidecar(500, 0, 1),
+		testSidecar(499, 1, 2),
+	})
+	require.Error(t, err)
+	count, err := bs.KzgCommitmentsCount(t.Context(), root)
+	require.NoError(t, err)
+	require.Zero(t, count)
+	for _, slot := range []uint64{499, 500} {
+		for index := range uint64(2) {
+			exists, err := bs.BlobSidecarExists(t.Context(), slot, root, index)
+			require.NoError(t, err)
+			require.False(t, exists)
+		}
+	}
+}
+
+func TestBlobStoreRejectsMissingHeadersBeforeMutation(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	bs := NewBlobStore(db, afero.NewMemMapFs())
+	root := common.Hash{1}
+
+	for _, sidecar := range []*cltypes.BlobSidecar{
+		nil,
+		{},
+		{SignedBlockHeader: &cltypes.SignedBeaconBlockHeader{}},
+	} {
+		require.Error(t, bs.WriteBlobSidecars(t.Context(), root, []*cltypes.BlobSidecar{sidecar}))
+	}
+	count, err := bs.KzgCommitmentsCount(t.Context(), root)
+	require.NoError(t, err)
+	require.Zero(t, count)
+}
+
+type createOrderFs struct {
+	afero.Fs
+	mu      sync.Mutex
+	creates []string
+	hook    func(name string)
+}
+
+func newCreateOrderFs(fs afero.Fs) *createOrderFs {
+	return &createOrderFs{Fs: fs}
+}
+
+func (c *createOrderFs) Create(name string) (afero.File, error) {
+	c.mu.Lock()
+	c.creates = append(c.creates, name)
+	hook := c.hook
+	c.mu.Unlock()
+	if hook != nil {
+		hook(name)
+	}
+	return c.Fs.Create(name)
+}
+
+func (c *createOrderFs) order() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return slices.Clone(c.creates)
+}
+
+func TestBlobStoreRemoveSucceedsWhenAFileIsAlreadyGone(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	fs := afero.NewMemMapFs()
+	bs := NewBlobStore(db, fs)
+	root := common.Hash{4}
+	const slot = 12_345
+
+	require.NoError(t, bs.WriteBlobSidecars(t.Context(), root, []*cltypes.BlobSidecar{
+		testSidecar(slot, 0, 1), testSidecar(slot, 1, 2),
+	}))
+
+	b := newBucketStore(t, fs)
+	_, first := b.path(slot, root, 0)
+	require.NoError(t, fs.Remove(first))
+
+	require.NoError(t, bs.RemoveBlobSidecars(t.Context(), slot, root))
+
+	_, second := b.path(slot, root, 1)
+	stillThere, err := afero.Exists(fs, second)
+	require.NoError(t, err)
+	require.False(t, stillThere)
+
+	_, found, err := bs.ReadBlobSidecars(t.Context(), slot, root)
+	require.NoError(t, err)
+	require.False(t, found)
+}
+
+func TestBlobStoreRemoveDropsTheCountRowDespiteAFailureOnAMiddleIndex(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	fs := newRemoveFailingFs(afero.NewMemMapFs())
+	bs := NewBlobStore(db, fs)
+	root := common.Hash{6}
+	const slot = 12_345
+
+	require.NoError(t, bs.WriteBlobSidecars(t.Context(), root, []*cltypes.BlobSidecar{
+		testSidecar(slot, 0, 1), testSidecar(slot, 1, 2), testSidecar(slot, 2, 3),
+	}))
+
+	b := newBucketStore(t, fs)
+	_, failPath := b.path(slot, root, 1)
+	fs.failOn[failPath] = errInducedFailure
+
+	err := bs.RemoveBlobSidecars(t.Context(), slot, root)
+	require.ErrorIs(t, err, errInducedFailure)
+
+	tx, err := db.BeginRo(t.Context())
+	require.NoError(t, err)
+	defer tx.Rollback()
+	val, err := tx.GetOne(kv.BlockRootToKzgCommitments, root[:])
+	require.NoError(t, err)
+	require.Empty(t, val, "the count row should be dropped so the block reads as unknown, not permanently unavailable")
+}
+
+func TestBlobStoreBatchWriteDoesNotInterleaveWithAConcurrentWrite(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	fs := newCreateOrderFs(afero.NewMemMapFs())
+	bs := NewBlobStore(db, fs)
+
+	const slot = 100
+	batchRoot, otherRoot := common.Hash{1}, common.Hash{2}
+
+	entered := make(chan struct{})
+	var once sync.Once
+	fs.hook = func(name string) {
+		if !strings.Contains(name, batchRoot.String()) {
+			return
+		}
+		once.Do(func() {
+			close(entered)
+			time.Sleep(200 * time.Millisecond)
+		})
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- bs.WriteBlobSidecars(context.Background(), batchRoot, []*cltypes.BlobSidecar{
+			testSidecar(slot, 0, 1), testSidecar(slot, 1, 2), testSidecar(slot, 2, 3),
+		})
+	}()
+
+	<-entered
+	require.NoError(t, bs.WriteBlobSidecars(t.Context(), otherRoot, []*cltypes.BlobSidecar{testSidecar(slot, 0, 4)}))
+	require.NoError(t, <-done)
+
+	order := fs.order()
+	lastOfBatch := -1
+	for i, name := range order {
+		if strings.Contains(name, batchRoot.String()) {
+			lastOfBatch = i
+		}
+	}
+	other := slices.IndexFunc(order, func(name string) bool { return strings.Contains(name, otherRoot.String()) })
+	require.Positive(t, other)
+	require.Greater(t, other, lastOfBatch, "concurrent write interleaved with the batch: %v", order)
+}
+
+func TestBlobStoreReadReturnsACompletedWrite(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	bs := NewBlobStore(db, afero.NewMemMapFs())
+	root := common.Hash{9}
+	const slot = 54_321
+
+	want := []*cltypes.BlobSidecar{testSidecar(slot, 0, 5), testSidecar(slot, 1, 6)}
+	require.NoError(t, bs.WriteBlobSidecars(t.Context(), root, want))
+
+	got, found, err := bs.ReadBlobSidecars(t.Context(), slot, root)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Len(t, got, len(want))
+	for i := range want {
+		require.Equal(t, want[i].Blob, got[i].Blob)
+	}
+}
+
+func TestBlobStoreEmptyBatchRecordsItsZeroRowWithoutLocking(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	bs := NewBlobStore(db, afero.NewMemMapFs()).(*BlobStore)
+	root := common.Hash{3}
+
+	for i := range bs.locks {
+		bs.locks[i].Lock()
+	}
+	done := make(chan error, 1)
+	go func() { done <- bs.WriteBlobSidecars(context.Background(), root, nil) }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("an empty batch took a slot lock")
+	}
+	for i := range bs.locks {
+		bs.locks[i].Unlock()
+	}
+
+	sidecars, found, err := bs.ReadBlobSidecars(t.Context(), 0, root)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Empty(t, sidecars)
+}
+
+func TestKzgCommitmentsCountHonorsCanceledContext(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	bs := NewBlobStore(db, afero.NewMemMapFs())
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := bs.KzgCommitmentsCount(ctx, common.Hash{})
+	require.ErrorIs(t, err, context.Canceled)
 }

--- a/cl/persistence/blob_storage/bucket_store.go
+++ b/cl/persistence/blob_storage/bucket_store.go
@@ -1,0 +1,297 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package blob_storage
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"sync"
+
+	"github.com/spf13/afero"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/sentinel/communication/ssz_snappy"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/common/ssz"
+)
+
+const (
+	subdivisionSlot = 10_000
+	rwLocksCount    = 64
+	tmpSuffix       = ".tmp"
+)
+
+// ErrPruneNotStarted reports that pruning failed before any bucket was attempted, so the
+// store still holds everything the caller was about to stop advertising.
+var ErrPruneNotStarted = errors.New("prune did not start")
+
+// bucketStore holds sidecars under <slot/subdivisionSlot>/<blockRoot>_<index>.
+//
+// The caller picks the slot granularity. Reads need none: a write lands by rename, so a
+// reader sees the old file or the new one and never a partial. Writes do — see write.
+type bucketStore struct {
+	fs         afero.Fs
+	pruneMutex sync.RWMutex
+	pruneFloor uint64
+	// bucketLocks order a write into a bucket against pruneBelow removing that bucket. The
+	// slot stripe locks cannot: one bucket spans subdivisionSlot slots.
+	bucketLocks []sync.RWMutex
+}
+
+func (b *bucketStore) init(fs afero.Fs) {
+	b.fs = fs
+	b.bucketLocks = make([]sync.RWMutex, rwLocksCount)
+}
+
+func (b *bucketStore) forBucket(bucket uint64) *sync.RWMutex {
+	return &b.bucketLocks[bucket%rwLocksCount]
+}
+
+func (b *bucketStore) path(slot uint64, root common.Hash, idx uint64) (dir, file string) {
+	dir = strconv.FormatUint(slot/subdivisionSlot, 10)
+	file = fmt.Sprintf("%s/%s_%d", dir, root.String(), idx)
+	return dir, file
+}
+
+func (b *bucketStore) startWrite(slot uint64) bool {
+	b.pruneMutex.RLock()
+	if slot < b.pruneFloor {
+		b.pruneMutex.RUnlock()
+		return false
+	}
+	return true
+}
+
+func (b *bucketStore) finishWrite() {
+	b.pruneMutex.RUnlock()
+}
+
+// write encodes v onto a temp file and renames it onto the target, so a failure
+// never leaves a partial file where a reader would take it for a complete one.
+// created reports whether the target was absent beforehand.
+//
+// The temp name is derived from the target alone, so two writes of the same
+// (slot, root, idx) would share it and interleave into one file. Callers must
+// hold that slot's lock.
+func (b *bucketStore) write(slot uint64, root common.Hash, idx uint64, v ssz.Marshaler) (bool, error) {
+	if !b.startWrite(slot) {
+		return false, nil
+	}
+	defer b.finishWrite()
+	return b.writeAdmitted(slot, root, idx, v)
+}
+
+func (b *bucketStore) writeAdmitted(slot uint64, root common.Hash, idx uint64, v ssz.Marshaler) (bool, error) {
+	l := b.forBucket(slot / subdivisionSlot)
+	l.RLock()
+	defer l.RUnlock()
+	dir, file := b.path(slot, root, idx)
+	created := false
+	if _, err := b.fs.Stat(file); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return false, err
+		}
+		created = true
+	}
+	if err := b.fs.MkdirAll(dir, 0o755); err != nil {
+		return false, err
+	}
+	tmp := file + tmpSuffix
+	if err := b.encodeTo(tmp, v); err != nil {
+		b.removeTemp(tmp)
+		return false, err
+	}
+	if err := b.fs.Rename(tmp, file); err != nil {
+		b.removeTemp(tmp)
+		if created || !isSharingViolation(err) {
+			return false, err
+		}
+		// Windows replaces via MoveFileEx, which needs delete access to the destination,
+		// so this fails while another goroutine holds the target open for reading. A
+		// sidecar is determined by its (slot, root, idx), so a target still in place is
+		// the one this write would have produced; a target that is gone stored nothing.
+		if _, statErr := b.fs.Stat(file); statErr != nil {
+			return false, err
+		}
+		return false, nil
+	}
+	return created, nil
+}
+
+// removeTemp best-effort deletes the temp file; the caller already holds the
+// real error.
+func (b *bucketStore) removeTemp(tmp string) {
+	if err := b.fs.Remove(tmp); err != nil && !errors.Is(err, os.ErrNotExist) {
+		log.Debug("failed to remove temp file after write failure", "path", tmp, "err", err)
+	}
+}
+
+func (b *bucketStore) encodeTo(path string, v ssz.Marshaler) error {
+	fh, err := b.fs.Create(path)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+	// EncodeAndWrite flushes in a defer and discards that error, so a short write is
+	// only observable on the writer it was handed.
+	w := &errWriter{w: fh}
+	if err := ssz_snappy.EncodeAndWrite(w, v); err != nil {
+		return err
+	}
+	if w.err != nil {
+		return w.err
+	}
+	if err := fh.Sync(); err != nil {
+		return err
+	}
+	return fh.Close()
+}
+
+// read decodes the stored sidecar into out. A missing file is reported as not found,
+// leaving each caller to decide what absence means.
+func (b *bucketStore) read(slot uint64, root common.Hash, idx uint64, out ssz.EncodableSSZ, version clparams.StateVersion) (bool, error) {
+	_, file := b.path(slot, root, idx)
+	fh, err := b.fs.Open(file)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	defer fh.Close()
+	if err := ssz_snappy.DecodeAndReadNoForkDigest(fh, out, version); err != nil {
+		// A sidecar that will not decode is a truncated pre-rename write; reporting it absent
+		// lets the caller re-fetch and overwrite it, which returning the error never does.
+		log.Warn("[blob_storage] discarding undecodable sidecar", "file", file, "err", err)
+		return false, nil
+	}
+	return true, nil
+}
+
+func (b *bucketStore) exists(slot uint64, root common.Hash, idx uint64) (bool, error) {
+	_, file := b.path(slot, root, idx)
+	if _, err := b.fs.Stat(file); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func (b *bucketStore) remove(slot uint64, root common.Hash, idx uint64) error {
+	_, file := b.path(slot, root, idx)
+	if err := b.fs.Remove(file); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+func (b *bucketStore) stream(w io.Writer, slot uint64, root common.Hash, idx uint64) error {
+	_, file := b.path(slot, root, idx)
+	fh, err := b.fs.Open(file)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+	_, err = io.Copy(w, fh)
+	return err
+}
+
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (e *errWriter) Write(p []byte) (int, error) {
+	n, err := e.w.Write(p)
+	if err == nil && n < len(p) {
+		err = io.ErrShortWrite
+	}
+	if err != nil && e.err == nil {
+		e.err = err
+	}
+	return n, err
+}
+
+// pruneBelow removes every bucket that ends before slot. It attempts all of them and
+// returns the first failure, so one bucket that cannot be removed — an open file blocks
+// its directory on Windows — does not stop the rest.
+func (b *bucketStore) pruneBelow(slot uint64) error {
+	if slot == 0 {
+		return nil
+	}
+	b.pruneMutex.Lock()
+	entries, err := afero.ReadDir(b.fs, ".")
+	if err != nil {
+		b.pruneMutex.Unlock()
+		return fmt.Errorf("%w: %w", ErrPruneNotStarted, err)
+	}
+	if slot > b.pruneFloor {
+		b.pruneFloor = slot
+	}
+	effectiveFloor := b.pruneFloor
+	b.pruneMutex.Unlock()
+
+	cutoff := effectiveFloor / subdivisionSlot
+	if cutoff == 0 {
+		return nil
+	}
+	var firstErr error
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		bucket, err := strconv.ParseUint(name, 10, 64)
+		// The blob index database is a sibling of the buckets in this directory, so only
+		// a name this store could itself have produced may be removed.
+		if err != nil || strconv.FormatUint(bucket, 10) != name {
+			continue
+		}
+		if bucket >= cutoff {
+			continue
+		}
+		if err := b.removeBucket(bucket, name); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (b *bucketStore) removeBucket(bucket uint64, name string) error {
+	l := b.forBucket(bucket)
+	l.Lock()
+	defer l.Unlock()
+	return b.fs.RemoveAll(name)
+}
+
+type slotLocks struct {
+	locks []sync.RWMutex
+}
+
+func (s *slotLocks) initLocks() {
+	s.locks = make([]sync.RWMutex, rwLocksCount)
+}
+
+func (s *slotLocks) forSlot(slot uint64) *sync.RWMutex {
+	return &s.locks[slot%rwLocksCount]
+}

--- a/cl/persistence/blob_storage/bucket_store_test.go
+++ b/cl/persistence/blob_storage/bucket_store_test.go
@@ -1,0 +1,790 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package blob_storage
+
+import (
+	"bytes"
+	"io"
+	"path/filepath"
+	"slices"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/beacon/beaconevents"
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/common"
+)
+
+type removeAllFailingFs struct {
+	afero.Fs
+	failOn map[string]error
+}
+
+func newRemoveAllFailingFs(fs afero.Fs) *removeAllFailingFs {
+	return &removeAllFailingFs{Fs: fs, failOn: map[string]error{}}
+}
+
+func (r *removeAllFailingFs) RemoveAll(path string) error {
+	if err, ok := r.failOn[path]; ok {
+		return err
+	}
+	return r.Fs.RemoveAll(path)
+}
+
+func newBucketStore(t *testing.T, fs afero.Fs) *bucketStore {
+	t.Helper()
+	b := &bucketStore{}
+	b.init(fs)
+	return b
+}
+
+func makeBuckets(t *testing.T, fs afero.Fs, names ...string) {
+	t.Helper()
+	for _, name := range names {
+		require.NoError(t, fs.MkdirAll(name, 0o755))
+	}
+}
+
+func rootEntryNames(t *testing.T, fs afero.Fs) []string {
+	t.Helper()
+	entries, err := afero.ReadDir(fs, ".")
+	require.NoError(t, err)
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	slices.Sort(names)
+	return names
+}
+
+func TestBucketStorePath(t *testing.T) {
+	b := newBucketStore(t, afero.NewMemMapFs())
+	root := common.HexToHash("0x1234567890abcdef")
+	const rootHex = "0x0000000000000000000000000000000000000000000000001234567890abcdef"
+
+	for _, tc := range []struct {
+		name     string
+		slot     uint64
+		idx      uint64
+		wantDir  string
+		wantFile string
+	}{
+		{name: "first bucket", slot: 1000, idx: 2, wantDir: "0", wantFile: "0/" + rootHex + "_2"},
+		{name: "bucket boundary", slot: subdivisionSlot, idx: 0, wantDir: "1", wantFile: "1/" + rootHex + "_0"},
+		{name: "last slot of bucket", slot: 2*subdivisionSlot - 1, idx: 127, wantDir: "1", wantFile: "1/" + rootHex + "_127"},
+		{name: "deep bucket", slot: 12_345_678, idx: 5, wantDir: "1234", wantFile: "1234/" + rootHex + "_5"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir, file := b.path(tc.slot, root, tc.idx)
+			require.Equal(t, tc.wantDir, dir)
+			require.Equal(t, tc.wantFile, file)
+		})
+	}
+}
+
+func TestBucketStorePruneBelowRemovesOnlyExpiredBuckets(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	b := newBucketStore(t, fs)
+	makeBuckets(t, fs, "0", "1", "2", "3", "4")
+
+	require.NoError(t, b.pruneBelow(3*subdivisionSlot))
+
+	require.Equal(t, []string{"3", "4"}, rootEntryNames(t, fs))
+}
+
+func TestBucketStorePruneBelowKeepsTheBucketHoldingTheFloor(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	b := newBucketStore(t, fs)
+	makeBuckets(t, fs, "0", "1", "2")
+
+	require.NoError(t, b.pruneBelow(2*subdivisionSlot+4321))
+
+	require.Equal(t, []string{"2"}, rootEntryNames(t, fs))
+}
+
+func TestBucketStorePruneBelowIsIdempotent(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	b := newBucketStore(t, fs)
+	makeBuckets(t, fs, "0", "1", "2")
+	require.NoError(t, afero.WriteFile(fs, "2/kept", []byte("payload"), 0o644))
+
+	require.NoError(t, b.pruneBelow(2*subdivisionSlot))
+	require.NoError(t, b.pruneBelow(2*subdivisionSlot))
+
+	require.Equal(t, []string{"2"}, rootEntryNames(t, fs))
+	content, err := afero.ReadFile(fs, "2/kept")
+	require.NoError(t, err)
+	require.Equal(t, []byte("payload"), content)
+}
+
+// The blob index database lives in the store root as a sibling of the buckets, so a
+// pruner that treats any directory as a bucket deletes it on the first tick.
+func TestBucketStorePruneBelowKeepsTheBlobDatabase(t *testing.T) {
+	fs := afero.NewBasePathFs(afero.NewOsFs(), t.TempDir())
+	b := newBucketStore(t, fs)
+	makeBuckets(t, fs, "0", "1", "chaindata", "0x", "12a", " 7", "007")
+	require.NoError(t, afero.WriteFile(fs, "chaindata/mdbx.dat", []byte("database"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, "5", []byte("not a bucket"), 0o644))
+
+	require.NoError(t, b.pruneBelow(1000*subdivisionSlot))
+
+	require.Equal(t, []string{" 7", "007", "0x", "12a", "5", "chaindata"}, rootEntryNames(t, fs))
+	content, err := afero.ReadFile(fs, "chaindata/mdbx.dat")
+	require.NoError(t, err)
+	require.Equal(t, []byte("database"), content)
+}
+
+func TestBucketStorePruneBelowZeroRemovesNothing(t *testing.T) {
+	fs := newCountingFs(afero.NewMemMapFs())
+	b := newBucketStore(t, fs)
+	makeBuckets(t, fs, "0", "1", "2")
+
+	require.NoError(t, b.pruneBelow(0))
+
+	require.Equal(t, []string{"0", "1", "2"}, rootEntryNames(t, fs))
+	require.Zero(t, fs.count(opRemoveAll))
+}
+
+func TestBucketStorePruneBelowBelowOneBucketRemovesNothing(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	b := newBucketStore(t, fs)
+	makeBuckets(t, fs, "0")
+
+	require.NoError(t, b.pruneBelow(subdivisionSlot-1))
+
+	require.Equal(t, []string{"0"}, rootEntryNames(t, fs))
+}
+
+func TestBucketStorePruneBelowPropagatesReaddirError(t *testing.T) {
+	fs := afero.NewBasePathFs(afero.NewOsFs(), filepath.Join(t.TempDir(), "missing-root"))
+	b := newBucketStore(t, fs)
+
+	require.ErrorIs(t, b.pruneBelow(3*subdivisionSlot), ErrPruneNotStarted)
+	require.Zero(t, b.pruneFloor)
+}
+
+func TestBucketStorePruneBelowContinuesPastRemoveAllError(t *testing.T) {
+	fs := newRemoveAllFailingFs(afero.NewMemMapFs())
+	fs.failOn["1"] = errInducedFailure
+	b := newBucketStore(t, fs)
+	makeBuckets(t, fs, "0", "1", "2", "3")
+
+	require.ErrorIs(t, b.pruneBelow(3*subdivisionSlot), errInducedFailure)
+
+	require.Equal(t, []string{"1", "3"}, rootEntryNames(t, fs))
+}
+
+func TestBucketStoreLowerPruneRetriesTheEstablishedFloor(t *testing.T) {
+	fs := newRemoveAllFailingFs(afero.NewMemMapFs())
+	fs.failOn["1"] = errInducedFailure
+	b := newBucketStore(t, fs)
+	makeBuckets(t, fs, "0", "1", "2")
+	require.ErrorIs(t, b.pruneBelow(2*subdivisionSlot), errInducedFailure)
+	require.Equal(t, []string{"1", "2"}, rootEntryNames(t, fs))
+
+	delete(fs.failOn, "1")
+	require.NoError(t, b.pruneBelow(subdivisionSlot))
+	require.Equal(t, []string{"2"}, rootEntryNames(t, fs))
+}
+
+func TestBucketStorePruneBelowRemovesEachExpiredBucketOnce(t *testing.T) {
+	fs := newCountingFs(afero.NewMemMapFs())
+	b := newBucketStore(t, fs)
+	makeBuckets(t, fs, "0", "1", "2", "7")
+
+	require.NoError(t, b.pruneBelow(5*subdivisionSlot))
+
+	removed := fs.paths(opRemoveAll)
+	slices.Sort(removed)
+	require.Equal(t, []string{"0", "1", "2"}, removed)
+
+	fs.reset()
+	require.NoError(t, b.pruneBelow(5*subdivisionSlot))
+	require.Zero(t, fs.count(opRemoveAll))
+}
+
+func TestSlotLocksStripesBySlot(t *testing.T) {
+	var s slotLocks
+	s.initLocks()
+
+	require.Same(t, s.forSlot(7), s.forSlot(7))
+	require.Same(t, s.forSlot(7), s.forSlot(7+rwLocksCount))
+	require.NotSame(t, s.forSlot(7), s.forSlot(8))
+}
+
+func TestSlotLocksDoNotBlockOtherStripes(t *testing.T) {
+	var s slotLocks
+	s.initLocks()
+
+	s.forSlot(7).Lock()
+	defer s.forSlot(7).Unlock()
+
+	require.False(t, s.forSlot(7+rwLocksCount).TryLock())
+	require.True(t, s.forSlot(8).TryLock())
+	s.forSlot(8).Unlock()
+}
+
+func testSidecar(slot, idx uint64, marker byte) *cltypes.BlobSidecar {
+	blob := &cltypes.Blob{}
+	blob[0] = marker
+	return cltypes.NewBlobSidecar(
+		idx,
+		blob,
+		common.Bytes48{marker},
+		common.Bytes48{marker, marker},
+		&cltypes.SignedBeaconBlockHeader{Header: &cltypes.BeaconBlockHeader{Slot: slot}},
+		solid.NewHashVector(cltypes.CommitmentBranchSize),
+	)
+}
+
+func TestBucketStoreWriteReadRoundTrip(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	b := newBucketStore(t, fs)
+	root := common.Hash{7}
+	want := testSidecar(12_345, 2, 9)
+
+	created, err := b.write(12_345, root, 2, want)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	got := &cltypes.BlobSidecar{}
+	found, err := b.read(12_345, root, 2, got, clparams.DenebVersion)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	require.Equal(t, want.Index, got.Index)
+	require.Equal(t, want.Blob, got.Blob)
+	require.Equal(t, want.KzgCommitment, got.KzgCommitment)
+	require.Equal(t, want.KzgProof, got.KzgProof)
+	require.Equal(t, want.SignedBlockHeader, got.SignedBlockHeader)
+}
+
+func TestBucketStoreWriteLandsAtThePathItDerives(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	b := newBucketStore(t, fs)
+	root := common.Hash{7}
+
+	_, err := b.write(12_345, root, 2, testSidecar(12_345, 2, 9))
+	require.NoError(t, err)
+
+	_, file := b.path(12_345, root, 2)
+	exists, err := afero.Exists(fs, file)
+	require.NoError(t, err)
+	require.True(t, exists)
+}
+
+func TestBucketStoreExistsFollowsTheFile(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	b := newBucketStore(t, fs)
+	root := common.Hash{7}
+
+	exists, err := b.exists(12_345, root, 2)
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	_, err = b.write(12_345, root, 2, testSidecar(12_345, 2, 9))
+	require.NoError(t, err)
+
+	exists, err = b.exists(12_345, root, 2)
+	require.NoError(t, err)
+	require.True(t, exists)
+
+	exists, err = b.exists(12_345, root, 3)
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
+func TestBucketStoreStreamReproducesTheStoredBytes(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	b := newBucketStore(t, fs)
+	root := common.Hash{7}
+
+	_, err := b.write(12_345, root, 2, testSidecar(12_345, 2, 9))
+	require.NoError(t, err)
+
+	_, file := b.path(12_345, root, 2)
+	want, err := afero.ReadFile(fs, file)
+	require.NoError(t, err)
+	require.NotEmpty(t, want)
+
+	var got bytes.Buffer
+	require.NoError(t, b.stream(&got, 12_345, root, 2))
+	require.Equal(t, want, got.Bytes())
+}
+
+func TestBucketStoreStreamOfMissingFileErrors(t *testing.T) {
+	b := newBucketStore(t, afero.NewMemMapFs())
+
+	var got bytes.Buffer
+	require.Error(t, b.stream(&got, 12_345, common.Hash{7}, 2))
+}
+
+func TestBucketStoreRemoveThenExistsIsFalse(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	b := newBucketStore(t, fs)
+	root := common.Hash{7}
+
+	_, err := b.write(12_345, root, 2, testSidecar(12_345, 2, 9))
+	require.NoError(t, err)
+	require.NoError(t, b.remove(12_345, root, 2))
+
+	exists, err := b.exists(12_345, root, 2)
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
+func TestBucketStoreRemoveOfMissingFileIsNil(t *testing.T) {
+	b := newBucketStore(t, afero.NewMemMapFs())
+
+	require.NoError(t, b.remove(12_345, common.Hash{7}, 2))
+	require.NoError(t, b.remove(12_345, common.Hash{7}, 2))
+}
+
+func TestBucketStoreReadOfMissingFileIsNotFound(t *testing.T) {
+	b := newBucketStore(t, afero.NewMemMapFs())
+
+	got := &cltypes.BlobSidecar{}
+	found, err := b.read(12_345, common.Hash{7}, 2, got, clparams.DenebVersion)
+	require.NoError(t, err)
+	require.False(t, found)
+}
+
+func TestBucketStoreReadOfATruncatedFileIsNotFound(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	b := newBucketStore(t, fs)
+	root := common.Hash{7}
+
+	_, err := b.write(12_345, root, 2, testSidecar(12_345, 2, 9))
+	require.NoError(t, err)
+
+	_, file := b.path(12_345, root, 2)
+	original, err := afero.ReadFile(fs, file)
+	require.NoError(t, err)
+	require.NoError(t, afero.WriteFile(fs, file, original[:len(original)/2], 0o644))
+
+	got := &cltypes.BlobSidecar{}
+	found, err := b.read(12_345, root, 2, got, clparams.DenebVersion)
+	require.NoError(t, err)
+	require.False(t, found)
+
+	created, err := b.write(12_345, root, 2, testSidecar(12_345, 2, 11))
+	require.NoError(t, err)
+	require.False(t, created)
+
+	got2 := &cltypes.BlobSidecar{}
+	found2, err := b.read(12_345, root, 2, got2, clparams.DenebVersion)
+	require.NoError(t, err)
+	require.True(t, found2)
+	require.Equal(t, byte(11), got2.Blob[0])
+}
+
+func TestBucketStoreWriteReportsCreatedOnlyOnce(t *testing.T) {
+	b := newBucketStore(t, afero.NewMemMapFs())
+	root := common.Hash{7}
+
+	created, err := b.write(12_345, root, 2, testSidecar(12_345, 2, 9))
+	require.NoError(t, err)
+	require.True(t, created)
+
+	created, err = b.write(12_345, root, 2, testSidecar(12_345, 2, 11))
+	require.NoError(t, err)
+	require.False(t, created)
+
+	created, err = b.write(12_345, root, 3, testSidecar(12_345, 3, 9))
+	require.NoError(t, err)
+	require.True(t, created)
+}
+
+func TestBucketStoreWriteOverwritesTheStoredValue(t *testing.T) {
+	b := newBucketStore(t, afero.NewMemMapFs())
+	root := common.Hash{7}
+
+	_, err := b.write(12_345, root, 2, testSidecar(12_345, 2, 9))
+	require.NoError(t, err)
+	_, err = b.write(12_345, root, 2, testSidecar(12_345, 2, 11))
+	require.NoError(t, err)
+
+	got := &cltypes.BlobSidecar{}
+	found, err := b.read(12_345, root, 2, got, clparams.DenebVersion)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, byte(11), got.Blob[0])
+}
+
+func TestBucketStoreFailedWriteLeavesNothingBehind(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		budget int
+	}{
+		{name: "no byte written", budget: 0},
+		{name: "truncated", budget: 4},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := newFailingFs(afero.NewMemMapFs())
+			b := newBucketStore(t, fs)
+			root := common.Hash{7}
+			_, file := b.path(12_345, root, 2)
+			fs.failWritesAfter(file+tmpSuffix, tc.budget, errInducedFailure)
+
+			created, err := b.write(12_345, root, 2, testSidecar(12_345, 2, 9))
+			require.ErrorIs(t, err, errInducedFailure)
+			require.False(t, created)
+
+			exists, err := b.exists(12_345, root, 2)
+			require.NoError(t, err)
+			require.False(t, exists)
+
+			tmpExists, err := afero.Exists(fs, file+tmpSuffix)
+			require.NoError(t, err)
+			require.False(t, tmpExists)
+		})
+	}
+}
+
+func TestBucketStoreFailedWriteKeepsThePreviousValue(t *testing.T) {
+	fs := newFailingFs(afero.NewMemMapFs())
+	b := newBucketStore(t, fs)
+	root := common.Hash{7}
+
+	_, err := b.write(12_345, root, 2, testSidecar(12_345, 2, 9))
+	require.NoError(t, err)
+
+	_, file := b.path(12_345, root, 2)
+	fs.failWritesAfter(file+tmpSuffix, 4, errInducedFailure)
+	_, err = b.write(12_345, root, 2, testSidecar(12_345, 2, 11))
+	require.ErrorIs(t, err, errInducedFailure)
+
+	fs.clearFailures()
+	got := &cltypes.BlobSidecar{}
+	found, err := b.read(12_345, root, 2, got, clparams.DenebVersion)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, byte(9), got.Blob[0])
+
+	tmpExists, err := afero.Exists(fs, file+tmpSuffix)
+	require.NoError(t, err)
+	require.False(t, tmpExists)
+}
+
+func TestBucketStoreFailedSyncLeavesNothingBehind(t *testing.T) {
+	fs := newFailingFs(afero.NewMemMapFs())
+	b := newBucketStore(t, fs)
+	root := common.Hash{7}
+	_, file := b.path(12_345, root, 2)
+	fs.failSyncAt(file+tmpSuffix, errInducedFailure)
+
+	_, err := b.write(12_345, root, 2, testSidecar(12_345, 2, 9))
+	require.ErrorIs(t, err, errInducedFailure)
+
+	exists, err := b.exists(12_345, root, 2)
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	tmpExists, err := afero.Exists(fs, file+tmpSuffix)
+	require.NoError(t, err)
+	require.False(t, tmpExists)
+}
+
+func TestFacadePruneRejectsAWriteIntoTheBucketItRemoves(t *testing.T) {
+	fs := newPruneRaceFs(afero.NewMemMapFs())
+	fs.removePath = "0"
+	storage := NewDataColumnStore(fs, globalBeaconConfig, beaconevents.NewEventEmitter())
+	require.NoError(t, fs.MkdirAll("0", 0o755))
+
+	const liveSlot = 5*subdivisionSlot + 1
+	liveRoot := common.Hash{1}
+	require.NoError(t, storage.WriteColumnSidecars(t.Context(), liveRoot, 0, createTestDataColumnSidecar(liveSlot, 0)))
+
+	pruneDone := make(chan error, 1)
+	go func() { pruneDone <- storage.PruneBelow(subdivisionSlot) }()
+	<-fs.removeEntered
+
+	var streamed bytes.Buffer
+	require.NoError(t, storage.WriteStream(&streamed, liveSlot, liveRoot, 0))
+
+	require.NoError(t, storage.WriteColumnSidecars(t.Context(), common.Hash{2}, 0, createTestDataColumnSidecar(liveSlot+1, 0)))
+
+	require.NoError(t, storage.WriteColumnSidecars(t.Context(), common.Hash{3}, 0, createTestDataColumnSidecar(1, 0)))
+	prunedWriteExists, err := storage.ColumnSidecarExists(t.Context(), 1, common.Hash{3}, 0)
+	require.NoError(t, err)
+	require.False(t, prunedWriteExists)
+
+	close(fs.removeRelease)
+	require.NoError(t, <-pruneDone)
+}
+
+func TestFacadeWriteRacingPruneLeavesNoPartialFile(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		releaseWriteFirst bool
+	}{
+		{name: "write released first", releaseWriteFirst: true},
+		{name: "both released together", releaseWriteFirst: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := newPruneRaceFs(afero.NewBasePathFs(afero.NewOsFs(), t.TempDir()))
+			storage := NewDataColumnStore(fs, globalBeaconConfig, beaconevents.NewEventEmitter())
+			const slot = 1000
+			root := common.Hash{3}
+			_, file := (&bucketStore{fs: fs}).path(slot, root, 0)
+			fs.removePath = "0"
+			fs.createPath = file + tmpSuffix
+			require.NoError(t, fs.MkdirAll(fs.removePath, 0o755))
+
+			writeDone := make(chan error, 1)
+			go func() {
+				writeDone <- storage.WriteColumnSidecars(t.Context(), root, 0, createTestDataColumnSidecar(slot, 0))
+			}()
+			<-fs.createEntered
+
+			pruneDone := make(chan error, 1)
+			go func() { pruneDone <- storage.PruneBelow(subdivisionSlot) }()
+
+			if tc.releaseWriteFirst {
+				close(fs.createRelease)
+				require.NoError(t, <-writeDone)
+				stored, err := storage.ReadColumnSidecarByColumnIndex(t.Context(), slot, root, 0)
+				require.NoError(t, err)
+				require.Equal(t, uint64(0), stored.Index)
+				<-fs.removeEntered
+				close(fs.removeRelease)
+				require.NoError(t, <-pruneDone)
+			} else {
+				// The prune lock serializes write and prune regardless of release order, so
+				// releasing both gates up front still resolves one at a time and both sides
+				// still must succeed.
+				close(fs.removeRelease)
+				close(fs.createRelease)
+				require.NoError(t, <-writeDone)
+				require.NoError(t, <-pruneDone)
+			}
+
+			tmpExists, err := afero.Exists(fs, file+tmpSuffix)
+			require.NoError(t, err)
+			require.False(t, tmpExists)
+			exists, err := storage.ColumnSidecarExists(t.Context(), slot, root, 0)
+			require.NoError(t, err)
+			if exists {
+				stored, err := storage.ReadColumnSidecarByColumnIndex(t.Context(), slot, root, 0)
+				require.NoError(t, err)
+				require.Equal(t, uint64(0), stored.Index)
+			}
+		})
+	}
+}
+
+func TestFacadeConcurrentWritesUseOneTempFileAtATime(t *testing.T) {
+	fs := newSerializedCreateFs(afero.NewMemMapFs())
+	storage := NewDataColumnStore(fs, globalBeaconConfig, beaconevents.NewEventEmitter())
+	const slot = 1000
+	root := common.Hash{4}
+	_, file := (&bucketStore{fs: fs}).path(slot, root, 0)
+	fs.tempPath = file + tmpSuffix
+
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- storage.WriteColumnSidecars(t.Context(), root, 0, createTestDataColumnSidecar(slot, 0))
+	}()
+	<-fs.firstWriteEntered
+
+	secondStarted := make(chan struct{})
+	secondDone := make(chan error, 1)
+	go func() {
+		close(secondStarted)
+		secondDone <- storage.WriteColumnSidecars(t.Context(), root, 0, createTestDataColumnSidecar(slot, 0))
+	}()
+	<-secondStarted
+
+	interleaved := false
+	select {
+	case <-fs.secondCreateEntered:
+		interleaved = true
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(fs.releaseFirstWrite)
+	require.NoError(t, <-firstDone)
+	require.NoError(t, <-secondDone)
+	require.False(t, interleaved)
+
+	stored, err := storage.ReadColumnSidecarByColumnIndex(t.Context(), slot, root, 0)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), stored.Index)
+	tmpExists, err := afero.Exists(fs, file+tmpSuffix)
+	require.NoError(t, err)
+	require.False(t, tmpExists)
+}
+
+type pruneRaceFs struct {
+	afero.Fs
+	removePath    string
+	createPath    string
+	removeEntered chan struct{}
+	removeRelease chan struct{}
+	createEntered chan struct{}
+	createRelease chan struct{}
+	removeOnce    sync.Once
+	createOnce    sync.Once
+}
+
+func newPruneRaceFs(fs afero.Fs) *pruneRaceFs {
+	return &pruneRaceFs{
+		Fs:            fs,
+		removeEntered: make(chan struct{}),
+		removeRelease: make(chan struct{}),
+		createEntered: make(chan struct{}),
+		createRelease: make(chan struct{}),
+	}
+}
+
+func (f *pruneRaceFs) RemoveAll(path string) error {
+	if path == f.removePath {
+		f.removeOnce.Do(func() { close(f.removeEntered) })
+		<-f.removeRelease
+	}
+	return f.Fs.RemoveAll(path)
+}
+
+func (f *pruneRaceFs) Create(name string) (afero.File, error) {
+	fh, err := f.Fs.Create(name)
+	if err != nil {
+		return nil, err
+	}
+	if name == f.createPath {
+		f.createOnce.Do(func() { close(f.createEntered) })
+		<-f.createRelease
+	}
+	return fh, nil
+}
+
+type serializedCreateFs struct {
+	afero.Fs
+	tempPath            string
+	firstWriteEntered   chan struct{}
+	releaseFirstWrite   chan struct{}
+	secondCreateEntered chan struct{}
+	createMu            sync.Mutex
+	createCount         int
+}
+
+func newSerializedCreateFs(fs afero.Fs) *serializedCreateFs {
+	return &serializedCreateFs{
+		Fs:                  fs,
+		firstWriteEntered:   make(chan struct{}),
+		releaseFirstWrite:   make(chan struct{}),
+		secondCreateEntered: make(chan struct{}),
+	}
+}
+
+func (f *serializedCreateFs) Create(name string) (afero.File, error) {
+	fh, err := f.Fs.Create(name)
+	if err != nil || name != f.tempPath {
+		return fh, err
+	}
+
+	f.createMu.Lock()
+	f.createCount++
+	createCount := f.createCount
+	f.createMu.Unlock()
+	if createCount == 1 {
+		return &serializedWriteFile{
+			File:    fh,
+			entered: f.firstWriteEntered,
+			release: f.releaseFirstWrite,
+		}, nil
+	}
+	if createCount == 2 {
+		close(f.secondCreateEntered)
+	}
+	return fh, nil
+}
+
+type serializedWriteFile struct {
+	afero.File
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (f *serializedWriteFile) Write(p []byte) (int, error) {
+	f.once.Do(func() {
+		close(f.entered)
+		<-f.release
+	})
+	return f.File.Write(p)
+}
+
+func TestBucketStoreWriteReportsRenameFailureWhenTheTargetIsGone(t *testing.T) {
+	fs := newRenameFailingFs(afero.NewMemMapFs(), errInducedFailure)
+	b := newBucketStore(t, fs)
+	root := common.Hash{7}
+
+	_, err := b.write(12_345, root, 2, testSidecar(12_345, 2, 9))
+	require.ErrorIs(t, err, errInducedFailure)
+
+	fs.err = nil
+	_, err = b.write(12_345, root, 2, testSidecar(12_345, 2, 9))
+	require.NoError(t, err)
+
+	// A rename failure that is not a sharing violation always propagates, target present
+	// or not.
+	fs.err = errInducedFailure
+	created, err := b.write(12_345, root, 2, testSidecar(12_345, 2, 11))
+	require.ErrorIs(t, err, errInducedFailure)
+	require.False(t, created)
+
+	fs.dropDestination = true
+	_, err = b.write(12_345, root, 2, testSidecar(12_345, 2, 11))
+	require.ErrorIs(t, err, errInducedFailure)
+}
+
+func TestBucketStoreWriteRenameFailurePropagatesWhenNotASharingViolation(t *testing.T) {
+	fs := newRenameFailingFs(afero.NewMemMapFs(), nil)
+	b := newBucketStore(t, fs)
+	root := common.Hash{7}
+
+	_, err := b.write(12_345, root, 2, testSidecar(12_345, 2, 9))
+	require.NoError(t, err)
+
+	fs.err = syscall.ENOSPC
+	created, err := b.write(12_345, root, 2, testSidecar(12_345, 2, 11))
+	require.ErrorIs(t, err, syscall.ENOSPC)
+	require.False(t, created)
+}
+
+func TestBucketStoreWriteSurfacesAShortWriteFromTheFinalFlush(t *testing.T) {
+	fs := newFailingFs(afero.NewMemMapFs())
+	b := newBucketStore(t, fs)
+	root := common.Hash{7}
+	_, file := b.path(12_345, root, 2)
+	fs.failShortWrite(file + tmpSuffix)
+
+	created, err := b.write(12_345, root, 2, testSidecar(12_345, 2, 9))
+	require.ErrorIs(t, err, io.ErrShortWrite)
+	require.False(t, created)
+
+	exists, err := afero.Exists(fs, file)
+	require.NoError(t, err)
+	require.False(t, exists)
+}

--- a/cl/persistence/blob_storage/data_column_db.go
+++ b/cl/persistence/blob_storage/data_column_db.go
@@ -5,14 +5,10 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strconv"
-	"sync"
 
 	"github.com/erigontech/erigon/cl/beacon/beaconevents"
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
-	"github.com/erigontech/erigon/cl/sentinel/communication/ssz_snappy"
-	"github.com/erigontech/erigon/cl/utils/eth_clock"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/spf13/afero"
@@ -22,48 +18,28 @@ import (
 type DataColumnStorage interface {
 	WriteColumnSidecars(ctx context.Context, blockRoot common.Hash, columnIndex int64, columnData *cltypes.DataColumnSidecar) error
 	RemoveColumnSidecars(ctx context.Context, slot uint64, blockRoot common.Hash, columnIndices ...int64) error
-	RemoveAllColumnSidecars(ctx context.Context, slot uint64, blockRoot common.Hash) error
 	ReadColumnSidecarByColumnIndex(ctx context.Context, slot uint64, blockRoot common.Hash, columnIndex int64) (*cltypes.DataColumnSidecar, error)
 	ColumnSidecarExists(ctx context.Context, slot uint64, blockRoot common.Hash, columnIndex int64) (bool, error)
 	WriteStream(w io.Writer, slot uint64, blockRoot common.Hash, idx uint64) error // Used for P2P networking
 	GetSavedColumnIndex(ctx context.Context, slot uint64, blockRoot common.Hash) ([]uint64, error)
-	Prune(keepSlotDistance uint64) error
+	PruneBelow(slot uint64) error
 }
 
 type dataColumnStorageImpl struct {
-	fs                afero.Fs
+	bucketStore
+	slotLocks
 	beaconChainConfig *clparams.BeaconChainConfig
-	ethClock          eth_clock.EthereumClock
-	slotsKept         uint64
 	emitters          *beaconevents.EventEmitter
-
-	//lock sync.RWMutex
-	rwLocks []sync.RWMutex
 }
 
-const rwLocksCount = 64
-
-func NewDataColumnStore(fs afero.Fs, slotsKept uint64, beaconChainConfig *clparams.BeaconChainConfig, ethClock eth_clock.EthereumClock, emitters *beaconevents.EventEmitter) DataColumnStorage {
+func NewDataColumnStore(fs afero.Fs, beaconChainConfig *clparams.BeaconChainConfig, emitters *beaconevents.EventEmitter) DataColumnStorage {
 	impl := &dataColumnStorageImpl{
-		fs:                fs,
 		beaconChainConfig: beaconChainConfig,
-		ethClock:          ethClock,
-		slotsKept:         slotsKept,
 		emitters:          emitters,
-		rwLocks:           make([]sync.RWMutex, rwLocksCount),
 	}
+	impl.bucketStore.init(fs)
+	impl.slotLocks.initLocks()
 	return impl
-}
-
-func (s *dataColumnStorageImpl) acquireLock(slot uint64) *sync.RWMutex {
-	return &s.rwLocks[slot%rwLocksCount]
-}
-
-func dataColumnFilePath(slot uint64, blockRoot common.Hash, columnIndex uint64) (dir, filepath string) {
-	subdir := slot / subdivisionSlot
-	dir = strconv.FormatUint(subdir, 10)
-	filepath = fmt.Sprintf("%s/%s_%d", dir, blockRoot.String(), columnIndex)
-	return
 }
 
 func (s *dataColumnStorageImpl) WriteColumnSidecars(ctx context.Context, blockRoot common.Hash, columnIndex int64, columnData *cltypes.DataColumnSidecar) error {
@@ -71,11 +47,12 @@ func (s *dataColumnStorageImpl) WriteColumnSidecars(ctx context.Context, blockRo
 	// For Fulu: slot is in SignedBlockHeader.Header.Slot
 	// For GLOAS: slot is directly in Slot field
 	var slot uint64
-	if columnData.Version() >= clparams.GloasVersion {
+	switch {
+	case columnData.Version() >= clparams.GloasVersion:
 		slot = columnData.Slot
-	} else if columnData.SignedBlockHeader != nil {
+	case columnData.SignedBlockHeader != nil:
 		slot = columnData.SignedBlockHeader.Header.Slot
-	} else {
+	default:
 		slot = columnData.Slot // fallback
 	}
 
@@ -83,53 +60,33 @@ func (s *dataColumnStorageImpl) WriteColumnSidecars(ctx context.Context, blockRo
 	columnData.BlockRoot = blockRoot
 	columnData.Slot = slot
 
-	lock := s.acquireLock(slot)
+	lock := s.forSlot(slot)
 	lock.Lock()
 	defer lock.Unlock()
-	dir, filepath := dataColumnFilePath(slot, blockRoot, uint64(columnIndex))
-	if err := s.fs.MkdirAll(dir, 0755); err != nil {
-		return err
-	}
-	if _, err := s.fs.Stat(filepath); err == nil {
-		// File already exists, no need to write again
+	if !s.startWrite(slot) {
 		return nil
 	}
-	fh, err := s.fs.Create(filepath)
+	created, err := s.writeAdmitted(slot, blockRoot, uint64(columnIndex), columnData)
+	s.finishWrite()
 	if err != nil {
 		return err
 	}
-	defer func() {
-		fh.Close()
-		if err != nil {
-			s.fs.Remove(filepath)
-		}
-	}()
-	// snappy of | length | ssz data |
-	if err = ssz_snappy.EncodeAndWrite(fh, columnData); err != nil {
-		return err
+	if created {
+		s.emitters.Operation().SendDataColumnSidecar(beaconevents.NewDataColumnSidecarData(columnData))
+		log.Trace("wrote data column sidecar", "slot", slot, "block_root", blockRoot.String(), "column_index", columnIndex)
 	}
-	if err = fh.Sync(); err != nil {
-		return err
-	}
-	s.emitters.Operation().SendDataColumnSidecar(beaconevents.NewDataColumnSidecarData(columnData))
-	log.Trace("wrote data column sidecar", "slot", slot, "block_root", blockRoot.String(), "column_index", columnIndex)
 	return nil
 }
 
 func (s *dataColumnStorageImpl) ReadColumnSidecarByColumnIndex(ctx context.Context, slot uint64, blockRoot common.Hash, columnIndex int64) (*cltypes.DataColumnSidecar, error) {
-	lock := s.acquireLock(slot)
-	lock.RLock()
-	defer lock.RUnlock()
-	_, filepath := dataColumnFilePath(slot, blockRoot, uint64(columnIndex))
-	fh, err := s.fs.Open(filepath)
+	data := &cltypes.DataColumnSidecar{}
+	version := s.beaconChainConfig.GetCurrentStateVersion(slot / s.beaconChainConfig.SlotsPerEpoch)
+	found, err := s.read(slot, blockRoot, uint64(columnIndex), data, version)
 	if err != nil {
 		return nil, err
 	}
-	defer fh.Close()
-	data := &cltypes.DataColumnSidecar{}
-	version := s.beaconChainConfig.GetCurrentStateVersion(slot / s.beaconChainConfig.SlotsPerEpoch)
-	if err := ssz_snappy.DecodeAndReadNoForkDigest(fh, data, version); err != nil {
-		return nil, err
+	if !found {
+		return nil, os.ErrNotExist
 	}
 	// BlockRoot and Slot are not part of SSZ schema, set them from parameters
 	data.BlockRoot = blockRoot
@@ -138,92 +95,50 @@ func (s *dataColumnStorageImpl) ReadColumnSidecarByColumnIndex(ctx context.Conte
 }
 
 func (s *dataColumnStorageImpl) ColumnSidecarExists(ctx context.Context, slot uint64, blockRoot common.Hash, columnIndex int64) (bool, error) {
-	lock := s.acquireLock(slot)
-	lock.RLock()
-	defer lock.RUnlock()
-	_, filepath := dataColumnFilePath(slot, blockRoot, uint64(columnIndex))
-	if _, err := s.fs.Stat(filepath); os.IsNotExist(err) {
-		return false, nil
-	} else if err != nil {
-		return false, err
-	}
-	return true, nil
-}
-
-func (s *dataColumnStorageImpl) RemoveAllColumnSidecars(ctx context.Context, slot uint64, blockRoot common.Hash) error {
-	lock := s.acquireLock(slot)
-	lock.Lock()
-	defer lock.Unlock()
-	for i := uint64(0); i < s.beaconChainConfig.NumberOfColumns; i++ {
-		_, filepath := dataColumnFilePath(slot, blockRoot, i)
-		s.fs.Remove(filepath)
-	}
-	return nil
+	return s.exists(slot, blockRoot, uint64(columnIndex))
 }
 
 func (s *dataColumnStorageImpl) RemoveColumnSidecars(ctx context.Context, slot uint64, blockRoot common.Hash, columnIndices ...int64) error {
-	lock := s.acquireLock(slot)
+	lock := s.forSlot(slot)
 	lock.Lock()
 	defer lock.Unlock()
+	var firstErr error
 	for _, index := range columnIndices {
-		_, filepath := dataColumnFilePath(slot, blockRoot, uint64(index))
-		if err := s.fs.Remove(filepath); err != nil {
-			if os.IsNotExist(err) {
-				continue // file does not exist, nothing to remove
+		if err := s.remove(slot, blockRoot, uint64(index)); err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("failed to remove column sidecar: %w", err)
 			}
-			return fmt.Errorf("failed to remove column sidecar: %v", err)
+			continue
 		}
 		log.Trace("removed data column sidecar", "slot", slot, "block_root", blockRoot.String(), "column_index", index)
 	}
-	return nil
+	return firstErr
 }
 
 func (s *dataColumnStorageImpl) WriteStream(w io.Writer, slot uint64, blockRoot common.Hash, idx uint64) error {
-	lock := s.acquireLock(slot)
-	lock.RLock()
-	defer lock.RUnlock()
-	_, filepath := dataColumnFilePath(slot, blockRoot, idx)
-	fh, err := s.fs.Open(filepath)
-	if err != nil {
-		return err
-	}
-	defer fh.Close()
-	_, err = io.Copy(w, fh)
-	return err
+	return s.stream(w, slot, blockRoot, idx)
 }
 
 // GetSavedColumnIndex returns the list of saved column indices for the given slot and block root.
 func (s *dataColumnStorageImpl) GetSavedColumnIndex(ctx context.Context, slot uint64, blockRoot common.Hash) ([]uint64, error) {
-	lock := s.acquireLock(slot)
+	lock := s.forSlot(slot)
 	lock.RLock()
 	defer lock.RUnlock()
 	var savedColumns []uint64
 	for i := uint64(0); i < s.beaconChainConfig.NumberOfColumns; i++ {
-		_, filepath := dataColumnFilePath(slot, blockRoot, i)
-		if _, err := s.fs.Stat(filepath); os.IsNotExist(err) {
-			continue // file does not exist
-		} else if err != nil {
-			return nil, err // some other error
+		exists, err := s.exists(slot, blockRoot, i)
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			continue
 		}
 		savedColumns = append(savedColumns, i)
 	}
 	return savedColumns, nil
 }
 
-func (s *dataColumnStorageImpl) Prune(keepSlotDistance uint64) error {
-	currentSlot := s.ethClock.GetCurrentSlot()
-	if currentSlot <= keepSlotDistance {
-		return nil
-	}
-	currentSlot -= keepSlotDistance
-	currentSlot = (currentSlot / subdivisionSlot) * subdivisionSlot
-	log.Debug("pruning data column sidecars", "cutoff_slot", currentSlot)
-	// delete all the folders that are older than slotsKept
-	for i := uint64(0); i < currentSlot; i += subdivisionSlot {
-		lock := s.acquireLock(i)
-		lock.Lock()
-		s.fs.RemoveAll(strconv.FormatUint(i/subdivisionSlot, 10))
-		lock.Unlock()
-	}
-	return nil
+func (s *dataColumnStorageImpl) PruneBelow(slot uint64) error {
+	log.Debug("pruning data column sidecars", "cutoff_slot", slot)
+	return s.pruneBelow(slot)
 }

--- a/cl/persistence/blob_storage/data_column_db_test.go
+++ b/cl/persistence/blob_storage/data_column_db_test.go
@@ -3,23 +3,26 @@ package blob_storage
 import (
 	"bytes"
 	"context"
+	"os"
 	"slices"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/erigontech/erigon/cl/beacon/beaconevents"
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/sentinel/communication/ssz_snappy"
-	"github.com/erigontech/erigon/cl/utils/eth_clock"
 	"github.com/erigontech/erigon/common"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	gomock "go.uber.org/mock/gomock"
 )
 
-var globalBeaconConfig *clparams.BeaconChainConfig
-var globalCaplinConfig *clparams.CaplinConfig
+var (
+	globalBeaconConfig *clparams.BeaconChainConfig
+	globalCaplinConfig *clparams.CaplinConfig
+)
 
 func init() {
 	// Initialize global config once for all tests
@@ -35,25 +38,13 @@ func init() {
 	clparams.InitGlobalStaticConfig(globalBeaconConfig, globalCaplinConfig)
 }
 
-func setupTestDataColumnStorage(t *testing.T) (DataColumnStorage, afero.Fs, *clparams.BeaconChainConfig, eth_clock.EthereumClock) {
+func setupTestDataColumnStorage(t *testing.T) (DataColumnStorage, afero.Fs, *clparams.BeaconChainConfig) {
 	fs := afero.NewBasePathFs(afero.NewOsFs(), t.TempDir())
 
-	ctrl := gomock.NewController(t)
-	mockClock := eth_clock.NewMockEthereumClock(ctrl)
-
-	// Set up mock expectations
-	mockClock.EXPECT().GetCurrentSlot().Return(uint64(1000)).AnyTimes()
-	mockClock.EXPECT().GetCurrentEpoch().Return(uint64(31)).AnyTimes()
-	mockClock.EXPECT().GetEpochAtSlot(gomock.Any()).DoAndReturn(func(slot uint64) uint64 {
-		return slot / 32
-	}).AnyTimes()
-
 	emitters := beaconevents.NewEventEmitter()
-	storage := NewDataColumnStore(fs, 1000, globalBeaconConfig, mockClock, emitters)
-	return storage, fs, globalBeaconConfig, mockClock
+	storage := NewDataColumnStore(fs, globalBeaconConfig, emitters)
+	return storage, fs, globalBeaconConfig
 }
-
-// Mock implementation removed - using eth_clock.NewMockEthereumClock instead
 
 func createTestDataColumnSidecar(slot uint64, columnIndex int64) *cltypes.DataColumnSidecar {
 	sidecar := cltypes.NewDataColumnSidecar()
@@ -66,13 +57,173 @@ func createTestDataColumnSidecar(slot uint64, columnIndex int64) *cltypes.DataCo
 	return sidecar
 }
 
+type blockingColumnFs struct {
+	afero.Fs
+	blockStatPath   string
+	blockRemovePath string
+	createPath      string
+	statEntered     chan struct{}
+	statRelease     chan struct{}
+	removeEntered   chan struct{}
+	removeRelease   chan struct{}
+	createCalled    chan struct{}
+	statOnce        sync.Once
+	removeOnce      sync.Once
+	createOnce      sync.Once
+}
+
+func (f *blockingColumnFs) Stat(name string) (os.FileInfo, error) {
+	if name == f.blockStatPath {
+		f.statOnce.Do(func() { close(f.statEntered) })
+		<-f.statRelease
+	}
+	return f.Fs.Stat(name)
+}
+
+func (f *blockingColumnFs) Remove(name string) error {
+	if name == f.blockRemovePath {
+		f.removeOnce.Do(func() { close(f.removeEntered) })
+		<-f.removeRelease
+	}
+	return f.Fs.Remove(name)
+}
+
+func (f *blockingColumnFs) Create(name string) (afero.File, error) {
+	if name == f.createPath {
+		f.createOnce.Do(func() { close(f.createCalled) })
+	}
+	return f.Fs.Create(name)
+}
+
+func TestDataColumnStorageDoesNotReportTruncatedSidecar(t *testing.T) {
+	fs := newFailingFs(afero.NewMemMapFs())
+	storage := NewDataColumnStore(fs, globalBeaconConfig, beaconevents.NewEventEmitter())
+	impl := storage.(*dataColumnStorageImpl)
+	root := common.HexToHash("0x1234567890abcdef")
+	const slot = 1000
+	const index = 1
+	_, filepath := impl.path(slot, root, index)
+	fs.failWritesAfter(filepath, 1, errInducedFailure)
+	fs.failWritesAfter(filepath+tmpSuffix, 1, errInducedFailure)
+
+	err := storage.WriteColumnSidecars(t.Context(), root, index, createTestDataColumnSidecar(slot, index))
+	require.ErrorIs(t, err, errInducedFailure)
+
+	exists, err := storage.ColumnSidecarExists(t.Context(), slot, root, index)
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	saved, err := storage.GetSavedColumnIndex(t.Context(), slot, root)
+	require.NoError(t, err)
+	require.Empty(t, saved)
+}
+
+func TestDuplicateColumnWriteDoesNotEmitAnotherEvent(t *testing.T) {
+	emitters := beaconevents.NewEventEmitter()
+	events := make(chan *beaconevents.EventStream, 2)
+	subscription := emitters.Operation().Subscribe(events)
+	defer subscription.Unsubscribe()
+	storage := NewDataColumnStore(afero.NewMemMapFs(), globalBeaconConfig, emitters)
+	root := common.HexToHash("0x1234567890abcdef")
+	sidecar := createTestDataColumnSidecar(1000, 1)
+
+	require.NoError(t, storage.WriteColumnSidecars(t.Context(), root, 1, sidecar))
+	event := <-events
+	require.Equal(t, beaconevents.OpDataColumnSidecar, event.Event)
+
+	require.NoError(t, storage.WriteColumnSidecars(t.Context(), root, 1, sidecar))
+	require.Len(t, events, 0)
+}
+
+func TestDataColumnWholeSlotOperationsDoNotInterleaveWithWrite(t *testing.T) {
+	t.Run("saved index scan", func(t *testing.T) {
+		fs := &blockingColumnFs{Fs: afero.NewMemMapFs()}
+		storage := NewDataColumnStore(fs, globalBeaconConfig, beaconevents.NewEventEmitter())
+		root := common.HexToHash("0x1234567890abcdef")
+		const slot = 1000
+		require.NoError(t, storage.WriteColumnSidecars(t.Context(), root, 0, createTestDataColumnSidecar(slot, 0)))
+		impl := storage.(*dataColumnStorageImpl)
+		_, statPath := impl.path(slot, root, 0)
+		_, createPath := impl.path(slot, root, 1)
+		fs.blockStatPath = statPath
+		fs.statEntered = make(chan struct{})
+		fs.statRelease = make(chan struct{})
+		fs.createPath = createPath + tmpSuffix
+		fs.createCalled = make(chan struct{})
+
+		scanDone := make(chan []uint64, 1)
+		scanErr := make(chan error, 1)
+		go func() {
+			indices, err := storage.GetSavedColumnIndex(t.Context(), slot, root)
+			scanDone <- indices
+			scanErr <- err
+		}()
+		<-fs.statEntered
+
+		writeStarted := make(chan struct{})
+		writeDone := make(chan error, 1)
+		go func() {
+			close(writeStarted)
+			writeDone <- storage.WriteColumnSidecars(t.Context(), root, 1, createTestDataColumnSidecar(slot, 1))
+		}()
+		<-writeStarted
+		select {
+		case <-fs.createCalled:
+			t.Fatal("write interleaved with the saved-column scan")
+		case <-time.After(100 * time.Millisecond):
+		}
+		close(fs.statRelease)
+
+		require.NoError(t, <-scanErr)
+		require.Equal(t, []uint64{0}, <-scanDone)
+		require.NoError(t, <-writeDone)
+	})
+
+	t.Run("remove loop", func(t *testing.T) {
+		fs := &blockingColumnFs{Fs: afero.NewMemMapFs()}
+		storage := NewDataColumnStore(fs, globalBeaconConfig, beaconevents.NewEventEmitter())
+		root := common.HexToHash("0x1234567890abcdef")
+		const slot = 1000
+		for index := range int64(2) {
+			require.NoError(t, storage.WriteColumnSidecars(t.Context(), root, index, createTestDataColumnSidecar(slot, index)))
+		}
+		impl := storage.(*dataColumnStorageImpl)
+		_, removePath := impl.path(slot, root, 0)
+		_, createPath := impl.path(slot, root, 2)
+		fs.blockRemovePath = removePath
+		fs.removeEntered = make(chan struct{})
+		fs.removeRelease = make(chan struct{})
+		fs.createPath = createPath + tmpSuffix
+		fs.createCalled = make(chan struct{})
+
+		removeDone := make(chan error, 1)
+		go func() { removeDone <- storage.RemoveColumnSidecars(t.Context(), slot, root, 0, 1) }()
+		<-fs.removeEntered
+
+		writeStarted := make(chan struct{})
+		writeDone := make(chan error, 1)
+		go func() {
+			close(writeStarted)
+			writeDone <- storage.WriteColumnSidecars(t.Context(), root, 2, createTestDataColumnSidecar(slot, 2))
+		}()
+		<-writeStarted
+		select {
+		case <-fs.createCalled:
+			t.Fatal("write interleaved with the column-removal loop")
+		case <-time.After(100 * time.Millisecond):
+		}
+		close(fs.removeRelease)
+
+		require.NoError(t, <-removeDone)
+		require.NoError(t, <-writeDone)
+	})
+}
+
 func TestNewDataColumnStore(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	beaconConfig := &clparams.BeaconChainConfig{}
-	ctrl := gomock.NewController(t)
-	mockClock := eth_clock.NewMockEthereumClock(ctrl)
 
-	storage := NewDataColumnStore(fs, 1000, beaconConfig, mockClock, beaconevents.NewEventEmitter())
+	storage := NewDataColumnStore(fs, beaconConfig, beaconevents.NewEventEmitter())
 
 	assert.NotNil(t, storage)
 
@@ -80,26 +231,10 @@ func TestNewDataColumnStore(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, fs, impl.fs)
 	assert.Equal(t, beaconConfig, impl.beaconChainConfig)
-	assert.Equal(t, mockClock, impl.ethClock)
-	assert.Equal(t, uint64(1000), impl.slotsKept)
-}
-
-func TestDataColumnFilePath(t *testing.T) {
-	slot := uint64(1000)
-	blockRoot := common.HexToHash("0x1234567890abcdef")
-	columnIndex := uint64(2)
-
-	dir, filepath := dataColumnFilePath(slot, blockRoot, columnIndex)
-
-	expectedDir := "0" // 1000 / 10000 = 0
-	expectedFilepath := "0/0x0000000000000000000000000000000000000000000000001234567890abcdef_2"
-
-	assert.Equal(t, expectedDir, dir)
-	assert.Equal(t, expectedFilepath, filepath)
 }
 
 func TestWriteColumnSidecars(t *testing.T) {
-	storage, fs, _, _ := setupTestDataColumnStorage(t)
+	storage, _, _ := setupTestDataColumnStorage(t)
 	ctx := context.Background()
 
 	blockRoot := common.HexToHash("0x1234567890abcdef")
@@ -111,9 +246,9 @@ func TestWriteColumnSidecars(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify file was created
-	_, filepath := dataColumnFilePath(1000, blockRoot, uint64(columnIndex))
-	_, err = fs.Stat(filepath)
+	exists, err := storage.ColumnSidecarExists(ctx, 1000, blockRoot, columnIndex)
 	require.NoError(t, err)
+	require.True(t, exists)
 
 	// Test writing to same location again (should not error)
 	err = storage.WriteColumnSidecars(ctx, blockRoot, columnIndex, sidecar)
@@ -121,7 +256,7 @@ func TestWriteColumnSidecars(t *testing.T) {
 }
 
 func TestReadColumnSidecarByColumnIndex(t *testing.T) {
-	storage, _, _, _ := setupTestDataColumnStorage(t)
+	storage, _, _ := setupTestDataColumnStorage(t)
 	ctx := context.Background()
 
 	blockRoot := common.HexToHash("0x1234567890abcdef")
@@ -145,7 +280,7 @@ func TestReadColumnSidecarByColumnIndex(t *testing.T) {
 }
 
 func TestColumnSidecarExists(t *testing.T) {
-	storage, _, _, _ := setupTestDataColumnStorage(t)
+	storage, _, _ := setupTestDataColumnStorage(t)
 	ctx := context.Background()
 
 	blockRoot := common.HexToHash("0x1234567890abcdef")
@@ -168,7 +303,7 @@ func TestColumnSidecarExists(t *testing.T) {
 }
 
 func TestColumnSidecarExistsWithInvalidParameters(t *testing.T) {
-	storage, _, _, _ := setupTestDataColumnStorage(t)
+	storage, _, _ := setupTestDataColumnStorage(t)
 	ctx := context.Background()
 
 	blockRoot := common.Hash{} // Empty hash
@@ -187,16 +322,17 @@ func TestColumnSidecarExistsWithInvalidParameters(t *testing.T) {
 }
 
 func TestColumnSidecarExistsWithDirectoryError(t *testing.T) {
-	storage, fs, _, _ := setupTestDataColumnStorage(t)
+	storage, fs, _ := setupTestDataColumnStorage(t)
 	ctx := context.Background()
 
 	blockRoot := common.HexToHash("0x1234567890abcdef")
 	columnIndex := int64(1)
 
 	// Create a directory with the same name as the expected file to cause a stat error
-	_, filepath := dataColumnFilePath(1000, blockRoot, uint64(columnIndex))
+	impl := storage.(*dataColumnStorageImpl)
+	_, filepath := impl.path(1000, blockRoot, uint64(columnIndex))
 	dir := filepath[:len(filepath)-2] // Remove the "_1" part
-	err := fs.MkdirAll(dir, 0755)
+	err := fs.MkdirAll(dir, 0o755)
 	require.NoError(t, err)
 
 	// This should still work correctly
@@ -206,7 +342,7 @@ func TestColumnSidecarExistsWithDirectoryError(t *testing.T) {
 }
 
 func TestRemoveColumnSidecars(t *testing.T) {
-	storage, _, _, _ := setupTestDataColumnStorage(t)
+	storage, _, _ := setupTestDataColumnStorage(t)
 	ctx := context.Background()
 
 	blockRoot := common.HexToHash("0x1234567890abcdef")
@@ -243,40 +379,35 @@ func TestRemoveColumnSidecars(t *testing.T) {
 	assert.False(t, exists)
 }
 
-func TestRemoveAllColumnSidecars(t *testing.T) {
-	storage, _, _, _ := setupTestDataColumnStorage(t)
+func TestRemoveColumnSidecarsContinuesPastAFailureOnAMiddleIndex(t *testing.T) {
+	fs := newRemoveFailingFs(afero.NewMemMapFs())
+	storage := NewDataColumnStore(fs, globalBeaconConfig, beaconevents.NewEventEmitter())
 	ctx := context.Background()
-
 	blockRoot := common.HexToHash("0x1234567890abcdef")
+	const slot = 1000
 
-	// Write multiple sidecars
 	for i := range int64(3) {
-		sidecar := createTestDataColumnSidecar(1000, i)
-		err := storage.WriteColumnSidecars(ctx, blockRoot, i, sidecar)
-		require.NoError(t, err)
+		require.NoError(t, storage.WriteColumnSidecars(ctx, blockRoot, i, createTestDataColumnSidecar(slot, i)))
 	}
 
-	// Verify they exist
-	for i := range int64(3) {
-		exists, err := storage.ColumnSidecarExists(ctx, 1000, blockRoot, i)
-		require.NoError(t, err)
-		assert.True(t, exists)
-	}
+	impl := storage.(*dataColumnStorageImpl)
+	_, failPath := impl.path(slot, blockRoot, 1)
+	fs.failOn[failPath] = errInducedFailure
 
-	// Remove all sidecars
-	err := storage.RemoveAllColumnSidecars(ctx, 1000, blockRoot)
+	err := storage.RemoveColumnSidecars(ctx, slot, blockRoot, 0, 1, 2)
+	require.ErrorIs(t, err, errInducedFailure)
+
+	exists0, err := storage.ColumnSidecarExists(ctx, slot, blockRoot, 0)
 	require.NoError(t, err)
+	require.False(t, exists0, "index before the failing one should still be removed")
 
-	// Verify all are removed
-	for i := range int64(3) {
-		exists, err := storage.ColumnSidecarExists(ctx, 1000, blockRoot, i)
-		require.NoError(t, err)
-		assert.False(t, exists)
-	}
+	exists2, err := storage.ColumnSidecarExists(ctx, slot, blockRoot, 2)
+	require.NoError(t, err)
+	require.False(t, exists2, "index after the failing one should still be removed")
 }
 
 func TestWriteStream(t *testing.T) {
-	storage, _, _, _ := setupTestDataColumnStorage(t)
+	storage, _, _ := setupTestDataColumnStorage(t)
 	ctx := context.Background()
 
 	blockRoot := common.HexToHash("0x1234567890abcdef")
@@ -301,7 +432,7 @@ func TestWriteStream(t *testing.T) {
 }
 
 func TestGetSavedColumnIndex(t *testing.T) {
-	storage, _, _, _ := setupTestDataColumnStorage(t)
+	storage, _, _ := setupTestDataColumnStorage(t)
 	ctx := context.Background()
 
 	blockRoot := common.HexToHash("0x1234567890abcdef")
@@ -326,60 +457,149 @@ func TestGetSavedColumnIndex(t *testing.T) {
 	}
 }
 
-func TestPrune(t *testing.T) {
-	storage, fs, _, mockClock := setupTestDataColumnStorage(t)
+func TestDataColumnStorePruneBelowRemovesBucketsUnderTheFloor(t *testing.T) {
+	storage, fs, _ := setupTestDataColumnStorage(t)
+	for _, bucket := range []string{"0", "1", "2", "3", "4"} {
+		require.NoError(t, fs.MkdirAll(bucket, 0o755))
+	}
 
-	// Set up mock clock expectations for pruning
-	mockClock.(*eth_clock.MockEthereumClock).EXPECT().GetCurrentSlot().Return(uint64(50000)).AnyTimes()
+	require.NoError(t, storage.PruneBelow(40000))
 
-	// Create some test directories
-	fs.MkdirAll("0", 0755) // slot 0-9999
-	fs.MkdirAll("1", 0755) // slot 10000-19999
-	fs.MkdirAll("2", 0755) // slot 20000-29999
-	fs.MkdirAll("3", 0755) // slot 30000-39999
-	fs.MkdirAll("4", 0755) // slot 40000-49999
+	for _, gone := range []string{"0", "1", "2", "3"} {
+		exists, err := afero.DirExists(fs, gone)
+		require.NoError(t, err)
+		require.False(t, exists, "bucket %s is below the floor", gone)
+	}
+	exists, err := afero.DirExists(fs, "4")
+	require.NoError(t, err)
+	require.True(t, exists, "the floor's own bucket survives")
+}
 
-	// Test pruning with keepSlotDistance = 10000
-	err := storage.Prune(10000)
+func TestDataColumnStorePruneBelowZeroRemovesNothing(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("0", 0o755))
+	storage := NewDataColumnStore(fs, globalBeaconConfig, beaconevents.NewEventEmitter())
+
+	require.NoError(t, storage.PruneBelow(0))
+	_, err := fs.Stat("0")
 	require.NoError(t, err)
 }
 
-func TestPruneWithLargeKeepDistance(t *testing.T) {
-	storage, fs, _, mockClock := setupTestDataColumnStorage(t)
+func TestDataColumnStorePruneBelowFloorAboveEveryBucketEmptiesTheStore(t *testing.T) {
+	storage, fs, _ := setupTestDataColumnStorage(t)
+	for _, bucket := range []string{"0", "1"} {
+		require.NoError(t, fs.MkdirAll(bucket, 0o755))
+	}
 
-	// Set up mock clock expectations for pruning
-	mockClock.(*eth_clock.MockEthereumClock).EXPECT().GetCurrentSlot().Return(uint64(100000)).AnyTimes()
+	require.NoError(t, storage.PruneBelow(50000))
 
-	// Create some test directories
-	fs.MkdirAll("0", 0755) // slot 0-9999
-	fs.MkdirAll("1", 0755) // slot 10000-19999
-
-	// Test pruning with very large keepSlotDistance
-	err := storage.Prune(50000)
-	require.NoError(t, err)
+	for _, gone := range []string{"0", "1"} {
+		exists, err := afero.DirExists(fs, gone)
+		require.NoError(t, err)
+		require.False(t, exists)
+	}
 }
 
-func TestPruneWithZeroKeepDistance(t *testing.T) {
-	storage, fs, _, mockClock := setupTestDataColumnStorage(t)
+func TestDataColumnStorePruneFloorRejectsLateWritesAndAllowsCleanup(t *testing.T) {
+	emitters := beaconevents.NewEventEmitter()
+	events := make(chan *beaconevents.EventStream, 4)
+	subscription := emitters.Operation().Subscribe(events)
+	defer subscription.Unsubscribe()
+	storage := NewDataColumnStore(afero.NewMemMapFs(), globalBeaconConfig, emitters)
+	oldRoot := common.Hash{1}
+	require.NoError(t, storage.WriteColumnSidecars(t.Context(), oldRoot, 0, createTestDataColumnSidecar(100, 0)))
+	<-events
 
-	// Set up mock clock expectations for pruning
-	mockClock.(*eth_clock.MockEthereumClock).EXPECT().GetCurrentSlot().Return(uint64(1000)).AnyTimes()
-
-	// Create some test directories
-	fs.MkdirAll("0", 0755) // slot 0-9999
-
-	// Test pruning with zero keepSlotDistance
-	err := storage.Prune(0)
+	require.NoError(t, storage.PruneBelow(500))
+	require.NoError(t, storage.RemoveColumnSidecars(t.Context(), 100, oldRoot, 0))
+	exists, err := storage.ColumnSidecarExists(t.Context(), 100, oldRoot, 0)
 	require.NoError(t, err)
+	require.False(t, exists, "cleanup removes must remain available below the write floor")
+
+	lateRoot := common.Hash{2}
+	require.NoError(t, storage.WriteColumnSidecars(t.Context(), lateRoot, 0, createTestDataColumnSidecar(499, 0)))
+	exists, err = storage.ColumnSidecarExists(t.Context(), 499, lateRoot, 0)
+	require.NoError(t, err)
+	require.False(t, exists)
+	require.Empty(t, events, "a rejected write must not emit a sidecar event")
+
+	boundaryRoot := common.Hash{3}
+	require.NoError(t, storage.WriteColumnSidecars(t.Context(), boundaryRoot, 0, createTestDataColumnSidecar(500, 0)))
+	exists, err = storage.ColumnSidecarExists(t.Context(), 500, boundaryRoot, 0)
+	require.NoError(t, err)
+	require.True(t, exists, "the floor itself remains writable")
+	require.Equal(t, beaconevents.OpDataColumnSidecar, (<-events).Event)
+
+	require.NoError(t, storage.PruneBelow(250))
+	lowerRoot := common.Hash{4}
+	require.NoError(t, storage.WriteColumnSidecars(t.Context(), lowerRoot, 0, createTestDataColumnSidecar(499, 0)))
+	exists, err = storage.ColumnSidecarExists(t.Context(), 499, lowerRoot, 0)
+	require.NoError(t, err)
+	require.False(t, exists)
+	require.Empty(t, events, "a lower later prune must not lower the write floor")
+}
+
+func TestDataColumnStorePartialPruneStillRejectsLateWrites(t *testing.T) {
+	fs := newRemoveAllFailingFs(afero.NewMemMapFs())
+	fs.failOn["0"] = errInducedFailure
+	require.NoError(t, fs.MkdirAll("0", 0o755))
+	storage := NewDataColumnStore(fs, globalBeaconConfig, beaconevents.NewEventEmitter())
+
+	require.ErrorIs(t, storage.PruneBelow(subdivisionSlot), errInducedFailure)
+	root := common.Hash{1}
+	require.NoError(t, storage.WriteColumnSidecars(t.Context(), root, 0, createTestDataColumnSidecar(subdivisionSlot-1, 0)))
+	exists, err := storage.ColumnSidecarExists(t.Context(), subdivisionSlot-1, root, 0)
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
+func TestDataColumnStoreConcurrentPrunesKeepTheHighestFloor(t *testing.T) {
+	storage := NewDataColumnStore(afero.NewMemMapFs(), globalBeaconConfig, beaconevents.NewEventEmitter())
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	for _, floor := range []uint64{500, 1_000} {
+		go func() {
+			<-start
+			errs <- storage.PruneBelow(floor)
+		}()
+	}
+	close(start)
+	require.NoError(t, <-errs)
+	require.NoError(t, <-errs)
+
+	root := common.Hash{1}
+	require.NoError(t, storage.WriteColumnSidecars(t.Context(), root, 0, createTestDataColumnSidecar(999, 0)))
+	exists, err := storage.ColumnSidecarExists(t.Context(), 999, root, 0)
+	require.NoError(t, err)
+	require.False(t, exists)
+	require.NoError(t, storage.WriteColumnSidecars(t.Context(), root, 0, createTestDataColumnSidecar(1_000, 0)))
+	exists, err = storage.ColumnSidecarExists(t.Context(), 1_000, root, 0)
+	require.NoError(t, err)
+	require.True(t, exists)
+}
+
+func TestBucketStorePruneFloorsAreIndependent(t *testing.T) {
+	first := NewDataColumnStore(afero.NewMemMapFs(), globalBeaconConfig, beaconevents.NewEventEmitter())
+	second := NewDataColumnStore(afero.NewMemMapFs(), globalBeaconConfig, beaconevents.NewEventEmitter())
+	require.NoError(t, first.PruneBelow(500))
+	root := common.Hash{1}
+	sidecar := createTestDataColumnSidecar(499, 0)
+
+	require.NoError(t, first.WriteColumnSidecars(t.Context(), root, 0, sidecar))
+	require.NoError(t, second.WriteColumnSidecars(t.Context(), root, 0, sidecar))
+	firstExists, err := first.ColumnSidecarExists(t.Context(), 499, root, 0)
+	require.NoError(t, err)
+	secondExists, err := second.ColumnSidecarExists(t.Context(), 499, root, 0)
+	require.NoError(t, err)
+	require.False(t, firstExists)
+	require.True(t, secondExists)
 }
 
 func TestWriteColumnSidecarsErrorHandling(t *testing.T) {
 	// Create a filesystem that will fail on directory creation
 	fs := afero.NewMemMapFs()
-	ctrl := gomock.NewController(t)
-	mockClock := eth_clock.NewMockEthereumClock(ctrl)
 
-	storage := NewDataColumnStore(fs, 1000, globalBeaconConfig, mockClock, beaconevents.NewEventEmitter())
+	storage := NewDataColumnStore(fs, globalBeaconConfig, beaconevents.NewEventEmitter())
 
 	blockRoot := common.HexToHash("0x1234567890abcdef")
 	columnIndex := int64(1)
@@ -391,7 +611,7 @@ func TestWriteColumnSidecarsErrorHandling(t *testing.T) {
 }
 
 func TestReadColumnSidecarByColumnIndexErrorHandling(t *testing.T) {
-	storage, _, _, _ := setupTestDataColumnStorage(t)
+	storage, _, _ := setupTestDataColumnStorage(t)
 
 	blockRoot := common.HexToHash("0x1234567890abcdef")
 	columnIndex := int64(1)
@@ -402,7 +622,7 @@ func TestReadColumnSidecarByColumnIndexErrorHandling(t *testing.T) {
 }
 
 func TestRemoveColumnSidecarsNonExistent(t *testing.T) {
-	storage, _, _, _ := setupTestDataColumnStorage(t)
+	storage, _, _ := setupTestDataColumnStorage(t)
 
 	blockRoot := common.HexToHash("0x1234567890abcdef")
 
@@ -412,7 +632,7 @@ func TestRemoveColumnSidecarsNonExistent(t *testing.T) {
 }
 
 func TestWriteStreamErrorHandling(t *testing.T) {
-	storage, _, _, _ := setupTestDataColumnStorage(t)
+	storage, _, _ := setupTestDataColumnStorage(t)
 
 	blockRoot := common.HexToHash("0x1234567890abcdef")
 	columnIndex := int64(1)
@@ -424,7 +644,7 @@ func TestWriteStreamErrorHandling(t *testing.T) {
 }
 
 func TestConcurrentAccess(t *testing.T) {
-	storage, _, _, _ := setupTestDataColumnStorage(t)
+	storage, _, _ := setupTestDataColumnStorage(t)
 	ctx := context.Background()
 
 	blockRoot := common.HexToHash("0x1234567890abcdef")

--- a/cl/persistence/blob_storage/fs_helpers_test.go
+++ b/cl/persistence/blob_storage/fs_helpers_test.go
@@ -1,0 +1,231 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package blob_storage
+
+import (
+	"errors"
+	"os"
+	"sync"
+
+	"github.com/spf13/afero"
+)
+
+const opRemoveAll = "RemoveAll"
+
+var errInducedFailure = errors.New("induced filesystem failure")
+
+type removeFailingFs struct {
+	afero.Fs
+	failOn map[string]error
+}
+
+func newRemoveFailingFs(fs afero.Fs) *removeFailingFs {
+	return &removeFailingFs{Fs: fs, failOn: map[string]error{}}
+}
+
+func (r *removeFailingFs) Remove(path string) error {
+	if err, ok := r.failOn[path]; ok {
+		return err
+	}
+	return r.Fs.Remove(path)
+}
+
+type countingFs struct {
+	afero.Fs
+	mu    sync.Mutex
+	calls map[string][][]string
+}
+
+func newCountingFs(fs afero.Fs) *countingFs {
+	return &countingFs{Fs: fs, calls: map[string][][]string{}}
+}
+
+func (c *countingFs) record(op string, args ...string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls[op] = append(c.calls[op], args)
+}
+
+func (c *countingFs) count(op string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.calls[op])
+}
+
+func (c *countingFs) paths(op string) []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, 0, len(c.calls[op]))
+	for _, args := range c.calls[op] {
+		out = append(out, args[0])
+	}
+	return out
+}
+
+func (c *countingFs) reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	clear(c.calls)
+}
+
+func (c *countingFs) RemoveAll(path string) error {
+	c.record(opRemoveAll, path)
+	return c.Fs.RemoveAll(path)
+}
+
+type failRule struct {
+	writeBudget int
+	writeErr    error
+	syncErr     error
+	shortWrite  bool
+}
+
+type failingFs struct {
+	afero.Fs
+	mu    sync.Mutex
+	rules map[string]failRule
+}
+
+func newFailingFs(fs afero.Fs) *failingFs {
+	return &failingFs{Fs: fs, rules: map[string]failRule{}}
+}
+
+func (f *failingFs) failWritesAfter(name string, budget int, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	r := f.rules[name]
+	r.writeBudget, r.writeErr = budget, err
+	f.rules[name] = r
+}
+
+func (f *failingFs) failSyncAt(name string, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	r := f.rules[name]
+	r.syncErr = err
+	f.rules[name] = r
+}
+
+func (f *failingFs) failShortWrite(name string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	r := f.rules[name]
+	r.shortWrite = true
+	f.rules[name] = r
+}
+
+func (f *failingFs) clearFailures() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	clear(f.rules)
+}
+
+func (f *failingFs) ruleFor(name string) failRule {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.rules[name]
+}
+
+func (f *failingFs) Create(name string) (afero.File, error) {
+	fh, err := f.Fs.Create(name)
+	if err != nil {
+		return nil, err
+	}
+	return f.wrap(name, fh), nil
+}
+
+func (f *failingFs) OpenFile(name string, flag int, perm os.FileMode) (afero.File, error) {
+	fh, err := f.Fs.OpenFile(name, flag, perm)
+	if err != nil {
+		return nil, err
+	}
+	return f.wrap(name, fh), nil
+}
+
+func (f *failingFs) wrap(name string, fh afero.File) afero.File {
+	r := f.ruleFor(name)
+	if r.writeErr == nil && r.syncErr == nil && !r.shortWrite {
+		return fh
+	}
+	return &failingFile{File: fh, budget: r.writeBudget, writeErr: r.writeErr, syncErr: r.syncErr, shortWrite: r.shortWrite}
+}
+
+type failingFile struct {
+	afero.File
+	budget     int
+	writeErr   error
+	syncErr    error
+	shortWrite bool
+}
+
+func (f *failingFile) Write(p []byte) (int, error) {
+	return f.write(p)
+}
+
+func (f *failingFile) WriteString(s string) (int, error) {
+	return f.write([]byte(s))
+}
+
+func (f *failingFile) write(p []byte) (int, error) {
+	if f.shortWrite && len(p) > 0 {
+		return f.File.Write(p[:len(p)-1])
+	}
+	if f.writeErr == nil {
+		return f.File.Write(p)
+	}
+	if f.budget <= 0 {
+		return 0, f.writeErr
+	}
+	written, err := f.File.Write(p[:min(f.budget, len(p))])
+	f.budget -= written
+	if err != nil {
+		return written, err
+	}
+	if written < len(p) {
+		return written, f.writeErr
+	}
+	return written, nil
+}
+
+func (f *failingFile) Sync() error {
+	if f.syncErr != nil {
+		return f.syncErr
+	}
+	return f.File.Sync()
+}
+
+type renameFailingFs struct {
+	afero.Fs
+	err             error
+	dropDestination bool
+}
+
+func newRenameFailingFs(fs afero.Fs, err error) *renameFailingFs {
+	return &renameFailingFs{Fs: fs, err: err}
+}
+
+func (r *renameFailingFs) Rename(oldname, newname string) error {
+	if r.dropDestination {
+		if err := r.Fs.Remove(newname); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	if r.err != nil {
+		return r.err
+	}
+	return r.Fs.Rename(oldname, newname)
+}

--- a/cl/persistence/blob_storage/mock_services/blob_storage_mock.go
+++ b/cl/persistence/blob_storage/mock_services/blob_storage_mock.go
@@ -121,40 +121,40 @@ func (c *MockBlobStorageKzgCommitmentsCountCall) DoAndReturn(f func(context.Cont
 	return c
 }
 
-// Prune mocks base method.
-func (m *MockBlobStorage) Prune() error {
+// PruneBelow mocks base method.
+func (m *MockBlobStorage) PruneBelow(slot uint64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Prune")
+	ret := m.ctrl.Call(m, "PruneBelow", slot)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Prune indicates an expected call of Prune.
-func (mr *MockBlobStorageMockRecorder) Prune() *MockBlobStoragePruneCall {
+// PruneBelow indicates an expected call of PruneBelow.
+func (mr *MockBlobStorageMockRecorder) PruneBelow(slot any) *MockBlobStoragePruneBelowCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prune", reflect.TypeOf((*MockBlobStorage)(nil).Prune))
-	return &MockBlobStoragePruneCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PruneBelow", reflect.TypeOf((*MockBlobStorage)(nil).PruneBelow), slot)
+	return &MockBlobStoragePruneBelowCall{Call: call}
 }
 
-// MockBlobStoragePruneCall wrap *gomock.Call
-type MockBlobStoragePruneCall struct {
+// MockBlobStoragePruneBelowCall wrap *gomock.Call
+type MockBlobStoragePruneBelowCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockBlobStoragePruneCall) Return(arg0 error) *MockBlobStoragePruneCall {
+func (c *MockBlobStoragePruneBelowCall) Return(arg0 error) *MockBlobStoragePruneBelowCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockBlobStoragePruneCall) Do(f func() error) *MockBlobStoragePruneCall {
+func (c *MockBlobStoragePruneBelowCall) Do(f func(uint64) error) *MockBlobStoragePruneBelowCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockBlobStoragePruneCall) DoAndReturn(f func() error) *MockBlobStoragePruneCall {
+func (c *MockBlobStoragePruneBelowCall) DoAndReturn(f func(uint64) error) *MockBlobStoragePruneBelowCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/cl/persistence/blob_storage/mock_services/data_column_storage_mock.go
+++ b/cl/persistence/blob_storage/mock_services/data_column_storage_mock.go
@@ -121,40 +121,40 @@ func (c *MockDataColumnStorageGetSavedColumnIndexCall) DoAndReturn(f func(contex
 	return c
 }
 
-// Prune mocks base method.
-func (m *MockDataColumnStorage) Prune(keepSlotDistance uint64) error {
+// PruneBelow mocks base method.
+func (m *MockDataColumnStorage) PruneBelow(slot uint64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Prune", keepSlotDistance)
+	ret := m.ctrl.Call(m, "PruneBelow", slot)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Prune indicates an expected call of Prune.
-func (mr *MockDataColumnStorageMockRecorder) Prune(keepSlotDistance any) *MockDataColumnStoragePruneCall {
+// PruneBelow indicates an expected call of PruneBelow.
+func (mr *MockDataColumnStorageMockRecorder) PruneBelow(slot any) *MockDataColumnStoragePruneBelowCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prune", reflect.TypeOf((*MockDataColumnStorage)(nil).Prune), keepSlotDistance)
-	return &MockDataColumnStoragePruneCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PruneBelow", reflect.TypeOf((*MockDataColumnStorage)(nil).PruneBelow), slot)
+	return &MockDataColumnStoragePruneBelowCall{Call: call}
 }
 
-// MockDataColumnStoragePruneCall wrap *gomock.Call
-type MockDataColumnStoragePruneCall struct {
+// MockDataColumnStoragePruneBelowCall wrap *gomock.Call
+type MockDataColumnStoragePruneBelowCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockDataColumnStoragePruneCall) Return(arg0 error) *MockDataColumnStoragePruneCall {
+func (c *MockDataColumnStoragePruneBelowCall) Return(arg0 error) *MockDataColumnStoragePruneBelowCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockDataColumnStoragePruneCall) Do(f func(uint64) error) *MockDataColumnStoragePruneCall {
+func (c *MockDataColumnStoragePruneBelowCall) Do(f func(uint64) error) *MockDataColumnStoragePruneBelowCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockDataColumnStoragePruneCall) DoAndReturn(f func(uint64) error) *MockDataColumnStoragePruneCall {
+func (c *MockDataColumnStoragePruneBelowCall) DoAndReturn(f func(uint64) error) *MockDataColumnStoragePruneBelowCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -194,44 +194,6 @@ func (c *MockDataColumnStorageReadColumnSidecarByColumnIndexCall) Do(f func(cont
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockDataColumnStorageReadColumnSidecarByColumnIndexCall) DoAndReturn(f func(context.Context, uint64, common.Hash, int64) (*cltypes.DataColumnSidecar, error)) *MockDataColumnStorageReadColumnSidecarByColumnIndexCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// RemoveAllColumnSidecars mocks base method.
-func (m *MockDataColumnStorage) RemoveAllColumnSidecars(ctx context.Context, slot uint64, blockRoot common.Hash) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveAllColumnSidecars", ctx, slot, blockRoot)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RemoveAllColumnSidecars indicates an expected call of RemoveAllColumnSidecars.
-func (mr *MockDataColumnStorageMockRecorder) RemoveAllColumnSidecars(ctx, slot, blockRoot any) *MockDataColumnStorageRemoveAllColumnSidecarsCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAllColumnSidecars", reflect.TypeOf((*MockDataColumnStorage)(nil).RemoveAllColumnSidecars), ctx, slot, blockRoot)
-	return &MockDataColumnStorageRemoveAllColumnSidecarsCall{Call: call}
-}
-
-// MockDataColumnStorageRemoveAllColumnSidecarsCall wrap *gomock.Call
-type MockDataColumnStorageRemoveAllColumnSidecarsCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockDataColumnStorageRemoveAllColumnSidecarsCall) Return(arg0 error) *MockDataColumnStorageRemoveAllColumnSidecarsCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockDataColumnStorageRemoveAllColumnSidecarsCall) Do(f func(context.Context, uint64, common.Hash) error) *MockDataColumnStorageRemoveAllColumnSidecarsCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockDataColumnStorageRemoveAllColumnSidecarsCall) DoAndReturn(f func(context.Context, uint64, common.Hash) error) *MockDataColumnStorageRemoveAllColumnSidecarsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/cl/persistence/blob_storage/sharing_violation_other.go
+++ b/cl/persistence/blob_storage/sharing_violation_other.go
@@ -1,0 +1,21 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !windows
+
+package blob_storage
+
+func isSharingViolation(error) bool { return false }

--- a/cl/persistence/blob_storage/sharing_violation_windows.go
+++ b/cl/persistence/blob_storage/sharing_violation_windows.go
@@ -1,0 +1,29 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build windows
+
+package blob_storage
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+func isSharingViolation(err error) bool {
+	return errors.Is(err, windows.ERROR_SHARING_VIOLATION) || errors.Is(err, windows.ERROR_ACCESS_DENIED)
+}

--- a/cl/phase1/forkchoice/fork_choice_test.go
+++ b/cl/phase1/forkchoice/fork_choice_test.go
@@ -19,7 +19,6 @@ package forkchoice_test
 import (
 	"context"
 	_ "embed"
-	"math"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -91,7 +90,7 @@ func TestForkChoiceBasic(t *testing.T) {
 	genesisState, err := initial_state.GetGenesisState(1) // Mainnet
 	require.NoError(t, err)
 	ethClock := eth_clock.NewEthereumClock(genesisState.GenesisTime(), genesisState.GenesisValidatorsRoot(), &clparams.MainnetBeaconConfig)
-	blobStorage := blob_storage.NewBlobStore(memdb.NewTestDB(t, dbcfg.ChainDB), afero.NewMemMapFs(), math.MaxUint64, &clparams.MainnetBeaconConfig, ethClock)
+	blobStorage := blob_storage.NewBlobStore(memdb.NewTestDB(t, dbcfg.ChainDB), afero.NewMemMapFs())
 	localValidators := validator_params.NewValidatorParams()
 
 	store, err := forkchoice.NewForkChoiceStore(
@@ -187,7 +186,7 @@ func TestForkChoiceChainBellatrix(t *testing.T) {
 	genesisState, err := initial_state.GetGenesisState(1) // Mainnet
 	require.NoError(t, err)
 	ethClock := eth_clock.NewEthereumClock(genesisState.GenesisTime(), genesisState.GenesisValidatorsRoot(), &clparams.MainnetBeaconConfig)
-	blobStorage := blob_storage.NewBlobStore(memdb.NewTestDB(t, dbcfg.ChainDB), afero.NewMemMapFs(), math.MaxUint64, &clparams.MainnetBeaconConfig, ethClock)
+	blobStorage := blob_storage.NewBlobStore(memdb.NewTestDB(t, dbcfg.ChainDB), afero.NewMemMapFs())
 	localValidators := validator_params.NewValidatorParams()
 
 	store, err := forkchoice.NewForkChoiceStore(

--- a/cl/phase1/forkchoice/mock_services/forkchoice_mock.go
+++ b/cl/phase1/forkchoice/mock_services/forkchoice_mock.go
@@ -165,7 +165,7 @@ func NewForkChoiceStorageMock(t *testing.T) *ForkChoiceStorageMock {
 		Return(true, nil).
 		AnyTimes()
 	mockPeerDas.EXPECT().
-		Prune(gomock.Any()).
+		PruneBelow(gomock.Any()).
 		Return(nil).
 		AnyTimes()
 	mockPeerDas.EXPECT().

--- a/cl/phase1/forkchoice/weight_store_diff_test.go
+++ b/cl/phase1/forkchoice/weight_store_diff_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
-	"math"
 	"slices"
 	"testing"
 
@@ -84,7 +83,7 @@ func buildExAnteStore(tb testing.TB) *ForkChoiceStore {
 	gs, err := initial_state.GetGenesisState(1)
 	require.NoError(tb, err)
 	clk := eth_clock.NewEthereumClock(gs.GenesisTime(), gs.GenesisValidatorsRoot(), cfg)
-	bs := blob_storage.NewBlobStore(memdb.NewTestDB(tb, dbcfg.ChainDB), afero.NewMemMapFs(), math.MaxUint64, cfg, clk)
+	bs := blob_storage.NewBlobStore(memdb.NewTestDB(tb, dbcfg.ChainDB), afero.NewMemMapFs())
 	store, err := NewForkChoiceStore(clk, anchor, nil, pool.NewOperationsPool(cfg),
 		fork_graph.NewForkGraphDisk(anchor, nil, afero.NewMemMapFs(), beacon_router_configuration.RouterConfiguration{}),
 		em, sd, bs, public_keys_registry.NewInMemoryPublicKeysRegistry(), validator_params.NewValidatorParams(), false, nil)

--- a/cl/phase1/network/beacon_downloader.go
+++ b/cl/phase1/network/beacon_downloader.go
@@ -111,56 +111,140 @@ func (f *ForwardBeaconDownloader) SetHighestProcessedSlot(highestSlotProcessed u
 	}
 }
 
-type peerAndBlocks struct {
-	peerId string
-	blocks []*cltypes.SignedBeaconBlock
+func (f *ForwardBeaconDownloader) progressSnapshot() (uint64, time.Time, uint64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.highestSlotProcessed, f.highestSlotUpdateTime, f.minSlot
 }
 
+type peerAndBlocks struct {
+	peerId                 string
+	blocks                 []*cltypes.SignedBeaconBlock
+	httpSampledHighestSlot uint64
+	fromHTTP               bool
+}
+
+var (
+	forwardBeaconRequestInterval = 300 * time.Millisecond
+	forwardBeaconRequestTimeout  = 30 * time.Second
+	forwardBeaconProbeTimeout    = 21 * time.Second
+	forwardBeaconFallbackDelay   = 5 * time.Second
+	forwardBeaconResponsePoll    = 10 * time.Millisecond
+)
+
+const maxConcurrentForwardBeaconRequests = 2
+
 func (f *ForwardBeaconDownloader) RequestMore(ctx context.Context) {
+	requestCtx, cancelRequests := context.WithTimeout(ctx, forwardBeaconRequestTimeout)
+	defer cancelRequests()
+
 	count := uint64(32)
 	var atomicResp atomic.Value
 	atomicResp.Store(peerAndBlocks{})
+	commitHTTPBlocks := func(sampledHighestSlot, httpStart uint64, blocks []*cltypes.SignedBeaconBlock) bool {
+		if len(blocks) == 0 {
+			return false
+		}
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		if f.highestSlotProcessed != sampledHighestSlot || len(atomicResp.Load().(peerAndBlocks).blocks) > 0 {
+			return false
+		}
+		log.Debug("[ForwardBeaconDownloader] fetched blocks from beacon API",
+			"fromSlot", httpStart, "count", len(blocks))
+		atomicResp.Store(peerAndBlocks{
+			peerId:                 "http-fallback",
+			blocks:                 blocks,
+			httpSampledHighestSlot: sampledHighestSlot,
+			fromHTTP:               true,
+		})
+		return true
+	}
 
 	// Fast path: when HTTP has been working, skip P2P probing entirely.
 	if f.httpPreferred.Load() && f.httpFallbackURL != "" {
-		httpStart := f.highestSlotProcessed + 1
-		httpBlocks, httpErr := fetchBlocksFromBeaconAPI(ctx, f.httpFallbackURL, httpStart, count+10, f.beaconCfg)
-		if httpErr == nil && len(httpBlocks) > 0 {
-			atomicResp.Store(peerAndBlocks{"http-fallback", httpBlocks})
-		} else {
+		highestSlotProcessed, _, _ := f.progressSnapshot()
+		httpStart := highestSlotProcessed + 1
+		httpBlocks, httpErr := fetchBlocksFromBeaconAPI(requestCtx, f.httpFallbackURL, httpStart, count+10, f.beaconCfg)
+		if httpErr != nil || !commitHTTPBlocks(highestSlotProcessed, httpStart, httpBlocks) {
 			// HTTP failed — fall back to P2P probing.
 			f.httpPreferred.Store(false)
 		}
 		if len(atomicResp.Load().(peerAndBlocks).blocks) > 0 {
 			goto Process
 		}
+		if requestCtx.Err() != nil {
+			return
+		}
 	}
 
 	{
+		probeCtx, cancelProbes := context.WithCancel(requestCtx)
+		var probeWG sync.WaitGroup
+		probeSlots := make(chan struct{}, maxConcurrentForwardBeaconRequests)
+		var httpFallbackRunning atomic.Bool
+		stopProbes := func() {
+			cancelProbes()
+			probeWG.Wait()
+		}
+		defer stopProbes()
+		startHTTPFallback := func() {
+			if f.httpFallbackURL == "" || !httpFallbackRunning.CompareAndSwap(false, true) {
+				return
+			}
+			probeWG.Go(func() {
+				latestHighestSlotProcessed, _, _ := f.progressSnapshot()
+				httpStart := latestHighestSlotProcessed + 1
+				httpBlocks, httpErr := fetchBlocksFromBeaconAPI(probeCtx, f.httpFallbackURL, httpStart, count+10, f.beaconCfg)
+				if probeCtx.Err() != nil {
+					return
+				}
+				if httpErr == nil && len(httpBlocks) > 0 {
+					if commitHTTPBlocks(latestHighestSlotProcessed, httpStart, httpBlocks) {
+						return
+					}
+				}
+				httpFallbackRunning.Store(false)
+				if httpErr != nil {
+					log.Debug("[ForwardBeaconDownloader] HTTP fallback also failed", "err", httpErr)
+				}
+			})
+		}
+
 		// Start with a base interval; backoff increases it on repeated failures.
-		baseInterval := 300 * time.Millisecond
+		baseInterval := forwardBeaconRequestInterval
 		var consecutiveFailures atomic.Int32
 		reqInterval := time.NewTicker(baseInterval)
 		defer reqInterval.Stop()
-		// Timeout: if no blocks received within this duration, return to let the caller
-		// run stale detection and potentially switch to ChainTipSync.
-		requestTimeout := time.NewTimer(30 * time.Second)
-		defer requestTimeout.Stop()
+		var fallbackTimer *time.Timer
+		var fallbackTimerC <-chan time.Time
+		if f.httpFallbackURL != "" {
+			fallbackTimer = time.NewTimer(forwardBeaconFallbackDelay)
+			fallbackTimerC = fallbackTimer.C
+			defer fallbackTimer.Stop()
+		}
 
 	Loop:
 		for {
 			select {
 			case <-reqInterval.C:
-				go func() {
+				select {
+				case probeSlots <- struct{}{}:
+				default:
+					continue
+				}
+				probeWG.Go(func() {
+					defer func() { <-probeSlots }()
 					if len(atomicResp.Load().(peerAndBlocks).blocks) > 0 {
 						return
 					}
+					highestSlotProcessed, highestSlotUpdateTime, minSlot := f.progressSnapshot()
 					var reqSlot uint64
-					if f.highestSlotProcessed > 2 {
-						reqSlot = f.highestSlotProcessed - 2
+					if highestSlotProcessed > 2 {
+						reqSlot = highestSlotProcessed - 2
 					}
-					if reqSlot < f.minSlot {
-						reqSlot = f.minSlot
+					if reqSlot < minSlot {
+						reqSlot = minSlot
 					}
 					// Request one extra block beyond the batch for GLOAS lookahead:
 					// the extra block lets determineFullGloasRoots check whether the
@@ -171,14 +255,19 @@ func (f *ForwardBeaconDownloader) RequestMore(ctx context.Context) {
 					// says peers SHOULD NOT serve blocks across fork boundaries in a
 					// single BeaconBlocksByRange response.
 					if f.beaconCfg != nil {
-						reqSlot, reqCount = f.capAtForkBoundary(reqSlot, reqCount)
+						reqSlot, reqCount = f.capAtForkBoundary(reqSlot, reqCount, highestSlotProcessed)
 					}
 
 					// leave a warning if we are stuck for more than 90 seconds
-					if time.Since(f.highestSlotUpdateTime) > 90*time.Second {
-						log.Trace("Forward beacon downloader gets stuck", "time", time.Since(f.highestSlotUpdateTime).Seconds(), "highestSlotProcessed", f.highestSlotProcessed)
+					if time.Since(highestSlotUpdateTime) > 90*time.Second {
+						log.Trace("Forward beacon downloader gets stuck", "time", time.Since(highestSlotUpdateTime).Seconds(), "highestSlotProcessed", highestSlotProcessed)
 					}
-					responses, peerId, err := f.rpc.SendBeaconBlocksByRangeReq(ctx, reqSlot, reqCount)
+					attemptCtx, cancelAttempt := context.WithTimeout(probeCtx, forwardBeaconProbeTimeout)
+					responses, peerId, err := f.rpc.SendBeaconBlocksByRangeReq(attemptCtx, reqSlot, reqCount)
+					cancelAttempt()
+					if probeCtx.Err() != nil {
+						return
+					}
 					if err != nil {
 						if errors.Is(err, peers.ErrNoPeers) {
 							log.Debug("[Caplin] no peers available for beacon blocks by range request", "slot", reqSlot, "reqCount", reqCount)
@@ -199,19 +288,7 @@ func (f *ForwardBeaconDownloader) RequestMore(ctx context.Context) {
 							if len(atomicResp.Load().(peerAndBlocks).blocks) > 0 {
 								return
 							}
-							httpStart := f.highestSlotProcessed + 1
-							httpBlocks, httpErr := fetchBlocksFromBeaconAPI(ctx, f.httpFallbackURL, httpStart, count+10, f.beaconCfg)
-							if httpErr == nil && len(httpBlocks) > 0 {
-								log.Debug("[ForwardBeaconDownloader] P2P failed, fetched blocks from beacon API",
-									"fromSlot", httpStart, "count", len(httpBlocks))
-								consecutiveFailures.Store(0)
-								f.httpPreferred.Store(true)
-								atomicResp.Store(peerAndBlocks{"http-fallback", httpBlocks})
-								return
-							}
-							if httpErr != nil {
-								log.Debug("[ForwardBeaconDownloader] HTTP fallback also failed", "err", httpErr)
-							}
+							startHTTPFallback()
 						}
 
 						backoff := min(baseInterval*time.Duration(1<<uint(min(failures, 4))), 5*time.Second)
@@ -222,44 +299,51 @@ func (f *ForwardBeaconDownloader) RequestMore(ctx context.Context) {
 						return
 					}
 					if len(responses) == 0 {
-						// Empty response: no blocks in this slot range.
-						// Advance past the requested range so we don't get stuck requesting the same empty range.
-						f.mu.Lock()
-						newSlot := reqSlot + count
-						if newSlot > f.highestSlotProcessed {
-							log.Debug("Empty block range response, advancing past gap", "from", f.highestSlotProcessed, "to", newSlot, "peer", peerId)
-							f.highestSlotProcessed = newSlot
-							f.highestSlotUpdateTime = time.Now()
+						failures := int(consecutiveFailures.Add(1))
+						if failures >= 5 && f.httpFallbackURL != "" {
+							startHTTPFallback()
 						}
-						f.mu.Unlock()
+						backoff := min(baseInterval*time.Duration(1<<uint(min(failures, 4))), 5*time.Second)
+						reqInterval.Reset(backoff)
 						return
 					}
 					// Success: reset backoff
 					consecutiveFailures.Store(0)
 					reqInterval.Reset(baseInterval)
-					if len(atomicResp.Load().(peerAndBlocks).blocks) > 0 {
-						return
+					f.mu.Lock()
+					if len(atomicResp.Load().(peerAndBlocks).blocks) == 0 {
+						atomicResp.Store(peerAndBlocks{peerId: peerId, blocks: responses})
 					}
-					atomicResp.Store(peerAndBlocks{peerId, responses})
-				}()
-			case <-ctx.Done():
-				return
-			case <-requestTimeout.C:
+					f.mu.Unlock()
+				})
+			case <-requestCtx.Done():
 				// No blocks received in time — return to let stale detection run.
+				stopProbes()
 				return
+			case <-fallbackTimerC:
+				startHTTPFallback()
+				fallbackTimerC = nil
 			default:
 				if len(atomicResp.Load().(peerAndBlocks).blocks) > 0 {
 					break Loop
 				}
-				time.Sleep(10 * time.Millisecond)
+				time.Sleep(forwardBeaconResponsePoll)
 			}
 		}
+		stopProbes()
 	} // end P2P probing block
 
 Process:
 	resp := atomicResp.Load().(peerAndBlocks)
 	processBlocks := resp.blocks
 	pid := resp.peerId
+	if resp.fromHTTP {
+		highestSlotProcessed, _, _ := f.progressSnapshot()
+		if highestSlotProcessed != resp.httpSampledHighestSlot {
+			f.httpPreferred.Store(false)
+			return
+		}
+	}
 
 	slices.SortFunc(processBlocks, func(a, b *cltypes.SignedBeaconBlock) int {
 		return cmp.Compare(a.Block.Slot, b.Block.Slot)
@@ -325,14 +409,24 @@ Process:
 
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if resp.fromHTTP && f.highestSlotProcessed != resp.httpSampledHighestSlot {
+		f.httpPreferred.Store(false)
+		return
+	}
 
-	var highestSlotProcessed uint64
-	var err error
-	if highestSlotProcessed, err = f.process(f.highestSlotProcessed, processBlocks, envelopes); err != nil {
+	previousHighestSlotProcessed := f.highestSlotProcessed
+	highestSlotProcessed, err := f.process(previousHighestSlotProcessed, processBlocks, envelopes)
+	if err != nil {
+		if resp.fromHTTP {
+			f.httpPreferred.Store(false)
+		}
 		if pid != "http-fallback" {
 			f.rpc.BanPeer(pid)
 		}
 		return
+	}
+	if resp.fromHTTP {
+		f.httpPreferred.Store(highestSlotProcessed > previousHighestSlotProcessed)
 	}
 	if highestSlotProcessed > f.highestSlotProcessed {
 		f.highestSlotProcessed = highestSlotProcessed
@@ -399,7 +493,7 @@ func determineFullGloasRoots(blocks []*cltypes.SignedBeaconBlock, processCount i
 // the overlap slots are already processed, so we advance reqSlot past the
 // boundary instead of capping — otherwise the downloader re-requests the same
 // already-processed slots and never makes progress.
-func (f *ForwardBeaconDownloader) capAtForkBoundary(reqSlot, reqCount uint64) (uint64, uint64) {
+func (f *ForwardBeaconDownloader) capAtForkBoundary(reqSlot, reqCount, highestSlotProcessed uint64) (uint64, uint64) {
 	slotsPerEpoch := f.beaconCfg.SlotsPerEpoch
 	forkEpochs := []uint64{
 		f.beaconCfg.AltairForkEpoch,
@@ -429,7 +523,7 @@ func (f *ForwardBeaconDownloader) capAtForkBoundary(reqSlot, reqCount uint64) (u
 			break
 		}
 		// boundarySlot is in (reqSlot, endSlot).
-		if boundarySlot <= f.highestSlotProcessed+1 {
+		if boundarySlot <= highestSlotProcessed+1 {
 			// Already processed past this boundary — skip the pre-boundary
 			// overlap and start from the boundary so the request stays
 			// within a single fork.

--- a/cl/phase1/network/beacon_downloader_test.go
+++ b/cl/phase1/network/beacon_downloader_test.go
@@ -1,0 +1,870 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package network
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/rpc"
+	"github.com/erigontech/erigon/cl/sentinel/communication/ssz_snappy"
+	"github.com/erigontech/erigon/cl/utils/eth_clock"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/node/gointerfaces/sentinelproto"
+)
+
+type countingBlockingSentinel struct {
+	sentinelproto.SentinelClient
+	active    atomic.Int32
+	maximum   atomic.Int32
+	overLimit chan struct{}
+	drained   chan struct{}
+	overOnce  sync.Once
+	drainOnce sync.Once
+}
+
+type rotatingProbeSentinel struct {
+	sentinelproto.SentinelClient
+	response   []byte
+	calls      atomic.Int32
+	active     atomic.Int32
+	maximum    atomic.Int32
+	canceled   chan struct{}
+	cancelOnce sync.Once
+}
+
+type switchableProbeSentinel struct {
+	sentinelproto.SentinelClient
+	response []byte
+	healthy  atomic.Bool
+	calls    atomic.Int32
+}
+
+type emptyThenBlockSentinel struct {
+	sentinelproto.SentinelClient
+	response      []byte
+	emptyReturned chan struct{}
+	allowBlock    chan struct{}
+	calls         atomic.Int32
+}
+
+func (s *emptyThenBlockSentinel) SendRequest(ctx context.Context, _ *sentinelproto.RequestData, _ ...grpc.CallOption) (*sentinelproto.ResponseData, error) {
+	if s.calls.Add(1) == 1 {
+		close(s.emptyReturned)
+		return &sentinelproto.ResponseData{Peer: &sentinelproto.Peer{Pid: "empty-peer"}}, nil
+	}
+	select {
+	case <-s.allowBlock:
+		return &sentinelproto.ResponseData{Data: s.response, Peer: &sentinelproto.Peer{Pid: "block-peer"}}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (s *switchableProbeSentinel) SendRequest(ctx context.Context, _ *sentinelproto.RequestData, _ ...grpc.CallOption) (*sentinelproto.ResponseData, error) {
+	s.calls.Add(1)
+	if !s.healthy.Load() {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	return &sentinelproto.ResponseData{Data: s.response, Peer: &sentinelproto.Peer{Pid: "healthy-peer"}}, nil
+}
+
+func (s *rotatingProbeSentinel) SendRequest(ctx context.Context, _ *sentinelproto.RequestData, _ ...grpc.CallOption) (*sentinelproto.ResponseData, error) {
+	call := s.calls.Add(1)
+	active := s.active.Add(1)
+	defer s.active.Add(-1)
+	for {
+		maximum := s.maximum.Load()
+		if active <= maximum || s.maximum.CompareAndSwap(maximum, active) {
+			break
+		}
+	}
+	if call <= 2 {
+		<-ctx.Done()
+		if call == 2 {
+			s.cancelOnce.Do(func() { close(s.canceled) })
+		}
+		return nil, ctx.Err()
+	}
+	return &sentinelproto.ResponseData{
+		Data: s.response,
+		Peer: &sentinelproto.Peer{Pid: "healthy-peer"},
+	}, nil
+}
+
+func newCountingBlockingSentinel() *countingBlockingSentinel {
+	return &countingBlockingSentinel{
+		overLimit: make(chan struct{}),
+		drained:   make(chan struct{}),
+	}
+}
+
+func (s *countingBlockingSentinel) SendRequest(ctx context.Context, _ *sentinelproto.RequestData, _ ...grpc.CallOption) (*sentinelproto.ResponseData, error) {
+	active := s.active.Add(1)
+	for {
+		maximum := s.maximum.Load()
+		if active <= maximum || s.maximum.CompareAndSwap(maximum, active) {
+			break
+		}
+	}
+	if active > 2 {
+		s.overOnce.Do(func() { close(s.overLimit) })
+	}
+	<-ctx.Done()
+	if s.active.Add(-1) == 0 {
+		s.drainOnce.Do(func() { close(s.drained) })
+	}
+	return nil, ctx.Err()
+}
+
+type contextBlockingSentinel struct {
+	sentinelproto.SentinelClient
+	started  chan struct{}
+	canceled chan struct{}
+	start    sync.Once
+	stop     sync.Once
+}
+
+type emptyAfterFallbackStartsSentinel struct {
+	sentinelproto.SentinelClient
+	fallbackStarted <-chan struct{}
+}
+
+func (s *emptyAfterFallbackStartsSentinel) SendRequest(ctx context.Context, _ *sentinelproto.RequestData, _ ...grpc.CallOption) (*sentinelproto.ResponseData, error) {
+	select {
+	case <-s.fallbackStarted:
+		return &sentinelproto.ResponseData{Peer: &sentinelproto.Peer{Pid: "empty-peer"}}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func newContextBlockingSentinel() *contextBlockingSentinel {
+	return &contextBlockingSentinel{
+		started:  make(chan struct{}),
+		canceled: make(chan struct{}),
+	}
+}
+
+func (s *contextBlockingSentinel) SendRequest(ctx context.Context, _ *sentinelproto.RequestData, _ ...grpc.CallOption) (*sentinelproto.ResponseData, error) {
+	s.start.Do(func() { close(s.started) })
+	<-ctx.Done()
+	s.stop.Do(func() { close(s.canceled) })
+	return nil, ctx.Err()
+}
+
+func newContextBlockingBeaconRPC(ctx context.Context, sentinel sentinelproto.SentinelClient) (*rpc.BeaconRpcP2P, *clparams.BeaconChainConfig) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.InitializeForkSchedule()
+	clock := eth_clock.NewEthereumClock(uint64(time.Now().Unix()), common.Hash{}, &cfg)
+	return rpc.NewBeaconRpcP2P(ctx, sentinel, &cfg, clock, nil), &cfg
+}
+
+func TestForwardRequestMoreCancelsOutstandingRequestsWhenBatchExpires(t *testing.T) {
+	previousInterval := forwardBeaconRequestInterval
+	previousTimeout := forwardBeaconRequestTimeout
+	forwardBeaconRequestInterval = time.Millisecond
+	forwardBeaconRequestTimeout = 100 * time.Millisecond
+	t.Cleanup(func() {
+		forwardBeaconRequestInterval = previousInterval
+		forwardBeaconRequestTimeout = previousTimeout
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	sentinel := newContextBlockingSentinel()
+	rpcClient, cfg := newContextBlockingBeaconRPC(ctx, sentinel)
+	downloader := NewForwardBeaconDownloader(ctx, rpcClient, cfg)
+
+	done := make(chan struct{})
+	go func() {
+		downloader.RequestMore(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-sentinel.started:
+	case <-time.After(time.Second):
+		t.Fatal("request did not reach the Sentinel boundary")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("RequestMore did not return after its batch expired")
+	}
+
+	select {
+	case <-sentinel.canceled:
+	case <-time.After(time.Second):
+		t.Fatal("batch expiration returned without canceling the outstanding request")
+	}
+}
+
+func TestForwardRequestMoreEmptyResponseKeepsUnknownRange(t *testing.T) {
+	previousInterval := forwardBeaconRequestInterval
+	previousTimeout := forwardBeaconRequestTimeout
+	forwardBeaconRequestInterval = time.Millisecond
+	forwardBeaconRequestTimeout = time.Second
+	t.Cleanup(func() {
+		forwardBeaconRequestInterval = previousInterval
+		forwardBeaconRequestTimeout = previousTimeout
+	})
+
+	cfg := clparams.MainnetBeaconConfig
+	cfg.InitializeForkSchedule()
+	clock := eth_clock.NewEthereumClock(uint64(time.Now().Unix()), common.Hash{}, &cfg)
+	block := cltypes.NewSignedBeaconBlock(&cfg, clparams.Phase0Version)
+	block.Block.Slot = 11
+	digest, err := clock.ComputeForkDigest(cfg.GenesisEpoch)
+	require.NoError(t, err)
+	var response bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&response, block, digest[:]...))
+
+	sentinel := &emptyThenBlockSentinel{
+		response:      response.Bytes(),
+		emptyReturned: make(chan struct{}),
+		allowBlock:    make(chan struct{}),
+	}
+	rpcClient, rpcCfg := newContextBlockingBeaconRPC(t.Context(), sentinel)
+	downloader := NewForwardBeaconDownloader(t.Context(), rpcClient, rpcCfg)
+	downloader.SetHighestProcessedSlot(10)
+	processed := make(chan struct{}, 1)
+	downloader.SetProcessFunction(func(_ uint64, blocks []*cltypes.SignedBeaconBlock, _ map[common.Hash]*cltypes.SignedExecutionPayloadEnvelope) (uint64, error) {
+		processed <- struct{}{}
+		return blocks[len(blocks)-1].Block.Slot, nil
+	})
+
+	done := make(chan struct{})
+	go func() {
+		downloader.RequestMore(t.Context())
+		close(done)
+	}()
+	<-sentinel.emptyReturned
+	require.Eventually(t, func() bool { return sentinel.calls.Load() >= 3 }, time.Second, time.Millisecond)
+	require.Equal(t, uint64(10), downloader.GetHighestProcessedSlot())
+	close(sentinel.allowBlock)
+	select {
+	case <-processed:
+	case <-time.After(time.Second):
+		t.Fatal("valid response for the unknown range was not processed")
+	}
+	<-done
+	require.Equal(t, uint64(11), downloader.GetHighestProcessedSlot())
+}
+
+func TestForwardRequestMoreBoundsActiveProbes(t *testing.T) {
+	previousInterval := forwardBeaconRequestInterval
+	previousTimeout := forwardBeaconRequestTimeout
+	forwardBeaconRequestInterval = time.Millisecond
+	forwardBeaconRequestTimeout = 100 * time.Millisecond
+	t.Cleanup(func() {
+		forwardBeaconRequestInterval = previousInterval
+		forwardBeaconRequestTimeout = previousTimeout
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	sentinel := newCountingBlockingSentinel()
+	rpcClient, cfg := newContextBlockingBeaconRPC(ctx, sentinel)
+	downloader := NewForwardBeaconDownloader(ctx, rpcClient, cfg)
+
+	done := make(chan struct{})
+	go func() {
+		downloader.RequestMore(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-sentinel.overLimit:
+		t.Fatal("forward downloader exceeded two active probes")
+	case <-done:
+	}
+	select {
+	case <-sentinel.drained:
+	case <-time.After(time.Second):
+		t.Fatal("active probes did not drain after the request window closed")
+	}
+	require.LessOrEqual(t, sentinel.maximum.Load(), int32(2))
+	require.Zero(t, sentinel.active.Load())
+}
+
+func TestForwardRequestMoreRotatesSlowP2PProbes(t *testing.T) {
+	previousInterval := forwardBeaconRequestInterval
+	previousTimeout := forwardBeaconRequestTimeout
+	previousProbeTimeout := forwardBeaconProbeTimeout
+	previousResponsePoll := forwardBeaconResponsePoll
+	forwardBeaconRequestInterval = 3 * time.Millisecond
+	forwardBeaconRequestTimeout = 300 * time.Millisecond
+	forwardBeaconProbeTimeout = 210 * time.Millisecond
+	forwardBeaconResponsePoll = time.Millisecond
+	t.Cleanup(func() {
+		forwardBeaconRequestInterval = previousInterval
+		forwardBeaconRequestTimeout = previousTimeout
+		forwardBeaconProbeTimeout = previousProbeTimeout
+		forwardBeaconResponsePoll = previousResponsePoll
+	})
+
+	cfg := clparams.MainnetBeaconConfig
+	cfg.InitializeForkSchedule()
+	clock := eth_clock.NewEthereumClock(uint64(time.Now().Unix()), common.Hash{}, &cfg)
+	digest, err := clock.ComputeForkDigest(cfg.GenesisEpoch)
+	require.NoError(t, err)
+	block := cltypes.NewSignedBeaconBlock(&cfg, clparams.Phase0Version)
+	block.Block.Slot = 1
+	var response bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&response, block, digest[:]...))
+
+	sentinel := &rotatingProbeSentinel{response: response.Bytes(), canceled: make(chan struct{})}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	rpcClient := rpc.NewBeaconRpcP2P(ctx, sentinel, &cfg, clock, nil)
+	downloader := NewForwardBeaconDownloader(ctx, rpcClient, &cfg)
+	processed := make(chan int, 1)
+	var processOnce sync.Once
+	downloader.SetProcessFunction(func(highest uint64, blocks []*cltypes.SignedBeaconBlock, _ map[common.Hash]*cltypes.SignedExecutionPayloadEnvelope) (uint64, error) {
+		processOnce.Do(func() { processed <- len(blocks) })
+		return highest, nil
+	})
+
+	done := make(chan struct{})
+	go func() {
+		downloader.RequestMore(ctx)
+		close(done)
+	}()
+
+	select {
+	case blockCount := <-processed:
+		require.Equal(t, 1, blockCount)
+	case <-done:
+		t.Fatal("request window ended before a healthy probe was processed")
+	case <-time.After(time.Second):
+		t.Fatal("healthy probe was not processed")
+	}
+	select {
+	case <-sentinel.canceled:
+	case <-time.After(time.Second):
+		t.Fatal("slow probes were not canceled before the request window ended")
+	}
+	<-done
+	require.GreaterOrEqual(t, sentinel.calls.Load(), int32(3))
+	require.LessOrEqual(t, sentinel.maximum.Load(), int32(maxConcurrentForwardBeaconRequests))
+	require.Zero(t, sentinel.active.Load())
+}
+
+func TestForwardRequestMoreStartsHTTPFallbackWhileProbesAreSlow(t *testing.T) {
+	previousInterval := forwardBeaconRequestInterval
+	previousTimeout := forwardBeaconRequestTimeout
+	previousFallbackDelay := forwardBeaconFallbackDelay
+	forwardBeaconRequestInterval = time.Millisecond
+	forwardBeaconRequestTimeout = 200 * time.Millisecond
+	forwardBeaconFallbackDelay = 20 * time.Millisecond
+	t.Cleanup(func() {
+		forwardBeaconRequestInterval = previousInterval
+		forwardBeaconRequestTimeout = previousTimeout
+		forwardBeaconFallbackDelay = previousFallbackDelay
+	})
+
+	fallbackStarted := make(chan struct{})
+	var fallbackOnce sync.Once
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fallbackOnce.Do(func() { close(fallbackStarted) })
+		http.NotFound(w, nil)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	sentinel := newCountingBlockingSentinel()
+	rpcClient, cfg := newContextBlockingBeaconRPC(ctx, sentinel)
+	downloader := NewForwardBeaconDownloader(ctx, rpcClient, cfg)
+	downloader.SetHTTPFallbackURL(server.URL)
+
+	done := make(chan struct{})
+	go func() {
+		downloader.RequestMore(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-fallbackStarted:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("slow P2P probes prevented the HTTP fallback from starting")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("RequestMore did not finish after its request window")
+	}
+}
+
+func TestForwardRequestMoreDoesNotPreferHTTPWithoutProgress(t *testing.T) {
+	previousInterval := forwardBeaconRequestInterval
+	previousTimeout := forwardBeaconRequestTimeout
+	previousFallbackDelay := forwardBeaconFallbackDelay
+	previousResponsePoll := forwardBeaconResponsePoll
+	forwardBeaconRequestInterval = time.Millisecond
+	forwardBeaconRequestTimeout = 100 * time.Millisecond
+	forwardBeaconFallbackDelay = 5 * time.Millisecond
+	forwardBeaconResponsePoll = time.Millisecond
+	t.Cleanup(func() {
+		forwardBeaconRequestInterval = previousInterval
+		forwardBeaconRequestTimeout = previousTimeout
+		forwardBeaconFallbackDelay = previousFallbackDelay
+		forwardBeaconResponsePoll = previousResponsePoll
+	})
+
+	cfg := clparams.MainnetBeaconConfig
+	cfg.InitializeForkSchedule()
+	clock := eth_clock.NewEthereumClock(uint64(time.Now().Unix()), common.Hash{}, &cfg)
+	digest, err := clock.ComputeForkDigest(cfg.GenesisEpoch)
+	require.NoError(t, err)
+	block := cltypes.NewSignedBeaconBlock(&cfg, clparams.Phase0Version)
+	block.Block.Slot = 1
+	encodedBlock, err := block.EncodeSSZ(nil)
+	require.NoError(t, err)
+	var p2pResponse bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&p2pResponse, block, digest[:]...))
+
+	var httpCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		httpCalls.Add(1)
+		if r.URL.Path != "/eth/v2/beacon/blocks/1" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Eth-Consensus-Version", "phase0")
+		_, _ = w.Write(encodedBlock)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	sentinel := &switchableProbeSentinel{response: p2pResponse.Bytes()}
+	rpcClient := rpc.NewBeaconRpcP2P(ctx, sentinel, &cfg, clock, nil)
+	downloader := NewForwardBeaconDownloader(ctx, rpcClient, &cfg)
+	downloader.SetHTTPFallbackURL(server.URL)
+	var firstProcessCalls atomic.Int32
+	downloader.SetProcessFunction(func(highest uint64, _ []*cltypes.SignedBeaconBlock, _ map[common.Hash]*cltypes.SignedExecutionPayloadEnvelope) (uint64, error) {
+		firstProcessCalls.Add(1)
+		return highest, nil
+	})
+
+	downloader.RequestMore(ctx)
+	require.Positive(t, httpCalls.Load())
+	require.Equal(t, int32(1), firstProcessCalls.Load(), "HTTP response did not reach processing")
+	require.False(t, sentinel.healthy.Load())
+	p2pCalls := sentinel.calls.Load()
+	firstHTTPCalls := httpCalls.Load()
+
+	sentinel.healthy.Store(true)
+	downloader.SetProcessFunction(func(_ uint64, blocks []*cltypes.SignedBeaconBlock, _ map[common.Hash]*cltypes.SignedExecutionPayloadEnvelope) (uint64, error) {
+		return blocks[len(blocks)-1].Block.Slot, nil
+	})
+	downloader.RequestMore(ctx)
+
+	require.Greater(t, sentinel.calls.Load(), p2pCalls, "second request did not return to P2P")
+	require.Equal(t, firstHTTPCalls, httpCalls.Load(), "second request incorrectly preferred HTTP")
+	require.Equal(t, uint64(1), downloader.GetHighestProcessedSlot())
+}
+
+func TestForwardRequestMoreEmptyP2PDoesNotInvalidateHTTPFallback(t *testing.T) {
+	previousInterval := forwardBeaconRequestInterval
+	previousTimeout := forwardBeaconRequestTimeout
+	previousFallbackDelay := forwardBeaconFallbackDelay
+	forwardBeaconRequestInterval = time.Millisecond
+	forwardBeaconRequestTimeout = 100 * time.Millisecond
+	forwardBeaconFallbackDelay = 5 * time.Millisecond
+	t.Cleanup(func() {
+		forwardBeaconRequestInterval = previousInterval
+		forwardBeaconRequestTimeout = previousTimeout
+		forwardBeaconFallbackDelay = previousFallbackDelay
+	})
+
+	cfg := clparams.MainnetBeaconConfig
+	cfg.InitializeForkSchedule()
+	block := cltypes.NewSignedBeaconBlock(&cfg, clparams.Phase0Version)
+	block.Block.Slot = 11
+	encodedBlock, err := block.EncodeSSZ(nil)
+	require.NoError(t, err)
+
+	fallbackStarted := make(chan struct{})
+	releaseFallback := make(chan struct{})
+	var fallbackOnce sync.Once
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseFallback) }) }
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fallbackOnce.Do(func() { close(fallbackStarted) })
+		<-releaseFallback
+		if r.URL.Path != "/eth/v2/beacon/blocks/11" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Eth-Consensus-Version", "phase0")
+		_, _ = w.Write(encodedBlock)
+	}))
+	t.Cleanup(func() {
+		release()
+		server.Close()
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	sentinel := &emptyAfterFallbackStartsSentinel{fallbackStarted: fallbackStarted}
+	rpcClient, rpcCfg := newContextBlockingBeaconRPC(ctx, sentinel)
+	downloader := NewForwardBeaconDownloader(ctx, rpcClient, rpcCfg)
+	downloader.SetHighestProcessedSlot(10)
+	downloader.SetHTTPFallbackURL(server.URL)
+	var processCalls atomic.Int32
+	downloader.SetProcessFunction(func(highest uint64, _ []*cltypes.SignedBeaconBlock, _ map[common.Hash]*cltypes.SignedExecutionPayloadEnvelope) (uint64, error) {
+		processCalls.Add(1)
+		return highest, nil
+	})
+
+	done := make(chan struct{})
+	go func() {
+		downloader.RequestMore(ctx)
+		close(done)
+	}()
+	select {
+	case <-fallbackStarted:
+	case <-time.After(time.Second):
+		t.Fatal("HTTP fallback did not start")
+	}
+	require.Equal(t, uint64(10), downloader.GetHighestProcessedSlot(), "empty P2P response advanced the cursor")
+	release()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("RequestMore did not finish")
+	}
+	require.Equal(t, int32(1), processCalls.Load(), "valid HTTP fallback was discarded after an empty P2P response")
+}
+
+func TestForwardRequestMoreBoundsPreferredHTTPFallback(t *testing.T) {
+	previousTimeout := forwardBeaconRequestTimeout
+	forwardBeaconRequestTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { forwardBeaconRequestTimeout = previousTimeout })
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	sentinel := newContextBlockingSentinel()
+	rpcClient, cfg := newContextBlockingBeaconRPC(ctx, sentinel)
+	downloader := NewForwardBeaconDownloader(ctx, rpcClient, cfg)
+	downloader.SetHTTPFallbackURL(server.URL)
+	downloader.httpPreferred.Store(true)
+
+	done := make(chan struct{})
+	go func() {
+		downloader.RequestMore(ctx)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("preferred HTTP fallback exceeded the request window")
+	}
+}
+
+func TestForwardRequestMoreRejectsStalePreferredHTTPFallback(t *testing.T) {
+	previousTimeout := forwardBeaconRequestTimeout
+	forwardBeaconRequestTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { forwardBeaconRequestTimeout = previousTimeout })
+
+	cfg := clparams.MainnetBeaconConfig
+	cfg.InitializeForkSchedule()
+	block := cltypes.NewSignedBeaconBlock(&cfg, clparams.Phase0Version)
+	block.Block.Slot = 11
+	encodedBlock, err := block.EncodeSSZ(nil)
+	require.NoError(t, err)
+
+	fallbackStarted := make(chan struct{})
+	releaseFallback := make(chan struct{})
+	var fallbackOnce sync.Once
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fallbackOnce.Do(func() { close(fallbackStarted) })
+		<-releaseFallback
+		if r.URL.Path != "/eth/v2/beacon/blocks/11" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Eth-Consensus-Version", "phase0")
+		_, _ = w.Write(encodedBlock)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	sentinel := newContextBlockingSentinel()
+	rpcClient, rpcCfg := newContextBlockingBeaconRPC(ctx, sentinel)
+	downloader := NewForwardBeaconDownloader(ctx, rpcClient, rpcCfg)
+	downloader.SetHighestProcessedSlot(10)
+	downloader.SetHTTPFallbackURL(server.URL)
+	downloader.httpPreferred.Store(true)
+	var processCalls atomic.Int32
+	downloader.SetProcessFunction(func(highest uint64, _ []*cltypes.SignedBeaconBlock, _ map[common.Hash]*cltypes.SignedExecutionPayloadEnvelope) (uint64, error) {
+		processCalls.Add(1)
+		return highest, nil
+	})
+
+	done := make(chan struct{})
+	go func() {
+		downloader.RequestMore(ctx)
+		close(done)
+	}()
+	select {
+	case <-fallbackStarted:
+	case <-time.After(time.Second):
+		t.Fatal("preferred HTTP fallback did not start")
+	}
+	downloader.SetHighestProcessedSlot(20)
+	close(releaseFallback)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("RequestMore did not finish")
+	}
+	require.Zero(t, processCalls.Load(), "stale preferred HTTP result was processed after the frontier advanced")
+}
+
+func TestForwardRequestMoreRejectsHTTPFallbackWhenFrontierAdvancesDuringFetch(t *testing.T) {
+	previousInterval := forwardBeaconRequestInterval
+	previousTimeout := forwardBeaconRequestTimeout
+	previousFallbackDelay := forwardBeaconFallbackDelay
+	previousResponsePoll := forwardBeaconResponsePoll
+	forwardBeaconRequestInterval = time.Millisecond
+	forwardBeaconRequestTimeout = 300 * time.Millisecond
+	forwardBeaconFallbackDelay = 5 * time.Millisecond
+	forwardBeaconResponsePoll = 100 * time.Millisecond
+	t.Cleanup(func() {
+		forwardBeaconRequestInterval = previousInterval
+		forwardBeaconRequestTimeout = previousTimeout
+		forwardBeaconFallbackDelay = previousFallbackDelay
+		forwardBeaconResponsePoll = previousResponsePoll
+	})
+
+	cfg := clparams.MainnetBeaconConfig
+	cfg.InitializeForkSchedule()
+	block := cltypes.NewSignedBeaconBlock(&cfg, clparams.Phase0Version)
+	block.Block.Slot = 11
+	encodedBlock, err := block.EncodeSSZ(nil)
+	require.NoError(t, err)
+
+	requestsCompleted := make(chan struct{})
+	var completedOnce sync.Once
+	var completedRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if completedRequests.Add(1) == 42 {
+				completedOnce.Do(func() { close(requestsCompleted) })
+			}
+		}()
+		if r.URL.Path != "/eth/v2/beacon/blocks/11" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Eth-Consensus-Version", "phase0")
+		_, _ = w.Write(encodedBlock)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	sentinel := newContextBlockingSentinel()
+	rpcClient, rpcCfg := newContextBlockingBeaconRPC(ctx, sentinel)
+	downloader := NewForwardBeaconDownloader(ctx, rpcClient, rpcCfg)
+	downloader.SetHighestProcessedSlot(10)
+	downloader.SetHTTPFallbackURL(server.URL)
+	var processCalls atomic.Int32
+	downloader.SetProcessFunction(func(highest uint64, _ []*cltypes.SignedBeaconBlock, _ map[common.Hash]*cltypes.SignedExecutionPayloadEnvelope) (uint64, error) {
+		processCalls.Add(1)
+		return highest, nil
+	})
+
+	done := make(chan struct{})
+	go func() {
+		downloader.RequestMore(ctx)
+		close(done)
+	}()
+	select {
+	case <-requestsCompleted:
+	case <-time.After(time.Second):
+		t.Fatal("HTTP fallback did not complete")
+	}
+	downloader.SetHighestProcessedSlot(20)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("RequestMore did not finish")
+	}
+	require.Zero(t, processCalls.Load(), "HTTP response was not revalidated before processing")
+}
+
+func TestForwardRequestMoreDropsHTTPPreferenceWhenFrontierAdvancesDuringEnvelopeFetch(t *testing.T) {
+	previousInterval := forwardBeaconRequestInterval
+	previousTimeout := forwardBeaconRequestTimeout
+	forwardBeaconRequestInterval = time.Millisecond
+	forwardBeaconRequestTimeout = 100 * time.Millisecond
+	t.Cleanup(func() {
+		forwardBeaconRequestInterval = previousInterval
+		forwardBeaconRequestTimeout = previousTimeout
+	})
+
+	cfg := clparams.MainnetBeaconConfig
+	cfg.InitializeForkSchedule()
+	first := cltypes.NewSignedBeaconBlock(&cfg, clparams.GloasVersion)
+	first.Block.Slot = 11
+	first.Block.Body.GetSignedExecutionPayloadBid().Message.BlockHash = common.Hash{1}
+	second := cltypes.NewSignedBeaconBlock(&cfg, clparams.GloasVersion)
+	second.Block.Slot = 12
+	second.Block.Body.GetSignedExecutionPayloadBid().Message.ParentBlockHash = common.Hash{1}
+	firstEncoded, err := first.EncodeSSZ(nil)
+	require.NoError(t, err)
+	secondEncoded, err := second.EncodeSSZ(nil)
+	require.NoError(t, err)
+
+	envelopeStarted := make(chan struct{})
+	releaseEnvelope := make(chan struct{})
+	var envelopeOnce sync.Once
+	var blockSecondHTTP atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/eth/v2/beacon/blocks/11":
+			w.Header().Set("Eth-Consensus-Version", "gloas")
+			_, _ = w.Write(firstEncoded)
+		case "/eth/v2/beacon/blocks/12":
+			w.Header().Set("Eth-Consensus-Version", "gloas")
+			_, _ = w.Write(secondEncoded)
+		case "/eth/v1/beacon/execution_payload_envelope/11":
+			envelopeOnce.Do(func() { close(envelopeStarted) })
+			<-releaseEnvelope
+			http.Error(w, "unavailable", http.StatusServiceUnavailable)
+		default:
+			if r.URL.Path == "/eth/v2/beacon/blocks/21" && blockSecondHTTP.Load() {
+				<-r.Context().Done()
+				return
+			}
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	sentinel := newContextBlockingSentinel()
+	rpcClient, rpcCfg := newContextBlockingBeaconRPC(ctx, sentinel)
+	downloader := NewForwardBeaconDownloader(ctx, rpcClient, rpcCfg)
+	downloader.SetHighestProcessedSlot(10)
+	downloader.SetHTTPFallbackURL(server.URL)
+	downloader.httpPreferred.Store(true)
+
+	firstDone := make(chan struct{})
+	go func() {
+		downloader.RequestMore(ctx)
+		close(firstDone)
+	}()
+	select {
+	case <-envelopeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("preferred HTTP response did not start envelope fetch")
+	}
+	downloader.SetHighestProcessedSlot(20)
+	close(releaseEnvelope)
+	select {
+	case <-firstDone:
+	case <-time.After(time.Second):
+		t.Fatal("stale preferred HTTP request did not finish")
+	}
+	blockSecondHTTP.Store(true)
+
+	secondDone := make(chan struct{})
+	go func() {
+		downloader.RequestMore(ctx)
+		close(secondDone)
+	}()
+	select {
+	case <-sentinel.started:
+		cancel()
+		<-secondDone
+	case <-secondDone:
+		t.Fatal("next request skipped P2P after the preferred HTTP result became stale")
+	case <-time.After(time.Second):
+		t.Fatal("next request did not choose a transport")
+	}
+}
+
+func TestForwardRequestMoreSynchronizesConcurrentProgressUpdates(t *testing.T) {
+	previousInterval := forwardBeaconRequestInterval
+	previousTimeout := forwardBeaconRequestTimeout
+	forwardBeaconRequestInterval = time.Millisecond
+	forwardBeaconRequestTimeout = 100 * time.Millisecond
+	t.Cleanup(func() {
+		forwardBeaconRequestInterval = previousInterval
+		forwardBeaconRequestTimeout = previousTimeout
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	sentinel := newCountingBlockingSentinel()
+	rpcClient, cfg := newContextBlockingBeaconRPC(ctx, sentinel)
+	downloader := NewForwardBeaconDownloader(ctx, rpcClient, cfg)
+
+	done := make(chan struct{})
+	go func() {
+		downloader.RequestMore(ctx)
+		close(done)
+	}()
+
+	stopUpdates := make(chan struct{})
+	updatesDone := make(chan struct{})
+	go func() {
+		defer close(updatesDone)
+		for slot := uint64(1); ; slot++ {
+			select {
+			case <-stopUpdates:
+				return
+			default:
+				downloader.SetHighestProcessedSlot(slot)
+			}
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("RequestMore did not finish")
+	}
+	close(stopUpdates)
+	<-updatesDone
+	require.Positive(t, downloader.GetHighestProcessedSlot())
+}

--- a/cl/phase1/network/blob_backfill_request_test.go
+++ b/cl/phase1/network/blob_backfill_request_test.go
@@ -1,0 +1,566 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package network
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+)
+
+func TestBlobBackfillRequestBoundsInflightAttempts(t *testing.T) {
+	ticks := make(chan time.Time)
+	expires := make(chan time.Time, 1)
+	started := make(chan context.Context, 3)
+	client := blobRequesterFunc(func(ctx context.Context, _ *solid.ListSSZ[*cltypes.BlobIdentifier]) ([]*cltypes.BlobSidecar, string, error) {
+		started <- ctx
+		<-ctx.Done()
+		return nil, "peer", ctx.Err()
+	})
+	done := make(chan error, 1)
+	go func() {
+		_, err := requestBlobsForBackfillWithSchedule(t.Context(), client, emptyBlobRequest, func(context.Context, *PeerAndSidecars) (bool, bool, error) { return true, true, nil }, blobBackfillRequestSchedule{
+			ticks:   ticks,
+			expires: expires,
+			now:     func() time.Time { return time.Unix(100, 0) },
+		})
+		done <- err
+	}()
+
+	first := receiveBlobTestValue(t, started)
+	ticks <- time.Unix(101, 0)
+	second := receiveBlobTestValue(t, started)
+	ticks <- time.Unix(102, 0)
+	select {
+	case <-started:
+		t.Fatal("started more than two concurrent blob requests")
+	default:
+	}
+	expires <- time.Unix(103, 0)
+	require.ErrorIs(t, receiveBlobTestValue(t, done), ErrTimeout)
+	receiveBlobTestSignal(t, first.Done())
+	receiveBlobTestSignal(t, second.Done())
+}
+
+func TestBlobBackfillRequestRejectsPartialCandidateAndAcceptsFullLaterCandidate(t *testing.T) {
+	type scriptedRequest struct {
+		ctx   context.Context
+		reply chan blobRequestResult
+	}
+	ticks := make(chan time.Time)
+	expires := make(chan time.Time)
+	requests := make(chan scriptedRequest, 2)
+	client := blobRequesterFunc(func(ctx context.Context, _ *solid.ListSSZ[*cltypes.BlobIdentifier]) ([]*cltypes.BlobSidecar, string, error) {
+		reply := make(chan blobRequestResult)
+		requests <- scriptedRequest{ctx: ctx, reply: reply}
+		select {
+		case result := <-reply:
+			return result.responses, result.peer, result.err
+		case <-ctx.Done():
+			return nil, "", ctx.Err()
+		}
+	})
+	done := make(chan struct {
+		result *PeerAndSidecars
+		err    error
+	}, 1)
+	persisted := atomic.Bool{}
+	requestIndex := uint64(0)
+	requestFactory := func() *solid.ListSSZ[*cltypes.BlobIdentifier] {
+		request := solid.NewStaticListSSZ[*cltypes.BlobIdentifier](0, 2)
+		request.Append(&cltypes.BlobIdentifier{Index: requestIndex})
+		requestIndex++
+		return request
+	}
+	accept := func(_ context.Context, candidate *PeerAndSidecars) (bool, bool, error) {
+		expectedIndex := uint64(0)
+		if candidate.Peer == "full" {
+			expectedIndex = 1
+		}
+		if candidate.requested.Len() != 1 || candidate.requested.Get(0).Index != expectedIndex {
+			return false, false, errors.New("candidate lost its launch-time request snapshot")
+		}
+		if len(candidate.Responses) != 2 {
+			return false, false, errors.New("candidate is incomplete")
+		}
+		persisted.Store(true)
+		return true, true, nil
+	}
+	go func() {
+		result, err := requestBlobsForBackfillWithSchedule(t.Context(), client, requestFactory, accept, blobBackfillRequestSchedule{
+			ticks:   ticks,
+			expires: expires,
+			now:     func() time.Time { return time.Unix(100, 0) },
+		})
+		done <- struct {
+			result *PeerAndSidecars
+			err    error
+		}{result: result, err: err}
+	}()
+
+	first := receiveBlobTestValue(t, requests)
+	ticks <- time.Unix(101, 0)
+	second := receiveBlobTestValue(t, requests)
+	first.reply <- blobRequestResult{peer: "partial", responses: []*cltypes.BlobSidecar{{}}}
+	select {
+	case result := <-done:
+		t.Fatalf("partial candidate completed request: %+v", result)
+	default:
+	}
+	require.False(t, persisted.Load())
+	second.reply <- blobRequestResult{peer: "full", responses: []*cltypes.BlobSidecar{{}, {}}}
+	result := receiveBlobTestValue(t, done)
+	require.NoError(t, result.err)
+	require.Equal(t, "full", result.result.Peer)
+	require.Len(t, result.result.Responses, 2)
+	require.True(t, persisted.Load())
+}
+
+func TestBlobBackfillRequestRetriesProgressingCandidateWithoutRefetch(t *testing.T) {
+	ticks := make(chan time.Time)
+	expires := make(chan time.Time)
+	requests := make(chan struct{}, 2)
+	validationReady := make(chan struct{}, 2)
+	client := blobRequesterFunc(func(context.Context, *solid.ListSSZ[*cltypes.BlobIdentifier]) ([]*cltypes.BlobSidecar, string, error) {
+		requests <- struct{}{}
+		return []*cltypes.BlobSidecar{{}}, "peer", nil
+	})
+	attempts := 0
+	done := make(chan error, 1)
+	go func() {
+		_, err := requestBlobsForBackfillWithSchedule(t.Context(), client, emptyBlobRequest, func(context.Context, *PeerAndSidecars) (bool, bool, error) {
+			attempts++
+			if attempts == 1 {
+				return true, false, errors.New("temporary persistence failure")
+			}
+			return true, true, nil
+		}, blobBackfillRequestSchedule{
+			ticks: ticks, expires: expires, now: func() time.Time { return time.Unix(100, 0) },
+			validationReady: func() { validationReady <- struct{}{} },
+		})
+		done <- err
+	}()
+
+	receiveBlobTestSignal(t, requests)
+	receiveBlobTestSignal(t, validationReady)
+	ticks <- time.Unix(101, 0)
+	require.NoError(t, receiveBlobTestValue(t, done))
+	require.Equal(t, 2, attempts)
+	select {
+	case <-requests:
+		t.Fatal("refetched a candidate that had already made validation progress")
+	default:
+	}
+}
+
+func TestBlobBackfillProgressWithPersistenceErrorBacksOff(t *testing.T) {
+	base := time.Unix(100, 0)
+	pacing := newBlobBackfillRequestPacing()
+	pacing.failed(base)
+	validationTime := base.Add(requestBlobRetryInterval)
+
+	pacing.recordValidation(validationTime, true, errors.New("temporary persistence failure"))
+
+	require.False(t, pacing.ready(validationTime.Add(requestBlobRetryInterval)))
+	require.True(t, pacing.ready(validationTime.Add(2*requestBlobRetryInterval)))
+}
+
+func TestBlobBackfillSuccessfulProgressResetsFailureBackoff(t *testing.T) {
+	base := time.Unix(100, 0)
+	pacing := newBlobBackfillRequestPacing()
+	pacing.failed(base)
+	validationTime := base.Add(requestBlobRetryInterval)
+
+	pacing.recordValidation(validationTime, true, nil)
+
+	require.False(t, pacing.ready(validationTime.Add(requestBlobRetryInterval-time.Nanosecond)))
+	require.True(t, pacing.ready(validationTime.Add(requestBlobRetryInterval)))
+}
+
+func TestBlobBackfillRequestPacingBacksOffEveryFailure(t *testing.T) {
+	now := time.Unix(100, 0)
+	pacing := newBlobBackfillRequestPacing()
+
+	pacing.failed(now)
+	require.False(t, pacing.ready(now.Add(requestBlobRetryInterval-time.Nanosecond)))
+	require.True(t, pacing.ready(now.Add(requestBlobRetryInterval)))
+
+	for range 20 {
+		pacing.failed(now)
+	}
+	require.Equal(t, requestBlobMaxBackoff, pacing.backoff)
+}
+
+func TestBlobBackfillEmptyResponsesBackOffWithoutProgress(t *testing.T) {
+	ticks := make(chan time.Time)
+	expires := make(chan time.Time)
+	requests := make(chan struct{}, 3)
+	validationReady := make(chan struct{}, 3)
+	done := make(chan error, 1)
+	base := time.Unix(100, 0)
+	var elapsed atomic.Int64
+	var attempts atomic.Int64
+	client := blobRequesterFunc(func(context.Context, *solid.ListSSZ[*cltypes.BlobIdentifier]) ([]*cltypes.BlobSidecar, string, error) {
+		elapsed.Store((attempts.Add(1) - 1) * int64(requestBlobRetryInterval))
+		return nil, "peer", nil
+	})
+	go func() {
+		_, err := requestBlobsForBackfillWithSchedule(t.Context(), client, func() *solid.ListSSZ[*cltypes.BlobIdentifier] {
+			requests <- struct{}{}
+			return emptyBlobRequest()
+		}, func(context.Context, *PeerAndSidecars) (bool, bool, error) {
+			return false, false, nil
+		}, blobBackfillRequestSchedule{
+			ticks:   ticks,
+			expires: expires,
+			now:     func() time.Time { return base.Add(time.Duration(elapsed.Load())) },
+			validationReady: func() {
+				validationReady <- struct{}{}
+			},
+		})
+		done <- err
+	}()
+
+	receiveBlobTestSignal(t, requests)
+	receiveBlobTestSignal(t, validationReady)
+	ticks <- base.Add(requestBlobRetryInterval)
+	receiveBlobTestSignal(t, requests)
+	receiveBlobTestSignal(t, validationReady)
+	ticks <- base.Add(2 * requestBlobRetryInterval)
+	select {
+	case <-requests:
+		t.Fatal("empty response retried before exponential backoff elapsed")
+	default:
+	}
+	ticks <- base.Add(3 * requestBlobRetryInterval)
+	receiveBlobTestSignal(t, requests)
+	expires <- base.Add(4 * requestBlobRetryInterval)
+	require.ErrorIs(t, receiveBlobTestValue(t, done), ErrTimeout)
+}
+
+func TestBlobBackfillDenebEmptyResponsesBackOffWithoutProgress(t *testing.T) {
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	request, err := BlobsIdentifiersFromBlocks([]*cltypes.SignedBeaconBlock{block}, &clparams.MainnetBeaconConfig)
+	require.NoError(t, err)
+	batch, err := newDenebRecoveryBatch([]*cltypes.SignedBeaconBlock{block}, request)
+	require.NoError(t, err)
+
+	ticks := make(chan time.Time)
+	expires := make(chan time.Time)
+	requests := make(chan struct{}, 3)
+	validationReady := make(chan struct{}, 3)
+	done := make(chan error, 1)
+	base := time.Unix(100, 0)
+	var elapsed atomic.Int64
+	var attempts atomic.Int64
+	client := blobRequesterFunc(func(context.Context, *solid.ListSSZ[*cltypes.BlobIdentifier]) ([]*cltypes.BlobSidecar, string, error) {
+		elapsed.Store((attempts.Add(1) - 1) * int64(requestBlobRetryInterval))
+		return nil, "peer", nil
+	})
+	go func() {
+		_, err := requestBlobsForBackfillWithSchedule(t.Context(), client, func() *solid.ListSSZ[*cltypes.BlobIdentifier] {
+			requests <- struct{}{}
+			return batch.remaining()
+		}, func(_ context.Context, candidate *PeerAndSidecars) (bool, bool, error) {
+			progress, err := batch.validate(candidate.requested, candidate.Responses)
+			return progress > 0, false, err
+		}, blobBackfillRequestSchedule{
+			ticks: ticks, expires: expires,
+			now: func() time.Time { return base.Add(time.Duration(elapsed.Load())) },
+			validationReady: func() {
+				validationReady <- struct{}{}
+			},
+		})
+		done <- err
+	}()
+
+	receiveBlobTestSignal(t, requests)
+	receiveBlobTestSignal(t, validationReady)
+	ticks <- base.Add(requestBlobRetryInterval)
+	receiveBlobTestSignal(t, requests)
+	receiveBlobTestSignal(t, validationReady)
+	ticks <- base.Add(2 * requestBlobRetryInterval)
+	select {
+	case <-requests:
+		t.Fatal("production Deneb empty response retried before exponential backoff elapsed")
+	default:
+	}
+	ticks <- base.Add(3 * requestBlobRetryInterval)
+	receiveBlobTestSignal(t, requests)
+	expires <- base.Add(4 * requestBlobRetryInterval)
+	require.ErrorIs(t, receiveBlobTestValue(t, done), ErrTimeout)
+}
+
+func TestBlobBackfillReadyValidationWinsExpiration(t *testing.T) {
+	ticks := make(chan time.Time)
+	expires := make(chan time.Time, 1)
+	validationReady := make(chan struct{})
+	client := blobRequesterFunc(func(context.Context, *solid.ListSSZ[*cltypes.BlobIdentifier]) ([]*cltypes.BlobSidecar, string, error) {
+		return []*cltypes.BlobSidecar{{}}, "peer", nil
+	})
+	done := make(chan error, 1)
+	go func() {
+		_, err := requestBlobsForBackfillWithSchedule(t.Context(), client, emptyBlobRequest, func(context.Context, *PeerAndSidecars) (bool, bool, error) {
+			return true, true, nil
+		}, blobBackfillRequestSchedule{
+			ticks:           ticks,
+			expires:         expires,
+			now:             time.Now,
+			validationReady: func() { close(validationReady) },
+		})
+		done <- err
+	}()
+
+	receiveBlobTestSignal(t, validationReady)
+	expires <- time.Now()
+	require.NoError(t, receiveBlobTestValue(t, done))
+}
+
+func TestBlobBackfillBlockedValidationCancelsWithoutBlockingSender(t *testing.T) {
+	ticks := make(chan time.Time)
+	expires := make(chan time.Time, 1)
+	validationStarted := make(chan struct{})
+	validationReady := make(chan struct{})
+	client := blobRequesterFunc(func(context.Context, *solid.ListSSZ[*cltypes.BlobIdentifier]) ([]*cltypes.BlobSidecar, string, error) {
+		return []*cltypes.BlobSidecar{{}}, "peer", nil
+	})
+	done := make(chan error, 1)
+	go func() {
+		_, err := requestBlobsForBackfillWithSchedule(t.Context(), client, emptyBlobRequest, func(ctx context.Context, _ *PeerAndSidecars) (bool, bool, error) {
+			close(validationStarted)
+			<-ctx.Done()
+			return false, false, ctx.Err()
+		}, blobBackfillRequestSchedule{
+			ticks:           ticks,
+			expires:         expires,
+			now:             time.Now,
+			validationReady: func() { close(validationReady) },
+		})
+		done <- err
+	}()
+
+	receiveBlobTestSignal(t, validationStarted)
+	expires <- time.Now()
+	require.ErrorIs(t, receiveBlobTestValue(t, done), ErrTimeout)
+	receiveBlobTestSignal(t, validationReady)
+}
+
+func TestBlobBackfillStopWaitsForValidationOwnership(t *testing.T) {
+	tests := map[string]struct {
+		stop func(context.CancelFunc, chan<- time.Time)
+		want error
+	}{
+		"expiration": {
+			stop: func(_ context.CancelFunc, expires chan<- time.Time) { expires <- time.Now() },
+			want: ErrTimeout,
+		},
+		"caller cancellation": {
+			stop: func(cancel context.CancelFunc, _ chan<- time.Time) { cancel() },
+			want: context.Canceled,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			ticks := make(chan time.Time)
+			expires := make(chan time.Time, 1)
+			validationStarted := make(chan struct{})
+			validationContext := make(chan context.Context, 1)
+			releaseValidation := make(chan struct{})
+			client := blobRequesterFunc(func(context.Context, *solid.ListSSZ[*cltypes.BlobIdentifier]) ([]*cltypes.BlobSidecar, string, error) {
+				return []*cltypes.BlobSidecar{{}}, "peer", nil
+			})
+			done := make(chan error, 1)
+			go func() {
+				_, err := requestBlobsForBackfillWithSchedule(ctx, client, emptyBlobRequest, func(ctx context.Context, _ *PeerAndSidecars) (bool, bool, error) {
+					validationContext <- ctx
+					close(validationStarted)
+					<-releaseValidation
+					return true, false, nil
+				}, blobBackfillRequestSchedule{
+					ticks:   ticks,
+					expires: expires,
+					now:     time.Now,
+				})
+				done <- err
+			}()
+
+			receiveBlobTestSignal(t, validationStarted)
+			validationCtx := receiveBlobTestValue(t, validationContext)
+			test.stop(cancel, expires)
+			receiveBlobTestSignal(t, validationCtx.Done())
+			select {
+			case err := <-done:
+				t.Fatalf("request returned before validation released ownership: %v", err)
+			case <-time.After(100 * time.Millisecond):
+			}
+			close(releaseValidation)
+			require.ErrorIs(t, receiveBlobTestValue(t, done), test.want)
+		})
+	}
+}
+
+func TestBlobBackfillStopWaitsForRequestOwnership(t *testing.T) {
+	tests := map[string]struct {
+		stop func(context.CancelFunc, chan<- time.Time)
+		want error
+	}{
+		"expiration": {
+			stop: func(_ context.CancelFunc, expires chan<- time.Time) { expires <- time.Now() },
+			want: ErrTimeout,
+		},
+		"caller cancellation": {
+			stop: func(cancel context.CancelFunc, _ chan<- time.Time) { cancel() },
+			want: context.Canceled,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			ticks := make(chan time.Time)
+			expires := make(chan time.Time, 1)
+			requestStarted := make(chan struct{})
+			requestContext := make(chan context.Context, 1)
+			releaseRequest := make(chan struct{})
+			client := blobRequesterFunc(func(ctx context.Context, _ *solid.ListSSZ[*cltypes.BlobIdentifier]) ([]*cltypes.BlobSidecar, string, error) {
+				requestContext <- ctx
+				close(requestStarted)
+				<-ctx.Done()
+				<-releaseRequest
+				return nil, "peer", ctx.Err()
+			})
+			done := make(chan error, 1)
+			go func() {
+				_, err := requestBlobsForBackfillWithSchedule(ctx, client, emptyBlobRequest, func(context.Context, *PeerAndSidecars) (bool, bool, error) {
+					return true, true, nil
+				}, blobBackfillRequestSchedule{
+					ticks:   ticks,
+					expires: expires,
+					now:     time.Now,
+				})
+				done <- err
+			}()
+
+			receiveBlobTestSignal(t, requestStarted)
+			requestCtx := receiveBlobTestValue(t, requestContext)
+			test.stop(cancel, expires)
+			receiveBlobTestSignal(t, requestCtx.Done())
+			select {
+			case err := <-done:
+				t.Fatalf("request returned before request handler released ownership: %v", err)
+			case <-time.After(100 * time.Millisecond):
+			}
+			close(releaseRequest)
+			require.ErrorIs(t, receiveBlobTestValue(t, done), test.want)
+		})
+	}
+}
+
+func TestBlobBackfillSuccessWaitsForRequestOwnership(t *testing.T) {
+	ticks := make(chan time.Time)
+	expires := make(chan time.Time)
+	firstStarted := make(chan struct{})
+	firstReply := make(chan struct{})
+	secondStarted := make(chan context.Context, 1)
+	releaseSecond := make(chan struct{})
+	var requestIndex atomic.Int64
+	client := blobRequesterFunc(func(ctx context.Context, _ *solid.ListSSZ[*cltypes.BlobIdentifier]) ([]*cltypes.BlobSidecar, string, error) {
+		switch requestIndex.Add(1) {
+		case 1:
+			close(firstStarted)
+			<-firstReply
+			return []*cltypes.BlobSidecar{{}}, "first", nil
+		case 2:
+			secondStarted <- ctx
+			<-ctx.Done()
+			<-releaseSecond
+			return nil, "second", ctx.Err()
+		default:
+			return nil, "unexpected", errors.New("unexpected request")
+		}
+	})
+	type requestOutcome struct {
+		result *PeerAndSidecars
+		err    error
+	}
+	done := make(chan requestOutcome, 1)
+	go func() {
+		result, err := requestBlobsForBackfillWithSchedule(t.Context(), client, emptyBlobRequest, func(context.Context, *PeerAndSidecars) (bool, bool, error) {
+			return true, true, nil
+		}, blobBackfillRequestSchedule{
+			ticks:   ticks,
+			expires: expires,
+			now:     time.Now,
+		})
+		done <- requestOutcome{result: result, err: err}
+	}()
+
+	receiveBlobTestSignal(t, firstStarted)
+	ticks <- time.Now()
+	secondCtx := receiveBlobTestValue(t, secondStarted)
+	close(firstReply)
+	receiveBlobTestSignal(t, secondCtx.Done())
+	select {
+	case outcome := <-done:
+		t.Fatalf("request returned before request handler released ownership: %+v", outcome)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseSecond)
+	outcome := receiveBlobTestValue(t, done)
+	require.NoError(t, outcome.err)
+	require.Equal(t, "first", outcome.result.Peer)
+}
+
+func emptyBlobRequest() *solid.ListSSZ[*cltypes.BlobIdentifier] {
+	return solid.NewStaticListSSZ[*cltypes.BlobIdentifier](0, 2)
+}
+
+func receiveBlobTestValue[T any](t *testing.T, values <-chan T) T {
+	t.Helper()
+	select {
+	case value := <-values:
+		return value
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for test value")
+		var zero T
+		return zero
+	}
+}
+
+func receiveBlobTestSignal(t *testing.T, signal <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for test signal")
+	}
+}
+
+type blobRequesterFunc func(context.Context, *solid.ListSSZ[*cltypes.BlobIdentifier]) ([]*cltypes.BlobSidecar, string, error)
+
+func (f blobRequesterFunc) SendBlobsSidecarByIdentifierReq(ctx context.Context, req *solid.ListSSZ[*cltypes.BlobIdentifier]) ([]*cltypes.BlobSidecar, string, error) {
+	return f(ctx, req)
+}

--- a/cl/phase1/network/blob_downloader.go
+++ b/cl/phase1/network/blob_downloader.go
@@ -20,16 +20,21 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/google/btree"
+
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
 	"github.com/erigontech/erigon/cl/das"
 	"github.com/erigontech/erigon/cl/persistence/blob_storage"
 	"github.com/erigontech/erigon/cl/rpc"
 	"github.com/erigontech/erigon/cl/utils"
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/snapshotsync/freezeblocks"
@@ -40,11 +45,28 @@ const (
 	blobLogInterval             = 30 * time.Second
 	blobBackfillWarningInterval = 4 * time.Minute
 	blocksBatchSize             = uint64(8)
-	minPeersForBlobDownload     = 16
+	blobRetryShardBits          = 10
+	maxBlobRetryRanges          = 1 << blobRetryShardBits
+	blobRetryShardShift         = 64 - blobRetryShardBits
 	// bounds a fulu block's column recovery; columns past the custody window are
 	// unfetchable and would otherwise block forever.
 	blobColumnBackfillTimeout = 30 * time.Second
 )
+
+type blobRetryRange struct {
+	start          uint64
+	end            uint64
+	cursor         uint64
+	intervals      *btree.BTreeG[blobRetryInterval]
+	intervalCursor uint64
+	work           uint64
+}
+
+type blobRetryInterval struct {
+	start  uint64
+	end    uint64
+	cursor uint64
+}
 
 // SyncedChecker is an interface to check if the forkchoice is synced
 type SyncedChecker interface {
@@ -56,16 +78,25 @@ type PeerDasGetter interface {
 	GetPeerDas() das.PeerDas
 }
 
+type blobPeerClient interface {
+	Peers() (uint64, error)
+	blobRequester
+}
+
+type blobSnapshotReader interface {
+	FrozenBlobs() uint64
+}
+
 // BlobHistoryDownloader downloads blob history backwards from a head slot
 type BlobHistoryDownloader struct {
 	ctx context.Context
 
 	beaconCfg   *clparams.BeaconChainConfig
-	rpc         *rpc.BeaconRpcP2P
+	rpc         blobPeerClient
 	indiciesDB  kv.RoDB
 	blobStorage blob_storage.BlobStorage
 	blockReader freezeblocks.BeaconSnapshotReader
-	sn          *freezeblocks.CaplinSnapshots
+	sn          blobSnapshotReader
 
 	syncedChecker SyncedChecker
 	peerDasGetter PeerDasGetter
@@ -73,22 +104,25 @@ type BlobHistoryDownloader struct {
 	// headSlot is the slot we start downloading from (currentSlot + 1)
 	headSlot atomic.Uint64
 	// highestBackfilledSlot is the highest slot we've successfully backfilled to
-	highestBackfilledSlot atomic.Uint64
-	// targetSlot is the slot we're trying to reach (Deneb fork epoch start)
-	targetSlot uint64
+	highestBackfilledSlot  atomic.Uint64
+	nextBackfillTargetSlot uint64
+	denebStartSlot         uint64
+	retryRanges            []blobRetryRange
+	retryRangeCursor       uint64
 	// archiveBlobs indicates whether to archive all blobs or just recent ones
 	archiveBlobs bool
 	// immediateBlobsBackfilling indicates whether to backfill blobs immediately
 	immediateBlobsBackfilling bool
 	// columnBackfillTimeout bounds each fulu block's PeerDAS column recovery
 	columnBackfillTimeout time.Duration
+	verifyBlobSidecars    func([]*cltypes.BlobSidecar, clparams.StateVersion, func(*cltypes.SignedBeaconBlockHeader) error) error
 
 	running           atomic.Bool
 	backfillCompleted atomic.Bool
 	logger            log.Logger
 
-	// notifyBlobBackfilled is called when blob backfilling is complete
-	notifyBlobBackfilled func()
+	// notifyBlobBackfilled is called when blob backfilling completeness changes.
+	notifyBlobBackfilled func(bool)
 
 	mu sync.RWMutex
 }
@@ -119,10 +153,12 @@ func NewBlobHistoryDownloader(
 		sn:                        sn,
 		syncedChecker:             syncedChecker,
 		peerDasGetter:             peerDasGetter,
-		targetSlot:                targetSlot,
+		nextBackfillTargetSlot:    targetSlot,
+		denebStartSlot:            targetSlot,
 		archiveBlobs:              archiveBlobs,
 		immediateBlobsBackfilling: immediateBlobsBackfilling,
 		columnBackfillTimeout:     blobColumnBackfillTimeout,
+		verifyBlobSidecars:        blob_storage.VerifyBlobSidecars,
 		logger:                    logger,
 	}
 }
@@ -132,11 +168,23 @@ func (b *BlobHistoryDownloader) SetHeadSlot(slot uint64) {
 	b.headSlot.Store(slot)
 }
 
-// SetNotifyBlobBackfilled sets the callback for when blob backfilling is complete
-func (b *BlobHistoryDownloader) SetNotifyBlobBackfilled(notify func()) {
+// SetNotifyBlobBackfilled sets the callback for blob backfilling completeness changes.
+func (b *BlobHistoryDownloader) SetNotifyBlobBackfilled(notify func(bool)) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.notifyBlobBackfilled = notify
+}
+
+func (b *BlobHistoryDownloader) setBackfillCompleted(completed bool) {
+	if b.backfillCompleted.Swap(completed) == completed {
+		return
+	}
+	b.mu.RLock()
+	notify := b.notifyBlobBackfilled
+	b.mu.RUnlock()
+	if notify != nil {
+		notify(completed)
+	}
 }
 
 // HeadSlot returns the current head slot
@@ -206,14 +254,7 @@ func (b *BlobHistoryDownloader) downloadOnce(shouldLog bool) error {
 	}
 	startSlot := currentSlot
 
-	// Check peer count before proceeding
-	peers, err := b.rpc.Peers()
-	if err != nil {
-		b.logger.Warn("[BlobHistoryDownloader] Failed to get peer count", "err", err)
-		return nil
-	}
-	if peers < minPeersForBlobDownload {
-		b.logger.Warn("[BlobHistoryDownloader] Skipping iteration due to low peer count", "peers", peers, "required", minPeersForBlobDownload)
+	if !b.peersAvailable() {
 		return nil
 	}
 
@@ -222,36 +263,49 @@ func (b *BlobHistoryDownloader) downloadOnce(shouldLog bool) error {
 
 	prevLogSlot := currentSlot
 	prevTime := time.Now()
-
-	targetSlot := b.targetSlot
+	retryPending := true
+	targetSlot := b.nextBackfillTargetSlot
+	retryFloor := uint64(0)
 	// in case of non-archive mode, we only backfill the last relevant epochs
 	if !b.archiveBlobs {
-		targetSlot = currentSlot - min(currentSlot, b.beaconCfg.MinSlotsForBlobsSidecarsRequest())
+		retentionFloor := currentSlot - min(currentSlot, b.beaconCfg.MinSlotsForBlobsSidecarsRequest())
+		targetSlot = max(targetSlot, retentionFloor)
+		retryFloor = retentionFloor
 	}
-
-	defer func() {
-		// set target slot back in case it was modified
-		b.targetSlot = currentSlot - b.beaconCfg.SlotsPerEpoch*2
-	}()
 
 	if shouldLog {
 		b.logger.Info("[BlobHistoryDownloader] Downloading blobs backwards", "slot", currentSlot)
 	}
 
 	for currentSlot >= targetSlot {
-		if currentSlot <= b.sn.FrozenBlobs() {
+		firstUnfrozenSlot := max(targetSlot, b.sn.FrozenBlobs())
+		if currentSlot < firstUnfrozenSlot {
 			break
 		}
 		if !b.syncedChecker.Synced() {
-			time.Sleep(5 * time.Second)
+			if err := common.Sleep(b.ctx, 5*time.Second); err != nil {
+				return nil
+			}
 			continue
 		}
+		if retryPending {
+			if err := b.retryFailedRecoveries(retryFloor); err != nil {
+				return err
+			}
+			if b.ctx.Err() != nil {
+				return nil
+			}
+			retryPending = false
+			firstUnfrozenSlot = max(targetSlot, b.sn.FrozenBlobs())
+			if currentSlot < firstUnfrozenSlot {
+				break
+			}
+		}
 
-		batch, visited, err := b.collectIncompleteBlocks(currentSlot, targetSlot)
+		batch, visited, err := b.collectIncompleteBlocks(currentSlot, firstUnfrozenSlot)
 		if err != nil {
 			return err
 		}
-
 		if len(batch) > 0 {
 			select {
 			case <-b.ctx.Done():
@@ -273,8 +327,15 @@ func (b *BlobHistoryDownloader) downloadOnce(shouldLog bool) error {
 				}
 			default:
 			}
-			b.processBatch(batch)
-			b.highestBackfilledSlot.Store(currentSlot)
+			if !b.peersAvailable() {
+				return nil
+			}
+			if b.processBatch(batch) {
+				b.highestBackfilledSlot.Store(currentSlot)
+			}
+			if b.ctx.Err() != nil {
+				return nil
+			}
 		}
 
 		// Always advance so an uncompletable batch can't rebuild at the same slot forever.
@@ -290,17 +351,432 @@ func (b *BlobHistoryDownloader) downloadOnce(shouldLog bool) error {
 	if shouldLog {
 		b.logger.Info("[BlobHistoryDownloader] Blob history download finished successfully")
 	}
+	b.nextBackfillTargetSlot = max(b.denebStartSlot, startSlot-min(startSlot, b.beaconCfg.SlotsPerEpoch*2))
 
-	b.backfillCompleted.Store(true)
-
-	b.mu.RLock()
-	notify := b.notifyBlobBackfilled
-	b.mu.RUnlock()
-	if notify != nil {
-		notify()
+	if len(b.retryRanges) != 0 {
+		b.setBackfillCompleted(false)
+		return nil
 	}
-
+	b.setBackfillCompleted(true)
 	return nil
+}
+
+func (b *BlobHistoryDownloader) retryFailedRecoveries(retryFloor uint64) error {
+	if len(b.retryRanges) == 0 {
+		return nil
+	}
+	firstUnfrozenSlot := max(retryFloor, b.sn.FrozenBlobs())
+	b.trimRetryRanges(firstUnfrozenSlot)
+	attemptedSlots := make(map[uint64]struct{}, blocksBatchSize)
+	for range blocksBatchSize {
+		var slot uint64
+		found := false
+		for range len(b.retryRanges) {
+			if len(b.retryRanges) == 0 {
+				break
+			}
+			rangeIndex := int(b.retryRangeCursor % uint64(len(b.retryRanges)))
+			retryRange := &b.retryRanges[rangeIndex]
+			slot = retryRange.nextSlot()
+			b.retryRangeCursor++
+			if _, attempted := attemptedSlots[slot]; attempted {
+				continue
+			}
+			attemptedSlots[slot] = struct{}{}
+			found = true
+			break
+		}
+		if !found {
+			break
+		}
+
+		block, err := b.readRetryBlock(slot)
+		if err != nil {
+			if b.ctx.Err() != nil {
+				return nil
+			}
+			b.logger.Warn("[BlobHistoryDownloader] Failed to read retry block", "slot", slot, "err", err)
+			continue
+		}
+		if block == nil || block.Version() < clparams.DenebVersion || block.GetBlobKzgCommitments() == nil {
+			b.resolveRetrySlot(slot)
+			continue
+		}
+		complete, err := b.retryBlock(block)
+		if err != nil {
+			if b.ctx.Err() != nil {
+				return nil
+			}
+			b.logger.Warn("[BlobHistoryDownloader] Failed to retry blob recovery", "slot", slot, "err", err)
+			continue
+		}
+		if complete {
+			b.resolveRetrySlot(slot)
+		}
+		if b.ctx.Err() != nil {
+			return nil
+		}
+	}
+	return nil
+}
+
+func (b *BlobHistoryDownloader) readRetryBlock(slot uint64) (*cltypes.SignedBeaconBlock, error) {
+	tx, err := b.indiciesDB.BeginRo(b.ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+	return b.blockReader.ReadBeaconBlockBodyBySlot(b.ctx, tx, slot)
+}
+
+func (b *BlobHistoryDownloader) retryBlock(block *cltypes.SignedBeaconBlock) (bool, error) {
+	if block.Version() < clparams.FuluVersion {
+		blockRoot, err := block.Block.HashSSZ()
+		if err != nil {
+			return false, err
+		}
+		_, complete, err := b.storedBlobSidecarsComplete(b.ctx, block, blockRoot)
+		if err != nil {
+			b.logger.Warn("[BlobHistoryDownloader] Failed to read stored blob sidecars during retry", "slot", block.GetSlot(), "err", err)
+			return false, nil
+		}
+		if complete {
+			return true, nil
+		}
+	}
+	return b.processBatch([]*cltypes.SignedBeaconBlock{block}), nil
+}
+
+func (b *BlobHistoryDownloader) addRetrySlot(slot uint64) {
+	b.setBackfillCompleted(false)
+	shard := slot >> blobRetryShardShift
+	index := sort.Search(len(b.retryRanges), func(i int) bool {
+		return b.retryRanges[i].start>>blobRetryShardShift >= shard
+	})
+	if index < len(b.retryRanges) && b.retryRanges[index].start>>blobRetryShardShift == shard {
+		b.retryRanges[index].add(slot)
+		return
+	}
+	b.retryRanges = append(b.retryRanges, blobRetryRange{})
+	copy(b.retryRanges[index+1:], b.retryRanges[index:])
+	b.retryRanges[index] = blobRetryRange{start: slot, end: slot, cursor: slot}
+}
+
+func (r *blobRetryRange) nextSlot() uint64 {
+	if r.intervals == nil {
+		slot := r.cursor
+		if slot == r.start {
+			r.cursor = r.end
+		} else {
+			r.cursor--
+		}
+		return slot
+	}
+	interval, found := retryIntervalAtOrBefore(r.intervals, r.intervalCursor)
+	var slot uint64
+	if found && r.intervalCursor <= interval.end {
+		slot = r.intervalCursor
+	} else if interval, found = retryIntervalAtOrAfter(r.intervals, r.intervalCursor); found {
+		slot = interval.start
+	} else {
+		interval, _ = r.intervals.Min()
+		slot = interval.start
+	}
+	if slot == ^uint64(0) {
+		r.intervalCursor = 0
+	} else {
+		r.intervalCursor = slot + 1
+	}
+	r.cursor = slot
+	return slot
+}
+
+func (r blobRetryRange) contains(slot uint64) bool {
+	if slot < r.start || slot > r.end {
+		return false
+	}
+	if r.intervals == nil {
+		return true
+	}
+	interval, found := retryIntervalAtOrBefore(r.intervals, slot)
+	return found && slot <= interval.end
+}
+
+func (r blobRetryRange) workCount() uint64 {
+	if r.intervals == nil {
+		width := r.end - r.start
+		if width == ^uint64(0) {
+			return width
+		}
+		return width + 1
+	}
+	return r.work
+}
+
+func (r *blobRetryRange) add(slot uint64) {
+	if r.intervals == nil {
+		if r.start <= slot && slot <= r.end {
+			return
+		}
+		if r.end != ^uint64(0) && slot == r.end+1 {
+			r.end = slot
+			return
+		}
+		if slot != ^uint64(0) && slot+1 == r.start {
+			r.start = slot
+			return
+		}
+		r.intervals = newBlobRetryIntervalTree()
+		r.intervals.ReplaceOrInsert(blobRetryInterval{start: r.start, end: r.end, cursor: r.cursor})
+		r.intervals.ReplaceOrInsert(blobRetryInterval{start: slot, end: slot, cursor: slot})
+		r.work = r.workCountWithoutCache() + 1
+		r.refreshBounds()
+		return
+	}
+	previous, hasPrevious := retryIntervalAtOrBefore(r.intervals, slot)
+	if hasPrevious && slot <= previous.end {
+		return
+	}
+	next, hasNext := retryIntervalAtOrAfter(r.intervals, slot)
+	mergePrevious := hasPrevious && previous.end != ^uint64(0) && previous.end+1 == slot
+	mergeNext := hasNext && slot != ^uint64(0) && slot+1 == next.start
+	switch {
+	case mergePrevious && mergeNext:
+		r.intervals.Delete(previous)
+		r.intervals.Delete(next)
+		previous.end = next.end
+		r.intervals.ReplaceOrInsert(previous)
+	case mergePrevious:
+		r.intervals.Delete(previous)
+		previous.end = slot
+		r.intervals.ReplaceOrInsert(previous)
+	case mergeNext:
+		r.intervals.Delete(next)
+		next.start = slot
+		r.intervals.ReplaceOrInsert(next)
+	default:
+		r.intervals.ReplaceOrInsert(blobRetryInterval{start: slot, end: slot, cursor: slot})
+	}
+	if r.work != ^uint64(0) {
+		r.work++
+	}
+	r.refreshBounds()
+}
+
+func newBlobRetryIntervalTree() *btree.BTreeG[blobRetryInterval] {
+	return btree.NewG(8, func(left, right blobRetryInterval) bool { return left.start < right.start })
+}
+
+func retryIntervalAtOrBefore(tree *btree.BTreeG[blobRetryInterval], slot uint64) (blobRetryInterval, bool) {
+	var interval blobRetryInterval
+	found := false
+	tree.DescendLessOrEqual(blobRetryInterval{start: slot}, func(item blobRetryInterval) bool {
+		interval = item
+		found = true
+		return false
+	})
+	return interval, found
+}
+
+func retryIntervalAtOrAfter(tree *btree.BTreeG[blobRetryInterval], slot uint64) (blobRetryInterval, bool) {
+	var interval blobRetryInterval
+	found := false
+	tree.AscendGreaterOrEqual(blobRetryInterval{start: slot}, func(item blobRetryInterval) bool {
+		interval = item
+		found = true
+		return false
+	})
+	return interval, found
+}
+
+func (r *blobRetryRange) refreshBounds() {
+	first, _ := r.intervals.Min()
+	last, _ := r.intervals.Max()
+	r.start = first.start
+	r.end = last.end
+}
+
+func (r blobRetryRange) workCountWithoutCache() uint64 {
+	width := r.end - r.start
+	if width == ^uint64(0) {
+		return width
+	}
+	return width + 1
+}
+
+func (r blobRetryRange) intervalCount() int {
+	if r.intervals == nil {
+		return 1
+	}
+	return r.intervals.Len()
+}
+
+func (b *BlobHistoryDownloader) addRetryBlocks(blocks []*cltypes.SignedBeaconBlock) {
+	for _, block := range blocks {
+		b.addRetrySlot(block.GetSlot())
+	}
+}
+
+func (b *BlobHistoryDownloader) resolveRetrySlot(slot uint64) {
+	for i := range b.retryRanges {
+		retryRange := &b.retryRanges[i]
+		if !retryRange.contains(slot) {
+			continue
+		}
+		if retryRange.remove(slot) {
+			last := len(b.retryRanges) - 1
+			copy(b.retryRanges[i:], b.retryRanges[i+1:])
+			b.retryRanges[last] = blobRetryRange{}
+			b.retryRanges = b.retryRanges[:last]
+		}
+		return
+	}
+}
+
+func (r *blobRetryRange) remove(slot uint64) bool {
+	if r.intervals == nil {
+		if r.start == r.end {
+			return true
+		}
+		switch {
+		case slot == r.start:
+			r.start++
+		case slot == r.end:
+			r.end--
+		default:
+			left := blobRetryInterval{start: r.start, end: slot - 1, cursor: r.cursor}
+			if left.cursor < left.start || left.cursor > left.end {
+				left.cursor = left.end
+			}
+			right := blobRetryInterval{start: slot + 1, end: r.end, cursor: r.end}
+			r.intervals = newBlobRetryIntervalTree()
+			r.intervals.ReplaceOrInsert(left)
+			r.intervals.ReplaceOrInsert(right)
+			r.work = r.workCountWithoutCache() - 1
+			r.refreshBounds()
+			return false
+		}
+		if r.cursor < r.start || r.cursor > r.end {
+			r.cursor = r.end
+		}
+		return false
+	}
+	interval, found := retryIntervalAtOrBefore(r.intervals, slot)
+	if !found || slot > interval.end {
+		return false
+	}
+	r.intervals.Delete(interval)
+	switch {
+	case interval.start == interval.end:
+	case slot == interval.start:
+		interval.start++
+		if interval.cursor < interval.start || interval.cursor > interval.end {
+			interval.cursor = interval.end
+		}
+		r.intervals.ReplaceOrInsert(interval)
+	case slot == interval.end:
+		interval.end--
+		if interval.cursor > interval.end {
+			interval.cursor = interval.end
+		}
+		r.intervals.ReplaceOrInsert(interval)
+	default:
+		left := blobRetryInterval{start: interval.start, end: slot - 1, cursor: interval.cursor}
+		if left.cursor < left.start || left.cursor > left.end {
+			left.cursor = left.end
+		}
+		right := blobRetryInterval{start: slot + 1, end: interval.end, cursor: interval.end}
+		r.intervals.ReplaceOrInsert(left)
+		r.intervals.ReplaceOrInsert(right)
+	}
+	if r.work > 0 {
+		r.work--
+	}
+	if r.intervals.Len() == 0 {
+		return true
+	}
+	if r.intervals.Len() == 1 {
+		interval, _ := r.intervals.Min()
+		*r = blobRetryRange{start: interval.start, end: interval.end, cursor: interval.cursor}
+		return false
+	}
+	r.refreshBounds()
+	return false
+}
+
+func (b *BlobHistoryDownloader) trimRetryRanges(firstUnfrozenSlot uint64) {
+	kept := b.retryRanges[:0]
+	for _, retryRange := range b.retryRanges {
+		if retryRange.end < firstUnfrozenSlot {
+			continue
+		}
+		if retryRange.intervals != nil {
+			retryRange.trimBefore(firstUnfrozenSlot)
+			if retryRange.intervals != nil && retryRange.intervals.Len() == 0 {
+				continue
+			}
+			kept = append(kept, retryRange)
+			continue
+		}
+		if retryRange.start < firstUnfrozenSlot {
+			retryRange.start = firstUnfrozenSlot
+		}
+		if retryRange.cursor < retryRange.start || retryRange.cursor > retryRange.end {
+			retryRange.cursor = retryRange.end
+		}
+		kept = append(kept, retryRange)
+	}
+	clear(b.retryRanges[len(kept):])
+	b.retryRanges = kept
+}
+
+func (r *blobRetryRange) trimBefore(floor uint64) {
+	if floor == 0 || r.intervals == nil {
+		return
+	}
+	remove := make([]blobRetryInterval, 0)
+	r.intervals.AscendLessThan(blobRetryInterval{start: floor}, func(interval blobRetryInterval) bool {
+		remove = append(remove, interval)
+		return true
+	})
+	for _, interval := range remove {
+		r.intervals.Delete(interval)
+		removedEnd := min(interval.end, floor-1)
+		removed := removedEnd - interval.start + 1
+		if removed > r.work {
+			r.work = 0
+		} else {
+			r.work -= removed
+		}
+		if interval.end >= floor {
+			interval.start = floor
+			if interval.cursor < interval.start || interval.cursor > interval.end {
+				interval.cursor = interval.end
+			}
+			r.intervals.ReplaceOrInsert(interval)
+		}
+	}
+	if r.intervals.Len() == 1 {
+		interval, _ := r.intervals.Min()
+		*r = blobRetryRange{start: interval.start, end: interval.end, cursor: interval.cursor}
+		return
+	}
+	if r.intervals.Len() > 0 {
+		r.refreshBounds()
+	}
+}
+
+func (b *BlobHistoryDownloader) peersAvailable() bool {
+	peers, err := b.rpc.Peers()
+	if err != nil {
+		b.logger.Warn("[BlobHistoryDownloader] Failed to get peer count", "err", err)
+		return false
+	}
+	if peers == 0 {
+		b.logger.Debug("[BlobHistoryDownloader] Skipping iteration because no peers are available")
+		return false
+	}
+	return true
 }
 
 // collectIncompleteBlocks scans backwards from currentSlot for Deneb+ blocks still
@@ -331,16 +807,16 @@ func (b *BlobHistoryDownloader) collectIncompleteBlocks(currentSlot, targetSlot 
 		if err != nil {
 			return nil, 0, err
 		}
-		blobsCount, err := b.blobStorage.KzgCommitmentsCount(b.ctx, blockRoot)
-		if err != nil {
-			return nil, 0, err
-		}
 		commitments := block.Block.Body.GetBlobKzgCommitments()
 		if commitments == nil {
 			// For GLOAS, nil means SignedExecutionPayloadBid is absent — unexpected for a valid block.
 			// For pre-GLOAS this should not happen on Deneb+.
 			b.logger.Warn("[BlobHistoryDownloader] skipping block with nil kzg commitments", "slot", block.Block.Slot, "version", block.Version())
 			continue
+		}
+		blobsCount, err := b.blobStorage.KzgCommitmentsCount(b.ctx, blockRoot)
+		if err != nil {
+			return nil, 0, err
 		}
 		if commitments.Len() == int(blobsCount) {
 			continue
@@ -350,9 +826,7 @@ func (b *BlobHistoryDownloader) collectIncompleteBlocks(currentSlot, targetSlot 
 	return batch, visited, nil
 }
 
-// processBatch best-effort recovers each block's blobs: Deneb by-root, Fulu from
-// PeerDAS columns.
-func (b *BlobHistoryDownloader) processBatch(batch []*cltypes.SignedBeaconBlock) {
+func (b *BlobHistoryDownloader) processBatch(batch []*cltypes.SignedBeaconBlock) bool {
 	fuluBlocks := make([]*cltypes.SignedBeaconBlock, 0, len(batch))
 	denebBlocks := make([]*cltypes.SignedBeaconBlock, 0, len(batch))
 	for _, block := range batch {
@@ -362,56 +836,353 @@ func (b *BlobHistoryDownloader) processBatch(batch []*cltypes.SignedBeaconBlock)
 			denebBlocks = append(denebBlocks, block)
 		}
 	}
+	complete := true
 	if len(denebBlocks) > 0 {
-		b.recoverDenebBlobs(denebBlocks)
+		complete = b.recoverDenebBlobs(denebBlocks)
+	}
+	if b.ctx.Err() != nil {
+		return false
 	}
 	if len(fuluBlocks) > 0 {
-		b.recoverFuluColumns(fuluBlocks)
+		complete = b.recoverFuluColumns(fuluBlocks) && complete
 	}
+	return complete
 }
 
-func (b *BlobHistoryDownloader) recoverDenebBlobs(blocks []*cltypes.SignedBeaconBlock) {
-	req, err := BlobsIdentifiersFromBlocks(blocks, b.beaconCfg)
+func (b *BlobHistoryDownloader) recoverDenebBlobs(blocks []*cltypes.SignedBeaconBlock) bool {
+	requestedBlocks := make([]*cltypes.SignedBeaconBlock, 0, len(blocks))
+	for _, block := range blocks {
+		if block.GetBlobKzgCommitments().Len() == 0 {
+			continue
+		}
+		requestedBlocks = append(requestedBlocks, block)
+	}
+	if len(requestedBlocks) == 0 {
+		return true
+	}
+	req, err := BlobsIdentifiersFromBlocks(requestedBlocks, b.beaconCfg)
 	if err != nil {
 		b.logger.Debug("[BlobHistoryDownloader] Error generating blob identifiers", "err", err)
-		return
-	}
-	blobs, err := RequestBlobsFrantically(b.ctx, b.rpc, req)
-	if err != nil {
-		b.logger.Debug("[BlobHistoryDownloader] Error requesting blobs", "err", err)
-		return
-	}
-	_, _, err = blob_storage.VerifyAgainstIdentifiersAndInsertIntoTheBlobStore(b.ctx, b.blobStorage, req, blobs.Responses, func(header *cltypes.SignedBeaconBlockHeader) error {
-		// The block is preverified so just check that the signature is correct against the block
-		for _, block := range blocks {
-			if block.Block.Slot != header.Header.Slot {
-				continue
-			}
-			if block.Signature != header.Signature {
-				return errors.New("signature mismatch between blob and stored block")
-			}
-			return nil
+		for _, block := range requestedBlocks {
+			b.addRetrySlot(block.GetSlot())
 		}
-		return errors.New("block not in batch")
+		return false
+	}
+	batch, err := newDenebRecoveryBatch(requestedBlocks, req)
+	if err != nil {
+		for _, block := range requestedBlocks {
+			b.addRetrySlot(block.GetSlot())
+		}
+		return false
+	}
+	if !b.peersAvailable() {
+		b.addRetryBlocks(requestedBlocks)
+		return false
+	}
+	_, err = requestBlobsForBackfill(b.ctx, b.rpc, batch.remaining, func(ctx context.Context, candidate *PeerAndSidecars) (bool, bool, error) {
+		progress, err := batch.validate(candidate.requested, candidate.Responses)
+		if err != nil {
+			return false, false, err
+		}
+		stored, err := batch.store(ctx, b.blobStorage)
+		if err != nil {
+			return progress > 0 || batch.hasCompleteUnstoredGroup(), false, err
+		}
+		return progress > 0 || stored > 0, batch.complete(), nil
 	})
 	if err != nil {
-		// Best-effort backfill: log and move on rather than banning a peer from the
-		// shared live-sync pool for a historical-blob verification miss.
-		b.logger.Warn("[BlobHistoryDownloader] Error verifying blobs", "err", err)
+		b.logger.Debug("[BlobHistoryDownloader] Error requesting blobs", "err", err)
+		b.addRetryBlocks(requestedBlocks)
 	}
+	requestFailed := err != nil
+	complete := !requestFailed
+	for _, block := range blocks {
+		blockRoot, err := block.Block.HashSSZ()
+		if err != nil {
+			return false
+		}
+		if requestFailed {
+			group := batch.groups[blockRoot]
+			if group == nil || !group.stored {
+				continue
+			}
+		}
+		_, blockComplete, err := b.storedBlobSidecarsComplete(b.ctx, block, blockRoot)
+		if err != nil || !blockComplete {
+			b.addRetrySlot(block.GetSlot())
+			complete = false
+		}
+	}
+	return complete
+}
+
+type blobIdentifierKey struct {
+	root  common.Hash
+	index uint64
+}
+
+type requestedBlobBlock struct {
+	block    *cltypes.SignedBeaconBlock
+	ids      []*cltypes.BlobIdentifier
+	sidecars map[uint64]*cltypes.BlobSidecar
+	stored   bool
+}
+
+type denebRecoveryBatch struct {
+	groups   map[common.Hash]*requestedBlobBlock
+	order    []common.Hash
+	verifier func([]*cltypes.BlobSidecar, func(*cltypes.SignedBeaconBlockHeader) error) error
+}
+
+func newDenebRecoveryBatch(blocks []*cltypes.SignedBeaconBlock, req *solid.ListSSZ[*cltypes.BlobIdentifier]) (*denebRecoveryBatch, error) {
+	batch := &denebRecoveryBatch{
+		groups: make(map[common.Hash]*requestedBlobBlock, len(blocks)),
+		order:  make([]common.Hash, 0, len(blocks)),
+		verifier: func(sidecars []*cltypes.BlobSidecar, verifySignatureFn func(*cltypes.SignedBeaconBlockHeader) error) error {
+			return blob_storage.VerifyBlobSidecars(sidecars, clparams.DenebVersion, verifySignatureFn)
+		},
+	}
+	blocksByRoot := make(map[common.Hash]*cltypes.SignedBeaconBlock, len(blocks))
+	for _, block := range blocks {
+		root, err := block.Block.HashSSZ()
+		if err != nil {
+			return nil, err
+		}
+		blocksByRoot[root] = block
+	}
+	for i := range req.Len() {
+		id := req.Get(i)
+		group := batch.groups[id.BlockRoot]
+		if group == nil {
+			group = &requestedBlobBlock{block: blocksByRoot[id.BlockRoot], sidecars: make(map[uint64]*cltypes.BlobSidecar)}
+			batch.groups[id.BlockRoot] = group
+			batch.order = append(batch.order, id.BlockRoot)
+		}
+		group.ids = append(group.ids, id)
+	}
+	return batch, nil
+}
+
+func (b *denebRecoveryBatch) validate(request *solid.ListSSZ[*cltypes.BlobIdentifier], sidecars []*cltypes.BlobSidecar) (int, error) {
+	requested := make(map[blobIdentifierKey]struct{}, request.Len())
+	for i := range request.Len() {
+		id := request.Get(i)
+		requested[blobIdentifierKey{root: id.BlockRoot, index: id.Index}] = struct{}{}
+	}
+	seen := make(map[blobIdentifierKey]struct{}, len(sidecars))
+	newSidecars := make([]*cltypes.BlobSidecar, 0, len(sidecars))
+	for _, sidecar := range sidecars {
+		if sidecar == nil || sidecar.SignedBlockHeader == nil || sidecar.SignedBlockHeader.Header == nil {
+			return 0, errors.New("blob response contains incomplete sidecar")
+		}
+		root, err := sidecar.SignedBlockHeader.Header.HashSSZ()
+		if err != nil {
+			return 0, err
+		}
+		key := blobIdentifierKey{root: root, index: sidecar.Index}
+		if _, ok := requested[key]; !ok {
+			return 0, fmt.Errorf("unrequested blob sidecar %x:%d", root, sidecar.Index)
+		}
+		group := b.groups[root]
+		if group == nil || group.block == nil {
+			return 0, fmt.Errorf("blob response block %x is not in batch", root)
+		}
+		if _, duplicate := seen[key]; duplicate {
+			return 0, fmt.Errorf("duplicate blob sidecar %x:%d", root, sidecar.Index)
+		}
+		seen[key] = struct{}{}
+		if group.sidecars[sidecar.Index] == nil {
+			newSidecars = append(newSidecars, sidecar)
+		}
+	}
+	if len(sidecars) == 0 {
+		return 0, errors.New("empty blob response")
+	}
+	if len(newSidecars) == 0 {
+		return 0, nil
+	}
+	if err := b.verifier(newSidecars, func(header *cltypes.SignedBeaconBlockHeader) error {
+		root, err := header.Header.HashSSZ()
+		if err != nil {
+			return err
+		}
+		group := b.groups[root]
+		if group == nil || group.block.Signature != header.Signature {
+			return errors.New("signature mismatch between blob and stored block")
+		}
+		return nil
+	}); err != nil {
+		return 0, err
+	}
+	for _, sidecar := range newSidecars {
+		root, _ := sidecar.SignedBlockHeader.Header.HashSSZ()
+		b.groups[root].sidecars[sidecar.Index] = sidecar
+	}
+	return len(newSidecars), nil
+}
+
+func (b *denebRecoveryBatch) store(ctx context.Context, storage blob_storage.BlobStorage) (int, error) {
+	stored := 0
+	for _, root := range b.order {
+		group := b.groups[root]
+		if group.stored || len(group.sidecars) != len(group.ids) {
+			continue
+		}
+		ordered := make([]*cltypes.BlobSidecar, 0, len(group.ids))
+		for _, id := range group.ids {
+			ordered = append(ordered, group.sidecars[id.Index])
+		}
+		if err := storage.WriteBlobSidecars(ctx, root, ordered); err != nil {
+			return stored, err
+		}
+		group.stored = true
+		stored++
+	}
+	return stored, nil
+}
+
+func (b *denebRecoveryBatch) hasCompleteUnstoredGroup() bool {
+	for _, group := range b.groups {
+		if !group.stored && len(group.sidecars) == len(group.ids) {
+			return true
+		}
+	}
+	return false
+}
+
+func (b *denebRecoveryBatch) complete() bool {
+	for _, group := range b.groups {
+		if !group.stored {
+			return false
+		}
+	}
+	return true
+}
+
+func (b *denebRecoveryBatch) remaining() *solid.ListSSZ[*cltypes.BlobIdentifier] {
+	remaining := solid.NewStaticListSSZ[*cltypes.BlobIdentifier](0, 40)
+	for _, root := range b.order {
+		group := b.groups[root]
+		if group.stored {
+			continue
+		}
+		for _, id := range group.ids {
+			if group.sidecars[id.Index] == nil {
+				remaining.Append(id)
+			}
+		}
+	}
+	return remaining
 }
 
 // recoverFuluColumns recovers blobs from PeerDAS columns, bounding each attempt so
 // columns no peer still serves can't block the backfill indefinitely.
-func (b *BlobHistoryDownloader) recoverFuluColumns(blocks []*cltypes.SignedBeaconBlock) {
-	peerDas := b.peerDasGetter.GetPeerDas()
-	for _, block := range blocks {
-		// [Modified in Gloas:EIP7732] Use ColumnSyncableSignedBlock interface
-		ctx, cancel := context.WithTimeout(b.ctx, b.columnBackfillTimeout)
-		err := peerDas.DownloadColumnsAndRecoverBlobs(ctx, []cltypes.ColumnSyncableSignedBlock{block})
-		cancel()
+func (b *BlobHistoryDownloader) recoverFuluColumns(blocks []*cltypes.SignedBeaconBlock) bool {
+	completeBatch := true
+	for i, block := range blocks {
+		blockRoot, err := block.Block.HashSSZ()
 		if err != nil {
+			b.addRetryBlocks(blocks[i:])
+			b.logger.Warn("[BlobHistoryDownloader] Failed to hash recovered block", "err", err, "slot", block.GetSlot())
+			return false
+		}
+		commitments := block.GetBlobKzgCommitments()
+		if commitments == nil {
+			b.addRetryBlocks(blocks[i:])
+			b.logger.Warn("[BlobHistoryDownloader] Blob recovery completed without commitments", "slot", block.GetSlot())
+			return false
+		}
+		if commitments.Len() == 0 {
+			continue
+		}
+		ctx, cancel := context.WithTimeout(b.ctx, b.columnBackfillTimeout)
+		_, complete, err := b.storedBlobSidecarsComplete(ctx, block, blockRoot)
+		if err != nil {
+			cancel()
+			b.addRetryBlocks(blocks[i:])
+			b.logger.Warn("[BlobHistoryDownloader] Failed to read stored blobs", "err", err, "slot", block.GetSlot())
+			return false
+		}
+		if complete {
+			cancel()
+			continue
+		}
+		if !b.peersAvailable() {
+			cancel()
+			b.addRetryBlocks(blocks[i:])
+			return false
+		}
+		peerDas := b.peerDasGetter.GetPeerDas()
+		err = peerDas.DownloadColumnsAndRecoverBlobs(ctx, []cltypes.ColumnSyncableSignedBlock{block})
+		if err != nil {
+			cancel()
+			b.addRetryBlocks(blocks[i:])
 			b.logger.Warn("[BlobHistoryDownloader] Error recovering blobs from block", "err", err, "slot", block.GetSlot())
+			return false
+		}
+		stored, complete, err := b.waitForStoredBlobSidecars(ctx, block, blockRoot)
+		cancel()
+		if err != nil || !complete {
+			b.addRetrySlot(block.GetSlot())
+			completeBatch = false
+			b.logger.Warn("[BlobHistoryDownloader] Blob recovery did not satisfy durable postcondition", "err", err, "slot", block.GetSlot(), "stored", stored, "expected", commitments.Len())
+			if b.ctx.Err() != nil {
+				return false
+			}
 		}
 	}
+	return completeBatch
+}
+
+func (b *BlobHistoryDownloader) waitForStoredBlobSidecars(ctx context.Context, block *cltypes.SignedBeaconBlock, blockRoot common.Hash) (uint32, bool, error) {
+	ticker := time.NewTicker(requestBlobRetryInterval)
+	defer ticker.Stop()
+	for {
+		stored, complete, err := b.storedBlobSidecarsComplete(ctx, block, blockRoot)
+		if err != nil || complete {
+			return stored, complete, err
+		}
+		select {
+		case <-ctx.Done():
+			return stored, false, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (b *BlobHistoryDownloader) storedBlobSidecarsComplete(ctx context.Context, block *cltypes.SignedBeaconBlock, blockRoot common.Hash) (uint32, bool, error) {
+	commitments := block.GetBlobKzgCommitments()
+	if commitments == nil {
+		return 0, false, nil
+	}
+	if commitments.Len() == 0 {
+		return 0, true, nil
+	}
+	stored, err := b.blobStorage.KzgCommitmentsCount(ctx, blockRoot)
+	if err != nil || int(stored) != commitments.Len() {
+		return stored, false, err
+	}
+	sidecars, found, err := b.blobStorage.ReadBlobSidecars(ctx, block.GetSlot(), blockRoot)
+	if err != nil || !found || len(sidecars) != commitments.Len() {
+		return stored, false, err
+	}
+	seen := make([]bool, commitments.Len())
+	for _, sidecar := range sidecars {
+		if sidecar == nil || sidecar.SignedBlockHeader == nil || sidecar.SignedBlockHeader.Header == nil || sidecar.Index >= uint64(commitments.Len()) || seen[sidecar.Index] {
+			return stored, false, nil
+		}
+		root, err := sidecar.SignedBlockHeader.Header.HashSSZ()
+		if err != nil || root != blockRoot || sidecar.SignedBlockHeader.Header.Slot != block.GetSlot() || sidecar.SignedBlockHeader.Signature != block.Signature || sidecar.KzgCommitment != common.Bytes48(*commitments.Get(int(sidecar.Index))) {
+			return stored, false, nil
+		}
+		seen[sidecar.Index] = true
+	}
+	verify := b.verifyBlobSidecars
+	if verify == nil {
+		verify = blob_storage.VerifyBlobSidecars
+	}
+	if err := verify(sidecars, block.Version(), nil); err != nil {
+		return stored, false, nil
+	}
+	return stored, true, nil
 }

--- a/cl/phase1/network/blob_downloader.go
+++ b/cl/phase1/network/blob_downloader.go
@@ -819,7 +819,20 @@ func (b *BlobHistoryDownloader) collectIncompleteBlocks(currentSlot, targetSlot 
 			return nil, 0, err
 		}
 		if commitments.Len() == int(blobsCount) {
-			continue
+			complete := true
+			for i := range commitments.Len() {
+				exists, err := b.blobStorage.BlobSidecarExists(b.ctx, block.Block.Slot, blockRoot, uint64(i))
+				if err != nil {
+					return nil, 0, err
+				}
+				if !exists {
+					complete = false
+					break
+				}
+			}
+			if complete {
+				continue
+			}
 		}
 		batch = append(batch, block)
 	}

--- a/cl/phase1/network/blob_downloader.go
+++ b/cl/phase1/network/blob_downloader.go
@@ -819,20 +819,7 @@ func (b *BlobHistoryDownloader) collectIncompleteBlocks(currentSlot, targetSlot 
 			return nil, 0, err
 		}
 		if commitments.Len() == int(blobsCount) {
-			complete := true
-			for i := range commitments.Len() {
-				exists, err := b.blobStorage.BlobSidecarExists(b.ctx, block.Block.Slot, blockRoot, uint64(i))
-				if err != nil {
-					return nil, 0, err
-				}
-				if !exists {
-					complete = false
-					break
-				}
-			}
-			if complete {
-				continue
-			}
+			continue
 		}
 		batch = append(batch, block)
 	}

--- a/cl/phase1/network/blob_downloader_boundary_test.go
+++ b/cl/phase1/network/blob_downloader_boundary_test.go
@@ -1,0 +1,772 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package network
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/das/mock_services"
+	blobstoragemock "github.com/erigontech/erigon/cl/persistence/blob_storage/mock_services"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/dbcfg"
+	mdbxtest "github.com/erigontech/erigon/db/kv/memdb"
+	"github.com/erigontech/erigon/db/snapshotsync/freezeblocks"
+)
+
+func TestBlobHistoryDownloaderProcessesFirstUnfrozenSlot(t *testing.T) {
+	const firstUnfrozenSlot = uint64(100)
+	wantErr := errors.New("first unfrozen slot visited")
+	reader := &boundaryBlockReader{err: wantErr}
+	downloader := newBoundaryDownloader(t, firstUnfrozenSlot, firstUnfrozenSlot, firstUnfrozenSlot, reader)
+
+	require.ErrorIs(t, downloader.downloadOnce(false), wantErr)
+	require.Equal(t, []uint64{firstUnfrozenSlot}, reader.slots)
+}
+
+func TestBlobHistoryDownloaderBatchStopsAtFrozenBoundary(t *testing.T) {
+	const firstUnfrozenSlot = uint64(100)
+	reader := &boundaryBlockReader{}
+	downloader := newBoundaryDownloader(t, firstUnfrozenSlot+1, firstUnfrozenSlot, 0, reader)
+
+	require.NoError(t, downloader.downloadOnce(false))
+	require.Equal(t, []uint64{firstUnfrozenSlot + 1, firstUnfrozenSlot}, reader.slots)
+}
+
+func TestBlobHistoryDownloaderRefreshesFrozenBoundaryBetweenBatches(t *testing.T) {
+	snapshot := &boundaryMutableSnapshot{}
+	reader := &boundaryBlockReader{onRead: func(slot uint64) {
+		if slot == 13 {
+			snapshot.frozen.Store(13)
+		}
+	}}
+	downloader := newBoundaryDownloader(t, 20, 0, 0, reader)
+	downloader.sn = snapshot
+
+	require.NoError(t, downloader.downloadOnce(false))
+	require.Equal(t, []uint64{20, 19, 18, 17, 16, 15, 14, 13}, reader.slots)
+}
+
+func TestBlobHistoryDownloaderRefreshesFrozenBoundaryAfterRetry(t *testing.T) {
+	snapshot := &boundaryMutableSnapshot{}
+	reader := &boundaryBlockReader{onRead: func(slot uint64) {
+		if slot == 1 {
+			snapshot.frozen.Store(15)
+		}
+	}}
+	downloader := newBoundaryDownloader(t, 20, 0, 0, reader)
+	downloader.sn = snapshot
+	downloader.addRetrySlot(1)
+	notified := false
+	downloader.SetNotifyBlobBackfilled(func(completed bool) { notified = completed })
+
+	require.NoError(t, downloader.downloadOnce(false))
+	require.Equal(t, []uint64{1, 20, 19, 18, 17, 16, 15}, reader.slots)
+	require.Empty(t, downloader.retryRanges)
+	require.True(t, downloader.backfillCompleted.Load())
+	require.True(t, notified)
+}
+
+func TestBlobHistoryDownloaderRunsWithSinglePeer(t *testing.T) {
+	const slot = uint64(100)
+	wantErr := errors.New("single peer admitted")
+	reader := &boundaryBlockReader{err: wantErr}
+	downloader := newBoundaryDownloader(t, slot, 0, slot, reader)
+	downloader.rpc = boundaryPeerCounter(1)
+
+	require.ErrorIs(t, downloader.downloadOnce(false), wantErr)
+}
+
+func TestBlobHistoryDownloaderWaitsWithoutPeers(t *testing.T) {
+	reader := &boundaryBlockReader{}
+	downloader := newBoundaryDownloader(t, 100, 0, 100, reader)
+	downloader.rpc = boundaryPeerCounter(0)
+
+	require.NoError(t, downloader.downloadOnce(false))
+	require.Empty(t, reader.slots)
+}
+
+func TestBlobHistoryDownloaderStopsWhenPeersDisappear(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(0), nil).AnyTimes()
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+	block.Block.Slot = 20
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	reader := &boundaryBlockReader{block: block}
+	downloader := newBoundaryDownloader(t, 20, 0, 0, reader)
+	peers := &boundarySequencePeerCounter{counts: []uint64{1, 0}}
+	downloader.rpc = peers
+	downloader.blobStorage = blobStorage
+	notified := false
+	downloader.SetNotifyBlobBackfilled(func(completed bool) { notified = completed })
+
+	require.NoError(t, downloader.downloadOnce(false))
+	require.Equal(t, []uint64{20, 19, 18, 17, 16, 15, 14, 13}, reader.slots)
+	require.Zero(t, peers.requests)
+	require.False(t, notified)
+	require.Zero(t, downloader.nextBackfillTargetSlot)
+}
+
+func TestBlobHistoryDownloaderNewRetryRevokesPriorCompletionBeforeCancellationReturn(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(0), nil).AnyTimes()
+	peerDas := mock_services.NewMockPeerDas(ctrl)
+	peerDas.EXPECT().DownloadColumnsAndRecoverBlobs(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(context.Context, []cltypes.ColumnSyncableSignedBlock) error {
+			cancel()
+			return context.Canceled
+		},
+	)
+
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+	block.Block.Slot = 20
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	downloader := newBoundaryDownloader(t, block.GetSlot(), 0, block.GetSlot(), &boundaryBlockReader{block: block})
+	downloader.ctx = ctx
+	downloader.blobStorage = blobStorage
+	downloader.peerDasGetter = staticPeerDasGetter{pd: peerDas}
+	downloader.backfillCompleted.Store(true)
+	var downstreamComplete atomic.Bool
+	var transitions atomic.Int32
+	downstreamComplete.Store(true)
+	downloader.SetNotifyBlobBackfilled(func(completed bool) {
+		downstreamComplete.Store(completed)
+		transitions.Add(1)
+	})
+
+	require.NoError(t, downloader.downloadOnce(false))
+	require.NotEmpty(t, downloader.retryRanges)
+	require.False(t, downloader.backfillCompleted.Load())
+	require.False(t, downstreamComplete.Load())
+	require.Equal(t, int32(1), transitions.Load())
+	downloader.addRetrySlot(block.GetSlot())
+	require.Equal(t, int32(1), transitions.Load(), "duplicate retry emitted another false transition")
+}
+
+func TestBlobHistoryDownloaderCompletionCallbackCanReplaceItself(t *testing.T) {
+	downloader := &BlobHistoryDownloader{}
+	done := make(chan struct{})
+	downloader.SetNotifyBlobBackfilled(func(bool) {
+		downloader.SetNotifyBlobBackfilled(nil)
+		close(done)
+	})
+
+	go downloader.setBackfillCompleted(true)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("completion callback ran while the callback lock was held")
+	}
+}
+
+func TestBlobHistoryDownloaderRetryRechecksPeersBeforeDenebRequest(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(0), nil).AnyTimes()
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+	block.Block.Slot = 20
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	ctx, cancel := context.WithCancel(t.Context())
+	downloader := newBoundaryDownloader(t, block.GetSlot(), 0, block.GetSlot(), &boundaryBlockReader{block: block})
+	downloader.ctx = ctx
+	peers := &boundarySequencePeerCounter{counts: []uint64{1, 0}, onRequest: cancel}
+	downloader.rpc = peers
+	downloader.blobStorage = blobStorage
+	downloader.addRetrySlot(block.GetSlot())
+
+	require.NoError(t, downloader.downloadOnce(false))
+	require.GreaterOrEqual(t, peers.calls, 2)
+	require.Zero(t, peers.requests)
+	require.Equal(t, []blobRetryRange{{start: block.GetSlot(), end: block.GetSlot(), cursor: block.GetSlot()}}, downloader.retryRanges)
+}
+
+func TestBlobHistoryDownloaderRechecksPeersBeforeFuluRecovery(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(1), nil).AnyTimes()
+	peerDas := mock_services.NewMockPeerDas(ctrl)
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+	block.Block.Slot = 20
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	downloader := newBoundaryDownloader(t, block.GetSlot(), 0, block.GetSlot(), &boundaryBlockReader{block: block})
+	peers := &boundarySequencePeerCounter{counts: []uint64{1, 1, 0}}
+	downloader.rpc = peers
+	downloader.blobStorage = blobStorage
+	downloader.peerDasGetter = staticPeerDasGetter{pd: peerDas}
+	downloader.columnBackfillTimeout = time.Second
+
+	require.NoError(t, downloader.downloadOnce(false))
+	require.GreaterOrEqual(t, peers.calls, 3)
+	require.Equal(t, []blobRetryRange{{start: block.GetSlot(), end: block.GetSlot(), cursor: block.GetSlot()}}, downloader.retryRanges)
+}
+
+func TestBlobHistoryDownloaderLocalOnlyPassChecksPeersOnce(t *testing.T) {
+	reader := &boundaryBlockReader{}
+	downloader := newBoundaryDownloader(t, blocksBatchSize*2+1, 0, 1, reader)
+	peers := &boundarySequencePeerCounter{counts: []uint64{1}}
+	downloader.rpc = peers
+
+	require.NoError(t, downloader.downloadOnce(false))
+	require.Equal(t, 1, peers.calls)
+}
+
+func TestBlobHistoryDownloaderUnsyncedWaitObservesCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	entered := make(chan struct{})
+	downloader := newBoundaryDownloader(t, 20, 0, 0, &boundaryBlockReader{err: errors.New("retry ran while unsynced")})
+	downloader.ctx = ctx
+	downloader.addRetrySlot(20)
+	downloader.syncedChecker = boundarySyncedCheckerFunc(func() bool {
+		select {
+		case <-entered:
+		default:
+			close(entered)
+		}
+		return false
+	})
+	done := make(chan error, 1)
+	go func() { done <- downloader.downloadOnce(false) }()
+
+	select {
+	case <-entered:
+		cancel()
+		require.NoError(t, <-done)
+	case err := <-done:
+		require.Failf(t, "retry bypassed sync gate", "download exited before sync gate: %v", err)
+	}
+}
+
+func TestBlobHistoryDownloaderKeepsRetryTargetAtDenebStart(t *testing.T) {
+	const denebStart = uint64(100)
+	downloader := newBoundaryDownloader(t, denebStart+10, 0, denebStart, &boundaryBlockReader{})
+
+	require.NoError(t, downloader.downloadOnce(false))
+	require.Equal(t, denebStart, downloader.nextBackfillTargetSlot)
+}
+
+func TestBlobHistoryDownloaderSecondCompletedPassScansRecentUnfrozenRange(t *testing.T) {
+	const head = uint64(1_000)
+	reader := &boundaryBlockReader{block: cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.Phase0Version)}
+	downloader := newBoundaryDownloader(t, head, 0, 0, reader)
+
+	require.NoError(t, downloader.downloadOnce(false))
+	reader.slots = nil
+	require.NoError(t, downloader.downloadOnce(false))
+
+	recentFloor := head - clparams.MainnetBeaconConfig.SlotsPerEpoch*2
+	require.Equal(t, recentFloor, downloader.nextBackfillTargetSlot)
+	require.Equal(t, head-recentFloor+1, uint64(len(reader.slots)))
+	require.Equal(t, recentFloor, reader.slots[len(reader.slots)-1])
+}
+
+func TestBlobHistoryDownloaderRetryReadFailureDoesNotBlockRecentScan(t *testing.T) {
+	const (
+		head      = uint64(1_000)
+		retrySlot = uint64(1)
+	)
+	recentFloor := head - clparams.MainnetBeaconConfig.SlotsPerEpoch*2
+	reader := &boundaryBlockReader{errors: map[uint64]error{retrySlot: errors.New("retry read failed")}}
+	downloader := newBoundaryDownloader(t, head, 0, recentFloor, reader)
+	downloader.addRetrySlot(retrySlot)
+
+	for range 2 {
+		reader.slots = nil
+		require.NoError(t, downloader.downloadOnce(false))
+		require.Equal(t, retrySlot, reader.slots[0])
+		require.Equal(t, head, reader.slots[1])
+		require.Equal(t, recentFloor, reader.slots[len(reader.slots)-1])
+		require.Equal(t, []blobRetryRange{{start: retrySlot, end: retrySlot, cursor: retrySlot}}, downloader.retryRanges)
+	}
+}
+
+func TestBlobHistoryDownloaderCancellationDuringRetryStopsBeforeRecentScan(t *testing.T) {
+	const (
+		head      = uint64(1_000)
+		retrySlot = uint64(1)
+	)
+	ctx, cancel := context.WithCancel(t.Context())
+	reader := &boundaryBlockReader{
+		errors: map[uint64]error{retrySlot: context.Canceled},
+		onRead: func(slot uint64) {
+			if slot == retrySlot {
+				cancel()
+			}
+		},
+	}
+	recentFloor := head - clparams.MainnetBeaconConfig.SlotsPerEpoch*2
+	downloader := newBoundaryDownloader(t, head, 0, recentFloor, reader)
+	downloader.ctx = ctx
+	downloader.addRetrySlot(retrySlot)
+	notified := false
+	downloader.SetNotifyBlobBackfilled(func(completed bool) { notified = completed })
+
+	require.NoError(t, downloader.downloadOnce(false))
+	require.Equal(t, []uint64{retrySlot}, reader.slots)
+	require.Equal(t, []blobRetryRange{{start: retrySlot, end: retrySlot, cursor: retrySlot}}, downloader.retryRanges)
+	require.False(t, downloader.backfillCompleted.Load())
+	require.False(t, notified)
+}
+
+func TestBlobHistoryDownloaderFailedRecoveryContinuesScanWithoutNotifying(t *testing.T) {
+	const (
+		head   = uint64(100)
+		target = uint64(80)
+	)
+	ctrl := gomock.NewController(t)
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	failedRecovery := errors.New("recovery failed")
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(0), nil).AnyTimes()
+	peerDas := mock_services.NewMockPeerDas(ctrl)
+	peerDas.EXPECT().DownloadColumnsAndRecoverBlobs(gomock.Any(), gomock.Any()).Return(failedRecovery)
+
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+	block.Block.Slot = head
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	reader := &boundaryBlockReader{blocks: map[uint64]*cltypes.SignedBeaconBlock{head: block}}
+	downloader := newBoundaryDownloader(t, head, 0, target, reader)
+	downloader.blobStorage = blobStorage
+	downloader.peerDasGetter = staticPeerDasGetter{pd: peerDas}
+	notified := false
+	downloader.SetNotifyBlobBackfilled(func(completed bool) { notified = completed })
+
+	require.NoError(t, downloader.downloadOnce(false))
+	require.Equal(t, target, reader.slots[len(reader.slots)-1])
+	require.False(t, notified)
+	require.False(t, downloader.backfillCompleted.Load())
+	require.NotEmpty(t, downloader.retryRanges)
+}
+
+func TestBlobHistoryDownloaderNonArchiveSecondPassScansRecentRange(t *testing.T) {
+	const head = uint64(1_000)
+	reader := &boundaryBlockReader{}
+	downloader := newBoundaryDownloader(t, head, 0, 0, reader)
+	downloader.archiveBlobs = false
+	downloader.immediateBlobsBackfilling = true
+
+	require.NoError(t, downloader.downloadOnce(false))
+	reader.slots = nil
+	require.NoError(t, downloader.downloadOnce(false))
+
+	recentFloor := head - clparams.MainnetBeaconConfig.SlotsPerEpoch*2
+	require.Equal(t, recentFloor, downloader.nextBackfillTargetSlot)
+	require.Equal(t, head-recentFloor+1, uint64(len(reader.slots)))
+	require.Equal(t, recentFloor, reader.slots[len(reader.slots)-1])
+}
+
+func TestBlobHistoryDownloaderRetriesSparseSlotsWithoutScanningGap(t *testing.T) {
+	reader := &boundaryBlockReader{}
+	downloader := newBoundaryDownloader(t, 1_000, 0, 1_000, reader)
+	downloader.addRetrySlot(1)
+	downloader.addRetrySlot(20)
+
+	require.NoError(t, downloader.downloadOnce(false))
+	require.Equal(t, []uint64{1, 20}, reader.slots[:2])
+	require.Empty(t, downloader.retryRanges)
+}
+
+func TestBlobHistoryDownloaderRetryRangesRemainFairAcrossSparseFailures(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	reader := &boundaryBlockReader{blocks: map[uint64]*cltypes.SignedBeaconBlock{
+		1:         cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion),
+		1_000_000: cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion),
+	}}
+	for slot, block := range reader.blocks {
+		block.Block.Slot = slot
+		block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	}
+	downloader := newBoundaryDownloader(t, 1_000_000, 0, 1_000_000, reader)
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(0), errors.New("temporary read failure")).AnyTimes()
+	downloader.blobStorage = blobStorage
+	downloader.addRetrySlot(1)
+	downloader.addRetrySlot(1_000_000)
+
+	require.NoError(t, downloader.retryFailedRecoveries(0))
+	require.Equal(t, []uint64{1, 1_000_000}, reader.slots)
+}
+
+func TestBlobHistoryDownloaderRetryRangeExtensionPreservesProgress(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	blocks := make(map[uint64]*cltypes.SignedBeaconBlock, blocksBatchSize*2+1)
+	for slot := uint64(1); slot <= blocksBatchSize*2+1; slot++ {
+		block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+		block.Block.Slot = slot
+		block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+		blocks[slot] = block
+	}
+	reader := &boundaryBlockReader{blocks: blocks}
+	downloader := newBoundaryDownloader(t, blocksBatchSize*2+1, 0, blocksBatchSize*2+1, reader)
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(0), errors.New("temporary read failure")).AnyTimes()
+	downloader.blobStorage = blobStorage
+	downloader.retryRanges = []blobRetryRange{{start: 1, end: blocksBatchSize * 2, cursor: blocksBatchSize * 2}}
+
+	require.NoError(t, downloader.retryFailedRecoveries(0))
+	reader.slots = nil
+	downloader.addRetrySlot(blocksBatchSize*2 + 1)
+	require.NoError(t, downloader.retryFailedRecoveries(0))
+
+	require.Contains(t, reader.slots, uint64(1))
+}
+
+func TestBlobHistoryDownloaderRetriesThirtyThreeSparseFailuresWithoutDenseFallback(t *testing.T) {
+	const failureCount = 33
+	ctrl := gomock.NewController(t)
+	blocks := make(map[uint64]*cltypes.SignedBeaconBlock, failureCount)
+	downloader := newBoundaryDownloader(t, 1, 0, 1, &boundaryBlockReader{blocks: blocks})
+	reader := downloader.blockReader.(*boundaryBlockReader)
+	for i := range failureCount {
+		slot := uint64(i)*1_000_000 + 1
+		block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+		block.Block.Slot = slot
+		block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+		blocks[slot] = block
+		downloader.addRetrySlot(slot)
+	}
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(0), errors.New("temporary read failure")).AnyTimes()
+	downloader.blobStorage = blobStorage
+
+	require.Len(t, downloader.retryRanges, 1)
+	require.Equal(t, failureCount, downloader.retryRanges[0].intervalCount())
+	for range (failureCount + int(blocksBatchSize) - 1) / int(blocksBatchSize) {
+		require.NoError(t, downloader.retryFailedRecoveries(0))
+	}
+	for slot := range blocks {
+		require.Contains(t, reader.slots, slot)
+	}
+}
+
+func TestBlobHistoryDownloaderRetryRangeOverflowConservesEveryFailure(t *testing.T) {
+	downloader := newBoundaryDownloader(t, 1, 0, 1, &boundaryBlockReader{})
+	for shard := range maxBlobRetryRanges {
+		downloader.addRetrySlot(uint64(shard) << blobRetryShardShift)
+	}
+	downloader.addRetrySlot(1)
+
+	require.Len(t, downloader.retryRanges, maxBlobRetryRanges)
+	require.Equal(t, uint64(0), downloader.retryRanges[0].start)
+	require.Equal(t, uint64(1), downloader.retryRanges[0].end)
+	require.Equal(t, uint64(2), downloader.retryRanges[0].workCount())
+	for shard := range maxBlobRetryRanges {
+		slot := uint64(shard) << blobRetryShardShift
+		contained := false
+		for _, retryRange := range downloader.retryRanges {
+			contained = contained || retryRange.contains(slot)
+		}
+		require.Truef(t, contained, "retry slot %d was discarded", slot)
+	}
+	require.True(t, downloader.retryRanges[0].contains(1))
+}
+
+func TestBlobHistoryDownloaderRetryRangeOverflowVisitsOnlySparseFailures(t *testing.T) {
+	const failureCount = maxBlobRetryRanges + 1
+	ctrl := gomock.NewController(t)
+	blocks := make(map[uint64]*cltypes.SignedBeaconBlock, failureCount)
+	failures := make(map[uint64]struct{}, failureCount)
+	reader := &boundaryBlockReader{blocks: blocks}
+	downloader := newBoundaryDownloader(t, 1, 0, 1, reader)
+	for i := range failureCount {
+		slot := uint64(i)*1_000_000 + 1
+		block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+		block.Block.Slot = slot
+		block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+		blocks[slot] = block
+		failures[slot] = struct{}{}
+		downloader.addRetrySlot(slot)
+	}
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(0), errors.New("temporary read failure")).AnyTimes()
+	downloader.blobStorage = blobStorage
+
+	passes := (failureCount + int(blocksBatchSize) - 1) / int(blocksBatchSize)
+	for range passes {
+		require.NoError(t, downloader.retryFailedRecoveries(0))
+	}
+	seen := make(map[uint64]struct{}, len(reader.slots))
+	for _, slot := range reader.slots {
+		_, failed := failures[slot]
+		require.Truef(t, failed, "retried synthetic gap slot %d", slot)
+		seen[slot] = struct{}{}
+	}
+	require.Len(t, seen, failureCount)
+}
+
+func TestBlobHistoryDownloaderRetryVisitsMixedDenseAndSparseFailuresWithinOneCycle(t *testing.T) {
+	const denseFailures = 32
+	const sparseFailures = 32
+	ctrl := gomock.NewController(t)
+	blocks := make(map[uint64]*cltypes.SignedBeaconBlock, denseFailures+sparseFailures)
+	reader := &boundaryBlockReader{blocks: blocks}
+	downloader := newBoundaryDownloader(t, 1, 0, 1, reader)
+	addFailure := func(slot uint64) {
+		block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+		block.Block.Slot = slot
+		block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+		blocks[slot] = block
+		downloader.addRetrySlot(slot)
+	}
+	for slot := range uint64(denseFailures) {
+		addFailure(slot)
+	}
+	for i := range sparseFailures {
+		addFailure(uint64(i+1) * 1_000_000)
+	}
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(0), errors.New("temporary read failure")).AnyTimes()
+	downloader.blobStorage = blobStorage
+
+	for range (len(blocks) + int(blocksBatchSize) - 1) / int(blocksBatchSize) {
+		require.NoError(t, downloader.retryFailedRecoveries(0))
+	}
+	seen := make(map[uint64]struct{}, len(reader.slots))
+	for _, slot := range reader.slots {
+		_, failed := blocks[slot]
+		require.Truef(t, failed, "retried synthetic gap slot %d", slot)
+		seen[slot] = struct{}{}
+	}
+	require.Len(t, seen, len(blocks))
+}
+
+func BenchmarkBlobHistoryDownloaderAddSparseRetrySlots(b *testing.B) {
+	for _, failures := range []int{1024, 2048, 4096} {
+		b.Run(fmt.Sprintf("failures_%d", failures), func(b *testing.B) {
+			b.ReportMetric(float64(failures), "failures/op")
+			for b.Loop() {
+				downloader := &BlobHistoryDownloader{}
+				for i := range failures {
+					downloader.addRetrySlot(uint64(i)*1_000_000 + 1)
+				}
+			}
+		})
+	}
+}
+
+func TestBlobHistoryDownloaderRetryRangeCompressesContiguousSlots(t *testing.T) {
+	downloader := &BlobHistoryDownloader{}
+	for slot := range uint64(21) {
+		downloader.addRetrySlot(slot)
+	}
+
+	require.Equal(t, []blobRetryRange{{start: 0, end: 20, cursor: 0}}, downloader.retryRanges)
+}
+
+func TestBlobHistoryDownloaderResolveRetrySlotClearsVacatedRange(t *testing.T) {
+	newRange := func(slot uint64) blobRetryRange {
+		intervals := newBlobRetryIntervalTree()
+		intervals.ReplaceOrInsert(blobRetryInterval{start: slot, end: slot, cursor: slot})
+		return blobRetryRange{start: slot, end: slot, cursor: slot, intervals: intervals, work: 1}
+	}
+
+	downloader := &BlobHistoryDownloader{retryRanges: make([]blobRetryRange, 3, 4)}
+	downloader.retryRanges[0] = newRange(1)
+	downloader.retryRanges[1] = newRange(2)
+	downloader.retryRanges[2] = newRange(3)
+
+	downloader.resolveRetrySlot(2)
+
+	require.Equal(t, []uint64{1, 3}, []uint64{downloader.retryRanges[0].start, downloader.retryRanges[1].start})
+	for _, released := range downloader.retryRanges[len(downloader.retryRanges):cap(downloader.retryRanges)] {
+		require.Equal(t, blobRetryRange{}, released)
+	}
+
+	empty := &BlobHistoryDownloader{}
+	empty.resolveRetrySlot(1)
+	empty.trimRetryRanges(1)
+	require.Nil(t, empty.retryRanges)
+}
+
+func TestBlobHistoryDownloaderTrimRetryRangesClearsVacatedRanges(t *testing.T) {
+	newRange := func(slots ...uint64) blobRetryRange {
+		intervals := newBlobRetryIntervalTree()
+		for _, slot := range slots {
+			intervals.ReplaceOrInsert(blobRetryInterval{start: slot, end: slot, cursor: slot})
+		}
+		return blobRetryRange{start: slots[0], end: slots[len(slots)-1], cursor: slots[0], intervals: intervals, work: uint64(len(slots))}
+	}
+
+	downloader := &BlobHistoryDownloader{retryRanges: make([]blobRetryRange, 3, 4)}
+	downloader.retryRanges[0] = newRange(1)
+	downloader.retryRanges[1] = newRange(2, 5)
+	downloader.retryRanges[2] = newRange(8)
+
+	downloader.trimRetryRanges(4)
+
+	require.Equal(t, []uint64{5, 8}, []uint64{downloader.retryRanges[0].start, downloader.retryRanges[1].start})
+	require.True(t, downloader.retryRanges[0].contains(5))
+	require.False(t, downloader.retryRanges[0].contains(2))
+	for _, released := range downloader.retryRanges[len(downloader.retryRanges):cap(downloader.retryRanges)] {
+		require.Equal(t, blobRetryRange{}, released)
+	}
+}
+
+func TestBlobHistoryDownloaderResolvedRetrySlotsAreRemovedAroundReadFailure(t *testing.T) {
+	reader := &boundaryBlockReader{errors: map[uint64]error{2: errors.New("retry read failed")}}
+	downloader := newBoundaryDownloader(t, 2, 0, 2, reader)
+	downloader.retryRanges = []blobRetryRange{{start: 0, end: 2, cursor: 1}}
+
+	require.NoError(t, downloader.retryFailedRecoveries(0))
+	require.ElementsMatch(t, []uint64{0, 1, 2}, reader.slots)
+	require.Equal(t, []blobRetryRange{{start: 2, end: 2, cursor: 2}}, downloader.retryRanges)
+}
+
+func TestBlobHistoryDownloaderInteriorResolveKeepsRetryRangeBound(t *testing.T) {
+	downloader := newBoundaryDownloader(t, 10, 0, 10, &boundaryBlockReader{})
+	for slot := range uint64(11) {
+		downloader.addRetrySlot(slot)
+	}
+	for i := 1; i < maxBlobRetryRanges; i++ {
+		slot := uint64(i+1) * 10
+		downloader.addRetrySlot(slot)
+	}
+
+	downloader.resolveRetrySlot(5)
+
+	require.LessOrEqual(t, len(downloader.retryRanges), maxBlobRetryRanges)
+	for _, retryRange := range downloader.retryRanges {
+		require.False(t, retryRange.contains(5))
+	}
+	for i := range maxBlobRetryRanges + 1 {
+		slot := uint64(i) * 10
+		contained := false
+		for _, retryRange := range downloader.retryRanges {
+			contained = contained || retryRange.contains(slot)
+		}
+		require.Truef(t, contained, "retry slot %d was discarded", slot)
+	}
+}
+
+func TestBlobHistoryDownloaderDropsRetriesBeforeNonArchiveRetentionFloor(t *testing.T) {
+	retention := clparams.MainnetBeaconConfig.MinSlotsForBlobsSidecarsRequest()
+	headSlot := retention + 10
+	expiredSlot := uint64(9)
+	reader := &boundaryBlockReader{}
+	downloader := newBoundaryDownloader(t, headSlot, 0, 0, reader)
+	downloader.archiveBlobs = false
+	downloader.immediateBlobsBackfilling = true
+	downloader.addRetrySlot(expiredSlot)
+
+	require.NoError(t, downloader.downloadOnce(false))
+	require.NotContains(t, reader.slots, expiredSlot)
+	require.Empty(t, downloader.retryRanges)
+}
+
+func newBoundaryDownloader(t *testing.T, headSlot, frozenBlobs, targetSlot uint64, reader freezeblocks.BeaconSnapshotReader) *BlobHistoryDownloader {
+	t.Helper()
+	downloader := &BlobHistoryDownloader{
+		ctx:                    t.Context(),
+		beaconCfg:              &clparams.MainnetBeaconConfig,
+		rpc:                    boundaryPeerCounter(1),
+		indiciesDB:             mdbxtest.NewTestDB(t, dbcfg.ChainDB),
+		blockReader:            reader,
+		sn:                     boundarySnapshot(frozenBlobs),
+		syncedChecker:          boundarySyncedChecker(true),
+		nextBackfillTargetSlot: targetSlot,
+		denebStartSlot:         targetSlot,
+		archiveBlobs:           true,
+		logger:                 log.New(),
+	}
+	downloader.headSlot.Store(headSlot)
+	return downloader
+}
+
+type boundaryBlockReader struct {
+	freezeblocks.BeaconSnapshotReader
+	slots  []uint64
+	err    error
+	errors map[uint64]error
+	block  *cltypes.SignedBeaconBlock
+	blocks map[uint64]*cltypes.SignedBeaconBlock
+	onRead func(uint64)
+}
+
+func (r *boundaryBlockReader) ReadBeaconBlockBodyBySlot(_ context.Context, _ kv.Tx, slot uint64) (*cltypes.SignedBeaconBlock, error) {
+	r.slots = append(r.slots, slot)
+	if r.onRead != nil {
+		r.onRead(slot)
+	}
+	if err := r.errors[slot]; err != nil {
+		return nil, err
+	}
+	if r.blocks != nil {
+		return r.blocks[slot], r.err
+	}
+	return r.block, r.err
+}
+
+type boundaryPeerCounter uint64
+
+func (p boundaryPeerCounter) Peers() (uint64, error) { return uint64(p), nil }
+
+func (p boundaryPeerCounter) SendBlobsSidecarByIdentifierReq(context.Context, *solid.ListSSZ[*cltypes.BlobIdentifier]) ([]*cltypes.BlobSidecar, string, error) {
+	return nil, "", nil
+}
+
+type boundarySequencePeerCounter struct {
+	counts    []uint64
+	calls     int
+	requests  int
+	onRequest func()
+}
+
+func (p *boundarySequencePeerCounter) Peers() (uint64, error) {
+	index := min(p.calls, len(p.counts)-1)
+	p.calls++
+	return p.counts[index], nil
+}
+
+func (p *boundarySequencePeerCounter) SendBlobsSidecarByIdentifierReq(context.Context, *solid.ListSSZ[*cltypes.BlobIdentifier]) ([]*cltypes.BlobSidecar, string, error) {
+	p.requests++
+	if p.onRequest != nil {
+		p.onRequest()
+	}
+	return nil, "", nil
+}
+
+type boundarySnapshot uint64
+
+func (s boundarySnapshot) FrozenBlobs() uint64 { return uint64(s) }
+
+type boundaryMutableSnapshot struct {
+	frozen atomic.Uint64
+}
+
+func (s *boundaryMutableSnapshot) FrozenBlobs() uint64 { return s.frozen.Load() }
+
+type boundarySyncedChecker bool
+
+func (s boundarySyncedChecker) Synced() bool { return bool(s) }
+
+type boundarySyncedCheckerFunc func() bool
+
+func (f boundarySyncedCheckerFunc) Synced() bool { return f() }

--- a/cl/phase1/network/blob_downloader_test.go
+++ b/cl/phase1/network/blob_downloader_test.go
@@ -17,22 +17,52 @@
 package network
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	goethkzg "github.com/crate-crypto/go-eth-kzg"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
 	"github.com/erigontech/erigon/cl/das"
 	"github.com/erigontech/erigon/cl/das/mock_services"
+	"github.com/erigontech/erigon/cl/persistence/blob_storage"
+	blobstoragemock "github.com/erigontech/erigon/cl/persistence/blob_storage/mock_services"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/crypto/kzg"
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv/dbcfg"
+	mdbxtest "github.com/erigontech/erigon/db/kv/memdb"
 )
 
 type staticPeerDasGetter struct{ pd das.PeerDas }
 
 func (s staticPeerDasGetter) GetPeerDas() das.PeerDas { return s.pd }
+
+type completingBlobStorage struct {
+	blob_storage.BlobStorage
+	root     common.Hash
+	sidecars []*cltypes.BlobSidecar
+	once     sync.Once
+	writeErr error
+}
+
+func (s *completingBlobStorage) KzgCommitmentsCount(ctx context.Context, root common.Hash) (uint32, error) {
+	count, err := s.BlobStorage.KzgCommitmentsCount(ctx, root)
+	if root == s.root {
+		s.once.Do(func() { s.writeErr = s.BlobStorage.WriteBlobSidecars(ctx, root, s.sidecars) })
+	}
+	return count, errors.Join(err, s.writeErr)
+}
 
 // A historical fulu block whose PeerDAS data columns are served by no peer (older
 // than the network custody window) makes DownloadColumnsAndRecoverBlobs block until
@@ -49,9 +79,13 @@ func TestBlobHistoryDownloaderFuluColumnRecoveryIsBounded(t *testing.T) {
 			return ctx.Err()
 		}).
 		AnyTimes()
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(0), nil)
 
 	b := &BlobHistoryDownloader{
 		ctx:                   context.Background(),
+		rpc:                   boundaryPeerCounter(1),
+		blobStorage:           blobStorage,
 		peerDasGetter:         staticPeerDasGetter{pd: peerDas},
 		columnBackfillTimeout: 50 * time.Millisecond,
 		logger:                log.New(),
@@ -59,6 +93,7 @@ func TestBlobHistoryDownloaderFuluColumnRecoveryIsBounded(t *testing.T) {
 
 	fulu := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
 	fulu.Block.Slot = 100
+	fulu.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
 
 	done := make(chan struct{})
 	go func() {
@@ -71,4 +106,933 @@ func TestBlobHistoryDownloaderFuluColumnRecoveryIsBounded(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("recoverFuluColumns hung — unbounded PeerDAS column recovery")
 	}
+}
+
+func TestBlobHistoryDownloaderFuluInitialStorageCheckUsesBlockTimeout(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	peerDas := mock_services.NewMockPeerDas(ctrl)
+	peerDas.EXPECT().DownloadColumnsAndRecoverBlobs(gomock.Any(), gomock.Any()).Return(context.Canceled).AnyTimes()
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, _ common.Hash) (uint32, error) {
+		<-ctx.Done()
+		return 0, ctx.Err()
+	})
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	downloader := &BlobHistoryDownloader{
+		ctx:                   ctx,
+		rpc:                   boundaryPeerCounter(1),
+		blobStorage:           blobStorage,
+		peerDasGetter:         staticPeerDasGetter{pd: peerDas},
+		columnBackfillTimeout: 20 * time.Millisecond,
+		logger:                log.New(),
+	}
+	done := make(chan bool, 1)
+	go func() { done <- downloader.recoverFuluColumns([]*cltypes.SignedBeaconBlock{block}) }()
+
+	bounded := false
+	select {
+	case result := <-done:
+		bounded = !result
+	case <-time.After(100 * time.Millisecond):
+		cancel()
+		<-done
+	}
+	require.True(t, bounded, "initial durable check exceeded the per-block timeout")
+}
+
+func TestBlobHistoryDownloaderMixedBatchAttemptsFuluAfterDenebFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+
+	deneb := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+	deneb.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	fulu := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+	downloader := &BlobHistoryDownloader{
+		ctx:                   t.Context(),
+		beaconCfg:             &clparams.MainnetBeaconConfig,
+		rpc:                   boundaryPeerCounter(1),
+		blobStorage:           blobStorage,
+		columnBackfillTimeout: time.Second,
+		logger:                log.New(),
+	}
+
+	require.False(t, downloader.processBatch([]*cltypes.SignedBeaconBlock{deneb, fulu}))
+}
+
+func TestBlobHistoryDownloaderMixedBatchCancellationDoesNotStartFulu(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	deneb := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+	deneb.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	fulu := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+	downloader := &BlobHistoryDownloader{
+		ctx:                   ctx,
+		beaconCfg:             &clparams.MainnetBeaconConfig,
+		rpc:                   cancelingBlobPeerClient{cancel: cancel},
+		blobStorage:           blobstoragemock.NewMockBlobStorage(ctrl),
+		columnBackfillTimeout: time.Second,
+		logger:                log.New(),
+	}
+
+	require.False(t, downloader.processBatch([]*cltypes.SignedBeaconBlock{deneb, fulu}))
+}
+
+func TestBlobHistoryDownloaderIncompleteFuluRecoveryWithholdsCompletionUntilRetry(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	peerDas := mock_services.NewMockPeerDas(ctrl)
+	peerDas.EXPECT().DownloadColumnsAndRecoverBlobs(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+	block.Block.Slot = 100
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	var countReads atomic.Int32
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(context.Context, common.Hash) (uint32, error) {
+			if countReads.Add(1) >= 4 {
+				return 1, nil
+			}
+			return 0, nil
+		},
+	).AnyTimes()
+	blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), block.Block.Slot, gomock.Any()).Return(
+		[]*cltypes.BlobSidecar{storedFuluSidecar(block, 0)}, true, nil,
+	).AnyTimes()
+	downloader := newBoundaryDownloader(t, block.Block.Slot, 0, block.Block.Slot, &boundaryBlockReader{block: block})
+	downloader.blobStorage = blobStorage
+	downloader.peerDasGetter = staticPeerDasGetter{pd: peerDas}
+	downloader.columnBackfillTimeout = 20 * time.Millisecond
+	downloader.verifyBlobSidecars = func([]*cltypes.BlobSidecar, clparams.StateVersion, func(*cltypes.SignedBeaconBlockHeader) error) error {
+		return nil
+	}
+	var notified atomic.Int32
+	downloader.SetNotifyBlobBackfilled(func(bool) { notified.Add(1) })
+
+	require.NoError(t, downloader.downloadOnce(false))
+	require.Zero(t, notified.Load())
+	require.False(t, downloader.backfillCompleted.Load())
+	require.NotEmpty(t, downloader.retryRanges)
+
+	require.NoError(t, downloader.downloadOnce(false))
+	require.Equal(t, int32(1), notified.Load())
+	require.True(t, downloader.backfillCompleted.Load())
+	require.Empty(t, downloader.retryRanges)
+
+	require.NoError(t, downloader.downloadOnce(false))
+	require.Equal(t, int32(1), notified.Load())
+}
+
+func TestBlobHistoryDownloaderCompletedFuluRecoveryMeetsDurablePostcondition(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	peerDas := mock_services.NewMockPeerDas(ctrl)
+	peerDas.EXPECT().DownloadColumnsAndRecoverBlobs(gomock.Any(), gomock.Any()).Return(nil)
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(0), nil)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(1), nil)
+	blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), gomock.Any(), gomock.Any()).Return([]*cltypes.BlobSidecar{storedFuluSidecar(block, 0)}, true, nil)
+	downloader := &BlobHistoryDownloader{
+		ctx:                   t.Context(),
+		rpc:                   boundaryPeerCounter(1),
+		blobStorage:           blobStorage,
+		peerDasGetter:         staticPeerDasGetter{pd: peerDas},
+		columnBackfillTimeout: time.Second,
+		verifyBlobSidecars: func([]*cltypes.BlobSidecar, clparams.StateVersion, func(*cltypes.SignedBeaconBlockHeader) error) error {
+			return nil
+		},
+		logger: log.New(),
+	}
+
+	require.True(t, downloader.recoverFuluColumns([]*cltypes.SignedBeaconBlock{block}))
+}
+
+func TestBlobHistoryDownloaderFuluRecoveryDoesNotDeleteConcurrentCompletion(t *testing.T) {
+	db := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
+	fs := afero.NewMemMapFs()
+	storage := blob_storage.NewBlobStore(db, fs)
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+	block.Block.Slot = 100
+	blobs := []goethkzg.Blob{{1}, {2}}
+	commitments := make([]goethkzg.KZGCommitment, len(blobs))
+	for i := range blobs {
+		commitment, err := kzg.Ctx().BlobToKZGCommitment(&blobs[i], 0)
+		require.NoError(t, err)
+		commitments[i] = commitment
+		block.GetBlobKzgCommitments().Append((*cltypes.KZGCommitment)(&commitment))
+	}
+	root, err := block.Block.HashSSZ()
+	require.NoError(t, err)
+	full := make([]*cltypes.BlobSidecar, len(blobs))
+	for i := range blobs {
+		proof, err := kzg.Ctx().ComputeBlobKZGProof(&blobs[i], commitments[i], 0)
+		require.NoError(t, err)
+		branch, err := block.Block.Body.KzgCommitmentMerkleProof(i)
+		require.NoError(t, err)
+		inclusionProof := solid.NewHashVector(cltypes.CommitmentBranchSize)
+		for j := range branch {
+			inclusionProof.Set(j, common.Hash(branch[j]))
+		}
+		full[i] = cltypes.NewBlobSidecar(uint64(i), (*cltypes.Blob)(&blobs[i]), common.Bytes48(commitments[i]), common.Bytes48(proof), block.SignedBeaconBlockHeader(), inclusionProof)
+	}
+	require.NoError(t, storage.WriteBlobSidecars(t.Context(), root, full[:1]))
+	completing := &completingBlobStorage{BlobStorage: storage, root: root, sidecars: full}
+
+	ctrl := gomock.NewController(t)
+	peerDas := mock_services.NewMockPeerDas(ctrl)
+	peerDas.EXPECT().DownloadColumnsAndRecoverBlobs(gomock.Any(), gomock.Any()).Return(nil)
+	downloader := &BlobHistoryDownloader{
+		ctx:                   t.Context(),
+		rpc:                   boundaryPeerCounter(1),
+		blobStorage:           completing,
+		peerDasGetter:         staticPeerDasGetter{pd: peerDas},
+		columnBackfillTimeout: time.Second,
+		verifyBlobSidecars: func([]*cltypes.BlobSidecar, clparams.StateVersion, func(*cltypes.SignedBeaconBlockHeader) error) error {
+			return nil
+		},
+		logger: log.New(),
+	}
+
+	require.True(t, downloader.recoverFuluColumns([]*cltypes.SignedBeaconBlock{block}))
+	fresh := blob_storage.NewBlobStore(db, fs)
+	sidecars, found, err := fresh.ReadBlobSidecars(t.Context(), block.Block.Slot, root)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Len(t, sidecars, 2)
+}
+
+func TestBlobHistoryDownloaderFuluRecoveryWaitsForAsyncPersistence(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	peerDas := mock_services.NewMockPeerDas(ctrl)
+	peerDas.EXPECT().DownloadColumnsAndRecoverBlobs(gomock.Any(), gomock.Any()).Return(nil)
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	var reads atomic.Int32
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).DoAndReturn(func(context.Context, common.Hash) (uint32, error) {
+		if reads.Add(1) < 3 {
+			return 0, nil
+		}
+		return 1, nil
+	}).AnyTimes()
+	blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), gomock.Any(), gomock.Any()).Return([]*cltypes.BlobSidecar{storedFuluSidecar(block, 0)}, true, nil)
+	downloader := &BlobHistoryDownloader{
+		ctx:                   t.Context(),
+		rpc:                   boundaryPeerCounter(1),
+		blobStorage:           blobStorage,
+		peerDasGetter:         staticPeerDasGetter{pd: peerDas},
+		columnBackfillTimeout: time.Second,
+		verifyBlobSidecars: func([]*cltypes.BlobSidecar, clparams.StateVersion, func(*cltypes.SignedBeaconBlockHeader) error) error {
+			return nil
+		},
+		logger: log.New(),
+	}
+
+	require.True(t, downloader.recoverFuluColumns([]*cltypes.SignedBeaconBlock{block}))
+	require.GreaterOrEqual(t, reads.Load(), int32(3))
+}
+
+func TestBlobHistoryDownloaderFuluRecoveryRejectsStaleCommitmentCount(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	peerDas := mock_services.NewMockPeerDas(ctrl)
+	peerDas.EXPECT().DownloadColumnsAndRecoverBlobs(gomock.Any(), gomock.Any()).Return(nil)
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(1), nil).Times(2)
+	blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, false, nil).Times(2)
+
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+	block.Block.Slot = 100
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	downloader := &BlobHistoryDownloader{
+		ctx:                   t.Context(),
+		rpc:                   boundaryPeerCounter(1),
+		blobStorage:           blobStorage,
+		peerDasGetter:         staticPeerDasGetter{pd: peerDas},
+		columnBackfillTimeout: time.Nanosecond,
+		logger:                log.New(),
+	}
+
+	require.False(t, downloader.recoverFuluColumns([]*cltypes.SignedBeaconBlock{block}))
+}
+
+func TestBlobHistoryDownloaderFuluTransientReadErrorDoesNotRemoveStorage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(1), nil)
+	blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, false, errors.New("temporary read failure"))
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	downloader := &BlobHistoryDownloader{
+		ctx:                   t.Context(),
+		rpc:                   boundaryPeerCounter(1),
+		blobStorage:           blobStorage,
+		columnBackfillTimeout: time.Second,
+		logger:                log.New(),
+	}
+
+	require.False(t, downloader.recoverFuluColumns([]*cltypes.SignedBeaconBlock{block}))
+}
+
+func TestBlobHistoryDownloaderFuluRecoveryRetainsPartialCommitmentCount(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	peerDas := mock_services.NewMockPeerDas(ctrl)
+	peerDas.EXPECT().DownloadColumnsAndRecoverBlobs(gomock.Any(), gomock.Any()).Return(nil)
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(1), nil).AnyTimes()
+
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+	block.Block.Slot = 100
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	downloader := &BlobHistoryDownloader{
+		ctx:                   t.Context(),
+		rpc:                   boundaryPeerCounter(1),
+		blobStorage:           blobStorage,
+		peerDasGetter:         staticPeerDasGetter{pd: peerDas},
+		columnBackfillTimeout: time.Nanosecond,
+		logger:                log.New(),
+	}
+
+	require.False(t, downloader.recoverFuluColumns([]*cltypes.SignedBeaconBlock{block}))
+}
+
+func TestBlobHistoryDownloaderFuluRecoveryRetainsExcessCommitmentCount(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	peerDas := mock_services.NewMockPeerDas(ctrl)
+	peerDas.EXPECT().DownloadColumnsAndRecoverBlobs(gomock.Any(), gomock.Any()).Return(nil)
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(3), nil).AnyTimes()
+
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+	block.Block.Slot = 100
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	downloader := &BlobHistoryDownloader{
+		ctx:                   t.Context(),
+		rpc:                   boundaryPeerCounter(1),
+		blobStorage:           blobStorage,
+		peerDasGetter:         staticPeerDasGetter{pd: peerDas},
+		columnBackfillTimeout: time.Nanosecond,
+		logger:                log.New(),
+	}
+
+	require.False(t, downloader.recoverFuluColumns([]*cltypes.SignedBeaconBlock{block}))
+}
+
+func TestBlobHistoryDownloaderCountEqualFuluSkipsDeepScanValidation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(1), nil)
+
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+	block.Block.Slot = 100
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	downloader := newBoundaryDownloader(t, block.Block.Slot, 0, block.Block.Slot, &boundaryBlockReader{block: block})
+	downloader.blobStorage = blobStorage
+	notified := false
+	downloader.SetNotifyBlobBackfilled(func(completed bool) { notified = completed })
+
+	require.NoError(t, downloader.downloadOnce(false))
+	require.True(t, downloader.backfillCompleted.Load())
+	require.True(t, notified)
+}
+
+func TestBlobHistoryDownloaderDoesNotDeepVerifyCountEqualStorage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(1), nil).AnyTimes()
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+	block.Block.Slot = 100
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	downloader := newBoundaryDownloader(t, block.Block.Slot, 0, block.Block.Slot, &boundaryBlockReader{block: block})
+	downloader.blobStorage = blobStorage
+	verifyCalls := 0
+	downloader.verifyBlobSidecars = func([]*cltypes.BlobSidecar, clparams.StateVersion, func(*cltypes.SignedBeaconBlockHeader) error) error {
+		verifyCalls++
+		return nil
+	}
+
+	require.NoError(t, downloader.downloadOnce(false))
+	require.NoError(t, downloader.downloadOnce(false))
+	require.Zero(t, verifyCalls)
+}
+
+func TestBlobHistoryDownloaderRetriesRecoveryAfterDurablePostcheckFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	countCalls := 0
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).DoAndReturn(func(context.Context, common.Hash) (uint32, error) {
+		countCalls++
+		if countCalls <= 2 {
+			return 0, nil
+		}
+		return 1, nil
+	}).AnyTimes()
+
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+	block.Block.Slot = 100
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	invalidSidecar := storedFuluSidecar(block, 0)
+	invalidSidecar.KzgCommitment[0] = 1
+	validSidecar := storedFuluSidecar(block, 0)
+	readCalls := 0
+	blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), block.Block.Slot, gomock.Any()).DoAndReturn(func(context.Context, uint64, common.Hash) ([]*cltypes.BlobSidecar, bool, error) {
+		readCalls++
+		if readCalls <= 2 {
+			return []*cltypes.BlobSidecar{invalidSidecar}, true, nil
+		}
+		return []*cltypes.BlobSidecar{validSidecar}, true, nil
+	}).AnyTimes()
+	peerDas := mock_services.NewMockPeerDas(ctrl)
+	peerDas.EXPECT().DownloadColumnsAndRecoverBlobs(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+	downloader := newBoundaryDownloader(t, block.Block.Slot, 0, block.Block.Slot, &boundaryBlockReader{block: block})
+	downloader.blobStorage = blobStorage
+	downloader.peerDasGetter = staticPeerDasGetter{pd: peerDas}
+	downloader.columnBackfillTimeout = 5 * time.Millisecond
+	downloader.verifyBlobSidecars = func([]*cltypes.BlobSidecar, clparams.StateVersion, func(*cltypes.SignedBeaconBlockHeader) error) error {
+		return nil
+	}
+
+	require.NoError(t, downloader.downloadOnce(false))
+	require.NoError(t, downloader.downloadOnce(false))
+	require.Equal(t, 3, readCalls)
+}
+
+func TestBlobHistoryDownloaderConservesEveryIncompleteFuluBlockAcrossPasses(t *testing.T) {
+	tests := []struct {
+		name              string
+		completionAttempt map[uint64]int
+	}{
+		{
+			name:              "first block fails",
+			completionAttempt: map[uint64]int{8: 2, 7: 1},
+		},
+		{
+			name:              "later block fails",
+			completionAttempt: map[uint64]int{8: 1, 7: 2},
+		},
+		{
+			name:              "first and later blocks fail",
+			completionAttempt: map[uint64]int{8: 2, 7: 2},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			blocks := make(map[uint64]*cltypes.SignedBeaconBlock, 2)
+			roots := make(map[common.Hash]uint64, 2)
+			sidecars := make(map[uint64]*cltypes.BlobSidecar, 2)
+			for _, slot := range []uint64{8, 7} {
+				block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+				block.Block.Slot = slot
+				block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+				root, err := block.Block.HashSSZ()
+				require.NoError(t, err)
+				blocks[slot] = block
+				roots[root] = slot
+				sidecars[slot] = storedFuluSidecar(block, 0)
+			}
+
+			attempts := make(map[uint64]int, 2)
+			peerDas := mock_services.NewMockPeerDas(ctrl)
+			peerDas.EXPECT().DownloadColumnsAndRecoverBlobs(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, requested []cltypes.ColumnSyncableSignedBlock) error {
+					require.Len(t, requested, 1)
+					attempts[requested[0].GetSlot()]++
+					return nil
+				},
+			).AnyTimes()
+			blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+			blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, root common.Hash) (uint32, error) {
+					slot := roots[root]
+					if attempts[slot] >= tc.completionAttempt[slot] {
+						return 1, nil
+					}
+					return 0, nil
+				},
+			).AnyTimes()
+			blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, slot uint64, _ common.Hash) ([]*cltypes.BlobSidecar, bool, error) {
+					return []*cltypes.BlobSidecar{sidecars[slot]}, true, nil
+				},
+			).AnyTimes()
+
+			downloader := newBoundaryDownloader(t, 1_000, 0, 1, &boundaryBlockReader{blocks: blocks})
+			downloader.blobStorage = blobStorage
+			downloader.peerDasGetter = staticPeerDasGetter{pd: peerDas}
+			downloader.columnBackfillTimeout = time.Millisecond
+			downloader.verifyBlobSidecars = func([]*cltypes.BlobSidecar, clparams.StateVersion, func(*cltypes.SignedBeaconBlockHeader) error) error {
+				return nil
+			}
+
+			require.NoError(t, downloader.downloadOnce(false))
+			require.NoError(t, downloader.downloadOnce(false))
+			require.Equal(t, tc.completionAttempt, attempts)
+			require.Empty(t, downloader.retryRanges)
+		})
+	}
+}
+
+func TestBlobHistoryDownloaderRetryDropsAlreadyCompleteDenebBlock(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	block, sidecar := validDenebRecoverySidecar(t, 100)
+	blockRoot, err := block.Block.HashSSZ()
+	require.NoError(t, err)
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), blockRoot).Return(uint32(1), nil).AnyTimes()
+	blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), block.Block.Slot, blockRoot).Return([]*cltypes.BlobSidecar{sidecar}, true, nil).AnyTimes()
+	peer := &countingBlobPeerClient{responses: []*cltypes.BlobSidecar{sidecar}}
+	downloader := newBoundaryDownloader(t, block.Block.Slot, 0, block.Block.Slot, &boundaryBlockReader{block: block})
+	downloader.blobStorage = blobStorage
+	downloader.rpc = peer
+	downloader.addRetrySlot(block.Block.Slot)
+
+	require.NoError(t, downloader.downloadOnce(false))
+	require.Zero(t, peer.requests)
+	require.Empty(t, downloader.retryRanges)
+}
+
+func TestBlobHistoryDownloaderRetryRetainsDenebBlockOnStorageReadError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	block, _ := validDenebRecoverySidecar(t, 100)
+	blockRoot, err := block.Block.HashSSZ()
+	require.NoError(t, err)
+	wantErr := errors.New("temporary storage failure")
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	countCalls := 0
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), blockRoot).DoAndReturn(func(context.Context, common.Hash) (uint32, error) {
+		countCalls++
+		if countCalls == 1 {
+			return 0, wantErr
+		}
+		return 1, nil
+	}).AnyTimes()
+	peer := &countingBlobPeerClient{}
+	downloader := newBoundaryDownloader(t, block.Block.Slot, 0, block.Block.Slot, &boundaryBlockReader{block: block})
+	var logs bytes.Buffer
+	downloader.logger.SetHandler(log.StreamHandler(&logs, log.LogfmtFormat()))
+	downloader.blobStorage = blobStorage
+	downloader.rpc = peer
+	downloader.addRetrySlot(block.Block.Slot)
+
+	require.NoError(t, downloader.downloadOnce(false))
+	require.Zero(t, peer.requests)
+	require.Equal(t, []blobRetryRange{{start: block.Block.Slot, end: block.Block.Slot, cursor: block.Block.Slot}}, downloader.retryRanges)
+	require.Contains(t, logs.String(), "Failed to read stored blob sidecars during retry")
+	require.Contains(t, logs.String(), "slot=100")
+	require.Contains(t, logs.String(), wantErr.Error())
+}
+
+func TestBlobHistoryDownloaderFuluRecoveryRejectsInvalidStoredSidecars(t *testing.T) {
+	tests := map[string]func(*cltypes.BlobSidecar){
+		"missing header": func(sidecar *cltypes.BlobSidecar) { sidecar.SignedBlockHeader = nil },
+		"wrong index":    func(sidecar *cltypes.BlobSidecar) { sidecar.Index = 1 },
+		"wrong commitment": func(sidecar *cltypes.BlobSidecar) {
+			sidecar.KzgCommitment = common.Bytes48{1}
+		},
+		"wrong root": func(sidecar *cltypes.BlobSidecar) { sidecar.SignedBlockHeader.Header.Slot++ },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			peerDas := mock_services.NewMockPeerDas(ctrl)
+			peerDas.EXPECT().DownloadColumnsAndRecoverBlobs(gomock.Any(), gomock.Any()).Return(nil)
+			blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+			block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+			block.Block.Slot = 100
+			block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+			sidecar := storedFuluSidecar(block, 0)
+			mutate(sidecar)
+			blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(0), nil)
+			blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(1), nil)
+			blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), gomock.Any(), gomock.Any()).Return([]*cltypes.BlobSidecar{sidecar}, true, nil)
+			downloader := &BlobHistoryDownloader{
+				ctx:                   t.Context(),
+				rpc:                   boundaryPeerCounter(1),
+				blobStorage:           blobStorage,
+				peerDasGetter:         staticPeerDasGetter{pd: peerDas},
+				columnBackfillTimeout: time.Nanosecond,
+				verifyBlobSidecars: func([]*cltypes.BlobSidecar, clparams.StateVersion, func(*cltypes.SignedBeaconBlockHeader) error) error {
+					return nil
+				},
+				logger: log.New(),
+			}
+
+			require.False(t, downloader.recoverFuluColumns([]*cltypes.SignedBeaconBlock{block}))
+		})
+	}
+}
+
+func TestBlobHistoryDownloaderFuluRecoveryRejectsFailedStoredSidecarVerification(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	peerDas := mock_services.NewMockPeerDas(ctrl)
+	peerDas.EXPECT().DownloadColumnsAndRecoverBlobs(gomock.Any(), gomock.Any()).Return(nil)
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+	block.Block.Slot = 100
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(0), nil)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(1), nil)
+	blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), gomock.Any(), gomock.Any()).Return([]*cltypes.BlobSidecar{storedFuluSidecar(block, 0)}, true, nil)
+	downloader := &BlobHistoryDownloader{
+		ctx:                   t.Context(),
+		rpc:                   boundaryPeerCounter(1),
+		blobStorage:           blobStorage,
+		peerDasGetter:         staticPeerDasGetter{pd: peerDas},
+		columnBackfillTimeout: time.Nanosecond,
+		verifyBlobSidecars: func([]*cltypes.BlobSidecar, clparams.StateVersion, func(*cltypes.SignedBeaconBlockHeader) error) error {
+			return errors.New("invalid blob proof")
+		},
+		logger: log.New(),
+	}
+
+	require.False(t, downloader.recoverFuluColumns([]*cltypes.SignedBeaconBlock{block}))
+}
+
+func TestBlobHistoryDownloaderFuluBlockWithoutBlobsCompletes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(0), nil)
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+	block.Block.Slot = 100
+	downloader := newBoundaryDownloader(t, block.Block.Slot, 0, block.Block.Slot, &boundaryBlockReader{block: block})
+	downloader.blobStorage = blobStorage
+	notified := false
+	downloader.SetNotifyBlobBackfilled(func(completed bool) { notified = completed })
+
+	require.NoError(t, downloader.downloadOnce(false))
+	require.True(t, downloader.backfillCompleted.Load())
+	require.True(t, notified)
+}
+
+func TestBlobHistoryDownloaderFuluBlockWithoutBlobsIgnoresStaleMetadata(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(1), nil)
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+	block.Block.Slot = 100
+	downloader := newBoundaryDownloader(t, block.Block.Slot, 0, block.Block.Slot, &boundaryBlockReader{block: block})
+	downloader.blobStorage = blobStorage
+	notified := false
+	downloader.SetNotifyBlobBackfilled(func(completed bool) { notified = completed })
+
+	require.NoError(t, downloader.downloadOnce(false))
+	require.True(t, downloader.backfillCompleted.Load())
+	require.True(t, notified)
+}
+
+func storedFuluSidecar(block *cltypes.SignedBeaconBlock, index int) *cltypes.BlobSidecar {
+	return &cltypes.BlobSidecar{
+		Index:             uint64(index),
+		KzgCommitment:     common.Bytes48(*block.GetBlobKzgCommitments().Get(index)),
+		SignedBlockHeader: block.SignedBeaconBlockHeader(),
+	}
+}
+
+func TestDenebRecoveryBatchRejectsMalformedCandidates(t *testing.T) {
+	id := &cltypes.BlobIdentifier{}
+	batch := &denebRecoveryBatch{
+		groups: map[common.Hash]*requestedBlobBlock{
+			{}: {ids: []*cltypes.BlobIdentifier{id}, sidecars: make(map[uint64]*cltypes.BlobSidecar)},
+		},
+		order: []common.Hash{{}},
+	}
+	tests := map[string]*PeerAndSidecars{
+		"empty candidate":   {},
+		"nil sidecar":       {Responses: []*cltypes.BlobSidecar{nil}},
+		"nil signed header": {Responses: []*cltypes.BlobSidecar{{}}},
+		"nil header": {Responses: []*cltypes.BlobSidecar{{
+			SignedBlockHeader: &cltypes.SignedBeaconBlockHeader{},
+		}}},
+	}
+	for name, candidate := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := batch.validate(batch.remaining(), candidate.Responses)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestDenebRecoveryBatchAccumulatesComplementaryPartialsAndStoresCompleteGroup(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	storage := blobstoragemock.NewMockBlobStorage(ctrl)
+	block, req, sidecars := denebRecoveryFixture(t, 2)
+	batch, err := newDenebRecoveryBatch([]*cltypes.SignedBeaconBlock{block}, req)
+	require.NoError(t, err)
+	batch.verifier = func([]*cltypes.BlobSidecar, func(*cltypes.SignedBeaconBlockHeader) error) error { return nil }
+
+	progress, err := batch.validate(req, []*cltypes.BlobSidecar{sidecars[1]})
+	require.NoError(t, err)
+	require.Equal(t, 1, progress)
+	_, err = batch.store(t.Context(), storage)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), batch.remaining().Get(0).Index)
+
+	storage.EXPECT().WriteBlobSidecars(gomock.Any(), req.Get(0).BlockRoot, []*cltypes.BlobSidecar{sidecars[0], sidecars[1]}).Return(nil)
+	progress, err = batch.validate(batch.remaining(), []*cltypes.BlobSidecar{sidecars[0]})
+	require.NoError(t, err)
+	require.Equal(t, 1, progress)
+	_, err = batch.store(t.Context(), storage)
+	require.NoError(t, err)
+	require.Zero(t, batch.remaining().Len())
+}
+
+func TestDenebRecoveryBatchAcceptsUsefulOverlapFromInflightRequest(t *testing.T) {
+	block, req, sidecars := denebRecoveryFixture(t, 2)
+	batch, err := newDenebRecoveryBatch([]*cltypes.SignedBeaconBlock{block}, req)
+	require.NoError(t, err)
+	batch.verifier = func([]*cltypes.BlobSidecar, func(*cltypes.SignedBeaconBlockHeader) error) error { return nil }
+
+	progress, err := batch.validate(req, []*cltypes.BlobSidecar{sidecars[0]})
+	require.NoError(t, err)
+	require.Equal(t, 1, progress)
+
+	progress, err = batch.validate(req, []*cltypes.BlobSidecar{sidecars[0], sidecars[1]})
+	require.NoError(t, err)
+	require.Equal(t, 1, progress)
+	require.Zero(t, batch.remaining().Len())
+}
+
+func TestDenebRecoveryBatchRetriesStorageWithoutRefetch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	storage := blobstoragemock.NewMockBlobStorage(ctrl)
+	block, req, sidecars := denebRecoveryFixture(t, 1)
+	batch, err := newDenebRecoveryBatch([]*cltypes.SignedBeaconBlock{block}, req)
+	require.NoError(t, err)
+	batch.verifier = func([]*cltypes.BlobSidecar, func(*cltypes.SignedBeaconBlockHeader) error) error { return nil }
+	storage.EXPECT().WriteBlobSidecars(gomock.Any(), req.Get(0).BlockRoot, sidecars).Return(errors.New("temporary write failure"))
+	storage.EXPECT().WriteBlobSidecars(gomock.Any(), req.Get(0).BlockRoot, sidecars).Return(nil)
+
+	ticks := make(chan time.Time)
+	expires := make(chan time.Time)
+	validationReady := make(chan struct{}, 2)
+	var requests atomic.Int32
+	client := blobRequesterFunc(func(context.Context, *solid.ListSSZ[*cltypes.BlobIdentifier]) ([]*cltypes.BlobSidecar, string, error) {
+		requests.Add(1)
+		return sidecars, "peer", nil
+	})
+	done := make(chan error, 1)
+	go func() {
+		_, err := requestBlobsForBackfillWithSchedule(t.Context(), client, batch.remaining, func(ctx context.Context, candidate *PeerAndSidecars) (bool, bool, error) {
+			progress, err := batch.validate(candidate.requested, candidate.Responses)
+			if err != nil {
+				return false, false, err
+			}
+			stored, err := batch.store(ctx, storage)
+			if err != nil {
+				return progress > 0 || batch.hasCompleteUnstoredGroup(), false, err
+			}
+			return progress > 0 || stored > 0, batch.complete(), nil
+		}, blobBackfillRequestSchedule{
+			ticks: ticks, expires: expires, now: func() time.Time { return time.Unix(100, 0) },
+			validationReady: func() { validationReady <- struct{}{} },
+		})
+		done <- err
+	}()
+
+	receiveBlobTestSignal(t, validationReady)
+	ticks <- time.Unix(101, 0)
+	require.NoError(t, receiveBlobTestValue(t, done))
+	require.Equal(t, int32(1), requests.Load())
+	require.True(t, batch.complete())
+}
+
+func TestDenebRecoveryBatchInvalidResponsesDoNotPoisonAccumulator(t *testing.T) {
+	block, req, sidecars := denebRecoveryFixture(t, 2)
+	batch, err := newDenebRecoveryBatch([]*cltypes.SignedBeaconBlock{block}, req)
+	require.NoError(t, err)
+	batch.verifier = func([]*cltypes.BlobSidecar, func(*cltypes.SignedBeaconBlockHeader) error) error { return nil }
+
+	_, err = batch.validate(req, []*cltypes.BlobSidecar{sidecars[0], sidecars[0]})
+	require.Error(t, err)
+	unrequested := *sidecars[0]
+	unrequested.Index = 3
+	_, err = batch.validate(req, []*cltypes.BlobSidecar{&unrequested})
+	require.Error(t, err)
+	require.Equal(t, 2, batch.remaining().Len())
+
+	progress, err := batch.validate(req, []*cltypes.BlobSidecar{sidecars[0]})
+	require.NoError(t, err)
+	require.Equal(t, 1, progress)
+	require.Equal(t, uint64(1), batch.remaining().Get(0).Index)
+}
+
+func denebRecoveryFixture(t *testing.T, count int) (*cltypes.SignedBeaconBlock, *solid.ListSSZ[*cltypes.BlobIdentifier], []*cltypes.BlobSidecar) {
+	t.Helper()
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+	for range count {
+		block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	}
+	req, err := BlobsIdentifiersFromBlocks([]*cltypes.SignedBeaconBlock{block}, &clparams.MainnetBeaconConfig)
+	require.NoError(t, err)
+	header := block.SignedBeaconBlockHeader()
+	sidecars := make([]*cltypes.BlobSidecar, count)
+	for i := range count {
+		sidecars[i] = &cltypes.BlobSidecar{Index: uint64(i), SignedBlockHeader: header}
+	}
+	return block, req, sidecars
+}
+
+func TestBlobHistoryDownloaderFailedDenebRequestWithholdsCompletionNotification(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(0), nil)
+	ctx, cancel := context.WithCancel(t.Context())
+	client := cancelingBlobPeerClient{cancel: cancel}
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+	block.Block.Slot = 100
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	downloader := newBoundaryDownloader(t, block.Block.Slot, 0, block.Block.Slot, &boundaryBlockReader{block: block})
+	downloader.ctx = ctx
+	downloader.rpc = client
+	downloader.blobStorage = blobStorage
+	notified := false
+	downloader.SetNotifyBlobBackfilled(func(completed bool) { notified = completed })
+
+	require.NoError(t, downloader.downloadOnce(false))
+	require.False(t, notified)
+	require.False(t, downloader.backfillCompleted.Load())
+}
+
+func TestBlobHistoryDownloaderDenebWithoutBlobsIgnoresStaleStorage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(1), nil)
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+	block.Block.Slot = 100
+	downloader := newBoundaryDownloader(t, block.Block.Slot, 0, block.Block.Slot, &boundaryBlockReader{block: block})
+	downloader.blobStorage = blobStorage
+	notified := false
+	downloader.SetNotifyBlobBackfilled(func(completed bool) { notified = completed })
+
+	require.NoError(t, downloader.downloadOnce(false))
+	require.True(t, downloader.backfillCompleted.Load())
+	require.True(t, notified)
+}
+
+func TestBlobHistoryDownloaderPostchecksPersistedDenebGroupAfterRequestCancellation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	blockA, sidecarA := validDenebRecoverySidecar(t, 100)
+	blockB, _ := validDenebRecoverySidecar(t, 101)
+	rootA, err := blockA.Block.HashSSZ()
+	require.NoError(t, err)
+
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().WriteBlobSidecars(gomock.Any(), rootA, []*cltypes.BlobSidecar{sidecarA}).DoAndReturn(
+		func(context.Context, common.Hash, []*cltypes.BlobSidecar) error {
+			cancel()
+			return nil
+		},
+	)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, root common.Hash) (uint32, error) {
+			if root == rootA {
+				return 1, nil
+			}
+			return 0, nil
+		},
+	).AnyTimes()
+	blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), blockA.Block.Slot, rootA).Return(nil, false, nil)
+	downloader := &BlobHistoryDownloader{
+		ctx:         ctx,
+		beaconCfg:   &clparams.MainnetBeaconConfig,
+		rpc:         staticBlobPeerClient{responses: []*cltypes.BlobSidecar{sidecarA}},
+		blobStorage: blobStorage,
+		logger:      log.New(),
+	}
+
+	require.False(t, downloader.recoverDenebBlobs([]*cltypes.SignedBeaconBlock{blockA, blockB}))
+	require.Len(t, downloader.retryRanges, 1)
+	require.Equal(t, blockA.Block.Slot, downloader.retryRanges[0].start)
+	require.Equal(t, blockB.Block.Slot, downloader.retryRanges[0].end)
+}
+
+func TestBlobHistoryDownloaderMixedDenebBatchIgnoresZeroCommitmentStorage(t *testing.T) {
+	for _, zeroFirst := range []bool{true, false} {
+		t.Run(map[bool]string{true: "zero first", false: "zero last"}[zeroFirst], func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			zero := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+			zero.Block.Slot = 100
+			nonzero, sidecar := validDenebRecoverySidecar(t, 101)
+			nonzeroRoot, err := nonzero.Block.HashSSZ()
+			require.NoError(t, err)
+
+			blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+			blobStorage.EXPECT().WriteBlobSidecars(gomock.Any(), nonzeroRoot, []*cltypes.BlobSidecar{sidecar}).Return(nil)
+			blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), nonzeroRoot).Return(uint32(1), nil)
+			blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), nonzero.Block.Slot, nonzeroRoot).Return([]*cltypes.BlobSidecar{sidecar}, true, nil)
+			blocks := []*cltypes.SignedBeaconBlock{nonzero, zero}
+			if zeroFirst {
+				blocks[0], blocks[1] = blocks[1], blocks[0]
+			}
+			downloader := &BlobHistoryDownloader{
+				ctx:         t.Context(),
+				beaconCfg:   &clparams.MainnetBeaconConfig,
+				rpc:         staticBlobPeerClient{responses: []*cltypes.BlobSidecar{sidecar}},
+				blobStorage: blobStorage,
+				logger:      log.New(),
+			}
+
+			require.True(t, downloader.recoverDenebBlobs(blocks))
+		})
+	}
+}
+
+func validDenebRecoverySidecar(t *testing.T, slot uint64) (*cltypes.SignedBeaconBlock, *cltypes.BlobSidecar) {
+	t.Helper()
+	blob := goethkzg.Blob{}
+	commitment, err := kzg.Ctx().BlobToKZGCommitment(&blob, 0)
+	require.NoError(t, err)
+	proof, err := kzg.Ctx().ComputeBlobKZGProof(&blob, commitment, 0)
+	require.NoError(t, err)
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+	block.Block.Slot = slot
+	block.GetBlobKzgCommitments().Append((*cltypes.KZGCommitment)(&commitment))
+	_, err = block.Block.HashSSZ()
+	require.NoError(t, err)
+	branch, err := block.Block.Body.KzgCommitmentMerkleProof(0)
+	require.NoError(t, err)
+	inclusionProof := solid.NewHashVector(cltypes.CommitmentBranchSize)
+	for i := range branch {
+		inclusionProof.Set(i, common.Hash(branch[i]))
+	}
+	return block, cltypes.NewBlobSidecar(0, (*cltypes.Blob)(&blob), common.Bytes48(commitment), common.Bytes48(proof), block.SignedBeaconBlockHeader(), inclusionProof)
+}
+
+type staticBlobPeerClient struct{ responses []*cltypes.BlobSidecar }
+
+func (staticBlobPeerClient) Peers() (uint64, error) { return 1, nil }
+
+func (c staticBlobPeerClient) SendBlobsSidecarByIdentifierReq(context.Context, *solid.ListSSZ[*cltypes.BlobIdentifier]) ([]*cltypes.BlobSidecar, string, error) {
+	return c.responses, "peer", nil
+}
+
+type countingBlobPeerClient struct {
+	responses []*cltypes.BlobSidecar
+	requests  int
+}
+
+func (*countingBlobPeerClient) Peers() (uint64, error) { return 1, nil }
+
+func (c *countingBlobPeerClient) SendBlobsSidecarByIdentifierReq(context.Context, *solid.ListSSZ[*cltypes.BlobIdentifier]) ([]*cltypes.BlobSidecar, string, error) {
+	c.requests++
+	return c.responses, "peer", nil
+}
+
+type cancelingBlobPeerClient struct {
+	cancel context.CancelFunc
+}
+
+func (cancelingBlobPeerClient) Peers() (uint64, error) { return 1, nil }
+
+func (c cancelingBlobPeerClient) SendBlobsSidecarByIdentifierReq(ctx context.Context, _ *solid.ListSSZ[*cltypes.BlobIdentifier]) ([]*cltypes.BlobSidecar, string, error) {
+	c.cancel()
+	<-ctx.Done()
+	return nil, "", ctx.Err()
 }

--- a/cl/phase1/network/blob_downloader_test.go
+++ b/cl/phase1/network/blob_downloader_test.go
@@ -201,6 +201,7 @@ func TestBlobHistoryDownloaderIncompleteFuluRecoveryWithholdsCompletionUntilRetr
 	blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), block.Block.Slot, gomock.Any()).Return(
 		[]*cltypes.BlobSidecar{storedFuluSidecar(block, 0)}, true, nil,
 	).AnyTimes()
+	blobStorage.EXPECT().BlobSidecarExists(gomock.Any(), block.Block.Slot, gomock.Any(), uint64(0)).Return(true, nil).AnyTimes()
 	downloader := newBoundaryDownloader(t, block.Block.Slot, 0, block.Block.Slot, &boundaryBlockReader{block: block})
 	downloader.blobStorage = blobStorage
 	downloader.peerDasGetter = staticPeerDasGetter{pd: peerDas}
@@ -427,6 +428,7 @@ func TestBlobHistoryDownloaderCountEqualFuluSkipsDeepScanValidation(t *testing.T
 	ctrl := gomock.NewController(t)
 	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
 	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(1), nil)
+	blobStorage.EXPECT().BlobSidecarExists(gomock.Any(), uint64(100), gomock.Any(), uint64(0)).Return(true, nil)
 
 	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
 	block.Block.Slot = 100
@@ -441,10 +443,55 @@ func TestBlobHistoryDownloaderCountEqualFuluSkipsDeepScanValidation(t *testing.T
 	require.True(t, notified)
 }
 
+func TestBlobHistoryDownloaderCountEqualMissingFilesIsIncomplete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(1), nil)
+	blobStorage.EXPECT().BlobSidecarExists(gomock.Any(), uint64(100), gomock.Any(), uint64(0)).Return(false, nil)
+
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+	block.Block.Slot = 100
+	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
+	downloader := newBoundaryDownloader(t, block.Block.Slot, 0, block.Block.Slot, &boundaryBlockReader{block: block})
+	downloader.blobStorage = blobStorage
+
+	batch, visited, err := downloader.collectIncompleteBlocks(block.Block.Slot, block.Block.Slot)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), visited)
+	require.Equal(t, []*cltypes.SignedBeaconBlock{block}, batch)
+}
+
+func TestBlobHistoryDownloaderFindsFilesPrunedBehindStaleCount(t *testing.T) {
+	block, sidecar := validDenebRecoverySidecar(t, 100)
+	blockRoot, err := block.Block.HashSSZ()
+	require.NoError(t, err)
+	db := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
+	fs := afero.NewMemMapFs()
+	storage := blob_storage.NewBlobStore(db, fs)
+	require.NoError(t, storage.WriteBlobSidecars(t.Context(), blockRoot, []*cltypes.BlobSidecar{sidecar}))
+	require.NoError(t, storage.PruneBelow(10_000))
+	storage = blob_storage.NewBlobStore(db, fs)
+
+	count, err := storage.KzgCommitmentsCount(t.Context(), blockRoot)
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), count)
+	exists, err := storage.BlobSidecarExists(t.Context(), block.Block.Slot, blockRoot, 0)
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	downloader := newBoundaryDownloader(t, block.Block.Slot, 0, block.Block.Slot, &boundaryBlockReader{block: block})
+	downloader.blobStorage = storage
+	batch, visited, err := downloader.collectIncompleteBlocks(block.Block.Slot, block.Block.Slot)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), visited)
+	require.Equal(t, []*cltypes.SignedBeaconBlock{block}, batch)
+}
+
 func TestBlobHistoryDownloaderDoesNotDeepVerifyCountEqualStorage(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
 	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(1), nil).AnyTimes()
+	blobStorage.EXPECT().BlobSidecarExists(gomock.Any(), uint64(100), gomock.Any(), uint64(0)).Return(true, nil).AnyTimes()
 	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
 	block.Block.Slot = 100
 	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
@@ -487,6 +534,7 @@ func TestBlobHistoryDownloaderRetriesRecoveryAfterDurablePostcheckFailure(t *tes
 		}
 		return []*cltypes.BlobSidecar{validSidecar}, true, nil
 	}).AnyTimes()
+	blobStorage.EXPECT().BlobSidecarExists(gomock.Any(), block.Block.Slot, gomock.Any(), uint64(0)).Return(true, nil).AnyTimes()
 	peerDas := mock_services.NewMockPeerDas(ctrl)
 	peerDas.EXPECT().DownloadColumnsAndRecoverBlobs(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 	downloader := newBoundaryDownloader(t, block.Block.Slot, 0, block.Block.Slot, &boundaryBlockReader{block: block})
@@ -586,6 +634,7 @@ func TestBlobHistoryDownloaderRetryDropsAlreadyCompleteDenebBlock(t *testing.T) 
 	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
 	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), blockRoot).Return(uint32(1), nil).AnyTimes()
 	blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), block.Block.Slot, blockRoot).Return([]*cltypes.BlobSidecar{sidecar}, true, nil).AnyTimes()
+	blobStorage.EXPECT().BlobSidecarExists(gomock.Any(), block.Block.Slot, blockRoot, uint64(0)).Return(true, nil).AnyTimes()
 	peer := &countingBlobPeerClient{responses: []*cltypes.BlobSidecar{sidecar}}
 	downloader := newBoundaryDownloader(t, block.Block.Slot, 0, block.Block.Slot, &boundaryBlockReader{block: block})
 	downloader.blobStorage = blobStorage
@@ -612,6 +661,7 @@ func TestBlobHistoryDownloaderRetryRetainsDenebBlockOnStorageReadError(t *testin
 		}
 		return 1, nil
 	}).AnyTimes()
+	blobStorage.EXPECT().BlobSidecarExists(gomock.Any(), block.Block.Slot, blockRoot, uint64(0)).Return(true, nil).AnyTimes()
 	peer := &countingBlobPeerClient{}
 	downloader := newBoundaryDownloader(t, block.Block.Slot, 0, block.Block.Slot, &boundaryBlockReader{block: block})
 	var logs bytes.Buffer

--- a/cl/phase1/network/blob_downloader_test.go
+++ b/cl/phase1/network/blob_downloader_test.go
@@ -201,7 +201,6 @@ func TestBlobHistoryDownloaderIncompleteFuluRecoveryWithholdsCompletionUntilRetr
 	blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), block.Block.Slot, gomock.Any()).Return(
 		[]*cltypes.BlobSidecar{storedFuluSidecar(block, 0)}, true, nil,
 	).AnyTimes()
-	blobStorage.EXPECT().BlobSidecarExists(gomock.Any(), block.Block.Slot, gomock.Any(), uint64(0)).Return(true, nil).AnyTimes()
 	downloader := newBoundaryDownloader(t, block.Block.Slot, 0, block.Block.Slot, &boundaryBlockReader{block: block})
 	downloader.blobStorage = blobStorage
 	downloader.peerDasGetter = staticPeerDasGetter{pd: peerDas}
@@ -428,7 +427,6 @@ func TestBlobHistoryDownloaderCountEqualFuluSkipsDeepScanValidation(t *testing.T
 	ctrl := gomock.NewController(t)
 	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
 	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(1), nil)
-	blobStorage.EXPECT().BlobSidecarExists(gomock.Any(), uint64(100), gomock.Any(), uint64(0)).Return(true, nil)
 
 	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
 	block.Block.Slot = 100
@@ -443,25 +441,7 @@ func TestBlobHistoryDownloaderCountEqualFuluSkipsDeepScanValidation(t *testing.T
 	require.True(t, notified)
 }
 
-func TestBlobHistoryDownloaderCountEqualMissingFilesIsIncomplete(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
-	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(1), nil)
-	blobStorage.EXPECT().BlobSidecarExists(gomock.Any(), uint64(100), gomock.Any(), uint64(0)).Return(false, nil)
-
-	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
-	block.Block.Slot = 100
-	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
-	downloader := newBoundaryDownloader(t, block.Block.Slot, 0, block.Block.Slot, &boundaryBlockReader{block: block})
-	downloader.blobStorage = blobStorage
-
-	batch, visited, err := downloader.collectIncompleteBlocks(block.Block.Slot, block.Block.Slot)
-	require.NoError(t, err)
-	require.Equal(t, uint64(1), visited)
-	require.Equal(t, []*cltypes.SignedBeaconBlock{block}, batch)
-}
-
-func TestBlobHistoryDownloaderFindsFilesPrunedBehindStaleCount(t *testing.T) {
+func TestBlobHistoryDownloaderDoesNotRetryIntentionallyPrunedFiles(t *testing.T) {
 	block, sidecar := validDenebRecoverySidecar(t, 100)
 	blockRoot, err := block.Block.HashSSZ()
 	require.NoError(t, err)
@@ -470,7 +450,6 @@ func TestBlobHistoryDownloaderFindsFilesPrunedBehindStaleCount(t *testing.T) {
 	storage := blob_storage.NewBlobStore(db, fs)
 	require.NoError(t, storage.WriteBlobSidecars(t.Context(), blockRoot, []*cltypes.BlobSidecar{sidecar}))
 	require.NoError(t, storage.PruneBelow(10_000))
-	storage = blob_storage.NewBlobStore(db, fs)
 
 	count, err := storage.KzgCommitmentsCount(t.Context(), blockRoot)
 	require.NoError(t, err)
@@ -479,19 +458,23 @@ func TestBlobHistoryDownloaderFindsFilesPrunedBehindStaleCount(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, exists)
 
+	peer := &countingBlobPeerClient{responses: []*cltypes.BlobSidecar{sidecar}}
 	downloader := newBoundaryDownloader(t, block.Block.Slot, 0, block.Block.Slot, &boundaryBlockReader{block: block})
 	downloader.blobStorage = storage
-	batch, visited, err := downloader.collectIncompleteBlocks(block.Block.Slot, block.Block.Slot)
-	require.NoError(t, err)
-	require.Equal(t, uint64(1), visited)
-	require.Equal(t, []*cltypes.SignedBeaconBlock{block}, batch)
+	downloader.rpc = peer
+	downloader.archiveBlobs = false
+	downloader.immediateBlobsBackfilling = true
+
+	require.NoError(t, downloader.downloadOnce(false))
+	require.Zero(t, peer.requests)
+	require.Empty(t, downloader.retryRanges)
+	require.True(t, downloader.backfillCompleted.Load())
 }
 
 func TestBlobHistoryDownloaderDoesNotDeepVerifyCountEqualStorage(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
 	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(1), nil).AnyTimes()
-	blobStorage.EXPECT().BlobSidecarExists(gomock.Any(), uint64(100), gomock.Any(), uint64(0)).Return(true, nil).AnyTimes()
 	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
 	block.Block.Slot = 100
 	block.GetBlobKzgCommitments().Append(&cltypes.KZGCommitment{})
@@ -534,7 +517,6 @@ func TestBlobHistoryDownloaderRetriesRecoveryAfterDurablePostcheckFailure(t *tes
 		}
 		return []*cltypes.BlobSidecar{validSidecar}, true, nil
 	}).AnyTimes()
-	blobStorage.EXPECT().BlobSidecarExists(gomock.Any(), block.Block.Slot, gomock.Any(), uint64(0)).Return(true, nil).AnyTimes()
 	peerDas := mock_services.NewMockPeerDas(ctrl)
 	peerDas.EXPECT().DownloadColumnsAndRecoverBlobs(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 	downloader := newBoundaryDownloader(t, block.Block.Slot, 0, block.Block.Slot, &boundaryBlockReader{block: block})
@@ -634,7 +616,6 @@ func TestBlobHistoryDownloaderRetryDropsAlreadyCompleteDenebBlock(t *testing.T) 
 	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
 	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), blockRoot).Return(uint32(1), nil).AnyTimes()
 	blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), block.Block.Slot, blockRoot).Return([]*cltypes.BlobSidecar{sidecar}, true, nil).AnyTimes()
-	blobStorage.EXPECT().BlobSidecarExists(gomock.Any(), block.Block.Slot, blockRoot, uint64(0)).Return(true, nil).AnyTimes()
 	peer := &countingBlobPeerClient{responses: []*cltypes.BlobSidecar{sidecar}}
 	downloader := newBoundaryDownloader(t, block.Block.Slot, 0, block.Block.Slot, &boundaryBlockReader{block: block})
 	downloader.blobStorage = blobStorage
@@ -661,7 +642,6 @@ func TestBlobHistoryDownloaderRetryRetainsDenebBlockOnStorageReadError(t *testin
 		}
 		return 1, nil
 	}).AnyTimes()
-	blobStorage.EXPECT().BlobSidecarExists(gomock.Any(), block.Block.Slot, blockRoot, uint64(0)).Return(true, nil).AnyTimes()
 	peer := &countingBlobPeerClient{}
 	downloader := newBoundaryDownloader(t, block.Block.Slot, 0, block.Block.Slot, &boundaryBlockReader{block: block})
 	var logs bytes.Buffer

--- a/cl/phase1/network/blobs.go
+++ b/cl/phase1/network/blobs.go
@@ -19,7 +19,7 @@ package network
 import (
 	"context"
 	"errors"
-	"sync/atomic"
+	"sync"
 	"time"
 
 	"github.com/erigontech/erigon/cl/clparams"
@@ -31,7 +31,12 @@ import (
 
 var ErrTimeout = errors.New("timeout")
 
-var requestBlobBatchExpiration = 15 * time.Second
+const (
+	requestBlobBatchExpiration       = 15 * time.Second
+	requestBlobRetryInterval         = 100 * time.Millisecond
+	requestBlobMaxBackoff            = 2 * time.Second
+	maxConcurrentBlobBackfillRequest = 2
+)
 
 // This is just a bunch of functions to handle blobs
 
@@ -69,54 +74,202 @@ func BlobsIdentifiersFromBlocks(blocks []*cltypes.SignedBeaconBlock, cfg *clpara
 type PeerAndSidecars struct {
 	Peer      string
 	Responses []*cltypes.BlobSidecar
+	requested *solid.ListSSZ[*cltypes.BlobIdentifier]
 }
 
-// RequestBlobsFrantically requests blobs from the network frantically.
-func RequestBlobsFrantically(ctx context.Context, r *rpc.BeaconRpcP2P, req *solid.ListSSZ[*cltypes.BlobIdentifier]) (*PeerAndSidecars, error) {
-	var atomicResp atomic.Value
+type blobRequester interface {
+	SendBlobsSidecarByIdentifierReq(context.Context, *solid.ListSSZ[*cltypes.BlobIdentifier]) ([]*cltypes.BlobSidecar, string, error)
+}
 
-	atomicResp.Store(&PeerAndSidecars{})
+type blobRequestResult struct {
+	peer      string
+	responses []*cltypes.BlobSidecar
+	requested *solid.ListSSZ[*cltypes.BlobIdentifier]
+	err       error
+}
+
+type blobBackfillRequestPacing struct {
+	backoff     time.Duration
+	nextRequest time.Time
+}
+
+func newBlobBackfillRequestPacing() blobBackfillRequestPacing {
+	return blobBackfillRequestPacing{backoff: requestBlobRetryInterval}
+}
+
+func (p *blobBackfillRequestPacing) ready(now time.Time) bool {
+	return !now.Before(p.nextRequest)
+}
+
+func (p *blobBackfillRequestPacing) failed(now time.Time) {
+	p.nextRequest = now.Add(p.backoff)
+	p.backoff = min(p.backoff*2, requestBlobMaxBackoff)
+}
+
+func (p *blobBackfillRequestPacing) reset(now time.Time) {
+	p.backoff = requestBlobRetryInterval
+	p.nextRequest = now.Add(requestBlobRetryInterval)
+}
+
+func (p *blobBackfillRequestPacing) recordValidation(now time.Time, progress bool, err error) {
+	if progress && err == nil {
+		p.reset(now)
+		return
+	}
+	p.failed(now)
+}
+
+type blobBackfillRequestSchedule struct {
+	ticks           <-chan time.Time
+	expires         <-chan time.Time
+	now             func() time.Time
+	validationReady func()
+}
+
+type blobBackfillCandidateAcceptor func(context.Context, *PeerAndSidecars) (progress, complete bool, err error)
+type blobBackfillRequestFactory func() *solid.ListSSZ[*cltypes.BlobIdentifier]
+
+func requestBlobsForBackfill(ctx context.Context, r blobRequester, req blobBackfillRequestFactory, accept blobBackfillCandidateAcceptor) (*PeerAndSidecars, error) {
+	ticker := time.NewTicker(requestBlobRetryInterval)
+	defer ticker.Stop()
 	timer := time.NewTimer(requestBlobBatchExpiration)
 	defer timer.Stop()
-	reqInterval := time.NewTicker(100 * time.Millisecond)
-	defer reqInterval.Stop()
-Loop:
-	for {
-		select {
-		case <-reqInterval.C:
-			go func() {
-				if len(atomicResp.Load().(*PeerAndSidecars).Responses) > 0 {
-					return
-				}
-				// this is so we do not get stuck on a side-fork
-				responses, pid, err := r.SendBlobsSidecarByIdentifierReq(ctx, req)
-				if err != nil {
-					log.Trace("RequestBlobsFrantically: error", "err", err, "peer", pid)
-					return
-				}
-				if responses == nil {
-					log.Trace("RequestBlobsFrantically: response is nil", "peer", pid)
-					return
-				}
-				if len(atomicResp.Load().(*PeerAndSidecars).Responses) > 0 {
-					return
-				}
-				atomicResp.Store(&PeerAndSidecars{
-					Peer:      pid,
-					Responses: responses,
-				})
-			}()
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-timer.C:
-			log.Trace("RequestBlobsFrantically: timeout")
-			return nil, ErrTimeout
-		default:
-			if len(atomicResp.Load().(*PeerAndSidecars).Responses) > 0 {
-				break Loop
+	return requestBlobsForBackfillWithSchedule(ctx, r, req, accept, blobBackfillRequestSchedule{
+		ticks:   ticker.C,
+		expires: timer.C,
+		now:     time.Now,
+	})
+}
+
+type blobValidationResult struct {
+	candidate *PeerAndSidecars
+	progress  bool
+	complete  bool
+	err       error
+}
+
+func requestBlobsForBackfillWithSchedule(ctx context.Context, r blobRequester, req blobBackfillRequestFactory, acceptCandidate blobBackfillCandidateAcceptor, schedule blobBackfillRequestSchedule) (*PeerAndSidecars, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	requestCtx, cancel := context.WithCancel(ctx)
+	var requestWorkers sync.WaitGroup
+	defer func() {
+		cancel()
+		requestWorkers.Wait()
+	}()
+	results := make(chan blobRequestResult, maxConcurrentBlobBackfillRequest)
+	validationResults := make(chan blobValidationResult, 1)
+	inFlight := 0
+	validating := false
+	var retryCandidate *PeerAndSidecars
+	pacing := newBlobBackfillRequestPacing()
+	launch := func() {
+		inFlight++
+		requested := req()
+		requestWorkers.Go(func() {
+			responses, peer, err := r.SendBlobsSidecarByIdentifierReq(requestCtx, requested)
+			select {
+			case results <- blobRequestResult{peer: peer, responses: responses, requested: requested, err: err}:
+			case <-requestCtx.Done():
 			}
-			time.Sleep(10 * time.Millisecond)
+		})
+	}
+	startValidation := func(candidate *PeerAndSidecars) {
+		validating = true
+		go func() {
+			progress, complete, err := acceptCandidate(requestCtx, candidate)
+			validationResults <- blobValidationResult{candidate: candidate, progress: progress, complete: complete, err: err}
+			if schedule.validationReady != nil {
+				schedule.validationReady()
+			}
+		}()
+	}
+	waitForValidation := func() {
+		if validating {
+			<-validationResults
 		}
 	}
-	return atomicResp.Load().(*PeerAndSidecars), nil
+	handleRequest := func(result blobRequestResult) {
+		inFlight--
+		if result.err != nil {
+			pacing.failed(schedule.now())
+			log.Trace("requestBlobsForBackfill: error", "err", result.err, "peer", result.peer)
+			return
+		}
+		startValidation(&PeerAndSidecars{Peer: result.peer, Responses: result.responses, requested: result.requested})
+	}
+	handleValidation := func(result blobValidationResult) *PeerAndSidecars {
+		validating = false
+		pacing.recordValidation(schedule.now(), result.progress, result.err)
+		if result.err != nil || !result.progress {
+			if result.err != nil && result.progress {
+				retryCandidate = result.candidate
+			}
+			log.Trace("requestBlobsForBackfill: candidate rejected", "err", result.err, "peer", result.candidate.Peer)
+			return nil
+		}
+		if result.complete {
+			return result.candidate
+		}
+		return nil
+	}
+	launch()
+	for {
+		requestResults := (<-chan blobRequestResult)(results)
+		if validating {
+			requestResults = nil
+		}
+		select {
+		case now := <-schedule.ticks:
+			select {
+			case result := <-validationResults:
+				if response := handleValidation(result); response != nil {
+					return response, nil
+				}
+			default:
+			}
+			if !validating && pacing.ready(now) {
+				if retryCandidate != nil {
+					candidate := retryCandidate
+					retryCandidate = nil
+					startValidation(candidate)
+				} else if inFlight < maxConcurrentBlobBackfillRequest {
+					launch()
+				}
+			}
+		case result := <-requestResults:
+			handleRequest(result)
+		case result := <-validationResults:
+			if response := handleValidation(result); response != nil {
+				return response, nil
+			}
+		case <-ctx.Done():
+			cancel()
+			waitForValidation()
+			return nil, ctx.Err()
+		case <-schedule.expires:
+			select {
+			case result := <-validationResults:
+				if response := handleValidation(result); response != nil {
+					return response, nil
+				}
+			default:
+			}
+			cancel()
+			waitForValidation()
+			log.Trace("requestBlobsForBackfill: timeout")
+			return nil, ErrTimeout
+		}
+	}
+}
+
+// RequestBlobsFrantically requests blobs until a peer returns a non-empty response.
+func RequestBlobsFrantically(ctx context.Context, r *rpc.BeaconRpcP2P, req *solid.ListSSZ[*cltypes.BlobIdentifier]) (*PeerAndSidecars, error) {
+	return requestBlobsForBackfill(ctx, r, func() *solid.ListSSZ[*cltypes.BlobIdentifier] {
+		return req
+	}, func(_ context.Context, candidate *PeerAndSidecars) (bool, bool, error) {
+		complete := len(candidate.Responses) > 0
+		return complete, complete, nil
+	})
 }

--- a/cl/phase1/network/envelopes.go
+++ b/cl/phase1/network/envelopes.go
@@ -27,13 +27,20 @@ import (
 	"github.com/erigontech/erigon/common/log/v3"
 )
 
-var requestEnvelopeBatchExpiration = 30 * time.Second
+var (
+	requestEnvelopeBatchExpiration = 30 * time.Second
+	requestEnvelopeAttemptTimeout  = 21 * time.Second
+	requestEnvelopeRetryInterval   = 300 * time.Millisecond
+)
 
 // RequestEnvelopesFrantically requests execution payload envelopes from the network for the given beacon block roots.
 // It first tries by-root, then falls back to by-range using the slot range of fullBlocks.
 // EMPTY blocks will not have envelopes on the network, so timeout is non-fatal.
 // Returns a map of beacon block root -> envelope for all received envelopes.
 func RequestEnvelopesFrantically(ctx context.Context, r *rpc.BeaconRpcP2P, roots [][32]byte, fullBlocks ...*cltypes.SignedBeaconBlock) (map[common.Hash]*cltypes.SignedExecutionPayloadEnvelope, error) {
+	requestCtx, cancelRequests := context.WithTimeout(ctx, requestEnvelopeBatchExpiration)
+	defer cancelRequests()
+
 	received := make(map[common.Hash]*cltypes.SignedExecutionPayloadEnvelope, len(roots))
 	needed := make([][32]byte, len(roots))
 	copy(needed, roots)
@@ -44,16 +51,17 @@ func RequestEnvelopesFrantically(ctx context.Context, r *rpc.BeaconRpcP2P, roots
 		requestedRoots[common.Hash(root)] = struct{}{}
 	}
 
-	timer := time.NewTimer(requestEnvelopeBatchExpiration)
-	defer timer.Stop()
-
 	byRootAttempts := 0
 	byRangeAttempted := false
 	for len(needed) > 0 {
+		if err := ctx.Err(); err != nil {
+			return received, err
+		}
 		select {
-		case <-ctx.Done():
-			return received, ctx.Err()
-		case <-timer.C:
+		case <-requestCtx.Done():
+			if err := ctx.Err(); err != nil {
+				return received, err
+			}
 			log.Debug("RequestEnvelopesFrantically: timeout, some envelopes not received", "missing", len(needed))
 			return received, nil
 		default:
@@ -64,31 +72,52 @@ func RequestEnvelopesFrantically(ctx context.Context, r *rpc.BeaconRpcP2P, roots
 		// protocol but return EOF, wasting the entire 30s timeout budget.
 		if byRootAttempts >= 3 && len(fullBlocks) > 0 && !byRangeAttempted {
 			byRangeAttempted = true
-			requestEnvelopesByRange(ctx, r, fullBlocks, requestedRoots, received)
+			rangeCtx, cancelRange := context.WithTimeout(requestCtx, requestEnvelopeAttemptTimeout)
+			requestEnvelopesByRange(rangeCtx, r, fullBlocks, requestedRoots, received)
+			cancelRange()
 			needed = filterReceived(needed, received)
 			if len(needed) == 0 {
 				break
 			}
 		}
 
-		responses, err := requestEnvelopesByRoot(ctx, r, needed)
+		attemptCtx, cancelAttempt := context.WithTimeout(requestCtx, requestEnvelopeAttemptTimeout)
+		responses, err := requestEnvelopesByRoot(attemptCtx, r, needed)
+		attemptTimedOut := errors.Is(attemptCtx.Err(), context.DeadlineExceeded) && requestCtx.Err() == nil
+		cancelAttempt()
 		acceptEnvelopeResponses(responses, requestedRoots, received)
 		needed = filterReceived(needed, received)
 		if len(needed) == 0 {
 			break
 		}
+		if requestCtx.Err() != nil {
+			continue
+		}
 		if err != nil {
 			log.Trace("RequestEnvelopesFrantically: by-root error", "err", err)
+			if attemptTimedOut {
+				byRootAttempts = 3
+				continue
+			}
 			byRootAttempts++
-			time.Sleep(300 * time.Millisecond)
+			waitForEnvelopeRetry(requestCtx)
 			continue
 		}
 		if len(needed) > 0 {
 			byRootAttempts++
-			time.Sleep(300 * time.Millisecond)
+			waitForEnvelopeRetry(requestCtx)
 		}
 	}
 	return received, nil
+}
+
+func waitForEnvelopeRetry(ctx context.Context) {
+	timer := time.NewTimer(requestEnvelopeRetryInterval)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+	case <-timer.C:
+	}
 }
 
 func requestEnvelopesByRoot(ctx context.Context, r *rpc.BeaconRpcP2P, roots [][32]byte) ([]*cltypes.SignedExecutionPayloadEnvelope, error) {

--- a/cl/phase1/network/envelopes_test.go
+++ b/cl/phase1/network/envelopes_test.go
@@ -17,13 +17,240 @@
 package network
 
 import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 
 	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/sentinel/communication"
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/node/gointerfaces/sentinelproto"
 )
+
+type slowEnvelopeSentinel struct {
+	sentinelproto.SentinelClient
+	first       sync.Once
+	byRange     chan struct{}
+	byRangeOnce sync.Once
+}
+
+type blockedRangeEnvelopeSentinel struct {
+	sentinelproto.SentinelClient
+	byRootCalls   atomic.Int32
+	byRange       chan struct{}
+	laterByRoot   chan struct{}
+	byRangeOnce   sync.Once
+	laterRootOnce sync.Once
+}
+
+type immediateEnvelopeSentinel struct {
+	sentinelproto.SentinelClient
+	empty bool
+}
+
+func (s *immediateEnvelopeSentinel) SendRequest(context.Context, *sentinelproto.RequestData, ...grpc.CallOption) (*sentinelproto.ResponseData, error) {
+	if s.empty {
+		return &sentinelproto.ResponseData{Peer: &sentinelproto.Peer{Pid: "empty-peer"}}, nil
+	}
+	return nil, errors.New("request failed")
+}
+
+func (s *blockedRangeEnvelopeSentinel) SendRequest(ctx context.Context, req *sentinelproto.RequestData, _ ...grpc.CallOption) (*sentinelproto.ResponseData, error) {
+	if req.Topic == communication.ExecutionPayloadEnvelopesByRangeProtocolV1 {
+		s.byRangeOnce.Do(func() { close(s.byRange) })
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	if s.byRootCalls.Add(1) > 3 {
+		s.laterRootOnce.Do(func() { close(s.laterByRoot) })
+	}
+	return nil, context.Canceled
+}
+
+func (s *slowEnvelopeSentinel) SendRequest(ctx context.Context, req *sentinelproto.RequestData, _ ...grpc.CallOption) (*sentinelproto.ResponseData, error) {
+	first := false
+	s.first.Do(func() { first = true })
+	if first {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	if req.Topic == communication.ExecutionPayloadEnvelopesByRangeProtocolV1 {
+		s.byRangeOnce.Do(func() { close(s.byRange) })
+	}
+	return nil, context.Canceled
+}
+
+func TestRequestEnvelopesFranticallyCancelsBlockedRequestWhenBatchExpires(t *testing.T) {
+	previousExpiration := requestEnvelopeBatchExpiration
+	requestEnvelopeBatchExpiration = 100 * time.Millisecond
+	t.Cleanup(func() { requestEnvelopeBatchExpiration = previousExpiration })
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	sentinel := newContextBlockingSentinel()
+	rpcClient, _ := newContextBlockingBeaconRPC(ctx, sentinel)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := RequestEnvelopesFrantically(ctx, rpcClient, [][32]byte{{1}})
+		done <- err
+	}()
+
+	select {
+	case <-sentinel.started:
+	case <-time.After(time.Second):
+		t.Fatal("request did not reach the Sentinel boundary")
+	}
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("batch expiration did not stop the blocked envelope request")
+	}
+	select {
+	case <-sentinel.canceled:
+	case <-time.After(time.Second):
+		t.Fatal("batch expiration returned without canceling the blocked envelope request")
+	}
+}
+
+func TestRequestEnvelopesFranticallyReturnsCallerCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	sentinel := newContextBlockingSentinel()
+	rpcClient, _ := newContextBlockingBeaconRPC(ctx, sentinel)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := RequestEnvelopesFrantically(ctx, rpcClient, [][32]byte{{1}})
+		done <- err
+	}()
+
+	select {
+	case <-sentinel.started:
+	case <-time.After(time.Second):
+		t.Fatal("request did not reach the Sentinel boundary")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("caller cancellation did not stop the blocked envelope request")
+	}
+}
+
+func TestRequestEnvelopesFranticallyInterruptsRetryDelay(t *testing.T) {
+	previousExpiration := requestEnvelopeBatchExpiration
+	previousRetryInterval := requestEnvelopeRetryInterval
+	requestEnvelopeBatchExpiration = 20 * time.Millisecond
+	requestEnvelopeRetryInterval = time.Second
+	t.Cleanup(func() {
+		requestEnvelopeBatchExpiration = previousExpiration
+		requestEnvelopeRetryInterval = previousRetryInterval
+	})
+
+	for _, tc := range []struct {
+		name  string
+		empty bool
+	}{
+		{name: "request_error"},
+		{name: "empty_response", empty: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			rpcClient, _ := newContextBlockingBeaconRPC(ctx, &immediateEnvelopeSentinel{empty: tc.empty})
+			done := make(chan error, 1)
+			go func() {
+				_, err := RequestEnvelopesFrantically(ctx, rpcClient, [][32]byte{{1}})
+				done <- err
+			}()
+			select {
+			case err := <-done:
+				require.NoError(t, err)
+			case <-time.After(200 * time.Millisecond):
+				t.Fatal("batch expiration did not interrupt the retry delay")
+			}
+		})
+	}
+}
+
+func TestRequestEnvelopesFranticallyReservesTimeForRangeFallback(t *testing.T) {
+	previousExpiration := requestEnvelopeBatchExpiration
+	previousAttemptTimeout := requestEnvelopeAttemptTimeout
+	requestEnvelopeBatchExpiration = 200 * time.Millisecond
+	requestEnvelopeAttemptTimeout = 20 * time.Millisecond
+	t.Cleanup(func() {
+		requestEnvelopeBatchExpiration = previousExpiration
+		requestEnvelopeAttemptTimeout = previousAttemptTimeout
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	sentinel := &slowEnvelopeSentinel{byRange: make(chan struct{})}
+	rpcClient, _ := newContextBlockingBeaconRPC(ctx, sentinel)
+	block := &cltypes.SignedBeaconBlock{Block: &cltypes.BeaconBlock{Slot: 1}}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := RequestEnvelopesFrantically(ctx, rpcClient, [][32]byte{{1}}, block)
+		done <- err
+	}()
+
+	select {
+	case <-sentinel.byRange:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("slow by-root peer consumed the range fallback budget")
+	}
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+func TestRequestEnvelopesFranticallyBoundsRangeFallbackAttempt(t *testing.T) {
+	previousExpiration := requestEnvelopeBatchExpiration
+	previousAttemptTimeout := requestEnvelopeAttemptTimeout
+	previousRetryInterval := requestEnvelopeRetryInterval
+	requestEnvelopeBatchExpiration = 200 * time.Millisecond
+	requestEnvelopeAttemptTimeout = 20 * time.Millisecond
+	requestEnvelopeRetryInterval = time.Millisecond
+	t.Cleanup(func() {
+		requestEnvelopeBatchExpiration = previousExpiration
+		requestEnvelopeAttemptTimeout = previousAttemptTimeout
+		requestEnvelopeRetryInterval = previousRetryInterval
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	sentinel := &blockedRangeEnvelopeSentinel{
+		byRange:     make(chan struct{}),
+		laterByRoot: make(chan struct{}),
+	}
+	rpcClient, _ := newContextBlockingBeaconRPC(ctx, sentinel)
+	block := &cltypes.SignedBeaconBlock{Block: &cltypes.BeaconBlock{Slot: 1}}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := RequestEnvelopesFrantically(ctx, rpcClient, [][32]byte{{1}}, block)
+		done <- err
+	}()
+
+	select {
+	case <-sentinel.byRange:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("range fallback did not start")
+	}
+	select {
+	case <-sentinel.laterByRoot:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("blocked range fallback consumed the remaining by-root budget")
+	}
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
 
 func TestAcceptEnvelopeResponsesKeepsOnlyRequestedRoots(t *testing.T) {
 	requestedRoot := common.Hash{1}

--- a/cl/phase1/stages/cleanup_and_pruning.go
+++ b/cl/phase1/stages/cleanup_and_pruning.go
@@ -2,7 +2,9 @@ package stages
 
 import (
 	"context"
+	"math"
 
+	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/persistence/beacon_indicies"
 	"github.com/erigontech/erigon/common/log/v3"
 )
@@ -25,12 +27,38 @@ func cleanupAndPruning(ctx context.Context, logger log.Logger, cfg *Cfg, args Ar
 	if err := tx.Commit(); err != nil {
 		return err
 	}
-	cfg.blobStore.Prune()
-	columnKeepSlots := cfg.caplinConfig.ColumnKeepSlots
-	if columnKeepSlots == 0 {
-		// Default: MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS * SLOTS_PER_EPOCH
-		columnKeepSlots = cfg.beaconCfg.MinEpochsForDataColumnSidecarsRequests * cfg.beaconCfg.SlotsPerEpoch
+	currentSlot := cfg.ethClock.GetCurrentSlot()
+	pruneBlobDistance := uint64(128600)
+	if cfg.caplinConfig.ArchiveBlobs || cfg.caplinConfig.BlobPruningDisabled {
+		pruneBlobDistance = math.MaxUint64
 	}
-	cfg.peerDas.Prune(columnKeepSlots)
+	if err := cfg.blobStore.PruneBelow(floorFor(currentSlot, pruneBlobDistance)); err != nil {
+		logger.Warn("failed to prune blob sidecars", "err", err)
+	}
+	columnFloor := specColumnFloor(currentSlot, cfg.beaconCfg)
+	if keep := cfg.caplinConfig.ColumnKeepSlots; keep > 0 {
+		columnFloor = floorFor(currentSlot, keep)
+	}
+	if err := cfg.peerDas.PruneBelow(columnFloor); err != nil {
+		logger.Warn("failed to prune data column sidecars", "err", err)
+	}
 	return nil
+}
+
+func specColumnFloor(currentSlot uint64, beaconCfg *clparams.BeaconChainConfig) uint64 {
+	if beaconCfg.SlotsPerEpoch == 0 {
+		return 0
+	}
+	epoch := currentSlot / beaconCfg.SlotsPerEpoch
+	if epoch <= beaconCfg.MinEpochsForDataColumnSidecarsRequests {
+		return 0
+	}
+	return (epoch - beaconCfg.MinEpochsForDataColumnSidecarsRequests) * beaconCfg.SlotsPerEpoch
+}
+
+func floorFor(head, keep uint64) uint64 {
+	if head <= keep {
+		return 0
+	}
+	return head - keep
 }

--- a/cl/rpc/rpc.go
+++ b/cl/rpc/rpc.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/c2h5oh/datasize"
-	"github.com/golang/snappy"
 	"go.uber.org/zap/buffer"
 
 	"github.com/erigontech/erigon/cl/clparams"
@@ -40,11 +39,16 @@ import (
 	"github.com/erigontech/erigon/cl/utils/eth_clock"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/common/snappypool"
 	"github.com/erigontech/erigon/node/gointerfaces"
 	"github.com/erigontech/erigon/node/gointerfaces/sentinelproto"
 )
 
 const maxMessageLength = 18 * datasize.MB
+
+const reqRespFallbackTimeout = 30 * time.Second
+
+var errBlockForkSchemaSlotMismatch = errors.New("block schema fork disagrees with the fork implied by its slot")
 
 // blobSidecarRawBytes is the fixed SSZ size of a BlobSidecar (the blob dominates; fork-independent).
 func blobSidecarRawBytes() int { return (&cltypes.BlobSidecar{}).EncodingSizeSSZ() }
@@ -104,6 +108,10 @@ func (b *BeaconRpcP2P) sendBlocksRequest(ctx context.Context, topic string, reqD
 		if err := responseChunk.DecodeSSZ(data.raw, int(data.version)); err != nil {
 			return nil, pid, err
 		}
+		if !b.beaconConfig.ForkSchemaMatchesSlot(responseChunk.Block.Slot, responseChunk.Version()) {
+			b.BanPeer(pid)
+			return nil, pid, fmt.Errorf("%w: slot %d, decoded version %s", errBlockForkSchemaSlotMismatch, responseChunk.Block.Slot, responseChunk.Version())
+		}
 		responsePacket = append(responsePacket, responseChunk)
 	}
 
@@ -132,33 +140,8 @@ func (b *BeaconRpcP2P) SendColumnSidecarsByRootIdentifierReq(
 	ctx context.Context,
 	req *solid.ListSSZ[*cltypes.DataColumnsByRootIdentifier],
 ) ([]*cltypes.DataColumnSidecar, string, error) {
-	filteredReq, pid, _, err := b.columnDataPeers.pickPeerRoundRobin(ctx, req)
-	if err != nil {
-		return nil, pid, err
-	}
-
-	var buffer buffer.Buffer
-	if err := ssz_snappy.EncodeAndWrite(&buffer, filteredReq); err != nil {
-		return nil, "", err
-	}
-
-	data := buffer.Bytes()
-	maxResponseBytes := communication.MaxWireResponseBytes(b.columnSidecarRawBytes(), uint64(filteredReq.Len())*b.beaconConfig.NumberOfColumns)
-	responsePacket, pid, err := b.sendRequestWithPeer(ctx, communication.DataColumnSidecarsByRootProtocolV1, data, pid, maxResponseBytes)
-	if err != nil {
-		return nil, pid, err
-	}
-
-	ColumnSidecars := []*cltypes.DataColumnSidecar{}
-	for _, data := range responsePacket {
-		columnSidecar := &cltypes.DataColumnSidecar{}
-		if err := columnSidecar.DecodeSSZ(data.raw, int(data.version)); err != nil {
-			return nil, pid, err
-		}
-		ColumnSidecars = append(ColumnSidecars, columnSidecar)
-	}
-
-	return ColumnSidecars, pid, nil
+	response, pid, _, err := b.SendColumnSidecarsByRootIdentifierReqWithSnapshot(ctx, req)
+	return response, pid, err
 }
 
 func (b *BeaconRpcP2P) SendColumnSidecarsByRangeReqV1(
@@ -174,25 +157,85 @@ func (b *BeaconRpcP2P) SendColumnSidecarsByRangeReqV1(
 	for _, column := range columns {
 		req.Columns.Append(column)
 	}
-	var buffer buffer.Buffer
-	if err := ssz_snappy.EncodeAndWrite(&buffer, req); err != nil {
+	var buf buffer.Buffer
+	if err := ssz_snappy.EncodeAndWrite(&buf, req); err != nil {
 		return nil, "", err
 	}
 
-	responsePacket, pid, err := b.sendRequest(ctx, communication.DataColumnSidecarsByRangeProtocolV1, buffer.Bytes(), communication.MaxWireResponseBytes(b.columnSidecarRawBytes(), count*uint64(len(columns))))
+	responsePacket, pid, err := b.sendRequest(ctx, communication.DataColumnSidecarsByRangeProtocolV1, buf.Bytes(), communication.MaxWireResponseBytes(b.columnSidecarRawBytes(), count*uint64(len(columns))))
 	if err != nil {
 		return nil, pid, err
+	}
+
+	columnSidecars := make([]*cltypes.DataColumnSidecar, 0, len(responsePacket))
+	for _, data := range responsePacket {
+		columnSidecar := &cltypes.DataColumnSidecar{}
+		if err := columnSidecar.DecodeSSZ(data.raw, int(data.version)); err != nil {
+			return nil, pid, err
+		}
+		columnSidecars = append(columnSidecars, columnSidecar)
+	}
+	return columnSidecars, pid, nil
+}
+
+func (b *BeaconRpcP2P) SendColumnSidecarsByRootIdentifierReqWithSnapshot(
+	ctx context.Context,
+	req *solid.ListSSZ[*cltypes.DataColumnsByRootIdentifier],
+) ([]*cltypes.DataColumnSidecar, string, *solid.ListSSZ[*cltypes.DataColumnsByRootIdentifier], error) {
+	filteredReq, pid, _, err := b.columnDataPeers.pickPeerRoundRobin(ctx, req)
+	if err != nil {
+		return nil, pid, nil, err
+	}
+
+	var buffer buffer.Buffer
+	if err := ssz_snappy.EncodeAndWrite(&buffer, filteredReq); err != nil {
+		return nil, "", filteredReq, err
+	}
+	requestedColumnCount := uint64(0)
+	filteredReq.Range(func(_ int, id *cltypes.DataColumnsByRootIdentifier, _ int) bool {
+		requestedColumnCount += uint64(id.Columns.Length())
+		return true
+	})
+
+	data := buffer.Bytes()
+	maxResponseBytes := communication.MaxWireResponseBytes(b.columnSidecarRawBytes(), requestedColumnCount)
+	responsePacket, pid, err := b.sendRequestWithPeer(ctx, communication.DataColumnSidecarsByRootProtocolV1, data, pid, maxResponseBytes)
+	if err != nil {
+		return nil, pid, filteredReq, err
+	}
+	if uint64(len(responsePacket)) > requestedColumnCount {
+		b.BanPeer(pid)
+		return nil, pid, filteredReq, fmt.Errorf("response count %d exceeds requested column count %d", len(responsePacket), requestedColumnCount)
 	}
 
 	ColumnSidecars := []*cltypes.DataColumnSidecar{}
 	for _, data := range responsePacket {
 		columnSidecar := &cltypes.DataColumnSidecar{}
 		if err := columnSidecar.DecodeSSZ(data.raw, int(data.version)); err != nil {
-			return nil, pid, err
+			return nil, pid, filteredReq, err
+		}
+		var slot uint64
+		if data.version >= clparams.GloasVersion {
+			slot = columnSidecar.Slot
+		} else {
+			if columnSidecar.SignedBlockHeader == nil || columnSidecar.SignedBlockHeader.Header == nil {
+				b.BanPeer(pid)
+				return nil, pid, filteredReq, errors.New("column sidecar is missing its signed block header")
+			}
+			slot = columnSidecar.SignedBlockHeader.Header.Slot
+		}
+		expectedForkDigest, err := b.ethClock.ComputeForkDigest(slot / b.beaconConfig.SlotsPerEpoch)
+		if err != nil {
+			return nil, pid, filteredReq, err
+		}
+		if data.forkDigest != expectedForkDigest {
+			b.BanPeer(pid)
+			return nil, pid, filteredReq, fmt.Errorf("column sidecar fork digest %x disagrees with slot %d fork digest %x", data.forkDigest, slot, expectedForkDigest)
 		}
 		ColumnSidecars = append(ColumnSidecars, columnSidecar)
 	}
-	return ColumnSidecars, pid, nil
+
+	return ColumnSidecars, pid, filteredReq, nil
 }
 
 // SendExecutionPayloadEnvelopesByRangeReq retrieves execution payload envelopes by slot range.
@@ -359,20 +402,24 @@ func (b *BeaconRpcP2P) SetStatus(finalizedRoot common.Hash, finalizedEpoch uint6
 }
 
 func (b *BeaconRpcP2P) BanPeer(pid string) {
-	b.sentinel.BanPeer(b.ctx, &sentinelproto.Peer{Pid: pid})
+	if _, err := b.sentinel.BanPeer(b.ctx, &sentinelproto.Peer{Pid: pid}); err != nil {
+		log.Debug("failed to ban peer", "pid", pid, "err", err)
+	}
 }
 
-// responseData is a helper struct to store the version and the raw data of the response for each data container.
+// responseData stores decoded response metadata and raw container bytes.
 type responseData struct {
-	version clparams.StateVersion
-	raw     []byte
+	version    clparams.StateVersion
+	forkDigest common.Bytes4
+	raw        []byte
 }
 
 // parseResponseData parses the response data from a sentinel message and returns the parsed response data.
 func (b *BeaconRpcP2P) parseResponseData(message *sentinelproto.ResponseData) ([]responseData, string, error) {
 	if message.Error {
-		rd := snappy.NewReader(bytes.NewBuffer(message.Data))
+		rd := snappypool.Reader(bytes.NewReader(message.Data))
 		errBytes, _ := io.ReadAll(rd)
+		snappypool.PutReader(rd)
 		errMsg := string(errBytes)
 		log.Trace("received range req error", "err", errMsg, "raw", string(message.Data))
 		return nil, message.Peer.Pid, fmt.Errorf("peer error response: %s", errMsg)
@@ -380,6 +427,8 @@ func (b *BeaconRpcP2P) parseResponseData(message *sentinelproto.ResponseData) ([
 
 	responsePacket := []responseData{}
 	r := bytes.NewReader(message.Data)
+	sr := snappypool.Reader(r)
+	defer snappypool.PutReader(sr)
 	for {
 		forkDigest := make([]byte, 4)
 		if n, err := r.Read(forkDigest); err != nil {
@@ -403,7 +452,7 @@ func (b *BeaconRpcP2P) parseResponseData(message *sentinelproto.ResponseData) ([
 
 		// Read bytes using snappy into a new raw buffer of side encodedLn.
 		raw := make([]byte, encodedLn)
-		sr := snappy.NewReader(r)
+		sr.Reset(r)
 		bytesRead := 0
 		for bytesRead < int(encodedLn) {
 			n, err := sr.Read(raw[bytesRead:])
@@ -418,13 +467,15 @@ func (b *BeaconRpcP2P) parseResponseData(message *sentinelproto.ResponseData) ([
 			return nil, message.Peer.Pid, errors.New("null fork digest")
 		}
 
-		version, err := b.ethClock.StateVersionByForkDigest(utils.Uint32ToBytes4(respForkDigest))
+		responseForkDigest := utils.Uint32ToBytes4(respForkDigest)
+		version, err := b.ethClock.StateVersionByForkDigest(responseForkDigest)
 		if err != nil {
 			return nil, message.Peer.Pid, fmt.Errorf("unknown fork digest %x: %w", respForkDigest, err)
 		}
 		responsePacket = append(responsePacket, responseData{
-			version: version,
-			raw:     raw,
+			version:    version,
+			forkDigest: responseForkDigest,
+			raw:        raw,
 		})
 
 		// read next result byte
@@ -445,9 +496,10 @@ func (b *BeaconRpcP2P) sendRequest(
 	reqPayload []byte,
 	maxResponseBytes uint64,
 ) ([]responseData, string, error) {
-	ctx, cn := context.WithTimeout(ctx, time.Second*2)
-	defer cn()
-	message, err := b.sentinel.SendRequest(ctx, &sentinelproto.RequestData{
+	requestCtx, cancel := boundReqRespContext(ctx)
+	defer cancel()
+
+	message, err := b.sentinel.SendRequest(requestCtx, &sentinelproto.RequestData{
 		Data:             reqPayload,
 		Topic:            topic,
 		MaxResponseBytes: maxResponseBytes,
@@ -465,9 +517,10 @@ func (b *BeaconRpcP2P) sendRequestWithPeer(
 	peerId string,
 	maxResponseBytes uint64,
 ) ([]responseData, string, error) {
-	ctx, cn := context.WithTimeout(ctx, time.Second*2)
-	defer cn()
-	message, err := b.sentinel.SendPeerRequest(ctx, &sentinelproto.RequestDataWithPeer{
+	requestCtx, cancel := boundReqRespContext(ctx)
+	defer cancel()
+
+	message, err := b.sentinel.SendPeerRequest(requestCtx, &sentinelproto.RequestDataWithPeer{
 		Pid:              peerId,
 		Data:             reqPayload,
 		Topic:            topic,
@@ -477,4 +530,11 @@ func (b *BeaconRpcP2P) sendRequestWithPeer(
 		return nil, "", err
 	}
 	return b.parseResponseData(message)
+}
+
+func boundReqRespContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, reqRespFallbackTimeout)
 }

--- a/cl/rpc/rpc_test.go
+++ b/cl/rpc/rpc_test.go
@@ -1,13 +1,369 @@
 package rpc
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 
 	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/sentinel/communication"
+	"github.com/erigontech/erigon/cl/sentinel/communication/ssz_snappy"
+	"github.com/erigontech/erigon/cl/utils/eth_clock"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/node/gointerfaces/sentinelproto"
 )
+
+type blockResponseSentinel struct {
+	sentinelproto.SentinelClient
+	response   []byte
+	bannedPeer string
+}
+
+type contextRecordingSentinel struct {
+	sentinelproto.SentinelClient
+	deadline    time.Time
+	hasDeadline bool
+}
+
+type emptyColumnResponseSentinel struct {
+	sentinelproto.SentinelClient
+	calls            int
+	maxResponseBytes []uint64
+	response         []byte
+	bannedPeer       string
+}
+
+func (s *emptyColumnResponseSentinel) BanPeer(_ context.Context, peer *sentinelproto.Peer, _ ...grpc.CallOption) (*sentinelproto.EmptyMessage, error) {
+	s.bannedPeer = peer.Pid
+	return &sentinelproto.EmptyMessage{}, nil
+}
+
+func (s *emptyColumnResponseSentinel) SendPeerRequest(_ context.Context, req *sentinelproto.RequestDataWithPeer, _ ...grpc.CallOption) (*sentinelproto.ResponseData, error) {
+	s.calls++
+	s.maxResponseBytes = append(s.maxResponseBytes, req.MaxResponseBytes)
+	return &sentinelproto.ResponseData{Data: s.response, Peer: &sentinelproto.Peer{Pid: req.Pid}}, nil
+}
+
+type rawSSZBytes []byte
+
+func (r rawSSZBytes) EncodeSSZ(dst []byte) ([]byte, error) {
+	return append(dst, r...), nil
+}
+
+func (r rawSSZBytes) EncodingSizeSSZ() int {
+	return len(r)
+}
+
+func (s *contextRecordingSentinel) SendRequest(ctx context.Context, _ *sentinelproto.RequestData, _ ...grpc.CallOption) (*sentinelproto.ResponseData, error) {
+	s.deadline, s.hasDeadline = ctx.Deadline()
+	return nil, errors.New("request stopped")
+}
+
+func (s *contextRecordingSentinel) SendPeerRequest(ctx context.Context, _ *sentinelproto.RequestDataWithPeer, _ ...grpc.CallOption) (*sentinelproto.ResponseData, error) {
+	s.deadline, s.hasDeadline = ctx.Deadline()
+	return nil, errors.New("request stopped")
+}
+
+func TestReqRespRequestsPreserveCallerDeadline(t *testing.T) {
+	deadline := time.Now().Add(time.Hour)
+	ctx, cancel := context.WithDeadline(t.Context(), deadline)
+	defer cancel()
+
+	for _, withPeer := range []bool{false, true} {
+		sentinel := &contextRecordingSentinel{}
+		client := &BeaconRpcP2P{sentinel: sentinel}
+		if withPeer {
+			_, _, _ = client.sendRequestWithPeer(ctx, "topic", nil, "peer", 0)
+		} else {
+			_, _, _ = client.sendRequest(ctx, "topic", nil, 0)
+		}
+		require.True(t, sentinel.hasDeadline)
+		require.Equal(t, deadline, sentinel.deadline)
+	}
+}
+
+func TestReqRespRequestsBoundContextsWithoutDeadline(t *testing.T) {
+	for _, withPeer := range []bool{false, true} {
+		sentinel := &contextRecordingSentinel{}
+		client := &BeaconRpcP2P{sentinel: sentinel}
+		before := time.Now().Add(30 * time.Second)
+		if withPeer {
+			_, _, _ = client.sendRequestWithPeer(t.Context(), "topic", nil, "peer", 0)
+		} else {
+			_, _, _ = client.sendRequest(t.Context(), "topic", nil, 0)
+		}
+		after := time.Now().Add(30 * time.Second)
+		require.True(t, sentinel.hasDeadline)
+		require.False(t, sentinel.deadline.Before(before))
+		require.False(t, sentinel.deadline.After(after))
+	}
+}
+
+func TestColumnSidecarsRequestSnapshotReflectsPeerMaskAndPreservesWrapper(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	if clparams.GetBeaconConfig() == nil {
+		clparams.InitGlobalStaticConfig(&cfg, &clparams.CaplinConfig{})
+	}
+	sentinel := &emptyColumnResponseSentinel{}
+	client := &BeaconRpcP2P{
+		sentinel:     sentinel,
+		beaconConfig: &cfg,
+		columnDataPeers: &columnDataPeers{
+			beaconConfig: &cfg,
+			peersQueue: []peerData{{
+				pid:  "partial-peer",
+				mask: map[uint64]bool{0: true},
+			}},
+		},
+	}
+	root := common.HexToHash("0x1234")
+	request := solid.NewDynamicListSSZ[*cltypes.DataColumnsByRootIdentifier](1)
+	identifier := &cltypes.DataColumnsByRootIdentifier{
+		BlockRoot: root,
+		Columns:   solid.NewUint64ListSSZ(int(cfg.NumberOfColumns)),
+	}
+	identifier.Columns.Append(0)
+	identifier.Columns.Append(1)
+	request.Append(identifier)
+
+	sidecars, pid, snapshot, err := client.SendColumnSidecarsByRootIdentifierReqWithSnapshot(t.Context(), request)
+	require.NoError(t, err)
+	require.Empty(t, sidecars)
+	require.Equal(t, "partial-peer", pid)
+	require.Equal(t, 1, snapshot.Len())
+	require.Equal(t, []uint64{communication.MaxWireResponseBytes(client.columnSidecarRawBytes(), 1)}, sentinel.maxResponseBytes)
+	snapshot.Range(func(_ int, item *cltypes.DataColumnsByRootIdentifier, _ int) bool {
+		require.Equal(t, root, common.Hash(item.BlockRoot))
+		require.Equal(t, 1, item.Columns.Length())
+		require.Equal(t, uint64(0), item.Columns.Get(0))
+		return true
+	})
+
+	sidecars, pid, err = client.SendColumnSidecarsByRootIdentifierReq(t.Context(), request)
+	require.NoError(t, err)
+	require.Empty(t, sidecars)
+	require.Equal(t, "partial-peer", pid)
+	require.Equal(t, 2, sentinel.calls)
+}
+
+func TestColumnSidecarsRequestRejectsOverCardinalityBeforeSidecarDecode(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.InitializeForkSchedule()
+	if clparams.GetBeaconConfig() == nil {
+		clparams.InitGlobalStaticConfig(&cfg, &clparams.CaplinConfig{})
+	}
+	clock := eth_clock.NewEthereumClock(0, common.Hash{}, &cfg)
+	digest, err := clock.ComputeForkDigest(cfg.FuluForkEpoch)
+	require.NoError(t, err)
+	valid := cltypes.NewDataColumnSidecarWithVersion(clparams.FuluVersion)
+	var response bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&response, valid, digest[:]...))
+	require.NoError(t, response.WriteByte(0))
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&response, rawSSZBytes{0xff}, digest[:]...))
+
+	sentinel := &emptyColumnResponseSentinel{response: response.Bytes()}
+	client := &BeaconRpcP2P{
+		sentinel:     sentinel,
+		beaconConfig: &cfg,
+		ethClock:     clock,
+		columnDataPeers: &columnDataPeers{
+			beaconConfig: &cfg,
+			peersQueue: []peerData{{
+				pid:  "cap-ignoring-peer",
+				mask: map[uint64]bool{0: true},
+			}},
+		},
+	}
+	request := solid.NewDynamicListSSZ[*cltypes.DataColumnsByRootIdentifier](1)
+	identifier := &cltypes.DataColumnsByRootIdentifier{
+		BlockRoot: common.HexToHash("0x1234"),
+		Columns:   solid.NewUint64ListSSZ(int(cfg.NumberOfColumns)),
+	}
+	identifier.Columns.Append(0)
+	request.Append(identifier)
+
+	sidecars, pid, snapshot, err := client.SendColumnSidecarsByRootIdentifierReqWithSnapshot(t.Context(), request)
+	require.ErrorContains(t, err, "response count 2 exceeds requested column count 1")
+	require.Nil(t, sidecars)
+	require.Equal(t, "cap-ignoring-peer", pid)
+	require.Equal(t, 1, snapshot.Len())
+	require.Equal(t, "cap-ignoring-peer", sentinel.bannedPeer)
+}
+
+func TestColumnSidecarsRequestAcceptsExactGloasForkDigest(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.AltairForkEpoch = 0
+	cfg.BellatrixForkEpoch = 0
+	cfg.CapellaForkEpoch = 0
+	cfg.DenebForkEpoch = 0
+	cfg.ElectraForkEpoch = 0
+	cfg.FuluForkEpoch = 1
+	cfg.GloasForkEpoch = 2
+	cfg.InitializeForkSchedule()
+	if clparams.GetBeaconConfig() == nil {
+		clparams.InitGlobalStaticConfig(&cfg, &clparams.CaplinConfig{})
+	}
+	clock := eth_clock.NewEthereumClock(0, common.Hash{}, &cfg)
+	digest, err := clock.ComputeForkDigest(cfg.GloasForkEpoch)
+	require.NoError(t, err)
+	sidecar := cltypes.NewDataColumnSidecarWithVersion(clparams.GloasVersion)
+	sidecar.Slot = cfg.GloasForkEpoch * cfg.SlotsPerEpoch
+	sidecar.BeaconBlockRoot = common.HexToHash("0x1234")
+	var response bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&response, sidecar, digest[:]...))
+
+	sentinel := &emptyColumnResponseSentinel{response: response.Bytes()}
+	client := &BeaconRpcP2P{
+		sentinel:     sentinel,
+		beaconConfig: &cfg,
+		ethClock:     clock,
+		columnDataPeers: &columnDataPeers{
+			beaconConfig: &cfg,
+			peersQueue: []peerData{{
+				pid:  "gloas-peer",
+				mask: map[uint64]bool{0: true},
+			}},
+		},
+	}
+	request := solid.NewDynamicListSSZ[*cltypes.DataColumnsByRootIdentifier](1)
+	identifier := &cltypes.DataColumnsByRootIdentifier{
+		BlockRoot: sidecar.BeaconBlockRoot,
+		Columns:   solid.NewUint64ListSSZ(int(cfg.NumberOfColumns)),
+	}
+	identifier.Columns.Append(0)
+	request.Append(identifier)
+
+	sidecars, pid, snapshot, err := client.SendColumnSidecarsByRootIdentifierReqWithSnapshot(t.Context(), request)
+	require.NoError(t, err)
+	require.Equal(t, "gloas-peer", pid)
+	require.Equal(t, 1, snapshot.Len())
+	require.Len(t, sidecars, 1)
+	require.Equal(t, clparams.GloasVersion, sidecars[0].Version())
+	require.Equal(t, sidecar.Slot, sidecars[0].Slot)
+	require.Empty(t, sentinel.bannedPeer)
+}
+
+func TestColumnSidecarsRequestRejectsUnknownForkDigest(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.InitializeForkSchedule()
+	if clparams.GetBeaconConfig() == nil {
+		clparams.InitGlobalStaticConfig(&cfg, &clparams.CaplinConfig{})
+	}
+	clock := eth_clock.NewEthereumClock(0, common.Hash{}, &cfg)
+	unknownDigest := common.Bytes4{0xde, 0xad, 0xbe, 0xef}
+	_, err := clock.StateVersionByForkDigest(unknownDigest)
+	require.Error(t, err)
+	var response bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&response, rawSSZBytes{0}, unknownDigest[:]...))
+
+	sentinel := &emptyColumnResponseSentinel{response: response.Bytes()}
+	client := &BeaconRpcP2P{
+		sentinel:     sentinel,
+		beaconConfig: &cfg,
+		ethClock:     clock,
+		columnDataPeers: &columnDataPeers{
+			beaconConfig: &cfg,
+			peersQueue: []peerData{{
+				pid:  "unknown-digest-peer",
+				mask: map[uint64]bool{0: true},
+			}},
+		},
+	}
+	request := solid.NewDynamicListSSZ[*cltypes.DataColumnsByRootIdentifier](1)
+	identifier := &cltypes.DataColumnsByRootIdentifier{
+		BlockRoot: common.HexToHash("0x1234"),
+		Columns:   solid.NewUint64ListSSZ(int(cfg.NumberOfColumns)),
+	}
+	identifier.Columns.Append(0)
+	request.Append(identifier)
+
+	sidecars, pid, snapshot, err := client.SendColumnSidecarsByRootIdentifierReqWithSnapshot(t.Context(), request)
+	require.ErrorContains(t, err, "unknown fork digest deadbeef")
+	require.Nil(t, sidecars)
+	require.Equal(t, "unknown-digest-peer", pid)
+	require.Equal(t, 1, snapshot.Len())
+}
+
+func TestColumnSidecarsSparseMultiRootCapPreservesFilteredOrderAndWrapper(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	if clparams.GetBeaconConfig() == nil {
+		clparams.InitGlobalStaticConfig(&cfg, &clparams.CaplinConfig{})
+	}
+	sentinel := &emptyColumnResponseSentinel{}
+	client := &BeaconRpcP2P{
+		sentinel:     sentinel,
+		beaconConfig: &cfg,
+		columnDataPeers: &columnDataPeers{
+			beaconConfig: &cfg,
+			peersQueue: []peerData{{
+				pid:  "sparse-peer",
+				mask: map[uint64]bool{1: true, 7: true},
+			}},
+		},
+	}
+	request := solid.NewDynamicListSSZ[*cltypes.DataColumnsByRootIdentifier](2)
+	rootA := common.HexToHash("0xa")
+	rootB := common.HexToHash("0xb")
+	for _, item := range []struct {
+		root    common.Hash
+		columns []uint64
+	}{
+		{root: rootB, columns: []uint64{9, 7}},
+		{root: rootA, columns: []uint64{7, 1, 3}},
+	} {
+		identifier := &cltypes.DataColumnsByRootIdentifier{
+			BlockRoot: item.root,
+			Columns:   solid.NewUint64ListSSZ(int(cfg.NumberOfColumns)),
+		}
+		for _, column := range item.columns {
+			identifier.Columns.Append(column)
+		}
+		request.Append(identifier)
+	}
+
+	_, _, snapshot, err := client.SendColumnSidecarsByRootIdentifierReqWithSnapshot(t.Context(), request)
+	require.NoError(t, err)
+	require.Equal(t, 2, snapshot.Len())
+	require.Equal(t, rootB, common.Hash(snapshot.Get(0).BlockRoot))
+	require.Equal(t, rootA, common.Hash(snapshot.Get(1).BlockRoot))
+	filtered := make(map[common.Hash][]uint64)
+	snapshot.Range(func(_ int, item *cltypes.DataColumnsByRootIdentifier, _ int) bool {
+		columns := make([]uint64, item.Columns.Length())
+		item.Columns.Range(func(i int, column uint64, _ int) bool {
+			columns[i] = column
+			return true
+		})
+		filtered[item.BlockRoot] = columns
+		return true
+	})
+	require.Equal(t, []uint64{7, 1}, filtered[rootA])
+	require.Equal(t, []uint64{7}, filtered[rootB])
+	wantCap := communication.MaxWireResponseBytes(client.columnSidecarRawBytes(), 3)
+	require.Equal(t, []uint64{wantCap}, sentinel.maxResponseBytes)
+
+	_, _, err = client.SendColumnSidecarsByRootIdentifierReq(t.Context(), request)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{wantCap, wantCap}, sentinel.maxResponseBytes)
+}
+
+func (s *blockResponseSentinel) SendRequest(context.Context, *sentinelproto.RequestData, ...grpc.CallOption) (*sentinelproto.ResponseData, error) {
+	return &sentinelproto.ResponseData{
+		Data: s.response,
+		Peer: &sentinelproto.Peer{Pid: "malicious-peer"},
+	}, nil
+}
+
+func (s *blockResponseSentinel) BanPeer(_ context.Context, peer *sentinelproto.Peer, _ ...grpc.CallOption) (*sentinelproto.EmptyMessage, error) {
+	s.bannedPeer = peer.Pid
+	return &sentinelproto.EmptyMessage{}, nil
+}
 
 func TestExecutionPayloadEnvelopeRequestsRejectOverLimit(t *testing.T) {
 	cfg := clparams.MainnetBeaconConfig
@@ -34,4 +390,34 @@ func TestMaxRequestPayloadsFallback(t *testing.T) {
 
 	_, _, err = rpc.SendExecutionPayloadEnvelopesByRootReq(context.Background(), make([][32]byte, 18))
 	require.ErrorContains(t, err, "17")
+}
+
+func TestSendBeaconBlocksByRangeReqRejectsForkSchemaSlotMismatch(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.InitializeForkSchedule()
+	clock := eth_clock.NewEthereumClock(0, common.Hash{}, &cfg)
+
+	gloasDigest, err := clock.ComputeForkDigest(cfg.GloasForkEpoch)
+	require.NoError(t, err)
+
+	slot := (cfg.FuluForkEpoch + 1) * cfg.SlotsPerEpoch
+	block := cltypes.NewSignedBeaconBlock(&cfg, clparams.GloasVersion)
+	block.Block.Slot = slot
+
+	var response bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&response, block, gloasDigest[:]...))
+
+	sentinel := &blockResponseSentinel{response: response.Bytes()}
+	client := &BeaconRpcP2P{
+		ctx:          context.Background(),
+		sentinel:     sentinel,
+		beaconConfig: &cfg,
+		ethClock:     clock,
+	}
+
+	blocks, pid, err := client.SendBeaconBlocksByRangeReq(context.Background(), slot, 1)
+	require.ErrorIs(t, err, errBlockForkSchemaSlotMismatch)
+	require.Nil(t, blocks)
+	require.Equal(t, "malicious-peer", pid)
+	require.Equal(t, "malicious-peer", sentinel.bannedPeer)
 }

--- a/cl/sentinel/handlers/blobs_test.go
+++ b/cl/sentinel/handlers/blobs_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
-	"math"
 	"testing"
 
 	"github.com/golang/snappy"
@@ -97,7 +96,7 @@ func TestBlobsByRangeHandler(t *testing.T) {
 	h := expBlocks[0].SignedBeaconBlockHeader()
 	sidecars := getTestBlobSidecars(h)
 	_, beaconCfg := clparams.GetConfigsByNetwork(1)
-	blobStorage := blob_storage.NewBlobStore(blobDb, afero.NewMemMapFs(), math.MaxUint64, beaconCfg, nil)
+	blobStorage := blob_storage.NewBlobStore(blobDb, afero.NewMemMapFs())
 	r, _ := h.Header.HashSSZ()
 	require.NoError(t, blobStorage.WriteBlobSidecars(ctx, r, sidecars))
 
@@ -221,7 +220,7 @@ func TestBlobsByIdentifiersHandler(t *testing.T) {
 	h := expBlocks[0].SignedBeaconBlockHeader()
 	sidecars := getTestBlobSidecars(h)
 	_, beaconCfg := clparams.GetConfigsByNetwork(1)
-	blobStorage := blob_storage.NewBlobStore(blobDb, afero.NewMemMapFs(), math.MaxUint64, beaconCfg, ethClock)
+	blobStorage := blob_storage.NewBlobStore(blobDb, afero.NewMemMapFs())
 	r, _ := h.Header.HashSSZ()
 	require.NoError(t, blobStorage.WriteBlobSidecars(ctx, r, sidecars))
 

--- a/cl/sentinel/handlers/data_column_sidecar_test.go
+++ b/cl/sentinel/handlers/data_column_sidecar_test.go
@@ -469,7 +469,7 @@ func setupDataColumnSidecarHandlerTestWithStore(t *testing.T, fuluForkEpoch uint
 	})
 	beaconCfg := *mainnetCfg
 	beaconCfg.FuluForkEpoch = fuluForkEpoch
-	columnStorage := blob_storage.NewDataColumnStore(afero.NewMemMapFs(), 1000, &beaconCfg, ethClock, beaconevents.NewEventEmitter())
+	columnStorage := blob_storage.NewDataColumnStore(afero.NewMemMapFs(), &beaconCfg, beaconevents.NewEventEmitter())
 
 	c := NewConsensusHandlers(
 		ctx,

--- a/cl/sentinel/httpreqresp/server.go
+++ b/cl/sentinel/httpreqresp/server.go
@@ -19,6 +19,7 @@ package httpreqresp
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -265,10 +266,18 @@ func NewRequestHandler(host host.Host) http.HandlerFunc {
 			http.Error(w, "can't Connect to Peer: "+err.Error(), http.StatusBadRequest)
 			return
 		}
+		cancelled := make(chan struct{})
+		stopCancellation := context.AfterFunc(r.Context(), func() {
+			defer close(cancelled)
+			_ = stream.Reset()
+		})
 		// The successful path hands the stream off to the response body, which closes it; on every
 		// other path this deferred close releases it.
 		streamTransferred := false
 		defer func() {
+			if !stopCancellation() {
+				<-cancelled
+			}
 			if !streamTransferred {
 				stream.Close()
 			}

--- a/cl/sentinel/httpreqresp/server_test.go
+++ b/cl/sentinel/httpreqresp/server_test.go
@@ -188,6 +188,58 @@ func TestDoClosesStreamingBodyOnContextCancel(t *testing.T) {
 	}
 }
 
+func TestRequestContextCancelClosesEstablishedStream(t *testing.T) {
+	const topic = protocol.ID("/erigon/test/cancel/1")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	victim, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	require.NoError(t, err)
+	t.Cleanup(func() { victim.Close() })
+	peerHost, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	require.NoError(t, err)
+	t.Cleanup(func() { peerHost.Close() })
+
+	established := make(chan struct{})
+	releasePeer := make(chan struct{})
+	peerHost.SetStreamHandler(topic, func(s network.Stream) {
+		close(established)
+		<-releasePeer
+		s.Close()
+	})
+	t.Cleanup(func() { close(releasePeer) })
+	require.NoError(t, victim.Connect(ctx, peer.AddrInfo{ID: peerHost.ID(), Addrs: peerHost.Addrs()}))
+
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://service.internal/", http.NoBody)
+	require.NoError(t, err)
+	req.Header.Set(PeerIdHeader, peerHost.ID().String())
+	req.Header.Set(TopicHeader, string(topic))
+	errCh := make(chan error, 1)
+	go func() {
+		resp, doErr := Do(NewRequestHandler(victim), req)
+		if resp != nil {
+			resp.Body.Close()
+		}
+		errCh <- doErr
+	}()
+
+	select {
+	case <-established:
+	case <-time.After(5 * time.Second):
+		t.Fatal("libp2p stream was not established")
+	}
+	cancel()
+	require.ErrorIs(t, <-errCh, context.Canceled)
+	require.Eventually(t, func() bool {
+		for _, conn := range victim.Network().ConnsToPeer(peerHost.ID()) {
+			if len(conn.GetStreams()) != 0 {
+				return false
+			}
+		}
+		return true
+	}, time.Second, 10*time.Millisecond, "request cancellation left the underlying libp2p stream active")
+}
+
 type signalCloser struct{ closed chan struct{} }
 
 func (s *signalCloser) Read([]byte) (int, error) { return 0, io.EOF }

--- a/cl/sentinel/service/request_peer_test.go
+++ b/cl/sentinel/service/request_peer_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/sentinel"
+	"github.com/erigontech/erigon/cl/sentinel/httpreqresp"
+	"github.com/erigontech/erigon/node/gointerfaces/sentinelproto"
+)
+
+func TestPeerRequestUsesCallerContext(t *testing.T) {
+	requestCancelled := make(chan struct{})
+	server := &SentinelServer{peerRequestBackend: peerRequestBackendStub{
+		handler: http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {
+			<-request.Context().Done()
+			close(requestCancelled)
+		}),
+	}}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		_, err := server.requestPeer(ctx, peer.ID("peer"), &sentinelproto.RequestData{Data: []byte("request")})
+		done <- err
+	}()
+
+	cancel()
+	require.ErrorIs(t, receivePeerRequestTestValue(t, done), context.Canceled)
+	receivePeerRequestTestValue(t, requestCancelled)
+}
+
+func TestPeerProtocolErrorBodyClosesOnCancellation(t *testing.T) {
+	body := &blockingResponseBody{closed: make(chan struct{})}
+	ctx, cancel := context.WithCancel(t.Context())
+	stopClose := closeBodyOnCancel(ctx, body)
+	defer stopClose()
+	done := make(chan error, 1)
+	go func() {
+		_, err := httpreqresp.ResponseCodeServerError.ErrorMessage(&http.Response{Body: body})
+		done <- err
+	}()
+
+	cancel()
+	require.Error(t, receivePeerRequestTestValue(t, done))
+	receivePeerRequestTestValue(t, body.closed)
+}
+
+type blockingResponseBody struct {
+	closed chan struct{}
+}
+
+func (b *blockingResponseBody) Read([]byte) (int, error) {
+	<-b.closed
+	return 0, errors.New("response body closed")
+}
+
+func (b *blockingResponseBody) Close() error {
+	select {
+	case <-b.closed:
+	default:
+		close(b.closed)
+	}
+	return nil
+}
+
+var _ io.ReadCloser = (*blockingResponseBody)(nil)
+
+type peerRequestBackendStub struct {
+	handler http.Handler
+}
+
+func (p peerRequestBackendStub) GetPeersCount() (int, int, int) { return 0, 0, 0 }
+func (p peerRequestBackendStub) Config() *sentinel.SentinelConfig {
+	config := &sentinel.SentinelConfig{}
+	config.MaxPeerCount = 1
+	return config
+}
+func (p peerRequestBackendStub) ReqRespHandler() http.Handler { return p.handler }
+
+func receivePeerRequestTestValue[T any](t *testing.T, values <-chan T) T {
+	t.Helper()
+	select {
+	case value := <-values:
+		return value
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for peer request")
+		var zero T
+		return zero
+	}
+}

--- a/cl/sentinel/service/service.go
+++ b/cl/sentinel/service/service.go
@@ -44,21 +44,45 @@ var _ sentinelproto.SentinelServer = (*SentinelServer)(nil)
 type SentinelServer struct {
 	sentinelproto.UnimplementedSentinelServer
 
-	ctx      context.Context
-	sentinel *sentinel.Sentinel
+	ctx                context.Context
+	sentinel           *sentinel.Sentinel
+	peerRequestBackend peerRequestBackend
 
 	logger log.Logger
 }
 
-type HTTPError = httpreqresp.HTTPError
-type PeerResponseError = httpreqresp.PeerResponseError
-type ResponseCode = httpreqresp.ResponseCode
+type peerRequestBackend interface {
+	GetPeersCount() (active int, connected int, disconnected int)
+	Config() *sentinel.SentinelConfig
+	ReqRespHandler() http.Handler
+}
+
+type (
+	HTTPError         = httpreqresp.HTTPError
+	PeerResponseError = httpreqresp.PeerResponseError
+	ResponseCode      = httpreqresp.ResponseCode
+)
 
 func NewSentinelServer(ctx context.Context, sentinel *sentinel.Sentinel, logger log.Logger) *SentinelServer {
 	return &SentinelServer{
-		sentinel: sentinel,
-		ctx:      ctx,
-		logger:   logger,
+		sentinel:           sentinel,
+		peerRequestBackend: sentinel,
+		ctx:                ctx,
+		logger:             logger,
+	}
+}
+
+// dropPeer disconnects pid and forgets it, so the same failing peer is not
+// picked again for the next request.
+func (s *SentinelServer) dropPeer(pid peer.ID) {
+	s.sentinel.Peers().RemovePeer(pid)
+	s.sentinel.Host().Peerstore().RemovePeer(pid)
+	s.closePeer(pid)
+}
+
+func (s *SentinelServer) closePeer(pid peer.ID) {
+	if err := s.sentinel.Host().Network().ClosePeer(pid); err != nil {
+		s.logger.Trace("[sentinel] failed to close peer", "peer", pid, "err", err)
 	}
 }
 
@@ -74,7 +98,7 @@ func (s *SentinelServer) BanPeer(_ context.Context, p *sentinelproto.Peer) (*sen
 	}
 	s.sentinel.Peers().SetBanStatus(pid, true)
 	s.sentinel.Host().Peerstore().RemovePeer(pid)
-	s.sentinel.Host().Network().ClosePeer(pid)
+	s.closePeer(pid)
 	return &sentinelproto.EmptyMessage{}, nil
 }
 
@@ -88,30 +112,37 @@ func (s *SentinelServer) SubscribeGossip(data *sentinelproto.SubscriptionData, s
 
 func (s *SentinelServer) requestPeer(ctx context.Context, pid peer.ID, req *sentinelproto.RequestData) (*sentinelproto.ResponseData, error) {
 	// prepare the http request
-	httpReq, err := http.NewRequest("GET", "http://service.internal/", bytes.NewBuffer(req.Data))
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", "http://service.internal/", bytes.NewBuffer(req.Data))
 	if err != nil {
 		return nil, err
 	}
 
-	activePeers, _, _ := s.sentinel.GetPeersCount()
+	activePeers, _, _ := s.peerRequestBackend.GetPeersCount()
 
-	shouldBanOnFail := activePeers >= int(s.sentinel.Config().MaxPeerCount)
+	shouldBanOnFail := activePeers >= int(s.peerRequestBackend.Config().MaxPeerCount)
 	// set the peer and topic we are requesting
 	httpReq.Header.Set("REQRESP-PEER-ID", pid.String())
 	httpReq.Header.Set("REQRESP-TOPIC", req.Topic)
 	if req.MaxResponseBytes > 0 {
 		httpReq.Header.Set(httpreqresp.MaxResponseBytesHeader, strconv.FormatUint(req.MaxResponseBytes, 10))
 	}
-	// for now this can't actually error. in the future, it can due to a network error
-	resp, err := httpreqresp.Do(s.sentinel.ReqRespHandler(), httpReq)
+	resp, err := httpreqresp.Do(s.peerRequestBackend.ReqRespHandler(), httpReq)
 	if err != nil {
 		// we remove, but dont ban the peer if we fail. this is because its probably not their fault, but maybe it is.
 		return nil, err
 	}
+	stopBodyClose := closeBodyOnCancel(ctx, resp.Body)
+	defer stopBodyClose()
 	defer resp.Body.Close()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	// some standard http error code parsing
 	if resp.StatusCode < 200 || resp.StatusCode > 399 {
 		errBody, _ := io.ReadAll(resp.Body)
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		errorMessage := &HTTPError{
 			StatusCode: resp.StatusCode,
 			Body:       string(errBody),
@@ -121,15 +152,16 @@ func (s *SentinelServer) requestPeer(ctx context.Context, pid peer.ID, req *sent
 		//	return nil, errorMessage
 		//}
 		if shouldBanOnFail {
-			s.sentinel.Peers().RemovePeer(pid)
-			s.sentinel.Host().Peerstore().RemovePeer(pid)
-			s.sentinel.Host().Network().ClosePeer(pid)
+			s.dropPeer(pid)
 		}
 		return nil, errorMessage
 	}
 	// we should never get an invalid response to this. our responder should always set it on non-error response
 	code, err := strconv.Atoi(resp.Header.Get("REQRESP-RESPONSE-CODE"))
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
 		// TODO: think about how to properly handle this. should we? (or should we just assume no response is success?)
 		return nil, err
 	}
@@ -138,17 +170,16 @@ func (s *SentinelServer) requestPeer(ctx context.Context, pid peer.ID, req *sent
 	if !responseCode.Success() {
 		errorMessage, err := responseCode.ErrorMessage(resp)
 		if err != nil {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
 			if shouldBanOnFail {
-				s.sentinel.Peers().RemovePeer(pid)
-				s.sentinel.Host().Peerstore().RemovePeer(pid)
-				s.sentinel.Host().Network().ClosePeer(pid)
+				s.dropPeer(pid)
 			}
 			return nil, err
 		}
 		if shouldBanOnFail && responseCode != httpreqresp.ResponseCodeResourceUnavailable {
-			s.sentinel.Peers().RemovePeer(pid)
-			s.sentinel.Host().Peerstore().RemovePeer(pid)
-			s.sentinel.Host().Network().ClosePeer(pid)
+			s.dropPeer(pid)
 		}
 		return nil, &PeerResponseError{
 			Code:    responseCode,
@@ -159,12 +190,13 @@ func (s *SentinelServer) requestPeer(ctx context.Context, pid peer.ID, req *sent
 	// read the body from the response
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 		// An over-cap flood surfaces here as ErrResponseTooLarge rather than a non-2xx status, so
 		// drop the peer as the status path above would.
 		if errors.Is(err, httpreqresp.ErrResponseTooLarge) && shouldBanOnFail {
-			s.sentinel.Peers().RemovePeer(pid)
-			s.sentinel.Host().Peerstore().RemovePeer(pid)
-			s.sentinel.Host().Network().ClosePeer(pid)
+			s.dropPeer(pid)
 		}
 		return nil, err
 	}
@@ -176,7 +208,10 @@ func (s *SentinelServer) requestPeer(ctx context.Context, pid peer.ID, req *sent
 		},
 	}
 	return ans, nil
+}
 
+func closeBodyOnCancel(ctx context.Context, body io.Closer) func() bool {
+	return context.AfterFunc(ctx, func() { _ = body.Close() })
 }
 
 func (s *SentinelServer) SendRequest(ctx context.Context, req *sentinelproto.RequestData) (*sentinelproto.ResponseData, error) {
@@ -193,9 +228,7 @@ func (s *SentinelServer) SendRequest(ctx context.Context, req *sentinelproto.Req
 	resp, err := s.requestPeer(ctx, pid, req)
 	if err != nil {
 		if strings.Contains(err.Error(), "protocols not supported") {
-			s.sentinel.Peers().RemovePeer(pid)
-			s.sentinel.Host().Peerstore().RemovePeer(pid)
-			s.sentinel.Host().Network().ClosePeer(pid)
+			s.dropPeer(pid)
 			s.sentinel.Peers().SetBanStatus(pid, true)
 		}
 		s.logger.Trace("[sentinel] peer gave us bad data", "peer", pid, "err", err, "topic", req.Topic)
@@ -217,9 +250,7 @@ func (s *SentinelServer) SendPeerRequest(ctx context.Context, reqWithPeer *senti
 	resp, err := s.requestPeer(ctx, pid, req)
 	if err != nil {
 		if strings.Contains(err.Error(), "protocols not supported") {
-			s.sentinel.Peers().RemovePeer(pid)
-			s.sentinel.Host().Peerstore().RemovePeer(pid)
-			s.sentinel.Host().Network().ClosePeer(pid)
+			s.dropPeer(pid)
 			s.sentinel.Peers().SetBanStatus(pid, true)
 		}
 		s.logger.Trace("[sentinel] peer gave us bad data", "peer", pid, "err", err, "topic", req.Topic)
@@ -242,7 +273,6 @@ func (s *SentinelServer) Identity(ctx context.Context, in *sentinelproto.EmptyMe
 			Syncnets: fmt.Sprintf("%x", *metadata.Syncnets),
 		},
 	}, nil
-
 }
 
 func (s *SentinelServer) SetStatus(_ context.Context, req *sentinelproto.Status) (*sentinelproto.EmptyMessage, error) {

--- a/cl/spectest/consensus_tests/fork_choice.go
+++ b/cl/spectest/consensus_tests/fork_choice.go
@@ -305,7 +305,7 @@ func (b *ForkChoice) Run(t *testing.T, root fs.FS, c spectest.TestCase) (err err
 	blobStorage := blob_storage.NewBlobStore(memdb.New(t, "/tmp", dbcfg.ChainDB), afero.NewMemMapFs())
 	columnStorage := blob_storage.NewDataColumnStore(afero.NewMemMapFs(), &clparams.MainnetBeaconConfig, emitters)
 	peerDasState := peerdasstate.NewPeerDasState(&clparams.MainnetBeaconConfig, &clparams.NetworkConfig{})
-	peerDas := das.NewPeerDas(ctx, nil, &clparams.MainnetBeaconConfig, &clparams.CaplinConfig{}, columnStorage, blobStorage, nil, enode.ID{}, ethClock, peerDasState, nil, nil, nil)
+	peerDas := das.NewPeerDas(nil, &clparams.MainnetBeaconConfig, &clparams.CaplinConfig{}, columnStorage, blobStorage, nil, enode.ID{}, ethClock, peerDasState, nil, nil, nil)
 	localValidators := validator_params.NewValidatorParams()
 
 	forkStore, err := forkchoice.NewForkChoiceStore(

--- a/cl/spectest/consensus_tests/fork_choice.go
+++ b/cl/spectest/consensus_tests/fork_choice.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"math"
 	"math/big"
 	"testing"
 
@@ -303,8 +302,8 @@ func (b *ForkChoice) Run(t *testing.T, root fs.FS, c spectest.TestCase) (err err
 	emitters := beaconevents.NewEventEmitter()
 	_, beaconConfig := clparams.GetConfigsByNetwork(chainspec.MainnetChainID)
 	ethClock := eth_clock.NewEthereumClock(genesisState.GenesisTime(), genesisState.GenesisValidatorsRoot(), beaconConfig)
-	blobStorage := blob_storage.NewBlobStore(memdb.New(t, "/tmp", dbcfg.ChainDB), afero.NewMemMapFs(), math.MaxUint64, &clparams.MainnetBeaconConfig, ethClock)
-	columnStorage := blob_storage.NewDataColumnStore(afero.NewMemMapFs(), 1000, &clparams.MainnetBeaconConfig, ethClock, emitters)
+	blobStorage := blob_storage.NewBlobStore(memdb.New(t, "/tmp", dbcfg.ChainDB), afero.NewMemMapFs())
+	columnStorage := blob_storage.NewDataColumnStore(afero.NewMemMapFs(), &clparams.MainnetBeaconConfig, emitters)
 	peerDasState := peerdasstate.NewPeerDasState(&clparams.MainnetBeaconConfig, &clparams.NetworkConfig{})
 	peerDas := das.NewPeerDas(ctx, nil, &clparams.MainnetBeaconConfig, &clparams.CaplinConfig{}, columnStorage, blobStorage, nil, enode.ID{}, ethClock, peerDasState, nil, nil, nil)
 	localValidators := validator_params.NewValidatorParams()

--- a/cmd/caplin/caplin1/run.go
+++ b/cmd/caplin/caplin1/run.go
@@ -467,7 +467,7 @@ func RunCaplinService(ctx context.Context, engine execution_client.ExecutionEngi
 	peerDasState.SetLocalNodeID(localNode)
 	beaconRpc := rpc.NewBeaconRpcP2P(ctx, sentinel, beaconConfig, ethClock, state)
 	gossipManager.SetPeerBanner(beaconRpc)
-	peerDas := das.NewPeerDas(ctx, beaconRpc, beaconConfig, &config, columnStorage, blobStorage, sentinel, localNode.ID(), ethClock, peerDasState, gossipManager, rcsn, indexDB)
+	peerDas := das.NewPeerDas(beaconRpc, beaconConfig, &config, columnStorage, blobStorage, sentinel, localNode.ID(), ethClock, peerDasState, gossipManager, rcsn, indexDB)
 	forkChoice.InitPeerDas(peerDas)   // hack init
 	peerDas.SetForkChoice(forkChoice) // [New in Gloas:EIP7732] Set forkChoice for GLOAS kzg_commitments lookup
 	committeeSub := committee_subscription.NewCommitteeSubscribeManagement(ctx, beaconConfig, networkConfig, ethClock, aggregationPool, syncedDataManager, gossipManager)
@@ -508,6 +508,7 @@ func RunCaplinService(ctx context.Context, engine execution_client.ExecutionEngi
 		proposerPreferencesService,
 		executionPayloadBidService,
 	)
+	peerDas.Start(ctx)
 
 	{
 		go batchSignatureVerifier.Start()

--- a/cmd/caplin/caplin1/run.go
+++ b/cmd/caplin/caplin1/run.go
@@ -127,7 +127,7 @@ func OpenCaplinDatabase(ctx context.Context,
 			blobDB.Close() // close blob database here
 		}()
 	}
-	return db, blob_storage.NewBlobStore(blobDB, afero.NewBasePathFs(afero.NewOsFs(), blobDir), blobPruneDistance, beaconConfig, ethClock), nil
+	return db, blob_storage.NewBlobStore(blobDB, afero.NewBasePathFs(afero.NewOsFs(), blobDir)), nil
 }
 
 func OpenCaplinIndexDb(ctx context.Context, dbPath string) (kv.RwDB, error) {
@@ -415,7 +415,7 @@ func RunCaplinService(ctx context.Context, engine execution_client.ExecutionEngi
 		return err
 	}
 	peerDasState := peerdasstate.NewPeerDasState(beaconConfig, networkConfig)
-	columnStorage := blob_storage.NewDataColumnStore(afero.NewBasePathFs(afero.NewOsFs(), dirs.CaplinColumnData), pruneBlobDistance, beaconConfig, ethClock, emitters)
+	columnStorage := blob_storage.NewDataColumnStore(afero.NewBasePathFs(afero.NewOsFs(), dirs.CaplinColumnData), beaconConfig, emitters)
 	sentinel, localNode, err := service.StartSentinelService(ctx, &sentinel.SentinelConfig{
 		P2PConfig: clp2p.P2PConfig{
 			IpAddr:             config.CaplinDiscoveryAddr,

--- a/common/snappypool/pool.go
+++ b/common/snappypool/pool.go
@@ -1,0 +1,52 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+// Package snappypool pools the stream codecs of github.com/golang/snappy.
+package snappypool
+
+import (
+	"io"
+	"sync"
+
+	"github.com/golang/snappy"
+)
+
+var (
+	readers = sync.Pool{New: func() any { return snappy.NewReader(nil) }}
+	writers = sync.Pool{New: func() any { return snappy.NewBufferedWriter(nil) }}
+)
+
+func Reader(r io.Reader) *snappy.Reader {
+	sr := readers.Get().(*snappy.Reader)
+	sr.Reset(r)
+	return sr
+}
+
+func PutReader(sr *snappy.Reader) {
+	sr.Reset(nil)
+	readers.Put(sr)
+}
+
+func Writer(w io.Writer) *snappy.Writer {
+	sw := writers.Get().(*snappy.Writer)
+	sw.Reset(w)
+	return sw
+}
+
+func PutWriter(sw *snappy.Writer) {
+	sw.Reset(nil)
+	writers.Put(sw)
+}


### PR DESCRIPTION
Cherry-pick of #23138 to release/3.6.

## r3.6-specific adaptations

- Adapt release-only constructors and mocks, and start PeerDAS workers explicitly after fork-choice/gossip wiring.
- Backport the main-branch prerequisites required by #23138:
  - #23451 bucket storage and its `PruneBelow` API, including temp-file-and-rename writes, missing/undecodable sidecars reported as absent, and directory-based bucket pruning.
  - #23423 pooled snappy buffers.
  - #22683 `PeerDas.Start`/`startOnce`; its upstream start/idempotence test is included.
  - #22907 peer banning for fork-schema/slot mismatches.
  - #23610 chain-configured data-column retention and the cleanup caller's absolute-floor calculation.

## Verification

- `go test ./cl/das ./cl/phase1/network -count=1`
- `make lint`
- `make erigon integration`

## Known limitations

- Matching main, a count-equal blob block stays on the metadata fast path; this backport does not re-download files intentionally removed below the live pruning floor. The shared pruning/backfill retention mismatch remains tracked in #23752 and should be fixed on main first.
- Backfill cursor and retry ownership remain process-local, so restart rescans from HEAD.
- Historical Fulu blobs beyond PeerDAS retention still require newer blob snapshots or another archival source.
- Existing-but-undecodable legacy sidecar files require a durable one-time migration rather than full decoding during every backfill scan.
