### PR TITLE
cache: tune avg code size

### DIFF
--- a/execution/cache/code_cache.go
+++ b/execution/cache/code_cache.go
@@ -47,11 +47,15 @@ const (
 	// EXTCODESIZE / EXTCODEHASH callers).
 	DefaultCodeSizeCacheEntries int64 = 1_000_000
 	// avgCodeEntryBytes translates the code byte budget into the freelru
-	// entry-count cap (the only bound — the byte counters don't evict). Sized to
-	// the resident-code skew (hot contracts run 10-24 KB) rather than the raw
-	// average so the cap keeps RAM near the budget instead of several × over; the
-	// persistent (MDBX-backed) cold tier backstops entries the tighter cap evicts.
-	avgCodeEntryBytes = 12 * 1024
+	// entry-count cap (the only bound — the byte counters don't evict). It
+	// rations the shared envelope rather than predicting residency, so the cap
+	// it buys governs the hit rate, not how close it lands to any one workload.
+	// Sized to the LRU-resident mean of mainnet contract code.
+	avgCodeEntryBytes = 6554
+	// codeSizeEntryBytes is the resident cost of one size-layer slot (freelru
+	// element holding size/keyHash/txNum/epoch), used to map the size-layer entry
+	// ceiling to an envelope byte budget.
+	codeSizeEntryBytes = 64
 )
 
 type versionedAddressID struct {

--- a/execution/cache/code_cache.go
+++ b/execution/cache/code_cache.go
@@ -52,10 +52,6 @@ const (
 	// it buys governs the hit rate, not how close it lands to any one workload.
 	// Sized to the LRU-resident mean of mainnet contract code.
 	avgCodeEntryBytes = 6554
-	// codeSizeEntryBytes is the resident cost of one size-layer slot (freelru
-	// element holding size/keyHash/txNum/epoch), used to map the size-layer entry
-	// ceiling to an envelope byte budget.
-	codeSizeEntryBytes = 64
 )
 
 type versionedAddressID struct {


### PR DESCRIPTION
`avgCodeEntryBytes` converts the code byte budget into the freelru entry cap. It rations the shared `cachebudget` envelope rather than predicting residency, so the cap it buys — not how close the number lands to any one workload — is what governs the hit rate. 12KB was sized to a hot-contract skew; the LRU-resident mean of real mainnet contract code is 6.4KB, measured by replaying 1.8M `getCode` requests over 4,550 mainnet blocks.

benchmarkoor, code-heavy EXTCODECOPY ladder on `dec25ab34b`, 2.1999 Ggas byte-identical in every run:

| arm | MGas/s | peak heap |
|---|---|---|
| main | 260.5 | 10.8 GB |
| main + `STATE_CACHE_CODE=1GB` | 288.4 | 10.4 GB |
| **this PR** | **312.2** | **8.8 GB** |

+19.8% and 2.0 GB less heap, without raising the envelope. Raising the code budget on top of this adds nothing (312.7)

### No regression elsewhere

15-test sweep at `value_200M` (account access, warm ext-account queries, both `ether_transfers` variants, bloated `sload`/`sstore`), 3 rounds alternating order, same base. Mean delta **-0.35%**, and no test's delta exceeds its own run-to-run spread. `ether_transfers` on its own 11-level ladder: 167.6 -> 167.1 (-0.3%).

<details><summary>per-test MGas/s</summary>

| test | main | this PR | delta | run spread |
|---|---|---|---|---|
| `account_access BALANCE NON_EXISTING_ACCOUNT` | 410 | 411 | +0.5% | 3.8% |
| `account_access CALL EXISTING_EOA` | 363 | 369 | +1.6% | 8.0% |
| `account_access EXTCODESIZE EXISTING_CONTRACT_DIFF_MAX` | 194 | 195 | +0.7% | 5.5% |
| `ether_transfers_onchain_receivers diff_to_existent` | 121 | 121 | +0.0% | 1.0% |
| `ether_transfers_onchain_receivers diff_to_nonexistent` | 771 | 785 | +1.8% | 4.0% |
| `ext_account_query_warm BALANCE` | 3535 | 3375 | -4.5% | 15.3% |
| `ext_account_query_warm CALL` | 862 | 873 | +1.3% | 3.5% |
| `ext_account_query_warm CALLCODE` | 1346 | 1256 | -6.7% | 27.9% |
| `ext_account_query_warm DELEGATECALL` | 1354 | 1376 | +1.6% | 7.4% |
| `ext_account_query_warm EXTCODEHASH` | 2135 | 2218 | +3.9% | 7.3% |
| `ext_account_query_warm EXTCODESIZE` | 7010 | 6839 | -2.4% | 10.9% |
| `ext_account_query_warm STATICCALL` | 1143 | 1113 | -2.7% | 7.7% |
| `sload_bloated existing_slots_True` | 651 | 652 | +0.1% | 4.7% |
| `sload_same_key_benchmark storage_keys_pre_set_True` | 3306 | 3289 | -0.5% | 5.6% |
| `sstore_bloated existing_slots_True write_new_value_True` | 109 | 109 | -0.0% | 1.3% |

</details>
