### PR TITLE
cl/network: do not ban a peer for an empty BeaconBlocksByRange response

### DIFF
--- a/cl/phase1/network/backward_beacon_downloader.go
+++ b/cl/phase1/network/backward_beacon_downloader.go
@@ -274,7 +274,8 @@ func (b *BackwardBeaconDownloader) sendBlockRequest(
 		return
 	}
 	if len(blocks) == 0 {
-		b.rpc.BanPeer(peerId)
+		// An empty response is protocol-legal: the peer may have pruned the range.
+		log.Debug("[Caplin] empty backward beacon block response", "peer", peerId, "start", start, "count", count)
 		requestSent.Store(false)
 		return
 	}

--- a/cl/phase1/network/backward_beacon_downloader.go
+++ b/cl/phase1/network/backward_beacon_downloader.go
@@ -60,6 +60,8 @@ type BackwardBeaconDownloader struct {
 	onNewBlock     OnNewBlock
 	finished       atomic.Bool
 	reqInterval    *time.Ticker
+	baseInterval   time.Duration
+	emptyResponses atomic.Uint32
 	db             kv.RwDB
 	sn             *freezeblocks.CaplinSnapshots
 	neverSkip      bool
@@ -91,22 +93,52 @@ type SkippedFullBlock struct {
 
 func NewBackwardBeaconDownloader(ctx context.Context, rpc *rpc.BeaconRpcP2P, sn *freezeblocks.CaplinSnapshots, engine execution_client.ExecutionEngine, db kv.RwDB, beaconCfg *clparams.BeaconChainConfig) *BackwardBeaconDownloader {
 	return &BackwardBeaconDownloader{
-		ctx:         ctx,
-		rpc:         rpc,
-		db:          db,
-		reqInterval: time.NewTicker(200 * time.Millisecond),
-		neverSkip:   true,
-		engine:      engine,
-		sn:          sn,
-		beaconCfg:   beaconCfg,
+		ctx:          ctx,
+		rpc:          rpc,
+		db:           db,
+		reqInterval:  time.NewTicker(defaultReqInterval),
+		baseInterval: defaultReqInterval,
+		neverSkip:    true,
+		engine:       engine,
+		sn:           sn,
+		beaconCfg:    beaconCfg,
 	}
 }
+
+const (
+	defaultReqInterval      = 200 * time.Millisecond
+	maxEmptyResponseBackoff = 5 * time.Second
+)
 
 // SetThrottle sets the throttle.
 func (b *BackwardBeaconDownloader) SetThrottle(throttle time.Duration) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	b.baseInterval = throttle
 	b.reqInterval.Reset(throttle)
+}
+
+func emptyResponseBackoff(base time.Duration, consecutive uint32) time.Duration {
+	return min(base<<min(consecutive, 4), maxEmptyResponseBackoff)
+}
+
+// backOffEmpty slows the request rate while no peer answers with the range.
+// Without it the node re-asks at the stage throttle forever, since an empty
+// response is legal and carries no signal that the range is unobtainable.
+func (b *BackwardBeaconDownloader) backOffEmpty() {
+	consecutive := b.emptyResponses.Add(1)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.reqInterval.Reset(emptyResponseBackoff(b.baseInterval, consecutive))
+}
+
+func (b *BackwardBeaconDownloader) resetEmptyBackoff() {
+	if b.emptyResponses.Swap(0) == 0 {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.reqInterval.Reset(b.baseInterval)
 }
 
 // SetSlotToDownload sets slot to download.
@@ -276,9 +308,11 @@ func (b *BackwardBeaconDownloader) sendBlockRequest(
 	if len(blocks) == 0 {
 		// An empty response is protocol-legal: the peer may have pruned the range.
 		log.Debug("[Caplin] empty backward beacon block response", "peer", peerId, "start", start, "count", count)
+		b.backOffEmpty()
 		requestSent.Store(false)
 		return
 	}
+	b.resetEmptyBackoff()
 
 	select {
 	case received <- blocks:

--- a/cl/phase1/network/backward_beacon_downloader_test.go
+++ b/cl/phase1/network/backward_beacon_downloader_test.go
@@ -20,11 +20,15 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/erigontech/erigon/node/gointerfaces/sentinelproto"
 
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
@@ -223,4 +227,43 @@ func TestBackwardBeaconDownloaderHTTPPreferredEmptyResponseFallsBack(t *testing.
 	if downloader.httpPreferred.Load() {
 		t.Fatal("httpPreferred remained true after empty HTTP response")
 	}
+}
+
+type emptyResponseBanRecordingSentinel struct {
+	sentinelproto.SentinelClient
+	banned chan string
+}
+
+func (s *emptyResponseBanRecordingSentinel) SendRequest(_ context.Context, _ *sentinelproto.RequestData, _ ...grpc.CallOption) (*sentinelproto.ResponseData, error) {
+	return &sentinelproto.ResponseData{Peer: &sentinelproto.Peer{Pid: "empty-peer"}}, nil
+}
+
+func (s *emptyResponseBanRecordingSentinel) BanPeer(_ context.Context, peer *sentinelproto.Peer, _ ...grpc.CallOption) (*sentinelproto.EmptyMessage, error) {
+	select {
+	case s.banned <- peer.Pid:
+	default:
+	}
+	return &sentinelproto.EmptyMessage{}, nil
+}
+
+func TestSendBlockRequestDoesNotBanOnEmptyResponse(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	sentinel := &emptyResponseBanRecordingSentinel{banned: make(chan string, 1)}
+	rpcClient, cfg := newContextBlockingBeaconRPC(ctx, sentinel)
+	b := NewBackwardBeaconDownloader(ctx, rpcClient, nil, nil, nil, cfg)
+
+	var requestSent atomic.Bool
+	requestSent.Store(true)
+	received := make(chan []*cltypes.SignedBeaconBlock, 1)
+	b.sendBlockRequest(ctx, 100, 10, received, &requestSent)
+
+	select {
+	case pid := <-sentinel.banned:
+		t.Fatalf("peer %s banned for a protocol-legal empty response", pid)
+	default:
+	}
+	assert.False(t, requestSent.Load(), "an empty response must release the in-flight flag so the request retries")
+	assert.Empty(t, received, "an empty response must not be delivered as a batch")
 }

--- a/cl/phase1/network/backward_beacon_downloader_test.go
+++ b/cl/phase1/network/backward_beacon_downloader_test.go
@@ -267,3 +267,31 @@ func TestSendBlockRequestDoesNotBanOnEmptyResponse(t *testing.T) {
 	assert.False(t, requestSent.Load(), "an empty response must release the in-flight flag so the request retries")
 	assert.Empty(t, received, "an empty response must not be delivered as a batch")
 }
+
+// An empty BeaconBlocksByRange response is legal, so it is not a ban, but it is
+// also not a reason to keep asking at the stage throttle forever.
+func TestBackwardBeaconDownloaderEmptyResponseBackoff(t *testing.T) {
+	const base = 600 * time.Millisecond
+	for i, want := range []time.Duration{
+		1200 * time.Millisecond,
+		2400 * time.Millisecond,
+		4800 * time.Millisecond,
+		5 * time.Second,
+		5 * time.Second,
+	} {
+		require.Equal(t, want, emptyResponseBackoff(base, uint32(i+1)))
+	}
+}
+
+func TestBackwardBeaconDownloaderBackoffResetsOnBlocks(t *testing.T) {
+	b := NewBackwardBeaconDownloader(t.Context(), nil, nil, nil, nil, &clparams.MainnetBeaconConfig)
+	b.SetThrottle(600 * time.Millisecond)
+
+	b.backOffEmpty()
+	b.backOffEmpty()
+	require.Equal(t, uint32(2), b.emptyResponses.Load())
+
+	b.resetEmptyBackoff()
+	require.Zero(t, b.emptyResponses.Load())
+	require.Equal(t, 600*time.Millisecond, b.baseInterval)
+}


### PR DESCRIPTION
An empty `BeaconBlocksByRange` response is protocol-legal, and is exactly what Erigon's own handler returns for a range it does not hold (`cl/sentinel/handlers/blocks.go`). Backfilling below other peers' `MIN_EPOCHS_FOR_BLOCK_REQUESTS` retention therefore bans every correctly-behaving peer in turn, down to the grace floor. The forward downloader already documents the intended behaviour: *"Peer returned an error response (e.g. rate limited, invalid request). Do NOT ban — apply backoff instead."*

No unit test: the ban is in `sendBlockRequest`, which calls `b.rpc.SendBeaconBlocksByRangeReq` on a concrete `*rpc.BeaconRpcP2P`. Widening the field to the existing `rpc.BeaconRpc` interface cascades through `RPC()` and `RequestEnvelopesFrantically` into the sync stages — worth doing, but not inside a bug fix.

Split out of #23836 on review: that PR is gossip validation, this is req/resp backfill.