### PR TITLE
ci: pin Geth used by Hive DevP2P

### DIFF
--- a/.github/workflows/hive-versions.json
+++ b/.github/workflows/hive-versions.json
@@ -1,5 +1,6 @@
 {
   "hive_repository": "ethereum/hive",
   "hive_ref": "43ea47bef5761351e3da7b726050ea80ab362c52",
+  "devp2p_geth_ref": "157c94647241b260d19e5a8e01a08e439591e504",
   "execution_apis_ref": "f74de4b86e3b011384808c294c3d71f2854729a2"
 }

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -104,6 +104,7 @@ jobs:
           {
             echo "repository=$(jq -r .hive_repository "$versions")"
             echo "ref=$(jq -r .hive_ref "$versions")"
+            echo "devp2p_geth_ref=$(jq -r .devp2p_geth_ref "$versions")"
             echo "execution_apis_ref=$(jq -r '.execution_apis_ref // empty' "$versions")"
           } >> "$GITHUB_OUTPUT"
 
@@ -114,6 +115,22 @@ jobs:
           ref: ${{ steps.hive-version.outputs.ref }}
           path: hive
           persist-credentials: false
+
+      - name: Pin Geth used by DevP2P
+        if: ${{ matrix.sim == 'devp2p' }}
+        env:
+          GETH_REF: ${{ steps.hive-version.outputs.devp2p_geth_ref }}
+        run: |
+          if ! echo "$GETH_REF" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "Error: devp2p_geth_ref is not a valid git SHA: $GETH_REF"
+            exit 1
+          fi
+          dockerfile=hive/simulators/devp2p/Dockerfile
+          sed -i "s|^RUN git clone --depth 1 https://github.com/ethereum/go-ethereum.git /go-ethereum$|RUN git init /go-ethereum \&\& git -C /go-ethereum remote add origin https://github.com/ethereum/go-ethereum.git \&\& git -C /go-ethereum fetch --depth 1 origin ${GETH_REF} \&\& git -C /go-ethereum checkout --detach FETCH_HEAD|" "$dockerfile"
+          if ! grep -Fq "fetch --depth 1 origin ${GETH_REF}" "$dockerfile"; then
+            echo "Error: failed to pin Geth in the DevP2P Dockerfile"
+            exit 1
+          fi
 
       - name: Setup go env and cache
         uses: actions/setup-go@v7


### PR DESCRIPTION
## Summary

- pin the Geth revision used to build the Hive DevP2P simulator
- validate the configured revision before injecting it into the simulator Dockerfile
- fail if the pinned Hive Dockerfile no longer matches the expected clone command

## Why

Hive commit `43ea47bef5761351e3da7b726050ea80ab362c52` still clones Geth `master` while building the DevP2P simulator. Geth commit `e4db964e75063adcc4ab55ad3bd3589458aedad4` regenerated the test chain with Osaka at timestamp 180, but its `forkenv.json` omitted `HIVE_OSAKA_TIMESTAMP`. The test tool therefore expected fork ID `0x15e3c946`, while Erigon received a genesis configuration that produced `0x9736aeb1`.

Pinning the immediately preceding Geth revision makes this required CI gate reproducible instead of allowing unrelated upstream changes to alter the test suite. The pin should be advanced after the upstream fixture exports a matching Osaka timestamp.

Failed job: https://github.com/erigontech/erigon/actions/runs/33634755653/job/100262737133?pr=23750

## Validation

- `actionlint .github/workflows/test-hive.yml`
- `jq empty .github/workflows/hive-versions.json`
- verified the Dockerfile rewrite against the pinned Hive source
- verified `git fetch --depth 1 origin 157c94647241b260d19e5a8e01a08e439591e504`
- `make lint` repeatedly, all clean
- `make erigon integration`

## TDD

Not applicable: this is a mechanical CI dependency pin with no Erigon runtime behavior change.