### PR TITLE
[r3.6] cl/phase1/stages: saturate the derived column retention window

### DIFF
--- a/cl/phase1/stages/cleanup_and_pruning.go
+++ b/cl/phase1/stages/cleanup_and_pruning.go
@@ -2,6 +2,7 @@ package stages
 
 import (
 	"context"
+	"math"
 
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/persistence/beacon_indicies"
@@ -40,6 +41,19 @@ func cleanupAndPruning(ctx context.Context, logger log.Logger, cfg *Cfg, args Ar
 // exact epochs * SLOTS_PER_EPOCH distance cuts above that boundary whenever the head sits inside
 // an epoch. The extra epoch keeps the cut at or below it, which matters because this distance also
 // sets the earliest slot we advertise as servable.
+//
+// A custom chain config supplies both inputs unchecked, and zero here means "keep nothing", so
+// anything unrepresentable saturates to keeping everything rather than wrapping into a distance
+// that prunes the whole store.
 func specColumnKeepSlots(beaconCfg *clparams.BeaconChainConfig) uint64 {
-	return (beaconCfg.MinEpochsForDataColumnSidecarsRequests + 1) * beaconCfg.SlotsPerEpoch
+	epochs := beaconCfg.MinEpochsForDataColumnSidecarsRequests
+	slotsPerEpoch := beaconCfg.SlotsPerEpoch
+	if slotsPerEpoch == 0 || epochs == math.MaxUint64 {
+		return math.MaxUint64
+	}
+	epochs++
+	if epochs > math.MaxUint64/slotsPerEpoch {
+		return math.MaxUint64
+	}
+	return epochs * slotsPerEpoch
 }

--- a/cl/phase1/stages/cleanup_and_pruning_test.go
+++ b/cl/phase1/stages/cleanup_and_pruning_test.go
@@ -17,6 +17,7 @@
 package stages
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -84,5 +85,46 @@ func TestSpecColumnKeepSlotsNeverCutsAboveTheEpochBoundary(t *testing.T) {
 		required := (epoch - beaconCfg.MinEpochsForDataColumnSidecarsRequests) * beaconCfg.SlotsPerEpoch
 		require.LessOrEqual(t, head-keep, required,
 			"head %d cuts above the first slot the node must still serve", head)
+	}
+}
+
+// Both inputs arrive as plain uint64 from --caplin.custom-config, so the derived distance must
+// not wrap. A distance of zero is the dangerous outcome: it makes Prune delete every bucket
+// below the head and advertise nothing as available, so anything unrepresentable has to
+// saturate towards retaining instead.
+func TestSpecColumnKeepSlotsSaturatesInsteadOfWrapping(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		minEpochs     uint64
+		slotsPerEpoch uint64
+	}{
+		{name: "epoch count at the limit", minEpochs: math.MaxUint64, slotsPerEpoch: 32},
+		{name: "product overflows", minEpochs: math.MaxUint64 / 32, slotsPerEpoch: 32},
+		{name: "no slots per epoch", minEpochs: 4096, slotsPerEpoch: 0},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			beaconCfg := clparams.MainnetBeaconConfig
+			beaconCfg.MinEpochsForDataColumnSidecarsRequests = test.minEpochs
+			beaconCfg.SlotsPerEpoch = test.slotsPerEpoch
+
+			require.Equal(t, uint64(math.MaxUint64), specColumnKeepSlots(&beaconCfg),
+				"an unrepresentable window must retain everything, never prune everything")
+		})
+	}
+}
+
+// The distance reaches PeerDas.Prune directly, where zero means "keep nothing", so no config
+// may produce it.
+func TestSpecColumnKeepSlotsIsNeverZero(t *testing.T) {
+	for _, minEpochs := range []uint64{0, 1, 4096, math.MaxUint64 - 1, math.MaxUint64} {
+		for _, slotsPerEpoch := range []uint64{0, 1, 12, 16, 32, math.MaxUint64} {
+			beaconCfg := clparams.MainnetBeaconConfig
+			beaconCfg.MinEpochsForDataColumnSidecarsRequests = minEpochs
+			beaconCfg.SlotsPerEpoch = slotsPerEpoch
+
+			require.NotZero(t, specColumnKeepSlots(&beaconCfg),
+				"MIN_EPOCHS=%d SLOTS_PER_EPOCH=%d resolved to a destructive zero distance",
+				minEpochs, slotsPerEpoch)
+		}
 	}
 }

