### PR TITLE
[r3.5] cl/antiquary: back off retirement steps that keep failing

### DIFF
--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -230,32 +230,47 @@ func (a *Antiquary) Loop() error {
 	if a.states {
 		go a.loopStates(a.ctx)
 	}
-	// Check for snapshots retirement every 3 minutes
+	return a.retirementLoop()
+}
+
+func (a *Antiquary) retirementLoop() error {
+	blocks := &retirementStep{
+		run:     a.antiquate,
+		onError: func(err error) { log.Warn("[Antiquary] Failed to antiquate", "err", err) },
+	}
+	blobs := &retirementStep{
+		run:     a.antiquateBlobs,
+		onError: func(err error) { log.Error("[Antiquary] Failed to antiquate blobs", "err", err) },
+	}
+
 	retirementTicker := time.NewTicker(12 * time.Second)
 	defer retirementTicker.Stop()
 	for {
 		select {
 		case <-retirementTicker.C:
-			if !a.backfilled.Load() {
-				continue
-			}
-
-			if err := a.antiquate(); err != nil {
-				log.Warn("[Antiquary] Failed to antiquate", "err", err)
-			}
-			if a.cfg.DenebForkEpoch == math.MaxUint64 {
-				continue
-			}
-			if !a.blobBackfilled.Load() {
-				continue
-			}
-			if err := a.antiquateBlobs(); err != nil {
-				log.Error("[Antiquary] Failed to antiquate blobs", "err", err)
-			}
+			a.retirementTick(blocks, blobs)
 		case <-a.ctx.Done():
+			return nil
 		}
 	}
 }
+
+func (a *Antiquary) retirementTick(blocks, blobs *retirementStep) {
+	if !a.backfilled.Load() {
+		return
+	}
+	blocks.attempt(a.shuttingDown)
+
+	if a.cfg.DenebForkEpoch == math.MaxUint64 {
+		return
+	}
+	if !a.blobBackfilled.Load() {
+		return
+	}
+	blobs.attempt(a.shuttingDown)
+}
+
+func (a *Antiquary) shuttingDown() bool { return a.ctx.Err() != nil }
 
 // weight for the semaphore to build only one type of snapshots at a time
 // for now all of them have the same weight

--- a/cl/antiquary/retirement_backoff.go
+++ b/cl/antiquary/retirement_backoff.go
@@ -1,0 +1,71 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package antiquary
+
+// maxRetirementSkipTicks caps the gap at roughly an hour of retirementLoop ticks.
+const maxRetirementSkipTicks = 300
+
+// retirementBackoff spaces out a retirement step that keeps failing. Not every
+// failure is transient: a data gap the step cannot get past fails identically on
+// every tick, and without a gap it would redo the same work and log the same error
+// for the life of the process.
+type retirementBackoff struct {
+	skipTicks int
+	remaining int
+}
+
+func (b *retirementBackoff) ready() bool {
+	if b.remaining > 0 {
+		b.remaining--
+		return false
+	}
+	return true
+}
+
+func (b *retirementBackoff) failed() {
+	b.skipTicks = min(max(b.skipTicks*2, 1), maxRetirementSkipTicks)
+	b.remaining = b.skipTicks
+}
+
+func (b *retirementBackoff) succeeded() {
+	b.skipTicks, b.remaining = 0, 0
+}
+
+// retirementStep pairs one retirement operation with its own backoff, so a step that
+// wedges on a data gap cannot slow down the other.
+type retirementStep struct {
+	run     func() error
+	onError func(error)
+	backoff retirementBackoff
+}
+
+func (s *retirementStep) attempt(shuttingDown func() bool) {
+	if !s.backoff.ready() {
+		return
+	}
+	err := s.run()
+	if err == nil {
+		s.backoff.succeeded()
+		return
+	}
+	// A cancelled context is a shutdown, not the step's failure.
+	if shuttingDown() {
+		return
+	}
+	s.backoff.failed()
+	s.onError(err)
+}

