### PR TITLE
db: enable errcheck across db/*

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -125,25 +125,7 @@ linters:
       - linters:
           - errcheck
         path: "^(\
-          db/datadir\
-          |db/datadir/reset\
-          |db/datastruct/btindex\
-          |db/datastruct/fusefilter\
-          |db/downloader\
-          |db/downloader/webseeds\
-          |db/etl\
-          |db/kv/kvcache\
-          |db/kv/mdbx\
-          |db/kv/mdbx/mdbxtest\
-          |db/kv/membatchwithdb\
-          |db/rawdb\
-          |db/recsplit\
-          |db/recsplit/eliasfano32\
-          |db/seg\
-          |db/snapshotsync\
-          |db/snapshotsync/freezeblocks\
-          |db/test\
-          |diagnostics/diaglib\
+          diagnostics/diaglib\
           |diagnostics/diskutils\
           |execution/commitment\
           |execution/commitment/trie\

--- a/db/datadir/dirs.go
+++ b/db/datadir/dirs.go
@@ -246,7 +246,7 @@ func ApplyMigrations(dirs Dirs) error { //nolint
 	if !locked {
 		return nil
 	}
-	defer lock.Unlock()
+	defer func() { panicif.Err(lock.Unlock()) }()
 
 	// add your migration here
 

--- a/db/datadir/reset/reset_test.go
+++ b/db/datadir/reset/reset_test.go
@@ -393,7 +393,8 @@ func makeEntries(t *testing.T, entries []fsEntry, root *os.Root) {
 	for _, entry := range entries {
 		localName, err := filepath.Localize(string(entry.Name))
 		qt.Assert(t, qt.IsNil(err), qt.Commentf("localizing entry name %q", entry.Name))
-		root.MkdirAll(filepath.Dir(localName), dir.DirPerm)
+		err = root.MkdirAll(filepath.Dir(localName), dir.DirPerm)
+		qt.Assert(t, qt.IsNil(err), qt.Commentf("mkdir for entry %q", entry.Name))
 		switch {
 		case entry.Mode&fs.ModeSymlink != 0:
 			// Windows doesn't seem to create SYMLINKD types when going through os.Root. So we do

--- a/db/datastruct/btindex/bps_tree.go
+++ b/db/datastruct/btindex/bps_tree.go
@@ -371,9 +371,9 @@ func (b *BpsTree) Seek(g *seg.Reader, seekKey []byte) (cur *Cursor, err error) {
 		if r-l <= DefaultBtreeStartSkip { // found small range, faster to scan now
 			// m = l
 			if cur.d == 0 {
-				// l stays within [0, offt.Count()) by the binary-search invariant above,
-				// so the only failure resetNoRead can report (an out-of-bounds index) can't occur here.
-				_ = cur.resetNoRead(l, g)
+				if err := cur.resetNoRead(l, g); err != nil {
+					return nil, err
+				}
 			} else {
 				cur.nextNoRead()
 			}

--- a/db/datastruct/btindex/bps_tree.go
+++ b/db/datastruct/btindex/bps_tree.go
@@ -342,7 +342,9 @@ func (b *BpsTree) Seek(g *seg.Reader, seekKey []byte) (cur *Cursor, err error) {
 	}
 	cur = b.cursorGetter(nil, nil, 0, g)
 	if len(seekKey) == 0 && b.offt.Count() > 0 {
-		cur.Reset(0, g)
+		if err := cur.Reset(0, g); err != nil {
+			return nil, err
+		}
 		return cur, nil
 	}
 
@@ -369,7 +371,9 @@ func (b *BpsTree) Seek(g *seg.Reader, seekKey []byte) (cur *Cursor, err error) {
 		if r-l <= DefaultBtreeStartSkip { // found small range, faster to scan now
 			// m = l
 			if cur.d == 0 {
-				cur.resetNoRead(l, g)
+				// l stays within [0, offt.Count()) by the binary-search invariant above,
+				// so the only failure resetNoRead can report (an out-of-bounds index) can't occur here.
+				_ = cur.resetNoRead(l, g)
 			} else {
 				cur.nextNoRead()
 			}

--- a/db/datastruct/btindex/btree_index.go
+++ b/db/datastruct/btindex/btree_index.go
@@ -135,8 +135,8 @@ func (c *Cursor) next() bool {
 }
 
 func (c *Cursor) resetNoRead(di uint64, g *seg.Reader) error {
-	if c.d >= c.ef.Count() {
-		return fmt.Errorf("%w %d/%d", ErrBtIndexLookupBounds, c.d, c.ef.Count())
+	if di >= c.ef.Count() {
+		return fmt.Errorf("%w %d/%d", ErrBtIndexLookupBounds, di, c.ef.Count())
 	}
 
 	c.d = di

--- a/db/datastruct/btindex/btree_index_test.go
+++ b/db/datastruct/btindex/btree_index_test.go
@@ -533,7 +533,7 @@ func Test_BtreeIndex_Seek2(t *testing.T) {
 
 		k, v, _, err := bt.dataLookup(0, getter)
 		require.NoError(t, err)
-		cur.Reset(0, getter)
+		require.NoError(t, cur.Reset(0, getter))
 
 		require.Equal(t, k, cur.Key())
 		require.Equal(t, v, cur.Value())

--- a/db/datastruct/fusefilter/fusefilter_writer.go
+++ b/db/datastruct/fusefilter/fusefilter_writer.go
@@ -48,7 +48,7 @@ func NewWriterOffHeap(filePath string) (*WriterOffHeap, error) {
 func (w *WriterOffHeap) Close() {
 	if w.tmpFile != nil {
 		w.tmpFile.Close()
-		dir.RemoveFile(w.tmpFilePath)
+		_ = dir.RemoveFile(w.tmpFilePath)
 		w.tmpFile = nil
 	}
 }
@@ -59,7 +59,7 @@ func (w *WriterOffHeap) build() (*xorfilter.BinaryFuse[uint8], error) {
 			w.tmpFile.Close()
 			w.tmpFile = nil
 		}
-		dir.RemoveFile(w.tmpFilePath)
+		_ = dir.RemoveFile(w.tmpFilePath)
 	}()
 	if w.count%bufSize != 0 {
 		if _, err := w.tmpFile.Write(castToBytes(w.buf[:w.count%bufSize])); err != nil {
@@ -76,7 +76,7 @@ func (w *WriterOffHeap) build() (*xorfilter.BinaryFuse[uint8], error) {
 	if err != nil {
 		return nil, fmt.Errorf("%s %w", w.tmpFilePath, err)
 	}
-	defer m.Unmap()
+	defer func() { _ = m.Unmap() }()
 	_ = mmap.MadviseSequential(m) // the whole temp file is read front-to-back below
 
 	keysHashes := castToArrU64(m[:sz])
@@ -167,7 +167,7 @@ func (w *Writer) Build() error {
 	if err != nil {
 		return fmt.Errorf("%s %w", w.filePath, err)
 	}
-	defer dir.RemoveFile(f.Name())
+	defer func() { _ = dir.RemoveFile(f.Name()) }()
 	defer f.Close()
 
 	fw := bufio.NewWriter(f)
@@ -229,7 +229,7 @@ func (w *WriterSharded) Build() error {
 	if err != nil {
 		return fmt.Errorf("%s %w", w.filePath, err)
 	}
-	defer dir.RemoveFile(f.Name())
+	defer func() { _ = dir.RemoveFile(f.Name()) }()
 	defer f.Close()
 
 	fw := bufio.NewWriter(f)
@@ -259,7 +259,7 @@ func (w *WriterSharded) BuildTo(fw io.Writer) (int, error) {
 			w.tmpFile.Close()
 			w.tmpFile = nil
 		}
-		dir.RemoveFile(w.tmpFilePath)
+		_ = dir.RemoveFile(w.tmpFilePath)
 	}()
 
 	if rem := w.count % bufSize; rem != 0 {
@@ -281,7 +281,7 @@ func (w *WriterSharded) BuildTo(fw io.Writer) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("%s %w", w.tmpFilePath, err)
 	}
-	defer m.Unmap()
+	defer func() { _ = m.Unmap() }()
 
 	all := castToArrU64(m[:sz])
 	slices.Sort(all) // ascending sort groups hashes by top byte = shard index

--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -1794,14 +1794,14 @@ func (d *Downloader) HandleTorrentClientStatus(debugMux *http.ServeMux) {
 		d.log(log.LvlDebug, "compressed torrent client status", "size", buf.Len(), "Accept-Encoding", h)
 		if strings.Contains(h, "gzip") {
 			w.Header().Set("Content-Encoding", "gzip")
-			w.Write(buf.Bytes())
+			_, _ = w.Write(buf.Bytes())
 		} else {
 			gzR, err := gzip.NewReader(&buf)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
-			io.Copy(w, gzR)
+			_, _ = io.Copy(w, gzR)
 			gzR.Close()
 		}
 	})

--- a/db/downloader/downloader_test.go
+++ b/db/downloader/downloader_test.go
@@ -69,7 +69,7 @@ func TestConcurrentDownload(t *testing.T) {
 	test.downloader.Close()
 	for w := range waits {
 		// Make sure we don't get stuck. The torrents shouldn't exist, and the Downloader is closed.
-		w(t.Context())
+		_ = w(t.Context())
 	}
 }
 
@@ -214,7 +214,7 @@ func TestVerifyData(t *testing.T) {
 	}
 	require := require.New(t)
 	test := newDownloaderTest(t)
-	os.WriteFile(filepath.Join(test.dirs.Snap, "a"), nil, 0o644)
+	require.NoError(os.WriteFile(filepath.Join(test.dirs.Snap, "a"), nil, 0o644))
 	err := test.downloader.AddNewSeedableFile(t.Context(), "a")
 	require.NoError(err)
 	err = test.downloader.VerifyData(test.downloader.ctx, nil, false)
@@ -1174,8 +1174,8 @@ func TestEndIsIdempotent(t *testing.T) {
 	_, batch.cancel = context.WithCancelCause(d.ctx)
 	batch.seedCtx, batch.seedCancel = context.WithCancelCause(d.ctx)
 
-	batch.end(t.Context(), errors.New("first end"))
-	batch.end(t.Context(), errors.New("second end"))
+	_ = batch.end(t.Context(), errors.New("first end"))
+	_ = batch.end(t.Context(), errors.New("second end"))
 
 	d.activeDownloadRequestsLock.Lock()
 	defer d.activeDownloadRequestsLock.Unlock()

--- a/db/downloader/webseeds/verify.go
+++ b/db/downloader/webseeds/verify.go
@@ -63,8 +63,7 @@ func Verify(
 	}
 	g.MakeMapWithCap(&checker.state, len(chains))
 	defer func() {
-		// Result is redundant here: either err is already set (an early return, which
-		// takes priority over anything items reports) or line 100 already captured it.
+		// The early-return err takes priority; the normal path already returns items.Wait().
 		_ = items.Wait()
 		// Strict evaluation for the win.
 		err = cmp.Or(err, json.NewEncoder(os.Stdout).Encode(checker.state))

--- a/db/downloader/webseeds/verify.go
+++ b/db/downloader/webseeds/verify.go
@@ -63,7 +63,9 @@ func Verify(
 	}
 	g.MakeMapWithCap(&checker.state, len(chains))
 	defer func() {
-		items.Wait()
+		// Result is redundant here: either err is already set (an early return, which
+		// takes priority over anything items reports) or line 100 already captured it.
+		_ = items.Wait()
 		// Strict evaluation for the win.
 		err = cmp.Or(err, json.NewEncoder(os.Stdout).Encode(checker.state))
 		logger.Info("finished check",

--- a/db/etl/dataprovider.go
+++ b/db/etl/dataprovider.go
@@ -204,8 +204,6 @@ func (p *fileDataProvider) Wait() error { return p.wg.Wait() }
 func (p *fileDataProvider) Dispose() {
 	// Wait first: the async flush assigns p.file from its own goroutine, so
 	// reading it before joining both races and can leak a file created after.
-	// The error itself is already surfaced by mergeSortFiles before any provider
-	// reaches Dispose, and Wait is safe to call again (errgroup caches the result).
 	_ = p.Wait()
 	if p.file == nil {
 		return

--- a/db/etl/dataprovider.go
+++ b/db/etl/dataprovider.go
@@ -204,7 +204,9 @@ func (p *fileDataProvider) Wait() error { return p.wg.Wait() }
 func (p *fileDataProvider) Dispose() {
 	// Wait first: the async flush assigns p.file from its own goroutine, so
 	// reading it before joining both races and can leak a file created after.
-	p.Wait()
+	// The error itself is already surfaced by mergeSortFiles before any provider
+	// reaches Dispose, and Wait is safe to call again (errgroup caches the result).
+	_ = p.Wait()
 	if p.file == nil {
 		return
 	}

--- a/db/etl/etl_bench_test.go
+++ b/db/etl/etl_bench_test.go
@@ -59,7 +59,7 @@ func BenchmarkFileDataProviderNext(b *testing.B) {
 
 				b.StopTimer()
 				provider.Dispose()
-				dir.RemoveAll(tmpdir)
+				_ = dir.RemoveAll(tmpdir)
 				b.StartTimer()
 			}
 		})

--- a/db/etl/etl_test.go
+++ b/db/etl/etl_test.go
@@ -1084,7 +1084,7 @@ func TestVmtouchMmap(t *testing.T) {
 		cmd := exec.Command("vmtouch", "-v", fname) //nolint:noctx
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
-		cmd.Run()
+		_ = cmd.Run()
 	}
 
 	vmtouch("BEFORE first Next()")
@@ -1098,19 +1098,19 @@ func TestVmtouchMmap(t *testing.T) {
 
 	// Read 25%
 	for range n/4 - 1 {
-		provider.Next()
+		_, _, _ = provider.Next()
 	}
 	vmtouch("AFTER 25%")
 
 	// Read to 50%
 	for range n / 4 {
-		provider.Next()
+		_, _, _ = provider.Next()
 	}
 	vmtouch("AFTER 50%")
 
 	// Read to 75%
 	for range n / 4 {
-		provider.Next()
+		_, _, _ = provider.Next()
 	}
 	vmtouch("AFTER 75%")
 

--- a/db/etl/read_bench_test.go
+++ b/db/etl/read_bench_test.go
@@ -90,14 +90,24 @@ func createTestFileU16(b *testing.B, tmpdir string, keySize, valSize, fileSize i
 	written := 0
 	for written < fileSize {
 		*(*uint16)(unsafe.Pointer(&lenBuf[0])) = uint16(keySize)
-		w.Write(lenBuf[:])
-		w.Write(key)
+		if _, err := w.Write(lenBuf[:]); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := w.Write(key); err != nil {
+			b.Fatal(err)
+		}
 		*(*uint16)(unsafe.Pointer(&lenBuf[0])) = uint16(valSize)
-		w.Write(lenBuf[:])
-		w.Write(val)
+		if _, err := w.Write(lenBuf[:]); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := w.Write(val); err != nil {
+			b.Fatal(err)
+		}
 		written += 2 + keySize + 2 + valSize
 	}
-	w.Flush()
+	if err := w.Flush(); err != nil {
+		b.Fatal(err)
+	}
 	f.Close()
 	return f.Name()
 }
@@ -119,14 +129,24 @@ func createTestFileU32(b *testing.B, tmpdir string, keySize, valSize, fileSize i
 	written := 0
 	for written < fileSize {
 		*(*uint32)(unsafe.Pointer(&lenBuf[0])) = uint32(keySize)
-		w.Write(lenBuf[:])
-		w.Write(key)
+		if _, err := w.Write(lenBuf[:]); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := w.Write(key); err != nil {
+			b.Fatal(err)
+		}
 		*(*uint32)(unsafe.Pointer(&lenBuf[0])) = uint32(valSize)
-		w.Write(lenBuf[:])
-		w.Write(val)
+		if _, err := w.Write(lenBuf[:]); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := w.Write(val); err != nil {
+			b.Fatal(err)
+		}
 		written += 4 + keySize + 4 + valSize
 	}
-	w.Flush()
+	if err := w.Flush(); err != nil {
+		b.Fatal(err)
+	}
 	f.Close()
 	return f.Name()
 }

--- a/db/etl/read_bench_test.go
+++ b/db/etl/read_bench_test.go
@@ -90,19 +90,11 @@ func createTestFileU16(b *testing.B, tmpdir string, keySize, valSize, fileSize i
 	written := 0
 	for written < fileSize {
 		*(*uint16)(unsafe.Pointer(&lenBuf[0])) = uint16(keySize)
-		if _, err := w.Write(lenBuf[:]); err != nil {
-			b.Fatal(err)
-		}
-		if _, err := w.Write(key); err != nil {
-			b.Fatal(err)
-		}
+		_, _ = w.Write(lenBuf[:])
+		_, _ = w.Write(key)
 		*(*uint16)(unsafe.Pointer(&lenBuf[0])) = uint16(valSize)
-		if _, err := w.Write(lenBuf[:]); err != nil {
-			b.Fatal(err)
-		}
-		if _, err := w.Write(val); err != nil {
-			b.Fatal(err)
-		}
+		_, _ = w.Write(lenBuf[:])
+		_, _ = w.Write(val)
 		written += 2 + keySize + 2 + valSize
 	}
 	if err := w.Flush(); err != nil {
@@ -129,19 +121,11 @@ func createTestFileU32(b *testing.B, tmpdir string, keySize, valSize, fileSize i
 	written := 0
 	for written < fileSize {
 		*(*uint32)(unsafe.Pointer(&lenBuf[0])) = uint32(keySize)
-		if _, err := w.Write(lenBuf[:]); err != nil {
-			b.Fatal(err)
-		}
-		if _, err := w.Write(key); err != nil {
-			b.Fatal(err)
-		}
+		_, _ = w.Write(lenBuf[:])
+		_, _ = w.Write(key)
 		*(*uint32)(unsafe.Pointer(&lenBuf[0])) = uint32(valSize)
-		if _, err := w.Write(lenBuf[:]); err != nil {
-			b.Fatal(err)
-		}
-		if _, err := w.Write(val); err != nil {
-			b.Fatal(err)
-		}
+		_, _ = w.Write(lenBuf[:])
+		_, _ = w.Write(val)
 		written += 4 + keySize + 4 + valSize
 	}
 	if err := w.Flush(); err != nil {

--- a/db/kv/kvcache/cache_test.go
+++ b/db/kv/kvcache/cache_test.go
@@ -497,7 +497,7 @@ func TestOnNewBlockCodeHashKey(t *testing.T) {
 	require.Len(elems, 1)
 
 	h := keccak.NewFastKeccak()
-	h.Write(code)
+	_, _ = h.Write(code)
 	expectedKey := h.Sum(nil)
 
 	require.Equal(expectedKey, elems[0].K)

--- a/db/kv/mdbx/kv_mdbx_test.go
+++ b/db/kv/mdbx/kv_mdbx_test.go
@@ -113,7 +113,8 @@ func iteration(t *testing.T, c kv.RwCursorDupSort, start []byte, val []byte) ([]
 		i += 1
 	}
 	for ind := i; ind > 1; ind-- {
-		c.Prev()
+		_, _, err = c.Prev()
+		require.NoError(t, err)
 	}
 
 	return keys, values

--- a/db/kv/mdbx/mdbxtest/mdbxtest.go
+++ b/db/kv/mdbx/mdbxtest/mdbxtest.go
@@ -67,7 +67,7 @@ func NewTestDB(tb testing.TB, label kv.Label) kv.RwDB {
 	if err != nil {
 		tb.Fatal(err)
 	}
-	tb.Cleanup(func() { dir.RemoveAll(dirname) })
+	tb.Cleanup(func() { _ = dir.RemoveAll(dirname) })
 	db := New(tb, dirname, label)
 	tb.Cleanup(func() { db.Close() })
 	return db

--- a/db/kv/membatchwithdb/memory_mutation_test.go
+++ b/db/kv/membatchwithdb/memory_mutation_test.go
@@ -33,17 +33,18 @@ import (
 	"github.com/erigontech/erigon/db/rawdb"
 )
 
-func initializeDbNonDupSort(rwTx kv.RwTx) {
-	rwTx.Put(kv.HeaderNumber, []byte("AAAA"), []byte("value"))
-	rwTx.Put(kv.HeaderNumber, []byte("CAAA"), []byte("value1"))
-	rwTx.Put(kv.HeaderNumber, []byte("CBAA"), []byte("value2"))
-	rwTx.Put(kv.HeaderNumber, []byte("CCAA"), []byte("value3"))
+func initializeDbNonDupSort(tb testing.TB, rwTx kv.RwTx) {
+	tb.Helper()
+	require.NoError(tb, rwTx.Put(kv.HeaderNumber, []byte("AAAA"), []byte("value")))
+	require.NoError(tb, rwTx.Put(kv.HeaderNumber, []byte("CAAA"), []byte("value1")))
+	require.NoError(tb, rwTx.Put(kv.HeaderNumber, []byte("CBAA"), []byte("value2")))
+	require.NoError(tb, rwTx.Put(kv.HeaderNumber, []byte("CCAA"), []byte("value3")))
 }
 
 func TestPutAppendHas(t *testing.T) {
 	_, rwTx := newTestTx(t)
 
-	initializeDbNonDupSort(rwTx)
+	initializeDbNonDupSort(t, rwTx)
 
 	batch, err := membatchwithdb.NewMemoryBatch(rwTx, "", log.Root())
 	require.NoError(t, err)
@@ -78,13 +79,13 @@ func TestPutAppendHas(t *testing.T) {
 func TestLastMiningDB(t *testing.T) {
 	_, rwTx := newTestTx(t)
 
-	initializeDbNonDupSort(rwTx)
+	initializeDbNonDupSort(t, rwTx)
 
 	batch, err := membatchwithdb.NewMemoryBatch(rwTx, "", log.Root())
 	require.NoError(t, err)
 	defer batch.Close()
-	batch.Put(kv.HeaderNumber, []byte("BAAA"), []byte("value4"))
-	batch.Put(kv.HeaderNumber, []byte("BCAA"), []byte("value5"))
+	require.NoError(t, batch.Put(kv.HeaderNumber, []byte("BAAA"), []byte("value4")))
+	require.NoError(t, batch.Put(kv.HeaderNumber, []byte("BCAA"), []byte("value5")))
 
 	cursor, err := batch.Cursor(kv.HeaderNumber)
 	require.NoError(t, err)
@@ -105,13 +106,13 @@ func TestLastMiningDB(t *testing.T) {
 func TestLastMiningMem(t *testing.T) {
 	_, rwTx := newTestTx(t)
 
-	initializeDbNonDupSort(rwTx)
+	initializeDbNonDupSort(t, rwTx)
 
 	batch, err := membatchwithdb.NewMemoryBatch(rwTx, "", log.Root())
 	require.NoError(t, err)
 	defer batch.Close()
-	batch.Put(kv.HeaderNumber, []byte("BAAA"), []byte("value4"))
-	batch.Put(kv.HeaderNumber, []byte("DCAA"), []byte("value5"))
+	require.NoError(t, batch.Put(kv.HeaderNumber, []byte("BAAA"), []byte("value4")))
+	require.NoError(t, batch.Put(kv.HeaderNumber, []byte("DCAA"), []byte("value5")))
 
 	cursor, err := batch.Cursor(kv.HeaderNumber)
 	require.NoError(t, err)
@@ -132,16 +133,16 @@ func TestLastMiningMem(t *testing.T) {
 func TestDeleteMining(t *testing.T) {
 	_, rwTx := newTestTx(t)
 
-	initializeDbNonDupSort(rwTx)
+	initializeDbNonDupSort(t, rwTx)
 	batch, err := membatchwithdb.NewMemoryBatch(rwTx, "", log.Root())
 	require.NoError(t, err)
 	defer batch.Close()
-	batch.Put(kv.HeaderNumber, []byte("BAAA"), []byte("value4"))
-	batch.Put(kv.HeaderNumber, []byte("DCAA"), []byte("value5"))
-	batch.Put(kv.HeaderNumber, []byte("FCAA"), []byte("value5"))
+	require.NoError(t, batch.Put(kv.HeaderNumber, []byte("BAAA"), []byte("value4")))
+	require.NoError(t, batch.Put(kv.HeaderNumber, []byte("DCAA"), []byte("value5")))
+	require.NoError(t, batch.Put(kv.HeaderNumber, []byte("FCAA"), []byte("value5")))
 
-	batch.Delete(kv.HeaderNumber, []byte("BAAA"))
-	batch.Delete(kv.HeaderNumber, []byte("CBAA"))
+	require.NoError(t, batch.Delete(kv.HeaderNumber, []byte("BAAA")))
+	require.NoError(t, batch.Delete(kv.HeaderNumber, []byte("CBAA")))
 
 	cursor, err := batch.Cursor(kv.HeaderNumber)
 	require.NoError(t, err)
@@ -161,13 +162,13 @@ func TestDeleteMining(t *testing.T) {
 func TestFlush(t *testing.T) {
 	_, rwTx := newTestTx(t)
 
-	initializeDbNonDupSort(rwTx)
+	initializeDbNonDupSort(t, rwTx)
 	batch, err := membatchwithdb.NewMemoryBatch(rwTx, "", log.Root())
 	require.NoError(t, err)
 	defer batch.Close()
-	batch.Put(kv.HeaderNumber, []byte("BAAA"), []byte("value4"))
-	batch.Put(kv.HeaderNumber, []byte("AAAA"), []byte("value5"))
-	batch.Put(kv.HeaderNumber, []byte("FCAA"), []byte("value5"))
+	require.NoError(t, batch.Put(kv.HeaderNumber, []byte("BAAA"), []byte("value4")))
+	require.NoError(t, batch.Put(kv.HeaderNumber, []byte("AAAA"), []byte("value5")))
+	require.NoError(t, batch.Put(kv.HeaderNumber, []byte("FCAA"), []byte("value5")))
 
 	require.NoError(t, batch.Flush(t.Context(), rwTx))
 
@@ -186,14 +187,14 @@ func TestFlush(t *testing.T) {
 func TestFlushAppendPath(t *testing.T) {
 	_, rwTx := newTestTx(t)
 
-	initializeDbNonDupSort(rwTx) // seeds AAAA..CCAA
+	initializeDbNonDupSort(t, rwTx) // seeds AAAA..CCAA
 	batch, err := membatchwithdb.NewMemoryBatch(rwTx, "", log.Root())
 	require.NoError(t, err)
 	defer batch.Close()
 	// All keys strictly greater than CCAA → Append path.
-	batch.Put(kv.HeaderNumber, []byte("DAAA"), []byte("v-d"))
-	batch.Put(kv.HeaderNumber, []byte("EAAA"), []byte("v-e"))
-	batch.Put(kv.HeaderNumber, []byte("FAAA"), []byte("v-f"))
+	require.NoError(t, batch.Put(kv.HeaderNumber, []byte("DAAA"), []byte("v-d")))
+	require.NoError(t, batch.Put(kv.HeaderNumber, []byte("EAAA"), []byte("v-e")))
+	require.NoError(t, batch.Put(kv.HeaderNumber, []byte("FAAA"), []byte("v-f")))
 
 	require.NoError(t, batch.Flush(t.Context(), rwTx))
 
@@ -216,8 +217,8 @@ func TestFlushEmptyDestinationPlain(t *testing.T) {
 	batch, err := membatchwithdb.NewMemoryBatch(rwTx, "", log.Root())
 	require.NoError(t, err)
 	defer batch.Close()
-	batch.Put(kv.HeaderNumber, []byte("AAAA"), []byte("v1"))
-	batch.Put(kv.HeaderNumber, []byte("BBBB"), []byte("v2"))
+	require.NoError(t, batch.Put(kv.HeaderNumber, []byte("AAAA"), []byte("v1")))
+	require.NoError(t, batch.Put(kv.HeaderNumber, []byte("BBBB"), []byte("v2")))
 
 	require.NoError(t, batch.Flush(t.Context(), rwTx))
 
@@ -236,7 +237,7 @@ func TestFlushEmptyDestinationPlain(t *testing.T) {
 func TestFlushDupsortNonEmptyDestination(t *testing.T) {
 	_, rwTx := newTestTx(t)
 
-	initializeDbDupSort(rwTx) // seeds key1=(1.1, 1.3), key3=(3.1, 3.3)
+	initializeDbDupSort(t, rwTx) // seeds key1=(1.1, 1.3), key3=(3.1, 3.3)
 
 	batch, err := membatchwithdb.NewMemoryBatch(rwTx, "", log.Root())
 	require.NoError(t, err)
@@ -290,12 +291,12 @@ func TestFlushEmptyDestinationDupsort(t *testing.T) {
 func TestForEach(t *testing.T) {
 	_, rwTx := newTestTx(t)
 
-	initializeDbNonDupSort(rwTx)
+	initializeDbNonDupSort(t, rwTx)
 
 	batch, err := membatchwithdb.NewMemoryBatch(rwTx, "", log.Root())
 	require.NoError(t, err)
 	defer batch.Close()
-	batch.Put(kv.HeaderNumber, []byte("FCAA"), []byte("value5"))
+	require.NoError(t, batch.Put(kv.HeaderNumber, []byte("FCAA"), []byte("value5")))
 	require.NoError(t, batch.Flush(t.Context(), rwTx))
 
 	var keys []string
@@ -347,7 +348,7 @@ func newTestTx(tb testing.TB) (kv.TemporalRwDB, kv.TemporalRwTx) {
 func TestPrefix(t *testing.T) {
 	_, rwTx := newTestTx(t)
 
-	initializeDbNonDupSort(rwTx)
+	initializeDbNonDupSort(t, rwTx)
 
 	kvs1, err := rwTx.Prefix(kv.HeaderNumber, []byte("AB"))
 	require.NoError(t, err)
@@ -386,7 +387,7 @@ func TestPrefix(t *testing.T) {
 func TestForAmount(t *testing.T) {
 	_, rwTx := newTestTx(t)
 
-	initializeDbNonDupSort(rwTx)
+	initializeDbNonDupSort(t, rwTx)
 
 	batch, err := membatchwithdb.NewMemoryBatch(rwTx, "", log.Root())
 	require.NoError(t, err)
@@ -420,7 +421,7 @@ func TestForAmount(t *testing.T) {
 func TestGetOneAfterClearBucket(t *testing.T) {
 	_, rwTx := newTestTx(t)
 
-	initializeDbNonDupSort(rwTx)
+	initializeDbNonDupSort(t, rwTx)
 
 	batch, err := membatchwithdb.NewMemoryBatch(rwTx, "", log.Root())
 	require.NoError(t, err)
@@ -441,7 +442,7 @@ func TestGetOneAfterClearBucket(t *testing.T) {
 func TestSeekExactAfterClearBucket(t *testing.T) {
 	_, rwTx := newTestTx(t)
 
-	initializeDbNonDupSort(rwTx)
+	initializeDbNonDupSort(t, rwTx)
 
 	batch, err := membatchwithdb.NewMemoryBatch(rwTx, "", log.Root())
 	require.NoError(t, err)
@@ -476,7 +477,7 @@ func TestSeekExactAfterClearBucket(t *testing.T) {
 func TestFirstAfterClearBucket(t *testing.T) {
 	_, rwTx := newTestTx(t)
 
-	initializeDbNonDupSort(rwTx)
+	initializeDbNonDupSort(t, rwTx)
 
 	batch, err := membatchwithdb.NewMemoryBatch(rwTx, "", log.Root())
 	require.NoError(t, err)
@@ -506,7 +507,7 @@ func TestFirstAfterClearBucket(t *testing.T) {
 func TestIncReadSequence(t *testing.T) {
 	_, rwTx := newTestTx(t)
 
-	initializeDbNonDupSort(rwTx)
+	initializeDbNonDupSort(t, rwTx)
 	require.NoError(t, rwTx.ResetSequence(kv.HeaderNumber, 7))
 
 	batch, err := membatchwithdb.NewMemoryBatch(rwTx, "", log.Root())
@@ -688,23 +689,24 @@ func TestMemoryMutationFlushDoesNotOverwriteUnchangedStateVersion(t *testing.T) 
 		"the overlay's explicit table writes must still be flushed")
 }
 
-func initializeDbDupSort(rwTx kv.RwTx) {
-	rwTx.Put(kv.TblAccountVals, []byte("key1"), []byte("value1.1"))
-	rwTx.Put(kv.TblAccountVals, []byte("key3"), []byte("value3.1"))
-	rwTx.Put(kv.TblAccountVals, []byte("key1"), []byte("value1.3"))
-	rwTx.Put(kv.TblAccountVals, []byte("key3"), []byte("value3.3"))
+func initializeDbDupSort(tb testing.TB, rwTx kv.RwTx) {
+	tb.Helper()
+	require.NoError(tb, rwTx.Put(kv.TblAccountVals, []byte("key1"), []byte("value1.1")))
+	require.NoError(tb, rwTx.Put(kv.TblAccountVals, []byte("key3"), []byte("value3.1")))
+	require.NoError(tb, rwTx.Put(kv.TblAccountVals, []byte("key1"), []byte("value1.3")))
+	require.NoError(tb, rwTx.Put(kv.TblAccountVals, []byte("key3"), []byte("value3.3")))
 }
 
 func TestNext(t *testing.T) {
 	_, rwTx := newTestTx(t)
 
-	initializeDbDupSort(rwTx)
+	initializeDbDupSort(t, rwTx)
 
 	batch, err := membatchwithdb.NewMemoryBatch(rwTx, "", log.Root())
 	require.NoError(t, err)
 	defer batch.Close()
 
-	batch.Put(kv.TblAccountVals, []byte("key1"), []byte("value1.2"))
+	require.NoError(t, batch.Put(kv.TblAccountVals, []byte("key1"), []byte("value1.2")))
 
 	cursor, err := batch.CursorDupSort(kv.TblAccountVals)
 	require.NoError(t, err)
@@ -744,14 +746,14 @@ func TestNext(t *testing.T) {
 func TestNextNoDup(t *testing.T) {
 	_, rwTx := newTestTx(t)
 
-	initializeDbDupSort(rwTx)
+	initializeDbDupSort(t, rwTx)
 
 	batch, err := membatchwithdb.NewMemoryBatch(rwTx, "", log.Root())
 	require.NoError(t, err)
 	defer batch.Close()
 
-	batch.Put(kv.TblAccountVals, []byte("key2"), []byte("value2.1"))
-	batch.Put(kv.TblAccountVals, []byte("key2"), []byte("value2.2"))
+	require.NoError(t, batch.Put(kv.TblAccountVals, []byte("key2"), []byte("value2.1")))
+	require.NoError(t, batch.Put(kv.TblAccountVals, []byte("key2"), []byte("value2.2")))
 
 	cursor, err := batch.CursorDupSort(kv.TblAccountVals)
 	require.NoError(t, err)
@@ -773,7 +775,7 @@ func TestNextNoDup(t *testing.T) {
 func TestDeleteCurrentDuplicates(t *testing.T) {
 	_, rwTx := newTestTx(t)
 
-	initializeDbDupSort(rwTx)
+	initializeDbDupSort(t, rwTx)
 
 	batch, err := membatchwithdb.NewMemoryBatch(rwTx, "", log.Root())
 	require.NoError(t, err)
@@ -809,8 +811,8 @@ func TestDeleteCurrentDuplicates(t *testing.T) {
 func TestSeekBothRange(t *testing.T) {
 	_, rwTx := newTestTx(t)
 
-	rwTx.Put(kv.TblAccountVals, []byte("key1"), []byte("value1.1"))
-	rwTx.Put(kv.TblAccountVals, []byte("key3"), []byte("value3.3"))
+	require.NoError(t, rwTx.Put(kv.TblAccountVals, []byte("key1"), []byte("value1.1")))
+	require.NoError(t, rwTx.Put(kv.TblAccountVals, []byte("key3"), []byte("value3.3")))
 
 	batch, err := membatchwithdb.NewMemoryBatch(rwTx, "", log.Root())
 	require.NoError(t, err)
@@ -833,20 +835,21 @@ func TestSeekBothRange(t *testing.T) {
 	require.Equal(t, "value3.3", string(v))
 }
 
-func initializeDbHeaders(rwTx kv.RwTx) {
-	rwTx.Put(kv.Headers, []byte("A"), []byte("0"))
-	rwTx.Put(kv.Headers, []byte("A..........................._______________________________A"), []byte("1"))
-	rwTx.Put(kv.Headers, []byte("A..........................._______________________________C"), []byte("2"))
-	rwTx.Put(kv.Headers, []byte("B"), []byte("8"))
-	rwTx.Put(kv.Headers, []byte("C"), []byte("9"))
-	rwTx.Put(kv.Headers, []byte("D..........................._______________________________A"), []byte("3"))
-	rwTx.Put(kv.Headers, []byte("D..........................._______________________________C"), []byte("4"))
+func initializeDbHeaders(tb testing.TB, rwTx kv.RwTx) {
+	tb.Helper()
+	require.NoError(tb, rwTx.Put(kv.Headers, []byte("A"), []byte("0")))
+	require.NoError(tb, rwTx.Put(kv.Headers, []byte("A..........................._______________________________A"), []byte("1")))
+	require.NoError(tb, rwTx.Put(kv.Headers, []byte("A..........................._______________________________C"), []byte("2")))
+	require.NoError(tb, rwTx.Put(kv.Headers, []byte("B"), []byte("8")))
+	require.NoError(tb, rwTx.Put(kv.Headers, []byte("C"), []byte("9")))
+	require.NoError(tb, rwTx.Put(kv.Headers, []byte("D..........................._______________________________A"), []byte("3")))
+	require.NoError(tb, rwTx.Put(kv.Headers, []byte("D..........................._______________________________C"), []byte("4")))
 }
 
 func TestGetOne(t *testing.T) {
 	_, rwTx := newTestTx(t)
 
-	initializeDbHeaders(rwTx)
+	initializeDbHeaders(t, rwTx)
 
 	require.NoError(t, rwTx.Put(kv.Headers, []byte("A..........................."), []byte("?")))
 

--- a/db/rawdb/accessors_chain.go
+++ b/db/rawdb/accessors_chain.go
@@ -24,6 +24,7 @@ import (
 	"container/heap"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -98,21 +99,18 @@ var (
 	bheapMu    sync.RWMutex
 )
 
-func GetLatestBadBlocks(tx kv.Tx) ([]*types.Block, error) {
-	bheapMu.RLock()
-	needsInit := bheapCache == nil
-	bheapMu.RUnlock()
+// ErrBadBlockCacheEmptyAfterReset is returned when a just-completed reset finds bheapCache nil
+// again by the time it re-reads it: a concurrent ResetBadBlockCache call raced in and cleared it
+// on its own failure first. Retrying (a fresh call) resolves it; it is not expected to recur.
+var ErrBadBlockCacheEmptyAfterReset = errors.New("bad block cache: reset reported success but cache is still empty")
 
-	if needsInit {
-		if err := ResetBadBlockCache(tx, 100); err != nil {
-			return nil, err
-		}
+func GetLatestBadBlocks(tx kv.Tx) ([]*types.Block, error) {
+	cache, err := latestBadBlockCache(tx)
+	if err != nil {
+		return nil, err
 	}
 
-	bheapMu.RLock()
-	blockIds := bheapCache.SortedValues()
-	bheapMu.RUnlock()
-
+	blockIds := cache.SortedValues()
 	blocks := make([]*types.Block, len(blockIds))
 	for i, blockId := range blockIds {
 		blocks[i] = ReadBlock(tx, blockId.Hash, blockId.Number)
@@ -121,24 +119,50 @@ func GetLatestBadBlocks(tx kv.Tx) ([]*types.Block, error) {
 	return blocks, nil
 }
 
+// latestBadBlockCache returns the loaded heap, initializing it first if needed.
+// The returned reference stays valid even if a concurrent ResetBadBlockCache
+// call later replaces or clears bheapCache.
+func latestBadBlockCache(tx kv.Tx) (utils.ExtendedHeap, error) {
+	bheapMu.RLock()
+	cache := bheapCache
+	bheapMu.RUnlock()
+	if cache != nil {
+		return cache, nil
+	}
+
+	if err := ResetBadBlockCache(tx, 100); err != nil {
+		return nil, err
+	}
+
+	bheapMu.RLock()
+	cache = bheapCache
+	bheapMu.RUnlock()
+	if cache == nil {
+		return nil, ErrBadBlockCacheEmptyAfterReset
+	}
+	return cache, nil
+}
+
 // mainly for testing purposes
 func ResetBadBlockCache(tx kv.Tx, limit int) error {
-	bheapMu.Lock()
-	bheapCache = utils.NewBlockMaxHeap(limit)
-	bheapMu.Unlock()
-	// load the heap
+	// Built privately so a concurrent GetLatestBadBlocks never observes a
+	// partially-loaded heap; bheapCache is only ever touched once, atomically,
+	// once the load has fully succeeded or failed.
+	newCache := utils.NewBlockMaxHeap(limit)
 	if err := tx.ForEach(kv.BadHeaderNumber, nil, func(blockHash, blockNumBytes []byte) error {
-		bheapMu.Lock()
-		heap.Push(bheapCache, &utils.BlockId{Number: binary.BigEndian.Uint64(blockNumBytes), Hash: common.BytesToHash(blockHash)})
-		bheapMu.Unlock()
+		heap.Push(newCache, &utils.BlockId{Number: binary.BigEndian.Uint64(blockNumBytes), Hash: common.BytesToHash(blockHash)})
 		return nil
 	}); err != nil {
-		// drop the half-filled heap, otherwise readers see it as loaded and get a truncated list
+		// drop the stale cache, otherwise a reader would see the old value as still fresh
 		bheapMu.Lock()
 		bheapCache = nil
 		bheapMu.Unlock()
 		return err
 	}
+
+	bheapMu.Lock()
+	bheapCache = newCache
+	bheapMu.Unlock()
 	return nil
 }
 

--- a/db/rawdb/accessors_chain.go
+++ b/db/rawdb/accessors_chain.go
@@ -127,12 +127,19 @@ func ResetBadBlockCache(tx kv.Tx, limit int) error {
 	bheapCache = utils.NewBlockMaxHeap(limit)
 	bheapMu.Unlock()
 	// load the heap
-	return tx.ForEach(kv.BadHeaderNumber, nil, func(blockHash, blockNumBytes []byte) error {
+	if err := tx.ForEach(kv.BadHeaderNumber, nil, func(blockHash, blockNumBytes []byte) error {
 		bheapMu.Lock()
 		heap.Push(bheapCache, &utils.BlockId{Number: binary.BigEndian.Uint64(blockNumBytes), Hash: common.BytesToHash(blockHash)})
 		bheapMu.Unlock()
 		return nil
-	})
+	}); err != nil {
+		// drop the half-filled heap, otherwise readers see it as loaded and get a truncated list
+		bheapMu.Lock()
+		bheapCache = nil
+		bheapMu.Unlock()
+		return err
+	}
+	return nil
 }
 
 /* latest bad blocks end */

