### PR TITLE
db/state, cmd: enable parallel commitment by default

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests-latest.yml
+++ b/.github/workflows/qa-rpc-integration-tests-latest.yml
@@ -57,8 +57,8 @@ jobs:
       RPC_PAST_TEST_DIR: /opt/rpc-past-tests
       CHAIN: mainnet
       # Toggle statecfg.ExperimentalParallelCommitment from CI without code
-      # changes. envLookup in common/dbg/dbg_env.go auto-prepends ERIGON_, so
-      # this maps to the COMMITMENT_PARALLEL flag read in db/state/statecfg.
+      # changes. db/state/statecfg reads this name directly; the unprefixed
+      # COMMITMENT_PARALLEL is deliberately not accepted.
       ERIGON_COMMITMENT_PARALLEL: ${{ matrix.commitment_mode == 'parallel' && 'true' || 'false' }}
 
     steps:

--- a/.github/workflows/qa-rpc-integration-tests-latest.yml
+++ b/.github/workflows/qa-rpc-integration-tests-latest.yml
@@ -56,9 +56,6 @@ jobs:
       ERIGON_ASSERT: true
       RPC_PAST_TEST_DIR: /opt/rpc-past-tests
       CHAIN: mainnet
-      # Toggle statecfg.ExperimentalParallelCommitment from CI without code
-      # changes. db/state/statecfg reads this name directly; the unprefixed
-      # COMMITMENT_PARALLEL is deliberately not accepted.
       ERIGON_COMMITMENT_PARALLEL: ${{ matrix.commitment_mode == 'parallel' && 'true' || 'false' }}
 
     steps:

--- a/.github/workflows/qa-stage-exec.yml
+++ b/.github/workflows/qa-stage-exec.yml
@@ -59,8 +59,8 @@ jobs:
       TIMEOUT_SECONDS: 360
       CHAIN: mainnet
       # Toggle statecfg.ExperimentalParallelCommitment from CI without code
-      # changes. envLookup in common/dbg/dbg_env.go auto-prepends ERIGON_, so
-      # this maps to the COMMITMENT_PARALLEL flag read in db/state/statecfg.
+      # changes. db/state/statecfg reads this name directly; the unprefixed
+      # COMMITMENT_PARALLEL is deliberately not accepted.
       ERIGON_COMMITMENT_PARALLEL: ${{ matrix.commitment_mode == 'parallel' && 'true' || 'false' }}
 
     steps:

--- a/.github/workflows/qa-stage-exec.yml
+++ b/.github/workflows/qa-stage-exec.yml
@@ -58,9 +58,6 @@ jobs:
       ERIGON_QA_PATH: /home/qarunner/erigon-qa
       TIMEOUT_SECONDS: 360
       CHAIN: mainnet
-      # Toggle statecfg.ExperimentalParallelCommitment from CI without code
-      # changes. db/state/statecfg reads this name directly; the unprefixed
-      # COMMITMENT_PARALLEL is deliberately not accepted.
       ERIGON_COMMITMENT_PARALLEL: ${{ matrix.commitment_mode == 'parallel' && 'true' || 'false' }}
 
     steps:

--- a/.github/workflows/qa-txpool-performance-test.yml
+++ b/.github/workflows/qa-txpool-performance-test.yml
@@ -34,9 +34,6 @@ jobs:
     env:
       ERIGON_QA_PATH: /home/qarunner/erigon-qa
       ENCLAVE_NAME: "kurtosis-run-${{ github.run_id }}-${{ matrix.commitment_mode }}"
-      # Toggle statecfg.ExperimentalParallelCommitment from CI without code
-      # changes. db/state/statecfg reads this name directly; the unprefixed
-      # COMMITMENT_PARALLEL is deliberately not accepted.
       ERIGON_COMMITMENT_PARALLEL: ${{ matrix.commitment_mode == 'parallel' && 'true' || 'false' }}
 
     steps:

--- a/.github/workflows/qa-txpool-performance-test.yml
+++ b/.github/workflows/qa-txpool-performance-test.yml
@@ -35,8 +35,8 @@ jobs:
       ERIGON_QA_PATH: /home/qarunner/erigon-qa
       ENCLAVE_NAME: "kurtosis-run-${{ github.run_id }}-${{ matrix.commitment_mode }}"
       # Toggle statecfg.ExperimentalParallelCommitment from CI without code
-      # changes. envLookup in common/dbg/dbg_env.go auto-prepends ERIGON_, so
-      # this maps to the COMMITMENT_PARALLEL flag read in db/state/statecfg.
+      # changes. db/state/statecfg reads this name directly; the unprefixed
+      # COMMITMENT_PARALLEL is deliberately not accepted.
       ERIGON_COMMITMENT_PARALLEL: ${{ matrix.commitment_mode == 'parallel' && 'true' || 'false' }}
 
     steps:

--- a/.github/workflows/test-all-erigon-race.yml
+++ b/.github/workflows/test-all-erigon-race.yml
@@ -95,9 +95,6 @@ jobs:
         env:
           SKIP_FLAKY_TESTS: 'true'
           CGO_CFLAGS: -D__BLST_PORTABLE__
-          # Toggle statecfg.ExperimentalParallelCommitment from CI without code
-          # changes. db/state/statecfg reads this name directly; the unprefixed
-          # COMMITMENT_PARALLEL is deliberately not accepted.
           ERIGON_COMMITMENT_PARALLEL: ${{ matrix.commitment_mode == 'parallel' && 'true' || 'false' }}
           TEST_GROUP: ${{ matrix.test-group }}
         run: make test-group TEST_GROUP="$TEST_GROUP" GO_FLAGS="-race -timeout=60m"

--- a/.github/workflows/test-all-erigon-race.yml
+++ b/.github/workflows/test-all-erigon-race.yml
@@ -96,8 +96,8 @@ jobs:
           SKIP_FLAKY_TESTS: 'true'
           CGO_CFLAGS: -D__BLST_PORTABLE__
           # Toggle statecfg.ExperimentalParallelCommitment from CI without code
-          # changes. envLookup in common/dbg/dbg_env.go auto-prepends ERIGON_, so
-          # this maps to the COMMITMENT_PARALLEL flag read in db/state/statecfg.
+          # changes. db/state/statecfg reads this name directly; the unprefixed
+          # COMMITMENT_PARALLEL is deliberately not accepted.
           ERIGON_COMMITMENT_PARALLEL: ${{ matrix.commitment_mode == 'parallel' && 'true' || 'false' }}
           TEST_GROUP: ${{ matrix.test-group }}
         run: make test-group TEST_GROUP="$TEST_GROUP" GO_FLAGS="-race -timeout=60m"

--- a/.github/workflows/test-all-erigon.yml
+++ b/.github/workflows/test-all-erigon.yml
@@ -74,9 +74,6 @@ jobs:
           SKIP_FLAKY_TESTS: 'true'
           TEST_TIMEOUT: ${{ matrix.test_timeout || '20m' }}
           ERIGON_SKIP_EXECUTION_TESTS: ${{ matrix.skip_execution_tests || '' }}
-          # Toggle statecfg.ExperimentalParallelCommitment from CI without code
-          # changes. db/state/statecfg reads this name directly; the unprefixed
-          # COMMITMENT_PARALLEL is deliberately not accepted.
           ERIGON_COMMITMENT_PARALLEL: ${{ matrix.commitment_mode == 'parallel' && 'true' || 'false' }}
         run: |
           if ! make test-all GO_FLAGS="--timeout $TEST_TIMEOUT"; then

