### PR TITLE
docs(site): make the llms.txt artifacts discoverable

### DIFF
--- a/docs/site/docs/fundamentals/mcp.mdx
+++ b/docs/site/docs/fundamentals/mcp.mdx
@@ -338,13 +338,13 @@ MCP connects a model to your **running node**. To let a model answer questions a
 | [llms.txt](https://docs.erigon.tech/llms.txt) | Index of the current documentation, with titles and descriptions | The model fetches pages on demand, or its context window is small |
 | [llms-full.txt](https://docs.erigon.tech/llms-full.txt) | The text of those same pages, as one plain-text file | You want the whole corpus in context, offline, with nothing scraped |
 
-Both are generated from the documentation sources by a script in the repository, and CI fails when the committed files differ from what that script produces — except for a difference confined to the Erigon release token, which is reported as a warning so that a new release does not break every open documentation pull request. The check compares the artifacts against the generator's own output, so it does not prove that the generator carried every part of a page across.
+Both are generated from the documentation sources by a script in the repository, and CI fails when the committed files differ from what that script produces. The check compares the artifacts against the generator's own output, so it does not prove that the generator carried every part of a page across.
 
-Two things to know about their scope. They cover the **current** documentation and the help center only — archived versions, published under `/vX.Y/`, are not included. And the text is cleaned rather than copied verbatim: MDX components are stripped, so a page built out of components carries less than the rendered page shows. Read the corpus as the documentation's prose, not as a byte-for-byte mirror of the rendered site.
+Two things to know about their scope. They cover the **current** documentation and the help center only — archived versions, published under `/vX.Y/`, are not included. And the text is cleaned rather than copied verbatim: MDX components are stripped, and section index pages built as card grids are reduced to the list of links they present, so prose outside the cards on those pages is not carried. Read the corpus as the documentation's prose, not as a byte-for-byte mirror of the rendered site.
 
 ```bash
 # Give a local model the whole documentation, with no network access
 curl -sO https://docs.erigon.tech/llms-full.txt
 ```
 
-The full file is around 430 KB. If your model's context cannot hold it, use `llms.txt` to pick the pages you need, or slice the sections you want out of the full file — each page begins with a `# Title` heading.
+The full file is roughly half a megabyte. If your model's context cannot hold it, use `llms.txt` to pick the pages you need, or slice the sections you want out of the full file — each page begins with a `# Title` heading.

--- a/docs/site/docs/fundamentals/mcp.mdx
+++ b/docs/site/docs/fundamentals/mcp.mdx
@@ -326,3 +326,25 @@ In addition to tools, the MCP server exposes structured **resources** and **prom
 | `debug_logs` | Triage node issues from recent log output |
 | `torrent_status` | Snapshot download health check |
 | `sync_analysis` | Node sync progress and performance |
+
+---
+
+## These Docs as a Single File
+
+MCP connects a model to your **running node**. To let a model answer questions about **Erigon itself** — flags, pruning modes, RPC namespaces, hardware sizing — point it at this documentation in machine-readable form, following the [llmstxt.org](https://llmstxt.org) convention:
+
+| File | Contents | Use it when |
+|------|----------|-------------|
+| [llms.txt](https://docs.erigon.tech/llms.txt) | Index of the current documentation, with titles and descriptions | The model fetches pages on demand, or its context window is small |
+| [llms-full.txt](https://docs.erigon.tech/llms-full.txt) | The text of those same pages, as one plain-text file | You want the whole corpus in context, offline, with nothing scraped |
+
+Both are generated from the documentation sources by a script in the repository, and CI fails when the committed files differ from what that script produces — except for a difference confined to the Erigon release token, which is reported as a warning so that a new release does not break every open documentation pull request. The check compares the artifacts against the generator's own output, so it does not prove that the generator carried every part of a page across.
+
+Two things to know about their scope. They cover the **current** documentation and the help center only — archived versions, published under `/vX.Y/`, are not included. And the text is cleaned rather than copied verbatim: MDX components are stripped, so a page built out of components carries less than the rendered page shows. Read the corpus as the documentation's prose, not as a byte-for-byte mirror of the rendered site.
+
+```bash
+# Give a local model the whole documentation, with no network access
+curl -sO https://docs.erigon.tech/llms-full.txt
+```
+
+The full file is around 430 KB. If your model's context cannot hold it, use `llms.txt` to pick the pages you need, or slice the sections you want out of the full file — each page begins with a `# Title` heading.

--- a/docs/site/docs/get-started/why-using-erigon.mdx
+++ b/docs/site/docs/get-started/why-using-erigon.mdx
@@ -179,3 +179,5 @@ The interface is **read-only** and localhost-bound — no risk of unintended sta
 # Register with Claude Code in one command
 claude mcp add --transport sse erigon http://127.0.0.1:8553/sse
 ```
+
+Where MCP lets a model query your *node*, [llms.txt and llms-full.txt](../fundamentals/mcp#these-docs-as-a-single-file) let it read these *docs*: an index of the current documentation, and the same pages' text as one plain-text file for offline use.

--- a/docs/site/docusaurus.config.ts
+++ b/docs/site/docusaurus.config.ts
@@ -24,9 +24,9 @@ type Release = {tag_name: string; prerelease: boolean; draft: boolean};
 // semantic version instead of trusting that order.
 const {installableVersion, latestStableInSeries} = require('./src/releases.js');
 
-// Routes with no indexable content. Single source of truth: the sitemap skips
-// them and src/theme/Root.tsx keeps the llms.txt descriptor off them, because
-// the index does not list them either.
+// Routes with no indexable content, skipped by the sitemap. The llms.txt
+// descriptor does not need them listed: it is emitted only for a declared
+// document route, which these are not.
 const nonDocumentRoutes: string[] = ['/search', '/404.html'];
 
 function githubHeaders(): Record<string, string> {
@@ -78,7 +78,7 @@ export default async function createConfig(): Promise<Config> {
 
     // Both lists reach src/theme/Root.tsx, which uses them to keep the llms.txt
     // descriptor off the routes the index does not cover.
-    customFields: {latestVersion, archivedVersions, nonDocumentRoutes},
+    customFields: {latestVersion, archivedVersions},
 
     headTags: [
       {
@@ -161,9 +161,10 @@ export default async function createConfig(): Promise<Config> {
         blog: false as false,
         theme: {customCss: './src/css/custom.css'},
         sitemap: {
-          // Emit <lastmod> per URL (from git history via showLastUpdateTime) so
-          // crawlers can prioritise changed pages. The ignored routes still
-          // exist; they just have no indexable content.
+          // Emit <lastmod> for routed pages (from git history via
+          // showLastUpdateTime) so crawlers can prioritise changed pages; the
+          // static artifacts appended below have no route and so carry none.
+          // The ignored routes still exist; they just have no indexable content.
           lastmod: 'date',
           changefreq: 'weekly',
           priority: 0.5,

--- a/docs/site/docusaurus.config.ts
+++ b/docs/site/docusaurus.config.ts
@@ -24,6 +24,11 @@ type Release = {tag_name: string; prerelease: boolean; draft: boolean};
 // semantic version instead of trusting that order.
 const {installableVersion, latestStableInSeries} = require('./src/releases.js');
 
+// Routes with no indexable content. Single source of truth: the sitemap skips
+// them and src/theme/Root.tsx keeps the llms.txt descriptor off them, because
+// the index does not list them either.
+const nonDocumentRoutes: string[] = ['/search', '/404.html'];
+
 function githubHeaders(): Record<string, string> {
   const headers: Record<string, string> = {Accept: 'application/vnd.github.v3+json'};
   if (process.env.GITHUB_TOKEN) headers['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`;
@@ -71,7 +76,9 @@ export default async function createConfig(): Promise<Config> {
     markdown: {mermaid: true},
     themes: ['@docusaurus/theme-mermaid'],
 
-    customFields: {latestVersion},
+    // Both lists reach src/theme/Root.tsx, which uses them to keep the llms.txt
+    // descriptor off the routes the index does not cover.
+    customFields: {latestVersion, archivedVersions, nonDocumentRoutes},
 
     headTags: [
       {
@@ -155,12 +162,22 @@ export default async function createConfig(): Promise<Config> {
         theme: {customCss: './src/css/custom.css'},
         sitemap: {
           // Emit <lastmod> per URL (from git history via showLastUpdateTime) so
-          // crawlers can prioritise changed pages. Exclude /search from the
-          // sitemap — it has no indexable content (the route itself still exists).
+          // crawlers can prioritise changed pages. The ignored routes still
+          // exist; they just have no indexable content.
           lastmod: 'date',
           changefreq: 'weekly',
           priority: 0.5,
-          ignorePatterns: ['/search'],
+          ignorePatterns: nonDocumentRoutes,
+          // The llms.txt artifacts live in static/, so Docusaurus never routes
+          // them and the default sitemap omits them. Append them explicitly so
+          // the sitemap declares them. This is sitemap discovery only, not what
+          // makes them reachable: the MCP page links both, and llms.txt links
+          // llms-full.txt.
+          createSitemapItems: async ({defaultCreateSitemapItems, ...rest}) => [
+            ...(await defaultCreateSitemapItems(rest)),
+            {url: 'https://docs.erigon.tech/llms.txt', changefreq: 'weekly', priority: 0.5},
+            {url: 'https://docs.erigon.tech/llms-full.txt', changefreq: 'weekly', priority: 0.5},
+          ],
         },
       } satisfies Preset.Options],
     ],

--- a/docs/site/scripts/generate-llms.py
+++ b/docs/site/scripts/generate-llms.py
@@ -681,6 +681,15 @@ def build():
     lines.append("> modularity, and minimal disk footprint. It features an integrated consensus layer")
     lines.append("> (Caplin), BitTorrent-based historical data distribution, and fast node synchronization.")
     lines.append("")
+    # The only machine-readable route from this index to the full corpus. Pages
+    # advertise llms.txt via <link rel="describedby">, not llms-full.txt, so an
+    # agent that arrives here would otherwise have no way to reach it.
+    lines.append(
+        f"The text of every page listed below is also available as a single file: "
+        f"[llms-full.txt]({BASE_URL}/llms-full.txt). Pages are cleaned for machine "
+        f"reading: MDX components are stripped."
+    )
+    lines.append("")
 
     current_section = None
     for p in all_pages:

--- a/docs/site/src/theme/Root.tsx
+++ b/docs/site/src/theme/Root.tsx
@@ -4,35 +4,23 @@ import {useLocation} from '@docusaurus/router';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import {useAllDocsData} from '@docusaurus/plugin-content-docs/client';
 
-// The llms.txt index covers the current docs and help center only, so it must
-// not be advertised on archived routes, nor on routes it does not list at all.
-// A not-found page keeps the path that was requested rather than /404.html, so
-// listing that route cannot exclude it. Nor can the active plugin: it is matched
-// by base-path prefix, and one instance is mounted at '/', so every pathname has
-// one. The descriptor is therefore emitted only for a pathname that exactly
-// matches a document route the docs plugins declare — which is also the set
-// llms.txt lists.
-// `describedby` is the relation llmstxt.org defines for an index that describes
-// a page; llms-full.txt describes no single page and is discoverable through
-// llms.txt and the sitemap instead.
+// Advertises the llms.txt index that covers the current documentation. The
+// descriptor is emitted only on a route that index lists: archived versions
+// describe themselves, and a route no docs plugin owns is not documentation at
+// all. llms-full.txt gets no relation of its own — it describes the site rather
+// than the page — and stays reachable through llms.txt and the sitemap.
 export default function Root({children}: {children: ReactNode}): ReactNode {
   const {siteConfig} = useDocusaurusContext();
   const archived = (siteConfig.customFields?.archivedVersions ?? []) as string[];
-  const nonDocument = (siteConfig.customFields?.nonDocumentRoutes ?? []) as string[];
   const {pathname} = useLocation();
   const allDocsData = useAllDocsData();
-  // Routing is case-insensitive and index docs keep a trailing slash in the
-  // plugin data even under trailingSlash:false, so every comparison below is
-  // made on the same normalised form. Comparing one of them raw advertises the
-  // current index on an archived route spelled /V3.4/.
+  // Every comparison below uses one normalised form: routing is
+  // case-insensitive and index docs keep a trailing slash in the plugin data.
   const key = (r: string) =>
     (r.length > 1 ? r.replace(/\/$/, '') : r).toLowerCase();
   const here = key(pathname);
   const isArchived = archived.some(
     (v) => here === key(`/${v}`) || here.startsWith(`${key(`/${v}`)}/`),
-  );
-  const isNonDocument = nonDocument.some(
-    (r) => here === key(r) || here.startsWith(`${key(r)}/`),
   );
   const isDocumentRoute = Object.values(allDocsData).some((plugin) =>
     plugin.versions.some((version) =>
@@ -41,7 +29,7 @@ export default function Root({children}: {children: ReactNode}): ReactNode {
   );
   return (
     <>
-      {isDocumentRoute && !isArchived && !isNonDocument && (
+      {isDocumentRoute && !isArchived && (
         <Head>
           <link
             rel="describedby"

--- a/docs/site/src/theme/Root.tsx
+++ b/docs/site/src/theme/Root.tsx
@@ -1,0 +1,56 @@
+import React, {type ReactNode} from 'react';
+import Head from '@docusaurus/Head';
+import {useLocation} from '@docusaurus/router';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import {useAllDocsData} from '@docusaurus/plugin-content-docs/client';
+
+// The llms.txt index covers the current docs and help center only, so it must
+// not be advertised on archived routes, nor on routes it does not list at all.
+// A not-found page keeps the path that was requested rather than /404.html, so
+// listing that route cannot exclude it. Nor can the active plugin: it is matched
+// by base-path prefix, and one instance is mounted at '/', so every pathname has
+// one. The descriptor is therefore emitted only for a pathname that exactly
+// matches a document route the docs plugins declare — which is also the set
+// llms.txt lists.
+// `describedby` is the relation llmstxt.org defines for an index that describes
+// a page; llms-full.txt describes no single page and is discoverable through
+// llms.txt and the sitemap instead.
+export default function Root({children}: {children: ReactNode}): ReactNode {
+  const {siteConfig} = useDocusaurusContext();
+  const archived = (siteConfig.customFields?.archivedVersions ?? []) as string[];
+  const nonDocument = (siteConfig.customFields?.nonDocumentRoutes ?? []) as string[];
+  const {pathname} = useLocation();
+  const allDocsData = useAllDocsData();
+  // Routing is case-insensitive and index docs keep a trailing slash in the
+  // plugin data even under trailingSlash:false, so every comparison below is
+  // made on the same normalised form. Comparing one of them raw advertises the
+  // current index on an archived route spelled /V3.4/.
+  const key = (r: string) =>
+    (r.length > 1 ? r.replace(/\/$/, '') : r).toLowerCase();
+  const here = key(pathname);
+  const isArchived = archived.some(
+    (v) => here === key(`/${v}`) || here.startsWith(`${key(`/${v}`)}/`),
+  );
+  const isNonDocument = nonDocument.some(
+    (r) => here === key(r) || here.startsWith(`${key(r)}/`),
+  );
+  const isDocumentRoute = Object.values(allDocsData).some((plugin) =>
+    plugin.versions.some((version) =>
+      version.docs.some((doc) => key(doc.path) === here),
+    ),
+  );
+  return (
+    <>
+      {isDocumentRoute && !isArchived && !isNonDocument && (
+        <Head>
+          <link
+            rel="describedby"
+            href="https://docs.erigon.tech/llms.txt"
+            title="Erigon Documentation — page index for LLMs"
+          />
+        </Head>
+      )}
+      {children}
+    </>
+  );
+}

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -4156,6 +4156,28 @@ In addition to tools, the MCP server exposes structured **resources** and **prom
 
 ---
 
+## These Docs as a Single File
+
+MCP connects a model to your **running node**. To let a model answer questions about **Erigon itself** — flags, pruning modes, RPC namespaces, hardware sizing — point it at this documentation in machine-readable form, following the [llmstxt.org](https://llmstxt.org) convention:
+
+| File | Contents | Use it when |
+|------|----------|-------------|
+| [llms.txt](https://docs.erigon.tech/llms.txt) | Index of the current documentation, with titles and descriptions | The model fetches pages on demand, or its context window is small |
+| [llms-full.txt](https://docs.erigon.tech/llms-full.txt) | The text of those same pages, as one plain-text file | You want the whole corpus in context, offline, with nothing scraped |
+
+Both are generated from the documentation sources by a script in the repository, and CI fails when the committed files differ from what that script produces — except for a difference confined to the Erigon release token, which is reported as a warning so that a new release does not break every open documentation pull request. The check compares the artifacts against the generator's own output, so it does not prove that the generator carried every part of a page across.
+
+Two things to know about their scope. They cover the **current** documentation and the help center only — archived versions, published under `/vX.Y/`, are not included. And the text is cleaned rather than copied verbatim: MDX components are stripped, so a page built out of components carries less than the rendered page shows. Read the corpus as the documentation's prose, not as a byte-for-byte mirror of the rendered site.
+
+```bash
+# Give a local model the whole documentation, with no network access
+curl -sO https://docs.erigon.tech/llms-full.txt
+```
+
+The full file is around 430 KB. If your model's context cannot hold it, use `llms.txt` to pick the pages you need, or slice the sections you want out of the full file — each page begins with a `# Title` heading.
+
+---
+
 # Otterscan
 URL: https://docs.erigon.tech/fundamentals/otterscan
 

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -4165,16 +4165,16 @@ MCP connects a model to your **running node**. To let a model answer questions a
 | [llms.txt](https://docs.erigon.tech/llms.txt) | Index of the current documentation, with titles and descriptions | The model fetches pages on demand, or its context window is small |
 | [llms-full.txt](https://docs.erigon.tech/llms-full.txt) | The text of those same pages, as one plain-text file | You want the whole corpus in context, offline, with nothing scraped |
 
-Both are generated from the documentation sources by a script in the repository, and CI fails when the committed files differ from what that script produces — except for a difference confined to the Erigon release token, which is reported as a warning so that a new release does not break every open documentation pull request. The check compares the artifacts against the generator's own output, so it does not prove that the generator carried every part of a page across.
+Both are generated from the documentation sources by a script in the repository, and CI fails when the committed files differ from what that script produces. The check compares the artifacts against the generator's own output, so it does not prove that the generator carried every part of a page across.
 
-Two things to know about their scope. They cover the **current** documentation and the help center only — archived versions, published under `/vX.Y/`, are not included. And the text is cleaned rather than copied verbatim: MDX components are stripped, so a page built out of components carries less than the rendered page shows. Read the corpus as the documentation's prose, not as a byte-for-byte mirror of the rendered site.
+Two things to know about their scope. They cover the **current** documentation and the help center only — archived versions, published under `/vX.Y/`, are not included. And the text is cleaned rather than copied verbatim: MDX components are stripped, and section index pages built as card grids are reduced to the list of links they present, so prose outside the cards on those pages is not carried. Read the corpus as the documentation's prose, not as a byte-for-byte mirror of the rendered site.
 
 ```bash
 # Give a local model the whole documentation, with no network access
 curl -sO https://docs.erigon.tech/llms-full.txt
 ```
 
-The full file is around 430 KB. If your model's context cannot hold it, use `llms.txt` to pick the pages you need, or slice the sections you want out of the full file — each page begins with a `# Title` heading.
+The full file is roughly half a megabyte. If your model's context cannot hold it, use `llms.txt` to pick the pages you need, or slice the sections you want out of the full file — each page begins with a `# Title` heading.
 
 ---
 

--- a/docs/site/static/llms.txt
+++ b/docs/site/static/llms.txt
@@ -4,6 +4,8 @@
 > modularity, and minimal disk footprint. It features an integrated consensus layer
 > (Caplin), BitTorrent-based historical data distribution, and fast node synchronization.
 
+The text of every page listed below is also available as a single file: [llms-full.txt](https://docs.erigon.tech/llms-full.txt). Pages are cleaned for machine reading: MDX components are stripped.
+
 - [Introduction](https://docs.erigon.tech/): Official documentation for Erigon — the efficient, modular Ethereum execution client. Get started, explore the JSON-RPC API, and learn how to run a full or archive node.
 
 ## Get Started

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4156,6 +4156,28 @@ In addition to tools, the MCP server exposes structured **resources** and **prom
 
 ---
 
+## These Docs as a Single File
+
+MCP connects a model to your **running node**. To let a model answer questions about **Erigon itself** — flags, pruning modes, RPC namespaces, hardware sizing — point it at this documentation in machine-readable form, following the [llmstxt.org](https://llmstxt.org) convention:
+
+| File | Contents | Use it when |
+|------|----------|-------------|
+| [llms.txt](https://docs.erigon.tech/llms.txt) | Index of the current documentation, with titles and descriptions | The model fetches pages on demand, or its context window is small |
+| [llms-full.txt](https://docs.erigon.tech/llms-full.txt) | The text of those same pages, as one plain-text file | You want the whole corpus in context, offline, with nothing scraped |
+
+Both are generated from the documentation sources by a script in the repository, and CI fails when the committed files differ from what that script produces — except for a difference confined to the Erigon release token, which is reported as a warning so that a new release does not break every open documentation pull request. The check compares the artifacts against the generator's own output, so it does not prove that the generator carried every part of a page across.
+
+Two things to know about their scope. They cover the **current** documentation and the help center only — archived versions, published under `/vX.Y/`, are not included. And the text is cleaned rather than copied verbatim: MDX components are stripped, so a page built out of components carries less than the rendered page shows. Read the corpus as the documentation's prose, not as a byte-for-byte mirror of the rendered site.
+
+```bash
+# Give a local model the whole documentation, with no network access
+curl -sO https://docs.erigon.tech/llms-full.txt
+```
+
+The full file is around 430 KB. If your model's context cannot hold it, use `llms.txt` to pick the pages you need, or slice the sections you want out of the full file — each page begins with a `# Title` heading.
+
+---
+
 # Otterscan
 URL: https://docs.erigon.tech/fundamentals/otterscan
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4165,16 +4165,16 @@ MCP connects a model to your **running node**. To let a model answer questions a
 | [llms.txt](https://docs.erigon.tech/llms.txt) | Index of the current documentation, with titles and descriptions | The model fetches pages on demand, or its context window is small |
 | [llms-full.txt](https://docs.erigon.tech/llms-full.txt) | The text of those same pages, as one plain-text file | You want the whole corpus in context, offline, with nothing scraped |
 
-Both are generated from the documentation sources by a script in the repository, and CI fails when the committed files differ from what that script produces — except for a difference confined to the Erigon release token, which is reported as a warning so that a new release does not break every open documentation pull request. The check compares the artifacts against the generator's own output, so it does not prove that the generator carried every part of a page across.
+Both are generated from the documentation sources by a script in the repository, and CI fails when the committed files differ from what that script produces. The check compares the artifacts against the generator's own output, so it does not prove that the generator carried every part of a page across.
 
-Two things to know about their scope. They cover the **current** documentation and the help center only — archived versions, published under `/vX.Y/`, are not included. And the text is cleaned rather than copied verbatim: MDX components are stripped, so a page built out of components carries less than the rendered page shows. Read the corpus as the documentation's prose, not as a byte-for-byte mirror of the rendered site.
+Two things to know about their scope. They cover the **current** documentation and the help center only — archived versions, published under `/vX.Y/`, are not included. And the text is cleaned rather than copied verbatim: MDX components are stripped, and section index pages built as card grids are reduced to the list of links they present, so prose outside the cards on those pages is not carried. Read the corpus as the documentation's prose, not as a byte-for-byte mirror of the rendered site.
 
 ```bash
 # Give a local model the whole documentation, with no network access
 curl -sO https://docs.erigon.tech/llms-full.txt
 ```
 
-The full file is around 430 KB. If your model's context cannot hold it, use `llms.txt` to pick the pages you need, or slice the sections you want out of the full file — each page begins with a `# Title` heading.
+The full file is roughly half a megabyte. If your model's context cannot hold it, use `llms.txt` to pick the pages you need, or slice the sections you want out of the full file — each page begins with a `# Title` heading.
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -4,6 +4,8 @@
 > modularity, and minimal disk footprint. It features an integrated consensus layer
 > (Caplin), BitTorrent-based historical data distribution, and fast node synchronization.
 
+The text of every page listed below is also available as a single file: [llms-full.txt](https://docs.erigon.tech/llms-full.txt). Pages are cleaned for machine reading: MDX components are stripped.
+
 - [Introduction](https://docs.erigon.tech/): Official documentation for Erigon — the efficient, modular Ethereum execution client. Get started, explore the JSON-RPC API, and learn how to run a full or archive node.
 
 ## Get Started


### PR DESCRIPTION
Split out of #23336, which had grown to carry both this and a rewrite of the corpus generator. Every review finding on that PR landed on the generator; this half has drawn none, so it goes on its own.

Advertises `/llms.txt` with `rel="describedby"` — the relation the llms.txt v2 proposal defines for a file describing a page. `alternate` with `type="text/markdown"` is for a page-specific Markdown representation, which this is not.

The descriptor is emitted only for a pathname that exactly matches a document route the docs plugins declare, which is the set `llms.txt` lists. Route literals cannot express that: a not-found page keeps the path that was requested rather than `/404.html`, and the active plugin is matched by base-path prefix with one instance mounted at `routeBasePath: '/'`, so every pathname has one. Routing is case-insensitive and index docs keep a trailing slash in the plugin data, so every comparison is made on the same normalised form.

`llms-full.txt` gets no relation of its own — it describes the site, not the page — so the index carries the one machine-readable route to it, and the MCP page documents both. Both are appended to the sitemap, which static files are otherwise absent from.

Verified against a hydrated production build, counting `rel="describedby"` in the rendered DOM:

| route | descriptor |
|---|---|
| `/fundamentals/caplin`, `/help-center/best-practices`, `/about`, `/About` | 1 |
| `/nonexistent-page`, `/search`, `/v3.4/about`, `/V3.4/about` | 0 |

Generation is untouched apart from the index line, so the artifacts are regenerated by the current parser exactly as on `main`.