### PR TITLE
[r3.6] release: Erigon v3.6.1

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,6 @@
 # Erigon v3.6.1 — Upstream Underbelly — 2026-09-09
 
-v3.6.1 is a bugfix release recommended for all users. It fixes a downloader regression that could silently replace a valid local snapshot (#23859), a peer-ban bypass that let a banned Caplin peer reconnect immediately (#23866), and an index-build defect that could leave stale bits in a `recsplit` index after a salt-collision retry (#23858). It is a drop-in upgrade from 3.6.0 — no re-sync required.
+v3.6.1 is a bugfix and security release recommended for all users. It fixes a downloader regression that could silently replace a valid local snapshot (#23859), a peer-ban bypass that let a banned Caplin peer reconnect immediately (#23866), an index-build defect that could leave stale bits in a `recsplit` index after a salt-collision retry (#23858), and bumps `google.golang.org/grpc` for two HIGH-severity CVEs (#23888). It is a drop-in upgrade from 3.6.0 — no re-sync required.
 
 **Bugfixes**
 
@@ -15,6 +15,7 @@ v3.6.1 is a bugfix release recommended for all users. It fixes a downloader regr
 **Security**
 
 - p2p/discover: require a proven bond before accepting a PING endpoint statement (#23639) by @yperbasis — an unbonded PING could feed an arbitrary claimed address into a node's local endpoint predictor; a statement is now only accepted once a recent PONG has proven return reachability.
+- build: bump `google.golang.org/grpc` to v1.83.2 (#23888) by @lystopad — CVE-2026-84304: fragmented HTTP/2 DATA frames were each stored as a separate `recvMsg`, letting an unauthenticated peer exhaust heap memory with many one-byte frames across concurrent streams. CVE-2026-84445: an xDS gRPC server panicked on a request missing both `:authority` and `Host`; not reachable in Erigon, which never calls `xds.NewGRPCServer()`.
 
 **Improvements**
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,29 @@
+# Erigon v3.6.1 — Upstream Underbelly — 2026-09-09
+
+v3.6.1 is a bugfix release recommended for all users. It fixes a downloader regression that could silently replace a valid local snapshot (#23859), a peer-ban bypass that let a banned Caplin peer reconnect immediately (#23866), and an index-build defect that could leave stale bits in a `recsplit` index after a salt-collision retry (#23858). It is a drop-in upgrade from 3.6.0 — no re-sync required.
+
+**Bugfixes**
+
+- db/downloader: keep local snapshot data once the initial download is complete (#23859) by @AskAlexSharov — a locally-differing `.seg` that no longer matched its `.torrent` was silently replaced even after `preverified.toml` existed; it is now kept and registered for seeding, with a warn-level log when a mismatched file is still replaced. Fixes #21522.
+- cl/sentinel: honour the peer ban on inbound connections (#23866) by @lystopad — `BanStatus` was only consulted on outbound dials, so a peer already three-strike banned still received a fresh handshake on every inbound reconnect; one Gnosis archive node logged 13,827 failed handshakes against 1,638 banned peers in ninety minutes. Fixes #23605.
+- db/recsplit: reset the Golomb-Rice encoder, Elias-Fano structure, and existence filter on `ResetNextSalt` (#23858) by @AskAlexSharov — retrying an index build after a salt collision left the failed attempt's encoded bits and existence-filter data in place, corrupting the rebuilt index.
+- sd: lock `changesetMu` on every `DomainPut`, not only on field reads (#23680) by @AskAlexSharov — the mutex guarded reads of change-set state but not the writes that mutate it, leaving a data race under concurrent commits.
+- rpc/jsonrpc: report base-fee sub-pool transactions as pending (#23647) by @lupin012 — transactions parked in the base-fee sub-pool were reported as queued instead of pending, understating the pending count seen by clients and tooling.
+- cl/beacon: report a syncing node as 503, not 500 (#23608) by @lystopad — the committee-subscription and duties endpoints answered `500 Internal Server Error` while starting up or catching up, where beacon-APIs specifies `503 CurrentlySyncing`; alerting on 500s no longer fires on ordinary startup or resync.
+- cl: seed the ENR custody group count instead of an empty entry (#23591) by @lystopad — nodes advertised an empty PeerDAS custody-group-count ENR entry, making them unselectable as custody peers by counterparties that filter on it.
+
+**Security**
+
+- p2p/discover: require a proven bond before accepting a PING endpoint statement (#23639) by @yperbasis — an unbonded PING could feed an arbitrary claimed address into a node's local endpoint predictor; a statement is now only accepted once a recent PONG has proven return reachability.
+
+**Improvements**
+
+- cl, cmd/utils: derive the data-column retention window from the chain config instead of a hardcoded constant, guarding the derivation against zero and overflow inputs (#23851, #23863) by @lystopad — mainnet retention grows from 131072 to 131104 slots (one extra epoch of alignment slack); Gnosis and Chiado drop from 131072 to 65552.
+
+**Full Changelog**: https://github.com/erigontech/erigon/compare/v3.6.0...v3.6.1
+
+---
+
 # Erigon v3.6.0 — Upstream Underbelly — 2026-08-24
 
 Erigon 3.6.0 is headlined by **more reliable Caplin block production**, **pruned nodes reclaiming old snapshots**, and

--- a/db/version/app.go
+++ b/db/version/app.go
@@ -32,7 +32,7 @@ var (
 const (
 	Major                    = 3             // Major version component of the current release
 	Minor                    = 6             // Minor version component of the current release
-	Micro                    = 0             // Patch version component of the current release
+	Micro                    = 1             // Patch version component of the current release
 	Modifier                 = ""            // Modifier component of the current release
 	DefaultSnapshotGitBranch = "release/3.6" // Branch of erigontech/erigon-snapshot to use in OtterSync.
 	VersionKeyCreated        = "ErigonVersionCreated"


### PR DESCRIPTION
Prepares the Erigon v3.6.1 bugfix release on `release/3.6`.

- **`db/version/app.go`**: bump `Micro` `0` -> `1` (3.6.0 -> 3.6.1).
- **`ChangeLog.md`**: add the v3.6.1 release notes section.

## Included since v3.6.0

**Bugfixes**
- db/downloader: keep local snapshot data once the initial download is complete (#23859, fixes #21522)
- cl/sentinel: honour the peer ban on inbound connections (#23866, fixes #23605)
- db/recsplit: reset encoder/filter state on `ResetNextSalt` (#23858)
- sd: lock `changesetMu` on every `DomainPut` (#23680)
- rpc/jsonrpc: report base-fee sub-pool transactions as pending (#23647)
- cl/beacon: report a syncing node as 503, not 500 (#23608)
- cl: seed the ENR custody group count instead of an empty entry (#23591)

**Security**
- p2p/discover: require a proven bond before accepting a PING endpoint statement (#23639)

**Improvements**
- cl, cmd/utils: derive the data-column retention window from the chain config (#23851, #23863)

## Not listed in the release notes

Docs-only and CI-only, per the established convention of omitting them:
#23870, #23674, #23850, #23827, #23828 (test-only flaky fix), #23595, #23625, #23628, #23587, #23593, #23601, #23582, #23570, #23550, #23283, #23477, #23530

**Full Changelog**: https://github.com/erigontech/erigon/compare/v3.6.0...v3.6.1

## Notes for reviewers

- `ChangeLog.md` and `db/version/app.go` only — documentation and a version-constant bump, so TDD does not apply per the repo's mechanical-changes exception.
- All 3.6.2-milestone items (performance-regression follow-up, SELFDESTRUCT/parallel-exec TxOut bug, Caplin LRU goroutine leak) were deliberately excluded from this release's scope.

## Follow-up

After this release, port the v3.6.1 notes to `main`'s `ChangeLog.md`, mirroring how #23554 ported the 3.6.0 notes and #23196 ported 3.5.5's.