### PR TITLE
ci(docs): automate the docs release-series cutover

### DIFF
--- a/.github/workflows/docs-cutover.yml
+++ b/.github/workflows/docs-cutover.yml
@@ -96,6 +96,25 @@ jobs:
           persist-credentials: false
           sparse-checkout: .github/workflows/scripts
 
+      - name: Ensure the trigger parser has a YAML library
+        run: |
+          set -euo pipefail
+          # docs-deploy-trigger.py reads on.push.branches with PyYAML instead of
+          # matching it with regexes, so that every shape GitHub accepts is read
+          # the way GitHub reads it. `import yaml` is not a safe assumption on
+          # the runner: the image installs yamllint and ansible-core through
+          # pipx, into their own virtualenvs, and lists no python3-yaml of its
+          # own. Install the distro package rather than the PyPI one — same
+          # library, already signed by a repository the runner trusts, and no
+          # escape hatch needed for Ubuntu's externally-managed environment.
+          if python3 -c 'import yaml' 2>/dev/null; then
+            echo "PyYAML already present: $(python3 -c 'import yaml; print(yaml.__version__)')"
+            exit 0
+          fi
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends python3-yaml
+          python3 -c 'import yaml; print("PyYAML installed:", yaml.__version__)'
+
       - name: Resolve the newest stable series and compare with the deploy variable
         id: compare
         env:
@@ -143,16 +162,38 @@ jobs:
           # the belt to that braces: a docs cutover advances at most one major,
           # so anything outside [current, current+1] is not a candidate however
           # it got tagged.
-          major_now="$(echo "$DEPLOY_BRANCH" | sed 's|release/||' | cut -d. -f1)"
-          newest="$(gh api 'repos/{owner}/{repo}/releases?per_page=100' \
+          current_series="${DEPLOY_BRANCH#release/}"
+          major_now="${current_series%%.*}"
+          minor_now="${current_series#*.}"
+
+          # Every stable SERIES in the window, de-duplicated and ascending. The
+          # patch level is dropped here on purpose: a cutover targets a series,
+          # and v3.7.0 and v3.7.3 are the same target.
+          series="$(gh api 'repos/{owner}/{repo}/releases?per_page=100' \
             --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' \
             | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' \
             | sed 's/^v//' \
             | awk -F. -v m="$major_now" '$1 >= m && $1 <= m + 1' \
-            | sort -t. -k1,1n -k2,2n -k3,3n \
-            | tail -n1 || true)"
+            | cut -d. -f1-2 \
+            | sort -t. -k1,1n -k2,2n -u || true)"
           # `|| true`: with no match `grep`/`awk` exit non-zero and pipefail would
           # abort the assignment, killing the step before the diagnostic prints.
+
+          # The NEXT series after the published one, not the newest one. A
+          # cutover ARCHIVES the series it replaces, so advancing two at once
+          # would archive 3.6, publish 3.8, and drop 3.7's docs from the site
+          # with no version-picker entry and nothing to say it happened. The
+          # major bound alone did not prevent this: 3.6 -> 3.8 sits inside
+          # [m, m+1], so it passed silently, and the loss detector further down
+          # compares inventories rather than counting series, so it passed too.
+          #
+          # A series that never shipped is not skipped: with no 3.7 release,
+          # 3.8 IS the next series and there is nothing to archive in between.
+          target_series="$(echo "$series" \
+            | awk -F. -v M="$major_now" -v N="$minor_now" \
+                '($1 > M) || ($1 == M && $2 > N)' \
+            | head -n1 || true)"
+          newest="$(echo "$series" | tail -n1 || true)"
 
           if [ -z "$newest" ]; then
             echo "::error::No stable release in the cutover window (majors ${major_now}-$((major_now + 1)))."
@@ -161,9 +202,44 @@ jobs:
             exit 1
           fi
 
-          # The bound advances one major at a time by design. When a stable
-          # release sits ABOVE that window, the bound is why it is being
-          # ignored — say so, rather than going quiet about a whole major.
+          # Nothing above the published series. Two very different reasons, and
+          # only one of them is benign:
+          if [ -z "$target_series" ]; then
+            if [ "$current_series" = "$newest" ]; then
+              # Published series IS the newest. The branch compare below reports
+              # "nothing to do".
+              target_series="$current_series"
+            else
+              # The variable names a series with no stable release at all, so
+              # there is nothing above it AND nothing at it. Falling through as
+              # "nothing to do" would make that a green run, which is the silent
+              # failure this whole workflow exists to remove.
+              echo "::error::DOCS_DEPLOY_BRANCH (${DEPLOY_BRANCH}) is AHEAD of every stable series (newest is ${newest})."
+              echo "Refusing to move the published docs backwards, and refusing to call this nothing to do."
+              echo "Investigate before changing anything: a yanked release or a hand-edited variable both look like this."
+              exit 1
+            fi
+          fi
+
+          # Being more than one series behind is normal-but-notable: the cutover
+          # walks there one series per run, archiving each. Say so, or a reader
+          # comparing the target against the release list sees a stale-looking
+          # answer and has no way to tell it is deliberate.
+          # `target_series` is the smallest series above the published one, so it
+          # is always <= newest and `!=` would do. Compared explicitly anyway:
+          # relying on that invariant means a reader has to re-derive it from the
+          # selection twenty lines up, and the ahead-of-everything case that used
+          # to reach here with target > newest now exits before it.
+          if [ "$target_series" != "$newest" ] \
+             && [ "$(printf '%s\n%s\n' "$target_series" "$newest" \
+                     | sort -t. -k1,1n -k2,2n | tail -n1)" = "$newest" ]; then
+            echo "::warning::${DEPLOY_BRANCH} is more than one series behind: newest stable is ${newest}."
+            echo "::warning::This run advances one series, to ${target_series}, so each intermediate series is archived. Re-run after it lands."
+          fi
+
+          # The major bound advances one major at a time by design. A stable
+          # release ABOVE that window is excluded by the bound, not overlooked —
+          # say so, rather than going quiet about a whole major.
           higher="$(gh api 'repos/{owner}/{repo}/releases?per_page=100' \
             --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' \
             | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | sed 's/^v//' \
@@ -173,10 +249,7 @@ jobs:
             echo "::warning::This run targets the next major only. If no release exists in between, the window never advances — cut the intermediate series or widen the bound."
           fi
 
-          target_series="$(echo "$newest" | cut -d. -f1-2)"
           target_branch="release/${target_series}"
-
-          current_series="${DEPLOY_BRANCH#release/}"
 
           echo "newest stable release : v${newest}"
           echo "target series         : ${target_series} (${target_branch})"
@@ -197,10 +270,32 @@ jobs:
             # 06:20 cron does — quietly, for as long as nobody notices. The
             # state machine below never looks at the branch in this case, so
             # check it here.
-            deploy_yml="$(gh api "repos/{owner}/{repo}/contents/.github/workflows/docs-deploy.yml?ref=${target_branch}" \
-              --jq '.content' 2>/dev/null | base64 -d || echo '')"
+            # Same absent-vs-unreadable distinction as `prepare`'s Condition B,
+            # which explains it in full. Nothing is written from this branch, so
+            # an unreadable file is reported rather than fatal — but it must not
+            # be reported as "carries no docs-deploy.yml", which is a different
+            # fact and sends the reader to the wrong fix.
+            read_err="${RUNNER_TEMP}/detect-deploy-yml.err"
+            present=no
+            unreadable=no
+            deploy_yml=''
+            if content="$(gh api "repos/{owner}/{repo}/contents/.github/workflows/docs-deploy.yml?ref=${target_branch}" \
+                 --jq '.content' 2>"$read_err")"; then
+              present=yes
+              deploy_yml="$(printf '%s' "$content" | base64 -d)"
+            elif grep -q 'No commit found for the ref' "$read_err"; then
+              # Both 404 shapes say "HTTP 404", so this one has to be matched
+              # FIRST: a deploy branch that does not resolve is a fault, and
+              # calling it "carries no docs-deploy.yml" sends the reader to seed
+              # a file onto a branch that is not there.
+              unreadable=yes
+            elif grep -q 'HTTP 404' "$read_err"; then
+              : # genuinely absent
+            else
+              unreadable=yes
+            fi
             # Parse only when there is something to parse: running the script on
-            # an empty file logs "has no push: trigger" just above the accurate
+            # an empty file logs "the file is empty" just above the accurate
             # "carries no docs-deploy.yml" warning, which reads like two faults.
             pinned=no
             if [ -n "$deploy_yml" ]; then
@@ -212,11 +307,21 @@ jobs:
               fi
             fi
 
-            if [ -z "$deploy_yml" ]; then
+            half=""
+            if [ "$unreadable" = yes ]; then
+              echo "::warning::Could not read docs-deploy.yml on ${target_branch}: $(tr '\n' ' ' < "$read_err")"
+              echo "::warning::Cannot confirm whether the push trigger pins it. Nothing was changed."
+              half="Could not read \`docs-deploy.yml\` on \`${target_branch}\`, so the push trigger is unconfirmed."
+            elif [ "$present" = yes ] && [ -z "$deploy_yml" ]; then
+              echo "::warning::docs-deploy.yml exists on ${target_branch} but is empty; nothing publishes from it."
+              half="\`docs-deploy.yml\` on \`${target_branch}\` exists but is empty, so merges never publish — only the 06:20 cron does."
+            elif [ "$present" = no ]; then
               echo "::warning::${target_branch} is the deploy branch but carries no docs-deploy.yml."
+              half="\`${target_branch}\` carries no \`docs-deploy.yml\`, so merges to it never publish — only the 06:20 cron does."
             elif [ "$pinned" = no ]; then
               echo "::warning::${target_branch} is the deploy branch, but its docs-deploy.yml push trigger does not pin it."
               echo "::warning::Merges to ${target_branch} will not publish; only the 06:20 cron will. Repoint the trigger."
+              half="\`${target_branch}\`'s \`docs-deploy.yml\` push trigger does not pin it, so merges never publish — only the 06:20 cron does."
             else
               # The trigger is right; the label can still be wrong if a hand-flip
               # skipped the version bump, which publishes the site under the
@@ -227,27 +332,39 @@ jobs:
                 | grep -oE "label: *'v[0-9]+\.[0-9]+'" | grep -oE "v[0-9]+\.[0-9]+" | head -n1 || true)"
               if [ -z "$lbl" ]; then
                 echo "::warning::Could not read currentDocsVersion.label on ${target_branch}; cannot confirm the published series."
+                half="Could not read \`currentDocsVersion.label\` on \`${target_branch}\`; the published series is unconfirmed."
               elif [ "$lbl" != "v${target_series}" ]; then
                 echo "::warning::${target_branch} publishes under label ${lbl}, expected v${target_series} — the version bump never ran."
+                half="\`${target_branch}\` publishes under label \`${lbl}\`, expected \`v${target_series}\` — the version bump never ran."
               else
                 echo "Docs deploy branch is current, pins itself, and publishes as ${lbl}. Nothing to do."
               fi
             fi
+
+            # A half-applied cutover is exactly the silent failure this workflow
+            # exists to convert into a visible one, so it goes in the summary
+            # like divergence does. Without this the run list shows a green
+            # check with nothing under it and the warnings scroll past in a log
+            # nobody opens.
+            if [ -n "$half" ]; then
+              {
+                echo "### Docs cutover is half applied"
+                echo ""
+                echo "$half"
+                echo ""
+                echo "\`DOCS_DEPLOY_BRANCH\` already reads \`${target_branch}\`, so this workflow's state machine will not act — the remaining step is manual."
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
             exit 0
           fi
 
-          # Refuse to move BACKWARDS. A yanked release, an API blip or a
-          # re-tagged older series must never unpublish a newer docs series.
-          if [ "$(printf '%s\n%s\n' "$current_series" "$target_series" \
-                  | sort -t. -k1,1n -k2,2n | tail -n1)" = "$current_series" ] \
-             && [ "$current_series" != "$target_series" ]; then
-            echo "::error::DOCS_DEPLOY_BRANCH (${DEPLOY_BRANCH}) is AHEAD of the newest stable series (${target_series})."
-            echo "Refusing to move the published docs backwards. Investigate before changing anything."
-            exit 1
-          fi
+          # No backwards guard is needed here any more: the selection above
+          # yields only a series strictly ABOVE the published one, and the one
+          # case that used to reach this point — the variable being ahead of
+          # every stable release — is refused where it is detected, by name.
 
           echo "diverged=true" >> "$GITHUB_OUTPUT"
-          echo "::warning::Docs deploy branch is stale: ${DEPLOY_BRANCH} published, ${target_branch} is the newest stable series."
+          echo "::warning::Docs deploy branch is stale: ${DEPLOY_BRANCH} published, ${target_branch} is the next stable series."
           {
             echo "### Docs cutover needed"
             echo ""
@@ -278,6 +395,19 @@ jobs:
           persist-credentials: false
           sparse-checkout: .github/workflows/scripts
 
+      - name: Ensure the trigger parser has a YAML library
+        run: |
+          set -euo pipefail
+          # Same reason as in `detect`: the runner carries no importable PyYAML
+          # of its own, and the parser needs one.
+          if python3 -c 'import yaml' 2>/dev/null; then
+            echo "PyYAML already present: $(python3 -c 'import yaml; print(yaml.__version__)')"
+            exit 0
+          fi
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends python3-yaml
+          python3 -c 'import yaml; print("PyYAML installed:", yaml.__version__)'
+
       - name: Generate GitHub App token
         id: app_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  ## v3.2.0
@@ -286,6 +416,7 @@ jobs:
           # `app-id` is the deprecated alias and warns on each run.
           client-id: ${{ vars.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
+          repositories: "erigon"
           # Least privilege, as in update-disk-sizes.yml: push a branch, open a
           # PR, dispatch docs-version-bump.yml. Nothing else.
           permission-contents: write
@@ -414,15 +545,57 @@ jobs:
           echo "Docs tree on ${TARGET_BRANCH} preserves ${CURRENT_BRANCH}'s versions (live ${cur_label})."
 
           # Condition B — does docs-deploy.yml on the target branch pin itself?
-          deploy_yml="$(gh api "repos/{owner}/{repo}/contents/.github/workflows/docs-deploy.yml?ref=${TARGET_BRANCH}" \
-            --jq '.content' 2>/dev/null | base64 -d || echo '')"
+          #
+          # "Absent" and "could not read" MUST be told apart here, because
+          # absent means seed, and seeding overwrites whatever is on the branch.
+          # `gh api | base64 -d || echo ''` cannot tell them apart: gh writes the
+          # error body to stdout, base64 rejects it, and `||` swallows the whole
+          # pipeline — so a 500, a rate-limit or a network blip all arrive as the
+          # empty string, exactly like a file that is not there.
+          #
+          # Two 404 shapes, both measured against the live API: a genuinely
+          # absent file gives `gh: Not Found (HTTP 404)`, while a ref that does
+          # not resolve gives `gh: No commit found for the ref <x> (HTTP 404)`.
+          # Only the first is "absent"; a vanished target branch is a fault.
+          read_err="${RUNNER_TEMP}/deploy-yml-read.err"
+          present=no
+          if content="$(gh api "repos/{owner}/{repo}/contents/.github/workflows/docs-deploy.yml?ref=${TARGET_BRANCH}" \
+               --jq '.content' 2>"$read_err")"; then
+            # Presence comes from the read SUCCEEDING, never from the decoded
+            # bytes being non-empty: a zero-byte or newline-only file decodes to
+            # the empty string, and inferring absence from that would seed over
+            # a file that is really there.
+            present=yes
+            deploy_yml="$(printf '%s' "$content" | base64 -d)"
+          elif grep -q 'No commit found for the ref' "$read_err"; then
+            echo "::error::${TARGET_BRANCH} does not resolve: $(tr '\n' ' ' < "$read_err")"
+            exit 1
+          elif grep -q 'HTTP 404' "$read_err"; then
+            deploy_yml=''
+          else
+            echo "::error::Could not read docs-deploy.yml on ${TARGET_BRANCH}: $(tr '\n' ' ' < "$read_err")"
+            echo "An unreadable file is not an absent file, and treating it as absent would seed"
+            echo "over a docs-deploy.yml that may well exist. Refusing until the read succeeds."
+            exit 1
+          fi
+
+          # Present but empty is a broken file, not an absent one: seeding would
+          # overwrite it and repointing cannot read it. Neither guess is right,
+          # so say which it is and stop.
+          if [ "$present" = yes ] && [ -z "$deploy_yml" ]; then
+            echo "::error::docs-deploy.yml exists on ${TARGET_BRANCH} but is empty."
+            echo "Fix or delete it, then re-run: this workflow will neither seed over a file that"
+            echo "exists nor repoint one it cannot read."
+            exit 1
+          fi
+
           # A missing file is NOT an error. docs-deploy.yml lives only on the
           # deploy branch — `main` has never carried it, and PR #23283 ADDED it
           # to release/3.6 rather than inheriting it. So a release branch cut
           # from `main` (create-release-branch.yml's default base) legitimately
           # arrives without it, and the repoint step seeds it from the branch
           # currently publishing.
-          if [ -z "$deploy_yml" ]; then
+          if [ "$present" = no ]; then
             echo "${TARGET_BRANCH} carries no docs-deploy.yml — it will be seeded from ${CURRENT_BRANCH}."
             {
               echo "seed=true"
@@ -484,6 +657,22 @@ jobs:
             exit 0
           fi
 
+          # A bump PR CLOSED without merging is a human decision, not an absent
+          # proposal — and `--state open` cannot see it. Without this the next
+          # run finds no open PR, nothing in flight, and a *successful* last run
+          # (it did open a PR; someone closed it), so it dispatches another one.
+          # Every day, one PR per day against a release branch, all green.
+          closed="$(gh pr list --state closed --base "$TARGET_BRANCH" --limit 100 \
+            --json number,headRefName,mergedAt \
+            --jq "[.[] | select((.headRefName | startswith(\"docs/version-bump-v${TARGET_SERIES}-\")) and .mergedAt == null)] | .[0].number // empty")"
+          if [ -n "$closed" ]; then
+            echo "::error::Version-bump PR #${closed} for v${TARGET_SERIES} was closed without merging."
+            echo "The cutover cannot continue until ${ARCHIVE_LABEL} is archived on ${TARGET_BRANCH}."
+            echo "Re-open #${closed}, or land the archive by hand, then re-run. Re-dispatching daily would"
+            echo "only open another PR beside the one that was deliberately closed."
+            exit 1
+          fi
+
           # A dispatched run takes minutes to build before it opens its PR. Without
           # this, a re-run inside that window sees no PR and dispatches a second
           # version bump, and both race to open competing PRs from the same base.
@@ -513,7 +702,18 @@ jobs:
             -f "new_label=v${TARGET_SERIES}"
 
       - name: Repoint the deploy push trigger
-        if: steps.state.outputs.repointed == 'false' && !inputs.dry_run
+        # Archiving the previous series and repointing the push trigger are
+        # independent prerequisites of the same cutover, so a transient failure
+        # in the archive step must not make this one unreachable until a human
+        # re-dispatches. Hence `!cancelled()` in place of the implicit
+        # `success()` — the job still ends red on the archive's failure.
+        #
+        # But `state` is required, not independent: it is what computes the
+        # outputs read here, and it writes them one at a time, so a failure
+        # part-way leaves a truthful `repointed` beside an empty `seed`. That
+        # combination would repoint a file this step was supposed to seed first.
+        # So tolerate a failed Archive, never a failed state.
+        if: ${{ !cancelled() && steps.state.outcome == 'success' && steps.state.outputs.repointed == 'false' && !inputs.dry_run }}
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           GH_REPO: ${{ github.repository }}
@@ -537,25 +737,64 @@ jobs:
           # every subsequent run, with only git's rejection text as a diagnostic.
           # Re-point it at the current target tip instead, guarded by the SHA we
           # actually observed so a concurrent writer is never clobbered.
-          remote_sha="$(git ls-remote "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
-            "refs/heads/${head}" | cut -f1 || true)"
+          # The token goes in a credential file, not in a URL on the command
+          # line: an argv token is readable in the process table and survives in
+          # any git error output that is not redacted. Plain URLs from here on.
+          creds="${RUNNER_TEMP}/git-credentials"
+          install -m 600 /dev/null "$creds"
+          printf 'https://x-access-token:%s@github.com\n' "$GH_TOKEN" > "$creds"
+          git config --global credential.helper "store --file=${creds}"
+          repo_url="https://github.com/${GITHUB_REPOSITORY}.git"
+
+          # ls-remote's exit status, kept separate from "the ref is not there".
+          # `| cut -f1 || true` covered the whole pipeline, so an auth failure or
+          # a network blip produced the same empty string as an absent branch —
+          # and absent takes the plain-push path below, dropping the
+          # --force-with-lease guard that keeps a concurrent writer safe.
+          ls_out="${RUNNER_TEMP}/ls-remote.out"
+          ls_err="${RUNNER_TEMP}/ls-remote.err"
+          if ! git ls-remote "$repo_url" "refs/heads/${head}" > "$ls_out" 2>"$ls_err"; then
+            echo "::error::Could not list refs on ${GITHUB_REPOSITORY}: $(tr '\n' ' ' < "$ls_err")"
+            echo "Whether ${head} already exists is what decides between a guarded force-push and a"
+            echo "plain one. Refusing to guess: either wrong answer clobbers a writer or wedges the push."
+            exit 1
+          fi
+          remote_sha="$(cut -f1 < "$ls_out")"
           if [ -n "$remote_sha" ]; then
             echo "::warning::Branch ${head} already exists (${remote_sha:0:10}) with no open PR — recreating it from the ${TARGET_BRANCH} tip."
           fi
 
           workdir="${RUNNER_TEMP}/cutover-repo"
           rm -rf "$workdir"
-          git clone --depth 1 --branch "$TARGET_BRANCH" \
-            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$workdir"
+          git clone --depth 1 --branch "$TARGET_BRANCH" "$repo_url" "$workdir"
           cd "$workdir"
 
           # Seed the file when the branch never had one (cut from `main`).
           # Taken from the branch currently publishing, so the copy is the one
           # in production, then repointed below like any inherited copy.
           if [ "${SEED}" = "true" ]; then
-            mkdir -p .github/workflows
+            # Staged through a temp file, then moved. A direct `> target` is the
+            # wrong shape twice over: the shell truncates the destination before
+            # `gh` runs, so a failed read leaves an empty file where the real one
+            # was, and the destination here is a clone of TARGET_BRANCH, which
+            # holds the real file whenever seed was decided on a bad read.
+            seeded="${RUNNER_TEMP}/seed-docs-deploy.yml"
             gh api "repos/{owner}/{repo}/contents/.github/workflows/docs-deploy.yml?ref=${CURRENT_BRANCH}" \
-              --jq '.content' | base64 -d > .github/workflows/docs-deploy.yml
+              --jq '.content' | base64 -d > "$seeded"
+            if [ ! -s "$seeded" ]; then
+              echo "::error::Read an empty docs-deploy.yml from ${CURRENT_BRANCH}; refusing to seed with it."
+              exit 1
+            fi
+            # Belt to that braces: seed means the file was absent, so finding one
+            # here says the decision was made on a read that lied.
+            if [ -e .github/workflows/docs-deploy.yml ]; then
+              echo "::error::seed=true, but ${TARGET_BRANCH} already has .github/workflows/docs-deploy.yml."
+              echo "That contradicts the state read earlier in this run — most likely a transient API"
+              echo "failure was read as 'absent'. Refusing to overwrite it. Re-run to re-read the state."
+              exit 1
+            fi
+            mkdir -p .github/workflows
+            mv "$seeded" .github/workflows/docs-deploy.yml
             echo "Seeded docs-deploy.yml from ${CURRENT_BRANCH}."
           fi
 
@@ -683,18 +922,37 @@ jobs:
           persist-credentials: false
           sparse-checkout: .github/workflows/scripts
 
+      - name: Ensure the trigger parser has a YAML library
+        run: |
+          set -euo pipefail
+          # Same reason as in `detect`: the runner carries no importable PyYAML
+          # of its own, and the parser needs one.
+          if python3 -c 'import yaml' 2>/dev/null; then
+            echo "PyYAML already present: $(python3 -c 'import yaml; print(yaml.__version__)')"
+            exit 0
+          fi
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends python3-yaml
+          python3 -c 'import yaml; print("PyYAML installed:", yaml.__version__)'
+
       - name: Generate GitHub App token
         id: app_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  ## v3.2.0
         with:
           client-id: ${{ vars.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
-          # Deliberately UNSCOPED, unlike every other consumer of this App.
-          # Writing a repository variable needs the App's `variables` permission,
-          # and this action version exposes no `permission-variables` input — so
-          # listing any permission-* here would mint a token that is *missing*
-          # the one permission this job exists to use. Revisit when the action
-          # gains that input.
+          repositories: "erigon"
+          # Deliberately unscoped on the PERMISSION axis, unlike every other
+          # consumer of this App. Writing a repository variable needs the App's
+          # `variables` permission, and this action version exposes no
+          # `permission-variables` input (v3.2.0 is the newest release and its
+          # action.yml has no such key) — so listing any permission-* here would
+          # mint a token that is *missing* the one permission this job exists to
+          # use. Revisit when the action gains that input.
+          #
+          # The REPOSITORY axis is scoped regardless: unavoidable on one axis is
+          # not a reason to be unscoped on both. `.github/zizmor.yml` records the
+          # `github-app` exception this leaves behind.
 
       - name: Assert the approval gate is real
         env:
@@ -763,25 +1021,42 @@ jobs:
             exit 1
           fi
 
-          # Same bounded selection as `detect` — see the comment there for why
-          # --paginate and an unbounded major are both wrong.
-          major_now="$(echo "$DEPLOY_BRANCH" | sed 's|release/||' | cut -d. -f1)"
-          newest="$(gh api 'repos/{owner}/{repo}/releases?per_page=100' \
+          # Same bounded NEXT-series selection as `detect` — see the comment
+          # there for why --paginate and an unbounded major are both wrong, and
+          # why the target is the next series rather than the newest.
+          #
+          # This must agree with detect's rule, not merely resemble it. Checking
+          # "is the target the NEWEST series" here while detect answers "the NEXT
+          # one" deadlocks the case that rule exists for: two series behind,
+          # detect prepares 3.7 on every run and this gate rejects 3.7 as
+          # superseded by 3.8, so the cutover can never complete.
+          minor_now="${current_series#*.}"
+          major_now="${current_series%%.*}"
+          series="$(gh api 'repos/{owner}/{repo}/releases?per_page=100' \
             --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' \
             | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' \
             | sed 's/^v//' \
             | awk -F. -v m="$major_now" '$1 >= m && $1 <= m + 1' \
-            | sort -t. -k1,1n -k2,2n -k3,3n \
-            | tail -n1 || true)"
-          if [ -z "$newest" ]; then
+            | cut -d. -f1-2 \
+            | sort -t. -k1,1n -k2,2n -u || true)"
+          if [ -z "$series" ]; then
             echo "::error::No stable release visible at approval time. Refusing to flip."
             exit 1
           fi
-          newest_branch="release/$(echo "$newest" | cut -d. -f1-2)"
+          next_series="$(echo "$series" \
+            | awk -F. -v M="$major_now" -v N="$minor_now" \
+                '($1 > M) || ($1 == M && $2 > N)' \
+            | head -n1 || true)"
+          if [ -z "$next_series" ]; then
+            echo "::error::DOCS_DEPLOY_BRANCH (${DEPLOY_BRANCH}) already names the newest stable series."
+            echo "There is nothing to flip to. Refusing."
+            exit 1
+          fi
+          next_branch="release/${next_series}"
 
-          if [ "$newest_branch" != "$TARGET_BRANCH" ]; then
-            echo "::error::Newest stable series is now ${newest_branch}, but this run was prepared for ${TARGET_BRANCH}."
-            echo "Refusing to publish a superseded series. Re-run the workflow to prepare ${newest_branch}."
+          if [ "$next_branch" != "$TARGET_BRANCH" ]; then
+            echo "::error::The next series to publish is now ${next_branch}, but this run was prepared for ${TARGET_BRANCH}."
+            echo "Refusing to flip to a series that is no longer the next step. Re-run the workflow to prepare ${next_branch}."
             exit 1
           fi
 
@@ -817,7 +1092,7 @@ jobs:
             exit 0
           fi
 
-          echo "Re-validated: ${TARGET_BRANCH} is the newest stable series, versioned and repointed."
+          echo "Re-validated: ${TARGET_BRANCH} is the next stable series, versioned and repointed."
           echo "already_done=false" >> "$GITHUB_OUTPUT"
 
       - name: Flip DOCS_DEPLOY_BRANCH
@@ -841,10 +1116,24 @@ jobs:
             exit 1
           fi
 
-          actual="$(gh api "repos/{owner}/{repo}/actions/variables/DOCS_DEPLOY_BRANCH" --jq '.value')"
-          if [ "$actual" != "$TARGET_BRANCH" ]; then
-            echo "::error::Variable reads '${actual}' after the update, expected '${TARGET_BRANCH}'."
-            exit 1
+          # The PATCH already succeeded, so the cutover HAS happened. A failing
+          # read-back is not evidence against it, and failing the job here would
+          # tell the operator the opposite of the truth while the site changes at
+          # the next cron — the same argument the dispatch step below makes for
+          # itself. Only a read that succeeds and DISAGREES is a real fault.
+          # Branch on the GET's exit status, not on a sentinel value: any
+          # sentinel is also a legal value for a repository variable, so one
+          # written concurrently would read as "unreadable" and hide exactly the
+          # mismatch this check exists to catch.
+          if actual="$(gh api "repos/{owner}/{repo}/actions/variables/DOCS_DEPLOY_BRANCH" \
+               --jq '.value' 2>/dev/null)"; then
+            if [ "$actual" != "$TARGET_BRANCH" ]; then
+              echo "::error::Variable reads '${actual}' after the update, expected '${TARGET_BRANCH}'."
+              exit 1
+            fi
+          else
+            echo "::warning::DOCS_DEPLOY_BRANCH was set to ${TARGET_BRANCH}, but reading it back failed."
+            echo "::warning::Not failing the job: the update itself succeeded. Confirm the variable by hand."
           fi
           echo "DOCS_DEPLOY_BRANCH: ${CURRENT_BRANCH} -> ${TARGET_BRANCH}"
 

--- a/.github/workflows/docs-cutover.yml
+++ b/.github/workflows/docs-cutover.yml
@@ -194,7 +194,7 @@ jobs:
               --jq '.content' 2>/dev/null | base64 -d || echo '')"
             if [ -z "$deploy_yml" ]; then
               echo "::warning::${target_branch} is the deploy branch but carries no docs-deploy.yml."
-            elif ! echo "$deploy_yml" | sed -n '/^on:/,/^permissions:/p' | grep -qE "^[ \t]*-[ \t]*${target_branch//./\\.}[ \t]*\$"; then
+            elif ! echo "$deploy_yml" | sed -n '/^on:/,/^permissions:/p' | grep -qE "^[[:blank:]]*-[[:blank:]]*${target_branch//./\\.}[[:blank:]]*\$"; then
               echo "::warning::${target_branch} is the deploy branch, but its docs-deploy.yml push trigger does not pin it."
               echo "::warning::Merges to ${target_branch} will not publish; only the 06:20 cron will. Repoint the trigger."
             else
@@ -318,6 +318,66 @@ jobs:
           fi
           echo "archive_label=${current_label}" >> "$GITHUB_OUTPUT"
 
+          # Before any version bump is dispatched, prove the target branch holds
+          # the PUBLISHED docs tree. Presence of docs-deploy.yml is not the test:
+          # PR #23283 added that file to release/3.6 by hand, so a human can
+          # cherry-pick it onto a branch cut from `main` and the tree is still
+          # main's. main carries versions.json ["v3.4","v3.3"] where release/3.6
+          # has ["v3.5","v3.4","v3.3"], and main's label already reads v3.6 — so
+          # a bump there archives the wrong content under the right name and
+          # drops a version from the published dropdown, silently. Run this
+          # whenever a bump is pending, not only when the workflow file is absent.
+          if [ "$archived" = false ]; then
+            tgt_versions="$(gh api "repos/{owner}/{repo}/contents/docs/site/versions.json?ref=${TARGET_BRANCH}" \
+              --jq '.content' 2>/dev/null | base64 -d | tr -d ' \n' || echo '')"
+            cur_versions="$(gh api "repos/{owner}/{repo}/contents/docs/site/versions.json?ref=${CURRENT_BRANCH}" \
+              --jq '.content' 2>/dev/null | base64 -d | tr -d ' \n' || echo '')"
+            cur_config="$(gh api "repos/{owner}/{repo}/contents/docs/site/docusaurus.config.ts?ref=${CURRENT_BRANCH}" \
+              --jq '.content' 2>/dev/null | base64 -d || echo '')"
+            cur_label="$(echo "$cur_config" | grep -A3 'const currentDocsVersion' \
+              | grep -oE "label: *'v[0-9]+\.[0-9]+'" | grep -oE "v[0-9]+\.[0-9]+" | head -n1 || true)"
+
+            # Fail CLOSED. An unreadable inventory is indistinguishable from an
+            # empty one, and an empty one makes every comparison below pass —
+            # admitting exactly the branch this refuses.
+            if [ -z "$tgt_versions" ] || [ -z "$cur_versions" ] || [ -z "$cur_label" ]; then
+              echo "::error::Could not read the docs inventory needed to validate ${TARGET_BRANCH}:"
+              [ -z "$tgt_versions" ] && echo "  - versions.json on ${TARGET_BRANCH}"
+              [ -z "$cur_versions" ] && echo "  - versions.json on ${CURRENT_BRANCH}"
+              [ -z "$cur_label" ] && echo "  - currentDocsVersion.label on ${CURRENT_BRANCH}"
+              echo "Refusing to dispatch a version bump without confirming the branch holds the published docs."
+              exit 1
+            fi
+
+            missing=""
+            for v in $(echo "$cur_versions" | tr -d '[]"' | tr ',' ' '); do
+              case "$tgt_versions" in
+                *"\"${v}\""*) ;;
+                *) missing="${missing} ${v}" ;;
+              esac
+            done
+            # The LIVE series on the publishing branch must survive too: either
+            # it is still the target's current label (the bump will archive it)
+            # or it is already archived there. Archived-superset alone misses
+            # this — after a skipped cutover both inventories can match while the
+            # live label is archived nowhere and simply disappears.
+            if [ "$cur_label" != "$current_label" ]; then
+              case "$tgt_versions" in
+                *"\"${cur_label}\""*) ;;
+                *) missing="${missing} ${cur_label}(live)" ;;
+              esac
+            fi
+
+            if [ -n "$missing" ]; then
+              echo "::error::${TARGET_BRANCH} does not carry the published docs versions present on ${CURRENT_BRANCH}:${missing}"
+              echo "Its docs tree is not the published one — most likely it was cut from 'main' rather than from ${CURRENT_BRANCH}."
+              echo "Versioning it would archive the wrong content and drop those versions from the site."
+              echo "Re-cut ${TARGET_BRANCH} from ${CURRENT_BRANCH}, or port docs/site across, then re-run."
+              exit 1
+            fi
+            echo "Docs tree on ${TARGET_BRANCH} preserves ${CURRENT_BRANCH}'s versions (live ${cur_label})."
+          fi
+
           # Condition B — does docs-deploy.yml on the target branch pin itself?
           deploy_yml="$(gh api "repos/{owner}/{repo}/contents/.github/workflows/docs-deploy.yml?ref=${TARGET_BRANCH}" \
             --jq '.content' 2>/dev/null | base64 -d || echo '')"
@@ -328,33 +388,6 @@ jobs:
           # arrives without it, and the repoint step seeds it from the branch
           # currently publishing.
           if [ -z "$deploy_yml" ]; then
-            # Seeding the workflow file is not enough to make this a valid docs
-            # branch. A branch cut from `main` also carries main's docs TREE,
-            # which is not the previous series': main's versions.json is
-            # ["v3.4","v3.3"] where release/3.6 has ["v3.5","v3.4","v3.3"], and
-            # the doc pages differ. Versioning that tree would archive main's
-            # content under the previous series' label and drop a version from
-            # the published dropdown — a wrong site, silently. Refuse instead,
-            # and say what to do about it.
-            tgt_versions="$(gh api "repos/{owner}/{repo}/contents/docs/site/versions.json?ref=${TARGET_BRANCH}" \
-              --jq '.content' 2>/dev/null | base64 -d | tr -d ' \n' || echo '')"
-            cur_versions="$(gh api "repos/{owner}/{repo}/contents/docs/site/versions.json?ref=${CURRENT_BRANCH}" \
-              --jq '.content' 2>/dev/null | base64 -d | tr -d ' \n' || echo '')"
-            missing=""
-            for v in $(echo "$cur_versions" | tr -d '[]"' | tr ',' ' '); do
-              case "$tgt_versions" in
-                *"\"${v}\""*) ;;
-                *) missing="${missing} ${v}" ;;
-              esac
-            done
-            if [ -n "$missing" ]; then
-              echo "::error::${TARGET_BRANCH} is missing archived docs versions present on ${CURRENT_BRANCH}:${missing}"
-              echo "Its docs tree is not the published one — most likely it was cut from 'main' rather than from ${CURRENT_BRANCH}."
-              echo "Versioning it would archive the wrong content and drop those versions from the site."
-              echo "Re-cut ${TARGET_BRANCH} from ${CURRENT_BRANCH}, or port docs/site across, then re-run."
-              exit 1
-            fi
-
             echo "${TARGET_BRANCH} carries no docs-deploy.yml — it will be seeded from ${CURRENT_BRANCH}."
             {
               echo "seed=true"
@@ -372,7 +405,7 @@ jobs:
           # Escape the dots: unescaped, release/3.6 as an ERE also matches a
           # typo'd release/3x6 and would report the trigger as correctly pinned.
           target_re="${TARGET_BRANCH//./\\.}"
-          if echo "$deploy_yml" | sed -n '/^on:/,/^permissions:/p' | grep -qE "^[ \t]*-[ \t]*${target_re}[ \t]*\$"; then
+          if echo "$deploy_yml" | sed -n '/^on:/,/^permissions:/p' | grep -qE "^[[:blank:]]*-[[:blank:]]*${target_re}[[:blank:]]*\$"; then
             repointed=true
           else
             repointed=false
@@ -728,7 +761,7 @@ jobs:
             echo "::error::${TARGET_BRANCH} docs label reads '${label:-unreadable}', expected v${TARGET_SERIES}. The version bump is no longer in place."
             exit 1
           fi
-          if ! echo "$deploy_yml" | sed -n '/^on:/,/^permissions:/p' | grep -qE "^[ \t]*-[ \t]*${TARGET_BRANCH//./\\.}[ \t]*\$"; then
+          if ! echo "$deploy_yml" | sed -n '/^on:/,/^permissions:/p' | grep -qE "^[[:blank:]]*-[[:blank:]]*${TARGET_BRANCH//./\\.}[[:blank:]]*\$"; then
             echo "::error::${TARGET_BRANCH} docs-deploy.yml no longer pins itself. The repoint is no longer in place."
             exit 1
           fi

--- a/.github/workflows/docs-cutover.yml
+++ b/.github/workflows/docs-cutover.yml
@@ -160,10 +160,10 @@ jobs:
           higher="$(gh api 'repos/{owner}/{repo}/releases?per_page=100' \
             --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' \
             | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | sed 's/^v//' \
-            | awk -F. -v m="$major_now" '$1 > m + 1' | sort -t. -k1,1n | tail -n1 || true)"
+            | awk -F. -v m="$major_now" '$1 > m + 1' | sort -t. -k1,1n -k2,2n -k3,3n | tail -n1 || true)"
           if [ -n "$higher" ]; then
             echo "::warning::Stable v${higher} is above the one-major cutover window from ${DEPLOY_BRANCH}."
-            echo "::warning::This run targets the next major only; re-run after that cutover lands to continue."
+            echo "::warning::This run targets the next major only. If no release exists in between, the window never advances — cut the intermediate series or widen the bound."
           fi
 
           target_series="$(echo "$newest" | cut -d. -f1-2)"
@@ -194,7 +194,7 @@ jobs:
               --jq '.content' 2>/dev/null | base64 -d || echo '')"
             if [ -z "$deploy_yml" ]; then
               echo "::warning::${target_branch} is the deploy branch but carries no docs-deploy.yml."
