### PR TITLE
execution/types: fast-path JSON for the eth_getLogs result

### DIFF
--- a/execution/types/log_fastjson.go
+++ b/execution/types/log_fastjson.go
@@ -1,0 +1,126 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/common/length"
+)
+
+// quotedHexLen is the encoded size of n bytes as a quoted 0x-prefixed hex string.
+func quotedHexLen(n int) int { return len(`"0x"`) + 2*n }
+
+// maxQuotedUintLen bounds a quoted 0x-prefixed hex uint64.
+const maxQuotedUintLen = len(`"0x0123456789abcdef"`)
+
+func appendQuotedHex(dst []byte, b []byte) []byte {
+	dst = append(dst, '"')
+	dst, _ = hexutil.Bytes(b).AppendText(dst)
+	return append(dst, '"')
+}
+
+func appendQuotedUint64(dst []byte, v hexutil.Uint64) []byte {
+	dst = append(dst, '"')
+	dst, _ = v.AppendText(dst)
+	return append(dst, '"')
+}
+
+// fastJSONLen is an upper bound on the encoded size, so the buffer is allocated
+// once instead of doubling.
+func (l *RPCLog) fastJSONLen() int {
+	n := len(`{"address":,"topics":[],"data":,"blockNumber":,"transactionHash":,`) +
+		len(`"transactionIndex":,"blockHash":,"logIndex":,"removed":false,"blockTimestamp":}`)
+	n += quotedHexLen(length.Addr)
+	n += len(l.Topics) * (quotedHexLen(length.Hash) + 1)
+	n += quotedHexLen(len(l.Data))
+	n += 2 * quotedHexLen(length.Hash) // transactionHash, blockHash
+	n += 4 * maxQuotedUintLen          // blockNumber, transactionIndex, logIndex, blockTimestamp
+	return n
+}
+
+// appendFastJSON writes the log in the field order encoding/json uses for the
+// struct, so the output is byte-identical to reflection-based marshalling.
+func (l *RPCLog) appendFastJSON(dst []byte) []byte {
+	dst = append(dst, `{"address":`...)
+	dst = appendQuotedHex(dst, l.Address[:])
+
+	dst = append(dst, `,"topics":`...)
+	if l.Topics == nil {
+		dst = append(dst, "null"...)
+	} else {
+		dst = append(dst, '[')
+		for i := range l.Topics {
+			if i > 0 {
+				dst = append(dst, ',')
+			}
+			dst = appendQuotedHex(dst, l.Topics[i][:])
+		}
+		dst = append(dst, ']')
+	}
+
+	dst = append(dst, `,"data":`...)
+	dst = appendQuotedHex(dst, l.Data)
+	dst = append(dst, `,"blockNumber":`...)
+	dst = appendQuotedUint64(dst, l.BlockNumber)
+	dst = append(dst, `,"transactionHash":`...)
+	dst = appendQuotedHex(dst, l.TxHash[:])
+	dst = append(dst, `,"transactionIndex":`...)
+	dst = appendQuotedUint64(dst, hexutil.Uint64(l.TxIndex))
+	dst = append(dst, `,"blockHash":`...)
+	dst = appendQuotedHex(dst, l.BlockHash[:])
+	dst = append(dst, `,"logIndex":`...)
+	dst = appendQuotedUint64(dst, hexutil.Uint64(l.Index))
+	if l.Removed {
+		dst = append(dst, `,"removed":true`...)
+	} else {
+		dst = append(dst, `,"removed":false`...)
+	}
+	dst = append(dst, `,"blockTimestamp":`...)
+	dst = appendQuotedUint64(dst, l.BlockTimestamp)
+	return append(dst, '}')
+}
+
+// MarshalFastJSON serializes the eth_getLogs result into one pre-sized buffer
+// (direct hex encoding) instead of reflection. The count and each log's data
+// length are known up front, so the size is exact enough to allocate once.
+// Byte-identical to json.Marshal of the same value.
+func (logs RPCLogs) MarshalFastJSON() ([]byte, error) {
+	if logs == nil {
+		return []byte("null"), nil
+	}
+	size := len("[]")
+	for _, l := range logs {
+		if l == nil {
+			size += len("null,")
+			continue
+		}
+		size += l.fastJSONLen() + 1
+	}
+	out := make([]byte, 0, size)
+	out = append(out, '[')
+	for i, l := range logs {
+		if i > 0 {
+			out = append(out, ',')
+		}
+		if l == nil {
+			out = append(out, "null"...)
+			continue
+		}
+		out = l.appendFastJSON(out)
+	}
+	return append(out, ']'), nil
+}

