### PR TITLE
db/kv/prune: check the progress-log ticker every 1024 keys, not per key

### DIFF
--- a/db/kv/prune/prune.go
+++ b/db/kv/prune/prune.go
@@ -60,6 +60,8 @@ const (
 	ValueOffset8StorageMode // txNum at val[8:16], used by TxLookup
 )
 
+const logPollEvery = 1024
+
 func HashSeekingPrune(
 	ctx context.Context,
 	name, filenameBase, tmp string,
@@ -147,13 +149,15 @@ func HashSeekingPrune(
 		}
 		stat.PruneCountValues++
 
-		select {
-		case <-logEvery.C:
-			txNum := binary.BigEndian.Uint64(txnm)
-			logger.Info("[snapshots] prune index", "name", filenameBase, "prunedTx", stat.PruneCountTx,
-				"prunedValues", stat.PruneCountValues,
-				"steps", fmt.Sprintf("%.2f-%.2f", float64(txFrom)/float64(stepSize), float64(txNum)/float64(stepSize)))
-		default:
+		if stat.PruneCountValues%logPollEvery == 0 {
+			select {
+			case <-logEvery.C:
+				txNum := binary.BigEndian.Uint64(txnm)
+				logger.Info("[snapshots] prune index", "name", filenameBase, "prunedTx", stat.PruneCountTx,
+					"prunedValues", stat.PruneCountValues,
+					"steps", fmt.Sprintf("%.2f-%.2f", float64(txFrom)/float64(stepSize), float64(txNum)/float64(stepSize)))
+			default:
+			}
 		}
 		return nil
 	}, etl.TransformArgs{Quit: ctx.Done()})
@@ -326,6 +330,7 @@ func tableScanningPrune(
 	if err != nil {
 		return nil, fmt.Errorf("cursor position %s: %w", filenameBase, err)
 	}
+	var polls int
 	for ; val != nil; val, txNumBytes, err = valDelCursor.NextNoDup() {
 		if err != nil {
 			return nil, fmt.Errorf("iterate over %s index keys: %w", filenameBase, err)
@@ -434,15 +439,18 @@ func tableScanningPrune(
 		}
 	nextKey:
 
-		select {
-		case <-logEvery.C:
-			args := []any{"name", filenameBase, "scanned keys", stat.ScanCountKeys, "pruned values", stat.PruneCountValues}
-			if keysCursor != nil {
-				args = append(args, "pruned tx", stat.PruneCountTx)
+		polls++
+		if polls%logPollEvery == 0 {
+			select {
+			case <-logEvery.C:
+				args := []any{"name", filenameBase, "scanned keys", stat.ScanCountKeys, "pruned values", stat.PruneCountValues}
+				if keysCursor != nil {
+					args = append(args, "pruned tx", stat.PruneCountTx)
+				}
+				args = append(args, "val status", stat.ValueProgress.String())
+				logger.Info("[snapshots] prune index", args...)
+			default:
 			}
-			args = append(args, "val status", stat.ValueProgress.String())
-			logger.Info("[snapshots] prune index", args...)
-		default:
 		}
 	}
 


### PR DESCRIPTION
The table-scanning prune runs a non-blocking `select` on the progress-log ticker once per scanned key. On a hoodi node the step-boundary history prune of 40.88M commitment values took 12.26 s, and 0.94 s of that (7.7%, `runtime.selectnbrecv` under `prune.tableScanningPrune` in a 30 s CPU profile) was that select. The ticker fires once per interval, so the other polls found nothing.

## Changes
- `tableScanningPrune`: check `logEvery.C` on every 1024th visit to the poll site, counted at the poll site itself. A key entirely outside the prune range `continue`s past the site, so a counter that advances on every iteration could starve the check; a local counter cannot.
- `HashSeekingPrune` load func: the same guard on `stat.PruneCountValues`.

## Notes
Deletion, statistics, resume points, throttling and ctx handling are untouched. A progress line still appears at most once per ticker interval; it can now land up to 1023 keys late, under a millisecond at the 3.3M keys/s of the profiled prune. No test: the change is log cadence only, nothing observable besides when a log line lands.
