### PR TITLE
cmd/capcli: migrate from kong to urfave/cli/v3

### DIFF
--- a/cmd/capcli/cli.go
+++ b/cmd/capcli/cli.go
@@ -75,38 +75,20 @@ import (
 	"github.com/erigontech/erigon/node/gointerfaces/sentinelproto"
 )
 
-var CLI struct {
-	Chain                     Chain                     `cmd:"" help:"download the entire chain from reqresp network"`
-	DumpSnapshots             DumpSnapshots             `cmd:"" help:"generate caplin snapshots"`
-	CheckSnapshots            CheckSnapshots            `cmd:"" help:"check snapshot folder against content of chain data"`
-	LoopSnapshots             LoopSnapshots             `cmd:"" help:"loop over snapshots"`
-	RetrieveHistoricalState   RetrieveHistoricalState   `cmd:"" help:"retrieve historical state from db"`
-	ChainEndpoint             ChainEndpoint             `cmd:"" help:"chain endpoint"`
-	ArchiveSanitizer          ArchiveSanitizer          `cmd:"" help:"archive sanitizer"`
-	BenchmarkNode             BenchmarkNode             `cmd:"" help:"benchmark node"`
-	BlobArchiveStoreCheck     BlobArchiveStoreCheck     `cmd:"" help:"blob archive store check"`
-	DumpBlobsSnapshots        DumpBlobsSnapshots        `cmd:"" help:"dump blobs snapshots"`
-	CheckBlobsSnapshots       CheckBlobsSnapshots       `cmd:"" help:"check blobs snapshots"`
-	CheckBlobsSnapshotsCount  CheckBlobsSnapshotsCount  `cmd:"" help:"check blobs snapshots count"`
-	DumpBlobsSnapshotsToStore DumpBlobsSnapshotsToStore `cmd:"" help:"dump blobs snapshots to store"`
-	DumpStateSnapshots        DumpStateSnapshots        `cmd:"" help:"dump state snapshots"`
-	MakeDepositArgs           MakeDepositArgs           `cmd:"" help:"make deposit args"`
-}
-
 type chainCfg struct {
-	Chain string `help:"chain" default:"mainnet"`
+	Chain string
 }
 
 type outputFolder struct {
-	Datadir string `help:"datadir" default:"~/.local/share/erigon" type:"existingdir"`
+	Datadir string
 }
 
 type withSentinel struct {
-	Sentinel string `help:"sentinel url" default:"localhost:7777"`
+	Sentinel string
 }
 
 type withPPROF struct {
-	Pprof bool `help:"enable pprof" default:"false"`
+	Pprof bool
 }
 
 func (w *withPPROF) withProfile() {
@@ -130,7 +112,7 @@ type Chain struct {
 	outputFolder
 }
 
-func (c *Chain) Run(ctx *Context) error {
+func (c *Chain) Run(ctx context.Context) error {
 	s, err := c.withSentinel.connectSentinel()
 	if err != nil {
 		return err
@@ -188,8 +170,8 @@ func (c *Chain) Run(ctx *Context) error {
 }
 
 type ChainEndpoint struct {
-	Endpoint string `help:"endpoint" default:""`
-	Blobs    bool   `help:"also download blobs" default:"false"`
+	Endpoint string
+	Blobs    bool
 	chainCfg
 	outputFolder
 }
@@ -282,7 +264,7 @@ func retrieveBlobsFromRemoteEndpoint(ctx context.Context, beaconConfig *clparams
 	return blobsResponse.Data, nil
 }
 
-func (c *ChainEndpoint) Run(ctx *Context) error {
+func (c *ChainEndpoint) Run(ctx context.Context) error {
 	_, beaconConfig, _, err := clparams.GetConfigsByNetworkName(c.Chain)
 	if err != nil {
 		return err
@@ -465,10 +447,10 @@ type DumpSnapshots struct {
 	chainCfg
 	outputFolder
 
-	To uint64 `name:"to" help:"slot to dump"`
+	To uint64
 }
 
-func (c *DumpSnapshots) Run(ctx *Context) error {
+func (c *DumpSnapshots) Run(ctx context.Context) error {
 	_, beaconConfig, _, err := clparams.GetConfigsByNetworkName(c.Chain)
 	if err != nil {
 		return err
@@ -510,7 +492,7 @@ type CheckSnapshots struct {
 	withPPROF
 }
 
-func (c *CheckSnapshots) Run(ctx *Context) error {
+func (c *CheckSnapshots) Run(ctx context.Context) error {
 	_, beaconConfig, _, err := clparams.GetConfigsByNetworkName(c.Chain)
 	if err != nil {
 		return err
@@ -593,10 +575,10 @@ type LoopSnapshots struct {
 	outputFolder
 	withPPROF
 
-	Slot uint64 `name:"slot" help:"slot to check"`
+	Slot uint64
 }
 
-func (c *LoopSnapshots) Run(ctx *Context) error {
+func (c *LoopSnapshots) Run(ctx context.Context) error {
 	c.withProfile()
 
 	_, beaconConfig, _, err := clparams.GetConfigsByNetworkName(c.Chain)
@@ -650,12 +632,12 @@ type RetrieveHistoricalState struct {
 	chainCfg
 	outputFolder
 	withPPROF
-	CompareFile string `help:"compare file" default:""`
-	CompareSlot uint64 `help:"compare slot" default:"0"`
-	Out         string `help:"output file" default:""`
+	CompareFile string
+	CompareSlot uint64
+	Out         string
 }
 
-func (r *RetrieveHistoricalState) Run(ctx *Context) error {
+func (r *RetrieveHistoricalState) Run(ctx context.Context) error {
 	vt := state_accessors.NewStaticValidatorTable()
 	_, beaconConfig, t, err := clparams.GetConfigsByNetworkName(r.Chain)
 	if err != nil {
@@ -833,10 +815,10 @@ func (r *RetrieveHistoricalState) Run(ctx *Context) error {
 type ArchiveSanitizer struct {
 	chainCfg
 	outputFolder
-	BeaconApiURL string `help:"beacon api url" default:"http://localhost:5555"`
-	IntervalSlot uint64 `help:"interval slot" default:"19"` // odd number so that we can test many potential cases.
-	StartSlot    uint64 `help:"start slot" default:"0"`
-	FaultOut     string `help:"fault out" default:""`
+	BeaconApiURL string
+	IntervalSlot uint64 // odd number so that we can test many potential cases.
+	StartSlot    uint64
+	FaultOut     string
 }
 
 func getHead(ctx context.Context, beaconApiURL string) (uint64, error) {
@@ -930,7 +912,7 @@ func getBeaconState(ctx context.Context, beaconConfig *clparams.BeaconChainConfi
 	return beaconState, nil
 }
 
-func (a *ArchiveSanitizer) Run(ctx *Context) error {
+func (a *ArchiveSanitizer) Run(ctx context.Context) error {
 	_, beaconConfig, _, err := clparams.GetConfigsByNetworkName(a.Chain)
 	if err != nil {
 		return err
@@ -978,16 +960,16 @@ func (a *ArchiveSanitizer) Run(ctx *Context) error {
 
 type BenchmarkNode struct {
 	chainCfg
-	BaseURL  string `help:"base url" default:"http://localhost:5555"`
-	Endpoint string `help:"endpoint" default:"/eth/v1/beacon/states/{slot}/validators"`
-	OutCSV   string `help:"output csv" default:""`
-	Accept   string `help:"accept" default:"application/json"`
-	Head     bool   `help:"head" default:"false"`
-	Method   string `help:"method" default:"GET"`
-	Body     string `help:"body" default:"{}"`
+	BaseURL  string
+	Endpoint string
+	OutCSV   string
+	Accept   string
+	Head     bool
+	Method   string
+	Body     string
 }
 
-func (b *BenchmarkNode) Run(ctx *Context) error {
+func (b *BenchmarkNode) Run(ctx context.Context) error {
 	_, beaconConfig, _, err := clparams.GetConfigsByNetworkName(b.Chain)
 	if err != nil {
 		return err
@@ -1062,10 +1044,10 @@ func timeRequest(ctx context.Context, uri, accept, method, body string) (time.Du
 type BlobArchiveStoreCheck struct {
 	chainCfg
 	outputFolder
-	FromSlot uint64 `help:"from slot" default:"0"`
+	FromSlot uint64
 }
 
-func (b *BlobArchiveStoreCheck) Run(ctx *Context) error {
+func (b *BlobArchiveStoreCheck) Run(ctx context.Context) error {
 
 	_, beaconConfig, _, err := clparams.GetConfigsByNetworkName(b.Chain)
 	if err != nil {
@@ -1138,10 +1120,10 @@ type DumpBlobsSnapshots struct {
 	chainCfg
 	outputFolder
 
-	To uint64 `name:"to" help:"slot to dump"`
+	To uint64
 }
 
-func (c *DumpBlobsSnapshots) Run(ctx *Context) error {
+func (c *DumpBlobsSnapshots) Run(ctx context.Context) error {
 	_, beaconConfig, _, err := clparams.GetConfigsByNetworkName(c.Chain)
 	if err != nil {
 		return err
@@ -1184,7 +1166,7 @@ type CheckBlobsSnapshots struct {
 	withPPROF
 }
 
-func (c *CheckBlobsSnapshots) Run(ctx *Context) error {
+func (c *CheckBlobsSnapshots) Run(ctx context.Context) error {
 	_, beaconConfig, _, err := clparams.GetConfigsByNetworkName(c.Chain)
 	if err != nil {
 		return err
@@ -1243,11 +1225,11 @@ type CheckBlobsSnapshotsCount struct {
 	chainCfg
 	outputFolder
 	withPPROF
-	From           uint64 `name:"from" help:"from slot" default:"0"`
-	CheckNeedRegen bool   `name:"check-need-regen" help:"check if blobs need regen"`
+	From           uint64
+	CheckNeedRegen bool
 }
 
-func (c *CheckBlobsSnapshotsCount) Run(ctx *Context) error {
+func (c *CheckBlobsSnapshotsCount) Run(ctx context.Context) error {
 	_, beaconConfig, _, err := clparams.GetConfigsByNetworkName(c.Chain)
 	if err != nil {
 		return err
@@ -1320,7 +1302,7 @@ type DumpBlobsSnapshotsToStore struct {
 	withPPROF
 }
 
-func (c *DumpBlobsSnapshotsToStore) Run(ctx *Context) error {
+func (c *DumpBlobsSnapshotsToStore) Run(ctx context.Context) error {
 	_, beaconConfig, _, err := clparams.GetConfigsByNetworkName(c.Chain)
 	if err != nil {
 		return err
@@ -1375,11 +1357,11 @@ func (c *DumpBlobsSnapshotsToStore) Run(ctx *Context) error {
 type DumpStateSnapshots struct {
 	chainCfg
 	outputFolder
-	To       uint64 `name:"to" help:"slot to dump"`
-	StepSize uint64 `name:"step-size" help:"step size" default:"10000"`
+	To       uint64
+	StepSize uint64
 }
 
-func (c *DumpStateSnapshots) Run(ctx *Context) error {
+func (c *DumpStateSnapshots) Run(ctx context.Context) error {
 	_, beaconConfig, _, err := clparams.GetConfigsByNetworkName(c.Chain)
 	if err != nil {
 		return err
@@ -1435,14 +1417,14 @@ func (c *DumpStateSnapshots) Run(ctx *Context) error {
 }
 
 type MakeDepositArgs struct {
-	PrivateKey         string `name:"private-key" help:"private key to use for signing deposit" default:""`
-	WithdrawalAddress  string `name:"withdrawal-address" help:"withdrawal address to use for deposit" default:""`
-	AmountEth          uint64 `name:"amount-eth" help:"amount of ETH to deposit" default:"32"`                                     // in ETH
-	DomainDeposit      string `name:"domain-deposit" help:"domain for deposit signature" default:"0x03000000"`                     // 0x03000000 for mainnet
-	GenesisForkVersion string `name:"genesis-fork-version" help:"genesis fork version for deposit signature" default:"0x00000000"` // 0x00000000 for mainnet
+	PrivateKey         string
+	WithdrawalAddress  string
+	AmountEth          uint64 // in ETH
+	DomainDeposit      string // 0x03000000 for mainnet
+	GenesisForkVersion string // 0x00000000 for mainnet
 }
 
-func (m *MakeDepositArgs) Run(ctx *Context) error {
+func (m *MakeDepositArgs) Run(ctx context.Context) error {
 
 	var privateKeyBls *bls.PrivateKey
 	if m.PrivateKey == "" {

--- a/cmd/capcli/flags.go
+++ b/cmd/capcli/flags.go
@@ -1,0 +1,349 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/urfave/cli/v3"
+
+	cliutils "github.com/erigontech/erigon/cmd/utils"
+)
+
+var (
+	sentinelFlag = &cli.StringFlag{Name: "sentinel", Usage: "sentinel url", Value: "localhost:7777"}
+	pprofFlag    = &cli.BoolFlag{Name: "pprof", Usage: "enable pprof"}
+	toSlotFlag   = &cli.Uint64Flag{Name: "to", Usage: "slot to dump"}
+)
+
+func (c *chainCfg) fromCmd(cmd *cli.Command) { c.Chain = cmd.String(cliutils.ChainFlag.Name) }
+
+// fromCmd keeps the existence check the kong `existingdir` type used to do:
+// every command here reads an existing datadir, none creates one.
+func (o *outputFolder) fromCmd(cmd *cli.Command) error {
+	o.Datadir = cmd.String(cliutils.DataDirFlag.Name)
+	if _, err := os.Stat(o.Datadir); err != nil {
+		return fmt.Errorf("--datadir: %w", err)
+	}
+	return nil
+}
+
+func (w *withSentinel) fromCmd(cmd *cli.Command) { w.Sentinel = cmd.String(sentinelFlag.Name) }
+
+func (w *withPPROF) fromCmd(cmd *cli.Command) { w.Pprof = cmd.Bool(pprofFlag.Name) }
+
+func commands() []*cli.Command {
+	return []*cli.Command{
+		(&Chain{}).command(),
+		(&DumpSnapshots{}).command(),
+		(&CheckSnapshots{}).command(),
+		(&LoopSnapshots{}).command(),
+		(&RetrieveHistoricalState{}).command(),
+		(&ChainEndpoint{}).command(),
+		(&ArchiveSanitizer{}).command(),
+		(&BenchmarkNode{}).command(),
+		(&BlobArchiveStoreCheck{}).command(),
+		(&DumpBlobsSnapshots{}).command(),
+		(&CheckBlobsSnapshots{}).command(),
+		(&CheckBlobsSnapshotsCount{}).command(),
+		(&DumpBlobsSnapshotsToStore{}).command(),
+		(&DumpStateSnapshots{}).command(),
+		(&MakeDepositArgs{}).command(),
+	}
+}
+
+func (c *Chain) command() *cli.Command {
+	return &cli.Command{
+		Name:  "chain",
+		Usage: "download the entire chain from reqresp network",
+		Flags: []cli.Flag{&cliutils.ChainFlag, sentinelFlag, &cliutils.DataDirFlag},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			c.chainCfg.fromCmd(cmd)
+			c.withSentinel.fromCmd(cmd)
+			if err := c.outputFolder.fromCmd(cmd); err != nil {
+				return err
+			}
+			return c.Run(ctx)
+		},
+	}
+}
+
+func (c *DumpSnapshots) command() *cli.Command {
+	return &cli.Command{
+		Name:  "dump-snapshots",
+		Usage: "generate caplin snapshots",
+		Flags: []cli.Flag{&cliutils.ChainFlag, &cliutils.DataDirFlag, toSlotFlag},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			c.chainCfg.fromCmd(cmd)
+			if err := c.outputFolder.fromCmd(cmd); err != nil {
+				return err
+			}
+			c.To = cmd.Uint64(toSlotFlag.Name)
+			return c.Run(ctx)
+		},
+	}
+}
+
+func (c *CheckSnapshots) command() *cli.Command {
+	return &cli.Command{
+		Name:  "check-snapshots",
+		Usage: "check snapshot folder against content of chain data",
+		Flags: []cli.Flag{&cliutils.ChainFlag, &cliutils.DataDirFlag, pprofFlag},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			c.chainCfg.fromCmd(cmd)
+			if err := c.outputFolder.fromCmd(cmd); err != nil {
+				return err
+			}
+			c.withPPROF.fromCmd(cmd)
+			return c.Run(ctx)
+		},
+	}
+}
+
+func (c *LoopSnapshots) command() *cli.Command {
+	slot := &cli.Uint64Flag{Name: "slot", Usage: "slot to check"}
+	return &cli.Command{
+		Name:  "loop-snapshots",
+		Usage: "loop over snapshots",
+		Flags: []cli.Flag{&cliutils.ChainFlag, &cliutils.DataDirFlag, pprofFlag, slot},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			c.chainCfg.fromCmd(cmd)
+			if err := c.outputFolder.fromCmd(cmd); err != nil {
+				return err
+			}
+			c.withPPROF.fromCmd(cmd)
+			c.Slot = cmd.Uint64(slot.Name)
+			return c.Run(ctx)
+		},
+	}
+}
+
+func (r *RetrieveHistoricalState) command() *cli.Command {
+	compareFile := &cli.StringFlag{Name: "compare-file", Usage: "compare file"}
+	compareSlot := &cli.Uint64Flag{Name: "compare-slot", Usage: "compare slot"}
+	out := &cli.StringFlag{Name: "out", Usage: "output file"}
+	return &cli.Command{
+		Name:  "retrieve-historical-state",
+		Usage: "retrieve historical state from db",
+		Flags: []cli.Flag{&cliutils.ChainFlag, &cliutils.DataDirFlag, pprofFlag, compareFile, compareSlot, out},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			r.chainCfg.fromCmd(cmd)
+			if err := r.outputFolder.fromCmd(cmd); err != nil {
+				return err
+			}
+			r.withPPROF.fromCmd(cmd)
+			r.CompareFile = cmd.String(compareFile.Name)
+			r.CompareSlot = cmd.Uint64(compareSlot.Name)
+			r.Out = cmd.String(out.Name)
+			return r.Run(ctx)
+		},
+	}
+}
+
+func (c *ChainEndpoint) command() *cli.Command {
+	endpoint := &cli.StringFlag{Name: "endpoint", Usage: "endpoint"}
+	blobs := &cli.BoolFlag{Name: "blobs", Usage: "also download blobs"}
+	return &cli.Command{
+		Name:  "chain-endpoint",
+		Usage: "chain endpoint",
+		Flags: []cli.Flag{endpoint, blobs, &cliutils.ChainFlag, &cliutils.DataDirFlag},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			c.Endpoint = cmd.String(endpoint.Name)
+			c.Blobs = cmd.Bool(blobs.Name)
+			c.chainCfg.fromCmd(cmd)
+			if err := c.outputFolder.fromCmd(cmd); err != nil {
+				return err
+			}
+			return c.Run(ctx)
+		},
+	}
+}
+
+func (a *ArchiveSanitizer) command() *cli.Command {
+	beaconAPIURL := &cli.StringFlag{Name: "beacon-api-url", Usage: "beacon api url", Value: "http://localhost:5555"}
+	intervalSlot := &cli.Uint64Flag{Name: "interval-slot", Usage: "interval slot", Value: 19}
+	startSlot := &cli.Uint64Flag{Name: "start-slot", Usage: "start slot"}
+	faultOut := &cli.StringFlag{Name: "fault-out", Usage: "fault out"}
+	return &cli.Command{
+		Name:  "archive-sanitizer",
+		Usage: "archive sanitizer",
+		Flags: []cli.Flag{&cliutils.ChainFlag, &cliutils.DataDirFlag, beaconAPIURL, intervalSlot, startSlot, faultOut},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			a.chainCfg.fromCmd(cmd)
+			if err := a.outputFolder.fromCmd(cmd); err != nil {
+				return err
+			}
+			a.BeaconApiURL = cmd.String(beaconAPIURL.Name)
+			a.IntervalSlot = cmd.Uint64(intervalSlot.Name)
+			a.StartSlot = cmd.Uint64(startSlot.Name)
+			a.FaultOut = cmd.String(faultOut.Name)
+			return a.Run(ctx)
+		},
+	}
+}
+
+func (b *BenchmarkNode) command() *cli.Command {
+	baseURL := &cli.StringFlag{Name: "base-url", Usage: "base url", Value: "http://localhost:5555"}
+	endpoint := &cli.StringFlag{Name: "endpoint", Usage: "endpoint", Value: "/eth/v1/beacon/states/{slot}/validators"}
+	outCSV := &cli.StringFlag{Name: "out-csv", Usage: "output csv"}
+	accept := &cli.StringFlag{Name: "accept", Usage: "accept", Value: "application/json"}
+	head := &cli.BoolFlag{Name: "head", Usage: "head"}
+	method := &cli.StringFlag{Name: "method", Usage: "method", Value: "GET"}
+	body := &cli.StringFlag{Name: "body", Usage: "body", Value: "{}"}
+	return &cli.Command{
+		Name:  "benchmark-node",
+		Usage: "benchmark node",
+		Flags: []cli.Flag{&cliutils.ChainFlag, baseURL, endpoint, outCSV, accept, head, method, body},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			b.chainCfg.fromCmd(cmd)
+			b.BaseURL = cmd.String(baseURL.Name)
+			b.Endpoint = cmd.String(endpoint.Name)
+			b.OutCSV = cmd.String(outCSV.Name)
+			b.Accept = cmd.String(accept.Name)
+			b.Head = cmd.Bool(head.Name)
+			b.Method = cmd.String(method.Name)
+			b.Body = cmd.String(body.Name)
+			return b.Run(ctx)
+		},
+	}
+}
+
+func (b *BlobArchiveStoreCheck) command() *cli.Command {
+	fromSlot := &cli.Uint64Flag{Name: "from-slot", Usage: "from slot"}
+	return &cli.Command{
+		Name:  "blob-archive-store-check",
+		Usage: "blob archive store check",
+		Flags: []cli.Flag{&cliutils.ChainFlag, &cliutils.DataDirFlag, fromSlot},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			b.chainCfg.fromCmd(cmd)
+			if err := b.outputFolder.fromCmd(cmd); err != nil {
+				return err
+			}
+			b.FromSlot = cmd.Uint64(fromSlot.Name)
+			return b.Run(ctx)
+		},
+	}
+}
+
+func (c *DumpBlobsSnapshots) command() *cli.Command {
+	return &cli.Command{
+		Name:  "dump-blobs-snapshots",
+		Usage: "dump blobs snapshots",
+		Flags: []cli.Flag{&cliutils.ChainFlag, &cliutils.DataDirFlag, toSlotFlag},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			c.chainCfg.fromCmd(cmd)
+			if err := c.outputFolder.fromCmd(cmd); err != nil {
+				return err
+			}
+			c.To = cmd.Uint64(toSlotFlag.Name)
+			return c.Run(ctx)
+		},
+	}
+}
+
+func (c *CheckBlobsSnapshots) command() *cli.Command {
+	return &cli.Command{
+		Name:  "check-blobs-snapshots",
+		Usage: "check blobs snapshots",
+		Flags: []cli.Flag{&cliutils.ChainFlag, &cliutils.DataDirFlag, pprofFlag},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			c.chainCfg.fromCmd(cmd)
+			if err := c.outputFolder.fromCmd(cmd); err != nil {
+				return err
+			}
+			c.withPPROF.fromCmd(cmd)
+			return c.Run(ctx)
+		},
+	}
+}
+
+func (c *CheckBlobsSnapshotsCount) command() *cli.Command {
+	from := &cli.Uint64Flag{Name: "from", Usage: "from slot"}
+	checkNeedRegen := &cli.BoolFlag{Name: "check-need-regen", Usage: "check if blobs need regen"}
+	return &cli.Command{
+		Name:  "check-blobs-snapshots-count",
+		Usage: "check blobs snapshots count",
+		Flags: []cli.Flag{&cliutils.ChainFlag, &cliutils.DataDirFlag, pprofFlag, from, checkNeedRegen},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			c.chainCfg.fromCmd(cmd)
+			if err := c.outputFolder.fromCmd(cmd); err != nil {
+				return err
+			}
+			c.withPPROF.fromCmd(cmd)
+			c.From = cmd.Uint64(from.Name)
+			c.CheckNeedRegen = cmd.Bool(checkNeedRegen.Name)
+			return c.Run(ctx)
+		},
+	}
+}
+
+func (c *DumpBlobsSnapshotsToStore) command() *cli.Command {
+	return &cli.Command{
+		Name:  "dump-blobs-snapshots-to-store",
+		Usage: "dump blobs snapshots to store",
+		Flags: []cli.Flag{&cliutils.ChainFlag, &cliutils.DataDirFlag, pprofFlag},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			c.chainCfg.fromCmd(cmd)
+			if err := c.outputFolder.fromCmd(cmd); err != nil {
+				return err
+			}
+			c.withPPROF.fromCmd(cmd)
+			return c.Run(ctx)
+		},
+	}
+}
+
+func (c *DumpStateSnapshots) command() *cli.Command {
+	stepSize := &cli.Uint64Flag{Name: "step-size", Usage: "step size", Value: 10000}
+	return &cli.Command{
+		Name:  "dump-state-snapshots",
+		Usage: "dump state snapshots",
+		Flags: []cli.Flag{&cliutils.ChainFlag, &cliutils.DataDirFlag, toSlotFlag, stepSize},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			c.chainCfg.fromCmd(cmd)
+			if err := c.outputFolder.fromCmd(cmd); err != nil {
+				return err
+			}
+			c.To = cmd.Uint64(toSlotFlag.Name)
+			c.StepSize = cmd.Uint64(stepSize.Name)
+			return c.Run(ctx)
+		},
+	}
+}
+
+func (m *MakeDepositArgs) command() *cli.Command {
+	privateKey := &cli.StringFlag{Name: "private-key", Usage: "private key to use for signing deposit"}
+	withdrawalAddress := &cli.StringFlag{Name: "withdrawal-address", Usage: "withdrawal address to use for deposit"}
+	amountEth := &cli.Uint64Flag{Name: "amount-eth", Usage: "amount of ETH to deposit", Value: 32}
+	domainDeposit := &cli.StringFlag{Name: "domain-deposit", Usage: "domain for deposit signature", Value: "0x03000000"}
+	genesisForkVersion := &cli.StringFlag{Name: "genesis-fork-version", Usage: "genesis fork version for deposit signature", Value: "0x00000000"}
+	return &cli.Command{
+		Name:  "make-deposit-args",
+		Usage: "make deposit args",
+		Flags: []cli.Flag{privateKey, withdrawalAddress, amountEth, domainDeposit, genesisForkVersion},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			m.PrivateKey = cmd.String(privateKey.Name)
+			m.WithdrawalAddress = cmd.String(withdrawalAddress.Name)
+			m.AmountEth = cmd.Uint64(amountEth.Name)
+			m.DomainDeposit = cmd.String(domainDeposit.Name)
+			m.GenesisForkVersion = cmd.String(genesisForkVersion.Name)
+			return m.Run(ctx)
+		},
+	}
+}

--- a/cmd/capcli/flags.go
+++ b/cmd/capcli/flags.go
@@ -38,8 +38,12 @@ func (c *chainCfg) fromCmd(cmd *cli.Command) { c.Chain = cmd.String(cliutils.Cha
 // every command here reads an existing datadir, none creates one.
 func (o *outputFolder) fromCmd(cmd *cli.Command) error {
 	o.Datadir = cmd.String(cliutils.DataDirFlag.Name)
-	if _, err := os.Stat(o.Datadir); err != nil {
+	st, err := os.Stat(o.Datadir)
+	if err != nil {
 		return fmt.Errorf("--datadir: %w", err)
+	}
+	if !st.IsDir() {
+		return fmt.Errorf("--datadir: %q exists but is not a directory", o.Datadir)
 	}
 	return nil
 }

--- a/cmd/capcli/main.go
+++ b/cmd/capcli/main.go
@@ -18,21 +18,20 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"os"
 
-	"github.com/alecthomas/kong"
+	"github.com/urfave/cli/v3"
 )
 
-type Context struct {
-	context.Context
-	kctx *kong.Context
-}
-
 func main() {
-	ctx := kong.Parse(&CLI)
-	// Call the Run() method of the selected parsed command.
-	err := ctx.Run(&Context{
-		kctx:    ctx,
-		Context: context.TODO(),
-	})
-	ctx.FatalIfErrorf(err)
+	app := &cli.Command{
+		Name:     "capcli",
+		Usage:    "Caplin command line interface",
+		Commands: commands(),
+	}
+	if err := app.Run(context.Background(), os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/OffchainLabs/go-bitfield v0.0.0-20260504143531-5cbb6d0f5f2e
 	github.com/RoaringBitmap/roaring/v2 v2.26.0
-	github.com/alecthomas/kong v1.16.1
 	github.com/anacrolix/envpprof v1.5.0
 	github.com/anacrolix/generics v0.2.0
 	github.com/anacrolix/go-libutp v1.5.1-0.20260817025621-104d95cd4dc1

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,6 @@ github.com/alecthomas/chroma/v2 v2.24.1 h1:m5ffpfZbIb++k8AqFEKy9uVgY12xIQtBsQlc6
 github.com/alecthomas/chroma/v2 v2.24.1/go.mod h1:l+ohZ9xRXIbGe7cIW+YZgOGbvuVLjMps/FYN/CwuabI=
 github.com/alecthomas/go-check-sumtype v0.3.1 h1:u9aUvbGINJxLVXiFvHUlPEaD7VDULsrxJb4Aq31NLkU=
 github.com/alecthomas/go-check-sumtype v0.3.1/go.mod h1:A8TSiN3UPRw3laIgWEUOHHLPa6/r9MtoigdlP5h3K/E=
-github.com/alecthomas/kong v1.16.1 h1:ixhCt93XkJ98kGposQ54+bl0IK6XwqB40AsMynU7Z8E=
-github.com/alecthomas/kong v1.16.1/go.mod h1:wrlbXem1CWqUV5Vbmss5ISYhsVPkBb1Yo7YKJghju2I=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=


### PR DESCRIPTION
`capcli` was the only user of `alecthomas/kong`, the third CLI framework in the tree. It now uses `urfave/cli/v3`, so the repo is down to two (urfave and cobra) and the dependency is gone from `go.mod`.

No command logic moved: all 15 `Run` methods keep their bodies, and only their signature changes from `*Context` to `context.Context`. The wiring — flag declarations, the command tree, and the struct population — lives in the new `cmd/capcli/flags.go`, so the `cli.go` diff is kong tags coming off.

Verified by diffing `--help` of the old and new binaries: identical command names and identical flag sets for all 15 subcommands.

Three intentional behavior changes:

- `--datadir` reuses `utils.DataDirFlag`, so its default becomes `paths.DefaultDataDir()` rather than a hardcoded `~/.local/share/erigon` — same on Linux, correct instead of wrong on macOS and Windows. `--chain` reuses `utils.ChainFlag`; the default is identical, the help text now reads "name of the network to join".
- kong's `type:"existingdir"` validation is kept explicitly in `outputFolder.fromCmd`, with the same messages for both a missing path and a path that exists but is not a directory.
- Exit code on an unknown command is now 3 (urfave) instead of 80 (kong). Both non-zero.

