### PR TITLE
cl/services: claim the attestation seen slot only after signature verification

### DIFF
--- a/cl/phase1/network/services/attestation_service.go
+++ b/cl/phase1/network/services/attestation_service.go
@@ -289,7 +289,6 @@ func (s *attestationService) ProcessMessage(ctx context.Context, subnet *uint64,
 			}
 		}
 		// [IGNORE] There has been no other valid attestation seen on an attestation subnet that has an identical attestation.data.target.epoch and participating validator index.
-		// mark the validator as seen
 		epochLastTime, ok := s.validatorAttestationSeen.Get(vIndex)
 		if ok && epochLastTime == targetEpoch {
 			return fmt.Errorf("validator already seen in target epoch %w", ErrIgnore)

--- a/cl/phase1/network/services/attestation_service.go
+++ b/cl/phase1/network/services/attestation_service.go
@@ -156,6 +156,7 @@ func (s *attestationService) ProcessMessage(ctx context.Context, subnet *uint64,
 	clVersion := s.beaconCfg.GetCurrentStateVersion(attEpoch)
 
 	var err error
+	var markValidatorSeen func()
 	if clVersion >= clparams.ElectraVersion {
 		if att.SingleAttestation == nil {
 			return errors.New("single attestation is empty")
@@ -294,7 +295,9 @@ func (s *attestationService) ProcessMessage(ctx context.Context, subnet *uint64,
 		if ok && epochLastTime == targetEpoch {
 			return fmt.Errorf("validator already seen in target epoch %w", ErrIgnore)
 		}
-		s.validatorAttestationSeen.Add(vIndex, targetEpoch)
+		// The entry is claimed in F, once the signature has been verified: a
+		// message dropped before that must not consume the validator's slot.
+		markValidatorSeen = func() { s.validatorAttestationSeen.Add(vIndex, targetEpoch) }
 
 		// [REJECT] The signature of attestation is valid.
 		pubKey, err = headState.ValidatorPublicKey(int(vIndex))
@@ -353,6 +356,9 @@ func (s *attestationService) ProcessMessage(ctx context.Context, subnet *uint64,
 		F: func() {
 			start := time.Now()
 			defer monitor.ObserveAggregateAttestation(start)
+			if markValidatorSeen != nil {
+				markValidatorSeen()
+			}
 			if err = s.committeeSubscribe.AggregateAttestation(attestation); errors.Is(err, aggregation.ErrIsSuperset) {
 				return
 			} else if err != nil {

--- a/cl/phase1/network/services/attestation_service.go
+++ b/cl/phase1/network/services/attestation_service.go
@@ -156,7 +156,6 @@ func (s *attestationService) ProcessMessage(ctx context.Context, subnet *uint64,
 	clVersion := s.beaconCfg.GetCurrentStateVersion(attEpoch)
 
 	var err error
-	var markValidatorSeen func()
 	if clVersion >= clparams.ElectraVersion {
 		if att.SingleAttestation == nil {
 			return errors.New("single attestation is empty")
@@ -205,6 +204,7 @@ func (s *attestationService) ProcessMessage(ctx context.Context, subnet *uint64,
 	var (
 		domain      []byte
 		pubKey      common.Bytes48
+		vIndex      uint64
 		attestation *solid.Attestation // SingleAttestation will be transformed to Attestation struct with given member index in committee
 	)
 	if err := s.syncedDataManager.ViewHeadState(func(headState *state.CachingBeaconState) error {
@@ -229,7 +229,6 @@ func (s *attestationService) ProcessMessage(ctx context.Context, subnet *uint64,
 		if err != nil {
 			return err
 		}
-		var vIndex uint64
 		if clVersion <= clparams.DenebVersion {
 			// [REJECT] The number of aggregation bits matches the committee size -- i.e. len(aggregation_bits) == len(get_beacon_committee(state, attestation.data.slot, index)).
 			bits := att.Attestation.AggregationBits.Bytes()
@@ -295,9 +294,6 @@ func (s *attestationService) ProcessMessage(ctx context.Context, subnet *uint64,
 		if ok && epochLastTime == targetEpoch {
 			return fmt.Errorf("validator already seen in target epoch %w", ErrIgnore)
 		}
-		// The entry is claimed in F, once the signature has been verified: a
-		// message dropped before that must not consume the validator's slot.
-		markValidatorSeen = func() { s.validatorAttestationSeen.Add(vIndex, targetEpoch) }
 
 		// [REJECT] The signature of attestation is valid.
 		pubKey, err = headState.ValidatorPublicKey(int(vIndex))
@@ -356,9 +352,9 @@ func (s *attestationService) ProcessMessage(ctx context.Context, subnet *uint64,
 		F: func() {
 			start := time.Now()
 			defer monitor.ObserveAggregateAttestation(start)
-			if markValidatorSeen != nil {
-				markValidatorSeen()
-			}
+			// Claimed only now: a message dropped before its signature was
+			// verified must not consume the validator's slot for the epoch.
+			s.validatorAttestationSeen.Add(vIndex, targetEpoch)
 			if err = s.committeeSubscribe.AggregateAttestation(attestation); errors.Is(err, aggregation.ErrIsSuperset) {
 				return
 			} else if err != nil {

--- a/cl/phase1/network/services/attestation_service_test.go
+++ b/cl/phase1/network/services/attestation_service_test.go
@@ -411,10 +411,9 @@ func (t *attestationTestSuite) TestAttestationProcessMessageAllowsNextEpochWhenC
 	t.Require().NoError(err)
 }
 
-// An attestation that is dropped before its signature is checked must not
-// consume the per-validator seen slot, otherwise anyone can name a real
-// committee member and censor that validator's genuine attestation for the
-// rest of the epoch at no cost.
+// The per-validator seen slot must be claimed only once the signature has been
+// verified, otherwise anyone can name a real committee member and censor that
+// validator's genuine attestation for the rest of the epoch at no cost.
 func (t *attestationTestSuite) TestAttestationSeenOnlyAfterSignatureVerification() {
 	computeCommitteeCountPerSlot = func(_ abstract.BeaconStateReader, _, _ uint64) uint64 {
 		return 8
@@ -432,8 +431,8 @@ func (t *attestationTestSuite) TestAttestationSeenOnlyAfterSignatureVerification
 	t.ethClock.EXPECT().GetCurrentSlot().Return(mockSlot).AnyTimes()
 	t.mockForkChoice.HighestSeenVal = mockSlot
 
-	// The forged copy names the same validator but a block this node has not seen,
-	// so validation stops before any signature work.
+	// The block is not in fork choice yet, so validation stops before any
+	// signature work.
 	err := t.attService.ProcessMessage(context.Background(), common.NewUint64(1), &AttestationForGossip{
 		Attestation:      att,
 		ImmediateProcess: true,
@@ -459,6 +458,14 @@ func (t *attestationTestSuite) TestAttestationSeenOnlyAfterSignatureVerification
 	})
 	time.Sleep(time.Millisecond * 60)
 	t.Require().NoError(err)
+
+	// ...and having been verified, it now holds the slot against a duplicate.
+	err = t.attService.ProcessMessage(context.Background(), common.NewUint64(1), &AttestationForGossip{
+		Attestation:      att,
+		ImmediateProcess: true,
+	})
+	t.Require().ErrorIs(err, ErrIgnore)
+	t.Require().Contains(err.Error(), "already seen")
 }
 
 func (t *attestationTestSuite) TestAttestationProcessMessageRejectsBeyondNextEpochDespiteForkchoiceHavingSeenIt() {

--- a/cl/phase1/network/services/attestation_service_test.go
+++ b/cl/phase1/network/services/attestation_service_test.go
@@ -424,22 +424,15 @@ func (t *attestationTestSuite) TestAttestationSeenOnlyAfterSignatureVerification
 	computeSigningRoot = func(obj ssz.HashableSSZ, domain []byte) ([32]byte, error) {
 		return [32]byte{}, nil
 	}
+	signatureValid := false
 	blsVerifyMultipleSignatures = func(signatures [][]byte, signRoots [][]byte, pks [][]byte) (bool, error) {
-		return true, nil
+		return signatureValid, nil
 	}
 	t.ethClock.EXPECT().GetEpochAtSlot(mockSlot).Return(mockEpoch).AnyTimes()
 	t.ethClock.EXPECT().GetCurrentSlot().Return(mockSlot).AnyTimes()
 	t.mockForkChoice.HighestSeenVal = mockSlot
 
-	// The block is not in fork choice yet, so validation stops before any
-	// signature work.
-	err := t.attService.ProcessMessage(context.Background(), common.NewUint64(1), &AttestationForGossip{
-		Attestation:      att,
-		ImmediateProcess: true,
-	})
-	t.Require().Error(err)
-	t.Require().Contains(err.Error(), "block not seen")
-
+	// The block is known, so validation reaches signature verification.
 	finalizedCheckpoint := solid.Checkpoint{Root: [32]byte{1, 0}, Epoch: 1}
 	t.mockForkChoice.Headers = map[common.Hash]*cltypes.BeaconBlockHeader{
 		attData.BeaconBlockRoot: {},
@@ -451,12 +444,19 @@ func (t *attestationTestSuite) TestAttestationSeenOnlyAfterSignatureVerification
 	t.mockForkChoice.FinalizedCheckpointVal = finalizedCheckpoint
 	t.committeeSubscibe.EXPECT().AggregateAttestation(att).Return(nil).Times(1)
 
+	// An invalid signature must not consume the validator's slot.
+	err := t.attService.ProcessMessage(context.Background(), common.NewUint64(1), &AttestationForGossip{
+		Attestation:      att,
+		ImmediateProcess: true,
+	})
+	t.Require().Error(err)
+
 	// The validator's genuine attestation must still be accepted.
+	signatureValid = true
 	err = t.attService.ProcessMessage(context.Background(), common.NewUint64(1), &AttestationForGossip{
 		Attestation:      att,
 		ImmediateProcess: true,
 	})
-	time.Sleep(time.Millisecond * 60)
 	t.Require().NoError(err)
 
 	// ...and having been verified, it now holds the slot against a duplicate.

--- a/cl/phase1/network/services/attestation_service_test.go
+++ b/cl/phase1/network/services/attestation_service_test.go
@@ -411,6 +411,56 @@ func (t *attestationTestSuite) TestAttestationProcessMessageAllowsNextEpochWhenC
 	t.Require().NoError(err)
 }
 
+// An attestation that is dropped before its signature is checked must not
+// consume the per-validator seen slot, otherwise anyone can name a real
+// committee member and censor that validator's genuine attestation for the
+// rest of the epoch at no cost.
+func (t *attestationTestSuite) TestAttestationSeenOnlyAfterSignatureVerification() {
+	computeCommitteeCountPerSlot = func(_ abstract.BeaconStateReader, _, _ uint64) uint64 {
+		return 8
+	}
+	computeSubnetForAttestation = func(_, _, _, _, _ uint64) uint64 {
+		return 1
+	}
+	computeSigningRoot = func(obj ssz.HashableSSZ, domain []byte) ([32]byte, error) {
+		return [32]byte{}, nil
+	}
+	blsVerifyMultipleSignatures = func(signatures [][]byte, signRoots [][]byte, pks [][]byte) (bool, error) {
+		return true, nil
+	}
+	t.ethClock.EXPECT().GetEpochAtSlot(mockSlot).Return(mockEpoch).AnyTimes()
+	t.ethClock.EXPECT().GetCurrentSlot().Return(mockSlot).AnyTimes()
+	t.mockForkChoice.HighestSeenVal = mockSlot
+
+	// The forged copy names the same validator but a block this node has not seen,
+	// so validation stops before any signature work.
+	err := t.attService.ProcessMessage(context.Background(), common.NewUint64(1), &AttestationForGossip{
+		Attestation:      att,
+		ImmediateProcess: true,
+	})
+	t.Require().Error(err)
+	t.Require().Contains(err.Error(), "block not seen")
+
+	finalizedCheckpoint := solid.Checkpoint{Root: [32]byte{1, 0}, Epoch: 1}
+	t.mockForkChoice.Headers = map[common.Hash]*cltypes.BeaconBlockHeader{
+		attData.BeaconBlockRoot: {},
+	}
+	t.mockForkChoice.Ancestors = map[uint64]forkchoice.ForkChoiceNode{
+		mockEpoch * mockSlotsPerEpoch:                 {Root: attData.Target.Root},
+		finalizedCheckpoint.Epoch * mockSlotsPerEpoch: {Root: finalizedCheckpoint.Root},
+	}
+	t.mockForkChoice.FinalizedCheckpointVal = finalizedCheckpoint
+	t.committeeSubscibe.EXPECT().AggregateAttestation(att).Return(nil).Times(1)
+
+	// The validator's genuine attestation must still be accepted.
+	err = t.attService.ProcessMessage(context.Background(), common.NewUint64(1), &AttestationForGossip{
+		Attestation:      att,
+		ImmediateProcess: true,
+	})
+	time.Sleep(time.Millisecond * 60)
+	t.Require().NoError(err)
+}
+
 func (t *attestationTestSuite) TestAttestationProcessMessageRejectsBeyondNextEpochDespiteForkchoiceHavingSeenIt() {
 	beyondNextEpochSlot := mockSlot + 2*mockSlotsPerEpoch
 	beyondNextEpoch := mockEpoch + 2


### PR DESCRIPTION
`attestation_service.go` marks a validator seen for the target epoch before its signature is checked, and before the `block not seen` ignore path.

An attacker sends a `SingleAttestation` on the right subnet naming any real committee member (membership is publicly derivable), with a garbage signature and a `BeaconBlockRoot` this node has not seen. The entry is claimed, the message is dropped as `ErrIgnore` before any signature work, and the peer is not penalised. That validator's genuine attestation is then discarded as a duplicate for the rest of the epoch. Repeat per committee member to silence the subnets this node serves.

Every sibling service in the package already claims after verification — see the `// Mark as seen AFTER successful validation` comment in `execution_payload_service.go`.

The new test is red on `main`.

One behaviour change worth naming: the duplicate check (`Get`) and the claim (`Add`) are now separated by the batch verification interval rather than a few instructions, so an equivocating validator can get two attestations relayed where one would previously have been dropped. That is the cost of not letting an unauthenticated message claim the slot; the spec wording for the duplicate rule is `[IGNORE]`, not `[REJECT]`.
