### PR TITLE
[r3.6] cl, cmd/utils: derive the column retention window from the chain config

### DIFF
--- a/cl/clparams/config.go
+++ b/cl/clparams/config.go
@@ -50,7 +50,8 @@ type CaplinConfig struct {
 	BlobPruningDisabled       bool
 	SnapshotGenerationEnabled bool
 	// ColumnKeepSlots is the number of slots to keep PeerDAS data column sidecars.
-	// Default: MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS * SLOTS_PER_EPOCH (4096 * 32 = 131072, ~18 days).
+	// Zero resolves to the active chain's spec window, MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS *
+	// SLOTS_PER_EPOCH, which differs per chain because SLOTS_PER_EPOCH does.
 	// Increase for DA oracle nodes or rollups that need longer history; decrease only if disk is constrained
 	// and spec compliance for column serving is not required.
 	ColumnKeepSlots uint64

--- a/cl/phase1/stages/cleanup_and_pruning.go
+++ b/cl/phase1/stages/cleanup_and_pruning.go
@@ -3,6 +3,7 @@ package stages
 import (
 	"context"
 
+	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/persistence/beacon_indicies"
 	"github.com/erigontech/erigon/common/log/v3"
 )
@@ -28,9 +29,17 @@ func cleanupAndPruning(ctx context.Context, logger log.Logger, cfg *Cfg, args Ar
 	cfg.blobStore.Prune()
 	columnKeepSlots := cfg.caplinConfig.ColumnKeepSlots
 	if columnKeepSlots == 0 {
-		// Default: MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS * SLOTS_PER_EPOCH
-		columnKeepSlots = cfg.beaconCfg.MinEpochsForDataColumnSidecarsRequests * cfg.beaconCfg.SlotsPerEpoch
+		columnKeepSlots = specColumnKeepSlots(cfg.beaconCfg)
 	}
 	cfg.peerDas.Prune(columnKeepSlots)
 	return nil
+}
+
+// specColumnKeepSlots is the retention distance for MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS.
+// The window is stated in epochs and measured from the start of current_epoch - MIN_EPOCHS, so an
+// exact epochs * SLOTS_PER_EPOCH distance cuts above that boundary whenever the head sits inside
+// an epoch. The extra epoch keeps the cut at or below it, which matters because this distance also
+// sets the earliest slot we advertise as servable.
+func specColumnKeepSlots(beaconCfg *clparams.BeaconChainConfig) uint64 {
+	return (beaconCfg.MinEpochsForDataColumnSidecarsRequests + 1) * beaconCfg.SlotsPerEpoch
 }

--- a/cl/phase1/stages/cleanup_and_pruning_test.go
+++ b/cl/phase1/stages/cleanup_and_pruning_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package stages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	das_mock_services "github.com/erigontech/erigon/cl/das/mock_services"
+	blob_mock_services "github.com/erigontech/erigon/cl/persistence/blob_storage/mock_services"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv/dbcfg"
+	"github.com/erigontech/erigon/db/kv/memdb"
+)
+
+func pruningCfg(t *testing.T, ctrl *gomock.Controller, beaconCfg *clparams.BeaconChainConfig, caplinCfg clparams.CaplinConfig) (*Cfg, *das_mock_services.MockPeerDas) {
+	t.Helper()
+	blobStore := blob_mock_services.NewMockBlobStorage(ctrl)
+	blobStore.EXPECT().Prune().Return(nil)
+	peerDas := das_mock_services.NewMockPeerDas(ctrl)
+	return &Cfg{
+		indiciesDB:   memdb.NewTestDB(t, dbcfg.ChainDB),
+		beaconCfg:    beaconCfg,
+		blobStore:    blobStore,
+		peerDas:      peerDas,
+		caplinConfig: caplinCfg,
+	}, peerDas
+}
+
+// An unset --caplin.columns-keep-slots must resolve to the chain's own window rather than a
+// fixed slot count, so a chain with shorter slots stops retaining twice what it needs.
+func TestCleanupAndPruningDerivesColumnRetentionFromTheChainConfig(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	beaconCfg := clparams.MainnetBeaconConfig
+	beaconCfg.SlotsPerEpoch = 16
+	beaconCfg.MinEpochsForDataColumnSidecarsRequests = 4096
+
+	cfg, peerDas := pruningCfg(t, ctrl, &beaconCfg, clparams.CaplinConfig{})
+	peerDas.EXPECT().Prune(uint64(65_552)).Return(nil)
+
+	require.NoError(t, cleanupAndPruning(t.Context(), log.New(), cfg, Args{}))
+}
+
+// An explicit value is a slot count and must reach the pruner unchanged.
+func TestCleanupAndPruningKeepsAnExplicitColumnSlotCount(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	beaconCfg := clparams.MainnetBeaconConfig
+
+	cfg, peerDas := pruningCfg(t, ctrl, &beaconCfg, clparams.CaplinConfig{ColumnKeepSlots: 4_242})
+	peerDas.EXPECT().Prune(uint64(4_242)).Return(nil)
+
+	require.NoError(t, cleanupAndPruning(t.Context(), log.New(), cfg, Args{}))
+}
+
+// The serving window starts at the first slot of current_epoch - MIN_EPOCHS, and the distance
+// also sets the earliest slot we advertise as servable, so it must never cut above that
+// boundary for any head position inside an epoch.
+func TestSpecColumnKeepSlotsNeverCutsAboveTheEpochBoundary(t *testing.T) {
+	beaconCfg := clparams.MainnetBeaconConfig
+	beaconCfg.SlotsPerEpoch = 16
+	beaconCfg.MinEpochsForDataColumnSidecarsRequests = 4096
+	keep := specColumnKeepSlots(&beaconCfg)
+
+	const epoch = 5000
+	for offset := uint64(0); offset < beaconCfg.SlotsPerEpoch; offset++ {
+		head := epoch*beaconCfg.SlotsPerEpoch + offset
+		required := (epoch - beaconCfg.MinEpochsForDataColumnSidecarsRequests) * beaconCfg.SlotsPerEpoch
+		require.LessOrEqual(t, head-keep, required,
+			"head %d cuts above the first slot the node must still serve", head)
+	}
+}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1024,8 +1024,8 @@ var (
 	}
 	CaplinColumnKeepSlotsFlag = cli.Uint64Flag{
 		Name:  "caplin.columns-keep-slots",
-		Usage: "number of slots to retain PeerDAS data column sidecars (default: MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS * SLOTS_PER_EPOCH = 131072, ~18 days); increase for DA oracle or rollup nodes that need longer column history",
-		Value: 131072,
+		Usage: "number of slots to retain PeerDAS data column sidecars; 0 uses the chain's spec window (MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS * SLOTS_PER_EPOCH), increase for DA oracle or rollup nodes that need longer column history",
+		Value: 0,
 	}
 	CaplinDisableCheckpointSyncFlag = cli.BoolFlag{
 		Name:  "caplin.checkpoint-sync.disable",

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/node/direct"
+	"github.com/erigontech/erigon/node/ethconfig"
 	"github.com/erigontech/erigon/p2p"
 )
 
