### PR TITLE
cl/phase1/forkchoice: bound badBlocks so a peer cannot grow it without limit

### DIFF
--- a/cl/cltypes/execution_requests.go
+++ b/cl/cltypes/execution_requests.go
@@ -55,9 +55,10 @@ func (e *ExecutionRequests) effectiveVersion() clparams.StateVersion {
 
 // Gloas encodes the execution requests as progressive lists, which are
 // semantically unbounded: the Electra per-payload maxima no longer cap them, so
-// the decode guard is sized by what a req/resp chunk can carry.
+// the decode guard is sized by what a req/resp chunk can carry. The progressive
+// constructors double whatever they are given, so this returns half the count.
 func progressiveResourceLimit(bytesPerElement int) int {
-	return int(clparams.MaxChunkSize) / bytesPerElement
+	return int(clparams.MaxChunkSize) / bytesPerElement / 2
 }
 
 func (e *ExecutionRequests) ensureLists() {
@@ -220,11 +221,11 @@ func (e *ExecutionRequests) UnmarshalJSON(b []byte) error {
 	newBuilderDeposits := solid.NewStaticListSSZ[*solid.BuilderDepositRequest](int(e.cfg.MaxBuilderDepositRequestsPerPayload), solid.SizeBuilderDepositRequest)
 	newBuilderExits := solid.NewStaticListSSZ[*solid.BuilderExitRequest](int(e.cfg.MaxBuilderExitRequestsPerPayload), solid.SizeBuilderExitRequest)
 	if e.effectiveVersion() >= clparams.GloasVersion {
-		newDeposits = solid.NewStaticProgressiveListSSZ[*solid.DepositRequest](int(e.cfg.MaxDepositRequestsPerPayload), solid.SizeDepositRequest)
-		newWithdrawals = solid.NewStaticProgressiveListSSZ[*solid.WithdrawalRequest](int(e.cfg.MaxWithdrawalRequestsPerPayload), solid.SizeWithdrawalRequest)
-		newConsolidations = solid.NewStaticProgressiveListSSZ[*solid.ConsolidationRequest](int(e.cfg.MaxConsolidationRequestsPerPayload), solid.SizeConsolidationRequest)
-		newBuilderDeposits = solid.NewStaticProgressiveListSSZ[*solid.BuilderDepositRequest](int(e.cfg.MaxBuilderDepositRequestsPerPayload), solid.SizeBuilderDepositRequest)
-		newBuilderExits = solid.NewStaticProgressiveListSSZ[*solid.BuilderExitRequest](int(e.cfg.MaxBuilderExitRequestsPerPayload), solid.SizeBuilderExitRequest)
+		newDeposits = solid.NewStaticProgressiveListSSZ[*solid.DepositRequest](progressiveResourceLimit(solid.SizeDepositRequest), solid.SizeDepositRequest)
+		newWithdrawals = solid.NewStaticProgressiveListSSZ[*solid.WithdrawalRequest](progressiveResourceLimit(solid.SizeWithdrawalRequest), solid.SizeWithdrawalRequest)
+		newConsolidations = solid.NewStaticProgressiveListSSZ[*solid.ConsolidationRequest](progressiveResourceLimit(solid.SizeConsolidationRequest), solid.SizeConsolidationRequest)
+		newBuilderDeposits = solid.NewStaticProgressiveListSSZ[*solid.BuilderDepositRequest](progressiveResourceLimit(solid.SizeBuilderDepositRequest), solid.SizeBuilderDepositRequest)
+		newBuilderExits = solid.NewStaticProgressiveListSSZ[*solid.BuilderExitRequest](progressiveResourceLimit(solid.SizeBuilderExitRequest), solid.SizeBuilderExitRequest)
 	}
 	c := struct {
 		Deposits        *solid.ListSSZ[*solid.DepositRequest]        `json:"deposits"`

--- a/cl/cltypes/execution_requests.go
+++ b/cl/cltypes/execution_requests.go
@@ -53,33 +53,40 @@ func (e *ExecutionRequests) effectiveVersion() clparams.StateVersion {
 	return e.version
 }
 
+// Gloas encodes the execution requests as progressive lists, which are
+// semantically unbounded: the Electra per-payload maxima no longer cap them, so
+// the decode guard is sized by what a req/resp chunk can carry.
+func progressiveResourceLimit(bytesPerElement int) int {
+	return int(clparams.MaxChunkSize) / bytesPerElement
+}
+
 func (e *ExecutionRequests) ensureLists() {
 	if e.cfg == nil {
 		panic("execution requests beacon config is nil")
 	}
 	progressive := e.effectiveVersion() >= clparams.GloasVersion
 	if e.Deposits == nil && progressive {
-		e.Deposits = solid.NewStaticProgressiveListSSZ[*solid.DepositRequest](int(e.cfg.MaxDepositRequestsPerPayload), solid.SizeDepositRequest)
+		e.Deposits = solid.NewStaticProgressiveListSSZ[*solid.DepositRequest](progressiveResourceLimit(solid.SizeDepositRequest), solid.SizeDepositRequest)
 	} else if e.Deposits == nil {
 		e.Deposits = solid.NewStaticListSSZ[*solid.DepositRequest](int(e.cfg.MaxDepositRequestsPerPayload), solid.SizeDepositRequest)
 	}
 	if e.Withdrawals == nil && progressive {
-		e.Withdrawals = solid.NewStaticProgressiveListSSZ[*solid.WithdrawalRequest](int(e.cfg.MaxWithdrawalRequestsPerPayload), solid.SizeWithdrawalRequest)
+		e.Withdrawals = solid.NewStaticProgressiveListSSZ[*solid.WithdrawalRequest](progressiveResourceLimit(solid.SizeWithdrawalRequest), solid.SizeWithdrawalRequest)
 	} else if e.Withdrawals == nil {
 		e.Withdrawals = solid.NewStaticListSSZ[*solid.WithdrawalRequest](int(e.cfg.MaxWithdrawalRequestsPerPayload), solid.SizeWithdrawalRequest)
 	}
 	if e.Consolidations == nil && progressive {
-		e.Consolidations = solid.NewStaticProgressiveListSSZ[*solid.ConsolidationRequest](int(e.cfg.MaxConsolidationRequestsPerPayload), solid.SizeConsolidationRequest)
+		e.Consolidations = solid.NewStaticProgressiveListSSZ[*solid.ConsolidationRequest](progressiveResourceLimit(solid.SizeConsolidationRequest), solid.SizeConsolidationRequest)
 	} else if e.Consolidations == nil {
 		e.Consolidations = solid.NewStaticListSSZ[*solid.ConsolidationRequest](int(e.cfg.MaxConsolidationRequestsPerPayload), solid.SizeConsolidationRequest)
 	}
 	if e.BuilderDeposits == nil && progressive {
-		e.BuilderDeposits = solid.NewStaticProgressiveListSSZ[*solid.BuilderDepositRequest](int(e.cfg.MaxBuilderDepositRequestsPerPayload), solid.SizeBuilderDepositRequest)
+		e.BuilderDeposits = solid.NewStaticProgressiveListSSZ[*solid.BuilderDepositRequest](progressiveResourceLimit(solid.SizeBuilderDepositRequest), solid.SizeBuilderDepositRequest)
 	} else if e.BuilderDeposits == nil {
 		e.BuilderDeposits = solid.NewStaticListSSZ[*solid.BuilderDepositRequest](int(e.cfg.MaxBuilderDepositRequestsPerPayload), solid.SizeBuilderDepositRequest)
 	}
 	if e.BuilderExits == nil && progressive {
-		e.BuilderExits = solid.NewStaticProgressiveListSSZ[*solid.BuilderExitRequest](int(e.cfg.MaxBuilderExitRequestsPerPayload), solid.SizeBuilderExitRequest)
+		e.BuilderExits = solid.NewStaticProgressiveListSSZ[*solid.BuilderExitRequest](progressiveResourceLimit(solid.SizeBuilderExitRequest), solid.SizeBuilderExitRequest)
 	} else if e.BuilderExits == nil {
 		e.BuilderExits = solid.NewStaticListSSZ[*solid.BuilderExitRequest](int(e.cfg.MaxBuilderExitRequestsPerPayload), solid.SizeBuilderExitRequest)
 	}

--- a/cl/cltypes/execution_requests_progressive_test.go
+++ b/cl/cltypes/execution_requests_progressive_test.go
@@ -91,3 +91,53 @@ func appendN[T solid.EncodableHashableSSZ](n int, list *solid.ListSSZ[T], value 
 		list.Append(value)
 	}
 }
+
+// The guard is a resource bound, so it must sit at one req/resp chunk, not the
+// two the progressive constructors would give it unadjusted.
+func TestExecutionRequestsGloasRejectsAboveOneChunk(t *testing.T) {
+	cfg := &clparams.MainnetBeaconConfig
+	perChunk := int(clparams.MaxChunkSize) / solid.SizeDepositRequest
+
+	for _, tc := range []struct {
+		name    string
+		count   int
+		wantErr bool
+	}{
+		{name: "at the chunk bound", count: perChunk},
+		{name: "above the chunk bound", count: perChunk + 1, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			requests := cltypes.NewExecutionRequestsWithVersion(cfg, clparams.GloasVersion)
+			appendN(tc.count, requests.Deposits, &solid.DepositRequest{})
+			encoded, err := requests.EncodeSSZ(nil)
+			require.NoError(t, err)
+
+			decoded := cltypes.NewExecutionRequestsWithVersion(cfg, clparams.GloasVersion)
+			err = decoded.DecodeSSZ(encoded, int(clparams.GloasVersion))
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.count, decoded.Deposits.Len())
+		})
+	}
+}
+
+// DecodeSSZ keeps whatever lists the object already holds, so a JSON-built one
+// must carry the same guards as a freshly constructed one.
+func TestExecutionRequestsGloasJSONKeepsProgressiveLimits(t *testing.T) {
+	cfg := &clparams.MainnetBeaconConfig
+	want := int(cfg.MaxDepositRequestsPerPayload)*2 + 1
+
+	fromJSON := cltypes.NewExecutionRequestsWithVersion(cfg, clparams.GloasVersion)
+	require.NoError(t, fromJSON.UnmarshalJSON([]byte(`{"deposits":[]}`)))
+
+	requests := cltypes.NewExecutionRequestsWithVersion(cfg, clparams.GloasVersion)
+	appendN(want, requests.Deposits, &solid.DepositRequest{})
+	encoded, err := requests.EncodeSSZ(nil)
+	require.NoError(t, err)
+
+	require.NoError(t, fromJSON.DecodeSSZ(encoded, int(clparams.GloasVersion)))
+	require.Equal(t, want, fromJSON.Deposits.Len())
+}

--- a/cl/cltypes/execution_requests_progressive_test.go
+++ b/cl/cltypes/execution_requests_progressive_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package cltypes_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+)
+
+// Gloas carries the execution requests as progressive lists, which are
+// semantically unbounded, so a payload holding more than the Electra
+// per-payload maximum must still decode.
+func TestExecutionRequestsGloasDecodesAboveElectraMaxima(t *testing.T) {
+	cfg := &clparams.MainnetBeaconConfig
+
+	for _, tc := range []struct {
+		name  string
+		count uint64
+		fill  func(*cltypes.ExecutionRequests, int)
+		got   func(*cltypes.ExecutionRequests) int
+	}{
+		{
+			name:  "deposits",
+			count: cfg.MaxDepositRequestsPerPayload,
+			fill:  func(e *cltypes.ExecutionRequests, n int) { appendN(n, e.Deposits, &solid.DepositRequest{}) },
+			got:   func(e *cltypes.ExecutionRequests) int { return e.Deposits.Len() },
+		},
+		{
+			name:  "withdrawals",
+			count: cfg.MaxWithdrawalRequestsPerPayload,
+			fill:  func(e *cltypes.ExecutionRequests, n int) { appendN(n, e.Withdrawals, &solid.WithdrawalRequest{}) },
+			got:   func(e *cltypes.ExecutionRequests) int { return e.Withdrawals.Len() },
+		},
+		{
+			name:  "consolidations",
+			count: cfg.MaxConsolidationRequestsPerPayload,
+			fill:  func(e *cltypes.ExecutionRequests, n int) { appendN(n, e.Consolidations, &solid.ConsolidationRequest{}) },
+			got:   func(e *cltypes.ExecutionRequests) int { return e.Consolidations.Len() },
+		},
+		{
+			name:  "builder deposits",
+			count: cfg.MaxBuilderDepositRequestsPerPayload,
+			fill: func(e *cltypes.ExecutionRequests, n int) {
+				appendN(n, e.BuilderDeposits, &solid.BuilderDepositRequest{})
+			},
+			got: func(e *cltypes.ExecutionRequests) int { return e.BuilderDeposits.Len() },
+		},
+		{
+			name:  "builder exits",
+			count: cfg.MaxBuilderExitRequestsPerPayload,
+			fill:  func(e *cltypes.ExecutionRequests, n int) { appendN(n, e.BuilderExits, &solid.BuilderExitRequest{}) },
+			got:   func(e *cltypes.ExecutionRequests) int { return e.BuilderExits.Len() },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// progressiveDecodeLimit doubles the configured limit, so exceed that too.
+			want := int(tc.count)*2 + 1
+			requests := cltypes.NewExecutionRequestsWithVersion(cfg, clparams.GloasVersion)
+			tc.fill(requests, want)
+			encoded, err := requests.EncodeSSZ(nil)
+			require.NoError(t, err)
+
+			decoded := cltypes.NewExecutionRequestsWithVersion(cfg, clparams.GloasVersion)
+			require.NoError(t, decoded.DecodeSSZ(encoded, int(clparams.GloasVersion)))
+			require.Equal(t, want, tc.got(decoded))
+		})
+	}
+}
+
+func appendN[T solid.EncodableHashableSSZ](n int, list *solid.ListSSZ[T], value T) {
+	for range n {
+		list.Append(value)
+	}
+}

