### PR TITLE
[r3.6] build: bump google.golang.org/grpc to v1.83.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -118,7 +118,7 @@ require (
 	golang.org/x/sys v0.47.0
 	golang.org/x/text v0.41.0
 	golang.org/x/time v0.15.0
-	google.golang.org/grpc v1.83.0
+	google.golang.org/grpc v1.83.2
 	google.golang.org/protobuf v1.36.12
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1318,8 +1318,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
-google.golang.org/grpc v1.83.0 h1:JeNZEKJFbQxArAMl+hiytHauacDNqJUllNfmIMmpqnQ=
-google.golang.org/grpc v1.83.0/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
+google.golang.org/grpc v1.83.2 h1:EManeRomTObA0BU7I8vXgg/78uE5MJ9M8B39EX2WscU=
+google.golang.org/grpc v1.83.2/go.mod h1:YPI1hK3kDked6iHvgX3tR0y+nX/qpMFKhPgFsokw1S8=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.6.2 h1:rgSNvqscFZ1JgV/4wH5GOsZFSFkR2Eua9As3KIr2LlM=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.6.2/go.mod h1:iMEtFwDlAhjDU9L5mY6U1XLwlIId/G3h+QcBHDIvrJ8=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=


### PR DESCRIPTION
Fixes two HIGH-severity CVEs flagged by the release-branch security scan (https://github.com/erigontech/erigon/actions/runs/34310690185/) against the installed v1.83.0:

- **CVE-2026-84304** ([GHSA-vp52-pcj8-j9qc](https://github.com/advisories/GHSA-vp52-pcj8-j9qc), fixed in 1.83.1) — the HTTP/2 transport stores each fragmented DATA frame as a separate `recvMsg` in `recvBuffer`, so an unauthenticated peer can drive disproportionate heap usage with many one-byte frames across concurrent multiplexed streams, even within flow-control limits — a remote DoS via memory exhaustion / panic.
- **CVE-2026-84445** ([GHSA-2v4p-qf9q-27wj](https://github.com/advisories/GHSA-2v4p-qf9q-27wj), fixed in 1.82.2/1.83.2/1.85.0-dev) — a gRPC-Go xDS server built with `xds.NewGRPCServer()` panics (index out of bounds in the routing interceptor) on a request missing both `:authority` and `Host`. **Not reachable in Erigon** — `grep -rn "xds.NewGRPCServer"` finds no call sites — but v1.83.2 also fixes this one, so bumping to it clears both advisories in one move.

`v1.83.2` matches what `main` already carries (via #23267), so no new compatibility surface versus what's already running there.

## Scope

Scoped to `google.golang.org/grpc` only — `go get google.golang.org/grpc@v1.83.2 && go mod tidy`. Deliberately not backporting #23267's other bundled bumps (x/*, protobuf, mcp-go, roaring, kong); those are unrelated to this scan finding and out of scope for a security-only backport.

`go build ./...` clean. Dependency bump, mechanical — TDD does not apply.

## Follow-up

This should land before the v3.6.1 tag; #23886 (the v3.6.1 release/changelog PR) will get a **Security** entry referencing this PR's number once it merges.