-            elif ! echo "$deploy_yml" | sed -n '/^on:/,/^permissions:/p' | grep -qE "^ *- *${target_branch//./\\.}\$"; then
+            elif ! echo "$deploy_yml" | sed -n '/^on:/,/^permissions:/p' | grep -qE "^[ \t]*-[ \t]*${target_branch//./\\.}[ \t]*\$"; then
               echo "::warning::${target_branch} is the deploy branch, but its docs-deploy.yml push trigger does not pin it."
               echo "::warning::Merges to ${target_branch} will not publish; only the 06:20 cron will. Repoint the trigger."
             else
@@ -205,10 +205,12 @@ jobs:
                 --jq '.content' 2>/dev/null | base64 -d || echo '')"
               lbl="$(echo "$cfg" | grep -A3 'const currentDocsVersion' \
                 | grep -oE "label: *'v[0-9]+\.[0-9]+'" | grep -oE "v[0-9]+\.[0-9]+" | head -n1 || true)"
-              if [ -n "$lbl" ] && [ "$lbl" != "v${target_series}" ]; then
+              if [ -z "$lbl" ]; then
+                echo "::warning::Could not read currentDocsVersion.label on ${target_branch}; cannot confirm the published series."
+              elif [ "$lbl" != "v${target_series}" ]; then
                 echo "::warning::${target_branch} publishes under label ${lbl}, expected v${target_series} — the version bump never ran."
               else
-                echo "Docs deploy branch is current, pins itself, and publishes as ${lbl:-unknown}. Nothing to do."
+                echo "Docs deploy branch is current, pins itself, and publishes as ${lbl}. Nothing to do."
               fi
             fi
             exit 0
@@ -326,11 +328,43 @@ jobs:
           # arrives without it, and the repoint step seeds it from the branch
           # currently publishing.
           if [ -z "$deploy_yml" ]; then
+            # Seeding the workflow file is not enough to make this a valid docs
+            # branch. A branch cut from `main` also carries main's docs TREE,
+            # which is not the previous series': main's versions.json is
+            # ["v3.4","v3.3"] where release/3.6 has ["v3.5","v3.4","v3.3"], and
+            # the doc pages differ. Versioning that tree would archive main's
+            # content under the previous series' label and drop a version from
+            # the published dropdown — a wrong site, silently. Refuse instead,
+            # and say what to do about it.
+            tgt_versions="$(gh api "repos/{owner}/{repo}/contents/docs/site/versions.json?ref=${TARGET_BRANCH}" \
+              --jq '.content' 2>/dev/null | base64 -d | tr -d ' \n' || echo '')"
+            cur_versions="$(gh api "repos/{owner}/{repo}/contents/docs/site/versions.json?ref=${CURRENT_BRANCH}" \
+              --jq '.content' 2>/dev/null | base64 -d | tr -d ' \n' || echo '')"
+            missing=""
+            for v in $(echo "$cur_versions" | tr -d '[]"' | tr ',' ' '); do
+              case "$tgt_versions" in
+                *"\"${v}\""*) ;;
+                *) missing="${missing} ${v}" ;;
+              esac
+            done
+            if [ -n "$missing" ]; then
+              echo "::error::${TARGET_BRANCH} is missing archived docs versions present on ${CURRENT_BRANCH}:${missing}"
+              echo "Its docs tree is not the published one — most likely it was cut from 'main' rather than from ${CURRENT_BRANCH}."
+              echo "Versioning it would archive the wrong content and drop those versions from the site."
+              echo "Re-cut ${TARGET_BRANCH} from ${CURRENT_BRANCH}, or port docs/site across, then re-run."
+              exit 1
+            fi
+
             echo "${TARGET_BRANCH} carries no docs-deploy.yml — it will be seeded from ${CURRENT_BRANCH}."
-            echo "seed=true" >> "$GITHUB_OUTPUT"
-            repointed=false
-            echo "repointed=false" >> "$GITHUB_OUTPUT"
-            echo "ready=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "seed=true"
+              echo "repointed=false"
+              # Emitted here too: an early exit that omits it leaves the Archive
+              # step's `archived == 'false'` gate reading '' and silently skips
+              # the version bump for the whole run.
+              echo "archived=${archived}"
+              echo "ready=false"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "seed=false" >> "$GITHUB_OUTPUT"
@@ -338,7 +372,7 @@ jobs:
           # Escape the dots: unescaped, release/3.6 as an ERE also matches a
           # typo'd release/3x6 and would report the trigger as correctly pinned.
           target_re="${TARGET_BRANCH//./\\.}"
-          if echo "$deploy_yml" | sed -n '/^on:/,/^permissions:/p' | grep -qE "^ *- *${target_re}\$"; then
+          if echo "$deploy_yml" | sed -n '/^on:/,/^permissions:/p' | grep -qE "^[ \t]*-[ \t]*${target_re}[ \t]*\$"; then
             repointed=true
           else
             repointed=false
@@ -488,11 +522,20 @@ jobs:
           git checkout -b "$head"
           git add .github/workflows/docs-deploy.yml
 
-          cat > "${RUNNER_TEMP}/commit-msg.txt" <<MSG
-          ci(docs): repoint the docs deploy trigger to ${TARGET_BRANCH}
+          if [ "${SEED}" = "true" ]; then
+            why="This branch had no docs-deploy.yml at all, so it was seeded from
+          ${CURRENT_BRANCH} and pointed at itself."
+            subject="add the docs deploy workflow to ${TARGET_BRANCH}"
+          else
+            why="A release branch is cut from the previous one, so it inherits that
+          branch in its own push trigger and never fires for itself."
+            subject="repoint the docs deploy trigger to ${TARGET_BRANCH}"
+          fi
 
-          A release branch is cut from the previous one, so it inherits that
-          branch in its own push trigger and never fires for itself.
+          cat > "${RUNNER_TEMP}/commit-msg.txt" <<MSG
+          ci(docs): ${subject}
+
+          ${why}
 
           Opened automatically by the docs cutover workflow (run ${RUN_ID}).
           MSG
@@ -511,9 +554,7 @@ jobs:
           cat > "${RUNNER_TEMP}/pr-body.md" <<'MD'
           Step 1 of 2 of the docs cutover to `__TARGET__`.
 
-          `docs-deploy.yml` on this branch still fires only for pushes to
-          `__CURRENT__`, because a release branch inherits the previous branch's
-          trigger and so never publishes for itself.
+          __WHY__
 
           Merging this changes nothing on its own: `docs-deploy.yml`'s job gate
           also checks the `DOCS_DEPLOY_BRANCH` variable, which still reads
@@ -523,8 +564,8 @@ jobs:
           Opened automatically by run __RUN__.
           MD
           TARGET_BRANCH="$TARGET_BRANCH" CURRENT_BRANCH="$CURRENT_BRANCH" RUN_ID="$RUN_ID" \
-            python3 -c 'import os,sys; p=sys.argv[1]; s=open(p).read(); \
-          s=s.replace("__TARGET__",os.environ["TARGET_BRANCH"]).replace("__CURRENT__",os.environ["CURRENT_BRANCH"]).replace("__RUN__",os.environ["RUN_ID"]); \
+            WHY="$why" python3 -c 'import os,sys; p=sys.argv[1]; s=open(p).read(); \
+          s=s.replace("__TARGET__",os.environ["TARGET_BRANCH"]).replace("__CURRENT__",os.environ["CURRENT_BRANCH"]).replace("__RUN__",os.environ["RUN_ID"]).replace("__WHY__",os.environ["WHY"]); \
           open(p,"w").write(s)' "${RUNNER_TEMP}/pr-body.md"
 
           # Push succeeded, so the branch exists even if this fails; the guard
@@ -532,7 +573,7 @@ jobs:
           gh pr create \
             --base "$TARGET_BRANCH" \
             --head "$head" \
-            --title "ci(docs): repoint the docs deploy trigger to ${TARGET_BRANCH}" \
+            --title "ci(docs): ${subject}" \
             --label docs \
             --body-file "${RUNNER_TEMP}/pr-body.md"
 
@@ -637,6 +678,21 @@ jobs:
           #
           # Selection duplicated from the `detect` job on purpose: the two must
           # agree, and a shared step would need a composite action for three lines.
+          # detect's guards do not carry across the approval wait, and the
+          # variable can have been edited by hand meanwhile. Re-apply both.
+          if ! echo "$DEPLOY_BRANCH" | grep -qE '^release/[0-9]+\.[0-9]+$'; then
+            echo "::error::DOCS_DEPLOY_BRANCH now reads '${DEPLOY_BRANCH}', which is not a release/N.N branch."
+            exit 1
+          fi
+          current_series="${DEPLOY_BRANCH#release/}"
+          if [ "$(printf '%s\n%s\n' "$current_series" "$TARGET_SERIES" \
+                  | sort -t. -k1,1n -k2,2n | tail -n1)" = "$current_series" ] \
+             && [ "$current_series" != "$TARGET_SERIES" ]; then
+            echo "::error::DOCS_DEPLOY_BRANCH is now ${DEPLOY_BRANCH}, ahead of this run's target ${TARGET_BRANCH}."
+            echo "Approving would move the published docs backwards. Refusing."
+            exit 1
+          fi
+
           # Same bounded selection as `detect` — see the comment there for why
           # --paginate and an unbounded major are both wrong.
           major_now="$(echo "$DEPLOY_BRANCH" | sed 's|release/||' | cut -d. -f1)"
@@ -672,7 +728,7 @@ jobs:
             echo "::error::${TARGET_BRANCH} docs label reads '${label:-unreadable}', expected v${TARGET_SERIES}. The version bump is no longer in place."
             exit 1
           fi
-          if ! echo "$deploy_yml" | sed -n '/^on:/,/^permissions:/p' | grep -qE "^ *- *${TARGET_BRANCH//./\\.}\$"; then
+          if ! echo "$deploy_yml" | sed -n '/^on:/,/^permissions:/p' | grep -qE "^[ \t]*-[ \t]*${TARGET_BRANCH//./\\.}[ \t]*\$"; then
             echo "::error::${TARGET_BRANCH} docs-deploy.yml no longer pins itself. The repoint is no longer in place."
             exit 1
           fi

