### PR TITLE
db/recsplit: spill Enums=true offsets as gaps, read them back streamed

### DIFF
--- a/db/recsplit/recsplit.go
+++ b/db/recsplit/recsplit.go
@@ -177,8 +177,7 @@ type RecSplit struct {
 	// and the sequence of cumulative bit offsets of buckets in the Golomb-Rice code.
 	ef                 eliasfano16.DoubleEliasFano
 	lvl                log.Lvl
-	minDelta           uint64 // minDelta for Elias Fano encoding of "enum -> offset" index
-	prevOffset         uint64 // Previously added offset (for calculating minDelta for Elias Fano encoding of "enum -> offset" index)
+	prevOffset         uint64 // Previously added offset - the base of the gap written to the offsets file
 	bucketSize         int
 	keyExpectedCount   uint64 // Number of keys in the hash table
 	keysAdded          uint64 // Number of keys actually added to the recSplit (to check the match with keyExpectedCount)
@@ -548,13 +547,6 @@ func (rs *RecSplit) addHashedKey(hi, lo, offset uint64) error {
 	if offset > rs.maxOffset {
 		rs.maxOffset = offset
 	}
-	if rs.keysAdded > 0 {
-		delta := offset - rs.prevOffset
-		if rs.keysAdded == 1 || delta < rs.minDelta {
-			rs.minDelta = delta
-		}
-	}
-
 	if rs.enums {
 		if rs.keysAdded > 0 && offset < rs.prevOffset {
 			panic(fmt.Sprintf("recsplit: AddKey offsets must be monotonically increasing: prev=%d, cur=%d", rs.prevOffset, offset))

--- a/db/recsplit/recsplit.go
+++ b/db/recsplit/recsplit.go
@@ -36,7 +36,6 @@ import (
 	"github.com/erigontech/erigon/common/background"
 	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/log/v3"
-	"github.com/erigontech/erigon/common/mmap"
 	"github.com/erigontech/erigon/common/murmur3"
 	"github.com/erigontech/erigon/db/bufiopool"
 	"github.com/erigontech/erigon/db/datastruct/fusefilter"
@@ -190,6 +189,7 @@ type RecSplit struct {
 	salt               uint32 // Murmur3 hash used for converting keys to 64-bit values and assigning to buckets
 	bucketKeyBuf       [12]byte
 	numBuf             [8]byte
+	gapBuf             [binary.MaxVarintLen64]byte
 	collision          bool
 	enums              bool // Whether to build two level index with perfect hash table pointing to enumeration and enumeration pointing to offsets
 	lessFalsePositives bool
@@ -463,6 +463,7 @@ func (rs *RecSplit) ResetNextSalt() {
 	rs.bucketCollector = etl.NewCollectorWithAllocator(RecSplitLogPrefix+" "+rs.fileName, rs.tmpDir, etl.SmallSortableBuffers, rs.logger)
 	rs.bucketCollector.SortAndFlushInBackground(rs.workers > 1)
 	rs.bucketCollector.LogLvl(log.LvlDebug)
+	rs.prevOffset = 0
 	if rs.offsetFile != nil {
 		_ = rs.offsetFile.Truncate(0)
 		_, _ = rs.offsetFile.Seek(0, 0)
@@ -558,7 +559,8 @@ func (rs *RecSplit) addHashedKey(hi, lo, offset uint64) error {
 		if rs.keysAdded > 0 && offset < rs.prevOffset {
 			panic(fmt.Sprintf("recsplit: AddKey offsets must be monotonically increasing: prev=%d, cur=%d", rs.prevOffset, offset))
 		}
-		if _, err := rs.offsetWriter.Write(rs.numBuf[:]); err != nil {
+		n := binary.PutUvarint(rs.gapBuf[:], offset-rs.prevOffset)
+		if _, err := rs.offsetWriter.Write(rs.gapBuf[:n]); err != nil {
 			return err
 		}
 		binary.BigEndian.PutUint64(rs.numBuf[:], rs.keysAdded)
@@ -593,19 +595,6 @@ func (rs *RecSplit) addHashedKey(hi, lo, offset uint64) error {
 	rs.prevOffset = offset
 	if rs.progress != nil && rs.keysAdded%1024 == 0 {
 		rs.progress.Processed.Add(1024)
-	}
-	return nil
-}
-
-func (rs *RecSplit) AddOffset(offset uint64) error {
-	if rs.enums {
-		if rs.keysAdded > 0 && offset < rs.prevOffset {
-			panic(fmt.Sprintf("recsplit: AddOffset offsets must be monotonically increasing: prev=%d, cur=%d", rs.prevOffset, offset))
-		}
-		binary.BigEndian.PutUint64(rs.numBuf[:], offset)
-		if _, err := rs.offsetWriter.Write(rs.numBuf[:]); err != nil {
-			return err
-		}
 	}
 	return nil
 }
@@ -870,7 +859,7 @@ func (rs *RecSplit) loadFuncBucket(k, v []byte, _ etl.CurrentTableReader, _ etl.
 	return nil
 }
 
-// buildOffsetEf mmaps the offset temp file and builds the Elias-Fano encoding.
+// buildOffsetEf replays the offset temp file and builds the Elias-Fano encoding.
 // Uses off-heap EF to keep multi-GB backing buffers out of the Go heap.
 func (rs *RecSplit) buildOffsetEf() (retErr error) {
 	var err error
@@ -888,18 +877,20 @@ func (rs *RecSplit) buildOffsetEf() (retErr error) {
 		return fmt.Errorf("flush offset writer: %w", err)
 	}
 
-	mmapSize := int(rs.keysAdded * 8)
-	mmapHandle1, err := mmap.OpenRo(rs.offsetFile, mmapSize)
-	if err != nil {
-		return fmt.Errorf("mmap offset file: %w", err)
+	if _, err := rs.offsetFile.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("rewind offset file: %w", err)
 	}
-	// Discarded, not folded into retErr: an Unmap failure here would trigger the
-	// retErr-triggered cleanup above and discard an offsetEf that finished building correctly.
-	defer func() { _ = mmapHandle1.Unmap() }()
+	r := bufiopool.Reader(rs.offsetFile)
+	defer bufiopool.PutReader(r)
 
-	data := mmapHandle1[:mmapSize]
+	var offset uint64
 	for i := uint64(0); i < rs.keysAdded; i++ {
-		rs.offsetEf.AddOffset(binary.BigEndian.Uint64(data[i*8:]))
+		gap, err := binary.ReadUvarint(r)
+		if err != nil {
+			return fmt.Errorf("read offset %d of %d: %w", i, rs.keysAdded, err)
+		}
+		offset += gap
+		rs.offsetEf.AddOffset(offset)
 	}
 	rs.offsetEf.Build()
 	return nil

--- a/db/recsplit/recsplit_test.go
+++ b/db/recsplit/recsplit_test.go
@@ -483,6 +483,8 @@ func TestTwoLayerIndexOffsetGaps(t *testing.T) {
 	for i := range offsets {
 		switch {
 		case i%7 == 0: // duplicate offset: gap 0
+		case i == N/3:
+			off += 1 << 62 // gap needs all 10 uvarint bytes
 		case i == N/2:
 			off += 1 << 33
 		default:

--- a/db/recsplit/recsplit_test.go
+++ b/db/recsplit/recsplit_test.go
@@ -469,3 +469,53 @@ func TestParallelMatchesSequential(t *testing.T) {
 		})
 	}
 }
+
+// Offsets of an `Enums: true` index are spilled as gaps, so pin the round-trip
+// for what gap encoding is sensitive to: repeated offsets and a jump past 2^32.
+func TestTwoLayerIndexOffsetGaps(t *testing.T) {
+	logger := log.New()
+	tmpDir := t.TempDir()
+	salt := uint32(1)
+	const N = 1000
+
+	offsets := make([]uint64, N)
+	var off uint64
+	for i := range offsets {
+		switch {
+		case i%7 == 0: // duplicate offset: gap 0
+		case i == N/2:
+			off += 1 << 33
+		default:
+			off += uint64(i)
+		}
+		offsets[i] = off
+	}
+
+	indexFile := filepath.Join(tmpDir, "index")
+	rs, err := NewRecSplit(RecSplitArgs{
+		KeyCount: N, BucketSize: 10, Salt: &salt, TmpDir: tmpDir,
+		IndexFile: indexFile, LeafSize: 8, Enums: true,
+	}, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rs.Close()
+
+	for i := range N {
+		if err := rs.AddKey(fmt.Appendf(nil, "key %d", i), offsets[i]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := rs.Build(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	idx := MustOpen(indexFile)
+	defer idx.Close()
+	reader := NewIndexReader(idx)
+	for i := range N {
+		e, _ := reader.Lookup(fmt.Appendf(nil, "key %d", i))
+		require.Equal(t, uint64(i), e)
+		require.Equal(t, offsets[i], idx.OrdinalLookup(e))
+	}
+}


### PR DESCRIPTION
With `Enums=true`, every key writes its offset to a temp file as 8 raw bytes, and `Build()` then mmaps the whole file to feed the Elias-Fano encoder.

At 1B keys that is an 8 GB temp file mapped with `MADV_RANDOM` — `mmap.OpenRo`'s default — and then read strictly sequentially. Worst of both: no readahead, and every page stays resident.

Offsets are already required to increase monotonically (there is a panic enforcing it), so this stores the gap as a uvarint and replays the file through a pooled buffered reader instead.

## Measured

1B keys, `Enums: true`, gaps of 137 (two uvarint bytes; one-byte gaps give 8x on the file), Linux, 16 cores:

| | before | after |
|---|---|---|
| offsets temp file | 8.00 B/key | 2.00 B/key |
| peak RSS | 35.76 GB | 28.09 GB |
| build | 22m05s | 22m11s |
| index output | 5.36 B/key | 5.36 B/key |

Same at 200M (7.25 → 5.67 GB) and 20M. The index file is unaffected — this is build cost only.

## Also removed

`AddOffset` had no callers, and it wrote an offset without bumping `keysAdded` or `maxOffset`, so the Elias-Fano it fed would have been undersized. Removing it also keeps the gap stream single-writer.

## Tests

`TestTwoLayerIndexOffsetGaps` pins the round-trip for what gap encoding is sensitive to — repeated offsets (gap 0) and a jump past 2^32. It fails on a broken gap decode. `FuzzRecSplit` already covers this path with `Enums: true`; ran it for 3 minutes, 222k execs, clean.

## Note for reviewers

While writing the test I found a pre-existing bug next door: `ResetNextSalt` never resets `rs.gr`, so the retry accumulates Golomb-Rice bits on top of the previous attempt and `DoubleEliasFano.Build` panics with `slice bounds out of range`. Every collision retry goes through that path. Not fixed here to keep this change focused — filing separately.