### PR TITLE
build: compile the cgo deps with clang-22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,16 @@ COPY --from=xx / /
 
 COPY go.mod go.sum /erigon/
 
+## Build the cgo dependencies with clang instead of the image's gcc 12.
+## xx-go prefers clang when an unversioned "clang" is on PATH and falls back to
+## gcc otherwise, so pointing the alternatives at clang-22 is all that is needed.
+RUN apt-get update -qq && apt-get install -y -qq clang-22 lld-22 && \
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-22 100 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-22 100 && \
+    update-alternatives --install /usr/bin/ld.lld ld.lld /usr/bin/ld.lld-22 100
+
 ## Make sure required dependencies are installed (some packages required only for arm64):
+## g++ stays: it supplies the target libstdc++ headers that clang++ compiles against.
 RUN xx-apt-get install -y libc6-dev g++ && \
     xx-go mod download && \
     xx-go mod tidy


### PR DESCRIPTION
Draft. Stacked on #23874 — review that one first; this diff is the Dockerfile hunk only.

The builder image (`golang:1.26-bookworm`) ships gcc 12.2, which generates markedly worse code than clang for evmone's multi-precision modexp. `clang-22` (22.1.8) is in `bookworm-security/main`, so this needs no extra apt repository.

`xx-go` already prefers clang: it sets `CC`/`CXX` from `xx-clang` when an unversioned `clang` is on `PATH` and falls back to gcc otherwise. So pointing the alternatives at clang-22 is the whole change — no `CC`/`CXX` plumbing. Verified it selects `x86_64-linux-gnu-clang++` natively and `aarch64-linux-gnu-clang++` for the arm64 cross build. The target `g++` stays installed because clang++ compiles against its libstdc++ headers.

Retired instructions per `evmone::crypto::modexp` call, measured in the builder image with its own compilers, `-O3 -DNDEBUG -march=x86-64-v2`:

| modulus words | gcc 12.2 | clang 16 | clang 19 | clang 22 | clang 22 vs gcc 12 |
| --- | --- | --- | --- | --- | --- |
| 1 | 35,130 | 43,112 | 42,098 | 31,709 | -9.7% |
| 2 | 93,569 | 97,335 | 96,688 | 76,662 | -18.1% |
| 3 | 172,884 | 161,946 | 161,308 | 127,421 | -26.3% |
| 4 | 107,634 | 199,981 | 200,159 | 102,363 | -4.9% |
| 6 | 586,260 | 396,643 | 395,973 | 333,310 | -43.1% |
| 8 | 994,338 | 601,909 | 601,270 | 512,536 | -48.5% |
| 12 | 2,162,733 | 1,155,376 | 1,154,683 | 1,018,267 | -52.9% |
| 16 | 3,790,237 | 1,886,507 | 1,885,813 | 1,702,587 | -55.1% |

clang 16 and 19 are not viable: both regress 86% at 4 words, the 256-bit path. Only 22 wins everywhere.

A separate full-suite run (`BenchmarkPrecompiled`, 964 cases, gcc-15 vs clang-23) showed modexp -24.9% and everything else flat: bn254 +0.7%, blst BLS12-381 +0.03%, pointEvaluation -0.07%. blst is hand-written assembly, so the C compiler barely touches it. ecrecover, p256verify and mdbx were not resolvable — repeat runs of the same binary varied by 13%, 4.7% and 45%.

Verified: `docker build --target builder` completes with zero errors and the resulting 150 MB erigon binary reports `clang version 22.1.8` in `.comment`.

Not yet verified: an end-to-end multi-platform buildx run, and whether the arm64 image is unaffected in practice (only the cgo toolchain selection was checked there, not a full image build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5mkCRUCqKRkgyiq5aPL7P