--- a/execution/types/log_test.go
+++ b/execution/types/log_test.go
@@ -442,3 +442,86 @@ func TestToRPCLogsEmpty(t *testing.T) {
 		require.Len(t, rpcLogs, 0)
 	}
 }
+
+// MarshalFastJSON must be byte-identical to reflection-based json.Marshal,
+// since it replaces it on the eth_getLogs response path.
+func TestRPCLogsMarshalFastJSON(t *testing.T) {
+	t.Parallel()
+	mk := func(topics []common.Hash, data []byte, removed bool) *RPCLog {
+		return &RPCLog{
+			Log: Log{
+				Address:     common.HexToAddress("0xdAC17F958D2ee523a2206206994597C13D831ec7"),
+				Topics:      topics,
+				Data:        data,
+				BlockNumber: hexutil.Uint64(25880000),
+				TxHash:      common.HexToHash("0xaabb"),
+				TxIndex:     hexutil.Uint(7),
+				BlockHash:   common.HexToHash("0xccdd"),
+				Index:       hexutil.Uint(3),
+				Removed:     removed,
+			},
+			BlockTimestamp: hexutil.Uint64(1700000000),
+		}
+	}
+	topic := common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef")
+	maxed := mk(nil, nil, true)
+	maxed.BlockNumber = hexutil.Uint64(^uint64(0))
+	maxed.BlockTimestamp = hexutil.Uint64(^uint64(0))
+	maxed.Index = hexutil.Uint(^uint(0))
+
+	for name, logs := range map[string]RPCLogs{
+		"nil":          nil,
+		"empty":        {},
+		"nil-topics":   {mk(nil, []byte{1, 2, 3}, false)},
+		"empty-topics": {mk([]common.Hash{}, nil, false)},
+		"topics":       {mk([]common.Hash{topic, {}}, []byte{0xff}, false)},
+		"removed":      {mk([]common.Hash{topic}, nil, true)},
+		"maxed":        {maxed},
+		"nil-entry":    {nil, mk([]common.Hash{topic}, []byte{9}, false), nil},
+		"many":         {mk([]common.Hash{topic}, []byte{1}, false), mk(nil, nil, true)},
+	} {
+		t.Run(name, func(t *testing.T) {
+			want, err := json.Marshal(logs)
+			require.NoError(t, err)
+			got, err := logs.MarshalFastJSON()
+			require.NoError(t, err)
+			require.Equal(t, string(want), string(got))
+		})
+	}
+}
+
+func benchmarkLogs(n int) RPCLogs {
+	topic := common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef")
+	logs := make(RPCLogs, n)
+	for i := range logs {
+		logs[i] = &RPCLog{
+			Log: Log{
+				Address: common.HexToAddress("0xdAC17F958D2ee523a2206206994597C13D831ec7"),
+				Topics:  []common.Hash{topic, {}, {}},
+				Data:    make([]byte, 64),
+			},
+			BlockTimestamp: hexutil.Uint64(1700000000),
+		}
+	}
+	return logs
+}
+
+func BenchmarkRPCLogsMarshalReflect(b *testing.B) {
+	logs := benchmarkLogs(1000)
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := json.Marshal(logs); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkRPCLogsMarshalFast(b *testing.B) {
+	logs := benchmarkLogs(1000)
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := logs.MarshalFastJSON(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Draft. `RPCLogs.MarshalFastJSON` encodes the `eth_getLogs` result into one buffer sized from the log count, instead of reflection. `rpc/json.go` already routes through `fastJSONResult` when a result implements it; this follows the existing `BlobsBundle.MarshalFastJSON` pattern.

`BenchmarkRPCLogsMarshal*`, 1000 logs of 3 topics + 64B data:

| | ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| `json.Marshal` | 822586 | 718050 | 3 |
| `MarshalFastJSON` | 194529 | 745472 | 1 |

Byte-identity with `json.Marshal` is pinned by a table test over nil / empty / nil-topics / nil-entry / max-uint cases.

Open before this leaves draft: the size estimate assumes max width for every uint, so it over-allocates ~4%. Worth tightening, or dropping the estimate to the exact figure now that the encoder is explicit.
