### PR TITLE
execution/commitment: make the split-point primitives depth-agnostic

### DIFF
--- a/docs/design/parallel-patricia-hashed.md
+++ b/docs/design/parallel-patricia-hashed.md
@@ -174,10 +174,19 @@ variant (§10).
 3. **Aggregate.** `stitchSplitCells` overlays the folded child cells onto the unfolded
    base row (setting/clearing each touched present bit, leaving untouched on-disk
    siblings intact) and `foldSplitRow` folds it once to the account's storage-root cell.
-4. **Inject.** `setAccountStorageRoot` writes that hash into the account leaf
-   (`cell.hash`, `hashLen = 32`); `computeCellHash` uses it as the storageRoot for an
-   account whose storage cell was not streamed, so the leaf hashes identically to the
-   serial path. The DFS then skips the account's storage children.
+   Three outcomes: an empty row with no prior branch returns an empty cell; two or more
+   survivors fold into a branch cell and write the branch record at the split prefix;
+   a single survivor does not fold at all — `splitCellFromSingleChild` deletes the
+   branch record at the split prefix and promotes the survivor one nibble shallower,
+   prepending its nibble to the extension of a keyless sub-branch (and mirroring it into
+   `hashedExtension`) or to the hashed path of a keyed leaf, exactly as
+   `fillFromLowerCell`/`deriveHashedKeys` would at the destination depth.
+4. **Inject.** `setAccountStorageRoot` carries the returned cell onto the account leaf:
+   a branch or extension root as `cell.extension`/`cell.hash`, a single surviving slot as
+   `storageAddr`/`Storage` with `hashLen = 0`. `computeCellHash` derives the storageRoot
+   from whichever it finds for an account whose storage cell was not streamed, so the
+   leaf hashes identically to the serial path. The DFS then skips the account's storage
+   children.
 
 Below `deepStorageThreshold`, or with storage in a single first nibble, the account
 streams inline as in §4.1 — the per-account setup cost (a pooled worker, a fresh

--- a/docs/design/parallel-patricia-hashed.md
+++ b/docs/design/parallel-patricia-hashed.md
@@ -174,8 +174,11 @@ variant (§10).
 3. **Aggregate.** `stitchSplitCells` overlays the folded child cells onto the unfolded
    base row (setting/clearing each touched present bit, leaving untouched on-disk
    siblings intact) and `foldSplitRow` folds it once to the account's storage-root cell.
-   Three outcomes: an empty row with no prior branch returns an empty cell; two or more
-   survivors fold into a branch cell and write the branch record at the split prefix;
+   Four outcomes, by the surviving child count and whether a branch record was already
+   on disk: an empty row with no prior branch returns an empty cell without folding; an
+   empty row that had one folds through `foldDelete`, writing the branch delete record at
+   the split prefix and returning an empty cell; two or more survivors fold into a branch
+   cell and write the branch record at the split prefix;
    a single survivor does not fold at all — `splitCellFromSingleChild` deletes the
    branch record at the split prefix and promotes the survivor one nibble shallower,
    prepending its nibble to the extension of a keyless sub-branch (and mirroring it into
@@ -183,8 +186,9 @@ variant (§10).
    `fillFromLowerCell`/`deriveHashedKeys` would at the destination depth.
 4. **Inject.** `setAccountStorageRoot` carries the returned cell onto the account leaf:
    a branch or extension root as `cell.extension`/`cell.hash`, a single surviving slot as
-   `storageAddr`/`Storage` with `hashLen = 0`. `computeCellHash` derives the storageRoot
-   from whichever it finds for an account whose storage cell was not streamed, so the
+   `storageAddr`/`Storage` with its `hashLen` carried through unchanged. `computeCellHash`
+   derives the storageRoot from whichever it finds for an account whose storage cell was
+   not streamed — a set `storageAddr` wins and the carried `hashLen` is ignored — so the
    leaf hashes identically to the serial path. The DFS then skips the account's storage
    children.
 

--- a/docs/design/parallel-patricia-hashed.md
+++ b/docs/design/parallel-patricia-hashed.md
@@ -158,7 +158,7 @@ mount/fold model one level down at depth 64. It runs the same primitives
 (`mountTo`/`foldMounted`/`followAndUpdate`) and is shared verbatim by the streaming
 variant (§10).
 
-1. **Unfold the storage-root branch.** `unfoldStorageBase(base, accHash[:64])` seeds a
+1. **Unfold the storage-root branch.** `unfoldSplitBase(base, accHash[:64])` seeds a
    base worker by reading the account's on-disk storage-root branch
    (`branchFromCacheOrDB` + `decodeBranchIntoRow` — the same decode the account unfold
    `unfoldBranchNode` uses, entered manually at depth 64 instead of by recursive
@@ -171,9 +171,9 @@ variant (§10).
    streams the nibble's sorted slots, and `foldMounted` returns the depth-65 child
    cell. Workers defer their branch writes into the shared accumulator. They own
    disjoint storage prefixes, so concurrent reads of the shared base are race-free.
-3. **Aggregate.** `aggregateMountedStorageRoot` overlays the folded child cells onto
-   the unfolded base row (setting/clearing each touched present bit, leaving untouched
-   on-disk siblings intact) and folds once to the account's storage-root cell.
+3. **Aggregate.** `stitchSplitCells` overlays the folded child cells onto the unfolded
+   base row (setting/clearing each touched present bit, leaving untouched on-disk
+   siblings intact) and `foldSplitRow` folds it once to the account's storage-root cell.
 4. **Inject.** `setAccountStorageRoot` writes that hash into the account leaf
    (`cell.hash`, `hashLen = 32`); `computeCellHash` uses it as the storageRoot for an
    account whose storage cell was not streamed, so the leaf hashes identically to the
@@ -209,7 +209,7 @@ primary enforcement of I1.
   nibbles, every branch row a fold collapses MUST first be unfolded from `ctx.Branch`
   so untouched on-disk siblings are present. This holds at two depths: the shared
   root row before mounting (`processMounted`), and each big-storage account's
-  storage-root branch before the deep fold (`unfoldStorageBase`, §4.1.1). Dropping
+  storage-root branch before the deep fold (`unfoldSplitBase`, §4.1.1). Dropping
   either unfold drops untouched siblings and diverges the root.
 - **I3 — `plainKey` follows the split.** `prefixTrie.Insert` MUST route a
   terminator's `plainKey` to the correct node across path-compression splits (§3.1).
@@ -348,7 +348,8 @@ MDBX readers; figures are for inspection, not a CI gate.
 | --- | --- |
 | `execution/commitment/parallel_patricia_hashed.go` | `ParallelPatriciaHashed`, `Process` (routes to `processStreaming` when a committer is set), `dfsSubtree`, deferred apply and hand-off |
 | `execution/commitment/parallel_mount.go` | `processMounted` — unfold, per-nibble mount/fold via `dfsSubtreeDeep`, merged root fold; `mountTo`; `setAccountStorageRoot`; `deepStorageThreshold` |
-| `execution/commitment/streaming_deep_fold.go` | the deep storage fold shared by the parallel and streaming paths: `dfsSubtreeDeep`, `isDeepStorageAccount`, `foldStorageRoot`, `unfoldStorageBase`, `foldStorageLeaf`, `aggregateMountedStorageRoot` |
+| `execution/commitment/streaming_deep_fold.go` | the deep storage fold shared by the parallel and streaming paths: `dfsSubtreeDeep`, `isDeepStorageAccount`, `foldStorageRoot`, `foldStorageLeaf` |
+| `execution/commitment/split_point.go` | depth-agnostic split-point primitives used at every split depth: `unfoldSplitBase`, `stitchSplitCells`, `foldSplitRow`, `splitCellFromSingleChild` |
 | `execution/commitment/hex_patricia_hashed.go` | sequential engine; `foldMounted` and the `mountWall` stop used by both fold levels |
 | `execution/commitment/parallel_update.go` | `parallelUpdate`, `plainKeyArena`, `Insert`/deferred accumulation |
 | `execution/commitment/prefix_trie.go` | path-compressed prefix trie + slab arena; `Insert` `plainKey` placement |

--- a/execution/commitment/deepfold_test.go
+++ b/execution/commitment/deepfold_test.go
@@ -589,12 +589,28 @@ func TestDeepFold_EmptyStorageThenRepopulate(t *testing.T) {
 }
 
 func storageLocsForNibble(nibble byte, n, seed int) []string {
+	return slotLocsForHexPrefix([]byte{nibble}, n, seed)
+}
+func slotLocsForHexPrefix(nibblePrefix []byte, n, seed int) []string {
 	out := make([]string, 0, n)
 	var s [32]byte
 	for i := seed; len(out) < n; i++ {
 		binary.BigEndian.PutUint64(s[24:], uint64(i))
 		h := keccak.Sum256(s[:])
-		if (h[0]>>4)&0xf == nibble {
+		match := true
+		for j, nb := range nibblePrefix {
+			var hn byte
+			if j%2 == 0 {
+				hn = h[j/2] >> 4
+			} else {
+				hn = h[j/2] & 0xf
+			}
+			if hn != nb {
+				match = false
+				break
+			}
+		}
+		if match {
 			out = append(out, common.Bytes2Hex(s[:]))
 		}
 	}

--- a/execution/commitment/deepfold_test.go
+++ b/execution/commitment/deepfold_test.go
@@ -347,7 +347,7 @@ func TestDeepFold_PreExistingWhale_SubsetTouched(t *testing.T) {
 	requireAllEnginesParity(t, k1, u1, k2, u2, 4)
 }
 
-// Single-nibble on-disk storage has no branch record at the account prefix; unfoldStorageBase
+// Single-nibble on-disk storage has no branch record at the account prefix; unfoldSplitBase
 // must still recover it rather than seeding an empty base.
 func TestDeepFold_PreExistingWhale_SingleNibbleOnDisk(t *testing.T) {
 	onDisk := nibs(0)
@@ -392,7 +392,7 @@ func TestDeepFold_ExistingWhaleStillDemotes(t *testing.T) {
 }
 
 // A streaming collapse leaves an afterMap==0 tombstone at the account prefix, distinct from
-// the deep fold's outright branch-key delete; unfoldStorageBase must not seed an empty base
+// the deep fold's outright branch-key delete; unfoldSplitBase must not seed an empty base
 // from it, or a later re-expansion drops the untouched survivor.
 func TestDeepFold_SingleSlotCollapseThenDeepReexpand(t *testing.T) {
 	t.Parallel()

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -556,6 +556,10 @@ func (cell *cell) fillFromUpperCell(upCell *cell, depth, depthIncrement int16) {
 	cell.loaded = upCell.loaded
 }
 
+func (cell *cell) keylessInPlane(depth int16) bool {
+	return (cell.accountAddrLen == 0 && depth < 64) || (cell.storageAddrLen == 0 && depth > 64)
+}
+
 // fillFromLowerCell fills the cell with the data from the cell of the lower row during fold
 func (cell *cell) fillFromLowerCell(lowCell *cell, lowDepth int16, preExtension []byte, nibble int) {
 	if lowCell.accountAddrLen > 0 || lowDepth < 64 {
@@ -576,7 +580,7 @@ func (cell *cell) fillFromLowerCell(lowCell *cell, lowDepth int16, preExtension 
 		}
 	}
 	if lowCell.hashLen > 0 {
-		if (lowCell.accountAddrLen == 0 && lowDepth < 64) || (lowCell.storageAddrLen == 0 && lowDepth > 64) {
+		if lowCell.keylessInPlane(lowDepth) {
 			// Extension is related to either accounts branch node, or storage branch node, we prepend it by preExtension | nibble
 			if len(preExtension) > 0 {
 				copy(cell.extension[:], preExtension)

--- a/execution/commitment/parallel_mount.go
+++ b/execution/commitment/parallel_mount.go
@@ -74,23 +74,6 @@ func (hph *HexPatriciaHashed) mountTo(root *HexPatriciaHashed, nibble int) {
 	copy(hph.grid[:n], root.grid[:n])
 }
 
-func stitchSplitCells(base *HexPatriciaHashed, cells *[16]cell, present *[16]bool) {
-	for nib := range 16 {
-		if !present[nib] {
-			continue
-		}
-		c := cells[nib]
-		base.touchMap[0] |= uint16(1) << nib
-		if !c.IsEmpty() {
-			base.afterMap[0] |= uint16(1) << nib
-		} else {
-			base.afterMap[0] &^= uint16(1) << nib
-		}
-		base.depths[0] = 1
-		base.grid[0][nib] = c
-	}
-}
-
 func (p *ParallelPatriciaHashed) processMounted(ctx context.Context, updates *Updates) ([]byte, error) {
 	pu := updates.parallel
 	base := p.template
@@ -127,10 +110,7 @@ func (p *ParallelPatriciaHashed) processMounted(ctx context.Context, updates *Up
 		tUnfolded = time.Now()
 	}
 
-	var (
-		cells   [16]cell
-		present [16]bool
-	)
+	var cells [16]cell
 	foldSem := newFoldSem()
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(parallelMountConcurrency(p.numWorkers))
@@ -198,7 +178,6 @@ func (p *ParallelPatriciaHashed) processMounted(ctx context.Context, updates *Up
 				return fmt.Errorf("mount[%x] fold: %w", ni, err)
 			}
 			cells[ni] = c
-			present[ni] = true
 			if deferred := w.TakeDeferredUpdates(); len(deferred) > 0 {
 				pu.appendDeferred(deferred)
 			}
@@ -215,18 +194,10 @@ func (p *ParallelPatriciaHashed) processMounted(ctx context.Context, updates *Up
 		tWorkers = time.Now()
 	}
 
-	stitchSplitCells(base, &cells, &present)
+	stitchSplitCells(base, &cells, root.bitmap)
 
-	if base.activeRows == 0 {
-		base.activeRows = 1
-	}
-	for base.activeRows > 0 {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		if err := base.fold(); err != nil {
-			return nil, fmt.Errorf("processMounted: root fold: %w", err)
-		}
+	if _, err := foldSplitRow(ctx, base, foldToRoot); err != nil {
+		return nil, fmt.Errorf("processMounted: root fold: %w", err)
 	}
 	if deferred := base.TakeDeferredUpdates(); len(deferred) > 0 {
 		pu.appendDeferred(deferred)

--- a/execution/commitment/parallel_testkit_test.go
+++ b/execution/commitment/parallel_testkit_test.go
@@ -246,7 +246,7 @@ func requireBranchParity(t *testing.T, seq, got *MockState) {
 		branchDiff(t, seq, got)
 	}
 	require.Equal(t, len(seq.cm), len(got.cm), "branch count must match")
-	require.Zero(t, mism, "stored branch metadata differs between streaming and sequential")
+	require.Zero(t, mism, "stored branch metadata differs from sequential")
 }
 
 func branchDiff(t *testing.T, seq, par *MockState) {

--- a/execution/commitment/parallel_testkit_test.go
+++ b/execution/commitment/parallel_testkit_test.go
@@ -222,6 +222,7 @@ func requireAllEnginesParity(t *testing.T, k1 [][]byte, u1 []Update, k2 [][]byte
 		branchDiff(t, seqMs, parMs)
 	}
 	require.Equalf(t, seqRoot, parRoot, "parallel(workers=%d) vs sequential root mismatch", workers)
+	requireBranchParity(t, seqMs, parMs)
 }
 
 func requireBranchParity(t *testing.T, seq, got *MockState) {

--- a/execution/commitment/split_point.go
+++ b/execution/commitment/split_point.go
@@ -1,0 +1,133 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package commitment
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/bits"
+
+	"github.com/erigontech/erigon/execution/commitment/nibbles"
+)
+
+var errSplitNotBranch = errors.New("commitment: no stored branch at split prefix")
+
+func unfoldSplitBase(base *HexPatriciaHashed, prefix []byte) error {
+	d := int16(len(prefix))
+	copy(base.currentKey[:], prefix)
+	base.currentKeyLen = d
+	base.depths[0] = d + 1
+	base.activeRows = 1
+	for i := range base.grid[0] {
+		base.grid[0][i].reset()
+	}
+	base.touchMap[0], base.afterMap[0], base.branchBefore[0] = 0, 0, false
+
+	branch, err := base.branchFromCacheOrDB(nibbles.HexToCompactInto(base.compactKeyBuf[:], prefix))
+	if err != nil {
+		return err
+	}
+	if len(branch) == 0 {
+		return errSplitNotBranch
+	}
+	if len(branch) < 4 {
+		return fmt.Errorf("unfoldSplitBase: corrupt branch record at %x: %d bytes", prefix, len(branch))
+	}
+	if BranchData(branch).ChildCount() == 0 {
+		return errSplitNotBranch
+	}
+	base.branchBefore[0] = true
+	return base.decodeBranchIntoRow(0, d+1, branch[2:], false)
+}
+
+func stitchSplitCells(base *HexPatriciaHashed, cells *[16]cell, present uint16) {
+	for bm := present; bm != 0; {
+		bit := bm & -bm
+		nib := bits.TrailingZeros16(bit)
+		base.touchMap[0] |= bit
+		if cells[nib].IsEmpty() {
+			base.afterMap[0] &^= bit
+			base.grid[0][nib].reset()
+		} else {
+			base.afterMap[0] |= bit
+			base.grid[0][nib] = cells[nib]
+		}
+		bm ^= bit
+	}
+}
+
+type foldTo uint8
+
+const (
+	foldToCell foldTo = iota
+	foldToRoot
+)
+
+func foldSplitRow(ctx context.Context, base *HexPatriciaHashed, to foldTo) (cell, error) {
+	if to == foldToRoot {
+		if base.activeRows == 0 {
+			base.activeRows = 1
+		}
+		for base.activeRows > 0 {
+			if err := ctx.Err(); err != nil {
+				return cell{}, err
+			}
+			if err := base.fold(); err != nil {
+				return cell{}, err
+			}
+		}
+		return base.root, nil
+	}
+	if base.afterMap[0] == 0 && !base.branchBefore[0] {
+		base.activeRows = 0
+		return cell{}, nil
+	}
+	if kind, _ := afterMapUpdateKind(base.afterMap[0]); kind == updateKindPropagate {
+		return splitCellFromSingleChild(base)
+	}
+	if err := base.fold(); err != nil {
+		return cell{}, err
+	}
+	out := base.root
+	out.extLen = 0
+	return out, nil
+}
+
+func splitCellFromSingleChild(base *HexPatriciaHashed) (cell, error) {
+	survNib := bits.TrailingZeros16(base.afterMap[0])
+	child := base.grid[0][survNib]
+
+	if base.branchBefore[0] {
+		if err := base.collectDeleteUpdate(nibbles.HexToCompactInto(base.compactKeyBuf[:], base.currentKey[:base.currentKeyLen]), 0); err != nil {
+			return cell{}, err
+		}
+	}
+	base.activeRows = 0
+
+	var out cell
+	if child.hashLen > 0 {
+		out.extLen = child.extLen + 1
+		out.extension[0] = byte(survNib)
+		copy(out.extension[1:], child.extension[:child.extLen])
+		out.hashLen = child.hashLen
+		copy(out.hash[:], child.hash[:child.hashLen])
+	} else {
+		out = child
+	}
+	return out, nil
+}

--- a/execution/commitment/split_point.go
+++ b/execution/commitment/split_point.go
@@ -132,6 +132,9 @@ func splitCellFromSingleChild(base *HexPatriciaHashed) (cell, error) {
 		copy(out.hashedExtension[:], out.extension[:out.extLen])
 	} else {
 		out = child
+		copy(out.hashedExtension[1:], child.hashedExtension[:child.hashedExtLen])
+		out.hashedExtension[0] = byte(survNib)
+		out.hashedExtLen = min(child.hashedExtLen+1, int16(len(out.hashedExtension)))
 	}
 	return out, nil
 }

--- a/execution/commitment/split_point.go
+++ b/execution/commitment/split_point.go
@@ -122,7 +122,7 @@ func splitCellFromSingleChild(base *HexPatriciaHashed) (cell, error) {
 
 	var out cell
 	d := base.depths[0]
-	if child.hashLen > 0 && ((child.accountAddrLen == 0 && d < 64) || (child.storageAddrLen == 0 && d > 64)) {
+	if child.hashLen > 0 && child.keylessInPlane(d) {
 		out.extLen = child.extLen + 1
 		out.extension[0] = byte(survNib)
 		copy(out.extension[1:], child.extension[:child.extLen])

--- a/execution/commitment/split_point.go
+++ b/execution/commitment/split_point.go
@@ -126,7 +126,7 @@ func splitCellFromSingleChild(base *HexPatriciaHashed) (cell, error) {
 		copy(out.extension[1:], child.extension[:child.extLen])
 		out.hashLen = child.hashLen
 		copy(out.hash[:], child.hash[:child.hashLen])
-		if base.currentKeyLen < 64 {
+		if base.depths[0] != 64 {
 			out.hashedExtLen = out.extLen
 			copy(out.hashedExtension[:], out.extension[:out.extLen])
 		}

--- a/execution/commitment/split_point.go
+++ b/execution/commitment/split_point.go
@@ -105,6 +105,7 @@ func foldSplitRow(ctx context.Context, base *HexPatriciaHashed, to foldTo) (cell
 	}
 	out := base.root
 	out.extLen = 0
+	out.hashedExtLen = 0
 	return out, nil
 }
 

--- a/execution/commitment/split_point.go
+++ b/execution/commitment/split_point.go
@@ -120,16 +120,15 @@ func splitCellFromSingleChild(base *HexPatriciaHashed) (cell, error) {
 	base.activeRows = 0
 
 	var out cell
-	if child.hashLen > 0 {
+	d := base.depths[0]
+	if child.hashLen > 0 && ((child.accountAddrLen == 0 && d < 64) || (child.storageAddrLen == 0 && d > 64)) {
 		out.extLen = child.extLen + 1
 		out.extension[0] = byte(survNib)
 		copy(out.extension[1:], child.extension[:child.extLen])
 		out.hashLen = child.hashLen
 		copy(out.hash[:], child.hash[:child.hashLen])
-		if base.depths[0] != 64 {
-			out.hashedExtLen = out.extLen
-			copy(out.hashedExtension[:], out.extension[:out.extLen])
-		}
+		out.hashedExtLen = out.extLen
+		copy(out.hashedExtension[:], out.extension[:out.extLen])
 	} else {
 		out = child
 	}

--- a/execution/commitment/split_point.go
+++ b/execution/commitment/split_point.go
@@ -126,6 +126,10 @@ func splitCellFromSingleChild(base *HexPatriciaHashed) (cell, error) {
 		copy(out.extension[1:], child.extension[:child.extLen])
 		out.hashLen = child.hashLen
 		copy(out.hash[:], child.hash[:child.hashLen])
+		if base.currentKeyLen < 64 {
+			out.hashedExtLen = out.extLen
+			copy(out.hashedExtension[:], out.extension[:out.extLen])
+		}
 	} else {
 		out = child
 	}

--- a/execution/commitment/split_point_test.go
+++ b/execution/commitment/split_point_test.go
@@ -19,13 +19,16 @@ package commitment
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/hex"
 	"math/rand"
 	"slices"
 	"testing"
 
+	keccak "github.com/erigontech/fastkeccak"
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/length"
 	"github.com/erigontech/erigon/execution/commitment/nibbles"
 )
@@ -66,13 +69,20 @@ type splitRound struct {
 	ms       *MockState
 	splits   map[string]bool
 	seams    map[string]cell
+	replay   map[string][]splitKV
 	captured map[string]cell
 	deferred []*DeferredBranchUpdate
 	workers  int
 }
 
 func newSplitRound(ms *MockState) *splitRound {
-	return &splitRound{ms: ms, splits: map[string]bool{}, seams: map[string]cell{}, captured: map[string]cell{}}
+	return &splitRound{
+		ms:       ms,
+		splits:   map[string]bool{},
+		seams:    map[string]cell{},
+		replay:   map[string][]splitKV{},
+		captured: map[string]cell{},
+	}
 }
 
 func (r *splitRound) newTrie() *HexPatriciaHashed {
@@ -161,17 +171,72 @@ func (r *splitRound) foldAt(prefix []byte, keys []splitKV) (cell, error) {
 	if err := unfoldSplitBase(base, prefix); err != nil {
 		return cell{}, err
 	}
-	cells, bitmap, err := r.foldChildren(base, prefix, keys)
+	later := r.replay[string(prefix)]
+	cells, bitmap, err := r.foldChildren(base, prefix, withoutKeys(keys, later))
 	if err != nil {
 		return cell{}, err
 	}
 	stitchSplitCells(base, &cells, bitmap)
+	for i := range later {
+		if err := base.followAndUpdate(later[i].hk, later[i].pk, later[i].upd); err != nil {
+			return cell{}, err
+		}
+	}
+	for base.activeRows > 1 {
+		if err := base.fold(); err != nil {
+			return cell{}, err
+		}
+	}
 	out, err := foldSplitRow(context.Background(), base, foldToCell)
 	if err != nil {
 		return cell{}, err
 	}
 	r.captured[string(prefix)] = out
 	return out, nil
+}
+
+func withoutKeys(keys, drop []splitKV) []splitKV {
+	if len(drop) == 0 {
+		return keys
+	}
+	skip := make(map[string]struct{}, len(drop))
+	for _, k := range drop {
+		skip[string(k.hk)] = struct{}{}
+	}
+	out := make([]splitKV, 0, len(keys))
+	for _, k := range keys {
+		if _, ok := skip[string(k.hk)]; ok {
+			continue
+		}
+		out = append(out, k)
+	}
+	return out
+}
+
+func slotLocsForHexPrefix(nibblePrefix []byte, n, seed int) []string {
+	out := make([]string, 0, n)
+	var s [32]byte
+	for i := seed; len(out) < n; i++ {
+		binary.BigEndian.PutUint64(s[24:], uint64(i))
+		h := keccak.Sum256(s[:])
+		match := true
+		for j, nb := range nibblePrefix {
+			var hn byte
+			if j%2 == 0 {
+				hn = h[j/2] >> 4
+			} else {
+				hn = h[j/2] & 0xf
+			}
+			if hn != nb {
+				match = false
+				break
+			}
+		}
+		if match {
+			out = append(out, common.Bytes2Hex(s[:]))
+		}
+	}
+	return out
 }
 
 func (r *splitRound) foldRoot(keys []splitKV) ([]byte, error) {
@@ -533,4 +598,107 @@ func TestSplitPoint_CollapsedCellFoldsInParentSplit(t *testing.T) {
 	require.Equalf(t, collapsed.extension[:collapsed.extLen], collapsed.hashedExtension[:collapsed.hashedExtLen],
 		"a collapsed account-plane cell must carry a hashed extension matching its extension; extLen=%d hashedExtLen=%d",
 		collapsed.extLen, collapsed.hashedExtLen)
+}
+
+func splitStorageCollapseCorpus() (addr []byte, doomed []string, survivors []string, pk [][]byte, upds []Update) {
+	rnd := rand.New(rand.NewSource(70707))
+	addr = make([]byte, length.Addr)
+	rnd.Read(addr)
+	a := hex.EncodeToString(addr)
+
+	ub := NewUpdateBuilder()
+	ub.Balance(a, 1234)
+	for i, tail := range []byte{0x0, 0x4, 0x8} {
+		loc := slotLocsForHexPrefix([]byte{0x1, 0x2, tail}, 1, 5000*(i+1))[0]
+		doomed = append(doomed, loc)
+		ub.Storage(a, loc, "11")
+	}
+	survivors = slotLocsForHexPrefix([]byte{0x1, 0x2, 0xf}, 4, 900_000)
+	for _, loc := range survivors {
+		ub.Storage(a, loc, "22")
+	}
+	for _, tail := range []byte{0x5, 0x9} {
+		for _, loc := range slotLocsForHexPrefix([]byte{0x1, tail}, 2, 31_000) {
+			ub.Storage(a, loc, "33")
+		}
+	}
+	for _, nib := range []byte{0x3, 0x7, 0xb} {
+		for _, loc := range storageLocsForNibble(nib, 2, 77_000) {
+			ub.Storage(a, loc, "44")
+		}
+	}
+	for range 2_000 {
+		addRandomAccount(ub, rnd, 0)
+	}
+	pk, upds = ub.Build()
+	return addr, doomed, survivors, pk, upds
+}
+
+func TestSplitPoint_CollapsedStorageCellReUnfolded(t *testing.T) {
+	addr, doomed, survivors, pk1, u1 := splitStorageCollapseCorpus()
+	require.Len(t, survivors, 4, "the survivor nibble must hold a sub-branch, not a single slot")
+
+	msSeq := NewMockState(t)
+	seq := NewHexPatriciaHashed(length.Addr, msSeq, DefaultTrieConfig())
+	defer seq.Release()
+	processBatch(t, msSeq, seq, pk1, u1)
+
+	accHash := KeyToHexNibbleHash(addr)
+	accPrefix := accHash[:64]
+	prefix65 := append(bytes.Clone(accPrefix), 0x1)
+	prefix66 := append(bytes.Clone(prefix65), 0x2)
+	for _, p := range [][]byte{accPrefix, prefix65, prefix66} {
+		require.Truef(t, hasBranchAt(msSeq, p), "corpus must produce an on-disk branch at %x", p)
+	}
+
+	msSplit := cloneMockState(t, msSeq)
+
+	a := hex.EncodeToString(addr)
+	ub := NewUpdateBuilder()
+	ub.Balance(a, 5678)
+	for _, loc := range doomed {
+		ub.DeleteStorage(a, loc)
+	}
+	ub.Storage(a, survivors[0], "99")
+	pk2, u2 := ub.Build()
+	seqRoot := processBatch(t, msSeq, seq, pk2, u2)
+	require.NoError(t, msSplit.applyPlainUpdates(pk2, u2))
+
+	all := splitKVs(pk2, u2)
+	var storage []splitKV
+	var reUnfold []splitKV
+	laterHK := KeyToHexNibbleHash(storageKey(addr, common.Hex2Bytes(survivors[0])))
+	for _, k := range all {
+		if len(k.hk) != 128 || !bytes.HasPrefix(k.hk, accPrefix) {
+			continue
+		}
+		storage = append(storage, k)
+		if bytes.Equal(k.hk, laterHK) {
+			reUnfold = append(reUnfold, k)
+		}
+	}
+	require.Len(t, reUnfold, 1, "the surviving slot must be touched so the base descends through the collapsed cell")
+
+	r := newSplitRound(msSplit)
+	r.splits[string(prefix65)] = true
+	r.splits[string(prefix66)] = true
+	r.replay[string(prefix65)] = reUnfold
+
+	sr, err := r.foldAt(accPrefix, storage)
+	require.NoError(t, err)
+
+	collapsed, ok := r.captured[string(prefix66)]
+	require.True(t, ok, "the interior split at depth 66 did not run")
+	require.Positive(t, collapsed.extLen, "the split at depth 66 must collapse to a single survivor")
+	require.EqualValues(t, 0xf, collapsed.extension[0], "the survivor nibble must lead the extension")
+	require.Zero(t, collapsed.accountAddrLen+collapsed.storageAddrLen, "the survivor must be keyless, not a single-slot leaf")
+
+	r.seams[string(accHash)] = sr
+	splitRoot, err := r.foldRoot(all)
+	require.NoError(t, err)
+	r.flush(t)
+
+	require.Equalf(t, seqRoot, splitRoot,
+		"a collapsed cell at %x re-unfolded by a later key in the same round != sequential root", prefix66)
+	requireBranchParity(t, msSeq, msSplit)
 }

--- a/execution/commitment/split_point_test.go
+++ b/execution/commitment/split_point_test.go
@@ -682,6 +682,19 @@ func TestSplitPoint_CollapsedStorageCellReUnfolded(t *testing.T) {
 	requireBranchParity(t, msSeq, msSplit)
 }
 
+func requireBranchParityExceptTouchMapAt(t *testing.T, seq, got *MockState, prefix []byte) {
+	t.Helper()
+	key := string(nibbles.HexToCompact(prefix))
+	sb, sok := seq.cm[key]
+	pb, pok := got.cm[key]
+	require.Truef(t, sok && pok, "both engines must store a record at %x", prefix)
+	require.Equalf(t, sb[2:], pb[2:],
+		"record at %x must match serial in afterMap and cells; only its touch bitmap may differ, because the collapse writes the deletions as a separate delete record before the row is rebuilt on re-entry", prefix)
+	masked := cloneMockState(t, seq)
+	masked.cm[key] = pb
+	requireBranchParity(t, masked, got)
+}
+
 func decodedRowCell(t *testing.T, ms *MockState, prefix []byte, nib byte) cell {
 	t.Helper()
 	base := NewHexPatriciaHashed(length.Addr, ms, DefaultTrieConfig())
@@ -690,7 +703,15 @@ func decodedRowCell(t *testing.T, ms *MockState, prefix []byte, nib byte) cell {
 	return base.grid[0][nib]
 }
 
-func splitKeyedSurvivorCorpus(sharedSlotPrefix bool) (doomed [][]byte, touch [][]byte, pk [][]byte, upds []Update) {
+type survivorKind uint8
+
+const (
+	survivorBareRoot survivorKind = iota
+	survivorExtRoot
+	survivorEOA
+)
+
+func splitKeyedSurvivorCorpus(kind survivorKind) (doomed [][]byte, touch [][]byte, surv []byte, pk [][]byte, upds []Update) {
 	rnd := rand.New(rand.NewSource(515151))
 	ub := NewUpdateBuilder()
 	for _, tail := range []byte{0x0, 0x4, 0x8} {
@@ -699,11 +720,14 @@ func splitKeyedSurvivorCorpus(sharedSlotPrefix bool) (doomed [][]byte, touch [][
 		ub.Balance(hex.EncodeToString(a), uint64(tail)+7)
 	}
 
-	surv := findAddressForHexPrefix([]byte{0x1, 0x2, 0x3, 0xf}, 359)
+	surv = findAddressForHexPrefix([]byte{0x1, 0x2, 0x3, 0xf}, 359)
 	sa := hex.EncodeToString(surv)
 	ub.Balance(sa, 4242)
-	locs := append(slotLocsForHexPrefix([]byte{0x2}, 1, 12_000), slotLocsForHexPrefix([]byte{0x9}, 1, 12_000)...)
-	if sharedSlotPrefix {
+	var locs []string
+	switch kind {
+	case survivorBareRoot:
+		locs = append(slotLocsForHexPrefix([]byte{0x2}, 1, 12_000), slotLocsForHexPrefix([]byte{0x9}, 1, 12_000)...)
+	case survivorExtRoot:
 		locs = slotLocsForHexPrefix([]byte{0xa, 0xb}, 2, 640_000)
 	}
 	for i, loc := range locs {
@@ -723,19 +747,20 @@ func splitKeyedSurvivorCorpus(sharedSlotPrefix bool) (doomed [][]byte, touch [][
 		addRandomAccount(ub, rnd, 0)
 	}
 	pk, upds = ub.Build()
-	return doomed, touch, pk, upds
+	return doomed, touch, surv, pk, upds
 }
 
 func TestSplitPoint_KeyedSurvivorCollapse(t *testing.T) {
 	for _, tc := range []struct {
-		name   string
-		shared bool
+		name string
+		kind survivorKind
 	}{
-		{"storage-root-hash", false},
-		{"storage-root-extension", true},
+		{"storage-root-hash", survivorBareRoot},
+		{"storage-root-extension", survivorExtRoot},
+		{"eoa", survivorEOA},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			doomed, touch, pk1, u1 := splitKeyedSurvivorCorpus(tc.shared)
+			doomed, touch, surv, pk1, u1 := splitKeyedSurvivorCorpus(tc.kind)
 
 			msSeq := NewMockState(t)
 			seq := NewHexPatriciaHashed(length.Addr, msSeq, DefaultTrieConfig())
@@ -751,12 +776,31 @@ func TestSplitPoint_KeyedSurvivorCollapse(t *testing.T) {
 
 			survCell := decodedRowCell(t, msSplit, prefix, 0xf)
 			require.Positivef(t, survCell.accountAddrLen, "the survivor decoded from the record at %x must be an account", prefix)
-			require.Positive(t, survCell.hashLen, "the survivor account must carry a storage root hash")
-			if tc.shared {
+			switch tc.kind {
+			case survivorEOA:
+				require.Zero(t, survCell.hashLen, "an EOA survivor carries no storage root hash")
+			case survivorExtRoot:
+				require.Positive(t, survCell.hashLen, "the survivor account must carry a storage root hash")
 				require.Positive(t, survCell.extLen, "the survivor's storage root must be an extension")
-			} else {
+			default:
+				require.Positive(t, survCell.hashLen, "the survivor account must carry a storage root hash")
 				require.Zero(t, survCell.extLen, "the survivor's storage root must be a bare branch hash")
 			}
+			require.Positive(t, survCell.hashedExtLen, "the decoded survivor must carry its hashed path from the row depth")
+
+			survHK := KeyToHexNibbleHash(surv)
+			var later []byte
+			for x := byte(0); x < 16; x++ {
+				if x == 0xf || x == survHK[len(prefix)+1] {
+					continue
+				}
+				later = findAddressForHexPrefix(append(append([]byte{}, prefix...), x), 373)
+				break
+			}
+			laterHK := KeyToHexNibbleHash(later)
+			require.Equal(t, prefix, laterHK[:len(prefix)], "the later key must descend into the promoted survivor's slot")
+			require.NotEqual(t, survHK[len(prefix)+1], laterHK[len(prefix)],
+				"the later key's next nibble must differ from the survivor's, so a stale hashed path misroutes instead of colliding")
 
 			ub := NewUpdateBuilder()
 			for _, a := range doomed {
@@ -765,15 +809,26 @@ func TestSplitPoint_KeyedSurvivorCollapse(t *testing.T) {
 			for i, a := range touch {
 				ub.Balance(hex.EncodeToString(a), uint64(i)+7001)
 			}
+			ub.Balance(hex.EncodeToString(later), 7777)
 			pk2, u2 := ub.Build()
 			seqRoot := processBatch(t, msSeq, seq, pk2, u2)
 			require.NoError(t, msSplit.applyPlainUpdates(pk2, u2))
+
+			all := splitKVs(pk2, u2)
+			var reUnfold []splitKV
+			for _, k := range all {
+				if bytes.Equal(k.hk, laterHK) {
+					reUnfold = append(reUnfold, k)
+				}
+			}
+			require.Len(t, reUnfold, 1, "the later key must be touched so the parent base descends through the promoted survivor")
 
 			r := newSplitRound(msSplit)
 			r.splits[string(prefix[:1])] = true
 			r.splits[string(prefix[:2])] = true
 			r.splits[string(prefix)] = true
-			splitRoot, err := r.foldRoot(splitKVs(pk2, u2))
+			r.replay[string(prefix[:2])] = reUnfold
+			splitRoot, err := r.foldRoot(all)
 			require.NoError(t, err)
 			r.flush(t)
 
@@ -783,8 +838,14 @@ func TestSplitPoint_KeyedSurvivorCollapse(t *testing.T) {
 				"a collapse onto a keyed survivor must promote the account, not wrap its storage root in an extension cell; got accountAddrLen=%d extLen=%d",
 				collapsed.accountAddrLen, collapsed.extLen)
 
-			require.Equalf(t, seqRoot, splitRoot, "root with a keyed survivor collapse at %x != sequential", prefix)
-			requireBranchParity(t, msSeq, msSplit)
+			require.Equalf(t, seqRoot, splitRoot, "root with a re-entry through the promoted keyed survivor at %x != sequential", prefix)
+			requireBranchParityExceptTouchMapAt(t, msSeq, msSplit, prefix)
+
+			require.Equal(t, survCell.hashedExtLen+1, collapsed.hashedExtLen,
+				"the promoted survivor's hashed path must be measured from the parent row, one nibble longer")
+			require.EqualValues(t, 0xf, collapsed.hashedExtension[0], "the promoted survivor's hashed path must start with its nibble in the collapsed row")
+			require.Equal(t, survCell.hashedExtension[:survCell.hashedExtLen], collapsed.hashedExtension[1:collapsed.hashedExtLen],
+				"the promoted survivor's hashed path must continue with the path it had in the collapsed row")
 		})
 	}
 }

--- a/execution/commitment/split_point_test.go
+++ b/execution/commitment/split_point_test.go
@@ -790,7 +790,7 @@ func TestSplitPoint_KeyedSurvivorCollapse(t *testing.T) {
 
 			survHK := KeyToHexNibbleHash(surv)
 			var later []byte
-			for x := byte(0); x < 16; x++ {
+			for x := range byte(16) {
 				if x == 0xf || x == survHK[len(prefix)+1] {
 					continue
 				}

--- a/execution/commitment/split_point_test.go
+++ b/execution/commitment/split_point_test.go
@@ -177,6 +177,13 @@ func (r *splitRound) foldAt(prefix []byte, keys []splitKV) (cell, error) {
 		return cell{}, err
 	}
 	stitchSplitCells(base, &cells, bitmap)
+	if len(later) > 0 {
+		r.take(base)
+		if _, err := ApplyDeferredBranchUpdates(r.deferred, 1, r.ms.PutBranch, nil); err != nil {
+			return cell{}, err
+		}
+		r.deferred = nil
+	}
 	for i := range later {
 		if err := base.followAndUpdate(later[i].hk, later[i].pk, later[i].upd); err != nil {
 			return cell{}, err
@@ -459,6 +466,7 @@ func TestSplitPoint_InteriorSingleSurvivorCollapse(t *testing.T) {
 	survNib := byte(0xf)
 	child := base.grid[0][survNib]
 	require.Positive(t, child.hashLen, "the survivor child must be a branch reference")
+	require.Zero(t, child.accountAddrLen+child.storageAddrLen, "this case pins the keyless survivor; the keyed one has its own test")
 
 	cells, bitmap, err := r.foldChildren(base, prefix, splitKVs(pk2, u2))
 	require.NoError(t, err)
@@ -701,4 +709,111 @@ func TestSplitPoint_CollapsedStorageCellReUnfolded(t *testing.T) {
 	require.Equalf(t, seqRoot, splitRoot,
 		"a collapsed cell at %x re-unfolded by a later key in the same round != sequential root", prefix66)
 	requireBranchParity(t, msSeq, msSplit)
+}
+
+func decodedRowCell(t *testing.T, ms *MockState, prefix []byte, nib byte) cell {
+	t.Helper()
+	base := NewHexPatriciaHashed(length.Addr, ms, DefaultTrieConfig())
+	defer base.Release()
+	require.NoError(t, unfoldSplitBase(base, prefix))
+	return base.grid[0][nib]
+}
+
+func splitKeyedSurvivorCorpus(sharedSlotPrefix bool) (doomed [][]byte, touch [][]byte, pk [][]byte, upds []Update) {
+	rnd := rand.New(rand.NewSource(515151))
+	ub := NewUpdateBuilder()
+	for _, tail := range []byte{0x0, 0x4, 0x8} {
+		a := findAddressForHexPrefix([]byte{0x1, 0x2, 0x3, tail}, int(tail)+301)
+		doomed = append(doomed, a)
+		ub.Balance(hex.EncodeToString(a), uint64(tail)+7)
+	}
+
+	surv := findAddressForHexPrefix([]byte{0x1, 0x2, 0x3, 0xf}, 359)
+	sa := hex.EncodeToString(surv)
+	ub.Balance(sa, 4242)
+	locs := append(slotLocsForHexPrefix([]byte{0x2}, 1, 12_000), slotLocsForHexPrefix([]byte{0x9}, 1, 12_000)...)
+	if sharedSlotPrefix {
+		locs = slotLocsForHexPrefix([]byte{0xa, 0xb}, 2, 640_000)
+	}
+	for i, loc := range locs {
+		ub.Storage(sa, loc, hex.EncodeToString([]byte{byte(i) + 1}))
+	}
+
+	for _, p := range [][]byte{{0x1, 0x2, 0x7}, {0x1, 0x2, 0xc}, {0x1, 0x7}, {0x1, 0xc}} {
+		for seed := range 2 {
+			a := findAddressForHexPrefix(p, seed*17+401)
+			ub.Balance(hex.EncodeToString(a), uint64(seed)+53)
+			if seed == 0 && (len(p) == 2 || p[2] == 0x7) {
+				touch = append(touch, a)
+			}
+		}
+	}
+	for range 400 {
+		addRandomAccount(ub, rnd, 0)
+	}
+	pk, upds = ub.Build()
+	return doomed, touch, pk, upds
+}
+
+func TestSplitPoint_KeyedSurvivorCollapse(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		shared bool
+	}{
+		{"storage-root-hash", false},
+		{"storage-root-extension", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			doomed, touch, pk1, u1 := splitKeyedSurvivorCorpus(tc.shared)
+
+			msSeq := NewMockState(t)
+			seq := NewHexPatriciaHashed(length.Addr, msSeq, DefaultTrieConfig())
+			defer seq.Release()
+			processBatch(t, msSeq, seq, pk1, u1)
+
+			prefix := []byte{0x1, 0x2, 0x3}
+			for _, p := range [][]byte{prefix[:1], prefix[:2], prefix} {
+				require.Truef(t, hasBranchAt(msSeq, p), "corpus must produce an on-disk branch at %x", p)
+			}
+
+			msSplit := cloneMockState(t, msSeq)
+
+			survCell := decodedRowCell(t, msSplit, prefix, 0xf)
+			require.Positivef(t, survCell.accountAddrLen, "the survivor decoded from the record at %x must be an account", prefix)
+			require.Positive(t, survCell.hashLen, "the survivor account must carry a storage root hash")
+			if tc.shared {
+				require.Positive(t, survCell.extLen, "the survivor's storage root must be an extension")
+			} else {
+				require.Zero(t, survCell.extLen, "the survivor's storage root must be a bare branch hash")
+			}
+
+			ub := NewUpdateBuilder()
+			for _, a := range doomed {
+				ub.Delete(hex.EncodeToString(a))
+			}
+			for i, a := range touch {
+				ub.Balance(hex.EncodeToString(a), uint64(i)+7001)
+			}
+			pk2, u2 := ub.Build()
+			seqRoot := processBatch(t, msSeq, seq, pk2, u2)
+			require.NoError(t, msSplit.applyPlainUpdates(pk2, u2))
+
+			r := newSplitRound(msSplit)
+			r.splits[string(prefix[:1])] = true
+			r.splits[string(prefix[:2])] = true
+			r.splits[string(prefix)] = true
+			splitRoot, err := r.foldRoot(splitKVs(pk2, u2))
+			require.NoError(t, err)
+			r.flush(t)
+
+			collapsed, ok := r.captured[string(prefix)]
+			require.True(t, ok, "the interior split at 123 did not run")
+			require.Equalf(t, survCell.accountAddrLen, collapsed.accountAddrLen,
+				"a collapse onto a keyed survivor must promote the account, not wrap its storage root in an extension cell; got accountAddrLen=%d extLen=%d",
+				collapsed.accountAddrLen, collapsed.extLen)
+
+			require.Equalf(t, seqRoot, splitRoot, "root with a keyed survivor collapse at %x != sequential", prefix)
+			requireBranchParity(t, msSeq, msSplit)
+		})
+	}
 }

--- a/execution/commitment/split_point_test.go
+++ b/execution/commitment/split_point_test.go
@@ -284,6 +284,7 @@ func TestSplitPoint_StoragePlaneInteriorSplit(t *testing.T) {
 	r.seams[string(accHash)] = sr
 	splitRoot, err := r.foldRoot(all)
 	require.NoError(t, err)
+	r.flush(t)
 
 	rc := newSplitRound(msCell)
 	base := rc.newTrie()
@@ -297,6 +298,7 @@ func TestSplitPoint_StoragePlaneInteriorSplit(t *testing.T) {
 	require.Equalf(t, c64.extension[:c64.extLen], c65.extension[:c65.extLen],
 		"interior split at depth 65 (prefix %x) must yield the same cell extension as the depth-64 path", prefix65)
 	require.Equal(t, seqRoot, splitRoot, "round root through a depth-65 split != sequential root")
+	requireBranchParity(t, msSeq, msSplit)
 }
 
 func TestSplitPoint_AccountPlaneInteriorSplit(t *testing.T) {
@@ -456,4 +458,79 @@ func TestSplitPoint_RefusesPrefixWithoutBranch(t *testing.T) {
 	_, err := r.foldAt(absent, under)
 	require.ErrorIs(t, err, errSplitNotBranch)
 	require.Zero(t, r.workers, "positioning must refuse before any worker is created")
+}
+
+func splitCollapseParentCorpus() (doomed [][]byte, keep [][]byte, pk [][]byte, upds []Update) {
+	rnd := rand.New(rand.NewSource(4242))
+	ub := NewUpdateBuilder()
+	for _, tail := range []byte{0x0, 0x5, 0xa} {
+		a := findAddressForHexPrefix([]byte{0x1, 0x2, 0x3, tail}, int(tail)+11)
+		doomed = append(doomed, a)
+		ub.Balance(hex.EncodeToString(a), uint64(tail)+7)
+	}
+	for seed := range 6 {
+		a := findAddressForHexPrefix([]byte{0x1, 0x2, 0x3, 0xf}, seed+77)
+		ub.Balance(hex.EncodeToString(a), uint64(seed)+31)
+	}
+	for _, p := range [][]byte{{0x1, 0x2, 0x7}, {0x1, 0x2, 0xc}, {0x1, 0x7}, {0x1, 0xc}} {
+		for seed := range 2 {
+			a := findAddressForHexPrefix(p, seed*13+101)
+			ub.Balance(hex.EncodeToString(a), uint64(seed)+53)
+			if seed == 0 && (p[len(p)-1] == 0x7) {
+				keep = append(keep, a)
+			}
+		}
+	}
+	for range 400 {
+		addRandomAccount(ub, rnd, 0)
+	}
+	pk, upds = ub.Build()
+	return doomed, keep, pk, upds
+}
+
+func TestSplitPoint_CollapsedCellFoldsInParentSplit(t *testing.T) {
+	doomed, keep, pk1, u1 := splitCollapseParentCorpus()
+	require.Len(t, keep, 2, "corpus must keep one touchable account under 127 and one under 17")
+
+	msSeq := NewMockState(t)
+	seq := NewHexPatriciaHashed(length.Addr, msSeq, DefaultTrieConfig())
+	defer seq.Release()
+	processBatch(t, msSeq, seq, pk1, u1)
+
+	prefix := []byte{0x1, 0x2, 0x3}
+	for _, p := range [][]byte{prefix[:1], prefix[:2], prefix} {
+		require.Truef(t, hasBranchAt(msSeq, p), "corpus must produce an on-disk branch at %x", p)
+	}
+
+	msSplit := cloneMockState(t, msSeq)
+
+	ub := NewUpdateBuilder()
+	for _, a := range doomed {
+		ub.Delete(hex.EncodeToString(a))
+	}
+	for i, a := range keep {
+		ub.Balance(hex.EncodeToString(a), uint64(i)+9001)
+	}
+	pk2, u2 := ub.Build()
+	seqRoot := processBatch(t, msSeq, seq, pk2, u2)
+	require.NoError(t, msSplit.applyPlainUpdates(pk2, u2))
+
+	r := newSplitRound(msSplit)
+	r.splits[string(prefix[:1])] = true
+	r.splits[string(prefix[:2])] = true
+	r.splits[string(prefix)] = true
+	splitRoot, err := r.foldRoot(splitKVs(pk2, u2))
+	require.NoError(t, err)
+	r.flush(t)
+
+	collapsed, ok := r.captured[string(prefix)]
+	require.True(t, ok, "the interior split at 123 did not run")
+	require.Positive(t, collapsed.extLen, "the split at 123 must collapse to a single survivor")
+	require.EqualValues(t, 0xf, collapsed.extension[0], "the survivor nibble must lead the extension")
+	require.Equalf(t, seqRoot, splitRoot, "root with a collapse at %x folded through parent splits at %x and %x != sequential", prefix, prefix[:2], prefix[:1])
+	requireBranchParity(t, msSeq, msSplit)
+
+	require.Equalf(t, collapsed.extension[:collapsed.extLen], collapsed.hashedExtension[:collapsed.hashedExtLen],
+		"a collapsed account-plane cell must carry a hashed extension matching its extension; extLen=%d hashedExtLen=%d",
+		collapsed.extLen, collapsed.hashedExtLen)
 }

--- a/execution/commitment/split_point_test.go
+++ b/execution/commitment/split_point_test.go
@@ -158,16 +158,15 @@ func (r *splitRound) foldAt(prefix []byte, keys []splitKV) (cell, error) {
 		r.take(base)
 		base.Release()
 	}()
-	if err := unfoldStorageBase(base, prefix); err != nil {
+	if err := unfoldSplitBase(base, prefix); err != nil {
 		return cell{}, err
 	}
 	cells, bitmap, err := r.foldChildren(base, prefix, keys)
 	if err != nil {
 		return cell{}, err
 	}
-	present := presentFlags(bitmap)
-	stitchSplitCells(base, &cells, &present)
-	out, err := aggregateMountedStorageRoot(base, &cells, bitmap)
+	stitchSplitCells(base, &cells, bitmap)
+	out, err := foldSplitRow(context.Background(), base, foldToCell)
 	if err != nil {
 		return cell{}, err
 	}
@@ -190,25 +189,11 @@ func (r *splitRound) foldRoot(keys []splitKV) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	present := presentFlags(bitmap)
-	stitchSplitCells(base, &cells, &present)
-	if base.activeRows == 0 {
-		base.activeRows = 1
-	}
-	for base.activeRows > 0 {
-		if err := base.fold(); err != nil {
-			return nil, err
-		}
+	stitchSplitCells(base, &cells, bitmap)
+	if _, err := foldSplitRow(ctx, base, foldToRoot); err != nil {
+		return nil, err
 	}
 	return base.RootHash()
-}
-
-func presentFlags(bitmap uint16) [16]bool {
-	var present [16]bool
-	for nib := range 16 {
-		present[nib] = bitmap&(uint16(1)<<nib) != 0
-	}
-	return present
 }
 
 func splitWhaleCorpus(slots, background int) (addr []byte, pk [][]byte, upds []Update) {
@@ -303,7 +288,7 @@ func TestSplitPoint_StoragePlaneInteriorSplit(t *testing.T) {
 	rc := newSplitRound(msCell)
 	base := rc.newTrie()
 	defer base.Release()
-	require.NoError(t, unfoldStorageBase(base, accPrefix))
+	require.NoError(t, unfoldSplitBase(base, accPrefix))
 	c64, err := rc.foldLeaf(base, splitNib, byNib[byte(splitNib)])
 	require.NoError(t, err)
 
@@ -402,7 +387,7 @@ func TestSplitPoint_InteriorSingleSurvivorCollapse(t *testing.T) {
 	r := newSplitRound(ms)
 	base := r.newTrie()
 	defer base.Release()
-	require.NoError(t, unfoldStorageBase(base, prefix))
+	require.NoError(t, unfoldSplitBase(base, prefix))
 
 	survNib := byte(0xf)
 	child := base.grid[0][survNib]
@@ -412,9 +397,8 @@ func TestSplitPoint_InteriorSingleSurvivorCollapse(t *testing.T) {
 	require.NoError(t, err)
 	require.Zero(t, bitmap&(uint16(1)<<survNib), "the survivor must not be touched")
 
-	present := presentFlags(bitmap)
-	stitchSplitCells(base, &cells, &present)
-	got, err := aggregateMountedStorageRoot(base, &cells, bitmap)
+	stitchSplitCells(base, &cells, bitmap)
+	got, err := foldSplitRow(context.Background(), base, foldToCell)
 	require.NoError(t, err)
 
 	want := append([]byte{survNib}, child.extension[:child.extLen]...)
@@ -470,6 +454,6 @@ func TestSplitPoint_RefusesPrefixWithoutBranch(t *testing.T) {
 		}
 	}
 	_, err := r.foldAt(absent, under)
-	require.ErrorIs(t, err, errStorageBaseNotBranch)
+	require.ErrorIs(t, err, errSplitNotBranch)
 	require.Zero(t, r.workers, "positioning must refuse before any worker is created")
 }

--- a/execution/commitment/split_point_test.go
+++ b/execution/commitment/split_point_test.go
@@ -19,13 +19,11 @@ package commitment
 import (
 	"bytes"
 	"context"
-	"encoding/binary"
 	"encoding/hex"
 	"math/rand"
 	"slices"
 	"testing"
 
-	keccak "github.com/erigontech/fastkeccak"
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common"
@@ -220,32 +218,6 @@ func withoutKeys(keys, drop []splitKV) []splitKV {
 	return out
 }
 
-func slotLocsForHexPrefix(nibblePrefix []byte, n, seed int) []string {
-	out := make([]string, 0, n)
-	var s [32]byte
-	for i := seed; len(out) < n; i++ {
-		binary.BigEndian.PutUint64(s[24:], uint64(i))
-		h := keccak.Sum256(s[:])
-		match := true
-		for j, nb := range nibblePrefix {
-			var hn byte
-			if j%2 == 0 {
-				hn = h[j/2] >> 4
-			} else {
-				hn = h[j/2] & 0xf
-			}
-			if hn != nb {
-				match = false
-				break
-			}
-		}
-		if match {
-			out = append(out, common.Bytes2Hex(s[:]))
-		}
-	}
-	return out
-}
-
 func (r *splitRound) foldRoot(keys []splitKV) ([]byte, error) {
 	ctx := context.Background()
 	base := r.newTrie()
@@ -419,7 +391,7 @@ func TestSplitPoint_AccountPlaneInteriorSplit(t *testing.T) {
 	requireBranchParity(t, msSeq, msSplit)
 }
 
-func splitCollapseCorpus() (survivors, doomed [][]byte, pk [][]byte, upds []Update) {
+func splitCollapseCorpus() (doomed [][]byte, pk [][]byte, upds []Update) {
 	rnd := rand.New(rand.NewSource(9090))
 	ub := NewUpdateBuilder()
 	for _, tail := range []byte{0x0, 0x5, 0xa} {
@@ -429,18 +401,17 @@ func splitCollapseCorpus() (survivors, doomed [][]byte, pk [][]byte, upds []Upda
 	}
 	for seed := range 6 {
 		a := findAddressForHexPrefix([]byte{0x1, 0x2, 0x3, 0xf}, seed+77)
-		survivors = append(survivors, a)
 		ub.Balance(hex.EncodeToString(a), uint64(seed)+31)
 	}
 	for range 400 {
 		addRandomAccount(ub, rnd, 0)
 	}
 	pk, upds = ub.Build()
-	return survivors, doomed, pk, upds
+	return doomed, pk, upds
 }
 
 func TestSplitPoint_InteriorSingleSurvivorCollapse(t *testing.T) {
-	_, doomed, pk1, u1 := splitCollapseCorpus()
+	doomed, pk1, u1 := splitCollapseCorpus()
 
 	ms := NewMockState(t)
 	seq := NewHexPatriciaHashed(length.Addr, ms, DefaultTrieConfig())
@@ -816,4 +787,90 @@ func TestSplitPoint_KeyedSurvivorCollapse(t *testing.T) {
 			requireBranchParity(t, msSeq, msSplit)
 		})
 	}
+}
+
+func splitMultiChildReentryCorpus() (splitTouch []byte, later []byte, touch [][]byte, pk [][]byte, upds []Update) {
+	rnd := rand.New(rand.NewSource(818181))
+	ub := NewUpdateBuilder()
+	for seed := range 2 {
+		a := findAddressForHexPrefix([]byte{0x1, 0x2, 0x3, 0x0}, seed*23+601)
+		ub.Balance(hex.EncodeToString(a), uint64(seed)+11)
+		if seed == 0 {
+			splitTouch = a
+		}
+	}
+	later = findAddressForHexPrefix([]byte{0x1, 0x2, 0x3, 0x1}, 631)
+	ub.Balance(hex.EncodeToString(later), 71)
+
+	for _, p := range [][]byte{{0x1, 0x2, 0x7}, {0x1, 0x2, 0xc}, {0x1, 0x7}, {0x1, 0xc}} {
+		for seed := range 2 {
+			a := findAddressForHexPrefix(p, seed*29+661)
+			ub.Balance(hex.EncodeToString(a), uint64(seed)+37)
+			if seed == 0 && (len(p) == 2 || p[2] == 0x7) {
+				touch = append(touch, a)
+			}
+		}
+	}
+	for range 400 {
+		addRandomAccount(ub, rnd, 0)
+	}
+	pk, upds = ub.Build()
+	return splitTouch, later, touch, pk, upds
+}
+
+func TestSplitPoint_MultiChildSplitCellReUnfolded(t *testing.T) {
+	splitTouch, later, touch, pk1, u1 := splitMultiChildReentryCorpus()
+
+	msSeq := NewMockState(t)
+	seq := NewHexPatriciaHashed(length.Addr, msSeq, DefaultTrieConfig())
+	defer seq.Release()
+	processBatch(t, msSeq, seq, pk1, u1)
+
+	prefix := []byte{0x1, 0x2, 0x3}
+	for _, p := range [][]byte{prefix[:1], prefix[:2], prefix} {
+		require.Truef(t, hasBranchAt(msSeq, p), "corpus must produce an on-disk branch at %x", p)
+	}
+	laterHK := KeyToHexNibbleHash(later)
+	require.EqualValues(t, prefix[0], laterHK[len(prefix)],
+		"the later key's continuation must share a nibble with the split prefix so a stale hashed extension misroutes it")
+
+	msSplit := cloneMockState(t, msSeq)
+
+	ub := NewUpdateBuilder()
+	ub.Balance(hex.EncodeToString(splitTouch), 8001)
+	ub.Balance(hex.EncodeToString(later), 8002)
+	for i, a := range touch {
+		ub.Balance(hex.EncodeToString(a), uint64(i)+8100)
+	}
+	pk2, u2 := ub.Build()
+	seqRoot := processBatch(t, msSeq, seq, pk2, u2)
+	require.NoError(t, msSplit.applyPlainUpdates(pk2, u2))
+
+	all := splitKVs(pk2, u2)
+	var reUnfold []splitKV
+	for _, k := range all {
+		if bytes.Equal(k.hk, laterHK) {
+			reUnfold = append(reUnfold, k)
+		}
+	}
+	require.Len(t, reUnfold, 1, "the later key must be touched so the base descends through the split cell")
+
+	r := newSplitRound(msSplit)
+	r.splits[string(prefix[:1])] = true
+	r.splits[string(prefix[:2])] = true
+	r.splits[string(prefix)] = true
+	r.replay[string(prefix[:2])] = reUnfold
+	splitRoot, err := r.foldRoot(all)
+	require.NoError(t, err)
+	r.flush(t)
+
+	split, ok := r.captured[string(prefix)]
+	require.True(t, ok, "the interior split at 123 did not run")
+	require.Zero(t, split.extLen, "a multi-child split returns a bare branch cell")
+
+	require.Equalf(t, seqRoot, splitRoot, "root with a re-entry into the multi-child split cell at %x != sequential", prefix)
+	requireBranchParity(t, msSeq, msSplit)
+
+	require.Zerof(t, split.hashedExtLen,
+		"a multi-child split cell must not carry the absolute split prefix as a hashed extension; got %x", split.hashedExtension[:split.hashedExtLen])
 }

--- a/execution/commitment/split_point_test.go
+++ b/execution/commitment/split_point_test.go
@@ -1,0 +1,475 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package commitment
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"math/rand"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/length"
+	"github.com/erigontech/erigon/execution/commitment/nibbles"
+)
+
+type splitKV struct {
+	hk  []byte
+	pk  []byte
+	upd *Update
+}
+
+func splitKVs(pk [][]byte, upds []Update) []splitKV {
+	out := make([]splitKV, len(pk))
+	for i := range pk {
+		out[i] = splitKV{hk: KeyToHexNibbleHash(pk[i]), pk: pk[i], upd: &upds[i]}
+	}
+	slices.SortFunc(out, func(a, b splitKV) int { return bytes.Compare(a.hk, b.hk) })
+	return out
+}
+
+func cloneMockState(t *testing.T, src *MockState) *MockState {
+	t.Helper()
+	dst := NewMockState(t)
+	for k, v := range src.sm {
+		dst.sm[k] = bytes.Clone(v)
+	}
+	for k, v := range src.cm {
+		dst.cm[k] = bytes.Clone(v)
+	}
+	return dst
+}
+
+func hasBranchAt(ms *MockState, prefix []byte) bool {
+	_, ok := ms.cm[string(nibbles.HexToCompact(prefix))]
+	return ok
+}
+
+type splitRound struct {
+	ms       *MockState
+	splits   map[string]bool
+	seams    map[string]cell
+	captured map[string]cell
+	deferred []*DeferredBranchUpdate
+	workers  int
+}
+
+func newSplitRound(ms *MockState) *splitRound {
+	return &splitRound{ms: ms, splits: map[string]bool{}, seams: map[string]cell{}, captured: map[string]cell{}}
+}
+
+func (r *splitRound) newTrie() *HexPatriciaHashed {
+	w := NewHexPatriciaHashed(length.Addr, r.ms, DefaultTrieConfig())
+	w.SetLeaveDeferredForCaller(true)
+	return w
+}
+
+func (r *splitRound) take(w *HexPatriciaHashed) {
+	r.deferred = append(r.deferred, w.TakeDeferredUpdates()...)
+}
+
+func (r *splitRound) flush(t *testing.T) {
+	t.Helper()
+	_, err := ApplyDeferredBranchUpdates(r.deferred, 1, r.ms.PutBranch, nil)
+	require.NoError(t, err)
+	r.deferred = nil
+}
+
+func (r *splitRound) foldLeaf(base *HexPatriciaHashed, nib int, group []splitKV) (cell, error) {
+	w := r.newTrie()
+	defer func() {
+		r.take(w)
+		w.Release()
+	}()
+	r.workers++
+	w.mountTo(base, nib)
+	for i := 0; i < len(group); i++ {
+		k := group[i]
+		if err := w.followAndUpdate(k.hk, k.pk, k.upd); err != nil {
+			return cell{}, err
+		}
+		sr, ok := r.seams[string(k.hk)]
+		if !ok {
+			continue
+		}
+		setAccountStorageRoot(w, k.hk, sr)
+		for i+1 < len(group) && bytes.HasPrefix(group[i+1].hk, k.hk) {
+			i++
+		}
+	}
+	return w.foldMounted(context.Background(), nib)
+}
+
+func (r *splitRound) foldChildren(base *HexPatriciaHashed, prefix []byte, keys []splitKV) ([16]cell, uint16, error) {
+	var (
+		cells  [16]cell
+		bitmap uint16
+	)
+	d := len(prefix)
+	for i := 0; i < len(keys); {
+		nib := keys[i].hk[d]
+		j := i
+		for j < len(keys) && keys[j].hk[d] == nib {
+			j++
+		}
+		childPrefix := make([]byte, 0, d+1)
+		childPrefix = append(childPrefix, prefix...)
+		childPrefix = append(childPrefix, nib)
+
+		var (
+			c   cell
+			err error
+		)
+		if r.splits[string(childPrefix)] {
+			c, err = r.foldAt(childPrefix, keys[i:j])
+		} else {
+			c, err = r.foldLeaf(base, int(nib), keys[i:j])
+		}
+		if err != nil {
+			return cells, bitmap, err
+		}
+		cells[nib] = c
+		bitmap |= uint16(1) << nib
+		i = j
+	}
+	return cells, bitmap, nil
+}
+
+func (r *splitRound) foldAt(prefix []byte, keys []splitKV) (cell, error) {
+	base := r.newTrie()
+	defer func() {
+		r.take(base)
+		base.Release()
+	}()
+	if err := unfoldStorageBase(base, prefix); err != nil {
+		return cell{}, err
+	}
+	cells, bitmap, err := r.foldChildren(base, prefix, keys)
+	if err != nil {
+		return cell{}, err
+	}
+	present := presentFlags(bitmap)
+	stitchSplitCells(base, &cells, &present)
+	out, err := aggregateMountedStorageRoot(base, &cells, bitmap)
+	if err != nil {
+		return cell{}, err
+	}
+	r.captured[string(prefix)] = out
+	return out, nil
+}
+
+func (r *splitRound) foldRoot(keys []splitKV) ([]byte, error) {
+	ctx := context.Background()
+	base := r.newTrie()
+	defer func() {
+		r.take(base)
+		base.Release()
+	}()
+	if err := unfoldRootWall(ctx, base); err != nil {
+		return nil, err
+	}
+	seedRootBase(base)
+	cells, bitmap, err := r.foldChildren(base, nil, keys)
+	if err != nil {
+		return nil, err
+	}
+	present := presentFlags(bitmap)
+	stitchSplitCells(base, &cells, &present)
+	if base.activeRows == 0 {
+		base.activeRows = 1
+	}
+	for base.activeRows > 0 {
+		if err := base.fold(); err != nil {
+			return nil, err
+		}
+	}
+	return base.RootHash()
+}
+
+func presentFlags(bitmap uint16) [16]bool {
+	var present [16]bool
+	for nib := range 16 {
+		present[nib] = bitmap&(uint16(1)<<nib) != 0
+	}
+	return present
+}
+
+func splitWhaleCorpus(slots, background int) (addr []byte, pk [][]byte, upds []Update) {
+	rnd := rand.New(rand.NewSource(20260903))
+	addr = make([]byte, length.Addr)
+	rnd.Read(addr)
+	ub := NewUpdateBuilder()
+	ub.Balance(hex.EncodeToString(addr), 12345)
+	for range slots {
+		addRandomSlot(ub, rnd, hex.EncodeToString(addr))
+	}
+	for range background {
+		addRandomAccount(ub, rnd, 0)
+	}
+	pk, upds = ub.Build()
+	return addr, pk, upds
+}
+
+func splitWhaleTouch(addr []byte, pk [][]byte, every int) ([][]byte, []Update) {
+	a := hex.EncodeToString(addr)
+	ub := NewUpdateBuilder()
+	ub.Balance(a, 987654)
+	n := 0
+	for _, k := range pk {
+		if len(k) != length.Addr+length.Hash || !bytes.HasPrefix(k, addr) {
+			continue
+		}
+		if n%every == 0 {
+			ub.Storage(a, hex.EncodeToString(k[length.Addr:]), "beef01")
+		}
+		n++
+	}
+	return ub.Build()
+}
+
+func TestSplitPoint_StoragePlaneInteriorSplit(t *testing.T) {
+	addr, pk1, u1 := splitWhaleCorpus(400, 2_000)
+
+	msSeq := NewMockState(t)
+	seq := NewHexPatriciaHashed(length.Addr, msSeq, DefaultTrieConfig())
+	defer seq.Release()
+	processBatch(t, msSeq, seq, pk1, u1)
+
+	msSplit := cloneMockState(t, msSeq)
+	msCell := cloneMockState(t, msSeq)
+
+	pk2, u2 := splitWhaleTouch(addr, pk1, 3)
+	seqRoot := processBatch(t, msSeq, seq, pk2, u2)
+
+	require.NoError(t, msSplit.applyPlainUpdates(pk2, u2))
+	require.NoError(t, msCell.applyPlainUpdates(pk2, u2))
+
+	accHash := KeyToHexNibbleHash(addr)
+	accPrefix := accHash[:64]
+
+	all := splitKVs(pk2, u2)
+	var storage []splitKV
+	for _, k := range all {
+		if len(k.hk) == 128 && bytes.HasPrefix(k.hk, accPrefix) {
+			storage = append(storage, k)
+		}
+	}
+	require.NotEmpty(t, storage, "round 2 must touch whale storage")
+
+	byNib := map[byte][]splitKV{}
+	for _, k := range storage {
+		byNib[k.hk[64]] = append(byNib[k.hk[64]], k)
+	}
+	splitNib := -1
+	best := 0
+	for nib := range 16 {
+		g := byNib[byte(nib)]
+		prefix65 := append(bytes.Clone(accPrefix), byte(nib))
+		if len(g) > best && hasBranchAt(msSplit, prefix65) {
+			splitNib, best = nib, len(g)
+		}
+	}
+	require.GreaterOrEqual(t, splitNib, 0, "no touched storage nibble has an on-disk branch below the storage root")
+	prefix65 := append(bytes.Clone(accPrefix), byte(splitNib))
+
+	r := newSplitRound(msSplit)
+	r.splits[string(prefix65)] = true
+	sr, err := r.foldAt(accPrefix, storage)
+	require.NoError(t, err)
+	c65, ok := r.captured[string(prefix65)]
+	require.True(t, ok, "the interior split at depth 65 did not run")
+
+	r.seams[string(accHash)] = sr
+	splitRoot, err := r.foldRoot(all)
+	require.NoError(t, err)
+
+	rc := newSplitRound(msCell)
+	base := rc.newTrie()
+	defer base.Release()
+	require.NoError(t, unfoldStorageBase(base, accPrefix))
+	c64, err := rc.foldLeaf(base, splitNib, byNib[byte(splitNib)])
+	require.NoError(t, err)
+
+	require.Equalf(t, c64.hash[:c64.hashLen], c65.hash[:c65.hashLen],
+		"interior split at depth 65 (prefix %x) must yield the same cell hash as the depth-64 path for nibble %x", prefix65, splitNib)
+	require.Equalf(t, c64.extension[:c64.extLen], c65.extension[:c65.extLen],
+		"interior split at depth 65 (prefix %x) must yield the same cell extension as the depth-64 path", prefix65)
+	require.Equal(t, seqRoot, splitRoot, "round root through a depth-65 split != sequential root")
+}
+
+func TestSplitPoint_AccountPlaneInteriorSplit(t *testing.T) {
+	pk1, u1 := buildMixedCorpus(20260903, 8_000)
+
+	msSeq := NewMockState(t)
+	seq := NewHexPatriciaHashed(length.Addr, msSeq, DefaultTrieConfig())
+	defer seq.Release()
+	processBatch(t, msSeq, seq, pk1, u1)
+
+	msSplit := cloneMockState(t, msSeq)
+
+	pk2, u2 := buildMixedCorpus(771177, 1_500)
+	seqRoot := processBatch(t, msSeq, seq, pk2, u2)
+	require.NoError(t, msSplit.applyPlainUpdates(pk2, u2))
+
+	keys := splitKVs(pk2, u2)
+	var chosen []byte
+	for i := 0; i < len(keys); {
+		j := i
+		for j < len(keys) && bytes.HasPrefix(keys[j].hk, keys[i].hk[:3]) {
+			j++
+		}
+		p := bytes.Clone(keys[i].hk[:3])
+		distinct := map[byte]struct{}{}
+		for _, k := range keys[i:j] {
+			distinct[k.hk[3]] = struct{}{}
+		}
+		if len(distinct) >= 2 && hasBranchAt(msSplit, p[:1]) && hasBranchAt(msSplit, p[:2]) && hasBranchAt(msSplit, p) {
+			chosen = p
+			break
+		}
+		i = j
+	}
+	require.NotNil(t, chosen, "no 3-nibble prefix with an on-disk branch and 2+ touched children")
+
+	r := newSplitRound(msSplit)
+	r.splits[string(chosen[:1])] = true
+	r.splits[string(chosen[:2])] = true
+	r.splits[string(chosen)] = true
+	splitRoot, err := r.foldRoot(keys)
+	require.NoError(t, err)
+	r.flush(t)
+
+	require.Equalf(t, seqRoot, splitRoot, "round root split at the root and again at %x != sequential root", chosen)
+	requireBranchParity(t, msSeq, msSplit)
+}
+
+func splitCollapseCorpus() (survivors, doomed [][]byte, pk [][]byte, upds []Update) {
+	rnd := rand.New(rand.NewSource(9090))
+	ub := NewUpdateBuilder()
+	for _, tail := range []byte{0x0, 0x5, 0xa} {
+		a := findAddressForHexPrefix([]byte{0x1, 0x2, 0x3, tail}, int(tail)+11)
+		doomed = append(doomed, a)
+		ub.Balance(hex.EncodeToString(a), uint64(tail)+7)
+	}
+	for seed := range 6 {
+		a := findAddressForHexPrefix([]byte{0x1, 0x2, 0x3, 0xf}, seed+77)
+		survivors = append(survivors, a)
+		ub.Balance(hex.EncodeToString(a), uint64(seed)+31)
+	}
+	for range 400 {
+		addRandomAccount(ub, rnd, 0)
+	}
+	pk, upds = ub.Build()
+	return survivors, doomed, pk, upds
+}
+
+func TestSplitPoint_InteriorSingleSurvivorCollapse(t *testing.T) {
+	_, doomed, pk1, u1 := splitCollapseCorpus()
+
+	ms := NewMockState(t)
+	seq := NewHexPatriciaHashed(length.Addr, ms, DefaultTrieConfig())
+	defer seq.Release()
+	processBatch(t, ms, seq, pk1, u1)
+
+	prefix := []byte{0x1, 0x2, 0x3}
+	require.True(t, hasBranchAt(ms, prefix), "corpus must produce an on-disk branch at 123")
+
+	ub := NewUpdateBuilder()
+	for _, a := range doomed {
+		ub.Delete(hex.EncodeToString(a))
+	}
+	pk2, u2 := ub.Build()
+	require.NoError(t, ms.applyPlainUpdates(pk2, u2))
+
+	before := snapshotBranches(ms)
+	r := newSplitRound(ms)
+	base := r.newTrie()
+	defer base.Release()
+	require.NoError(t, unfoldStorageBase(base, prefix))
+
+	survNib := byte(0xf)
+	child := base.grid[0][survNib]
+	require.Positive(t, child.hashLen, "the survivor child must be a branch reference")
+
+	cells, bitmap, err := r.foldChildren(base, prefix, splitKVs(pk2, u2))
+	require.NoError(t, err)
+	require.Zero(t, bitmap&(uint16(1)<<survNib), "the survivor must not be touched")
+
+	present := presentFlags(bitmap)
+	stitchSplitCells(base, &cells, &present)
+	got, err := aggregateMountedStorageRoot(base, &cells, bitmap)
+	require.NoError(t, err)
+
+	want := append([]byte{survNib}, child.extension[:child.extLen]...)
+	require.Equal(t, want, got.extension[:got.extLen],
+		"a single-survivor collapse must return an extension cell of survivor nibble + child extension")
+	require.Equal(t, child.hash[:child.hashLen], got.hash[:got.hashLen], "the collapsed cell must carry the survivor's hash")
+
+	r.take(base)
+	require.Empty(t, r.deferred, "a single-survivor collapse must rewrite no branch")
+
+	var written []string
+	for k, v := range ms.cm {
+		if !bytes.Equal(before[k], v) {
+			written = append(written, k)
+		}
+	}
+	require.Lenf(t, written, 1, "a single-survivor collapse must emit exactly one branch record, got %x", written)
+	require.Equalf(t, string(nibbles.HexToCompact(prefix)), written[0],
+		"the one branch record must sit at the collapsed prefix %x", prefix)
+	_, afterMap, _, _ := BranchData(ms.cm[written[0]]).decodeCells()
+	require.Zero(t, afterMap, "the record at the collapsed prefix must be a delete (afterMap 0)")
+}
+
+func TestSplitPoint_RefusesPrefixWithoutBranch(t *testing.T) {
+	pk1, u1 := buildMixedCorpus(31337, 2_000)
+
+	ms := NewMockState(t)
+	seq := NewHexPatriciaHashed(length.Addr, ms, DefaultTrieConfig())
+	defer seq.Release()
+	processBatch(t, ms, seq, pk1, u1)
+
+	var absent []byte
+	for n0 := range 16 {
+		for n1 := range 16 {
+			p := []byte{byte(n0), byte(n1), 0xd, 0xe, 0xa, 0xd}
+			if !hasBranchAt(ms, p) {
+				absent = p
+				break
+			}
+		}
+		if absent != nil {
+			break
+		}
+	}
+	require.NotNil(t, absent, "need a prefix with no stored branch")
+
+	r := newSplitRound(ms)
+	keys := splitKVs(pk1, u1)
+	var under []splitKV
+	for _, k := range keys {
+		if bytes.HasPrefix(k.hk, absent) {
+			under = append(under, k)
+		}
+	}
+	_, err := r.foldAt(absent, under)
+	require.ErrorIs(t, err, errStorageBaseNotBranch)
+	require.Zero(t, r.workers, "positioning must refuse before any worker is created")
+}

--- a/execution/commitment/streaming_deep_fold.go
+++ b/execution/commitment/streaming_deep_fold.go
@@ -26,8 +26,6 @@ import (
 
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
-
-	"github.com/erigontech/erigon/execution/commitment/nibbles"
 )
 
 // hk is copied off the walk path; pk and upd still reference the caller's storage.
@@ -41,37 +39,6 @@ type touchedKey struct {
 func maxFoldConcurrency() int { return max(1, runtime.GOMAXPROCS(0)) }
 
 func newFoldSem() *semaphore.Weighted { return semaphore.NewWeighted(int64(maxFoldConcurrency())) }
-
-var errStorageBaseNotBranch = errors.New("streaming: storage base has no branch at account prefix")
-
-func unfoldStorageBase(base *HexPatriciaHashed, accPrefix []byte) error {
-	d := int16(len(accPrefix))
-	copy(base.currentKey[:], accPrefix)
-	base.currentKeyLen = d
-	base.depths[0] = d + 1
-	base.activeRows = 1
-	for i := range base.grid[0] {
-		base.grid[0][i].reset()
-	}
-	base.touchMap[0], base.afterMap[0], base.branchBefore[0] = 0, 0, false
-
-	branch, err := base.branchFromCacheOrDB(nibbles.HexToCompactInto(base.compactKeyBuf[:], accPrefix))
-	if err != nil {
-		return err
-	}
-	if len(branch) == 0 {
-		return errStorageBaseNotBranch
-	}
-	if len(branch) < 4 {
-		// A stored branch always carries touchMap+afterMap (4 bytes); shorter means corrupt, not missing.
-		return fmt.Errorf("unfoldStorageBase: corrupt branch record at %x: %d bytes", accPrefix, len(branch))
-	}
-	if BranchData(branch).ChildCount() == 0 {
-		return errStorageBaseNotBranch
-	}
-	base.branchBefore[0] = true
-	return base.decodeBranchIntoRow(0, d+1, branch[2:], false)
-}
 
 func foldStorageLeaf(ctx context.Context, w *HexPatriciaHashed, base *HexPatriciaHashed, nib int, group []touchedKey) (cell, error) {
 	w.mountTo(base, nib)
@@ -108,7 +75,7 @@ func dfsSubtreeDeep(w *HexPatriciaHashed, node *prefixNode, path []byte, storage
 			setAccountStorageRoot(w, path, sr)
 			return nil
 		}
-		if !errors.Is(err, errStorageBaseNotBranch) {
+		if !errors.Is(err, errSplitNotBranch) {
 			return fmt.Errorf("storageRoot: %w", err)
 		}
 	}
@@ -145,8 +112,8 @@ func foldStorageRoot(ctx context.Context, sem *semaphore.Weighted, newWorker fun
 		accTag = fmt.Sprintf("[%x] ", accID)
 		base.SetTraceWriter(tracePrefix(base.traceW, accTag))
 	}
-	if err := unfoldStorageBase(base, accPrefix); err != nil {
-		if !accountFresh || !errors.Is(err, errStorageBaseNotBranch) {
+	if err := unfoldSplitBase(base, accPrefix); err != nil {
+		if !accountFresh || !errors.Is(err, errSplitNotBranch) {
 			return cell{}, fmt.Errorf("unfold storage root: %w", err)
 		}
 	}
@@ -192,7 +159,8 @@ func foldStorageRoot(ctx context.Context, sem *semaphore.Weighted, newWorker fun
 		return cell{}, err
 	}
 
-	sr, err := aggregateMountedStorageRoot(base, &children, node.bitmap)
+	stitchSplitCells(base, &children, node.bitmap)
+	sr, err := foldSplitRow(ctx, base, foldToCell)
 	if err != nil {
 		return cell{}, fmt.Errorf("storage branch fold: %w", err)
 	}
@@ -203,59 +171,6 @@ func foldStorageRoot(ctx context.Context, sem *semaphore.Weighted, newWorker fun
 		return cell{}, nil
 	}
 	return sr, nil
-}
-
-func aggregateMountedStorageRoot(base *HexPatriciaHashed, children *[16]cell, bitmap uint16) (cell, error) {
-	for bm := bitmap; bm != 0; {
-		bit := bm & -bm
-		x := bits.TrailingZeros16(bit)
-		base.touchMap[0] |= bit
-		if children[x].IsEmpty() {
-			base.afterMap[0] &^= bit
-			base.grid[0][x].reset()
-		} else {
-			base.afterMap[0] |= bit
-			base.grid[0][x] = children[x]
-		}
-		bm ^= bit
-	}
-	if base.afterMap[0] == 0 && !base.branchBefore[0] {
-		base.activeRows = 0
-		return cell{}, nil
-	}
-	if kind, _ := afterMapUpdateKind(base.afterMap[0]); kind == updateKindPropagate {
-		return storageRootFromSingleChild(base)
-	}
-	if err := base.fold(); err != nil {
-		return cell{}, err
-	}
-	out := base.root
-	out.extLen = 0
-	return out, nil
-}
-
-func storageRootFromSingleChild(base *HexPatriciaHashed) (cell, error) {
-	survNib := bits.TrailingZeros16(base.afterMap[0])
-	child := base.grid[0][survNib]
-
-	if base.branchBefore[0] {
-		if err := base.collectDeleteUpdate(nibbles.HexToCompactInto(base.compactKeyBuf[:], base.currentKey[:base.currentKeyLen]), 0); err != nil {
-			return cell{}, err
-		}
-	}
-	base.activeRows = 0
-
-	var root cell
-	if child.hashLen > 0 {
-		root.extLen = child.extLen + 1
-		root.extension[0] = byte(survNib)
-		copy(root.extension[1:], child.extension[:child.extLen])
-		root.hashLen = child.hashLen
-		copy(root.hash[:], child.hash[:child.hashLen])
-	} else {
-		root = child
-	}
-	return root, nil
 }
 
 func newDeferredStorageWorker(ctx context.Context, accountKeyLen int16, cfg TrieConfig, factory TrieContextFactory, traceW io.Writer) (*HexPatriciaHashed, func()) {


### PR DESCRIPTION
The mount and deep-storage fold had separate split-row logic, so collapse and branch-row rules could drift between split depths. This adds shared split-point primitives, routes both paths through them, and pins account-plane and storage-plane interior splits against the sequential trie.

## Changes
- Add `execution/commitment/split_point.go`: `unfoldSplitBase`, `stitchSplitCells`, `foldSplitRow` covering branch-row unfold, child overlay, root/cell fold, branch delete, and single-survivor promotion.
- Replace the storage-only deep-fold helpers in `streaming_deep_fold.go` with the shared primitives and a shared `errSplitNotBranch`.
- Route `processMounted` through `stitchSplitCells(..., root.bitmap)` and `foldSplitRow(..., foldToRoot)`.
- Add `cell.keylessInPlane` and use it when propagating keyless branch/reference cells, so `extension` and `hashedExtension` stay aligned by account or storage plane.
- Add split-point coverage for interior account/storage splits, missing stored branches, single-survivor collapse, collapsed-cell re-entry, keyed-survivor promotion, and multi-child split re-entry.
- Run branch-record parity from `requireAllEnginesParity`; refresh `docs/design/parallel-patricia-hashed.md` for the shared split-point flow.

## Notes
Draft — one parity gap is open. After a collapse plus in-round re-entry, the rebuilt record's touch bitmap lacks the deleted nibbles, because the collapse already wrote them as a write-through delete record. Root, `afterMap` and every cell byte match serial; one test masks that one bitmap, all other parity is byte-strict. The DAG never re-enters a collapsed prefix within a round, so nothing reaches it today. An adversarial round asked to break that mask did not, so treat the assumption as unchallenged rather than confirmed.

Production scheduling is unchanged. `processMounted` still splits by touched root nibble and `foldStorageRoot` still splits big-storage accounts by first storage nibble; deeper split depths are primitives plus test-harness coverage only.
