### PR TITLE
common/maphash: document that Map stores only the key hash

### DIFF
--- a/common/maphash/maphash.go
+++ b/common/maphash/maphash.go
@@ -23,7 +23,10 @@ func Hash(key []byte) uint64 {
 	return maphash.Bytes(seed, key)
 }
 
-// Map is a concurrent map that uses maphash to hash []byte keys.
+// Map is a concurrent map that uses maphash to hash []byte keys. Only the
+// 64-bit hash of the key is stored, so Get returns the value under a
+// colliding key instead of a miss, and the original byte-key is not
+// recoverable.
 type Map[V any] struct {
 	m *xsync.Map[uint64, V]
 }
@@ -101,7 +104,6 @@ func (m *Map[V]) Clear() {
 // unspecified. Return false from fn to stop early. Concurrent
 // modification during Range is permitted by the underlying xsync.Map.
 //
-// The original byte-key is not recoverable — Set hashes-and-discards.
 // Pair with DeleteByHash to evict entries discovered via Range.
 func (m *Map[V]) Range(fn func(hash uint64, v V) bool) {
 	m.m.Range(func(key uint64, value V) bool {
@@ -117,6 +119,8 @@ func (m *Map[V]) DeleteByHash(hash uint64) {
 
 // NonConcurrentMap is a non-thread-safe map that uses maphash to hash []byte keys.
 // Use this when you don't need concurrent access for better performance.
+// Only the 64-bit hash of the key is stored, so Get returns the value under
+// a colliding key instead of a miss.
 type NonConcurrentMap[V any] struct {
 	m map[uint64]V
 }


### PR DESCRIPTION
`maphash.Map` stores only the 64-bit hash of a key, so `Get` can return the value stored under a different, colliding key. That property was documented only on `Map.Range`, where it reads as a caveat about iteration rather than about lookups. Callers reading the type doc — `execution/cache`, `execution/commitment`, txpool, caplin — see nothing.

Found while checking #22212, which assumed a collision in the commitment branch cache would silently diverge a node's state root. It would not: the root is checked against the header at `execution/stagedsync/committer.go:936` and a mismatch raises `ErrWrongTrieRoot`. Closed as such; this is the part of it that was real.

## Changes

- `common/maphash`: move the hash-is-the-key caveat from `Map.Range` to the `Map` type doc, stated as what `Get` does on a collision.
- Same sentence on `NonConcurrentMap`, which has the identical behaviour and no note at all.

Docs only, no behaviour change.
