### PR TITLE
execution/cache: shard the two addr-keyed code caches

### DIFF
--- a/execution/cache/code_cache.go
+++ b/execution/cache/code_cache.go
@@ -17,12 +17,13 @@
 package cache
 
 import (
+	"encoding/binary"
 	"sync"
 	"sync/atomic"
 	"unsafe"
 
 	"github.com/c2h5oh/datasize"
-	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/elastic/go-freelru"
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
@@ -120,11 +121,19 @@ type codeSizeEntry struct {
 // honor the same (txNum, epoch) lazy-drop as the addr layers. This can re-fetch
 // code shared across deployments when one is unwound (a multiplicity cost), but
 // keeps stale code out of the cache.
+// hashAddr keys the addr-scoped shards. freelru selects a shard from the high
+// bits, so fold the whole address and mix before returning.
+func hashAddr(a common.Address) uint32 {
+	h := binary.LittleEndian.Uint64(a[0:8]) ^ binary.LittleEndian.Uint64(a[8:16]) ^ uint64(binary.LittleEndian.Uint32(a[16:20]))
+	h *= 0x9E3779B97F4A7C15
+	return uint32(h >> 32)
+}
+
 type CodeCache struct {
 	// addrToHash maps a 20-byte Ethereum address to the maphash-derived
 	// codeID for the code at that address. An LRU so fresh-address workloads
 	// evict oldest entries and warm up the working set.
-	addrToHash *lru.Cache[common.Address, versionedAddressID]
+	addrToHash *freelru.ShardedLRU[common.Address, versionedAddressID]
 	hashToCode *growLRU[codeEntry] // codeID(maphash(code)) → code, jump-grow + LRU-evicting
 	codeSize   atomic.Int64        // resident bytes (stat; hard bound is the entry cap)
 
@@ -133,7 +142,7 @@ type CodeCache struct {
 	// for bytes-lookup chaining). Used by SharedDomains.codeHashForAddr to
 	// skip a cold account-domain read when the EVM-known codeHash is
 	// already in cache. An addr → codeHash LRU.
-	addrToCodeHash *lru.Cache[common.Address, addrCodeHashEntry]
+	addrToCodeHash *freelru.ShardedLRU[common.Address, addrCodeHashEntry]
 
 	// codeHashToCode: 32-byte Ethereum codeHash (keccak256) → code bytes. Populated
 	// alongside L2 when the caller provides codeHash on Put. Independent
@@ -229,11 +238,11 @@ func NewCodeCache(codeCapacityBytes, addrCapacityBytes datasize.ByteSize) *CodeC
 	// addrEntryBytes (both entries combined). Divide in ByteSize space so the
 	// budget isn't truncated to int before the division.
 	addrEntries := max(int(addrCapacityBytes/datasize.ByteSize(addrEntryBytes)), 1024)
-	addrLRU, err := lru.New[common.Address, versionedAddressID](addrEntries)
+	addrLRU, err := freelru.NewSharded[common.Address, versionedAddressID](uint32(addrEntries), hashAddr)
 	if err != nil {
 		panic(err)
 	}
-	addrCodeHashLRU, err := lru.New[common.Address, addrCodeHashEntry](addrEntries)
+	addrCodeHashLRU, err := freelru.NewSharded[common.Address, addrCodeHashEntry](uint32(addrEntries), hashAddr)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
`addrToHash` and `addrToCodeHash` were the only `hashicorp/golang-lru` caches
left in `code_cache.go`; every other cache there is already a sharded `freelru`.
That matters because hashicorp's `Get` takes the **write** lock — it promotes the
entry in the recency list — so all exec workers serialize even on pure reads.

## Measured

Mutex profile (`PERF_PROFILES=true`) over one benchmarkoor fixture family, 6
workers on 3 physical cores:

| lock holder | before | after |
|---|---|---|
| `CodeCache.PutAddrCodeHash` | 5.10 s | 0.60 s |
| `RWMutex.Unlock` (hashicorp `Get`/`Add`) | 1.09 s | 0.13 s |
| `BranchCache.Put` | 1.51 s | 1.95 s |
| total | 8.95 s | 3.87 s |

`BranchCache.Put` grows because removing one bottleneck lets workers reach the
next one sooner; it is now the largest holder.

Throughput, single fixture per run, two rounds with the order swapped:

| fixture | base, MGas/s | pr, MGas/s |
|---|---|---|
| EXTCODECOPY code_size_65536 @200M | 118.4 | 120.2 |
| ether_transfers diff_to_contract @300M | 80.7 | 81.1 |

Land this for the consistency and the lock, not for the throughput. Diffing a
profile pair shows only 1.58 s of mutex delay accumulating over ~45 s of payload
execution — ~0.6 % of wall across 6 workers — so ~1 % is the whole ceiling here,
and it sits near this harness's resolution.

## The hash

`freelru` selects the shard from the high bits of the hash. A first version
returning only the low address bytes silently held **320 of 1024** entries;
`TestCodeCache_AddrCapacityLimit` fails on it. Hence folding all 20 bytes and
returning the top half of the mix.