### PR TITLE
jsonstream: write a large raw payload straight to underlying writer

### DIFF
--- a/rpc/jsonstream/stack_stream.go
+++ b/rpc/jsonstream/stack_stream.go
@@ -43,6 +43,9 @@ const (
 type StackStream struct {
 	stream *jsoniter.Stream
 	stack  []stackItem
+	// out is the stream's own writer, kept because jsoniter does not expose it.
+	// Nil means the caller reads the response back out of Buffer instead.
+	out io.Writer
 }
 
 // newStackStream creates a new StackStream writing to out. Building the
@@ -52,6 +55,7 @@ func newStackStream(out io.Writer, bufSize int) *StackStream {
 	return &StackStream{
 		stream: jsoniter.NewStream(jsoniter.ConfigDefault, out, bufSize),
 		stack:  make([]stackItem, 0, InitialStackSize),
+		out:    out,
 	}
 }
 
@@ -63,16 +67,42 @@ func (s *StackStream) Buffer() []byte {
 // Reset resets the underlying jsoniter.Stream and clears the stack
 func (s *StackStream) Reset(out io.Writer) {
 	s.stream.Reset(out)
+	s.out = out
 	// jsoniter latches the error on the stream, so a reused one would fail every
 	// later Flush without draining.
 	s.stream.Error = nil
 	s.stack = s.stack[:0]
 }
 
-// WriteRawBytes writes already-encoded JSON held as bytes.
+// WriteRawBytes writes already-encoded JSON held as bytes. A payload at or above
+// FlushThreshold goes straight to the writer. Such a response commits the HTTP
+// status either way, since flushIfFull drains the buffer the moment this returns.
 func (s *StackStream) WriteRawBytes(content []byte) {
+	if s.out != nil && len(content) >= FlushThreshold {
+		s.writeThrough(content)
+		s.popCommaOrField()
+		return
+	}
 	s.stream.SetBuffer(append(s.stream.Buffer(), content...))
 	s.popCommaOrField()
+}
+
+// writeThrough drains what is buffered and hands content to the writer. The
+// empty-buffer check only skips a pointless zero-length Write; content is large
+// by the time we get here, so it is written either way.
+func (s *StackStream) writeThrough(content []byte) {
+	if len(s.stream.Buffer()) > 0 && s.stream.Flush() != nil {
+		// Same as flushIfFull: jsoniter latches the error, so these bytes can never
+		// reach the client and holding them only pins memory.
+		s.stream.SetBuffer(s.stream.Buffer()[:0])
+		return
+	}
+	if s.stream.Error != nil {
+		return
+	}
+	if _, err := s.out.Write(content); err != nil {
+		s.stream.Error = err
+	}
 }
 
 // WriteRaw writes raw content to the stream

--- a/rpc/jsonstream/stack_stream_bench_test.go
+++ b/rpc/jsonstream/stack_stream_bench_test.go
@@ -17,6 +17,7 @@
 package jsonstream
 
 import (
+	"bytes"
 	"io"
 	"strings"
 	"testing"
@@ -50,4 +51,20 @@ func BenchmarkStreamAcquire(b *testing.B) {
 			Put(s)
 		}
 	})
+}
+
+// Mirrors the response path: pooled stream, envelope, one big pre-encoded result.
+func BenchmarkWriteRawBytesLargeResult(b *testing.B) {
+	payload := append([]byte(`"`), bytes.Repeat([]byte("a"), 4<<20)...)
+	payload = append(payload, '"')
+	b.ReportAllocs()
+	for b.Loop() {
+		s := Get(io.Discard)
+		s.WriteObjectStart()
+		s.WriteObjectField("result")
+		s.WriteRawBytes(payload)
+		s.WriteObjectEnd()
+		_ = s.Flush()
+		Put(s)
+	}
 }

--- a/rpc/jsonstream/stack_stream_test.go
+++ b/rpc/jsonstream/stack_stream_test.go
@@ -1240,22 +1240,6 @@ func TestWriteRawBytesNilWriterAlwaysBuffers(t *testing.T) {
 	require.Equal(t, `{"result":`+string(payload)+`}`, string(s.Buffer()))
 }
 