--- a/.github/workflows/docs-cutover.yml
+++ b/.github/workflows/docs-cutover.yml
@@ -1,0 +1,451 @@
+name: Docs - Release-series cutover
+
+run-name: "Docs cutover check${{ inputs.dry_run && ' (dry run)' || '' }}"
+
+# Moves the published docs to a new release series when one goes stable.
+#
+# A release changes nothing in the docs pipeline on its own. Making the new
+# series live takes two edits in two different places:
+#
+#   1. `on.push.branches` in docs-deploy.yml ON THE NEW RELEASE BRANCH. A new
+#      release branch is cut from the previous one, so it inherits the OLD
+#      branch name in its own push trigger and never fires for itself.
+#   2. The DOCS_DEPLOY_BRANCH repository variable, read by docs-deploy.yml's
+#      job gate and by docs-deploy-cron.yml.
+#
+# Doing neither is what happens by default, and it fails silently: the daily
+# cron keeps republishing the PREVIOUS series' docs, every run green. The
+# cron's fail-if-unset guard catches an absent variable, not a stale one.
+#
+# WHY A SCHEDULE AND NOT `release: published`
+# A release event's ref is the tag, so the workflow file is resolved from the
+# tagged tree — a workflow added today does not exist in tags cut before it, and
+# a tag cut from a branch that lacks the file silently runs nothing. A schedule
+# resolves from the default branch, which is where this file lives. Latency is
+# bounded by the daily run and `workflow_dispatch` forces it immediately.
+#
+# WHY A STATE MACHINE AND NOT ONE LINEAR RUN
+# The cutover spans several human merges. Rather than tracking pull requests
+# across runs — which breaks the moment someone renames or recreates one — each
+# run reads the DESIRED END STATE off the target branch and advances at most one
+# step. Runs are idempotent: when there is nothing to do, the workflow no-ops.
+#
+#   detect      -> is the deploy variable behind the newest stable series?
+#   prepare     -> archive the previous series, repoint the push trigger (PRs)
+#   switch      -> both landed on the branch: flip the variable
+#
+# WHY THE SWITCH IS ENVIRONMENT-GATED
+# create-release-branch.yml puts privileged release-namespace operations behind
+# an environment with required reviewers, deliberately. Publishing a different
+# docs series is that kind of operation: the docs for a new series should go
+# live when they are ready, not the instant a tag appears. The gate keeps the
+# detection and preparation fully automatic while the last step stays a click.
+# To make the cutover zero-touch, delete the `environment:` line on the `switch`
+# job; nothing else depends on it.
+
+on:
+  schedule:
+    # 06:50 UTC — after docs-deploy-cron (06:20) so a cutover lands on a site
+    # that has already refreshed, and clear of the 04:00 QA cron block.
+    - cron: '50 6 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Report what would happen, change nothing"
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  # One cutover in flight at a time. Never cancel: a half-applied cutover is
+  # the failure state this workflow exists to prevent.
+  group: docs-cutover
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # ---------------------------------------------------------------- detect --
+  detect:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      diverged: ${{ steps.compare.outputs.diverged }}
+      current_branch: ${{ steps.compare.outputs.current_branch }}
+      target_branch: ${{ steps.compare.outputs.target_branch }}
+      target_series: ${{ steps.compare.outputs.target_series }}
+    steps:
+      - name: Resolve the newest stable series and compare with the deploy variable
+        id: compare
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          # No default on purpose: a hardcoded fallback would let this workflow
+          # "succeed" while pointing at a branch nobody chose.
+          DEPLOY_BRANCH: ${{ vars.DOCS_DEPLOY_BRANCH }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$DEPLOY_BRANCH" ]; then
+            echo "::error::Repository variable DOCS_DEPLOY_BRANCH is not set."
+            echo "Set it (Settings -> Actions -> Variables) to the branch the docs site publishes from."
+            exit 1
+          fi
+
+          # Selection must agree with docs/site/src/releases.js, which drives the
+          # {ERIGON_VERSION} the site renders. Two rules from there matter here:
+          #   - the API orders by publish date, which is wrong the moment a
+          #     back-port ships after a newer series (v3.2.4 after v3.3.0), so
+          #     sort by semantic version;
+          #   - tag SHAPE decides pre-release, because releases do not reliably
+          #     set the API's `prerelease` flag; any hyphen disqualifies a tag.
+          newest="$(gh api --paginate 'repos/{owner}/{repo}/releases?per_page=100' \
+            --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' \
+            | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' \
+            | sed 's/^v//' \
+            | sort -t. -k1,1n -k2,2n -k3,3n \
+            | tail -n1)"
+
+          if [ -z "$newest" ]; then
+            echo "::error::No stable release found. Refusing to guess a target series."
+            exit 1
+          fi
+
+          target_series="$(echo "$newest" | cut -d. -f1-2)"
+          target_branch="release/${target_series}"
+
+          # The backwards-move guard below compares series numerically, which is
+          # meaningless if the variable is not a release branch at all. Refuse
+          # rather than compare "main" against "3.6".
+          if ! echo "$DEPLOY_BRANCH" | grep -qE '^release/[0-9]+\.[0-9]+$'; then
+            echo "::error::DOCS_DEPLOY_BRANCH is '${DEPLOY_BRANCH}', which is not a release/N.N branch."
+            echo "This workflow only understands release-series branches. Fix the variable or disable this workflow."
+            exit 1
+          fi
+          current_series="${DEPLOY_BRANCH#release/}"
+
+          echo "newest stable release : v${newest}"
+          echo "target series         : ${target_series} (${target_branch})"
+          echo "DOCS_DEPLOY_BRANCH    : ${DEPLOY_BRANCH}"
+
+          {
+            echo "current_branch=${DEPLOY_BRANCH}"
+            echo "target_branch=${target_branch}"
+            echo "target_series=${target_series}"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "$DEPLOY_BRANCH" = "$target_branch" ]; then
+            echo "diverged=false" >> "$GITHUB_OUTPUT"
+            echo "Docs deploy branch is current. Nothing to do."
+            exit 0
+          fi
+
+          # Refuse to move BACKWARDS. A yanked release, an API blip or a
+          # re-tagged older series must never unpublish a newer docs series.
+          if [ "$(printf '%s\n%s\n' "$current_series" "$target_series" \
+                  | sort -t. -k1,1n -k2,2n | tail -n1)" = "$current_series" ] \
+             && [ "$current_series" != "$target_series" ]; then
+            echo "::error::DOCS_DEPLOY_BRANCH (${DEPLOY_BRANCH}) is AHEAD of the newest stable series (${target_series})."
+            echo "Refusing to move the published docs backwards. Investigate before changing anything."
+            exit 1
+          fi
+
+          echo "diverged=true" >> "$GITHUB_OUTPUT"
+          echo "::warning::Docs deploy branch is stale: ${DEPLOY_BRANCH} published, ${target_branch} is the newest stable series."
+          {
+            echo "### Docs cutover needed"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Published now | \`${DEPLOY_BRANCH}\` |"
+            echo "| Newest stable | \`${target_branch}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # --------------------------------------------------------------- prepare --
+  prepare:
+    needs: detect
+    if: needs.detect.outputs.diverged == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      ready: ${{ steps.state.outputs.ready }}
+    permissions:
+      contents: read
+    steps:
+      - name: Generate GitHub App token
+        id: app_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  ## v3.2.0
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
+
+      - name: Read the desired end state off the target branch
+        id: state
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          TARGET_BRANCH: ${{ needs.detect.outputs.target_branch }}
+          TARGET_SERIES: ${{ needs.detect.outputs.target_series }}
+        run: |
+          set -euo pipefail
+
+          if ! gh api "repos/{owner}/{repo}/branches/${TARGET_BRANCH}" --silent 2>/dev/null; then
+            echo "::error::Target branch ${TARGET_BRANCH} does not exist yet."
+            echo "Create it with the 'Create release branch' workflow, then re-run this one."
+            exit 1
+          fi
+
+          # Condition A — has this branch been versioned for its own series yet?
+          #
+          # The label to archive is read from the branch itself, not inferred
+          # from release history: docusaurus.config.ts carries
+          # `currentDocsVersion.label`, rewritten at each cutover, and that is
+          # exactly what docs-version-bump.yml freezes ("the CURRENT docs").
+          # Guessing "the highest series below the target" would archive the
+          # wrong label whenever a cutover was skipped.
+          config="$(gh api "repos/{owner}/{repo}/contents/docs/site/docusaurus.config.ts?ref=${TARGET_BRANCH}" \
+            --jq '.content' 2>/dev/null | base64 -d || echo '')"
+          if [ -z "$config" ]; then
+            echo "::error::${TARGET_BRANCH} carries no docs/site/docusaurus.config.ts."
+            exit 1
+          fi
+          current_label="$(echo "$config" \
+            | grep -A3 'const currentDocsVersion' \
+            | grep -oE "label: *'v[0-9]+\.[0-9]+'" \
+            | grep -oE "v[0-9]+\.[0-9]+" | head -n1)"
+          if [ -z "$current_label" ]; then
+            echo "::error::Could not read currentDocsVersion.label from docusaurus.config.ts on ${TARGET_BRANCH}."
+            echo "The literal is rewritten at each cutover; if its shape changed, this workflow must be updated."
+            exit 1
+          fi
+
+          if [ "$current_label" = "v${TARGET_SERIES}" ]; then
+            archived=true
+          else
+            archived=false
+          fi
+          echo "archive_label=${current_label}" >> "$GITHUB_OUTPUT"
+
+          # Condition B — does docs-deploy.yml on the target branch pin itself?
+          deploy_yml="$(gh api "repos/{owner}/{repo}/contents/.github/workflows/docs-deploy.yml?ref=${TARGET_BRANCH}" \
+            --jq '.content' 2>/dev/null | base64 -d || echo '')"
+          if [ -z "$deploy_yml" ]; then
+            echo "::error::${TARGET_BRANCH} carries no docs-deploy.yml. It cannot become the docs branch."
+            exit 1
+          fi
+          # Only the push-trigger block matters; workflow_dispatch ignores it.
+          if echo "$deploy_yml" | sed -n '/^on:/,/^permissions:/p' | grep -qE "^ *- *${TARGET_BRANCH}\$"; then
+            repointed=true
+          else
+            repointed=false
+          fi
+
+          echo "docs label on ${TARGET_BRANCH}: ${current_label} (target v${TARGET_SERIES}) -> versioned=${archived}"
+          echo "docs-deploy.yml push trigger pins ${TARGET_BRANCH}              : ${repointed}"
+
+          {
+            echo "archived=${archived}"
+            echo "repointed=${repointed}"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "$archived" = true ] && [ "$repointed" = true ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Archive the previous series
+        if: steps.state.outputs.archived == 'false' && !inputs.dry_run
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          TARGET_BRANCH: ${{ needs.detect.outputs.target_branch }}
+          TARGET_SERIES: ${{ needs.detect.outputs.target_series }}
+          ARCHIVE_LABEL: ${{ steps.state.outputs.archive_label }}
+        run: |
+          set -euo pipefail
+
+          # docs-version-bump.yml names its branch docs/version-bump-<label>-<run id>,
+          # so an existing proposal can only be found by head prefix. Without this
+          # check every daily run would open another identical pull request.
+          existing="$(gh pr list --state open --base "$TARGET_BRANCH" \
+            --json number,headRefName \
+            --jq "[.[] | select(.headRefName | startswith(\"docs/version-bump-v${TARGET_SERIES}-\"))] | .[0].number // empty")"
+          if [ -n "$existing" ]; then
+            echo "Version-bump PR #${existing} is already open against ${TARGET_BRANCH}. Waiting for it to merge."
+            exit 0
+          fi
+
+          echo "Dispatching docs-version-bump.yml on ${TARGET_BRANCH}: archive ${ARCHIVE_LABEL}, publish v${TARGET_SERIES}"
+          gh workflow run docs-version-bump.yml \
+            --ref "$TARGET_BRANCH" \
+            -f "archive_version=${ARCHIVE_LABEL}" \
+            -f "new_label=v${TARGET_SERIES}"
+
+      - name: Repoint the deploy push trigger
+        if: steps.state.outputs.repointed == 'false' && !inputs.dry_run
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          TARGET_BRANCH: ${{ needs.detect.outputs.target_branch }}
+          CURRENT_BRANCH: ${{ needs.detect.outputs.current_branch }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          head="docs/cutover-repoint-${TARGET_BRANCH#release/}"
+          open_count="$(gh pr list --state open --base "$TARGET_BRANCH" --head "$head" --json number --jq 'length')"
+          if [ "$open_count" != "0" ]; then
+            echo "Repoint PR is already open against ${TARGET_BRANCH}. Waiting for it to merge."
+            exit 0
+          fi
+
+          workdir="${RUNNER_TEMP}/cutover-repo"
+          rm -rf "$workdir"
+          git clone --depth 1 --branch "$TARGET_BRANCH" \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$workdir"
+          cd "$workdir"
+
+          # Rewrite the branch name only inside the `on:` block, so a match in a
+          # comment or a job condition further down is left alone.
+          python3 - "$CURRENT_BRANCH" "$TARGET_BRANCH" <<'PY'
+          import re, sys
+          old, new = sys.argv[1], sys.argv[2]
+          path = '.github/workflows/docs-deploy.yml'
+          src = open(path).read()
+          head, sep, tail = src.partition('\npermissions:')
+          if not sep:
+              sys.exit('docs-deploy.yml has no permissions: block - refusing to edit blindly')
+          patched, n = re.subn(rf'^(\s*-\s*){re.escape(old)}\s*$', rf'\g<1>{new}', head, flags=re.M)
+          if n != 1:
+              sys.exit(f'expected exactly one push-trigger entry for {old} in the on: block, found {n}')
+          open(path, 'w').write(patched + sep + tail)
+          PY
+
+          git config user.name "erigon-release-bot[bot]"
+          git config user.email "erigon-release-bot[bot]@users.noreply.github.com"
+          git checkout -b "$head"
+          git add .github/workflows/docs-deploy.yml
+
+          cat > "${RUNNER_TEMP}/commit-msg.txt" <<MSG
+          ci(docs): repoint the docs deploy trigger to ${TARGET_BRANCH}
+
+          A release branch is cut from the previous one, so it inherits that
+          branch in its own push trigger and never fires for itself.
+
+          Opened automatically by the docs cutover workflow (run ${RUN_ID}).
+          MSG
+          git commit -F "${RUNNER_TEMP}/commit-msg.txt"
+          git push origin "HEAD:refs/heads/${head}"
+
+          # Quoted delimiter: the body is markdown full of backticks, which an
+          # interpolating heredoc would run as command substitution. Placeholders
+          # are substituted afterwards from the environment, never from the body.
+          cat > "${RUNNER_TEMP}/pr-body.md" <<'MD'
+          Step 1 of 2 of the docs cutover to `__TARGET__`.
+
+          `docs-deploy.yml` on this branch still fires only for pushes to
+          `__CURRENT__`, because a release branch inherits the previous branch's
+          trigger and so never publishes for itself.
+
+          Merging this changes nothing on its own: `docs-deploy.yml`'s job gate
+          also checks the `DOCS_DEPLOY_BRANCH` variable, which still reads
+          `__CURRENT__`. The cutover workflow flips that variable once this PR
+          and the version-bump PR have both landed.
+
+          Opened automatically by run __RUN__.
+          MD
+          TARGET_BRANCH="$TARGET_BRANCH" CURRENT_BRANCH="$CURRENT_BRANCH" RUN_ID="$RUN_ID" \
+            python3 -c 'import os,sys; p=sys.argv[1]; s=open(p).read(); \
+          s=s.replace("__TARGET__",os.environ["TARGET_BRANCH"]).replace("__CURRENT__",os.environ["CURRENT_BRANCH"]).replace("__RUN__",os.environ["RUN_ID"]); \
+          open(p,"w").write(s)' "${RUNNER_TEMP}/pr-body.md"
+
+          gh pr create \
+            --base "$TARGET_BRANCH" \
+            --head "$head" \
+            --title "ci(docs): repoint the docs deploy trigger to ${TARGET_BRANCH}" \
+            --label docs \
+            --body-file "${RUNNER_TEMP}/pr-body.md"
+
+      - name: Report remaining work
+        if: steps.state.outputs.ready == 'false'
+        env:
+          ARCHIVED: ${{ steps.state.outputs.archived }}
+          REPOINTED: ${{ steps.state.outputs.repointed }}
+          TARGET_BRANCH: ${{ needs.detect.outputs.target_branch }}
+        run: |
+          {
+            echo "### Cutover to \`${TARGET_BRANCH}\` in progress"
+            echo ""
+            echo "| Step | Done |"
+            echo "|---|---|"
+            echo "| Previous series versioned | ${ARCHIVED} |"
+            echo "| Deploy trigger repointed | ${REPOINTED} |"
+            echo "| Variable flipped | waiting on the two above |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------- switch --
+  switch:
+    needs: [detect, prepare]
+    if: needs.detect.outputs.diverged == 'true' && needs.prepare.outputs.ready == 'true' && !inputs.dry_run
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Approval gate, matching create-release-branch.yml: configure required
+    # reviewers on this environment in repo settings. Remove this line to make
+    # the cutover zero-touch.
+    environment: docs-deploy-cutover
+    steps:
+      - name: Generate GitHub App token
+        id: app_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  ## v3.2.0
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
+
+      - name: Flip DOCS_DEPLOY_BRANCH
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          TARGET_BRANCH: ${{ needs.detect.outputs.target_branch }}
+          CURRENT_BRANCH: ${{ needs.detect.outputs.current_branch }}
+        run: |
+          set -euo pipefail
+
+          # Repository variables need the App's "Variables: read and write"
+          # permission. That is NOT administration:write — create-release-branch.yml
+          # keeps administration out of automation tokens on purpose, and this
+          # stays within that rule. If the App lacks it, say exactly what to grant.
+          if ! gh api -X PATCH "repos/{owner}/{repo}/actions/variables/DOCS_DEPLOY_BRANCH" \
+                 -f "name=DOCS_DEPLOY_BRANCH" -f "value=${TARGET_BRANCH}" --silent; then
+            echo "::error::Could not update DOCS_DEPLOY_BRANCH (${CURRENT_BRANCH} -> ${TARGET_BRANCH})."
+            echo "Grant the release App the repository 'Variables: read and write' permission, or set it by hand."
+            exit 1
+          fi
+
+          actual="$(gh api "repos/{owner}/{repo}/actions/variables/DOCS_DEPLOY_BRANCH" --jq '.value')"
+          if [ "$actual" != "$TARGET_BRANCH" ]; then
+            echo "::error::Variable reads '${actual}' after the update, expected '${TARGET_BRANCH}'."
+            exit 1
+          fi
+          echo "DOCS_DEPLOY_BRANCH: ${CURRENT_BRANCH} -> ${TARGET_BRANCH}"
+
+      - name: Publish the new series immediately
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          TARGET_BRANCH: ${{ needs.detect.outputs.target_branch }}
+        run: |
+          set -euo pipefail
+          # Without this the site would keep serving the old series until the
+          # 06:20 cron, up to 24h later.
+          gh workflow run docs-deploy.yml --ref "$TARGET_BRANCH"
+          {
+            echo "### Docs cutover complete"
+            echo ""
+            echo "\`DOCS_DEPLOY_BRANCH\` now reads \`${TARGET_BRANCH}\`, and a deploy has been dispatched."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docs-cutover.yml
+++ b/.github/workflows/docs-cutover.yml
@@ -199,12 +199,17 @@ jobs:
             # check it here.
             deploy_yml="$(gh api "repos/{owner}/{repo}/contents/.github/workflows/docs-deploy.yml?ref=${target_branch}" \
               --jq '.content' 2>/dev/null | base64 -d || echo '')"
-            printf '%s' "$deploy_yml" > "${RUNNER_TEMP}/deploy.yml"
+            # Parse only when there is something to parse: running the script on
+            # an empty file logs "has no push: trigger" just above the accurate
+            # "carries no docs-deploy.yml" warning, which reads like two faults.
             pinned=no
-            if DEPLOY_YML="${RUNNER_TEMP}/deploy.yml" \
-               python3 "${GITHUB_WORKSPACE}/.github/workflows/scripts/docs-deploy-trigger.py" --list \
-               | grep -Fxq "$target_branch"; then
-              pinned=yes
+            if [ -n "$deploy_yml" ]; then
+              printf '%s' "$deploy_yml" > "${RUNNER_TEMP}/deploy.yml"
+              if DEPLOY_YML="${RUNNER_TEMP}/deploy.yml" \
+                 python3 "${GITHUB_WORKSPACE}/.github/workflows/scripts/docs-deploy-trigger.py" --list \
+                 | grep -Fxq "$target_branch"; then
+                pinned=yes
+              fi
             fi
 
             if [ -z "$deploy_yml" ]; then
@@ -563,6 +568,17 @@ jobs:
           DEPLOY_YML="${workdir}/.github/workflows/docs-deploy.yml" \
             python3 "${GITHUB_WORKSPACE}/.github/workflows/scripts/docs-deploy-trigger.py" \
             --repoint "$TARGET_BRANCH"
+
+          # The script treats "already pinned" as a no-op, but the commit below
+          # would then fail with "nothing to commit" and turn the whole step red.
+          # That happens whenever a human lands the repoint between the state
+          # step's API read and this clone. Use `status --porcelain` rather than
+          # `diff --quiet`: on the seed path the file is new and untracked, which
+          # `diff` cannot see.
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "Nothing to repoint — ${TARGET_BRANCH} already pins itself. Done by someone else."
+            exit 0
+          fi
 
           git config user.name "erigon-release-bot[bot]"
           git config user.email "erigon-release-bot[bot]@users.noreply.github.com"

--- a/.github/workflows/docs-cutover.yml
+++ b/.github/workflows/docs-cutover.yml
@@ -4,8 +4,11 @@ run-name: "Docs cutover${{ inputs.dry_run && ' (dry run)' || '' }}"
 
 # Moves the published docs to a new release series when one goes stable.
 #
-# A release changes nothing in the docs pipeline on its own. Making the new
-# series live takes two edits in two different places:
+# A PATCH release needs nothing: docs-deploy-cron.yml dispatches a build daily,
+# and that build resolves its install version with `stableInSeries`, so the
+# newest patch of the series already being published goes live on its own.
+#
+# A new SERIES is the gap. Making it live takes two edits in two places:
 #
 #   1. `on.push.branches` in docs-deploy.yml ON THE NEW RELEASE BRANCH, which
 #      arrives wrong in one of two ways. Cut from the previous release branch,

--- a/.github/workflows/docs-cutover.yml
+++ b/.github/workflows/docs-cutover.yml
@@ -971,6 +971,10 @@ jobs:
             # no approval in exactly the misconfiguration this asserts against.
             echo "::error::Could not read protection rules for release-branch-management."
             echo "Refusing to flip the published docs series without confirming the approval gate."
+            echo "Two things look identical from here and both are refused on purpose: an"
+            echo "environment with no protection rules, and an environment this token cannot read."
+            echo "GitHub documents this endpoint as needing only repository read access, so if it"
+            echo "is returning 403, check what the release App is actually installed with."
             exit 1
           elif ! echo "$rules" | grep -q 'required_reviewers'; then
             echo "::error::Environment release-branch-management has no required_reviewers rule (rules: ${rules:-none})."
@@ -987,6 +991,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           TARGET_BRANCH: ${{ needs.detect.outputs.target_branch }}
           TARGET_SERIES: ${{ needs.detect.outputs.target_series }}
+          CURRENT_BRANCH: ${{ needs.detect.outputs.current_branch }}
         run: |
           set -euo pipefail
 
@@ -1033,8 +1038,17 @@ jobs:
           # one" deadlocks the case that rule exists for: two series behind,
           # detect prepares 3.7 on every run and this gate rejects 3.7 as
           # superseded by 3.8, so the cutover can never complete.
-          minor_now="${current_series#*.}"
-          major_now="${current_series%%.*}"
+          # Evaluated from the branch this run was PREPARED against, not from
+          # the variable's current value. Someone flipping the variable to
+          # TARGET while this job waits for approval is a supported case, handled
+          # at the end of this step — but deriving the next series from the
+          # flipped value makes TARGET look already-past, so the "nothing to flip
+          # to" refusal below fires and that supported case never reaches its
+          # handler. The question here is "is TARGET still the next step from
+          # where this run started", which is what CURRENT_BRANCH answers.
+          base_series="${CURRENT_BRANCH#release/}"
+          minor_now="${base_series#*.}"
+          major_now="${base_series%%.*}"
           series="$(gh api 'repos/{owner}/{repo}/releases?per_page=100' \
             --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' \
             | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' \
@@ -1051,8 +1065,9 @@ jobs:
                 '($1 > M) || ($1 == M && $2 > N)' \
             | head -n1 || true)"
           if [ -z "$next_series" ]; then
-            echo "::error::DOCS_DEPLOY_BRANCH (${DEPLOY_BRANCH}) already names the newest stable series."
-            echo "There is nothing to flip to. Refusing."
+            echo "::error::No stable series above ${CURRENT_BRANCH} is visible at approval time."
+            echo "This run was prepared to publish ${TARGET_BRANCH}; there is now nothing above the"
+            echo "branch it started from, so the release it was prepared for has gone. Refusing."
             exit 1
           fi
           next_branch="release/${next_series}"

--- a/.github/workflows/docs-cutover.yml
+++ b/.github/workflows/docs-cutover.yml
@@ -7,9 +7,14 @@ run-name: "Docs cutover${{ inputs.dry_run && ' (dry run)' || '' }}"
 # A release changes nothing in the docs pipeline on its own. Making the new
 # series live takes two edits in two different places:
 #
-#   1. `on.push.branches` in docs-deploy.yml ON THE NEW RELEASE BRANCH. A new
-#      release branch is cut from the previous one, so it inherits the OLD
-#      branch name in its own push trigger and never fires for itself.
+#   1. `on.push.branches` in docs-deploy.yml ON THE NEW RELEASE BRANCH, which
+#      arrives wrong in one of two ways. Cut from the previous release branch,
+#      it inherits that branch's name and never fires for itself. Cut from
+#      `main` — create-release-branch.yml's default base — docs-deploy.yml is
+#      not there at all: `main` has never carried it, and PR #23283 ADDED it to
+#      release/3.6 (+84/-0) rather than inheriting it. This workflow handles
+#      both: it repoints an inherited copy, and seeds a missing one from the
+#      branch currently publishing.
 #   2. The DOCS_DEPLOY_BRANCH repository variable, read by docs-deploy.yml's
 #      job gate and by docs-deploy-cron.yml.
 #
@@ -101,6 +106,15 @@ jobs:
             exit 1
           fi
 
+          # The backwards-move guard below compares series numerically, which is
+          # meaningless if the variable is not a release branch at all. Refuse
+          # rather than compare "main" against "3.6".
+          if ! echo "$DEPLOY_BRANCH" | grep -qE '^release/[0-9]+\.[0-9]+$'; then
+            echo "::error::DOCS_DEPLOY_BRANCH is '${DEPLOY_BRANCH}', which is not a release/N.N branch."
+            echo "This workflow only understands release-series branches. Fix the variable or disable this workflow."
+            exit 1
+          fi
+
           # Selection must agree with docs/site/src/releases.js, which drives the
           # {ERIGON_VERSION} the site renders. Two rules from there matter here:
           #   - the API orders by publish date, which is wrong the moment a
@@ -134,21 +148,27 @@ jobs:
           # abort the assignment, killing the step before the diagnostic prints.
 
           if [ -z "$newest" ]; then
-            echo "::error::No stable release found. Refusing to guess a target series."
+            echo "::error::No stable release in the cutover window (majors ${major_now}-$((major_now + 1)))."
+            echo "Either the newest series has only pre-releases, or DOCS_DEPLOY_BRANCH is ahead of every stable release."
+            echo "Refusing to guess a target series."
             exit 1
+          fi
+
+          # The bound advances one major at a time by design. When a stable
+          # release sits ABOVE that window, the bound is why it is being
+          # ignored — say so, rather than going quiet about a whole major.
+          higher="$(gh api 'repos/{owner}/{repo}/releases?per_page=100' \
+            --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' \
+            | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | sed 's/^v//' \
+            | awk -F. -v m="$major_now" '$1 > m + 1' | sort -t. -k1,1n | tail -n1 || true)"
+          if [ -n "$higher" ]; then
+            echo "::warning::Stable v${higher} is above the one-major cutover window from ${DEPLOY_BRANCH}."
+            echo "::warning::This run targets the next major only; re-run after that cutover lands to continue."
           fi
 
           target_series="$(echo "$newest" | cut -d. -f1-2)"
           target_branch="release/${target_series}"
 
-          # The backwards-move guard below compares series numerically, which is
-          # meaningless if the variable is not a release branch at all. Refuse
-          # rather than compare "main" against "3.6".
-          if ! echo "$DEPLOY_BRANCH" | grep -qE '^release/[0-9]+\.[0-9]+$'; then
-            echo "::error::DOCS_DEPLOY_BRANCH is '${DEPLOY_BRANCH}', which is not a release/N.N branch."
-            echo "This workflow only understands release-series branches. Fix the variable or disable this workflow."
-            exit 1
-          fi
           current_series="${DEPLOY_BRANCH#release/}"
 
           echo "newest stable release : v${newest}"
@@ -174,11 +194,22 @@ jobs:
               --jq '.content' 2>/dev/null | base64 -d || echo '')"
             if [ -z "$deploy_yml" ]; then
               echo "::warning::${target_branch} is the deploy branch but carries no docs-deploy.yml."
-            elif ! echo "$deploy_yml" | sed -n '/^on:/,/^permissions:/p' | grep -qE "^ *- *${target_branch}\$"; then
+            elif ! echo "$deploy_yml" | sed -n '/^on:/,/^permissions:/p' | grep -qE "^ *- *${target_branch//./\\.}\$"; then
               echo "::warning::${target_branch} is the deploy branch, but its docs-deploy.yml push trigger does not pin it."
               echo "::warning::Merges to ${target_branch} will not publish; only the 06:20 cron will. Repoint the trigger."
             else
-              echo "Docs deploy branch is current and its push trigger pins itself. Nothing to do."
+              # The trigger is right; the label can still be wrong if a hand-flip
+              # skipped the version bump, which publishes the site under the
+              # previous series' label.
+              cfg="$(gh api "repos/{owner}/{repo}/contents/docs/site/docusaurus.config.ts?ref=${target_branch}" \
+                --jq '.content' 2>/dev/null | base64 -d || echo '')"
+              lbl="$(echo "$cfg" | grep -A3 'const currentDocsVersion' \
+                | grep -oE "label: *'v[0-9]+\.[0-9]+'" | grep -oE "v[0-9]+\.[0-9]+" | head -n1 || true)"
+              if [ -n "$lbl" ] && [ "$lbl" != "v${target_series}" ]; then
+                echo "::warning::${target_branch} publishes under label ${lbl}, expected v${target_series} — the version bump never ran."
+              else
+                echo "Docs deploy branch is current, pins itself, and publishes as ${lbl:-unknown}. Nothing to do."
+              fi
             fi
             exit 0
           fi
@@ -244,6 +275,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           TARGET_BRANCH: ${{ needs.detect.outputs.target_branch }}
           TARGET_SERIES: ${{ needs.detect.outputs.target_series }}
+          CURRENT_BRANCH: ${{ needs.detect.outputs.current_branch }}
         run: |
           set -euo pipefail
 
@@ -287,12 +319,26 @@ jobs:
           # Condition B — does docs-deploy.yml on the target branch pin itself?
           deploy_yml="$(gh api "repos/{owner}/{repo}/contents/.github/workflows/docs-deploy.yml?ref=${TARGET_BRANCH}" \
             --jq '.content' 2>/dev/null | base64 -d || echo '')"
+          # A missing file is NOT an error. docs-deploy.yml lives only on the
+          # deploy branch — `main` has never carried it, and PR #23283 ADDED it
+          # to release/3.6 rather than inheriting it. So a release branch cut
+          # from `main` (create-release-branch.yml's default base) legitimately
+          # arrives without it, and the repoint step seeds it from the branch
+          # currently publishing.
           if [ -z "$deploy_yml" ]; then
-            echo "::error::${TARGET_BRANCH} carries no docs-deploy.yml. It cannot become the docs branch."
-            exit 1
+            echo "${TARGET_BRANCH} carries no docs-deploy.yml — it will be seeded from ${CURRENT_BRANCH}."
+            echo "seed=true" >> "$GITHUB_OUTPUT"
+            repointed=false
+            echo "repointed=false" >> "$GITHUB_OUTPUT"
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          echo "seed=false" >> "$GITHUB_OUTPUT"
           # Only the push-trigger block matters; workflow_dispatch ignores it.
-          if echo "$deploy_yml" | sed -n '/^on:/,/^permissions:/p' | grep -qE "^ *- *${TARGET_BRANCH}\$"; then
+          # Escape the dots: unescaped, release/3.6 as an ERE also matches a
+          # typo'd release/3x6 and would report the trigger as correctly pinned.
+          target_re="${TARGET_BRANCH//./\\.}"
+          if echo "$deploy_yml" | sed -n '/^on:/,/^permissions:/p' | grep -qE "^ *- *${target_re}\$"; then
             repointed=true
           else
             repointed=false
@@ -372,6 +418,7 @@ jobs:
           TARGET_BRANCH: ${{ needs.detect.outputs.target_branch }}
           CURRENT_BRANCH: ${{ needs.detect.outputs.current_branch }}
           RUN_ID: ${{ github.run_id }}
+          SEED: ${{ steps.state.outputs.seed }}
         run: |
           set -euo pipefail
 
@@ -400,6 +447,16 @@ jobs:
             "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$workdir"
           cd "$workdir"
 
+          # Seed the file when the branch never had one (cut from `main`).
+          # Taken from the branch currently publishing, so the copy is the one
+          # in production, then repointed below like any inherited copy.
+          if [ "${SEED}" = "true" ]; then
+            mkdir -p .github/workflows
+            gh api "repos/{owner}/{repo}/contents/.github/workflows/docs-deploy.yml?ref=${CURRENT_BRANCH}" \
+              --jq '.content' | base64 -d > .github/workflows/docs-deploy.yml
+            echo "Seeded docs-deploy.yml from ${CURRENT_BRANCH}."
+          fi
+
           # Rewrite the pinned branch inside the `on:` block only, so a match in a
           # comment or a job condition further down is left alone.
           #
@@ -416,12 +473,12 @@ jobs:
           head, sep, tail = src.partition('\npermissions:')
           if not sep:
               sys.exit('docs-deploy.yml has no permissions: block - refusing to edit blindly')
-          entries = re.findall(r'^\s*-\s*(release/[0-9]+\.[0-9]+)\s*$', head, flags=re.M)
+          entries = re.findall(r'^[ \t]*-[ \t]*(release/[0-9]+\.[0-9]+)[ \t]*$', head, flags=re.M)
           if len(entries) != 1:
               sys.exit(f'expected exactly one release/N.N push-trigger entry in the on: block, found {entries}')
           if entries[0] == new:
               sys.exit(f'{path} already pins {new} - nothing to repoint')
-          patched = re.sub(r'^(\s*-\s*)release/[0-9]+\.[0-9]+\s*$', rf'\g<1>{new}', head, flags=re.M)
+          patched = re.sub(r'^([ \t]*-[ \t]*)release/[0-9]+\.[0-9]+[ \t]*$', rf'\g<1>{new}', head, flags=re.M)
           open(path, 'w').write(patched + sep + tail)
           print(f'repointed {entries[0]} -> {new}')
           PY
@@ -566,7 +623,11 @@ jobs:
           # runner detail, and this guarantee must not depend on it. (An
           # environment-scoped variable of the same name would also shadow the
           # repository one in the context, but not here.)
-          DEPLOY_BRANCH="$(gh api "repos/{owner}/{repo}/actions/variables/DOCS_DEPLOY_BRANCH" --jq '.value')"
+          if ! DEPLOY_BRANCH="$(gh api "repos/{owner}/{repo}/actions/variables/DOCS_DEPLOY_BRANCH" --jq '.value')"; then
+            echo "::error::Could not read DOCS_DEPLOY_BRANCH through the API."
+            echo "Grant the release App the repository 'Variables: read and write' permission, or set the variable by hand."
+            exit 1
+          fi
 
           # Everything in `needs.*` was computed BEFORE the approval wait, which
           # can last up to the 30-day environment timeout. Approving a stale run
@@ -598,15 +659,6 @@ jobs:
             exit 1
           fi
 
-          if [ "$DEPLOY_BRANCH" = "$TARGET_BRANCH" ]; then
-            # Someone flipped it by hand while this waited. The variable alone
-            # does not publish anything, so the site can still be serving the
-            # old series; dispatch a deploy rather than declaring victory.
-            echo "::warning::DOCS_DEPLOY_BRANCH already reads ${TARGET_BRANCH} — flipped outside this run."
-            echo "already_done=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           # The two preparation steps must STILL be satisfied: a merged PR can be
           # reverted while this job waits for approval.
           config="$(gh api "repos/{owner}/{repo}/contents/docs/site/docusaurus.config.ts?ref=${TARGET_BRANCH}" \
@@ -620,9 +672,20 @@ jobs:
             echo "::error::${TARGET_BRANCH} docs label reads '${label:-unreadable}', expected v${TARGET_SERIES}. The version bump is no longer in place."
             exit 1
           fi
-          if ! echo "$deploy_yml" | sed -n '/^on:/,/^permissions:/p' | grep -qE "^ *- *${TARGET_BRANCH}\$"; then
+          if ! echo "$deploy_yml" | sed -n '/^on:/,/^permissions:/p' | grep -qE "^ *- *${TARGET_BRANCH//./\\.}\$"; then
             echo "::error::${TARGET_BRANCH} docs-deploy.yml no longer pins itself. The repoint is no longer in place."
             exit 1
+          fi
+
+          # Only now, with both prerequisites re-confirmed, is it safe to notice
+          # that someone flipped the variable by hand while this waited. Taking
+          # this exit any earlier would skip the checks above and then dispatch
+          # a deploy of a branch whose version bump may have been reverted.
+          if [ "$DEPLOY_BRANCH" = "$TARGET_BRANCH" ]; then
+            echo "::warning::DOCS_DEPLOY_BRANCH already reads ${TARGET_BRANCH} — flipped outside this run."
+            echo "The branch is versioned and repointed, so a deploy is dispatched below."
+            echo "already_done=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           echo "Re-validated: ${TARGET_BRANCH} is the newest stable series, versioned and repointed."

--- a/.github/workflows/docs-cutover.yml
+++ b/.github/workflows/docs-cutover.yml
@@ -1,6 +1,6 @@
 name: Docs - Release-series cutover
 
-run-name: "Docs cutover check${{ inputs.dry_run && ' (dry run)' || '' }}"
+run-name: "Docs cutover${{ inputs.dry_run && ' (dry run)' || '' }}"
 
 # Moves the published docs to a new release series when one goes stable.
 #
@@ -36,12 +36,15 @@ run-name: "Docs cutover check${{ inputs.dry_run && ' (dry run)' || '' }}"
 #
 # WHY THE SWITCH IS ENVIRONMENT-GATED
 # create-release-branch.yml puts privileged release-namespace operations behind
-# an environment with required reviewers, deliberately. Publishing a different
-# docs series is that kind of operation: the docs for a new series should go
-# live when they are ready, not the instant a tag appears. The gate keeps the
-# detection and preparation fully automatic while the last step stays a click.
-# To make the cutover zero-touch, delete the `environment:` line on the `switch`
-# job; nothing else depends on it.
+# the `release-branch-management` environment and its required reviewers,
+# deliberately. Publishing a different docs series is that kind of operation:
+# the docs for a new series should go live when they are ready, not the instant
+# a tag appears. The gate keeps detection and preparation fully automatic while
+# the last step stays a click. The `switch` job reuses that same environment —
+# naming a NEW one would be worse than no gate at all, because GitHub creates a
+# referenced-but-missing environment on demand with no protection rules, and the
+# run would go green having approved nothing. To make the cutover zero-touch,
+# delete the `environment:` line and the gate assertion on the `switch` job.
 
 on:
   schedule:
@@ -56,11 +59,12 @@ on:
         type: boolean
         default: true
 
-concurrency:
-  # One cutover in flight at a time. Never cancel: a half-applied cutover is
-  # the failure state this workflow exists to prevent.
-  group: docs-cutover
-  cancel-in-progress: false
+# NOTE: concurrency is deliberately NOT set at workflow level. A `switch` job
+# parked on environment approval would hold the group for up to the 30-day
+# approval timeout, and every later scheduled run would queue behind it — the
+# read-only detector would go silent for exactly as long as the cutover is
+# half-applied, which is the state this workflow exists to surface. The acting
+# jobs carry their own group instead.
 
 permissions:
   contents: read
@@ -109,7 +113,9 @@ jobs:
             | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' \
             | sed 's/^v//' \
             | sort -t. -k1,1n -k2,2n -k3,3n \
-            | tail -n1)"
+            | tail -n1 || true)"
+          # `|| true`: with no match `grep` exits 1 and pipefail would abort the
+          # assignment, killing the step before the diagnostic below can print.
 
           if [ -z "$newest" ]; then
             echo "::error::No stable release found. Refusing to guess a target series."
@@ -172,6 +178,9 @@ jobs:
     if: needs.detect.outputs.diverged == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    concurrency:
+      group: docs-cutover-prepare
+      cancel-in-progress: false
     outputs:
       ready: ${{ steps.state.outputs.ready }}
     permissions:
@@ -181,8 +190,15 @@ jobs:
         id: app_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  ## v3.2.0
         with:
-          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          # `client-id`, matching every other consumer of this App in the repo;
+          # `app-id` is the deprecated alias and warns on each run.
+          client-id: ${{ vars.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
+          # Least privilege, as in update-disk-sizes.yml: push a branch, open a
+          # PR, dispatch docs-version-bump.yml. Nothing else.
+          permission-contents: write
+          permission-pull-requests: write
+          permission-actions: write
 
       - name: Read the desired end state off the target branch
         id: state
@@ -217,7 +233,7 @@ jobs:
           current_label="$(echo "$config" \
             | grep -A3 'const currentDocsVersion' \
             | grep -oE "label: *'v[0-9]+\.[0-9]+'" \
-            | grep -oE "v[0-9]+\.[0-9]+" | head -n1)"
+            | grep -oE "v[0-9]+\.[0-9]+" | head -n1 || true)"
           if [ -z "$current_label" ]; then
             echo "::error::Could not read currentDocsVersion.label from docusaurus.config.ts on ${TARGET_BRANCH}."
             echo "The literal is rewritten at each cutover; if its shape changed, this workflow must be updated."
@@ -271,14 +287,38 @@ jobs:
           set -euo pipefail
 
           # docs-version-bump.yml names its branch docs/version-bump-<label>-<run id>,
-          # so an existing proposal can only be found by head prefix. Without this
-          # check every daily run would open another identical pull request.
-          existing="$(gh pr list --state open --base "$TARGET_BRANCH" \
+          # so an existing proposal can only be found by head prefix. --limit is
+          # explicit: the default page is 30, and release branches accumulate
+          # back-port PRs, which would push the match off the page and make this
+          # dispatch a duplicate every single day.
+          existing="$(gh pr list --state open --base "$TARGET_BRANCH" --limit 100 \
             --json number,headRefName \
             --jq "[.[] | select(.headRefName | startswith(\"docs/version-bump-v${TARGET_SERIES}-\"))] | .[0].number // empty")"
           if [ -n "$existing" ]; then
             echo "Version-bump PR #${existing} is already open against ${TARGET_BRANCH}. Waiting for it to merge."
             exit 0
+          fi
+
+          # A dispatched run takes minutes to build before it opens its PR. Without
+          # this, a re-run inside that window sees no PR and dispatches a second
+          # version bump, and both race to open competing PRs from the same base.
+          inflight="$(gh run list --workflow docs-version-bump.yml --branch "$TARGET_BRANCH" \
+            --limit 20 --json status,databaseId \
+            --jq '[.[] | select(.status == "in_progress" or .status == "queued" or .status == "requested" or .status == "waiting")] | length' || echo 0)"
+          if [ "$inflight" != "0" ]; then
+            echo "A docs-version-bump run is already in flight on ${TARGET_BRANCH}. Waiting for it."
+            exit 0
+          fi
+
+          # If the last attempt failed and left no PR, re-dispatching daily just
+          # produces a stream of identical failures. Stop and say why.
+          last="$(gh run list --workflow docs-version-bump.yml --branch "$TARGET_BRANCH" \
+            --limit 1 --json conclusion --jq '.[0].conclusion // empty' || true)"
+          if [ "$last" = "failure" ]; then
+            echo "::error::The last docs-version-bump run on ${TARGET_BRANCH} failed and opened no PR."
+            echo "Fix that run before the cutover can continue — re-dispatching it daily would only repeat the failure."
+            echo "A common cause: ${ARCHIVE_LABEL} is already present in versions.json from a partial manual archive."
+            exit 1
           fi
 
           echo "Dispatching docs-version-bump.yml on ${TARGET_BRANCH}: archive ${ARCHIVE_LABEL}, publish v${TARGET_SERIES}"
@@ -305,26 +345,48 @@ jobs:
             exit 0
           fi
 
+          # The remote branch can outlive its PR: closed-without-merging keeps it,
+          # and a push that lands before a failed `gh pr create` leaves it with no
+          # PR at all. A plain push would then be rejected non-fast-forward on
+          # every subsequent run, with only git's rejection text as a diagnostic.
+          # Re-point it at the current target tip instead, guarded by the SHA we
+          # actually observed so a concurrent writer is never clobbered.
+          remote_sha="$(git ls-remote "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "refs/heads/${head}" | cut -f1 || true)"
+          if [ -n "$remote_sha" ]; then
+            echo "::warning::Branch ${head} already exists (${remote_sha:0:10}) with no open PR — recreating it from the ${TARGET_BRANCH} tip."
+          fi
+
           workdir="${RUNNER_TEMP}/cutover-repo"
           rm -rf "$workdir"
           git clone --depth 1 --branch "$TARGET_BRANCH" \
             "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$workdir"
           cd "$workdir"
 
-          # Rewrite the branch name only inside the `on:` block, so a match in a
+          # Rewrite the pinned branch inside the `on:` block only, so a match in a
           # comment or a job condition further down is left alone.
-          python3 - "$CURRENT_BRANCH" "$TARGET_BRANCH" <<'PY'
+          #
+          # The entry is matched as "whatever release/N.N is pinned", NOT as the
+          # value of DOCS_DEPLOY_BRANCH. Those differ whenever a previous cutover
+          # stalled: the variable can still read release/3.5 while this branch
+          # already inherited release/3.6. Anchoring on the variable would make the
+          # detector and this rewrite disagree, and the step would fail daily.
+          python3 - "$TARGET_BRANCH" <<'PY'
           import re, sys
-          old, new = sys.argv[1], sys.argv[2]
+          new = sys.argv[1]
           path = '.github/workflows/docs-deploy.yml'
           src = open(path).read()
           head, sep, tail = src.partition('\npermissions:')
           if not sep:
               sys.exit('docs-deploy.yml has no permissions: block - refusing to edit blindly')
-          patched, n = re.subn(rf'^(\s*-\s*){re.escape(old)}\s*$', rf'\g<1>{new}', head, flags=re.M)
-          if n != 1:
-              sys.exit(f'expected exactly one push-trigger entry for {old} in the on: block, found {n}')
+          entries = re.findall(r'^\s*-\s*(release/[0-9]+\.[0-9]+)\s*$', head, flags=re.M)
+          if len(entries) != 1:
+              sys.exit(f'expected exactly one release/N.N push-trigger entry in the on: block, found {entries}')
+          if entries[0] == new:
+              sys.exit(f'{path} already pins {new} - nothing to repoint')
+          patched = re.sub(r'^(\s*-\s*)release/[0-9]+\.[0-9]+\s*$', rf'\g<1>{new}', head, flags=re.M)
           open(path, 'w').write(patched + sep + tail)
+          print(f'repointed {entries[0]} -> {new}')
           PY
 
           git config user.name "erigon-release-bot[bot]"
@@ -341,7 +403,13 @@ jobs:
           Opened automatically by the docs cutover workflow (run ${RUN_ID}).
           MSG
           git commit -F "${RUNNER_TEMP}/commit-msg.txt"
-          git push origin "HEAD:refs/heads/${head}"
+
+          if [ -n "$remote_sha" ]; then
+            git push --force-with-lease="refs/heads/${head}:${remote_sha}" \
+              origin "HEAD:refs/heads/${head}"
+          else
+            git push origin "HEAD:refs/heads/${head}"
+          fi
 
           # Quoted delimiter: the body is markdown full of backticks, which an
           # interpolating heredoc would run as command substitution. Placeholders
@@ -365,6 +433,8 @@ jobs:
           s=s.replace("__TARGET__",os.environ["TARGET_BRANCH"]).replace("__CURRENT__",os.environ["CURRENT_BRANCH"]).replace("__RUN__",os.environ["RUN_ID"]); \
           open(p,"w").write(s)' "${RUNNER_TEMP}/pr-body.md"
 
+          # Push succeeded, so the branch exists even if this fails; the guard
+          # above is what lets the next run recover instead of wedging.
           gh pr create \
             --base "$TARGET_BRANCH" \
             --head "$head" \
@@ -394,20 +464,117 @@ jobs:
     needs: [detect, prepare]
     if: needs.detect.outputs.diverged == 'true' && needs.prepare.outputs.ready == 'true' && !inputs.dry_run
     runs-on: ubuntu-latest
-    timeout-minutes: 5
-    # Approval gate, matching create-release-branch.yml: configure required
-    # reviewers on this environment in repo settings. Remove this line to make
-    # the cutover zero-touch.
-    environment: docs-deploy-cutover
+    timeout-minutes: 10
+    concurrency:
+      group: docs-cutover-switch
+      cancel-in-progress: false
+    # Approval gate. This reuses release-branch-management — the environment
+    # create-release-branch.yml already gates on, which carries a
+    # required_reviewers rule today — rather than naming a fresh environment.
+    # A referenced environment that does not exist is CREATED ON DEMAND with no
+    # protection rules at all, so an invented name would look like a gate while
+    # approving nothing. The pre-flight step below asserts the rule is really
+    # there, because that property lives in repo settings and can be removed
+    # without touching this file.
+    environment: release-branch-management
     steps:
       - name: Generate GitHub App token
         id: app_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  ## v3.2.0
         with:
-          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          client-id: ${{ vars.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
+          # Deliberately UNSCOPED, unlike every other consumer of this App.
+          # Writing a repository variable needs the App's `variables` permission,
+          # and this action version exposes no `permission-variables` input — so
+          # listing any permission-* here would mint a token that is *missing*
+          # the one permission this job exists to use. Revisit when the action
+          # gains that input.
+
+      - name: Assert the approval gate is real
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          rules="$(gh api "repos/{owner}/{repo}/environments/release-branch-management" \
+            --jq '[.protection_rules[]?.type] | join(",")' 2>/dev/null || echo "__unreadable__")"
+          if [ "$rules" = "__unreadable__" ]; then
+            echo "::warning::Could not read the environment's protection rules with this token; continuing."
+          elif ! echo "$rules" | grep -q 'required_reviewers'; then
+            echo "::error::Environment release-branch-management has no required_reviewers rule (rules: ${rules:-none})."
+            echo "This job would flip the published docs series with no human approval. Refusing."
+            exit 1
+          else
+            echo "Approval gate present (rules: ${rules})."
+          fi
+
+      - name: Re-validate before flipping
+        id: revalidate
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          DEPLOY_BRANCH: ${{ vars.DOCS_DEPLOY_BRANCH }}
+          TARGET_BRANCH: ${{ needs.detect.outputs.target_branch }}
+          TARGET_SERIES: ${{ needs.detect.outputs.target_series }}
+        run: |
+          set -euo pipefail
+
+          # Everything in `needs.*` was computed BEFORE the approval wait, which
+          # can last up to the 30-day environment timeout. Approving a stale run
+          # would publish a series that is no longer the newest, or re-apply a
+          # cutover somebody already did by hand. Re-read the world instead of
+          # trusting the snapshot.
+          #
+          # Selection duplicated from the `detect` job on purpose: the two must
+          # agree, and a shared step would need a composite action for three lines.
+          newest="$(gh api --paginate 'repos/{owner}/{repo}/releases?per_page=100' \
+            --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' \
+            | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' \
+            | sed 's/^v//' \
+            | sort -t. -k1,1n -k2,2n -k3,3n \
+            | tail -n1 || true)"
+          if [ -z "$newest" ]; then
+            echo "::error::No stable release visible at approval time. Refusing to flip."
+            exit 1
+          fi
+          newest_branch="release/$(echo "$newest" | cut -d. -f1-2)"
+
+          if [ "$newest_branch" != "$TARGET_BRANCH" ]; then
+            echo "::error::Newest stable series is now ${newest_branch}, but this run was prepared for ${TARGET_BRANCH}."
+            echo "Refusing to publish a superseded series. Re-run the workflow to prepare ${newest_branch}."
+            exit 1
+          fi
+
+          if [ "$DEPLOY_BRANCH" = "$TARGET_BRANCH" ]; then
+            echo "DOCS_DEPLOY_BRANCH already reads ${TARGET_BRANCH} — someone completed the cutover. Nothing to do."
+            echo "already_done=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # The two preparation steps must STILL be satisfied: a merged PR can be
+          # reverted while this job waits for approval.
+          config="$(gh api "repos/{owner}/{repo}/contents/docs/site/docusaurus.config.ts?ref=${TARGET_BRANCH}" \
+            --jq '.content' 2>/dev/null | base64 -d || echo '')"
+          label="$(echo "$config" | grep -A3 'const currentDocsVersion' \
+            | grep -oE "label: *'v[0-9]+\.[0-9]+'" | grep -oE "v[0-9]+\.[0-9]+" | head -n1 || true)"
+          deploy_yml="$(gh api "repos/{owner}/{repo}/contents/.github/workflows/docs-deploy.yml?ref=${TARGET_BRANCH}" \
+            --jq '.content' 2>/dev/null | base64 -d || echo '')"
+
+          if [ "$label" != "v${TARGET_SERIES}" ]; then
+            echo "::error::${TARGET_BRANCH} docs label reads '${label:-unreadable}', expected v${TARGET_SERIES}. The version bump is no longer in place."
+            exit 1
+          fi
+          if ! echo "$deploy_yml" | sed -n '/^on:/,/^permissions:/p' | grep -qE "^ *- *${TARGET_BRANCH}\$"; then
+            echo "::error::${TARGET_BRANCH} docs-deploy.yml no longer pins itself. The repoint is no longer in place."
+            exit 1
+          fi
+
+          echo "Re-validated: ${TARGET_BRANCH} is the newest stable series, versioned and repointed."
+          echo "already_done=false" >> "$GITHUB_OUTPUT"
 
       - name: Flip DOCS_DEPLOY_BRANCH
+        if: steps.revalidate.outputs.already_done == 'false'
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           GH_REPO: ${{ github.repository }}
@@ -434,18 +601,34 @@ jobs:
           fi
           echo "DOCS_DEPLOY_BRANCH: ${CURRENT_BRANCH} -> ${TARGET_BRANCH}"
 
-      - name: Publish the new series immediately
+      - name: Publish the new series
+        if: steps.revalidate.outputs.already_done == 'false'
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           GH_REPO: ${{ github.repository }}
           TARGET_BRANCH: ${{ needs.detect.outputs.target_branch }}
         run: |
           set -euo pipefail
-          # Without this the site would keep serving the old series until the
-          # 06:20 cron, up to 24h later.
-          gh workflow run docs-deploy.yml --ref "$TARGET_BRANCH"
+
+          # The variable is already flipped, so the site is going to change either
+          # way: this only decides whether it changes now or at the 06:20 cron.
+          # A dispatch failure must therefore NOT fail the job and imply the
+          # cutover did not happen — it did.
+          if gh workflow run docs-deploy.yml --ref "$TARGET_BRANCH"; then
+            dispatched="dispatched"
+          else
+            dispatched="NOT dispatched"
+            echo "::warning::Variable flipped, but dispatching docs-deploy.yml failed (the App may lack actions:write)."
+            echo "::warning::The 06:20 UTC docs-deploy-cron will publish ${TARGET_BRANCH} within 24h."
+          fi
+
+          # Deliberately not claiming the site is live: accepting a dispatch is
+          # not a successful build, and a Pages failure would make that a lie.
           {
-            echo "### Docs cutover complete"
+            echo "### Docs cutover applied"
             echo ""
-            echo "\`DOCS_DEPLOY_BRANCH\` now reads \`${TARGET_BRANCH}\`, and a deploy has been dispatched."
+            echo "\`DOCS_DEPLOY_BRANCH\` now reads \`${TARGET_BRANCH}\`. Deploy ${dispatched}."
+            echo ""
+            echo "The site serves the new series once that deploy run succeeds — check the"
+            echo "\`Deploy Docs\` workflow on \`${TARGET_BRANCH}\`, not this run."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docs-cutover.yml
+++ b/.github/workflows/docs-cutover.yml
@@ -190,11 +190,25 @@ jobs:
             # 06:20 cron does — quietly, for as long as nobody notices. The
             # state machine below never looks at the branch in this case, so
             # check it here.
+          # Extract the branches of the PUSH trigger only. The `on:` block can
+          # carry other triggers with their own branch filters, and a match in
+          # one of those is not a deploy trigger: a file whose push list still
+          # names the old branch would read as pinned, the variable would flip,
+          # and merges would never publish. Comparing with `grep -Fx` against
+          # this list also removes every regex-escaping question.
+          cat > "${RUNNER_TEMP}/push-branches.awk" <<'AWKEOF'
+          /^[[:blank:]]*push:[[:blank:]]*$/ { p=1; pind=match($0,/[^ \t]/); next }
+          p && /^[[:blank:]]*[^ \t#-]/ { if (match($0,/[^ \t]/) <= pind) { p=0; b=0 } }
+          p && /^[[:blank:]]*branches:[[:blank:]]*$/ { b=1; next }
+          p && b && /^[[:blank:]]*-/ { gsub(/^[[:blank:]]*-[[:blank:]]*/,""); gsub(/['"'"'"]/,""); gsub(/[[:blank:]]*$/,""); print; next }
+          p && b && /^[[:blank:]]*[^ \t-]/ { b=0 }
+          AWKEOF
             deploy_yml="$(gh api "repos/{owner}/{repo}/contents/.github/workflows/docs-deploy.yml?ref=${target_branch}" \
               --jq '.content' 2>/dev/null | base64 -d || echo '')"
             if [ -z "$deploy_yml" ]; then
               echo "::warning::${target_branch} is the deploy branch but carries no docs-deploy.yml."
-            elif ! echo "$deploy_yml" | sed -n '/^on:/,/^permissions:/p' | grep -qE "^[[:blank:]]*-[[:blank:]]*${target_branch//./\\.}[[:blank:]]*\$"; then
+            elif ! printf '%s' "$deploy_yml" | awk -f "${RUNNER_TEMP}/push-branches.awk" \
+                   | grep -Fxq "$target_branch"; then
               echo "::warning::${target_branch} is the deploy branch, but its docs-deploy.yml push trigger does not pin it."
               echo "::warning::Merges to ${target_branch} will not publish; only the 06:20 cron will. Repoint the trigger."
             else
@@ -318,65 +332,73 @@ jobs:
           fi
           echo "archive_label=${current_label}" >> "$GITHUB_OUTPUT"
 
-          # Before any version bump is dispatched, prove the target branch holds
-          # the PUBLISHED docs tree. Presence of docs-deploy.yml is not the test:
-          # PR #23283 added that file to release/3.6 by hand, so a human can
-          # cherry-pick it onto a branch cut from `main` and the tree is still
-          # main's. main carries versions.json ["v3.4","v3.3"] where release/3.6
-          # has ["v3.5","v3.4","v3.3"], and main's label already reads v3.6 — so
-          # a bump there archives the wrong content under the right name and
-          # drops a version from the published dropdown, silently. Run this
-          # whenever a bump is pending, not only when the workflow file is absent.
-          if [ "$archived" = false ]; then
-            tgt_versions="$(gh api "repos/{owner}/{repo}/contents/docs/site/versions.json?ref=${TARGET_BRANCH}" \
-              --jq '.content' 2>/dev/null | base64 -d | tr -d ' \n' || echo '')"
-            cur_versions="$(gh api "repos/{owner}/{repo}/contents/docs/site/versions.json?ref=${CURRENT_BRANCH}" \
-              --jq '.content' 2>/dev/null | base64 -d | tr -d ' \n' || echo '')"
-            cur_config="$(gh api "repos/{owner}/{repo}/contents/docs/site/docusaurus.config.ts?ref=${CURRENT_BRANCH}" \
-              --jq '.content' 2>/dev/null | base64 -d || echo '')"
-            cur_label="$(echo "$cur_config" | grep -A3 'const currentDocsVersion' \
-              | grep -oE "label: *'v[0-9]+\.[0-9]+'" | grep -oE "v[0-9]+\.[0-9]+" | head -n1 || true)"
+          # What this proves, precisely: publishing the target branch loses no
+          # docs version — every version archived on the branch currently
+          # publishing is archived on the target too, and that branch's LIVE
+          # series either is the target's current label (so the bump will
+          # archive it) or is already archived there.
+          #
+          # What it does NOT prove: that the branch was cut from the right
+          # place. The archived `versioned_docs` trees are byte-identical across
+          # main, release/3.5 and release/3.6, and the live docs tree differs on
+          # all three, so no cheap structural test separates "cut from main"
+          # from "cut from the previous release and edited since". This is a
+          # loss detector, not a provenance detector.
+          #
+          # It runs UNCONDITIONALLY. Gating it on "a bump is pending" skipped it
+          # in the worst case: main today carries label v3.6 with versions.json
+          # ["v3.4","v3.3"], so a branch cut from main reads as already
+          # versioned, and the check that would notice v3.5 vanishing is exactly
+          # the code the gate skipped.
+          # (unconditional — see above)
+          tgt_versions="$(gh api "repos/{owner}/{repo}/contents/docs/site/versions.json?ref=${TARGET_BRANCH}" \
+            --jq '.content' 2>/dev/null | base64 -d | tr -d ' \n' || echo '')"
+          cur_versions="$(gh api "repos/{owner}/{repo}/contents/docs/site/versions.json?ref=${CURRENT_BRANCH}" \
+            --jq '.content' 2>/dev/null | base64 -d | tr -d ' \n' || echo '')"
+          cur_config="$(gh api "repos/{owner}/{repo}/contents/docs/site/docusaurus.config.ts?ref=${CURRENT_BRANCH}" \
+            --jq '.content' 2>/dev/null | base64 -d || echo '')"
+          cur_label="$(echo "$cur_config" | grep -A3 'const currentDocsVersion' \
+            | grep -oE "label: *'v[0-9]+\.[0-9]+'" | grep -oE "v[0-9]+\.[0-9]+" | head -n1 || true)"
 
-            # Fail CLOSED. An unreadable inventory is indistinguishable from an
-            # empty one, and an empty one makes every comparison below pass —
-            # admitting exactly the branch this refuses.
-            if [ -z "$tgt_versions" ] || [ -z "$cur_versions" ] || [ -z "$cur_label" ]; then
-              echo "::error::Could not read the docs inventory needed to validate ${TARGET_BRANCH}:"
-              [ -z "$tgt_versions" ] && echo "  - versions.json on ${TARGET_BRANCH}"
-              [ -z "$cur_versions" ] && echo "  - versions.json on ${CURRENT_BRANCH}"
-              [ -z "$cur_label" ] && echo "  - currentDocsVersion.label on ${CURRENT_BRANCH}"
-              echo "Refusing to dispatch a version bump without confirming the branch holds the published docs."
-              exit 1
-            fi
-
-            missing=""
-            for v in $(echo "$cur_versions" | tr -d '[]"' | tr ',' ' '); do
-              case "$tgt_versions" in
-                *"\"${v}\""*) ;;
-                *) missing="${missing} ${v}" ;;
-              esac
-            done
-            # The LIVE series on the publishing branch must survive too: either
-            # it is still the target's current label (the bump will archive it)
-            # or it is already archived there. Archived-superset alone misses
-            # this — after a skipped cutover both inventories can match while the
-            # live label is archived nowhere and simply disappears.
-            if [ "$cur_label" != "$current_label" ]; then
-              case "$tgt_versions" in
-                *"\"${cur_label}\""*) ;;
-                *) missing="${missing} ${cur_label}(live)" ;;
-              esac
-            fi
-
-            if [ -n "$missing" ]; then
-              echo "::error::${TARGET_BRANCH} does not carry the published docs versions present on ${CURRENT_BRANCH}:${missing}"
-              echo "Its docs tree is not the published one — most likely it was cut from 'main' rather than from ${CURRENT_BRANCH}."
-              echo "Versioning it would archive the wrong content and drop those versions from the site."
-              echo "Re-cut ${TARGET_BRANCH} from ${CURRENT_BRANCH}, or port docs/site across, then re-run."
-              exit 1
-            fi
-            echo "Docs tree on ${TARGET_BRANCH} preserves ${CURRENT_BRANCH}'s versions (live ${cur_label})."
+          # Fail CLOSED. An unreadable inventory is indistinguishable from an
+          # empty one, and an empty one makes every comparison below pass —
+          # admitting exactly the branch this refuses.
+          if [ -z "$tgt_versions" ] || [ -z "$cur_versions" ] || [ -z "$cur_label" ]; then
+            echo "::error::Could not read the docs inventory needed to validate ${TARGET_BRANCH}:"
+            [ -z "$tgt_versions" ] && echo "  - versions.json on ${TARGET_BRANCH}"
+            [ -z "$cur_versions" ] && echo "  - versions.json on ${CURRENT_BRANCH}"
+            [ -z "$cur_label" ] && echo "  - currentDocsVersion.label on ${CURRENT_BRANCH}"
+            echo "Refusing to dispatch a version bump without confirming the branch holds the published docs."
+            exit 1
           fi
+
+          missing=""
+          for v in $(echo "$cur_versions" | tr -d '[]"' | tr ',' ' '); do
+            case "$tgt_versions" in
+              *"\"${v}\""*) ;;
+              *) missing="${missing} ${v}" ;;
+            esac
+          done
+          # The LIVE series on the publishing branch must survive too: either
+          # it is still the target's current label (the bump will archive it)
+          # or it is already archived there. Archived-superset alone misses
+          # this — after a skipped cutover both inventories can match while the
+          # live label is archived nowhere and simply disappears.
+          if [ "$cur_label" != "$current_label" ]; then
+            case "$tgt_versions" in
+              *"\"${cur_label}\""*) ;;
+              *) missing="${missing} ${cur_label}(live)" ;;
+            esac
+          fi
+
+          if [ -n "$missing" ]; then
+            echo "::error::${TARGET_BRANCH} does not carry the published docs versions present on ${CURRENT_BRANCH}:${missing}"
+            echo "Its docs tree is not the published one — most likely it was cut from 'main' rather than from ${CURRENT_BRANCH}."
+            echo "Versioning it would archive the wrong content and drop those versions from the site."
+            echo "Re-cut ${TARGET_BRANCH} from ${CURRENT_BRANCH}, or port docs/site across, then re-run."
+            exit 1
+          fi
+          echo "Docs tree on ${TARGET_BRANCH} preserves ${CURRENT_BRANCH}'s versions (live ${cur_label})."
 
           # Condition B — does docs-deploy.yml on the target branch pin itself?
           deploy_yml="$(gh api "repos/{owner}/{repo}/contents/.github/workflows/docs-deploy.yml?ref=${TARGET_BRANCH}" \
@@ -402,10 +424,21 @@ jobs:
           fi
           echo "seed=false" >> "$GITHUB_OUTPUT"
           # Only the push-trigger block matters; workflow_dispatch ignores it.
-          # Escape the dots: unescaped, release/3.6 as an ERE also matches a
-          # typo'd release/3x6 and would report the trigger as correctly pinned.
-          target_re="${TARGET_BRANCH//./\\.}"
-          if echo "$deploy_yml" | sed -n '/^on:/,/^permissions:/p' | grep -qE "^[[:blank:]]*-[[:blank:]]*${target_re}[[:blank:]]*\$"; then
+          # Extract the branches of the PUSH trigger only. The `on:` block can
+          # carry other triggers with their own branch filters, and a match in
+          # one of those is not a deploy trigger: a file whose push list still
+          # names the old branch would read as pinned, the variable would flip,
+          # and merges would never publish. Comparing with `grep -Fx` against
+          # this list also removes every regex-escaping question.
+          cat > "${RUNNER_TEMP}/push-branches.awk" <<'AWKEOF'
+          /^[[:blank:]]*push:[[:blank:]]*$/ { p=1; pind=match($0,/[^ \t]/); next }
+          p && /^[[:blank:]]*[^ \t#-]/ { if (match($0,/[^ \t]/) <= pind) { p=0; b=0 } }
+          p && /^[[:blank:]]*branches:[[:blank:]]*$/ { b=1; next }
+          p && b && /^[[:blank:]]*-/ { gsub(/^[[:blank:]]*-[[:blank:]]*/,""); gsub(/['"'"'"]/,""); gsub(/[[:blank:]]*$/,""); print; next }
+          p && b && /^[[:blank:]]*[^ \t-]/ { b=0 }
+          AWKEOF
+          if printf '%s' "$deploy_yml" | awk -f "${RUNNER_TEMP}/push-branches.awk" \
+               | grep -Fxq "$TARGET_BRANCH"; then
             repointed=true
           else
             repointed=false
@@ -537,16 +570,46 @@ jobs:
           new = sys.argv[1]
           path = '.github/workflows/docs-deploy.yml'
           src = open(path).read()
-          head, sep, tail = src.partition('\npermissions:')
-          if not sep:
-              sys.exit('docs-deploy.yml has no permissions: block - refusing to edit blindly')
-          entries = re.findall(r'^[ \t]*-[ \t]*(release/[0-9]+\.[0-9]+)[ \t]*$', head, flags=re.M)
+
+          # Scope to the PUSH trigger's branch list, matching the shell check.
+          # The `on:` block may hold other triggers with their own branch
+          # filters; rewriting one of those would leave the deploy trigger
+          # pointing at the old branch while everything reported success.
+          m = re.search(r'^(?P<i>[ \t]+)push:[ \t]*$', src, re.M)
+          if not m:
+              sys.exit('docs-deploy.yml has no push: trigger - refusing to edit blindly')
+          pind = len(m.group('i'))
+          rest = src[m.end():]
+          end = len(rest)
+          for line in re.finditer(r'^(?P<i>[ \t]*)\S.*$', rest, re.M):
+              if len(line.group('i')) <= pind:
+                  end = line.start()
+                  break
+          push_block = rest[:end]
+
+          bm = re.search(r'^(?P<i>[ \t]+)branches:[ \t]*$', push_block, re.M)
+          if not bm:
+              sys.exit('the push: trigger has no branches: list - refusing to edit blindly')
+          bind = len(bm.group('i'))
+          tail_of_block = push_block[bm.end():]
+          bend = len(tail_of_block)
+          for line in re.finditer(r'^(?P<i>[ \t]*)\S.*$', tail_of_block, re.M):
+              if len(line.group('i')) <= bind:
+                  bend = line.start()
+                  break
+          branches = tail_of_block[:bend]
+
+          entries = re.findall(r"^[ \t]*-[ \t]*['\"]?(\S+?)['\"]?[ \t]*$", branches, re.M)
           if len(entries) != 1:
-              sys.exit(f'expected exactly one release/N.N push-trigger entry in the on: block, found {entries}')
+              sys.exit(f'expected exactly one push branch entry, found {entries}')
           if entries[0] == new:
               sys.exit(f'{path} already pins {new} - nothing to repoint')
-          patched = re.sub(r'^([ \t]*-[ \t]*)release/[0-9]+\.[0-9]+[ \t]*$', rf'\g<1>{new}', head, flags=re.M)
-          open(path, 'w').write(patched + sep + tail)
+
+          patched_branches = re.sub(r"^([ \t]*-[ \t]*)['\"]?\S+?['\"]?([ \t]*)$",
+                                    rf'\g<1>{new}\g<2>', branches, flags=re.M)
+          out = (src[:m.end()] + push_block[:bm.end()] + patched_branches
+                 + tail_of_block[bend:] + rest[end:])
+          open(path, 'w').write(out)
           print(f'repointed {entries[0]} -> {new}')
           PY
 
@@ -761,7 +824,21 @@ jobs:
             echo "::error::${TARGET_BRANCH} docs label reads '${label:-unreadable}', expected v${TARGET_SERIES}. The version bump is no longer in place."
             exit 1
           fi
-          if ! echo "$deploy_yml" | sed -n '/^on:/,/^permissions:/p' | grep -qE "^[[:blank:]]*-[[:blank:]]*${TARGET_BRANCH//./\\.}[[:blank:]]*\$"; then
+          # Extract the branches of the PUSH trigger only. The `on:` block can
+          # carry other triggers with their own branch filters, and a match in
+          # one of those is not a deploy trigger: a file whose push list still
+          # names the old branch would read as pinned, the variable would flip,
+          # and merges would never publish. Comparing with `grep -Fx` against
+          # this list also removes every regex-escaping question.
+          cat > "${RUNNER_TEMP}/push-branches.awk" <<'AWKEOF'
+          /^[[:blank:]]*push:[[:blank:]]*$/ { p=1; pind=match($0,/[^ \t]/); next }
+          p && /^[[:blank:]]*[^ \t#-]/ { if (match($0,/[^ \t]/) <= pind) { p=0; b=0 } }
+          p && /^[[:blank:]]*branches:[[:blank:]]*$/ { b=1; next }
+          p && b && /^[[:blank:]]*-/ { gsub(/^[[:blank:]]*-[[:blank:]]*/,""); gsub(/['"'"'"]/,""); gsub(/[[:blank:]]*$/,""); print; next }
+          p && b && /^[[:blank:]]*[^ \t-]/ { b=0 }
+          AWKEOF
+          if ! printf '%s' "$deploy_yml" | awk -f "${RUNNER_TEMP}/push-branches.awk" \
+               | grep -Fxq "$TARGET_BRANCH"; then
             echo "::error::${TARGET_BRANCH} docs-deploy.yml no longer pins itself. The repoint is no longer in place."
             exit 1
           fi

--- a/.github/workflows/docs-cutover.yml
+++ b/.github/workflows/docs-cutover.yml
@@ -108,14 +108,30 @@ jobs:
           #     sort by semantic version;
           #   - tag SHAPE decides pre-release, because releases do not reliably
           #     set the API's `prerelease` flag; any hyphen disqualifies a tag.
-          newest="$(gh api --paginate 'repos/{owner}/{repo}/releases?per_page=100' \
+          # NOT --paginate, and majors are bounded. Both matter:
+          #
+          # Erigon shipped CALENDAR-versioned releases in 2022 (v2022.07.02 ...
+          # v2022.10.01). They are real releases, not drafts, not pre-releases,
+          # and they match the semver shape — so a paginated numeric sort picks
+          # 2022.10.01 as "newest" (2022 > 3) and this workflow would chase
+          # release/2022.10 forever. Verified against the live release list.
+          #
+          # The API returns releases newest-first by publish date, so the first
+          # page is the recent window the docs site itself looks at
+          # (docs/site/src/releases.js reads one page too). The major bound is
+          # the belt to that braces: a docs cutover advances at most one major,
+          # so anything outside [current, current+1] is not a candidate however
+          # it got tagged.
+          major_now="$(echo "$DEPLOY_BRANCH" | sed 's|release/||' | cut -d. -f1)"
+          newest="$(gh api 'repos/{owner}/{repo}/releases?per_page=100' \
             --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' \
             | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' \
             | sed 's/^v//' \
+            | awk -F. -v m="$major_now" '$1 >= m && $1 <= m + 1' \
             | sort -t. -k1,1n -k2,2n -k3,3n \
             | tail -n1 || true)"
-          # `|| true`: with no match `grep` exits 1 and pipefail would abort the
-          # assignment, killing the step before the diagnostic below can print.
+          # `|| true`: with no match `grep`/`awk` exit non-zero and pipefail would
+          # abort the assignment, killing the step before the diagnostic prints.
 
           if [ -z "$newest" ]; then
             echo "::error::No stable release found. Refusing to guess a target series."
@@ -147,7 +163,23 @@ jobs:
 
           if [ "$DEPLOY_BRANCH" = "$target_branch" ]; then
             echo "diverged=false" >> "$GITHUB_OUTPUT"
-            echo "Docs deploy branch is current. Nothing to do."
+
+            # "Variable is current" is not the same as "the cutover finished".
+            # If someone flipped the variable by hand without repointing the
+            # push trigger, merges to this branch never publish and only the
+            # 06:20 cron does — quietly, for as long as nobody notices. The
+            # state machine below never looks at the branch in this case, so
+            # check it here.
+            deploy_yml="$(gh api "repos/{owner}/{repo}/contents/.github/workflows/docs-deploy.yml?ref=${target_branch}" \
+              --jq '.content' 2>/dev/null | base64 -d || echo '')"
+            if [ -z "$deploy_yml" ]; then
+              echo "::warning::${target_branch} is the deploy branch but carries no docs-deploy.yml."
+            elif ! echo "$deploy_yml" | sed -n '/^on:/,/^permissions:/p' | grep -qE "^ *- *${target_branch}\$"; then
+              echo "::warning::${target_branch} is the deploy branch, but its docs-deploy.yml push trigger does not pin it."
+              echo "::warning::Merges to ${target_branch} will not publish; only the 06:20 cron will. Repoint the trigger."
+            else
+              echo "Docs deploy branch is current and its push trigger pins itself. Nothing to do."
+            fi
             exit 0
           fi
 
@@ -199,6 +231,11 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
           permission-actions: write
+          # The repoint commit modifies .github/workflows/docs-deploy.yml, and
+          # GitHub rejects a workflow-file push from an App token without this
+          # (release.yml requests it for the same reason). Scoping the token
+          # without it would break the push that scoping was applied to.
+          permission-workflows: write
 
       - name: Read the desired end state off the target branch
         id: state
@@ -304,7 +341,7 @@ jobs:
           # version bump, and both race to open competing PRs from the same base.
           inflight="$(gh run list --workflow docs-version-bump.yml --branch "$TARGET_BRANCH" \
             --limit 20 --json status,databaseId \
-            --jq '[.[] | select(.status == "in_progress" or .status == "queued" or .status == "requested" or .status == "waiting")] | length' || echo 0)"
+            --jq '[.[] | select(.status == "in_progress" or .status == "queued" or .status == "requested" or .status == "waiting" or .status == "pending")] | length' || echo 0)"
           if [ "$inflight" != "0" ]; then
             echo "A docs-version-bump run is already in flight on ${TARGET_BRANCH}. Waiting for it."
             exit 0
@@ -500,7 +537,12 @@ jobs:
           rules="$(gh api "repos/{owner}/{repo}/environments/release-branch-management" \
             --jq '[.protection_rules[]?.type] | join(",")' 2>/dev/null || echo "__unreadable__")"
           if [ "$rules" = "__unreadable__" ]; then
-            echo "::warning::Could not read the environment's protection rules with this token; continuing."
+            # Fail CLOSED. The unreadable case and the unprotected case look the
+            # same from here, and proceeding would flip the published docs with
+            # no approval in exactly the misconfiguration this asserts against.
+            echo "::error::Could not read protection rules for release-branch-management."
+            echo "Refusing to flip the published docs series without confirming the approval gate."
+            exit 1
           elif ! echo "$rules" | grep -q 'required_reviewers'; then
             echo "::error::Environment release-branch-management has no required_reviewers rule (rules: ${rules:-none})."
             echo "This job would flip the published docs series with no human approval. Refusing."
@@ -514,11 +556,17 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           GH_REPO: ${{ github.repository }}
-          DEPLOY_BRANCH: ${{ vars.DOCS_DEPLOY_BRANCH }}
           TARGET_BRANCH: ${{ needs.detect.outputs.target_branch }}
           TARGET_SERIES: ${{ needs.detect.outputs.target_series }}
         run: |
           set -euo pipefail
+
+          # Read the variable from the API, not from the `vars` context: whether
+          # that context is materialised before or after the approval wait is a
+          # runner detail, and this guarantee must not depend on it. (An
+          # environment-scoped variable of the same name would also shadow the
+          # repository one in the context, but not here.)
+          DEPLOY_BRANCH="$(gh api "repos/{owner}/{repo}/actions/variables/DOCS_DEPLOY_BRANCH" --jq '.value')"
 
           # Everything in `needs.*` was computed BEFORE the approval wait, which
           # can last up to the 30-day environment timeout. Approving a stale run
@@ -528,10 +576,14 @@ jobs:
           #
           # Selection duplicated from the `detect` job on purpose: the two must
           # agree, and a shared step would need a composite action for three lines.
-          newest="$(gh api --paginate 'repos/{owner}/{repo}/releases?per_page=100' \
+          # Same bounded selection as `detect` — see the comment there for why
+          # --paginate and an unbounded major are both wrong.
+          major_now="$(echo "$DEPLOY_BRANCH" | sed 's|release/||' | cut -d. -f1)"
+          newest="$(gh api 'repos/{owner}/{repo}/releases?per_page=100' \
             --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' \
             | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' \
             | sed 's/^v//' \
+            | awk -F. -v m="$major_now" '$1 >= m && $1 <= m + 1' \
             | sort -t. -k1,1n -k2,2n -k3,3n \
             | tail -n1 || true)"
           if [ -z "$newest" ]; then
@@ -547,7 +599,10 @@ jobs:
           fi
 
           if [ "$DEPLOY_BRANCH" = "$TARGET_BRANCH" ]; then
-            echo "DOCS_DEPLOY_BRANCH already reads ${TARGET_BRANCH} — someone completed the cutover. Nothing to do."
+            # Someone flipped it by hand while this waited. The variable alone
+            # does not publish anything, so the site can still be serving the
+            # old series; dispatch a deploy rather than declaring victory.
+            echo "::warning::DOCS_DEPLOY_BRANCH already reads ${TARGET_BRANCH} — flipped outside this run."
             echo "already_done=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -602,7 +657,10 @@ jobs:
           echo "DOCS_DEPLOY_BRANCH: ${CURRENT_BRANCH} -> ${TARGET_BRANCH}"
 
       - name: Publish the new series
-        if: steps.revalidate.outputs.already_done == 'false'
+        # Runs on the already-flipped path too: a variable set by hand publishes
+        # nothing on its own, so skipping this would leave the site on the old
+        # series until the 06:20 cron while this run reported success.
+        if: steps.revalidate.outputs.already_done != ''
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/docs-cutover.yml
+++ b/.github/workflows/docs-cutover.yml
@@ -89,6 +89,13 @@ jobs:
       target_branch: ${{ steps.compare.outputs.target_branch }}
       target_series: ${{ steps.compare.outputs.target_series }}
     steps:
+      - name: Check out the trigger parser
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          sparse-checkout: .github/workflows/scripts
+
       - name: Resolve the newest stable series and compare with the deploy variable
         id: compare
         env:
@@ -190,25 +197,19 @@ jobs:
             # 06:20 cron does — quietly, for as long as nobody notices. The
             # state machine below never looks at the branch in this case, so
             # check it here.
-          # Extract the branches of the PUSH trigger only. The `on:` block can
-          # carry other triggers with their own branch filters, and a match in
-          # one of those is not a deploy trigger: a file whose push list still
-          # names the old branch would read as pinned, the variable would flip,
-          # and merges would never publish. Comparing with `grep -Fx` against
-          # this list also removes every regex-escaping question.
-          cat > "${RUNNER_TEMP}/push-branches.awk" <<'AWKEOF'
-          /^[[:blank:]]*push:[[:blank:]]*$/ { p=1; pind=match($0,/[^ \t]/); next }
-          p && /^[[:blank:]]*[^ \t#-]/ { if (match($0,/[^ \t]/) <= pind) { p=0; b=0 } }
-          p && /^[[:blank:]]*branches:[[:blank:]]*$/ { b=1; next }
-          p && b && /^[[:blank:]]*-/ { gsub(/^[[:blank:]]*-[[:blank:]]*/,""); gsub(/['"'"'"]/,""); gsub(/[[:blank:]]*$/,""); print; next }
-          p && b && /^[[:blank:]]*[^ \t-]/ { b=0 }
-          AWKEOF
             deploy_yml="$(gh api "repos/{owner}/{repo}/contents/.github/workflows/docs-deploy.yml?ref=${target_branch}" \
               --jq '.content' 2>/dev/null | base64 -d || echo '')"
+            printf '%s' "$deploy_yml" > "${RUNNER_TEMP}/deploy.yml"
+            pinned=no
+            if DEPLOY_YML="${RUNNER_TEMP}/deploy.yml" \
+               python3 "${GITHUB_WORKSPACE}/.github/workflows/scripts/docs-deploy-trigger.py" --list \
+               | grep -Fxq "$target_branch"; then
+              pinned=yes
+            fi
+
             if [ -z "$deploy_yml" ]; then
               echo "::warning::${target_branch} is the deploy branch but carries no docs-deploy.yml."
-            elif ! printf '%s' "$deploy_yml" | awk -f "${RUNNER_TEMP}/push-branches.awk" \
-                   | grep -Fxq "$target_branch"; then
+            elif [ "$pinned" = no ]; then
               echo "::warning::${target_branch} is the deploy branch, but its docs-deploy.yml push trigger does not pin it."
               echo "::warning::Merges to ${target_branch} will not publish; only the 06:20 cron will. Repoint the trigger."
             else
@@ -265,6 +266,13 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Check out the trigger parser
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          sparse-checkout: .github/workflows/scripts
+
       - name: Generate GitHub App token
         id: app_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  ## v3.2.0
@@ -424,21 +432,10 @@ jobs:
           fi
           echo "seed=false" >> "$GITHUB_OUTPUT"
           # Only the push-trigger block matters; workflow_dispatch ignores it.
-          # Extract the branches of the PUSH trigger only. The `on:` block can
-          # carry other triggers with their own branch filters, and a match in
-          # one of those is not a deploy trigger: a file whose push list still
-          # names the old branch would read as pinned, the variable would flip,
-          # and merges would never publish. Comparing with `grep -Fx` against
-          # this list also removes every regex-escaping question.
-          cat > "${RUNNER_TEMP}/push-branches.awk" <<'AWKEOF'
-          /^[[:blank:]]*push:[[:blank:]]*$/ { p=1; pind=match($0,/[^ \t]/); next }
-          p && /^[[:blank:]]*[^ \t#-]/ { if (match($0,/[^ \t]/) <= pind) { p=0; b=0 } }
-          p && /^[[:blank:]]*branches:[[:blank:]]*$/ { b=1; next }
-          p && b && /^[[:blank:]]*-/ { gsub(/^[[:blank:]]*-[[:blank:]]*/,""); gsub(/['"'"'"]/,""); gsub(/[[:blank:]]*$/,""); print; next }
-          p && b && /^[[:blank:]]*[^ \t-]/ { b=0 }
-          AWKEOF
-          if printf '%s' "$deploy_yml" | awk -f "${RUNNER_TEMP}/push-branches.awk" \
-               | grep -Fxq "$TARGET_BRANCH"; then
+          printf '%s' "$deploy_yml" > "${RUNNER_TEMP}/deploy.yml"
+          if DEPLOY_YML="${RUNNER_TEMP}/deploy.yml" \
+             python3 "${GITHUB_WORKSPACE}/.github/workflows/scripts/docs-deploy-trigger.py" --list \
+             | grep -Fxq "$TARGET_BRANCH"; then
             repointed=true
           else
             repointed=false
@@ -557,61 +554,15 @@ jobs:
             echo "Seeded docs-deploy.yml from ${CURRENT_BRANCH}."
           fi
 
-          # Rewrite the pinned branch inside the `on:` block only, so a match in a
-          # comment or a job condition further down is left alone.
-          #
-          # The entry is matched as "whatever release/N.N is pinned", NOT as the
-          # value of DOCS_DEPLOY_BRANCH. Those differ whenever a previous cutover
-          # stalled: the variable can still read release/3.5 while this branch
-          # already inherited release/3.6. Anchoring on the variable would make the
-          # detector and this rewrite disagree, and the step would fail daily.
-          python3 - "$TARGET_BRANCH" <<'PY'
-          import re, sys
-          new = sys.argv[1]
-          path = '.github/workflows/docs-deploy.yml'
-          src = open(path).read()
-
-          # Scope to the PUSH trigger's branch list, matching the shell check.
-          # The `on:` block may hold other triggers with their own branch
-          # filters; rewriting one of those would leave the deploy trigger
-          # pointing at the old branch while everything reported success.
-          m = re.search(r'^(?P<i>[ \t]+)push:[ \t]*$', src, re.M)
-          if not m:
-              sys.exit('docs-deploy.yml has no push: trigger - refusing to edit blindly')
-          pind = len(m.group('i'))
-          rest = src[m.end():]
-          end = len(rest)
-          for line in re.finditer(r'^(?P<i>[ \t]*)\S.*$', rest, re.M):
-              if len(line.group('i')) <= pind:
-                  end = line.start()
-                  break
-          push_block = rest[:end]
-
-          bm = re.search(r'^(?P<i>[ \t]+)branches:[ \t]*$', push_block, re.M)
-          if not bm:
-              sys.exit('the push: trigger has no branches: list - refusing to edit blindly')
-          bind = len(bm.group('i'))
-          tail_of_block = push_block[bm.end():]
-          bend = len(tail_of_block)
-          for line in re.finditer(r'^(?P<i>[ \t]*)\S.*$', tail_of_block, re.M):
-              if len(line.group('i')) <= bind:
-                  bend = line.start()
-                  break
-          branches = tail_of_block[:bend]
-
-          entries = re.findall(r"^[ \t]*-[ \t]*['\"]?(\S+?)['\"]?[ \t]*$", branches, re.M)
-          if len(entries) != 1:
-              sys.exit(f'expected exactly one push branch entry, found {entries}')
-          if entries[0] == new:
-              sys.exit(f'{path} already pins {new} - nothing to repoint')
-
-          patched_branches = re.sub(r"^([ \t]*-[ \t]*)['\"]?\S+?['\"]?([ \t]*)$",
-                                    rf'\g<1>{new}\g<2>', branches, flags=re.M)
-          out = (src[:m.end()] + push_block[:bm.end()] + patched_branches
-                 + tail_of_block[bend:] + rest[end:])
-          open(path, 'w').write(out)
-          print(f'repointed {entries[0]} -> {new}')
-          PY
+          # One parser for both the check above and this rewrite. Two parsers of
+          # the same list disagreeing is a daily-failing job: the check says
+          # "not pinned", the rewrite says "already pinned" and exits non-zero,
+          # and the cutover never advances. The script comes from GITHUB_WORKSPACE
+          # (this workflow's own ref), never from the branch being edited, so a
+          # release branch cannot supply code that runs against a write token.
+          DEPLOY_YML="${workdir}/.github/workflows/docs-deploy.yml" \
+            python3 "${GITHUB_WORKSPACE}/.github/workflows/scripts/docs-deploy-trigger.py" \
+            --repoint "$TARGET_BRANCH"
 
           git config user.name "erigon-release-bot[bot]"
           git config user.email "erigon-release-bot[bot]@users.noreply.github.com"
@@ -709,6 +660,13 @@ jobs:
     # without touching this file.
     environment: release-branch-management
     steps:
+      - name: Check out the trigger parser
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          sparse-checkout: .github/workflows/scripts
+
       - name: Generate GitHub App token
         id: app_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  ## v3.2.0
@@ -824,20 +782,9 @@ jobs:
             echo "::error::${TARGET_BRANCH} docs label reads '${label:-unreadable}', expected v${TARGET_SERIES}. The version bump is no longer in place."
             exit 1
           fi
-          # Extract the branches of the PUSH trigger only. The `on:` block can
-          # carry other triggers with their own branch filters, and a match in
-          # one of those is not a deploy trigger: a file whose push list still
-          # names the old branch would read as pinned, the variable would flip,
-          # and merges would never publish. Comparing with `grep -Fx` against
-          # this list also removes every regex-escaping question.
-          cat > "${RUNNER_TEMP}/push-branches.awk" <<'AWKEOF'
-          /^[[:blank:]]*push:[[:blank:]]*$/ { p=1; pind=match($0,/[^ \t]/); next }
-          p && /^[[:blank:]]*[^ \t#-]/ { if (match($0,/[^ \t]/) <= pind) { p=0; b=0 } }
-          p && /^[[:blank:]]*branches:[[:blank:]]*$/ { b=1; next }
-          p && b && /^[[:blank:]]*-/ { gsub(/^[[:blank:]]*-[[:blank:]]*/,""); gsub(/['"'"'"]/,""); gsub(/[[:blank:]]*$/,""); print; next }
-          p && b && /^[[:blank:]]*[^ \t-]/ { b=0 }
-          AWKEOF
-          if ! printf '%s' "$deploy_yml" | awk -f "${RUNNER_TEMP}/push-branches.awk" \
+          printf '%s' "$deploy_yml" > "${RUNNER_TEMP}/deploy.yml"
+          if ! DEPLOY_YML="${RUNNER_TEMP}/deploy.yml" \
+               python3 "${GITHUB_WORKSPACE}/.github/workflows/scripts/docs-deploy-trigger.py" --list \
                | grep -Fxq "$TARGET_BRANCH"; then
             echo "::error::${TARGET_BRANCH} docs-deploy.yml no longer pins itself. The repoint is no longer in place."
             exit 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,7 +59,13 @@ jobs:
           # for every pull request, to load a single module.
           js_yaml_version="$(python3 -c \
             "import json; print(json.load(open('docs/site/package-lock.json'))['packages']['node_modules/js-yaml']['version'])")"
-          npm install --no-save --no-audit --no-fund \
+          # --ignore-scripts: this job's token carries actions: write, and the
+          # version string is a pin, not a lockfile — it does not carry the
+          # resolved integrity hash or the locked transitive tree. Refusing to
+          # run lifecycle scripts is what keeps a compromised publish from
+          # executing against that token. js-yaml has no install scripts today;
+          # this is about what it could grow, or what a dependency could.
+          npm install --no-save --no-audit --no-fund --ignore-scripts \
             --prefix "${RUNNER_TEMP}/oracle" "js-yaml@${js_yaml_version}"
 
           JS_YAML_FROM="${RUNNER_TEMP}/oracle" \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,6 +32,39 @@ jobs:
       - name: Install zizmor
         run: pip install --break-system-packages zizmor==1.26.1
 
+      # docs-cutover.yml decides whether DOCS_DEPLOY_BRANCH gets flipped to a
+      # branch that publishes, and it decides it by parsing another workflow's
+      # `on.push.branches`. That parser has a fixture suite and a second,
+      # unrelated YAML implementation to cross-check it against — neither of
+      # which was run by anything, so a parser regression could land with every
+      # signal green. --oracle is not optional here: the fixtures were written
+      # from what PyYAML does, and checking them against js-yaml is what makes
+      # them evidence about YAML rather than about PyYAML. js-yaml is already a
+      # docs/site dependency, so this needs no new package.
+      - name: Docs deploy-trigger parser tests
+        run: |
+          set -euo pipefail
+
+          # The runner image ships no python3-yaml: its yamllint and ansible-core
+          # come from pipx, in their own virtualenvs. Distro package, not PyPI, so
+          # no --break-system-packages and no unsigned dependency in a lint job.
+          if ! python3 -c 'import yaml' 2>/dev/null; then
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends python3-yaml
+          fi
+
+          # js-yaml only, at the version docs/site's lockfile already resolves —
+          # one source of truth, and no drift between the two. `npm ci` on
+          # docs/site would pull the whole Docusaurus tree into a job that runs
+          # for every pull request, to load a single module.
+          js_yaml_version="$(python3 -c \
+            "import json; print(json.load(open('docs/site/package-lock.json'))['packages']['node_modules/js-yaml']['version'])")"
+          npm install --no-save --no-audit --no-fund \
+            --prefix "${RUNNER_TEMP}/oracle" "js-yaml@${js_yaml_version}"
+
+          JS_YAML_FROM="${RUNNER_TEMP}/oracle" \
+            python3 .github/workflows/scripts/docs-deploy-trigger.test.py --oracle
+
       # -shellcheck '' disables actionlint's built-in inline-script checking;
       # the repo's QA workflow run: blocks have many pre-existing shellcheck
       # warnings that need a separate cleanup pass (#21128).  .sh files are

--- a/.github/workflows/scripts/docs-deploy-trigger.oracle.mjs
+++ b/.github/workflows/scripts/docs-deploy-trigger.oracle.mjs
@@ -1,0 +1,87 @@
+// An independent reader for docs-deploy.yml's on.push.branches, used only to
+// cross-check docs-deploy-trigger.py's fixtures against a YAML implementation
+// that shares no code with PyYAML.
+//
+// Why this exists: fixtures written from what one parser does are evidence
+// about that parser, not about YAML. Four review rounds in a row found the
+// earlier hand-rolled matcher disagreeing with real parsers on a shape its own
+// test suite said was fine, because the suite and the parser were the same
+// opinion twice.
+//
+//   node docs-deploy-trigger.oracle.mjs <file>
+//   -> {"status":"ok","branches":[...]}    a branch list
+//      {"status":"nolist","detail":...}    no on.push.branches sequence
+//      {"status":"nonstring","detail":...} entries that are not strings
+//      {"status":"invalid","detail":...}   not a document YAML accepts
+//
+// js-yaml is not a dependency of this repo. Set JS_YAML_FROM to any directory
+// whose node_modules has one -- resolution is relative to it, not to NODE_PATH,
+// which ES module imports ignore:
+//   JS_YAML_FROM=docs/site node .../docs-deploy-trigger.oracle.mjs <file>
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+import { resolve } from 'node:path';
+
+const from = process.env.JS_YAML_FROM;
+const require = createRequire(
+  from ? pathToFileURL(resolve(from) + '/') : import.meta.url,
+);
+
+let yaml;
+try {
+  yaml = require('js-yaml');
+} catch {
+  console.error(
+    'js-yaml not found. Set JS_YAML_FROM to a directory whose node_modules has it.',
+  );
+  process.exit(2);
+}
+
+const path = process.argv[2];
+if (!path) {
+  console.error('usage: docs-deploy-trigger.oracle.mjs <file>');
+  process.exit(2);
+}
+
+// Reading is NOT inside the try. This script's whole job is to answer "does an
+// unrelated parser accept this document", so an unreadable file reported as
+// `invalid` would be the oracle agreeing with PyYAML for a reason that has
+// nothing to do with YAML -- the same "one opinion twice" failure it exists to
+// prevent. An I/O failure is an operator error and exits 2 like the others.
+let text;
+try {
+  text = readFileSync(path, 'utf8');
+} catch (e) {
+  console.error(`cannot read ${path}: ${e.message}`);
+  process.exit(2);
+}
+
+let doc;
+try {
+  doc = yaml.load(text);
+} catch (e) {
+  console.log(JSON.stringify({ status: 'invalid', detail: e.name }));
+  process.exit(0);
+}
+
+// js-yaml reads YAML 1.2, where `on` is the string it looks like; PyYAML reads
+// 1.1, where a bare `on` is boolean true. Accept either so that the comparison
+// is about the branch list and not about that difference.
+const on = doc && typeof doc === 'object' ? doc.on ?? doc[true] : undefined;
+const push = on && typeof on === 'object' ? on.push : undefined;
+const branches = push && typeof push === 'object' ? push.branches : undefined;
+
+if (!Array.isArray(branches)) {
+  console.log(JSON.stringify({
+    status: 'nolist',
+    detail: branches === undefined ? 'absent' : typeof branches,
+  }));
+} else if (!branches.every((b) => typeof b === 'string')) {
+  console.log(JSON.stringify({
+    status: 'nonstring',
+    detail: branches.map((b) => typeof b),
+  }));
+} else {
+  console.log(JSON.stringify({ status: 'ok', branches }));
+}

--- a/.github/workflows/scripts/docs-deploy-trigger.py
+++ b/.github/workflows/scripts/docs-deploy-trigger.py
@@ -33,6 +33,7 @@ import sys
 import yaml
 
 STR_TAG = 'tag:yaml.org,2002:str'
+BOOL_TAG = 'tag:yaml.org,2002:bool'
 MAP_TAG = 'tag:yaml.org,2002:map'
 SEQ_TAG = 'tag:yaml.org,2002:seq'
 
@@ -51,8 +52,15 @@ def target_path():
     return os.environ.get('DEPLOY_YML', '.github/workflows/docs-deploy.yml')
 
 
-def _value_of(node, *keys):
+def _value_of(node, *keys, key_tags=(STR_TAG,)):
     """The value node of `keys` in a mapping node, refusing a duplicate.
+
+    `key_tags` are the tags the KEY itself may carry. Checking the value's tag
+    is not enough: `!unknown on:` tags the key, and GitHub's parser rejects the
+    workflow, but a lookup that compares only `key.value` accepts it. The bare
+    `on` key needs BOOL_TAG in that set, because YAML 1.1 resolves `on` to a
+    boolean -- quoting it is what makes it a string -- so both spellings of the
+    same trigger have to pass.
 
     A duplicate key is the one shape where "read it the way GitHub reads it"
     has no answer to give. YAML itself calls it an error; js-yaml raises;
@@ -66,7 +74,8 @@ def _value_of(node, *keys):
     if not isinstance(node, yaml.MappingNode):
         return None
     found = [value for key, value in node.value
-             if isinstance(key, yaml.ScalarNode) and key.value in keys]
+             if isinstance(key, yaml.ScalarNode) and key.value in keys
+             and key.tag in key_tags]
     if len(found) > 1:
         raise Unreadable(f'{keys[0]}: appears {len(found)} times'
                          ' - refusing to guess which one GitHub reads')
@@ -100,17 +109,33 @@ def branch_nodes(src):
     # `On:` and `ON:` are therefore different keys and not triggers at all, so
     # reading a pin out of one would report a pin on a file that has no push
     # trigger and let a repoint "succeed" on a workflow GitHub cannot load.
-    trigger = _value_of(root, 'on')
+    trigger = _value_of(root, 'on', key_tags=(STR_TAG, BOOL_TAG))
     if trigger is None:
         raise Unreadable('no on: block')
     push = _value_of(trigger, 'push')
     if push is None:
         raise Unreadable('no push: trigger - refusing to edit blindly')
 
+    branches_key = None
+    for key, value in push.value if isinstance(push, yaml.MappingNode) else ():
+        if isinstance(key, yaml.ScalarNode) and key.value == 'branches':
+            branches_key = key
+            break
     branches = _value_of(push, 'branches')
     if branches is None or not isinstance(branches, yaml.SequenceNode):
         raise Unreadable('the push: trigger has no branches: list'
                          ' - refusing to edit blindly')
+    # `branches: *b` resolves to the very node the anchor named, so its span is
+    # wherever that anchor was written -- possibly another key. Rewriting by
+    # span would then edit THAT key: with `paths: &b [release/3.6]` above it,
+    # repointing rewrote the path filter, and the pre-write check still passed
+    # because the alias made branches read the new value too. An anchor must be
+    # defined before the alias that uses it, so a value starting before its own
+    # key is exactly this case.
+    if branches_key is not None and \
+            branches.start_mark.index < branches_key.end_mark.index:
+        raise Unreadable('branches: is an alias of a list defined elsewhere'
+                         ' - refusing to rewrite another key by its span')
     # An unresolvable tag anywhere on the path is a workflow GitHub rejects
     # outright, and a custom-tagged mapping still composes to a MappingNode --
     # so without this the pre-write verification would happily bless

--- a/.github/workflows/scripts/docs-deploy-trigger.py
+++ b/.github/workflows/scripts/docs-deploy-trigger.py
@@ -53,14 +53,23 @@ def branch_span(src):
     return b
 
 
-# A '#' only starts a comment when whitespace precedes it (YAML requires that,
-# and git permits '#' inside a branch name) — otherwise `- release/3.6#keep`
-# would read as `release/3.6` and the trigger would be reported as pinned to a
-# branch it does not actually name.
+# Shapes are matched the way a YAML parser reads them, because the cost of
+# being lenient is asymmetric: listing a branch that `on.push.branches` does
+# not actually contain reports a pin the deploy trigger does not have, and the
+# cutover then flips the variable to a branch that never publishes.
+#
+#   - the dash needs whitespace after it: `-release/3.6` is the scalar
+#     "-release/3.6", not a one-item list;
+#   - indentation must be spaces, since a tab makes the document invalid;
+#   - a plain scalar cannot begin with a quote, so a half-quoted entry is
+#     not a name at all;
+#   - a '#' starts a comment only when whitespace precedes it (git permits '#'
+#     inside a branch name, so `- release/3.6#keep` is that whole name) —
+#     except after a closing quote, which has already ended the name.
 ENTRY = re.compile(
-    r"^(?P<lead>[ \t]*-[ \t]*)"
+    r"^(?P<lead>[ ]*-[ \t]+)"
     r"(?:(?P<q>['\"])(?P<qname>[^'\"]+)(?P=q)(?P<qtrail>[ \t]*(?:#.*)?)"
-    r"|(?P<name>\S+)(?P<trail>(?:[ \t]+#.*)?[ \t]*))$", re.M)
+    r"|(?P<name>[^'\"\s]\S*)(?P<trail>(?:[ \t]+#.*)?[ \t]*))$", re.M)
 
 
 def entries(block):

--- a/.github/workflows/scripts/docs-deploy-trigger.py
+++ b/.github/workflows/scripts/docs-deploy-trigger.py
@@ -44,10 +44,10 @@ def _block_after(src, key_re, start=0):
 
 
 def branch_span(src):
-    push = _block_after(src, r'^(?P<i>[ \t]*)push:[ \t]*(?:#.*)?$')
+    push = _block_after(src, r'^(?P<i>[ \t]*)push:(?:[ \t]+#.*)?[ \t]*$')
     if not push:
         sys.exit('docs-deploy.yml has no push: trigger - refusing to edit blindly')
-    b = _block_after(src[:push[1]], r'^(?P<i>[ \t]*)branches:[ \t]*(?:#.*)?$', push[0])
+    b = _block_after(src[:push[1]], r'^(?P<i>[ \t]*)branches:(?:[ \t]+#.*)?[ \t]*$', push[0])
     if not b:
         sys.exit('the push: trigger has no branches: list - refusing to edit blindly')
     return b
@@ -59,8 +59,8 @@ def branch_span(src):
 # branch it does not actually name.
 ENTRY = re.compile(
     r"^(?P<lead>[ \t]*-[ \t]*)"
-    r"(?:(?P<q>['\"])(?P<qname>[^'\"]+)(?P=q)|(?P<name>\S+))"
-    r"(?P<trail>(?:[ \t]+#.*)?[ \t]*)$", re.M)
+    r"(?:(?P<q>['\"])(?P<qname>[^'\"]+)(?P=q)(?P<qtrail>[ \t]*(?:#.*)?)"
+    r"|(?P<name>\S+)(?P<trail>(?:[ \t]+#.*)?[ \t]*))$", re.M)
 
 
 def entries(block):
