### PR TITLE
[r3.6] exec: rewrite the fee credit in place

### DIFF
--- a/execution/stagedsync/exec3_fee_merge_temp_test.go
+++ b/execution/stagedsync/exec3_fee_merge_temp_test.go
@@ -84,9 +84,12 @@ func TestRecordFeeMerge_RevalidationReleasesSupersededTemp(t *testing.T) {
 	be.recordFeeMerge(version, first, second, feeCreditNew, [2]accounts.Address{addr})
 	be.awaitMapReleases()
 
-	require.Same(t, second, be.feeMergeTemp[0].writes)
-	require.Equal(t, 0, first.Count(), "the superseded fee-merge temp must be released")
-	require.Equal(t, 1, second.Count())
+	require.Same(t, first, be.feeMergeTemp[0].writes, "the recorded product is rewritten in place")
+	require.Equal(t, 0, second.Count(), "the credit the rewrite consumed must be released")
+	require.Equal(t, 1, first.Count())
+	vw, ok := first.GetBalance(addr)
+	require.True(t, ok)
+	require.Equal(t, uint64(3), vw.Val.Uint64(), "the recorded product must carry the newest credit")
 }
 
 func TestRecordFeeMerge_AfterReExecutionKeepsStaleTemp(t *testing.T) {
@@ -343,6 +346,110 @@ func BenchmarkDropStaleVersionedWrites(b *testing.B) {
 			for b.Loop() {
 				be.dropStaleVersionedWrites(version, prev, next, [2]accounts.Address{coinbase, burnt})
 			}
+		})
+	}
+}
+
+// A re-credit at the same headers only moves the fee values, so the round must
+// rewrite them in the recorded set rather than rebuild it from the tx's whole
+// write set and pool the one it replaces.
+func TestRecordFeeMerge_ReCreditRewritesTheRecordedSet(t *testing.T) {
+	t.Parallel()
+	s := simpleTransferScenario()
+	r := newFeeCreditRound(t, s)
+
+	first, _ := r.run(t)
+	require.NotNil(t, first, "the first round must credit the tip")
+	merged := r.recorded()
+
+	r.setPreCreditBalance(s.coinbase, 9_000)
+	credit, _ := r.run(t)
+	require.NotNil(t, credit, "a moved coinbase makes the credit differ")
+
+	require.Same(t, merged, r.recorded(), "the same headers must be rewritten, not rebuilt")
+	require.Same(t, merged, r.credited(), "the rewritten set is still this version's credit")
+	require.Equal(t, findBalance(credit, s.coinbase).Val, findBalance(merged, s.coinbase).Val,
+		"the recorded set must carry the round's credit")
+	require.Equal(t, findAddress(credit, s.coinbase).Val, findAddress(merged, s.coinbase).Val,
+		"the account sibling must carry it too")
+
+	r.be.awaitMapReleases()
+	require.NotEqual(t, 0, merged.Count(), "the recorded set must not be released")
+}
+
+func feeMergeBenchWorkerWrites(b *testing.B, addrs, slots int) *state.WriteSet {
+	b.Helper()
+	ws := &state.WriteSet{}
+	for a := range addrs {
+		addr := feeMergeTestAddr(fmt.Sprintf("0x%040x", a+1))
+		ws.SetBalance(addr, &state.VersionedWrite[uint256.Int]{
+			WriteHeader: state.WriteHeader{Address: addr, Path: state.BalancePath},
+			Val:         *uint256.NewInt(uint64(a)),
+		})
+		ws.SetNonce(addr, &state.VersionedWrite[uint64]{
+			WriteHeader: state.WriteHeader{Address: addr, Path: state.NoncePath},
+			Val:         uint64(a),
+		})
+		for k := range slots {
+			key := accounts.InternKey(common.HexToHash(fmt.Sprintf("0x%x", k+1)))
+			ws.SetStorage(addr, key, &state.VersionedWrite[uint256.Int]{
+				WriteHeader: state.WriteHeader{Address: addr, Path: state.StoragePath, Key: key},
+				Val:         *uint256.NewInt(uint64(k)),
+			})
+		}
+	}
+	return ws
+}
+
+func feeMergeBenchTip(version state.Version, coinbase, burnt accounts.Address, amount uint64) *state.WriteSet {
+	tip := &state.WriteSet{}
+	for _, addr := range [...]accounts.Address{coinbase, burnt} {
+		acc := accounts.Account{Balance: *uint256.NewInt(amount), CodeHash: accounts.EmptyCodeHash}
+		tip.SetBalance(addr, &state.VersionedWrite[uint256.Int]{
+			WriteHeader: state.WriteHeader{Address: addr, Path: state.BalancePath, Version: version},
+			Val:         acc.Balance,
+		})
+		tip.SetAddress(addr, &state.VersionedWrite[*accounts.Account]{
+			WriteHeader: state.WriteHeader{Address: addr, Path: state.AddressPath, Version: version},
+			Val:         &acc,
+		})
+	}
+	return tip
+}
+
+// BenchmarkRecordFeeMerge measures one re-credit round against a worker write
+// set the size mainnet actually produces. The percentiles come from replaying
+// blocks 25881700-15, where a tx that gets credited sees 12-24 rounds.
+func BenchmarkRecordFeeMerge(b *testing.B) {
+	coinbase := feeMergeTestAddr("0x00000000000000000000000000000000000000c0")
+	burnt := feeMergeTestAddr("0x00000000000000000000000000000000000000b1")
+	version := state.Version{TxIndex: 0, TxNum: 1}
+	feeAddrs := [2]accounts.Address{coinbase, burnt}
+
+	for _, size := range []struct {
+		name         string
+		addrs, slots int
+	}{
+		{"p50=4", 2, 0},
+		{"p90=10", 2, 3},
+		{"p99=24", 4, 4},
+		{"max=444", 37, 10},
+	} {
+		b.Run(size.name, func(b *testing.B) {
+			be := feeMergeTestExecutor(b)
+			base := feeMergeBenchWorkerWrites(b, size.addrs, size.slots)
+			be.recordWorkerWrites(version, base)
+			be.recordFeeMerge(version, base, feeMergeBenchTip(version, coinbase, burnt, 1), feeCreditNew, feeAddrs)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			rounds := 0
+			for ; b.Loop(); rounds++ {
+				tip := feeMergeBenchTip(version, coinbase, burnt, uint64(rounds+2))
+				be.recordFeeMerge(version, be.blockIO.WriteSet(version.TxIndex), tip, feeCreditNew, feeAddrs)
+			}
+			b.StopTimer()
+			be.awaitMapReleases()
 		})
 	}
 }

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2546,6 +2546,18 @@ func (be *blockExecutor) recordFeeMerge(txVersion state.Version, prev, tipWrites
 		return
 	}
 
