### PR TITLE
db/snapshotsync, rpc/jsonrpc: three review follow-ups from #23322

### DIFF
--- a/cmd/rpcdaemon/rpcservices/eth_backend.go
+++ b/cmd/rpcdaemon/rpcservices/eth_backend.go
@@ -119,6 +119,9 @@ func (back *RemoteBackend) Ready(ctx context.Context) <-chan error {
 
 func (back *RemoteBackend) AllTypes() []snaptype.Type { panic("not implemented") }
 func (back *RemoteBackend) FrozenBlocks() uint64      { return back.blockReader.FrozenBlocks() }
+func (back *RemoteBackend) FrozenBlocksObserved() (uint64, bool) {
+	return back.blockReader.FrozenBlocksObserved()
+}
 func (back *RemoteBackend) FrozenBlocksInView(tx kv.Getter) uint64 {
 	return back.blockReader.FrozenBlocksInView(tx)
 }

--- a/common/concurrent/cached_value.go
+++ b/common/concurrent/cached_value.go
@@ -1,0 +1,142 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package concurrent
+
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+	"sync"
+	"time"
+
+	"github.com/erigontech/erigon/common/log/v3"
+)
+
+// CachedValue keeps a value for a TTL and lets one producer at a time refresh it. Whether
+// a value was ever produced is tracked apart from when it was last asked for, so a caller
+// can tell a default from an observation and a producer that keeps failing costs one
+// attempt per TTL. The zero value is usable and never fresh.
+type CachedValue[T any] struct {
+	mu        sync.Mutex
+	value     T
+	observed  bool
+	attempted time.Time
+	ttl       time.Duration
+	running   *run[T]
+}
+
+// run is one pass of a producer. Its result is readable once done is closed.
+type run[T any] struct {
+	done  chan struct{}
+	value T
+	err   error
+}
+
+func (c *CachedValue[T]) SetTTL(ttl time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.ttl = ttl
+}
+
+// Load reports the value, whether a producer ever delivered one, and whether the last
+// attempt is recent enough to stand in for another one.
+func (c *CachedValue[T]) Load() (value T, observed, fresh bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.value, c.observed, time.Since(c.attempted) < c.ttl
+}
+
+// Produce runs produce on the caller's goroutine, or waits for the pass already running
+// and reports ran=false. Running on the caller's own goroutine is what a producer reading
+// through the caller's transaction needs: the pass cannot outlive the caller that owns it.
+// A caller that only waits is released by ctx, since the pass is not its to abandon.
+func (c *CachedValue[T]) Produce(ctx context.Context, produce func() (value T, store bool, err error)) (value T, ran bool, err error) {
+	r, mine := c.claim()
+	if mine {
+		value, err = c.run(r, produce)
+		return value, true, err
+	}
+	select {
+	case <-r.done:
+		return r.value, false, r.err
+	case <-ctx.Done():
+		var zero T
+		return zero, false, ctx.Err()
+	}
+}
+
+// Go runs produce on a goroutine of its own, or joins the pass already running, and
+// returns the channel closed when that pass ends. It is for a caller that must not pay
+// for the refresh it triggers; the value is read back with Load.
+func (c *CachedValue[T]) Go(produce func() (value T, store bool, err error)) <-chan struct{} {
+	r, mine := c.claim()
+	if mine {
+		go func() {
+			// The pass owns this goroutine, where an escaping panic would take the
+			// process down instead of the caller that caused it.
+			defer func() {
+				if p := recover(); p != nil {
+					log.Error("[cached-value] producer panicked", "err", p, "stack", string(debug.Stack()))
+				}
+			}()
+			_, _ = c.run(r, produce)
+		}()
+	}
+	return r.done
+}
+
+func (c *CachedValue[T]) claim() (*run[T], bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.running != nil {
+		return c.running, false
+	}
+	c.running = &run[T]{done: make(chan struct{})}
+	return c.running, true
+}
+
+// run publishes what produce answered and releases the callers waiting on it. A producer
+// that panics is published as a failed pass and then re-panics: swallowing it here would
+// hand the caller a zero value it cannot tell from an answer.
+func (c *CachedValue[T]) run(r *run[T], produce func() (T, bool, error)) (value T, err error) {
+	store := false
+	defer func() {
+		if p := recover(); p != nil {
+			c.publish(r, value, false, fmt.Errorf("cached value producer panicked: %v", p))
+			panic(p)
+		}
+		c.publish(r, value, store, err)
+	}()
+
+	value, store, err = produce()
+	return value, err
+}
+
+// publish records the attempt, stores what is worth keeping, and ends the pass. Closing
+// done before clearing running keeps a caller from starting a pass of its own while this
+// one is still published as in flight.
+func (c *CachedValue[T]) publish(r *run[T], value T, store bool, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.attempted = time.Now()
+	if store && err == nil {
+		c.value, c.observed = value, true
+	}
+	r.value, r.err = value, err
+	close(r.done)
+	c.running = nil
+}

