### PR TITLE
cl/persistence/blob_storage: validate sidecar structure before dereferencing it

### DIFF
--- a/cl/persistence/blob_storage/blob_db.go
+++ b/cl/persistence/blob_storage/blob_db.go
@@ -280,6 +280,13 @@ func VerifyAgainstIdentifiersAndInsertIntoTheBlobStore(ctx context.Context, stor
 
 	storableSidecars := []*sidecarsPayload{}
 	currentSidecarsPayload := &sidecarsPayload{blockRoot: identifiers.Get(0).BlockRoot}
+	// Structure first: the slot read below and the loop's hashing both go through the nested header,
+	// which a decoded response can leave absent.
+	for _, sidecar := range sidecars {
+		if sidecar == nil || sidecar.SignedBlockHeader == nil || sidecar.SignedBlockHeader.Header == nil {
+			return 0, 0, errors.New("blob response contains incomplete sidecar")
+		}
+	}
 	lastProcessed := sidecars[0].SignedBlockHeader.Header.Slot
 	// Some will be stored, truncate when validation goes to shit
 	for i, sidecar := range sidecars {

--- a/cl/persistence/blob_storage/blob_db.go
+++ b/cl/persistence/blob_storage/blob_db.go
@@ -238,7 +238,7 @@ func VerifyBlobSidecars(sidecars []*cltypes.BlobSidecar, version clparams.StateV
 		if sidecar == nil || sidecar.SignedBlockHeader == nil || sidecar.SignedBlockHeader.Header == nil {
 			return errors.New("blob response contains incomplete sidecar")
 		}
-		if sidecar.CommitmentInclusionProof.Length() != cltypes.CommitmentBranchSize {
+		if sidecar.CommitmentInclusionProof == nil || sidecar.CommitmentInclusionProof.Length() != cltypes.CommitmentBranchSize {
 			return errors.New("blob sidecar commitment inclusion proof has the wrong length")
 		}
 		if version < clparams.GloasVersion && !cltypes.VerifyCommitmentInclusionProof(sidecar.KzgCommitment, sidecar.CommitmentInclusionProof, sidecar.Index, clparams.DenebVersion, sidecar.SignedBlockHeader.Header.BodyRoot) {
@@ -300,7 +300,7 @@ func VerifyAgainstIdentifiersAndInsertIntoTheBlobStore(ctx context.Context, stor
 		// The reader always decodes a fixed-length proof, so a shorter one would replace a readable
 		// file with an undecodable one. Checked for every version, including those that skip the
 		// proof's contents.
-		if sidecar.CommitmentInclusionProof.Length() != cltypes.CommitmentBranchSize {
+		if sidecar.CommitmentInclusionProof == nil || sidecar.CommitmentInclusionProof.Length() != cltypes.CommitmentBranchSize {
 			return 0, 0, errors.New("blob sidecar commitment inclusion proof has the wrong length")
 		}
 		if version < clparams.GloasVersion && !cltypes.VerifyCommitmentInclusionProof(sidecar.KzgCommitment, sidecar.CommitmentInclusionProof, sidecar.Index, clparams.DenebVersion, sidecar.SignedBlockHeader.Header.BodyRoot) {

--- a/cl/persistence/blob_storage/blob_db_test.go
+++ b/cl/persistence/blob_storage/blob_db_test.go
@@ -118,6 +118,31 @@ func TestVerifyAgainstIdentifiersRejectsAShortProofWithoutLosingStoredData(t *te
 	require.Equal(t, stored.CommitmentInclusionProof, sidecars[0].CommitmentInclusionProof)
 }
 
+// A remote response can decode with the nested header absent, and the insert path reads through it
+// before validating anything, so the structural check has to come first.
+func TestVerifyAgainstIdentifiersRejectsAnIncompleteHeader(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	bs := NewBlobStore(db, afero.NewMemMapFs())
+
+	ids := solid.NewStaticListSSZ[*cltypes.BlobIdentifier](40269, 40)
+	ids.Append(&cltypes.BlobIdentifier{BlockRoot: common.HexToHash("0xaa"), Index: 0})
+
+	for _, tc := range []struct {
+		name    string
+		sidecar *cltypes.BlobSidecar
+	}{
+		{"nil signed block header", &cltypes.BlobSidecar{}},
+		{"nil header", &cltypes.BlobSidecar{SignedBlockHeader: &cltypes.SignedBeaconBlockHeader{}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, inserted, err := VerifyAgainstIdentifiersAndInsertIntoTheBlobStore(t.Context(), bs, ids, []*cltypes.BlobSidecar{tc.sidecar}, clparams.DenebVersion, nil)
+			require.Error(t, err)
+			require.Zero(t, inserted)
+		})
+	}
+}
+
 func setupTestDB(t *testing.T) kv.RwDB {
 	db := mdbxtest.NewTestDB(t, dbcfg.ChainDB)
 	return db

--- a/cl/persistence/blob_storage/blob_db_test.go
+++ b/cl/persistence/blob_storage/blob_db_test.go
@@ -102,6 +102,15 @@ func TestVerifyAgainstIdentifiersRejectsAShortProofWithoutLosingStoredData(t *te
 	require.Error(t, err, "a sidecar the reader cannot decode must be rejected before it is written")
 	require.Zero(t, inserted)
 
+	// A JSON null proof decodes to a nil interface rather than a short vector, so the shape check
+	// has to answer that without dereferencing it.
+	nilProof := cltypes.NewBlobSidecar(0, (*cltypes.Blob)(&blob), common.Bytes48(commitment), common.Bytes48(proof), header, solid.NewHashVector(cltypes.CommitmentBranchSize))
+	nilProof.CommitmentInclusionProof = nil
+	_, inserted, err = VerifyAgainstIdentifiersAndInsertIntoTheBlobStore(t.Context(), bs, ids, []*cltypes.BlobSidecar{nilProof}, clparams.GloasVersion, nil)
+	require.Error(t, err, "a nil proof must be an error, not a panic")
+	require.Zero(t, inserted)
+	require.Error(t, VerifyBlobSidecars([]*cltypes.BlobSidecar{nilProof}, clparams.GloasVersion, nil))
+
 	sidecars, found, err := bs.ReadBlobSidecars(t.Context(), 1, blockRoot)
 	require.NoError(t, err)
 	require.True(t, found, "a rejected write must leave the existing sidecar readable")


### PR DESCRIPTION
Follow-up to #23934, which is already merged. Found by @awskii reviewing the same change on #23923 — the fix I added there introduced a panic where the code it replaced returned an error.

The shape check calls `sidecar.CommitmentInclusionProof.Length()` on a `solid.HashVectorSSZ` interface field without checking for nil. A JSON `null` leaves that field nil:

- `BlobSidecar.UnmarshalJSON` pre-fills `tmp.CommitmentInclusionProof` with `NewHashVector(17)`.
- For `null`, encoding/json does not descend into that pointer and calls `SetZero()` on the interface instead.
- So `"kzg_commitment_inclusion_proof": null` yields a nil proof, while `[]` yields a zero-length one.

Measured both, rather than reasoning about encoding/json's behaviour: `null` → `nil == true`, `[]` → `nil == false`.

**This is a regression #23934 introduced.** Previously the unconditional `VerifyCommitmentInclusionProof` handled it — it guards `commitmentInclusionProof == nil` and returns false (cl/cltypes/blob_sidecar.go:154) — so the caller got a clean "could not verify blob's inclusion proof". Now it panics.

Reachable through `capcli chain --blobs` → `retrieveBlobsFromRemoteEndpoint` (JSON decode) → `storeRemoteBlobs`, which checks only the nil sidecar, index and commitment. A response repeating the block's real header, index and commitment passes the root and index matches, then panics. It happens on every fork, because the length check runs before the version gate.

Severity is a tooling crash, not a node halt: the only production caller of the insert path is capcli, and the input is a malformed response from an endpoint the operator chose. The `VerifyBlobSidecars` copy has the same unguarded call; its callers do not take sidecars from JSON, so it is not reachable with nil today — guarded anyway, since the two sites should not disagree.

Both sites now check nil first, matching `blob_sidecar.go:154`. Pinned by a nil-proof case next to the existing `NewHashVector(0)` one; removing the guards panics the test.

`make lint` clean; `cl/persistence/blob_storage`, `cl/das` and `cmd/capcli` pass.

## Second guard: the nested header (`d42a9381c5`)

Raised by Copilot on #23923, and the same defect I filed as #23907 on 2026-09-10.

`VerifyAgainstIdentifiersAndInsertIntoTheBlobStore` dereferences the nested header twice before
validating anything — once to seed `lastProcessed` ahead of the loop, once to hash inside it — so a
response that decodes with `signed_block_header` or its `header` absent panics. `VerifyBlobSidecars`
has guarded exactly this all along; the insert path never did.

The pre-loop read is the one that bites first, so a check placed inside the loop would not help. The
guard therefore runs over the whole slice before the first dereference, reusing the existing
"blob response contains incomplete sidecar" wording.

Unlike the nil-proof guard above, this one is **not** a regression from #23934 — it predates that
change and is present on `main`, `release/3.6` and `release/3.5` alike. It is fixed here because the
surrounding validation is already being corrected, and leaving one field guarded and the next not is
how the next reader gets caught.

Pinned by `TestVerifyAgainstIdentifiersRejectsAnIncompleteHeader`, covering both a nil
`SignedBlockHeader` and a non-nil header struct with a nil `Header`.

Closes #23907.
