### PR TITLE
cl/network: make the slow-probe rotation test deterministic with synctest

### DIFF
--- a/cl/phase1/network/beacon_downloader_test.go
+++ b/cl/phase1/network/beacon_downloader_test.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -317,21 +318,6 @@ func TestForwardRequestMoreBoundsActiveProbes(t *testing.T) {
 }
 
 func TestForwardRequestMoreRotatesSlowP2PProbes(t *testing.T) {
-	previousInterval := forwardBeaconRequestInterval
-	previousTimeout := forwardBeaconRequestTimeout
-	previousProbeTimeout := forwardBeaconProbeTimeout
-	previousResponsePoll := forwardBeaconResponsePoll
-	forwardBeaconRequestInterval = 3 * time.Millisecond
-	forwardBeaconRequestTimeout = 300 * time.Millisecond
-	forwardBeaconProbeTimeout = 210 * time.Millisecond
-	forwardBeaconResponsePoll = time.Millisecond
-	t.Cleanup(func() {
-		forwardBeaconRequestInterval = previousInterval
-		forwardBeaconRequestTimeout = previousTimeout
-		forwardBeaconProbeTimeout = previousProbeTimeout
-		forwardBeaconResponsePoll = previousResponsePoll
-	})
-
 	cfg := clparams.MainnetBeaconConfig
 	cfg.InitializeForkSchedule()
 	clock := eth_clock.NewEthereumClock(uint64(time.Now().Unix()), common.Hash{}, &cfg)
@@ -343,37 +329,36 @@ func TestForwardRequestMoreRotatesSlowP2PProbes(t *testing.T) {
 	require.NoError(t, ssz_snappy.EncodeAndWrite(&response, block, digest[:]...))
 
 	sentinel := &rotatingProbeSentinel{response: response.Bytes(), canceled: make(chan struct{})}
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	rpcClient := rpc.NewBeaconRpcP2P(ctx, sentinel, &cfg, clock, nil)
-	downloader := NewForwardBeaconDownloader(ctx, rpcClient, &cfg)
-	processed := make(chan int, 1)
-	var processOnce sync.Once
-	downloader.SetProcessFunction(func(highest uint64, blocks []*cltypes.SignedBeaconBlock, _ map[common.Hash]*cltypes.SignedExecutionPayloadEnvelope) (uint64, error) {
-		processOnce.Do(func() { processed <- len(blocks) })
-		return highest, nil
+	// Outside the bubble: NewBeaconRpcP2P starts loops that outlive a request,
+	// and a bubble may not end while they are parked.
+	rpcClient := rpc.NewBeaconRpcP2P(t.Context(), sentinel, &cfg, clock, nil)
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+		downloader := NewForwardBeaconDownloader(ctx, rpcClient, &cfg)
+		processed := make(chan int, 1)
+		var processOnce sync.Once
+		downloader.SetProcessFunction(func(highest uint64, blocks []*cltypes.SignedBeaconBlock, _ map[common.Hash]*cltypes.SignedExecutionPayloadEnvelope) (uint64, error) {
+			processOnce.Do(func() { processed <- len(blocks) })
+			return highest, nil
+		})
+
+		done := make(chan struct{})
+		go func() {
+			downloader.RequestMore(ctx)
+			close(done)
+		}()
+
+		select {
+		case blockCount := <-processed:
+			require.Equal(t, 1, blockCount)
+		case <-done:
+			t.Fatal("request window ended before a healthy probe was processed")
+		}
+		<-sentinel.canceled
+		<-done
 	})
 
-	done := make(chan struct{})
-	go func() {
-		downloader.RequestMore(ctx)
-		close(done)
-	}()
-
-	select {
-	case blockCount := <-processed:
-		require.Equal(t, 1, blockCount)
-	case <-done:
-		t.Fatal("request window ended before a healthy probe was processed")
-	case <-time.After(time.Second):
-		t.Fatal("healthy probe was not processed")
-	}
-	select {
-	case <-sentinel.canceled:
-	case <-time.After(time.Second):
-		t.Fatal("slow probes were not canceled before the request window ended")
-	}
-	<-done
 	require.GreaterOrEqual(t, sentinel.calls.Load(), int32(3))
 	require.LessOrEqual(t, sentinel.maximum.Load(), int32(maxConcurrentForwardBeaconRequests))
 	require.Zero(t, sentinel.active.Load())

--- a/cl/phase1/network/beacon_downloader_test.go
+++ b/cl/phase1/network/beacon_downloader_test.go
@@ -328,12 +328,16 @@ func TestForwardRequestMoreRotatesSlowP2PProbes(t *testing.T) {
 	var response bytes.Buffer
 	require.NoError(t, ssz_snappy.EncodeAndWrite(&response, block, digest[:]...))
 
-	sentinel := &rotatingProbeSentinel{response: response.Bytes(), canceled: make(chan struct{})}
+	sentinel := &rotatingProbeSentinel{response: response.Bytes()}
 	// Outside the bubble: NewBeaconRpcP2P starts loops that outlive a request,
 	// and a bubble may not end while they are parked.
 	rpcClient := rpc.NewBeaconRpcP2P(t.Context(), sentinel, &cfg, clock, nil)
 
 	synctest.Test(t, func(t *testing.T) {
+		// synctest treats a receive as durably blocking only for a channel created
+		// inside the bubble, so this one cannot be built with the sentinel.
+		sentinel.canceled = make(chan struct{})
+
 		ctx := t.Context()
 		downloader := NewForwardBeaconDownloader(ctx, rpcClient, &cfg)
 		processed := make(chan int, 1)


### PR DESCRIPTION
## Problem

`TestForwardRequestMoreRotatesSlowP2PProbes` compressed the request window to 300ms against a 210ms probe timeout. That left 90ms for two probe rotations plus scheduling, and a loaded windows-2025 runner ended the window first:

```
--- FAIL: TestForwardRequestMoreRotatesSlowP2PProbes (0.30s)
    beacon_downloader_test.go:367: request window ended before a healthy probe was processed
```

The failing assertion is not about the behaviour under test. Probe rotation is genuinely time-based — probe timeout fires, attempt is cancelled, a new one starts — but the request window is scaffolding, and the test only passed while those two independent deadlines stayed far enough apart in wall-clock terms.

## Fix

Run the test inside a `testing/synctest` bubble. The bubble's fake clock only advances when every goroutine in it is durably blocked, so the rotation and the window are ordered by construction rather than by how fast the runner is.

That removes the tuning entirely:

- the four timing overrides are gone — the test now exercises the **shipped** values (30s window, 21s probe timeout, 300ms interval), which it never did before
- the two `time.After(time.Second)` guards are gone — a stalled bubble deadlocks with a goroutine dump instead of hanging
- runtime is 0.00s

`NewBeaconRpcP2P` is constructed outside the bubble: it starts background loops (an expirable-LRU janitor, `columnDataPeers.refreshPeers`) that outlive any single request, and a bubble may not end while goroutines are parked. Every deadline this test exercises is created inside `RequestMore`, so nothing under test leaves the bubble.

## Verification

- 50 sequential runs, 30 runs at `GOMAXPROCS=1` under 10 busy-spinning cores, and `-race`: all pass
- still fails for the right reason — replacing the probe `context.WithTimeout` with `context.WithCancel` (rotation disabled) fails in 0.00s with the same message

No skip added.