--- a/cl/antiquary/retirement_backoff_test.go
+++ b/cl/antiquary/retirement_backoff_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package antiquary
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ticksUntilReady counts how many ticks are refused before the step runs again.
+func ticksUntilReady(t *testing.T, b *retirementBackoff) int {
+	t.Helper()
+	for skipped := 0; skipped <= maxRetirementSkipTicks*2; skipped++ {
+		if b.ready() {
+			return skipped
+		}
+	}
+	t.Fatal("backoff never became ready")
+	return 0
+}
+
+func TestRetirementBackoffRunsUntilSomethingFails(t *testing.T) {
+	var b retirementBackoff
+	for range 5 {
+		require.True(t, b.ready(), "an unfailed step must run on every tick")
+	}
+}
+
+func TestRetirementBackoffSpacesOutRepeatedFailures(t *testing.T) {
+	var b retirementBackoff
+
+	b.failed()
+	require.Equal(t, 1, ticksUntilReady(t, &b))
+
+	b.failed()
+	require.Equal(t, 2, ticksUntilReady(t, &b))
+
+	b.failed()
+	require.Equal(t, 4, ticksUntilReady(t, &b))
+}
+
+func TestRetirementBackoffCapsTheGap(t *testing.T) {
+	var b retirementBackoff
+	for range 64 {
+		b.failed()
+		ticksUntilReady(t, &b)
+	}
+
+	b.failed()
+	require.Equal(t, maxRetirementSkipTicks, ticksUntilReady(t, &b))
+}
+
+func TestRetirementBackoffResetsOnSuccess(t *testing.T) {
+	var b retirementBackoff
+	for range 4 {
+		b.failed()
+		ticksUntilReady(t, &b)
+	}
+
+	b.succeeded()
+	require.True(t, b.ready())
+	require.True(t, b.ready())
+}

--- a/cl/antiquary/retirement_loop_test.go
+++ b/cl/antiquary/retirement_loop_test.go
@@ -1,0 +1,236 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package antiquary
+
+import (
+	"context"
+	"errors"
+	"math"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/clparams"
+)
+
+// tickHarness drives retirementTick without a ticker: each step counts its calls and
+// returns whatever the test tells it to.
+type tickHarness struct {
+	a            *Antiquary
+	blocks       *retirementStep
+	blobs        *retirementStep
+	blocksRuns   int
+	blobsRuns    int
+	blocksFails  bool
+	blobsFails   bool
+	cancel       context.CancelFunc
+	denebEnabled bool
+}
+
+func newTickHarness(t *testing.T) *tickHarness {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	h := &tickHarness{cancel: cancel, denebEnabled: true}
+	backfilled, blobBackfilled := &atomic.Bool{}, &atomic.Bool{}
+	backfilled.Store(true)
+	blobBackfilled.Store(true)
+
+	h.a = &Antiquary{
+		ctx:            ctx,
+		backfilled:     backfilled,
+		blobBackfilled: blobBackfilled,
+		cfg:            &clparams.BeaconChainConfig{DenebForkEpoch: 0},
+	}
+	h.blocks = &retirementStep{
+		run: func() error {
+			h.blocksRuns++
+			if h.blocksFails {
+				return errors.New("blocks failed")
+			}
+			return nil
+		},
+		onError: func(error) {},
+	}
+	h.blobs = &retirementStep{
+		run: func() error {
+			h.blobsRuns++
+			if h.blobsFails {
+				return errors.New("blobs failed")
+			}
+			return nil
+		},
+		onError: func(error) {},
+	}
+	return h
+}
+
+func (h *tickHarness) tick(n int) {
+	for range n {
+		h.a.retirementTick(h.blocks, h.blobs)
+	}
+}
+
+// ticksUntilBlobsRun ticks until the blobs step runs again and reports how many ticks
+// its backoff refused first, so a test can assert the exact width of the gap.
+func (h *tickHarness) ticksUntilBlobsRun(t *testing.T) int {
+	t.Helper()
+	before := h.blobsRuns
+	for skipped := 0; skipped <= maxRetirementSkipTicks*2; skipped++ {
+		h.tick(1)
+		if h.blobsRuns > before {
+			return skipped
+		}
+	}
+	t.Fatal("blobs step never ran again")
+	return 0
+}
+
+// A step that keeps failing must not drag its sibling down with it.
+func TestRetirementTickBacksOffEachStepIndependently(t *testing.T) {
+	h := newTickHarness(t)
+	h.blocksFails = true
+
+	h.tick(6)
+
+	require.Equal(t, 6, h.blobsRuns, "a succeeding step must run on every tick")
+	require.Less(t, h.blocksRuns, 6, "a failing step must be skipped on some ticks")
+	require.Positive(t, h.blocksRuns)
+}
+
+func TestRetirementTickBacksOffBlobsIndependently(t *testing.T) {
+	h := newTickHarness(t)
+	h.blobsFails = true
+
+	h.tick(6)
+
+	require.Equal(t, 6, h.blocksRuns)
+	require.Less(t, h.blobsRuns, 6)
+	require.Positive(t, h.blobsRuns)
+}
+
+// Success on one step must not clear the other's accumulated backoff.
+func TestRetirementTickSuccessResetsOnlyItsOwnStep(t *testing.T) {
+	h := newTickHarness(t)
+	h.blobsFails = true
+	h.tick(8)
+	blobsAfterFailures := h.blobsRuns
+
+	h.blocksFails = false
+	h.tick(2)
+
+	require.Equal(t, blobsAfterFailures, h.blobsRuns,
+		"blocks succeeding must not reset the blobs backoff")
+}
+
+func TestRetirementTickRecoversAfterSuccess(t *testing.T) {
+	h := newTickHarness(t)
+	h.blobsFails = true
+	h.tick(8)
+
+	h.blobsFails = false
+	// Enough ticks for the accumulated gap to elapse, then it must run every tick.
+	h.tick(8)
+	before := h.blobsRuns
+	h.tick(3)
+
+	require.Equal(t, before+3, h.blobsRuns)
+}
+
+// A success must clear the accumulated gap, not merely let the current one elapse:
+// the next failure has to restart at the minimum width.
+func TestRetirementTickSuccessClearsAccumulatedGap(t *testing.T) {
+	h := newTickHarness(t)
+
+	h.blobsFails = true
+	for range 4 {
+		h.ticksUntilBlobsRun(t)
+	}
+	require.Greater(t, h.ticksUntilBlobsRun(t), 1, "repeated failures must widen the gap")
+
+	h.blobsFails = false
+	h.ticksUntilBlobsRun(t)
+
+	h.blobsFails = true
+	h.ticksUntilBlobsRun(t)
+	require.Equal(t, 1, h.ticksUntilBlobsRun(t),
+		"after a success the next failure must restart at the minimum gap")
+}
+
+func TestRetirementTickSkipsBlobsBeforeDeneb(t *testing.T) {
+	h := newTickHarness(t)
+	h.a.cfg = &clparams.BeaconChainConfig{DenebForkEpoch: math.MaxUint64}
+
+	h.tick(3)
+
+	require.Equal(t, 3, h.blocksRuns)
+	require.Zero(t, h.blobsRuns, "blobs must not be antiquated before Deneb")
+}
+
+func TestRetirementTickWaitsForBackfill(t *testing.T) {
+	h := newTickHarness(t)
+	h.a.backfilled.Store(false)
+	h.tick(3)
+	require.Zero(t, h.blocksRuns)
+	require.Zero(t, h.blobsRuns)
+
+	h.a.backfilled.Store(true)
+	h.a.blobBackfilled.Store(false)
+	h.tick(3)
+	require.Equal(t, 3, h.blocksRuns)
+	require.Zero(t, h.blobsRuns)
+}
+
+// A failure during shutdown is not the step's fault, so it must not be counted.
+func TestRetirementTickDoesNotBackOffOnShutdown(t *testing.T) {
+	h := newTickHarness(t)
+	h.blocksFails = true
+	h.blobsFails = true
+	h.cancel()
+
+	h.tick(4)
+
+	require.Equal(t, 4, h.blocksRuns)
+	require.Equal(t, 4, h.blobsRuns)
+}
+
+// A cancelled context must end the loop. Without the return the select keeps matching the closed
+// channel and the goroutine spins for the life of the process.
+func TestRetirementLoopReturnsOnShutdown(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	backfilled, blobBackfilled := &atomic.Bool{}, &atomic.Bool{}
+	a := &Antiquary{
+		ctx:            ctx,
+		backfilled:     backfilled,
+		blobBackfilled: blobBackfilled,
+		cfg:            &clparams.BeaconChainConfig{DenebForkEpoch: 0},
+	}
+	cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- a.retirementLoop() }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("retirementLoop kept spinning after its context was cancelled")
+	}
+}


