### PR TITLE
commitment: workers amount to base on `GOMAXPROCS` instead of `NumCPU`

### DIFF
--- a/execution/commitment/parallel_patricia_hashed.go
+++ b/execution/commitment/parallel_patricia_hashed.go
@@ -28,7 +28,9 @@ import (
 	"time"
 )
 
-var defaultParallelCommitmentWorkers = runtime.NumCPU()
+// Must track the same quantity as maxFoldConcurrency: parallelMountConcurrency mins
+// the two, so sourcing this from anything else silently caps mounting below folding.
+var defaultParallelCommitmentWorkers = max(1, runtime.GOMAXPROCS(0))
 
 type ParallelPatriciaHashed struct {
 	template       *HexPatriciaHashed

--- a/execution/commitment/parallel_patricia_hashed_test.go
+++ b/execution/commitment/parallel_patricia_hashed_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -74,9 +73,9 @@ func TestParallelPatriciaHashedSkeletonPlumbing(t *testing.T) {
 		assert.Equal(t, 4, p.numWorkers)
 
 		p.SetNumWorkers(0)
-		assert.Equal(t, runtime.NumCPU(), p.numWorkers)
+		assert.Equal(t, defaultParallelCommitmentWorkers, p.numWorkers)
 		p.SetNumWorkers(-3)
-		assert.Equal(t, runtime.NumCPU(), p.numWorkers)
+		assert.Equal(t, defaultParallelCommitmentWorkers, p.numWorkers)
 	})
 
 	t.Run("ResetContextPropagates", func(t *testing.T) {


### PR DESCRIPTION
- a container CPU limit — since Go 1.25, `GOMAXPROCS` [defaults to the container's CPU limit](https://go.dev/blog/container-aware-gomaxprocs#new-default) when that is below the core count, while `NumCPU` still reports the machine's cores. There `NumCPU > GOMAXPROCS`, so the default over-subscribes relative to the limit the runtime is respecting