### PR TITLE
docs: drop the `make -j<n>` build advice

### DIFF
--- a/docs/site/docs/get-started/installation/index.mdx
+++ b/docs/site/docs/get-started/installation/index.mdx
@@ -343,16 +343,8 @@ git checkout v{ERIGON_VERSION}
 
 Compile the Erigon binary using the `make` command.
 
-Standard Compilation:
-
 ```sh
 make erigon
-```
-
-Fast Compilation (Recommended): to significantly speed up the process, specify the number of processors you want to use with the `-j<n>` option, where `<n>` is the number of processor you want to use (we recommend using a number slightly less than your total core count):
-
-```sh
-make -j<n> erigon
 ```
 
 The resulting executable binary will be created in the `./build/bin/erigon` path.

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -634,16 +634,8 @@ git checkout v{ERIGON_VERSION}
 
 Compile the Erigon binary using the `make` command.
 
-Standard Compilation:
-
 ```sh
 make erigon
-```
-
-Fast Compilation (Recommended): to significantly speed up the process, specify the number of processors you want to use with the `-j<n>` option, where `<n>` is the number of processor you want to use (we recommend using a number slightly less than your total core count):
-
-```sh
-make -j<n> erigon
 ```
 
 The resulting executable binary will be created in the `./build/bin/erigon` path.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -634,16 +634,8 @@ git checkout v{ERIGON_VERSION}
 
 Compile the Erigon binary using the `make` command.
 
-Standard Compilation:
-
 ```sh
 make erigon
-```
-
-Fast Compilation (Recommended): to significantly speed up the process, specify the number of processors you want to use with the `-j<n>` option, where `<n>` is the number of processor you want to use (we recommend using a number slightly less than your total core count):
-
-```sh
-make -j<n> erigon
 ```
 
 The resulting executable binary will be created in the `./build/bin/erigon` path.


### PR DESCRIPTION
The installation page recommended `make -j<n> erigon` as "Fast Compilation (Recommended)" that would "significantly speed up the process". It does neither.

`make erigon` resolves to `erigon: go-version erigon.cmd` — a single `go build` recipe. Make has no independent targets to schedule, and Go does not implement make's jobserver protocol, so `-j` never reaches the compiler. Build parallelism comes from `go build` itself, which defaults to GOMAXPROCS.

Measured on a 22-thread machine, cold build cache both times:

| command | wall time |
|---|---|
| `make erigon` | 175s |
| `make -j20 erigon` | 181s |

Also removes the now-orphaned `Standard Compilation:` label, which only existed to contrast with the block above. No other instruction on the page is changed.

llms artifacts regenerated — the drift guard fails without it.

The same text is still present in `versioned_docs` v3.3, v3.4 and v3.5, which publish as the version-selector pages. Left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