+	// The credit almost always lands on the same headers as the round before it,
+	// carrying only a moved value: overwrite those entries in the product that
+	// already holds them rather than pour the tx's whole write set into a fresh
+	// one and pool the set it replaces.
+	if outcome == feeCreditNew && superseded && rewritesCredit(temp.writes, tipWrites, feeAddrs) {
+		overwriteFeeWrites(temp.writes, tipWrites)
+		// calcFees hands the credit to this call and keeps no reference, so its
+		// maps go back to the pool now rather than waiting for the block.
+		tipWrites.ReleaseMaps()
+		return
+	}
+
 	// A credit is merged onto the worker's own writes, never onto an earlier
 	// round's product: an entry that credit emitted and this one does not would
 	// otherwise survive the merge.
@@ -2573,6 +2585,45 @@ func (be *blockExecutor) recordFeeMerge(txVersion state.Version, prev, tipWrites
 		be.feeMergeTemp[txVersion.TxIndex] = feeMerge{writes: merged, base: base, version: txVersion}
 	} else {
 		delete(be.feeMergeTemp, txVersion.TxIndex)
+	}
+}
+
+// rewritesCredit reports whether tip writes every fee entry recorded still
+// holds, so overwriting them in place leaves the set a rebuild would. An entry
+// recorded holds and tip does not would otherwise survive.
+func rewritesCredit(recorded, tip *state.WriteSet, feeAddrs [2]accounts.Address) bool {
+	for _, addr := range feeAddrs {
+		if addr.IsNil() {
+			continue
+		}
+		for _, path := range feeWritePaths {
+			h := state.WriteHeader{Address: addr, Path: path}
+			if recorded.Has(h) && !tip.Has(h) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// overwriteFeeWrites replaces dst's entries at tip's headers. It copies only
+// feeWritePaths, so a credit reaching any other path would be dropped.
+func overwriteFeeWrites(dst, tip *state.WriteSet) {
+	copied := 0
+	for a, vw := range tip.Addresses() {
+		dst.SetAddress(a, vw)
+		copied++
+	}
+	for a, vw := range tip.Balances() {
+		dst.SetBalance(a, vw)
+		copied++
+	}
+	for a, vw := range tip.SelfDestructs() {
+		dst.SetSelfDestruct(a, vw)
+		copied++
+	}
+	if dbg.AssertEnabled && copied != tip.Count() {
+		panic("fee credit wrote a path overwriteFeeWrites does not copy")
 	}
 }
 

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -1036,6 +1036,12 @@ func (s *WriteSet) addrs() map[accounts.Address]struct{} {
 // the self-destruct-vs-field priority iterate these in explicit order (e.g.
 // SelfDestructs before the reviving field writes) rather than relying on a flat
 // stream's element order.
+func (s *WriteSet) Addresses() iter.Seq2[accounts.Address, *VersionedWrite[*accounts.Account]] {
+	if s == nil {
+		return maps.All(map[accounts.Address]*VersionedWrite[*accounts.Account](nil))
+	}
+	return maps.All(s.address)
+}
 func (s *WriteSet) Balances() iter.Seq2[accounts.Address, *VersionedWrite[uint256.Int]] {
 	if s == nil {
 		return maps.All(map[accounts.Address]*VersionedWrite[uint256.Int](nil))


### PR DESCRIPTION
Cherry-pick of #23703 to release/3.6. 

## r3.6-specific adaptations

- `WriteSet.Addresses()` written against r3.6's `maps.All` iterators; `main`'s `writeSetSeq` helper does not exist here.
- `WriteSet.Released()` does not exist on r3.6 — assertions use `Count()`.
- `feeCreditRound.run` returns `(*WriteSet, feeOutcome)` on r3.6, single-value on `main`.
- Release is `be.awaitMapReleases()` on r3.6, `be.superseded.release()` on `main`. `BenchmarkRecordFeeMerge` therefore drops the `rebuilds/op` metric, which counted entries in the `main`-only `be.superseded` slice.

`BenchmarkRecordFeeMerge` is flat in the worker write-set size: 384 / 355 / 359 / 386 ns/op for p50=4 / p90=10 / p99=24 / max=444.

Stacked on #23825, which is stacked on #23828 (flaky `TestFairMixRemoveSource` fix). Retargets down the chain as each merges.
