### PR TITLE
execution/tracing/tracers/native: stream callFrame under encoding/json v2

### DIFF
--- a/execution/tracing/tracers/native/call_jsonv2.go
+++ b/execution/tracing/tracers/native/call_jsonv2.go
@@ -1,0 +1,102 @@
+//go:build go1.27
+
+package native
+
+import (
+	"encoding/json/jsontext"
+	jsonv2 "encoding/json/v2"
+
+	"github.com/erigontech/erigon/common/hexutil"
+)
+
+// callFrame must keep satisfying MarshalerTo: json/v2 silently falls back to the
+// generated MarshalJSON if the signature ever drifts, and the only symptom would
+// be the allocation regression coming back.
+var _ jsonv2.MarshalerTo = callFrame{}
+
+// MarshalJSONTo streams the frame straight into the encoder. encoding/json/v2
+// prefers it over MarshalJSON, which returns a []byte that v2 then has to
+// re-parse and re-emit — a cost paid once per nesting level, since frames nest.
+// Output is byte-identical to the generated MarshalJSON, which older toolchains
+// keep using.
+func (c callFrame) MarshalJSONTo(enc *jsontext.Encoder) error {
+	if err := enc.WriteToken(jsontext.BeginObject); err != nil {
+		return err
+	}
+	// buf keeps the hex scalars off the heap; every one of them fits.
+	var buf [80]byte
+	name := func(n string) error { return enc.WriteToken(jsontext.String(n)) }
+	// hexField writes a 0x-quoted scalar without boxing it into an interface.
+	hexField := func(n string, appendText func([]byte) ([]byte, error)) error {
+		if err := name(n); err != nil {
+			return err
+		}
+		v := append(buf[:0], '"')
+		v, err := appendText(v)
+		if err != nil {
+			return err
+		}
+		return enc.WriteValue(append(v, '"'))
+	}
+	strField := func(n, v string) error {
+		if err := name(n); err != nil {
+			return err
+		}
+		return enc.WriteToken(jsontext.String(v))
+	}
+	field := func(n string, v any) error {
+		if err := name(n); err != nil {
+			return err
+		}
+		return jsonv2.MarshalEncode(enc, v)
+	}
+	if err := hexField("from", c.From.AppendText); err != nil {
+		return err
+	}
+	if err := hexField("gas", hexutil.Uint64(c.Gas).AppendText); err != nil {
+		return err
+	}
+	if err := hexField("gasUsed", hexutil.Uint64(c.GasUsed).AppendText); err != nil {
+		return err
+	}
+	if err := hexField("to", c.To.AppendText); err != nil {
+		return err
+	}
+	if err := field("input", hexutil.Bytes(c.Input)); err != nil {
+		return err
+	}
+	if len(c.Output) > 0 {
+		if err := field("output", hexutil.Bytes(c.Output)); err != nil {
+			return err
+		}
+	}
+	if c.Error != "" {
+		if err := strField("error", c.Error); err != nil {
+			return err
+		}
+	}
+	if c.Revertal != "" {
+		if err := strField("revertReason", c.Revertal); err != nil {
+			return err
+		}
+	}
+	if len(c.Calls) > 0 {
+		if err := field("calls", c.Calls); err != nil {
+			return err
+		}
+	}
+	if len(c.Logs) > 0 {
+		if err := field("logs", c.Logs); err != nil {
+			return err
+		}
+	}
+	if c.Value != nil {
+		if err := hexField("value", (*hexutil.Big)(c.Value).AppendText); err != nil {
+			return err
+		}
+	}
+	if err := strField("type", c.TypeString()); err != nil {
+		return err
+	}
+	return enc.WriteToken(jsontext.EndObject)
+}

