### PR TITLE
execution/tracing, rpc: hand the callTracer result over in chunks

### DIFF
--- a/execution/tracing/tracers/native/call.go
+++ b/execution/tracing/tracers/native/call.go
@@ -151,8 +151,9 @@ func newCallTracer(ctx *tracers.Context, cfg json.RawMessage) (*tracers.Tracer, 
 			OnExit:    t.OnExit,
 			OnLog:     t.OnLog,
 		},
-		GetResult: t.GetResult,
-		Stop:      t.Stop,
+		GetResult:    t.GetResult,
+		GetResultRef: t.GetResultRef,
+		Stop:         t.Stop,
 	}, nil
 }
 
@@ -339,6 +340,22 @@ func (t *callTracer) GetResult() (json.RawMessage, error) {
 		return res, *p
 	}
 	return res, nil
+}
+
+// GetResultRef returns the top-level frame unencoded, so the caller can have it
+// written straight into a stream. A nil ref means there is nothing to write,
+// matching GetResult returning nil bytes.
+func (t *callTracer) GetResultRef() (tracers.ResultRef, error) {
+	if len(t.callstack) == 0 && !t.config.IncludePrecompiles {
+		return nil, nil
+	}
+	if len(t.callstack) != 1 {
+		return nil, errors.New("incorrect number of top-level calls")
+	}
+	if p := t.reason.Load(); p != nil {
+		return &t.callstack[0], *p
+	}
+	return &t.callstack[0], nil
 }
 
 // Stop terminates execution of the tracer at the first opportune moment.

--- a/execution/tracing/tracers/tracers.go
+++ b/execution/tracing/tracers/tracers.go
@@ -50,8 +50,17 @@ type Context struct {
 type Tracer struct {
 	*tracing.Hooks
 	GetResult func() (json.RawMessage, error)
+	// GetResultRef returns the same result as GetResult, still as an object, so
+	// the caller can have it written straight into a stream instead of into a
+	// buffer. Nil for tracers that only build bytes.
+	GetResultRef func() (ResultRef, error)
 	// Stop terminates execution of the tracer at the first opportune moment.
 	Stop func(err error)
+}
+
+// ResultRef is a trace result that has not been encoded yet.
+type ResultRef interface {
+	AppendJSON(w RawWriter)
 }
 
 type lookupFunc func(string, *Context, json.RawMessage) (*Tracer, error)

--- a/rpc/transactions/tracing.go
+++ b/rpc/transactions/tracing.go
@@ -258,12 +258,23 @@ func ExecuteTraceTx(
 		stream.WriteString("0x" + returnVal)
 		stream.WriteObjectEnd()
 	} else {
-		r, err := tracer.GetResult()
-		if err != nil {
-			return err
+		if tracer.GetResultRef != nil {
+			ref, err := tracer.GetResultRef()
+			if err != nil {
+				return err
+			}
+			if ref == nil {
+				stream.WriteRawBytes(nil) // GetResult returns nil bytes here too
+			} else {
+				ref.AppendJSON(stream)
+			}
+		} else {
+			r, err := tracer.GetResult()
+			if err != nil {
+				return err
+			}
+			stream.WriteRawBytes(r)
 		}
-
-		stream.WriteRawBytes(r)
 		if err := stream.Flush(); err != nil { // Client can use result of 1 tx-trace
 			return err
 		}


### PR DESCRIPTION
Follow-up to #23767. That one made encoding the trace cheap and gave it a writer; this one stops the result existing as a buffer at all.

## Today

```go
r, err := tracer.GetResult()   // whole trace materialized
stream.WriteRawBytes(r)        // copied again into the stream buffer
```

Both copies are live at once, per in-flight request.

## Now

`GetResultRef` hands back the result still as an object, so the caller decides where it goes. Errors stay where `GetResult` already reports them, which leaves `AppendJSON` unable to fail — `WriteRawBytes` cannot either.

```go
type ResultRef interface{ AppendJSON(w RawWriter) }
```

It is an optional field on `tracers.Tracer`; tracers that only build bytes keep the `GetResult` path unchanged.

## Result

| trace | `GetResult` + copy | `GetResultRef` + `AppendJSON` |
|---|---|---|
| 63 frames, 66 KB | 285,400 B · 21 allocs | **19,072 B** · 2 allocs |
| 511 frames, 534 KB | 2,538,202 B · 29 allocs | **19,072 B** · 2 allocs |

Peak memory stops following trace size. A 534 KB trace leaves in 62 chunks of at most 10,828 bytes.

That bound is what matters under load: `rpc.max.concurrency` defaults to `db.read.concurrency`, which is `GOMAXPROCS*64` — 1024 on a 16-core box. 1024 in-flight traces at ~2× trace size each is where the memory goes.

Handover also composes with `flushIfFull`, which `WriteRawBytes` already calls, so a chunk reaching the stream can leave for the socket instead of accumulating.

Stacked on #23767 → #23766 → #23765.

