### PR TITLE
execution/execfinality, db: let the finality context own the db it reads

### DIFF
--- a/db/dbfinality/context.go
+++ b/db/dbfinality/context.go
@@ -16,16 +16,12 @@
 
 package dbfinality
 
-import (
-	"context"
-
-	"github.com/erigontech/erigon/db/kv"
-)
+import "context"
 
 // Context defines immutable block boundaries for database retention work.
 type Context interface {
 	PruneToBlockNum() uint64
 	RetireToBlockNum() uint64
 	MaxReorgDepth() uint64
-	ReadyForCollation(ctx context.Context, db kv.RoDB, stepLastTxNum uint64) (finalisedBlockNum, lastBlockInStep, lastBlockInDB, lastTxInDB uint64, ok bool, err error)
+	ReadyForCollation(ctx context.Context, stepLastTxNum uint64) (finalisedBlockNum, lastBlockInStep, lastBlockInDB, lastTxInDB uint64, ok bool, err error)
 }

--- a/db/snapshotsync/freezeblocks/block_snapshots_test.go
+++ b/db/snapshotsync/freezeblocks/block_snapshots_test.go
@@ -56,7 +56,7 @@ func (c blockFinalityContextStub) MaxReorgDepth() uint64 {
 	return 0
 }
 
-func (c blockFinalityContextStub) ReadyForCollation(_ context.Context, _ kv.RoDB, _ uint64) (finalisedBlockNum, lastBlockInStep, lastBlockInDB, lastTxInDB uint64, ok bool, err error) {
+func (c blockFinalityContextStub) ReadyForCollation(_ context.Context, _ uint64) (finalisedBlockNum, lastBlockInStep, lastBlockInDB, lastTxInDB uint64, ok bool, err error) {
 	return 0, 0, 0, 0, false, nil
 }
 

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -1160,7 +1160,7 @@ func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step, finalityCtx d
 func (a *Aggregator) readyForCollation(ctx context.Context, step kv.Step, finalityCtx dbfinality.Context) (finalisedBlockNum, lastBlockInStep, lastBlockInDB, lastTxInDB uint64, ok bool, err error) {
 	a.commitGate.RLock()
 	defer a.commitGate.RUnlock()
-	return finalityCtx.ReadyForCollation(ctx, a.db, step.LastTxNum(a.stepSize.Load()))
+	return finalityCtx.ReadyForCollation(ctx, step.LastTxNum(a.stepSize.Load()))
 }
 
 func (a *Aggregator) reorgSafeBlockAndStep(ctx context.Context, maxReorgDepth uint64) (reorgSafeBlock uint64, reorgSafeStep float64, ok bool) {

--- a/db/state/aggregator_finality_test.go
+++ b/db/state/aggregator_finality_test.go
@@ -48,7 +48,7 @@ func (c finalityContextStub) MaxReorgDepth() uint64 {
 	return c.maxReorgDepth
 }
 
-func (c finalityContextStub) ReadyForCollation(_ context.Context, _ kv.RoDB, _ uint64) (finalisedBlockNum, lastBlockInStep, lastBlockInDB, lastTxInDB uint64, ok bool, err error) {
+func (c finalityContextStub) ReadyForCollation(_ context.Context, _ uint64) (finalisedBlockNum, lastBlockInStep, lastBlockInDB, lastTxInDB uint64, ok bool, err error) {
 	return c.finalisedBlockNum, c.lastBlockInStep, c.lastBlockInDB, c.lastTxInDB, c.ready, nil
 }
 

--- a/db/test/aggregator_ext_test.go
+++ b/db/test/aggregator_ext_test.go
@@ -774,7 +774,7 @@ func testAggregatorV3BuildFilesWithFinalityContext(t *testing.T, buildFiles2 boo
 	require.NoError(t, err)
 	err = tx.Commit()
 	require.NoError(t, err)
-	finalityCtx := execfinality.NewContext(blocks, 0, 5, true)
+	finalityCtx := execfinality.NewContext(blocks, 0, 5, true, execfinality.WithTxNumsReader(tdb, rawdbv3.TxNums))
 	if buildFiles2 {
 		err = agg.BuildFiles2(ctx, 0, kv.Step(txnNums/agg.StepSize()), finalityCtx, true)
 		agg.WaitForFiles()

--- a/execution/execfinality/context.go
+++ b/execution/execfinality/context.go
@@ -31,13 +31,13 @@ type finalityContext struct {
 	maxReorgDepth     uint64
 	retentionBlockNum uint64
 	collateToBlockNum uint64
-	txNumsDB          kv.TemporalRoDB
+	db                kv.TemporalRoDB
 	txNumsReader      rawdbv3.TxNumsReader
 }
 
 type resolveOptions struct {
 	withoutFinalisedBlock bool
-	txNumsDB              kv.TemporalRoDB
+	db                    kv.TemporalRoDB
 	txNumsReader          rawdbv3.TxNumsReader
 }
 
@@ -54,10 +54,11 @@ func WithoutFinalisedBlock() ResolveOption {
 // re-executing from scratch a step from the executed range falls below the table and
 // the search answers with its floor; a reader backed by the block snapshots names the
 // real block. Such a reader reads block files, so it needs db to open the read tx: only
-// a temporal tx pins the block-files view those reads go through.
+// a temporal tx pins the block-files view those reads go through. Without this option
+// the context has no db and reads every step boundary as unresolvable.
 func WithTxNumsReader(db kv.TemporalRoDB, reader rawdbv3.TxNumsReader) ResolveOption {
 	return func(options *resolveOptions) {
-		options.txNumsDB = db
+		options.db = db
 		options.txNumsReader = reader
 	}
 }
@@ -70,7 +71,7 @@ func NewContext(headBlockNum, finalisedBlockNum, maxReorgDepth uint64, initialCy
 	ctx := finalityContext{
 		finalisedBlockNum: finalisedBlockNum,
 		maxReorgDepth:     maxReorgDepth,
-		txNumsDB:          opts.txNumsDB,
+		db:                opts.db,
 		txNumsReader:      opts.txNumsReader,
 	}
 	if finalisedBlockNum > 0 && !initialCycle {
@@ -114,24 +115,21 @@ func (c finalityContext) MaxReorgDepth() uint64 {
 	return c.maxReorgDepth
 }
 
-func (c finalityContext) ReadyForCollation(ctx context.Context, db kv.RoDB, stepLastTxNum uint64) (finalisedBlockNum, lastBlockInStep, lastBlockInDB, lastTxInDB uint64, ok bool, err error) {
+func (c finalityContext) ReadyForCollation(ctx context.Context, stepLastTxNum uint64) (finalisedBlockNum, lastBlockInStep, lastBlockInDB, lastTxInDB uint64, ok bool, err error) {
 	finalisedBlockNum = c.finalisedBlockNum
-	// db is the aggregator's chaindata, whose tx pins no block-files view. A
-	// snapshot-backed reader reads block files, so it gets the temporal db instead.
-	if c.txNumsDB != nil {
-		db = c.txNumsDB
-	}
-	err = db.View(ctx, func(tx kv.Tx) error {
-		lastBlockInStep, ok, err = c.txNumsReader.FindBlockNum(ctx, tx, stepLastTxNum)
-		if err != nil {
+	if c.db != nil {
+		err = c.db.View(ctx, func(tx kv.Tx) error {
+			lastBlockInStep, ok, err = c.txNumsReader.FindBlockNum(ctx, tx, stepLastTxNum)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				lastBlockInStep = 0
+			}
+			lastBlockInDB, lastTxInDB, err = rawdbv3.TxNums.Last(tx)
 			return err
-		}
-		if !ok {
-			lastBlockInStep = 0
-		}
-		lastBlockInDB, lastTxInDB, err = rawdbv3.TxNums.Last(tx)
-		return err
-	})
+		})
+	}
 	ok = err == nil && c.retentionBlockNum > 0 && lastBlockInStep <= c.collateToBlockNum
 	return
 }

--- a/execution/execfinality/context_test.go
+++ b/execution/execfinality/context_test.go
@@ -170,7 +170,7 @@ func TestContextReadyForCollationUsesTransactionVisibleTxNums(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			db := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
+			db := temporaltest.NewTestDB(t, datadir.New(t.TempDir()))
 			require.NoError(t, db.Update(t.Context(), func(tx kv.RwTx) error {
 				for blockNum := uint64(0); blockNum <= tc.headBlockNum; blockNum++ {
 					if err := rawdbv3.TxNums.Append(tx, blockNum, blockNum); err != nil {
@@ -179,8 +179,9 @@ func TestContextReadyForCollationUsesTransactionVisibleTxNums(t *testing.T) {
 				}
 				return nil
 			}))
-			ctx := NewContext(tc.headBlockNum, tc.finalisedBlockNum, tc.maxReorgDepth, tc.initialCycle)
-			finalisedBlockNum, lastBlockInStep, lastBlockInDB, lastTxInDB, ready, err := ctx.ReadyForCollation(t.Context(), db, tc.stepLastTxNum)
+			ctx := NewContext(tc.headBlockNum, tc.finalisedBlockNum, tc.maxReorgDepth, tc.initialCycle,
+				WithTxNumsReader(db, rawdbv3.TxNums))
+			finalisedBlockNum, lastBlockInStep, lastBlockInDB, lastTxInDB, ready, err := ctx.ReadyForCollation(t.Context(), tc.stepLastTxNum)
 			require.NoError(t, err)
 			require.Equal(t, tc.finalisedBlockNum, finalisedBlockNum)
 			require.Equal(t, tc.stepLastTxNum, lastBlockInStep)
@@ -210,9 +211,9 @@ func (s snapshotTxNums) BlockNumber(_ context.Context, _ kv.Tx, txNum uint64) (u
 
 // pruned chaindata: genesis plus the downloaded-blocks window, far above the head a
 // node re-executing from scratch has reached.
-func txNumWindowDB(t *testing.T) kv.RwDB {
+func txNumWindowDB(t *testing.T) kv.TemporalRwDB {
 	t.Helper()
-	db := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
+	db := temporaltest.NewTestDB(t, datadir.New(t.TempDir()))
 	require.NoError(t, db.Update(t.Context(), func(tx kv.RwTx) error {
 		// Genesis spans two txnums, so its max is 1.
 		if err := rawdbv3.TxNums.Append(tx, 0, 1); err != nil {
@@ -240,9 +241,9 @@ func TestContextReadyForCollationCollatesStepsBelowTheTxNumWindow(t *testing.T) 
 
 	db := txNumWindowDB(t)
 	reader := rawdbv3.TxNums.WithCustomReadTxNumFunc(snapshotTxNums{map[uint64]uint64{stepLastBlock: stepLastTxNum}})
-	ctx := NewContext(headBlockNum, 25_837_750, 96, true, WithTxNumsReader(nil, reader))
+	ctx := NewContext(headBlockNum, 25_837_750, 96, true, WithTxNumsReader(db, reader))
 
-	_, lastBlockInStep, _, _, ready, err := ctx.ReadyForCollation(t.Context(), db, stepLastTxNum)
+	_, lastBlockInStep, _, _, ready, err := ctx.ReadyForCollation(t.Context(), stepLastTxNum)
 	require.NoError(t, err)
 	require.Equal(t, stepLastBlock, lastBlockInStep, "must resolve the real block, not the table floor")
 	require.True(t, ready, "a step below the reorg window must collate")
@@ -260,9 +261,9 @@ func TestContextReadyForCollationStillGatesStepsBelowTheTxNumWindow(t *testing.T
 
 	db := txNumWindowDB(t)
 	reader := rawdbv3.TxNums.WithCustomReadTxNumFunc(snapshotTxNums{map[uint64]uint64{stepLastBlock: stepLastTxNum}})
-	ctx := NewContext(headBlockNum, 25_837_750, 96, true, WithTxNumsReader(nil, reader))
+	ctx := NewContext(headBlockNum, 25_837_750, 96, true, WithTxNumsReader(db, reader))
 
-	_, lastBlockInStep, _, _, ready, err := ctx.ReadyForCollation(t.Context(), db, stepLastTxNum)
+	_, lastBlockInStep, _, _, ready, err := ctx.ReadyForCollation(t.Context(), stepLastTxNum)
 	require.NoError(t, err)
 	require.Equal(t, stepLastBlock, lastBlockInStep)
 	require.False(t, ready, "a step inside the reorg window stays gated")
@@ -271,7 +272,7 @@ func TestContextReadyForCollationStillGatesStepsBelowTheTxNumWindow(t *testing.T
 // A synced node also prunes MaxTxNum down to a recent window. There chaindata covers the
 // step, so the default reader resolves it and nothing changes.
 func TestContextReadyForCollationResolvesStepsInsideTheTxNumWindow(t *testing.T) {
-	db := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
+	db := temporaltest.NewTestDB(t, datadir.New(t.TempDir()))
 	require.NoError(t, db.Update(t.Context(), func(tx kv.RwTx) error {
 		for _, e := range []struct{ blockNum, maxTxNum uint64 }{
 			{0, 1}, {25_472_999, 3_630_627_978}, {25_473_000, 3_630_628_100}, {25_473_001, 3_630_628_300},
@@ -283,13 +284,13 @@ func TestContextReadyForCollationResolvesStepsInsideTheTxNumWindow(t *testing.T)
 		return nil
 	}))
 
-	ctx := NewContext(25_473_001, 25_473_000, 96, false)
-	_, lastBlockInStep, _, _, ready, err := ctx.ReadyForCollation(t.Context(), db, 3_630_628_100)
+	ctx := NewContext(25_473_001, 25_473_000, 96, false, WithTxNumsReader(db, rawdbv3.TxNums))
+	_, lastBlockInStep, _, _, ready, err := ctx.ReadyForCollation(t.Context(), 3_630_628_100)
 	require.NoError(t, err)
 	require.Equal(t, uint64(25_473_000), lastBlockInStep)
 	require.True(t, ready)
 
-	_, lastBlockInStep, _, _, ready, err = ctx.ReadyForCollation(t.Context(), db, 3_630_628_300)
+	_, lastBlockInStep, _, _, ready, err = ctx.ReadyForCollation(t.Context(), 3_630_628_300)
 	require.NoError(t, err)
 	require.Equal(t, uint64(25_473_001), lastBlockInStep)
 	require.False(t, ready, "step above the finalised head stays gated")
@@ -308,15 +309,12 @@ func (i *txRecordingIndex) BlockNumber(_ context.Context, tx kv.Tx, _ uint64) (u
 }
 
 // A snapshot-backed reader reads block files, which only a temporal tx pins a view for.
-// The collation caller passes the aggregator's chaindata, so the lookup has to run on
-// the db the reader came with instead.
 func TestContextReadyForCollationResolvesStepsOnATemporalTx(t *testing.T) {
-	temporalDB := temporaltest.NewTestDB(t, datadir.New(t.TempDir()))
 	index := &txRecordingIndex{}
 	ctx := NewContext(25_473_001, 25_473_000, 96, false,
-		WithTxNumsReader(temporalDB, rawdbv3.TxNums.WithCustomReadTxNumFunc(index)))
+		WithTxNumsReader(txNumWindowDB(t), rawdbv3.TxNums.WithCustomReadTxNumFunc(index)))
 
-	_, _, _, _, _, err := ctx.ReadyForCollation(t.Context(), txNumWindowDB(t), 3_630_628_100)
+	_, _, _, _, _, err := ctx.ReadyForCollation(t.Context(), 3_630_628_100)
 	require.NoError(t, err)
 	require.Implements(t, (*kv.TemporalTx)(nil), index.tx)
 }


### PR DESCRIPTION
Follow-up to #23704. After a9df487 `ReadyForCollation` took a `db` it then replaced with the context's own `txNumsDB`, so the aggregator passed its chaindata for nothing.

- `dbfinality.Context.ReadyForCollation(ctx, stepLastTxNum)` — the db parameter is gone; the context reads through the db `WithTxNumsReader` already carries.
- `Aggregator.readyForCollation` no longer hands over `a.db` (one step toward the TODO on `Aggregator.db`).
- A context built without `WithTxNumsReader` has no db and resolves no block, the same path as an unresolvable step. All production sites pass the option; `TestAggregatorV3_BuildFiles*_WithFinalityContext` now passes its temporal db so its gating stays real (it fails without it).