### PR TITLE
rpc: apply block pruning gates consistently

### DIFF
--- a/rpc/jsonrpc/check_prune_gates_test.go
+++ b/rpc/jsonrpc/check_prune_gates_test.go
@@ -104,6 +104,65 @@ func TestPruneGateArchive(t *testing.T) {
 	require.NoError(t, apis.eth.checkReceiptsAvailable(ctx, tx, 0))
 }
 
+func TestTransactionEndpointsUseBlocksPruneGate(t *testing.T) {
+	t.Parallel()
+
+	wide := prune.Distance(pruneGatingChainLen * 3)
+	apis, chainInfo := setupPruneGating(t, pruneGatingConfig{
+		mode: prune.Mode{Initialised: true, History: wide, Blocks: prune.Distance(2)},
+	})
+	ctx := t.Context()
+	tx, err := apis.eth.db.BeginTemporalRo(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+	header, err := apis.eth._blockReader.HeaderByNumber(ctx, tx, chainInfo.old.num)
+	require.NoError(t, err)
+	require.NotNil(t, header)
+	tx.Rollback()
+
+	for _, tc := range []struct {
+		name string
+		call func() error
+	}{
+		{"debug_getRawBlock", func() error {
+			_, err := apis.debug.GetRawBlock(ctx, rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(chainInfo.old.num)))
+			return err
+		}},
+		{"debug_getRawTransaction", func() error {
+			_, err := apis.debug.GetRawTransaction(ctx, chainInfo.old.txHash)
+			return err
+		}},
+		{"eth_callBundle", func() error {
+			_, err := apis.eth.CallBundle(ctx, []common.Hash{chainInfo.old.txHash}, rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber), nil)
+			return err
+		}},
+		{"erigon_getBlockByTimestamp", func() error {
+			_, err := apis.erigon.GetBlockByTimestamp(ctx, rpc.Timestamp(header.Time), false)
+			return err
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.ErrorIs(t, tc.call(), state.PrunedError)
+		})
+	}
+}
+
+func TestBlockTransactionCountsDoNotNeedTransactions(t *testing.T) {
+	t.Parallel()
+
+	wide := prune.Distance(pruneGatingChainLen * 3)
+	apis, chainInfo := setupPruneGating(t, pruneGatingConfig{
+		mode: prune.Mode{Initialised: true, History: wide, Blocks: prune.Distance(2)},
+	})
+
+	byNumber, err := apis.eth.GetBlockTransactionCountByNumber(t.Context(), rpc.BlockNumber(chainInfo.old.num))
+	require.NoError(t, err)
+	require.NotNil(t, byNumber)
+	byHash, err := apis.eth.GetBlockTransactionCountByHash(t.Context(), chainInfo.old.hash)
+	require.NoError(t, err)
+	require.NotNil(t, byHash)
+}
+
 // TestReceiptsGateFollowsRetention pins checkReceiptsAvailable against the
 // retention actually applied to the receipt cache. Enabling the cache says
 // only that it exists on disk, not how much of it is kept: RCacheDomain is

--- a/rpc/jsonrpc/debug_api.go
+++ b/rpc/jsonrpc/debug_api.go
@@ -700,7 +700,7 @@ func (api *DebugAPIImpl) GetRawBlock(ctx context.Context, blockNrOrHash rpc.Bloc
 		return nil, err
 	}
 
-	err = api.BaseAPI.checkPruneHistory(ctx, overlayTx, n)
+	err = api.BaseAPI.checkPruneBlocks(ctx, overlayTx, n)
 	if err != nil {
 		return nil, err
 	}
@@ -815,7 +815,7 @@ func (api *DebugAPIImpl) GetRawTransaction(ctx context.Context, txnHash common.H
 		return nil, nil
 	}
 