@@ -89,7 +89,8 @@ def main():
         return 0
     def swap(m):
         q = m.group('q') or ''
-        return f"{m.group('lead')}{q}{new}{q}{m.group('trail')}"
+        trail = m.group('qtrail') if q else m.group('trail')
+        return f"{m.group('lead')}{q}{new}{q}{trail}"
 
     patched = ENTRY.sub(swap, block)
     open(path, 'w').write(src[:lo] + patched + src[hi:])

--- a/.github/workflows/scripts/docs-deploy-trigger.py
+++ b/.github/workflows/scripts/docs-deploy-trigger.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Read or repoint the push trigger's branch list in docs-deploy.yml.
+
+ONE parser, two modes, because the check and the rewrite disagreeing is a
+failure that repeats daily: the check says "not pinned", the rewrite says
+"already pinned" and exits non-zero, and the job never makes progress.
+
+  --list             print each push branch, one per line
+  --repoint <branch> rewrite the list to that single branch
+"""
+import os
+import re
+import sys
+
+# The file to read or edit. The callers point this at a temp copy fetched from
+# a branch, or at a clone's working copy; it is never assumed to be this repo's.
+PATH = os.environ.get('DEPLOY_YML', '.github/workflows/docs-deploy.yml')
+
+
+def _is_skippable(line):
+    return not line.strip() or line.lstrip().startswith('#')
+
+
+def _block_after(src, key_re, start=0):
+    """Span of the lines nested under the first `key:` matching key_re."""
+    m = re.compile(key_re, re.M).search(src, start)
+    if not m:
+        return None
+    indent = len(m.group('i'))
+    rest = src[m.end():]
+    end = len(rest)
+    for line in re.finditer(r'^(?P<i>[ \t]*)(?P<body>.*)$', rest, re.M):
+        if _is_skippable(line.group(0)):
+            continue                      # comments/blanks never close a block
+        if len(line.group('i')) <= indent and not line.group('body').startswith('-'):
+            end = line.start()            # a dash at the key's column is a member
+            break
+    return m.end(), m.end() + end
+
+
+def branch_span(src):
+    push = _block_after(src, r'^(?P<i>[ \t]*)push:[ \t]*$')
+    if not push:
+        sys.exit('docs-deploy.yml has no push: trigger - refusing to edit blindly')
+    b = _block_after(src[:push[1]], r'^(?P<i>[ \t]*)branches:[ \t]*$', push[0])
+    if not b:
+        sys.exit('the push: trigger has no branches: list - refusing to edit blindly')
+    return b
+
+
+ENTRY = re.compile(r"^(?P<lead>[ \t]*-[ \t]*)(?P<q>['\"]?)(?P<name>[^'\"#\s]+)(?P=q)"
+                   r"(?P<trail>[ \t]*(?:#.*)?)$", re.M)
+
+
+def entries(block):
+    return [m.group('name') for m in ENTRY.finditer(block)]
+
+
+def main():
+    src = open(PATH).read()
+    lo, hi = branch_span(src)
+    block = src[lo:hi]
+    names = entries(block)
+
+    if sys.argv[1] == '--list':
+        print('\n'.join(names))
+        return 0
+
+    new = sys.argv[2]
+    if len(names) != 1:
+        sys.exit(f'expected exactly one push branch entry, found {names}')
+    if names[0] == new:
+        # Not an error: the check and this rewrite read the same list, so this
+        # means the state was satisfied between the two. Degrade to a no-op
+        # rather than failing the job every day.
+        print(f'{PATH} already pins {new} - nothing to do')
+        return 0
+    patched = ENTRY.sub(lambda m: f"{m.group('lead')}{m.group('q')}{new}{m.group('q')}{m.group('trail')}", block)
+    open(PATH, 'w').write(src[:lo] + patched + src[hi:])
+    print(f'repointed {names[0]} -> {new}')
+    return 0
+
+
+sys.exit(main())

--- a/.github/workflows/scripts/docs-deploy-trigger.py
+++ b/.github/workflows/scripts/docs-deploy-trigger.py
@@ -1,16 +1,45 @@
 #!/usr/bin/env python3
 """Read or repoint the push trigger's branch list in docs-deploy.yml.
 
