### PR TITLE
cl: support Gloas-at-genesis state shape

### DIFF
--- a/.github/workflows/kurtosis/gloas-caplin-genesis.io
+++ b/.github/workflows/kurtosis/gloas-caplin-genesis.io
@@ -1,0 +1,32 @@
+participants:
+  - cl_type: caplin
+    cl_image: test/erigon:current
+    cl_log_level: "debug"
+    cl_extra_params: ["--local-discovery", "--caplin.subscribe-all-topics", "--beacon.api=beacon,validator,node,config,debug"]
+    el_type: erigon
+    el_image: test/erigon:current
+    el_log_level: "debug"
+    el_extra_params: ["--experimental.bal"]
+    use_separate_vc: true
+    vc_type: lighthouse
+    vc_image: ethpandaops/lighthouse:glamsterdam-devnet-8
+    count: 1
+global_log_level: "debug"
+network_params:
+  preset: mainnet
+  seconds_per_slot: 6
+  genesis_delay: 20
+  altair_fork_epoch: 0
+  bellatrix_fork_epoch: 0
+  capella_fork_epoch: 0
+  deneb_fork_epoch: 0
+  electra_fork_epoch: 0
+  fulu_fork_epoch: 0
+  gloas_fork_epoch: 0
+ethereum_genesis_generator_params:
+  image: ethpandaops/ethereum-genesis-generator:6.2.0
+additional_services: [assertoor]
+assertoor_params:
+  run_stability_check: false
+  run_block_proposal_check: true
+  image: ethpandaops/assertoor:v0.1.3

--- a/.github/workflows/kurtosis/gloas-caplin-genesis.io
+++ b/.github/workflows/kurtosis/gloas-caplin-genesis.io
@@ -3,10 +3,9 @@ participants:
     cl_image: test/erigon:current
     cl_log_level: "debug"
     cl_extra_params: ["--local-discovery", "--caplin.subscribe-all-topics", "--beacon.api=beacon,validator,node,config,debug"]
-    el_type: erigon
-    el_image: test/erigon:current
+    el_type: geth
+    el_image: ethpandaops/geth:glamsterdam-devnet-8
     el_log_level: "debug"
-    el_extra_params: ["--experimental.bal"]
     use_separate_vc: true
     vc_type: lighthouse
     vc_image: ethpandaops/lighthouse:glamsterdam-devnet-8
@@ -14,7 +13,7 @@ participants:
 global_log_level: "debug"
 network_params:
   preset: mainnet
-  seconds_per_slot: 6
+  seconds_per_slot: 12
   genesis_delay: 20
   altair_fork_epoch: 0
   bellatrix_fork_epoch: 0

--- a/.github/workflows/test-kurtosis-gloas.yml
+++ b/.github/workflows/test-kurtosis-gloas.yml
@@ -400,6 +400,7 @@ jobs:
 
       - name: Verify Gloas genesis and payload attestations through the Beacon API
         if: matrix.suite == 'gloas-caplin-genesis'
+        timeout-minutes: 5
         run: |
           set -euo pipefail
           enclave_name="kurtosis-${{ matrix.suite }}-${{ github.run_id }}"
@@ -413,6 +414,7 @@ jobs:
             --retry 4
             --retry-delay 1
             --retry-connrefused
+            --retry-max-time 30
             --connect-timeout 5
             --max-time 15
           )
@@ -439,6 +441,7 @@ jobs:
           initial_head_slot=$(jq -er '.data.message.slot | tonumber' "$api_tmp_dir/head.json")
           target_head_slot=$((initial_head_slot + 8))
           last_head_slot=$initial_head_slot
+          next_slot=$((initial_head_slot > 8 ? initial_head_slot - 8 : 1))
           deadline=$((SECONDS + 180))
           payload_attestation_found=false
           while ((SECONDS < deadline)); do
@@ -447,8 +450,10 @@ jobs:
               --output "$api_tmp_dir/head.json"
             head_slot=$(jq -er '.data.message.slot | tonumber' "$api_tmp_dir/head.json")
             last_head_slot=$head_slot
