### PR TITLE
ci: bump docker builder image to golang:1.27-trixie

### DIFF
--- a/.github/workflows/ci-cd-main-branch-docker-images.yml
+++ b/.github/workflows/ci-cd-main-branch-docker-images.yml
@@ -5,7 +5,7 @@ env:
   APPLICATION: "erigon"
   APP_REPO: "erigontech/erigon"
   DOCKERHUB_REPOSITORY: "erigontech/erigon"
-  BUILDER_IMAGE: "golang:1.26-trixie"
+  BUILDER_IMAGE: "golang:1.27-trixie"
   LABEL_DESCRIPTION: "[docker image built on the last commit id from the main branch] Erigon is an implementation of Ethereum (execution layer with embeddable consensus layer), on the efficiency frontier. Archive Node by default."
 
 on:


### PR DESCRIPTION
## Summary
- Go 1.27.1 has been released; bump the main-branch docker-image build (`.github/workflows/ci-cd-main-branch-docker-images.yml`) from `golang:1.26-trixie` to `golang:1.27-trixie`.
- Scoped to this workflow only. `golang:1.27-trixie` is a floating minor tag (moves with future 1.27.x patch releases), which is fine here — it's the same pattern already used for `1.26-trixie`.
- `go.mod` still declares `go 1.26.0` with no `toolchain` pin; a 1.27 builder builds it without issue. Bumping `go.mod`, and the `golang:1.26-*` pins in `release.yml` / `release-branch-sec-scan.yml`, are left as separate follow-ups.

## Test plan
- [x] Simulated the workflow's `docker buildx build` step locally against the Dockerfile with `BUILDER_IMAGE=golang:1.27-trixie` and the same `BINARIES`/`BUILD_TAGS` args — build succeeds, no compile/cgo errors.
- [x] Ran the resulting `erigon` binary (`erigon version 3.7.0-dev-...`) to confirm it starts.
- [ ] CI on this PR (docker image build is not part of PR checks; this workflow only runs on push to `main`/`docker_pectra` or manual dispatch)