### PR TITLE
db/seg: stop ReadFrom decoding into the file mapping

### DIFF
--- a/cmd/utils/app/seg_info_cmd.go
+++ b/cmd/utils/app/seg_info_cmd.go
@@ -49,21 +49,18 @@ func segInfo(ctx context.Context, cliCtx *cli.Command) error {
 	g := seg.MakeGetter()
 	sizes := make([]int, 0, seg.Count())
 	i := 0
-	// buf holds only words Next decoded into. A word from NextUncompressed is a
-	// slice of the read-only mapping, and feeding it back would decode into the file.
-	var w, buf []byte
 	compressedKeys := compress == "all" || compress == "keys"
 	compressedValues := compress == "all" || compress == "values"
 	for g.HasNext() {
+		var wordLen int
 		if (i%2 == 0 && compressedKeys) || (i%2 == 1 && compressedValues) {
-			w, _ = g.Next(buf[:0])
-			buf = w
+			_, wordLen = g.Skip()
 		} else {
-			w, _ = g.NextUncompressed()
+			_, wordLen = g.SkipUncompressed()
 		}
 
 		i++
-		sizes = append(sizes, len(w))
+		sizes = append(sizes, wordLen)
 
 		select {
 		case <-ticker.C:

--- a/cmd/utils/app/seg_info_cmd.go
+++ b/cmd/utils/app/seg_info_cmd.go
@@ -21,17 +21,8 @@ func segInfo(ctx context.Context, cliCtx *cli.Command) error {
 
 	// Compression settings
 	var compression seg.FileCompression
-	switch compress := cliCtx.String("compress"); compress {
-	case "none":
-		compression = seg.CompressNone
-	case "keys":
-		compression = seg.CompressKeys
-	case "values":
-		compression = seg.CompressVals
-	case "all":
-		compression = seg.CompressKeys | seg.CompressVals
-	default:
-		return errors.New("invalid compression type: " + compress)
+	if err := compression.FromString(cliCtx.String("compress")); err != nil {
+		return err
 	}
 
 	// Opens datadir/file

--- a/cmd/utils/app/seg_info_cmd.go
+++ b/cmd/utils/app/seg_info_cmd.go
@@ -20,8 +20,17 @@ func segInfo(ctx context.Context, cliCtx *cli.Command) error {
 	logger := log.Root()
 
 	// Compression settings
-	compress := cliCtx.String("compress")
-	if compress != "all" && compress != "none" && compress != "keys" && compress != "values" {
+	var compression seg.FileCompression
+	switch compress := cliCtx.String("compress"); compress {
+	case "none":
+		compression = seg.CompressNone
+	case "keys":
+		compression = seg.CompressKeys
+	case "values":
+		compression = seg.CompressVals
+	case "all":
+		compression = seg.CompressKeys | seg.CompressVals
+	default:
 		return errors.New("invalid compression type: " + compress)
 	}
 
@@ -35,41 +44,33 @@ func segInfo(ctx context.Context, cliCtx *cli.Command) error {
 	fullFilepath := filepath.Join(dirs.Snap, file)
 	logger.Info("Opening file...", "file", fullFilepath)
 
-	seg, err := seg.NewDecompressor(fullFilepath)
+	d, err := seg.NewDecompressor(fullFilepath)
 	if err != nil {
 		return err
 	}
-	defer seg.Close()
+	defer d.Close()
 
 	// Scan entire file and collect statistics
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 
 	logger.Info("Scanning file...")
-	g := seg.MakeGetter()
-	sizes := make([]int, 0, seg.Count())
+	r := seg.NewReader(d.MakeGetter(), compression)
+	sizes := make([]int, 0, d.Count())
 	i := 0
-	compressedKeys := compress == "all" || compress == "keys"
-	compressedValues := compress == "all" || compress == "values"
-	for g.HasNext() {
-		var wordLen int
-		if (i%2 == 0 && compressedKeys) || (i%2 == 1 && compressedValues) {
-			_, wordLen = g.Skip()
-		} else {
-			_, wordLen = g.SkipUncompressed()
-		}
-
+	for r.HasNext() {
+		_, wordLen := r.Skip()
 		i++
 		sizes = append(sizes, wordLen)
 
 		select {
 		case <-ticker.C:
-			logger.Info("Still scanning file...", "i", i, "total", seg.Count())
+			logger.Info("Still scanning file...", "i", i, "total", d.Count())
 		default:
 		}
 	}
-	if len(sizes) != seg.Count() {
-		logger.Warn("Full scan of words doesn't match word count in file header", "header", seg.Count(), "scanned", len(sizes))
+	if len(sizes) != d.Count() {
+		logger.Warn("Full scan of words doesn't match word count in file header", "header", d.Count(), "scanned", len(sizes))
 	}
 	slices.Sort(sizes)
 	minWordLen := sizes[0]
@@ -90,17 +91,17 @@ func segInfo(ctx context.Context, cliCtx *cli.Command) error {
 	// Print stats
 	p := message.NewPrinter(language.English)
 	p.Printf("\nFile statistics:\n\n")
-	p.Printf("File size: %d byte(s)\n", seg.Size())
-	p.Printf("Serialized dict size: %d byte(s)\n", seg.SerializedDictSize()) // word 3
-	p.Printf("Dict words: %d\n", seg.DictWords())
-	p.Printf("Serialized len size: %d byte(s)\n", seg.SerializedLenSize()) // word 4
-	p.Printf("Dict lens: %d\n", seg.DictLens())
+	p.Printf("File size: %d byte(s)\n", d.Size())
+	p.Printf("Serialized dict size: %d byte(s)\n", d.SerializedDictSize()) // word 3
+	p.Printf("Dict words: %d\n", d.DictWords())
+	p.Printf("Serialized len size: %d byte(s)\n", d.SerializedLenSize()) // word 4
+	p.Printf("Dict lens: %d\n", d.DictLens())
 	p.Printf("Unique lengths: %d\n", uniqueLengths)
-	p.Printf("Data length: %d byte(s)\n", g.DataLen())
+	p.Printf("Data length: %d byte(s)\n", r.DataLen())
 	p.Printf("Total raw words length: %d byte(s)\n", rawWordLen)
 
-	p.Printf("\nWord count: %d\n", seg.Count())                // word 1
-	p.Printf("Empty words count: %d\n", seg.EmptyWordsCount()) // word 2
+	p.Printf("\nWord count: %d\n", d.Count())                // word 1
+	p.Printf("Empty words count: %d\n", d.EmptyWordsCount()) // word 2
 	p.Printf("\nMin word length: %d byte(s)\n", minWordLen)
 	p.Printf("Max word length: %d byte(s)\n", maxWordLen)
 	p.Printf("Median word length: %d byte(s)\n", sizes[len(sizes)/2])

--- a/cmd/utils/app/seg_info_cmd.go
+++ b/cmd/utils/app/seg_info_cmd.go
@@ -49,12 +49,15 @@ func segInfo(ctx context.Context, cliCtx *cli.Command) error {
 	g := seg.MakeGetter()
 	sizes := make([]int, 0, seg.Count())
 	i := 0
-	var w []byte
+	// buf holds only words Next decoded into. A word from NextUncompressed is a
+	// slice of the read-only mapping, and feeding it back would decode into the file.
+	var w, buf []byte
 	compressedKeys := compress == "all" || compress == "keys"
 	compressedValues := compress == "all" || compress == "values"
 	for g.HasNext() {
 		if (i%2 == 0 && compressedKeys) || (i%2 == 1 && compressedValues) {
-			w, _ = g.Next(w[:0])
+			w, _ = g.Next(buf[:0])
+			buf = w
 		} else {
 			w, _ = g.NextUncompressed()
 		}

--- a/db/seg/decompress.go
+++ b/db/seg/decompress.go
@@ -1044,7 +1044,7 @@ func (g *Getter) NextUncompressed() ([]byte, uint64) {
 			g.dataP++
 			g.dataBit = 0
 		}
-		return g.data[g.dataP:g.dataP], g.dataP
+		return g.data[g.dataP:g.dataP:g.dataP], g.dataP
 	}
 	g.nextPos()
 	if g.dataBit > 0 {
@@ -1053,7 +1053,7 @@ func (g *Getter) NextUncompressed() ([]byte, uint64) {
 	}
 	pos := g.dataP
 	g.dataP += wordLen
-	return g.data[pos:g.dataP], g.dataP
+	return g.data[pos:g.dataP:g.dataP], g.dataP
 }
 
 // Skip moves offset to the next word and returns the new offset and the length of the word.

--- a/db/seg/seg_auto_rw.go
+++ b/db/seg/seg_auto_rw.go
@@ -153,10 +153,26 @@ func (c *Writer) Write(word []byte) (n int, err error) {
 }
 
 func (c *Writer) ReadFrom(r *Reader) error {
-	var v []byte
+	// Keep the two buffers apart and only keep the one Next decoded into: for
+	// the half the domain does not compress, Next returns a slice of the
+	// read-only mapping, and feeding that back would decode into the file.
+	var k, v []byte
 	for r.HasNext() {
-		v, _ = r.Next(v[:0])
-		if _, err := c.Write(v); err != nil {
+		key, _ := r.Next(k[:0])
+		if r.c.Has(CompressKeys) {
+			k = key
+		}
+		if _, err := c.Write(key); err != nil {
+			return err
+		}
+		if !r.HasNext() {
+			return nil
+		}
+		val, _ := r.Next(v[:0])
+		if r.c.Has(CompressVals) {
+			v = val
+		}
+		if _, err := c.Write(val); err != nil {
 			return err
 		}
 	}

--- a/db/seg/seg_auto_rw_test.go
+++ b/db/seg/seg_auto_rw_test.go
@@ -57,9 +57,14 @@ func TestWriterReadFromMixedCompression(t *testing.T) {
 	const pairs = 4096
 	words := make([][]byte, 0, 2*pairs)
 	for i := range pairs {
-		words = append(words,
-			[]byte(fmt.Sprintf("key-%06d", i)),
-			bytes.Repeat([]byte(fmt.Sprintf("value-%06d-", i)), 16))
+		// Alternate long and short values: a value no longer than the key it
+		// follows still fits the key's own slice, so a capacity bound alone
+		// does not stop the decode from landing in the mapping.
+		value := bytes.Repeat([]byte(fmt.Sprintf("value-%06d-", i)), 16)
+		if i%2 == 1 {
+			value = []byte(fmt.Sprintf("v%03d", i%1000))
+		}
+		words = append(words, []byte(fmt.Sprintf("key-%06d", i)), value)
 	}
 
 	src := writeKVFile(t, "src", CompressVals, words)

--- a/db/seg/seg_auto_rw_test.go
+++ b/db/seg/seg_auto_rw_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package seg
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+)
+
+// writeKVFile builds a key/value seg file under the given compression and
+// returns its path.
+func writeKVFile(t *testing.T, name string, compression FileCompression, words [][]byte) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	file := filepath.Join(tmpDir, name)
+	c, err := NewCompressor(t.Context(), t.Name(), file, tmpDir, DefaultCfg, log.LvlDebug, log.New())
+	require.NoError(t, err)
+	defer c.Close()
+
+	w := NewWriter(c, compression)
+	for _, word := range words {
+		_, err = w.Write(word)
+		require.NoError(t, err)
+	}
+	require.NoError(t, c.Compress())
+	return file
+}
+
+// TestWriterReadFromMixedCompression copies a file whose keys are stored raw
+// and whose values are compressed. An uncompressed read hands back a slice of
+// the read-only mapping, so reusing it as the next read's buffer faults.
+//
+// The mapping slice's capacity runs to the end of the file, so the fault needs
+// a file long enough that the bytes left after a key still exceed the next
+// value: below that, slices.Grow reallocates and hides the aliasing.
+func TestWriterReadFromMixedCompression(t *testing.T) {
+	const pairs = 4096
+	words := make([][]byte, 0, 2*pairs)
+	for i := range pairs {
+		words = append(words,
+			[]byte(fmt.Sprintf("key-%06d", i)),
+			bytes.Repeat([]byte(fmt.Sprintf("value-%06d-", i)), 16))
+	}
+
+	src := writeKVFile(t, "src", CompressVals, words)
+	srcDecomp, err := NewDecompressor(src)
+	require.NoError(t, err)
+	defer srcDecomp.Close()
+
+	dstDir := t.TempDir()
+	dst := filepath.Join(dstDir, "dst")
+	c, err := NewCompressor(t.Context(), t.Name(), dst, dstDir, DefaultCfg, log.LvlDebug, log.New())
+	require.NoError(t, err)
+	defer c.Close()
+
+	require.NoError(t, NewWriter(c, CompressVals).ReadFrom(NewReader(srcDecomp.MakeGetter(), CompressVals)))
+	require.NoError(t, c.Compress())
+
+	dstDecomp, err := NewDecompressor(dst)
+	require.NoError(t, err)
+	defer dstDecomp.Close()
+
+	g := NewReader(dstDecomp.MakeGetter(), CompressVals)
+	for i, want := range words {
+		require.True(t, g.HasNext(), "word %d missing", i)
+		got, _ := g.Next(nil)
+		require.Equal(t, want, got, "word %d", i)
+	}
+	require.False(t, g.HasNext())
+}

--- a/db/seg/seg_auto_rw_test.go
+++ b/db/seg/seg_auto_rw_test.go
@@ -29,10 +29,10 @@ import (
 
 // writeKVFile builds a key/value seg file under the given compression and
 // returns its path.
-func writeKVFile(t *testing.T, name string, compression FileCompression, words [][]byte) string {
+func writeKVFile(t *testing.T, compression FileCompression, words [][]byte) string {
 	t.Helper()
 	tmpDir := t.TempDir()
-	file := filepath.Join(tmpDir, name)
+	file := filepath.Join(tmpDir, "src")
 	c, err := NewCompressor(t.Context(), t.Name(), file, tmpDir, DefaultCfg, log.LvlDebug, log.New())
 	require.NoError(t, err)
 	defer c.Close()
@@ -67,7 +67,7 @@ func TestWriterReadFromMixedCompression(t *testing.T) {
 		words = append(words, []byte(fmt.Sprintf("key-%06d", i)), value)
 	}
 
-	src := writeKVFile(t, "src", CompressVals, words)
+	src := writeKVFile(t, CompressVals, words)
 	srcDecomp, err := NewDecompressor(src)
 	require.NoError(t, err)
 	defer srcDecomp.Close()
@@ -90,6 +90,23 @@ func TestWriterReadFromMixedCompression(t *testing.T) {
 		require.True(t, g.HasNext(), "word %d missing", i)
 		got, _ := g.Next(nil)
 		require.Equal(t, want, got, "word %d", i)
+	}
+	require.False(t, g.HasNext())
+}
+
+// TestNextUncompressedCapacityBound pins the capacity contract: a returned word
+// must not let the caller append into the read-only mapping. Empty words go
+// through a separate return path, so cover both.
+func TestNextUncompressedCapacityBound(t *testing.T) {
+	words := [][]byte{[]byte("key-0"), {}, []byte("key-1"), []byte("value-1")}
+	d, err := NewDecompressor(writeKVFile(t, CompressNone, words))
+	require.NoError(t, err)
+	defer d.Close()
+
+	g := d.MakeGetter()
+	for i := range words {
+		w, _ := g.NextUncompressed()
+		require.Equal(t, len(w), cap(w), "word %d: cap must not run past the word", i)
 	}
 	require.False(t, g.HasNext())
 }

--- a/db/seg/seg_auto_rw_test.go
+++ b/db/seg/seg_auto_rw_test.go
@@ -110,3 +110,18 @@ func TestNextUncompressedCapacityBound(t *testing.T) {
 	}
 	require.False(t, g.HasNext())
 }
+
+func TestFileCompressionFromString(t *testing.T) {
+	for s, want := range map[string]FileCompression{
+		"": CompressNone, "none": CompressNone,
+		"k": CompressKeys, "keys": CompressKeys,
+		"v": CompressVals, "values": CompressVals,
+		"kv": CompressKeys | CompressVals, "all": CompressKeys | CompressVals,
+	} {
+		var c FileCompression
+		require.NoError(t, c.FromString(s), s)
+		require.Equal(t, want, c, s)
+	}
+	var c FileCompression
+	require.Error(t, c.FromString("nope"))
+}

--- a/db/seg/seg_interface.go
+++ b/db/seg/seg_interface.go
@@ -47,19 +47,28 @@ func (m *FeatureFlagBitmask) Set(flag FeatureFlag) {
 	*m |= FeatureFlagBitmask(flag)
 }
 
-func ParseFileCompression(s string) (FileCompression, error) {
+// FromString accepts both the short form used in file metadata ("k", "v",
+// "kv") and the long form CLI flags take ("keys", "values", "all").
+func (c *FileCompression) FromString(s string) error {
 	switch s {
 	case "none", "":
-		return CompressNone, nil
-	case "k":
-		return CompressKeys, nil
-	case "v":
-		return CompressVals, nil
-	case "kv":
-		return CompressKeys | CompressVals, nil
+		*c = CompressNone
+	case "k", "keys":
+		*c = CompressKeys
+	case "v", "values":
+		*c = CompressVals
+	case "kv", "all":
+		*c = CompressKeys | CompressVals
 	default:
-		return CompressNone, fmt.Errorf("invalid file compression type: %s", s)
+		return fmt.Errorf("invalid file compression type: %s", s)
 	}
+	return nil
+}
+
+func ParseFileCompression(s string) (FileCompression, error) {
+	var c FileCompression
+	err := c.FromString(s)
+	return c, err
 }
 
 func (c FileCompression) Has(flag FileCompression) bool {


### PR DESCRIPTION
`Reader.Next` alternates `CompressKeys` / `CompressVals` per call and falls
through to `Getter.NextUncompressed` for whichever half the domain does not
compress:

```
unexpected fault address 0x10ebc6bb6
fatal error: fault
[signal SIGBUS: bus error code=0x1 ...]
runtime.memmove()
db/seg.(*Getter).Next(..., {0x10ebc6bb6, 0x0, 0x31e25})
db/seg.(*Reader).Next(...)
db/seg.(*Writer).ReadFrom(...)
```
