### PR TITLE
[r3.6] ci: pin Geth used by Hive DevP2P

### DIFF
--- a/.github/workflows/hive-versions.json
+++ b/.github/workflows/hive-versions.json
@@ -1,4 +1,5 @@
 {
   "hive_ref": "3184ac37d3dfbb9b8b0348ae70ea98bb61fa6f13",
+  "devp2p_geth_ref": "157c94647241b260d19e5a8e01a08e439591e504",
   "execution_apis_ref": "f74de4b86e3b011384808c294c3d71f2854729a2"
 }

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -95,8 +95,12 @@ jobs:
       - name: Read pinned versions
         id: hive-version
         run: |
-          echo "ref=$(jq -r .hive_ref erigon-full/.github/workflows/hive-versions.json)" >> "$GITHUB_OUTPUT"
-          echo "execution_apis_ref=$(jq -r '.execution_apis_ref // empty' erigon-full/.github/workflows/hive-versions.json)" >> "$GITHUB_OUTPUT"
+          versions=erigon-full/.github/workflows/hive-versions.json
+          {
+            echo "ref=$(jq -r .hive_ref "$versions")"
+            echo "devp2p_geth_ref=$(jq -r '.devp2p_geth_ref // empty' "$versions")"
+            echo "execution_apis_ref=$(jq -r '.execution_apis_ref // empty' "$versions")"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Checkout Hive
         uses: actions/checkout@v7
@@ -106,6 +110,23 @@ jobs:
           ref: ${{ steps.hive-version.outputs.ref }}
           path: hive
           persist-credentials: false
+
+      # TODO: remove devp2p_geth_ref from hive-versions.json after Geth fixes its fixture and https://github.com/erigontech/erigon/issues/22808 is completed
+      - name: Pin Geth used by DevP2P
+        if: ${{ matrix.sim == 'devp2p' && steps.hive-version.outputs.devp2p_geth_ref != '' }}
+        env:
+          GETH_REF: ${{ steps.hive-version.outputs.devp2p_geth_ref }}
+        run: |
+          if ! echo "$GETH_REF" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "Error: devp2p_geth_ref is not a valid git SHA: $GETH_REF"
+            exit 1
+          fi
+          dockerfile=hive/simulators/devp2p/Dockerfile
+          sed -i "s|^RUN git clone --depth 1 https://github.com/ethereum/go-ethereum.git /go-ethereum$|RUN git init /go-ethereum \&\& git -C /go-ethereum remote add origin https://github.com/ethereum/go-ethereum.git \&\& git -C /go-ethereum fetch --depth 1 origin ${GETH_REF} \&\& git -C /go-ethereum checkout --detach FETCH_HEAD|" "$dockerfile"
+          if ! grep -Fq "fetch --depth 1 origin ${GETH_REF}" "$dockerfile"; then
+            echo "Error: failed to pin Geth in the DevP2P Dockerfile"
+            exit 1
+          fi
 
       - name: Setup go env and cache
         uses: actions/setup-go@v7


### PR DESCRIPTION
Cherry-pick of #23756 to `release/3.6`.

Hive builds the `devp2p` test peer from Geth `master`, and a Geth commit with wrong fork IDs turned `hive / test-hive (devp2p, ...)` red on every `release/3.6` PR (`wrong fork ID in status`). `main` is green because it has the pin; `release/3.6` does not.

## r3.6-specific adaptations

- `release/3.6` checks out Hive from a hardcoded `ethereum/hive`, so the `hive_repository` key and its `GITHUB_OUTPUT` line are dropped; only `devp2p_geth_ref` is added.
- `hive_ref` stays at the one `release/3.6` pins. Verified the `RUN git clone ... go-ethereum` line the `sed` targets exists in `simulators/devp2p/Dockerfile` at that ref.
