### PR TITLE
cl, p2p/rlpx: grow reused buffers with slices.Grow

### DIFF
--- a/cl/cltypes/solid/bitlist.go
+++ b/cl/cltypes/solid/bitlist.go
@@ -96,10 +96,7 @@ func (u *BitList) CopyTo(target IterableSSZ[byte]) {
 }
 
 func (u *BitList) Copy() *BitList {
-	n := NewBitList(u.l, u.c)
-	n.u = make([]byte, len(u.u), cap(u.u))
-	copy(n.u, u.u)
-	return n
+	return &BitList{u: slices.Clone(u.u), l: u.l, c: u.c}
 }
 
 // Range allows us to do something to each bit in the list, just like a Power Rangers roll call.

--- a/cl/cltypes/solid/participation_bitlist.go
+++ b/cl/cltypes/solid/participation_bitlist.go
@@ -19,6 +19,7 @@ package solid
 import (
 	"encoding/json"
 	"math/bits"
+	"slices"
 	"strconv"
 
 	"github.com/erigontech/erigon/cl/merkle_tree"
@@ -83,10 +84,7 @@ func (u *ParticipationBitList) CopyTo(target IterableSSZ[byte]) {
 }
 
 func (u *ParticipationBitList) Copy() *ParticipationBitList {
-	n := NewParticipationBitList(u.l, u.c)
-	n.u = make([]byte, len(u.u), cap(u.u))
-	copy(n.u, u.u)
-	return n
+	return &ParticipationBitList{u: slices.Clone(u.u), l: u.l, c: u.c}
 }
 
 // Range allows us to do something to each bit in the list, just like a Power Rangers roll call.

--- a/cl/cltypes/solid/validator_set.go
+++ b/cl/cltypes/solid/validator_set.go
@@ -80,14 +80,11 @@ func (v *ValidatorSet) Bytes() []byte {
 func (v *ValidatorSet) expandBuffer(newValidatorSetLength int) {
 	size := newValidatorSetLength * validatorSize
 
-	if size <= cap(v.buffer) {
-		v.buffer = v.buffer[:size]
-		return
+	if size > cap(v.buffer) {
+		increasedValidatorsCapacity := int(uint64(float64(newValidatorSetLength)*validatorSetCapacityMultiplier)+1) * validatorSize
+		v.buffer = slices.Grow(v.buffer, increasedValidatorsCapacity-len(v.buffer))
 	}
-	increasedValidatorsCapacity := uint64(float64(newValidatorSetLength)*validatorSetCapacityMultiplier) + 1
-	buffer := make([]byte, size, increasedValidatorsCapacity*validatorSize)
-	copy(buffer, v.buffer)
-	v.buffer = buffer
+	v.buffer = v.buffer[:size]
 }
 
 func (v *ValidatorSet) Append(val Validator) {

--- a/cl/phase1/forkchoice/gloas_weight_tree.go
+++ b/cl/phase1/forkchoice/gloas_weight_tree.go
@@ -228,16 +228,10 @@ func growGloasContributions(applied []gloasVoteContribution, size int) []gloasVo
 	if len(applied) >= size {
 		return applied
 	}
-	if cap(applied) >= size {
-		oldLen := len(applied)
-		applied = applied[:size]
-		clear(applied[oldLen:])
-		return applied
-	}
-	nextCap := max(cap(applied)*2, size)
-	next := make([]gloasVoteContribution, size, nextCap)
-	copy(next, applied)
-	return next
+	oldLen := len(applied)
+	applied = slices.Grow(applied, size-oldLen)[:size]
+	clear(applied[oldLen:])
+	return applied
 }
 
 func (t *gloasWeightTree) addValidatorContribution(validatorIndex uint64, cs *checkpointState) {

--- a/p2p/rlpx/buffer.go
+++ b/p2p/rlpx/buffer.go
@@ -98,11 +98,8 @@ func (b *writeBuffer) appendZero(n int) []byte {
 	offset := len(b.data)
 	newLen := offset + n
 	if cap(b.data) >= newLen {
-		// Grow in place and ensure the new region is zero-filled.
 		b.data = b.data[:newLen]
-		for i := offset; i < newLen; i++ {
-			b.data[i] = 0
-		}
+		clear(b.data[offset:])
 		return b.data[offset:newLen]
 	}
 	b.data = append(b.data, make([]byte, n)...)


### PR DESCRIPTION
Follow-up to #23794: the same `make` + partial `copy` grow pattern, at sites where a **reused** buffer is grown. The win only exists there — for a fresh allocation Go has no non-zeroing sized `make`, so `slices.Grow` buys nothing.

**`ValidatorSet.expandBuffer`** — the big one. `validatorSetCapacityMultiplier` is 1.01, so on mainnet (~1.9M validators x 121B ~= 230MB) the buffer reallocates about every 1% of growth, and each time the 3-arg `make` zeroes the full new capacity while `copy` restores only the old length. `slices.Grow` zeroes only what is above the old capacity. The memmove stays.
Safe because all three callers overwrite everything past the preserved prefix (`Append` writes `v.buffer[offset:]`, `DecodeSSZ` does `copy(v.buffer, buf)`, `CopyTo` does `copy(t.buffer, v.buffer)`), and the in-cap fast path already resliced without zeroing.

**`writeBuffer.appendZero`** — zeroed byte by byte. The compiler's memclr idiom only matches `for i := range a`, not `for i := offset; i < newLen; i++`, so the loop really ran per byte. `clear` replaces it.

**`growGloasContributions`** — hand-rolled `slices.Grow` (`nextCap := max(cap(applied)*2, size)`). The two branches collapse into one; the explicit `clear` stays, since `Grow` does not zero the stale region between the old length and the old capacity.

**`BitList.Copy` / `ParticipationBitList.Copy`** — allocated twice (`NewBitList` built a buffer that was immediately discarded) and the 3-arg `make` zeroed the full `cap(u.u)` while only `len(u.u)` was copied and the tail is never read. `slices.Clone` is one allocation of exactly the length. Dropping the capacity carry-over is safe: `Append` uses `append`, and `Get`/`Set` index within the length.

