### PR TITLE
db/downloader: skip malformed .torrent files in AddTorrentsFromDisk

### DIFF
--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -412,8 +412,8 @@ func (d *Downloader) AddTorrentsFromDisk(ctx context.Context) (incompleteTorrent
 			}
 			t, complete, new, err := d.addTorrentIfComplete(name)
 			if err != nil {
-				err = fmt.Errorf("adding torrent for %v: %w", path, err)
-				return err
+				d.log(log.LvlWarn, "add torrents from disk: skipping malformed torrent", "path", path, "err", err)
+				return nil
 			}
 			if !complete {
 				d.log(log.LvlDebug, "add torrents from disk: skipping incomplete torrent",

--- a/db/downloader/downloader_test.go
+++ b/db/downloader/downloader_test.go
@@ -1406,3 +1406,26 @@ func TestVerifyDataFailFastClosesFiles(t *testing.T) {
 	}
 	require.Less(openFdCount(t)-before, runs/2, "VerifyFileFailFast leaks a file descriptor per verified file")
 }
+
+func TestAddTorrentsFromDiskSkipsMalformedTorrent(t *testing.T) {
+	require := require.New(t)
+	test := newDownloaderTest(t)
+	d := test.downloader
+
+	corruptName := "0-corrupt.seg.torrent"
+	require.NoError(os.WriteFile(filepath.Join(test.dirs.Snap, corruptName), []byte("not a torrent"), 0o644))
+
+	segName := "v1-000000-001000-headers.seg"
+	require.NoError(os.WriteFile(filepath.Join(test.dirs.Snap, segName), []byte("headers data"), 0o644))
+	ok, err := BuildTorrentIfNeed(t.Context(), segName, test.dirs.Snap, d.torrentFS)
+	require.NoError(err)
+	require.True(ok)
+
+	incomplete, err := d.AddTorrentsFromDisk(t.Context())
+	require.NoError(err)
+	require.Zero(incomplete)
+
+	torrents := d.torrentClient.Torrents()
+	require.Len(torrents, 1)
+	require.Equal(segName, torrents[0].Name())
+}


### PR DESCRIPTION
A single unparseable .torrent aborted the fs.WalkDir callback, so every later torrent on disk was skipped and the error bubbled up into the post-sync snapshot step. 

Log a warning and continue the walk instead, matching the existing tolerance for filesystem walk errors.

Fixes #23754
