### PR TITLE
[r3.6] docs: replace image-size with image-size-next to fix CVE-2025-71329/71330

### DIFF
--- a/docs/site/package-lock.json
+++ b/docs/site/package-lock.json
@@ -3649,6 +3649,19 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@docusaurus/mdx-loader/node_modules/image-size": {
+      "name": "image-size-next",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/image-size-next/-/image-size-next-2.1.1.tgz",
+      "integrity": "sha512-n+DFjUct+G9mxZck+lvzqrTsqBJvSHMs6iEo//W5iAgRV7oUbrh1JWmKgAEpmyRB5lw6plIQizS1wK1dvrsvAw==",
+      "license": "MIT",
+      "bin": {
+        "image-size-next": "bin/image-size-next.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@docusaurus/module-type-aliases": {
       "version": "3.10.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.2.tgz",
@@ -11140,18 +11153,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/image-size": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
-      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
-      "license": "MIT",
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
       }
     },
     "node_modules/immediate": {

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -51,6 +51,7 @@
     "node": ">=20.0"
   },
   "overrides": {
+    "image-size": "npm:image-size-next@^2.1.1",
     "webpack": "5.105.0",
     "@babel/plugin-transform-modules-systemjs": "^7.29.4",
     "@babel/core": "^7.29.6",


### PR DESCRIPTION
## Summary

Backport of #23869 to `release/3.6` — this is the branch `docs.erigon.tech` is actually deployed from (`DOCS_DEPLOY_BRANCH` repo variable, consumed by `docs-deploy-cron.yml` / `docs-deploy.yml`), so it carries priority over the `main`-branch fix for live-site risk.

Fixes dependabot alerts [#142](https://github.com/erigontech/erigon/security/dependabot/142) and [#143](https://github.com/erigontech/erigon/security/dependabot/143) as they apply to this branch's `docs/site/package-lock.json`.

`image-size@2.0.2` (pulled in transitively by `@docusaurus/mdx-loader`, used to inject `width`/`height` on local markdown images at docs-build time) has two high-severity DoS advisories with **no upstream fix**:

- [GHSA-5p2g-fcmc-qvqq](https://github.com/advisories/GHSA-5p2g-fcmc-qvqq) / CVE-2025-71329 — infinite loop parsing malformed JXL/HEIF
- [GHSA-w3rx-r6r6-pgpr](https://github.com/advisories/GHSA-w3rx-r6r6-pgpr) / CVE-2025-71330 — infinite loop parsing malformed ICNS

## Fix

Adds `"image-size": "npm:image-size-next@^2.1.1"` to the existing `overrides` block in `docs/site/package.json`, same as #23869 on `main`. `image-size-next` is an actively maintained fork carrying real fixes for both loops (verified by diffing its source against `image-size@2.0.2`).

## Test plan

- [x] `npm install` in `docs/site` — resolves `node_modules/@docusaurus/mdx-loader/node_modules/image-size` to `image-size-next@2.1.1`
- [x] `npm run build` in `docs/site` — succeeds
- [x] `npm audit` — no more `image-size` findings. 5 unrelated pre-existing advisories remain (`browserslist`, `fast-uri`, `qs`) that already exist on this branch independent of this change — left out of scope per this PR's focus.
- [x] Output-equivalence already verified against `main`'s identical override in #23869 (byte-identical rendered `<img>` dimensions for both SVG and PNG test images across an A/B build).

## r3.6-specific adaptations

None — this branch's `docs/site/package.json` `overrides` block is structurally identical to `main`'s at the point of this change; same one-line addition applies cleanly.