### PR TITLE
db/state: pass db to aggregator via funcs

### DIFF
--- a/cmd/capcli/cli.go
+++ b/cmd/capcli/cli.go
@@ -696,12 +696,12 @@ func (r *RetrieveHistoricalState) Run(ctx *Context) error {
 	if err != nil {
 		return err
 	}
-	agg, err := dbstate.New(dirs).SanityOldNaming().Logger(log.Root()).WithErigonDBSettings(erigonDBSettings).Open(ctx, chainDB)
+	agg, err := dbstate.New(dirs).SanityOldNaming().Logger(log.Root()).WithErigonDBSettings(erigonDBSettings).Open(ctx)
 	if err != nil {
 		return err
 	}
 	defer agg.Close()
-	if err := agg.OpenFolder(); err != nil {
+	if err := agg.OpenFolder(chainDB); err != nil {
 		return err
 	}
 	elDB, err := temporal.New(chainDB, agg, allSnapshots)

--- a/cmd/integration/commands/commitment.go
+++ b/cmd/integration/commands/commitment.go
@@ -387,7 +387,7 @@ func commitmentRebuild(db kv.TemporalRwDB, ctx context.Context, logger log.Logge
 	}
 
 	agg := db.(dbstate.HasAgg).Agg().(*dbstate.Aggregator)
-	if err = agg.OpenFolder(); err != nil { // reopen after snapshot file deletions
+	if err = agg.OpenFolder(db); err != nil { // reopen after snapshot file deletions
 		return fmt.Errorf("failed to re-open aggregator: %w", err)
 	}
 

--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -1197,7 +1197,7 @@ func allSnapshots(ctx context.Context, db kv.RoDB, logger log.Logger) (*blocksna
 		if reset {
 			aggOpts = aggOpts.SkipFilesDBGapCheck()
 		}
-		_aggSingleton = aggOpts.MustOpen(ctx, db)
+		_aggSingleton = aggOpts.MustOpen(ctx)
 
 		_aggSingleton.SetProduceMod(snapCfg.ProduceE3)
 
@@ -1207,7 +1207,7 @@ func allSnapshots(ctx context.Context, db kv.RoDB, logger log.Logger) (*blocksna
 			return nil
 		})
 		g.Go(func() error {
-			err := _aggSingleton.OpenFolder()
+			err := _aggSingleton.OpenFolder(db)
 			if err != nil {
 				return fmt.Errorf("aggregator opening: %w", err)
 			}

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -429,7 +429,7 @@ func RemoteServices(ctx context.Context, cfg *httpcfg.HttpCfg, logger log.Logger
 		if err != nil {
 			return nil, nil, nil, nil, nil, nil, nil, nil, err
 		}
-		agg, err := dbstate.New(cfg.Dirs).Logger(logger).WithErigonDBSettings(erigonDBSettings).Open(ctx, rawDB)
+		agg, err := dbstate.New(cfg.Dirs).Logger(logger).WithErigonDBSettings(erigonDBSettings).Open(ctx)
 		if err != nil {
 			return nil, nil, nil, nil, nil, nil, nil, ff, fmt.Errorf("create aggregator: %w", err)
 		}
@@ -468,7 +468,7 @@ func RemoteServices(ctx context.Context, cfg *httpcfg.HttpCfg, logger log.Logger
 			allSnapshots.OptimisticalyOpenFolder()
 
 			allSnapshots.LogStat("remote")
-			_ = agg.OpenFolder() //TODO: must use analog of `OptimisticReopenWithDB`
+			_ = agg.OpenFolder(db)
 
 			logSnapshotStats()
 		} else {
@@ -487,7 +487,7 @@ func RemoteServices(ctx context.Context, cfg *httpcfg.HttpCfg, logger log.Logger
 					allSnapshots.LogStat("reopen")
 				}
 
-				if err = agg.OpenFolder(); err != nil {
+				if err = agg.OpenFolder(db); err != nil {
 					logger.Error("[snapshots] reopen", "err", err)
 				} else {
 					logSnapshotStats()

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -3531,7 +3531,7 @@ func doRetireCommand(ctx context.Context, cliCtx *cli.Command, dirs datadir.Dirs
 	}
 
 	logger.Info("Build state history snapshots")
-	if err := agg.BuildFiles(lastTxNum, finalityCtx); err != nil {
+	if err := agg.BuildFiles(temporalDb, lastTxNum, finalityCtx); err != nil {
 		return err
 	}
 
@@ -3661,11 +3661,11 @@ func tryOpenAgg(ctx context.Context, dirs datadir.Dirs, chainDB kv.RwDB, logger 
 	if err != nil {
 		return nil, err
 	}
-	agg, err := state.New(dirs).SanityOldNaming().Logger(logger).WithErigonDBSettings(erigonDBSettings).Open(ctx, chainDB)
+	agg, err := state.New(dirs).SanityOldNaming().Logger(logger).WithErigonDBSettings(erigonDBSettings).Open(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if err = agg.OpenFolder(); err != nil {
+	if err = agg.OpenFolder(chainDB); err != nil {
 		agg.Close()
 		return nil, err
 	}

--- a/cmd/utils/app/squeeze_cmd.go
+++ b/cmd/utils/app/squeeze_cmd.go
@@ -92,10 +92,10 @@ func squeezeCommitment(ctx context.Context, dirs datadir.Dirs, logger log.Logger
 	}
 	defer clean()
 	agg.PresetOfflineMerge()
-	if err := agg.OpenFolder(); err != nil {
+	if err := agg.OpenFolder(res.TemporalDB); err != nil {
 		return err
 	}
-	if err := agg.BuildMissedAccessors(ctx, estimate.IndexSnapshot.Workers()); err != nil {
+	if err := agg.BuildMissedAccessors(ctx, res.TemporalDB, estimate.IndexSnapshot.Workers()); err != nil {
 		return err
 	}
 	ac := agg.BeginFilesRo()
@@ -107,7 +107,7 @@ func squeezeCommitment(ctx context.Context, dirs datadir.Dirs, logger log.Logger
 	if err := agg.ReloadFiles(); err != nil {
 		return err
 	}
-	if err := agg.BuildMissedAccessors(ctx, estimate.IndexSnapshot.Workers()); err != nil {
+	if err := agg.BuildMissedAccessors(ctx, res.TemporalDB, estimate.IndexSnapshot.Workers()); err != nil {
 		return err
 	}
 	return nil
@@ -131,10 +131,10 @@ func squeezeStorage(ctx context.Context, dirs datadir.Dirs, logger log.Logger) e
 		return err
 	}
 
-	if err := agg.OpenFolder(); err != nil {
+	if err := agg.OpenFolder(res.TemporalDB); err != nil {
 		return err
 	}
-	if err := agg.BuildMissedAccessors(ctx, estimate.IndexSnapshot.Workers()); err != nil {
+	if err := agg.BuildMissedAccessors(ctx, res.TemporalDB, estimate.IndexSnapshot.Workers()); err != nil {
 		return err
 	}
 	ac := agg.BeginFilesRo()
@@ -144,19 +144,19 @@ func squeezeStorage(ctx context.Context, dirs datadir.Dirs, logger log.Logger) e
 	if err != nil {
 		panic(err)
 	}
-	aggOld, err := state.New(dirsOld).Logger(logger).WithErigonDBSettings(erigonDBSettingsOld).Open(ctx, db)
+	aggOld, err := state.New(dirsOld).Logger(logger).WithErigonDBSettings(erigonDBSettingsOld).Open(ctx)
 	if err != nil {
 		panic(err)
 	}
 	defer aggOld.Close()
-	if err = aggOld.OpenFolder(); err != nil {
+	if err = aggOld.OpenFolder(db); err != nil {
 		panic(err)
 	}
 	aggOld.PresetOfflineMerge()
-	if err := aggOld.BuildMissedAccessors(ctx, estimate.IndexSnapshot.Workers()); err != nil {
+	if err := aggOld.BuildMissedAccessors(ctx, db, estimate.IndexSnapshot.Workers()); err != nil {
 		return err
 	}
-	if err := agg.BuildMissedAccessors(ctx, estimate.IndexSnapshot.Workers()); err != nil {
+	if err := agg.BuildMissedAccessors(ctx, res.TemporalDB, estimate.IndexSnapshot.Workers()); err != nil {
 		return err
 	}
 
@@ -168,11 +168,11 @@ func squeezeStorage(ctx context.Context, dirs datadir.Dirs, logger log.Logger) e
 	}
 	acOld.Close()
 	ac.Close()
-	if err := agg.BuildMissedAccessors(ctx, estimate.IndexSnapshot.Workers()); err != nil {
+	if err := agg.BuildMissedAccessors(ctx, res.TemporalDB, estimate.IndexSnapshot.Workers()); err != nil {
 		return err
 	}
 	// TODO: aggOld.reload files?
-	if err := aggOld.BuildMissedAccessors(ctx, estimate.IndexSnapshot.Workers()); err != nil {
+	if err := aggOld.BuildMissedAccessors(ctx, db, estimate.IndexSnapshot.Workers()); err != nil {
 		return err
 	}
 	agg.Close()
@@ -190,7 +190,7 @@ func squeezeCode(ctx context.Context, dirs datadir.Dirs, logger log.Logger) erro
 	if err != nil {
 		return err
 	}
-	agg := state.New(dirs).Logger(logger).WithErigonDBSettings(erigonDBSettings).MustOpen(ctx, db)
+	agg := state.New(dirs).Logger(logger).WithErigonDBSettings(erigonDBSettings).MustOpen(ctx)
 	defer agg.Close()
 	agg.PresetOfflineMerge()
 
@@ -198,10 +198,10 @@ func squeezeCode(ctx context.Context, dirs datadir.Dirs, logger log.Logger) erro
 	if err := agg.Sqeeze(ctx, kv.CodeDomain); err != nil {
 		return err
 	}
-	if err := agg.OpenFolder(); err != nil {
+	if err := agg.OpenFolder(db); err != nil {
 		return err
 	}
-	if err := agg.BuildMissedAccessors(ctx, estimate.IndexSnapshot.Workers()); err != nil {
+	if err := agg.BuildMissedAccessors(ctx, db, estimate.IndexSnapshot.Workers()); err != nil {
 		return err
 	}
 	return nil

--- a/db/integrity/commitment_plainvalues_firststart_integration_test.go
+++ b/db/integrity/commitment_plainvalues_firststart_integration_test.go
@@ -90,8 +90,8 @@ func runFirstStartRegimeCheck(t *testing.T, plainValues bool) {
 func newTestDBWithSettings(t *testing.T, ctx context.Context, dirs datadir.Dirs, settings *state.ErigonDBSettings) kv.TemporalRwDB {
 	t.Helper()
 	rawDB := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
-	agg := state.NewTest(dirs).WithErigonDBSettings(settings).MustOpen(ctx, rawDB)
-	require.NoError(t, agg.OpenFolder())
+	agg := state.NewTest(dirs).WithErigonDBSettings(settings).MustOpen(ctx)
+	require.NoError(t, agg.OpenFolder(rawDB))
 	t.Cleanup(agg.Close)
 	db, err := temporal.New(rawDB, agg, nil)
 	require.NoError(t, err)

--- a/db/integrity/commitment_state_verify_test.go
+++ b/db/integrity/commitment_state_verify_test.go
@@ -104,7 +104,7 @@ func TestCheckStateVerify(t *testing.T) {
 	require.NoError(t, err)
 
 	// Build snapshot files
-	err = agg.BuildFiles(txs, unboundedFinalityCtx)
+	err = agg.BuildFiles(db, txs, unboundedFinalityCtx)
 	require.NoError(t, err)
 
 	endTxNum := agg.EndTxNumMinimax()
@@ -224,7 +224,7 @@ func TestCheckStateVerify_NoopWrite(t *testing.T) {
 	require.NoError(t, err)
 
 	// Build snapshot files for all steps
-	err = agg.BuildFiles(400, unboundedFinalityCtx)
+	err = agg.BuildFiles(db, 400, unboundedFinalityCtx)
 	require.NoError(t, err)
 
 	endTxNum := agg.EndTxNumMinimax()

--- a/db/integrity/commitment_version_integration_test.go
+++ b/db/integrity/commitment_version_integration_test.go
@@ -117,16 +117,16 @@ func writeAndBuild(t *testing.T, ctx context.Context, db kv.TemporalRwDB, agg *s
 
 	require.NoError(t, domains.Flush(ctx, tx))
 	require.NoError(t, tx.Commit())
-	require.NoError(t, agg.BuildFiles(txs, unboundedFinalityCtx))
+	require.NoError(t, agg.BuildFiles(db, txs, unboundedFinalityCtx))
 }
 
 func reopenAgg(t *testing.T, db kv.TemporalRwDB, agg *state.Aggregator, dirs datadir.Dirs, stepSize uint64, logger log.Logger) kv.TemporalRwDB {
 	t.Helper()
 	agg.Close()
-	newAgg := state.NewTest(dirs).StepSize(stepSize).Logger(logger).MustOpen(t.Context(), db)
+	newAgg := state.NewTest(dirs).StepSize(stepSize).Logger(logger).MustOpen(t.Context())
 	t.Cleanup(newAgg.Close)
-	require.NoError(t, newAgg.OpenFolder())
-	require.NoError(t, newAgg.BuildMissedAccessors(t.Context(), 1))
+	require.NoError(t, newAgg.OpenFolder(db))
+	require.NoError(t, newAgg.BuildMissedAccessors(t.Context(), db, 1))
 	newDB, err := temporal.New(db, newAgg, nil)
 	require.NoError(t, err)
 	return newDB

--- a/db/kv/temporal/kv_temporal.go
+++ b/db/kv/temporal/kv_temporal.go
@@ -745,7 +745,7 @@ func (db *DB) InvertedIdxTables(domain ...kv.InvertedIdx) []string {
 	return db.stateFiles.InvertedIdxTables(domain...)
 }
 func (db *DB) BuildMissedAccessors(ctx context.Context, workers int, opts ...kv.BuildAccessorsOption) (err error) {
-	return db.stateFiles.BuildMissedAccessors(ctx, workers, opts...)
+	return db.stateFiles.BuildMissedAccessors(ctx, db, workers, opts...)
 }
 func (db *DB) EnableReadAhead() kv.TemporalDebugDB {
 	db.stateFiles.MadvNormal()

--- a/db/kv/temporal/kv_temporal_resources_test.go
+++ b/db/kv/temporal/kv_temporal_resources_test.go
@@ -23,7 +23,7 @@ func TestTemporalTx_AbandonedIteratorsRollbackCleanly(t *testing.T) {
 
 	mdbxDb := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
 	dirs := datadir.New(t.TempDir())
-	agg := state.NewTest(dirs).StepSize(1).MustOpen(ctx, mdbxDb)
+	agg := state.NewTest(dirs).StepSize(1).MustOpen(ctx)
 	defer agg.Close()
 
 	temporalDb, err := New(mdbxDb, agg, nil)

--- a/db/kv/temporal/kv_temporal_test.go
+++ b/db/kv/temporal/kv_temporal_test.go
@@ -32,7 +32,7 @@ func TestTemporalTx_HasPrefix_StorageDomain(t *testing.T) {
 	mdbxDb := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
 	dirs := datadir.New(t.TempDir())
 	stepSize := uint64(1)
-	agg := state.NewTest(dirs).StepSize(stepSize).MustOpen(ctx, mdbxDb)
+	agg := state.NewTest(dirs).StepSize(stepSize).MustOpen(ctx)
 	defer agg.Close()
 
 	temporalDb, err := New(mdbxDb, agg, nil)
@@ -130,7 +130,7 @@ func TestTemporalTx_HasPrefix_StorageDomain(t *testing.T) {
 		require.NoError(t, err)
 
 		// build files
-		err = agg.BuildFiles(2, unboundedFinalityCtx)
+		err = agg.BuildFiles(temporalDb, 2, unboundedFinalityCtx)
 		require.NoError(t, err)
 		rwTtx3, err := temporalDb.BeginTemporalRw(ctx)
 		require.NoError(t, err)
@@ -233,7 +233,7 @@ func TestTemporalTx_PinsBlockFilesView(t *testing.T) {
 	newDB := func(withBlocks bool) *DB {
 		mdbxDb := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
 		dirs := datadir.New(t.TempDir())
-		agg := state.NewTest(dirs).StepSize(1).MustOpen(ctx, mdbxDb)
+		agg := state.NewTest(dirs).StepSize(1).MustOpen(ctx)
 		t.Cleanup(agg.Close)
 
 		var blockSnaps *blocksnapshots.RoSnapshots
@@ -270,7 +270,7 @@ func TestTemporalTx_DomainVisibleEndConcurrent(t *testing.T) {
 
 	mdbxDb := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
 	dirs := datadir.New(t.TempDir())
-	agg := state.NewTest(dirs).StepSize(1).MustOpen(ctx, mdbxDb)
+	agg := state.NewTest(dirs).StepSize(1).MustOpen(ctx)
 	defer agg.Close()
 	temporalDb, err := New(mdbxDb, agg, nil)
 	require.NoError(t, err)
@@ -332,7 +332,7 @@ func TestTemporalTx_ForceReopenRefreshesDomainVisibleEnd(t *testing.T) {
 
 	mdbxDb := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
 	dirs := datadir.New(t.TempDir())
-	agg := state.NewTest(dirs).StepSize(1).MustOpen(ctx, mdbxDb)
+	agg := state.NewTest(dirs).StepSize(1).MustOpen(ctx)
 	defer agg.Close()
 	temporalDb, err := New(mdbxDb, agg, nil)
 	require.NoError(t, err)
@@ -371,7 +371,7 @@ func TestTemporalTx_ForceReopenRefreshesDomainVisibleEnd(t *testing.T) {
 			require.NoError(t, rwTtx.Commit())
 		}()
 	}
-	require.NoError(t, agg.BuildFiles(3, unboundedFinalityCtx))
+	require.NoError(t, agg.BuildFiles(temporalDb, 3, unboundedFinalityCtx))
 
 	freshRoTtx, err := temporalDb.BeginTemporalRo(ctx)
 	require.NoError(t, err)
@@ -396,7 +396,7 @@ func TestTemporalTx_RangeAsOf_StorageDomain(t *testing.T) {
 	mdbxDb := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
 	dirs := datadir.New(t.TempDir())
 	stepSize := uint64(1)
-	agg := state.NewTest(dirs).StepSize(stepSize).MustOpen(ctx, mdbxDb)
+	agg := state.NewTest(dirs).StepSize(stepSize).MustOpen(ctx)
 	defer agg.Close()
 	temporalDb, err := New(mdbxDb, agg, nil)
 	require.NoError(t, err)

--- a/db/kv/temporal/temporaltest/kv_temporal_testdb.go
+++ b/db/kv/temporal/temporaltest/kv_temporal_testdb.go
@@ -98,12 +98,12 @@ func newTestDB(tb testing.TB, dirs datadir.Dirs, stepSize uint64) kv.TemporalRwD
 		panic(err)
 	}
 
-	stateSnapshots := state.NewTest(dirs).StepSize(stepSize).MustOpen(ctx, rawDB)
+	stateSnapshots := state.NewTest(dirs).StepSize(stepSize).MustOpen(ctx)
 	if tb != nil {
 		tb.Cleanup(stateSnapshots.Close)
 	}
 
-	if err := stateSnapshots.OpenFolder(); err != nil {
+	if err := stateSnapshots.OpenFolder(rawDB); err != nil {
 		panic(err)
 	}
 

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -60,7 +60,6 @@ import (
 )
 
 type Aggregator struct {
-	db                kv.RoDB //TODO: remove this field. Accept `tx` and `db` from outside. But it must be field of `temporal.DB` - and only `temporal.DB` must pass it to us. App-Level code must call methods of `temporal.DB`
 	d                 [kv.DomainLen]*Domain
 	iis               [kv.StandaloneIdxLen]*InvertedIndex
 	iisCount          int
@@ -144,7 +143,7 @@ type Aggregator struct {
 	commitmentRefsOverride *bool
 }
 
-func newAggregator(ctx context.Context, dirs datadir.Dirs, db kv.RoDB, logger log.Logger) (*Aggregator, error) {
+func newAggregator(ctx context.Context, dirs datadir.Dirs, logger log.Logger) (*Aggregator, error) {
 	ctx, ctxCancel := context.WithCancel(ctx)
 	a := &Aggregator{
 		ctx:                ctx,
@@ -152,7 +151,6 @@ func newAggregator(ctx context.Context, dirs datadir.Dirs, db kv.RoDB, logger lo
 		onFilesChange:      func(frozenFileNames []string) {},
 		onFilesDelete:      func(frozenFileNames []string) {},
 		dirs:               dirs,
-		db:                 db,
 		leakDetector:       dbg.NewLeakDetector("agg", dbg.SlowTx()),
 		backgroundProgress: background.NewProgressSet(),
 		logger:             logger,
@@ -576,7 +574,7 @@ func (a *Aggregator) DisableInterDomainDependencies() {
 	a.recalcVisibleFiles(nil)
 }
 
-func (a *Aggregator) OpenFolder() error {
+func (a *Aggregator) OpenFolder(db kv.RoDB) error {
 	if err := func() error {
 		a.dirtyFilesLock.Lock()
 		defer a.dirtyFilesLock.Unlock()
@@ -590,18 +588,18 @@ func (a *Aggregator) OpenFolder() error {
 	}(); err != nil {
 		return err
 	}
-	return a.checkFilesDBGap()
+	return a.checkFilesDBGap(db)
 }
 
 // checkFilesDBGap refuses to open a datadir where the DB was pruned past where the
 // snapshot files end (the hole `rm-state --latest` leaves without a reset — reads
 // below it silently return stale data). Skipped when SkipFilesDBGapCheck is set so
 // `--reset` tooling can open and fix it.
-func (a *Aggregator) checkFilesDBGap() error {
-	if a.skipFilesDBGapCheck || a.db == nil {
+func (a *Aggregator) checkFilesDBGap(db kv.RoDB) error {
+	if a.skipFilesDBGapCheck || db == nil {
 		return nil
 	}
-	return a.db.View(context.Background(), func(tx kv.Tx) error {
+	return db.View(context.Background(), func(tx kv.Tx) error {
 		at := a.BeginFilesRo()
 		defer at.Close()
 		if err := at.CheckFilesDBGap(tx); err != nil {
@@ -708,8 +706,8 @@ func (a *Aggregator) closeDirtyFilesNoReopen() {
 	a.recalcVisibleFiles(nil)
 }
 
-func (a *Aggregator) OpenList(files []string, readonly bool) error {
-	return a.OpenFolder()
+func (a *Aggregator) OpenList(db kv.RoDB, files []string, readonly bool) error {
+	return a.OpenFolder(db)
 }
 
 func (a *Aggregator) WaitForFiles() {
@@ -951,7 +949,7 @@ func (a *Aggregator) WaitForBuildAndMerge(ctx context.Context) chan struct{} {
 	return res
 }
 
-func (a *Aggregator) BuildMissedAccessors(ctx context.Context, workers int, opts ...kv.BuildAccessorsOption) error {
+func (a *Aggregator) BuildMissedAccessors(ctx context.Context, db kv.RoDB, workers int, opts ...kv.BuildAccessorsOption) error {
 	rotx := a.DebugBeginDirtyFilesRo()
 	defer rotx.Close()
 
@@ -998,7 +996,7 @@ func (a *Aggregator) BuildMissedAccessors(ctx context.Context, workers int, opts
 
 	rotx.Close()
 
-	if err := a.OpenFolder(); err != nil {
+	if err := a.OpenFolder(db); err != nil {
 		return err
 	}
 	return nil
@@ -1021,7 +1019,7 @@ func (sf AggV3StaticFiles) CleanupOnError() {
 
 var errStepNotReady = errors.New("step not ready")
 
-func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step, finalityCtx dbfinality.Context) error {
+func (a *Aggregator) buildFiles(ctx context.Context, db kv.RoDB, step kv.Step, finalityCtx dbfinality.Context) error {
 	// Pin worker counts for the duration of buildFiles. The collate/build phases
 	// below read per-domain/per-II CompressorCfg.Workers (passed by-value into
 	// seg.NewCompressor); without this guard, ExecV3's chain-tip-driven
@@ -1029,12 +1027,12 @@ func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step, finalityCtx d
 	a.LockWorkersEditing()
 	defer a.UnlockWorkersEditing()
 
-	finalisedBlockNum, lastBlockInStep, lastBlockInDB, lastTxInDB, ok, err := a.readyForCollation(ctx, step, finalityCtx)
+	finalisedBlockNum, lastBlockInStep, lastBlockInDB, lastTxInDB, ok, err := a.readyForCollation(ctx, db, step, finalityCtx)
 	if err != nil {
 		return err
 	}
 	if !ok {
-		lastStepInDB := lastIdInDB(a.db, a.d[kv.AccountsDomain])
+		lastStepInDB := lastIdInDB(db, a.d[kv.AccountsDomain])
 		var lastCollatableStepInDB kv.Step
 		if lastStepInDB > 0 {
 			lastCollatableStepInDB = lastStepInDB - 1
@@ -1087,7 +1085,7 @@ func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step, finalityCtx d
 
 		g.Go(func() error {
 			var collation Collation
-			if err := a.db.View(ctx, func(tx kv.Tx) (err error) {
+			if err := db.View(ctx, func(tx kv.Tx) (err error) {
 				collation, err = d.collate(ctx, step, txFrom, txTo, tx)
 				return err
 			}); err != nil {
@@ -1127,7 +1125,7 @@ func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step, finalityCtx d
 
 		g.Go(func() error {
 			var collation InvertedIndexCollation
-			err := a.db.View(ctx, func(tx kv.Tx) (err error) {
+			err := db.View(ctx, func(tx kv.Tx) (err error) {
 				collation, err = ii.collate(ctx, step, tx)
 				return err
 			})
@@ -1157,19 +1155,19 @@ func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step, finalityCtx d
 	return nil
 }
 
-func (a *Aggregator) readyForCollation(ctx context.Context, step kv.Step, finalityCtx dbfinality.Context) (finalisedBlockNum, lastBlockInStep, lastBlockInDB, lastTxInDB uint64, ok bool, err error) {
+func (a *Aggregator) readyForCollation(ctx context.Context, db kv.RoDB, step kv.Step, finalityCtx dbfinality.Context) (finalisedBlockNum, lastBlockInStep, lastBlockInDB, lastTxInDB uint64, ok bool, err error) {
 	a.commitGate.RLock()
 	defer a.commitGate.RUnlock()
-	return finalityCtx.ReadyForCollation(ctx, a.db, step.LastTxNum(a.stepSize.Load()))
+	return finalityCtx.ReadyForCollation(ctx, db, step.LastTxNum(a.stepSize.Load()))
 }
 
-func (a *Aggregator) reorgSafeBlockAndStep(ctx context.Context, maxReorgDepth uint64) (reorgSafeBlock uint64, reorgSafeStep float64, ok bool) {
+func (a *Aggregator) reorgSafeBlockAndStep(ctx context.Context, db kv.RoDB, maxReorgDepth uint64) (reorgSafeBlock uint64, reorgSafeStep float64, ok bool) {
 	if maxReorgDepth == 0 {
 		return 0, 0, false
 	}
 	a.commitGate.RLock()
 	defer a.commitGate.RUnlock()
-	if err := a.db.View(ctx, func(tx kv.Tx) error {
+	if err := db.View(ctx, func(tx kv.Tx) error {
 		lastBlockInDB, _, err := rawdbv3.TxNums.Last(tx)
 		if err != nil {
 			return err
@@ -1192,8 +1190,8 @@ func (a *Aggregator) reorgSafeBlockAndStep(ctx context.Context, maxReorgDepth ui
 	return reorgSafeBlock, reorgSafeStep, ok
 }
 
-func (a *Aggregator) BuildFiles(toTxNum uint64, finalityCtx dbfinality.Context) error {
-	finished, _ := a.buildFilesInBackground(toTxNum, true, finalityCtx)
+func (a *Aggregator) BuildFiles(db kv.RoDB, toTxNum uint64, finalityCtx dbfinality.Context) error {
+	finished, _ := a.buildFilesInBackground(db, toTxNum, true, finalityCtx)
 	if !(a.buildingFiles.Load() || a.mergingFiles.Load()) {
 		return nil
 	}
@@ -1221,7 +1219,7 @@ Loop:
 }
 
 // [from, to)
-func (a *Aggregator) BuildFiles2(ctx context.Context, fromStep, toStep kv.Step, finalityCtx dbfinality.Context, doMerge bool) error {
+func (a *Aggregator) BuildFiles2(ctx context.Context, db kv.RoDB, fromStep, toStep kv.Step, finalityCtx dbfinality.Context, doMerge bool) error {
 	if ok := a.buildingFiles.CompareAndSwap(false, true); !ok {
 		return nil
 	}
@@ -1231,7 +1229,7 @@ func (a *Aggregator) BuildFiles2(ctx context.Context, fromStep, toStep kv.Step, 
 			log.Info("[agg] build", "fromStep", fromStep, "toStep", toStep)
 		}
 		for step := fromStep; step < toStep; step++ { //`step` must be fully-written - means `step+1` records must be visible
-			if err := a.buildFiles(ctx, step, finalityCtx); err != nil {
+			if err := a.buildFiles(ctx, db, step, finalityCtx); err != nil {
 				if errors.Is(err, errStepNotReady) {
 					break
 				}
@@ -1787,7 +1785,7 @@ func (a *Aggregator) CollateAndPrune(ctx context.Context, db kv.TemporalRwDB, pr
 	if err != nil {
 		return false, nil, err
 	}
-	finished, started := a.buildFilesInBackground(a.EndTxNumMinimax()+a.StepSize(), true, finalityCtx)
+	finished, started := a.buildFilesInBackground(db, a.EndTxNumMinimax()+a.StepSize(), true, finalityCtx)
 	return started, finished, nil
 }
 func (a *Aggregator) FilesAmount() (res []int) {
@@ -2220,13 +2218,13 @@ func (a *Aggregator) SetProduceMod(produce bool) {
 	a.produce = produce
 }
 
-func (a *Aggregator) BuildFilesInBackground(txNum uint64, finalityCtx dbfinality.Context) chan struct{} {
-	finished, _ := a.buildFilesInBackground(txNum, true, finalityCtx)
+func (a *Aggregator) BuildFilesInBackground(db kv.RoDB, txNum uint64, finalityCtx dbfinality.Context) chan struct{} {
+	finished, _ := a.buildFilesInBackground(db, txNum, true, finalityCtx)
 	return finished
 }
 
 // Returns a channel which is closed when aggregation is done and whether it started.
-func (a *Aggregator) buildFilesInBackground(txNum uint64, doMerge bool, finalityCtx dbfinality.Context) (chan struct{}, bool) {
+func (a *Aggregator) buildFilesInBackground(db kv.RoDB, txNum uint64, doMerge bool, finalityCtx dbfinality.Context) (chan struct{}, bool) {
 	fin := make(chan struct{})
 
 	if dbg.NoBackgroundMaintenance() {
@@ -2274,12 +2272,12 @@ func (a *Aggregator) buildFilesInBackground(txNum uint64, doMerge bool, finality
 			a.commitGate.RLock()
 			defer a.commitGate.RUnlock()
 			return max(
-				lastIdInDB(a.db, a.d[kv.AccountsDomain]),
-				lastIdInDB(a.db, a.d[kv.CodeDomain]),
-				lastIdInDB(a.db, a.d[kv.StorageDomain]),
-				lastIdInDB(a.db, a.d[kv.CommitmentDomain]))
+				lastIdInDB(db, a.d[kv.AccountsDomain]),
+				lastIdInDB(db, a.d[kv.CodeDomain]),
+				lastIdInDB(db, a.d[kv.StorageDomain]),
+				lastIdInDB(db, a.d[kv.CommitmentDomain]))
 		}()
-		reorgSafeBlock, reorgSafeStep, reorgSafeOK := a.reorgSafeBlockAndStep(a.ctx, finalityCtx.MaxReorgDepth())
+		reorgSafeBlock, reorgSafeStep, reorgSafeOK := a.reorgSafeBlockAndStep(a.ctx, db, finalityCtx.MaxReorgDepth())
 		a.logger.Info("BuildFilesInBackground", "step", step, "lastInDB", lastInDB, "targetStep", kv.Step(txNum/a.StepSize()),
 			"reorgSafeBlock", reorgSafeBlock, "reorgSafeStep", fmt.Sprintf("%.2f", reorgSafeStep), "reorgSafeOK", reorgSafeOK)
 
@@ -2328,7 +2326,7 @@ func (a *Aggregator) buildFilesInBackground(txNum uint64, doMerge bool, finality
 		// we don't need to disambiguate.
 		if step > 0 {
 			var firstInDB kv.Step
-			if err := a.db.View(a.ctx, func(tx kv.Tx) error {
+			if err := db.View(a.ctx, func(tx kv.Tx) error {
 				for _, d := range []*Domain{a.d[kv.AccountsDomain], a.d[kv.StorageDomain], a.d[kv.CodeDomain]} {
 					s := kv.Step(d.minStepInDB(tx))
 					if s > 0 && (firstInDB == 0 || s < firstInDB) {
@@ -2355,7 +2353,7 @@ func (a *Aggregator) buildFilesInBackground(txNum uint64, doMerge bool, finality
 		// - to remove old data from db as early as possible
 		// - during files build, may happen commit of new data. on each loop step getting latest id in db
 		for ; step < lastInDB; step++ { //`step` must be fully-written - means `step+1` records must be visible
-			if err := a.buildFiles(a.ctx, step, finalityCtx); err != nil {
+			if err := a.buildFiles(a.ctx, db, step, finalityCtx); err != nil {
 				if errors.Is(err, errStepNotReady) {
 					break
 				}

--- a/db/state/aggregator2.go
+++ b/db/state/aggregator2.go
@@ -13,7 +13,6 @@ import (
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/config3"
 	"github.com/erigontech/erigon/db/datadir"
-	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/snaptype"
 	"github.com/erigontech/erigon/db/state/statecfg"
 )
@@ -48,7 +47,7 @@ func NewTest(dirs datadir.Dirs) AggOpts { //nolint:gocritic
 	return New(dirs).DisableFsync().GenSaltIfNeed(true).StepSize(config3.DefaultStepSize).StepsInFrozenFile(config3.DefaultStepsInFrozenFile)
 }
 
-func (opts AggOpts) Open(ctx context.Context, db kv.RoDB) (*Aggregator, error) { //nolint:gocritic
+func (opts AggOpts) Open(ctx context.Context) (*Aggregator, error) { //nolint:gocritic
 	//TODO: rename `OpenFolder` to `ReopenFolder`
 	if opts.sanityOldNaming {
 		if err := CheckSnapshotsCompatibility(opts.dirs); err != nil {
@@ -61,7 +60,7 @@ func (opts AggOpts) Open(ctx context.Context, db kv.RoDB) (*Aggregator, error) {
 		return nil, err
 	}
 
-	a, err := newAggregator(ctx, opts.dirs, db, opts.logger)
+	a, err := newAggregator(ctx, opts.dirs, opts.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +86,8 @@ func (opts AggOpts) Open(ctx context.Context, db kv.RoDB) (*Aggregator, error) {
 	return a, nil
 }
 
-func (opts AggOpts) MustOpen(ctx context.Context, db kv.RoDB) *Aggregator { //nolint:gocritic
-	agg, err := opts.Open(ctx, db)
+func (opts AggOpts) MustOpen(ctx context.Context) *Aggregator { //nolint:gocritic
+	agg, err := opts.Open(ctx)
 	if err != nil {
 		panic(fmt.Errorf("fail to open mdbx: %w", err))
 	}

--- a/db/state/aggregator_align_test.go
+++ b/db/state/aggregator_align_test.go
@@ -58,12 +58,12 @@ func requireVisibleEnd(t *testing.T, agg *Aggregator, end uint64) {
 // state visible past commitment's files = state no commitment covers
 func TestVisibleFilesAligned_LaggingCommitmentClampsEveryone(t *testing.T) {
 	t.Parallel()
-	_, agg := testDbAndAggregatorv3(t, alignStepSize)
+	db, agg := testDbAndAggregatorv3(t, alignStepSize)
 
 	generateStateFiles(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
 	generateStandaloneIIFiles(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
 	generateCommitmentFile(t, agg.Dirs(), []testFileRange{{0, 1}})
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 
 	requireVisibleEnd(t, agg, alignStepSize)
 }
@@ -71,7 +71,7 @@ func TestVisibleFilesAligned_LaggingCommitmentClampsEveryone(t *testing.T) {
 // domains visible past the log/trace indexes answer eth_getLogs from blocks no index saw
 func TestVisibleFilesAligned_LaggingStandaloneIdxClampsEveryone(t *testing.T) {
 	t.Parallel()
-	_, agg := testDbAndAggregatorv3(t, alignStepSize)
+	db, agg := testDbAndAggregatorv3(t, alignStepSize)
 
 	generateStateFiles(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
 	generateCommitmentFile(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
@@ -79,7 +79,7 @@ func TestVisibleFilesAligned_LaggingStandaloneIdxClampsEveryone(t *testing.T) {
 		generateStandaloneIIFile(t, name, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
 	}
 	generateStandaloneIIFile(t, kv.LogAddrIdx, agg.Dirs(), []testFileRange{{0, 1}})
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 
 	requireVisibleEnd(t, agg, alignStepSize)
 }
@@ -87,11 +87,11 @@ func TestVisibleFilesAligned_LaggingStandaloneIdxClampsEveryone(t *testing.T) {
 // no files at all = nothing to be misaligned with, so the domains stay visible
 func TestVisibleFilesAligned_EntityWithoutFilesDoesNotClamp(t *testing.T) {
 	t.Parallel()
-	_, agg := testDbAndAggregatorv3(t, alignStepSize)
+	db, agg := testDbAndAggregatorv3(t, alignStepSize)
 
 	generateStateFiles(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
 	generateCommitmentFile(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 
 	at := agg.BeginFilesRo()
 	defer at.Close()
@@ -104,13 +104,13 @@ func TestVisibleFilesAligned_EntityWithoutFilesDoesNotClamp(t *testing.T) {
 // doing it
 func TestUnalign_KeepsStateVisibleWhileReceiptsLag(t *testing.T) {
 	t.Parallel()
-	_, agg := testDbAndAggregatorv3(t, alignStepSize)
+	db, agg := testDbAndAggregatorv3(t, alignStepSize)
 
 	generateStateFiles(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
 	generateCommitmentFile(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
 	generateStandaloneIIFiles(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
 	generateDomainFiles(t, "receipt", agg.Dirs(), []testFileRange{{0, 1}})
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 
 	requireVisibleEnd(t, agg, alignStepSize)
 
@@ -129,12 +129,12 @@ func TestUnalign_KeepsStateVisibleWhileReceiptsLag(t *testing.T) {
 // rebuilt so far
 func TestUnalign_KeepsStateVisibleWhileCommitmentLags(t *testing.T) {
 	t.Parallel()
-	_, agg := testDbAndAggregatorv3(t, alignStepSize)
+	db, agg := testDbAndAggregatorv3(t, alignStepSize)
 
 	generateStateFiles(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
 	generateStandaloneIIFiles(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
 	generateCommitmentFile(t, agg.Dirs(), []testFileRange{{0, 1}})
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 
 	agg.DisableAllDependencies() // what the rebuild does about file ranges
 	realign := agg.Unalign(kv.CommitmentDomain)
@@ -168,13 +168,13 @@ func TestUnalign_RejectsStateDomain(t *testing.T) {
 // must panic, whichever entry point caused it.
 func TestVisibilityLowering_ForbiddenAggregatorPanicsOnLoweringOnly(t *testing.T) {
 	t.Parallel()
-	_, agg := testDbAndAggregatorv3(t, alignStepSize)
+	db, agg := testDbAndAggregatorv3(t, alignStepSize)
 
 	generateStateFiles(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
 	generateCommitmentFile(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
 	generateStandaloneIIFiles(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
 	generateDomainFiles(t, "receipt", agg.Dirs(), []testFileRange{{0, 1}})
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 
 	agg.ForbidVisibilityLowering()
 	realign := agg.Unalign(kv.ReceiptDomain) // raises the ceiling: allowed
@@ -213,7 +213,7 @@ func TestDomainVisibleEnd_ClampedViewHasNoExactFrontier(t *testing.T) {
 	generateStateFiles(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
 	generateCommitmentFile(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
 	generateStandaloneIIFiles(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 
 	craftedClampedVisible(t, agg)
 
@@ -232,12 +232,12 @@ func TestDomainVisibleEnd_ClampedViewHasNoExactFrontier(t *testing.T) {
 // ceiling they can lower while every values end stays put.
 func TestVisibilityLowering_GuardsHistoryIIEnd(t *testing.T) {
 	t.Parallel()
-	_, agg := testDbAndAggregatorv3(t, alignStepSize)
+	db, agg := testDbAndAggregatorv3(t, alignStepSize)
 
 	generateStateFiles(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
 	generateCommitmentFile(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
 	generateStandaloneIIFiles(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 
 	craftedClampedVisible(t, agg)
 	agg.ForbidVisibilityLowering()

--- a/db/state/aggregator_close_test.go
+++ b/db/state/aggregator_close_test.go
@@ -44,10 +44,10 @@ func TestAggregatorCloseWaitsForBackgroundMerge(t *testing.T) {
 	for range 64 {
 		dirs := datadir.New(t.TempDir())
 		db := mdbxtest.InMem(t, mdbx.New(dbcfg.ChainDB, logger), dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
-		agg := NewTest(dirs).StepSize(16).Logger(logger).MustOpen(t.Context(), db)
-		require.NoError(t, agg.OpenFolder())
+		agg := NewTest(dirs).StepSize(16).Logger(logger).MustOpen(t.Context())
+		require.NoError(t, agg.OpenFolder(db))
 
-		require.NoError(t, agg.BuildFiles2(t.Context(), 0, 0, unboundedFinalityCtx, true))
+		require.NoError(t, agg.BuildFiles2(t.Context(), db, 0, 0, unboundedFinalityCtx, true))
 		agg.background.Wait()
 		agg.Close()
 		db.Close()
@@ -63,8 +63,8 @@ func TestAggregatorCloseVsConcurrentMergeLoop(t *testing.T) {
 	for range 4 {
 		dirs := datadir.New(t.TempDir())
 		db := mdbxtest.InMem(t, mdbx.New(dbcfg.ChainDB, logger), dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
-		agg := NewTest(dirs).StepSize(16).Logger(logger).MustOpen(t.Context(), db)
-		require.NoError(t, agg.OpenFolder())
+		agg := NewTest(dirs).StepSize(16).Logger(logger).MustOpen(t.Context())
+		require.NoError(t, agg.OpenFolder(db))
 
 		start := make(chan struct{})
 		var loops sync.WaitGroup
@@ -89,8 +89,8 @@ func TestAggregatorCloseVsConcurrentBuildFilesInBackground(t *testing.T) {
 	for range 4 {
 		dirs := datadir.New(t.TempDir())
 		db := mdbxtest.InMem(t, mdbx.New(dbcfg.ChainDB, logger), dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
-		agg := NewTest(dirs).StepSize(16).Logger(logger).MustOpen(t.Context(), db)
-		require.NoError(t, agg.OpenFolder())
+		agg := NewTest(dirs).StepSize(16).Logger(logger).MustOpen(t.Context())
+		require.NoError(t, agg.OpenFolder(db))
 
 		start := make(chan struct{})
 		fins := make(chan chan struct{}, 8)
@@ -99,7 +99,7 @@ func TestAggregatorCloseVsConcurrentBuildFilesInBackground(t *testing.T) {
 			loops.Go(func() {
 				<-start
 				time.Sleep(time.Duration(i) * 250 * time.Microsecond)
-				fins <- agg.BuildFilesInBackground(1_000_000, unboundedFinalityCtx)
+				fins <- agg.BuildFilesInBackground(db, 1_000_000, unboundedFinalityCtx)
 			})
 		}
 		close(start)
@@ -120,8 +120,8 @@ func TestAggregatorCloseVsConcurrentBuildFiles2(t *testing.T) {
 	for range 4 {
 		dirs := datadir.New(t.TempDir())
 		db := mdbxtest.InMem(t, mdbx.New(dbcfg.ChainDB, logger), dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
-		agg := NewTest(dirs).StepSize(16).Logger(logger).MustOpen(t.Context(), db)
-		require.NoError(t, agg.OpenFolder())
+		agg := NewTest(dirs).StepSize(16).Logger(logger).MustOpen(t.Context())
+		require.NoError(t, agg.OpenFolder(db))
 
 		start := make(chan struct{})
 		var loops sync.WaitGroup
@@ -129,7 +129,7 @@ func TestAggregatorCloseVsConcurrentBuildFiles2(t *testing.T) {
 			loops.Go(func() {
 				<-start
 				time.Sleep(time.Duration(i) * 250 * time.Microsecond)
-				_ = agg.BuildFiles2(context.Background(), 0, 0, unboundedFinalityCtx, true)
+				_ = agg.BuildFiles2(context.Background(), db, 0, 0, unboundedFinalityCtx, true)
 			})
 		}
 		close(start)
@@ -146,8 +146,8 @@ func TestAggregatorConcurrentClose(t *testing.T) {
 	for range 4 {
 		dirs := datadir.New(t.TempDir())
 		db := mdbxtest.InMem(t, mdbx.New(dbcfg.ChainDB, logger), dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
-		agg := NewTest(dirs).StepSize(16).Logger(logger).MustOpen(t.Context(), db)
-		require.NoError(t, agg.OpenFolder())
+		agg := NewTest(dirs).StepSize(16).Logger(logger).MustOpen(t.Context())
+		require.NoError(t, agg.OpenFolder(db))
 
 		start := make(chan struct{})
 		var closes sync.WaitGroup
@@ -174,8 +174,8 @@ func TestAggregatorCloseReleasesBranchCache(t *testing.T) {
 	dirs := datadir.New(t.TempDir())
 	db := mdbxtest.InMem(t, mdbx.New(dbcfg.ChainDB, logger), dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
 	defer db.Close()
-	agg := NewTest(dirs).StepSize(16).Logger(logger).MustOpen(t.Context(), db)
-	require.NoError(t, agg.OpenFolder())
+	agg := NewTest(dirs).StepSize(16).Logger(logger).MustOpen(t.Context())
+	require.NoError(t, agg.OpenFolder(db))
 
 	cd := agg.d[kv.CommitmentDomain]
 	require.NotNil(t, cd)
@@ -207,7 +207,7 @@ func TestAggregatorOpenFolderKeepsReaderFilesAlive(t *testing.T) {
 	}
 	// generate* helpers hardcode stepSize=10; keep the aggregator consistent.
 	const stepSize = uint64(10)
-	_, agg := testDbAndAggregatorv3(t, stepSize)
+	db, agg := testDbAndAggregatorv3(t, stepSize)
 	dirs := agg.Dirs()
 
 	// All state domains must have matching coverage or the integrity checker hides
@@ -217,7 +217,7 @@ func TestAggregatorOpenFolderKeepsReaderFilesAlive(t *testing.T) {
 	generateStorageFile(t, dirs, ranges)
 	generateCodeFile(t, dirs, ranges)
 	generateCommitmentFile(t, dirs, ranges)
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 
 	// Reader pins the current generation, which still references the newest file.
 	at := agg.BeginFilesRo()
@@ -226,7 +226,7 @@ func TestAggregatorOpenFolderKeepsReaderFilesAlive(t *testing.T) {
 	// An external actor removes the newest accounts file from disk (e.g. after an
 	// unwind or merge cleanup), then the folder is reopened while `at` is still live.
 	require.NoError(t, dir.RemoveFile(domainFileBySuffix(t, dirs.SnapDomain, "accounts.2-3.kv")))
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 
 	var err error
 	require.NotPanics(t, func() {
@@ -246,7 +246,7 @@ func TestAggregatorOpenFolderReclaimKeepsRecreatedFile(t *testing.T) {
 		t.Skip("deletes a file that is still mmapped; not possible on Windows")
 	}
 	const stepSize = uint64(10)
-	_, agg := testDbAndAggregatorv3(t, stepSize)
+	db, agg := testDbAndAggregatorv3(t, stepSize)
 	dirs := agg.Dirs()
 
 	ranges := []testFileRange{{0, 1}, {1, 2}, {2, 3}}
@@ -254,7 +254,7 @@ func TestAggregatorOpenFolderReclaimKeepsRecreatedFile(t *testing.T) {
 	generateStorageFile(t, dirs, ranges)
 	generateCodeFile(t, dirs, ranges)
 	generateCommitmentFile(t, dirs, ranges)
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 
 	at := agg.BeginFilesRo() // pins the generation that references accounts.2-3
 	defer func() {
@@ -266,7 +266,7 @@ func TestAggregatorOpenFolderReclaimKeepsRecreatedFile(t *testing.T) {
 	// External actor removes the newest accounts file; the folder reopens (retiring
 	// it), then the same file is recreated on disk before the reader drains.
 	require.NoError(t, dir.RemoveFile(domainFileBySuffix(t, dirs.SnapDomain, "accounts.2-3.kv")))
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 	generateAccountsFile(t, dirs, []testFileRange{{2, 3}})
 	recreated := domainFileBySuffix(t, dirs.SnapDomain, "accounts.2-3.kv")
 

--- a/db/state/aggregator_finality_test.go
+++ b/db/state/aggregator_finality_test.go
@@ -53,7 +53,7 @@ func (c finalityContextStub) ReadyForCollation(_ context.Context, _ kv.RoDB, _ u
 }
 
 func TestReadyForCollationPreservesFinalityContextResult(t *testing.T) {
-	_, agg := testDbAndAggregatorv3(t, 10)
+	db, agg := testDbAndAggregatorv3(t, 10)
 	finalityCtx := finalityContextStub{
 		finalisedBlockNum: 12,
 		lastBlockInStep:   10,
@@ -61,7 +61,7 @@ func TestReadyForCollationPreservesFinalityContextResult(t *testing.T) {
 		lastTxInDB:        25,
 		ready:             true,
 	}
-	finalisedBlockNum, lastBlockInStep, lastBlockInDB, lastTxInDB, ready, err := agg.readyForCollation(t.Context(), kv.Step(0), finalityCtx)
+	finalisedBlockNum, lastBlockInStep, lastBlockInDB, lastTxInDB, ready, err := agg.readyForCollation(t.Context(), db, kv.Step(0), finalityCtx)
 	require.NoError(t, err)
 	require.True(t, ready)
 	require.Equal(t, uint64(12), finalisedBlockNum)

--- a/db/state/aggregator_fuzz_test.go
+++ b/db/state/aggregator_fuzz_test.go
@@ -121,7 +121,7 @@ func Fuzz_AggregatorV3_Merge(f *testing.F) {
 		err = rwTx.Commit()
 		require.NoError(t, err)
 
-		err = agg.BuildFiles(txs, unboundedFinalityCtx)
+		err = agg.BuildFiles(db, txs, unboundedFinalityCtx)
 		require.NoError(t, err)
 
 		rwTx, err = db.BeginTemporalRw(t.Context())
@@ -221,7 +221,7 @@ func Fuzz_AggregatorV3_MergeValTransform(f *testing.F) {
 		err = rwTx.Commit()
 		require.NoError(t, err)
 
-		err = agg.BuildFiles(txs, unboundedFinalityCtx)
+		err = agg.BuildFiles(db, txs, unboundedFinalityCtx)
 		require.NoError(t, err)
 
 		rwTx, err = db.BeginTemporalRw(t.Context())
@@ -247,10 +247,10 @@ func testFuzzDbAndAggregatorv3(f *testing.F, stepSize uint64) (kv.TemporalRwDB, 
 	db := mdbxtest.InMem(f, mdbx.New(dbcfg.ChainDB, logger), dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
 	f.Cleanup(db.Close)
 
-	agg, err := state.NewTest(dirs).StepSize(stepSize).Logger(logger).Open(f.Context(), db)
+	agg, err := state.NewTest(dirs).StepSize(stepSize).Logger(logger).Open(f.Context())
 	require.NoError(err)
 	f.Cleanup(agg.Close)
-	err = agg.OpenFolder()
+	err = agg.OpenFolder(db)
 	require.NoError(err)
 	tdb, err := temporal.New(db, agg, nil)
 	require.NoError(err)

--- a/db/state/aggregator_refs_test.go
+++ b/db/state/aggregator_refs_test.go
@@ -47,7 +47,7 @@ func openTestAggForRefs(t *testing.T, dirs datadir.Dirs, settings *ErigonDBSetti
 	logger := log.New()
 	db := mdbxtest.InMem(t, mdbx.New(dbcfg.ChainDB, logger), dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
 	t.Cleanup(db.Close)
-	agg := NewTest(dirs).Logger(logger).WithErigonDBSettings(settings).MustOpen(t.Context(), db)
+	agg := NewTest(dirs).Logger(logger).WithErigonDBSettings(settings).MustOpen(t.Context())
 	t.Cleanup(agg.Close)
 	return agg
 }
@@ -61,7 +61,7 @@ func TestReloadErigonDBSettingsAppliesCommitmentRefsFlag(t *testing.T) {
 	logger := log.New()
 	db := mdbxtest.InMem(t, mdbx.New(dbcfg.ChainDB, logger), dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
 	t.Cleanup(db.Close)
-	agg := NewTest(dirs).Logger(logger).MustOpen(t.Context(), db)
+	agg := NewTest(dirs).Logger(logger).MustOpen(t.Context())
 	t.Cleanup(agg.Close)
 
 	require.NoError(t, agg.ReloadErigonDBSettings(true))

--- a/db/state/aggregator_test.go
+++ b/db/state/aggregator_test.go
@@ -173,9 +173,9 @@ func testDbAndAggregatorv3(tb testing.TB, stepSize uint64) (kv.RwDB, *Aggregator
 	db := mdbxtest.InMem(tb, mdbx.New(dbcfg.ChainDB, logger), dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
 	tb.Cleanup(db.Close)
 
-	agg := NewTest(dirs).StepSize(stepSize).Logger(logger).MustOpen(tb.Context(), db)
+	agg := NewTest(dirs).StepSize(stepSize).Logger(logger).MustOpen(tb.Context())
 	tb.Cleanup(agg.Close)
-	err := agg.OpenFolder()
+	err := agg.OpenFolder(db)
 	require.NoError(tb, err)
 	return db, agg
 }
@@ -265,14 +265,14 @@ func Test_helper_decodeAccountv3Bytes(t *testing.T) {
 
 func TestAggregator_CheckDependencyHistoryII(t *testing.T) {
 	stepSize := uint64(10)
-	_, agg := testDbAndAggregatorv3(t, stepSize)
+	db, agg := testDbAndAggregatorv3(t, stepSize)
 
 	generateAccountsFile(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}, {0, 2}})
 	generateCodeFile(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}, {0, 2}})
 	generateStorageFile(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}, {0, 2}})
 	generateCommitmentFile(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
 
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 
 	aggTx := agg.BeginFilesRo()
 	defer aggTx.Close()
@@ -309,7 +309,7 @@ func TestAggregator_CheckDependencyHistoryII(t *testing.T) {
 
 	require.NoError(t, dir.RemoveFile(codeMergedFile))
 
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 	aggTx = agg.BeginFilesRo()
 	defer aggTx.Close()
 
@@ -327,7 +327,7 @@ func TestAggregator_CheckDependencyBtwnDomains(t *testing.T) {
 	// 	stepSize:                         10,
 	// 	disableCommitmentBranchTransform: false,
 	// })
-	_, agg := testDbAndAggregatorv3(t, stepSize)
+	db, agg := testDbAndAggregatorv3(t, stepSize)
 
 	require.NotNil(t, agg.d[kv.AccountsDomain].checker)
 	require.NotNil(t, agg.d[kv.StorageDomain].checker)
@@ -339,7 +339,7 @@ func TestAggregator_CheckDependencyBtwnDomains(t *testing.T) {
 	generateStorageFile(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}, {0, 2}})
 	generateCommitmentFile(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
 
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 
 	aggTx := agg.BeginFilesRo()
 	defer aggTx.Close()
@@ -387,7 +387,7 @@ func TestReceiptFilesVersionAdjust(t *testing.T) {
 		touchFn(t, dirs, "v1.0-receipt.0-2048.kv")
 		touchFn(t, dirs, "v1.0-receipt.2048-2049.kv")
 
-		agg := NewTest(dirs).Logger(logger).MustOpen(t.Context(), db)
+		agg := NewTest(dirs).Logger(logger).MustOpen(t.Context())
 		t.Cleanup(agg.Close)
 
 		kv_versions := agg.d[kv.ReceiptDomain].FileVersion.DataKV
@@ -413,7 +413,7 @@ func TestReceiptFilesVersionAdjust(t *testing.T) {
 		touchFn(t, dirs, "v1.1-receipt.0-2048.kv")
 		touchFn(t, dirs, "v1.1-receipt.2048-2049.kv")
 
-		agg := NewTest(dirs).Logger(logger).MustOpen(t.Context(), db)
+		agg := NewTest(dirs).Logger(logger).MustOpen(t.Context())
 		t.Cleanup(agg.Close)
 
 		kv_versions := agg.d[kv.ReceiptDomain].FileVersion.DataKV
@@ -439,7 +439,7 @@ func TestReceiptFilesVersionAdjust(t *testing.T) {
 		touchFn(t, dirs, "v2.0-receipt.0-2048.kv")
 		touchFn(t, dirs, "v2.0-receipt.2048-2049.kv")
 
-		agg := NewTest(dirs).Logger(logger).MustOpen(t.Context(), db)
+		agg := NewTest(dirs).Logger(logger).MustOpen(t.Context())
 		t.Cleanup(agg.Close)
 
 		kv_versions := agg.d[kv.ReceiptDomain].FileVersion.DataKV
@@ -461,7 +461,7 @@ func TestReceiptFilesVersionAdjust(t *testing.T) {
 
 		db := mdbxtest.InMem(t, mdbx.New(dbcfg.ChainDB, logger), dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
 		t.Cleanup(db.Close)
-		agg := NewTest(dirs).Logger(logger).MustOpen(t.Context(), db)
+		agg := NewTest(dirs).Logger(logger).MustOpen(t.Context())
 		t.Cleanup(agg.Close)
 
 		kv_versions := agg.d[kv.ReceiptDomain].FileVersion.DataKV
@@ -592,7 +592,7 @@ func TestAggregator_BuildFiles_GapRefuses(t *testing.T) {
 	generateStorageFile(t, dirs, []testFileRange{{0, 5}})
 	generateCodeFile(t, dirs, []testFileRange{{0, 5}})
 	generateCommitmentFile(t, dirs, []testFileRange{{0, 5}})
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 
 	// Establish the "MDBX only has step 10" side of the gap.
 	putHistoryKey(t, db, agg.d[kv.AccountsDomain].History.KeysTable, 100, []byte("k"))
@@ -600,7 +600,7 @@ func TestAggregator_BuildFiles_GapRefuses(t *testing.T) {
 	// Ask the aggregator to build up through step 11.
 	// With the guard, step=5 (files cover 0..5), firstInDB=10, firstInDB>step
 	// → refuse. No new accounts file gets produced.
-	require.NoError(t, agg.BuildFiles(11*stepSize, unboundedFinalityCtx))
+	require.NoError(t, agg.BuildFiles(db, 11*stepSize, unboundedFinalityCtx))
 
 	// Only the pre-existing file v1.0-accounts.0-5.kv should be present.
 	files, err := dir.ListFiles(dirs.SnapDomain, ".kv")
@@ -629,7 +629,7 @@ func TestAggregator_BuildFiles_EmptyStepOK(t *testing.T) {
 
 	// BuildFiles must not refuse — the guard's `step > 0` clause should let
 	// this through.
-	require.NoError(t, agg.BuildFiles(2*stepSize, unboundedFinalityCtx))
+	require.NoError(t, agg.BuildFiles(db, 2*stepSize, unboundedFinalityCtx))
 }
 
 // putHistoryKey inserts a single (txNumBE, key) pair into the domain's
@@ -650,7 +650,7 @@ func TestAggregator_CommitmentHistoryOnlyMerge(t *testing.T) {
 	// MergeRange, causing "failed to create commitment value transformer: file
 	// v2.0-storage.0-0.kv was not found".
 	stepSize := uint64(10)
-	_, agg := testDbAndAggregatorv3(t, stepSize)
+	db, agg := testDbAndAggregatorv3(t, stepSize)
 	agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, true)
 	dirs := agg.Dirs()
 
@@ -663,7 +663,7 @@ func TestAggregator_CommitmentHistoryOnlyMerge(t *testing.T) {
 	// Commitment history+index: unmerged {0,1},{1,2} — history.needMerge will be true.
 	generateCommitmentHistoryAndIndexFiles(t, dirs, []testFileRange{{0, 1}, {1, 2}})
 
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 
 	aggTx := agg.BeginFilesRo()
 	r := aggTx.findMergeRange(2*stepSize, stepSize, 32)
@@ -754,7 +754,7 @@ func TestCommitmentVisibleFilesReferenced(t *testing.T) {
 	check := func(t *testing.T, ver version.Version, want bool) {
 		t.Helper()
 		stepSize := uint64(10)
-		_, agg := testDbAndAggregatorv3(t, stepSize)
+		db, agg := testDbAndAggregatorv3(t, stepSize)
 		agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, false)
 		dirs := agg.Dirs()
 		ranges := []testFileRange{{0, 2}}
@@ -762,7 +762,7 @@ func TestCommitmentVisibleFilesReferenced(t *testing.T) {
 		generateStorageFile(t, dirs, ranges)
 		generateCodeFile(t, dirs, ranges)
 		generateCommitmentFile(t, dirs, ranges)
-		require.NoError(t, agg.OpenFolder())
+		require.NoError(t, agg.OpenFolder(db))
 
 		// Drive the verdict by version+range: set the version directly on the dirty FilesItem
 		// (visibleFile.Version reads it live through src), independent of the generated file name.

--- a/db/state/aggregator_visible_from_test.go
+++ b/db/state/aggregator_visible_from_test.go
@@ -29,7 +29,7 @@ import (
 // whatever generation is current when it runs.
 func TestFilesPin_PinsSourceGeneration(t *testing.T) {
 	stepSize := uint64(10)
-	_, agg := testDbAndAggregatorv3(t, stepSize)
+	db, agg := testDbAndAggregatorv3(t, stepSize)
 
 	gen := func(ranges []testFileRange) {
 		t.Helper()
@@ -37,7 +37,7 @@ func TestFilesPin_PinsSourceGeneration(t *testing.T) {
 		generateCodeFile(t, agg.Dirs(), ranges)
 		generateStorageFile(t, agg.Dirs(), ranges)
 		generateCommitmentFile(t, agg.Dirs(), ranges)
-		require.NoError(t, agg.OpenFolder())
+		require.NoError(t, agg.OpenFolder(db))
 	}
 
 	gen([]testFileRange{{0, 1}})

--- a/db/state/commitment_merge_version_test.go
+++ b/db/state/commitment_merge_version_test.go
@@ -49,7 +49,7 @@ func TestCommitmentMergeFlagOffExpandsReferencedInputs(t *testing.T) {
 	agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, true)
 	writeStepsKeys(t, db, agg, setA, 0, 6)
 	writeStepsKeys(t, db, agg, setB, 6, 32)
-	require.NoError(t, agg.BuildFiles(32*stepSize, unboundedFinalityCtx))
+	require.NoError(t, agg.BuildFiles(db, 32*stepSize, unboundedFinalityCtx))
 
 	in016 := filepath.Join(dirs.SnapDomain, "v2.1-commitment.0-16.kv")
 	_, shortIn := branchKeyKinds(t, in016)
@@ -58,7 +58,7 @@ func TestCommitmentMergeFlagOffExpandsReferencedInputs(t *testing.T) {
 	// phase 2: flag off -> the merge consuming the v2.1 inputs must produce plain (v2.2) output
 	agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, false)
 	writeStepsKeys(t, db, agg, setB, 32, 64)
-	require.NoError(t, agg.BuildFiles(64*stepSize, unboundedFinalityCtx))
+	require.NoError(t, agg.BuildFiles(db, 64*stepSize, unboundedFinalityCtx))
 	require.NoError(t, agg.MergeLoop(t.Context()))
 
 	merged := filepath.Join(dirs.SnapDomain, "v2.2-commitment.0-32.kv")
@@ -68,8 +68,8 @@ func TestCommitmentMergeFlagOffExpandsReferencedInputs(t *testing.T) {
 
 	// reopen from disk (file versions parsed from names) and confirm the state still reads back
 	db, agg = reopenAggregator(t, db, agg, stepSize)
-	require.NoError(t, agg.OpenFolder())
-	require.NoError(t, agg.BuildMissedAccessors(t.Context(), 1))
+	require.NoError(t, agg.OpenFolder(db))
+	require.NoError(t, agg.BuildMissedAccessors(t.Context(), db, 1))
 	assertCommitmentVersionConsistency(t, dirs.SnapDomain)
 	require.NotEmpty(t, recomputeRootFromState(t, db))
 }
@@ -92,8 +92,8 @@ func TestCommitmentRebuildSqueezeReadableAfterReload(t *testing.T) {
 
 	// reopen fresh so commitment file versions come from the on-disk names
 	db, agg = reopenAggregator(t, db, agg, stepSize)
-	require.NoError(t, agg.OpenFolder())
-	require.NoError(t, agg.BuildMissedAccessors(t.Context(), 1))
+	require.NoError(t, agg.OpenFolder(db))
+	require.NoError(t, agg.BuildMissedAccessors(t.Context(), db, 1))
 
 	referenced := assertCommitmentVersionConsistency(t, dirs.SnapDomain)
 	require.Positive(t, referenced, "squeeze must produce referenced (v2.1) commitment files")
@@ -111,7 +111,7 @@ func TestMergedCommitmentFileVersionStampedInMemory(t *testing.T) {
 
 	agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, false)
 	writeStepsKeys(t, db, agg, keys, 0, 8)
-	require.NoError(t, agg.BuildFiles(8*stepSize, unboundedFinalityCtx))
+	require.NoError(t, agg.BuildFiles(db, 8*stepSize, unboundedFinalityCtx))
 	require.NoError(t, agg.MergeLoop(t.Context()))
 
 	tx, err := db.BeginTemporalRw(t.Context())

--- a/db/state/commitment_version_testutil_test.go
+++ b/db/state/commitment_version_testutil_test.go
@@ -254,17 +254,17 @@ func buildMixedRegimeDatadir(t *testing.T, stepSize, frozenSteps uint64) (kv.Tem
 	agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, true)
 	writeStepsKeys(t, db, agg, setA, 0, frozenSteps)
 	writeStepsKeys(t, db, agg, setB, frozenSteps, 2*frozenSteps)
-	require.NoError(t, agg.BuildFiles(2*frozenSteps*stepSize, unboundedFinalityCtx))
+	require.NoError(t, agg.BuildFiles(db, 2*frozenSteps*stepSize, unboundedFinalityCtx))
 	require.NoError(t, agg.MergeLoop(t.Context()))
 
 	agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, false)
 	writeStepsKeys(t, db, agg, setB, 2*frozenSteps, 3*frozenSteps)
-	require.NoError(t, agg.BuildFiles(3*frozenSteps*stepSize, unboundedFinalityCtx))
+	require.NoError(t, agg.BuildFiles(db, 3*frozenSteps*stepSize, unboundedFinalityCtx))
 	require.NoError(t, agg.MergeLoop(t.Context()))
 
 	db, agg = reopenAggregator(t, db, agg, stepSize)
-	require.NoError(t, agg.OpenFolder())
-	require.NoError(t, agg.BuildMissedAccessors(t.Context(), 1))
+	require.NoError(t, agg.OpenFolder(db))
+	require.NoError(t, agg.BuildMissedAccessors(t.Context(), db, 1))
 	return db, agg, dirs, setA, setB
 }
 
@@ -328,10 +328,10 @@ func wipeCommitment(t *testing.T, db kv.TemporalRwDB, agg *state.Aggregator, dir
 		}
 	}
 
-	newAgg := testAgg(t, db, dirs, stepSize, log.New())
+	newAgg := testAgg(t, dirs, stepSize, log.New())
 	newDB, err := temporal.New(db, newAgg, nil)
 	require.NoError(t, err)
-	require.NoError(t, newAgg.OpenFolder())
+	require.NoError(t, newAgg.OpenFolder(newDB))
 
 	remaining := collectCommitmentFiles(t, dirs)
 	require.Empty(t, remaining, "commitment files must be fully removed after wipe")
@@ -344,7 +344,7 @@ func reopenAggregator(t *testing.T, db kv.TemporalRwDB, agg *state.Aggregator, s
 	dirs := agg.Dirs()
 	agg.Close()
 
-	newAgg := testAgg(t, db, dirs, stepSize, log.New())
+	newAgg := testAgg(t, dirs, stepSize, log.New())
 	newDB, err := temporal.New(db, newAgg, nil)
 	require.NoError(t, err)
 

--- a/db/state/execctx/branch_cache_flush_test.go
+++ b/db/state/execctx/branch_cache_flush_test.go
@@ -73,7 +73,7 @@ func commitmentFileFixture(t *testing.T, stepSize uint64) (kv.TemporalRwDB, []by
 	value := []byte{0, 0, 0, 0, 1}
 	writeCommitmentRows(t, db, key, nil, commitmentWrite{txNum: 5, value: value})
 	writeAggregationGuard(t, db, 20)
-	require.NoError(t, db.(state.HasAgg).Agg().(*state.Aggregator).BuildFiles(stepSize, unboundedFinalityCtx))
+	require.NoError(t, db.(state.HasAgg).Agg().(*state.Aggregator).BuildFiles(db, stepSize, unboundedFinalityCtx))
 	return db, key, value
 }
 
@@ -92,7 +92,7 @@ func mergedCommitmentFileFixture(t *testing.T, stepSize uint64) (kv.TemporalRwDB
 	writeCommitmentRows(t, db, commitmentdb.KeyCommitmentState, nil, commitmentWrite{txNum: 20, value: commitmentState})
 	writeAggregationGuard(t, db, 40)
 	agg := db.(state.HasAgg).Agg().(*state.Aggregator)
-	require.NoError(t, agg.BuildFiles(2*stepSize, unboundedFinalityCtx))
+	require.NoError(t, agg.BuildFiles(db, 2*stepSize, unboundedFinalityCtx))
 	require.NoError(t, agg.MergeLoop(t.Context()))
 	roTx, err := db.BeginTemporalRo(t.Context())
 	require.NoError(t, err)

--- a/db/state/execctx/domain_shared_test.go
+++ b/db/state/execctx/domain_shared_test.go
@@ -65,9 +65,9 @@ func newTestDb(tb testing.TB, stepSize uint64) kv.TemporalRwDB {
 	db := mdbxtest.InMem(tb, mdbx.New(dbcfg.ChainDB, logger), dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
 	tb.Cleanup(db.Close)
 
-	agg := NewTest(dirs).StepSize(stepSize).Logger(logger).MustOpen(tb.Context(), db)
+	agg := NewTest(dirs).StepSize(stepSize).Logger(logger).MustOpen(tb.Context())
 	tb.Cleanup(agg.Close)
-	err := agg.OpenFolder()
+	err := agg.OpenFolder(db)
 	require.NoError(tb, err)
 	tdb, err := temporal.New(db, agg, nil)
 	require.NoError(tb, err)
@@ -1028,7 +1028,7 @@ func TestSharedDomain_StorageIter(t *testing.T) {
 	err = rwTx.Commit()
 	require.NoError(t, err)
 
-	err = db.(state.HasAgg).Agg().(*state.Aggregator).BuildFiles(maxTx-stepSize, unboundedFinalityCtx)
+	err = db.(state.HasAgg).Agg().(*state.Aggregator).BuildFiles(db, maxTx-stepSize, unboundedFinalityCtx)
 	require.NoError(t, err)
 
 	{ //prune
@@ -1204,7 +1204,7 @@ func TestSharedDomain_IteratePrefix(t *testing.T) {
 		domains.Close()
 		err = rwTx.Commit() // otherwise agg.BuildFiles will not see data
 		require.NoError(err)
-		require.NoError(db.(state.HasAgg).Agg().(*state.Aggregator).BuildFiles(stepSize*2, unboundedFinalityCtx))
+		require.NoError(db.(state.HasAgg).Agg().(*state.Aggregator).BuildFiles(db, stepSize*2, unboundedFinalityCtx))
 
 		rwTx, err = db.BeginTemporalRw(ctx)
 		require.NoError(err)
@@ -1382,7 +1382,7 @@ func TestSharedDomain_HasPrefix_StorageDomain(t *testing.T) {
 		require.NoError(t, err)
 
 		// build files
-		err = db.(state.HasAgg).Agg().(*state.Aggregator).BuildFiles(2, unboundedFinalityCtx)
+		err = db.(state.HasAgg).Agg().(*state.Aggregator).BuildFiles(db, 2, unboundedFinalityCtx)
 		require.NoError(t, err)
 		rwTtx3, err := db.BeginTemporalRw(ctx)
 		require.NoError(t, err)

--- a/db/state/execctx_test/statecache_rpc_integration_test.go
+++ b/db/state/execctx_test/statecache_rpc_integration_test.go
@@ -544,9 +544,9 @@ func newTestDb(tb testing.TB, stepSize uint64) kv.TemporalRwDB {
 	db := mdbxtest.InMem(tb, mdbx.New(dbcfg.ChainDB, logger), dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
 	tb.Cleanup(db.Close)
 
-	agg := dbstate.NewTest(dirs).StepSize(stepSize).Logger(logger).MustOpen(tb.Context(), db)
+	agg := dbstate.NewTest(dirs).StepSize(stepSize).Logger(logger).MustOpen(tb.Context())
 	tb.Cleanup(agg.Close)
-	err := agg.OpenFolder()
+	err := agg.OpenFolder(db)
 	require.NoError(tb, err)
 	tdb, err := temporal.New(db, agg, nil)
 	require.NoError(tb, err)

--- a/db/state/gc_test.go
+++ b/db/state/gc_test.go
@@ -30,14 +30,14 @@ import (
 // generateAllDomainsOverlap writes {0,1},{1,2} subset files shadowed by a {0,2}
 // covering file for every state domain, so that overlap-cleanup has garbage to
 // retire after OpenFolder.
-func generateAllDomainsOverlap(t *testing.T, agg *Aggregator) {
+func generateAllDomainsOverlap(t *testing.T, db kv.RoDB, agg *Aggregator) {
 	t.Helper()
 	ranges := []testFileRange{{0, 1}, {1, 2}, {0, 2}}
 	generateAccountsFile(t, agg.Dirs(), ranges)
 	generateCodeFile(t, agg.Dirs(), ranges)
 	generateStorageFile(t, agg.Dirs(), ranges)
 	generateCommitmentFile(t, agg.Dirs(), ranges)
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 }
 
 func mustExist(t *testing.T, path string, want bool) {
@@ -53,8 +53,8 @@ func mustExist(t *testing.T, path string, want bool) {
 // closes. A reader opened after retirement no longer sees it.
 func TestAggregatorReadAfterRetire(t *testing.T) {
 	stepSize := uint64(10)
-	_, agg := testDbAndAggregatorv3(t, stepSize)
-	generateAllDomainsOverlap(t, agg)
+	db, agg := testDbAndAggregatorv3(t, stepSize)
+	generateAllDomainsOverlap(t, db, agg)
 
 	// subset (overlap) files for the accounts history — shadowed by 0-2, non-frozen
 	subset01 := filepath.Join(agg.Dirs().SnapHistory, "v1.0-accounts.0-1.v")
@@ -96,8 +96,8 @@ func TestAggregatorReadAfterRetire(t *testing.T) {
 // under a concurrent accessor build.
 func TestAggregatorRetireDeferredWhileDebugPins(t *testing.T) {
 	stepSize := uint64(10)
-	_, agg := testDbAndAggregatorv3(t, stepSize)
-	generateAllDomainsOverlap(t, agg)
+	db, agg := testDbAndAggregatorv3(t, stepSize)
+	generateAllDomainsOverlap(t, db, agg)
 
 	subset01 := filepath.Join(agg.Dirs().SnapHistory, "v1.0-accounts.0-1.v")
 	mustExist(t, subset01, true)
@@ -119,8 +119,8 @@ func TestAggregatorRetireDeferredWhileDebugPins(t *testing.T) {
 // of FilesItem regardless of how Close and reclamation interleave.
 func TestAggregatorReclaimConcurrent(t *testing.T) {
 	stepSize := uint64(10)
-	_, agg := testDbAndAggregatorv3(t, stepSize)
-	generateAllDomainsOverlap(t, agg)
+	db, agg := testDbAndAggregatorv3(t, stepSize)
+	generateAllDomainsOverlap(t, db, agg)
 
 	var wg sync.WaitGroup
 	stop := make(chan struct{})

--- a/db/state/merge_test.go
+++ b/db/state/merge_test.go
@@ -1377,7 +1377,7 @@ func TestHistoryAndIIAlignment(t *testing.T) {
 	db := mdbxtest.InMem(t, mdbx.New(dbcfg.ChainDB, logger), dirs.Chaindata).MustOpen()
 	t.Cleanup(db.Close)
 
-	agg := NewTest(dirs).Logger(logger).StepSize(1).MustOpen(t.Context(), db)
+	agg := NewTest(dirs).Logger(logger).StepSize(1).MustOpen(t.Context())
 	t.Cleanup(agg.Close)
 	setup := func() (account *Domain) {
 		require.NoError(t, agg.RegisterDomain(statecfg.Schema.GetDomainCfg(kv.AccountsDomain), nil, dirs, logger))

--- a/db/state/rebuild_shard_merge_test.go
+++ b/db/state/rebuild_shard_merge_test.go
@@ -54,7 +54,7 @@ func TestAggregator_RebuildCommitmentAcrossMergedShards(t *testing.T) {
 		stepSize:                         stepSize,
 		disableCommitmentBranchTransform: true,
 	})
-	require.NoError(t, agg.BuildFiles(uint64(txCount), unboundedFinalityCtx))
+	require.NoError(t, agg.BuildFiles(db, uint64(txCount), unboundedFinalityCtx))
 
 	var rootInFiles []byte
 	var fPaths []string
@@ -85,7 +85,7 @@ func TestAggregator_RebuildCommitmentAcrossMergedShards(t *testing.T) {
 		agg.Close()
 	}
 
-	agg = testAgg(t, db, agg.Dirs(), stepSize, log.New())
+	agg = testAgg(t, agg.Dirs(), stepSize, log.New())
 	db, err := temporal.New(db, agg, nil)
 	require.NoError(t, err)
 	defer db.Close()
@@ -107,7 +107,7 @@ func TestAggregator_RebuildCommitmentAcrossMergedShards(t *testing.T) {
 			require.NoError(t, dir.RemoveFile(fn))
 		}
 	}
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 
 	finalRoot, err := state.RebuildCommitmentFiles(t.Context(), db, &rawdbv3.TxNums, log.New(), false)
 	require.NoError(t, err)

--- a/db/state/retire_history_test.go
+++ b/db/state/retire_history_test.go
@@ -37,16 +37,16 @@ import (
 
 // testDbAndAggregatorSmallFrozen is like testDbAndAggregatorv3 but with a
 // configurable stepsInFrozenFile, so "frozen" files can use small step ranges.
-func testDbAndAggregatorSmallFrozen(t *testing.T, stepSize, stepsInFrozenFile uint64) *Aggregator {
+func testDbAndAggregatorSmallFrozen(t *testing.T, stepSize, stepsInFrozenFile uint64) (kv.RwDB, *Aggregator) {
 	t.Helper()
 	logger := log.New()
 	dirs := datadir.New(t.TempDir())
 	db := mdbxtest.InMem(t, mdbx.New(dbcfg.ChainDB, logger), dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
 	t.Cleanup(db.Close)
-	agg := NewTest(dirs).StepSize(stepSize).StepsInFrozenFile(stepsInFrozenFile).Logger(logger).MustOpen(t.Context(), db)
+	agg := NewTest(dirs).StepSize(stepSize).StepsInFrozenFile(stepsInFrozenFile).Logger(logger).MustOpen(t.Context())
 	t.Cleanup(agg.Close)
-	require.NoError(t, agg.OpenFolder())
-	return agg
+	require.NoError(t, agg.OpenFolder(db))
+	return db, agg
 }
 
 // aggRetire runs Retire on a fresh RoTx (Retire is an AggregatorRoTx method). Tests that must
@@ -87,7 +87,7 @@ func generateStandaloneIIFile(t *testing.T, name kv.InvertedIdx, dirs datadir.Di
 // drain), while one still at/after cutoff is kept.
 func TestRetire_RetiresFrozenFileEntirelyBelowCutoff(t *testing.T) {
 	stepSize, stepsInFrozenFile := uint64(10), uint64(2)
-	agg := testDbAndAggregatorSmallFrozen(t, stepSize, stepsInFrozenFile)
+	db, agg := testDbAndAggregatorSmallFrozen(t, stepSize, stepsInFrozenFile)
 
 	// {0,2}: frozen (2 steps == stepsInFrozenFile). {2,3}: recent, kept.
 	// Storage/Code need matching files too, or dirtyFilesEndTxNumMinimax
@@ -96,7 +96,7 @@ func TestRetire_RetiresFrozenFileEntirelyBelowCutoff(t *testing.T) {
 	generateAccountsFile(t, agg.Dirs(), ranges)
 	generateCodeFile(t, agg.Dirs(), ranges)
 	generateStorageFile(t, agg.Dirs(), ranges)
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 
 	oldHistory := filepath.Join(agg.Dirs().SnapHistory, "v1.0-accounts.0-2.v")
 	oldIdx := filepath.Join(agg.Dirs().SnapIdx, "v1.0-accounts.0-2.ef")
@@ -159,7 +159,7 @@ func enableCommitmentHistory(agg *Aggregator) {
 // at its own cutoff, independent of Default (0 here).
 func TestRetire_RetiresCommitmentAtOwnCutoff(t *testing.T) {
 	stepSize, stepsInFrozenFile := uint64(10), uint64(2)
-	agg := testDbAndAggregatorSmallFrozen(t, stepSize, stepsInFrozenFile)
+	db, agg := testDbAndAggregatorSmallFrozen(t, stepSize, stepsInFrozenFile)
 
 	// State domains lead the visible ceiling (dirtyFilesEndTxNumMinimax). Without them
 	// commitment history is clamped out of the visible set that Retire reads.
@@ -167,7 +167,7 @@ func TestRetire_RetiresCommitmentAtOwnCutoff(t *testing.T) {
 	generateCodeFile(t, agg.Dirs(), []testFileRange{{0, 2}, {2, 3}})
 	generateStorageFile(t, agg.Dirs(), []testFileRange{{0, 2}, {2, 3}})
 	generateCommitmentHistoryAndIndexFiles(t, agg.Dirs(), []testFileRange{{0, 2}, {2, 3}})
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 	enableCommitmentHistory(agg)
 
 	commitmentHist := agg.d[kv.CommitmentDomain].History
@@ -186,7 +186,7 @@ func TestRetire_RetiresCommitmentAtOwnCutoff(t *testing.T) {
 // commitment keep-all and the RCacheDomain skip are expressed).
 func TestRetire_KeepsDomainWhenCutoffZero(t *testing.T) {
 	stepSize, stepsInFrozenFile := uint64(10), uint64(2)
-	agg := testDbAndAggregatorSmallFrozen(t, stepSize, stepsInFrozenFile)
+	db, agg := testDbAndAggregatorSmallFrozen(t, stepSize, stepsInFrozenFile)
 
 	// State domains lead the visible ceiling (dirtyFilesEndTxNumMinimax). Without them
 	// commitment history is clamped out of the visible set that Retire reads.
@@ -194,7 +194,7 @@ func TestRetire_KeepsDomainWhenCutoffZero(t *testing.T) {
 	generateCodeFile(t, agg.Dirs(), []testFileRange{{0, 2}, {2, 3}})
 	generateStorageFile(t, agg.Dirs(), []testFileRange{{0, 2}, {2, 3}})
 	generateCommitmentHistoryAndIndexFiles(t, agg.Dirs(), []testFileRange{{0, 2}, {2, 3}})
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 	enableCommitmentHistory(agg)
 
 	commitmentHist := agg.d[kv.CommitmentDomain].History
@@ -212,12 +212,12 @@ func TestRetire_KeepsDomainWhenCutoffZero(t *testing.T) {
 // txNum→step floor).
 func TestRetire_SubStepTxNumKeepsFiles(t *testing.T) {
 	stepSize, stepsInFrozenFile := uint64(10), uint64(2)
-	agg := testDbAndAggregatorSmallFrozen(t, stepSize, stepsInFrozenFile)
+	db, agg := testDbAndAggregatorSmallFrozen(t, stepSize, stepsInFrozenFile)
 
 	generateAccountsFile(t, agg.Dirs(), []testFileRange{{0, 2}})
 	generateCodeFile(t, agg.Dirs(), []testFileRange{{0, 2}})
 	generateStorageFile(t, agg.Dirs(), []testFileRange{{0, 2}})
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 
 	n, err := aggRetire(t, agg, kv.RetireCutoffs{Default: stepSize - 1})
 	require.NoError(t, err)
@@ -229,7 +229,7 @@ func TestRetire_SubStepTxNumKeepsFiles(t *testing.T) {
 // (LogAddrIdx et al.), separate from the per-domain loop.
 func TestRetire_StandaloneII(t *testing.T) {
 	stepSize, stepsInFrozenFile := uint64(10), uint64(2)
-	agg := testDbAndAggregatorSmallFrozen(t, stepSize, stepsInFrozenFile)
+	db, agg := testDbAndAggregatorSmallFrozen(t, stepSize, stepsInFrozenFile)
 
 	ranges := []testFileRange{{0, 2}, {2, 3}}
 	// State domains lead the visible ceiling that Retire reads (see dirtyFilesEndTxNumMinimax).
@@ -237,7 +237,7 @@ func TestRetire_StandaloneII(t *testing.T) {
 	generateCodeFile(t, agg.Dirs(), ranges)
 	generateStorageFile(t, agg.Dirs(), ranges)
 	generateStandaloneIIFile(t, kv.LogAddrIdx, agg.Dirs(), ranges)
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 
 	oldIdx := filepath.Join(agg.Dirs().SnapIdx, "v1.0-logaddrs.0-2.ef")
 	recentIdx := filepath.Join(agg.Dirs().SnapIdx, "v1.0-logaddrs.2-3.ef")
@@ -258,13 +258,13 @@ func TestRetire_StandaloneII(t *testing.T) {
 // against concurrent retirement under the race detector.
 func TestRetire_ReclaimConcurrent(t *testing.T) {
 	stepSize, stepsInFrozenFile := uint64(10), uint64(2)
-	agg := testDbAndAggregatorSmallFrozen(t, stepSize, stepsInFrozenFile)
+	db, agg := testDbAndAggregatorSmallFrozen(t, stepSize, stepsInFrozenFile)
 
 	ranges := []testFileRange{{0, 2}, {2, 3}}
 	generateAccountsFile(t, agg.Dirs(), ranges)
 	generateCodeFile(t, agg.Dirs(), ranges)
 	generateStorageFile(t, agg.Dirs(), ranges)
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 
 	var wg sync.WaitGroup
 	stop := make(chan struct{})
@@ -295,13 +295,13 @@ func TestRetire_ReclaimConcurrent(t *testing.T) {
 // would be rebuilt back into visible by the next recalcVisibleFiles.
 func TestRetire_DetachesFromDirtyFiles(t *testing.T) {
 	stepSize, stepsInFrozenFile := uint64(10), uint64(2)
-	agg := testDbAndAggregatorSmallFrozen(t, stepSize, stepsInFrozenFile)
+	db, agg := testDbAndAggregatorSmallFrozen(t, stepSize, stepsInFrozenFile)
 
 	ranges := []testFileRange{{0, 2}, {2, 3}}
 	generateAccountsFile(t, agg.Dirs(), ranges)
 	generateCodeFile(t, agg.Dirs(), ranges)
 	generateStorageFile(t, agg.Dirs(), ranges)
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 
 	accountsHist := agg.d[kv.AccountsDomain].History
 	require.Equal(t, 2, accountsHist.dirtyFiles.Len())
@@ -324,13 +324,13 @@ func TestRetire_DetachesFromDirtyFiles(t *testing.T) {
 // cutoff is covered garbage left to the merge clean-up, not retired here.
 func TestRetire_SkipsDirtyButNotVisibleFile(t *testing.T) {
 	stepSize, stepsInFrozenFile := uint64(10), uint64(2)
-	agg := testDbAndAggregatorSmallFrozen(t, stepSize, stepsInFrozenFile)
+	db, agg := testDbAndAggregatorSmallFrozen(t, stepSize, stepsInFrozenFile)
 
 	ranges := []testFileRange{{0, 2}, {0, 4}}
 	generateAccountsFile(t, agg.Dirs(), ranges)
 	generateCodeFile(t, agg.Dirs(), ranges)
 	generateStorageFile(t, agg.Dirs(), ranges)
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 
 	accountsHist := agg.d[kv.AccountsDomain].History
 	require.Equal(t, 2, accountsHist.dirtyFiles.Len())
@@ -354,13 +354,13 @@ func TestRetire_SkipsDirtyButNotVisibleFile(t *testing.T) {
 // retries once the tip advances — it must not error and poison retirement of the healthy ones.
 func TestRetire_SkipsWindowTooSmall(t *testing.T) {
 	stepSize, stepsInFrozenFile := uint64(10), uint64(2)
-	agg := testDbAndAggregatorSmallFrozen(t, stepSize, stepsInFrozenFile)
+	db, agg := testDbAndAggregatorSmallFrozen(t, stepSize, stepsInFrozenFile)
 
 	ranges := []testFileRange{{0, 2}, {2, 3}}
 	generateAccountsFile(t, agg.Dirs(), ranges)
 	generateCodeFile(t, agg.Dirs(), ranges)
 	generateStorageFile(t, agg.Dirs(), ranges)
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 
 	accountsHist := agg.d[kv.AccountsDomain].History
 	require.Equal(t, 2, accountsHist.dirtyFiles.Len())

--- a/db/state/squeeze.go
+++ b/db/state/squeeze.go
@@ -601,7 +601,7 @@ func RebuildCommitmentFilesWithHistory(ctx context.Context, rwDb kv.TemporalRwDB
 		fromStep := kv.Step(a.EndTxNumMinimax() / a.StepSize())
 		toStep := kv.Step((lastToTxNum + 1) / a.StepSize())
 		logger.Info("[rebuild_commitment_history] build files", "fromStep", fromStep, "toStep", toStep, "lastToTxNum", lastToTxNum)
-		if err := a.BuildFiles2(ctx, fromStep, toStep, finalityCtx, false); err != nil {
+		if err := a.BuildFiles2(ctx, rwDb, fromStep, toStep, finalityCtx, false); err != nil {
 			return err
 		}
 		a.WaitForFiles()
@@ -864,7 +864,7 @@ func RebuildCommitmentFilesWithHistory(ctx context.Context, rwDb kv.TemporalRwDB
 		logger.Warn("[rebuild_commitment_history] failed to reload folder after squeeze", "err", err)
 	}
 
-	if err = a.BuildMissedAccessors(ctx, 4); err != nil {
+	if err = a.BuildMissedAccessors(ctx, rwDb, 4); err != nil {
 		logger.Warn("[rebuild_commitment_history] failed to build missed accessors", "err", err)
 		return nil, err
 	}
@@ -960,7 +960,7 @@ func RebuildCommitmentFiles(ctx context.Context, rwDb kv.TemporalRwDB, txNumsRea
 			continue
 		}
 
-		roTx, err := a.db.BeginRo(ctx)
+		roTx, err := rwDb.BeginRo(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -1161,7 +1161,7 @@ func RebuildCommitmentFiles(ctx context.Context, rwDb kv.TemporalRwDB, txNumsRea
 		logger.Warn("[squeeze] failed to reload folder after squeeze", "err", err)
 	}
 
-	if err = a.BuildMissedAccessors(ctx, 4); err != nil {
+	if err = a.BuildMissedAccessors(ctx, rwDb, 4); err != nil {
 		logger.Warn("[squeeze] failed to build missed accessors", "err", err)
 		return nil, err
 	}

--- a/db/state/squeeze_test.go
+++ b/db/state/squeeze_test.go
@@ -50,7 +50,7 @@ func testDbAggregatorWithFiles(tb testing.TB, cfg *testAggConfig) (kv.TemporalRw
 	db, agg := testDbAggregatorWithNoFiles(tb, txCount, cfg)
 
 	// build files out of db
-	err := agg.BuildFiles(uint64(txCount), unboundedFinalityCtx)
+	err := agg.BuildFiles(db, uint64(txCount), unboundedFinalityCtx)
 	require.NoError(tb, err)
 	return db, agg
 }
@@ -118,8 +118,8 @@ func testDbAndAggregatorForLargeData(tb testing.TB, aggStep uint64, persistentDi
 	}
 	tb.Cleanup(db.Close)
 
-	agg := testAgg(tb, db, dirs, aggStep, logger)
-	err := agg.OpenFolder()
+	agg := testAgg(tb, dirs, aggStep, logger)
+	err := agg.OpenFolder(db)
 	require.NoError(tb, err)
 	tdb, err := temporal.New(db, agg, nil)
 	require.NoError(tb, err)
@@ -134,8 +134,8 @@ func testDbAndAggregatorv3(tb testing.TB, aggStep uint64) (kv.TemporalRwDB, *sta
 	db := mdbxtest.InMem(tb, mdbx.New(dbcfg.ChainDB, logger), dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
 	tb.Cleanup(db.Close)
 
-	agg := testAgg(tb, db, dirs, aggStep, logger)
-	err := agg.OpenFolder()
+	agg := testAgg(tb, dirs, aggStep, logger)
+	err := agg.OpenFolder(db)
 	require.NoError(tb, err)
 	tdb, err := temporal.New(db, agg, nil)
 	require.NoError(tb, err)
@@ -143,10 +143,10 @@ func testDbAndAggregatorv3(tb testing.TB, aggStep uint64) (kv.TemporalRwDB, *sta
 	return tdb, agg
 }
 
-func testAgg(tb testing.TB, db kv.RwDB, dirs datadir.Dirs, aggStep uint64, logger log.Logger) *state.Aggregator {
+func testAgg(tb testing.TB, dirs datadir.Dirs, aggStep uint64, logger log.Logger) *state.Aggregator {
 	tb.Helper()
 
-	agg := state.NewTest(dirs).StepSize(aggStep).Logger(logger).MustOpen(tb.Context(), db)
+	agg := state.NewTest(dirs).StepSize(aggStep).Logger(logger).MustOpen(tb.Context())
 	tb.Cleanup(agg.Close)
 	return agg
 }
@@ -239,7 +239,7 @@ func TestAggregator_SqueezeCommitment(t *testing.T) {
 	// Squeeze leaves the rewritten files without accessors, so every production
 	// caller reloads and rebuilds before reading them again.
 	require.NoError(t, agg.ReloadFiles())
-	require.NoError(t, agg.BuildMissedAccessors(t.Context(), 4))
+	require.NoError(t, agg.BuildMissedAccessors(t.Context(), db, 4))
 
 	rwTx, err = db.BeginTemporalRw(t.Context())
 	require.NoError(t, err)
@@ -376,7 +376,7 @@ func TestAggregator_RebuildCommitmentBasedOnFiles(t *testing.T) {
 		//db.Close()
 	}
 
-	agg = testAgg(t, db, agg.Dirs(), agg.StepSize(), log.New())
+	agg = testAgg(t, agg.Dirs(), agg.StepSize(), log.New())
 	db, err := temporal.New(db, agg, nil)
 	require.NoError(t, err)
 	defer db.Close()
@@ -406,7 +406,7 @@ func TestAggregator_RebuildCommitmentBasedOnFiles(t *testing.T) {
 			//t.Logf("removed file %s", filepath.Base(fn))
 		}
 	}
-	err = agg.OpenFolder()
+	err = agg.OpenFolder(db)
 	require.NoError(t, err)
 
 	ctx := t.Context()
@@ -574,15 +574,15 @@ func aggregatorV3_RestartOnDatadir(t *testing.T, rc runCfg) {
 	err = tx.Commit()
 	require.NoError(t, err)
 
-	err = agg.BuildFiles(txs, unboundedFinalityCtx)
+	err = agg.BuildFiles(db, txs, unboundedFinalityCtx)
 	require.NoError(t, err)
 
 	agg.Close()
 
 	// Start another aggregator on same datadir
-	anotherAgg := state.NewTest(agg.Dirs()).StepSize(aggStep).Logger(logger).MustOpen(t.Context(), db)
+	anotherAgg := state.NewTest(agg.Dirs()).StepSize(aggStep).Logger(logger).MustOpen(t.Context())
 	defer anotherAgg.Close()
-	require.NoError(t, anotherAgg.OpenFolder())
+	require.NoError(t, anotherAgg.OpenFolder(db))
 
 	db, err = temporal.New(db, anotherAgg, nil) // to set aggregator in the db
 	require.NoError(t, err)
@@ -792,7 +792,7 @@ func TestGenerateCommitmentRebuildData(t *testing.T) {
 
 	// Build files
 	t.Logf("Building files for %d txs...", totalTxs)
-	err = agg.BuildFiles(totalTxs, unboundedFinalityCtx)
+	err = agg.BuildFiles(db, totalTxs, unboundedFinalityCtx)
 	require.NoError(t, err)
 
 	// Validate

--- a/db/test/aggregator_ext_test.go
+++ b/db/test/aggregator_ext_test.go
@@ -130,7 +130,7 @@ func TestAggregatorV3_RestartOnFiles(t *testing.T) {
 	err = tx.Commit()
 	require.NoError(t, err)
 
-	err = agg.BuildFiles(txs, unboundedFinalityCtx)
+	err = agg.BuildFiles(db, txs, unboundedFinalityCtx)
 	require.NoError(t, err)
 
 	agg.Close()
@@ -143,9 +143,9 @@ func TestAggregatorV3_RestartOnFiles(t *testing.T) {
 	newDb := mdbxtest.InMem(t, mdbx.New(dbcfg.ChainDB, logger), dirs.Chaindata).MustOpen()
 	t.Cleanup(newDb.Close)
 
-	newAgg := state.New(agg.Dirs()).StepSize(stepSize).StepsInFrozenFile(config3.DefaultStepsInFrozenFile).MustOpen(ctx, newDb)
+	newAgg := state.New(agg.Dirs()).StepSize(stepSize).StepsInFrozenFile(config3.DefaultStepsInFrozenFile).MustOpen(ctx)
 	t.Cleanup(newAgg.Close)
-	require.NoError(t, newAgg.OpenFolder())
+	require.NoError(t, newAgg.OpenFolder(newDb))
 
 	db, _ = temporal.New(newDb, newAgg, nil)
 
@@ -408,7 +408,7 @@ func TestAggregatorV3_Merge(t *testing.T) {
 		}
 	})
 
-	err = agg.BuildFiles(txs, unboundedFinalityCtx)
+	err = agg.BuildFiles(db, txs, unboundedFinalityCtx)
 	require.NoError(t, err)
 	require.Equal(t, 6, onChangeCalls)
 	require.Equal(t, 7, onDelCalls)
@@ -510,7 +510,7 @@ func TestAggregatorV3_PruneSmallBatches(t *testing.T) {
 	err = tx.Commit()
 	require.NoError(t, err)
 
-	err = agg.BuildFiles(maxTx, unboundedFinalityCtx)
+	err = agg.BuildFiles(db, maxTx, unboundedFinalityCtx)
 	require.NoError(t, err)
 
 	buildTx, err := db.BeginTemporalRw(t.Context())
@@ -622,7 +622,7 @@ func TestSharedDomain_CommitmentKeyReplacement(t *testing.T) {
 	require.NoError(t, err)
 
 	//t.Logf("expected hash: %x", expectedHash)
-	err = agg.BuildFiles(stepSize*16, unboundedFinalityCtx)
+	err = agg.BuildFiles(db, stepSize*16, unboundedFinalityCtx)
 	require.NoError(t, err)
 
 	err = rwTx.Commit()
@@ -713,7 +713,7 @@ func TestAggregatorV3_MergeValTransform(t *testing.T) {
 	err = rwTx.Commit()
 	require.NoError(t, err)
 
-	err = agg.BuildFiles(txs, unboundedFinalityCtx)
+	err = agg.BuildFiles(db, txs, unboundedFinalityCtx)
 	require.NoError(t, err)
 
 	rwTx, err = db.BeginTemporalRw(t.Context())
@@ -748,9 +748,9 @@ func testAggregatorV3BuildFilesWithFinalityContext(t *testing.T, buildFiles2 boo
 	dirs := datadir.New(t.TempDir())
 	db := mdbxtest.InMem(t, mdbx.New(dbcfg.ChainDB, logger), dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
 	t.Cleanup(db.Close)
-	agg := state.NewTest(dirs).StepSize(2).Logger(logger).MustOpen(ctx, db)
+	agg := state.NewTest(dirs).StepSize(2).Logger(logger).MustOpen(ctx)
 	t.Cleanup(agg.Close)
-	err := agg.OpenFolder()
+	err := agg.OpenFolder(db)
 	require.NoError(t, err)
 	tdb, err := temporal.New(db, agg, nil)
 	require.NoError(t, err)
@@ -776,10 +776,10 @@ func testAggregatorV3BuildFilesWithFinalityContext(t *testing.T, buildFiles2 boo
 	require.NoError(t, err)
 	finalityCtx := execfinality.NewContext(blocks, 0, 5, true)
 	if buildFiles2 {
-		err = agg.BuildFiles2(ctx, 0, kv.Step(txnNums/agg.StepSize()), finalityCtx, true)
+		err = agg.BuildFiles2(ctx, tdb, 0, kv.Step(txnNums/agg.StepSize()), finalityCtx, true)
 		agg.WaitForFiles()
 	} else {
-		err = agg.BuildFiles(txnNums, finalityCtx)
+		err = agg.BuildFiles(tdb, txnNums, finalityCtx)
 	}
 	require.NoError(t, err)
 	require.Equal(t, uint64(12), agg.EndTxNumMinimax())

--- a/db/test/domain_shared_bench_test.go
+++ b/db/test/domain_shared_bench_test.go
@@ -110,7 +110,7 @@ func Benchmark_SharedDomains_GetLatest(t *testing.B) {
 			err = domains.Flush(ctx, rwTx)
 			require.NoError(t, err)
 			if i/stepSize > 3 {
-				err = agg.BuildFiles(i-(2*stepSize), unboundedFinalityCtx)
+				err = agg.BuildFiles(db, i-(2*stepSize), unboundedFinalityCtx)
 				require.NoError(t, err)
 			}
 		}
@@ -363,7 +363,7 @@ func BenchmarkPruneSmallBatches(b *testing.B) {
 	domains.Close()
 
 	// Build snapshot files so there is data to prune
-	err = agg.BuildFiles(maxTx, unboundedFinalityCtx)
+	err = agg.BuildFiles(db, maxTx, unboundedFinalityCtx)
 	require.NoError(b, err)
 
 	b.ResetTimer()

--- a/db/test/domains_restart_test.go
+++ b/db/test/domains_restart_test.go
@@ -169,7 +169,7 @@ func Test_AggregatorV3_RestartOnDatadir_WithoutDB(t *testing.T) {
 	err = tx.Commit()
 	require.NoError(t, err)
 
-	err = agg.BuildFiles(txs, unboundedFinalityCtx)
+	err = agg.BuildFiles(db, txs, unboundedFinalityCtx)
 	require.NoError(t, err)
 
 	domains.Close()
@@ -351,7 +351,7 @@ func Test_AggregatorV3_RestartOnDatadir_WithoutAnything(t *testing.T) {
 		err = tx.Commit()
 		require.NoError(t, err)
 
-		err = agg.BuildFiles(txs, unboundedFinalityCtx)
+		err = agg.BuildFiles(db, txs, unboundedFinalityCtx)
 		require.NoError(t, err)
 
 		domains.Close()

--- a/db/test/lifecycle_bench_test.go
+++ b/db/test/lifecycle_bench_test.go
@@ -232,7 +232,7 @@ func runLifecycle(b *testing.B, cfg lifecycleConfig) (*lifecycleTimings, kv.Temp
 		if step > 3 {
 			collateStart := time.Now()
 			buildTo := txNum - 2*stepSize
-			err = agg.BuildFiles(buildTo, unboundedFinalityCtx)
+			err = agg.BuildFiles(db, buildTo, unboundedFinalityCtx)
 			require.NoError(b, err)
 			timings.collate += time.Since(collateStart)
 		}
@@ -478,7 +478,7 @@ func BenchmarkLifecycle_PhaseIsolation(b *testing.B) {
 		b.ResetTimer()
 		b.ReportAllocs()
 		for b.Loop() {
-			err := agg.BuildFiles(txNum-2*stepSize, unboundedFinalityCtx)
+			err := agg.BuildFiles(db, txNum-2*stepSize, unboundedFinalityCtx)
 			require.NoError(b, err)
 		}
 	})

--- a/execution/exec/worker_overlay_test.go
+++ b/execution/exec/worker_overlay_test.go
@@ -58,9 +58,9 @@ func TestWorker_ChainReader_SeesOverlayHeader(t *testing.T) {
 		MustOpen()
 	t.Cleanup(rawDB.Close)
 
-	agg := dbstate.NewTest(dirs).StepSize(16).Logger(logger).MustOpen(t.Context(), rawDB)
+	agg := dbstate.NewTest(dirs).StepSize(16).Logger(logger).MustOpen(t.Context())
 	t.Cleanup(agg.Close)
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(rawDB))
 
 	db, err := temporal.New(rawDB, agg, nil)
 	require.NoError(t, err)
@@ -124,9 +124,9 @@ func TestWorker_ChainReader_NoOverlayStillWorks(t *testing.T) {
 		MustOpen()
 	t.Cleanup(rawDB.Close)
 
-	agg := dbstate.NewTest(dirs).StepSize(16).Logger(logger).MustOpen(t.Context(), rawDB)
+	agg := dbstate.NewTest(dirs).StepSize(16).Logger(logger).MustOpen(t.Context())
 	t.Cleanup(agg.Close)
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(rawDB))
 
 	db, err := temporal.New(rawDB, agg, nil)
 	require.NoError(t, err)

--- a/execution/execmodule/executor.go
+++ b/execution/execmodule/executor.go
@@ -269,7 +269,7 @@ func (pe *PipelineExecutor) ProcessFrozenBlocks(ctx context.Context, hook *stage
 			// snapshot files advance as PFB processes frozen blocks.
 			if hasAgg, ok := pe.db.(dbstate.HasAgg); ok {
 				if agg, ok := hasAgg.Agg().(*dbstate.Aggregator); ok && agg != nil {
-					agg.BuildFilesInBackground(agg.EndTxNumMinimax()+agg.StepSize(), finalityCtx)
+					agg.BuildFilesInBackground(pe.db, agg.EndTxNumMinimax()+agg.StepSize(), finalityCtx)
 				}
 			}
 			// Last iter: skip BeginTemporalRw — no next iter will use it.

--- a/execution/stagedsync/exec3_2cache_test.go
+++ b/execution/stagedsync/exec3_2cache_test.go
@@ -59,7 +59,7 @@ func setup2CacheTest(t *testing.T) (kv.TemporalRwTx, *execctx.SharedDomains) {
 	rawDb := mdbxtest.InMem(t, mdbx.New(dbcfg.ChainDB, lgr), dirs.Chaindata).MustOpen()
 	t.Cleanup(rawDb.Close)
 
-	agg, err := dbstate.NewTest(dirs).StepSize(16).Logger(lgr).Open(context.Background(), rawDb)
+	agg, err := dbstate.NewTest(dirs).StepSize(16).Logger(lgr).Open(context.Background())
 	require.NoError(t, err)
 	t.Cleanup(agg.Close)
 

--- a/execution/stagedsync/stage_custom_trace.go
+++ b/execution/stagedsync/stage_custom_trace.go
@@ -311,7 +311,7 @@ func customTraceBatchProduce(ctx context.Context, produce Produce, cfg *exec.Exe
 	}); err != nil {
 		return err
 	}
-	if err := agg.BuildFiles2(ctx, fromStep, toStep, finalityCtx, true); err != nil {
+	if err := agg.BuildFiles2(ctx, db, fromStep, toStep, finalityCtx, true); err != nil {
 		return err
 	}
 	if err := db.Update(ctx, func(tx kv.RwTx) error {

--- a/execution/stagedsync/stage_snapshots.go
+++ b/execution/stagedsync/stage_snapshots.go
@@ -397,7 +397,7 @@ func DownloadAndIndexSnapshotsIfNeed(s *StageState, ctx context.Context, tx kv.R
 		if err := cfg.blockReader.Snapshots().OpenFolder(); err != nil {
 			return err
 		}
-		if err := agg.OpenFolder(); err != nil {
+		if err := agg.OpenFolder(cfg.db); err != nil {
 			return err
 		}
 

--- a/execution/state/genesiswrite/genesis_write.go
+++ b/execution/state/genesiswrite/genesis_write.go
@@ -424,7 +424,7 @@ func GenesisToBlock(g *types.Genesis, dirs datadir.Dirs, logger log.Logger) (*ty
 	if err != nil {
 		return nil, nil, err
 	}
-	agg, err := dbstate.New(dirs).Logger(logger).WithErigonDBSettings(erigonDBSettings).DisableBranchCache().Open(ctx, genesisTmpDB)
+	agg, err := dbstate.New(dirs).Logger(logger).WithErigonDBSettings(erigonDBSettings).DisableBranchCache().Open(ctx)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/execution/verify/history_verify_test.go
+++ b/execution/verify/history_verify_test.go
@@ -84,7 +84,7 @@ func TestHistoryVerification_SimpleBlocks(t *testing.T) {
 	t.Logf("Last txNum: %d, stepSize: %d, steps: %d", lastTxNum, agg.StepSize(), lastTxNum/agg.StepSize())
 
 	// Build files.
-	err = agg.BuildFiles(lastTxNum, unboundedFinalityCtx)
+	err = agg.BuildFiles(m.DB, lastTxNum, unboundedFinalityCtx)
 	require.NoError(t, err)
 
 	if agg.EndTxNumMinimax() == 0 {
@@ -178,7 +178,7 @@ func TestHistoryVerification_WithUserTransactions(t *testing.T) {
 	t.Logf("Last txNum: %d, stepSize: %d, steps: %d", lastTxNum, agg.StepSize(), lastTxNum/agg.StepSize())
 
 	// Build files.
-	err = agg.BuildFiles(lastTxNum, unboundedFinalityCtx)
+	err = agg.BuildFiles(m.DB, lastTxNum, unboundedFinalityCtx)
 	require.NoError(t, err)
 
 	if agg.EndTxNumMinimax() == 0 {

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -1293,14 +1293,14 @@ func SetUpBlockReader(ctx context.Context, db kv.RwDB, dirs datadir.Dirs, snConf
 			logger.Info("domain merge cap overridden", "steps_in_frozen_file", stepsStr)
 			aggOpts = aggOpts.ErigondbDomainStepsInFrozenFile(v)
 		}
-		agg, openErr := aggOpts.Open(ctx, db)
+		agg, openErr := aggOpts.Open(ctx)
 		if openErr != nil {
 			return nil, nil, nil, nil, openErr
 		}
 		agg.SetSnapshotBuildSema(blockSnapBuildSema)
 		agg.SetProduceMod(snConfig.Snapshot.ProduceE3)
 		if allSegmentsDownloadComplete {
-			_ = agg.OpenFolder()
+			_ = agg.OpenFolder(db)
 		}
 		temporalDb, err = temporal.New(db, agg, allSnapshots)
 		if err != nil {

--- a/rpc/jsonrpc/eth_simulation_intrablock_test.go
+++ b/rpc/jsonrpc/eth_simulation_intrablock_test.go
@@ -45,9 +45,9 @@ func TestSimulationIntraBlockHasStorageRAMBatch(t *testing.T) {
 		MustOpen()
 	t.Cleanup(db.Close)
 
-	agg := state.NewTest(dirs).Logger(logger).MustOpen(t.Context(), db)
+	agg := state.NewTest(dirs).Logger(logger).MustOpen(t.Context())
 	t.Cleanup(agg.Close)
-	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.OpenFolder(db))
 
 	tdb, err := temporal.New(db, agg, nil)
 	require.NoError(t, err)

--- a/rpc/rpchelper/commitment.go
+++ b/rpc/rpchelper/commitment.go
@@ -76,7 +76,7 @@ func (r *CommitmentReplay) ComputeCustomCommitmentFromStateHistory(
 	if err != nil {
 		return nil, err
 	}
-	agg, err := dbstate.New(r.dirs).Logger(r.logger).WithErigonDBSettings(erigonDBSettings).Open(ctx, db)
+	agg, err := dbstate.New(r.dirs).Logger(r.logger).WithErigonDBSettings(erigonDBSettings).Open(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
follow up (part 1) to https://github.com/erigontech/erigon/pull/23704

A cleaner direction instead of holding the `TemporalDB` in `finalityContext` as an attribute  is to pass it via func input (i.e. via the existing `finalityContext.ReadyForCollation` API.

However to do this we should first address one of the `TODO`s in the `Aggregator` which is to remove `Aggregator.db` attribute from the egg and pass it via func inputs.