### PR TITLE
execution/stagedsync: propagate initial cursor seek errors

### DIFF
--- a/execution/stagedsync/stage_senders.go
+++ b/execution/stagedsync/stage_senders.go
@@ -201,8 +201,13 @@ func SpawnRecoverSendersStage(cfg SendersCfg, s *StageState, u Unwinder, tx kv.R
 	}
 	defer bodiesC.Close()
 
+	k, v, err := bodiesC.Seek(hexutil.EncodeTs(startFrom))
+	if err != nil {
+		return err
+	}
+
 Loop:
-	for k, v, err := bodiesC.Seek(hexutil.EncodeTs(startFrom)); k != nil; k, v, err = bodiesC.Next() {
+	for ; k != nil; k, v, err = bodiesC.Next() {
 		if err != nil {
 			return err
 		}

--- a/execution/stagedsync/stage_senders_test.go
+++ b/execution/stagedsync/stage_senders_test.go
@@ -17,6 +17,7 @@
 package stagedsync_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,6 +38,50 @@ import (
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/node/ethconfig"
 )
+
+type seekErrorTx struct {
+	kv.RwTx
+	cursor kv.Cursor
+}
+
+func (tx seekErrorTx) Cursor(string) (kv.Cursor, error) {
+	return tx.cursor, nil
+}
+
+type seekErrorCursor struct {
+	err error
+}
+
+func (c seekErrorCursor) First() ([]byte, []byte, error) { return nil, nil, nil }
+func (c seekErrorCursor) Seek([]byte) ([]byte, []byte, error) {
+	return nil, nil, c.err
+}
+func (c seekErrorCursor) SeekExact([]byte) ([]byte, []byte, error) { return nil, nil, nil }
+func (c seekErrorCursor) Next() ([]byte, []byte, error)            { return nil, nil, nil }
+func (c seekErrorCursor) Prev() ([]byte, []byte, error)            { return nil, nil, nil }
+func (c seekErrorCursor) Last() ([]byte, []byte, error)            { return nil, nil, nil }
+func (c seekErrorCursor) Current() ([]byte, []byte, error)         { return nil, nil, nil }
+func (c seekErrorCursor) Close()                                   {}
+
+func TestSendersReturnsInitialSeekError(t *testing.T) {
+	m := execmoduletester.New(t)
+	tx, err := m.DB.BeginRw(m.Ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+	require.NoError(t, stages.SaveStageProgress(tx, stages.Bodies, 1))
+
+	sentinelErr := errors.New("initial seek failed")
+	err = stagedsync.SpawnRecoverSendersStage(
+		stagedsync.StageSendersCfg(chain.TestChainBerlinConfig, ethconfig.Defaults.Sync, false, "", prune.Mode{}, m.BlockReader, exec.NewBlockReadAheader()),
+		&stagedsync.StageState{ID: stages.Senders},
+		nil,
+		seekErrorTx{RwTx: tx, cursor: seekErrorCursor{err: sentinelErr}},
+		1,
+		m.Ctx,
+		log.New(),
+	)
+	require.ErrorIs(t, err, sentinelErr)
+}
 
 func TestSenders(t *testing.T) {
 	require := require.New(t)


### PR DESCRIPTION

Propagate errors returned by the initial `Seek` in the senders stage.

The current loop checks the cursor error only inside the loop body:

```go
for k, v, err := bodiesC.Seek(...); k != nil; k, v, err = bodiesC.Next() {
    if err != nil {
        return err
    }
    ...
}
```

If the initial `Seek` returns a nil key together with an error, the loop body is never entered and the error is silently ignored. The senders stage then continues as if there were no canonical bodies to process.


Perform the initial `Seek` before entering the loop and return its error immediately.
