### PR TITLE
execution/types/sszblocks: add EIP-7807 payload root

### DIFF
--- a/execution/types/sszblocks/payload.go
+++ b/execution/types/sszblocks/payload.go
@@ -137,6 +137,9 @@ func ExecutionPayloadFromBlock(input *types.BlockWithReceipts, cfg BlockAdapterC
 	if header.RequestsHash == nil {
 		return nil, errors.New("header is missing execution requests hash")
 	}
+	if header.WithdrawalsHash == nil {
+		return nil, errors.New("header is missing withdrawals hash")
+	}
 	if len(header.Extra) > 32 {
 		return nil, fmt.Errorf("extra data length %d exceeds limit 32", len(header.Extra))
 	}
@@ -158,6 +161,10 @@ func ExecutionPayloadFromBlock(input *types.BlockWithReceipts, cfg BlockAdapterC
 	if err != nil {
 		return nil, err
 	}
+	transactionCommitment := types.DeriveSha(block.Transactions())
+	if transactionCommitment != header.TxHash {
+		return nil, fmt.Errorf("transaction hash mismatch: header %x, computed %x", header.TxHash, transactionCommitment)
+	}
 	receipts, err := encodeReceipts(input.Receipts)
 	if err != nil {
 		return nil, err
@@ -169,6 +176,10 @@ func ExecutionPayloadFromBlock(input *types.BlockWithReceipts, cfg BlockAdapterC
 	withdrawals, err := encodeWithdrawals(block.Withdrawals())
 	if err != nil {
 		return nil, err
+	}
+	withdrawalsCommitment := types.DeriveSha(block.Withdrawals())
+	if withdrawalsCommitment != *header.WithdrawalsHash {
+		return nil, fmt.Errorf("withdrawals hash mismatch: header %x, computed %x", *header.WithdrawalsHash, withdrawalsCommitment)
 	}
 	requestsHash, err := executionRequestsRoot(input.Requests, cfg.BeaconConfig)
 	if err != nil {

--- a/execution/types/sszblocks/payload.go
+++ b/execution/types/sszblocks/payload.go
@@ -113,6 +113,9 @@ func ExecutionPayloadFromBlock(input *types.BlockWithReceipts, cfg BlockAdapterC
 
 	block := input.Block
 	header := block.Header()
+	if !header.Number.IsUint64() {
+		return nil, errors.New("block number does not fit uint64")
+	}
 	if header.BaseFee == nil {
 		return nil, errors.New("header is missing base fee")
 	}
@@ -131,6 +134,9 @@ func ExecutionPayloadFromBlock(input *types.BlockWithReceipts, cfg BlockAdapterC
 	if header.BlockAccessListHash == nil {
 		return nil, errors.New("header is missing block access list hash")
 	}
+	if header.RequestsHash == nil {
+		return nil, errors.New("header is missing execution requests hash")
+	}
 	if len(header.Extra) > 32 {
 		return nil, fmt.Errorf("extra data length %d exceeds limit 32", len(header.Extra))
 	}
@@ -143,6 +149,10 @@ func ExecutionPayloadFromBlock(input *types.BlockWithReceipts, cfg BlockAdapterC
 	if len(block.Transactions()) != len(input.Receipts) {
 		return nil, fmt.Errorf("transaction and receipt counts differ: %d != %d", len(block.Transactions()), len(input.Receipts))
 	}
+	requestsCommitment := input.Requests.Hash()
+	if *requestsCommitment != *header.RequestsHash {
+		return nil, fmt.Errorf("execution requests hash mismatch: header %x, computed %x", *header.RequestsHash, *requestsCommitment)
+	}
 
 	transactions, err := encodeTransactions(block.Transactions())
 	if err != nil {
@@ -151,6 +161,10 @@ func ExecutionPayloadFromBlock(input *types.BlockWithReceipts, cfg BlockAdapterC
 	receipts, err := encodeReceipts(input.Receipts)
 	if err != nil {
 		return nil, err
+	}
+	receiptCommitment := types.DeriveSha(input.Receipts)
+	if receiptCommitment != header.ReceiptHash {
+		return nil, fmt.Errorf("receipt hash mismatch: header %x, computed %x", header.ReceiptHash, receiptCommitment)
 	}
 	withdrawals, err := encodeWithdrawals(block.Withdrawals())
 	if err != nil {

--- a/execution/types/sszblocks/payload.go
+++ b/execution/types/sszblocks/payload.go
@@ -1,0 +1,398 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package sszblocks
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/holiman/uint256"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/merkle_tree"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/crypto"
+	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/protocol/misc"
+	"github.com/erigontech/erigon/execution/rlp"
+	"github.com/erigontech/erigon/execution/types"
+)
+
+const executionPayloadFieldCount = 18
+
+type GasAmounts struct {
+	Regular uint64
+	Blob    uint64
+}
+
+func (g GasAmounts) HashSSZ() ([32]byte, error) {
+	return merkle_tree.ProgressiveContainerRootAll(g.Regular, g.Blob)
+}
+
+type BlobFeesPerGas struct {
+	Regular uint256.Int
+	Blob    uint256.Int
+}
+
+func (f BlobFeesPerGas) HashSSZ() ([32]byte, error) {
+	regular, err := f.Regular.MarshalSSZ()
+	if err != nil {
+		return [32]byte{}, err
+	}
+	blob, err := f.Blob.MarshalSSZ()
+	if err != nil {
+		return [32]byte{}, err
+	}
+	return merkle_tree.ProgressiveContainerRootAll(regular, blob)
+}
+
+type ExecutionPayload struct {
+	ParentHash            common.Hash
+	Miner                 common.Address
+	StateRoot             common.Hash
+	Transactions          [][]byte
+	Receipts              [][]byte
+	Number                uint64
+	GasLimits             GasAmounts
+	GasUsed               GasAmounts
+	Timestamp             uint64
+	ExtraData             []byte
+	MixHash               common.Hash
+	BaseFeesPerGas        BlobFeesPerGas
+	Withdrawals           [][]byte
+	ExcessGas             GasAmounts
+	ParentBeaconBlockRoot common.Hash
+	RequestsHash          common.Hash
+	BlockAccessList       []byte
+	SlotNumber            uint64
+}
+
+type BlockAdapterConfig struct {
+	ChainConfig  *chain.Config
+	BeaconConfig *clparams.BeaconChainConfig
+
+	// RegularExcessGas is explicit because the legacy Erigon header has no equivalent field.
+	RegularExcessGas *uint64
+}
+
+func ExecutionPayloadFromBlock(input *types.BlockWithReceipts, cfg BlockAdapterConfig) (*ExecutionPayload, error) {
+	if input == nil {
+		return nil, errors.New("nil block with receipts")
+	}
+	if input.Block == nil {
+		return nil, errors.New("nil block")
+	}
+	if cfg.ChainConfig == nil {
+		return nil, errors.New("nil chain config")
+	}
+	if cfg.BeaconConfig == nil {
+		return nil, errors.New("nil beacon config")
+	}
+	if cfg.RegularExcessGas == nil {
+		return nil, errors.New("regular excess gas is required")
+	}
+
+	block := input.Block
+	header := block.Header()
+	if header.BaseFee == nil {
+		return nil, errors.New("header is missing base fee")
+	}
+	if header.BlobGasUsed == nil {
+		return nil, errors.New("header is missing blob gas used")
+	}
+	if header.ExcessBlobGas == nil {
+		return nil, errors.New("header is missing excess blob gas")
+	}
+	if header.ParentBeaconBlockRoot == nil {
+		return nil, errors.New("header is missing parent beacon block root")
+	}
+	if header.SlotNumber == nil {
+		return nil, errors.New("header is missing slot number")
+	}
+	if header.BlockAccessListHash == nil {
+		return nil, errors.New("header is missing block access list hash")
+	}
+	if len(header.Extra) > 32 {
+		return nil, fmt.Errorf("extra data length %d exceeds limit 32", len(header.Extra))
+	}
+	if block.Withdrawals() == nil {
+		return nil, errors.New("block is missing withdrawals")
+	}
+	if input.Requests == nil {
+		return nil, errors.New("block is missing execution requests")
+	}
+	if len(block.Transactions()) != len(input.Receipts) {
+		return nil, fmt.Errorf("transaction and receipt counts differ: %d != %d", len(block.Transactions()), len(input.Receipts))
+	}
+
+	transactions, err := encodeTransactions(block.Transactions())
+	if err != nil {
+		return nil, err
+	}
+	receipts, err := encodeReceipts(input.Receipts)
+	if err != nil {
+		return nil, err
+	}
+	withdrawals, err := encodeWithdrawals(block.Withdrawals())
+	if err != nil {
+		return nil, err
+	}
+	requestsHash, err := executionRequestsRoot(input.Requests, cfg.BeaconConfig)
+	if err != nil {
+		return nil, err
+	}
+	blockAccessList, err := blockAccessListBytes(input)
+	if err != nil {
+		return nil, err
+	}
+	if got := crypto.Keccak256Hash(blockAccessList); got != *header.BlockAccessListHash {
+		return nil, fmt.Errorf("block access list hash mismatch: header %x, computed %x", *header.BlockAccessListHash, got)
+	}
+
+	blobConfig := cfg.ChainConfig.GetBlobConfig(header.Time)
+	if blobConfig == nil {
+		return nil, errors.New("chain config has no blob schedule for block timestamp")
+	}
+	blobBaseFee, err := misc.GetBlobGasPrice(cfg.ChainConfig, *header.ExcessBlobGas, header.Time)
+	if err != nil {
+		return nil, fmt.Errorf("compute blob base fee: %w", err)
+	}
+
+	return &ExecutionPayload{
+		ParentHash:   header.ParentHash,
+		Miner:        header.Coinbase,
+		StateRoot:    header.Root,
+		Transactions: transactions,
+		Receipts:     receipts,
+		Number:       header.Number.Uint64(),
+		GasLimits: GasAmounts{
+			Regular: header.GasLimit,
+			Blob:    cfg.ChainConfig.GetMaxBlobGasPerBlock(header.Time),
+		},
+		GasUsed: GasAmounts{
+			Regular: header.GasUsed,
+			Blob:    *header.BlobGasUsed,
+		},
+		Timestamp:      header.Time,
+		ExtraData:      bytes.Clone(header.Extra),
+		MixHash:        header.MixDigest,
+		BaseFeesPerGas: BlobFeesPerGas{Regular: *header.BaseFee, Blob: blobBaseFee},
+		Withdrawals:    withdrawals,
+		ExcessGas: GasAmounts{
+			Regular: *cfg.RegularExcessGas,
+			Blob:    *header.ExcessBlobGas,
+		},
+		ParentBeaconBlockRoot: *header.ParentBeaconBlockRoot,
+		RequestsHash:          common.Hash(requestsHash),
+		BlockAccessList:       blockAccessList,
+		SlotNumber:            *header.SlotNumber,
+	}, nil
+}
+
+func (p *ExecutionPayload) HashSSZ() ([32]byte, error) {
+	roots, err := p.FieldRoots()
+	if err != nil {
+		return [32]byte{}, err
+	}
+	schema := make([]any, len(roots))
+	for i := range roots {
+		schema[i] = roots[i][:]
+	}
+	return merkle_tree.ProgressiveContainerRootAll(schema...)
+}
+
+func (p *ExecutionPayload) FieldRoots() ([executionPayloadFieldCount][32]byte, error) {
+	var roots [executionPayloadFieldCount][32]byte
+	if p == nil {
+		return roots, errors.New("nil execution payload")
+	}
+	if len(p.ExtraData) > 32 {
+		return roots, fmt.Errorf("extra data length %d exceeds limit 32", len(p.ExtraData))
+	}
+
+	transactionsRoot, err := progressiveByteListListRoot(p.Transactions)
+	if err != nil {
+		return roots, fmt.Errorf("hash transactions: %w", err)
+	}
+	receiptsRoot, err := progressiveByteListListRoot(p.Receipts)
+	if err != nil {
+		return roots, fmt.Errorf("hash receipts: %w", err)
+	}
+	gasLimitsRoot, err := p.GasLimits.HashSSZ()
+	if err != nil {
+		return roots, fmt.Errorf("hash gas limits: %w", err)
+	}
+	gasUsedRoot, err := p.GasUsed.HashSSZ()
+	if err != nil {
+		return roots, fmt.Errorf("hash gas used: %w", err)
+	}
+	extraData := solid.NewExtraData()
+	extraData.SetBytes(p.ExtraData)
+	extraDataRoot, err := extraData.HashSSZ()
+	if err != nil {
+		return roots, fmt.Errorf("hash extra data: %w", err)
+	}
+	baseFeesRoot, err := p.BaseFeesPerGas.HashSSZ()
+	if err != nil {
+		return roots, fmt.Errorf("hash base fees per gas: %w", err)
+	}
+	withdrawalsRoot, err := progressiveByteListListRoot(p.Withdrawals)
+	if err != nil {
+		return roots, fmt.Errorf("hash withdrawals: %w", err)
+	}
+	excessGasRoot, err := p.ExcessGas.HashSSZ()
+	if err != nil {
+		return roots, fmt.Errorf("hash excess gas: %w", err)
+	}
+	blockAccessListRoot, err := merkle_tree.ProgressiveByteListRoot(p.BlockAccessList)
+	if err != nil {
+		return roots, fmt.Errorf("hash block access list: %w", err)
+	}
+
+	roots[0] = bytesRoot(p.ParentHash[:])
+	roots[1] = bytesRoot(p.Miner[:])
+	roots[2] = bytesRoot(p.StateRoot[:])
+	roots[3] = transactionsRoot
+	roots[4] = receiptsRoot
+	roots[5] = uint64Root(p.Number)
+	roots[6] = gasLimitsRoot
+	roots[7] = gasUsedRoot
+	roots[8] = uint64Root(p.Timestamp)
+	roots[9] = extraDataRoot
+	roots[10] = bytesRoot(p.MixHash[:])
+	roots[11] = baseFeesRoot
+	roots[12] = withdrawalsRoot
+	roots[13] = excessGasRoot
+	roots[14] = bytesRoot(p.ParentBeaconBlockRoot[:])
+	roots[15] = bytesRoot(p.RequestsHash[:])
+	roots[16] = blockAccessListRoot
+	roots[17] = uint64Root(p.SlotNumber)
+	return roots, nil
+}
+
+func encodeTransactions(transactions types.Transactions) ([][]byte, error) {
+	for i, transaction := range transactions {
+		if transaction == nil {
+			return nil, fmt.Errorf("transaction %d is nil", i)
+		}
+	}
+	encoded, err := types.MarshalTransactionsBinary(transactions)
+	if err != nil {
+		return nil, fmt.Errorf("encode transactions: %w", err)
+	}
+	return encoded, nil
+}
+
+func encodeReceipts(receipts types.Receipts) ([][]byte, error) {
+	encoded := make([][]byte, len(receipts))
+	for i, receipt := range receipts {
+		if receipt == nil {
+			return nil, fmt.Errorf("receipt %d is nil", i)
+		}
+		var err error
+		encoded[i], err = receipt.MarshalBinary()
+		if err != nil {
+			return nil, fmt.Errorf("encode receipt %d: %w", i, err)
+		}
+	}
+	return encoded, nil
+}
+
+func encodeWithdrawals(withdrawals types.Withdrawals) ([][]byte, error) {
+	encoded := make([][]byte, len(withdrawals))
+	for i, withdrawal := range withdrawals {
+		if withdrawal == nil {
+			return nil, fmt.Errorf("withdrawal %d is nil", i)
+		}
+		var err error
+		encoded[i], err = rlp.EncodeToBytes(withdrawal)
+		if err != nil {
+			return nil, fmt.Errorf("encode withdrawal %d: %w", i, err)
+		}
+	}
+	return encoded, nil
+}
+
+func executionRequestsRoot(requests types.FlatRequests, cfg *clparams.BeaconChainConfig) ([32]byte, error) {
+	encoded := make([]hexutil.Bytes, len(requests))
+	for i := range requests {
+		encoded[i] = requests[i].Encode()
+	}
+	decoded, err := cltypes.DecodeExecutionRequestsList(cfg, encoded, clparams.GloasVersion)
+	if err != nil {
+		return [32]byte{}, fmt.Errorf("decode execution requests: %w", err)
+	}
+	root, err := decoded.HashSSZ()
+	if err != nil {
+		return [32]byte{}, fmt.Errorf("hash execution requests: %w", err)
+	}
+	return root, nil
+}
+
+func blockAccessListBytes(input *types.BlockWithReceipts) ([]byte, error) {
+	var fromSidecar []byte
+	if sidecar := input.Block.BlockAccessListSidecar(); sidecar != nil {
+		var err error
+		fromSidecar, err = sidecar.Bytes()
+		if err != nil {
+			return nil, fmt.Errorf("encode block access list sidecar: %w", err)
+		}
+	}
+	if input.BlockAccessList == nil {
+		if fromSidecar == nil {
+			return nil, errors.New("block is missing block access list")
+		}
+		return bytes.Clone(fromSidecar), nil
+	}
+	fromResult, err := types.EncodeBlockAccessListBytes(input.BlockAccessList)
+	if err != nil {
+		return nil, fmt.Errorf("encode block access list: %w", err)
+	}
+	if fromSidecar != nil && !bytes.Equal(fromSidecar, fromResult) {
+		return nil, errors.New("block access list result differs from block sidecar")
+	}
+	return fromResult, nil
+}
+
+func progressiveByteListListRoot(items [][]byte) ([32]byte, error) {
+	roots := make([][32]byte, len(items))
+	for i := range items {
+		root, err := merkle_tree.ProgressiveByteListRoot(items[i])
+		if err != nil {
+			return [32]byte{}, err
+		}
+		roots[i] = root
+	}
+	return merkle_tree.ProgressiveListRoot(roots, uint64(len(roots)))
+}
+
+func bytesRoot(data []byte) [32]byte {
+	var root [32]byte
+	copy(root[:], data)
+	return root
+}
+
+func uint64Root(value uint64) [32]byte {
+	var root [32]byte
+	binary.LittleEndian.PutUint64(root[:], value)
+	return root
+}

--- a/execution/types/sszblocks/payload_test.go
+++ b/execution/types/sszblocks/payload_test.go
@@ -132,6 +132,38 @@ func TestExecutionPayloadFromBlockRejectsReceiptCountMismatch(t *testing.T) {
 	require.EqualError(t, err, "transaction and receipt counts differ: 2 != 1")
 }
 
+func TestExecutionPayloadFromBlockRejectsTransactionHashMismatch(t *testing.T) {
+	t.Parallel()
+
+	block, cfg := payloadFixture(t)
+	block.Block.Transactions()[0] = block.Block.Transactions()[1]
+	_, err := ExecutionPayloadFromBlock(block, cfg)
+	require.ErrorContains(t, err, "transaction hash mismatch")
+}
+
+func TestExecutionPayloadFromBlockRejectsMissingWithdrawalsHash(t *testing.T) {
+	t.Parallel()
+
+	block, cfg := payloadFixture(t)
+	header := block.Block.Header()
+	header.WithdrawalsHash = nil
+	block.Block = types.NewBlockFromNetwork(header, &types.Body{
+		Transactions: block.Block.Transactions(),
+		Withdrawals:  block.Block.Withdrawals(),
+	}, block.Block.BlockAccessListSidecar())
+	_, err := ExecutionPayloadFromBlock(block, cfg)
+	require.EqualError(t, err, "header is missing withdrawals hash")
+}
+
+func TestExecutionPayloadFromBlockRejectsWithdrawalsHashMismatch(t *testing.T) {
+	t.Parallel()
+
+	block, cfg := payloadFixture(t)
+	block.Block.Withdrawals()[0].Amount++
+	_, err := ExecutionPayloadFromBlock(block, cfg)
+	require.ErrorContains(t, err, "withdrawals hash mismatch")
+}
+
 func TestExecutionPayloadFromBlockRejectsReceiptHashMismatch(t *testing.T) {
 	t.Parallel()
 

--- a/execution/types/sszblocks/payload_test.go
+++ b/execution/types/sszblocks/payload_test.go
@@ -17,6 +17,7 @@
 package sszblocks
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
 	"testing"
@@ -78,22 +79,48 @@ func TestExecutionPayloadFromBlockRejectsMissingRequests(t *testing.T) {
 	require.EqualError(t, err, "block is missing execution requests")
 }
 
+func TestExecutionPayloadFromBlockRejectsMissingRequestsHash(t *testing.T) {
+	t.Parallel()
+
+	block, cfg := payloadFixture(t)
+	header := block.Block.Header()
+	header.RequestsHash = nil
+	replaceBlockHeader(block, header)
+	_, err := ExecutionPayloadFromBlock(block, cfg)
+	require.EqualError(t, err, "header is missing execution requests hash")
+}
+
+func TestExecutionPayloadFromBlockRejectsRequestsHashMismatch(t *testing.T) {
+	t.Parallel()
+
+	block, cfg := payloadFixture(t)
+	block.Requests = append(types.FlatRequests(nil), block.Requests...)
+	block.Requests[0].RequestData = bytes.Clone(block.Requests[0].RequestData)
+	block.Requests[0].RequestData[len(block.Requests[0].RequestData)-8]++
+	_, err := ExecutionPayloadFromBlock(block, cfg)
+	require.ErrorContains(t, err, "execution requests hash mismatch")
+}
+
 func TestExecutionPayloadFromBlockRejectsMissingSlotNumber(t *testing.T) {
 	t.Parallel()
 
 	block, cfg := payloadFixture(t)
 	header := block.Block.Header()
 	header.SlotNumber = nil
-	block.Block = types.NewBlock(
-		header,
-		block.Block.Transactions(),
-		nil,
-		block.Receipts,
-		block.Block.Withdrawals(),
-		block.Block.BlockAccessListSidecar(),
-	)
+	replaceBlockHeader(block, header)
 	_, err := ExecutionPayloadFromBlock(block, cfg)
 	require.EqualError(t, err, "header is missing slot number")
+}
+
+func TestExecutionPayloadFromBlockRejectsOversizedBlockNumber(t *testing.T) {
+	t.Parallel()
+
+	block, cfg := payloadFixture(t)
+	header := block.Block.Header()
+	header.Number.Lsh(uint256.NewInt(1), 64)
+	replaceBlockHeader(block, header)
+	_, err := ExecutionPayloadFromBlock(block, cfg)
+	require.EqualError(t, err, "block number does not fit uint64")
 }
 
 func TestExecutionPayloadFromBlockRejectsReceiptCountMismatch(t *testing.T) {
@@ -103,6 +130,15 @@ func TestExecutionPayloadFromBlockRejectsReceiptCountMismatch(t *testing.T) {
 	block.Receipts = block.Receipts[:1]
 	_, err := ExecutionPayloadFromBlock(block, cfg)
 	require.EqualError(t, err, "transaction and receipt counts differ: 2 != 1")
+}
+
+func TestExecutionPayloadFromBlockRejectsReceiptHashMismatch(t *testing.T) {
+	t.Parallel()
+
+	block, cfg := payloadFixture(t)
+	block.Receipts[0].Status = types.ReceiptStatusFailed
+	_, err := ExecutionPayloadFromBlock(block, cfg)
+	require.ErrorContains(t, err, "receipt hash mismatch")
 }
 
 func TestExecutionPayloadFromBlockRequiresRegularExcessGas(t *testing.T) {
@@ -138,6 +174,9 @@ func TestExecutionPayloadFromBlockRejectsDuplicateRequestType(t *testing.T) {
 
 	block, cfg := payloadFixture(t)
 	block.Requests = append(block.Requests, block.Requests[0])
+	header := block.Block.Header()
+	header.RequestsHash = block.Requests.Hash()
+	replaceBlockHeader(block, header)
 	_, err := ExecutionPayloadFromBlock(block, cfg)
 	require.EqualError(t, err, "decode execution requests: execution request type 1 is not strictly ascending")
 }
@@ -228,6 +267,17 @@ func payloadFixture(t *testing.T) (*types.BlockWithReceipts, BlockAdapterConfig)
 			BeaconConfig:     &beaconCfg,
 			RegularExcessGas: &regularExcessGas,
 		}
+}
+
+func replaceBlockHeader(block *types.BlockWithReceipts, header *types.Header) {
+	block.Block = types.NewBlock(
+		header,
+		block.Block.Transactions(),
+		nil,
+		block.Receipts,
+		block.Block.Withdrawals(),
+		block.Block.BlockAccessListSidecar(),
+	)
 }
 
 func referencePayloadRoot(t *testing.T, payload *ExecutionPayload) [32]byte {

--- a/execution/types/sszblocks/payload_test.go
+++ b/execution/types/sszblocks/payload_test.go
@@ -1,0 +1,354 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package sszblocks
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/protocol/params"
+	"github.com/erigontech/erigon/execution/types"
+)
+
+const eip7807FixtureRevision = "ethereum/EIPs EIPS/eip-7807.md blob 3f2dc991ac65153842fd9b894c04ba590d58d3e6, retrieved 2026-09-07"
+
+func TestExecutionPayloadFromBlockAndHashSSZ(t *testing.T) {
+	t.Parallel()
+
+	block, cfg := payloadFixture(t)
+	payload, err := ExecutionPayloadFromBlock(block, cfg)
+	require.NoError(t, err)
+
+	require.Equal(t, block.Block.ParentHash(), payload.ParentHash)
+	require.Equal(t, block.Block.Coinbase(), payload.Miner)
+	require.Equal(t, block.Block.Root(), payload.StateRoot)
+	require.Len(t, payload.Transactions, 2)
+	require.Equal(t, byte(types.DynamicFeeTxType), payload.Transactions[1][0])
+	require.Len(t, payload.Receipts, 2)
+	require.Len(t, payload.Withdrawals, 1)
+	require.Equal(t, []byte{0xc0}, payload.BlockAccessList)
+	require.Equal(t, uint64(2*params.GasPerBlob), payload.GasLimits.Blob)
+	require.Equal(t, uint64(7), payload.ExcessGas.Regular)
+	require.Equal(t, uint64(4096), payload.ExcessGas.Blob)
+	require.Equal(t, uint64(12345), payload.SlotNumber)
+
+	root, err := payload.HashSSZ()
+	require.NoError(t, err)
+	require.Equal(t, referencePayloadRoot(t, payload), root)
+	require.Equal(t,
+		common.HexToHash("0x012a1eff0c6a7e4a22fb624721866d10ddb94283c678e9e0117d9fddffc43a73"),
+		common.Hash(root),
+		eip7807FixtureRevision,
+	)
+
+	fieldRoots, err := payload.FieldRoots()
+	require.NoError(t, err)
+	require.NotEqual(t, block.Block.ReceiptHash(), common.Hash(fieldRoots[4]))
+	require.NotEqual(t, *block.Block.RequestsHash(), payload.RequestsHash)
+}
+
+func TestExecutionPayloadFromBlockRejectsMissingRequests(t *testing.T) {
+	t.Parallel()
+
+	block, cfg := payloadFixture(t)
+	block.Requests = nil
+	_, err := ExecutionPayloadFromBlock(block, cfg)
+	require.EqualError(t, err, "block is missing execution requests")
+}
+
+func TestExecutionPayloadFromBlockRejectsMissingSlotNumber(t *testing.T) {
+	t.Parallel()
+
+	block, cfg := payloadFixture(t)
+	header := block.Block.Header()
+	header.SlotNumber = nil
+	block.Block = types.NewBlock(
+		header,
+		block.Block.Transactions(),
+		nil,
+		block.Receipts,
+		block.Block.Withdrawals(),
+		block.Block.BlockAccessListSidecar(),
+	)
+	_, err := ExecutionPayloadFromBlock(block, cfg)
+	require.EqualError(t, err, "header is missing slot number")
+}
+
+func TestExecutionPayloadFromBlockRejectsReceiptCountMismatch(t *testing.T) {
+	t.Parallel()
+
+	block, cfg := payloadFixture(t)
+	block.Receipts = block.Receipts[:1]
+	_, err := ExecutionPayloadFromBlock(block, cfg)
+	require.EqualError(t, err, "transaction and receipt counts differ: 2 != 1")
+}
+
+func TestExecutionPayloadFromBlockRequiresRegularExcessGas(t *testing.T) {
+	t.Parallel()
+
+	block, cfg := payloadFixture(t)
+	cfg.RegularExcessGas = nil
+	_, err := ExecutionPayloadFromBlock(block, cfg)
+	require.EqualError(t, err, "regular excess gas is required")
+}
+
+func TestExecutionPayloadFromBlockUsesBlockAccessListSidecar(t *testing.T) {
+	t.Parallel()
+
+	block, cfg := payloadFixture(t)
+	block.BlockAccessList = nil
+	payload, err := ExecutionPayloadFromBlock(block, cfg)
+	require.NoError(t, err)
+	require.Equal(t, []byte{0xc0}, payload.BlockAccessList)
+}
+
+func TestExecutionPayloadFromBlockRejectsMismatchedBlockAccessLists(t *testing.T) {
+	t.Parallel()
+
+	block, cfg := payloadFixture(t)
+	block.BlockAccessList = types.BlockAccessList{{}}
+	_, err := ExecutionPayloadFromBlock(block, cfg)
+	require.EqualError(t, err, "block access list result differs from block sidecar")
+}
+
+func TestExecutionPayloadFromBlockRejectsDuplicateRequestType(t *testing.T) {
+	t.Parallel()
+
+	block, cfg := payloadFixture(t)
+	block.Requests = append(block.Requests, block.Requests[0])
+	_, err := ExecutionPayloadFromBlock(block, cfg)
+	require.EqualError(t, err, "decode execution requests: execution request type 1 is not strictly ascending")
+}
+
+func TestExecutionPayloadHashSSZRejectsOversizedExtraData(t *testing.T) {
+	t.Parallel()
+
+	payload := &ExecutionPayload{ExtraData: make([]byte, 33)}
+	_, err := payload.HashSSZ()
+	require.EqualError(t, err, "extra data length 33 exceeds limit 32")
+}
+
+func payloadFixture(t *testing.T) (*types.BlockWithReceipts, BlockAdapterConfig) {
+	t.Helper()
+
+	to := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	legacyTx := types.NewTransaction(1, to, uint256.NewInt(2), 21_000, uint256.NewInt(3), []byte{0xaa})
+	dynamicTx := &types.DynamicFeeTransaction{
+		CommonTx: types.CommonTx{
+			Nonce:    2,
+			GasLimit: 50_000,
+			To:       &to,
+			Value:    *uint256.NewInt(4),
+			Data:     []byte{0xbb, 0xcc},
+		},
+		ChainID: *uint256.NewInt(1),
+		TipCap:  *uint256.NewInt(5),
+		FeeCap:  *uint256.NewInt(6),
+	}
+	receipts := types.Receipts{
+		&types.Receipt{Type: types.LegacyTxType, Status: types.ReceiptStatusSuccessful, CumulativeGasUsed: 21_000},
+		&types.Receipt{Type: types.DynamicFeeTxType, Status: types.ReceiptStatusFailed, CumulativeGasUsed: 42_000},
+	}
+	withdrawals := types.Withdrawals{
+		&types.Withdrawal{Index: 1, Validator: 2, Address: to, Amount: 3},
+	}
+
+	beaconCfg := clparams.MainnetBeaconConfig
+	request := &solid.WithdrawalRequest{SourceAddress: to, Amount: 8}
+	requestData, err := request.EncodeSSZ(nil)
+	require.NoError(t, err)
+	requests := types.FlatRequests{{Type: byte(beaconCfg.WithdrawalRequestType), RequestData: requestData}}
+
+	bal := make(types.BlockAccessList, 0)
+	sidecar := types.NewBlockAccessListSidecar(bal)
+	balHash, err := sidecar.Hash()
+	require.NoError(t, err)
+
+	blobGasUsed := uint64(params.GasPerBlob)
+	excessBlobGas := uint64(4096)
+	parentBeaconBlockRoot := common.HexToHash("0x4444444444444444444444444444444444444444444444444444444444444444")
+	slotNumber := uint64(12345)
+	header := &types.Header{
+		ParentHash:            common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111"),
+		Coinbase:              common.HexToAddress("0x2222222222222222222222222222222222222222"),
+		Root:                  common.HexToHash("0x3333333333333333333333333333333333333333333333333333333333333333"),
+		Number:                *uint256.NewInt(99),
+		GasLimit:              30_000_000,
+		GasUsed:               42_000,
+		Time:                  1,
+		Extra:                 []byte{0xde, 0xad, 0xbe, 0xef},
+		MixDigest:             common.HexToHash("0x5555555555555555555555555555555555555555555555555555555555555555"),
+		BaseFee:               uint256.NewInt(1_000_000_000),
+		BlobGasUsed:           &blobGasUsed,
+		ExcessBlobGas:         &excessBlobGas,
+		ParentBeaconBlockRoot: &parentBeaconBlockRoot,
+		RequestsHash:          requests.Hash(),
+		BlockAccessListHash:   &balHash,
+		SlotNumber:            &slotNumber,
+	}
+	block := types.NewBlock(header, []types.Transaction{legacyTx, dynamicTx}, nil, receipts, withdrawals, sidecar)
+
+	zero := uint64(0)
+	chainCfg := &chain.Config{
+		CancunTime: &zero,
+		BlobSchedule: map[string]*params.BlobConfig{
+			"cancun": {Target: 1, Max: 2, BaseFeeUpdateFraction: 10_000},
+		},
+	}
+	regularExcessGas := uint64(7)
+	return &types.BlockWithReceipts{
+			Block:           block,
+			Receipts:        receipts,
+			Requests:        requests,
+			BlockAccessList: bal,
+		}, BlockAdapterConfig{
+			ChainConfig:      chainCfg,
+			BeaconConfig:     &beaconCfg,
+			RegularExcessGas: &regularExcessGas,
+		}
+}
+
+func referencePayloadRoot(t *testing.T, payload *ExecutionPayload) [32]byte {
+	t.Helper()
+
+	transactionRoots := make([][32]byte, len(payload.Transactions))
+	for i := range payload.Transactions {
+		transactionRoots[i] = referenceProgressiveByteListRoot(payload.Transactions[i])
+	}
+	receiptRoots := make([][32]byte, len(payload.Receipts))
+	for i := range payload.Receipts {
+		receiptRoots[i] = referenceProgressiveByteListRoot(payload.Receipts[i])
+	}
+	withdrawalRoots := make([][32]byte, len(payload.Withdrawals))
+	for i := range payload.Withdrawals {
+		withdrawalRoots[i] = referenceProgressiveByteListRoot(payload.Withdrawals[i])
+	}
+	regularFee, err := payload.BaseFeesPerGas.Regular.MarshalSSZ()
+	require.NoError(t, err)
+	blobFee, err := payload.BaseFeesPerGas.Blob.MarshalSSZ()
+	require.NoError(t, err)
+
+	fields := [][32]byte{
+		referenceBytesRoot(payload.ParentHash[:]),
+		referenceBytesRoot(payload.Miner[:]),
+		referenceBytesRoot(payload.StateRoot[:]),
+		referenceProgressiveListRoot(transactionRoots, uint64(len(transactionRoots))),
+		referenceProgressiveListRoot(receiptRoots, uint64(len(receiptRoots))),
+		referenceUint64Root(payload.Number),
+		referenceProgressiveContainerRoot([][32]byte{
+			referenceUint64Root(payload.GasLimits.Regular),
+			referenceUint64Root(payload.GasLimits.Blob),
+		}),
+		referenceProgressiveContainerRoot([][32]byte{
+			referenceUint64Root(payload.GasUsed.Regular),
+			referenceUint64Root(payload.GasUsed.Blob),
+		}),
+		referenceUint64Root(payload.Timestamp),
+		referenceByteListRoot(payload.ExtraData),
+		referenceBytesRoot(payload.MixHash[:]),
+		referenceProgressiveContainerRoot([][32]byte{
+			referenceBytesRoot(regularFee),
+			referenceBytesRoot(blobFee),
+		}),
+		referenceProgressiveListRoot(withdrawalRoots, uint64(len(withdrawalRoots))),
+		referenceProgressiveContainerRoot([][32]byte{
+			referenceUint64Root(payload.ExcessGas.Regular),
+			referenceUint64Root(payload.ExcessGas.Blob),
+		}),
+		referenceBytesRoot(payload.ParentBeaconBlockRoot[:]),
+		referenceBytesRoot(payload.RequestsHash[:]),
+		referenceProgressiveByteListRoot(payload.BlockAccessList),
+		referenceUint64Root(payload.SlotNumber),
+	}
+	return referenceProgressiveContainerRoot(fields)
+}
+
+func referenceProgressiveContainerRoot(fields [][32]byte) [32]byte {
+	activeFields := [32]byte{}
+	for i := range fields {
+		activeFields[i/8] |= 1 << uint(i%8)
+	}
+	return referenceHashPair(referenceMerkleizeProgressive(fields, 1), activeFields)
+}
+
+func referenceProgressiveByteListRoot(data []byte) [32]byte {
+	chunks := make([][32]byte, (len(data)+31)/32)
+	for i := range data {
+		chunks[i/32][i%32] = data[i]
+	}
+	return referenceProgressiveListRoot(chunks, uint64(len(data)))
+}
+
+func referenceByteListRoot(data []byte) [32]byte {
+	return referenceHashPair(referenceBytesRoot(data), referenceUint64Root(uint64(len(data))))
+}
+
+func referenceProgressiveListRoot(chunks [][32]byte, length uint64) [32]byte {
+	return referenceHashPair(referenceMerkleizeProgressive(chunks, 1), referenceUint64Root(length))
+}
+
+func referenceMerkleizeProgressive(chunks [][32]byte, capacity int) [32]byte {
+	if len(chunks) == 0 {
+		return [32]byte{}
+	}
+	count := min(len(chunks), capacity)
+	left := referenceMerkleizeVector(chunks[:count], capacity)
+	right := referenceMerkleizeProgressive(chunks[count:], capacity*4)
+	return referenceHashPair(left, right)
+}
+
+func referenceMerkleizeVector(chunks [][32]byte, capacity int) [32]byte {
+	nodes := make([][32]byte, capacity)
+	copy(nodes, chunks)
+	for len(nodes) > 1 {
+		next := make([][32]byte, len(nodes)/2)
+		for i := range next {
+			next[i] = referenceHashPair(nodes[i*2], nodes[i*2+1])
+		}
+		nodes = next
+	}
+	return nodes[0]
+}
+
+func referenceBytesRoot(data []byte) [32]byte {
+	chunks := make([][32]byte, max(1, (len(data)+31)/32))
+	for i := range data {
+		chunks[i/32][i%32] = data[i]
+	}
+	return referenceMerkleizeVector(chunks, len(chunks))
+}
+
+func referenceUint64Root(value uint64) [32]byte {
+	var root [32]byte
+	binary.LittleEndian.PutUint64(root[:], value)
+	return root
+}
+
+func referenceHashPair(left, right [32]byte) [32]byte {
+	var pair [64]byte
+	copy(pair[:32], left[:])
+	copy(pair[32:], right[:])
+	return sha256.Sum256(pair[:])
+}


### PR DESCRIPTION
## Summary

Adds a `BlockWithReceipts` adapter and SSZ root for the 18-field EIP-7807 payload. Preserves transaction/receipt envelopes and withdrawal/access-list RLP, validates header commitments, and computes `ReceiptsRoot` using existing progressive hashing helpers.

Intended consumer: #22821. Integration is not included; `excess_gas.regular` remains an explicit input because the existing header has no source for it.

## Specification

- EIP-7807 blob: `3f2dc991ac65153842fd9b894c04ba590d58d3e6`.
- Uses the three-field Electra `ExecutionRequests` from the linked consensus-specs revision `4f1df00ff567ea1855fb7f37ec23bd324a96703b`.

## Validation

The fixture was independently checked on 2026-09-14 with `remerkleable@2f0baeef0082d4278acaef7d822deb7009d7db7e` and `rlp==5.0.0`. This exposed and corrected the previous Gloas request-container mismatch. Go and Python agree on payload root:

`0x51951516710af90e8c20092e086f37232c69b558d6ba0035333982e115e1f627`

Passed locally: package tests, `go vet`, `make lint`, `make erigon integration`, and `git diff --check`.
