### PR TITLE
execution/commitment: deep-fold storage whose account record is not in the round

### DIFF
--- a/execution/commitment/deepfold_test.go
+++ b/execution/commitment/deepfold_test.go
@@ -975,6 +975,40 @@ func buildStorageOnlyWhale(seed int64, wide, touch []byte, perNibble1, perNibble
 	return k1, u1, k2, u2
 }
 
+func FuzzParallelStorageOnlyEquivalence(f *testing.F) {
+	f.Add(int64(20260902), uint16(60), uint16(350), uint8(2))
+	f.Add(int64(0xB2), uint16(20), uint16(140), uint8(3))
+	f.Add(int64(0xC3), uint16(8), uint16(40), uint8(1))
+	f.Add(int64(0xD4), uint16(48), uint16(200), uint8(4))
+
+	f.Fuzz(func(t *testing.T, seed int64, per1, per2 uint16, nibCount uint8) {
+		perNibble1 := int(per1%32) + 1
+		perNibble2 := int(per2%192) + 1
+		nibbleCount := int(nibCount%3) + 2
+		wide := make([]byte, 0, nibbleCount)
+		for i := range nibbleCount {
+			wide = append(wide, byte(i*4))
+		}
+
+		k1, u1, k2, u2 := buildStorageOnlyWhale(seed, wide, wide, perNibble1, perNibble2)
+		for _, u := range u2 {
+			require.Equal(t, StorageUpdate, u.Flags, "batch 2 must carry storage writes only")
+		}
+
+		seqRoot, _ := incrementalRoot(t, modeSeq, 0, k1, u1, k2, u2)
+
+		ms := NewMockState(t)
+		ms.SetConcurrentCommitment(true)
+		_, blob, _ := parallelBatchDeepFolds(t, ms, 4, k1, u1, nil)
+		parRoot, _, deepFolds := parallelBatchDeepFolds(t, ms, 4, k2, u2, blob)
+		require.Equal(t, seqRoot, parRoot)
+		if len(k2) > deepStorageThreshold {
+			require.NotZero(t, deepFolds,
+				"a storage-only round of %d slots over %d nibbles must deep-fold", len(k2), nibbleCount)
+		}
+	})
+}
+
 func TestDeepFold_StorageOnlyWhaleFoldsParallel(t *testing.T) {
 	k1, u1, k2, u2 := buildStorageOnlyWhale(20260902, nibs(3, 7), nibs(3, 7), 60, 350)
 	fk, fu := buildMixedCorpus(557, 200)

--- a/execution/commitment/deepfold_test.go
+++ b/execution/commitment/deepfold_test.go
@@ -929,3 +929,69 @@ func TestKeyArena_ChunkSizedFromRemaining(t *testing.T) {
 		require.Equal(t, keyLen, cap(arena.buf))
 	})
 }
+
+func buildStorageOnlyWhale(seed int64, wide, touch []byte, perNibble1, perNibble2 int) (k1 [][]byte, u1 []Update, k2 [][]byte, u2 []Update) {
+	rnd := rand.New(rand.NewSource(seed))
+	addr := make([]byte, length.Addr)
+	rnd.Read(addr)
+	a := hex.EncodeToString(addr)
+
+	firstStorageNibble := func(loc []byte) byte {
+		pk := make([]byte, 0, length.Addr+len(loc))
+		pk = append(pk, addr...)
+		pk = append(pk, loc...)
+		return KeyToHexNibbleHash(pk)[64]
+	}
+	genSlot := func(want byte) (string, string) {
+		for {
+			loc := make([]byte, length.Hash)
+			rnd.Read(loc)
+			if firstStorageNibble(loc) == want {
+				val := make([]byte, 32)
+				rnd.Read(val)
+				return hex.EncodeToString(loc), hex.EncodeToString(val)
+			}
+		}
+	}
+
+	ub1 := NewUpdateBuilder()
+	ub1.Balance(a, 1)
+	for _, n := range wide {
+		for range perNibble1 {
+			l, v := genSlot(n)
+			ub1.Storage(a, l, v)
+		}
+	}
+	k1, u1 = ub1.Build()
+
+	ub2 := NewUpdateBuilder()
+	for _, n := range touch {
+		for range perNibble2 {
+			l, v := genSlot(n)
+			ub2.Storage(a, l, v)
+		}
+	}
+	k2, u2 = ub2.Build()
+	return k1, u1, k2, u2
+}
+
+func TestDeepFold_StorageOnlyWhaleFoldsParallel(t *testing.T) {
+	k1, u1, k2, u2 := buildStorageOnlyWhale(20260902, nibs(3, 7), nibs(3, 7), 60, 350)
+	fk, fu := buildMixedCorpus(557, 200)
+	k1 = append(append([][]byte{}, fk...), k1...)
+	u1 = append(append([]Update{}, fu...), u1...)
+
+	for _, u := range u2 {
+		require.Equal(t, StorageUpdate, u.Flags, "batch 2 must carry storage writes only")
+	}
+
+	seqRoot, _ := incrementalRoot(t, modeSeq, 0, k1, u1, k2, u2)
+
+	ms := NewMockState(t)
+	ms.SetConcurrentCommitment(true)
+	_, blob, _ := parallelBatchDeepFolds(t, ms, 4, k1, u1, nil)
+	parRoot, _, deepFolds := parallelBatchDeepFolds(t, ms, 4, k2, u2, blob)
+	require.Equal(t, seqRoot, parRoot)
+	require.Equal(t, uint64(1), deepFolds,
+		"an account whose record is not in the round must still deep-fold its storage")
+}

