### PR TITLE
downloader: report kept-local seeding dropped by shutdown

### DIFF
--- a/db/downloader/download-batch.go
+++ b/db/downloader/download-batch.go
@@ -120,9 +120,9 @@ func (me *downloadBatch) doMetainfoTask(task func() func()) {
 
 var errBatchEnded = errors.New("download batch ended")
 
-// end joins the batch and returns the cause it ended with. Queued seeding is dropped only when ctx
-// goes away, including a cancel arriving during the join, which is why the cause is read after it.
-// A batch that failed for its own reasons still seeds what it holds.
+// end joins the batch and returns the cause it ended with. Queued seeding is dropped only by a
+// cancel from outside the batch, including one arriving during the join, which is why the cause is
+// read after it. A batch that failed for its own reasons still seeds what it holds.
 func (me *downloadBatch) end(ctx context.Context, cause error) error {
 	me.ended.Do(func() {
 		ended := cmp.Or(cause, errBatchEnded)
@@ -137,6 +137,11 @@ func (me *downloadBatch) end(ctx context.Context, cause error) error {
 		}
 		me.d.decDownloadRequests()
 	})
+	if me.seedDropped.Load() > 0 {
+		// seedCtx hangs off d.ctx, so a shutdown drops seeding without the caller's ctx ever
+		// showing it, and the caller is told a batch that seeded nothing succeeded.
+		return cmp.Or(cause, context.Cause(ctx), context.Cause(me.seedCtx))
+	}
 	return cmp.Or(cause, context.Cause(ctx))
 }
 

--- a/db/downloader/downloader_test.go
+++ b/db/downloader/downloader_test.go
@@ -979,13 +979,13 @@ func TestGoSeedCountsCancelAfterStart(t *testing.T) {
 		"a cancel arriving after the task started must still count as a drop")
 }
 
-// goSeed waits on seedCtx, not the batch's own cancellation, so cancelling the batch alone must
-// not drop seed work still queued behind a full semaphore — it must all eventually run.
+// A batch that succeeds drops nothing: seed work queued behind a full semaphore must all still run
+// once the bound frees up. That goSeed waits on seedCtx rather than the batch's own cancellation is
+// pinned by TestKeptLocalSeedingSurvivesTorrentClosed, which drives the real end/wait path.
 func TestGoSeedRunsAllOnSuccess(t *testing.T) {
 	require := require.New(t)
 	const limit = 2
 	batch := &downloadBatch{d: &Downloader{seedSem: semaphore.NewWeighted(limit)}}
-	_, batch.cancel = context.WithCancelCause(context.Background())
 	batch.seedCtx, batch.seedCancel = context.WithCancelCause(context.Background())
 	defer batch.seedCancel(nil)
 
@@ -1006,7 +1006,6 @@ func TestGoSeedRunsAllOnSuccess(t *testing.T) {
 	require.Eventually(func() bool { return started.Load() == limit }, time.Second, time.Millisecond,
 		"only %d of %d tasks should be able to run concurrently", limit, n)
 
-	batch.cancel(nil)
 	closeRelease()
 
 	done := make(chan struct{})
@@ -1271,6 +1270,52 @@ func TestKeptLocalSeedingReportsCancelDuringJoin(t *testing.T) {
 			"seeding dropped mid-join must not report success, or the caller publishes chain.toml for it")
 	case <-time.After(30 * time.Second):
 		t.Fatal("wait did not return after the caller cancelled")
+	}
+}
+
+// Seeding hangs off d.ctx, so Downloader.Close drops it while the caller's context is still live.
+// wait reads only the caller's context, so that drop must reach the result some other way.
+func TestKeptLocalSeedingReportsDownloaderShutdown(t *testing.T) {
+	require := require.New(t)
+	d := newDownloaderTest(t).downloader
+	markInitialDownloadComplete(t, d)
+	d.seedSem = semaphore.NewWeighted(1)
+	d.incDownloadRequests()
+
+	// Hold the only slot so every goSeed task is parked in Acquire for the whole join.
+	require.NoError(d.seedSem.Acquire(context.Background(), 1))
+	defer d.seedSem.Release(1)
+
+	_, names := writeKeptLocalSnapshots(t, d, 2, 64)
+
+	// No torrents: wait's loop returns at once, so the shutdown below lands inside end()'s join.
+	batch := &downloadBatch{d: d}
+	_, batch.cancel = context.WithCancelCause(d.ctx)
+	batch.seedCtx, batch.seedCancel = context.WithCancelCause(d.ctx)
+	for _, name := range names {
+		batch.goSeed(func() error { return d.seedKeptSnapshot(batch.seedCtx, name) })
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- batch.wait(t.Context()) }()
+
+	require.Never(func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, 100*time.Millisecond, time.Millisecond, "wait must still be joining the parked seed tasks")
+
+	d.stop()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(err, context.Canceled,
+			"seeding dropped by shutdown must not report success to a caller whose context is still live")
+	case <-time.After(30 * time.Second):
+		t.Fatal("wait did not return after the downloader stopped")
 	}
 }
 

