### PR TITLE
common/concurrent, db/snapshotsync: drop three review leftovers from #23812

### DIFF
--- a/common/concurrent/cached_value.go
+++ b/common/concurrent/cached_value.go
@@ -123,12 +123,10 @@ func (c *CachedValue[T]) run(r *run[T], produce func() (T, bool, error)) (value 
 	}()
 
 	value, store, err = produce()
-	return value, err
+	return
 }
 
-// publish records the attempt, stores what is worth keeping, and ends the pass. Closing
-// done before clearing running keeps a caller from starting a pass of its own while this
-// one is still published as in flight.
+// publish records the attempt, stores what is worth keeping, and ends the pass.
 func (c *CachedValue[T]) publish(r *run[T], value T, store bool, err error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/db/snapshotsync/freezeblocks/block_reader.go
+++ b/db/snapshotsync/freezeblocks/block_reader.go
@@ -172,11 +172,9 @@ func (r *RemoteBlockReader) FrozenBlocksObserved() (uint64, bool) {
 	if observed {
 		return value, true
 	}
-	timeout := time.NewTimer(r.frozenBlocksTimeout)
-	defer timeout.Stop()
 	select {
 	case <-refreshed:
-	case <-timeout.C:
+	case <-time.After(r.frozenBlocksTimeout):
 	}
 	value, observed, _ = r.frozenBlocks.Load()
 	return value, observed


### PR DESCRIPTION
Post-merge review cuts on the `FrozenBlocks` / `CachedValue` code merged in #23812. No behavior change, net -5 lines.

- `RemoteBlockReader.FrozenBlocksObserved` waits with `time.After` instead of `NewTimer` plus a deferred `Stop`. Since go 1.23 an unreferenced timer is collected on its own, and the one-shot `select` form is what `db/kv/kvcache/cache.go` and `db/kv/mdbx/kv_mdbx.go` already use.
- The `publish` docstring claimed that closing `done` before clearing `running` keeps a waiter from starting a pass of its own. Both writes happen under `c.mu` and `claim` takes the same mutex, so no caller can observe that order. The sentence is gone; the first one stays.
- `run` returns bare: the named results are already assigned on the line above.

No test added, per the trivial-change carve-out in the TDD guidelines: cosmetic only, no new logic. Existing `common/concurrent` tests and `make lint` are green.
