### PR TITLE
[r3.6] execution/execmodule: deflake TestAssembleBlockWithFreshlyAddedTxns

### DIFF
--- a/execution/execmodule/exec_module_test.go
+++ b/execution/execmodule/exec_module_test.go
@@ -929,6 +929,10 @@ func TestAssembleBlockWithFreshlyAddedTxns(t *testing.T) {
 	require.NoError(t, err)
 	baseFee := chainPack.TopBlock.BaseFee().Uint64()
 	addTwoTxnsToPool(ctx, 1, t, m, txpool, baseFee)
+	provider := &observingTxnProvider{
+		TxnProvider: m.TxPool,
+		txnCounts:   make(chan int, 16),
+	}
 
 	var parentBeaconBlockRoot common.Hash
 	_, err = rand.Read(parentBeaconBlockRoot[:])
@@ -940,14 +944,16 @@ func TestAssembleBlockWithFreshlyAddedTxns(t *testing.T) {
 		SuggestedFeeRecipient: common.Address{1},
 		Withdrawals:           make([]*types.Withdrawal, 0),
 		ParentBeaconBlockRoot: &parentBeaconBlockRoot,
+		CustomTxnProvider:     provider,
 	})
 	require.NoError(t, err)
 
-	// Add new transactions with a delay
-	time.Sleep(300 * time.Millisecond)
+	waitForProvidedTxnCount(t, provider.txnCounts, 2)
+	waitForProvidedTxnCount(t, provider.txnCounts, 0)
 	addTwoTxnsToPool(ctx, 3, t, m, txpool, baseFee)
+	waitForProvidedTxnCount(t, provider.txnCounts, 2)
+	waitForProvidedTxnCount(t, provider.txnCounts, 0)
 
-	// The block should have all four transactions
 	block, err := getAssembledBlock(ctx, exec, payloadId)
 	require.NoError(t, err)
 	require.Equal(t, uint64(2), block.NumberU64())


### PR DESCRIPTION
Backport of the `TestAssembleBlockWithFreshlyAddedTxns` hunk of #22914 to release/3.6. On 3.6 the test sleeps 300 ms and assumes the builder has re-polled the txpool by then; under `-race` it lost that race in #23928's CI ([job](https://github.com/erigontech/erigon/actions/runs/34587720325/job/103225742213), `exec_module_test.go:954`: "should have 4 item(s), but has 2").

## Changes
- Pass `observingTxnProvider` as `CustomTxnProvider` and wait for polls returning 2 then 0 transactions before and after adding the second pair, replacing the fixed sleep.

## r3.6-specific adaptations
- Only the test hunk of #22914; its BAL changes are not included.
- Keeps 3.6's `assembleBlock`/`getAssembledBlock` helpers and omits `SlotNumber`, which main's version passes.
- `observingTxnProvider` and `waitForProvidedTxnCount` already exist on 3.6 from #23394, unused until now.
