### PR TITLE
[r3.5] cl/phase1/network: read the blob count under the canonical root

### DIFF
--- a/cl/phase1/network/blob_downloader.go
+++ b/cl/phase1/network/blob_downloader.go
@@ -27,8 +27,10 @@ import (
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/das"
+	"github.com/erigontech/erigon/cl/persistence/beacon_indicies"
 	"github.com/erigontech/erigon/cl/persistence/blob_storage"
 	"github.com/erigontech/erigon/cl/rpc"
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/snapshotsync/freezeblocks"
@@ -317,9 +319,16 @@ func (b *BlobHistoryDownloader) collectIncompleteBlocks(currentSlot, targetSlot 
 		if block.Version() < clparams.DenebVersion {
 			break
 		}
-		blockRoot, err := block.Block.HashSSZ()
+		// The canonical root from the index, never block.Block.HashSSZ(): ReadBeaconBlockBodyBySlot
+		// returns a block without its execution payload, so hashing it yields a root that never
+		// existed on chain and the store lookup always misses. Every blob-bearing block would
+		// then look incomplete forever, and the blob dump waits on a pass that cannot finish.
+		blockRoot, err := beacon_indicies.ReadCanonicalBlockRoot(tx, currentSlot-visited)
 		if err != nil {
 			return nil, 0, err
+		}
+		if blockRoot == (common.Hash{}) {
+			continue
 		}
 		blobsCount, err := b.blobStorage.KzgCommitmentsCount(b.ctx, blockRoot)
 		if err != nil {

--- a/cl/phase1/network/blob_downloader_test.go
+++ b/cl/phase1/network/blob_downloader_test.go
@@ -157,3 +157,44 @@ func TestCollectIncompleteBlocksReadsTheCountUnderTheCanonicalRoot(t *testing.T)
 	require.NoError(t, err)
 	require.Empty(t, batch, "a slot whose sidecars are stored under its canonical root must not be re-queued")
 }
+
+// A block can be readable while its canonical row is not yet written: below BlocksAvailable the
+// snapshot path serves blocks by ordinal lookup without consulting the index, and blob backfill
+// starts before the antiquary's indexing walk finishes.
+//
+// This branch deliberately skips such a slot rather than failing the pass, unlike main. Main pairs
+// its error return with indexing the inclusive visible tip; without that second half the error
+// fires on the tip every pass and backfill can never complete. Neither piece is on this branch, so
+// the skip is the coherent behaviour here — and this test exists to keep a later cherry-pick from
+// importing main's error return on its own.
+func TestCollectIncompleteBlocksSkipsAnUnindexedSlotInsteadOfFailing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	const slot = 1_000
+
+	// No MarkRootCanonical for this slot: the index has not caught up with the segment.
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+	block.Block.Slot = slot
+	commitment := cltypes.KZGCommitment{}
+	commitment[0] = 0x01
+	block.Block.Body.BlobKzgCommitments.Append(&commitment)
+
+	// Probing the store with a zero key would be meaningless, so the skip has to happen first.
+	store := blob_mock_services.NewMockBlobStorage(ctrl)
+	store.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Times(0)
+
+	b := &BlobHistoryDownloader{
+		ctx:         context.Background(),
+		beaconCfg:   &clparams.MainnetBeaconConfig,
+		indiciesDB:  db,
+		blobStorage: store,
+		blockReader: stubBlockReader{slot: slot, block: block},
+		logger:      log.New(),
+	}
+
+	batch, visited, err := b.collectIncompleteBlocks(slot, slot)
+	require.NoError(t, err, "an unindexed slot must be skipped, not fail the pass")
+	require.Empty(t, batch, "an unindexed slot must not be queued for download")
+	require.Equal(t, uint64(1), visited, "the pass must advance past the slot rather than stall on it")
+}

--- a/cl/phase1/network/blob_downloader_test.go
+++ b/cl/phase1/network/blob_downloader_test.go
@@ -21,13 +21,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/das"
 	"github.com/erigontech/erigon/cl/das/mock_services"
+	"github.com/erigontech/erigon/cl/persistence/beacon_indicies"
+	blob_mock_services "github.com/erigontech/erigon/cl/persistence/blob_storage/mock_services"
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/dbcfg"
+	"github.com/erigontech/erigon/db/kv/memdb"
+	"github.com/erigontech/erigon/execution/types"
 )
 
 type staticPeerDasGetter struct{ pd das.PeerDas }
@@ -71,4 +79,81 @@ func TestBlobHistoryDownloaderFuluColumnRecoveryIsBounded(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("recoverFuluColumns hung — unbounded PeerDAS column recovery")
 	}
