### PR TITLE
db/seg: fault mapped pages in from C so the read releases its P

### DIFF
--- a/db/seg/prefault_cgo_linux.go
+++ b/db/seg/prefault_cgo_linux.go
@@ -1,0 +1,57 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build linux
+
+package seg
+
+/*
+#include <stddef.h>
+
+static void erigon_prefault(const char *p, size_t n, size_t step) {
+	volatile char sink = 0;
+	for (size_t i = 0; i < n; i += step) {
+		sink ^= p[i];
+	}
+	(void)sink;
+}
+*/
+import "C"
+
+import (
+	"unsafe"
+
+	"github.com/erigontech/erigon/common/dbg"
+)
+
+var residencyCgoPrefault = dbg.EnvBool("RESIDENCY_CGO_PREFAULT", false)
+
+// cgoPrefault faults a mapped range in from C. A page fault taken in Go code
+// keeps the goroutine's P for the whole ~70us of the read, because the runtime
+// is never told the thread blocked; cgocall runs entersyscall first, so the same
+// fault taken from C releases the P and another goroutine can run. Concurrent
+// reads are otherwise capped at GOMAXPROCS.
+func (d *Decompressor) cgoPrefault(fileOffset int64, n int) bool {
+	if !residencyCgoPrefault || n <= 0 {
+		return false
+	}
+	off := int(fileOffset)
+	if off < 0 || off+n > len(d._mmapHandle) {
+		return false
+	}
+	C.erigon_prefault((*C.char)(unsafe.Pointer(&d._mmapHandle[off])), C.size_t(n), C.size_t(pageSize))
+	return true
+}

--- a/db/seg/residency_gate_linux.go
+++ b/db/seg/residency_gate_linux.go
@@ -105,6 +105,9 @@ func (d *Decompressor) residencyBitmap() *residencyBitmap {
 }
 
 func (d *Decompressor) blockingAsyncRead(fileOffset int64, n int) {
+	if d.cgoPrefault(fileOffset, n) {
+		return
+	}
 	iouring.BlockingRead(int(d.f.Fd()), fileOffset, n)
 }
 


### PR DESCRIPTION
Draft / RFC. The mechanism is measured and reproducible; the end-to-end win is **not** there yet, and I would like input on where to apply it before taking it further.

## The problem

A page fault taken in Go code keeps the goroutine's `P` for the entire duration of the read. The fault is a CPU trap, not a syscall, so it never goes through `entersyscall` and the runtime cannot tell the thread blocked — `sysmon` only preempts a running `P` after `forcePreemptNS` (10ms), while a fault resolves in ~70us. Concurrent reads are therefore hard-capped at `GOMAXPROCS`, and while those `P`s are parked no other goroutine can compute.

`cgocall` does run `entersyscall`, so the same fault taken from C releases the `P` first.

Note the asymmetry inside Erigon today: MDBX is also mmap-based, but we reach it through cgo, so its faults already release the `P`. Only the `seg` reader faults from Go.

## Measurement

Standalone program: mmap a real 11.7GB `v1.1-accounts.0-1024000.kv`, `MADV_RANDOM`, random 4KB page touches, **256 goroutines held constant**, `taskset` to 6 hyperthreads, caches dropped between runs. The only variable is whether the byte is touched from Go or from C.

| GOMAXPROCS | fault from Go | fault from C | ratio |
|---|---|---|---|
| 2 | 26,233/s | 48,856/s | 1.86x |
| 4 | 52,841/s | 112,933/s | 2.14x |
| 6 | 80,904/s | 182,402/s | **2.25x** |
| 8 | 110,737/s | 255,697/s | 2.31x |
| 16 | 232,403/s | 486,196/s | 2.09x |
| 32 | 468,818/s | 684,663/s | 1.46x |
| 64 | 743,324/s | 771,916/s | 1.04x |

Faulting from C at `GOMAXPROCS=6` reaches what Go-side faulting needs `GOMAXPROCS=16` for. The two converge at 64, where the device and CPU bind instead.

