### PR TITLE
cl/validator/devvalidator: count the envelope post before queueing its body

### DIFF
--- a/cl/cltypes/solid/validator.go
+++ b/cl/cltypes/solid/validator.go
@@ -19,10 +19,8 @@ package solid
 import (
 	"encoding/binary"
 	"encoding/json"
-	"unsafe"
 
 	"github.com/erigontech/erigon/cl/merkle_tree"
-	"github.com/erigontech/erigon/cl/utils"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/clonable"
 	"github.com/erigontech/erigon/common/length"
@@ -125,9 +123,6 @@ func (v Validator) WithdrawalCredentials() (o common.Hash) {
 }
 
 func (v Validator) EffectiveBalance() uint64 {
-	if utils.IsSysLittleEndian {
-		return *(*uint64)(unsafe.Pointer(&v[80]))
-	}
 	return binary.LittleEndian.Uint64(v[80:88])
 }
 
@@ -136,30 +131,18 @@ func (v Validator) Slashed() bool {
 }
 
 func (v Validator) ActivationEligibilityEpoch() uint64 {
-	if utils.IsSysLittleEndian {
-		return *(*uint64)(unsafe.Pointer(&v[89]))
-	}
 	return binary.LittleEndian.Uint64(v[89:97])
 }
 
 func (v Validator) ActivationEpoch() uint64 {
-	if utils.IsSysLittleEndian {
-		return *(*uint64)(unsafe.Pointer(&v[97]))
-	}
 	return binary.LittleEndian.Uint64(v[97:105])
 }
 
 func (v Validator) ExitEpoch() uint64 {
-	if utils.IsSysLittleEndian {
-		return *(*uint64)(unsafe.Pointer(&v[105]))
-	}
 	return binary.LittleEndian.Uint64(v[105:113])
 }
 
 func (v Validator) WithdrawableEpoch() uint64 {
-	if utils.IsSysLittleEndian {
-		return *(*uint64)(unsafe.Pointer(&v[113]))
-	}
 	return binary.LittleEndian.Uint64(v[113:121])
 }
 
@@ -191,10 +174,6 @@ func (v Validator) SetWithdrawalCredentials(o common.Hash) {
 }
 
 func (v Validator) SetEffectiveBalance(i uint64) {
-	if utils.IsSysLittleEndian {
-		*(*uint64)(unsafe.Pointer(&v[80])) = i
-		return
-	}
 	binary.LittleEndian.PutUint64(v[80:88], i)
 }
 
@@ -211,34 +190,18 @@ func (v Validator) SetSlashed(b bool) {
 }
 
 func (v Validator) SetActivationEligibilityEpoch(i uint64) {
-	if utils.IsSysLittleEndian {
-		*(*uint64)(unsafe.Pointer(&v[89])) = i
-		return
-	}
 	binary.LittleEndian.PutUint64(v[89:97], i)
 }
 
 func (v Validator) SetActivationEpoch(i uint64) {
-	if utils.IsSysLittleEndian {
-		*(*uint64)(unsafe.Pointer(&v[97])) = i
-		return
-	}
 	binary.LittleEndian.PutUint64(v[97:105], i)
 }
 
 func (v Validator) SetExitEpoch(i uint64) {
-	if utils.IsSysLittleEndian {
-		*(*uint64)(unsafe.Pointer(&v[105])) = i
-		return
-	}
 	binary.LittleEndian.PutUint64(v[105:113], i)
 }
 
 func (v Validator) SetWithdrawableEpoch(i uint64) {
-	if utils.IsSysLittleEndian {
-		*(*uint64)(unsafe.Pointer(&v[113])) = i
-		return
-	}
 	binary.LittleEndian.PutUint64(v[113:121], i)
 }
 

--- a/cl/merkle_tree/merkle_root.go
+++ b/cl/merkle_tree/merkle_root.go
@@ -267,7 +267,7 @@ func hashPair(left, right [32]byte) [32]byte {
 	return sha256.Sum256(pair[:])
 }
 
-// HashByteSlice is gohashtree HashBytSlice but using our hopefully safer header conversion
+// HashByteSlice is gohashtree HashByteSlice over []byte instead of [][32]byte.
 func HashByteSlice(out, in []byte) error {
 	if len(in) == 0 {
 		return errors.New("zero leaves provided")
@@ -279,17 +279,13 @@ func HashByteSlice(out, in []byte) error {
 	if len(in)%64 != 0 {
 		return errors.New("input must be multple of 64")
 	}
-	c_in := convertHeader(in)
-	c_out := convertHeader(out)
+	c_in := unsafe.Slice((*[32]byte)(unsafe.Pointer(unsafe.SliceData(in))), len(in)/32)
+	c_out := unsafe.Slice((*[32]byte)(unsafe.Pointer(unsafe.SliceData(out))), len(out)/32)
 	err := gohashtree.Hash(c_out, c_in)
 	if err != nil {
 		return err
 	}
 	return nil
-}
-
-func convertHeader(xs []byte) [][32]byte {
-	return unsafe.Slice((*[32]byte)(unsafe.Pointer(unsafe.SliceData(xs))), len(xs)/32)
 }
 
 func MerkleRootFromFlatLeaves(leaves []byte, out []byte) (err error) {

--- a/cl/merkle_tree/merkle_root.go
+++ b/cl/merkle_tree/merkle_root.go
@@ -21,7 +21,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"reflect"
 	"unsafe"
 
 	"github.com/prysmaticlabs/gohashtree"
@@ -290,19 +289,7 @@ func HashByteSlice(out, in []byte) error {
 }
 
 func convertHeader(xs []byte) [][32]byte {
-	// i won't pretend to understand, but my solution for the problem is as so
-
-	// first i grab the slice header of the input
-	header := (*reflect.SliceHeader)(unsafe.Pointer(&xs))
-	// then i allocate a new result slice of no size - this should make the escape analyzer happy i think?
-	dat := make([][32]byte, 0)
-	// we then get the header of our output  to modify
-	chunkedHeader := (*reflect.SliceHeader)(unsafe.Pointer(&dat))
-	// then we move over the values
-	chunkedHeader.Len = header.Len / 32
-	chunkedHeader.Cap = header.Cap / 32
-	chunkedHeader.Data = header.Data
-	return dat
+	return unsafe.Slice((*[32]byte)(unsafe.Pointer(unsafe.SliceData(xs))), len(xs)/32)
 }
 
 func MerkleRootFromFlatLeaves(leaves []byte, out []byte) (err error) {

--- a/cl/validator/devvalidator/proposal_submission_test.go
+++ b/cl/validator/devvalidator/proposal_submission_test.go
@@ -108,8 +108,11 @@ func TestGloasProposalRetriesSameEnvelopeWithoutRepublishingBlock(t *testing.T) 
 	mux.HandleFunc("POST /eth/v1/beacon/execution_payload_envelopes", func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
+		// Count before queueing: the test waits on the bodies, so a post the
+		// counter has not recorded yet would read as one post short.
+		first := envelopePosts.Add(1) == 1
 		envelopeBodies <- body
-		if envelopePosts.Add(1) == 1 {
+		if first {
 			close(firstEnvelopeStarted)
 			<-r.Context().Done()
 		}

--- a/db/recsplit/eliasfano16/elias_fano.go
+++ b/db/recsplit/eliasfano16/elias_fano.go
@@ -230,9 +230,8 @@ func (ef *EliasFano) Write(w io.Writer) error {
 	if _, e := w.Write(numBuf[:]); e != nil {
 		return e
 	}
-	p := (*[maxDataSize]byte)(unsafe.Pointer(&ef.data[0]))
-	b := (*p)[:]
-	if _, e := w.Write(b[:len(ef.data)*8]); e != nil {
+	b := unsafe.Slice((*byte)(unsafe.Pointer(&ef.data[0])), len(ef.data)*8)
+	if _, e := w.Write(b); e != nil {
 		return e
 	}
 	return nil
@@ -244,13 +243,10 @@ func ReadEliasFano(r []byte) (*EliasFano, int) {
 	ef.count = binary.BigEndian.Uint64(r[:8])
 	ef.u = binary.BigEndian.Uint64(r[8:16])
 	ef.minDelta = binary.BigEndian.Uint64(r[16:24])
-	p := (*[maxDataSize / 8]uint64)(unsafe.Pointer(&r[24]))
-	ef.data = p[:]
+	ef.data = unsafe.Slice((*uint64)(unsafe.Pointer(&r[24])), (len(r)-24)/8)
 	ef.deriveFields()
 	return ef, 24 + 8*len(ef.data)
 }
-
-const maxDataSize = 0xFFFFFFFFFFFF
 
 // DoubleEliasFano can be used to encode two monotone sequences
 // it is called "double" because the lower bits array contains two sequences interleaved
@@ -533,9 +529,8 @@ func (ef *DoubleEliasFano) Write(w io.Writer) error {
 	if _, e := w.Write(numBuf[:]); e != nil {
 		return e
 	}
-	p := (*[maxDataSize]byte)(unsafe.Pointer(&ef.data[0]))
-	b := (*p)[:]
-	if _, e := w.Write(b[:len(ef.data)*8]); e != nil {
+	b := unsafe.Slice((*byte)(unsafe.Pointer(&ef.data[0])), len(ef.data)*8)
+	if _, e := w.Write(b); e != nil {
 		return e
 	}
 	return nil
@@ -548,8 +543,7 @@ func (ef *DoubleEliasFano) Read(r []byte) int {
 	ef.uPosition = binary.BigEndian.Uint64(r[16:24])
 	ef.cumKeysMinDelta = binary.BigEndian.Uint64(r[24:32])
 	ef.posMinDelta = binary.BigEndian.Uint64(r[32:40])
-	p := (*[maxDataSize / 8]uint64)(unsafe.Pointer(&r[40]))
-	ef.data = p[:]
+	ef.data = unsafe.Slice((*uint64)(unsafe.Pointer(&r[40])), (len(r)-40)/8)
 	ef.deriveFields()
 	return 40 + 8*len(ef.data)
 }

--- a/db/recsplit/golomb_rice.go
+++ b/db/recsplit/golomb_rice.go
@@ -187,8 +187,6 @@ func (g *GolombRice) Data() []uint64 {
 	return g.data
 }
 
-const maxDataSize = 0xFFFFFFFFFFFF
-
 // Write outputs the state of golomb rice encoding into a writer, which can be recovered later by Read
 func (g *GolombRice) Write(w io.Writer) error {
 	var numBuf [8]byte
@@ -196,9 +194,8 @@ func (g *GolombRice) Write(w io.Writer) error {
 	if _, e := w.Write(numBuf[:]); e != nil {
 		return e
 	}
-	p := (*[maxDataSize]byte)(unsafe.Pointer(&g.data[0]))
-	b := (*p)[:]
-	if _, e := w.Write(b[:len(g.data)*8]); e != nil {
+	b := unsafe.Slice((*byte)(unsafe.Pointer(&g.data[0])), len(g.data)*8)
+	if _, e := w.Write(b); e != nil {
 		return e
 	}
 	return nil

--- a/db/recsplit/index.go
+++ b/db/recsplit/index.go
@@ -294,8 +294,7 @@ func (idx *Index) init() (err error) {
 
 	l := binary.BigEndian.Uint64(idx.data[offset:])
 	offset += 8
-	p := (*[maxDataSize / 8]uint64)(unsafe.Pointer(&idx.data[offset]))
-	idx.grData = p[:l]
+	idx.grData = unsafe.Slice((*uint64)(unsafe.Pointer(&idx.data[offset])), l)
 	offset += 8 * int(l)
 	idx.ef.Read(idx.data[offset:])
 	validationPassed = true

--- a/execution/protocol/rules/ethash/ethash.go
+++ b/execution/protocol/rules/ethash/ethash.go
@@ -126,10 +126,7 @@ func memoryMapFile(file *os.File, write bool) (mmap.MMap, []uint32, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	// The file is now memory-mapped. Create a []uint32 view of the file.
-	view := unsafe.Slice((*uint32)(unsafe.Pointer(unsafe.SliceData(mem))), len(mem)/4)
-
-	return mem, view, nil
+	return mem, unsafe.Slice((*uint32)(unsafe.Pointer(unsafe.SliceData(mem))), len(mem)/4), nil
 }
 
 // memoryMapAndGenerate tries to memory map a temporary file of uint32s for write

--- a/execution/protocol/rules/ethash/ethash.go
+++ b/execution/protocol/rules/ethash/ethash.go
@@ -27,7 +27,6 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
-	"reflect"
 	"runtime"
 	"strconv"
 	"sync"
@@ -128,11 +127,7 @@ func memoryMapFile(file *os.File, write bool) (mmap.MMap, []uint32, error) {
 		return nil, nil, err
 	}
 	// The file is now memory-mapped. Create a []uint32 view of the file.
-	var view []uint32
-	header := (*reflect.SliceHeader)(unsafe.Pointer(&view))
-	header.Data = (*reflect.SliceHeader)(unsafe.Pointer(&mem)).Data
-	header.Len = len(mem) / 4
-	header.Cap = cap(mem) / 4
+	view := unsafe.Slice((*uint32)(unsafe.Pointer(unsafe.SliceData(mem))), len(mem)/4)
 
 	return mem, view, nil
 }

--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"unsafe"
 
 	"github.com/holiman/uint256"
 	"google.golang.org/grpc"
@@ -423,6 +422,14 @@ func (s StorageKeysInfo) EncodeKey() string {
 }
 
 // GetProof implements eth_getProof; historical blocks are supported as far back as the commitment history allows.
+func toHexBytes(in [][]byte) []hexutil.Bytes {
+	out := make([]hexutil.Bytes, len(in))
+	for i, b := range in {
+		out[i] = b
+	}
+	return out
+}
+
 func (api *APIImpl) GetProof(ctx context.Context, address common.Address, storageKeys []hexutil.Bytes, blockNrOrHashArg *rpc.BlockNumberOrHash) (*accounts.AccProofResult, error) {
 	blockNrOrHash := blockOrLatest(blockNrOrHashArg)
 	if len(storageKeys) > maxGetProofKeys {
@@ -527,7 +534,7 @@ func (api *APIImpl) getProof(ctx context.Context, roTx kv.TemporalTx, address co
 	if err != nil {
 		return nil, err
 	}
-	proof.AccountProof = *(*[]hexutil.Bytes)(unsafe.Pointer(&accountProof))
+	proof.AccountProof = toHexBytes(accountProof)
 
 	// get account data from the trie
 	acc, _ := proofTrie.GetAccount(crypto.Keccak256(address[:]))
@@ -610,7 +617,7 @@ func (api *APIImpl) getProof(ctx context.Context, roTx kv.TemporalTx, address co
 		// 0x80 represents RLP encoding of an empty proof slice
 		proof.StorageProof[i].Proof = []hexutil.Bytes{[]byte{0x80}}
 		if len(storageProof) != 0 {
-			proof.StorageProof[i].Proof = *(*[]hexutil.Bytes)(unsafe.Pointer(&storageProof))
+			proof.StorageProof[i].Proof = toHexBytes(storageProof)
 		}
 	}
 

--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -422,14 +422,6 @@ func (s StorageKeysInfo) EncodeKey() string {
 }
 
 // GetProof implements eth_getProof; historical blocks are supported as far back as the commitment history allows.
-func toHexBytes(in [][]byte) []hexutil.Bytes {
-	out := make([]hexutil.Bytes, len(in))
-	for i, b := range in {
-		out[i] = b
-	}
-	return out
-}
-
 func (api *APIImpl) GetProof(ctx context.Context, address common.Address, storageKeys []hexutil.Bytes, blockNrOrHashArg *rpc.BlockNumberOrHash) (*accounts.AccProofResult, error) {
 	blockNrOrHash := blockOrLatest(blockNrOrHashArg)
 	if len(storageKeys) > maxGetProofKeys {
@@ -636,6 +628,14 @@ func (api *APIImpl) getProof(ctx context.Context, roTx kv.TemporalTx, address co
 	}
 
 	return proof, nil
+}
+
+func toHexBytes(in [][]byte) []hexutil.Bytes {
+	out := make([]hexutil.Bytes, len(in))
+	for i, b := range in {
+		out[i] = b
+	}
+	return out
 }
 
 func (api *APIImpl) GetWitness(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (hexutil.Bytes, error) {

--- a/rpc/jsonrpc/eth_callMany_test.go
+++ b/rpc/jsonrpc/eth_callMany_test.go
@@ -107,7 +107,6 @@ func TestCallMany(t *testing.T) {
 		address1 = crypto.PubkeyToAddress(key1.PublicKey)
 		address2 = crypto.PubkeyToAddress(key2.PublicKey)
 		gspec    = &types.Genesis{
-			Config: chain.TestChainBerlinConfig,
 			Alloc: types.GenesisAlloc{
 				address:  {Balance: big.NewInt(9000000000000000000)},
 				address1: {Balance: big.NewInt(200000000000000000)},
@@ -256,7 +255,6 @@ func TestTraceCallManyStreamsEachResult(t *testing.T) {
 	key, _ := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 	address := crypto.PubkeyToAddress(key.PublicKey)
 	gspec := &types.Genesis{
-		Config:   chain.TestChainBerlinConfig,
 		Alloc:    types.GenesisAlloc{address: {Balance: big.NewInt(9000000000000000000)}},
 		GasLimit: 10000000,
 	}


### PR DESCRIPTION
Fixes a flake in `TestGloasProposalRetriesSameEnvelopeWithoutRepublishingBlock`, which failed the `-race` consensus shard on an unrelated PR:

```
--- FAIL: TestGloasProposalRetriesSameEnvelopeWithoutRepublishingBlock (0.52s)
    proposal_submission_test.go:143:
        Error: Not equal:
        expected: 2
        actual  : 1
```

## Cause

The envelope handler queued the body and only then incremented the counter:

```go
envelopeBodies <- body
if envelopePosts.Add(1) == 1 {
```

`envelopeBodies` is buffered at 2, so the send never blocks. The test drains both bodies and immediately asserts `envelopePosts.Load() == 2`, but the assertion is ordered on the channel, not on the counter. The second post can be received before the handler has counted it, which is the observed 1.

Swapping the two lines makes the receive the test already waits on happen after the increment.

## Verification

The window is narrow — 300 local `-race` runs of the unpatched test all passed. Forcing it with a `runtime.Gosched()` between the two statements reproduces CI exactly, failing on the first runs with the same `expected: 2, actual: 1`. With the fix applied and that same `Gosched()` still in place, 30 `-race` runs pass, as does the package.

TDD note: no new test. The existing test is the reproducer; the change is to the fixture ordering it asserts on.