--- a/.github/workflows/test-all-erigon.yml
+++ b/.github/workflows/test-all-erigon.yml
@@ -75,8 +75,8 @@ jobs:
           TEST_TIMEOUT: ${{ matrix.test_timeout || '20m' }}
           ERIGON_SKIP_EXECUTION_TESTS: ${{ matrix.skip_execution_tests || '' }}
           # Toggle statecfg.ExperimentalParallelCommitment from CI without code
-          # changes. envLookup in common/dbg/dbg_env.go auto-prepends ERIGON_, so
-          # this maps to the COMMITMENT_PARALLEL flag read in db/state/statecfg.
+          # changes. db/state/statecfg reads this name directly; the unprefixed
+          # COMMITMENT_PARALLEL is deliberately not accepted.
           ERIGON_COMMITMENT_PARALLEL: ${{ matrix.commitment_mode == 'parallel' && 'true' || 'false' }}
         run: |
           if ! make test-all GO_FLAGS="--timeout $TEST_TIMEOUT"; then

--- a/.github/workflows/test-bench.yml
+++ b/.github/workflows/test-bench.yml
@@ -44,9 +44,6 @@ jobs:
           - serial
           - parallel
     env:
-      # Toggle statecfg.ExperimentalParallelCommitment from CI without code
-      # changes. db/state/statecfg reads this name directly; the unprefixed
-      # COMMITMENT_PARALLEL is deliberately not accepted.
       ERIGON_COMMITMENT_PARALLEL: ${{ matrix.commitment_mode == 'parallel' && 'true' || 'false' }}
 
     steps:

--- a/.github/workflows/test-bench.yml
+++ b/.github/workflows/test-bench.yml
@@ -45,8 +45,8 @@ jobs:
           - parallel
     env:
       # Toggle statecfg.ExperimentalParallelCommitment from CI without code
-      # changes. envLookup in common/dbg/dbg_env.go auto-prepends ERIGON_, so
-      # this maps to the COMMITMENT_PARALLEL flag read in db/state/statecfg.
+      # changes. db/state/statecfg reads this name directly; the unprefixed
+      # COMMITMENT_PARALLEL is deliberately not accepted.
       ERIGON_COMMITMENT_PARALLEL: ${{ matrix.commitment_mode == 'parallel' && 'true' || 'false' }}
 
     steps:

