### PR TITLE
cl/services: ignore, and retry, a block the execution layer did not answer for

### DIFF
--- a/cl/phase1/forkchoice/mock_services/forkchoice_mock.go
+++ b/cl/phase1/forkchoice/mock_services/forkchoice_mock.go
@@ -76,6 +76,7 @@ type ForkChoiceStorageMock struct {
 	Blocks                       map[common.Hash]*cltypes.SignedBeaconBlock
 	Envelopes                    map[common.Hash]*cltypes.SignedExecutionPayloadEnvelope
 	VerifiedPayloads             map[common.Hash]bool
+	OnBlockErr                   error
 	OnExecutionPayloadErr        error
 	GetBeaconCommitteeMock       func(slot, committeeIndex uint64) ([]uint64, error)
 
@@ -348,7 +349,7 @@ func (f *ForkChoiceStorageMock) OnBlock(
 	fullValidation bool,
 	checkDataAvaiability bool,
 ) error {
-	return nil
+	return f.OnBlockErr
 }
 
 func (f *ForkChoiceStorageMock) OnExecutionPayload(ctx context.Context, signedEnvelope *cltypes.SignedExecutionPayloadEnvelope, checkBlobData, validatePayload bool) error {

--- a/cl/phase1/network/backward_beacon_downloader.go
+++ b/cl/phase1/network/backward_beacon_downloader.go
@@ -274,7 +274,8 @@ func (b *BackwardBeaconDownloader) sendBlockRequest(
 		return
 	}
 	if len(blocks) == 0 {
-		b.rpc.BanPeer(peerId)
+		// An empty response is protocol-legal: the peer may have pruned the range.
+		log.Debug("[Caplin] empty backward beacon block response", "start", start, "count", count)
 		requestSent.Store(false)
 		return
 	}

--- a/cl/phase1/network/backward_beacon_downloader.go
+++ b/cl/phase1/network/backward_beacon_downloader.go
@@ -274,8 +274,7 @@ func (b *BackwardBeaconDownloader) sendBlockRequest(
 		return
 	}
 	if len(blocks) == 0 {
-		// An empty response is protocol-legal: the peer may have pruned the range.
-		log.Debug("[Caplin] empty backward beacon block response", "start", start, "count", count)
+		b.rpc.BanPeer(peerId)
 		requestSent.Store(false)
 		return
 	}

--- a/cl/phase1/network/services/block_service.go
+++ b/cl/phase1/network/services/block_service.go
@@ -225,8 +225,9 @@ func (b *blockService) ProcessMessage(ctx context.Context, _ *uint64, msg *cltyp
 			return nil
 		}
 		if errors.Is(err, forkchoice.ErrNewPayloadNoStatus) {
-			// The execution layer never answered, so nothing is known about the
-			// block. Banning the sender would punish it for a local failure.
+			// The execution layer did not answer, so nothing is known about the
+			// block yet. Retry rather than rejecting the sender for it.
+			b.scheduleBlockForLaterProcessing(msg)
 			return fmt.Errorf("%w: %w", ErrIgnore, err)
 		}
 		return err

--- a/cl/phase1/network/services/block_service.go
+++ b/cl/phase1/network/services/block_service.go
@@ -224,6 +224,11 @@ func (b *blockService) ProcessMessage(ctx context.Context, _ *uint64, msg *cltyp
 			b.scheduleBlockForLaterProcessing(msg)
 			return nil
 		}
+		if errors.Is(err, forkchoice.ErrNewPayloadNoStatus) {
+			// The execution layer never answered, so nothing is known about the
+			// block. Banning the sender would punish it for a local failure.
+			return fmt.Errorf("%w: %w", ErrIgnore, err)
+		}
 		return err
 	}
 	return nil

--- a/cl/phase1/network/services/block_service.go
+++ b/cl/phase1/network/services/block_service.go
@@ -283,10 +283,22 @@ func (b *blockService) processAndStoreBlock(ctx context.Context, block *cltypes.
 		return nil
 	}
 
-	if err := b.db.Update(ctx, func(tx kv.RwTx) error {
-		return beacon_indicies.WriteBeaconBlockAndIndicies(ctx, tx, block, false)
+	// A block the fork graph never took can be retried for 30s, so open the
+	// write tx only when the block is not already on disk.
+	var persisted bool
+	if err := b.db.View(ctx, func(tx kv.Tx) error {
+		slot, err := beacon_indicies.ReadBlockSlotByBlockRoot(tx, blockRoot)
+		persisted = slot != nil
+		return err
 	}); err != nil {
 		return err
+	}
+	if !persisted {
+		if err := b.db.Update(ctx, func(tx kv.RwTx) error {
+			return beacon_indicies.WriteBeaconBlockAndIndicies(ctx, tx, block, false)
+		}); err != nil {
+			return err
+		}
 	}
 
 	if err := b.forkchoiceStore.OnBlock(ctx, block, true, true, true); err != nil {

--- a/cl/phase1/network/services/block_service_test.go
+++ b/cl/phase1/network/services/block_service_test.go
@@ -121,7 +121,7 @@ func TestBlockServiceIgnoresLocalExecutionFailure(t *testing.T) {
 
 	blocks, _, post := tests.GetBellatrixRandom()
 
-	blockService, syncedData, ethClock, fcu := setupBlockService(t, ctrl)
+	svc, syncedData, ethClock, fcu := setupBlockService(t, ctrl)
 	require.NoError(t, syncedData.OnHeadState(post))
 	ethClock.EXPECT().GetCurrentSlot().Return(uint64(0)).AnyTimes()
 	ethClock.EXPECT().IsSlotCurrentSlotWithMaximumClockDisparity(gomock.Any()).Return(true).AnyTimes()
@@ -129,8 +129,13 @@ func TestBlockServiceIgnoresLocalExecutionFailure(t *testing.T) {
 	fcu.Headers[blocks[1].Block.ParentRoot] = blocks[0].SignedBeaconBlockHeader().Header.Copy()
 	fcu.OnBlockErr = fmt.Errorf("%w: execution client is down", forkchoice.ErrNewPayloadNoStatus)
 
-	err := blockService.ProcessMessage(context.Background(), nil, blocks[1])
+	err := svc.ProcessMessage(context.Background(), nil, blocks[1])
 	require.ErrorIs(t, err, ErrIgnore)
+
+	blockRoot, err := blocks[1].Block.HashSSZ()
+	require.NoError(t, err)
+	_, scheduled := svc.(*blockService).blocksScheduledForLaterExecution.Load(blockRoot)
+	require.True(t, scheduled, "the block must be queued for a retry")
 }
 
 func TestBlockServiceYoungerThanParent(t *testing.T) {

--- a/cl/phase1/network/services/block_service_test.go
+++ b/cl/phase1/network/services/block_service_test.go
@@ -31,10 +31,12 @@ import (
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/persistence/beacon_indicies"
 	"github.com/erigontech/erigon/cl/phase1/forkchoice"
 	"github.com/erigontech/erigon/cl/phase1/forkchoice/mock_services"
 	"github.com/erigontech/erigon/cl/utils/eth_clock"
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/dbcfg"
 	"github.com/erigontech/erigon/db/kv/mdbx/mdbxtest"
 )
@@ -136,7 +138,27 @@ func TestBlockServiceIgnoresLocalExecutionFailure(t *testing.T) {
 	require.NoError(t, err)
 	_, scheduled := svc.(*blockService).blocksScheduledForLaterExecution.Load(blockRoot)
 	require.True(t, scheduled, "the block must be queued for a retry")
+
+	// The block is already on disk, so a retry must cost one newPayload and no
+	// write tx: the loop re-attempts every 50ms for 30s.
+	db := svc.(*blockService).db
+	require.NoError(t, db.Update(t.Context(), func(tx kv.RwTx) error {
+		return beacon_indicies.WriteHeaderSlot(tx, blockRoot, sentinelSlot)
+	}))
+
+	err = svc.ProcessMessage(context.Background(), nil, blocks[1])
+	require.ErrorIs(t, err, ErrIgnore)
+
+	require.NoError(t, db.View(t.Context(), func(tx kv.Tx) error {
+		slot, err := beacon_indicies.ReadBlockSlotByBlockRoot(tx, blockRoot)
+		require.NoError(t, err)
+		require.NotNil(t, slot)
+		require.Equal(t, uint64(sentinelSlot), *slot, "the retry rewrote the block")
+		return nil
+	}))
 }
+
+const sentinelSlot = 0xbadbad
 
 func TestBlockServiceYoungerThanParent(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/cl/phase1/network/services/block_service_test.go
+++ b/cl/phase1/network/services/block_service_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -110,6 +111,26 @@ func TestBlockServiceUnseenParentRoot(t *testing.T) {
 	fcu.FinalizedCheckpointVal = post.FinalizedCheckpoint()
 
 	require.Error(t, blockService.ProcessMessage(context.Background(), nil, blocks[0]))
+}
+
+// A newPayload call the execution layer never answered says nothing about the
+// block, so the sender must not be rejected (and banned) for it.
+func TestBlockServiceIgnoresLocalExecutionFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	blocks, _, post := tests.GetBellatrixRandom()
+
+	blockService, syncedData, ethClock, fcu := setupBlockService(t, ctrl)
+	require.NoError(t, syncedData.OnHeadState(post))
+	ethClock.EXPECT().GetCurrentSlot().Return(uint64(0)).AnyTimes()
+	ethClock.EXPECT().IsSlotCurrentSlotWithMaximumClockDisparity(gomock.Any()).Return(true).AnyTimes()
+	fcu.FinalizedCheckpointVal = post.FinalizedCheckpoint()
+	fcu.Headers[blocks[1].Block.ParentRoot] = blocks[0].SignedBeaconBlockHeader().Header.Copy()
+	fcu.OnBlockErr = fmt.Errorf("%w: execution client is down", forkchoice.ErrNewPayloadNoStatus)
+
+	err := blockService.ProcessMessage(context.Background(), nil, blocks[1])
+	require.ErrorIs(t, err, ErrIgnore)
 }
 
 func TestBlockServiceYoungerThanParent(t *testing.T) {


### PR DESCRIPTION
`ErrNewPayloadNoStatus` means the execution layer returned no verdict — a local `InsertBlock`/`ValidateChain` failure or an engine-API error. The gossip manager bans on any error whose text lacks "ignore", so while the EL restarts the first peer to gossip each beacon block is banned, every slot, down to the grace floor. The block is also dropped rather than retried, even though the condition is transient, which is what `scheduleBlockForLaterProcessing` two lines above exists for.

Known gap this does not close: `execution_client_engine.go` collapses every engine JSON-RPC error into `PayloadStatusNone`, so an EL rejection of a proposer-shaped payload (e.g. `checkWithdrawalsPresence`) is indistinguishable here from the EL being down, and is now ignored rather than rejected. `main` cannot tell them apart either — it bans on both. Mapping invalid-params responses to `PayloadStatusInvalidated` in the engine client is the real fix and belongs in its own PR.

The empty-backfill half of this PR was split out to #23837 on review.

The new test is red on `main`.