### PR TITLE
p2p/discover: relay-check the discv5 handshake record before adding it to the table

### DIFF
--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -771,8 +771,16 @@ func (t *UDPv5) handlePacket(rawpacket []byte, fromAddr netip.AddrPort) error {
 		return err
 	}
 	if fromNode != nil {
-		// Handshake succeeded, add to table.
-		t.tab.addInboundNode(fromNode)
+		// Handshake succeeded, add to table. The record is self-signed and its
+		// endpoint is not tied to the packet source, so it gets the same relay
+		// check as a record learned from a NODES response.
+		if err := netutil.CheckRelayAddr(fromAddr.Addr(), fromNode.IPAddr()); err != nil {
+			if t.trace {
+				t.log.Trace("[p2p] Rejected discv5 handshake record", "id", fromID, "addr", fromAddr, "record", fromNode.IPAddr(), "err", err)
+			}
+		} else {
+			t.tab.addInboundNode(fromNode)
+		}
 	}
 	if t.trace && packet.Kind() != v5wire.WhoareyouPacket {
 		// WHOAREYOU logged separately to report errors.

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -488,6 +488,18 @@ func (t *UDPv5) waitForNodes(c *callV5, distances []uint) ([]*enode.Node, error)
 	}
 }
 
+// checkTableAddr reports whether a record relayed from sender may enter the
+// routing table.
+func (t *UDPv5) checkTableAddr(sender netip.Addr, node *enode.Node) error {
+	if err := netutil.CheckRelayAddr(sender, node.IPAddr()); err != nil {
+		return err
+	}
+	if t.netrestrict != nil && !t.netrestrict.ContainsAddr(node.IPAddr()) {
+		return errors.New("not contained in netrestrict list")
+	}
+	return nil
+}
+
 // verifyResponseNode checks validity of a record in a NODES response.
 func (t *UDPv5) verifyResponseNode(c *callV5, r *enr.Record, distances []uint, seen map[enode.ID]struct{}) (*enode.Node, error) {
 	node, err := enode.New(t.validSchemes, r)
@@ -772,9 +784,9 @@ func (t *UDPv5) handlePacket(rawpacket []byte, fromAddr netip.AddrPort) error {
 	}
 	if fromNode != nil {
 		// Handshake succeeded, add to table. The record is self-signed and its
-		// endpoint is not tied to the packet source, so it gets the same relay
-		// check as a record learned from a NODES response.
-		if err := netutil.CheckRelayAddr(fromAddr.Addr(), fromNode.IPAddr()); err != nil {
+		// endpoint is not tied to the packet source, so it gets the same filters
+		// as a record learned from a NODES response.
+		if err := t.checkTableAddr(fromAddr.Addr(), fromNode); err != nil {
 			if t.trace {
 				t.log.Trace("[p2p] Rejected discv5 handshake record", "id", fromID, "addr", fromAddr, "record", fromNode.IPAddr(), "err", err)
 			}

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -497,6 +497,9 @@ func (t *UDPv5) checkTableAddr(sender netip.Addr, node *enode.Node) error {
 	if t.netrestrict != nil && !t.netrestrict.ContainsAddr(node.IPAddr()) {
 		return errors.New("not contained in netrestrict list")
 	}
+	if node.UDP() <= 1024 {
+		return errLowPort
+	}
 	return nil
 }
 
@@ -506,14 +509,8 @@ func (t *UDPv5) verifyResponseNode(c *callV5, r *enr.Record, distances []uint, s
 	if err != nil {
 		return nil, err
 	}
-	if err := netutil.CheckRelayAddr(c.addr.Addr(), node.IPAddr()); err != nil {
+	if err := t.checkTableAddr(c.addr.Addr(), node); err != nil {
 		return nil, err
-	}
-	if t.netrestrict != nil && !t.netrestrict.ContainsAddr(node.IPAddr()) {
-		return nil, errors.New("not contained in netrestrict list")
-	}
-	if node.UDP() <= 1024 {
-		return nil, errLowPort
 	}
 	if distances != nil {
 		nd := enode.LogDist(c.id, node.ID())

--- a/p2p/discover/v5_udp_test.go
+++ b/p2p/discover/v5_udp_test.go
@@ -36,7 +36,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/common/testlog"
 	"github.com/erigontech/erigon/execution/rlp"
@@ -287,27 +286,39 @@ func TestUDPv5_handshakeNodeRelayAddr(t *testing.T) {
 	test := newUDPV5Test(t)
 	defer test.close()
 
-	remotekey, _ := crypto.GenerateKey()
-	db, _ := enode.OpenDB("")
-	defer db.Close()
-	ln := enode.NewLocalNode(db, remotekey)
-	ln.SetStaticIP(net.ParseIP("169.254.169.254"))
-	ln.SetFallbackUDP(30303)
-	planted := ln.Node()
-
-	test.udp.codec.(*testCodec).handshakeNode = planted
-	senderkey, _ := crypto.GenerateKey()
 	publicAddr := netip.MustParseAddrPort("1.2.3.4:30303")
-	test.packetInFrom(senderkey, publicAddr, &v5wire.Unknown{Nonce: v5wire.Nonce{1}})
-	test.waitPacketOut(func(*v5wire.Whoareyou, netip.AddrPort, v5wire.Nonce) {})
+	planted := test.getNode(newkey(), netip.MustParseAddrPort("169.254.169.254:30303")).Node()
+	allowed := test.getNode(newkey(), netip.MustParseAddrPort("5.6.7.8:30303")).Node()
 
-	for _, bucket := range test.table.Nodes() {
+	for _, tc := range []struct {
+		name   string
+		node   *enode.Node
+		inTabl bool
+	}{
+		{"unrelated link-local address", planted, false},
+		{"public address", allowed, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			test.udp.codec.(*testCodec).handshakeNode = tc.node
+			test.packetInFrom(newkey(), publicAddr, &v5wire.Unknown{Nonce: v5wire.Nonce{1}})
+			test.waitPacketOut(func(*v5wire.Whoareyou, netip.AddrPort, v5wire.Nonce) {})
+
+			if inTable(test.table, tc.node.ID()) != tc.inTabl {
+				t.Fatalf("node %v in table = %v, want %v", tc.node.IPAddr(), !tc.inTabl, tc.inTabl)
+			}
+		})
+	}
+}
+
+func inTable(tab *Table, id enode.ID) bool {
+	for _, bucket := range tab.Nodes() {
 		for _, n := range bucket {
-			if n.Node.ID() == planted.ID() {
-				t.Fatalf("node with unrelated address %v was added to the table", planted.IPAddr())
+			if n.Node.ID() == id {
+				return true
 			}
 		}
 	}
+	return false
 }
 
 // This test checks that incoming FINDNODE calls are handled correctly.

--- a/p2p/discover/v5_udp_test.go
+++ b/p2p/discover/v5_udp_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/erigontech/erigon/p2p/discover/v5wire"
 	"github.com/erigontech/erigon/p2p/enode"
 	"github.com/erigontech/erigon/p2p/enr"
+	"github.com/erigontech/erigon/p2p/netutil"
 )
 
 // Real sockets, real crypto: this test checks end-to-end connectivity for UDPv5.
@@ -289,16 +290,27 @@ func TestUDPv5_handshakeNodeRelayAddr(t *testing.T) {
 	publicAddr := netip.MustParseAddrPort("1.2.3.4:30303")
 	planted := test.getNode(newkey(), netip.MustParseAddrPort("169.254.169.254:30303")).Node()
 	allowed := test.getNode(newkey(), netip.MustParseAddrPort("5.6.7.8:30303")).Node()
+	lowPort := test.getNode(newkey(), netip.MustParseAddrPort("5.6.7.9:53")).Node()
+	inList := test.getNode(newkey(), netip.MustParseAddrPort("9.9.9.9:30303")).Node()
+	outOfList := test.getNode(newkey(), netip.MustParseAddrPort("8.8.8.8:30303")).Node()
+
+	list, err := netutil.ParseNetlist("9.9.9.0/24")
+	require.NoError(t, err)
 
 	for _, tc := range []struct {
-		name   string
-		node   *enode.Node
-		inTabl bool
+		name        string
+		node        *enode.Node
+		netrestrict *netutil.Netlist
+		inTabl      bool
 	}{
-		{"unrelated link-local address", planted, false},
-		{"public address", allowed, true},
+		{"unrelated link-local address", planted, nil, false},
+		{"public address", allowed, nil, true},
+		{"low port", lowPort, nil, false},
+		{"outside netrestrict", outOfList, list, false},
+		{"inside netrestrict", inList, list, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			test.udp.netrestrict = tc.netrestrict
 			test.udp.codec.(*testCodec).handshakeNode = tc.node
 			test.packetInFrom(newkey(), publicAddr, &v5wire.Unknown{Nonce: v5wire.Nonce{1}})
 			test.waitPacketOut(func(*v5wire.Whoareyou, netip.AddrPort, v5wire.Nonce) {})

--- a/p2p/discover/v5_udp_test.go
+++ b/p2p/discover/v5_udp_test.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/common/testlog"
 	"github.com/erigontech/erigon/execution/rlp"
@@ -276,6 +277,37 @@ func TestUDPv5_handshakeRepeatChallenge(t *testing.T) {
 	test.waitPacketOut(func(p *v5wire.Whoareyou, addr netip.AddrPort, authTag v5wire.Nonce) {
 		check(p, authTag, nonce1)
 	})
+}
+
+// A handshake record is self-signed by the sender and its endpoint is never
+// checked against the packet source, so a peer must not be able to plant an
+// arbitrary address in the routing table.
+func TestUDPv5_handshakeNodeRelayAddr(t *testing.T) {
+	t.Parallel()
+	test := newUDPV5Test(t)
+	defer test.close()
+
+	remotekey, _ := crypto.GenerateKey()
+	db, _ := enode.OpenDB("")
+	defer db.Close()
+	ln := enode.NewLocalNode(db, remotekey)
+	ln.SetStaticIP(net.ParseIP("169.254.169.254"))
+	ln.SetFallbackUDP(30303)
+	planted := ln.Node()
+
+	test.udp.codec.(*testCodec).handshakeNode = planted
+	senderkey, _ := crypto.GenerateKey()
+	publicAddr := netip.MustParseAddrPort("1.2.3.4:30303")
+	test.packetInFrom(senderkey, publicAddr, &v5wire.Unknown{Nonce: v5wire.Nonce{1}})
+	test.waitPacketOut(func(*v5wire.Whoareyou, netip.AddrPort, v5wire.Nonce) {})
+
+	for _, bucket := range test.table.Nodes() {
+		for _, n := range bucket {
+			if n.Node.ID() == planted.ID() {
+				t.Fatalf("node with unrelated address %v was added to the table", planted.IPAddr())
+			}
+		}
+	}
 }
 
 // This test checks that incoming FINDNODE calls are handled correctly.
@@ -950,6 +982,8 @@ type testCodec struct {
 	ctr  uint64
 
 	sentChallenges map[enode.ID]*v5wire.Whoareyou
+	// handshakeNode, when set, is returned as the node a handshake packet carried.
+	handshakeNode *enode.Node
 }
 
 type testCodecFrame struct {
@@ -997,7 +1031,7 @@ func (c *testCodec) Decode(input []byte, addr netip.AddrPort) (enode.ID, *enode.
 	if err != nil {
 		return enode.ID{}, nil, nil, err
 	}
-	return frame.NodeID, nil, p, nil
+	return frame.NodeID, c.handshakeNode, p, nil
 }
 
 func (c *testCodec) SessionNode(id enode.ID, addr netip.AddrPort) *enode.Node {


### PR DESCRIPTION
`handlePacket` adds the ENR carried by a successful discv5 handshake straight to the routing table. That record is self-signed and its `ip`/`tcp` are never compared against the packet source, so any peer that completes a handshake can plant an arbitrary endpoint under a key it controls. The other two paths that ingest records, `verifyResponseNode` and `collectTableNodes`, both filter first.

What makes it worth fixing rather than merely untidy: `Table.addIP` returns true unconditionally for LAN addresses, so a record with a private IP bypasses the per-bucket IP-diversity limits as well as the address check — unbounded table pollution from one peer.

The planted entry reaches dials. `p2p/dial.go` applies no address-class check, and caplin's only filter (`cl/sentinel/discovery.go`) is `net.IP.IsPrivate`, which is false for loopback, link-local and CGNAT. `lookupIterator.Next` yields table seeds before any network query, so no lookup has to succeed for the entry to be used.

No new false rejections: loopback-to-loopback, LAN-to-LAN, IPv6 ULA and link-local, 4-in-6 and public-to-public all pass `CheckRelayAddr`, and IP-less ENRs were already dropped by `addIP`. This is an Erigon-local divergence from upstream geth, which still adds the record unconditionally — expect a conflict on the next sync.

The negative case is red on `main`; the positive case is there so a later tightening of the predicate cannot silently stop the table growing from inbound contacts.