+}
+
+// stubBlockReader serves one block for one slot, standing in for a beaconblocks segment read.
+type stubBlockReader struct {
+	slot  uint64
+	block *cltypes.SignedBeaconBlock
+}
+
+func (s stubBlockReader) ReadBlockBySlot(_ context.Context, _ kv.Tx, slot uint64) (*cltypes.SignedBeaconBlock, error) {
+	return s.blockFor(slot), nil
+}
+
+func (s stubBlockReader) ReadBlockByRoot(_ context.Context, _ kv.Tx, _ common.Hash) (*cltypes.SignedBeaconBlock, error) {
+	return nil, nil
+}
+
+func (s stubBlockReader) ReadHeaderByRoot(_ context.Context, _ kv.Tx, _ common.Hash) (*cltypes.SignedBeaconBlockHeader, error) {
+	return nil, nil
+}
+
+func (s stubBlockReader) CacheBlockBody(_ uint64, _ [][]byte, _ []*types.Withdrawal) {}
+
+func (s stubBlockReader) ReadBeaconBlockBodyBySlot(_ context.Context, _ kv.Tx, slot uint64) (*cltypes.SignedBeaconBlock, error) {
+	return s.blockFor(slot), nil
+}
+
+func (s stubBlockReader) FrozenSlots() uint64 { return 0 }
+
+func (s stubBlockReader) blockFor(slot uint64) *cltypes.SignedBeaconBlock {
+	if slot == s.slot {
+		return s.block
+	}
+	return nil
+}
+
+// A block read out of a beaconblocks segment carries no execution payload, so hashing it gives
+// a root that never existed on chain and the store lookup misses. The count must therefore be
+// read under the canonical root from the index: otherwise every frozen blob-bearing block looks
+// incomplete forever, the backfill re-requests columns no peer still has, and the blob dump
+// stays gated behind a pass that never completes.
+func TestCollectIncompleteBlocksReadsTheCountUnderTheCanonicalRoot(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	const slot = 1_000
+	canonical := common.HexToHash("0xc0ffee")
+
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	require.NoError(t, db.Update(context.Background(), func(tx kv.RwTx) error {
+		return beacon_indicies.MarkRootCanonical(context.Background(), tx, slot, canonical)
+	}))
+
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+	block.Block.Slot = slot
+	commitment := cltypes.KZGCommitment{}
+	commitment[0] = 0x01
+	block.Block.Body.BlobKzgCommitments.Append(&commitment)
+
+	// The block's own hash is not the canonical root, exactly as for a payload-stripped read.
+	selfRoot, err := block.Block.HashSSZ()
+	require.NoError(t, err)
+	require.NotEqual(t, canonical, common.Hash(selfRoot), "fixture must reproduce the mismatch")
+
+	store := blob_mock_services.NewMockBlobStorage(ctrl)
+	store.EXPECT().KzgCommitmentsCount(gomock.Any(), canonical).Return(uint32(1), nil).AnyTimes()
+	store.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Not(gomock.Eq(canonical))).Return(uint32(0), nil).AnyTimes()
+
+	b := &BlobHistoryDownloader{
+		ctx:         context.Background(),
+		beaconCfg:   &clparams.MainnetBeaconConfig,
+		indiciesDB:  db,
+		blobStorage: store,
+		blockReader: stubBlockReader{slot: slot, block: block},
+		logger:      log.New(),
+	}
+
+	batch, _, err := b.collectIncompleteBlocks(slot, slot)
+	require.NoError(t, err)
+	require.Empty(t, batch, "a slot whose sidecars are stored under its canonical root must not be re-queued")
 }


### PR DESCRIPTION
Backport of #23895 to `release/3.5`. Applies as a clean cherry-pick, tests included.

`collectIncompleteBlocks` hashed the block it had just read to look up how many sidecars the store
holds. `ReadBeaconBlockBodyBySlot` returns a block **without its execution payload**, so that hash
is a root which never existed on chain and the lookup always missed, reporting zero. Every Deneb+
block carrying commitments was therefore classified incomplete regardless of what the store held,
and on an archive node the backfill re-requested PeerDAS columns back toward the Deneb fork,
spending the 30s per-block recovery timeout on data long past its retention window.

## Measured on a gnosis archive node running this branch

The node had a blob frontier stuck at slot 29,400,000 for about 30 days while beacon blocks reached
29,969,999. One chunk was repaired out of band and independently verified — 251 blob-bearing slots
present, each confirmed by reading the sidecars back — and this code still classified all 251 as
incomplete.

| | before | after |
|---|---|---|
| backward pass | 1.2 slots/sec, never completed across three restarts | finished in 39 s |
| blob dump | gated out, never ran | started 2 s later, completed in 15m25s |
| blob frontier | stuck at 29,400,000 for ~30 days | **29,400,000 -> 29,970,000** |

It has since kept pace on its own, resting at the structural one-chunk lag.

## Scope: deliberately only the first commit of #23895

#23895 has two later commits that are **not** included, because neither has a reachable effect on
this branch:

- Returning an error instead of `continue` on a missing canonical root. That exists on `main` to
  stop a false completion, but this branch has no `retryRanges` ledger (#23138 is `main`-only) and
  `downloadOnce` sets `backfillCompleted` unconditionally, so there is no false completion to
  prevent. Applied here it would only turn the unindexed snapshot tip into a per-pass error.
- Indexing the inclusive visible snapshot tip. The off-by-one is present here too — the indexing
  loop is `for i := from; i < a.sn.BlocksAvailable()` while the cursor is written as
  `BlocksAvailable()` — but it self-heals: the next pass starts at the old tip and indexes it. The
  tip also cannot fall inside a dump range, since `DumpBlobsSidecar` breaks when
  `toSlot - i < blocksPerFile`, so only whole chunks are ever dumped. It is worth fixing on `main`,
  where it pairs with the error above; it buys nothing here.

## Tests

`TestCollectIncompleteBlocksReadsTheCountUnderTheCanonicalRoot` keeps the indexed root distinct from
the block's own hash, as a payload-stripped read does, and asserts a slot already complete in the
store is not re-queued. Mutation-verified on this branch: restoring `HashSSZ()` fails it with
"a slot whose sidecars are stored under its canonical root must not be re-queued".

`make lint` clean twice, `cl/phase1/network` green.