@@ -303,6 +304,28 @@ func TestNewP2PConfig_DiscoveryDefaults(t *testing.T) {
 		require.True(t, cfg.NoDiscovery)
 		require.False(t, cfg.DiscoveryV5)
 	})
+}
+
+// The spec states column retention in epochs, so its slot count depends on SLOTS_PER_EPOCH.
+// Zero is the pruner's signal to derive the window from the active chain config, so an unset
+// flag must stay zero rather than pin one chain's slot count.
+func TestCaplinColumnKeepSlots_UnsetDefersToChainConfig(t *testing.T) {
+	parse := func(args ...string) uint64 {
+		keepSlots := CaplinColumnKeepSlotsFlag
+		cfg := ethconfig.Config{}
+		app := &cli.Command{
+			Flags: []cli.Flag{&keepSlots},
+			Action: func(_ context.Context, cmd *cli.Command) error {
+				setCaplin(cmd, &cfg)
+				return nil
+			},
+		}
+		require.NoError(t, app.Run(context.Background(), append([]string{"test"}, args...)))
+		return cfg.CaplinConfig.ColumnKeepSlots
+	}
+
+	require.Zero(t, parse(), "unset must defer to the chain config, not pin mainnet's slot count")
+	require.Equal(t, uint64(12345), parse("--caplin.columns-keep-slots=12345"), "a user-set window must reach the config")
 }
 
 func TestCommitmentPlainValuesFromCtx(t *testing.T) {

--- a/docs/site/docs/fundamentals/caplin.md
+++ b/docs/site/docs/fundamentals/caplin.md
@@ -34,7 +34,7 @@ With state archival enabled, Caplin's indexing database (`<datadir>/caplin/index
 
 For nodes participating in PeerDAS (EIP-7594), Caplin retains data column sidecars for a configurable window:
 
-* `--caplin.columns-keep-slots` (default: `131072`, ~18 days): Number of slots to retain PeerDAS data column sidecars. The default matches `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS × SLOTS_PER_EPOCH`. Increase this value for DA oracle or rollup nodes that require a longer column history.
+* `--caplin.columns-keep-slots` (default: `0`): Number of slots to retain PeerDAS data column sidecars. `0` uses the chain's own spec window, `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS × SLOTS_PER_EPOCH`, so the retained slot count and the wall-clock duration it covers both follow the chain (on Ethereum mainnet, 131072 slots, ~18 days). Increase this value for DA oracle or rollup nodes that require a longer column history.
 
 Caplin can also be used for [block production](../staking/caplin), aka **staking**.
 

--- a/docs/site/docs/fundamentals/configuring-erigon.mdx
+++ b/docs/site/docs/fundamentals/configuring-erigon.mdx
@@ -538,7 +538,7 @@ Flags for configuring the [Caplin](/fundamentals/caplin) consensus layer.
 * `--caplin.blobs-no-pruning`: Disables blob pruning.
   * Default: `false`
 * `--caplin.columns-keep-slots value`: Number of slots to retain PeerDAS data column sidecars. Increase for DA oracle or rollup nodes that need longer column history.
-  * Default: `131072` (~18 days)
+  * Default: `0` — uses the chain's spec window, `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS × SLOTS_PER_EPOCH`
 * `--caplin.checkpoint-sync.disable`: Disables checkpoint sync.
   * Default: `false`
 * `--caplin.snapgen`: Enables snapshot generation.

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -2156,7 +2156,7 @@ With state archival enabled, Caplin's indexing database (`<datadir>/caplin/index
 
 For nodes participating in PeerDAS (EIP-7594), Caplin retains data column sidecars for a configurable window:
 
-* `--caplin.columns-keep-slots` (default: `131072`, ~18 days): Number of slots to retain PeerDAS data column sidecars. The default matches `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS × SLOTS_PER_EPOCH`. Increase this value for DA oracle or rollup nodes that require a longer column history.
+* `--caplin.columns-keep-slots` (default: `0`): Number of slots to retain PeerDAS data column sidecars. `0` uses the chain's own spec window, `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS × SLOTS_PER_EPOCH`, so the retained slot count and the wall-clock duration it covers both follow the chain (on Ethereum mainnet, 131072 slots, ~18 days). Increase this value for DA oracle or rollup nodes that require a longer column history.
 
 Caplin can also be used for [block production](../staking/caplin), aka **staking**.
 
@@ -2719,7 +2719,7 @@ Flags for configuring the [Caplin](/fundamentals/caplin) consensus layer.
 * `--caplin.blobs-no-pruning`: Disables blob pruning.
   * Default: `false`
 * `--caplin.columns-keep-slots value`: Number of slots to retain PeerDAS data column sidecars. Increase for DA oracle or rollup nodes that need longer column history.
-  * Default: `131072` (~18 days)
+  * Default: `0` — uses the chain's spec window, `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS × SLOTS_PER_EPOCH`
 * `--caplin.checkpoint-sync.disable`: Disables checkpoint sync.
   * Default: `false`
 * `--caplin.snapgen`: Enables snapshot generation.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2156,7 +2156,7 @@ With state archival enabled, Caplin's indexing database (`<datadir>/caplin/index
 
 For nodes participating in PeerDAS (EIP-7594), Caplin retains data column sidecars for a configurable window:
 
-* `--caplin.columns-keep-slots` (default: `131072`, ~18 days): Number of slots to retain PeerDAS data column sidecars. The default matches `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS × SLOTS_PER_EPOCH`. Increase this value for DA oracle or rollup nodes that require a longer column history.
+* `--caplin.columns-keep-slots` (default: `0`): Number of slots to retain PeerDAS data column sidecars. `0` uses the chain's own spec window, `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS × SLOTS_PER_EPOCH`, so the retained slot count and the wall-clock duration it covers both follow the chain (on Ethereum mainnet, 131072 slots, ~18 days). Increase this value for DA oracle or rollup nodes that require a longer column history.
 
 Caplin can also be used for [block production](../staking/caplin), aka **staking**.
 
@@ -2719,7 +2719,7 @@ Flags for configuring the [Caplin](/fundamentals/caplin) consensus layer.
 * `--caplin.blobs-no-pruning`: Disables blob pruning.
   * Default: `false`
 * `--caplin.columns-keep-slots value`: Number of slots to retain PeerDAS data column sidecars. Increase for DA oracle or rollup nodes that need longer column history.
-  * Default: `131072` (~18 days)
+  * Default: `0` — uses the chain's spec window, `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS × SLOTS_PER_EPOCH`
 * `--caplin.checkpoint-sync.disable`: Disables checkpoint sync.
   * Default: `false`
 * `--caplin.snapgen`: Enables snapshot generation.


### PR DESCRIPTION
Cherry-pick of #23610 to `release/3.6`.

## r3.6-specific adaptations

`release/3.6` prunes columns by keep-distance (`peerDas.Prune(keepSlotDistance)`) rather than by
absolute floor (`PruneBelow`), so the original's `specColumnFloor` does not apply. The epoch
alignment lands instead as one extra epoch of slack in the derived distance:
`(MIN_EPOCHS + 1) * SLOTS_PER_EPOCH`.

That matters because the same distance sets `EarliestAvailableSlot` — the earliest slot we
advertise as servable — and `peerdas.Prune` computes it without the `subdivisionSlot` rounding
the on-disk path applies. An exact `MIN_EPOCHS * SLOTS_PER_EPOCH` distance therefore cuts above
the epoch boundary whenever the head sits inside an epoch, by up to `SLOTS_PER_EPOCH - 1` slots.
Note this is pre-existing on `release/3.6`, not introduced by defaulting the flag to `0`: the old
`131072` constant produced the same unaligned cut. Rounding up keeps the cut at or below the
boundary for any head position and needs no clock read in the stage.

Retention after this change: Gnosis and Chiado `4097 * 16 = 65552` slots, down from `131072`.
Mainnet `4097 * 32 = 131104`, i.e. one epoch more than before.

`cl/phase1/stages/cleanup_and_pruning_test.go` does not exist on this branch, so the original's
additions to it are replaced with a small file written against the keep-distance API, using
`memdb.NewTestDB` (this branch has no `mdbxtest`).

## Verification

Three new tests: the derived distance, an explicit slot count passing through unchanged, and the
boundary property checked across every head offset within an epoch. Mutation-verified — dropping
the `+1` fails the boundary test with `head 80001 cuts above the first slot the node must still
serve`, and restoring the `131072` flag default fails
`TestCaplinColumnKeepSlots_UnsetDefersToChainConfig`.

`cl/phase1/stages`, `cmd/utils` and `cl/clparams` pass; `make lint` clean.
