### PR TITLE
ci: pin Geth used by Hive DevP2P

### DIFF
--- a/.github/workflows/hive-versions.json
+++ b/.github/workflows/hive-versions.json
@@ -1,5 +1,6 @@
 {
   "hive_repository": "ethereum/hive",
   "hive_ref": "43ea47bef5761351e3da7b726050ea80ab362c52",
+  "devp2p_geth_ref": "157c94647241b260d19e5a8e01a08e439591e504",
   "execution_apis_ref": "f74de4b86e3b011384808c294c3d71f2854729a2"
 }

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -104,7 +104,7 @@ jobs:
           {
             echo "repository=$(jq -r .hive_repository "$versions")"
             echo "ref=$(jq -r .hive_ref "$versions")"
-            echo "devp2p_geth_ref=$(jq -r .devp2p_geth_ref "$versions")"
+            echo "devp2p_geth_ref=$(jq -r '.devp2p_geth_ref // empty' "$versions")"
             echo "execution_apis_ref=$(jq -r '.execution_apis_ref // empty' "$versions")"
           } >> "$GITHUB_OUTPUT"
 
@@ -116,8 +116,10 @@ jobs:
           path: hive
           persist-credentials: false
 
+      # TODO(taratorio): Remove this pin when the upstream Geth fixture is fixed
+      # and https://github.com/erigontech/erigon/issues/22808 is resolved.
       - name: Pin Geth used by DevP2P
-        if: ${{ matrix.sim == 'devp2p' }}
+        if: ${{ matrix.sim == 'devp2p' && steps.hive-version.outputs.devp2p_geth_ref != '' }}
         env:
           GETH_REF: ${{ steps.hive-version.outputs.devp2p_geth_ref }}
         run: |

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -104,6 +104,7 @@ jobs:
           {
             echo "repository=$(jq -r .hive_repository "$versions")"
             echo "ref=$(jq -r .hive_ref "$versions")"
+            echo "devp2p_geth_ref=$(jq -r .devp2p_geth_ref "$versions")"
             echo "execution_apis_ref=$(jq -r '.execution_apis_ref // empty' "$versions")"
           } >> "$GITHUB_OUTPUT"
 
@@ -114,6 +115,22 @@ jobs:
           ref: ${{ steps.hive-version.outputs.ref }}
           path: hive
           persist-credentials: false
+
+      - name: Pin Geth used by DevP2P
+        if: ${{ matrix.sim == 'devp2p' }}
+        env:
+          GETH_REF: ${{ steps.hive-version.outputs.devp2p_geth_ref }}
+        run: |
+          if ! echo "$GETH_REF" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "Error: devp2p_geth_ref is not a valid git SHA: $GETH_REF"
+            exit 1
+          fi
+          dockerfile=hive/simulators/devp2p/Dockerfile
+          sed -i "s|^RUN git clone --depth 1 https://github.com/ethereum/go-ethereum.git /go-ethereum$|RUN git init /go-ethereum \&\& git -C /go-ethereum remote add origin https://github.com/ethereum/go-ethereum.git \&\& git -C /go-ethereum fetch --depth 1 origin ${GETH_REF} \&\& git -C /go-ethereum checkout --detach FETCH_HEAD|" "$dockerfile"
+          if ! grep -Fq "fetch --depth 1 origin ${GETH_REF}" "$dockerfile"; then
+            echo "Error: failed to pin Geth in the DevP2P Dockerfile"
+            exit 1
+          fi
 
       - name: Setup go env and cache
         uses: actions/setup-go@v7

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -116,8 +116,7 @@ jobs:
           path: hive
           persist-credentials: false
 
-      # TODO(taratorio): Remove this pin when the upstream Geth fixture is fixed
-      # and https://github.com/erigontech/erigon/issues/22808 is resolved.
+      # TODO: remove devp2p_geth_ref from hive-versions.json after Geth fixes its fixture and https://github.com/erigontech/erigon/issues/22808 is completed
       - name: Pin Geth used by DevP2P
         if: ${{ matrix.sim == 'devp2p' && steps.hive-version.outputs.devp2p_geth_ref != '' }}
         env:


### PR DESCRIPTION
Geth pushed a commit to the `devp2p` binary that `Hive` uses for the `eth` devp2p tests - https://github.com/ethereum/go-ethereum/commit/e4db964e75063adcc4ab55ad3bd3589458aedad4
That commit has wrong fork IDs and broke our CI because Hive always uses latest Geth commit
This PR pins Geth inside the Hive docker file to a version before this commit so we are not affected by this until the dust settles
