### PR TITLE
engine_types, rpctest, protocol: drop gencodec tags that have no generator

### DIFF
--- a/cmd/rpctest/rpctest/type.go
+++ b/cmd/rpctest/rpctest/type.go
@@ -206,24 +206,24 @@ type DebugAccountRange struct {
 type Log struct { //nolint
 	// Consensus fields:
 	// address of the contract that generated the event
-	Address common.Address `json:"address" gencodec:"required"`
+	Address common.Address `json:"address"`
 	// list of topics provided by the contract.
-	Topics []common.Hash `json:"topics" gencodec:"required"`
+	Topics []common.Hash `json:"topics"`
 	// supplied by the contract, usually ABI-encoded
-	Data hexutil.Bytes `json:"data" gencodec:"required"`
+	Data hexutil.Bytes `json:"data"`
 
 	// Derived fields. These fields are filled in by the node
 	// but not secured by consensus.
 	// block in which the transaction was included
 	BlockNumber hexutil.Uint64 `json:"blockNumber"`
 	// hash of the transaction
-	TxHash common.Hash `json:"transactionHash" gencodec:"required"`
+	TxHash common.Hash `json:"transactionHash"`
 	// index of the transaction in the block
-	TxIndex hexutil.Uint `json:"transactionIndex" gencodec:"required"`
+	TxIndex hexutil.Uint `json:"transactionIndex"`
 	// hash of the block in which the transaction was included
 	BlockHash common.Hash `json:"blockHash"`
 	// index of the log in the receipt
-	Index hexutil.Uint `json:"logIndex" gencodec:"required"`
+	Index hexutil.Uint `json:"logIndex"`
 
 	// The Removed field is true if this log was reverted due to a chain reorganisation.
 	// You must pay attention to this field if you receive logs through a filter query.
@@ -234,14 +234,14 @@ type Receipt struct {
 	// Consensus fields
 	PostState         common.Hash    `json:"root"`
 	Status            hexutil.Uint64 `json:"status"`
-	CumulativeGasUsed hexutil.Uint64 `json:"cumulativeGasUsed" gencodec:"required"`
-	Bloom             hexutil.Bytes  `json:"logsBloom"         gencodec:"required"`
-	Logs              []*Log         `json:"logs"              gencodec:"required"`
+	CumulativeGasUsed hexutil.Uint64 `json:"cumulativeGasUsed"`
+	Bloom             hexutil.Bytes  `json:"logsBloom"`
+	Logs              []*Log         `json:"logs"`
 
 	// Implementation fields (don't reorder!)
-	TxHash          common.Hash     `json:"transactionHash" gencodec:"required"`
+	TxHash          common.Hash     `json:"transactionHash"`
 	ContractAddress *common.Address `json:"contractAddress"`
-	GasUsed         hexutil.Uint64  `json:"gasUsed" gencodec:"required"`
+	GasUsed         hexutil.Uint64  `json:"gasUsed"`
 }
 
 type EthReceipt struct {
@@ -314,7 +314,7 @@ type OtsFullBlock struct {
 	GasLimit   hexutil.Big    `json:"gasLimit"`
 	GasUsed    hexutil.Big    `json:"gasUsed"`
 	Hash       common.Hash    `json:"hash"`
-	Bloom      string         `json:"logsBloom" gencodec:"required"`
+	Bloom      string         `json:"logsBloom"`
 	Miner      common.Address `json:"miner"`
 	MixHash    string         `json:"mixHash"`
 	Nonce      string         `json:"nonce"`

--- a/cmd/rpctest/rpctest/utils.go
+++ b/cmd/rpctest/rpctest/utils.go
@@ -483,13 +483,13 @@ func compareStorageRanges(sm, smg map[common.Hash]storageEntry) bool {
 	// block in which the transaction was included
 	BlockNumber hexutil.Uint64 `json:"blockNumber"`
 	// hash of the transaction
-	TxHash common.Hash    `json:"transactionHash" gencodec:"required"`
+	TxHash common.Hash    `json:"transactionHash"`
 	// index of the transaction in the block
-	TxIndex hexutil.Uint  `json:"transactionIndex" gencodec:"required"`
+	TxIndex hexutil.Uint  `json:"transactionIndex"`
 	// hash of the block in which the transaction was included
 	BlockHash common.Hash `json:"blockHash"`
 	// index of the log in the receipt
-	Index hexutil.Uint    `json:"logIndex" gencodec:"required"`
+	Index hexutil.Uint    `json:"logIndex"`
 
 	// The Removed field is true if this log was reverted due to a chain reorganisation.
 	// You must pay attention to this field if you receive logs through a filter query.

--- a/execution/engineapi/engine_types/jsonrpc.go
+++ b/execution/engineapi/engine_types/jsonrpc.go
@@ -35,20 +35,20 @@ import (
 
 // ExecutionPayload represents an execution payload (aka block)
 type ExecutionPayload struct {
-	ParentHash      common.Hash           `json:"parentHash"    gencodec:"required"`
-	FeeRecipient    common.Address        `json:"feeRecipient"  gencodec:"required"`
-	StateRoot       common.Hash           `json:"stateRoot"     gencodec:"required"`
-	ReceiptsRoot    common.Hash           `json:"receiptsRoot"  gencodec:"required"`
-	LogsBloom       hexutil.Bytes         `json:"logsBloom"     gencodec:"required"`
-	PrevRandao      common.Hash           `json:"prevRandao"    gencodec:"required"`
-	BlockNumber     hexutil.Uint64        `json:"blockNumber"   gencodec:"required"`
-	GasLimit        hexutil.Uint64        `json:"gasLimit"      gencodec:"required"`
-	GasUsed         hexutil.Uint64        `json:"gasUsed"       gencodec:"required"`
-	Timestamp       hexutil.Uint64        `json:"timestamp"     gencodec:"required"`
-	ExtraData       hexutil.Bytes         `json:"extraData"     gencodec:"required"`
-	BaseFeePerGas   *hexutil.Big          `json:"baseFeePerGas" gencodec:"required"`
-	BlockHash       common.Hash           `json:"blockHash"     gencodec:"required"`
-	Transactions    []hexutil.Bytes       `json:"transactions"  gencodec:"required"`
+	ParentHash      common.Hash           `json:"parentHash"`
+	FeeRecipient    common.Address        `json:"feeRecipient"`
+	StateRoot       common.Hash           `json:"stateRoot"`
+	ReceiptsRoot    common.Hash           `json:"receiptsRoot"`
+	LogsBloom       hexutil.Bytes         `json:"logsBloom"`
+	PrevRandao      common.Hash           `json:"prevRandao"`
+	BlockNumber     hexutil.Uint64        `json:"blockNumber"`
+	GasLimit        hexutil.Uint64        `json:"gasLimit"`
+	GasUsed         hexutil.Uint64        `json:"gasUsed"`
+	Timestamp       hexutil.Uint64        `json:"timestamp"`
+	ExtraData       hexutil.Bytes         `json:"extraData"`
+	BaseFeePerGas   *hexutil.Big          `json:"baseFeePerGas"`
+	BlockHash       common.Hash           `json:"blockHash"`
+	Transactions    []hexutil.Bytes       `json:"transactions"`
 	Withdrawals     []*types.Withdrawal   `json:"withdrawals"`
 	BlobGasUsed     *hexutil.Uint64       `json:"blobGasUsed"`
 	ExcessBlobGas   *hexutil.Uint64       `json:"excessBlobGas"`
@@ -59,16 +59,16 @@ type ExecutionPayload struct {
 
 // PayloadAttributes represent the attributes required to start assembling a payload
 type ForkChoiceState struct {
-	HeadHash           common.Hash `json:"headBlockHash"             gencodec:"required"`
-	SafeBlockHash      common.Hash `json:"safeBlockHash"             gencodec:"required"`
-	FinalizedBlockHash common.Hash `json:"finalizedBlockHash"        gencodec:"required"`
+	HeadHash           common.Hash `json:"headBlockHash"`
+	SafeBlockHash      common.Hash `json:"safeBlockHash"`
+	FinalizedBlockHash common.Hash `json:"finalizedBlockHash"`
 }
 
 // PayloadAttributes represent the attributes required to start assembling a payload
 type PayloadAttributes struct {
-	Timestamp             hexutil.Uint64        `json:"timestamp"             gencodec:"required"`
-	PrevRandao            common.Hash           `json:"prevRandao"            gencodec:"required"`
-	SuggestedFeeRecipient common.Address        `json:"suggestedFeeRecipient" gencodec:"required"`
+	Timestamp             hexutil.Uint64        `json:"timestamp"`
+	PrevRandao            common.Hash           `json:"prevRandao"`
+	SuggestedFeeRecipient common.Address        `json:"suggestedFeeRecipient"`
 	Withdrawals           []*types.Withdrawal   `json:"withdrawals"`
 	ParentBeaconBlockRoot *common.Hash          `json:"parentBeaconBlockRoot"`
 	SlotNumber            *hexutil.Uint64       `json:"slotNumber"`
@@ -78,18 +78,18 @@ type PayloadAttributes struct {
 
 // TransitionConfiguration represents the correct configurations of the CL and the EL
 type TransitionConfiguration struct {
-	TerminalTotalDifficulty *hexutil.Big `json:"terminalTotalDifficulty" gencodec:"required"`
-	TerminalBlockHash       common.Hash  `json:"terminalBlockHash"       gencodec:"required"`
-	TerminalBlockNumber     *hexutil.Big `json:"terminalBlockNumber"     gencodec:"required"`
+	TerminalTotalDifficulty *hexutil.Big `json:"terminalTotalDifficulty"`
+	TerminalBlockHash       common.Hash  `json:"terminalBlockHash"`
+	TerminalBlockNumber     *hexutil.Big `json:"terminalBlockNumber"`
 }
 
 // BlobsBundle holds the blobs of an execution payload.
 // It covers both BlobsBundleV1 (https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md#blobsbundlev1)
 // and BlobsBundleV2 (https://github.com/ethereum/execution-apis/blob/main/src/engine/osaka.md#blobsbundlev2)
 type BlobsBundle struct {
-	Commitments []hexutil.Bytes       `json:"commitments" gencodec:"required"`
-	Proofs      []hexutil.Bytes       `json:"proofs"      gencodec:"required"`
-	Blobs       []hexutil.Bytes       `json:"blobs"       gencodec:"required"`
+	Commitments []hexutil.Bytes       `json:"commitments"`
+	Proofs      []hexutil.Bytes       `json:"proofs"`
+	Blobs       []hexutil.Bytes       `json:"blobs"`
 	SSZVersion  clparams.StateVersion `json:"-"`
 }
 
@@ -131,29 +131,29 @@ func BlobsBundleFromTransactions(txs types.Transactions) (*BlobsBundle, error) {
 
 // BlobAndProofV1 holds one item for engine_getBlobsV1
 type BlobAndProofV1 struct {
-	Blob  hexutil.Bytes `json:"blob" gencodec:"required"`
-	Proof hexutil.Bytes `json:"proof" gencodec:"required"`
+	Blob  hexutil.Bytes `json:"blob"`
+	Proof hexutil.Bytes `json:"proof"`
 }
 
 // BlobAndProofV2 holds one item for engine_getBlobsV2/engine_getBlobsV3
 type BlobAndProofV2 struct {
-	Blob       hexutil.Bytes   `json:"blob" gencodec:"required"`
-	CellProofs []hexutil.Bytes `json:"proofs" gencodec:"required"`
+	Blob       hexutil.Bytes   `json:"blob"`
+	CellProofs []hexutil.Bytes `json:"proofs"`
 }
 
 type ExecutionPayloadBody struct {
-	Transactions []hexutil.Bytes     `json:"transactions" gencodec:"required"`
-	Withdrawals  []*types.Withdrawal `json:"withdrawals"  gencodec:"required"`
+	Transactions []hexutil.Bytes     `json:"transactions"`
+	Withdrawals  []*types.Withdrawal `json:"withdrawals"`
 }
 
 type ExecutionPayloadBodyV2 struct {
-	Transactions    []hexutil.Bytes     `json:"transactions" gencodec:"required"`
-	Withdrawals     []*types.Withdrawal `json:"withdrawals"  gencodec:"required"`
+	Transactions    []hexutil.Bytes     `json:"transactions"`
+	Withdrawals     []*types.Withdrawal `json:"withdrawals"`
 	BlockAccessList *hexutil.Bytes      `json:"blockAccessList"`
 }
 
 type PayloadStatus struct {
-	Status          EngineStatus      `json:"status" gencodec:"required"`
+	Status          EngineStatus      `json:"status"`
 	ValidationError *StringifiedError `json:"validationError"`
 	LatestValidHash *common.Hash      `json:"latestValidHash"`
 	CriticalError   error             `json:"-"`
@@ -165,7 +165,7 @@ type ForkChoiceUpdatedResponse struct {
 }
 
 type GetPayloadResponse struct {
-	ExecutionPayload      *ExecutionPayload `json:"executionPayload" gencodec:"required"`
+	ExecutionPayload      *ExecutionPayload `json:"executionPayload"`
 	BlockValue            *hexutil.Big      `json:"blockValue"`
 	BlobsBundle           *BlobsBundle      `json:"blobsBundle"`
 	ExecutionRequests     []hexutil.Bytes   `json:"executionRequests"`
@@ -173,10 +173,10 @@ type GetPayloadResponse struct {
 }
 
 type ClientVersionV1 struct {
-	Code    string `json:"code" gencodec:"required"`
-	Name    string `json:"name" gencodec:"required"`
-	Version string `json:"version" gencodec:"required"`
-	Commit  string `json:"commit" gencodec:"required"`
+	Code    string `json:"code"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
 }
 
 func (c ClientVersionV1) String() string {

--- a/execution/protocol/block_exec.go
+++ b/execution/protocol/block_exec.go
@@ -54,8 +54,8 @@ const (
 )
 
 type RejectedTx struct {
-	Index int    `json:"index"    gencodec:"required"`
-	Err   string `json:"error"    gencodec:"required"`
+	Index int    `json:"index"`
+	Err   string `json:"error"`
 }
 
 type RejectedTxs []*RejectedTx
@@ -65,10 +65,10 @@ type EphemeralExecResult struct {
 	TxRoot      common.Hash           `json:"txRoot"`
 	ReceiptRoot common.Hash           `json:"receiptsRoot"`
 	LogsHash    common.Hash           `json:"logsHash"`
-	Bloom       types.Bloom           `json:"logsBloom"        gencodec:"required"`
+	Bloom       types.Bloom           `json:"logsBloom"`
 	Receipts    types.Receipts        `json:"receipts"`
 	Rejected    RejectedTxs           `json:"rejected,omitempty"`
-	Difficulty  *math.HexOrDecimal256 `json:"currentDifficulty" gencodec:"required"`
+	Difficulty  *math.HexOrDecimal256 `json:"currentDifficulty"`
 	GasUsed     math.HexOrDecimal64   `json:"gasUsed"`
 }
 


### PR DESCRIPTION
Follow-up to #23766.

These four files carry `gencodec:"required"` tags but no `//go:generate gencodec` directive and no generated file. The tag is only read by gencodec at generation time, so nothing acts on it here - the structs already declare the wire types (`hexutil.Uint64`, `hexutil.Bytes`) directly and marshal through plain reflection. They came over with the geth copy, where a generated `MarshalJSON` did read them.

| file | tags removed |
|---|---:|
| `execution/engineapi/engine_types/jsonrpc.go` | 40 |
| `cmd/rpctest/rpctest/type.go` | 12 |
| `execution/protocol/block_exec.go` | 4 |
| `cmd/rpctest/rpctest/utils.go` | 3 |

Struct tags only, no behaviour change - so no new test (mechanical change, existing suite is the check).

Left alone: `execution/types/block.go` and `execution/types/receipt.go` also carry inert tags, but their `//go:generate` lines are only commented out and the generated files are still there, so the tags stay meaningful if anyone re-enables the generator.