### PR TITLE
execution/blockmetrics: drop the copied consumer regex from the envelope test

### DIFF
--- a/execution/blockmetrics/slowblock_test.go
+++ b/execution/blockmetrics/slowblock_test.go
@@ -307,19 +307,14 @@ func TestCommitmentReadsAreNotExecutionReads(t *testing.T) {
 	assert.Equal(t, 6*time.Millisecond, accounts.ReadTime)
 }
 
-// The envelope is a cross-client contract, like the field names. The patterns
-// are the consumer's: ethpandaops/benchmarkoor pkg/blocklog/erigon.go.
-var (
-	ansiPattern    = regexp.MustCompile(`\x1b\[[0-9;]*m`)
-	consolePattern = regexp.MustCompile(
-		`^\[?\w+\s*\]?\s*(?:\[[^\]]+\]\s*)?(\{.+\})\s*$`)
-)
+var ansiPattern = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 
 func consolePayload(t *testing.T, line string) string {
 	t.Helper()
-	m := consolePattern.FindStringSubmatch(ansiPattern.ReplaceAllString(line, ""))
-	require.Len(t, m, 2, "console line does not match the consumer's parser: %q", line)
-	return m[1]
+	line = ansiPattern.ReplaceAllString(line, "")
+	i := strings.Index(line, "{")
+	require.GreaterOrEqual(t, i, 0, "no JSON payload in the console envelope: %q", line)
+	return line[i:]
 }
 
 func jsonPayload(t *testing.T, line string) string {

--- a/execution/blockmetrics/slowblock_test.go
+++ b/execution/blockmetrics/slowblock_test.go
@@ -312,7 +312,7 @@ func TestCommitmentReadsAreNotExecutionReads(t *testing.T) {
 var (
 	ansiPattern    = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 	consolePattern = regexp.MustCompile(
-		`^\[?(?:TRACE|DBUG|INFO|WARN|EROR|CRIT)\s*\]?\s*(?:\[[^\]]+\]\s*)?\s*(\{.+\})\s*$`)
+		`^\[?\w+\s*\]?\s*(?:\[[^\]]+\]\s*)?(\{.+\})\s*$`)
 )
 
 func consolePayload(t *testing.T, line string) string {


### PR DESCRIPTION
The test copied benchmarkoor's console regex to find the JSON payload. Nothing keeps the copy in sync — the file it cites is still a stub on master.

Now takes the first `{`, and nothing is lost. The two disagree on exactly one shape, a third bracketed field in the prefix, and `format.go` emits at most two: level and timestamp. Caller handlers append to `r.Ctx`, which lands after the msg and breaks both alike.
