### PR TITLE
docs(site): close the flag, env-var and port coverage gaps found in the w37 audit

### DIFF
--- a/docs/site/docs/fundamentals/configuring-erigon.mdx
+++ b/docs/site/docs/fundamentals/configuring-erigon.mdx
@@ -182,6 +182,8 @@ Options for configuring the [transaction pool](/fundamentals/modules/txpool).
 * `--txpool.queued.dormancy value`: Evicts queued transactions from senders with no on-chain state changes for at least this duration (e.g. `3h`, `2h30m`).
   * Default: `3h0m0s`
   * Set to `0` to disable dormancy-based eviction.
+* `--aa`: Accepts account-abstraction (AA) transactions. Gates them both in the pool and during execution; with it unset they are rejected.
+  * Default: `false`
 
 ### Network and Peers
 
@@ -206,7 +208,9 @@ These flags manage network connectivity, peer discovery, and traffic control. Se
 * `--staticpeers value`: Comma-separated enode URLs to connect to.
 * `--trustedpeers value`: Comma-separated enode URLs for trusted peers.
 * `--maxpeers value`: The maximum number of network peers.
-  * Default: `32`
+  * Default: `64`
+* `--maxpendpeers value`: The maximum number of peers still completing the handshake, counted separately for inbound and outbound connections.
+  * Default: `1000`
 
 ### RPC & API
 