-	err = api.BaseAPI.checkPruneHistory(ctx, overlayTx, blockNum)
+	err = api.BaseAPI.checkPruneBlocks(ctx, overlayTx, blockNum)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/jsonrpc/debug_execution_witness.go
+++ b/rpc/jsonrpc/debug_execution_witness.go
@@ -1365,6 +1365,9 @@ func (api *DebugAPIImpl) resolveWitnessBlock(
 	if err := rpchelper.CheckBlockExecuted(tx, blockNum); err != nil {
 		return nil, err
 	}
+	if err := api.checkPruneBlocks(ctx, tx, blockNum); err != nil {
+		return nil, err
+	}
 
 	block, err := api.blockWithSenders(ctx, tx, hash, blockNum)
 	if err != nil {

--- a/rpc/jsonrpc/erigon_block.go
+++ b/rpc/jsonrpc/erigon_block.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/hexutil"
-	"github.com/erigontech/erigon/db/dbservices"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/order"
 	"github.com/erigontech/erigon/db/rawdb"
@@ -116,7 +115,7 @@ func (api *ErigonImpl) GetBlockByTimestamp(ctx context.Context, timeStamp rpc.Ti
 	firstHeaderTime := firstHeader.Time
 
 	if currentHeaderTime <= uintTimestamp {
-		blockResponse, err := buildBlockResponse(ctx, api._blockReader, overlayTx, highestNumber, fullTx)
+		blockResponse, err := api.buildBlockResponse(ctx, overlayTx, highestNumber, fullTx)
 		if err != nil {
 			return nil, err
 		}
@@ -125,7 +124,7 @@ func (api *ErigonImpl) GetBlockByTimestamp(ctx context.Context, timeStamp rpc.Ti
 	}
 
 	if firstHeaderTime >= uintTimestamp {
-		blockResponse, err := buildBlockResponse(ctx, api._blockReader, overlayTx, 0, fullTx)
+		blockResponse, err := api.buildBlockResponse(ctx, overlayTx, 0, fullTx)
 		if err != nil {
 			return nil, err
 		}
@@ -173,7 +172,7 @@ func (api *ErigonImpl) GetBlockByTimestamp(ctx context.Context, timeStamp rpc.Ti
 	if err != nil {
 		return nil, err
 	}
-	response, err := buildBlockResponse(ctx, api._blockReader, overlayTx, uint64(blockNum), fullTx)
+	response, err := api.buildBlockResponse(ctx, overlayTx, uint64(blockNum), fullTx)
 	if err != nil {
 		return nil, err
 	}
@@ -181,8 +180,11 @@ func (api *ErigonImpl) GetBlockByTimestamp(ctx context.Context, timeStamp rpc.Ti
 	return response, nil
 }
 
-func buildBlockResponse(ctx context.Context, br dbservices.FullBlockReader, db kv.Tx, blockNum uint64, fullTx bool) (map[string]any, error) {
-	header, err := br.HeaderByNumber(ctx, db, blockNum)
+func (api *ErigonImpl) buildBlockResponse(ctx context.Context, tx kv.Tx, blockNum uint64, fullTx bool) (map[string]any, error) {
+	if err := api.checkPruneBlocks(ctx, tx, blockNum); err != nil {
+		return nil, err
+	}
+	header, err := api._blockReader.HeaderByNumber(ctx, tx, blockNum)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +192,7 @@ func buildBlockResponse(ctx context.Context, br dbservices.FullBlockReader, db k
 		return nil, nil
 	}
 
-	block, _, err := br.BlockWithSenders(ctx, db, header.Hash(), blockNum)
+	block, err := api.blockWithSenders(ctx, tx, header.Hash(), blockNum)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/jsonrpc/eth_block.go
+++ b/rpc/jsonrpc/eth_block.go
@@ -68,7 +68,7 @@ func (api *APIImpl) CallBundle(ctx context.Context, txHashes []common.Hash, stat
 			return nil, nil
 		}
 
-		err = api.BaseAPI.checkPruneHistory(ctx, tx, blockNumber)
+		err = api.BaseAPI.checkPruneBlocks(ctx, tx, blockNumber)
 		if err != nil {
 			return nil, err
 		}
@@ -409,11 +409,6 @@ func (api *APIImpl) GetBlockTransactionCountByNumber(ctx context.Context, blockN
 		return nil, err
 	}
 
-	err = api.BaseAPI.checkPruneBlocks(ctx, tx, blockNum)
-	if err != nil {
-		return nil, err
-	}
-
 	latestBlockNumber, err := rpchelper.GetLatestBlockNumber(overlayTx)
 	if err != nil {
 		return nil, err
@@ -450,11 +445,6 @@ func (api *APIImpl) GetBlockTransactionCountByHash(ctx context.Context, blockHas
 		// (Compatibility) Every other node just return `null` for when the block does not exist.
 		log.Debug("eth_getBlockTransactionCountByHash GetBlockNumber failed", "err", err)
 		return nil, nil
-	}
-
-	err = api.BaseAPI.checkPruneBlocks(ctx, tx, blockNum)
-	if err != nil {
-		return nil, err
 	}
 
 	body, txCount, err := api._blockReader.Body(ctx, overlayTx, blockHash, blockNum)

--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -679,7 +679,7 @@ func (api *BaseAPI) getWitness(ctx context.Context, db kv.TemporalRoDB, blockNrO
 		return nil, err
 	}
 
-	if err := api.checkPruneHistory(ctx, tx, blockNr); err != nil {
+	if err := api.checkBlockHistoryAvailable(ctx, tx, blockNr); err != nil {
 		return nil, err
 	}
 

--- a/rpc/jsonrpc/eth_callMany.go
+++ b/rpc/jsonrpc/eth_callMany.go
@@ -122,7 +122,7 @@ func (api *APIImpl) CallMany(ctx context.Context, bundles []Bundle, simulateCont
 		return nil, err
 	}
 
-	err = api.BaseAPI.checkPruneHistory(ctx, tx, blockNum)
+	err = api.BaseAPI.checkBlockHistoryAvailable(ctx, tx, blockNum)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/jsonrpc/eth_simulation.go
+++ b/rpc/jsonrpc/eth_simulation.go
@@ -135,6 +135,9 @@ func (api *APIImpl) SimulateV1(ctx context.Context, req SimulationRequest, block
 	if err := rpchelper.CheckBlockExecuted(tx, blockNumber); err != nil {
 		return nil, err
 	}
+	if err := api.checkBlockHistoryAvailable(ctx, tx, blockNumber); err != nil {
+		return nil, err
+	}
 
 	block, err := api.blockWithSenders(ctx, tx, blockHash, blockNumber)
 	if err != nil {

--- a/rpc/jsonrpc/otterscan_api.go
+++ b/rpc/jsonrpc/otterscan_api.go
@@ -95,7 +95,7 @@ func (api *OtterscanAPIImpl) getTransactionByHash(ctx context.Context, tx kv.Tx,
 		return nil, nil, common.Hash{}, 0, 0, nil
 	}
 
-	err = api.BaseAPI.checkPruneHistory(ctx, tx, blockNum)
+	err = api.BaseAPI.checkBlockHistoryAvailable(ctx, tx, blockNum)
 	if err != nil {
 		return nil, nil, common.Hash{}, 0, 0, err
 	}

--- a/rpc/jsonrpc/otterscan_generic_tracer.go
+++ b/rpc/jsonrpc/otterscan_generic_tracer.go
@@ -34,6 +34,9 @@ type GenericTracer interface {
 }
 
 func (api *OtterscanAPIImpl) genericTracer(tx kv.TemporalTx, ctx context.Context, blockNum, txnID uint64, txIndex int, chainConfig *chain.Config, tracer GenericTracer) error {
+	if err := api.checkPruneBlocks(ctx, tx, blockNum); err != nil {
+		return err
+	}
 	executor := exec.NewTraceWorker(tx, chainConfig, api.engine(), api._blockReader, tracer)
 	defer executor.Close()
 

--- a/rpc/jsonrpc/otterscan_search_v3.go
+++ b/rpc/jsonrpc/otterscan_search_v3.go
@@ -79,6 +79,9 @@ func (api *OtterscanAPIImpl) buildSearchResults(ctx context.Context, tx kv.Tempo
 		}
 
 		if mustReadBlock {
+			if err := api.checkPruneBlocks(ctx, tx, blockNum); err != nil {
+				return nil, nil, false, err
+			}
 			block, err = api.blockByNumberWithSenders(ctx, tx, blockNum)
 			if err != nil {
 				return nil, nil, false, err

--- a/rpc/jsonrpc/otterscan_transaction_by_sender_and_nonce.go
+++ b/rpc/jsonrpc/otterscan_transaction_by_sender_and_nonce.go
@@ -141,6 +141,9 @@ func (api *OtterscanAPIImpl) GetTransactionBySenderAndNonce(ctx context.Context,
 	if txIndex == -1 {
 		txIndex = (idx + int(prevTxnID)) - int(minTxNum) - 1
 	}
+	if err := api.checkPruneBlocks(ctx, tx, bn); err != nil {
+		return nil, err
+	}
 	txn, ok, err := api._txnReader.TxnByIdxInBlock(ctx, tx, bn, txIndex)
 	if err != nil {
 		return nil, err

--- a/rpc/jsonrpc/overlay_api.go
+++ b/rpc/jsonrpc/overlay_api.go
@@ -125,7 +125,7 @@ func (api *OverlayAPIImpl) CallConstructor(ctx context.Context, address common.A
 		return nil, errors.New("contract construction txn not found")
 	}
 
-	err = api.BaseAPI.checkPruneHistory(ctx, tx, blockNum)
+	err = api.BaseAPI.checkBlockHistoryAvailable(ctx, tx, blockNum)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/jsonrpc/prune_gating_test.go
+++ b/rpc/jsonrpc/prune_gating_test.go
@@ -106,12 +106,6 @@ var pruneGatingEndpoints = []pruneGatingEndpoint{
 	{"eth_getBlockByHash", gatedByBlocks, func(ctx context.Context, apis pruneGatingAPIs, ref pruneGatingRef) (any, error) {
 		return apis.eth.GetBlockByHash(ctx, rpc.BlockNumberOrHashWithHash(ref.hash, false), false)
 	}},
-	{"eth_getBlockTransactionCountByNumber", gatedByBlocks, func(ctx context.Context, apis pruneGatingAPIs, ref pruneGatingRef) (any, error) {
-		return apis.eth.GetBlockTransactionCountByNumber(ctx, rpc.BlockNumber(ref.num))
-	}},
-	{"eth_getBlockTransactionCountByHash", gatedByBlocks, func(ctx context.Context, apis pruneGatingAPIs, ref pruneGatingRef) (any, error) {
-		return apis.eth.GetBlockTransactionCountByHash(ctx, ref.hash)
-	}},
 	{"eth_getTransactionByHash", gatedByBlocks, func(ctx context.Context, apis pruneGatingAPIs, ref pruneGatingRef) (any, error) {
 		return apis.eth.GetTransactionByHash(ctx, ref.txHash)
 	}},

--- a/rpc/jsonrpc/trace_adhoc.go
+++ b/rpc/jsonrpc/trace_adhoc.go
@@ -919,7 +919,7 @@ func (api *TraceAPIImpl) ReplayTransaction(ctx context.Context, txHash common.Ha
 		return nil, nil
 	}
 
-	err = api.BaseAPI.checkPruneHistory(ctx, tx, blockNum)
+	err = api.BaseAPI.checkBlockHistoryAvailable(ctx, tx, blockNum)
 	if err != nil {
 		return nil, err
 	}
@@ -968,7 +968,7 @@ func (api *TraceAPIImpl) ReplayBlockTransactions(ctx context.Context, blockNrOrH
 		return nil, err
 	}
 
-	err = api.BaseAPI.checkPruneHistory(ctx, tx, blockNumber)
+	err = api.BaseAPI.checkBlockHistoryAvailable(ctx, tx, blockNumber)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/jsonrpc/trace_filtering.go
+++ b/rpc/jsonrpc/trace_filtering.go
@@ -92,7 +92,7 @@ func (api *TraceAPIImpl) Transaction(ctx context.Context, txHash common.Hash, ga
 		return nil, nil
 	}
 
-	err = api.BaseAPI.checkPruneHistory(ctx, tx, blockNumber)
+	err = api.BaseAPI.checkBlockHistoryAvailable(ctx, tx, blockNumber)
 	if err != nil {
 		return nil, err
 	}
@@ -201,9 +201,7 @@ func (api *TraceAPIImpl) Block(ctx context.Context, blockNr rpc.BlockNumber, gas
 	}
 	bn := hexutil.Uint64(blockNum)
 
-	// if we've pruned this history away for this block then just return early
-	// to save any red herring errors
-	err = api.BaseAPI.checkPruneHistory(ctx, tx, blockNum)
+	err = api.BaseAPI.checkBlockHistoryAvailable(ctx, tx, blockNum)
 	if err != nil {
 		return nil, err
 	}
@@ -372,10 +370,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest, gas
 		return errors.New("invalid parameters: fromBlock cannot be greater than toBlock")
 	}
 
-	// if we've pruned this history away for this block then just return early
-	// to save any red herring errors
-
-	err = api.BaseAPI.checkPruneHistory(ctx, dbtx, fromBlock)
+	err = api.BaseAPI.checkBlockHistoryAvailable(ctx, dbtx, fromBlock)
 	if err != nil {
 		return err
 	}

--- a/rpc/jsonrpc/tracing.go
+++ b/rpc/jsonrpc/tracing.go
@@ -91,9 +91,7 @@ func (api *DebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rpc.Block
 		return fmt.Errorf("genesis is not traceable")
 	}
 
-	// if we've pruned this history away for this block then just return early
-	// to save any red herring errors
-	err = api.BaseAPI.checkPruneHistory(ctx, tx, blockNumber)
+	err = api.BaseAPI.checkBlockHistoryAvailable(ctx, tx, blockNumber)
 	if err != nil {
 		return err
 	}
@@ -238,8 +236,7 @@ func (api *DebugAPIImpl) TraceTransaction(ctx context.Context, hash common.Hash,
 		return fmt.Errorf("genesis is not traceable")
 	}
 
-	// check pruning to ensure we have history at this block level
-	err = api.BaseAPI.checkPruneHistory(ctx, tx, blockNum)
+	err = api.BaseAPI.checkBlockHistoryAvailable(ctx, tx, blockNum)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- gate transaction-only RPC methods on block-transaction retention instead of state-history retention
- gate replay, witness, simulation, and tracing methods on both transaction and state-history retention
- add missing transaction-data checks before block reads
- keep block transaction-count methods available when their bodies exist, even if transaction payloads are outside retention

## Motivation

Several historical RPC paths either checked only state history or did not check transaction retention before reading a block. Configurations whose block and history windows differ could therefore return internal storage errors, empty results, or admit unavailable data. Conversely, the transaction-count methods need only block bodies and were rejected by a transaction-data gate.

This fixes pre-existing gate selection and is independent of both #23708 and #23776. It was split out of #23708 to keep the default-retention change focused.
