### PR TITLE
execution/commitment: keep the storage extension as the navigation path when unfolding an account leaf at depth 64

### DIFF
--- a/execution/commitment/deepfold_test.go
+++ b/execution/commitment/deepfold_test.go
@@ -429,6 +429,33 @@ func TestSoleAccount_CollapseThenReexpand(t *testing.T) {
 	require.Equal(t, want, restored, "state-restored trie re-expanded the survivor under the wrong nibble")
 }
 
+func TestSoleAccount_StorageBranchUnderExtension(t *testing.T) {
+	t.Parallel()
+	a := addrHex(findAddressForNibble(3, 4244))
+	under := storageLocsForNibble(0x6, 2, 17)
+	fresh := storageLocsForNibble(0x0, 1, 4711)
+
+	ub1 := NewUpdateBuilder().Balance(a, 1)
+	ubf := NewUpdateBuilder().Balance(a, 2)
+	for _, loc := range under {
+		ub1.Storage(a, loc, loc)
+		ubf.Storage(a, loc, loc)
+	}
+	ub2 := NewUpdateBuilder().Balance(a, 2)
+	for _, loc := range fresh {
+		ub2.Storage(a, loc, loc)
+		ubf.Storage(a, loc, loc)
+	}
+	k1, u1 := ub1.Build()
+	k2, u2 := ub2.Build()
+	kf, uf := ubf.Build()
+
+	want, _ := engineRoot(t, modeSeq, 0, kf, uf)
+	restored, _ := incrementalRoot(t, modeSeq, 0, k1, u1, k2, u2)
+	require.Equal(t, want, carriedRoot(t, k1, u1, k2, u2), "carried trie lost the storage extension below the sole account")
+	require.Equal(t, want, restored, "state-restored trie lost the storage extension below the sole account")
+}
+
 // wide-minus-touch nibbles stay untouched on disk and must survive batch 2.
 func buildSubsetTouchedWhale(seed int64, wide, touch []byte, perNibble1, perNibble2 int) (k1 [][]byte, u1 []Update, k2 [][]byte, u2 []Update) {
 	rnd := rand.New(rand.NewSource(seed))

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -541,6 +541,10 @@ func (cell *cell) fillFromUpperCell(upCell *cell, depth, depthIncrement int16) {
 	} else {
 		cell.accountAddrLen = 0
 	}
+	if depth == 64 && cell.hashedExtLen == 0 && cell.extLen > 0 {
+		copy(cell.hashedExtension[:], cell.extension[:cell.extLen])
+		cell.hashedExtLen = cell.extLen
+	}
 	cell.storageAddrLen = upCell.storageAddrLen
 	if upCell.storageAddrLen > 0 {
 		copy(cell.storageAddr[:], upCell.storageAddr[:upCell.storageAddrLen])


### PR DESCRIPTION
A sole account whose slots share their first storage nibble keeps its storage plane under a one-nibble extension, so the branch record sits at `keccak(addr)‖<nibble>`. The propagate fold to the root carries `extension` up but leaves `hashedExtension` at the 64 account nibbles. The next block unfolds by 64, lands on `hashedExtLen == 0` with `extLen == 1`, and reads a branch at the bare account prefix: `empty branch data read during unfold`, `row=1 depth=65`. Both lifecycles. Pre-existing on main.

## Changes

- Seed `hashedExtension` from `extension` in `fillFromUpperCell` at `depth == 64`, where an account leaf's path is spent and an extension remains. Only `hashedExtension` moves: branch records carry `extension` (`commitment.go:190`), and the blob encodes `hph.root`, which `fillFromUpperCell` never fills.
- Add `TestSoleAccount_StorageBranchUnderExtension`. Reverting the hunk turns only it red.

A randomized sole-account differential diverges on 73 of 1500 seeds on main, 4 with #23897 and #23900, 0 of 6000 here.
