### PR TITLE
[r3.5] cmd/capcli: read the store check's block root from the canonical index

### DIFF
--- a/cmd/capcli/blob_archive_store_check_test.go
+++ b/cmd/capcli/blob_archive_store_check_test.go
@@ -1,0 +1,251 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"errors"
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/persistence/beacon_indicies"
+	"github.com/erigontech/erigon/cl/persistence/blob_storage"
+	blob_mock_services "github.com/erigontech/erigon/cl/persistence/blob_storage/mock_services"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/dbcfg"
+	"github.com/erigontech/erigon/db/kv/memdb"
+	"github.com/erigontech/erigon/db/snapshotsync/freezeblocks"
+	"github.com/spf13/afero"
+)
+
+type storeCheckReader struct {
+	freezeblocks.BeaconSnapshotReader
+	blocks map[uint64]*cltypes.SignedBeaconBlock
+}
+
+func (r *storeCheckReader) ReadBeaconBlockBodyBySlot(_ context.Context, _ kv.Tx, slot uint64) (*cltypes.SignedBeaconBlock, error) {
+	return r.blocks[slot], nil
+}
+
+// storeCheckFixture builds a slot whose sidecars are stored under its canonical root, with the
+// indexed root deliberately different from the block's own hash — which is what a payload-stripped
+// read produces.
+func storeCheckFixture(t *testing.T, slot uint64, commitments int) (kv.RwDB, *storeCheckReader, common.Hash) {
+	t.Helper()
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+	block.Block.Slot = slot
+	for range commitments {
+		block.Block.Body.BlobKzgCommitments.Append(&cltypes.KZGCommitment{})
+	}
+	strippedRoot, err := block.Block.HashSSZ()
+	require.NoError(t, err)
+
+	canonical := common.HexToHash("0xc0ffee")
+	require.NotEqual(t, common.Hash(strippedRoot), canonical, "fixture must keep the two roots distinct")
+	require.NoError(t, db.Update(context.Background(), func(tx kv.RwTx) error {
+		return beacon_indicies.MarkRootCanonical(context.Background(), tx, slot, canonical)
+	}))
+
+	return db, &storeCheckReader{blocks: map[uint64]*cltypes.SignedBeaconBlock{slot: block}}, canonical
+}
+
+// The audit resolved each block's root by hashing a payload-stripped block, so the store lookup
+// always missed and every blob-bearing slot was reported as holding nothing.
+func TestBlobArchiveStoreCheckReadsTheCountUnderTheCanonicalRoot(t *testing.T) {
+	const slot = uint64(1_000)
+	ctrl := gomock.NewController(t)
+	db, reader, canonical := storeCheckFixture(t, slot, 2)
+
+	storage := blob_mock_services.NewMockBlobStorage(ctrl)
+	storage.EXPECT().KzgCommitmentsCount(gomock.Any(), canonical).Return(uint32(2), nil).AnyTimes()
+	storage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Not(canonical)).Return(uint32(0), nil).AnyTimes()
+	// A count-equal slot is only complete if its files are still there.
+	storage.EXPECT().BlobSidecarExists(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
+
+	tx, err := db.BeginRo(t.Context())
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	mismatched, _, err := checkBlobStore(t.Context(), tx, reader, storage, slot, slot, false)
+	require.NoError(t, err)
+	require.Zero(t, mismatched, "a slot complete under its canonical root must not be reported as a gap")
+}
+
+// A check that deletes is unusable on a datadir about to be published from, so discarding a
+// mismatched slot has to be opt-in.
+func TestBlobArchiveStoreCheckDoesNotDeleteUnlessAsked(t *testing.T) {
+	const slot = uint64(1_000)
+	ctrl := gomock.NewController(t)
+	db, reader, _ := storeCheckFixture(t, slot, 2)
+
+	storage := blob_mock_services.NewMockBlobStorage(ctrl)
+	storage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(1), nil).AnyTimes()
+	storage.EXPECT().RemoveBlobSidecars(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	tx, err := db.BeginRo(t.Context())
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	mismatched, _, err := checkBlobStore(t.Context(), tx, reader, storage, slot, slot, false)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), mismatched, "the short slot must still be reported")
+}
+
+// An audit that cannot resolve a slot's root has not checked it, so finishing with
+// mismatchedSlots=0 would be false confidence before publication. The snapshot reader serves block
+// bodies independently of the canonical index, so a missing or partial index is exactly the state
+// this has to surface rather than skip.
+func TestBlobArchiveStoreCheckFailsWhenASlotHasNoCanonicalRoot(t *testing.T) {
+	const slot = uint64(1_000)
+	ctrl := gomock.NewController(t)
+
+	// A readable blob-bearing block with no canonical row for its slot.
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+	block.Block.Slot = slot
+	block.Block.Body.BlobKzgCommitments.Append(&cltypes.KZGCommitment{})
+	reader := &storeCheckReader{blocks: map[uint64]*cltypes.SignedBeaconBlock{slot: block}}
+
+	// Probing the store under a zero root would be meaningless.
+	storage := blob_mock_services.NewMockBlobStorage(ctrl)
+	storage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Times(0)
+
+	tx, err := db.BeginRo(t.Context())
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	mismatched, unresolved, err := checkBlobStore(t.Context(), tx, reader, storage, slot, slot, false)
+	require.Error(t, err, "an unresolvable slot must not let the audit report success")
+	require.Equal(t, uint64(1), unresolved, "the slot must be counted as unchecked")
+	require.Zero(t, mismatched, "an unchecked slot is not a mismatch")
+}
+
+// The opt-in delete flag has to be reachable from the command line, not just present on the struct:
+// a field kong does not turn into a flag leaves --remove-mismatched undefined.
+func TestBlobArchiveStoreCheckExposesTheRemoveFlag(t *testing.T) {
+	var cli struct {
+		BlobArchiveStoreCheck BlobArchiveStoreCheck `cmd:""`
+	}
+	parser, err := kong.New(&cli)
+	require.NoError(t, err)
+
+	_, err = parser.Parse([]string{"blob-archive-store-check", "--datadir", t.TempDir(), "--remove-mismatched"})
+	require.NoError(t, err, "the command must define --remove-mismatched")
+	require.True(t, cli.BlobArchiveStoreCheck.RemoveMismatched, "parsing --remove-mismatched must set the field")
+
+	var defaults struct {
+		BlobArchiveStoreCheck BlobArchiveStoreCheck `cmd:""`
+	}
+	defaultParser, err := kong.New(&defaults)
+	require.NoError(t, err)
+	_, err = defaultParser.Parse([]string{"blob-archive-store-check", "--datadir", t.TempDir()})
+	require.NoError(t, err)
+	require.False(t, defaults.BlobArchiveStoreCheck.RemoveMismatched, "deleting must stay opt-in")
+}
+
+// PruneBelow removes sidecar files but leaves their BlockRootToKzgCommitments rows, so a count can
+// match for a slot whose files are gone. Accepting metadata equality as completeness makes the audit
+// report a clean datadir right before it is published from. The old wrong-root lookup missed every
+// count and flagged these by accident; reading the canonical root removes that accident.
+func TestBlobArchiveStoreCheckFlagsCountEqualSlotsWithNoFiles(t *testing.T) {
+	const slot = uint64(1_000)
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	fs := afero.NewMemMapFs()
+
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+	block.Block.Slot = slot
+	block.Block.Body.BlobKzgCommitments.Append(&cltypes.KZGCommitment{})
+	reader := &storeCheckReader{blocks: map[uint64]*cltypes.SignedBeaconBlock{slot: block}}
+
+	canonical := common.HexToHash("0xc0ffee")
+	require.NoError(t, db.Update(context.Background(), func(tx kv.RwTx) error {
+		return beacon_indicies.MarkRootCanonical(context.Background(), tx, slot, canonical)
+	}))
+
+	sidecar := &cltypes.BlobSidecar{
+		Index:                    0,
+		SignedBlockHeader:        &cltypes.SignedBeaconBlockHeader{Header: &cltypes.BeaconBlockHeader{Slot: slot}},
+		CommitmentInclusionProof: solid.NewHashVector(cltypes.CommitmentBranchSize),
+	}
+	storage := blob_storage.NewBlobStore(db, fs, math.MaxUint64, &clparams.MainnetBeaconConfig, nil)
+	require.NoError(t, storage.WriteBlobSidecars(t.Context(), canonical, []*cltypes.BlobSidecar{sidecar}))
+	// What pruning leaves behind: the bucket directory is gone, the count row is not.
+	require.NoError(t, fs.RemoveAll("0"))
+
+	// The state: the count row survives, the file does not.
+	count, err := storage.KzgCommitmentsCount(t.Context(), canonical)
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), count)
+
+	tx, err := db.BeginRo(t.Context())
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	mismatched, unresolved, err := checkBlobStore(t.Context(), tx, reader,
+		blob_storage.NewBlobStore(db, fs, math.MaxUint64, &clparams.MainnetBeaconConfig, nil), slot, slot, false)
+	require.NoError(t, err)
+	require.Zero(t, unresolved)
+	require.Equal(t, uint64(1), mismatched, "a count-equal slot with no files must not pass the audit")
+}
+
+// --remove-mismatched has to actually delete, not just be parseable.
+func TestBlobArchiveStoreCheckDeletesWhenAsked(t *testing.T) {
+	const slot = uint64(1_000)
+	ctrl := gomock.NewController(t)
+	db, reader, canonical := storeCheckFixture(t, slot, 2)
+
+	storage := blob_mock_services.NewMockBlobStorage(ctrl)
+	storage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(1), nil).AnyTimes()
+	storage.EXPECT().RemoveBlobSidecars(gomock.Any(), slot, canonical).Return(nil).Times(1)
+
+	tx, err := db.BeginRo(t.Context())
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	mismatched, _, err := checkBlobStore(t.Context(), tx, reader, storage, slot, slot, true)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), mismatched)
+}
+
+// A failed delete must stop the run rather than be counted as a successful audit.
+func TestBlobArchiveStoreCheckPropagatesDeleteFailure(t *testing.T) {
+	const slot = uint64(1_000)
+	ctrl := gomock.NewController(t)
+	db, reader, _ := storeCheckFixture(t, slot, 2)
+	wantErr := errors.New("remove failed")
+
+	storage := blob_mock_services.NewMockBlobStorage(ctrl)
+	storage.EXPECT().KzgCommitmentsCount(gomock.Any(), gomock.Any()).Return(uint32(1), nil).AnyTimes()
+	storage.EXPECT().RemoveBlobSidecars(gomock.Any(), gomock.Any(), gomock.Any()).Return(wantErr).AnyTimes()
+
+	tx, err := db.BeginRo(t.Context())
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	_, _, err = checkBlobStore(t.Context(), tx, reader, storage, slot, slot, true)
+	require.ErrorIs(t, err, wantErr, "a failed delete must not be swallowed")
+}

