### PR TITLE
cl/cltypes: size Gloas execution-request decode guards by the chunk limit

### DIFF
--- a/cl/cltypes/execution_requests.go
+++ b/cl/cltypes/execution_requests.go
@@ -55,9 +55,10 @@ func (e *ExecutionRequests) effectiveVersion() clparams.StateVersion {
 
 // Gloas encodes the execution requests as progressive lists, which are
 // semantically unbounded: the Electra per-payload maxima no longer cap them, so
-// the decode guard is sized by what a req/resp chunk can carry.
+// the decode guard is sized by what a req/resp chunk can carry. The progressive
+// constructors double whatever they are given, so this returns half the count.
 func progressiveResourceLimit(bytesPerElement int) int {
-	return int(clparams.MaxChunkSize) / bytesPerElement
+	return int(clparams.MaxChunkSize) / bytesPerElement / 2
 }
 
 func (e *ExecutionRequests) ensureLists() {
@@ -220,11 +221,11 @@ func (e *ExecutionRequests) UnmarshalJSON(b []byte) error {
 	newBuilderDeposits := solid.NewStaticListSSZ[*solid.BuilderDepositRequest](int(e.cfg.MaxBuilderDepositRequestsPerPayload), solid.SizeBuilderDepositRequest)
 	newBuilderExits := solid.NewStaticListSSZ[*solid.BuilderExitRequest](int(e.cfg.MaxBuilderExitRequestsPerPayload), solid.SizeBuilderExitRequest)
 	if e.effectiveVersion() >= clparams.GloasVersion {
-		newDeposits = solid.NewStaticProgressiveListSSZ[*solid.DepositRequest](int(e.cfg.MaxDepositRequestsPerPayload), solid.SizeDepositRequest)
-		newWithdrawals = solid.NewStaticProgressiveListSSZ[*solid.WithdrawalRequest](int(e.cfg.MaxWithdrawalRequestsPerPayload), solid.SizeWithdrawalRequest)
-		newConsolidations = solid.NewStaticProgressiveListSSZ[*solid.ConsolidationRequest](int(e.cfg.MaxConsolidationRequestsPerPayload), solid.SizeConsolidationRequest)
-		newBuilderDeposits = solid.NewStaticProgressiveListSSZ[*solid.BuilderDepositRequest](int(e.cfg.MaxBuilderDepositRequestsPerPayload), solid.SizeBuilderDepositRequest)
-		newBuilderExits = solid.NewStaticProgressiveListSSZ[*solid.BuilderExitRequest](int(e.cfg.MaxBuilderExitRequestsPerPayload), solid.SizeBuilderExitRequest)
+		newDeposits = solid.NewStaticProgressiveListSSZ[*solid.DepositRequest](progressiveResourceLimit(solid.SizeDepositRequest), solid.SizeDepositRequest)
+		newWithdrawals = solid.NewStaticProgressiveListSSZ[*solid.WithdrawalRequest](progressiveResourceLimit(solid.SizeWithdrawalRequest), solid.SizeWithdrawalRequest)
+		newConsolidations = solid.NewStaticProgressiveListSSZ[*solid.ConsolidationRequest](progressiveResourceLimit(solid.SizeConsolidationRequest), solid.SizeConsolidationRequest)
+		newBuilderDeposits = solid.NewStaticProgressiveListSSZ[*solid.BuilderDepositRequest](progressiveResourceLimit(solid.SizeBuilderDepositRequest), solid.SizeBuilderDepositRequest)
+		newBuilderExits = solid.NewStaticProgressiveListSSZ[*solid.BuilderExitRequest](progressiveResourceLimit(solid.SizeBuilderExitRequest), solid.SizeBuilderExitRequest)
 	}
 	c := struct {
 		Deposits        *solid.ListSSZ[*solid.DepositRequest]        `json:"deposits"`

--- a/cl/cltypes/execution_requests.go
+++ b/cl/cltypes/execution_requests.go
@@ -53,33 +53,40 @@ func (e *ExecutionRequests) effectiveVersion() clparams.StateVersion {
 	return e.version
 }
 
+// Gloas encodes the execution requests as progressive lists, which are
+// semantically unbounded: the Electra per-payload maxima no longer cap them, so
+// the decode guard is sized by what a req/resp chunk can carry.
+func progressiveResourceLimit(bytesPerElement int) int {
+	return int(clparams.MaxChunkSize) / bytesPerElement
+}
+
 func (e *ExecutionRequests) ensureLists() {
 	if e.cfg == nil {
 		panic("execution requests beacon config is nil")
 	}
 	progressive := e.effectiveVersion() >= clparams.GloasVersion
 	if e.Deposits == nil && progressive {
-		e.Deposits = solid.NewStaticProgressiveListSSZ[*solid.DepositRequest](int(e.cfg.MaxDepositRequestsPerPayload), solid.SizeDepositRequest)
+		e.Deposits = solid.NewStaticProgressiveListSSZ[*solid.DepositRequest](progressiveResourceLimit(solid.SizeDepositRequest), solid.SizeDepositRequest)
 	} else if e.Deposits == nil {
 		e.Deposits = solid.NewStaticListSSZ[*solid.DepositRequest](int(e.cfg.MaxDepositRequestsPerPayload), solid.SizeDepositRequest)
 	}
 	if e.Withdrawals == nil && progressive {
-		e.Withdrawals = solid.NewStaticProgressiveListSSZ[*solid.WithdrawalRequest](int(e.cfg.MaxWithdrawalRequestsPerPayload), solid.SizeWithdrawalRequest)
+		e.Withdrawals = solid.NewStaticProgressiveListSSZ[*solid.WithdrawalRequest](progressiveResourceLimit(solid.SizeWithdrawalRequest), solid.SizeWithdrawalRequest)
 	} else if e.Withdrawals == nil {
 		e.Withdrawals = solid.NewStaticListSSZ[*solid.WithdrawalRequest](int(e.cfg.MaxWithdrawalRequestsPerPayload), solid.SizeWithdrawalRequest)
 	}
 	if e.Consolidations == nil && progressive {
-		e.Consolidations = solid.NewStaticProgressiveListSSZ[*solid.ConsolidationRequest](int(e.cfg.MaxConsolidationRequestsPerPayload), solid.SizeConsolidationRequest)
+		e.Consolidations = solid.NewStaticProgressiveListSSZ[*solid.ConsolidationRequest](progressiveResourceLimit(solid.SizeConsolidationRequest), solid.SizeConsolidationRequest)
 	} else if e.Consolidations == nil {
 		e.Consolidations = solid.NewStaticListSSZ[*solid.ConsolidationRequest](int(e.cfg.MaxConsolidationRequestsPerPayload), solid.SizeConsolidationRequest)
 	}
 	if e.BuilderDeposits == nil && progressive {
-		e.BuilderDeposits = solid.NewStaticProgressiveListSSZ[*solid.BuilderDepositRequest](int(e.cfg.MaxBuilderDepositRequestsPerPayload), solid.SizeBuilderDepositRequest)
+		e.BuilderDeposits = solid.NewStaticProgressiveListSSZ[*solid.BuilderDepositRequest](progressiveResourceLimit(solid.SizeBuilderDepositRequest), solid.SizeBuilderDepositRequest)
 	} else if e.BuilderDeposits == nil {
 		e.BuilderDeposits = solid.NewStaticListSSZ[*solid.BuilderDepositRequest](int(e.cfg.MaxBuilderDepositRequestsPerPayload), solid.SizeBuilderDepositRequest)
 	}
 	if e.BuilderExits == nil && progressive {
-		e.BuilderExits = solid.NewStaticProgressiveListSSZ[*solid.BuilderExitRequest](int(e.cfg.MaxBuilderExitRequestsPerPayload), solid.SizeBuilderExitRequest)
+		e.BuilderExits = solid.NewStaticProgressiveListSSZ[*solid.BuilderExitRequest](progressiveResourceLimit(solid.SizeBuilderExitRequest), solid.SizeBuilderExitRequest)
 	} else if e.BuilderExits == nil {
 		e.BuilderExits = solid.NewStaticListSSZ[*solid.BuilderExitRequest](int(e.cfg.MaxBuilderExitRequestsPerPayload), solid.SizeBuilderExitRequest)
 	}

--- a/cl/cltypes/execution_requests_progressive_test.go
+++ b/cl/cltypes/execution_requests_progressive_test.go
@@ -91,3 +91,53 @@ func appendN[T solid.EncodableHashableSSZ](n int, list *solid.ListSSZ[T], value 
 		list.Append(value)
 	}
 }
+
+// The guard is a resource bound, so it must sit at one req/resp chunk, not the
+// two the progressive constructors would give it unadjusted.
+func TestExecutionRequestsGloasRejectsAboveOneChunk(t *testing.T) {
+	cfg := &clparams.MainnetBeaconConfig
+	perChunk := int(clparams.MaxChunkSize) / solid.SizeDepositRequest
+
+	for _, tc := range []struct {
+		name    string
+		count   int
+		wantErr bool
+	}{
+		{name: "at the chunk bound", count: perChunk},
+		{name: "above the chunk bound", count: perChunk + 1, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			requests := cltypes.NewExecutionRequestsWithVersion(cfg, clparams.GloasVersion)
+			appendN(tc.count, requests.Deposits, &solid.DepositRequest{})
+			encoded, err := requests.EncodeSSZ(nil)
+			require.NoError(t, err)
+
+			decoded := cltypes.NewExecutionRequestsWithVersion(cfg, clparams.GloasVersion)
+			err = decoded.DecodeSSZ(encoded, int(clparams.GloasVersion))
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.count, decoded.Deposits.Len())
+		})
+	}
+}
+
+// DecodeSSZ keeps whatever lists the object already holds, so a JSON-built one
+// must carry the same guards as a freshly constructed one.
+func TestExecutionRequestsGloasJSONKeepsProgressiveLimits(t *testing.T) {
+	cfg := &clparams.MainnetBeaconConfig
+	want := int(cfg.MaxDepositRequestsPerPayload)*2 + 1
+
+	fromJSON := cltypes.NewExecutionRequestsWithVersion(cfg, clparams.GloasVersion)
+	require.NoError(t, fromJSON.UnmarshalJSON([]byte(`{"deposits":[]}`)))
+
+	requests := cltypes.NewExecutionRequestsWithVersion(cfg, clparams.GloasVersion)
+	appendN(want, requests.Deposits, &solid.DepositRequest{})
+	encoded, err := requests.EncodeSSZ(nil)
+	require.NoError(t, err)
+
+	require.NoError(t, fromJSON.DecodeSSZ(encoded, int(clparams.GloasVersion)))
+	require.Equal(t, want, fromJSON.Deposits.Len())
+}

--- a/cl/cltypes/execution_requests_progressive_test.go
+++ b/cl/cltypes/execution_requests_progressive_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package cltypes_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+)
+
+// Gloas carries the execution requests as progressive lists, which are
+// semantically unbounded, so a payload holding more than the Electra
+// per-payload maximum must still decode.
+func TestExecutionRequestsGloasDecodesAboveElectraMaxima(t *testing.T) {
+	cfg := &clparams.MainnetBeaconConfig
+
+	for _, tc := range []struct {
+		name  string
+		count uint64
+		fill  func(*cltypes.ExecutionRequests, int)
+		got   func(*cltypes.ExecutionRequests) int
+	}{
+		{
+			name:  "deposits",
+			count: cfg.MaxDepositRequestsPerPayload,
+			fill:  func(e *cltypes.ExecutionRequests, n int) { appendN(n, e.Deposits, &solid.DepositRequest{}) },
+			got:   func(e *cltypes.ExecutionRequests) int { return e.Deposits.Len() },
+		},
+		{
+			name:  "withdrawals",
+			count: cfg.MaxWithdrawalRequestsPerPayload,
+			fill:  func(e *cltypes.ExecutionRequests, n int) { appendN(n, e.Withdrawals, &solid.WithdrawalRequest{}) },
+			got:   func(e *cltypes.ExecutionRequests) int { return e.Withdrawals.Len() },
+		},
+		{
+			name:  "consolidations",
+			count: cfg.MaxConsolidationRequestsPerPayload,
+			fill:  func(e *cltypes.ExecutionRequests, n int) { appendN(n, e.Consolidations, &solid.ConsolidationRequest{}) },
+			got:   func(e *cltypes.ExecutionRequests) int { return e.Consolidations.Len() },
+		},
+		{
+			name:  "builder deposits",
+			count: cfg.MaxBuilderDepositRequestsPerPayload,
+			fill: func(e *cltypes.ExecutionRequests, n int) {
+				appendN(n, e.BuilderDeposits, &solid.BuilderDepositRequest{})
+			},
+			got: func(e *cltypes.ExecutionRequests) int { return e.BuilderDeposits.Len() },
+		},
+		{
+			name:  "builder exits",
+			count: cfg.MaxBuilderExitRequestsPerPayload,
+			fill:  func(e *cltypes.ExecutionRequests, n int) { appendN(n, e.BuilderExits, &solid.BuilderExitRequest{}) },
+			got:   func(e *cltypes.ExecutionRequests) int { return e.BuilderExits.Len() },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// progressiveDecodeLimit doubles the configured limit, so exceed that too.
+			want := int(tc.count)*2 + 1
+			requests := cltypes.NewExecutionRequestsWithVersion(cfg, clparams.GloasVersion)
+			tc.fill(requests, want)
+			encoded, err := requests.EncodeSSZ(nil)
+			require.NoError(t, err)
+
+			decoded := cltypes.NewExecutionRequestsWithVersion(cfg, clparams.GloasVersion)
+			require.NoError(t, decoded.DecodeSSZ(encoded, int(clparams.GloasVersion)))
+			require.Equal(t, want, tc.got(decoded))
+		})
+	}
+}
+
+func appendN[T solid.EncodableHashableSSZ](n int, list *solid.ListSSZ[T], value T) {
+	for range n {
+		list.Append(value)
+	}
+}

