### PR TITLE
cl/phase1/network: require file availability before skipping an archive slot

### DIFF
--- a/cl/phase1/network/blob_downloader.go
+++ b/cl/phase1/network/blob_downloader.go
@@ -843,17 +843,25 @@ func (b *BlobHistoryDownloader) collectIncompleteBlocks(currentSlot, targetSlot 
 	return batch, visited, nil
 }
 
-// storedSidecarsAvailable reports whether a count-equal slot is actually backed by files. PruneBelow
-// drops sidecar files but leaves their count rows, so on an archive node a matching count alone is
-// not evidence the store can serve the slot. Only the first index is probed: pruning removes whole
-// bucket directories, so absence is all-or-nothing, and writes commit the count row after the files.
+// storedSidecarsAvailable reports whether a count-equal slot is actually backed by files. Pruning
+// drops sidecar files but leaves their count rows, and a rewrite can fail partway, so on an archive
+// node a matching count alone is not evidence the store can serve the slot.
 //
 // Non-archive nodes prune on purpose, so a missing file there is expected and must not be re-queued.
 func (b *BlobHistoryDownloader) storedSidecarsAvailable(blockRoot common.Hash, slot uint64, commitments int) (bool, error) {
-	if !b.archiveBlobs || commitments == 0 {
+	if !b.archiveBlobs {
 		return true, nil
 	}
-	return b.blobStorage.BlobSidecarExists(b.ctx, slot, blockRoot, 0)
+	for idx := range commitments {
+		exists, err := b.blobStorage.BlobSidecarExists(b.ctx, slot, blockRoot, uint64(idx))
+		if err != nil {
+			return false, err
+		}
+		if !exists {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 func (b *BlobHistoryDownloader) processBatch(batch []*cltypes.SignedBeaconBlock) bool {

--- a/cl/phase1/network/blob_downloader.go
+++ b/cl/phase1/network/blob_downloader.go
@@ -830,11 +830,30 @@ func (b *BlobHistoryDownloader) collectIncompleteBlocks(currentSlot, targetSlot 
 			return nil, 0, err
 		}
 		if commitments.Len() == int(blobsCount) {
-			continue
+			available, err := b.storedSidecarsAvailable(blockRoot, currentSlot-visited, commitments.Len())
+			if err != nil {
+				return nil, 0, err
+			}
+			if available {
+				continue
+			}
 		}
 		batch = append(batch, block)
 	}
 	return batch, visited, nil
+}
+
+// storedSidecarsAvailable reports whether a count-equal slot is actually backed by files. PruneBelow
+// drops sidecar files but leaves their count rows, so on an archive node a matching count alone is
+// not evidence the store can serve the slot. Only the first index is probed: pruning removes whole
+// bucket directories, so absence is all-or-nothing, and writes commit the count row after the files.
+//
+// Non-archive nodes prune on purpose, so a missing file there is expected and must not be re-queued.
+func (b *BlobHistoryDownloader) storedSidecarsAvailable(blockRoot common.Hash, slot uint64, commitments int) (bool, error) {
+	if !b.archiveBlobs || commitments == 0 {
+		return true, nil
+	}
+	return b.blobStorage.BlobSidecarExists(b.ctx, slot, blockRoot, 0)
 }
 
 func (b *BlobHistoryDownloader) processBatch(batch []*cltypes.SignedBeaconBlock) bool {

--- a/cl/phase1/network/blob_downloader_boundary_test.go
+++ b/cl/phase1/network/blob_downloader_boundary_test.go
@@ -811,6 +811,7 @@ func TestBlobHistoryDownloaderDoesNotCompleteWhileASlotIsUnindexed(t *testing.T)
 
 	downloader := newBoundaryDownloader(t, head, 0, head, reader)
 	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	expectSidecarFilesPresent(blobStorage)
 	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(1), nil).AnyTimes()
 	downloader.blobStorage = blobStorage
 

--- a/cl/phase1/network/blob_downloader_test.go
+++ b/cl/phase1/network/blob_downloader_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1021,6 +1022,33 @@ func validDenebRecoverySidecar(t *testing.T, slot uint64) (*cltypes.SignedBeacon
 	return block, cltypes.NewBlobSidecar(0, (*cltypes.Blob)(&blob), common.Bytes48(commitment), common.Bytes48(proof), block.SignedBeaconBlockHeader(), inclusionProof)
 }
 
+func validDenebRecoverySidecars(t *testing.T, slot uint64, count int) (*cltypes.SignedBeaconBlock, []*cltypes.BlobSidecar) {
+	t.Helper()
+	blob := goethkzg.Blob{}
+	commitment, err := kzg.Ctx().BlobToKZGCommitment(&blob, 0)
+	require.NoError(t, err)
+	proof, err := kzg.Ctx().ComputeBlobKZGProof(&blob, commitment, 0)
+	require.NoError(t, err)
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+	block.Block.Slot = slot
+	for range count {
+		block.GetBlobKzgCommitments().Append((*cltypes.KZGCommitment)(&commitment))
+	}
+	_, err = block.Block.HashSSZ()
+	require.NoError(t, err)
+	sidecars := make([]*cltypes.BlobSidecar, 0, count)
+	for idx := range count {
+		branch, err := block.Block.Body.KzgCommitmentMerkleProof(idx)
+		require.NoError(t, err)
+		inclusionProof := solid.NewHashVector(cltypes.CommitmentBranchSize)
+		for i := range branch {
+			inclusionProof.Set(i, common.Hash(branch[i]))
+		}
+		sidecars = append(sidecars, cltypes.NewBlobSidecar(uint64(idx), (*cltypes.Blob)(&blob), common.Bytes48(commitment), common.Bytes48(proof), block.SignedBeaconBlockHeader(), inclusionProof))
+	}
+	return block, sidecars
+}
+
 type staticBlobPeerClient struct{ responses []*cltypes.BlobSidecar }
 
 func (staticBlobPeerClient) Peers() (uint64, error) { return 1, nil }
@@ -1116,6 +1144,37 @@ func TestCollectIncompleteBlocksQueuesArchiveSlotsWhoseFilesWerePruned(t *testin
 	batch, _, err := downloader.collectIncompleteBlocks(block.Block.Slot, block.Block.Slot)
 	require.NoError(t, err)
 	require.Len(t, batch, 1, "an archive slot whose sidecar files are gone must stay queued")
+}
+
+// A rewrite that publishes early indices and then fails leaves the count row whole while only part
+// of the data reaches disk, so a file at index zero is not evidence the slot can be served.
+func TestCollectIncompleteBlocksQueuesArchiveSlotsMissingALaterSidecarFile(t *testing.T) {
+	block, sidecars := validDenebRecoverySidecars(t, 100, 2)
+	blockRoot, err := block.Block.HashSSZ()
+	require.NoError(t, err)
+	db := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
+	fs := afero.NewMemMapFs()
+	storage := blob_storage.NewBlobStore(db, fs)
+	require.NoError(t, storage.WriteBlobSidecars(t.Context(), blockRoot, sidecars))
+	require.NoError(t, fs.Remove(fmt.Sprintf("%d/%s_1", block.Block.Slot/10_000, common.Hash(blockRoot).String())))
+
+	count, err := storage.KzgCommitmentsCount(t.Context(), blockRoot)
+	require.NoError(t, err)
+	require.Equal(t, uint32(2), count, "the count row must survive the lost file")
+	first, err := storage.BlobSidecarExists(t.Context(), block.Block.Slot, blockRoot, 0)
+	require.NoError(t, err)
+	require.True(t, first, "index zero must stay present for the fixture to be meaningful")
+	second, err := storage.BlobSidecarExists(t.Context(), block.Block.Slot, blockRoot, 1)
+	require.NoError(t, err)
+	require.False(t, second)
+
+	downloader := newBoundaryDownloader(t, block.Block.Slot, 0, block.Block.Slot, &boundaryBlockReader{block: block})
+	downloader.blobStorage = storage
+	downloader.archiveBlobs = true
+
+	batch, _, err := downloader.collectIncompleteBlocks(block.Block.Slot, block.Block.Slot)
+	require.NoError(t, err)
+	require.Len(t, batch, 1, "a partially stored archive slot must stay queued")
 }
 
 // A non-archive node prunes on purpose, so a missing file below its retention window is expected and

--- a/cl/phase1/network/blob_downloader_test.go
+++ b/cl/phase1/network/blob_downloader_test.go
@@ -79,7 +79,6 @@ func expectSidecarFilesPresent(blobStorage *blobstoragemock.MockBlobStorage) {
 // than the network custody window) makes DownloadColumnsAndRecoverBlobs block until
 // its context is cancelled. Column recovery must be bounded per block so the archive
 // blob backfill cannot hang forever holding the index read tx.
-
 func TestBlobHistoryDownloaderFuluColumnRecoveryIsBounded(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/cl/phase1/network/blob_downloader_test.go
+++ b/cl/phase1/network/blob_downloader_test.go
@@ -67,17 +67,18 @@ func (s *completingBlobStorage) KzgCommitmentsCount(ctx context.Context, root co
 	return count, errors.Join(err, s.writeErr)
 }
 
-// A historical fulu block whose PeerDAS data columns are served by no peer (older
-// than the network custody window) makes DownloadColumnsAndRecoverBlobs block until
-// its context is cancelled. Column recovery must be bounded per block so the archive
-// blob backfill cannot hang forever holding the index read tx.
 // expectSidecarFilesPresent declares that the store still holds the files its count rows claim.
-// The archive path stats index 0 before accepting a count-equal slot, so a test that reaches that
-// branch has to say which side of it it is on.
+// The archive path stats every sidecar index before accepting a count-equal slot, so a test that
+// reaches that branch has to say which side of it it is on.
 func expectSidecarFilesPresent(blobStorage *blobstoragemock.MockBlobStorage) {
 	blobStorage.EXPECT().BlobSidecarExists(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(true, nil).AnyTimes()
 }
+
+// A historical fulu block whose PeerDAS data columns are served by no peer (older
+// than the network custody window) makes DownloadColumnsAndRecoverBlobs block until
+// its context is cancelled. Column recovery must be bounded per block so the archive
+// blob backfill cannot hang forever holding the index read tx.
 
 func TestBlobHistoryDownloaderFuluColumnRecoveryIsBounded(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -1003,23 +1004,8 @@ func TestBlobHistoryDownloaderMixedDenebBatchIgnoresZeroCommitmentStorage(t *tes
 
 func validDenebRecoverySidecar(t *testing.T, slot uint64) (*cltypes.SignedBeaconBlock, *cltypes.BlobSidecar) {
 	t.Helper()
-	blob := goethkzg.Blob{}
-	commitment, err := kzg.Ctx().BlobToKZGCommitment(&blob, 0)
-	require.NoError(t, err)
-	proof, err := kzg.Ctx().ComputeBlobKZGProof(&blob, commitment, 0)
-	require.NoError(t, err)
-	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
-	block.Block.Slot = slot
-	block.GetBlobKzgCommitments().Append((*cltypes.KZGCommitment)(&commitment))
-	_, err = block.Block.HashSSZ()
-	require.NoError(t, err)
-	branch, err := block.Block.Body.KzgCommitmentMerkleProof(0)
-	require.NoError(t, err)
-	inclusionProof := solid.NewHashVector(cltypes.CommitmentBranchSize)
-	for i := range branch {
-		inclusionProof.Set(i, common.Hash(branch[i]))
-	}
-	return block, cltypes.NewBlobSidecar(0, (*cltypes.Blob)(&blob), common.Bytes48(commitment), common.Bytes48(proof), block.SignedBeaconBlockHeader(), inclusionProof)
+	block, sidecars := validDenebRecoverySidecars(t, slot, 1)
+	return block, sidecars[0]
 }
 
 func validDenebRecoverySidecars(t *testing.T, slot uint64, count int) (*cltypes.SignedBeaconBlock, []*cltypes.BlobSidecar) {
@@ -1096,12 +1082,16 @@ func TestCollectIncompleteBlocksSkipsSlotsCompleteUnderTheCanonicalRoot(t *testi
 	require.NotEqual(t, canonical, common.Hash(selfHash), "fixture must separate the two roots")
 
 	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
-	expectSidecarFilesPresent(blobStorage)
-	// Complete under the canonical root, absent under anything else.
+	// Complete under the canonical root, absent under anything else. The file probe is pinned to the
+	// same root and slot, so looking either up under the block's own hash fails the test.
 	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), canonical).
 		Return(uint32(block.GetBlobKzgCommitments().Len()), nil).AnyTimes()
 	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Not(gomock.Eq(canonical))).
 		Return(uint32(0), nil).AnyTimes()
+	blobStorage.EXPECT().BlobSidecarExists(gomock.Any(), uint64(slot), canonical, uint64(0)).
+		Return(true, nil).AnyTimes()
+	blobStorage.EXPECT().BlobSidecarExists(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(false, nil).AnyTimes()
 
 	downloader := newBoundaryDownloader(t, slot, 0, slot, &boundaryBlockReader{block: block})
 	downloader.blobStorage = blobStorage

--- a/cl/phase1/network/blob_downloader_test.go
+++ b/cl/phase1/network/blob_downloader_test.go
@@ -70,6 +70,14 @@ func (s *completingBlobStorage) KzgCommitmentsCount(ctx context.Context, root co
 // than the network custody window) makes DownloadColumnsAndRecoverBlobs block until
 // its context is cancelled. Column recovery must be bounded per block so the archive
 // blob backfill cannot hang forever holding the index read tx.
+// expectSidecarFilesPresent declares that the store still holds the files its count rows claim.
+// The archive path stats index 0 before accepting a count-equal slot, so a test that reaches that
+// branch has to say which side of it it is on.
+func expectSidecarFilesPresent(blobStorage *blobstoragemock.MockBlobStorage) {
+	blobStorage.EXPECT().BlobSidecarExists(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(true, nil).AnyTimes()
+}
+
 func TestBlobHistoryDownloaderFuluColumnRecoveryIsBounded(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -187,6 +195,7 @@ func TestBlobHistoryDownloaderIncompleteFuluRecoveryWithholdsCompletionUntilRetr
 	peerDas := mock_services.NewMockPeerDas(ctrl)
 	peerDas.EXPECT().DownloadColumnsAndRecoverBlobs(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	expectSidecarFilesPresent(blobStorage)
 
 	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
 	block.Block.Slot = 100
@@ -428,6 +437,7 @@ func TestBlobHistoryDownloaderFuluRecoveryRetainsExcessCommitmentCount(t *testin
 func TestBlobHistoryDownloaderCountEqualFuluSkipsDeepScanValidation(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	expectSidecarFilesPresent(blobStorage)
 	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(1), nil)
 
 	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
@@ -446,6 +456,7 @@ func TestBlobHistoryDownloaderCountEqualFuluSkipsDeepScanValidation(t *testing.T
 func TestBlobHistoryDownloaderDoesNotDeepVerifyCountEqualStorage(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	expectSidecarFilesPresent(blobStorage)
 	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(1), nil).AnyTimes()
 	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
 	block.Block.Slot = 100
@@ -466,6 +477,7 @@ func TestBlobHistoryDownloaderDoesNotDeepVerifyCountEqualStorage(t *testing.T) {
 func TestBlobHistoryDownloaderRetriesRecoveryAfterDurablePostcheckFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	expectSidecarFilesPresent(blobStorage)
 	countCalls := 0
 	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).DoAndReturn(func(context.Context, common.Hash) (uint32, error) {
 		countCalls++
@@ -586,6 +598,7 @@ func TestBlobHistoryDownloaderRetryDropsAlreadyCompleteDenebBlock(t *testing.T) 
 	blockRoot, err := block.Block.HashSSZ()
 	require.NoError(t, err)
 	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	expectSidecarFilesPresent(blobStorage)
 	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), blockRoot).Return(uint32(1), nil).AnyTimes()
 	blobStorage.EXPECT().ReadBlobSidecars(gomock.Any(), block.Block.Slot, blockRoot).Return([]*cltypes.BlobSidecar{sidecar}, true, nil).AnyTimes()
 	peer := &countingBlobPeerClient{responses: []*cltypes.BlobSidecar{sidecar}}
@@ -606,6 +619,7 @@ func TestBlobHistoryDownloaderRetryRetainsDenebBlockOnStorageReadError(t *testin
 	require.NoError(t, err)
 	wantErr := errors.New("temporary storage failure")
 	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	expectSidecarFilesPresent(blobStorage)
 	countCalls := 0
 	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), blockRoot).DoAndReturn(func(context.Context, common.Hash) (uint32, error) {
 		countCalls++
@@ -1054,6 +1068,7 @@ func TestCollectIncompleteBlocksSkipsSlotsCompleteUnderTheCanonicalRoot(t *testi
 	require.NotEqual(t, canonical, common.Hash(selfHash), "fixture must separate the two roots")
 
 	blobStorage := blobstoragemock.NewMockBlobStorage(ctrl)
+	expectSidecarFilesPresent(blobStorage)
 	// Complete under the canonical root, absent under anything else.
 	blobStorage.EXPECT().KzgCommitmentsCount(gomock.Any(), canonical).
 		Return(uint32(block.GetBlobKzgCommitments().Len()), nil).AnyTimes()
@@ -1070,4 +1085,56 @@ func TestCollectIncompleteBlocksSkipsSlotsCompleteUnderTheCanonicalRoot(t *testi
 	batch, _, err := downloader.collectIncompleteBlocks(slot, slot)
 	require.NoError(t, err)
 	require.Empty(t, batch, "a slot already complete in the store must not be queued for download")
+}
+
+// PruneBelow removes sidecar files but leaves their BlockRootToKzgCommitments rows, so a datadir
+// pruned as non-archive and later reopened with --caplin.blobs-archive carries counts that no file
+// backs. A matching count is then not evidence the store can serve the slot, and skipping it lets
+// the pass report completion and move its target past work an archive node still owes.
+func TestCollectIncompleteBlocksQueuesArchiveSlotsWhoseFilesWerePruned(t *testing.T) {
+	block, sidecar := validDenebRecoverySidecar(t, 100)
+	blockRoot, err := block.Block.HashSSZ()
+	require.NoError(t, err)
+	db := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
+	fs := afero.NewMemMapFs()
+	storage := blob_storage.NewBlobStore(db, fs)
+	require.NoError(t, storage.WriteBlobSidecars(t.Context(), blockRoot, []*cltypes.BlobSidecar{sidecar}))
+	require.NoError(t, storage.PruneBelow(10_000))
+
+	// The count row survives pruning; the file does not.
+	count, err := storage.KzgCommitmentsCount(t.Context(), blockRoot)
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), count)
+	exists, err := storage.BlobSidecarExists(t.Context(), block.Block.Slot, blockRoot, 0)
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	downloader := newBoundaryDownloader(t, block.Block.Slot, 0, block.Block.Slot, &boundaryBlockReader{block: block})
+	downloader.blobStorage = storage
+	downloader.archiveBlobs = true
+
+	batch, _, err := downloader.collectIncompleteBlocks(block.Block.Slot, block.Block.Slot)
+	require.NoError(t, err)
+	require.Len(t, batch, 1, "an archive slot whose sidecar files are gone must stay queued")
+}
+
+// A non-archive node prunes on purpose, so a missing file below its retention window is expected and
+// must not be re-queued. Only the archive path treats a count-equal slot with no file as work.
+func TestCollectIncompleteBlocksLeavesPrunedNonArchiveSlotsAlone(t *testing.T) {
+	block, sidecar := validDenebRecoverySidecar(t, 100)
+	blockRoot, err := block.Block.HashSSZ()
+	require.NoError(t, err)
+	db := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
+	fs := afero.NewMemMapFs()
+	storage := blob_storage.NewBlobStore(db, fs)
+	require.NoError(t, storage.WriteBlobSidecars(t.Context(), blockRoot, []*cltypes.BlobSidecar{sidecar}))
+	require.NoError(t, storage.PruneBelow(10_000))
+
+	downloader := newBoundaryDownloader(t, block.Block.Slot, 0, block.Block.Slot, &boundaryBlockReader{block: block})
+	downloader.blobStorage = storage
+	downloader.archiveBlobs = false
+
+	batch, _, err := downloader.collectIncompleteBlocks(block.Block.Slot, block.Block.Slot)
+	require.NoError(t, err)
+	require.Empty(t, batch, "a non-archive node must not re-queue what it deliberately pruned")
 }


### PR DESCRIPTION
Forward-port of a fix made on `release/3.6` while backporting #23895 (see #23922). `release/3.6` was
the only branch carrying it, which @awskii spotted — `git log --all -S storedSidecarsAvailable` found
one commit, on that branch alone.

Pruning drops sidecar files but leaves their `BlockRootToKzgCommitments` rows. A datadir pruned as
non-archive and later reopened with `--caplin.blobs-archive` therefore carries counts that no file
backs. `collectIncompleteBlocks` finds the stale count, matches it against the block's commitments
and skips the slot, so the pass can report completion and move `nextBackfillTargetSlot` past work an
archive node still owes.

This only became reachable with #23895: the earlier payload-stripped hash missed every count and
queued those slots by accident. Fixing the root removed that accident.

## The check

On an archive node, a count-equal slot is only skipped once **every** sidecar index up to the
commitment count is backed by a file; the first miss re-queues the block. Two deliberate choices:

- **a stat, not a read-back** — no KZG work is added;
  `TestBlobHistoryDownloaderDoesNotDeepVerifyCountEqualStorage` still passes with `verifyCalls == 0`.
- **gated on `archiveBlobs`** — a non-archive node prunes on purpose and must not re-queue what it
  deliberately dropped.

An earlier revision probed index 0 only, reasoning that pruning removes whole bucket directories so
absence is all-or-nothing. That holds for pruning but not for a rewrite that publishes index 0 and
then fails, which leaves the count row whole with only part of the data on disk. @domiwei caught
that on #23922; the loop is the fix.

## Tests

`release/3.6` pins the non-archive direction with
`TestBlobHistoryDownloaderDoesNotRetryIntentionallyPrunedFiles`; this branch has no such test, so the
gate would have been unpinned here. All three directions are pinned:

- `TestCollectIncompleteBlocksQueuesArchiveSlotsWhoseFilesWerePruned` — archive node, stale row,
  pruned file, block stays queued
- `TestCollectIncompleteBlocksQueuesArchiveSlotsMissingALaterSidecarFile` — two sidecars written,
  index 1's file removed, leaving `count=2, index0=true, index1=false`; the block stays queued
- `TestCollectIncompleteBlocksLeavesPrunedNonArchiveSlotsAlone` — same state, non-archive, left alone

Mutation-verified in all three directions: dropping the availability check fails the first, reverting
the loop to probe index 0 only fails the second, and dropping the `archiveBlobs` gate fails the
third.

`TestCollectIncompleteBlocksSkipsSlotsCompleteUnderTheCanonicalRoot` pins the probe to the canonical
root and slot rather than `gomock.Any()`, so regressing it to the block's own hash or a wrong slot
fails the test — verified by changing the production call to `slot+1`.

The mock declaration is one helper called at the seven tests that can actually reach the check — it
runs only when `archiveBlobs` is set, the count matches and the block carries commitments, so
hand-built downloaders and tests whose count lookup errors never get there.

`make lint` clean, `cl/phase1/network` green.

`release/3.5` carries the same fix in #23932.
