### PR TITLE
[r3.5] cl/phase1/network: require file availability before skipping an archive slot

### DIFF
--- a/cl/phase1/network/blob_downloader.go
+++ b/cl/phase1/network/blob_downloader.go
@@ -342,7 +342,13 @@ func (b *BlobHistoryDownloader) collectIncompleteBlocks(currentSlot, targetSlot 
 			continue
 		}
 		if commitments.Len() == int(blobsCount) {
-			continue
+			available, err := b.storedSidecarsAvailable(blockRoot, currentSlot-visited, commitments.Len())
+			if err != nil {
+				return nil, 0, err
+			}
+			if available {
+				continue
+			}
 		}
 		batch = append(batch, block)
 	}
@@ -351,6 +357,19 @@ func (b *BlobHistoryDownloader) collectIncompleteBlocks(currentSlot, targetSlot 
 
 // processBatch best-effort recovers each block's blobs: Deneb by-root, Fulu from
 // PeerDAS columns.
+// storedSidecarsAvailable reports whether a count-equal slot is actually backed by files. Prune
+// removes whole bucket directories but leaves their count rows, so on an archive node a matching
+// count alone is not evidence the store can serve the slot. Only the first index is probed: pruning
+// is per bucket, so absence is all-or-nothing, and writes commit the count row after the files.
+//
+// Non-archive nodes prune on purpose, so a missing file there is expected and must not be re-queued.
+func (b *BlobHistoryDownloader) storedSidecarsAvailable(blockRoot common.Hash, slot uint64, commitments int) (bool, error) {
+	if !b.archiveBlobs || commitments == 0 {
+		return true, nil
+	}
+	return b.blobStorage.BlobSidecarExists(b.ctx, slot, blockRoot, 0)
+}
+
 func (b *BlobHistoryDownloader) processBatch(batch []*cltypes.SignedBeaconBlock) {
 	fuluBlocks := make([]*cltypes.SignedBeaconBlock, 0, len(batch))
 	denebBlocks := make([]*cltypes.SignedBeaconBlock, 0, len(batch))

--- a/cl/phase1/network/blob_downloader.go
+++ b/cl/phase1/network/blob_downloader.go
@@ -355,21 +355,29 @@ func (b *BlobHistoryDownloader) collectIncompleteBlocks(currentSlot, targetSlot 
 	return batch, visited, nil
 }
 
-// processBatch best-effort recovers each block's blobs: Deneb by-root, Fulu from
-// PeerDAS columns.
-// storedSidecarsAvailable reports whether a count-equal slot is actually backed by files. Prune
-// removes whole bucket directories but leaves their count rows, so on an archive node a matching
-// count alone is not evidence the store can serve the slot. Only the first index is probed: pruning
-// is per bucket, so absence is all-or-nothing, and writes commit the count row after the files.
+// storedSidecarsAvailable reports whether a count-equal slot is actually backed by files. Pruning
+// removes sidecar files but leaves their count rows, and a rewrite can fail partway, so on an
+// archive node a matching count alone is not evidence the store can serve the slot.
 //
 // Non-archive nodes prune on purpose, so a missing file there is expected and must not be re-queued.
 func (b *BlobHistoryDownloader) storedSidecarsAvailable(blockRoot common.Hash, slot uint64, commitments int) (bool, error) {
-	if !b.archiveBlobs || commitments == 0 {
+	if !b.archiveBlobs {
 		return true, nil
 	}
-	return b.blobStorage.BlobSidecarExists(b.ctx, slot, blockRoot, 0)
+	for idx := range commitments {
+		exists, err := b.blobStorage.BlobSidecarExists(b.ctx, slot, blockRoot, uint64(idx))
+		if err != nil {
+			return false, err
+		}
+		if !exists {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
+// processBatch best-effort recovers each block's blobs: Deneb by-root, Fulu from
+// PeerDAS columns.
 func (b *BlobHistoryDownloader) processBatch(batch []*cltypes.SignedBeaconBlock) {
 	fuluBlocks := make([]*cltypes.SignedBeaconBlock, 0, len(batch))
 	denebBlocks := make([]*cltypes.SignedBeaconBlock, 0, len(batch))

--- a/cl/phase1/network/blob_downloader_test.go
+++ b/cl/phase1/network/blob_downloader_test.go
@@ -26,9 +26,11 @@ import (
 
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
 	"github.com/erigontech/erigon/cl/das"
 	"github.com/erigontech/erigon/cl/das/mock_services"
 	"github.com/erigontech/erigon/cl/persistence/beacon_indicies"
+	"github.com/erigontech/erigon/cl/persistence/blob_storage"
 	blob_mock_services "github.com/erigontech/erigon/cl/persistence/blob_storage/mock_services"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
@@ -36,6 +38,8 @@ import (
 	"github.com/erigontech/erigon/db/kv/dbcfg"
 	"github.com/erigontech/erigon/db/kv/memdb"
 	"github.com/erigontech/erigon/execution/types"
+	"github.com/spf13/afero"
+	"math"
 )
 
 type staticPeerDasGetter struct{ pd das.PeerDas }
@@ -197,4 +201,64 @@ func TestCollectIncompleteBlocksSkipsAnUnindexedSlotInsteadOfFailing(t *testing.
 	require.NoError(t, err, "an unindexed slot must be skipped, not fail the pass")
 	require.Empty(t, batch, "an unindexed slot must not be queued for download")
 	require.Equal(t, uint64(1), visited, "the pass must advance past the slot rather than stall on it")
+}
+
+// Prune removes whole bucket directories but leaves their BlockRootToKzgCommitments rows, so a
+// datadir pruned as non-archive and later reopened with --caplin.blobs-archive carries counts that
+// no file backs. A matching count is then not evidence the store can serve the slot, and skipping it
+// lets the pass report completion and move its target past work an archive node still owes.
+func TestCollectIncompleteBlocksAndPrunedFiles(t *testing.T) {
+	const slot = 100
+	canonical := common.HexToHash("0xc0ffee")
+
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+	block.Block.Slot = slot
+	commitment := cltypes.KZGCommitment{}
+	commitment[0] = 0x01
+	block.Block.Body.BlobKzgCommitments.Append(&commitment)
+
+	sidecar := &cltypes.BlobSidecar{
+		Index:                    0,
+		SignedBlockHeader:        &cltypes.SignedBeaconBlockHeader{Header: &cltypes.BeaconBlockHeader{Slot: slot}},
+		CommitmentInclusionProof: solid.NewHashVector(cltypes.CommitmentBranchSize),
+	}
+
+	for _, tc := range []struct {
+		name         string
+		archiveBlobs bool
+		wantQueued   int
+	}{
+		{"archive node must re-queue a slot whose files are gone", true, 1},
+		{"non-archive node must leave what it deliberately pruned", false, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db := memdb.NewTestDB(t, dbcfg.ChainDB)
+			require.NoError(t, db.Update(context.Background(), func(tx kv.RwTx) error {
+				return beacon_indicies.MarkRootCanonical(context.Background(), tx, slot, canonical)
+			}))
+			fs := afero.NewMemMapFs()
+			store := blob_storage.NewBlobStore(db, fs, math.MaxUint64, &clparams.MainnetBeaconConfig, nil)
+			require.NoError(t, store.WriteBlobSidecars(context.Background(), canonical, []*cltypes.BlobSidecar{sidecar}))
+
+			// What Prune leaves behind: the bucket directory is gone, the count row is not.
+			require.NoError(t, fs.RemoveAll("0"))
+			count, err := store.KzgCommitmentsCount(context.Background(), canonical)
+			require.NoError(t, err)
+			require.Equal(t, uint32(1), count)
+
+			b := &BlobHistoryDownloader{
+				ctx:          context.Background(),
+				beaconCfg:    &clparams.MainnetBeaconConfig,
+				indiciesDB:   db,
+				blobStorage:  store,
+				blockReader:  stubBlockReader{slot: slot, block: block},
+				archiveBlobs: tc.archiveBlobs,
+				logger:       log.New(),
+			}
+
+			batch, _, err := b.collectIncompleteBlocks(slot, slot)
+			require.NoError(t, err)
+			require.Len(t, batch, tc.wantQueued)
+		})
+	}
 }

--- a/cl/phase1/network/blob_downloader_test.go
+++ b/cl/phase1/network/blob_downloader_test.go
@@ -19,9 +19,11 @@ package network
 import (
 	"context"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
@@ -39,8 +41,6 @@ import (
 	"github.com/erigontech/erigon/db/kv/dbcfg"
 	"github.com/erigontech/erigon/db/kv/memdb"
 	"github.com/erigontech/erigon/execution/types"
-	"github.com/spf13/afero"
-	"math"
 )
 
 type staticPeerDasGetter struct{ pd das.PeerDas }

--- a/cl/phase1/network/blob_downloader_test.go
+++ b/cl/phase1/network/blob_downloader_test.go
@@ -18,6 +18,7 @@ package network
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -261,4 +262,58 @@ func TestCollectIncompleteBlocksAndPrunedFiles(t *testing.T) {
 			require.Len(t, batch, tc.wantQueued)
 		})
 	}
+}
+
+// A rewrite that publishes early indices and then fails leaves the count row whole while only part
+// of the data reaches disk, so a file at index zero is not evidence the slot can be served.
+func TestCollectIncompleteBlocksMissingALaterSidecarFile(t *testing.T) {
+	const slot = 100
+	canonical := common.HexToHash("0xc0ffee")
+
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+	block.Block.Slot = slot
+	sidecars := make([]*cltypes.BlobSidecar, 0, 2)
+	for idx := range 2 {
+		commitment := cltypes.KZGCommitment{}
+		commitment[0] = byte(idx + 1)
+		block.Block.Body.BlobKzgCommitments.Append(&commitment)
+		sidecars = append(sidecars, &cltypes.BlobSidecar{
+			Index:                    uint64(idx),
+			SignedBlockHeader:        &cltypes.SignedBeaconBlockHeader{Header: &cltypes.BeaconBlockHeader{Slot: slot}},
+			CommitmentInclusionProof: solid.NewHashVector(cltypes.CommitmentBranchSize),
+		})
+	}
+
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	require.NoError(t, db.Update(context.Background(), func(tx kv.RwTx) error {
+		return beacon_indicies.MarkRootCanonical(context.Background(), tx, slot, canonical)
+	}))
+	fs := afero.NewMemMapFs()
+	store := blob_storage.NewBlobStore(db, fs, math.MaxUint64, &clparams.MainnetBeaconConfig, nil)
+	require.NoError(t, store.WriteBlobSidecars(context.Background(), canonical, sidecars))
+
+	require.NoError(t, fs.Remove(fmt.Sprintf("%d/%s_1", slot/10_000, canonical.String())))
+	count, err := store.KzgCommitmentsCount(context.Background(), canonical)
+	require.NoError(t, err)
+	require.Equal(t, uint32(2), count, "the count row must survive the lost file")
+	first, err := store.BlobSidecarExists(context.Background(), slot, canonical, 0)
+	require.NoError(t, err)
+	require.True(t, first, "index zero must stay present for the fixture to be meaningful")
+	second, err := store.BlobSidecarExists(context.Background(), slot, canonical, 1)
+	require.NoError(t, err)
+	require.False(t, second)
+
+	b := &BlobHistoryDownloader{
+		ctx:          context.Background(),
+		beaconCfg:    &clparams.MainnetBeaconConfig,
+		indiciesDB:   db,
+		blobStorage:  store,
+		blockReader:  stubBlockReader{slot: slot, block: block},
+		archiveBlobs: true,
+		logger:       log.New(),
+	}
+
+	batch, _, err := b.collectIncompleteBlocks(slot, slot)
+	require.NoError(t, err)
+	require.Len(t, batch, 1, "a partially stored archive slot must stay queued")
 }


### PR DESCRIPTION
Backport of the archive-availability fix made on `release/3.6` (#23922) and forward-ported to `main`
(#23930). @awskii flagged that the fix existed only on `release/3.6`; this closes the third branch.

`Prune` removes whole bucket directories but leaves their `BlockRootToKzgCommitments` rows, so a
datadir pruned as non-archive and later reopened with `--caplin.blobs-archive` carries counts that no
file backs. Reading the canonical root — which this branch gained in #23915 — finds the stale count,
matches it against the block's commitments and skips the slot, so the pass can report completion and
move past work an archive node still owes. The earlier payload-stripped hash missed every count and
queued those slots by accident, which is why this only becomes reachable now.

On an archive node, a count-equal slot is only skipped once **every** sidecar index up to the
commitment count is backed by a file; the first miss re-queues the block. Gated on `archiveBlobs` so
a non-archive node does not re-queue what it deliberately pruned.

An earlier revision probed index 0 only, reasoning that pruning removes whole bucket directories so
absence is all-or-nothing. That holds for pruning but not for a rewrite that publishes index 0 and
then fails, which leaves the count row whole with only part of the data on disk. @domiwei caught that
on #23922; the loop is the fix.

## r3.5-specific adaptations

- this branch prunes with `Prune()` rather than `PruneBelow(slot)`, and `NewBlobStore` takes five
  arguments
- it has neither `validDenebRecoverySidecar` nor `newBoundaryDownloader`, which arrived with #23138
  on `main`, so the tests build the downloader directly in the style of the existing canonical-root
  test
- the pruned state is reached by removing the bucket directory from the in-memory filesystem rather
  than calling `Prune()`, which avoids depending on its `ethClock` and slots-kept machinery while
  producing the identical row-without-files state

## Tests

A table test covering both directions of the gate, since it is only meaningful as a pair:

- archive node, stale row, pruned file → block stays queued
- same state, non-archive → left alone

Plus `TestCollectIncompleteBlocksMissingALaterSidecarFile`: two sidecars written, index 1's file
removed, leaving `count=2, index0=true, index1=false`; the block stays queued.

Mutation-verified in all three directions: dropping the availability check fails the archive case,
dropping the `archiveBlobs` gate fails the non-archive case, and reverting the loop to probe index 0
only fails the partial-rewrite test.

Also restores `processBatch`'s doc comment, which this branch's port had left attached to
`storedSidecarsAvailable`.

`make lint` clean, `cl/phase1/network` green.