--- a/cl/cltypes/execution_requests_progressive_test.go
+++ b/cl/cltypes/execution_requests_progressive_test.go
@@ -72,8 +72,9 @@ func TestExecutionRequestsGloasDecodesAboveElectraMaxima(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			// progressiveDecodeLimit doubles the configured limit, so exceed that too.
-			want := int(tc.count)*2 + 1
+			// The old guard was progressiveDecodeLimit(count), which doubles the
+			// configured limit but floors at 16. Exceed whichever applies.
+			want := max(int(tc.count)*2, 16) + 1
 			requests := cltypes.NewExecutionRequestsWithVersion(cfg, clparams.GloasVersion)
 			tc.fill(requests, want)
 			encoded, err := requests.EncodeSSZ(nil)

--- a/cl/phase1/forkchoice/fork_graph/fork_graph_badblocks_test.go
+++ b/cl/phase1/forkchoice/fork_graph/fork_graph_badblocks_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package fork_graph
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/beacon/beacon_router_configuration"
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/erigontech/erigon/cl/utils"
+	"github.com/erigontech/erigon/common"
+)
+
+// A block rejected below the anchor slot is recorded in badBlocks but never
+// reaches f.blocks, which is the only source Prune walks. Any peer can
+// therefore grow the map without bound by replaying below-anchor blocks.
+func TestForkGraphPrunesBelowAnchorBadBlocks(t *testing.T) {
+	anchorState := state.New(&clparams.MainnetBeaconConfig)
+	require.NoError(t, utils.DecodeSSZSnappy(anchorState, anchor, int(clparams.Phase0Version)))
+	graph, err := NewForkGraphDisk(anchorState, nil, afero.NewMemMapFs(), beacon_router_configuration.RouterConfiguration{})
+	require.NoError(t, err)
+	disk := graph.(*forkGraphDisk)
+
+	const rejected = 64
+	for i := range uint64(rejected) {
+		block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.Phase0Version)
+		block.Block.Slot = anchorState.Slot()
+		block.Block.ProposerIndex = i
+		_, status, err := graph.AddChainSegment(block, false)
+		require.NoError(t, err)
+		require.Equal(t, BelowAnchor, status)
+	}
+	require.Equal(t, rejected, countSyncMap(&disk.badBlocks))
+
+	require.NoError(t, graph.Prune(anchorState.Slot()+clparams.MainnetBeaconConfig.SlotsPerEpoch))
+	require.Zero(t, countSyncMap(&disk.badBlocks),
+		"below-anchor bad blocks must not survive a prune past their slot")
+}
+
+// MarkHeaderAsInvalid has no slot of its own, so the entry must survive until a
+// prune passes the header's slot rather than being dropped on the next prune.
+func TestForkGraphKeepsMarkedInvalidHeaderUntilItsSlotIsPruned(t *testing.T) {
+	anchorState := state.New(&clparams.MainnetBeaconConfig)
+	require.NoError(t, utils.DecodeSSZSnappy(anchorState, anchor, int(clparams.Phase0Version)))
+	graph, err := NewForkGraphDisk(anchorState, nil, afero.NewMemMapFs(), beacon_router_configuration.RouterConfiguration{})
+	require.NoError(t, err)
+	disk := graph.(*forkGraphDisk)
+
+	root := common.Hash{0xaa}
+	graph.MarkHeaderAsInvalid(root)
+	require.Equal(t, 1, countSyncMap(&disk.badBlocks))
+
+	require.NoError(t, graph.Prune(anchorState.Slot()+clparams.MainnetBeaconConfig.SlotsPerEpoch))
+	require.Equal(t, 1, countSyncMap(&disk.badBlocks),
+		"a header with no known slot must not be dropped by an unrelated prune")
+}
+
+func countSyncMap(m *sync.Map) int {
+	count := 0
+	m.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	return count
+}