--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -91,20 +91,11 @@ func (api *APIImpl) Call(ctx context.Context, args ethapi2.CallArgs, requestedBl
 		return nil, err
 	}
 
-	roTx, err := api.db.BeginTemporalRo(ctx)
+	tx, err := api.filters.BeginTemporalRoWithOverlay(ctx, api.db)
 	if err != nil {
 		return nil, err
 	}
-	defer roTx.Rollback()
-
-	var tx kv.TemporalTx = roTx
-	if api.filters != nil {
-		if sd := api.filters.LatestSD(); sd != nil {
-			if overlayTx := sd.BlockOverlayTemporalTx(roTx); overlayTx != nil {
-				tx = overlayTx
-			}
-		}
-	}
+	defer tx.Rollback()
 
 	chainConfig, err := api.chainConfig(ctx, tx)
 	if err != nil {

--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -120,7 +120,7 @@ func (api *APIImpl) Call(ctx context.Context, args ethapi2.CallArgs, requestedBl
 		return nil, err
 	}
 
-	err = rpchelper.CheckBlockExecuted(api.filters.WithOverlay(tx), header.Number.Uint64())
+	err = rpchelper.CheckBlockExecuted(tx, header.Number.Uint64())
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/jsonrpc/graphql_api.go
+++ b/rpc/jsonrpc/graphql_api.go
@@ -428,7 +428,7 @@ func (api *GraphQLAPIImpl) Call(ctx context.Context, blockNumber rpc.BlockNumber
 		return nil, err
 	}
 
-	if err := rpchelper.CheckBlockExecuted(api.filters.WithOverlay(tx), header.Number.Uint64()); err != nil {
+	if err := rpchelper.CheckBlockExecuted(tx, header.Number.Uint64()); err != nil {
 		return nil, err
 	}
 

--- a/rpc/jsonrpc/graphql_api.go
+++ b/rpc/jsonrpc/graphql_api.go
@@ -401,20 +401,11 @@ func (api *GraphQLAPIImpl) Call(ctx context.Context, blockNumber rpc.BlockNumber
 		return nil, err
 	}
 
-	roTx, err := api.db.BeginTemporalRo(ctx)
+	tx, err := api.filters.BeginTemporalRoWithOverlay(ctx, api.db)
 	if err != nil {
 		return nil, err
 	}
-	defer roTx.Rollback()
-
-	var tx kv.TemporalTx = roTx
-	if api.filters != nil {
-		if sd := api.filters.LatestSD(); sd != nil {
-			if overlayTx := sd.BlockOverlayTemporalTx(roTx); overlayTx != nil {
-				tx = overlayTx
-			}
-		}
-	}
+	defer tx.Rollback()
 
 	chainConfig, err := api.chainConfig(ctx, tx)
 	if err != nil {

--- a/rpc/jsonrpc/overlay_race_test.go
+++ b/rpc/jsonrpc/overlay_race_test.go
@@ -2372,3 +2372,23 @@ func TestGraphQLGetBlockDetails_PinsOverlayView(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, details)
 }
+
+// TestCall_PublishCycleDuringTxAcquisition pins that eth_call acquires
+// (tx, overlay) atomically: a publish/commit/unpublish cycle landing between
+// the tx open and the overlay capture leaves the head block visible in neither
+// layer, so the call would resolve against a snapshot that predates the commit.
+func TestCall_PublishCycleDuringTxAcquisition(t *testing.T) {
+	t.Parallel()
+	h := newOverlayAheadHarness(t, false)
+	h.events.PublishOverlay(nil)
+	h.doms.Close()
+
+	db := newCycleHookDB(h, true)
+	api := newEthApiForTest(h.base, db, nil, nil)
+
+	to := common.HexToAddress("0x0d3ab14bbad3d99f4203bd7a11acb94882050e7e")
+	blockNr := rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(h.overlayHeader.Number.Uint64()))
+	_, err := api.Call(h.m.Ctx, ethapi.CallArgs{From: &h.m.Address, To: &to}, &blockNr, nil, nil)
+	require.NoError(t, err,
+		"a publish/commit/unpublish cycle during tx acquisition must not hide the head block")
+}

--- a/rpc/jsonrpc/overlay_race_test.go
+++ b/rpc/jsonrpc/overlay_race_test.go
@@ -2392,3 +2392,23 @@ func TestCall_PublishCycleDuringTxAcquisition(t *testing.T) {
 	require.NoError(t, err,
 		"a publish/commit/unpublish cycle during tx acquisition must not hide the head block")
 }
+
+// TestGraphQLCall_PublishCycleDuringTxAcquisition is the GraphQL twin of
+// TestCall_PublishCycleDuringTxAcquisition: the same handler shape, so the
+// same torn (tx, overlay) acquisition hides the head block.
+func TestGraphQLCall_PublishCycleDuringTxAcquisition(t *testing.T) {
+	t.Parallel()
+	h := newOverlayAheadHarness(t, false)
+	h.events.PublishOverlay(nil)
+	h.doms.Close()
+
+	db := newCycleHookDB(h, true)
+	api := NewGraphQLAPI(h.base, db, newEthApiForTest(h.base, db, nil, nil), nil,
+		&rpccfg.GraphQLApiConfig{GasCap: 50_000_000})
+
+	to := common.HexToAddress("0x0d3ab14bbad3d99f4203bd7a11acb94882050e7e")
+	_, err := api.Call(h.m.Ctx, rpc.BlockNumber(h.overlayHeader.Number.Uint64()),
+		ethapi.CallArgs{From: &h.m.Address, To: &to})
+	require.NoError(t, err,
+		"a publish/commit/unpublish cycle during tx acquisition must not hide the head block")
+}


### PR DESCRIPTION
A batch that seeded nothing reported success. `end` returns `cmp.Or(cause, context.Cause(ctx))`, but `seedCtx` is a `d.ctx` child — `Downloader.Close` drops queued seeding without the caller's `ctx` ever showing it. An all-kept-local batch has no torrents, so `wait`'s loop never samples `ctx` either, and the RPC caller is told the download succeeded.

`end` already counts the drops; it now returns `seedCtx`'s cause when there are any. Consequence of the bug: a kept file whose derivation was dropped is missing from a chain.toml written at shutdown. Recovered on the next start, so this is minor.

Also drops the dead `batch.cancel(nil)` from `TestGoSeedRunsAllOnSuccess` — the test built a context it discarded, so the line cancelled something no production code reads, and the assertion held identically without it. The comment now names what is asserted.

Found by awskii on [#23446](https://github.com/erigontech/erigon/pull/23446).