### PR TITLE
rpc/jsonrpc: keep trace_callMany bundles on the parent state boundary

### DIFF
--- a/rpc/jsonrpc/trace_adhoc.go
+++ b/rpc/jsonrpc/trace_adhoc.go
@@ -1353,15 +1353,25 @@ func (api *TraceAPIImpl) CallMany(ctx context.Context, calls json.RawMessage, pa
 	defer ibs.Close()
 
 	trace, _, err := api.doCallBlock(ctx, tx, stateReader, stateCache, cachedWriter, ibs,
-		txns, msgs, callParams, parentHeader, parentNrOrHash.RequireCanonical, true /* gasBailout */, traceConfig)
+		txns, msgs, callParams, parentHeader, parentNrOrHash.RequireCanonical, true /* gasBailout */, pinnedParent, traceConfig)
 
 	return trace, err
 }
 
+// stateBoundary selects the history position doCallBlock reads through. Block
+// replay must advance with the transaction index; an ad-hoc bundle must not, or
+// a call falls through to state left by a real transaction it never executed.
+type stateBoundary bool
+
+const (
+	pinnedParent   stateBoundary = false
+	perTransaction stateBoundary = true
+)
+
 func (api *TraceAPIImpl) doCallBlock(ctx context.Context, dbtx kv.Tx, stateReader state.StateReader,
 	stateCache *shards.StateCache, cachedWriter state.StateWriter, ibs *state.IntraBlockState,
 	txns []types.Transaction, msgs []*types.Message, callParams []TraceCallParam,
-	header *types.Header, requireCanonical, gasBailout bool,
+	header *types.Header, requireCanonical, gasBailout bool, boundary stateBoundary,
 	traceConfig *config.TraceConfig,
 ) ([]*TraceCallResult, *tracing.Hooks, error) {
 	chainConfig, err := api.chainConfig(ctx, dbtx)
@@ -1398,7 +1408,7 @@ func (api *TraceAPIImpl) doCallBlock(ctx context.Context, dbtx kv.Tx, stateReade
 	var tracingHooks *tracing.Hooks
 
 	for txIndex, msg := range msgs {
-		if isHistoricalStateReader {
+		if isHistoricalStateReader && boundary == perTransaction {
 			historicalStateReader.SetTxNum(baseTxNum + uint64(txIndex))
 		}
 		if err := common.Stopped(ctx.Done()); err != nil {
@@ -1451,7 +1461,7 @@ func (api *TraceAPIImpl) doCallBlock(ctx context.Context, dbtx kv.Tx, stateReade
 			ibs.Reset()
 			cloneCache := stateCache.Clone()
 			cloneReader = state.NewCachedReader(stateReader, cloneCache)
-			if isHistoricalStateReader {
+			if isHistoricalStateReader && boundary == perTransaction {
 				historicalStateReader.SetTxNum(baseTxNum + uint64(txIndex))
 			}
 			sdMap := make(map[accounts.Address]*StateDiffAccount)

--- a/rpc/jsonrpc/trace_adhoc_test.go
+++ b/rpc/jsonrpc/trace_adhoc_test.go
@@ -1225,3 +1225,62 @@ func TestReplayTransactionInvalidType(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unrecognized trace type")
 }
+
+// theAddr receives 1e15 wei in block 1 and another 1e15 wei in block 2. With
+// parent block 1, a bundle call that touches theAddr must see the post-block-1
+// balance, never the one block 2's real transaction produced.
+func TestCallManyHistoricalParentPinsStateBoundary(t *testing.T) {
+	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
+	api := newTraceApiForTest(m)
+	parentNum := rpc.BlockNumber(1)
+	parent := &rpc.BlockNumberOrHash{BlockNumber: &parentNum}
+
+	const bundle = `[
+	[{"from":"0x14627ea0e2B27b817DbfF94c3dA383bB73F8C30b","to":"0x703c4b2bD70c169f5717101CaeE543299Fc946C7","gas":"0x5208","gasPrice":"0x0","value":"0x1"},["trace"]],
+	[{"from":"0x71562b71999873db5b286df957af199ec94617f7","to":"0x0100000000000000000000000000000000000000","gas":"0x5208","gasPrice":"0x0","value":"0x1"},["stateDiff"]]
+]`
+
+	results, err := api.CallMany(context.Background(), json.RawMessage(bundle), parent, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	diff, ok := results[1].StateDiff[internedAddress("0x0100000000000000000000000000000000000000")]
+	require.True(t, ok, "theAddr missing from the second call's stateDiff")
+	balance, ok := diff.Balance.(map[string]*StateDiffBalance)
+	require.True(t, ok, "unexpected balance diff shape %+v", diff.Balance)
+	require.Len(t, balance, 1)
+	for _, b := range balance {
+		require.Equal(t, uint64(1000000000000000), b.From.ToInt().Uint64(),
+			"second bundle call read state past the parent boundary")
+		require.Equal(t, uint64(1000000000000001), b.To.ToInt().Uint64())
+	}
+}
+
+// Pinning the reader to the parent boundary must not stop a call from seeing
+// the previous calls' writes: they reach it through ibs, not through history.
+func TestCallManyHistoricalParentKeepsSequentialState(t *testing.T) {
+	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
+	api := newTraceApiForTest(m)
+	parentNum := rpc.BlockNumber(1)
+	parent := &rpc.BlockNumberOrHash{BlockNumber: &parentNum}
+
+	// Init code deploys runtime code that returns 42.
+	const deploy = `[{"from":"0x71562b71999873db5b286df957af199ec94617f7","gas":"0x30000","gasPrice":"0x0","data":"0x600a600c600039600a6000f3602a60005260206000f3"},["trace"]]`
+	deployRes, err := api.CallMany(context.Background(), json.RawMessage("["+deploy+"]"), parent, nil)
+	require.NoError(t, err)
+	require.Len(t, deployRes, 1)
+	created, ok := deployRes[0].Trace[0].Result.(*CreateTraceResult)
+	require.True(t, ok)
+	require.NotNil(t, created.Address)
+
+	pair := fmt.Sprintf(`[
+	%s,
+	[{"from":"0x71562b71999873db5b286df957af199ec94617f7","to":"%s","gas":"0x30000","gasPrice":"0x0"},["trace"]]
+]`, deploy, created.Address)
+	results, err := api.CallMany(context.Background(), json.RawMessage(pair), parent, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	invoked, ok := results[1].Trace[0].Result.(*TraceResult)
+	require.True(t, ok)
+	require.Equal(t, "0x000000000000000000000000000000000000000000000000000000000000002a", invoked.Output.String())
+}

--- a/rpc/jsonrpc/trace_filtering.go
+++ b/rpc/jsonrpc/trace_filtering.go
@@ -802,7 +802,7 @@ func (api *TraceAPIImpl) callBlock(
 		traces, cmErr = api.doCallBlockParallel(ctx, dbtx, baseTxNum, txs, msgs, callParams, header, gasBailOut, traceConfig)
 	} else {
 		traces, _, cmErr = api.doCallBlock(ctx, dbtx, stateReader, stateCache, cachedWriter, ibs, txs, msgs, callParams,
-			header, true /* requireCanonical */, gasBailOut /* gasBailout */, traceConfig)
+			header, true /* requireCanonical */, gasBailOut /* gasBailout */, perTransaction, traceConfig)
 	}
 
 	if cmErr != nil {

--- a/rpc/jsonrpc/trace_filtering_test.go
+++ b/rpc/jsonrpc/trace_filtering_test.go
@@ -131,7 +131,7 @@ func TestCallBlockParallelMatchesSequential(t *testing.T) {
 
 	// Sequential path — uses the stateReader/ibs prepared above.
 	sequentialResults, _, err := api.doCallBlock(ctx, tx, stateReader, sc, cachedWriter, ibs, txs, msgs,
-		callParams, header, parentNrOrHash.RequireCanonical, false, nil)
+		callParams, header, parentNrOrHash.RequireCanonical, false, perTransaction, nil)
 	require.NoError(t, err)
 	require.Len(t, sequentialResults, len(txs))
 


### PR DESCRIPTION
Closes #23501.

`doCallBlock` advanced the history reader with the call index. That is right when replaying a real block, but wrong for an ad-hoc bundle: the i-th simulated call read history as of after the first i real transactions of the block following the selected parent, so keys those transactions changed leaked into the result.

The policy is now an explicit `advanceTxNum` parameter of `doCallBlock` — `trace_callMany` passes false and stays on the parent, block replay passes true and keeps advancing. Earlier calls of a bundle stay visible through `ibs` and the state cache, where they already came from. `doCall` (single-transaction replay) is unchanged.

The stateDiff branch also repeated the `SetTxNum` from the top of the loop with the same value, with nothing in between moving the reader; that repetition is gone.

## Tests

- `TestCallManyHistoricalParentPinsStateBoundary` — regression test, red before the fix (reads 2e15, the post-next-block balance, instead of 1e15).