--- a/execution/commitment/streaming_deep_fold.go
+++ b/execution/commitment/streaming_deep_fold.go
@@ -83,26 +83,53 @@ func foldStorageLeaf(ctx context.Context, w *HexPatriciaHashed, base *HexPatrici
 	return w.foldMounted(ctx, nib)
 }
 
-func isDeepStorageAccount(node *prefixNode, depth int) bool {
-	return depth == 64 && node.plainKey != nil &&
-		bits.OnesCount16(node.bitmap) >= 2 && node.subtreeCount > deepStorageThreshold
+func isDeepStorageSubtree(node *prefixNode, depth int) bool {
+	return depth == 64 && bits.OnesCount16(node.bitmap) >= 2 && node.subtreeCount > deepStorageThreshold
+}
+
+func storageSubtreeAccountKey(node *prefixNode, accountKeyLen int16) []byte {
+	for n := node; n != nil; {
+		if n.plainKey != nil {
+			if int16(len(n.plainKey)) <= accountKeyLen {
+				return nil
+			}
+			return n.plainKey[:accountKeyLen]
+		}
+		if len(n.children) == 0 {
+			return nil
+		}
+		n = n.children[0]
+	}
+	return nil
 }
 
 func dfsSubtreeDeep(w *HexPatriciaHashed, node *prefixNode, path []byte, storageRoot func(node *prefixNode, path []byte, accountFresh bool) (cell, error)) error {
 	if node == nil {
 		return nil
 	}
+	deepStorage := isDeepStorageSubtree(node, len(path))
+	var accountKey []byte
+	var accountUpdate *Update
+	switch {
+	case node.plainKey != nil:
+		accountKey, accountUpdate = node.plainKey, node.update
+	case node.bitmap == 0:
+		return errors.New("commitment: trie leaf without a plainKey")
+	case deepStorage:
+		if accountKey = storageSubtreeAccountKey(node, w.accountKeyLen); accountKey == nil {
+			return fmt.Errorf("commitment: storage subtree at %x carries no storage plain key", path)
+		}
+	}
+
 	accountFresh := false
-	if node.plainKey != nil {
-		if err := w.followAndUpdate(path, node.plainKey, node.update); err != nil {
+	if accountKey != nil {
+		if err := w.followAndUpdate(path, accountKey, accountUpdate); err != nil {
 			return err
 		}
 		accountFresh = w.lastUpdateCellWasEmpty
-	} else if node.bitmap == 0 {
-		return errors.New("commitment: trie leaf without a plainKey")
 	}
 
-	if isDeepStorageAccount(node, len(path)) {
+	if deepStorage {
 		sr, err := storageRoot(node, path, accountFresh)
 		if err == nil {
 			setAccountStorageRoot(w, path, sr)


### PR DESCRIPTION
The concurrent deep storage fold only ran when the account node itself carried a plain key. `isDeepStorageAccount` required `node.plainKey != nil`, and `dfsSubtreeDeep` only positioned the worker from `node.plainKey`, so a storage-only second batch for an existing account could arrive at depth 64 as a keyless account subtree and miss the deep-fold path even when it spanned multiple storage nibbles and exceeded `deepStorageThreshold`.

A depth-64 subtree with at least two child nibbles and more than `deepStorageThreshold` entries now qualifies independently of `node.plainKey`. When the account key is absent at the account node, `dfsSubtreeDeep` derives it from the first descendant storage plain key, passes a nil update to `followAndUpdate`, and deep-folds the storage root.

## Changes
- `isDeepStorageAccount` becomes `isDeepStorageSubtree` and drops the account-key requirement; `storageSubtreeAccountKey` derives the account key by slicing the first descendant storage plain key to `w.accountKeyLen`; `dfsSubtreeDeep` positions a keyless node before the deep fold.
- `dfsSubtreeDeep` now returns `commitment: storage subtree at %x carries no storage plain key` when a deep-storage candidate has no descendant storage plain key to derive from.
- `buildStorageOnlyWhale` builds a two-batch account shape: batch 1 writes the account balance and wide storage, and batch 2 writes storage only across selected first storage nibbles.
- `TestDeepFold_StorageOnlyWhaleFoldsParallel`: an existing account with an on-disk storage branch, then a 700-slot storage-only round; root equal to the serial engine and one deep fold (zero before this change).
- `FuzzParallelStorageOnlyEquivalence`: the same two-batch shape under the fuzzer - batch 1 creates the account, batch 2 touches storage only - asserting root parity against the serial engine and that a round above the threshold actually deep-folds. `FuzzParallelEquivalence` cannot reach this path by construction: `shapeStorageHeavySingle` is its only single-account storage shape and it always seeds the account first, so it never generates a keyless node. Reverting this PR's `streaming_deep_fold.go` change reddens two of the four seeds on "must deep-fold". 137k execs clean.

## Notes
The fuzz shapes are constrained to >=2 storage nibbles, which is what the keyless path requires (`OnesCount16(bitmap) >= 2` at the account node). A single-nibble storage-only second batch fails in the *serial* engine with "empty branch data read during unfold" at depth 65 - reproduced byte-identically with this PR's production change reverted to the merge base, so it is pre-existing on main and not something this change introduces.

The positioned account counts as one processed key and one account load in the round's metrics; `updates.Size()` and progress reporting are unchanged. A demoted keyless whale now pays one account read before the inline recursion.
