### PR TITLE
cl/phase1/network, execution/execmodule: stop two tests racing the Windows clock

### DIFF
--- a/cl/phase1/network/beacon_downloader_test.go
+++ b/cl/phase1/network/beacon_downloader_test.go
@@ -554,14 +554,11 @@ func TestForwardRequestMoreDoesNotPreferHTTPWithoutProgress(t *testing.T) {
 
 func TestForwardRequestMoreEmptyP2PDoesNotInvalidateHTTPFallback(t *testing.T) {
 	previousInterval := forwardBeaconRequestInterval
-	previousTimeout := forwardBeaconRequestTimeout
 	previousFallbackDelay := forwardBeaconFallbackDelay
 	forwardBeaconRequestInterval = time.Millisecond
-	forwardBeaconRequestTimeout = 100 * time.Millisecond
 	forwardBeaconFallbackDelay = 5 * time.Millisecond
 	t.Cleanup(func() {
 		forwardBeaconRequestInterval = previousInterval
-		forwardBeaconRequestTimeout = previousTimeout
 		forwardBeaconFallbackDelay = previousFallbackDelay
 	})
 

--- a/execution/commitment/commitmentdb/commitment_context_test.go
+++ b/execution/commitment/commitmentdb/commitment_context_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/execution/commitment"
@@ -251,4 +252,21 @@ func Test_TrieContext_BranchKeepsNilAndEmptyDistinct(t *testing.T) {
 	got, _, err = ctx.Branch([]byte{0xdd})
 	require.NoError(t, err)
 	require.Nil(t, got, "absent branch must stay nil after the buffer is warm")
+}
+
+type commitmentTimeRecorder struct {
+	sd
+	calls int
+}
+
+func (r *commitmentTimeRecorder) AddCommitmentTime(time.Duration) { r.calls++ }
+
+func TestComputeCommitmentReportsItsDuration(t *testing.T) {
+	t.Parallel()
+	rec := &commitmentTimeRecorder{}
+	sdc := NewSharedDomainsCommitmentContext(rec, commitment.ModeDirect, t.TempDir(), commitment.TrieConfig{})
+
+	_, err := sdc.ComputeCommitment(t.Context(), nil, false, 0, 0, "", nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, rec.calls)
 }

--- a/execution/execmodule/block_metrics_test.go
+++ b/execution/execmodule/block_metrics_test.go
@@ -157,8 +157,6 @@ func TestSlowBlockMetricsAreEmittedForValidatedBlocks(t *testing.T) {
 		timing := rec["timing"].(map[string]any)
 		require.Contains(t, timing, "execution_ms")
 		require.Contains(t, timing, "state_hash_ms")
-		// state_hash_ms gets no lower bound: commitment over a test-sized block runs
-		// in ~0.1ms whatever the block carries, below the Windows clock resolution.
 		assert.GreaterOrEqual(t, timing["total_ms"].(float64), timing["state_hash_ms"].(float64))
 
 		if block["gas_used"].(float64) > 0 {

--- a/execution/execmodule/block_metrics_test.go
+++ b/execution/execmodule/block_metrics_test.go
@@ -148,7 +148,7 @@ func TestSlowBlockMetricsAreEmittedForValidatedBlocks(t *testing.T) {
 	require.Len(t, records, len(chainResult.Blocks),
 		"exactly one record per block: a second emission site would double every block")
 
-	var sawStateHash, sawAccountReads, sawCodeWrites bool
+	var sawAccountReads, sawCodeWrites bool
 	for _, rec := range records {
 		block := rec["block"].(map[string]any)
 		assert.NotZero(t, block["number"], "block number must be filled in")
@@ -157,10 +157,9 @@ func TestSlowBlockMetricsAreEmittedForValidatedBlocks(t *testing.T) {
 		timing := rec["timing"].(map[string]any)
 		require.Contains(t, timing, "execution_ms")
 		require.Contains(t, timing, "state_hash_ms")
+		// state_hash_ms gets no lower bound: commitment over a test-sized block runs
+		// in ~0.1ms whatever the block carries, below the Windows clock resolution.
 		assert.GreaterOrEqual(t, timing["total_ms"].(float64), timing["state_hash_ms"].(float64))
-		if timing["state_hash_ms"].(float64) > 0 {
-			sawStateHash = true
-		}
 
 		if block["gas_used"].(float64) > 0 {
 			assert.Positive(t, timing["execution_ms"].(float64),
@@ -182,7 +181,6 @@ func TestSlowBlockMetricsAreEmittedForValidatedBlocks(t *testing.T) {
 		}
 	}
 
-	assert.True(t, sawStateHash, "state_hash_ms was zero in every record — commitment timing is not reaching the emitter")
 	assert.True(t, sawAccountReads, "state_reads.accounts was zero in every record — the counters are not reaching the emitter")
 	assert.True(t, sawCodeWrites, "state_writes.code was zero across a contract deploy — the one code counter claimed real is not counted")
 }

--- a/execution/execmodule/exec_module_internal_test.go
+++ b/execution/execmodule/exec_module_internal_test.go
@@ -33,6 +33,8 @@ import (
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/dbservices"
 	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/state/execctx"
+	"github.com/erigontech/erigon/execution/blockmetrics"
 	"github.com/erigontech/erigon/execution/types"
 )
 
@@ -171,4 +173,25 @@ func TestForkValidatorBuildsBlockMetricsCacheOnlyWhenEnabled(t *testing.T) {
 	every := time.Duration(0)
 	on := newForkValidator(t.Context(), 10, &PipelineExecutor{}, reader, 16, &every)
 	require.NotNil(t, on.blockMetricsCache)
+}
+
+func TestRecordBlockMetricsTakesCommitmentTimeFromSharedDomains(t *testing.T) {
+	prevReadMetrics := dbg.KVReadLevelledMetrics
+	t.Cleanup(func() { dbg.KVReadLevelledMetrics = prevReadMetrics })
+
+	every := time.Duration(0)
+	fv := newForkValidator(t.Context(), 10, &PipelineExecutor{}, sideForkReader{}, 16, &every)
+	sd := &execctx.SharedDomains{}
+	header := &types.Header{Number: *uint256.NewInt(7), GasUsed: 21_000}
+	hash := header.Hash()
+
+	sd.AddCommitmentTime(5 * time.Millisecond)
+	fv.recordBlockMetrics(sd, header, &types.RawBody{}, hash, &blockmetrics.Sample{}, 1, 20*time.Millisecond, 12*time.Millisecond)
+
+	rec := fv.TakeBlockMetrics(hash)
+	require.NotNil(t, rec)
+	require.Equal(t, 5*time.Millisecond, rec.StateHash)
+	require.Equal(t, 7*time.Millisecond, rec.Execution)
+	require.Equal(t, 20*time.Millisecond, rec.Validation)
+	require.Zero(t, sd.TakeCommitmentTime(), "a commitment time left behind is reported again by the next block")
 }

--- a/execution/execmodule/fork_validator.go
+++ b/execution/execmodule/fork_validator.go
@@ -330,7 +330,7 @@ func (fv *ForkValidator) validateAndStorePayload(ctx context.Context, sd *execct
 	}
 	validation := time.Since(start)
 	fv.timingsCache.Add(hash, BlockTimings{validation, 0})
-	fv.recordBlockMetrics(sd, header, body, hash, &beforeIO, len(headersChain), validation)
+	fv.recordBlockMetrics(sd, header, body, hash, &beforeIO, len(headersChain), validation, fv.executor.lastValidationExecStageTiming())
 
 	latestValidHash = hash
 	fv.extendingForkHeadHash = hash
@@ -377,7 +377,7 @@ func (fv *ForkValidator) GetTimings(hash common.Hash) BlockTimings {
 	return BlockTimings{}
 }
 
-func (fv *ForkValidator) recordBlockMetrics(sd *execctx.SharedDomains, header *types.Header, body *types.RawBody, hash common.Hash, beforeIO *blockmetrics.Sample, blocksValidated int, validation time.Duration) {
+func (fv *ForkValidator) recordBlockMetrics(sd *execctx.SharedDomains, header *types.Header, body *types.RawBody, hash common.Hash, beforeIO *blockmetrics.Sample, blocksValidated int, validation, execStage time.Duration) {
 	if fv.blockMetricsCache == nil {
 		return
 	}
@@ -398,7 +398,7 @@ func (fv *ForkValidator) recordBlockMetrics(sd *execctx.SharedDomains, header *t
 		rec.TxCount = len(body.Transactions)
 	}
 	rec.Accounts, rec.Storage, rec.Code, rec.CountersValid = blockmetrics.Take(sd.Metrics(), sd.NonExecMetrics()).Since(*beforeIO)
-	rec.Execution = max(fv.executor.lastValidationExecStageTiming()-stateHash, 0)
+	rec.Execution = max(execStage-stateHash, 0)
 	fv.blockMetricsCache.Add(hash, rec)
 }
 


### PR DESCRIPTION
Fixes both failures in `tests / tests-mac-linux (windows-2025, serial)`, seen on https://github.com/erigontech/erigon/actions/runs/34673097118/job/103499473721. Neither is caused by the PR that surfaced them, and both are specific to Windows: every other arm of that matrix passed, including `ubuntu-24.04, serial`, which runs the same commitment path.

## `TestForwardRequestMoreEmptyP2PDoesNotInvalidateHTTPFallback`

```
beacon_downloader_test.go:625: Not equal: expected: 1, actual: 0
    valid HTTP fallback was discarded after an empty P2P response
```

The test sequences itself on two channels. The HTTP handler signals `fallbackStarted` and then blocks until the test calls `release()`. In between, the test asserts on the cursor. It also capped `forwardBeaconRequestTimeout` at 100ms, which is a second clock running against that handshake. When the runner is loaded enough that more than 100ms passes before `release()`, the request context expires, the fallback blocks are discarded and the process function is never called.

Reproduced exactly by sleeping 150ms before `release()` on an otherwise unmodified tree: same line, same message, same expected and actual.

The test already bounds itself with its own one-second guards on `fallbackStarted` and on `RequestMore` returning, so it does not need the cap. Dropping the override lets the production default apply and the handshake decide the sequence.

Verified by keeping the 150ms sleep in place, which now passes, then removing it and running the `TestForwardRequestMore` family 20 times.

## `TestSlowBlockMetricsAreEmittedForValidatedBlocks`

```
block_metrics_test.go:185: Should be true
    state_hash_ms was zero in every record — commitment timing is not reaching the emitter
```

The assertion needed a measured commitment duration to be positive. Commitment over a test-sized block takes about 0.1ms, so the result depends on the clock resolution of the runner, and on `windows-2025, serial` it reads zero. The check races the clock.

It is replaced by two tests that do not read the clock:

- `TestComputeCommitmentReportsItsDuration` in `execution/commitment/commitmentdb`: `ComputeCommitment` calls `AddCommitmentTime` exactly once. It counts calls, not durations.
- `TestRecordBlockMetricsTakesCommitmentTimeFromSharedDomains` in `execution/execmodule`: with 5ms of commitment time in `SharedDomains` and a 12ms exec stage, the record gets `StateHash` 5ms and `Execution` 7ms, and the commitment time is drained.

For the second test, `recordBlockMetrics` now takes the exec stage duration as a parameter instead of reading it from the executor. No behavior change.

Each new test fails when its wiring is removed: deleting the `AddCommitmentTime(took)` call fails the first, dropping `StateHash` from the `Record` literal fails the second.

All other checks in `TestSlowBlockMetricsAreEmittedForValidatedBlocks` are unchanged.

Not covered without the clock: moving the discarding `TakeCommitmentTime()` in `validateAndStorePayload` after `ValidateBlock`.

## Notes

`make lint` reports one gofmt issue in `db/snapshotsync/snapshots_test.go`. It exists on `main`, and this PR does not touch the file.

TDD: for the beacon test the reproduction came first and the fix was verified against it. The execmodule test drove the `recordBlockMetrics` signature change (red on compile, then green). The commitmentdb test covers existing behavior, so it was checked by mutation instead.

