### PR TITLE
cl/sentinel: build one peers.Pool for the whole test package

### DIFF
--- a/cl/sentinel/ban_on_connection_test.go
+++ b/cl/sentinel/ban_on_connection_test.go
@@ -18,6 +18,7 @@ package sentinel
 
 import (
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -44,10 +45,16 @@ func (s stubP2P) UDPv5Listener() *discover.UDPv5               { return nil }
 func (s stubP2P) UpdateENRAttSubnets(subnetIndex int, on bool) {}
 func (s stubP2P) UpdateENRSyncNets(subnetIndex int, on bool)   {}
 
+// testPeerPool is shared package-wide because every peers.NewPool starts two TTL-cache cleanup
+// goroutines that the upstream cache offers no way to stop. Sharing is safe because each test
+// creates its own hosts, so no two tests touch the same peer ID, and it carries no host because
+// nothing in this package reaches Pool.Request, the only method that needs one.
+var testPeerPool = sync.OnceValue(func() *peers.Pool { return peers.NewPool(nil) })
+
 func testSentinel(t *testing.T, h host.Host) *Sentinel {
 	t.Helper()
 	return &Sentinel{
-		peers: peers.NewPool(h),
+		peers: testPeerPool(),
 		p2p:   stubP2P{host: h},
 		cfg:   &SentinelConfig{P2PConfig: p2p.P2PConfig{MaxPeerCount: 100}},
 	}
@@ -133,6 +140,13 @@ func TestRepeatedHandshakeFailuresStopBeingHandshaked(t *testing.T) {
 	require.False(t, s.handleNewConnection(remote.ID(), failing))
 	require.Equal(t, 3, validations, "a banned peer must not be handshaked again")
 	waitDisconnected(t, local, remote.ID())
+}
+
+// Each pool leaves two cleanup goroutines running for the rest of the process, so building one
+// per test makes the count grow with the size of the suite.
+func TestFixtureReusesOnePeerPool(t *testing.T) {
+	local, _ := connectedPair(t)
+	require.Same(t, testSentinel(t, local).peers, testSentinel(t, local).peers)
 }
 
 // A peer that is not banned still reaches its handshake and is kept.

--- a/cl/sentinel/discovery_test.go
+++ b/cl/sentinel/discovery_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/p2p"
 	"github.com/erigontech/erigon/cl/p2p/mock_services"
-	"github.com/erigontech/erigon/cl/sentinel/peers"
 	libp2p "github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/multiformats/go-multiaddr"
@@ -67,7 +66,7 @@ func TestListenForPeersDialsDirectPeersWithoutDiscovery(t *testing.T) {
 			NetworkConfig: &clparams.NetworkConfig{StaticPeers: []string{unsupportedPeer, directPeer}},
 			NoDiscovery:   true,
 		}},
-		peers:      peers.NewPool(local),
+		peers:      testPeerPool(),
 		p2p:        p2pManager,
 		connectSem: semaphore.NewWeighted(goRoutinesOpeningPeerConnections),
 	}


### PR DESCRIPTION
Follow-up to #23606, addressing @domiwei's second non-blocking review comment.

Every `peers.NewPool` starts two TTL-cache cleanup goroutines, and the upstream expirable LRU
never closes their `done` channel — `Close()` is commented out in the dependency with a note
that it will only arrive after v2. The goroutines therefore run for the rest of the process.
The `cl/sentinel` fixture built a pool per test, so the count grew with the size of the package.

Share one pool instead. It is safe because each test creates its own hosts, so peer IDs are
disjoint and ban state cannot carry between tests, and nothing in this package reaches
`Pool.Request` — the only method that uses the host.

Measured with a temporary probe counting surviving cleanup goroutines: **eight per suite
repetition before, a flat two after**, at `-count=1`, `2` and `3`.

`TestFixtureReusesOnePeerPool` pins the arrangement; restoring the per-test pool fails it.
Removing the ban read from `handleNewConnection` still fails
`TestBannedPeerIsClosedInsteadOfHandshaked`, so the shared pool has not weakened the tests it
carries. Package passes with `-shuffle=on` (three runs) and under `-race` at `-count=2`;
`make lint` clean.

Test-only change, so no new coverage beyond the pin above.

Not addressed here: production code has the same unstoppable-goroutine property, but every
call site is a process-level singleton, so nothing leaks at runtime. Making `lru.CacheWithTTL`
closable would need us to own the expiry sweep — `expirable`'s `Get` already checks `ExpiresAt`,
so the background goroutine only reclaims memory — and it would touch consensus-adjacent caches.
Filed separately rather than folded in here.
