### PR TITLE
docs(site): raise the installation prerequisite to Go 1.26

### DIFF
--- a/docs/site/docs/get-started/installation/index.mdx
+++ b/docs/site/docs/get-started/installation/index.mdx
@@ -299,7 +299,7 @@ sudo apt install build-essential cmake -y
 
 **1.3 Go Programming Language**
 
-Erigon utilizes Go (also known as Golang) version 1.25 or newer for part of its development. It is recommended to have a
+Erigon utilizes Go (also known as Golang) version 1.26 or newer for part of its development. It is recommended to have a
 fresh Go installation. If you have an older version, consider deleting the `/usr/local/go` folder (you may need to use
 `sudo`) and re-extract the new version in its place.
 
@@ -423,7 +423,7 @@ Git is a tool that helps download and manage the Erigon source code. To install 
 
 **1.4 Go Programming Language**
 
-Erigon utilizes Go (also known as Golang) version 1.25 or newer for part of its development. It is recommended to have a
+Erigon utilizes Go (also known as Golang) version 1.26 or newer for part of its development. It is recommended to have a
 fresh Go installation. If you have an older version, consider deleting the `/usr/local/go` folder (you may need to use
 `sudo`) and re-extract the new version in its place.
 

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -586,7 +586,7 @@ sudo apt install build-essential cmake -y
 
 **1.3 Go Programming Language**
 
-Erigon utilizes Go (also known as Golang) version 1.25 or newer for part of its development. It is recommended to have a
+Erigon utilizes Go (also known as Golang) version 1.26 or newer for part of its development. It is recommended to have a
 fresh Go installation. If you have an older version, consider deleting the `/usr/local/go` folder (you may need to use
 `sudo`) and re-extract the new version in its place.
 
@@ -704,7 +704,7 @@ Git is a tool that helps download and manage the Erigon source code. To install 
 
 **1.4 Go Programming Language**
 
-Erigon utilizes Go (also known as Golang) version 1.25 or newer for part of its development. It is recommended to have a
+Erigon utilizes Go (also known as Golang) version 1.26 or newer for part of its development. It is recommended to have a
 fresh Go installation. If you have an older version, consider deleting the `/usr/local/go` folder (you may need to use
 `sudo`) and re-extract the new version in its place.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -586,7 +586,7 @@ sudo apt install build-essential cmake -y
 
 **1.3 Go Programming Language**
 
-Erigon utilizes Go (also known as Golang) version 1.25 or newer for part of its development. It is recommended to have a
+Erigon utilizes Go (also known as Golang) version 1.26 or newer for part of its development. It is recommended to have a
 fresh Go installation. If you have an older version, consider deleting the `/usr/local/go` folder (you may need to use
 `sudo`) and re-extract the new version in its place.
 
@@ -704,7 +704,7 @@ Git is a tool that helps download and manage the Erigon source code. To install 
 
 **1.4 Go Programming Language**
 
-Erigon utilizes Go (also known as Golang) version 1.25 or newer for part of its development. It is recommended to have a
+Erigon utilizes Go (also known as Golang) version 1.26 or newer for part of its development. It is recommended to have a
 fresh Go installation. If you have an older version, consider deleting the `/usr/local/go` folder (you may need to use
 `sudo`) and re-extract the new version in its place.
 


### PR DESCRIPTION
The minimum Go version went to 1.26 in #23735. That PR updated the build step in `contributing.md` but not the install prerequisites, so both sections of the installation page — Linux/macOS and Windows — still asked for 1.25 and following the guide produced a toolchain that cannot build `main`.

`go.mod` on `main` is `go 1.26.0`; these two lines were the only remaining 1.25 mentions anywhere under `docs/site/docs`.

The llms.txt artifacts are regenerated because the installation page is part of the corpus; the delta is those two lines and nothing else.