-ONE parser, two modes, because the check and the rewrite disagreeing is a
-failure that repeats daily: the check says "not pinned", the rewrite says
-"already pinned" and exits non-zero, and the job never makes progress.
-
   --list             print each push branch, one per line
   --repoint <branch> rewrite the list to that single branch
+
+READING IS DELEGATED TO A REAL YAML PARSER.
+An earlier version of this script matched the branch list with regexes and
+answered differently from a real parser in four separate review rounds. Every
+shape GitHub accepts has to be read the way GitHub reads it, because the cost
+of disagreeing is asymmetric in both directions: reporting a pin that
+`on.push.branches` does not contain makes the cutover flip the deploy variable
+to a branch that never publishes, and failing to see a pin that IS there makes
+it open a repoint pull request that is not needed. Flow sequences, folded and
+tagged scalars, quoting styles and CRLF are all things a hand-rolled matcher
+gets wrong one shape at a time; `yaml.compose` gets them right by construction,
+and rejects the documents no parser accepts (a dash indented below its key, a
+tab used for indentation) instead of reading a pin out of them.
+
+WRITING STAYS A SURGICAL TEXT EDIT.
+Serialising the parsed document back out would reformat the file and drop every
+comment in it. Instead the node's own source span -- the parser's answer to
+"where is this scalar" -- is the only region touched, so quoting style, inline
+comments, line endings and the rest of the file survive byte for byte. The
+rewritten text is then handed back to the same parser and must read as exactly
+the requested branch BEFORE anything is written to disk: a bad edit fails
+closed with the file untouched, rather than landing a workflow GitHub cannot
+load.
 """
 import os
-import re
 import sys
+
+import yaml
+
+STR_TAG = 'tag:yaml.org,2002:str'
+MAP_TAG = 'tag:yaml.org,2002:map'
+SEQ_TAG = 'tag:yaml.org,2002:seq'
+
+
+class Unreadable(Exception):
+    """The file's push-branch list cannot be determined."""
+
 
 def target_path():
     """File to read or edit.
@@ -22,88 +51,172 @@ def target_path():
     return os.environ.get('DEPLOY_YML', '.github/workflows/docs-deploy.yml')
 
 
-def _is_skippable(line):
-    return not line.strip() or line.lstrip().startswith('#')
+def _value_of(node, *keys):
+    """The value node of `keys` in a mapping node, refusing a duplicate.
 
