### PR TITLE
execution/commitment: drop duplicate hot-path metric counters

### DIFF
--- a/cmd/prometheus/dashboards/erigon_internals.json
+++ b/cmd/prometheus/dashboards/erigon_internals.json
@@ -4164,7 +4164,7 @@
                 "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
               },
               "editorMode": "code",
-              "expr": "irate(domain_commitment_updates_applied{instance=~\"$instance\"}[$__rate_interval]) > 0",
+              "expr": "irate(commitment_branch_writes_total{instance=~\"$instance\"}[$__rate_interval]) > 0",
               "hide": false,
               "legendFormat": "commitment trie node updates: {{instance}}",
               "range": true,

--- a/cmd/prometheus/dashboards/erigon_internals.json
+++ b/cmd/prometheus/dashboards/erigon_internals.json
@@ -4164,7 +4164,7 @@
                 "uid": "${DS_GRAFANACLOUD-ERIGONOVHMONITORING-PROM}"
               },
               "editorMode": "code",
-              "expr": "irate(commitment_branch_writes_total{instance=~\"$instance\"}[$__rate_interval]) > 0",
+              "expr": "irate(domain_commitment_updates_applied{instance=~\"$instance\"}[$__rate_interval]) > 0",
               "hide": false,
               "legendFormat": "commitment trie node updates: {{instance}}",
               "range": true,

--- a/dashboards/erigon_custom_metrics/erigon_custom_metrics.internal.json
+++ b/dashboards/erigon_custom_metrics/erigon_custom_metrics.internal.json
@@ -4005,7 +4005,7 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "irate(domain_commitment_updates_applied{instance=~\"$instance\"}[$__rate_interval]) > 0",
+              "expr": "irate(commitment_branch_writes_total{instance=~\"$instance\"}[$__rate_interval]) > 0",
               "legendFormat": "commitment trie node updates",
               "range": true,
               "refId": "F"

--- a/dashboards/erigon_custom_metrics/erigon_custom_metrics.internal.json
+++ b/dashboards/erigon_custom_metrics/erigon_custom_metrics.internal.json
@@ -3983,7 +3983,7 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "sum(rate(domain_commitment_keys{instance=~\"$instance\"}[$__rate_interval])) by (instance) > 0",
+              "expr": "sum(rate(commitment_key_traversals_total{instance=~\"$instance\"}[$__rate_interval])) by (instance) > 0",
               "legendFormat": "keys committed",
               "range": true,
               "refId": "A"

--- a/execution/commitment/commitment.go
+++ b/execution/commitment/commitment.go
@@ -50,9 +50,6 @@ import (
 )
 
 var (
-	mxTrieProcessedKeys   = metrics.GetOrCreateCounter("domain_commitment_keys")
-	mxTrieBranchesUpdated = metrics.GetOrCreateCounter("domain_commitment_updates_applied")
-
 	mxTrieStateSkipRate                 = metrics.GetOrCreateCounter("trie_state_skip_rate")
 	mxTrieStateLoadRate                 = metrics.GetOrCreateCounter("trie_state_load_rate")
 	mxTrieStateLevelledSkipRatesAccount = [...]metrics.Counter{
@@ -423,7 +420,6 @@ func ApplyDeferredBranchUpdates(
 			written++
 			bytesOut += len(upd.encoded)
 		}
-		mxTrieBranchesUpdated.AddInt(written)
 		publishBranchWrites(written, bytesOut, m)
 		return written, nil
 	}
@@ -468,7 +464,6 @@ func ApplyDeferredBranchUpdates(
 		written++
 		bytesOut += len(upd.encoded)
 	}
-	mxTrieBranchesUpdated.AddInt(written)
 	publishBranchWrites(written, bytesOut, m)
 	return written, nil
 }
@@ -518,7 +513,6 @@ func (be *BranchEncoder) CollectUpdate(
 		return err
 	}
 	publishBranchWrites(1, len(updateCopy), be.metrics)