--- a/cl/cltypes/execution_requests_progressive_test.go
+++ b/cl/cltypes/execution_requests_progressive_test.go
@@ -72,8 +72,9 @@ func TestExecutionRequestsGloasDecodesAboveElectraMaxima(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			// progressiveDecodeLimit doubles the configured limit, so exceed that too.
-			want := int(tc.count)*2 + 1
+			// The old guard was progressiveDecodeLimit(count), which doubles the
+			// configured limit but floors at 16. Exceed whichever applies.
+			want := max(int(tc.count)*2, 16) + 1
 			requests := cltypes.NewExecutionRequestsWithVersion(cfg, clparams.GloasVersion)
 			tc.fill(requests, want)
 			encoded, err := requests.EncodeSSZ(nil)


### PR DESCRIPTION
Found while reviewing #23548; the bug is on `main` already, so it is here rather than in that PR.

Gloas encodes the five execution-request lists as progressive lists, which are semantically unbounded — `solid/list_ssz.go:84` says so — but `ensureLists` still builds them with the Electra per-payload maxima. `progressiveDecodeLimit` doubles that and floors at 16, so the effective decode caps are 16384 / 32 / 16 / 128 / 32.

Only `deposits` changes what a node accepts. The Gloas `apply_parent_execution_payload` asserts a per-payload bound on the other four:

```
assert len(requests.withdrawals) <= MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD
assert len(requests.consolidations) <= MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD
assert len(requests.builder_deposits) <= MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD
assert len(requests.builder_exits) <= MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD
```

`deposits` is absent from that list. Erigon implements the four at `cl/transition/impl/eth2/operations.go:650-665`, reached on every import, so for those the assert bound sits strictly below the old decode cap and the guard was never the binding constraint — such a block now decodes and is rejected by the assert instead, with a clearer message. `deposits` (max 8192, old cap 16384, no assert) is the one with a real import-path effect, which is what #23548 fixes.

Size the guard by what one req/resp chunk can carry instead, so the container matches its spec type. Roots are unaffected — `HashSSZProgressive` ignores the limit.

The test targets the old guard directly (`max(count*2, 16) + 1`) and is red on `main` for all five lists. #23548 makes the same fix for deposits only; that hunk becomes redundant on rebase.