-            first_slot=$((initial_head_slot > 8 ? initial_head_slot - 8 : 1))
-            for ((slot = first_slot; slot <= head_slot; slot++)); do
+            for ((slot = next_slot; slot <= head_slot; slot++)); do
+              if ((SECONDS >= deadline)); then
+                break 2
+              fi
               if curl "${curl_args[@]}" \
                 "$beacon_url/eth/v2/beacon/blocks/$slot" \
                 --output "$api_tmp_dir/candidate.json"; then
@@ -467,13 +472,17 @@ jobs:
                       test("^0x[0-9a-fA-F]{192}$") and
                       (test("^0x0+$"; "i") | not)
                     )
+                  ) and
+                  any(.data.message.body.payload_attestations[];
+                    .data.payload_present == true
                   )
                 ' "$api_tmp_dir/candidate.json"; then
-                  echo "Found payload attestations in Gloas block at slot $slot"
+                  echo "Found available payload attestations in Gloas block at slot $slot"
                   payload_attestation_found=true
                   break 2
                 fi
               fi
+              next_slot=$((slot + 1))
             done
             if ((head_slot >= target_head_slot)); then
               break

--- a/.github/workflows/test-kurtosis-gloas.yml
+++ b/.github/workflows/test-kurtosis-gloas.yml
@@ -210,6 +210,10 @@ jobs:
             package_args: .github/workflows/kurtosis/gloas-three-cl-mixed.io
             ethereum_package_branch: "6.1.0"
             test_timeout_minutes: 20
+          - suite: gloas-caplin-genesis
+            package_args: .github/workflows/kurtosis/gloas-caplin-genesis.io
+            ethereum_package_branch: "6.1.0"
+            test_timeout_minutes: 30
 
     steps:
       - name: Fast checkout git repository
@@ -393,6 +397,23 @@ jobs:
             ethereum_package_branch: "${{ matrix.ethereum_package_branch }}"
             kurtosis_extra_args: --verbosity detailed --cli-log-level trace
             persistent_logs: "true"
+
+      - name: Verify Gloas genesis through the Beacon API
+        if: matrix.suite == 'gloas-caplin-genesis'
+        run: |
+          set -euo pipefail
+          enclave_name="kurtosis-${{ matrix.suite }}-${{ github.run_id }}"
+          beacon_url=$(kurtosis port print "$enclave_name" cl-1-caplin-erigon http)
+          curl --fail --silent --show-error \
+            "$beacon_url/eth/v2/debug/beacon/states/genesis" \
+            | jq -e '
+                .version == "gloas" and
+                .data.slot == "0" and
+                (.data.latest_execution_payload_bid.block_hash != "0x" + ("0" * 64)) and
+                (.data.latest_execution_payload_bid.gas_limit | tonumber) > 0 and
+                (.data.latest_execution_payload_bid.execution_requests_root != "0x" + ("0" * 64)) and
+                .data.latest_block_hash == .data.latest_execution_payload_bid.block_hash
+              '
 
       - name: Dump Kurtosis enclave on failure
         if: failure()

--- a/.github/workflows/test-kurtosis-gloas.yml
+++ b/.github/workflows/test-kurtosis-gloas.yml
@@ -398,18 +398,28 @@ jobs:
             kurtosis_extra_args: --verbosity detailed --cli-log-level trace
             persistent_logs: "true"
 
-      - name: Verify Gloas genesis through the Beacon API
+      - name: Verify Gloas genesis and payload attestations through the Beacon API
         if: matrix.suite == 'gloas-caplin-genesis'
         run: |
           set -euo pipefail
           enclave_name="kurtosis-${{ matrix.suite }}-${{ github.run_id }}"
-          beacon_url=$(kurtosis port print "$enclave_name" cl-1-caplin-erigon http)
+          beacon_url=$(kurtosis port print "$enclave_name" cl-1-caplin-geth http)
           api_tmp_dir=$(mktemp -d)
           trap 'rm -r "$api_tmp_dir"' EXIT