-
-def _block_after(src, key_re, start=0):
-    """Span of the lines nested under the first `key:` matching key_re."""
-    m = re.compile(key_re, re.M).search(src, start)
-    if not m:
+    A duplicate key is the one shape where "read it the way GitHub reads it"
+    has no answer to give. YAML itself calls it an error; js-yaml raises;
+    PyYAML's LOADER silently keeps the LAST occurrence; and taking the first --
+    the obvious thing for a node walk -- would make this script report a pin
+    the effective document does not have, repoint the occurrence that loses,
+    and then bless its own edit, because the pre-write verification reads by
+    the same rule. That is the disagree-with-the-real-parser failure this
+    script was rewritten to eliminate, so it is refused rather than resolved.
+    """
+    if not isinstance(node, yaml.MappingNode):
         return None
-    indent = len(m.group('i'))
-    rest = src[m.end():]
-    end = len(rest)
-    for line in re.finditer(r'^(?P<i>[ \t]*)(?P<body>.*)$', rest, re.M):
-        if _is_skippable(line.group(0)):
-            continue                      # comments/blanks never close a block
-        if len(line.group('i')) <= indent and not line.group('body').startswith('-'):
-            end = line.start()            # a dash at the key's column is a member
-            break
-    return m.end(), m.end() + end
+    found = [value for key, value in node.value
+             if isinstance(key, yaml.ScalarNode) and key.value in keys]
+    if len(found) > 1:
+        raise Unreadable(f'{keys[0]}: appears {len(found)} times'
+                         ' - refusing to guess which one GitHub reads')
+    return found[0] if found else None
 
 
-def branch_span(src):
-    push = _block_after(src, r'^(?P<i>[ \t]*)push:(?:[ \t]+#.*)?[ \t]*$')
-    if not push:
-        sys.exit('docs-deploy.yml has no push: trigger - refusing to edit blindly')
-    b = _block_after(src[:push[1]], r'^(?P<i>[ \t]*)branches:(?:[ \t]+#.*)?[ \t]*$', push[0])
-    if not b:
-        sys.exit('the push: trigger has no branches: list - refusing to edit blindly')
-    return b
+def branch_nodes(src):
+    """The scalar nodes of `on.push.branches`, with their source spans.
+
+    Raises Unreadable when the document is not valid YAML or does not have a
+    push trigger with a branch list, so that callers can distinguish "no pin"
+    from "cannot tell" -- and so the pre-write verification can catch its own
+    failure instead of exiting the process.
+    """
+    try:
+        root = yaml.compose(src, Loader=yaml.SafeLoader)
+    except yaml.YAMLError as exc:
+        raise Unreadable(f'not valid YAML: {exc}') from exc
+    if root is None:
+        raise Unreadable('the file is empty')
+
+    # At node level the `on` key is the literal string 'on', whether or not it
+    # was quoted to dodge YAML 1.1's on/off booleans; it is PyYAML's
+    # constructor, not its parser, that would turn a bare `on` into boolean
+    # true. Reading the node keeps this independent of that resolution.
+    #
+    # Only the exact lowercase key counts. GitHub parses workflows with the
+    # `yaml` npm package -- YAML 1.2, where `on` is the string it looks like,
+    # not a boolean -- and matches the literal key `on` from its own schema
+    # (actions/languageservices, workflow-parser/src/workflow-v1.0.json).
+    # `On:` and `ON:` are therefore different keys and not triggers at all, so
+    # reading a pin out of one would report a pin on a file that has no push
+    # trigger and let a repoint "succeed" on a workflow GitHub cannot load.
+    trigger = _value_of(root, 'on')
+    if trigger is None:
+        raise Unreadable('no on: block')
+    push = _value_of(trigger, 'push')
+    if push is None:
+        raise Unreadable('no push: trigger - refusing to edit blindly')
+
+    branches = _value_of(push, 'branches')
+    if branches is None or not isinstance(branches, yaml.SequenceNode):
+        raise Unreadable('the push: trigger has no branches: list'
+                         ' - refusing to edit blindly')
+    # An unresolvable tag anywhere on the path is a workflow GitHub rejects
+    # outright, and a custom-tagged mapping still composes to a MappingNode --
+    # so without this the pre-write verification would happily bless
+    # `on: !nope` as loadable.
+    for label, node, tag in (('on', trigger, MAP_TAG),
+                             ('push', push, MAP_TAG),
+                             ('branches', branches, SEQ_TAG)):
+        if node.tag != tag:
+            raise Unreadable(f'{label}: has a non-standard tag ({node.tag})')
+
+    for entry in branches.value:
+        # A non-string entry is not a branch name: `- 3.6` resolves to a float,
+        # and comparing that to a branch is the silent mismatch this script
+        # exists to prevent. An unknown tag (`- !mine x`) is a workflow GitHub
+        # would reject outright.
+        if not isinstance(entry, yaml.ScalarNode) or entry.tag != STR_TAG:
+            raise Unreadable(f'branches: has a non-string entry (tag {entry.tag})')
+    return branches.value
 
 
-# Shapes are matched the way a YAML parser reads them, because the cost of
-# being lenient is asymmetric: listing a branch that `on.push.branches` does
-# not actually contain reports a pin the deploy trigger does not have, and the
-# cutover then flips the variable to a branch that never publishes.
-#
-#   - the dash needs whitespace after it: `-release/3.6` is the scalar
-#     "-release/3.6", not a one-item list;
-#   - indentation must be spaces, since a tab makes the document invalid;
-#   - a plain scalar cannot begin with a quote, so a half-quoted entry is
-#     not a name at all;
-#   - a '#' starts a comment only when whitespace precedes it (git permits '#'
-#     inside a branch name, so `- release/3.6#keep` is that whole name) —
-#     except after a closing quote, which has already ended the name.
-ENTRY = re.compile(
-    r"^(?P<lead>[ ]*-[ \t]+)"
-    r"(?:(?P<q>['\"])(?P<qname>[^'\"]+)(?P=q)(?P<qtrail>[ \t]*(?:#.*)?)"
-    r"|(?P<name>[^'\"\s]\S*)(?P<trail>(?:[ \t]+#.*)?[ \t]*))$", re.M)
+def read_branches(src):
+    """The branch scalar nodes, or exit with the reason they cannot be read."""
+    try:
+        return branch_nodes(src)
+    except Unreadable as exc:
+        sys.exit(f'docs-deploy.yml {exc}')
 
 
-def entries(block):
-    return [m.group('qname') or m.group('name') for m in ENTRY.finditer(block)]
+def repoint(src, new):
+    """`src` with its single push branch replaced by `new`.
 
