### PR TITLE
execution/types: correct why the generated withdrawal decoder tolerated null

### DIFF
--- a/execution/types/withdrawal_test.go
+++ b/execution/types/withdrawal_test.go
@@ -95,9 +95,11 @@ func TestWithdrawalJSONGolden(t *testing.T) {
 	assert.Equal(t, ws, back)
 }
 
-// The rejection comes from hexutil.Uint64 and common.Address carrying their own
-// UnmarshalJSON, not from reflection: encoding/json ignores a null literal for a
-// plain uint64 field, which is what the generated pointer-decoder relied on.
+// Null is rejected because hexutil.Uint64 and common.Address carry their own
+// UnmarshalJSON. The generated decoder tolerated it for the opposite reason: it
+// decoded into pointer fields, and encoding/json nils the pointer on null
+// without reaching the element type at all, which its non-nil guard then read
+// as an absent field.
 func TestWithdrawalJSONRejectsNull(t *testing.T) {
 	t.Parallel()
 	for _, input := range []string{


### PR DESCRIPTION
Follow-up to #23879, addressing https://github.com/erigontech/erigon/pull/23879#discussion_r3975031499, which arrived after the merge.

The docstring on `TestWithdrawalJSONRejectsNull` gets the first half right and the second half wrong. Rejection does come from `hexutil.Uint64` and `common.Address` carrying their own `UnmarshalJSON`. But the tolerance it replaced did not come from the plain-`uint64` null rule: `gen_withdrawal_json.go` decoded into `*hexutil.Uint64` / `*common.Address`, and `encoding/json` stops at a settable pointer for a `null` literal, nils it, and never reaches the element type. The non-nil guard then read that as an absent field.

Verified against `encoding/json` directly, with a type whose `UnmarshalJSON` errors on a non-string:

| field shape | `{"index":null}` |
|---|---|
| `*H` (the generated shape) | no error, pointer nil, `UnmarshalJSON` never called |
| `H` (this PR's shape) | error |
| plain `uint64` | no error, value zero |

So the sentence also named two different mechanisms for one thing. Comment only, no behaviour change.

TDD not applicable: comment-only edit, covered by the existing test.