### PR DESCRIPTION
Cherry-pick of #23252 to `release/3.5`, via the `release/3.6` port #23408.

Needed on this branch because a retirement step that wedges on a data gap retries every 12 s for
the life of the process, which is how a gnosis archive node on this line spent hours logging
`blob storage count mismatch at slot N` at a flat 12 s period.

## r3.5-specific adaptations

#23408 does not apply as a cherry-pick. Its diff carries `release/3.6`'s antiquary structure,
including six helpers `release/3.5` does not have — `indexBeaconSnapshots`,
`indexBeaconSnapshotBatch`, `nextBatchEnd`, `clampBeaconSnapshotProgress`,
`readBeaconSnapshotHeaderFunc` and `pruneBeaconBlocksAndWriteProgress` — so taking the conflict
resolution wholesale would have added dead code to this branch while its surrounding context only
partially matched.

`retirement_backoff.go` is self-contained and is taken unchanged. The loop rework is a manual port
of `release/3.5`'s inline retirement ticker into `retirementLoop` and `retirementTick`, keeping the
same gating order: block backfill, then `DenebForkEpoch`, then blob backfill.

`release/3.5`'s loop also never returned on a cancelled context, so shutdown left it spinning on
the closed channel. This port returns instead. `main` already does this; **`release/3.6` still does
not**, which is worth a separate fix there.

## Tests

#23408's `retirement_backoff_test.go` and `retirement_loop_test.go` unchanged — the tick harness
only touches `Antiquary` fields this branch already has — plus one test for the shutdown return.

Both hand-written parts are mutation-verified: bypassing the backoff fails three tick tests, and
removing the shutdown return fails with `retirementLoop kept spinning after its context was
cancelled`.

`make lint` clean twice, `cl/antiquary` green.