Supporting evidence for the same mechanism, from the Go side only: fault throughput is linear in `GOMAXPROCS` and **independent of core count** — a 2-, 6- and 12-hyperthread cpuset all give 26k/53k/81k/111k at `GOMAXPROCS` 2/4/6/8. Per-`P` rate stays pinned at ~13-14.6k/s, i.e. ~70us, one outstanding read per `P`. `runtime.LockOSThread` does not help (3-13% slower, still linear): it binds G to M and says nothing about P.

## What this change does

Routes the residency gate's pre-fault through C instead of io_uring, behind `RESIDENCY_CGO_PREFAULT` (default off). It keeps the mapping zero-copy, unlike a buffer-backed read.

## Why it is a draft: no end-to-end win yet

On `ether_transfers diff_to_contract@300M` (EIP-7870 spec, 6 logical cores, cold):

| arm | MGas/s | read_GB | read_iops | cpu_s |
|---|---|---|---|---|
| baseline | 81.02 | 1.728 | 311,543 | 8.56 |
| cgo prefault | 79.74 | 1.782 | 312,803 | 9.29 |
| `MADV_POPULATE_READ` | 78.34 | 1.778 | 312,009 | 9.56 |
| pread | 86.56 | 2.249 | 266,709 | 9.18 |

The cgo arm's I/O signature is *identical* to baseline (312k ops, ~5.7KB each).

The pre-fault is definitely running — a CPU profile of that arm shows `ensureResident` -> `blockingAsyncRead` -> `cgoPrefault` -> `_Cfunc_erigon_prefault` at 4.61% cum — so this is not a wiring problem. It converts faults and still does not pay, which is the part I do not yet understand.

Thread counts explain it. Sampling `/proc/<pid>/status` at 100ms:

| arm | MGas/s | threads p50 | p90 | max |
|---|---|---|---|---|
| baseline | 81.83 | 14 | 16 | 16 |
| cgo prefault | 81.39 | 14 | 19 | 19 |
| GOMAXPROCS=32 | 133.46 | 29 | 45 | 45 |

The cgo arm barely moves the thread count. If the pre-fault were releasing Ps at scale, blocked Ms would accumulate and the runtime would spawn replacements. It does not, because Erigon never has many reads outstanding in the first place — around 14 threads of activity total. The isolated benchmark has 256 goroutines all faulting at once, so there the P cap binds hard and releasing it is worth 2.25x; Erigon is not read-pressure-bound in the same way, so converting individual faults buys nothing.

This also means raising GOMAXPROCS does **not** work by adding read concurrency, as I first assumed: array queue depth only reaches 7.31 at GOMAXPROCS=32, not ~26. It works because parked Ps stop starving *other* work — CPU utilisation goes 38.8% -> 75.6% on the same six hyperthreads.

Two further hypotheses are falsified:

- *the path is not wired* — no, the profile above shows it running;
- *the window is too narrow to cover neighbouring metadata* — no, `RESIDENCY_WINDOW_PAGES=8` makes it worse (75.52 MGas/s, 823k ops, 3.87GB: 2.6x the operations and 2.2x the bytes of baseline). Whatever still faults is not adjacent to the value, so a wider contiguous window only amplifies reads.

`EnableResidencyGate` is set only on `.kv` data readers in `Domain.dataReader`, so one possibility is simply that the dominant cold-path faults are elsewhere — but I have not identified where, and would rather ask than guess.

`pread` is the only arm that improves, and for an unrelated reason — it goes through the ordinary file path and gets kernel readahead (267k ops at 8.4KB vs 312k at 5.5KB), where mmap under `MADV_RANDOM` has readahead disabled. That is I/O coalescing, not `P` release, and the two are additive rather than alternatives.

## Questions

- Where else should the pre-fault go? The remaining faults are not in `.bt` (its node blob is decoded at open), so I would like a pointer to the mapped reads that actually dominate a cold `getLatestFromFiles`.
- Is the residency bitmap worth keeping? Its `mincore` seed scans the whole mapping per file on first touch — 2.38s of CPU (24.7% of profile) across ~100 files — to avoid a per-read check that an idempotent cgo touch makes unnecessary. Skipping the seed alone is worth +7% with the pread variant.