### PR TITLE
execution/engineapi, rpc/requests: wait for a poke to be pending before building

### DIFF
--- a/execution/engineapi/engine_api_state_churn_reorg_test.go
+++ b/execution/engineapi/engine_api_state_churn_reorg_test.go
@@ -271,6 +271,7 @@ func applyStateChurnPoke(
 	t.Helper()
 	txn, err := churn.Poke(transactOpts, big.NewInt(seed))
 	require.NoError(t, err)
+	require.NoError(t, eat.TxnInclusionVerifier.WaitForPending(ctx, transactOpts.From, txn.Hash()))
 	block, err := eat.MockCl.BuildCanonicalBlock(ctx)
 	require.NoError(t, err)
 	require.NoError(t, eat.TxnInclusionVerifier.VerifyTxnsInclusion(ctx, block.ExecutionPayload, txn.Hash()))
@@ -303,6 +304,7 @@ func churnAndAssert(
 			}
 			return err == nil
 		}, 30*time.Second, 100*time.Millisecond, "poke submission did not settle")
+		require.NoError(t, eat.TxnInclusionVerifier.WaitForPending(ctx, transactOpts.From, txn.Hash()))
 		block, err := eat.MockCl.BuildCanonicalBlock(ctx)
 		require.NoError(t, err)
 		require.NoError(t, eat.TxnInclusionVerifier.VerifyTxnsInclusion(ctx, block.ExecutionPayload, txn.Hash()))

