### PR TITLE
execution/cache: size the LRU ceiling by exact cost, not the 5/4 table boundary

### DIFF
--- a/execution/cache/generic_cache.go
+++ b/execution/cache/generic_cache.go
@@ -68,10 +68,10 @@ func elemBytesFor[T any]() int64 {
 	return int64(unsafe.Sizeof(e)) + 4
 }
 
-// slotChargeBytes is a slot at the 5/4 ratio fitTableSlots pins, plus a byte to
-// stay on the covering side of the rounding. It sizes the ceiling only: a
-// power-of-two capacity rounds to a 2x table, so every generation below the
-// ceiling charges from tableSlots instead.
+// slotChargeBytes is a slot at freelru's best table ratio, 5/4. It seeds the
+// ceiling search and nothing else: a capacity off that ratio costs more, up to
+// 5/2, so this is a lower bound on the real charge and the search starts above
+// the answer. Every reservation charges the exact table through tableSlots.
 func slotChargeBytes(elemBytes int64) int64 { return elemBytes*5/4 + 1 }
 
 // tableSlots is the array length freelru allocates for a capacity. It sizes both
@@ -102,47 +102,45 @@ func shardArrayBytes(totalCap, shards uint32, elemBytes int64) int64 {
 // maxCacheSlots caps the slot array whatever the byte budget says.
 const maxCacheSlots = 16_000_000
 
-// fitTableSlots rounds a capacity down to the largest one freelru does not round
-// up. Only 4/5 of a power of two leaves the table ratio at 5/4; anywhere else it
-// lands in [5/4, 5/2), where a fixed per-slot charge is wrong in either
-// direction, swinging with GOMAXPROCS through the shard count.
-func fitTableSlots(perShard uint32) uint32 {
-	if perShard < minShardStart {
-		return perShard
-	}
-	// Start at the capacity's own table: it is already the fitted one whenever
-	// the capacity sits on the boundary, and stepping straight past it would
-	// halve the cache.
-	for table := tableSlots(perShard); table >= minShardStart; table /= 2 {
-		if fitted := uint32(table / 5 * 4); fitted >= minShardStart && fitted <= perShard {
-			return fitted
-		}
-	}
-	return perShard
-}
-
 // budgetedSlots splits a byte budget into a slot ceiling and the shard count it
-// is divided by, sized so each shard's table sits on the 5/4 boundary.
+// is divided by, the ceiling being the largest one whose exact cost fits.
 func budgetedSlots(capacityBytes datasize.ByteSize, payloadBytes uint32, elemBytes int64) (maxCap, shards uint32) {
 	perSlot := uint64(payloadBytes) + uint64(slotChargeBytes(elemBytes))
 	approx := uint32(min(uint64(capacityBytes)/perSlot, maxCacheSlots))
 	shards = max(initialShardCount(approx, shardCeil()), 1)
-	perShardCap := fitCeiling(fitTableSlots(approx/shards), capacityBytes, func(c uint32) int64 {
+	perShardCap := fitCeiling(approx/shards, maxCacheSlots/shards, capacityBytes, func(c uint32) int64 {
 		return generationBytesFor(c*shards, shards, int64(payloadBytes), elemBytes)
 	})
 	return perShardCap * shards, shards
 }
 
-// fitCeiling steps a fitted ceiling down until cost reports it inside the
-// budget. A ceiling derived by dividing a budget by the per-slot charge is an
-// estimate: it carries neither the per-shard structs nor the gap between a
-// fitted table and the 5/4 ratio it is charged at, both of which scale with the
-// shard count, so the quotient alone can buy a generation larger than itself.
-func fitCeiling(fitted uint32, budget datasize.ByteSize, cost func(uint32) int64) uint32 {
-	for fitted > 1 && cost(fitted) > int64(budget) {
-		fitted = max(fitTableSlots(fitted-1), 1)
+// fitCeiling is the largest capacity up to ceiling whose exact cost is inside
+// the budget. estimate only seeds the search: dividing a budget by the per-slot
+// charge carries neither the per-shard structs nor the gap between a capacity's
+// table and the 5/4 ratio it is charged at, both of which scale with the shard
+// count, so the quotient alone can buy a generation larger than itself and can
+// also fall short of one. cost is non-decreasing in capacity -- the payload term
+// grows with it and the table it rounds up to never shrinks -- so the answer is
+// the boundary a binary search converges on.
+func fitCeiling(estimate, ceiling uint32, budget datasize.ByteSize, cost func(uint32) int64) uint32 {
+	if cost(1) > int64(budget) {
+		return 1
 	}
-	return fitted
+	ceiling = max(ceiling, 1)
+	hi := max(min(estimate, ceiling), 1)
+	for hi < ceiling && cost(hi) <= int64(budget) {
+		hi = uint32(min(uint64(hi)*2, uint64(ceiling)))
+	}
+	lo := uint32(1)
+	for lo < hi {
+		mid := lo + (hi-lo+1)/2
+		if cost(mid) <= int64(budget) {
+			lo = mid
+		} else {
+			hi = mid - 1
+		}
+	}
+	return lo
 }
 
 // minShardStart keeps a shard's initial table off a handful of slots, which a

--- a/execution/cache/generic_cache.go
+++ b/execution/cache/generic_cache.go
@@ -68,10 +68,9 @@ func elemBytesFor[T any]() int64 {
 	return int64(unsafe.Sizeof(e)) + 4
 }
 
-// slotChargeBytes is a slot at freelru's best table ratio, 5/4. It seeds the
-// ceiling search and nothing else: a capacity off that ratio costs more, up to
-// 5/2, so this is a lower bound on the real charge and the search starts above
-// the answer. Every reservation charges the exact table through tableSlots.
+// slotChargeBytes is a slot at freelru's best table ratio, 5/4, so it is a lower
+// bound: a capacity off that ratio costs up to 5/2. It seeds the ceiling search
+// only; every reservation charges the exact table through tableSlots.
 func slotChargeBytes(elemBytes int64) int64 { return elemBytes*5/4 + 1 }
 
 // tableSlots is the array length freelru allocates for a capacity. It sizes both
@@ -114,14 +113,10 @@ func budgetedSlots(capacityBytes datasize.ByteSize, payloadBytes uint32, elemByt
 	return perShardCap * shards, shards
 }
 
-// fitCeiling is the largest capacity up to ceiling whose exact cost is inside
-// the budget. estimate only seeds the search: dividing a budget by the per-slot
-// charge carries neither the per-shard structs nor the gap between a capacity's
-// table and the 5/4 ratio it is charged at, both of which scale with the shard
-// count, so the quotient alone can buy a generation larger than itself and can
-// also fall short of one. cost is non-decreasing in capacity -- the payload term
-// grows with it and the table it rounds up to never shrinks -- so the answer is
-// the boundary a binary search converges on.
+// fitCeiling is the largest capacity up to ceiling whose exact cost is inside the
+// budget. estimate only seeds the search and may sit on either side of the answer.
+// cost must be non-decreasing in capacity, as both callers' are: the payload term
+// grows with it and the table it rounds up to never shrinks.
 func fitCeiling(estimate, ceiling uint32, budget datasize.ByteSize, cost func(uint32) int64) uint32 {
 	if cost(1) > int64(budget) {
 		return 1

--- a/execution/cache/generic_cache_concurrency_test.go
+++ b/execution/cache/generic_cache_concurrency_test.go
@@ -595,11 +595,11 @@ func TestSlotCeilingClampsAboveUint32(t *testing.T) {
 	elem := elemBytesFor[entry[[]byte]]()
 	maxCap, shards := budgetedSlots(overflow(uint64(slotChargeBytes(elem))), 0, elem)
 	require.Positive(t, shards)
-	require.Equal(t, fitTableSlots(maxCacheSlots/shards)*shards, maxCap)
+	require.Equal(t, maxCacheSlots/shards*shards, maxCap)
 
 	g := newGrowLRU[codeSizeEntry](overflow(avgBytesPerEntry+uint64(slotChargeBytes(elemBytesFor[codeSizeEntry]()))), 0, nil)
 	t.Cleanup(g.Close)
-	require.Equal(t, fitTableSlots(maxCacheSlots), g.maxCap)
+	require.Equal(t, uint32(maxCacheSlots), g.maxCap)
 }
 
 // The reservation counts bytes outside freelru's element; the usage report counts
@@ -626,34 +626,61 @@ func TestGenericCache_PayloadEstimateExcludesEntryBookkeeping(t *testing.T) {
 	require.Equal(t, int64(avgStoragePayloadBytes+currentSizeEntryOverhead), external.currentSize.Load())
 }
 
-// A capacity that already sits on a fitted boundary must be kept, not dropped to
-// the boundary below: rounding down past it halves the cache, so raising the
-// byte budget can shrink it.
-func TestFitTableSlotsNoCapacityCliff(t *testing.T) {
+// The ceiling is the largest capacity that fits, not the largest one whose table
+// sits on freelru's 5/4 boundary. One boundary per power-of-two band, so rounding
+// to it strands most of a band: 39% of the code cache's budget, 17% of the
+// account cache's, and it never comes back -- the ceiling only ever descends.
+func TestCeilingLeavesNoAffordableSlot(t *testing.T) {
 	t.Parallel()
 
-	prev := uint32(0)
-	for perShard := uint32(minShardStart); perShard <= 1<<17; perShard++ {
-		fitted := fitTableSlots(perShard)
-		require.LessOrEqual(t, fitted, perShard, "fitTableSlots(%d) is above its input", perShard)
-		require.GreaterOrEqual(t, fitted, prev,
-			"fitTableSlots(%d) fell to %d from fitTableSlots(%d)=%d", perShard, fitted, perShard-1, prev)
-		prev = fitted
+	elem := elemBytesFor[entry[[]byte]]()
+	for _, budget := range []datasize.ByteSize{16 * datasize.MB, 150 * datasize.MB, 512 * datasize.MB, 1 * datasize.GB} {
+		for _, payload := range []uint32{0, 64, avgStoragePayloadBytes, avgAccountPayloadBytes, 12288} {
+			maxCap, shards := budgetedSlots(budget, payload, elem)
+			cost := func(total uint32) int64 {
+				return generationBytesFor(total, shards, int64(payload), elem)
+			}
+			require.LessOrEqual(t, cost(maxCap), int64(budget),
+				"budgetedSlots(%s, %d) ceiling %d is outside its own budget", budget, payload, maxCap)
+			if maxCap < maxCacheSlots/shards*shards {
+				require.Greater(t, cost(maxCap+shards), int64(budget),
+					"budgetedSlots(%s, %d) stopped at %d over %d shards with a step still affordable",
+					budget, payload, maxCap, shards)
+			}
+		}
 	}
 }
 
-// The fitted ceiling has to stay inside the per-slot charge budgetedSlots divides
-// the byte budget by; above it a cache built from that budget allocates a table
-// the envelope never reserved.
-func TestFitTableSlotsStaysWithinSlotCharge(t *testing.T) {
+// The search doubles its seed when the estimate lands under the answer, so a
+// ceiling in the top half of uint32 has to be reached in wider arithmetic: the
+// doubling wraps to zero otherwise and the walk never ends.
+func TestCeilingTerminatesAboveTheSlotClamp(t *testing.T) {
 	t.Parallel()
 
-	for _, perShard := range []uint32{1 << 10, 20_000, 26_212, 26_215, 1 << 20, maxCacheSlots} {
-		fitted := fitTableSlots(perShard)
-		elem := elemBytesFor[entry[[]byte]]()
-		require.LessOrEqual(t, int64(tableSlots(fitted))*elem, int64(fitted)*slotChargeBytes(elem),
-			"fitTableSlots(%d)=%d needs a %d-slot table, above the per-slot charge",
-			perShard, fitted, tableSlots(fitted))
+	free := func(uint32) int64 { return 0 }
+	for _, estimate := range []uint32{0, 1, 3, 1 << 31, math.MaxUint32} {
+		require.Equal(t, uint32(math.MaxUint32),
+			fitCeiling(estimate, math.MaxUint32, datasize.ByteSize(math.MaxInt64), free),
+			"seeded at %d", estimate)
+	}
+}
+
+// The same for the unsharded ceiling, over the value types that reach the widest
+// freelru elements. Its budget funds one table, so the strand is the same band.
+func TestGrowLRUCeilingLeavesNoAffordableSlot(t *testing.T) {
+	t.Parallel()
+
+	for _, budget := range []datasize.ByteSize{16 * datasize.MB, 64 * datasize.MB, 512 * datasize.MB} {
+		for _, payload := range []uint32{1, 64, 12288} {
+			g := closeOnCleanup(t, newGrowLRU[codeEntry](budget, payload, nil))
+			cost := func(c uint32) int64 { return growLRUBytes(c, g.procs, g.avgBytes, g.elemBytes) }
+			require.LessOrEqual(t, cost(g.maxCap), int64(budget),
+				"newGrowLRU(%s, %d) ceiling %d is outside its own budget", budget, payload, g.maxCap)
+			if g.maxCap < maxCacheSlots {
+				require.Greater(t, cost(g.maxCap+1), int64(budget),
+					"newGrowLRU(%s, %d) stopped at %d with a slot still affordable", budget, payload, g.maxCap)
+			}
+		}
 	}
 }
 

--- a/execution/cache/generic_cache_concurrency_test.go
+++ b/execution/cache/generic_cache_concurrency_test.go
@@ -628,8 +628,8 @@ func TestGenericCache_PayloadEstimateExcludesEntryBookkeeping(t *testing.T) {
 
 // The ceiling is the largest capacity that fits, not the largest one whose table
 // sits on freelru's 5/4 boundary. One boundary per power-of-two band, so rounding
-// to it strands most of a band: 39% of the code cache's budget, 17% of the
-// account cache's, and it never comes back -- the ceiling only ever descends.
+// to it strands most of a band: 39% of the code cache's ceiling, 17% of the
+// account cache's.
 func TestCeilingLeavesNoAffordableSlot(t *testing.T) {
 	t.Parallel()
 

--- a/execution/cache/grow_lru.go
+++ b/execution/cache/grow_lru.go
@@ -78,8 +78,8 @@ func newGrowLRU[V any](maxBytes datasize.ByteSize, avgBytes uint32, onEvict func
 	procs := uint32(runtime.GOMAXPROCS(0))
 	elemBytes := elemBytesFor[V]()
 	perSlot := int64(avgBytes) + slotChargeBytes(elemBytes)
-	approx := max(fitTableSlots(uint32(min(uint64(maxBytes)/uint64(perSlot), maxCacheSlots))), 1)
-	maxCap := fitCeiling(approx, maxBytes, func(c uint32) int64 {
+	approx := max(uint32(min(uint64(maxBytes)/uint64(perSlot), maxCacheSlots)), 1)
+	maxCap := fitCeiling(approx, maxCacheSlots, maxBytes, func(c uint32) int64 {
 		return growLRUBytes(c, procs, int64(avgBytes), elemBytes)
 	})
 	return newGrowLRUWith(maxCap, int64(avgBytes), procs, onEvict)


### PR DESCRIPTION
`fitTableSlots` rounds a capacity down to `floor(2^n/5)*4` — one value per power-of-two band — and `fitCeiling` only descends, so a seed rounded past the affordable capacity is never recovered. Seeding it raw does not help either: the first failing step calls `fitTableSlots(seed-1)` and lands back on the same boundary.

Entry ceilings at GOMAXPROCS=16 (256 shards), from the shipped budgets:

| cache | ceiling before | after | budget spent before | after |
|---|---|---|---|---|
| code, 512 MB | 26,212 | 43,058 | 311 MiB | 512 MiB |
| accounts, 150 MB | 418,816 | 506,880 | 86 MiB | 150 MiB |
| storage, 1 GB | 3,354,624 | 3,355,392 | 669 MiB | 669 MiB |

Same shape across GOMAXPROCS 1-64. Storage barely moves because its ceiling already sits against freelru's table-doubling wall — the rounding was never what bounded it.

## Changes

- `fitCeiling` is an exact binary search for the largest capacity within a `ceiling` bound whose cost fits, replacing the boundary-snapping descent. Both callers' cost closures are non-decreasing in capacity, which is what makes it exact.
- `fitTableSlots` is deleted — no remaining consumer. `budgetedSlots` bounds the search at `maxCacheSlots/shards` to keep the global clamp on the total, `newGrowLRU` at `maxCacheSlots`.
- `slotChargeBytes` is unchanged in value, documented as what it now is: a lower bound that seeds the search, not a covering charge.

## Notes

The boundary was not an invariant anything relied on — `code_cache.go` already built a `growLRU` with a raw ceiling of `DefaultCodeSizeCacheEntries`, and the ladder's `min(oldCap*4, maxCap)` rungs never sat on it.

`TestSlotCeilingClampsAboveUint32` now expects the clamp reached exactly, 16,000,000 rather than 13,421,772. The two `fitTableSlots` unit tests give way to `TestCeilingLeavesNoAffordableSlot` and `TestGrowLRUCeilingLeavesNoAffordableSlot`, which assert the next step is unaffordable, and `TestCeilingTerminatesAboveTheSlotClamp`, which pins the uint64 widening in the seed doubling. All three fail on this branch's base.
