### PR TITLE
cl/persistence/blob_storage: validate the stored inclusion proof shape

### DIFF
--- a/cl/persistence/blob_storage/blob_db.go
+++ b/cl/persistence/blob_storage/blob_db.go
@@ -238,6 +238,9 @@ func VerifyBlobSidecars(sidecars []*cltypes.BlobSidecar, version clparams.StateV
 		if sidecar == nil || sidecar.SignedBlockHeader == nil || sidecar.SignedBlockHeader.Header == nil {
 			return errors.New("blob response contains incomplete sidecar")
 		}
+		if sidecar.CommitmentInclusionProof.Length() != cltypes.CommitmentBranchSize {
+			return errors.New("blob sidecar commitment inclusion proof has the wrong length")
+		}
 		if version < clparams.GloasVersion && !cltypes.VerifyCommitmentInclusionProof(sidecar.KzgCommitment, sidecar.CommitmentInclusionProof, sidecar.Index, clparams.DenebVersion, sidecar.SignedBlockHeader.Header.BodyRoot) {
 			return errors.New("could not verify blob's inclusion proof")
 		}

--- a/cl/persistence/blob_storage/blob_db.go
+++ b/cl/persistence/blob_storage/blob_db.go
@@ -297,6 +297,12 @@ func VerifyAgainstIdentifiersAndInsertIntoTheBlobStore(ctx context.Context, stor
 			break
 		}
 
+		// The reader always decodes a fixed-length proof, so a shorter one would replace a readable
+		// file with an undecodable one. Checked for every version, including those that skip the
+		// proof's contents.
+		if sidecar.CommitmentInclusionProof.Length() != cltypes.CommitmentBranchSize {
+			return 0, 0, errors.New("blob sidecar commitment inclusion proof has the wrong length")
+		}
 		if version < clparams.GloasVersion && !cltypes.VerifyCommitmentInclusionProof(sidecar.KzgCommitment, sidecar.CommitmentInclusionProof, sidecar.Index, clparams.DenebVersion, sidecar.SignedBlockHeader.Header.BodyRoot) {
 			return 0, 0, errors.New("could not verify blob's inclusion proof")
 		}

--- a/cl/persistence/blob_storage/blob_db_test.go
+++ b/cl/persistence/blob_storage/blob_db_test.go
@@ -70,6 +70,45 @@ func TestVerifyBlobSidecarsGloasDoesNotRequireInclusionProof(t *testing.T) {
 	require.Error(t, VerifyBlobSidecars([]*cltypes.BlobSidecar{short}, clparams.GloasVersion, nil))
 }
 
+// Skipping the inclusion-proof check for Gloas must not also skip checking that the sidecar can be
+// encoded in the shape the reader expects: a short proof vector round-trips through the writer but
+// not the reader, so accepting one replaces readable data with a file nothing can decode.
+func TestVerifyAgainstIdentifiersRejectsAShortProofWithoutLosingStoredData(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	bs := NewBlobStore(db, afero.NewMemMapFs())
+
+	blob := goethkzg.Blob{}
+	commitment, err := kzg.Ctx().BlobToKZGCommitment(&blob, 0)
+	require.NoError(t, err)
+	proof, err := kzg.Ctx().ComputeBlobKZGProof(&blob, commitment, 0)
+	require.NoError(t, err)
+	header := &cltypes.SignedBeaconBlockHeader{Header: &cltypes.BeaconBlockHeader{Slot: 1}}
+	blockRoot, err := header.Header.HashSSZ()
+	require.NoError(t, err)
+
+	stored := cltypes.NewBlobSidecar(0, (*cltypes.Blob)(&blob), common.Bytes48(commitment), common.Bytes48(proof), header, solid.NewHashVector(cltypes.CommitmentBranchSize))
+	require.NoError(t, bs.WriteBlobSidecars(t.Context(), blockRoot, []*cltypes.BlobSidecar{stored}))
+	_, found, err := bs.ReadBlobSidecars(t.Context(), 1, blockRoot)
+	require.NoError(t, err)
+	require.True(t, found, "the fixture must start from readable data")
+
+	// What an explicit "kzg_commitment_inclusion_proof": [] decodes to.
+	short := cltypes.NewBlobSidecar(0, (*cltypes.Blob)(&blob), common.Bytes48(commitment), common.Bytes48(proof), header, solid.NewHashVector(0))
+	ids := solid.NewStaticListSSZ[*cltypes.BlobIdentifier](40269, 40)
+	ids.Append(&cltypes.BlobIdentifier{BlockRoot: blockRoot, Index: 0})
+
+	_, inserted, err := VerifyAgainstIdentifiersAndInsertIntoTheBlobStore(t.Context(), bs, ids, []*cltypes.BlobSidecar{short}, clparams.GloasVersion, nil)
+	require.Error(t, err, "a sidecar the reader cannot decode must be rejected before it is written")
+	require.Zero(t, inserted)
+
+	sidecars, found, err := bs.ReadBlobSidecars(t.Context(), 1, blockRoot)
+	require.NoError(t, err)
+	require.True(t, found, "a rejected write must leave the existing sidecar readable")
+	require.Len(t, sidecars, 1)
+	require.Equal(t, stored.CommitmentInclusionProof, sidecars[0].CommitmentInclusionProof)
+}
+
 func setupTestDB(t *testing.T) kv.RwDB {
 	db := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
 	return db

--- a/cl/persistence/blob_storage/blob_db_test.go
+++ b/cl/persistence/blob_storage/blob_db_test.go
@@ -56,6 +56,18 @@ func TestVerifyBlobSidecarsGloasDoesNotRequireInclusionProof(t *testing.T) {
 
 	require.NoError(t, VerifyBlobSidecars([]*cltypes.BlobSidecar{sidecar}, clparams.GloasVersion, nil))
 	require.Error(t, VerifyBlobSidecars([]*cltypes.BlobSidecar{sidecar}, clparams.FuluVersion, nil))
+
+	// Not checking the proof's contents does not make its shape optional: the reader always decodes
+	// a fixed-length vector, so a short one is unreadable once stored.
+	short := cltypes.NewBlobSidecar(
+		0,
+		(*cltypes.Blob)(&blob),
+		common.Bytes48(commitment),
+		common.Bytes48(proof),
+		&cltypes.SignedBeaconBlockHeader{Header: &cltypes.BeaconBlockHeader{}},
+		solid.NewHashVector(0),
+	)
+	require.Error(t, VerifyBlobSidecars([]*cltypes.BlobSidecar{short}, clparams.GloasVersion, nil))
 }
 
 func setupTestDB(t *testing.T) kv.RwDB {


### PR DESCRIPTION
Found while addressing @domiwei's review on #23923; the same defect is on `main`, reached through the Gloas gate that #23868 added.

Skipping the inclusion-proof check from Gloas on also skipped any check that the proof vector has the length the reader expects. `WriteBlobSidecars` encodes a short vector happily, but `ReadBlobSidecars` always constructs a fixed-length proof schema and rejects the shorter encoding. A response carrying an explicit `"kzg_commitment_inclusion_proof": []` therefore **replaces a previously readable sidecar with a file nothing can decode, and reports no error**. The count row still says the blobs are there.

Measured on this branch before the fix: `VerifyAgainstIdentifiersAndInsertIntoTheBlobStore` returns `err=nil, inserted=1`, and the following `ReadBlobSidecars` returns `found=false` where it returned the sidecar a moment earlier. The beacon transaction that records the count is separate, so nothing rolls the replacement back.

The gate appears at two sites and both needed it:

- `VerifyAgainstIdentifiersAndInsertIntoTheBlobStore` — the insert path.
- `VerifyBlobSidecars` — the shared verifier. `cl/das/peer_das.go` passes a version that can be Gloas and writes once verification succeeds, so fixing only the first would have left the same path open.

Whether the proof's *contents* are meaningful is fork-dependent; whether the sidecar is encodable in the shape the reader expects is not. The length is now checked for every version, before anything is written.

Pinned by `TestVerifyAgainstIdentifiersRejectsAShortProofWithoutLosingStoredData`, which asserts both the rejection and that the existing sidecar stays readable, and by an added case in `TestVerifyBlobSidecarsGloasDoesNotRequireInclusionProof`. Removing either check fails its test.

`make lint` clean; `cl/persistence/blob_storage`, `cl/das`, `cl/phase1/network` and `cmd/capcli` pass.