--- a/docs/site/docs/fundamentals/caplin.md
+++ b/docs/site/docs/fundamentals/caplin.md
@@ -34,7 +34,7 @@ With state archival enabled, Caplin's indexing database (`<datadir>/caplin/index
 
 For nodes participating in PeerDAS (EIP-7594), Caplin retains data column sidecars for a configurable window:
 
-* `--caplin.columns-keep-slots` (default: `0`): Number of slots to retain PeerDAS data column sidecars. `0` uses the chain's own spec window, `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS × SLOTS_PER_EPOCH`, so the retained slot count and the wall-clock duration it covers both follow the chain (on Ethereum mainnet, 131072 slots, ~18 days). Increase this value for DA oracle or rollup nodes that require a longer column history.
+* `--caplin.columns-keep-slots` (default: `0`): Number of slots to retain PeerDAS data column sidecars. `0` uses the chain's own spec window, `(MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS + 1) × SLOTS_PER_EPOCH`, so the retained slot count and the wall-clock duration it covers both follow the chain (on Ethereum mainnet, 131104 slots, ~18 days). The extra epoch is a safety margin: the spec window starts at an epoch boundary, so retaining exactly `MIN_EPOCHS × SLOTS_PER_EPOCH` slots would drop columns the node must still serve whenever the head sits inside an epoch. Increase this value for DA oracle or rollup nodes that require a longer column history.
 
 Caplin can also be used for [block production](../staking/caplin), aka **staking**.
 

--- a/docs/site/docs/fundamentals/configuring-erigon.mdx
+++ b/docs/site/docs/fundamentals/configuring-erigon.mdx
@@ -538,7 +538,7 @@ Flags for configuring the [Caplin](/fundamentals/caplin) consensus layer.
 * `--caplin.blobs-no-pruning`: Disables blob pruning.
   * Default: `false`
 * `--caplin.columns-keep-slots value`: Number of slots to retain PeerDAS data column sidecars. Increase for DA oracle or rollup nodes that need longer column history.
-  * Default: `0` — uses the chain's spec window, `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS × SLOTS_PER_EPOCH`
+  * Default: `0` — uses the chain's spec window plus one epoch of alignment margin, `(MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS + 1) × SLOTS_PER_EPOCH` (131104 slots on Ethereum mainnet)
 * `--caplin.checkpoint-sync.disable`: Disables checkpoint sync.
   * Default: `false`
 * `--caplin.snapgen`: Enables snapshot generation.

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -2156,7 +2156,7 @@ With state archival enabled, Caplin's indexing database (`<datadir>/caplin/index
 
 For nodes participating in PeerDAS (EIP-7594), Caplin retains data column sidecars for a configurable window:
 
-* `--caplin.columns-keep-slots` (default: `0`): Number of slots to retain PeerDAS data column sidecars. `0` uses the chain's own spec window, `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS × SLOTS_PER_EPOCH`, so the retained slot count and the wall-clock duration it covers both follow the chain (on Ethereum mainnet, 131072 slots, ~18 days). Increase this value for DA oracle or rollup nodes that require a longer column history.
+* `--caplin.columns-keep-slots` (default: `0`): Number of slots to retain PeerDAS data column sidecars. `0` uses the chain's own spec window, `(MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS + 1) × SLOTS_PER_EPOCH`, so the retained slot count and the wall-clock duration it covers both follow the chain (on Ethereum mainnet, 131104 slots, ~18 days). The extra epoch is a safety margin: the spec window starts at an epoch boundary, so retaining exactly `MIN_EPOCHS × SLOTS_PER_EPOCH` slots would drop columns the node must still serve whenever the head sits inside an epoch. Increase this value for DA oracle or rollup nodes that require a longer column history.
 
 Caplin can also be used for [block production](../staking/caplin), aka **staking**.
 
@@ -2719,7 +2719,7 @@ Flags for configuring the [Caplin](/fundamentals/caplin) consensus layer.
 * `--caplin.blobs-no-pruning`: Disables blob pruning.
   * Default: `false`
 * `--caplin.columns-keep-slots value`: Number of slots to retain PeerDAS data column sidecars. Increase for DA oracle or rollup nodes that need longer column history.
