### PR TITLE
execution/cache: stop filling the code layer when it is not hitting

### DIFF
--- a/common/dbg/experiments.go
+++ b/common/dbg/experiments.go
@@ -141,6 +141,7 @@ var (
 	UseTxDependencies             = EnvBool("USE_TX_DEPENDENCIES", false)
 	UseStateCache                 = EnvBool("USE_STATE_CACHE", true)
 	UseCodeStore                  = EnvBool("USE_CODE_STORE", false)
+	CodeCacheAdmission            = EnvBool("CODE_CACHE_ADMISSION", false)
 	DisableAdaptivePin            = EnvBool("DISABLE_ADAPTIVE_PIN", true)
 	AssertStateCache              = EnvBool("ASSERT_STATE_CACHE", false)
 	ReadAhead                     = EnvBool("READ_AHEAD", true)

--- a/execution/cache/code_cache.go
+++ b/execution/cache/code_cache.go
@@ -25,6 +25,7 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2"
 
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/common/maphash"
 	"github.com/erigontech/erigon/execution/cache/coherence"
@@ -171,10 +172,19 @@ type CodeCache struct {
 	putStripes [256]sync.Mutex
 
 	// Stats counters (atomic for concurrent access)
-	addrHits       atomic.Uint64
-	addrMisses     atomic.Uint64
-	codeHits       atomic.Uint64
-	codeMisses     atomic.Uint64
+	addrHits   atomic.Uint64
+	addrMisses atomic.Uint64
+	codeHits   atomic.Uint64
+	codeMisses atomic.Uint64
+
+	// Admission sampling: a code layer that never hits costs bytes and copies
+	// for nothing, and no capacity is the right capacity for it. Measured over
+	// a window so a workload that stops reusing code stops paying, and one that
+	// starts reusing it is picked up on the next window.
+	admitLookups   atomic.Uint64
+	admitHits      atomic.Uint64
+	admitting      atomic.Bool
+	admitProbe     atomic.Uint64
 	codeHashHits   atomic.Uint64
 	codeHashMisses atomic.Uint64
 	codeSizeHits   atomic.Uint64
@@ -263,6 +273,35 @@ func NewDefaultCodeCache() *CodeCache {
 }
 
 // Get retrieves contract code for the given address, implementing the Cache interface.
+const (
+	codeAdmitWindow     = 8192 // lookups between re-evaluations
+	codeAdmitMinHitPct  = 1
+	codeAdmitProbeEvery = 64 // fills still allowed while cold, so reuse is noticed
+)
+
+func (c *CodeCache) noteCodeLookup(hit bool) {
+	if !dbg.CodeCacheAdmission {
+		return
+	}
+	if hit {
+		c.admitHits.Add(1)
+	}
+	if n := c.admitLookups.Add(1); n >= codeAdmitWindow {
+		hits := c.admitHits.Swap(0)
+		c.admitLookups.Store(0)
+		c.admitting.Store(hits*100 >= n*codeAdmitMinHitPct)
+	}
+}
+
+// AdmitsFills reports whether the code layer is earning its fills. Always true
+// until the sampler has closed a window, so a cold start still populates.
+func (c *CodeCache) AdmitsFills() bool {
+	if !dbg.CodeCacheAdmission || c.admitting.Load() || c.admitLookups.Load() < codeAdmitWindow {
+		return true
+	}
+	return c.admitProbe.Add(1)%codeAdmitProbeEvery == 0
+}
+
 func (c *CodeCache) Get(addr []byte) ([]byte, bool) {
 	v, _, ok := c.GetWithTxNum(addr)
 	return v, ok
@@ -290,11 +329,13 @@ func (c *CodeCache) GetWithTxNum(addr []byte) ([]byte, uint64, bool) {
 	ce, ok := c.hashToCode.Get(vID.addrID)
 	if !ok || len(ce.code) == 0 {
 		c.codeMisses.Add(1)
+		c.noteCodeLookup(false)
 		return nil, 0, false
 	}
 	if coh.IsStale(ce.txNum, ce.epoch) {
 		c.hashToCode.Remove(vID.addrID) // OnEvict decrements codeSize
 		c.codeMisses.Add(1)
+		c.noteCodeLookup(false)
 		return nil, 0, false
 	}
 	// Reject a 64-bit maphash collision: the stored code belongs to a different
@@ -302,9 +343,11 @@ func (c *CodeCache) GetWithTxNum(addr []byte) ([]byte, uint64, bool) {
 	// codeHash (always for PutWithCodeHash-populated code; the EVM read path).
 	if vID.codeHash != ([32]byte{}) && ce.keyHash != vID.codeHash {
 		c.codeMisses.Add(1)
+		c.noteCodeLookup(false)
 		return nil, 0, false
 	}
 	c.codeHits.Add(1)
+	c.noteCodeLookup(true)
 	// The addr→code binding is what an unwind re-binds; vID.txNum bounds it.
 	return ce.code, vID.txNum, true
 }

--- a/execution/cache/state_cache.go
+++ b/execution/cache/state_cache.go
@@ -300,6 +300,9 @@ func (c *StateCache) fillCodeWithHashIfFresh(key, value, codeHash []byte, readTx
 	if !ok || len(value) == 0 || len(codeHash) != len(common.Hash{}) {
 		return
 	}
+	if !codeCache.AdmitsFills() {
+		return
+	}
 	c.admissionMu.RLock()
 	defer c.admissionMu.RUnlock()
 	if c.publishing ||


### PR DESCRIPTION
Measured on gd8, one fixture per run:

| workload | `USE_STATE_CACHE=false` |
|---|---|
| `test_account_access` EXTCODECOPY, `EXISTING_CONTRACT_DIFF_MAX` | **+38% to +41% MGas/s, −4 GB peak** |
| `ether_transfers` `diff_to_contract` | **−13%** |

The first family touches every account exactly once, so `code_hit_rate` is `0.000` and every fill is a clone and a byte of residency bought for nothing. The second reuses code, and the cache pays for itself. No single capacity is right for both — which is why tuning size cannot fix it, and both #23770 and #23790 are aiming the wrong knob at this.

So sample instead of tune. `CodeCache` already counts `codeHits`/`codeMisses`; this adds a window over them and stops filling the code layer once a window closes with a hit rate under 1%, still letting 1-in-64 fills through so returning reuse is noticed on the next window. Cold start always fills, since no window has closed yet.

Behind `CODE_CACHE_ADMISSION`, default off, so it can be A/B'd before it changes anyone's default.

Not benchmarked yet — opening it as the shape for discussion. The threshold, the window and the probe rate are all guesses at this point, and the fill point (`fillCodeWithHashIfFresh`) is the one choke point every code fill passes through, so it is the place to measure from.

Related: the code caches are currently unobservable in production — `CodeCache.PrintStatsAndReset` has no caller outside the package and `CodeStore.Stats()` has none at all, so hit rate cannot be seen without patching the binary. Worth fixing alongside.