-
-def main():
-    path = target_path()
-    src = open(path).read()
-    lo, hi = branch_span(src)
-    block = src[lo:hi]
-    names = entries(block)
-
-    if sys.argv[1] == '--list':
-        print('\n'.join(names))
-        return 0
-
-    new = sys.argv[2]
+    Returns (patched_text, old_name), or None when it already reads `new`.
+    """
+    nodes = read_branches(src)
+    names = [node.value for node in nodes]
     if len(names) != 1:
         sys.exit(f'expected exactly one push branch entry, found {names}')
     if names[0] == new:
+        return None
+
+    lo, hi = nodes[0].start_mark.index, nodes[0].end_mark.index
+    raw = src[lo:hi]
+    # The span is the scalar NODE's, which for some styles is wider than the
+    # text of the name: an anchor (`&pin release/3.6`), an explicit tag
+    # (`!!str release/3.6`) and a block header with its comment
+    # (`|- # why\n    release/3.6`) are all inside it. Replacing the span
+    # therefore collapses those styles to a plain scalar, dropping the anchor,
+    # the tag and any comment on the header line. That is deliberate: the
+    # result is still exactly the requested one-branch list, the deploy trigger
+    # has no use for any of them, and the one case where dropping an anchor
+    # would change meaning -- an anchor something else aliases -- makes the
+    # rewrite unparseable and is refused below rather than written. Anything
+    # narrower would mean re-deriving a style the parser already resolved,
+    # which is the hand-rolled matching this script exists to avoid.
+    #
+    # The span of a block-style entry runs to the end of its line, so it can
+    # swallow trailing whitespace and the newline itself; putting them back
+    # keeps the edit off the following line. A quoted span ends at its closing
+    # quote, where there is nothing to put back.
+    body = raw.rstrip()
+    tail = raw[len(body):]
+    quote = body[0] if body[:1] in ('"', "'") else ''
+    patched = f'{src[:lo]}{quote}{new}{quote}{tail}{src[hi:]}'
+
+    # The rewrite is verified before it is written, not after: the failure this
+    # guards against is a workflow file GitHub cannot load, and leaving that on
+    # disk to be repaired afterwards is the outcome to avoid.
+    try:
+        got = [node.value for node in branch_nodes(patched)]
+    except Unreadable as exc:
+        sys.exit(f'refusing to write: the rewrite would not parse ({exc})')
+    if got != [new]:
+        sys.exit(f'refusing to write: the rewrite reads {got}, expected {[new]}')
+    return patched, names[0]
+
+
+def main():
+    if len(sys.argv) < 2 or sys.argv[1] not in ('--list', '--repoint'):
+        sys.exit(f'usage: {sys.argv[0]} --list | --repoint <branch>')
+    if sys.argv[1] == '--repoint' and (len(sys.argv) < 3 or not sys.argv[2]):
+        sys.exit(f'usage: {sys.argv[0]} --repoint <branch>')
+
+    path = target_path()
+    # newline='' keeps CRLF intact in both directions: read as text with
+    # translation on, a CRLF file arrives with LF endings, every source span
+    # shifts, and writing it back would silently reformat the whole file.
+    with open(path, encoding='utf-8', newline='') as handle:
+        src = handle.read()
+
+    if sys.argv[1] == '--list':
+        print('\n'.join(node.value for node in read_branches(src)))
+        return 0
+
+    new = sys.argv[2]
+    result = repoint(src, new)
+    if result is None:
         # Not an error: the check and this rewrite read the same list, so this
         # means the state was satisfied between the two. Degrade to a no-op
         # rather than failing the job every day.
         print(f'{path} already pins {new} - nothing to do')
         return 0
-    def swap(m):
-        q = m.group('q') or ''
-        trail = m.group('qtrail') if q else m.group('trail')
-        return f"{m.group('lead')}{q}{new}{q}{trail}"
+    patched, old = result
 
-    patched = ENTRY.sub(swap, block)
-    open(path, 'w').write(src[:lo] + patched + src[hi:])
-    print(f'repointed {names[0]} -> {new}')
+    with open(path, 'w', encoding='utf-8', newline='') as handle:
+        handle.write(patched)
+    print(f'repointed {old} -> {new}')
     return 0
 
 

--- a/.github/workflows/scripts/docs-deploy-trigger.py
+++ b/.github/workflows/scripts/docs-deploy-trigger.py
@@ -12,9 +12,14 @@ import os
 import re
 import sys
 
-# The file to read or edit. The callers point this at a temp copy fetched from
-# a branch, or at a clone's working copy; it is never assumed to be this repo's.
-PATH = os.environ.get('DEPLOY_YML', '.github/workflows/docs-deploy.yml')
+def target_path():
+    """File to read or edit.
+
+    Callers point DEPLOY_YML at a temp copy fetched from a branch, or at a
+    clone's working copy; it is never assumed to be this repo's own file.
+    Read per call rather than at import so tests can vary it.
+    """
+    return os.environ.get('DEPLOY_YML', '.github/workflows/docs-deploy.yml')
 
 
 def _is_skippable(line):
@@ -39,25 +44,32 @@ def _block_after(src, key_re, start=0):
 
 
 def branch_span(src):
-    push = _block_after(src, r'^(?P<i>[ \t]*)push:[ \t]*$')
+    push = _block_after(src, r'^(?P<i>[ \t]*)push:[ \t]*(?:#.*)?$')
     if not push:
         sys.exit('docs-deploy.yml has no push: trigger - refusing to edit blindly')
-    b = _block_after(src[:push[1]], r'^(?P<i>[ \t]*)branches:[ \t]*$', push[0])
+    b = _block_after(src[:push[1]], r'^(?P<i>[ \t]*)branches:[ \t]*(?:#.*)?$', push[0])
     if not b:
         sys.exit('the push: trigger has no branches: list - refusing to edit blindly')
     return b
 
 
-ENTRY = re.compile(r"^(?P<lead>[ \t]*-[ \t]*)(?P<q>['\"]?)(?P<name>[^'\"#\s]+)(?P=q)"
-                   r"(?P<trail>[ \t]*(?:#.*)?)$", re.M)
+# A '#' only starts a comment when whitespace precedes it (YAML requires that,
+# and git permits '#' inside a branch name) — otherwise `- release/3.6#keep`
+# would read as `release/3.6` and the trigger would be reported as pinned to a
+# branch it does not actually name.
+ENTRY = re.compile(
+    r"^(?P<lead>[ \t]*-[ \t]*)"
+    r"(?:(?P<q>['\"])(?P<qname>[^'\"]+)(?P=q)|(?P<name>\S+))"
+    r"(?P<trail>(?:[ \t]+#.*)?[ \t]*)$", re.M)
 
 
 def entries(block):
-    return [m.group('name') for m in ENTRY.finditer(block)]
+    return [m.group('qname') or m.group('name') for m in ENTRY.finditer(block)]
 
 
 def main():
-    src = open(PATH).read()
+    path = target_path()
+    src = open(path).read()
     lo, hi = branch_span(src)
     block = src[lo:hi]
     names = entries(block)
@@ -73,12 +85,17 @@ def main():
         # Not an error: the check and this rewrite read the same list, so this
         # means the state was satisfied between the two. Degrade to a no-op
         # rather than failing the job every day.
-        print(f'{PATH} already pins {new} - nothing to do')
+        print(f'{path} already pins {new} - nothing to do')
         return 0
-    patched = ENTRY.sub(lambda m: f"{m.group('lead')}{m.group('q')}{new}{m.group('q')}{m.group('trail')}", block)
-    open(PATH, 'w').write(src[:lo] + patched + src[hi:])
+    def swap(m):
+        q = m.group('q') or ''
+        return f"{m.group('lead')}{q}{new}{q}{m.group('trail')}"
+
+    patched = ENTRY.sub(swap, block)
+    open(path, 'w').write(src[:lo] + patched + src[hi:])
     print(f'repointed {names[0]} -> {new}')
     return 0
 
 
-sys.exit(main())
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.github/workflows/scripts/docs-deploy-trigger.test.py
+++ b/.github/workflows/scripts/docs-deploy-trigger.test.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Fixture tests for docs-deploy-trigger.py.
+
+Run: python3 .github/workflows/scripts/docs-deploy-trigger.test.py
+
+Every case here is a YAML shape that a human might plausibly write into
+docs-deploy.yml's `on.push.branches` list. They exist because the cutover
+workflow's "is the trigger pinned to this branch?" check and its rewrite must
+agree on every one of them: when they disagree the check says "not pinned", the
+rewrite says "already pinned", and the job fails on every scheduled run.
+"""
+import importlib.util
+import os
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+spec = importlib.util.spec_from_file_location(
+    "docs_deploy_trigger", os.path.join(HERE, "docs-deploy-trigger.py"))
+assert spec is not None and spec.loader is not None
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+def parse(text):
+    lo, hi = mod.branch_span(text)
+    return mod.entries(text[lo:hi])
+
+
+HEAD = "on:\n  push:\n"
+TAIL = "\npermissions:\n  contents: read\n"
+
+# (name, on-block body, expected branches)
+CASES = [
+    ("plain",
+     "    branches:\n      - release/3.6\n", ["release/3.6"]),
+    ("paths after branches",
+     "    branches:\n      - release/3.6\n    paths:\n      - 'docs/site/**'\n", ["release/3.6"]),
+    ("single quotes",
+     "    branches:\n      - 'release/3.6'\n", ["release/3.6"]),
+    ("double quotes",
+     '    branches:\n      - "release/3.6"\n', ["release/3.6"]),
+    ("trailing comment on the entry",
+     "    branches:\n      - release/3.6  # deploy\n", ["release/3.6"]),
+    ("comment line inside the list",
+     "    branches:\n      # the publishing branch\n      - release/3.6\n", ["release/3.6"]),
+    ("blank line inside the list",
+     "    branches:\n\n      - release/3.6\n", ["release/3.6"]),
+    ("dash at the key's indent",
+     "    branches:\n    - release/3.6\n", ["release/3.6"]),
+    ("tab-indented entry",
+     "    branches:\n\t- release/3.6\n", ["release/3.6"]),
+    ("extra spaces after the dash",
+     "    branches:\n      -    release/3.6\n", ["release/3.6"]),
+    ("trailing whitespace on the entry",
+     "    branches:\n      - release/3.6   \n", ["release/3.6"]),
+    ("comment on the push: key",
+     None, ["release/3.6"]),          # handled specially below
+    ("comment on the branches: key",
+     "    branches:  # only the deploy branch\n      - release/3.6\n", ["release/3.6"]),
+    ("'#' inside the branch name",
+     "    branches:\n      - release/3.6#keep\n", ["release/3.6#keep"]),
+    ("two entries",
+     "    branches:\n      - release/3.6\n      - release/3.5\n",
+     ["release/3.6", "release/3.5"]),
+]
+
+
+def run():
+    failures = []
+
+    for name, body, expected in CASES:
+        if body is None:                       # the push:-key comment case
+            text = "on:\n  push:  # publish\n    branches:\n      - release/3.6\n" + TAIL
+        else:
+            text = HEAD + body + TAIL
+        try:
+            got = parse(text)
+        except SystemExit as e:
+            failures.append(f"{name}: refused with {e}")
+            continue
+        if got != expected:
+            failures.append(f"{name}: got {got}, want {expected}")
+
+    # A branch named only by another trigger is not a deploy pin.
+    other = ("on:\n  push:\n    branches:\n      - release/3.6\n"
+             "  pull_request:\n    branches:\n      - release/3.7\n" + TAIL)
+    if parse(other) != ["release/3.6"]:
+        failures.append(f"pull_request leak: got {parse(other)}")
+
+    # Round trip: repointing preserves comment, quoting and indentation.
+    src = ("on:\n  push:\n    branches:\n      # publishing branch\n"
+           '      - "release/3.6"  # deploy\n    paths:\n      - x\n' + TAIL)
+    with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as fh:
+        fh.write(src)
+        path = fh.name
+    os.environ["DEPLOY_YML"] = path
+    sys.argv = ["docs-deploy-trigger.py", "--repoint", "release/3.7"]
+    mod.main()
+    out = open(path).read()
+    os.unlink(path)
+    want = src.replace('"release/3.6"', '"release/3.7"')
+    if out != want:
+        failures.append("round trip changed more than the branch name:\n" + out)
+
+    for f in failures:
+        print("FAIL", f)
+    print(f"{len(CASES) + 2 - len(failures)}/{len(CASES) + 2} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/.github/workflows/scripts/docs-deploy-trigger.test.py
+++ b/.github/workflows/scripts/docs-deploy-trigger.test.py
@@ -3,13 +3,17 @@
 
 Run: python3 .github/workflows/scripts/docs-deploy-trigger.test.py
 
-Every case here is a YAML shape that a human might plausibly write into
-docs-deploy.yml's `on.push.branches` list. They exist because the cutover
-workflow's "is the trigger pinned to this branch?" check and its rewrite must
-agree on every one of them: when they disagree the check says "not pinned", the
-rewrite says "already pinned", and the job fails on every scheduled run.
+Every case is a YAML shape a human might write into docs-deploy.yml's
+`on.push.branches`. They exist because the cutover workflow's "is this trigger
+pinned?" check and its rewrite read the same list: when the two disagree, the
+check reports "not pinned", the rewrite reports "already pinned", and the job
+fails on every scheduled run. The negative cases matter as much as the positive
+ones — a parser that accepts a shape YAML itself rejects reports a pin that the
+deploy trigger does not actually have.
 """
+import contextlib
 import importlib.util
+import io
 import os
 import sys
 import tempfile
@@ -21,92 +25,141 @@ assert spec is not None and spec.loader is not None
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
 
+FAILURES = []
+
+
+def check(name, got, want):
+    if got != want:
+        FAILURES.append(f"{name}: got {got!r}, want {want!r}")
+
 
 def parse(text):
-    lo, hi = mod.branch_span(text)
-    return mod.entries(text[lo:hi])
+    """Branch names, or the refusal message — never an escaping SystemExit.
+
+    A refusal must be comparable data: letting SystemExit propagate kills the
+    run and hides every result gathered so far, so a regression shows up as one
+    stray line instead of a report.
+    """
+    try:
+        lo, hi = mod.branch_span(text)
+        return mod.entries(text[lo:hi])
+    except SystemExit as e:
+        return f"REFUSED: {e}"
+
+
+def run_cli(text, argv):
+    """Run main() over `text`, returning (rc, stdout, resulting file)."""
+    with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as fh:
+        fh.write(text)
+        path = fh.name
+    os.environ["DEPLOY_YML"] = path
+    sys.argv = ["docs-deploy-trigger.py", *argv]
+    out = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(out):
+            rc = mod.main()
+    except SystemExit as e:
+        rc = e.code if isinstance(e.code, int) else 1
+        if e.code and not isinstance(e.code, int):
+            out.write(str(e.code))
+    result = open(path).read()
+    os.unlink(path)
+    return rc, out.getvalue(), result
 
 
 HEAD = "on:\n  push:\n"
 TAIL = "\npermissions:\n  contents: read\n"
+REFUSE_NO_LIST = "REFUSED: the push: trigger has no branches: list - refusing to edit blindly"
+REFUSE_NO_PUSH = "REFUSED: docs-deploy.yml has no push: trigger - refusing to edit blindly"
 
-# (name, on-block body, expected branches)
-CASES = [
-    ("plain",
-     "    branches:\n      - release/3.6\n", ["release/3.6"]),
+ACCEPTED = [
+    ("plain", "    branches:\n      - release/3.6\n", ["release/3.6"]),
     ("paths after branches",
      "    branches:\n      - release/3.6\n    paths:\n      - 'docs/site/**'\n", ["release/3.6"]),
-    ("single quotes",
-     "    branches:\n      - 'release/3.6'\n", ["release/3.6"]),
-    ("double quotes",
-     '    branches:\n      - "release/3.6"\n', ["release/3.6"]),
-    ("trailing comment on the entry",
+    ("single quotes", "    branches:\n      - 'release/3.6'\n", ["release/3.6"]),
+    ("double quotes", '    branches:\n      - "release/3.6"\n', ["release/3.6"]),
+    ("trailing comment on entry",
      "    branches:\n      - release/3.6  # deploy\n", ["release/3.6"]),
-    ("comment line inside the list",
+    ("quoted entry, comment with no gap",
+     "    branches:\n      - 'release/3.6'#c\n", ["release/3.6"]),
+    ("indented comment in the list",
      "    branches:\n      # the publishing branch\n      - release/3.6\n", ["release/3.6"]),
-    ("blank line inside the list",
-     "    branches:\n\n      - release/3.6\n", ["release/3.6"]),
-    ("dash at the key's indent",
-     "    branches:\n    - release/3.6\n", ["release/3.6"]),
-    ("tab-indented entry",
-     "    branches:\n\t- release/3.6\n", ["release/3.6"]),
-    ("extra spaces after the dash",
-     "    branches:\n      -    release/3.6\n", ["release/3.6"]),
-    ("trailing whitespace on the entry",
-     "    branches:\n      - release/3.6   \n", ["release/3.6"]),
-    ("comment on the push: key",
-     None, ["release/3.6"]),          # handled specially below
+    ("column-0 comment in the list",
+     "    branches:\n# publishing branch\n      - release/3.6\n", ["release/3.6"]),
+    ("blank line in the list", "    branches:\n\n      - release/3.6\n", ["release/3.6"]),
+    ("dash at the key's indent", "    branches:\n    - release/3.6\n", ["release/3.6"]),
+    ("tab-indented entry", "    branches:\n\t- release/3.6\n", ["release/3.6"]),
+    ("extra spaces after dash", "    branches:\n      -    release/3.6\n", ["release/3.6"]),
+    ("trailing whitespace", "    branches:\n      - release/3.6   \n", ["release/3.6"]),
     ("comment on the branches: key",
      "    branches:  # only the deploy branch\n      - release/3.6\n", ["release/3.6"]),
     ("'#' inside the branch name",
      "    branches:\n      - release/3.6#keep\n", ["release/3.6#keep"]),
-    ("two entries",
-     "    branches:\n      - release/3.6\n      - release/3.5\n",
+    ("two entries", "    branches:\n      - release/3.6\n      - release/3.5\n",
      ["release/3.6", "release/3.5"]),
+]
+
+# Shapes YAML itself does not read as a branches list. Accepting one would
+# report a pin the deploy trigger does not have.
+REJECTED = [
+    ("branches:#c — not a key in YAML",
+     "    branches:#c\n      - release/3.6\n", REFUSE_NO_LIST),
+    ("push: with only paths, pull_request lists branches later",
+     "    paths:\n      - x\n  pull_request:\n    branches:\n      - release/3.6\n",
+     REFUSE_NO_LIST),
 ]
 
 
 def run():
-    failures = []
+    for name, body, want in ACCEPTED + REJECTED:
+        check(name, parse(HEAD + body + TAIL), want)
 
-    for name, body, expected in CASES:
-        if body is None:                       # the push:-key comment case
-            text = "on:\n  push:  # publish\n    branches:\n      - release/3.6\n" + TAIL
-        else:
-            text = HEAD + body + TAIL
-        try:
-            got = parse(text)
-        except SystemExit as e:
-            failures.append(f"{name}: refused with {e}")
-            continue
-        if got != expected:
-            failures.append(f"{name}: got {got}, want {expected}")
+    check("comment on the push: key",
+          parse("on:\n  push:  # publish\n    branches:\n      - release/3.6\n" + TAIL),
+          ["release/3.6"])
+    check("push:#c — not a key in YAML",
+          parse("on:\n  push:#c\n    branches:\n      - release/3.6\n" + TAIL),
+          REFUSE_NO_PUSH)
 
-    # A branch named only by another trigger is not a deploy pin.
-    other = ("on:\n  push:\n    branches:\n      - release/3.6\n"
+    # A branch named by another trigger is not a deploy pin — in either order.
+    after = ("on:\n  push:\n    branches:\n      - release/3.6\n"
              "  pull_request:\n    branches:\n      - release/3.7\n" + TAIL)
-    if parse(other) != ["release/3.6"]:
-        failures.append(f"pull_request leak: got {parse(other)}")
+    check("pull_request after push", parse(after), ["release/3.6"])
+    before = ("on:\n  pull_request:\n    branches:\n      - release/3.5\n"
+              "  push:\n    branches:\n      - release/3.6\n" + TAIL)
+    check("pull_request before push", parse(before), ["release/3.6"])
 
-    # Round trip: repointing preserves comment, quoting and indentation.
+    # --list is the contract the workflow greps with `-Fxq`: one name per line.
+    rc, out, _ = run_cli(HEAD + "    branches:\n      - release/3.6\n" + TAIL, ["--list"])
+    check("--list rc", rc, 0)
+    check("--list output", out, "release/3.6\n")
+
+    # Repointing rewrites the name and nothing else.
     src = ("on:\n  push:\n    branches:\n      # publishing branch\n"
            '      - "release/3.6"  # deploy\n    paths:\n      - x\n' + TAIL)
-    with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as fh:
-        fh.write(src)
-        path = fh.name
-    os.environ["DEPLOY_YML"] = path
-    sys.argv = ["docs-deploy-trigger.py", "--repoint", "release/3.7"]
-    mod.main()
-    out = open(path).read()
-    os.unlink(path)
-    want = src.replace('"release/3.6"', '"release/3.7"')
-    if out != want:
-        failures.append("round trip changed more than the branch name:\n" + out)
+    rc, _, result = run_cli(src, ["--repoint", "release/3.7"])
+    check("repoint rc", rc, 0)
+    check("repoint round trip", result, src.replace('"release/3.6"', '"release/3.7"'))
 
-    for f in failures:
+    # Already pinned is a no-op, not a failure: the workflow's step would
+    # otherwise try to commit an unchanged tree and go red.
+    pinned = HEAD + "    branches:\n      - release/3.7\n" + TAIL
+    rc, out, result = run_cli(pinned, ["--repoint", "release/3.7"])
+    check("already-pinned rc", rc, 0)
+    check("already-pinned is a no-op", result, pinned)
+    check("already-pinned says so", "already pins release/3.7" in out, True)
+
+    # An ambiguous list must not be rewritten by guesswork.
+    two = HEAD + "    branches:\n      - release/3.6\n      - release/3.5\n" + TAIL
+    rc, out, result = run_cli(two, ["--repoint", "release/3.7"])
+    check("two entries refuses", rc != 0 or "expected exactly one" in out, True)
+    check("two entries unchanged", result, two)
+
+    total = len(ACCEPTED) + len(REJECTED) + 12
+    for f in FAILURES:
         print("FAIL", f)
-    print(f"{len(CASES) + 2 - len(failures)}/{len(CASES) + 2} passed")
-    return 1 if failures else 0
+    print(f"{total - len(FAILURES)}/{total} passed")
+    return 1 if FAILURES else 0
 
 
 if __name__ == "__main__":

--- a/.github/workflows/scripts/docs-deploy-trigger.test.py
+++ b/.github/workflows/scripts/docs-deploy-trigger.test.py
@@ -28,7 +28,14 @@ spec.loader.exec_module(mod)
 FAILURES = []
 
 
+CHECKS = 0
+
+
 def check(name, got, want):
+    """Record one assertion. Counted, not hardcoded — a hand-maintained total
+    drifts, and then a real failure prints a denominator nobody trusts."""
+    global CHECKS
+    CHECKS += 1
     if got != want:
         FAILURES.append(f"{name}: got {got!r}, want {want!r}")
 
@@ -88,7 +95,6 @@ ACCEPTED = [
      "    branches:\n# publishing branch\n      - release/3.6\n", ["release/3.6"]),
     ("blank line in the list", "    branches:\n\n      - release/3.6\n", ["release/3.6"]),
     ("dash at the key's indent", "    branches:\n    - release/3.6\n", ["release/3.6"]),
-    ("tab-indented entry", "    branches:\n\t- release/3.6\n", ["release/3.6"]),
     ("extra spaces after dash", "    branches:\n      -    release/3.6\n", ["release/3.6"]),
     ("trailing whitespace", "    branches:\n      - release/3.6   \n", ["release/3.6"]),
     ("comment on the branches: key",
@@ -101,6 +107,16 @@ ACCEPTED = [
 
 # Shapes YAML itself does not read as a branches list. Accepting one would
 # report a pin the deploy trigger does not have.
+# Shapes a real YAML parser does not read as a one-branch list. The parser must
+# not name a branch for any of them: reporting a pin the deploy trigger does not
+# have is the failure that flips the variable to a branch that never publishes.
+NOT_A_PIN = [
+    ("tab indentation — invalid YAML", "    branches:\n\t- release/3.6\n", []),
+    ("no space after the dash", "    branches:\n      -release/3.6\n", []),
+    ("trailing junk after the name", "    branches:\n      - release/3.6 x\n", []),
+    ("mismatched quotes", "    branches:\n      - 'release/3.6\"\n", []),
+]
+
 REJECTED = [
     ("branches:#c — not a key in YAML",
      "    branches:#c\n      - release/3.6\n", REFUSE_NO_LIST),
@@ -111,7 +127,7 @@ REJECTED = [
 
 
 def run():
-    for name, body, want in ACCEPTED + REJECTED:
+    for name, body, want in ACCEPTED + NOT_A_PIN + REJECTED:
         check(name, parse(HEAD + body + TAIL), want)
 
     check("comment on the push: key",
@@ -129,10 +145,20 @@ def run():
               "  push:\n    branches:\n      - release/3.6\n" + TAIL)
     check("pull_request before push", parse(before), ["release/3.6"])
 
-    # --list is the contract the workflow greps with `-Fxq`: one name per line.
+    # A comment at the key's own indent must not close the block.
+    keyc = ("on:\n  push:\n    # which branch publishes\n    branches:\n"
+            "      - release/3.6\n    paths:  # only the site\n      - x\n" + TAIL)
+    check("comment at key indent, comment on closing key", parse(keyc), ["release/3.6"])
+
+    # --list is the contract the workflow greps with `-Fxq`: ONE NAME PER LINE.
+    # Verified with two entries, because a single entry cannot distinguish a
+    # newline-joined list from a space-joined one.
     rc, out, _ = run_cli(HEAD + "    branches:\n      - release/3.6\n" + TAIL, ["--list"])
     check("--list rc", rc, 0)
     check("--list output", out, "release/3.6\n")
+    _, out2, _ = run_cli(
+        HEAD + "    branches:\n      - release/3.6\n      - release/3.5\n" + TAIL, ["--list"])
+    check("--list is one name per line", out2, "release/3.6\nrelease/3.5\n")
 
     # Repointing rewrites the name and nothing else.
     src = ("on:\n  push:\n    branches:\n      # publishing branch\n"
@@ -149,16 +175,30 @@ def run():
     check("already-pinned is a no-op", result, pinned)
     check("already-pinned says so", "already pins release/3.7" in out, True)
 
+    # A quoted entry with no trailing comment must round trip unchanged apart
+    # from the name — the trail group is empty here, not absent.
+    q = HEAD + "    branches:\n      - 'release/3.6'\n" + TAIL
+    rc, _, result = run_cli(q, ["--repoint", "release/3.7"])
+    check("quoted entry, no trail, rc", rc, 0)
+    check("quoted entry, no trail", result, q.replace("'release/3.6'", "'release/3.7'"))
+
+    # A list the parser cannot read must refuse, not traceback or guess.
+    empty = HEAD + "    branches:\n      -release/3.6\n" + TAIL
+    rc, out, result = run_cli(empty, ["--repoint", "release/3.7"])
+    check("unreadable list refuses", rc != 0, True)
+    check("unreadable list unchanged", result, empty)
+
     # An ambiguous list must not be rewritten by guesswork.
     two = HEAD + "    branches:\n      - release/3.6\n      - release/3.5\n" + TAIL
     rc, out, result = run_cli(two, ["--repoint", "release/3.7"])
-    check("two entries refuses", rc != 0 or "expected exactly one" in out, True)
+    # rc, not the message: a mutant that prints the refusal and returns 0 would
+    # let the step go on to commit an unchanged tree and fail there instead.
+    check("two entries refuses", rc != 0, True)
     check("two entries unchanged", result, two)
 
-    total = len(ACCEPTED) + len(REJECTED) + 12
     for f in FAILURES:
         print("FAIL", f)
-    print(f"{total - len(FAILURES)}/{total} passed")
+    print(f"{CHECKS - len(FAILURES)}/{CHECKS} passed")
     return 1 if FAILURES else 0
 
 

--- a/.github/workflows/scripts/docs-deploy-trigger.test.py
+++ b/.github/workflows/scripts/docs-deploy-trigger.test.py
@@ -2,19 +2,39 @@
 """Fixture tests for docs-deploy-trigger.py.
 
 Run: python3 .github/workflows/scripts/docs-deploy-trigger.test.py
+     python3 .github/workflows/scripts/docs-deploy-trigger.test.py --oracle
 
 Every case is a YAML shape a human might write into docs-deploy.yml's
 `on.push.branches`. They exist because the cutover workflow's "is this trigger
-pinned?" check and its rewrite read the same list: when the two disagree, the
-check reports "not pinned", the rewrite reports "already pinned", and the job
-fails on every scheduled run. The negative cases matter as much as the positive
-ones — a parser that accepts a shape YAML itself rejects reports a pin that the
-deploy trigger does not actually have.
+pinned?" check and its rewrite read the same list, and because both directions
+of a wrong answer cost something: naming a branch `on.push.branches` does not
+contain makes the cutover flip the deploy variable to a branch that never
+publishes, and failing to see a pin that IS there makes it open a repoint pull
+request that is not needed and fail while trying.
+
+Reading is delegated to PyYAML, so these fixtures are not re-implementing a
+parser's job; they pin down THIS script's contract on top of it -- which key it
+reads, what it refuses, and that a rewrite touches nothing but the name.
+
+`--oracle` additionally re-reads every fixture with an unrelated YAML
+implementation (js-yaml, via docs-deploy-trigger.oracle.mjs) and requires the
+two to agree. Run it whenever the reader changes: without it the fixtures are
+only ever checked against the same library that produced them. It is not part
+of the default run because js-yaml is a Node dependency this repo does not
+otherwise need, and a check that quietly skips itself is worse than none.
+
+    JS_YAML_FROM=docs/site python3 .../docs-deploy-trigger.test.py --oracle
+
+JS_YAML_FROM names a directory whose node_modules has js-yaml; docs/site does
+once its dependencies are installed.
 """
 import contextlib
 import importlib.util
 import io
+import json
 import os
+import shutil
+import subprocess
 import sys
 import tempfile
 
@@ -25,8 +45,9 @@ assert spec is not None and spec.loader is not None
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
 
-FAILURES = []
+ORACLE = os.path.join(HERE, "docs-deploy-trigger.oracle.mjs")
 
+FAILURES = []
 
 CHECKS = 0
 
@@ -41,22 +62,28 @@ def check(name, got, want):
 
 
 def parse(text):
-    """Branch names, or the refusal message — never an escaping SystemExit.
+    """Branch names, or the refusal reason — never an escaping exception.
 
-    A refusal must be comparable data: letting SystemExit propagate kills the
-    run and hides every result gathered so far, so a regression shows up as one
-    stray line instead of a report.
+    A refusal must be comparable data: letting it propagate kills the run and
+    hides every result gathered so far, so a regression shows up as one stray
+    line instead of a report. The reason is reduced to a tag because PyYAML's
+    own message wording is not this script's contract.
     """
     try:
-        lo, hi = mod.branch_span(text)
-        return mod.entries(text[lo:hi])
-    except SystemExit as e:
-        return f"REFUSED: {e}"
+        return [node.value for node in mod.branch_nodes(text)]
+    except mod.Unreadable as exc:
+        text = str(exc)
+        if text.startswith("not valid YAML"):
+            return "INVALID"
+        if "has a non-string entry" in text:
+            return "NON_STRING"
+        return "NO_LIST"
 
 
 def run_cli(text, argv):
     """Run main() over `text`, returning (rc, stdout, resulting file)."""
-    with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as fh:
+    with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False,
+                                     newline="") as fh:
         fh.write(text)
         path = fh.name
     os.environ["DEPLOY_YML"] = path
@@ -69,16 +96,32 @@ def run_cli(text, argv):
         rc = e.code if isinstance(e.code, int) else 1
         if e.code and not isinstance(e.code, int):
             out.write(str(e.code))
-    result = open(path).read()
+    with open(path, encoding="utf-8", newline="") as fh:
+        result = fh.read()
     os.unlink(path)
     return rc, out.getvalue(), result
 
 
+def oracle_read(text):
+    """What an unrelated YAML implementation makes of the same document."""
+    with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False,
+                                     newline="") as fh:
+        fh.write(text)
+        path = fh.name
+    try:
+        proc = subprocess.run(["node", ORACLE, path],
+                              capture_output=True, text=True, check=True)
+    finally:
+        os.unlink(path)
+    return json.loads(proc.stdout)
+
+
 HEAD = "on:\n  push:\n"
 TAIL = "\npermissions:\n  contents: read\n"
-REFUSE_NO_LIST = "REFUSED: the push: trigger has no branches: list - refusing to edit blindly"
-REFUSE_NO_PUSH = "REFUSED: docs-deploy.yml has no push: trigger - refusing to edit blindly"
 