-          curl --fail --silent --show-error \
+          curl_args=(
+            --fail
+            --silent
+            --show-error
+            --retry 4
+            --retry-delay 1
+            --retry-connrefused
+            --connect-timeout 5
+            --max-time 15
+          )
+          curl "${curl_args[@]}" \
             "$beacon_url/eth/v2/debug/beacon/states/genesis" \
             --output "$api_tmp_dir/state.json"
-          curl --fail --silent --show-error \
+          curl "${curl_args[@]}" \
             "$beacon_url/eth/v2/beacon/blocks/genesis" \
             --output "$api_tmp_dir/block.json"
           jq -e --slurpfile block "$api_tmp_dir/block.json" '
@@ -420,6 +430,64 @@ jobs:
             .data.latest_execution_payload_bid ==
               $block[0].data.message.body.signed_execution_payload_bid.message
           ' "$api_tmp_dir/state.json"
+
+          curl "${curl_args[@]}" \
+            "$beacon_url/eth/v2/beacon/blocks/head" \
+            --output "$api_tmp_dir/head.json"
+          initial_head_slot=$(jq -er '.data.message.slot | tonumber' "$api_tmp_dir/head.json")
+          target_head_slot=$((initial_head_slot + 8))
+          last_head_slot=$initial_head_slot
+          deadline=$((SECONDS + 180))
+          payload_attestation_found=false
+          while ((SECONDS < deadline)); do
+            curl "${curl_args[@]}" \
+              "$beacon_url/eth/v2/beacon/blocks/head" \
+              --output "$api_tmp_dir/head.json"
+            head_slot=$(jq -er '.data.message.slot | tonumber' "$api_tmp_dir/head.json")
+            last_head_slot=$head_slot
+            first_slot=$((initial_head_slot > 8 ? initial_head_slot - 8 : 1))
+            for ((slot = first_slot; slot <= head_slot; slot++)); do
+              if curl "${curl_args[@]}" \
+                "$beacon_url/eth/v2/beacon/blocks/$slot" \
+                --output "$api_tmp_dir/candidate.json"; then
+                if jq -e '
+                  (.data.message.slot | tonumber) as $block_slot |
+                  .version == "gloas" and
+                  $block_slot > 0 and
+                  (.data.message.body.payload_attestations | length) > 0 and
+                  all(.data.message.body.payload_attestations[];
+                    (.data.slot | tonumber) == ($block_slot - 1) and
+                    (.aggregation_bits |
+                      test("^0x[0-9a-fA-F]+$") and
+                      (test("^0x0+$"; "i") | not)
+                    ) and
+                    (.signature |
+                      test("^0x[0-9a-fA-F]{192}$") and
+                      (test("^0x0+$"; "i") | not)
+                    )
+                  )
+                ' "$api_tmp_dir/candidate.json"; then
+                  echo "Found payload attestations in Gloas block at slot $slot"
+                  payload_attestation_found=true
+                  break 2
+                fi
+              fi
+            done
+            if ((head_slot >= target_head_slot)); then
+              break
+            fi
+            echo "Waiting for payload attestations: head slot $head_slot, target slot $target_head_slot"
+            sleep 3
+          done
+          if [ "$payload_attestation_found" = true ]; then
+            exit 0
+          fi
+          if ((last_head_slot < target_head_slot)); then
+            echo "::error::Chain liveness failure: head only advanced from slot $initial_head_slot to $last_head_slot before the deadline"
+          else
+            echo "::error::No canonical Gloas block exposed a payload attestation by head slot $last_head_slot"
+          fi
+          exit 1
 
       - name: Dump Kurtosis enclave on failure
         if: failure()

--- a/.github/workflows/test-kurtosis-gloas.yml
+++ b/.github/workflows/test-kurtosis-gloas.yml
@@ -404,16 +404,22 @@ jobs:
           set -euo pipefail
           enclave_name="kurtosis-${{ matrix.suite }}-${{ github.run_id }}"
           beacon_url=$(kurtosis port print "$enclave_name" cl-1-caplin-erigon http)
