### PR TITLE
[r3.5] cl/sentinel: honour the peer ban on inbound connections

### DIFF
--- a/cl/sentinel/ban_on_connection_test.go
+++ b/cl/sentinel/ban_on_connection_test.go
@@ -1,0 +1,164 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package sentinel
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/metrics"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/p2p"
+	"github.com/erigontech/erigon/cl/sentinel/peers"
+	"github.com/erigontech/erigon/p2p/discover"
+)
+
+// stubP2P satisfies p2p.P2PManager with only the host the connection handler needs.
+type stubP2P struct{ host host.Host }
+
+func (s stubP2P) Pubsub() *pubsub.PubSub                       { return nil }
+func (s stubP2P) Host() host.Host                              { return s.host }
+func (s stubP2P) BandwidthCounter() *metrics.BandwidthCounter  { return nil }
+func (s stubP2P) UDPv5Listener() *discover.UDPv5               { return nil }
+func (s stubP2P) UpdateENRAttSubnets(subnetIndex int, on bool) {}
+func (s stubP2P) UpdateENRSyncNets(subnetIndex int, on bool)   {}
+
+// testPeerPool is shared package-wide because every peers.NewPool starts two TTL-cache cleanup
+// goroutines that the upstream cache offers no way to stop. Sharing is safe because each test
+// creates its own hosts, so no two tests touch the same peer ID, and it carries no host because
+// nothing in this package reaches Pool.Request, the only method that needs one.
+var testPeerPool = sync.OnceValue(func() *peers.Pool { return peers.NewPool(nil) })
+
+func testSentinel(t *testing.T, h host.Host) *Sentinel {
+	t.Helper()
+	return &Sentinel{
+		peers: testPeerPool(),
+		p2p:   stubP2P{host: h},
+		cfg:   &SentinelConfig{P2PConfig: p2p.P2PConfig{MaxPeerCount: 100}},
+	}
+}
+
+// connectedPair returns a host acting as the local node and a peer connected to it.
+func connectedPair(t *testing.T) (host.Host, host.Host) {
+	t.Helper()
+	local, err := libp2p.New(libp2p.NoListenAddrs)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = local.Close() })
+
+	remote, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = remote.Close() })
+
+	require.NoError(t, local.Connect(t.Context(), peer.AddrInfo{ID: remote.ID(), Addrs: remote.Addrs()}))
+	require.Equal(t, network.Connected, local.Network().Connectedness(remote.ID()))
+	return local, remote
+}
+
+func waitDisconnected(t *testing.T, local host.Host, pid peer.ID) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for local.Network().Connectedness(pid) == network.Connected {
+		if time.Now().After(deadline) {
+			t.Fatal("peer was still connected: the ban did not close it")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// ConnectWithPeer consults the ban list, but it only covers dials we initiate. A peer banned
+// for repeated handshake failures reconnects and its connection event must close it rather
+// than run another status handshake — otherwise the ban never takes effect on inbound
+// connections and the peer is handshaked again on every reconnect.
+func TestBannedPeerIsClosedInsteadOfHandshaked(t *testing.T) {
+	local, remote := connectedPair(t)
+	s := testSentinel(t, local)
+	s.peers.SetBanStatus(remote.ID(), true)
+
+	kept := s.handleNewConnection(remote.ID(), func() (bool, error) {
+		t.Error("a banned peer must not be handshaked")
+		return false, nil
+	})
+	require.False(t, kept)
+	waitDisconnected(t, local, remote.ID())
+}
+
+// The connection callback must route through that check: onConnection is what libp2p calls,
+// and it is the only path an inbound connection takes.
+func TestOnConnectionClosesABannedPeer(t *testing.T) {
+	local, remote := connectedPair(t)
+	s := testSentinel(t, local)
+	s.peers.SetBanStatus(remote.ID(), true)
+
+	conns := local.Network().ConnsToPeer(remote.ID())
+	require.NotEmpty(t, conns)
+	s.onConnection(local.Network(), conns[0])
+
+	waitDisconnected(t, local, remote.ID())
+}
+
+// Three handshake failures ban the peer, and the ban must then be honoured: the storm this
+// fixes was one peer handshaked repeatedly because its failures were recorded and never read.
+func TestRepeatedHandshakeFailuresStopBeingHandshaked(t *testing.T) {
+	local, remote := connectedPair(t)
+	s := testSentinel(t, local)
+
+	validations := 0
+	failing := func() (bool, error) {
+		validations++
+		return false, errors.New("stream reset")
+	}
+
+	for range 3 {
+		require.True(t, s.handleNewConnection(remote.ID(), failing),
+			"a transport error keeps the peer: it may still serve gossip")
+	}
+	require.Equal(t, 3, validations)
+	require.True(t, s.peers.BanStatus(remote.ID()), "three handshake failures must ban the peer")
+
+	require.False(t, s.handleNewConnection(remote.ID(), failing))
+	require.Equal(t, 3, validations, "a banned peer must not be handshaked again")
+	waitDisconnected(t, local, remote.ID())
+}
+
+// Each pool leaves two cleanup goroutines running for the rest of the process, so building one
+// per test makes the count grow with the size of the suite.
+func TestFixtureReusesOnePeerPool(t *testing.T) {
+	local, _ := connectedPair(t)
+	require.Same(t, testSentinel(t, local).peers, testSentinel(t, local).peers)
+}
+
+// A peer that is not banned still reaches its handshake and is kept.
+func TestUnbannedPeerIsHandshakedAndKept(t *testing.T) {
+	local, remote := connectedPair(t)
+	s := testSentinel(t, local)
+
+	validations := 0
+	require.True(t, s.handleNewConnection(remote.ID(), func() (bool, error) {
+		validations++
+		return true, nil
+	}))
+	require.Equal(t, 1, validations)
+	require.Equal(t, network.Connected, local.Network().Connectedness(remote.ID()))
+}

--- a/cl/sentinel/discovery.go
+++ b/cl/sentinel/discovery.go
@@ -548,9 +548,23 @@ func (s *Sentinel) listenForPeers() {
 }
 
 func (s *Sentinel) onConnection(_ network.Network, conn network.Conn) {
-	go func() {
-		peerId := conn.RemotePeer()
+	peerId := conn.RemotePeer()
+	go s.handleNewConnection(peerId, func() (bool, error) {
+		return s.handshaker.ValidatePeer(peerId)
+	})
+}
 
+// handleNewConnection admits or rejects a peer that has just connected, then runs its status
+// handshake. Reports whether the peer was kept.
+func (s *Sentinel) handleNewConnection(peerId peer.ID, validate func() (bool, error)) bool {
+	// ConnectWithPeer consults the ban list, but it only covers dials we initiate; a peer
+	// banned for repeated handshake failures reconnects and reaches here regardless.
+	if s.peers.BanStatus(peerId) {
+		s.p2p.Host().Network().ClosePeer(peerId)
+		return false
+	}
+
+	{
 		// Check if this peer helps any underserved subnets (< minimumPeersPerSubnet)
 		peerHelpsSubnets := false
 		if nodeVal, ok := s.pidToEnr.Load(peerId); ok {
@@ -574,34 +588,34 @@ func (s *Sentinel) onConnection(_ network.Network, conn network.Conn) {
 			s.p2p.Host().Peerstore().RemovePeer(peerId)
 			s.p2p.Host().Network().ClosePeer(peerId)
 			s.peers.RemovePeer(peerId)
-			return
+			return false
 		}
+	}
 
-		valid, err := s.handshaker.ValidatePeer(peerId)
-		if err != nil {
-			// Handshake transport error (stream reset, timeout, etc.) — keep the peer.
-			// The peer may still work for gossip even if status exchange failed.
-			log.Debug("[Sentinel] Handshake transport error (keeping connection)", "peer", peerId, "err", err)
-		}
+	valid, err := validate()
+	if err != nil {
+		// Handshake transport error (stream reset, timeout, etc.) — keep the peer.
+		// The peer may still work for gossip even if status exchange failed.
+		log.Debug("[Sentinel] Handshake transport error (keeping connection)", "peer", peerId, "err", err)
+	}
 
-		if !valid && err == nil {
-			// Handshake succeeded but fork digest mismatched — peer is on a different fork.
-			// Must disconnect to avoid receiving incompatible blocks.
-			log.Debug("[Sentinel] Fork mismatch, disconnecting peer", "peer", peerId)
-			s.p2p.Host().Peerstore().RemovePeer(peerId)
-			s.p2p.Host().Network().ClosePeer(peerId)
-			s.peers.RemovePeer(peerId)
-			return
-		}
+	if !valid && err == nil {
+		// Handshake succeeded but fork digest mismatched — peer is on a different fork.
+		// Must disconnect to avoid receiving incompatible blocks.
+		log.Debug("[Sentinel] Fork mismatch, disconnecting peer", "peer", peerId)
+		s.p2p.Host().Peerstore().RemovePeer(peerId)
+		s.p2p.Host().Network().ClosePeer(peerId)
+		s.peers.RemovePeer(peerId)
+		return false
+	}
 
-		if !valid {
-			// Handshake had a transport error AND returned invalid — keep anyway.
-			s.peers.RecordHandshakeFailure(peerId)
-		} else {
-			// we were able to succesfully connect, so add this peer to our pool
-			s.peers.AddPeer(peerId)
-
-			log.Trace("[Sentinel] Peer validated and added", "peer", peerId)
-		}
-	}()
+	if !valid {
+		// Handshake had a transport error AND returned invalid — keep anyway.
+		s.peers.RecordHandshakeFailure(peerId)
+		return true
+	}
+	// we were able to successfully connect, so add this peer to our pool
+	s.peers.AddPeer(peerId)
+	log.Trace("[Sentinel] Peer validated and added", "peer", peerId)
+	return true
 }


### PR DESCRIPTION
Cherry-pick of #23606 and its follow-up #23847 to `release/3.5`, via the `release/3.6` port #23866,
which closed with "release/3.5 has the same defect and still needs the same backport".

## Why it matters here

The defect is live on this branch. `onConnection` calls `RecordHandshakeFailure`, so the
three-strike ban is *written*, but `BanStatus` is only read on the outbound dial paths. Nothing
consults it for a connection that arrives on its own, so a banned peer gets a fresh status handshake
on every reconnect.

Measured on a gnosis archive node running this line: 101 attempts against a single peer in two
minutes, and 13,827 handshake failures across 1,638 peers in ninety minutes.

The admission logic moves out of the closure into `handleNewConnection`, so the ban check has
somewhere to return from and the behaviour is testable without a live dial.

## r3.5-specific adaptations

The pick applied cleanly except for the tail of the old closure, which this branch still ended with
`}()` rather than a `return`.

`#23866` also carried a one-line fixture change to `discovery_test.go` — swapping `peers.NewPool` for
the shared `testPeerPool()`. **That does not apply here**: this branch's copy never builds its own
pool. The conflict in that file was entirely context from
`TestListenForPeersDialsDirectPeersWithoutDiscovery`, which exists only on `release/3.6` and is
unrelated to this fix, so it is deliberately not imported. `#23866` changed one line there and added
no functions, which is how that was confirmed rather than assumed.

Retained-peer behaviour is untouched: keeping a peer whose status exchange failed on a transport
error is deliberate and unchanged. Only the rate at which a *banned* peer is re-attempted changes.

## Verification

Five tests, using two real connected hosts so closing the peer is observable rather than a no-op
against an absent connection. `cl/sentinel` passes normally and under `-race`.

Mutation-verified on this branch, not inherited from the upstream PR: disabling the inbound
`BanStatus` read fails `TestBannedPeerIsClosedInsteadOfHandshaked`.

`make lint` clean twice.

Closes the `release/3.5` side of #23605. With this in, the ban fix is on `main`, `release/3.6` and
`release/3.5` alike.
