### PR TITLE
[r3.6] db/downloader: keep local snapshot data once the initial download is complete

### DIFF
--- a/db/downloader/download-batch.go
+++ b/db/downloader/download-batch.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/anacrolix/sync"
 	"github.com/anacrolix/torrent"
+
+	"github.com/erigontech/erigon/common/log/v3"
 )
 
 type downloadBatch struct {
@@ -38,12 +40,18 @@ func (me *downloadBatch) taskWaiter() {
 	}
 }
 
-func (me *downloadBatch) addDownload(item preverifiedSnapshot) error {
+func (me *downloadBatch) addDownload(ctx context.Context, item preverifiedSnapshot) error {
 	t, first, miOpt, err := me.d.addPreverifiedSnapshotForDownload(item.InfoHash, item.Name)
 	if err != nil {
 		return err
 	}
-	if t == nil { // local data kept
+	// A nil torrent means the local data was kept, so no download registers it and the file would
+	// be neither seeded nor visible in the stats. Not done at the keep site: deriving the metainfo
+	// hashes the whole file, and d.lock is held there.
+	if t == nil {
+		if err := me.d.AddNewSeedableFile(ctx, item.Name); err != nil {
+			me.d.log(log.LvlWarn, "seeding kept local snapshot", "name", item.Name, "err", err)
+		}
 		return nil
 	}
 	me.torrents = append(me.torrents, t)
@@ -66,7 +74,7 @@ func (me *downloadBatch) addAllItems(ctx context.Context, items []preverifiedSna
 		if ctx.Err() != nil {
 			return context.Cause(ctx)
 		}
-		err := me.addDownload(it)
+		err := me.addDownload(ctx, it)
 		if err != nil {
 			err = fmt.Errorf("downloading snapshot %s (infohash %s): %w", it.Name, it.InfoHash.HexString(), err)
 			return err

--- a/db/downloader/download-batch.go
+++ b/db/downloader/download-batch.go
@@ -43,6 +43,9 @@ func (me *downloadBatch) addDownload(item preverifiedSnapshot) error {
 	if err != nil {
 		return err
 	}
+	if t == nil { // local data kept
+		return nil
+	}
 	me.torrents = append(me.torrents, t)
 	if !first {
 		return nil

--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -57,6 +57,7 @@ import (
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dbg"
+	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/downloader/downloadercfg"
@@ -1000,6 +1001,17 @@ func (d *Downloader) testStartSingleDownloadNoWait(
 	return err
 }
 
+// Once preverified.toml is on disk the local files are what this node built or restored, so the
+// manifest no longer outranks them: data that is present is neither moved aside nor downloaded
+// over. Read every call, the snapshot stage writes the file mid-run.
+func (d *Downloader) keepLocalSnapshot(name snapshotName) (bool, error) {
+	complete, err := dir.FileExist(d.cfg.Dirs.PreverifiedPath())
+	if err != nil || !complete {
+		return false, err
+	}
+	return dir.FileExist(d.filePathForName(name))
+}
+
 func (d *Downloader) invalidateData(name snapshotName, infoHash metainfo.Hash) (err error) {
 	_, ok := d.torrentClient.Torrent(infoHash)
 	// Torrent in use, bad idea to proceed. This shouldn't happen since we should have found
@@ -1008,10 +1020,17 @@ func (d *Downloader) invalidateData(name snapshotName, infoHash metainfo.Hash) (
 	// Ensure the data isn't reused. We're presuming the storage in use, but we can't afford
 	// to wait until another torrent is fetched, and then we mistake a non-partial file with
 	// the correct size as being complete.
-	err = os.Rename(d.filePathForName(name), d.filePathForName(name+".part"))
-	if err != nil && errors.Is(err, os.ErrNotExist) {
-		err = nil
+	from := d.filePathForName(name)
+	to := d.filePathForName(name + ".part")
+	err = os.Rename(from, to)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			err = nil
+		}
+		return
 	}
+	d.log(log.LvlWarn, "invalidated local snapshot data, will re-download",
+		"name", name, "renamed_to", to, "preverified", infoHash)
 	return
 }
 
@@ -1056,8 +1075,10 @@ func (d *Downloader) addPreverifiedSnapshotForDownload(
 	}
 	// We can invalidate data if a torrent isn't yet loaded.
 	if !ok {
-		miOpt, err = d.loadMatchingMetainfoOrInvalidateData(infoHash, name)
-		if err != nil {
+		var keep bool
+		miOpt, keep, err = d.loadMatchingMetainfoOrInvalidateData(infoHash, name)
+		// A nil torrent tells the caller the local file was kept.
+		if err != nil || keep {
 			return
 		}
 		var new bool
@@ -1077,6 +1098,8 @@ func (d *Downloader) loadMatchingMetainfoOrInvalidateData(
 	name string,
 ) (
 	miOpt g.Option[*metainfo.MetaInfo],
+	// Local data was kept, so there is nothing to download.
+	keep bool,
 	err error,
 ) {
 	miOpt, err = d.maybeLoadMetainfoFromDisk(name)
@@ -1098,6 +1121,13 @@ func (d *Downloader) loadMatchingMetainfoOrInvalidateData(
 		miOpt.SetNone()
 	} else {
 		d.log(log.LvlDebug, "snapshot metainfo missing", "name", name)
+	}
+	keep, err = d.keepLocalSnapshot(name)
+	if err != nil || keep {
+		if keep {
+			d.log(log.LvlWarn, "keeping local snapshot, skipping preverified download", "name", name)
+		}
+		return
 	}
 	err = d.invalidateData(name, infoHash)
 	if err != nil {

--- a/db/downloader/downloader_test.go
+++ b/db/downloader/downloader_test.go
@@ -366,18 +366,25 @@ func TestKeepsLocalSnapshotAfterInitialDownload(t *testing.T) {
 				require.NoError(os.WriteFile(d.cfg.Dirs.PreverifiedPath(), nil, 0o644))
 			}
 
-			_, _, _, err := d.addPreverifiedSnapshotForDownload(snaptype.Hex2InfoHash("aa"), name)
-			require.NoError(err)
+			require.NoError(d.testStartSingleDownloadNoWait(t.Context(), snaptype.Hex2InfoHash("aa"), name))
 
 			if initialDownloadComplete {
 				require.FileExists(path)
 				require.NoFileExists(path+".part", "local data must survive once the initial download is complete")
+				require.Contains(activeSnapshotNames(d), name, "a kept snapshot must stay registered, or it is not seeded and not in the stats")
 			} else {
 				require.NoFileExists(path, "the manifest still outranks local data")
 				require.FileExists(path + ".part")
 			}
 		})
 	}
+}
+
+func activeSnapshotNames(d *Downloader) (names []string) {
+	for _, s := range d.allActiveSnapshots() {
+		names = append(names, s.Name)
+	}
+	return
 }
 
 // logBuffer is a log sink readable while the Downloader's goroutines write to it.

--- a/db/downloader/downloader_test.go
+++ b/db/downloader/downloader_test.go
@@ -17,6 +17,7 @@
 package downloader
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io/fs"
@@ -305,6 +306,10 @@ type downloaderTest struct {
 // newDownloaderTest creates a Downloader with proper cleanup handling.
 // All resources (cfg.TorrentLogFile and downloader) are automatically cleaned up via t.Cleanup.
 func newDownloaderTest(t *testing.T) *downloaderTest {
+	return newDownloaderTestWithLogger(t, log.New())
+}
+
+func newDownloaderTestWithLogger(t *testing.T, logger log.Logger) *downloaderTest {
 	require := require.New(t)
 
 	dirs := datadir.New(t.TempDir())
@@ -328,7 +333,7 @@ func newDownloaderTest(t *testing.T) *downloaderTest {
 		cfg.ClientConfig.DisableUTP = true
 	}
 
-	d, err := New(t.Context(), cfg, log.New())
+	d, err := New(t.Context(), cfg, logger)
 	require.NoError(err)
 
 	// Register cleanup in reverse order (downloader closes before config file)
@@ -344,5 +349,73 @@ func newDownloaderTest(t *testing.T) *downloaderTest {
 		dirs:       dirs,
 		cfg:        cfg,
 		downloader: d,
+	}
+}
+
+// Once preverified.toml is on disk the local file is what this node built or restored, so a
+// preverified download must not move it aside — whatever the manifest says its hash should be.
+func TestKeepsLocalSnapshotAfterInitialDownload(t *testing.T) {
+	for _, initialDownloadComplete := range []bool{false, true} {
+		t.Run(fmt.Sprint("initialDownloadComplete=", initialDownloadComplete), func(t *testing.T) {
+			require := require.New(t)
+			d := newDownloaderTest(t).downloader
+			const name = "v1.0-000000-000500-headers.seg"
+			path := filepath.Join(d.snapDir(), name)
+			require.NoError(os.WriteFile(path, []byte("built here"), 0o644))
+			if initialDownloadComplete {
+				require.NoError(os.WriteFile(d.cfg.Dirs.PreverifiedPath(), nil, 0o644))
+			}
+
+			_, _, _, err := d.addPreverifiedSnapshotForDownload(snaptype.Hex2InfoHash("aa"), name)
+			require.NoError(err)
+
+			if initialDownloadComplete {
+				require.FileExists(path)
+				require.NoFileExists(path+".part", "local data must survive once the initial download is complete")
+			} else {
+				require.NoFileExists(path, "the manifest still outranks local data")
+				require.FileExists(path + ".part")
+			}
+		})
+	}
+}
+
+// logBuffer is a log sink readable while the Downloader's goroutines write to it.
+type logBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *logBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *logBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// Renaming a snapshot away from completeness leaves a hole in the tier that surfaces much later
+// as a wrong read, so the operator has to be told which file it was.
+func TestInvalidatingLocalSnapshotIsLogged(t *testing.T) {
+	require := require.New(t)
+	logs := &logBuffer{}
+	logger := log.New()
+	logger.SetHandler(log.LvlFilterHandler(log.LvlWarn, log.StreamHandler(logs, log.TerminalFormat())))
+	d := newDownloaderTestWithLogger(t, logger).downloader
+
+	const name = "v1.0-000000-000500-headers.seg"
+	path := filepath.Join(d.snapDir(), name)
+	require.NoError(os.WriteFile(path, []byte("built here"), 0o644))
+
+	_, _, _, err := d.addPreverifiedSnapshotForDownload(snaptype.Hex2InfoHash("aa"), name)
+	require.NoError(err)
+	require.FileExists(path + ".part")
+
+	for _, want := range []string{"invalidated local snapshot data", name, ".part"} {
+		require.Contains(logs.String(), want)
 	}
 }


### PR DESCRIPTION
Minimal extract of the keep decision from #23350, plus the log #21522 asked for. Not a cherry-pick — #23350 and its follow-ups also add a seeding semaphore, batch cancellation accounting and metainfo repair, none of which is needed to stop data being lost.

Three changes:

- **The rename is no longer silent.** `invalidateData` logs at warn with the name, the `.part` path and the preverified hash. This was #21522's "at minimum" ask, and it covers the case the guard below does not.
- **A kept snapshot is still registered.** The keep path returns no torrent, and `addTorrent` is the only writer of `torrentsByName`, so without this the file would be neither seeded nor visible in the stats — a regression against today's rename-then-download. `addDownload` calls `AddNewSeedableFile` instead. (`AddNewSeedableFile` not calling `afterAdd` is a pre-existing 3.6 defect, fixed on main by #23653; separate backport.)
- **A completed datadir is not re-downloaded over.** Once `preverified.toml` is on disk, a snapshot that is present is kept. A missing file is still downloaded.

The incomplete path is otherwise unchanged: the manifest is still authoritative, so that data is still renamed — now audibly.

**Scope:** `SyncSnapshots` already skips download requests once `preverified.toml` exists (`snapshotsync.go:411`), so the guard is a second line of defence. It does not cover a datadir with no `preverified.toml` — deciding what should happen there changes the incomplete regime and needs its own PR. Hence `Refs`, not `Fixes`.

Measured on a real erigon node (mainnet), locally-differing `.seg` beside a mismatching `.torrent`:

| `preverified.toml` | 3.6 today | this PR |
| --- | --- | --- |
| present | kept, silent | kept, silent |
| absent | **replaced, silent** | replaced, **logged at warn** |

**Tests:** `TestKeepsLocalSnapshotAfterInitialDownload` (both regimes, driven through `addDownload` so the kept branch of the batch is covered, and asserting the kept name reaches `allActiveSnapshots()`) and `TestInvalidatingLocalSnapshotIsLogged`, each red first. `./db/downloader/...` green, `-race -count=2` green.

Note: `make lint` reports a gofmt issue in `db/snapshotsync/snapshots_test.go`, which is pre-existing on `release/3.6` and untouched here.

