### PR TITLE
all: upgrade minimum Go version to 1.26

### DIFF
--- a/.github/docs/caplin-hive-testing.md
+++ b/.github/docs/caplin-hive-testing.md
@@ -47,7 +47,7 @@ Location: `/erigon/mark/hive/`
 ### Dockerfile.local (full)
 
 ```dockerfile
-FROM golang:1.25.0-trixie as builder
+FROM golang:1.26.0-trixie as builder
 ARG local_path=erigon
 COPY $local_path erigon
 RUN apt-get update && apt-get install -y bash build-essential ca-certificates git \

--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -259,7 +259,7 @@ jobs:
       - name: Setup go env and cache
         uses: actions/setup-go@v7
         with:
-          go-version: '>=1.25'
+          go-version: '>=1.26'
 
       # Build erigon from the checked-out commit, then wrap it with Hive's
       # prebuilt-image client Dockerfile — avoids cloning the ephemeral

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Setup go env and cache
         uses: actions/setup-go@v7
         with:
-          go-version: '>=1.25'
+          go-version: '>=1.26'
           go-version-file: 'hive/go.mod'
 
       - name: Conditional Docker Login

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,6 +65,10 @@ linters:
           rules: rules.go
         underef:
           skipRecvDeref: true
+    modernize:
+      # newexpr wants //go:fix inline on common.NewUint64 (391 call sites) — its own PR.
+      disable:
+        - newexpr
     staticcheck:
       # The only place staticcheck checks are turned off. A text: exclusion runs
       # the check and drops its output, which is how the SA/S1 gap this list

--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,8 @@ default: all
 
 ## go-version:                        print and verify go version
 go-version:
-	@if [ $(shell $(GO) version | cut -c 16-17) -lt 25 ]; then \
-		echo "minimum required Golang version is 1.25"; \
+	@if [ $(shell $(GO) version | cut -c 16-17) -lt 26 ]; then \
+		echo "minimum required Golang version is 1.26"; \
 		exit 1 ;\
 	fi
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ For developers
 
 ### Building
 
-Toolchain: [Go >= 1.25](https://golang.org/doc/install), GCC 10+ or Clang, 64-bit architecture. On Linux, kernel > v4.
+Toolchain: [Go >= 1.26](https://golang.org/doc/install), GCC 10+ or Clang, 64-bit architecture. On Linux, kernel > v4.
 
 ```sh
 git clone https://github.com/erigontech/erigon.git