-	mxTrieBranchesUpdated.Inc()
 	return nil
 }
 

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -2353,8 +2353,6 @@ func (hph *HexPatriciaHashed) followAndUpdate(hashedKey, plainKey []byte, stateU
 		}
 	}
 	hph.updateCell(plainKey, hashedKey, stateUpdate)
-
-	mxTrieProcessedKeys.Inc()
 	return nil
 }
 

--- a/execution/commitment/parallel_metrics_test.go
+++ b/execution/commitment/parallel_metrics_test.go
@@ -199,3 +199,64 @@ func TestBranchWritesArePublishedOnce(t *testing.T) {
 	assert.EqualValues(t, got.Metrics.BranchWriteBytes, mxWriteBytes.GetValueUint64()-beforeBytes,
 		"commitment_branch_write_bytes_total counts each write once")
 }
+
+func TestProcessedKeysPublishedPerRound(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		run  func(t *testing.T, ms *MockState, keys [][]byte, upds []Update) MetricValues
+	}{
+		{"sequential", func(t *testing.T, ms *MockState, keys [][]byte, upds []Update) MetricValues {
+			tr := newSeqTrie(t, ms)
+			defer tr.Release()
+			ut := WrapKeyUpdates(t, ModeDirect, KeyToHexNibbleHash, keys, upds)
+			defer ut.Close()
+			_, err := tr.Process(context.Background(), ut, "", nil, WarmupConfig{})
+			require.NoError(t, err)
+			return tr.metrics.AsValues()
+		}},
+		{"parallel", func(t *testing.T, ms *MockState, keys [][]byte, upds []Update) MetricValues {
+			tr := newParTrie(t, ms, 4)
+			defer tr.Release()
+			ut := NewUpdates(ModeParallel, t.TempDir(), KeyToHexNibbleHash)
+			defer ut.Close()
+			for _, k := range keys {
+				ut.TouchPlainKey(string(k), nil, nil)
+			}
+			_, err := tr.Process(context.Background(), ut, "", nil, WarmupConfig{})
+			require.NoError(t, err)
+			return tr.metrics.AsValues()
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ms := NewMockState(t)
+			keys, upds := buildNibbleSpread(t, 16, 4)
+			require.NoError(t, ms.applyPlainUpdates(keys, upds))
+
+			before := mxTrieProcessedKeys.GetValueUint64()
+			v := tc.run(t, ms, keys, upds)
+			published := mxTrieProcessedKeys.GetValueUint64() - before
+
+			require.Positive(t, v.AddressKeys+v.StorageKeys, "the round traversed keys")
+			assert.EqualValues(t, v.AddressKeys+v.StorageKeys, published,
+				"domain_commitment_keys publishes one tick per processed key")
+		})
+	}
+}
+
+func TestProcessedKeysCountsDeepFoldedStorage(t *testing.T) {
+	k1, u1, _, _ := buildSubsetTouchedWhale(20260707, nibs(3, 7), nil, 700, 0)
+	fk, fu := buildMixedCorpus(555, 200)
+	keys := append(append([][]byte{}, fk...), k1...)
+	upds := append(append([]Update{}, fu...), u1...)
+
+	ms := NewMockState(t)
+	ms.SetConcurrentCommitment(true)
+
+	before := mxTrieProcessedKeys.GetValueUint64()
+	_, _, deepFolds := parallelBatchDeepFolds(t, ms, 4, keys, upds, nil)
+	published := mxTrieProcessedKeys.GetValueUint64() - before
+
+	require.Positive(t, deepFolds, "the whale must take the concurrent deep fold")
+	assert.GreaterOrEqual(t, published, uint64(len(keys)),
+		"every touched key is traversed at least once, deep-folded storage included")
+}