--- a/db/rawdb/accessors_chain.go
+++ b/db/rawdb/accessors_chain.go
@@ -104,7 +104,9 @@ func GetLatestBadBlocks(tx kv.Tx) ([]*types.Block, error) {
 	bheapMu.RUnlock()
 
 	if needsInit {
-		ResetBadBlockCache(tx, 100)
+		if err := ResetBadBlockCache(tx, 100); err != nil {
+			return nil, err
+		}
 	}
 
 	bheapMu.RLock()

--- a/db/rawdb/accessors_chain.go
+++ b/db/rawdb/accessors_chain.go
@@ -110,7 +110,12 @@ func GetLatestBadBlocks(tx kv.Tx) ([]*types.Block, error) {
 		return nil, err
 	}
 
+	// cache is not immutable once published: TruncateCanonicalHash pushes into the
+	// live bheapCache under bheapMu.Lock(), so SortedValues' iteration over the
+	// heap's slice needs the same lock held to avoid racing that mutation.
+	bheapMu.RLock()
 	blockIds := cache.SortedValues()
+	bheapMu.RUnlock()
 	blocks := make([]*types.Block, len(blockIds))
 	for i, blockId := range blockIds {
 		blocks[i] = ReadBlock(tx, blockId.Hash, blockId.Number)

--- a/db/rawdb/accessors_chain_test.go
+++ b/db/rawdb/accessors_chain_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -1389,7 +1390,22 @@ func TestBadBlocks(t *testing.T) {
 	require.Len(badBlks, 2)
 	require.Equal(badBlks[0].Hash(), hash4)
 	require.Equal(badBlks[1].Hash(), hash3)
+
+	// a reset that fails mid-load must not leave a half-filled cache installed
+	require.Error(rawdb.ResetBadBlockCache(forEachErrTx{err: errors.New("read failed")}, 4))
+
+	badBlks, err = rawdb.GetLatestBadBlocks(tx)
+	require.NoError(err)
+	require.Len(badBlks, 4)
+	require.Equal(badBlks[0].Hash(), hash4)
 }
+
+type forEachErrTx struct {
+	kv.Tx
+	err error
+}
+
+func (t forEachErrTx) ForEach(string, []byte, func(k, v []byte) error) error { return t.err }
 
 func checkReceiptsRLP(have, want types.Receipts) error {
 	if len(have) != len(want) {

--- a/db/rawdb/accessors_chain_test.go
+++ b/db/rawdb/accessors_chain_test.go
@@ -389,7 +389,7 @@ func TestHeaderStorage(t *testing.T) {
 		t.Fatalf("Non existent header returned: %v", entry)
 	}
 	// Write and verify the header in the database
-	rawdb.WriteHeader(tx, header)
+	require.NoError(t, rawdb.WriteHeader(tx, header))
 	if entry, _ := br.Header(ctx, tx, header.Hash(), header.Number.Uint64()); entry == nil {
 		t.Fatalf("Stored header not found")
 	} else if entry.Hash() != header.Hash() {
@@ -399,7 +399,7 @@ func TestHeaderStorage(t *testing.T) {
 		t.Fatalf("Stored header RLP not found")
 	} else {
 		hasher := keccak.NewFastKeccak()
-		hasher.Write(entry)
+		_, _ = hasher.Write(entry)
 
 		if hash := common.BytesToHash(hasher.Sum(nil)); hash != header.Hash() {
 			t.Fatalf("Retrieved RLP header mismatch: have %v, want %v", entry, header)
@@ -471,7 +471,7 @@ func TestBodyStorage(t *testing.T) {
 			log.Error("ReadBodyRLP failed", "err", err)
 		}
 		hasher := keccak.NewFastKeccak()
-		hasher.Write(bodyRlp)
+		_, _ = hasher.Write(bodyRlp)
 
 		if calc := common.BytesToHash(hasher.Sum(nil)); calc != hash {
 			t.Fatalf("Retrieved RLP body mismatch: have %v, want %v", entry, body)
@@ -627,7 +627,9 @@ func TestPartialBlockStorage(t *testing.T) {
 	header := block.Header() // Not identical to struct literal above, due to other fields
 
 	// Store a header and check that it's not recognized as a block
-	rawdb.WriteHeader(tx, header)
+	if err := rawdb.WriteHeader(tx, header); err != nil {
+		t.Fatal(err)
+	}
 	if entry, _, _ := br.BlockWithSenders(ctx, tx, block.Hash(), block.NumberU64()); entry != nil {
 		t.Fatalf("Non existent block returned: %v", entry)
 	}
@@ -643,7 +645,9 @@ func TestPartialBlockStorage(t *testing.T) {
 	rawdb.DeleteBody(tx, block.Hash(), block.NumberU64())
 
 	// Store a header and a body separately and check reassembly
-	rawdb.WriteHeader(tx, header)
+	if err := rawdb.WriteHeader(tx, header); err != nil {
+		t.Fatal(err)
+	}
 	if err := rawdb.WriteBody(tx, block.Hash(), block.NumberU64(), block.Body()); err != nil {
 		t.Fatal(err)
 	}
@@ -768,7 +772,9 @@ func TestHeadStorage2(t *testing.T) {
 		t.Fatalf("Non head block entry returned: %v", entry)
 	}
 	// Assign separate entries for the head header and block
-	rawdb.WriteHeadHeaderHash(db, blockHead.Hash())
+	if err := rawdb.WriteHeadHeaderHash(db, blockHead.Hash()); err != nil {
+		t.Fatal(err)
+	}
 	rawdb.WriteHeadBlockHash(db, blockFull.Hash())
 
 	// Check that both heads are present, and different (i.e. two heads maintained)
@@ -795,7 +801,7 @@ func TestHeadStorage(t *testing.T) {
 	blockFull := types.NewBlockWithHeader(&types.Header{Extra: []byte("test block full"), Number: *common.Num1}, nil)
 
 	// Assign separate entries for the head header and block
-	rawdb.WriteHeadHeaderHash(tx, blockHead.Hash())
+	require.NoError(t, rawdb.WriteHeadHeaderHash(tx, blockHead.Hash()))
 	rawdb.WriteHeadBlockHash(tx, blockFull.Hash())
 
 	// Check that both heads are present, and different (i.e. two heads maintained)
@@ -1262,7 +1268,7 @@ func TestPreShanghaiBodyNoPanicOnWithdrawals(t *testing.T) {
 	bstring, _ := hex.DecodeString(bodyRlp)
 
 	body := new(types.Body)
-	rlp.DecodeBytes(bstring, body)
+	require.NoError(rlp.DecodeBytes(bstring, body))
 
 	require.Nil(body.Withdrawals)
 	require.Len(body.Transactions, 2)
@@ -1277,7 +1283,7 @@ func TestPreShanghaiBodyForStorageNoPanicOnWithdrawals(t *testing.T) {
 	bstring, _ := hex.DecodeString(bodyForStorageRlp)
 
 	body := new(types.BodyForStorage)
-	rlp.DecodeBytes(bstring, body)
+	require.NoError(rlp.DecodeBytes(bstring, body))
 
 	require.Nil(body.Withdrawals)
 	require.Equal(uint32(2), body.TxCount)
@@ -1292,7 +1298,7 @@ func TestShanghaiBodyForStorageHasWithdrawals(t *testing.T) {
 	bstring, _ := hex.DecodeString(bodyForStorageRlp)
 
 	body := new(types.BodyForStorage)
-	rlp.DecodeBytes(bstring, body)
+	require.NoError(rlp.DecodeBytes(bstring, body))
 
 	require.NotNil(body.Withdrawals)
 	require.Len(body.Withdrawals, 2)
@@ -1304,11 +1310,11 @@ func TestShanghaiBodyForStorageNoWithdrawals(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	const bodyForStorageRlp = "c48002c0c0c0"
+	const bodyForStorageRlp = "c48002c0c0"
 	bstring, _ := hex.DecodeString(bodyForStorageRlp)
 
 	body := new(types.BodyForStorage)
-	rlp.DecodeBytes(bstring, body)
+	require.NoError(rlp.DecodeBytes(bstring, body))
 
 	require.NotNil(body.Withdrawals)
 	require.Empty(body.Withdrawals)
@@ -1354,7 +1360,7 @@ func TestBadBlocks(t *testing.T) {
 
 		return header.Hash()
 	}
-	rawdb.ResetBadBlockCache(tx, 4)
+	require.NoError(rawdb.ResetBadBlockCache(tx, 4))
 
 	// put some blocks
 	for i := 1; i <= 6; i++ {
@@ -1377,7 +1383,7 @@ func TestBadBlocks(t *testing.T) {
 	require.Equal(badBlks[3].Hash(), hash1)
 
 	// testing the "limit"
-	rawdb.ResetBadBlockCache(tx, 2)
+	require.NoError(rawdb.ResetBadBlockCache(tx, 2))
 	badBlks, err = rawdb.GetLatestBadBlocks(tx)
 	require.NoError(err)
 	require.Len(badBlks, 2)

--- a/db/rawdb/accessors_chain_test.go
+++ b/db/rawdb/accessors_chain_test.go
@@ -22,10 +22,12 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 
 	keccak "github.com/erigontech/fastkeccak"
 	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common"
@@ -1406,6 +1408,61 @@ type forEachErrTx struct {
 }
 
 func (t forEachErrTx) ForEach(string, []byte, func(k, v []byte) error) error { return t.err }
+
+// TestGetLatestBadBlocksConcurrentWithFailingReset pins that GetLatestBadBlocks never
+// panics or blows up when ResetBadBlockCache runs concurrently, including resets that
+// fail mid-load and clear the shared cache out from under an in-flight reader.
+func TestGetLatestBadBlocksConcurrentWithFailingReset(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow test")
+	}
+	// Not t.Parallel(): bheapCache is a package-level global also touched by
+	// other tests (e.g. TestBadBlocks), which also run in parallel with each
+	// other. Running this one sequentially avoids cross-test interference on
+	// that shared state; the concurrency under test is the goroutines below.
+	m := execmoduletester.New(t)
+
+	rwTx, err := m.DB.BeginRw(m.Ctx)
+	require.NoError(t, err)
+	defer rwTx.Rollback()
+	require.NoError(t, rawdb.ResetBadBlockCache(rwTx, 4))
+	require.NoError(t, rwTx.Commit())
+
+	const iterations = 200
+	var wg sync.WaitGroup
+	for i := range iterations {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			roTx, err := m.DB.BeginRo(m.Ctx)
+			if err != nil {
+				return
+			}
+			defer roTx.Rollback()
+			// ErrBadBlockCacheEmptyAfterReset is the one expected outcome under this
+			// test's artificially dense failure injection (see ResetBadBlockCache's
+			// doc comment); anything else is a real failure.
+			_, err = rawdb.GetLatestBadBlocks(roTx)
+			if err != nil {
+				assert.ErrorIs(t, err, rawdb.ErrBadBlockCacheEmptyAfterReset)
+			}
+		}()
+		go func(i int) {
+			defer wg.Done()
+			if i%2 == 0 {
+				roTx, err := m.DB.BeginRo(m.Ctx)
+				if err != nil {
+					return
+				}
+				defer roTx.Rollback()
+				_ = rawdb.ResetBadBlockCache(roTx, 4)
+			} else {
+				_ = rawdb.ResetBadBlockCache(forEachErrTx{err: errors.New("boom")}, 4)
+			}
+		}(i)
+	}
+	wg.Wait()
+}
 
 func checkReceiptsRLP(have, want types.Receipts) error {
 	if len(have) != len(want) {

--- a/db/rawdb/accessors_chain_test.go
+++ b/db/rawdb/accessors_chain_test.go
@@ -1464,6 +1464,55 @@ func TestGetLatestBadBlocksConcurrentWithFailingReset(t *testing.T) {
 	wg.Wait()
 }
 
+// TestGetLatestBadBlocksConcurrentWithTruncateCanonicalHash pins that reading the bad-block
+// cache holds the same lock TruncateCanonicalHash uses to push into it in place, so SortedValues
+// never iterates the heap's backing slice while a concurrent truncate is mutating it.
+func TestGetLatestBadBlocksConcurrentWithTruncateCanonicalHash(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow test")
+	}
+	// Not t.Parallel(): see TestGetLatestBadBlocksConcurrentWithFailingReset.
+	m := execmoduletester.New(t)
+
+	const numCanonical = 50
+	setupTx, err := m.DB.BeginRw(m.Ctx)
+	require.NoError(t, err)
+	defer setupTx.Rollback()
+	for i := uint64(1); i <= numCanonical; i++ {
+		require.NoError(t, rawdb.WriteCanonicalHash(setupTx, common.Hash{byte(i)}, i))
+	}
+	require.NoError(t, rawdb.ResetBadBlockCache(setupTx, 100))
+	require.NoError(t, setupTx.Commit())
+
+	const iterations = 100
+	var wg sync.WaitGroup
+	for range iterations {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			roTx, err := m.DB.BeginRo(m.Ctx)
+			if err != nil {
+				return
+			}
+			defer roTx.Rollback()
+			_, err = rawdb.GetLatestBadBlocks(roTx)
+			assert.NoError(t, err)
+		}()
+		go func() {
+			defer wg.Done()
+			// Never committed, so the same numCanonical rows are still there for
+			// the next goroutine's truncate to push into the live heap again.
+			rwTx, err := m.DB.BeginRw(m.Ctx)
+			if err != nil {
+				return
+			}
+			defer rwTx.Rollback()
+			assert.NoError(t, rawdb.TruncateCanonicalHash(rwTx, 1, true))
+		}()
+	}
+	wg.Wait()
+}
+
 func checkReceiptsRLP(have, want types.Receipts) error {
 	if len(have) != len(want) {
 		return fmt.Errorf("receipts sizes mismatch: have %d, want %d", len(have), len(want))

--- a/db/recsplit/eliasfano32/elias_fano.go
+++ b/db/recsplit/eliasfano32/elias_fano.go
@@ -88,7 +88,7 @@ func (b *OffHeapBuilder) Close() {
 	if b.backingFile != nil {
 		name := b.backingFile.Name()
 		_ = b.backingFile.Close()
-		dir.RemoveFile(name)
+		_ = dir.RemoveFile(name)
 		b.backingFile = nil
 	}
 }
@@ -140,7 +140,7 @@ func NewEliasFanoOffHeap(count uint64, maxOffset uint64, tmpFilePath string) (_ 
 	defer func() {
 		if err != nil {
 			f.Close()
-			dir.RemoveFile(f.Name())
+			_ = dir.RemoveFile(f.Name())
 		}
 	}()
 	if err := fallocate(f, sizeBytes); err != nil {

--- a/db/recsplit/eliasfano32/rebased_elias_fano.go
+++ b/db/recsplit/eliasfano32/rebased_elias_fano.go
@@ -92,7 +92,7 @@ func (it *RebasedIterWrapper) Seek(v uint64) {
 		it.it.Seek(0)
 		if it.reverse {
 			// force exhaustion as we are seeking before the first elem
-			it.it.Next()
+			_, _ = it.it.Next()
 		}
 		return
 	}

--- a/db/recsplit/recsplit.go
+++ b/db/recsplit/recsplit.go
@@ -893,7 +893,9 @@ func (rs *RecSplit) buildOffsetEf() (retErr error) {
 	if err != nil {
 		return fmt.Errorf("mmap offset file: %w", err)
 	}
-	defer mmapHandle1.Unmap()
+	// Discarded, not folded into retErr: an Unmap failure here would trigger the
+	// retErr-triggered cleanup above and discard an offsetEf that finished building correctly.
+	defer func() { _ = mmapHandle1.Unmap() }()
 
 	data := mmapHandle1[:mmapSize]
 	for i := uint64(0); i < rs.keysAdded; i++ {

--- a/db/seg/multi_page_blocking_async_io_linux_test.go
+++ b/db/seg/multi_page_blocking_async_io_linux_test.go
@@ -106,7 +106,7 @@ func TestMultiPageBlockingAsyncIO(t *testing.T) {
 
 	mapping, err := mmap.OpenRo(file, len(payload))
 	require.NoError(t, err)
-	defer mapping.Unmap()
+	t.Cleanup(func() { require.NoError(t, mapping.Unmap()) })
 
 	region := mapping[:2*page]
 	require.NoError(t, unix.Madvise(mapping, unix.MADV_DONTNEED))

--- a/db/seg/multi_page_blocking_async_io_linux_test.go
+++ b/db/seg/multi_page_blocking_async_io_linux_test.go
@@ -106,7 +106,7 @@ func TestMultiPageBlockingAsyncIO(t *testing.T) {
 
 	mapping, err := mmap.OpenRo(file, len(payload))
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, mapping.Unmap()) })
+	defer func() { require.NoError(t, mapping.Unmap()) }()
 
 	region := mapping[:2*page]
 	require.NoError(t, unix.Madvise(mapping, unix.MADV_DONTNEED))

--- a/db/snapshotsync/freezeblocks/caplin_snapshots.go
+++ b/db/snapshotsync/freezeblocks/caplin_snapshots.go
@@ -320,7 +320,9 @@ func DumpBlobSidecarsRange(ctx context.Context, db kv.RoDB, storage blob_storage
 			}
 		}
 		if commitmentsCount == 0 {
-			sn.AddWord(nil)
+			if err := sn.AddWord(nil); err != nil {
+				return err
+			}
 			continue
 		}
 		sidecars, found, err := storage.ReadBlobSidecars(ctx, i, blockRoot)

--- a/db/snapshotsync/snapshots.go
+++ b/db/snapshotsync/snapshots.go
@@ -1888,7 +1888,8 @@ func (s *BaseRoSnapshots) buildMissedIndices(logPrefix string, ctx context.Conte
 
 	go func() {
 		defer close(finish)
-		g.Wait()
+		// g's task always returns nil; failures route through failedIndexes below.
+		_ = g.Wait()
 
 		fmu.Lock()
 		for fname, err := range failedIndexes {

--- a/db/snapshotsync/snapshots_test.go
+++ b/db/snapshotsync/snapshots_test.go
@@ -210,7 +210,7 @@ func TestMergeSnapshots(t *testing.T) {
 	{
 		merger := NewMerger(dir, 1, log.LvlInfo, nil, chainspec.Mainnet.Config, logger)
 		merger.DisableFsync()
-		s.OpenFolder()
+		require.NoError(s.OpenFolder())
 		Ranges := merger.FindMergeRanges(s.Ranges(false), s.SegmentsMax())
 		require.Empty(Ranges)
 		// doIndex=false, same rationale as above
@@ -586,7 +586,7 @@ func TestRemoveOverlaps(t *testing.T) {
 	require.Len(list, 60)
 
 	//corner case: small header.seg was removed, but header.idx left as garbage. such garbage must be cleaned.
-	dir2.RemoveFile(filepath.Join(s.Dir(), list[15].Name()))
+	require.NoError(dir2.RemoveFile(filepath.Join(s.Dir(), list[15].Name())))
 
 	require.NoError(s.OpenSegments(snaptype2.BlockSnapshotTypes, true))
 	require.NoError(s.RemoveOverlaps(func(delFiles []string) error {

--- a/db/test/domain_shared_bench_test.go
+++ b/db/test/domain_shared_bench_test.go
@@ -91,7 +91,7 @@ func Benchmark_SharedDomains_GetLatest(t *testing.B) {
 	keys := make([][]byte, 8)
 	for i := range keys {
 		keys[i] = make([]byte, length.Addr)
-		rnd.Read(keys[i])
+		_, _ = rnd.Read(keys[i])
 	}
 
 	var txNum, blockNum uint64
@@ -268,7 +268,7 @@ func generateRandomKey(r *rndGen, size uint64) string {
 
 func generateRandomKeyBytes(r *rndGen, size uint64) []byte {
 	key := make([]byte, size)
-	r.Read(key)
+	_, _ = r.Read(key)
 	return key
 }
 
@@ -304,7 +304,7 @@ func generateArbitraryValueUpdates(r *rndGen, totalTx, keyTxsLimit, maxSize uint
 		txNum := generateRandomTxNum(r, totalTx, usedTxNums)
 
 		value := make([]byte, r.IntN(int(maxSize)))
-		r.Read(value)
+		_, _ = r.Read(value)
 
 		updates = append(updates, upd{txNum: txNum, value: value})
 		usedTxNums[txNum] = true
@@ -430,7 +430,7 @@ func generateSharedDomainsUpdatesForBench(b *testing.B, domains *execctx.SharedD
 
 		case r > 33 && r <= 66:
 			codeUpd := make([]byte, rnd.IntN(24576))
-			rnd.Read(codeUpd)
+			_, _ = rnd.Read(codeUpd)
 			for limit := 1000; len(key) > length.Addr && limit > 0; limit-- {
 				key, existed = getKey() //nolint
 				if !existed {
@@ -476,7 +476,7 @@ func generateSharedDomainsUpdatesForBench(b *testing.B, domains *execctx.SharedD
 
 			sk := make([]byte, length.Addr+length.Hash)
 			copy(sk, key)
-			rnd.Read(sk[length.Addr:])
+			_, _ = rnd.Read(sk[length.Addr:])
 
 			prev, _, err = domains.GetLatest(kv.StorageDomain, tx, sk)
 			require.NoError(b, err)

--- a/db/test/lifecycle_bench_test.go
+++ b/db/test/lifecycle_bench_test.go
@@ -72,11 +72,11 @@ func newKeyGenerator(rnd *rndGen, nHot, nCold int) *keyGenerator {
 	}
 	for i := range g.hotAddrs {
 		g.hotAddrs[i] = make([]byte, length.Addr)
-		rnd.Read(g.hotAddrs[i])
+		_, _ = rnd.Read(g.hotAddrs[i])
 	}
 	for i := range g.coldAddrs {
 		g.coldAddrs[i] = make([]byte, length.Addr)
-		rnd.Read(g.coldAddrs[i])
+		_, _ = rnd.Read(g.coldAddrs[i])
 	}
 	return g
 }


### PR DESCRIPTION
Continues the errcheck rollout from #22538 by removing the remaining bootstrap exclusions for a batch of storage packages and fixing every violation this surfaces.

Fixes are per-callsite, not mechanical: real errors get propagated (including a couple of genuine bugs found this way, like an inconsistently-checked call and a stale cache silently returning partial data on failure), while writes into contracts that are documented to never fail (hash writers, RNG readers, fmt.Formatter buffers) are explicitly discarded with a short note on why. A stale test fixture that a previously-swallowed decode error had been masking is also corrected.

All touched packages build, vet, and pass their test suites; errcheck reports zero remaining issues in this scope.