--- a/cl/phase1/forkchoice/fork_graph/fork_graph_badblocks_test.go
+++ b/cl/phase1/forkchoice/fork_graph/fork_graph_badblocks_test.go
@@ -32,8 +32,9 @@ import (
 )
 
 // A block rejected below the anchor slot is recorded in badBlocks but never
-// reaches f.blocks, which is the only source Prune walks. Any peer can
-// therefore grow the map without bound by replaying below-anchor blocks.
+// reaches f.blocks, so the block-keyed prune loop cannot reach it. OnBlock caps
+// finalizedSlot at the anchor, so this store site is out of a peer's reach; the
+// reachable one is the invalid-block path below.
 func TestForkGraphPrunesBelowAnchorBadBlocks(t *testing.T) {
 	anchorState := state.New(&clparams.MainnetBeaconConfig)
 	require.NoError(t, utils.DecodeSSZSnappy(anchorState, anchor, int(clparams.Phase0Version)))
@@ -57,9 +58,9 @@ func TestForkGraphPrunesBelowAnchorBadBlocks(t *testing.T) {
 		"below-anchor bad blocks must not survive a prune past their slot")
 }
 
-// MarkHeaderAsInvalid has no slot of its own, so the entry must survive until a
-// prune passes the header's slot rather than being dropped on the next prune.
-func TestForkGraphKeepsMarkedInvalidHeaderUntilItsSlotIsPruned(t *testing.T) {
+// MarkHeaderAsInvalid takes the slot from the stored header. With no header it
+// falls back to slotUnknown, which no prune slot can pass.
+func TestForkGraphKeepsMarkedInvalidRootWithUnknownSlot(t *testing.T) {
 	anchorState := state.New(&clparams.MainnetBeaconConfig)
 	require.NoError(t, utils.DecodeSSZSnappy(anchorState, anchor, int(clparams.Phase0Version)))
 	graph, err := NewForkGraphDisk(anchorState, nil, afero.NewMemMapFs(), beacon_router_configuration.RouterConfiguration{})
@@ -73,6 +74,64 @@ func TestForkGraphKeepsMarkedInvalidHeaderUntilItsSlotIsPruned(t *testing.T) {
 	require.NoError(t, graph.Prune(anchorState.Slot()+clparams.MainnetBeaconConfig.SlotsPerEpoch))
 	require.Equal(t, 1, countSyncMap(&disk.badBlocks),
 		"a header with no known slot must not be dropped by an unrelated prune")
+}
+
+// An invalid block is deleted from f.blocks before its root reaches badBlocks,
+// so the block-keyed prune loop never sees it. This is the site a peer can
+// drive, with many distinct invalid blocks off one known parent.
+func TestForkGraphPrunesInvalidBlockBadBlocks(t *testing.T) {
+	blockA := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+	blockC := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+	anchorState := state.New(&clparams.MainnetBeaconConfig)
+	require.NoError(t, utils.DecodeSSZSnappy(blockA, block1, int(clparams.Phase0Version)))
+	require.NoError(t, utils.DecodeSSZSnappy(blockC, block2, int(clparams.Phase0Version)))
+	require.NoError(t, utils.DecodeSSZSnappy(anchorState, anchor, int(clparams.Phase0Version)))
+	graph, err := NewForkGraphDisk(anchorState, nil, afero.NewMemMapFs(), beacon_router_configuration.RouterConfiguration{})
+	require.NoError(t, err)
+	disk := graph.(*forkGraphDisk)
+
+	_, status, err := graph.AddChainSegment(blockA, true)
+	require.NoError(t, err)
+	require.Equal(t, Success, status)
+
+	blockC.Block.ProposerIndex = 81214459 // fails the transition, so the block is invalid
+	_, status, _ = graph.AddChainSegment(blockC, true)
+	require.Equal(t, InvalidBlock, status)
+	require.Equal(t, 1, countSyncMap(&disk.badBlocks))
+
+	require.NoError(t, graph.Prune(blockC.Block.Slot))
+	require.Equal(t, 1, countSyncMap(&disk.badBlocks),
+		"a prune at the block's own slot must not drop it")
+
+	require.NoError(t, graph.Prune(blockC.Block.Slot+1))
+	require.Zero(t, countSyncMap(&disk.badBlocks),
+		"an invalid block must not survive a prune past its slot")
+}
+
+// A root marked through MarkHeaderAsInvalid whose header is stored carries that
+// header's slot, so it expires by slot rather than living for the process.
+func TestForkGraphPrunesMarkedInvalidHeaderBySlot(t *testing.T) {
+	anchorState := state.New(&clparams.MainnetBeaconConfig)
+	require.NoError(t, utils.DecodeSSZSnappy(anchorState, anchor, int(clparams.Phase0Version)))
+	graph, err := NewForkGraphDisk(anchorState, nil, afero.NewMemMapFs(), beacon_router_configuration.RouterConfiguration{})
+	require.NoError(t, err)
+	disk := graph.(*forkGraphDisk)
+
+	anchorRoot, err := anchorState.BlockRoot()
+	require.NoError(t, err)
+	header, ok := graph.GetHeader(anchorRoot)
+	require.True(t, ok)
+
+	graph.MarkHeaderAsInvalid(anchorRoot)
+	require.Equal(t, 1, countSyncMap(&disk.badBlocks))
+
+	require.NoError(t, graph.Prune(header.Slot))
+	require.Equal(t, 1, countSyncMap(&disk.badBlocks),
+		"a prune at the header's own slot must not drop it")
+
+	require.NoError(t, graph.Prune(header.Slot+1))
+	require.Zero(t, countSyncMap(&disk.badBlocks),
+		"a marked root with a known slot must not survive a prune past it")
 }
 
 func countSyncMap(m *sync.Map) int {

--- a/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
+++ b/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"math"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -90,10 +91,14 @@ func convertHashSliceToHashList(in [][32]byte) solid.HashVectorSSZ {
 // each edge is the path described as (prevBlockRoot, currBlockRoot). if we want to go forward we use blocks.
 type forkGraphDisk struct {
 	// Alternate beacon states
-	fs        afero.Fs
-	blocks    sync.Map // set of blocks (block root -> block)
-	headers   sync.Map // set of headers
-	badBlocks sync.Map // blocks that are invalid and that leads to automatic fail of extension.
+	fs      afero.Fs
+	blocks  sync.Map // set of blocks (block root -> block)
+	headers sync.Map // set of headers
+	// badBlocks maps an invalid block root to the slot it was seen at, so Prune
+	// can drop it. Roots marked without a slot are stored as slotUnknown: a peer
+	// can replay below-anchor blocks, which never reach f.blocks and so are not
+	// covered by the block-keyed pruning below.
+	badBlocks sync.Map // common.Hash -> uint64 slot
 
 	// current state data — dual-protected. AddChainSegment is the sole writer
 	// and runs under the outer forkchoice f.mu, so reads taken under f.mu are
@@ -225,7 +230,7 @@ func (f *forkGraphDisk) AddChainSegment(signedBlock *cltypes.SignedBeaconBlock, 
 	// Blocks below anchors are invalid.
 	if block.Slot <= f.anchorSlot {
 		log.Debug("block below anchor slot", "slot", block.Slot, "hash", common.Hash(blockRoot))
-		f.badBlocks.Store(common.Hash(blockRoot), struct{}{})
+		f.badBlocks.Store(common.Hash(blockRoot), block.Slot)
 		return nil, BelowAnchor, nil
 	}
 
@@ -303,7 +308,7 @@ func (f *forkGraphDisk) AddChainSegment(signedBlock *cltypes.SignedBeaconBlock, 
 			// Add block to list of invalid blocks
 			log.Warn("Invalid beacon block", "slot", block.Slot, "blockRoot", common.Bytes2Hex(blockRoot[:]), "reason", invalidBlockErr)
 			f.blocks.Delete(common.Hash(blockRoot)) // remove early-stored block
-			f.badBlocks.Store(common.Hash(blockRoot), struct{}{})
+			f.badBlocks.Store(common.Hash(blockRoot), block.Slot)
 			f.currentStateMu.Lock()
 			f.currentState = nil
 			f.currentStateBlockRoot = common.Hash{}
@@ -556,7 +561,11 @@ func (f *forkGraphDisk) GetFinalizedCheckpoint(blockRoot common.Hash) (solid.Che
 }
 
 func (f *forkGraphDisk) MarkHeaderAsInvalid(blockRoot common.Hash) {
-	f.badBlocks.Store(blockRoot, struct{}{})
+	slot := uint64(slotUnknown)
+	if header, ok := f.GetHeader(blockRoot); ok {
+		slot = header.Slot
+	}
+	f.badBlocks.Store(blockRoot, slot)
 }
 
 func (f *forkGraphDisk) hasBeaconState(blockRoot common.Hash) bool {
@@ -564,7 +573,16 @@ func (f *forkGraphDisk) hasBeaconState(blockRoot common.Hash) bool {
 	return err == nil && exists
 }
 
+// slotUnknown marks a bad block whose slot is not known, so no prune drops it.
+const slotUnknown = math.MaxUint64
+
 func (f *forkGraphDisk) Prune(pruneSlot uint64) (err error) {
+	f.badBlocks.Range(func(key, value any) bool {
+		if value.(uint64) < pruneSlot {
+			f.badBlocks.Delete(key)
+		}
+		return true
+	})
 	oldRoots := make([]common.Hash, 0, f.beaconCfg.SlotsPerEpoch)
 	highestStoredBeaconStateSlot := uint64(0)
 	f.blocks.Range(func(key, value any) bool {

--- a/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
+++ b/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
@@ -95,9 +95,9 @@ type forkGraphDisk struct {
 	blocks  sync.Map // set of blocks (block root -> block)
 	headers sync.Map // set of headers
 	// badBlocks maps an invalid block root to the slot it was seen at, so Prune
-	// can drop it. Roots marked without a slot are stored as slotUnknown: a peer
-	// can replay below-anchor blocks, which never reach f.blocks and so are not
-	// covered by the block-keyed pruning below.
+	// can drop it: an invalid block is deleted from blocks before its root is
+	// recorded here, so the block-keyed pruning below never reaches it. Roots
+	// marked with no header to take a slot from are stored as slotUnknown.
 	badBlocks sync.Map // common.Hash -> uint64 slot
 
 	// current state data — dual-protected. AddChainSegment is the sole writer
@@ -573,7 +573,8 @@ func (f *forkGraphDisk) hasBeaconState(blockRoot common.Hash) bool {
 	return err == nil && exists
 }
 
-// slotUnknown marks a bad block whose slot is not known, so no prune drops it.
+// slotUnknown marks a bad block with no header to take a slot from, so no prune
+// drops it; MarkHeaderAsInvalid records the header's slot when there is one.
 const slotUnknown = math.MaxUint64
 
 func (f *forkGraphDisk) Prune(pruneSlot uint64) (err error) {


### PR DESCRIPTION
Found while reviewing #23548; the bug is on `main` already, so it is here rather than in that PR.

`Prune` builds its delete set by walking `f.blocks` (`fork_graph_disk.go:570`), and two store sites put a root in `badBlocks` without it ever being in that walk.

The one a peer can drive is the invalid-block path (`:310-311`): the block is deleted from `f.blocks` and *then* its root is recorded, so the walk never sees it and the old `badBlocks.Delete(root)` at `:618` never fired. A peer with a known parent can submit many distinct invalid blocks off it.

The below-anchor path (`:229`) has the same shape but is out of a peer's reach: `OnBlock` caps `finalizedSlot` up to `AnchorSlot()` and returns for any block at or below it, so every block that reaches `addChainSegmentAndQueueLightClientEvents` is already above the anchor. The branch stays covered because `AddChainSegment` is exported.

Store the slot alongside the root and prune `badBlocks` by slot. `MarkHeaderAsInvalid` records the header's slot when the header is stored — which is the case for the `markPayloadInvalidLocked` callers — and `slotUnknown` otherwise, which is what the `PayloadStatusInvalidated` caller in `on_block.go:249` produces, since it returns before the header is stored. A `slotUnknown` entry is dropped by no prune.

Three tests are red on `main`: the two store sites and the known-slot mark. The fourth pins the `slotUnknown` fallback, which passes on `main` too — it guards the sentinel, so a zero-valued default would make it fail.

Note for #23548: that PR adds `IsBlockInvalid` — the first reader of this map — and a second store site for blocks below the *pruned boundary*, which rises on every prune rather than staying fixed like the anchor. That site needs the same slot, and `payloadStatusAuthorityWithRetention` mapping `IsBlockInvalid` to a latched `PayloadStatusInvalidated` makes a stale entry harmful rather than merely wasteful.
