### PR TITLE
mcp: fix log stats, tail memory and rpc.url discovery; drop dead code

### DIFF
--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -125,10 +125,12 @@ Examples:
 
 			// --- Mode 2/3: JSON-RPC proxy ---
 			url := rpcURL
-			if port > 0 {
+			switch {
+			case port > 0:
 				url = fmt.Sprintf("http://127.0.0.1:%d", port)
-			} else {
-				// Auto-discover: probe default ports.
+			case !cmd.Flags().Changed("rpc.url"):
+				// Only probe when the user named no endpoint at all; discovery
+				// must never override an explicit --rpc.url.
 				if discovered := autoDiscover(ctx, logger); discovered != "" {
 					url = discovered
 				}

--- a/docs/site/docs/fundamentals/mcp.mdx
+++ b/docs/site/docs/fundamentals/mcp.mdx
@@ -307,7 +307,6 @@ In addition to tools, the MCP server exposes structured **resources** and **prom
 | Resource | Description |
 |----------|-------------|
 | `erigon://node/info` | Node version, chain, capabilities |
-| `erigon://chain/config` | Full chain configuration |
 | `erigon://blocks/recent` | Last 10 blocks summary |
 | `erigon://network/status` | Sync state and peer count |
 | `erigon://gas/current` | Current gas price |

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -4134,7 +4134,6 @@ In addition to tools, the MCP server exposes structured **resources** and **prom
 | Resource | Description |
 |----------|-------------|
 | `erigon://node/info` | Node version, chain, capabilities |
-| `erigon://chain/config` | Full chain configuration |
 | `erigon://blocks/recent` | Last 10 blocks summary |
 | `erigon://network/status` | Sync state and peer count |
 | `erigon://gas/current` | Current gas price |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4134,7 +4134,6 @@ In addition to tools, the MCP server exposes structured **resources** and **prom
 | Resource | Description |
 |----------|-------------|
 | `erigon://node/info` | Node version, chain, capabilities |
-| `erigon://chain/config` | Full chain configuration |
 | `erigon://blocks/recent` | Last 10 blocks summary |
 | `erigon://network/status` | Sync state and peer count |
 | `erigon://gas/current` | Current gas price |

--- a/rpc/mcp/handlers_logs.go
+++ b/rpc/mcp/handlers_logs.go
@@ -254,7 +254,7 @@ func getLogStats(filename string) (map[string]any, error) {
 	for scanner.Scan() {
 		totalLines++
 		switch logLevel(scanner.Text()) {
-		case "eror", "crit":
+		case "eror", "error", "crit":
 			errorLines++
 		case "warn":
 			warnLines++
@@ -282,8 +282,9 @@ func getLogStats(filename string) (map[string]any, error) {
 }
 
 // logLevel is the level token a log line carries: "[EROR] [time] msg" in the
-// default file format, {"lvl":"eror"} under --log.dir.json. It is empty for a
-// line in neither shape, such as a panic trace. Matching the token rather than
+// default file format, {"lvl":"eror"} under --log.dir.json, {"level":"WARN"} in
+// torrent.log, which the downloader writes through slog. It is empty for a line
+// in none of those shapes, such as a panic trace. Matching the token rather than
 // the whole line keeps an "err=" key on an info line out of the error count.
 func logLevel(line string) string {
 	if rest, ok := strings.CutPrefix(line, "["); ok {
@@ -291,9 +292,11 @@ func logLevel(line string) string {
 			return strings.ToLower(rest[:i])
 		}
 	}
-	if _, rest, ok := strings.Cut(line, `"lvl":"`); ok {
-		if i := strings.IndexByte(rest, '"'); i > 0 {
-			return strings.ToLower(rest[:i])
+	for _, key := range []string{`"lvl":"`, `"level":"`} {
+		if _, rest, ok := strings.Cut(line, key); ok {
+			if i := strings.IndexByte(rest, '"'); i > 0 {
+				return strings.ToLower(rest[:i])
+			}
 		}
 	}
 	return ""

--- a/rpc/mcp/handlers_logs.go
+++ b/rpc/mcp/handlers_logs.go
@@ -128,7 +128,7 @@ func (l logTools) handleLogsGrep(ctx context.Context, req mcp.CallToolRequest) (
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	logLines, err := grepLog(logFile, pattern, maxLines, caseInsensitive)
+	logLines, err := scanLog(logFile, maxLines, pattern, caseInsensitive)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to grep log: %v", err)), nil
 	}
@@ -155,7 +155,16 @@ func (l logTools) handleLogsStats(ctx context.Context, req mcp.CallToolRequest) 
 	return mcp.NewToolResultText(toJSONText(stats)), nil
 }
 
-// readLogTail reads the last N lines from a log file with optional filtering
+// newLogScanner reads a log file line by line, with room for erigon's long
+// lines: the scanner's default 64 KB token limit would truncate them.
+func newLogScanner(f *os.File) *bufio.Scanner {
+	s := bufio.NewScanner(f)
+	s.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	return s
+}
+
+// readLogTail reads the last N matching lines, holding only those N: a node's
+// erigon.log runs to hundreds of MB.
 func readLogTail(filename string, lines int, filter string) ([]string, error) {
 	file, err := os.Open(filename)
 	if err != nil {
@@ -163,101 +172,64 @@ func readLogTail(filename string, lines int, filter string) ([]string, error) {
 	}
 	defer file.Close()
 
-	// Read all lines (for simplicity, could optimize with reverse reading for large files)
-	var allLines []string
-	scanner := bufio.NewScanner(file)
-
-	// Increase buffer size for long log lines
-	buf := make([]byte, 0, 64*1024)
-	scanner.Buffer(buf, 1024*1024)
-
+	ring := make([]string, 0, lines)
+	oldest := 0
+	scanner := newLogScanner(file)
 	for scanner.Scan() {
 		line := scanner.Text()
-		if filter == "" || strings.Contains(line, filter) {
-			allLines = append(allLines, line)
+		if filter != "" && !strings.Contains(line, filter) {
+			continue
 		}
+		if len(ring) < lines {
+			ring = append(ring, line)
+			continue
+		}
+		ring[oldest] = line
+		oldest = (oldest + 1) % lines
 	}
-
 	if err := scanner.Err(); err != nil {
 		return nil, err
 	}
-
-	// Return last N lines
-	start := max(len(allLines)-lines, 0)
-
-	return allLines[start:], nil
+	if oldest == 0 {
+		return ring, nil
+	}
+	// Full-capacity slice so the append copies instead of overwriting the head.
+	return append(ring[oldest:len(ring):len(ring)], ring[:oldest]...), nil
 }
 
-// readLogHead reads the first N lines from a log file with optional filtering
-func readLogHead(filename string, lines int, filter string) ([]string, error) {
+// scanLog returns up to max lines matching match, from the start of the file.
+// An empty match keeps every line.
+func scanLog(filename string, max int, match string, caseInsensitive bool) ([]string, error) {
 	file, err := os.Open(filename)
 	if err != nil {
 		return nil, err
 	}
 	defer file.Close()
 
-	var result []string
-	scanner := bufio.NewScanner(file)
-
-	// Increase buffer size for long log lines
-	buf := make([]byte, 0, 64*1024)
-	scanner.Buffer(buf, 1024*1024)
-
-	count := 0
-	for scanner.Scan() && count < lines {
-		line := scanner.Text()
-		if filter == "" || strings.Contains(line, filter) {
-			result = append(result, line)
-			count++
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
-
-	return result, nil
-}
-
-// grepLog searches for a pattern in log file
-func grepLog(filename, pattern string, maxLines int, caseInsensitive bool) ([]string, error) {
-	file, err := os.Open(filename)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	var result []string
-	scanner := bufio.NewScanner(file)
-
-	// Increase buffer size for long log lines
-	buf := make([]byte, 0, 64*1024)
-	scanner.Buffer(buf, 1024*1024)
-
-	searchPattern := pattern
 	if caseInsensitive {
-		searchPattern = strings.ToLower(pattern)
+		match = strings.ToLower(match)
 	}
-
-	count := 0
-	for scanner.Scan() && count < maxLines {
+	var result []string
+	scanner := newLogScanner(file)
+	for scanner.Scan() && len(result) < max {
 		line := scanner.Text()
-		searchLine := line
+		hay := line
 		if caseInsensitive {
-			searchLine = strings.ToLower(line)
+			hay = strings.ToLower(hay)
 		}
-
-		if strings.Contains(searchLine, searchPattern) {
+		if match == "" || strings.Contains(hay, match) {
 			result = append(result, line)
-			count++
 		}
 	}
-
 	if err := scanner.Err(); err != nil {
 		return nil, err
 	}
-
 	return result, nil
+}
+
+// readLogHead reads the first N lines from a log file with optional filtering.
+func readLogHead(filename string, lines int, filter string) ([]string, error) {
+	return scanLog(filename, lines, filter, false)
 }
 
 // getLogStats returns statistics about a log file
@@ -278,20 +250,15 @@ func getLogStats(filename string) (map[string]any, error) {
 	var warnLines int
 	var infoLines int
 
-	scanner := bufio.NewScanner(file)
-	buf := make([]byte, 0, 64*1024)
-	scanner.Buffer(buf, 1024*1024)
-
+	scanner := newLogScanner(file)
 	for scanner.Scan() {
 		totalLines++
-		line := strings.ToLower(scanner.Text())
-
-		switch {
-		case strings.Contains(line, "error") || strings.Contains(line, "err="):
+		switch logLevel(scanner.Text()) {
+		case "eror", "crit":
 			errorLines++
-		case strings.Contains(line, "warn"):
+		case "warn":
 			warnLines++
-		case strings.Contains(line, "info"):
+		case "info":
 			infoLines++
 		}
 	}
@@ -312,4 +279,22 @@ func getLogStats(filename string) (map[string]any, error) {
 	}
 
 	return stats, nil
+}
+
+// logLevel is the level token a log line carries: "[EROR] [time] msg" in the
+// default file format, {"lvl":"eror"} under --log.dir.json. It is empty for a
+// line in neither shape, such as a panic trace. Matching the token rather than
+// the whole line keeps an "err=" key on an info line out of the error count.
+func logLevel(line string) string {
+	if rest, ok := strings.CutPrefix(line, "["); ok {
+		if i := strings.IndexByte(rest, ']'); i > 0 {
+			return strings.ToLower(rest[:i])
+		}
+	}
+	if _, rest, ok := strings.Cut(line, `"lvl":"`); ok {
+		if i := strings.IndexByte(rest, '"'); i > 0 {
+			return strings.ToLower(rest[:i])
+		}
+	}
+	return ""
 }

--- a/rpc/mcp/mcp_test.go
+++ b/rpc/mcp/mcp_test.go
@@ -190,3 +190,21 @@ func TestLogStatsCountsLevelTokens(t *testing.T) {
 	require.Equal(t, 1, stats["warn_lines"])
 	require.Equal(t, 1, stats["info_lines"])
 }
+
+// torrent.log comes from slog, which spells the key "level" and the value in
+// upper case.
+func TestLogStatsCountsSlogLevels(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "torrent.log")
+	require.NoError(t, os.WriteFile(file, []byte(
+		`{"time":"2026-09-04T08:52:12Z","level":"WARN","msg":"piece failed"}`+"\n"+
+			`{"time":"2026-09-04T08:52:13Z","level":"ERROR","msg":"tracker gone"}`+"\n"+
+			`{"time":"2026-09-04T08:52:14Z","level":"INFO","msg":"seeding"}`+"\n"), 0600))
+
+	stats, err := getLogStats(file)
+	require.NoError(t, err)
+	require.Equal(t, 3, stats["total_lines"])
+	require.Equal(t, 1, stats["error_lines"])
+	require.Equal(t, 1, stats["warn_lines"])
+	require.Equal(t, 1, stats["info_lines"])
+}

--- a/rpc/mcp/mcp_test.go
+++ b/rpc/mcp/mcp_test.go
@@ -3,7 +3,11 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -137,4 +141,52 @@ func TestJSONMarshaling(t *testing.T) {
 	} else {
 		t.Errorf("Block structure not preserved")
 	}
+}
+
+// logs_tail keeps only the requested number of lines while scanning, so the
+// ring it fills has to unwrap back into file order.
+func TestReadLogTail(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "erigon.log")
+	var content strings.Builder
+	for i := range 10 {
+		fmt.Fprintf(&content, "line %d\n", i)
+	}
+	require.NoError(t, os.WriteFile(file, []byte(content.String()), 0600))
+
+	lines, err := readLogTail(file, 3, "")
+	require.NoError(t, err)
+	require.Equal(t, []string{"line 7", "line 8", "line 9"}, lines)
+
+	// Fewer matches than asked for: no wraparound to unwrap.
+	lines, err = readLogTail(file, 3, "line 1")
+	require.NoError(t, err)
+	require.Equal(t, []string{"line 1"}, lines)
+
+	// Exactly as many as asked for.
+	lines, err = readLogTail(file, 10, "")
+	require.NoError(t, err)
+	require.Len(t, lines, 10)
+	require.Equal(t, "line 0", lines[0])
+}
+
+// logs_stats counts levels off the token the log formats emit ("[EROR]", or
+// "lvl":"eror" under --log.dir.json). Scanning the whole line instead puts
+// every info line carrying an err= key in the error count, and finds no EROR
+// line at all, since the level is spelled without the second "r".
+func TestLogStatsCountsLevelTokens(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "erigon.log")
+	require.NoError(t, os.WriteFile(file, []byte(
+		"[EROR] [09-04|08:52:12.133] rpc failed reason=timeout\n"+
+			"[INFO] [09-04|08:52:12.134] p2p peer dropped err=nil\n"+
+			"[WARN] [09-04|08:52:12.135] no error here\n"+
+			`{"lvl":"eror","msg":"json mode"}`+"\n"), 0600))
+
+	stats, err := getLogStats(file)
+	require.NoError(t, err)
+	require.Equal(t, 4, stats["total_lines"])
+	require.Equal(t, 2, stats["error_lines"])
+	require.Equal(t, 1, stats["warn_lines"])
+	require.Equal(t, 1, stats["info_lines"])
 }

--- a/rpc/mcp/metrics/gather.go
+++ b/rpc/mcp/metrics/gather.go
@@ -43,8 +43,14 @@ func GatherMetricsFiltered(pattern string) (map[string]any, error) {
 		metricName := *mf.Name
 
 		// Apply filter if pattern is provided
-		if pattern != "" && !matchPattern(pattern, metricName) {
-			continue
+		if pattern != "" {
+			ok, err := matchPattern(pattern, metricName)
+			if err != nil {
+				return nil, fmt.Errorf("invalid pattern %q: %w", pattern, err)
+			}
+			if !ok {
+				continue
+			}
 		}
 
 		metricType := mf.Type.String()
@@ -150,7 +156,6 @@ func GatherMetricsFiltered(pattern string) (map[string]any, error) {
 
 // matchPattern reports whether a metric name matches a glob pattern. Prometheus
 // names carry no "/", so path.Match's separator handling never applies.
-func matchPattern(pattern, name string) bool {
-	ok, err := path.Match(pattern, name)
-	return err == nil && ok
+func matchPattern(pattern, name string) (bool, error) {
+	return path.Match(pattern, name)
 }

--- a/rpc/mcp/metrics/gather.go
+++ b/rpc/mcp/metrics/gather.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"fmt"
+	"path"
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -139,7 +140,7 @@ func GatherMetricsFiltered(pattern string) (map[string]any, error) {
 
 		result[metricName] = map[string]any{
 			"type":    metricType,
-			"help":    getStringPtr(mf.Help),
+			"help":    mf.GetHelp(),
 			"metrics": metrics,
 		}
 	}
@@ -147,53 +148,9 @@ func GatherMetricsFiltered(pattern string) (map[string]any, error) {
 	return result, nil
 }
 
-// matchPattern performs simple wildcard matching (* and ? wildcards).
+// matchPattern reports whether a metric name matches a glob pattern. Prometheus
+// names carry no "/", so path.Match's separator handling never applies.
 func matchPattern(pattern, name string) bool {
-	// Handle exact match first
-	if pattern == name {
-		return true
-	}
-
-	// Handle wildcards
-	i, j := 0, 0
-	starIdx, matchIdx := -1, 0
-
-	for i < len(name) {
-		switch {
-		case j < len(pattern) && (pattern[j] == name[i] || pattern[j] == '?'):
-			i++
-			j++
-		case j < len(pattern) && pattern[j] == '*':
-			starIdx = j
-			matchIdx = i
-			j++
-		case starIdx != -1:
-			j = starIdx + 1
-			matchIdx++
-			i = matchIdx
-		default:
-			return false
-		}
-	}
-
-	// Check remaining pattern characters
-	for j < len(pattern) && pattern[j] == '*' {
-		j++
-	}
-
-	return j == len(pattern)
-}
-
-// GatherMetrics gathers all metrics from the Prometheus default registry
-// and returns them as a structured map for MCP consumption.
-func GatherMetrics() (map[string]any, error) {
-	return GatherMetricsFiltered("")
-}
-
-// getStringPtr safely dereferences a string pointer
-func getStringPtr(s *string) string {
-	if s == nil {
-		return ""
-	}
-	return *s
+	ok, err := path.Match(pattern, name)
+	return err == nil && ok
 }

--- a/rpc/mcp/metrics/gather_test.go
+++ b/rpc/mcp/metrics/gather_test.go
@@ -44,7 +44,10 @@ func TestMatchPattern(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.pattern+"_"+tt.name, func(t *testing.T) {
-			got := matchPattern(tt.pattern, tt.name)
+			got, err := matchPattern(tt.pattern, tt.name)
+			if err != nil {
+				t.Fatalf("matchPattern(%q, %q): %v", tt.pattern, tt.name, err)
+			}
 			if got != tt.want {
 				t.Errorf("matchPattern(%q, %q) = %v, want %v", tt.pattern, tt.name, got, tt.want)
 			}

--- a/rpc/mcp/metrics/gather_test.go
+++ b/rpc/mcp/metrics/gather_test.go
@@ -99,13 +99,13 @@ func TestGatherMetrics(t *testing.T) {
 	testCounter.Inc()
 	testGauge.Set(42.5)
 
-	metrics, err := GatherMetrics()
+	metrics, err := GatherMetricsFiltered("")
 	if err != nil {
-		t.Fatalf("GatherMetrics() error = %v", err)
+		t.Fatalf("GatherMetricsFiltered: %v", err)
 	}
 
 	if len(metrics) == 0 {
-		t.Error("GatherMetrics() returned empty map")
+		t.Error("GatherMetricsFiltered returned empty map")
 	}
 
 	// Check counter

--- a/rpc/mcp/resources.go
+++ b/rpc/mcp/resources.go
@@ -24,15 +24,6 @@ func (e *ErigonMCPServer) registerResources() {
 	)
 
 	srv.AddResource(
-		mcp.NewResource("erigon://chain/config",
-			"chain config",
-			mcp.WithResourceDescription("Get chain configuration"),
-			mcp.WithMIMEType("application/json"),
-		),
-		e.handleResourceChainConfig,
-	)
-
-	srv.AddResource(
 		mcp.NewResource("erigon://blocks/recent",
 			"recent blocks",
 			mcp.WithResourceDescription("Get recent blocks (default: last 10)"),
@@ -99,24 +90,6 @@ func (e *ErigonMCPServer) handleResourceNodeInfo(ctx context.Context, req mcp.Re
 			URI:      "erigon://node/info",
 			MIMEType: "application/json",
 			Text:     toJSONIndent(result),
-		},
-	}, nil
-}
-
-func (e *ErigonMCPServer) handleResourceChainConfig(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
-	var blockNum string
-	if err := e.client.CallContext(ctx, &blockNum, "eth_blockNumber"); err != nil {
-		return nil, fmt.Errorf("eth_blockNumber: %w", err)
-	}
-
-	return []mcp.ResourceContents{
-		mcp.TextResourceContents{
-			URI:      "erigon://chain/config",
-			MIMEType: "application/json",
-			Text: toJSONText(map[string]any{
-				"current_block": blockNum,
-				"note":          "Chain config details would come from Erigon's chain spec",
-			}),
 		},
 	}, nil
 }


### PR DESCRIPTION


**Bugs**
- `logs_stats` matched `"error"`/`"err="` anywhere in a line. Erigon writes the level as `[EROR]`, so no real error line was counted and every info line carrying an `err=` key was. Now reads the level token (`[EROR]`, or `"lvl":"eror"` under `--log.dir.json`).
- `logs_tail` read the whole file into memory to return the last N lines; a node's `erigon.log` is hundreds of MB. Ring buffer of N.
- Auto-discovery ran whenever `--port` was absent, so `mcp --rpc.url http://remote:8545` silently retargeted to localhost if anything answered there.

**Deletions**
- `matchPattern`: 30-line hand-rolled `*`/`?` glob → `path.Match`. Metric names contain no `/`; the existing 20-case table passes unchanged.
- `GatherMetrics()` (only its own test called it) and `getStringPtr` (→ generated `mf.GetHelp()`).
- `erigon://chain/config` advertised "Get chain configuration" and returned `{"note": "Chain config details would come from Erigon's chain spec"}`. The real config is already in `erigon://node/info`.
- `readLogHead`/`grepLog` were one scan with different case folding, plus four copies of the scanner-buffer setup → one `scanLog`, one `newLogScanner`.

The log-stats test is red on the old counting. The `--rpc.url` guard has no test — it is cobra flag plumbing, and a test would need a full command harness.