@@ -216,6 +220,12 @@ Flags for configuring various RPC servers and their behavior. See [Interacting w
   * Default: `127.0.0.1:9090`
 * `--private.api.ratelimit value`: Limits the number of simultaneous internal API requests.
   * Default: `31872`
+* `--tls`: Secures the internal gRPC API (`--private.api.addr`) with TLS. This does not affect the JSON-RPC HTTP server.
+  * Default: `false`
+  * `--tls.cert` and `--tls.key` are both required when this is set. If either is missing Erigon logs a warning and continues without TLS — and because it abandons the rest of that setup step, `--healthcheck` is silently dropped too.
+* `--tls.cert value`: Path to the certificate presented on the internal gRPC API.
+* `--tls.key value`: Path to the private key for `--tls.cert`.
+* `--tls.cacert value`: Path to the certificate authority used to verify gRPC clients. Setting it switches the server to mutual TLS: every gRPC client of `--private.api.addr` must then present a certificate signed by this CA, or the handshake is rejected. Leave it unset for server-only TLS. Read only when `--tls` is set.
 * `--http`: Enables the JSON-RPC HTTP server.
   * Default: `true`
 * `--http.enabled`: An alternative flag to enable the HTTP server.
@@ -356,6 +366,16 @@ Flags for configuring various RPC servers and their behavior. See [Interacting w
   * Default: `false`
 * `--witness.cache.maxmb value`: Resident-memory cap, in MB, for the witness cache; whichever limit binds first wins between the byte budget and `--witness.cache.blocks` (still capped at `96`). `0` means count-only (no byte cap).
   * Default: `0`
+* `--http.trace`: Logs every HTTP RPC request at INFO level.
+  * Default: `false`
+* `--http.dbg.single`: Accepts the `dbg: true` HTTP header on an RPC request and logs how that request was executed. Intended for debugging a single call, not for continuous use.
+  * Default: `false`
+* `--trace.maxtraces value`: Caps the number of traces `trace_filter` may return.
+  * Default: `200`
+* `--trace.compat`: Reproduces OpenEthereum's quirks in the `trace_` namespace, for consumers that depend on them.
+  * Default: `false`
+* `--ots.search.max.pagesize value`: Caps the page size accepted by the Otterscan (`ots_`) search methods.
+  * Default: `25`
 
 ### MCP Server
 
@@ -474,6 +494,12 @@ These flags control the block synchronization and data downloading process, incl
 * `--torrent.verbosity value`: Sets the verbosity level for BitTorrent logs. 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail (must set `--verbosity` to equal or higher level)
   * Default: `1`
 
+The two flags below are registered but hidden, so they do not appear in `erigon --help`, and neither changes any behaviour. They are listed here so their presence in an old command line is not mistaken for a working setting.
+
+* `--torrent.staticpeers value`: Accepted but inert — the binary marks it *"Currently unused"* and nothing reads the value.
+* `--torrent.download.slots value`: Accepted but inert — the binary marks it deprecated; it no longer affects how many files download in parallel. Unlike `--torrent.staticpeers`, setting it logs a `[DEPRECATED]` warning on every startup.
+  * Default: `32`
+
 ### Fork Choice Update (FCU)
 
 Flags for configuring Fork Choice Update behavior.
@@ -505,12 +531,10 @@ Flags for configuring the parallel block execution engine.
 * `--exec.state-cache`: Enable the executor's domain-shared read cache. Equivalent to `USE_STATE_CACHE=true`. Disable for cold-read performance measurements.
   * Default: `true`
 
-**Commitment-trie construction.** The following flags change how the commitment (state-root) trie is computed during execution.
+**Commitment-trie construction.** The following flag changes how the commitment (state-root) trie is computed during execution.
 
 * `--experimental.parallel-commitment` *(New in v3.6)*: Compute the commitment trie with the fully parallel `ParallelPatriciaHashed` implementation. Pass `--experimental.parallel-commitment=false`, or set `COMMITMENT_PARALLEL=false`, to fall back to the sequential `HexPatriciaHashed` trie.
   * Default: `true`
-* `--experimental.streaming-commitment` *(New in v3.6)* (experimental): Compute the commitment trie with the `StreamingCommitter`, which overlaps trie folding with block execution. If set, takes precedence over `--experimental.parallel-commitment`. No environment-variable equivalent.
-  * Default: `false`
 
 ### Caplin (Consensus Layer)
 
@@ -676,6 +700,26 @@ The budgets are not reserved up front. The account, storage and code caches star
 What that means for sizing: each of these state caches starts at `max(1024, shards × 16)` entries, capped by its own ceiling. The shard count is the smaller of the ceiling over 64 and `GOMAXPROCS × 16`, each rounded up to a power of two, so on a multi-core host the initial reservation is larger than the 1024-entry floor — with 8 cores it settles at 2048 entries once the budget is big enough to support that many shards. A `STATE_CACHE_CODE` below about 12 MiB is bounded by its ceiling instead and stays under 1024 entries. That initial capacity is reserved from the envelope at construction, not on first use: the two byte-bearing code layers take 24 MiB between them before a single block executes. Only growth beyond it is demand-driven, so twice `STATE_CACHE_CODE` is the largest reservation those layers can reach, not one they hold from the start. `STATE_CACHE_CODE_INDEX` differs again — it fixes its entry count at construction but never reserves envelope bytes at all.
 
 Budgets summing past the envelope therefore mean it *can* saturate, not that it will — that depends on the working set. With 32 GiB available to Erigon after limits the whole envelope is 1 GiB — below the roughly 2.2 GiB the envelope-backed caches can reserve under the defaults (accounts, storage, twice the code budget, and the size-only layer) — so a large enough working set saturates it; past that point raising the envelope-backed budgets together adds no aggregate capacity and only changes which cache wins the space left. Where more is available the envelope may never saturate, and there raising them does help. Mind that the figure follows the *lowest* of physical RAM, the cgroup limit and `GOMEMLIMIT`: a 32 GiB host running Erigon in an 8 GiB container gets a 256 MiB envelope, not 1 GiB. `STATE_CACHE_CODE_INDEX` sits outside the envelope altogether — its entry cap is fixed up front from the budget, so above the 1024-entry floor noted above, raising it adds index capacity independently of how saturated the envelope is.
+
+### Snapshot Download Variables
+
+These tune the downloader's HTTP and BitTorrent transport. They are read once at startup and have no CLI-flag equivalent; reach for them when snapshot downloads stall or a network path misbehaves.
+
+The four switches below are **presence-checked, not parsed** — the downloader tests them with `!= ""`, so any non-empty value turns the behaviour on. `DOWNLOADER_HTTP3=false` and `DOWNLOADER_HTTP3=0` both *enable* HTTP/3. Unset the variable to turn it off.
+
+* `DOWNLOADER_HTTP3` - Uses HTTP/3 for webseed requests
+* `DOWNLOADER_FORCE_IPV4` - Restricts webseed connections to IPv4
+* `DOWNLOADER_DISABLE_HTTP2` - Stops HTTP/2 being negotiated automatically, forcing HTTP/1.1
+* `DOWNLOADER_DISABLE_KEEP_ALIVES` - Disables connection reuse, giving one request per connection
+
+Setting `DOWNLOADER_HTTP3` replaces the whole HTTP transport, so the other six HTTP variables below and above are then ignored — they are still parsed, and an unparseable integer still panics.
+
+The four below are parsed as base-10 integers. **An unparseable value panics at startup** rather than falling back to the default, so set them to a bare number with no unit suffix.
+
+* `DOWNLOADER_MAX_CONNS_PER_HOST` - Concurrent connections per webseed host (default: `10`)
+* `DOWNLOADER_HTTP_READ_BUFFER_SIZE` - Read buffer for webseed HTTP responses, in bytes (default: `2097152`, i.e. 2 MiB)
+* `DOWNLOADER_TCP_READ_BUFFER_SIZE` - TCP read buffer size, in bytes (default: `0`, leaving the OS default in place)
+* `DOWNLOADER_NETWORK_CHUNK_SIZE` - BitTorrent chunk request size, in bytes (default: `262144`, i.e. 256 KiB)
 
 ### Memory and Debugging Variables
 

--- a/docs/site/docs/fundamentals/configuring-erigon.mdx
+++ b/docs/site/docs/fundamentals/configuring-erigon.mdx
@@ -496,7 +496,7 @@ These flags control the block synchronization and data downloading process, incl
 
 The two flags below are registered but hidden, so they do not appear in `erigon --help`, and neither changes any behaviour. They are listed here so their presence in an old command line is not mistaken for a working setting.
 
-* `--torrent.staticpeers value`: Accepted but inert — the binary marks it *"Currently unused"* and nothing reads the value.
+* `--torrent.staticpeers value`: Accepted but currently unused — nothing in the binary reads the value.
 * `--torrent.download.slots value`: Accepted but inert — the binary marks it deprecated; it no longer affects how many files download in parallel. Unlike `--torrent.staticpeers`, setting it logs a `[DEPRECATED]` warning on every startup.
   * Default: `32`
 

--- a/docs/site/docs/fundamentals/default-ports.md
+++ b/docs/site/docs/fundamentals/default-ports.md
@@ -56,6 +56,7 @@ Here is a comprehensive list of port-related options:
 
 * `--caplin.discovery.port [value]`: Port for Caplin DISCV5 protocol (default: `4000`)
 * `--caplin.discovery.tcpport [value]`: TCP Port for Caplin DISCV5 protocol (default: `4001`)
+* `--sentinel.port [value]`: Port the Caplin sentinel gRPC service listens on (default: `7777`)
 
 ### BeaconAPI
 

--- a/docs/site/docs/fundamentals/multiple-instances.md
+++ b/docs/site/docs/fundamentals/multiple-instances.md
@@ -183,7 +183,7 @@ Erigon itself consumes less than 2GB of RAM. Therefore, Erigon will benefit from
 ```
 
 ```yaml
-      --datadir=/home/erigon/.local/share/erigon --chain=dev --private.api.addr=0.0.0.0:9090 --mine --log.dir.path=/logs/node1
+      --datadir=/home/erigon/.local/share/erigon --chain=dev --private.api.addr=0.0.0.0:9090 --log.dir.path=/logs/node1
     ports:
       - "8551:8551"
     volumes:

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -2387,6 +2387,8 @@ Options for configuring the [transaction pool](/fundamentals/modules/txpool).
 * `--txpool.queued.dormancy value`: Evicts queued transactions from senders with no on-chain state changes for at least this duration (e.g. `3h`, `2h30m`).
   * Default: `3h0m0s`
   * Set to `0` to disable dormancy-based eviction.
+* `--aa`: Accepts account-abstraction (AA) transactions. Gates them both in the pool and during execution; with it unset they are rejected.
+  * Default: `false`
 
 ### Network and Peers
 
@@ -2411,7 +2413,9 @@ These flags manage network connectivity, peer discovery, and traffic control. Se
 * `--staticpeers value`: Comma-separated enode URLs to connect to.
 * `--trustedpeers value`: Comma-separated enode URLs for trusted peers.
 * `--maxpeers value`: The maximum number of network peers.
-  * Default: `32`
+  * Default: `64`
+* `--maxpendpeers value`: The maximum number of peers still completing the handshake, counted separately for inbound and outbound connections.
+  * Default: `1000`
 
 ### RPC & API
 
@@ -2421,6 +2425,12 @@ Flags for configuring various RPC servers and their behavior. See [Interacting w
   * Default: `127.0.0.1:9090`
 * `--private.api.ratelimit value`: Limits the number of simultaneous internal API requests.
   * Default: `31872`
+* `--tls`: Secures the internal gRPC API (`--private.api.addr`) with TLS. This does not affect the JSON-RPC HTTP server.
+  * Default: `false`
+  * `--tls.cert` and `--tls.key` are both required when this is set. If either is missing Erigon logs a warning and continues without TLS — and because it abandons the rest of that setup step, `--healthcheck` is silently dropped too.
+* `--tls.cert value`: Path to the certificate presented on the internal gRPC API.
+* `--tls.key value`: Path to the private key for `--tls.cert`.
+* `--tls.cacert value`: Path to the certificate authority used to verify gRPC clients. Setting it switches the server to mutual TLS: every gRPC client of `--private.api.addr` must then present a certificate signed by this CA, or the handshake is rejected. Leave it unset for server-only TLS. Read only when `--tls` is set.
 * `--http`: Enables the JSON-RPC HTTP server.
   * Default: `true`
 * `--http.enabled`: An alternative flag to enable the HTTP server.
@@ -2561,6 +2571,16 @@ Flags for configuring various RPC servers and their behavior. See [Interacting w
   * Default: `false`
 * `--witness.cache.maxmb value`: Resident-memory cap, in MB, for the witness cache; whichever limit binds first wins between the byte budget and `--witness.cache.blocks` (still capped at `96`). `0` means count-only (no byte cap).
   * Default: `0`
+* `--http.trace`: Logs every HTTP RPC request at INFO level.
+  * Default: `false`
+* `--http.dbg.single`: Accepts the `dbg: true` HTTP header on an RPC request and logs how that request was executed. Intended for debugging a single call, not for continuous use.
+  * Default: `false`
+* `--trace.maxtraces value`: Caps the number of traces `trace_filter` may return.
+  * Default: `200`
+* `--trace.compat`: Reproduces OpenEthereum's quirks in the `trace_` namespace, for consumers that depend on them.
+  * Default: `false`
+* `--ots.search.max.pagesize value`: Caps the page size accepted by the Otterscan (`ots_`) search methods.
+  * Default: `25`
 
 ### MCP Server
 
@@ -2679,6 +2699,12 @@ These flags control the block synchronization and data downloading process, incl
 * `--torrent.verbosity value`: Sets the verbosity level for BitTorrent logs. 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail (must set `--verbosity` to equal or higher level)
   * Default: `1`
 
+The two flags below are registered but hidden, so they do not appear in `erigon --help`, and neither changes any behaviour. They are listed here so their presence in an old command line is not mistaken for a working setting.
+
+* `--torrent.staticpeers value`: Accepted but inert — the binary marks it *"Currently unused"* and nothing reads the value.
+* `--torrent.download.slots value`: Accepted but inert — the binary marks it deprecated; it no longer affects how many files download in parallel. Unlike `--torrent.staticpeers`, setting it logs a `[DEPRECATED]` warning on every startup.
+  * Default: `32`
+
 ### Fork Choice Update (FCU)
 
 Flags for configuring Fork Choice Update behavior.
@@ -2710,12 +2736,10 @@ Flags for configuring the parallel block execution engine.
 * `--exec.state-cache`: Enable the executor's domain-shared read cache. Equivalent to `USE_STATE_CACHE=true`. Disable for cold-read performance measurements.
   * Default: `true`
 
-**Commitment-trie construction.** The following flags change how the commitment (state-root) trie is computed during execution.
+**Commitment-trie construction.** The following flag changes how the commitment (state-root) trie is computed during execution.
 
 * `--experimental.parallel-commitment` *(New in v3.6)*: Compute the commitment trie with the fully parallel `ParallelPatriciaHashed` implementation. Pass `--experimental.parallel-commitment=false`, or set `COMMITMENT_PARALLEL=false`, to fall back to the sequential `HexPatriciaHashed` trie.
   * Default: `true`
-* `--experimental.streaming-commitment` *(New in v3.6)* (experimental): Compute the commitment trie with the `StreamingCommitter`, which overlaps trie folding with block execution. If set, takes precedence over `--experimental.parallel-commitment`. No environment-variable equivalent.
-  * Default: `false`
 
 ### Caplin (Consensus Layer)
 
@@ -2881,6 +2905,26 @@ The budgets are not reserved up front. The account, storage and code caches star
 What that means for sizing: each of these state caches starts at `max(1024, shards × 16)` entries, capped by its own ceiling. The shard count is the smaller of the ceiling over 64 and `GOMAXPROCS × 16`, each rounded up to a power of two, so on a multi-core host the initial reservation is larger than the 1024-entry floor — with 8 cores it settles at 2048 entries once the budget is big enough to support that many shards. A `STATE_CACHE_CODE` below about 12 MiB is bounded by its ceiling instead and stays under 1024 entries. That initial capacity is reserved from the envelope at construction, not on first use: the two byte-bearing code layers take 24 MiB between them before a single block executes. Only growth beyond it is demand-driven, so twice `STATE_CACHE_CODE` is the largest reservation those layers can reach, not one they hold from the start. `STATE_CACHE_CODE_INDEX` differs again — it fixes its entry count at construction but never reserves envelope bytes at all.
 
 Budgets summing past the envelope therefore mean it *can* saturate, not that it will — that depends on the working set. With 32 GiB available to Erigon after limits the whole envelope is 1 GiB — below the roughly 2.2 GiB the envelope-backed caches can reserve under the defaults (accounts, storage, twice the code budget, and the size-only layer) — so a large enough working set saturates it; past that point raising the envelope-backed budgets together adds no aggregate capacity and only changes which cache wins the space left. Where more is available the envelope may never saturate, and there raising them does help. Mind that the figure follows the *lowest* of physical RAM, the cgroup limit and `GOMEMLIMIT`: a 32 GiB host running Erigon in an 8 GiB container gets a 256 MiB envelope, not 1 GiB. `STATE_CACHE_CODE_INDEX` sits outside the envelope altogether — its entry cap is fixed up front from the budget, so above the 1024-entry floor noted above, raising it adds index capacity independently of how saturated the envelope is.
+
+### Snapshot Download Variables
+
+These tune the downloader's HTTP and BitTorrent transport. They are read once at startup and have no CLI-flag equivalent; reach for them when snapshot downloads stall or a network path misbehaves.
+
+The four switches below are **presence-checked, not parsed** — the downloader tests them with `!= ""`, so any non-empty value turns the behaviour on. `DOWNLOADER_HTTP3=false` and `DOWNLOADER_HTTP3=0` both *enable* HTTP/3. Unset the variable to turn it off.
+
+* `DOWNLOADER_HTTP3` - Uses HTTP/3 for webseed requests
+* `DOWNLOADER_FORCE_IPV4` - Restricts webseed connections to IPv4
+* `DOWNLOADER_DISABLE_HTTP2` - Stops HTTP/2 being negotiated automatically, forcing HTTP/1.1
+* `DOWNLOADER_DISABLE_KEEP_ALIVES` - Disables connection reuse, giving one request per connection
+
+Setting `DOWNLOADER_HTTP3` replaces the whole HTTP transport, so the other six HTTP variables below and above are then ignored — they are still parsed, and an unparseable integer still panics.
+
+The four below are parsed as base-10 integers. **An unparseable value panics at startup** rather than falling back to the default, so set them to a bare number with no unit suffix.
+
+* `DOWNLOADER_MAX_CONNS_PER_HOST` - Concurrent connections per webseed host (default: `10`)
+* `DOWNLOADER_HTTP_READ_BUFFER_SIZE` - Read buffer for webseed HTTP responses, in bytes (default: `2097152`, i.e. 2 MiB)
+* `DOWNLOADER_TCP_READ_BUFFER_SIZE` - TCP read buffer size, in bytes (default: `0`, leaving the OS default in place)
+* `DOWNLOADER_NETWORK_CHUNK_SIZE` - BitTorrent chunk request size, in bytes (default: `262144`, i.e. 256 KiB)
 
 ### Memory and Debugging Variables
 
@@ -3058,6 +3102,7 @@ Here is a comprehensive list of port-related options:
 
 * `--caplin.discovery.port [value]`: Port for Caplin DISCV5 protocol (default: `4000`)
 * `--caplin.discovery.tcpport [value]`: TCP Port for Caplin DISCV5 protocol (default: `4001`)
+* `--sentinel.port [value]`: Port the Caplin sentinel gRPC service listens on (default: `7777`)
 
 ### BeaconAPI
 
@@ -3488,7 +3533,7 @@ Erigon itself consumes less than 2GB of RAM. Therefore, Erigon will benefit from
 ```
 
 ```yaml
-      --datadir=/home/erigon/.local/share/erigon --chain=dev --private.api.addr=0.0.0.0:9090 --mine --log.dir.path=/logs/node1
+      --datadir=/home/erigon/.local/share/erigon --chain=dev --private.api.addr=0.0.0.0:9090 --log.dir.path=/logs/node1
     ports:
       - "8551:8551"
     volumes:

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -2701,7 +2701,7 @@ These flags control the block synchronization and data downloading process, incl
 
 The two flags below are registered but hidden, so they do not appear in `erigon --help`, and neither changes any behaviour. They are listed here so their presence in an old command line is not mistaken for a working setting.
 
-* `--torrent.staticpeers value`: Accepted but inert — the binary marks it *"Currently unused"* and nothing reads the value.
+* `--torrent.staticpeers value`: Accepted but currently unused — nothing in the binary reads the value.
 * `--torrent.download.slots value`: Accepted but inert — the binary marks it deprecated; it no longer affects how many files download in parallel. Unlike `--torrent.staticpeers`, setting it logs a `[DEPRECATED]` warning on every startup.
   * Default: `32`
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2387,6 +2387,8 @@ Options for configuring the [transaction pool](/fundamentals/modules/txpool).
 * `--txpool.queued.dormancy value`: Evicts queued transactions from senders with no on-chain state changes for at least this duration (e.g. `3h`, `2h30m`).
   * Default: `3h0m0s`
   * Set to `0` to disable dormancy-based eviction.
+* `--aa`: Accepts account-abstraction (AA) transactions. Gates them both in the pool and during execution; with it unset they are rejected.
+  * Default: `false`
 
 ### Network and Peers
 
@@ -2411,7 +2413,9 @@ These flags manage network connectivity, peer discovery, and traffic control. Se
 * `--staticpeers value`: Comma-separated enode URLs to connect to.
 * `--trustedpeers value`: Comma-separated enode URLs for trusted peers.
 * `--maxpeers value`: The maximum number of network peers.
-  * Default: `32`
+  * Default: `64`
+* `--maxpendpeers value`: The maximum number of peers still completing the handshake, counted separately for inbound and outbound connections.
+  * Default: `1000`
 
 ### RPC & API
 
@@ -2421,6 +2425,12 @@ Flags for configuring various RPC servers and their behavior. See [Interacting w
   * Default: `127.0.0.1:9090`
 * `--private.api.ratelimit value`: Limits the number of simultaneous internal API requests.
   * Default: `31872`
+* `--tls`: Secures the internal gRPC API (`--private.api.addr`) with TLS. This does not affect the JSON-RPC HTTP server.
+  * Default: `false`
+  * `--tls.cert` and `--tls.key` are both required when this is set. If either is missing Erigon logs a warning and continues without TLS — and because it abandons the rest of that setup step, `--healthcheck` is silently dropped too.
+* `--tls.cert value`: Path to the certificate presented on the internal gRPC API.
+* `--tls.key value`: Path to the private key for `--tls.cert`.
+* `--tls.cacert value`: Path to the certificate authority used to verify gRPC clients. Setting it switches the server to mutual TLS: every gRPC client of `--private.api.addr` must then present a certificate signed by this CA, or the handshake is rejected. Leave it unset for server-only TLS. Read only when `--tls` is set.
 * `--http`: Enables the JSON-RPC HTTP server.
   * Default: `true`
 * `--http.enabled`: An alternative flag to enable the HTTP server.
@@ -2561,6 +2571,16 @@ Flags for configuring various RPC servers and their behavior. See [Interacting w
   * Default: `false`
 * `--witness.cache.maxmb value`: Resident-memory cap, in MB, for the witness cache; whichever limit binds first wins between the byte budget and `--witness.cache.blocks` (still capped at `96`). `0` means count-only (no byte cap).
   * Default: `0`
+* `--http.trace`: Logs every HTTP RPC request at INFO level.
+  * Default: `false`
+* `--http.dbg.single`: Accepts the `dbg: true` HTTP header on an RPC request and logs how that request was executed. Intended for debugging a single call, not for continuous use.
+  * Default: `false`
+* `--trace.maxtraces value`: Caps the number of traces `trace_filter` may return.
+  * Default: `200`
+* `--trace.compat`: Reproduces OpenEthereum's quirks in the `trace_` namespace, for consumers that depend on them.
+  * Default: `false`
+* `--ots.search.max.pagesize value`: Caps the page size accepted by the Otterscan (`ots_`) search methods.
+  * Default: `25`
 
 ### MCP Server
 
@@ -2679,6 +2699,12 @@ These flags control the block synchronization and data downloading process, incl
 * `--torrent.verbosity value`: Sets the verbosity level for BitTorrent logs. 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail (must set `--verbosity` to equal or higher level)
   * Default: `1`
 
+The two flags below are registered but hidden, so they do not appear in `erigon --help`, and neither changes any behaviour. They are listed here so their presence in an old command line is not mistaken for a working setting.
+
+* `--torrent.staticpeers value`: Accepted but inert — the binary marks it *"Currently unused"* and nothing reads the value.
+* `--torrent.download.slots value`: Accepted but inert — the binary marks it deprecated; it no longer affects how many files download in parallel. Unlike `--torrent.staticpeers`, setting it logs a `[DEPRECATED]` warning on every startup.
+  * Default: `32`
+
 ### Fork Choice Update (FCU)
 
 Flags for configuring Fork Choice Update behavior.
@@ -2710,12 +2736,10 @@ Flags for configuring the parallel block execution engine.
 * `--exec.state-cache`: Enable the executor's domain-shared read cache. Equivalent to `USE_STATE_CACHE=true`. Disable for cold-read performance measurements.
   * Default: `true`
 
-**Commitment-trie construction.** The following flags change how the commitment (state-root) trie is computed during execution.
+**Commitment-trie construction.** The following flag changes how the commitment (state-root) trie is computed during execution.
 
 * `--experimental.parallel-commitment` *(New in v3.6)*: Compute the commitment trie with the fully parallel `ParallelPatriciaHashed` implementation. Pass `--experimental.parallel-commitment=false`, or set `COMMITMENT_PARALLEL=false`, to fall back to the sequential `HexPatriciaHashed` trie.
   * Default: `true`
-* `--experimental.streaming-commitment` *(New in v3.6)* (experimental): Compute the commitment trie with the `StreamingCommitter`, which overlaps trie folding with block execution. If set, takes precedence over `--experimental.parallel-commitment`. No environment-variable equivalent.
-  * Default: `false`
 
 ### Caplin (Consensus Layer)
 
@@ -2881,6 +2905,26 @@ The budgets are not reserved up front. The account, storage and code caches star
 What that means for sizing: each of these state caches starts at `max(1024, shards × 16)` entries, capped by its own ceiling. The shard count is the smaller of the ceiling over 64 and `GOMAXPROCS × 16`, each rounded up to a power of two, so on a multi-core host the initial reservation is larger than the 1024-entry floor — with 8 cores it settles at 2048 entries once the budget is big enough to support that many shards. A `STATE_CACHE_CODE` below about 12 MiB is bounded by its ceiling instead and stays under 1024 entries. That initial capacity is reserved from the envelope at construction, not on first use: the two byte-bearing code layers take 24 MiB between them before a single block executes. Only growth beyond it is demand-driven, so twice `STATE_CACHE_CODE` is the largest reservation those layers can reach, not one they hold from the start. `STATE_CACHE_CODE_INDEX` differs again — it fixes its entry count at construction but never reserves envelope bytes at all.
 
 Budgets summing past the envelope therefore mean it *can* saturate, not that it will — that depends on the working set. With 32 GiB available to Erigon after limits the whole envelope is 1 GiB — below the roughly 2.2 GiB the envelope-backed caches can reserve under the defaults (accounts, storage, twice the code budget, and the size-only layer) — so a large enough working set saturates it; past that point raising the envelope-backed budgets together adds no aggregate capacity and only changes which cache wins the space left. Where more is available the envelope may never saturate, and there raising them does help. Mind that the figure follows the *lowest* of physical RAM, the cgroup limit and `GOMEMLIMIT`: a 32 GiB host running Erigon in an 8 GiB container gets a 256 MiB envelope, not 1 GiB. `STATE_CACHE_CODE_INDEX` sits outside the envelope altogether — its entry cap is fixed up front from the budget, so above the 1024-entry floor noted above, raising it adds index capacity independently of how saturated the envelope is.
+
+### Snapshot Download Variables
+
+These tune the downloader's HTTP and BitTorrent transport. They are read once at startup and have no CLI-flag equivalent; reach for them when snapshot downloads stall or a network path misbehaves.
+
+The four switches below are **presence-checked, not parsed** — the downloader tests them with `!= ""`, so any non-empty value turns the behaviour on. `DOWNLOADER_HTTP3=false` and `DOWNLOADER_HTTP3=0` both *enable* HTTP/3. Unset the variable to turn it off.
+
+* `DOWNLOADER_HTTP3` - Uses HTTP/3 for webseed requests
+* `DOWNLOADER_FORCE_IPV4` - Restricts webseed connections to IPv4
+* `DOWNLOADER_DISABLE_HTTP2` - Stops HTTP/2 being negotiated automatically, forcing HTTP/1.1
+* `DOWNLOADER_DISABLE_KEEP_ALIVES` - Disables connection reuse, giving one request per connection
+
+Setting `DOWNLOADER_HTTP3` replaces the whole HTTP transport, so the other six HTTP variables below and above are then ignored — they are still parsed, and an unparseable integer still panics.
+
+The four below are parsed as base-10 integers. **An unparseable value panics at startup** rather than falling back to the default, so set them to a bare number with no unit suffix.
+
+* `DOWNLOADER_MAX_CONNS_PER_HOST` - Concurrent connections per webseed host (default: `10`)
+* `DOWNLOADER_HTTP_READ_BUFFER_SIZE` - Read buffer for webseed HTTP responses, in bytes (default: `2097152`, i.e. 2 MiB)
+* `DOWNLOADER_TCP_READ_BUFFER_SIZE` - TCP read buffer size, in bytes (default: `0`, leaving the OS default in place)
+* `DOWNLOADER_NETWORK_CHUNK_SIZE` - BitTorrent chunk request size, in bytes (default: `262144`, i.e. 256 KiB)
 
 ### Memory and Debugging Variables
 
@@ -3058,6 +3102,7 @@ Here is a comprehensive list of port-related options:
 
 * `--caplin.discovery.port [value]`: Port for Caplin DISCV5 protocol (default: `4000`)
 * `--caplin.discovery.tcpport [value]`: TCP Port for Caplin DISCV5 protocol (default: `4001`)
+* `--sentinel.port [value]`: Port the Caplin sentinel gRPC service listens on (default: `7777`)
 
 ### BeaconAPI
 
@@ -3488,7 +3533,7 @@ Erigon itself consumes less than 2GB of RAM. Therefore, Erigon will benefit from
 ```
 
 ```yaml
-      --datadir=/home/erigon/.local/share/erigon --chain=dev --private.api.addr=0.0.0.0:9090 --mine --log.dir.path=/logs/node1
+      --datadir=/home/erigon/.local/share/erigon --chain=dev --private.api.addr=0.0.0.0:9090 --log.dir.path=/logs/node1
     ports:
       - "8551:8551"
     volumes:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2701,7 +2701,7 @@ These flags control the block synchronization and data downloading process, incl
 
 The two flags below are registered but hidden, so they do not appear in `erigon --help`, and neither changes any behaviour. They are listed here so their presence in an old command line is not mistaken for a working setting.
 
-* `--torrent.staticpeers value`: Accepted but inert — the binary marks it *"Currently unused"* and nothing reads the value.
+* `--torrent.staticpeers value`: Accepted but currently unused — nothing in the binary reads the value.
 * `--torrent.download.slots value`: Accepted but inert — the binary marks it deprecated; it no longer affects how many files download in parallel. Unlike `--torrent.staticpeers`, setting it logs a `[DEPRECATED]` warning on every startup.
   * Default: `32`
 


### PR DESCRIPTION
The w37 audit of the flag, env-var and port surface turned up gaps. This closes them.

Newly documented: `--aa`, `--maxpendpeers`, `--private.api.addr`, `--tls` and its three companions, `--http.trace`, `--http.dbg.single`, `--trace.compat`, `--trace.maxtraces`, `--ots.search.max.pagesize`, and the eight `DOWNLOADER_*` variables. `--sentinel.port` joins the ports page.

Four needed more than a one-liner:

- `--tls` with a missing cert logs a warning and continues without TLS — and because it abandons the rest of that step, `--healthcheck` is silently dropped too.
- `--tls.cacert` turns on mutual TLS rather than just verifying clients, so every gRPC client of `--private.api.addr` then needs a certificate signed by that CA.
- `DOWNLOADER_HTTP3` short-circuits the transport and leaves the six HTTP variables inert. Four of the others panic at startup on an unparseable value instead of falling back.
- `--torrent.staticpeers` and `--torrent.download.slots` are both hidden and change nothing, but only the second logs a deprecation warning when set.

Also: `--maxpeers` defaults to 64, not 32 (a pre-existing error); the multiple-instances compose example no longer passes `--mine`; and `--experimental.streaming-commitment` is dropped, since the flag is gone from main.

The llms.txt artifacts are regenerated to match.
