### PR TITLE
db/seg: drop dead code, fix the ParseFileCompression stub

### DIFF
--- a/db/seg/compress.go
+++ b/db/seg/compress.go
@@ -812,80 +812,6 @@ type DynamicCell struct {
 	patternIdx  int // offset of the last element in the pattern slice
 }
 
-type Ring struct {
-	cells             []DynamicCell
-	head, tail, count int
-}
-
-func NewRing() *Ring {
-	return &Ring{
-		cells: make([]DynamicCell, 16),
-		head:  0,
-		tail:  0,
-		count: 0,
-	}
-}
-
-func (r *Ring) Reset() {
-	r.count = 0
-	r.head = 0
-	r.tail = 0
-}
-
-func (r *Ring) ensureSize() {
-	if r.count < len(r.cells) {
-		return
-	}
-	newcells := make([]DynamicCell, r.count*2)
-	if r.tail > r.head {
-		copy(newcells, r.cells[r.head:r.tail])
-	} else {
-		n := copy(newcells, r.cells[r.head:])
-		copy(newcells[n:], r.cells[:r.tail])
-	}
-	r.head = 0
-	r.tail = r.count
-	r.cells = newcells
-}
-
-func (r *Ring) PushFront() *DynamicCell {
-	r.ensureSize()
-	if r.head == 0 {
-		r.head = len(r.cells)
-	}
-	r.head--
-	r.count++
-	return &r.cells[r.head]
-}
-
-func (r *Ring) PushBack() *DynamicCell {
-	r.ensureSize()
-	if r.tail == len(r.cells) {
-		r.tail = 0
-	}
-	result := &r.cells[r.tail]
-	r.tail++
-	r.count++
-	return result
-}
-
-func (r Ring) Len() int {
-	return r.count
-}
-
-func (r *Ring) Get(i int) *DynamicCell {
-	if i < 0 || i >= r.count {
-		return nil
-	}
-	return &r.cells[(r.head+i)&(len(r.cells)-1)]
-}
-
-// Truncate removes all items starting from i
-func (r *Ring) Truncate(i int) {
-	r.count = i
-	r.tail = (r.head + i) & (len(r.cells) - 1)
-}
-
 type DictAggregator struct {
 	collector     *etl.Collector
 	dist          map[int]int
@@ -951,14 +877,6 @@ type RawWordsFile struct {
 
 func NewRawWordsFile(filePath string) (*RawWordsFile, error) {
 	f, err := os.Create(filePath)
-	if err != nil {
-		return nil, err
-	}
-	return &RawWordsFile{filePath: filePath, f: f, w: bufiopool.Writer(f), buf: make([]byte, 128)}, nil
-}
-
-func OpenRawWordsFile(filePath string) (*RawWordsFile, error) {
-	f, err := os.Open(filePath)
 	if err != nil {
 		return nil, err
 	}

--- a/db/seg/compress_test.go
+++ b/db/seg/compress_test.go
@@ -455,3 +455,21 @@ func TestCompressorCloseReleasesWorkers(t *testing.T) {
 		t.Fatal("Close() returned while pattern workers are still running")
 	}
 }
+
+func TestParseFileCompression(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want FileCompression
+	}{
+		{"none", CompressNone},
+		{"k", CompressKeys},
+		{"v", CompressVals},
+		{"kv", CompressKeys | CompressVals},
+	} {
+		got, err := ParseFileCompression(tc.in)
+		require.NoError(t, err)
+		require.Equalf(t, tc.want, got, "%q", tc.in)
+	}
+	_, err := ParseFileCompression("zstd")
+	require.Error(t, err)
+}

--- a/db/seg/parallel_compress.go
+++ b/db/seg/parallel_compress.go
@@ -1184,34 +1184,3 @@ func PersistDictionary(fileName string, db *DictionaryBuilder) error {
 	}
 	return df.Close()
 }
-
-func ReadSimpleFile(fileName string, walker func(v []byte) error) error {
-	// Read keys from the file and generate superstring (with extra byte 0x1 prepended to each character, and with 0x0 0x0 pair inserted between keys and values)
-	// We only consider values with length > 2, because smaller values are not compressible without going into bits
-	f, err := os.Open(fileName)
-	if err != nil {
-		return err
-	}
-	defer f.Close() //nolint:errcheck
-	r := bufiopool.Reader(f)
-	defer bufiopool.PutReader(r)
-	buf := make([]byte, 4096)
-	for l, e := binary.ReadUvarint(r); ; l, e = binary.ReadUvarint(r) {
-		if e != nil {
-			if errors.Is(e, io.EOF) {
-				break
-			}
-			return e
-		}
-		if len(buf) < int(l) {
-			buf = make([]byte, l)
-		}
-		if _, e = io.ReadFull(r, buf[:l]); e != nil {
-			return e
-		}
-		if err := walker(buf[:l]); err != nil {
-			return err
-		}
-	}
-	return nil
-}