+          api_tmp_dir=$(mktemp -d)
+          trap 'rm -r "$api_tmp_dir"' EXIT
           curl --fail --silent --show-error \
             "$beacon_url/eth/v2/debug/beacon/states/genesis" \
-            | jq -e '
-                .version == "gloas" and
-                .data.slot == "0" and
-                (.data.latest_execution_payload_bid.block_hash != "0x" + ("0" * 64)) and
-                (.data.latest_execution_payload_bid.gas_limit | tonumber) > 0 and
-                (.data.latest_execution_payload_bid.execution_requests_root != "0x" + ("0" * 64)) and
-                .data.latest_block_hash == .data.latest_execution_payload_bid.block_hash
-              '
+            --output "$api_tmp_dir/state.json"
+          curl --fail --silent --show-error \
+            "$beacon_url/eth/v2/beacon/blocks/genesis" \
+            --output "$api_tmp_dir/block.json"
+          jq -e --slurpfile block "$api_tmp_dir/block.json" '
+            .version == "gloas" and
+            .data.slot == "0" and
+            $block[0].version == "gloas" and
+            $block[0].data.message.slot == "0" and
+            .data.latest_execution_payload_bid ==
+              $block[0].data.message.body.signed_execution_payload_bid.message
+          ' "$api_tmp_dir/state.json"
 
       - name: Dump Kurtosis enclave on failure
         if: failure()

--- a/.github/workflows/test-kurtosis-gloas.yml
+++ b/.github/workflows/test-kurtosis-gloas.yml
@@ -427,6 +427,8 @@ jobs:
             .data.slot == "0" and
             $block[0].version == "gloas" and
             $block[0].data.message.slot == "0" and
+            .data.latest_execution_payload_bid != null and
+            $block[0].data.message.body.signed_execution_payload_bid.message != null and
             .data.latest_execution_payload_bid ==
               $block[0].data.message.body.signed_execution_payload_bid.message
           ' "$api_tmp_dir/state.json"

--- a/cmd/caplin/caplin1/dev_genesis.go
+++ b/cmd/caplin/caplin1/dev_genesis.go
@@ -99,10 +99,6 @@ func devGenesisBeaconBody(genesisState *state.CachingBeaconState, cfg *clparams.
 	}
 	if version >= clparams.GloasVersion {
 		if bid := genesisState.GetLatestExecutionPayloadBid(); bid != nil {
-			header := genesisState.LatestBlockHeader()
-			if root, err := body.HashSSZ(); err == nil && root == header.BodyRoot {
-				return body
-			}
 			body.SignedExecutionPayloadBid.Message = bid
 		}
 	}

--- a/cmd/caplin/caplin1/dev_genesis.go
+++ b/cmd/caplin/caplin1/dev_genesis.go
@@ -34,33 +34,8 @@ func writeDevGenesisBeaconBlock(ctx context.Context, genesisState *state.Caching
 	}
 	blk.StateRoot = stateRoot
 
-	// Initialize the body with preset-aware defaults.
-	body := blk.Body
-	if version >= clparams.AltairVersion {
-		body.SyncAggregate = cltypes.NewSyncAggregateWithSize(int(cfg.SyncCommitteeSize) / 8)
-	}
-	// [Modified in Gloas:EIP7732] GLOAS blocks do not have ExecutionPayload in the body.
-	if version >= clparams.BellatrixVersion && version < clparams.GloasVersion {
-		body.ExecutionPayload.Extra = solid.NewExtraData()
-		body.ExecutionPayload.Transactions = &solid.TransactionsSSZ{}
-
-		// Copy execution payload header from genesis state so the block hash
-		// matches the EL genesis (needed for fork choice to find the EL block).
-		execHeader := genesisState.LatestExecutionPayloadHeader()
-		if execHeader != nil {
-			body.ExecutionPayload.BlockHash = execHeader.BlockHash
-			body.ExecutionPayload.StateRoot = execHeader.StateRoot
-			body.ExecutionPayload.ParentHash = execHeader.ParentHash
-			body.ExecutionPayload.BlockNumber = execHeader.BlockNumber
-			body.ExecutionPayload.GasLimit = execHeader.GasLimit
-			body.ExecutionPayload.Time = execHeader.Time
-			body.ExecutionPayload.BaseFeePerGas = execHeader.BaseFeePerGas
-		}
-
-		if version >= clparams.CapellaVersion {
-			body.ExecutionPayload.Withdrawals = solid.NewStaticListSSZ[*cltypes.Withdrawal](int(cfg.MaxWithdrawalsPerPayload), 44)
-		}
-	}
+	body := devGenesisBeaconBody(genesisState, cfg)
+	blk.Body = body
 
 	// Verify the reconstructed body root matches what the genesis state header expects.
 	// A mismatch means the block root we write differs from state.BlockRoot(), breaking