--- a/cl/beacon/beaconhttp/api.go
+++ b/cl/beacon/beaconhttp/api.go
@@ -54,8 +54,7 @@ var (
 func WrapEndpointError(err error) *EndpointError {
 	// Handlers build these with NewEndpointError, so the pointer form is the one that carries a
 	// deliberate code; matching only the value form would silently turn it into a 500.
-	var byPointer *EndpointError
-	if errors.As(err, &byPointer) {
+	if byPointer, ok := errors.AsType[*EndpointError](err); ok {
 		return byPointer
 	}
 	byValue := EndpointError{}

--- a/cl/das/peer_das.go
+++ b/cl/das/peer_das.go
@@ -1697,8 +1697,7 @@ func isExpectedColumnDownloadMiss(err error) bool {
 	if err == nil {
 		return false
 	}
-	var peerErr *httpreqresp.PeerResponseError
-	if errors.As(err, &peerErr) {
+	if peerErr, ok := errors.AsType[*httpreqresp.PeerResponseError](err); ok {
 		return peerErr.Code == httpreqresp.ResponseCodeResourceUnavailable
 	}
 	return false

--- a/cl/das/peer_das_test.go
+++ b/cl/das/peer_das_test.go
@@ -1933,16 +1933,16 @@ func assertBlobsRecoverWorkerPrewriteUnavailable(t *testing.T, persistent bool) 
 func TestRecoverBlobsRequestDoesNotRetainFullBlock(t *testing.T) {
 	blockType := reflect.TypeFor[cltypes.ColumnSyncableSignedBlock]()
 	requestType := reflect.TypeFor[recoverBlobsRequest]()
-	for i := range requestType.NumField() {
-		require.NotEqual(t, blockType, requestType.Field(i).Type, "recovery queue must not retain a full block")
+	for field := range requestType.Fields() {
+		require.NotEqual(t, blockType, field.Type, "recovery queue must not retain a full block")
 	}
 }
 
 func TestDownloadRequestDoesNotRetainFullBlock(t *testing.T) {
 	blockType := reflect.TypeFor[cltypes.ColumnSyncableSignedBlock]()
 	requestType := reflect.TypeFor[downloadRequest]()
-	for i := range requestType.NumField() {
-		fieldType := requestType.Field(i).Type
+	for field := range requestType.Fields() {
+		fieldType := field.Type
 		if fieldType.Kind() == reflect.Map {
 			require.NotEqual(t, blockType, fieldType.Elem(), "column download lifecycle must not retain full blocks")
 		}

--- a/cmd/bumper/cmd/inspect.go
+++ b/cmd/bumper/cmd/inspect.go
@@ -40,8 +40,7 @@ func inspectSchemaFields(s *statecfg.SchemaGen) []FieldInfo {
 	var result []FieldInfo
 	v := reflect.ValueOf(*s)
 	t := v.Type()
-	for i := 0; i < t.NumField(); i++ {
-		field := t.Field(i)
+	for field := range t.Fields() {
 		kind := field.Type.Name() // domainCfg, iiCfg, etc.
 		result = append(result, FieldInfo{
 			Name: field.Name,

--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -224,8 +224,7 @@ func init() {
 func main() {
 	if err := app.Run(context.Background(), os.Args); err != nil {
 		code := 1
-		var ec *t8ntool.NumberedError
-		if errors.As(err, &ec) {
+		if ec, ok := errors.AsType[*t8ntool.NumberedError](err); ok {
 			code = ec.ExitCode()
 		}
 		_, printErr := fmt.Fprintln(os.Stderr, err)

--- a/common/crypto/crypto.go
+++ b/common/crypto/crypto.go
@@ -284,8 +284,7 @@ func FromECDSAPub(pub *ecdsa.PublicKey) []byte {
 // HexToECDSA parses a secp256k1 private key.
 func HexToECDSA(hexkey string) (*ecdsa.PrivateKey, error) {
 	b, err := hex.DecodeString(hexkey)
-	var byteErr hex.InvalidByteError
-	if errors.As(err, &byteErr) {
+	if byteErr, ok := errors.AsType[hex.InvalidByteError](err); ok {
 		return nil, fmt.Errorf("invalid hex character %q in private key", byte(byteErr))
 	} else if err != nil {
 		return nil, errors.New("invalid hex data for private key")

--- a/common/hexutil/json.go
+++ b/common/hexutil/json.go
@@ -454,8 +454,7 @@ func wrapTypeError(err error, typ reflect.Type) error {
 	//if _, ok := err.(*decError); ok {
 	//	return &json.UnmarshalTypeError{Value: err.Error(), Type: typ}
 	//}
-	var dec *decError
-	if errors.As(err, &dec) {
+	if _, ok := errors.AsType[*decError](err); ok {
 		return &json.UnmarshalTypeError{Value: err.Error(), Type: typ}
 	}
 	return err

--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.2
-FROM docker.io/library/golang:1.26-alpine3.20 AS builder
+FROM docker.io/library/golang:1.26-alpine3.24 AS builder
 
 RUN apk --no-cache add build-base linux-headers git bash ca-certificates libstdc++
 
@@ -16,7 +16,7 @@ RUN --mount=type=cache,target=/root/.cache \
     make all
 
 
-FROM docker.io/library/golang:1.26-alpine3.20 AS tools-builder
+FROM docker.io/library/golang:1.26-alpine3.24 AS tools-builder
 RUN apk --no-cache add build-base linux-headers git bash ca-certificates libstdc++
 WORKDIR /app
 
@@ -27,7 +27,7 @@ COPY go.sum go.sum
 
 RUN mkdir -p /app/build/bin
 
-FROM docker.io/library/alpine:3.20
+FROM docker.io/library/alpine:3.24
 
 # install required runtime libs, along with some helpers for debugging
 RUN apk add --no-cache ca-certificates libstdc++ tzdata

--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.2
-FROM docker.io/library/golang:1.25-alpine3.20 AS builder
+FROM docker.io/library/golang:1.26-alpine3.20 AS builder
 
 RUN apk --no-cache add build-base linux-headers git bash ca-certificates libstdc++
 
@@ -16,7 +16,7 @@ RUN --mount=type=cache,target=/root/.cache \
     make all
 
 
-FROM docker.io/library/golang:1.25-alpine3.20 AS tools-builder
+FROM docker.io/library/golang:1.26-alpine3.20 AS tools-builder
 RUN apk --no-cache add build-base linux-headers git bash ca-certificates libstdc++
 WORKDIR /app
 

--- a/diagnostics/mem/mem_linux.go
+++ b/diagnostics/mem/mem_linux.go
@@ -56,9 +56,7 @@ func ReadVirtualMemStats() (process.MemoryMapsStat, error) {
 
 	// convert from kilobytes to bytes
 	val := reflect.ValueOf(&m).Elem()
-	for i := 0; i < val.NumField(); i++ {
-		field := val.Field(i)
-
+	for _, field := range val.Fields() {
 		if field.Kind() == reflect.Uint64 {
 			field.SetUint(field.Interface().(uint64) * 1024)
 		}

--- a/docs/site/docs/about/contributing.md
+++ b/docs/site/docs/about/contributing.md
@@ -17,7 +17,7 @@ The Erigon node software is developed in the [erigontech/erigon](https://github.
    git clone https://github.com/<your-username>/erigon.git
    cd erigon
    ```
-2. Build the project (requires Go 1.25+ and a C++ compiler):
+2. Build the project (requires Go 1.26+ and a C++ compiler):
    ```bash
    make erigon
    ```

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -8155,7 +8155,7 @@ The Erigon node software is developed in the [erigontech/erigon](https://github.
    git clone https://github.com/<your-username>/erigon.git
    cd erigon
    ```
-2. Build the project (requires Go 1.25+ and a C++ compiler):
+2. Build the project (requires Go 1.26+ and a C++ compiler):
    ```bash
    make erigon
    ```

--- a/execution/abi/bind/backends/simulated_test.go
+++ b/execution/abi/bind/backends/simulated_test.go
@@ -524,8 +524,7 @@ func TestSimulatedBackend_EstimateGas(t *testing.T) {
 				t.Fatalf("Expect error, want %v, got %v", c.expectError, err)
 			}
 			if c.expectData != nil {
-				var rerr *revertError
-				if !errors.As(err, &rerr) {
+				if rerr, ok := errors.AsType[*revertError](err); !ok {
 					t.Fatalf("Expect revert error, got %T", err)
 				} else if !reflect.DeepEqual(rerr.ErrorData(), c.expectData) {
 					t.Fatalf("Error data mismatch, want %v, got %v", c.expectData, rerr.ErrorData())

--- a/execution/abi/reflect.go
+++ b/execution/abi/reflect.go
@@ -188,15 +188,15 @@ func mapArgNamesToStructFields(argNames []string, value reflect.Value) (map[stri
 	struct2abi := make(map[string]string)
 
 	// first round ~~~
-	for i := 0; i < typ.NumField(); i++ {
-		structFieldName := typ.Field(i).Name
+	for field := range typ.Fields() {
+		structFieldName := field.Name
 
 		// skip private struct fields.
 		if structFieldName[:1] != strings.ToUpper(structFieldName[:1]) {
 			continue
 		}
 		// skip fields that have no abi:"" tag.
-		tagName, ok := typ.Field(i).Tag.Lookup("abi")
+		tagName, ok := field.Tag.Lookup("abi")
 		if !ok {
 			continue
 		}

--- a/execution/chain/chain_config_test.go
+++ b/execution/chain/chain_config_test.go
@@ -331,8 +331,7 @@ func TestForkTimestampsCoversEveryTimeField(t *testing.T) {
 	}
 
 	cfg := reflect.TypeFor[Config]()
-	for i := range cfg.NumField() {
-		field := cfg.Field(i)
+	for field := range cfg.Fields() {
 		if field.Type != reflect.TypeFor[*uint64]() {
 			continue
 		}

--- a/execution/engineapi/sszrest_handler.go
+++ b/execution/engineapi/sszrest_handler.go
@@ -152,8 +152,7 @@ func writeEngineError(w http.ResponseWriter, err error) {
 	if err == nil {
 		return
 	}
-	var rpcErr rpc.Error
-	if errors.As(err, &rpcErr) {
+	if rpcErr, ok := errors.AsType[rpc.Error](err); ok {
 		switch rpcErr.ErrorCode() {
 		case engine_helpers.UnknownPayloadErr.Code:
 			writeSSZError(w, http.StatusNotFound, err.Error())

--- a/execution/exec/txtask.go
+++ b/execution/exec/txtask.go
@@ -585,8 +585,7 @@ func (txTask *TxTask) Execute(evm *vm.EVM,
 			}
 
 			if applyErr != nil {
-				var abortErr protocol.ErrExecAbortError
-				if !errors.As(applyErr, &abortErr) {
+				if _, ok := errors.AsType[protocol.ErrExecAbortError](applyErr); !ok {
 					return evmtypes.ExecutionResult{}, protocol.ErrExecAbortError{DependencyTxIndex: ibs.DepTxIndex(), OriginError: applyErr}
 				}
 

--- a/execution/p2p/fetcher_tracking.go
+++ b/execution/p2p/fetcher_tracking.go
@@ -45,8 +45,7 @@ func (tf *TrackingFetcher) FetchHeaders(
 ) (FetcherResponse[[]*types.Header], error) {
 	res, err := tf.Fetcher.FetchHeaders(ctx, start, end, peerId, opts...)
 	if err != nil {
-		var errIncompleteHeaders *ErrIncompleteHeaders
-		if errors.As(err, &errIncompleteHeaders) {
+		if errIncompleteHeaders, ok := errors.AsType[*ErrIncompleteHeaders](err); ok {
 			tf.peerTracker.BlockNumMissing(peerId, errIncompleteHeaders.LowestMissingBlockNum())
 		} else if errors.Is(err, context.DeadlineExceeded) {
 			tf.peerTracker.BlockNumMissing(peerId, start)
@@ -83,8 +82,7 @@ func (tf *TrackingFetcher) FetchBodies(
 ) (FetcherResponse[[]*types.Body], error) {
 	bodies, err := tf.Fetcher.FetchBodies(ctx, headers, peerId, opts...)
 	if err != nil {
-		var errMissingBodies *ErrMissingBodies
-		if errors.As(err, &errMissingBodies) {
+		if errMissingBodies, ok := errors.AsType[*ErrMissingBodies](err); ok {
 			lowest, exists := errMissingBodies.LowestMissingBlockNum()
 			if exists {
 				tf.peerTracker.BlockNumMissing(peerId, lowest)

--- a/execution/protocol/aa/aa_exec.go
+++ b/execution/protocol/aa/aa_exec.go
@@ -445,8 +445,7 @@ func newValidationPhaseError(
 	revertEntityName string,
 	frameReverted bool,
 ) *ValidationPhaseError {
-	var vpeCast *ValidationPhaseError
-	if errors.As(innerErr, &vpeCast) {
+	if vpeCast, ok := errors.AsType[*ValidationPhaseError](innerErr); ok {
 		return vpeCast
 	}
 	var errorMessage string

--- a/execution/rlp/decode.go
+++ b/execution/rlp/decode.go
@@ -173,8 +173,7 @@ func WrapStreamError(err error, typ reflect.Type) error {
 }
 
 func addErrorContext(err error, ctx string) error {
-	var decErr *decodeError
-	if errors.As(err, &decErr) {
+	if decErr, ok := errors.AsType[*decodeError](err); ok {
 		decErr.ctx = append(decErr.ctx, ctx)
 	}
 	return err

--- a/execution/rlp/typecache.go
+++ b/execution/rlp/typecache.go
@@ -144,13 +144,11 @@ func structFields(typ reflect.Type) (fields []field, err error) {
 	// Filter/validate fields.
 	structFields, structTags, err := rlpstruct.ProcessFields(allStructFields)
 	if err != nil {
-		var tagErr rlpstruct.TagError
-		if errors.As(err, &tagErr) {
+		if tagErr, ok := errors.AsType[rlpstruct.TagError](err); ok {
 			tagErr.StructType = typ.String()
 			return nil, tagErr
 		}
-		var optErr rlpstruct.OptionalFieldError
-		if errors.As(err, &optErr) {
+		if optErr, ok := errors.AsType[rlpstruct.OptionalFieldError](err); ok {
 			optErr.StructType = typ.String()
 			return nil, optErr
 		}

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -189,8 +189,7 @@ func (s *stopCause) Error() string {
 
 // stopCauseOf returns the stopCause published on ctx, if any.
 func stopCauseOf(ctx context.Context) (*stopCause, bool) {
-	var s *stopCause
-	if errors.As(context.Cause(ctx), &s) {
+	if s, ok := errors.AsType[*stopCause](context.Cause(ctx)); ok {
 		return s, true
 	}
 	return nil, false
@@ -1462,8 +1461,7 @@ func (fc *failCandidate) consider(block uint64, blockHash common.Hash, exec bool
 // preserving the real origErr as OriginError instead of the zero-value an
 // inline type-assertion would substitute on the failure branch.
 func wrapAsExecAbort(origErr error, depTxIndex int) error {
-	var abortErr protocol.ErrExecAbortError
-	if errors.As(origErr, &abortErr) {
+	if _, ok := errors.AsType[protocol.ErrExecAbortError](origErr); ok {
 		return origErr
 	}
 	return protocol.ErrExecAbortError{DependencyTxIndex: depTxIndex, OriginError: origErr}
@@ -2741,8 +2739,7 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 	tx := task.index
 	be.results[tx] = &execResult{TxResult: res}
 	if res.Err != nil {
-		var execErr protocol.ErrExecAbortError
-		if errors.As(res.Err, &execErr) {
+		if execErr, ok := errors.AsType[protocol.ErrExecAbortError](res.Err); ok {
 			if res.Version().Incarnation > len(be.tasks) {
 				// Parallel scheduler exhausted retries for this tx. Surface
 				// through blockResult.Err for the same reason as the other

--- a/execution/stagedsync/sync.go
+++ b/execution/stagedsync/sync.go
@@ -499,8 +499,7 @@ func (s *Sync) runStage(stage *Stage, doms *execctx.SharedDomains, rwTx kv.Tempo
 	}
 
 	if err = stage.Forward(badBlockUnwind, stageState, s, doms, rwTx, s.logger); err != nil {
-		var errExhausted *ErrLoopExhausted
-		if errors.As(err, &errExhausted) {
+		if _, ok := errors.AsType[*ErrLoopExhausted](err); ok {
 			s.logger.Debug(fmt.Sprintf("[%s] loop exhausted", s.LogPrefix()), "msg", err.Error())
 			s.logRunStageDone(stageState, start)
 			return true, nil

--- a/execution/state/intra_block_state_test.go
+++ b/execution/state/intra_block_state_test.go
@@ -58,8 +58,7 @@ func TestSnapshotRandom(t *testing.T) {
 	err := quick.Check(func() bool {
 		return ts.run(t)
 	}, config)
-	var cerr *quick.CheckError
-	if errors.As(err, &cerr) {
+	if cerr, ok := errors.AsType[*quick.CheckError](err); ok {
 		test := cerr.In[0].(*snapshotTest)
 		t.Errorf("%v:\n%s", test.err, test)
 	} else if err != nil {

--- a/execution/vm/instructions_test.go
+++ b/execution/vm/instructions_test.go
@@ -994,8 +994,7 @@ func TestEIP8024_Execution(t *testing.T) {
 						}
 					}
 				case errors.As(tc.wantErr, &stackUnderflow):
-					var want *ErrStackUnderflow
-					if !errors.As(err, &want) {
+					if _, ok := errors.AsType[*ErrStackUnderflow](err); !ok {
 						t.Fatalf("expected ErrStackUnderflow, got %v", err)
 					}
 				default:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/erigontech/erigon
 
-go 1.25.7
+go 1.26.0
 
 replace github.com/holiman/bloomfilter/v2 => github.com/AskAlexSharov/bloomfilter/v2 v2.0.9
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8155,7 +8155,7 @@ The Erigon node software is developed in the [erigontech/erigon](https://github.
    git clone https://github.com/<your-username>/erigon.git
    cd erigon
    ```
-2. Build the project (requires Go 1.25+ and a C++ compiler):
+2. Build the project (requires Go 1.26+ and a C++ compiler):
    ```bash
    make erigon
    ```

--- a/node/app/event/managedeventbus.go
+++ b/node/app/event/managedeventbus.go
@@ -41,8 +41,8 @@ func (bus *ManagedEventBus) String() string {
 func (bus *ManagedEventBus) Register(object any, fns ...any) (err error) {
 	objectVal := reflect.ValueOf(object)
 	if len(fns) == 0 {
-		for i := 0; i < objectVal.NumMethod(); i++ {
-			if method := objectVal.Method(i); method.Type().NumIn() > 0 && method.Type().NumOut() == 0 {
+		for _, method := range objectVal.Methods() {
+			if method.Type().NumIn() > 0 && method.Type().NumOut() == 0 {
 				fns = append(fns, method.Interface())
 			}
 		}

--- a/node/app/typeid.go
+++ b/node/app/typeid.go
@@ -337,8 +337,8 @@ func TypeIdValues(typeIds any) []TypeId {
 	}
 
 	var values []TypeId
-	for i := 0; i < s.NumField(); i++ {
-		if value, ok := reflect.TypeAssert[TypeId](s.Field(i)); ok {
+	for _, field := range s.Fields() {
+		if value, ok := reflect.TypeAssert[TypeId](field); ok {
 			values = append(values, value)
 		}
 	}

--- a/node/cli/helpers.go
+++ b/node/cli/helpers.go
@@ -58,8 +58,7 @@ func NewApp(desc string) *cli.Command {
 			return
 		}
 		// For cli.Exit errors, just exit with the code
-		var exitErr cli.ExitCoder
-		if errors.As(err, &exitErr) {
+		if exitErr, ok := errors.AsType[cli.ExitCoder](err); ok {
 			cli.OsExiter(exitErr.ExitCode())
 		} else {
 			// For other errors, print them and exit

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -381,8 +381,7 @@ func TestLifecycleTerminationGuarantee(t *testing.T) {
 	}
 	// Stop the stack, verify failure and check all terminations
 	err = stack.Close()
-	var stopErr *StopError
-	if !errors.As(err, &stopErr) {
+	if stopErr, ok := errors.AsType[*StopError](err); !ok {
 		t.Fatalf("termination failure mismatch: have %v, want StopError", err)
 	} else {
 		failer := reflect.TypeFor[*InstrumentedService]()

--- a/p2p/dnsdisc/error.go
+++ b/p2p/dnsdisc/error.go
@@ -50,8 +50,7 @@ type nameError struct {
 }
 
 func (err nameError) Error() string {
-	var ee entryError
-	if errors.As(err.err, &ee) {
+	if ee, ok := errors.AsType[entryError](err.err); ok {
 		return fmt.Sprintf("invalid %s entry at %s: %v", ee.typ, err.name, ee.err)
 	}
 	return err.name + ": " + err.err.Error()

--- a/p2p/enr/entries.go
+++ b/p2p/enr/entries.go
@@ -256,8 +256,7 @@ func (err *KeyError) Unwrap() error {
 // IsNotFound reports whether the given error means that a key/value pair is
 // missing from a record.
 func IsNotFound(err error) bool {
-	var ke *KeyError
-	if errors.As(err, &ke) {
+	if ke, ok := errors.AsType[*KeyError](err); ok {
 		return errors.Is(ke.Err, errNotFound)
 	}
 	return false

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -281,8 +281,7 @@ func (p *Peer) run() (peerErr *PeerError) {
 			// Allow the next write to start if there was no error.
 			writeStart <- struct{}{}
 		case err := <-readErr:
-			var reason DiscReason
-			if errors.As(err, &reason) {
+			if reason, ok := errors.AsType[DiscReason](err); ok {
 				return NewPeerError(PeerErrorDiscReasonRemote, reason, nil, "Peer.run got a remote DiscReason")
 			} else {
 				return NewPeerError(PeerErrorDiscReason, DiscNetworkError, err, "Peer.run readErr")

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -684,8 +684,7 @@ func (c *Client) drainRead() {
 func (c *Client) read(codec ServerCodec) {
 	for {
 		msgs, batch, err := codec.ReadBatch()
-		var syntaxErr *json.SyntaxError
-		if errors.As(err, &syntaxErr) {
+		if _, ok := errors.AsType[*json.SyntaxError](err); ok {
 			codec.WriteJSON(context.Background(), errorMessage(&parseError{err.Error()}))
 		}
 		if err != nil {

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -106,15 +106,13 @@ func TestClientErrorData(t *testing.T) {
 	}
 
 	// Check code.
-	var errCode Error
-	if !errors.As(err, &errCode) {
+	if errCode, ok := errors.AsType[Error](err); !ok {
 		t.Fatalf("client did not return rpc.Error, got %#v", err)
 	} else if errCode.ErrorCode() != (testError{}.ErrorCode()) {
 		t.Fatalf("wrong error code %d, want %d", errCode.ErrorCode(), testError{}.ErrorCode())
 	}
 	// Check data.
-	var errData DataError
-	if !errors.As(err, &errData) {
+	if errData, ok := errors.AsType[DataError](err); !ok {
 		t.Fatalf("client did not return rpc.DataError, got %#v", err)
 	} else if errData.ErrorData() != (testError{}.ErrorData()) {
 		t.Fatalf("wrong error data %#v, want %#v", errData.ErrorData(), testError{}.ErrorData())

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -95,8 +95,7 @@ func HandleError(err error, stream jsonstream.Stream) {
 		stream.WriteObjectField("error")
 		stream.WriteObjectStart()
 		stream.WriteObjectField("code")
-		var ec Error
-		if errors.As(err, &ec) {
+		if ec, ok := errors.AsType[Error](err); ok {
 			stream.WriteInt(ec.ErrorCode())
 		} else {
 			stream.WriteInt(ErrCodeDefault)
@@ -104,8 +103,7 @@ func HandleError(err error, stream jsonstream.Stream) {
 		stream.WriteMore()
 		stream.WriteObjectField("message")
 		stream.WriteString(err.Error())
-		var de DataError
-		if errors.As(err, &de) {
+		if de, ok := errors.AsType[DataError](err); ok {
 			stream.WriteMore()
 			stream.WriteObjectField("data")
 			data, derr := json.Marshal(de.ErrorData())

--- a/rpc/jsonrpc/eth_api.go
+++ b/rpc/jsonrpc/eth_api.go
@@ -255,8 +255,7 @@ func (api *BaseAPI) pendingBlock() *types.Block {
 // view. The probe never changes the selected transaction.
 func (api *BaseAPI) resolveCommittedBlockNumber(ctx context.Context, tx kv.Tx, blockNrOrHash rpc.BlockNumberOrHash) (uint64, error) {
 	blockNumber, _, _, err := rpchelper.GetCanonicalBlockNumber(ctx, blockNrOrHash, tx, api._blockReader, nil)
-	var blockNotFound rpc.BlockNotFoundErr
-	if !errors.As(err, &blockNotFound) {
+	if _, ok := errors.AsType[rpc.BlockNotFoundErr](err); !ok {
 		return blockNumber, err
 	}
 

--- a/rpc/jsonrpc/graphql_api_test.go
+++ b/rpc/jsonrpc/graphql_api_test.go
@@ -42,8 +42,7 @@ func TestGetAccountStorage_InvalidSlot(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := api.GetAccountStorage(context.Background(), common.Address{}, tt.slot, rpc.BlockNumber(0))
-			var paramErr *rpc.InvalidParamsError
-			if !errors.As(err, &paramErr) {
+			if _, ok := errors.AsType[*rpc.InvalidParamsError](err); !ok {
 				t.Errorf("expected *rpc.InvalidParamsError, got %T: %v", err, err)
 			}
 		})

--- a/rpc/metrics.go
+++ b/rpc/metrics.go
@@ -63,8 +63,7 @@ func getRPCMethodNames(apiList []API) (methods []string) {
 	for _, api := range apiList {
 		apiType := reflect.TypeOf(api.Service)
 
-		for i := 0; i < apiType.NumMethod(); i++ {
-			method := apiType.Method(i)
+		for method := range apiType.Methods() {
 			rpcMethod := fmt.Sprintf("%s_%s", api.Namespace, pascalToCamel(method.Name))
 			methods = append(methods, rpcMethod)
 		}

--- a/rpc/service.go
+++ b/rpc/service.go
@@ -133,8 +133,7 @@ func (r *serviceRegistry) subscription(service, name string) *callback {
 func suitableCallbacks(receiver reflect.Value, logger log.Logger) map[string]*callback {
 	typ := receiver.Type()
 	callbacks := make(map[string]*callback)
-	for m := 0; m < typ.NumMethod(); m++ {
-		method := typ.Method(m)
+	for method := range typ.Methods() {
 		if method.PkgPath != "" {
 			continue // method not exported
 		}


### PR DESCRIPTION
Raises the Go floor from 1.25 to 1.26 (because `go 1.27.1` released today)

- `go.mod`: `go 1.25.7` -> `go 1.26.0` (no `go mod tidy` churn).
- `Makefile` version guard, `debug.Dockerfile` builder images, `test-hive.yml` / `test-hive-eest.yml` `go-version`, README and the contributing doc.
- `Dockerfile` and the release / docker-image workflows already build on `golang:1.26`. The main CI resolves its version from go.mod, so it moves to 1.26.x on its own.

No version-guarded Go code is left in the tree, so nothing to delete alongside. Whole tree plus every test binary compiles under go1.26.8.

`modernize` gates on the go directive, so 1.26 switches three sub-analyzers on. Two are applied here, one commit each:

- `errorsastype` (32) - `errors.As` -> `errors.AsType[T]`, 26 files.
- `stditerators` (7) - range `reflect.Type.Fields()` / `.Methods()` instead of `NumField`/`Field(i)` loops.

`newexpr` (10) stays parked in `.golangci.yml`: its fix marks `common.NewUint64` with `//go:fix inline`, which puts 391 call sites in scope of the next `go fix` run. That belongs in its own PR, not a toolchain bump.

