### PR TITLE
rpc: `eth_getLogs` results conversion in Append-style

### DIFF
--- a/execution/types/log.go
+++ b/execution/types/log.go
@@ -120,16 +120,14 @@ type RPCLog struct {
 	BlockTimestamp hexutil.Uint64 `json:"blockTimestamp" codec:"-"`
 }
 
-// ToRPCLogs converts Logs to RPCLogs, adding a timestamp to each entry.
-func (logs Logs) ToRPCLogs(timestamp uint64) RPCLogs {
-	result := make(RPCLogs, len(logs))
+// AppendRPCLogs appends logs to dst as RPCLogs, adding a timestamp to each entry.
+func (logs Logs) AppendRPCLogs(dst RPCLogs, timestamp uint64) RPCLogs {
+	backing := make([]RPCLog, len(logs))
 	for i, l := range logs {
-		result[i] = &RPCLog{
-			Log:            *l,
-			BlockTimestamp: hexutil.Uint64(timestamp),
-		}
+		backing[i] = RPCLog{Log: *l, BlockTimestamp: hexutil.Uint64(timestamp)}
+		dst = append(dst, &backing[i])
 	}
-	return result
+	return dst
 }
 
 // UnmarshalJSON parses both the embedded Log fields and the RPC-specific blockTimestamp field.

--- a/execution/types/log_test.go
+++ b/execution/types/log_test.go
@@ -395,7 +395,7 @@ func TestRPCLogUnmarshalJSONLegacyTimestampIgnored(t *testing.T) {
 	require.Equal(t, common.HexToAddress("0x3333333333333333333333333333333333333333"), log.Address)
 }
 
-func TestToRPCLogs(t *testing.T) {
+func TestAppendRPCLogs(t *testing.T) {
 	t.Parallel()
 
 	logs := Logs{
@@ -423,7 +423,7 @@ func TestToRPCLogs(t *testing.T) {
 		},
 	}
 
-	rpcLogs := logs.ToRPCLogs(1900000000)
+	rpcLogs := logs.AppendRPCLogs(nil, 1900000000)
 
 	require.Len(t, rpcLogs, len(logs))
 	for i, rpcLog := range rpcLogs {
@@ -432,12 +432,13 @@ func TestToRPCLogs(t *testing.T) {
 	}
 }
 
-func TestToRPCLogsEmpty(t *testing.T) {
+func TestAppendRPCLogsEmpty(t *testing.T) {
 	t.Parallel()
 
-	// Non-nil empty, so eth_getLogs/erigon_getLogs serialise `[]` and not `null`.
+	// Appending nothing must leave dst as it was, so an empty eth_getLogs result
+	// stays non-nil and serialises `[]` and not `null`.
 	for _, logs := range []Logs{{}, nil} {
-		rpcLogs := logs.ToRPCLogs(1)
+		rpcLogs := logs.AppendRPCLogs(RPCLogs{}, 1)
 		require.NotNil(t, rpcLogs)
 		require.Len(t, rpcLogs, 0)
 	}

--- a/rpc/jsonrpc/eth_receipts.go
+++ b/rpc/jsonrpc/eth_receipts.go
@@ -424,7 +424,7 @@ func appendRPCLogs(logs types.RPCLogs, filtered types.Logs, blockTime uint64, ma
 			Message: fmt.Sprintf("%s: %d", errExceedLogResults, maxResults),
 		}
 	}
-	return append(logs, filtered.ToRPCLogs(blockTime)...), nil
+	return filtered.AppendRPCLogs(logs, blockTime), nil
 }
 
 // The Topic list restricts matches to particular event topics. Each event has a list


### PR DESCRIPTION
ToRPCLogs allocated a fresh `RPCLogs` plus one `&RPCLog{}` per log, and its only caller appended that straight into an accumulator - so both were garbage by construction. `AppendRPCLogs` appends into the caller's slice and takes the `RPCLog` values from one backing array.

Microbenchmark over 500 receipts of 2 matching logs (the shape `appendRPCLogs` sees):

| | ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| before | 24400 | 193520 | 1010 |
| after | 22878 | 193527 | 510 |

The non-nil-empty contract moves to the caller: `getLogsV3` already starts from `types.RPCLogs{}`, so an empty result still serialises `[]` and not `null`. `TestAppendRPCLogsEmpty` pins it.