@@ -95,4 +70,41 @@ func writeDevGenesisBeaconBlock(ctx context.Context, genesisState *state.Caching
 	return db.Update(ctx, func(tx kv.RwTx) error {
 		return beacon_indicies.WriteBeaconBlockAndIndicies(ctx, tx, block, true)
 	})
+}
+
+func devGenesisBeaconBody(genesisState *state.CachingBeaconState, cfg *clparams.BeaconChainConfig) *cltypes.BeaconBody {
+	version := genesisState.Version()
+	body := cltypes.NewBeaconBody(cfg, version)
+	if version >= clparams.AltairVersion {
+		body.SyncAggregate = cltypes.NewSyncAggregateWithSize(int(cfg.SyncCommitteeSize) / 8)
+	}
+	if version >= clparams.BellatrixVersion && version < clparams.GloasVersion {
+		body.ExecutionPayload.Extra = solid.NewExtraData()
+		body.ExecutionPayload.Transactions = &solid.TransactionsSSZ{}
+
+		execHeader := genesisState.LatestExecutionPayloadHeader()
+		if execHeader != nil {
+			body.ExecutionPayload.BlockHash = execHeader.BlockHash
+			body.ExecutionPayload.StateRoot = execHeader.StateRoot
+			body.ExecutionPayload.ParentHash = execHeader.ParentHash
+			body.ExecutionPayload.BlockNumber = execHeader.BlockNumber
+			body.ExecutionPayload.GasLimit = execHeader.GasLimit
+			body.ExecutionPayload.Time = execHeader.Time
+			body.ExecutionPayload.BaseFeePerGas = execHeader.BaseFeePerGas
+		}
+
+		if version >= clparams.CapellaVersion {
+			body.ExecutionPayload.Withdrawals = solid.NewStaticListSSZ[*cltypes.Withdrawal](int(cfg.MaxWithdrawalsPerPayload), 44)
+		}
+	}
+	if version >= clparams.GloasVersion {
+		if bid := genesisState.GetLatestExecutionPayloadBid(); bid != nil {
+			header := genesisState.LatestBlockHeader()
+			if root, err := body.HashSSZ(); err == nil && root == header.BodyRoot {
+				return body
+			}
+			body.SignedExecutionPayloadBid.Message = bid
+		}
+	}
+	return body
 }

