### PR TITLE
execution/cache: pin the step and generation cost formulas together

### DIFF
--- a/execution/cache/generic_cache_concurrency_test.go
+++ b/execution/cache/generic_cache_concurrency_test.go
@@ -938,3 +938,40 @@ func TestGrowLRU_CloseStopsFurtherReservations(t *testing.T) {
 // spreadKey mixes a counter into the bits freelru selects a shard with, so a
 // test fills a growLRU the way hashed production keys do.
 func spreadKey(i uint64) uint64 { return i * 0x9E3779B97F4A7C15 }
+
+// The envelope is charged one way and audited another: growBytes prices a step
+// as a per-shard delta, generationBytes prices a whole generation. They agree
+// only by telescoping, which nothing enforces, so an edit to either drifts the
+// reservation away from what the cache holds without any test noticing. At a
+// ceiling every shard has reached, the sum of the steps is the generation.
+func TestGenericCache_StepAndGenerationCostsAgreeAtTheCeiling(t *testing.T) {
+	prevProcs := runtime.GOMAXPROCS(0)
+	prevBudget := cachebudget.Global
+	t.Cleanup(func() {
+		runtime.GOMAXPROCS(prevProcs)
+		cachebudget.Global = prevBudget
+	})
+
+	key := make([]byte, 32)
+	for _, procs := range []int{1, 8, 64} {
+		runtime.GOMAXPROCS(procs)
+		for _, budget := range []datasize.ByteSize{1 * datasize.MB, 16 * datasize.MB} {
+			cachebudget.Global = cachebudget.New(math.MaxInt64)
+			c := NewGenericCacheWithAvg[[]byte](budget, avgStoragePayloadBytes,
+				func(v []byte) int { return len(v) }, ModeEvictLRU)
+			for i := range 40 * int(c.maxCap) {
+				binary.BigEndian.PutUint64(key, uint64(i))
+				c.Put(key, key[:8], 1)
+			}
+			require.Equal(t, int(c.maxCap), c.data.Load().Cap(),
+				"procs=%d budget=%s: the fill left a shard below the ceiling, so the sums are not comparable",
+				procs, budget)
+			require.Equal(t, c.generationBytes(c.maxCap), c.reservedBytes.Load(),
+				"procs=%d budget=%s: the steps charged %d B for a generation costing %d B",
+				procs, budget, c.reservedBytes.Load(), c.generationBytes(c.maxCap))
+			require.Equal(t, c.reservedBytes.Load(), cachebudget.Global.Used(),
+				"procs=%d budget=%s", procs, budget)
+			c.Close()
+		}
+	}
+}

--- a/execution/cache/generic_cache_concurrency_test.go
+++ b/execution/cache/generic_cache_concurrency_test.go
@@ -959,18 +959,20 @@ func TestGenericCache_StepAndGenerationCostsAgreeAtTheCeiling(t *testing.T) {
 			cachebudget.Global = cachebudget.New(math.MaxInt64)
 			c := NewGenericCacheWithAvg[[]byte](budget, avgStoragePayloadBytes,
 				func(v []byte) int { return len(v) }, ModeEvictLRU)
-			for i := range 40 * int(c.maxCap) {
+			// Shards grow independently, so fill until the last one reaches the
+			// ceiling. The bound is only there to fail the assertion below rather
+			// than spin if a regression stops the climb.
+			lru := c.data.Load()
+			for i := 0; lru.Cap() < int(c.maxCap) && i < 40*int(c.maxCap); i++ {
 				binary.BigEndian.PutUint64(key, uint64(i))
 				c.Put(key, key[:8], 1)
 			}
-			require.Equal(t, int(c.maxCap), c.data.Load().Cap(),
+			require.Equal(t, int(c.maxCap), lru.Cap(),
 				"procs=%d budget=%s: the fill left a shard below the ceiling, so the sums are not comparable",
 				procs, budget)
 			require.Equal(t, c.generationBytes(c.maxCap), c.reservedBytes.Load(),
 				"procs=%d budget=%s: the steps charged %d B for a generation costing %d B",
 				procs, budget, c.reservedBytes.Load(), c.generationBytes(c.maxCap))
-			require.Equal(t, c.reservedBytes.Load(), cachebudget.Global.Used(),
-				"procs=%d budget=%s", procs, budget)
 			c.Close()
 		}
 	}

--- a/execution/cache/generic_cache_concurrency_test.go
+++ b/execution/cache/generic_cache_concurrency_test.go
@@ -939,11 +939,8 @@ func TestGrowLRU_CloseStopsFurtherReservations(t *testing.T) {
 // test fills a growLRU the way hashed production keys do.
 func spreadKey(i uint64) uint64 { return i * 0x9E3779B97F4A7C15 }
 
-// The envelope is charged one way and audited another: growBytes prices a step
-// as a per-shard delta, generationBytes prices a whole generation. They agree
-// only by telescoping, which nothing enforces, so an edit to either drifts the
-// reservation away from what the cache holds without any test noticing. At a
-// ceiling every shard has reached, the sum of the steps is the generation.
+// At the ceiling, summing every per-shard growBytes delta must equal
+// generationBytes for the complete generation.
 func TestGenericCache_StepAndGenerationCostsAgreeAtTheCeiling(t *testing.T) {
 	prevProcs := runtime.GOMAXPROCS(0)
 	prevBudget := cachebudget.Global


### PR DESCRIPTION
Stacked on #23552.

The envelope is charged one way and audited another: `growBytes` prices a grow step as a per-shard delta, `generationBytes` prices a whole generation. They agree only by telescoping, and nothing enforced it — an edit to either drifts the reservation away from what the cache holds, with no test noticing. That shape is what every review round on #23552 kept finding: one quantity, two derivations, no pin.

At a ceiling every shard has reached, the sum of the steps is the generation. Swept over 3 shard counts x 2 budgets.

Test-only, no behavior change, so no red step: verified by mutation instead. Dropping the payload term from `growBytes` turns it red. A term dropped from *both* formulas stays green here and is caught by the `EnvelopeCovers*` allocator calibration — the two layers are complementary, not redundant.
