### PR TITLE
execution/types: pin RegisterTxType's nil spec.New guard

### DIFF
--- a/execution/types/tx_registry_test.go
+++ b/execution/types/tx_registry_test.go
@@ -305,6 +305,20 @@ func TestRegisterTxTypeCollisions(t *testing.T) {
 	})
 }
 
+func TestRegisterTxTypeNilNew(t *testing.T) {
+	const nilNewType = 0x79
+
+	require.Panics(t, func() {
+		RegisterTxType(nilNewType, TxTypeSpec{})
+	})
+
+	// The guard runs before the registry write, so the rejected id stays free.
+	require.NotPanics(t, func() {
+		RegisterTxType(nilNewType, TxTypeSpec{New: func() Transaction { return &fakeRegisteredTx{} }})
+	})
+	t.Cleanup(func() { unregisterTxType(nilNewType) })
+}
+
 func TestUnregisteredTxTypeStillUnsupported(t *testing.T) {
 	const unknownType = 0x7f
 


### PR DESCRIPTION
`RegisterTxType` has four guards. `TestRegisterTxTypeCollisions` covers three of them — built-in collision, already-registered, and the `>= 0x80` EIP-2718 range. The `spec.New == nil` guard had no test.

It also pins where the guard sits. `spec.New == nil` is checked before the registry write, so a rejected id stays free; moving the check below `txTypeRegistry[id] = spec` would still panic but leave the id taken, and the next registration of that id would fail with "already registered".

Both halves are mutation-checked against `execution/types/tx_registry.go`:

| mutation | red at |
|---|---|
| delete the `spec.New == nil` guard | `tx_registry_test.go:311`, "should panic" |
| move the guard below `txTypeRegistry[id] = spec` | `tx_registry_test.go:316`, "should not panic" |

## Changes

- `execution/types/tx_registry_test.go`: add `TestRegisterTxTypeNilNew`, using the unclaimed type byte `0x79`.
