### PR TITLE
[r3.6] ci: backport dependabot action bumps from main

### DIFF
--- a/.github/workflows/ci-cd-main-branch-docker-images.yml
+++ b/.github/workflows/ci-cd-main-branch-docker-images.yml
@@ -99,7 +99,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PUSH_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4.2.0
+        uses: docker/setup-qemu-action@v4.3.0
 
       - name: Set up Docker Buildx
         id: docker-buildx

--- a/.github/workflows/daily-repo-status.lock.yml
+++ b/.github/workflows/daily-repo-status.lock.yml
@@ -52,7 +52,7 @@ jobs:
       comment_repo: ""
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@eed4304d8740f0593f2797276cb8299d228ffd9b # v0.81.6
+        uses: github/gh-aw/actions/setup@8e30bcd8897f5047051fa3971188e1dd4cdb23cf # v0.88.2
         with:
           destination: /opt/gh-aw/actions
       - name: Check workflow file timestamps
@@ -81,7 +81,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@eed4304d8740f0593f2797276cb8299d228ffd9b # v0.81.6
+        uses: github/gh-aw/actions/setup@8e30bcd8897f5047051fa3971188e1dd4cdb23cf # v0.88.2
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout .github and .agents folders

--- a/.github/workflows/qa-txpool-performance-test.yml
+++ b/.github/workflows/qa-txpool-performance-test.yml
@@ -424,7 +424,7 @@ jobs:
           fi
 
       - name: Clean test results
-        uses: gacts/run-and-post-run@v1.4.4
+        uses: gacts/run-and-post-run@v1.4.5
         if: always()
         with:
           post: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,7 +203,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PUSH_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  ## v4.2.0
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a  ## v4.3.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  ## v4.0.0
@@ -345,7 +345,7 @@ jobs:
         run: rm -drfv *
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
## Summary
`release/3.6` had fallen behind `main` on several GitHub Actions dependency pins in `.github/`. This replays the dependabot bumps that were only applied to `main`:

- `docker/setup-qemu-action`: v4.2.0 -> v4.3.0 in `ci-cd-main-branch-docker-images.yml` and `release.yml` (#23805)
- `gacts/run-and-post-run`: v1.4.4 -> v1.4.5 in `qa-txpool-performance-test.yml` (#23806)
- `github/gh-aw/actions/setup`: v0.81.6 -> v0.88.2 (2 jobs) in `daily-repo-status.lock.yml`, chained across #22233, #21934, #22935, #23111, #23309, #23660, #23807
- `actions/setup-python`: v6 -> v7 in `release.yml` (#22729)

Not included: `actions/download-artifact@v8` added to `test-fuzz.yml` on main — that's a new feature step (fuzz-failure marker download), not a dependency bump, out of scope here.

Each pin now matches `main`'s current value exactly (verified with a diff against `main` limited to these lines).

## r3.6-specific adaptations
None — straight version-pin replay, no other changes needed.

## Test plan
- [x] Diffed each touched file against `main` to confirm the bumped pins now match exactly
- [x] No other lines changed in any of the 4 files
- Mechanical dependency-bump change; no behavior change, so no new tests per repo TDD guidance