### PR TITLE
txnprovider/txpool: release sender ids for remote txns that reach no sub-pool

### DIFF
--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -502,10 +502,8 @@ func (p *TxPool) processRemoteTxns(ctx context.Context) (err error) {
 		return nil
 	}
 
-	err = p.senders.registerNewSenders(p.unprocessedRemoteTxns, p.logger)
-	if err != nil {
-		return err
-	}
+	allocatedSenders := p.senders.registerNewSendersFrom(p.unprocessedRemoteTxns, p.logger)
+	defer func() { p.senders.forgetUnusedSenders(allocatedSenders, p.all.hasTxns) }()
 
 	validateReasons, newTxns, err := p.validateTxns(p.unprocessedRemoteTxns, cacheView)
 	if err != nil {

--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -468,8 +468,8 @@ func (p *TxPool) publishDepthMetrics() {
 	queuedSubCounter.SetInt(p.queued.Len())
 }
 
-// forgetUnusedSenders drops the sender id of every txn in the batch that
-// reached no sub-pool. Validation rejects a txn before it becomes a metaTxn, so
+// forgetUnusedSenders drops the id of every sender in the batch that has no
+// txn left in p.all. Validation rejects a txn before it becomes a metaTxn, so
 // it never enters p.deletedTxns and the flush-time eviction never sees it.
 // Callers must hold p.lock.
 func (p *TxPool) forgetUnusedSenders(ids []uint64) {

--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -468,6 +468,32 @@ func (p *TxPool) publishDepthMetrics() {
 	queuedSubCounter.SetInt(p.queued.Len())
 }
 
+// forgetUnusedSenders drops the sender id of every txn in the batch that
+// reached no sub-pool. Validation rejects a txn before it becomes a metaTxn, so
+// it never enters p.deletedTxns and the flush-time eviction never sees it.
+// Callers must hold p.lock.
+func (p *TxPool) forgetUnusedSenders(ids []uint64) {
+	for _, id := range ids {
+		if p.all.hasTxns(id) {
+			continue
+		}
+		if addr, ok := p.senders.senderID2Addr[id]; ok {
+			delete(p.senders.senderID2Addr, id)
+			delete(p.senders.senderIDs, addr)
+		}
+	}
+}
+
+// senderIDsOf snapshots the batch's sender ids, which forgetUnusedSenders needs
+// after the batch itself has been reset.
+func senderIDsOf(txns *TxnSlots) []uint64 {
+	ids := make([]uint64, len(txns.Txns))
+	for i, txn := range txns.Txns {
+		ids[i] = txn.SenderID
+	}
+	return ids
+}
+
 func (p *TxPool) processRemoteTxns(ctx context.Context) (err error) {
 	if !p.Started() {
 		return errors.New("txpool not started yet")
@@ -502,8 +528,11 @@ func (p *TxPool) processRemoteTxns(ctx context.Context) (err error) {
 		return nil
 	}
 
-	allocatedSenders := p.senders.registerNewSendersFrom(p.unprocessedRemoteTxns, p.logger)
-	defer func() { p.senders.forgetUnusedSenders(allocatedSenders, p.all.hasTxns) }()
+	err = p.senders.registerNewSenders(p.unprocessedRemoteTxns, p.logger)
+	if err != nil {
+		return err
+	}
+	defer p.forgetUnusedSenders(senderIDsOf(p.unprocessedRemoteTxns))
 
 	validateReasons, newTxns, err := p.validateTxns(p.unprocessedRemoteTxns, cacheView)
 	if err != nil {
@@ -1444,6 +1473,7 @@ func (p *TxPool) AddLocalTxns(ctx context.Context, newTxns TxnSlots) ([]txpoolcf
 	if err := p.senders.registerNewSenders(&newTxns, p.logger); err != nil {
 		return nil, err
 	}
+	defer p.forgetUnusedSenders(senderIDsOf(&newTxns))
 
 	originalTxns := newTxns
 

--- a/txnprovider/txpool/pool_sender_leak_test.go
+++ b/txnprovider/txpool/pool_sender_leak_test.go
@@ -45,17 +45,49 @@ func TestProcessRemoteTxnsDoesNotLeakSenderIDsForRejectedTxns(t *testing.T) {
 		slots.Append(&slot, addr[:], false)
 	}
 
+	pool.lock.Lock()
+	idsBefore, addrsBefore := len(pool.senders.senderIDs), len(pool.senders.senderID2Addr)
+	pool.lock.Unlock()
+
 	pool.AddRemoteTxns(ctx, slots, gointerfaces.ConvertHashToH512([64]byte{0x41}), nil)
 	require.NoError(t, pool.processRemoteTxns(ctx))
 
 	pool.lock.Lock()
 	defer pool.lock.Unlock()
+	require.Equal(t, idsBefore, len(pool.senders.senderIDs),
+		"sender ids for txns that reached no sub-pool must not be retained")
+	require.Equal(t, addrsBefore, len(pool.senders.senderID2Addr),
+		"senderID2Addr must be swept in step with senderIDs")
+}
+
+// The same defect on the local path: AddLocalTxns registers senders, then
+// validateTxns can reject every txn.
+func TestAddLocalTxnsDoesNotLeakSenderIDsForRejectedTxns(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	pool := seedBlobKZGTestPool(t, ctx)
+	require.NoError(t, pool.start(ctx))
+
+	const senders = 16
+	var slots TxnSlots
 	for i := range senders {
+		slot := makeBlobSlot(byte(0x60+i), false)
 		var addr [20]byte
-		binary.BigEndian.PutUint64(addr[12:], uint64(i+1))
-		id, ok := pool.senders.senderIDs[addr]
-		require.False(t, ok,
-			"sender id for a txn that reached no sub-pool must not be retained, got %d for %x", id, addr)
-		require.NotContains(t, pool.senders.senderID2Addr, id)
+		binary.BigEndian.PutUint64(addr[12:], uint64(i+1+senders))
+		slots.Append(&slot, addr[:], false)
 	}
+
+	pool.lock.Lock()
+	idsBefore, addrsBefore := len(pool.senders.senderIDs), len(pool.senders.senderID2Addr)
+	pool.lock.Unlock()
+
+	_, err := pool.AddLocalTxns(ctx, slots)
+	require.NoError(t, err)
+
+	pool.lock.Lock()
+	defer pool.lock.Unlock()
+	require.Equal(t, idsBefore, len(pool.senders.senderIDs),
+		"sender ids for txns that reached no sub-pool must not be retained")
+	require.Equal(t, addrsBefore, len(pool.senders.senderID2Addr))
 }

--- a/txnprovider/txpool/pool_sender_leak_test.go
+++ b/txnprovider/txpool/pool_sender_leak_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package txpool
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/node/gointerfaces"
+)
+
+// A remote txn that never reaches a sub-pool still allocates a sender id, and
+// the only eviction walks p.deletedTxns, which such a txn never enters. Without
+// a sweep, one peer can grow senderIDs/senderID2Addr for the process lifetime.
+func TestProcessRemoteTxnsDoesNotLeakSenderIDsForRejectedTxns(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	pool := seedBlobKZGTestPool(t, ctx)
+	require.NoError(t, pool.start(ctx))
+
+	const senders = 16
+	var slots TxnSlots
+	for i := range senders {
+		slot := makeBlobSlot(byte(0x40+i), false)
+		var addr [20]byte
+		binary.BigEndian.PutUint64(addr[12:], uint64(i+1))
+		slots.Append(&slot, addr[:], false)
+	}
+
+	pool.AddRemoteTxns(ctx, slots, gointerfaces.ConvertHashToH512([64]byte{0x41}), nil)
+	require.NoError(t, pool.processRemoteTxns(ctx))
+
+	pool.lock.Lock()
+	defer pool.lock.Unlock()
+	for i := range senders {
+		var addr [20]byte
+		binary.BigEndian.PutUint64(addr[12:], uint64(i+1))
+		id, ok := pool.senders.senderIDs[addr]
+		require.False(t, ok,
+			"sender id for a txn that reached no sub-pool must not be retained, got %d for %x", id, addr)
+		require.NotContains(t, pool.senders.senderID2Addr, id)
+	}
+}

--- a/txnprovider/txpool/senders.go
+++ b/txnprovider/txpool/senders.go
@@ -233,37 +233,10 @@ func (sc *sendersBatch) info(cacheView kvcache.CacheView, id uint64) (uint64, ui
 }
 
 func (sc *sendersBatch) registerNewSenders(newTxns *TxnSlots, logger log.Logger) (err error) {
-	sc.registerNewSendersFrom(newTxns, logger)
-	return nil
-}
-
-// registerNewSendersFrom assigns sender ids and reports the ones it had to
-// allocate, so a caller whose txns may all be rejected can hand them back to
-// forgetUnusedSenders.
-func (sc *sendersBatch) registerNewSendersFrom(newTxns *TxnSlots, logger log.Logger) (allocated []uint64) {
 	for i, txn := range newTxns.Txns {
-		before := sc.senderID
 		txn.SenderID, txn.Traced = sc.getOrCreateID(newTxns.Senders.AddressAt(i), logger)
-		if sc.senderID != before {
-			allocated = append(allocated, txn.SenderID)
-		}
 	}
-	return allocated
-}
-
-// forgetUnusedSenders drops the ids from allocated that never made it into a
-// sub-pool. Validation rejects a txn before it becomes a metaTxn, so it never
-// reaches p.deletedTxns and the flush-time eviction never sees it.
-func (sc *sendersBatch) forgetUnusedSenders(allocated []uint64, inUse func(uint64) bool) {
-	for _, id := range allocated {
-		if inUse(id) {
-			continue
-		}
-		if addr, ok := sc.senderID2Addr[id]; ok {
-			delete(sc.senderID2Addr, id)
-			delete(sc.senderIDs, addr)
-		}
-	}
+	return nil
 }
 
 func (sc *sendersBatch) onNewBlock(stateChanges *remoteproto.StateChangeBatch, unwindTxns, minedTxns TxnSlots, logger log.Logger) error {

--- a/txnprovider/txpool/senders.go
+++ b/txnprovider/txpool/senders.go
@@ -233,10 +233,37 @@ func (sc *sendersBatch) info(cacheView kvcache.CacheView, id uint64) (uint64, ui
 }
 
 func (sc *sendersBatch) registerNewSenders(newTxns *TxnSlots, logger log.Logger) (err error) {
-	for i, txn := range newTxns.Txns {
-		txn.SenderID, txn.Traced = sc.getOrCreateID(newTxns.Senders.AddressAt(i), logger)
-	}
+	sc.registerNewSendersFrom(newTxns, logger)
 	return nil
+}
+
+// registerNewSendersFrom assigns sender ids and reports the ones it had to
+// allocate, so a caller whose txns may all be rejected can hand them back to
+// forgetUnusedSenders.
+func (sc *sendersBatch) registerNewSendersFrom(newTxns *TxnSlots, logger log.Logger) (allocated []uint64) {
+	for i, txn := range newTxns.Txns {
+		before := sc.senderID
+		txn.SenderID, txn.Traced = sc.getOrCreateID(newTxns.Senders.AddressAt(i), logger)
+		if sc.senderID != before {
+			allocated = append(allocated, txn.SenderID)
+		}
+	}
+	return allocated
+}
+
+// forgetUnusedSenders drops the ids from allocated that never made it into a
+// sub-pool. Validation rejects a txn before it becomes a metaTxn, so it never
+// reaches p.deletedTxns and the flush-time eviction never sees it.
+func (sc *sendersBatch) forgetUnusedSenders(allocated []uint64, inUse func(uint64) bool) {
+	for _, id := range allocated {
+		if inUse(id) {
+			continue
+		}
+		if addr, ok := sc.senderID2Addr[id]; ok {
+			delete(sc.senderID2Addr, id)
+			delete(sc.senderIDs, addr)
+		}
+	}
 }
 
 func (sc *sendersBatch) onNewBlock(stateChanges *remoteproto.StateChangeBatch, unwindTxns, minedTxns TxnSlots, logger log.Logger) error {


### PR DESCRIPTION
`processRemoteTxns` and `AddLocalTxns` both register senders for the whole batch before validating it, so every distinct recovered address gets an entry in `senderIDs` and `senderID2Addr`. The only eviction is in `flushLocked`, walking `p.deletedTxns`, which is appended solely by `discardLocked` — reachable only for a txn that was admitted to a sub-pool. A txn rejected by `validateTxns` (insufficient funds, underpriced, nonce too low, spammer) never becomes a `metaTxn`, so its two entries are never removed. One peer streaming correctly-signed, zero-balance transactions from fresh offline keys, or an exposed `eth_sendRawTransaction`, grows both maps until restart.

Not the largest instance of this leak: `sendersBatch.onNewBlock` allocates an id for every account changed in every block and those are never evicted either, which on mainnet dwarfs the batch paths. That one needs a different mechanism (the ids stay live for `onSenderStateChange`) and is left for a separate change.

Both new tests are red on `main`.