--- a/execution/engineapi/engine_api_state_churn_reorg_test.go
+++ b/execution/engineapi/engine_api_state_churn_reorg_test.go
@@ -246,6 +246,7 @@ func buildChurnChain(
 
 	addr, deployTxn, churn, err := contracts.DeployStateChurn(transactOpts, eat.ContractBackend)
 	require.NoError(t, err)
+	require.NoError(t, eat.TxnInclusionVerifier.WaitForPending(ctx, transactOpts.From, deployTxn.Hash()))
 	deployBlock, err := eat.MockCl.BuildCanonicalBlock(ctx)
 	require.NoError(t, err)
 	require.NoError(t, eat.TxnInclusionVerifier.VerifyTxnsInclusion(ctx, deployBlock.ExecutionPayload, deployTxn.Hash()))

--- a/execution/engineapi/engineapitester/engine_api_tester.go
+++ b/execution/engineapi/engineapitester/engine_api_tester.go
@@ -249,7 +249,7 @@ func InitialiseEngineApiTester(ctx context.Context, args EngineApiTesterInitArgs
 	engineApiPort := engineApiListener.Addr().(*net.TCPAddr).Port
 	logger.Debug("[engine-api-tester] selected ports", "engineApi", engineApiPort, "jsonRpc", jsonRpcPort)
 
-	httpAPIs := []string{"eth"}
+	httpAPIs := []string{"eth", "txpool"}
 	if args.EnableTestingAPI {
 		httpAPIs = append(httpAPIs, "testing")
 	}

--- a/execution/engineapi/engineapitester/txn_inclusion_verifier.go
+++ b/execution/engineapi/engineapitester/txn_inclusion_verifier.go
@@ -141,11 +141,12 @@ type OrderedInclusion struct {
 	TxnIndex uint64
 }
 
-// WaitForPending blocks until the pool holds hash in its pending subpool for
-// sender. A transaction the pool accepted can still sit in queued while the
-// pool catches up with a new head, and block building selects only pending, so
-// building immediately after a successful submission can produce a block
-// without it.
+// WaitForPending blocks until the pool reports hash as pending for sender.
+// Block building selects only the pending subpool, and a transaction the pool
+// accepted can sit in queued while the pool catches up with a new head, so
+// building right after a successful submission can leave it out. The signal is
+// a superset: txpool_contentFrom folds baseFee into pending, so a txn priced
+// below the base fee reports ready while the builder still skips it.
 func (v TxnInclusionVerifier) WaitForPending(
 	ctx context.Context,
 	sender common.Address,
@@ -153,15 +154,19 @@ func (v TxnInclusionVerifier) WaitForPending(
 ) error {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
+	var lastErr error
 	for {
 		pending, err := v.rpcApiClient.TxpoolPendingHashesFrom(sender)
-		if err == nil {
-			if _, ok := pending[hash]; ok {
-				return nil
-			}
+		if err != nil {
+			lastErr = err
+		} else if _, ok := pending[hash]; ok {
+			return nil
 		}
 		select {
 		case <-ctx.Done():
+			if lastErr != nil {
+				return fmt.Errorf("txn %s not pending in pool: %w (last query error: %v)", hash, ctx.Err(), lastErr)
+			}
 			return fmt.Errorf("txn %s not pending in pool: %w", hash, ctx.Err())
 		case <-time.After(20 * time.Millisecond):
 		}

--- a/execution/engineapi/engineapitester/txn_inclusion_verifier.go
+++ b/execution/engineapi/engineapitester/txn_inclusion_verifier.go
@@ -165,7 +165,7 @@ func (v TxnInclusionVerifier) WaitForPending(
 		select {
 		case <-ctx.Done():
 			if lastErr != nil {
-				return fmt.Errorf("txn %s not pending in pool: %w (last query error: %v)", hash, ctx.Err(), lastErr)
+				return fmt.Errorf("txn %s not pending in pool: %w (last query error: %w)", hash, ctx.Err(), lastErr)
 			}
 			return fmt.Errorf("txn %s not pending in pool: %w", hash, ctx.Err())
 		case <-time.After(20 * time.Millisecond):

--- a/execution/engineapi/engineapitester/txn_inclusion_verifier.go
+++ b/execution/engineapi/engineapitester/txn_inclusion_verifier.go
@@ -140,3 +140,30 @@ type OrderedInclusion struct {
 	TxnHash  common.Hash
 	TxnIndex uint64
 }
+
+// WaitForPending blocks until the pool holds hash in its pending subpool for
+// sender. A transaction the pool accepted can still sit in queued while the
+// pool catches up with a new head, and block building selects only pending, so
+// building immediately after a successful submission can produce a block
+// without it.
+func (v TxnInclusionVerifier) WaitForPending(
+	ctx context.Context,
+	sender common.Address,
+	hash common.Hash,
+) error {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	for {
+		pending, err := v.rpcApiClient.TxpoolPendingHashesFrom(sender)
+		if err == nil {
+			if _, ok := pending[hash]; ok {
+				return nil
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("txn %s not pending in pool: %w", hash, ctx.Err())
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+}

--- a/execution/engineapi/engineapitester/txn_inclusion_verifier.go
+++ b/execution/engineapi/engineapitester/txn_inclusion_verifier.go
@@ -157,10 +157,11 @@ func (v TxnInclusionVerifier) WaitForPending(
 	var lastErr error
 	for {
 		pending, err := v.rpcApiClient.TxpoolPendingHashesFrom(sender)
-		if err != nil {
-			lastErr = err
-		} else if _, ok := pending[hash]; ok {
-			return nil
+		lastErr = err
+		if err == nil {
+			if _, ok := pending[hash]; ok {
+				return nil
+			}
 		}
 		select {
 		case <-ctx.Done():

--- a/rpc/requests/request_generator.go
+++ b/rpc/requests/request_generator.go
@@ -88,6 +88,7 @@ type RequestGenerator interface {
 	Subscribe(ctx context.Context, method SubMethod, subChan any, args ...any) (event.Subscription, error)
 	UnsubscribeAll()
 	TxpoolContent() (int, int, int, error)
+	TxpoolPendingHashesFrom(address common.Address) (map[common.Hash]struct{}, error)
 	Call(args ethapi.CallArgs, blockRef rpc.BlockReference, overrides *ethapi.StateOverrides) ([]byte, error)
 	TraceCall(blockRef rpc.BlockReference, args ethapi.CallArgs, traceOpts ...TraceOpt) (*TraceCallResult, error)
 	DebugAccountAt(blockHash common.Hash, txIndex uint64, account common.Address) (*AccountResult, error)
@@ -137,6 +138,8 @@ var Methods = struct {
 	AdminNodeInfo RPCMethod
 	// TxpoolContent represents the txpool_content method
 	TxpoolContent RPCMethod
+	// TxpoolContentFrom represents the txpool_contentFrom method
+	TxpoolContentFrom RPCMethod
 	// OTSGetBlockDetails represents the ots_getBlockDetails method
 	OTSGetBlockDetails RPCMethod
 	// ETHNewHeads represents the eth_newHeads sub method
@@ -164,6 +167,7 @@ var Methods = struct {
 	ETHBlockNumber:            "eth_blockNumber",
 	AdminNodeInfo:             "admin_nodeInfo",
 	TxpoolContent:             "txpool_content",
+	TxpoolContentFrom:         "txpool_contentFrom",
 	OTSGetBlockDetails:        "ots_getBlockDetails",
 	ETHNewHeads:               "eth_newHeads",
 	ETHLogs:                   "eth_logs",

--- a/rpc/requests/tx.go
+++ b/rpc/requests/tx.go
@@ -18,6 +18,8 @@ package requests
 
 import (
 	"fmt"
+
+	"github.com/erigontech/erigon/common"
 )
 
 type EthTxPool struct {
@@ -79,4 +81,30 @@ func (reqGen *requestGenerator) TxpoolContent() (int, int, int, error) {
 func (req *requestGenerator) txpoolContent() (RPCMethod, string) {
 	const template = `{"jsonrpc":"2.0","method":%q,"params":[],"id":%d}`
 	return Methods.TxpoolContent, fmt.Sprintf(template, Methods.TxpoolContent, req.reqID)
+}
+
+// TxpoolPendingHashesFrom returns the hashes the pool holds for address in its
+// pending subpool. A transaction the pool accepted may still sit in queued,
+// where block building will not pick it up, so acceptance alone is not enough
+// to assert that the next block must contain it.
+func (reqGen *requestGenerator) TxpoolPendingHashesFrom(address common.Address) (map[common.Hash]struct{}, error) {
+	var b struct {
+		CommonResponse
+		Result map[string]map[string]struct {
+			Hash common.Hash `json:"hash"`
+		} `json:"result"`
+	}
+	const template = `{"jsonrpc":"2.0","method":%q,"params":["0x%x"],"id":%d}`
+	body := fmt.Sprintf(template, Methods.TxpoolContentFrom, address, reqGen.reqID)
+	if res := reqGen.rpcCallJSON(Methods.TxpoolContentFrom, body, &b); res.Err != nil {
+		return nil, fmt.Errorf("failed to fetch txpool content: %w", res.Err)
+	}
+	if b.Error != nil {
+		return nil, fmt.Errorf("txpool_contentFrom rpc failed: %w", b.Error)
+	}
+	hashes := make(map[common.Hash]struct{}, len(b.Result["pending"]))
+	for _, txn := range b.Result["pending"] {
+		hashes[txn.Hash] = struct{}{}
+	}
+	return hashes, nil
 }

--- a/rpc/requests/tx.go
+++ b/rpc/requests/tx.go
@@ -83,10 +83,9 @@ func (req *requestGenerator) txpoolContent() (RPCMethod, string) {
 	return Methods.TxpoolContent, fmt.Sprintf(template, Methods.TxpoolContent, req.reqID)
 }
 
-// TxpoolPendingHashesFrom returns the hashes the pool holds for address in its
-// pending subpool. A transaction the pool accepted may still sit in queued,
-// where block building will not pick it up, so acceptance alone is not enough
-// to assert that the next block must contain it.
+// TxpoolPendingHashesFrom returns the hashes txpool_contentFrom reports as
+// pending for address. The server folds the baseFee subpool into that bucket,
+// so the result is a superset of what block building selects.
 func (reqGen *requestGenerator) TxpoolPendingHashesFrom(address common.Address) (map[common.Hash]struct{}, error) {
 	var b struct {
 		CommonResponse


### PR DESCRIPTION

The state-churn helpers submit a transaction and immediately build the next
canonical block, then require that transaction to be in it. A successful local
submission only means the pool accepted the transaction, not that it reached the
pending subpool: while the pool is still catching up with a new head, the
transaction can be accepted into queued instead. Block building selects pending,
so the immediate payload can omit it and the assertion fails with "txns not found
in block".

Wait for the pool to report the transaction as pending before building.
eth_getTransactionCount on the pending block cannot express this - it resolves to
NonceFromAddress, which reads the all-subpools index and so advances for a queued
transaction too. txpool_contentFrom does separate the two, so the tester now
enables the txpool namespace and the request generator gains a query for the
pending hashes of one sender.

Fixes #23377

Verified: previously-failing `TestEngineApiUnwindAcrossDomainStepBoundaries` passes, and it plus `TestEngineApiReorgWithPruningInterference` pass `-count=3 -race`. The runtime is itself evidence the wait resolves rather than timing out — a broken query would add 30s per poke.

Not a data race despite the failing job being `race-tests`: no `WARNING: DATA RACE` appears in the log, only the assertion.