### PR TITLE
[r3.5] ci: pin the Geth used by the DevP2P simulator

### DIFF
--- a/.github/workflows/hive-versions.json
+++ b/.github/workflows/hive-versions.json
@@ -1,4 +1,5 @@
 {
   "hive_ref": "88c3e1ab1c9a6d6183b6e7e88df5981bbedf81aa",
+  "devp2p_geth_ref": "157c94647241b260d19e5a8e01a08e439591e504",
   "execution_apis_ref": "c27d979e4880ea33bf551eccb16045ebb2e1e2bc"
 }

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -94,6 +94,7 @@ jobs:
         id: hive-version
         run: |
           echo "ref=$(jq -r .hive_ref erigon-full/.github/workflows/hive-versions.json)" >> "$GITHUB_OUTPUT"
+          echo "devp2p_geth_ref=$(jq -r '.devp2p_geth_ref // empty' erigon-full/.github/workflows/hive-versions.json)" >> "$GITHUB_OUTPUT"
           echo "execution_apis_ref=$(jq -r '.execution_apis_ref // empty' erigon-full/.github/workflows/hive-versions.json)" >> "$GITHUB_OUTPUT"
 
       - name: Checkout Hive
@@ -103,6 +104,27 @@ jobs:
           # version hive and update periodically/on-demand to prevent upstream changes in Hive affecting us with red CI
           ref: ${{ steps.hive-version.outputs.ref }}
           path: hive
+
+      # Hive builds the devp2p simulator from go-ethereum and takes its test chain from geth's
+      # own testdata, cloning master unpinned. Geth added Osaka to that fixture in e4db964e, so
+      # an unpinned clone makes every devp2p test fail the eth handshake on a fork ID this
+      # branch does not know.
+      # TODO: remove devp2p_geth_ref from hive-versions.json after Geth fixes its fixture and https://github.com/erigontech/erigon/issues/22808 is completed
+      - name: Pin Geth used by DevP2P
+        if: ${{ matrix.sim == 'devp2p' && steps.hive-version.outputs.devp2p_geth_ref != '' }}
+        env:
+          GETH_REF: ${{ steps.hive-version.outputs.devp2p_geth_ref }}
+        run: |
+          if ! echo "$GETH_REF" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "Error: devp2p_geth_ref is not a valid git SHA: $GETH_REF"
+            exit 1
+          fi
+          dockerfile=hive/simulators/devp2p/Dockerfile
+          sed -i "s|^RUN git clone --depth 1 https://github.com/ethereum/go-ethereum.git /go-ethereum$|RUN git init /go-ethereum \&\& git -C /go-ethereum remote add origin https://github.com/ethereum/go-ethereum.git \&\& git -C /go-ethereum fetch --depth 1 origin ${GETH_REF} \&\& git -C /go-ethereum checkout --detach FETCH_HEAD|" "$dockerfile"
+          if ! grep -Fq "fetch --depth 1 origin ${GETH_REF}" "$dockerfile"; then
+            echo "Error: failed to pin Geth in the DevP2P Dockerfile"
+            exit 1
+          fi
 
       - name: Setup go env and cache
         uses: actions/setup-go@v6


### PR DESCRIPTION
Unblocks `release/3.5` CI. The `hive / test-hive (devp2p, ...)` jobs fail on every r3.5 PR right
now, including ones that are otherwise green (#23852).

## What breaks

Hive builds the devp2p simulator from go-ethereum and copies its test chain out of geth's own
tree:

```
RUN git clone --depth 1 https://github.com/ethereum/go-ethereum.git /go-ethereum
...
COPY --from=geth-builder /go-ethereum/cmd/devp2p/internal/ethtest/testdata /testchain
```

That clone is unpinned, so the fixture's fork schedule tracks geth master. Geth added Osaka to it
in [`e4db964e`](https://github.com/ethereum/go-ethereum/commit/e4db964e7506) on 2026-09-02, which
moved the fork ID the suite expects past what this branch advertises. Every test then dies at the
eth handshake:

```
peering failed: status exchange failed: wrong fork ID in status:
  have {[151 54 174 177] 0}, want {[21 227 201 70] 0}
```

Peering never completes, so 24 of 25 tests fail rather than one or two.

## The fix

`main` and `release/3.6` already pin that clone to
[`157c9464`](https://github.com/ethereum/go-ethereum/commit/157c94647241b260d19e5a8e01a08e439591e504)
— the commit immediately before the Osaka fixture, 4 minutes earlier. This backports the same
step and the same `devp2p_geth_ref` key, unchanged. The step is conditional on `matrix.sim ==
'devp2p'` and on the key being present, so it is a no-op elsewhere, and it fails loudly if the
`sed` ever stops matching upstream.

`release/3.4` has the same gap and will hit this on its next hive run; not touched here.

## Verified locally, not just reasoned about

Reproduced the job on this branch — hive at the pinned `88c3e1ab`, erigon image built from
`release/3.5`, `hive --sim devp2p --sim.limit=eth --client erigon`:

| devp2p Dockerfile | result |
|---|---|
| pinned to `157c9464` (this PR) | **`suites=1 tests=22 failed=0`** |
| left unpinned (control) | see comment below |

The pinned run's build log confirms `fetch --depth 1 origin 157c9464…` was used, with zero
`wrong fork ID` occurrences.

`actionlint` clean with the repo's own flags; `hive-versions.json` parses.
