### PR TITLE
execution/tracing/tracers: build the callTracer result in one buffer

### DIFF
--- a/execution/tracing/tracers/native/call.go
+++ b/execution/tracing/tracers/native/call.go
@@ -332,10 +332,9 @@ func (t *callTracer) GetResult() (json.RawMessage, error) {
 	if len(t.callstack) != 1 {
 		return nil, errors.New("incorrect number of top-level calls")
 	}
-	res, err := json.Marshal(t.callstack[0])
-	if err != nil {
-		return nil, err
-	}
+	var buf byteWriter
+	t.callstack[0].AppendJSON(&buf)
+	res := buf.b
 	if p := t.reason.Load(); p != nil {
 		return res, *p
 	}

--- a/execution/tracing/tracers/native/call_fastjson.go
+++ b/execution/tracing/tracers/native/call_fastjson.go
@@ -1,0 +1,145 @@
+package native
+
+import (
+	"encoding/json"
+
+	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/execution/tracing/tracers"
+)
+
+// chunkSize only has to hold one frame: handover is free, so a bigger buffer
+// buys no speed and costs its own size in peak memory.
+const chunkSize = 8 * 1024
+
+type frameWriter struct {
+	buf []byte
+	w   tracers.RawWriter
+}
+
+// flush hands the buffer over once it holds more than min bytes. Only ever
+// called at a frame boundary, so a value is never split across two writes.
+func (fw *frameWriter) flush(min int) {
+	if len(fw.buf) > min {
+		fw.w.WriteRawBytes(fw.buf)
+		fw.buf = fw.buf[:0]
+	}
+}
+
+// byteWriter collects everything into one slice, for callers that want the
+// whole result rather than a stream.
+type byteWriter struct{ b []byte }
+
+func (b *byteWriter) WriteRawBytes(p []byte) { b.b = append(b.b, p...) }
+
+// AppendJSON writes the same bytes as the gencodec MarshalJSON. Going through
+// MarshalJSON makes encoding/json re-scan every child's output at each level
+// (appendCompact), which is quadratic in call depth; recursing into one buffer
+// is not.
+func (c *callFrame) AppendJSON(w tracers.RawWriter) {
+	fw := frameWriter{buf: make([]byte, 0, chunkSize), w: w}
+	fw.frame(*c)
+	fw.flush(0)
+}
+
+func (fw *frameWriter) frame(c callFrame) {
+	dst := fw.buf
+	dst = append(dst, `{"from":`...)
+	dst = appendText(dst, c.From.AppendText)
+	dst = append(dst, `,"gas":`...)
+	dst = appendText(dst, hexutil.Uint64(c.Gas).AppendText)
+	dst = append(dst, `,"gasUsed":`...)
+	dst = appendText(dst, hexutil.Uint64(c.GasUsed).AppendText)
+	if c.To != nil {
+		dst = append(dst, `,"to":`...)
+		dst = appendText(dst, c.To.AppendText)
+	}
+	dst = append(dst, `,"input":`...)
+	dst = appendText(dst, hexutil.Bytes(c.Input).AppendText)
+	if len(c.Output) > 0 {
+		dst = append(dst, `,"output":`...)
+		dst = appendText(dst, hexutil.Bytes(c.Output).AppendText)
+	}
+	if c.Error != "" {
+		dst = append(dst, `,"error":`...)
+		dst = appendJSONString(dst, c.Error)
+	}
+	if c.Revertal != "" {
+		dst = append(dst, `,"revertReason":`...)
+		dst = appendJSONString(dst, c.Revertal)
+	}
+	if len(c.Calls) > 0 {
+		dst = append(dst, `,"calls":[`...)
+		for i := range c.Calls {
+			if i > 0 {
+				dst = append(dst, ',')
+			}
+			fw.buf = dst
+			fw.flush(chunkSize)
+			fw.frame(c.Calls[i])
+			dst = fw.buf
+		}
+		dst = append(dst, ']')
+	}
+	if len(c.Logs) > 0 {
+		dst = append(dst, `,"logs":[`...)
+		for i := range c.Logs {
+			if i > 0 {
+				dst = append(dst, ',')
+			}
+			dst = c.Logs[i].appendJSON(dst)
+		}
+		dst = append(dst, ']')
+	}
+	if c.Value != nil {
+		dst = append(dst, `,"value":`...)
+		dst = appendText(dst, (*hexutil.U256)(c.Value).AppendText)
+	}
+	dst = append(dst, `,"type":`...)
+	dst = appendJSONString(dst, c.TypeString())
+	fw.buf = append(dst, '}')
+}
+
+func (l callLog) appendJSON(dst []byte) []byte {
+	dst = append(dst, `{"index":`...)
+	dst = appendText(dst, l.Index.AppendText)
+	dst = append(dst, `,"address":`...)
+	dst = appendText(dst, l.Address.AppendText)
+	dst = append(dst, `,"topics":`...)
+	if l.Topics == nil {
+		dst = append(dst, `null`...)
+	} else {
+		dst = append(dst, '[')
+		for i := range l.Topics {
+			if i > 0 {
+				dst = append(dst, ',')
+			}
+			dst = appendText(dst, l.Topics[i].AppendText)
+		}
+		dst = append(dst, ']')
+	}
+	dst = append(dst, `,"data":`...)
+	dst = appendText(dst, hexutil.Bytes(l.Data).AppendText)
+	dst = append(dst, `,"position":`...)
+	dst = appendText(dst, l.Position.AppendText)
+	return append(dst, '}')
+}
+
+func appendText(dst []byte, appendTo func([]byte) ([]byte, error)) []byte {
+	dst = append(dst, '"')
+	dst, _ = appendTo(dst) // hexutil appenders never fail
+	return append(dst, '"')
+}
+
+// appendJSONString matches encoding/json, HTML escaping included. The escape
+// path is rare here: these are opcode names and EVM error strings.
+func appendJSONString(dst []byte, s string) []byte {
+	for i := range len(s) {
+		if c := s[i]; c < 0x20 || c >= 0x7f || c == '"' || c == '\\' || c == '<' || c == '>' || c == '&' {
+			b, _ := json.Marshal(s)
+			return append(dst, b...)
+		}
+	}
+	dst = append(dst, '"')
+	dst = append(dst, s...)
+	return append(dst, '"')
+}

--- a/execution/tracing/tracers/native/prestate_test.go
+++ b/execution/tracing/tracers/native/prestate_test.go
@@ -17,7 +17,10 @@
 package native
 
 import (
+	"encoding/json"
+	"fmt"
 	"math/big"
+	"reflect"
 	"testing"
 
 	"github.com/holiman/uint256"
@@ -203,4 +206,140 @@ func TestPrestateTracerDiffModeZeroStorageUnmodified(t *testing.T) {
 	require.False(t, inPre, "unmodified account with only a zero storage slot must not remain in pre state")
 	_, inPost := tr.post[addr]
 	require.False(t, inPost, "unmodified account with only a zero storage slot must not appear in post state")
+}
+
+type discardWriter struct{ n int }
+
+func (d *discardWriter) WriteRawBytes(p []byte) { d.n += len(p) }
+
+// chunkRecorder keeps the bytes and the largest handover.
+type chunkRecorder struct {
+	out      []byte
+	maxChunk int
+}
+
+func (c *chunkRecorder) WriteRawBytes(p []byte) {
+	c.out = append(c.out, p...)
+	c.maxChunk = max(c.maxChunk, len(p))
+}
+
+func encodeFrame(f *callFrame) string {
+	var w byteWriter
+	f.AppendJSON(&w)
+	return string(w.b)
+}
+
+func mkBenchFrame(depth, width int) callFrame {
+	to := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	f := callFrame{
+		Type: vm.CALL, From: common.HexToAddress("0xdAC17F958D2ee523a2206206994597C13D831ec7"),
+		Gas: 21000, GasUsed: 12345, To: &to,
+		Input: make([]byte, 128), Output: make([]byte, 64), Value: uint256.NewInt(1e18),
+		Logs: []callLog{{Index: 1, Address: common.HexToAddress("0x2222222222222222222222222222222222222222"),
+			Topics: []common.Hash{common.HexToHash("0xaa"), {}}, Data: make([]byte, 96), Position: 0}},
+	}
+	if depth > 0 {
+		for range width {
+			f.Calls = append(f.Calls, mkBenchFrame(depth-1, width))
+		}
+	}
+	return f
+}
+
+func TestAppendJSONMatchesGencodec(t *testing.T) {
+	t.Parallel()
+	for _, f := range []callFrame{
+		mkBenchFrame(6, 2), // deep enough to hand the buffer over many times
+		{Type: vm.CREATE, Error: `bad <thing> "x"`, Revertal: "a\tb"},
+		{Type: vm.STATICCALL, Logs: []callLog{{Topics: nil}}},
+	} {
+		want, err := json.Marshal(f)
+		require.NoError(t, err)
+
+		var rec chunkRecorder
+		f.AppendJSON(&rec)
+		require.Equal(t, string(want), string(rec.out))
+		// A chunk is handed over at frame boundaries, so it holds at most one
+		// frame beyond the buffer. Frames here are uniform and small.
+		require.LessOrEqual(t, rec.maxChunk, 2*chunkSize, "a chunk grew past the bound")
+	}
+}
+
+func BenchmarkCallFrameMarshal(b *testing.B) {
+	for _, depth := range []int{1, 3, 5, 7} {
+		f := mkBenchFrame(depth, 2)
+		b.Run(fmt.Sprintf("depth=%d/gencodec", depth), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, err := json.Marshal(f); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+		b.Run(fmt.Sprintf("depth=%d/appendJSON", depth), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				var w byteWriter
+				f.AppendJSON(&w)
+			}
+		})
+		b.Run(fmt.Sprintf("depth=%d/appendJSONToStream", depth), func(b *testing.B) {
+			b.ReportAllocs()
+			var w discardWriter
+			for b.Loop() {
+				f.AppendJSON(&w)
+			}
+		})
+	}
+}
+
+// fillNonZero sets every field of v to a non-zero value, recursing into structs
+// and allocating one element for slices and pointers. A field added to callFrame
+// is therefore populated automatically, so TestAppendJSONCoversEveryField fails
+// if appendJSON forgets it.
+func fillNonZero(v reflect.Value, depth int) {
+	switch v.Kind() {
+	case reflect.Struct:
+		for i := range v.NumField() {
+			if v.Type().Field(i).IsExported() {
+				fillNonZero(v.Field(i), depth)
+			}
+		}
+	case reflect.Slice:
+		if depth <= 0 { // callFrame.Calls recurses; stop before it blows the stack
+			return
+		}
+		v.Set(reflect.MakeSlice(v.Type(), 1, 1))
+		fillNonZero(v.Index(0), depth-1)
+	case reflect.Pointer:
+		if depth <= 0 {
+			return
+		}
+		v.Set(reflect.New(v.Type().Elem()))
+		fillNonZero(v.Elem(), depth-1)
+	case reflect.Array:
+		for i := range v.Len() {
+			fillNonZero(v.Index(i), depth)
+		}
+	case reflect.String:
+		v.SetString("x")
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		v.SetUint(7)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v.SetInt(7)
+	case reflect.Bool:
+		v.SetBool(true)
+	}
+}
+
+func TestAppendJSONCoversEveryField(t *testing.T) {
+	t.Parallel()
+	var f callFrame
+	fillNonZero(reflect.ValueOf(&f).Elem(), 2)
+	f.Type = vm.CALL // fillNonZero picks an opcode that has no name
+
+	want, err := json.Marshal(f)
+	require.NoError(t, err)
+	require.Equal(t, string(want), encodeFrame(&f),
+		"AppendJSON drifted from the generated MarshalJSON - a new callFrame field is probably unhandled")
 }

--- a/execution/tracing/tracers/tracers.go
+++ b/execution/tracing/tracers/tracers.go
@@ -30,6 +30,12 @@ import (
 	"github.com/erigontech/erigon/execution/tracing"
 )
 
+// RawWriter takes already-encoded JSON. It is the half of the RPC stream a
+// tracer needs, kept here so tracers do not depend on the stream package.
+type RawWriter interface {
+	WriteRawBytes(content []byte)
+}
+
 // Context contains some contextual infos for a transaction execution that is not
 // available from within the EVM object.
 type Context struct {


### PR DESCRIPTION
Alternative to #23744 — same problem, no build tag, and it works on the toolchain we ship today.

## The cost

gencodec's `MarshalJSON` does not replace reflection. It builds a shadow struct, copies every field, and calls `json.Marshal` on it. What it *does* do is make `callFrame` satisfy `json.Marshaler`, which forces the parent encoder down `marshalerEncoder` → `appendCompact` over the child's bytes (`encode.go:486`). `callFrame.Calls` is `[]callFrame`, so the innermost frame's bytes are re-scanned once per level: quadratic in call depth.

`AppendJSON` recurses into one buffer and hands it to a writer at frame boundaries — a boundary is the only place the buffer changes hands, so no value is ever split. The generated marshaler stays for every other caller.

```go
type RawWriter interface{ WriteRawBytes(content []byte) }
```

That is the half of `jsonstream.Stream` a tracer needs, declared in `tracers` so `execution/tracing` does not import the RPC stream package. `GetResult` uses a slice-collecting writer; #23768 passes the RPC stream instead.

## Numbers

Tree of `callFrame`, width 2, so depth 7 is 255 frames. Best of 6, M4 Max.

**go1.25.7 — the toolchain `go.mod` names. #23744 is inactive here; its file needs go1.27.**

| depth | frames | generated `MarshalJSON` | `AppendJSON` | |
|---|---|---|---|---|
| 1 | 3 | 19,513 ns · 12.8 KB · 47 allocs | 914 ns | 21× |
| 3 | 15 | 168,932 ns · 91 KB · 227 | 4,492 ns | 38× |
| 5 | 63 | 1,031,804 ns · 525 KB · 950 | 19,780 ns | 52× |
| 7 | 255 | 5,624,719 ns · 2.7 MB · 3,840 | 80,154 ns | 70× |

**go1.27, with #23744's `MarshalJSONTo` applied**

| depth | #23744 | `AppendJSON` → stream | `AppendJSON` → slice |
|---|---|---|---|
| 1 | 3,651 ns · 4.3 KB · 26 | 1,154 ns · 8.2 KB · 1 | 1,287 ns · 11.4 KB · 3 |
| 3 | 20,027 ns · 20.6 KB · 122 | 4,879 ns · 19.1 KB · 2 | 6,650 ns · 49 KB · 5 |
| 5 | 78,815 ns · 90.5 KB · 506 | 20,070 ns · 19.1 KB · 2 | 31,291 ns · 248 KB · 9 |
| 7 | 335,153 ns · 338 KB · 2,042 | 80,929 ns · **19.1 KB** · 2 | 133,604 ns · 1.15 MB · 14 |

The stream column is the writer reused across calls, as a pooled stream is; the slice column allocates a fresh collector each time, as `GetResult` does.

Per-frame cost is the structural result — it says which implementations are actually linear:

| | d1 | d3 | d5 | d7 |
|---|---|---|---|---|
| generated, go1.25.7 | 6,504 | 11,262 | 16,378 | 22,058 ns/frame |
| #23744, go1.27 | 1,217 | 1,335 | 1,251 | 1,314 |
| `AppendJSON` | 342 | 320 | 310 | 320 |

#23744 also flattens the curve — v2 streams instead of re-parsing. This lands at the same shape with a ~4× lower constant, on every toolchain, with no `//go:build`.

## Chunk size

Handover turns out to be free, so the buffer only has to hold one frame. Sweeping it on a 511-frame trace, time is flat and only memory moves:

| chunk | handovers | ns/op | B/op | allocs |
|---|---|---|---|---|
| 1 | 511 | 164,447 | 17,896 | 14 |
| 1 KB | 341 | 160,132 | 17,416 | 7 |
| 8 KB | 62 | 161,773 | 19,080 | 3 |
| 32 KB | 16 | 163,437 | 81,928 | 3 |
| 128 KB | 4 | 169,912 | 303,112 | 3 |

8 KB it is; anything larger just buys its own size in peak memory. The buffer cannot go away entirely — `input` and `output` are unbounded hex and `AppendText` needs somewhere growable to put them. The real bound is `chunkSize` plus one frame, since a frame with large calldata is handed over whole.

## Drift

Hand-written marshalers rot. `TestAppendJSONCoversEveryField` builds a `callFrame` by reflection with every field set non-zero and diffs against the generated marshaler, so a new field fails the build rather than vanishing from the wire. Verified by deleting the `revertReason` branch — the test fails with exactly that message.

Stacked on #23766 (`Value` as uint256) and #23765 (`to` omitted on failed CREATE).