--- a/cmd/caplin/caplin1/dev_genesis_test.go
+++ b/cmd/caplin/caplin1/dev_genesis_test.go
@@ -1,0 +1,91 @@
+package caplin1
+
+import (
+	"testing"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/erigontech/erigon/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDevGenesisBeaconBodyUsesGloasStateBid(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	genesisState := state.New(&cfg)
+	genesisState.SetVersion(clparams.GloasVersion)
+
+	bid := &cltypes.ExecutionPayloadBid{
+		ParentBlockHash:       common.HexToHash("0x01"),
+		BlockHash:             common.HexToHash("0x02"),
+		GasLimit:              30_000_000,
+		BlobKzgCommitments:    *solid.NewStaticProgressiveListSSZ[*cltypes.KZGCommitment](cltypes.MaxBlobsCommittmentsPerBlock, 48),
+		ExecutionRequestsRoot: common.HexToHash("0x03"),
+	}
+	genesisState.SetLatestExecutionPayloadBid(bid)
+
+	body := devGenesisBeaconBody(genesisState, &cfg)
+	require.Equal(t, bid, body.SignedExecutionPayloadBid.Message)
+
+	expected := cltypes.NewBeaconBody(&cfg, clparams.GloasVersion)
+	expected.SyncAggregate = cltypes.NewSyncAggregateWithSize(int(cfg.SyncCommitteeSize) / 8)
+	expected.SignedExecutionPayloadBid.Message = bid
+	expectedRoot, err := expected.HashSSZ()
+	require.NoError(t, err)
+	bodyRoot, err := body.HashSSZ()
+	require.NoError(t, err)
+	require.Equal(t, expectedRoot, bodyRoot)
+}
+
+func TestDevGenesisBeaconBodyUsesPreGloasPayloadHeader(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	genesisState := state.New(&cfg)
+	genesisState.SetVersion(clparams.FuluVersion)
+	header := cltypes.NewEth1Header(clparams.FuluVersion)
+	header.ParentHash = common.HexToHash("0x01")
+	header.StateRoot = common.HexToHash("0x02")
+	header.BlockHash = common.HexToHash("0x03")
+	header.GasLimit = 30_000_000
+	genesisState.SetLatestExecutionPayloadHeader(header)
+
+	body := devGenesisBeaconBody(genesisState, &cfg)
+	require.Equal(t, header.ParentHash, body.ExecutionPayload.ParentHash)
+	require.Equal(t, header.StateRoot, body.ExecutionPayload.StateRoot)
+	require.Equal(t, header.BlockHash, body.ExecutionPayload.BlockHash)
+	require.Equal(t, header.GasLimit, body.ExecutionPayload.GasLimit)
+	require.Nil(t, body.SignedExecutionPayloadBid)
+}
+
+func TestDevGenesisBeaconBodyToleratesMissingGloasBid(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	genesisState := state.New(&cfg)
+	genesisState.SetVersion(clparams.GloasVersion)
+
+	body := devGenesisBeaconBody(genesisState, &cfg)
+	require.NotNil(t, body.SignedExecutionPayloadBid.Message)
+	_, err := body.HashSSZ()
+	require.NoError(t, err)
+}
+
+func TestDevGenesisBeaconBodyPreservesMatchingDefaultGloasBody(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	genesisState := state.New(&cfg)
+	genesisState.SetVersion(clparams.GloasVersion)
+	genesisState.SetLatestExecutionPayloadBid(&cltypes.ExecutionPayloadBid{
+		BlockHash:          common.HexToHash("0x01"),
+		BlobKzgCommitments: *solid.NewStaticProgressiveListSSZ[*cltypes.KZGCommitment](cltypes.MaxBlobsCommittmentsPerBlock, 48),
+	})
+
+	expected := cltypes.NewBeaconBody(&cfg, clparams.GloasVersion)
+	expected.SyncAggregate = cltypes.NewSyncAggregateWithSize(int(cfg.SyncCommitteeSize) / 8)
+	expectedRoot, err := expected.HashSSZ()
+	require.NoError(t, err)
+	genesisState.SetLatestBlockHeader(&cltypes.BeaconBlockHeader{BodyRoot: expectedRoot})
+
+	body := devGenesisBeaconBody(genesisState, &cfg)
+	bodyRoot, err := body.HashSSZ()
+	require.NoError(t, err)
+	require.Equal(t, expectedRoot, bodyRoot)
+	require.Equal(t, common.Hash{}, body.SignedExecutionPayloadBid.Message.BlockHash)
+}

--- a/cmd/caplin/caplin1/dev_genesis_test.go
+++ b/cmd/caplin/caplin1/dev_genesis_test.go
@@ -68,14 +68,15 @@ func TestDevGenesisBeaconBodyToleratesMissingGloasBid(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestDevGenesisBeaconBodyPreservesMatchingDefaultGloasBody(t *testing.T) {
+func TestDevGenesisBeaconBodyUsesGloasStateBidWhenDefaultBodyMatchesHeader(t *testing.T) {
 	cfg := clparams.MainnetBeaconConfig
 	genesisState := state.New(&cfg)
 	genesisState.SetVersion(clparams.GloasVersion)
-	genesisState.SetLatestExecutionPayloadBid(&cltypes.ExecutionPayloadBid{
+	bid := &cltypes.ExecutionPayloadBid{
 		BlockHash:          common.HexToHash("0x01"),
 		BlobKzgCommitments: *solid.NewStaticProgressiveListSSZ[*cltypes.KZGCommitment](cltypes.MaxBlobsCommittmentsPerBlock, 48),
-	})
+	}
+	genesisState.SetLatestExecutionPayloadBid(bid)
 
 	expected := cltypes.NewBeaconBody(&cfg, clparams.GloasVersion)
 	expected.SyncAggregate = cltypes.NewSyncAggregateWithSize(int(cfg.SyncCommitteeSize) / 8)
@@ -86,6 +87,6 @@ func TestDevGenesisBeaconBodyPreservesMatchingDefaultGloasBody(t *testing.T) {
 	body := devGenesisBeaconBody(genesisState, &cfg)
 	bodyRoot, err := body.HashSSZ()
 	require.NoError(t, err)
-	require.Equal(t, expectedRoot, bodyRoot)
-	require.Equal(t, common.Hash{}, body.SignedExecutionPayloadBid.Message.BlockHash)
+	require.Equal(t, bid, body.SignedExecutionPayloadBid.Message)
+	require.NotEqual(t, expectedRoot, bodyRoot)
 }


### PR DESCRIPTION
## Summary

- reconstruct the synthetic Gloas genesis block from `state.latest_execution_payload_bid` whenever the state carries a bid
- add a mainnet-preset ethereum-package suite with every fork, including Gloas, active at epoch 0
- exercise standalone Caplin against a non-Erigon Geth EL with a separate Lighthouse validator client
- verify through Caplin's Beacon API that the genesis state and block expose the same non-null execution payload bid
- verify that a canonical post-genesis Gloas block contains non-empty, signed payload attestations
- use protocol slot timing and bounded Beacon API retries that distinguish missing attestations from chain-liveness failure

This PR builds on the Gloas devnet 8 implementation merged in #23548.

## Issue coverage

- Closes #23385: starts Caplin from a mainnet-preset Gloas `genesis.ssz` with all fork epochs set to 0.
- Closes #23386: runs Caplin from genesis against a non-Erigon Geth execution client.
- Closes #23387: runs a separate Lighthouse validator client through Caplin's validator-facing Beacon API, with block proposal and payload-attestation coverage.
- Closes #23388: #23548 aligned `UpgradeToGloas` with the devnet 8 state shape; this PR covers direct Gloas genesis decoding and enforces the state/block bid agreement required by the Lighthouse-compatible genesis shape.

The Lighthouse/Teku disagreement over the Gloas-at-genesis anchor body remains an upstream interoperability issue tracked in https://github.com/CPerezz/pbt-devnet/issues/6. This PR targets the Lighthouse-compatible genesis shape used by the devnet and does not claim to make one genesis state acceptable to both clients.

The genesis suite deliberately uses the `mainnet` preset, unlike the existing minimal-preset Gloas suites. Its 30-minute timeout accommodates the heavier preset and image startup; the Beacon API assertion itself is slot-driven and bounded.

## Testing

- `go test ./cmd/caplin/caplin1 -count=1`
- `make lint` (two consecutive clean runs)
- `make erigon integration`
- Kurtosis GLOAS workflow: https://github.com/erigontech/erigon/actions/runs/34581082636
  - all three Gloas matrix jobs passed
  - the Caplin + Geth + Lighthouse VC genesis suite passed
  - the non-null genesis state/block bid invariant passed
  - signed payload attestations with `payload_present: true` were observed in canonical Gloas block slot 2
