### PR TITLE
db/state, db/kv/temporal: close state files after the read-tx drain

### DIFF
--- a/db/kv/temporal/kv_temporal.go
+++ b/db/kv/temporal/kv_temporal.go
@@ -264,11 +264,19 @@ func (db *DB) UpdateNosync(ctx context.Context, f func(tx kv.RwTx) error) error 
 	return tx.Commit()
 }
 
+// Close tears down state files only after every reader is gone. A temporal tx
+// releases its aggtx before its mdbx tx, so the mdbx read-tx drain inside
+// RwDB.Close also joins readers the aggregator knows nothing about — detached
+// ones like the background block-retire goroutine. The aggregator's own
+// goroutines hold mdbx read txs, so they must be joined before that drain.
 func (db *DB) Close() {
+	if db.stateFiles != nil {
+		db.stateFiles.StopBackground()
+	}
+	db.RwDB.Close()
 	if db.stateFiles != nil {
 		db.stateFiles.Close()
 	}
-	db.RwDB.Close()
 }
 
 func (db *DB) OnFilesChange(onChange, onDel kv.OnFilesChange) {

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -140,6 +140,8 @@ type Aggregator struct {
 	savedSalt              *uint32
 	disableFsync           bool
 	commitmentRefsOverride *bool
+
+	closeFilesOnce sync.Once
 }
 
 func newAggregator(ctx context.Context, dirs datadir.Dirs, logger log.Logger) (*Aggregator, error) {
@@ -722,12 +724,16 @@ func (a *Aggregator) WaitForFiles() {
 	}
 }
 
-func (a *Aggregator) Close() {
+// StopBackground cancels and joins the aggregator's own background goroutines,
+// releasing the DB read transactions they hold, but leaves the files open. It
+// lets an owner drain external file readers (via the DB's own read-tx drain)
+// between the two halves of shutdown. Idempotent; Close calls it.
+func (a *Aggregator) StopBackground() {
 	a.dirtyFilesLock.Lock()
 	a.visibilityLoweringForbidden.Store(false) // shutdown is not a fill window
 	a.dirtyFilesLock.Unlock()
 	a.WaitForFiles()
-	if !a.background.BeginClose() { // idempotent: safe to call Close multiple times
+	if !a.background.BeginClose() {
 		return
 	}
 	a.ctxCancel()
@@ -735,7 +741,14 @@ func (a *Aggregator) Close() {
 		a.metricsCollector.Stop() // drain buffered samples before wg.Wait joins the goroutine
 	}
 	a.background.Wait()
+}
 
+func (a *Aggregator) Close() {
+	a.StopBackground()
+	a.closeFilesOnce.Do(a.closeFilesOnShutdown)
+}
+
+func (a *Aggregator) closeFilesOnShutdown() {
 	// A closed Aggregator may linger referenced; release the cached branch data
 	// eagerly and drop this cache from the active-instance count so later
 	// BranchCaches size their trunk depth against real concurrency.

--- a/db/state/temporal_close_test.go
+++ b/db/state/temporal_close_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/db/kv/temporal"
+)
+
+// A temporal tx pins the aggregator's files through its aggtx, so Close must not
+// tear those files down while such a tx is still open. Detached readers exist at
+// shutdown (the background block-retire goroutine is one), and they are only
+// joined by the mdbx read-tx drain inside RwDB.Close.
+func TestTemporalDBClose_KeepsFilesUntilOpenTxIsDone(t *testing.T) {
+	t.Parallel()
+
+	db, agg := testDbAggregatorWithFiles(t, &testAggConfig{stepSize: 2})
+	require.NotZero(t, agg.EndTxNumMinimax())
+
+	tx, err := db.BeginTemporalRo(t.Context())
+	require.NoError(t, err)
+
+	closed := make(chan struct{})
+	go func() {
+		defer close(closed)
+		db.Close()
+	}()
+
+	// Close is in progress once the underlying mdbx db refuses new read txs.
+	raw := db.(*temporal.DB).InternalDB()
+	for {
+		rtx, err := raw.BeginRo(t.Context())
+		if err != nil {
+			break
+		}
+		rtx.Rollback()
+		time.Sleep(time.Millisecond)
+	}
+
+	require.NotZero(t, agg.EndTxNumMinimax(), "state files were closed while a temporal tx was still open")
+
+	tx.Rollback()
+	select {
+	case <-closed:
+	case <-time.After(time.Minute):
+		t.Fatal("Close did not return after the temporal tx was rolled back")
+	}
+	require.Zero(t, agg.EndTxNumMinimax())
+}


### PR DESCRIPTION
Fixes #22115.

## Problem

`temporal.DB.Close()` closed the state aggregator before the MDBX handle. `Aggregator.Close()` force-closes the dirty files and ignores the `aggtx` reader refcount, so any goroutine still holding a temporal tx raced the teardown. The reported case is the detached background block-retire goroutine, which opens temporal read txs through `br.db.View(...)` and is not joined by every shutdown path.

## Fix

Close the state files *after* the MDBX read-tx drain instead of before it.

`RwDB.Close()` already waits for every open read tx (`waitTxsAllDoneOnClose`) and refuses new ones. A temporal tx closes its `aggtx` in `closeFilesView()` before rolling back its MDBX tx, so once that drain returns no `aggtx` holder is left — including readers the aggregator knows nothing about.

The aggregator's own background goroutines hold MDBX read txs, so they must still be joined before the drain, otherwise `RwDB.Close()` would block on them. `Aggregator.Close()` is split for that:

- `StopBackground()` — cancel the context and join the background goroutines, leaving the files open.
- `Close()` — `StopBackground()` plus the file teardown, run once.

So `temporal.DB.Close()` becomes: stop the aggregator's background work, drain the DB, then close the files.

This is the root-cause fix Alex suggested on the issue ("for 'wait all readers before close' we have `txsCountMutex` / `txsAllDoneOnCloseCond` in `kv_mdbx.go`"): every temporal reader is covered, not just the retire goroutine.

## Test

`TestTemporalDBClose_KeepsFilesUntilOpenTxIsDone` builds state files, holds a temporal read tx open, calls `Close()` from another goroutine, and waits until the DB starts refusing new read txs. At that point the aggregator must still have its files; it may only drop them after the tx rolls back.

On `main` it fails at the first assertion (`EndTxNumMinimax()` is already 0 — the files were closed while the tx was open). With the fix it passes, also under `-race`.