--- a/db/seg/seg_auto_rw.go
+++ b/db/seg/seg_auto_rw.go
@@ -30,9 +30,6 @@ import (
 //Reader and Writer - decorators on Getter and Compressor - which
 //can auto-use Next/NextUncompressed and Write/AddUncompressedWord - based on `FileCompression` passed to constructor
 
-// Maybe in future will add support of io.Reader/Writer interfaces to this decorators
-// Maybe in future will merge decorators into it's parents
-
 type Reader struct {
 	*Getter
 	nextValue bool            // if nextValue true then getter.Next() expected to return value

--- a/db/seg/seg_interface.go
+++ b/db/seg/seg_interface.go
@@ -16,6 +16,8 @@
 
 package seg
 
+import "fmt"
+
 type FileCompression uint8
 
 const (
@@ -33,8 +35,6 @@ type FeatureFlag uint8
 
 const (
 	PageLevelCompressionEnabled FeatureFlag = 1 << iota // 0b001
-	KeyCompressionEnabled                               // 0b010
-	ValCompressionEnabled                               // 0b100
 )
 
 type FeatureFlagBitmask uint8
@@ -48,30 +48,22 @@ func (m *FeatureFlagBitmask) Set(flag FeatureFlag) {
 }
 
 func ParseFileCompression(s string) (FileCompression, error) {
-	// Implementation would be here
-	return CompressNone, nil
+	switch s {
+	case "none", "":
+		return CompressNone, nil
+	case "k":
+		return CompressKeys, nil
+	case "v":
+		return CompressVals, nil
+	case "kv":
+		return CompressKeys | CompressVals, nil
+	default:
+		return CompressNone, fmt.Errorf("invalid file compression type: %s", s)
+	}
 }
 
 func (c FileCompression) Has(flag FileCompression) bool {
 	return c&flag != 0
-}
-
-func (c FileCompression) String() string {
-	return "none" // Simplified implementation
-}
-
-type ReaderI interface {
-	Next(buf []byte) ([]byte, uint64)
-	Size() int
-	Count() int
-	Reset(offset uint64)
-	HasNext() bool
-	Skip() (uint64, int)
-	FileName() string
-	BinarySearch(seek []byte, count int, getOffset func(i uint64) (offset uint64)) (foundOffset uint64, ok bool)
-	GetMetadata() []byte
-	MadvNormal() MadvDisabler
-	DisableReadAhead()
 }
 
 type MadvDisabler interface {

--- a/db/seg/seg_paged_rw.go
+++ b/db/seg/seg_paged_rw.go
@@ -76,12 +76,6 @@ type Page struct {
 	compressionBuf []byte
 }
 
-func FromBytes(buf []byte, compressionEnabled bool) *Page {
-	r := &Page{}
-	r.Reset(buf, compressionEnabled)
-	return r
-}
-
 func (r *Page) Reset(v []byte, compressionEnabled bool) (n int) {
 	var err error
 	r.compressionBuf, v, err = compress.DecodeZstdIfNeed(r.compressionBuf[:0], v, compressionEnabled)
@@ -146,7 +140,7 @@ type pageResult struct {
 }
 
 type PagedReader struct {
-	file         ReaderI
+	file         *Reader
 	isCompressed bool
 	pageSize     int
 	page         *Page
@@ -154,7 +148,7 @@ type PagedReader struct {
 	currentPageOffset, nextPageOffset uint64
 }
 
-func NewPagedReader(r ReaderI, pageSize int, snappy bool) *PagedReader {
+func NewPagedReader(r *Reader, pageSize int, snappy bool) *PagedReader {
 	if pageSize == 0 {
 		pageSize = 1
 	}

--- a/db/seg/seg_paged_rw_test.go
+++ b/db/seg/seg_paged_rw_test.go
@@ -64,7 +64,7 @@ func TestPagedReader(t *testing.T) {
 	require := require.New(t)
 	d := prepareLoremDictOnPagedWriter(t, 2, false)
 	defer d.Close()
-	g1 := NewPagedReader(d.MakeGetter(), 2, false)
+	g1 := NewPagedReader(NewReader(d.MakeGetter(), CompressKeys|CompressVals), 2, false)
 	var buf []byte
 	_, _, buf, o1 := g1.Next2(buf[:0])
 	require.Zero(o1)
@@ -73,7 +73,7 @@ func TestPagedReader(t *testing.T) {
 	_, _, buf, o1 = g1.Next2(buf[:0])
 	require.NotZero(o1)
 
-	g := NewPagedReader(d.MakeGetter(), 2, false)
+	g := NewPagedReader(NewReader(d.MakeGetter(), CompressKeys|CompressVals), 2, false)
 	i := 0
 	for g.HasNext() {
 		w := loremStrings[i]
@@ -157,7 +157,7 @@ func TestPagedReaderWithCompression(t *testing.T) {
 	d := prepareLoremDictOnPagedWriter(t, 2, true) // Enable page-level compression
 	defer d.Close()
 
-	g := NewPagedReader(d.MakeGetter(), 2, true) // Read with compression enabled
+	g := NewPagedReader(NewReader(d.MakeGetter(), CompressKeys|CompressVals), 2, true) // Read with compression enabled
 	var buf []byte
 	i := 0
 	for g.HasNext() {
@@ -404,7 +404,7 @@ func TestPagedReaderSortedKeyOrder(t *testing.T) {
 	require.NoError(err)
 	defer d.Close()
 
-	g := NewPagedReader(d.MakeGetter(), 3, false)
+	g := NewPagedReader(NewReader(d.MakeGetter(), CompressKeys|CompressVals), 3, false)
 	var buf []byte
 	var prevKey []byte
 	i := 0
@@ -626,7 +626,7 @@ func TestPagedReaderResetSeeksToPage(t *testing.T) {
 		pageStart uint64
 	}
 	var entries []entry
-	g := NewPagedReader(d.MakeGetter(), pageSize, true)
+	g := NewPagedReader(NewReader(d.MakeGetter(), CompressKeys|CompressVals), pageSize, true)
 	for i := 0; g.HasNext(); i++ {
 		k, v, _, offset := g.Next2(nil)
 		entries = append(entries, entry{string(k), string(v), offset})
@@ -638,7 +638,7 @@ func TestPagedReaderResetSeeksToPage(t *testing.T) {
 		if i == 0 || entries[i-1].pageStart == want.pageStart {
 			continue // not the first entry of its page
 		}
-		g := NewPagedReader(d.MakeGetter(), pageSize, true)
+		g := NewPagedReader(NewReader(d.MakeGetter(), CompressKeys|CompressVals), pageSize, true)
 		g.Reset(want.pageStart)
 		require.True(g.HasNext(), "seek to offset %d left the reader empty", want.pageStart)
 		k, v, _, offset := g.Next2(nil)
@@ -664,14 +664,14 @@ func TestPagedReaderResetToCurrentPageKeepsPosition(t *testing.T) {
 	d := prepareLoremDictOnPagedWriter(t, pageSize, true)
 	defer d.Close()
 
-	ref := NewPagedReader(d.MakeGetter(), pageSize, true)
+	ref := NewPagedReader(NewReader(d.MakeGetter(), CompressKeys|CompressVals), pageSize, true)
 	k0, v0, _, pageStart := ref.Next2(nil)
 	first := string(k0) + "|" + string(v0)
 	k1, v1, _, _ := ref.Next2(nil)
 	second := string(k1) + "|" + string(v1)
 	require.NotEqual(first, second)
 
-	g := NewPagedReader(d.MakeGetter(), pageSize, true)
+	g := NewPagedReader(NewReader(d.MakeGetter(), CompressKeys|CompressVals), pageSize, true)
 	_, _, _, offset := g.Next2(nil)
 	require.Equal(pageStart, offset)
 


### PR DESCRIPTION
Dead code found by a sweep of `db/seg`. Nothing referenced any of it, in the package or outside:

- `Ring` (74 lines) — `parallel_compress.go` uses `DynamicCell` as a plain slice; the ring was left behind by that refactor.
- `ReadSimpleFile`, `OpenRawWordsFile` (which wrapped a read-only `os.Open` in a `bufio.Writer`), `FromBytes`, `KeyCompressionEnabled`, `ValCompressionEnabled`.
- `ReaderI` — every production caller of `NewPagedReader` passes a `*seg.Reader`; the interface only existed because in-package tests passed a bare `*Getter`. Those now wrap it.
- `FileCompression.String()` returned `"none"` for every value and had no callers.

One behavior fix in the same file: `ParseFileCompression` returned `CompressNone` for every input, so `integration commitment visualize --compression=kv` was silently ignored. Test added first, red against the stub.