-// Mirrors the response path: pooled stream, envelope, one big pre-encoded result.
-func BenchmarkWriteRawBytesLargeResult(b *testing.B) {
-	payload := append([]byte(`"`), bytes.Repeat([]byte("a"), 4<<20)...)
-	payload = append(payload, '"')
-	b.ReportAllocs()
-	for b.Loop() {
-		s := Get(io.Discard)
-		s.WriteObjectStart()
-		s.WriteObjectField("result")
-		s.WriteRawBytes(payload)
-		s.WriteObjectEnd()
-		_ = s.Flush()
-		Put(s)
-	}
-}
-
 // The mirror of TestPutDropsOversizedBuffer: a large result no longer grows the
 // buffer, so the stream survives Put instead of being dropped by the size check.
 func TestPutKeepsStreamAfterLargeWriteThrough(t *testing.T) {
@@ -1271,5 +1255,35 @@ func TestPutKeepsStreamAfterLargeWriteThrough(t *testing.T) {
 		"a written-through result must not grow the buffer past the pool limit")
 
 	Put(s)
-	require.Same(t, s, Get(nil).(*StackStream), "the stream must go back to the pool, not be dropped")
+	// sync.Pool may drop an admitted stream at any time, so admission is observed
+	// through the reset Put does on the way in, not through what Get hands back.
+	require.Empty(t, s.Buffer(), "an admitted stream is reset by Put")
+	require.Nil(t, s.out, "an admitted stream pins no writer")
+}
+
+// The write-through path must surface a writer failure the same way the buffered
+// path does, and must not let the failed bytes accumulate.
+func TestWriteRawBytesWriteThroughError(t *testing.T) {
+	t.Parallel()
+	payload := append([]byte(`"`), bytes.Repeat([]byte("a"), 4*FlushThreshold)...)
+	payload = append(payload, '"')
+
+	for name, out := range map[string]io.Writer{
+		// Fails on the prefix flush, before the payload is handed over.
+		"prefix-flush": goneWriter{},
+		// Takes the prefix, then fails on the direct write of the payload.
+		"direct-write": &failingWriter{failAfter: len(payload) - 1},
+	} {
+		t.Run(name, func(t *testing.T) {
+			s := New(out).(*StackStream)
+			s.WriteObjectStart()
+			s.WriteObjectField("result")
+			s.WriteRawBytes(payload)
+			s.WriteObjectEnd()
+
+			require.Error(t, s.Flush(), "the writer failure must reach the caller")
+			require.Less(t, len(s.Buffer()), FlushThreshold,
+				"a failed write must not accumulate, buffer holds %d", len(s.Buffer()))
+		})
+	}
 }

--- a/rpc/jsonstream/stack_stream_test.go
+++ b/rpc/jsonstream/stack_stream_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"strings"
 	"testing"