--- a/cmd/capcli/cli.go
+++ b/cmd/capcli/cli.go
@@ -1032,6 +1032,10 @@ func timeRequest(uri, accept, method, body string) (time.Duration, error) {
 }
 
 type BlobArchiveStoreCheck struct {
+	// A partial sidecar set is still worth refetching one blob for, so discarding it is opt-in:
+	// the audit has to be safe to run on a datadir about to be published from.
+	RemoveMismatched bool `help:"delete the stored sidecars and index entry of every mismatched slot instead of only reporting it" default:"false"`
+
 	chainCfg
 	outputFolder
 	FromSlot uint64 `help:"from slot" default:"0"`
@@ -1068,10 +1072,21 @@ func (b *BlobArchiveStoreCheck) Run(ctx *Context) error {
 		return err
 	}
 	defer tx.Rollback()
-	for i := b.FromSlot; i >= targetSlot; i-- {
+	mismatched, unresolved, err := checkBlobStore(ctx, tx, snr, blobStorage, b.FromSlot, targetSlot, b.RemoveMismatched)
+	log.Info("Blob archive store check finished", "mismatchedSlots", mismatched, "unresolvedSlots", unresolved,
+		"scannedFrom", b.FromSlot, "scannedTo", targetSlot, "removed", b.RemoveMismatched)
+	return err
+}
+
+// checkBlobStore reports how many blob-bearing slots hold a different number of sidecars than
+// their block commits to, and how many could not be checked at all. Unresolved slots are an error:
+// an audit that silently skips them reports completeness it never established.
+func checkBlobStore(ctx context.Context, tx kv.Tx, snr freezeblocks.BeaconSnapshotReader, blobStorage blob_storage.BlobStorage, fromSlot, targetSlot uint64, removeMismatched bool) (uint64, uint64, error) {
+	var mismatched, unresolved uint64
+	for i := fromSlot; i >= targetSlot; i-- {
 		blk, err := snr.ReadBeaconBlockBodyBySlot(ctx, tx, i)
 		if err != nil {
-			return err
+			return mismatched, unresolved, err
 		}
 		if blk == nil {
 			continue
@@ -1082,28 +1097,59 @@ func (b *BlobArchiveStoreCheck) Run(ctx *Context) error {
 		if blk.Block.Slot%10_000 == 0 {
 			log.Info("Checking slot", "slot", blk.Block.Slot)
 		}
-		blockRoot, err := blk.Block.HashSSZ()
+		// Sidecars are keyed by the canonical root, and ReadBeaconBlockBodyBySlot returns a block
+		// without its execution payload, so its own hash is not that root.
+		blockRoot, err := beacon_indicies.ReadCanonicalBlockRoot(tx, i)
 		if err != nil {
-			return err
+			return mismatched, unresolved, err
+		}
+		if blockRoot == (common.Hash{}) {
+			unresolved++
+			log.Warn("Slot has no canonical root, cannot be checked", "slot", i)
+			continue
 		}
 
 		haveBlobs, err := blobStorage.KzgCommitmentsCount(ctx, blockRoot)
 		if err != nil {
-			return err
+			return mismatched, unresolved, err
 		}
 		wantBlobs := 0
 		if c := blk.Block.Body.GetBlobKzgCommitments(); c != nil {
 			wantBlobs = c.Len()
 		}
-		if haveBlobs != uint32(wantBlobs) {
-			if err := blobStorage.RemoveBlobSidecars(ctx, i, blockRoot); err != nil {
-				return err
+		// PruneBelow drops sidecar files but leaves their count rows, so a matching count is not
+		// evidence the store can still serve the slot. Stat each expected file rather than reading
+		// it back: the scan runs to the Deneb fork, so decoding every blob is not affordable, and
+		// an absent file is the failure this has to catch.
+		missingIndex := -1
+		if haveBlobs == uint32(wantBlobs) {
+			for idx := 0; idx < wantBlobs; idx++ {
+				present, err := blobStorage.BlobSidecarExists(ctx, i, blockRoot, uint64(idx))
+				if err != nil {
+					return mismatched, unresolved, err
+				}
+				if !present {
+					missingIndex = idx
+					break
+				}
 			}
-			log.Warn("Slot", "slot", i, "have", haveBlobs, "want", wantBlobs)
+		}
+		if haveBlobs != uint32(wantBlobs) || missingIndex >= 0 {
+			mismatched++
+			if removeMismatched {
+				if err := blobStorage.RemoveBlobSidecars(ctx, i, blockRoot); err != nil {
+					return mismatched, unresolved, err
+				}
+			}
+			log.Warn("Slot", "slot", i, "blockRoot", fmt.Sprintf("%x", blockRoot),
+				"have", haveBlobs, "want", wantBlobs, "missingIndex", missingIndex,
+				"removed", removeMismatched)
 		}
 	}
-	log.Info("Blob archive store check passed")
-	return nil
+	if unresolved > 0 {
+		return mismatched, unresolved, fmt.Errorf("%d slots could not be checked: no canonical block root, so the index is incomplete over this range", unresolved)
+	}
+	return mismatched, unresolved, nil
 }
 
 type DumpBlobsSnapshots struct {


### PR DESCRIPTION
Cherry-pick of #23918 to `release/3.5`.

`release/3.5` still derives the store check's block root from `blk.Block.HashSSZ()`, a block read without its execution payload, so the hash never existed on chain and `blob-archive-store-check` reports `have=0` for every slot. The other audit command, `check-blobs-snapshots-count`, is unaffected and is the one used before publishing, so this is a diagnostic fix rather than a publishing risk — but the audit command lying on a branch users run is not worth carrying.

## r3.5-specific adaptations

- **`cmd/capcli/flags.go` dropped.** That file is main's urfave/cli wiring, needed there because a kong struct tag is inert on that path. `capcli` is kong-based here, so the flag comes from the tag directly; `RemoveMismatched` carries main's usage string as `help:`.
- **`TestBlobArchiveStoreCheckExposesTheRemoveFlag` rewritten against kong** rather than dropped, so `--remove-mismatched` stays pinned on this branch. It also asserts the flag defaults to off. Verified by hiding the field with `kong:"-"`: the test then fails with `unknown flag --remove-mismatched`.
- **`NewBlobStore` takes five arguments here and there is no `PruneBelow`.** The test reaches the same state — count row present, files gone — by removing the bucket directory from the in-memory filesystem directly.
- **`mdbxtest.NewTestDB` → `memdb.NewTestDB`.**

Mutation-checked: reverting the production lookup to `blk.Block.HashSSZ()` fails three tests, including `TestBlobArchiveStoreCheckReadsTheCountUnderTheCanonicalRoot`.

`make lint` clean; `cmd/capcli` passes.