### PR TITLE
db: read code as an owned value instead of cloning it into the cache

### DIFF
--- a/db/kv/kv_interface.go
+++ b/db/kv/kv_interface.go
@@ -465,7 +465,19 @@ type GetLatestOptions struct {
 	maxStep     Step
 	hasMaxStep  bool
 	branchCache bool
+	ownedValue  bool
 }
+
+// WithOwnedValue asks for a value the caller may keep past the transaction. A
+// plain read returns memory owned by a file mapping or a db page; this makes the
+// read copy it when that is what it would otherwise return. Ask for it only to
+// hand the value to something outliving the tx — a copy no one keeps is waste.
+func (opts GetLatestOptions) WithOwnedValue() GetLatestOptions {
+	opts.ownedValue = true
+	return opts
+}
+
+func (opts GetLatestOptions) OwnedValue() bool { return opts.ownedValue }
 
 func (opts GetLatestOptions) WithMetrics(metrics GetLatestMetrics, start time.Time) GetLatestOptions {
 	opts.metrics, opts.start = metrics, start

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1874,6 +1874,9 @@ func (dt *DomainRoTx) getLatest(key []byte, roTx kv.Tx, opts kv.GetLatestOptions
 		if metrics != nil && dbg.KVReadLevelledMetrics {
 			metrics.UpdateDbReads(dt.name, start)
 		}
+		if opts.OwnedValue() {
+			v = bytes.Clone(v) // db values point into tx pages; a file value is already ours
+		}
 		return v, foundStep, true, nil
 	}
 

--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -1498,13 +1498,19 @@ func (sd *SharedDomains) getLatest(domain kv.Domain, tx kv.TemporalTx, k []byte,
 	if useBranchCache {
 		getOpts = getOpts.WithBranchCache()
 	}
+	willFill := maxStep == kv.NoStepBound && sd.stateCache != nil && sd.stateCache.Caches(domain)
+	fillsCode := willFill && len(opts.codeHash) == len(common.Hash{})
+	if fillsCode {
+		getOpts = getOpts.WithOwnedValue()
+	}
+
 	v, step, err = tx.GetLatest(domain, k, getOpts)
 	if err != nil {
 		return nil, 0, fmt.Errorf("storage %x read error: %w", k, err)
 	}
 
 	// A bounded read observes a staged unwind, not stable committed state.
-	if maxStep == kv.NoStepBound && sd.stateCache != nil && sd.stateCache.Caches(domain) {
+	if willFill {
 		readTxNum := step.LastTxNum(sd.StepSize())
 		fillView := view
 		if fillView.NeedsFrontier() {
@@ -1512,7 +1518,7 @@ func (sd *SharedDomains) getLatest(domain kv.Domain, tx kv.TemporalTx, k []byte,
 			// amortized by the backing read. Stale views do not request a retry.
 			fillView = fillView.WithFrontier(sd.cacheFrontierFor(tx))
 		}
-		if len(opts.codeHash) == len(common.Hash{}) {
+		if fillsCode {
 			fillView.FillCode(k, v, opts.codeHash, readTxNum)
 		} else {
 			fillView.Fill(domain, k, v, readTxNum)

--- a/execution/cache/view.go
+++ b/execution/cache/view.go
@@ -17,8 +17,6 @@
 package cache
 
 import (
-	"bytes"
-
 	"github.com/erigontech/erigon/db/kv"
 )
 
@@ -277,8 +275,11 @@ func (v ReadView) Fill(domain kv.Domain, key []byte, value []byte, readTxNum uin
 	v.c.fillIfFresh(domain, key, value, readTxNum, visibleEnd, v.readViewEpoch)
 }
 
+// FillCode takes ownership of code: the caller must not reuse or mutate it.
+// Read it with GetLatestOptions.WithOwnedValue so the copy happens once, at the
+// read, rather than here on a value the caller also keeps.
 func (v ReadView) FillCode(addr, code, codeHash []byte, readTxNum uint64) {
-	v.fillCodeWithHash(addr, bytes.Clone(code), codeHash, readTxNum)
+	v.fillCodeWithHash(addr, code, codeHash, readTxNum)
 }
 
 // SeedAddrCodeHash offers an addr → codeHash mapping derived from an account


### PR DESCRIPTION
Alternative to #23798 — same win, without lending a buffer through the read path.

Facts in `main`:
- `FillCode` does `bytes.Clone` before storing, because the `lru` outlives the `tx`.
- `seg.Getter.Next(nil)` has already allocated a fresh buffer to decode the value into.

So a cold code read allocates twice for one value, and the first allocation is discarded.

`CodeDomain` is the only domain where this happens: it alone sets `Compression: seg.CompressVals`, so every other domain hands back a slice of the mapped file and allocates nothing.

Instead of lending a buffer down (#23798), the reader is asked for a value the caller may keep: `GetLatestOptions.WithOwnedValue()`. Only `DomainRoTx.getLatest` acts on it, because that is the one place that knows where the value came from — a file value is already a fresh allocation, a db value points into tx pages and is copied there. `FillCode` then stores what it is given and the second clone is gone.

The ownership decision therefore stays at the boundary and never reaches `btindex`, `seg`, or any caller that does not care.

| | #23798 | this |
|---|---|---|
| diff | 75 insertions, 17 files | 27 insertions, 4 files |
| signatures changed | 5 (+ `nil` at every caller) | 0 |
| new API | `WithBuf`, `codeBuf`, `maxLentCodeBuf`, resize heuristic | `WithOwnedValue` |
| `Fill` / `FillCode` asymmetry | `FillCode` returns `[]byte` | unchanged |

Benchmarks pending; #23798 measured +15.5%/+16.9%/+24.9%/+24.4% MGas/s and −1.2 to −4.5 GB peak on the four gd8 `code_size` fixtures, and this removes the same allocation.