--- a/cmd/integration/commands/dump_state_test.go
+++ b/cmd/integration/commands/dump_state_test.go
@@ -629,7 +629,7 @@ func TestResolveExecTarget_ChainTipLoopReachesTarget(t *testing.T) {
 
 // TestExecCommandsExposeParallelCommitment pins the flag on every integration
 // command that computes commitment. Without it the flag is unknown on stage_exec,
-// so integration is stuck on whatever ERIGON_COMMITMENT_PARALLEL selected and
+// so integration is stuck on whatever COMMITMENT_PARALLEL selected and
 // cannot switch tries.
 func TestExecCommandsExposeParallelCommitment(t *testing.T) {
 	for _, tc := range []struct {
@@ -661,7 +661,7 @@ func TestWithExperimentalCommitmentResolution(t *testing.T) {
 
 	for _, seed := range []bool{true, false} {
 		require.Equal(t, seed, resolve(seed),
-			"integration overrode ERIGON_COMMITMENT_PARALLEL with the flag default")
+			"integration overrode COMMITMENT_PARALLEL with the flag default")
 		require.True(t, resolve(seed, "--"+utils.ExperimentalParallelCommitmentFlag.Name+"=true"))
 		require.False(t, resolve(seed, "--"+utils.ExperimentalParallelCommitmentFlag.Name+"=false"))
 	}

--- a/cmd/integration/commands/dump_state_test.go
+++ b/cmd/integration/commands/dump_state_test.go
@@ -630,7 +630,7 @@ func TestResolveExecTarget_ChainTipLoopReachesTarget(t *testing.T) {
 // TestExecCommandsExposeParallelCommitment pins the flag on every integration
 // command that computes commitment. Without it the flag is unknown on stage_exec,
 // so integration is stuck on whatever ERIGON_COMMITMENT_PARALLEL selected and
-// switch tries.
+// cannot switch tries.
 func TestExecCommandsExposeParallelCommitment(t *testing.T) {
 	for _, tc := range []struct {
 		name string

--- a/cmd/integration/commands/dump_state_test.go
+++ b/cmd/integration/commands/dump_state_test.go
@@ -629,7 +629,7 @@ func TestResolveExecTarget_ChainTipLoopReachesTarget(t *testing.T) {
 
 // TestExecCommandsExposeParallelCommitment pins the flag on every integration
 // command that computes commitment. Without it the flag is unknown on stage_exec,
-// so integration is stuck on whatever COMMITMENT_PARALLEL selected and cannot
+// so integration is stuck on whatever ERIGON_COMMITMENT_PARALLEL selected and
 // switch tries.
 func TestExecCommandsExposeParallelCommitment(t *testing.T) {
 	for _, tc := range []struct {
@@ -661,7 +661,7 @@ func TestWithExperimentalCommitmentResolution(t *testing.T) {
 
 	for _, seed := range []bool{true, false} {
 		require.Equal(t, seed, resolve(seed),
-			"integration overrode COMMITMENT_PARALLEL with the flag default")
+			"integration overrode ERIGON_COMMITMENT_PARALLEL with the flag default")
 		require.True(t, resolve(seed, "--"+utils.ExperimentalParallelCommitmentFlag.Name+"=true"))
 		require.False(t, resolve(seed, "--"+utils.ExperimentalParallelCommitmentFlag.Name+"=false"))
 	}

--- a/cmd/integration/commands/dump_state_test.go
+++ b/cmd/integration/commands/dump_state_test.go
@@ -647,18 +647,21 @@ func TestExecCommandsExposeParallelCommitment(t *testing.T) {
 	}
 }
 
-// TestWithExperimentalCommitmentFollowsErigonDefault pins integration's default to
-// erigon's own flag default, so flipping it in one place cannot leave the two
-// binaries computing commitment with different tries.
-func TestWithExperimentalCommitmentFollowsErigonDefault(t *testing.T) {
-	defer func(v bool) { utils.ExperimentalParallelCommitmentFlag.Value = v }(utils.ExperimentalParallelCommitmentFlag.Value)
+func TestWithExperimentalCommitmentResolution(t *testing.T) {
 	defer func(v bool) { statecfg.ExperimentalParallelCommitment = v }(statecfg.ExperimentalParallelCommitment)
 
-	utils.ExperimentalParallelCommitmentFlag.Value = true
-	statecfg.ExperimentalParallelCommitment = false
+	resolve := func(seed bool, args ...string) bool {
+		statecfg.ExperimentalParallelCommitment = seed
+		cmd := &cobra.Command{Use: "probe"}
+		withExperimentalCommitment(cmd)
+		require.NoError(t, cmd.Flags().Parse(args))
+		return statecfg.ExperimentalParallelCommitment
+	}
 
-	withExperimentalCommitment(&cobra.Command{Use: "probe"})
-
-	require.True(t, statecfg.ExperimentalParallelCommitment,
-		"integration ignored erigon's default and would run the sequential trie")
+	for _, seed := range []bool{true, false} {
+		require.Equal(t, seed, resolve(seed),
+			"integration overrode COMMITMENT_PARALLEL with the flag default")
+		require.True(t, resolve(seed, "--"+utils.ExperimentalParallelCommitmentFlag.Name+"=true"))
+		require.False(t, resolve(seed, "--"+utils.ExperimentalParallelCommitmentFlag.Name+"=false"))
+	}
 }

--- a/cmd/integration/commands/dump_state_test.go
+++ b/cmd/integration/commands/dump_state_test.go
@@ -629,7 +629,8 @@ func TestResolveExecTarget_ChainTipLoopReachesTarget(t *testing.T) {
 
 // TestExecCommandsExposeParallelCommitment pins the flag on every integration
 // command that computes commitment. Without it the flag is unknown on stage_exec,
-// so integration can only ever run the sequential trie.
+// so integration is stuck on whatever COMMITMENT_PARALLEL selected and cannot
+// switch tries.
 func TestExecCommandsExposeParallelCommitment(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -642,7 +643,7 @@ func TestExecCommandsExposeParallelCommitment(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			require.NotNil(t, tc.cmd.Flags().Lookup(utils.ExperimentalParallelCommitmentFlag.Name),
-				"command cannot select the parallel trie")
+				"command cannot select the commitment trie")
 		})
 	}
 }

--- a/cmd/integration/commands/flags.go
+++ b/cmd/integration/commands/flags.go
@@ -174,11 +174,10 @@ func withDataDir(cmd *cobra.Command) {
 }
 
 // withExperimentalCommitment binds the flag erigon uses to pick the commitment
-// trie. The default ORs erigon's own flag default with the env-derived value so
-// that flipping the default in one binary cannot leave the other on a different
-// trie.
+// trie. statecfg already carries the COMMITMENT_PARALLEL value, so it is the
+// default here; an explicit flag overrides it in either direction.
 func withExperimentalCommitment(cmd *cobra.Command) {
-	def := statecfg.ExperimentalParallelCommitment || utils.ExperimentalParallelCommitmentFlag.Value
+	def := statecfg.ExperimentalParallelCommitment
 	cmd.Flags().BoolVar(&statecfg.ExperimentalParallelCommitment, utils.ExperimentalParallelCommitmentFlag.Name, def, utils.ExperimentalParallelCommitmentFlag.Usage)
 }
 

--- a/cmd/integration/commands/flags.go
+++ b/cmd/integration/commands/flags.go
@@ -173,9 +173,6 @@ func withDataDir(cmd *cobra.Command) {
 	must(cmd.MarkFlagDirname("chaindata"))
 }
 
-// withExperimentalCommitment binds the flag erigon uses to pick the commitment
-// trie. statecfg already carries the ERIGON_COMMITMENT_PARALLEL value, so it is the
-// default here; an explicit flag overrides it in either direction.
 func withExperimentalCommitment(cmd *cobra.Command) {
 	def := statecfg.ExperimentalParallelCommitment
 	cmd.Flags().BoolVar(&statecfg.ExperimentalParallelCommitment, utils.ExperimentalParallelCommitmentFlag.Name, def, utils.ExperimentalParallelCommitmentFlag.Usage)

--- a/cmd/integration/commands/flags.go
+++ b/cmd/integration/commands/flags.go
@@ -174,7 +174,7 @@ func withDataDir(cmd *cobra.Command) {
 }
 
 // withExperimentalCommitment binds the flag erigon uses to pick the commitment
-// trie. statecfg already carries the COMMITMENT_PARALLEL value, so it is the
+// trie. statecfg already carries the ERIGON_COMMITMENT_PARALLEL value, so it is the
 // default here; an explicit flag overrides it in either direction.
 func withExperimentalCommitment(cmd *cobra.Command) {
 	def := statecfg.ExperimentalParallelCommitment

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1895,11 +1895,10 @@ func CheckExclusive(ctx *cli.Command, args ...any) {
 	}
 }
 
-func setParallelCommitment(ctx *cli.Command, cfg *ethconfig.Config) {
+func setParallelCommitment(ctx *cli.Command) {
 	if ctx.IsSet(ExperimentalParallelCommitmentFlag.Name) {
 		statecfg.ExperimentalParallelCommitment = ctx.Bool(ExperimentalParallelCommitmentFlag.Name)
 	}
-	cfg.ExperimentalParallelCommitment = statecfg.ExperimentalParallelCommitment
 }
 
 // RpcGasCap reads the rpc.gascap flag; the accessor must match its registered UintFlag type.
@@ -2001,7 +2000,7 @@ func SetEthConfig(nodeCtx context.Context, ctx *cli.Command, nodeConfig *nodecfg
 	cfg.AllowAA = ctx.Bool(AAFlag.Name)
 	cfg.Ethstats = ctx.String(EthStatsURLFlag.Name)
 
-	setParallelCommitment(ctx, cfg)
+	setParallelCommitment(ctx)
 
 	cfg.FcuTimeout = ctx.Duration(FcuTimeoutFlag.Name)
 	cfg.FcuBackgroundPrune = ctx.Bool(FcuBackgroundPruneFlag.Name)
@@ -2042,7 +2041,7 @@ func SetEthConfig(nodeCtx context.Context, ctx *cli.Command, nodeConfig *nodecfg
 		warmupWorkers := dbg.BALCommitmentWarmupReaders()
 		blockReadAheadWorkers := dbg.ReadAheadWorkerReaders()
 		parallelCommitmentReaders := 0
-		if cfg.ExperimentalParallelCommitment || statecfg.ExperimentalParallelCommitment {
+		if statecfg.ExperimentalParallelCommitment {
 			parallelCommitmentReaders = commitment.ParallelCommitmentReadTxs()
 		}
 		if limit := httpcfg.RoTxsLimit(c, cfg.ExecWorkerCount, parallelCommitmentReaders, warmupWorkers, blockReadAheadWorkers); int64(c) < limit {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1123,9 +1123,6 @@ var (
 		Name:  "shutter.p2p.listen.port",
 		Usage: "Use to override the default p2p listen port (defaults to 23102)",
 	}
-	// ExperimentalParallelCommitmentFlag selects ParallelPatriciaHashed
-	// (ModeParallel) for commitment computation. Default on; pass =false to fall
-	// back to the sequential HexPatriciaHashed trie.
 	ExperimentalParallelCommitmentFlag = cli.BoolFlag{
 		Name:  "experimental.parallel-commitment",
 		Usage: "Compute commitment on the parallel trie (ParallelPatriciaHashed). Pass =false for the sequential trie.",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1124,12 +1124,12 @@ var (
 		Usage: "Use to override the default p2p listen port (defaults to 23102)",
 	}
 	// ExperimentalParallelCommitmentFlag selects ParallelPatriciaHashed
-	// (ModeParallel) for commitment computation. Default off; flip to compare
-	// root hashes against a sequential sync before enabling broadly.
+	// (ModeParallel) for commitment computation. Default on; pass =false to fall
+	// back to the sequential HexPatriciaHashed trie.
 	ExperimentalParallelCommitmentFlag = cli.BoolFlag{
 		Name:  "experimental.parallel-commitment",
-		Usage: "EXPERIMENTAL: enables fully parallel trie for commitment (ParallelPatriciaHashed).",
-		Value: false,
+		Usage: "Compute commitment on the parallel trie (ParallelPatriciaHashed). Pass =false for the sequential trie.",
+		Value: true,
 	}
 	GDBMeFlag = cli.BoolFlag{
 		Name:  "gdbme",
@@ -1898,6 +1898,13 @@ func CheckExclusive(ctx *cli.Command, args ...any) {
 	}
 }
 
+func setParallelCommitment(ctx *cli.Command, cfg *ethconfig.Config) {
+	if ctx.IsSet(ExperimentalParallelCommitmentFlag.Name) {
+		statecfg.ExperimentalParallelCommitment = ctx.Bool(ExperimentalParallelCommitmentFlag.Name)
+	}
+	cfg.ExperimentalParallelCommitment = statecfg.ExperimentalParallelCommitment
+}
+
 // RpcGasCap reads the rpc.gascap flag; the accessor must match its registered UintFlag type.
 func RpcGasCap(ctx *cli.Command) uint64 {
 	return uint64(ctx.Uint(RpcGasCapFlag.Name))
@@ -1997,9 +2004,7 @@ func SetEthConfig(nodeCtx context.Context, ctx *cli.Command, nodeConfig *nodecfg
 	cfg.AllowAA = ctx.Bool(AAFlag.Name)
 	cfg.Ethstats = ctx.String(EthStatsURLFlag.Name)
 
-	if ctx.Bool(ExperimentalParallelCommitmentFlag.Name) {
-		cfg.ExperimentalParallelCommitment = true
-	}
+	setParallelCommitment(ctx, cfg)
 
 	cfg.FcuTimeout = ctx.Duration(FcuTimeoutFlag.Name)
 	cfg.FcuBackgroundPrune = ctx.Bool(FcuBackgroundPruneFlag.Name)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1129,7 +1129,7 @@ var (
 	ExperimentalParallelCommitmentFlag = cli.BoolFlag{
 		Name:  "experimental.parallel-commitment",
 		Usage: "Compute commitment on the parallel trie (ParallelPatriciaHashed). Pass =false for the sequential trie.",
-		Value: true,
+		Value: statecfg.DefaultParallelCommitment,
 	}
 	GDBMeFlag = cli.BoolFlag{
 		Name:  "gdbme",

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -380,7 +380,7 @@ func TestSetParallelCommitment(t *testing.T) {
 
 	for _, seed := range []bool{true, false} {
 		cfg := run(seed)
-		require.Equal(t, seed, statecfg.ExperimentalParallelCommitment, "unset flag must leave COMMITMENT_PARALLEL in charge")
+		require.Equal(t, seed, statecfg.ExperimentalParallelCommitment, "unset flag must leave ERIGON_COMMITMENT_PARALLEL in charge")
 		require.Equal(t, seed, cfg.ExperimentalParallelCommitment)
 
 		cfg = run(seed, "--"+ExperimentalParallelCommitmentFlag.Name+"=false")

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -378,7 +378,7 @@ func TestSetParallelCommitment(t *testing.T) {
 	}
 
 	for _, seed := range []bool{true, false} {
-		require.Equal(t, seed, run(seed), "unset flag must leave ERIGON_COMMITMENT_PARALLEL in charge")
+		require.Equal(t, seed, run(seed), "unset flag must leave COMMITMENT_PARALLEL in charge")
 		require.False(t, run(seed, "--"+ExperimentalParallelCommitmentFlag.Name+"=false"),
 			"explicit =false must select the sequential trie")
 		require.True(t, run(seed, "--"+ExperimentalParallelCommitmentFlag.Name+"=true"))

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/node/direct"
 	"github.com/erigontech/erigon/node/ethconfig"
 	"github.com/erigontech/erigon/p2p"
@@ -352,4 +353,40 @@ func TestCommitmentPlainValuesFromCtx(t *testing.T) {
 	gotFalse := parse("--commitment.plainValues=false")
 	require.NotNil(t, gotFalse)
 	require.False(t, *gotFalse)
+}
+
+func TestSetParallelCommitment(t *testing.T) {
+	orig := statecfg.ExperimentalParallelCommitment
+	t.Cleanup(func() { statecfg.ExperimentalParallelCommitment = orig })
+
+	require.True(t, ExperimentalParallelCommitmentFlag.Value, "parallel commitment must be on by default")
+
+	run := func(seed bool, args ...string) ethconfig.Config {
+		statecfg.ExperimentalParallelCommitment = seed
+		flag := ExperimentalParallelCommitmentFlag
+		var cfg ethconfig.Config
+		app := &cli.Command{
+			Flags: []cli.Flag{&flag},
+			Action: func(_ context.Context, cmd *cli.Command) error {
+				setParallelCommitment(cmd, &cfg)
+				return nil
+			},
+		}
+		require.NoError(t, app.Run(context.Background(), append([]string{"test"}, args...)))
+		return cfg
+	}
+
+	for _, seed := range []bool{true, false} {
+		cfg := run(seed)
+		require.Equal(t, seed, statecfg.ExperimentalParallelCommitment, "unset flag must leave COMMITMENT_PARALLEL in charge")
+		require.Equal(t, seed, cfg.ExperimentalParallelCommitment)
+
+		cfg = run(seed, "--"+ExperimentalParallelCommitmentFlag.Name+"=false")
+		require.False(t, statecfg.ExperimentalParallelCommitment, "explicit =false must select the sequential trie")
+		require.False(t, cfg.ExperimentalParallelCommitment)
+
+		cfg = run(seed, "--"+ExperimentalParallelCommitmentFlag.Name+"=true")
+		require.True(t, statecfg.ExperimentalParallelCommitment)
+		require.True(t, cfg.ExperimentalParallelCommitment)
+	}
 }

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -363,32 +363,24 @@ func TestSetParallelCommitment(t *testing.T) {
 	require.Equal(t, statecfg.DefaultParallelCommitment, ExperimentalParallelCommitmentFlag.Value,
 		"advertised flag default drifted from the effective default")
 
-	run := func(seed bool, args ...string) ethconfig.Config {
+	run := func(seed bool, args ...string) bool {
 		statecfg.ExperimentalParallelCommitment = seed
 		flag := ExperimentalParallelCommitmentFlag
-		var cfg ethconfig.Config
 		app := &cli.Command{
 			Flags: []cli.Flag{&flag},
 			Action: func(_ context.Context, cmd *cli.Command) error {
-				setParallelCommitment(cmd, &cfg)
+				setParallelCommitment(cmd)
 				return nil
 			},
 		}
 		require.NoError(t, app.Run(context.Background(), append([]string{"test"}, args...)))
-		return cfg
+		return statecfg.ExperimentalParallelCommitment
 	}
 
 	for _, seed := range []bool{true, false} {
-		cfg := run(seed)
-		require.Equal(t, seed, statecfg.ExperimentalParallelCommitment, "unset flag must leave ERIGON_COMMITMENT_PARALLEL in charge")
-		require.Equal(t, seed, cfg.ExperimentalParallelCommitment)
-
-		cfg = run(seed, "--"+ExperimentalParallelCommitmentFlag.Name+"=false")
-		require.False(t, statecfg.ExperimentalParallelCommitment, "explicit =false must select the sequential trie")
-		require.False(t, cfg.ExperimentalParallelCommitment)
-
-		cfg = run(seed, "--"+ExperimentalParallelCommitmentFlag.Name+"=true")
-		require.True(t, statecfg.ExperimentalParallelCommitment)
-		require.True(t, cfg.ExperimentalParallelCommitment)
+		require.Equal(t, seed, run(seed), "unset flag must leave ERIGON_COMMITMENT_PARALLEL in charge")
+		require.False(t, run(seed, "--"+ExperimentalParallelCommitmentFlag.Name+"=false"),
+			"explicit =false must select the sequential trie")
+		require.True(t, run(seed, "--"+ExperimentalParallelCommitmentFlag.Name+"=true"))
 	}
 }

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -359,7 +359,9 @@ func TestSetParallelCommitment(t *testing.T) {
 	orig := statecfg.ExperimentalParallelCommitment
 	t.Cleanup(func() { statecfg.ExperimentalParallelCommitment = orig })
 
-	require.True(t, ExperimentalParallelCommitmentFlag.Value, "parallel commitment must be on by default")
+	require.True(t, statecfg.DefaultParallelCommitment, "parallel commitment must be on by default")
+	require.Equal(t, statecfg.DefaultParallelCommitment, ExperimentalParallelCommitmentFlag.Value,
+		"advertised flag default drifted from the effective default")
 
 	run := func(seed bool, args ...string) ethconfig.Config {
 		statecfg.ExperimentalParallelCommitment = seed

--- a/db/integrity/commitment_integrity.go
+++ b/db/integrity/commitment_integrity.go
@@ -1219,7 +1219,7 @@ func CheckCommitmentHistAtBlkRange(ctx context.Context, sc SamplerCfg, db kv.Tem
 			for blockNum := range sampler.BlockNums(windowStart, windowEnd) {
 				// Fresh SharedDomains per block: an SD is committed-or-closed,
 				// never reset in place.
-				sd, err := execctx.NewSharedDomains(wCtx, tx, logger, execctx.WithoutDeferredBranchUpdates())
+				sd, err := execctx.NewSharedDomains(wCtx, tx, logger, execctx.WithoutDeferredBranchUpdates(), execctx.WithSequentialCommitment())
 				if err != nil {
 					return err
 				}

--- a/db/state/statecfg/state_schema.go
+++ b/db/state/statecfg/state_schema.go
@@ -198,11 +198,15 @@ func commitmentKVWriteVersion(c *DomainCfg) version.Version {
 
 // ExperimentalParallelCommitment toggles the ParallelPatriciaHashed trie path
 // (commitment.ModeParallel + VariantParallelHexPatricia). Default true; set
-// COMMITMENT_PARALLEL=false (or --experimental.parallel-commitment=false) to
-// fall back to the sequential HexPatriciaHashed trie.
-const DefaultParallelCommitment = true
+// ERIGON_COMMITMENT_PARALLEL=false (or --experimental.parallel-commitment=false)
+// to fall back to the sequential HexPatriciaHashed trie. The name is spelled
+// with its prefix so the unprefixed COMMITMENT_PARALLEL is not also accepted.
+const (
+	DefaultParallelCommitment = true
+	parallelCommitmentEnvVar  = "ERIGON_COMMITMENT_PARALLEL"
+)
 
-var ExperimentalParallelCommitment = dbg.EnvBool("COMMITMENT_PARALLEL", DefaultParallelCommitment)
+var ExperimentalParallelCommitment = dbg.EnvBool(parallelCommitmentEnvVar, DefaultParallelCommitment)
 
 var Schema = SchemaGen{
 	AccountsDomain: DomainCfg{

--- a/db/state/statecfg/state_schema.go
+++ b/db/state/statecfg/state_schema.go
@@ -196,14 +196,10 @@ func commitmentKVWriteVersion(c *DomainCfg) version.Version {
 	return version.V2_2
 }
 
-// ExperimentalParallelCommitment toggles the ParallelPatriciaHashed trie path
-// (commitment.ModeParallel + VariantParallelHexPatricia). Default true; set
-// ERIGON_COMMITMENT_PARALLEL=false (or --experimental.parallel-commitment=false)
-// to fall back to the sequential HexPatriciaHashed trie. The name is spelled
-// with its prefix so the unprefixed COMMITMENT_PARALLEL is not also accepted.
 const (
 	DefaultParallelCommitment = true
-	parallelCommitmentEnvVar  = "ERIGON_COMMITMENT_PARALLEL"
+	// Spelled with the prefix so envLookup does not also accept COMMITMENT_PARALLEL.
+	parallelCommitmentEnvVar = "ERIGON_COMMITMENT_PARALLEL"
 )
 
 var ExperimentalParallelCommitment = dbg.EnvBool(parallelCommitmentEnvVar, DefaultParallelCommitment)

--- a/db/state/statecfg/state_schema.go
+++ b/db/state/statecfg/state_schema.go
@@ -197,9 +197,10 @@ func commitmentKVWriteVersion(c *DomainCfg) version.Version {
 }
 
 // ExperimentalParallelCommitment toggles the ParallelPatriciaHashed trie path
-// (commitment.ModeParallel + VariantParallelHexPatricia). Default false; the
-// COMMITMENT_PARALLEL env var (or the CLI flag) turns it on.
-var ExperimentalParallelCommitment = dbg.EnvBool("COMMITMENT_PARALLEL", false)
+// (commitment.ModeParallel + VariantParallelHexPatricia). Default true; set
+// COMMITMENT_PARALLEL=false (or --experimental.parallel-commitment=false) to
+// fall back to the sequential HexPatriciaHashed trie.
+var ExperimentalParallelCommitment = dbg.EnvBool("COMMITMENT_PARALLEL", true)
 
 var Schema = SchemaGen{
 	AccountsDomain: DomainCfg{

--- a/db/state/statecfg/state_schema.go
+++ b/db/state/statecfg/state_schema.go
@@ -200,7 +200,9 @@ func commitmentKVWriteVersion(c *DomainCfg) version.Version {
 // (commitment.ModeParallel + VariantParallelHexPatricia). Default true; set
 // COMMITMENT_PARALLEL=false (or --experimental.parallel-commitment=false) to
 // fall back to the sequential HexPatriciaHashed trie.
-var ExperimentalParallelCommitment = dbg.EnvBool("COMMITMENT_PARALLEL", true)
+const DefaultParallelCommitment = true
+
+var ExperimentalParallelCommitment = dbg.EnvBool("COMMITMENT_PARALLEL", DefaultParallelCommitment)
 
 var Schema = SchemaGen{
 	AccountsDomain: DomainCfg{

--- a/db/state/statecfg/state_schema.go
+++ b/db/state/statecfg/state_schema.go
@@ -196,13 +196,9 @@ func commitmentKVWriteVersion(c *DomainCfg) version.Version {
 	return version.V2_2
 }
 
-const (
-	DefaultParallelCommitment = true
-	// Spelled with the prefix so envLookup does not also accept COMMITMENT_PARALLEL.
-	parallelCommitmentEnvVar = "ERIGON_COMMITMENT_PARALLEL"
-)
+const DefaultParallelCommitment = true
 
-var ExperimentalParallelCommitment = dbg.EnvBool(parallelCommitmentEnvVar, DefaultParallelCommitment)
+var ExperimentalParallelCommitment = dbg.EnvBool("COMMITMENT_PARALLEL", DefaultParallelCommitment)
 
 var Schema = SchemaGen{
 	AccountsDomain: DomainCfg{

--- a/db/state/statecfg/state_schema_test.go
+++ b/db/state/statecfg/state_schema_test.go
@@ -20,7 +20,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/db/config3"
 )
 
@@ -50,4 +52,16 @@ func TestSchemaEntityEnabled(t *testing.T) {
 	} {
 		assert.Equal(t, tc.enabled, tc.cfg.Enabled, tc.name)
 	}
+}
+
+func TestParallelCommitmentEnvName(t *testing.T) {
+	t.Setenv("ERIGON_COMMITMENT_PARALLEL", "")
+	t.Setenv("COMMITMENT_PARALLEL", "false")
+	require.Equal(t, DefaultParallelCommitment,
+		dbg.EnvBool(parallelCommitmentEnvVar, DefaultParallelCommitment),
+		"unprefixed COMMITMENT_PARALLEL must not select the commitment trie")
+
+	t.Setenv("ERIGON_COMMITMENT_PARALLEL", "false")
+	require.False(t, dbg.EnvBool(parallelCommitmentEnvVar, DefaultParallelCommitment),
+		"ERIGON_COMMITMENT_PARALLEL=false must select the sequential trie")
 }

--- a/db/state/statecfg/state_schema_test.go
+++ b/db/state/statecfg/state_schema_test.go
@@ -20,9 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
-	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/db/config3"
 )
 
@@ -52,16 +50,4 @@ func TestSchemaEntityEnabled(t *testing.T) {
 	} {
 		assert.Equal(t, tc.enabled, tc.cfg.Enabled, tc.name)
 	}
-}
-
-func TestParallelCommitmentEnvName(t *testing.T) {
-	t.Setenv("ERIGON_COMMITMENT_PARALLEL", "")
-	t.Setenv("COMMITMENT_PARALLEL", "false")
-	require.Equal(t, DefaultParallelCommitment,
-		dbg.EnvBool(parallelCommitmentEnvVar, DefaultParallelCommitment),
-		"unprefixed COMMITMENT_PARALLEL must not select the commitment trie")
-
-	t.Setenv("ERIGON_COMMITMENT_PARALLEL", "false")
-	require.False(t, dbg.EnvBool(parallelCommitmentEnvVar, DefaultParallelCommitment),
-		"ERIGON_COMMITMENT_PARALLEL=false must select the sequential trie")
 }

--- a/docs/design/parallel-patricia-hashed.md
+++ b/docs/design/parallel-patricia-hashed.md
@@ -268,7 +268,7 @@ substitution of the as-of reader is validated at runtime by the block-root check
 
 | parameter | default | effect |
 | --- | --- | --- |
-| `--experimental.parallel-commitment` | on | selects `VariantParallelHexPatricia` (`execctx.PickTrieVariant`); `=false`, or `ERIGON_COMMITMENT_PARALLEL=false`, selects `VariantHexPatriciaTrie` |
+| `--experimental.parallel-commitment` | on | selects `VariantParallelHexPatricia` (`execctx.PickTrieVariant`); `=false`, or `COMMITMENT_PARALLEL=false`, selects `VariantHexPatriciaTrie` |
 | `--experimental.streaming-commitment` | off | selects `VariantStreamingHexPatricia` (`StreamingCommitter`); takes precedence over `--experimental.parallel-commitment` |
 | `deepStorageThreshold` | 1000 | compile-time const (not a runtime flag): per-account touched-storage-key count above which the storage subtree folds concurrently (§4.1.1); mitigates the whale bottleneck of §11 |
 | `numWorkers` | `runtime.NumCPU()` | worker-pool size and errgroup limit; override via `SetNumWorkers` |

--- a/docs/design/parallel-patricia-hashed.md
+++ b/docs/design/parallel-patricia-hashed.md
@@ -268,7 +268,7 @@ substitution of the as-of reader is validated at runtime by the block-root check
 
 | parameter | default | effect |
 | --- | --- | --- |
-| `--experimental.parallel-commitment` | on | selects `VariantParallelHexPatricia` (`execctx.PickTrieVariant`); `=false`, or `COMMITMENT_PARALLEL=false`, selects `VariantHexPatriciaTrie` |
+| `--experimental.parallel-commitment` | on | selects `VariantParallelHexPatricia` (`execctx.PickTrieVariant`); `=false`, or `ERIGON_COMMITMENT_PARALLEL=false`, selects `VariantHexPatriciaTrie` |
 | `--experimental.streaming-commitment` | off | selects `VariantStreamingHexPatricia` (`StreamingCommitter`); takes precedence over `--experimental.parallel-commitment` |
 | `deepStorageThreshold` | 1000 | compile-time const (not a runtime flag): per-account touched-storage-key count above which the storage subtree folds concurrently (§4.1.1); mitigates the whale bottleneck of §11 |
 | `numWorkers` | `runtime.NumCPU()` | worker-pool size and errgroup limit; override via `SetNumWorkers` |

--- a/docs/design/parallel-patricia-hashed.md
+++ b/docs/design/parallel-patricia-hashed.md
@@ -3,7 +3,7 @@
 | | |
 | --- | --- |
 | Component | `execution/commitment` |
-| Stability | Experimental — `--experimental.parallel-commitment`, default off |
+| Stability | Default on — `--experimental.parallel-commitment=false` selects the sequential trie |
 | Implements | `commitment.Trie` |
 | Audience | Contributors to commitment / state-root computation |
 
@@ -268,7 +268,7 @@ substitution of the as-of reader is validated at runtime by the block-root check
 
 | parameter | default | effect |
 | --- | --- | --- |
-| `--experimental.parallel-commitment` | off | selects `VariantParallelHexPatricia` (`execctx.PickTrieVariant`) |
+| `--experimental.parallel-commitment` | on | selects `VariantParallelHexPatricia` (`execctx.PickTrieVariant`); `=false`, or `COMMITMENT_PARALLEL=false`, selects `VariantHexPatriciaTrie` |
 | `--experimental.streaming-commitment` | off | selects `VariantStreamingHexPatricia` (`StreamingCommitter`); takes precedence over `--experimental.parallel-commitment` |
 | `deepStorageThreshold` | 1000 | compile-time const (not a runtime flag): per-account touched-storage-key count above which the storage subtree folds concurrently (§4.1.1); mitigates the whale bottleneck of §11 |
 | `numWorkers` | `runtime.NumCPU()` | worker-pool size and errgroup limit; override via `SetNumWorkers` |
@@ -300,7 +300,7 @@ in scheduling.
 
 | | `HexPatriciaHashed` | `ParallelPatriciaHashed` |
 | --- | --- | --- |
-| flag | (default) | `--experimental.parallel-commitment` |
+| flag | `--experimental.parallel-commitment=false` | (default) |
 | `Updates` mode | `ModeDirect` / `ModeUpdate` | `ModeParallel` |
 | parallel unit | none | one worker per **touched** top nibble (≤16), plus one per first-storage nibble inside a big-storage account |
 | split granularity | none | touched top nibbles at depth 1, and first-storage nibbles at depth 64 for big-storage accounts (§4.1.1) |

--- a/docs/site/docs/fundamentals/configuring-erigon.mdx
+++ b/docs/site/docs/fundamentals/configuring-erigon.mdx
@@ -507,7 +507,7 @@ Flags for configuring the parallel block execution engine.
 
 **Commitment-trie construction.** The following flags change how the commitment (state-root) trie is computed during execution.
 
-* `--experimental.parallel-commitment` *(New in v3.6)*: Compute the commitment trie with the fully parallel `ParallelPatriciaHashed` implementation. Pass `--experimental.parallel-commitment=false`, or set `COMMITMENT_PARALLEL=false`, to fall back to the sequential `HexPatriciaHashed` trie.
+* `--experimental.parallel-commitment` *(New in v3.6)*: Compute the commitment trie with the fully parallel `ParallelPatriciaHashed` implementation. Pass `--experimental.parallel-commitment=false`, or set `ERIGON_COMMITMENT_PARALLEL=false`, to fall back to the sequential `HexPatriciaHashed` trie.
   * Default: `true`
 * `--experimental.streaming-commitment` *(New in v3.6)* (experimental): Compute the commitment trie with the `StreamingCommitter`, which overlaps trie folding with block execution. If set, takes precedence over `--experimental.parallel-commitment`. No environment-variable equivalent.
   * Default: `false`

--- a/docs/site/docs/fundamentals/configuring-erigon.mdx
+++ b/docs/site/docs/fundamentals/configuring-erigon.mdx
@@ -505,10 +505,10 @@ Flags for configuring the parallel block execution engine.
 * `--exec.state-cache`: Enable the executor's domain-shared read cache. Equivalent to `USE_STATE_CACHE=true`. Disable for cold-read performance measurements.
   * Default: `true`
 
-**Commitment-trie construction.** The following flags change how the commitment (state-root) trie is computed during execution. Both default off and are intended for comparing root hashes against a sequential sync before enabling broadly.
+**Commitment-trie construction.** The following flags change how the commitment (state-root) trie is computed during execution.
 
-* `--experimental.parallel-commitment` *(New in v3.6)* (experimental): Compute the commitment trie with the fully parallel `ParallelPatriciaHashed` implementation. Equivalent to the `COMMITMENT_PARALLEL=true` environment variable.
-  * Default: `false`
+* `--experimental.parallel-commitment` *(New in v3.6)*: Compute the commitment trie with the fully parallel `ParallelPatriciaHashed` implementation. Pass `--experimental.parallel-commitment=false`, or set `COMMITMENT_PARALLEL=false`, to fall back to the sequential `HexPatriciaHashed` trie.
+  * Default: `true`
 * `--experimental.streaming-commitment` *(New in v3.6)* (experimental): Compute the commitment trie with the `StreamingCommitter`, which overlaps trie folding with block execution. If set, takes precedence over `--experimental.parallel-commitment`. No environment-variable equivalent.
   * Default: `false`
 

--- a/docs/site/docs/fundamentals/configuring-erigon.mdx
+++ b/docs/site/docs/fundamentals/configuring-erigon.mdx
@@ -507,7 +507,7 @@ Flags for configuring the parallel block execution engine.
 
 **Commitment-trie construction.** The following flags change how the commitment (state-root) trie is computed during execution.
 
-* `--experimental.parallel-commitment` *(New in v3.6)*: Compute the commitment trie with the fully parallel `ParallelPatriciaHashed` implementation. Pass `--experimental.parallel-commitment=false`, or set `ERIGON_COMMITMENT_PARALLEL=false`, to fall back to the sequential `HexPatriciaHashed` trie.
+* `--experimental.parallel-commitment` *(New in v3.6)*: Compute the commitment trie with the fully parallel `ParallelPatriciaHashed` implementation. Pass `--experimental.parallel-commitment=false`, or set `COMMITMENT_PARALLEL=false`, to fall back to the sequential `HexPatriciaHashed` trie.
   * Default: `true`
 * `--experimental.streaming-commitment` *(New in v3.6)* (experimental): Compute the commitment trie with the `StreamingCommitter`, which overlaps trie folding with block execution. If set, takes precedence over `--experimental.parallel-commitment`. No environment-variable equivalent.
   * Default: `false`

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -2712,7 +2712,7 @@ Flags for configuring the parallel block execution engine.
 
 **Commitment-trie construction.** The following flags change how the commitment (state-root) trie is computed during execution.
 
-* `--experimental.parallel-commitment` *(New in v3.6)*: Compute the commitment trie with the fully parallel `ParallelPatriciaHashed` implementation. Pass `--experimental.parallel-commitment=false`, or set `COMMITMENT_PARALLEL=false`, to fall back to the sequential `HexPatriciaHashed` trie.
+* `--experimental.parallel-commitment` *(New in v3.6)*: Compute the commitment trie with the fully parallel `ParallelPatriciaHashed` implementation. Pass `--experimental.parallel-commitment=false`, or set `ERIGON_COMMITMENT_PARALLEL=false`, to fall back to the sequential `HexPatriciaHashed` trie.
   * Default: `true`
 * `--experimental.streaming-commitment` *(New in v3.6)* (experimental): Compute the commitment trie with the `StreamingCommitter`, which overlaps trie folding with block execution. If set, takes precedence over `--experimental.parallel-commitment`. No environment-variable equivalent.
   * Default: `false`

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -2712,7 +2712,7 @@ Flags for configuring the parallel block execution engine.
 
 **Commitment-trie construction.** The following flags change how the commitment (state-root) trie is computed during execution.
 
-* `--experimental.parallel-commitment` *(New in v3.6)*: Compute the commitment trie with the fully parallel `ParallelPatriciaHashed` implementation. Pass `--experimental.parallel-commitment=false`, or set `ERIGON_COMMITMENT_PARALLEL=false`, to fall back to the sequential `HexPatriciaHashed` trie.
+* `--experimental.parallel-commitment` *(New in v3.6)*: Compute the commitment trie with the fully parallel `ParallelPatriciaHashed` implementation. Pass `--experimental.parallel-commitment=false`, or set `COMMITMENT_PARALLEL=false`, to fall back to the sequential `HexPatriciaHashed` trie.
   * Default: `true`
 * `--experimental.streaming-commitment` *(New in v3.6)* (experimental): Compute the commitment trie with the `StreamingCommitter`, which overlaps trie folding with block execution. If set, takes precedence over `--experimental.parallel-commitment`. No environment-variable equivalent.
   * Default: `false`

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -2710,10 +2710,10 @@ Flags for configuring the parallel block execution engine.
 * `--exec.state-cache`: Enable the executor's domain-shared read cache. Equivalent to `USE_STATE_CACHE=true`. Disable for cold-read performance measurements.
   * Default: `true`
 
-**Commitment-trie construction.** The following flags change how the commitment (state-root) trie is computed during execution. Both default off and are intended for comparing root hashes against a sequential sync before enabling broadly.
+**Commitment-trie construction.** The following flags change how the commitment (state-root) trie is computed during execution.
 
-* `--experimental.parallel-commitment` *(New in v3.6)* (experimental): Compute the commitment trie with the fully parallel `ParallelPatriciaHashed` implementation. Equivalent to the `COMMITMENT_PARALLEL=true` environment variable.
-  * Default: `false`
+* `--experimental.parallel-commitment` *(New in v3.6)*: Compute the commitment trie with the fully parallel `ParallelPatriciaHashed` implementation. Pass `--experimental.parallel-commitment=false`, or set `COMMITMENT_PARALLEL=false`, to fall back to the sequential `HexPatriciaHashed` trie.
+  * Default: `true`
 * `--experimental.streaming-commitment` *(New in v3.6)* (experimental): Compute the commitment trie with the `StreamingCommitter`, which overlaps trie folding with block execution. If set, takes precedence over `--experimental.parallel-commitment`. No environment-variable equivalent.
   * Default: `false`
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2712,7 +2712,7 @@ Flags for configuring the parallel block execution engine.
 
 **Commitment-trie construction.** The following flags change how the commitment (state-root) trie is computed during execution.
 
-* `--experimental.parallel-commitment` *(New in v3.6)*: Compute the commitment trie with the fully parallel `ParallelPatriciaHashed` implementation. Pass `--experimental.parallel-commitment=false`, or set `COMMITMENT_PARALLEL=false`, to fall back to the sequential `HexPatriciaHashed` trie.
+* `--experimental.parallel-commitment` *(New in v3.6)*: Compute the commitment trie with the fully parallel `ParallelPatriciaHashed` implementation. Pass `--experimental.parallel-commitment=false`, or set `ERIGON_COMMITMENT_PARALLEL=false`, to fall back to the sequential `HexPatriciaHashed` trie.
   * Default: `true`
 * `--experimental.streaming-commitment` *(New in v3.6)* (experimental): Compute the commitment trie with the `StreamingCommitter`, which overlaps trie folding with block execution. If set, takes precedence over `--experimental.parallel-commitment`. No environment-variable equivalent.
   * Default: `false`

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2712,7 +2712,7 @@ Flags for configuring the parallel block execution engine.
 
 **Commitment-trie construction.** The following flags change how the commitment (state-root) trie is computed during execution.
 
-* `--experimental.parallel-commitment` *(New in v3.6)*: Compute the commitment trie with the fully parallel `ParallelPatriciaHashed` implementation. Pass `--experimental.parallel-commitment=false`, or set `ERIGON_COMMITMENT_PARALLEL=false`, to fall back to the sequential `HexPatriciaHashed` trie.
+* `--experimental.parallel-commitment` *(New in v3.6)*: Compute the commitment trie with the fully parallel `ParallelPatriciaHashed` implementation. Pass `--experimental.parallel-commitment=false`, or set `COMMITMENT_PARALLEL=false`, to fall back to the sequential `HexPatriciaHashed` trie.
   * Default: `true`
 * `--experimental.streaming-commitment` *(New in v3.6)* (experimental): Compute the commitment trie with the `StreamingCommitter`, which overlaps trie folding with block execution. If set, takes precedence over `--experimental.parallel-commitment`. No environment-variable equivalent.
   * Default: `false`

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2710,10 +2710,10 @@ Flags for configuring the parallel block execution engine.
 * `--exec.state-cache`: Enable the executor's domain-shared read cache. Equivalent to `USE_STATE_CACHE=true`. Disable for cold-read performance measurements.
   * Default: `true`
 
-**Commitment-trie construction.** The following flags change how the commitment (state-root) trie is computed during execution. Both default off and are intended for comparing root hashes against a sequential sync before enabling broadly.
+**Commitment-trie construction.** The following flags change how the commitment (state-root) trie is computed during execution.
 
-* `--experimental.parallel-commitment` *(New in v3.6)* (experimental): Compute the commitment trie with the fully parallel `ParallelPatriciaHashed` implementation. Equivalent to the `COMMITMENT_PARALLEL=true` environment variable.
-  * Default: `false`
+* `--experimental.parallel-commitment` *(New in v3.6)*: Compute the commitment trie with the fully parallel `ParallelPatriciaHashed` implementation. Pass `--experimental.parallel-commitment=false`, or set `COMMITMENT_PARALLEL=false`, to fall back to the sequential `HexPatriciaHashed` trie.
+  * Default: `true`
 * `--experimental.streaming-commitment` *(New in v3.6)* (experimental): Compute the commitment trie with the `StreamingCommitter`, which overlaps trie folding with block execution. If set, takes precedence over `--experimental.parallel-commitment`. No environment-variable equivalent.
   * Default: `false`
 

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -299,9 +299,6 @@ func New(
 	}
 
 	// Assemble the Ethereum object
-	if config.ExperimentalParallelCommitment {
-		statecfg.ExperimentalParallelCommitment = true
-	}
 	stack.Config().ExecWorkerCount = config.Sync.ExecWorkerCount
 	rawChainDB, err := node.OpenDatabase(ctx, stack.Config(), dbcfg.ChainDB, "", false, logger)
 	if err != nil {

--- a/node/ethconfig/config.go
+++ b/node/ethconfig/config.go
@@ -306,11 +306,10 @@ type Sync struct {
 	LoopBlockLimit             uint
 	ParallelStateFlushing      bool
 
-	ChaosMonkey                    bool
-	AlwaysGenerateChangesets       bool
-	MaxReorgDepth                  uint64
-	KeepExecutionProofs            bool
-	ExperimentalParallelCommitment bool
-	PersistReceiptsCacheV2         bool
-	SnapshotDownloadToBlock        uint64 // exclusive [0,toBlock)
+	ChaosMonkey              bool
+	AlwaysGenerateChangesets bool
+	MaxReorgDepth            uint64
+	KeepExecutionProofs      bool
+	PersistReceiptsCacheV2   bool
+	SnapshotDownloadToBlock  uint64 // exclusive [0,toBlock)
 }


### PR DESCRIPTION
`--experimental.parallel-commitment` and `COMMITMENT_PARALLEL` now default to on: a node with neither set computes commitment on `ParallelPatriciaHashed`. Closes #21137.

Flipping the two defaults is not enough on its own. The CLI flag was one-way (`if ctx.Bool(...) { cfg.X = true }`) and integration's binding merged both defaults with `||`, so a `true` default would have left `=false` and the env var inert. Resolution is now: the env var seeds `statecfg.ExperimentalParallelCommitment`, an explicit flag overrides it either way, and `statecfg` carries the effective value. `statecfg.DefaultParallelCommitment` is the single literal behind both the env fallback and the flag's advertised default, so the two cannot drift.

The flip also makes `checkParaTrieWired` reachable for any `NewSharedDomains` that selects the parallel variant with no DB wired — under `ERIGON_ASSERT` that path returns an error rather than warning and falling back. All 46 non-test call sites audited, and they fall into three groups, not two: wired (`execV3`/`execV3Serial` call `EnableParaTrieDB` centrally, covering the `cmd/integration` and `execmodule` clusters), opted out (`WithSequentialCommitment`), and never reaching `ComputeCommitment` at all (`execmodule` only flushes the `BlockOverlay`; `InitPraguePreDeploys` and the `vm/runtime` helpers compute no root). That last group is safe by unreachability, not by opting out — do not read it as an invariant the guard depends on. One site was genuinely exposed, `db/integrity/commitment_integrity.go:1222`, fixed here.

`node/ethconfig.Config.ExperimentalParallelCommitment` is gone. It had one writer and two readers and could only ever disagree with `statecfg`; `statecfg.ExperimentalParallelCommitment` is now the single source of truth, which removes the `||` merge at `cmd/utils/flags.go` and the one-way set in `node/eth/backend.go`.

CI arms are unaffected — every `commitment_mode` matrix leg already sets `ERIGON_COMMITMENT_PARALLEL` explicitly, so both stay pinned regardless of the default.

## Changes
- `db/state/statecfg`: `DefaultParallelCommitment = true` behind `EnvBool("COMMITMENT_PARALLEL", …)`; `cmd/utils` takes the flag's `Value` from the same const
- `cmd/utils`: `setParallelCommitment` replaces the one-way set and honours an explicit `=false`
- `node/ethconfig`, `node/eth`: drop the duplicate `ExperimentalParallelCommitment` field and the one-way sync it fed
- `cmd/integration`: `withExperimentalCommitment` defaults to `statecfg`; the previous `||` clobbered an env `false` once the flag default became `true`
- `db/integrity`: the per-block history check passes `WithSequentialCommitment()`, matching its two siblings at :1140 and :1208
- tests: the default, const-vs-flag drift, and both override directions in each binary
- docs: design doc, the operator flag reference, and both generated `llms-full.txt` copies