--- a/common/concurrent/cached_value_test.go
+++ b/common/concurrent/cached_value_test.go
@@ -1,0 +1,252 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package concurrent
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func produced[T any](value T) func() (T, bool, error) {
+	return func() (T, bool, error) { return value, true, nil }
+}
+
+func TestCachedValueReportsNothingBeforeTheFirstPass(t *testing.T) {
+	t.Parallel()
+
+	value, observed, fresh := new(CachedValue[uint64]).Load()
+	require.Zero(t, value)
+	require.False(t, observed, "the zero value is a default, not an observation")
+	require.False(t, fresh)
+}
+
+func TestCachedValueKeepsWhatWasProduced(t *testing.T) {
+	t.Parallel()
+
+	cached := new(CachedValue[uint64])
+	cached.SetTTL(time.Hour)
+	value, ran, err := cached.Produce(t.Context(), produced(uint64(42)))
+	require.NoError(t, err)
+	require.True(t, ran)
+	require.Equal(t, uint64(42), value)
+
+	value, observed, fresh := cached.Load()
+	require.Equal(t, uint64(42), value)
+	require.True(t, observed)
+	require.True(t, fresh)
+}
+
+func TestCachedValueStopsBeingFreshAfterTheTTL(t *testing.T) {
+	t.Parallel()
+
+	cached := new(CachedValue[uint64])
+	cached.SetTTL(time.Hour)
+	_, _, err := cached.Produce(t.Context(), produced(uint64(42)))
+	require.NoError(t, err)
+	cached.SetTTL(0)
+
+	value, observed, fresh := cached.Load()
+	require.Equal(t, uint64(42), value, "a stale value is still the one that was observed")
+	require.True(t, observed)
+	require.False(t, fresh)
+}
+
+// TestCachedValueRecordsAFailedAttempt pins that a failure is remembered as an attempt
+// without becoming an observation: a producer that is down must cost one attempt per TTL,
+// and a caller must still be able to tell that nothing was ever produced.
+func TestCachedValueRecordsAFailedAttempt(t *testing.T) {
+	t.Parallel()
+
+	cached := new(CachedValue[uint64])
+	cached.SetTTL(time.Hour)
+	_, _, err := cached.Produce(t.Context(), func() (uint64, bool, error) {
+		return 0, false, errors.New("down")
+	})
+	require.Error(t, err)
+
+	value, observed, fresh := cached.Load()
+	require.Zero(t, value)
+	require.False(t, observed)
+	require.True(t, fresh, "a recent failure stands in for the attempts that would follow it")
+}
+
+// TestCachedValueKeepsAnUndecidedProducerOutOfTheValue pins the store=false contract: the
+// answer reaches the caller that asked for it, but a producer with nothing worth
+// remembering leaves the stored value and observed untouched.
+func TestCachedValueKeepsAnUndecidedProducerOutOfTheValue(t *testing.T) {
+	t.Parallel()
+
+	cached := new(CachedValue[uint64])
+	cached.SetTTL(time.Hour)
+	value, ran, err := cached.Produce(t.Context(), func() (uint64, bool, error) { return 7, false, nil })
+	require.NoError(t, err)
+	require.True(t, ran)
+	require.Equal(t, uint64(7), value, "the caller that asked gets the answer")
+
+	stored, observed, _ := cached.Load()
+	require.Zero(t, stored)
+	require.False(t, observed)
+}
+
+// TestCachedValueProduceRunsThePassToTheEnd pins what a producer bound to the caller's
+// transaction depends on: the caller that runs the pass does not return, or honour its own
+// cancellation, before the producer is done with what it borrowed.
+func TestCachedValueProduceRunsThePassToTheEnd(t *testing.T) {
+	t.Parallel()
+
+	cached := new(CachedValue[uint64])
+	cached.SetTTL(time.Hour)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	var finished atomic.Bool
+	_, ran, err := cached.Produce(ctx, func() (uint64, bool, error) {
+		time.Sleep(10 * time.Millisecond)
+		finished.Store(true)
+		return 42, true, nil
+	})
+	require.NoError(t, err, "a cancelled context does not abandon a pass the caller runs itself")
+	require.True(t, ran)
+	require.True(t, finished.Load())
+}
+
+// TestCachedValueReleasesAWaiterWithItsOwnContext pins the other half: a caller that only
+// waits owns nothing the pass borrowed, so its own cancellation releases it.
+func TestCachedValueReleasesAWaiterWithItsOwnContext(t *testing.T) {
+	t.Parallel()
+
+	cached := new(CachedValue[uint64])
+	cached.SetTTL(time.Hour)
+	entered, release := make(chan struct{}), make(chan struct{})
+	go func() {
+		_, _, _ = cached.Produce(t.Context(), func() (uint64, bool, error) {
+			close(entered)
+			<-release
+			return 42, true, nil
+		})
+	}()
+	<-entered
+	defer close(release)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, ran, err := cached.Produce(ctx, produced(uint64(1)))
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, ran, "the waiter must not run a producer of its own")
+}
+
+// TestCachedValueRunsOneProducerForConcurrentCallers pins the dedup: the pass exists to
+// keep one slow producer from being asked once per caller.
+func TestCachedValueRunsOneProducerForConcurrentCallers(t *testing.T) {
+	t.Parallel()
+
+	const waiters = 8
+	cached := new(CachedValue[uint64])
+	cached.SetTTL(time.Hour)
+	entered := make(chan struct{}, waiters+1)
+	release := make(chan struct{})
+
+	var producers atomic.Int64
+	produce := func() (uint64, bool, error) {
+		producers.Add(1)
+		entered <- struct{}{}
+		<-release
+		return 42, true, nil
+	}
+
+	answers := make(chan uint64, waiters+1)
+	for range waiters + 1 {
+		go func() {
+			value, _, _ := cached.Produce(t.Context(), produce)
+			answers <- value
+		}()
+	}
+	<-entered
+	select {
+	case <-entered:
+		close(release)
+		t.Fatal("a caller arriving while the producer ran asked for one of its own")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(release)
+
+	for range waiters + 1 {
+		require.Equal(t, uint64(42), <-answers, "the pass answers every caller waiting on it")
+	}
+	require.EqualValues(t, 1, producers.Load())
+}
+
+// TestCachedValueProducePropagatesAProducerPanic pins that a panic reaches the caller that
+// caused it, having released the pass: swallowing it would hand that caller a zero value
+// it cannot tell from an answer, and holding the pass would strand the next caller.
+func TestCachedValueProducePropagatesAProducerPanic(t *testing.T) {
+	t.Parallel()
+
+	cached := new(CachedValue[uint64])
+	cached.SetTTL(0)
+	require.Panics(t, func() {
+		_, _, _ = cached.Produce(t.Context(), func() (uint64, bool, error) { panic("producer blew up") })
+	})
+	_, observed, _ := cached.Load()
+	require.False(t, observed, "a producer that did not finish observed nothing")
+
+	value, ran, err := cached.Produce(t.Context(), produced(uint64(42)))
+	require.NoError(t, err)
+	require.True(t, ran, "the pass a panic ended is over, so the next caller runs its own")
+	require.Equal(t, uint64(42), value)
+}
+
+// TestCachedValueGoContainsAProducerPanic pins that a panic on the goroutine the pass owns
+// does not escape it: there is no caller there to recover it, so it would end the process.
+func TestCachedValueGoContainsAProducerPanic(t *testing.T) {
+	t.Parallel()
+
+	cached := new(CachedValue[uint64])
+	cached.SetTTL(time.Hour)
+	<-cached.Go(func() (uint64, bool, error) { panic("producer blew up") })
+
+	_, observed, fresh := cached.Load()
+	require.False(t, observed)
+	require.True(t, fresh, "a pass that panicked still counts as an attempt")
+}
+
+// TestCachedValueGoDoesNotHoldTheCaller pins the refresh-behind form: the caller gets the
+// channel and moves on while the producer is still running.
+func TestCachedValueGoDoesNotHoldTheCaller(t *testing.T) {
+	t.Parallel()
+
+	cached := new(CachedValue[uint64])
+	cached.SetTTL(time.Hour)
+	release := make(chan struct{})
+	done := cached.Go(func() (uint64, bool, error) {
+		<-release
+		return 42, true, nil
+	})
+
+	_, observed, _ := cached.Load()
+	require.False(t, observed, "Go returned before the producer did")
+	close(release)
+	<-done
+	value, observed, _ := cached.Load()
+	require.Equal(t, uint64(42), value)
+	require.True(t, observed)
+}

--- a/db/dbservices/interfaces.go
+++ b/db/dbservices/interfaces.go
@@ -98,6 +98,8 @@ type FullBlockReader interface {
 	CanonicalReader
 
 	FrozenBlocks() uint64
+	// FrozenBlocksObserved reports the count and whether it was observed rather than defaulted.
+	FrozenBlocksObserved() (uint64, bool)
 	FrozenBlocksInView(tx kv.Getter) uint64
 	FreezingCfg() ethconfig.BlocksFreezing
 	CanPruneTo(currentBlockInDB uint64) (canPruneBlocksTo uint64)

--- a/db/snapshotsync/freezeblocks/block_reader.go
+++ b/db/snapshotsync/freezeblocks/block_reader.go
@@ -23,13 +23,13 @@ import (
 	"fmt"
 	"slices"
 	"sort"
-	"sync"
 	"time"
 
 	lru "github.com/hashicorp/golang-lru/v2"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/concurrent"
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/dbservices"
@@ -54,13 +54,8 @@ type RemoteBlockReader struct {
 	client       remoteproto.ETHBACKENDClient
 	txNumsReader rawdbv3.TxNumsReader
 
-	frozenBlocksMu        sync.Mutex
-	frozenBlocksValue     uint64
-	frozenBlocksFetchedAt time.Time
-	frozenBlocksFetching  bool
-	frozenBlocksFetched   chan struct{}
-	frozenBlocksTTL       time.Duration
-	frozenBlocksTimeout   time.Duration
+	frozenBlocks        concurrent.CachedValue[uint64]
+	frozenBlocksTimeout time.Duration
 }
 
 func (r *RemoteBlockReader) CanPruneTo(uint64) uint64 {
@@ -156,79 +151,46 @@ func (r *RemoteBlockReader) AllTypes() []snaptype.Type              { panic("not
 func (r *RemoteBlockReader) FrozenBlocksInView(tx kv.Getter) uint64 { panic("not supported") }
 func (r *RemoteBlockReader) FreezingCfg() ethconfig.BlocksFreezing  { panic("not supported") }
 
-// FrozenBlocks is answered by the backend. The context-free signature leaves no way to
-// surface an error or honor cancellation, so the whole call is bounded by an internal
-// timeout however many rounds it takes, cached for a short TTL, and not duplicated while
-// one is in flight. The count only grows, so a stale-low answer is conservative for the
-// availability gates; zero is not, since callers read it as "no snapshots", so a failed
-// fetch is not cached.
+// FrozenBlocks answers with the count alone. The zero it hands out before the backend
+// ever answers reads as "no snapshots", which is what FrozenBlocksObserved separates.
 func (r *RemoteBlockReader) FrozenBlocks() uint64 {
-	deadline := time.Now().Add(r.frozenBlocksTimeout)
-	for waited := false; ; waited = true {
-		r.frozenBlocksMu.Lock()
-		observed := !r.frozenBlocksFetchedAt.IsZero()
-		fresh := time.Since(r.frozenBlocksFetchedAt) < r.frozenBlocksTTL
-		if observed && (fresh || r.frozenBlocksFetching) {
-			value := r.frozenBlocksValue
-			r.frozenBlocksMu.Unlock()
-			return value
-		}
-		if waited && !time.Now().Before(deadline) {
-			value := r.frozenBlocksValue
-			r.frozenBlocksMu.Unlock()
-			return value
-		}
-		if r.frozenBlocksFetching {
-			fetched := r.frozenBlocksFetched
-			r.frozenBlocksMu.Unlock()
-			select {
-			case <-fetched:
-			case <-time.After(time.Until(deadline)):
-			}
-			if waited {
-				r.frozenBlocksMu.Lock()
-				value := r.frozenBlocksValue
-				r.frozenBlocksMu.Unlock()
-				return value
-			}
-			// A caller that has not fetched yet retries once the in-flight one ends;
-			// waiting again would put it past the single timeout it is bounded by.
-			continue
-		}
-		r.frozenBlocksFetching = true
-		r.frozenBlocksFetched = make(chan struct{})
-		fetched := r.frozenBlocksFetched
-		r.frozenBlocksMu.Unlock()
-
-		return r.fetchFrozenBlocks(fetched, deadline)
-	}
+	value, _ := r.FrozenBlocksObserved()
+	return value
 }
 
-// fetchFrozenBlocks asks the backend, within what is left of the caller's budget, and
-// publishes what came back. Releasing the callers waiting on it is deferred: a fetch
-// that dies must not leave them on a result nobody will produce.
-func (r *RemoteBlockReader) fetchFrozenBlocks(fetched chan struct{}, deadline time.Time) uint64 {
-	defer func() {
-		r.frozenBlocksMu.Lock()
-		defer r.frozenBlocksMu.Unlock()
-		close(fetched)
-		r.frozenBlocksFetching = false
-	}()
+// FrozenBlocksObserved reports the count and whether the backend ever answered. The
+// context-free signature leaves no way to honor cancellation, so a fetch is bounded by an
+// internal timeout and runs on a goroutine of its own: this getter is reached with a read
+// transaction open, so a caller that has a value to serve must not pay for the next one.
+// The count only grows, so a stale-low answer stays conservative for the availability gates.
+func (r *RemoteBlockReader) FrozenBlocksObserved() (uint64, bool) {
+	value, observed, fresh := r.frozenBlocks.Load()
+	if fresh {
+		return value, observed
+	}
+	refreshed := r.frozenBlocks.Go(r.fetchFrozenBlocks)
+	if observed {
+		return value, true
+	}
+	timeout := time.NewTimer(r.frozenBlocksTimeout)
+	defer timeout.Stop()
+	select {
+	case <-refreshed:
+	case <-timeout.C:
+	}
+	value, observed, _ = r.frozenBlocks.Load()
+	return value, observed
+}
 
-	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+func (r *RemoteBlockReader) fetchFrozenBlocks() (uint64, bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), r.frozenBlocksTimeout)
 	defer cancel()
 	reply, err := r.client.FrozenBlocks(ctx, &emptypb.Empty{})
 	if err != nil {
 		log.Warn("[frozen-blocks] backend did not answer", "err", err)
+		return 0, false, err
 	}
-
-	r.frozenBlocksMu.Lock()
-	defer r.frozenBlocksMu.Unlock()
-	if err == nil {
-		r.frozenBlocksValue = reply.FrozenBlocks
-		r.frozenBlocksFetchedAt = time.Now()
-	}
-	return r.frozenBlocksValue
+	return reply.FrozenBlocks, true, nil
 }
 
 func (r *RemoteBlockReader) HeaderByHash(ctx context.Context, tx kv.Getter, hash common.Hash) (*types.Header, error) {
@@ -274,9 +236,9 @@ var _ dbservices.FullBlockReader = &RemoteBlockReader{}
 func NewRemoteBlockReader(client remoteproto.ETHBACKENDClient) *RemoteBlockReader {
 	br := &RemoteBlockReader{
 		client:              client,
-		frozenBlocksTTL:     30 * time.Second,
 		frozenBlocksTimeout: 5 * time.Second,
 	}
+	br.frozenBlocks.SetTTL(30 * time.Second)
 	br.txNumsReader = rawdbv3.TxNums.WithCustomReadTxNumFunc(TxBlockIndexFromBlockReader(br))
 	return br
 }
@@ -491,6 +453,8 @@ func (r *BlockReader) AllTypes() []snaptype.Type {
 }
 
 func (r *BlockReader) FrozenBlocks() uint64 { return r.sn.BlocksAvailable() }
+
+func (r *BlockReader) FrozenBlocksObserved() (uint64, bool) { return r.sn.BlocksAvailable(), true }
 
 // FrozenBlocksInView is FrozenBlocks as seen by tx: a caller that then reads the block
 // must ask the same generation it reads from, not the live set that may be ahead of it.

--- a/db/snapshotsync/freezeblocks/block_reader_test.go
+++ b/db/snapshotsync/freezeblocks/block_reader_test.go
@@ -640,11 +640,15 @@ func TestRemoteBlockReaderFrozenBlocks(t *testing.T) {
 
 type countingFrozenBlocksClient struct {
 	remoteproto.ETHBACKENDClient
+	err   error
 	calls atomic.Int64
 }
 
 func (c *countingFrozenBlocksClient) FrozenBlocks(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*remoteproto.FrozenBlocksReply, error) {
 	c.calls.Add(1)
+	if c.err != nil {
+		return nil, c.err
+	}
 	return &remoteproto.FrozenBlocksReply{FrozenBlocks: 42}, nil
 }
 
@@ -659,7 +663,8 @@ func (c stalledFrozenBlocksClient) FrozenBlocks(ctx context.Context, in *emptypb
 
 // TestRemoteBlockReaderFrozenBlocksCachesValue pins that the getter does not perform a
 // live RPC on every call: receipt and capability handlers reach it while holding read
-// transactions, so repeated calls within the TTL must be answered from the cache.
+// transactions, so repeated calls within the TTL must be answered from the cache, and a
+// stale one must be answered before the refresh it triggers.
 func TestRemoteBlockReaderFrozenBlocksCachesValue(t *testing.T) {
 	t.Parallel()
 
@@ -670,9 +675,10 @@ func TestRemoteBlockReaderFrozenBlocksCachesValue(t *testing.T) {
 	require.Equal(t, uint64(42), reader.FrozenBlocks())
 	require.EqualValues(t, 1, client.calls.Load())
 
-	reader.frozenBlocksTTL = 0
+	reader.frozenBlocks.SetTTL(0)
 	require.Equal(t, uint64(42), reader.FrozenBlocks())
-	require.EqualValues(t, 2, client.calls.Load())
+	require.Eventually(t, func() bool { return client.calls.Load() == 2 },
+		time.Second, 10*time.Millisecond, "a stale value is refreshed behind the caller")
 }
 
 // TestRemoteBlockReaderFrozenBlocksStalledBackend pins that a connected but
@@ -708,18 +714,37 @@ func (c *recoveringFrozenBlocksClient) FrozenBlocks(ctx context.Context, in *emp
 }
 
 // TestRemoteBlockReaderFrozenBlocksRetriesAfterFailure pins that a failed fetch is not
-// cached as if it had succeeded. Zero is not a neutral answer: it makes the receipt
-// paths treat pre-Byzantium blocks as needing re-execution, which a node with pruned
-// state history cannot serve.
+// remembered as an observation: it reports that nothing was observed, and once its
+// attempt is no longer fresh the backend is asked again.
 func TestRemoteBlockReaderFrozenBlocksRetriesAfterFailure(t *testing.T) {
 	t.Parallel()
 
-	client := &recoveringFrozenBlocksClient{}
-	reader := NewRemoteBlockReader(client)
-	reader.frozenBlocksTTL = time.Hour
+	reader := NewRemoteBlockReader(&recoveringFrozenBlocksClient{})
+	reader.frozenBlocks.SetTTL(0)
 
-	require.Zero(t, reader.FrozenBlocks())
-	require.Equal(t, uint64(42), reader.FrozenBlocks())
+	value, observed := reader.FrozenBlocksObserved()
+	require.Zero(t, value)
+	require.False(t, observed, "callers read zero as \"no snapshots\", which a failed fetch did not say")
+
+	value, observed = reader.FrozenBlocksObserved()
+	require.Equal(t, uint64(42), value)
+	require.True(t, observed)
+}
+
+// TestRemoteBlockReaderFrozenBlocksSuppressesRepeatFetchesAfterFailure pins that a
+// backend that is down costs one attempt per TTL rather than one per caller.
+func TestRemoteBlockReaderFrozenBlocksSuppressesRepeatFetchesAfterFailure(t *testing.T) {
+	t.Parallel()
+
+	client := &countingFrozenBlocksClient{err: errors.New("backend down")}
+	reader := NewRemoteBlockReader(client)
+	reader.frozenBlocks.SetTTL(time.Hour)
+
+	for range 8 {
+		require.Zero(t, reader.FrozenBlocks())
+	}
+	require.EqualValues(t, 1, client.calls.Load(),
+		"a recent failed attempt stands in for the ones that would follow it")
 }
 
 // blockingFrozenBlocksClient reports when a call arrives and holds it until released.
@@ -800,9 +825,9 @@ func TestRemoteBlockReaderFrozenBlocksWaitsForTheFirstFetch(t *testing.T) {
 }
 
 // TestRemoteBlockReaderFrozenBlocksServesCacheWhileRefreshing pins that once a value has
-// been observed a slow backend delays only the goroutine refreshing it. FrozenBlocks
-// sits on every receipt request, so holding the others behind the refresh turns one slow
-// backend into a stall of the whole handler pool.
+// been observed no caller waits for the next one: a slow backend delays only the refresh
+// running behind them. FrozenBlocks sits on every receipt request, so holding callers
+// behind the refresh turns one slow backend into a stall of the whole handler pool.
 func TestRemoteBlockReaderFrozenBlocksServesCacheWhileRefreshing(t *testing.T) {
 	t.Parallel()
 
@@ -811,102 +836,65 @@ func TestRemoteBlockReaderFrozenBlocksServesCacheWhileRefreshing(t *testing.T) {
 	reader.frozenBlocksTimeout = 10 * time.Second
 	require.Equal(t, uint64(42), reader.FrozenBlocks())
 
-	reader.frozenBlocksTTL = 0
-	refreshing := make(chan uint64, 1)
-	go func() { refreshing <- reader.FrozenBlocks() }()
+	reader.frozenBlocks.SetTTL(0)
+	require.Equal(t, uint64(42), reader.FrozenBlocks(), "the caller that finds the value stale does not wait for the refresh")
 	<-client.entered
 
-	waiting := make(chan uint64, 1)
-	go func() { waiting <- reader.FrozenBlocks() }()
-	select {
-	case value := <-waiting:
-		require.Equal(t, uint64(42), value, "the observed value answers while the refresh runs")
-	case <-time.After(time.Second):
-		close(client.release)
-		t.Fatal("FrozenBlocks held a caller behind an in-flight refresh")
-	}
-	require.EqualValues(t, 2, client.calls.Load(), "the waiting caller must not issue its own fetch")
+	require.Equal(t, uint64(42), reader.FrozenBlocks(), "the observed value answers while the refresh runs")
+	require.EqualValues(t, 2, client.calls.Load(), "the refresh in flight is not duplicated")
 
 	close(client.release)
-	require.Equal(t, uint64(43), <-refreshing)
+	require.Eventually(t, func() bool { return reader.FrozenBlocks() == 43 },
+		2*time.Second, 10*time.Millisecond, "the refreshed value replaces the one served")
 }
 
-// failingFirstFrozenBlocksClient holds and fails its first call, then holds its second
-// and answers it, so a test can watch the queue re-form behind the caller that took over.
+// failingFirstFrozenBlocksClient reports when a call arrives, holds it, and fails it.
 type failingFirstFrozenBlocksClient struct {
 	remoteproto.ETHBACKENDClient
 	entered chan int64
 	release chan struct{}
-	answer  chan struct{}
 	calls   atomic.Int64
 }
 
 func (c *failingFirstFrozenBlocksClient) FrozenBlocks(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*remoteproto.FrozenBlocksReply, error) {
-	call := c.calls.Add(1)
-	c.entered <- call
-	if call == 1 {
-		<-c.release
-		return nil, errors.New("backend down")
-	}
-	<-c.answer
-	return &remoteproto.FrozenBlocksReply{FrozenBlocks: 42}, nil
+	c.entered <- c.calls.Add(1)
+	<-c.release
+	return nil, errors.New("backend down")
 }
 
-// TestRemoteBlockReaderFrozenBlocksAsksAgainWhenTheFirstFetchFails pins that waiting for
-// the first fetch is not a substitute for asking: a caller that waited and found nothing
-// observed has spent no attempt of its own, and zero is the answer this getter must not
-// hand out while it can still be asked.
-func TestRemoteBlockReaderFrozenBlocksAsksAgainWhenTheFirstFetchFails(t *testing.T) {
+// TestRemoteBlockReaderFrozenBlocksSharesTheFirstFailedFetch pins that callers arriving
+// while the first fetch is in flight share it: when it fails they all report that nothing
+// was observed, and none of them spends a timeout of its own on a backend that is down.
+func TestRemoteBlockReaderFrozenBlocksSharesTheFirstFailedFetch(t *testing.T) {
 	t.Parallel()
 
 	const waiters = 8
 	client := &failingFirstFrozenBlocksClient{
 		entered: make(chan int64, waiters+1),
 		release: make(chan struct{}),
-		answer:  make(chan struct{}),
 	}
 	reader := NewRemoteBlockReader(client)
-	reader.frozenBlocksTTL = time.Hour
+	reader.frozenBlocks.SetTTL(time.Hour)
 
-	failing := make(chan uint64, 1)
-	go func() { failing <- reader.FrozenBlocks() }()
+	results := make(chan uint64, waiters+1)
+	go func() { results <- reader.FrozenBlocks() }()
 	require.EqualValues(t, 1, <-client.entered)
 
-	waiting := make(chan uint64, waiters)
 	for range waiters {
-		go func() { waiting <- reader.FrozenBlocks() }()
+		go func() { results <- reader.FrozenBlocks() }()
 	}
 	select {
-	case value := <-waiting:
+	case value := <-results:
 		close(client.release)
-		close(client.answer)
 		t.Fatalf("a caller was served %d while the first fetch was still in flight", value)
 	case <-time.After(100 * time.Millisecond):
 	}
 	close(client.release)
-	require.Zero(t, <-failing, "the caller whose own fetch failed has no value to report")
 
-	require.EqualValues(t, 2, <-client.entered, "one of the waiting callers takes the fetch over")
-	select {
-	case value := <-waiting:
-		close(client.answer)
-		t.Fatalf("a caller was served %d while the retry was still in flight", value)
-	case call := <-client.entered:
-		close(client.answer)
-		t.Fatalf("a waiting caller ran a fetch of its own (call %d) instead of taking the retry", call)
-	case <-time.After(100 * time.Millisecond):
+	for range waiters + 1 {
+		require.Zero(t, <-results, "a failed first fetch leaves nothing to report")
 	}
-	close(client.answer)
-
-	for range waiters {
-		select {
-		case value := <-waiting:
-			require.Equal(t, uint64(42), value, "the retry answers the caller that ran it and the ones queued behind it")
-		case <-time.After(5 * time.Second):
-			t.Fatal("a waiting caller neither answered nor retried")
-		}
-	}
-	require.EqualValues(t, 2, client.calls.Load(), "one retry, not one per waiting caller")
+	require.EqualValues(t, 1, client.calls.Load(), "one attempt, not one per caller")
 }
 
 // stalledCountingFrozenBlocksClient never answers and reports when a call arrives.

--- a/execution/blockreplay/memreader.go
+++ b/execution/blockreplay/memreader.go
@@ -213,6 +213,7 @@ func (r *memBlockReader) BadHeaderNumber(ctx context.Context, tx kv.Getter, hash
 // --- misc / freezing ---
 
 func (r *memBlockReader) FrozenBlocks() uint64                      { return 0 }
+func (r *memBlockReader) FrozenBlocksObserved() (uint64, bool)      { return 0, true }
 func (r *memBlockReader) FrozenBlocksInView(tx kv.Getter) uint64    { return 0 }
 func (r *memBlockReader) FreezingCfg() ethconfig.BlocksFreezing     { return ethconfig.BlocksFreezing{} }
 func (r *memBlockReader) CanPruneTo(currentBlockInDB uint64) uint64 { return 0 }

--- a/rpc/jsonrpc/check_prune_gates_test.go
+++ b/rpc/jsonrpc/check_prune_gates_test.go
@@ -1375,7 +1375,7 @@ func TestBlocksGateReopensWhenOlderBlocksArrive(t *testing.T) {
 	// The verdict is cached for a short TTL, which is what keeps a widening snapshot
 	// set from being read on every request. This test is about the later observation
 	// winning, not about how long the previous one lingers.
-	apis.eth._preMergeDataTTL = 0
+	apis.eth._preMergeData.SetTTL(0)
 
 	gateOnOldBlock := func() error {
 		tx, err := apis.eth.db.BeginTemporalRo(ctx)
@@ -1619,7 +1619,7 @@ func TestBlocksGateCachesTheVerdictForAShortWhile(t *testing.T) {
 	dropTransactions(t, apis.rwDB, 1, pruneGatingMergeHeight)
 	require.NoError(t, gateOnOldBlock(), "within the window the remembered verdict answers")
 
-	apis.eth._preMergeDataTTL = 0
+	apis.eth._preMergeData.SetTTL(0)
 	require.ErrorIs(t, gateOnOldBlock(), state.PrunedError, "past the window the datadir is read again")
 }
 

--- a/rpc/jsonrpc/eth_api.go
+++ b/rpc/jsonrpc/eth_api.go
@@ -29,6 +29,7 @@ import (
 	"github.com/holiman/uint256"
 
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/concurrent"
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/common/math"
@@ -150,10 +151,9 @@ type BaseAPI struct {
 	_genesis                  atomic.Pointer[types.Block]
 	_pruneMode                atomic.Pointer[prune.Mode]
 	_commitmentHistoryEnabled atomic.Pointer[bool]
-	_preMergeData             atomic.Pointer[preMergeVerdict]
-	_preMergeDataTTL          time.Duration
-	_preMergeProbeMu          sync.Mutex
-	_preMergeProbeInFlight    *preMergeProbe
+	// _preMergeData is kept for a TTL rather than settled once: it reads live snapshot
+	// availability, which widens as segments arrive.
+	_preMergeData concurrent.CachedValue[bool]
 
 	_blockReader dbservices.FullBlockReader
 	_txNumReader rawdbv3.TxNumsReader
@@ -194,14 +194,13 @@ func NewBaseApi(f *rpchelper.Filters, stateCache kvcache.Cache, blockReader dbse
 		evmCallTimeout = rpccfg.DefaultEvmCallTimeout
 	}
 
-	return &BaseAPI{
+	api := &BaseAPI{
 		filters:           f,
 		stateCache:        stateCache,
 		blocksLRU:         blocksLRU,
 		_blockReader:      blockReader,
 		_txnReader:        blockReader,
 		_txNumReader:      blockReader.TxnumReader(),
-		_preMergeDataTTL:  defaultPreMergeDataTTL,
 		evmCallTimeout:    evmCallTimeout,
 		_engine:           engine,
 		receiptsGenerator: receipts.NewGenerator(conf.Dirs, blockReader, engine, stateCache, evmCallTimeout, f),
@@ -211,6 +210,8 @@ func NewBaseApi(f *rpchelper.Filters, stateCache kvcache.Cache, blockReader dbse
 		getLogsMaxResults: conf.GetLogsMaxResults,
 		logQueryLimit:     conf.LogQueryLimit,
 	}
+	api._preMergeData.SetTTL(defaultPreMergeDataTTL)
+	return api
 }
 
 func (api *BaseAPI) chainConfig(ctx context.Context, tx kv.Tx) (*chain.Config, error) {
@@ -456,23 +457,6 @@ func (api *BaseAPI) headerByHash(ctx context.Context, hash common.Hash, tx kv.Tx
 	return api._blockReader.Header(ctx, overlayTx, hash, *number)
 }
 
-// preMergeVerdict is the archive-vs-expiry answer with the time it was observed: it
-// reads live snapshot availability, which widens as segments arrive.
-type preMergeVerdict struct {
-	holds bool
-	at    time.Time
-}
-
-// preMergeProbe is a probe other callers can wait on rather than repeat. Its result is
-// readable once done is closed.
-type preMergeProbe struct {
-	done  chan struct{}
-	holds bool
-	err   error
-}
-
-var errPreMergeProbeAbandoned = errors.New("pre-merge block data probe did not complete")
-
 const defaultPreMergeDataTTL = 30 * time.Second
 
 // systemTxsPerBlock is the pair of system entries every block carries in the txnum
@@ -534,60 +518,22 @@ func (api *BaseAPI) blocksFollowChainHistoryExpiry(ctx context.Context, tx kv.Tx
 // spanning the merge point reaches below it.
 func (api *BaseAPI) holdsPreMergeBlockData(ctx context.Context, tx kv.Tx, mergeHeight uint64) (bool, error) {
 	for {
-		if v := api._preMergeData.Load(); v != nil && time.Since(v.at) < api._preMergeDataTTL {
-			return v.holds, nil
+		if holds, observed, fresh := api._preMergeData.Load(); observed && fresh {
+			return holds, nil
 		}
-		probe, leader := api.joinPreMergeProbe()
-		if leader {
-			return api.runPreMergeProbe(ctx, tx, mergeHeight, probe)
+		holds, ran, err := api._preMergeData.Produce(ctx, func() (bool, bool, error) {
+			return api.probePreMergeBlockData(ctx, tx, mergeHeight)
+		})
+		switch {
+		case err == nil:
+			return holds, nil
+		case ran || ctx.Err() != nil:
+			return false, err
 		}
-		select {
-		case <-probe.done:
-			if probe.err == nil {
-				return probe.holds, nil
-			}
-			// The probe reads through the transaction of the caller that ran it, so its
-			// failure is about that caller rather than about the datadir: ask again here.
-		case <-ctx.Done():
-			return false, ctx.Err()
-		}
+		// The probe reads through the transaction of the caller that ran it, so a failure
+		// is about that caller rather than about the datadir: one that only waited asks
+		// again on its own.
 	}
-}
-
-// runPreMergeProbe answers the callers waiting on probe. A probe that dies without a
-// result must still release them, and with an error rather than its zero verdict, so
-// that the next caller asks again instead of taking an answer nobody produced.
-func (api *BaseAPI) runPreMergeProbe(ctx context.Context, tx kv.Tx, mergeHeight uint64, probe *preMergeProbe) (bool, error) {
-	holds, decided := false, false
-	err := errPreMergeProbeAbandoned
-	defer func() { api.finishPreMergeProbe(probe, holds, err) }()
-
-	holds, decided, err = api.probePreMergeBlockData(ctx, tx, mergeHeight)
-	if err == nil && decided {
-		api._preMergeData.Store(&preMergeVerdict{holds: holds, at: time.Now()})
-	}
-	return holds, err
-}
-
-// joinPreMergeProbe registers this caller as the one running the probe, or hands back
-// the probe already in flight. The lock covers that bookkeeping alone, never the probe.
-func (api *BaseAPI) joinPreMergeProbe() (*preMergeProbe, bool) {
-	api._preMergeProbeMu.Lock()
-	defer api._preMergeProbeMu.Unlock()
-	if probe := api._preMergeProbeInFlight; probe != nil {
-		return probe, false
-	}
-	probe := &preMergeProbe{done: make(chan struct{})}
-	api._preMergeProbeInFlight = probe
-	return probe, true
-}
-
-func (api *BaseAPI) finishPreMergeProbe(probe *preMergeProbe, holds bool, err error) {
-	api._preMergeProbeMu.Lock()
-	defer api._preMergeProbeMu.Unlock()
-	probe.holds, probe.err = holds, err
-	close(probe.done)
-	api._preMergeProbeInFlight = nil
 }
 
 // probePreMergeBlockData answers holdsPreMergeBlockData from what is on disk. It reports

--- a/rpc/jsonrpc/eth_simulation.go
+++ b/rpc/jsonrpc/eth_simulation.go
@@ -743,7 +743,7 @@ func (s *simulator) computeSimulatedStateRoot(
 	}
 
 	// No commitment history: compute from state history if blocks are not frozen, otherwise leave root as zero.
-	if s.blockReader.FrozenBlocks() == 0 {
+	if frozen, observed := s.blockReader.FrozenBlocksObserved(); observed && frozen == 0 {
 		txNum := minTxNum + 1 + uint64(len(bsc.Calls))
 		stateRoot, err := s.computeCommitmentFromStateHistory(ctx, tx, sharedDomains, touchedKeys, parent.Number.Uint64(), txNum)
 		if err != nil {

--- a/rpc/jsonrpc/pre_merge_probe_test.go
+++ b/rpc/jsonrpc/pre_merge_probe_test.go
@@ -71,7 +71,9 @@ func (r *probeBlockReader) CanonicalBodyForStorage(ctx context.Context, tx kv.Ge
 }
 
 func newProbeAPI(reader dbservices.FullBlockReader) *BaseAPI {
-	return &BaseAPI{_blockReader: reader, _preMergeDataTTL: time.Minute}
+	api := &BaseAPI{_blockReader: reader}
+	api._preMergeData.SetTTL(time.Minute)
+	return api
 }
 
 type probeResult struct {
@@ -488,7 +490,8 @@ func TestPreMergeGateLeavesAMissingSearchBodyUnanswered(t *testing.T) {
 
 	require.ErrorIs(t, api.checkPruneBlocks(t.Context(), nil, 1), state.PrunedError,
 		"a body the search needs and cannot read does not open the gate")
-	require.Nil(t, api._preMergeData.Load(), "a question left open is not an observation")
+	_, observed, _ := api._preMergeData.Load()
+	require.False(t, observed, "a question left open is not an observation")
 }
 
 // TestPreMergeSearchStopsAtItsReadBudget pins that a search walking past its budget

--- a/rpc/jsonrpc/receipts/post_state_calculated_test.go
+++ b/rpc/jsonrpc/receipts/post_state_calculated_test.go
@@ -40,10 +40,18 @@ type unreachableFrozenBlocks struct {
 	t *testing.T
 }
 
-func (r unreachableFrozenBlocks) FrozenBlocks() uint64 {
+func (r unreachableFrozenBlocks) FrozenBlocksObserved() (uint64, bool) {
 	r.t.Fatal("FrozenBlocks read for a block whose fork answers on its own")
-	return 0
+	return 0, false
 }
+
+// neverObservedFrozenBlocks stands for a remote rpcdaemon whose backend has not answered
+// yet: the count it reports is a default, not an observation.
+type neverObservedFrozenBlocks struct {
+	dbservices.FullBlockReader
+}
+
+func (r neverObservedFrozenBlocks) FrozenBlocksObserved() (uint64, bool) { return 0, false }
 
 func TestPostStateCalculated(t *testing.T) {
 	t.Parallel()
@@ -59,6 +67,11 @@ func TestPostStateCalculated(t *testing.T) {
 	t.Run("below the fork commitment history decides without it", func(t *testing.T) {
 		t.Parallel()
 		require.True(t, PostStateCalculated(cfg, byzantium-1, true, unreachableFrozenBlocks{t: t}))
+	})
+
+	t.Run("a count that was never observed does not stand for an absent snapshot", func(t *testing.T) {
+		t.Parallel()
+		require.False(t, PostStateCalculated(cfg, byzantium-1, false, neverObservedFrozenBlocks{}))
 	})
 }
 

--- a/rpc/jsonrpc/receipts/receipts_generator.go
+++ b/rpc/jsonrpc/receipts/receipts_generator.go
@@ -469,7 +469,11 @@ func PostStateCalculated(cfg *chain.Config, blockNum uint64, commitmentHistoryEn
 	if cfg.IsByzantium(blockNum) {
 		return false
 	}
-	return commitmentHistoryEnabled || blockReader.FrozenBlocks() == 0
+	if commitmentHistoryEnabled {
+		return true
+	}
+	frozen, observed := blockReader.FrozenBlocksObserved()
+	return observed && frozen == 0
 }
 
 func (g *Generator) GetReceipts(ctx context.Context, cfg *chain.Config, tx kv.TemporalTx, block *types.Block, opts eth.ReceiptsOpts) (_ types.Receipts, err error) {


### PR DESCRIPTION
Follow-up to #23322. #23690 closed seven of its deferred review notes and #23759 two more; this closes the three that are about `RemoteBlockReader.FrozenBlocks` and the mechanism behind it.

| Note | Site | Change |
| --- | --- | --- |
| [r3885705116](https://github.com/erigontech/erigon/pull/23322#discussion_r3885705116) | `block_reader.go` | a slow backend no longer costs every caller a full timeout |
| [r3885704185](https://github.com/erigontech/erigon/pull/23322#discussion_r3885704185) | `block_reader.go` | the zero handed out before the backend answers is no longer read as "no snapshots" |
| [r3885706881](https://github.com/erigontech/erigon/pull/23322#discussion_r3885706881) | `block_reader.go`, `eth_api.go` | one shared TTL-cache instead of two hand-rolled ones |

## Change

- The refresh runs on a goroutine of its own; a caller that has a value to serve returns without waiting for the next one. A failed attempt is stamped like a successful one, so an unreachable backend costs one attempt per TTL instead of one per caller and per request.
- `FrozenBlocksObserved() (uint64, bool)` reports the count together with whether the backend ever answered. `receipts.PostStateCalculated` and the `eth_simulateV1` commitment path both read it; those are the two sentinel readers a remote reader can reach.
- `common/concurrent.CachedValue[T]` holds what the getter and `holdsPreMergeBlockData` each kept by hand: one TTL, one dedup, one rule for what a failed pass leaves behind. Each site keeps its own waiting policy — `Produce` runs on the caller's goroutine, `Go` refreshes behind it.

## For review

**`singleflight` was tried and dropped.** `DoChan` cannot join the pass in flight without possibly starting one of its own, and it runs the producer on a goroutine the caller does not own. That is unsafe for the pre-merge probe, which reads through the caller's `kv.Tx`: a caller released by `ctx.Done()` rolls that transaction back under a live reader. `Produce` runs the pass on the caller's goroutine instead. `DoChan` also turns a producer panic into `go panic(e)`, which ends the process rather than the request.

**An unobserved count now reads as "snapshots exist".** For a pre-Byzantium block on a remote rpcdaemon whose backend has not answered yet, `PostStateCalculated` returns false, so the stored receipt is served — possibly without its `root` field — where before the block was re-executed and the gate could answer `PrunedError` for receipts that are on disk. That is the direction the note asks for, and the window is one TTL after a failed round trip.

**Panics.** `Produce` publishes the failed pass and re-panics, so the RPC server logs it as before; `Go` contains and logs it with the stack, since its goroutine has no caller to recover it.

## Tests

`common/concurrent/cached_value_test.go` (11) pins the contract, including that a caller running the pass finishes it before returning while one that only waits is released by its own context. `TestRemoteBlockReaderFrozenBlocks*` cover the getter, `rpc/jsonrpc/receipts/post_state_calculated_test.go` the sentinel. The `eth_simulateV1` leg has no dedicated test — the branch sits inside the commitment path.

`make lint` clean; `./common/concurrent/...`, `./db/snapshotsync/freezeblocks/...`, `./rpc/jsonrpc/...`, `./execution/blockreplay/...`, `./cmd/rpcdaemon/...` green, with `-race` on the concurrency tests.
