### PR TITLE
cl/services: drop the blob-sidecar pending map that nothing drains

### DIFF
--- a/cl/phase1/network/services/blob_sidecar_service.go
+++ b/cl/phase1/network/services/blob_sidecar_service.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"time"
 
 	goethkzg "github.com/crate-crypto/go-eth-kzg"
@@ -50,13 +49,7 @@ type blobSidecarService struct {
 	ethClock          eth_clock.EthereumClock
 	emitters          *beaconevents.EventEmitter
 
-	blobSidecarsScheduledForLaterExecution sync.Map
-	test                                   bool
-}
-
-type blobSidecarJob struct {
-	blobSidecar  *cltypes.BlobSidecar
-	creationTime time.Time
+	test bool
 }
 
 // NewBlobSidecarService creates a new blob sidecar service
@@ -77,7 +70,6 @@ func NewBlobSidecarService(
 		ethClock:          ethClock,
 		emitters:          emitters,
 	}
-	// go b.loop(ctx)
 	return b
 }
 
@@ -142,7 +134,6 @@ func (b *blobSidecarService) ProcessMessage(ctx context.Context, subnetId *uint6
 
 	parentHeader, has := b.forkchoiceStore.GetHeader(msg.SignedBlockHeader.Header.ParentRoot)
 	if !has {
-		b.scheduleBlobSidecarForLaterExecution(msg)
 		return ErrIgnore
 	}
 	if msg.SignedBlockHeader.Header.Slot <= parentHeader.Slot {
@@ -220,16 +211,4 @@ func (b *blobSidecarService) verifySidecarsSignature(header *cltypes.SignedBeaco
 		return errors.New("blob signature validation: signature not valid")
 	}
 	return nil
-}
-
-func (b *blobSidecarService) scheduleBlobSidecarForLaterExecution(blobSidecar *cltypes.BlobSidecar) {
-	blobSidecarJob := &blobSidecarJob{
-		blobSidecar:  blobSidecar,
-		creationTime: time.Now(),
-	}
-	blobSidecarHash, err := blobSidecar.HashSSZ()
-	if err != nil {
-		return
-	}
-	b.blobSidecarsScheduledForLaterExecution.Store(blobSidecarHash, blobSidecarJob)
 }

--- a/cl/phase1/network/services/blob_sidecar_service_test.go
+++ b/cl/phase1/network/services/blob_sidecar_service_test.go
@@ -69,14 +69,12 @@ func getObjectsForBlobSidecarServiceTests(t *testing.T) (*state.CachingBeaconSta
 
 func setupBlobSidecarService(t *testing.T, ctrl *gomock.Controller, test bool) (BlobSidecarsService, *synced_data.SyncedDataManager, *eth_clock.MockEthereumClock, *mock_services.ForkChoiceStorageMock) {
 	ctx := context.Background()
-	ctx2, cn := context.WithTimeout(ctx, 1)
-	cn()
 	cfg := &clparams.MainnetBeaconConfig
 	syncedDataManager := synced_data.NewSyncedDataManager(cfg, true)
 	ethClock := eth_clock.NewMockEthereumClock(ctrl)
 	forkchoiceMock := mock_services.NewForkChoiceStorageMock(t)
 	emitters := beaconevents.NewEventEmitter()
-	blockService := NewBlobSidecarService(ctx2, cfg, forkchoiceMock, syncedDataManager, ethClock, emitters, test)
+	blockService := NewBlobSidecarService(ctx, cfg, forkchoiceMock, syncedDataManager, ethClock, emitters, test)
 	return blockService, syncedDataManager, ethClock, forkchoiceMock
 }
 

--- a/cl/phase1/network/services/constants.go
+++ b/cl/phase1/network/services/constants.go
@@ -30,11 +30,9 @@ const (
 	operationSeenCacheSize        = 16_384
 	seenBlockCacheSize            = 1000 // SeenBlockCacheSize is the size of the cache for seen blocks.
 	blockJobsIntervalTick         = 50 * time.Millisecond
-	blobJobsIntervalTick          = 5 * time.Millisecond
 	singleAttestationIntervalTick = 10 * time.Millisecond
 	attestationJobsIntervalTick   = 100 * time.Millisecond
 	blockJobExpiry                = 30 * time.Second
-	blobJobExpiry                 = 30 * time.Second
 	attestationJobExpiry          = 30 * time.Minute
 	singleAttestationJobExpiry    = 6 * time.Second
 )


### PR DESCRIPTION
`blobSidecarsScheduledForLaterExecution` is written on the "parent block not seen yet" gossip path and read by nothing: the eviction goroutine is the commented-out `// go b.loop(ctx)`, and no `loop` method exists. So the map never retries anything and never shrinks.

The store happens before the KZG proof check and before the proposer-signature check, keyed on the sidecar's own `HashSSZ()`, and each entry pins a 128 KiB blob. A gossip peer publishing sidecars with a random `ParentRoot` retains roughly 700 KB/s for the process lifetime; honest traffic leaks too, just slower. Reachable pre-Fulu, where the subscription is gated.

Removing it is behaviour-preserving — those sidecars are already never reprocessed — so the unused `blobJobExpiry` and `blobJobsIntervalTick` go with it.