--- a/execution/commitment/parallel_metrics_test.go
+++ b/execution/commitment/parallel_metrics_test.go
@@ -200,50 +200,7 @@ func TestBranchWritesArePublishedOnce(t *testing.T) {
 		"commitment_branch_write_bytes_total counts each write once")
 }
 
-func TestProcessedKeysPublishedPerRound(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		run  func(t *testing.T, ms *MockState, keys [][]byte, upds []Update) MetricValues
-	}{
-		{"sequential", func(t *testing.T, ms *MockState, keys [][]byte, upds []Update) MetricValues {
-			tr := newSeqTrie(t, ms)
-			defer tr.Release()
-			ut := WrapKeyUpdates(t, ModeDirect, KeyToHexNibbleHash, keys, upds)
-			defer ut.Close()
-			_, err := tr.Process(context.Background(), ut, "", nil, WarmupConfig{})
-			require.NoError(t, err)
-			return tr.metrics.AsValues()
-		}},
-		{"parallel", func(t *testing.T, ms *MockState, keys [][]byte, upds []Update) MetricValues {
-			tr := newParTrie(t, ms, 4)
-			defer tr.Release()
-			ut := NewUpdates(ModeParallel, t.TempDir(), KeyToHexNibbleHash)
-			defer ut.Close()
-			for _, k := range keys {
-				ut.TouchPlainKey(string(k), nil, nil)
-			}
-			_, err := tr.Process(context.Background(), ut, "", nil, WarmupConfig{})
-			require.NoError(t, err)
-			return tr.metrics.AsValues()
-		}},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			ms := NewMockState(t)
-			keys, upds := buildNibbleSpread(t, 16, 4)
-			require.NoError(t, ms.applyPlainUpdates(keys, upds))
-
-			before := mxTrieProcessedKeys.GetValueUint64()
-			v := tc.run(t, ms, keys, upds)
-			published := mxTrieProcessedKeys.GetValueUint64() - before
-
-			require.Positive(t, v.AddressKeys+v.StorageKeys, "the round traversed keys")
-			assert.EqualValues(t, v.AddressKeys+v.StorageKeys, published,
-				"domain_commitment_keys publishes one tick per processed key")
-		})
-	}
-}
-
-func TestProcessedKeysCountsDeepFoldedStorage(t *testing.T) {
+func TestDeepFoldedStorageReachesRoundMetrics(t *testing.T) {
 	k1, u1, _, _ := buildSubsetTouchedWhale(20260707, nibs(3, 7), nil, 700, 0)
 	fk, fu := buildMixedCorpus(555, 200)
 	keys := append(append([][]byte{}, fk...), k1...)
@@ -251,12 +208,20 @@ func TestProcessedKeysCountsDeepFoldedStorage(t *testing.T) {
 
 	ms := NewMockState(t)
 	ms.SetConcurrentCommitment(true)
+	require.NoError(t, ms.applyPlainUpdates(keys, upds))
 
-	before := mxTrieProcessedKeys.GetValueUint64()
-	_, _, deepFolds := parallelBatchDeepFolds(t, ms, 4, keys, upds, nil)
-	published := mxTrieProcessedKeys.GetValueUint64() - before
+	tr := newParTrie(t, ms, 4)
+	defer tr.Release()
+	ut := NewUpdates(ModeParallel, t.TempDir(), KeyToHexNibbleHash)
+	defer ut.Close()
+	for _, k := range keys {
+		ut.TouchPlainKey(string(k), nil, nil)
+	}
+	_, err := tr.Process(context.Background(), ut, "", nil, WarmupConfig{})
+	require.NoError(t, err)
 
-	require.Positive(t, deepFolds, "the whale must take the concurrent deep fold")
-	assert.GreaterOrEqual(t, published, uint64(len(keys)),
+	require.Positive(t, tr.DeepLocalFolds(), "the whale must take the concurrent deep fold")
+	v := tr.metrics.AsValues()
+	assert.GreaterOrEqual(t, v.AddressKeys+v.StorageKeys, uint64(len(keys)),
 		"every touched key is traversed at least once, deep-folded storage included")
 }

--- a/execution/commitment/parallel_mount.go
+++ b/execution/commitment/parallel_mount.go
@@ -284,7 +284,12 @@ func (p *ParallelPatriciaHashed) newStorageWorker(ctx context.Context) (*HexPatr
 	if p.template != nil {
 		traceW = p.template.traceW
 	}
-	return newDeferredStorageWorker(ctx, p.accountKeyLen, p.cfg, p.trieCtxFactory, traceW)
+	w, release := newDeferredStorageWorker(ctx, p.accountKeyLen, p.cfg, p.trieCtxFactory, traceW)
+	w.metrics.Reset()
+	return w, func() {
+		p.metrics.Merge(w.metrics)
+		release()
+	}
 }
 
 func setAccountStorageRoot(w *HexPatriciaHashed, accHash []byte, sr cell) {

--- a/execution/commitment/prom_metrics.go
+++ b/execution/commitment/prom_metrics.go
@@ -32,9 +32,8 @@ import (
 // trie now does the same. Publishing from the executor's log ticker instead
 // would both mis-difference that snapshot and drop every round between ticks.
 var (
-	mxRounds = metrics.GetOrCreateCounter("commitment_rounds_total")
-
-	// Buckets span a fast incremental block through a whale fold.
+	// Buckets span a fast incremental block through a whale fold. The histogram's
+	// _count is the round count; a separate counter for it would restate it.
 	mxRoundDuration = metrics.NewHistogram("commitment_round_duration_seconds",
 		[]float64{0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60})
 
@@ -88,7 +87,6 @@ func publishBranchWrites(n, bytesOut int, m *Metrics) {
 // observeRound publishes one finished round. Branch writes are not published
 // here — publishBranchWrites bills those where they land.
 func observeRound(m *Metrics, start time.Time) {
-	mxRounds.Inc()
 	mxRoundDuration.ObserveDuration(start)
 	if m == nil {
 		return

--- a/execution/commitment/prom_metrics.go
+++ b/execution/commitment/prom_metrics.go
@@ -38,7 +38,11 @@ var (
 	mxRoundDuration = metrics.NewHistogram("commitment_round_duration_seconds",
 		[]float64{0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60})
 
-	mxKeys       = metrics.GetOrCreateCounter("commitment_keys_total")
+	mxKeys = metrics.GetOrCreateCounter("commitment_keys_total")
+
+	// Same event as mxTraversals, under the name the shipped dashboards use.
+	mxTrieProcessedKeys = metrics.GetOrCreateCounter("domain_commitment_keys")
+
 	mxFolds      = metrics.GetOrCreateCounter("commitment_folds_total")
 	mxUnfolds    = metrics.GetOrCreateCounter("commitment_unfolds_total")
 	mxBranchPuts = metrics.GetOrCreateCounter("commitment_branch_writes_total")
@@ -100,6 +104,7 @@ func observeRound(m *Metrics, start time.Time) {
 	addU64(mxReadBytes, v.BranchReadBytes)
 	addVec(mxTraversals, "address", v.AddressKeys)
 	addVec(mxTraversals, "storage", v.StorageKeys)
+	addU64(mxTrieProcessedKeys, v.AddressKeys+v.StorageKeys)
 	addVec(mxReads, "account", v.LoadAccount)
 	addVec(mxReads, "storage", v.LoadStorage)
 	addVec(mxReads, "branch", v.LoadBranch)

--- a/execution/commitment/prom_metrics.go
+++ b/execution/commitment/prom_metrics.go
@@ -38,11 +38,7 @@ var (
 	mxRoundDuration = metrics.NewHistogram("commitment_round_duration_seconds",
 		[]float64{0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60})
 
-	mxKeys = metrics.GetOrCreateCounter("commitment_keys_total")
-
-	// Same event as mxTraversals, under the name the shipped dashboards use.
-	mxTrieProcessedKeys = metrics.GetOrCreateCounter("domain_commitment_keys")
-
+	mxKeys       = metrics.GetOrCreateCounter("commitment_keys_total")
 	mxFolds      = metrics.GetOrCreateCounter("commitment_folds_total")
 	mxUnfolds    = metrics.GetOrCreateCounter("commitment_unfolds_total")
 	mxBranchPuts = metrics.GetOrCreateCounter("commitment_branch_writes_total")
@@ -104,7 +100,6 @@ func observeRound(m *Metrics, start time.Time) {
 	addU64(mxReadBytes, v.BranchReadBytes)
 	addVec(mxTraversals, "address", v.AddressKeys)
 	addVec(mxTraversals, "storage", v.StorageKeys)
-	addU64(mxTrieProcessedKeys, v.AddressKeys+v.StorageKeys)
 	addVec(mxReads, "account", v.LoadAccount)
 	addVec(mxReads, "storage", v.LoadStorage)
 	addVec(mxReads, "branch", v.LoadBranch)


### PR DESCRIPTION
Three counters restated a counter that was already there, two of them on the commitment hot path. `domain_commitment_keys` incremented once per key at the end of `followAndUpdate`, right after `updateCell` bumps `commitment_key_traversals_total` for the same event; `domain_commitment_updates_applied` was added at the same three sites as `commitment_branch_writes_total`, with the same values; `commitment_rounds_total` was incremented next to the round histogram, which already exposes `_count`. The first two are process-global, so every mount worker contended on them.

Removing the per-key one exposed a separate gap: the deep-fold storage worker's counters are never merged into the round. `newStorageWorker` builds a worker off the trie pool and releases it without the `Reset` on checkout and `Merge` before release that the mount worker in the same file already does, so every key a deep fold handles is missing from `commitment_key_traversals_total`, `commitment_reads_total`, `commitment_folds_total` and `commitment_branch_read_bytes_total`. On a 1601-key round with one 1400-slot whale, 201 of 1601 keys are counted.

## Changes
- `domain_commitment_keys` removed. It is `sum without (kind) (commitment_key_traversals_total)`, from the same two values in the same round snapshot.
- `domain_commitment_updates_applied` removed. It is `commitment_branch_writes_total`.
- `commitment_rounds_total` removed. It is `commitment_round_duration_seconds_count`.
- `newStorageWorker` resets the deferred storage worker's metrics on checkout and merges them into the round before releasing it, matching `processMounted`.
- `dashboards/erigon_custom_metrics` repoints the two panels that named a removed metric. The `cmd/prometheus` copy is left alone; it is not the maintained dashboard.
- `TestDeepFoldedStorageReachesRoundMetrics` pins the merge: dropping it fails at 201 against 1601.

## Notes
The merge fix raises the reported values of the four counters above on rounds that deep-fold a whale. They were undercounting, not over-reporting now.

The two branch-write counters agreed except on the `ApplyDeferredBranchUpdates` error returns, which billed the partial count to `commitment_branch_writes_total` alone.

Left alone here, found while auditing the rest of the commitment metrics:

- `commitment_folds_total` undercounts on the parallel engine because `foldMounted`'s fold is uninstrumented: 552 folds on a 900-key parallel round against the sequential engine's 601. The folds and unfolds under `Witnesses` are uncounted too.
- `trie_state_levelled_{skip,load}_rate{level="L0"}` is never written. `Li` starts at 0 and is incremented before indexing, so the first bucket used is `L1`. Correcting it would re-label every series in that family, since `ends` is sorted newest-first and the `min(Li, 5)` catch-all labelled `recent` actually collects the oldest files.
- The 24 `trie_state_levelled_*` series, `domain_commitment_took` and `domain_running_commitment` only move under `KV_READ_METRICS=true`, which defaults to false. Two dashboard panels read empty on a default node.