-  * Default: `0` — uses the chain's spec window, `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS × SLOTS_PER_EPOCH`
+  * Default: `0` — uses the chain's spec window plus one epoch of alignment margin, `(MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS + 1) × SLOTS_PER_EPOCH` (131104 slots on Ethereum mainnet)
 * `--caplin.checkpoint-sync.disable`: Disables checkpoint sync.
   * Default: `false`
 * `--caplin.snapgen`: Enables snapshot generation.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2156,7 +2156,7 @@ With state archival enabled, Caplin's indexing database (`<datadir>/caplin/index
 
 For nodes participating in PeerDAS (EIP-7594), Caplin retains data column sidecars for a configurable window:
 
-* `--caplin.columns-keep-slots` (default: `0`): Number of slots to retain PeerDAS data column sidecars. `0` uses the chain's own spec window, `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS × SLOTS_PER_EPOCH`, so the retained slot count and the wall-clock duration it covers both follow the chain (on Ethereum mainnet, 131072 slots, ~18 days). Increase this value for DA oracle or rollup nodes that require a longer column history.
+* `--caplin.columns-keep-slots` (default: `0`): Number of slots to retain PeerDAS data column sidecars. `0` uses the chain's own spec window, `(MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS + 1) × SLOTS_PER_EPOCH`, so the retained slot count and the wall-clock duration it covers both follow the chain (on Ethereum mainnet, 131104 slots, ~18 days). The extra epoch is a safety margin: the spec window starts at an epoch boundary, so retaining exactly `MIN_EPOCHS × SLOTS_PER_EPOCH` slots would drop columns the node must still serve whenever the head sits inside an epoch. Increase this value for DA oracle or rollup nodes that require a longer column history.
 
 Caplin can also be used for [block production](../staking/caplin), aka **staking**.
 
@@ -2719,7 +2719,7 @@ Flags for configuring the [Caplin](/fundamentals/caplin) consensus layer.
 * `--caplin.blobs-no-pruning`: Disables blob pruning.
   * Default: `false`
 * `--caplin.columns-keep-slots value`: Number of slots to retain PeerDAS data column sidecars. Increase for DA oracle or rollup nodes that need longer column history.
-  * Default: `0` — uses the chain's spec window, `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS × SLOTS_PER_EPOCH`
+  * Default: `0` — uses the chain's spec window plus one epoch of alignment margin, `(MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS + 1) × SLOTS_PER_EPOCH` (131104 slots on Ethereum mainnet)
 * `--caplin.checkpoint-sync.disable`: Disables checkpoint sync.
   * Default: `false`
 * `--caplin.snapgen`: Enables snapshot generation.


### PR DESCRIPTION
Follow-up to #23851, which merged with this hole. Same fix as requested by @domiwei on #23852.

`specColumnKeepSlots` feeds `PeerDas.Prune(keepSlotDistance)`, where zero means *keep nothing*:
`columnStorage.Prune` then deletes every bucket below the head and `peerdas.Prune` advances
`earliest_available_slot` to the current slot. Both `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS`
and `SLOTS_PER_EPOCH` are `spec:"true"` yaml fields, so `--caplin.custom-config` supplies them
unchecked.

Three configurations produced a zero distance:

| config | old result |
|---|---|
| `MIN_EPOCHS = MaxUint64` | `+1` wraps to `0`, product `0` |
| `SLOTS_PER_EPOCH = 0` | product `0` |
| `MIN_EPOCHS = MaxUint64/32`, `SLOTS_PER_EPOCH = 32` | multiplication wraps |

All three now saturate to `MaxUint64`, which is the retaining direction: `columnStorage.Prune`
returns early on `currentSlot <= keepSlotDistance` and `peerdas.Prune` sets
`EarliestAvailableSlot(0)`.

`main` is **not** affected and needs no equivalent change. It prunes by absolute floor
(`specColumnFloor` / `PruneBelow`) where `0` means keep everything — the inverse of this API — it
has no `+1` to wrap, and its multiplication is bounded by `currentSlot` because
`epoch = currentSlot / SLOTS_PER_EPOCH`.

## Tests

`TestSpecColumnKeepSlotsSaturatesInsteadOfWrapping` covers the three cases above;
`TestSpecColumnKeepSlotsIsNeverZero` sweeps the boundary values of both fields and asserts the
distance is never the destructive zero. Each guard is mutation-verified independently — removing
any one of the three fails a named case.

Also documents the extra alignment epoch and the resulting mainnet value (131104), which the flag
docs still described as the bare spec window; `generate-llms.py --check` passes.
