### PR TITLE
rpc/jsonrpc: acquire the tx and overlay atomically in eth_call

### DIFF
--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -91,20 +91,11 @@ func (api *APIImpl) Call(ctx context.Context, args ethapi2.CallArgs, requestedBl
 		return nil, err
 	}
 
-	roTx, err := api.db.BeginTemporalRo(ctx)
+	tx, err := api.filters.BeginTemporalRoWithOverlay(ctx, api.db)
 	if err != nil {
 		return nil, err
 	}
-	defer roTx.Rollback()
-
-	var tx kv.TemporalTx = roTx
-	if api.filters != nil {
-		if sd := api.filters.LatestSD(); sd != nil {
-			if overlayTx := sd.BlockOverlayTemporalTx(roTx); overlayTx != nil {
-				tx = overlayTx
-			}
-		}
-	}
+	defer tx.Rollback()
 
 	chainConfig, err := api.chainConfig(ctx, tx)
 	if err != nil {

--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -120,7 +120,7 @@ func (api *APIImpl) Call(ctx context.Context, args ethapi2.CallArgs, requestedBl
 		return nil, err
 	}
 
-	err = rpchelper.CheckBlockExecuted(api.filters.WithOverlay(tx), header.Number.Uint64())
+	err = rpchelper.CheckBlockExecuted(tx, header.Number.Uint64())
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/jsonrpc/graphql_api.go
+++ b/rpc/jsonrpc/graphql_api.go
@@ -428,7 +428,7 @@ func (api *GraphQLAPIImpl) Call(ctx context.Context, blockNumber rpc.BlockNumber
 		return nil, err
 	}
 
-	if err := rpchelper.CheckBlockExecuted(api.filters.WithOverlay(tx), header.Number.Uint64()); err != nil {
+	if err := rpchelper.CheckBlockExecuted(tx, header.Number.Uint64()); err != nil {
 		return nil, err
 	}
 

--- a/rpc/jsonrpc/graphql_api.go
+++ b/rpc/jsonrpc/graphql_api.go
@@ -401,20 +401,11 @@ func (api *GraphQLAPIImpl) Call(ctx context.Context, blockNumber rpc.BlockNumber
 		return nil, err
 	}
 
-	roTx, err := api.db.BeginTemporalRo(ctx)
+	tx, err := api.filters.BeginTemporalRoWithOverlay(ctx, api.db)
 	if err != nil {
 		return nil, err
 	}
-	defer roTx.Rollback()
-
-	var tx kv.TemporalTx = roTx
-	if api.filters != nil {
-		if sd := api.filters.LatestSD(); sd != nil {
-			if overlayTx := sd.BlockOverlayTemporalTx(roTx); overlayTx != nil {
-				tx = overlayTx
-			}
-		}
-	}
+	defer tx.Rollback()
 
 	chainConfig, err := api.chainConfig(ctx, tx)
 	if err != nil {

--- a/rpc/jsonrpc/overlay_race_test.go
+++ b/rpc/jsonrpc/overlay_race_test.go
@@ -2372,3 +2372,23 @@ func TestGraphQLGetBlockDetails_PinsOverlayView(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, details)
 }
+
+// TestCall_PublishCycleDuringTxAcquisition pins that eth_call acquires
+// (tx, overlay) atomically: a publish/commit/unpublish cycle landing between
+// the tx open and the overlay capture leaves the head block visible in neither
+// layer, so the call would resolve against a snapshot that predates the commit.
+func TestCall_PublishCycleDuringTxAcquisition(t *testing.T) {
+	t.Parallel()
+	h := newOverlayAheadHarness(t, false)
+	h.events.PublishOverlay(nil)
+	h.doms.Close()
+
+	db := newCycleHookDB(h, true)
+	api := newEthApiForTest(h.base, db, nil, nil)
+
+	to := common.HexToAddress("0x0d3ab14bbad3d99f4203bd7a11acb94882050e7e")
+	blockNr := rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(h.overlayHeader.Number.Uint64()))
+	_, err := api.Call(h.m.Ctx, ethapi.CallArgs{From: &h.m.Address, To: &to}, &blockNr, nil, nil)
+	require.NoError(t, err,
+		"a publish/commit/unpublish cycle during tx acquisition must not hide the head block")
+}

--- a/rpc/jsonrpc/overlay_race_test.go
+++ b/rpc/jsonrpc/overlay_race_test.go
@@ -2392,3 +2392,23 @@ func TestCall_PublishCycleDuringTxAcquisition(t *testing.T) {
 	require.NoError(t, err,
 		"a publish/commit/unpublish cycle during tx acquisition must not hide the head block")
 }
+
+// TestGraphQLCall_PublishCycleDuringTxAcquisition is the GraphQL twin of
+// TestCall_PublishCycleDuringTxAcquisition: the same handler shape, so the
+// same torn (tx, overlay) acquisition hides the head block.
+func TestGraphQLCall_PublishCycleDuringTxAcquisition(t *testing.T) {
+	t.Parallel()
+	h := newOverlayAheadHarness(t, false)
+	h.events.PublishOverlay(nil)
+	h.doms.Close()
+
+	db := newCycleHookDB(h, true)
+	api := NewGraphQLAPI(h.base, db, newEthApiForTest(h.base, db, nil, nil), nil,
+		&rpccfg.GraphQLApiConfig{GasCap: 50_000_000})
+
+	to := common.HexToAddress("0x0d3ab14bbad3d99f4203bd7a11acb94882050e7e")
+	_, err := api.Call(h.m.Ctx, rpc.BlockNumber(h.overlayHeader.Number.Uint64()),
+		ethapi.CallArgs{From: &h.m.Address, To: &to})
+	require.NoError(t, err,
+		"a publish/commit/unpublish cycle during tx acquisition must not hide the head block")
+}


### PR DESCRIPTION
`TestShutterBlockBuilding` fails in CI with `eon tracker issue: ... get num keyper sets: block not found: 5`, which kills the shutter pool and times the test out. Shutter's contract reads go through `eth_call`, and `eth_call` acquired its tx and its overlay separately:

```go
roTx, err := api.db.BeginTemporalRo(ctx)   // snapshot taken here
...
if sd := api.filters.LatestSD(); sd != nil // overlay captured here
```

A publish/commit/unpublish cycle landing between those two lines leaves the head block in neither layer: the snapshot predates the commit and the overlay is already gone. `BeginTemporalRoWithOverlay` exists for exactly this and re-opens when the publish sequence moves around the open; `eth_call` and the GraphQL `Call` were the last two callers still doing it by hand.

Red test first: `TestCall_PublishCycleDuringTxAcquisition` reproduces the CI error verbatim (`block not found: 6`) on the existing `newCycleHookDB` harness.