+# Shapes that name a branch, and the names they name. A real parser reads all
+# of these; the earlier hand-rolled matcher did not, and each miss made the
+# workflow act on a pin it could not see.
 ACCEPTED = [
     ("plain", "    branches:\n      - release/3.6\n", ["release/3.6"]),
     ("paths after branches",
@@ -103,39 +146,201 @@ ACCEPTED = [
      "    branches:\n      - release/3.6#keep\n", ["release/3.6#keep"]),
     ("two entries", "    branches:\n      - release/3.6\n      - release/3.5\n",
      ["release/3.6", "release/3.5"]),
+    # Round-11 findings: every one of these is a list GitHub acts on, and the
+    # regex parser reported no branches for all of them.
+    ("flow sequence", "    branches: [release/3.6]\n", ["release/3.6"]),
+    ("flow sequence, quoted", '    branches: ["release/3.6"]\n', ["release/3.6"]),
+    ("flow sequence, padded", "    branches: [ release/3.6 ]\n", ["release/3.6"]),
+    ("flow sequence, two", "    branches: [release/3.6, main]\n", ["release/3.6", "main"]),
+    ("flow sequence, empty", "    branches: []\n", []),
+    ("folded scalar entry",
+     "    branches:\n      - >-\n          release/3.6\n", ["release/3.6"]),
+    ("literal scalar entry",
+     "    branches:\n      - |-\n          release/3.6\n", ["release/3.6"]),
+    ("explicitly tagged entry",
+     "    branches:\n      - !!str release/3.6\n", ["release/3.6"]),
+    ("anchored list", "    branches: &b\n      - release/3.6\n    tags: *b\n", ["release/3.6"]),
+    # A plain scalar may contain spaces, so this is a one-branch list whose
+    # branch happens not to exist. The workflow greps for an exact line, so it
+    # reads as "not pinned" — which is right — but the name is reported as YAML
+    # reads it, not silently dropped.
+    ("space inside the name", "    branches:\n      - release/3.6 x\n", ["release/3.6 x"]),
 ]
 
-# Shapes YAML itself does not read as a branches list. Accepting one would
-# report a pin the deploy trigger does not have.
-# Shapes a real YAML parser does not read as a one-branch list. The parser must
-# not name a branch for any of them: reporting a pin the deploy trigger does not
-# have is the failure that flips the variable to a branch that never publishes.
-NOT_A_PIN = [
-    ("tab indentation — invalid YAML", "    branches:\n\t- release/3.6\n", []),
-    ("no space after the dash", "    branches:\n      -release/3.6\n", []),
-    ("trailing junk after the name", "    branches:\n      - release/3.6 x\n", []),
-    ("mismatched quotes", "    branches:\n      - 'release/3.6\"\n", []),
-]
-
-REJECTED = [
+# Documents no YAML parser reads as a branch list. Refusing is the point: these
+# are the shapes where guessing invents a pin.
+REFUSED = [
+    # `- release/3.6` indented BELOW its own key. The compact form allows a dash
+    # only at exactly the key's indentation; less than that closes the mapping
+    # and leaves a stray sequence, which is why every parser rejects the
+    # document. The regex parser read it as a pin, and the chain from there was
+    # the worst one available: repoint considered done, variable flipped, and a
+    # docs-deploy.yml GitHub cannot load at all.
+    ("dash indented below the key", "    branches:\n  - release/3.6\n", "INVALID"),
+    ("tab indentation", "    branches:\n\t- release/3.6\n", "INVALID"),
+    ("mismatched quotes, '..\"", "    branches:\n      - 'release/3.6\"\n", "INVALID"),
+    # Both quote polarities, because a check that only ever sees one of them
+    # passes for a parser that handles only that one.
+    ('mismatched quotes, "..\'', '    branches:\n      - "release/3.6\'\n', "INVALID"),
+    # `-release/3.6` is the plain scalar "-release/3.6", so `branches` is a
+    # string, not a list.
+    ("no space after the dash", "    branches:\n      -release/3.6\n", "NO_LIST"),
     ("branches:#c — not a key in YAML",
-     "    branches:#c\n      - release/3.6\n", REFUSE_NO_LIST),
+     "    branches:#c\n      - release/3.6\n", "NO_LIST"),
+    ("branches: with no value", "    branches:\n", "NO_LIST"),
+    # A different key entirely; it must not be mistaken for `branches:`.
+    ("branches-ignore only", "    branches-ignore:\n      - main\n", "NO_LIST"),
     ("push: with only paths, pull_request lists branches later",
      "    paths:\n      - x\n  pull_request:\n    branches:\n      - release/3.6\n",
-     REFUSE_NO_LIST),
+     "NO_LIST"),
+    # Entries that resolve to something other than a string are not branch
+    # names, and comparing one to a branch is the silent mismatch this script
+    # exists to prevent.
+    ("numeric entry", "    branches:\n      - 3.6\n", "NON_STRING"),
+    ("nested sequence entry", "    branches:\n      - - release/3.6\n", "NON_STRING"),
+    ("mapping entry", "    branches:\n      - name: release/3.6\n", "NON_STRING"),
+    # A duplicate key has no single right answer: js-yaml raises, and PyYAML's
+    # loader keeps the LAST occurrence while a node walk would naturally take
+    # the first. Taking the first would report `release/3.6` for a document
+    # whose effective value is `main`, repoint the losing copy, and pass its own
+    # pre-write verification. Refusing is the only reading that cannot be wrong.
+    ("duplicate branches: key",
+     "    branches:\n      - release/3.6\n    branches:\n      - main\n", "NO_LIST"),
+]
+
+# A tab used as separation whitespace after the dash, or a tab-only blank line.
+# js-yaml accepts both; PyYAML and libyaml (the reference C implementation)
+# reject both. We follow the two that reject, and record the disagreement here
+# rather than leaving it to be rediscovered: the direction is the safe one. A
+# refusal makes `detect` warn that the branch is not pinned and hold, and makes
+# `prepare` fail loudly during a cutover; neither can invent a pin. actionlint
+# and yamllint both flag tabs, so a shape like this does not survive review.
+TAB_DIVERGENCE = [
+    ("tab after the dash", "    branches:\n    -\trelease/3.6\n", "INVALID"),
+    ("tab-only blank line inside the list",
+     "    branches:\n      - release/3.6\n\t\n    paths:\n      - x\n", "INVALID"),
+]
+
+# Repoint cases: (label, body, the exact substring the rewrite must change).
+# Checking a substring swap rather than a recomputed expectation keeps the
+# assertion honest about the promise — one name, nothing else.
+ROUND_TRIP = [
+    ("plain", "    branches:\n      - release/3.6\n", "release/3.6", "release/3.7"),
+    ("single quotes", "    branches:\n      - 'release/3.6'\n",
+     "'release/3.6'", "'release/3.7'"),
+    ("double quotes", '    branches:\n      - "release/3.6"\n',
+     '"release/3.6"', '"release/3.7"'),
+    ("comment preserved", "    branches:\n      - release/3.6  # deploy\n",
+     "- release/3.6  # deploy", "- release/3.7  # deploy"),
+    ("flow sequence", "    branches: [release/3.6]\n", "[release/3.6]", "[release/3.7]"),
+    ("flow sequence, padded", "    branches: [ release/3.6 ]\n",
+     "[ release/3.6 ]", "[ release/3.7 ]"),
+    ("dash at the key's indent", "    branches:\n    - release/3.6\n",
+     "    - release/3.6", "    - release/3.7"),
 ]
 
 
 def run():
-    for name, body, want in ACCEPTED + NOT_A_PIN + REJECTED:
-        check(name, parse(HEAD + body + TAIL), want)
+    oracle = "--oracle" in sys.argv
+    if oracle and not shutil.which("node"):
+        print("--oracle requested but node is not available; refusing to skip")
+        return 1
+    if oracle:
+        # Fail before running 300 comparisons that would all report the same
+        # missing dependency.
+        # Probed with a real document, not a missing path: the oracle exits 2
+        # on an unreadable file too, and a probe that cannot tell "js-yaml is
+        # missing" from "that path does not exist" would report the wrong
+        # reason. Requiring a parsed answer also exercises the whole path once
+        # before 300 comparisons rely on it.
+        with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False,
+                                         newline="") as fh:
+            fh.write(HEAD + "    branches:\n      - release/3.6\n" + TAIL)
+            probe_path = fh.name
+        try:
+            probe = subprocess.run(["node", ORACLE, probe_path],
+                                   capture_output=True, text=True)
+        finally:
+            os.unlink(probe_path)
+        if probe.returncode != 0 or '"status":"ok"' not in probe.stdout.replace(" ", ""):
+            detail = (probe.stderr or probe.stdout).strip()
+            print(f"--oracle requested but unusable: {detail}")
+            return 1
+
+    corpus = []
+    for name, body, want in ACCEPTED + REFUSED + TAB_DIVERGENCE:
+        src = HEAD + body + TAIL
+        check(name, parse(src), want)
+        corpus.append((name, src, want))
+        # Line endings are not content. Every shape must read the same with
+        # CRLF, which the regex parser refused outright.
+        crlf = src.replace("\n", "\r\n")
+        check(f"CRLF {name}", parse(crlf), want)
+        corpus.append((f"CRLF {name}", crlf, want))
 
     check("comment on the push: key",
           parse("on:\n  push:  # publish\n    branches:\n      - release/3.6\n" + TAIL),
           ["release/3.6"])
+    # `push:#c` is a plain scalar, not a key, so the more-indented block under
+    # it makes the whole document invalid. Both parsers agree.
     check("push:#c — not a key in YAML",
           parse("on:\n  push:#c\n    branches:\n      - release/3.6\n" + TAIL),
-          REFUSE_NO_PUSH)
+          "INVALID")
+    check("no on: block at all",
+          parse("jobs:\n  build:\n    runs-on: ubuntu-latest\n"), "NO_LIST")
+    check("empty file", parse(""), "NO_LIST")
+    # The MESSAGE, not just the refusal: `parse()` reduces both an empty file
+    # and a missing `on:` to NO_LIST, so the dedicated empty-file branch could
+    # be deleted with the suite still green — while docs-cutover.yml's detect
+    # step has a comment that names this exact wording as the reason it does
+    # not parse an empty file at all.
+    rc, out, _ = run_cli("", ["--list"])
+    check("empty file rc", rc, 1)
+    check("empty file names the reason", "the file is empty" in out, True)
+    # `on: push` with no configuration has no branch list to read.
+    check("on: as a bare string", parse("on: push\n" + TAIL), "NO_LIST")
+    # Quoted to dodge YAML 1.1's on/off booleans — the same trigger, and it
+    # must read the same. This is read at node level precisely so that the
+    # 1.1-vs-1.2 resolution of a bare `on` never enters into it.
+    # Every spelling that still composes to the scalar key `on`: both quote
+    # polarities and the explicit-key form. All three are the same trigger, and
+    # a check that only ever sees one of them passes for a reader that handles
+    # only that one.
+    for label, doc in (
+        ('double-quoted "on"', '"on":\n  push:\n    branches:\n      - release/3.6\n'),
+        ("single-quoted 'on'", "'on':\n  push:\n    branches:\n      - release/3.6\n"),
+        ("explicit key ? on", "? on\n:\n  push:\n    branches:\n      - release/3.6\n"),
+    ):
+        check(f"{label} key", parse(doc + TAIL), ["release/3.6"])
+    # ...but capitalisation is not that difference. GitHub parses workflows
+    # with the `yaml` npm package (YAML 1.2, where `on` is a string, not a
+    # boolean) and matches the literal lowercase key from its own schema, so
+    # `On:` is a different key and the file has no push trigger at all.
+    # Reading a pin out of it would report a pin that does not publish.
+    for key in ("On", "ON"):
+        check(f"{key}: is not a trigger",
+              parse(f"{key}:\n  push:\n    branches:\n      - release/3.6\n" + TAIL),
+              "NO_LIST")
+
+    # A tag GitHub cannot resolve makes the whole workflow unloadable, and a
+    # custom-tagged mapping still composes to a MappingNode — so each node on
+    # the path is checked, or the pre-write verification would bless a file
+    # Actions rejects.
+    for label, doc in (
+        ("on", "on: !nope\n  push:\n    branches:\n      - release/3.6\n"),
+        ("push", "on:\n  push: !nope\n    branches:\n      - release/3.6\n"),
+        ("branches", "on:\n  push:\n    branches: !nope\n      - release/3.6\n"),
+    ):
+        check(f"custom tag on {label}: refused", parse(doc + TAIL), "NO_LIST")
+
+    # ...at every level of the path, not just the innermost one.
+    for label, doc in (
+        ("push", "on:\n  push:\n    branches:\n      - release/3.6\n"
+                 "  push:\n    branches:\n      - main\n"),
+        ("on", "on:\n  push:\n    branches:\n      - release/3.6\n"
+               "on:\n  push:\n    branches:\n      - main\n"),
+    ):
+        check(f"duplicate {label}: key refused", parse(doc + TAIL), "NO_LIST")
 
     # A branch named by another trigger is not a deploy pin — in either order.
     after = ("on:\n  push:\n    branches:\n      - release/3.6\n"
@@ -145,10 +350,15 @@ def run():
               "  push:\n    branches:\n      - release/3.6\n" + TAIL)
     check("pull_request before push", parse(before), ["release/3.6"])
 
-    # A comment at the key's own indent must not close the block.
     keyc = ("on:\n  push:\n    # which branch publishes\n    branches:\n"
             "      - release/3.6\n    paths:  # only the site\n      - x\n" + TAIL)
     check("comment at key indent, comment on closing key", parse(keyc), ["release/3.6"])
+
+    # A second document in the stream is not a workflow GitHub would load, and
+    # reading the branch list out of one of them is a guess about which.
+    check("multi-document stream",
+          parse(HEAD + "    branches:\n      - release/3.6\n" + TAIL + "---\non:\n  push:\n"),
+          "INVALID")
 
     # --list is the contract the workflow greps with `-Fxq`: ONE NAME PER LINE.
     # Verified with two entries, because a single entry cannot distinguish a
@@ -160,12 +370,55 @@ def run():
         HEAD + "    branches:\n      - release/3.6\n      - release/3.5\n" + TAIL, ["--list"])
     check("--list is one name per line", out2, "release/3.6\nrelease/3.5\n")
 
-    # Repointing rewrites the name and nothing else.
-    src = ("on:\n  push:\n    branches:\n      # publishing branch\n"
-           '      - "release/3.6"  # deploy\n    paths:\n      - x\n' + TAIL)
-    rc, _, result = run_cli(src, ["--repoint", "release/3.7"])
-    check("repoint rc", rc, 0)
-    check("repoint round trip", result, src.replace('"release/3.6"', '"release/3.7"'))
+    # Repointing rewrites the name and nothing else, in every shape and under
+    # both line endings.
+    for label, body, old, new in ROUND_TRIP:
+        for eol, join in (("LF", "\n"), ("CRLF", "\r\n")):
+            src = (HEAD + body + TAIL).replace("\n", join)
+            rc, _, result = run_cli(src, ["--repoint", "release/3.7"])
+            check(f"repoint {label} ({eol}) rc", rc, 0)
+            check(f"repoint {label} ({eol})", result,
+                  src.replace(old.replace("\n", join), new.replace("\n", join)))
+
+    # A folded entry cannot be edited in place without collapsing it, so this
+    # one is checked for what it must be rather than for a substring swap: one
+    # line, the new name, and a file that still parses.
+    folded = HEAD + "    branches:\n      - >-\n          release/3.6\n" + TAIL
+    rc, _, result = run_cli(folded, ["--repoint", "release/3.7"])
+    check("repoint folded rc", rc, 0)
+    check("repoint folded collapses to one entry", parse(result), ["release/3.7"])
+    check("repoint folded keeps the rest of the file", result.endswith(TAIL), True)
+
+    # Same for the styles whose node span is wider than the name itself: the
+    # anchor, the explicit tag and the block header are inside the span, so
+    # repointing collapses them to a plain scalar. Asserted rather than left to
+    # chance, because "the edit touches only the name" is not what happens and
+    # the tests should say which it is.
+    for label, body, keeps in (
+        ("anchored entry", "    branches:\n      - &pin release/3.6 # target\n",
+         "# target"),
+        ("tagged entry", "    branches:\n      - !!str release/3.6\n", None),
+        ("block header with a comment",
+         "    branches:\n      - |- # suppress the newline\n          release/3.6\n",
+         None),
+    ):
+        src = HEAD + body + TAIL
+        rc, _, result = run_cli(src, ["--repoint", "release/3.7"])
+        check(f"repoint {label} rc", rc, 0)
+        check(f"repoint {label} reads as one entry", parse(result), ["release/3.7"])
+        check(f"repoint {label} keeps the rest of the file",
+              result.endswith(TAIL), True)
+        if keeps:
+            check(f"repoint {label} keeps its trailing comment", keeps in result, True)
+
+    # The one case where dropping the anchor would change meaning: something
+    # else aliases it. The rewrite is then unparseable, and the pre-write
+    # verification refuses rather than landing an undefined alias.
+    aliased = ("on:\n  push:\n    branches:\n      - &pin release/3.6\n"
+               "  pull_request:\n    branches: [*pin]\n" + TAIL)
+    rc, _, result = run_cli(aliased, ["--repoint", "release/3.7"])
+    check("aliased anchor refuses", rc != 0, True)
+    check("aliased anchor unchanged", result, aliased)
 
     # Already pinned is a no-op, not a failure: the workflow's step would
     # otherwise try to commit an unchanged tree and go red.
@@ -175,30 +428,75 @@ def run():
     check("already-pinned is a no-op", result, pinned)
     check("already-pinned says so", "already pins release/3.7" in out, True)
 
-    # A quoted entry with no trailing comment must round trip unchanged apart
-    # from the name — the trail group is empty here, not absent.
-    q = HEAD + "    branches:\n      - 'release/3.6'\n" + TAIL
-    rc, _, result = run_cli(q, ["--repoint", "release/3.7"])
-    check("quoted entry, no trail, rc", rc, 0)
-    check("quoted entry, no trail", result, q.replace("'release/3.6'", "'release/3.7'"))
+    # Refusals must leave the file alone. A partial rewrite of a workflow file
+    # is the one outcome worse than not rewriting it.
+    for label, body in (
+        ("unreadable list", "    branches:\n      -release/3.6\n"),
+        ("two entries", "    branches:\n      - release/3.6\n      - release/3.5\n"),
+        ("empty list", "    branches: []\n"),
+        ("invalid document", "    branches:\n  - release/3.6\n"),
+        ("non-string entry", "    branches:\n      - 3.6\n"),
+    ):
+        src = HEAD + body + TAIL
+        rc, _, result = run_cli(src, ["--repoint", "release/3.7"])
+        # rc, not the message: a mutant that prints the refusal and returns 0
+        # would let the step go on to commit an unchanged tree and fail there.
+        check(f"{label} refuses", rc != 0, True)
+        check(f"{label} unchanged", result, src)
 
-    # A list the parser cannot read must refuse, not traceback or guess.
-    empty = HEAD + "    branches:\n      -release/3.6\n" + TAIL
-    rc, out, result = run_cli(empty, ["--repoint", "release/3.7"])
-    check("unreadable list refuses", rc != 0, True)
-    check("unreadable list unchanged", result, empty)
+    # A bad invocation must say so rather than traceback on a path it never
+    # needed to read.
+    os.environ["DEPLOY_YML"] = os.path.join(HERE, "does-not-exist.yml")
+    for argv in ([], ["--nope"], ["--repoint"], ["--repoint", ""]):
+        sys.argv = ["docs-deploy-trigger.py", *argv]
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                rc = mod.main()
+        except SystemExit as e:
+            rc = e.code if isinstance(e.code, int) else 1
+        except OSError:
+            rc = "OSError"
+        check(f"usage {argv}", rc, 1)
 
-    # An ambiguous list must not be rewritten by guesswork.
-    two = HEAD + "    branches:\n      - release/3.6\n      - release/3.5\n" + TAIL
-    rc, out, result = run_cli(two, ["--repoint", "release/3.7"])
-    # rc, not the message: a mutant that prints the refusal and returns 0 would
-    # let the step go on to commit an unchanged tree and fail there instead.
-    check("two entries refuses", rc != 0, True)
-    check("two entries unchanged", result, two)
+    # The pre-write verification is the guarantee that a rewrite can never land
+    # a file GitHub cannot load, so it is tested directly: a branch name that
+    # would not survive being spliced in as a plain scalar must be refused, not
+    # written.
+    src = HEAD + "    branches:\n      - release/3.6\n" + TAIL
+    # The last one matters most: it splices in as a syntactically valid
+    # one-entry list, so only comparing the parsed name against the requested
+    # one catches it. A check of the entry COUNT alone passes and writes a
+    # branch nobody asked for.
+    for bad in ("release/3.7: x", "[release/3.7", "release/3.7\n      - main",
+                "release/3.7 # do not deploy"):
+        rc, _, result = run_cli(src, ["--repoint", bad])
+        check(f"unsafe name {bad!r} refuses", rc != 0, True)
+        check(f"unsafe name {bad!r} unchanged", result, src)
+
+    if oracle:
+        # The fixtures above were written from what PyYAML does. Checking them
+        # against an unrelated implementation is what makes them evidence about
+        # YAML rather than about PyYAML.
+        known = {name for name, _, _ in TAB_DIVERGENCE}
+        known |= {f"CRLF {name}" for name, _, _ in TAB_DIVERGENCE}
+        for name, src, want in corpus:
+            got = oracle_read(src)
+            if name in known:
+                # Recorded divergence: js-yaml accepts what we refuse. Assert
+                # that it is still exactly this, so the day js-yaml tightens up
+                # (or we stop refusing) the note stops being true out loud.
+                check(f"oracle {name} still diverges", got["status"], "ok")
+                continue
+            if isinstance(want, list):
+                check(f"oracle {name}", (got["status"], got.get("branches")),
+                      ("ok", want))
+            else:
+                check(f"oracle {name} refused by both", got["status"] != "ok", True)
 
     for f in FAILURES:
         print("FAIL", f)
-    print(f"{CHECKS - len(FAILURES)}/{CHECKS} passed")
+    print(f"{CHECKS - len(FAILURES)}/{CHECKS} passed"
+          f"{'' if oracle else ' (run with --oracle to cross-check against js-yaml)'}")
     return 1 if FAILURES else 0
 
 

--- a/.github/workflows/scripts/docs-deploy-trigger.test.py
+++ b/.github/workflows/scripts/docs-deploy-trigger.test.py
@@ -312,6 +312,19 @@ def run():
         ("explicit key ? on", "? on\n:\n  push:\n    branches:\n      - release/3.6\n"),
     ):
         check(f"{label} key", parse(doc + TAIL), ["release/3.6"])
+
+    # ...and a tag on the KEY is not one of them. GitHub's parser rejects an
+    # unresolvable tag, but a lookup comparing only key.value accepts it, so the
+    # key's own tag is checked too. A bare `on` key carries YAML 1.1's BOOLEAN
+    # tag and a quoted one carries the string tag; both are the same trigger, so
+    # the check has to admit both and still refuse anything else.
+    for label, doc in (
+        ("custom tag on the on: key", "!unknown on:\n  push:\n    branches: [release/3.6]\n"),
+        ("custom tag on the push: key", "on:\n  !unknown push:\n    branches: [release/3.6]\n"),
+        ("custom tag on the branches: key",
+         "on:\n  push:\n    !unknown branches: [release/3.6]\n"),
+    ):
+        check(f"{label} refused", parse(doc + TAIL), "NO_LIST")
     # ...but capitalisation is not that difference. GitHub parses workflows
     # with the `yaml` npm package (YAML 1.2, where `on` is a string, not a
     # boolean) and matches the literal lowercase key from its own schema, so
@@ -410,6 +423,29 @@ def run():
               result.endswith(TAIL), True)
         if keeps:
             check(f"repoint {label} keeps its trailing comment", keeps in result, True)
+
+    # `branches: *b` IS the node the anchor named, so its source span sits
+    # wherever that anchor was written. With the anchor on another key, a
+    # span rewrite edits THAT key — repointing rewrote `paths` and the
+    # pre-write check still passed, because the alias made branches read the
+    # new value too. Refused, and the file is left alone.
+    aliased_elsewhere = ("on:\n  push:\n    paths: &b [release/3.6]\n"
+                         "    branches: *b\n" + TAIL)
+    check("branches aliasing another key reads as unreadable",
+          parse(aliased_elsewhere), "NO_LIST")
+    rc, _, result = run_cli(aliased_elsewhere, ["--repoint", "release/3.7"])
+    check("branches aliasing another key refuses", rc != 0, True)
+    check("branches aliasing another key unchanged", result, aliased_elsewhere)
+
+    # The mirror image must still WORK: the anchor on branches itself, aliased
+    # into another key. Those really are one list, so rewriting both is what
+    # the document says.
+    anchor_on_branches = ("on:\n  push:\n    branches: &b\n      - release/3.6\n"
+                          "    tags: *b\n" + TAIL)
+    check("anchor on branches still reads", parse(anchor_on_branches), ["release/3.6"])
+    rc, _, result = run_cli(anchor_on_branches, ["--repoint", "release/3.7"])
+    check("anchor on branches still repoints", rc, 0)
+    check("anchor on branches reads back as one entry", parse(result), ["release/3.7"])
 
     # The one case where dropping the anchor would change meaning: something
     # else aliases it. The rewrite is then unparseable, and the pre-write

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -48,3 +48,30 @@ rules:
   concurrency-limits:
     ignore:
       - ci-cd-main-branch-docker-images.yml
+
+  # docs-cutover.yml's `switch` job writes the DOCS_DEPLOY_BRANCH repository
+  # variable, which needs the release App's `variables` permission. The pinned
+  # actions/create-github-app-token exposes no `permission-variables` input
+  # (v3.2.0 is the newest release and its action.yml has no such key), so any
+  # permission-* list there would mint a token MISSING the one permission the
+  # job exists to use. The token is scoped on the repository axis
+  # (`repositories: "erigon"`) and the job is gated on the
+  # `release-branch-management` environment behind its required reviewers, so
+  # the blanket grant is never reached without a human approving that run.
+  # Drop this ignore once the action gains `permission-variables`.
+  github-app:
+    ignore:
+      - docs-cutover.yml
+
+  # lint.yml installs js-yaml to cross-check the docs-deploy trigger parser
+  # against a second, unrelated YAML implementation. The version is not ad-hoc:
+  # it is read at runtime out of docs/site/package-lock.json, so the lockfile
+  # stays the single source of truth and the two cannot drift. zizmor cannot see
+  # that the version came from a lockfile, only that `npm install` was called.
+  # `npm ci` on docs/site would be lockfile-visible but pulls the whole
+  # Docusaurus tree into a job that runs for every pull request, to load one
+  # module. The apt line beside it installs a DISTRO package (python3-yaml),
+  # deliberately not PyPI, for the same supply-chain reason.
+  adhoc-packages:
+    ignore:
+      - lint.yml


### PR DESCRIPTION
Patch releases already publish themselves. `docs-deploy-cron.yml` wakes daily and dispatches
`docs-deploy.yml` on the branch named by the `DOCS_DEPLOY_BRANCH` repository variable, and that
build resolves its install version with `installableVersion(releases, currentDocsVersion.label)` —
`stableInSeries`, so the newest patch *of the published series*. A v3.6.5 goes live on its own.

A new minor is not that, because it changes the series. Two things have to change, in two places:
the variable, and `on.push.branches` in the `docs-deploy.yml` carried on the new release branch.
Nothing writes the variable — the cron only reads it — so doing neither, which is the default after
any release, leaves the cron rebuilding the previous series indefinitely and advertising that
series' newest patch, with every run green. A new major behaves the same way: both are series
changes.

This adds `docs-cutover.yml`, which runs daily and advances the cutover one step per run:

- **detect** — compares the next stable series against `DOCS_DEPLOY_BRANCH` and reports divergence.
  Read-only. It also reports the half-applied states, where one of the two edits was made and the
  other was not.
- **prepare** — archives the outgoing series via `docs-version-bump.yml` and opens a PR repointing
  the push trigger on the new release branch. Both land as normal PRs and are merged by a human.
- **switch** — flips the variable, then dispatches a deploy. Gated on the
  `release-branch-management` environment, the same gate `create-release-branch.yml` uses for
  release-namespace operations.

Each run reads the desired end state off the target branch rather than tracking pull requests
across runs, so runs are idempotent and no-op when there is nothing to do. It targets the next
series rather than the newest, because a cutover archives the series it replaces.

The trigger edit is not always the same edit. `create-release-branch.yml` cuts from `main` by
default, and `main` has never carried a `docs-deploy.yml`, so a branch cut that way arrives with no
push trigger at all and the file is seeded from the branch currently publishing. A branch cut from
the previous release branch instead inherits a stale pin and is repointed. Both are handled.

The `on.push.branches` list is read with PyYAML rather than matched, and a rewrite is re-parsed and
checked before it is written, so a workflow file Actions cannot load is never committed. The
fixture suite cross-checks itself against js-yaml, and `lint.yml` now runs it.

**Before this can run:** the release App needs the repository `Variables: read and write`
permission. I cannot verify whether it holds it; `switch` fails with the exact grant to make if
not. The `release-branch-management` environment already exists with its required reviewers.

See also docs-side specification: [Erigon Docs — Flow Specification
](https://github.com/erigontech/erigon-documents/blob/master/public-docs/erigon-docs-flow-spec.md)

Draft while the prerequisite above is confirmed and the schedule is reviewed.