@@ -1181,4 +1182,94 @@ func TestPutDropsOversizedBuffer(t *testing.T) {
 	Put(s)
 	require.NotEmpty(t, s.Buffer(), "an oversized stream is dropped, not reset and pooled")
 	require.NotSame(t, s, Get(nil).(*StackStream))
+}
+
+// A raw payload at or above FlushThreshold goes to the writer instead of being
+// copied into the buffer. Both branches emit the same bytes, so the buffer is the
+// only thing that shows which one ran.
+func TestWriteRawBytesLargePayloadWritesThrough(t *testing.T) {
+	t.Parallel()
+	// Sizes are pre-quoting; two quote bytes are added, so these land the quoted
+	// length exactly on FlushThreshold and exactly one byte below it.
+	for name, tc := range map[string]struct {
+		size          int
+		writesThrough bool
+	}{
+		"below-threshold": {FlushThreshold - 3, false},
+		"at-threshold":    {FlushThreshold - 2, true},
+		"far-above":       {32 * FlushThreshold, true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			payload := append([]byte(`"`), bytes.Repeat([]byte("a"), tc.size)...)
+			payload = append(payload, '"')
+
+			var out bytes.Buffer
+			s := New(&out)
+			s.WriteObjectStart()
+			s.WriteObjectField("result")
+			s.WriteRawBytes(payload)
+			s.WriteObjectEnd()
+			require.NoError(t, s.Flush())
+
+			require.Equal(t, `{"result":`+string(payload)+`}`, out.String())
+
+			if tc.writesThrough {
+				require.Less(t, cap(s.(*StackStream).Buffer()), FlushThreshold,
+					"payload must reach the writer without being copied into the buffer")
+			} else {
+				require.GreaterOrEqual(t, cap(s.(*StackStream).Buffer()), FlushThreshold,
+					"a payload below the threshold must still be buffered")
+			}
+		})
+	}
+}
+
+// With no writer the caller reads the response back out of Buffer, so everything
+// must still be buffered no matter how large.
+func TestWriteRawBytesNilWriterAlwaysBuffers(t *testing.T) {
+	t.Parallel()
+	payload := append([]byte(`"`), bytes.Repeat([]byte("a"), 4*FlushThreshold)...)
+	payload = append(payload, '"')
+
+	s := New(nil)
+	s.WriteObjectStart()
+	s.WriteObjectField("result")
+	s.WriteRawBytes(payload)
+	s.WriteObjectEnd()
+
+	require.Equal(t, `{"result":`+string(payload)+`}`, string(s.Buffer()))
+}
+
+// Mirrors the response path: pooled stream, envelope, one big pre-encoded result.
+func BenchmarkWriteRawBytesLargeResult(b *testing.B) {
+	payload := append([]byte(`"`), bytes.Repeat([]byte("a"), 4<<20)...)
+	payload = append(payload, '"')
+	b.ReportAllocs()
+	for b.Loop() {
+		s := Get(io.Discard)
+		s.WriteObjectStart()
+		s.WriteObjectField("result")
+		s.WriteRawBytes(payload)
+		s.WriteObjectEnd()
+		_ = s.Flush()
+		Put(s)
+	}
+}
+
+// The mirror of TestPutDropsOversizedBuffer: a large result no longer grows the
+// buffer, so the stream survives Put instead of being dropped by the size check.
+func TestPutKeepsStreamAfterLargeWriteThrough(t *testing.T) {
+	var out bytes.Buffer
+	s := Get(&out).(*StackStream)
+	s.WriteObjectStart()
+	s.WriteObjectField("result")
+	s.WriteRawBytes(append(bytes.Repeat([]byte(`"a`), 2<<20), '"'))
+	s.WriteObjectEnd()
+	require.NoError(t, s.Flush())
+
+	require.LessOrEqual(t, cap(s.Buffer()), maxPooledBufferSize,
+		"a written-through result must not grow the buffer past the pool limit")
+
+	Put(s)
+	require.Same(t, s, Get(nil).(*StackStream), "the stream must go back to the pool, not be dropped")
 }


### PR DESCRIPTION
`WriteRawBytes` copied a pre-encoded result into the stream buffer only to flush it straight back out. For a 4MB `debug_trace*` result that grows the buffer to 4MB, which then fails `Put`'s `maxPooledBufferSize` check (1MB) — so exactly the responses that cost the most never get pooled, and the next one re-grows from 4KB.

A payload at or above `FlushThreshold` now drains whatever is buffered and goes straight to the writer. Below the threshold nothing changes, so the late-status paths (400, and the 503 from #23488) keep their buffer.

Which responses cross `FlushThreshold` and take the new path, measured on a mainnet `minimal` node:

| method | response size | new path |
| --- | ---: | --- |
| `trace_block` | 4.51 MB | yes |
| `debug_traceBlockByNumber` (callTracer) | 3.64 MB | yes |
| `eth_getBlockReceipts` | 1.33 MB | yes |
| `eth_getBlockByNumber` (fullTx) | 851 KB | yes |
| `eth_getLogs` (20-block window, address filter) | varies | above 64KB only |
| `eth_getBalance`, `eth_call` | tens of bytes | no, still buffered |

Measured on n0, mainnet `--prune.mode=minimal`, `wrk -t8 -c32` for 120s after a 30s warmup over that mix (40% tracing / 20% receipts / 20% logs / 20% light, random blocks from an 88k-block window), same node and same base branch on both arms so this commit is the only variable:

| | `StackStream.WriteRawBytes` alloc | rps | p99 |
| --- | ---: | ---: | ---: |
| base | 9.27 GB (5.63% of all allocated bytes) | 79.9 | 2164ms |
| this | absent from the top 500 | 84.1 | 2042ms |

Context: this restores the write-through behaviour `stream.Write` had before #23488 swapped it for `WriteRawBytes` to make the late 503 possible. A response over `FlushThreshold` already commits its status via `flushIfFull` the moment this returns, so nothing that needed buffering loses it.

----

`WriteString` must escape its input. Pass-through works for `WriteRawBytes` only because the bytes are already valid JSON. WriteString would have to build the escaped form first — which is the buffer allocation you were trying to avoid.