--- a/execution/tracing/tracers/native/call_jsonv2_test.go
+++ b/execution/tracing/tracers/native/call_jsonv2_test.go
@@ -1,0 +1,121 @@
+//go:build go1.27
+
+package native
+
+import (
+	"encoding/json"
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/vm"
+	"github.com/stretchr/testify/require"
+)
+
+func mkFrame(depth, width int) callFrame {
+	f := callFrame{
+		Type: vm.CALL, From: common.HexToAddress("0xdAC17F958D2ee523a2206206994597C13D831ec7"),
+		Gas: 21000, GasUsed: 12345, To: common.HexToAddress("0x1111111111111111111111111111111111111111"),
+		Input: make([]byte, 128), Output: make([]byte, 64), Value: big.NewInt(1e18),
+		Logs: []callLog{{Index: 1, Address: common.HexToAddress("0x2222222222222222222222222222222222222222"),
+			Topics: []common.Hash{common.HexToHash("0xaa"), {}}, Data: make([]byte, 96), Position: 0}},
+	}
+	if depth > 0 {
+		for i := 0; i < width; i++ {
+			f.Calls = append(f.Calls, mkFrame(depth-1, width))
+		}
+	}
+	return f
+}
+
+// fillNonZero sets every field of v to a non-zero value, recursing into structs
+// and allocating one element for slices and pointers. A field added to callFrame
+// is therefore populated automatically, without anyone remembering to extend a
+// fixture.
+func fillNonZero(t *testing.T, v reflect.Value, depth int) {
+	t.Helper()
+	switch v.Kind() {
+	case reflect.Struct:
+		for i := range v.NumField() {
+			if v.Type().Field(i).IsExported() {
+				fillNonZero(t, v.Field(i), depth)
+			}
+		}
+	case reflect.Slice:
+		if depth <= 0 { // callFrame.Calls recurses; stop before it blows the stack
+			return
+		}
+		v.Set(reflect.MakeSlice(v.Type(), 1, 1))
+		fillNonZero(t, v.Index(0), depth-1)
+	case reflect.Pointer:
+		if depth <= 0 {
+			return
+		}
+		v.Set(reflect.New(v.Type().Elem()))
+		fillNonZero(t, v.Elem(), depth-1)
+	case reflect.Array:
+		for i := range v.Len() {
+			fillNonZero(t, v.Index(i), depth)
+		}
+	case reflect.String:
+		v.SetString("x")
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		v.SetUint(7)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v.SetInt(7)
+	case reflect.Bool:
+		v.SetBool(true)
+	}
+}
+
+// MarshalJSONTo must be byte-identical to the generated MarshalJSON. The frame is
+// filled by reflection rather than by hand, so adding a field to callFrame without
+// teaching MarshalJSONTo about it fails here instead of silently changing the RPC
+// output under go1.27.
+func TestCallFrameMarshalJSONToMatchesGenerated(t *testing.T) {
+	var filled callFrame
+	fillNonZero(t, reflect.ValueOf(&filled).Elem(), 2)
+
+	for name, f := range map[string]callFrame{
+		"every-field-set": filled,
+		"zero":            {},
+		"revert":          {Error: "execution reverted", Revertal: "boom", Output: []byte{1, 2}},
+		"deep":            mkFrame(3, 2),
+	} {
+		t.Run(name, func(t *testing.T) {
+			want, err := f.MarshalJSON()
+			require.NoError(t, err)
+			got, err := json.Marshal(f)
+			require.NoError(t, err)
+			require.Equal(t, string(want), string(got))
+		})
+	}
+}
+
+// Every exported field of callFrame must be reachable by the reflection fill, so
+// the guard above cannot be defeated by a field kind it silently skips.
+func TestFillNonZeroTouchesEveryCallFrameField(t *testing.T) {
+	var filled callFrame
+	fillNonZero(t, reflect.ValueOf(&filled).Elem(), 2)
+	rv := reflect.ValueOf(filled)
+	for i := range rv.NumField() {
+		f := rv.Type().Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		require.False(t, rv.Field(i).IsZero(), "field %s left zero; fillNonZero needs to handle %s", f.Name, f.Type)
+	}
+}
+
+func BenchmarkCallFrameMarshalJSONTo(b *testing.B) {
+	f := mkFrame(5, 3) // 364 frames, ~ a real trace tree
+	raw, _ := json.Marshal(f)
+	b.SetBytes(int64(len(raw)))
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := json.Marshal(f); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Draft — prototype, measured, looking for a view on whether it is worth carrying.

Go 1.27 makes `encoding/json` v2-backed by default (`go list -deps` pulls in `encoding/json/v2` and `jsontext` with no `GOEXPERIMENT` set), so this lands on us at the next toolchain bump whether or not anyone opts in.

v2 handles a type implementing `MarshalJSON() ([]byte, error)` by calling it and pushing the returned bytes through `Encoder.WriteValue`, which re-parses and re-emits them. `callFrame` nests (`Calls []callFrame`), so a nested frame's JSON is built as bytes, re-scanned by its parent, and that result re-scanned by its parent — once per level.

Measured on n0, mainnet, `--prune.mode=minimal`, 120s of mixed tracing load, same commit both arms, only the toolchain differing:

| | go1.26.7 | go1.27.1 |
| --- | ---: | ---: |
| total alloc_space | 128.46 GB | **189.07 GB** |
| `hexutil.Bytes.MarshalText` | 8.00 GB | gone (AppendText now reachable) |
| `jsontext.reformatValue` | — | 25.39 GB |
| `slices.Grow[[]uint8]` | — | 25.15 GB |
| `bytes.Clone` | — | 23.07 GB |

`MarshalJSONTo` streams straight into the encoder, so there is no intermediate `[]byte` and no reformat. `BenchmarkCallFrameMarshalJSONTo`, a 364-frame tree (~380KB of JSON):

| | ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| falls back to `MarshalJSON` | 1806880 | 7061026 | 1247 |
| `MarshalJSONTo` | **452966** | **478723** | 3157 |

4.0x faster, 14.7x less memory. Allocation *count* goes up 2.5x — streaming writes many small tokens instead of a few large buffers — which is the right trade here since the regression is in bytes, but worth knowing.

This is the pattern the Go team recommends, not an invention here. From the `encoding/json/v2` docs on `MarshalerTo`:

> It is recommended that types implement MarshalerTo instead of Marshaler since it is both more performant and more flexible. If a type implements both Marshaler and MarshalerTo, then MarshalerTo takes precedence. In such a case, both implementations should aim to have equivalent behavior for the default marshal options.

Carrying both is therefore expected; keeping them equivalent is the part that needs enforcing, hence the reflection-based guard below rather than hand-written fixtures.

The go1.27 release notes say Marshal performance is "broadly at parity" with the old implementation. That holds for types without a custom marshaler — our `hexutil` types actually get faster, since `AppendText` finally becomes reachable. It does not hold for a recursive type with a `MarshalJSON`, which is what this fixes.

### Prior art, and an alternative worth considering

There is no jsonv2-aware code generator: `gencodec` and `easyjson` emit `MarshalJSON` only, and a GitHub code search for `MarshalJSONTo` turns up hand-written implementations exclusively. Adopters so far include open-policy-agent/opa, tailscale, microsoft/TypeScript (tsgo) and DataDog/datadog-agent.

OPA solves the two-implementations problem more cleanly than this PR does. They pair `location_json.go` (`//go:build !go1.27`) with `location_jsonv2.go` (`//go:build go1.27`), and in the latter the v1 method delegates:

```go
func (loc *Location) MarshalJSON() ([]byte, error) {
	return jsonv2.MarshalMarshalerTo(loc)
}
```

On go1.27 there is then exactly one implementation and drift is impossible by construction.

That does not port directly here, because our v1 marshaler is generated: putting `//go:build !go1.27` on `gen_callframe_json.go` would be dropped by the next `make gen`. So this PR keeps both live and enforces equivalence with a test instead. If reviewers prefer the OPA shape, the cost is dropping `callFrame` from gencodec and hand-writing the pre-1.27 marshaler too — happy to switch.

Notes:

- `//go:build go1.27` gates the file. Verified `call_jsonv2.go` is excluded under go1.26.7 (package still builds) and included under go1.27.1, so this is a no-op for current toolchains and needs no `go.mod` change.
- Output is byte-identical to the generated `MarshalJSON`, pinned by a test that fills every field of `callFrame` by reflection rather than by hand, so a field added later is populated automatically and the mismatch fails the test. Verified by adding a field and watching it go red. A second test asserts the reflection fill leaves no exported field zero, so the guard cannot be defeated by a field kind it silently skips.
- New test file rather than appending to an existing one, because the build tag would otherwise gate unrelated tests behind go1.27.
- `callFrame` is the worst case because it recurses. The same pattern applies to every `gen_*_json.go` type on the response path (`types.Header`, `Log`, receipts); those are flat and cheaper, and I would measure before porting them.

